### PR TITLE
fix(ux): Sort keyspaces in plan output

### DIFF
--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -3438,25 +3438,6 @@ Vitess plan: Multi-keyspace with DDL + VSchema across keyspaces
 ╰─────────────────────────────────────────────╯
 
 
-  ── testapp_sharded ──
-
-  ~ VSchema:
-       "vindexes": {
-    -    "hash": {"type": "hash"}
-    +    "hash": {"type": "hash"},
-    +    "lookup_email": {
-    +      "type": "consistent_lookup",
-    +      "params": {"table": "users_email_idx", "from": "email", "to": "user_id"}
-    +    }
-       },
-
-     ~ users
-       ALTER TABLE `users` ADD COLUMN `email_verified` tinyint(1) DEFAULT FALSE;
-
-     ~ orders
-       ALTER TABLE `orders` ADD INDEX `idx_status_created`(`status`, `created_at`);
-
-
   ── testapp ──
 
   ~ VSchema:
@@ -3475,6 +3456,25 @@ Vitess plan: Multi-keyspace with DDL + VSchema across keyspaces
            `user_id` bigint NOT NULL,
            PRIMARY KEY(`email`, `user_id`)
        );
+
+
+  ── testapp_sharded ──
+
+  ~ VSchema:
+       "vindexes": {
+    -    "hash": {"type": "hash"}
+    +    "hash": {"type": "hash"},
+    +    "lookup_email": {
+    +      "type": "consistent_lookup",
+    +      "params": {"table": "users_email_idx", "from": "email", "to": "user_id"}
+    +    }
+       },
+
+     ~ users
+       ALTER TABLE `users` ADD COLUMN `email_verified` tinyint(1) DEFAULT FALSE;
+
+     ~ orders
+       ALTER TABLE `orders` ADD INDEX `idx_status_created`(`status`, `created_at`);
 
 📋 **Plan**: 1 table to create, 2 tables to alter, 2 VSchema changes
 

--- a/pkg/cmd/templates/plan.go
+++ b/pkg/cmd/templates/plan.go
@@ -93,10 +93,15 @@ type NamespaceChange struct {
 func WriteNamespaceChanges(namespaces []NamespaceChange, isMySQL bool, database string) {
 	singleNamespace := len(namespaces) == 1 && isMySQL && namespaces[0].Namespace == database
 
-	// Sort keyspaces so identical changes are adjacent for collapsing.
-	sort.Slice(namespaces, func(i, j int) bool {
-		return namespaces[i].Namespace < namespaces[j].Namespace
+	// Sort a copy so callers aren't affected by reordering. This keeps output
+	// stable and groups similarly named keyspaces together, but collapsing still
+	// only applies to consecutive keyspaces with identical changes.
+	sorted := make([]NamespaceChange, len(namespaces))
+	copy(sorted, namespaces)
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].Namespace < sorted[j].Namespace
 	})
+	namespaces = sorted
 
 	// Group consecutive keyspaces with identical DDL changes for collapsing.
 	type nsGroup struct {

--- a/pkg/cmd/templates/plan.go
+++ b/pkg/cmd/templates/plan.go
@@ -3,6 +3,7 @@ package templates
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"golang.org/x/text/cases"
@@ -91,6 +92,11 @@ type NamespaceChange struct {
 // For Vitess, each keyspace gets a header with optional VSchema diff.
 func WriteNamespaceChanges(namespaces []NamespaceChange, isMySQL bool, database string) {
 	singleNamespace := len(namespaces) == 1 && isMySQL && namespaces[0].Namespace == database
+
+	// Sort keyspaces so identical changes are adjacent for collapsing.
+	sort.Slice(namespaces, func(i, j int) bool {
+		return namespaces[i].Namespace < namespaces[j].Namespace
+	})
 
 	// Group consecutive keyspaces with identical DDL changes for collapsing.
 	type nsGroup struct {

--- a/pkg/cmd/templates/plan.go
+++ b/pkg/cmd/templates/plan.go
@@ -94,8 +94,8 @@ func WriteNamespaceChanges(namespaces []NamespaceChange, isMySQL bool, database 
 	singleNamespace := len(namespaces) == 1 && isMySQL && namespaces[0].Namespace == database
 
 	// Sort a copy so callers aren't affected by reordering. This keeps output
-	// stable and groups similarly named keyspaces together, but collapsing still
-	// only applies to consecutive keyspaces with identical changes.
+	// stable and groups similarly named namespaces together, but collapsing
+	// still only applies to consecutive namespaces with identical changes.
 	sorted := make([]NamespaceChange, len(namespaces))
 	copy(sorted, namespaces)
 	sort.Slice(sorted, func(i, j int) bool {


### PR DESCRIPTION
## Summary

- Sort keyspaces alphabetically before rendering plan output
- Fixes non-deterministic ordering from map iteration that prevented identical changes from being collapsed
- Sharded keyspace variants now appear in natural sorted order (e.g., `_001`, `_002`, ...)

🤖 Generated with [Claude Code](https://claude.com/claude-code)