### PR TITLE
Support structured storage connection fields

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -36,14 +36,57 @@ tern_deployments:
     production: "tern1-production:9090"
 ```
 
+## Storage Connection
+
+The `storage` section configures SchemaBot's internal database. You can provide the connection as a single DSN string or as individual fields.
+
+### DSN (default)
+
+A single connection string — the simplest option for most deployments:
+
+```yaml
+storage:
+  dsn: "user:pass@tcp(localhost:3306)/schemabot?parseTime=true"
+```
+
+### Individual Fields
+
+When credentials come from different sources (e.g., cloud-managed database passwords stored in a separate secret), use individual connection fields instead:
+
+```yaml
+storage:
+  host: "file:/secrets/db/host"
+  port: "file:/secrets/db/port"
+  database: "file:/secrets/db/database"
+  username: "file:/secrets/db/username"
+  password: "file:/secrets/db/password"
+```
+
+Each field supports secret resolution prefixes (see below). SchemaBot assembles the DSN at startup. Port defaults to 3306 if not specified. This pattern works well with Kubernetes External Secrets Operator, which can sync multiple secrets into a single mounted volume.
+
+The `dsn` field and individual fields are mutually exclusive — set one or the other, not both.
+
+If `storage` is not configured at all, SchemaBot falls back to the `MYSQL_DSN` environment variable.
+
 ## Secret Resolution
 
-DSN values support secret resolution prefixes:
+All config values that accept secret references support these prefixes:
 
 | Prefix | Example | Description |
 |---|---|---|
 | `env:` | `env:STAGING_DSN` | Read from environment variable |
 | `file:` | `file:/run/secrets/prod-dsn` | Read from file |
 | `secretsmanager:` | `secretsmanager:prod/db-dsn` | Read from AWS Secrets Manager |
+
+### AWS Secrets Manager Authentication
+
+The `secretsmanager:` resolver uses the [AWS SDK default credential chain](https://docs.aws.amazon.com/sdkref/latest/guide/standardized-credentials.html). It does not require any SchemaBot-specific configuration — it uses whatever AWS credentials are available to the process:
+
+1. **Environment variables** (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`) — useful for local development
+2. **Shared credentials file** (`~/.aws/credentials`) — useful for local development with named profiles
+3. **ECS/App Runner task role** — automatic when running on AWS compute with an attached IAM role
+4. **EKS IAM Roles for Service Accounts (IRSA)** — automatic when the pod's service account is annotated with an IAM role
+
+The IAM role or credentials must have `secretsmanager:GetSecretValue` permission on the secrets being referenced. No additional SchemaBot configuration is needed beyond ensuring the runtime environment has valid AWS credentials.
 
 See [`pkg/secrets`](../pkg/secrets/) for implementation details.

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -4,7 +4,11 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"sort"
 	"strconv"
+	"strings"
+
+	"github.com/go-sql-driver/mysql"
 
 	"github.com/block/schemabot/pkg/secrets"
 	"github.com/block/schemabot/pkg/storage"
@@ -106,10 +110,36 @@ func (g *GitHubConfig) ResolveWebhookSecret() (string, error) {
 }
 
 // StorageConfig configures SchemaBot's internal storage database.
+// Use either DSN (a complete connection string) or the individual fields
+// (Host, Username, Password, Database, Port) to build the DSN at runtime.
+// The individual fields are useful when credentials come from different
+// sources (e.g., RDS-managed passwords in a separate secret).
+// All fields support secret resolution prefixes (env:, file:, secretsmanager:).
 type StorageConfig struct {
 	// DSN is the MySQL connection string for SchemaBot's internal database.
 	// Can be a direct DSN or a reference (e.g., "env:MYSQL_DSN" to read from env var).
+	// Mutually exclusive with the individual connection fields below.
 	DSN string `yaml:"dsn"`
+
+	// Host is the database hostname or IP address.
+	Host string `yaml:"host"`
+
+	// Port is the database port (default: 3306).
+	Port string `yaml:"port"`
+
+	// Username is the database user.
+	Username string `yaml:"username"`
+
+	// Password is the database password.
+	Password string `yaml:"password"`
+
+	// Database is the database name.
+	Database string `yaml:"database"`
+}
+
+// hasConnectionFields returns true if any individual connection field is set.
+func (s *StorageConfig) hasConnectionFields() bool {
+	return s.Host != "" || s.Port != "" || s.Username != "" || s.Password != "" || s.Database != ""
 }
 
 // DatabaseConfig holds configuration for a registered database.
