### PR TITLE
fix: gracefully skip GitHub setup when credentials are unavailable

### DIFF
--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
 	"strconv"
 
@@ -56,13 +57,30 @@ type GitHubConfig struct {
 // It actually resolves the private key so that file: or secretsmanager: references that
 // point to non-existent resources cause Configured() to return false instead of crashing.
 func (g *GitHubConfig) Configured() bool {
-	if g.ResolveAppID() == 0 || g.PrivateKey == "" {
+	appID := g.ResolveAppID()
+	if appID == 0 && g.PrivateKey == "" {
+		return false
+	}
+	if appID == 0 {
+		slog.Warn("GitHub App private_key is set but app_id is missing — skipping GitHub setup")
+		return false
+	}
+	if g.PrivateKey == "" {
+		slog.Warn("GitHub App app_id is set but private_key is missing — skipping GitHub setup")
 		return false
 	}
 	// Actually resolve the private key — if the file/secret doesn't exist yet,
 	// treat GitHub as not configured rather than failing startup.
 	pk, err := g.ResolvePrivateKey()
-	return err == nil && pk != ""
+	if err != nil {
+		slog.Warn("GitHub App credentials not resolvable — skipping GitHub setup", "error", err)
+		return false
+	}
+	if pk == "" {
+		slog.Warn("GitHub App private key resolved to empty — skipping GitHub setup")
+		return false
+	}
+	return true
 }
 
 // ResolveAppID resolves the app ID from config (supports secret references),

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -53,8 +53,16 @@ type GitHubConfig struct {
 }
 
 // Configured returns true if the GitHub App is configured (app ID and private key are set).
+// It actually resolves the private key so that file: or secretsmanager: references that
+// point to non-existent resources cause Configured() to return false instead of crashing.
 func (g *GitHubConfig) Configured() bool {
-	return g.ResolveAppID() != 0 && g.PrivateKey != ""
+	if g.ResolveAppID() == 0 || g.PrivateKey == "" {
+		return false
+	}
+	// Actually resolve the private key — if the file/secret doesn't exist yet,
+	// treat GitHub as not configured rather than failing startup.
+	pk, err := g.ResolvePrivateKey()
+	return err == nil && pk != ""
 }
 
 // ResolveAppID resolves the app ID from config (supports secret references),

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -59,6 +59,7 @@ type GitHubConfig struct {
 func (g *GitHubConfig) Configured() bool {
 	appID := g.ResolveAppID()
 	if appID == 0 && g.PrivateKey == "" {
+		slog.Info("GitHub App not configured — skipping GitHub setup")
 		return false
 	}
 	if appID == 0 {

--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -219,7 +219,8 @@ func TestGitHubConfig_Configured(t *testing.T) {
 	})
 
 	t.Run("not configured when file reference does not exist", func(t *testing.T) {
-		g := GitHubConfig{AppID: "123", PrivateKey: "file:/tmp/nonexistent-key.pem"}
+		nonexistent := filepath.Join(t.TempDir(), "nonexistent-key.pem")
+		g := GitHubConfig{AppID: "123", PrivateKey: "file:" + nonexistent}
 		assert.False(t, g.Configured())
 	})
 }

--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -217,6 +217,11 @@ func TestGitHubConfig_Configured(t *testing.T) {
 		g := GitHubConfig{AppID: "123", PrivateKey: "some-key"}
 		assert.True(t, g.Configured())
 	})
+
+	t.Run("not configured when file reference does not exist", func(t *testing.T) {
+		g := GitHubConfig{AppID: "123", PrivateKey: "file:/tmp/nonexistent-key.pem"}
+		assert.False(t, g.Configured())
+	})
 }
 
 func TestGitHubConfig_ResolveAppID(t *testing.T) {

--- a/pkg/cmd/commands/serve.go
+++ b/pkg/cmd/commands/serve.go
@@ -114,8 +114,15 @@ func (cmd *ServeCmd) Run(g *Globals) error {
 		webhookHandler := webhook.NewHandler(svc, ghClient, []byte(ghWebhookSecret), logger)
 		mux.Handle("POST /webhook", webhookHandler)
 		logger.Info("GitHub webhook endpoint registered", "app_id", appID)
-	} else if serverConfig.GitHub.PrivateKey != "" {
-		logger.Warn("GitHub App config found but credentials not available yet — webhook endpoint disabled")
+	} else {
+		if serverConfig.GitHub.PrivateKey != "" {
+			logger.Warn("GitHub App config found but credentials not available yet — webhook endpoint disabled")
+		}
+		mux.Handle("POST /webhook", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusServiceUnavailable)
+			w.Write([]byte(`{"error":"GitHub App credentials not available — webhook endpoint is disabled"}`))
+		}))
 	}
 
 	// Create server

