### PR TITLE
Remove duplicate state constants from CLI commands

### DIFF
--- a/pkg/cmd/commands/apply.go
+++ b/pkg/cmd/commands/apply.go
@@ -51,18 +51,18 @@ func (cmd *ApplyCmd) Run(g *Globals) error {
 	active, err := client.CheckActiveSchemaChange(ep, cfg.Database, cmd.Environment)
 	if err != nil {
 		// Ignore errors - progress API may fail if no schema change exists
-	} else if active != nil && active.State != "" && active.State != "STATE_NO_ACTIVE_CHANGE" {
+	} else if active != nil && active.State != "" && !state.IsState(active.State, state.NoActiveChange) {
 		progressCmd := fmt.Sprintf("schemabot status %s", active.ApplyID)
 		if active.ApplyID == "" {
 			progressCmd = fmt.Sprintf("schemabot progress -d %s -e %s", cfg.Database, cmd.Environment)
 		}
 		var stateMsg string
 		switch {
-		case state.IsState(active.State, StateWaitingForCutover):
+		case state.IsState(active.State, state.Apply.WaitingForCutover):
 			stateMsg = "A schema change is waiting for cutover."
-		case state.IsState(active.State, StateRunning):
+		case state.IsState(active.State, state.Apply.Running):
 			stateMsg = "A schema change is already running."
-		case state.IsState(active.State, StateCuttingOver):
+		case state.IsState(active.State, state.Apply.CuttingOver):
 			stateMsg = "A schema change is currently cutting over."
 		}
 		if stateMsg != "" {
@@ -74,7 +74,7 @@ func (cmd *ApplyCmd) Run(g *Globals) error {
 			fmt.Println()
 			fmt.Println(stateMsg)
 			fmt.Println()
-			if state.IsState(active.State, StateWaitingForCutover) {
+			if state.IsState(active.State, state.Apply.WaitingForCutover) {
 				if active.ApplyID != "" {
 					fmt.Printf("To trigger cutover:  schemabot cutover --apply-id %s\n", active.ApplyID)
 				} else {
@@ -306,7 +306,7 @@ func WatchApplyProgressAfterCutover(endpoint, database, environment string) erro
 		}
 
 		// Check for terminal states
-		if state.IsState(curState, StateCompleted) {
+		if state.IsState(curState, state.Apply.Completed) {
 			// Show green completion bar
 			for _, tbl := range tables {
 				bar := ui.ProgressBarComplete()
@@ -316,14 +316,14 @@ func WatchApplyProgressAfterCutover(endpoint, database, environment string) erro
 			return nil
 		}
 
-		if state.IsState(curState, StateFailed) {
+		if state.IsState(curState, state.Apply.Failed) {
 			if result.ErrorMessage != "" {
 				return fmt.Errorf("cutover failed: %s", result.ErrorMessage)
 			}
 			return fmt.Errorf("cutover failed")
 		}
 
-		if state.IsState(curState, StateStopped) {
+		if state.IsState(curState, state.Apply.Stopped) {
 			return fmt.Errorf("schema change was stopped during cutover")
 		}
 
@@ -476,7 +476,7 @@ func watchApplyProgressLog(endpoint, database, environment string, heartbeatInte
 			}
 		}
 
-		if state.IsState(curState, StateNoActiveChange) {
+		if state.IsState(curState, state.NoActiveChange) {
 			log.emit("msg", "No active schema change")
 			return nil
 		}
@@ -546,24 +546,24 @@ func watchApplyProgressLog(endpoint, database, environment string, heartbeatInte
 		if globalNorm != lastGlobalState {
 			// Emit global state changes that aren't covered by per-table events
 			switch {
-			case state.IsState(curState, StateWaitingForCutover) && lastGlobalState != "":
+			case state.IsState(curState, state.Apply.WaitingForCutover) && lastGlobalState != "":
 				log.emit("msg", "Waiting for cutover")
-			case state.IsState(curState, StateCuttingOver):
+			case state.IsState(curState, state.Apply.CuttingOver):
 				log.emit("msg", "Cutting over")
 			}
 			lastGlobalState = globalNorm
 		}
 
 		// Terminal states — emit summary and exit
-		if state.IsState(curState, StateCompleted) {
+		if state.IsState(curState, state.Apply.Completed) {
 			log.emitApplySummary("completed", tableStates, applyStart, "")
 			return nil
 		}
-		if state.IsState(curState, StateFailed) {
+		if state.IsState(curState, state.Apply.Failed) {
 			log.emitApplySummary("failed", tableStates, applyStart, result.ErrorMessage)
 			return ErrSilent
 		}
-		if state.IsState(curState, StateStopped) {
+		if state.IsState(curState, state.Apply.Stopped) {
 			log.emitApplySummary("stopped", tableStates, applyStart, "")
 			return nil
 		}
@@ -705,16 +705,16 @@ func watchApplyProgressJSON(endpoint, database, environment string) error {
 		}
 
 		// Check for terminal states
-		if state.IsState(curState, StateCompleted) {
+		if state.IsState(curState, state.Apply.Completed) {
 			return nil
 		}
-		if state.IsState(curState, StateFailed) {
+		if state.IsState(curState, state.Apply.Failed) {
 			return ErrSilent
 		}
-		if state.IsState(curState, StateStopped) {
+		if state.IsState(curState, state.Apply.Stopped) {
 			return nil
 		}
-		if state.IsState(curState, StateNoActiveChange) {
+		if state.IsState(curState, state.NoActiveChange) {
 			return nil
 		}
 

--- a/pkg/cmd/commands/common.go
+++ b/pkg/cmd/commands/common.go
@@ -59,20 +59,6 @@ func (cf *ControlFlags) RequireApplyID() error {
 // and no additional "Error:" message should be printed.
 var ErrSilent = errors.New("silent error")
 
-// API state constants (proto enum string representations)
-const (
-	StateNoActiveChange    = "STATE_NO_ACTIVE_CHANGE"
-	StatePending           = "STATE_PENDING"
-	StateCompleted         = "STATE_COMPLETED"
-	StateFailed            = "STATE_FAILED"
-	StateRunning           = "STATE_RUNNING"
-	StateWaitingForCutover = "STATE_WAITING_FOR_CUTOVER"
-	StateCuttingOver       = "STATE_CUTTING_OVER"
-	StateStopped           = "STATE_STOPPED"
-	StateRevertWindow      = "STATE_REVERT_WINDOW"
-	StateReverted          = "STATE_REVERTED"
-)
-
 // CLIConfig represents the schemabot.yaml configuration file for CLI commands.
 type CLIConfig struct {
 	Database     string                   `yaml:"database"`

--- a/pkg/cmd/commands/cutover.go
+++ b/pkg/cmd/commands/cutover.go
@@ -27,7 +27,7 @@ func (cmd *CutoverCmd) Run(g *Globals) error {
 	// Check current state first
 	result, err := client.GetProgress(ep, cmd.Database, cmd.Environment)
 	if err == nil {
-		if state.IsState(result.State, StateCompleted) {
+		if state.IsState(result.State, state.Apply.Completed) {
 			fmt.Println("✓ Schema change already complete")
 			tables := ddl.FilterInternalTablesTyped(result.Tables)
 			if len(tables) > 0 {

--- a/pkg/cmd/commands/rollback.go
+++ b/pkg/cmd/commands/rollback.go
@@ -39,13 +39,13 @@ func (cmd *RollbackCmd) Run(g *Globals) error {
 	active, err := client.CheckActiveSchemaChange(ep, database, environment)
 	if err != nil {
 		// Ignore errors - progress API may fail if no schema change exists
-	} else if active != nil && active.State != "" && active.State != "STATE_NO_ACTIVE_CHANGE" {
+	} else if active != nil && active.State != "" && !state.IsState(active.State, state.NoActiveChange) {
 		switch {
-		case state.IsState(active.State, StateWaitingForCutover):
+		case state.IsState(active.State, state.Apply.WaitingForCutover):
 			return fmt.Errorf("cannot rollback: a schema change is waiting for cutover")
-		case state.IsState(active.State, StateRunning):
+		case state.IsState(active.State, state.Apply.Running):
 			return fmt.Errorf("cannot rollback: a schema change is already running")
-		case state.IsState(active.State, StateCuttingOver):
+		case state.IsState(active.State, state.Apply.CuttingOver):
 			return fmt.Errorf("cannot rollback: a schema change is currently cutting over")
 		}
 	}

--- a/pkg/cmd/commands/start.go
+++ b/pkg/cmd/commands/start.go
@@ -31,18 +31,18 @@ func (cmd *StartCmd) Run(g *Globals) error {
 	}
 
 	curState := result.State
-	if state.IsState(curState, StateCompleted) {
+	if state.IsState(curState, state.Apply.Completed) {
 		fmt.Println("Schema change already complete - nothing to start")
 		return nil
 	}
-	if state.IsState(curState, StateRunning, StateCuttingOver) {
+	if state.IsState(curState, state.Apply.Running, state.Apply.CuttingOver) {
 		fmt.Println("Schema change already running")
 		if cmd.Watch {
 			return WatchApplyProgress(ep, cmd.Database, cmd.Environment, true)
 		}
 		return nil
 	}
-	if !state.IsState(curState, StateStopped) {
+	if !state.IsState(curState, state.Apply.Stopped) {
 		return fmt.Errorf("cannot start schema change in state: %s (expected STOPPED)", curState)
 	}
 

--- a/pkg/cmd/commands/status.go
+++ b/pkg/cmd/commands/status.go
@@ -84,7 +84,7 @@ func showApplyByID(endpoint, applyID string, outputJSON bool) error {
 	}
 
 	// Use the existing progress display
-	if result.State == "" || state.IsState(result.State, StateNoActiveChange) {
+	if result.State == "" || state.IsState(result.State, state.NoActiveChange) {
 		fmt.Printf("No schema change found for apply '%s'\n", applyID)
 		return nil
 	}

--- a/pkg/cmd/commands/stop.go
+++ b/pkg/cmd/commands/stop.go
@@ -35,19 +35,19 @@ func (cmd *StopCmd) Run(g *Globals) error {
 	}
 
 	curState := result.State
-	if state.IsState(curState, StateNoActiveChange) || curState == "" {
+	if state.IsState(curState, state.NoActiveChange) || curState == "" {
 		fmt.Printf("No active schema change for database '%s' environment '%s'\n", cmd.Database, cmd.Environment)
 		return nil
 	}
-	if state.IsState(curState, StateCompleted) {
+	if state.IsState(curState, state.Apply.Completed) {
 		fmt.Println("Schema change already complete - nothing to stop")
 		return nil
 	}
-	if state.IsState(curState, StateStopped) {
+	if state.IsState(curState, state.Apply.Stopped) {
 		fmt.Println("Schema change already stopped")
 		return nil
 	}
-	if !state.IsState(curState, StateRunning, StateCuttingOver, StateWaitingForCutover, StatePending) {
+	if !state.IsState(curState, state.Apply.Running, state.Apply.CuttingOver, state.Apply.WaitingForCutover, state.Apply.Pending) {
 		return fmt.Errorf("cannot stop schema change in state: %s", curState)
 	}
 

--- a/pkg/cmd/commands/volume.go
+++ b/pkg/cmd/commands/volume.go
@@ -35,14 +35,14 @@ func (cmd *VolumeCmd) Run(g *Globals) error {
 	}
 
 	curState := result.State
-	if state.IsState(curState, StateCompleted) {
+	if state.IsState(curState, state.Apply.Completed) {
 		fmt.Println("Schema change already complete - cannot adjust volume")
 		return nil
 	}
-	if state.IsState(curState, StateFailed) {
+	if state.IsState(curState, state.Apply.Failed) {
 		return fmt.Errorf("schema change failed - cannot adjust volume")
 	}
-	if !state.IsState(curState, StateRunning, StateCuttingOver, StateWaitingForCutover, StateStopped) {
+	if !state.IsState(curState, state.Apply.Running, state.Apply.CuttingOver, state.Apply.WaitingForCutover, state.Apply.Stopped) {
 		return fmt.Errorf("cannot adjust volume in state: %s", curState)
 	}
 

--- a/pkg/cmd/commands/watch_tui.go
+++ b/pkg/cmd/commands/watch_tui.go
@@ -112,7 +112,7 @@ func (m WatchModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
 		// During cutover, ignore all keyboard input except q to force quit
-		isCuttingOver := state.IsState(m.state, StateCuttingOver) || m.cutoverTriggered
+		isCuttingOver := state.IsState(m.state, state.Apply.CuttingOver) || m.cutoverTriggered
 
 		// Handle volume mode inputs
 		if m.volumeMode {
@@ -136,19 +136,19 @@ func (m WatchModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, nil
 			}
 			// Stop the schema change if running and not already stopped/stopping
-			if state.IsState(m.state, StateRunning, StateWaitingForCutover) && !m.stopTriggered {
+			if state.IsState(m.state, state.Apply.Running, state.Apply.WaitingForCutover) && !m.stopTriggered {
 				m.stopTriggered = true
 				return m, m.triggerStop()
 			}
 		case "v":
 			// Enter volume mode (only when running)
-			if state.IsState(m.state, StateRunning) && !isCuttingOver {
+			if state.IsState(m.state, state.Apply.Running) && !isCuttingOver {
 				m.volumeMode = true
 				return m, nil
 			}
 		case "enter":
 			// Trigger cutover if waiting and not already triggered
-			if state.IsState(m.state, StateWaitingForCutover) && m.allowCutover && !m.cutoverTriggered {
+			if state.IsState(m.state, state.Apply.WaitingForCutover) && m.allowCutover && !m.cutoverTriggered {
 				m.cutoverTriggered = true
 				return m, m.triggerCutover()
 			}
@@ -188,15 +188,15 @@ func (m WatchModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 		// Check for terminal states
-		if state.IsState(m.state, StateCompleted, StateFailed) {
+		if state.IsState(m.state, state.Apply.Completed, state.Apply.Failed) {
 			return m, tea.Quit
 		}
 		// Also quit on stopped state
-		if state.IsState(m.state, StateStopped) {
+		if state.IsState(m.state, state.Apply.Stopped) {
 			return m, tea.Quit
 		}
 		// Quit if no active schema change
-		if state.IsState(m.state, StateNoActiveChange) {
+		if state.IsState(m.state, state.NoActiveChange) {
 			return m, tea.Quit
 		}
 
@@ -262,10 +262,10 @@ func runWatchModel(model WatchModel) error {
 
 	// The TUI view already displays errors inline, so return ErrSilent
 	// to exit with code 1 without printing the error again.
-	if m.errorMsg != "" && !state.IsState(m.state, StateCompleted) {
+	if m.errorMsg != "" && !state.IsState(m.state, state.Apply.Completed) {
 		return ErrSilent
 	}
-	if state.IsState(m.state, StateFailed) {
+	if state.IsState(m.state, state.Apply.Failed) {
 		return ErrSilent
 	}
 

--- a/pkg/cmd/commands/watch_tui_commands.go
+++ b/pkg/cmd/commands/watch_tui_commands.go
@@ -246,7 +246,7 @@ func isTableStopped(status string) bool {
 // Note: stopTriggered alone does NOT count — we wait for the backend to confirm
 // the stop so the progress data reflects the true final state of each table.
 func (m WatchModel) isEffectivelyStopped() bool {
-	if state.IsState(m.state, StateStopped) {
+	if state.IsState(m.state, state.Apply.Stopped) {
 		return true
 	}
 	// Check if any table is stopped (backend may not have updated apply state yet)

--- a/pkg/cmd/commands/watch_tui_view.go
+++ b/pkg/cmd/commands/watch_tui_view.go
@@ -27,7 +27,7 @@ func (m WatchModel) View() string {
 	}
 
 	// Handle no active schema change
-	if state.IsState(m.state, StateNoActiveChange) {
+	if state.IsState(m.state, state.NoActiveChange) {
 		return "No active schema change for this database.\n"
 	}
 
@@ -55,12 +55,12 @@ func (m WatchModel) progressView() string {
 	case m.volumeChanging:
 		// Volume change in progress
 		b.WriteString(m.spinner.View() + fmt.Sprintf("Changing volume to %d...\n", m.volumePending))
-	case m.stopTriggered && !state.IsState(m.state, StateStopped):
+	case m.stopTriggered && !state.IsState(m.state, state.Apply.Stopped):
 		// Stop has been triggered but state hasn't updated yet
 		b.WriteString(m.spinner.View() + "Stopping...\n")
 	case effectivelyStopped:
 		// Don't show status line - stopped message comes after tables
-	case state.IsState(m.state, StateRunning) && !m.cutoverTriggered:
+	case state.IsState(m.state, state.Apply.Running) && !m.cutoverTriggered:
 		// Find overall ETA and check if any table is actually copying rows
 		eta := ""
 		hasRowCopy := false
@@ -79,17 +79,17 @@ func (m WatchModel) progressView() string {
 			b.WriteString(m.spinner.View() + "Running...")
 		}
 		b.WriteString("\n")
-	case state.IsState(m.state, StateWaitingForCutover):
+	case state.IsState(m.state, state.Apply.WaitingForCutover):
 		if m.cutoverTriggered {
 			b.WriteString(m.spinner.View() + "Cutover triggered, waiting for completion...\n")
 		}
-	case state.IsState(m.state, StateCuttingOver):
+	case state.IsState(m.state, state.Apply.CuttingOver):
 		b.WriteString(m.spinner.View() + "Cutting over...\n")
-	case state.IsState(m.state, StateCompleted):
+	case state.IsState(m.state, state.Apply.Completed):
 		// No status line for completed - just show completion message after tables
-	case state.IsState(m.state, StateStopped):
+	case state.IsState(m.state, state.Apply.Stopped):
 		// No status line - show stopped message after tables
-	case state.IsState(m.state, StatePending):
+	case state.IsState(m.state, state.Apply.Pending):
 		b.WriteString(m.spinner.View() + "Starting...\n")
 	}
 
@@ -103,10 +103,10 @@ func (m WatchModel) progressView() string {
 	}
 
 	// Footer based on state
-	isCuttingOver := state.IsState(m.state, StateCuttingOver) || m.cutoverTriggered
+	isCuttingOver := state.IsState(m.state, state.Apply.CuttingOver) || m.cutoverTriggered
 
 	switch {
-	case state.IsState(m.state, StateCompleted):
+	case state.IsState(m.state, state.Apply.Completed):
 		b.WriteString("\n\n")
 		b.WriteString(templates.FormatApplyComplete())
 		b.WriteString("\n")
@@ -125,7 +125,7 @@ func (m WatchModel) progressView() string {
 		dimStyle := lipgloss.NewStyle().Faint(true)
 		b.WriteString(dimStyle.Render("Cutover in progress - please wait..."))
 		b.WriteString("\n")
-	case state.IsState(m.state, StateWaitingForCutover):
+	case state.IsState(m.state, state.Apply.WaitingForCutover):
 		b.WriteString("\n\n")
 		b.WriteString("Row copy complete. All data has been copied and new writes\n")
 		b.WriteString("continue to be replicated to keep the shadow table in sync.\n\n")
@@ -139,7 +139,7 @@ func (m WatchModel) progressView() string {
 			}
 			b.WriteString("Watching for cutover... (ESC to detach)\n")
 		}
-	case state.IsState(m.state, StateRunning):
+	case state.IsState(m.state, state.Apply.Running):
 		b.WriteString("\n\n")
 		if m.volumeMode {
 			// Volume mode - show volume adjustment UI
@@ -193,19 +193,19 @@ func (m WatchModel) renderTable(t tableProgress) string {
 	// Overall state takes priority to ensure consistent display during transitions
 	switch {
 	// Terminal states - check overall state first
-	case state.IsState(m.state, StateCompleted):
+	case state.IsState(m.state, state.Apply.Completed):
 		bar := ui.ProgressBarComplete()
 		fmt.Fprintf(&b, "%*s: %s ✓ Complete\n", m.maxTableNameLen, t.Name, bar)
 		writeDDL()
 
 	// Stopped state - show tables with their actual status
 	// Tables that completed before the stop should show as complete, not stopped
-	case m.isEffectivelyStopped() && !state.IsState(m.state, StateCompleted):
+	case m.isEffectivelyStopped() && !state.IsState(m.state, state.Apply.Completed):
 		switch {
-		case state.IsState(t.Status, StateCompleted):
+		case state.IsState(t.Status, state.Apply.Completed):
 			bar := ui.ProgressBarComplete()
 			fmt.Fprintf(&b, "%*s: %s ✓ Complete\n", m.maxTableNameLen, t.Name, bar)
-		case state.IsState(t.Status, StateFailed):
+		case state.IsState(t.Status, state.Apply.Failed):
 			bar := ui.ProgressBarFailed(t.Percent)
 			fmt.Fprintf(&b, "%*s: %s ❌ Failed\n", m.maxTableNameLen, t.Name, bar)
 		default:
@@ -224,38 +224,38 @@ func (m WatchModel) renderTable(t tableProgress) string {
 
 	// Cutover states - all tables show same state during cutover
 	// Also handle when cutover has been triggered but state hasn't updated yet
-	case state.IsState(m.state, StateCuttingOver) || (m.cutoverTriggered && !state.IsState(m.state, StateCompleted)):
+	case state.IsState(m.state, state.Apply.CuttingOver) || (m.cutoverTriggered && !state.IsState(m.state, state.Apply.Completed)):
 		bar := ui.ProgressBarWaitingCutover()
 		fmt.Fprintf(&b, "%*s: %s 🔄 Cutting over...\n", m.maxTableNameLen, t.Name, bar)
 		writeDDL()
 
-	case state.IsState(m.state, StateWaitingForCutover):
+	case state.IsState(m.state, state.Apply.WaitingForCutover):
 		bar := ui.ProgressBarWaitingCutover()
 		fmt.Fprintf(&b, "%*s: %s ⏸️ Waiting for cutover\n", m.maxTableNameLen, t.Name, bar)
 		writeDDL()
 
 	// Per-table states - check individual table status
-	case state.IsState(t.Status, StateCompleted):
+	case state.IsState(t.Status, state.Apply.Completed):
 		bar := ui.ProgressBarComplete()
 		fmt.Fprintf(&b, "%*s: %s ✓ Complete\n", m.maxTableNameLen, t.Name, bar)
 		writeDDL()
 
-	case state.IsState(t.Status, StateWaitingForCutover):
+	case state.IsState(t.Status, state.Apply.WaitingForCutover):
 		bar := ui.ProgressBarWaitingCutover()
 		fmt.Fprintf(&b, "%*s: %s ⏸️ Waiting for cutover\n", m.maxTableNameLen, t.Name, bar)
 		writeDDL()
 
-	case state.IsState(t.Status, StateCuttingOver):
+	case state.IsState(t.Status, state.Apply.CuttingOver):
 		bar := ui.ProgressBarWaitingCutover()
 		fmt.Fprintf(&b, "%*s: %s 🔄 Cutting over...\n", m.maxTableNameLen, t.Name, bar)
 		writeDDL()
 
-	case state.IsState(t.Status, StatePending):
+	case state.IsState(t.Status, state.Apply.Pending):
 		bar := ui.ProgressBarRowCopy(0)
 		fmt.Fprintf(&b, "%*s: %s queued\n", m.maxTableNameLen, t.Name, bar)
 		writeDDL()
 
-	case state.IsState(t.Status, StateStopped):
+	case state.IsState(t.Status, state.Apply.Stopped):
 		if t.Percent > 0 {
 			bar := ui.ProgressBarStopped(t.Percent)
 			fmt.Fprintf(&b, "%*s: %s ⏹️ Stopped\n", m.maxTableNameLen, t.Name, bar)
@@ -264,7 +264,7 @@ func (m WatchModel) renderTable(t tableProgress) string {
 		}
 		writeDDL()
 
-	case state.IsState(t.Status, StateFailed):
+	case state.IsState(t.Status, state.Apply.Failed):
 		bar := ui.ProgressBarFailed(t.Percent)
 		fmt.Fprintf(&b, "%*s: %s ❌ Failed\n", m.maxTableNameLen, t.Name, bar)
 		writeDDL()


### PR DESCRIPTION
The CLI commands package maintained its own state constants (STATE_PENDING, STATE_COMPLETED, etc.) that duplicated what pkg/state already provides. All references now use state.Apply.* and state.NoActiveChange, which is the canonical source per CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)