### PR TITLE
feat(scheduler): add retryable failure handling and worker pool semantics

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -376,3 +376,87 @@ The engine is a stateless executor. It diffs schemas, executes DDL, and reports 
 ## State Machine
 
 See [pkg/state/README.md](../pkg/state/README.md) for the full state machine documentation, including apply states, task states, and how engine states map to SchemaBot states.
+
+## Scheduler
+
+The scheduler ([`pkg/api/scheduler.go`](../pkg/api/scheduler.go)) is a background component that runs on every SchemaBot server instance. It handles two concerns:
+
+1. **Crash recovery**: When a server restarts or a worker goroutine crashes, in-progress applies are left with stale heartbeats. The scheduler detects these (heartbeat older than 1 minute) and resumes them via `ResumeApply`.
+
+2. **Retryable failures**: When an engine reports a transient error (e.g., PlanetScale API timeout), the apply transitions to `failed_retryable` instead of permanent `failed`. The scheduler re-dispatches these applies up to 10 times before permanently failing them.
+
+### How it works
+
+```
+Server startup
+    │
+    ▼
+StartScheduler(ctx)
+    │
+    ├── Worker 0 ─── poll ─── expireExhaustedRetries() ─── recoverApplies()
+    ├── Worker 1 ─── poll ─── recoverApplies()
+    └── Worker N ─── poll ─── recoverApplies()
+                       │
+                  every 10 seconds
+```
+
+Each worker independently calls `FindNextApply()` which atomically:
+- Selects one apply that needs attention (`FOR UPDATE SKIP LOCKED`)
+- Increments the attempt counter
+- Updates the heartbeat timestamp
+
+The SQL query matches two types of applies:
+- **Stale active**: `state IN (pending, running, ...) AND updated_at < NOW() - 1 MINUTE`
+- **Retryable**: `state = failed_retryable AND attempt < 10`
+
+After claiming, the worker resolves the appropriate Tern client (`LocalClient` or `GRPCClient`) and calls `ResumeApply`. For `LocalClient`, this re-executes the apply. For `GRPCClient`, this re-establishes the progress polling connection.
+
+### Worker pool
+
+The scheduler launches N concurrent workers (configured via `scheduler_workers`). Each worker is an independent goroutine running the same poll loop. Workers do not share state — concurrency safety comes from the database:
+
+- `FOR UPDATE SKIP LOCKED` ensures two workers never claim the same apply
+- Each worker claims at most one apply per poll cycle, then resumes it
+- Workers poll independently on the same 10-second interval (not synchronized)
+
+With 1 worker (default), the scheduler processes 1 apply every 10 seconds (6/minute). With 3 workers, up to 3 applies can be resumed concurrently. For most deployments, 1-3 workers is sufficient. Increase if you have many databases and frequent transient failures.
+
+### Configuration
+
+```yaml
+# config.yaml
+scheduler_workers: 3  # Number of concurrent workers (default: 1)
+```
+
+### Heartbeat
+
+Every running apply has a background goroutine that updates `updated_at` every 10 seconds. If the heartbeat fails 6 times consecutively (e.g., database connection lost), the apply context is cancelled to stop the engine cleanly. The scheduler will then pick up the stale apply on its next poll.
+
+### Retryable errors
+
+**All engine errors are retryable by default.** Engines must explicitly wrap errors with `engine.ErrNonRetryable` to mark them as permanent. This design reflects the reality that transient failures (connection drops, lock conflicts, API timeouts) are the common case — permanent failures (syntax errors, auth failures) are the exception.
+
+Examples of retryable errors (automatic, no wrapping needed):
+- MySQL connection refused, metadata lock timeout
+- PlanetScale API timeout, rate limit, schema snapshot in progress
+- Spirit checkpoint corruption (resume from clean state)
+
+Examples of non-retryable errors (engine wraps with `NewNonRetryableError`):
+- Deploy request not found after server restart (PlanetScale)
+- Authentication failure
+
+Retryable applies are re-dispatched immediately on the next scheduler poll (every 10 seconds). After 10 failed attempts, the apply transitions to permanent `failed`.
+
+### Retry granularity
+
+Retry operates at the **apply level**, not the task level. When an apply with 10 tasks fails at task 3:
+
+1. Tasks 1-2: already `completed` — preserved across retries
+2. Task 3: marked `failed_retryable`
+3. Tasks 4-10: marked `failed_retryable` (never ran)
+
+On retry, the scheduler calls `ResumeApply` which resets `failed_retryable` tasks to `pending` and re-executes with the same DDL. Completed tasks are not reset — only tasks in `failed_retryable` state are retried. The same task records are reused (no new tasks created).
+
+For crash recovery (stale heartbeat, not retryable), the path is different: `ResumeApply` calls `replanAndFilterTasks` which re-diffs desired vs current schema and filters out tasks whose DDL has already been applied.
+
+The `attempt` counter on the `applies` table controls the retry budget (max 10). Tasks also track their attempt count for debugging, but only the apply-level counter determines when to permanently fail.

--- a/e2e/local/vitess_test.go
+++ b/e2e/local/vitess_test.go
@@ -1610,6 +1610,38 @@ func TestVitess_Apply_DeferDeploy_StartTooEarly(t *testing.T) {
 	waitForApplyState(t, endpoint, applyResp.ApplyID, state.Apply.Completed, testutil.PollDeadline)
 }
 
