### PR TITLE
CLI: shared TUI rendering, keyspace headers, and staging phase

### DIFF
--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -2345,9 +2345,9 @@ Single table progress (default):
 
   ── testapp ──
 
-     users: 🟦🟦🟦🟦🟦🟦🟦🟦🟦⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ 48%
-       ~ ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
-       Rows: 3,500,000 / 7,200,000 · ETA: 5m 30s
+     ~ users: 🟦🟦🟦🟦🟦🟦🟦🟦🟦⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ 48%
+       ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
+       • Rows: 3,500,000 / 7,200,000 · ETA: 5m 30s
 
 
 ```
@@ -2368,11 +2368,11 @@ Single table progress (default):
 
   ── testapp ──
 
-     order_items: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
-       ~ ALTER TABLE `order_items` ADD INDEX `idx_product_id`(`product_id`);
+     ~ order_items: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+       ALTER TABLE `order_items` ADD INDEX `idx_product_id`(`product_id`);
 
-     users: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
-       ~ ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
+     ~ users: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+       ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
 
 ✓ Apply complete!
 
@@ -2396,8 +2396,8 @@ Single table progress (default):
 
   ── testapp ──
 
-     users: ⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ ❌ Failed
-       ~ ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
+     ~ users: ⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ ❌ Failed
+       ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
 
 
 To recover: Fix the issue above, then run a new apply.
@@ -2421,12 +2421,12 @@ The new apply will only process tables that haven't completed.
 
   ── testapp ──
 
-     users: 🟧🟧🟧🟧🟧🟧🟧⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ ⏹️ Stopped at 39%
-       ~ ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
-      Rows: 156,342 / 397,453
+     ~ users: 🟧🟧🟧🟧🟧🟧🟧⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ ⏹️ Stopped at 39%
+       ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
+       • Rows: 156,342 / 397,453
 
-     orders: ⏹️ Stopped (not started)
-       ~ ALTER TABLE `orders` ADD INDEX `idx_total_cents`(`total_cents`);
+     ~ orders: ⏹️ Stopped (not started)
+       ALTER TABLE `orders` ADD INDEX `idx_total_cents`(`total_cents`);
 
 
 Stopped. Use 'schemabot start --apply-id <apply_id>' to resume from checkpoint.
@@ -2449,11 +2449,11 @@ Stopped. Use 'schemabot start --apply-id <apply_id>' to resume from checkpoint.
 
   ── testapp ──
 
-     order_items: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦 Waiting for cutover
-       ~ ALTER TABLE `order_items` ADD INDEX `idx_product_id`(`product_id`);
+     ~ order_items: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦 Waiting for cutover
+       ALTER TABLE `order_items` ADD INDEX `idx_product_id`(`product_id`);
 
-     users: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦 Waiting for cutover
-       ~ ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
+     ~ users: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦 Waiting for cutover
+       ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
 
 Row copy complete. All data has been copied and new writes
 continue to be replicated to keep the shadow table in sync.
@@ -2492,11 +2492,11 @@ Watching for cutover... (Ctrl+C to detach)
 
   ── testapp ──
 
-     order_items: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦 🔄 Cutting over...
-       ~ ALTER TABLE `order_items` ADD INDEX `idx_product_id`(`product_id`);
+     ~ order_items: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦 🔄 Cutting over...
+       ALTER TABLE `order_items` ADD INDEX `idx_product_id`(`product_id`);
 
-     users: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦 🔄 Cutting over...
-       ~ ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
+     ~ users: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦 🔄 Cutting over...
+       ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
 
 
 ```
@@ -2517,14 +2517,14 @@ Sequential mode: Just started (all tables pending)
 └──────────────────────────────────┘
 
 
-     users: ⏳ Queued
-       ~ ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
+     ~ users: ⏳ Queued
+       ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
 
-     orders: ⏳ Queued
-       ~ ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
+     ~ orders: ⏳ Queued
+       ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
 
-     products: ⏳ Queued
-       ~ ALTER TABLE `products` ADD COLUMN `weight_grams` int DEFAULT 0;
+     ~ products: ⏳ Queued
+       ALTER TABLE `products` ADD COLUMN `weight_grams` int DEFAULT 0;
 
 
 ```
@@ -2545,15 +2545,15 @@ Sequential mode: First table running, others queued
 └──────────────────────────────────┘
 
 
-     users: 🟦🟦🟦🟦🟦🟦🟦⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ 35%
-       ~ ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
-       Rows: 875,000 / 2,500,000 · ETA: 8m 30s
+     ~ users: 🟦🟦🟦🟦🟦🟦🟦⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ 35%
+       ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
+       • Rows: 875,000 / 2,500,000 · ETA: 8m 30s
 
-     orders: ⏳ Queued
-       ~ ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
+     ~ orders: ⏳ Queued
+       ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
 
-     products: ⏳ Queued
-       ~ ALTER TABLE `products` ADD COLUMN `weight_grams` int DEFAULT 0;
+     ~ products: ⏳ Queued
+       ALTER TABLE `products` ADD COLUMN `weight_grams` int DEFAULT 0;
 
 
 ```
@@ -2574,15 +2574,15 @@ Sequential mode: First complete, second running
 └──────────────────────────────────┘
 
 
-     orders: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦⬜⬜⬜⬜⬜⬜⬜⬜ 60%
-       ~ ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
-       Rows: 3,000,000 / 5,000,000 · ETA: 12m 15s
+     ~ orders: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦⬜⬜⬜⬜⬜⬜⬜⬜ 60%
+       ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
+       • Rows: 3,000,000 / 5,000,000 · ETA: 12m 15s
 
-     products: ⏳ Queued
-       ~ ALTER TABLE `products` ADD COLUMN `weight_grams` int DEFAULT 0;
+     ~ products: ⏳ Queued
+       ALTER TABLE `products` ADD COLUMN `weight_grams` int DEFAULT 0;
 
-     users: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
-       ~ ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
+     ~ users: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+       ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
 
 
 ```
@@ -2603,15 +2603,15 @@ Sequential mode: First two complete, third running
 └──────────────────────────────────┘
 
 
-     products: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦⬜⬜⬜⬜ 80%
-       ~ ALTER TABLE `products` ADD COLUMN `weight_grams` int DEFAULT 0;
-       Rows: 160,000 / 200,000 · ETA: 2m 45s
+     ~ products: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦⬜⬜⬜⬜ 80%
+       ALTER TABLE `products` ADD COLUMN `weight_grams` int DEFAULT 0;
+       • Rows: 160,000 / 200,000 · ETA: 2m 45s
 
-     users: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
-       ~ ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
+     ~ users: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+       ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
 
-     orders: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
-       ~ ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
+     ~ orders: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+       ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
 
 
 ```
@@ -2632,14 +2632,14 @@ Sequential mode: All tables completed successfully
 └──────────────────────────────────┘
 
 
-     users: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
-       ~ ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
+     ~ users: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+       ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
 
-     orders: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
-       ~ ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
+     ~ orders: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+       ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
 
-     products: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
-       ~ ALTER TABLE `products` ADD COLUMN `weight_grams` int DEFAULT 0;
+     ~ products: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+       ALTER TABLE `products` ADD COLUMN `weight_grams` int DEFAULT 0;
 
 ✓ Apply complete!
 
@@ -2663,14 +2663,14 @@ Sequential mode: First table failed (others cancelled)
   lock wait timeout exceeded; try restarting transaction
 
 
-     users: 🟥🟥🟥🟥🟥🟥🟥🟥🟥🟥🟥🟥🟥⬜⬜⬜⬜⬜⬜⬜ ❌ Failed
-       ~ ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
+     ~ users: 🟥🟥🟥🟥🟥🟥🟥🟥🟥🟥🟥🟥🟥⬜⬜⬜⬜⬜⬜⬜ ❌ Failed
+       ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
 
-     orders: ⊘ Cancelled (not started)
-       ~ ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
+     ~ orders: ⊘ Cancelled (not started)
+       ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
 
-     products: ⊘ Cancelled (not started)
-       ~ ALTER TABLE `products` ADD COLUMN `weight_grams` int DEFAULT 0;
+     ~ products: ⊘ Cancelled (not started)
+       ALTER TABLE `products` ADD COLUMN `weight_grams` int DEFAULT 0;
 
 
 To recover: Fix the issue above, then run a new apply.
@@ -2696,14 +2696,14 @@ Sequential mode: Middle table failed
   Lost connection to MySQL server during query (MySQL error 2013)
 
 
-     orders: 🟥🟥🟥🟥🟥🟥🟥🟥🟥⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ ❌ Failed
-       ~ ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
+     ~ orders: 🟥🟥🟥🟥🟥🟥🟥🟥🟥⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ ❌ Failed
+       ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
 
-     users: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
-       ~ ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
+     ~ users: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+       ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
 
-     products: ⊘ Cancelled (not started)
-       ~ ALTER TABLE `products` ADD COLUMN `weight_grams` int DEFAULT 0;
+     ~ products: ⊘ Cancelled (not started)
+       ALTER TABLE `products` ADD COLUMN `weight_grams` int DEFAULT 0;
 
 
 To recover: Fix the issue above, then run a new apply.
@@ -2727,15 +2727,15 @@ Sequential mode: User stopped mid-apply
 └──────────────────────────────────┘
 
 
-     orders: 🟧🟧🟧🟧🟧🟧🟧🟧⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ ⏹️ Stopped at 42%
-       ~ ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
-      Rows: 112,045 / 266,383
+     ~ orders: 🟧🟧🟧🟧🟧🟧🟧🟧⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ ⏹️ Stopped at 42%
+       ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
+       • Rows: 112,045 / 266,383
 
-     products: ⏹️ Stopped (not started)
-       ~ ALTER TABLE `products` ADD COLUMN `weight_grams` int DEFAULT 0;
+     ~ products: ⏹️ Stopped (not started)
+       ALTER TABLE `products` ADD COLUMN `weight_grams` int DEFAULT 0;
 
-     users: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
-       ~ ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
+     ~ users: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+       ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
 
 Use 'schemabot start' to resume from checkpoint.
 
@@ -2757,8 +2757,8 @@ Use 'schemabot start' to resume from checkpoint.
 
   ── myapp_sharded ──
 
-     users: ⏳ Queued
-       ~ ALTER TABLE `users` ADD COLUMN `phone` varchar(20);
+     ~ users: ⏳ Queued
+       ALTER TABLE `users` ADD COLUMN `phone` varchar(20);
 
 
 ```
@@ -2780,8 +2780,8 @@ Use 'schemabot start' to resume from checkpoint.
 
   ── myapp_sharded ──
 
-     users: ⏳ Queued
-       ~ ALTER TABLE `users` ADD COLUMN `phone` varchar(20);
+     ~ users: ⏳ Queued
+       ALTER TABLE `users` ADD COLUMN `phone` varchar(20);
 
 
 ```
@@ -2803,8 +2803,8 @@ Use 'schemabot start' to resume from checkpoint.
 
   ── myapp_sharded ──
 
-     users: ⏳ Queued
-       ~ ALTER TABLE `users` ADD COLUMN `phone` varchar(20);
+     ~ users: ⏳ Queued
+       ALTER TABLE `users` ADD COLUMN `phone` varchar(20);
 
 
 ```
@@ -2827,12 +2827,11 @@ Use 'schemabot start' to resume from checkpoint.
 
   ── myapp_sharded ──
 
-     customers: Staging schema changes...
-       ~ ALTER TABLE `customers` ADD INDEX `idx_created_at`(`created_at`);
-
-    Shards: 2 (2 copying)
-      ◉ -80: 0% (0/60,483,380 rows)
-      ◉ 80-: 0% (0/64,277,080 rows)
+     ~ customers: Staging schema changes...
+       ALTER TABLE `customers` ADD INDEX `idx_created_at`(`created_at`);
+       • Shards: 2 (2 copying)
+           ◉ -80: 0% (0/60,483,380 rows)
+           ◉ 80-: 0% (0/64,277,080 rows)
 
 ```
 </details>
@@ -2856,8 +2855,8 @@ Use 'schemabot start' to resume from checkpoint.
 
   ── myapp_sharded ──
 
-     users: Running...
-       ~ ALTER TABLE `users` ADD COLUMN `phone` varchar(20);
+     ~ users: Running...
+       ALTER TABLE `users` ADD COLUMN `phone` varchar(20);
 
 
 ```
@@ -2882,8 +2881,8 @@ Use 'schemabot start' to resume from checkpoint.
 
   ── myapp_sharded ──
 
-     users: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
-       ~ ALTER TABLE `users` ADD COLUMN `phone` varchar(20);
+     ~ users: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+       ALTER TABLE `users` ADD COLUMN `phone` varchar(20);
 
 
 ```
@@ -2910,8 +2909,8 @@ Use 'schemabot start' to resume from checkpoint.
 
   ── myapp_sharded ──
 
-     users: ⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ ❌ Failed
-       ~ ALTER TABLE `users` ADD COLUMN `phone` varchar(20);
+     ~ users: ⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ ❌ Failed
+       ALTER TABLE `users` ADD COLUMN `phone` varchar(20);
 
 
 To recover: Fix the issue above, then run a new apply.
@@ -2940,12 +2939,12 @@ The new apply will only process tables that haven't completed.
 
   ── myapp_sharded ──
 
-     orders: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦 Waiting for cutover
-       ~ ALTER TABLE `orders` ADD INDEX `idx_total`(`total_cents`);
+     ~ orders: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦 Waiting for cutover
+       ALTER TABLE `orders` ADD INDEX `idx_total`(`total_cents`);
 
-    Shards: 2 (2 ready for cutover)
-      ● -80: ready for cutover
-      ● 80-: ready for cutover
+       • Shards: 2 (2 ready for cutover)
+           ● -80: ready for cutover
+           ● 80-: ready for cutover
 
 ```
 </details>
@@ -2970,12 +2969,12 @@ The new apply will only process tables that haven't completed.
 
   ── myapp_sharded ──
 
-     orders: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦 🔄 Cutting over...
-       ~ ALTER TABLE `orders` ADD INDEX `idx_total`(`total_cents`);
+     ~ orders: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦 🔄 Cutting over...
+       ALTER TABLE `orders` ADD INDEX `idx_total`(`total_cents`);
 
-    Shards: 2 (2 cutting over)
-      ● -80: cutting over
-      ● 80-: cutting over
+       • Shards: 2 (2 cutting over)
+           ● -80: cutting over
+           ● 80-: cutting over
 
 ```
 </details>
@@ -2999,12 +2998,12 @@ The new apply will only process tables that haven't completed.
 
   ── myapp_sharded ──
 
-     orders: 🟥🟥🟥🟥🟥🟥⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ ⊘ Cancelled at 30%
-       ~ ALTER TABLE `orders` ADD INDEX `idx_total`(`total_cents`);
+     ~ orders: 🟥🟥🟥🟥🟥🟥⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ ⊘ Cancelled at 30%
+       ALTER TABLE `orders` ADD INDEX `idx_total`(`total_cents`);
 
-    Shards: 2 (2 cancelled)
-      ○ -80: cancelled
-      ○ 80-: cancelled
+       • Shards: 2 (2 cancelled)
+           ○ -80: cancelled
+           ○ 80-: cancelled
 
 ```
 </details>
@@ -3028,21 +3027,20 @@ The new apply will only process tables that haven't completed.
 
   ── commerce_sharded ──
 
-     transactions: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦⬜⬜⬜⬜⬜⬜⬜⬜⬜ 57%
-       ~ ALTER TABLE `transactions` ADD COLUMN `region_id` int;
-       Rows: 110,573,340 / 193,280,000 · ETA: 4m 40s
-
-    Shards: 256 (30 ready for cutover, 226 copying)
-      ● -01: ready for cutover
-      ● 01-02: ready for cutover
-      ● 02-03: ready for cutover
-      ... 27 more ready for cutover
-      ◉ ff-: 10% (101,000/1,010,000 rows) ETA 4m 40s
-      ◉ fe-ff: 10% (100,800/1,008,000 rows) ETA 4m 40s
-      ◉ fd-fe: 11% (110,660/1,006,000 rows) ETA 4m 38s
-      ◉ fc-fd: 11% (110,440/1,004,000 rows) ETA 4m 38s
-      ◉ fb-fc: 12% (120,240/1,002,000 rows) ETA 4m 36s
-      ... 221 more copying shards
+     ~ transactions: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦⬜⬜⬜⬜⬜⬜⬜⬜⬜ 57%
+       ALTER TABLE `transactions` ADD COLUMN `region_id` int;
+       • Rows: 110,573,340 / 193,280,000 · ETA: 4m 40s
+       • Shards: 256 (30 ready for cutover, 226 copying)
+           ● -01: ready for cutover
+           ● 01-02: ready for cutover
+           ● 02-03: ready for cutover
+           ... 27 more ready for cutover
+           ◉ ff-: 10% (101,000/1,010,000 rows) ETA 4m 40s
+           ◉ fe-ff: 10% (100,800/1,008,000 rows) ETA 4m 40s
+           ◉ fd-fe: 11% (110,660/1,006,000 rows) ETA 4m 38s
+           ◉ fc-fd: 11% (110,440/1,004,000 rows) ETA 4m 38s
+           ◉ fb-fc: 12% (120,240/1,002,000 rows) ETA 4m 36s
+           ... 221 more copying shards
 
 ```
 </details>
@@ -3066,50 +3064,49 @@ The new apply will only process tables that haven't completed.
 
   ── commerce_sharded ──
 
-     transactions: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦⬜⬜⬜⬜⬜⬜⬜ 67%
-       ~ ALTER TABLE `transactions` ADD COLUMN `region_id` int;
-       Rows: 29,435,000 / 43,360,000 · ETA: 2m 37s
-
-    Shards: 32 (12 ready for cutover, 20 copying)
-      ● -08: ready for cutover
-      ● 08-10: ready for cutover
-      ● 10-18: ready for cutover
-      ... 9 more ready for cutover
-      ◉ f8-: 23% (347,300/1,510,000 rows) ETA 2m 37s
-      ◉ f0-f8: 26% (390,000/1,500,000 rows) ETA 2m 34s
-      ◉ e8-f0: 29% (432,100/1,490,000 rows) ETA 2m 31s
-      ◉ e0-e8: 32% (473,600/1,480,000 rows) ETA 2m 28s
-      ◉ d8-e0: 35% (514,500/1,470,000 rows) ETA 2m 25s
-      ... 15 more copying shards
+     ~ transactions: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦⬜⬜⬜⬜⬜⬜⬜ 67%
+       ALTER TABLE `transactions` ADD COLUMN `region_id` int;
+       • Rows: 29,435,000 / 43,360,000 · ETA: 2m 37s
+       • Shards: 32 (12 ready for cutover, 20 copying)
+           ● -08: ready for cutover
+           ● 08-10: ready for cutover
+           ● 10-18: ready for cutover
+           ... 9 more ready for cutover
+           ◉ f8-: 23% (347,300/1,510,000 rows) ETA 2m 37s
+           ◉ f0-f8: 26% (390,000/1,500,000 rows) ETA 2m 34s
+           ◉ e8-f0: 29% (432,100/1,490,000 rows) ETA 2m 31s
+           ◉ e0-e8: 32% (473,600/1,480,000 rows) ETA 2m 28s
+           ◉ d8-e0: 35% (514,500/1,470,000 rows) ETA 2m 25s
+           ... 15 more copying shards
 
   ── commerce_001 ──
 
-     transactions: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
-       ~ ALTER TABLE `transactions` ADD COLUMN `region_id` int;
+     ~ transactions: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+       ALTER TABLE `transactions` ADD COLUMN `region_id` int;
 
 
   ── commerce_002 ──
 
-     transactions: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
-       ~ ALTER TABLE `transactions` ADD COLUMN `region_id` int;
+     ~ transactions: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+       ALTER TABLE `transactions` ADD COLUMN `region_id` int;
 
 
   ── commerce_003 ──
 
-     transactions: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
-       ~ ALTER TABLE `transactions` ADD COLUMN `region_id` int;
+     ~ transactions: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+       ALTER TABLE `transactions` ADD COLUMN `region_id` int;
 
 
   ── commerce_004 ──
 
-     transactions: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
-       ~ ALTER TABLE `transactions` ADD COLUMN `region_id` int;
+     ~ transactions: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+       ALTER TABLE `transactions` ADD COLUMN `region_id` int;
 
 
   ── commerce_005 ──
 
-     transactions: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
-       ~ ALTER TABLE `transactions` ADD COLUMN `region_id` int;
+     ~ transactions: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+       ALTER TABLE `transactions` ADD COLUMN `region_id` int;
 
 
   ... and 27 more keyspaces (all completed)
@@ -3162,19 +3159,19 @@ The new apply will only process tables that haven't completed.
 
   ── myapp_unsharded ──
 
-     orders_seq: Running...
-       ~ CREATE TABLE `orders_seq` (
-             `id` int unsigned NOT NULL DEFAULT '0',
-             `next_id` bigint unsigned,
-             `cache` bigint unsigned,
-             PRIMARY KEY(`id`)
-         ) ENGINE InnoDB;
+     ~ orders_seq: Running...
+       CREATE TABLE `orders_seq` (
+           `id` int unsigned NOT NULL DEFAULT '0',
+           `next_id` bigint unsigned,
+           `cache` bigint unsigned,
+           PRIMARY KEY(`id`)
+       ) ENGINE InnoDB;
 
 
   ── myapp_sharded ──
 
