### PR TITLE
Add --version flag to CLI

### DIFF
--- a/integration/cli/version_test.go
+++ b/integration/cli/version_test.go
@@ -1,0 +1,21 @@
+//go:build integration
+
+package cli
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/block/schemabot/pkg/e2eutil"
+)
+
+func TestCLI_Version(t *testing.T) {
+	var cli e2eutil.CLIFinder
+	binPath := cli.FindOrBuild(t, "../..", "./pkg/cmd", "../../bin/schemabot")
+
+	out, err := e2eutil.RunCLIWithError(binPath, "", "--version")
+	require.NoError(t, err)
+	assert.Contains(t, out, "(commit:")
+}

--- a/pkg/cmd/main.go
+++ b/pkg/cmd/main.go
@@ -22,6 +22,8 @@ var (
 type CLI struct {
 	commands.Globals
 
+	VersionFlag kong.VersionFlag `name:"version" help:"Show version information"`
+
 	Plan      commands.PlanCmd      `cmd:"" help:"Create a schema change plan"`
 	Apply     commands.ApplyCmd     `cmd:"" help:"Apply schema changes"`
 	Progress  commands.ProgressCmd  `cmd:"" help:"Get schema change progress"`
@@ -47,6 +49,7 @@ func main() {
 		kong.Name("schemabot"),
 		kong.Description("Declarative schema GitOps orchestrator"),
 		kong.UsageOnError(),
+		kong.Vars{"version": fmt.Sprintf("%s (commit: %s)", version, commit)},
 	)
 
 	cli.Version = version


### PR DESCRIPTION
Adds a `--version` flag that prints the version and commit SHA. The version is set at build time via ldflags from `git describe --tags`, following the standard Go pattern used by tools like Docker and Kubernetes.

```
$ schemabot --version
v0.1.1 (commit: 383e839a84777baf2677f11ad349ef13377013f4)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)