### PR TITLE
Block unsafe schema changes in webhook apply flow

### DIFF
--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -1128,7 +1128,7 @@ Schema changes require approval from a code owner before applying.
 ┌───────────────────────────────────┐
 │  Database:   testapp (mysql)      │
 │  Locked by:  block/schemabot#123  │
-│  Since:      85 days ago          │
+│  Since:      2 hours ago          │
 │  PR:         block/schemabot#123  │
 └───────────────────────────────────┘
 
@@ -1154,7 +1154,7 @@ Options:
 ┌────────────────────────────────────────────────┐
 │  Database:   testapp (mysql)                   │
 │  Locked by:  cli:deploy@prod-host.example.com  │
-│  Since:      85 days ago                       │
+│  Since:      45 minutes ago                    │
 └────────────────────────────────────────────────┘
 
 Another schema change is in progress for this database.
@@ -1226,12 +1226,12 @@ Use --force to release a lock owned by someone else.
 
   1. testapp (mysql)
      Owner: cli:aparajon@macbook
-     Since: 85 days ago
-     Last activity: 85 days ago
+     Since: 30 minutes ago
+     Last activity: 5 minutes ago
 
   2. payments (vitess)
      Owner: block/payments-api#456
-     Since: 85 days ago
+     Since: 3 hours ago
      PR:    block/payments-api#456
 
 To release a lock:
@@ -2971,10 +2971,10 @@ Volume: ██░░░░░░░░░ 2/11
 
 3 active schema changes
 
-  APPLY ID      DATABASE   ENV         STATE                STARTED      DURATION  CALLER
-  apply_abc123  orders-db  staging     Running              85 days ago  15m       
-  apply_def456  users-db   production  Waiting for cutover  85 days ago  45m       
-  apply_ghi789  analytics  staging     Stopped              85 days ago  2h        
+  APPLY ID      DATABASE   ENV         STATE                STARTED         DURATION  CALLER
+  apply_abc123  orders-db  staging     Running              15 minutes ago  15m       
+  apply_def456  users-db   production  Waiting for cutover  45 minutes ago  45m       
+  apply_ghi789  analytics  staging     Stopped              2 hours ago     2h        
 
 Use 'schemabot status <apply_id>' to view details
 
@@ -2992,11 +2992,11 @@ No recent schema changes
 
 Schema change history for orders-db
 
-  APPLY ID      ENV         STATE      STARTED      DURATION  CALLER
-  apply_abc123  staging     Completed  85 days ago  15m       cli
-  apply_def456  staging     Running    85 days ago  15m       PR 42
-  apply_ghi789  production  Failed     85 days ago  30m       PR 42
-  apply_jkl012  production  Completed  86 days ago  30m       cli
+  APPLY ID      ENV         STATE      STARTED         DURATION  CALLER
+  apply_abc123  staging     Completed  1 hour ago      15m       cli
+  apply_def456  staging     Running    15 minutes ago  15m       PR 42
+  apply_ghi789  production  Failed     3 hours ago     30m       PR 42
+  apply_jkl012  production  Completed  1 day ago       30m       cli
 
 Use 'schemabot status <apply_id>' to view details
 

--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -1128,7 +1128,7 @@ Schema changes require approval from a code owner before applying.
 ┌───────────────────────────────────┐
 │  Database:   testapp (mysql)      │
 │  Locked by:  block/schemabot#123  │
-│  Since:      82 days ago          │
+│  Since:      84 days ago          │
 │  PR:         block/schemabot#123  │
 └───────────────────────────────────┘
 
@@ -1154,7 +1154,7 @@ Options:
 ┌────────────────────────────────────────────────┐
 │  Database:   testapp (mysql)                   │
 │  Locked by:  cli:deploy@prod-host.example.com  │
-│  Since:      82 days ago                       │
+│  Since:      84 days ago                       │
 └────────────────────────────────────────────────┘
 
 Another schema change is in progress for this database.
@@ -1226,12 +1226,12 @@ Use --force to release a lock owned by someone else.
 
   1. testapp (mysql)
      Owner: cli:aparajon@macbook
-     Since: 82 days ago
-     Last activity: 82 days ago
+     Since: 84 days ago
+     Last activity: 84 days ago
 
   2. payments (vitess)
      Owner: block/payments-api#456
-     Since: 82 days ago
+     Since: 84 days ago
      PR:    block/payments-api#456
 
 To release a lock:
@@ -2972,9 +2972,9 @@ Volume: ██░░░░░░░░░ 2/11
 3 active schema changes
 
   APPLY ID      DATABASE   ENV         STATE                STARTED      DURATION  CALLER
-  apply_abc123  orders-db  staging     Running              82 days ago  15m       
-  apply_def456  users-db   production  Waiting for cutover  82 days ago  45m       
-  apply_ghi789  analytics  staging     Stopped              82 days ago  2h        
+  apply_abc123  orders-db  staging     Running              84 days ago  15m       
+  apply_def456  users-db   production  Waiting for cutover  84 days ago  45m       
+  apply_ghi789  analytics  staging     Stopped              84 days ago  2h        
 
 Use 'schemabot status <apply_id>' to view details
 
@@ -2993,10 +2993,10 @@ No recent schema changes
 Schema change history for orders-db
 
   APPLY ID      ENV         STATE      STARTED      DURATION  CALLER
-  apply_abc123  staging     Completed  82 days ago  15m       cli
-  apply_def456  staging     Running    82 days ago  15m       PR 42
-  apply_ghi789  production  Failed     82 days ago  30m       PR 42
-  apply_jkl012  production  Completed  83 days ago  30m       cli
+  apply_abc123  staging     Completed  84 days ago  15m       cli
+  apply_def456  staging     Running    84 days ago  15m       PR 42
+  apply_ghi789  production  Failed     84 days ago  30m       PR 42
+  apply_jkl012  production  Completed  85 days ago  30m       cli
 
 Use 'schemabot status <apply_id>' to view details
 

--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -1128,7 +1128,7 @@ Schema changes require approval from a code owner before applying.
 ┌───────────────────────────────────┐
 │  Database:   testapp (mysql)      │
 │  Locked by:  block/schemabot#123  │
-│  Since:      84 days ago          │
+│  Since:      85 days ago          │
 │  PR:         block/schemabot#123  │
 └───────────────────────────────────┘
 
@@ -1154,7 +1154,7 @@ Options:
 ┌────────────────────────────────────────────────┐
 │  Database:   testapp (mysql)                   │
 │  Locked by:  cli:deploy@prod-host.example.com  │
-│  Since:      84 days ago                       │
+│  Since:      85 days ago                       │
 └────────────────────────────────────────────────┘
 
 Another schema change is in progress for this database.
@@ -1226,12 +1226,12 @@ Use --force to release a lock owned by someone else.
 
   1. testapp (mysql)
      Owner: cli:aparajon@macbook
