### PR TITLE
feat(observability): add docker-compose telemetry overlay with Grafana

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ else
   GOTEST := go test
 endif
 
-.PHONY: help lint lint-fix setup test test-unit test-e2e test-e2e-grpc test-e2e-local-down test-e2e-mysql test-e2e-vitess test-integration test-localscale build-localscale-image test-coverage build install clean proto up up-grpc down down-grpc status mysql logs logs-grpc test-endpoints plan-testapp apply-testapp seed-testapp seed-testapp-large seed-vitess demo demo-vitess demo-grpc demo-grpc-logs wait-healthy wait-healthy-grpc wait-localscale cli
+.PHONY: help lint lint-fix setup test test-unit test-e2e test-e2e-grpc test-e2e-local-down test-e2e-mysql test-e2e-vitess test-integration test-localscale build-localscale-image test-coverage build install clean proto up up-telemetry up-grpc down down-grpc status mysql logs logs-grpc test-endpoints plan-testapp apply-testapp seed-testapp seed-testapp-large seed-vitess demo demo-vitess demo-grpc demo-grpc-logs wait-healthy wait-healthy-grpc wait-localscale cli
 
 # Multi-line message definitions
 define HELP_HEADER
@@ -170,6 +170,15 @@ ifeq ($(FRESH),1)
 	docker compose -f deploy/local/docker-compose.yml down -v 2>/dev/null || true
 endif
 	docker compose -f deploy/local/docker-compose.yml up --build
+
+# Start local dev with observability (Grafana + Prometheus + Loki + Tempo)
+#   make up-telemetry           # Start with Grafana at http://localhost:3000
+#   make up-telemetry FRESH=1   # Reinitialize databases
+up-telemetry:
+ifeq ($(FRESH),1)
+	docker compose -f deploy/local/docker-compose.yml -f deploy/local/docker-compose.telemetry.yml down -v 2>/dev/null || true
+endif
+	docker compose -f deploy/local/docker-compose.yml -f deploy/local/docker-compose.telemetry.yml up --build
 
 # Start services, apply testapp schema, then show logs (full demo workflow)
 #   make demo              # Start and apply MySQL + Vitess schema (wipes data)

--- a/deploy/local/docker-compose.telemetry.yml
+++ b/deploy/local/docker-compose.telemetry.yml
@@ -1,0 +1,35 @@
+# Observability overlay: adds Grafana + Prometheus + Loki + Tempo via otel-lgtm.
+#
+# Usage (layer on top of the base compose):
+#   docker compose -f docker-compose.yml -f docker-compose.telemetry.yml up
+#
+# Endpoints:
+#   Grafana:    http://localhost:3000 (admin/admin)
+#   OTLP HTTP:  localhost:4318
+#   OTLP gRPC:  localhost:4317
+#   Prometheus: http://localhost:9090
+#
+# SchemaBot's /metrics endpoint is scraped by Prometheus inside otel-lgtm.
+# Grafana comes pre-configured with Prometheus, Loki, and Tempo datasources.
+
+services:
+  otel-lgtm:
+    image: grafana/otel-lgtm:0.26.0
+    ports:
+      - "3000:3000"   # Grafana
+      - "4317:4317"   # OTLP gRPC
+      - "4318:4318"   # OTLP HTTP
+      - "9090:9090"   # Prometheus
+    volumes:
+      - ./telemetry/prometheus.yml:/otel-lgtm/prometheus.yaml:ro
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:3000/api/health"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 15s
+
+  schemabot:
+    depends_on:
+      otel-lgtm:
+        condition: service_started

--- a/deploy/local/telemetry/prometheus.yml
+++ b/deploy/local/telemetry/prometheus.yml
@@ -1,0 +1,22 @@
+---
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+  scrape_native_histograms: true
+
+otlp:
+  keep_identifying_resource_attributes: true
+  promote_resource_attributes:
+    - service.instance.id
+    - service.name
+    - service.namespace
+    - service.version
+
+storage:
+  tsdb:
+    out_of_order_time_window: 10m
+
+scrape_configs:
+  - job_name: schemabot
+    static_configs:
+      - targets: ["schemabot:8080"]


### PR DESCRIPTION
Adds a docker-compose overlay that layers `grafana/otel-lgtm` onto the local dev environment. This gives you Grafana at `localhost:3000` with pre-configured Prometheus, Loki, and Tempo datasources. Prometheus scrapes SchemaBot's `/metrics` endpoint every 15s.

Usage: `make up-telemetry` (or `make up-telemetry FRESH=1` to reset volumes).

No Go code changes — this is purely infrastructure for local observability during development.

🤖 Generated with [Claude Code](https://claude.com/claude-code)