### PR TITLE
Add Docker image and Helm chart publishing

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -98,16 +98,16 @@ jobs:
       - name: Package and push Helm chart
         if: startsWith(github.ref, 'refs/tags/v')
         run: |
-          # Extract version from tag (v0.1.0 → 0.1.0)
-          VERSION="${GITHUB_REF_NAME#v}"
+          # Chart.yaml is the source of truth for version and appVersion.
+          # Validate that the tag matches what's committed.
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          CHART_VERSION=$(grep '^version:' charts/schemabot/Chart.yaml | awk '{print $2}')
+          if [ "$TAG_VERSION" != "$CHART_VERSION" ]; then
+            echo "::error::Tag ${GITHUB_REF_NAME} does not match Chart.yaml version ${CHART_VERSION}. Bump Chart.yaml before tagging."
+            exit 1
+          fi
 
-          # Update chart version and appVersion to match the tag
-          sed -i "s/^version:.*/version: ${VERSION}/" charts/schemabot/Chart.yaml
-          sed -i "s/^appVersion:.*/appVersion: \"${VERSION}\"/" charts/schemabot/Chart.yaml
-
-          # Package the chart
+          # Package and push
           helm package charts/schemabot --destination ./build
-
-          # Push to GHCR OCI
           echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io -u ${{ github.actor }} --password-stdin
-          helm push ./build/schemabot-${VERSION}.tgz oci://ghcr.io/block/charts
+          helm push ./build/schemabot-${CHART_VERSION}.tgz oci://ghcr.io/block/charts

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -30,24 +30,24 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # actions/checkout@v6
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # docker/setup-buildx-action@v3
 
       - name: Login to GitHub Container Registry
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract metadata
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # docker/metadata-action@v5
         id: meta
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
@@ -58,7 +58,7 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # docker/build-push-action@v6
         with:
           context: .
           file: deploy/Dockerfile
@@ -74,7 +74,7 @@ jobs:
       # Helm chart publishing (only on tags)
       - name: Install Helm
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # azure/setup-helm@v4
 
       - name: Package and push Helm chart
         if: startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -31,10 +31,10 @@ jobs:
           fetch-depth: 0
 
       - name: Install Helm
-        uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # azure/setup-helm@v4.3.0
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # azure/setup-helm@v4
 
       - name: Lint Helm chart
-        uses: helm/chart-testing-action@cf48dbf901ed202ae2c5aee26422dd6dfdf41e47 # helm/chart-testing-action@v2.7.0
+        uses: helm/chart-testing-action@0d28d3144d3a25ea2cc349d6e59901c4ff469b3b # helm/chart-testing-action@v2.7.0
 
       - name: Run chart-testing lint
         run: ct lint --target-branch ${{ github.event.pull_request.base.ref }} --charts charts/schemabot
@@ -93,7 +93,7 @@ jobs:
       # Helm chart publishing (only on tags)
       - name: Install Helm
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # azure/setup-helm@v4.3.0
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # azure/setup-helm@v4
 
       - name: Package and push Helm chart
         if: startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -39,6 +39,24 @@ jobs:
       - name: Run chart-testing lint
         run: ct lint --target-branch ${{ github.event.pull_request.base.ref }} --charts charts/schemabot
 
+      - name: Check chart version bump
+        run: |
+          # If any chart files changed, Chart.yaml version must be bumped.
+          CHANGED=$(git diff --name-only origin/${{ github.event.pull_request.base.ref }}...HEAD -- 'charts/schemabot/')
+          if [ -z "$CHANGED" ]; then
+            echo "No chart changes detected, skipping version check."
+            exit 0
+          fi
+
+          BASE_VERSION=$(git show origin/${{ github.event.pull_request.base.ref }}:charts/schemabot/Chart.yaml 2>/dev/null | grep '^version:' | awk '{print $2}')
+          HEAD_VERSION=$(grep '^version:' charts/schemabot/Chart.yaml | awk '{print $2}')
+
+          if [ "$BASE_VERSION" = "$HEAD_VERSION" ]; then
+            echo "::error::Chart files changed but charts/schemabot/Chart.yaml version was not bumped (still ${HEAD_VERSION}). Bump the version before merging."
+            exit 1
+          fi
+          echo "Chart version bumped: ${BASE_VERSION} → ${HEAD_VERSION}"
+
   build-and-push:
     runs-on: ubuntu-latest
     if: github.repository == 'block/schemabot'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,94 @@
