### PR TITLE
cli/api: error handling and retry for TUI progress polling

### DIFF
--- a/pkg/api/health_handlers.go
+++ b/pkg/api/health_handlers.go
@@ -3,6 +3,8 @@ package api
 import (
 	"encoding/json"
 	"net/http"
+
+	"github.com/block/schemabot/pkg/apitypes"
 )
 
 func (s *Service) handleHealth(w http.ResponseWriter, r *http.Request) {
@@ -46,7 +48,13 @@ func (s *Service) writeJSON(w http.ResponseWriter, status int, v any) {
 	}
 }
 
-// writeError writes a JSON error response.
+// writeError writes a JSON error response without an error code.
 func (s *Service) writeError(w http.ResponseWriter, status int, message string) {
-	s.writeJSON(w, status, map[string]string{"error": message})
+	s.writeJSON(w, status, apitypes.ErrorResponse{Error: message})
+}
+
+// writeErrorCode writes a JSON error response with an error code.
+// Clients should match on error_code rather than parsing the error message.
+func (s *Service) writeErrorCode(w http.ResponseWriter, status int, code, message string) {
+	s.writeJSON(w, status, apitypes.ErrorResponse{Error: message, ErrorCode: code})
 }

--- a/pkg/api/progress_handlers.go
+++ b/pkg/api/progress_handlers.go
@@ -14,7 +14,7 @@ import (
 	"github.com/block/schemabot/pkg/tern"
 )
 
