### PR TITLE
fix(vitess): derive planning keyspaces from source directory

### DIFF
--- a/pkg/engine/planetscale/planetscale.go
+++ b/pkg/engine/planetscale/planetscale.go
@@ -1183,7 +1183,7 @@ func (e *Engine) updateBranchVSchema(ctx context.Context, client psclient.PSClie
 // diffBranchForResume fetches the working branch's current schema and diffs it
 // against the desired schema to find DDL that wasn't applied before the crash.
 func (e *Engine) diffBranchForResume(ctx context.Context, client psclient.PSClient, org, database, branch string, schemaFiles schema.SchemaFiles) ([]engine.SchemaChange, error) {
-	currentSchema, err := e.fetchDatabaseSchema(ctx, client, org, database, branch)
+	currentSchema, err := e.fetchDatabaseSchema(ctx, client, org, database, branch, sortedKeyspaces(schemaFiles))
 	if err != nil {
 		return nil, fmt.Errorf("fetch branch schema: %w", err)
 	}
@@ -2174,33 +2174,44 @@ func shardLess(a, b string) bool {
 
 // --- Helper functions ---
 
-func (e *Engine) fetchDatabaseSchema(ctx context.Context, client psclient.PSClient, org, database, branch string) (map[string][]table.TableSchema, error) {
-	keyspaces, err := client.ListKeyspaces(ctx, &ps.ListKeyspacesRequest{
-		Organization: org,
-		Database:     database,
-		Branch:       branch,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("list keyspaces: %w", err)
-	}
+func (e *Engine) fetchDatabaseSchema(ctx context.Context, client psclient.PSClient, org, database, branch string, keyspaces []string) (map[string][]table.TableSchema, error) {
+	var mu sync.Mutex
+	result := make(map[string][]table.TableSchema, len(keyspaces))
+	g, gCtx := errgroup.WithContext(ctx)
+	g.SetLimit(20)
 
-	result := make(map[string][]table.TableSchema)
-	for _, ks := range keyspaces {
-		schemaResult, err := client.GetBranchSchema(ctx, &ps.BranchSchemaRequest{
-			Organization: org,
-			Database:     database,
-			Branch:       branch,
-			Keyspace:     ks.Name,
+	for _, keyspace := range keyspaces {
+		ks := keyspace
+		g.Go(func() error {
+			schemaResult, err := client.GetBranchSchema(gCtx, &ps.BranchSchemaRequest{
+				Organization: org,
+				Database:     database,
+				Branch:       branch,
+				Keyspace:     ks,
+			})
+			if err != nil {
+				// Keyspace doesn't exist yet — treat as empty so all tables
+				// appear as CREATEs in the diff.
+				e.logger.Info("keyspace not found on branch, treating as empty",
+					"keyspace", ks, "branch", branch, "error", err)
+				mu.Lock()
+				result[ks] = nil
+				mu.Unlock()
+				return nil
+			}
+
+			tables := make([]table.TableSchema, len(schemaResult))
+			for i, t := range schemaResult {
+				tables[i] = table.TableSchema{Name: t.Name, Schema: t.Raw}
+			}
+			mu.Lock()
+			result[ks] = tables
+			mu.Unlock()
+			return nil
 		})
-		if err != nil {
-			return nil, fmt.Errorf("fetch schema for keyspace %s: %w", ks.Name, err)
-		}
-
-		tables := make([]table.TableSchema, len(schemaResult))
-		for i, t := range schemaResult {
-			tables[i] = table.TableSchema{Name: t.Name, Schema: t.Raw}
-		}
-		result[ks.Name] = tables
+	}
+	if err := g.Wait(); err != nil {
+		return nil, err
 	}
 	return result, nil
 }
@@ -2217,7 +2228,7 @@ func (e *Engine) fetchPlanSchema(ctx context.Context, client psclient.PSClient, 
 
 	if parent.SafeMigrations {
 		e.logger.Debug("using PlanetScale schema API for plan", "database", database, "branch", branch)
-		return e.fetchDatabaseSchema(ctx, client, org, database, branch)
+		return e.fetchDatabaseSchema(ctx, client, org, database, branch, keyspaces)
 	}
 
 	if creds == nil || creds.DSN == "" {

--- a/pkg/engine/planetscale/planetscale.go
+++ b/pkg/engine/planetscale/planetscale.go
@@ -388,6 +388,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"maps"
@@ -2190,14 +2191,18 @@ func (e *Engine) fetchDatabaseSchema(ctx context.Context, client psclient.PSClie
 				Keyspace:     ks,
 			})
 			if err != nil {
-				// Keyspace doesn't exist yet — treat as empty so all tables
-				// appear as CREATEs in the diff.
-				e.logger.Info("keyspace not found on branch, treating as empty",
-					"keyspace", ks, "branch", branch, "error", err)
-				mu.Lock()
-				result[ks] = nil
-				mu.Unlock()
-				return nil
+				var psErr *ps.Error
+				if errors.As(err, &psErr) && psErr.Code == ps.ErrNotFound {
+					// Keyspace doesn't exist yet — treat as empty so all
+					// tables appear as CREATEs in the diff.
+					e.logger.Info("keyspace not found on branch, treating as empty",
+						"keyspace", ks, "branch", branch)
+					mu.Lock()
+					result[ks] = nil
+					mu.Unlock()
+					return nil
+				}
+				return fmt.Errorf("fetch schema for keyspace %s: %w", ks, err)
 			}
 
 			tables := make([]table.TableSchema, len(schemaResult))

--- a/pkg/localscale/helpers.go
+++ b/pkg/localscale/helpers.go
@@ -886,9 +886,27 @@ func (s *Server) writeError(w http.ResponseWriter, code int, format string, args
 	s.logger.Warn("api error", "code", code, "message", msg)
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(code)
-	// PS SDK expects "code" as a string, not a number
+	// Use PlanetScale SDK error code strings so the SDK's error parser
+	// produces typed *ps.Error values (e.g., ErrNotFound for 404).
 	_ = json.NewEncoder(w).Encode(map[string]any{
-		"code":    fmt.Sprintf("%d", code),
+		"code":    httpStatusToPSCode(code),
 		"message": msg,
 	})
+}
+
+// httpStatusToPSCode maps HTTP status codes to PlanetScale SDK error code
+// strings. The SDK parses these in its error handler to set ps.Error.Code.
+func httpStatusToPSCode(status int) string {
+	switch status {
+	case http.StatusNotFound:
+		return "not_found"
+	case http.StatusUnauthorized, http.StatusForbidden:
+		return "unauthorized"
+	case http.StatusBadRequest:
+		return "bad_request"
+	case http.StatusUnprocessableEntity:
+		return "unprocessable"
+	default:
+		return fmt.Sprintf("%d", status)
+	}
 }

--- a/pkg/localscale/server_integration_test.go
+++ b/pkg/localscale/server_integration_test.go
@@ -912,3 +912,19 @@ func TestGetKeyspaceVSchemaOnNonMainBranch(t *testing.T) {
 	require.NotNil(t, mainVS, "expected non-nil VSchema for main")
 	assert.NotContains(t, mainVS.Raw, "branch_test_vdx", "main VSchema should NOT contain 'branch_test_vdx'")
 }
+
+// TestGetBranchSchemaUnknownKeyspace verifies that GetBranchSchema returns an
+// error for a keyspace that doesn't exist. The PlanetScale engine relies on
+// this behavior to detect new keyspaces and treat them as empty (all tables
+// show as CREATEs in the plan diff).
+func TestGetBranchSchemaUnknownKeyspace(t *testing.T) {
+	ctx := t.Context()
+
+	_, err := testClient.GetBranchSchema(ctx, &ps.BranchSchemaRequest{
+		Organization: testOrg,
+		Database:     testDB,
+		Branch:       "main",
+		Keyspace:     "nonexistent_keyspace",
+	})
+	require.Error(t, err, "GetBranchSchema should fail for unknown keyspace")
+}


### PR DESCRIPTION
## Summary

- Drive schema fetches from the keyspace list in the plan request instead of discovering via the PlanetScale ListKeyspaces API
- Fetches are now parallel (bounded at 20 concurrency)
- Keyspaces not yet created on the remote are treated as empty, correctly showing all tables as CREATEs

🤖 Generated with [Claude Code](https://claude.com/claude-code)