+# .github/workflows/docker.yml — Docker image + Helm chart publishing
+#
+# Triggers:
+#   - Pull request: build Docker image only (validates Dockerfile, no push)
+#   - Push to main: build + push Docker image (latest, <sha>)
+#   - Tag v*:       build + push Docker image + package + push Helm chart
+#
+# Published to:
+#   - Docker: ghcr.io/block/schemabot:<tag>
+#   - Helm:   oci://ghcr.io/block/charts/schemabot:<version>
+
+name: Docker & Helm
+
+on:
+  push:
+    tags: ["v*"]
+    branches: [main]
+  pull_request:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    if: github.repository == 'block/schemabot'
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=sha,prefix=
+            type=semver,pattern=v{{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: deploy/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ github.ref_name }}
+            COMMIT=${{ github.sha }}
+            BUILD_DATE=${{ github.event.head_commit.timestamp }}
+
+      # Helm chart publishing (only on tags)
+      - name: Install Helm
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: azure/setup-helm@v4
+
+      - name: Package and push Helm chart
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          # Extract version from tag (v0.1.0 → 0.1.0)
+          VERSION="${GITHUB_REF_NAME#v}"
+
+          # Update chart version and appVersion to match the tag
+          sed -i "s/^version:.*/version: ${VERSION}/" charts/schemabot/Chart.yaml
+          sed -i "s/^appVersion:.*/appVersion: \"${VERSION}\"/" charts/schemabot/Chart.yaml
+
+          # Package the chart
+          helm package charts/schemabot --destination ./build
+
+          # Push to GHCR OCI
+          echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io -u ${{ github.actor }} --password-stdin
+          helm push ./build/schemabot-${VERSION}.tgz oci://ghcr.io/block/charts

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,9 +1,9 @@
 # .github/workflows/docker.yml — Docker image + Helm chart publishing
 #
 # Triggers:
-#   - Pull request: build Docker image only (validates Dockerfile, no push)
-#   - Push to main: build + push Docker image (latest, <sha>)
-#   - Tag v*:       build + push Docker image + package + push Helm chart
+#   - Pull request: build Docker image (single platform) + lint Helm chart
+#   - Push to main: build + push Docker image (multi-arch, latest + sha)
+#   - Tag v*:       build + push Docker image (multi-arch) + package + push Helm chart
 #
 # Published to:
 #   - Docker: ghcr.io/block/schemabot:<tag>
@@ -22,6 +22,23 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
+  lint-chart:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Install Helm
+        uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # azure/setup-helm@v4.3.0
+
+      - name: Lint Helm chart
+        uses: helm/chart-testing-action@cf48dbf901ed202ae2c5aee26422dd6dfdf41e47 # helm/chart-testing-action@v2.7.0
+
+      - name: Run chart-testing lint
+        run: ct lint --target-branch ${{ github.event.pull_request.base.ref }} --charts charts/schemabot
+
   build-and-push:
     runs-on: ubuntu-latest
     if: github.repository == 'block/schemabot'
@@ -33,6 +50,7 @@ jobs:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # actions/checkout@v6
 
       - name: Set up QEMU
+        if: github.event_name != 'pull_request'
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
@@ -62,7 +80,8 @@ jobs:
         with:
           context: .
           file: deploy/Dockerfile