--- a/pkg/cmd/commands/serve.go
+++ b/pkg/cmd/commands/serve.go
@@ -97,7 +97,7 @@ func (cmd *ServeCmd) Run(g *Globals) error {
 	svc.ConfigureRoutes(mux)
 
 	// Register GitHub webhook handler if GitHub App is configured
-	if serverConfig.GitHub.Configured() {
+	if serverConfig.GitHub.Configured() { //nolint:nestif
 		ghPrivateKey, err := serverConfig.GitHub.ResolvePrivateKey()
 		if err != nil {
 			return fmt.Errorf("resolve GitHub private key: %w", err)
@@ -114,6 +114,8 @@ func (cmd *ServeCmd) Run(g *Globals) error {
 		webhookHandler := webhook.NewHandler(svc, ghClient, []byte(ghWebhookSecret), logger)
 		mux.Handle("POST /webhook", webhookHandler)
 		logger.Info("GitHub webhook endpoint registered", "app_id", appID)
+	} else if serverConfig.GitHub.PrivateKey != "" {
+		logger.Warn("GitHub App config found but credentials not available yet — webhook endpoint disabled")
 	}
 
 	// Create server

--- a/pkg/cmd/commands/serve.go
+++ b/pkg/cmd/commands/serve.go
@@ -97,33 +97,11 @@ func (cmd *ServeCmd) Run(g *Globals) error {
 	svc.ConfigureRoutes(mux)
 
 	// Register GitHub webhook handler if GitHub App is configured
-	if serverConfig.GitHub.Configured() { //nolint:nestif
-		ghPrivateKey, err := serverConfig.GitHub.ResolvePrivateKey()
-		if err != nil {
-			return fmt.Errorf("resolve GitHub private key: %w", err)
-		}
-		ghWebhookSecret, err := serverConfig.GitHub.ResolveWebhookSecret()
-		if err != nil {
-			return fmt.Errorf("resolve GitHub webhook secret: %w", err)
-		}
-		if ghWebhookSecret == "" {
-			return fmt.Errorf("GitHub App is configured but webhook secret is empty — set github.webhook_secret to secure the /webhook endpoint")
-		}
-		appID := serverConfig.GitHub.ResolveAppID()
-		ghClient := ghclient.NewClient(appID, []byte(ghPrivateKey), logger)
-		webhookHandler := webhook.NewHandler(svc, ghClient, []byte(ghWebhookSecret), logger)
-		mux.Handle("POST /webhook", webhookHandler)
-		logger.Info("GitHub webhook endpoint registered", "app_id", appID)
-	} else {
-		if serverConfig.GitHub.PrivateKey != "" {
-			logger.Warn("GitHub App config found but credentials not available yet — webhook endpoint disabled")
-		}
-		mux.Handle("POST /webhook", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusServiceUnavailable)
-			w.Write([]byte(`{"error":"GitHub App credentials not available — webhook endpoint is disabled"}`))
-		}))
+	webhookHandler, err := buildWebhookHandler(serverConfig, svc, logger)
+	if err != nil {
+		return err
 	}
+	mux.Handle("POST /webhook", webhookHandler)
 
 	// Create server
 	server := &http.Server{
@@ -216,6 +194,37 @@ func startGRPCServer(ctx context.Context, config *api.ServerConfig, st *mysqlsto
 	}()
 
 	return grpcSrv, nil
+}
+
+func buildWebhookHandler(serverConfig *api.ServerConfig, svc *api.Service, logger *slog.Logger) (http.Handler, error) {
+	if !serverConfig.GitHub.Configured() {
+		if serverConfig.GitHub.PrivateKey != "" {
+			logger.Warn("GitHub App config found but credentials not available yet — webhook endpoint disabled")
+		}
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusServiceUnavailable)
+			w.Write([]byte(`{"error":"GitHub App credentials not available — webhook endpoint is disabled"}`)) //nolint:errcheck
+		}), nil
+	}
+
+	ghPrivateKey, err := serverConfig.GitHub.ResolvePrivateKey()
+	if err != nil {
+		return nil, fmt.Errorf("resolve GitHub private key: %w", err)
+	}
+	ghWebhookSecret, err := serverConfig.GitHub.ResolveWebhookSecret()
+	if err != nil {
+		return nil, fmt.Errorf("resolve GitHub webhook secret: %w", err)
+	}
+	if ghWebhookSecret == "" {
+		return nil, fmt.Errorf("GitHub App is configured but webhook secret is empty — set github.webhook_secret to secure the /webhook endpoint")
+	}
+
+	appID := serverConfig.GitHub.ResolveAppID()
+	ghClient := ghclient.NewClient(appID, []byte(ghPrivateKey), logger)
+	handler := webhook.NewHandler(svc, ghClient, []byte(ghWebhookSecret), logger)
+	logger.Info("GitHub webhook endpoint registered", "app_id", appID)
+	return handler, nil
 }
 
 func getEnv(key, defaultValue string) string {


### PR DESCRIPTION
## Summary
- **`Configured()` now resolves the private key** before returning `true`. Previously it only checked if the raw `PrivateKey` string was non-empty, which meant `file:` or `secretsmanager:` references would pass the check even when the underlying resource didn't exist yet, causing a crash later.
- **Added a warning log** in `serve.go` when GitHub App config is present in values but credentials aren't resolvable yet, so operators can see why the webhook endpoint isn't registered.
- **Added a test case** for the `file:` reference scenario where the referenced file doesn't exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)