### PR TITLE
fix(vitess): improve large keyspace branch handling

### DIFF
--- a/pkg/cmd/commands/watch_tui_view.go
+++ b/pkg/cmd/commands/watch_tui_view.go
@@ -92,9 +92,16 @@ func (m WatchModel) progressView() string {
 		if m.metadata != nil && m.metadata["existing_branch"] != "" {
 			label = "Refreshing branch schema..."
 		}
+		if m.metadata != nil && m.metadata["status_detail"] != "" {
+			label = m.metadata["status_detail"]
+		}
 		b.WriteString(m.spinner.View() + label + m.elapsed() + "\n")
 	case state.IsState(m.state, state.Apply.ApplyingBranchChanges):
-		b.WriteString(m.spinner.View() + "Applying changes to branch..." + m.elapsed() + "\n")
+		label := "Applying changes to branch..."
+		if m.metadata != nil && m.metadata["status_detail"] != "" {
+			label = m.metadata["status_detail"]
+		}
+		b.WriteString(m.spinner.View() + label + m.elapsed() + "\n")
 	case state.IsState(m.state, state.Apply.CreatingDeployRequest):
 		msg := "Creating deploy request..."
 		if m.deployRequestURL != "" {

--- a/pkg/cmd/templates/progress.go
+++ b/pkg/cmd/templates/progress.go
@@ -62,6 +62,12 @@ func WriteProgress(data ProgressData) {
 	if data.State == state.Apply.CreatingBranch && data.Metadata != nil && data.Metadata["existing_branch"] != "" {
 		displayState = "Refreshing branch schema"
 	}
+	// Show latest event detail during setup phases
+	if data.Metadata != nil && data.Metadata["status_detail"] != "" {
+		if state.IsState(data.State, state.Apply.CreatingBranch, state.Apply.ApplyingBranchChanges, state.Apply.CreatingDeployRequest) {
+			displayState = data.Metadata["status_detail"]
+		}
+	}
 	colorFn := stateColorFunc(data.State)
 
 	var rows []BoxRow

--- a/pkg/engine/planetscale/planetscale.go
+++ b/pkg/engine/planetscale/planetscale.go
@@ -1057,69 +1057,42 @@ func (e *Engine) applyChangesToBranch(ctx context.Context, changes []engine.Sche
 
 	total := len(changes)
 	var applied atomic.Int32
-	emitProgress := func(message string, metadata map[string]string) {
-		n := int(applied.Load())
-		msg := fmt.Sprintf("Applying to branch (%d/%d keyspaces)... %s", n, total, message)
-		emitEvent(msg, metadata)
-	}
 
 	emitEvent(fmt.Sprintf("Applying changes to %d keyspaces on branch %s", total, branchName), map[string]string{"branch": branchName})
 
-	// Track which keyspaces need DDL (vs VSchema-only)
-	needsDDL := make(map[string]bool, len(changes))
-	for _, sc := range changes {
-		if len(sc.TableChanges) > 0 {
-			needsDDL[sc.Namespace] = true
-		}
-	}
-
-	// Phase 1: Apply VSchema changes sequentially. PlanetScale blocks
-	// concurrent VSchema writes while schema snapshots are in progress.
-	for _, sc := range changes {
-		vschemaContent := getVSchemaContent(sc, schemaFiles)
-		if vschemaContent == "" {
-			continue
-		}
-		if err := e.updateBranchVSchemaWithRetry(ctx, client, org, database, branchName, sc.Namespace, vschemaContent, emitProgress); err != nil {
-			return fmt.Errorf("update vschema for %s: %w", sc.Namespace, err)
-		}
-		// VSchema-only keyspaces are done after this phase
-		if !needsDDL[sc.Namespace] {
-			applied.Add(1)
-			emitProgress(fmt.Sprintf("VSchema applied to %s", sc.Namespace), map[string]string{"keyspace": sc.Namespace})
-		}
-	}
-
-	// Phase 2: Apply DDL changes in parallel (MySQL connections are independent).
 	g, gCtx := errgroup.WithContext(ctx)
 	g.SetLimit(maxConcurrentKeyspaces)
 	for _, sc := range changes {
-		if !needsDDL[sc.Namespace] {
-			continue
-		}
 		g.Go(func() error {
-			if err := e.applyKeyspaceDDL(gCtx, sc, password, org, database, branchName, emitProgress); err != nil {
+			if err := e.applyKeyspaceChanges(gCtx, sc, schemaFiles, password, client, org, database, branchName); err != nil {
 				return err
 			}
-			applied.Add(1)
-			emitProgress(fmt.Sprintf("DDL applied to %s", sc.Namespace), map[string]string{"keyspace": sc.Namespace})
+			n := int(applied.Add(1))
+			emitEvent(fmt.Sprintf("Applied keyspace %s (%d/%d)", sc.Namespace, n, total),
+				map[string]string{"keyspace": sc.Namespace})
 			return nil
 		})
 	}
 	return g.Wait()
 }
 
-// updateBranchVSchemaWithRetry applies VSchema for a keyspace with retries.
-// Uses longer backoff when a schema snapshot is in progress.
-func (e *Engine) updateBranchVSchemaWithRetry(ctx context.Context, client psclient.PSClient, org, database, branchName, keyspace, vschemaContent string, emitEvent func(string, map[string]string)) error {
-	e.logger.Info("updating VSchema on branch", "keyspace", keyspace, "branch", branchName)
+// applyKeyspaceChanges applies VSchema and DDL for a single keyspace with retries.
+// Uses longer backoff when PlanetScale reports a schema snapshot is in progress.
+func (e *Engine) applyKeyspaceChanges(ctx context.Context, sc engine.SchemaChange, schemaFiles schema.SchemaFiles, password *ps.DatabaseBranchPassword, client psclient.PSClient, org, database, branchName string) error {
+	start := time.Now()
+	e.logger.Info("applying changes to keyspace",
+		"keyspace", sc.Namespace,
+		"ddl_count", len(sc.TableChanges),
+		"has_vschema", sc.Metadata["vschema"] != "",
+		"branch", branchName,
+	)
 
-	maxAttempts := maxSnapshotRetries
+	maxAttempts := maxRetries
 	var lastErr error
 	for attempt := range maxAttempts {
 		if attempt > 0 {
 			delay := retryDelay(attempt, lastErr)
-			e.logger.Warn("retrying VSchema update", "keyspace", keyspace, "attempt", attempt+1, "delay", delay.Round(time.Millisecond), "error", lastErr)
+			e.logger.Warn("retrying keyspace apply", "keyspace", sc.Namespace, "attempt", attempt+1, "delay", delay.Round(time.Millisecond), "error", lastErr)
 			select {
 			case <-ctx.Done():
 				return ctx.Err()
@@ -1127,50 +1100,20 @@ func (e *Engine) updateBranchVSchemaWithRetry(ctx context.Context, client psclie
 			}
 		}
 
-		if err := e.updateBranchVSchema(ctx, client, org, database, branchName, keyspace, vschemaContent); err != nil {
+		if err := e.applyKeyspaceChangesOnce(ctx, sc, schemaFiles, password, client, org, database, branchName); err != nil {
 			lastErr = err
-			e.logger.Error("VSchema update failed", "keyspace", keyspace, "attempt", attempt+1, "error", err)
-			continue
-		}
-		emitEvent(fmt.Sprintf("Applied VSchema to keyspace %s", keyspace), map[string]string{"keyspace": keyspace})
-		return nil
-	}
-	return fmt.Errorf("update vschema for keyspace %s on branch %s (after %d attempts): %w", keyspace, branchName, maxAttempts, lastErr)
-}
-
-// applyKeyspaceDDL applies DDL statements for a single keyspace with retries.
-func (e *Engine) applyKeyspaceDDL(ctx context.Context, sc engine.SchemaChange, password *ps.DatabaseBranchPassword, org, database, branchName string, emitEvent func(string, map[string]string)) error {
-	start := time.Now()
-	e.logger.Info("applying DDL to keyspace",
-		"keyspace", sc.Namespace,
-		"ddl_count", len(sc.TableChanges),
-		"branch", branchName,
-	)
-
-	var lastErr error
-	for attempt := range maxRetries {
-		if attempt > 0 {
-			delay := retryDelay(attempt, lastErr)
-			e.logger.Warn("retrying DDL apply", "keyspace", sc.Namespace, "attempt", attempt+1, "delay", delay.Round(time.Millisecond), "error", lastErr)
-			select {
-			case <-ctx.Done():
-				return ctx.Err()
-			case <-time.After(delay):
+			e.logger.Error("keyspace apply attempt failed", "keyspace", sc.Namespace, "attempt", attempt+1, "error", err)
+			if isSnapshotInProgress(err) && maxAttempts == maxRetries {
+				maxAttempts = maxSnapshotRetries
+				e.logger.Info("schema snapshot in progress, extending retries",
+					"keyspace", sc.Namespace, "max_attempts", maxAttempts)
 			}
-		}
-
-		if err := e.applyKeyspaceDDLOnce(ctx, sc, password, branchName); err != nil {
-			lastErr = err
-			e.logger.Error("DDL apply failed", "keyspace", sc.Namespace, "attempt", attempt+1, "error", err)
 			continue
 		}
-		elapsed := time.Since(start).Round(time.Second)
-		e.logger.Info("keyspace DDL applied", "keyspace", sc.Namespace, "elapsed", elapsed)
-		emitEvent(fmt.Sprintf("Applied DDL to keyspace %s (%s)", sc.Namespace, elapsed),
-			map[string]string{"keyspace": sc.Namespace})
+		e.logger.Info("keyspace changes applied", "keyspace", sc.Namespace, "elapsed", time.Since(start).Round(time.Second))
 		return nil
 	}
-	return fmt.Errorf("apply DDL for keyspace %s (after %d attempts): %w", sc.Namespace, maxRetries, lastErr)
+	return fmt.Errorf("apply keyspace %s (after %d attempts): %w", sc.Namespace, maxAttempts, lastErr)
 }
 
 // isSnapshotInProgress returns true if the error indicates PlanetScale is
@@ -1193,8 +1136,21 @@ func retryDelay(attempt int, lastErr error) time.Duration {
 	return base + jitter
 }
 
-// applyKeyspaceDDLOnce executes DDL statements for a single keyspace in one attempt.
-func (e *Engine) applyKeyspaceDDLOnce(ctx context.Context, sc engine.SchemaChange, password *ps.DatabaseBranchPassword, branchName string) error {
+// applyKeyspaceChangesOnce applies VSchema and DDL for a single keyspace in one attempt.
+func (e *Engine) applyKeyspaceChangesOnce(ctx context.Context, sc engine.SchemaChange, schemaFiles schema.SchemaFiles, password *ps.DatabaseBranchPassword, client psclient.PSClient, org, database, branchName string) error {
+	// Apply VSchema first — vtgate needs VSchema to route DDL correctly
+	if vschemaContent := getVSchemaContent(sc, schemaFiles); vschemaContent != "" {
+		if err := e.updateBranchVSchema(ctx, client, org, database, branchName, sc.Namespace, vschemaContent); err != nil {
+			return fmt.Errorf("update vschema for %s: %w", sc.Namespace, err)
+		}
+		e.logger.Info("applied vschema to branch", "keyspace", sc.Namespace, "branch", branchName)
+	}
+
+	if len(sc.TableChanges) == 0 {
+		e.logger.Debug("no DDL for keyspace, vschema-only", "keyspace", sc.Namespace, "branch", branchName)
+		return nil
+	}
+
 	// Build DSN targeting this specific keyspace.
 	// TLS is configured automatically when RegisterMTLS has been called.
 	mysqlCfg := mysql.NewConfig()

--- a/pkg/engine/planetscale/planetscale.go
+++ b/pkg/engine/planetscale/planetscale.go
@@ -419,7 +419,7 @@ import (
 const (
 	// maxConcurrentKeyspaces limits parallel DDL application during Apply.
 	// Each keyspace gets its own MySQL connection to the branch.
-	maxConcurrentKeyspaces = 6
+	maxConcurrentKeyspaces = 2
 
 	// maxRetries is the number of retry attempts per keyspace when applying DDL.
 	maxRetries = 3
@@ -1123,17 +1123,18 @@ func isSnapshotInProgress(err error) bool {
 	return err != nil && strings.Contains(err.Error(), "schema snapshot is in progress")
 }
 
-// retryDelay returns the backoff duration for a retry attempt. Uses longer
-// delays when a schema snapshot is in progress since those can take 30-60s.
+// retryDelay returns the backoff duration for a retry attempt using
+// exponential backoff with full jitter. When a schema snapshot is in
+// progress the base delay is longer since snapshots can take 30-60s.
 func retryDelay(attempt int, lastErr error) time.Duration {
 	if isSnapshotInProgress(lastErr) {
-		// Snapshot retries: 5s base + jitter
-		return 5*time.Second + time.Duration(rand.IntN(2000))*time.Millisecond
+		// Snapshot: 5s, 10s, 20s, 40s, ... capped at 60s + up to 5s jitter
+		base := min(5*time.Second*(1<<min(attempt, 4)), 60*time.Second)
+		return base + time.Duration(rand.IntN(5000))*time.Millisecond
 	}
-	// Normal retries: exponential backoff 2s, 4s, 6s + jitter
-	base := time.Duration(attempt) * 2 * time.Second
-	jitter := time.Duration(rand.IntN(1000)) * time.Millisecond
-	return base + jitter
+	// Normal: 2s, 4s, 8s capped at 10s + up to 2s jitter
+	base := min(2*time.Second*(1<<min(attempt, 3)), 10*time.Second)
+	return base + time.Duration(rand.IntN(2000))*time.Millisecond
 }
 
 // applyKeyspaceChangesOnce applies VSchema and DDL for a single keyspace in one attempt.

--- a/pkg/engine/planetscale/planetscale.go
+++ b/pkg/engine/planetscale/planetscale.go
@@ -1044,10 +1044,10 @@ func (e *Engine) Apply(ctx context.Context, req *engine.ApplyRequest) (*engine.A
 	}, nil
 }
 
-// applyChangesToBranch applies DDL and VSchema changes to all keyspaces concurrently.
-// Each keyspace gets its own MySQL connection and runs independently. Transient
-// failures are retried up to 3 times per keyspace (more for snapshot-in-progress).
-// The emitEvent callback is used to report per-keyspace progress to the caller.
+// applyChangesToBranch applies VSchema and DDL changes to all keyspaces.
+// VSchema updates are applied sequentially (PlanetScale rejects concurrent
+// VSchema writes during schema snapshots). DDL is applied in parallel after
+// all VSchema changes are committed.
 func (e *Engine) applyChangesToBranch(ctx context.Context, changes []engine.SchemaChange, schemaFiles schema.SchemaFiles, password *ps.DatabaseBranchPassword, client psclient.PSClient, org, database, branchName string, emitEvent func(string, map[string]string)) error {
 	if len(changes) == 0 {
 		e.logger.Debug("no changes to apply to branch", "branch", branchName)
@@ -1056,33 +1056,43 @@ func (e *Engine) applyChangesToBranch(ctx context.Context, changes []engine.Sche
 
 	emitEvent(fmt.Sprintf("Applying changes to %d keyspaces on branch %s", len(changes), branchName), map[string]string{"branch": branchName})
 
+	// Phase 1: Apply VSchema changes sequentially. PlanetScale blocks
+	// concurrent VSchema writes while schema snapshots are in progress.
+	for _, sc := range changes {
+		vschemaContent := getVSchemaContent(sc, schemaFiles)
+		if vschemaContent == "" {
+			continue
+		}
+		if err := e.updateBranchVSchemaWithRetry(ctx, client, org, database, branchName, sc.Namespace, vschemaContent, emitEvent); err != nil {
+			return fmt.Errorf("update vschema for %s: %w", sc.Namespace, err)
+		}
+	}
+
+	// Phase 2: Apply DDL changes in parallel (MySQL connections are independent).
 	g, gCtx := errgroup.WithContext(ctx)
 	g.SetLimit(maxConcurrentKeyspaces)
 	for _, sc := range changes {
+		if len(sc.TableChanges) == 0 {
+			continue
+		}
 		g.Go(func() error {
-			return e.applyKeyspaceChanges(gCtx, sc, schemaFiles, password, client, org, database, branchName, emitEvent)
+			return e.applyKeyspaceDDL(gCtx, sc, password, org, database, branchName, emitEvent)
 		})
 	}
 	return g.Wait()
 }
 
-// applyKeyspaceChanges applies DDL and VSchema for a single keyspace with retries.
-// Uses longer backoff when PlanetScale reports a schema snapshot is in progress.
-func (e *Engine) applyKeyspaceChanges(ctx context.Context, sc engine.SchemaChange, schemaFiles schema.SchemaFiles, password *ps.DatabaseBranchPassword, client psclient.PSClient, org, database, branchName string, emitEvent func(string, map[string]string)) error {
-	start := time.Now()
-	e.logger.Info("applying changes to keyspace",
-		"keyspace", sc.Namespace,
-		"ddl_count", len(sc.TableChanges),
-		"has_vschema", sc.Metadata["vschema"] != "",
-		"branch", branchName,
-	)
+// updateBranchVSchemaWithRetry applies VSchema for a keyspace with retries.
+// Uses longer backoff when a schema snapshot is in progress.
+func (e *Engine) updateBranchVSchemaWithRetry(ctx context.Context, client psclient.PSClient, org, database, branchName, keyspace, vschemaContent string, emitEvent func(string, map[string]string)) error {
+	e.logger.Info("updating VSchema on branch", "keyspace", keyspace, "branch", branchName)
 
-	maxAttempts := maxRetries
+	maxAttempts := maxSnapshotRetries
 	var lastErr error
 	for attempt := range maxAttempts {
 		if attempt > 0 {
 			delay := retryDelay(attempt, lastErr)
-			e.logger.Warn("retrying keyspace apply", "keyspace", sc.Namespace, "attempt", attempt+1, "delay", delay.Round(time.Millisecond), "error", lastErr)
+			e.logger.Warn("retrying VSchema update", "keyspace", keyspace, "attempt", attempt+1, "delay", delay.Round(time.Millisecond), "error", lastErr)
 			select {
 			case <-ctx.Done():
 				return ctx.Err()
@@ -1090,25 +1100,50 @@ func (e *Engine) applyKeyspaceChanges(ctx context.Context, sc engine.SchemaChang
 			}
 		}
 
-		if err := e.applyKeyspaceChangesOnce(ctx, sc, schemaFiles, password, client, org, database, branchName); err != nil {
+		if err := e.updateBranchVSchema(ctx, client, org, database, branchName, keyspace, vschemaContent); err != nil {
 			lastErr = err
-			e.logger.Error("keyspace apply attempt failed", "keyspace", sc.Namespace, "attempt", attempt+1, "error", err)
-			// Schema snapshot errors are transient but can last 30-60s.
-			// Extend retries so we don't give up too early.
-			if isSnapshotInProgress(err) && maxAttempts == maxRetries {
-				maxAttempts = maxSnapshotRetries
-				e.logger.Info("schema snapshot in progress, extending retries",
-					"keyspace", sc.Namespace, "max_attempts", maxAttempts)
+			e.logger.Error("VSchema update failed", "keyspace", keyspace, "attempt", attempt+1, "error", err)
+			continue
+		}
+		emitEvent(fmt.Sprintf("Applied VSchema to keyspace %s", keyspace), map[string]string{"keyspace": keyspace})
+		return nil
+	}
+	return fmt.Errorf("update vschema for keyspace %s on branch %s (after %d attempts): %w", keyspace, branchName, maxAttempts, lastErr)
+}
+
+// applyKeyspaceDDL applies DDL statements for a single keyspace with retries.
+func (e *Engine) applyKeyspaceDDL(ctx context.Context, sc engine.SchemaChange, password *ps.DatabaseBranchPassword, org, database, branchName string, emitEvent func(string, map[string]string)) error {
+	start := time.Now()
+	e.logger.Info("applying DDL to keyspace",
+		"keyspace", sc.Namespace,
+		"ddl_count", len(sc.TableChanges),
+		"branch", branchName,
+	)
+
+	var lastErr error
+	for attempt := range maxRetries {
+		if attempt > 0 {
+			delay := retryDelay(attempt, lastErr)
+			e.logger.Warn("retrying DDL apply", "keyspace", sc.Namespace, "attempt", attempt+1, "delay", delay.Round(time.Millisecond), "error", lastErr)
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(delay):
 			}
+		}
+
+		if err := e.applyKeyspaceDDLOnce(ctx, sc, password, branchName); err != nil {
+			lastErr = err
+			e.logger.Error("DDL apply failed", "keyspace", sc.Namespace, "attempt", attempt+1, "error", err)
 			continue
 		}
 		elapsed := time.Since(start).Round(time.Second)
-		e.logger.Info("keyspace changes applied", "keyspace", sc.Namespace, "elapsed", elapsed)
-		emitEvent(fmt.Sprintf("Applied changes to keyspace %s (%s)", sc.Namespace, elapsed),
+		e.logger.Info("keyspace DDL applied", "keyspace", sc.Namespace, "elapsed", elapsed)
+		emitEvent(fmt.Sprintf("Applied DDL to keyspace %s (%s)", sc.Namespace, elapsed),
 			map[string]string{"keyspace": sc.Namespace})
 		return nil
 	}
-	return fmt.Errorf("apply keyspace %s (after %d attempts): %w", sc.Namespace, maxAttempts, lastErr)
+	return fmt.Errorf("apply DDL for keyspace %s (after %d attempts): %w", sc.Namespace, maxRetries, lastErr)
 }
 
 // isSnapshotInProgress returns true if the error indicates PlanetScale is
@@ -1131,21 +1166,8 @@ func retryDelay(attempt int, lastErr error) time.Duration {
 	return base + jitter
 }
 
-// applyKeyspaceChangesOnce applies VSchema and DDL for a single keyspace in one attempt.
-func (e *Engine) applyKeyspaceChangesOnce(ctx context.Context, sc engine.SchemaChange, schemaFiles schema.SchemaFiles, password *ps.DatabaseBranchPassword, client psclient.PSClient, org, database, branchName string) error {
-	// Apply VSchema first — vtgate needs VSchema to route DDL correctly
-	if vschemaContent := getVSchemaContent(sc, schemaFiles); vschemaContent != "" {
-		if err := e.updateBranchVSchema(ctx, client, org, database, branchName, sc.Namespace, vschemaContent); err != nil {
-			return fmt.Errorf("update vschema for %s: %w", sc.Namespace, err)
-		}
-		e.logger.Info("applied vschema to branch", "keyspace", sc.Namespace, "branch", branchName)
-	}
-
-	if len(sc.TableChanges) == 0 {
-		e.logger.Debug("no DDL for keyspace, vschema-only", "keyspace", sc.Namespace, "branch", branchName)
-		return nil
-	}
-
+// applyKeyspaceDDLOnce executes DDL statements for a single keyspace in one attempt.
+func (e *Engine) applyKeyspaceDDLOnce(ctx context.Context, sc engine.SchemaChange, password *ps.DatabaseBranchPassword, branchName string) error {
 	// Build DSN targeting this specific keyspace.
 	// TLS is configured automatically when RegisterMTLS has been called.
 	mysqlCfg := mysql.NewConfig()

--- a/pkg/engine/planetscale/planetscale.go
+++ b/pkg/engine/planetscale/planetscale.go
@@ -425,7 +425,7 @@ const (
 
 	// maxSnapshotRetries is used when a schema snapshot is in progress
 	// (e.g., after RefreshSchema). Snapshots can take 30-60s on large databases.
-	maxSnapshotRetries = 12
+	maxSnapshotRetries = 5
 )
 
 // deployState is a shorthand alias for PlanetScale deploy request state constants.

--- a/pkg/engine/planetscale/planetscale.go
+++ b/pkg/engine/planetscale/planetscale.go
@@ -419,7 +419,7 @@ import (
 const (
 	// maxConcurrentKeyspaces limits parallel DDL application during Apply.
 	// Each keyspace gets its own MySQL connection to the branch.
-	maxConcurrentKeyspaces = 2
+	maxConcurrentKeyspaces = 3
 
 	// maxRetries is the number of retry attempts per keyspace when applying DDL.
 	maxRetries = 3

--- a/pkg/engine/planetscale/planetscale.go
+++ b/pkg/engine/planetscale/planetscale.go
@@ -422,6 +422,10 @@ const (
 
 	// maxRetries is the number of retry attempts per keyspace when applying DDL.
 	maxRetries = 3
+
+	// maxSnapshotRetries is used when a schema snapshot is in progress
+	// (e.g., after RefreshSchema). Snapshots can take 30-60s on large databases.
+	maxSnapshotRetries = 12
 )
 
 // deployState is a shorthand alias for PlanetScale deploy request state constants.
@@ -891,8 +895,9 @@ func (e *Engine) Apply(ctx context.Context, req *engine.ApplyRequest) (*engine.A
 		return nil, fmt.Errorf("create branch password: %w", err)
 	}
 
-	// Apply DDL and VSchema changes to all keyspaces concurrently
-	if err := e.applyChangesToBranch(ctx, req.Changes, req.SchemaFiles, password, client, org, req.Database, branchName); err != nil {
+	// Apply DDL and VSchema changes to all keyspaces
+	emitEvent("Applying changes to branch", map[string]string{"branch": branchName})
+	if err := e.applyChangesToBranch(ctx, req.Changes, req.SchemaFiles, password, client, org, req.Database, branchName, emitEvent); err != nil {
 		return nil, fmt.Errorf("apply changes to branch: %w", err)
 	}
 	ddlCount := 0
@@ -1039,28 +1044,31 @@ func (e *Engine) Apply(ctx context.Context, req *engine.ApplyRequest) (*engine.A
 	}, nil
 }
 
-// applyDDLToBranch connects to the branch via MySQL and executes DDL statements.
 // applyChangesToBranch applies DDL and VSchema changes to all keyspaces concurrently.
 // Each keyspace gets its own MySQL connection and runs independently. Transient
-// failures are retried up to 3 times per keyspace.
-func (e *Engine) applyChangesToBranch(ctx context.Context, changes []engine.SchemaChange, schemaFiles schema.SchemaFiles, password *ps.DatabaseBranchPassword, client psclient.PSClient, org, database, branchName string) error {
+// failures are retried up to 3 times per keyspace (more for snapshot-in-progress).
+// The emitEvent callback is used to report per-keyspace progress to the caller.
+func (e *Engine) applyChangesToBranch(ctx context.Context, changes []engine.SchemaChange, schemaFiles schema.SchemaFiles, password *ps.DatabaseBranchPassword, client psclient.PSClient, org, database, branchName string, emitEvent func(string, map[string]string)) error {
 	if len(changes) == 0 {
 		e.logger.Debug("no changes to apply to branch", "branch", branchName)
 		return nil
 	}
 
+	emitEvent(fmt.Sprintf("Applying changes to %d keyspaces on branch %s", len(changes), branchName), map[string]string{"branch": branchName})
+
 	g, gCtx := errgroup.WithContext(ctx)
 	g.SetLimit(maxConcurrentKeyspaces)
 	for _, sc := range changes {
 		g.Go(func() error {
-			return e.applyKeyspaceChanges(gCtx, sc, schemaFiles, password, client, org, database, branchName)
+			return e.applyKeyspaceChanges(gCtx, sc, schemaFiles, password, client, org, database, branchName, emitEvent)
 		})
 	}
 	return g.Wait()
 }
 
 // applyKeyspaceChanges applies DDL and VSchema for a single keyspace with retries.
-func (e *Engine) applyKeyspaceChanges(ctx context.Context, sc engine.SchemaChange, schemaFiles schema.SchemaFiles, password *ps.DatabaseBranchPassword, client psclient.PSClient, org, database, branchName string) error {
+// Uses longer backoff when PlanetScale reports a schema snapshot is in progress.
+func (e *Engine) applyKeyspaceChanges(ctx context.Context, sc engine.SchemaChange, schemaFiles schema.SchemaFiles, password *ps.DatabaseBranchPassword, client psclient.PSClient, org, database, branchName string, emitEvent func(string, map[string]string)) error {
 	start := time.Now()
 	e.logger.Info("applying changes to keyspace",
 		"keyspace", sc.Namespace,
@@ -1069,25 +1077,58 @@ func (e *Engine) applyKeyspaceChanges(ctx context.Context, sc engine.SchemaChang
 		"branch", branchName,
 	)
 
+	maxAttempts := maxRetries
 	var lastErr error
-	for attempt := range maxRetries {
+	for attempt := range maxAttempts {
 		if attempt > 0 {
-			base := time.Duration(attempt) * 2 * time.Second
-			jitter := time.Duration(rand.IntN(1000)) * time.Millisecond
-			delay := base + jitter
+			delay := retryDelay(attempt, lastErr)
 			e.logger.Warn("retrying keyspace apply", "keyspace", sc.Namespace, "attempt", attempt+1, "delay", delay.Round(time.Millisecond), "error", lastErr)
-			time.Sleep(delay)
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(delay):
+			}
 		}
 
 		if err := e.applyKeyspaceChangesOnce(ctx, sc, schemaFiles, password, client, org, database, branchName); err != nil {
 			lastErr = err
 			e.logger.Error("keyspace apply attempt failed", "keyspace", sc.Namespace, "attempt", attempt+1, "error", err)
+			// Schema snapshot errors are transient but can last 30-60s.
+			// Extend retries so we don't give up too early.
+			if isSnapshotInProgress(err) && maxAttempts == maxRetries {
+				maxAttempts = maxSnapshotRetries
+				e.logger.Info("schema snapshot in progress, extending retries",
+					"keyspace", sc.Namespace, "max_attempts", maxAttempts)
+			}
 			continue
 		}
-		e.logger.Info("keyspace changes applied", "keyspace", sc.Namespace, "elapsed", time.Since(start).Round(time.Second))
+		elapsed := time.Since(start).Round(time.Second)
+		e.logger.Info("keyspace changes applied", "keyspace", sc.Namespace, "elapsed", elapsed)
+		emitEvent(fmt.Sprintf("Applied changes to keyspace %s (%s)", sc.Namespace, elapsed),
+			map[string]string{"keyspace": sc.Namespace})
 		return nil
 	}
-	return fmt.Errorf("apply keyspace %s (after %d attempts): %w", sc.Namespace, maxRetries, lastErr)
+	return fmt.Errorf("apply keyspace %s (after %d attempts): %w", sc.Namespace, maxAttempts, lastErr)
+}
+
+// isSnapshotInProgress returns true if the error indicates PlanetScale is
+// running a schema snapshot (e.g., after RefreshSchema). VSchema updates
+// are blocked while the snapshot completes.
+func isSnapshotInProgress(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "schema snapshot is in progress")
+}
+
+// retryDelay returns the backoff duration for a retry attempt. Uses longer
+// delays when a schema snapshot is in progress since those can take 30-60s.
+func retryDelay(attempt int, lastErr error) time.Duration {
+	if isSnapshotInProgress(lastErr) {
+		// Snapshot retries: 5s base + jitter
+		return 5*time.Second + time.Duration(rand.IntN(2000))*time.Millisecond
+	}
+	// Normal retries: exponential backoff 2s, 4s, 6s + jitter
+	base := time.Duration(attempt) * 2 * time.Second
+	jitter := time.Duration(rand.IntN(1000)) * time.Millisecond
+	return base + jitter
 }
 
 // applyKeyspaceChangesOnce applies VSchema and DDL for a single keyspace in one attempt.
@@ -1244,6 +1285,17 @@ func (e *Engine) resumeApply(ctx context.Context, client psclient.PSClient, org 
 		return nil, fmt.Errorf("decode resume state: %w", err)
 	}
 
+	emitEvent := func(message string, metadata map[string]string) {
+		attrs := []any{"database", req.Database}
+		for k, v := range metadata {
+			attrs = append(attrs, k, v)
+		}
+		e.logger.Info(message, attrs...)
+		if req.OnEvent != nil {
+			req.OnEvent(engine.ApplyEvent{Message: message, Metadata: metadata})
+		}
+	}
+
 	e.logger.Info("resuming apply",
 		"branch", meta.BranchName,
 		"deploy_request", meta.DeployRequestID,
@@ -1315,7 +1367,7 @@ func (e *Engine) resumeApply(ctx context.Context, client psclient.PSClient, org 
 		if err != nil {
 			return nil, fmt.Errorf("create branch password on resume: %w", err)
 		}
-		if err := e.applyChangesToBranch(ctx, remainingChanges, req.SchemaFiles, password, client, org, req.Database, meta.BranchName); err != nil {
+		if err := e.applyChangesToBranch(ctx, remainingChanges, req.SchemaFiles, password, client, org, req.Database, meta.BranchName, emitEvent); err != nil {
 			return nil, fmt.Errorf("apply remaining DDL on resume: %w", err)
 		}
 	} else {

--- a/pkg/engine/planetscale/planetscale.go
+++ b/pkg/engine/planetscale/planetscale.go
@@ -397,6 +397,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	mysql "github.com/go-sql-driver/mysql"
@@ -1054,7 +1055,23 @@ func (e *Engine) applyChangesToBranch(ctx context.Context, changes []engine.Sche
 		return nil
 	}
 
-	emitEvent(fmt.Sprintf("Applying changes to %d keyspaces on branch %s", len(changes), branchName), map[string]string{"branch": branchName})
+	total := len(changes)
+	var applied atomic.Int32
+	emitProgress := func(message string, metadata map[string]string) {
+		n := int(applied.Load())
+		msg := fmt.Sprintf("Applying to branch (%d/%d keyspaces)... %s", n, total, message)
+		emitEvent(msg, metadata)
+	}
+
+	emitEvent(fmt.Sprintf("Applying changes to %d keyspaces on branch %s", total, branchName), map[string]string{"branch": branchName})
+
+	// Track which keyspaces need DDL (vs VSchema-only)
+	needsDDL := make(map[string]bool, len(changes))
+	for _, sc := range changes {
+		if len(sc.TableChanges) > 0 {
+			needsDDL[sc.Namespace] = true
+		}
+	}
 
 	// Phase 1: Apply VSchema changes sequentially. PlanetScale blocks
 	// concurrent VSchema writes while schema snapshots are in progress.
@@ -1063,8 +1080,13 @@ func (e *Engine) applyChangesToBranch(ctx context.Context, changes []engine.Sche
 		if vschemaContent == "" {
 			continue
 		}
-		if err := e.updateBranchVSchemaWithRetry(ctx, client, org, database, branchName, sc.Namespace, vschemaContent, emitEvent); err != nil {
+		if err := e.updateBranchVSchemaWithRetry(ctx, client, org, database, branchName, sc.Namespace, vschemaContent, emitProgress); err != nil {
 			return fmt.Errorf("update vschema for %s: %w", sc.Namespace, err)
+		}
+		// VSchema-only keyspaces are done after this phase
+		if !needsDDL[sc.Namespace] {
+			applied.Add(1)
+			emitProgress(fmt.Sprintf("VSchema applied to %s", sc.Namespace), map[string]string{"keyspace": sc.Namespace})
 		}
 	}
 
@@ -1072,11 +1094,16 @@ func (e *Engine) applyChangesToBranch(ctx context.Context, changes []engine.Sche
 	g, gCtx := errgroup.WithContext(ctx)
 	g.SetLimit(maxConcurrentKeyspaces)
 	for _, sc := range changes {
-		if len(sc.TableChanges) == 0 {
+		if !needsDDL[sc.Namespace] {
 			continue
 		}
 		g.Go(func() error {
-			return e.applyKeyspaceDDL(gCtx, sc, password, org, database, branchName, emitEvent)
+			if err := e.applyKeyspaceDDL(gCtx, sc, password, org, database, branchName, emitProgress); err != nil {
+				return err
+			}
+			applied.Add(1)
+			emitProgress(fmt.Sprintf("DDL applied to %s", sc.Namespace), map[string]string{"keyspace": sc.Namespace})
+			return nil
 		})
 	}
 	return g.Wait()

--- a/pkg/engine/planetscale/planetscale.go
+++ b/pkg/engine/planetscale/planetscale.go
@@ -1058,7 +1058,15 @@ func (e *Engine) applyChangesToBranch(ctx context.Context, changes []engine.Sche
 	total := len(changes)
 	var applied atomic.Int32
 
-	emitEvent(fmt.Sprintf("Applying changes to %d keyspaces on branch %s", total, branchName), map[string]string{"branch": branchName})
+	// Serialize event callbacks — OnEvent mutates shared apply state.
+	var eventMu sync.Mutex
+	safeEmit := func(message string, metadata map[string]string) {
+		eventMu.Lock()
+		defer eventMu.Unlock()
+		emitEvent(message, metadata)
+	}
+
+	safeEmit(fmt.Sprintf("Applying changes to %d keyspaces on branch %s", total, branchName), map[string]string{"branch": branchName})
 
 	g, gCtx := errgroup.WithContext(ctx)
 	g.SetLimit(maxConcurrentKeyspaces)
@@ -1068,7 +1076,7 @@ func (e *Engine) applyChangesToBranch(ctx context.Context, changes []engine.Sche
 				return err
 			}
 			n := int(applied.Add(1))
-			emitEvent(fmt.Sprintf("Applied keyspace %s (%d/%d)", sc.Namespace, n, total),
+			safeEmit(fmt.Sprintf("Applied keyspace %s (%d/%d)", sc.Namespace, n, total),
 				map[string]string{"keyspace": sc.Namespace})
 			return nil
 		})
@@ -1089,7 +1097,7 @@ func (e *Engine) applyKeyspaceChanges(ctx context.Context, sc engine.SchemaChang
 
 	maxAttempts := maxRetries
 	var lastErr error
-	for attempt := range maxAttempts {
+	for attempt := 0; attempt < maxAttempts; attempt++ {
 		if attempt > 0 {
 			delay := retryDelay(attempt, lastErr)
 			e.logger.Warn("retrying keyspace apply", "keyspace", sc.Namespace, "attempt", attempt+1, "delay", delay.Round(time.Millisecond), "error", lastErr)

--- a/pkg/engine/planetscale/planetscale_test.go
+++ b/pkg/engine/planetscale/planetscale_test.go
@@ -1,7 +1,9 @@
 package planetscale
 
 import (
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -337,4 +339,40 @@ func TestSplitStatements(t *testing.T) {
 	// Semicolons with no valid statements are a parse error
 	_, err = ddl.SplitStatements("  ;  ;  ")
 	assert.Error(t, err)
+}
+
+func TestIsSnapshotInProgress(t *testing.T) {
+	assert.True(t, isSnapshotInProgress(fmt.Errorf("Cannot update VSchema while a schema snapshot is in progress.")))
+	assert.True(t, isSnapshotInProgress(fmt.Errorf("wrapped: schema snapshot is in progress")))
+	assert.False(t, isSnapshotInProgress(fmt.Errorf("connection refused")))
+	assert.False(t, isSnapshotInProgress(nil))
+}
+
+func TestRetryDelay(t *testing.T) {
+	t.Run("normal backoff is exponential", func(t *testing.T) {
+		d0 := retryDelay(0, fmt.Errorf("connection refused"))
+		d1 := retryDelay(1, fmt.Errorf("connection refused"))
+		d2 := retryDelay(2, fmt.Errorf("connection refused"))
+		// Base: 2s, 4s, 8s (plus up to 2s jitter)
+		assert.GreaterOrEqual(t, d0, 2*time.Second)
+		assert.Less(t, d0, 5*time.Second)
+		assert.GreaterOrEqual(t, d1, 4*time.Second)
+		assert.GreaterOrEqual(t, d2, 8*time.Second)
+	})
+
+	t.Run("snapshot backoff is longer", func(t *testing.T) {
+		snapshotErr := fmt.Errorf("schema snapshot is in progress")
+		d0 := retryDelay(0, snapshotErr)
+		d1 := retryDelay(1, snapshotErr)
+		// Base: 5s, 10s (plus up to 5s jitter)
+		assert.GreaterOrEqual(t, d0, 5*time.Second)
+		assert.Less(t, d0, 11*time.Second)
+		assert.GreaterOrEqual(t, d1, 10*time.Second)
+	})
+
+	t.Run("snapshot backoff caps at 60s", func(t *testing.T) {
+		snapshotErr := fmt.Errorf("schema snapshot is in progress")
+		d10 := retryDelay(10, snapshotErr)
+		assert.LessOrEqual(t, d10, 65*time.Second)
+	})
 }

--- a/pkg/tern/local_client.go
+++ b/pkg/tern/local_client.go
@@ -918,6 +918,16 @@ func (c *LocalClient) Progress(ctx context.Context, req *ternv1.ProgressRequest)
 			resp.Metadata = ensureMetadata(resp.Metadata)
 			resp.Metadata["existing_branch"] = opts.Branch
 		}
+
+		// During branch setup phases, include the latest event message so the
+		// CLI can show what's happening instead of a static spinner.
+		if state.IsState(overallState, state.Apply.CreatingBranch, state.Apply.ApplyingBranchChanges, state.Apply.CreatingDeployRequest) {
+			if logs, err := c.storage.ApplyLogs().GetByApply(ctx, apply.ID); err == nil && len(logs) > 0 {
+				latest := logs[len(logs)-1]
+				resp.Metadata = ensureMetadata(resp.Metadata)
+				resp.Metadata["status_detail"] = latest.Message
+			}
+		}
 	}
 
 	return resp, nil


### PR DESCRIPTION
## Summary

- Show per-keyspace progress during branch apply phase instead of a static spinner (e.g., `"Applied keyspace X (12/33)"`)
- Handle PlanetScale "schema snapshot in progress" errors with exponential backoff and extended retries (5 × 5-60s)
- Serialize event callbacks to prevent data races from concurrent goroutines
- Reduce keyspace concurrency from 6 to 3 to avoid VSchema API contention
- Surface latest apply event in TUI and progress view via `status_detail` metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)