-          platforms: linux/amd64,linux/arm64
+          # Multi-arch on push/tag, single platform on PR for speed
+          platforms: ${{ github.event_name != 'pull_request' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -74,7 +93,7 @@ jobs:
       # Helm chart publishing (only on tags)
       - name: Install Helm
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # azure/setup-helm@v4
+        uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # azure/setup-helm@v4.3.0
 
       - name: Package and push Helm chart
         if: startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -88,7 +88,7 @@ jobs:
           build-args: |
             VERSION=${{ github.ref_name }}
             COMMIT=${{ github.sha }}
-            BUILD_DATE=${{ github.event.head_commit.timestamp }}
+            BUILD_DATE=${{ github.event.head_commit.timestamp || github.event.pull_request.updated_at }}
 
       # Helm chart publishing (only on tags)
       - name: Install Helm

--- a/charts/schemabot/.helmignore
+++ b/charts/schemabot/.helmignore
@@ -1,0 +1,3 @@
+.git
+.gitignore
+*.md

--- a/charts/schemabot/Chart.yaml
+++ b/charts/schemabot/Chart.yaml
@@ -4,3 +4,8 @@ description: GitOps for database schemas
 type: application
 version: 0.1.0
 appVersion: "0.1.0"
+maintainers:
+  - name: aparajon
+    url: https://github.com/aparajon
+  - name: morgo
+    url: https://github.com/morgo

--- a/charts/schemabot/Chart.yaml
+++ b/charts/schemabot/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: schemabot
+description: GitOps for database schemas
+type: application
+version: 0.1.0
+appVersion: "0.1.0"

--- a/charts/schemabot/templates/_helpers.tpl
+++ b/charts/schemabot/templates/_helpers.tpl
@@ -1,0 +1,58 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "schemabot.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "schemabot.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Common labels.
+*/}}
+{{- define "schemabot.labels" -}}
+helm.sh/chart: {{ include "schemabot.chart" . }}
+{{ include "schemabot.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Values.image.tag | default .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels.
+*/}}
+{{- define "schemabot.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "schemabot.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Chart label.
+*/}}
+{{- define "schemabot.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Service account name.
+*/}}
+{{- define "schemabot.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "schemabot.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/schemabot/templates/configmap.yaml
+++ b/charts/schemabot/templates/configmap.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.config }}
+{{- $_ := required "config is required — set config.storage.dsn and at least one of config.databases or config.tern_deployments (see values.yaml for examples)" .Values.config }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -9,4 +9,3 @@ metadata:
 data:
   config.yaml: |
     {{- toYaml .Values.config | nindent 4 }}
-{{- end }}

--- a/charts/schemabot/templates/configmap.yaml
+++ b/charts/schemabot/templates/configmap.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.config }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "schemabot.fullname" . }}-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "schemabot.labels" . | nindent 4 }}
+data:
+  config.yaml: |
+    {{- toYaml .Values.config | nindent 4 }}
+{{- end }}

