### PR TITLE
Store deployment on applies and wire through full lifecycle

### DIFF
--- a/integration/grpc_integration_test.go
+++ b/integration/grpc_integration_test.go
@@ -161,7 +161,7 @@ func TestGRPC_ExternalID_StoredOnApply(t *testing.T) {
 	_, err = targetDB.ExecContext(ctx, "CREATE DATABASE IF NOT EXISTS "+appDBName)
 	require.NoError(t, err, "create app database")
 	defer func() {
-		_, _ = targetDB.ExecContext(context.Background(), "DROP DATABASE IF EXISTS "+appDBName) //nolint:usetesting // cleanup
+		_, _ = targetDB.ExecContext(context.WithoutCancel(t.Context()), "DROP DATABASE IF EXISTS "+appDBName)
 	}()
 
 	appDSN := strings.Replace(targetDSN, "/target_test", "/"+appDBName, 1)
@@ -467,4 +467,115 @@ func TestGRPC_TargetInPlanRequest(t *testing.T) {
 	grpcResp, err := grpcClient.Plan(t.Context(), ternReq)
 	require.NoError(t, err, "gRPC Plan with target")
 	assert.NotEmpty(t, grpcResp.PlanId, "gRPC plan with target should return plan_id")
+}
+
+// TestGRPC_Deployment_StoredOnApply verifies that when a plan/apply request
+// includes a deployment field, the deployment is persisted on the apply record.
+func TestGRPC_Deployment_StoredOnApply(t *testing.T) {
+	ctx := t.Context()
+
+	targetDB, err := sql.Open("mysql", targetDSN+"&multiStatements=true")
+	require.NoError(t, err, "open target db")
+	defer utils.CloseAndLog(targetDB)
+
+	appDBName := fmt.Sprintf("deploy_%d", time.Now().UnixNano()%100000)
+	_, err = targetDB.ExecContext(ctx, "CREATE DATABASE IF NOT EXISTS "+appDBName)
+	require.NoError(t, err, "create app database")
+	defer func() {
+		_, _ = targetDB.ExecContext(context.WithoutCancel(t.Context()), "DROP DATABASE IF EXISTS "+appDBName)
+	}()
+
+	appDSN := strings.Replace(targetDSN, "/target_test", "/"+appDBName, 1)
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	ternGRPCAddr, err := startTernGRPC(ctx, appDSN, ternStorageDSN)
+	require.NoError(t, err, "start tern grpc")
+
+	schemabotDB, err := sql.Open("mysql", schemabotDSN)
+	require.NoError(t, err, "open schemabot db")
+	defer utils.CloseAndLog(schemabotDB)
+	schemabotStorage := schemabotmysql.New(schemabotDB)
+
+	ternClient, err := tern.NewGRPCClient(tern.Config{Address: ternGRPCAddr})
+	require.NoError(t, err, "create tern client")
+	defer utils.CloseAndLog(ternClient)
+
+	// Configure with a named deployment (not "default")
+	serverConfig := &schemabotapi.ServerConfig{
+		TernDeployments: schemabotapi.TernConfig{
+			"us-west": {"staging": ternGRPCAddr},
+		},
+	}
+	svc := schemabotapi.New(schemabotStorage, serverConfig, map[string]tern.Client{
+		"us-west/staging": ternClient,
+	}, logger)
+	defer utils.CloseAndLog(svc)
+
+	mux := http.NewServeMux()
+	svc.ConfigureRoutes(mux)
+	listener, err := (&net.ListenConfig{}).Listen(ctx, "tcp", "localhost:0")
+	require.NoError(t, err, "listen")
+	server := &http.Server{Handler: mux}
+	go func() { _ = server.Serve(listener) }()
+	defer utils.CloseAndLog(server)
+	schemabotAddr := listener.Addr().String()
+	time.Sleep(50 * time.Millisecond)
+
+	// Plan with explicit deployment
+	schemaSQL := "CREATE TABLE widgets (\n\tid BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,\n\tname VARCHAR(255) NOT NULL\n);"
+	planReq := map[string]any{
+		"database":    appDBName,
+		"environment": "staging",
+		"type":        "mysql",
+		"deployment":  "us-west",
+		"schema_files": map[string]any{
+			"default": map[string]any{
+				"files": map[string]string{"widgets.sql": schemaSQL},
+			},
+		},
+		"repository":   "test/deployment",
+		"pull_request": 1,
+	}
+	planBody, _ := json.Marshal(planReq)
+	planHTTPReq, _ := http.NewRequestWithContext(ctx, http.MethodPost, "http://"+schemabotAddr+"/api/plan", bytes.NewReader(planBody))
+	planHTTPReq.Header.Set("Content-Type", "application/json")
+	planResp, err := http.DefaultClient.Do(planHTTPReq)
+	require.NoError(t, err, "POST /api/plan")
+	t.Cleanup(func() { utils.CloseAndLog(planResp.Body) })
+	if planResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(planResp.Body)
+		require.Failf(t, "plan failed", "(%d): %s", planResp.StatusCode, body)
+	}
+	var planResult map[string]any
+	require.NoError(t, json.NewDecoder(planResp.Body).Decode(&planResult), "decode plan response")
+	planID, ok := planResult["plan_id"].(string)
+	require.True(t, ok && planID != "", "plan response missing plan_id: %v", planResult)
+
+	// Apply with explicit deployment
+	applyReq := map[string]any{
+		"plan_id":     planID,
+		"environment": "staging",
+		"deployment":  "us-west",
+	}
+	applyBody, _ := json.Marshal(applyReq)
+	applyHTTPReq, _ := http.NewRequestWithContext(ctx, http.MethodPost, "http://"+schemabotAddr+"/api/apply", bytes.NewReader(applyBody))
+	applyHTTPReq.Header.Set("Content-Type", "application/json")
+	applyResp, err := http.DefaultClient.Do(applyHTTPReq)
+	require.NoError(t, err, "POST /api/apply")
+	t.Cleanup(func() { utils.CloseAndLog(applyResp.Body) })
+	if applyResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(applyResp.Body)
+		require.Failf(t, "apply failed", "(%d): %s", applyResp.StatusCode, body)
+	}
+	var applyResult map[string]any
+	require.NoError(t, json.NewDecoder(applyResp.Body).Decode(&applyResult), "decode apply response")
+	require.Equal(t, true, applyResult["accepted"], "apply not accepted: %v", applyResult)
+	applyID, ok := applyResult["apply_id"].(string)
+	require.True(t, ok && applyID != "", "apply response missing apply_id: %v", applyResult)
+
+	// Verify deployment is stored on the apply record
+	storedApply, err := schemabotStorage.Applies().GetByApplyIdentifier(ctx, applyID)
+	require.NoError(t, err, "get apply by identifier")
+	require.NotNil(t, storedApply, "apply %s not found in storage", applyID)
+	assert.Equal(t, "us-west", storedApply.Deployment, "deployment should be stored on the apply")
 }

