### PR TITLE
Add service.annotations and podLabels to helm chart

### DIFF
--- a/charts/schemabot/Chart.yaml
+++ b/charts/schemabot/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: schemabot
 description: GitOps for database schemas
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: "v0.1.2"
 maintainers:
   - name: aparajon

--- a/charts/schemabot/templates/deployment.yaml
+++ b/charts/schemabot/templates/deployment.yaml
@@ -20,6 +20,9 @@ spec:
         {{- end }}
       labels:
         {{- include "schemabot.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       serviceAccountName: {{ include "schemabot.serviceAccountName" . }}
       securityContext:

--- a/charts/schemabot/templates/service.yaml
+++ b/charts/schemabot/templates/service.yaml
@@ -5,6 +5,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "schemabot.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/charts/schemabot/values.yaml
+++ b/charts/schemabot/values.yaml
@@ -18,6 +18,7 @@ serviceAccount:
 service:
   type: ClusterIP
   port: 8080
+  annotations: {}
 
 # SchemaBot config file contents. Rendered into a ConfigMap and mounted
 # at /config/config.yaml. See docs/configuration.md for all options.
@@ -75,8 +76,11 @@ resources:
     cpu: 1000m
     memory: 512Mi
 
-# Pod annotations (e.g., Istio sidecar config, Datadog).
+# Pod annotations (e.g., Istio sidecar config).
 podAnnotations: {}
+
+# Pod labels (e.g., Datadog unified service tagging).
+podLabels: {}
 
 # Node selector, tolerations, affinity.
 nodeSelector: {}


### PR DESCRIPTION
Adds two commonly needed customization points to the SchemaBot helm chart:

- `service.annotations` — allows setting annotations on the Service resource, needed for LoadBalancer configuration (e.g., internal NLB for webhook ingress)
- `podLabels` — allows setting additional labels on pods, needed for observability tooling that discovers pods by label

Both default to empty and are backwards-compatible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)