-     Since: 84 days ago
-     Last activity: 84 days ago
+     Since: 85 days ago
+     Last activity: 85 days ago
 
   2. payments (vitess)
      Owner: block/payments-api#456
-     Since: 84 days ago
+     Since: 85 days ago
      PR:    block/payments-api#456
 
 To release a lock:
@@ -2972,9 +2972,9 @@ Volume: ██░░░░░░░░░ 2/11
 3 active schema changes
 
   APPLY ID      DATABASE   ENV         STATE                STARTED      DURATION  CALLER
-  apply_abc123  orders-db  staging     Running              84 days ago  15m       
-  apply_def456  users-db   production  Waiting for cutover  84 days ago  45m       
-  apply_ghi789  analytics  staging     Stopped              84 days ago  2h        
+  apply_abc123  orders-db  staging     Running              85 days ago  15m       
+  apply_def456  users-db   production  Waiting for cutover  85 days ago  45m       
+  apply_ghi789  analytics  staging     Stopped              85 days ago  2h        
 
 Use 'schemabot status <apply_id>' to view details
 
@@ -2993,10 +2993,10 @@ No recent schema changes
 Schema change history for orders-db
 
   APPLY ID      ENV         STATE      STARTED      DURATION  CALLER
-  apply_abc123  staging     Completed  84 days ago  15m       cli
-  apply_def456  staging     Running    84 days ago  15m       PR 42
-  apply_ghi789  production  Failed     84 days ago  30m       PR 42
-  apply_jkl012  production  Completed  85 days ago  30m       cli
+  apply_abc123  staging     Completed  85 days ago  15m       cli
+  apply_def456  staging     Running    85 days ago  15m       PR 42
+  apply_ghi789  production  Failed     85 days ago  30m       PR 42
+  apply_jkl012  production  Completed  86 days ago  30m       cli
 
 Use 'schemabot status <apply_id>' to view details
 

