### PR TITLE
bump spirit api

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.32.7
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.7
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.1
-	github.com/block/spirit v0.12.1-0.20260414123006-daa99d533e68
+	github.com/block/spirit v0.12.1-0.20260428210128-cd4aecfd2fcd
 	github.com/bradleyfalzon/ghinstallation/v2 v2.17.0
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
@@ -34,6 +34,7 @@ require (
 	go.opentelemetry.io/otel/metric v1.43.0
 	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/sdk/metric v1.43.0
+	golang.org/x/net v0.52.0
 	golang.org/x/sync v0.20.0
 	golang.org/x/text v0.35.0
 	golang.org/x/tools v0.43.0
@@ -235,7 +236,6 @@ require (
 	golang.org/x/crypto v0.49.0 // indirect
 	golang.org/x/exp v0.0.0-20250911091902-df9299821621 // indirect
 	golang.org/x/mod v0.34.0 // indirect
-	golang.org/x/net v0.52.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/time v0.13.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -107,8 +107,8 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/block/spirit v0.12.1-0.20260414123006-daa99d533e68 h1:xeqyQXjhD3mSsA0SUoCZ0EtxKkZDN6IwbJmDSvjiB1w=
-github.com/block/spirit v0.12.1-0.20260414123006-daa99d533e68/go.mod h1:TpxEit7CjSLSrhDG21K5ORu3abMED5OipGLDAadjX5Y=
+github.com/block/spirit v0.12.1-0.20260428210128-cd4aecfd2fcd h1:KGwjKbjDe5fAWQHXoButCeAIoqeuzOptBoUZFUVmoN0=
+github.com/block/spirit v0.12.1-0.20260428210128-cd4aecfd2fcd/go.mod h1:TpxEit7CjSLSrhDG21K5ORu3abMED5OipGLDAadjX5Y=
 github.com/block/vitess v0.0.0-20260312213147-c2d162972c2d h1:IUsLaXSDLqBWN/5KiuGwhP8GOKVSY3ORkZuqoQnryrI=
 github.com/block/vitess v0.0.0-20260312213147-c2d162972c2d/go.mod h1:Q6qWoQw3mAEBOMg0Hn28sb5EWi7pRJ9885zrVtU6MGM=
 github.com/bndr/gotabulate v1.1.2 h1:yC9izuZEphojb9r+KYL4W9IJKO/ceIO8HDwxMA24U4c=


### PR DESCRIPTION
Spirit contains some breaking API changes in @main, mainly in the chunker API which schemabot is not using.

We should bump the dependency though so we can dogfood changes.