### PR TITLE
Add morgo as a codeowner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -9,7 +9,7 @@
 # The format is described: https://github.blog/2017-07-06-introducing-code-owners/
 
 # These owners will be the default owners for everything in the repo.
-*       @aparajon
+*       @aparajon @morgo
 
 
 # -----------------------------------------------


### PR DESCRIPTION
Adds @morgo as a codeowner for all files alongside @aparajon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)