### PR TITLE
Wire PlanetScale engine into tern with full Vitess lifecycle support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -323,7 +323,7 @@ endif
 	wait $$MYSQL_PID
 	@echo "Running e2e tests..."
 	@E2E_SCHEMABOT_URL=http://localhost:14370 \
-	E2E_LOCALSCALE_URL=http://localhost:14374 \
+	LOCALSCALE_URL=http://localhost:14374 \
 	E2E_MYSQL_DSN="root:testpassword@tcp(localhost:14371)/schemabot" \
 	E2E_TESTAPP_STAGING_DSN="root:testpassword@tcp(localhost:14372)/testapp" \
 	E2E_TESTAPP_PRODUCTION_DSN="root:testpassword@tcp(localhost:14373)/testapp" \

--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -538,7 +538,7 @@ schemabot apply -e production
 | `schemabot rollback <apply-id>` | Generate a rollback plan |
 | `schemabot rollback-confirm <apply-id>` | Execute a rollback |
 
-**Options**: `-e <env>` environment, `-d <db>` database, `--defer-cutover`, `--allow-unsafe`, `--enable-revert` (Vitess)
+**Options**: `-e <env>` environment, `-d <db>` database, `--defer-cutover`, `--allow-unsafe`, `--skip-revert` (Vitess)
 
 **Quick start**: `plan` → `apply` → `apply-confirm`
 
@@ -685,7 +685,7 @@ That command wasn't recognized. Available commands:
 | `schemabot rollback <apply-id>` | Generate a rollback plan |
 | `schemabot rollback-confirm <apply-id>` | Execute a rollback |
 
-**Options**: `-e <env>` environment, `-d <db>` database, `--defer-cutover`, `--allow-unsafe`, `--enable-revert` (Vitess)
+**Options**: `-e <env>` environment, `-d <db>` database, `--defer-cutover`, `--allow-unsafe`, `--skip-revert` (Vitess)
 
 **Quick start**: `plan` → `apply` → `apply-confirm`
 </details>

--- a/deploy/e2e/config/localscale-e2e.json
+++ b/deploy/e2e/config/localscale-e2e.json
@@ -22,7 +22,7 @@
     }
   },
   "listen_addr": ":8080",
-  "revert_window_duration": "30m",
+  "revert_window_duration": "15s",
   "default_throttle_ratio": 0.85,
   "branch_creation_delay": "50ms",
   "deploy_request_delay": "50ms",