-// deriveErrorCode returns a machine-readable error code based on apply state
+// deriveErrorCode returns an error code based on apply state
 // and error message. Returns empty string when no error code applies.
 func deriveErrorCode(applyState, errorMessage string) string {
 	if errorMessage != "" && state.IsState(applyState, state.Apply.Failed) {
@@ -128,7 +128,7 @@ func (s *Service) GetProgress(ctx context.Context, database, environment string)
 func (s *Service) handleProgress(w http.ResponseWriter, r *http.Request) {
 	database := r.PathValue("database")
 	if database == "" {
-		s.writeError(w, http.StatusBadRequest, "database is required")
+		s.writeErrorCode(w, http.StatusBadRequest, apitypes.ErrCodeInvalidRequest, "database is required")
 		return
 	}
 
@@ -144,7 +144,7 @@ func (s *Service) handleProgress(w http.ResponseWriter, r *http.Request) {
 	if qApplyID := r.URL.Query().Get("apply_id"); qApplyID != "" {
 		resolved, err := s.resolveApplyID(r.Context(), qApplyID)
 		if err != nil {
-			s.writeError(w, http.StatusInternalServerError, "failed to resolve apply_id: "+err.Error())
+			s.writeErrorCode(w, http.StatusInternalServerError, apitypes.ErrCodeStorageError, "failed to resolve apply_id: "+err.Error())
 			return
 		}
 		ternApplyID = resolved
@@ -153,8 +153,8 @@ func (s *Service) handleProgress(w http.ResponseWriter, r *http.Request) {
 		var err error
 		ternApplyID, activeApply, err = s.findActiveApplyID(r.Context(), database, environment)
 		if err != nil {
-			s.logger.Error("failed to resolve active apply", "database", database, "error", err)
-			s.writeError(w, http.StatusInternalServerError, "failed to resolve active apply: "+err.Error())
+			s.logger.Error("failed to look up active apply from storage", "database", database, "environment", environment, "error", err)
+			s.writeErrorCode(w, http.StatusInternalServerError, apitypes.ErrCodeStorageError, "failed to look up active apply: "+err.Error())
 			return
 		}
 	}
@@ -169,7 +169,7 @@ func (s *Service) handleProgress(w http.ResponseWriter, r *http.Request) {
 
 	client, err := s.TernClient(deployment, environment)
 	if err != nil {
-		s.writeError(w, http.StatusNotFound, err.Error())
+		s.writeErrorCode(w, http.StatusNotFound, apitypes.ErrCodeDeploymentNotFound, err.Error())
 		return
 	}
 
@@ -179,7 +179,7 @@ func (s *Service) handleProgress(w http.ResponseWriter, r *http.Request) {
 	})
 	if err != nil {
 		s.logger.Error("progress failed", "database", database, "error", err)
-		s.writeError(w, http.StatusInternalServerError, "progress failed: "+err.Error())
+		s.writeErrorCode(w, http.StatusInternalServerError, apitypes.ErrCodeEngineUnavailable, "progress failed: "+err.Error())
 		return
 	}
 
@@ -202,7 +202,7 @@ func (s *Service) handleProgress(w http.ResponseWriter, r *http.Request) {
 func (s *Service) handleProgressByApplyID(w http.ResponseWriter, r *http.Request) {
 	applyID := r.PathValue("apply_id")
 	if applyID == "" {
-		s.writeError(w, http.StatusBadRequest, "apply_id is required")
+		s.writeErrorCode(w, http.StatusBadRequest, apitypes.ErrCodeInvalidRequest, "apply_id is required")
 		return
 	}
 
@@ -210,11 +210,11 @@ func (s *Service) handleProgressByApplyID(w http.ResponseWriter, r *http.Request
 	apply, err := s.storage.Applies().GetByApplyIdentifier(r.Context(), applyID)
 	if err != nil {
 		s.logger.Error("failed to get apply", "apply_id", applyID, "error", err)
-		s.writeError(w, http.StatusInternalServerError, "failed to get apply: "+err.Error())
+		s.writeErrorCode(w, http.StatusInternalServerError, apitypes.ErrCodeStorageError, "failed to get apply: "+err.Error())
 		return
 	}
 	if apply == nil {
-		s.writeError(w, http.StatusNotFound, "apply not found: "+applyID)
+		s.writeErrorCode(w, http.StatusNotFound, apitypes.ErrCodeNotFound, "apply not found: "+applyID)
 		return
 	}
 
@@ -222,8 +222,8 @@ func (s *Service) handleProgressByApplyID(w http.ResponseWriter, r *http.Request
 	if state.IsTerminalApplyState(apply.State) {
 		httpResp, err := s.progressFromLocalStorage(r.Context(), apply)
 		if err != nil {
-			s.logger.Error("local progress failed", "apply_id", applyID, "error", err)
-			s.writeError(w, http.StatusInternalServerError, "progress failed: "+err.Error())
+			s.logger.Error("failed to read tasks from storage for terminal apply", "apply_id", applyID, "error", err)
+			s.writeErrorCode(w, http.StatusInternalServerError, apitypes.ErrCodeStorageError, "failed to read tasks: "+err.Error())
 			return
 		}
 		s.writeJSON(w, http.StatusOK, httpResp)
@@ -235,7 +235,7 @@ func (s *Service) handleProgressByApplyID(w http.ResponseWriter, r *http.Request
 
 	client, err := s.TernClient(deployment, apply.Environment)
 	if err != nil {
-		s.writeError(w, http.StatusNotFound, err.Error())
+		s.writeErrorCode(w, http.StatusNotFound, apitypes.ErrCodeDeploymentNotFound, err.Error())
 		return
 	}
 
@@ -251,7 +251,7 @@ func (s *Service) handleProgressByApplyID(w http.ResponseWriter, r *http.Request
 	})
 	if err != nil {
 		s.logger.Error("progress failed", "apply_id", applyID, "database", apply.Database, "error", err)
-		s.writeError(w, http.StatusInternalServerError, "progress failed: "+err.Error())
+		s.writeErrorCode(w, http.StatusInternalServerError, apitypes.ErrCodeEngineUnavailable, "progress failed: "+err.Error())
 		return
 	}
 

--- a/pkg/apitypes/apitypes.go
+++ b/pkg/apitypes/apitypes.go
@@ -7,18 +7,37 @@ package apitypes
 // Error Codes
 // =============================================================================
 
-// Machine-readable error codes returned in API responses. Clients should
-// match on these constants rather than parsing error_message strings.
+// Error codes returned in API responses. Clients should match on these
+// constants rather than parsing error_message strings or HTTP status codes.
+// Use IsRetryableErrorCode to determine whether a given code is retryable.
 const (
-	// ErrCodeStateSyncFailed indicates the operation succeeded on the backend
-	// but local state synchronization failed. Status and progress endpoints
-	// may show stale state until the next recovery cycle.
-	ErrCodeStateSyncFailed = "state_sync_failed"
-
-	// ErrCodeEngineError indicates the schema change engine (Spirit, PlanetScale)
-	// encountered a failure during execution.
-	ErrCodeEngineError = "engine_error"
+	ErrCodeInvalidRequest     = "invalid_request"      // Malformed request (missing params, bad values)
+	ErrCodeNotFound           = "not_found"            // Resource doesn't exist (unknown apply ID, database)
+	ErrCodeDeploymentNotFound = "deployment_not_found" // No tern deployment configured for database/environment
+	ErrCodeEngineError        = "engine_error"         // Schema change engine failure during execution
+	ErrCodeStorageError       = "storage_error"        // Storage backend (MySQL) read/write failure
+	ErrCodeEngineUnavailable  = "engine_unavailable"   // Schema change engine (Tern) unreachable or RPC error
+	ErrCodeStateSyncFailed    = "state_sync_failed"    // Operation succeeded but local state sync failed
 )
+
+var retryableErrorCodes = map[string]bool{
+	ErrCodeStorageError:      true,
+	ErrCodeEngineUnavailable: true,
+	ErrCodeStateSyncFailed:   true,
+}
+
+// IsRetryableErrorCode reports whether the given API error code represents a
+// transient failure that clients should retry with backoff.
+func IsRetryableErrorCode(code string) bool {
+	return retryableErrorCodes[code]
+}
+
+// ErrorResponse is the standard error response body for non-200 HTTP responses.
+// All error endpoints return this shape.
+type ErrorResponse struct {
+	Error     string `json:"error"`
+	ErrorCode string `json:"error_code"`
+}
 
 // =============================================================================
 // Request Types

--- a/pkg/cmd/client/client.go
+++ b/pkg/cmd/client/client.go
@@ -443,10 +443,10 @@ func ReleaseLock(endpoint, database, dbType, owner string) error {
 	if err != nil {
 		var apiErr *APIError
 		if errors.As(err, &apiErr) {
-			if apiErr.StatusCode == http.StatusForbidden {
+			if apiErr.Status == http.StatusForbidden {
 				return ErrLockNotOwned
 			}
-			if apiErr.StatusCode == http.StatusNotFound {
+			if apiErr.Status == http.StatusNotFound {
 				return ErrLockNotFound
 			}
 		}

--- a/pkg/cmd/client/request.go
+++ b/pkg/cmd/client/request.go
@@ -16,10 +16,11 @@ import (
 // Uses a 30s timeout to avoid hanging indefinitely on network stalls.
 var httpClient = &http.Client{Timeout: 30 * time.Second}
 
-// APIError represents an error response from the API with an HTTP status code.
+// APIError represents an error response from the API.
 type APIError struct {
-	StatusCode int
-	Message    string
+	Status    int    // HTTP status code (e.g., 404, 500)
+	ErrorCode string // Error code from API response (e.g., "not_found", "storage_error")
+	Message   string
 }
 
 func (e *APIError) Error() string {
@@ -29,7 +30,7 @@ func (e *APIError) Error() string {
 // IsNotFound reports whether the error is a 404 from the API.
 func IsNotFound(err error) bool {
 	var apiErr *APIError
-	return errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusNotFound
+	return errors.As(err, &apiErr) && apiErr.Status == http.StatusNotFound
 }
 
 // doGetInto sends a GET request and unmarshals the JSON response into result.
@@ -56,10 +57,7 @@ func doGetIntoCtx(ctx context.Context, endpoint, path string, result any) error 
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return &APIError{
-			StatusCode: resp.StatusCode,
-			Message:    FormatAPIError(resp.StatusCode, respBody),
-		}
+		return parseAPIError(resp.StatusCode, respBody)
 	}
 
 	if err := json.Unmarshal(respBody, result); err != nil {
@@ -92,10 +90,7 @@ func doSendBody(endpoint, method, path string, body any) error {
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return &APIError{
-			StatusCode: resp.StatusCode,
-			Message:    FormatAPIError(resp.StatusCode, respBody),
-		}
+		return parseAPIError(resp.StatusCode, respBody)
 	}
 	return nil
 }
@@ -124,10 +119,7 @@ func doPostInto(endpoint, path string, body any, result any) error {
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return &APIError{
-			StatusCode: resp.StatusCode,
-			Message:    FormatAPIError(resp.StatusCode, respBody),
-		}
+		return parseAPIError(resp.StatusCode, respBody)
 	}
 
 	if err := json.Unmarshal(respBody, result); err != nil {
@@ -136,18 +128,55 @@ func doPostInto(endpoint, path string, body any, result any) error {
 	return nil
 }
 
-// FormatConnectionError returns a user-friendly error for connection failures.
+// parseAPIError builds an APIError from a non-200 HTTP response, extracting
+// the error_code if present in the JSON body.
+func parseAPIError(statusCode int, body []byte) *APIError {
+	apiErr := &APIError{
+		Status:  statusCode,
+		Message: FormatAPIError(statusCode, body),
+	}
+	var resp struct {
+		ErrorCode string `json:"error_code"`
+	}
+	if json.Unmarshal(body, &resp) == nil && resp.ErrorCode != "" {
+		apiErr.ErrorCode = resp.ErrorCode
+	}
+	return apiErr
+}
+
+// ConnectionError represents a client-side failure to reach the server
+// (connection refused, DNS resolution, timeout). Distinct from APIError,
+// which means the server responded with a non-200 status.
+type ConnectionError struct {
+	Endpoint string
+	Err      error
+}
+
+func (e *ConnectionError) Error() string {
+	return e.message()
+}
+
+func (e *ConnectionError) Unwrap() error {
+	return e.Err
+}
+
+func (e *ConnectionError) message() string {
+	msg := e.Err.Error()
+	if strings.Contains(msg, "connection refused") {
+		return fmt.Sprintf("cannot connect to %s (is the server running?)", e.Endpoint)
+	}
+	if strings.Contains(msg, "no such host") {
+		return fmt.Sprintf("cannot resolve host: %s", e.Endpoint)
+	}
+	if strings.Contains(msg, "timeout") {
+		return fmt.Sprintf("connection timeout: %s", e.Endpoint)
+	}
+	return fmt.Sprintf("connection failed: %s", e.Endpoint)
+}
+
+// FormatConnectionError returns a ConnectionError wrapping the underlying cause.
 func FormatConnectionError(endpoint string, err error) error {
-	if strings.Contains(err.Error(), "connection refused") {
-		return fmt.Errorf("cannot connect to %s (is the server running?)", endpoint)
-	}
-	if strings.Contains(err.Error(), "no such host") {
-		return fmt.Errorf("cannot resolve host: %s", endpoint)
-	}
-	if strings.Contains(err.Error(), "timeout") {
-		return fmt.Errorf("connection timeout: %s", endpoint)
-	}
-	return fmt.Errorf("connection failed: %s", endpoint)
+	return &ConnectionError{Endpoint: endpoint, Err: err}
 }
 
 // FormatAPIError returns a user-friendly error message from an API response.

--- a/pkg/cmd/commands/watch_tui.go
+++ b/pkg/cmd/commands/watch_tui.go
@@ -158,6 +158,15 @@ func (m WatchModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, tea.Batch(m.fetchProgress(), m.tick())
 
 	case progressMsg:
+		// Connection error: the server didn't respond (empty state + error).
+		// Preserve last known state and tables, show the error, keep polling.
+		// Don't mark as initialized or set a terminal state — we don't know
+		// whether the apply succeeded, failed, or is still running.
+		if msg.errorMsg != "" && msg.state == "" {
+			m.errorMsg = msg.errorMsg
+			return m, nil
+		}
+
 		m.state = msg.state
 		// Preserve last known tables during volume change to avoid visual reset
 		if !m.volumeChanging || len(m.tables) == 0 {

--- a/pkg/cmd/commands/watch_tui.go
+++ b/pkg/cmd/commands/watch_tui.go
@@ -29,14 +29,15 @@ type WatchModel struct {
 	currentVolume int // Current volume (1-11)
 
 	// UI state
-	detached       bool
-	quitting       bool
-	spinner        spinner.Model
-	startedAt      time.Time
-	initialized    bool
-	volumeMode     bool // True when in volume adjustment mode
-	volumePending  int  // Pending volume change (0 = none)
-	volumeChanging bool // True while volume change is in progress
+	detached          bool
+	quitting          bool
+	spinner           spinner.Model
+	startedAt         time.Time
+	initialized       bool
+	volumeMode        bool // True when in volume adjustment mode
+	volumePending     int  // Pending volume change (0 = none)
+	volumeChanging    bool // True while volume change is in progress
+	consecutiveErrors int  // Consecutive fetch failures (drives backoff)
 }
 
 // tableProgress represents progress for a single table.
@@ -54,11 +55,17 @@ type tableProgress struct {
 // Messages
 type tickMsg time.Time
 
+// Error codes for progressMsg.errorCode.
+const (
+	errRetryable = "retryable" // 5xx, connection refused, timeout — retry with backoff
+	errPermanent = "permanent" // 4xx: bad request, not found — don't retry
+)
+
 type progressMsg struct {
 	state       string
 	tables      []tableProgress
-	errorMsg    string
-	fetchErr    bool // true when the API call itself failed (connection, timeout, HTTP error)
+	errorMsg    string // Human-readable error message
+	errorCode   string // "" on success, errRetryable or errPermanent on fetch failure
 	volume      int
 	applyID     string // Populated from progress responses
 	database    string // Populated from apply-id progress responses
@@ -159,15 +166,22 @@ func (m WatchModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, tea.Batch(m.fetchProgress(), m.tick())
 
 	case progressMsg:
-		// API call failed (connection refused, timeout, HTTP error, bad JSON).
-		// Preserve last known state and tables, show the error, keep polling.
-		// Don't mark as initialized or set a terminal state — we don't know
-		// whether the apply succeeded, failed, or is still running.
-		if msg.fetchErr {
+		switch msg.errorCode {
+		case errRetryable:
+			// 5xx, connection refused, timeout, DNS failure.
+			// Preserve last known state and tables, keep polling with backoff.
+			m.consecutiveErrors++
 			m.errorMsg = msg.errorMsg
 			return m, nil
+		case errPermanent:
+			// 4xx: bad request, not found, etc. Retrying won't help.
+			m.errorMsg = msg.errorMsg
+			m.initialized = true
+			return m, tea.Quit
 		}
 
+		m.consecutiveErrors = 0
+		m.errorMsg = ""
 		m.state = msg.state
 		// Preserve last known tables during volume change to avoid visual reset
 		if !m.volumeChanging || len(m.tables) == 0 {

--- a/pkg/cmd/commands/watch_tui.go
+++ b/pkg/cmd/commands/watch_tui.go
@@ -1,12 +1,15 @@
 package commands
 
 import (
+	"errors"
 	"time"
 
 	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 
+	"github.com/block/schemabot/pkg/apitypes"
+	"github.com/block/schemabot/pkg/cmd/client"
 	"github.com/block/schemabot/pkg/state"
 )
 
@@ -55,17 +58,29 @@ type tableProgress struct {
 // Messages
 type tickMsg time.Time
 
-// Error codes for progressMsg.errorCode.
-const (
-	errRetryable = "retryable" // 5xx, connection refused, timeout — retry with backoff
-	errPermanent = "permanent" // 4xx: bad request, not found — don't retry
-)
+// isRetryableFetchError reports whether a fetch error is retryable.
+//
+//   - ConnectionError (server unreachable): always retryable.
+//   - APIError with error code: classified by apitypes.IsRetryableErrorCode.
+//   - APIError without error code, or unknown error types: permanent.
+func isRetryableFetchError(err error) bool {
+	var connErr *client.ConnectionError
+	if errors.As(err, &connErr) {
+		return true
+	}
+	var apiErr *client.APIError
+	if errors.As(err, &apiErr) && apiErr.ErrorCode != "" {
+		return apitypes.IsRetryableErrorCode(apiErr.ErrorCode)
+	}
+	return false
+}
 
 type progressMsg struct {
 	state       string
 	tables      []tableProgress
 	errorMsg    string // Human-readable error message
-	errorCode   string // "" on success, errRetryable or errPermanent on fetch failure
+	failed      bool   // true when the API call didn't return usable progress data
+	retryable   bool   // when failed, whether the TUI should keep polling
 	volume      int
 	applyID     string // Populated from progress responses
 	database    string // Populated from apply-id progress responses
@@ -166,15 +181,15 @@ func (m WatchModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, tea.Batch(m.fetchProgress(), m.tick())
 
 	case progressMsg:
-		switch msg.errorCode {
-		case errRetryable:
-			// 5xx, connection refused, timeout, DNS failure.
+		if msg.failed && msg.retryable {
+			// Transient error (connection refused, timeout, engine_unavailable).
 			// Preserve last known state and tables, keep polling with backoff.
 			m.consecutiveErrors++
 			m.errorMsg = msg.errorMsg
 			return m, nil
-		case errPermanent:
-			// 4xx: bad request, not found, etc. Retrying won't help.
+		}
+		if msg.failed && !msg.retryable {
+			// Permanent error (not_found, invalid_request, deployment_not_found).
 			m.errorMsg = msg.errorMsg
 			m.initialized = true
 			return m, tea.Quit

--- a/pkg/cmd/commands/watch_tui.go
+++ b/pkg/cmd/commands/watch_tui.go
@@ -58,6 +58,7 @@ type progressMsg struct {
 	state       string
 	tables      []tableProgress
 	errorMsg    string
+	fetchErr    bool // true when the API call itself failed (connection, timeout, HTTP error)
 	volume      int
 	applyID     string // Populated from progress responses
 	database    string // Populated from apply-id progress responses
@@ -158,11 +159,11 @@ func (m WatchModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, tea.Batch(m.fetchProgress(), m.tick())
 
 	case progressMsg:
-		// Connection error: the server didn't respond (empty state + error).
+		// API call failed (connection refused, timeout, HTTP error, bad JSON).
 		// Preserve last known state and tables, show the error, keep polling.
 		// Don't mark as initialized or set a terminal state — we don't know
 		// whether the apply succeeded, failed, or is still running.
-		if msg.errorMsg != "" && msg.state == "" {
+		if msg.fetchErr {
 			m.errorMsg = msg.errorMsg
 			return m, nil
 		}

--- a/pkg/cmd/commands/watch_tui_commands.go
+++ b/pkg/cmd/commands/watch_tui_commands.go
@@ -1,7 +1,6 @@
 package commands
 
 import (
-	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -28,10 +27,7 @@ const maxPollInterval = 30 * time.Second
 func (m WatchModel) tick() tea.Cmd {
 	d := pollInterval
 	if m.consecutiveErrors > 0 {
-		d = pollInterval << min(m.consecutiveErrors, 4) // 4s, 8s, 16s, 32→30s cap
-		if d > maxPollInterval {
-			d = maxPollInterval
-		}
+		d = min(pollInterval<<min(m.consecutiveErrors, 4), maxPollInterval)
 	}
 	return tea.Tick(d, func(t time.Time) tea.Msg {
 		return tickMsg(t)
@@ -48,12 +44,11 @@ func (m WatchModel) fetchProgress() tea.Cmd {
 			result, err = client.GetProgress(m.endpoint, m.database, m.environment)
 		}
 		if err != nil {
-			code := errRetryable
-			var apiErr *client.APIError
-			if errors.As(err, &apiErr) && apiErr.StatusCode >= 400 && apiErr.StatusCode < 500 {
-				code = errPermanent
+			return progressMsg{
+				errorMsg:  err.Error(),
+				failed:    true,
+				retryable: isRetryableFetchError(err),
 			}
-			return progressMsg{errorMsg: err.Error(), errorCode: code}
 		}
 
 		return parseProgressResult(result)

--- a/pkg/cmd/commands/watch_tui_commands.go
+++ b/pkg/cmd/commands/watch_tui_commands.go
@@ -34,7 +34,7 @@ func (m WatchModel) fetchProgress() tea.Cmd {
 			result, err = client.GetProgress(m.endpoint, m.database, m.environment)
 		}
 		if err != nil {
-			return progressMsg{errorMsg: err.Error()}
+			return progressMsg{errorMsg: err.Error(), fetchErr: true}
 		}
 
 		return parseProgressResult(result)

--- a/pkg/cmd/commands/watch_tui_commands.go
+++ b/pkg/cmd/commands/watch_tui_commands.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -18,8 +19,21 @@ import (
 
 // Commands (async operations)
 
+// pollInterval is the base polling interval between progress fetches.
+const pollInterval = 2 * time.Second
+
+// maxPollInterval is the ceiling for exponential backoff on consecutive errors.
+const maxPollInterval = 30 * time.Second
+
 func (m WatchModel) tick() tea.Cmd {
-	return tea.Tick(2*time.Second, func(t time.Time) tea.Msg {
+	d := pollInterval
+	if m.consecutiveErrors > 0 {
+		d = pollInterval << min(m.consecutiveErrors, 4) // 4s, 8s, 16s, 32→30s cap
+		if d > maxPollInterval {
+			d = maxPollInterval
+		}
+	}
+	return tea.Tick(d, func(t time.Time) tea.Msg {
 		return tickMsg(t)
 	})
 }
@@ -34,7 +48,12 @@ func (m WatchModel) fetchProgress() tea.Cmd {
 			result, err = client.GetProgress(m.endpoint, m.database, m.environment)
 		}
 		if err != nil {
-			return progressMsg{errorMsg: err.Error(), fetchErr: true}
+			code := errRetryable
+			var apiErr *client.APIError
+			if errors.As(err, &apiErr) && apiErr.StatusCode >= 400 && apiErr.StatusCode < 500 {
+				code = errPermanent
+			}
+			return progressMsg{errorMsg: err.Error(), errorCode: code}
 		}
 
 		return parseProgressResult(result)

--- a/pkg/cmd/commands/watch_tui_test.go
+++ b/pkg/cmd/commands/watch_tui_test.go
@@ -28,7 +28,7 @@ func TestFetchProgress_ServerReturns500_ReturnsError(t *testing.T) {
 	pmsg, ok := msg.(progressMsg)
 	require.True(t, ok, "expected progressMsg, got %T", msg)
 	assert.Empty(t, pmsg.state, "fetchProgress should not set state on error")
-	assert.True(t, pmsg.fetchErr, "fetchProgress should set fetchErr on HTTP error")
+	assert.Equal(t, errRetryable, pmsg.errorCode, "5xx should be classified as transient")
 	assert.Contains(t, pmsg.errorMsg, "500")
 }
 
@@ -46,7 +46,7 @@ func TestFetchProgress_ServerReturnsNoActiveChange(t *testing.T) {
 	pmsg, ok := msg.(progressMsg)
 	require.True(t, ok, "expected progressMsg, got %T", msg)
 	assert.Equal(t, state.NoActiveChange, pmsg.state)
-	assert.False(t, pmsg.fetchErr, "successful response should not set fetchErr")
+	assert.Empty(t, pmsg.errorCode, "successful response should not set errorCode")
 	assert.Empty(t, pmsg.errorMsg)
 }
 
@@ -99,11 +99,11 @@ func TestWatchModel_MidFlightError_PreservesLastState(t *testing.T) {
 	assert.True(t, m.initialized)
 	assert.Equal(t, state.Apply.Running, m.state)
 
-	// Second: server crashes — API call fails (fetchErr distinguishes this
+	// Second: server crashes — API call fails (errorCode distinguishes this
 	// from a server response that happens to have an empty state).
 	errorMsg := progressMsg{
-		errorMsg: "500: connection refused",
-		fetchErr: true,
+		errorMsg:  "500: connection refused",
+		errorCode: errRetryable,
 	}
 	updated, cmd := m.Update(errorMsg)
 	m = updated.(WatchModel)
@@ -136,8 +136,8 @@ func TestWatchModel_ConnectionError_CanEscape(t *testing.T) {
 	// User should be able to ESC out of the loading+error state.
 	m := NewWatchModel("http://localhost:8080", "testdb", "staging", false)
 
-	// Simulate fetch error (API call failed).
-	updated, _ := m.Update(progressMsg{errorMsg: "connection refused", fetchErr: true})
+	// Simulate transient fetch error (API call failed).
+	updated, _ := m.Update(progressMsg{errorMsg: "connection refused", errorCode: errRetryable})
 	m = updated.(WatchModel)
 	assert.False(t, m.initialized)
 
@@ -165,6 +165,63 @@ func TestWatchModel_ServerErrorWithState_TreatedAsRealResponse(t *testing.T) {
 	assert.Equal(t, state.Apply.Failed, model.state)
 	assert.Contains(t, model.errorMsg, "checksum mismatch")
 	assert.NotNil(t, cmd, "terminal state should return tea.Quit")
+}
+
+func TestFetchProgress_ServerReturns404_PermanentError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = fmt.Fprint(w, `{"error":"apply not found"}`)
+	}))
+	t.Cleanup(srv.Close)
+
+	m := NewWatchModel(srv.URL, "testdb", "staging", false)
+	cmd := m.fetchProgress()
+	msg := cmd()
+
+	pmsg, ok := msg.(progressMsg)
+	require.True(t, ok, "expected progressMsg, got %T", msg)
+	assert.Equal(t, errPermanent, pmsg.errorCode, "4xx should be classified as permanent")
+	assert.Contains(t, pmsg.errorMsg, "apply not found")
+}
+
+func TestWatchModel_PermanentError_QuitsImmediately(t *testing.T) {
+	m := NewWatchModel("http://localhost:8080", "testdb", "staging", false)
+
+	msg := progressMsg{
+		errorMsg:  "apply not found",
+		errorCode: errPermanent,
+	}
+	updated, cmd := m.Update(msg)
+	model := updated.(WatchModel)
+
+	assert.True(t, model.initialized, "permanent error should mark as initialized so view renders")
+	assert.Contains(t, model.errorMsg, "apply not found")
+	assert.NotNil(t, cmd, "permanent error should return tea.Quit")
+
+	view := model.View()
+	assert.Contains(t, view, "apply not found")
+	assert.NotContains(t, view, "Loading")
+}
+
+func TestWatchModel_ConsecutiveErrors_IncrementCounter(t *testing.T) {
+	m := NewWatchModel("http://localhost:8080", "testdb", "staging", false)
+
+	// Three consecutive transient errors.
+	for i := 1; i <= 3; i++ {
+		updated, cmd := m.Update(progressMsg{
+			errorMsg:  "connection refused",
+			errorCode: errRetryable,
+		})
+		m = updated.(WatchModel)
+		assert.Equal(t, i, m.consecutiveErrors)
+		assert.Nil(t, cmd)
+	}
+
+	// Successful poll resets the counter.
+	updated, _ := m.Update(progressMsg{state: state.Apply.Running})
+	m = updated.(WatchModel)
+	assert.Equal(t, 0, m.consecutiveErrors)
+	assert.Empty(t, m.errorMsg, "error should be cleared on success")
 }
 
 func TestGetProgress_ServerReturns500_CLIReturnsError(t *testing.T) {

--- a/pkg/cmd/commands/watch_tui_test.go
+++ b/pkg/cmd/commands/watch_tui_test.go
@@ -1,0 +1,157 @@
+package commands
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/block/schemabot/pkg/cmd/client"
+	"github.com/block/schemabot/pkg/state"
+)
+
+func TestFetchProgress_ServerReturns500_ReturnsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = fmt.Fprint(w, "internal server error")
+	}))
+	t.Cleanup(srv.Close)
+
+	m := NewWatchModel(srv.URL, "testdb", "staging", false)
+	cmd := m.fetchProgress()
+	msg := cmd()
+
+	pmsg, ok := msg.(progressMsg)
+	require.True(t, ok, "expected progressMsg, got %T", msg)
+	assert.Empty(t, pmsg.state, "fetchProgress should not set state on error")
+	assert.Contains(t, pmsg.errorMsg, "500")
+}
+
+func TestFetchProgress_ServerReturnsNoActiveChange(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"state":"no_active_change","tables":[]}`)
+	}))
+	t.Cleanup(srv.Close)
+
+	m := NewWatchModel(srv.URL, "testdb", "staging", false)
+	cmd := m.fetchProgress()
+	msg := cmd()
+
+	pmsg, ok := msg.(progressMsg)
+	require.True(t, ok, "expected progressMsg, got %T", msg)
+	assert.Equal(t, state.NoActiveChange, pmsg.state)
+	assert.Empty(t, pmsg.errorMsg)
+}
+
+func TestWatchModel_FirstPollError_ShowsLoadingWithError(t *testing.T) {
+	// First poll fails (server 500 before any successful poll).
+	// TUI should stay in loading state with the error visible, not show
+	// "No active schema change" or assume the apply failed.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = fmt.Fprint(w, "progress endpoint not implemented")
+	}))
+	t.Cleanup(srv.Close)
+
+	m := NewWatchModel(srv.URL, "testdb", "staging", false)
+	cmd := m.fetchProgress()
+	msg := cmd()
+
+	updated, retCmd := m.Update(msg)
+	model := updated.(WatchModel)
+
+	assert.False(t, model.initialized,
+		"should not be initialized — we haven't gotten a real response yet")
+	assert.Contains(t, model.errorMsg, "500")
+
+	view := model.View()
+	assert.NotContains(t, view, "No active schema change")
+	assert.Contains(t, view, "Loading",
+		"should still show loading spinner")
+	assert.Contains(t, view, "500",
+		"should show the connection error")
+
+	// Should keep polling — the server may recover.
+	assert.Nil(t, retCmd, "should return nil cmd to continue polling")
+}
+
+func TestWatchModel_MidFlightError_PreservesLastState(t *testing.T) {
+	// Apply is running, then server crashes (returns 500).
+	// TUI should preserve the running state and show the error, not quit.
+	m := NewWatchModel("http://localhost:8080", "testdb", "staging", false)
+
+	// First: a successful poll with running state.
+	successMsg := progressMsg{
+		state: state.Apply.Running,
+		tables: []tableProgress{
+			{Name: "users", Status: state.Apply.Running, RowsCopied: 500, RowsTotal: 1000, Percent: 50},
+		},
+	}
+	updated, _ := m.Update(successMsg)
+	m = updated.(WatchModel)
+	assert.True(t, m.initialized)
+	assert.Equal(t, state.Apply.Running, m.state)
+
+	// Second: server crashes, returns error with empty state.
+	errorMsg := progressMsg{
+		errorMsg: "500: connection refused",
+	}
+	updated, cmd := m.Update(errorMsg)
+	m = updated.(WatchModel)
+
+	// State should be preserved from last successful poll.
+	assert.Equal(t, state.Apply.Running, m.state,
+		"mid-flight error should preserve last known state")
+	assert.Contains(t, m.errorMsg, "500")
+	assert.Len(t, m.tables, 1, "tables should be preserved from last successful poll")
+
+	// TUI should not quit — keep polling.
+	assert.Nil(t, cmd, "should return nil cmd to continue polling")
+}
+
+func TestWatchModel_NoActiveChange_WithoutError(t *testing.T) {
+	m := NewWatchModel("http://localhost:8080", "testdb", "staging", false)
+
+	msg := progressMsg{
+		state: state.NoActiveChange,
+	}
+
+	updated, _ := m.Update(msg)
+	model := updated.(WatchModel)
+
+	view := model.View()
+	assert.Contains(t, view, "No active schema change")
+}
+
+func TestWatchModel_ConnectionError_CanEscape(t *testing.T) {
+	// User should be able to ESC out of the loading+error state.
+	m := NewWatchModel("http://localhost:8080", "testdb", "staging", false)
+
+	// Simulate connection error.
+	updated, _ := m.Update(progressMsg{errorMsg: "connection refused"})
+	m = updated.(WatchModel)
+	assert.False(t, m.initialized)
+
+	// ESC should quit.
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	m = updated.(WatchModel)
+	assert.True(t, m.detached)
+	assert.NotNil(t, cmd, "ESC should return tea.Quit")
+}
+
+func TestGetProgress_ServerReturns500_CLIReturnsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = fmt.Fprint(w, "internal server error")
+	}))
+	t.Cleanup(srv.Close)
+
+	_, err := client.GetProgress(srv.URL, "testdb", "staging")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "500")
+}

--- a/pkg/cmd/commands/watch_tui_test.go
+++ b/pkg/cmd/commands/watch_tui_test.go
@@ -28,7 +28,8 @@ func TestFetchProgress_ServerReturns500_ReturnsError(t *testing.T) {
 	pmsg, ok := msg.(progressMsg)
 	require.True(t, ok, "expected progressMsg, got %T", msg)
 	assert.Empty(t, pmsg.state, "fetchProgress should not set state on error")
-	assert.Equal(t, errRetryable, pmsg.errorCode, "5xx should be classified as transient")
+	assert.True(t, pmsg.failed, "should be a fetch error")
+	assert.False(t, pmsg.retryable, "5xx without error code should not be retryable")
 	assert.Contains(t, pmsg.errorMsg, "500")
 }
 
@@ -46,17 +47,17 @@ func TestFetchProgress_ServerReturnsNoActiveChange(t *testing.T) {
 	pmsg, ok := msg.(progressMsg)
 	require.True(t, ok, "expected progressMsg, got %T", msg)
 	assert.Equal(t, state.NoActiveChange, pmsg.state)
-	assert.Empty(t, pmsg.errorCode, "successful response should not set errorCode")
+	assert.False(t, pmsg.retryable, "successful response should not be marked retryable")
 	assert.Empty(t, pmsg.errorMsg)
 }
 
-func TestWatchModel_FirstPollError_ShowsLoadingWithError(t *testing.T) {
-	// First poll fails (server 500 before any successful poll).
-	// TUI should stay in loading state with the error visible, not show
-	// "No active schema change" or assume the apply failed.
+func TestWatchModel_FirstPollRetryableError_ShowsLoadingWithError(t *testing.T) {
+	// First poll fails with a retryable error (engine unavailable).
+	// TUI should stay in loading state with the error visible.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusInternalServerError)
-		_, _ = fmt.Fprint(w, "progress endpoint not implemented")
+		_, _ = fmt.Fprint(w, `{"error":"progress failed: rpc timeout","error_code":"engine_unavailable"}`)
 	}))
 	t.Cleanup(srv.Close)
 
@@ -69,17 +70,38 @@ func TestWatchModel_FirstPollError_ShowsLoadingWithError(t *testing.T) {
 
 	assert.False(t, model.initialized,
 		"should not be initialized — we haven't gotten a real response yet")
-	assert.Contains(t, model.errorMsg, "500")
+	assert.Contains(t, model.errorMsg, "rpc timeout")
 
 	view := model.View()
 	assert.NotContains(t, view, "No active schema change")
 	assert.Contains(t, view, "Loading",
 		"should still show loading spinner")
-	assert.Contains(t, view, "500",
-		"should show the connection error")
+	assert.Contains(t, view, "rpc timeout",
+		"should show the error")
 
-	// Should keep polling — the server may recover.
-	assert.Nil(t, retCmd, "should return nil cmd to continue polling")
+	assert.Nil(t, retCmd, "retryable error should return nil cmd (tick loop handles retry)")
+}
+
+func TestWatchModel_FirstPollPermanentError_QuitsWithError(t *testing.T) {
+	// First poll fails with a permanent error (not found).
+	// TUI should show the error and quit.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = fmt.Fprint(w, `{"error":"apply not found: abc123","error_code":"not_found"}`)
+	}))
+	t.Cleanup(srv.Close)
+
+	m := NewWatchModel(srv.URL, "testdb", "staging", false)
+	cmd := m.fetchProgress()
+	msg := cmd()
+
+	updated, retCmd := m.Update(msg)
+	model := updated.(WatchModel)
+
+	assert.True(t, model.initialized, "permanent error should mark initialized for view rendering")
+	assert.Contains(t, model.errorMsg, "apply not found")
+	assert.NotNil(t, retCmd, "permanent error should return tea.Quit")
 }
 
 func TestWatchModel_MidFlightError_PreservesLastState(t *testing.T) {
@@ -99,11 +121,12 @@ func TestWatchModel_MidFlightError_PreservesLastState(t *testing.T) {
 	assert.True(t, m.initialized)
 	assert.Equal(t, state.Apply.Running, m.state)
 
-	// Second: server crashes — API call fails (errorCode distinguishes this
+	// Second: server crashes — API call fails (retryable flag distinguishes this
 	// from a server response that happens to have an empty state).
 	errorMsg := progressMsg{
 		errorMsg:  "500: connection refused",
-		errorCode: errRetryable,
+		failed:    true,
+		retryable: true,
 	}
 	updated, cmd := m.Update(errorMsg)
 	m = updated.(WatchModel)
@@ -137,7 +160,7 @@ func TestWatchModel_ConnectionError_CanEscape(t *testing.T) {
 	m := NewWatchModel("http://localhost:8080", "testdb", "staging", false)
 
 	// Simulate transient fetch error (API call failed).
-	updated, _ := m.Update(progressMsg{errorMsg: "connection refused", errorCode: errRetryable})
+	updated, _ := m.Update(progressMsg{errorMsg: "connection refused", failed: true, retryable: true})
 	m = updated.(WatchModel)
 	assert.False(t, m.initialized)
 
@@ -168,6 +191,7 @@ func TestWatchModel_ServerErrorWithState_TreatedAsRealResponse(t *testing.T) {
 }
 
 func TestFetchProgress_ServerReturns404_PermanentError(t *testing.T) {
+	// 404 without error_code — falls back to status code classification.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
 		_, _ = fmt.Fprint(w, `{"error":"apply not found"}`)
@@ -180,16 +204,81 @@ func TestFetchProgress_ServerReturns404_PermanentError(t *testing.T) {
 
 	pmsg, ok := msg.(progressMsg)
 	require.True(t, ok, "expected progressMsg, got %T", msg)
-	assert.Equal(t, errPermanent, pmsg.errorCode, "4xx should be classified as permanent")
+	assert.False(t, pmsg.retryable, "4xx should not be retryable")
 	assert.Contains(t, pmsg.errorMsg, "apply not found")
+}
+
+func TestFetchProgress_ErrorCodeClassification(t *testing.T) {
+	tests := []struct {
+		name      string
+		status    int
+		body      string
+		retryable bool
+	}{
+		{
+			name:      "engine_unavailable is retryable",
+			status:    http.StatusInternalServerError,
+			body:      `{"error":"progress failed: rpc timeout","error_code":"engine_unavailable"}`,
+			retryable: true,
+		},
+		{
+			name:      "storage_error is retryable",
+			status:    http.StatusInternalServerError,
+			body:      `{"error":"failed to get apply: connection lost","error_code":"storage_error"}`,
+			retryable: true,
+		},
+		{
+			name:      "not_found is permanent",
+			status:    http.StatusNotFound,
+			body:      `{"error":"apply not found: abc123","error_code":"not_found"}`,
+			retryable: false,
+		},
+		{
+			name:      "deployment_not_found is permanent",
+			status:    http.StatusNotFound,
+			body:      `{"error":"no deployment configured","error_code":"deployment_not_found"}`,
+			retryable: false,
+		},
+		{
+			name:      "invalid_request is permanent",
+			status:    http.StatusBadRequest,
+			body:      `{"error":"database is required","error_code":"invalid_request"}`,
+			retryable: false,
+		},
+		{
+			name:      "no error_code treated as permanent",
+			status:    http.StatusInternalServerError,
+			body:      `{"error":"internal server error"}`,
+			retryable: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tt.status)
+				_, _ = fmt.Fprint(w, tt.body)
+			}))
+			t.Cleanup(srv.Close)
+
+			m := NewWatchModel(srv.URL, "testdb", "staging", false)
+			cmd := m.fetchProgress()
+			msg := cmd()
+
+			pmsg, ok := msg.(progressMsg)
+			require.True(t, ok, "expected progressMsg, got %T", msg)
+			assert.Equal(t, tt.retryable, pmsg.retryable)
+		})
+	}
 }
 
 func TestWatchModel_PermanentError_QuitsImmediately(t *testing.T) {
 	m := NewWatchModel("http://localhost:8080", "testdb", "staging", false)
 
 	msg := progressMsg{
-		errorMsg:  "apply not found",
-		errorCode: errPermanent,
+		errorMsg: "apply not found",
+		failed:   true,
 	}
 	updated, cmd := m.Update(msg)
 	model := updated.(WatchModel)
@@ -210,7 +299,8 @@ func TestWatchModel_ConsecutiveErrors_IncrementCounter(t *testing.T) {
 	for i := 1; i <= 3; i++ {
 		updated, cmd := m.Update(progressMsg{
 			errorMsg:  "connection refused",
-			errorCode: errRetryable,
+			failed:    true,
+			retryable: true,
 		})
 		m = updated.(WatchModel)
 		assert.Equal(t, i, m.consecutiveErrors)
@@ -222,6 +312,18 @@ func TestWatchModel_ConsecutiveErrors_IncrementCounter(t *testing.T) {
 	m = updated.(WatchModel)
 	assert.Equal(t, 0, m.consecutiveErrors)
 	assert.Empty(t, m.errorMsg, "error should be cleared on success")
+}
+
+func TestFetchProgress_ConnectionRefused_RetryableConnectionError(t *testing.T) {
+	// Server is not listening — connection refused.
+	m := NewWatchModel("http://127.0.0.1:1", "testdb", "staging", false)
+	cmd := m.fetchProgress()
+	msg := cmd()
+
+	pmsg, ok := msg.(progressMsg)
+	require.True(t, ok, "expected progressMsg, got %T", msg)
+	assert.True(t, pmsg.retryable, "connection errors should be retryable")
+	assert.Contains(t, pmsg.errorMsg, "cannot connect")
 }
 
 func TestGetProgress_ServerReturns500_CLIReturnsError(t *testing.T) {

--- a/pkg/cmd/commands/watch_tui_test.go
+++ b/pkg/cmd/commands/watch_tui_test.go
@@ -28,6 +28,7 @@ func TestFetchProgress_ServerReturns500_ReturnsError(t *testing.T) {
 	pmsg, ok := msg.(progressMsg)
 	require.True(t, ok, "expected progressMsg, got %T", msg)
 	assert.Empty(t, pmsg.state, "fetchProgress should not set state on error")
+	assert.True(t, pmsg.fetchErr, "fetchProgress should set fetchErr on HTTP error")
 	assert.Contains(t, pmsg.errorMsg, "500")
 }
 
@@ -45,6 +46,7 @@ func TestFetchProgress_ServerReturnsNoActiveChange(t *testing.T) {
 	pmsg, ok := msg.(progressMsg)
 	require.True(t, ok, "expected progressMsg, got %T", msg)
 	assert.Equal(t, state.NoActiveChange, pmsg.state)
+	assert.False(t, pmsg.fetchErr, "successful response should not set fetchErr")
 	assert.Empty(t, pmsg.errorMsg)
 }
 
@@ -97,9 +99,11 @@ func TestWatchModel_MidFlightError_PreservesLastState(t *testing.T) {
 	assert.True(t, m.initialized)
 	assert.Equal(t, state.Apply.Running, m.state)
 
-	// Second: server crashes, returns error with empty state.
+	// Second: server crashes — API call fails (fetchErr distinguishes this
+	// from a server response that happens to have an empty state).
 	errorMsg := progressMsg{
 		errorMsg: "500: connection refused",
+		fetchErr: true,
 	}
 	updated, cmd := m.Update(errorMsg)
 	m = updated.(WatchModel)
@@ -132,8 +136,8 @@ func TestWatchModel_ConnectionError_CanEscape(t *testing.T) {
 	// User should be able to ESC out of the loading+error state.
 	m := NewWatchModel("http://localhost:8080", "testdb", "staging", false)
 
-	// Simulate connection error.
-	updated, _ := m.Update(progressMsg{errorMsg: "connection refused"})
+	// Simulate fetch error (API call failed).
+	updated, _ := m.Update(progressMsg{errorMsg: "connection refused", fetchErr: true})
 	m = updated.(WatchModel)
 	assert.False(t, m.initialized)
 
@@ -142,6 +146,25 @@ func TestWatchModel_ConnectionError_CanEscape(t *testing.T) {
 	m = updated.(WatchModel)
 	assert.True(t, m.detached)
 	assert.NotNil(t, cmd, "ESC should return tea.Quit")
+}
+
+func TestWatchModel_ServerErrorWithState_TreatedAsRealResponse(t *testing.T) {
+	// Server returns a real response with state=failed and an error message.
+	// This is NOT a fetch error — it's a valid API response indicating the
+	// apply failed. The TUI should update state normally (and quit on terminal state).
+	m := NewWatchModel("http://localhost:8080", "testdb", "staging", false)
+
+	msg := progressMsg{
+		state:    state.Apply.Failed,
+		errorMsg: "engine error: checksum mismatch",
+	}
+	updated, cmd := m.Update(msg)
+	model := updated.(WatchModel)
+
+	assert.True(t, model.initialized, "should be initialized from real response")
+	assert.Equal(t, state.Apply.Failed, model.state)
+	assert.Contains(t, model.errorMsg, "checksum mismatch")
+	assert.NotNil(t, cmd, "terminal state should return tea.Quit")
 }
 
 func TestGetProgress_ServerReturns500_CLIReturnsError(t *testing.T) {

--- a/pkg/cmd/commands/watch_tui_view.go
+++ b/pkg/cmd/commands/watch_tui_view.go
@@ -21,9 +21,15 @@ func (m WatchModel) View() string {
 		return ""
 	}
 
-	// Show nothing until we have data
+	// Show spinner until we have data. If there's a connection error,
+	// display it below the spinner so the user knows why it's still loading.
 	if !m.initialized {
-		return m.spinner.View() + "Loading...\n"
+		s := m.spinner.View() + "Loading...\n"
+		if m.errorMsg != "" {
+			errStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("9"))
+			s += errStyle.Render("Error: "+m.errorMsg) + "\n"
+		}
+		return s
 	}
 
 	// Handle no active schema change

--- a/pkg/cmd/commands/watch_tui_view.go
+++ b/pkg/cmd/commands/watch_tui_view.go
@@ -31,7 +31,7 @@ func (m WatchModel) View() string {
 		return s
 	}
 
-	// Permanent API error (4xx). Show the error and exit.
+	// Permanent fetch error (not_found, invalid_request, etc.). Show and exit.
 	if m.errorMsg != "" && m.state == "" {
 		errStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("9"))
 		return errStyle.Render("Error: "+m.errorMsg) + "\n"

--- a/pkg/cmd/commands/watch_tui_view.go
+++ b/pkg/cmd/commands/watch_tui_view.go
@@ -21,15 +21,20 @@ func (m WatchModel) View() string {
 		return ""
 	}
 
-	// Show spinner until we have data. If there's a connection error,
+	// Show spinner until we have data. If there's a fetch error,
 	// display it below the spinner so the user knows why it's still loading.
 	if !m.initialized {
 		s := m.spinner.View() + "Loading...\n"
 		if m.errorMsg != "" {
-			errStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("9"))
-			s += errStyle.Render("Error: "+m.errorMsg) + "\n"
+			s += m.fetchErrorLine()
 		}
 		return s
+	}
+
+	// Permanent API error (4xx). Show the error and exit.
+	if m.errorMsg != "" && m.state == "" {
+		errStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("9"))
+		return errStyle.Render("Error: "+m.errorMsg) + "\n"
 	}
 
 	// Handle no active schema change
@@ -157,15 +162,25 @@ func (m WatchModel) progressView() string {
 		b.WriteString("\n")
 	}
 
-	// Error message if present
-	if m.errorMsg != "" {
+	// Fetch error during active progress (mid-flight). State and tables are
+	// preserved from the last successful poll; the error tells the user
+	// the server is currently unreachable.
+	if m.errorMsg != "" && m.consecutiveErrors > 0 {
 		b.WriteString("\n")
-		errStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("9"))
-		b.WriteString(errStyle.Render("Error: " + m.errorMsg))
-		b.WriteString("\n")
+		b.WriteString(m.fetchErrorLine())
 	}
 
 	return b.String()
+}
+
+// fetchErrorLine formats the fetch error with consecutive failure count.
+func (m WatchModel) fetchErrorLine() string {
+	errStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("9"))
+	label := "Error"
+	if m.consecutiveErrors > 1 {
+		label = fmt.Sprintf("Error (attempt %d)", m.consecutiveErrors)
+	}
+	return errStyle.Render(label+": "+m.errorMsg) + "\n"
 }
 
 // renderTable renders a single table's progress.


### PR DESCRIPTION
When the progress API call fails, the TUI watch displayed "No active schema change" and quit — the empty state from the failed call was treated as a real server response. This PR adds structured error handling across the progress polling stack.

The progress API handlers now return error codes (e.g., `storage_error`, `engine_unavailable`, `not_found`) in all error responses. The CLI client parses these into typed errors — `ConnectionError` for network failures, `APIError` with an `ErrorCode` for server responses. The TUI classifies errors as retryable or permanent using `apitypes.IsRetryableErrorCode`, retrying transient failures with exponential backoff (2s→30s cap) while quitting immediately on permanent errors like `not_found`. On retryable errors the TUI preserves the last known state and shows the error with a consecutive failure count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)