--- a/pkg/api/control_handlers.go
+++ b/pkg/api/control_handlers.go
@@ -2,11 +2,13 @@ package api
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 
 	"github.com/block/schemabot/pkg/apitypes"
 	ternv1 "github.com/block/schemabot/pkg/proto/ternv1"
 	"github.com/block/schemabot/pkg/state"
+	"github.com/block/schemabot/pkg/tern"
 )
 
 // writeControlError logs and writes an HTTP error for a control operation.
@@ -15,10 +17,80 @@ func (s *Service) writeControlError(w http.ResponseWriter, opName, database stri
 	s.writeError(w, http.StatusInternalServerError, opName+" failed: "+err.Error())
 }
 
+// decodeControlRequest decodes a control request (stop/start/cutover/volume),
+// resolves the apply ID, and returns a Tern client using the deployment stored
+// on the apply record. Deployment is a plan-time decision — control operations
+// always use the stored deployment, never a caller-provided one.
+func (s *Service) decodeControlRequest(w http.ResponseWriter, r *http.Request, dest any,
+	database, environment, applyID *string) (tern.Client, string, bool) {
+
+	if err := json.NewDecoder(r.Body).Decode(dest); err != nil {
+		s.writeError(w, http.StatusBadRequest, "invalid request body: "+err.Error())
+		return nil, "", false
+	}
+	if *database == "" {
+		s.writeError(w, http.StatusBadRequest, "database is required")
+		return nil, "", false
+	}
+	if *environment == "" {
+		*environment = "staging"
+	}
+
+	// Resolve the apply — either from explicit apply_id or by finding the active
+	// apply for the database/environment. This ensures we always use the deployment
+	// stored on the apply, even when the caller only provides database+environment.
+	var resolvedApplyID string
+	var deployment string
+	applyIdentifier := *applyID
+	if applyIdentifier == "" {
+		// No explicit apply_id — find the active apply for this database/environment.
+		_, activeApply, err := s.findActiveApplyID(r.Context(), *database, *environment)
+		if err != nil {
+			s.writeError(w, http.StatusNotFound, fmt.Sprintf("no active schema change for %s/%s: %v", *database, *environment, err))
+			return nil, "", false
+		}
+		if activeApply != nil {
+			applyIdentifier = activeApply.ApplyIdentifier
+			deployment = activeApply.Deployment
+		}
+	}
+	if applyIdentifier != "" {
+		resolved, err := s.resolveApplyID(r.Context(), applyIdentifier)
+		if err != nil {
+			s.writeError(w, http.StatusInternalServerError, fmt.Sprintf("resolve apply_id: %v", err))
+			return nil, "", false
+		}
+		resolvedApplyID = resolved
+
+		// If we didn't get the deployment from findActiveApplyID, look it up now.
+		if deployment == "" {
+			if applyStore := s.storage.Applies(); applyStore != nil {
+				apply, err := applyStore.GetByApplyIdentifier(r.Context(), applyIdentifier)
+				if err == nil && apply != nil {
+					deployment = apply.Deployment
+				}
+			}
+		}
+	}
+	deployment = s.resolveDeployment(*database, deployment)
+
+	client, err := s.TernClient(deployment, *environment)
+	if err != nil {
+		s.logger.Error("failed to create Tern client",
+			"deployment", deployment,
+			"database", *database,
+			"environment", *environment,
+			"error", err)
+		s.writeError(w, http.StatusNotFound, err.Error())
+		return nil, "", false
+	}
+
+	return client, resolvedApplyID, true
+}
+
 // CutoverRequest is the HTTP request body for POST /api/cutover.
 type CutoverRequest struct {
 	Database    string `json:"database"`
-	Deployment  string `json:"deployment,omitempty"`
 	Environment string `json:"environment"`
 	ApplyID     string `json:"apply_id,omitempty"`
 }