-     users: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
-       ~ ALTER TABLE `users` ADD COLUMN `phone` varchar(20);
+     ~ users: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+       ALTER TABLE `users` ADD COLUMN `phone` varchar(20);
 
 
 ```
@@ -3202,8 +3199,8 @@ The new apply will only process tables that haven't completed.
     ~ VSchema: Applying...
        + "users": {"column_vindexes": [{"column": "id", "name": "hash"}]}
 
-     users: Running...
-       ~ ALTER TABLE `users` ADD COLUMN `phone` varchar(20);
+     ~ users: Running...
+       ALTER TABLE `users` ADD COLUMN `phone` varchar(20);
 
 
 ```
@@ -3228,13 +3225,12 @@ The new apply will only process tables that haven't completed.
 
   ── myapp_sharded ──
 
-     orders: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦⬜⬜⬜⬜⬜⬜ 70%
-       ~ ALTER TABLE `orders` ADD INDEX `idx_total`(`total_cents`);
-       Rows: 2,800,000 / 4,000,000 · ETA: 2m 0s
-
-    Shards: 2 (2 copying)
-      ◉ -80: 95% (2,000,000/2,100,000 rows) ETA 10s
-      ◉ 80-: 42% (800,000/1,900,000 rows) ETA 2m 0s
+     ~ orders: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦⬜⬜⬜⬜⬜⬜ 70%
+       ALTER TABLE `orders` ADD INDEX `idx_total`(`total_cents`);
+       • Rows: 2,800,000 / 4,000,000 · ETA: 2m 0s
+       • Shards: 2 (2 copying)
+           ◉ -80: 95% (2,000,000/2,100,000 rows) ETA 10s
+           ◉ 80-: 42% (800,000/1,900,000 rows) ETA 2m 0s
 
 ```
 </details>
@@ -3258,12 +3254,12 @@ The new apply will only process tables that haven't completed.
 
   ── myapp_sharded ──
 
-     orders: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦 Waiting for cutover
-       ~ ALTER TABLE `orders` ADD INDEX `idx_total`(`total_cents`);
+     ~ orders: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦 Waiting for cutover
+       ALTER TABLE `orders` ADD INDEX `idx_total`(`total_cents`);
 
-    Shards: 2 (2 ready for cutover)
-      ● -80: ready for cutover
-      ● 80-: ready for cutover
+       • Shards: 2 (2 ready for cutover)
+           ● -80: ready for cutover
+           ● 80-: ready for cutover
 
 ```
 </details>
@@ -3432,8 +3428,8 @@ Vitess plan: Multi-keyspace with DDL + VSchema across keyspaces
 
   ── myapp_sharded ──
 
-     users: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
-       ~ ALTER TABLE `users` ADD COLUMN `phone` varchar(20);
+     ~ users: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+       ALTER TABLE `users` ADD COLUMN `phone` varchar(20);
 
 
 ```
@@ -3459,8 +3455,8 @@ Vitess plan: Multi-keyspace with DDL + VSchema across keyspaces
 
   ── myapp_sharded ──
 
-     orders: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 ✓ Complete (pending revert)
-       ~ ALTER TABLE `orders` ADD INDEX `idx_total`(`total_cents`);
+     ~ orders: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 ✓ Complete (pending revert)
+       ALTER TABLE `orders` ADD INDEX `idx_total`(`total_cents`);
 
 
 ```
@@ -3484,15 +3480,15 @@ Apply watch mode: Running with footer controls
 
   ── testapp ──
 
-     users: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦⬜⬜⬜⬜⬜⬜⬜⬜ 62%
-       ~ ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
-       Rows: 914,707 / 1,466,232 · ETA: 3m 15s
+     ~ users: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦⬜⬜⬜⬜⬜⬜⬜⬜ 62%
+       ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
+       • Rows: 914,707 / 1,466,232 · ETA: 3m 15s
 
-     products: ⏳ Queued
-       ~ ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
+     ~ products: ⏳ Queued
+       ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
 
-     orders: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
-       ~ ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
+     ~ orders: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+       ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
 
 ESC detach • s stop • v volume
 
@@ -3514,14 +3510,14 @@ ESC detach • s stop • v volume
 
   ── testapp ──
 
-     orders: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
-       ~ ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
+     ~ orders: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+       ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
 
-     products: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
-       ~ ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
+     ~ products: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+       ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
 
-     users: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
-       ~ ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
+     ~ users: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+       ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
 
 ✓ Apply complete!
 
@@ -3562,15 +3558,15 @@ Checkpoint saved. Use 'schemabot start --apply-id apply-a1b2c3d4e5f67890' to res
 
   ── testapp ──
 
-     users: 🟧🟧🟧🟧🟧🟧🟧⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ ⏹️ Stopped at 39%
-       ~ ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
-      Rows: 156,342 / 397,453
+     ~ users: 🟧🟧🟧🟧🟧🟧🟧⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ ⏹️ Stopped at 39%
+       ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
+       • Rows: 156,342 / 397,453
 
-     products: ⏹️ Stopped (not started)
-       ~ ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
+     ~ products: ⏹️ Stopped (not started)
+       ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
 
-     orders: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
-       ~ ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
+     ~ orders: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+       ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
 
 
 ```
@@ -3610,15 +3606,15 @@ Resuming from checkpoint...
 
   ── testapp ──
 
-     users: 🟦🟦🟦🟦🟦🟦🟦🟦⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ 40%
-       ~ ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
-       Rows: 158,000 / 397,453 · ETA: 8m 0s
+     ~ users: 🟦🟦🟦🟦🟦🟦🟦🟦⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ 40%
+       ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
+       • Rows: 158,000 / 397,453 · ETA: 8m 0s
 
-     products: ⏳ Queued
-       ~ ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
+     ~ products: ⏳ Queued
+       ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
 
-     orders: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
-       ~ ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
+     ~ orders: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+       ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
 
 ESC detach • s stop • v volume
 
@@ -3728,14 +3724,14 @@ Sequential mode: Just started (all tables pending)
 └──────────────────────────────────┘
 
 
-     users: ⏳ Queued
-       ~ ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
+     ~ users: ⏳ Queued
+       ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
 
-     orders: ⏳ Queued
-       ~ ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
+     ~ orders: ⏳ Queued
+       ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
 
-     products: ⏳ Queued
-       ~ ALTER TABLE `products` ADD COLUMN `weight_grams` int DEFAULT 0;
+     ~ products: ⏳ Queued
+       ALTER TABLE `products` ADD COLUMN `weight_grams` int DEFAULT 0;
 
 
 ```
@@ -3756,15 +3752,15 @@ Sequential mode: First table running, others queued
 └──────────────────────────────────┘
 
 
-     users: 🟦🟦🟦🟦🟦🟦🟦⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ 35%
-       ~ ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
-       Rows: 875,000 / 2,500,000 · ETA: 8m 30s
+     ~ users: 🟦🟦🟦🟦🟦🟦🟦⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ 35%
+       ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
+       • Rows: 875,000 / 2,500,000 · ETA: 8m 30s
 
-     orders: ⏳ Queued
-       ~ ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
+     ~ orders: ⏳ Queued
+       ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
 
-     products: ⏳ Queued
-       ~ ALTER TABLE `products` ADD COLUMN `weight_grams` int DEFAULT 0;
+     ~ products: ⏳ Queued
+       ALTER TABLE `products` ADD COLUMN `weight_grams` int DEFAULT 0;
 
 
 ```
@@ -3785,15 +3781,15 @@ Sequential mode: First complete, second running
 └──────────────────────────────────┘
 
 
-     orders: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦⬜⬜⬜⬜⬜⬜⬜⬜ 60%
-       ~ ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
-       Rows: 3,000,000 / 5,000,000 · ETA: 12m 15s
+     ~ orders: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦⬜⬜⬜⬜⬜⬜⬜⬜ 60%
+       ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
+       • Rows: 3,000,000 / 5,000,000 · ETA: 12m 15s
 
-     products: ⏳ Queued
-       ~ ALTER TABLE `products` ADD COLUMN `weight_grams` int DEFAULT 0;
+     ~ products: ⏳ Queued
+       ALTER TABLE `products` ADD COLUMN `weight_grams` int DEFAULT 0;
 
-     users: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
-       ~ ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
+     ~ users: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+       ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
 
 
 ```
@@ -3814,15 +3810,15 @@ Sequential mode: First two complete, third running
 └──────────────────────────────────┘
 
 
-     products: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦⬜⬜⬜⬜ 80%
-       ~ ALTER TABLE `products` ADD COLUMN `weight_grams` int DEFAULT 0;
-       Rows: 160,000 / 200,000 · ETA: 2m 45s
+     ~ products: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦⬜⬜⬜⬜ 80%
+       ALTER TABLE `products` ADD COLUMN `weight_grams` int DEFAULT 0;
+       • Rows: 160,000 / 200,000 · ETA: 2m 45s
 
-     users: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
-       ~ ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
+     ~ users: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+       ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
 
-     orders: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
-       ~ ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
+     ~ orders: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+       ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
 
 
 ```
@@ -3843,14 +3839,14 @@ Sequential mode: All tables completed successfully
 └──────────────────────────────────┘
 
 
-     users: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
-       ~ ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
+     ~ users: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+       ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
 
-     orders: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
-       ~ ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
+     ~ orders: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+       ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
 
-     products: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
-       ~ ALTER TABLE `products` ADD COLUMN `weight_grams` int DEFAULT 0;
+     ~ products: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+       ALTER TABLE `products` ADD COLUMN `weight_grams` int DEFAULT 0;
 
 ✓ Apply complete!
 
@@ -3874,14 +3870,14 @@ Sequential mode: First table failed (others cancelled)
   lock wait timeout exceeded; try restarting transaction
 
 
-     users: 🟥🟥🟥🟥🟥🟥🟥🟥🟥🟥🟥🟥🟥⬜⬜⬜⬜⬜⬜⬜ ❌ Failed
-       ~ ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
+     ~ users: 🟥🟥🟥🟥🟥🟥🟥🟥🟥🟥🟥🟥🟥⬜⬜⬜⬜⬜⬜⬜ ❌ Failed
+       ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
 
-     orders: ⊘ Cancelled (not started)
-       ~ ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
+     ~ orders: ⊘ Cancelled (not started)
+       ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
 
-     products: ⊘ Cancelled (not started)
-       ~ ALTER TABLE `products` ADD COLUMN `weight_grams` int DEFAULT 0;
+     ~ products: ⊘ Cancelled (not started)
+       ALTER TABLE `products` ADD COLUMN `weight_grams` int DEFAULT 0;
 
 
 To recover: Fix the issue above, then run a new apply.
@@ -3907,14 +3903,14 @@ Sequential mode: Middle table failed
   Lost connection to MySQL server during query (MySQL error 2013)
 
 
-     orders: 🟥🟥🟥🟥🟥🟥🟥🟥🟥⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ ❌ Failed
-       ~ ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
+     ~ orders: 🟥🟥🟥🟥🟥🟥🟥🟥🟥⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ ❌ Failed
+       ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
 
-     users: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
-       ~ ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
+     ~ users: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+       ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
 
-     products: ⊘ Cancelled (not started)
-       ~ ALTER TABLE `products` ADD COLUMN `weight_grams` int DEFAULT 0;
+     ~ products: ⊘ Cancelled (not started)
+       ALTER TABLE `products` ADD COLUMN `weight_grams` int DEFAULT 0;
 
 
 To recover: Fix the issue above, then run a new apply.
@@ -3938,15 +3934,15 @@ Sequential mode: User stopped mid-apply
 └──────────────────────────────────┘
 
 
-     orders: 🟧🟧🟧🟧🟧🟧🟧🟧⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ ⏹️ Stopped at 42%
-       ~ ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
-      Rows: 112,045 / 266,383
+     ~ orders: 🟧🟧🟧🟧🟧🟧🟧🟧⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ ⏹️ Stopped at 42%
+       ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
+       • Rows: 112,045 / 266,383
 
-     products: ⏹️ Stopped (not started)
-       ~ ALTER TABLE `products` ADD COLUMN `weight_grams` int DEFAULT 0;
+     ~ products: ⏹️ Stopped (not started)
+       ALTER TABLE `products` ADD COLUMN `weight_grams` int DEFAULT 0;
 
-     users: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
-       ~ ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
+     ~ users: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+       ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
 
 Use 'schemabot start' to resume from checkpoint.
 ```
@@ -3969,17 +3965,17 @@ Atomic mode (--defer-cutover): All tables copy rows, then cutover together
 └──────────────────────────────────┘
 
 
-     orders: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦⬜⬜⬜⬜⬜⬜ 72%
-       ~ ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
-       Rows: 1,800,000 / 2,500,000 · ETA: 3m 15s
+     ~ orders: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦⬜⬜⬜⬜⬜⬜ 72%
+       ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
+       • Rows: 1,800,000 / 2,500,000 · ETA: 3m 15s
 
-     products: 🟦🟦🟦🟦🟦🟦🟦🟦🟦⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ 45%
-       ~ ALTER TABLE `products` ADD INDEX `idx_category`(`category`);
-       Rows: 450,000 / 1,000,000 · ETA: 6m 20s
+     ~ products: 🟦🟦🟦🟦🟦🟦🟦🟦🟦⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ 45%
+       ALTER TABLE `products` ADD INDEX `idx_category`(`category`);
+       • Rows: 450,000 / 1,000,000 · ETA: 6m 20s
 
-     users: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦⬜⬜⬜ 89%
-       ~ ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
-       Rows: 6,400,000 / 7,200,000 · ETA: 1m 45s
+     ~ users: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦⬜⬜⬜ 89%
+       ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
+       • Rows: 6,400,000 / 7,200,000 · ETA: 1m 45s
 
 All tables copy rows simultaneously. Cutover happens atomically
 after all tables complete row copy.
@@ -4003,8 +3999,8 @@ Defer cutover: Single table waiting
 └──────────────────────────────────┘
 
 
-     users: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦 Waiting for cutover
-       ~ ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
+     ~ users: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦 Waiting for cutover
+       ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
 
 Row copy complete. All data has been copied and new writes
 continue to be replicated to keep the shadow table in sync.
@@ -4029,14 +4025,14 @@ Atomic mode (--defer-cutover): All tables waiting for cutover
 └──────────────────────────────────┘
 
 
-     orders: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦 Waiting for cutover
-       ~ ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
+     ~ orders: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦 Waiting for cutover
+       ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
 
-     products: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦 Waiting for cutover
-       ~ ALTER TABLE `products` ADD INDEX `idx_category`(`category`);
+     ~ products: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦 Waiting for cutover
+       ALTER TABLE `products` ADD INDEX `idx_category`(`category`);
 
-     users: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦 Waiting for cutover
-       ~ ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
+     ~ users: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦 Waiting for cutover
+       ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
 
 Row copy complete for all tables. New writes continue to be
 replicated to keep shadow tables in sync.
@@ -4062,14 +4058,14 @@ Defer cutover: Sequential mode, first complete, second waiting
 └──────────────────────────────────┘
 
 
-     orders: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦 Waiting for cutover
-       ~ ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
+     ~ orders: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦 Waiting for cutover
+       ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
 
-     products: ⏳ Queued
-       ~ ALTER TABLE `products` ADD COLUMN `weight_grams` int DEFAULT 0;
+     ~ products: ⏳ Queued
+       ALTER TABLE `products` ADD COLUMN `weight_grams` int DEFAULT 0;
 
-     users: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
-       ~ ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
+     ~ users: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+       ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
 
 Row copy complete for current table. Press Enter to cutover
 and start the next table (or Ctrl+C to detach): _
@@ -4093,17 +4089,17 @@ Defer cutover: Stopped by user (s)
 └──────────────────────────────────┘
 
 
-     orders: 🟧🟧🟧🟧🟧🟧🟧🟧🟧🟧🟧🟧🟧🟧⬜⬜⬜⬜⬜⬜ ⏹️ Stopped at 72%
-       ~ ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
-      Rows: 1,800,000 / 2,500,000
+     ~ orders: 🟧🟧🟧🟧🟧🟧🟧🟧🟧🟧🟧🟧🟧🟧⬜⬜⬜⬜⬜⬜ ⏹️ Stopped at 72%
+       ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
+       • Rows: 1,800,000 / 2,500,000
 
-     products: 🟧🟧🟧🟧🟧🟧🟧🟧🟧⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ ⏹️ Stopped at 45%
-       ~ ALTER TABLE `products` ADD INDEX `idx_category`(`category`);
-      Rows: 450,000 / 1,000,000
+     ~ products: 🟧🟧🟧🟧🟧🟧🟧🟧🟧⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ ⏹️ Stopped at 45%
+       ALTER TABLE `products` ADD INDEX `idx_category`(`category`);
+       • Rows: 450,000 / 1,000,000
 
-     users: 🟧🟧🟧🟧🟧🟧🟧🟧🟧🟧🟧🟧🟧🟧🟧🟧🟧⬜⬜⬜ ⏹️ Stopped at 89%
-       ~ ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
-      Rows: 6,400,000 / 7,200,000
+     ~ users: 🟧🟧🟧🟧🟧🟧🟧🟧🟧🟧🟧🟧🟧🟧🟧🟧🟧⬜⬜⬜ ⏹️ Stopped at 89%
+       ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
+       • Rows: 6,400,000 / 7,200,000
 
 Use 'schemabot start --apply-id <apply_id>' to resume.
 
@@ -4150,14 +4146,14 @@ Defer cutover: Cutting over in progress
 └──────────────────────────────────┘
 
 
-     orders: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦 🔄 Cutting over...
-       ~ ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
+     ~ orders: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦 🔄 Cutting over...
+       ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
 
-     products: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦 🔄 Cutting over...
-       ~ ALTER TABLE `products` ADD INDEX `idx_category`(`category`);
+     ~ products: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦 🔄 Cutting over...
+       ALTER TABLE `products` ADD INDEX `idx_category`(`category`);
 
-     users: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦 🔄 Cutting over...
-       ~ ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
+     ~ users: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦 🔄 Cutting over...
+       ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
 
 Cutover in progress. This typically completes within seconds.
 Tables are being renamed atomically...

--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -2344,9 +2344,10 @@ Single table progress (default):
 
 
   ── testapp ──
-    users: 🟦🟦🟦🟦🟦🟦🟦🟦🟦⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ 48%
-      ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
-      Rows: 3,500,000 / 7,200,000 · ETA: 5m 30s
+
+     users: 🟦🟦🟦🟦🟦🟦🟦🟦🟦⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ 48%
+       ~ ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
+       Rows: 3,500,000 / 7,200,000 · ETA: 5m 30s
 
 
 ```
@@ -2366,11 +2367,12 @@ Single table progress (default):
 
 
   ── testapp ──
-    order_items: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
-      ALTER TABLE `order_items` ADD INDEX `idx_product_id`(`product_id`);
 
-    users: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
-      ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
+     order_items: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+       ~ ALTER TABLE `order_items` ADD INDEX `idx_product_id`(`product_id`);
+
+     users: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+       ~ ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
 
 ✓ Apply complete!
 
@@ -2393,8 +2395,9 @@ Single table progress (default):
 
 
   ── testapp ──
-    users: ⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ ❌ Failed
-      ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
+
+     users: ⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ ❌ Failed
+       ~ ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
 
 
 To recover: Fix the issue above, then run a new apply.
@@ -2417,12 +2420,13 @@ The new apply will only process tables that haven't completed.
 
 
   ── testapp ──
-    users: 🟧🟧🟧🟧🟧🟧🟧⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ ⏹️ Stopped at 39%
-      ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
+
+     users: 🟧🟧🟧🟧🟧🟧🟧⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ ⏹️ Stopped at 39%
+       ~ ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
       Rows: 156,342 / 397,453
 
-    orders: ⏹️ Stopped (not started)
-      ALTER TABLE `orders` ADD INDEX `idx_total_cents`(`total_cents`);
+     orders: ⏹️ Stopped (not started)
+       ~ ALTER TABLE `orders` ADD INDEX `idx_total_cents`(`total_cents`);
 
 
 Stopped. Use 'schemabot start --apply-id <apply_id>' to resume from checkpoint.
@@ -2444,11 +2448,12 @@ Stopped. Use 'schemabot start --apply-id <apply_id>' to resume from checkpoint.
 
 
   ── testapp ──
-    order_items: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦 Waiting for cutover
-      ALTER TABLE `order_items` ADD INDEX `idx_product_id`(`product_id`);
 
-    users: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦 Waiting for cutover
-      ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
+     order_items: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦 Waiting for cutover
+       ~ ALTER TABLE `order_items` ADD INDEX `idx_product_id`(`product_id`);
+
+     users: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦 Waiting for cutover
+       ~ ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
 
 Row copy complete. All data has been copied and new writes
 continue to be replicated to keep the shadow table in sync.
@@ -2486,11 +2491,12 @@ Watching for cutover... (Ctrl+C to detach)
 
 
   ── testapp ──
-    order_items: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦 🔄 Cutting over...
-      ALTER TABLE `order_items` ADD INDEX `idx_product_id`(`product_id`);
 
-    users: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦 🔄 Cutting over...
-      ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
+     order_items: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦 🔄 Cutting over...
+       ~ ALTER TABLE `order_items` ADD INDEX `idx_product_id`(`product_id`);
+
+     users: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦 🔄 Cutting over...
+       ~ ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
 
 
 ```