--- a/e2e/local/apply_wait_test.go
+++ b/e2e/local/apply_wait_test.go
@@ -49,20 +49,27 @@ func waitForApplyState(t *testing.T, endpoint, applyID, expectedState string, ti
 	expected := strings.ToLower(expectedState)
 	deadline := time.Now().Add(timeout)
 	var lastState, lastError string
+	start := time.Now()
 	for time.Now().Before(deadline) {
 		ctx, cancel := context.WithTimeout(t.Context(), testutil.ProgressTimeout)
 		result, err := client.GetProgressCtx(ctx, endpoint, applyID)
 		cancel()
 		if err == nil {
-			lastState = state.NormalizeState(result.State)
+			newState := state.NormalizeState(result.State)
+			if newState != lastState {
+				t.Logf("waitForApplyState: %s state=%s (elapsed=%s)", applyID, newState, time.Since(start))
+			}
+			lastState = newState
 			lastError = result.ErrorMessage
 			if lastState == expected {
 				return
 			}
+		} else {
+			t.Logf("waitForApplyState: %s poll error: %v (elapsed=%s)", applyID, err, time.Since(start))
 		}
 		time.Sleep(300 * time.Millisecond)
 	}
-	require.Failf(t, "timeout", "timeout waiting for apply %s state %q, last API state: %q, error: %q", applyID, expectedState, lastState, lastError)
+	require.Failf(t, "timeout", "timeout waiting for apply %s state %q after %s, last API state: %q, error: %q", applyID, expectedState, time.Since(start), lastState, lastError)
 }
 
 func waitForApplyAnyState(t *testing.T, endpoint, applyID string, expectedStates []string, timeout time.Duration) string {

--- a/e2e/local/helpers_test.go
+++ b/e2e/local/helpers_test.go
@@ -7,6 +7,7 @@ import (
 	"database/sql"
 	"fmt"
 	"log"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -209,10 +210,9 @@ func ensureNoActiveChange(t *testing.T, endpoint string) {
 }
 
 func clearSchemaBotState(t *testing.T) {
-	if t != nil {
-		t.Helper()
-	}
+	t.Helper()
 	clearSchemaBotStateImpl()
+	resetLocalScaleState(t)
 }
 
 func clearSchemaBotStateImpl() {
@@ -243,6 +243,51 @@ func clearSchemaBotStateImpl() {
 		_, _ = db.ExecContext(context.Background(), "DELETE FROM `"+table+"`")
 	}
 	log.Printf("Cleared %d schemabot state tables", len(tables))
+}
+
+// localscaleMetadataQuery sends a query to the LocalScale metadata endpoint.
+// Returns an error instead of failing — callers decide how to handle.
+func localscaleMetadataQuery(query string) error {
+	localscaleURL := os.Getenv("LOCALSCALE_URL")
+	if localscaleURL == "" {
+		return fmt.Errorf("LOCALSCALE_URL not set")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	body := strings.NewReader(fmt.Sprintf(`{"query":%q}`, query))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, localscaleURL+"/admin/metadata-query", body)
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("execute request: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected status %d", resp.StatusCode)
+	}
+	return nil
+}
+
+const resetDeployRequestsQuery = "UPDATE localscale_deploy_requests SET deployment_state = 'complete', deployed = FALSE, cancelled = TRUE WHERE deployment_state != 'complete'"
+
+// resetLocalScaleState clears LocalScale deploy request state via the metadata-query
+// admin endpoint. Marks all deploy requests as closed (not DELETE — preserves the
+// auto-increment counter so new deploy requests get unique numbers, which ensures
+// unique migration_context values for SHOW VITESS_MIGRATIONS discovery).
+func resetLocalScaleState(t *testing.T) {
+	t.Helper()
+	err := localscaleMetadataQuery(resetDeployRequestsQuery)
+	require.NoError(t, err, "reset LocalScale deploy requests")
+}
+
+// resetLocalScaleStateOrFatal is the TestMain variant (no *testing.T).
+func resetLocalScaleStateOrFatal() {
+	if err := localscaleMetadataQuery(resetDeployRequestsQuery); err != nil {
+		log.Fatalf("reset LocalScale deploy requests: %v", err)
+	}
 }
 
 func uniqueTableName(prefix string) string {

--- a/e2e/local/local_test.go
+++ b/e2e/local/local_test.go
@@ -36,6 +36,8 @@ import (
 func TestMain(m *testing.M) {
 	// Clean up SchemaBot's state tables to ensure fresh state
 	clearSchemaBotStateImpl()
+	// Clear LocalScale deploy requests to prevent stale deploys from blocking tests
+	resetLocalScaleStateOrFatal()
 
 	// Clean up any leftover tables from previous runs in testapp database
 	// Keep only the base fixture tables (users, orders, products) that are part of the testapp schema

--- a/e2e/local/vitess_test.go
+++ b/e2e/local/vitess_test.go
@@ -1,0 +1,1348 @@
+//go:build e2e
+
+package local
+
+import (
+	"encoding/json"
+	"fmt"
+	"maps"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/block/schemabot/e2e/testutil"
+	"github.com/block/schemabot/pkg/cmd/client"
+	"github.com/block/schemabot/pkg/e2eutil"
+	"github.com/block/schemabot/pkg/state"
+)
+
+// =============================================================================
+// Vitess/PlanetScale Engine E2E Tests
+//
+// These test the PlanetScale engine flow against LocalScale + real Vitess.
+// They run as part of `make test-e2e-local` when LocalScale is in the docker-compose.
+//
+// Database: testapp-vitess (type: vitess)
+// Environments: staging, production
+// Keyspaces: testapp (unsharded, 1 shard), testapp_sharded (2 shards)
+//
+// Test isolation: Tests that CREATE new tables use unique names and are fully
+// isolated. Tests that ALTER existing tables must restore the original schema
+// via a cleanup apply to prevent drift between tests.
+// =============================================================================
+
+const vitessDB = "testapp-vitess"
+
+func vitessAvailable(t *testing.T) {
+	t.Helper()
+	if os.Getenv("LOCALSCALE_URL") == "" {
+		t.Skip("LOCALSCALE_URL not set (LocalScale not running)")
+	}
+}
+
+// newVitessSchemaDir creates a temp schema directory with schemabot.yaml and
+// the given SQL/JSON files organized by keyspace subdirectory.
+func newVitessSchemaDir(t *testing.T, sqlFiles map[string]string) string {
+	t.Helper()
+	dir := t.TempDir()
+	e2eutil.WriteFile(t, filepath.Join(dir, "schemabot.yaml"), "database: "+vitessDB+"\ntype: vitess\n")
+	for path, content := range sqlFiles {
+		fullPath := filepath.Join(dir, path)
+		require.NoError(t, os.MkdirAll(filepath.Dir(fullPath), 0o755))
+		e2eutil.WriteFile(t, fullPath, content)
+	}
+	return dir
+}
+
+// vitessApplyAndWait runs apply in log mode and waits for completion.
+func vitessApplyAndWait(t *testing.T, schemaDir, env string, extraArgs ...string) string {
+	t.Helper()
+	start := time.Now()
+	binPath := buildCLI(t)
+	endpoint := schemabotURL(t)
+
+	args := []string{"apply", "-s", ".", "-e", env, "--endpoint", endpoint, "-y", "-o", "log", "--allow-unsafe"}
+	args = append(args, extraArgs...)
+	t.Logf("vitessApplyAndWait: starting CLI apply (elapsed=%s)", time.Since(start))
+	out := e2eutil.RunCLIInDir(t, binPath, schemaDir, args...)
+	t.Logf("vitessApplyAndWait: CLI returned (elapsed=%s)", time.Since(start))
+	e2eutil.AssertContains(t, out, "Apply started")
+
+	applyID := extractApplyIDFromLog(out)
+	require.NotEmpty(t, applyID)
+	t.Logf("vitessApplyAndWait: waiting for completion apply_id=%s (elapsed=%s)", applyID, time.Since(start))
+	waitForApplyState(t, endpoint, applyID, state.Apply.Completed, testutil.PollDeadline)
+	t.Logf("vitessApplyAndWait: done (elapsed=%s)", time.Since(start))
+	return out
+}
+
+// vitessBaseSchema reads the canonical Vitess schema files from examples/.
+// This ensures the test schema always matches the source of truth.
+func vitessBaseSchema() map[string]string {
+	baseDir := "examples/vitess/schema"
+	// Find the repo root by looking for go.mod
+	dir, _ := os.Getwd()
+	for dir != "/" {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			baseDir = filepath.Join(dir, "examples/vitess/schema")
+			break
+		}
+		dir = filepath.Dir(dir)
+	}
+
+	files := make(map[string]string)
+	keyspaces := []string{"testapp", "testapp_sharded"}
+	for _, ks := range keyspaces {
+		entries, err := os.ReadDir(filepath.Join(baseDir, ks))
+		if err != nil {
+			// Keyspace directory may not exist in the schema dir
+			continue
+		}
+		for _, e := range entries {
+			if e.IsDir() {
+				continue
+			}
+			data, err := os.ReadFile(filepath.Join(baseDir, ks, e.Name()))
+			if err != nil {
+				panic(fmt.Sprintf("failed to read schema file %s/%s: %v", ks, e.Name(), err))
+			}
+			files[ks+"/"+e.Name()] = string(data)
+		}
+	}
+	return files
+}
+
+// vitessSchemaWithOverrides returns the full base schema with specific files overridden.
+// This ensures all keyspace tables are present so the differ doesn't generate DROPs.
+func vitessSchemaWithOverrides(overrides map[string]string) map[string]string {
+	files := vitessBaseSchema()
+	maps.Copy(files, overrides)
+	return files
+}
+
+// localscaleAdminPost delegates to the shared e2eutil helper.
+func localscaleAdminPost(t *testing.T, endpoint string, body string) ([]byte, error) {
+	t.Helper()
+	return e2eutil.LocalScaleAdminPost(t, os.Getenv("LOCALSCALE_URL"), endpoint, body)
+}
+
+// vitessResetVSchema seeds the base VSchema directly via LocalScale admin endpoint.
+// This ensures vtgate's VSchema matches the examples/vitess/schema files regardless
+// of what previous tests may have applied.
+func vitessResetVSchema(t *testing.T) {
+	t.Helper()
+	baseFiles := vitessBaseSchema()
+	for _, ks := range []string{"testapp", "testapp_sharded"} {
+		vschemaContent, ok := baseFiles[ks+"/vschema.json"]
+		if !ok {
+			continue
+		}
+		for _, org := range []string{"localscale-staging", "localscale-production"} {
+			body := fmt.Sprintf(`{"org":%q,"database":%q,"keyspace":%q,"vschema":%s}`,
+				org, vitessDB, ks, vschemaContent)
+			_, err := localscaleAdminPost(t, "/admin/seed-vschema", body)
+			if err != nil {
+				t.Logf("reset vschema for %s/%s: %v", org, ks, err)
+			}
+		}
+	}
+}
+
+// vitessRestoreBaseSchema resets the Vitess schema to the canonical base state
+// using direct DDL via admin endpoints, bypassing the deploy request lifecycle.
+// Drops extra tables, indexes, and columns that tests added (~1s vs ~10s for a full apply).
+func vitessRestoreBaseSchema(t *testing.T, _ string) {
+	t.Helper()
+	start := time.Now()
+	clearSchemaBotState(t)
+	t.Logf("vitessRestoreBaseSchema: clearState done (elapsed=%s)", time.Since(start))
+	vitessResetVSchema(t)
+	t.Logf("vitessRestoreBaseSchema: resetVSchema done (elapsed=%s)", time.Since(start))
+	vitessCleanupSchema(t)
+	t.Logf("vitessRestoreBaseSchema: cleanup done (elapsed=%s)", time.Since(start))
+}
+
+// baseSchemaTableNames returns the expected table names per keyspace,
+// derived from the example schema files (source of truth).
+func baseSchemaTableNames() map[string][]string {
+	files := vitessBaseSchema()
+	result := make(map[string][]string)
+	for path := range files {
+		parts := strings.SplitN(path, "/", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		ks := parts[0]
+		name := strings.TrimSuffix(parts[1], ".sql")
+		name = strings.TrimSuffix(name, ".json") // skip vschema.json
+		if strings.HasSuffix(parts[1], ".json") {
+			continue
+		}
+		result[ks] = append(result[ks], name)
+	}
+	return result
+}
+
+// vitessCleanupSchema drops extra tables and non-base indexes via direct DDL
+// on vtgate, restoring the schema to a clean state for the next test.
+// Uses the example schema files as the source of truth for which tables should exist.
+func vitessCleanupSchema(t *testing.T) {
+	t.Helper()
+	localscaleURL := os.Getenv("LOCALSCALE_URL")
+	if localscaleURL == "" {
+		t.Log("LOCALSCALE_URL not set, skipping vitess schema cleanup")
+		return
+	}
+
+	expected := baseSchemaTableNames()
+	for _, org := range []string{"localscale-staging", "localscale-production"} {
+		for ks, expectedTables := range expected {
+			expectedSet := make(map[string]bool, len(expectedTables))
+			for _, name := range expectedTables {
+				expectedSet[name] = true
+			}
+
+			// Drop extra tables
+			tables := vitessAdminQuery(t, localscaleURL, org, ks, "SHOW TABLES")
+			for _, row := range tables {
+				if len(row) == 0 {
+					continue
+				}
+				if !expectedSet[row[0]] {
+					vitessAdminDDL(t, localscaleURL, org, ks, fmt.Sprintf("DROP TABLE IF EXISTS `%s`", row[0]))
+				}
+			}
+
+			// Drop non-base indexes from base tables (tests add indexes that must be cleaned)
+			for _, tbl := range expectedTables {
+				indexes := vitessAdminQuery(t, localscaleURL, org, ks, fmt.Sprintf("SHOW INDEX FROM `%s`", tbl))
+				baseIdxSet := baseTableIndexes(ks, tbl)
+				seen := make(map[string]bool)
+				for _, idx := range indexes {
+					if len(idx) < 3 {
+						continue
+					}
+					idxName := idx[2] // Key_name column
+					if seen[idxName] || baseIdxSet[idxName] {
+						seen[idxName] = true
+						continue
+					}
+					seen[idxName] = true
+					vitessAdminDDL(t, localscaleURL, org, ks, fmt.Sprintf("ALTER TABLE `%s` DROP INDEX `%s`", tbl, idxName))
+				}
+
+				// Drop non-base columns
+				cols := vitessAdminQuery(t, localscaleURL, org, ks, fmt.Sprintf("SHOW COLUMNS FROM `%s`", tbl))
+				baseColSet := baseTableColumns(ks, tbl)
+				for _, col := range cols {
+					if len(col) == 0 {
+						continue
+					}
+					if !baseColSet[col[0]] {
+						vitessAdminDDL(t, localscaleURL, org, ks, fmt.Sprintf("ALTER TABLE `%s` DROP COLUMN `%s`", tbl, col[0]))
+					}
+				}
+			}
+		}
+	}
+}
+
+// baseTableIndexes returns the expected index names for a table, parsed from the schema files.
+func baseTableIndexes(keyspace, table string) map[string]bool {
+	files := vitessBaseSchema()
+	content, ok := files[keyspace+"/"+table+".sql"]
+	if !ok {
+		return map[string]bool{"PRIMARY": true}
+	}
+	result := map[string]bool{"PRIMARY": true}
+	// Parse KEY `name` patterns from CREATE TABLE
+	for line := range strings.SplitSeq(content, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "KEY ") || strings.HasPrefix(line, "UNIQUE KEY ") || strings.HasPrefix(line, "INDEX ") {
+			// Extract index name from KEY `name` or UNIQUE KEY `name`
+			start := strings.Index(line, "`")
+			end := strings.Index(line[start+1:], "`")
+			if start >= 0 && end >= 0 {
+				result[line[start+1:start+1+end]] = true
+			}
+		}
+	}
+	return result
+}
+
+// baseTableColumns returns the expected column names for a table, parsed from the schema files.
+func baseTableColumns(keyspace, table string) map[string]bool {
+	files := vitessBaseSchema()
+	content, ok := files[keyspace+"/"+table+".sql"]
+	if !ok {
+		return nil
+	}
+	result := make(map[string]bool)
+	for line := range strings.SplitSeq(content, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "`") {
+			end := strings.Index(line[1:], "`")
+			if end >= 0 {
+				result[line[1:1+end]] = true
+			}
+		}
+	}
+	return result
+}
+
+// vitessAdminQuery runs a query via the LocalScale vtgate-exec admin endpoint.
+func vitessAdminQuery(t *testing.T, localscaleURL, org, keyspace, query string) [][]string {
+	t.Helper()
+	_ = localscaleURL // preserved for call-site compatibility; localscaleAdminPost reads the env var
+	body := fmt.Sprintf(`{"org":%q,"database":%q,"keyspace":%q,"query":%q}`,
+		org, vitessDB, keyspace, query)
+	respBody, err := localscaleAdminPost(t, "/admin/vtgate-exec", body)
+	require.NoError(t, err, "vtgate-exec query %s", query)
+	var result struct {
+		Rows [][]string `json:"rows"`
+	}
+	require.NoError(t, json.NewDecoder(strings.NewReader(string(respBody))).Decode(&result))
+	return result.Rows
+}
+
+// vitessAdminDDL runs a DDL statement via the LocalScale seed-ddl admin endpoint.
+// Best-effort: logs failures (e.g., dropping a non-existent index) without failing the test.
+func vitessAdminDDL(t *testing.T, localscaleURL, org, keyspace, ddl string) {
+	t.Helper()
+	_ = localscaleURL // preserved for call-site compatibility; localscaleAdminPost reads the env var
+	body := fmt.Sprintf(`{"org":%q,"database":%q,"keyspace":%q,"statements":[%q]}`,
+		org, vitessDB, keyspace, ddl)
+	_, err := localscaleAdminPost(t, "/admin/seed-ddl", body)
+	if err != nil {
+		t.Logf("vitessAdminDDL: %s: %v (non-fatal)", ddl, err)
+	}
+}
+
+// extractApplyIDFromLog extracts the apply ID from log mode output.
+// Handles both "Apply started: apply-xxx" text and "apply_id=apply-xxx" logfmt.
+func extractApplyIDFromLog(output string) string {
+	for line := range strings.SplitSeq(output, "\n") {
+		line = strings.TrimSpace(line)
+		// Log mode: "Apply started: apply-xxx"
+		if after, ok := strings.CutPrefix(line, "Apply started: "); ok {
+			return after
+		}
+		// Logfmt: apply_id=apply-xxx
+		if _, after, ok := strings.Cut(line, "apply_id="); ok {
+			rest := after
+			if before, _, ok := strings.Cut(rest, " "); ok {
+				return before
+			}
+			return rest
+		}
+		// JSON mode fallback
+		if strings.HasPrefix(line, "{") {
+			var result struct {
+				ApplyID string `json:"apply_id"`
+			}
+			if json.Unmarshal([]byte(line), &result) == nil && result.ApplyID != "" {
+				return result.ApplyID
+			}
+		}
+	}
+	return ""
+}
+
+// --- Plan Tests ---
+
+func TestVitess_Plan_Header(t *testing.T) {
+	vitessAvailable(t)
+	binPath := buildCLI(t)
+	endpoint := schemabotURL(t)
+
+	tableName := uniqueTableName("vhdr")
+	schemaDir := newVitessSchemaDir(t, vitessSchemaWithOverrides(map[string]string{
+		"testapp/" + tableName + ".sql": fmt.Sprintf(`CREATE TABLE %s (
+    id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;`, tableName),
+	}))
+
+	out := e2eutil.RunCLIInDir(t, binPath, schemaDir, "plan",
+		"-s", ".", "-e", "staging", "--endpoint", endpoint)
+
+	e2eutil.AssertContains(t, out, "Vitess Schema Change Plan")
+	e2eutil.AssertContains(t, out, vitessDB)
+	assert.NotContains(t, out, "Schema name")
+}
+
+func TestVitess_Plan_JSON(t *testing.T) {
+	vitessAvailable(t)
+	binPath := buildCLI(t)
+	endpoint := schemabotURL(t)
+
+	tableName := uniqueTableName("vjson")
+	schemaDir := newVitessSchemaDir(t, vitessSchemaWithOverrides(map[string]string{
+		"testapp/" + tableName + ".sql": fmt.Sprintf(`CREATE TABLE %s (
+    id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;`, tableName),
+	}))
+
+	out := e2eutil.RunCLIInDir(t, binPath, schemaDir, "plan",
+		"-s", ".", "-e", "staging", "--endpoint", endpoint, "--json")
+
+	var result map[string]*json.RawMessage
+	require.NoError(t, json.Unmarshal([]byte(out), &result))
+
+	var staging struct {
+		Engine string `json:"engine"`
+	}
+	stagingRaw, ok := result["staging"]
+	require.True(t, ok, "expected 'staging' key in plan output")
+	require.NoError(t, json.Unmarshal(*stagingRaw, &staging))
+	assert.Equal(t, "PlanetScale", staging.Engine)
+}
+
+func TestVitess_Plan_CreateTable(t *testing.T) {
+	vitessAvailable(t)
+	binPath := buildCLI(t)
+	endpoint := schemabotURL(t)
+
+	tableName := uniqueTableName("vplan")
+	schemaDir := newVitessSchemaDir(t, vitessSchemaWithOverrides(map[string]string{
+		"testapp/" + tableName + ".sql": fmt.Sprintf(`CREATE TABLE %s (
+    id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(255) NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;`, tableName),
+	}))
+
+	out := e2eutil.RunCLIInDir(t, binPath, schemaDir, "plan",
+		"-s", ".", "-e", "staging", "--endpoint", endpoint)
+
+	e2eutil.AssertContains(t, out, "CREATE TABLE")
+	e2eutil.AssertContains(t, out, tableName)
+}
+
+// --- Apply Tests ---
+
+func TestVitess_Apply_CreateTable_Unsharded(t *testing.T) {
+	vitessAvailable(t)
+	clearSchemaBotState(t)
+	defer vitessRestoreBaseSchema(t, "staging")
+
+	tableName := uniqueTableName("vcreate")
+	schemaDir := newVitessSchemaDir(t, vitessSchemaWithOverrides(map[string]string{
+		"testapp/" + tableName + ".sql": fmt.Sprintf(`CREATE TABLE %s (
+    id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(255) NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;`, tableName),
+	}))
+
+	out := vitessApplyAndWait(t, schemaDir, "staging")
+
+	e2eutil.AssertContains(t, out, "Table started")
+	e2eutil.AssertContains(t, out, tableName)
+	e2eutil.AssertContains(t, out, "Apply completed")
+}
+
+func TestVitess_Apply_AddIndex_Sharded(t *testing.T) {
+	vitessAvailable(t)
+	clearSchemaBotState(t)
+	defer vitessRestoreBaseSchema(t, "staging")
+
+	indexName := fmt.Sprintf("idx_e2e_%d", time.Now().UnixMilli()%100000)
+	schemaDir := newVitessSchemaDir(t, vitessSchemaWithOverrides(map[string]string{
+		"testapp_sharded/orders.sql": fmt.Sprintf(`CREATE TABLE `+"`orders`"+` (
+    `+"`id`"+` bigint unsigned NOT NULL,
+    `+"`user_id`"+` bigint unsigned NOT NULL,
+    `+"`total_cents`"+` bigint NOT NULL,
+    `+"`status`"+` varchar(100) NOT NULL DEFAULT 'pending',
+    `+"`created_at`"+` timestamp DEFAULT CURRENT_TIMESTAMP,
+    `+"`updated_at`"+` timestamp DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (`+"`id`"+`),
+    KEY `+"`idx_user_id`"+` (`+"`user_id`"+`),
+    KEY `+"`idx_status`"+` (`+"`status`"+`),
+    KEY `+"`idx_created_at`"+` (`+"`created_at`"+`),
+    KEY `+"`%s`"+` (`+"`total_cents`"+`)
+) ENGINE InnoDB,
+  CHARSET utf8mb4,
+  COLLATE utf8mb4_0900_ai_ci;`, indexName),
+	}))
+
+	out := vitessApplyAndWait(t, schemaDir, "staging")
+
+	e2eutil.AssertContains(t, out, "ADD INDEX")
+	e2eutil.AssertContains(t, out, indexName)
+	e2eutil.AssertContains(t, out, "Apply completed")
+	// Sharded table (2 shards) should show shard progress
+	assert.Contains(t, out, "shards=2")
+}
+
+func TestVitess_Apply_AddColumn_Sharded(t *testing.T) {
+	vitessAvailable(t)
+	clearSchemaBotState(t)
+
+	defer vitessRestoreBaseSchema(t, "staging")
+
+	colName := fmt.Sprintf("col_e2e_%d", time.Now().UnixMilli()%100000)
+	schemaDir := newVitessSchemaDir(t, vitessSchemaWithOverrides(map[string]string{
+		"testapp_sharded/users.sql": fmt.Sprintf(`CREATE TABLE `+"`users`"+` (
+  `+"`id`"+` bigint NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  `+"`email`"+` varchar(255) NOT NULL,
+  `+"`full_name`"+` varchar(255) NULL,
+  `+"`%s`"+` varchar(100) NULL,
+  `+"`created_at`"+` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  INDEX `+"`idx_email`"+` (`+"`email`"+`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;`, colName),
+	}))
+
+	out := vitessApplyAndWait(t, schemaDir, "staging")
+
+	e2eutil.AssertContains(t, out, "ADD COLUMN")
+	e2eutil.AssertContains(t, out, colName)
+	e2eutil.AssertContains(t, out, "Apply completed")
+}
+
+func TestVitess_Apply_ConsecutiveApplies(t *testing.T) {
+	vitessAvailable(t)
+	clearSchemaBotState(t)
+	defer vitessRestoreBaseSchema(t, "staging")
+
+	// First apply: add index
+	idx1 := fmt.Sprintf("idx_c1_%d", time.Now().UnixMilli()%100000)
+	schemaDir1 := newVitessSchemaDir(t, vitessSchemaWithOverrides(map[string]string{
+		"testapp_sharded/users.sql": fmt.Sprintf(`CREATE TABLE `+"`users`"+` (
+  `+"`id`"+` bigint NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  `+"`email`"+` varchar(255) NOT NULL,
+  `+"`full_name`"+` varchar(255) NULL,
+  `+"`created_at`"+` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  INDEX `+"`idx_email`"+` (`+"`email`"+`),
+  INDEX `+"`%s`"+` (`+"`full_name`"+`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;`, idx1),
+	}))
+
+	out1 := vitessApplyAndWait(t, schemaDir1, "staging")
+	e2eutil.AssertContains(t, out1, "Apply completed")
+
+	clearSchemaBotState(t)
+
+	// Second apply immediately after — tests that previous deploy's revert window
+	// is auto-completed and VReplication streams are cleaned up.
+	idx2 := fmt.Sprintf("idx_c2_%d", time.Now().UnixMilli()%100000)
+	schemaDir2 := newVitessSchemaDir(t, vitessSchemaWithOverrides(map[string]string{
+		"testapp_sharded/users.sql": fmt.Sprintf(`CREATE TABLE `+"`users`"+` (
+  `+"`id`"+` bigint NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  `+"`email`"+` varchar(255) NOT NULL,
+  `+"`full_name`"+` varchar(255) NULL,
+  `+"`created_at`"+` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  INDEX `+"`idx_email`"+` (`+"`email`"+`),
+  INDEX `+"`%s`"+` (`+"`full_name`"+`),
+  INDEX `+"`%s`"+` (`+"`created_at`"+`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;`, idx1, idx2),
+	}))
+
+	out2 := vitessApplyAndWait(t, schemaDir2, "staging")
+	e2eutil.AssertContains(t, out2, "Apply completed")
+}
+
+func TestVitess_Apply_ShardProgress(t *testing.T) {
+	vitessAvailable(t)
+	clearSchemaBotState(t)
+
+	defer vitessRestoreBaseSchema(t, "staging")
+
+	indexName := fmt.Sprintf("idx_sp_%d", time.Now().UnixMilli()%100000)
+	schemaDir := newVitessSchemaDir(t, vitessSchemaWithOverrides(map[string]string{
+		"testapp_sharded/orders.sql": fmt.Sprintf(`CREATE TABLE `+"`orders`"+` (
+    `+"`id`"+` bigint unsigned NOT NULL,
+    `+"`user_id`"+` bigint unsigned NOT NULL,
+    `+"`total_cents`"+` bigint NOT NULL,
+    `+"`status`"+` varchar(100) NOT NULL DEFAULT 'pending',
+    `+"`created_at`"+` timestamp DEFAULT CURRENT_TIMESTAMP,
+    `+"`updated_at`"+` timestamp DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (`+"`id`"+`),
+    KEY `+"`idx_user_id`"+` (`+"`user_id`"+`),
+    KEY `+"`idx_status`"+` (`+"`status`"+`),
+    KEY `+"`idx_created_at`"+` (`+"`created_at`"+`),
+    KEY `+"`%s`"+` (`+"`total_cents`"+`)
+) ENGINE InnoDB,
+  CHARSET utf8mb4,
+  COLLATE utf8mb4_0900_ai_ci;`, indexName),
+	}))
+
+	out := vitessApplyAndWait(t, schemaDir, "staging")
+
+	e2eutil.AssertContains(t, out, "Apply completed")
+	// testapp_sharded has 2 shards — verify shard progress appears
+	assert.Contains(t, out, "shards=2", "expected per-shard progress for 2-shard keyspace")
+}
+
+func TestVitess_Apply_LogMode_Lifecycle(t *testing.T) {
+	vitessAvailable(t)
+	clearSchemaBotState(t)
+
+	defer vitessRestoreBaseSchema(t, "staging")
+
+	indexName := fmt.Sprintf("idx_lm_%d", time.Now().UnixMilli()%100000)
+	schemaDir := newVitessSchemaDir(t, vitessSchemaWithOverrides(map[string]string{
+		"testapp_sharded/products.sql": fmt.Sprintf(`CREATE TABLE `+"`products`"+` (
+    `+"`id`"+` bigint unsigned NOT NULL,
+    `+"`name`"+` varchar(255) NOT NULL,
+    `+"`description`"+` text NULL,
+    `+"`price_cents`"+` bigint NOT NULL,
+    `+"`sku`"+` varchar(100) NOT NULL,
+    `+"`created_at`"+` timestamp DEFAULT CURRENT_TIMESTAMP,
+    `+"`updated_at`"+` timestamp DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (`+"`id`"+`),
+    KEY `+"`idx_name`"+` (`+"`name`"+`),
+    UNIQUE KEY `+"`idx_sku`"+` (`+"`sku`"+`),
+    KEY `+"`idx_price`"+` (`+"`price_cents`"+`),
+    KEY `+"`%s`"+` (`+"`name`"+`, `+"`price_cents`"+`)
+) ENGINE InnoDB,
+  CHARSET utf8mb4,
+  COLLATE utf8mb4_0900_ai_ci;`, indexName),
+	}))
+
+	out := vitessApplyAndWait(t, schemaDir, "staging")
+
+	// Verify log mode lifecycle events
+	e2eutil.AssertContains(t, out, "Table started")
+	e2eutil.AssertContains(t, out, "Apply completed")
+	e2eutil.AssertContains(t, out, "keyspace=testapp_sharded")
+}
+
+func TestVitess_Apply_Production(t *testing.T) {
+	vitessAvailable(t)
+	clearSchemaBotState(t)
+	defer vitessRestoreBaseSchema(t, "production")
+
+	tableName := uniqueTableName("vprod")
+	schemaDir := newVitessSchemaDir(t, vitessSchemaWithOverrides(map[string]string{
+		"testapp/" + tableName + ".sql": fmt.Sprintf(`CREATE TABLE %s (
+    id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    label VARCHAR(100)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;`, tableName),
+	}))
+
+	out := vitessApplyAndWait(t, schemaDir, "production")
+
+	e2eutil.AssertContains(t, out, "Table started")
+	e2eutil.AssertContains(t, out, tableName)
+	e2eutil.AssertContains(t, out, "Apply completed")
+}
+
+// --- Plan-only Tests ---
+
+func TestVitess_Plan_NoChanges(t *testing.T) {
+	vitessAvailable(t)
+	vitessRestoreBaseSchema(t, "staging")
+	binPath := buildCLI(t)
+	endpoint := schemabotURL(t)
+
+	schemaDir := newVitessSchemaDir(t, vitessBaseSchema())
+	out := e2eutil.RunCLIInDir(t, binPath, schemaDir, "plan",
+		"-s", ".", "-e", "staging", "--endpoint", endpoint)
+
+	e2eutil.AssertContains(t, out, "No schema changes detected")
+}
+
+func TestVitess_Plan_AddIndex(t *testing.T) {
+	vitessAvailable(t)
+	binPath := buildCLI(t)
+	endpoint := schemabotURL(t)
+
+	indexName := fmt.Sprintf("idx_plan_%d", time.Now().UnixMilli()%100000)
+	schemaDir := newVitessSchemaDir(t, vitessSchemaWithOverrides(map[string]string{
+		"testapp_sharded/users.sql": fmt.Sprintf(`CREATE TABLE `+"`users`"+` (
+  `+"`id`"+` bigint NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  `+"`email`"+` varchar(255) NOT NULL,
+  `+"`full_name`"+` varchar(255) NULL,
+  `+"`created_at`"+` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  INDEX `+"`idx_email`"+` (`+"`email`"+`),
+  INDEX `+"`%s`"+` (`+"`full_name`"+`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;`, indexName),
+	}))
+
+	out := e2eutil.RunCLIInDir(t, binPath, schemaDir, "plan",
+		"-s", ".", "-e", "staging", "--endpoint", endpoint)
+
+	e2eutil.AssertContains(t, out, "ADD INDEX")
+	e2eutil.AssertContains(t, out, indexName)
+	e2eutil.AssertContains(t, out, "1 table to alter")
+}
+
+func TestVitess_Plan_AddColumn(t *testing.T) {
+	vitessAvailable(t)
+	binPath := buildCLI(t)
+	endpoint := schemabotURL(t)
+
+	colName := fmt.Sprintf("col_plan_%d", time.Now().UnixMilli()%100000)
+	schemaDir := newVitessSchemaDir(t, vitessSchemaWithOverrides(map[string]string{
+		"testapp_sharded/users.sql": fmt.Sprintf(`CREATE TABLE `+"`users`"+` (
+  `+"`id`"+` bigint NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  `+"`email`"+` varchar(255) NOT NULL,
+  `+"`full_name`"+` varchar(255) NULL,
+  `+"`%s`"+` text NULL,
+  `+"`created_at`"+` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  INDEX `+"`idx_email`"+` (`+"`email`"+`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;`, colName),
+	}))
+
+	out := e2eutil.RunCLIInDir(t, binPath, schemaDir, "plan",
+		"-s", ".", "-e", "staging", "--endpoint", endpoint)
+
+	e2eutil.AssertContains(t, out, "ADD COLUMN")
+	e2eutil.AssertContains(t, out, colName)
+	e2eutil.AssertContains(t, out, "1 table to alter")
+}
+
+func TestVitess_Plan_MultiKeyspace(t *testing.T) {
+	vitessAvailable(t)
+	binPath := buildCLI(t)
+	endpoint := schemabotURL(t)
+
+	tableName := uniqueTableName("vmulti")
+	schemaDir := newVitessSchemaDir(t, vitessSchemaWithOverrides(map[string]string{
+		// Change in sharded keyspace
+		"testapp_sharded/users.sql": `CREATE TABLE ` + "`users`" + ` (
+  ` + "`id`" + ` bigint NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  ` + "`email`" + ` varchar(255) NOT NULL,
+  ` + "`full_name`" + ` varchar(255) NULL,
+  ` + "`created_at`" + ` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  INDEX ` + "`idx_email`" + ` (` + "`email`" + `),
+  INDEX ` + "`idx_created_at`" + ` (` + "`created_at`" + `)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;`,
+		// New table in unsharded keyspace
+		"testapp/" + tableName + ".sql": fmt.Sprintf(`CREATE TABLE %s (
+    id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    label VARCHAR(100)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;`, tableName),
+	}))
+
+	out := e2eutil.RunCLIInDir(t, binPath, schemaDir, "plan",
+		"-s", ".", "-e", "staging", "--endpoint", endpoint)
+
+	// Both keyspaces should appear in plan
+	e2eutil.AssertContains(t, out, "ADD INDEX")
+	e2eutil.AssertContains(t, out, "CREATE TABLE")
+	e2eutil.AssertContains(t, out, tableName)
+}
+
+func TestVitess_Plan_Deduplication(t *testing.T) {
+	vitessAvailable(t)
+	binPath := buildCLI(t)
+	endpoint := schemabotURL(t)
+
+	// Add an index — this change is the same on both envs since
+	// neither env has this index. Note: earlier tests may have modified
+	// production, so we use an index change that's additive.
+	indexName := fmt.Sprintf("idx_dedup_%d", time.Now().UnixMilli()%100000)
+	schemaDir := newVitessSchemaDir(t, vitessSchemaWithOverrides(map[string]string{
+		"testapp_sharded/users.sql": fmt.Sprintf(`CREATE TABLE `+"`users`"+` (
+  `+"`id`"+` bigint NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  `+"`email`"+` varchar(255) NOT NULL,
+  `+"`full_name`"+` varchar(255) NULL,
+  `+"`created_at`"+` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  INDEX `+"`idx_email`"+` (`+"`email`"+`),
+  INDEX `+"`%s`"+` (`+"`full_name`"+`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;`, indexName),
+	}))
+
+	// Plan for staging only, then all envs — compare
+	outStaging := e2eutil.RunCLIInDir(t, binPath, schemaDir, "plan",
+		"-s", ".", "-e", "staging", "--endpoint", endpoint)
+	e2eutil.AssertContains(t, outStaging, "ADD INDEX")
+	e2eutil.AssertContains(t, outStaging, "Staging")
+
+	// Plan without env should show both or dedup
+	outAll := e2eutil.RunCLIInDir(t, binPath, schemaDir, "plan",
+		"-s", ".", "--endpoint", endpoint)
+	e2eutil.AssertContains(t, outAll, "ADD INDEX")
+	e2eutil.AssertContains(t, outAll, indexName)
+}
+
+func TestVitess_Plan_UnsafeBlocked(t *testing.T) {
+	vitessAvailable(t)
+	binPath := buildCLI(t)
+	endpoint := schemabotURL(t)
+
+	// Remove the idx_email index from users — this is a DROP INDEX (unsafe)
+	schemaDir := newVitessSchemaDir(t, vitessSchemaWithOverrides(map[string]string{
+		"testapp_sharded/users.sql": `CREATE TABLE ` + "`users`" + ` (
+  ` + "`id`" + ` bigint NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  ` + "`email`" + ` varchar(255) NOT NULL,
+  ` + "`full_name`" + ` varchar(255) NULL,
+  ` + "`created_at`" + ` timestamp NULL DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;`,
+	}))
+
+	out := e2eutil.RunCLIInDir(t, binPath, schemaDir, "plan",
+		"-s", ".", "-e", "staging", "--endpoint", endpoint)
+
+	e2eutil.AssertContains(t, out, "DROP INDEX")
+	e2eutil.AssertContains(t, out, "Unsafe Changes Detected")
+}
+
+// --- Apply: CREATE TABLE (sharded + sequence + VSchema) ---
+
+func TestVitess_Apply_CreateTable_Sharded_WithSequence(t *testing.T) {
+	vitessAvailable(t)
+	clearSchemaBotState(t)
+	defer vitessRestoreBaseSchema(t, "staging")
+
+	tableName := uniqueTableName("vshrd")
+	seqName := tableName + "_seq"
+	schemaDir := newVitessSchemaDir(t, vitessSchemaWithOverrides(map[string]string{
+		// Sharded table
+		"testapp_sharded/" + tableName + ".sql": fmt.Sprintf(`CREATE TABLE `+"`%s`"+` (
+    `+"`id`"+` bigint unsigned NOT NULL,
+    `+"`user_id`"+` bigint unsigned NOT NULL,
+    `+"`amount`"+` bigint NOT NULL DEFAULT 0,
+    `+"`created_at`"+` timestamp DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (`+"`id`"+`),
+    KEY `+"`idx_user_id`"+` (`+"`user_id`"+`)
+) ENGINE InnoDB,
+  CHARSET utf8mb4,
+  COLLATE utf8mb4_0900_ai_ci;`, tableName),
+		// Sequence table in unsharded keyspace
+		"testapp/" + seqName + ".sql": fmt.Sprintf(`CREATE TABLE `+"`%s`"+` (
+    `+"`id`"+` int unsigned NOT NULL DEFAULT '0',
+    `+"`next_id`"+` bigint unsigned,
+    `+"`cache`"+` bigint unsigned,
+    PRIMARY KEY (`+"`id`"+`)
+) ENGINE InnoDB,
+  CHARSET utf8mb4,
+  COLLATE utf8mb4_0900_ai_ci,
+  COMMENT 'vitess_sequence';`, seqName),
+		// Updated VSchema with new table
+		"testapp_sharded/vschema.json": fmt.Sprintf(`{
+  "sharded": true,
+  "vindexes": {"hash": {"type": "hash"}},
+  "tables": {
+    "users": {"column_vindexes": [{"column": "id", "name": "hash"}], "auto_increment": {"column": "id", "sequence": "users_seq"}},
+    "orders": {"column_vindexes": [{"column": "user_id", "name": "hash"}], "auto_increment": {"column": "id", "sequence": "orders_seq"}},
+    "products": {"column_vindexes": [{"column": "id", "name": "hash"}], "auto_increment": {"column": "id", "sequence": "products_seq"}},
+    "%s": {"column_vindexes": [{"column": "user_id", "name": "hash"}], "auto_increment": {"column": "id", "sequence": "%s"}}
+  }
+}`, tableName, seqName),
+		"testapp/vschema.json": fmt.Sprintf(`{
+  "tables": {
+    "users_seq": {"type": "sequence"},
+    "orders_seq": {"type": "sequence"},
+    "products_seq": {"type": "sequence"},
+    "%s": {"type": "sequence"}
+  }
+}`, seqName),
+	}))
+
+	out := vitessApplyAndWait(t, schemaDir, "staging")
+
+	e2eutil.AssertContains(t, out, "Table started")
+	e2eutil.AssertContains(t, out, tableName)
+	e2eutil.AssertContains(t, out, seqName)
+	e2eutil.AssertContains(t, out, "Apply completed")
+	// Sharded table should show 2 shards, sequence should show 1
+	assert.Contains(t, out, "shards=2")
+	assert.Contains(t, out, "shards=1")
+}
+
+// --- VSchema-only changes ---
+
+func TestVitess_Plan_VSchemaOnly(t *testing.T) {
+	vitessAvailable(t)
+	defer vitessRestoreBaseSchema(t, "staging")
+	binPath := buildCLI(t)
+	endpoint := schemabotURL(t)
+
+	schemaDir := newVitessSchemaDir(t, vitessSchemaWithOverrides(map[string]string{
+		"testapp_sharded/vschema.json": `{"sharded":true,"vindexes":{"hash":{"type":"hash"},"xxhash":{"type":"xxhash"}},"tables":{"users":{"column_vindexes":[{"column":"id","name":"hash"}],"auto_increment":{"column":"id","sequence":"users_seq"}},"orders":{"column_vindexes":[{"column":"user_id","name":"hash"}],"auto_increment":{"column":"id","sequence":"orders_seq"}},"products":{"column_vindexes":[{"column":"id","name":"hash"}],"auto_increment":{"column":"id","sequence":"products_seq"}}}}`,
+	}))
+
+	out := e2eutil.RunCLIInDir(t, binPath, schemaDir, "plan",
+		"-s", ".", "-e", "staging", "--endpoint", endpoint)
+
+	e2eutil.AssertContains(t, out, "VSchema")
+	e2eutil.AssertContains(t, out, "xxhash")
+	assert.NotContains(t, out, "No schema changes detected")
+}
+
+func TestVitess_Apply_VSchemaOnly(t *testing.T) {
+	vitessAvailable(t)
+	clearSchemaBotState(t)
+	defer vitessRestoreBaseSchema(t, "staging")
+
+	schemaDir := newVitessSchemaDir(t, vitessSchemaWithOverrides(map[string]string{
+		"testapp_sharded/vschema.json": `{"sharded":true,"vindexes":{"hash":{"type":"hash"},"xxhash":{"type":"xxhash"}},"tables":{"users":{"column_vindexes":[{"column":"id","name":"hash"}],"auto_increment":{"column":"id","sequence":"users_seq"}},"orders":{"column_vindexes":[{"column":"user_id","name":"hash"}],"auto_increment":{"column":"id","sequence":"orders_seq"}},"products":{"column_vindexes":[{"column":"id","name":"hash"}],"auto_increment":{"column":"id","sequence":"products_seq"}}}}`,
+	}))
+
+	out := vitessApplyAndWait(t, schemaDir, "staging")
+	e2eutil.AssertContains(t, out, "Apply completed")
+}
+
+func TestVitess_Apply_VSchemaOnly_MultiKeyspace(t *testing.T) {
+	vitessAvailable(t)
+	vitessResetVSchema(t)
+	clearSchemaBotState(t)
+	defer vitessRestoreBaseSchema(t, "staging")
+
+	// VSchema changes in both keyspaces: add xxhash to sharded, add audit_seq to unsharded
+	schemaDir := newVitessSchemaDir(t, vitessSchemaWithOverrides(map[string]string{
+		"testapp_sharded/vschema.json": `{"sharded":true,"vindexes":{"hash":{"type":"hash"},"xxhash":{"type":"xxhash"}},"tables":{"users":{"column_vindexes":[{"column":"id","name":"hash"}],"auto_increment":{"column":"id","sequence":"users_seq"}},"orders":{"column_vindexes":[{"column":"user_id","name":"hash"}],"auto_increment":{"column":"id","sequence":"orders_seq"}},"products":{"column_vindexes":[{"column":"id","name":"hash"}],"auto_increment":{"column":"id","sequence":"products_seq"}}}}`,
+		"testapp/vschema.json":         `{"tables":{"users_seq":{"type":"sequence"},"orders_seq":{"type":"sequence"},"products_seq":{"type":"sequence"},"audit_seq":{"type":"sequence"}}}`,
+	}))
+
+	binPath := buildCLI(t)
+	endpoint := schemabotURL(t)
+
+	// Plan should show both keyspaces
+	planOut := e2eutil.RunCLIInDir(t, binPath, schemaDir, "plan",
+		"-s", ".", "-e", "staging", "--endpoint", endpoint)
+	e2eutil.AssertContains(t, planOut, "Keyspace: testapp_sharded")
+	e2eutil.AssertContains(t, planOut, "Keyspace: testapp")
+	e2eutil.AssertContains(t, planOut, "~ VSchema:")
+
+	// Apply should complete
+	out := vitessApplyAndWait(t, schemaDir, "staging")
+	e2eutil.AssertContains(t, out, "Apply completed")
+}
+
+// --- Apply: VSchema with DDL ---
+
+func TestVitess_Apply_VSchemaWithDDL(t *testing.T) {
+	vitessAvailable(t)
+	clearSchemaBotState(t)
+	defer vitessRestoreBaseSchema(t, "staging")
+
+	// VSchema change paired with a DDL change. Pure VSchema-only changes
+	// are not yet detected by the plan differ — this tests that VSchema
+	// is propagated when DDL changes are present.
+	indexName := fmt.Sprintf("idx_vs_%d", time.Now().UnixMilli()%100000)
+	schemaDir := newVitessSchemaDir(t, vitessSchemaWithOverrides(map[string]string{
+		"testapp_sharded/users.sql": fmt.Sprintf(`CREATE TABLE `+"`users`"+` (
+  `+"`id`"+` bigint NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  `+"`email`"+` varchar(255) NOT NULL,
+  `+"`full_name`"+` varchar(255) NULL,
+  `+"`created_at`"+` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  INDEX `+"`idx_email`"+` (`+"`email`"+`),
+  INDEX `+"`%s`"+` (`+"`full_name`"+`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;`, indexName),
+		"testapp_sharded/vschema.json": `{
+  "sharded": true,
+  "vindexes": {
+    "hash": {"type": "hash"},
+    "xxhash": {"type": "xxhash"}
+  },
+  "tables": {
+    "users": {
+      "column_vindexes": [{"column": "id", "name": "hash"}],
+      "auto_increment": {"column": "id", "sequence": "users_seq"}
+    },
+    "orders": {
+      "column_vindexes": [{"column": "user_id", "name": "hash"}],
+      "auto_increment": {"column": "id", "sequence": "orders_seq"}
+    },
+    "products": {
+      "column_vindexes": [{"column": "id", "name": "hash"}],
+      "auto_increment": {"column": "id", "sequence": "products_seq"}
+    }
+  }
+}`,
+	}))
+
+	out := vitessApplyAndWait(t, schemaDir, "staging")
+	e2eutil.AssertContains(t, out, "Apply completed")
+	e2eutil.AssertContains(t, out, indexName)
+}
+
+// --- Apply: Unsafe (DROP) ---
+
+func TestVitess_Apply_DropIndex_BlockedWithoutFlag(t *testing.T) {
+	vitessAvailable(t)
+	vitessRestoreBaseSchema(t, "staging")
+	defer vitessRestoreBaseSchema(t, "staging")
+	binPath := buildCLI(t)
+	endpoint := schemabotURL(t)
+
+	// First add an index
+	indexName := fmt.Sprintf("idx_drop_%d", time.Now().UnixMilli()%100000)
+	addSchema := newVitessSchemaDir(t, vitessSchemaWithOverrides(map[string]string{
+		"testapp_sharded/users.sql": fmt.Sprintf(`CREATE TABLE `+"`users`"+` (
+  `+"`id`"+` bigint NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  `+"`email`"+` varchar(255) NOT NULL,
+  `+"`full_name`"+` varchar(255) NULL,
+  `+"`created_at`"+` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  INDEX `+"`idx_email`"+` (`+"`email`"+`),
+  INDEX `+"`%s`"+` (`+"`full_name`"+`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;`, indexName),
+	}))
+	vitessApplyAndWait(t, addSchema, "staging")
+	clearSchemaBotState(t)
+
+	// Now try to drop it without --allow-unsafe — should be blocked
+	dropSchema := newVitessSchemaDir(t, vitessBaseSchema())
+	out, err := e2eutil.RunCLIWithErrorInDir(t, binPath, dropSchema, "apply",
+		"-s", ".", "-e", "staging", "--endpoint", endpoint, "-y", "-o", "log")
+	t.Logf("DROP INDEX apply output:\n%s", out)
+	require.Error(t, err, "expected apply to fail without --allow-unsafe")
+	assert.Contains(t, out, "Unsafe Changes Detected")
+}
+
+func TestVitess_Apply_DropTable_WithVSchema(t *testing.T) {
+	vitessAvailable(t)
+	clearSchemaBotState(t)
+	binPath := buildCLI(t)
+	endpoint := schemabotURL(t)
+
+	// Step 1: Create a sharded table + sequence + VSchema entry
+	tableName := uniqueTableName("vdrop")
+	seqName := tableName + "_seq"
+	createSchema := newVitessSchemaDir(t, vitessSchemaWithOverrides(map[string]string{
+		"testapp_sharded/" + tableName + ".sql": fmt.Sprintf(
+			"CREATE TABLE `%s` (`id` bigint unsigned NOT NULL, `data` varchar(255), PRIMARY KEY (`id`)) ENGINE InnoDB, CHARSET utf8mb4, COLLATE utf8mb4_0900_ai_ci;", tableName),
+		"testapp/" + seqName + ".sql": fmt.Sprintf(
+			"CREATE TABLE `%s` (`id` int unsigned NOT NULL DEFAULT '0', `next_id` bigint unsigned, `cache` bigint unsigned, PRIMARY KEY (`id`)) ENGINE InnoDB, CHARSET utf8mb4, COLLATE utf8mb4_0900_ai_ci, COMMENT 'vitess_sequence';", seqName),
+		"testapp_sharded/vschema.json": fmt.Sprintf(
+			`{"sharded":true,"vindexes":{"hash":{"type":"hash"}},"tables":{"users":{"column_vindexes":[{"column":"id","name":"hash"}],"auto_increment":{"column":"id","sequence":"users_seq"}},"orders":{"column_vindexes":[{"column":"user_id","name":"hash"}],"auto_increment":{"column":"id","sequence":"orders_seq"}},"products":{"column_vindexes":[{"column":"id","name":"hash"}],"auto_increment":{"column":"id","sequence":"products_seq"}},"%s":{"column_vindexes":[{"column":"id","name":"hash"}],"auto_increment":{"column":"id","sequence":"%s"}}}}`, tableName, seqName),
+		"testapp/vschema.json": fmt.Sprintf(
+			`{"tables":{"users_seq":{"type":"sequence"},"orders_seq":{"type":"sequence"},"products_seq":{"type":"sequence"},"%s":{"type":"sequence"}}}`, seqName),
+	}))
+	vitessApplyAndWait(t, createSchema, "staging")
+	clearSchemaBotState(t)
+
+	// Step 2: Plan the DROP — base schema without the new table, sequence, or VSchema entries
+	dropSchema := newVitessSchemaDir(t, vitessBaseSchema())
+
+	planOut := e2eutil.RunCLIInDir(t, binPath, dropSchema, "plan",
+		"-s", ".", "-e", "staging", "--endpoint", endpoint)
+	e2eutil.AssertContains(t, planOut, "DROP TABLE")
+	e2eutil.AssertContains(t, planOut, tableName)
+	e2eutil.AssertContains(t, planOut, "Unsafe Changes Detected")
+	// VSchema diff should show the removed table entry
+	e2eutil.AssertContains(t, planOut, "VSchema")
+
+	// Step 3: Apply the DROP with --allow-unsafe
+	clearSchemaBotState(t)
+	out := vitessApplyAndWait(t, dropSchema, "staging")
+	e2eutil.AssertContains(t, out, "Apply completed")
+}
+
+// --- Progress & Engine Tests ---
+
+func TestVitess_Apply_DeployRequestURL(t *testing.T) {
+	vitessAvailable(t)
+	clearSchemaBotState(t)
+
+	defer vitessRestoreBaseSchema(t, "staging")
+
+	indexName := fmt.Sprintf("idx_dr_%d", time.Now().UnixMilli()%100000)
+	schemaDir := newVitessSchemaDir(t, vitessSchemaWithOverrides(map[string]string{
+		"testapp_sharded/orders.sql": fmt.Sprintf(`CREATE TABLE `+"`orders`"+` (
+    `+"`id`"+` bigint unsigned NOT NULL,
+    `+"`user_id`"+` bigint unsigned NOT NULL,
+    `+"`total_cents`"+` bigint NOT NULL,
+    `+"`status`"+` varchar(100) NOT NULL DEFAULT 'pending',
+    `+"`created_at`"+` timestamp DEFAULT CURRENT_TIMESTAMP,
+    `+"`updated_at`"+` timestamp DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (`+"`id`"+`),
+    KEY `+"`idx_user_id`"+` (`+"`user_id`"+`),
+    KEY `+"`idx_status`"+` (`+"`status`"+`),
+    KEY `+"`idx_created_at`"+` (`+"`created_at`"+`),
+    KEY `+"`%s`"+` (`+"`total_cents`"+`)
+) ENGINE InnoDB,
+  CHARSET utf8mb4,
+  COLLATE utf8mb4_0900_ai_ci;`, indexName),
+	}))
+
+	out := vitessApplyAndWait(t, schemaDir, "staging")
+
+	e2eutil.AssertContains(t, out, "Apply completed")
+	// Deploy request URL should appear in log output
+	assert.Contains(t, out, "deploy-requests/", "expected deploy request URL in log output")
+}
+
+func TestVitess_Apply_SetupPhases(t *testing.T) {
+	vitessAvailable(t)
+	clearSchemaBotState(t)
+
+	defer vitessRestoreBaseSchema(t, "staging")
+
+	indexName := fmt.Sprintf("idx_sp2_%d", time.Now().UnixMilli()%100000)
+	schemaDir := newVitessSchemaDir(t, vitessSchemaWithOverrides(map[string]string{
+		"testapp_sharded/products.sql": fmt.Sprintf(`CREATE TABLE `+"`products`"+` (
+    `+"`id`"+` bigint unsigned NOT NULL,
+    `+"`name`"+` varchar(255) NOT NULL,
+    `+"`description`"+` text NULL,
+    `+"`price_cents`"+` bigint NOT NULL,
+    `+"`sku`"+` varchar(100) NOT NULL,
+    `+"`created_at`"+` timestamp DEFAULT CURRENT_TIMESTAMP,
+    `+"`updated_at`"+` timestamp DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (`+"`id`"+`),
+    KEY `+"`idx_name`"+` (`+"`name`"+`),
+    UNIQUE KEY `+"`idx_sku`"+` (`+"`sku`"+`),
+    KEY `+"`idx_price`"+` (`+"`price_cents`"+`),
+    KEY `+"`%s`"+` (`+"`created_at`"+`, `+"`price_cents`"+`)
+) ENGINE InnoDB,
+  CHARSET utf8mb4,
+  COLLATE utf8mb4_0900_ai_ci;`, indexName),
+	}))
+
+	out := vitessApplyAndWait(t, schemaDir, "staging")
+
+	e2eutil.AssertContains(t, out, "Apply completed")
+	// Setup phase messages should appear during the pending phase
+	assert.Contains(t, out, "Setting up branch", "expected 'Setting up branch' message during setup")
+	assert.Contains(t, out, "Deploy request", "expected 'Deploy request' message during setup")
+}
+
+func TestVitess_Progress_DeployRequestMetadata(t *testing.T) {
+	vitessAvailable(t)
+	clearSchemaBotState(t)
+
+	defer vitessRestoreBaseSchema(t, "staging")
+
+	endpoint := schemabotURL(t)
+	indexName := fmt.Sprintf("idx_pm_%d", time.Now().UnixMilli()%100000)
+	schemaDir := newVitessSchemaDir(t, vitessSchemaWithOverrides(map[string]string{
+		"testapp_sharded/orders.sql": fmt.Sprintf(`CREATE TABLE `+"`orders`"+` (
+    `+"`id`"+` bigint unsigned NOT NULL,
+    `+"`user_id`"+` bigint unsigned NOT NULL,
+    `+"`total_cents`"+` bigint NOT NULL,
+    `+"`status`"+` varchar(100) NOT NULL DEFAULT 'pending',
+    `+"`created_at`"+` timestamp DEFAULT CURRENT_TIMESTAMP,
+    `+"`updated_at`"+` timestamp DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (`+"`id`"+`),
+    KEY `+"`idx_user_id`"+` (`+"`user_id`"+`),
+    KEY `+"`idx_status`"+` (`+"`status`"+`),
+    KEY `+"`idx_created_at`"+` (`+"`created_at`"+`),
+    KEY `+"`%s`"+` (`+"`total_cents`"+`)
+) ENGINE InnoDB,
+  CHARSET utf8mb4,
+  COLLATE utf8mb4_0900_ai_ci;`, indexName),
+	}))
+
+	// Start apply without watching (returns immediately)
+	binPath := buildCLI(t)
+	applyOut := e2eutil.RunCLI(t, binPath, schemaDir, "apply",
+		"-s", ".",
+		"-e", "staging",
+		"--endpoint", endpoint,
+		"-y", "-o", "log", "--no-watch", "--allow-unsafe",
+	)
+	applyID := extractApplyIDFromLog(applyOut)
+	require.NotEmpty(t, applyID, "expected apply ID in output")
+
+	// Poll progress API until completion, checking for deploy_request_url along the way
+	var foundURL bool
+	var finalState string
+	deadline := time.Now().Add(testutil.PollDeadline)
+	for time.Now().Before(deadline) {
+		resp, err := client.GetProgress(endpoint, applyID)
+		if err == nil {
+			if !foundURL && resp.Metadata != nil {
+				if url := resp.Metadata["deploy_request_url"]; url != "" {
+					foundURL = true
+					assert.Contains(t, url, "deploy-requests/", "expected deploy request URL in metadata")
+				}
+			}
+			if state.IsTerminalApplyState(resp.State) {
+				finalState = resp.State
+				break
+			}
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	assert.True(t, foundURL, "expected deploy_request_url in progress metadata during apply")
+	require.NotEmpty(t, finalState, "apply did not reach terminal state within poll deadline")
+	assert.Equal(t, state.Apply.Completed, finalState)
+}
+
+func TestVitess_Apply_Timestamps(t *testing.T) {
+	vitessAvailable(t)
+	clearSchemaBotState(t)
+
+	defer vitessRestoreBaseSchema(t, "staging")
+
+	endpoint := schemabotURL(t)
+	indexName := fmt.Sprintf("idx_ts_%d", time.Now().UnixMilli()%100000)
+	schemaDir := newVitessSchemaDir(t, vitessSchemaWithOverrides(map[string]string{
+		"testapp_sharded/orders.sql": fmt.Sprintf(`CREATE TABLE `+"`orders`"+` (
+    `+"`id`"+` bigint unsigned NOT NULL,
+    `+"`user_id`"+` bigint unsigned NOT NULL,
+    `+"`total_cents`"+` bigint NOT NULL,
+    `+"`status`"+` varchar(100) NOT NULL DEFAULT 'pending',
+    `+"`created_at`"+` timestamp DEFAULT CURRENT_TIMESTAMP,
+    `+"`updated_at`"+` timestamp DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (`+"`id`"+`),
+    KEY `+"`idx_user_id`"+` (`+"`user_id`"+`),
+    KEY `+"`idx_status`"+` (`+"`status`"+`),
+    KEY `+"`idx_created_at`"+` (`+"`created_at`"+`),
+    KEY `+"`%s`"+` (`+"`total_cents`"+`)
+) ENGINE InnoDB,
+  CHARSET utf8mb4,
+  COLLATE utf8mb4_0900_ai_ci;`, indexName),
+	}))
+
+	// Start apply without watching
+	binPath := buildCLI(t)
+	applyOut := e2eutil.RunCLI(t, binPath, schemaDir, "apply",
+		"-s", ".",
+		"-e", "staging",
+		"--endpoint", endpoint,
+		"-y", "-o", "log", "--no-watch", "--allow-unsafe",
+	)
+	applyID := extractApplyIDFromLog(applyOut)
+	require.NotEmpty(t, applyID, "expected apply ID in output")
+
+	// Poll until completion
+	waitForApplyState(t, endpoint, applyID, state.Apply.Completed, testutil.PollDeadline)
+
+	// Verify timestamps on completed apply
+	resp, err := client.GetProgress(endpoint, applyID)
+	require.NoError(t, err)
+	assert.Equal(t, state.Apply.Completed, resp.State)
+
+	// Apply-level started_at should be populated and before completed_at
+	assert.NotEmpty(t, resp.StartedAt, "apply started_at should be populated")
+	assert.NotEmpty(t, resp.CompletedAt, "apply completed_at should be populated")
+	if resp.StartedAt != "" && resp.CompletedAt != "" {
+		startedAt, err := time.Parse(time.RFC3339, resp.StartedAt)
+		require.NoError(t, err, "parse started_at")
+		completedAt, err := time.Parse(time.RFC3339, resp.CompletedAt)
+		require.NoError(t, err, "parse completed_at")
+		assert.True(t, startedAt.Before(completedAt) || startedAt.Equal(completedAt),
+			"started_at (%s) should be <= completed_at (%s)", resp.StartedAt, resp.CompletedAt)
+	}
+
+	// Table progress should exist with per-table timestamps
+	require.NotEmpty(t, resp.Tables, "expected at least one table in progress")
+	for _, tbl := range resp.Tables {
+		assert.NotEmpty(t, tbl.Status, "table %s should have a status", tbl.TableName)
+		assert.NotEmpty(t, tbl.StartedAt, "table %s should have started_at", tbl.TableName)
+		assert.NotEmpty(t, tbl.CompletedAt, "table %s should have completed_at", tbl.TableName)
+	}
+}
+
+// --- Revert behavior tests ---
+
+func TestVitess_Apply_RevertWindow(t *testing.T) {
+	// Verify that applies without --skip-revert correctly reach the revert window state.
+	vitessAvailable(t)
+	clearSchemaBotState(t)
+
+	defer vitessRestoreBaseSchema(t, "staging")
+
+	indexName := fmt.Sprintf("idx_rv_%d", time.Now().UnixMilli()%100000)
+	schemaDir := newVitessSchemaDir(t, vitessSchemaWithOverrides(map[string]string{
+		"testapp_sharded/orders.sql": fmt.Sprintf(`CREATE TABLE `+"`orders`"+` (
+    `+"`id`"+` bigint unsigned NOT NULL,
+    `+"`user_id`"+` bigint unsigned NOT NULL,
+    `+"`total_cents`"+` bigint NOT NULL,
+    `+"`status`"+` varchar(100) NOT NULL DEFAULT 'pending',
+    `+"`created_at`"+` timestamp DEFAULT CURRENT_TIMESTAMP,
+    `+"`updated_at`"+` timestamp DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (`+"`id`"+`),
+    KEY `+"`idx_user_id`"+` (`+"`user_id`"+`),
+    KEY `+"`idx_status`"+` (`+"`status`"+`),
+    KEY `+"`idx_created_at`"+` (`+"`created_at`"+`),
+    KEY `+"`%s`"+` (`+"`total_cents`"+`)
+) ENGINE InnoDB,
+  CHARSET utf8mb4,
+  COLLATE utf8mb4_0900_ai_ci;`, indexName),
+	}))
+
+	// Apply without --skip-revert (revert window enabled by default).
+	// Use --no-watch without -o log so the CLI exits after starting the apply.
+	binPath := buildCLI(t)
+	endpoint := schemabotURL(t)
+	applyOut := e2eutil.RunCLI(t, binPath, schemaDir, "apply",
+		"-s", ".",
+		"-e", "staging",
+		"--endpoint", endpoint,
+		"-y", "--no-watch", "--allow-unsafe",
+	)
+	applyID := extractApplyIDFromLog(applyOut)
+	require.NotEmpty(t, applyID, "expected apply ID in output")
+
+	// Poll until we see revert_window (not completed — that means auto-skip fired)
+	var sawRevertWindow bool
+	deadline := time.Now().Add(testutil.PollDeadline)
+	for time.Now().Before(deadline) {
+		resp, err := client.GetProgress(endpoint, applyID)
+		if err == nil {
+			if resp.State == state.Apply.RevertWindow {
+				sawRevertWindow = true
+				break
+			}
+			if resp.State == state.Apply.Completed {
+				break
+			}
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	require.True(t, sawRevertWindow, "expected revert_window state (revert enabled by default), but apply jumped to completed")
+
+	// Clean up: skip-revert to finalize
+	_, _ = client.CallSkipRevertAPI(endpoint, vitessDB, "staging")
+	waitForApplyState(t, endpoint, applyID, state.Apply.Completed, testutil.PollDeadline)
+}
+
+// --- Cancel Tests ---
+
+func TestVitess_Apply_Cancel(t *testing.T) {
+	vitessAvailable(t)
+	clearSchemaBotState(t)
+	defer vitessRestoreBaseSchema(t, "staging")
+
+	endpoint := schemabotURL(t)
+	// Use defer_cutover so the apply holds at waiting_for_cutover — a stable
+	// state we can reliably cancel from without racing against completion.
+	indexName := fmt.Sprintf("idx_cancel_%d", time.Now().UnixMilli()%100000)
+	schemaDir := newVitessSchemaDir(t, vitessSchemaWithOverrides(map[string]string{
+		"testapp_sharded/orders.sql": fmt.Sprintf(`CREATE TABLE `+"`orders`"+` (
+    `+"`id`"+` bigint unsigned NOT NULL,
+    `+"`user_id`"+` bigint unsigned NOT NULL,
+    `+"`total_cents`"+` bigint NOT NULL,
+    `+"`status`"+` varchar(100) NOT NULL DEFAULT 'pending',
+    `+"`created_at`"+` timestamp DEFAULT CURRENT_TIMESTAMP,
+    `+"`updated_at`"+` timestamp DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (`+"`id`"+`),
+    KEY `+"`idx_user_id`"+` (`+"`user_id`"+`),
+    KEY `+"`idx_status`"+` (`+"`status`"+`),
+    KEY `+"`idx_created_at`"+` (`+"`created_at`"+`),
+    KEY `+"`%s`"+` (`+"`total_cents`"+`)
+) ENGINE InnoDB,
+  CHARSET utf8mb4,
+  COLLATE utf8mb4_0900_ai_ci;`, indexName),
+	}))
+
+	// Apply with defer_cutover so it pauses at waiting_for_cutover
+	binPath := buildCLI(t)
+	applyOut := e2eutil.RunCLI(t, binPath, schemaDir, "apply",
+		"-s", ".",
+		"-e", "staging",
+		"--endpoint", endpoint,
+		"-y", "-o", "log", "--no-watch", "--allow-unsafe", "--defer-cutover",
+	)
+	applyID := extractApplyIDFromLog(applyOut)
+	require.NotEmpty(t, applyID, "expected apply ID in output")
+
+	// Wait for waiting_for_cutover — deterministic pause point
+	waitForApplyState(t, endpoint, applyID, state.Apply.WaitingForCutover, testutil.PollDeadline)
+
+	// Cancel from the stable waiting_for_cutover state
+	t.Logf("calling stop API: endpoint=%s database=%s applyID=%s", endpoint, vitessDB, applyID)
+	stopResult, err := client.CallStopAPI(endpoint, vitessDB, "staging", applyID)
+	require.NoError(t, err, "stop/cancel API call")
+	t.Logf("stop API returned: accepted=%v stopped=%d skipped=%d error=%q",
+		stopResult.Accepted, stopResult.StoppedCount, stopResult.SkippedCount, stopResult.ErrorMessage)
+	require.True(t, stopResult.Accepted, "stop should be accepted: %s", stopResult.ErrorMessage)
+
+	// Verify it reaches cancelled state (not stopped)
+	waitForApplyState(t, endpoint, applyID, state.Apply.Cancelled, testutil.PollDeadline)
+
+	// Verify status shows cancelled
+	resp, err := client.GetProgress(endpoint, applyID)
+	require.NoError(t, err)
+	assert.Equal(t, state.Apply.Cancelled, resp.State)
+}
+
+// extractApplyID is defined in apply_wait_test.go

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -133,6 +133,31 @@ type EnvironmentConfig struct {
 
 	// TokenSecretRef is the reference to the PlanetScale API token secret.
 	TokenSecretRef string `yaml:"token_secret_ref,omitempty"`
+
+	// RevertWindowDuration is how long to keep the revert window open after a
+	// PlanetScale deploy completes (e.g., "30m", "1h"). Defaults to 30m if empty.
+	RevertWindowDuration string `yaml:"revert_window_duration,omitempty"`
+
+	// APIURL is the PlanetScale API base URL (e.g., "http://localscale:8080").
+	// DSN is the vtgate MySQL endpoint for schema queries and SHOW VITESS_MIGRATIONS.
+	APIURL string `yaml:"api_url,omitempty"`
+
+	// TLS configures MySQL TLS for branch connections.
+	// When set, registers a named TLS config with the Go MySQL driver.
+	// Omit for LocalScale (no TLS) or set for real PlanetScale (mTLS with CA bundle).
+	TLS *TLSConfig `yaml:"tls,omitempty"`
+}
+
+// TLSConfig holds TLS certificate paths for MySQL connections to PlanetScale branches.
+type TLSConfig struct {
+	// CABundle is the path to the CA certificate bundle (PEM).
+	CABundle string `yaml:"ca_bundle"`
+
+	// ClientCert is the path to the client certificate (PEM).
+	ClientCert string `yaml:"client_cert,omitempty"`
+
+	// ClientKey is the path to the client private key (PEM).
+	ClientKey string `yaml:"client_key,omitempty"`
 }
 
 // RepoConfig holds configuration for a specific repository.

--- a/pkg/api/control_handlers.go
+++ b/pkg/api/control_handlers.go
@@ -4,10 +4,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/block/schemabot/pkg/apitypes"
 	ternv1 "github.com/block/schemabot/pkg/proto/ternv1"
 	"github.com/block/schemabot/pkg/state"
+	"github.com/block/schemabot/pkg/storage"
 	"github.com/block/schemabot/pkg/tern"
 )
 
@@ -303,6 +305,30 @@ func (s *Service) handleSkipRevert(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		s.writeControlError(w, "skip-revert", req.Database, err)
 		return
+	}
+
+	// Record skip-revert on VitessApplyData for progress visibility
+	if resp.Accepted && req.ApplyID != "" && s.storage != nil && s.storage.Applies() != nil {
+		if apply, _ := s.storage.Applies().GetByApplyIdentifier(r.Context(), req.ApplyID); apply != nil {
+			if apply.Engine == storage.EnginePlanetScale {
+				now := time.Now()
+				if vad, err := s.storage.VitessApplyData().GetByApplyID(r.Context(), apply.ID); err == nil {
+					vad.RevertSkippedAt = &now
+					if err := s.storage.VitessApplyData().Save(r.Context(), vad); err != nil {
+						s.logger.Error("failed to save vitess apply data", "apply_id", apply.ID, "error", err)
+					}
+				}
+			}
+			if err := s.storage.ApplyLogs().Append(r.Context(), &storage.ApplyLog{
+				ApplyID:   apply.ID,
+				Level:     storage.LogLevelInfo,
+				EventType: storage.LogEventSkipRevertTriggered,
+				Source:    storage.LogSourceSchemaBot,
+				Message:   "Skip-revert triggered by user",
+			}); err != nil {
+				s.logger.Error("failed to append apply log", "apply_id", apply.ID, "error", err)
+			}
+		}
 	}
 
 	s.writeJSON(w, http.StatusOK, &apitypes.ControlResponse{

--- a/pkg/api/ensure_schema.go
+++ b/pkg/api/ensure_schema.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"log/slog"
+	"sort"
 	"time"
 
 	"github.com/block/spirit/pkg/table"
@@ -33,10 +34,30 @@ func EnsureSchema(dsn string, logger *slog.Logger) error {
 	ctx, cancel := context.WithTimeout(context.Background(), EnsureSchemaTimeout)
 	defer cancel()
 
+	// Diagnostic preamble: log the actual database target and current state
+	// before doing any work. This is critical for debugging bootstrap issues
+	// in embedded environments (e.g., Tern) where the DSN is constructed
+	// dynamically and we need to confirm we're hitting the right database.
+	if diag, err := diagnoseStorageTarget(ctx, dsn); err != nil {
+		logger.Warn("storage target diagnostic failed", "error", err)
+	} else {
+		logger.Info("EnsureSchema storage target",
+			"hostname", diag.hostname,
+			"database", diag.database,
+			"existing_tables", diag.tableCount,
+			"table_names", diag.tableNames,
+		)
+	}
+
 	schemaFiles, err := readEmbeddedSchemaFiles()
 	if err != nil {
 		return err
 	}
+	logger.Info("loaded embedded storage schema files",
+		"namespace_count", len(schemaFiles),
+		"file_count", countSchemaFiles(schemaFiles),
+		"files", schemaFileNames(schemaFiles),
+	)
 
 	// Clean up stale Spirit internal tables before planning. These are
 	// leftover from a previous interrupted schema change (e.g., pod killed
@@ -67,7 +88,7 @@ func EnsureSchema(dsn string, logger *slog.Logger) error {
 		return fmt.Errorf("plan schema: %w", err)
 	}
 	if planResult.NoChanges {
-		logger.Info("storage schema up-to-date", "tables", len(planResult.OriginalSchema))
+		logger.Info("storage schema up-to-date")
 		return nil
 	}
 
@@ -162,6 +183,9 @@ func readEmbeddedSchemaFiles() (schema.SchemaFiles, error) {
 	if err != nil {
 		return nil, fmt.Errorf("read schema directory: %w", err)
 	}
+	if len(entries) == 0 {
+		return nil, fmt.Errorf("read schema directory: no embedded schema files found in mysql/")
+	}
 
 	files := make(map[string]string)
 	for _, entry := range entries {
@@ -178,6 +202,77 @@ func readEmbeddedSchemaFiles() (schema.SchemaFiles, error) {
 	return schema.SchemaFiles{
 		"schemabot": &schema.Namespace{Files: files},
 	}, nil
+}
+
+func countSchemaFiles(schemaFiles schema.SchemaFiles) int {
+	total := 0
+	for _, namespace := range schemaFiles {
+		if namespace == nil {
+			continue
+		}
+		total += len(namespace.Files)
+	}
+	return total
+}
+
+func schemaFileNames(schemaFiles schema.SchemaFiles) []string {
+	names := make([]string, 0)
+	for namespaceName, namespace := range schemaFiles {
+		if namespace == nil {
+			continue
+		}
+		for fileName := range namespace.Files {
+			names = append(names, namespaceName+"/"+fileName)
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
+type storageDiagnostic struct {
+	hostname   string
+	database   string
+	tableCount int
+	tableNames []string
+}
+
+// diagnoseStorageTarget connects to the DSN and queries the actual database
+// identity and existing table state. Used for diagnostic logging only.
+func diagnoseStorageTarget(ctx context.Context, dsn string) (*storageDiagnostic, error) {
+	db, err := sql.Open("mysql", dsn)
+	if err != nil {
+		return nil, fmt.Errorf("open database: %w", err)
+	}
+	defer utils.CloseAndLog(db)
+
+	if err := db.PingContext(ctx); err != nil {
+		return nil, fmt.Errorf("ping database: %w", err)
+	}
+
+	var diag storageDiagnostic
+	if err := db.QueryRowContext(ctx, "SELECT @@hostname, DATABASE()").Scan(&diag.hostname, &diag.database); err != nil {
+		return nil, fmt.Errorf("query hostname and database: %w", err)
+	}
+
+	rows, err := db.QueryContext(ctx, "SHOW TABLES")
+	if err != nil {
+		return nil, fmt.Errorf("show tables: %w", err)
+	}
+	defer utils.CloseAndLog(rows)
+
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, fmt.Errorf("scan table name: %w", err)
+		}
+		diag.tableNames = append(diag.tableNames, name)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate tables: %w", err)
+	}
+	diag.tableCount = len(diag.tableNames)
+
+	return &diag, nil
 }
 
 // ensureSchemaLockName is the MySQL advisory lock name used to serialize
@@ -250,16 +345,33 @@ func cleanStaleSpiritTables(ctx context.Context, dsn string, logger *slog.Logger
 		return fmt.Errorf("load schema: %w", err)
 	}
 
+	var staleCount int
+	tableNames := make([]string, len(tables))
+	for i, t := range tables {
+		tableNames[i] = t.Name
+	}
+	logger.Info("cleanStaleSpiritTables loaded schema",
+		"total_tables", len(tables),
+		"table_names", tableNames,
+	)
+
 	for _, t := range tables {
 		if !ddl.IsSpiritInternalTable(t.Name) {
 			continue
 		}
+		staleCount++
 		logger.Info("cleaning up stale Spirit temporary table from previous schema change",
 			"table", t.Name,
 		)
 		if _, err := db.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS `%s`", t.Name)); err != nil {
 			return fmt.Errorf("drop stale Spirit table %s: %w", t.Name, err)
 		}
+	}
+
+	if staleCount == 0 {
+		logger.Info("no stale Spirit tables found")
+	} else {
+		logger.Info("cleaned stale Spirit tables", "dropped", staleCount)
 	}
 
 	return nil

--- a/pkg/api/plan_handlers.go
+++ b/pkg/api/plan_handlers.go
@@ -236,11 +236,6 @@ func (s *Service) ExecuteApply(ctx context.Context, req ApplyRequest) (*apitypes
 	if options == nil {
 		options = make(map[string]string)
 	}
-	options["environment"] = req.Environment
-	if req.Caller != "" {
-		options["caller"] = req.Caller
-	}
-
 	applyTarget := req.Target
 	if applyTarget == "" {
 		applyTarget = plan.Database
@@ -253,6 +248,7 @@ func (s *Service) ExecuteApply(ctx context.Context, req ApplyRequest) (*apitypes
 		DdlChanges:  storageToProtoTableChanges(plan.FlatDDLChanges()),
 		Environment: req.Environment,
 		Target:      applyTarget,
+		Caller:      req.Caller,
 	}
 
 	resp, err := client.Apply(ctx, ternReq)

--- a/pkg/api/progress_handlers.go
+++ b/pkg/api/progress_handlers.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"sort"
 	"time"
@@ -78,7 +79,7 @@ func progressResponseFromProto(resp *ternv1.ProgressResponse) *apitypes.Progress
 	}
 
 	for _, t := range resp.Tables {
-		httpResp.Tables = append(httpResp.Tables, &apitypes.TableProgressResponse{
+		tpr := &apitypes.TableProgressResponse{
 			TableName:       t.TableName,
 			Keyspace:        t.Namespace,
 			ChangeType:      changeTypeToString(t.ChangeType),
@@ -91,7 +92,23 @@ func progressResponseFromProto(resp *ternv1.ProgressResponse) *apitypes.Progress
 			IsInstant:       t.IsInstant,
 			ProgressDetail:  t.ProgressDetail,
 			TaskID:          t.TaskId,
-		})
+		}
+		for _, sh := range t.Shards {
+			var pct int32
+			if sh.RowsTotal > 0 {
+				pct = int32(sh.RowsCopied * 100 / sh.RowsTotal)
+			}
+			tpr.Shards = append(tpr.Shards, &apitypes.ShardProgressResponse{
+				Shard:           sh.Shard,
+				Status:          state.NormalizeShardStatus(sh.Status),
+				RowsCopied:      sh.RowsCopied,
+				RowsTotal:       sh.RowsTotal,
+				ETASeconds:      sh.EtaSeconds,
+				PercentComplete: pct,
+				CutoverAttempts: sh.CutoverAttempts,
+			})
+		}
+		httpResp.Tables = append(httpResp.Tables, tpr)
 	}
 
 	return httpResp
@@ -131,10 +148,8 @@ func (s *Service) GetProgress(ctx context.Context, database, environment string)
 
 	if activeApply != nil {
 		httpResp.ApplyID = activeApply.ApplyIdentifier
-		opts := storage.ParseApplyOptions(activeApply.Options)
-		if opts.Volume > 0 {
-			httpResp.Volume = int32(opts.Volume)
-		}
+		overlayApplyOptions(httpResp, activeApply)
+		s.overlayVitessMetadata(ctx, httpResp, activeApply)
 	}
 
 	return httpResp, nil
@@ -148,6 +163,7 @@ func (s *Service) handleProgress(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	s.logger.Info("progress by database", "database", database)
 	environment := r.URL.Query().Get("environment")
 	if environment == "" {
 		environment = "staging"
@@ -204,10 +220,8 @@ func (s *Service) handleProgress(w http.ResponseWriter, r *http.Request) {
 	// Overlay apply metadata from storage.
 	if activeApply != nil {
 		httpResp.ApplyID = activeApply.ApplyIdentifier
-		opts := storage.ParseApplyOptions(activeApply.Options)
-		if opts.Volume > 0 {
-			httpResp.Volume = int32(opts.Volume)
-		}
+		overlayApplyOptions(httpResp, activeApply)
+		s.overlayVitessMetadata(r.Context(), httpResp, activeApply)
 	}
 
 	s.writeJSON(w, http.StatusOK, httpResp)
@@ -221,6 +235,8 @@ func (s *Service) handleProgressByApplyID(w http.ResponseWriter, r *http.Request
 		s.writeErrorCode(w, http.StatusBadRequest, apitypes.ErrCodeInvalidRequest, "apply_id is required")
 		return
 	}
+
+	s.logger.Info("progress by apply-id", "apply_id", applyID)
 
 	// Look up the apply by its external identifier
 	apply, err := s.storage.Applies().GetByApplyIdentifier(r.Context(), applyID)
@@ -248,12 +264,17 @@ func (s *Service) handleProgressByApplyID(w http.ResponseWriter, r *http.Request
 
 	// Active apply — use the deployment stored on the apply record.
 	deployment := s.resolveDeployment(apply.Database, apply.Deployment)
+	s.logger.Debug("progress by apply-id: resolving client", "apply_id", applyID, "database", apply.Database, "deployment", deployment, "environment", apply.Environment)
 
 	client, err := s.TernClient(deployment, apply.Environment)
 	if err != nil {
-		s.writeErrorCode(w, http.StatusNotFound, apitypes.ErrCodeDeploymentNotFound, err.Error())
+		s.logger.Error("no tern client for active apply — server is misconfigured",
+			"apply_id", applyID, "database", apply.Database, "deployment", deployment, "environment", apply.Environment, "error", err)
+		s.writeErrorCode(w, http.StatusNotFound, apitypes.ErrCodeDeploymentNotFound,
+			fmt.Sprintf("no tern client configured for database %q (deployment=%q, environment=%q) — add this database to the server config", apply.Database, deployment, apply.Environment))
 		return
 	}
+	s.logger.Debug("progress by apply-id: got client", "apply_id", applyID, "is_remote", client.IsRemote())
 
 	// Resolve to the Tern-facing ID: external_id (remote engine's apply identifier) or apply_identifier (local mode).
 	ternApplyID := apply.ApplyIdentifier
@@ -280,7 +301,12 @@ func (s *Service) handleProgressByApplyID(w http.ResponseWriter, r *http.Request
 		httpResp.PullRequest = fmt.Sprintf("https://github.com/%s/pull/%d", apply.Repository, apply.PullRequest)
 	}
 
-	// Use apply record as source of truth for timestamps
+	// Re-read the apply record — the tern client's Progress call may have
+	// updated state and timestamps (e.g., CompletedAt set when engine reports
+	// terminal state).
+	if freshApply, err := s.storage.Applies().GetByApplyIdentifier(r.Context(), applyID); err == nil && freshApply != nil {
+		apply = freshApply
+	}
 	if apply.StartedAt != nil {
 		httpResp.StartedAt = apply.StartedAt.Format(time.RFC3339)
 	}
@@ -288,13 +314,60 @@ func (s *Service) handleProgressByApplyID(w http.ResponseWriter, r *http.Request
 		httpResp.CompletedAt = apply.CompletedAt.Format(time.RFC3339)
 	}
 
-	// Add volume from apply options
-	opts := storage.ParseApplyOptions(apply.Options)
-	if opts.Volume > 0 {
-		httpResp.Volume = int32(opts.Volume)
+	overlayApplyOptions(httpResp, apply)
+
+	s.overlayVitessMetadata(r.Context(), httpResp, apply)
+
+	// Overlay per-table timestamps from task records. The proto response
+	// doesn't carry task timestamps, but storage has them from engine
+	// progress polling (e.g., SHOW VITESS_MIGRATIONS started_timestamp).
+	if tasks, err := s.storage.Tasks().GetByApplyID(r.Context(), apply.ID); err == nil {
+		taskByTable := make(map[string]*storage.Task, len(tasks))
+		for _, t := range tasks {
+			taskByTable[t.TableName] = t
+		}
+		for _, tpr := range httpResp.Tables {
+			if task, ok := taskByTable[tpr.TableName]; ok {
+				if task.StartedAt != nil && tpr.StartedAt == "" {
+					tpr.StartedAt = task.StartedAt.Format(time.RFC3339)
+				}
+				if task.CompletedAt != nil && tpr.CompletedAt == "" {
+					tpr.CompletedAt = task.CompletedAt.Format(time.RFC3339)
+				}
+			}
+		}
 	}
 
 	s.writeJSON(w, http.StatusOK, httpResp)
+}
+
+// overlayVitessMetadata loads VitessApplyData for the given apply and merges
+// engine-specific metadata (deploy request URL, revert status) into the response.
+func (s *Service) overlayVitessMetadata(ctx context.Context, resp *apitypes.ProgressResponse, apply *storage.Apply) {
+	if apply == nil {
+		slog.Warn("overlayVitessMetadata: no apply record")
+		return
+	}
+	if apply.Engine != storage.EnginePlanetScale {
+		return
+	}
+	vad, err := s.storage.VitessApplyData().GetByApplyID(ctx, apply.ID)
+	if err != nil {
+		slog.Error("overlayVitessMetadata: failed to load vitess apply data", "apply_id", apply.ApplyIdentifier, "error", err)
+		return
+	}
+	if resp.Metadata == nil {
+		resp.Metadata = make(map[string]string)
+	}
+	if vad.BranchName != "" {
+		resp.Metadata["branch_name"] = vad.BranchName
+	}
+	if vad.DeployRequestURL != "" {
+		resp.Metadata["deploy_request_url"] = vad.DeployRequestURL
+	}
+	if vad.RevertSkippedAt != nil {
+		resp.Metadata["revert_skipped"] = "true"
+	}
 }
 
 // handleDatabaseHistory handles GET /api/history/{database} requests.
@@ -521,13 +594,11 @@ func (s *Service) progressFromLocalStorage(ctx context.Context, apply *storage.A
 		httpResp.ErrorCode = deriveErrorCode(apply.State, apply.ErrorMessage)
 		httpResp.ErrorMessage = apply.ErrorMessage
 	}
-	opts := storage.ParseApplyOptions(apply.Options)
-	if opts.Volume > 0 {
-		httpResp.Volume = int32(opts.Volume)
-	}
+	overlayApplyOptions(httpResp, apply)
+	s.overlayVitessMetadata(ctx, httpResp, apply)
 
 	for _, task := range tasks {
-		httpResp.Tables = append(httpResp.Tables, &apitypes.TableProgressResponse{
+		tpr := &apitypes.TableProgressResponse{
 			TableName:       task.TableName,
 			ChangeType:      task.DDLAction,
 			DDL:             task.DDL,
@@ -537,7 +608,14 @@ func (s *Service) progressFromLocalStorage(ctx context.Context, apply *storage.A
 			PercentComplete: int32(task.ProgressPercent),
 			IsInstant:       task.IsInstant,
 			TaskID:          task.TaskIdentifier,
-		})
+		}
+		if task.StartedAt != nil {
+			tpr.StartedAt = task.StartedAt.Format(time.RFC3339)
+		}
+		if task.CompletedAt != nil {
+			tpr.CompletedAt = task.CompletedAt.Format(time.RFC3339)
+		}
+		httpResp.Tables = append(httpResp.Tables, tpr)
 	}
 
 	return httpResp, nil
@@ -593,4 +671,25 @@ func (s *Service) syncTasksFromTern(ctx context.Context, apply *storage.Apply, t
 	s.logger.Info("synced stale task records from Tern",
 		"apply_id", apply.ApplyIdentifier, "synced", synced, "total", len(tasks))
 	return nil
+}
+
+// overlayApplyOptions populates volume and options on the response from the apply record.
+func overlayApplyOptions(resp *apitypes.ProgressResponse, apply *storage.Apply) {
+	opts := storage.ParseApplyOptions(apply.Options)
+	if opts.Volume > 0 {
+		resp.Volume = int32(opts.Volume)
+	}
+	optMap := make(map[string]string)
+	if opts.DeferCutover {
+		optMap["defer_cutover"] = "true"
+	}
+	if opts.SkipRevert {
+		optMap["skip_revert"] = "true"
+	}
+	if opts.AllowUnsafe {
+		optMap["allow_unsafe"] = "true"
+	}
+	if len(optMap) > 0 {
+		resp.Options = optMap
+	}
 }

--- a/pkg/api/service.go
+++ b/pkg/api/service.go
@@ -3,10 +3,17 @@ package api
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"log/slog"
 	"net/http"
+	"os"
+	"strings"
 	"sync"
+	"time"
+
+	gomysql "github.com/go-sql-driver/mysql"
 
 	"github.com/block/schemabot/pkg/secrets"
 	"github.com/block/schemabot/pkg/state"
@@ -138,6 +145,19 @@ func (s *Service) TernDeployment(repo string) string {
 //
 // The method first checks for config-based database registration (local mode),
 // then falls back to TernDeployments (gRPC mode).
+// RegisterTernClient registers a tern client for the given deployment and
+// environment. This allows embedders to add clients dynamically as they
+// are created (e.g., lazily per-cluster).
+func (s *Service) RegisterTernClient(deployment, environment string, client tern.Client) {
+	if deployment == "" {
+		deployment = DefaultDeployment
+	}
+	key := deployment + "/" + environment
+	s.ternMu.Lock()
+	defer s.ternMu.Unlock()
+	s.ternClients[key] = client
+}
+
 func (s *Service) TernClient(deployment, environment string) (tern.Client, error) {
 	if deployment == "" {
 		deployment = DefaultDeployment
@@ -161,16 +181,60 @@ func (s *Service) TernClient(deployment, environment string) (tern.Client, error
 				return nil, fmt.Errorf("resolve DSN for %s: %w", key, err)
 			}
 
+			// Resolve PlanetScale token if configured
+			var tokenName, tokenValue string
+			if envConfig.TokenSecretRef != "" {
+				token, err := secrets.Resolve(envConfig.TokenSecretRef, "")
+				if err != nil {
+					return nil, fmt.Errorf("resolve token for %s: %w", key, err)
+				}
+				parts := strings.SplitN(token, ":", 2)
+				if len(parts) == 2 {
+					tokenName, tokenValue = parts[0], parts[1]
+				}
+			}
+
+			// Register TLS config for PlanetScale MySQL connections if configured
+			var tlsName string
+			if envConfig.TLS != nil {
+				tlsName, err = registerTLSConfig(key, envConfig.TLS)
+				if err != nil {
+					return nil, fmt.Errorf("register TLS for %s: %w", key, err)
+				}
+			}
+
 			// LocalClient uses SchemaBot's storage directly
+			var revertWindow time.Duration
+			if envConfig.RevertWindowDuration != "" {
+				if d, err := time.ParseDuration(envConfig.RevertWindowDuration); err == nil {
+					revertWindow = d
+				}
+			}
+			metadata := map[string]string{
+				"organization": envConfig.Organization,
+				"token_name":   tokenName,
+				"token_value":  tokenValue,
+			}
+			if tlsName != "" {
+				metadata["tls_name"] = tlsName
+			}
+			if revertWindow > 0 {
+				metadata["revert_window_duration"] = revertWindow.String()
+			}
+			if envConfig.APIURL != "" {
+				metadata["api_url"] = envConfig.APIURL
+			}
 			client, err := tern.NewLocalClient(tern.LocalConfig{
 				Database:  deployment,
 				Type:      dbConfig.Type,
 				TargetDSN: targetDSN,
+				Metadata:  metadata,
 			}, s.storage, s.logger)
 			if err != nil {
 				return nil, fmt.Errorf("create local tern client for %s: %w", key, err)
 			}
 			s.ternClients[key] = client
+			s.logger.Info("created local tern client", "key", key, "type", dbConfig.Type, "deployment", deployment)
 			return client, nil
 		}
 	}
@@ -195,7 +259,97 @@ func (s *Service) TernClient(deployment, environment string) (tern.Client, error
 	return client, nil
 }
 
-// ConfigureRoutes registers HTTP handlers on the given mux.
+// =============================================================================
+// Exported Handlers
+// =============================================================================
+//
+// Public HTTP handler methods that delegate to the internal handlers. These
+// allow embedders to register individual SchemaBot routes on their own mux
+// while using the OSS handler logic, preventing behavior drift.
+
+// HandleProgressByApplyID is the HTTP handler for GET /api/progress/apply/{apply_id}.
+func (s *Service) HandleProgressByApplyID(w http.ResponseWriter, r *http.Request) {
+	s.handleProgressByApplyID(w, r)
+}
+
+// HandleProgress is the HTTP handler for GET /api/progress/{database}.
+// Returns progress for the active apply on the given database/environment.
+func (s *Service) HandleProgress(w http.ResponseWriter, r *http.Request) {
+	s.handleProgress(w, r)
+}
+
+// HandleStatus is the HTTP handler for GET /api/status.
+// Returns recent applies across all databases.
+func (s *Service) HandleStatus(w http.ResponseWriter, r *http.Request) {
+	s.handleStatus(w, r)
+}
+
+// HandleDatabaseHistory is the HTTP handler for GET /api/history/{database}.
+// Returns apply history for a specific database.
+func (s *Service) HandleDatabaseHistory(w http.ResponseWriter, r *http.Request) {
+	s.handleDatabaseHistory(w, r)
+}
+
+// HandleLogs is the HTTP handler for GET /api/logs/{database}.
+func (s *Service) HandleLogs(w http.ResponseWriter, r *http.Request) {
+	s.handleLogs(w, r)
+}
+
+// HandleLogsWithoutDatabase is the HTTP handler for GET /api/logs.
+func (s *Service) HandleLogsWithoutDatabase(w http.ResponseWriter, r *http.Request) {
+	s.handleLogsWithoutDatabase(w, r)
+}
+
+// HandlePlan is the HTTP handler for POST /api/plan.
+func (s *Service) HandlePlan(w http.ResponseWriter, r *http.Request) {
+	s.handlePlan(w, r)
+}
+
+// HandleApply is the HTTP handler for POST /api/apply.
+func (s *Service) HandleApply(w http.ResponseWriter, r *http.Request) {
+	s.handleApply(w, r)
+}
+
+// HandleCutover is the HTTP handler for POST /api/cutover.
+func (s *Service) HandleCutover(w http.ResponseWriter, r *http.Request) {
+	s.handleCutover(w, r)
+}
+
+// HandleStop is the HTTP handler for POST /api/stop.
+func (s *Service) HandleStop(w http.ResponseWriter, r *http.Request) {
+	s.handleStop(w, r)
+}
+
+// HandleStart is the HTTP handler for POST /api/start.
+func (s *Service) HandleStart(w http.ResponseWriter, r *http.Request) {
+	s.handleStart(w, r)
+}
+
+// HandleVolume is the HTTP handler for POST /api/volume.
+func (s *Service) HandleVolume(w http.ResponseWriter, r *http.Request) {
+	s.handleVolume(w, r)
+}
+
+// HandleRevert is the HTTP handler for POST /api/revert.
+func (s *Service) HandleRevert(w http.ResponseWriter, r *http.Request) {
+	s.handleRevert(w, r)
+}
+
+// HandleSkipRevert is the HTTP handler for POST /api/skip-revert.
+func (s *Service) HandleSkipRevert(w http.ResponseWriter, r *http.Request) {
+	s.handleSkipRevert(w, r)
+}
+
+// HandleRollbackPlan is the HTTP handler for POST /api/rollback/plan.
+func (s *Service) HandleRollbackPlan(w http.ResponseWriter, r *http.Request) {
+	s.handleRollbackPlan(w, r)
+}
+
+// =============================================================================
+// Route Registration
+// =============================================================================
+
+// ConfigureRoutes registers all HTTP API routes on the given mux.
 func (s *Service) ConfigureRoutes(mux *http.ServeMux) {
 	// Health endpoints
 	mux.HandleFunc("GET /health", s.handleHealth)
@@ -326,4 +480,41 @@ func (s *Service) Close() error {
 		return fmt.Errorf("close errors: %v", errs)
 	}
 	return nil
+}
+
+// registerTLSConfig registers a named TLS config with the Go MySQL driver.
+// Returns the config name to use in DSN parameters (tls=<name>).
+func registerTLSConfig(name string, cfg *TLSConfig) (string, error) {
+	if cfg.CABundle == "" {
+		return "", fmt.Errorf("tls.ca_bundle is required")
+	}
+
+	caPEM, err := os.ReadFile(cfg.CABundle)
+	if err != nil {
+		return "", fmt.Errorf("read CA bundle %s: %w", cfg.CABundle, err)
+	}
+	rootPool := x509.NewCertPool()
+	if !rootPool.AppendCertsFromPEM(caPEM) {
+		return "", fmt.Errorf("failed to parse CA bundle %s", cfg.CABundle)
+	}
+
+	tlsCfg := &tls.Config{
+		RootCAs:    rootPool,
+		MinVersion: tls.VersionTLS12,
+	}
+
+	// Client certificate is optional (mTLS).
+	if cfg.ClientCert != "" && cfg.ClientKey != "" {
+		cert, err := tls.LoadX509KeyPair(cfg.ClientCert, cfg.ClientKey)
+		if err != nil {
+			return "", fmt.Errorf("load client cert/key: %w", err)
+		}
+		tlsCfg.Certificates = []tls.Certificate{cert}
+	}
+
+	tlsName := "schemabot-" + name
+	if err := gomysql.RegisterTLSConfig(tlsName, tlsCfg); err != nil {
+		return "", fmt.Errorf("register TLS config %s: %w", tlsName, err)
+	}
+	return tlsName, nil
 }

--- a/pkg/cmd/commands/watch_tui.go
+++ b/pkg/cmd/commands/watch_tui.go
@@ -324,6 +324,9 @@ func WatchApplyProgressByApplyID(endpoint, applyID string, allowCutover bool) er
 	return runWatchModel(model)
 }
 
+// drainStdin discards any pending bytes on stdin so that leftover input
+// from a prior prompt (e.g., confirmation "yes" + key repeat) doesn't
+// leak into the Bubbletea event loop.
 // runWatchModel runs a WatchModel and returns the result.
 func runWatchModel(model WatchModel) error {
 	// Don't use alt-screen - render inline for seamless experience

--- a/pkg/cmd/templates/progress.go
+++ b/pkg/cmd/templates/progress.go
@@ -274,6 +274,7 @@ func FormatNamespacedTables(tables []TableProgress) string {
 	return b.String()
 }
 
+// writeNamespacedTables renders tables grouped by keyspace to stdout.
 // isVSchemaTask returns true if this is a synthetic VSchema update task.
 func isVSchemaTask(t TableProgress) bool {
 	return t.TableName == "VSchema" || strings.HasPrefix(t.TableName, "vschema:") || strings.HasPrefix(t.TableName, "VSchema:")
@@ -306,6 +307,7 @@ func FormatVSchemaDiff(diff, indent string) string {
 	return b.String()
 }
 
+// writeVSchemaDiff renders a VSchema diff to stdout.
 // vschemaStatusLabel maps a task status to a VSchema-specific display label.
 func vschemaStatusLabel(status string) string {
 	switch status {
@@ -538,6 +540,7 @@ func FormatTableProgress(t TableProgress) string {
 	return b.String()
 }
 
+// writeTableProgress writes progress for a single table to stdout.
 // StopData contains data for rendering stop command output.
 type StopData struct {
 	Database       string

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -75,17 +75,12 @@ type Drainer interface {
 // Credentials contains the resolved credentials for accessing a database.
 // These are populated by the service layer from discovery before calling the engine.
 type Credentials struct {
-	// PlanetScale-specific
-	Organization string // PlanetScale organization name
-	TokenName    string // Service token name
-	TokenValue   string // Service token value
-	MainBranch   string // Main branch name (default: "main")
-
 	// DSN is the primary connection endpoint (vtgate MySQL DSN, direct MySQL DSN, etc.)
 	DSN string
 
-	// Metadata holds engine-specific key-value pairs. Examples:
-	//   "tls_name" — registered MySQL TLS config name for branch connections
+	// Metadata holds engine-specific key-value pairs.
+	// PlanetScale: "organization", "token_name", "token_value", "main_branch"
+	// Spirit: (none currently)
 	Metadata map[string]string
 }
 

--- a/pkg/engine/planetscale/planetscale.go
+++ b/pkg/engine/planetscale/planetscale.go
@@ -457,6 +457,7 @@ func decodePSMetadata(s string) (*psMetadata, error) {
 type Engine struct {
 	clientFunc func(tokenName, tokenValue string) (psclient.PSClient, error)
 	linter     *lint.Linter
+	logger     *slog.Logger
 
 	vtgateDBsMu sync.Mutex
 	vtgateDBs   map[string]*sql.DB // dsn -> cached *sql.DB
@@ -466,13 +467,17 @@ type Engine struct {
 // Compile-time check that Engine implements the interface.
 var _ engine.Engine = (*Engine)(nil)
 
-// New creates a new PlanetScale engine.
-func New() *Engine {
+// New creates a new PlanetScale engine with the given logger.
+func New(logger *slog.Logger) *Engine {
+	if logger == nil {
+		logger = slog.Default()
+	}
 	return &Engine{
 		clientFunc: func(tokenName, tokenValue string) (psclient.PSClient, error) {
 			return psclient.NewPSClient(tokenName, tokenValue)
 		},
 		linter:    lint.New(),
+		logger:    logger,
 		vtgateDBs: make(map[string]*sql.DB),
 	}
 }
@@ -480,10 +485,14 @@ func New() *Engine {
 // NewWithClient creates a new PlanetScale engine with a custom client factory.
 // Use this when the default PlanetScale SDK client needs to be replaced (e.g.,
 // pointing at a different API base URL or using custom authentication).
-func NewWithClient(clientFunc func(tokenName, tokenValue string) (psclient.PSClient, error)) *Engine {
+func NewWithClient(logger *slog.Logger, clientFunc func(tokenName, tokenValue string) (psclient.PSClient, error)) *Engine {
+	if logger == nil {
+		logger = slog.Default()
+	}
 	return &Engine{
 		clientFunc: clientFunc,
 		linter:     lint.New(),
+		logger:     logger,
 		vtgateDBs:  make(map[string]*sql.DB),
 	}
 }
@@ -498,35 +507,70 @@ func (e *Engine) getClient(creds *engine.Credentials) (psclient.PSClient, error)
 	if creds == nil {
 		return nil, fmt.Errorf("credentials required")
 	}
-	if creds.TokenName == "" || creds.TokenValue == "" {
+	if credTokenName(creds) == "" || credTokenValue(creds) == "" {
 		return nil, fmt.Errorf("token credentials required")
 	}
-	return e.clientFunc(creds.TokenName, creds.TokenValue)
+	return e.clientFunc(credTokenName(creds), credTokenValue(creds))
 }
 
 // getVtgateDB returns a cached *sql.DB for the given DSN, creating one if needed.
+// If RegisterMTLS has been called, the mTLS config is applied automatically.
 func (e *Engine) getVtgateDB(ctx context.Context, dsn string) (*sql.DB, error) {
+	// Apply mTLS before cache lookup so the cache key matches the actual connection.
+	if mtlsRegistered.Load() {
+		mysqlCfg, err := mysql.ParseDSN(dsn)
+		if err != nil {
+			return nil, fmt.Errorf("parse vtgate DSN: %w", err)
+		}
+		mysqlCfg.TLSConfig = mtlsConfigName
+		dsn = mysqlCfg.FormatDSN()
+	}
+
 	e.vtgateDBsMu.Lock()
 	defer e.vtgateDBsMu.Unlock()
 	if db, ok := e.vtgateDBs[dsn]; ok {
 		return db, nil
 	}
+
 	db, err := sql.Open("mysql", dsn)
 	if err != nil {
 		return nil, fmt.Errorf("open vtgate: %w", err)
 	}
 	if err := db.PingContext(ctx); err != nil {
 		utils.CloseAndLog(db)
-		return nil, fmt.Errorf("ping vtgate: %w", err)
+		return nil, fmt.Errorf("vtgate connection failed (check DSN and network access): %w", err)
 	}
 	e.vtgateDBs[dsn] = db
 	return db, nil
 }
 
 // mainBranch returns the main branch name from credentials, defaulting to "main".
+// Credential helpers — read PlanetScale-specific values from Metadata.
+
+func credOrg(creds *engine.Credentials) string {
+	if creds != nil {
+		return creds.Metadata["organization"]
+	}
+	return ""
+}
+
+func credTokenName(creds *engine.Credentials) string {
+	if creds != nil {
+		return creds.Metadata["token_name"]
+	}
+	return ""
+}
+
+func credTokenValue(creds *engine.Credentials) string {
+	if creds != nil {
+		return creds.Metadata["token_value"]
+	}
+	return ""
+}
+
 func mainBranch(creds *engine.Credentials) string {
-	if creds != nil && creds.MainBranch != "" {
-		return creds.MainBranch
+	if creds != nil && creds.Metadata["main_branch"] != "" {
+		return creds.Metadata["main_branch"]
 	}
 	return "main"
 }
@@ -537,7 +581,7 @@ func mainBranch(creds *engine.Credentials) string {
 // For each keyspace in the schema files, it fetches the current schema from PlanetScale
 // and uses Spirit's PlanChanges to diff and lint in a single pass.
 func (e *Engine) Plan(ctx context.Context, req *engine.PlanRequest) (*engine.PlanResult, error) {
-	slog.Info("computing plan",
+	e.logger.Info("computing plan",
 		"database", req.Database,
 		"schema_files", len(req.SchemaFiles),
 	)
@@ -547,7 +591,7 @@ func (e *Engine) Plan(ctx context.Context, req *engine.PlanRequest) (*engine.Pla
 		return nil, fmt.Errorf("get planetscale client: %w", err)
 	}
 
-	org := req.Credentials.Organization
+	org := credOrg(req.Credentials)
 	branch := mainBranch(req.Credentials)
 
 	// Fetch current schema from PlanetScale per keyspace
@@ -600,7 +644,7 @@ func (e *Engine) Plan(ctx context.Context, req *engine.PlanRequest) (*engine.Pla
 				Keyspace:     keyspace,
 			})
 			if fetchErr != nil {
-				slog.Warn("failed to fetch current VSchema, treating as empty",
+				e.logger.Warn("failed to fetch current VSchema, treating as empty",
 					"keyspace", keyspace, "error", fetchErr)
 			}
 			currentVSchemaRaw := ""
@@ -648,7 +692,7 @@ func (e *Engine) Plan(ctx context.Context, req *engine.PlanRequest) (*engine.Pla
 					Table:    pc.TableName,
 					Linter:   v.Linter.Name(),
 					Message:  v.Message,
-					Severity: v.Severity.String(),
+					Severity: strings.ToLower(v.Severity.String()),
 				})
 			}
 		}
@@ -680,7 +724,7 @@ func (e *Engine) Plan(ctx context.Context, req *engine.PlanRequest) (*engine.Pla
 // Creates a PlanetScale branch, applies DDL via MySQL connection to the branch,
 // then creates and starts a deploy request.
 func (e *Engine) Apply(ctx context.Context, req *engine.ApplyRequest) (*engine.ApplyResult, error) {
-	slog.Info("applying plan",
+	e.logger.Info("applying plan",
 		"plan_id", req.PlanID,
 		"database", req.Database,
 	)
@@ -690,12 +734,27 @@ func (e *Engine) Apply(ctx context.Context, req *engine.ApplyRequest) (*engine.A
 		return nil, fmt.Errorf("get planetscale client: %w", err)
 	}
 
-	org := req.Credentials.Organization
+	org := credOrg(req.Credentials)
 	main := mainBranch(req.Credentials)
 
 	// Check if resuming
 	if req.ResumeState != nil && req.ResumeState.Metadata != "" {
 		return e.resumeApply(ctx, client, org, req)
+	}
+
+	// emitEvent logs a lifecycle event and sends it to the caller for apply_logs recording.
+	emitEvent := func(message string, metadata map[string]string) {
+		attrs := []any{"database", req.Database}
+		for k, v := range metadata {
+			attrs = append(attrs, k, v)
+		}
+		e.logger.Info(message, attrs...)
+		if req.OnEvent != nil {
+			req.OnEvent(engine.ApplyEvent{
+				Message:  message,
+				Metadata: metadata,
+			})
+		}
 	}
 
 	// Track in-flight apply metadata for progress queries during setup.
@@ -714,7 +773,7 @@ func (e *Engine) Apply(ctx context.Context, req *engine.ApplyRequest) (*engine.A
 		}
 		encoded, err := encodePSMetadata(meta)
 		if err != nil {
-			slog.Warn("failed to encode apply metadata for persistence", "error", err)
+			e.logger.Warn("failed to encode apply metadata for persistence", "error", err)
 			return
 		}
 		req.OnStateChange(&engine.ResumeState{
@@ -726,9 +785,10 @@ func (e *Engine) Apply(ctx context.Context, req *engine.ApplyRequest) (*engine.A
 	// Create a new branch
 	branchName := generateBranchName(req.Database, req.PlanID)
 	persistState(&psMetadata{BranchName: branchName})
+	emitEvent(fmt.Sprintf("Creating branch %s", branchName), map[string]string{"branch": branchName})
 
 	branchStart := time.Now()
-	branch, err := e.createBranch(ctx, client, org, req.Database, branchName, main)
+	_, err = e.createBranch(ctx, client, org, req.Database, branchName, main)
 	if err != nil {
 		return nil, fmt.Errorf("create branch: %w", err)
 	}
@@ -737,7 +797,8 @@ func (e *Engine) Apply(ctx context.Context, req *engine.ApplyRequest) (*engine.A
 	if err := e.waitForBranchReady(ctx, client, org, req.Database, branchName); err != nil {
 		return nil, fmt.Errorf("wait for branch: %w", err)
 	}
-	slog.Info("branch ready", "branch", branch.Name, "org", org, "database", req.Database, "elapsed", time.Since(branchStart).Round(time.Second))
+	elapsed := time.Since(branchStart).Round(time.Second)
+	emitEvent(fmt.Sprintf("Branch %s ready (%s)", branchName, elapsed), map[string]string{"branch": branchName})
 
 	// Get branch credentials to apply DDL via MySQL
 	pwCtx, pwCancel := context.WithTimeout(ctx, 10*time.Second)
@@ -755,9 +816,14 @@ func (e *Engine) Apply(ctx context.Context, req *engine.ApplyRequest) (*engine.A
 	}
 
 	// Apply DDL and VSchema changes to all keyspaces concurrently
-	if err := e.applyChangesToBranch(ctx, req.Changes, req.SchemaFiles, password, req.Credentials.Metadata["tls_name"], client, org, req.Database, branchName); err != nil {
+	if err := e.applyChangesToBranch(ctx, req.Changes, req.SchemaFiles, password, client, org, req.Database, branchName); err != nil {
 		return nil, fmt.Errorf("apply changes to branch: %w", err)
 	}
+	ddlCount := 0
+	for _, sc := range req.Changes {
+		ddlCount += len(sc.TableChanges)
+	}
+	emitEvent(fmt.Sprintf("Applied %d DDL changes to branch %s", ddlCount, branchName), map[string]string{"branch": branchName})
 
 	// Capture existing migration_contexts before deploy so we can discover the new one
 	existingContexts := e.captureExistingContexts(ctx, client, req.Database, req.Credentials)
@@ -773,6 +839,11 @@ func (e *Engine) Apply(ctx context.Context, req *engine.ApplyRequest) (*engine.A
 	if err != nil {
 		return nil, fmt.Errorf("create deploy request: %w", err)
 	}
+	emitEvent(fmt.Sprintf("Deploy request #%d created", dr.Number), map[string]string{
+		"deploy_request_id":  fmt.Sprintf("%d", dr.Number),
+		"deploy_request_url": dr.HtmlURL,
+		"branch":             branchName,
+	})
 	persistState(&psMetadata{
 		BranchName:       branchName,
 		DeployRequestID:  dr.Number,
@@ -789,37 +860,43 @@ func (e *Engine) Apply(ctx context.Context, req *engine.ApplyRequest) (*engine.A
 		return nil, fmt.Errorf("deploy request #%d failed during preparation (state: %s)", dr.Number, dr.DeploymentState)
 	}
 	if dr.DeploymentState == deployState.NoChanges {
-		slog.Info("deploy request: no changes", "number", dr.Number, "elapsed", time.Since(drStart).Round(time.Second))
+		emitEvent(fmt.Sprintf("Deploy request #%d: no changes detected", dr.Number), map[string]string{
+			"deploy_request_id": fmt.Sprintf("%d", dr.Number),
+		})
 		return &engine.ApplyResult{Message: "no changes detected"}, nil
 	}
 
 	// Determine instant DDL eligibility
 	instantEligible := dr.Deployment != nil && dr.Deployment.InstantDDLEligible
-	enableRevert := req.Options["enable_revert"] == "true"
-	useInstant := instantEligible && !deferCutover && !enableRevert
+	skipRevert := req.Options["skip_revert"] == "true"
+	useInstant := instantEligible && !deferCutover && skipRevert
 
-	slog.Info("deploy request ready",
-		"number", dr.Number,
-		"url", dr.HtmlURL,
-		"state", dr.DeploymentState,
-		"defer_cutover", deferCutover,
-		"instant_ddl_eligible", instantEligible,
-		"instant_ddl", useInstant,
-		"elapsed", time.Since(drStart).Round(time.Second),
-	)
+	drElapsed := time.Since(drStart).Round(time.Second)
+	emitEvent(fmt.Sprintf("Deploy request #%d ready (%s)", dr.Number, drElapsed), map[string]string{
+		"deploy_request_id":  fmt.Sprintf("%d", dr.Number),
+		"deploy_request_url": dr.HtmlURL,
+		"instant_ddl":        fmt.Sprintf("%t", useInstant),
+	})
 
 	// Deploy (starts the schema change)
+	drNumber := dr.Number
 	dr, err = client.DeployDeployRequest(ctx, &ps.PerformDeployRequest{
 		Organization: org,
 		Database:     req.Database,
-		Number:       dr.Number,
+		Number:       drNumber,
 		InstantDDL:   useInstant,
 	})
 	if err != nil {
+		if strings.Contains(err.Error(), "approved") {
+			return nil, fmt.Errorf("deploy request #%d could not be deployed: PlanetScale deploy request approvals are not supported — disable 'Require administrator approval for deploy requests' in the PlanetScale database settings", drNumber)
+		}
 		return nil, fmt.Errorf("deploy deploy request: %w", err)
 	}
 
-	slog.Info("deployed deploy request", "number", dr.Number, "instant_ddl", useInstant)
+	emitEvent(fmt.Sprintf("Deploy request #%d deployed", dr.Number), map[string]string{
+		"deploy_request_id": fmt.Sprintf("%d", dr.Number),
+		"instant_ddl":       fmt.Sprintf("%t", useInstant),
+	})
 
 	// Discover migration_context by diffing current SHOW VITESS_MIGRATIONS against
 	// the pre-deploy baseline. Retries because Vitess may not have created migrations
@@ -858,9 +935,9 @@ func (e *Engine) Apply(ctx context.Context, req *engine.ApplyRequest) (*engine.A
 // applyChangesToBranch applies DDL and VSchema changes to all keyspaces concurrently.
 // Each keyspace gets its own MySQL connection and runs independently. Transient
 // failures are retried up to 3 times per keyspace.
-func (e *Engine) applyChangesToBranch(ctx context.Context, changes []engine.SchemaChange, schemaFiles schema.SchemaFiles, password *ps.DatabaseBranchPassword, tlsName string, client psclient.PSClient, org, database, branchName string) error {
+func (e *Engine) applyChangesToBranch(ctx context.Context, changes []engine.SchemaChange, schemaFiles schema.SchemaFiles, password *ps.DatabaseBranchPassword, client psclient.PSClient, org, database, branchName string) error {
 	if len(changes) == 0 {
-		slog.Debug("no changes to apply to branch", "branch", branchName)
+		e.logger.Debug("no changes to apply to branch", "branch", branchName)
 		return nil
 	}
 
@@ -868,16 +945,16 @@ func (e *Engine) applyChangesToBranch(ctx context.Context, changes []engine.Sche
 	g.SetLimit(maxConcurrentKeyspaces)
 	for _, sc := range changes {
 		g.Go(func() error {
-			return e.applyKeyspaceChanges(gCtx, sc, schemaFiles, password, tlsName, client, org, database, branchName)
+			return e.applyKeyspaceChanges(gCtx, sc, schemaFiles, password, client, org, database, branchName)
 		})
 	}
 	return g.Wait()
 }
 
 // applyKeyspaceChanges applies DDL and VSchema for a single keyspace with retries.
-func (e *Engine) applyKeyspaceChanges(ctx context.Context, sc engine.SchemaChange, schemaFiles schema.SchemaFiles, password *ps.DatabaseBranchPassword, tlsName string, client psclient.PSClient, org, database, branchName string) error {
+func (e *Engine) applyKeyspaceChanges(ctx context.Context, sc engine.SchemaChange, schemaFiles schema.SchemaFiles, password *ps.DatabaseBranchPassword, client psclient.PSClient, org, database, branchName string) error {
 	start := time.Now()
-	slog.Info("applying changes to keyspace",
+	e.logger.Info("applying changes to keyspace",
 		"keyspace", sc.Namespace,
 		"ddl_count", len(sc.TableChanges),
 		"has_vschema", sc.Metadata["vschema"] != "",
@@ -890,56 +967,50 @@ func (e *Engine) applyKeyspaceChanges(ctx context.Context, sc engine.SchemaChang
 			base := time.Duration(attempt) * 2 * time.Second
 			jitter := time.Duration(rand.IntN(1000)) * time.Millisecond
 			delay := base + jitter
-			slog.Warn("retrying keyspace apply", "keyspace", sc.Namespace, "attempt", attempt+1, "delay", delay.Round(time.Millisecond), "error", lastErr)
+			e.logger.Warn("retrying keyspace apply", "keyspace", sc.Namespace, "attempt", attempt+1, "delay", delay.Round(time.Millisecond), "error", lastErr)
 			time.Sleep(delay)
 		}
 
-		if err := e.applyKeyspaceChangesOnce(ctx, sc, schemaFiles, password, tlsName, client, org, database, branchName); err != nil {
+		if err := e.applyKeyspaceChangesOnce(ctx, sc, schemaFiles, password, client, org, database, branchName); err != nil {
 			lastErr = err
-			slog.Error("keyspace apply attempt failed", "keyspace", sc.Namespace, "attempt", attempt+1, "error", err)
+			e.logger.Error("keyspace apply attempt failed", "keyspace", sc.Namespace, "attempt", attempt+1, "error", err)
 			continue
 		}
-		slog.Info("keyspace changes applied", "keyspace", sc.Namespace, "elapsed", time.Since(start).Round(time.Second))
+		e.logger.Info("keyspace changes applied", "keyspace", sc.Namespace, "elapsed", time.Since(start).Round(time.Second))
 		return nil
 	}
 	return fmt.Errorf("apply keyspace %s (after %d attempts): %w", sc.Namespace, maxRetries, lastErr)
 }
 
 // applyKeyspaceChangesOnce applies VSchema and DDL for a single keyspace in one attempt.
-func (e *Engine) applyKeyspaceChangesOnce(ctx context.Context, sc engine.SchemaChange, schemaFiles schema.SchemaFiles, password *ps.DatabaseBranchPassword, tlsName string, client psclient.PSClient, org, database, branchName string) error {
+func (e *Engine) applyKeyspaceChangesOnce(ctx context.Context, sc engine.SchemaChange, schemaFiles schema.SchemaFiles, password *ps.DatabaseBranchPassword, client psclient.PSClient, org, database, branchName string) error {
 	// Apply VSchema first — vtgate needs VSchema to route DDL correctly
 	if vschemaContent := getVSchemaContent(sc, schemaFiles); vschemaContent != "" {
 		if err := e.updateBranchVSchema(ctx, client, org, database, branchName, sc.Namespace, vschemaContent); err != nil {
 			return fmt.Errorf("update vschema for %s: %w", sc.Namespace, err)
 		}
-		slog.Info("applied vschema to branch", "keyspace", sc.Namespace, "branch", branchName)
+		e.logger.Info("applied vschema to branch", "keyspace", sc.Namespace, "branch", branchName)
 	}
 
 	if len(sc.TableChanges) == 0 {
-		slog.Debug("no DDL for keyspace, vschema-only", "keyspace", sc.Namespace, "branch", branchName)
+		e.logger.Debug("no DDL for keyspace, vschema-only", "keyspace", sc.Namespace, "branch", branchName)
 		return nil
 	}
 
 	// Build DSN targeting this specific keyspace.
-	// TLS mode is configurable via Credentials.Metadata["tls_name"]:
-	//   - Empty: no TLS (development/testing environments)
-	//   - Named config: registered TLS config with CA bundle + client certs (production)
-	tlsParam := "false"
-	if tlsName != "" {
-		tlsParam = tlsName
+	// TLS is configured automatically when RegisterMTLS has been called.
+	mysqlCfg := mysql.NewConfig()
+	mysqlCfg.User = password.Username
+	mysqlCfg.Passwd = password.PlainText
+	mysqlCfg.Net = "tcp"
+	mysqlCfg.Addr = password.Hostname
+	mysqlCfg.InterpolateParams = true
+	if mtlsRegistered.Load() {
+		mysqlCfg.TLSConfig = mtlsConfigName
 	}
-	cfg := mysql.Config{
-		User:                 password.Username,
-		Passwd:               password.PlainText,
-		Net:                  "tcp",
-		Addr:                 password.Hostname,
-		DBName:               sc.Namespace,
-		TLSConfig:            tlsParam,
-		AllowNativePasswords: true,
-		InterpolateParams:    true,
-	}
+	dsn := mysqlCfg.FormatDSN()
 
-	db, err := sql.Open("mysql", cfg.FormatDSN())
+	db, err := sql.Open("mysql", dsn)
 	if err != nil {
 		return fmt.Errorf("open branch connection for %s: %w", sc.Namespace, err)
 	}
@@ -949,8 +1020,13 @@ func (e *Engine) applyKeyspaceChangesOnce(ctx context.Context, sc engine.SchemaC
 		return fmt.Errorf("ping branch for %s: %w", sc.Namespace, err)
 	}
 
+	// USE the keyspace — vtgate branch proxy routes based on the database name.
+	if _, err := db.ExecContext(ctx, "USE `"+sc.Namespace+"`"); err != nil {
+		return fmt.Errorf("use keyspace %s: %w", sc.Namespace, err)
+	}
+
 	for _, tc := range sc.TableChanges {
-		slog.Info("applying DDL to branch",
+		e.logger.Info("applying DDL to branch",
 			"keyspace", sc.Namespace,
 			"table", tc.Table,
 			"operation", tc.Operation,
@@ -980,7 +1056,7 @@ func getVSchemaContent(sc engine.SchemaChange, schemaFiles schema.SchemaFiles) s
 // updateBranchVSchema updates the VSchema for a keyspace on a branch
 // using the PlanetScale SDK's UpdateKeyspaceVSchema endpoint.
 func (e *Engine) updateBranchVSchema(ctx context.Context, client psclient.PSClient, org, database, branch, keyspace, vschemaJSON string) error {
-	slog.Info("updating VSchema on branch",
+	e.logger.Info("updating VSchema on branch",
 		"branch", branch,
 		"keyspace", keyspace,
 	)
@@ -1060,7 +1136,7 @@ func (e *Engine) resumeApply(ctx context.Context, client psclient.PSClient, org 
 		return nil, fmt.Errorf("decode resume state: %w", err)
 	}
 
-	slog.Info("resuming apply",
+	e.logger.Info("resuming apply",
 		"branch", meta.BranchName,
 		"deploy_request", meta.DeployRequestID,
 	)
@@ -1070,7 +1146,7 @@ func (e *Engine) resumeApply(ctx context.Context, client psclient.PSClient, org 
 		dr, err := e.getDeployRequest(ctx, client, org, req.Database, meta.DeployRequestID)
 		if err != nil {
 			// Deploy request may have been cleaned up — start fresh.
-			slog.Warn("deploy request not found on resume, starting fresh",
+			e.logger.Warn("deploy request not found on resume, starting fresh",
 				"deploy_request", meta.DeployRequestID, "error", err)
 			req.ResumeState = nil
 			return e.Apply(ctx, req)
@@ -1079,7 +1155,7 @@ func (e *Engine) resumeApply(ctx context.Context, client psclient.PSClient, org 
 		// If the deploy request failed, start fresh with a new branch rather
 		// than resuming a broken deploy.
 		if dr.DeploymentState == deployState.Error || dr.DeploymentState == deployState.CompleteError {
-			slog.Warn("deploy request in error state on resume, starting fresh",
+			e.logger.Warn("deploy request in error state on resume, starting fresh",
 				"deploy_request", meta.DeployRequestID, "state", dr.DeploymentState)
 			req.ResumeState = nil
 			return e.Apply(ctx, req)
@@ -1104,12 +1180,12 @@ func (e *Engine) resumeApply(ctx context.Context, client psclient.PSClient, org 
 	// the deploy request was created. Diff the branch against desired schema
 	// to find DDL that wasn't applied before the crash, then apply only the
 	// missing changes.
-	slog.Info("resuming from branch (no deploy request yet)", "branch", meta.BranchName)
+	e.logger.Info("resuming from branch (no deploy request yet)", "branch", meta.BranchName)
 
 	// Check if the branch still exists — it may have been deleted by TTL
 	// between the crash and recovery. If so, start fresh.
 	if err := e.waitForBranchReady(ctx, client, org, req.Database, meta.BranchName); err != nil {
-		slog.Warn("branch no longer available on resume, starting fresh", "branch", meta.BranchName, "error", err)
+		e.logger.Warn("branch no longer available on resume, starting fresh", "branch", meta.BranchName, "error", err)
 		req.ResumeState = nil
 		return e.Apply(ctx, req)
 	}
@@ -1121,7 +1197,7 @@ func (e *Engine) resumeApply(ctx context.Context, client psclient.PSClient, org 
 	}
 
 	if len(remainingChanges) > 0 {
-		slog.Info("applying remaining DDL on resume", "branch", meta.BranchName, "keyspaces", len(remainingChanges))
+		e.logger.Info("applying remaining DDL on resume", "branch", meta.BranchName, "keyspaces", len(remainingChanges))
 		resumePwCtx, resumePwCancel := context.WithTimeout(ctx, 10*time.Second)
 		defer resumePwCancel()
 
@@ -1131,11 +1207,11 @@ func (e *Engine) resumeApply(ctx context.Context, client psclient.PSClient, org 
 		if err != nil {
 			return nil, fmt.Errorf("create branch password on resume: %w", err)
 		}
-		if err := e.applyChangesToBranch(ctx, remainingChanges, req.SchemaFiles, password, req.Credentials.Metadata["tls_name"], client, org, req.Database, meta.BranchName); err != nil {
+		if err := e.applyChangesToBranch(ctx, remainingChanges, req.SchemaFiles, password, client, org, req.Database, meta.BranchName); err != nil {
 			return nil, fmt.Errorf("apply remaining DDL on resume: %w", err)
 		}
 	} else {
-		slog.Info("all DDL already applied on branch", "branch", meta.BranchName)
+		e.logger.Info("all DDL already applied on branch", "branch", meta.BranchName)
 	}
 
 	// VSchema may not have been applied before the crash — re-apply
@@ -1185,8 +1261,8 @@ func (e *Engine) resumeApply(ctx context.Context, client psclient.PSClient, org 
 
 	// Deploy
 	instantEligible := dr.Deployment != nil && dr.Deployment.InstantDDLEligible
-	enableRevert := req.Options["enable_revert"] == "true"
-	useInstant := instantEligible && !deferCutover && !enableRevert
+	skipRevert := req.Options["skip_revert"] == "true"
+	useInstant := instantEligible && !deferCutover && skipRevert
 
 	dr, err = client.DeployDeployRequest(ctx, &ps.PerformDeployRequest{
 		Organization: org, Database: req.Database, Number: dr.Number, InstantDDL: useInstant,
@@ -1195,7 +1271,7 @@ func (e *Engine) resumeApply(ctx context.Context, client psclient.PSClient, org 
 		return nil, fmt.Errorf("deploy on resume: %w", err)
 	}
 
-	slog.Info("resumed and deployed", "number", dr.Number, "branch", meta.BranchName)
+	e.logger.Info("resumed and deployed", "number", dr.Number, "branch", meta.BranchName)
 	return &engine.ApplyResult{
 		Accepted: true,
 		Message:  fmt.Sprintf("Resumed and deployed request #%d", dr.Number),
@@ -1235,7 +1311,7 @@ func (e *Engine) Progress(ctx context.Context, req *engine.ProgressRequest) (*en
 		return nil, fmt.Errorf("get planetscale client: %w", err)
 	}
 
-	dr, err := e.getDeployRequest(ctx, client, req.Credentials.Organization, req.Database, meta.DeployRequestID)
+	dr, err := e.getDeployRequest(ctx, client, credOrg(req.Credentials), req.Database, meta.DeployRequestID)
 	if err != nil {
 		return nil, fmt.Errorf("get deploy request: %w", err)
 	}
@@ -1261,19 +1337,24 @@ func (e *Engine) Progress(ctx context.Context, req *engine.ProgressRequest) (*en
 		ResumeState: req.ResumeState,
 	}
 
-	// Enrich with per-shard progress from SHOW VITESS_MIGRATIONS if available.
-	if req.Credentials.DSN != "" {
-		migCtx := req.ResumeState.MigrationContext
-		if migCtx == "" {
-			slog.Warn("no schema change context captured, skipping per-shard progress")
-			return result, nil
-		}
-		tables, overallProgress := e.queryVitessMigrations(ctx, client, req.Database, req.Credentials, migCtx)
-		if len(tables) > 0 {
-			result.Tables = tables
-			if overallProgress > 0 {
-				result.Progress = overallProgress
-			}
+	// Enrich with per-shard progress from SHOW VITESS_MIGRATIONS.
+	// Requires a vtgate DSN (Credentials.DSN) and a migration context
+	// (from VitessApplyData) to query per-shard state.
+	if req.Credentials.DSN == "" {
+		e.logger.Info("no vtgate DSN configured, skipping per-shard progress",
+			"database", req.Database)
+		return result, nil
+	}
+	if req.ResumeState == nil || req.ResumeState.MigrationContext == "" {
+		e.logger.Warn("no migration context for per-shard progress — VitessApplyData may not be saved yet",
+			"database", req.Database, "has_resume_state", req.ResumeState != nil)
+		return result, nil
+	}
+	tables, overallProgress := e.queryVitessMigrations(ctx, client, req.Database, req.Credentials, req.ResumeState.MigrationContext)
+	if len(tables) > 0 {
+		result.Tables = tables
+		if overallProgress > 0 {
+			result.Progress = overallProgress
 		}
 	}
 
@@ -1295,7 +1376,7 @@ func (e *Engine) Stop(ctx context.Context, req *engine.ControlRequest) (*engine.
 	}
 
 	_, err = client.CancelDeployRequest(ctx, &ps.CancelDeployRequestRequest{
-		Organization: req.Credentials.Organization,
+		Organization: credOrg(req.Credentials),
 		Database:     req.Database,
 		Number:       meta.DeployRequestID,
 	})
@@ -1305,7 +1386,7 @@ func (e *Engine) Stop(ctx context.Context, req *engine.ControlRequest) (*engine.
 
 	return &engine.ControlResult{
 		Accepted:    true,
-		Message:     "Schema change stopped",
+		Message:     "Deploy request cancelled",
 		ResumeState: req.ResumeState,
 	}, nil
 }
@@ -1328,7 +1409,7 @@ func (e *Engine) Cutover(ctx context.Context, req *engine.ControlRequest) (*engi
 	}
 
 	dr, err := client.ApplyDeployRequest(ctx, &ps.ApplyDeployRequestRequest{
-		Organization: req.Credentials.Organization,
+		Organization: credOrg(req.Credentials),
 		Database:     req.Database,
 		Number:       meta.DeployRequestID,
 	})
@@ -1356,7 +1437,7 @@ func (e *Engine) Revert(ctx context.Context, req *engine.ControlRequest) (*engin
 	}
 
 	dr, err := client.RevertDeployRequest(ctx, &ps.RevertDeployRequestRequest{
-		Organization: req.Credentials.Organization,
+		Organization: credOrg(req.Credentials),
 		Database:     req.Database,
 		Number:       meta.DeployRequestID,
 	})
@@ -1384,7 +1465,7 @@ func (e *Engine) SkipRevert(ctx context.Context, req *engine.ControlRequest) (*e
 	}
 
 	dr, err := client.SkipRevertDeployRequest(ctx, &ps.SkipRevertDeployRequestRequest{
-		Organization: req.Credentials.Organization,
+		Organization: credOrg(req.Credentials),
 		Database:     req.Database,
 		Number:       meta.DeployRequestID,
 	})
@@ -1438,12 +1519,12 @@ func (e *Engine) Volume(ctx context.Context, req *engine.VolumeRequest) (*engine
 	}
 
 	if req.Volume < 1 || req.Volume > 11 {
-		slog.Warn("volume out of range, clamping to [1, 11]", "requested", req.Volume)
+		e.logger.Warn("volume out of range, clamping to [1, 11]", "requested", req.Volume)
 	}
 	ratio := volumeToThrottleRatio(req.Volume)
 
 	err = client.ThrottleDeployRequest(ctx, &psclient.ThrottleDeployRequestRequest{
-		Organization:  req.Credentials.Organization,
+		Organization:  credOrg(req.Credentials),
 		Database:      req.Database,
 		Number:        meta.DeployRequestID,
 		ThrottleRatio: ratio,
@@ -1506,19 +1587,19 @@ func (e *Engine) captureExistingContexts(ctx context.Context, client psclient.PS
 
 	branch := mainBranch(creds)
 	keyspaces, err := client.ListKeyspaces(ctx, &ps.ListKeyspacesRequest{
-		Organization: creds.Organization,
+		Organization: credOrg(creds),
 		Database:     database,
 		Branch:       branch,
 	})
 	if err != nil {
-		slog.Warn("captureExistingContexts: failed to list keyspaces", "error", err)
+		e.logger.Warn("captureExistingContexts: failed to list keyspaces", "error", err)
 		return existing
 	}
 
 	for _, ks := range keyspaces {
 		rows, err := e.showVitessMigrationsForKeyspace(ctx, creds.DSN, ks.Name, "")
 		if err != nil {
-			slog.Debug("capture existing contexts: query failed", "keyspace", ks.Name, "error", err)
+			e.logger.Debug("capture existing contexts: query failed", "keyspace", ks.Name, "error", err)
 			continue
 		}
 		for _, r := range rows {
@@ -1528,7 +1609,7 @@ func (e *Engine) captureExistingContexts(ctx context.Context, client psclient.PS
 		}
 	}
 
-	slog.Info("captured schema change context baseline", "count", len(existing))
+	e.logger.Info("captured schema change context baseline", "count", len(existing))
 	return existing
 }
 
@@ -1536,38 +1617,38 @@ func (e *Engine) captureExistingContexts(ctx context.Context, client psclient.PS
 // deploying by comparing current contexts against the pre-deploy baseline.
 func (e *Engine) discoverMigrationContext(ctx context.Context, client psclient.PSClient, database string, creds *engine.Credentials, existingContexts map[string]bool) string {
 	if creds.DSN == "" {
-		slog.Debug("skipping schema change context discovery, no DSN configured")
+		e.logger.Debug("skipping schema change context discovery, no DSN configured")
 		return ""
 	}
 
-	slog.Info("discovering schema change context", "database", database, "baseline_count", len(existingContexts))
+	e.logger.Info("discovering schema change context", "database", database, "baseline_count", len(existingContexts))
 
 	branch := mainBranch(creds)
 	keyspaces, err := client.ListKeyspaces(ctx, &ps.ListKeyspacesRequest{
-		Organization: creds.Organization,
+		Organization: credOrg(creds),
 		Database:     database,
 		Branch:       branch,
 	})
 	if err != nil {
-		slog.Warn("failed to list keyspaces for schema change context discovery", "error", err)
+		e.logger.Warn("failed to list keyspaces for schema change context discovery", "error", err)
 		return ""
 	}
 
 	for _, ks := range keyspaces {
 		rows, err := e.showVitessMigrationsForKeyspace(ctx, creds.DSN, ks.Name, "")
 		if err != nil {
-			slog.Debug("failed to query schema changes for keyspace", "keyspace", ks.Name, "error", err)
+			e.logger.Debug("failed to query schema changes for keyspace", "keyspace", ks.Name, "error", err)
 			continue
 		}
 		for _, r := range rows {
 			if r.MigrationContext != "" && !existingContexts[r.MigrationContext] {
-				slog.Info("discovered schema change context", "context", r.MigrationContext)
+				e.logger.Info("discovered schema change context", "context", r.MigrationContext)
 				return r.MigrationContext
 			}
 		}
 	}
 
-	slog.Warn("schema change context not discovered yet")
+	e.logger.Warn("schema change context not discovered yet")
 	return ""
 }
 
@@ -1586,6 +1667,9 @@ type vitessMigrationRow struct {
 	RowsCopied       int64
 	TableRows        int64
 	IsImmediate      bool
+	CutoverAttempts  int
+	StartedAt        *time.Time
+	CompletedAt      *time.Time
 }
 
 // queryVitessMigrations queries SHOW VITESS_MIGRATIONS across all keyspaces via vtgate
@@ -1593,12 +1677,12 @@ type vitessMigrationRow struct {
 func (e *Engine) queryVitessMigrations(ctx context.Context, client psclient.PSClient, database string, creds *engine.Credentials, migrationContext string) ([]engine.TableProgress, int) {
 	branch := mainBranch(creds)
 	keyspaces, err := client.ListKeyspaces(ctx, &ps.ListKeyspacesRequest{
-		Organization: creds.Organization,
+		Organization: credOrg(creds),
 		Database:     database,
 		Branch:       branch,
 	})
 	if err != nil {
-		slog.Warn("queryVitessMigrations: failed to list keyspaces", "error", err)
+		e.logger.Warn("queryVitessMigrations: failed to list keyspaces", "error", err)
 		return nil, 0
 	}
 
@@ -1606,7 +1690,7 @@ func (e *Engine) queryVitessMigrations(ctx context.Context, client psclient.PSCl
 	for _, ks := range keyspaces {
 		rows, err := e.showVitessMigrationsForKeyspace(ctx, creds.DSN, ks.Name, migrationContext)
 		if err != nil {
-			slog.Warn("queryVitessMigrations: query failed", "keyspace", ks.Name, "error", err)
+			e.logger.Error("per-shard progress query failed", "keyspace", ks.Name, "database", database, "error", err)
 			continue
 		}
 		allRows = append(allRows, rows...)
@@ -1667,7 +1751,7 @@ func (e *Engine) showVitessMigrationsForKeyspace(ctx context.Context, dsn, keysp
 			colPtrs[i] = &colValues[i]
 		}
 		if err := rows.Scan(colPtrs...); err != nil {
-			slog.Debug("scan vitess_migrations row", "keyspace", keyspace, "error", err)
+			e.logger.Debug("scan vitess_migrations row", "keyspace", keyspace, "error", err)
 			continue
 		}
 		colMap := make(map[string]string)
@@ -1689,24 +1773,34 @@ func (e *Engine) showVitessMigrationsForKeyspace(ctx context.Context, dsn, keysp
 			IsImmediate:      colMap["is_immediate_operation"] == "1",
 		}
 		if v, err := strconv.Atoi(colMap["progress"]); err != nil && colMap["progress"] != "" {
-			slog.Debug("parse vitess_migrations field", "field", "progress", "value", colMap["progress"], "error", err)
+			e.logger.Debug("parse vitess_migrations field", "field", "progress", "value", colMap["progress"], "error", err)
 		} else {
 			row.Progress = v
 		}
 		if v, err := parseInt64(colMap["eta_seconds"]); err != nil {
-			slog.Debug("parse vitess_migrations field", "field", "eta_seconds", "value", colMap["eta_seconds"], "error", err)
+			e.logger.Debug("parse vitess_migrations field", "field", "eta_seconds", "value", colMap["eta_seconds"], "error", err)
 		} else {
 			row.ETASeconds = v
 		}
 		if v, err := parseInt64(colMap["rows_copied"]); err != nil {
-			slog.Debug("parse vitess_migrations field", "field", "rows_copied", "value", colMap["rows_copied"], "error", err)
+			e.logger.Debug("parse vitess_migrations field", "field", "rows_copied", "value", colMap["rows_copied"], "error", err)
 		} else {
 			row.RowsCopied = v
 		}
 		if v, err := parseInt64(colMap["table_rows"]); err != nil {
-			slog.Debug("parse vitess_migrations field", "field", "table_rows", "value", colMap["table_rows"], "error", err)
+			e.logger.Debug("parse vitess_migrations field", "field", "table_rows", "value", colMap["table_rows"], "error", err)
 		} else {
 			row.TableRows = v
+		}
+		if v, err := parseInt64(colMap["cutover_attempts"]); err == nil {
+			row.CutoverAttempts = int(v)
+		}
+
+		if ts, parseErr := time.Parse("2006-01-02 15:04:05", colMap["started_timestamp"]); parseErr == nil {
+			row.StartedAt = &ts
+		}
+		if ts, parseErr := time.Parse("2006-01-02 15:04:05", colMap["completed_timestamp"]); parseErr == nil {
+			row.CompletedAt = &ts
 		}
 
 		result = append(result, row)
@@ -1746,6 +1840,9 @@ func aggregateShardProgress(rows []vitessMigrationRow) ([]engine.TableProgress, 
 		tableRows       int64
 		etaSeconds      int64
 		isImmediate     bool
+		cutoverAttempts int
+		startedAt       *time.Time
+		completedAt     *time.Time
 	}
 
 	tableShards := make(map[tableKey][]shardData)
@@ -1765,6 +1862,9 @@ func aggregateShardProgress(rows []vitessMigrationRow) ([]engine.TableProgress, 
 			tableRows:       r.TableRows,
 			etaSeconds:      r.ETASeconds,
 			isImmediate:     r.IsImmediate,
+			cutoverAttempts: r.CutoverAttempts,
+			startedAt:       r.StartedAt,
+			completedAt:     r.CompletedAt,
 		})
 	}
 
@@ -1781,6 +1881,9 @@ func aggregateShardProgress(rows []vitessMigrationRow) ([]engine.TableProgress, 
 
 		var tblRowsCopied, tblTableRows, maxETA int64
 		var tblProgress int
+		var tblStartedAt *time.Time
+		var latestCompletedAt *time.Time
+		allShardsCompleted := true
 		shardProgress := make([]engine.ShardProgress, len(shards))
 		isInstant := true
 
@@ -1795,6 +1898,16 @@ func aggregateShardProgress(rows []vitessMigrationRow) ([]engine.TableProgress, 
 			if !sh.isImmediate {
 				isInstant = false
 			}
+			// Table started_at = earliest shard started_at
+			if sh.startedAt != nil && (tblStartedAt == nil || sh.startedAt.Before(*tblStartedAt)) {
+				tblStartedAt = sh.startedAt
+			}
+			// Track latest completed_at across shards
+			if sh.completedAt == nil {
+				allShardsCompleted = false
+			} else if latestCompletedAt == nil || sh.completedAt.After(*latestCompletedAt) {
+				latestCompletedAt = sh.completedAt
+			}
 
 			// Resolve effective shard state: running + ready_to_complete = ready_to_complete
 			shardState := sh.status
@@ -1803,12 +1916,13 @@ func aggregateShardProgress(rows []vitessMigrationRow) ([]engine.TableProgress, 
 			}
 
 			shardProgress[i] = engine.ShardProgress{
-				Shard:      sh.shard,
-				State:      shardState,
-				Progress:   sh.progress,
-				RowsCopied: sh.rowsCopied,
-				RowsTotal:  sh.tableRows,
-				ETASeconds: sh.etaSeconds,
+				Shard:           sh.shard,
+				State:           shardState,
+				Progress:        sh.progress,
+				RowsCopied:      sh.rowsCopied,
+				RowsTotal:       sh.tableRows,
+				ETASeconds:      sh.etaSeconds,
+				CutoverAttempts: sh.cutoverAttempts,
 			}
 
 			tableState = resolveTableState(tableState, shardState)
@@ -1823,15 +1937,23 @@ func aggregateShardProgress(rows []vitessMigrationRow) ([]engine.TableProgress, 
 		totalRowsCopied += tblRowsCopied
 		totalTableRows += tblTableRows
 
+		// Table completed_at is only set when all shards have completed.
+		var tblCompletedAt *time.Time
+		if allShardsCompleted {
+			tblCompletedAt = latestCompletedAt
+		}
+
 		tables = append(tables, engine.TableProgress{
-			Table:      key.table,
-			State:      tableState,
-			Progress:   tblProgress,
-			RowsCopied: tblRowsCopied,
-			RowsTotal:  tblTableRows,
-			ETASeconds: maxETA,
-			Shards:     shardProgress,
-			IsInstant:  isInstant,
+			Table:       key.table,
+			State:       tableState,
+			Progress:    tblProgress,
+			RowsCopied:  tblRowsCopied,
+			RowsTotal:   tblTableRows,
+			ETASeconds:  maxETA,
+			Shards:      shardProgress,
+			IsInstant:   isInstant,
+			StartedAt:   tblStartedAt,
+			CompletedAt: tblCompletedAt,
 		})
 	}
 
@@ -1965,7 +2087,7 @@ func (e *Engine) createBranch(ctx context.Context, client psclient.PSClient, org
 	if err != nil {
 		// Idempotent: if branch exists, return it
 		if strings.Contains(err.Error(), "Name has already been taken") {
-			slog.Info("branch already exists, reusing", "branch", branchName)
+			e.logger.Info("branch already exists, reusing", "branch", branchName)
 			return client.GetBranch(ctx, &ps.GetDatabaseBranchRequest{
 				Organization: org,
 				Database:     database,
@@ -1984,6 +2106,7 @@ func (e *Engine) waitForBranchReady(ctx context.Context, client psclient.PSClien
 	ticker := time.NewTicker(2 * time.Second)
 	defer ticker.Stop()
 
+	var consecutiveErrors int
 	for {
 		select {
 		case <-ctx.Done():
@@ -1995,9 +2118,15 @@ func (e *Engine) waitForBranchReady(ctx context.Context, client psclient.PSClien
 				Branch:       branchName,
 			})
 			if err != nil {
-				slog.Warn("error checking branch status", "error", err)
+				consecutiveErrors++
+				e.logger.Warn("error checking branch status",
+					"branch", branchName, "error", err, "consecutive_errors", consecutiveErrors)
+				if consecutiveErrors >= 5 {
+					return fmt.Errorf("branch %s not reachable after %d attempts: %w", branchName, consecutiveErrors, err)
+				}
 				continue
 			}
+			consecutiveErrors = 0
 			if branch.Ready {
 				return nil
 			}
@@ -2034,7 +2163,7 @@ func generateBranchName(database, planID string) string {
 	if len(shortID) > 8 {
 		shortID = shortID[len(shortID)-8:]
 	}
-	return fmt.Sprintf("tern-%s-%s", sanitized, shortID)
+	return fmt.Sprintf("schemabot-%s-%s", sanitized, shortID)
 }
 
 // --- Deploy state mapping ---

--- a/pkg/engine/planetscale/planetscale_test.go
+++ b/pkg/engine/planetscale/planetscale_test.go
@@ -113,25 +113,25 @@ func TestGenerateBranchName(t *testing.T) {
 			name:     "basic",
 			database: "mydb",
 			planID:   "plan-12345678",
-			expected: "tern-mydb-12345678",
+			expected: "schemabot-mydb-12345678",
 		},
 		{
 			name:     "underscores replaced",
 			database: "my_cool_db",
 			planID:   "plan-abcdefgh",
-			expected: "tern-my-cool-db-abcdefgh",
+			expected: "schemabot-my-cool-db-abcdefgh",
 		},
 		{
 			name:     "long database name truncated",
 			database: "this_is_a_very_long_database_name",
 			planID:   "plan-xyz12345",
-			expected: "tern-this-is-a-very-long--xyz12345",
+			expected: "schemabot-this-is-a-very-long--xyz12345",
 		},
 		{
 			name:     "short plan ID",
 			database: "db",
 			planID:   "abc",
-			expected: "tern-db-abc",
+			expected: "schemabot-db-abc",
 		},
 	}
 
@@ -145,14 +145,14 @@ func TestGenerateBranchName(t *testing.T) {
 
 func TestPSMetadataEncodeDecode(t *testing.T) {
 	original := &psMetadata{
-		BranchName:       "tern-mydb-12345678",
+		BranchName:       "schemabot-mydb-12345678",
 		DeployRequestID:  42,
 		DeployRequestURL: "https://app.planetscale.com/org/db/deploy-requests/42",
 	}
 
 	encoded, err := encodePSMetadata(original)
 	require.NoError(t, err)
-	assert.Contains(t, encoded, "tern-mydb-12345678")
+	assert.Contains(t, encoded, "schemabot-mydb-12345678")
 	assert.Contains(t, encoded, "42")
 
 	decoded, err := decodePSMetadata(encoded)

--- a/pkg/engine/planetscale/tls.go
+++ b/pkg/engine/planetscale/tls.go
@@ -5,6 +5,7 @@ import (
 	"crypto/x509"
 	"fmt"
 	"os"
+	"sync/atomic"
 
 	mysql "github.com/go-sql-driver/mysql"
 )
@@ -12,6 +13,10 @@ import (
 // mtlsConfigName is the Go MySQL driver TLS config name registered by RegisterMTLS.
 // Used for all PlanetScale MySQL connections (branches and vtgate).
 const mtlsConfigName = "planetscale"
+
+// mtlsRegistered tracks whether RegisterMTLS has been called.
+// Accessed from multiple goroutines (branch apply + vtgate progress polling).
+var mtlsRegistered atomic.Bool
 
 // TLSConfigName returns the Go MySQL driver TLS config name registered by
 // RegisterMTLS. Use this in DSN strings (e.g., "user:pass@tcp(host)/?tls=<name>")
@@ -72,5 +77,6 @@ func RegisterMTLS(cfg MTLSConfig) error {
 	if err := mysql.RegisterTLSConfig(mtlsConfigName, tlsCfg); err != nil {
 		return fmt.Errorf("register TLS config: %w", err)
 	}
+	mtlsRegistered.Store(true)
 	return nil
 }

--- a/pkg/psclient/client.go
+++ b/pkg/psclient/client.go
@@ -37,6 +37,9 @@ type PSClient interface {
 	RevertDeployRequest(ctx context.Context, req *ps.RevertDeployRequestRequest) (*ps.DeployRequest, error)
 	SkipRevertDeployRequest(ctx context.Context, req *ps.SkipRevertDeployRequestRequest) (*ps.DeployRequest, error)
 
+	// ListDeployRequests lists all deploy requests for a database.
+	ListDeployRequests(ctx context.Context, req *ps.ListDeployRequestsRequest) ([]*ps.DeployRequest, error)
+
 	// ThrottleDeployRequest sets the throttle ratio for a running deploy request.
 	// This controls the speed of the online DDL copy phase (0.0 = full speed,
 	// 0.95 = max throttle). The PlanetScale API supports this endpoint but the
@@ -156,6 +159,10 @@ func (w *psClientWrapper) RevertDeployRequest(ctx context.Context, req *ps.Rever
 
 func (w *psClientWrapper) SkipRevertDeployRequest(ctx context.Context, req *ps.SkipRevertDeployRequestRequest) (*ps.DeployRequest, error) {
 	return w.client.DeployRequests.SkipRevertDeploy(ctx, req)
+}
+
+func (w *psClientWrapper) ListDeployRequests(ctx context.Context, req *ps.ListDeployRequestsRequest) ([]*ps.DeployRequest, error) {
+	return w.client.DeployRequests.List(ctx, req)
 }
 
 // ThrottleDeployRequest sets the throttle ratio via a raw HTTP PUT.

--- a/pkg/tern/apply_states_test.go
+++ b/pkg/tern/apply_states_test.go
@@ -1,0 +1,69 @@
+package tern
+
+import (
+	"testing"
+
+	"github.com/block/schemabot/pkg/engine"
+	"github.com/block/schemabot/pkg/state"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestOnEventApplyStateTransitions verifies that engine lifecycle events
+// trigger the correct apply state transitions for PlanetScale applies.
+func TestOnEventApplyStateTransitions(t *testing.T) {
+	tests := []struct {
+		name         string
+		message      string
+		wantState    string
+		wantNoChange bool
+	}{
+		{
+			name:      "branch ready transitions to applying_branch_changes",
+			message:   "Branch schemabot-boardgames-123 ready (44s)",
+			wantState: state.Apply.ApplyingBranchChanges,
+		},
+		{
+			name:      "DDL applied transitions to creating_deploy_request",
+			message:   "Applied 1 DDL changes to branch schemabot-boardgames-123",
+			wantState: state.Apply.CreatingDeployRequest,
+		},
+		{
+			name:      "multiple DDL changes transitions to creating_deploy_request",
+			message:   "Applied 3 DDL changes to branch schemabot-inventory2-456",
+			wantState: state.Apply.CreatingDeployRequest,
+		},
+		{
+			name:         "creating branch does not transition",
+			message:      "Creating branch schemabot-boardgames-123",
+			wantNoChange: true,
+		},
+		{
+			name:         "deploy request created does not transition",
+			message:      "Deploy request #77 created",
+			wantNoChange: true,
+		},
+		{
+			name:         "deploy request deployed does not transition",
+			message:      "Deploy request #77 deployed",
+			wantNoChange: true,
+		},
+		{
+			name:         "no changes detected does not transition",
+			message:      "Deploy request #77: no changes detected",
+			wantNoChange: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			event := engine.ApplyEvent{Message: tt.message}
+			newState := deriveApplyPhase(event.Message)
+
+			if tt.wantNoChange {
+				assert.Empty(t, newState, "expected no state change for %q", tt.message)
+			} else {
+				assert.Equal(t, tt.wantState, newState, "wrong state for %q", tt.message)
+			}
+		})
+	}
+}

--- a/pkg/tern/local_apply.go
+++ b/pkg/tern/local_apply.go
@@ -69,6 +69,7 @@ func (c *LocalClient) findBlockingTask(ctx context.Context, tasks []*storage.Tas
 func (c *LocalClient) tryResolveStaleTask(ctx context.Context, t *storage.Task, database string) bool {
 	eng := c.getEngine()
 	if eng == nil {
+		c.logger.Error("tryResolveStaleTask: engine is nil", "database", database)
 		return false
 	}
 
@@ -174,7 +175,9 @@ func (c *LocalClient) transitionTaskState(ctx context.Context, task *storage.Tas
 	oldState := task.State
 	task.State = newState
 	task.UpdatedAt = time.Now()
-	_ = c.storage.Tasks().Update(ctx, task)
+	if err := c.storage.Tasks().Update(ctx, task); err != nil {
+		c.logger.Error("failed to update task state", "task_id", task.TaskIdentifier, "state", newState, "error", err)
+	}
 	if logMsg != "" && applyID > 0 {
 		taskID := task.ID
 		c.logApplyEvent(ctx, applyID, &taskID, storage.LogLevelInfo, storage.LogEventStateTransition, storage.LogSourceSchemaBot,
@@ -189,8 +192,23 @@ func (c *LocalClient) markTasksRunning(ctx context.Context, tasks []*storage.Tas
 		task.State = state.Task.Running
 		task.StartedAt = &now
 		task.UpdatedAt = now
-		_ = c.storage.Tasks().Update(ctx, task)
+		if err := c.storage.Tasks().Update(ctx, task); err != nil {
+			c.logger.Error("failed to update task state", "task_id", task.TaskIdentifier, "state", state.Task.Running, "error", err)
+		}
 	}
+}
+
+// runWithRecovery wraps an apply function with panic recovery so a single panic
+// doesn't crash the entire process. On panic, all tasks and the apply are marked failed.
+func (c *LocalClient) runWithRecovery(ctx context.Context, apply *storage.Apply, tasks []*storage.Task, fn func()) {
+	defer func() {
+		if r := recover(); r != nil {
+			errMsg := fmt.Sprintf("panic in apply goroutine: %v", r)
+			c.logger.Error(errMsg, "apply_id", apply.ApplyIdentifier)
+			c.failApplyWithTasks(ctx, apply, tasks, errMsg)
+		}
+	}()
+	fn()
 }
 
 // executeApplyAtomic runs all DDLs in one Spirit call for atomic cutover (--defer-cutover).
@@ -208,8 +226,15 @@ func (c *LocalClient) executeApplyAtomic(ctx context.Context, apply *storage.App
 	}
 
 	// Log atomic mode start
+	deferCutover := options["defer_cutover"] == "true"
+	var modeDesc string
+	if deferCutover {
+		modeDesc = "atomic mode (defer-cutover)"
+	} else {
+		modeDesc = "atomic mode"
+	}
 	c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventInfo, storage.LogSourceSchemaBot,
-		fmt.Sprintf("Starting atomic mode (defer-cutover) with %d tables: %v", len(tasks), tableNames), "", "")
+		fmt.Sprintf("Starting %s with %d tables: %v", modeDesc, len(tasks), tableNames), "", "")
 
 	eng := c.getEngine()
 	defer c.setupSpiritLogging(ctx, apply, tasks)()
@@ -218,26 +243,110 @@ func (c *LocalClient) executeApplyAtomic(ctx context.Context, apply *storage.App
 	c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventInfo, storage.LogSourceSchemaBot,
 		"Calling engine.Apply for all tables", "", "")
 
-	// Build per-table changes for the engine
-	var tableChanges []engine.TableChange
-	for _, t := range tasks {
-		tableChanges = append(tableChanges, engine.TableChange{
-			Table: t.TableName,
-			DDL:   t.DDL,
-		})
+	// Build per-namespace changes from the plan. For Vitess databases, each
+	// namespace is a keyspace (e.g., "testapp", "testapp_sharded"). For MySQL,
+	// there's typically one namespace ("default" or the database name).
+	var changes []engine.SchemaChange
+	c.logger.Info("building changes from plan", "namespaces", len(plan.Namespaces), "plan_id", plan.PlanIdentifier)
+	if len(plan.Namespaces) > 0 {
+		for namespace, nsData := range plan.Namespaces {
+			var tableChanges []engine.TableChange
+			for _, tc := range nsData.Tables {
+				tableChanges = append(tableChanges, engine.TableChange{
+					Table: tc.Table,
+					DDL:   tc.DDL,
+				})
+			}
+			metadata := make(map[string]string)
+			if len(nsData.VSchema) > 0 {
+				metadata["vschema"] = "true"
+			}
+			changes = append(changes, engine.SchemaChange{
+				Namespace:    namespace,
+				TableChanges: tableChanges,
+				Metadata:     metadata,
+			})
+		}
+	} else {
+		c.failApplyWithTasks(ctx, apply, tasks, "plan has no namespace data")
+		return
+	}
+
+	// For Vitess: set apply state to creating_branch before the engine call.
+	// eng.Apply() blocks during branch creation and deploy request setup, so
+	// this state is what the progress handler returns during that period.
+	if c.config.Type == storage.DatabaseTypeVitess {
+		apply.State = state.Apply.CreatingBranch
+		apply.UpdatedAt = time.Now()
+		if err := c.storage.Applies().Update(ctx, apply); err != nil {
+			c.logger.Error("failed to update apply state", "apply_id", apply.ApplyIdentifier, "state", state.Apply.CreatingBranch, "error", err)
+		}
+
+		if err := c.storage.VitessApplyData().Save(ctx, &storage.VitessApplyData{
+			ApplyID:          apply.ID,
+			MigrationContext: apply.ApplyIdentifier,
+		}); err != nil {
+			c.logger.Error("failed to save vitess apply data", "apply_id", apply.ID, "error", err)
+		}
+	}
+
+	// Mark the apply as started before calling the engine. The engine may run
+	// for a long time (branch creation, DDL application, deploy request) and
+	// started_at should reflect when work actually began, not when it finished.
+	now := time.Now()
+	apply.StartedAt = &now
+	apply.UpdatedAt = now
+	if err := c.storage.Applies().Update(ctx, apply); err != nil {
+		c.logger.Error("failed to set started_at", "apply_id", apply.ApplyIdentifier, "error", err)
 	}
 
 	// Atomic mode: all DDLs in one engine call. Use the apply identifier as
 	// MigrationContext so all migrations share one context for progress tracking.
 	result, err := eng.Apply(ctx, &engine.ApplyRequest{
-		Database: apply.Database,
-		Changes: []engine.SchemaChange{{
-			Namespace:    apply.Database,
-			TableChanges: tableChanges,
-		}},
+		Database:    apply.Database,
+		PlanID:      plan.PlanIdentifier,
+		Changes:     changes,
+		SchemaFiles: planToSchemaFiles(plan),
 		Options:     options,
 		ResumeState: &engine.ResumeState{MigrationContext: apply.ApplyIdentifier},
 		Credentials: creds,
+		OnEvent: func(event engine.ApplyEvent) {
+			c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventInfo, storage.LogSourceSchemaBot,
+				event.Message, "", "")
+			// Update apply state to reflect engine setup phases so the
+			// progress handler returns the current phase to the CLI.
+			if newState := deriveApplyPhase(event.Message); newState != "" {
+				apply.State = newState
+				apply.UpdatedAt = time.Now()
+				if err := c.storage.Applies().Update(ctx, apply); err != nil {
+					c.logger.Error("failed to update apply phase", "apply_id", apply.ApplyIdentifier, "state", newState, "error", err)
+				}
+			}
+		},
+		OnStateChange: func(rs *engine.ResumeState) {
+			if rs == nil {
+				c.logger.Debug("OnStateChange: nil resume state", "apply_id", apply.ApplyIdentifier)
+				return
+			}
+			meta, err := decodePSMetadataForStorage(rs.Metadata)
+			if err != nil {
+				c.logger.Warn("OnStateChange: failed to decode metadata", "apply_id", apply.ApplyIdentifier, "error", err)
+				return
+			}
+			if meta == nil {
+				c.logger.Warn("OnStateChange: no PS metadata in resume state", "apply_id", apply.ApplyIdentifier)
+				return
+			}
+			if saveErr := c.storage.VitessApplyData().Save(ctx, &storage.VitessApplyData{
+				ApplyID:          apply.ID,
+				BranchName:       meta.BranchName,
+				DeployRequestID:  meta.DeployRequestID,
+				MigrationContext: rs.MigrationContext,
+				DeployRequestURL: meta.DeployRequestURL,
+			}); saveErr != nil {
+				c.logger.Warn("OnStateChange: failed to persist resume state", "apply_id", apply.ApplyIdentifier, "error", saveErr)
+			}
+		},
 	})
 
 	if err != nil {
@@ -257,17 +366,36 @@ func (c *LocalClient) executeApplyAtomic(ctx context.Context, apply *storage.App
 
 	// All tasks start running together
 	c.markTasksRunning(ctx, tasks)
-	now := time.Now()
 	apply.State = state.Apply.Running
-	apply.StartedAt = &now
-	apply.UpdatedAt = now
-	_ = c.storage.Applies().Update(ctx, apply)
+	apply.UpdatedAt = time.Now()
+	if err := c.storage.Applies().Update(ctx, apply); err != nil {
+		c.logger.Error("failed to update apply state", "apply_id", apply.ApplyIdentifier, "state", state.Apply.Running, "error", err)
+	}
 	c.logger.Info("atomic apply started", "apply_id", apply.ApplyIdentifier, "task_count", len(tasks))
 	c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventStateTransition, storage.LogSourceSchemaBot,
 		fmt.Sprintf("All %d tables started copying in parallel", len(tasks)), state.Apply.Pending, state.Apply.Running)
 
+	// Store resume state from engine (deploy request ID, migration context)
+	// so progress polling can track the deploy request.
+	var resumeState *engine.ResumeState
+	if result.ResumeState != nil {
+		resumeState = result.ResumeState
+		// Persist to vitess_apply_data for crash recovery and external progress queries.
+		if meta, err := decodePSMetadataForStorage(resumeState.Metadata); meta != nil && err == nil {
+			if saveErr := c.storage.VitessApplyData().Save(ctx, &storage.VitessApplyData{
+				ApplyID:          apply.ID,
+				BranchName:       meta.BranchName,
+				DeployRequestID:  meta.DeployRequestID,
+				MigrationContext: resumeState.MigrationContext,
+				DeployRequestURL: meta.DeployRequestURL,
+			}); saveErr != nil {
+				c.logger.Warn("failed to save vitess apply data", "apply_id", apply.ApplyIdentifier, "error", saveErr)
+			}
+		}
+	}
+
 	// Poll for completion - all tasks share the same state
-	c.pollForCompletionAtomic(ctx, apply, tasks, creds)
+	c.pollForCompletionAtomic(ctx, apply, tasks, creds, resumeState)
 }
 
 // executeApplySequential runs each DDL as a separate Spirit call (independent mode).
@@ -289,9 +417,9 @@ func (c *LocalClient) executeApplySequential(ctx context.Context, apply *storage
 	apply.State = state.Apply.Running
 	apply.StartedAt = &now
 	apply.UpdatedAt = now
-	_ = c.storage.Applies().Update(ctx, apply)
-
-	defer c.startApplyHeartbeat(ctx, apply)()
+	if err := c.storage.Applies().Update(ctx, apply); err != nil {
+		c.logger.Error("failed to update apply state", "apply_id", apply.ApplyIdentifier, "state", state.Apply.Running, "error", err)
+	}
 
 	var failedTask *storage.Task
 	var stoppedByUser bool
@@ -419,11 +547,33 @@ func (c *LocalClient) runEngineTask(ctx context.Context, task *storage.Task, pla
 	}
 }
 
+// Timeouts for idle states where user action is expected.
+const (
+	// waitingForCutoverTimeout is how long to wait for a manual cutover trigger
+	// before auto-cancelling the apply.
+	waitingForCutoverTimeout = 14 * 24 * time.Hour
+
+	// defaultRevertWindowDuration is the default revert window period.
+	// 30 minutes matches PlanetScale's default.
+	defaultRevertWindowDuration = 30 * time.Minute
+)
+
 // atomicPollState tracks mutable state across polling ticks in atomic mode.
 type atomicPollState struct {
 	lastTaskState   string
 	lastLoggedState string
 	lastProgressLog time.Time
+
+	// stateEnteredAt tracks when the current waiting state was entered,
+	// used for timeout enforcement on deferred cutover and revert window.
+	stateEnteredAt time.Time
+
+	// revertSkipped is set after SkipRevert is called to prevent repeated calls.
+	revertSkipped bool
+
+	// consecutiveErrors tracks progress poll failures to fail fast when the
+	// engine is unreachable (e.g., branch deleted mid-apply).
+	consecutiveErrors int
 }
 
 // startApplyHeartbeat starts a background goroutine that heartbeats the apply
@@ -449,7 +599,7 @@ func (c *LocalClient) startApplyHeartbeat(ctx context.Context, apply *storage.Ap
 }
 
 // pollForCompletionAtomic polls the engine for progress in atomic mode (all tasks share state).
-func (c *LocalClient) pollForCompletionAtomic(ctx context.Context, apply *storage.Apply, tasks []*storage.Task, creds *engine.Credentials) {
+func (c *LocalClient) pollForCompletionAtomic(ctx context.Context, apply *storage.Apply, tasks []*storage.Task, creds *engine.Credentials, resumeState *engine.ResumeState) {
 	eng := c.getEngine()
 	ticker := time.NewTicker(500 * time.Millisecond)
 	defer ticker.Stop()
@@ -461,7 +611,7 @@ func (c *LocalClient) pollForCompletionAtomic(ctx context.Context, apply *storag
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			if done := c.handleAtomicProgressTick(ctx, eng, apply, tasks, creds, ps); done {
+			if done := c.handleAtomicProgressTick(ctx, eng, apply, tasks, creds, resumeState, ps); done {
 				return
 			}
 		}
@@ -470,24 +620,41 @@ func (c *LocalClient) pollForCompletionAtomic(ctx context.Context, apply *storag
 
 // handleAtomicProgressTick processes a single progress poll tick in atomic mode.
 // Returns true when the apply has reached a terminal state.
-func (c *LocalClient) handleAtomicProgressTick(ctx context.Context, eng engine.Engine, apply *storage.Apply, tasks []*storage.Task, creds *engine.Credentials, ps *atomicPollState) bool {
+func (c *LocalClient) handleAtomicProgressTick(ctx context.Context, eng engine.Engine, apply *storage.Apply, tasks []*storage.Task, creds *engine.Credentials, resumeState *engine.ResumeState, ps *atomicPollState) bool {
 	result, err := eng.Progress(ctx, &engine.ProgressRequest{
 		Database:    apply.Database,
 		Credentials: creds,
+		ResumeState: resumeState,
 	})
 	if err != nil {
-		c.logger.Warn("progress check failed", "error", err, "apply_id", apply.ApplyIdentifier)
+		ps.consecutiveErrors++
+		c.logger.Warn("progress check failed",
+			"error", err, "apply_id", apply.ApplyIdentifier, "consecutive_errors", ps.consecutiveErrors)
+		if ps.consecutiveErrors >= 10 {
+			c.logger.Error("progress polling failed repeatedly, failing apply",
+				"apply_id", apply.ApplyIdentifier, "consecutive_errors", ps.consecutiveErrors)
+			c.failApplyWithTasks(ctx, apply, tasks, fmt.Sprintf("progress polling failed after %d consecutive errors: %v", ps.consecutiveErrors, err))
+			return true
+		}
 		return false
+	}
+	ps.consecutiveErrors = 0
+
+	// Update resumeState if the engine returned a newer one (e.g., with
+	// updated metadata like deploy request URL or migration context).
+	if result.ResumeState != nil && resumeState != nil {
+		*resumeState = *result.ResumeState
 	}
 
 	now := time.Now()
 	newState := engineStateToStorage(result.State)
 
-	// Log state transitions
+	// Log state transitions and track when waiting states are entered (for timeouts)
 	if newState != ps.lastTaskState {
 		c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventStateTransition, storage.LogSourceSchemaBot,
 			fmt.Sprintf("State changed to %s", newState), ps.lastTaskState, newState)
 		ps.lastTaskState = newState
+		ps.stateEnteredAt = now
 	}
 
 	// Log progress every 10 seconds
@@ -496,13 +663,70 @@ func (c *LocalClient) handleAtomicProgressTick(ctx context.Context, eng engine.E
 	// Update all tasks with engine progress
 	c.syncAtomicTaskProgress(ctx, tasks, result, newState, now)
 
+	opts := apply.GetOptions()
+	controlReq := &engine.ControlRequest{
+		Database:    apply.Database,
+		Credentials: creds,
+		ResumeState: resumeState,
+	}
+
 	// Auto-trigger cutover if waiting and not in defer mode
-	if result.State == engine.StateWaitingForCutover && !apply.GetOptions().DeferCutover {
+	if result.State == engine.StateWaitingForCutover && !opts.DeferCutover {
 		c.logger.Info("auto-triggering cutover (not in defer mode)", "apply_id", apply.ApplyIdentifier)
 		c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventCutoverTriggered, storage.LogSourceSchemaBot,
 			"Auto-triggering cutover (defer_cutover not set)", "", "")
-		if _, err := eng.Cutover(ctx, &engine.ControlRequest{Database: apply.Database, Credentials: creds}); err != nil {
+		if _, err := eng.Cutover(ctx, controlReq); err != nil {
 			c.logger.Error("auto-cutover failed", "error", err, "apply_id", apply.ApplyIdentifier)
+		}
+	}
+
+	// Timeout: cancel the apply if waiting for manual cutover too long.
+	if result.State == engine.StateWaitingForCutover && opts.DeferCutover &&
+		!ps.stateEnteredAt.IsZero() && time.Since(ps.stateEnteredAt) > waitingForCutoverTimeout {
+		c.logger.Info("waiting-for-cutover timed out, cancelling apply",
+			"apply_id", apply.ApplyIdentifier, "timeout", waitingForCutoverTimeout)
+		c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelWarn, storage.LogEventStateTransition, storage.LogSourceSchemaBot,
+			fmt.Sprintf("Waiting for cutover timed out after %s, cancelling", waitingForCutoverTimeout), "", "")
+		if _, err := eng.Stop(ctx, controlReq); err != nil {
+			c.logger.Error("timeout stop failed", "error", err, "apply_id", apply.ApplyIdentifier)
+		}
+	}
+
+	// If --skip-revert was set, auto-skip the revert window immediately.
+	if result.State == engine.StateRevertWindow && opts.SkipRevert && !ps.revertSkipped {
+		c.logger.Info("auto-skipping revert window (--skip-revert)",
+			"apply_id", apply.ApplyIdentifier,
+		)
+		c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventStateTransition, storage.LogSourceSchemaBot,
+			"Auto-skipping revert window (--skip-revert)", "", "")
+		_, err := eng.SkipRevert(ctx, controlReq)
+		if err != nil {
+			c.logger.Error("auto-skip revert failed", "error", err, "apply_id", apply.ApplyIdentifier)
+		} else {
+			c.logger.Info("skip-revert triggered", "apply_id", apply.ApplyIdentifier, "reason", "--skip-revert")
+			c.markRevertSkipped(ctx, apply)
+		}
+		c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventSkipRevertTriggered, storage.LogSourceSchemaBot,
+			"Skip-revert triggered (--skip-revert)", state.Apply.RevertWindow, "")
+		ps.revertSkipped = true
+	}
+
+	// Revert window enabled (default): auto-skip based on deployed_at + configured duration.
+	// Falls back to stateEnteredAt if deployed_at is unavailable.
+	if result.State == engine.StateRevertWindow && !opts.SkipRevert && !ps.revertSkipped {
+		revertDeadline := c.revertWindowDeadline(result.ResumeState, ps.stateEnteredAt)
+		if !revertDeadline.IsZero() && now.After(revertDeadline) {
+			c.logger.Info("revert window expired, skipping", "apply_id", apply.ApplyIdentifier, "deadline", revertDeadline)
+			c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventStateTransition, storage.LogSourceSchemaBot,
+				"Revert window expired, finalizing", "", "")
+			if _, err := eng.SkipRevert(ctx, controlReq); err != nil {
+				c.logger.Error("revert window timeout skip failed", "error", err, "apply_id", apply.ApplyIdentifier)
+			} else {
+				c.markRevertSkipped(ctx, apply)
+				c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventSkipRevertTriggered, storage.LogSourceSchemaBot,
+					"Revert window expired, skip-revert triggered", state.Apply.RevertWindow, "")
+			}
+			ps.revertSkipped = true
 		}
 	}
 
@@ -512,15 +736,58 @@ func (c *LocalClient) handleAtomicProgressTick(ctx context.Context, eng engine.E
 
 	if result.State.IsTerminal() {
 		apply.CompletedAt = &now
-		_ = c.storage.Applies().Update(ctx, apply)
+		if err := c.storage.Applies().Update(ctx, apply); err != nil {
+			c.logger.Error("failed to update apply state", "apply_id", apply.ApplyIdentifier, "state", apply.State, "error", err)
+		}
 		c.logger.Info("atomic apply completed", "apply_id", apply.ApplyIdentifier, "state", result.State, "task_count", len(tasks))
 		c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventStateTransition, storage.LogSourceSchemaBot,
 			fmt.Sprintf("Apply completed with state: %s", result.State), ps.lastTaskState, apply.State)
 		return true
 	}
 
-	_ = c.storage.Applies().Update(ctx, apply)
+	if err := c.storage.Applies().Update(ctx, apply); err != nil {
+		c.logger.Error("failed to update apply state", "apply_id", apply.ApplyIdentifier, "state", apply.State, "error", err)
+	}
 	return false
+}
+
+// markRevertSkipped sets RevertSkippedAt on the VitessApplyData record so
+// progress consumers know finalization is in progress.
+func (c *LocalClient) markRevertSkipped(ctx context.Context, apply *storage.Apply) {
+	now := time.Now()
+	if vad, err := c.storage.VitessApplyData().GetByApplyID(ctx, apply.ID); err == nil {
+		vad.RevertSkippedAt = &now
+		if saveErr := c.storage.VitessApplyData().Save(ctx, vad); saveErr != nil {
+			c.logger.Warn("failed to save revert_skipped_at", "apply_id", apply.ApplyIdentifier, "error", saveErr)
+		}
+	}
+}
+
+// revertWindowDuration returns the configured revert window duration,
+// falling back to PlanetScale's default of 30 minutes.
+func (c *LocalClient) revertWindowDuration() time.Duration {
+	if s := c.config.Metadata["revert_window_duration"]; s != "" {
+		if d, err := time.ParseDuration(s); err == nil && d > 0 {
+			return d
+		}
+	}
+	return defaultRevertWindowDuration
+}
+
+// revertWindowDeadline computes when the revert window expires.
+// Uses deployed_at from engine metadata (accurate to PlanetScale's clock) plus
+// the configured revert period. Falls back to stateEnteredAt if metadata is unavailable.
+func (c *LocalClient) revertWindowDeadline(resumeState *engine.ResumeState, stateEnteredAt time.Time) time.Time {
+	duration := c.revertWindowDuration()
+	if resumeState != nil && resumeState.Metadata != "" {
+		if meta, err := decodePSMetadataForStorage(resumeState.Metadata); err == nil && meta != nil && meta.DeployedAt != nil {
+			return meta.DeployedAt.Add(duration)
+		}
+	}
+	if !stateEnteredAt.IsZero() {
+		return stateEnteredAt.Add(duration)
+	}
+	return time.Time{}
 }
 
 // logAtomicProgress logs per-table progress to apply_logs every 10 seconds.
@@ -553,14 +820,27 @@ func (c *LocalClient) syncAtomicTaskProgress(ctx context.Context, tasks []*stora
 	}
 
 	for _, task := range tasks {
-		if result.State.IsTerminal() {
-			task.CompletedAt = &now
-		}
 		if tp, ok := tableProgress[task.TableName]; ok {
 			task.RowsCopied = tp.RowsCopied
 			task.RowsTotal = tp.RowsTotal
 			task.ProgressPercent = tp.Progress
 			task.ETASeconds = int(tp.ETASeconds)
+			// Use engine-reported timestamps (from SHOW VITESS_MIGRATIONS) if available.
+			if tp.StartedAt != nil && task.StartedAt == nil {
+				task.StartedAt = tp.StartedAt
+			}
+			if tp.CompletedAt != nil && task.CompletedAt == nil {
+				task.CompletedAt = tp.CompletedAt
+			}
+		}
+		// For tasks transitioning to a non-pending state without a started_at
+		// (e.g., instant DDL where SHOW VITESS_MIGRATIONS has no timestamp),
+		// use the current time.
+		if task.StartedAt == nil && newState != state.Task.Pending {
+			task.StartedAt = &now
+		}
+		if result.State.IsTerminal() && task.CompletedAt == nil {
+			task.CompletedAt = &now
 		}
 		c.transitionTaskState(ctx, task, 0, newState, "")
 	}
@@ -653,18 +933,37 @@ func (c *LocalClient) markTaskFailed(ctx context.Context, task *storage.Task, er
 }
 
 // failApplyWithTasks marks all tasks and the apply as failed with the given error.
+// If the apply is already in a terminal state (e.g., cancelled by Stop()), the
+// apply state is not overwritten.
 func (c *LocalClient) failApplyWithTasks(ctx context.Context, apply *storage.Apply, tasks []*storage.Task, errMsg string) {
 	now := time.Now()
 	for _, task := range tasks {
-		task.ErrorMessage = errMsg
+		if state.IsTerminalTaskState(task.State) {
+			continue
+		}
+		if task.ErrorMessage == "" {
+			task.ErrorMessage = errMsg
+		}
 		task.CompletedAt = &now
 		c.transitionTaskState(ctx, task, 0, state.Task.Failed, "")
 	}
+
+	// Re-read the apply from storage — Stop() may have already set a terminal
+	// state (e.g., cancelled) between when the engine error occurred and now.
+	fresh, err := c.storage.Applies().Get(ctx, apply.ID)
+	if err == nil && fresh != nil && state.IsTerminalApplyState(fresh.State) {
+		c.logger.Debug("apply already in terminal state, not overwriting",
+			"apply_id", apply.ApplyIdentifier, "state", fresh.State)
+		return
+	}
+
 	apply.State = state.Apply.Failed
 	apply.ErrorMessage = errMsg
 	apply.CompletedAt = &now
 	apply.UpdatedAt = now
-	_ = c.storage.Applies().Update(ctx, apply)
+	if err := c.storage.Applies().Update(ctx, apply); err != nil {
+		c.logger.Error("failed to update apply state", "apply_id", apply.ApplyIdentifier, "state", state.Apply.Failed, "error", err)
+	}
 }
 
 // finalizeSequentialApply updates the apply state based on sequential task outcomes.
@@ -688,7 +987,9 @@ func (c *LocalClient) finalizeSequentialApply(ctx context.Context, apply *storag
 		apply.CompletedAt = &now
 	}
 	apply.UpdatedAt = now
-	_ = c.storage.Applies().Update(ctx, apply)
+	if err := c.storage.Applies().Update(ctx, apply); err != nil {
+		c.logger.Error("failed to update apply state", "apply_id", apply.ApplyIdentifier, "state", apply.State, "error", err)
+	}
 }
 
 // deriveOverallState determines the overall state from a list of tasks.
@@ -741,7 +1042,8 @@ func deriveOverallState(tasks []*storage.Task) string {
 		return state.Task.Stopped
 	}
 	if hasFailed || hasCancelled {
-		// CANCELLED implies a prior task failed, so overall state is FAILED
+		// Cancelled implies a prior task failed (sequential mode), so overall is failed.
+		// For Vitess cancellation (user-initiated), the apply state is set directly.
 		return state.Task.Failed
 	}
 	if hasCompleted {
@@ -750,4 +1052,17 @@ func deriveOverallState(tasks []*storage.Task) string {
 
 	// Fallback to first task's state
 	return tasks[0].State
+}
+
+// deriveApplyPhase maps an engine lifecycle event message to a PlanetScale
+// apply phase state. Returns empty string if the event doesn't trigger a
+// state transition.
+func deriveApplyPhase(message string) string {
+	if strings.Contains(message, "Branch") && strings.Contains(message, "ready") {
+		return state.Apply.ApplyingBranchChanges
+	}
+	if strings.Contains(message, "DDL changes to branch") {
+		return state.Apply.CreatingDeployRequest
+	}
+	return ""
 }

--- a/pkg/tern/local_client.go
+++ b/pkg/tern/local_client.go
@@ -87,16 +87,20 @@ package tern
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
 
 	"github.com/block/schemabot/pkg/engine"
+	"github.com/block/schemabot/pkg/engine/planetscale"
 	"github.com/block/schemabot/pkg/engine/spirit"
 	ternv1 "github.com/block/schemabot/pkg/proto/ternv1"
+	"github.com/block/schemabot/pkg/psclient"
 	"github.com/block/schemabot/pkg/state"
 	"github.com/block/schemabot/pkg/storage"
 )
@@ -111,16 +115,24 @@ type LocalConfig struct {
 
 	// TargetDSN is the connection string to the target database for schema changes.
 	TargetDSN string
+
+	// Metadata holds engine-specific configuration as key-value pairs.
+	// The tern layer does not interpret these — it passes them through to the
+	// engine via Credentials.Metadata and reads specific keys as needed.
+	// Keys used by PlanetScale: organization, token_name, token_value,
+	// tls_name, revert_window_duration, main_branch.
+	Metadata map[string]string
 }
 
 // LocalClient implements Client by calling the Spirit engine directly.
 // This is used when SchemaBot runs as a single service with embedded engine.
 // It uses SchemaBot's storage for plans and tasks.
 type LocalClient struct {
-	config       LocalConfig
-	storage      storage.Storage
-	spiritEngine engine.Engine
-	logger       *slog.Logger
+	config            LocalConfig
+	storage           storage.Storage
+	spiritEngine      engine.Engine
+	planetscaleEngine engine.Engine
+	logger            *slog.Logger
 
 	// heartbeatInterval controls how often the apply heartbeat updates updated_at.
 	// Defaults to 10s. Tests may lower this to verify heartbeat behavior.
@@ -128,6 +140,8 @@ type LocalClient struct {
 
 	// cancelApply cancels the background goroutine running executeApplySequential
 	// or executeApplyAtomic. Set when an apply starts, called by Stop().
+	// Protected by cancelMu since Apply and Stop run on different goroutines.
+	cancelMu    sync.Mutex
 	cancelApply context.CancelFunc
 }
 
@@ -137,10 +151,22 @@ var _ Client = (*LocalClient)(nil)
 // NewLocalClient creates a new local Tern client that calls the Spirit engine directly.
 // The storage parameter should be SchemaBot's storage instance for plan/task management.
 func NewLocalClient(cfg LocalConfig, stor storage.Storage, logger *slog.Logger) (*LocalClient, error) {
+	// For Vitess databases, create a PlanetScale engine with a client factory
+	// that points at the API base URL from metadata (e.g., "http://localscale:8080").
+	// TargetDSN is the vtgate MySQL DSN for SHOW VITESS_MIGRATIONS.
+	var psEngine engine.Engine
+	if cfg.Type == storage.DatabaseTypeVitess {
+		apiURL := cfg.Metadata["api_url"]
+		psEngine = planetscale.NewWithClient(logger, func(tokenName, tokenValue string) (psclient.PSClient, error) {
+			return psclient.NewPSClientWithBaseURL(tokenName, tokenValue, apiURL)
+		})
+	}
+
 	return &LocalClient{
 		config:            cfg,
 		storage:           stor,
 		spiritEngine:      spirit.New(spirit.Config{Logger: logger}),
+		planetscaleEngine: psEngine,
 		logger:            logger,
 		heartbeatInterval: 10 * time.Second,
 	}, nil
@@ -150,6 +176,26 @@ func NewLocalClient(cfg LocalConfig, stor storage.Storage, logger *slog.Logger) 
 // apply/task records in the same database as the API layer.
 func (c *LocalClient) IsRemote() bool { return false }
 
+// protoEngine returns the proto engine type based on database configuration.
+func (c *LocalClient) protoEngine() ternv1.Engine {
+	if c.config.Type == storage.DatabaseTypeVitess {
+		return ternv1.Engine_ENGINE_PLANETSCALE
+	}
+	return ternv1.Engine_ENGINE_SPIRIT
+}
+
+// engineNameToProto converts a storage engine name to the proto enum.
+func engineNameToProto(name string) (ternv1.Engine, error) {
+	switch name {
+	case storage.EnginePlanetScale:
+		return ternv1.Engine_ENGINE_PLANETSCALE, nil
+	case storage.EngineSpirit:
+		return ternv1.Engine_ENGINE_SPIRIT, nil
+	default:
+		return 0, fmt.Errorf("unknown engine: %s", name)
+	}
+}
+
 // Close closes the client and releases resources.
 func (c *LocalClient) Close() error {
 	// LocalClient doesn't own storage, so nothing to close
@@ -158,7 +204,10 @@ func (c *LocalClient) Close() error {
 
 // credentials returns engine credentials from the client config.
 func (c *LocalClient) credentials() *engine.Credentials {
-	return &engine.Credentials{DSN: c.config.TargetDSN}
+	return &engine.Credentials{
+		DSN:      c.config.TargetDSN,
+		Metadata: c.config.Metadata,
+	}
 }
 
 // Health checks the service health.
@@ -226,6 +275,66 @@ func (c *LocalClient) Plan(ctx context.Context, req *ternv1.PlanRequest) (*ternv
 		}
 	}
 
+	// Build per-namespace plan data from the engine's changes.
+	// For Vitess, each namespace is a keyspace. For Spirit, there's one namespace.
+	namespaces := make(map[string]*storage.NamespacePlanData)
+	for _, sc := range result.Changes {
+		ns := sc.Namespace
+		if ns == "" {
+			ns = c.config.Database
+		}
+		nsData := namespaces[ns]
+		if nsData == nil {
+			nsData = &storage.NamespacePlanData{}
+			namespaces[ns] = nsData
+		}
+		for _, tc := range sc.TableChanges {
+			nsData.Tables = append(nsData.Tables, storage.TableChange{
+				Table:     tc.Table,
+				DDL:       tc.DDL,
+				Operation: tc.Operation,
+			})
+		}
+		// Store VSchema from schema files if present for this namespace.
+		if nsFiles, ok := schemaFiles[ns]; ok && nsFiles != nil {
+			if vs, ok := nsFiles.Files["vschema.json"]; ok {
+				nsData.VSchema = json.RawMessage(vs)
+			}
+		}
+	}
+	// Store original schema for rollback support.
+	// For single-namespace (Spirit), attach to that namespace.
+	// For multi-namespace (Vitess), original schema is per-keyspace from the engine.
+	if result.OriginalSchema != nil {
+		if len(namespaces) == 1 {
+			for _, nsData := range namespaces {
+				nsData.OriginalSchema = result.OriginalSchema
+			}
+		}
+	}
+	if len(namespaces) == 0 {
+		namespaces[c.config.Database] = &storage.NamespacePlanData{
+			Tables:         ddlChanges,
+			OriginalSchema: result.OriginalSchema,
+		}
+	}
+
+	// Don't store empty plans — no DDL changes, no VSchema changes.
+	hasVSchemaChanges := false
+	for _, ns := range namespaces {
+		if len(ns.VSchema) > 0 {
+			hasVSchemaChanges = true
+			break
+		}
+	}
+	if len(ddlChanges) == 0 && !hasVSchemaChanges {
+		c.logger.Info("Plan: no changes, skipping storage", "plan_id", result.PlanID, "database", c.config.Database)
+		return &ternv1.PlanResponse{
+			PlanId: result.PlanID,
+			Engine: c.protoEngine(),
+		}, nil
+	}
+
 	plan := &storage.Plan{
 		PlanIdentifier: result.PlanID,
 		Database:       c.config.Database,
@@ -234,13 +343,8 @@ func (c *LocalClient) Plan(ctx context.Context, req *ternv1.PlanRequest) (*ternv
 		PullRequest:    int(req.PullRequest),
 		Environment:    req.Environment,
 		SchemaFiles:    schemaFiles,
-		Namespaces: map[string]*storage.NamespacePlanData{
-			c.config.Database: {
-				Tables:         ddlChanges,
-				OriginalSchema: result.OriginalSchema,
-			},
-		},
-		CreatedAt: time.Now(),
+		Namespaces:     namespaces,
+		CreatedAt:      time.Now(),
 	}
 	c.logger.Info("Plan: storing plan",
 		"plan_id", result.PlanID,
@@ -282,9 +386,9 @@ func (c *LocalClient) Plan(ctx context.Context, req *ternv1.PlanRequest) (*ternv
 	}
 
 	// Convert lint violations to proto
-	warnings := make([]*ternv1.LintViolation, len(result.LintViolations))
+	violations := make([]*ternv1.LintViolation, len(result.LintViolations))
 	for i, w := range result.LintViolations {
-		warnings[i] = &ternv1.LintViolation{
+		violations[i] = &ternv1.LintViolation{
 			Table:    w.Table,
 			Column:   w.Column,
 			Linter:   w.Linter,
@@ -295,9 +399,9 @@ func (c *LocalClient) Plan(ctx context.Context, req *ternv1.PlanRequest) (*ternv
 
 	return &ternv1.PlanResponse{
 		PlanId:         result.PlanID,
-		Engine:         ternv1.Engine_ENGINE_SPIRIT,
+		Engine:         c.protoEngine(),
 		Changes:        changes,
-		LintViolations: warnings,
+		LintViolations: violations,
 	}, nil
 }
 
@@ -353,14 +457,27 @@ func (c *LocalClient) Apply(ctx context.Context, req *ternv1.ApplyRequest) (*ter
 		options = make(map[string]string)
 	}
 
+	// Read environment and caller from proto fields (preferred), fall back to options.
+	environment := req.Environment
+	if environment == "" {
+		environment = options["environment"]
+	}
+	caller := req.Caller
+	if caller == "" {
+		caller = options["caller"]
+	}
+
 	// Detect atomic mode (--defer-cutover)
 	deferCutover := options["defer_cutover"] == "true"
 	allowUnsafe := options["allow_unsafe"] == "true"
 
-	// Build typed ApplyOptions for storage (booleans, not strings)
+	// Build typed ApplyOptions for storage (booleans, not strings).
+	// Revert window is ON by default — only disabled when skip_revert is explicitly set.
+	skipRevert := options["skip_revert"] == "true"
 	applyOpts := storage.ApplyOptions{
 		DeferCutover: deferCutover,
 		AllowUnsafe:  allowUnsafe,
+		SkipRevert:   skipRevert,
 	}
 	optionsJSON := storage.MarshalApplyOptions(applyOpts)
 
@@ -371,10 +488,11 @@ func (c *LocalClient) Apply(ctx context.Context, req *ternv1.ApplyRequest) (*ter
 		PlanID:          plan.ID,
 		Database:        plan.Database,
 		DatabaseType:    plan.DatabaseType,
+		Deployment:      c.config.Database,
 		Repository:      plan.Repository,
 		PullRequest:     plan.PullRequest,
-		Environment:     options["environment"],
-		Caller:          options["caller"],
+		Environment:     environment,
+		Caller:          caller,
 		Engine:          eng.Name(),
 		State:           state.Apply.Pending,
 		Options:         optionsJSON,
@@ -391,7 +509,9 @@ func (c *LocalClient) Apply(ctx context.Context, req *ternv1.ApplyRequest) (*ter
 	c.logApplyEvent(ctx, applyID, nil, storage.LogLevelInfo, storage.LogEventInfo, storage.LogSourceSchemaBot,
 		fmt.Sprintf("Apply started: %s", applyIdentifier), "", state.Apply.Pending)
 
-	// Create one Task per DDLChange in the plan
+	// Create one Task per DDLChange in the plan.
+	// For VSchema-only deploys (0 DDL changes), create a synthetic task per
+	// keyspace with VSchema changes so the progress API has something to track.
 	c.logger.Info("Apply: creating tasks",
 		"plan_id", plan.PlanIdentifier,
 		"ddl_change_count", len(ddlChanges),
@@ -403,6 +523,21 @@ func (c *LocalClient) Apply(ctx context.Context, req *ternv1.ApplyRequest) (*ter
 			"ddl", ddlChange.DDL,
 		)
 	}
+
+	// Add synthetic VSchema tasks when there are VSchema changes but no DDL
+	// for a given namespace. This ensures the progress API tracks VSchema-only deploys.
+	if len(ddlChanges) == 0 {
+		for ns, nsData := range plan.Namespaces {
+			if len(nsData.VSchema) > 0 {
+				ddlChanges = append(ddlChanges, storage.TableChange{
+					Table:     "vschema:" + ns,
+					Namespace: ns,
+					Operation: "vschema_update",
+				})
+			}
+		}
+	}
+
 	tasks := make([]*storage.Task, len(ddlChanges))
 	for i, ddlChange := range ddlChanges {
 		taskIdentifier := "task-" + strings.ReplaceAll(uuid.New().String(), "-", "")[:16]
@@ -419,6 +554,7 @@ func (c *LocalClient) Apply(ctx context.Context, req *ternv1.ApplyRequest) (*ter
 			State:          state.Task.Pending,
 			Options:        optionsJSON,
 			TableName:      ddlChange.Table,
+			Namespace:      ddlChange.Namespace,
 			DDL:            ddlChange.DDL,
 			DDLAction:      ddlChange.Operation,
 			CreatedAt:      now,
@@ -432,14 +568,22 @@ func (c *LocalClient) Apply(ctx context.Context, req *ternv1.ApplyRequest) (*ter
 	}
 
 	// Start apply in background with cancellable context (Stop() cancels this)
-	applyCtx, cancelApply := context.WithCancel(context.Background())
+	applyCtx, cancelApply := context.WithCancel(context.WithoutCancel(ctx))
+	c.cancelMu.Lock()
 	c.cancelApply = cancelApply
-	if deferCutover {
-		// Atomic mode: all DDLs in one Spirit call, atomic cutover
-		go c.executeApplyAtomic(applyCtx, apply, tasks, plan, options)
+	c.cancelMu.Unlock()
+	if deferCutover || c.config.Type == storage.DatabaseTypeVitess {
+		// Atomic mode: all DDLs in one engine call.
+		// For Spirit: atomic cutover (--defer-cutover).
+		// For Vitess: always atomic — one deploy request per apply.
+		go c.runWithRecovery(applyCtx, apply, tasks, func() {
+			c.executeApplyAtomic(applyCtx, apply, tasks, plan, options)
+		})
 	} else {
 		// Independent mode: each DDL runs separately, cuts over independently
-		go c.executeApplySequential(applyCtx, apply, tasks, plan, options)
+		go c.runWithRecovery(applyCtx, apply, tasks, func() {
+			c.executeApplySequential(applyCtx, apply, tasks, plan, options)
+		})
 	}
 
 	return &ternv1.ApplyResponse{
@@ -453,8 +597,9 @@ func (c *LocalClient) getEngine() engine.Engine {
 	switch c.config.Type {
 	case storage.DatabaseTypeMySQL:
 		return c.spiritEngine
+	case storage.DatabaseTypeVitess:
+		return c.planetscaleEngine
 	default:
-		// For vitess, return nil - not supported in local mode
 		return nil
 	}
 }
@@ -505,7 +650,8 @@ func (c *LocalClient) Progress(ctx context.Context, req *ternv1.ProgressRequest)
 		switch {
 		case t.State == state.Task.Running ||
 			t.State == state.Task.WaitingForCutover ||
-			t.State == state.Task.CuttingOver:
+			t.State == state.Task.CuttingOver ||
+			t.State == state.Task.RevertWindow:
 			// Prefer actively running/waiting tasks
 			activeTask = t
 		case t.State == state.Task.Stopped && stoppedTask == nil:
@@ -517,6 +663,12 @@ func (c *LocalClient) Progress(ctx context.Context, req *ternv1.ProgressRequest)
 		case state.IsTerminalTaskState(t.State) && latestTask == nil:
 			// Track most recent terminal task as final fallback
 			latestTask = t
+		default:
+			// Unknown/new state — still select as fallback to avoid losing engine context
+			c.logger.Warn("unexpected task state in progress", "task_id", t.TaskIdentifier, "state", t.State)
+			if latestTask == nil {
+				latestTask = t
+			}
 		}
 		// Stop searching once we find a running task
 		if activeTask != nil {
@@ -537,7 +689,8 @@ func (c *LocalClient) Progress(ctx context.Context, req *ternv1.ProgressRequest)
 
 	if activeTask == nil {
 		return &ternv1.ProgressResponse{
-			State: ternv1.State_STATE_NO_ACTIVE_CHANGE,
+			State:  ternv1.State_STATE_NO_ACTIVE_CHANGE,
+			Engine: c.protoEngine(),
 		}, nil
 	}
 	c.logger.Info("Progress: selected task", "task_id", activeTask.TaskIdentifier, "state", activeTask.State, "apply_id", activeTask.ApplyID)
@@ -548,13 +701,38 @@ func (c *LocalClient) Progress(ctx context.Context, req *ternv1.ProgressRequest)
 	creds := c.credentials()
 	eng := c.getEngine()
 
-	// Get live progress from engine for the currently running task
+	// Get live progress from engine for the currently running task.
+	// For Vitess, reconstruct ResumeState from vitess_apply_data so the engine
+	// can poll the deploy request and query SHOW VITESS_MIGRATIONS.
 	var engineResult *engine.ProgressResult
-	if eng != nil && activeTask.State != state.Task.Pending {
-		result, err := eng.Progress(ctx, &engine.ProgressRequest{
+	// Query engine for live progress. For Vitess, also query during pending state
+	// to surface PlanetScale states (creating branch, deploy request, etc.).
+	queryDuringPending := c.config.Type == storage.DatabaseTypeVitess
+	if eng != nil && (activeTask.State != state.Task.Pending || queryDuringPending) {
+		progressReq := &engine.ProgressRequest{
 			Database:    c.config.Database,
 			Credentials: creds,
-		})
+		}
+		if c.config.Type == storage.DatabaseTypeVitess {
+			vad, vadErr := c.storage.VitessApplyData().GetByApplyID(ctx, activeTask.ApplyID)
+			switch {
+			case vadErr != nil:
+				c.logger.Error("failed to load VitessApplyData for progress", "apply_id", activeTask.ApplyID, "error", vadErr)
+			case vad == nil:
+				c.logger.Warn("VitessApplyData not found for progress — apply may still be initializing", "apply_id", activeTask.ApplyID)
+			default:
+				meta, _ := json.Marshal(map[string]any{
+					"branch_name":        vad.BranchName,
+					"deploy_request_id":  vad.DeployRequestID,
+					"deploy_request_url": vad.DeployRequestURL,
+				})
+				progressReq.ResumeState = &engine.ResumeState{
+					MigrationContext: vad.MigrationContext,
+					Metadata:         string(meta),
+				}
+			}
+		}
+		result, err := eng.Progress(ctx, progressReq)
 		if err == nil {
 			engineResult = result
 			c.logger.Info("Progress: engine returned", "engine_state", result.State, "message", result.Message, "task_id", activeTask.TaskIdentifier, "storage_state", activeTask.State)
@@ -569,7 +747,27 @@ func (c *LocalClient) Progress(ctx context.Context, req *ternv1.ProgressRequest)
 				if result.State.IsTerminal() && activeTask.CompletedAt == nil {
 					activeTask.CompletedAt = &now
 				}
-				_ = c.storage.Tasks().Update(ctx, activeTask)
+				if err := c.storage.Tasks().Update(ctx, activeTask); err != nil {
+					c.logger.Warn("failed to update task state from progress poll", "task_id", activeTask.TaskIdentifier, "state", activeTask.State, "error", err)
+				}
+			}
+
+			// Also update the apply record if the engine reports a terminal state
+			// but the apply hasn't been updated yet. This can happen when the
+			// progress handler detects completion before the background polling
+			// goroutine persists it.
+			if result.State.IsTerminal() {
+				apply, _ := c.storage.Applies().GetByApplyIdentifier(ctx, req.ApplyId)
+				if apply != nil && !state.IsTerminalApplyState(apply.State) {
+					now := time.Now()
+					apply.State = engineStateToStorage(result.State)
+					apply.CompletedAt = &now
+					apply.UpdatedAt = now
+					if err := c.storage.Applies().Update(ctx, apply); err != nil {
+						c.logger.Warn("failed to update apply from progress poll", "apply_id", apply.ApplyIdentifier, "state", apply.State, "apply_db_id", apply.ID, "error", err)
+					}
+					c.logger.Info("apply state updated from progress polling", "apply_id", apply.ApplyIdentifier, "state", apply.State)
+				}
 			}
 		}
 	}
@@ -594,6 +792,7 @@ func (c *LocalClient) Progress(ctx context.Context, req *ternv1.ProgressRequest)
 		tp := &ternv1.TableProgress{
 			TableName: t.TableName,
 			Ddl:       t.DDL,
+			Namespace: t.Namespace,
 			Status:    t.State,
 			TaskId:    t.TaskIdentifier,
 		}
@@ -609,15 +808,33 @@ func (c *LocalClient) Progress(ctx context.Context, req *ternv1.ProgressRequest)
 			tp.IsInstant = et.IsInstant
 			tp.ProgressDetail = et.ProgressDetail
 
+			// Update task timestamps from engine if not already set.
+			updated := false
+			if et.StartedAt != nil && t.StartedAt == nil {
+				t.StartedAt = et.StartedAt
+				updated = true
+			}
+			if et.CompletedAt != nil && t.CompletedAt == nil {
+				t.CompletedAt = et.CompletedAt
+				updated = true
+			}
+			if updated {
+				t.UpdatedAt = time.Now()
+				if err := c.storage.Tasks().Update(ctx, t); err != nil {
+					c.logger.Error("failed to update task timestamps", "task_id", t.TaskIdentifier, "error", err)
+				}
+			}
+
 			// Build shards if available
 			shards := make([]*ternv1.ShardProgress, len(et.Shards))
 			for j, sh := range et.Shards {
 				shards[j] = &ternv1.ShardProgress{
-					Shard:      sh.Shard,
-					Status:     sh.State,
-					RowsCopied: sh.RowsCopied,
-					RowsTotal:  sh.RowsTotal,
-					EtaSeconds: sh.ETASeconds,
+					Shard:           sh.Shard,
+					Status:          sh.State,
+					RowsCopied:      sh.RowsCopied,
+					RowsTotal:       sh.RowsTotal,
+					EtaSeconds:      sh.ETASeconds,
+					CutoverAttempts: int32(sh.CutoverAttempts),
 				}
 			}
 			tp.Shards = shards
@@ -633,8 +850,21 @@ func (c *LocalClient) Progress(ctx context.Context, req *ternv1.ProgressRequest)
 		tables = append(tables, tp)
 	}
 
-	// Derive overall state from ALL tasks in this apply
+	// Derive overall state from ALL tasks in this apply.
+	// If tasks are all pending, check the apply record for a more specific state
+	// (e.g., creating_branch, creating_deploy_request during PlanetScale setup).
 	overallState := deriveOverallState(currentApplyTasks)
+	// For Vitess setup phases, the apply record has a more specific state
+	// (creating_branch, applying_branch_changes, creating_deploy_request)
+	// than what task states alone can derive. Check the apply record when
+	// tasks are still pending or when the overall state doesn't yet reflect
+	// real progress (e.g., engine returns "running" during setup).
+	if applyRec, err := c.storage.Applies().Get(ctx, activeTask.ApplyID); err == nil && applyRec != nil {
+		switch applyRec.State {
+		case state.Apply.CreatingBranch, state.Apply.ApplyingBranchChanges, state.Apply.CreatingDeployRequest:
+			overallState = applyRec.State
+		}
+	}
 
 	// If no error from engine, check stored task errors (for restart recovery)
 	if errorMessage == "" {
@@ -648,15 +878,21 @@ func (c *LocalClient) Progress(ctx context.Context, req *ternv1.ProgressRequest)
 
 	resp := &ternv1.ProgressResponse{
 		State:        storageStateToProto(overallState),
-		Engine:       ternv1.Engine_ENGINE_SPIRIT,
+		Engine:       c.protoEngine(), // default from client config
 		Tables:       tables,
 		Summary:      summary,
 		ErrorMessage: errorMessage,
 	}
 
-	// Populate apply_id and volume from the apply record.
+	// Populate apply_id, engine, and volume from the apply record.
+	// The apply record's engine is the source of truth (set at apply creation time).
 	if apply, err := c.storage.Applies().Get(ctx, activeTask.ApplyID); err == nil && apply != nil {
 		resp.ApplyId = apply.ApplyIdentifier
+		if eng, err := engineNameToProto(apply.Engine); err != nil {
+			return nil, fmt.Errorf("invalid engine on apply %s: %w", apply.ApplyIdentifier, err)
+		} else {
+			resp.Engine = eng
+		}
 		opts := storage.ParseApplyOptions(apply.Options)
 		if opts.Volume > 0 {
 			resp.Volume = int32(opts.Volume)

--- a/pkg/tern/local_control.go
+++ b/pkg/tern/local_control.go
@@ -2,6 +2,7 @@ package tern
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -52,10 +53,7 @@ func (c *LocalClient) Cutover(ctx context.Context, req *ternv1.CutoverRequest) (
 	c.logApplyEvent(ctx, task.ApplyID, nil, storage.LogLevelInfo, storage.LogEventCutoverTriggered, storage.LogSourceSchemaBot,
 		"Cutover triggered", "", "")
 
-	_, err = eng.Cutover(ctx, &engine.ControlRequest{
-		Database:    c.config.Database,
-		Credentials: creds,
-	})
+	_, err = eng.Cutover(ctx, c.buildControlRequest(ctx, task, creds))
 	if err != nil {
 		c.logApplyEvent(ctx, task.ApplyID, nil, storage.LogLevelError, storage.LogEventError, storage.LogSourceSchemaBot,
 			fmt.Sprintf("Cutover failed: %v", err), "", "")
@@ -67,6 +65,7 @@ func (c *LocalClient) Cutover(ctx context.Context, req *ternv1.CutoverRequest) (
 
 // Stop pauses an in-progress schema change.
 func (c *LocalClient) Stop(ctx context.Context, req *ternv1.StopRequest) (*ternv1.StopResponse, error) {
+	c.logger.Info("Stop requested", "database", c.config.Database, "type", c.config.Type, "apply_id", req.ApplyId)
 	tasks, err := c.storage.Tasks().GetByDatabase(ctx, c.config.Database)
 	if err != nil {
 		return nil, fmt.Errorf("get tasks failed: %w", err)
@@ -88,25 +87,46 @@ func (c *LocalClient) Stop(ctx context.Context, req *ternv1.StopRequest) (*ternv
 	// Stop the engine first, THEN snapshot progress.
 	// eng.Stop() blocks until Spirit's goroutine exits, so by the time it
 	// returns the progress data reflects the true final state of each table.
-	c.stopEngineForTasks(ctx, eng, creds, tasks, targetApplyID)
+	if err := c.stopEngineForTasks(ctx, eng, creds, tasks, targetApplyID); err != nil {
+		return nil, fmt.Errorf("engine stop failed: %w", err)
+	}
 
 	// Cancel the apply goroutine's context so it stops iterating over tasks.
 	// Without this, executeApplySequential would continue to the next table
 	// after Spirit's runner exits, racing with the resume goroutine.
+	c.cancelMu.Lock()
 	if c.cancelApply != nil {
 		c.cancelApply()
 		c.cancelApply = nil
 	}
+	c.cancelMu.Unlock()
 
 	// Snapshot progress AFTER Spirit has fully stopped to preserve row copy progress.
 	engineTableProgress := c.snapshotEngineProgress(ctx, eng, creds)
 
-	// Mark all non-terminal tasks as STOPPED and preserve their engine progress.
-	stoppedCount, skippedCount, applyID := c.markTasksStopped(ctx, tasks, targetApplyID, engineTableProgress)
+	// For Vitess/PlanetScale, stopping means cancelling the deploy request —
+	// this is permanent (not resumable). Use "cancelled" instead of "stopped".
+	terminalState := state.Task.Stopped
+	if c.config.Type == storage.DatabaseTypeVitess {
+		terminalState = state.Task.Cancelled
+	}
+
+	stoppedCount, skippedCount, applyID := c.markTasksWithState(ctx, tasks, targetApplyID, engineTableProgress, terminalState)
 
 	if applyID > 0 && stoppedCount > 0 {
+		eventMsg := fmt.Sprintf("Stop requested: %d tasks stopped, %d skipped", stoppedCount, skippedCount)
+		if terminalState == state.Task.Cancelled {
+			eventMsg = fmt.Sprintf("Cancel requested: %d tasks cancelled, %d skipped (deploy request cancelled)", stoppedCount, skippedCount)
+
+			// For Vitess: set the apply state to cancelled now. The apply
+			// goroutine will see a context cancellation error from the engine
+			// and call failApplyWithTasks, but we set cancelled first so the
+			// apply record reflects the true outcome. failApplyWithTasks skips
+			// tasks already in terminal state, so the cancelled tasks are preserved.
+			c.markApplyCancelled(ctx, applyID)
+		}
 		c.logApplyEvent(ctx, applyID, nil, storage.LogLevelInfo, storage.LogEventStopRequested, storage.LogSourceSchemaBot,
-			fmt.Sprintf("Stop requested: %d tasks stopped, %d skipped", stoppedCount, skippedCount), "", "")
+			eventMsg, "", "")
 	}
 
 	if stoppedCount == 0 && skippedCount == 0 {
@@ -127,32 +147,41 @@ func (c *LocalClient) Stop(ctx context.Context, req *ternv1.StopRequest) (*ternv
 }
 
 // stopEngineForTasks calls eng.Stop() if any targeted task is actively running.
-func (c *LocalClient) stopEngineForTasks(ctx context.Context, eng engine.Engine, creds *engine.Credentials, tasks []*storage.Task, targetApplyID int64) {
+// Returns an error if the engine stop fails (e.g., PlanetScale deploy request
+// cancellation failed). For Spirit, stop errors are non-fatal since the runner
+// may have already exited.
+func (c *LocalClient) stopEngineForTasks(ctx context.Context, eng engine.Engine, creds *engine.Credentials, tasks []*storage.Task, targetApplyID int64) error {
 	if eng == nil {
-		return
+		c.logger.Error("stopEngineForTasks: engine is nil")
+		return fmt.Errorf("no engine configured for type: %s", c.config.Type)
 	}
 	for _, task := range tasks {
 		if targetApplyID > 0 && task.ApplyID != targetApplyID {
 			continue
 		}
 		if state.IsTerminalTaskState(task.State) {
+			c.logger.Info("skipping terminal task in stop", "task_id", task.TaskIdentifier, "state", task.State)
 			continue
 		}
 		if task.State == state.Task.Running ||
 			task.State == state.Task.WaitingForCutover ||
 			task.State == state.Task.CuttingOver {
-			if _, err := eng.Stop(ctx, &engine.ControlRequest{Database: c.config.Database, Credentials: creds}); err != nil {
-				c.logger.Warn("engine stop returned error", "task_id", task.TaskIdentifier, "error", err)
+			req := c.buildControlRequest(ctx, task, creds)
+			if _, err := eng.Stop(ctx, req); err != nil {
+				c.logger.Warn("engine stop returned error (runner may have already exited)",
+					"task_id", task.TaskIdentifier, "error", err)
 			}
-			return
+			return nil
 		}
 	}
+	return nil
 }
 
 // snapshotEngineProgress captures per-table progress from the engine after stopping.
 func (c *LocalClient) snapshotEngineProgress(ctx context.Context, eng engine.Engine, creds *engine.Credentials) map[string]*engine.TableProgress {
 	result := make(map[string]*engine.TableProgress)
 	if eng == nil {
+		c.logger.Error("snapshotEngineProgress: engine is nil")
 		return result
 	}
 	progress, _ := eng.Progress(ctx, &engine.ProgressRequest{
@@ -170,7 +199,7 @@ func (c *LocalClient) snapshotEngineProgress(ctx context.Context, eng engine.Eng
 
 // markTasksStopped sets all non-terminal targeted tasks to STOPPED, preserving engine progress.
 // Returns (stopped count, skipped count, apply ID for logging).
-func (c *LocalClient) markTasksStopped(ctx context.Context, tasks []*storage.Task, targetApplyID int64, engineProgress map[string]*engine.TableProgress) (int64, int64, int64) {
+func (c *LocalClient) markTasksWithState(ctx context.Context, tasks []*storage.Task, targetApplyID int64, engineProgress map[string]*engine.TableProgress, newState string) (int64, int64, int64) {
 	var stoppedCount, skippedCount int64
 	var applyID int64
 
@@ -196,8 +225,8 @@ func (c *LocalClient) markTasksStopped(ctx context.Context, tasks []*storage.Tas
 			task.ETASeconds = int(et.ETASeconds)
 		}
 
-		c.transitionTaskState(ctx, task, task.ApplyID, state.Task.Stopped,
-			fmt.Sprintf("Task %s stopped", task.TaskIdentifier))
+		c.transitionTaskState(ctx, task, task.ApplyID, newState,
+			fmt.Sprintf("Task %s %s", task.TaskIdentifier, newState))
 
 		stoppedCount++
 	}
@@ -213,7 +242,9 @@ func (c *LocalClient) handleStopAllCompleted(ctx context.Context, applyID int64,
 		apply.State = state.Apply.Completed
 		apply.CompletedAt = &now
 		apply.UpdatedAt = now
-		_ = c.storage.Applies().Update(ctx, apply)
+		if err := c.storage.Applies().Update(ctx, apply); err != nil {
+			c.logger.Error("failed to update apply state", "apply_id", apply.ApplyIdentifier, "state", state.Apply.Completed, "error", err)
+		}
 
 		c.logApplyEvent(ctx, applyID, nil, storage.LogLevelInfo, storage.LogEventStateTransition, storage.LogSourceSchemaBot,
 			"All tasks completed before stop took effect", "", state.Apply.Completed)
@@ -225,6 +256,25 @@ func (c *LocalClient) handleStopAllCompleted(ctx context.Context, applyID int64,
 		StoppedCount: 0,
 		SkippedCount: skippedCount,
 	}, nil
+}
+
+// markApplyCancelled sets the apply to cancelled. Called by Stop() for Vitess
+// databases where cancelling the deploy request is permanent. This runs before
+// the apply goroutine sees the context cancellation, so failApplyWithTasks
+// will find the apply already terminal and leave it alone.
+func (c *LocalClient) markApplyCancelled(ctx context.Context, applyID int64) {
+	apply, err := c.storage.Applies().Get(ctx, applyID)
+	if err != nil || apply == nil {
+		c.logger.Error("failed to load apply for cancellation", "apply_id", applyID, "error", err)
+		return
+	}
+	now := time.Now()
+	apply.State = state.Apply.Cancelled
+	apply.CompletedAt = &now
+	apply.UpdatedAt = now
+	if err := c.storage.Applies().Update(ctx, apply); err != nil {
+		c.logger.Error("failed to mark apply as cancelled", "apply_id", apply.ApplyIdentifier, "error", err)
+	}
 }
 
 // controlSetup resolves the active task, credentials, and engine for a control operation.
@@ -242,6 +292,30 @@ func (c *LocalClient) controlSetup(ctx context.Context) (*storage.Task, *engine.
 		return nil, nil, nil, fmt.Errorf("no engine configured for type: %s", c.config.Type)
 	}
 	return task, c.credentials(), eng, nil
+}
+
+// buildControlRequest creates a ControlRequest with ResumeState from VitessApplyData.
+// For PlanetScale, the engine needs the deploy request ID (in ResumeState.Metadata)
+// to execute control operations (cutover, revert, skip-revert).
+func (c *LocalClient) buildControlRequest(ctx context.Context, task *storage.Task, creds *engine.Credentials) *engine.ControlRequest {
+	req := &engine.ControlRequest{
+		Database:    c.config.Database,
+		Credentials: creds,
+	}
+	if c.config.Type == storage.DatabaseTypeVitess {
+		if vad, err := c.storage.VitessApplyData().GetByApplyID(ctx, task.ApplyID); err == nil {
+			meta, _ := json.Marshal(map[string]any{
+				"branch_name":        vad.BranchName,
+				"deploy_request_id":  vad.DeployRequestID,
+				"deploy_request_url": vad.DeployRequestURL,
+			})
+			req.ResumeState = &engine.ResumeState{
+				MigrationContext: vad.MigrationContext,
+				Metadata:         string(meta),
+			}
+		}
+	}
+	return req
 }
 
 // Volume modifies the schema change speed/concurrency in-flight.
@@ -273,12 +347,12 @@ func (c *LocalClient) Volume(ctx context.Context, req *ternv1.VolumeRequest) (*t
 
 // Revert reverts a completed schema change during the revert window.
 func (c *LocalClient) Revert(ctx context.Context, req *ternv1.RevertRequest) (*ternv1.RevertResponse, error) {
-	_, creds, eng, err := c.controlSetup(ctx)
+	task, creds, eng, err := c.controlSetup(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	if _, err = eng.Revert(ctx, &engine.ControlRequest{Database: c.config.Database, Credentials: creds}); err != nil {
+	if _, err = eng.Revert(ctx, c.buildControlRequest(ctx, task, creds)); err != nil {
 		return nil, fmt.Errorf("revert failed: %w", err)
 	}
 	return &ternv1.RevertResponse{Accepted: true}, nil
@@ -286,12 +360,12 @@ func (c *LocalClient) Revert(ctx context.Context, req *ternv1.RevertRequest) (*t
 
 // SkipRevert skips the revert window and finalizes the schema change.
 func (c *LocalClient) SkipRevert(ctx context.Context, req *ternv1.SkipRevertRequest) (*ternv1.SkipRevertResponse, error) {
-	_, creds, eng, err := c.controlSetup(ctx)
+	task, creds, eng, err := c.controlSetup(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	if _, err = eng.SkipRevert(ctx, &engine.ControlRequest{Database: c.config.Database, Credentials: creds}); err != nil {
+	if _, err = eng.SkipRevert(ctx, c.buildControlRequest(ctx, task, creds)); err != nil {
 		return nil, fmt.Errorf("skip revert failed: %w", err)
 	}
 	return &ternv1.SkipRevertResponse{Accepted: true}, nil

--- a/pkg/tern/local_control_resume.go
+++ b/pkg/tern/local_control_resume.go
@@ -113,7 +113,9 @@ func (c *LocalClient) Start(ctx context.Context, req *ternv1.StartRequest) (*ter
 		apply.State = state.Apply.Completed
 		apply.CompletedAt = &now
 		apply.UpdatedAt = now
-		_ = c.storage.Applies().Update(ctx, apply)
+		if err := c.storage.Applies().Update(ctx, apply); err != nil {
+			c.logger.Error("failed to update apply state", "apply_id", apply.ApplyIdentifier, "state", state.Apply.Completed, "error", err)
+		}
 		c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventStateTransition, storage.LogSourceSchemaBot,
 			"All tasks already completed on resume (re-plan shows no changes)", apply.State, state.Apply.Completed)
 
@@ -142,7 +144,9 @@ func (c *LocalClient) Start(ctx context.Context, req *ternv1.StartRequest) (*ter
 
 		apply.State = state.Apply.Running
 		apply.UpdatedAt = now
-		_ = c.storage.Applies().Update(ctx, apply)
+		if err := c.storage.Applies().Update(ctx, apply); err != nil {
+			c.logger.Error("failed to update apply state", "apply_id", apply.ApplyIdentifier, "state", state.Apply.Running, "error", err)
+		}
 
 		c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventStartRequested, storage.LogSourceSchemaBot,
 			fmt.Sprintf("Resume requested (sequential): %d tasks to resume, %d already completed", len(resumeTasks), completedCount), oldApplyState, state.Apply.Running)
@@ -386,7 +390,9 @@ func (c *LocalClient) launchAtomicResume(ctx context.Context, apply *storage.App
 
 	apply.State = state.Apply.Running
 	apply.UpdatedAt = now
-	_ = c.storage.Applies().Update(ctx, apply)
+	if err := c.storage.Applies().Update(ctx, apply); err != nil {
+		c.logger.Error("failed to update apply state", "apply_id", apply.ApplyIdentifier, "state", state.Apply.Running, "error", err)
+	}
 
 	c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventStateTransition, storage.LogSourceSchemaBot,
 		logMessage, oldApplyState, state.Apply.Running)
@@ -394,7 +400,7 @@ func (c *LocalClient) launchAtomicResume(ctx context.Context, apply *storage.App
 	stopHeartbeat := c.startApplyHeartbeat(context.Background(), apply)
 	go func() {
 		defer stopHeartbeat()
-		c.pollForCompletionAtomic(context.Background(), apply, tasks, creds)
+		c.pollForCompletionAtomic(context.Background(), apply, tasks, creds, nil)
 	}()
 	return nil
 }
@@ -414,7 +420,9 @@ func (c *LocalClient) ResumeApply(ctx context.Context, apply *storage.Apply) err
 			"apply_id", apply.ApplyIdentifier)
 		apply.State = state.Apply.Failed
 		apply.ErrorMessage = "no tasks found during recovery"
-		_ = c.storage.Applies().Update(ctx, apply)
+		if err := c.storage.Applies().Update(ctx, apply); err != nil {
+			c.logger.Error("failed to update apply state", "apply_id", apply.ApplyIdentifier, "state", state.Apply.Failed, "error", err)
+		}
 		return nil
 	}
 
@@ -426,7 +434,9 @@ func (c *LocalClient) ResumeApply(ctx context.Context, apply *storage.Apply) err
 			"plan_id", apply.PlanID)
 		apply.State = state.Apply.Failed
 		apply.ErrorMessage = "plan not found during recovery"
-		_ = c.storage.Applies().Update(ctx, apply)
+		if err := c.storage.Applies().Update(ctx, apply); err != nil {
+			c.logger.Error("failed to update apply state", "apply_id", apply.ApplyIdentifier, "state", state.Apply.Failed, "error", err)
+		}
 		return nil
 	}
 
@@ -456,7 +466,9 @@ func (c *LocalClient) ResumeApply(ctx context.Context, apply *storage.Apply) err
 		apply.State = state.Apply.Completed
 		apply.CompletedAt = &now
 		apply.UpdatedAt = now
-		_ = c.storage.Applies().Update(ctx, apply)
+		if err := c.storage.Applies().Update(ctx, apply); err != nil {
+			c.logger.Error("failed to update apply state", "apply_id", apply.ApplyIdentifier, "state", state.Apply.Completed, "error", err)
+		}
 		return nil
 	}
 
@@ -476,7 +488,9 @@ func (c *LocalClient) ResumeApply(ctx context.Context, apply *storage.Apply) err
 		now := time.Now()
 		apply.State = state.Apply.Running
 		apply.UpdatedAt = now
-		_ = c.storage.Applies().Update(ctx, apply)
+		if err := c.storage.Applies().Update(ctx, apply); err != nil {
+			c.logger.Error("failed to update apply state", "apply_id", apply.ApplyIdentifier, "state", state.Apply.Running, "error", err)
+		}
 
 		c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventStateTransition, storage.LogSourceSchemaBot,
 			"Apply resumed from checkpoint (sequential)", "", state.Apply.Running)

--- a/pkg/tern/state_converters.go
+++ b/pkg/tern/state_converters.go
@@ -1,8 +1,10 @@
 package tern
 
 import (
+	"encoding/json"
 	"maps"
 	"sort"
+	"time"
 
 	"github.com/block/schemabot/pkg/engine"
 	ternv1 "github.com/block/schemabot/pkg/proto/ternv1"
@@ -190,4 +192,43 @@ func protoToSchemaFiles(sf map[string]*ternv1.SchemaFiles) schema.SchemaFiles {
 		result[ns] = &schema.Namespace{Files: files}
 	}
 	return result
+}
+
+// planToSchemaFiles converts a stored plan's namespace data to engine SchemaFiles.
+// Used by executeApplyAtomic to pass VSchema files to the engine.
+func planToSchemaFiles(plan *storage.Plan) schema.SchemaFiles {
+	if plan == nil || len(plan.Namespaces) == 0 {
+		return nil
+	}
+	result := make(schema.SchemaFiles, len(plan.Namespaces))
+	for ns, nsData := range plan.Namespaces {
+		files := make(map[string]string)
+		if len(nsData.VSchema) > 0 {
+			files["vschema.json"] = string(nsData.VSchema)
+		}
+		if len(files) > 0 {
+			result[ns] = &schema.Namespace{Files: files}
+		}
+	}
+	return result
+}
+
+// psMetadataForStorage is a subset of the PlanetScale engine's metadata
+// used for storing deploy request tracking data.
+type psMetadataForStorage struct {
+	BranchName       string     `json:"branch_name"`
+	DeployRequestID  uint64     `json:"deploy_request_id"`
+	DeployRequestURL string     `json:"deploy_request_url,omitempty"`
+	DeployedAt       *time.Time `json:"deployed_at,omitempty"`
+}
+
+func decodePSMetadataForStorage(s string) (*psMetadataForStorage, error) {
+	if s == "" {
+		return nil, nil
+	}
+	var m psMetadataForStorage
+	if err := json.Unmarshal([]byte(s), &m); err != nil {
+		return nil, err
+	}
+	return &m, nil
 }

--- a/pkg/webhook/templates/help.go
+++ b/pkg/webhook/templates/help.go
@@ -15,7 +15,7 @@ func commandReference() string {
 | ` + "`schemabot rollback <apply-id>`" + ` | Generate a rollback plan |
 | ` + "`schemabot rollback-confirm <apply-id>`" + ` | Execute a rollback |
 
-**Options**: ` + "`-e <env>`" + ` environment, ` + "`-d <db>`" + ` database, ` + "`--defer-cutover`" + `, ` + "`--allow-unsafe`" + `, ` + "`--enable-revert`" + ` (Vitess)
+**Options**: ` + "`-e <env>`" + ` environment, ` + "`-d <db>`" + ` database, ` + "`--defer-cutover`" + `, ` + "`--allow-unsafe`" + `, ` + "`--skip-revert`" + ` (Vitess)
 
 **Quick start**: ` + "`plan`" + ` → ` + "`apply`" + ` → ` + "`apply-confirm`" + `
 `

--- a/pkg/webhook/templates/preview.go
+++ b/pkg/webhook/templates/preview.go
@@ -276,7 +276,7 @@ func PreviewCommentApplyPlan() string {
 	})
 }
 
-// PreviewCommentApplyPlanOptions renders a locked apply-plan with options (defer cutover, enable revert).
+// PreviewCommentApplyPlanOptions renders a locked apply-plan with options (defer cutover, skip revert).
 func PreviewCommentApplyPlanOptions() string {
 	return RenderPlanComment(PlanCommentData{
 		Database:     "testapp",


### PR DESCRIPTION
Wires the PlanetScale engine into tern for end-to-end Vitess schema change management — branch creation, DDL application, deploy requests, per-shard progress with ETAs, cutover, cancel, and revert window support.

The `LocalClient` orchestrates the full lifecycle with phase state tracking visible in the CLI (`creating_branch` → `applying_branch_changes` → `creating_deploy_request` → `running`). Per-shard progress from vtgate `SHOW VITESS_MIGRATIONS` is overlaid onto the progress API so the CLI shows real-time row copy per shard. `VitessApplyData` storage persists deploy request metadata across restarts. Auto-applies mTLS to vtgate connections. Engine `Credentials` cleaned up to be engine-agnostic (PS-specific fields moved to `Metadata`).

Includes Vitess e2e tests and hardening from self-review: Spirit `Stop()` errors non-fatal, `cancelApply` mutex, vtgate cache key normalization, `waitForBranchReady` failfast on consecutive errors, `resumeState` nil safety.

Generated with [Claude Code](https://claude.com/claude-code)