### PR TITLE
feat(github): add aggregate check run for branch protection

### DIFF
--- a/pkg/checks/README.md
+++ b/pkg/checks/README.md
@@ -16,7 +16,15 @@ A GitHub Check Run has:
 
 ## Check Run Naming
 
-One check per (environment, database type, database name):
+**Aggregate check** (one per PR):
+
+```
+SchemaBot
+```
+
+This is the only check that needs to be required in branch protection. It rolls up all per-database checks into a single conclusion.
+
+**Per-database checks** (one per environment × database, informational):
 
 ```
 SchemaBot: staging/mysql/payments
@@ -24,7 +32,7 @@ SchemaBot: production/mysql/payments
 SchemaBot: staging/vitess/commerce
 ```
 
-A PR touching one database gets 2 checks (staging + production). A PR touching 3 databases gets 6 checks.
+A PR touching one database gets 2 per-database checks (staging + production) plus 1 aggregate. A PR touching 3 databases gets 6 per-database checks plus 1 aggregate.
 
 ## Lifecycle
 
@@ -253,6 +261,56 @@ When new commits are pushed (`synchronize`), SchemaBot re-discovers which databa
 
 When a PR is closed (merged or not), all locks held by the PR are released and all check records are deleted from storage.
 
-## Aggregate Checks (Future)
+## Aggregate Check
 
-For monorepos with many apps, a single `SchemaBot` aggregate check can roll up all per-database checks. Branch protection requires only the aggregate — per-database checks remain informational.
+The `SchemaBot` aggregate check rolls up all per-database checks into a single conclusion. This solves the monorepo problem: you can't require dynamic per-database check names in branch protection because different PRs produce different names, and new databases would require branch protection updates.
+
+### Aggregate Logic
+
+Priority order (first match wins):
+
+1. ANY per-database check `in_progress` → aggregate status `in_progress`
+2. ANY per-database check `failure` → aggregate `failure`
+3. ANY per-database check `action_required` → aggregate `action_required`
+4. ALL per-database checks `success` → aggregate `success`
+
+PRs that don't touch schema files get no aggregate check — they aren't blocked.
+
+### Branch Protection Setup
+
+Require the `SchemaBot` status check in branch protection. This is a one-time setup that never changes.
+
+**Via the GitHub UI** (after SchemaBot has run on at least one PR):
+
+1. Go to **Settings → Branches → Branch protection rules**
+2. Edit (or add) a rule for your default branch
+3. Enable **Require status checks to pass before merging**
+4. Search for `SchemaBot` in the status check dropdown and select it
+
+**Via the GitHub API** (works before SchemaBot has ever run):
+
+```bash
+gh api repos/{owner}/{repo}/branches/{branch}/protection \
+  --method PUT \
+  --input - <<'EOF'
+{
+  "required_status_checks": {
+    "strict": false,
+    "contexts": ["SchemaBot"]
+  },
+  "enforce_admins": null,
+  "required_pull_request_reviews": null,
+  "restrictions": null
+}
+EOF
+```
+
+### SHA Tracking
+
+Check runs are tied to a specific commit SHA. When new commits are pushed:
+
+- Per-database checks for removed databases are **re-created** on the new SHA as `success`
+- The aggregate check is **re-created** on the new SHA (not updated on the old one)
+- Per-database checks for still-affected databases are re-created by the auto-plan
+
+This ensures all checks are visible on the current HEAD commit in the PR.

--- a/pkg/webhook/apply_handlers.go
+++ b/pkg/webhook/apply_handlers.go
@@ -174,8 +174,10 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 
 	h.postComment(repo, pr, installationID, templates.RenderPlanComment(commentData))
 
-	// Create check run (action_required — waiting for apply-confirm)
-	h.createApplyPlanCheckRun(ctx, client, repo, pr, schemaResult, planResp, environment, installationID)
+	// Create check run (action_required — waiting for apply-confirm) and update aggregate
+	if headSHA := h.createApplyPlanCheckRun(ctx, client, repo, pr, schemaResult, planResp, environment, installationID); headSHA != "" {
+		h.updateAggregateCheck(ctx, client, repo, pr, headSHA)
+	}
 }
 
 // handleApplyConfirmCommand handles the "schemabot apply-confirm -e <env>" PR comment command.