@@ -2511,14 +2517,14 @@ Sequential mode: Just started (all tables pending)
 └──────────────────────────────────┘
 
 
-    users: ⏳ Queued
-      ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
+     users: ⏳ Queued
+       ~ ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
 
-    orders: ⏳ Queued
-      ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
+     orders: ⏳ Queued
+       ~ ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
 
-    products: ⏳ Queued
-      ALTER TABLE `products` ADD COLUMN `weight_grams` int DEFAULT 0;
+     products: ⏳ Queued
+       ~ ALTER TABLE `products` ADD COLUMN `weight_grams` int DEFAULT 0;
 
 
 ```
@@ -2539,15 +2545,15 @@ Sequential mode: First table running, others queued
 └──────────────────────────────────┘
 
 
-    users: 🟦🟦🟦🟦🟦🟦🟦⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ 35%
-      ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
-      Rows: 875,000 / 2,500,000 · ETA: 8m 30s
+     users: 🟦🟦🟦🟦🟦🟦🟦⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ 35%
+       ~ ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
+       Rows: 875,000 / 2,500,000 · ETA: 8m 30s
 
-    orders: ⏳ Queued
-      ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
+     orders: ⏳ Queued
+       ~ ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
 
-    products: ⏳ Queued
-      ALTER TABLE `products` ADD COLUMN `weight_grams` int DEFAULT 0;
+     products: ⏳ Queued
+       ~ ALTER TABLE `products` ADD COLUMN `weight_grams` int DEFAULT 0;
 
 
 ```
@@ -2568,15 +2574,15 @@ Sequential mode: First complete, second running
 └──────────────────────────────────┘
 
 
-    orders: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦⬜⬜⬜⬜⬜⬜⬜⬜ 60%
-      ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
-      Rows: 3,000,000 / 5,000,000 · ETA: 12m 15s
+     orders: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦⬜⬜⬜⬜⬜⬜⬜⬜ 60%
+       ~ ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
+       Rows: 3,000,000 / 5,000,000 · ETA: 12m 15s
 
-    products: ⏳ Queued
-      ALTER TABLE `products` ADD COLUMN `weight_grams` int DEFAULT 0;
+     products: ⏳ Queued
+       ~ ALTER TABLE `products` ADD COLUMN `weight_grams` int DEFAULT 0;
 
-    users: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
-      ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
+     users: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+       ~ ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
 
 
 ```
@@ -2597,15 +2603,15 @@ Sequential mode: First two complete, third running
 └──────────────────────────────────┘
 
 
-    products: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦⬜⬜⬜⬜ 80%
-      ALTER TABLE `products` ADD COLUMN `weight_grams` int DEFAULT 0;
-      Rows: 160,000 / 200,000 · ETA: 2m 45s
+     products: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦⬜⬜⬜⬜ 80%
+       ~ ALTER TABLE `products` ADD COLUMN `weight_grams` int DEFAULT 0;
+       Rows: 160,000 / 200,000 · ETA: 2m 45s
 
-    users: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
-      ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
+     users: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+       ~ ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
 
-    orders: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
-      ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
+     orders: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+       ~ ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
 
 
 ```
@@ -2626,14 +2632,14 @@ Sequential mode: All tables completed successfully
 └──────────────────────────────────┘
 
 
-    users: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
-      ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
+     users: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+       ~ ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
 
-    orders: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
-      ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
+     orders: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+       ~ ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
 
-    products: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
-      ALTER TABLE `products` ADD COLUMN `weight_grams` int DEFAULT 0;
+     products: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+       ~ ALTER TABLE `products` ADD COLUMN `weight_grams` int DEFAULT 0;
 
 ✓ Apply complete!
 
@@ -2657,14 +2663,14 @@ Sequential mode: First table failed (others cancelled)
   lock wait timeout exceeded; try restarting transaction
 
 
-    users: 🟥🟥🟥🟥🟥🟥🟥🟥🟥🟥🟥🟥🟥⬜⬜⬜⬜⬜⬜⬜ ❌ Failed
-      ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
+     users: 🟥🟥🟥🟥🟥🟥🟥🟥🟥🟥🟥🟥🟥⬜⬜⬜⬜⬜⬜⬜ ❌ Failed
+       ~ ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
 
-    orders: ⊘ Cancelled (not started)
-      ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
+     orders: ⊘ Cancelled (not started)
+       ~ ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
 
-    products: ⊘ Cancelled (not started)
-      ALTER TABLE `products` ADD COLUMN `weight_grams` int DEFAULT 0;
+     products: ⊘ Cancelled (not started)
+       ~ ALTER TABLE `products` ADD COLUMN `weight_grams` int DEFAULT 0;
 
 
 To recover: Fix the issue above, then run a new apply.
@@ -2690,14 +2696,14 @@ Sequential mode: Middle table failed
   Lost connection to MySQL server during query (MySQL error 2013)
 
 
-    orders: 🟥🟥🟥🟥🟥🟥🟥🟥🟥⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ ❌ Failed
-      ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
+     orders: 🟥🟥🟥🟥🟥🟥🟥🟥🟥⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ ❌ Failed
+       ~ ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
 
-    users: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
-      ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
+     users: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+       ~ ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
 
-    products: ⊘ Cancelled (not started)
-      ALTER TABLE `products` ADD COLUMN `weight_grams` int DEFAULT 0;
+     products: ⊘ Cancelled (not started)
+       ~ ALTER TABLE `products` ADD COLUMN `weight_grams` int DEFAULT 0;
 
 
 To recover: Fix the issue above, then run a new apply.
@@ -2721,15 +2727,15 @@ Sequential mode: User stopped mid-apply
 └──────────────────────────────────┘
 
 
-    orders: 🟧🟧🟧🟧🟧🟧🟧🟧⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ ⏹️ Stopped at 42%
-      ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
+     orders: 🟧🟧🟧🟧🟧🟧🟧🟧⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ ⏹️ Stopped at 42%
+       ~ ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
       Rows: 112,045 / 266,383
 
-    products: ⏹️ Stopped (not started)
-      ALTER TABLE `products` ADD COLUMN `weight_grams` int DEFAULT 0;
+     products: ⏹️ Stopped (not started)
+       ~ ALTER TABLE `products` ADD COLUMN `weight_grams` int DEFAULT 0;
 
-    users: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
-      ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
+     users: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+       ~ ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
 
 Use 'schemabot start' to resume from checkpoint.
 
@@ -2750,8 +2756,9 @@ Use 'schemabot start' to resume from checkpoint.
 
 
   ── myapp_sharded ──
-    users: ⏳ Queued
-      ALTER TABLE `users` ADD COLUMN `phone` varchar(20);
+
+     users: ⏳ Queued
+       ~ ALTER TABLE `users` ADD COLUMN `phone` varchar(20);
 
 
 ```
@@ -2772,8 +2779,9 @@ Use 'schemabot start' to resume from checkpoint.
 
 
   ── myapp_sharded ──
-    users: ⏳ Queued
-      ALTER TABLE `users` ADD COLUMN `phone` varchar(20);
+
+     users: ⏳ Queued
+       ~ ALTER TABLE `users` ADD COLUMN `phone` varchar(20);
 
 
 ```
@@ -2794,9 +2802,37 @@ Use 'schemabot start' to resume from checkpoint.
 
 
   ── myapp_sharded ──
-    users: ⏳ Queued
-      ALTER TABLE `users` ADD COLUMN `phone` varchar(20);
 
+     users: ⏳ Queued
+       ~ ALTER TABLE `users` ADD COLUMN `phone` varchar(20);
+
+
+```
+</details>
+
+<details>
+<summary><a name="vitess-staging-schema-changes-0-with-shards"></a><strong>Vitess: Staging Schema Changes (0% With Shards)</strong></summary>
+
+```
+
+┌─────────────────────────────────────┐
+│  Apply ID:     apply-a1b2c3d4e5f6   │
+│  Database:     myapp                │
+│  Environment:  staging              │
+│  State:        Running              │
+│  Started:      Jan 15 14:29:15 UTC  │
+│  Duration:     45s                  │
+└─────────────────────────────────────┘
+
+
+  ── myapp_sharded ──
+
+     customers: Staging schema changes...
+       ~ ALTER TABLE `customers` ADD INDEX `idx_created_at`(`created_at`);
+
+    Shards: 2 (2 copying)
+      ◉ -80: 0% (0/60,483,380 rows)
+      ◉ 80-: 0% (0/64,277,080 rows)
 
 ```
 </details>
@@ -2819,8 +2855,9 @@ Use 'schemabot start' to resume from checkpoint.
 
 
   ── myapp_sharded ──
-    users: Running...
-      ALTER TABLE `users` ADD COLUMN `phone` varchar(20);
+
+     users: Running...
+       ~ ALTER TABLE `users` ADD COLUMN `phone` varchar(20);
 
 
 ```
@@ -2844,8 +2881,9 @@ Use 'schemabot start' to resume from checkpoint.
 
 
   ── myapp_sharded ──
-    users: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
-      ALTER TABLE `users` ADD COLUMN `phone` varchar(20);
+
+     users: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+       ~ ALTER TABLE `users` ADD COLUMN `phone` varchar(20);
 
 
 ```
@@ -2871,8 +2909,9 @@ Use 'schemabot start' to resume from checkpoint.
 
 
   ── myapp_sharded ──
-    users: ⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ ❌ Failed
-      ALTER TABLE `users` ADD COLUMN `phone` varchar(20);
+
+     users: ⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ ❌ Failed
+       ~ ALTER TABLE `users` ADD COLUMN `phone` varchar(20);
 
 
 To recover: Fix the issue above, then run a new apply.
@@ -2900,8 +2939,9 @@ The new apply will only process tables that haven't completed.
 
 
   ── myapp_sharded ──
-    orders: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦 Waiting for cutover
-      ALTER TABLE `orders` ADD INDEX `idx_total`(`total_cents`);
+
+     orders: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦 Waiting for cutover
+       ~ ALTER TABLE `orders` ADD INDEX `idx_total`(`total_cents`);
 
     Shards: 2 (2 ready for cutover)
       ● -80: ready for cutover
@@ -2929,8 +2969,9 @@ The new apply will only process tables that haven't completed.
 
 
   ── myapp_sharded ──
-    orders: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦 🔄 Cutting over...
-      ALTER TABLE `orders` ADD INDEX `idx_total`(`total_cents`);
+
+     orders: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦 🔄 Cutting over...
+       ~ ALTER TABLE `orders` ADD INDEX `idx_total`(`total_cents`);
 
     Shards: 2 (2 cutting over)
       ● -80: cutting over
@@ -2957,8 +2998,9 @@ The new apply will only process tables that haven't completed.
 
 
   ── myapp_sharded ──
-    orders: 🟥🟥🟥🟥🟥🟥⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ ⊘ Cancelled at 30%
-      ALTER TABLE `orders` ADD INDEX `idx_total`(`total_cents`);
+
+     orders: 🟥🟥🟥🟥🟥🟥⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ ⊘ Cancelled at 30%
+       ~ ALTER TABLE `orders` ADD INDEX `idx_total`(`total_cents`);
 
     Shards: 2 (2 cancelled)
       ○ -80: cancelled
@@ -2985,9 +3027,10 @@ The new apply will only process tables that haven't completed.
 
 
   ── commerce_sharded ──
-    transactions: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦⬜⬜⬜⬜⬜⬜⬜⬜⬜ 57%
-      ALTER TABLE `transactions` ADD COLUMN `region_id` int;
-      Rows: 110,573,340 / 193,280,000 · ETA: 4m 40s
+
+     transactions: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦⬜⬜⬜⬜⬜⬜⬜⬜⬜ 57%
+       ~ ALTER TABLE `transactions` ADD COLUMN `region_id` int;
+       Rows: 110,573,340 / 193,280,000 · ETA: 4m 40s
 
     Shards: 256 (30 ready for cutover, 226 copying)
       ● -01: ready for cutover
@@ -3022,9 +3065,10 @@ The new apply will only process tables that haven't completed.
 
 
   ── commerce_sharded ──
-    transactions: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦⬜⬜⬜⬜⬜⬜⬜ 67%
-      ALTER TABLE `transactions` ADD COLUMN `region_id` int;
-      Rows: 29,435,000 / 43,360,000 · ETA: 2m 37s
+
+     transactions: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦⬜⬜⬜⬜⬜⬜⬜ 67%
+       ~ ALTER TABLE `transactions` ADD COLUMN `region_id` int;
+       Rows: 29,435,000 / 43,360,000 · ETA: 2m 37s
 
     Shards: 32 (12 ready for cutover, 20 copying)
       ● -08: ready for cutover
@@ -3039,28 +3083,33 @@ The new apply will only process tables that haven't completed.
       ... 15 more copying shards
 
   ── commerce_001 ──
-    transactions: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
-      ALTER TABLE `transactions` ADD COLUMN `region_id` int;
+
+     transactions: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+       ~ ALTER TABLE `transactions` ADD COLUMN `region_id` int;
 
 
   ── commerce_002 ──
-    transactions: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
-      ALTER TABLE `transactions` ADD COLUMN `region_id` int;
+
+     transactions: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+       ~ ALTER TABLE `transactions` ADD COLUMN `region_id` int;
 
 
   ── commerce_003 ──
-    transactions: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
-      ALTER TABLE `transactions` ADD COLUMN `region_id` int;
+
+     transactions: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+       ~ ALTER TABLE `transactions` ADD COLUMN `region_id` int;
 
 
   ── commerce_004 ──
-    transactions: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
-      ALTER TABLE `transactions` ADD COLUMN `region_id` int;
+
+     transactions: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+       ~ ALTER TABLE `transactions` ADD COLUMN `region_id` int;
 
 
   ── commerce_005 ──
-    transactions: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
-      ALTER TABLE `transactions` ADD COLUMN `region_id` int;
+
+     transactions: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+       ~ ALTER TABLE `transactions` ADD COLUMN `region_id` int;
 
 
   ... and 27 more keyspaces (all completed)
@@ -3086,8 +3135,9 @@ The new apply will only process tables that haven't completed.
 
 
   ── myapp_sharded ──
+
     ~ VSchema: Applying...
-      + "xxhash": {"type": "xxhash"}
+       + "xxhash": {"type": "xxhash"}
 
 
 ```
@@ -3111,18 +3161,20 @@ The new apply will only process tables that haven't completed.
 
 
   ── myapp_unsharded ──
-    orders_seq: Running...
-      CREATE TABLE `orders_seq` (
-          `id` int unsigned NOT NULL DEFAULT '0',
-          `next_id` bigint unsigned,
-          `cache` bigint unsigned,
-          PRIMARY KEY(`id`)
-      ) ENGINE InnoDB;
+
+     orders_seq: Running...
+       ~ CREATE TABLE `orders_seq` (
+             `id` int unsigned NOT NULL DEFAULT '0',
+             `next_id` bigint unsigned,
+             `cache` bigint unsigned,
+             PRIMARY KEY(`id`)
+         ) ENGINE InnoDB;
 
 
   ── myapp_sharded ──
-    users: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
-      ALTER TABLE `users` ADD COLUMN `phone` varchar(20);
+
+     users: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+       ~ ALTER TABLE `users` ADD COLUMN `phone` varchar(20);
 
 
 ```
@@ -3146,11 +3198,12 @@ The new apply will only process tables that haven't completed.
 
 
   ── myapp_sharded ──
-    ~ VSchema: Applying...
-      + "users": {"column_vindexes": [{"column": "id", "name": "hash"}]}
 
-    users: Running...
-      ALTER TABLE `users` ADD COLUMN `phone` varchar(20);
+    ~ VSchema: Applying...
+       + "users": {"column_vindexes": [{"column": "id", "name": "hash"}]}
+
+     users: Running...
+       ~ ALTER TABLE `users` ADD COLUMN `phone` varchar(20);
 
 
 ```
@@ -3174,9 +3227,10 @@ The new apply will only process tables that haven't completed.
 
 
   ── myapp_sharded ──
-    orders: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦⬜⬜⬜⬜⬜⬜ 70%
-      ALTER TABLE `orders` ADD INDEX `idx_total`(`total_cents`);
-      Rows: 2,800,000 / 4,000,000 · ETA: 2m 0s
+
+     orders: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦⬜⬜⬜⬜⬜⬜ 70%
+       ~ ALTER TABLE `orders` ADD INDEX `idx_total`(`total_cents`);
+       Rows: 2,800,000 / 4,000,000 · ETA: 2m 0s
 
     Shards: 2 (2 copying)
       ◉ -80: 95% (2,000,000/2,100,000 rows) ETA 10s
@@ -3203,8 +3257,9 @@ The new apply will only process tables that haven't completed.
 
 
   ── myapp_sharded ──
-    orders: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦 Waiting for cutover
-      ALTER TABLE `orders` ADD INDEX `idx_total`(`total_cents`);
+
+     orders: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦 Waiting for cutover
+       ~ ALTER TABLE `orders` ADD INDEX `idx_total`(`total_cents`);
 
     Shards: 2 (2 ready for cutover)
       ● -80: ready for cutover
@@ -3376,8 +3431,9 @@ Vitess plan: Multi-keyspace with DDL + VSchema across keyspaces
 
 
   ── myapp_sharded ──
-    users: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
-      ALTER TABLE `users` ADD COLUMN `phone` varchar(20);
+
+     users: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+       ~ ALTER TABLE `users` ADD COLUMN `phone` varchar(20);
 
 
 ```
@@ -3402,8 +3458,9 @@ Vitess plan: Multi-keyspace with DDL + VSchema across keyspaces
 
 
   ── myapp_sharded ──
-    orders: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 ✓ Complete (pending revert)
-      ALTER TABLE `orders` ADD INDEX `idx_total`(`total_cents`);
+
+     orders: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 ✓ Complete (pending revert)
+       ~ ALTER TABLE `orders` ADD INDEX `idx_total`(`total_cents`);
 
 
 ```
@@ -3426,15 +3483,16 @@ Apply watch mode: Running with footer controls
 
 
   ── testapp ──
-    users: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦⬜⬜⬜⬜⬜⬜⬜⬜ 62%
-      ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
-      Rows: 914,707 / 1,466,232 · ETA: 3m 15s
 
-    products: ⏳ Queued
-      ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
+     users: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦⬜⬜⬜⬜⬜⬜⬜⬜ 62%
+       ~ ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
+       Rows: 914,707 / 1,466,232 · ETA: 3m 15s
 
-    orders: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
-      ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
+     products: ⏳ Queued
+       ~ ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
+
+     orders: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+       ~ ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
 
 ESC detach • s stop • v volume
 
@@ -3455,14 +3513,15 @@ ESC detach • s stop • v volume
 
 
   ── testapp ──
-    orders: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
-      ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
 
-    products: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
-      ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
+     orders: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+       ~ ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
 
-    users: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
-      ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
+     products: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+       ~ ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
+
+     users: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+       ~ ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
 
 ✓ Apply complete!
 
@@ -3502,15 +3561,16 @@ Checkpoint saved. Use 'schemabot start --apply-id apply-a1b2c3d4e5f67890' to res
 
 
   ── testapp ──
-    users: 🟧🟧🟧🟧🟧🟧🟧⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ ⏹️ Stopped at 39%
-      ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
+
+     users: 🟧🟧🟧🟧🟧🟧🟧⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ ⏹️ Stopped at 39%
+       ~ ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
       Rows: 156,342 / 397,453
 
-    products: ⏹️ Stopped (not started)
-      ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
+     products: ⏹️ Stopped (not started)
+       ~ ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
 
-    orders: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
-      ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
+     orders: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+       ~ ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
 
 
 ```
@@ -3549,15 +3609,16 @@ Resuming from checkpoint...
 
 
   ── testapp ──
-    users: 🟦🟦🟦🟦🟦🟦🟦🟦⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ 40%
-      ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
-      Rows: 158,000 / 397,453 · ETA: 8m 0s
 
-    products: ⏳ Queued
-      ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
+     users: 🟦🟦🟦🟦🟦🟦🟦🟦⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ 40%
+       ~ ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
+       Rows: 158,000 / 397,453 · ETA: 8m 0s
 
-    orders: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
-      ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
+     products: ⏳ Queued
+       ~ ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
+
+     orders: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+       ~ ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
 
 ESC detach • s stop • v volume
 
@@ -3667,14 +3728,14 @@ Sequential mode: Just started (all tables pending)
 └──────────────────────────────────┘
 
 
-    users: ⏳ Queued
-      ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
+     users: ⏳ Queued
+       ~ ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
 
-    orders: ⏳ Queued
-      ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
+     orders: ⏳ Queued
+       ~ ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
 
-    products: ⏳ Queued
-      ALTER TABLE `products` ADD COLUMN `weight_grams` int DEFAULT 0;
+     products: ⏳ Queued
+       ~ ALTER TABLE `products` ADD COLUMN `weight_grams` int DEFAULT 0;
 
 
 ```
@@ -3695,15 +3756,15 @@ Sequential mode: First table running, others queued
 └──────────────────────────────────┘
 
 
-    users: 🟦🟦🟦🟦🟦🟦🟦⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ 35%
-      ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
-      Rows: 875,000 / 2,500,000 · ETA: 8m 30s
+     users: 🟦🟦🟦🟦🟦🟦🟦⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ 35%
+       ~ ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
+       Rows: 875,000 / 2,500,000 · ETA: 8m 30s
 
-    orders: ⏳ Queued
-      ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
+     orders: ⏳ Queued
+       ~ ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
 
