### PR TITLE
Add --no-lock flag to CLI apply command

### DIFF
--- a/integration/locks_test.go
+++ b/integration/locks_test.go
@@ -767,8 +767,6 @@ CREATE TABLE users (
 		)
 		// Should not show lock conflict
 		assert.NotContains(t, stripANSI(out), "Database Locked")
-		// Should show the no-lock warning
-		assertContains(t, out, "--no-lock")
 		// Should proceed with apply
 		assertContains(t, out, "Apply started")
 		waitForStateDB(t, endpoint, dbName, "completed", 30*time.Second)

--- a/integration/locks_test.go
+++ b/integration/locks_test.go
@@ -729,6 +729,125 @@ CREATE TABLE users (
 	})
 }
 
+// TestCLI_Locking_NoLockBypassesLocking tests that --no-lock allows apply even when
+// another user holds the lock, and that no lock is acquired by the caller.
+func TestCLI_Locking_NoLockBypassesLocking(t *testing.T) {
+	binPath := buildBinary(t, "schemabot", "./pkg/cmd")
+
+	dbName := fmt.Sprintf("lock_nolock_%d", time.Now().UnixNano())
+
+	schemabotAddr := startSchemaBotLocalDB(t, dbName)
+
+	endpoint := "http://" + schemabotAddr
+
+	schemaDir := newSchemaDirForDB(t, dbName)
+	writeFile(t, filepath.Join(schemaDir, "users.sql"), `
+CREATE TABLE users (
+    id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    email VARCHAR(255) NOT NULL
+);
+`)
+
+	// Another user holds the lock
+	t.Run("other_user_acquires_lock", func(t *testing.T) {
+		resp, err := acquireLockViaAPI(t, endpoint, dbName, "mysql", "cli:otheruser@othermachine", "", 0)
+		require.NoError(t, err, "acquire lock via API")
+		require.Equal(t, 200, resp.StatusCode, "expected 200, got %d", resp.StatusCode)
+		_ = resp.Body.Close()
+	})
+
+	t.Run("apply_with_no_lock_bypasses_lock", func(t *testing.T) {
+		out := runCLIInDir(t, binPath, schemaDir, "apply",
+			"-s", ".",
+			"-e", "staging",
+			"--endpoint", endpoint,
+			"-y",
+			"--watch=false",
+			"--no-lock",
+		)
+		// Should not show lock conflict
+		assert.NotContains(t, stripANSI(out), "Database Locked")
+		// Should show the no-lock warning
+		assertContains(t, out, "--no-lock")
+		// Should proceed with apply
+		assertContains(t, out, "Apply started")
+		waitForStateDB(t, endpoint, dbName, "completed", 30*time.Second)
+	})
+
+	t.Run("original_lock_still_held", func(t *testing.T) {
+		// The other user's lock should still be in place (--no-lock doesn't touch it)
+		out := runCLI(t, binPath, "locks", "--endpoint", endpoint)
+		assertContains(t, out, dbName)
+		assertContains(t, out, "otheruser")
+	})
+
+	// Cleanup
+	t.Run("cleanup", func(t *testing.T) {
+		runCLI(t, binPath, "unlock", "-d", dbName, "-t", "mysql", "--endpoint", endpoint, "--force")
+	})
+}
+
+// TestCLI_Locking_NoLockStillBlockedByActiveApply tests that --no-lock does not bypass
+// the active schema change check. If an apply is already running (or waiting for cutover),
+// a second apply with --no-lock is still blocked by the progress API check.
+func TestCLI_Locking_NoLockStillBlockedByActiveApply(t *testing.T) {
+	binPath := buildBinary(t, "schemabot", "./pkg/cmd")
+
+	dbName := fmt.Sprintf("lock_nolock_active_%d", time.Now().UnixNano())
+
+	schemabotAddr := startSchemaBotLocalDB(t, dbName)
+
+	endpoint := "http://" + schemabotAddr
+
+	schemaDir := newSchemaDirForDB(t, dbName)
+	writeFile(t, filepath.Join(schemaDir, "users.sql"), `
+CREATE TABLE users (
+    id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    email VARCHAR(255) NOT NULL,
+    INDEX idx_email (email)
+);
+`)
+
+	// Start an apply with --defer-cutover so it stays in "waiting for cutover" state
+	t.Run("first_apply_deferred", func(t *testing.T) {
+		out := runCLIInDir(t, binPath, schemaDir, "apply",
+			"-s", ".",
+			"-e", "staging",
+			"--endpoint", endpoint,
+			"-y",
+			"--watch=false",
+			"--defer-cutover",
+			"--no-lock",
+		)
+		assertContains(t, out, "Apply started")
+		waitForStateDB(t, endpoint, dbName, "waiting_for_cutover", 30*time.Second)
+	})
+
+	// Second apply with --no-lock should still be blocked by the active schema change
+	t.Run("second_apply_blocked_by_active_change", func(t *testing.T) {
+		_, err := runCLIWithErrorInDir(t, binPath, schemaDir, "apply",
+			"-s", ".",
+			"-e", "staging",
+			"--endpoint", endpoint,
+			"-y",
+			"--watch=false",
+			"--no-lock",
+		)
+		assert.Error(t, err, "expected second apply to fail due to active schema change")
+	})
+
+	// Cleanup: cutover to complete the deferred apply
+	t.Run("cleanup", func(t *testing.T) {
+		runCLIInDir(t, binPath, schemaDir, "cutover",
+			"-d", dbName,
+			"-e", "staging",
+			"--endpoint", endpoint,
+			"--watch=false",
+		)
+		waitForStateDB(t, endpoint, dbName, "completed", 30*time.Second)
+	})
+}
+
 // TestCLI_Locking_SameEnvDifferentOwners tests lock blocking for same environment, different owners.
 func TestCLI_Locking_SameEnvDifferentOwners(t *testing.T) {
 	binPath := buildBinary(t, "schemabot", "./pkg/cmd")

--- a/integration/locks_test.go
+++ b/integration/locks_test.go
@@ -798,15 +798,41 @@ func TestCLI_Locking_NoLockStillBlockedByActiveApply(t *testing.T) {
 	endpoint := "http://" + schemabotAddr
 
 	schemaDir := newSchemaDirForDB(t, dbName)
-	writeFile(t, filepath.Join(schemaDir, "users.sql"), `
-CREATE TABLE users (
+
+	// Step 1: Create the base table (completes instantly, no Spirit row-copy)
+	writeFile(t, filepath.Join(schemaDir, "orders.sql"), `
+CREATE TABLE orders (
     id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
-    email VARCHAR(255) NOT NULL,
-    INDEX idx_email (email)
+    user_id BIGINT NOT NULL,
+    total_cents BIGINT NOT NULL
 );
 `)
 
-	// Start an apply with --defer-cutover so it stays in "waiting for cutover" state
+	t.Run("setup_base_schema", func(t *testing.T) {
+		out := runCLIInDir(t, binPath, schemaDir, "apply",
+			"-s", ".",
+			"-e", "staging",
+			"--endpoint", endpoint,
+			"-y",
+			"--watch=false",
+			"--no-lock",
+		)
+		assertContains(t, out, "Apply started")
+		waitForStateDB(t, endpoint, dbName, "completed", 30*time.Second)
+	})
+
+	// Step 2: ALTER TABLE with --defer-cutover so Spirit pauses at cutover
+	writeFile(t, filepath.Join(schemaDir, "orders.sql"), `
+CREATE TABLE orders (
+    id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    user_id BIGINT NOT NULL,
+    total_cents BIGINT NOT NULL,
+    INDEX idx_user_id (user_id)
+);
+`)
+
+	var applyID string
+
 	t.Run("first_apply_deferred", func(t *testing.T) {
 		out := runCLIInDir(t, binPath, schemaDir, "apply",
 			"-s", ".",
@@ -818,10 +844,11 @@ CREATE TABLE users (
 			"--no-lock",
 		)
 		assertContains(t, out, "Apply started")
+		applyID = parseApplyID(t, out)
 		waitForStateDB(t, endpoint, dbName, "waiting_for_cutover", 30*time.Second)
 	})
 
-	// Second apply with --no-lock should still be blocked by the active schema change
+	// Step 3: Second apply with --no-lock should still be blocked by the active schema change
 	t.Run("second_apply_blocked_by_active_change", func(t *testing.T) {
 		out, err := runCLIWithErrorInDir(t, binPath, schemaDir, "apply",
 			"-s", ".",
@@ -838,8 +865,7 @@ CREATE TABLE users (
 	// Cleanup: cutover to complete the deferred apply
 	t.Run("cleanup", func(t *testing.T) {
 		runCLIInDir(t, binPath, schemaDir, "cutover",
-			"-d", dbName,
-			"-e", "staging",
+			applyID,
 			"--endpoint", endpoint,
 			"--watch=false",
 		)

--- a/integration/locks_test.go
+++ b/integration/locks_test.go
@@ -823,7 +823,7 @@ CREATE TABLE users (
 
 	// Second apply with --no-lock should still be blocked by the active schema change
 	t.Run("second_apply_blocked_by_active_change", func(t *testing.T) {
-		_, err := runCLIWithErrorInDir(t, binPath, schemaDir, "apply",
+		out, err := runCLIWithErrorInDir(t, binPath, schemaDir, "apply",
 			"-s", ".",
 			"-e", "staging",
 			"--endpoint", endpoint,
@@ -832,6 +832,7 @@ CREATE TABLE users (
 			"--no-lock",
 		)
 		assert.Error(t, err, "expected second apply to fail due to active schema change")
+		assertContains(t, out, "Schema Change In Progress")
 	})
 
 	// Cleanup: cutover to complete the deferred apply

--- a/pkg/cmd/commands/apply.go
+++ b/pkg/cmd/commands/apply.go
@@ -34,6 +34,13 @@ type ApplyCmd struct {
 
 // Run executes the apply command.
 func (cmd *ApplyCmd) Run(g *Globals) error {
+	if cmd.NoLock && cmd.Force {
+		return fmt.Errorf("--no-lock and --force are mutually exclusive")
+	}
+	if cmd.NoLock && cmd.Yield {
+		return fmt.Errorf("--no-lock and --yield are mutually exclusive")
+	}
+
 	// Load config from schema directory
 	cfg, err := LoadCLIConfig(cmd.SchemaDir)
 	if err != nil {

--- a/pkg/cmd/commands/apply.go
+++ b/pkg/cmd/commands/apply.go
@@ -35,10 +35,10 @@ type ApplyCmd struct {
 // Run executes the apply command.
 func (cmd *ApplyCmd) Run(g *Globals) error {
 	if cmd.NoLock && cmd.Force {
-		return fmt.Errorf("--no-lock and --force are mutually exclusive")
+		return fmt.Errorf("--force requires locking to break an existing lock; remove --no-lock to use it")
 	}
 	if cmd.NoLock && cmd.Yield {
-		return fmt.Errorf("--no-lock and --yield are mutually exclusive")
+		return fmt.Errorf("--yield requires locking to release after completion; remove --no-lock to use it")
 	}
 
 	// Load config from schema directory

--- a/pkg/cmd/commands/apply.go
+++ b/pkg/cmd/commands/apply.go
@@ -160,9 +160,7 @@ func (cmd *ApplyCmd) Run(g *Globals) error {
 
 	// Step 4: Acquire lock and apply the plan
 
-	if cmd.NoLock {
-		fmt.Printf("\n%sWarning: --no-lock skips lock acquisition. Cross-environment lock protection is disabled.%s\n", templates.ANSIYellow, templates.ANSIReset)
-	} else {
+	if !cmd.NoLock {
 		// If --force, break any existing lock first
 		if cmd.Force {
 			existingLock, err := client.GetLock(ep, cfg.Database, cfg.Type)

--- a/pkg/cmd/commands/apply.go
+++ b/pkg/cmd/commands/apply.go
@@ -27,6 +27,7 @@ type ApplyCmd struct {
 	AllowUnsafe  bool          `help:"Allow destructive changes (DROP TABLE, DROP COLUMN, etc.)" name:"allow-unsafe"`
 	Force        bool          `help:"Force acquire lock (breaks existing lock from another owner)"`
 	Yield        bool          `help:"Yield lock after successful completion"`
+	NoLock       bool          `help:"Don't hold a database lock during the operation" name:"no-lock"`
 	Output       OutputFormat  `short:"o" help:"Output format" default:"interactive" enum:"interactive,log,json"`
 	LogHeartbeat time.Duration `help:"Interval between progress heartbeats in log mode" default:"10s" name:"log-heartbeat"`
 }
@@ -113,8 +114,8 @@ func (cmd *ApplyCmd) Run(g *Globals) error {
 		return blockUnsafeApply(planResult, cfg.Database, cmd.Environment, cfg.SchemaDir)
 	}
 
-	// Check lock availability before showing plan (unless --force will break it anyway)
-	if !cmd.Force {
+	// Check lock availability before showing plan (unless --force will break it anyway or --no-lock skips locking)
+	if !cmd.NoLock && !cmd.Force {
 		existingLock, err := client.GetLock(ep, cfg.Database, cfg.Type)
 		if err != nil {
 			return fmt.Errorf("check lock: %w", err)
@@ -159,46 +160,50 @@ func (cmd *ApplyCmd) Run(g *Globals) error {
 
 	// Step 4: Acquire lock and apply the plan
 
-	// If --force, break any existing lock first
-	if cmd.Force {
-		existingLock, err := client.GetLock(ep, cfg.Database, cfg.Type)
-		if err != nil {
-			return fmt.Errorf("check existing lock: %w", err)
-		}
-		if existingLock != nil && existingLock.Owner != owner {
-			if err := client.ForceReleaseLock(ep, cfg.Database, cfg.Type); err != nil {
-				return fmt.Errorf("force release lock: %w", err)
+	if cmd.NoLock {
+		fmt.Printf("\n%sWarning: --no-lock skips lock acquisition. Cross-environment lock protection is disabled.%s\n", templates.ANSIYellow, templates.ANSIReset)
+	} else {
+		// If --force, break any existing lock first
+		if cmd.Force {
+			existingLock, err := client.GetLock(ep, cfg.Database, cfg.Type)
+			if err != nil {
+				return fmt.Errorf("check existing lock: %w", err)
 			}
-			templates.WriteLockForceReleased(cfg.Database, cfg.Type, existingLock.Owner)
+			if existingLock != nil && existingLock.Owner != owner {
+				if err := client.ForceReleaseLock(ep, cfg.Database, cfg.Type); err != nil {
+					return fmt.Errorf("force release lock: %w", err)
+				}
+				templates.WriteLockForceReleased(cfg.Database, cfg.Type, existingLock.Owner)
+			}
 		}
-	}
 
-	// Acquire the lock
-	_, err = client.AcquireLock(ep, cfg.Database, cfg.Type, owner, cmd.Repository, cmd.PullRequest)
-	if errors.Is(err, client.ErrLockHeld) {
-		// Lock is held by someone else - show conflict message
-		existingLock, getErr := client.GetLock(ep, cfg.Database, cfg.Type)
-		if getErr != nil || existingLock == nil {
-			return fmt.Errorf("database is locked by another user")
+		// Acquire the lock
+		_, err = client.AcquireLock(ep, cfg.Database, cfg.Type, owner, cmd.Repository, cmd.PullRequest)
+		if errors.Is(err, client.ErrLockHeld) {
+			// Lock is held by someone else - show conflict message
+			existingLock, getErr := client.GetLock(ep, cfg.Database, cfg.Type)
+			if getErr != nil || existingLock == nil {
+				return fmt.Errorf("database is locked by another user")
+			}
+			templates.WriteLockConflict(templates.LockConflictData{
+				Database:     cfg.Database,
+				DatabaseType: cfg.Type,
+				Owner:        existingLock.Owner,
+				Repository:   existingLock.Repository,
+				PullRequest:  existingLock.PullRequest,
+				CreatedAt:    existingLock.CreatedAt,
+			})
+			return fmt.Errorf("database is locked")
 		}
-		templates.WriteLockConflict(templates.LockConflictData{
+		if err != nil {
+			return fmt.Errorf("acquire lock: %w", err)
+		}
+		templates.WriteLockAcquired(templates.LockData{
 			Database:     cfg.Database,
 			DatabaseType: cfg.Type,
-			Owner:        existingLock.Owner,
-			Repository:   existingLock.Repository,
-			PullRequest:  existingLock.PullRequest,
-			CreatedAt:    existingLock.CreatedAt,
+			Owner:        owner,
 		})
-		return fmt.Errorf("database is locked")
 	}
-	if err != nil {
-		return fmt.Errorf("acquire lock: %w", err)
-	}
-	templates.WriteLockAcquired(templates.LockData{
-		Database:     cfg.Database,
-		DatabaseType: cfg.Type,
-		Owner:        owner,
-	})
 
 	fmt.Println("\nApplying changes...")
 
@@ -207,7 +212,7 @@ func (cmd *ApplyCmd) Run(g *Globals) error {
 	}
 
 	// Yield lock if requested and apply was successful
-	if cmd.Yield {
+	if cmd.Yield && !cmd.NoLock {
 		if err := client.ReleaseLock(ep, cfg.Database, cfg.Type, owner); err != nil {
 			fmt.Printf("Warning: failed to release lock: %v\n", err)
 		} else {


### PR DESCRIPTION
Adds `--no-lock` to `schemabot apply`, allowing the CLI to skip lock acquisition and release during the operation. Follows the same pattern as Terraform's `-lock=false`.

Locking is a coordination mechanism that prevents concurrent schema changes across environments and callers for a single database. In some deployment topologies — it's possible that an endpoint doesn't implement the lock API — and locking adds friction without benefit. Using `--no-lock` leaves this to operator discretion. Note however that there is still a server-side active schema change check, so concurrent applies on the same database and environment are still blocked regardless of this flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)