@@ -425,9 +427,9 @@ func (h *Handler) handleUnlockCommand(repo string, pr int, installationID int64,
 
 // createApplyPlanCheckRun creates or updates the check run when an apply plan is posted.
 // Uses the same check name as the plan check run so it updates the existing one.
-func (h *Handler) createApplyPlanCheckRun(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, schema *ghclient.SchemaRequestResult, planResp *apitypes.PlanResponse, environment string, installationID int64) {
-	// Reuse the plan check run infrastructure which stores the check record
-	h.createPlanCheckRun(ctx, client, repo, pr, schema, planResp, environment, installationID)
+// Returns the PR head SHA, or empty string on error.
+func (h *Handler) createApplyPlanCheckRun(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, schema *ghclient.SchemaRequestResult, planResp *apitypes.PlanResponse, environment string, installationID int64) string {
+	return h.createPlanCheckRun(ctx, client, repo, pr, schema, planResp, environment, installationID)
 }
 
 // updateCheckRunForApplyStart updates the existing plan check run to "in_progress"
@@ -448,7 +450,7 @@ func (h *Handler) updateCheckRunForApplyStart(ctx context.Context, client *ghcli
 		checkName := checkRunName(environment, schema.Type, schema.Database)
 		opts := ghclient.CheckRunOptions{
 			Name:   checkName,
-			Status: "in_progress",
+			Status: checkStatusInProgress,
 			Output: &ghclient.CheckRunOutput{
 				Title:   "Schema change in progress",
 				Summary: "Applying schema changes...",
@@ -469,12 +471,15 @@ func (h *Handler) updateCheckRunForApplyStart(ctx context.Context, client *ghcli
 			DatabaseName: schema.Database,
 			CheckRunID:   checkRunID,
 			HasChanges:   true,
-			Status:       "in_progress",
+			Status:       checkStatusInProgress,
 			Conclusion:   "",
 		}
 		if err := h.service.Storage().Checks().Upsert(ctx, newCheck); err != nil {
 			h.logger.Error("failed to upsert new check record", "error", err)
 		}
+
+		// Update aggregate check to reflect in_progress state
+		h.updateAggregateCheck(ctx, client, repo, pr, prInfo.HeadSHA)
 		return
 	}
 
@@ -482,7 +487,7 @@ func (h *Handler) updateCheckRunForApplyStart(ctx context.Context, client *ghcli
 	checkName := checkRunName(check.Environment, check.DatabaseType, check.DatabaseName)
 	opts := ghclient.CheckRunOptions{
 		Name:   checkName,
-		Status: "in_progress",
+		Status: checkStatusInProgress,
 		Output: &ghclient.CheckRunOutput{
 			Title:   "Schema change in progress",
 			Summary: "Applying schema changes...",
@@ -493,11 +498,14 @@ func (h *Handler) updateCheckRunForApplyStart(ctx context.Context, client *ghcli
 	}
 
 	// Update stored record
-	check.Status = "in_progress"
+	check.Status = checkStatusInProgress
 	check.Conclusion = ""
 	if err := h.service.Storage().Checks().Upsert(ctx, check); err != nil {
 		h.logger.Error("failed to upsert check record", "error", err)
 	}
+
+	// Update aggregate check to reflect in_progress state
+	h.updateAggregateCheck(ctx, client, repo, pr, check.HeadSHA)
 }
 
 // updateCheckRunAfterUnlock updates a check run to neutral after lock release.
@@ -518,8 +526,8 @@ func (h *Handler) updateCheckRunAfterUnlock(ctx context.Context, repo string, pr
 
 	opts := ghclient.CheckRunOptions{
 		Name:       checkName,
-		Status:     "completed",
-		Conclusion: "neutral",
+		Status:     checkStatusCompleted,
+		Conclusion: checkConclusionNeutral,
 		Output: &ghclient.CheckRunOutput{
 			Title:   "Lock released",
 			Summary: "Schema change cancelled. Lock has been released.",

--- a/pkg/webhook/apply_handlers.go
+++ b/pkg/webhook/apply_handlers.go
@@ -175,7 +175,11 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 	h.postComment(repo, pr, installationID, templates.RenderPlanComment(commentData))
 
 	// Create check run (action_required — waiting for apply-confirm) and update aggregate
-	if headSHA := h.createApplyPlanCheckRun(ctx, client, repo, pr, schemaResult, planResp, environment, installationID); headSHA != "" {
+	headSHA, checkErr := h.createApplyPlanCheckRun(ctx, client, repo, pr, schemaResult, planResp, environment, installationID)
+	if checkErr != nil {
+		h.logger.Error("failed to create apply plan check run", "repo", repo, "pr", pr, "error", checkErr)
+	}
+	if headSHA != "" {
 		h.updateAggregateCheck(ctx, client, repo, pr, headSHA)
 	}
 }
@@ -427,8 +431,7 @@ func (h *Handler) handleUnlockCommand(repo string, pr int, installationID int64,
 
 // createApplyPlanCheckRun creates or updates the check run when an apply plan is posted.
 // Uses the same check name as the plan check run so it updates the existing one.
-// Returns the PR head SHA, or empty string on error.
-func (h *Handler) createApplyPlanCheckRun(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, schema *ghclient.SchemaRequestResult, planResp *apitypes.PlanResponse, environment string, installationID int64) string {
+func (h *Handler) createApplyPlanCheckRun(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, schema *ghclient.SchemaRequestResult, planResp *apitypes.PlanResponse, environment string, installationID int64) (string, error) {
 	return h.createPlanCheckRun(ctx, client, repo, pr, schema, planResp, environment, installationID)
 }
 

--- a/pkg/webhook/check_runs.go
+++ b/pkg/webhook/check_runs.go
@@ -15,18 +15,53 @@ import (
 // maxCheckRunTextLength is the GitHub API limit for check run output text.
 const maxCheckRunTextLength = 65530
 
+// GitHub Check Run status values.
+const (
+	checkStatusCompleted  = "completed"
+	checkStatusInProgress = "in_progress"
+)
+
+// GitHub Check Run conclusion values.
+const (
+	checkConclusionSuccess        = "success"
+	checkConclusionFailure        = "failure"
+	checkConclusionActionRequired = "action_required"
+	checkConclusionNeutral        = "neutral"
+)
+
+// aggregateCheckName is the single required check name for branch protection.
+// Per-database checks (e.g., "SchemaBot: staging/mysql/orders") are informational;
+// this aggregate reflects the overall state of all schema changes in a PR.
+const aggregateCheckName = "SchemaBot"
+
+// Sentinel values to store the aggregate check record in the checks table,
+// distinct from per-database checks which use real environment/type/database values.
+const (
+	aggregateEnvironment = "_aggregate"
+	aggregateDBType      = "_aggregate"
+	aggregateDBName      = "_aggregate"
+)
+
+// isAggregateCheck returns true if the check is the aggregate (not a per-database check).
+func isAggregateCheck(c *storage.Check) bool {
+	return c.Environment == aggregateEnvironment &&
+		c.DatabaseType == aggregateDBType &&
+		c.DatabaseName == aggregateDBName
+}
+
 // checkRunName returns the canonical check run name for a given environment, database type, and database.
 func checkRunName(environment, dbType, database string) string {
 	return fmt.Sprintf("SchemaBot: %s/%s/%s", environment, dbType, database)
 }
 
 // createPlanCheckRun creates a GitHub Check Run after a plan is generated.
-func (h *Handler) createPlanCheckRun(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, schema *ghclient.SchemaRequestResult, planResp *apitypes.PlanResponse, environment string, installationID int64) {
+// Returns the PR head SHA used for the check run, or empty string on error.
+func (h *Handler) createPlanCheckRun(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, schema *ghclient.SchemaRequestResult, planResp *apitypes.PlanResponse, environment string, installationID int64) string {
 	// Get PR head SHA for the check run
 	prInfo, err := client.FetchPullRequest(ctx, repo, pr)
 	if err != nil {
 		h.logger.Error("failed to fetch PR for check run", "error", err)
-		return
+		return ""
 	}
 
 	tables := planResp.FlatTables()
@@ -39,15 +74,15 @@ func (h *Handler) createPlanCheckRun(ctx context.Context, client *ghclient.Insta
 
 	switch {
 	case len(planResp.Errors) > 0:
-		conclusion = "failure"
+		conclusion = checkConclusionFailure
 		title = "Plan failed"
 		summary = fmt.Sprintf("Plan failed with %d error(s)", len(planResp.Errors))
 	case hasChanges:
-		conclusion = "action_required"
+		conclusion = checkConclusionActionRequired
 		title = fmt.Sprintf("%d schema change(s) detected", len(tables))
 		summary = buildCheckRunSummary(planResp)
 	default:
-		conclusion = "success"
+		conclusion = checkConclusionSuccess
 		title = "No schema changes"
 		summary = "Schema is up to date — no changes detected."
 	}
@@ -57,7 +92,7 @@ func (h *Handler) createPlanCheckRun(ctx context.Context, client *ghclient.Insta
 
 	opts := ghclient.CheckRunOptions{
 		Name:       checkName,
-		Status:     "completed",
+		Status:     checkStatusCompleted,
 		Conclusion: conclusion,
 		Output: &ghclient.CheckRunOutput{
 			Title:   title,
@@ -69,7 +104,7 @@ func (h *Handler) createPlanCheckRun(ctx context.Context, client *ghclient.Insta
 	checkRunID, err := client.CreateCheckRun(ctx, repo, prInfo.HeadSHA, opts)
 	if err != nil {
 		h.logger.Error("failed to create check run", "error", err)
-		return
+		return ""
 	}
 
 	// Store check record in CheckStore
@@ -82,12 +117,14 @@ func (h *Handler) createPlanCheckRun(ctx context.Context, client *ghclient.Insta
 		DatabaseName: schema.Database,
 		CheckRunID:   checkRunID,
 		HasChanges:   hasChanges,
-		Status:       "completed",
+		Status:       checkStatusCompleted,
 		Conclusion:   conclusion,
 	}
 	if err := h.service.Storage().Checks().Upsert(ctx, check); err != nil {
 		h.logger.Error("failed to store check record", "error", err)
 	}
+
+	return prInfo.HeadSHA
 }
 
 // buildCheckRunSummary builds a brief summary for the check run.
@@ -169,11 +206,11 @@ func (h *Handler) updateCheckRunForApplyResult(ctx context.Context, repo string,
 	var conclusion, title, summary string
 	switch apply.State {
 	case state.Apply.Completed:
-		conclusion = "success"
+		conclusion = checkConclusionSuccess
 		title = "Schema changes applied"
 		summary = fmt.Sprintf("All schema changes for `%s` (%s) have been applied successfully.", apply.Database, apply.Environment)
 	case state.Apply.Failed:
-		conclusion = "failure"
+		conclusion = checkConclusionFailure
 		title = "Schema change failed"
 		summary = "The apply failed."
 		if apply.ErrorMessage != "" {
@@ -181,14 +218,14 @@ func (h *Handler) updateCheckRunForApplyResult(ctx context.Context, repo string,
 		}
 	default:
 		// stopped, reverted, or other terminal states
-		conclusion = "failure"
+		conclusion = checkConclusionFailure
 		title = fmt.Sprintf("Schema change %s", apply.State)
 		summary = fmt.Sprintf("The apply was %s.", apply.State)
 	}
 
 	opts := ghclient.CheckRunOptions{
 		Name:       checkRunName(check.Environment, check.DatabaseType, check.DatabaseName),
-		Status:     "completed",
+		Status:     checkStatusCompleted,
 		Conclusion: conclusion,
 		Output: &ghclient.CheckRunOutput{
 			Title:   title,
@@ -203,9 +240,9 @@ func (h *Handler) updateCheckRunForApplyResult(ctx context.Context, repo string,
 	}
 
 	// Update stored check record
-	check.Status = "completed"
+	check.Status = checkStatusCompleted
 	check.Conclusion = conclusion
-	check.HasChanges = conclusion != "success"
+	check.HasChanges = conclusion != checkConclusionSuccess
 	if err := h.service.Storage().Checks().Upsert(ctx, check); err != nil {
 		h.logger.Error("failed to update check record after apply", "error", err)
 	}
@@ -213,6 +250,9 @@ func (h *Handler) updateCheckRunForApplyResult(ctx context.Context, repo string,
 	h.logger.Info("check run updated after apply",
 		"repo", repo, "pr", pr, "database", apply.Database,
 		"environment", apply.Environment, "conclusion", conclusion)
+
+	// Update aggregate check to reflect the terminal state
+	h.updateAggregateCheck(ctx, client, repo, pr, check.HeadSHA)
 }
 
 // checkPriorEnvironments enforces environment ordering: all environments before
@@ -261,16 +301,16 @@ func (h *Handler) checkPriorEnvironments(
 		}
 
 		switch {
-		case check.Conclusion == "success":
+		case check.Conclusion == checkConclusionSuccess:
 			continue
-		case check.Status == "in_progress":
+		case check.Status == checkStatusInProgress:
 			h.postComment(repo, pr, installationID,
 				templates.RenderApplyBlockedByPriorEnvInProgress(database, environment, priorEnv))
 			return true
 		default:
 			status := "has pending changes"
 			action := fmt.Sprintf("Apply %s first", priorEnv)
-			if check.Conclusion == "failure" {
+			if check.Conclusion == checkConclusionFailure {
 				status = "failed"
 				action = fmt.Sprintf("Fix the issue and re-apply %s", priorEnv)
 			}
@@ -281,4 +321,186 @@ func (h *Handler) checkPriorEnvironments(
 	}
 
 	return false
+}
+
+// updateAggregateCheck recomputes and creates/updates the single "SchemaBot" aggregate
+// check run that rolls up all per-database checks for a PR. This is the only check
+// that needs to be required in branch protection — it works regardless of how many
+// databases a PR touches.
+//
+// Aggregate logic (first match wins):
+//   - ANY check "in_progress"     → aggregate status "in_progress"
+//   - ANY check "failure"         → aggregate "failure"
+//   - ANY check "action_required" → aggregate "action_required"
+//   - ALL checks "success"        → aggregate "success"
+//   - NO per-database checks      → no aggregate (PR doesn't touch schema)
+func (h *Handler) updateAggregateCheck(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, headSHA string) {
+	checks, err := h.service.Storage().Checks().GetByPR(ctx, repo, pr)
+	if err != nil {
+		h.logger.Error("failed to fetch checks for aggregate", "repo", repo, "pr", pr, "error", err)
+		return
+	}
+
+	// Filter out the aggregate check itself — only per-database checks contribute
+	var dbChecks []*storage.Check
+	for _, c := range checks {
+		if !isAggregateCheck(c) {
+			dbChecks = append(dbChecks, c)
+		}
+	}
+
+	if len(dbChecks) == 0 {
+		h.logger.Debug("no per-database checks for aggregate", "repo", repo, "pr", pr)
+		return
+	}
+
+	conclusion, status := computeAggregate(dbChecks)
+	title, summary := aggregateSummary(dbChecks, conclusion)
+
+	opts := ghclient.CheckRunOptions{
+		Name:   aggregateCheckName,
+		Status: status,
+		Output: &ghclient.CheckRunOutput{
+			Title:   title,
+			Summary: summary,
+		},
+	}
+	// GitHub requires conclusion only when status is "completed"
+	if status == checkStatusCompleted {
+		opts.Conclusion = conclusion
+	}
+
+	// Look up existing aggregate check record
+	existing, err := h.service.Storage().Checks().Get(ctx, repo, pr, aggregateEnvironment, aggregateDBType, aggregateDBName)
+	if err != nil {
+		h.logger.Error("failed to look up aggregate check", "repo", repo, "pr", pr, "error", err)
+		return
+	}
+
+	// Create a new check run if no existing record, or if the HEAD SHA changed
+	// (new commit pushed). Updating an old check run tied to a previous SHA is
+	// invisible on the PR — GitHub only shows checks for the HEAD commit.
+	var checkRunID int64
+	if existing != nil && existing.CheckRunID != 0 && existing.HeadSHA == headSHA {
+		if err := client.UpdateCheckRun(ctx, repo, existing.CheckRunID, opts); err != nil {
+			h.logger.Error("failed to update aggregate check run", "checkRunID", existing.CheckRunID, "error", err)
+			return
+		}
+		checkRunID = existing.CheckRunID
+	} else {
+		id, err := client.CreateCheckRun(ctx, repo, headSHA, opts)
+		if err != nil {
+			h.logger.Error("failed to create aggregate check run", "error", err)
+			return
+		}
+		checkRunID = id
+	}
+
+	aggCheck := &storage.Check{
+		Repository:   repo,
+		PullRequest:  pr,
+		HeadSHA:      headSHA,
+		Environment:  aggregateEnvironment,
+		DatabaseType: aggregateDBType,
+		DatabaseName: aggregateDBName,
+		CheckRunID:   checkRunID,
+		HasChanges:   conclusion != checkConclusionSuccess,
+		Status:       status,
+		Conclusion:   conclusion,
+	}
+	if err := h.service.Storage().Checks().Upsert(ctx, aggCheck); err != nil {
+		h.logger.Error("failed to store aggregate check record", "error", err)
+	}
+
+	h.logger.Info("aggregate check updated",
+		"repo", repo, "pr", pr, "status", status, "conclusion", conclusion,
+		"per_database_checks", len(dbChecks))
+}
+
+// computeAggregate determines the aggregate conclusion and status from per-database checks.
+func computeAggregate(checks []*storage.Check) (conclusion, status string) {
+	// in_progress takes precedence — the aggregate should show running
+	for _, c := range checks {
+		if c.Status == checkStatusInProgress {
+			return "", checkStatusInProgress
+		}
+	}
+
+	// All checks are completed — compute conclusion
+	for _, c := range checks {
+		if c.Conclusion == checkConclusionFailure {
+			return checkConclusionFailure, checkStatusCompleted
+		}
+	}
+	for _, c := range checks {
+		if c.Conclusion == checkConclusionActionRequired {
+			return checkConclusionActionRequired, checkStatusCompleted
+		}
+	}
+
+	return checkConclusionSuccess, checkStatusCompleted
+}
+
+// aggregateSummary builds a human-readable title and markdown summary for the aggregate check.
+func aggregateSummary(checks []*storage.Check, conclusion string) (title, summary string) {
+	switch conclusion {
+	case checkConclusionSuccess:
+		title = "All schema changes applied"
+		summary = buildAggregateTable(checks)
+	case checkConclusionFailure:
+		title = "Schema change failed"
+		summary = buildAggregateTable(checks)
+	case checkConclusionActionRequired:
+		pending := 0
+		for _, c := range checks {
+			if c.Conclusion == checkConclusionActionRequired {
+				pending++
+			}
+		}
+		title = fmt.Sprintf("%d schema change(s) pending", pending)
+		summary = buildAggregateTable(checks)
+	default:
+		// in_progress — conclusion is empty
+		title = "Schema changes in progress"
+		summary = buildAggregateTable(checks)
+	}
+	return title, summary
+}
+
+// buildAggregateTable builds a markdown table showing the status of each per-database check.
+// Truncates to stay within GitHub's check run output limits.
+func buildAggregateTable(checks []*storage.Check) string {
+	var sb strings.Builder
+	sb.WriteString("| Database | Environment | Status |\n")
+	sb.WriteString("|----------|-------------|--------|\n")
+
+	for i, c := range checks {
+		row := fmt.Sprintf("| `%s` | %s | %s |\n", c.DatabaseName, c.Environment, conclusionEmoji(c.Status, c.Conclusion))
+		if sb.Len()+len(row) > maxCheckRunTextLength-1000 {
+			fmt.Fprintf(&sb, "\n... and %d more check(s)\n", len(checks)-i)
+			break
+		}
+		sb.WriteString(row)
+	}
+
+	return sb.String()
+}
+
+// conclusionEmoji returns a short status label for a check.
+func conclusionEmoji(status, conclusion string) string {
+	if status == checkStatusInProgress {
+		return "In progress"
+	}
+	switch conclusion {
+	case checkConclusionSuccess:
+		return "Applied"
+	case checkConclusionFailure:
+		return "Failed"
+	case checkConclusionActionRequired:
+		return "Pending"
+	case checkConclusionNeutral:
+		return "Cancelled"
+	default:
+		return conclusion
+	}
 }

--- a/pkg/webhook/check_runs.go
+++ b/pkg/webhook/check_runs.go
@@ -53,13 +53,13 @@ func checkRunName(environment, dbType, database string) string {
 }
 
 // createPlanCheckRun creates a GitHub Check Run after a plan is generated.
-// Returns the PR head SHA used for the check run, or empty string on error.
-func (h *Handler) createPlanCheckRun(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, schema *ghclient.SchemaRequestResult, planResp *apitypes.PlanResponse, environment string, installationID int64) string {
+// Returns the PR head SHA used for the check run. Check run failures are non-fatal —
+// they should not prevent the plan from being posted.
+func (h *Handler) createPlanCheckRun(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, schema *ghclient.SchemaRequestResult, planResp *apitypes.PlanResponse, environment string, installationID int64) (string, error) {
 	// Get PR head SHA for the check run
 	prInfo, err := client.FetchPullRequest(ctx, repo, pr)
 	if err != nil {
-		h.logger.Error("failed to fetch PR for check run", "error", err)
-		return ""
+		return "", fmt.Errorf("fetch PR for check run: %w", err)
 	}
 
 	tables := planResp.FlatTables()
@@ -101,8 +101,7 @@ func (h *Handler) createPlanCheckRun(ctx context.Context, client *ghclient.Insta
 
 	checkRunID, err := client.CreateCheckRun(ctx, repo, prInfo.HeadSHA, opts)
 	if err != nil {
-		h.logger.Error("failed to create check run", "error", err)
-		return ""
+		return "", fmt.Errorf("create check run: %w", err)
 	}
 
 	// Store check record in CheckStore
@@ -119,10 +118,10 @@ func (h *Handler) createPlanCheckRun(ctx context.Context, client *ghclient.Insta
 		Conclusion:   conclusion,
 	}
 	if err := h.service.Storage().Checks().Upsert(ctx, check); err != nil {
-		h.logger.Error("failed to store check record", "error", err)
+		return prInfo.HeadSHA, fmt.Errorf("store check record: %w", err)
 	}
 
-	return prInfo.HeadSHA
+	return prInfo.HeadSHA, nil
 }
 
 // buildCheckRunSummary builds a brief summary for the check run.

--- a/pkg/webhook/check_runs.go
+++ b/pkg/webhook/check_runs.go
@@ -29,24 +29,22 @@ const (
 	checkConclusionNeutral        = "neutral"
 )
 
-// aggregateCheckName is the single required check name for branch protection.
-// Per-database checks (e.g., "SchemaBot: staging/mysql/orders") are informational;
-// this aggregate reflects the overall state of all schema changes in a PR.
+// aggregateCheckName is the check name to require in branch protection.
+// Per-database checks (e.g., "SchemaBot: staging/mysql/orders") provide granular
+// visibility per environment and database; the aggregate rolls them into a single
+// conclusion so branch protection only needs one stable name.
 const aggregateCheckName = "SchemaBot"
 
-// Sentinel values to store the aggregate check record in the checks table,
-// distinct from per-database checks which use real environment/type/database values.
-const (
-	aggregateEnvironment = "_aggregate"
-	aggregateDBType      = "_aggregate"
-	aggregateDBName      = "_aggregate"
-)
+// aggregateSentinel is used for environment, database type, and database name when
+// storing the aggregate check record in the checks table. Distinguishes it from
+// per-database checks which use real values.
+const aggregateSentinel = "_aggregate"
 
 // isAggregateCheck returns true if the check is the aggregate (not a per-database check).
 func isAggregateCheck(c *storage.Check) bool {
-	return c.Environment == aggregateEnvironment &&
-		c.DatabaseType == aggregateDBType &&
-		c.DatabaseName == aggregateDBName
+	return c.Environment == aggregateSentinel &&
+		c.DatabaseType == aggregateSentinel &&
+		c.DatabaseName == aggregateSentinel
 }
 
 // checkRunName returns the canonical check run name for a given environment, database type, and database.
@@ -349,6 +347,8 @@ func (h *Handler) updateAggregateCheck(ctx context.Context, client *ghclient.Ins
 		}
 	}
 
+	// No per-database checks means the PR doesn't touch schema files (or all check
+	// records were already deleted by PR close cleanup). No aggregate to create.
 	if len(dbChecks) == 0 {
 		h.logger.Debug("no per-database checks for aggregate", "repo", repo, "pr", pr)
 		return
@@ -371,7 +371,7 @@ func (h *Handler) updateAggregateCheck(ctx context.Context, client *ghclient.Ins
 	}
 
 	// Look up existing aggregate check record
-	existing, err := h.service.Storage().Checks().Get(ctx, repo, pr, aggregateEnvironment, aggregateDBType, aggregateDBName)
+	existing, err := h.service.Storage().Checks().Get(ctx, repo, pr, aggregateSentinel, aggregateSentinel, aggregateSentinel)
 	if err != nil {
 		h.logger.Error("failed to look up aggregate check", "repo", repo, "pr", pr, "error", err)
 		return
@@ -388,6 +388,11 @@ func (h *Handler) updateAggregateCheck(ctx context.Context, client *ghclient.Ins
 		}
 		checkRunID = existing.CheckRunID
 	} else {
+		if existing != nil && existing.HeadSHA != headSHA {
+			h.logger.Info("re-creating aggregate check on new HEAD SHA",
+				"repo", repo, "pr", pr,
+				"old_sha", existing.HeadSHA, "new_sha", headSHA)
+		}
 		id, err := client.CreateCheckRun(ctx, repo, headSHA, opts)
 		if err != nil {
 			h.logger.Error("failed to create aggregate check run", "error", err)
@@ -400,9 +405,9 @@ func (h *Handler) updateAggregateCheck(ctx context.Context, client *ghclient.Ins
 		Repository:   repo,
 		PullRequest:  pr,
 		HeadSHA:      headSHA,
-		Environment:  aggregateEnvironment,
-		DatabaseType: aggregateDBType,
-		DatabaseName: aggregateDBName,
+		Environment:  aggregateSentinel,
+		DatabaseType: aggregateSentinel,
+		DatabaseName: aggregateSentinel,
 		CheckRunID:   checkRunID,
 		HasChanges:   conclusion != checkConclusionSuccess,
 		Status:       status,

--- a/pkg/webhook/check_runs_test.go
+++ b/pkg/webhook/check_runs_test.go
@@ -1,0 +1,132 @@
+package webhook
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/block/schemabot/pkg/storage"
+)
+
+func TestComputeAggregate(t *testing.T) {
+	tests := []struct {
+		name           string
+		checks         []*storage.Check
+		wantConclusion string
+		wantStatus     string
+	}{
+		{
+			name: "all success",
+			checks: []*storage.Check{
+				{Status: checkStatusCompleted, Conclusion: checkConclusionSuccess},
+				{Status: checkStatusCompleted, Conclusion: checkConclusionSuccess},
+			},
+			wantConclusion: checkConclusionSuccess,
+			wantStatus:     checkStatusCompleted,
+		},
+		{
+			name: "any failure dominates",
+			checks: []*storage.Check{
+				{Status: checkStatusCompleted, Conclusion: checkConclusionSuccess},
+				{Status: checkStatusCompleted, Conclusion: checkConclusionFailure},
+				{Status: checkStatusCompleted, Conclusion: checkConclusionActionRequired},
+			},
+			wantConclusion: checkConclusionFailure,
+			wantStatus:     checkStatusCompleted,
+		},
+		{
+			name: "action_required when no failure",
+			checks: []*storage.Check{
+				{Status: checkStatusCompleted, Conclusion: checkConclusionSuccess},
+				{Status: checkStatusCompleted, Conclusion: checkConclusionActionRequired},
+			},
+			wantConclusion: checkConclusionActionRequired,
+			wantStatus:     checkStatusCompleted,
+		},
+		{
+			name: "in_progress takes priority over conclusions",
+			checks: []*storage.Check{
+				{Status: checkStatusCompleted, Conclusion: checkConclusionSuccess},
+				{Status: checkStatusInProgress, Conclusion: ""},
+				{Status: checkStatusCompleted, Conclusion: checkConclusionFailure},
+			},
+			wantConclusion: "", // in_progress has no conclusion
+			wantStatus:     checkStatusInProgress,
+		},
+		{
+			name: "single check success",
+			checks: []*storage.Check{
+				{Status: checkStatusCompleted, Conclusion: checkConclusionSuccess},
+			},
+			wantConclusion: checkConclusionSuccess,
+			wantStatus:     checkStatusCompleted,
+		},
+		{
+			name: "single check action_required",
+			checks: []*storage.Check{
+				{Status: checkStatusCompleted, Conclusion: checkConclusionActionRequired},
+			},
+			wantConclusion: checkConclusionActionRequired,
+			wantStatus:     checkStatusCompleted,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conclusion, status := computeAggregate(tt.checks)
+			assert.Equal(t, tt.wantConclusion, conclusion)
+			assert.Equal(t, tt.wantStatus, status)
+		})
+	}
+}
+
+func TestIsAggregateCheck(t *testing.T) {
+	aggregate := &storage.Check{
+		Environment:  aggregateEnvironment,
+		DatabaseType: aggregateDBType,
+		DatabaseName: aggregateDBName,
+	}
+	require.True(t, isAggregateCheck(aggregate))
+
+	perDB := &storage.Check{
+		Environment:  "staging",
+		DatabaseType: "mysql",
+		DatabaseName: "orders",
+	}
+	require.False(t, isAggregateCheck(perDB))
+}
+
+func TestAggregateSummary(t *testing.T) {
+	checks := []*storage.Check{
+		{DatabaseName: "orders", Environment: "staging", Status: checkStatusCompleted, Conclusion: checkConclusionSuccess},
+		{DatabaseName: "orders", Environment: "production", Status: checkStatusCompleted, Conclusion: checkConclusionActionRequired},
+	}
+
+	title, summary := aggregateSummary(checks, checkConclusionActionRequired)
+
+	assert.Contains(t, title, "1 schema change(s) pending")
+	assert.Contains(t, summary, "`orders`")
+	assert.Contains(t, summary, "staging")
+	assert.Contains(t, summary, "production")
+	assert.Contains(t, summary, "Applied")
+	assert.Contains(t, summary, "Pending")
+}
+
+func TestAggregateSummary_AllSuccess(t *testing.T) {
+	checks := []*storage.Check{
+		{DatabaseName: "orders", Environment: "staging", Status: checkStatusCompleted, Conclusion: checkConclusionSuccess},
+		{DatabaseName: "orders", Environment: "production", Status: checkStatusCompleted, Conclusion: checkConclusionSuccess},
+	}
+
+	title, _ := aggregateSummary(checks, checkConclusionSuccess)
+	assert.Equal(t, "All schema changes applied", title)
+}
+
+func TestConclusionEmoji(t *testing.T) {
+	assert.Equal(t, "Applied", conclusionEmoji(checkStatusCompleted, checkConclusionSuccess))
+	assert.Equal(t, "Failed", conclusionEmoji(checkStatusCompleted, checkConclusionFailure))
+	assert.Equal(t, "Pending", conclusionEmoji(checkStatusCompleted, checkConclusionActionRequired))
+	assert.Equal(t, "In progress", conclusionEmoji(checkStatusInProgress, ""))
+	assert.Equal(t, "Cancelled", conclusionEmoji(checkStatusCompleted, checkConclusionNeutral))
+}

--- a/pkg/webhook/check_runs_test.go
+++ b/pkg/webhook/check_runs_test.go
@@ -83,9 +83,9 @@ func TestComputeAggregate(t *testing.T) {
 
 func TestIsAggregateCheck(t *testing.T) {
 	aggregate := &storage.Check{
-		Environment:  aggregateEnvironment,
-		DatabaseType: aggregateDBType,
-		DatabaseName: aggregateDBName,
+		Environment:  aggregateSentinel,
+		DatabaseType: aggregateSentinel,
+		DatabaseName: aggregateSentinel,
 	}
 	require.True(t, isAggregateCheck(aggregate))
 

--- a/pkg/webhook/plan.go
+++ b/pkg/webhook/plan.go
@@ -68,7 +68,10 @@ func (h *Handler) handlePlanCommand(w http.ResponseWriter, repo string, pr int, 
 	h.postComment(repo, pr, installationID, templates.RenderPlanComment(commentData))
 
 	// Create check run and update aggregate
-	headSHA := h.createPlanCheckRun(ctx, client, repo, pr, schemaResult, planResp, environment, installationID)
+	headSHA, checkErr := h.createPlanCheckRun(ctx, client, repo, pr, schemaResult, planResp, environment, installationID)
+	if checkErr != nil {
+		h.logger.Error("failed to create plan check run", "repo", repo, "pr", pr, "error", checkErr)
+	}
 	if headSHA != "" {
 		h.updateAggregateCheck(ctx, client, repo, pr, headSHA)
 	}
@@ -156,7 +159,11 @@ func (h *Handler) handleMultiEnvPlan(repo string, pr int, databaseName string, i
 		multiEnvData.Plans[env] = &commentData
 
 		// Create check run per environment
-		if sha := h.createPlanCheckRun(ctx, client, repo, pr, schemaResult, planResp, env, installationID); sha != "" {
+		sha, checkErr := h.createPlanCheckRun(ctx, client, repo, pr, schemaResult, planResp, env, installationID)
+		if checkErr != nil {
+			h.logger.Error("failed to create plan check run", "repo", repo, "pr", pr, "env", env, "error", checkErr)
+		}
+		if sha != "" {
 			headSHA = sha
 		}
 	}

--- a/pkg/webhook/plan.go
+++ b/pkg/webhook/plan.go
@@ -67,8 +67,11 @@ func (h *Handler) handlePlanCommand(w http.ResponseWriter, repo string, pr int, 
 	// Post plan comment
 	h.postComment(repo, pr, installationID, templates.RenderPlanComment(commentData))
 
-	// Create check run
-	h.createPlanCheckRun(ctx, client, repo, pr, schemaResult, planResp, environment, installationID)
+	// Create check run and update aggregate
+	headSHA := h.createPlanCheckRun(ctx, client, repo, pr, schemaResult, planResp, environment, installationID)
+	if headSHA != "" {
+		h.updateAggregateCheck(ctx, client, repo, pr, headSHA)
+	}
 
 	h.writeJSON(w, http.StatusOK, map[string]string{
 		"message": "plan generated successfully",
@@ -107,6 +110,7 @@ func (h *Handler) handleMultiEnvPlan(repo string, pr int, databaseName string, i
 	}
 
 	// Collect plans for all environments
+	var headSHA string
 	multiEnvData := templates.MultiEnvPlanCommentData{
 		RequestedBy:  requestedBy,
 		Environments: environments,
@@ -152,7 +156,14 @@ func (h *Handler) handleMultiEnvPlan(repo string, pr int, databaseName string, i
 		multiEnvData.Plans[env] = &commentData
 
 		// Create check run per environment
-		h.createPlanCheckRun(ctx, client, repo, pr, schemaResult, planResp, env, installationID)
+		if sha := h.createPlanCheckRun(ctx, client, repo, pr, schemaResult, planResp, env, installationID); sha != "" {
+			headSHA = sha
+		}
+	}
+
+	// Update aggregate check once after all environments are planned
+	if headSHA != "" {
+		h.updateAggregateCheck(ctx, client, repo, pr, headSHA)
 	}
 
 	// Auto-plan: skip comment if no changes and no errors (reduce PR noise)

--- a/pkg/webhook/pull_request.go
+++ b/pkg/webhook/pull_request.go
@@ -96,9 +96,11 @@ func (h *Handler) handlePullRequest(w http.ResponseWriter, body []byte) {
 		affectedDatabases[cfg.Config.Database] = true
 	}
 
-	// Clean up stale checks from databases no longer in the PR
+	// Clean up stale checks from databases no longer in the PR.
+	// Pass the new HEAD SHA so cleanup can create new check runs on the correct commit.
+	headSHA := payload.PullRequest.Head.SHA
 	h.goSafe(repo, pr, installationID, func() {
-		h.cleanupStaleChecks(repo, pr, installationID, affectedDatabases)
+		h.cleanupStaleChecks(repo, pr, headSHA, installationID, affectedDatabases)
 	})
 
 	if len(configs) == 0 {
@@ -155,7 +157,11 @@ func (h *Handler) handlePRClosed(repo string, pr int, _ int64) {
 // cleanupStaleChecks marks checks for databases no longer in the PR as "success".
 // This handles the case where a user removes a schema change from the PR — the old
 // check would otherwise stay at "action_required" and block merge.
-func (h *Handler) cleanupStaleChecks(repo string, pr int, installationID int64, affectedDatabases map[string]bool) {
+//
+// On synchronize events, headSHA is the new commit SHA. Stale checks must be created
+// as new check runs on this SHA (not updated on the old SHA) so GitHub shows them
+// on the current commit.
+func (h *Handler) cleanupStaleChecks(repo string, pr int, headSHA string, installationID int64, affectedDatabases map[string]bool) {
 	if h.service == nil {
 		return
 	}
@@ -169,7 +175,15 @@ func (h *Handler) cleanupStaleChecks(repo string, pr int, installationID int64, 
 		return
 	}
 
+	var client *ghclient.InstallationClient
+	cleaned := false
+
 	for _, check := range checks {
+		// Skip the aggregate check — it's recomputed, not cleaned up
+		if isAggregateCheck(check) {
+			continue
+		}
+
 		if affectedDatabases[check.DatabaseName] {
 			continue // still affected, not stale
 		}
@@ -180,34 +194,46 @@ func (h *Handler) cleanupStaleChecks(repo string, pr int, installationID int64, 
 			"database", check.DatabaseName, "environment", check.Environment,
 			"previous_conclusion", check.Conclusion)
 
-		if check.CheckRunID > 0 {
-			client, err := h.ghClient.ForInstallation(installationID)
+		if client == nil {
+			client, err = h.ghClient.ForInstallation(installationID)
 			if err != nil {
 				h.logger.Error("failed to create GitHub client for stale check cleanup", "error", err)
-				continue
-			}
-
-			checkName := checkRunName(check.Environment, check.DatabaseType, check.DatabaseName)
-			opts := ghclient.CheckRunOptions{
-				Name:       checkName,
-				Status:     "completed",
-				Conclusion: "success",
-				Output: &ghclient.CheckRunOutput{
-					Title:   "No schema changes",
-					Summary: "Schema files for this database were removed from the PR.",
-				},
-			}
-			if err := client.UpdateCheckRun(ctx, repo, check.CheckRunID, opts); err != nil {
-				h.logger.Error("failed to update stale check run", "checkRunID", check.CheckRunID, "error", err)
+				return
 			}
 		}
 
-		// Update stored check record to reflect success
-		check.Conclusion = "success"
+		// Create a new check run on the current HEAD SHA so it shows on the latest commit.
+		// Updating the old check run (tied to the previous SHA) would be invisible in the PR.
+		checkName := checkRunName(check.Environment, check.DatabaseType, check.DatabaseName)
+		opts := ghclient.CheckRunOptions{
+			Name:       checkName,
+			Status:     checkStatusCompleted,
+			Conclusion: checkConclusionSuccess,
+			Output: &ghclient.CheckRunOutput{
+				Title:   "No schema changes",
+				Summary: "Schema files for this database were removed from the PR.",
+			},
+		}
+		newCheckRunID, createErr := client.CreateCheckRun(ctx, repo, headSHA, opts)
+		if createErr != nil {
+			h.logger.Error("failed to create stale check run on new SHA", "error", createErr)
+			continue
+		}
+
+		// Update stored check record with new check run ID and SHA
+		check.CheckRunID = newCheckRunID
+		check.HeadSHA = headSHA
+		check.Conclusion = checkConclusionSuccess
 		check.HasChanges = false
-		check.Status = "completed"
+		check.Status = checkStatusCompleted
 		if err := h.service.Storage().Checks().Upsert(ctx, check); err != nil {
 			h.logger.Error("failed to update stale check record", "checkID", check.ID, "error", err)
 		}
+		cleaned = true
+	}
+
+	// Recompute aggregate on the new HEAD SHA after cleaning up stale checks
+	if cleaned && client != nil {
+		h.updateAggregateCheck(ctx, client, repo, pr, headSHA)
 	}
 }

--- a/pkg/webhook/webhook_e2e_test.go
+++ b/pkg/webhook/webhook_e2e_test.go
@@ -1127,7 +1127,7 @@ func TestE2EAggregateCheck(t *testing.T) {
 	// Verify aggregate check record persisted in storage
 	ctx := t.Context()
 	aggCheck, err := svc.Storage().Checks().Get(ctx, "octocat/hello-world", 1,
-		aggregateEnvironment, aggregateDBType, aggregateDBName)
+		aggregateSentinel, aggregateSentinel, aggregateSentinel)
 	require.NoError(t, err)
 	require.NotNil(t, aggCheck, "expected aggregate check record in storage")
 	assert.Equal(t, "action_required", aggCheck.Conclusion)
@@ -1165,9 +1165,9 @@ func TestE2EAggregateCheckStaleCleanup(t *testing.T) {
 		Repository:   "octocat/hello-world",
 		PullRequest:  1,
 		HeadSHA:      "oldsha111",
-		Environment:  aggregateEnvironment,
-		DatabaseType: aggregateDBType,
-		DatabaseName: aggregateDBName,
+		Environment:  aggregateSentinel,
+		DatabaseType: aggregateSentinel,
+		DatabaseName: aggregateSentinel,
 		CheckRunID:   200,
 		HasChanges:   true,
 		Status:       checkStatusCompleted,
@@ -1274,7 +1274,7 @@ func TestE2EAggregateCheckStaleCleanup(t *testing.T) {
 	deadline2 := time.After(5 * time.Second)
 	for {
 		storedAgg, aggErr = svc.Storage().Checks().Get(ctx, "octocat/hello-world", 1,
-			aggregateEnvironment, aggregateDBType, aggregateDBName)
+			aggregateSentinel, aggregateSentinel, aggregateSentinel)
 		if aggErr == nil && storedAgg != nil && storedAgg.HeadSHA == "newsha222" {
 			break
 		}
@@ -1929,7 +1929,8 @@ func TestE2EMultiAppAutoPlan(t *testing.T) {
 		t.Fatal("timed out waiting for plan comment")
 	}
 
-	// Check runs should be for payments only (plus the aggregate)
+	// Check runs should be for payments only (1 per-database + 1 aggregate).
+	// This test uses a single-env setup, so expect exactly 1 per-database check.
 	var perDBCheckNames []string
 	hasAggregate := false
 	deadline := time.After(5 * time.Second)
@@ -1941,7 +1942,7 @@ func TestE2EMultiAppAutoPlan(t *testing.T) {
 			} else {
 				perDBCheckNames = append(perDBCheckNames, cr.Name)
 			}
-			if len(perDBCheckNames) >= 2 && hasAggregate {
+			if len(perDBCheckNames) >= 1 && hasAggregate {
 				goto checksDone
 			}
 		case <-deadline:
@@ -1950,6 +1951,7 @@ func TestE2EMultiAppAutoPlan(t *testing.T) {
 	}
 checksDone:
 	assert.True(t, hasAggregate, "expected aggregate check run")
+	require.NotEmpty(t, perDBCheckNames, "expected at least one per-database check run")
 	for _, name := range perDBCheckNames {
 		assert.Contains(t, name, "payments", "check run should be for payments: %s", name)
 		assert.NotContains(t, name, "orders", "check run should NOT be for orders: %s", name)

--- a/pkg/webhook/webhook_e2e_test.go
+++ b/pkg/webhook/webhook_e2e_test.go
@@ -71,6 +71,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -373,13 +374,15 @@ func setupFakeGitHubForPlan(t *testing.T, mux *http.ServeMux, schemaSQL map[stri
 		_ = json.NewEncoder(w).Encode(map[string]any{"id": 1})
 	})
 
-	// Capture check run creates
+	// Capture check run creates (incrementing IDs so aggregate can distinguish create vs update)
+	var checkRunIDCounter atomic.Int64
 	mux.HandleFunc("POST /repos/octocat/hello-world/check-runs", func(w http.ResponseWriter, r *http.Request) {
 		var body checkRunCapture
 		_ = json.NewDecoder(r.Body).Decode(&body)
 		result.checkRuns <- body
+		id := checkRunIDCounter.Add(1)
 		w.WriteHeader(http.StatusCreated)
-		_ = json.NewEncoder(w).Encode(map[string]any{"id": 1})
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": id})
 	})
 
 	// Capture check run updates (PATCH)
@@ -440,7 +443,7 @@ func TestE2EPlanWithChanges(t *testing.T) {
 		t.Fatal("timed out waiting for plan comment")
 	}
 
-	// Verify check run was created
+	// Verify check run was created (per-database + aggregate)
 	select {
 	case cr := <-result.checkRuns:
 		assert.Contains(t, cr.Name, "SchemaBot")
@@ -670,7 +673,7 @@ func TestE2EMultiEnvPlan(t *testing.T) {
 		t.Fatal("timed out waiting for multi-env plan comment")
 	}
 
-	// Should get check runs for both environments
+	// Should get check runs for both environments (plus aggregate updates on the channel)
 	checkRunNames := make(map[string]bool)
 	for i := range 2 {
 		select {
@@ -1059,6 +1062,230 @@ func setupE2EServiceMultiEnv(t *testing.T, appDBName string) *api.Service {
 	t.Cleanup(func() { _ = svc.Close() })
 
 	return svc
+}
+
+// TestE2EAggregateCheck verifies that a multi-env plan creates a single aggregate
+// "SchemaBot" check run that rolls up per-database checks, and that the aggregate
+// record is persisted in storage with the correct conclusion.
+func TestE2EAggregateCheck(t *testing.T) {
+	dbName := "webhook_aggregate_check"
+	svc := setupE2EServiceMultiEnv(t, dbName)
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	client := gh.NewClient(nil)
+	client.BaseURL, _ = url.Parse(server.URL + "/")
+
+	schemabotConfig := fmt.Sprintf("database: %s\ntype: mysql\nenvironments:\n  - staging\n  - production\n", dbName)
+	schemaFiles := map[string]string{
+		"users.sql": "CREATE TABLE `users` (\n  `id` bigint unsigned NOT NULL AUTO_INCREMENT,\n  `name` varchar(255) NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;",
+	}
+
+	result := setupFakeGitHubForPlan(t, mux, schemaFiles, schemabotConfig, dbName)
+	h := newE2EHandler(t, svc, client)
+
+	// Trigger multi-env plan
+	req := buildWebhookRequest(t, webhookPayloadOpts{
+		comment: "schemabot plan",
+		isPR:    true,
+	}, nil)
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	// Drain the comment
+	select {
+	case <-result.comments:
+	case <-time.After(30 * time.Second):
+		t.Fatal("timed out waiting for plan comment")
+	}
+
+	// Collect all check runs: 2 per-database + 1 aggregate = 3 total
+	checkRuns := make(map[string]checkRunCapture)
+	for range 3 {
+		select {
+		case cr := <-result.checkRuns:
+			checkRuns[cr.Name] = cr
+		case <-time.After(30 * time.Second):
+			t.Fatalf("timed out waiting for check runs, got %d so far: %v", len(checkRuns), checkRuns)
+		}
+	}
+
+	// Per-database checks exist
+	assert.Contains(t, checkRuns, "SchemaBot: staging/mysql/"+dbName)
+	assert.Contains(t, checkRuns, "SchemaBot: production/mysql/"+dbName)
+
+	// Aggregate check exists with correct conclusion
+	aggCR, ok := checkRuns["SchemaBot"]
+	require.True(t, ok, "expected aggregate check run named 'SchemaBot'")
+	assert.Equal(t, "completed", aggCR.Status)
+	assert.Equal(t, "action_required", aggCR.Conclusion)
+
+	// Verify aggregate check record persisted in storage
+	ctx := t.Context()
+	aggCheck, err := svc.Storage().Checks().Get(ctx, "octocat/hello-world", 1,
+		aggregateEnvironment, aggregateDBType, aggregateDBName)
+	require.NoError(t, err)
+	require.NotNil(t, aggCheck, "expected aggregate check record in storage")
+	assert.Equal(t, "action_required", aggCheck.Conclusion)
+	assert.Equal(t, "completed", aggCheck.Status)
+	assert.True(t, aggCheck.HasChanges)
+	assert.Equal(t, "abc123", aggCheck.HeadSHA)
+}
+
+// TestE2EAggregateCheckStaleCleanup verifies that when a new commit removes all schema
+// changes from a PR, the stale per-database checks and aggregate check are re-created
+// on the new HEAD SHA with "success" conclusion. This reproduces the scenario where a
+// user pushes a commit that reverts their schema change.
+func TestE2EAggregateCheckStaleCleanup(t *testing.T) {
+	dbName := "webhook_aggregate_stale"
+	svc := setupE2EServiceMultiEnv(t, dbName)
+	ctx := t.Context()
+
+	// Seed per-database checks and aggregate as if a plan already ran on the first commit.
+	for _, env := range []string{"staging", "production"} {
+		check := &storage.Check{
+			Repository:   "octocat/hello-world",
+			PullRequest:  1,
+			HeadSHA:      "oldsha111",
+			Environment:  env,
+			DatabaseType: "mysql",
+			DatabaseName: dbName,
+			CheckRunID:   100,
+			HasChanges:   true,
+			Status:       checkStatusCompleted,
+			Conclusion:   checkConclusionActionRequired,
+		}
+		require.NoError(t, svc.Storage().Checks().Upsert(ctx, check))
+	}
+	aggCheck := &storage.Check{
+		Repository:   "octocat/hello-world",
+		PullRequest:  1,
+		HeadSHA:      "oldsha111",
+		Environment:  aggregateEnvironment,
+		DatabaseType: aggregateDBType,
+		DatabaseName: aggregateDBName,
+		CheckRunID:   200,
+		HasChanges:   true,
+		Status:       checkStatusCompleted,
+		Conclusion:   checkConclusionActionRequired,
+	}
+	require.NoError(t, svc.Storage().Checks().Upsert(ctx, aggCheck))
+
+	// Set up fake GitHub server that returns NO changed files (simulating revert commit)
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	client := gh.NewClient(nil)
+	client.BaseURL, _ = url.Parse(server.URL + "/")
+
+	// PR info with new HEAD SHA
+	mux.HandleFunc("GET /repos/octocat/hello-world/pulls/1", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(gh.PullRequest{
+			Head: &gh.PullRequestBranch{
+				Ref: new("feature-branch"),
+				SHA: new("newsha222"),
+			},
+			Base: &gh.PullRequestBranch{
+				Ref: new("main"),
+				SHA: new("def456"),
+			},
+			User: &gh.User{Login: new("testuser")},
+		})
+	})
+
+	// Empty PR files — the revert commit means no schema files changed
+	mux.HandleFunc("GET /repos/octocat/hello-world/pulls/1/files", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode([]*gh.CommitFile{})
+	})
+
+	// Capture check run creates on the new SHA
+	checkRuns := make(chan checkRunCapture, 10)
+	var checkRunIDCounter atomic.Int64
+	checkRunIDCounter.Store(300)
+	mux.HandleFunc("POST /repos/octocat/hello-world/check-runs", func(w http.ResponseWriter, r *http.Request) {
+		var body checkRunCapture
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		checkRuns <- body
+		id := checkRunIDCounter.Add(1)
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": id})
+	})
+
+	h := newE2EHandler(t, svc, client)
+
+	// Send synchronize event with new HEAD SHA
+	req := buildPRWebhookRequest(t, prWebhookPayloadOpts{
+		action:  "synchronize",
+		headSHA: "newsha222",
+	}, nil)
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	// cleanupStaleChecks runs async via goSafe — collect the 3 new check runs
+	// (2 per-database + 1 aggregate, all created on the new SHA with success)
+	newCheckRuns := make(map[string]checkRunCapture)
+	for range 3 {
+		select {
+		case cr := <-checkRuns:
+			newCheckRuns[cr.Name] = cr
+		case <-time.After(10 * time.Second):
+			t.Fatalf("timed out waiting for stale cleanup check runs, got %d: %v", len(newCheckRuns), newCheckRuns)
+		}
+	}
+
+	// Per-database checks re-created as success
+	for _, name := range []string{
+		"SchemaBot: staging/mysql/" + dbName,
+		"SchemaBot: production/mysql/" + dbName,
+	} {
+		cr, ok := newCheckRuns[name]
+		require.True(t, ok, "expected check run %s", name)
+		assert.Equal(t, checkStatusCompleted, cr.Status)
+		assert.Equal(t, checkConclusionSuccess, cr.Conclusion)
+	}
+
+	// Aggregate check re-created as success
+	aggCR, ok := newCheckRuns[aggregateCheckName]
+	require.True(t, ok, "expected aggregate check run")
+	assert.Equal(t, checkStatusCompleted, aggCR.Status)
+	assert.Equal(t, checkConclusionSuccess, aggCR.Conclusion)
+
+	// Verify storage records updated with new SHA
+	for _, env := range []string{"staging", "production"} {
+		check, err := svc.Storage().Checks().Get(ctx, "octocat/hello-world", 1, env, "mysql", dbName)
+		require.NoError(t, err)
+		require.NotNil(t, check)
+		assert.Equal(t, "newsha222", check.HeadSHA, "check should have new HEAD SHA")
+		assert.Equal(t, checkConclusionSuccess, check.Conclusion)
+		assert.False(t, check.HasChanges)
+	}
+
+	// Poll for aggregate storage update — the Upsert runs after the GitHub API call
+	// that sends the check run to the channel, so there's a brief race.
+	var storedAgg *storage.Check
+	var aggErr error
+	deadline2 := time.After(5 * time.Second)
+	for {
+		storedAgg, aggErr = svc.Storage().Checks().Get(ctx, "octocat/hello-world", 1,
+			aggregateEnvironment, aggregateDBType, aggregateDBName)
+		if aggErr == nil && storedAgg != nil && storedAgg.HeadSHA == "newsha222" {
+			break
+		}
+		select {
+		case <-deadline2:
+			t.Fatal("timed out waiting for aggregate storage update")
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
+	assert.Equal(t, checkConclusionSuccess, storedAgg.Conclusion)
+	assert.False(t, storedAgg.HasChanges)
 }
 
 // TestE2EPlanUsesRepoDeployment verifies that the webhook plan handler routes
@@ -1702,14 +1929,19 @@ func TestE2EMultiAppAutoPlan(t *testing.T) {
 		t.Fatal("timed out waiting for plan comment")
 	}
 
-	// Check runs should be for payments only
-	var checkNames []string
+	// Check runs should be for payments only (plus the aggregate)
+	var perDBCheckNames []string
+	hasAggregate := false
 	deadline := time.After(5 * time.Second)
 	for {
 		select {
 		case cr := <-result.checkRuns:
-			checkNames = append(checkNames, cr.Name)
-			if len(checkNames) >= 2 { // staging + production
+			if cr.Name == aggregateCheckName {
+				hasAggregate = true
+			} else {
+				perDBCheckNames = append(perDBCheckNames, cr.Name)
+			}
+			if len(perDBCheckNames) >= 2 && hasAggregate {
 				goto checksDone
 			}
 		case <-deadline:
@@ -1717,7 +1949,8 @@ func TestE2EMultiAppAutoPlan(t *testing.T) {
 		}
 	}
 checksDone:
-	for _, name := range checkNames {
+	assert.True(t, hasAggregate, "expected aggregate check run")
+	for _, name := range perDBCheckNames {
 		assert.Contains(t, name, "payments", "check run should be for payments: %s", name)
 		assert.NotContains(t, name, "orders", "check run should NOT be for orders: %s", name)
 	}


### PR DESCRIPTION
Adds a single aggregate check run named `SchemaBot` that rolls up all per-database checks into one conclusion. This is the only check name that needs to be required in branch protection — it works regardless of how many databases or environments a PR touches.

Per-database checks like `SchemaBot: staging/mysql/orders` are still created for visibility but don't need to be required. The aggregate conclusion follows priority order: any in_progress → any failure → any action_required → all success. Its output includes a markdown table showing each database/environment status.

Key behaviors:
- Created once per plan operation (not per environment), updated on apply start/result
- On new commits (`synchronize`), stale per-database checks and the aggregate are re-created on the new HEAD SHA so they appear on the current commit
- PRs that don't touch schema files get no aggregate check (doesn't block merge)
- Cleaned up automatically on PR close via the existing `DeleteByPR` path