-    products: ⏳ Queued
-      ALTER TABLE `products` ADD COLUMN `weight_grams` int DEFAULT 0;
+     products: ⏳ Queued
+       ~ ALTER TABLE `products` ADD COLUMN `weight_grams` int DEFAULT 0;
 
 
 ```
@@ -3724,15 +3785,15 @@ Sequential mode: First complete, second running
 └──────────────────────────────────┘
 
 
-    orders: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦⬜⬜⬜⬜⬜⬜⬜⬜ 60%
-      ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
-      Rows: 3,000,000 / 5,000,000 · ETA: 12m 15s
+     orders: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦⬜⬜⬜⬜⬜⬜⬜⬜ 60%
+       ~ ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
+       Rows: 3,000,000 / 5,000,000 · ETA: 12m 15s
 
-    products: ⏳ Queued
-      ALTER TABLE `products` ADD COLUMN `weight_grams` int DEFAULT 0;
+     products: ⏳ Queued
+       ~ ALTER TABLE `products` ADD COLUMN `weight_grams` int DEFAULT 0;
 
-    users: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
-      ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
+     users: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+       ~ ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
 
 
 ```
@@ -3753,15 +3814,15 @@ Sequential mode: First two complete, third running
 └──────────────────────────────────┘
 
 
-    products: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦⬜⬜⬜⬜ 80%
-      ALTER TABLE `products` ADD COLUMN `weight_grams` int DEFAULT 0;
-      Rows: 160,000 / 200,000 · ETA: 2m 45s
+     products: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦⬜⬜⬜⬜ 80%
+       ~ ALTER TABLE `products` ADD COLUMN `weight_grams` int DEFAULT 0;
+       Rows: 160,000 / 200,000 · ETA: 2m 45s
 
-    users: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
-      ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
+     users: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+       ~ ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
 
-    orders: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
-      ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
+     orders: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+       ~ ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
 
 
 ```
@@ -3782,14 +3843,14 @@ Sequential mode: All tables completed successfully
 └──────────────────────────────────┘
 
 
-    users: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
-      ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
+     users: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+       ~ ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
 
-    orders: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
-      ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
+     orders: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+       ~ ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
 
-    products: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
-      ALTER TABLE `products` ADD COLUMN `weight_grams` int DEFAULT 0;
+     products: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+       ~ ALTER TABLE `products` ADD COLUMN `weight_grams` int DEFAULT 0;
 
 ✓ Apply complete!
 
@@ -3813,14 +3874,14 @@ Sequential mode: First table failed (others cancelled)
   lock wait timeout exceeded; try restarting transaction
 
 
-    users: 🟥🟥🟥🟥🟥🟥🟥🟥🟥🟥🟥🟥🟥⬜⬜⬜⬜⬜⬜⬜ ❌ Failed
-      ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
+     users: 🟥🟥🟥🟥🟥🟥🟥🟥🟥🟥🟥🟥🟥⬜⬜⬜⬜⬜⬜⬜ ❌ Failed
+       ~ ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
 
-    orders: ⊘ Cancelled (not started)
-      ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
+     orders: ⊘ Cancelled (not started)
+       ~ ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
 
-    products: ⊘ Cancelled (not started)
-      ALTER TABLE `products` ADD COLUMN `weight_grams` int DEFAULT 0;
+     products: ⊘ Cancelled (not started)
+       ~ ALTER TABLE `products` ADD COLUMN `weight_grams` int DEFAULT 0;
 
 
 To recover: Fix the issue above, then run a new apply.
@@ -3846,14 +3907,14 @@ Sequential mode: Middle table failed
   Lost connection to MySQL server during query (MySQL error 2013)
 
 
-    orders: 🟥🟥🟥🟥🟥🟥🟥🟥🟥⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ ❌ Failed
-      ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
+     orders: 🟥🟥🟥🟥🟥🟥🟥🟥🟥⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ ❌ Failed
+       ~ ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
 
-    users: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
-      ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
+     users: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+       ~ ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
 
-    products: ⊘ Cancelled (not started)
-      ALTER TABLE `products` ADD COLUMN `weight_grams` int DEFAULT 0;
+     products: ⊘ Cancelled (not started)
+       ~ ALTER TABLE `products` ADD COLUMN `weight_grams` int DEFAULT 0;
 
 
 To recover: Fix the issue above, then run a new apply.
@@ -3877,15 +3938,15 @@ Sequential mode: User stopped mid-apply
 └──────────────────────────────────┘
 
 
-    orders: 🟧🟧🟧🟧🟧🟧🟧🟧⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ ⏹️ Stopped at 42%
-      ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
+     orders: 🟧🟧🟧🟧🟧🟧🟧🟧⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ ⏹️ Stopped at 42%
+       ~ ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
       Rows: 112,045 / 266,383
 
-    products: ⏹️ Stopped (not started)
-      ALTER TABLE `products` ADD COLUMN `weight_grams` int DEFAULT 0;
+     products: ⏹️ Stopped (not started)
+       ~ ALTER TABLE `products` ADD COLUMN `weight_grams` int DEFAULT 0;
 
-    users: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
-      ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
+     users: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+       ~ ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
 
 Use 'schemabot start' to resume from checkpoint.
 ```
@@ -3908,17 +3969,17 @@ Atomic mode (--defer-cutover): All tables copy rows, then cutover together
 └──────────────────────────────────┘
 
 
-    orders: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦⬜⬜⬜⬜⬜⬜ 72%
-      ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
-      Rows: 1,800,000 / 2,500,000 · ETA: 3m 15s
+     orders: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦⬜⬜⬜⬜⬜⬜ 72%
+       ~ ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
+       Rows: 1,800,000 / 2,500,000 · ETA: 3m 15s
 
-    products: 🟦🟦🟦🟦🟦🟦🟦🟦🟦⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ 45%
-      ALTER TABLE `products` ADD INDEX `idx_category`(`category`);
-      Rows: 450,000 / 1,000,000 · ETA: 6m 20s
+     products: 🟦🟦🟦🟦🟦🟦🟦🟦🟦⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ 45%
+       ~ ALTER TABLE `products` ADD INDEX `idx_category`(`category`);
+       Rows: 450,000 / 1,000,000 · ETA: 6m 20s
 
-    users: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦⬜⬜⬜ 89%
-      ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
-      Rows: 6,400,000 / 7,200,000 · ETA: 1m 45s
+     users: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦⬜⬜⬜ 89%
+       ~ ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
+       Rows: 6,400,000 / 7,200,000 · ETA: 1m 45s
 
 All tables copy rows simultaneously. Cutover happens atomically
 after all tables complete row copy.
@@ -3942,8 +4003,8 @@ Defer cutover: Single table waiting
 └──────────────────────────────────┘
 
 
-    users: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦 Waiting for cutover
-      ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
+     users: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦 Waiting for cutover
+       ~ ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
 
 Row copy complete. All data has been copied and new writes
 continue to be replicated to keep the shadow table in sync.
@@ -3968,14 +4029,14 @@ Atomic mode (--defer-cutover): All tables waiting for cutover
 └──────────────────────────────────┘
 
 
-    orders: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦 Waiting for cutover
-      ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
+     orders: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦 Waiting for cutover
+       ~ ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
 
-    products: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦 Waiting for cutover
-      ALTER TABLE `products` ADD INDEX `idx_category`(`category`);
+     products: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦 Waiting for cutover
+       ~ ALTER TABLE `products` ADD INDEX `idx_category`(`category`);
 
-    users: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦 Waiting for cutover
-      ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
+     users: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦 Waiting for cutover
+       ~ ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
 
 Row copy complete for all tables. New writes continue to be
 replicated to keep shadow tables in sync.
@@ -4001,14 +4062,14 @@ Defer cutover: Sequential mode, first complete, second waiting
 └──────────────────────────────────┘
 
 
-    orders: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦 Waiting for cutover
-      ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
+     orders: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦 Waiting for cutover
+       ~ ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
 
-    products: ⏳ Queued
-      ALTER TABLE `products` ADD COLUMN `weight_grams` int DEFAULT 0;
+     products: ⏳ Queued
+       ~ ALTER TABLE `products` ADD COLUMN `weight_grams` int DEFAULT 0;
 
-    users: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
-      ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
+     users: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+       ~ ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
 
 Row copy complete for current table. Press Enter to cutover
 and start the next table (or Ctrl+C to detach): _
@@ -4032,16 +4093,16 @@ Defer cutover: Stopped by user (s)
 └──────────────────────────────────┘
 
 
-    orders: 🟧🟧🟧🟧🟧🟧🟧🟧🟧🟧🟧🟧🟧🟧⬜⬜⬜⬜⬜⬜ ⏹️ Stopped at 72%
-      ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
+     orders: 🟧🟧🟧🟧🟧🟧🟧🟧🟧🟧🟧🟧🟧🟧⬜⬜⬜⬜⬜⬜ ⏹️ Stopped at 72%
+       ~ ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
       Rows: 1,800,000 / 2,500,000
 
-    products: 🟧🟧🟧🟧🟧🟧🟧🟧🟧⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ ⏹️ Stopped at 45%
-      ALTER TABLE `products` ADD INDEX `idx_category`(`category`);
+     products: 🟧🟧🟧🟧🟧🟧🟧🟧🟧⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ ⏹️ Stopped at 45%
+       ~ ALTER TABLE `products` ADD INDEX `idx_category`(`category`);
       Rows: 450,000 / 1,000,000
 
-    users: 🟧🟧🟧🟧🟧🟧🟧🟧🟧🟧🟧🟧🟧🟧🟧🟧🟧⬜⬜⬜ ⏹️ Stopped at 89%
-      ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
+     users: 🟧🟧🟧🟧🟧🟧🟧🟧🟧🟧🟧🟧🟧🟧🟧🟧🟧⬜⬜⬜ ⏹️ Stopped at 89%
+       ~ ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
       Rows: 6,400,000 / 7,200,000
 
 Use 'schemabot start --apply-id <apply_id>' to resume.
@@ -4089,14 +4150,14 @@ Defer cutover: Cutting over in progress
 └──────────────────────────────────┘
 
 
-    orders: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦 🔄 Cutting over...
-      ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
+     orders: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦 🔄 Cutting over...
+       ~ ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
 
-    products: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦 🔄 Cutting over...
-      ALTER TABLE `products` ADD INDEX `idx_category`(`category`);
+     products: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦 🔄 Cutting over...
+       ~ ALTER TABLE `products` ADD INDEX `idx_category`(`category`);
 
-    users: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦 🔄 Cutting over...
-      ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
+     users: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦 🔄 Cutting over...
+       ~ ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
 
 Cutover in progress. This typically completes within seconds.
 Tables are being renamed atomically...

--- a/pkg/api/progress_handlers.go
+++ b/pkg/api/progress_handlers.go
@@ -14,6 +14,20 @@ import (
 	"github.com/block/schemabot/pkg/tern"
 )
 
