### PR TITLE
Converge GitHub App secret keys to kebab-case

### DIFF
--- a/deploy/aws/config.yaml
+++ b/deploy/aws/config.yaml
@@ -24,9 +24,9 @@ storage:
 # GitHub App integration (webhook-driven schema changes via PR comments).
 # All credentials are stored in Secrets Manager by setup-github-app.sh.
 github:
-  app_id: "secretsmanager:schemabot-example/github-app#app_id"
-  private_key: "secretsmanager:schemabot-example/github-app#private_key"
-  webhook_secret: "secretsmanager:schemabot-example/github-app#webhook_secret"
+  app-id: "secretsmanager:schemabot-example/github-app#app-id"
+  private-key: "secretsmanager:schemabot-example/github-app#private-key"
+  webhook-secret: "secretsmanager:schemabot-example/github-app#webhook-secret"
 
 databases:
   testapp:

--- a/deploy/aws/main.tf
+++ b/deploy/aws/main.tf
@@ -514,9 +514,9 @@ resource "aws_secretsmanager_secret" "github_app" {
 resource "aws_secretsmanager_secret_version" "github_app" {
   secret_id = aws_secretsmanager_secret.github_app.id
   secret_string = jsonencode({
-    app_id         = "0"
-    private_key    = ""
-    webhook_secret = ""
+    "app-id"         = "0"
+    "private-key"    = ""
+    "webhook-secret" = ""
   })
 
   # Credentials are managed by setup-github-app.sh via AWS CLI, not Terraform
@@ -848,9 +848,9 @@ output "config_yaml" {
       dsn: "secretsmanager:${aws_secretsmanager_secret.storage_dsn.name}#dsn"
 
     github:
-      app_id: "secretsmanager:${aws_secretsmanager_secret.github_app.name}#app_id"
-      private_key: "secretsmanager:${aws_secretsmanager_secret.github_app.name}#private_key"
-      webhook_secret: "secretsmanager:${aws_secretsmanager_secret.github_app.name}#webhook_secret"
+      app-id: "secretsmanager:${aws_secretsmanager_secret.github_app.name}#app-id"
+      private-key: "secretsmanager:${aws_secretsmanager_secret.github_app.name}#private-key"
+      webhook-secret: "secretsmanager:${aws_secretsmanager_secret.github_app.name}#webhook-secret"
 
     databases:
       testapp:

--- a/deploy/aws/scripts/setup-github-app.sh
+++ b/deploy/aws/scripts/setup-github-app.sh
@@ -14,8 +14,8 @@ GITHUB_APP_SECRET_ID="${GITHUB_APP_SECRET_ID:-}"
 
 while [ $# -gt 0 ]; do
     case "$1" in
-        --profile)    AWS_PROFILE="$2"; shift 2 ;;
-        --secret-id)  GITHUB_APP_SECRET_ID="$2"; shift 2 ;;
+        --profile)    AWS_PROFILE="${2:?--profile requires a value}"; shift 2 ;;
+        --secret-id)  GITHUB_APP_SECRET_ID="${2:?--secret-id requires a value}"; shift 2 ;;
         --deploy)     DEPLOY=true; shift ;;
         *) echo "Unknown option: $1"; exit 1 ;;
     esac

--- a/deploy/aws/scripts/setup-github-app.sh
+++ b/deploy/aws/scripts/setup-github-app.sh
@@ -2,19 +2,27 @@
 set -euo pipefail
 
 # Store GitHub App credentials in AWS Secrets Manager
-# Usage: ./setup-github-app.sh [--deploy]
+# Usage: ./setup-github-app.sh [--profile PROFILE] [--secret-id ID] [--deploy]
 #
 # Prompts for App ID, private key file, and webhook secret.
-# Safe to re-run — updates the secret in place.
+# Safe to re-run — creates the secret if missing, updates if it exists.
 # Use --deploy to build and deploy the service afterwards.
 
 DEPLOY=false
-if [ "${1:-}" = "--deploy" ]; then
-    DEPLOY=true
-fi
+AWS_PROFILE="${AWS_PROFILE:-schemabot-deployer}"
+GITHUB_APP_SECRET_ID="${GITHUB_APP_SECRET_ID:-}"
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --profile)    AWS_PROFILE="$2"; shift 2 ;;
+        --secret-id)  GITHUB_APP_SECRET_ID="$2"; shift 2 ;;
+        --deploy)     DEPLOY=true; shift ;;
+        *) echo "Unknown option: $1"; exit 1 ;;
+    esac
+done
+export AWS_PROFILE
 
 REGION="us-west-2"
-export AWS_PROFILE="${AWS_PROFILE:-schemabot-deployer}"
 
 echo "🔐 GitHub App Setup"
 echo "======================"
@@ -23,7 +31,7 @@ echo ""
 cd "$(dirname "$0")/.."
 
 # Derive secret name from Terraform output (falls back to default)
-SECRET_ID="${GITHUB_APP_SECRET_ID:-}"
+SECRET_ID="${GITHUB_APP_SECRET_ID}"
 if [ -z "$SECRET_ID" ] && command -v terraform &> /dev/null && [ -d .terraform ]; then
     SECRET_ID=$(terraform output -raw github_app_secret_id 2>/dev/null || true)
 fi