--- a/pkg/api/proto_helpers.go
+++ b/pkg/api/proto_helpers.go
@@ -13,11 +13,11 @@ import (
 // planResponseFromProto converts a protobuf PlanResponse to an HTTP PlanResponse.
 func planResponseFromProto(resp *ternv1.PlanResponse) *apitypes.PlanResponse {
 	httpResp := &apitypes.PlanResponse{
-		PlanID:       resp.PlanId,
-		Engine:       engineName(resp.Engine),
-		Changes:      []*apitypes.SchemaChangeResponse{},
-		LintWarnings: []*apitypes.LintWarningResponse{},
-		Errors:       []string{},
+		PlanID:      resp.PlanId,
+		Engine:      engineName(resp.Engine),
+		Changes:     []*apitypes.SchemaChangeResponse{},
+		LintResults: []*apitypes.LintWarningResponse{},
+		Errors:      []string{},
 	}
 
 	if len(resp.Errors) > 0 {
@@ -43,7 +43,7 @@ func planResponseFromProto(resp *ternv1.PlanResponse) *apitypes.PlanResponse {
 	}
 
 	for _, w := range resp.LintWarnings {
-		httpResp.LintWarnings = append(httpResp.LintWarnings, &apitypes.LintWarningResponse{
+		httpResp.LintResults = append(httpResp.LintResults, &apitypes.LintWarningResponse{
 			Message:  w.Message,
 			Table:    w.Table,
 			Column:   w.Column,

--- a/pkg/apitypes/apitypes.go
+++ b/pkg/apitypes/apitypes.go
@@ -84,13 +84,13 @@ type PlanResponse struct {
 	Environment  string                  `json:"environment,omitempty"`
 	Engine       string                  `json:"engine"`
 	Changes      []*SchemaChangeResponse `json:"changes"`
-	LintWarnings []*LintWarningResponse  `json:"lint_warnings"`
+	LintResults  []*LintWarningResponse  `json:"lint_warnings"`
 	Errors       []string                `json:"errors"`
 }
 
-// HasErrors returns true if any lint warning has error severity.
+// HasErrors returns true if any lint result has error severity.
 func (r *PlanResponse) HasErrors() bool {
-	for _, w := range r.LintWarnings {
+	for _, w := range r.LintResults {
 		if w.Severity == "error" {
 			return true
 		}
@@ -105,6 +105,70 @@ func (r *PlanResponse) FlatTables() []*TableChangeResponse {
 		tables = append(tables, sc.TableChanges...)
 	}
 	return tables
+}
+
+// UnsafeChange represents a destructive schema change extracted from a plan.
+type UnsafeChange struct {
+	Table      string
+	Reason     string
+	ChangeType string
+}
+
+// UnsafeChanges extracts all table changes marked as unsafe (DROP TABLE, DROP COLUMN, etc.).
+func (r *PlanResponse) UnsafeChanges() []UnsafeChange {
+	var changes []UnsafeChange
+	for _, tbl := range r.FlatTables() {
+		if !tbl.IsUnsafe {
+			continue
+		}
+		changes = append(changes, UnsafeChange{
+			Table:      tbl.TableName,
+			Reason:     tbl.UnsafeReason,
+			ChangeType: tbl.ChangeType,
+		})
+	}
+	return changes
+}
+
+// LintWarning represents a lint warning extracted from a plan response.
+type LintWarning struct {
+	Message string
+	Table   string
+	Linter  string
+}
+
+// LintWarnings returns non-error lint results (warning and info severity).
+// Error-severity results represent unsafe/blocking changes and are shown
+// separately via UnsafeChanges().
+func (r *PlanResponse) LintWarnings() []LintWarning {
+	var warnings []LintWarning
+	for _, w := range r.LintResults {
+		if w.Severity == "error" {
+			continue
+		}
+		warnings = append(warnings, LintWarning{
+			Message: w.Message,
+			Table:   w.Table,
+			Linter:  w.Linter,
+		})
+	}
+	return warnings
+}
+
+// LintErrors returns error-severity lint results (unsafe/blocking changes).
+func (r *PlanResponse) LintErrors() []LintWarning {
+	var warnings []LintWarning
+	for _, w := range r.LintResults {
+		if w.Severity != "error" {
+			continue
+		}
+		warnings = append(warnings, LintWarning{
+			Message: w.Message,
+			Table:   w.Table,
+			Linter:  w.Linter,
+		})
+	}
+	return warnings
 }
 
 // SchemaChangeResponse groups changes for a single namespace.

--- a/pkg/apitypes/apitypes_test.go
+++ b/pkg/apitypes/apitypes_test.go
@@ -1,0 +1,89 @@
+package apitypes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPlanResponse_UnsafeChanges(t *testing.T) {
+	resp := &PlanResponse{
+		Changes: []*SchemaChangeResponse{{
+			Namespace: "testdb",
+			TableChanges: []*TableChangeResponse{
+				{TableName: "orders", DDL: "ALTER TABLE orders ADD COLUMN x INT", IsUnsafe: false},
+				{TableName: "users", DDL: "DROP TABLE users", ChangeType: "drop", IsUnsafe: true, UnsafeReason: "DROP TABLE removes all data"},
+				{TableName: "items", DDL: "ALTER TABLE items DROP INDEX idx", ChangeType: "alter", IsUnsafe: true, UnsafeReason: "DROP INDEX without making invisible first"},
+			},
+		}},
+	}
+
+	changes := resp.UnsafeChanges()
+	require.Len(t, changes, 2)
+	assert.Equal(t, "users", changes[0].Table)
+	assert.Equal(t, "DROP TABLE removes all data", changes[0].Reason)
+	assert.Equal(t, "drop", changes[0].ChangeType)
+	assert.Equal(t, "items", changes[1].Table)
+}
+
+func TestPlanResponse_UnsafeChanges_None(t *testing.T) {
+	resp := &PlanResponse{
+		Changes: []*SchemaChangeResponse{{
+			TableChanges: []*TableChangeResponse{
+				{TableName: "orders", DDL: "ALTER TABLE orders ADD COLUMN x INT", IsUnsafe: false},
+			},
+		}},
+	}
+
+	assert.Empty(t, resp.UnsafeChanges())
+}
+
+func TestPlanResponse_LintWarnings(t *testing.T) {
+	resp := &PlanResponse{
+		LintResults: []*LintWarningResponse{
+			{Message: "DROP TABLE", Table: "users", Linter: "unsafe", Severity: "error"},
+			{Message: "invisible index", Table: "items", Linter: "invisible_index_before_drop", Severity: "error"},
+			{Message: "INT PK", Table: "orders", Linter: "primary_key", Severity: "warning"},
+			{Message: "charset", Table: "orders", Linter: "allow_charset", Severity: "info"},
+		},
+	}
+
+	warnings := resp.LintWarnings()
+	require.Len(t, warnings, 2)
+	assert.Equal(t, "primary_key", warnings[0].Linter)
+	assert.Equal(t, "allow_charset", warnings[1].Linter)
+}
+
+func TestPlanResponse_LintErrors(t *testing.T) {
+	resp := &PlanResponse{
+		LintResults: []*LintWarningResponse{
+			{Message: "DROP TABLE", Table: "users", Linter: "unsafe", Severity: "error"},
+			{Message: "invisible index", Table: "items", Linter: "invisible_index_before_drop", Severity: "error"},
+			{Message: "INT PK", Table: "orders", Linter: "primary_key", Severity: "warning"},
+		},
+	}
+
+	errors := resp.LintErrors()
+	require.Len(t, errors, 2)
+	assert.Equal(t, "unsafe", errors[0].Linter)
+	assert.Equal(t, "invisible_index_before_drop", errors[1].Linter)
+}
+
+func TestPlanResponse_LintWarnings_Empty(t *testing.T) {
+	resp := &PlanResponse{}
+	assert.Empty(t, resp.LintWarnings())
+	assert.Empty(t, resp.LintErrors())
+}
+
+func TestPlanResponse_HasErrors(t *testing.T) {
+	resp := &PlanResponse{
+		LintResults: []*LintWarningResponse{
+			{Severity: "warning"},
+		},
+	}
+	assert.False(t, resp.HasErrors())
+
+	resp.LintResults = append(resp.LintResults, &LintWarningResponse{Severity: "error"})
+	assert.True(t, resp.HasErrors())
+}

--- a/pkg/cmd/commands/apply.go
+++ b/pkg/cmd/commands/apply.go
@@ -137,7 +137,7 @@ func (cmd *ApplyCmd) Run(g *Globals) error {
 
 	// Show unsafe warning if --allow-unsafe was used
 	if planResult.HasErrors() && cmd.AllowUnsafe {
-		templates.WriteUnsafeWarningAllowed(GetUnsafeChanges(planResult))
+		templates.WriteUnsafeWarningAllowed(planResult.UnsafeChanges())
 	}
 
 	// Show options if any flags are set
@@ -338,7 +338,7 @@ func blockUnsafeApply(planResult *apitypes.PlanResponse, database, environment, 
 	OutputPlanResult(planResult, database, environment, schemaDir, true)
 
 	// Then show the unsafe changes warning
-	unsafeChanges := GetUnsafeChanges(planResult)
+	unsafeChanges := planResult.UnsafeChanges()
 	templates.WriteUnsafeChangesBlocked(unsafeChanges, database, environment, schemaDir)
 	return ErrSilent
 }

--- a/pkg/cmd/commands/common.go
+++ b/pkg/cmd/commands/common.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/block/schemabot/pkg/apitypes"
 	"github.com/block/schemabot/pkg/cmd/client"
-	"github.com/block/schemabot/pkg/cmd/templates"
 	ghclient "github.com/block/schemabot/pkg/github"
 )
 
@@ -124,57 +123,6 @@ func LoadCLIConfig(dir string) (*CLIConfig, error) {
 	}
 
 	return &cfg, nil
-}
-
-// GetUnsafeChanges extracts unsafe change descriptions from a plan result.
-// Used by both plan and apply commands to display unsafe changes consistently.
-func GetUnsafeChanges(planResult *apitypes.PlanResponse) []templates.UnsafeChange {
-	var changes []templates.UnsafeChange
-
-	for _, tbl := range planResult.FlatTables() {
-		if !tbl.IsUnsafe {
-			continue
-		}
-		changes = append(changes, templates.UnsafeChange{
-			Table:      tbl.TableName,
-			Reason:     tbl.UnsafeReason,
-			ChangeType: tbl.ChangeType,
-		})
-	}
-
-	return changes
-}
-
-// ParseLintWarnings extracts all lint warnings from the API response.
-func ParseLintWarnings(warnings []*apitypes.LintWarningResponse) []templates.LintWarning {
-	var lintWarnings []templates.LintWarning
-	for _, warn := range warnings {
-		lintWarnings = append(lintWarnings, templates.LintWarning{
-			Message: warn.Message,
-			Table:   warn.Table,
-			Linter:  warn.Linter,
-		})
-	}
-	return lintWarnings
-}
-
-// ParseNonUnsafeLintWarnings extracts lint warnings that are NOT unsafe changes.
-// Unsafe changes are shown separately with the ⛔ template.
-func ParseNonUnsafeLintWarnings(warnings []*apitypes.LintWarningResponse) []templates.LintWarning {
-	var lintWarnings []templates.LintWarning
-	for _, warn := range warnings {
-		// Skip unsafe linter warnings - they're shown in the unsafe changes section
-		if warn.Linter == "unsafe" || warn.Linter == "invisible_index_before_drop" {
-			continue
-		}
-
-		lintWarnings = append(lintWarnings, templates.LintWarning{
-			Message: warn.Message,
-			Table:   warn.Table,
-			Linter:  warn.Linter,
-		})
-	}
-	return lintWarnings
 }
 
 // resolveEndpoint resolves the API endpoint from explicit flag or profile config.

--- a/pkg/cmd/commands/plan.go
+++ b/pkg/cmd/commands/plan.go
@@ -178,17 +178,15 @@ func writePlanBody(result *apitypes.PlanResponse, isApply bool) {
 
 	// Check for unsafe changes and show with ⛔ (error level)
 	// Skip in apply context — apply shows its own 🚨 warning via WriteUnsafeWarningAllowed
-	unsafeChanges := GetUnsafeChanges(result)
+	unsafeChanges := result.UnsafeChanges()
 	if len(unsafeChanges) > 0 && !isApply {
 		templates.WriteUnsafeChangesWarning(unsafeChanges)
 	}
 
 	// Show non-unsafe lint warnings with ⚠️
-	if len(result.LintWarnings) > 0 {
-		lintWarnings := ParseNonUnsafeLintWarnings(result.LintWarnings)
-		if len(lintWarnings) > 0 {
-			templates.WriteLintWarnings(lintWarnings)
-		}
+	lintWarnings := result.LintWarnings()
+	if len(lintWarnings) > 0 {
+		templates.WriteLintWarnings(lintWarnings)
 	}
 
 	// Write summary line at the end

--- a/pkg/cmd/commands/rollback.go
+++ b/pkg/cmd/commands/rollback.go
@@ -82,7 +82,7 @@ func (cmd *RollbackCmd) Run(g *Globals) error {
 
 	// Show unsafe warning if any
 	if planResult.HasErrors() {
-		unsafeChanges := GetUnsafeChanges(planResult)
+		unsafeChanges := planResult.UnsafeChanges()
 		templates.WriteUnsafeWarningAllowed(unsafeChanges)
 	}
 

--- a/pkg/cmd/templates/plan.go
+++ b/pkg/cmd/templates/plan.go
@@ -8,6 +8,7 @@ import (
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 
+	"github.com/block/schemabot/pkg/apitypes"
 	"github.com/block/schemabot/pkg/ddl"
 )
 
@@ -324,11 +325,8 @@ func WriteOptions(deferCutover bool) {
 }
 
 // LintWarning represents a lint warning.
-type LintWarning struct {
-	Message string
-	Table   string
-	Linter  string
-}
+// LintWarning is a type alias for the shared lint warning type.
+type LintWarning = apitypes.LintWarning
 
 // WriteLintWarnings writes lint warnings if any.
 func WriteLintWarnings(warnings []LintWarning) {
@@ -367,12 +365,8 @@ func WriteErrors(errors []string) {
 	fmt.Println()
 }
 
-// UnsafeChange represents a destructive schema change.
-type UnsafeChange struct {
-	Table      string
-	Reason     string
-	ChangeType string
-}
+// UnsafeChange is a type alias for the shared unsafe change type.
+type UnsafeChange = apitypes.UnsafeChange
 
 // WriteUnsafeChangesWarning writes a warning about unsafe changes (for plan output).
 func WriteUnsafeChangesWarning(changes []UnsafeChange) {

--- a/pkg/cmd/templates/plan.go
+++ b/pkg/cmd/templates/plan.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/block/schemabot/pkg/apitypes"
 	"github.com/block/schemabot/pkg/ddl"
+	"github.com/block/schemabot/pkg/ui"
 )
 
 const minBoxWidth = 45
@@ -407,18 +408,17 @@ func WriteUnsafeWarningAllowed(changes []UnsafeChange) {
 // writeUnsafeChangesList writes the list of unsafe changes, splitting multi-reason entries.
 func writeUnsafeChangesList(changes []UnsafeChange) {
 	for _, c := range changes {
-		if c.Reason != "" {
+		reason := ui.CleanLintReason(c.Reason)
+		if reason != "" {
 			// Split multiple reasons (joined by "; " in the engine)
-			reasons := strings.Split(c.Reason, "; ")
+			reasons := strings.Split(reason, "; ")
 			if len(reasons) > 1 {
-				// Multiple reasons - show table header then indented list
 				fmt.Printf("  • %s:\n", c.Table)
 				for _, r := range reasons {
 					fmt.Printf("      - %s\n", r)
 				}
 			} else {
-				// Single reason - inline format
-				fmt.Printf("  • %s: %s\n", c.Table, c.Reason)
+				fmt.Printf("  • %s: %s\n", c.Table, reason)
 			}
 		} else {
 			fmt.Printf("  • %s: %s\n", c.Table, c.ChangeType)

--- a/pkg/cmd/templates/preview.go
+++ b/pkg/cmd/templates/preview.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/block/schemabot/pkg/state"
+	"github.com/block/schemabot/pkg/ui"
 	webhooktemplates "github.com/block/schemabot/pkg/webhook/templates"
 )
 
@@ -16,6 +17,7 @@ var previewTime = time.Date(2026, 1, 15, 14, 30, 0, 0, time.UTC)
 // SetPreviewMode configures the package to use fixed timestamps for deterministic output.
 func SetPreviewMode() {
 	nowFunc = func() time.Time { return previewTime }
+	ui.NowFunc = func() time.Time { return previewTime }
 }
 
 // PreviewType represents the type of preview to show.

--- a/pkg/ui/format.go
+++ b/pkg/ui/format.go
@@ -176,8 +176,17 @@ func TableStatePriority(taskState string) int {
 }
 
 // CleanLintReason strips severity prefixes like "[ERROR] linter_name:" from
-// Spirit's raw lint violation strings for cleaner display.
+// Spirit's raw lint violation strings for cleaner display. Handles multiple
+// violations joined by "; " by cleaning each segment individually.
 func CleanLintReason(reason string) string {
+	segments := strings.Split(reason, "; ")
+	for i, seg := range segments {
+		segments[i] = cleanSingleLintReason(seg)
+	}
+	return strings.Join(segments, "; ")
+}
+
+func cleanSingleLintReason(reason string) string {
 	for _, prefix := range []string{"[ERROR] ", "[WARNING] ", "[INFO] "} {
 		if strings.HasPrefix(reason, prefix) {
 			reason = reason[len(prefix):]

--- a/pkg/ui/format.go
+++ b/pkg/ui/format.go
@@ -171,3 +171,18 @@ func TableStatePriority(taskState string) int {
 		return 2
 	}
 }
+
+// CleanLintReason strips severity prefixes like "[ERROR] linter_name:" from
+// Spirit's raw lint violation strings for cleaner display.
+func CleanLintReason(reason string) string {
+	for _, prefix := range []string{"[ERROR] ", "[WARNING] ", "[INFO] "} {
+		if strings.HasPrefix(reason, prefix) {
+			reason = reason[len(prefix):]
+			if idx := strings.Index(reason, ": "); idx != -1 {
+				reason = reason[idx+2:]
+			}
+			break
+		}
+	}
+	return reason
+}

--- a/pkg/ui/format.go
+++ b/pkg/ui/format.go
@@ -59,9 +59,12 @@ func ClampPercent(pct int) int {
 	return pct
 }
 
+// NowFunc returns the current time. Override in previews for deterministic output.
+var NowFunc = time.Now
+
 // FormatTimeAgo formats a time as a relative string like "5 minutes ago".
 func FormatTimeAgo(t time.Time) string {
-	d := time.Since(t)
+	d := NowFunc().Sub(t)
 	if d < time.Minute {
 		return "just now"
 	}

--- a/pkg/ui/format_test.go
+++ b/pkg/ui/format_test.go
@@ -53,6 +53,11 @@ func TestCleanLintReason(t *testing.T) {
 			expect: "DROP TABLE removes all data",
 		},
 		{
+			name:   "multiple reasons joined by semicolon",
+			input:  "[ERROR] unsafe: DROP COLUMN removes data; [ERROR] invisible_index_before_drop: Index should be invisible first",
+			expect: "DROP COLUMN removes data; Index should be invisible first",
+		},
+		{
 			name:   "empty string",
 			input:  "",
 			expect: "",

--- a/pkg/ui/format_test.go
+++ b/pkg/ui/format_test.go
@@ -30,3 +30,38 @@ func TestTableStatePriority(t *testing.T) {
 		})
 	}
 }
+
+func TestCleanLintReason(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		expect string
+	}{
+		{
+			name:   "strips ERROR prefix and linter name",
+			input:  "[ERROR] invisible_index_before_drop: Index 'idx_status' should be made invisible",
+			expect: "Index 'idx_status' should be made invisible",
+		},
+		{
+			name:   "strips WARNING prefix and linter name",
+			input:  "[WARNING] unsafe: DROP COLUMN removes data",
+			expect: "DROP COLUMN removes data",
+		},
+		{
+			name:   "no prefix passes through",
+			input:  "DROP TABLE removes all data",
+			expect: "DROP TABLE removes all data",
+		},
+		{
+			name:   "empty string",
+			input:  "",
+			expect: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expect, CleanLintReason(tt.input))
+		})
+	}
+}

--- a/pkg/webhook/apply_handlers.go
+++ b/pkg/webhook/apply_handlers.go
@@ -136,6 +136,14 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 		return
 	}
 
+	// Block unsafe changes unless --allow-unsafe was specified
+	if planResp.HasErrors() && !result.AllowUnsafe {
+		commentData := buildPlanCommentData(schemaResult, planResp, environment, requestedBy)
+		h.logger.Info("apply blocked by unsafe changes", "repo", repo, "pr", pr, "database", database, "environment", environment)
+		h.postComment(repo, pr, installationID, templates.RenderUnsafeChangesBlocked(commentData))
+		return
+	}
+
 	// Acquire lock
 	lock := &storage.Lock{
 		DatabaseName: database,
@@ -162,6 +170,7 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 	commentData.LockAcquired = time.Now().UTC().Format("2006-01-02 15:04:05 UTC")
 	commentData.DeferCutover = result.DeferCutover
 	commentData.EnableRevert = result.EnableRevert
+	commentData.AllowUnsafe = result.AllowUnsafe
 
 	h.postComment(repo, pr, installationID, templates.RenderPlanComment(commentData))
 
@@ -267,6 +276,9 @@ func (h *Handler) handleApplyConfirmCommand(repo string, pr int, environment, da
 	}
 	if result.EnableRevert {
 		options["enable_revert"] = "true"
+	}
+	if result.AllowUnsafe {
+		options["allow_unsafe"] = "true"
 	}
 
 	caller := fmt.Sprintf("github:%s@%s#%d", requestedBy, repo, pr)

--- a/pkg/webhook/apply_handlers.go
+++ b/pkg/webhook/apply_handlers.go
@@ -137,7 +137,7 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 	}
 
 	// Block unsafe changes unless --allow-unsafe was specified
-	if planResp.HasErrors() && !result.AllowUnsafe {
+	if len(planResp.UnsafeChanges()) > 0 && !result.AllowUnsafe {
 		commentData := buildPlanCommentData(schemaResult, planResp, environment, requestedBy)
 		h.logger.Info("apply blocked by unsafe changes", "repo", repo, "pr", pr, "database", database, "environment", environment)
 		h.postComment(repo, pr, installationID, templates.RenderUnsafeChangesBlocked(commentData))
@@ -266,6 +266,14 @@ func (h *Handler) handleApplyConfirmCommand(repo string, pr int, environment, da
 	if len(planResp.FlatTables()) == 0 {
 		_ = h.service.Storage().Locks().ForceRelease(ctx, database, dbType)
 		h.postComment(repo, pr, installationID, templates.RenderApplyConfirmNoChanges(database, environment))
+		return
+	}
+
+	// Block unsafe changes on confirm (re-plan may have detected new unsafe changes)
+	if len(planResp.UnsafeChanges()) > 0 && !result.AllowUnsafe {
+		commentData := buildPlanCommentData(schemaResult, planResp, environment, requestedBy)
+		h.logger.Info("apply-confirm blocked by unsafe changes", "repo", repo, "pr", pr, "database", database, "environment", environment)
+		h.postComment(repo, pr, installationID, templates.RenderUnsafeChangesBlocked(commentData))
 		return
 	}
 

--- a/pkg/webhook/check_runs.go
+++ b/pkg/webhook/check_runs.go
@@ -100,12 +100,12 @@ func buildCheckRunSummary(planResp *apitypes.PlanResponse) string {
 		fmt.Fprintf(&sb, "- `%s` (%s)\n", table.TableName, table.ChangeType)
 	}
 
-	if len(planResp.LintResults) > 0 {
-		fmt.Fprintf(&sb, "\n**%d lint warning(s)**\n", len(planResp.LintResults))
+	if lintWarnings := planResp.LintWarnings(); len(lintWarnings) > 0 {
+		fmt.Fprintf(&sb, "\n**%d lint warning(s)**\n", len(lintWarnings))
 	}
 
-	if planResp.HasErrors() {
-		sb.WriteString("\n**Warning: contains unsafe changes that require --allow-unsafe**\n")
+	if lintErrors := planResp.LintErrors(); len(lintErrors) > 0 {
+		fmt.Fprintf(&sb, "\n**%d unsafe change(s) require --allow-unsafe**\n", len(lintErrors))
 	}
 
 	return sb.String()

--- a/pkg/webhook/check_runs.go
+++ b/pkg/webhook/check_runs.go
@@ -100,8 +100,8 @@ func buildCheckRunSummary(planResp *apitypes.PlanResponse) string {
 		fmt.Fprintf(&sb, "- `%s` (%s)\n", table.TableName, table.ChangeType)
 	}
 
-	if len(planResp.LintWarnings) > 0 {
-		fmt.Fprintf(&sb, "\n**%d lint warning(s)**\n", len(planResp.LintWarnings))
+	if len(planResp.LintResults) > 0 {
+		fmt.Fprintf(&sb, "\n**%d lint warning(s)**\n", len(planResp.LintResults))
 	}
 
 	if planResp.HasErrors() {

--- a/pkg/webhook/commands.go
+++ b/pkg/webhook/commands.go
@@ -15,6 +15,7 @@ type CommandParser struct {
 	databaseRegex          *regexp.Regexp
 	enableRevertRegex      *regexp.Regexp
 	deferCutoverRegex      *regexp.Regexp
+	allowUnsafeRegex       *regexp.Regexp
 }
 
 // NewCommandParser creates a new command parser.
@@ -28,6 +29,7 @@ func NewCommandParser() *CommandParser {
 		databaseRegex:          regexp.MustCompile(`(?i)-d\s+([a-zA-Z0-9_-]+)`),
 		enableRevertRegex:      regexp.MustCompile(`(?i)--enable-revert\b`),
 		deferCutoverRegex:      regexp.MustCompile(`(?i)--defer-cutover\b`),
+		allowUnsafeRegex:       regexp.MustCompile(`(?i)--allow-unsafe\b`),
 	}
 }
 
@@ -39,6 +41,7 @@ type CommandResult struct {
 	Database     string // Optional -d flag value
 	EnableRevert bool
 	DeferCutover bool
+	AllowUnsafe  bool
 	Found        bool
 	IsHelp       bool
 	IsMention    bool
@@ -79,6 +82,7 @@ func (p *CommandParser) ParseCommand(body string) CommandResult {
 			IsMention:    true,
 			EnableRevert: p.enableRevertRegex.MatchString(body),
 			DeferCutover: p.deferCutoverRegex.MatchString(body),
+			AllowUnsafe:  p.allowUnsafeRegex.MatchString(body),
 		}
 
 		dbMatches := p.databaseRegex.FindStringSubmatch(body)

--- a/pkg/webhook/commands_test.go
+++ b/pkg/webhook/commands_test.go
@@ -235,8 +235,19 @@ func TestParseCommand(t *testing.T) {
 			},
 		},
 		{
+			name: "apply with allow-unsafe",
+			body: "schemabot apply -e staging --allow-unsafe",
+			expected: CommandResult{
+				Action:      "apply",
+				Environment: "staging",
+				Found:       true,
+				IsMention:   true,
+				AllowUnsafe: true,
+			},
+		},
+		{
 			name: "all flags combined",
-			body: "schemabot apply -e production -d payments_db --defer-cutover --enable-revert",
+			body: "schemabot apply -e production -d payments_db --defer-cutover --enable-revert --allow-unsafe",
 			expected: CommandResult{
 				Action:       "apply",
 				Environment:  "production",
@@ -245,6 +256,7 @@ func TestParseCommand(t *testing.T) {
 				IsMention:    true,
 				EnableRevert: true,
 				DeferCutover: true,
+				AllowUnsafe:  true,
 			},
 		},
 	}

--- a/pkg/webhook/plan.go
+++ b/pkg/webhook/plan.go
@@ -233,21 +233,20 @@ func buildPlanCommentData(schema *ghclient.SchemaRequestResult, planResp *apityp
 		data.Changes = append(data.Changes, ksData)
 	}
 
-	// Extract unsafe changes from table changes
-	for _, sc := range planResp.Changes {
-		for _, t := range sc.TableChanges {
-			if t.IsUnsafe {
-				data.HasUnsafeChanges = true
-				data.UnsafeChanges = append(data.UnsafeChanges, templates.UnsafeChangeData{
-					Table:  t.TableName,
-					Reason: t.UnsafeReason,
-				})
-			}
+	// Extract unsafe changes using shared logic
+	unsafeChanges := planResp.UnsafeChanges()
+	if len(unsafeChanges) > 0 {
+		data.HasUnsafeChanges = true
+		for _, uc := range unsafeChanges {
+			data.UnsafeChanges = append(data.UnsafeChanges, templates.UnsafeChangeData{
+				Table:  uc.Table,
+				Reason: uc.Reason,
+			})
 		}
 	}
 
-	// Add lint warnings
-	for _, w := range planResp.LintWarnings {
+	// Add lint warnings (error-severity results are shown via UnsafeChanges instead)
+	for _, w := range planResp.LintWarnings() {
 		data.LintWarnings = append(data.LintWarnings, templates.LintWarningData{
 			Message: w.Message,
 			Table:   w.Table,

--- a/pkg/webhook/plan.go
+++ b/pkg/webhook/plan.go
@@ -233,7 +233,6 @@ func buildPlanCommentData(schema *ghclient.SchemaRequestResult, planResp *apityp
 		data.Changes = append(data.Changes, ksData)
 	}
 
-	// Extract unsafe changes using shared logic
 	unsafeChanges := planResp.UnsafeChanges()
 	if len(unsafeChanges) > 0 {
 		data.HasUnsafeChanges = true

--- a/pkg/webhook/plan.go
+++ b/pkg/webhook/plan.go
@@ -233,6 +233,19 @@ func buildPlanCommentData(schema *ghclient.SchemaRequestResult, planResp *apityp
 		data.Changes = append(data.Changes, ksData)
 	}
 
+	// Extract unsafe changes from table changes
+	for _, sc := range planResp.Changes {
+		for _, t := range sc.TableChanges {
+			if t.IsUnsafe {
+				data.HasUnsafeChanges = true
+				data.UnsafeChanges = append(data.UnsafeChanges, templates.UnsafeChangeData{
+					Table:  t.TableName,
+					Reason: t.UnsafeReason,
+				})
+			}
+		}
+	}
+
 	// Add lint warnings
 	for _, w := range planResp.LintWarnings {
 		data.LintWarnings = append(data.LintWarnings, templates.LintWarningData{

--- a/pkg/webhook/plan_test.go
+++ b/pkg/webhook/plan_test.go
@@ -28,7 +28,7 @@ func TestBuildPlanCommentData_UnsafeChangesPopulated(t *testing.T) {
 				UnsafeReason: "DROP INDEX without making invisible first",
 			}},
 		}},
-		LintWarnings: []*apitypes.LintWarningResponse{{
+		LintResults: []*apitypes.LintWarningResponse{{
 			Message:  "Index 'idx_status' should be made invisible before dropping",
 			Table:    "orders",
 			Linter:   "invisible_index_before_drop",

--- a/pkg/webhook/plan_test.go
+++ b/pkg/webhook/plan_test.go
@@ -120,7 +120,7 @@ func TestRenderPlanComment_ShowsUnsafeWarning(t *testing.T) {
 
 	rendered := templates.RenderPlanComment(data)
 
-	assert.Contains(t, rendered, "Unsafe Changes Detected")
+	assert.Contains(t, rendered, "⛔ Unsafe Changes Detected")
 	assert.Contains(t, rendered, "`orders`")
 	assert.Contains(t, rendered, "DROP INDEX without making invisible first")
 	// Plan comment should NOT say "--allow-unsafe enabled" since it wasn't

--- a/pkg/webhook/plan_test.go
+++ b/pkg/webhook/plan_test.go
@@ -1,0 +1,129 @@
+package webhook
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/block/schemabot/pkg/apitypes"
+	ghclient "github.com/block/schemabot/pkg/github"
+	"github.com/block/schemabot/pkg/webhook/templates"
+)
+
+func TestBuildPlanCommentData_UnsafeChangesPopulated(t *testing.T) {
+	schema := &ghclient.SchemaRequestResult{
+		Database: "testdb",
+		Type:     "mysql",
+	}
+
+	planResp := &apitypes.PlanResponse{
+		Changes: []*apitypes.SchemaChangeResponse{{
+			Namespace: "testdb",
+			TableChanges: []*apitypes.TableChangeResponse{{
+				TableName:    "orders",
+				DDL:          "ALTER TABLE `orders` DROP INDEX `idx_status`",
+				ChangeType:   "alter",
+				IsUnsafe:     true,
+				UnsafeReason: "DROP INDEX without making invisible first",
+			}},
+		}},
+		LintWarnings: []*apitypes.LintWarningResponse{{
+			Message:  "Index 'idx_status' should be made invisible before dropping",
+			Table:    "orders",
+			Linter:   "invisible_index_before_drop",
+			Severity: "error",
+		}},
+	}
+
+	data := buildPlanCommentData(schema, planResp, "staging", "testuser")
+
+	assert.True(t, data.HasUnsafeChanges, "expected HasUnsafeChanges=true when plan contains unsafe table changes")
+	require.Len(t, data.UnsafeChanges, 1)
+	assert.Equal(t, "orders", data.UnsafeChanges[0].Table)
+	assert.Equal(t, "DROP INDEX without making invisible first", data.UnsafeChanges[0].Reason)
+}
+
+func TestBuildPlanCommentData_NoUnsafeChanges(t *testing.T) {
+	schema := &ghclient.SchemaRequestResult{
+		Database: "testdb",
+		Type:     "mysql",
+	}
+
+	planResp := &apitypes.PlanResponse{
+		Changes: []*apitypes.SchemaChangeResponse{{
+			Namespace: "testdb",
+			TableChanges: []*apitypes.TableChangeResponse{{
+				TableName:  "orders",
+				DDL:        "ALTER TABLE `orders` ADD COLUMN `status2` varchar(50)",
+				ChangeType: "alter",
+				IsUnsafe:   false,
+			}},
+		}},
+	}
+
+	data := buildPlanCommentData(schema, planResp, "staging", "testuser")
+
+	assert.False(t, data.HasUnsafeChanges)
+	assert.Empty(t, data.UnsafeChanges)
+}
+
+func TestBuildPlanCommentData_MixedSafeAndUnsafe(t *testing.T) {
+	schema := &ghclient.SchemaRequestResult{
+		Database: "testdb",
+		Type:     "mysql",
+	}
+
+	planResp := &apitypes.PlanResponse{
+		Changes: []*apitypes.SchemaChangeResponse{{
+			Namespace: "testdb",
+			TableChanges: []*apitypes.TableChangeResponse{
+				{
+					TableName:  "orders",
+					DDL:        "ALTER TABLE `orders` ADD COLUMN `status2` varchar(50)",
+					ChangeType: "alter",
+					IsUnsafe:   false,
+				},
+				{
+					TableName:    "users",
+					DDL:          "DROP TABLE `users`",
+					ChangeType:   "drop",
+					IsUnsafe:     true,
+					UnsafeReason: "DROP TABLE removes all data",
+				},
+			},
+		}},
+	}
+
+	data := buildPlanCommentData(schema, planResp, "staging", "testuser")
+
+	assert.True(t, data.HasUnsafeChanges)
+	require.Len(t, data.UnsafeChanges, 1)
+	assert.Equal(t, "users", data.UnsafeChanges[0].Table)
+}
+
+func TestRenderUnsafeChangesBlocked_UsedByApplyFlow(t *testing.T) {
+	// Verify RenderUnsafeChangesBlocked produces the expected blocking content
+	data := templates.PlanCommentData{
+		Database:    "testdb",
+		Environment: "staging",
+		IsMySQL:     true,
+		Changes: []templates.KeyspaceChangeData{{
+			Keyspace:   "testdb",
+			Statements: []string{"DROP TABLE `users`"},
+		}},
+		HasUnsafeChanges: true,
+		UnsafeChanges: []templates.UnsafeChangeData{{
+			Table:  "users",
+			Reason: "DROP TABLE removes all data",
+		}},
+	}
+
+	rendered := templates.RenderUnsafeChangesBlocked(data)
+
+	assert.Contains(t, rendered, "⛔ Unsafe Changes Detected")
+	assert.Contains(t, rendered, "`users`")
+	assert.Contains(t, rendered, "DROP TABLE removes all data")
+	assert.Contains(t, rendered, "--allow-unsafe")
+	assert.Contains(t, rendered, "schemabot apply -e staging --allow-unsafe")
+}

--- a/pkg/webhook/plan_test.go
+++ b/pkg/webhook/plan_test.go
@@ -102,6 +102,72 @@ func TestBuildPlanCommentData_MixedSafeAndUnsafe(t *testing.T) {
 	assert.Equal(t, "users", data.UnsafeChanges[0].Table)
 }
 
+func TestRenderPlanComment_ShowsUnsafeWarning(t *testing.T) {
+	data := templates.PlanCommentData{
+		Database:    "testdb",
+		Environment: "staging",
+		IsMySQL:     true,
+		Changes: []templates.KeyspaceChangeData{{
+			Keyspace:   "testdb",
+			Statements: []string{"ALTER TABLE `orders` DROP INDEX `idx_status`"},
+		}},
+		HasUnsafeChanges: true,
+		UnsafeChanges: []templates.UnsafeChangeData{{
+			Table:  "orders",
+			Reason: "DROP INDEX without making invisible first",
+		}},
+	}
+
+	rendered := templates.RenderPlanComment(data)
+
+	assert.Contains(t, rendered, "Unsafe Changes Detected")
+	assert.Contains(t, rendered, "`orders`")
+	assert.Contains(t, rendered, "DROP INDEX without making invisible first")
+	// Plan comment should NOT say "--allow-unsafe enabled" since it wasn't
+	assert.NotContains(t, rendered, "--allow-unsafe` enabled")
+}
+
+func TestRenderPlanComment_UnsafeWithAllowUnsafe(t *testing.T) {
+	data := templates.PlanCommentData{
+		Database:    "testdb",
+		Environment: "staging",
+		IsMySQL:     true,
+		IsLocked:    true,
+		AllowUnsafe: true,
+		Changes: []templates.KeyspaceChangeData{{
+			Keyspace:   "testdb",
+			Statements: []string{"DROP TABLE `users`"},
+		}},
+		HasUnsafeChanges: true,
+		UnsafeChanges: []templates.UnsafeChangeData{{
+			Table:  "users",
+			Reason: "DROP TABLE removes all data",
+		}},
+	}
+
+	rendered := templates.RenderPlanComment(data)
+
+	assert.Contains(t, rendered, "--allow-unsafe` enabled")
+	assert.Contains(t, rendered, "`users`")
+	assert.Contains(t, rendered, "apply-confirm -e staging --allow-unsafe")
+}
+
+func TestRenderPlanComment_NoUnsafe_NoWarning(t *testing.T) {
+	data := templates.PlanCommentData{
+		Database:    "testdb",
+		Environment: "staging",
+		IsMySQL:     true,
+		Changes: []templates.KeyspaceChangeData{{
+			Keyspace:   "testdb",
+			Statements: []string{"ALTER TABLE `orders` ADD COLUMN `x` INT"},
+		}},
+	}
+
+	rendered := templates.RenderPlanComment(data)
+
+	assert.NotContains(t, rendered, "Unsafe")
+}
+
 func TestRenderUnsafeChangesBlocked_UsedByApplyFlow(t *testing.T) {
 	// Verify RenderUnsafeChangesBlocked produces the expected blocking content
 	data := templates.PlanCommentData{

--- a/pkg/webhook/rollback.go
+++ b/pkg/webhook/rollback.go
@@ -159,7 +159,7 @@ func (h *Handler) handleRollbackCommand(repo string, pr int, installationID int6
 		commentData.Changes = append(commentData.Changes, nsData)
 	}
 
-	for _, w := range planResp.LintWarnings {
+	for _, w := range planResp.LintWarnings() {
 		commentData.LintWarnings = append(commentData.LintWarnings, templates.LintWarningData{
 			Message: w.Message,
 			Table:   w.Table,

--- a/pkg/webhook/templates/apply_commands.go
+++ b/pkg/webhook/templates/apply_commands.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 	"time"
+
+	"github.com/block/schemabot/pkg/ui"
 )
 
 // ApplyLockConflictData contains data for apply lock conflict comments.
@@ -56,8 +58,9 @@ func RenderUnsafeChangesBlocked(data PlanCommentData) string {
 	sb.WriteString("---\n\n")
 	sb.WriteString("**⛔ Unsafe Changes Detected:**\n")
 	for _, c := range data.UnsafeChanges {
-		if c.Reason != "" {
-			fmt.Fprintf(&sb, "- `%s`: %s\n", c.Table, c.Reason)
+		reason := ui.CleanLintReason(c.Reason)
+		if reason != "" {
+			fmt.Fprintf(&sb, "- `%s`: %s\n", c.Table, reason)
 		} else {
 			fmt.Fprintf(&sb, "- `%s`\n", c.Table)
 		}

--- a/pkg/webhook/templates/plan.go
+++ b/pkg/webhook/templates/plan.go
@@ -97,9 +97,9 @@ func RenderPlanComment(data PlanCommentData) string {
 	// Detailed changes
 	writeKeyspaceChanges(&sb, data)
 
-	// Unsafe changes warning (when --allow-unsafe was used)
-	if data.HasUnsafeChanges && data.AllowUnsafe && len(data.UnsafeChanges) > 0 {
-		writeUnsafeWarning(&sb, data.UnsafeChanges)
+	// Unsafe changes warning
+	if data.HasUnsafeChanges && len(data.UnsafeChanges) > 0 {
+		writeUnsafeWarning(&sb, data.UnsafeChanges, data.AllowUnsafe)
 	}
 
 	// Lint warnings
@@ -283,8 +283,12 @@ func writeKeyspaceChanges(sb *strings.Builder, data PlanCommentData) {
 	}
 }
 
-func writeUnsafeWarning(sb *strings.Builder, changes []UnsafeChangeData) {
-	sb.WriteString("**🚨 Unsafe Changes** (`--allow-unsafe` enabled):\n")
+func writeUnsafeWarning(sb *strings.Builder, changes []UnsafeChangeData, allowUnsafe bool) {
+	if allowUnsafe {
+		sb.WriteString("**🚨 Unsafe Changes** (`--allow-unsafe` enabled):\n")
+	} else {
+		sb.WriteString("**⚠️ Unsafe Changes Detected:**\n")
+	}
 	for _, c := range changes {
 		if c.Reason != "" {
 			fmt.Fprintf(sb, "- `%s`: %s\n", c.Table, c.Reason)
@@ -417,9 +421,9 @@ func writeEnvironmentPlanSection(sb *strings.Builder, plan *PlanCommentData, isM
 	// Detailed changes
 	writeKeyspaceChanges(sb, *plan)
 
-	// Unsafe changes warning (when --allow-unsafe was used)
-	if plan.HasUnsafeChanges && plan.AllowUnsafe && len(plan.UnsafeChanges) > 0 {
-		writeUnsafeWarning(sb, plan.UnsafeChanges)
+	// Unsafe changes warning
+	if plan.HasUnsafeChanges && len(plan.UnsafeChanges) > 0 {
+		writeUnsafeWarning(sb, plan.UnsafeChanges, plan.AllowUnsafe)
 	}
 
 	// Lint warnings

--- a/pkg/webhook/templates/plan.go
+++ b/pkg/webhook/templates/plan.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/block/schemabot/pkg/ddl"
+	"github.com/block/schemabot/pkg/ui"
 )
 
 // LintWarningData represents a structured lint warning for template rendering.
@@ -287,11 +288,12 @@ func writeUnsafeWarning(sb *strings.Builder, changes []UnsafeChangeData, allowUn
 	if allowUnsafe {
 		sb.WriteString("**🚨 Unsafe Changes** (`--allow-unsafe` enabled):\n")
 	} else {
-		sb.WriteString("**⚠️ Unsafe Changes Detected:**\n")
+		sb.WriteString("**⛔ Unsafe Changes Detected:**\n")
 	}
 	for _, c := range changes {
-		if c.Reason != "" {
-			fmt.Fprintf(sb, "- `%s`: %s\n", c.Table, c.Reason)
+		reason := ui.CleanLintReason(c.Reason)
+		if reason != "" {
+			fmt.Fprintf(sb, "- `%s`: %s\n", c.Table, reason)
 		} else {
 			fmt.Fprintf(sb, "- `%s`\n", c.Table)
 		}


### PR DESCRIPTION
The webhook apply handler was not checking for unsafe changes (DROP INDEX, DROP TABLE, DROP COLUMN) before acquiring a lock and posting a confirmation comment. The CLI correctly blocks these but the webhook path skipped the check entirely, allowing users to confirm and execute destructive changes without `--allow-unsafe`.

This extracts shared plan result processing into `PlanResponse` methods (`UnsafeChanges()`, `LintWarnings()`, `LintErrors()`) so both CLI and webhook use the same rules. Filtering is by lint severity level rather than hardcoded linter names, which is more correct and future-proof as Spirit promotes more linters to error severity (block/spirit#670).

The webhook now blocks apply when unsafe changes are detected, parses `--allow-unsafe` from PR comments, and shows consistent `⛔` unsafe warnings in plan comments matching the CLI UX.