+// changeTypeToString converts a proto ChangeType enum to a lowercase string.
+func changeTypeToString(ct ternv1.ChangeType) string {
+	switch ct {
+	case ternv1.ChangeType_CHANGE_TYPE_CREATE:
+		return "create"
+	case ternv1.ChangeType_CHANGE_TYPE_ALTER:
+		return "alter"
+	case ternv1.ChangeType_CHANGE_TYPE_DROP:
+		return "drop"
+	default:
+		return ""
+	}
+}
+
 // deriveErrorCode returns an error code based on apply state
 // and error message. Returns empty string when no error code applies.
 func deriveErrorCode(applyState, errorMessage string) string {
@@ -66,6 +80,8 @@ func progressResponseFromProto(resp *ternv1.ProgressResponse) *apitypes.Progress
 	for _, t := range resp.Tables {
 		httpResp.Tables = append(httpResp.Tables, &apitypes.TableProgressResponse{
 			TableName:       t.TableName,
+			Keyspace:        t.Namespace,
+			ChangeType:      changeTypeToString(t.ChangeType),
 			DDL:             t.Ddl,
 			Status:          t.Status,
 			RowsCopied:      t.RowsCopied,
@@ -513,6 +529,7 @@ func (s *Service) progressFromLocalStorage(ctx context.Context, apply *storage.A
 	for _, task := range tasks {
 		httpResp.Tables = append(httpResp.Tables, &apitypes.TableProgressResponse{
 			TableName:       task.TableName,
+			ChangeType:      task.DDLAction,
 			DDL:             task.DDL,
 			Status:          task.State,
 			RowsCopied:      task.RowsCopied,

--- a/pkg/apitypes/apitypes.go
+++ b/pkg/apitypes/apitypes.go
@@ -285,6 +285,7 @@ type TableProgressResponse struct {
 	TableName       string                   `json:"table_name"`
 	DDL             string                   `json:"ddl"`
 	Keyspace        string                   `json:"keyspace,omitempty"`
+	ChangeType      string                   `json:"change_type,omitempty"` // create, alter, drop
 	Status          string                   `json:"status"`
 	RowsCopied      int64                    `json:"rows_copied"`
 	RowsTotal       int64                    `json:"rows_total"`

--- a/pkg/cmd/commands/common.go
+++ b/pkg/cmd/commands/common.go
@@ -271,6 +271,9 @@ func applyAndWatch(ep string, planResult *apitypes.PlanResponse, database, envir
 	if deferCutover {
 		options["defer_cutover"] = "true"
 	}
+	if skipRevert {
+		options["skip_revert"] = "true"
+	}
 
 	applyResult, err := client.CallApplyAPI(ep, planResult.PlanID, database, environment, caller, options, opts...)
 	if err != nil {

--- a/pkg/cmd/commands/watch_tui.go
+++ b/pkg/cmd/commands/watch_tui.go
@@ -16,20 +16,26 @@ import (
 // WatchModel is the Bubbletea model for watching apply progress.
 type WatchModel struct {
 	// Config
-	endpoint         string
-	database         string
-	environment      string
-	applyID          string // When set, fetches progress by apply ID instead of database/environment
-	allowCutover     bool
-	maxTableNameLen  int
-	cutoverTriggered bool
-	stopTriggered    bool
+	endpoint            string
+	database            string
+	environment         string
+	applyID             string // When set, fetches progress by apply ID instead of database/environment
+	allowCutover        bool
+	maxTableNameLen     int
+	cutoverTriggered    bool
+	skipRevertTriggered bool
+	stopTriggered       bool
 
 	// State from API
 	state         string
 	tables        []tableProgress
 	errorMsg      string
 	currentVolume int // Current volume (1-11)
+
+	// Engine metadata
+	engine           string // "Spirit", "PlanetScale", etc.
+	deployRequestURL string
+	metadata         map[string]string // Full metadata from progress response
 
 	// UI state
 	detached          bool
@@ -46,6 +52,7 @@ type WatchModel struct {
 // tableProgress represents progress for a single table.
 type tableProgress struct {
 	Name           string
+	Keyspace       string
 	DDL            string
 	Status         string
 	RowsCopied     int64
@@ -53,6 +60,17 @@ type tableProgress struct {
 	Percent        int
 	ETA            string
 	ProgressDetail string
+	Shards         []shardProgress
+}
+
+type shardProgress struct {
+	Shard           string
+	Status          string
+	RowsCopied      int64
+	RowsTotal       int64
+	Percent         int
+	ETASeconds      int64
+	CutoverAttempts int
 }
 
 // Messages
@@ -82,9 +100,11 @@ type progressMsg struct {
 	failed      bool   // true when the API call didn't return usable progress data
 	retryable   bool   // when failed, whether the TUI should keep polling
 	volume      int
-	applyID     string // Populated from progress responses
-	database    string // Populated from apply-id progress responses
-	environment string // Populated from apply-id progress responses
+	applyID     string            // Populated from progress responses
+	database    string            // Populated from apply-id progress responses
+	environment string            // Populated from apply-id progress responses
+	engine      string            // Engine name (e.g., "Spirit", "PlanetScale")
+	metadata    map[string]string // Engine metadata (e.g., deploy_request_url)
 }
 
 type cutoverResultMsg struct {
@@ -153,12 +173,12 @@ func (m WatchModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "q":
 			m.quitting = true
 			return m, tea.Quit
-		case "s":
-			// Don't allow stop during cutover
+		case "s", "c":
+			// Don't allow stop/cancel during cutover
 			if isCuttingOver {
 				return m, nil
 			}
-			// Stop the schema change if running and not already stopped/stopping
+			// Stop (Spirit) or cancel (PlanetScale) the schema change
 			if state.IsState(m.state, state.Apply.Running, state.Apply.WaitingForCutover) && !m.stopTriggered {
 				m.stopTriggered = true
 				return m, m.triggerStop()
@@ -174,6 +194,11 @@ func (m WatchModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if state.IsState(m.state, state.Apply.WaitingForCutover) && m.allowCutover && !m.cutoverTriggered {
 				m.cutoverTriggered = true
 				return m, m.triggerCutover()
+			}
+			// Trigger skip-revert if in revert window
+			if state.IsState(m.state, state.Apply.RevertWindow) && !m.skipRevertTriggered {
+				m.skipRevertTriggered = true
+				return m, m.triggerSkipRevert()
 			}
 		}
 
@@ -218,6 +243,17 @@ func (m WatchModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.environment == "" && msg.environment != "" {
 			m.environment = msg.environment
 		}
+		if m.engine == "" && msg.engine != "" {
+			m.engine = msg.engine
+		}
+		if msg.metadata != nil {
+			m.metadata = msg.metadata
+			if m.deployRequestURL == "" {
+				if url := msg.metadata["deploy_request_url"]; url != "" {
+					m.deployRequestURL = url
+				}
+			}
+		}
 
 		// Calculate max table name length for alignment
 		for _, t := range m.tables {
@@ -230,8 +266,8 @@ func (m WatchModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if state.IsState(m.state, state.Apply.Completed, state.Apply.Failed) {
 			return m, tea.Quit
 		}
-		// Also quit on stopped state
-		if state.IsState(m.state, state.Apply.Stopped) {
+		// Also quit on stopped/cancelled state
+		if state.IsState(m.state, state.Apply.Stopped, state.Apply.Cancelled) {
 			return m, tea.Quit
 		}
 		// Quit if no active schema change

--- a/pkg/cmd/commands/watch_tui_commands.go
+++ b/pkg/cmd/commands/watch_tui_commands.go
@@ -88,6 +88,25 @@ func (m WatchModel) triggerStop() tea.Cmd {
 	}
 }
 
+func (m WatchModel) triggerSkipRevert() tea.Cmd {
+	return func() tea.Msg {
+		result, err := client.CallSkipRevertAPI(m.endpoint, m.database, m.environment)
+		if err != nil {
+			return stopResultMsg{success: false, err: err}
+		}
+
+		if !result.Accepted {
+			errMsg := result.ErrorMessage
+			if errMsg == "" {
+				errMsg = "skip-revert not accepted"
+			}
+			return stopResultMsg{success: false, err: fmt.Errorf("%s", errMsg)}
+		}
+
+		return stopResultMsg{success: true, message: "Revert window closed"}
+	}
+}
+
 // handleVolumeKeys handles keyboard input when in volume mode.
 func (m WatchModel) handleVolumeKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	key := msg.String()
@@ -191,6 +210,8 @@ func parseProgressResult(result *apitypes.ProgressResponse) progressMsg {
 		applyID:     result.ApplyID,
 		database:    result.Database,
 		environment: result.Environment,
+		engine:      result.Engine,
+		metadata:    result.Metadata,
 	}
 
 	// Convert tables with internal table filtering and Spirit progress parsing
@@ -198,6 +219,7 @@ func parseProgressResult(result *apitypes.ProgressResponse) progressMsg {
 	for _, tbl := range filtered {
 		tp := tableProgress{
 			Name:           tbl.TableName,
+			Keyspace:       tbl.Keyspace,
 			DDL:            tbl.DDL,
 			Status:         tbl.Status,
 			RowsCopied:     tbl.RowsCopied,
@@ -212,6 +234,21 @@ func parseProgressResult(result *apitypes.ProgressResponse) progressMsg {
 				tp.RowsTotal = info.RowsTotal
 				tp.ETA = info.ETA
 			}
+		}
+		for _, sh := range tbl.Shards {
+			pct := int(sh.PercentComplete)
+			if pct == 0 && sh.RowsTotal > 0 {
+				pct = int(sh.RowsCopied * 100 / sh.RowsTotal)
+			}
+			tp.Shards = append(tp.Shards, shardProgress{
+				Shard:           sh.Shard,
+				Status:          sh.Status,
+				RowsCopied:      sh.RowsCopied,
+				RowsTotal:       sh.RowsTotal,
+				Percent:         pct,
+				ETASeconds:      sh.ETASeconds,
+				CutoverAttempts: int(sh.CutoverAttempts),
+			})
 		}
 		msg.tables = append(msg.tables, tp)
 	}
@@ -235,11 +272,6 @@ func sortStoppedByProgress(tables []tableProgress) {
 		}
 		return false
 	})
-}
-
-func isTableComplete(status string) bool {
-	upper := strings.ToUpper(status)
-	return upper == "COMPLETED" || upper == "STATE_COMPLETED"
 }
 
 func isTableStopped(status string) bool {

--- a/pkg/cmd/commands/watch_tui_view.go
+++ b/pkg/cmd/commands/watch_tui_view.go
@@ -3,13 +3,12 @@ package commands
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/charmbracelet/lipgloss"
 
 	"github.com/block/schemabot/pkg/cmd/templates"
-	"github.com/block/schemabot/pkg/ddl"
 	"github.com/block/schemabot/pkg/state"
-	"github.com/block/schemabot/pkg/ui"
 )
 
 // View implements tea.Model.
@@ -66,29 +65,17 @@ func (m WatchModel) progressView() string {
 	case m.volumeChanging:
 		// Volume change in progress
 		b.WriteString(m.spinner.View() + fmt.Sprintf("Changing volume to %d...\n", m.volumePending))
-	case m.stopTriggered && !state.IsState(m.state, state.Apply.Stopped):
-		// Stop has been triggered but state hasn't updated yet
-		b.WriteString(m.spinner.View() + "Stopping...\n")
+	case m.stopTriggered && !state.IsState(m.state, state.Apply.Stopped, state.Apply.Cancelled):
+		// Stop/cancel has been triggered but state hasn't updated yet
+		if m.isPlanetScale() {
+			b.WriteString(m.spinner.View() + "Cancelling...\n")
+		} else {
+			b.WriteString(m.spinner.View() + "Stopping...\n")
+		}
 	case effectivelyStopped:
 		// Don't show status line - stopped message comes after tables
 	case state.IsState(m.state, state.Apply.Running) && !m.cutoverTriggered:
-		// Find overall ETA and check if any table is actually copying rows
-		eta := ""
-		hasRowCopy := false
-		for _, t := range tables {
-			if t.RowsTotal > 0 && !isTableComplete(t.Status) {
-				hasRowCopy = true
-				if t.ETA != "" && t.ETA != "TBD" {
-					eta = t.ETA
-				}
-				break
-			}
-		}
-		if hasRowCopy {
-			b.WriteString(m.spinner.View() + templates.FormatStatusLine("Copying rows...", eta))
-		} else {
-			b.WriteString(m.spinner.View() + "Running...")
-		}
+		b.WriteString(m.spinner.View() + "Running...")
 		b.WriteString("\n")
 	case state.IsState(m.state, state.Apply.WaitingForCutover):
 		if m.cutoverTriggered {
@@ -100,18 +87,22 @@ func (m WatchModel) progressView() string {
 		// No status line for completed - just show completion message after tables
 	case state.IsState(m.state, state.Apply.Stopped):
 		// No status line - show stopped message after tables
+	case state.IsState(m.state, state.Apply.CreatingBranch):
+		b.WriteString(m.spinner.View() + "Creating branch..." + m.elapsed() + "\n")
+	case state.IsState(m.state, state.Apply.ApplyingBranchChanges):
+		b.WriteString(m.spinner.View() + "Applying changes to branch..." + m.elapsed() + "\n")
+	case state.IsState(m.state, state.Apply.CreatingDeployRequest):
+		msg := "Creating deploy request..."
+		if m.deployRequestURL != "" {
+			msg = fmt.Sprintf("Deploy request created  %s", m.deployRequestURL)
+		}
+		b.WriteString(m.spinner.View() + msg + m.elapsed() + "\n")
 	case state.IsState(m.state, state.Apply.Pending):
 		b.WriteString(m.spinner.View() + "Starting...\n")
 	}
 
-	// Render each table
-	for i, t := range tables {
-		b.WriteString(m.renderTable(t))
-		// Add spacing between tables (but not after the last one)
-		if i < len(tables)-1 {
-			b.WriteString("\n")
-		}
-	}
+	// Render tables grouped by keyspace
+	m.renderTables(&b, tables)
 
 	// Footer based on state
 	isCuttingOver := state.IsState(m.state, state.Apply.CuttingOver) || m.cutoverTriggered
@@ -121,6 +112,18 @@ func (m WatchModel) progressView() string {
 		b.WriteString("\n\n")
 		b.WriteString(templates.FormatApplyComplete())
 		b.WriteString("\n")
+	case state.IsState(m.state, state.Apply.Cancelled):
+		b.WriteString("\n\n")
+		b.WriteString("🚫 Schema change cancelled.\n")
+		b.WriteString("The deploy request has been cancelled. Start a new apply to retry.\n")
+	case state.IsState(m.state, state.Apply.RevertWindow):
+		b.WriteString("\n\n")
+		if m.skipRevertTriggered || (m.metadata != nil && m.metadata["revert_skipped"] == "true") {
+			b.WriteString(m.spinner.View() + "Finalizing — closing revert window...\n")
+		} else {
+			b.WriteString("Schema change deployed. Revert window is open.\n\n")
+			b.WriteString("Press Enter to skip revert or ESC to detach\n")
+		}
 	case effectivelyStopped:
 		b.WriteString("\n\n")
 		b.WriteString(templates.FormatApplyStopped())
@@ -183,141 +186,79 @@ func (m WatchModel) fetchErrorLine() string {
 	return errStyle.Render(label+": "+m.errorMsg) + "\n"
 }
 
-// renderTable renders a single table's progress.
-func (m WatchModel) renderTable(t tableProgress) string {
-	var b strings.Builder
-
-	// Format DDL with multi-line support for multiple clauses
-	ddlFormatted := ddl.FormatDDL(t.DDL)
-
-	// Calculate indentation to align with table name
-	indent := strings.Repeat(" ", m.maxTableNameLen+2) // +2 for ": "
-
-	// Helper to write DDL with proper indentation and syntax highlighting
-	// Truncates if too many lines
-	writeDDL := func() {
-		if ddlFormatted == "" {
-			return
-		}
-		const maxLines = 5
-		lines := strings.Split(ddlFormatted, "\n")
-		for i, line := range lines {
-			if i >= maxLines {
-				fmt.Fprintf(&b, "%s... (%d more clauses)\n", indent, len(lines)-maxLines)
-				break
+// toTemplateTables converts TUI tableProgress slices to template TableProgress
+// so the shared rendering functions can be used.
+func toTemplateTables(tables []tableProgress) []templates.TableProgress {
+	result := make([]templates.TableProgress, len(tables))
+	for i, t := range tables {
+		// Derive table-level ETA from max shard ETA for Vitess tables
+		var etaSeconds int64
+		for _, sh := range t.Shards {
+			if sh.ETASeconds > etaSeconds {
+				etaSeconds = sh.ETASeconds
 			}
-			fmt.Fprintf(&b, "%s%s\n", indent, templates.FormatSQL(line))
+		}
+		tp := templates.TableProgress{
+			TableName:       t.Name,
+			Namespace:       t.Keyspace,
+			DDL:             t.DDL,
+			Status:          state.NormalizeTaskStatus(t.Status),
+			RowsCopied:      t.RowsCopied,
+			RowsTotal:       t.RowsTotal,
+			PercentComplete: t.Percent,
+			ETASeconds:      etaSeconds,
+			ProgressDetail:  t.ProgressDetail,
+		}
+		for _, sh := range t.Shards {
+			tp.Shards = append(tp.Shards, templates.ShardProgress{
+				Shard:      sh.Shard,
+				Status:     state.NormalizeShardStatus(sh.Status),
+				RowsCopied: sh.RowsCopied,
+				RowsTotal:  sh.RowsTotal,
+				ETASeconds: sh.ETASeconds,
+			})
+		}
+		result[i] = tp
+	}
+	return result
+}
+
+// renderTables converts TUI tables to template types and uses the shared
+// FormatNamespacedTables / FormatTableProgress rendering from the CLI templates.
+func (m WatchModel) renderTables(b *strings.Builder, tables []tableProgress) {
+	tplTables := toTemplateTables(tables)
+
+	hasNamespaces := false
+	for _, t := range tplTables {
+		if t.Namespace != "" {
+			hasNamespaces = true
+			break
 		}
 	}
 
-	// Determine display based on overall state first, then table status
-	// Overall state takes priority to ensure consistent display during transitions
-	switch {
-	// Terminal states - check overall state first
-	case state.IsState(m.state, state.Apply.Completed):
-		bar := ui.ProgressBarComplete()
-		fmt.Fprintf(&b, "%*s: %s ✓ Complete\n", m.maxTableNameLen, t.Name, bar)
-		writeDDL()
-
-	// Stopped state - show tables with their actual status
-	// Tables that completed before the stop should show as complete, not stopped
-	case m.isEffectivelyStopped() && !state.IsState(m.state, state.Apply.Completed):
-		switch {
-		case state.IsState(t.Status, state.Apply.Completed):
-			bar := ui.ProgressBarComplete()
-			fmt.Fprintf(&b, "%*s: %s ✓ Complete\n", m.maxTableNameLen, t.Name, bar)
-		case state.IsState(t.Status, state.Apply.Failed):
-			bar := ui.ProgressBarFailed(t.Percent)
-			fmt.Fprintf(&b, "%*s: %s ❌ Failed\n", m.maxTableNameLen, t.Name, bar)
-		default:
-			pct := t.Percent
-			if pct == 0 && t.RowsTotal > 0 {
-				pct = int(float64(t.RowsCopied) / float64(t.RowsTotal) * 100)
-			}
-			bar := ui.ProgressBarStopped(pct)
-			if pct > 0 {
-				fmt.Fprintf(&b, "%*s: %s ⏹️ Stopped at %d%%\n", m.maxTableNameLen, t.Name, bar, pct)
-			} else {
-				fmt.Fprintf(&b, "%*s: %s ⏹️ Stopped\n", m.maxTableNameLen, t.Name, bar)
-			}
+	if hasNamespaces {
+		b.WriteString(templates.FormatNamespacedTables(tplTables))
+	} else {
+		b.WriteString("\n")
+		for _, t := range tplTables {
+			b.WriteString(templates.FormatTableProgress(t))
 		}
-		writeDDL()
-
-	// Cutover states - all tables show same state during cutover
-	// Also handle when cutover has been triggered but state hasn't updated yet
-	case state.IsState(m.state, state.Apply.CuttingOver) || (m.cutoverTriggered && !state.IsState(m.state, state.Apply.Completed)):
-		bar := ui.ProgressBarWaitingCutover()
-		fmt.Fprintf(&b, "%*s: %s 🔄 Cutting over...\n", m.maxTableNameLen, t.Name, bar)
-		writeDDL()
-
-	case state.IsState(m.state, state.Apply.WaitingForCutover):
-		bar := ui.ProgressBarWaitingCutover()
-		fmt.Fprintf(&b, "%*s: %s ⏸️ Waiting for cutover\n", m.maxTableNameLen, t.Name, bar)
-		writeDDL()
-
-	// Per-table states - check individual table status
-	case state.IsState(t.Status, state.Apply.Completed):
-		bar := ui.ProgressBarComplete()
-		fmt.Fprintf(&b, "%*s: %s ✓ Complete\n", m.maxTableNameLen, t.Name, bar)
-		writeDDL()
-
-	case state.IsState(t.Status, state.Apply.WaitingForCutover):
-		bar := ui.ProgressBarWaitingCutover()
-		fmt.Fprintf(&b, "%*s: %s ⏸️ Waiting for cutover\n", m.maxTableNameLen, t.Name, bar)
-		writeDDL()
-
-	case state.IsState(t.Status, state.Apply.CuttingOver):
-		bar := ui.ProgressBarWaitingCutover()
-		fmt.Fprintf(&b, "%*s: %s 🔄 Cutting over...\n", m.maxTableNameLen, t.Name, bar)
-		writeDDL()
-
-	case state.IsState(t.Status, state.Apply.Pending):
-		bar := ui.ProgressBarRowCopy(0)
-		fmt.Fprintf(&b, "%*s: %s queued\n", m.maxTableNameLen, t.Name, bar)
-		writeDDL()
-
-	case state.IsState(t.Status, state.Apply.Stopped):
-		if t.Percent > 0 {
-			bar := ui.ProgressBarStopped(t.Percent)
-			fmt.Fprintf(&b, "%*s: %s ⏹️ Stopped\n", m.maxTableNameLen, t.Name, bar)
-		} else {
-			fmt.Fprintf(&b, "%*s: ⏹️ Stopped (not started)\n", m.maxTableNameLen, t.Name)
-		}
-		writeDDL()
-
-	case state.IsState(t.Status, state.Apply.Failed):
-		bar := ui.ProgressBarFailed(t.Percent)
-		fmt.Fprintf(&b, "%*s: %s ❌ Failed\n", m.maxTableNameLen, t.Name, bar)
-		writeDDL()
-
-	default:
-		// Running state - show progress bar with percentage
-		etaSuffix := ""
-		if t.ETA != "" && t.ETA != "TBD" {
-			etaSuffix = fmt.Sprintf(" ETA %s", strings.TrimSpace(t.ETA))
-		}
-
-		if t.RowsTotal > 0 {
-			bar := ui.ProgressBarRowCopy(t.Percent)
-			fmt.Fprintf(&b, "%*s: %s %d%% (%s/%s rows)%s\n",
-				m.maxTableNameLen, t.Name, bar, t.Percent,
-				ui.FormatNumber(t.RowsCopied),
-				ui.FormatNumber(t.RowsTotal),
-				etaSuffix)
-		} else {
-			// No row data yet (initializing or instant DDL) — just show running
-			fmt.Fprintf(&b, "%*s: Running...\n", m.maxTableNameLen, t.Name)
-		}
-		writeDDL()
 	}
-
-	return b.String()
 }
 
 // formatFooter returns the standard footer (no volume shown by default).
 func (m WatchModel) formatFooter() string {
 	dimStyle := lipgloss.NewStyle().Faint(true)
-	return dimStyle.Render("ESC detach • " + templates.StopKeyHint + " • v volume")
+	stopHint := templates.StopKeyHint
+	if m.isPlanetScale() {
+		stopHint = "c cancel"
+	}
+	return dimStyle.Render("ESC detach • " + stopHint + " • v volume")
+}
+
+// isPlanetScale returns true if the current apply is using the PlanetScale engine.
+func (m WatchModel) isPlanetScale() bool {
+	return strings.EqualFold(m.engine, "PlanetScale") || strings.EqualFold(m.engine, "planetscale")
 }
 
 // formatVolumeMode returns the footer when in volume adjustment mode.
@@ -337,6 +278,19 @@ func (m WatchModel) formatVolumeMode() string {
 	return b.String()
 }
 
+// elapsed returns a formatted elapsed time string for the status line.
+// Shows nothing for the first few seconds to avoid visual noise.
+func (m WatchModel) elapsed() string {
+	if m.startedAt.IsZero() {
+		return ""
+	}
+	d := time.Since(m.startedAt).Round(time.Second)
+	if d < 3*time.Second {
+		return ""
+	}
+	return fmt.Sprintf(" (%s)", d)
+}
+
 // detachedView returns the message shown when user detaches.
 func (m WatchModel) detachedView() string {
 	var b strings.Builder
@@ -345,11 +299,11 @@ func (m WatchModel) detachedView() string {
 	b.WriteString("The schema change continues running in the background.\n")
 	b.WriteString("\n")
 	if m.applyID != "" {
-		fmt.Fprintf(&b, "To watch and manage: schemabot progress --apply-id %s\n", m.applyID)
-		fmt.Fprintf(&b, "To stop:             schemabot stop --apply-id %s\n", m.applyID)
+		fmt.Fprintf(&b, "To reattach: schemabot progress %s\n", m.applyID)
+		fmt.Fprintf(&b, "To stop:     schemabot stop %s\n", m.applyID)
 	} else {
-		fmt.Fprintf(&b, "To watch and manage: schemabot progress -d %s -e %s\n", m.database, m.environment)
-		fmt.Fprintf(&b, "To stop:             schemabot stop -d %s -e %s\n", m.database, m.environment)
+		fmt.Fprintf(&b, "To reattach: schemabot progress -d %s -e %s\n", m.database, m.environment)
+		fmt.Fprintf(&b, "To stop:     schemabot stop -d %s -e %s\n", m.database, m.environment)
 	}
 	return b.String()
 }

--- a/pkg/cmd/commands/watch_tui_vitess_test.go
+++ b/pkg/cmd/commands/watch_tui_vitess_test.go
@@ -1,0 +1,100 @@
+package commands
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/block/schemabot/pkg/cmd/templates"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestTUIShardRendering verifies that the TUI's shard progress conversion
+// and shared template rendering produce expected output.
+func TestTUIShardRendering(t *testing.T) {
+	tests := []struct {
+		name     string
+		tables   []tableProgress
+		contains []string
+		absent   []string
+	}{
+		{
+			name: "keyspace header shown for vitess tables",
+			tables: []tableProgress{
+				{Name: "users", Keyspace: "myapp_sharded", DDL: "ALTER TABLE users ADD COLUMN x int", Status: "pending"},
+			},
+			contains: []string{"myapp_sharded"},
+		},
+		{
+			name: "no keyspace header for mysql tables",
+			tables: []tableProgress{
+				{Name: "users", DDL: "ALTER TABLE users ADD COLUMN x int", Status: "pending"},
+			},
+			absent: []string{"──"},
+		},
+		{
+			name: "multiple keyspaces grouped",
+			tables: []tableProgress{
+				{Name: "users", Keyspace: "app", Status: "completed"},
+				{Name: "orders", Keyspace: "app_sharded", Status: "pending"},
+			},
+			contains: []string{"app", "app_sharded"},
+		},
+		{
+			name: "shard progress rendered via shared templates",
+			tables: []tableProgress{
+				{
+					Name: "users", Keyspace: "myapp", Status: "running",
+					Shards: []shardProgress{
+						{Shard: "-80", Status: "running", RowsCopied: 500, RowsTotal: 1000},
+						{Shard: "80-", Status: "running", RowsCopied: 300, RowsTotal: 1000},
+					},
+				},
+			},
+			contains: []string{"Shards:", "2 copying"},
+		},
+		{
+			name: "uppercase and prefixed statuses normalized for rendering",
+			tables: []tableProgress{
+				{
+					Name: "users", Keyspace: "myapp", Status: "STATE_RUNNING",
+					RowsCopied: 500, RowsTotal: 1000,
+					Shards: []shardProgress{
+						{Shard: "-80", Status: "STATE_RUNNING", RowsCopied: 300, RowsTotal: 500},
+						{Shard: "80-", Status: "RUNNING", RowsCopied: 200, RowsTotal: 500},
+					},
+				},
+			},
+			contains: []string{"Rows:", "1,000", "Shards:", "2 copying"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tplTables := toTemplateTables(tt.tables)
+
+			var b strings.Builder
+			hasNS := false
+			for _, tbl := range tplTables {
+				if tbl.Namespace != "" {
+					hasNS = true
+					break
+				}
+			}
+			if hasNS {
+				b.WriteString(templates.FormatNamespacedTables(tplTables))
+			} else {
+				for _, tbl := range tplTables {
+					b.WriteString(templates.FormatTableProgress(tbl))
+				}
+			}
+
+			result := b.String()
+			for _, expected := range tt.contains {
+				assert.Contains(t, result, expected)
+			}
+			for _, unexpected := range tt.absent {
+				assert.NotContains(t, result, unexpected)
+			}
+		})
+	}
+}

--- a/pkg/cmd/templates/plan.go
+++ b/pkg/cmd/templates/plan.go
@@ -109,7 +109,7 @@ func WriteNamespaceChanges(namespaces []NamespaceChange, isMySQL bool, database 
 		if ns.VSchemaChanged && !isMySQL {
 			fmt.Println("  ~ VSchema:")
 			if ns.VSchemaDiff != "" {
-				writeVSchemaDiff(ns.VSchemaDiff, "    ")
+				fmt.Print(FormatVSchemaDiff(ns.VSchemaDiff, "    "))
 				fmt.Println()
 			}
 		}
@@ -384,7 +384,7 @@ func WriteOptions(deferCutover bool, skipRevert bool) {
 		options = append(options, "⏸️ Defer Cutover")
 	}
 	if skipRevert {
-		options = append(options, "⏩ Revert Window Disabled")
+		options = append(options, "⏩ Skip Revert")
 	}
 	if len(options) > 0 {
 		fmt.Printf("Options: %s\n", strings.Join(options, " | "))

--- a/pkg/cmd/templates/preview.go
+++ b/pkg/cmd/templates/preview.go
@@ -1094,6 +1094,7 @@ func previewCLIApplyAllOutput() {
 		{"VITESS: CREATING BRANCH", previewCreatingBranchOutput},
 		{"VITESS: APPLYING BRANCH CHANGES", previewApplyingBranchChangesOutput},
 		{"VITESS: CREATING DEPLOY REQUEST", previewCreatingDeployRequestOutput},
+		{"VITESS: STAGING SCHEMA CHANGES (0% with shards)", previewVitessStagingOutput},
 		{"VITESS: RUNNING", previewVitessRunningOutput},
 		{"VITESS: COMPLETED", previewVitessCompletedOutput},
 		{"VITESS: FAILED", previewVitessFailedOutput},

--- a/pkg/cmd/templates/preview_progress.go
+++ b/pkg/cmd/templates/preview_progress.go
@@ -259,6 +259,32 @@ func previewVitessRevertWindowOutput() {
 	WriteProgress(data)
 }
 
+func previewVitessStagingOutput() {
+	data := ProgressData{
+		State:       state.Apply.Running,
+		Engine:      "PlanetScale",
+		ApplyID:     "apply-a1b2c3d4e5f6",
+		Database:    "myapp",
+		Environment: "staging",
+		StartedAt:   previewTime.Add(-45 * time.Second).Format(time.RFC3339),
+		Tables: []TableProgress{
+			{
+				TableName: "customers", Namespace: "myapp_sharded",
+				DDL:    "ALTER TABLE `customers` ADD INDEX `idx_created_at`(`created_at`)",
+				Status: state.Apply.Running,
+				// RowsTotal > 0 but RowsCopied == 0 triggers "Staging schema changes..."
+				RowsCopied: 0,
+				RowsTotal:  124760460,
+				Shards: []ShardProgress{
+					{Shard: "-80", Status: state.Task.Running, RowsCopied: 0, RowsTotal: 60483380},
+					{Shard: "80-", Status: state.Task.Running, RowsCopied: 0, RowsTotal: 64277080},
+				},
+			},
+		},
+	}
+	WriteProgress(data)
+}
+
 func previewVitessRunningOutput() {
 	data := ProgressData{
 		State:       state.Apply.Running,

--- a/pkg/cmd/templates/progress.go
+++ b/pkg/cmd/templates/progress.go
@@ -15,34 +15,31 @@ import (
 // indentTable is the prefix for table names. Aligns with keyspace name after "── " in headers.
 const indentTable = "     " // 5 spaces — matches "  ── " in FormatKeyspaceHeader
 
-// formatDDLWithSymbol renders a DDL statement with a Terraform-style change symbol
-// (+ create, ~ alter, - drop) and syntax highlighting, indented under the table name.
-func formatDDLWithSymbol(changeType, rawDDL string) string {
+// progressSymbol returns a Terraform-style prefix for the change type.
+func progressSymbol(changeType string) string {
+	switch strings.ToLower(changeType) {
+	case "create":
+		return "+ "
+	case "drop":
+		return "- "
+	default:
+		return "~ "
+	}
+}
+
+// formatProgressDDL renders a DDL statement with syntax highlighting, indented under the table name.
+func formatProgressDDL(rawDDL string) string {
 	if rawDDL == "" {
 		return ""
 	}
-	symbol := "~"
-	switch strings.ToLower(changeType) {
-	case "create":
-		symbol = "+"
-	case "drop":
-		symbol = "-"
-	}
-	formatted := ddl.FormatDDL(rawDDL)
-	lines := strings.Split(formatted, "\n")
-	var b strings.Builder
-	for i, line := range lines {
-		if i == 0 {
-			fmt.Fprintf(&b, "%s%s %s\n", indentContent, symbol, FormatSQL(line))
-		} else if line != "" {
-			fmt.Fprintf(&b, "%s  %s\n", indentContent, FormatSQL(line))
-		}
-	}
-	return b.String()
+	return IndentSQL(ddl.FormatDDL(rawDDL), indentContent) + "\n"
 }
 
-// indentContent is the indentation for DDL, rows, and status lines under a table name.
+// indentContent is the indentation for DDL lines under a table name.
 var indentContent = strings.Repeat(" ", 7)
+
+// indentDetail is the prefix for Rows/Shards detail lines (one level deeper than DDL, with bullet).
+const indentDetail = "       • " // 7 spaces + bullet + space
 
 // FormatKeyspaceHeader returns a keyspace divider line.
 func FormatKeyspaceHeader(ns string) string {
@@ -382,54 +379,54 @@ func FormatTableProgress(t TableProgress) string {
 	switch t.Status {
 	case state.Apply.Pending:
 		// Pending = queued, not yet started
-		fmt.Fprintf(&b, indentTable+"%s: ⏳ Queued\n", t.TableName)
+		fmt.Fprintf(&b, indentTable+progressSymbol(t.ChangeType)+"%s: ⏳ Queued\n", t.TableName)
 		if t.DDL != "" {
-			b.WriteString(formatDDLWithSymbol(t.ChangeType, t.DDL))
+			b.WriteString(formatProgressDDL(t.DDL))
 		}
 		b.WriteString("\n")
 		b.WriteString(FormatShardProgress(t.Shards))
 		return b.String()
 	case state.Apply.Completed:
 		bar := ui.ProgressBarComplete()
-		fmt.Fprintf(&b, indentTable+"%s: %s ✓ Complete\n", t.TableName, bar)
+		fmt.Fprintf(&b, indentTable+progressSymbol(t.ChangeType)+"%s: %s ✓ Complete\n", t.TableName, bar)
 		if t.DDL != "" {
-			b.WriteString(formatDDLWithSymbol(t.ChangeType, t.DDL))
+			b.WriteString(formatProgressDDL(t.DDL))
 		}
 		b.WriteString("\n")
 		b.WriteString(FormatShardProgress(t.Shards))
 		return b.String()
 	case state.Apply.WaitingForCutover:
 		bar := ui.ProgressBarRowCopy(100) // blue — in progress, row copy done
-		fmt.Fprintf(&b, indentTable+"%s: %s Waiting for cutover\n", t.TableName, bar)
+		fmt.Fprintf(&b, indentTable+progressSymbol(t.ChangeType)+"%s: %s Waiting for cutover\n", t.TableName, bar)
 		if t.DDL != "" {
-			b.WriteString(formatDDLWithSymbol(t.ChangeType, t.DDL))
+			b.WriteString(formatProgressDDL(t.DDL))
 		}
 		b.WriteString("\n")
 		b.WriteString(FormatShardProgress(t.Shards))
 		return b.String()
 	case state.Apply.CuttingOver:
 		bar := ui.ProgressBarRowCopy(100) // blue — still in progress
-		fmt.Fprintf(&b, indentTable+"%s: %s 🔄 Cutting over...\n", t.TableName, bar)
+		fmt.Fprintf(&b, indentTable+progressSymbol(t.ChangeType)+"%s: %s 🔄 Cutting over...\n", t.TableName, bar)
 		if t.DDL != "" {
-			b.WriteString(formatDDLWithSymbol(t.ChangeType, t.DDL))
+			b.WriteString(formatProgressDDL(t.DDL))
 		}
 		b.WriteString("\n")
 		b.WriteString(FormatShardProgress(t.Shards))
 		return b.String()
 	case state.Apply.Failed:
 		bar := ui.ProgressBarFailed(t.PercentComplete)
-		fmt.Fprintf(&b, indentTable+"%s: %s ❌ Failed\n", t.TableName, bar)
+		fmt.Fprintf(&b, indentTable+progressSymbol(t.ChangeType)+"%s: %s ❌ Failed\n", t.TableName, bar)
 		if t.DDL != "" {
-			b.WriteString(formatDDLWithSymbol(t.ChangeType, t.DDL))
+			b.WriteString(formatProgressDDL(t.DDL))
 		}
 		b.WriteString("\n")
 		b.WriteString(FormatShardProgress(t.Shards))
 		return b.String()
 	case state.Apply.RevertWindow:
 		bar := ui.ProgressBarWaitingCutover() // yellow — complete but revert available
-		fmt.Fprintf(&b, indentTable+"%s: %s ✓ Complete (pending revert)\n", t.TableName, bar)
+		fmt.Fprintf(&b, indentTable+progressSymbol(t.ChangeType)+"%s: %s ✓ Complete (pending revert)\n", t.TableName, bar)
 		if t.DDL != "" {
-			b.WriteString(formatDDLWithSymbol(t.ChangeType, t.DDL))
+			b.WriteString(formatProgressDDL(t.DDL))
 		}
 		b.WriteString("\n")
 		b.WriteString(FormatShardProgress(t.Shards))
@@ -437,12 +434,12 @@ func FormatTableProgress(t TableProgress) string {
 	case state.Apply.Cancelled:
 		if t.PercentComplete > 0 {
 			bar := ui.ProgressBarFailed(t.PercentComplete)
-			fmt.Fprintf(&b, indentTable+"%s: %s ⊘ Cancelled at %d%%\n", t.TableName, bar, t.PercentComplete)
+			fmt.Fprintf(&b, indentTable+progressSymbol(t.ChangeType)+"%s: %s ⊘ Cancelled at %d%%\n", t.TableName, bar, t.PercentComplete)
 		} else {
-			fmt.Fprintf(&b, indentTable+"%s: ⊘ Cancelled (not started)\n", t.TableName)
+			fmt.Fprintf(&b, indentTable+progressSymbol(t.ChangeType)+"%s: ⊘ Cancelled (not started)\n", t.TableName)
 		}
 		if t.DDL != "" {
-			b.WriteString(formatDDLWithSymbol(t.ChangeType, t.DDL))
+			b.WriteString(formatProgressDDL(t.DDL))
 		}
 		b.WriteString("\n")
 		b.WriteString(FormatShardProgress(t.Shards))
@@ -453,18 +450,18 @@ func FormatTableProgress(t TableProgress) string {
 		switch {
 		case t.PercentComplete >= 100:
 			// At 100% = was waiting for cutover when stopped
-			fmt.Fprintf(&b, indentTable+"%s: %s ⏹️ Stopped (was waiting for cutover)\n", t.TableName, bar)
+			fmt.Fprintf(&b, indentTable+progressSymbol(t.ChangeType)+"%s: %s ⏹️ Stopped (was waiting for cutover)\n", t.TableName, bar)
 		case t.PercentComplete > 0:
 			stoppedPercent := min(t.PercentComplete, 100)
-			fmt.Fprintf(&b, indentTable+"%s: %s ⏹️ Stopped at %d%%\n", t.TableName, bar, stoppedPercent)
+			fmt.Fprintf(&b, indentTable+progressSymbol(t.ChangeType)+"%s: %s ⏹️ Stopped at %d%%\n", t.TableName, bar, stoppedPercent)
 		default:
-			fmt.Fprintf(&b, indentTable+"%s: ⏹️ Stopped (not started)\n", t.TableName)
+			fmt.Fprintf(&b, indentTable+progressSymbol(t.ChangeType)+"%s: ⏹️ Stopped (not started)\n", t.TableName)
 		}
 		if t.DDL != "" {
-			b.WriteString(formatDDLWithSymbol(t.ChangeType, t.DDL))
+			b.WriteString(formatProgressDDL(t.DDL))
 		}
 		if t.RowsTotal > 0 && t.PercentComplete > 0 {
-			fmt.Fprintf(&b, "      Rows: %s / %s\n", ui.FormatNumber(ui.ClampRows(t.RowsCopied, t.RowsTotal)), ui.FormatNumber(t.RowsTotal))
+			fmt.Fprintf(&b, indentDetail+"Rows: %s / %s\n", ui.FormatNumber(ui.ClampRows(t.RowsCopied, t.RowsTotal)), ui.FormatNumber(t.RowsTotal))
 		}
 		b.WriteString("\n")
 		b.WriteString(FormatShardProgress(t.Shards))
@@ -477,64 +474,66 @@ func FormatTableProgress(t TableProgress) string {
 		if info := ParseSpiritProgress(t.ProgressDetail); info != nil {
 			// Parsed successfully - show emoji progress bar with structured data
 			bar := ui.ProgressBarRowCopy(info.Percent)
-			fmt.Fprintf(&b, indentTable+"%s: %s %d%%\n", t.TableName, bar, info.Percent)
+			fmt.Fprintf(&b, indentTable+progressSymbol(t.ChangeType)+"%s: %s %d%%\n", t.TableName, bar, info.Percent)
 			if t.DDL != "" {
-				b.WriteString(formatDDLWithSymbol(t.ChangeType, t.DDL))
+				b.WriteString(formatProgressDDL(t.DDL))
 			}
 			// Rows and ETA on same line
 			if info.ETA != "" && info.ETA != "TBD" {
-				fmt.Fprintf(&b, indentContent+"Rows: %s / %s · ETA: %s\n", ui.FormatNumber(ui.ClampRows(info.RowsCopied, info.RowsTotal)), ui.FormatNumber(info.RowsTotal), info.ETA)
+				fmt.Fprintf(&b, indentDetail+"Rows: %s / %s · ETA: %s\n", ui.FormatNumber(ui.ClampRows(info.RowsCopied, info.RowsTotal)), ui.FormatNumber(info.RowsTotal), info.ETA)
 			} else {
-				fmt.Fprintf(&b, indentContent+"Rows: %s / %s\n", ui.FormatNumber(ui.ClampRows(info.RowsCopied, info.RowsTotal)), ui.FormatNumber(info.RowsTotal))
+				fmt.Fprintf(&b, indentDetail+"Rows: %s / %s\n", ui.FormatNumber(ui.ClampRows(info.RowsCopied, info.RowsTotal)), ui.FormatNumber(info.RowsTotal))
 			}
 			if info.State != "" && info.State != "copyRows" {
-				fmt.Fprintf(&b, indentContent+"Status: %s\n", info.State)
+				fmt.Fprintf(&b, indentDetail+"Status: %s\n", info.State)
 			}
 		} else {
 			// Can't parse - show raw detail
-			fmt.Fprintf(&b, indentTable+"%s:\n", t.TableName)
+			fmt.Fprintf(&b, indentTable+progressSymbol(t.ChangeType)+"%s:\n", t.TableName)
 			if t.DDL != "" {
-				b.WriteString(formatDDLWithSymbol(t.ChangeType, t.DDL))
+				b.WriteString(formatProgressDDL(t.DDL))
 			}
 			fmt.Fprintf(&b, "    %s\n", t.ProgressDetail)
 		}
 	case t.RowsTotal > 0 && t.RowsCopied == 0 && len(t.Shards) > 0:
 		// Staging phase — shards have row totals but no rows copied yet.
 		// Show "Staging schema changes..." instead of a misleading 0% bar.
-		fmt.Fprintf(&b, indentTable+"%s: Staging schema changes...\n", t.TableName)
+		fmt.Fprintf(&b, indentTable+progressSymbol(t.ChangeType)+"%s: Staging schema changes...\n", t.TableName)
 		if t.DDL != "" {
-			b.WriteString(formatDDLWithSymbol(t.ChangeType, t.DDL))
+			b.WriteString(formatProgressDDL(t.DDL))
 		}
 	case t.RowsTotal > 0:
 		// Row copy in progress — show progress bar with structured fields
 		bar := ui.ProgressBarRowCopy(t.PercentComplete)
 		displayPercent := min(t.PercentComplete, 100)
-		fmt.Fprintf(&b, indentTable+"%s: %s %d%%\n", t.TableName, bar, displayPercent)
+		fmt.Fprintf(&b, indentTable+progressSymbol(t.ChangeType)+"%s: %s %d%%\n", t.TableName, bar, displayPercent)
 
 		if t.DDL != "" {
-			b.WriteString(formatDDLWithSymbol(t.ChangeType, t.DDL))
+			b.WriteString(formatProgressDDL(t.DDL))
 		}
 
 		// Rows and ETA on same line
 		if t.ETASeconds > 0 {
-			fmt.Fprintf(&b, indentContent+"Rows: %s / %s · ETA: %s\n", ui.FormatNumber(ui.ClampRows(t.RowsCopied, t.RowsTotal)), ui.FormatNumber(t.RowsTotal), ui.FormatETA(t.ETASeconds))
+			fmt.Fprintf(&b, indentDetail+"Rows: %s / %s · ETA: %s\n", ui.FormatNumber(ui.ClampRows(t.RowsCopied, t.RowsTotal)), ui.FormatNumber(t.RowsTotal), ui.FormatETA(t.ETASeconds))
 		} else {
-			fmt.Fprintf(&b, "      Rows: %s / %s\n", ui.FormatNumber(ui.ClampRows(t.RowsCopied, t.RowsTotal)), ui.FormatNumber(t.RowsTotal))
+			fmt.Fprintf(&b, indentDetail+"Rows: %s / %s\n", ui.FormatNumber(ui.ClampRows(t.RowsCopied, t.RowsTotal)), ui.FormatNumber(t.RowsTotal))
 		}
 
 		statusLower := strings.ToLower(t.Status)
 		if statusLower != "" && statusLower != "running" && statusLower != "row_copy" {
-			fmt.Fprintf(&b, indentContent+"Status: %s\n", t.Status)
+			fmt.Fprintf(&b, indentDetail+"Status: %s\n", t.Status)
 		}
 	default:
 		// No row copy data yet (initializing or instant DDL) — just show running state
-		fmt.Fprintf(&b, indentTable+"%s: Running...\n", t.TableName)
+		fmt.Fprintf(&b, indentTable+progressSymbol(t.ChangeType)+"%s: Running...\n", t.TableName)
 		if t.DDL != "" {
-			b.WriteString(formatDDLWithSymbol(t.ChangeType, t.DDL))
+			b.WriteString(formatProgressDDL(t.DDL))
 		}
 	}
 
-	b.WriteString("\n")
+	if len(t.Shards) == 0 {
+		b.WriteString("\n")
+	}
 	b.WriteString(FormatShardProgress(t.Shards))
 	return b.String()
 }

--- a/pkg/cmd/templates/progress.go
+++ b/pkg/cmd/templates/progress.go
@@ -12,12 +12,41 @@ import (
 )
 
 // Indentation for progress rendering.
-// indentContent is the indentation for DDL, rows, and status lines under a table name.
-var indentContent = strings.Repeat(" ", 6)
+// indentTable is the prefix for table names. Aligns with keyspace name after "── " in headers.
+const indentTable = "     " // 5 spaces — matches "  ── " in FormatKeyspaceHeader
 
-// writeKeyspaceHeader renders a keyspace divider line.
-func writeKeyspaceHeader(ns string) {
-	fmt.Printf("\n  %s── %s ──%s\n", ANSIBold, ns, ANSIReset)
+// formatDDLWithSymbol renders a DDL statement with a Terraform-style change symbol
+// (+ create, ~ alter, - drop) and syntax highlighting, indented under the table name.
+func formatDDLWithSymbol(changeType, rawDDL string) string {
+	if rawDDL == "" {
+		return ""
+	}
+	symbol := "~"
+	switch strings.ToLower(changeType) {
+	case "create":
+		symbol = "+"
+	case "drop":
+		symbol = "-"
+	}
+	formatted := ddl.FormatDDL(rawDDL)
+	lines := strings.Split(formatted, "\n")
+	var b strings.Builder
+	for i, line := range lines {
+		if i == 0 {
+			fmt.Fprintf(&b, "%s%s %s\n", indentContent, symbol, FormatSQL(line))
+		} else if line != "" {
+			fmt.Fprintf(&b, "%s  %s\n", indentContent, FormatSQL(line))
+		}
+	}
+	return b.String()
+}
+
+// indentContent is the indentation for DDL, rows, and status lines under a table name.
+var indentContent = strings.Repeat(" ", 7)
+
+// FormatKeyspaceHeader returns a keyspace divider line.
+func FormatKeyspaceHeader(ns string) string {
+	return fmt.Sprintf("\n  %s── %s ──%s\n\n", ANSIBold, ns, ANSIReset)
 }
 
 // nowFunc returns the current time. Overridden in previews for deterministic output.
@@ -59,7 +88,7 @@ func WriteProgress(data ProgressData) {
 			opts = append(opts, "⏸️ Defer Cutover")
 		}
 		if data.Options["skip_revert"] == "true" {
-			opts = append(opts, "⏩ Revert Window Disabled")
+			opts = append(opts, "⏩ Skip Revert")
 		}
 		if len(opts) > 0 {
 			rows = append(rows, BoxRow{"Options", strings.Join(opts, " | ")})
@@ -139,11 +168,11 @@ func WriteProgress(data ProgressData) {
 		}
 
 		if hasNamespaces {
-			writeNamespacedTables(activeTables)
+			fmt.Print(FormatNamespacedTables(activeTables))
 		} else {
 			fmt.Println()
 			for _, t := range activeTables {
-				writeTableProgress(t)
+				fmt.Print(FormatTableProgress(t))
 			}
 		}
 	}
@@ -154,10 +183,10 @@ func WriteProgress(data ProgressData) {
 	}
 }
 
-// writeNamespacedTables renders tables grouped by keyspace, collapsing
+// FormatNamespacedTables returns tables grouped by keyspace as a string, collapsing
 // keyspaces where all tables share the same terminal status.
-// This prevents a wall of "✓ Complete" lines for 30+ unsharded keyspaces.
-func writeNamespacedTables(tables []TableProgress) {
+// This prevents a wall of "Complete" lines for 30+ unsharded keyspaces.
+func FormatNamespacedTables(tables []TableProgress) string {
 	type nsEntry struct {
 		namespace string
 		tables    []TableProgress
@@ -171,7 +200,7 @@ func writeNamespacedTables(tables []TableProgress) {
 		if ns == "" {
 			ns = "(default)"
 		}
-		// Strip namespace prefix from VSchema task names (e.g., "VSchema: myapp_sharded" → "VSchema")
+		// Strip namespace prefix from VSchema task names (e.g., "VSchema: myapp_sharded" -> "VSchema")
 		// since the keyspace header already provides context.
 		if strings.HasPrefix(t.TableName, "vschema:") || strings.HasPrefix(t.TableName, "VSchema:") {
 			parts := strings.SplitN(t.TableName, ": ", 2)
@@ -217,33 +246,35 @@ func writeNamespacedTables(tables []TableProgress) {
 		})
 	}
 
+	var b strings.Builder
 	for _, g := range groups {
 		if g.collapsed && len(g.namespaces) > 1 {
 			const maxShown = 5
 			for i, ns := range g.namespaces {
 				if i >= maxShown {
-					fmt.Printf("\n  %s... and %d more keyspaces (all %s)%s\n",
+					fmt.Fprintf(&b, "\n  %s... and %d more keyspaces (all %s)%s\n",
 						ANSIDim, len(g.namespaces)-maxShown, g.tables[0].Status, ANSIReset)
 					break
 				}
-				writeKeyspaceHeader(ns)
-				writeTableProgress(g.tables[0])
+				b.WriteString(FormatKeyspaceHeader(ns))
+				b.WriteString(FormatTableProgress(g.tables[0]))
 			}
 		} else {
-			writeKeyspaceHeader(g.namespaces[0])
+			b.WriteString(FormatKeyspaceHeader(g.namespaces[0]))
 			// Render VSchema tasks first, then DDL tables
 			for _, t := range g.tables {
 				if isVSchemaTask(t) {
-					writeVSchemaProgress(t)
+					b.WriteString(FormatVSchemaProgress(t))
 				}
 			}
 			for _, t := range g.tables {
 				if !isVSchemaTask(t) {
-					writeTableProgress(t)
+					b.WriteString(FormatTableProgress(t))
 				}
 			}
 		}
 	}
+	return b.String()
 }
 
 // isVSchemaTask returns true if this is a synthetic VSchema update task.
@@ -251,27 +282,31 @@ func isVSchemaTask(t TableProgress) bool {
 	return t.TableName == "VSchema" || strings.HasPrefix(t.TableName, "vschema:") || strings.HasPrefix(t.TableName, "VSchema:")
 }
 
-// writeVSchemaProgress renders a VSchema update without a progress bar.
+// FormatVSchemaProgress returns a VSchema update rendered as a string.
 // The DDL field contains a VSchema diff (not SQL), so we render it with
 // diff coloring via colorizeDiffLine, stripping ---/+++/@@ headers.
-func writeVSchemaProgress(t TableProgress) {
+func FormatVSchemaProgress(t TableProgress) string {
+	var b strings.Builder
 	label := vschemaStatusLabel(state.NormalizeState(t.Status))
-	fmt.Printf("    ~ VSchema: %s\n", label)
+	fmt.Fprintf(&b, "    ~ VSchema: %s\n", label)
 	if t.DDL != "" {
-		writeVSchemaDiff(t.DDL, indentContent)
+		b.WriteString(FormatVSchemaDiff(t.DDL, indentContent))
 	}
-	fmt.Println()
+	b.WriteString("\n")
+	return b.String()
 }
 
-// writeVSchemaDiff renders a VSchema diff with colorized +/- lines,
+// FormatVSchemaDiff returns a VSchema diff with colorized +/- lines as a string,
 // stripping ---/+++/@@ headers. Shared between plan and progress views.
-func writeVSchemaDiff(diff, indent string) {
+func FormatVSchemaDiff(diff, indent string) string {
+	var b strings.Builder
 	for line := range strings.SplitSeq(strings.TrimRight(diff, "\n"), "\n") {
 		if strings.HasPrefix(line, "---") || strings.HasPrefix(line, "+++") || strings.HasPrefix(line, "@@") {
 			continue
 		}
-		fmt.Printf("%s%s\n", indent, colorizeDiffLine(line))
+		fmt.Fprintf(&b, "%s%s\n", indent, colorizeDiffLine(line))
 	}
+	return b.String()
 }
 
 // vschemaStatusLabel maps a task status to a VSchema-specific display label.
@@ -297,11 +332,6 @@ func writeFailureGuidance() {
 	fmt.Println()
 	fmt.Printf("%sTo recover:%s Fix the issue above, then run a new apply.\n", ANSIBold, ANSIReset)
 	fmt.Printf("The new apply will only process tables that haven't completed.\n")
-}
-
-// writeShardSummary renders per-shard progress using the detailed shard renderer.
-func writeShardSummary(shards []ShardProgress) {
-	writeShardProgress(shards)
 }
 
 // FormatProgressState formats the state for display with color.
@@ -340,96 +370,105 @@ func FormatProgressState(s string) string {
 	}
 }
 
-// writeTableProgress writes progress for a single table with state-aware colors.
+// FormatTableProgress returns progress for a single table as a string.
 // Format: tablename: [progress bar] [status]
 //
 //	DDL statement (indented below)
 //	Rows: X / Y (if applicable)
-func writeTableProgress(t TableProgress) {
-	defer writeShardSummary(t.Shards)
+func FormatTableProgress(t TableProgress) string {
+	var b strings.Builder
+
 	// Handle special states first - all use format: tablename: [bar] [status]
 	switch t.Status {
 	case state.Apply.Pending:
 		// Pending = queued, not yet started
-		fmt.Printf("    %s: ⏳ Queued\n", t.TableName)
+		fmt.Fprintf(&b, indentTable+"%s: ⏳ Queued\n", t.TableName)
 		if t.DDL != "" {
-			fmt.Printf("%s\n", IndentSQL(ddl.FormatDDL(t.DDL), indentContent))
+			b.WriteString(formatDDLWithSymbol(t.ChangeType, t.DDL))
 		}
-		fmt.Println()
-		return
+		b.WriteString("\n")
+		b.WriteString(FormatShardProgress(t.Shards))
+		return b.String()
 	case state.Apply.Completed:
 		bar := ui.ProgressBarComplete()
-		fmt.Printf("    %s: %s ✓ Complete\n", t.TableName, bar)
+		fmt.Fprintf(&b, indentTable+"%s: %s ✓ Complete\n", t.TableName, bar)
 		if t.DDL != "" {
-			fmt.Printf("%s\n", IndentSQL(ddl.FormatDDL(t.DDL), indentContent))
+			b.WriteString(formatDDLWithSymbol(t.ChangeType, t.DDL))
 		}
-		fmt.Println()
-		return
+		b.WriteString("\n")
+		b.WriteString(FormatShardProgress(t.Shards))
+		return b.String()
 	case state.Apply.WaitingForCutover:
 		bar := ui.ProgressBarRowCopy(100) // blue — in progress, row copy done
-		fmt.Printf("    %s: %s Waiting for cutover\n", t.TableName, bar)
+		fmt.Fprintf(&b, indentTable+"%s: %s Waiting for cutover\n", t.TableName, bar)
 		if t.DDL != "" {
-			fmt.Printf("%s\n", IndentSQL(ddl.FormatDDL(t.DDL), indentContent))
+			b.WriteString(formatDDLWithSymbol(t.ChangeType, t.DDL))
 		}
-		fmt.Println()
-		return
+		b.WriteString("\n")
+		b.WriteString(FormatShardProgress(t.Shards))
+		return b.String()
 	case state.Apply.CuttingOver:
 		bar := ui.ProgressBarRowCopy(100) // blue — still in progress
-		fmt.Printf("    %s: %s 🔄 Cutting over...\n", t.TableName, bar)
+		fmt.Fprintf(&b, indentTable+"%s: %s 🔄 Cutting over...\n", t.TableName, bar)
 		if t.DDL != "" {
-			fmt.Printf("%s\n", IndentSQL(ddl.FormatDDL(t.DDL), indentContent))
+			b.WriteString(formatDDLWithSymbol(t.ChangeType, t.DDL))
 		}
-		fmt.Println()
-		return
+		b.WriteString("\n")
+		b.WriteString(FormatShardProgress(t.Shards))
+		return b.String()
 	case state.Apply.Failed:
 		bar := ui.ProgressBarFailed(t.PercentComplete)
-		fmt.Printf("    %s: %s ❌ Failed\n", t.TableName, bar)
+		fmt.Fprintf(&b, indentTable+"%s: %s ❌ Failed\n", t.TableName, bar)
 		if t.DDL != "" {
-			fmt.Printf("%s\n", IndentSQL(ddl.FormatDDL(t.DDL), indentContent))
+			b.WriteString(formatDDLWithSymbol(t.ChangeType, t.DDL))
 		}
-		fmt.Println()
-		return
+		b.WriteString("\n")
+		b.WriteString(FormatShardProgress(t.Shards))
+		return b.String()
 	case state.Apply.RevertWindow:
 		bar := ui.ProgressBarWaitingCutover() // yellow — complete but revert available
-		fmt.Printf("    %s: %s ✓ Complete (pending revert)\n", t.TableName, bar)
+		fmt.Fprintf(&b, indentTable+"%s: %s ✓ Complete (pending revert)\n", t.TableName, bar)
 		if t.DDL != "" {
-			fmt.Printf("%s\n", IndentSQL(ddl.FormatDDL(t.DDL), indentContent))
+			b.WriteString(formatDDLWithSymbol(t.ChangeType, t.DDL))
 		}
-		fmt.Println()
-		return
+		b.WriteString("\n")
+		b.WriteString(FormatShardProgress(t.Shards))
+		return b.String()
 	case state.Apply.Cancelled:
 		if t.PercentComplete > 0 {
 			bar := ui.ProgressBarFailed(t.PercentComplete)
-			fmt.Printf("    %s: %s ⊘ Cancelled at %d%%\n", t.TableName, bar, t.PercentComplete)
+			fmt.Fprintf(&b, indentTable+"%s: %s ⊘ Cancelled at %d%%\n", t.TableName, bar, t.PercentComplete)
 		} else {
-			fmt.Printf("    %s: ⊘ Cancelled (not started)\n", t.TableName)
+			fmt.Fprintf(&b, indentTable+"%s: ⊘ Cancelled (not started)\n", t.TableName)
 		}
 		if t.DDL != "" {
-			fmt.Printf("%s\n", IndentSQL(ddl.FormatDDL(t.DDL), indentContent))
+			b.WriteString(formatDDLWithSymbol(t.ChangeType, t.DDL))
 		}
-		fmt.Println()
-		return
+		b.WriteString("\n")
+		b.WriteString(FormatShardProgress(t.Shards))
+		return b.String()
 	case state.Apply.Stopped:
 		// Show orange progress bar with current progress when stopped
 		bar := ui.ProgressBarStopped(t.PercentComplete)
 		switch {
 		case t.PercentComplete >= 100:
 			// At 100% = was waiting for cutover when stopped
-			fmt.Printf("    %s: %s ⏹️ Stopped (was waiting for cutover)\n", t.TableName, bar)
+			fmt.Fprintf(&b, indentTable+"%s: %s ⏹️ Stopped (was waiting for cutover)\n", t.TableName, bar)
 		case t.PercentComplete > 0:
 			stoppedPercent := min(t.PercentComplete, 100)
-			fmt.Printf("    %s: %s ⏹️ Stopped at %d%%\n", t.TableName, bar, stoppedPercent)
+			fmt.Fprintf(&b, indentTable+"%s: %s ⏹️ Stopped at %d%%\n", t.TableName, bar, stoppedPercent)
 		default:
-			fmt.Printf("    %s: ⏹️ Stopped (not started)\n", t.TableName)
+			fmt.Fprintf(&b, indentTable+"%s: ⏹️ Stopped (not started)\n", t.TableName)
 		}
 		if t.DDL != "" {
-			fmt.Printf("%s\n", IndentSQL(ddl.FormatDDL(t.DDL), indentContent))
+			b.WriteString(formatDDLWithSymbol(t.ChangeType, t.DDL))
 		}
 		if t.RowsTotal > 0 && t.PercentComplete > 0 {
-			fmt.Printf("      Rows: %s / %s\n", ui.FormatNumber(ui.ClampRows(t.RowsCopied, t.RowsTotal)), ui.FormatNumber(t.RowsTotal))
+			fmt.Fprintf(&b, "      Rows: %s / %s\n", ui.FormatNumber(ui.ClampRows(t.RowsCopied, t.RowsTotal)), ui.FormatNumber(t.RowsTotal))
 		}
-		fmt.Println()
-		return
+		b.WriteString("\n")
+		b.WriteString(FormatShardProgress(t.Shards))
+		return b.String()
 	}
 
 	// In-progress state - try to parse Spirit's progress detail
@@ -438,57 +477,66 @@ func writeTableProgress(t TableProgress) {
 		if info := ParseSpiritProgress(t.ProgressDetail); info != nil {
 			// Parsed successfully - show emoji progress bar with structured data
 			bar := ui.ProgressBarRowCopy(info.Percent)
-			fmt.Printf("    %s: %s %d%%\n", t.TableName, bar, info.Percent)
+			fmt.Fprintf(&b, indentTable+"%s: %s %d%%\n", t.TableName, bar, info.Percent)
 			if t.DDL != "" {
-				fmt.Printf("%s\n", IndentSQL(ddl.FormatDDL(t.DDL), indentContent))
+				b.WriteString(formatDDLWithSymbol(t.ChangeType, t.DDL))
 			}
 			// Rows and ETA on same line
 			if info.ETA != "" && info.ETA != "TBD" {
-				fmt.Printf(indentContent+"Rows: %s / %s · ETA: %s\n", ui.FormatNumber(ui.ClampRows(info.RowsCopied, info.RowsTotal)), ui.FormatNumber(info.RowsTotal), info.ETA)
+				fmt.Fprintf(&b, indentContent+"Rows: %s / %s · ETA: %s\n", ui.FormatNumber(ui.ClampRows(info.RowsCopied, info.RowsTotal)), ui.FormatNumber(info.RowsTotal), info.ETA)
 			} else {
-				fmt.Printf(indentContent+"Rows: %s / %s\n", ui.FormatNumber(ui.ClampRows(info.RowsCopied, info.RowsTotal)), ui.FormatNumber(info.RowsTotal))
+				fmt.Fprintf(&b, indentContent+"Rows: %s / %s\n", ui.FormatNumber(ui.ClampRows(info.RowsCopied, info.RowsTotal)), ui.FormatNumber(info.RowsTotal))
 			}
 			if info.State != "" && info.State != "copyRows" {
-				fmt.Printf(indentContent+"Status: %s\n", info.State)
+				fmt.Fprintf(&b, indentContent+"Status: %s\n", info.State)
 			}
 		} else {
 			// Can't parse - show raw detail
-			fmt.Printf("    %s:\n", t.TableName)
+			fmt.Fprintf(&b, indentTable+"%s:\n", t.TableName)
 			if t.DDL != "" {
-				fmt.Printf("%s\n", IndentSQL(ddl.FormatDDL(t.DDL), indentContent))
+				b.WriteString(formatDDLWithSymbol(t.ChangeType, t.DDL))
 			}
-			fmt.Printf("    %s\n", t.ProgressDetail)
+			fmt.Fprintf(&b, "    %s\n", t.ProgressDetail)
+		}
+	case t.RowsTotal > 0 && t.RowsCopied == 0 && len(t.Shards) > 0:
+		// Staging phase — shards have row totals but no rows copied yet.
+		// Show "Staging schema changes..." instead of a misleading 0% bar.
+		fmt.Fprintf(&b, indentTable+"%s: Staging schema changes...\n", t.TableName)
+		if t.DDL != "" {
+			b.WriteString(formatDDLWithSymbol(t.ChangeType, t.DDL))
 		}
 	case t.RowsTotal > 0:
 		// Row copy in progress — show progress bar with structured fields
 		bar := ui.ProgressBarRowCopy(t.PercentComplete)
 		displayPercent := min(t.PercentComplete, 100)
-		fmt.Printf("    %s: %s %d%%\n", t.TableName, bar, displayPercent)
+		fmt.Fprintf(&b, indentTable+"%s: %s %d%%\n", t.TableName, bar, displayPercent)
 
 		if t.DDL != "" {
-			fmt.Printf("%s\n", IndentSQL(ddl.FormatDDL(t.DDL), indentContent))
+			b.WriteString(formatDDLWithSymbol(t.ChangeType, t.DDL))
 		}
 
 		// Rows and ETA on same line
 		if t.ETASeconds > 0 {
-			fmt.Printf(indentContent+"Rows: %s / %s · ETA: %s\n", ui.FormatNumber(ui.ClampRows(t.RowsCopied, t.RowsTotal)), ui.FormatNumber(t.RowsTotal), ui.FormatETA(t.ETASeconds))
+			fmt.Fprintf(&b, indentContent+"Rows: %s / %s · ETA: %s\n", ui.FormatNumber(ui.ClampRows(t.RowsCopied, t.RowsTotal)), ui.FormatNumber(t.RowsTotal), ui.FormatETA(t.ETASeconds))
 		} else {
-			fmt.Printf("      Rows: %s / %s\n", ui.FormatNumber(ui.ClampRows(t.RowsCopied, t.RowsTotal)), ui.FormatNumber(t.RowsTotal))
+			fmt.Fprintf(&b, "      Rows: %s / %s\n", ui.FormatNumber(ui.ClampRows(t.RowsCopied, t.RowsTotal)), ui.FormatNumber(t.RowsTotal))
 		}
 
 		statusLower := strings.ToLower(t.Status)
 		if statusLower != "" && statusLower != "running" && statusLower != "row_copy" {
-			fmt.Printf(indentContent+"Status: %s\n", t.Status)
+			fmt.Fprintf(&b, indentContent+"Status: %s\n", t.Status)
 		}
 	default:
 		// No row copy data yet (initializing or instant DDL) — just show running state
-		fmt.Printf("    %s: Running...\n", t.TableName)
+		fmt.Fprintf(&b, indentTable+"%s: Running...\n", t.TableName)
 		if t.DDL != "" {
-			fmt.Printf("%s\n", IndentSQL(ddl.FormatDDL(t.DDL), indentContent))
+			b.WriteString(formatDDLWithSymbol(t.ChangeType, t.DDL))
 		}
 	}
 
-	fmt.Println()
+	b.WriteString("\n")
+	b.WriteString(FormatShardProgress(t.Shards))
+	return b.String()
 }
 
 // StopData contains data for rendering stop command output.

--- a/pkg/cmd/templates/progress_parse.go
+++ b/pkg/cmd/templates/progress_parse.go
@@ -35,6 +35,7 @@ type ProgressData struct {
 type TableProgress struct {
 	TableName       string
 	Namespace       string // Keyspace (Vitess) or schema name (MySQL)
+	ChangeType      string // create, alter, drop
 	DDL             string
 	Status          string
 	RowsCopied      int64
@@ -134,6 +135,7 @@ func ParseProgressResponse(result *apitypes.ProgressResponse) ProgressData {
 		tp := TableProgress{
 			TableName:       tbl.TableName,
 			Namespace:       tbl.Keyspace,
+			ChangeType:      tbl.ChangeType,
 			DDL:             tbl.DDL,
 			Status:          state.NormalizeState(tbl.Status),
 			RowsCopied:      tbl.RowsCopied,

--- a/pkg/cmd/templates/progress_shard.go
+++ b/pkg/cmd/templates/progress_shard.go
@@ -9,6 +9,13 @@ import (
 	"github.com/block/schemabot/pkg/ui"
 )
 
+// Shard indentation constants (derived from indentContent in progress.go).
+var (
+	indentShardHeader = indentContent + "• "   // Shards: header with bullet
+	indentShardLine   = indentContent + "    " // individual shard lines
+	indentShardMore   = indentContent + "    " // "... N more" lines
+)
+
 // maxShardDetail is the maximum number of individual shard lines to render.
 // Beyond this, only non-terminal (copying/queued/failed) shards are shown
 // with a collapsed summary for complete shards.
@@ -26,7 +33,7 @@ func FormatShardProgress(shards []ShardProgress) string {
 
 	c := CountShardsByStatus(shards)
 	parts := FormatShardSummaryParts(c, false)
-	fmt.Fprintf(&b, "    %sShards: %d (%s)%s\n", ANSIDim, len(shards), strings.Join(parts, ", "), ANSIReset)
+	fmt.Fprintf(&b, indentShardHeader+"%sShards: %d (%s)%s\n", ANSIDim, len(shards), strings.Join(parts, ", "), ANSIReset)
 
 	// For small shard counts, show all shards
 	if len(shards) <= maxShardDetail {
@@ -64,11 +71,11 @@ func FormatShardProgress(shards []ShardProgress) string {
 		}
 	}
 	if waitingCount > maxNonCopyingShown {
-		fmt.Fprintf(&b, "      %s... %d more ready for cutover%s\n",
+		fmt.Fprintf(&b, indentShardMore+"%s... %d more ready for cutover%s\n",
 			ANSIDim, waitingCount-maxNonCopyingShown, ANSIReset)
 	}
 	if cuttingCount > maxNonCopyingShown {
-		fmt.Fprintf(&b, "      %s... %d more cutting over%s\n",
+		fmt.Fprintf(&b, indentShardMore+"%s... %d more cutting over%s\n",
 			ANSIDim, cuttingCount-maxNonCopyingShown, ANSIReset)
 	}
 
@@ -90,7 +97,7 @@ func FormatShardProgress(shards []ShardProgress) string {
 		b.WriteString(formatShardLine(s))
 	}
 	if len(copying) > maxCopyingShown {
-		fmt.Fprintf(&b, "      %s... %d more copying shards%s\n",
+		fmt.Fprintf(&b, indentShardMore+"%s... %d more copying shards%s\n",
 			ANSIDim, len(copying)-maxCopyingShown, ANSIReset)
 	}
 
@@ -103,7 +110,7 @@ func FormatShardProgress(shards []ShardProgress) string {
 		if c.Queued > 0 {
 			remainParts = append(remainParts, fmt.Sprintf("%d queued", c.Queued))
 		}
-		fmt.Fprintf(&b, "      %s... %s%s\n", ANSIDim, strings.Join(remainParts, ", "), ANSIReset)
+		fmt.Fprintf(&b, indentShardMore+"%s... %s%s\n", ANSIDim, strings.Join(remainParts, ", "), ANSIReset)
 	}
 
 	return b.String()
@@ -112,7 +119,7 @@ func FormatShardProgress(shards []ShardProgress) string {
 func formatShardLine(s ShardProgress) string {
 	switch s.Status {
 	case state.Task.Completed:
-		return fmt.Sprintf("      %s✓ %s%s: %s rows\n", ANSIGreen, s.Shard, ANSIReset, ui.FormatNumber(s.RowsTotal))
+		return fmt.Sprintf(indentShardLine+"%s✓ %s%s: %s rows\n", ANSIGreen, s.Shard, ANSIReset, ui.FormatNumber(s.RowsTotal))
 	case state.Task.Running:
 		pct := s.PercentComplete
 		if pct == 0 && s.RowsTotal > 0 {
@@ -122,17 +129,17 @@ func formatShardLine(s ShardProgress) string {
 		if s.ETASeconds > 0 {
 			detail += fmt.Sprintf(" ETA %s", FormatDurationSeconds(s.ETASeconds))
 		}
-		return fmt.Sprintf("      %s◉ %s%s: %s\n", ANSICyan, s.Shard, ANSIReset, detail)
+		return fmt.Sprintf(indentShardLine+"%s◉ %s%s: %s\n", ANSICyan, s.Shard, ANSIReset, detail)
 	case state.Task.WaitingForCutover:
-		return fmt.Sprintf("      %s● %s%s: ready for cutover\n", ANSIYellow, s.Shard, ANSIReset)
+		return fmt.Sprintf(indentShardLine+"%s● %s%s: ready for cutover\n", ANSIYellow, s.Shard, ANSIReset)
 	case state.Task.CuttingOver:
-		return fmt.Sprintf("      %s● %s%s: cutting over\n", ANSIYellow, s.Shard, ANSIReset)
+		return fmt.Sprintf(indentShardLine+"%s● %s%s: cutting over\n", ANSIYellow, s.Shard, ANSIReset)
 	case state.Task.Pending:
-		return fmt.Sprintf("      %s○ %s: queued%s\n", ANSIDim, s.Shard, ANSIReset)
+		return fmt.Sprintf(indentShardLine+"%s○ %s: queued%s\n", ANSIDim, s.Shard, ANSIReset)
 	case state.Task.Failed:
-		return fmt.Sprintf("      %s✗ %s%s: failed\n", ANSIRed, s.Shard, ANSIReset)
+		return fmt.Sprintf(indentShardLine+"%s✗ %s%s: failed\n", ANSIRed, s.Shard, ANSIReset)
 	default:
-		return fmt.Sprintf("      %s○ %s: %s%s\n", ANSIDim, s.Shard, s.Status, ANSIReset)
+		return fmt.Sprintf(indentShardLine+"%s○ %s: %s%s\n", ANSIDim, s.Shard, s.Status, ANSIReset)
 	}
 }
 

--- a/pkg/cmd/templates/progress_shard.go
+++ b/pkg/cmd/templates/progress_shard.go
@@ -14,24 +14,26 @@ import (
 // with a collapsed summary for complete shards.
 const maxShardDetail = 8
 
-// writeShardProgress renders per-shard progress for a Vitess table.
+// FormatShardProgress returns per-shard progress for a Vitess table as a string.
 // For large shard counts (>maxShardDetail), only shows non-terminal shards
 // plus a collapsed count for complete/queued shards.
-func writeShardProgress(shards []ShardProgress) {
+func FormatShardProgress(shards []ShardProgress) string {
 	if len(shards) == 0 {
-		return
+		return ""
 	}
+
+	var b strings.Builder
 
 	c := CountShardsByStatus(shards)
 	parts := FormatShardSummaryParts(c, false)
-	fmt.Printf("    %sShards: %d (%s)%s\n", ANSIDim, len(shards), strings.Join(parts, ", "), ANSIReset)
+	fmt.Fprintf(&b, "    %sShards: %d (%s)%s\n", ANSIDim, len(shards), strings.Join(parts, ", "), ANSIReset)
 
 	// For small shard counts, show all shards
 	if len(shards) <= maxShardDetail {
 		for _, s := range shards {
-			writeShardLine(s)
+			b.WriteString(formatShardLine(s))
 		}
-		return
+		return b.String()
 	}
 
 	// For large shard counts: show failed first (always), then a sample
@@ -41,11 +43,9 @@ func writeShardProgress(shards []ShardProgress) {
 	// Always show failed shards (they need attention). Limit other non-copying
 	// shards to avoid a wall of identical "ready for cutover" lines.
 	const maxNonCopyingShown = 3
-	var shownCount int
 	for _, s := range shards {
 		if s.Status == state.Task.Failed {
-			writeShardLine(s)
-			shownCount++
+			b.WriteString(formatShardLine(s))
 		}
 	}
 	var waitingCount, cuttingCount int
@@ -53,24 +53,22 @@ func writeShardProgress(shards []ShardProgress) {
 		switch s.Status {
 		case state.Task.WaitingForCutover:
 			if waitingCount < maxNonCopyingShown {
-				writeShardLine(s)
-				shownCount++
+				b.WriteString(formatShardLine(s))
 			}
 			waitingCount++
 		case state.Task.CuttingOver:
 			if cuttingCount < maxNonCopyingShown {
-				writeShardLine(s)
-				shownCount++
+				b.WriteString(formatShardLine(s))
 			}
 			cuttingCount++
 		}
 	}
 	if waitingCount > maxNonCopyingShown {
-		fmt.Printf("      %s... %d more ready for cutover%s\n",
+		fmt.Fprintf(&b, "      %s... %d more ready for cutover%s\n",
 			ANSIDim, waitingCount-maxNonCopyingShown, ANSIReset)
 	}
 	if cuttingCount > maxNonCopyingShown {
-		fmt.Printf("      %s... %d more cutting over%s\n",
+		fmt.Fprintf(&b, "      %s... %d more cutting over%s\n",
 			ANSIDim, cuttingCount-maxNonCopyingShown, ANSIReset)
 	}
 
@@ -89,31 +87,32 @@ func writeShardProgress(shards []ShardProgress) {
 		if i >= maxCopyingShown {
 			break
 		}
-		writeShardLine(s)
-		shownCount++
+		b.WriteString(formatShardLine(s))
 	}
 	if len(copying) > maxCopyingShown {
-		fmt.Printf("      %s... %d more copying shards%s\n",
+		fmt.Fprintf(&b, "      %s... %d more copying shards%s\n",
 			ANSIDim, len(copying)-maxCopyingShown, ANSIReset)
 	}
 
 	// Summarize remaining shards not individually shown
 	if c.Complete > 0 || c.Queued > 0 {
-		var parts []string
+		var remainParts []string
 		if c.Complete > 0 {
-			parts = append(parts, fmt.Sprintf("%d complete", c.Complete))
+			remainParts = append(remainParts, fmt.Sprintf("%d complete", c.Complete))
 		}
 		if c.Queued > 0 {
-			parts = append(parts, fmt.Sprintf("%d queued", c.Queued))
+			remainParts = append(remainParts, fmt.Sprintf("%d queued", c.Queued))
 		}
-		fmt.Printf("      %s... %s%s\n", ANSIDim, strings.Join(parts, ", "), ANSIReset)
+		fmt.Fprintf(&b, "      %s... %s%s\n", ANSIDim, strings.Join(remainParts, ", "), ANSIReset)
 	}
+
+	return b.String()
 }
 
-func writeShardLine(s ShardProgress) {
+func formatShardLine(s ShardProgress) string {
 	switch s.Status {
 	case state.Task.Completed:
-		fmt.Printf("      %s✓ %s%s: %s rows\n", ANSIGreen, s.Shard, ANSIReset, ui.FormatNumber(s.RowsTotal))
+		return fmt.Sprintf("      %s✓ %s%s: %s rows\n", ANSIGreen, s.Shard, ANSIReset, ui.FormatNumber(s.RowsTotal))
 	case state.Task.Running:
 		pct := s.PercentComplete
 		if pct == 0 && s.RowsTotal > 0 {
@@ -123,17 +122,17 @@ func writeShardLine(s ShardProgress) {
 		if s.ETASeconds > 0 {
 			detail += fmt.Sprintf(" ETA %s", FormatDurationSeconds(s.ETASeconds))
 		}
-		fmt.Printf("      %s◉ %s%s: %s\n", ANSICyan, s.Shard, ANSIReset, detail)
+		return fmt.Sprintf("      %s◉ %s%s: %s\n", ANSICyan, s.Shard, ANSIReset, detail)
 	case state.Task.WaitingForCutover:
-		fmt.Printf("      %s● %s%s: ready for cutover\n", ANSIYellow, s.Shard, ANSIReset)
+		return fmt.Sprintf("      %s● %s%s: ready for cutover\n", ANSIYellow, s.Shard, ANSIReset)
 	case state.Task.CuttingOver:
-		fmt.Printf("      %s● %s%s: cutting over\n", ANSIYellow, s.Shard, ANSIReset)
+		return fmt.Sprintf("      %s● %s%s: cutting over\n", ANSIYellow, s.Shard, ANSIReset)
 	case state.Task.Pending:
-		fmt.Printf("      %s○ %s: queued%s\n", ANSIDim, s.Shard, ANSIReset)
+		return fmt.Sprintf("      %s○ %s: queued%s\n", ANSIDim, s.Shard, ANSIReset)
 	case state.Task.Failed:
-		fmt.Printf("      %s✗ %s%s: failed\n", ANSIRed, s.Shard, ANSIReset)
+		return fmt.Sprintf("      %s✗ %s%s: failed\n", ANSIRed, s.Shard, ANSIReset)
 	default:
-		fmt.Printf("      %s○ %s: %s%s\n", ANSIDim, s.Shard, s.Status, ANSIReset)
+		return fmt.Sprintf("      %s○ %s: %s%s\n", ANSIDim, s.Shard, s.Status, ANSIReset)
 	}
 }
 

--- a/pkg/proto/tern.proto
+++ b/pkg/proto/tern.proto
@@ -356,6 +356,7 @@ message TableProgress {
   bool is_instant = 10;
   repeated ShardProgress shards = 11;
   string progress_detail = 12;
+  ChangeType change_type = 13;
 }
 
 // ProgressResponse contains detailed progress information.

--- a/pkg/proto/ternv1/tern.pb.go
+++ b/pkg/proto/ternv1/tern.pb.go
@@ -1031,6 +1031,7 @@ type TableProgress struct {
 	IsInstant       bool                   `protobuf:"varint,10,opt,name=is_instant,json=isInstant,proto3" json:"is_instant,omitempty"`
 	Shards          []*ShardProgress       `protobuf:"bytes,11,rep,name=shards,proto3" json:"shards,omitempty"`
 	ProgressDetail  string                 `protobuf:"bytes,12,opt,name=progress_detail,json=progressDetail,proto3" json:"progress_detail,omitempty"`
+	ChangeType      ChangeType             `protobuf:"varint,13,opt,name=change_type,json=changeType,proto3,enum=tern.v1.ChangeType" json:"change_type,omitempty"`
 	unknownFields   protoimpl.UnknownFields
 	sizeCache       protoimpl.SizeCache
 }
@@ -1147,6 +1148,13 @@ func (x *TableProgress) GetProgressDetail() string {
 		return x.ProgressDetail
 	}
 	return ""
+}
+
+func (x *TableProgress) GetChangeType() ChangeType {
+	if x != nil {
+		return x.ChangeType
+	}
+	return ChangeType_CHANGE_TYPE_OTHER
 }
 
 // ProgressResponse contains detailed progress information.
@@ -2261,7 +2269,7 @@ const file_tern_proto_rawDesc = "" +
 	"etaSeconds\x12)\n" +
 	"\x10cutover_attempts\x18\x06 \x01(\x05R\x0fcutoverAttempts\x120\n" +
 	"\x14last_cutover_attempt\x18\a \x01(\tR\x12lastCutoverAttempt\x12*\n" +
-	"\x11ready_to_complete\x18\b \x01(\bR\x0freadyToComplete\"\x93\x03\n" +
+	"\x11ready_to_complete\x18\b \x01(\bR\x0freadyToComplete\"\xc9\x03\n" +
 	"\rTableProgress\x12\x17\n" +
 	"\atask_id\x18\x01 \x01(\tR\x06taskId\x12\x1c\n" +
 	"\tnamespace\x18\x02 \x01(\tR\tnamespace\x12\x1d\n" +
@@ -2280,7 +2288,9 @@ const file_tern_proto_rawDesc = "" +
 	"is_instant\x18\n" +
 	" \x01(\bR\tisInstant\x12.\n" +
 	"\x06shards\x18\v \x03(\v2\x16.tern.v1.ShardProgressR\x06shards\x12'\n" +
-	"\x0fprogress_detail\x18\f \x01(\tR\x0eprogressDetail\"\xc7\x03\n" +
+	"\x0fprogress_detail\x18\f \x01(\tR\x0eprogressDetail\x124\n" +
+	"\vchange_type\x18\r \x01(\x0e2\x13.tern.v1.ChangeTypeR\n" +
+	"changeType\"\xc7\x03\n" +
 	"\x10ProgressResponse\x12\x19\n" +
 	"\bapply_id\x18\x01 \x01(\tR\aapplyId\x12$\n" +
 	"\x05state\x18\x02 \x01(\x0e2\x0e.tern.v1.StateR\x05state\x12'\n" +
@@ -2462,37 +2472,38 @@ var file_tern_proto_depIdxs = []int32{
 	33, // 9: tern.v1.ApplyRequest.schema_files:type_name -> tern.v1.ApplyRequest.SchemaFilesEntry
 	5,  // 10: tern.v1.ApplyRequest.ddl_changes:type_name -> tern.v1.TableChange
 	12, // 11: tern.v1.TableProgress.shards:type_name -> tern.v1.ShardProgress
-	1,  // 12: tern.v1.ProgressResponse.state:type_name -> tern.v1.State
-	0,  // 13: tern.v1.ProgressResponse.engine:type_name -> tern.v1.Engine
-	13, // 14: tern.v1.ProgressResponse.tables:type_name -> tern.v1.TableProgress
-	34, // 15: tern.v1.ProgressResponse.metadata:type_name -> tern.v1.ProgressResponse.MetadataEntry
-	3,  // 16: tern.v1.PlanRequest.SchemaFilesEntry.value:type_name -> tern.v1.SchemaFiles
-	3,  // 17: tern.v1.ApplyRequest.SchemaFilesEntry.value:type_name -> tern.v1.SchemaFiles
-	4,  // 18: tern.v1.Tern.Plan:input_type -> tern.v1.PlanRequest
-	9,  // 19: tern.v1.Tern.Apply:input_type -> tern.v1.ApplyRequest
-	11, // 20: tern.v1.Tern.Progress:input_type -> tern.v1.ProgressRequest
-	15, // 21: tern.v1.Tern.Cutover:input_type -> tern.v1.CutoverRequest
-	17, // 22: tern.v1.Tern.Revert:input_type -> tern.v1.RevertRequest
-	19, // 23: tern.v1.Tern.SkipRevert:input_type -> tern.v1.SkipRevertRequest
-	21, // 24: tern.v1.Tern.Health:input_type -> tern.v1.HealthRequest
-	23, // 25: tern.v1.Tern.Stop:input_type -> tern.v1.StopRequest
-	25, // 26: tern.v1.Tern.Start:input_type -> tern.v1.StartRequest
-	27, // 27: tern.v1.Tern.Volume:input_type -> tern.v1.VolumeRequest
-	8,  // 28: tern.v1.Tern.Plan:output_type -> tern.v1.PlanResponse
-	10, // 29: tern.v1.Tern.Apply:output_type -> tern.v1.ApplyResponse
-	14, // 30: tern.v1.Tern.Progress:output_type -> tern.v1.ProgressResponse
-	16, // 31: tern.v1.Tern.Cutover:output_type -> tern.v1.CutoverResponse
-	18, // 32: tern.v1.Tern.Revert:output_type -> tern.v1.RevertResponse
-	20, // 33: tern.v1.Tern.SkipRevert:output_type -> tern.v1.SkipRevertResponse
-	22, // 34: tern.v1.Tern.Health:output_type -> tern.v1.HealthResponse
-	24, // 35: tern.v1.Tern.Stop:output_type -> tern.v1.StopResponse
-	26, // 36: tern.v1.Tern.Start:output_type -> tern.v1.StartResponse
-	28, // 37: tern.v1.Tern.Volume:output_type -> tern.v1.VolumeResponse
-	28, // [28:38] is the sub-list for method output_type
-	18, // [18:28] is the sub-list for method input_type
-	18, // [18:18] is the sub-list for extension type_name
-	18, // [18:18] is the sub-list for extension extendee
-	0,  // [0:18] is the sub-list for field type_name
+	2,  // 12: tern.v1.TableProgress.change_type:type_name -> tern.v1.ChangeType
+	1,  // 13: tern.v1.ProgressResponse.state:type_name -> tern.v1.State
+	0,  // 14: tern.v1.ProgressResponse.engine:type_name -> tern.v1.Engine
+	13, // 15: tern.v1.ProgressResponse.tables:type_name -> tern.v1.TableProgress
+	34, // 16: tern.v1.ProgressResponse.metadata:type_name -> tern.v1.ProgressResponse.MetadataEntry
+	3,  // 17: tern.v1.PlanRequest.SchemaFilesEntry.value:type_name -> tern.v1.SchemaFiles
+	3,  // 18: tern.v1.ApplyRequest.SchemaFilesEntry.value:type_name -> tern.v1.SchemaFiles
+	4,  // 19: tern.v1.Tern.Plan:input_type -> tern.v1.PlanRequest
+	9,  // 20: tern.v1.Tern.Apply:input_type -> tern.v1.ApplyRequest
+	11, // 21: tern.v1.Tern.Progress:input_type -> tern.v1.ProgressRequest
+	15, // 22: tern.v1.Tern.Cutover:input_type -> tern.v1.CutoverRequest
+	17, // 23: tern.v1.Tern.Revert:input_type -> tern.v1.RevertRequest
+	19, // 24: tern.v1.Tern.SkipRevert:input_type -> tern.v1.SkipRevertRequest
+	21, // 25: tern.v1.Tern.Health:input_type -> tern.v1.HealthRequest
+	23, // 26: tern.v1.Tern.Stop:input_type -> tern.v1.StopRequest
+	25, // 27: tern.v1.Tern.Start:input_type -> tern.v1.StartRequest
+	27, // 28: tern.v1.Tern.Volume:input_type -> tern.v1.VolumeRequest
+	8,  // 29: tern.v1.Tern.Plan:output_type -> tern.v1.PlanResponse
+	10, // 30: tern.v1.Tern.Apply:output_type -> tern.v1.ApplyResponse
+	14, // 31: tern.v1.Tern.Progress:output_type -> tern.v1.ProgressResponse
+	16, // 32: tern.v1.Tern.Cutover:output_type -> tern.v1.CutoverResponse
+	18, // 33: tern.v1.Tern.Revert:output_type -> tern.v1.RevertResponse
+	20, // 34: tern.v1.Tern.SkipRevert:output_type -> tern.v1.SkipRevertResponse
+	22, // 35: tern.v1.Tern.Health:output_type -> tern.v1.HealthResponse
+	24, // 36: tern.v1.Tern.Stop:output_type -> tern.v1.StopResponse
+	26, // 37: tern.v1.Tern.Start:output_type -> tern.v1.StartResponse
+	28, // 38: tern.v1.Tern.Volume:output_type -> tern.v1.VolumeResponse
+	29, // [29:39] is the sub-list for method output_type
+	19, // [19:29] is the sub-list for method input_type
+	19, // [19:19] is the sub-list for extension type_name
+	19, // [19:19] is the sub-list for extension extendee
+	0,  // [0:19] is the sub-list for field type_name
 }
 
 func init() { file_tern_proto_init() }


### PR DESCRIPTION
Refactors CLI progress rendering to use shared templates for both TUI and `--no-watch` output, adds Vitess-specific UX improvements, and wires `ChangeType` through the progress API.

**Shared rendering**: The TUI watch view now delegates all table rendering to `FormatNamespacedTables`, `FormatTableProgress`, and `FormatShardProgress. Status values are normalized via `NormalizeTaskStatus`/`NormalizeShardStatus` before passing to templates.

**Progress UX**: DDL change symbols (`+` create, `~` alter, `-` drop) on the table name line. "Staging schema changes..." replaces the misleading empty 0% progress bar during VReplication setup. Rows and Shards use bullet points (`•`) with consistent indentation. Table names align with keyspace header text. No blank line between `• Rows` and `• Shards` detail lines.

**`ChangeType` wiring**: Added `change_type` field to proto `TableProgress`, API `TableProgressResponse`, and template `TableProgress`. The progress handler populates it from the proto enum (live applies) and `task.DDLAction` (completed applies). The CLI renders symbols from the server-provided type — no DDL text inference needed.

**Interactive skip-revert**: During `revert_window` state, the TUI shows "Press Enter to skip revert" and triggers `CallSkipRevertAPI` on Enter, matching the cutover interaction pattern.

**Bug fix**: `--skip-revert` was accepted by the CLI but never passed through the apply options map to the server.

Generated with [Claude Code](https://claude.com/claude-code)