@@ -51,19 +59,29 @@ if [ -z "$WEBHOOK_SECRET" ]; then
     exit 1
 fi
 
-# Store credentials in Secrets Manager
+# Store credentials in Secrets Manager (create if missing, update if exists)
 echo ""
 echo "📦 Storing credentials in Secrets Manager..."
 PRIVATE_KEY=$(cat "$PEM_PATH")
-aws secretsmanager put-secret-value \
-    --secret-id "$SECRET_ID" \
-    --secret-string "$(jq -n \
-        --arg id "$APP_ID" \
-        --arg pk "$PRIVATE_KEY" \
-        --arg ws "$WEBHOOK_SECRET" \
-        '{"app-id": $id, "private-key": $pk, "webhook-secret": $ws}')" \
-    --region "$REGION" \
-    --output text > /dev/null
+SECRET_VALUE="$(jq -n \
+    --arg id "$APP_ID" \
+    --arg pk "$PRIVATE_KEY" \
+    --arg ws "$WEBHOOK_SECRET" \
+    '{"app-id": $id, "private-key": $pk, "webhook-secret": $ws}')"
+
+if aws secretsmanager describe-secret --secret-id "$SECRET_ID" --region "$REGION" > /dev/null 2>&1; then
+    aws secretsmanager put-secret-value \
+        --secret-id "$SECRET_ID" \
+        --secret-string "$SECRET_VALUE" \
+        --region "$REGION" \
+        --output text > /dev/null
+else
+    aws secretsmanager create-secret \
+        --name "$SECRET_ID" \
+        --secret-string "$SECRET_VALUE" \
+        --region "$REGION" \
+        --output text > /dev/null
+fi
 
 echo "   ✅ Credentials stored"
 

--- a/deploy/aws/scripts/setup-github-app.sh
+++ b/deploy/aws/scripts/setup-github-app.sh
@@ -61,7 +61,7 @@ aws secretsmanager put-secret-value \
         --arg id "$APP_ID" \
         --arg pk "$PRIVATE_KEY" \
         --arg ws "$WEBHOOK_SECRET" \
-        '{app_id: $id, private_key: $pk, webhook_secret: $ws}')" \
+        '{"app-id": $id, "private-key": $pk, "webhook-secret": $ws}')" \
     --region "$REGION" \
     --output text > /dev/null
 

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -41,15 +41,15 @@ type GitHubConfig struct {
 	// AppID is the GitHub App's numeric ID.
 	// Supports secret references: env:VAR, file:/path, secretsmanager:name#key.
 	// Falls back to GITHUB_APP_ID environment variable.
-	AppID string `yaml:"app_id"`
+	AppID string `yaml:"app-id"`
 
 	// PrivateKey is the PEM-encoded private key for the GitHub App.
 	// Supports secret references: env:VAR, file:/path, secretsmanager:name#key.
-	PrivateKey string `yaml:"private_key"`
+	PrivateKey string `yaml:"private-key"`
 
 	// WebhookSecret is the HMAC secret for validating webhook signatures.
 	// Supports secret references: env:VAR, file:/path, secretsmanager:name#key.
-	WebhookSecret string `yaml:"webhook_secret"`
+	WebhookSecret string `yaml:"webhook-secret"`
 }
 
 // Configured returns true if the GitHub App is configured (app ID and private key are set).

--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -197,6 +197,32 @@ repos:
 	assert.Error(t, err, "expected error for invalid config")
 }
 
+func TestGitHubConfig_YAMLKeys(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+	content := `
+databases:
+  testapp:
+    type: mysql
+    environments:
+      staging:
+        dsn: "root:pass@tcp(localhost:3306)/testapp"
+github:
+  app-id: "123456"
+  private-key: "my-private-key"
+  webhook-secret: "my-webhook-secret"
+`
+	err := os.WriteFile(configPath, []byte(content), 0644)
+	require.NoError(t, err)
+
+	cfg, err := LoadServerConfigFromFile(configPath)
+	require.NoError(t, err)
+
+	assert.Equal(t, "123456", cfg.GitHub.AppID)
+	assert.Equal(t, "my-private-key", cfg.GitHub.PrivateKey)
+	assert.Equal(t, "my-webhook-secret", cfg.GitHub.WebhookSecret)
+}
+
 func TestGitHubConfig_Configured(t *testing.T) {
 	t.Run("not configured when empty", func(t *testing.T) {
 		g := GitHubConfig{}


### PR DESCRIPTION
The k8s helm chart uses kebab-case key names for secrets mounted via ExternalSecret, which is the Kubernetes convention. Rather than maintaining two naming conventions (underscores for the app runner example, hyphens for k8s), this converges everything on kebab-case: the Go config struct yaml tags, the app runner AWS config, and the setup script.

The setup script also gains `--profile` and `--secret-id` flags (replacing env-var-only configuration) and now upserts secrets (create if missing, update if exists) so it works for bootstrapping new environments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)