### PR TITLE
feat(vitess): add --branch flag for reusing existing PlanetScale branches

### DIFF
--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -2777,6 +2777,29 @@ Use 'schemabot start' to resume from checkpoint.
 </details>
 
 <details>
+<summary><a name="vitess-refreshing-branch-branch"></a><strong>Vitess: Refreshing Branch (--branch)</strong></summary>
+
+```
+
+┌──────────────────────────────────────────┐
+│  Apply ID:     apply-b7c8d9e0f1a2        │
+│  Database:     myapp                     │
+│  Environment:  staging                   │
+│  State:        Refreshing branch schema  │
+│  Branch:       my-reusable-branch        │
+└──────────────────────────────────────────┘
+
+
+  ── myapp_sharded ──
+
+     ~ users: ⏳ Queued
+       ALTER TABLE `users` ADD COLUMN `region` varchar(50);
+
+
+```
+</details>
+
+<details>
 <summary><a name="vitess-applying-branch-changes"></a><strong>Vitess: Applying Branch Changes</strong></summary>
 
 ```

--- a/e2e/local/vitess_test.go
+++ b/e2e/local/vitess_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"maps"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -1421,3 +1422,106 @@ func TestVitess_Apply_Cancel(t *testing.T) {
 }
 
 // extractApplyID is defined in apply_wait_test.go
+
+// createBranchViaLocalScale creates a PlanetScale branch via the LocalScale API
+// and waits for it to be ready. Returns the branch name.
+func createBranchViaLocalScale(t *testing.T, branchName string) {
+	t.Helper()
+	ctx := t.Context()
+	localscaleURL := os.Getenv("LOCALSCALE_URL")
+	require.NotEmpty(t, localscaleURL, "LOCALSCALE_URL not set")
+
+	body := fmt.Sprintf(`{"name":"%s","parent_branch":"main"}`, branchName)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		localscaleURL+"/v1/organizations/localscale-staging/databases/"+vitessDB+"/branches",
+		strings.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode, "CreateBranch failed")
+
+	// Poll until branch is ready
+	deadline := time.Now().Add(testutil.PollDeadline)
+	for time.Now().Before(deadline) {
+		getReq, _ := http.NewRequestWithContext(ctx, http.MethodGet,
+			localscaleURL+"/v1/organizations/localscale-staging/databases/"+vitessDB+"/branches/"+branchName, nil)
+		resp, err := http.DefaultClient.Do(getReq)
+		if err == nil {
+			var branch struct {
+				Ready bool `json:"ready"`
+			}
+			_ = json.NewDecoder(resp.Body).Decode(&branch)
+			resp.Body.Close()
+			if branch.Ready {
+				return
+			}
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	t.Fatalf("branch %s not ready within deadline", branchName)
+}
+
+// TestVitess_Apply_BranchReuse tests the --branch flag for reusing an existing
+// PlanetScale branch. Creates a branch, applies with --branch, then syncs and
+// applies again on the same branch.
+func TestVitess_Apply_BranchReuse(t *testing.T) {
+	vitessAvailable(t)
+	clearSchemaBotState(t)
+	defer vitessRestoreBaseSchema(t, "staging")
+
+	branchName := fmt.Sprintf("reuse-e2e-%d", time.Now().UnixMilli()%100000)
+	createBranchViaLocalScale(t, branchName)
+
+	// First apply: add a column using --branch
+	col1 := fmt.Sprintf("reuse_col1_%d", time.Now().UnixMilli()%100000)
+	schemaDir := newVitessSchemaDir(t, vitessSchemaWithOverrides(map[string]string{
+		"testapp_sharded/users.sql": fmt.Sprintf(`CREATE TABLE `+"`users`"+` (
+  `+"`id`"+` bigint NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  `+"`email`"+` varchar(255) NOT NULL,
+  `+"`full_name`"+` varchar(255) NULL,
+  `+"`%s`"+` varchar(100) NULL,
+  `+"`created_at`"+` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  INDEX `+"`idx_email`"+` (`+"`email`"+`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;`, col1),
+	}))
+
+	out := vitessApplyAndWait(t, schemaDir, "staging", "--branch", branchName)
+	e2eutil.AssertContains(t, out, "Apply started")
+	e2eutil.AssertContains(t, out, "Apply completed")
+
+	// Verify branch refresh happened via apply logs
+	applyID := extractApplyIDFromLog(out)
+	endpoint := schemabotURL(t)
+	logs, err := client.GetLogs(endpoint, "", "", applyID, 50)
+	require.NoError(t, err)
+	var foundRefresh bool
+	for _, entry := range logs {
+		if strings.Contains(entry.Message, "Refreshing schema for branch") {
+			foundRefresh = true
+			break
+		}
+	}
+	assert.True(t, foundRefresh, "expected 'Refreshing schema for branch' in apply logs")
+
+	// Second apply on the same branch: add another column
+	clearSchemaBotState(t)
+	col2 := fmt.Sprintf("reuse_col2_%d", time.Now().UnixMilli()%100000)
+	schemaDir2 := newVitessSchemaDir(t, vitessSchemaWithOverrides(map[string]string{
+		"testapp_sharded/users.sql": fmt.Sprintf(`CREATE TABLE `+"`users`"+` (
+  `+"`id`"+` bigint NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  `+"`email`"+` varchar(255) NOT NULL,
+  `+"`full_name`"+` varchar(255) NULL,
+  `+"`%s`"+` varchar(100) NULL,
+  `+"`%s`"+` varchar(100) NULL,
+  `+"`created_at`"+` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  INDEX `+"`idx_email`"+` (`+"`email`"+`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;`, col1, col2),
+	}))
+
+	out2 := vitessApplyAndWait(t, schemaDir2, "staging", "--branch", branchName)
+	e2eutil.AssertContains(t, out2, "Apply started")
+	// Second apply completing proves the branch was preserved and reused
+	e2eutil.AssertContains(t, out2, "Apply completed")
+}

--- a/pkg/cmd/commands/apply.go
+++ b/pkg/cmd/commands/apply.go
@@ -27,6 +27,7 @@ type ApplyCmd struct {
 	Watch        bool          `short:"w" help:"Watch progress until completion" default:"true" negatable:""`
 	DeferCutover bool          `help:"Defer cutover until manual trigger (use 'schemabot cutover')" name:"defer-cutover"`
 	SkipRevert   bool          `help:"Skip revert window after completion (Vitess only)" name:"skip-revert"`
+	Branch       string        `help:"Reuse existing PlanetScale branch (syncs with main, skips branch creation)" name:"branch"`
 	AllowUnsafe  bool          `help:"Allow destructive changes (DROP TABLE, DROP COLUMN, etc.)" name:"allow-unsafe"`
 	Force        bool          `help:"Force acquire lock (breaks existing lock from another owner)"`
 	Yield        bool          `help:"Yield lock after successful completion"`
@@ -106,7 +107,13 @@ func (cmd *ApplyCmd) Run(g *Globals) error {
 
 	// Validate engine-specific options
 	if cmd.SkipRevert && planResult.Engine != "" && !state.IsPlanetScaleEngine(planResult.Engine) {
-		return fmt.Errorf("--skip-revert is only relevant for Vitess/PlanetScale databases")
+		return fmt.Errorf("--skip-revert is only supported for Vitess/PlanetScale databases")
+	}
+	if cmd.Branch != "" && planResult.Engine != "" && !state.IsPlanetScaleEngine(planResult.Engine) {
+		return fmt.Errorf("--branch is only supported for Vitess/PlanetScale databases")
+	}
+	if err := validateBranchFlag(cmd.Branch); err != nil {
+		return err
 	}
 
 	// Check for errors
@@ -229,7 +236,7 @@ func (cmd *ApplyCmd) Run(g *Globals) error {
 
 	fmt.Println("\nApplying changes...")
 
-	if _, err := applyAndWatch(ep, planResult, cfg.Database, cmd.Environment, owner, "apply", cmd.DeferCutover, cmd.SkipRevert, cmd.Watch, cmd.Output, cmd.LogHeartbeat, opts); err != nil {
+	if _, err := applyAndWatch(ep, planResult, cfg.Database, cmd.Environment, owner, "apply", cmd.DeferCutover, cmd.SkipRevert, cmd.Branch, cmd.Watch, cmd.Output, cmd.LogHeartbeat, opts); err != nil {
 		return err
 	}
 
@@ -935,4 +942,12 @@ func watchApplyProgressJSON(endpoint, applyID string) error {
 
 		time.Sleep(2 * time.Second)
 	}
+}
+
+// validateBranchFlag checks that the --branch flag value is safe to use.
+func validateBranchFlag(branch string) error {
+	if branch == "main" {
+		return fmt.Errorf("cannot reuse the main branch — use a development branch")
+	}
+	return nil
 }

--- a/pkg/cmd/commands/apply_test.go
+++ b/pkg/cmd/commands/apply_test.go
@@ -1,0 +1,40 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBranchFlagValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		branch  string
+		wantErr string
+	}{
+		{
+			name:   "empty branch is allowed",
+			branch: "",
+		},
+		{
+			name:   "development branch is allowed",
+			branch: "my-feature-branch",
+		},
+		{
+			name:    "main branch is rejected",
+			branch:  "main",
+			wantErr: "cannot reuse the main branch",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateBranchFlag(tt.branch)
+			if tt.wantErr != "" {
+				assert.ErrorContains(t, err, tt.wantErr)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/cmd/commands/common.go
+++ b/pkg/cmd/commands/common.go
@@ -261,7 +261,7 @@ func resolveControlFlags(endpoint, profile string, applyID, database, environmen
 // optionally watches progress. Returns the apply ID (for yield logic, etc.).
 // Used by both RunApply and RunRollback.
 func applyAndWatch(ep string, planResult *apitypes.PlanResponse, database, environment, caller, operation string,
-	deferCutover, skipRevert, watch bool, format OutputFormat, logHeartbeat time.Duration, opts ...client.PlanOptions) (string, error) {
+	deferCutover, skipRevert bool, branch string, watch bool, format OutputFormat, logHeartbeat time.Duration, opts ...client.PlanOptions) (string, error) {
 
 	if planResult.PlanID == "" {
 		return "", fmt.Errorf("no plan_id in response")
@@ -273,6 +273,9 @@ func applyAndWatch(ep string, planResult *apitypes.PlanResponse, database, envir
 	}
 	if skipRevert {
 		options["skip_revert"] = "true"
+	}
+	if branch != "" {
+		options["branch"] = branch
 	}
 
 	applyResult, err := client.CallApplyAPI(ep, planResult.PlanID, database, environment, caller, options, opts...)

--- a/pkg/cmd/commands/preview.go
+++ b/pkg/cmd/commands/preview.go
@@ -50,7 +50,7 @@ func (cmd *PreviewCmd) Run(g *Globals) error {
 		templates.PreviewDeferCuttingAll, templates.PreviewDeferAll:
 		templates.PreviewCLIOutput(previewType)
 	// Apply watch mode types
-	case templates.PreviewApplyWatch, templates.PreviewApplyStopped:
+	case templates.PreviewApplyWatch, templates.PreviewApplyStopped, templates.PreviewBranchRefresh:
 		templates.PreviewCLIOutput(previewType)
 	// Stop/Start command types
 	case templates.PreviewStopCommand, templates.PreviewStartCommand:
@@ -166,6 +166,7 @@ Atomic Mode (--defer-cutover flag):
 Apply Watch Mode:
   apply_watch           Running with footer controls
   apply_stopped         Stopped by user
+  branch_refresh        Reusing branch with --branch flag
 
 Stop/Start Commands:
   stop_command          Output when user runs 'schemabot stop'

--- a/pkg/cmd/commands/rollback.go
+++ b/pkg/cmd/commands/rollback.go
@@ -137,6 +137,6 @@ func (cmd *RollbackCmd) Run(g *Globals) error {
 
 	fmt.Println("\nApplying rollback...")
 
-	_, err = applyAndWatch(ep, planResult, database, environment, owner, "rollback", cmd.DeferCutover, false, cmd.Watch, OutputFormatInteractive, 0)
+	_, err = applyAndWatch(ep, planResult, database, environment, owner, "rollback", cmd.DeferCutover, false, "", cmd.Watch, OutputFormatInteractive, 0)
 	return err
 }

--- a/pkg/cmd/commands/watch_tui_view.go
+++ b/pkg/cmd/commands/watch_tui_view.go
@@ -88,7 +88,11 @@ func (m WatchModel) progressView() string {
 	case state.IsState(m.state, state.Apply.Stopped):
 		// No status line - show stopped message after tables
 	case state.IsState(m.state, state.Apply.CreatingBranch):
-		b.WriteString(m.spinner.View() + "Creating branch..." + m.elapsed() + "\n")
+		label := "Creating branch..."
+		if m.metadata != nil && m.metadata["existing_branch"] != "" {
+			label = "Refreshing branch schema..."
+		}
+		b.WriteString(m.spinner.View() + label + m.elapsed() + "\n")
 	case state.IsState(m.state, state.Apply.ApplyingBranchChanges):
 		b.WriteString(m.spinner.View() + "Applying changes to branch..." + m.elapsed() + "\n")
 	case state.IsState(m.state, state.Apply.CreatingDeployRequest):

--- a/pkg/cmd/templates/preview.go
+++ b/pkg/cmd/templates/preview.go
@@ -51,8 +51,9 @@ const (
 	PreviewCLIApplyAll         PreviewType = "cli_apply_all"          // CLI: apply watch, stop/start, volume
 
 	// Apply watch mode previews
-	PreviewApplyWatch   PreviewType = "apply_watch"   // Running with footer controls
-	PreviewApplyStopped PreviewType = "apply_stopped" // Stopped by user
+	PreviewApplyWatch    PreviewType = "apply_watch"    // Running with footer controls
+	PreviewApplyStopped  PreviewType = "apply_stopped"  // Stopped by user
+	PreviewBranchRefresh PreviewType = "branch_refresh" // Reusing branch with --branch flag
 
 	// Sequential mode previews (multi-table, one at a time)
 	PreviewSeqPending    PreviewType = "seq_pending"    // All tables pending (just started)
@@ -198,6 +199,8 @@ func PreviewCLIOutput(previewType PreviewType) {
 		previewApplyWatchOutput()
 	case PreviewApplyStopped:
 		previewApplyStoppedOutput()
+	case PreviewBranchRefresh:
+		previewRefreshingBranchOutput()
 	case PreviewSeqPending:
 		previewSeqPendingOutput()
 	case PreviewSeqFirstRun:
@@ -1092,6 +1095,7 @@ func previewCLIApplyAllOutput() {
 		{"MYSQL: MULTI-TABLE STOPPED", previewSeqStoppedOutput},
 		// Vitess: PlanetScale lifecycle
 		{"VITESS: CREATING BRANCH", previewCreatingBranchOutput},
+		{"VITESS: REFRESHING BRANCH (--branch)", previewRefreshingBranchOutput},
 		{"VITESS: APPLYING BRANCH CHANGES", previewApplyingBranchChangesOutput},
 		{"VITESS: CREATING DEPLOY REQUEST", previewCreatingDeployRequestOutput},
 		{"VITESS: STAGING SCHEMA CHANGES (0% with shards)", previewVitessStagingOutput},

--- a/pkg/cmd/templates/preview_progress.go
+++ b/pkg/cmd/templates/preview_progress.go
@@ -27,6 +27,28 @@ func previewCreatingBranchOutput() {
 	WriteProgress(data)
 }
 
+func previewRefreshingBranchOutput() {
+	data := ProgressData{
+		State:       state.Apply.CreatingBranch,
+		Engine:      "PlanetScale",
+		ApplyID:     "apply-b7c8d9e0f1a2",
+		Database:    "myapp",
+		Environment: "staging",
+		Metadata: map[string]string{
+			"existing_branch": "my-reusable-branch",
+			"branch_name":     "my-reusable-branch",
+		},
+		Tables: []TableProgress{
+			{
+				TableName: "users", Namespace: "myapp_sharded",
+				DDL:    "ALTER TABLE `users` ADD COLUMN `region` varchar(50) DEFAULT NULL",
+				Status: state.Apply.Pending,
+			},
+		},
+	}
+	WriteProgress(data)
+}
+
 func previewApplyingBranchChangesOutput() {
 	data := ProgressData{
 		State:       state.Apply.ApplyingBranchChanges,

--- a/pkg/cmd/templates/progress.go
+++ b/pkg/cmd/templates/progress.go
@@ -59,6 +59,9 @@ func WriteProgress(data ProgressData) {
 
 	// Build key/value pairs for the detail box
 	displayState := StateLabel(data.State)
+	if data.State == state.Apply.CreatingBranch && data.Metadata != nil && data.Metadata["existing_branch"] != "" {
+		displayState = "Refreshing branch schema"
+	}
 	colorFn := stateColorFunc(data.State)
 
 	var rows []BoxRow

--- a/pkg/engine/planetscale/planetscale.go
+++ b/pkg/engine/planetscale/planetscale.go
@@ -818,23 +818,62 @@ func (e *Engine) Apply(ctx context.Context, req *engine.ApplyRequest) (*engine.A
 		})
 	}
 
-	// Create a new branch
-	branchName := generateBranchName(req.Database, req.PlanID)
-	persistState(&psMetadata{BranchName: branchName})
-	emitEvent(fmt.Sprintf("Creating branch %s", branchName), map[string]string{"branch": branchName})
-
+	// Create or reuse a branch
+	existingBranch := req.Options["branch"]
+	var branchName string
 	branchStart := time.Now()
-	_, err = e.createBranch(ctx, client, org, req.Database, branchName, main)
-	if err != nil {
-		return nil, fmt.Errorf("create branch: %w", err)
-	}
 
-	// Wait for branch to be ready
-	if err := e.waitForBranchReady(ctx, client, org, req.Database, branchName); err != nil {
-		return nil, fmt.Errorf("wait for branch: %w", err)
+	if existingBranch != "" {
+		// Reuse existing branch: wait for ready, refresh schema from main, wait again
+		branchName = existingBranch
+		if branchName == main {
+			return nil, fmt.Errorf("cannot reuse the %s branch — use a development branch", main)
+		}
+		persistState(&psMetadata{BranchName: branchName})
+		emitEvent(fmt.Sprintf("Reusing branch %s", branchName), map[string]string{"branch": branchName})
+
+		// Verify branch exists
+		if _, err := client.GetBranch(ctx, &ps.GetDatabaseBranchRequest{
+			Organization: org, Database: req.Database, Branch: branchName,
+		}); err != nil {
+			return nil, fmt.Errorf("branch %s not found: %w", branchName, err)
+		}
+
+		// Wait for branch to be ready (may be initializing from a prior create)
+		if err := e.waitForBranchReady(ctx, client, org, req.Database, branchName); err != nil {
+			return nil, fmt.Errorf("wait for branch %s: %w", branchName, err)
+		}
+
+		// Sync with main to pick up latest schema
+		emitEvent(fmt.Sprintf("Refreshing schema for branch %s from %s", branchName, main), map[string]string{"branch": branchName})
+		if err := client.RefreshSchema(ctx, org, req.Database, branchName); err != nil {
+			return nil, fmt.Errorf("refresh schema for branch %s: %w", branchName, err)
+		}
+
+		// Wait for sync to complete
+		if err := e.waitForBranchReady(ctx, client, org, req.Database, branchName); err != nil {
+			return nil, fmt.Errorf("wait for schema refresh %s: %w", branchName, err)
+		}
+		elapsed := time.Since(branchStart).Round(time.Second)
+		emitEvent(fmt.Sprintf("Branch %s schema refreshed (%s)", branchName, elapsed), map[string]string{"branch": branchName})
+	} else {
+		// Create a new branch
+		branchName = generateBranchName(req.Database, req.PlanID)
+		persistState(&psMetadata{BranchName: branchName})
+		emitEvent(fmt.Sprintf("Creating branch %s", branchName), map[string]string{"branch": branchName})
+
+		_, err = e.createBranch(ctx, client, org, req.Database, branchName, main)
+		if err != nil {
+			return nil, fmt.Errorf("create branch: %w", err)
+		}
+
+		// Wait for branch to be ready
+		if err := e.waitForBranchReady(ctx, client, org, req.Database, branchName); err != nil {
+			return nil, fmt.Errorf("wait for branch: %w", err)
+		}
+		elapsed := time.Since(branchStart).Round(time.Second)
+		emitEvent(fmt.Sprintf("Branch %s ready (%s)", branchName, elapsed), map[string]string{"branch": branchName})
 	}
-	elapsed := time.Since(branchStart).Round(time.Second)
-	emitEvent(fmt.Sprintf("Branch %s ready (%s)", branchName, elapsed), map[string]string{"branch": branchName})
 
 	// Get branch credentials to apply DDL via MySQL
 	pwCtx, pwCancel := context.WithTimeout(ctx, 10*time.Second)
@@ -871,7 +910,8 @@ func (e *Engine) Apply(ctx context.Context, req *engine.ApplyRequest) (*engine.A
 	// The server computes the schema diff asynchronously — poll until the deploy
 	// request transitions from "pending" to "ready" (or "no_changes"/"error").
 	drStart := time.Now()
-	dr, err := e.createDeployRequest(ctx, client, org, req.Database, branchName, main, !deferCutover)
+	autoDeleteBranch := existingBranch == "" // don't delete reused branches
+	dr, err := e.createDeployRequest(ctx, client, org, req.Database, branchName, main, !deferCutover, autoDeleteBranch)
 	if err != nil {
 		return nil, fmt.Errorf("create deploy request: %w", err)
 	}
@@ -1295,7 +1335,7 @@ func (e *Engine) resumeApply(ctx context.Context, client psclient.PSClient, org 
 	main := mainBranch(req.Credentials)
 	deferCutover := req.Options["defer_cutover"] == "true"
 
-	dr, err := e.createDeployRequest(ctx, client, org, req.Database, meta.BranchName, main, !deferCutover)
+	dr, err := e.createDeployRequest(ctx, client, org, req.Database, meta.BranchName, main, !deferCutover, true)
 	if err != nil {
 		return nil, fmt.Errorf("create deploy request on resume: %w", err)
 	}
@@ -2294,14 +2334,14 @@ func (e *Engine) waitForBranchReady(ctx context.Context, client psclient.PSClien
 	}
 }
 
-func (e *Engine) createDeployRequest(ctx context.Context, client psclient.PSClient, org, database, branchName, intoBranch string, autoCutover bool) (*ps.DeployRequest, error) {
+func (e *Engine) createDeployRequest(ctx context.Context, client psclient.PSClient, org, database, branchName, intoBranch string, autoCutover, autoDeleteBranch bool) (*ps.DeployRequest, error) {
 	return client.CreateDeployRequest(ctx, &ps.CreateDeployRequestRequest{
 		Organization:     org,
 		Database:         database,
 		Branch:           branchName,
 		IntoBranch:       intoBranch,
 		AutoCutover:      autoCutover,
-		AutoDeleteBranch: true,
+		AutoDeleteBranch: autoDeleteBranch,
 	})
 }
 

--- a/pkg/localscale/handlers_branches.go
+++ b/pkg/localscale/handlers_branches.go
@@ -129,6 +129,55 @@ func (s *Server) handleCreateBranch(w http.ResponseWriter, r *http.Request) erro
 	return nil
 }
 
+// handleRefreshSchema re-snapshots a branch from main. Drops existing branch
+// databases, re-copies schema from vtgate, and marks the branch ready.
+// This is the LocalScale equivalent of PlanetScale's refresh-schema API.
+func (s *Server) handleRefreshSchema(w http.ResponseWriter, r *http.Request) error {
+	org := r.PathValue("org")
+	database := r.PathValue("db")
+	branchName := r.PathValue("branch")
+
+	backend, err := s.backendFor(org, database)
+	if err != nil {
+		return newHTTPError(http.StatusNotFound, "%v", err)
+	}
+
+	// Verify branch exists
+	var ready bool
+	if err := s.metadataDB.QueryRowContext(r.Context(),
+		"SELECT ready FROM localscale_branches WHERE org = ? AND database_name = ? AND name = ?",
+		org, database, branchName,
+	).Scan(&ready); err != nil {
+		return newHTTPError(http.StatusNotFound, "branch %s not found", branchName)
+	}
+
+	// Mark not ready during schema refresh
+	if err := s.execLog(r.Context(),
+		"UPDATE localscale_branches SET ready = FALSE WHERE org = ? AND database_name = ? AND name = ?",
+		org, database, branchName); err != nil {
+		return newHTTPError(http.StatusInternalServerError, "update branch: %v", err)
+	}
+
+	// Drop existing branch databases and re-snapshot from main
+	s.dropBranchDatabases(r.Context(), backend, branchName)
+
+	s.wg.Go(func() {
+		bgCtx := s.shutdownCtx
+		if err := s.snapshotBranch(bgCtx, backend, org, database, branchName); err != nil {
+			s.logger.Error("branch schema refresh failed", "branch", branchName, "error", err)
+			_ = s.execLog(bgCtx,
+				"UPDATE localscale_branches SET error_message = ? WHERE org = ? AND database_name = ? AND name = ?",
+				err.Error(), org, database, branchName)
+		}
+	})
+
+	s.writeJSON(w, map[string]any{
+		"name":  branchName,
+		"ready": false,
+	})
+	return nil
+}
+
 // snapshotBranch creates branch databases, copies schema from vtgate, snapshots
 // VSchema from vtctld, and marks the branch as ready. Called as a background
 // goroutine after the branch row is inserted.

--- a/pkg/localscale/server.go
+++ b/pkg/localscale/server.go
@@ -1104,6 +1104,7 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 
 	// Apply DDL/VSchema to a branch (used by PlanetScale engine before CreateDeployRequest)
 	mux.HandleFunc("POST /v1/organizations/{org}/databases/{db}/branches/{branch}/schema", s.handleError(s.handleApplyBranchSchema))
+	mux.HandleFunc("POST /v1/organizations/{org}/databases/{db}/branches/{branch}/refresh-schema", s.handleError(s.handleRefreshSchema))
 
 	// Deploy request action endpoints (registered before the GET for {number})
 	mux.HandleFunc("POST /v1/organizations/{org}/databases/{db}/deploy-requests/{number}/deploy", s.handleError(s.handleDeployDeployRequest))

--- a/pkg/localscale/server_deploy_integration_test.go
+++ b/pkg/localscale/server_deploy_integration_test.go
@@ -717,3 +717,96 @@ func TestCompleteRevertError(t *testing.T) {
 	verifyColumnNotExists(t, "users", "revert_error_col")
 	t.Logf("Verified revert flow with correct state differentiation for deploy request %d", dr.Number)
 }
+
+// TestRefreshSchema verifies that syncing a branch re-snapshots schema from main.
+func TestRefreshSchema(t *testing.T) {
+	cleanupActiveDeployRequests(t, t.Context())
+	t.Cleanup(func() { cleanupActiveDeployRequests(t, t.Context()) })
+	ctx := t.Context()
+
+	// Create a branch and apply DDL to it
+	branchName := createBranchWithDDL(t, ctx, "refresh-test",
+		map[string][]string{
+			"testapp_sharded": {"ALTER TABLE users ADD COLUMN refresh_test_col VARCHAR(50) NULL"},
+		},
+		nil,
+	)
+
+	// Verify branch has a diff (column was added)
+	branchSchema, err := testClient.GetBranchSchema(ctx, &ps.BranchSchemaRequest{
+		Organization: testOrg, Database: testDB, Branch: branchName, Keyspace: "testapp_sharded",
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, branchSchema, "expected schema diff before refresh")
+
+	// Refresh schema with main — re-snapshots from main, losing the added column
+	err = testClient.RefreshSchema(ctx, testOrg, testDB, branchName)
+	require.NoError(t, err, "RefreshSchema")
+	waitForBranchReady(t, ctx, branchName)
+
+	// Verify the added column is gone after schema refresh — the branch should match main
+	branchSchema, err = testClient.GetBranchSchema(ctx, &ps.BranchSchemaRequest{
+		Organization: testOrg, Database: testDB, Branch: branchName, Keyspace: "testapp_sharded",
+	})
+	require.NoError(t, err)
+	for _, d := range branchSchema {
+		assert.NotContains(t, d.Raw, "refresh_test_col",
+			"branch should not have refresh_test_col after schema refresh (table %s)", d.Name)
+	}
+}
+
+// TestRefreshSchemaAndApply verifies the full --branch reuse workflow:
+// create branch once, then sync + apply DDL multiple times.
+func TestRefreshSchemaAndApply(t *testing.T) {
+	cleanupActiveDeployRequests(t, t.Context())
+	t.Cleanup(func() { cleanupActiveDeployRequests(t, t.Context()) })
+	cancelAllVitessMigrations(t, t.Context())
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Minute)
+	defer cancel()
+
+	// Create a reusable branch
+	branchName := createBranch(t, ctx, "reuse-test")
+
+	// First apply: add a column
+	applyBranchDDL(t, ctx, branchName, map[string][]string{
+		"testapp_sharded": {"ALTER TABLE users ADD COLUMN reuse_col_1 VARCHAR(50) NULL"},
+	})
+	dr := createDeploy(t, ctx, branchName, true)
+	require.Equal(t, drState.Ready, dr.DeploymentState)
+
+	deploy(t, ctx, dr.Number, false)
+	dr = waitForDeployState(t, ctx, dr.Number, drState.CompletePendingRevert, drState.Complete)
+	if dr.DeploymentState == drState.CompletePendingRevert {
+		_, err := testClient.SkipRevertDeployRequest(ctx, &ps.SkipRevertDeployRequestRequest{
+			Organization: testOrg, Database: testDB, Number: dr.Number,
+		})
+		require.NoError(t, err, "SkipRevert")
+		waitForDeployState(t, ctx, dr.Number, drState.Complete)
+	}
+
+	// Refresh schema for reuse
+	err := testClient.RefreshSchema(ctx, testOrg, testDB, branchName)
+	require.NoError(t, err, "RefreshSchema after first apply")
+	waitForBranchReady(t, ctx, branchName)
+
+	// Second apply on same branch: add another column
+	applyBranchDDL(t, ctx, branchName, map[string][]string{
+		"testapp_sharded": {"ALTER TABLE users ADD COLUMN reuse_col_2 VARCHAR(50) NULL"},
+	})
+	dr2 := createDeploy(t, ctx, branchName, true)
+	require.Equal(t, drState.Ready, dr2.DeploymentState)
+
+	deploy(t, ctx, dr2.Number, false)
+	dr2 = waitForDeployState(t, ctx, dr2.Number, drState.CompletePendingRevert, drState.Complete)
+	if dr2.DeploymentState == drState.CompletePendingRevert {
+		_, err = testClient.SkipRevertDeployRequest(ctx, &ps.SkipRevertDeployRequestRequest{
+			Organization: testOrg, Database: testDB, Number: dr2.Number,
+		})
+		require.NoError(t, err, "SkipRevert")
+		waitForDeployState(t, ctx, dr2.Number, drState.Complete)
+	}
+
+	// Verify both columns exist on main
+	verifyColumnExists(t, "users", "reuse_col_1")
+	verifyColumnExists(t, "users", "reuse_col_2")
+}

--- a/pkg/psclient/client.go
+++ b/pkg/psclient/client.go
@@ -17,7 +17,11 @@ type PSClient interface {
 	// Branch operations
 	GetBranch(ctx context.Context, req *ps.GetDatabaseBranchRequest) (*ps.DatabaseBranch, error)
 	CreateBranch(ctx context.Context, req *ps.CreateDatabaseBranchRequest) (*ps.DatabaseBranch, error)
+	DeleteBranch(ctx context.Context, req *ps.DeleteDatabaseBranchRequest) error
 	GetBranchSchema(ctx context.Context, req *ps.BranchSchemaRequest) ([]*ps.Diff, error)
+
+	// RefreshSchema brings a branch's schema up to date with its parent (main).
+	RefreshSchema(ctx context.Context, org, database, branch string) error
 
 	// Branch credentials — returns a MySQL endpoint + credentials for connecting to a branch.
 	// The engine uses this to MySQL-connect and run DDL on the branch directly.
@@ -74,6 +78,7 @@ func NewPSClient(tokenName, tokenValue string, opts ...ps.ClientOption) (PSClien
 	}
 	return &psClientWrapper{
 		client:     client,
+		baseURL:    "https://api.planetscale.com",
 		tokenName:  tokenName,
 		tokenValue: tokenValue,
 	}, nil
@@ -107,6 +112,18 @@ func (w *psClientWrapper) GetBranch(ctx context.Context, req *ps.GetDatabaseBran
 
 func (w *psClientWrapper) CreateBranch(ctx context.Context, req *ps.CreateDatabaseBranchRequest) (*ps.DatabaseBranch, error) {
 	return w.client.DatabaseBranches.Create(ctx, req)
+}
+
+func (w *psClientWrapper) DeleteBranch(ctx context.Context, req *ps.DeleteDatabaseBranchRequest) error {
+	return w.client.DatabaseBranches.Delete(ctx, req)
+}
+
+func (w *psClientWrapper) RefreshSchema(ctx context.Context, org, database, branch string) error {
+	return w.client.DatabaseBranches.RefreshSchema(ctx, &ps.RefreshSchemaRequest{
+		Organization: org,
+		Database:     database,
+		Branch:       branch,
+	})
 }
 
 func (w *psClientWrapper) GetBranchSchema(ctx context.Context, req *ps.BranchSchemaRequest) ([]*ps.Diff, error) {

--- a/pkg/storage/types.go
+++ b/pkg/storage/types.go
@@ -313,22 +313,20 @@ type Apply struct {
 // Stored as JSON in the database for flexibility across engine types.
 type ApplyOptions struct {
 	// AllowUnsafe permits destructive changes (DROP TABLE, DROP COLUMN).
-	// Universal across all engines.
 	AllowUnsafe bool `json:"allow_unsafe,omitempty"`
 
+	// Branch is the name of an existing PlanetScale branch to reuse.
+	// When set, the engine refreshes the branch schema from main instead
+	// of creating a new branch.
+	Branch string `json:"branch,omitempty"`
+
 	// DeferCutover pauses at cutover and waits for explicit trigger.
-	// Spirit: enables atomic multi-table cutover
-	// PlanetScale: waits for manual cutover trigger
-	// Not applicable to direct MySQL DDL.
 	DeferCutover bool `json:"defer_cutover,omitempty"`
 
-	// SkipRevert skips the revert window after completion.
-	// Vitess/PlanetScale only — revert window is ON by default.
+	// SkipRevert skips the revert window after completion (Vitess only).
 	SkipRevert bool `json:"skip_revert,omitempty"`
 
 	// Volume controls schema change aggressiveness (1-11).
-	// Spirit: maps to threads and chunk time
-	// Not all engines support this.
 	Volume int `json:"volume,omitempty"`
 }
 

--- a/pkg/tern/local_client.go
+++ b/pkg/tern/local_client.go
@@ -913,10 +913,19 @@ func (c *LocalClient) Progress(ctx context.Context, req *ternv1.ProgressRequest)
 			resp.Engine = eng
 		}
 		opts := storage.ParseApplyOptions(apply.Options)
-		if opts.Volume > 0 {
-			resp.Volume = int32(opts.Volume)
+		resp.Volume = int32(opts.Volume)
+		if opts.Branch != "" {
+			resp.Metadata = ensureMetadata(resp.Metadata)
+			resp.Metadata["existing_branch"] = opts.Branch
 		}
 	}
 
 	return resp, nil
+}
+
+func ensureMetadata(m map[string]string) map[string]string {
+	if m == nil {
+		return make(map[string]string)
+	}
+	return m
 }


### PR DESCRIPTION
Adds `--branch` flag to `schemabot apply` for reusing an existing PlanetScale branch instead of creating a new one. This skips the 60s+ branch creation wait by refreshing the branch schema from main.

- `--branch <name>` verifies the branch exists, waits for ready, refreshes schema from main via the PlanetScale API, then continues with the normal DDL apply flow
- Rejects `--branch main` on both client and server side
- Preserves reused branches by disabling auto-delete on the deploy request
- Adds `RefreshSchema` to the PS client (uses SDK's `DatabaseBranches.RefreshSchema`)
- Adds `/refresh-schema` endpoint to LocalScale

🤖 Generated with [Claude Code](https://claude.com/claude-code)