--- a/charts/schemabot/templates/deployment.yaml
+++ b/charts/schemabot/templates/deployment.yaml
@@ -1,0 +1,107 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "schemabot.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "schemabot.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "schemabot.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        # Restart pods when config changes
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "schemabot.selectorLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "schemabot.serviceAccountName" . }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: schemabot
+          securityContext:
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args: ["serve"]
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          env:
+            - name: PORT
+              value: "8080"
+            {{- if .Values.config }}
+            - name: SCHEMABOT_CONFIG_FILE
+              value: /config/config.yaml
+            {{- end }}
+            {{- with .Values.env }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            timeoutSeconds: 3
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            {{- if .Values.config }}
+            - name: config
+              mountPath: /config
+              readOnly: true
+            {{- end }}
+            - name: tmp
+              mountPath: /tmp
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+      volumes:
+        {{- if .Values.config }}
+        - name: config
+          configMap:
+            name: {{ include "schemabot.fullname" . }}-config
+        {{- end }}
+        - name: tmp
+          emptyDir: {}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/schemabot/templates/deployment.yaml
+++ b/charts/schemabot/templates/deployment.yaml
@@ -46,10 +46,8 @@ spec:
           env:
             - name: PORT
               value: "8080"
-            {{- if .Values.config }}
             - name: SCHEMABOT_CONFIG_FILE
               value: /config/config.yaml
-            {{- end }}
             {{- with .Values.env }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -72,22 +70,18 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
-            {{- if .Values.config }}
             - name: config
               mountPath: /config
               readOnly: true
-            {{- end }}
             - name: tmp
               mountPath: /tmp
             {{- with .Values.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
       volumes:
-        {{- if .Values.config }}
         - name: config
           configMap:
             name: {{ include "schemabot.fullname" . }}-config
-        {{- end }}
         - name: tmp
           emptyDir: {}
         {{- with .Values.extraVolumes }}

--- a/charts/schemabot/templates/service.yaml
+++ b/charts/schemabot/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "schemabot.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "schemabot.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "schemabot.selectorLabels" . | nindent 4 }}

--- a/charts/schemabot/templates/serviceaccount.yaml
+++ b/charts/schemabot/templates/serviceaccount.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: false
 metadata:
   name: {{ include "schemabot.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}

--- a/charts/schemabot/templates/serviceaccount.yaml
+++ b/charts/schemabot/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "schemabot.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "schemabot.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/schemabot/values.yaml
+++ b/charts/schemabot/values.yaml
@@ -41,7 +41,8 @@ service:
 #       default:
 #         staging: "tern-staging:9090"
 #         production: "tern-production:9090"
-config: {}
+# config is required — helm install will fail without it.
+config: null
 
 # Additional environment variables for the SchemaBot container.
 # Useful for env: secret references in the config file.

--- a/charts/schemabot/values.yaml
+++ b/charts/schemabot/values.yaml
@@ -1,0 +1,83 @@
+# SchemaBot Helm Chart — Default Values
+#
+# Override these for your deployment. See docs/configuration.md for the
+# full config file reference.
+
+replicaCount: 1
+
+image:
+  repository: ghcr.io/block/schemabot
+  tag: ""  # defaults to appVersion
+  pullPolicy: IfNotPresent
+
+serviceAccount:
+  create: true
+  name: ""
+  annotations: {}
+
+service:
+  type: ClusterIP
+  port: 8080
+
+# SchemaBot config file contents. Rendered into a ConfigMap and mounted
+# at /config/config.yaml. See docs/configuration.md for all options.
+#
+# Example (local mode, embedded Tern):
+#   config:
+#     storage:
+#       dsn: "env:MYSQL_DSN"
+#     databases:
+#       myapp:
+#         type: mysql
+#         environments:
+#           staging:
+#             dsn: "root:pass@tcp(mysql-staging:3306)/myapp"
+#
+# Example (gRPC mode, remote Tern):
+#   config:
+#     storage:
+#       dsn: "secretsmanager:schemabot-db#dsn"
+#     tern_deployments:
+#       default:
+#         staging: "tern-staging:9090"
+#         production: "tern-production:9090"
+config: {}
+
+# Additional environment variables for the SchemaBot container.
+# Useful for env: secret references in the config file.
+env: []
+  # - name: MYSQL_DSN
+  #   value: "root:pass@tcp(mysql:3306)/schemabot"
+  # - name: MYSQL_DSN
+  #   valueFrom:
+  #     secretKeyRef:
+  #       name: schemabot-db
+  #       key: dsn
+
+# Additional volume mounts (e.g., for file: secret references).
+extraVolumeMounts: []
+  # - name: github-app-secrets
+  #   mountPath: /secrets/github-app
+  #   readOnly: true
+
+# Additional volumes.
+extraVolumes: []
+  # - name: github-app-secrets
+  #   secret:
+  #     secretName: schemabot-github-app
+
+resources:
+  requests:
+    cpu: 250m
+    memory: 256Mi
+  limits:
+    cpu: 1000m
+    memory: 512Mi
+
+# Pod annotations (e.g., Istio sidecar config, Datadog).
+podAnnotations: {}
+
+# Node selector, tolerations, affinity.
+nodeSelector: {}
+tolerations: []
+affinity: {}


### PR DESCRIPTION
## Summary

Adds CI for building/publishing the Docker image and a Helm chart for deploying SchemaBot to Kubernetes.

## Workflow: Docker & Helm (`.github/workflows/docker.yml`)

| Trigger | Docker image | Helm chart |
|---|---|---|
| **Pull request** | Build linux/amd64 only (validates Dockerfile, no push) | `ct lint` + version bump check |
| **Push to main** (PR merge) | Build multi-arch (amd64 + arm64), push to `ghcr.io/block/schemabot:latest` and `:<sha>` | — |
| **Version tag** (`v*`) | Build multi-arch, push to `ghcr.io/block/schemabot:v1.0.0` and `:1.0` | Validate tag matches Chart.yaml, package and push to `oci://ghcr.io/block/charts/schemabot:1.0.0` |

PR builds are single-platform for fast feedback (~2 min vs ~16 min with multi-arch).

### CI checks

**On every PR** (two separate jobs, both must pass):

| Job | What it checks |
|---|---|
| `build-and-push` | Docker image builds successfully |
| `lint-chart` | `ct lint` validates chart schema/templates, AND if any `charts/schemabot/` files changed, `Chart.yaml` version must be bumped |

**On version tag** (inside `build-and-push` job):

| Step | What it checks |
|---|---|
| Tag validation | Git tag (e.g. `v0.2.0`) must match committed `Chart.yaml` version (`0.2.0`). Fails with clear error if they diverge. |

### Versioning

`Chart.yaml` is the source of truth for both `version` (chart version) and `appVersion` (Docker image tag default). Both are committed in the repo and bumped in PRs before tagging a release.

Release flow:
1. PR that bumps `version` and `appVersion` in `Chart.yaml`
2. Merge to main
3. `git tag v0.2.0 && git push origin v0.2.0`
4. CI validates tag matches Chart.yaml, builds multi-arch image, packages and publishes chart

## Helm chart (`charts/schemabot/`)

A generic, reusable chart for deploying SchemaBot to Kubernetes. Configurable storage DSN, environment variables, extra volumes, and resource limits. Config is required at install time — `helm install` without setting `config` fails with a clear error instead of deploying a crashlooping pod.

Usage:
```bash
helm install schemabot oci://ghcr.io/block/charts/schemabot --version 0.1.0 \
  --set config.storage.dsn="env:MYSQL_DSN"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)