@@ -26,14 +98,8 @@ type CutoverRequest struct {
 // handleCutover handles POST /api/cutover requests.
 func (s *Service) handleCutover(w http.ResponseWriter, r *http.Request) {
 	var req CutoverRequest
-	client, ok := s.decodeRequest(w, r, &req, &req.Database, &req.Deployment, &req.Environment)
+	client, applyID, ok := s.decodeControlRequest(w, r, &req, &req.Database, &req.Environment, &req.ApplyID)
 	if !ok {
-		return
-	}
-
-	applyID, err := s.resolveApplyID(r.Context(), req.ApplyID)
-	if err != nil {
-		s.writeControlError(w, "cutover", req.Database, err)
 		return
 	}
 
@@ -56,7 +122,6 @@ func (s *Service) handleCutover(w http.ResponseWriter, r *http.Request) {
 // StopRequest is the HTTP request body for POST /api/stop.
 type StopRequest struct {
 	Database    string `json:"database"`
-	Deployment  string `json:"deployment,omitempty"`
 	Environment string `json:"environment"`
 	ApplyID     string `json:"apply_id,omitempty"`
 }
@@ -65,14 +130,8 @@ type StopRequest struct {
 // Stops all non-terminal tasks for the database.
 func (s *Service) handleStop(w http.ResponseWriter, r *http.Request) {
 	var req StopRequest
-	client, ok := s.decodeRequest(w, r, &req, &req.Database, &req.Deployment, &req.Environment)
+	client, applyID, ok := s.decodeControlRequest(w, r, &req, &req.Database, &req.Environment, &req.ApplyID)
 	if !ok {
-		return
-	}
-
-	applyID, err := s.resolveApplyID(r.Context(), req.ApplyID)
-	if err != nil {
-		s.writeControlError(w, "stop", req.Database, err)
 		return
 	}
 
@@ -97,7 +156,6 @@ func (s *Service) handleStop(w http.ResponseWriter, r *http.Request) {
 // StartRequest is the HTTP request body for POST /api/start.
 type StartRequest struct {
 	Database    string `json:"database"`
-	Deployment  string `json:"deployment,omitempty"`
 	Environment string `json:"environment"`
 	ApplyID     string `json:"apply_id,omitempty"`
 }
@@ -105,14 +163,8 @@ type StartRequest struct {
 // handleStart handles POST /api/start requests.
 func (s *Service) handleStart(w http.ResponseWriter, r *http.Request) {
 	var req StartRequest
-	client, ok := s.decodeRequest(w, r, &req, &req.Database, &req.Deployment, &req.Environment)
+	client, applyID, ok := s.decodeControlRequest(w, r, &req, &req.Database, &req.Environment, &req.ApplyID)
 	if !ok {
-		return
-	}
-
-	applyID, err := s.resolveApplyID(r.Context(), req.ApplyID)
-	if err != nil {
-		s.writeControlError(w, "start", req.Database, err)
 		return
 	}
 
@@ -164,7 +216,6 @@ func (s *Service) handleStart(w http.ResponseWriter, r *http.Request) {
 type VolumeRequest struct {
 	ApplyID     string `json:"apply_id,omitempty"`
 	Database    string `json:"database"`
-	Deployment  string `json:"deployment,omitempty"`
 	Environment string `json:"environment"`
 	Volume      int32  `json:"volume"` // 1-11 (1=conservative, 11=aggressive)
 }
@@ -172,19 +223,13 @@ type VolumeRequest struct {
 // handleVolume handles POST /api/volume requests.
 func (s *Service) handleVolume(w http.ResponseWriter, r *http.Request) {
 	var req VolumeRequest
-	client, ok := s.decodeRequest(w, r, &req, &req.Database, &req.Deployment, &req.Environment)
+	client, applyID, ok := s.decodeControlRequest(w, r, &req, &req.Database, &req.Environment, &req.ApplyID)
 	if !ok {
 		return
 	}
 
 	if req.Volume < 1 || req.Volume > 11 {
 		s.writeError(w, http.StatusBadRequest, "volume must be between 1 and 11")
-		return
-	}
-
-	applyID, err := s.resolveApplyID(r.Context(), req.ApplyID)
-	if err != nil {
-		s.writeControlError(w, "volume", req.Database, err)
 		return
 	}
 
@@ -209,7 +254,6 @@ func (s *Service) handleVolume(w http.ResponseWriter, r *http.Request) {
 // RevertRequest is the HTTP request body for POST /api/revert.
 type RevertRequest struct {
 	Database    string `json:"database"`
-	Deployment  string `json:"deployment,omitempty"`
 	Environment string `json:"environment"`
 	ApplyID     string `json:"apply_id,omitempty"`
 }
@@ -217,14 +261,8 @@ type RevertRequest struct {
 // handleRevert handles POST /api/revert requests.
 func (s *Service) handleRevert(w http.ResponseWriter, r *http.Request) {
 	var req RevertRequest
-	client, ok := s.decodeRequest(w, r, &req, &req.Database, &req.Deployment, &req.Environment)
+	client, applyID, ok := s.decodeControlRequest(w, r, &req, &req.Database, &req.Environment, &req.ApplyID)
 	if !ok {
-		return
-	}
-
-	applyID, err := s.resolveApplyID(r.Context(), req.ApplyID)
-	if err != nil {
-		s.writeControlError(w, "revert", req.Database, err)
 		return
 	}
 
@@ -246,7 +284,6 @@ func (s *Service) handleRevert(w http.ResponseWriter, r *http.Request) {
 // SkipRevertRequest is the HTTP request body for POST /api/skip-revert.
 type SkipRevertRequest struct {
 	Database    string `json:"database"`
-	Deployment  string `json:"deployment,omitempty"`
 	Environment string `json:"environment"`
 	ApplyID     string `json:"apply_id,omitempty"`
 }
@@ -254,14 +291,8 @@ type SkipRevertRequest struct {
 // handleSkipRevert handles POST /api/skip-revert requests.
 func (s *Service) handleSkipRevert(w http.ResponseWriter, r *http.Request) {
 	var req SkipRevertRequest
-	client, ok := s.decodeRequest(w, r, &req, &req.Database, &req.Deployment, &req.Environment)
+	client, applyID, ok := s.decodeControlRequest(w, r, &req, &req.Database, &req.Environment, &req.ApplyID)
 	if !ok {
-		return
-	}
-
-	applyID, err := s.resolveApplyID(r.Context(), req.ApplyID)
-	if err != nil {
-		s.writeControlError(w, "skip-revert", req.Database, err)
 		return
 	}
 
@@ -310,7 +341,7 @@ func (s *Service) handleRollbackPlan(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	resp, err := s.ExecuteRollbackPlan(r.Context(), apply.Database, apply.Environment, "")
+	resp, err := s.ExecuteRollbackPlan(r.Context(), apply.Database, apply.Environment, apply.Deployment)
 	if err != nil {
 		s.writeControlError(w, "rollback plan", apply.Database, err)
 		return

--- a/pkg/api/plan_handlers.go
+++ b/pkg/api/plan_handlers.go
@@ -322,6 +322,7 @@ func (s *Service) ExecuteApply(ctx context.Context, req ApplyRequest) (*apitypes
 				Repository:      plan.Repository,
 				PullRequest:     plan.PullRequest,
 				Environment:     req.Environment,
+				Deployment:      deployment,
 				Caller:          req.Caller,
 				InstallationID:  req.InstallationID,
 				ExternalID:      resp.ApplyId,

--- a/pkg/api/progress_handlers.go
+++ b/pkg/api/progress_handlers.go
@@ -84,16 +84,21 @@ func progressResponseFromProto(resp *ternv1.ProgressResponse) *apitypes.Progress
 // GetProgress fetches the current progress for a database from its tern client.
 // This is used by the webhook handler to populate table-level progress in PR comments.
 func (s *Service) GetProgress(ctx context.Context, database, environment string) (*apitypes.ProgressResponse, error) {
-	deployment := s.resolveDeployment(database, "")
+	ternApplyID, activeApply, err := s.findActiveApplyID(ctx, database, environment)
+	if err != nil {
+		return nil, fmt.Errorf("resolve active apply for %s: %w", database, err)
+	}
+
+	// Use deployment from the stored apply if available.
+	var storedDeployment string
+	if activeApply != nil {
+		storedDeployment = activeApply.Deployment
+	}
+	deployment := s.resolveDeployment(database, storedDeployment)
 
 	client, err := s.TernClient(deployment, environment)
 	if err != nil {
 		return nil, fmt.Errorf("get tern client for %s/%s: %w", database, environment, err)
-	}
-
-	ternApplyID, activeApply, err := s.findActiveApplyID(ctx, database, environment)
-	if err != nil {
-		return nil, fmt.Errorf("resolve active apply for %s: %w", database, err)
 	}
 
 	resp, err := client.Progress(ctx, &ternv1.ProgressRequest{
@@ -154,8 +159,9 @@ func (s *Service) handleProgress(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Use the deployment stored on the apply if available, otherwise resolve from request.
-	deployment := r.URL.Query().Get("deployment")
+	// Deployment is a plan-time decision stored on the apply record.
+	// Use the stored deployment if an apply exists, otherwise fall back to default resolution.
+	var deployment string
 	if activeApply != nil && activeApply.Deployment != "" {
 		deployment = activeApply.Deployment
 	}
@@ -224,8 +230,8 @@ func (s *Service) handleProgressByApplyID(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	// Active apply — call Tern for live progress.
-	deployment := s.resolveDeployment(apply.Database, "")
+	// Active apply — use the deployment stored on the apply record.
+	deployment := s.resolveDeployment(apply.Database, apply.Deployment)
 
 	client, err := s.TernClient(deployment, apply.Environment)
 	if err != nil {
@@ -524,7 +530,7 @@ func (s *Service) progressFromLocalStorage(ctx context.Context, apply *storage.A
 // per-table state into local task records. Called once for gRPC-mode applies
 // with stale task state; subsequent reads are served from local storage.
 func (s *Service) syncTasksFromTern(ctx context.Context, apply *storage.Apply, tasks []*storage.Task) error {
-	deployment := s.resolveDeployment(apply.Database, "")
+	deployment := s.resolveDeployment(apply.Database, apply.Deployment)
 	client, err := s.TernClient(deployment, apply.Environment)
 	if err != nil {
 		return fmt.Errorf("get tern client: %w", err)

--- a/pkg/api/progress_handlers.go
+++ b/pkg/api/progress_handlers.go
@@ -344,7 +344,8 @@ func (s *Service) handleDatabaseEnvironments(w http.ResponseWriter, r *http.Requ
 
 	// Check gRPC mode config (TernDeployments)
 	if len(environments) == 0 && len(s.config.TernDeployments) > 0 {
-		deployment := s.resolveDeployment(database, "")
+		deploymentParam := r.URL.Query().Get("deployment")
+		deployment := s.resolveDeployment(database, deploymentParam)
 		if endpoints, ok := s.config.TernDeployments[deployment]; ok {
 			for env := range endpoints {
 				environments = append(environments, env)
@@ -353,7 +354,22 @@ func (s *Service) handleDatabaseEnvironments(w http.ResponseWriter, r *http.Requ
 	}
 
 	if len(environments) == 0 {
-		s.writeError(w, http.StatusNotFound, "database not found: "+database)
+		available := make([]string, 0, len(s.config.TernDeployments))
+		for name := range s.config.TernDeployments {
+			available = append(available, name)
+		}
+		sort.Strings(available)
+		s.logger.Warn("no environments found for database",
+			"database", database,
+			"available_deployments", available)
+		if len(available) > 0 {
+			s.writeError(w, http.StatusNotFound,
+				fmt.Sprintf("no environments found for database %q — no matching deployment (available: %v). "+
+					"Add a 'deployment' field to schemabot.yaml or configure a 'default' deployment on the server.", database, available))
+		} else {
+			s.writeError(w, http.StatusNotFound,
+				fmt.Sprintf("no environments found for database %q — no databases or deployments configured on this server", database))
+		}
 		return
 	}
 

--- a/pkg/api/progress_handlers.go
+++ b/pkg/api/progress_handlers.go
@@ -127,16 +127,9 @@ func (s *Service) handleProgress(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	deployment := s.resolveDeployment(database, r.URL.Query().Get("deployment"))
 	environment := r.URL.Query().Get("environment")
 	if environment == "" {
 		environment = "staging"
-	}
-
-	client, err := s.TernClient(deployment, environment)
-	if err != nil {
-		s.writeError(w, http.StatusNotFound, err.Error())
-		return
 	}
 
 	// Resolve the Tern-facing apply_id. Prefer explicit apply_id query param
@@ -150,7 +143,6 @@ func (s *Service) handleProgress(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		ternApplyID = resolved
-		// Look up the apply for metadata overlay.
 		activeApply, _ = s.storage.Applies().GetByApplyIdentifier(r.Context(), qApplyID)
 	} else {
 		var err error
@@ -160,6 +152,19 @@ func (s *Service) handleProgress(w http.ResponseWriter, r *http.Request) {
 			s.writeError(w, http.StatusInternalServerError, "failed to resolve active apply: "+err.Error())
 			return
 		}
+	}
+
+	// Use the deployment stored on the apply if available, otherwise resolve from request.
+	deployment := r.URL.Query().Get("deployment")
+	if activeApply != nil && activeApply.Deployment != "" {
+		deployment = activeApply.Deployment
+	}
+	deployment = s.resolveDeployment(database, deployment)
+
+	client, err := s.TernClient(deployment, environment)
+	if err != nil {
+		s.writeError(w, http.StatusNotFound, err.Error())
+		return
 	}
 
 	resp, err := client.Progress(r.Context(), &ternv1.ProgressRequest{

--- a/pkg/api/scheduler.go
+++ b/pkg/api/scheduler.go
@@ -96,8 +96,8 @@ func (s *Service) resumeInProgressApplies(ctx context.Context) {
 			"state", apply.State,
 			"last_heartbeat", apply.UpdatedAt)
 
-		// Get Tern client for this database/environment
-		deployment := s.resolveDeployment(apply.Database, "")
+		// Get Tern client using the deployment stored on the apply.
+		deployment := s.resolveDeployment(apply.Database, apply.Deployment)
 		client, err := s.TernClient(deployment, apply.Environment)
 		if err != nil {
 			s.logger.Error("recovery worker: failed to get client",

--- a/pkg/api/service.go
+++ b/pkg/api/service.go
@@ -3,7 +3,6 @@ package api
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -222,42 +221,6 @@ func (s *Service) ConfigureRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("POST /api/settings", s.handleSettingsSet)
 
 	// GitHub webhook endpoint — registered externally via RegisterWebhook
-}
-
-// decodeRequest decodes a JSON request body, validates that database is set,
-// defaults environment to "staging" if empty, resolves the deployment, and
-// returns the matching Tern client. Returns false if an error HTTP response
-// was already written.
-func (s *Service) decodeRequest(w http.ResponseWriter, r *http.Request, dest any,
-	database, deployment, environment *string) (tern.Client, bool) {
-
-	if err := json.NewDecoder(r.Body).Decode(dest); err != nil {
-		s.writeError(w, http.StatusBadRequest, "invalid request body: "+err.Error())
-		return nil, false
-	}
-
-	if *database == "" {
-		s.writeError(w, http.StatusBadRequest, "database is required")
-		return nil, false
-	}
-	if *environment == "" {
-		*environment = "staging"
-	}
-
-	dep := s.resolveDeployment(*database, *deployment)
-
-	client, err := s.TernClient(dep, *environment)
-	if err != nil {
-		s.logger.Error("failed to create Tern client",
-			"deployment", dep,
-			"environment", *environment,
-			"error", err,
-		)
-		s.writeError(w, http.StatusInternalServerError, "failed to initialize database client")
-		return nil, false
-	}
-
-	return client, true
 }
 
 // resolveApplyID translates a SchemaBot apply_identifier into the ID that the

--- a/pkg/cmd/client/client.go
+++ b/pkg/cmd/client/client.go
@@ -156,7 +156,7 @@ func GetProgress(endpoint, database, environment string) (*apitypes.ProgressResp
 // GetProgressCtx is like GetProgress but accepts a context for timeout/cancellation control.
 func GetProgressCtx(ctx context.Context, endpoint, database, environment string) (*apitypes.ProgressResponse, error) {
 	var result apitypes.ProgressResponse
-	if err := doGetIntoCtx(ctx, endpoint, fmt.Sprintf("/api/progress/%s?environment=%s", database, environment), &result); err != nil {
+	if err := doGetIntoCtx(ctx, endpoint, fmt.Sprintf("/api/progress/%s?environment=%s", url.PathEscape(database), url.QueryEscape(environment)), &result); err != nil {
 		return nil, err
 	}
 	return &result, nil

--- a/pkg/cmd/client/client.go
+++ b/pkg/cmd/client/client.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"os/user"
 	"path"
@@ -38,11 +39,15 @@ func ResolveEndpoint(flag string, configEndpoint ...string) string {
 }
 
 // GetEnvironments fetches the list of environments for a database from the API.
-func GetEnvironments(endpoint, database string) ([]string, error) {
+func GetEnvironments(endpoint, database, deployment string) ([]string, error) {
 	var result struct {
 		Environments []string `json:"environments"`
 	}
-	if err := doGetInto(endpoint, fmt.Sprintf("/api/databases/%s/environments", database), &result); err != nil {
+	path := fmt.Sprintf("/api/databases/%s/environments", url.PathEscape(database))
+	if deployment != "" {
+		path += "?" + url.Values{"deployment": {deployment}}.Encode()
+	}
+	if err := doGetInto(endpoint, path, &result); err != nil {
 		return nil, err
 	}
 	return result.Environments, nil
@@ -50,7 +55,8 @@ func GetEnvironments(endpoint, database string) ([]string, error) {
 
 // PlanOptions holds optional parameters for CallPlanAPI.
 type PlanOptions struct {
-	Target string
+	Target     string
+	Deployment string
 }
 
 // CallPlanAPI calls the plan API by reading .sql files from schemaDir.
@@ -80,8 +86,13 @@ func CallPlanAPIWithFiles(endpoint, database, dbType, environment string, schema
 		prVal := int32(pr)
 		req.PullRequest = &prVal
 	}
-	if len(opts) > 0 && opts[0].Target != "" {
-		req.Target = opts[0].Target
+	if len(opts) > 0 {
+		if opts[0].Target != "" {
+			req.Target = opts[0].Target
+		}
+		if opts[0].Deployment != "" {
+			req.Deployment = opts[0].Deployment
+		}
 	}
 	var result apitypes.PlanResponse
 	if err := doPostInto(endpoint, "/api/plan", req, &result); err != nil {
@@ -112,8 +123,13 @@ func CallApplyAPI(endpoint, planID, database, environment, caller string, option
 		Caller:      caller,
 		Options:     options,
 	}
-	if len(opts) > 0 && opts[0].Target != "" {
-		req.Target = opts[0].Target
+	if len(opts) > 0 {
+		if opts[0].Target != "" {
+			req.Target = opts[0].Target
+		}
+		if opts[0].Deployment != "" {
+			req.Deployment = opts[0].Deployment
+		}
 	}
 	var result apitypes.ApplyResponse
 	if err := doPostInto(endpoint, "/api/apply", req, &result); err != nil {

--- a/pkg/cmd/commands/apply.go
+++ b/pkg/cmd/commands/apply.go
@@ -87,7 +87,7 @@ func (cmd *ApplyCmd) Run(g *Globals) error {
 	}
 
 	// Step 1: Generate plan
-	opts := client.PlanOptions{Target: cfg.GetTarget(cmd.Environment)}
+	opts := client.PlanOptions{Target: cfg.GetTarget(cmd.Environment), Deployment: cfg.Deployment}
 	planResult, err := client.CallPlanAPI(ep, cfg.Database, cfg.Type, cmd.Environment, cfg.SchemaDir, cmd.Repository, cmd.PullRequest, opts)
 	if err != nil {
 		return err

--- a/pkg/cmd/commands/common.go
+++ b/pkg/cmd/commands/common.go
@@ -77,6 +77,7 @@ const (
 type CLIConfig struct {
 	Database     string                   `yaml:"database"`
 	Type         string                   `yaml:"type"`
+	Deployment   string                   `yaml:"deployment,omitempty"`
 	Environments ghclient.EnvironmentList `yaml:"environments,omitempty"`
 	SchemaDir    string                   `yaml:"-"` // Set by LoadCLIConfig, not from YAML
 }

--- a/pkg/cmd/commands/common_test.go
+++ b/pkg/cmd/commands/common_test.go
@@ -3,6 +3,8 @@
 package commands
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -38,5 +40,19 @@ func TestLoadCLIConfig_WithoutEnvironments(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, "testapp", cfg.Database)
+	assert.Empty(t, cfg.Deployment, "deployment should be empty when not specified")
 	assert.Equal(t, "testapp", cfg.GetTarget("staging"), "no environments falls back to database name")
+}
+
+func TestLoadCLIConfig_WithDeployment(t *testing.T) {
+	dir := t.TempDir()
+	content := "database: mydb\ntype: mysql\ndeployment: us-west\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "schemabot.yaml"), []byte(content), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "users.sql"), []byte("CREATE TABLE users (id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY);"), 0644))
+
+	cfg, err := LoadCLIConfig(dir)
+	require.NoError(t, err)
+
+	assert.Equal(t, "mydb", cfg.Database)
+	assert.Equal(t, "us-west", cfg.Deployment)
 }

--- a/pkg/cmd/commands/plan.go
+++ b/pkg/cmd/commands/plan.go
@@ -51,7 +51,7 @@ func (cmd *PlanCmd) Run(g *Globals) error {
 	// If environment is not specified, get all environments and plan for each
 	var environments []string
 	if cmd.Environment == "" {
-		envs, err := client.GetEnvironments(ep, cfg.Database)
+		envs, err := client.GetEnvironments(ep, cfg.Database, cfg.Deployment)
 		if err != nil {
 			if cmd.JSON {
 				return client.ExitWithJSON("api_error", err.Error())
@@ -66,7 +66,7 @@ func (cmd *PlanCmd) Run(g *Globals) error {
 	// Collect results for all environments
 	allResults := make(map[string]*apitypes.PlanResponse)
 	for _, env := range environments {
-		opts := client.PlanOptions{Target: cfg.GetTarget(env)}
+		opts := client.PlanOptions{Target: cfg.GetTarget(env), Deployment: cfg.Deployment}
 		result, err := client.CallPlanAPI(ep, cfg.Database, cfg.Type, env, cfg.SchemaDir, cmd.Repository, cmd.PullRequest, opts)
 		if err != nil {
 			if cmd.JSON {

--- a/pkg/schema/mysql/applies.sql
+++ b/pkg/schema/mysql/applies.sql
@@ -8,6 +8,7 @@ CREATE TABLE `applies` (
   `repository` varchar(255) NOT NULL,
   `pull_request` int unsigned NOT NULL,
   `environment` varchar(50) NOT NULL,
+  `deployment` varchar(255) NOT NULL DEFAULT '',
   `caller` varchar(255) NOT NULL DEFAULT '',
   `installation_id` bigint NOT NULL DEFAULT '0',
   `external_id` varchar(255) NOT NULL DEFAULT '',

--- a/pkg/storage/mysqlstore/applies.go
+++ b/pkg/storage/mysqlstore/applies.go
@@ -15,7 +15,7 @@ import (
 
 // applyColumns lists all columns for SELECT queries.
 const applyColumns = `id, apply_identifier, lock_id, plan_id, database_name, database_type,
-	repository, pull_request, environment, caller, installation_id, external_id, engine,
+	repository, pull_request, environment, deployment, caller, installation_id, external_id, engine,
 	state, error_message, options,
 	created_at, started_at, completed_at, updated_at`
 
@@ -35,12 +35,12 @@ func (s *applyStore) Create(ctx context.Context, apply *storage.Apply) (int64, e
 	result, err := s.db.ExecContext(ctx, `
 		INSERT INTO applies (
 			apply_identifier, lock_id, plan_id, database_name, database_type,
-			repository, pull_request, environment, caller, installation_id, external_id, engine,
+			repository, pull_request, environment, deployment, caller, installation_id, external_id, engine,
 			state, error_message, options
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`,
 		apply.ApplyIdentifier, apply.LockID, apply.PlanID, apply.Database, apply.DatabaseType,
-		apply.Repository, apply.PullRequest, apply.Environment, apply.Caller, apply.InstallationID, apply.ExternalID, apply.Engine,
+		apply.Repository, apply.PullRequest, apply.Environment, apply.Deployment, apply.Caller, apply.InstallationID, apply.ExternalID, apply.Engine,
 		apply.State, apply.ErrorMessage, string(options),
 	)
 	if err != nil {
@@ -325,7 +325,7 @@ func scanApplyInto(s scanner) (*storage.Apply, error) {
 	err := s.Scan(
 		&apply.ID, &apply.ApplyIdentifier, &apply.LockID, &apply.PlanID,
 		&apply.Database, &apply.DatabaseType,
-		&apply.Repository, &apply.PullRequest, &apply.Environment,
+		&apply.Repository, &apply.PullRequest, &apply.Environment, &apply.Deployment,
 		&apply.Caller, &apply.InstallationID, &apply.ExternalID, &apply.Engine,
 		&apply.State, &apply.ErrorMessage, &options,
 		&apply.CreatedAt, &startedAt, &completedAt, &apply.UpdatedAt,

--- a/pkg/storage/types.go
+++ b/pkg/storage/types.go
@@ -259,6 +259,10 @@ type Apply struct {
 	// Environment is "staging" or "production".
 	Environment string
 
+	// Deployment is the Tern deployment name used for this apply.
+	// Empty for local mode (no Tern routing needed).
+	Deployment string
+
 	// Caller identifies who initiated this apply.
 	// For CLI: "cli:user@hostname", for PR: "repo#pr"
 	Caller string

--- a/scripts/run-spirit-fmt.sh
+++ b/scripts/run-spirit-fmt.sh
@@ -49,23 +49,44 @@ if [ ${#PATHS[@]} -eq 0 ]; then
     PATHS=("pkg/schema/mysql")
 fi
 
-# Ensure spirit binary is available.
+# Minimum spirit version required for the fmt command.
+SPIRIT_MIN_VERSION="0.12.0"
+
+# Check if a spirit binary supports the fmt command (introduced in v0.12.0).
+spirit_has_fmt() {
+    "$1" fmt --help &>/dev/null 2>&1
+}
+
+# Ensure spirit binary is available with fmt support.
 ensure_spirit() {
     # Check PATH (includes hermit-managed binaries if activated).
-    if command -v spirit &>/dev/null; then
+    if command -v spirit &>/dev/null && spirit_has_fmt "$(command -v spirit)"; then
         return
     fi
     # Check repo-local hermit bin directory.
-    if [ -x "./bin/spirit" ]; then
+    if [ -x "./bin/spirit" ] && spirit_has_fmt "./bin/spirit"; then
         export PATH="./bin:$PATH"
         return
     fi
-    echo "ERROR: spirit not found."
+    # Check go install location.
+    local gobin="${GOBIN:-$(go env GOPATH)/bin}"
+    if [ -x "$gobin/spirit" ] && spirit_has_fmt "$gobin/spirit"; then
+        export PATH="$gobin:$PATH"
+        return
+    fi
+    # Auto-install via go install.
+    echo "spirit >= $SPIRIT_MIN_VERSION not found, installing via go install..."
+    go install "github.com/block/spirit/cmd/spirit@v${SPIRIT_MIN_VERSION}" 2>&1
+    if [ -x "$gobin/spirit" ] && spirit_has_fmt "$gobin/spirit"; then
+        export PATH="$gobin:$PATH"
+        return
+    fi
+    echo "ERROR: spirit >= $SPIRIT_MIN_VERSION not found."
     echo ""
     echo "Install via one of:"
-    echo "  brew install block/tap/spirit      # macOS"
+    echo "  brew install block/tap/spirit      # macOS (once v$SPIRIT_MIN_VERSION is published)"
     echo "  hermit install spirit              # if using hermit"
-    echo "  go install github.com/block/spirit/cmd/spirit@v0.12.0"
+    echo "  go install github.com/block/spirit/cmd/spirit@v$SPIRIT_MIN_VERSION"
     exit 1
 }
 

--- a/scripts/run-spirit-fmt.sh
+++ b/scripts/run-spirit-fmt.sh
@@ -69,7 +69,11 @@ ensure_spirit() {
         return
     fi
     # Check go install location.
-    local gobin="${GOBIN:-$(go env GOPATH)/bin}"
+    local gobin
+    gobin="$(go env GOBIN)"
+    if [ -z "$gobin" ]; then
+        gobin="$(go env GOPATH | cut -d: -f1)/bin"
+    fi
     if [ -x "$gobin/spirit" ] && spirit_has_fmt "$gobin/spirit"; then
         export PATH="$gobin:$PATH"
         return


### PR DESCRIPTION
Adds an optional `deployment` field to `schemabot.yaml` that lets repos specify which Tern deployment to use. This is needed when the server has multiple deployments and the default doesn't apply.

The deployment is stored on the apply record in the database, so all subsequent operations (progress, stop, start, cutover, volume, revert) automatically use the correct Tern deployment. Control handlers no longer accept a deployment from the caller — it's a plan-time decision only.

Also improves the "database not found" error to list available deployments and suggest adding the field, and makes the spirit fmt hook auto-install v0.12.0 when needed.

Example `schemabot.yaml`:
```yaml
database: mydb
type: mysql
deployment: us-west
environments:
  staging:
    target: my-staging-target
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)