+func TestVitess_Apply_MainBranchReuseFailsPermanently(t *testing.T) {
+	vitessAvailable(t)
+	clearSchemaBotState(t)
+
+	endpoint := schemabotURL(t)
+	colName := fmt.Sprintf("main_branch_col_%d", time.Now().UnixMilli()%100000)
+	schemaDir := newVitessSchemaDir(t, vitessSchemaWithOverrides(map[string]string{
+		"testapp_sharded/users.sql": usersSchemaWithColumn(colName),
+	}))
+
+	planResp, err := client.CallPlanAPI(endpoint, vitessDB, "vitess", "staging", schemaDir, "", 0)
+	require.NoError(t, err)
+	require.NotEmpty(t, planResp.PlanID)
+	require.NotEmpty(t, planResp.Changes, "expected plan to have changes")
+
+	applyResp, err := client.CallApplyAPI(endpoint, planResp.PlanID, vitessDB, "staging", "e2e-test",
+		map[string]string{"branch": "main", "skip_revert": "true"})
+	require.NoError(t, err)
+	require.NotEmpty(t, applyResp.ApplyID)
+
+	finalState := waitForApplyAnyState(t, endpoint, applyResp.ApplyID,
+		[]string{state.Apply.Failed, state.Apply.FailedRetryable}, testutil.PollDeadline)
+	assert.Equal(t, state.Apply.Failed, finalState)
+
+	progress, err := client.GetProgress(endpoint, applyResp.ApplyID)
+	require.NoError(t, err)
+	assert.True(t, state.IsState(progress.State, state.Apply.Failed))
+	assert.Equal(t, apitypes.ErrCodeEngineError, progress.ErrorCode)
+	assert.NotEqual(t, apitypes.ErrCodeEngineErrorRetryable, progress.ErrorCode)
+	assert.Contains(t, progress.ErrorMessage, "cannot reuse the main branch")
+}
+
 func TestVitess_Apply_BranchReuse(t *testing.T) {
 	vitessAvailable(t)
 	clearSchemaBotState(t)

--- a/integration/scheduler_test.go
+++ b/integration/scheduler_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/block/spirit/pkg/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -244,6 +245,26 @@ func TestScheduler_ExhaustedRetries(t *testing.T) {
 	applyID, err := ts.Storage.Applies().Create(ctx, exhaustedApply)
 	require.NoError(t, err)
 
+	task := &storage.Task{
+		TaskIdentifier: "task-exhausted-" + fmt.Sprintf("%d", now.UnixNano()%100000),
+		ApplyID:        applyID,
+		PlanID:         plan.ID,
+		Database:       appDBName,
+		DatabaseType:   "mysql",
+		Engine:         "spirit",
+		State:          state.Task.FailedRetryable,
+		ErrorMessage:   "transient failure after many retries",
+		TableName:      "users",
+		DDL:            string(schemaSQL),
+		DDLAction:      "create",
+		Options:        []byte("{}"),
+		Environment:    "staging",
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+	_, err = ts.Storage.Tasks().Create(ctx, task)
+	require.NoError(t, err)
+
 	t.Logf("Created exhausted apply %s with attempt=%d", exhaustedApply.ApplyIdentifier, exhaustedApply.Attempt)
 
 	// Start the scheduler
@@ -257,6 +278,11 @@ func TestScheduler_ExhaustedRetries(t *testing.T) {
 		require.NoError(t, err)
 		if apply != nil && apply.State == state.Apply.Failed {
 			t.Logf("Apply permanently failed as expected (attempt %d): %s", apply.Attempt, apply.ErrorMessage)
+			updatedTask, err := ts.Storage.Tasks().Get(ctx, task.TaskIdentifier)
+			require.NoError(t, err)
+			require.NotNil(t, updatedTask)
+			assert.Equal(t, state.Task.Failed, updatedTask.State)
+			assert.NotNil(t, updatedTask.CompletedAt)
 			return
 		}
 		if apply != nil && apply.State == state.Apply.Completed {
@@ -265,6 +291,46 @@ func TestScheduler_ExhaustedRetries(t *testing.T) {
 		time.Sleep(500 * time.Millisecond)
 	}
 	t.Fatal("timeout: scheduler did not expire the exhausted apply within 15s")
+}
+
+// TestScheduler_FindNextApply_DoesNotReclaimRetryableImmediately verifies that
+// claiming a retryable apply creates an exclusive lease. A second scheduler
+// worker must not be able to claim the same failed_retryable row before the
+// first worker has finished dispatching it.
+func TestScheduler_FindNextApply_DoesNotReclaimRetryableImmediately(t *testing.T) {
+	ctx := t.Context()
+	schemabotDB, err := sql.Open("mysql", schemabotDSN)
+	require.NoError(t, err)
+	require.NoError(t, schemabotDB.PingContext(ctx))
+	defer utils.CloseAndLog(schemabotDB)
+	clearStorageDB(t, schemabotDB)
+	stor := mysqlstore.New(schemabotDB)
+
+	now := time.Now()
+	_, err = stor.Applies().Create(ctx, &storage.Apply{
+		ApplyIdentifier: "apply-retryable-exclusive",
+		Database:        "exclusive_db",
+		DatabaseType:    "mysql",
+		Engine:          "spirit",
+		State:           state.Apply.FailedRetryable,
+		ErrorMessage:    "transient",
+		Attempt:         1,
+		Options:         []byte("{}"),
+		Environment:     "staging",
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	})
+	require.NoError(t, err)
+
+	claimed, err := stor.Applies().FindNextApply(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, claimed)
+	assert.Equal(t, "apply-retryable-exclusive", claimed.ApplyIdentifier)
+	assert.Equal(t, state.Apply.FailedRetryable, claimed.State)
+
+	claimedAgain, err := stor.Applies().FindNextApply(ctx)
+	require.NoError(t, err)
+	assert.Nil(t, claimedAgain, "retryable apply should not be claimed twice while the first claim is fresh")
 }
 
 // TestScheduler_BasicClaimAndResume verifies the scheduler claims a stale apply

--- a/integration/scheduler_test.go
+++ b/integration/scheduler_test.go
@@ -665,8 +665,69 @@ func TestScheduler_FailureCancelsRemainingTasks(t *testing.T) {
 	t.Fatal("timeout: apply did not reach permanent failed state")
 }
 
-// TestScheduler_DatabaseExclusion verifies that the lock mechanism prevents
-// two applies from running on the same database simultaneously.
+// TestScheduler_ClaimOrdering verifies that FindNextApply returns applies in
+// created_at order across different databases.
+func TestScheduler_ClaimOrdering(t *testing.T) {
+	ctx := t.Context()
+
+	db1Name, _ := createTestDB(t, "ord1_")
+	db2Name, _ := createTestDB(t, "ord2_")
+	schemabotDB, err := sql.Open("mysql", schemabotDSN)
+	require.NoError(t, err)
+	clearStorageDB(t, schemabotDB)
+	stor := mysqlstore.New(schemabotDB)
+	defer func() { _ = schemabotDB.Close() }()
+
+	now := time.Now()
+
+	// Older stale running apply on db1
+	olderApply := &storage.Apply{
+		ApplyIdentifier: "apply-order-older",
+		Database:        db1Name,
+		DatabaseType:    "mysql",
+		Engine:          "spirit",
+		State:           state.Apply.Running,
+		Options:         []byte("{}"),
+		Environment:     "staging",
+		CreatedAt:       now.Add(-2 * time.Minute),
+		UpdatedAt:       now.Add(-2 * time.Minute),
+	}
+	olderID, err := stor.Applies().Create(ctx, olderApply)
+	require.NoError(t, err)
+	_, err = schemabotDB.ExecContext(ctx, "UPDATE applies SET updated_at = NOW() - INTERVAL 2 MINUTE WHERE id = ?", olderID)
+	require.NoError(t, err)
+
+	// Newer failed_retryable apply on db2
+	newerApply := &storage.Apply{
+		ApplyIdentifier: "apply-order-newer",
+		Database:        db2Name,
+		DatabaseType:    "mysql",
+		Engine:          "spirit",
+		State:           state.Apply.FailedRetryable,
+		ErrorMessage:    "transient",
+		Options:         []byte("{}"),
+		Environment:     "staging",
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+	_, err = stor.Applies().Create(ctx, newerApply)
+	require.NoError(t, err)
+
+	// First claim: older stale running apply (created_at order)
+	claimed, err := stor.Applies().FindNextApply(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, claimed)
+	assert.Equal(t, "apply-order-older", claimed.ApplyIdentifier)
+
+	// Second claim: newer retryable apply (different database, no exclusion)
+	claimed2, err := stor.Applies().FindNextApply(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, claimed2)
+	assert.Equal(t, "apply-order-newer", claimed2.ApplyIdentifier)
+}
+
+// TestScheduler_DatabaseExclusion verifies that FindNextApply skips applies
+// when another active apply with a fresh heartbeat exists on the same database.
 func TestScheduler_DatabaseExclusion(t *testing.T) {
 	ctx := t.Context()
 
@@ -677,25 +738,24 @@ func TestScheduler_DatabaseExclusion(t *testing.T) {
 	stor := mysqlstore.New(schemabotDB)
 	defer func() { _ = schemabotDB.Close() }()
 
-	// Seed two applies for the same database — one running (stale), one failed_retryable
 	now := time.Now()
-	runningApply := &storage.Apply{
-		ApplyIdentifier: "apply-excl-running",
+
+	// Active running apply with fresh heartbeat
+	activeApply := &storage.Apply{
+		ApplyIdentifier: "apply-excl-active",
 		Database:        appDBName,
 		DatabaseType:    "mysql",
 		Engine:          "spirit",
 		State:           state.Apply.Running,
 		Options:         []byte("{}"),
 		Environment:     "staging",
-		CreatedAt:       now.Add(-2 * time.Minute),
-		UpdatedAt:       now.Add(-2 * time.Minute), // stale
+		CreatedAt:       now,
+		UpdatedAt:       now, // fresh heartbeat
 	}
-	runningID, err := stor.Applies().Create(ctx, runningApply)
-	require.NoError(t, err)
-	// Make heartbeat stale
-	_, err = schemabotDB.ExecContext(ctx, "UPDATE applies SET updated_at = NOW() - INTERVAL 2 MINUTE WHERE id = ?", runningID)
+	_, err = stor.Applies().Create(ctx, activeApply)
 	require.NoError(t, err)
 
+	// Retryable apply on the same database
 	retryableApply := &storage.Apply{
 		ApplyIdentifier: "apply-excl-retryable",
 		Database:        appDBName,
@@ -705,34 +765,18 @@ func TestScheduler_DatabaseExclusion(t *testing.T) {
 		ErrorMessage:    "transient",
 		Options:         []byte("{}"),
 		Environment:     "staging",
-		CreatedAt:       now,
-		UpdatedAt:       now,
+		CreatedAt:       now.Add(-time.Minute),
+		UpdatedAt:       now.Add(-time.Minute),
 	}
 	_, err = stor.Applies().Create(ctx, retryableApply)
 	require.NoError(t, err)
 
-	// FindNextApply should return the stale running one first (oldest by created_at)
+	// FindNextApply should return nil — the retryable apply is blocked by the
+	// active apply on the same database, and the active apply has a fresh
+	// heartbeat so it's not claimable.
 	claimed, err := stor.Applies().FindNextApply(ctx)
 	require.NoError(t, err)
-	require.NotNil(t, claimed)
-	assert.Equal(t, "apply-excl-running", claimed.ApplyIdentifier)
-
-	// After claiming, the running apply's updated_at is refreshed (no longer stale).
-	// Second claim should return the retryable one (still eligible).
-	claimed2, err := stor.Applies().FindNextApply(ctx)
-	require.NoError(t, err)
-	require.NotNil(t, claimed2)
-	assert.Equal(t, "apply-excl-retryable", claimed2.ApplyIdentifier)
-
-	// The running apply is no longer stale (updated_at refreshed by first claim).
-	// The retryable apply still matches (attempt < max). Verify the running one
-	// is NOT re-claimed (its heartbeat is fresh).
-	claimed3, err := stor.Applies().FindNextApply(ctx)
-	require.NoError(t, err)
-	if claimed3 != nil {
-		// Only the retryable can be re-claimed (still failed_retryable with attempt < max)
-		assert.Equal(t, "apply-excl-retryable", claimed3.ApplyIdentifier)
-	}
+	assert.Nil(t, claimed, "retryable apply should be excluded while another apply is active on the same database")
 }
 
 // TestScheduler_PlanetScaleBranchStates verifies that PlanetScale branch setup

--- a/integration/scheduler_test.go
+++ b/integration/scheduler_test.go
@@ -1,0 +1,1099 @@
+//go:build integration
+
+package integration
+
+import (
+	"database/sql"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	schemabotapi "github.com/block/schemabot/pkg/api"
+	"github.com/block/schemabot/pkg/state"
+	"github.com/block/schemabot/pkg/storage"
+	"github.com/block/schemabot/pkg/storage/mysqlstore"
+	"github.com/block/schemabot/pkg/tern"
+)
+
+func TestRecoveryLoop_FailedRetryable(t *testing.T) {
+	ctx := t.Context()
+
+	schemaSQL, err := os.ReadFile("testdata/myapp/mysql/schema/users.sql")
+	require.NoError(t, err, "read schema file")
+
+	appDBName, appDSN := createTestDB(t, "recovery_")
+	ts := startTestServer(t, appDBName, appDSN)
+
+	// Plan a CREATE TABLE
+	planResp := postJSON(t, "http://"+ts.Addr+"/api/plan", map[string]any{
+		"database":    appDBName,
+		"environment": "staging",
+		"type":        "mysql",
+		"schema_files": map[string]any{
+			"default": map[string]any{
+				"files": map[string]string{
+					"users.sql": string(schemaSQL),
+				},
+			},
+		},
+	})
+	planID, _ := planResp["plan_id"].(string)
+	require.NotEmpty(t, planID)
+
+	// Apply — this creates the table normally
+	applyResp := postJSON(t, "http://"+ts.Addr+"/api/apply", map[string]any{
+		"plan_id":     planID,
+		"environment": "staging",
+	})
+	require.True(t, applyResp["accepted"] == true)
+	applyID1, _ := applyResp["apply_id"].(string)
+	waitForState(t, "http://"+ts.Addr, applyID1, "completed", 15*time.Second)
+	t.Log("First apply completed, table exists")
+
+	// Drop the table so the next plan produces the same CREATE TABLE
+	targetConn, err := sql.Open("mysql", appDSN)
+	require.NoError(t, err)
+	defer func() { _ = targetConn.Close() }()
+	_, err = targetConn.ExecContext(ctx, "DROP TABLE IF EXISTS users")
+	require.NoError(t, err, "drop users table")
+
+	// Second plan — same CREATE TABLE
+	plan2Resp := postJSON(t, "http://"+ts.Addr+"/api/plan", map[string]any{
+		"database":    appDBName,
+		"environment": "staging",
+		"type":        "mysql",
+		"schema_files": map[string]any{
+			"default": map[string]any{
+				"files": map[string]string{
+					"users.sql": string(schemaSQL),
+				},
+			},
+		},
+	})
+	planID2, _ := plan2Resp["plan_id"].(string)
+	require.NotEmpty(t, planID2)
+
+	// Apply — but we'll intercept and mark as failed_retryable
+	apply2Resp := postJSON(t, "http://"+ts.Addr+"/api/apply", map[string]any{
+		"plan_id":     planID2,
+		"environment": "staging",
+	})
+	require.True(t, apply2Resp["accepted"] == true)
+	applyID2, _ := apply2Resp["apply_id"].(string)
+	require.NotEmpty(t, applyID2)
+
+	// Wait for the second apply to complete (it will succeed quickly since it's CREATE TABLE)
+	waitForState(t, "http://"+ts.Addr, applyID2, "completed", 15*time.Second)
+
+	// Now simulate the recovery scenario: drop table again, create a third plan+apply,
+	// and manually set state to failed_retryable before the engine runs.
+	_, err = targetConn.ExecContext(ctx, "DROP TABLE IF EXISTS users")
+	require.NoError(t, err)
+
+	plan3Resp := postJSON(t, "http://"+ts.Addr+"/api/plan", map[string]any{
+		"database":    appDBName,
+		"environment": "staging",
+		"type":        "mysql",
+		"schema_files": map[string]any{
+			"default": map[string]any{
+				"files": map[string]string{
+					"users.sql": string(schemaSQL),
+				},
+			},
+		},
+	})
+	planID3, _ := plan3Resp["plan_id"].(string)
+	require.NotEmpty(t, planID3)
+
+	// Look up the plan in storage to create the apply record directly
+	plan3, err := ts.Storage.Plans().Get(ctx, planID3)
+	require.NoError(t, err)
+	require.NotNil(t, plan3)
+
+	// Create an apply record directly in failed_retryable state
+	// (simulating an apply that ran partway and hit a transient error)
+	now := time.Now()
+	failedApply := &storage.Apply{
+		ApplyIdentifier: "apply-recovery-test-" + fmt.Sprintf("%d", now.UnixNano()%100000),
+		PlanID:          plan3.ID,
+		Database:        appDBName,
+		DatabaseType:    "mysql",
+		Engine:          "spirit",
+		State:           state.Apply.FailedRetryable,
+		ErrorMessage:    "simulated transient failure",
+		Options:         []byte("{}"),
+		Environment:     "staging",
+		CreatedAt:       now,
+		UpdatedAt:       now.Add(-2 * time.Minute), // stale heartbeat so FindNextApply picks it up
+	}
+	applyID3, err := ts.Storage.Applies().Create(ctx, failedApply)
+	require.NoError(t, err)
+	failedApply.ID = applyID3
+
+	// Create tasks for this apply (one per DDL change in the plan)
+	for _, tc := range plan3.FlatDDLChanges() {
+		task := &storage.Task{
+			TaskIdentifier: "task-recovery-" + fmt.Sprintf("%d", time.Now().UnixNano()%100000),
+			ApplyID:        applyID3,
+			PlanID:         plan3.ID,
+			Database:       appDBName,
+			DatabaseType:   "mysql",
+			Engine:         "spirit",
+			State:          state.Task.FailedRetryable,
+			ErrorMessage:   "simulated transient failure",
+			TableName:      tc.Table,
+			DDL:            tc.DDL,
+			DDLAction:      tc.Operation,
+			Options:        []byte("{}"),
+			Environment:    "staging",
+			CreatedAt:      now,
+			UpdatedAt:      now,
+		}
+		_, err := ts.Storage.Tasks().Create(ctx, task)
+		require.NoError(t, err)
+	}
+
+	t.Logf("Created failed_retryable apply %s with %d tasks", failedApply.ApplyIdentifier, len(plan3.FlatDDLChanges()))
+
+	// Start the scheduler — it will pick up the failed_retryable apply
+	ts.Service.StartScheduler(t.Context())
+	defer ts.Service.StopScheduler()
+
+	// Wait for the apply to be picked up and completed
+	deadline := time.Now().Add(20 * time.Second)
+	for time.Now().Before(deadline) {
+		apply, err := ts.Storage.Applies().Get(ctx, applyID3)
+		require.NoError(t, err)
+		if apply != nil && apply.State == state.Apply.Completed {
+			t.Logf("Recovery succeeded: apply %s completed (attempt %d)", apply.ApplyIdentifier, apply.Attempt)
+
+			// Verify the table was actually created
+			var tableName string
+			err := targetConn.QueryRowContext(ctx, `
+				SELECT TABLE_NAME FROM information_schema.TABLES
+				WHERE TABLE_SCHEMA = ? AND TABLE_NAME = 'users'
+			`, appDBName).Scan(&tableName)
+			require.NoError(t, err, "users table should exist after recovery")
+			t.Log("Recovery loop test passed: failed_retryable apply recovered and completed")
+			return
+		}
+		// Also check if it permanently failed (shouldn't happen)
+		if apply != nil && apply.State == state.Apply.Failed {
+			t.Fatalf("Apply permanently failed instead of recovering: %s", apply.ErrorMessage)
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	t.Fatal("timeout: recovery loop did not complete the apply within 20s")
+}
+
+// TestScheduler_ExhaustedRetries verifies that a failed_retryable apply that
+// has exhausted its retry budget (attempt >= maxRecoveryAttempts) gets
+// transitioned to permanent failed by the scheduler.
+func TestScheduler_ExhaustedRetries(t *testing.T) {
+	ctx := t.Context()
+
+	schemaSQL, err := os.ReadFile("testdata/myapp/mysql/schema/users.sql")
+	require.NoError(t, err)
+
+	appDBName, appDSN := createTestDB(t, "exhaust_")
+	ts := startTestServer(t, appDBName, appDSN)
+
+	// Create a plan so we have a valid plan_id for the apply
+	planResp := postJSON(t, "http://"+ts.Addr+"/api/plan", map[string]any{
+		"database":    appDBName,
+		"environment": "staging",
+		"type":        "mysql",
+		"schema_files": map[string]any{
+			"default": map[string]any{
+				"files": map[string]string{
+					"users.sql": string(schemaSQL),
+				},
+			},
+		},
+	})
+	planID, _ := planResp["plan_id"].(string)
+	require.NotEmpty(t, planID)
+
+	plan, err := ts.Storage.Plans().Get(ctx, planID)
+	require.NoError(t, err)
+
+	// Create an apply that has already exhausted its retry budget
+	now := time.Now()
+	exhaustedApply := &storage.Apply{
+		ApplyIdentifier: "apply-exhausted-" + fmt.Sprintf("%d", now.UnixNano()%100000),
+		PlanID:          plan.ID,
+		Database:        appDBName,
+		DatabaseType:    "mysql",
+		Engine:          "spirit",
+		State:           state.Apply.FailedRetryable,
+		ErrorMessage:    "transient failure after many retries",
+		Attempt:         10, // at the limit
+		Options:         []byte("{}"),
+		Environment:     "staging",
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+	applyID, err := ts.Storage.Applies().Create(ctx, exhaustedApply)
+	require.NoError(t, err)
+
+	t.Logf("Created exhausted apply %s with attempt=%d", exhaustedApply.ApplyIdentifier, exhaustedApply.Attempt)
+
+	// Start the scheduler
+	ts.Service.StartScheduler(t.Context())
+	defer ts.Service.StopScheduler()
+
+	// The scheduler should expire this apply to permanent failed
+	deadline := time.Now().Add(15 * time.Second)
+	for time.Now().Before(deadline) {
+		apply, err := ts.Storage.Applies().Get(ctx, applyID)
+		require.NoError(t, err)
+		if apply != nil && apply.State == state.Apply.Failed {
+			t.Logf("Apply permanently failed as expected (attempt %d): %s", apply.Attempt, apply.ErrorMessage)
+			return
+		}
+		if apply != nil && apply.State == state.Apply.Completed {
+			t.Fatal("Apply should have been permanently failed, not completed")
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	t.Fatal("timeout: scheduler did not expire the exhausted apply within 15s")
+}
+
+// TestScheduler_BasicClaimAndResume verifies the scheduler claims a stale apply
+// and resumes it to completion via ResumeApply.
+func TestScheduler_BasicClaimAndResume(t *testing.T) {
+	ctx := t.Context()
+	schemaSQL, err := os.ReadFile("testdata/myapp/mysql/schema/users.sql")
+	require.NoError(t, err)
+
+	appDBName, appDSN := createTestDB(t, "basic_sched_")
+	ts := startTestServer(t, appDBName, appDSN)
+
+	// Create plan + apply normally first
+	planResp := postJSON(t, "http://"+ts.Addr+"/api/plan", map[string]any{
+		"database": appDBName, "environment": "staging", "type": "mysql",
+		"schema_files": map[string]any{"default": map[string]any{"files": map[string]string{"users.sql": string(schemaSQL)}}},
+	})
+	planID, _ := planResp["plan_id"].(string)
+	require.NotEmpty(t, planID)
+
+	applyResp := postJSON(t, "http://"+ts.Addr+"/api/apply", map[string]any{
+		"plan_id": planID, "environment": "staging",
+	})
+	require.True(t, applyResp["accepted"] == true)
+	applyID, _ := applyResp["apply_id"].(string)
+	waitForState(t, "http://"+ts.Addr, applyID, "completed", 15*time.Second)
+
+	// Drop table, create a new plan, and seed a stale apply manually
+	targetConn, err := sql.Open("mysql", appDSN)
+	require.NoError(t, err)
+	defer func() { _ = targetConn.Close() }()
+	_, err = targetConn.ExecContext(ctx, "DROP TABLE IF EXISTS users")
+	require.NoError(t, err)
+
+	plan2Resp := postJSON(t, "http://"+ts.Addr+"/api/plan", map[string]any{
+		"database": appDBName, "environment": "staging", "type": "mysql",
+		"schema_files": map[string]any{"default": map[string]any{"files": map[string]string{"users.sql": string(schemaSQL)}}},
+	})
+	planID2, _ := plan2Resp["plan_id"].(string)
+	plan2, err := ts.Storage.Plans().Get(ctx, planID2)
+	require.NoError(t, err)
+
+	// Create a stale running apply (simulating a crashed worker)
+	now := time.Now()
+	staleApply := &storage.Apply{
+		ApplyIdentifier: fmt.Sprintf("apply-stale-%d", now.UnixNano()%100000),
+		PlanID:          plan2.ID,
+		Database:        appDBName,
+		DatabaseType:    "mysql",
+		Engine:          "spirit",
+		State:           state.Apply.Running,
+		Options:         []byte("{}"),
+		Environment:     "staging",
+		StartedAt:       &now,
+		CreatedAt:       now,
+		UpdatedAt:       now.Add(-2 * time.Minute), // stale heartbeat
+	}
+	staleID, err := ts.Storage.Applies().Create(ctx, staleApply)
+	require.NoError(t, err)
+
+	// Make the heartbeat stale (Create uses NOW() for updated_at, so override with raw SQL)
+	schemabotDB, err := sql.Open("mysql", schemabotDSN)
+	require.NoError(t, err)
+	defer func() { _ = schemabotDB.Close() }()
+	_, err = schemabotDB.ExecContext(ctx, "UPDATE applies SET updated_at = NOW() - INTERVAL 2 MINUTE WHERE id = ?", staleID)
+	require.NoError(t, err)
+
+	// Create tasks
+	for _, tc := range plan2.FlatDDLChanges() {
+		_, err := ts.Storage.Tasks().Create(ctx, &storage.Task{
+			TaskIdentifier: fmt.Sprintf("task-stale-%d", time.Now().UnixNano()%100000),
+			ApplyID:        staleID,
+			PlanID:         plan2.ID,
+			Database:       appDBName,
+			DatabaseType:   "mysql",
+			Engine:         "spirit",
+			State:          state.Task.Running,
+			TableName:      tc.Table,
+			DDL:            tc.DDL,
+			DDLAction:      tc.Operation,
+			Options:        []byte("{}"),
+			Environment:    "staging",
+			CreatedAt:      now,
+			UpdatedAt:      now,
+		})
+		require.NoError(t, err)
+	}
+
+	// Start scheduler — it should claim the stale apply and resume it
+	ts.Service.StartScheduler(t.Context())
+	defer ts.Service.StopScheduler()
+
+	deadline := time.Now().Add(20 * time.Second)
+	for time.Now().Before(deadline) {
+		apply, err := ts.Storage.Applies().Get(ctx, staleID)
+		require.NoError(t, err)
+		if apply != nil && apply.State == state.Apply.Completed {
+			t.Logf("Scheduler resumed stale apply successfully")
+			return
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	t.Fatal("timeout: scheduler did not resume stale apply")
+}
+
+// TestScheduler_MultiWorkerClaiming verifies that multiple workers can claim
+// different applies concurrently without double-claiming.
+func TestScheduler_MultiWorkerClaiming(t *testing.T) {
+	ctx := t.Context()
+	schemaSQL, err := os.ReadFile("testdata/myapp/mysql/schema/users.sql")
+	require.NoError(t, err)
+
+	appDBName1, appDSN1 := createTestDB(t, "mw1_")
+	appDBName2, appDSN2 := createTestDB(t, "mw2_")
+
+	// Build a multi-database server
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	schemabotDB, err := sql.Open("mysql", schemabotDSN)
+	require.NoError(t, err)
+	clearStorageDB(t, schemabotDB)
+	stor := mysqlstore.New(schemabotDB)
+
+	client1, err := tern.NewLocalClient(tern.LocalConfig{
+		Database: appDBName1, Type: "mysql", TargetDSN: appDSN1,
+	}, stor, logger)
+	require.NoError(t, err)
+	client2, err := tern.NewLocalClient(tern.LocalConfig{
+		Database: appDBName2, Type: "mysql", TargetDSN: appDSN2,
+	}, stor, logger)
+	require.NoError(t, err)
+
+	serverConfig := &schemabotapi.ServerConfig{
+		SchedulerWorkers: 3,
+		Databases: map[string]schemabotapi.DatabaseConfig{
+			appDBName1: {Type: "mysql", Environments: map[string]schemabotapi.EnvironmentConfig{"staging": {DSN: appDSN1}}},
+			appDBName2: {Type: "mysql", Environments: map[string]schemabotapi.EnvironmentConfig{"staging": {DSN: appDSN2}}},
+		},
+	}
+	svc := schemabotapi.New(stor, serverConfig, map[string]tern.Client{
+		appDBName1 + "/staging": client1,
+		appDBName2 + "/staging": client2,
+	}, logger)
+	defer func() { _ = svc.Close() }()
+
+	mux := http.NewServeMux()
+	svc.ConfigureRoutes(mux)
+	listener, err := (&net.ListenConfig{}).Listen(t.Context(), "tcp", "localhost:0")
+	require.NoError(t, err)
+	server := &http.Server{Handler: mux}
+	go func() { _ = server.Serve(listener) }()
+	t.Cleanup(func() { _ = server.Close() })
+	addr := listener.Addr().String()
+	waitForHealth(t, addr)
+
+	// Create plans for both databases
+	plan1 := postJSON(t, "http://"+addr+"/api/plan", map[string]any{
+		"database": appDBName1, "environment": "staging", "type": "mysql",
+		"schema_files": map[string]any{"default": map[string]any{"files": map[string]string{"users.sql": string(schemaSQL)}}},
+	})
+	plan2 := postJSON(t, "http://"+addr+"/api/plan", map[string]any{
+		"database": appDBName2, "environment": "staging", "type": "mysql",
+		"schema_files": map[string]any{"default": map[string]any{"files": map[string]string{"users.sql": string(schemaSQL)}}},
+	})
+
+	// Create failed_retryable applies for both
+	now := time.Now()
+	p1, _ := stor.Plans().Get(ctx, plan1["plan_id"].(string))
+	p2, _ := stor.Plans().Get(ctx, plan2["plan_id"].(string))
+
+	for _, p := range []struct {
+		plan *storage.Plan
+		db   string
+	}{{p1, appDBName1}, {p2, appDBName2}} {
+		apply := &storage.Apply{
+			ApplyIdentifier: fmt.Sprintf("apply-mw-%s-%d", p.db, now.UnixNano()%100000),
+			PlanID:          p.plan.ID,
+			Database:        p.db,
+			DatabaseType:    "mysql",
+			Engine:          "spirit",
+			State:           state.Apply.FailedRetryable,
+			ErrorMessage:    "transient",
+			Options:         []byte("{}"),
+			Environment:     "staging",
+			CreatedAt:       now,
+			UpdatedAt:       now,
+		}
+		applyID, err := stor.Applies().Create(ctx, apply)
+		require.NoError(t, err)
+		for _, tc := range p.plan.FlatDDLChanges() {
+			_, err := stor.Tasks().Create(ctx, &storage.Task{
+				TaskIdentifier: fmt.Sprintf("task-mw-%d", time.Now().UnixNano()%100000),
+				ApplyID:        applyID,
+				PlanID:         p.plan.ID,
+				Database:       p.db,
+				DatabaseType:   "mysql",
+				Engine:         "spirit",
+				State:          state.Task.FailedRetryable,
+				TableName:      tc.Table,
+				DDL:            tc.DDL,
+				DDLAction:      tc.Operation,
+				Options:        []byte("{}"),
+				Environment:    "staging",
+				CreatedAt:      now,
+				UpdatedAt:      now,
+			})
+			require.NoError(t, err)
+		}
+	}
+
+	// Start scheduler with 3 workers
+	svc.StartScheduler(t.Context())
+	defer svc.StopScheduler()
+
+	// Both applies should complete
+	deadline := time.Now().Add(20 * time.Second)
+	completed := 0
+	for time.Now().Before(deadline) && completed < 2 {
+		completed = 0
+		applies, err := stor.Applies().GetInProgress(ctx)
+		require.NoError(t, err)
+		// Count non-terminal applies for our test databases
+		activeCount := 0
+		for _, a := range applies {
+			if a.Database == appDBName1 || a.Database == appDBName2 {
+				activeCount++
+			}
+		}
+		// If no active applies remain, both completed
+		if activeCount == 0 {
+			completed = 2
+			break
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	assert.Equal(t, 2, completed, "both applies should have completed")
+}
+
+// TestScheduler_PanicRecovery verifies that if an apply panics, the panic
+// is caught, the apply is marked as failed, and the scheduler continues working.
+func TestScheduler_PanicRecovery(t *testing.T) {
+	ctx := t.Context()
+	schemaSQL, err := os.ReadFile("testdata/myapp/mysql/schema/users.sql")
+	require.NoError(t, err)
+
+	appDBName, appDSN := createTestDB(t, "panic_")
+	ts := startTestServer(t, appDBName, appDSN)
+
+	// First: normal apply to verify the table gets created
+	planResp := postJSON(t, "http://"+ts.Addr+"/api/plan", map[string]any{
+		"database": appDBName, "environment": "staging", "type": "mysql",
+		"schema_files": map[string]any{"default": map[string]any{"files": map[string]string{"users.sql": string(schemaSQL)}}},
+	})
+	applyResp := postJSON(t, "http://"+ts.Addr+"/api/apply", map[string]any{
+		"plan_id": planResp["plan_id"], "environment": "staging",
+	})
+	require.True(t, applyResp["accepted"] == true)
+	waitForState(t, "http://"+ts.Addr, applyResp["apply_id"].(string), "completed", 15*time.Second)
+
+	// The table was created successfully. Drop it to set up the next test.
+	targetConn, err := sql.Open("mysql", appDSN)
+	require.NoError(t, err)
+	defer func() { _ = targetConn.Close() }()
+	_, err = targetConn.ExecContext(ctx, "DROP TABLE IF EXISTS users")
+	require.NoError(t, err)
+
+	// Second apply: this will succeed via normal path, verifying
+	// that runWithRecovery catches panics at the goroutine level.
+	// The panic recovery is tested by the unit test in local_apply_test.go.
+	// Here we verify the full scheduler path works end-to-end.
+	plan2 := postJSON(t, "http://"+ts.Addr+"/api/plan", map[string]any{
+		"database": appDBName, "environment": "staging", "type": "mysql",
+		"schema_files": map[string]any{"default": map[string]any{"files": map[string]string{"users.sql": string(schemaSQL)}}},
+	})
+	apply2 := postJSON(t, "http://"+ts.Addr+"/api/apply", map[string]any{
+		"plan_id": plan2["plan_id"], "environment": "staging",
+	})
+	require.True(t, apply2["accepted"] == true)
+	waitForState(t, "http://"+ts.Addr, apply2["apply_id"].(string), "completed", 15*time.Second)
+
+	// Verify table exists
+	var tableName string
+	err = targetConn.QueryRowContext(ctx, `
+		SELECT TABLE_NAME FROM information_schema.TABLES
+		WHERE TABLE_SCHEMA = ? AND TABLE_NAME = 'users'
+	`, appDBName).Scan(&tableName)
+	require.NoError(t, err, "users table should exist")
+}
+
+// TestScheduler_FailureCancelsRemainingTasks verifies that when a multi-task
+// apply is executed and the first task fails, the apply transitions to a failure
+// state and remaining tasks are not completed.
+func TestScheduler_FailureCancelsRemainingTasks(t *testing.T) {
+	ctx := t.Context()
+	schemaSQL, err := os.ReadFile("testdata/myapp/mysql/schema/users.sql")
+	require.NoError(t, err)
+
+	appDBName, appDSN := createTestDB(t, "cancel_tasks_")
+	ts := startTestServer(t, appDBName, appDSN)
+
+	// Create a plan that has changes
+	planResp := postJSON(t, "http://"+ts.Addr+"/api/plan", map[string]any{
+		"database": appDBName, "environment": "staging", "type": "mysql",
+		"schema_files": map[string]any{"default": map[string]any{"files": map[string]string{
+			"users.sql": string(schemaSQL),
+		}}},
+	})
+	planID, _ := planResp["plan_id"].(string)
+	require.NotEmpty(t, planID)
+	plan, err := ts.Storage.Plans().Get(ctx, planID)
+	require.NoError(t, err)
+
+	// Create an apply at max attempts so it gets expired to permanent failed
+	// without being retried. This verifies that task states are preserved.
+	now := time.Now()
+	failApply := &storage.Apply{
+		ApplyIdentifier: fmt.Sprintf("apply-cancel-%d", now.UnixNano()%100000),
+		PlanID:          plan.ID,
+		Database:        appDBName,
+		DatabaseType:    "mysql",
+		Engine:          "spirit",
+		State:           state.Apply.FailedRetryable,
+		ErrorMessage:    "simulated failure",
+		Attempt:         10, // at max — will be expired immediately
+		Options:         []byte("{}"),
+		Environment:     "staging",
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+	applyID, err := ts.Storage.Applies().Create(ctx, failApply)
+	require.NoError(t, err)
+
+	// First task: DROP TABLE that doesn't exist — will fail
+	_, err = ts.Storage.Tasks().Create(ctx, &storage.Task{
+		TaskIdentifier: fmt.Sprintf("task-drop-%d", time.Now().UnixNano()%100000),
+		ApplyID:        applyID,
+		PlanID:         plan.ID,
+		Database:       appDBName,
+		DatabaseType:   "mysql",
+		Engine:         "spirit",
+		State:          state.Task.FailedRetryable,
+		TableName:      "nonexistent",
+		DDL:            "DROP TABLE `nonexistent`",
+		DDLAction:      "drop",
+		Options:        []byte("{}"),
+		Environment:    "staging",
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	})
+	require.NoError(t, err)
+
+	// Second task: valid CREATE TABLE — should not be executed
+	_, err = ts.Storage.Tasks().Create(ctx, &storage.Task{
+		TaskIdentifier: fmt.Sprintf("task-create-%d", time.Now().UnixNano()%100000),
+		ApplyID:        applyID,
+		PlanID:         plan.ID,
+		Database:       appDBName,
+		DatabaseType:   "mysql",
+		Engine:         "spirit",
+		State:          state.Task.FailedRetryable,
+		TableName:      "users",
+		DDL:            string(schemaSQL),
+		DDLAction:      "create",
+		Options:        []byte("{}"),
+		Environment:    "staging",
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	})
+	require.NoError(t, err)
+
+	// Start scheduler
+	ts.Service.StartScheduler(t.Context())
+	defer ts.Service.StopScheduler()
+
+	// Wait for the apply to be expired to permanent failed
+	deadline := time.Now().Add(20 * time.Second)
+	for time.Now().Before(deadline) {
+		apply, err := ts.Storage.Applies().Get(ctx, applyID)
+		require.NoError(t, err)
+		if apply != nil && apply.State == state.Apply.Failed {
+			t.Logf("Apply permanently failed as expected (attempt %d)", apply.Attempt)
+
+			// Verify the users table was NOT created (second task should not have run)
+			targetConn, err := sql.Open("mysql", appDSN)
+			require.NoError(t, err)
+			defer func() { _ = targetConn.Close() }()
+			var count int
+			err = targetConn.QueryRowContext(ctx, `
+				SELECT COUNT(*) FROM information_schema.TABLES
+				WHERE TABLE_SCHEMA = ? AND TABLE_NAME = 'users'
+			`, appDBName).Scan(&count)
+			require.NoError(t, err)
+			assert.Equal(t, 0, count, "users table should NOT exist — second task should not have run")
+			return
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	t.Fatal("timeout: apply did not reach permanent failed state")
+}
+
+// TestScheduler_DatabaseExclusion verifies that the lock mechanism prevents
+// two applies from running on the same database simultaneously.
+func TestScheduler_DatabaseExclusion(t *testing.T) {
+	ctx := t.Context()
+
+	appDBName, _ := createTestDB(t, "excl_")
+	schemabotDB, err := sql.Open("mysql", schemabotDSN)
+	require.NoError(t, err)
+	clearStorageDB(t, schemabotDB)
+	stor := mysqlstore.New(schemabotDB)
+	defer func() { _ = schemabotDB.Close() }()
+
+	// Seed two applies for the same database — one running (stale), one failed_retryable
+	now := time.Now()
+	runningApply := &storage.Apply{
+		ApplyIdentifier: "apply-excl-running",
+		Database:        appDBName,
+		DatabaseType:    "mysql",
+		Engine:          "spirit",
+		State:           state.Apply.Running,
+		Options:         []byte("{}"),
+		Environment:     "staging",
+		CreatedAt:       now.Add(-2 * time.Minute),
+		UpdatedAt:       now.Add(-2 * time.Minute), // stale
+	}
+	runningID, err := stor.Applies().Create(ctx, runningApply)
+	require.NoError(t, err)
+	// Make heartbeat stale
+	_, err = schemabotDB.ExecContext(ctx, "UPDATE applies SET updated_at = NOW() - INTERVAL 2 MINUTE WHERE id = ?", runningID)
+	require.NoError(t, err)
+
+	retryableApply := &storage.Apply{
+		ApplyIdentifier: "apply-excl-retryable",
+		Database:        appDBName,
+		DatabaseType:    "mysql",
+		Engine:          "spirit",
+		State:           state.Apply.FailedRetryable,
+		ErrorMessage:    "transient",
+		Options:         []byte("{}"),
+		Environment:     "staging",
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+	_, err = stor.Applies().Create(ctx, retryableApply)
+	require.NoError(t, err)
+
+	// FindNextApply should return the stale running one first (oldest by created_at)
+	claimed, err := stor.Applies().FindNextApply(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, claimed)
+	assert.Equal(t, "apply-excl-running", claimed.ApplyIdentifier)
+
+	// After claiming, the running apply's updated_at is refreshed (no longer stale).
+	// Second claim should return the retryable one (still eligible).
+	claimed2, err := stor.Applies().FindNextApply(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, claimed2)
+	assert.Equal(t, "apply-excl-retryable", claimed2.ApplyIdentifier)
+
+	// The running apply is no longer stale (updated_at refreshed by first claim).
+	// The retryable apply still matches (attempt < max). Verify the running one
+	// is NOT re-claimed (its heartbeat is fresh).
+	claimed3, err := stor.Applies().FindNextApply(ctx)
+	require.NoError(t, err)
+	if claimed3 != nil {
+		// Only the retryable can be re-claimed (still failed_retryable with attempt < max)
+		assert.Equal(t, "apply-excl-retryable", claimed3.ApplyIdentifier)
+	}
+}
+
+// TestScheduler_PlanetScaleBranchStates verifies that PlanetScale branch setup
+// states (preparing_branch, applying_branch_changes, etc.) are claimed when
+// stale, and that database exclusion works for them.
+func TestScheduler_PlanetScaleBranchStates(t *testing.T) {
+	ctx := t.Context()
+
+	appDBName, _ := createTestDB(t, "ps_states_")
+	schemabotDB, err := sql.Open("mysql", schemabotDSN)
+	require.NoError(t, err)
+	clearStorageDB(t, schemabotDB)
+	stor := mysqlstore.New(schemabotDB)
+	defer func() { _ = schemabotDB.Close() }()
+
+	// Create a stale apply in preparing_branch state (server crashed during PS setup)
+	now := time.Now()
+	_, err = stor.Applies().Create(ctx, &storage.Apply{
+		ApplyIdentifier: "apply-ps-preparing",
+		Database:        appDBName,
+		DatabaseType:    "vitess",
+		Engine:          "planetscale",
+		State:           state.Apply.PreparingBranch,
+		Options:         []byte("{}"),
+		Environment:     "staging",
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	})
+	require.NoError(t, err)
+	// Make heartbeat stale
+	_, err = schemabotDB.ExecContext(ctx, "UPDATE applies SET updated_at = NOW() - INTERVAL 2 MINUTE WHERE apply_identifier = 'apply-ps-preparing'")
+	require.NoError(t, err)
+
+	// Stale preparing_branch should be claimed
+	claimed, err := stor.Applies().FindNextApply(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, claimed, "stale preparing_branch should be claimed")
+	assert.Equal(t, "apply-ps-preparing", claimed.ApplyIdentifier)
+
+	// Now create a fresh applying_branch_changes apply on the same database
+	_, err = stor.Applies().Create(ctx, &storage.Apply{
+		ApplyIdentifier: "apply-ps-applying",
+		Database:        appDBName,
+		DatabaseType:    "vitess",
+		Engine:          "planetscale",
+		State:           state.Apply.ApplyingBranchChanges,
+		Options:         []byte("{}"),
+		Environment:     "staging",
+		CreatedAt:       now,
+		UpdatedAt:       now, // fresh heartbeat
+	})
+	require.NoError(t, err)
+
+	// Create a retryable apply on the same database
+	_, err = stor.Applies().Create(ctx, &storage.Apply{
+		ApplyIdentifier: "apply-ps-retryable",
+		Database:        appDBName,
+		DatabaseType:    "vitess",
+		Engine:          "planetscale",
+		State:           state.Apply.FailedRetryable,
+		ErrorMessage:    "transient",
+		Options:         []byte("{}"),
+		Environment:     "staging",
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	})
+	require.NoError(t, err)
+
+	// The retryable should NOT be claimed because applying_branch_changes
+	// has a fresh heartbeat (database exclusion)
+	claimed2, err := stor.Applies().FindNextApply(ctx)
+	require.NoError(t, err)
+	// The first claim refreshed preparing_branch's heartbeat. The retryable
+	// should be blocked by the fresh applying_branch_changes apply.
+	if claimed2 != nil {
+		assert.NotEqual(t, "apply-ps-retryable", claimed2.ApplyIdentifier,
+			"retryable should be blocked by active apply on same database")
+	}
+
+	// Test all PlanetScale states are claimable when stale
+	for _, ps := range []string{
+		state.Apply.ValidatingBranch,
+		state.Apply.CreatingDeployRequest,
+		state.Apply.ValidatingDeployRequest,
+	} {
+		clearStorageDB(t, schemabotDB)
+		_, err = stor.Applies().Create(ctx, &storage.Apply{
+			ApplyIdentifier: "apply-ps-" + ps,
+			Database:        appDBName,
+			DatabaseType:    "vitess",
+			Engine:          "planetscale",
+			State:           ps,
+			Options:         []byte("{}"),
+			Environment:     "staging",
+			CreatedAt:       now,
+			UpdatedAt:       now,
+		})
+		require.NoError(t, err)
+		_, err = schemabotDB.ExecContext(ctx,
+			"UPDATE applies SET updated_at = NOW() - INTERVAL 2 MINUTE WHERE apply_identifier = ?",
+			"apply-ps-"+ps)
+		require.NoError(t, err)
+
+		claimed, err := stor.Applies().FindNextApply(ctx)
+		require.NoError(t, err)
+		require.NotNil(t, claimed, "stale %s should be claimed", ps)
+		assert.Equal(t, "apply-ps-"+ps, claimed.ApplyIdentifier)
+	}
+}
+
+// TestScheduler_HeartbeatFailureCancelsApply verifies that when the heartbeat
+// fails repeatedly (e.g., DB connection lost), the apply context is cancelled
+// and the apply is marked as failed rather than running indefinitely.
+func TestScheduler_HeartbeatFailureCancelsApply(t *testing.T) {
+	ctx := t.Context()
+	schemaSQL, err := os.ReadFile("testdata/myapp/mysql/schema/users.sql")
+	require.NoError(t, err)
+
+	appDBName, appDSN := createTestDB(t, "hb_fail_")
+
+	// Use a separate DB connection for storage that we can close mid-test
+	schemabotDB, err := sql.Open("mysql", schemabotDSN)
+	require.NoError(t, err)
+	clearStorageDB(t, schemabotDB)
+	stor := mysqlstore.New(schemabotDB)
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	localClient, err := tern.NewLocalClient(tern.LocalConfig{
+		Database: appDBName, Type: "mysql", TargetDSN: appDSN,
+	}, stor, logger)
+	require.NoError(t, err)
+	// Use a fast heartbeat so the test doesn't take long
+	localClient.SetHeartbeatInterval(50 * time.Millisecond)
+
+	serverConfig := &schemabotapi.ServerConfig{
+		Databases: map[string]schemabotapi.DatabaseConfig{
+			appDBName: {Type: "mysql", Environments: map[string]schemabotapi.EnvironmentConfig{
+				"staging": {DSN: appDSN},
+			}},
+		},
+	}
+	svc := schemabotapi.New(stor, serverConfig, map[string]tern.Client{
+		appDBName + "/staging": localClient,
+	}, logger)
+	defer func() { _ = svc.Close() }()
+
+	mux := http.NewServeMux()
+	svc.ConfigureRoutes(mux)
+	listener, err := (&net.ListenConfig{}).Listen(t.Context(), "tcp", "localhost:0")
+	require.NoError(t, err)
+	server := &http.Server{Handler: mux}
+	go func() { _ = server.Serve(listener) }()
+	t.Cleanup(func() { _ = server.Close() })
+	addr := listener.Addr().String()
+	waitForHealth(t, addr)
+
+	// Create a plan that produces a large ALTER TABLE (slow enough to be interrupted)
+	// First, create the table with data
+	targetConn, err := sql.Open("mysql", appDSN)
+	require.NoError(t, err)
+	defer func() { _ = targetConn.Close() }()
+
+	// Create table and seed data so ALTER takes time
+	_, err = targetConn.ExecContext(ctx, string(schemaSQL))
+	require.NoError(t, err)
+
+	// Plan an ALTER that adds a column
+	alterSchema := strings.Replace(string(schemaSQL),
+		"PRIMARY KEY (`id`)",
+		"`new_col` varchar(255) DEFAULT NULL,\n  PRIMARY KEY (`id`)",
+		1)
+	planResp := postJSON(t, "http://"+addr+"/api/plan", map[string]any{
+		"database": appDBName, "environment": "staging", "type": "mysql",
+		"schema_files": map[string]any{"default": map[string]any{"files": map[string]string{
+			"users.sql": alterSchema,
+		}}},
+	})
+	planID, _ := planResp["plan_id"].(string)
+	require.NotEmpty(t, planID)
+
+	// Start the apply
+	applyResp := postJSON(t, "http://"+addr+"/api/apply", map[string]any{
+		"plan_id": planID, "environment": "staging",
+	})
+	require.True(t, applyResp["accepted"] == true)
+	applyIDStr, _ := applyResp["apply_id"].(string)
+
+	// Wait briefly for apply to start running
+	time.Sleep(200 * time.Millisecond)
+
+	// Close the storage DB — this will cause heartbeat failures
+	err = schemabotDB.Close()
+	require.NoError(t, err)
+
+	// With heartbeat interval of 50ms and maxConsecutiveHeartbeatFailures=6,
+	// the context should be cancelled in ~300ms
+	time.Sleep(1 * time.Second)
+
+	// Reopen storage to check the state
+	schemabotDB2, err := sql.Open("mysql", schemabotDSN)
+	require.NoError(t, err)
+	defer func() { _ = schemabotDB2.Close() }()
+	stor2 := mysqlstore.New(schemabotDB2)
+
+	apply, err := stor2.Applies().GetByApplyIdentifier(ctx, applyIDStr)
+	require.NoError(t, err)
+	require.NotNil(t, apply)
+
+	// The apply should be in a failed or failed_retryable state due to heartbeat cancellation
+	t.Logf("Apply state after heartbeat failure: %s (error: %s)", apply.State, apply.ErrorMessage)
+	isFailed := apply.State == state.Apply.Failed ||
+		apply.State == state.Apply.FailedRetryable ||
+		apply.State == state.Apply.Completed // instant DDL may complete before heartbeat fails
+	assert.True(t, isFailed,
+		"apply should be failed/completed after heartbeat cancellation, got: %s", apply.State)
+}
+
+// waitForHealth polls the health endpoint until it returns 200.
+func waitForHealth(t *testing.T, addr string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if time.Now().After(deadline) {
+			require.Fail(t, "timeout waiting for HTTP server")
+		}
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://"+addr+"/health", nil)
+		require.NoError(t, err)
+		resp, err := http.DefaultClient.Do(req)
+		if err == nil {
+			_ = resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// TestScheduler_TaskRetryBehavior verifies that on apply-level retry:
+//   - completed tasks are preserved (not reset)
+//   - failed_retryable tasks are reset to pending and re-executed
+//   - task attempt counter is incremented
+func TestScheduler_TaskRetryBehavior(t *testing.T) {
+	ctx := t.Context()
+	schemaSQL, err := os.ReadFile("testdata/myapp/mysql/schema/users.sql")
+	require.NoError(t, err)
+
+	appDBName, appDSN := createTestDB(t, "task_retry_")
+	ts := startTestServer(t, appDBName, appDSN)
+
+	// Create a plan
+	planResp := postJSON(t, "http://"+ts.Addr+"/api/plan", map[string]any{
+		"database": appDBName, "environment": "staging", "type": "mysql",
+		"schema_files": map[string]any{"default": map[string]any{"files": map[string]string{
+			"users.sql": string(schemaSQL),
+		}}},
+	})
+	planID, _ := planResp["plan_id"].(string)
+	require.NotEmpty(t, planID)
+	plan, err := ts.Storage.Plans().Get(ctx, planID)
+	require.NoError(t, err)
+
+	// Create a failed_retryable apply with two tasks:
+	// - task 1: completed (should be preserved)
+	// - task 2: failed_retryable (should be reset and re-executed)
+	now := time.Now()
+	retryApply := &storage.Apply{
+		ApplyIdentifier: fmt.Sprintf("apply-task-retry-%d", now.UnixNano()%100000),
+		PlanID:          plan.ID,
+		Database:        appDBName,
+		DatabaseType:    "mysql",
+		Engine:          "spirit",
+		State:           state.Apply.FailedRetryable,
+		ErrorMessage:    "transient failure",
+		Attempt:         1,
+		Options:         []byte("{}"),
+		Environment:     "staging",
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+	applyID, err := ts.Storage.Applies().Create(ctx, retryApply)
+	require.NoError(t, err)
+
+	// Task 1: already completed — should not be touched
+	completedTask := &storage.Task{
+		TaskIdentifier: fmt.Sprintf("task-completed-%d", time.Now().UnixNano()%100000),
+		ApplyID:        applyID,
+		PlanID:         plan.ID,
+		Database:       appDBName,
+		DatabaseType:   "mysql",
+		Engine:         "spirit",
+		State:          state.Task.Completed,
+		TableName:      "users",
+		DDL:            string(schemaSQL),
+		DDLAction:      "create",
+		Attempt:        1,
+		Options:        []byte("{}"),
+		Environment:    "staging",
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+	completedNow := now
+	completedTask.CompletedAt = &completedNow
+	_, err = ts.Storage.Tasks().Create(ctx, completedTask)
+	require.NoError(t, err)
+
+	// Task 2: failed_retryable — should be reset to pending and retried
+	failedTask := &storage.Task{
+		TaskIdentifier: fmt.Sprintf("task-retryable-%d", time.Now().UnixNano()%100000),
+		ApplyID:        applyID,
+		PlanID:         plan.ID,
+		Database:       appDBName,
+		DatabaseType:   "mysql",
+		Engine:         "spirit",
+		State:          state.Task.FailedRetryable,
+		ErrorMessage:   "transient connection error",
+		TableName:      "users",
+		DDL:            string(schemaSQL),
+		DDLAction:      "create",
+		Attempt:        1,
+		Options:        []byte("{}"),
+		Environment:    "staging",
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+	_, err = ts.Storage.Tasks().Create(ctx, failedTask)
+	require.NoError(t, err)
+
+	t.Logf("Created apply %s with completed task %s and retryable task %s",
+		retryApply.ApplyIdentifier, completedTask.TaskIdentifier, failedTask.TaskIdentifier)
+
+	// Start scheduler
+	ts.Service.StartScheduler(t.Context())
+	defer ts.Service.StopScheduler()
+
+	// Wait for the apply to complete (or fail permanently)
+	deadline := time.Now().Add(20 * time.Second)
+	for time.Now().Before(deadline) {
+		apply, err := ts.Storage.Applies().Get(ctx, applyID)
+		require.NoError(t, err)
+		if apply != nil && (apply.State == state.Apply.Completed || apply.State == state.Apply.Failed) {
+			t.Logf("Apply reached state: %s (attempt %d)", apply.State, apply.Attempt)
+
+			// Verify completed task was NOT reset
+			ct, err := ts.Storage.Tasks().Get(ctx, completedTask.TaskIdentifier)
+			require.NoError(t, err)
+			assert.Equal(t, state.Task.Completed, ct.State, "completed task should stay completed")
+			assert.Equal(t, 0, ct.Attempt, "completed task attempt should not change")
+			assert.NotNil(t, ct.CompletedAt, "completed task should keep its CompletedAt")
+
+			// Verify retryable task was reset and re-executed
+			// Task.Create doesn't insert attempt (defaults to 0 in DB).
+			// retryFailedApply increments it to 1 on first retry.
+			ft, err := ts.Storage.Tasks().Get(ctx, failedTask.TaskIdentifier)
+			require.NoError(t, err)
+			assert.Equal(t, 1, ft.Attempt, "retryable task attempt should be incremented")
+
+			return
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	t.Fatal("timeout: apply did not reach terminal state")
+}

--- a/integration/workflow_test.go
+++ b/integration/workflow_test.go
@@ -33,6 +33,7 @@ import (
 type testServer struct {
 	Addr    string
 	Storage *mysqlstore.Storage
+	Service *schemabotapi.Service
 }
 
 // createTestDB creates a uniquely-named test database and returns its name and DSN.
@@ -125,7 +126,7 @@ func startTestServer(t *testing.T, appDBName, appDSN string) testServer {
 		_ = schemabotDB.Close()
 	})
 
-	return testServer{Addr: addr, Storage: storage}
+	return testServer{Addr: addr, Storage: storage, Service: svc}
 }
 
 // postJSON marshals body as JSON, POSTs to url, asserts HTTP 200,
@@ -1459,3 +1460,13 @@ CREATE TABLE ccc_cancelled (
 
 	t.Log("Partial failure test passed: 1 completed, 1 failed, 1 cancelled")
 }
+
+// TestRecoveryLoop_FailedRetryable verifies that the recovery loop picks up
+// a failed_retryable apply and completes it. The test:
+//  1. Creates a plan via API (CREATE TABLE)
+//  2. Creates an apply via API — it succeeds and creates the table
+//  3. Drops the table and creates a second plan (same CREATE TABLE)
+//  4. Calls Apply API for the second plan, waits for running, then
+//     manually sets the apply to failed_retryable (simulating transient failure)
+//  5. Starts the recovery loop
+//  6. Verifies the apply transitions to completed and the table exists

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -43,6 +43,11 @@ type ServerConfig struct {
 	// When empty or nil, all environments are allowed (backwards compatible).
 	AllowedEnvironments []string `yaml:"allowed_environments"`
 
+	// SchedulerWorkers is the number of concurrent scheduler workers that claim
+	// and resume applies. Each worker independently polls FindNextApply with
+	// FOR UPDATE SKIP LOCKED to prevent races. Defaults to 1.
+	SchedulerWorkers int `yaml:"scheduler_workers"`
+
 	// RequirePassingChecks blocks apply when non-SchemaBot PR checks are failing.
 	// When enabled (default), SchemaBot verifies that all other checks (CI, linters,
 	// security scans) have passed before executing a schema change. Checks with

--- a/pkg/api/progress_handlers.go
+++ b/pkg/api/progress_handlers.go
@@ -35,7 +35,13 @@ func changeTypeToString(ct ternv1.ChangeType) string {
 // deriveErrorCode returns an error code based on apply state
 // and error message. Returns empty string when no error code applies.
 func deriveErrorCode(applyState, errorMessage string) string {
-	if errorMessage != "" && state.IsState(applyState, state.Apply.Failed) {
+	if errorMessage == "" {
+		return ""
+	}
+	if state.IsState(applyState, state.Apply.FailedRetryable) {
+		return apitypes.ErrCodeEngineErrorRetryable
+	}
+	if state.IsState(applyState, state.Apply.Failed) {
 		return apitypes.ErrCodeEngineError
 	}
 	return ""

--- a/pkg/api/scheduler.go
+++ b/pkg/api/scheduler.go
@@ -5,66 +5,59 @@ import (
 	"time"
 
 	"github.com/block/schemabot/pkg/metrics"
+	"github.com/block/schemabot/pkg/state"
+	"github.com/block/schemabot/pkg/storage"
 )
 
-// Recovery worker constants.
+// Scheduler constants.
 const (
-	// RecoveryPollInterval is how often we poll for in-progress applies that need recovery.
-	RecoveryPollInterval = 10 * time.Second
+	// SchedulerPollInterval is how often each worker polls for applies that need attention.
+	SchedulerPollInterval = 10 * time.Second
 
 	// HeartbeatTimeout is how long since last heartbeat before
 	// an apply is considered to have a crashed worker and needs recovery.
-	// ClaimForRecovery uses this (via SQL: updated_at < NOW() - INTERVAL 1 MINUTE).
+	// FindNextApply uses this (via SQL: updated_at < NOW() - INTERVAL 1 MINUTE).
 	HeartbeatTimeout = 1 * time.Minute
+
+	// DefaultSchedulerWorkers is the number of concurrent scheduler workers
+	// when not configured via scheduler_workers in the server config.
+	DefaultSchedulerWorkers = 1
 )
 
-// StartRecoveryWorker starts a background worker that finds and resumes
-// in-progress applies whose workers crashed.
+// StartScheduler starts the background scheduler that handles:
+//   - Crash recovery: resumes applies whose workers crashed (stale heartbeats)
+//   - Retryable recovery: re-dispatches failed_retryable applies within attempt limit
+//   - Retry expiration: transitions exhausted failed_retryable applies to permanent failed
 //
-//   - Runs immediately on startup, then polls every 10 seconds
-//   - Finds applies with no heartbeat for 1+ minute (worker crashed)
-//   - Claims them using FOR UPDATE SKIP LOCKED (prevents races)
-//   - Resumes the apply via the appropriate Tern client
-//   - STOPPED applies are NOT auto-resumed (user must call `schemabot start`)
-//
-// This unified approach (vs separate startup + background recovery) ensures:
-//   - No race window if server restarts quickly (within 1 minute of last heartbeat)
-//   - In-progress applies are always recovered once their heartbeat times out
-//
-// Call StopRecoveryWorker to gracefully stop the worker.
-func (s *Service) StartRecoveryWorker(ctx context.Context) {
+// Launches N concurrent workers (configured via scheduler_workers in config).
+// Each worker independently claims applies using FOR UPDATE SKIP LOCKED.
+// Call StopScheduler to gracefully stop.
+func (s *Service) StartScheduler(ctx context.Context) {
 	if s.stopRecovery != nil {
-		s.logger.Info("recovery worker already running")
+		s.logger.Info("scheduler already running")
 		return
 	}
+
+	workers := s.config.SchedulerWorkers
+	if workers <= 0 {
+		workers = DefaultSchedulerWorkers
+	}
+
 	s.stopRecovery = make(chan struct{})
-	s.recoveryWg.Go(func() {
-		ticker := time.NewTicker(RecoveryPollInterval)
-		defer ticker.Stop()
 
-		s.logger.Info("started recovery worker", "interval", RecoveryPollInterval)
+	for i := range workers {
+		workerID := i
+		s.recoveryWg.Go(func() {
+			s.schedulerWorker(ctx, workerID)
+		})
+	}
 
-		// Run immediately on startup, then on each tick
-		s.resumeInProgressApplies(ctx)
-
-		for {
-			select {
-			case <-s.stopRecovery:
-				s.logger.Info("stopping recovery worker")
-				return
-			case <-ctx.Done():
-				s.logger.Info("recovery worker context cancelled")
-				return
-			case <-ticker.C:
-				s.resumeInProgressApplies(ctx)
-			}
-		}
-	})
+	s.logger.Info("scheduler started", "workers", workers, "interval", SchedulerPollInterval)
 }
 
-// StopRecoveryWorker stops the background recovery worker and waits for it to finish.
+// StopScheduler stops the background scheduler and waits for all workers to finish.
 // Safe to call multiple times.
-func (s *Service) StopRecoveryWorker() {
+func (s *Service) StopScheduler() {
 	if s.stopRecovery == nil {
 		return
 	}
@@ -73,67 +66,125 @@ func (s *Service) StopRecoveryWorker() {
 	s.recoveryWg.Wait()
 }
 
-// resumeInProgressApplies finds and resumes all in-progress applies whose workers crashed.
-// Loops until no more applies need recovery.
-func (s *Service) resumeInProgressApplies(ctx context.Context) {
-	var recovered, failed int
+// schedulerWorker is a single worker that polls for applies on each tick.
+func (s *Service) schedulerWorker(ctx context.Context, workerID int) {
+	ticker := time.NewTicker(SchedulerPollInterval)
+	defer ticker.Stop()
 
-	// Loop until no more applies to recover
+	s.logger.Debug("scheduler worker started", "worker", workerID)
+
+	// Run immediately on startup, then on each tick
+	s.schedulerTick(ctx, workerID)
+
 	for {
-		apply, err := s.storage.Applies().ClaimForRecovery(ctx)
-		if err != nil {
-			s.logger.Error("recovery worker: failed to claim apply", "error", err)
-			break
+		select {
+		case <-s.stopRecovery:
+			s.logger.Debug("scheduler worker stopping", "worker", workerID)
+			return
+		case <-ctx.Done():
+			s.logger.Debug("scheduler worker context cancelled", "worker", workerID)
+			return
+		case <-ticker.C:
+			s.schedulerTick(ctx, workerID)
 		}
+	}
+}
 
-		if apply == nil {
-			// No more applies need recovery
-			break
-		}
+// schedulerTick runs one cycle: expire exhausted retries, then claim and resume applies.
+func (s *Service) schedulerTick(ctx context.Context, workerID int) {
+	// Only one worker needs to run expiry per cycle (idempotent, but avoid redundant work)
+	if workerID == 0 {
+		s.expireExhaustedRetries(ctx)
+	}
+	s.recoverApplies(ctx, workerID)
+}
 
-		s.logger.Info("recovery worker: found in-progress apply with crashed worker",
-			"apply_id", apply.ApplyIdentifier,
-			"database", apply.Database,
-			"environment", apply.Environment,
-			"state", apply.State,
-			"last_heartbeat", apply.UpdatedAt)
+// expireExhaustedRetries transitions failed_retryable applies that have
+// exhausted their retry budget to permanent failed.
+func (s *Service) expireExhaustedRetries(ctx context.Context) {
+	n, err := s.storage.Applies().ExpireRetryable(ctx)
+	if err != nil {
+		s.logger.Error("scheduler: expire retryable failed", "error", err)
+		return
+	}
+	if n > 0 {
+		s.logger.Info("scheduler: expired exhausted retryable applies", "count", n)
+		metrics.RecordSchedulerExpired(ctx, n)
+	}
+}
 
-		// Get Tern client using the deployment stored on the apply.
-		deployment := s.resolveDeployment(apply.Database, apply.Deployment)
-		client, err := s.TernClient(deployment, apply.Environment)
-		if err != nil {
-			s.logger.Error("recovery worker: failed to get client",
-				"apply_id", apply.ApplyIdentifier,
-				"database", apply.Database,
-				"environment", apply.Environment,
-				"error", err)
-			failed++
-			continue
-		}
-
-		// Resume the apply
-		if err := client.ResumeApply(ctx, apply); err != nil {
-			s.logger.Error("recovery worker: failed to resume apply",
-				"apply_id", apply.ApplyIdentifier,
-				"database", apply.Database,
-				"error", err)
-			failed++
-			continue
-		}
-
-		s.logger.Info("recovery worker: resumed apply",
-			"apply_id", apply.ApplyIdentifier,
-			"database", apply.Database,
-			"environment", apply.Environment,
-			"previous_state", apply.State)
-		recovered++
+// recoverApplies claims and resumes applies that need attention.
+// Each call claims one apply (if available) to keep the scheduling loop responsive.
+func (s *Service) recoverApplies(ctx context.Context, workerID int) {
+	apply, err := s.storage.Applies().FindNextApply(ctx)
+	if err != nil {
+		s.logger.Error("scheduler: failed to claim apply", "worker", workerID, "error", err)
+		return
 	}
 
-	metrics.RecordRecoveryCycle(ctx, recovered, failed)
+	if apply == nil {
+		return
+	}
 
-	if recovered > 0 || failed > 0 {
-		s.logger.Info("recovery worker: cycle complete",
-			"recovered", recovered,
-			"failed", failed)
+	start := time.Now()
+	s.logger.Info("scheduler: claimed apply",
+		"worker", workerID,
+		"apply_id", apply.ApplyIdentifier,
+		"database", apply.Database,
+		"environment", apply.Environment,
+		"state", apply.State,
+		"attempt", apply.Attempt,
+		"last_heartbeat", apply.UpdatedAt)
+
+	previousState := apply.State
+
+	deployment := s.resolveDeployment(apply.Database, apply.Deployment)
+	client, err := s.TernClient(deployment, apply.Environment)
+	if err != nil {
+		s.logger.Error("scheduler: failed to get client",
+			"worker", workerID,
+			"apply_id", apply.ApplyIdentifier,
+			"database", apply.Database,
+			"environment", apply.Environment,
+			"error", err)
+		if apply.State == state.Apply.FailedRetryable {
+			s.failApply(ctx, apply, "scheduler: no client available for retry")
+		}
+		metrics.RecordSchedulerResumeFailure(ctx, apply.Database, apply.Environment, "no_client")
+		return
+	}
+
+	if err := client.ResumeApply(ctx, apply); err != nil {
+		s.logger.Error("scheduler: failed to resume apply",
+			"worker", workerID,
+			"apply_id", apply.ApplyIdentifier,
+			"database", apply.Database,
+			"error", err)
+		metrics.RecordSchedulerResumeFailure(ctx, apply.Database, apply.Environment, "resume_error")
+		return
+	}
+
+	duration := time.Since(start)
+	s.logger.Info("scheduler: resumed apply",
+		"worker", workerID,
+		"apply_id", apply.ApplyIdentifier,
+		"database", apply.Database,
+		"environment", apply.Environment,
+		"previous_state", previousState,
+		"duration", duration)
+	metrics.RecordSchedulerResume(ctx, apply.Database, apply.Environment, previousState)
+	metrics.RecordSchedulerClaimDuration(ctx, duration, apply.Database, apply.Environment, previousState)
+}
+
+// failApply permanently fails an apply that can't be recovered.
+func (s *Service) failApply(ctx context.Context, apply *storage.Apply, errMsg string) {
+	now := time.Now()
+	apply.State = state.Apply.Failed
+	apply.ErrorMessage = errMsg
+	apply.CompletedAt = &now
+	apply.UpdatedAt = now
+	if err := s.storage.Applies().Update(ctx, apply); err != nil {
+		s.logger.Error("scheduler: failed to mark apply as permanently failed",
+			"apply_id", apply.ApplyIdentifier, "error", err)
 	}
 }

--- a/pkg/api/scheduler_test.go
+++ b/pkg/api/scheduler_test.go
@@ -1,0 +1,19 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSchedulerWorkersConfig(t *testing.T) {
+	t.Run("default workers", func(t *testing.T) {
+		config := &ServerConfig{}
+		assert.Equal(t, 0, config.SchedulerWorkers)
+	})
+
+	t.Run("configured workers", func(t *testing.T) {
+		config := &ServerConfig{SchedulerWorkers: 3}
+		assert.Equal(t, 3, config.SchedulerWorkers)
+	})
+}

--- a/pkg/api/service.go
+++ b/pkg/api/service.go
@@ -470,8 +470,8 @@ func (s *Service) Storage() storage.Storage {
 
 // Close closes the service and releases resources.
 func (s *Service) Close() error {
-	// Stop the background recovery worker first
-	s.StopRecoveryWorker()
+	// Stop the scheduler first
+	s.StopScheduler()
 
 	s.ternMu.Lock()
 	var errs []error

--- a/pkg/api/telemetry_test.go
+++ b/pkg/api/telemetry_test.go
@@ -329,7 +329,7 @@ func TestRecordLockOperationMetric(t *testing.T) {
 	assert.True(t, names["schemabot.lock_operations_total"], "expected schemabot.lock_operations_total")
 }
 
-func TestRecordRecoveryCycleMetric(t *testing.T) {
+func TestRecordSchedulerMetrics(t *testing.T) {
 	reader := sdkmetric.NewManualReader()
 	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
 	prevMP := otel.GetMeterProvider()
@@ -339,12 +339,16 @@ func TestRecordRecoveryCycleMetric(t *testing.T) {
 		require.NoError(t, mp.Shutdown(t.Context()))
 	})
 
-	metrics.RecordRecoveryCycle(t.Context(), 2, 1)
+	metrics.RecordSchedulerResume(t.Context(), "testdb", "staging", "running")
+	metrics.RecordSchedulerResumeFailure(t.Context(), "testdb", "staging", "no_client")
+	metrics.RecordSchedulerExpired(t.Context(), 3)
+	metrics.RecordSchedulerClaimDuration(t.Context(), 50*time.Millisecond, "testdb", "staging", "failed_retryable")
 
 	names := collectMetricNames(t, reader)
-	assert.True(t, names["schemabot.recovery.cycles_total"], "expected schemabot.recovery.cycles_total")
-	assert.True(t, names["schemabot.recovery.recovered_total"], "expected schemabot.recovery.recovered_total")
-	assert.True(t, names["schemabot.recovery.failed_total"], "expected schemabot.recovery.failed_total")
+	assert.True(t, names["schemabot.scheduler.resumed_total"], "expected schemabot.scheduler.resumed_total")
+	assert.True(t, names["schemabot.scheduler.resume_failures_total"], "expected schemabot.scheduler.resume_failures_total")
+	assert.True(t, names["schemabot.scheduler.expired_total"], "expected schemabot.scheduler.expired_total")
+	assert.True(t, names["schemabot.scheduler.claim_duration_seconds"], "expected schemabot.scheduler.claim_duration_seconds")
 }
 
 // setupTraceTest creates an in-memory trace exporter and configures the global

--- a/pkg/apitypes/apitypes.go
+++ b/pkg/apitypes/apitypes.go
@@ -11,19 +11,21 @@ package apitypes
 // constants rather than parsing error_message strings or HTTP status codes.
 // Use IsRetryableErrorCode to determine whether a given code is retryable.
 const (
-	ErrCodeInvalidRequest     = "invalid_request"      // Malformed request (missing params, bad values)
-	ErrCodeNotFound           = "not_found"            // Resource doesn't exist (unknown apply ID, database)
-	ErrCodeDeploymentNotFound = "deployment_not_found" // No tern deployment configured for database/environment
-	ErrCodeEngineError        = "engine_error"         // Schema change engine failure during execution
-	ErrCodeStorageError       = "storage_error"        // Storage backend (MySQL) read/write failure
-	ErrCodeEngineUnavailable  = "engine_unavailable"   // Schema change engine (Tern) unreachable or RPC error
-	ErrCodeStateSyncFailed    = "state_sync_failed"    // Operation succeeded but local state sync failed
+	ErrCodeInvalidRequest       = "invalid_request"        // Malformed request (missing params, bad values)
+	ErrCodeNotFound             = "not_found"              // Resource doesn't exist (unknown apply ID, database)
+	ErrCodeDeploymentNotFound   = "deployment_not_found"   // No tern deployment configured for database/environment
+	ErrCodeEngineError          = "engine_error"           // Schema change engine failure during execution (permanent)
+	ErrCodeEngineErrorRetryable = "engine_error_retryable" // Schema change engine failure that may recover on retry
+	ErrCodeStorageError         = "storage_error"          // Storage backend (MySQL) read/write failure
+	ErrCodeEngineUnavailable    = "engine_unavailable"     // Schema change engine (Tern) unreachable or RPC error
+	ErrCodeStateSyncFailed      = "state_sync_failed"      // Operation succeeded but local state sync failed
 )
 
 var retryableErrorCodes = map[string]bool{
-	ErrCodeStorageError:      true,
-	ErrCodeEngineUnavailable: true,
-	ErrCodeStateSyncFailed:   true,
+	ErrCodeEngineErrorRetryable: true,
+	ErrCodeStorageError:         true,
+	ErrCodeEngineUnavailable:    true,
+	ErrCodeStateSyncFailed:      true,
 }
 
 // IsRetryableErrorCode reports whether the given API error code represents a

--- a/pkg/cmd/commands/serve.go
+++ b/pkg/cmd/commands/serve.go
@@ -88,6 +88,11 @@ func (cmd *ServeCmd) Run(g *Globals) error {
 		break
 	}
 
+	// Proactively discard idle connections before MySQL's wait_timeout (default 28800s)
+	// to avoid "invalid connection" errors when the pool hands out stale connections.
+	db.SetConnMaxLifetime(5 * time.Minute)
+	db.SetConnMaxIdleTime(3 * time.Minute)
+
 	// Log config summary for debugging
 	logger.Info("config loaded",
 		"databases", len(serverConfig.Databases),
@@ -109,13 +114,9 @@ func (cmd *ServeCmd) Run(g *Globals) error {
 	svc := api.New(storage, serverConfig, nil, logger)
 	defer utils.CloseAndLog(svc)
 
-	// Start the recovery worker.
-	// This unified approach polls for stale applies every 10 seconds:
-	// - Runs immediately on startup
-	// - Recovers applies with stale heartbeats (> 1 minute) using FOR UPDATE SKIP LOCKED
-	// - STOPPED applies are NOT auto-resumed (user must call `schemabot start`)
+	// Start the scheduler: crash recovery, retryable applies, and retry expiration.
 	ctx := context.Background()
-	svc.StartRecoveryWorker(ctx)
+	svc.StartScheduler(ctx)
 
 	// Optionally start gRPC server for Tern proto (used by docker-compose.grpc.yml)
 	var grpcServer *grpc.Server

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -12,6 +12,7 @@ package engine
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -430,4 +431,33 @@ type Config struct {
 	// Timeouts
 	BranchTimeout time.Duration // Timeout for branch creation/readiness
 	DeployTimeout time.Duration // Timeout for deploy operations
+}
+
+// RetryableError wraps an error to indicate it is transient and the operation
+// can be retried. Engines return this for known-recoverable failures like
+// network timeouts, schema snapshots in progress, or binlog streaming errors.
+type RetryableError struct {
+	Err error
+}
+
+func (e *RetryableError) Error() string { return e.Err.Error() }
+func (e *RetryableError) Unwrap() error { return e.Err }
+
+// NewRetryableError wraps an error as retryable.
+func NewRetryableError(err error) error {
+	return &RetryableError{Err: err}
+}
+
+// IsRetryable returns true if the error should be retried by the scheduler.
+// All errors are retryable by default — only errors explicitly wrapped with
+// ErrNonRetryable are permanent. This matches the proven pattern where
+// transient failures (connection drops, lock conflicts, API timeouts) are
+// the common case, and permanent failures (syntax errors, auth failures)
+// are the exception that engines must explicitly mark.
+func IsRetryable(err error) bool {
+	if err == nil {
+		return false
+	}
+	var nre *ErrNonRetryable
+	return !errors.As(err, &nre)
 }

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -112,4 +113,42 @@ func TestEncodeResumeState_Nil(t *testing.T) {
 	encoded, err := EncodeResumeState(nil)
 	require.NoError(t, err)
 	assert.Equal(t, "", encoded)
+}
+
+func TestIsRetryable(t *testing.T) {
+	t.Run("plain error is retryable by default", func(t *testing.T) {
+		err := fmt.Errorf("connection refused")
+		assert.True(t, IsRetryable(err))
+	})
+
+	t.Run("wrapped error is retryable by default", func(t *testing.T) {
+		err := fmt.Errorf("apply failed: %w", fmt.Errorf("network timeout"))
+		assert.True(t, IsRetryable(err))
+	})
+
+	t.Run("NonRetryableError is not retryable", func(t *testing.T) {
+		err := NewNonRetryableError("DDL syntax error")
+		assert.False(t, IsRetryable(err))
+	})
+
+	t.Run("wrapped NonRetryableError is not retryable", func(t *testing.T) {
+		err := fmt.Errorf("apply failed: %w", NewNonRetryableError("auth failure"))
+		assert.False(t, IsRetryable(err))
+	})
+
+	t.Run("nil is not retryable", func(t *testing.T) {
+		assert.False(t, IsRetryable(nil))
+	})
+
+	t.Run("RetryableError is still retryable", func(t *testing.T) {
+		err := NewRetryableError(fmt.Errorf("schema snapshot in progress"))
+		assert.True(t, IsRetryable(err))
+	})
+}
+
+func TestRetryableError_Unwrap(t *testing.T) {
+	inner := fmt.Errorf("network timeout")
+	err := NewRetryableError(inner)
+	assert.ErrorIs(t, err, inner)
+	assert.Contains(t, err.Error(), "network timeout")
 }

--- a/pkg/engine/planetscale/planetscale.go
+++ b/pkg/engine/planetscale/planetscale.go
@@ -829,7 +829,7 @@ func (e *Engine) Apply(ctx context.Context, req *engine.ApplyRequest) (*engine.A
 		// Reuse existing branch: wait for ready, refresh schema from main, wait again
 		branchName = existingBranch
 		if branchName == main {
-			return nil, fmt.Errorf("cannot reuse the %s branch — use a development branch", main)
+			return nil, engine.NewNonRetryableError("cannot reuse the %s branch: use a development branch", main)
 		}
 		persistState(&psMetadata{BranchName: branchName})
 		emitEvent(engine.ApplyEvent{
@@ -1258,6 +1258,9 @@ func (e *Engine) applyKeyspaceChanges(ctx context.Context, sc engine.SchemaChang
 		if err := e.applyKeyspaceChangesOnce(ctx, sc, schemaFiles, password, client, org, database, branchName); err != nil {
 			lastErr = err
 			e.logger.Error(fmt.Sprintf("keyspace %s apply attempt %d failed", sc.Namespace, attempt+1), "keyspace", sc.Namespace, "attempt", attempt+1, "error", err)
+			if !isRetryableEngineError(err) {
+				return engine.NewNonRetryableError("apply keyspace %s: %w", sc.Namespace, err)
+			}
 			if isSnapshotInProgress(err) && maxAttempts == maxRetries {
 				maxAttempts = maxSnapshotRetries
 				e.logger.Info("schema snapshot in progress, extending retries",
@@ -1274,7 +1277,7 @@ func (e *Engine) applyKeyspaceChanges(ctx context.Context, sc engine.SchemaChang
 	if isRetryableEngineError(lastErr) {
 		return engine.NewRetryableError(finalErr)
 	}
-	return finalErr
+	return engine.NewNonRetryableError("%w", finalErr)
 }
 
 // isRetryableEngineError returns true if the error is a transient condition

--- a/pkg/engine/planetscale/planetscale.go
+++ b/pkg/engine/planetscale/planetscale.go
@@ -1268,7 +1268,61 @@ func (e *Engine) applyKeyspaceChanges(ctx context.Context, sc engine.SchemaChang
 		e.logger.Info(fmt.Sprintf("keyspace %s changes applied (%s)", sc.Namespace, time.Since(start).Round(time.Second)), "keyspace", sc.Namespace, "elapsed", time.Since(start).Round(time.Second))
 		return nil
 	}
-	return fmt.Errorf("apply keyspace %s (after %d attempts): %w", sc.Namespace, maxAttempts, lastErr)
+	finalErr := fmt.Errorf("apply keyspace %s (after %d attempts): %w", sc.Namespace, maxAttempts, lastErr)
+	// Wrap as retryable if the last error was a transient condition.
+	// This signals the apply orchestration to use failed_retryable instead of failed.
+	if isRetryableEngineError(lastErr) {
+		return engine.NewRetryableError(finalErr)
+	}
+	return finalErr
+}
+
+// isRetryableEngineError returns true if the error is a transient condition
+// that may succeed on a future attempt. Used to wrap errors as RetryableError
+// when engine-level retries are exhausted.
+//
+// Classification uses the PlanetScale SDK's typed error codes where available,
+// falling back to message matching for errors outside the SDK (MySQL connection
+// errors, context deadlines, etc.).
+func isRetryableEngineError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	// PlanetScale SDK typed errors
+	var psErr *ps.Error
+	if errors.As(err, &psErr) {
+		switch psErr.Code {
+		case ps.ErrRetry:
+			return true // 422 "unprocessable" — SDK says retry
+		case ps.ErrInternal, ps.ErrResponseMalformed:
+			return true // 500 / malformed response — transient server issues
+		case ps.ErrNotFound, ps.ErrPermission, ps.ErrInvalid:
+			return false // permanent — wrong resource, auth, or bad request
+		default:
+			// Unknown code — check the message for known transient patterns.
+			// "schema snapshot is in progress" falls here (PS returns it with
+			// an empty error code).
+		}
+	}
+
+	// Message-based fallback for errors outside the PS SDK
+	return isSnapshotInProgress(err) ||
+		isTransientNetworkError(err)
+}
+
+// isTransientNetworkError returns true for common network/connection errors
+// that are transient and may resolve on retry.
+func isTransientNetworkError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "connection refused") ||
+		strings.Contains(msg, "connection reset") ||
+		strings.Contains(msg, "i/o timeout") ||
+		strings.Contains(msg, "context deadline exceeded") ||
+		strings.Contains(msg, "Too many requests")
 }
 
 // isSnapshotInProgress returns true if the error indicates PlanetScale is

--- a/pkg/engine/planetscale/planetscale_test.go
+++ b/pkg/engine/planetscale/planetscale_test.go
@@ -1,6 +1,7 @@
 package planetscale
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"os"
@@ -15,10 +16,23 @@ import (
 	"github.com/block/schemabot/pkg/ddl"
 	"github.com/block/schemabot/pkg/engine"
 	"github.com/block/schemabot/pkg/lint"
+	"github.com/block/schemabot/pkg/psclient"
 	"github.com/block/schemabot/pkg/schema"
 	"github.com/block/schemabot/pkg/state"
 	"github.com/block/spirit/pkg/table"
 )
+
+type permanentVSchemaErrorClient struct {
+	psclient.PSClient
+	updateCalls int
+}
+
+var _ psclient.PSClient = (*permanentVSchemaErrorClient)(nil)
+
+func (c *permanentVSchemaErrorClient) UpdateKeyspaceVSchema(context.Context, *ps.UpdateKeyspaceVSchemaRequest) (*ps.VSchema, error) {
+	c.updateCalls++
+	return nil, &ps.Error{Code: ps.ErrInvalid}
+}
 
 func TestDeployStateToEngineState(t *testing.T) {
 	tests := []struct {
@@ -466,6 +480,55 @@ func TestIsRetryableEngineError(t *testing.T) {
 	t.Run("nil is NOT retryable", func(t *testing.T) {
 		assert.False(t, isRetryableEngineError(nil))
 	})
+}
+
+func TestApply_MainBranchReuseIsNonRetryable(t *testing.T) {
+	e := NewWithClient(slog.New(slog.NewTextHandler(os.Stdout, nil)), func(_, _ string) (psclient.PSClient, error) {
+		return nil, nil
+	})
+
+	_, err := e.Apply(t.Context(), &engine.ApplyRequest{
+		Database: "testdb",
+		Options: map[string]string{
+			"branch": "main",
+		},
+		Credentials: &engine.Credentials{
+			Metadata: map[string]string{
+				"organization": "org",
+				"token_name":   "token",
+				"token_value":  "secret",
+				"main_branch":  "main",
+			},
+		},
+	})
+
+	require.Error(t, err)
+	assert.False(t, engine.IsRetryable(err))
+	assert.Contains(t, err.Error(), "cannot reuse the main branch")
+}
+
+func TestApplyKeyspaceChanges_PermanentVSchemaErrorIsNonRetryable(t *testing.T) {
+	e := New(slog.New(slog.NewTextHandler(os.Stdout, nil)))
+	client := &permanentVSchemaErrorClient{}
+
+	err := e.applyKeyspaceChanges(t.Context(),
+		engine.SchemaChange{
+			Namespace: "testapp",
+			Metadata:  map[string]string{"vschema_changed": "true"},
+		},
+		schema.SchemaFiles{
+			"testapp": &schema.Namespace{Files: map[string]string{"vschema.json": "{}"}},
+		},
+		&ps.DatabaseBranchPassword{},
+		client,
+		"org",
+		"database",
+		"branch",
+	)
+
+	require.Error(t, err)
+	assert.False(t, engine.IsRetryable(err))
+	assert.Equal(t, 1, client.updateCalls)
 }
 
 func TestRetryDelay(t *testing.T) {

--- a/pkg/engine/planetscale/planetscale_test.go
+++ b/pkg/engine/planetscale/planetscale_test.go
@@ -412,6 +412,62 @@ func TestIsSnapshotInProgress(t *testing.T) {
 	assert.False(t, isSnapshotInProgress(nil))
 }
 
+func TestIsRetryableEngineError(t *testing.T) {
+	t.Run("PS SDK ErrRetry is retryable", func(t *testing.T) {
+		err := &ps.Error{Code: ps.ErrRetry}
+		assert.True(t, isRetryableEngineError(err))
+	})
+
+	t.Run("PS SDK ErrInternal is retryable", func(t *testing.T) {
+		err := &ps.Error{Code: ps.ErrInternal}
+		assert.True(t, isRetryableEngineError(err))
+	})
+
+	t.Run("PS SDK ErrResponseMalformed is retryable", func(t *testing.T) {
+		err := &ps.Error{Code: ps.ErrResponseMalformed}
+		assert.True(t, isRetryableEngineError(err))
+	})
+
+	t.Run("PS SDK ErrNotFound is NOT retryable", func(t *testing.T) {
+		err := &ps.Error{Code: ps.ErrNotFound}
+		assert.False(t, isRetryableEngineError(err))
+	})
+
+	t.Run("PS SDK ErrPermission is NOT retryable", func(t *testing.T) {
+		err := &ps.Error{Code: ps.ErrPermission}
+		assert.False(t, isRetryableEngineError(err))
+	})
+
+	t.Run("PS SDK ErrInvalid is NOT retryable", func(t *testing.T) {
+		err := &ps.Error{Code: ps.ErrInvalid}
+		assert.False(t, isRetryableEngineError(err))
+	})
+
+	t.Run("snapshot in progress is retryable", func(t *testing.T) {
+		err := fmt.Errorf("Cannot update VSchema while a schema snapshot is in progress.")
+		assert.True(t, isRetryableEngineError(err))
+	})
+
+	t.Run("connection refused is retryable", func(t *testing.T) {
+		err := fmt.Errorf("connection refused")
+		assert.True(t, isRetryableEngineError(err))
+	})
+
+	t.Run("wrapped network error is retryable", func(t *testing.T) {
+		err := fmt.Errorf("apply failed: %w", fmt.Errorf("i/o timeout"))
+		assert.True(t, isRetryableEngineError(err))
+	})
+
+	t.Run("DDL syntax error is NOT retryable", func(t *testing.T) {
+		err := fmt.Errorf("Error 1064 (42000): You have an error in your SQL syntax")
+		assert.False(t, isRetryableEngineError(err))
+	})
+
+	t.Run("nil is NOT retryable", func(t *testing.T) {
+		assert.False(t, isRetryableEngineError(nil))
+	})
+}
+
 func TestRetryDelay(t *testing.T) {
 	t.Run("normal backoff is exponential", func(t *testing.T) {
 		d0 := retryDelay(0, fmt.Errorf("connection refused"))

--- a/pkg/localscale/server_deploy_integration_test.go
+++ b/pkg/localscale/server_deploy_integration_test.go
@@ -83,7 +83,7 @@ func TestBranchDatabaseCleanupOnSkipRevert(t *testing.T) {
 	branchName := createBranchWithDDL(t, ctx, "cleanup",
 		map[string][]string{
 			"testapp_sharded": {
-				"ALTER TABLE users ADD COLUMN cleanup_test_col varchar(50)",
+				"ALTER TABLE users ADD INDEX idx_cleanup_test_full_name (full_name)",
 			},
 		},
 		nil,
@@ -222,9 +222,13 @@ func TestStateValidation(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := t.Context()
+			ddl := fmt.Sprintf("ALTER TABLE %s ADD COLUMN %s varchar(50)", tt.table, tt.ddlCol)
+			if tt.name == "complete" {
+				ddl = fmt.Sprintf("ALTER TABLE %s ADD INDEX idx_%s (total_cents)", tt.table, tt.ddlCol)
+			}
 			branchName := createBranchWithDDL(t, ctx, "state-"+tt.name,
 				map[string][]string{
-					"testapp_sharded": {fmt.Sprintf("ALTER TABLE %s ADD COLUMN %s varchar(50)", tt.table, tt.ddlCol)},
+					"testapp_sharded": {ddl},
 				},
 				nil,
 			)
@@ -401,7 +405,7 @@ func TestRevertWindowExpiration(t *testing.T) {
 	branchName := createBranchWithDDL(t, ctx, "revert-expiry",
 		map[string][]string{
 			"testapp": {
-				"ALTER TABLE users_seq ADD COLUMN revert_expiry_col INT",
+				"ALTER TABLE users_seq ADD INDEX idx_revert_expiry_next_id (next_id)",
 			},
 		},
 		nil,
@@ -528,7 +532,7 @@ func TestDeploySubmittingToQueued(t *testing.T) {
 
 	branchName := createBranchWithDDL(t, ctx, "submitting-queued",
 		map[string][]string{
-			"testapp_sharded": {"ALTER TABLE users ADD COLUMN submitting_test_col VARCHAR(50) NULL"},
+			"testapp_sharded": {"ALTER TABLE users ADD INDEX idx_submitting_test_full_name (full_name)"},
 		},
 		nil,
 	)
@@ -541,7 +545,7 @@ func TestDeploySubmittingToQueued(t *testing.T) {
 		Organization: testOrg,
 		Database:     testDB,
 		Number:       dr.Number,
-		InstantDDL:   true,
+		InstantDDL:   false,
 	})
 	require.NoError(t, err, "DeployDeployRequest")
 	assert.Equal(t, drState.Submitting, dr.DeploymentState, "initial deploy state should be submitting")
@@ -688,13 +692,13 @@ func TestCompleteRevertError(t *testing.T) {
 
 	branchName := createBranchWithDDL(t, ctx, "revert-error",
 		map[string][]string{
-			"testapp_sharded": {"ALTER TABLE users ADD COLUMN revert_error_col VARCHAR(50) NULL"},
+			"testapp_sharded": {"ALTER TABLE users ADD INDEX idx_revert_error_full_name (full_name)"},
 		},
 		nil,
 	)
 
 	dr := createDeploy(t, ctx, branchName, true)
-	deploy(t, ctx, dr.Number, true)
+	deploy(t, ctx, dr.Number, false)
 	dr = waitForDeployState(t, ctx, dr.Number, drState.CompletePendingRevert)
 	require.Equal(t, drState.CompletePendingRevert, dr.DeploymentState, "test uses 5s revert window, should reach complete_pending_revert")
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -179,43 +179,84 @@ func RecordLockOperation(ctx context.Context, operation, database, status string
 	)
 }
 
-// RecordRecoveryCycle increments the recovery cycle counter and records
-// how many applies were recovered and how many failed in this cycle.
-func RecordRecoveryCycle(ctx context.Context, recovered, failed int) {
+// RecordSchedulerResume increments the scheduler resumed counter when an apply is
+// successfully claimed and resumed. Includes the previous state for distinguishing
+// crash recovery (stale active) from retryable recovery (failed_retryable).
+func RecordSchedulerResume(ctx context.Context, database, environment, previousState string) {
 	meter := otel.Meter(meterName)
-	cycleCounter, err := meter.Int64Counter("schemabot.recovery.cycles_total",
-		otelmetric.WithDescription("Total number of recovery worker cycles"),
-		otelmetric.WithUnit("{cycle}"),
+	counter, err := meter.Int64Counter("schemabot.scheduler.resumed_total",
+		otelmetric.WithDescription("Total number of applies resumed by the scheduler"),
+		otelmetric.WithUnit("{apply}"),
 	)
 	if err != nil {
-		slog.Warn("failed to create recovery cycles counter", "error", err)
+		slog.Warn("failed to create scheduler resumed counter", "error", err)
 		return
 	}
-	cycleCounter.Add(ctx, 1)
+	counter.Add(ctx, 1,
+		otelmetric.WithAttributes(
+			attribute.String("database", database),
+			attribute.String("environment", environment),
+			attribute.String("previous_state", previousState),
+		),
+	)
+}
 
-	if recovered > 0 {
-		recoveredCounter, err := meter.Int64Counter("schemabot.recovery.recovered_total",
-			otelmetric.WithDescription("Total number of applies recovered by the recovery worker"),
-			otelmetric.WithUnit("{apply}"),
-		)
-		if err != nil {
-			slog.Warn("failed to create recovery recovered counter", "error", err)
-			return
-		}
-		recoveredCounter.Add(ctx, int64(recovered))
+// RecordSchedulerResumeFailure increments the scheduler resume failure counter.
+func RecordSchedulerResumeFailure(ctx context.Context, database, environment, reason string) {
+	meter := otel.Meter(meterName)
+	counter, err := meter.Int64Counter("schemabot.scheduler.resume_failures_total",
+		otelmetric.WithDescription("Total number of scheduler resume attempts that failed"),
+		otelmetric.WithUnit("{apply}"),
+	)
+	if err != nil {
+		slog.Warn("failed to create scheduler resume failure counter", "error", err)
+		return
 	}
+	counter.Add(ctx, 1,
+		otelmetric.WithAttributes(
+			attribute.String("database", database),
+			attribute.String("environment", environment),
+			attribute.String("reason", reason),
+		),
+	)
+}
 
-	if failed > 0 {
-		failedCounter, err := meter.Int64Counter("schemabot.recovery.failed_total",
-			otelmetric.WithDescription("Total number of recovery attempts that failed"),
-			otelmetric.WithUnit("{apply}"),
-		)
-		if err != nil {
-			slog.Warn("failed to create recovery failed counter", "error", err)
-			return
-		}
-		failedCounter.Add(ctx, int64(failed))
+// RecordSchedulerExpired increments the counter for applies that exhausted their
+// retry budget and were permanently failed by the scheduler.
+func RecordSchedulerExpired(ctx context.Context, count int64) {
+	if count <= 0 {
+		return
 	}
+	meter := otel.Meter(meterName)
+	counter, err := meter.Int64Counter("schemabot.scheduler.expired_total",
+		otelmetric.WithDescription("Total number of applies expired to permanent failed (retry budget exhausted)"),
+		otelmetric.WithUnit("{apply}"),
+	)
+	if err != nil {
+		slog.Warn("failed to create scheduler expired counter", "error", err)
+		return
+	}
+	counter.Add(ctx, count)
+}
+
+// RecordSchedulerClaimDuration records how long it took to claim and resume an apply.
+func RecordSchedulerClaimDuration(ctx context.Context, duration time.Duration, database, environment, previousState string) {
+	meter := otel.Meter(meterName)
+	hist, err := meter.Float64Histogram("schemabot.scheduler.claim_duration_seconds",
+		otelmetric.WithDescription("Duration of scheduler claim + resume operations"),
+		otelmetric.WithUnit("s"),
+	)
+	if err != nil {
+		slog.Warn("failed to create scheduler claim duration histogram", "error", err)
+		return
+	}
+	hist.Record(ctx, duration.Seconds(),
+		otelmetric.WithAttributes(
+			attribute.String("database", database),
+			attribute.String("environment", environment),
+			attribute.String("previous_state", previousState),
+		),
+	)
 }
 
 // knownWebhookEvents limits metric cardinality to expected GitHub event types.

--- a/pkg/schema/mysql/applies.sql
+++ b/pkg/schema/mysql/applies.sql
@@ -16,6 +16,7 @@ CREATE TABLE `applies` (
   `state` varchar(100) NOT NULL,
   `error_message` text,
   `options` json NOT NULL,
+  `attempt` int unsigned NOT NULL DEFAULT '0',
   `started_at` datetime DEFAULT NULL,
   `completed_at` datetime DEFAULT NULL,
   `created_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,

--- a/pkg/schema/mysql/tasks.sql
+++ b/pkg/schema/mysql/tasks.sql
@@ -16,6 +16,7 @@ CREATE TABLE `tasks` (
   `state` varchar(100) NOT NULL,
   `error_message` text,
   `options` json DEFAULT NULL,
+  `attempt` int unsigned NOT NULL DEFAULT '0',
   `rows_copied` bigint DEFAULT '0',
   `rows_total` bigint DEFAULT '0',
   `progress_percent` int DEFAULT '0',

--- a/pkg/state/README.md
+++ b/pkg/state/README.md
@@ -25,7 +25,8 @@ Vitess OnlineDDL and Spirit report — and they are translated into Task and App
 | WaitingForCutover | `waiting_for_cutover` | All tasks ready, waiting for manual cutover (atomic mode only — in sequential mode each task cuts over independently) |
 | CuttingOver | `cutting_over` | Cutover in progress (atomic mode only) |
 | Completed | `completed` | All tasks finished successfully |
-| Failed | `failed` | At least one task failed |
+| Failed | `failed` | At least one task failed permanently |
+| FailedRetryable | `failed_retryable` | Transient failure, scheduler will retry (not terminal) |
 | Stopped | `stopped` | User requested stop, resumable via start (engine-dependent) |
 | RevertWindow | `revert_window` | Schema change applied, revert available. Only meaningful for PlanetScale; Spirit doesn't support revert so SchemaBot auto-advances to completed |
 | Reverted | `reverted` | Schema change was reverted |
@@ -41,9 +42,13 @@ stateDiagram-v2
     validating_deploy_request --> waiting_for_deploy
     waiting_for_deploy --> running : deploy triggered
     running --> completed
-    running --> failed
+    running --> failed : permanent
+    running --> failed_retryable : transient
     running --> stopped : resumable (Spirit only)
     running --> cancelled : permanent (PlanetScale only)
+
+    failed_retryable --> running : recovery retry
+    failed_retryable --> failed : attempts exhausted
     running --> waiting_for_cutover : atomic mode
     running --> revert_window : PlanetScale only
 
@@ -71,7 +76,8 @@ Per-table execution state. Same state machine as Apply, plus `cancelled`:
 | WaitingForCutover | `waiting_for_cutover` | Row copy complete, waiting for cutover signal |
 | CuttingOver | `cutting_over` | Table cutover in progress |
 | Completed | `complete` | Schema change applied successfully |
-| Failed | `failed` | Engine reported failure |
+| Failed | `failed` | Engine reported permanent failure |
+| FailedRetryable | `failed_retryable` | Transient failure, will be retried (not terminal) |
 | Stopped | `stopped` | User requested stop, checkpoint saved |
 | RevertWindow | `revert_window` | Schema change applied, revert available (PlanetScale only) |
 | Reverted | `reverted` | Schema change was reverted |
@@ -82,6 +88,7 @@ Per-table execution state. Same state machine as Apply, plus `cancelled`:
 `DeriveApplyState()` computes the apply state from the collective task states. Priority rules (highest to lowest):
 
 1. Any task **failed** → apply `failed`
+1b. Any task **failed_retryable** (and none permanent **failed**) → apply `failed_retryable`
 2. Any task **stopped** → apply `stopped`
 3. Any task **reverted** → apply `reverted`
 4. All tasks **completed** → apply `completed`
@@ -92,7 +99,7 @@ Per-table execution state. Same state machine as Apply, plus `cancelled`:
 9. Any task **running** → apply `running`
 10. Otherwise → apply `pending`
 
-Terminal states (`completed`, `failed`, `reverted`, `cancelled`) are checked via `IsTerminalApplyState()`. Note: `stopped` is NOT terminal at the task level — a stopped task can be resumed via Start.
+Terminal states (`completed`, `failed`, `reverted`, `cancelled`) are checked via `IsTerminalApplyState()`. Note: `stopped` is NOT terminal at the task level — a stopped task can be resumed via Start. `failed_retryable` is NOT terminal — the scheduler re-dispatches the apply with an incremented attempt counter.
 
 ## Spirit states
 

--- a/pkg/state/apply.go
+++ b/pkg/state/apply.go
@@ -21,6 +21,7 @@ var Apply = struct {
 	RevertWindow      string
 	Completed         string
 	Failed            string
+	FailedRetryable   string
 	Stopped           string
 	Cancelled         string
 	Reverted          string
@@ -42,6 +43,7 @@ var Apply = struct {
 	RevertWindow:      "revert_window",
 	Completed:         "completed",
 	Failed:            "failed",
+	FailedRetryable:   "failed_retryable",
 	Stopped:           "stopped",
 	Cancelled:         "cancelled",
 	Reverted:          "reverted",
@@ -82,6 +84,9 @@ func DeriveApplyState(taskStates []string) string {
 
 	if counts[Apply.Failed] > 0 {
 		return Apply.Failed
+	}
+	if counts[Apply.FailedRetryable] > 0 {
+		return Apply.FailedRetryable
 	}
 	if counts[Apply.Cancelled] > 0 {
 		return Apply.Cancelled
@@ -134,6 +139,8 @@ func normalizeApplyState(raw string) string {
 		return Apply.Completed
 	case "FAILED":
 		return Apply.Failed
+	case "FAILED_RETRYABLE":
+		return Apply.FailedRetryable
 	case "STOPPED":
 		return Apply.Stopped
 	case "CANCELLED":
@@ -164,7 +171,8 @@ func IsState(s string, expected ...string) bool {
 }
 
 // IsTerminalApplyState returns true if the state is a terminal state
-// where no further processing will occur.
+// where no further processing will occur. FailedRetryable is NOT terminal
+// — the recovery loop may re-dispatch the apply.
 func IsTerminalApplyState(s string) bool {
 	switch s {
 	case Apply.Completed, Apply.Failed, Apply.Stopped, Apply.Cancelled, Apply.Reverted:

--- a/pkg/state/apply_test.go
+++ b/pkg/state/apply_test.go
@@ -276,3 +276,37 @@ func TestNormalizeApplyState_NewStates(t *testing.T) {
 	assert.Equal(t, Apply.ValidatingBranch, normalizeApplyState("VALIDATING_BRANCH"))
 	assert.Equal(t, Apply.ValidatingDeployRequest, normalizeApplyState("VALIDATING_DEPLOY_REQUEST"))
 }
+
+// FailedRetryable tests
+
+func TestDeriveApplyState_FailedRetryable(t *testing.T) {
+	// FailedRetryable without permanent Failed → apply is FailedRetryable
+	states := []string{"COMPLETED", "FAILED_RETRYABLE", "RUNNING"}
+	assert.Equal(t, Apply.FailedRetryable, DeriveApplyState(states))
+}
+
+func TestDeriveApplyState_FailedRetryable_AllRetryable(t *testing.T) {
+	states := []string{"FAILED_RETRYABLE", "FAILED_RETRYABLE"}
+	assert.Equal(t, Apply.FailedRetryable, DeriveApplyState(states))
+}
+
+func TestDeriveApplyState_FailedOverridesFailedRetryable(t *testing.T) {
+	// Permanent Failed takes priority over FailedRetryable
+	states := []string{"FAILED_RETRYABLE", "FAILED", "COMPLETED"}
+	assert.Equal(t, Apply.Failed, DeriveApplyState(states))
+}
+
+func TestDeriveApplyState_FailedRetryable_NormalizedInput(t *testing.T) {
+	states := []string{"failed_retryable"}
+	assert.Equal(t, Apply.FailedRetryable, DeriveApplyState(states))
+}
+
+func TestIsTerminalApplyState_FailedRetryable(t *testing.T) {
+	assert.False(t, IsTerminalApplyState(Apply.FailedRetryable),
+		"FailedRetryable should NOT be terminal — recovery loop can retry")
+}
+
+func TestNormalizeApplyState_FailedRetryable(t *testing.T) {
+	assert.Equal(t, Apply.FailedRetryable, normalizeApplyState("FAILED_RETRYABLE"))
+	assert.Equal(t, Apply.FailedRetryable, normalizeApplyState("failed_retryable"))
+}

--- a/pkg/state/task.go
+++ b/pkg/state/task.go
@@ -18,6 +18,7 @@ var Task = struct {
 	RevertWindow      string
 	Completed         string
 	Failed            string
+	FailedRetryable   string
 	Stopped           string
 	Reverted          string
 	Cancelled         string
@@ -30,6 +31,7 @@ var Task = struct {
 	RevertWindow:      "revert_window",
 	Completed:         "completed",
 	Failed:            "failed",
+	FailedRetryable:   "failed_retryable",
 	Stopped:           "stopped",
 	Reverted:          "reverted",
 	Cancelled:         "cancelled",
@@ -47,6 +49,7 @@ var TerminalTaskStates = []string{
 // IsTerminalTaskState returns true if the state is a terminal task state
 // where no further processing will occur.
 // Stopped is NOT terminal — a stopped task can be resumed via Start.
+// FailedRetryable is NOT terminal — the recovery loop may retry the task.
 func IsTerminalTaskState(s string) bool {
 	switch s {
 	case Task.Completed, Task.Failed, Task.Reverted, Task.Cancelled:
@@ -110,7 +113,7 @@ func NormalizeTaskStatus(raw string) string {
 
 	// Pass-through for already-normalized values
 	case Task.Pending, Task.Running, Task.Completed, Task.Stopped, Task.Failed,
-		Task.RevertWindow, Task.Reverted,
+		Task.FailedRetryable, Task.RevertWindow, Task.Reverted,
 		Task.WaitingForDeploy, Task.WaitingForCutover, Task.CuttingOver, Task.Cancelled:
 		return s
 

--- a/pkg/storage/mysqlstore/applies.go
+++ b/pkg/storage/mysqlstore/applies.go
@@ -16,8 +16,12 @@ import (
 // applyColumns lists all columns for SELECT queries.
 const applyColumns = `id, apply_identifier, lock_id, plan_id, database_name, database_type,
 	repository, pull_request, environment, deployment, caller, installation_id, external_id, engine,
-	state, error_message, options,
+	state, error_message, options, attempt,
 	created_at, started_at, completed_at, updated_at`
+
+// maxRecoveryAttempts is the maximum number of times a failed_retryable apply
+// will be re-dispatched before transitioning to permanent failed.
+const maxRecoveryAttempts = 10
 
 // applyStore implements storage.ApplyStore using MySQL.
 type applyStore struct {
@@ -36,12 +40,12 @@ func (s *applyStore) Create(ctx context.Context, apply *storage.Apply) (int64, e
 		INSERT INTO applies (
 			apply_identifier, lock_id, plan_id, database_name, database_type,
 			repository, pull_request, environment, deployment, caller, installation_id, external_id, engine,
-			state, error_message, options
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			state, error_message, options, attempt
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`,
 		apply.ApplyIdentifier, apply.LockID, apply.PlanID, apply.Database, apply.DatabaseType,
 		apply.Repository, apply.PullRequest, apply.Environment, apply.Deployment, apply.Caller, apply.InstallationID, apply.ExternalID, apply.Engine,
-		apply.State, apply.ErrorMessage, string(options),
+		apply.State, apply.ErrorMessage, string(options), apply.Attempt,
 	)
 	if err != nil {
 		if isDuplicateKeyError(err) {
@@ -111,16 +115,16 @@ func (s *applyStore) GetByLock(ctx context.Context, lockID int64) ([]*storage.Ap
 func (s *applyStore) Update(ctx context.Context, apply *storage.Apply) error {
 	_, err := s.db.ExecContext(ctx, `
 		UPDATE applies
-		SET state = ?, error_message = ?,
+		SET state = ?, error_message = ?, attempt = ?,
 		    external_id = ?, started_at = ?, completed_at = ?, updated_at = NOW()
 		WHERE id = ?
-	`, apply.State, apply.ErrorMessage,
+	`, apply.State, apply.ErrorMessage, apply.Attempt,
 		apply.ExternalID, apply.StartedAt, apply.CompletedAt, apply.ID)
 	return err
 }
 
 // GetInProgress returns all applies in non-terminal states.
-// Note: For recovery, use ClaimForRecovery which handles locking and heartbeat staleness.
+// Note: For recovery, use FindNextApply which handles locking and heartbeat staleness.
 func (s *applyStore) GetInProgress(ctx context.Context) ([]*storage.Apply, error) {
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT `+applyColumns+`
@@ -152,13 +156,17 @@ func (s *applyStore) GetRecent(ctx context.Context, limit int) ([]*storage.Apply
 	return scanApplies(rows)
 }
 
-// ClaimForRecovery atomically claims an apply for recovery using heartbeat-based leasing.
-// It uses FOR UPDATE SKIP LOCKED to prevent race conditions between workers.
-// Only applies with stale heartbeats (updated_at > 1 minute ago) are claimed.
-// Returns the claimed apply, or nil if no apply is available to claim.
+// FindNextApply atomically claims the next apply that needs attention.
+// Returns the claimed apply, or nil if nothing needs work.
 //
-// The caller MUST call Heartbeat periodically (every 10 seconds) to maintain the lease.
-func (s *applyStore) ClaimForRecovery(ctx context.Context) (*storage.Apply, error) {
+// Matches two types of applies:
+//   - Stale active applies (crashed workers): heartbeat expired > 1 minute
+//   - failed_retryable applies within attempt limit: transient failures to retry
+//
+// Skips applies where another active apply is running on the same database
+// (database exclusion). Uses FOR UPDATE SKIP LOCKED to prevent race conditions
+// between concurrent scheduler workers.
+func (s *applyStore) FindNextApply(ctx context.Context) (*storage.Apply, error) {
 	// Start a transaction for the claim
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
@@ -166,30 +174,60 @@ func (s *applyStore) ClaimForRecovery(ctx context.Context) (*storage.Apply, erro
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	// Find an apply that:
-	// 1. Is in an active (non-terminal) state:
-	//    - pending: created but not started (server crashed before Apply spawned worker)
-	//    - running: actively copying rows
-	//    - waiting_for_cutover: copy complete, waiting for cutover trigger
-	//    - cutting_over: actively swapping tables
-	//    - revert_window: completed but monitoring for revert (optional recovery)
-	// 2. Has a stale heartbeat (updated_at > 1 minute ago) = crashed worker
-	// 3. Use FOR UPDATE SKIP LOCKED to prevent race conditions
+	// Claim applies that need attention:
+	// 1. Stale active applies (crashed workers): heartbeat expired > 1 minute
+	// 2. failed_retryable applies within attempt limit: retry immediately on next poll
+	//
+	// Database exclusion: skip if another active apply is running on the same
+	// database (prevents concurrent schema changes and metadata lock conflicts).
+	//
+	// Uses FOR UPDATE SKIP LOCKED to prevent race conditions between instances.
 	row := tx.QueryRowContext(ctx, `
 		SELECT `+applyColumns+`
-		FROM applies
-		WHERE state IN (?, ?, ?, ?, ?, ?)
-		  AND updated_at < NOW() - INTERVAL 1 MINUTE
-		ORDER BY created_at
+		FROM applies a
+		WHERE (
+			(a.state IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) AND a.updated_at < NOW() - INTERVAL 1 MINUTE)
+			OR (a.state = ? AND a.attempt < ?)
+		)
+		AND NOT EXISTS (
+			SELECT 1 FROM applies a2
+			WHERE a2.database_name = a.database_name
+			AND a2.database_type = a.database_type
+			AND a2.state IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			AND a2.updated_at >= NOW() - INTERVAL 1 MINUTE
+			AND a2.id != a.id
+		)
+		ORDER BY a.created_at
 		LIMIT 1
 		FOR UPDATE SKIP LOCKED
 	`,
+		// Stale active states (all non-terminal states that have a heartbeat)
 		state.Apply.Pending,
 		state.Apply.Running,
 		state.Apply.WaitingForDeploy,
 		state.Apply.WaitingForCutover,
 		state.Apply.CuttingOver,
 		state.Apply.RevertWindow,
+		state.Apply.PreparingBranch,
+		state.Apply.ApplyingBranchChanges,
+		state.Apply.ValidatingBranch,
+		state.Apply.CreatingDeployRequest,
+		state.Apply.ValidatingDeployRequest,
+		// Retryable
+		state.Apply.FailedRetryable,
+		maxRecoveryAttempts,
+		// Exclusion subquery: same active states with fresh heartbeat
+		state.Apply.Pending,
+		state.Apply.Running,
+		state.Apply.WaitingForDeploy,
+		state.Apply.WaitingForCutover,
+		state.Apply.CuttingOver,
+		state.Apply.RevertWindow,
+		state.Apply.PreparingBranch,
+		state.Apply.ApplyingBranchChanges,
+		state.Apply.ValidatingBranch,
+		state.Apply.CreatingDeployRequest,
+		state.Apply.ValidatingDeployRequest,
 	)
 
 	apply, err := scanApplyInto(row)
@@ -200,10 +238,11 @@ func (s *applyStore) ClaimForRecovery(ctx context.Context) (*storage.Apply, erro
 		return nil, err
 	}
 
-	// Claim by updating updated_at to now (this is our heartbeat)
+	// Claim by updating updated_at and incrementing attempt counter
 	_, err = tx.ExecContext(ctx, `
-		UPDATE applies SET updated_at = NOW() WHERE id = ?
+		UPDATE applies SET updated_at = NOW(), attempt = attempt + 1 WHERE id = ?
 	`, apply.ID)
+	apply.Attempt++ // reflect the increment in the returned object
 	if err != nil {
 		return nil, err
 	}
@@ -217,14 +256,31 @@ func (s *applyStore) ClaimForRecovery(ctx context.Context) (*storage.Apply, erro
 
 // Heartbeat updates the apply's updated_at timestamp to maintain the lease.
 // Should be called every 10 seconds while working on an apply.
-// If not called for > 1 minute, another worker can claim the apply via ClaimForRecovery.
+// If not called for > 1 minute, another worker can claim the apply via FindNextApply.
 // Does not check RowsAffected — if the apply was deleted, the UPDATE matches 0 rows
 // and returns nil.
 func (s *applyStore) Heartbeat(ctx context.Context, applyID int64) error {
 	_, err := s.db.ExecContext(ctx, `
 		UPDATE applies SET updated_at = NOW() WHERE id = ?
 	`, applyID)
-	return err
+	if err != nil {
+		return fmt.Errorf("heartbeat apply %d: %w", applyID, err)
+	}
+	return nil
+}
+
+// ExpireRetryable transitions failed_retryable applies that have exhausted
+// their retry budget to permanent failed. Returns the number of rows affected.
+func (s *applyStore) ExpireRetryable(ctx context.Context) (int64, error) {
+	result, err := s.db.ExecContext(ctx, `
+		UPDATE applies
+		SET state = ?, completed_at = NOW(), updated_at = NOW()
+		WHERE state = ? AND attempt >= ?
+	`, state.Apply.Failed, state.Apply.FailedRetryable, maxRecoveryAttempts)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
 }
 
 // GetByDatabase returns applies for a specific database and optionally filtered by dbType and environment.
@@ -324,7 +380,7 @@ func scanApplyInto(s scanner) (*storage.Apply, error) {
 		&apply.Database, &apply.DatabaseType,
 		&apply.Repository, &apply.PullRequest, &apply.Environment, &apply.Deployment,
 		&apply.Caller, &apply.InstallationID, &apply.ExternalID, &apply.Engine,
-		&apply.State, &apply.ErrorMessage, &options,
+		&apply.State, &apply.ErrorMessage, &options, &apply.Attempt,
 		&apply.CreatedAt, &startedAt, &completedAt, &apply.UpdatedAt,
 	)
 	if err != nil {

--- a/pkg/storage/mysqlstore/applies.go
+++ b/pkg/storage/mysqlstore/applies.go
@@ -238,14 +238,35 @@ func (s *applyStore) FindNextApply(ctx context.Context) (*storage.Apply, error) 
 		return nil, err
 	}
 
-	// Claim by updating updated_at and incrementing attempt counter
-	_, err = tx.ExecContext(ctx, `
-		UPDATE applies SET updated_at = NOW(), attempt = attempt + 1 WHERE id = ?
-	`, apply.ID)
-	apply.Attempt++ // reflect the increment in the returned object
-	if err != nil {
-		return nil, err
+	// Claim by updating updated_at and incrementing attempt counter.
+	// Retryable applies move back to pending while the worker dispatches them so
+	// other workers see a fresh active lease instead of the old retryable row.
+	if apply.State == state.Apply.FailedRetryable {
+		var result sql.Result
+		result, err = tx.ExecContext(ctx, `
+			UPDATE applies
+			SET state = ?, updated_at = NOW(), attempt = attempt + 1, completed_at = NULL
+			WHERE id = ? AND state = ?
+		`, state.Apply.Pending, apply.ID, state.Apply.FailedRetryable)
+		if err != nil {
+			return nil, err
+		}
+		rows, err := result.RowsAffected()
+		if err != nil {
+			return nil, err
+		}
+		if rows == 0 {
+			return nil, nil
+		}
+	} else {
+		_, err = tx.ExecContext(ctx, `
+			UPDATE applies SET updated_at = NOW(), attempt = attempt + 1 WHERE id = ?
+		`, apply.ID)
+		if err != nil {
+			return nil, err
+		}
 	}
+	apply.Attempt++ // reflect the increment in the returned object
 
 	if err := tx.Commit(); err != nil {
 		return nil, err
@@ -272,15 +293,38 @@ func (s *applyStore) Heartbeat(ctx context.Context, applyID int64) error {
 // ExpireRetryable transitions failed_retryable applies that have exhausted
 // their retry budget to permanent failed. Returns the number of rows affected.
 func (s *applyStore) ExpireRetryable(ctx context.Context) (int64, error) {
-	result, err := s.db.ExecContext(ctx, `
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	_, err = tx.ExecContext(ctx, `
+		UPDATE tasks t
+		JOIN applies a ON t.apply_id = a.id
+		SET t.state = ?, t.completed_at = COALESCE(t.completed_at, NOW()), t.updated_at = NOW()
+		WHERE a.state = ? AND a.attempt >= ? AND t.state = ?
+	`, state.Task.Failed, state.Apply.FailedRetryable, maxRecoveryAttempts, state.Task.FailedRetryable)
+	if err != nil {
+		return 0, err
+	}
+
+	result, err := tx.ExecContext(ctx, `
 		UPDATE applies
-		SET state = ?, completed_at = NOW(), updated_at = NOW()
+		SET state = ?, completed_at = COALESCE(completed_at, NOW()), updated_at = NOW()
 		WHERE state = ? AND attempt >= ?
 	`, state.Apply.Failed, state.Apply.FailedRetryable, maxRecoveryAttempts)
 	if err != nil {
 		return 0, err
 	}
-	return result.RowsAffected()
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return 0, err
+	}
+	if err := tx.Commit(); err != nil {
+		return 0, err
+	}
+	return rowsAffected, nil
 }
 
 // GetByDatabase returns applies for a specific database and optionally filtered by dbType and environment.

--- a/pkg/storage/mysqlstore/tasks.go
+++ b/pkg/storage/mysqlstore/tasks.go
@@ -17,7 +17,7 @@ import (
 // taskColumns lists all columns for SELECT queries.
 const taskColumns = `id, task_identifier, apply_id, plan_id, database_name, database_type,
 	namespace, table_name, ddl, ddl_action,
-	engine, repository, pull_request, environment, state, error_message, options,
+	engine, repository, pull_request, environment, state, error_message, options, attempt,
 	rows_copied, rows_total, progress_percent, eta_seconds,
 	is_instant, ready_to_complete, engine_migration_id,
 	started_at, completed_at, created_at, updated_at`
@@ -89,12 +89,12 @@ func (s *taskStore) Get(ctx context.Context, taskIdentifier string) (*storage.Ta
 func (s *taskStore) Update(ctx context.Context, task *storage.Task) error {
 	_, err := s.db.ExecContext(ctx, `
 		UPDATE tasks SET
-			state = ?, error_message = ?, options = ?,
+			state = ?, error_message = ?, options = ?, attempt = ?,
 			rows_copied = ?, rows_total = ?, progress_percent = ?, eta_seconds = ?,
 			is_instant = ?, ready_to_complete = ?, engine_migration_id = ?,
 			started_at = ?, completed_at = ?, updated_at = NOW()
 		WHERE id = ?
-	`, task.State, nullString(task.ErrorMessage), nullJSON(task.Options),
+	`, task.State, nullString(task.ErrorMessage), nullJSON(task.Options), task.Attempt,
 		task.RowsCopied, task.RowsTotal, task.ProgressPercent, task.ETASeconds,
 		task.IsInstant, task.ReadyToComplete, nullString(task.EngineMigrationID),
 		task.StartedAt, task.CompletedAt,
@@ -255,6 +255,7 @@ func scanTaskInto(s scanner) (*storage.Task, error) {
 		&task.State,
 		&errorMsg,
 		&options,
+		&task.Attempt,
 		&task.RowsCopied,
 		&task.RowsTotal,
 		&task.ProgressPercent,

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -175,20 +175,22 @@ type ApplyStore interface {
 	GetRecent(ctx context.Context, limit int) ([]*Apply, error)
 
 	// GetInProgress returns all applies in non-terminal states.
-	// Note: For recovery, use ClaimForRecovery which handles locking.
+	// Note: For recovery, use FindNextApply which handles locking.
 	GetInProgress(ctx context.Context) ([]*Apply, error)
 
-	// ClaimForRecovery atomically claims an apply for recovery using heartbeat-based leasing.
-	// Uses FOR UPDATE SKIP LOCKED to prevent race conditions between workers.
-	// Only applies with stale heartbeats (updated_at > 1 minute ago) are claimed.
-	// Returns the claimed apply, or nil if no apply is available to claim.
-	// The caller MUST call Heartbeat periodically (every 10 seconds) to maintain the lease.
-	ClaimForRecovery(ctx context.Context) (*Apply, error)
+	// FindNextApply atomically claims the next apply that needs attention.
+	// Returns the claimed apply, or nil if nothing needs work.
+	FindNextApply(ctx context.Context) (*Apply, error)
 
 	// Heartbeat updates the apply's updated_at timestamp to maintain the lease.
 	// Should be called every 10 seconds while working on an apply.
 	// If not called for > 1 minute, another worker can claim the apply.
 	Heartbeat(ctx context.Context, applyID int64) error
+
+	// ExpireRetryable transitions failed_retryable applies that have exhausted
+	// their retry budget (attempt >= maxRecoveryAttempts) to permanent failed.
+	// Returns the number of applies transitioned.
+	ExpireRetryable(ctx context.Context) (int64, error)
 
 	// GetByPR returns all applies for a PR.
 	GetByPR(ctx context.Context, repo string, pr int) ([]*Apply, error)

--- a/pkg/storage/types.go
+++ b/pkg/storage/types.go
@@ -296,6 +296,11 @@ type Apply struct {
 	// Use ParseApplyOptions() to get typed access.
 	Options []byte
 
+	// Attempt tracks how many times this apply has been dispatched.
+	// Incremented on each recovery attempt. When Attempt >= MaxAttempts,
+	// the apply transitions from FailedRetryable to Failed (permanent).
+	Attempt int
+
 	// CreatedAt is when the apply was created.
 	CreatedAt time.Time
 
@@ -410,6 +415,10 @@ type Task struct {
 
 	// Options contains engine-specific options as JSON.
 	Options []byte
+
+	// Attempt tracks how many times this task has been dispatched.
+	// Incremented on each recovery attempt.
+	Attempt int
 
 	// Namespace is the schema name (MySQL) or keyspace (Vitess) this table belongs to.
 	Namespace string

--- a/pkg/tern/local_apply.go
+++ b/pkg/tern/local_apply.go
@@ -208,7 +208,9 @@ func (c *LocalClient) markTasksRunning(ctx context.Context, tasks []*storage.Tas
 
 // runWithRecovery wraps an apply function with panic recovery so a single panic
 // doesn't crash the entire process. On panic, all tasks and the apply are marked failed.
+// Clears cancelApply on exit so Stop() doesn't reference a dead goroutine.
 func (c *LocalClient) runWithRecovery(ctx context.Context, apply *storage.Apply, tasks []*storage.Task, fn func()) {
+	defer c.clearCancelApply()
 	defer func() {
 		if r := recover(); r != nil {
 			errMsg := fmt.Sprintf("panic in apply goroutine: %v", r)
@@ -222,7 +224,8 @@ func (c *LocalClient) runWithRecovery(ctx context.Context, apply *storage.Apply,
 // executeApplyAtomic runs all DDLs in one Spirit call for atomic cutover (--defer-cutover).
 // All tables copy together and cut over atomically.
 func (c *LocalClient) executeApplyAtomic(ctx context.Context, apply *storage.Apply, tasks []*storage.Task, plan *storage.Plan, options map[string]string) {
-	defer c.startApplyHeartbeat(ctx, apply)()
+	ctx, stopHeartbeat := c.startApplyHeartbeat(ctx, apply)
+	defer stopHeartbeat()
 	creds := c.credentials()
 
 	// Extract all DDLs and table names from tasks
@@ -339,10 +342,14 @@ func (c *LocalClient) executeApplyAtomic(ctx context.Context, apply *storage.App
 	})
 
 	if err != nil {
-		c.failApplyWithTasks(ctx, apply, tasks, err.Error())
-		c.logger.Error("atomic apply failed", "error", err, "apply_id", apply.ApplyIdentifier)
+		c.failApplyWithTasks(ctx, apply, tasks, err.Error(), err)
+		newState := state.Apply.Failed
+		if engine.IsRetryable(err) {
+			newState = state.Apply.FailedRetryable
+		}
+		c.logger.Error("atomic apply failed", "error", err, "apply_id", apply.ApplyIdentifier, "retryable", engine.IsRetryable(err))
 		c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelError, storage.LogEventError, storage.LogSourceSchemaBot,
-			fmt.Sprintf("Engine apply failed: %v", err), state.Apply.Pending, state.Apply.Failed)
+			fmt.Sprintf("Engine apply failed: %v", err), state.Apply.Pending, newState)
 		return
 	}
 
@@ -408,7 +415,8 @@ func (c *LocalClient) executeApplyAtomic(ctx context.Context, apply *storage.App
 // executeApplySequential runs each DDL as a separate Spirit call (independent mode).
 // Each table copies and cuts over independently.
 func (c *LocalClient) executeApplySequential(ctx context.Context, apply *storage.Apply, tasks []*storage.Task, plan *storage.Plan, options map[string]string) {
-	defer c.startApplyHeartbeat(ctx, apply)()
+	ctx, stopHeartbeat := c.startApplyHeartbeat(ctx, apply)
+	defer stopHeartbeat()
 	seqStart := time.Now()
 	creds := c.credentials()
 	defer c.setupSpiritLogging(ctx, apply, tasks)()
@@ -583,26 +591,57 @@ type atomicPollState struct {
 	consecutiveErrors int
 }
 
-// startApplyHeartbeat starts a background goroutine that heartbeats the apply
-// every 10 seconds, preventing the recovery worker from treating it as crashed.
-// Returns a cancel function that stops the heartbeat. Must be deferred by the caller.
-func (c *LocalClient) startApplyHeartbeat(ctx context.Context, apply *storage.Apply) context.CancelFunc {
-	hbCtx, cancel := context.WithCancel(ctx)
+// maxConsecutiveHeartbeatFailures is how many consecutive heartbeat failures
+// trigger cancellation of the apply context. This prevents zombie applies from
+// continuing to run while the scheduler thinks they've crashed.
+const maxConsecutiveHeartbeatFailures = 6
+
+// startApplyHeartbeat wraps the apply context with cancellation and starts a
+// background heartbeat goroutine. If heartbeat fails maxConsecutiveHeartbeatFailures
+// times in a row, the APPLY context is cancelled — stopping the engine, polling
+// loops, and any other goroutines using the returned context.
+//
+// Usage:
+//
+//	ctx, stopHeartbeat := c.startApplyHeartbeat(ctx, apply)
+//	defer stopHeartbeat()
+//	// use ctx for all apply work — it will be cancelled on heartbeat failure
+func (c *LocalClient) startApplyHeartbeat(ctx context.Context, apply *storage.Apply) (context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithCancel(ctx)
 	go func() {
 		ticker := time.NewTicker(c.heartbeatInterval)
 		defer ticker.Stop()
+		consecutiveFailures := 0
 		for {
 			select {
-			case <-hbCtx.Done():
+			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				if err := c.storage.Applies().Heartbeat(hbCtx, apply.ID); err != nil {
-					c.logger.Warn("heartbeat failed", "apply_id", apply.ApplyIdentifier, "error", err)
+				if err := c.storage.Applies().Heartbeat(ctx, apply.ID); err != nil {
+					consecutiveFailures++
+					c.logger.Warn("heartbeat failed",
+						"apply_id", apply.ApplyIdentifier,
+						"consecutive_failures", consecutiveFailures,
+						"error", err)
+					if consecutiveFailures >= maxConsecutiveHeartbeatFailures {
+						c.logger.Error("heartbeat failed too many times, cancelling apply",
+							"apply_id", apply.ApplyIdentifier,
+							"consecutive_failures", consecutiveFailures)
+						cancel()
+						return
+					}
+				} else {
+					if consecutiveFailures > 0 {
+						c.logger.Info("heartbeat recovered",
+							"apply_id", apply.ApplyIdentifier,
+							"previous_failures", consecutiveFailures)
+					}
+					consecutiveFailures = 0
 				}
 			}
 		}
 	}()
-	return cancel
+	return ctx, cancel
 }
 
 // pollForCompletionAtomic polls the engine for progress in atomic mode (all tasks share state).
@@ -995,7 +1034,11 @@ func (c *LocalClient) pollTaskToCompletion(ctx context.Context, task *storage.Ta
 				Credentials: creds,
 			})
 			if err != nil {
-				c.logger.Warn("progress check failed", "error", err, "task_id", task.TaskIdentifier)
+				c.logger.Warn("progress check failed",
+					"error", err,
+					"task_id", task.TaskIdentifier,
+					"database", task.Database,
+					"table", task.TableName)
 				continue
 			}
 
@@ -1061,8 +1104,18 @@ func (c *LocalClient) markTaskFailed(ctx context.Context, task *storage.Task, er
 // failApplyWithTasks marks all tasks and the apply as failed with the given error.
 // If the apply is already in a terminal state (e.g., cancelled by Stop()), the
 // apply state is not overwritten.
-func (c *LocalClient) failApplyWithTasks(ctx context.Context, apply *storage.Apply, tasks []*storage.Task, errMsg string) {
+func (c *LocalClient) failApplyWithTasks(ctx context.Context, apply *storage.Apply, tasks []*storage.Task, errMsg string, originalErr ...error) {
 	now := time.Now()
+
+	// Determine if the failure is retryable based on the original error.
+	retryable := len(originalErr) > 0 && originalErr[0] != nil && engine.IsRetryable(originalErr[0])
+	taskState := state.Task.Failed
+	applyState := state.Apply.Failed
+	if retryable {
+		taskState = state.Task.FailedRetryable
+		applyState = state.Apply.FailedRetryable
+	}
+
 	for _, task := range tasks {
 		if state.IsTerminalTaskState(task.State) {
 			continue
@@ -1070,8 +1123,10 @@ func (c *LocalClient) failApplyWithTasks(ctx context.Context, apply *storage.App
 		if task.ErrorMessage == "" {
 			task.ErrorMessage = errMsg
 		}
-		task.CompletedAt = &now
-		c.transitionTaskState(ctx, task, 0, state.Task.Failed, "")
+		if !retryable {
+			task.CompletedAt = &now
+		}
+		c.transitionTaskState(ctx, task, 0, taskState, "")
 	}
 
 	// Re-read the apply from storage — Stop() may have already set a terminal
@@ -1083,12 +1138,19 @@ func (c *LocalClient) failApplyWithTasks(ctx context.Context, apply *storage.App
 		return
 	}
 
-	apply.State = state.Apply.Failed
+	apply.State = applyState
 	apply.ErrorMessage = errMsg
-	apply.CompletedAt = &now
+	if !retryable {
+		apply.CompletedAt = &now
+	}
 	apply.UpdatedAt = now
 	if err := c.storage.Applies().Update(ctx, apply); err != nil {
-		c.logger.Error("failed to update apply state", "apply_id", apply.ApplyIdentifier, "state", state.Apply.Failed, "error", err)
+		c.logger.Error("failed to update apply state", "apply_id", apply.ApplyIdentifier, "state", applyState, "error", err)
+	}
+
+	if retryable {
+		c.logger.Info("apply marked as retryable, recovery loop will retry",
+			"apply_id", apply.ApplyIdentifier, "attempt", apply.Attempt, "error", errMsg)
 	}
 	metrics.AdjustActiveApplies(ctx, -1, apply.Database, apply.Environment)
 }

--- a/pkg/tern/local_client.go
+++ b/pkg/tern/local_client.go
@@ -200,10 +200,49 @@ func engineNameToProto(name string) (ternv1.Engine, error) {
 	}
 }
 
+// SetHeartbeatInterval sets the heartbeat polling interval.
+// For testing only — production uses the default 10s.
+func (c *LocalClient) SetHeartbeatInterval(d time.Duration) {
+	c.heartbeatInterval = d
+}
+
+// clearCancelApply resets the cancel function after a background apply goroutine exits.
+// Prevents stale references to dead goroutines.
+func (c *LocalClient) clearCancelApply() {
+	c.cancelMu.Lock()
+	c.cancelApply = nil
+	c.cancelMu.Unlock()
+}
+
 // Close closes the client and releases resources.
 func (c *LocalClient) Close() error {
-	// LocalClient doesn't own storage, so nothing to close
 	return nil
+}
+
+// parseOptionsMap converts stored apply options JSON back to a string map
+// for re-dispatching applies through executeApplyAtomic/executeApplySequential.
+func parseOptionsMap(data []byte) map[string]string {
+	opts := storage.ParseApplyOptions(data)
+	m := make(map[string]string)
+	if opts.DeferCutover {
+		m["defer_cutover"] = "true"
+	}
+	if opts.DeferDeploy {
+		m["defer_deploy"] = "true"
+	}
+	if opts.SkipRevert {
+		m["skip_revert"] = "true"
+	}
+	if opts.AllowUnsafe {
+		m["allow_unsafe"] = "true"
+	}
+	if opts.Branch != "" {
+		m["branch"] = opts.Branch
+	}
+	if opts.Volume > 0 {
+		m["volume"] = fmt.Sprintf("%d", opts.Volume)
+	}
+	return m
 }
 
 // credentials returns engine credentials from the client config.

--- a/pkg/tern/local_client_integration_test.go
+++ b/pkg/tern/local_client_integration_test.go
@@ -255,6 +255,74 @@ func waitForApplyComplete(t *testing.T, client *LocalClient, ctx context.Context
 	t.Fatal("apply did not complete within 30s")
 }
 
+type recordingVitessEngine struct {
+	applyRequests chan *engine.ApplyRequest
+	ddl           string
+}
+
+func newRecordingVitessEngine(ddl string) *recordingVitessEngine {
+	return &recordingVitessEngine{
+		applyRequests: make(chan *engine.ApplyRequest, 1),
+		ddl:           ddl,
+	}
+}
+
+func (e *recordingVitessEngine) Name() string {
+	return storage.EnginePlanetScale
+}
+
+func (e *recordingVitessEngine) Plan(context.Context, *engine.PlanRequest) (*engine.PlanResult, error) {
+	return &engine.PlanResult{
+		Changes: []engine.SchemaChange{{
+			Namespace: "testapp_sharded",
+			TableChanges: []engine.TableChange{{
+				Table: "users",
+				DDL:   e.ddl,
+			}},
+		}},
+	}, nil
+}
+
+func (e *recordingVitessEngine) Apply(_ context.Context, req *engine.ApplyRequest) (*engine.ApplyResult, error) {
+	e.applyRequests <- req
+	return &engine.ApplyResult{
+		Accepted:    true,
+		ResumeState: req.ResumeState,
+	}, nil
+}
+
+func (e *recordingVitessEngine) Progress(_ context.Context, req *engine.ProgressRequest) (*engine.ProgressResult, error) {
+	return &engine.ProgressResult{
+		State:       engine.StateCompleted,
+		Progress:    100,
+		ResumeState: req.ResumeState,
+	}, nil
+}
+
+func (e *recordingVitessEngine) Stop(_ context.Context, req *engine.ControlRequest) (*engine.ControlResult, error) {
+	return &engine.ControlResult{Accepted: true, ResumeState: req.ResumeState}, nil
+}
+
+func (e *recordingVitessEngine) Start(_ context.Context, req *engine.ControlRequest) (*engine.ControlResult, error) {
+	return &engine.ControlResult{Accepted: true, ResumeState: req.ResumeState}, nil
+}
+
+func (e *recordingVitessEngine) Cutover(_ context.Context, req *engine.ControlRequest) (*engine.ControlResult, error) {
+	return &engine.ControlResult{Accepted: true, ResumeState: req.ResumeState}, nil
+}
+
+func (e *recordingVitessEngine) Revert(_ context.Context, req *engine.ControlRequest) (*engine.ControlResult, error) {
+	return &engine.ControlResult{Accepted: true, ResumeState: req.ResumeState}, nil
+}
+
+func (e *recordingVitessEngine) SkipRevert(_ context.Context, req *engine.ControlRequest) (*engine.ControlResult, error) {
+	return &engine.ControlResult{Accepted: true, ResumeState: req.ResumeState}, nil
+}
+
+func (e *recordingVitessEngine) Volume(_ context.Context, req *engine.VolumeRequest) (*engine.VolumeResult, error) {
+	return &engine.VolumeResult{Accepted: true, NewVolume: req.Volume}, nil
+}
+
 func TestLocalClient_NewLocalClient(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
@@ -508,6 +576,124 @@ func TestLocalClient_Apply(t *testing.T) {
 	err = db.QueryRowContext(ctx, "SELECT COUNT(*) FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = 'testdb' AND TABLE_NAME = 'users' AND COLUMN_NAME = 'email'").Scan(&columnCount)
 	require.NoError(t, err, "query columns")
 	assert.Equal(t, 1, columnCount, "expected email column to exist, got count %d", columnCount)
+}
+
+func TestLocalClient_ResumeApply_VitessUsesSavedResumeState(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	_, dsn := setupMySQLContainer(t)
+	setupStorageSchema(t, dsn)
+	cleanupTasks(t, dsn)
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	stor := createStorage(t, dsn)
+
+	ddl := "ALTER TABLE users ADD COLUMN resume_col BIGINT"
+	client, err := NewLocalClient(LocalConfig{
+		Database:  "testdb",
+		Type:      storage.DatabaseTypeVitess,
+		TargetDSN: dsn,
+		Metadata: map[string]string{
+			"organization": "org",
+			"token_name":   "token",
+			"token_value":  "secret",
+		},
+	}, stor, logger)
+	require.NoError(t, err, "failed to create client")
+	defer utils.CloseAndLog(client)
+	fakeEngine := newRecordingVitessEngine(ddl)
+	client.planetscaleEngine = fakeEngine
+
+	ctx := t.Context()
+	now := time.Now()
+	plan := &storage.Plan{
+		PlanIdentifier: fmt.Sprintf("plan-vitess-resume-%d", now.UnixNano()),
+		Database:       "testdb",
+		DatabaseType:   storage.DatabaseTypeVitess,
+		Environment:    "staging",
+		SchemaFiles: schema.SchemaFiles{
+			"testapp_sharded": &schema.Namespace{
+				Files: map[string]string{
+					"users.sql": "CREATE TABLE users (id BIGINT PRIMARY KEY) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;",
+				},
+			},
+		},
+		Namespaces: map[string]*storage.NamespacePlanData{
+			"testapp_sharded": {
+				Tables: []storage.TableChange{{
+					Namespace: "testapp_sharded",
+					Table:     "users",
+					DDL:       ddl,
+					Operation: "alter",
+				}},
+			},
+		},
+		CreatedAt: now,
+	}
+	planID, err := stor.Plans().Create(ctx, plan)
+	require.NoError(t, err)
+
+	apply := &storage.Apply{
+		ApplyIdentifier: fmt.Sprintf("apply-vitess-resume-%d", now.UnixNano()),
+		PlanID:          planID,
+		Database:        "testdb",
+		DatabaseType:    storage.DatabaseTypeVitess,
+		Engine:          storage.EnginePlanetScale,
+		State:           state.Apply.ApplyingBranchChanges,
+		Options:         []byte("{}"),
+		Environment:     "staging",
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+	applyID, err := stor.Applies().Create(ctx, apply)
+	require.NoError(t, err)
+	apply.ID = applyID
+
+	_, err = stor.Tasks().Create(ctx, &storage.Task{
+		TaskIdentifier: fmt.Sprintf("task-vitess-resume-%d", now.UnixNano()),
+		ApplyID:        applyID,
+		PlanID:         planID,
+		Database:       "testdb",
+		DatabaseType:   storage.DatabaseTypeVitess,
+		Engine:         storage.EnginePlanetScale,
+		Environment:    "staging",
+		State:          state.Task.Running,
+		Namespace:      "testapp_sharded",
+		TableName:      "users",
+		DDL:            ddl,
+		DDLAction:      "alter",
+		Options:        []byte("{}"),
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	})
+	require.NoError(t, err)
+
+	err = stor.VitessApplyData().Save(ctx, &storage.VitessApplyData{
+		ApplyID:          applyID,
+		BranchName:       "branch-resume",
+		DeployRequestID:  42,
+		MigrationContext: "apply-vitess-resume-context",
+		DeployRequestURL: "http://localscale/deploy-requests/42",
+		IsInstant:        true,
+		DeferredDeploy:   true,
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, client.ResumeApply(ctx, apply))
+
+	var req *engine.ApplyRequest
+	select {
+	case req = <-fakeEngine.applyRequests:
+	case <-time.After(5 * time.Second):
+		require.Fail(t, "timed out waiting for engine apply")
+	}
+	require.NotNil(t, req.ResumeState)
+	assert.Equal(t, "apply-vitess-resume-context", req.ResumeState.MigrationContext)
+	assert.Contains(t, req.ResumeState.Metadata, `"branch_name":"branch-resume"`)
+	assert.Contains(t, req.ResumeState.Metadata, `"deploy_request_id":42`)
+	assert.Contains(t, req.ResumeState.Metadata, `"deferred_deploy":true`)
 }
 
 func TestLocalClient_Progress(t *testing.T) {

--- a/pkg/tern/local_client_integration_test.go
+++ b/pkg/tern/local_client_integration_test.go
@@ -954,7 +954,7 @@ func TestLocalClient_StartApplyHeartbeat(t *testing.T) {
 	require.NoError(t, err, "query initial updated_at")
 
 	// Start the heartbeat and let it run for >1s
-	cancel := client.startApplyHeartbeat(ctx, apply)
+	_, cancel := client.startApplyHeartbeat(ctx, apply)
 	time.Sleep(2 * time.Second)
 	cancel()
 

--- a/pkg/tern/local_control.go
+++ b/pkg/tern/local_control.go
@@ -300,20 +300,53 @@ func (c *LocalClient) buildControlRequest(ctx context.Context, task *storage.Tas
 	}
 	if c.config.Type == storage.DatabaseTypeVitess {
 		if vad, err := c.storage.VitessApplyData().GetByApplyID(ctx, task.ApplyID); err == nil {
-			meta, _ := json.Marshal(map[string]any{
-				"branch_name":        vad.BranchName,
-				"deploy_request_id":  vad.DeployRequestID,
-				"deploy_request_url": vad.DeployRequestURL,
-				"is_instant":         vad.IsInstant,
-				"deferred_deploy":    vad.DeferredDeploy,
-			})
-			req.ResumeState = &engine.ResumeState{
-				MigrationContext: vad.MigrationContext,
-				Metadata:         string(meta),
+			resumeState, buildErr := vitessApplyDataResumeState(vad, task.TaskIdentifier)
+			if buildErr != nil {
+				c.logger.Error("failed to build Vitess resume state for control", "apply_id", task.ApplyID, "error", buildErr)
+			} else {
+				req.ResumeState = resumeState
 			}
+		} else {
+			c.logger.Error("failed to load Vitess apply data for control", "apply_id", task.ApplyID, "error", err)
 		}
 	}
 	return req
+}
+
+func vitessApplyDataResumeState(vad *storage.VitessApplyData, fallbackContext string) (*engine.ResumeState, error) {
+	if vad == nil {
+		return nil, fmt.Errorf("vitess apply data is nil")
+	}
+	resumeContext := vad.MigrationContext
+	if resumeContext == "" {
+		resumeContext = fallbackContext
+	}
+	meta, err := json.Marshal(map[string]any{
+		"branch_name":        vad.BranchName,
+		"deploy_request_id":  vad.DeployRequestID,
+		"deploy_request_url": vad.DeployRequestURL,
+		"is_instant":         vad.IsInstant,
+		"deferred_deploy":    vad.DeferredDeploy,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal Vitess resume metadata: %w", err)
+	}
+	return &engine.ResumeState{
+		MigrationContext: resumeContext,
+		Metadata:         string(meta),
+	}, nil
+}
+
+func (c *LocalClient) buildVitessResumeState(ctx context.Context, apply *storage.Apply) (*engine.ResumeState, error) {
+	vad, err := c.storage.VitessApplyData().GetByApplyID(ctx, apply.ID)
+	if err != nil {
+		return nil, fmt.Errorf("load Vitess apply data for apply %s: %w", apply.ApplyIdentifier, err)
+	}
+	resumeState, err := vitessApplyDataResumeState(vad, apply.ApplyIdentifier)
+	if err != nil {
+		return nil, err
+	}
+	return resumeState, nil
 }
 
 // Volume modifies the schema change speed/concurrency in-flight.

--- a/pkg/tern/local_control_resume.go
+++ b/pkg/tern/local_control_resume.go
@@ -182,9 +182,13 @@ func (c *LocalClient) Start(ctx context.Context, req *ternv1.StartRequest) (*ter
 		c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventStartRequested, storage.LogSourceSchemaBot,
 			fmt.Sprintf("Resume requested (sequential): %d tasks to resume, %d already completed", len(resumeTasks), completedCount), oldApplyState, state.Apply.Running)
 
-		resumeCtx, cancelResume := context.WithCancel(context.Background())
+		resumeCtx, cancelResume := context.WithCancel(context.WithoutCancel(ctx))
+		c.cancelMu.Lock()
 		c.cancelApply = cancelResume
-		go c.resumeApplySequential(resumeCtx, apply, resumeTasks, plan, options)
+		c.cancelMu.Unlock()
+		go c.runWithRecovery(resumeCtx, apply, resumeTasks, func() {
+			c.resumeApplySequential(resumeCtx, apply, resumeTasks, plan, options)
+		})
 	}
 
 	return &ternv1.StartResponse{
@@ -198,7 +202,8 @@ func (c *LocalClient) Start(ctx context.Context, req *ternv1.StartRequest) (*ter
 // This preserves the sequential behavior of the original apply when --defer-cutover
 // was NOT used. Each task gets its own eng.Apply + pollTaskToCompletion cycle.
 func (c *LocalClient) resumeApplySequential(ctx context.Context, apply *storage.Apply, tasks []*storage.Task, plan *storage.Plan, options map[string]string) {
-	defer c.startApplyHeartbeat(ctx, apply)()
+	ctx, stopHeartbeat := c.startApplyHeartbeat(ctx, apply)
+	defer stopHeartbeat()
 	creds := c.credentials()
 	eng := c.getEngine()
 
@@ -428,10 +433,14 @@ func (c *LocalClient) launchAtomicResume(ctx context.Context, apply *storage.App
 	c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventStateTransition, storage.LogSourceSchemaBot,
 		logMessage, oldApplyState, state.Apply.Running)
 
-	stopHeartbeat := c.startApplyHeartbeat(context.Background(), apply)
+	hbCtx, stopHeartbeat := c.startApplyHeartbeat(context.WithoutCancel(ctx), apply)
+	c.cancelMu.Lock()
+	c.cancelApply = stopHeartbeat
+	c.cancelMu.Unlock()
 	go func() {
 		defer stopHeartbeat()
-		c.pollForCompletionAtomic(context.Background(), apply, tasks, creds, nil)
+		defer c.clearCancelApply()
+		c.pollForCompletionAtomic(hbCtx, apply, tasks, creds, result.ResumeState)
 	}()
 	return nil
 }
@@ -439,8 +448,105 @@ func (c *LocalClient) launchAtomicResume(ctx context.Context, apply *storage.App
 // ResumeApply resumes an in-progress apply whose heartbeat has expired.
 // This can happen after a server restart or if the worker goroutine crashed.
 // Spirit's checkpoint table allows resuming from where the schema change left off.
+// retryFailedApply re-dispatches a failed_retryable apply. Loads the plan,
+// resets failed tasks to pending, transitions the apply to running, and
+// re-executes. Called by ResumeApply when the scheduler claims a retryable apply.
+func (c *LocalClient) retryFailedApply(ctx context.Context, apply *storage.Apply) error {
+	plan, err := c.storage.Plans().GetByID(ctx, apply.PlanID)
+	if err != nil || plan == nil {
+		errMsg := "retry failed: plan not found"
+		c.logger.Error("retry: plan not found", "apply_id", apply.ApplyIdentifier, "plan_id", apply.PlanID, "error", err)
+		c.failApplyPermanently(ctx, apply, errMsg)
+		return fmt.Errorf("%s (plan_id=%d): %w", errMsg, apply.PlanID, err)
+	}
+
+	tasks, err := c.storage.Tasks().GetByApplyID(ctx, apply.ID)
+	if err != nil {
+		errMsg := fmt.Sprintf("retry failed: load tasks: %v", err)
+		c.logger.Error("retry: failed to load tasks", "apply_id", apply.ApplyIdentifier, "error", err)
+		c.failApplyPermanently(ctx, apply, errMsg)
+		return fmt.Errorf("%s", errMsg)
+	}
+
+	// Transition to running
+	apply.State = state.Apply.Running
+	apply.ErrorMessage = ""
+	apply.CompletedAt = nil
+	apply.UpdatedAt = time.Now()
+	if err := c.storage.Applies().Update(ctx, apply); err != nil {
+		c.logger.Error("retry: failed to update apply state",
+			"apply_id", apply.ApplyIdentifier, "error", err)
+		return fmt.Errorf("retry: update apply state: %w", err)
+	}
+
+	// Reset failed tasks for retry
+	for _, task := range tasks {
+		if task.State == state.Task.FailedRetryable {
+			task.State = state.Task.Pending
+			task.ErrorMessage = ""
+			task.CompletedAt = nil
+			task.Attempt++
+			if err := c.storage.Tasks().Update(ctx, task); err != nil {
+				c.logger.Warn("retry: failed to reset task",
+					"task_id", task.TaskIdentifier, "error", err)
+			}
+		}
+	}
+
+	c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventInfo, storage.LogSourceSchemaBot,
+		fmt.Sprintf("Retry attempt %d: re-dispatching apply %s", apply.Attempt, apply.ApplyIdentifier), "", state.Apply.Running)
+
+	// Re-dispatch in background using the same execution mode as the original apply.
+	options := parseOptionsMap(apply.Options)
+	deferCutover := options["defer_cutover"] == "true"
+	applyCtx, cancelApply := context.WithCancel(context.WithoutCancel(ctx))
+	c.cancelMu.Lock()
+	c.cancelApply = cancelApply
+	c.cancelMu.Unlock()
+	if deferCutover || c.config.Type == storage.DatabaseTypeVitess {
+		go c.runWithRecovery(applyCtx, apply, tasks, func() {
+			c.executeApplyAtomic(applyCtx, apply, tasks, plan, options)
+		})
+	} else {
+		go c.runWithRecovery(applyCtx, apply, tasks, func() {
+			c.executeApplySequential(applyCtx, apply, tasks, plan, options)
+		})
+	}
+
+	return nil
+}
+
+// failApplyPermanently marks an apply as permanently failed.
+func (c *LocalClient) failApplyPermanently(ctx context.Context, apply *storage.Apply, errMsg string) {
+	now := time.Now()
+	apply.State = state.Apply.Failed
+	apply.ErrorMessage = errMsg
+	apply.CompletedAt = &now
+	apply.UpdatedAt = now
+	if err := c.storage.Applies().Update(ctx, apply); err != nil {
+		c.logger.Error("failed to mark apply as permanently failed",
+			"apply_id", apply.ApplyIdentifier, "error", err)
+	}
+}
+
 func (c *LocalClient) ResumeApply(ctx context.Context, apply *storage.Apply) error {
-	// Get tasks for this apply
+	// Re-fetch to get latest state and options (apply may have been modified
+	// by a control operation between FindNextApply and now).
+	fresh, err := c.storage.Applies().Get(ctx, apply.ID)
+	if err != nil {
+		return fmt.Errorf("refresh apply %s: %w", apply.ApplyIdentifier, err)
+	}
+	if fresh == nil {
+		return fmt.Errorf("apply %s not found during refresh", apply.ApplyIdentifier)
+	}
+	apply = fresh
+
+	// Route to the appropriate recovery path based on state
+	if apply.State == state.Apply.FailedRetryable {
+		return c.retryFailedApply(ctx, apply)
+	}
+
+	// Crash recovery path: apply was in-progress when worker crashed
 	tasks, err := c.storage.Tasks().GetByApplyID(ctx, apply.ID)
 	if err != nil {
 		return fmt.Errorf("get tasks for apply %s: %w", apply.ApplyIdentifier, err)
@@ -457,7 +563,6 @@ func (c *LocalClient) ResumeApply(ctx context.Context, apply *storage.Apply) err
 		return nil
 	}
 
-	// Get the plan to retrieve original DDLs
 	plan, err := c.storage.Plans().GetByID(ctx, apply.PlanID)
 	if err != nil || plan == nil {
 		c.logger.Warn("plan not found for apply, marking as failed",
@@ -526,7 +631,13 @@ func (c *LocalClient) ResumeApply(ctx context.Context, apply *storage.Apply) err
 		c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventStateTransition, storage.LogSourceSchemaBot,
 			"Apply resumed from checkpoint (sequential)", "", state.Apply.Running)
 
-		go c.resumeApplySequential(context.Background(), apply, activeTasks, plan, options)
+		resumeCtx, cancelResume := context.WithCancel(context.WithoutCancel(ctx))
+		c.cancelMu.Lock()
+		c.cancelApply = cancelResume
+		c.cancelMu.Unlock()
+		go c.runWithRecovery(resumeCtx, apply, activeTasks, func() {
+			c.resumeApplySequential(resumeCtx, apply, activeTasks, plan, options)
+		})
 	}
 
 	return nil

--- a/pkg/tern/local_control_resume.go
+++ b/pkg/tern/local_control_resume.go
@@ -160,7 +160,7 @@ func (c *LocalClient) Start(ctx context.Context, req *ternv1.StartRequest) (*ter
 	options := buildApplyOptions(apply)
 	oldApplyState := apply.State
 
-	if apply.GetOptions().DeferCutover {
+	if c.shouldUseAtomicResume(apply) {
 		logMsg := fmt.Sprintf("Resume requested: %d tasks resumed, %d already completed", len(resumeTasks), completedCount)
 		if err := c.launchAtomicResume(ctx, apply, resumeTasks, plan, options, logMsg); err != nil {
 			return nil, err
@@ -378,6 +378,10 @@ func buildApplyOptions(apply *storage.Apply) map[string]string {
 	return options
 }
 
+func (c *LocalClient) shouldUseAtomicResume(apply *storage.Apply) bool {
+	return apply.GetOptions().DeferCutover || c.config.Type == storage.DatabaseTypeVitess
+}
+
 // launchAtomicResume sends all DDLs to the engine in one call, marks tasks and
 // apply as RUNNING, logs the provided message, and starts pollForCompletionAtomic
 // in a background goroutine. Used by both Start() and ResumeApply().
@@ -398,8 +402,15 @@ func (c *LocalClient) launchAtomicResume(ctx context.Context, apply *storage.App
 		tableChanges = append(tableChanges, engine.TableChange{DDL: ddl})
 	}
 
-	// Resume atomic apply after restart. Use apply identifier as MigrationContext
-	// so Spirit can find existing checkpoint tables from the original run.
+	resumeState := &engine.ResumeState{MigrationContext: apply.ApplyIdentifier}
+	if c.config.Type == storage.DatabaseTypeVitess {
+		var err error
+		resumeState, err = c.buildVitessResumeState(ctx, apply)
+		if err != nil {
+			return fmt.Errorf("build Vitess resume state: %w", err)
+		}
+	}
+
 	result, err := eng.Apply(ctx, &engine.ApplyRequest{
 		Database: apply.Database,
 		Changes: []engine.SchemaChange{{
@@ -407,7 +418,7 @@ func (c *LocalClient) launchAtomicResume(ctx context.Context, apply *storage.App
 			TableChanges: tableChanges,
 		}},
 		Options:     options,
-		ResumeState: &engine.ResumeState{MigrationContext: apply.ApplyIdentifier},
+		ResumeState: resumeState,
 		Credentials: creds,
 	})
 	if err != nil {
@@ -530,6 +541,8 @@ func (c *LocalClient) failApplyPermanently(ctx context.Context, apply *storage.A
 }
 
 func (c *LocalClient) ResumeApply(ctx context.Context, apply *storage.Apply) error {
+	claimedRetryable := apply.State == state.Apply.FailedRetryable
+
 	// Re-fetch to get latest state and options (apply may have been modified
 	// by a control operation between FindNextApply and now).
 	fresh, err := c.storage.Applies().Get(ctx, apply.ID)
@@ -542,7 +555,7 @@ func (c *LocalClient) ResumeApply(ctx context.Context, apply *storage.Apply) err
 	apply = fresh
 
 	// Route to the appropriate recovery path based on state
-	if apply.State == state.Apply.FailedRetryable {
+	if claimedRetryable || apply.State == state.Apply.FailedRetryable {
 		return c.retryFailedApply(ctx, apply)
 	}
 
@@ -610,7 +623,7 @@ func (c *LocalClient) ResumeApply(ctx context.Context, apply *storage.Apply) err
 
 	options := buildApplyOptions(apply)
 
-	if apply.GetOptions().DeferCutover {
+	if c.shouldUseAtomicResume(apply) {
 		if err := c.launchAtomicResume(ctx, apply, activeTasks, plan, options, "Apply resumed from checkpoint (atomic)"); err != nil {
 			c.logger.Error("engine apply failed during recovery",
 				"apply_id", apply.ApplyIdentifier,


### PR DESCRIPTION
## Summary

Improve scheduler retry recovery so retryable failures can be recovered safely while permanent PlanetScale failures still become terminal.

- Adds `failed_retryable` handling for applies and tasks, with scheduler re-dispatch up to the retry budget before permanent failure
- Adds configurable scheduler worker concurrency with database exclusion and fresh leases for claimed retryable applies
- Keeps engine errors retryable by default for Spirit, while PlanetScale explicitly marks known permanent apply failures non-retryable
- Preserves Vitess resume metadata for PlanetScale deploy requests during recovery
- Covers retry recovery, retry exhaustion, exclusive claims, Vitess resume, LocalScale revert-window behavior, and permanent PlanetScale failure handling in tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)