@@ -174,6 +204,28 @@ func LoadServerConfigFromFile(path string) (*ServerConfig, error) {
 
 // Validate checks the configuration for required fields and consistency.
 func (c *ServerConfig) Validate() error {
+	// Validate storage config: use either "dsn" or individual connection fields, not both.
+	if c.Storage.DSN != "" && c.Storage.hasConnectionFields() {
+		return fmt.Errorf("storage: set either 'dsn' or individual connection fields (host, username, password, database), not both")
+	}
+	if c.Storage.hasConnectionFields() {
+		required := map[string]string{
+			"host":     c.Storage.Host,
+			"username": c.Storage.Username,
+			"database": c.Storage.Database,
+		}
+		var missing []string
+		for name, val := range required {
+			if val == "" {
+				missing = append(missing, name)
+			}
+		}
+		if len(missing) > 0 {
+			sort.Strings(missing)
+			return fmt.Errorf("storage: required fields missing: %s", strings.Join(missing, ", "))
+		}
+	}
+
 	// Either Databases (local mode) or TernDeployments (gRPC mode) must be configured
 	if len(c.Databases) == 0 && len(c.TernDeployments) == 0 {
 		return fmt.Errorf("either databases or tern_deployments is required")
@@ -253,8 +305,62 @@ func (c *ServerConfig) TernDeployment(repo string) string {
 }
 
 // StorageDSN returns the resolved storage DSN.
-// It handles special prefixes (env:, file:) to read from various sources.
-// Falls back to MYSQL_DSN environment variable if not configured.
+// If DSN is set, it is resolved directly (supports env:, file:, secretsmanager: prefixes).
+// Otherwise, individual connection fields are resolved and assembled into a DSN.
+// Falls back to MYSQL_DSN environment variable when neither DSN nor individual fields are set.
 func (c *ServerConfig) StorageDSN() (string, error) {
-	return secrets.Resolve(c.Storage.DSN, "MYSQL_DSN")
+	if c.Storage.DSN != "" {
+		return secrets.Resolve(c.Storage.DSN, "MYSQL_DSN")
+	}
+
+	// No individual fields set either — fall back to MYSQL_DSN env var.
+	if !c.Storage.hasConnectionFields() {
+		return secrets.Resolve("", "MYSQL_DSN")
+	}
+
+	host, err := secrets.Resolve(c.Storage.Host, "")
+	if err != nil {
+		return "", fmt.Errorf("resolve storage host: %w", err)
+	}
+	if host == "" {
+		return "", fmt.Errorf("storage host resolved to empty")
+	}
+
+	port := DefaultMySQLPort
+	if c.Storage.Port != "" {
+		port, err = secrets.Resolve(c.Storage.Port, "")
+		if err != nil {
+			return "", fmt.Errorf("resolve storage port: %w", err)
+		}
+	}
+
+	username, err := secrets.Resolve(c.Storage.Username, "")
+	if err != nil {
+		return "", fmt.Errorf("resolve storage username: %w", err)
+	}
+	if username == "" {
+		return "", fmt.Errorf("storage username resolved to empty")
+	}
+
+	password, err := secrets.Resolve(c.Storage.Password, "")
+	if err != nil {
+		return "", fmt.Errorf("resolve storage password: %w", err)
+	}
+
+	database, err := secrets.Resolve(c.Storage.Database, "")
+	if err != nil {
+		return "", fmt.Errorf("resolve storage database: %w", err)
+	}
+	if database == "" {
+		return "", fmt.Errorf("storage database resolved to empty")
+	}
+
+	mysqlCfg := mysql.NewConfig()
+	mysqlCfg.User = username
+	mysqlCfg.Passwd = password
+	mysqlCfg.Net = "tcp"
+	mysqlCfg.Addr = host + ":" + port
+	mysqlCfg.DBName = database
+	mysqlCfg.ParseTime = true
+	return mysqlCfg.FormatDSN(), nil
 }

--- a/pkg/api/config_integration_test.go
+++ b/pkg/api/config_integration_test.go
@@ -1,0 +1,78 @@
+//go:build integration
+
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/modules/localstack"
+
+	"github.com/block/schemabot/pkg/testutil"
+)
+
+func TestStorageDSN_StructuredFieldsWithSecretsManager(t *testing.T) {
+	container, err := localstack.Run(t.Context(), "localstack/localstack:3.0")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if err := testcontainers.TerminateContainer(container); err != nil {
+			t.Logf("failed to terminate container: %v", err)
+		}
+	})
+
+	host, err := testutil.ContainerHost(t.Context(), container)
+	require.NoError(t, err)
+	port, err := testutil.ContainerPort(t.Context(), container, "4566/tcp")
+	require.NoError(t, err)
+	endpoint := fmt.Sprintf("http://%s:%d", host, port)
+
+	t.Setenv("AWS_ENDPOINT_URL", endpoint)
+	t.Setenv("AWS_ACCESS_KEY_ID", "test")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "test")
+	t.Setenv("AWS_REGION", "us-east-1")
+
+	cfg, err := config.LoadDefaultConfig(t.Context(),
+		config.WithRegion("us-east-1"),
+		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider("test", "test", "")),
+	)
+	require.NoError(t, err)
+
+	client := secretsmanager.NewFromConfig(cfg, func(o *secretsmanager.Options) {
+		o.BaseEndpoint = aws.String(endpoint)
+	})
+
+	// Simulate an RDS-managed secret with a password key
+	rdsSecret, _ := json.Marshal(map[string]string{
+		"username": "admin",
+		"password": "rds-managed-password",
+	})
+	_, err = client.CreateSecret(t.Context(), &secretsmanager.CreateSecretInput{
+		Name:         aws.String("rds/schemabot-cluster"),
+		SecretString: aws.String(string(rdsSecret)),
+	})
+	require.NoError(t, err)
+
+	serverCfg := &ServerConfig{
+		Storage: StorageConfig{
+			Host:     "db.example.com",
+			Port:     "3306",
+			Username: "admin",
+			Password: "secretsmanager:rds/schemabot-cluster#password",
+			Database: "schemabot",
+		},
+		TernDeployments: TernConfig{"default": {"prod": "localhost:9090"}},
+	}
+	require.NoError(t, serverCfg.Validate())
+
+	dsn, err := serverCfg.StorageDSN()
+	require.NoError(t, err)
+	assert.Equal(t, "admin:rds-managed-password@tcp(db.example.com:3306)/schemabot?parseTime=true", dsn)
+}

