### PR TITLE
Fix MySQL health checks to use TCP and add failure log capture

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -250,7 +250,14 @@ test-e2e-local: build ## Run local e2e tests in isolated environment
 	SCHEMABOT_MYSQL_PORT=14371 \
 	STAGING_MYSQL_PORT=14372 \
 	PRODUCTION_MYSQL_PORT=14373 \
-	docker compose -p schemabot-e2e -f deploy/local/docker-compose.yml up --build -d
+	docker compose -p schemabot-e2e -f deploy/local/docker-compose.yml up --build -d || \
+		(echo "docker compose up failed — dumping logs:"; \
+		SCHEMABOT_PORT=14370 SCHEMABOT_MYSQL_PORT=14371 STAGING_MYSQL_PORT=14372 PRODUCTION_MYSQL_PORT=14373 \
+		docker compose -p schemabot-e2e -f deploy/local/docker-compose.yml logs; \
+		SCHEMABOT_PORT=14370 SCHEMABOT_MYSQL_PORT=14371 STAGING_MYSQL_PORT=14372 PRODUCTION_MYSQL_PORT=14373 \
+		docker compose -p schemabot-e2e -f deploy/local/docker-compose.yml down -v; \
+		rm -f deploy/local/schemabot; \
+		exit 1)
 	@rm -f deploy/local/schemabot
 	@echo "Waiting for SchemaBot e2e environment to be healthy..."
 	@for i in $$(seq 1 60); do \
@@ -301,7 +308,12 @@ test-e2e-grpc: build ## Run gRPC e2e tests in isolated environment
 	CGO_ENABLED=0 GOOS=linux go build -ldflags "$(LDFLAGS)" -o bin/schemabot-linux ./pkg/cmd
 	cp bin/schemabot-linux deploy/local/schemabot
 	@$(E2E_GRPC_ENV) docker compose -p schemabot-e2e-grpc -f deploy/local/docker-compose.grpc.yml down -v 2>/dev/null || true
-	@$(E2E_GRPC_ENV) docker compose -p schemabot-e2e-grpc -f deploy/local/docker-compose.grpc.yml up --build -d
+	@$(E2E_GRPC_ENV) docker compose -p schemabot-e2e-grpc -f deploy/local/docker-compose.grpc.yml up --build -d || \
+		(echo "docker compose up failed — dumping logs:"; \
+		$(E2E_GRPC_ENV) docker compose -p schemabot-e2e-grpc -f deploy/local/docker-compose.grpc.yml logs; \
+		$(E2E_GRPC_ENV) docker compose -p schemabot-e2e-grpc -f deploy/local/docker-compose.grpc.yml down -v; \
+		rm -f deploy/local/schemabot; \
+		exit 1)
 	@rm -f deploy/local/schemabot
 	@echo "Waiting for SchemaBot gRPC e2e environment to be healthy..."
 	@for i in $$(seq 1 90); do \

--- a/deploy/local/docker-compose.grpc.yml
+++ b/deploy/local/docker-compose.grpc.yml
@@ -36,7 +36,7 @@ services:
     ports:
       - "${TERN_STAGING_MYSQL_PORT:-13382}:3306"
     healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-ptestpassword"]
+      test: ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1", "-ptestpassword"]
       interval: 5s
       timeout: 5s
       retries: 10
@@ -85,7 +85,7 @@ services:
     ports:
       - "${TERN_PRODUCTION_MYSQL_PORT:-13383}:3306"
     healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-ptestpassword"]
+      test: ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1", "-ptestpassword"]
       interval: 5s
       timeout: 5s
       retries: 10
@@ -135,7 +135,7 @@ services:
       - ./mysql-init/mysql-config/my.cnf:/etc/mysql/conf.d/schemabot.cnf:ro
       - schemabot-mysql-data:/var/lib/mysql
     healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-ptestpassword"]
+      test: ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1", "-ptestpassword"]
       interval: 5s
       timeout: 5s
       retries: 10

--- a/deploy/local/docker-compose.yml
+++ b/deploy/local/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       - mysql-schemabot-data:/var/lib/mysql
       - ./mysql-init/mysql-config/my.cnf:/etc/mysql/conf.d/schemabot.cnf:ro
     healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-ptestpassword"]
+      test: ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1", "-ptestpassword"]
       interval: 5s
       timeout: 5s
       retries: 10
@@ -49,7 +49,7 @@ services:
       - ./mysql-init:/docker-entrypoint-initdb.d:ro
       - ./mysql-init/mysql-config/my.cnf:/etc/mysql/conf.d/schemabot.cnf:ro
     healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-ptestpassword"]
+      test: ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1", "-ptestpassword"]
       interval: 5s
       timeout: 5s
       retries: 10
@@ -67,7 +67,7 @@ services:
       - ./mysql-init:/docker-entrypoint-initdb.d:ro
       - ./mysql-init/mysql-config/my.cnf:/etc/mysql/conf.d/schemabot.cnf:ro
     healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-ptestpassword"]
+      test: ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1", "-ptestpassword"]
       interval: 5s
       timeout: 5s
       retries: 10


### PR DESCRIPTION
MySQL Docker health checks used `-h localhost` which connects via Unix socket on Linux. This can pass during MySQL's init phase (temp server) before the main TCP server is ready, causing dependent containers to crash on startup — as seen in the e2e gRPC CI failure on the initial port merge where `tern-staging` exited(1).

Switches to `-h 127.0.0.1` to force TCP, matching the pattern already used in `docker-compose.vitess.yml`. Also adds container log capture when `docker compose up` fails in both e2e Makefile targets so future startup failures are diagnosable in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)