### PR TITLE
fix(ui): handle Ctrl+C gracefully in confirmation prompts

### DIFF
--- a/pkg/cmd/commands/common.go
+++ b/pkg/cmd/commands/common.go
@@ -6,7 +6,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"strings"
 	"time"
@@ -143,18 +145,42 @@ func resolveApplyID(endpoint, applyID string) (string, string, error) {
 // confirmAction prompts the user for "yes" confirmation. Returns true if confirmed.
 func confirmAction(prompt, cancelMsg string) (bool, error) {
 	fmt.Print(prompt)
-	reader := bufio.NewReader(os.Stdin)
-	response, err := reader.ReadString('\n')
-	if err != nil {
-		return false, fmt.Errorf("failed to read response: %w", err)
-	}
 
-	response = strings.TrimSpace(strings.ToLower(response))
-	if response != "yes" {
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt)
+	defer signal.Stop(sigCh)
+
+	responseCh := make(chan string, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		reader := bufio.NewReader(os.Stdin)
+		response, err := reader.ReadString('\n')
+		if err != nil {
+			errCh <- err
+			return
+		}
+		responseCh <- response
+	}()
+
+	select {
+	case <-sigCh:
 		fmt.Println(cancelMsg)
 		return false, nil
+	case err := <-errCh:
+		// EOF from Ctrl+D or closed stdin
+		fmt.Println(cancelMsg)
+		if errors.Is(err, io.EOF) {
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to read response: %w", err)
+	case response := <-responseCh:
+		response = strings.TrimSpace(strings.ToLower(response))
+		if response != "yes" {
+			fmt.Println(cancelMsg)
+			return false, nil
+		}
+		return true, nil
 	}
-	return true, nil
 }
 
 // writeJSON writes v as pretty-printed JSON to stdout.

--- a/pkg/cmd/commands/common.go
+++ b/pkg/cmd/commands/common.go
@@ -150,31 +150,31 @@ func confirmAction(prompt, cancelMsg string) (bool, error) {
 	signal.Notify(sigCh, os.Interrupt)
 	defer signal.Stop(sigCh)
 
-	responseCh := make(chan string, 1)
-	errCh := make(chan error, 1)
+	type readResult struct {
+		response string
+		err      error
+	}
+	resultCh := make(chan readResult, 1)
 	go func() {
 		reader := bufio.NewReader(os.Stdin)
 		response, err := reader.ReadString('\n')
-		if err != nil {
-			errCh <- err
-			return
-		}
-		responseCh <- response
+		resultCh <- readResult{response, err}
 	}()
 
 	select {
 	case <-sigCh:
 		fmt.Println(cancelMsg)
 		return false, nil
-	case err := <-errCh:
-		// EOF from Ctrl+D or closed stdin
-		fmt.Println(cancelMsg)
-		if errors.Is(err, io.EOF) {
+	case r := <-resultCh:
+		// EOF with data is valid (e.g., echo -n yes | schemabot apply)
+		if r.err != nil && !errors.Is(r.err, io.EOF) {
+			return false, fmt.Errorf("failed to read response: %w", r.err)
+		}
+		response := strings.TrimSpace(strings.ToLower(r.response))
+		if errors.Is(r.err, io.EOF) && response == "" {
+			fmt.Println(cancelMsg)
 			return false, nil
 		}
-		return false, fmt.Errorf("failed to read response: %w", err)
-	case response := <-responseCh:
-		response = strings.TrimSpace(strings.ToLower(response))
 		if response != "yes" {
 			fmt.Println(cancelMsg)
 			return false, nil


### PR DESCRIPTION
## Summary

- Catch SIGINT (Ctrl+C) and EOF (Ctrl+D) during apply/rollback confirmation prompts
- Previously these would print raw errors; now they print the cancellation message and exit cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)