--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -223,6 +223,204 @@ github:
 	assert.Equal(t, "my-webhook-secret", cfg.GitHub.WebhookSecret)
 }
 
+func TestStorageDSN_StructuredFields(t *testing.T) {
+	cfg := &ServerConfig{
+		Storage: StorageConfig{
+			Host:     "myhost.example.com",
+			Port:     "3307",
+			Username: "admin",
+			Password: "s3cret",
+			Database: "schemabot",
+		},
+		TernDeployments: TernConfig{"default": {"prod": "localhost:9090"}},
+	}
+	require.NoError(t, cfg.Validate())
+
+	dsn, err := cfg.StorageDSN()
+	require.NoError(t, err)
+	assert.Equal(t, "admin:s3cret@tcp(myhost.example.com:3307)/schemabot?parseTime=true", dsn)
+}
+
+func TestStorageDSN_StructuredFieldsDefaultPort(t *testing.T) {
+	cfg := &ServerConfig{
+		Storage: StorageConfig{
+			Host:     "myhost.example.com",
+			Username: "admin",
+			Password: "s3cret",
+			Database: "schemabot",
+		},
+		TernDeployments: TernConfig{"default": {"prod": "localhost:9090"}},
+	}
+	require.NoError(t, cfg.Validate())
+
+	dsn, err := cfg.StorageDSN()
+	require.NoError(t, err)
+	assert.Equal(t, "admin:s3cret@tcp(myhost.example.com:3306)/schemabot?parseTime=true", dsn)
+}
+
+func TestStorageDSN_StructuredFieldsWithSecretRefs(t *testing.T) {
+	t.Setenv("TEST_DB_HOST", "resolved-host.example.com")
+	t.Setenv("TEST_DB_PASS", "resolved-pass")
+
+	cfg := &ServerConfig{
+		Storage: StorageConfig{
+			Host:     "env:TEST_DB_HOST",
+			Username: "admin",
+			Password: "env:TEST_DB_PASS",
+			Database: "schemabot",
+		},
+		TernDeployments: TernConfig{"default": {"prod": "localhost:9090"}},
+	}
+	require.NoError(t, cfg.Validate())
+
+	dsn, err := cfg.StorageDSN()
+	require.NoError(t, err)
+	assert.Equal(t, "admin:resolved-pass@tcp(resolved-host.example.com:3306)/schemabot?parseTime=true", dsn)
+}
+
+func TestStorageDSN_DSNTakesPrecedence(t *testing.T) {
+	cfg := &ServerConfig{
+		Storage: StorageConfig{
+			DSN: "root:pass@tcp(localhost:3306)/mydb",
+		},
+		TernDeployments: TernConfig{"default": {"prod": "localhost:9090"}},
+	}
+	require.NoError(t, cfg.Validate())
+
+	dsn, err := cfg.StorageDSN()
+	require.NoError(t, err)
+	assert.Equal(t, "root:pass@tcp(localhost:3306)/mydb", dsn)
+}
+
+func TestStorageDSN_FallbackToEnvVar(t *testing.T) {
+	t.Setenv("MYSQL_DSN", "root:envpass@tcp(envhost:3306)/envdb")
+
+	cfg := &ServerConfig{
+		Storage:         StorageConfig{},
+		TernDeployments: TernConfig{"default": {"prod": "localhost:9090"}},
+	}
+
+	dsn, err := cfg.StorageDSN()
+	require.NoError(t, err)
+	assert.Equal(t, "root:envpass@tcp(envhost:3306)/envdb", dsn)
+}
+
+func TestStorageDSN_NothingConfigured(t *testing.T) {
+	t.Setenv("MYSQL_DSN", "")
+
+	cfg := &ServerConfig{
+		Storage:         StorageConfig{},
+		TernDeployments: TernConfig{"default": {"prod": "localhost:9090"}},
+	}
+
+	dsn, err := cfg.StorageDSN()
+	require.NoError(t, err)
+	assert.Empty(t, dsn)
+}
+
+func TestStorageDSN_StructuredFieldsEmptyPassword(t *testing.T) {
+	cfg := &ServerConfig{
+		Storage: StorageConfig{
+			Host:     "myhost.example.com",
+			Username: "admin",
+			Password: "",
+			Database: "schemabot",
+		},
+		TernDeployments: TernConfig{"default": {"prod": "localhost:9090"}},
+	}
+	require.NoError(t, cfg.Validate())
+
+	dsn, err := cfg.StorageDSN()
+	require.NoError(t, err)
+	assert.Equal(t, "admin@tcp(myhost.example.com:3306)/schemabot?parseTime=true", dsn)
+}
+
+func TestStorageDSN_StructuredFieldsFromYAML(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+	content := `
+storage:
+  host: "db.example.com"
+  port: "3307"
+  username: "schemabot"
+  password: "env:TEST_YAML_PASS"
+  database: "schemabot"
+databases:
+  testapp:
+    type: mysql
+    environments:
+      staging:
+        dsn: "root:pass@tcp(localhost:3306)/testapp"
+`
+	t.Setenv("TEST_YAML_PASS", "yaml-resolved-pass")
+	err := os.WriteFile(configPath, []byte(content), 0644)
+	require.NoError(t, err)
+
+	cfg, err := LoadServerConfigFromFile(configPath)
+	require.NoError(t, err)
+
+	dsn, err := cfg.StorageDSN()
+	require.NoError(t, err)
+	assert.Equal(t, "schemabot:yaml-resolved-pass@tcp(db.example.com:3307)/schemabot?parseTime=true", dsn)
+}
+
+func TestStorageConfig_Validate_MutuallyExclusive(t *testing.T) {
+	cfg := &ServerConfig{
+		Storage: StorageConfig{
+			DSN:  "root:pass@tcp(localhost:3306)/mydb",
+			Host: "localhost",
+		},
+		TernDeployments: TernConfig{"default": {"prod": "localhost:9090"}},
+	}
+	err := cfg.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not both")
+}
+
+func TestStorageConfig_Validate_RequiredFields(t *testing.T) {
+	t.Run("missing host", func(t *testing.T) {
+		cfg := &ServerConfig{
+			Storage:         StorageConfig{Username: "admin", Database: "db"},
+			TernDeployments: TernConfig{"default": {"prod": "localhost:9090"}},
+		}
+		err := cfg.Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "host")
+	})
+
+	t.Run("missing username", func(t *testing.T) {
+		cfg := &ServerConfig{
+			Storage:         StorageConfig{Host: "localhost", Database: "db"},
+			TernDeployments: TernConfig{"default": {"prod": "localhost:9090"}},
+		}
+		err := cfg.Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "username")
+	})
+
+	t.Run("missing database", func(t *testing.T) {
+		cfg := &ServerConfig{
+			Storage:         StorageConfig{Host: "localhost", Username: "admin"},
+			TernDeployments: TernConfig{"default": {"prod": "localhost:9090"}},
+		}
+		err := cfg.Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "database")
+	})
+
+	t.Run("missing multiple", func(t *testing.T) {
+		cfg := &ServerConfig{
+			Storage:         StorageConfig{Password: "pass"},
+			TernDeployments: TernConfig{"default": {"prod": "localhost:9090"}},
+		}
+		err := cfg.Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "host")
+		assert.Contains(t, err.Error(), "username")
+		assert.Contains(t, err.Error(), "database")
+	})
+}
+
 func TestGitHubConfig_Configured(t *testing.T) {
 	t.Run("not configured when empty", func(t *testing.T) {
 		g := GitHubConfig{}

--- a/pkg/api/service.go
+++ b/pkg/api/service.go
@@ -60,8 +60,13 @@ type TernConfig map[string]TernEndpoints
 // TernEndpoints maps environment name to gRPC address (host:port).
 type TernEndpoints map[string]string
 
-// DefaultDeployment is the deployment key used for single-deployment deployments.
-const DefaultDeployment = "default"
+const (
+	// DefaultDeployment is the deployment key used for single-deployment deployments.
+	DefaultDeployment = "default"
+
+	// DefaultMySQLPort is the default port for MySQL connections.
+	DefaultMySQLPort = "3306"
+)
 
 // Endpoint returns the Tern endpoint for the given deployment and environment.
 // For single-deployment deployments, use DefaultDeployment ("default") as the deployment.


### PR DESCRIPTION
StorageConfig now accepts individual connection fields (host, port, username, password, database) as an alternative to a single DSN string. Each field supports secret resolution prefixes (env:, file:, secretsmanager:), and SchemaBot assembles the DSN at startup using the MySQL driver's FormatDSN for safe escaping.

This is useful for Kubernetes deployments where credentials are mounted as individual files via External Secrets Operator — for example, when the database password is managed by RDS in a separate secret. ESO syncs both secrets into a single k8s secret volume, and SchemaBot reads all fields uniformly as files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)