### PR TITLE
feat(vitess): add WaitingForDeploy state with TUI deploy review

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -186,11 +186,10 @@ endif
 #   make demo SKIP_APPLY=1 # Start server only, skip schema applies (for debugging)
 demo:
 ifeq ($(KEEP_DATA),1)
-	docker compose -f deploy/local/docker-compose.yml down -t 10 2>/dev/null || true
+	docker compose -f deploy/local/docker-compose.yml down --remove-orphans -t 10 2>/dev/null || true
 else
-	docker compose -f deploy/local/docker-compose.yml down -v -t 10 2>/dev/null || true
+	docker compose -f deploy/local/docker-compose.yml down --remove-orphans -v -t 10 2>/dev/null || true
 endif
-	docker rm -f schemabot-mysql-schemabot-1 schemabot-mysql-staging-1 schemabot-mysql-production-1 schemabot-schemabot-1 2>/dev/null || true
 	@# Build everything in parallel: LocalScale image + Go binaries + start MySQL containers
 	@echo "Building binaries and starting containers in parallel..."
 	@docker compose -f deploy/local/docker-compose.yml up -d mysql-schemabot mysql-staging mysql-production & \
@@ -206,26 +205,22 @@ endif
 	@$(MAKE) wait-localscale
 ifneq ($(SKIP_APPLY),1)
 	@trap 'kill 0' INT TERM; \
-	echo "Applying schemas (MySQL + Vitess in parallel, staging → production)..."; \
-	( ./bin/schemabot apply -s examples/mysql/schema/testapp -e staging --endpoint http://localhost:13370 -y --allow-unsafe -o log && \
-	  ./bin/schemabot apply -s examples/mysql/schema/testapp -e production --endpoint http://localhost:13370 -y --allow-unsafe -o log ) & \
-	( for ks in testapp testapp_sharded; do \
-		if [ -f examples/vitess/schema/$$ks/vschema.json ]; then \
-			curl -sf -X POST "http://localhost:13374/admin/seed-vschema" \
-				-H "Content-Type: application/json" \
-				-d "{\"org\":\"localscale-staging\",\"database\":\"testapp-vitess\",\"keyspace\":\"$$ks\",\"vschema\":$$(cat examples/vitess/schema/$$ks/vschema.json)}"; \
-			curl -sf -X POST "http://localhost:13374/admin/seed-vschema" \
-				-H "Content-Type: application/json" \
-				-d "{\"org\":\"localscale-production\",\"database\":\"testapp-vitess\",\"keyspace\":\"$$ks\",\"vschema\":$$(cat examples/vitess/schema/$$ks/vschema.json)}"; \
-		fi; \
-	done && \
-	  ./bin/schemabot apply -s examples/vitess/schema -e staging --endpoint http://localhost:13370 -y -o log && \
-	  ./bin/schemabot apply -s examples/vitess/schema -e production --endpoint http://localhost:13370 -y -o log ) & \
-	wait; \
-	echo "Seeding data (MySQL + Vitess in parallel)..."; \
-	./scripts/seed-large.sh 50 both & \
-	VTGATE_MYSQL_PORT=19101 ./scripts/seed-vitess.sh 200 & \
-	wait
+	echo "Applying MySQL schemas (staging → production)..."; \
+	./bin/schemabot apply -s examples/mysql/schema/testapp -e staging --endpoint http://localhost:13370 -y --allow-unsafe -o log && \
+	./bin/schemabot apply -s examples/mysql/schema/testapp -e production --endpoint http://localhost:13370 -y --allow-unsafe -o log && \
+	echo "MySQL schemas applied." && \
+	echo "" && \
+	echo "Applying Vitess schemas (staging → production)..." && \
+	./bin/schemabot apply -s examples/vitess/schema -e staging --endpoint http://localhost:13370 -y -o log --allow-unsafe --skip-revert && \
+	./bin/schemabot apply -s examples/vitess/schema -e production --endpoint http://localhost:13370 -y -o log --allow-unsafe --skip-revert && \
+	echo "Vitess schemas applied." && \
+	echo "Waiting for VSchema propagation..." && \
+	sleep 5 && \
+	echo "" && \
+	echo "Seeding data..." && \
+	./scripts/seed-large.sh 50 both && \
+	STAGING_VTGATE_PORT=19101 ./scripts/seed-vitess.sh 200 && \
+	echo "Seeding complete."
 	@echo "$$DEMO_READY_MSG"
 else
 	@echo "$$DEMO_SKIP_APPLY_MSG"

--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -2529,16 +2529,6 @@ Sequential mode: Just started (all tables pending)
 └──────────────────────────────────┘
 
 
-     ~ users: ⏳ Queued
-       ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
-
-     ~ orders: ⏳ Queued
-       ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
-
-     ~ products: ⏳ Queued
-       ALTER TABLE `products` ADD COLUMN `weight_grams` int DEFAULT 0;
-
-
 ```
 </details>
 
@@ -2767,12 +2757,6 @@ Use 'schemabot start' to resume from checkpoint.
 └────────────────────────────────────┘
 
 
-  ── myapp_sharded ──
-
-     ~ users: ⏳ Queued
-       ALTER TABLE `users` ADD COLUMN `phone` varchar(20);
-
-
 ```
 </details>
 
@@ -2788,12 +2772,6 @@ Use 'schemabot start' to resume from checkpoint.
 │  State:        Refreshing branch schema  │
 │  Branch:       my-reusable-branch        │
 └──────────────────────────────────────────┘
-
-
-  ── myapp_sharded ──
-
-     ~ users: ⏳ Queued
-       ALTER TABLE `users` ADD COLUMN `region` varchar(50);
 
 
 ```
@@ -2828,12 +2806,6 @@ Use 'schemabot start' to resume from checkpoint.
 │  State:        Creating deploy request   │
 │  Branch:       schemabot-myapp-28471035  │
 └──────────────────────────────────────────┘
-
-
-  ── myapp_sharded ──
-
-     ~ users: ⏳ Queued
-       ALTER TABLE `users` ADD COLUMN `phone` varchar(20);
 
 
 ```
@@ -2977,6 +2949,32 @@ Use 'schemabot start' to resume from checkpoint.
 
 To recover: Fix the issue above, then run a new apply.
 The new apply will only process tables that haven't completed.
+
+```
+</details>
+
+<details>
+<summary><a name="vitess-waiting-for-deploy"></a><strong>Vitess: Waiting For Deploy</strong></summary>
+
+```
+
+┌────────────────────────────────────────────────────────────────────────────────┐
+│  Apply ID:        apply-a1b2c3d4e5f6                                           │
+│  Database:        myapp                                                        │
+│  Environment:     production                                                   │
+│  State:           Waiting for deploy                                           │
+│  Options:         ⏸️ Defer Deploy                                              │
+│  Branch:          schemabot-myapp-28471035                                     │
+│  Deploy Request:  https://app.planetscale.com/my-org/myapp/deploy-requests/50  │
+│  Started:         Jan 15 14:29:30 UTC                                          │
+│  Duration:        30s                                                          │
+└────────────────────────────────────────────────────────────────────────────────┘
+
+
+Deploy request created: https://app.planetscale.com/my-org/myapp/deploy-requests/50
+⚡ This change will be applied using instant mode.
+
+Press Enter to deploy or proceed via the PlanetScale console (ESC to detach)
 
 ```
 </details>
@@ -3789,16 +3787,6 @@ Sequential mode: Just started (all tables pending)
 │  Started:   Jan 15 14:29:50 UTC  │
 │  Duration:  10s                  │
 └──────────────────────────────────┘
-
-
-     ~ users: ⏳ Queued
-       ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
-
-     ~ orders: ⏳ Queued
-       ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
-
-     ~ products: ⏳ Queued
-       ALTER TABLE `products` ADD COLUMN `weight_grams` int DEFAULT 0;
 
 
 ```

--- a/e2e/local/vitess_test.go
+++ b/e2e/local/vitess_test.go
@@ -1535,6 +1535,102 @@ func createBranchViaLocalScale(t *testing.T, branchName string) {
 // TestVitess_Apply_BranchReuse tests the --branch flag for reusing an existing
 // PlanetScale branch. Creates a branch, applies with --branch, then syncs and
 // applies again on the same branch.
+func TestVitess_Apply_DeferDeploy(t *testing.T) {
+	// Verify that applies with defer_deploy hold at WaitingForDeploy,
+	// and that calling Start triggers the deploy to completion.
+	vitessAvailable(t)
+	clearSchemaBotState(t)
+	defer vitessRestoreBaseSchema(t, "staging")
+
+	endpoint := schemabotURL(t)
+
+	// Plan via API
+	colName := fmt.Sprintf("defer_col_%d", time.Now().UnixMilli()%100000)
+	schemaDir := newVitessSchemaDir(t, vitessSchemaWithOverrides(map[string]string{
+		"testapp_sharded/users.sql": usersSchemaWithColumn(colName),
+	}))
+	planResp, err := client.CallPlanAPI(endpoint, vitessDB, "vitess", "staging", schemaDir, "", 0)
+	require.NoError(t, err)
+	require.NotEmpty(t, planResp.PlanID)
+	require.NotEmpty(t, planResp.Changes, "expected plan to have changes")
+
+	// Apply via API with defer_deploy option
+	applyResp, err := client.CallApplyAPI(endpoint, planResp.PlanID, vitessDB, "staging", "e2e-test",
+		map[string]string{"defer_deploy": "true", "skip_revert": "true"})
+	require.NoError(t, err)
+	require.NotEmpty(t, applyResp.ApplyID)
+	t.Logf("apply started: %s", applyResp.ApplyID)
+
+	// Poll until WaitingForDeploy
+	waitForApplyState(t, endpoint, applyResp.ApplyID, state.Apply.WaitingForDeploy, testutil.PollDeadline)
+	t.Logf("apply reached waiting_for_deploy")
+
+	// Verify the progress response has deferred_deploy metadata
+	progress, err := client.GetProgress(endpoint, applyResp.ApplyID)
+	require.NoError(t, err)
+	assert.Equal(t, state.Apply.WaitingForDeploy, progress.State)
+	assert.Equal(t, "true", progress.Metadata["deferred_deploy"])
+
+	// Trigger deploy via Start API. Retry briefly — the progress API may
+	// return WaitingForDeploy before the apply record in storage catches up.
+	var startResp *apitypes.StartResponse
+	for range 10 {
+		startResp, err = client.CallStartAPI(endpoint, vitessDB, "staging", applyResp.ApplyID)
+		if err == nil && startResp.Accepted {
+			break
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	require.NoError(t, err)
+	require.True(t, startResp.Accepted, "start should be accepted: %s", startResp.ErrorMessage)
+	t.Logf("deploy triggered via start API")
+
+	// Wait for completion
+	waitForApplyState(t, endpoint, applyResp.ApplyID, state.Apply.Completed, testutil.PollDeadline)
+	t.Logf("apply completed")
+}
+
+func TestVitess_Apply_DeferDeploy_StartTooEarly(t *testing.T) {
+	// Verify that calling Start before the apply reaches WaitingForDeploy
+	// returns a clear "not ready" error instead of a confusing message.
+	vitessAvailable(t)
+	clearSchemaBotState(t)
+	defer vitessRestoreBaseSchema(t, "staging")
+
+	endpoint := schemabotURL(t)
+
+	colName := fmt.Sprintf("early_col_%d", time.Now().UnixMilli()%100000)
+	schemaDir := newVitessSchemaDir(t, vitessSchemaWithOverrides(map[string]string{
+		"testapp_sharded/users.sql": usersSchemaWithColumn(colName),
+	}))
+	planResp, err := client.CallPlanAPI(endpoint, vitessDB, "vitess", "staging", schemaDir, "", 0)
+	require.NoError(t, err)
+	require.NotEmpty(t, planResp.PlanID)
+
+	applyResp, err := client.CallApplyAPI(endpoint, planResp.PlanID, vitessDB, "staging", "e2e-test",
+		map[string]string{"defer_deploy": "true", "skip_revert": "true"})
+	require.NoError(t, err)
+	require.NotEmpty(t, applyResp.ApplyID)
+
+	// Call Start immediately — apply hasn't reached WaitingForDeploy yet
+	_, startErr := client.CallStartAPI(endpoint, vitessDB, "staging", applyResp.ApplyID)
+	require.Error(t, startErr)
+	assert.Contains(t, startErr.Error(), "not ready for deploy")
+
+	// Clean up: wait for WaitingForDeploy, then trigger and complete
+	waitForApplyState(t, endpoint, applyResp.ApplyID, state.Apply.WaitingForDeploy, testutil.PollDeadline)
+	var startResp *apitypes.StartResponse
+	for range 10 {
+		startResp, err = client.CallStartAPI(endpoint, vitessDB, "staging", applyResp.ApplyID)
+		if err == nil && startResp.Accepted {
+			break
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	require.NoError(t, err)
+	waitForApplyState(t, endpoint, applyResp.ApplyID, state.Apply.Completed, testutil.PollDeadline)
+}
+
 func TestVitess_Apply_BranchReuse(t *testing.T) {
 	vitessAvailable(t)
 	clearSchemaBotState(t)

--- a/examples/vitess/schema/testapp/users_seq.sql
+++ b/examples/vitess/schema/testapp/users_seq.sql
@@ -3,4 +3,4 @@ CREATE TABLE `users_seq` (
   `next_id` bigint unsigned DEFAULT NULL,
   `cache` bigint unsigned DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='vitess_sequence'

--- a/pkg/api/progress_handlers.go
+++ b/pkg/api/progress_handlers.go
@@ -372,6 +372,12 @@ func (s *Service) overlayVitessMetadata(ctx context.Context, resp *apitypes.Prog
 	if vad.DeployRequestURL != "" {
 		resp.Metadata["deploy_request_url"] = vad.DeployRequestURL
 	}
+	if vad.IsInstant {
+		resp.Metadata["is_instant"] = "true"
+	}
+	if vad.DeferredDeploy {
+		resp.Metadata["deferred_deploy"] = "true"
+	}
 	if vad.RevertSkippedAt != nil {
 		resp.Metadata["revert_skipped"] = "true"
 	}
@@ -691,6 +697,9 @@ func overlayApplyOptions(resp *apitypes.ProgressResponse, apply *storage.Apply) 
 	optMap := make(map[string]string)
 	if opts.DeferCutover {
 		optMap["defer_cutover"] = "true"
+	}
+	if opts.DeferDeploy {
+		optMap["defer_deploy"] = "true"
 	}
 	if opts.SkipRevert {
 		optMap["skip_revert"] = "true"

--- a/pkg/cmd/commands/apply.go
+++ b/pkg/cmd/commands/apply.go
@@ -70,6 +70,8 @@ func (cmd *ApplyCmd) Run(g *Globals) error {
 		}
 		var stateMsg string
 		switch {
+		case state.IsState(active.State, state.Apply.WaitingForDeploy):
+			stateMsg = "A schema change is waiting for deploy."
 		case state.IsState(active.State, state.Apply.WaitingForCutover):
 			stateMsg = "A schema change is waiting for cutover."
 		case state.IsState(active.State, state.Apply.Running):
@@ -86,7 +88,7 @@ func (cmd *ApplyCmd) Run(g *Globals) error {
 			fmt.Println()
 			fmt.Println(stateMsg)
 			fmt.Println()
-			if state.IsState(active.State, state.Apply.WaitingForCutover) {
+			if state.IsState(active.State, state.Apply.WaitingForDeploy, state.Apply.WaitingForCutover) {
 				if active.ApplyID != "" {
 					fmt.Printf("To trigger cutover:  schemabot cutover --apply-id %s\n", active.ApplyID)
 				} else {
@@ -682,6 +684,8 @@ func watchApplyProgressLog(endpoint, applyID string, heartbeatInterval time.Dura
 		if globalNorm != lastGlobalState {
 			// Emit global state changes that aren't covered by per-table events
 			switch {
+			case state.IsState(curState, state.Apply.WaitingForDeploy) && lastGlobalState != "":
+				log.emit("msg", "Deploy request ready — waiting for deploy")
 			case state.IsState(curState, state.Apply.WaitingForCutover) && lastGlobalState != "":
 				log.emit("msg", "Waiting for cutover")
 			case state.IsState(curState, state.Apply.CuttingOver):

--- a/pkg/cmd/commands/common.go
+++ b/pkg/cmd/commands/common.go
@@ -297,6 +297,11 @@ func applyAndWatch(ep string, planResult *apitypes.PlanResponse, database, envir
 	if deferCutover {
 		options["defer_cutover"] = "true"
 	}
+	// TUI mode: defer deploy so the user can review the deploy request diff
+	// on PlanetScale before triggering. Non-interactive modes auto-deploy.
+	if watch && format == OutputFormatInteractive {
+		options["defer_deploy"] = "true"
+	}
 	if skipRevert {
 		options["skip_revert"] = "true"
 	}

--- a/pkg/cmd/commands/preview.go
+++ b/pkg/cmd/commands/preview.go
@@ -29,7 +29,7 @@ func (cmd *PreviewCmd) Run(g *Globals) error {
 	previewType := templates.PreviewType(cmd.Type)
 	switch previewType {
 	// Basic types
-	case templates.PreviewPlan, templates.PreviewProgress, templates.PreviewWaitingForCutover,
+	case templates.PreviewPlan, templates.PreviewProgress, templates.PreviewWaitingForDeploy, templates.PreviewWaitingForCutover,
 		templates.PreviewCuttingOver, templates.PreviewCompleted, templates.PreviewFailed,
 		templates.PreviewStopped, templates.PreviewStates:
 		templates.PreviewCLIOutput(previewType)
@@ -126,6 +126,7 @@ Usage:
 Basic Types:
   plan                  Show sample plan output
   progress              Show sample progress output (running state)
+  waiting_for_deploy    Show sample waiting for deploy output (PlanetScale)
   waiting_for_cutover   Show sample waiting for cutover output
   cutting_over          Show sample cutting over output
   completed             Show sample completed output

--- a/pkg/cmd/commands/rollback.go
+++ b/pkg/cmd/commands/rollback.go
@@ -41,6 +41,8 @@ func (cmd *RollbackCmd) Run(g *Globals) error {
 		// Ignore errors - progress API may fail if no schema change exists
 	} else if active != nil && active.State != "" && !state.IsState(active.State, state.NoActiveChange) {
 		switch {
+		case state.IsState(active.State, state.Apply.WaitingForDeploy):
+			return fmt.Errorf("cannot rollback: a schema change is waiting for deploy")
 		case state.IsState(active.State, state.Apply.WaitingForCutover):
 			return fmt.Errorf("cannot rollback: a schema change is waiting for cutover")
 		case state.IsState(active.State, state.Apply.Running):

--- a/pkg/cmd/commands/start.go
+++ b/pkg/cmd/commands/start.go
@@ -42,8 +42,8 @@ func (cmd *StartCmd) Run(g *Globals) error {
 		}
 		return nil
 	}
-	if !state.IsState(curState, state.Apply.Stopped) {
-		return fmt.Errorf("cannot start schema change in state: %s (expected STOPPED)", curState)
+	if !state.IsState(curState, state.Apply.Stopped, state.Apply.WaitingForDeploy) {
+		return fmt.Errorf("cannot start schema change in state: %s", curState)
 	}
 
 	// Always scope start to the specific apply to avoid cross-apply contamination.

--- a/pkg/cmd/commands/stop.go
+++ b/pkg/cmd/commands/stop.go
@@ -47,7 +47,7 @@ func (cmd *StopCmd) Run(g *Globals) error {
 		fmt.Println("Schema change already stopped")
 		return nil
 	}
-	if !state.IsState(curState, state.Apply.Running, state.Apply.CuttingOver, state.Apply.WaitingForCutover, state.Apply.Pending) {
+	if !state.IsState(curState, state.Apply.Running, state.Apply.CuttingOver, state.Apply.WaitingForDeploy, state.Apply.WaitingForCutover, state.Apply.Pending) {
 		return fmt.Errorf("cannot stop schema change in state: %s", curState)
 	}
 

--- a/pkg/cmd/commands/watch_tui.go
+++ b/pkg/cmd/commands/watch_tui.go
@@ -22,6 +22,7 @@ type WatchModel struct {
 	applyID             string // When set, fetches progress by apply ID instead of database/environment
 	allowCutover        bool
 	maxTableNameLen     int
+	deployTriggered     bool
 	cutoverTriggered    bool
 	skipRevertTriggered bool
 	skipRevertAt        time.Time // When skip-revert was triggered (for timeout)
@@ -113,6 +114,11 @@ type cutoverResultMsg struct {
 	err     error
 }
 
+type deployResultMsg struct {
+	success bool
+	err     error
+}
+
 type stopResultMsg struct {
 	success bool
 	err     error
@@ -180,7 +186,7 @@ func (m WatchModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, nil
 			}
 			// Stop (Spirit) or cancel (PlanetScale) the schema change
-			if state.IsState(m.state, state.Apply.Running, state.Apply.WaitingForCutover) && !m.stopTriggered {
+			if state.IsState(m.state, state.Apply.Running, state.Apply.WaitingForDeploy, state.Apply.WaitingForCutover) && !m.stopTriggered {
 				m.stopTriggered = true
 				return m, m.triggerStop()
 			}
@@ -191,6 +197,11 @@ func (m WatchModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, nil
 			}
 		case "enter":
+			// Trigger deploy if waiting for deploy and not already triggered
+			if state.IsState(m.state, state.Apply.WaitingForDeploy) && m.allowCutover && !m.deployTriggered {
+				m.deployTriggered = true
+				return m, m.triggerDeploy()
+			}
 			// Trigger cutover if waiting and not already triggered
 			if state.IsState(m.state, state.Apply.WaitingForCutover) && m.allowCutover && !m.cutoverTriggered {
 				m.cutoverTriggered = true
@@ -289,6 +300,13 @@ func (m WatchModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case cutoverResultMsg:
 		if msg.err != nil {
 			m.errorMsg = msg.err.Error()
+		}
+		// Continue polling - next tick will fetch updated state
+
+	case deployResultMsg:
+		if msg.err != nil {
+			m.errorMsg = msg.err.Error()
+			m.deployTriggered = false // Allow retry
 		}
 		// Continue polling - next tick will fetch updated state
 

--- a/pkg/cmd/commands/watch_tui_commands.go
+++ b/pkg/cmd/commands/watch_tui_commands.go
@@ -49,6 +49,25 @@ func (m WatchModel) fetchProgress() tea.Cmd {
 	}
 }
 
+func (m WatchModel) triggerDeploy() tea.Cmd {
+	return func() tea.Msg {
+		result, err := client.CallStartAPI(m.endpoint, m.database, m.environment, m.applyID)
+		if err != nil {
+			return deployResultMsg{success: false, err: err}
+		}
+
+		if !result.Accepted {
+			errMsg := result.ErrorMessage
+			if errMsg == "" {
+				errMsg = "deploy not accepted"
+			}
+			return deployResultMsg{success: false, err: fmt.Errorf("%s", errMsg)}
+		}
+
+		return deployResultMsg{success: true}
+	}
+}
+
 func (m WatchModel) triggerCutover() tea.Cmd {
 	return func() tea.Msg {
 		result, err := client.CallCutoverAPI(m.endpoint, m.database, m.environment, m.applyID)

--- a/pkg/cmd/commands/watch_tui_view.go
+++ b/pkg/cmd/commands/watch_tui_view.go
@@ -74,7 +74,7 @@ func (m WatchModel) progressView() string {
 		}
 	case effectivelyStopped:
 		// Don't show status line - stopped message comes after tables
-	case state.IsState(m.state, state.Apply.Running) && !m.cutoverTriggered:
+	case state.IsState(m.state, state.Apply.Running) && !m.cutoverTriggered && !m.deployTriggered:
 		b.WriteString(m.spinner.View() + "Running...")
 		b.WriteString("\n")
 	case state.IsState(m.state, state.Apply.WaitingForCutover):
@@ -165,6 +165,30 @@ func (m WatchModel) progressView() string {
 		dimStyle := lipgloss.NewStyle().Faint(true)
 		b.WriteString(dimStyle.Render("Cutover in progress - please wait..."))
 		b.WriteString("\n")
+	case m.deployTriggered:
+		b.WriteString("\n\n")
+		b.WriteString(m.spinner.View() + "Deploying...\n")
+	case state.IsState(m.state, state.Apply.WaitingForDeploy):
+		b.WriteString("\n\n")
+		if m.deployRequestURL != "" {
+			b.WriteString("Deploy request created: " + m.deployRequestURL + "\n")
+		} else {
+			b.WriteString("Deploy request created.\n")
+		}
+		if m.metadata != nil && m.metadata["is_instant"] == "true" {
+			b.WriteString("⚡ This change will be applied using instant mode.\n")
+		}
+		b.WriteString("\n")
+		if m.allowCutover {
+			b.WriteString("Press Enter to deploy or proceed via the PlanetScale console (ESC to detach)\n")
+		} else {
+			if m.applyID != "" {
+				fmt.Fprintf(&b, "To proceed: schemabot start --apply-id %s\n", m.applyID)
+			} else {
+				fmt.Fprintf(&b, "To proceed: schemabot start -d %s -e %s\n", m.database, m.environment)
+			}
+			b.WriteString("Watching for deploy... (ESC to detach)\n")
+		}
 	case state.IsState(m.state, state.Apply.WaitingForCutover):
 		b.WriteString("\n\n")
 		b.WriteString("Row copy complete. All data has been copied and new writes\n")
@@ -327,13 +351,23 @@ func (m WatchModel) detachedView() string {
 	var b strings.Builder
 	b.WriteString("\n")
 	b.WriteString("Detached from progress view.\n")
-	b.WriteString("The schema change continues running in the background.\n")
+	if state.IsState(m.state, state.Apply.WaitingForDeploy) {
+		b.WriteString("The deploy request is waiting for you to trigger it.\n")
+	} else {
+		b.WriteString("The schema change continues running in the background.\n")
+	}
 	b.WriteString("\n")
 	if m.applyID != "" {
 		fmt.Fprintf(&b, "To reattach: schemabot progress %s\n", m.applyID)
+		if state.IsState(m.state, state.Apply.WaitingForDeploy) {
+			fmt.Fprintf(&b, "To deploy:   schemabot start %s\n", m.applyID)
+		}
 		fmt.Fprintf(&b, "To stop:     schemabot stop %s\n", m.applyID)
 	} else {
 		fmt.Fprintf(&b, "To reattach: schemabot progress -d %s -e %s\n", m.database, m.environment)
+		if state.IsState(m.state, state.Apply.WaitingForDeploy) {
+			fmt.Fprintf(&b, "To deploy:   schemabot start -d %s -e %s\n", m.database, m.environment)
+		}
 		fmt.Fprintf(&b, "To stop:     schemabot stop -d %s -e %s\n", m.database, m.environment)
 	}
 	return b.String()

--- a/pkg/cmd/templates/preview.go
+++ b/pkg/cmd/templates/preview.go
@@ -27,6 +27,7 @@ type PreviewType string
 const (
 	PreviewPlan              PreviewType = "plan"
 	PreviewProgress          PreviewType = "progress"
+	PreviewWaitingForDeploy  PreviewType = "waiting_for_deploy"
 	PreviewWaitingForCutover PreviewType = "waiting_for_cutover"
 	PreviewCuttingOver       PreviewType = "cutting_over"
 	PreviewCompleted         PreviewType = "completed"
@@ -169,6 +170,8 @@ func PreviewCLIOutput(previewType PreviewType) {
 		previewVitessPlanOutput()
 	case PreviewProgress:
 		previewProgressOutput()
+	case PreviewWaitingForDeploy:
+		previewVitessWaitingForDeployOutput()
 	case PreviewWaitingForCutover:
 		previewWaitingForCutoverOutput()
 	case PreviewCuttingOver:
@@ -1103,6 +1106,7 @@ func previewCLIApplyAllOutput() {
 		{"VITESS: COMPLETED", previewVitessCompletedOutput},
 		{"VITESS: MULTI-KEYSPACE COMPLETED WATCH", previewVitessMultiKeyspaceCompletedWatchOutput},
 		{"VITESS: FAILED", previewVitessFailedOutput},
+		{"VITESS: WAITING FOR DEPLOY", previewVitessWaitingForDeployOutput},
 		{"VITESS: WAITING FOR CUTOVER", previewVitessWaitingForCutoverOutput},
 		{"VITESS: CUTTING OVER", previewVitessCuttingOverOutput},
 		{"VITESS: CANCELLED", previewVitessCancelledOutput},

--- a/pkg/cmd/templates/preview_progress.go
+++ b/pkg/cmd/templates/preview_progress.go
@@ -405,6 +405,34 @@ func previewVitessFailedOutput() {
 	WriteProgress(data)
 }
 
+func previewVitessWaitingForDeployOutput() {
+	data := ProgressData{
+		State:       state.Apply.WaitingForDeploy,
+		Engine:      "PlanetScale",
+		ApplyID:     "apply-a1b2c3d4e5f6",
+		Database:    "myapp",
+		Environment: "production",
+		StartedAt:   previewTime.Add(-30 * time.Second).Format(time.RFC3339),
+		Options: map[string]string{
+			"defer_deploy": "true",
+		},
+		Metadata: map[string]string{
+			"branch_name":        "schemabot-myapp-28471035",
+			"deploy_request_url": "https://app.planetscale.com/my-org/myapp/deploy-requests/50",
+			"deferred_deploy":    "true",
+			"is_instant":         "true",
+		},
+		Tables: []TableProgress{
+			{
+				TableName: "users", Namespace: "myapp_sharded",
+				DDL:    "ALTER TABLE `users` ADD COLUMN `phone` varchar(20) DEFAULT NULL",
+				Status: state.Apply.Pending,
+			},
+		},
+	}
+	WriteProgress(data)
+}
+
 func previewVitessWaitingForCutoverOutput() {
 	data := ProgressData{
 		State:       state.Apply.WaitingForCutover,

--- a/pkg/cmd/templates/progress.go
+++ b/pkg/cmd/templates/progress.go
@@ -90,6 +90,9 @@ func WriteProgress(data ProgressData) {
 	}
 	if len(data.Options) > 0 {
 		var opts []string
+		if data.Options["defer_deploy"] == "true" {
+			opts = append(opts, "⏸️ Defer Deploy")
+		}
 		if data.Options["defer_cutover"] == "true" {
 			opts = append(opts, "⏸️ Defer Cutover")
 		}
@@ -148,7 +151,8 @@ func WriteProgress(data ProgressData) {
 	}
 
 	// Table progress (sorted: active first, sharded before unsharded, terminal last)
-	if len(activeTables) > 0 {
+	// Hide tables during branch setup phases (all tables are Queued, not meaningful)
+	if len(activeTables) > 0 && !state.IsBranchSetupPhase(data.State) {
 		sort.SliceStable(activeTables, func(i, j int) bool {
 			pi := ui.TableStatePriority(state.NormalizeTaskStatus(activeTables[i].Status))
 			pj := ui.TableStatePriority(state.NormalizeTaskStatus(activeTables[j].Status))
@@ -181,6 +185,19 @@ func WriteProgress(data ProgressData) {
 				fmt.Print(FormatTableProgress(t))
 			}
 		}
+	}
+
+	// Show deploy request info for deferred deploys
+	if data.State == state.Apply.WaitingForDeploy {
+		fmt.Println()
+		if url := data.Metadata["deploy_request_url"]; url != "" {
+			fmt.Printf("Deploy request created: %s\n", url)
+		}
+		if data.Metadata["is_instant"] == "true" {
+			fmt.Println("⚡ This change will be applied using instant mode.")
+		}
+		fmt.Println()
+		fmt.Println("Press Enter to deploy or proceed via the PlanetScale console (ESC to detach)")
 	}
 
 	// Show remediation guidance for failed applies
@@ -361,6 +378,8 @@ func FormatProgressState(s string) string {
 		return "Idle"
 	case state.Apply.Running:
 		return ANSICyan + "🔄 Running" + ANSIReset
+	case state.Apply.WaitingForDeploy:
+		return ANSIYellow + "🟨 Waiting for deploy" + ANSIReset
 	case state.Apply.WaitingForCutover:
 		return ANSIYellow + "🟨 Waiting for cutover" + ANSIReset
 	case state.Apply.CuttingOver:
@@ -808,6 +827,8 @@ func StateLabel(s string) string {
 		return "Failed"
 	case state.Apply.Running:
 		return "Running"
+	case state.Apply.WaitingForDeploy:
+		return "Waiting for deploy"
 	case state.Apply.WaitingForCutover:
 		return "Waiting for cutover"
 	case state.Apply.CuttingOver:
@@ -842,7 +863,7 @@ func stateColorFunc(s string) func(string) string {
 		return colorWrap(ANSIRed)
 	case state.Apply.Running:
 		return colorWrap(ANSICyan)
-	case state.Apply.WaitingForCutover, state.Apply.CuttingOver:
+	case state.Apply.WaitingForDeploy, state.Apply.WaitingForCutover, state.Apply.CuttingOver:
 		return colorWrap(ANSIYellow)
 	case state.Apply.Stopped:
 		return colorWrap(ANSIOrange)

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -12,10 +12,26 @@ package engine
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"time"
 
 	"github.com/block/schemabot/pkg/schema"
 )
+
+// ErrNonRetryable wraps an error to indicate it should not be retried.
+// Engines return this from Progress when the error is permanent (e.g.,
+// deploy request not found after server restart).
+type ErrNonRetryable struct {
+	Err error
+}
+
+func (e *ErrNonRetryable) Error() string { return e.Err.Error() }
+func (e *ErrNonRetryable) Unwrap() error { return e.Err }
+
+// NewNonRetryableError wraps err as a non-retryable error.
+func NewNonRetryableError(msg string, args ...any) error {
+	return &ErrNonRetryable{Err: fmt.Errorf(msg, args...)}
+}
 
 // Engine defines the interface that all schema change backends must implement.
 //
@@ -305,6 +321,7 @@ type State string
 const (
 	StatePending           State = "pending"
 	StateRunning           State = "running"
+	StateWaitingForDeploy  State = "waiting_for_deploy"
 	StateWaitingForCutover State = "waiting_for_cutover"
 	StateCuttingOver       State = "cutting_over"
 	StateRevertWindow      State = "revert_window"

--- a/pkg/engine/planetscale/planetscale.go
+++ b/pkg/engine/planetscale/planetscale.go
@@ -441,6 +441,7 @@ type psMetadata struct {
 	DeployRequestURL string     `json:"deploy_request_url,omitempty"`
 	DeployedAt       *time.Time `json:"deployed_at,omitempty"`
 	IsInstant        bool       `json:"is_instant,omitempty"`
+	DeferredDeploy   bool       `json:"deferred_deploy,omitempty"`
 }
 
 func encodePSMetadata(m *psMetadata) (string, error) {
@@ -933,8 +934,9 @@ func (e *Engine) Apply(ctx context.Context, req *engine.ApplyRequest) (*engine.A
 	// Capture existing migration_contexts before deploy so we can discover the new one
 	existingContexts := e.captureExistingContexts(ctx, client, req.Database, req.Credentials)
 
-	// Check if we should defer cutover
+	// Check defer options
 	deferCutover := req.Options["defer_cutover"] == "true"
+	deferDeploy := req.Options["defer_deploy"] == "true"
 
 	// Create deploy request and wait for it to be ready.
 	// The server computes the schema diff asynchronously — poll until the deploy
@@ -979,8 +981,10 @@ func (e *Engine) Apply(ctx context.Context, req *engine.ApplyRequest) (*engine.A
 	// Determine instant DDL eligibility. Prefer instant when PlanetScale reports
 	// it as eligible — instant DDL modifies metadata only (no row copy), so it
 	// completes immediately and has no revert window regardless of skip_revert.
+	// Instant DDL is orthogonal to defer flags — the mechanism (instant vs row copy)
+	// is independent of when the deploy executes.
 	instantEligible := dr.Deployment != nil && dr.Deployment.InstantDDLEligible
-	useInstant := instantEligible && !deferCutover
+	useInstant := instantEligible
 
 	// Log the raw deploy request fields for debugging instant DDL detection.
 	if dr.Deployment != nil {
@@ -1004,8 +1008,20 @@ func (e *Engine) Apply(ctx context.Context, req *engine.ApplyRequest) (*engine.A
 		"instant_eligible", instantEligible,
 		"use_instant", useInstant,
 		"defer_cutover", deferCutover,
+		"defer_deploy", deferDeploy,
 		"deploy_state", dr.DeploymentState,
 	)
+
+	// Log when --defer-cutover has no effect for instant DDL
+	if deferCutover && useInstant {
+		e.logger.Info("--defer-cutover has no effect for instant DDL",
+			"database", req.Database,
+			"deploy_request", dr.Number,
+		)
+		emitEvent(engine.ApplyEvent{
+			Message: "Note: --defer-cutover has no effect for instant DDL",
+		})
+	}
 
 	drElapsed := time.Since(drStart).Round(time.Second)
 	readyMsg := fmt.Sprintf("Deploy request #%d ready (%s)", dr.Number, drElapsed)
@@ -1020,6 +1036,38 @@ func (e *Engine) Apply(ctx context.Context, req *engine.ApplyRequest) (*engine.A
 			"instant_ddl":        fmt.Sprintf("%t", useInstant),
 		},
 	})
+
+	// Deferred deploy: don't call DeployDeployRequest yet. The user will review
+	// the deploy request diff on PlanetScale and trigger via `schemabot cutover`.
+	if deferDeploy {
+		e.logger.Info("deferring deploy — user must trigger via cutover",
+			"database", req.Database,
+			"deploy_request", dr.Number,
+			"instant_eligible", useInstant,
+		)
+		meta, encErr := encodePSMetadata(&psMetadata{
+			BranchName:       branchName,
+			DeployRequestID:  dr.Number,
+			DeployRequestURL: dr.HtmlURL,
+			IsInstant:        useInstant,
+			DeferredDeploy:   true,
+		})
+		if encErr != nil {
+			return nil, fmt.Errorf("encode metadata for deferred deploy request #%d: %w", dr.Number, encErr)
+		}
+		suffix := ""
+		if useInstant {
+			suffix = " (instant DDL)"
+		}
+		return &engine.ApplyResult{
+			Accepted: true,
+			Message:  fmt.Sprintf("Deploy request #%d ready%s — waiting for deploy", dr.Number, suffix),
+			ResumeState: &engine.ResumeState{
+				MigrationContext: migCtx,
+				Metadata:         meta,
+			},
+		}, nil
+	}
 
 	// Deploy (starts the schema change). PlanetScale may still be validating
 	// the deploy request even after reporting "ready", so retry on transient
@@ -1478,6 +1526,7 @@ func (e *Engine) resumeApply(ctx context.Context, client psclient.PSClient, org 
 	// Create deploy request
 	main := mainBranch(req.Credentials)
 	deferCutover := req.Options["defer_cutover"] == "true"
+	deferDeploy := req.Options["defer_deploy"] == "true"
 
 	dr, err := e.createDeployRequest(ctx, client, org, req.Database, meta.BranchName, main, !deferCutover, true)
 	if err != nil {
@@ -1499,11 +1548,39 @@ func (e *Engine) resumeApply(ctx context.Context, client psclient.PSClient, org 
 
 	// Deploy — prefer instant when eligible (no row copy, no revert window needed).
 	instantEligible := dr.Deployment != nil && dr.Deployment.InstantDDLEligible
-	useInstant := instantEligible && !deferCutover
+	useInstant := instantEligible
 
 	meta.DeployRequestID = dr.Number
 	meta.DeployRequestURL = dr.HtmlURL
 	meta.IsInstant = useInstant
+
+	// Deferred deploy on resume: don't start the deploy yet.
+	if deferDeploy {
+		meta.DeferredDeploy = true
+		persistMeta, encErr := encodePSMetadata(meta)
+		if encErr != nil {
+			return nil, fmt.Errorf("encode metadata for deferred deploy on resume: %w", encErr)
+		}
+		if req.OnStateChange != nil {
+			req.OnStateChange(&engine.ResumeState{
+				MigrationContext: req.ResumeState.MigrationContext,
+				Metadata:         persistMeta,
+			})
+		}
+		suffix := ""
+		if useInstant {
+			suffix = " (instant DDL)"
+		}
+		return &engine.ApplyResult{
+			Accepted: true,
+			Message:  fmt.Sprintf("Deploy request #%d ready%s — waiting for deploy", dr.Number, suffix),
+			ResumeState: &engine.ResumeState{
+				MigrationContext: req.ResumeState.MigrationContext,
+				Metadata:         persistMeta,
+			},
+		}, nil
+	}
+
 	persistMeta, err := encodePSMetadata(meta)
 	if err != nil {
 		return nil, fmt.Errorf("encode metadata on resume: %w", err)
@@ -1564,10 +1641,22 @@ func (e *Engine) Progress(ctx context.Context, req *engine.ProgressRequest) (*en
 
 	dr, err := e.getDeployRequest(ctx, client, credOrg(req.Credentials), req.Database, meta.DeployRequestID)
 	if err != nil {
+		// Deploy request not found is non-retryable (e.g., server restarted
+		// with fresh LocalScale state but stale apply record).
+		var psErr *ps.Error
+		if errors.As(err, &psErr) && psErr.Code == ps.ErrNotFound {
+			return nil, engine.NewNonRetryableError("deploy request #%d not found: %w", meta.DeployRequestID, err)
+		}
 		return nil, fmt.Errorf("get deploy request: %w", err)
 	}
 
 	engineState, progress := deployStateToEngineState(dr.DeploymentState)
+
+	// Deferred deploy: the deploy request is ready but hasn't been triggered yet.
+	if meta.DeferredDeploy && dr.DeploymentState == deployState.Ready {
+		engineState = engine.StateWaitingForDeploy
+		progress = 0
+	}
 
 	// Update metadata with DeployedAt when available (used by tern layer for
 	// revert window timeout calculation).
@@ -1670,12 +1759,43 @@ func (e *Engine) Stop(ctx context.Context, req *engine.ControlRequest) (*engine.
 	}, nil
 }
 
-// Start is not supported for PlanetScale. Cancelled deploy requests cannot be restarted.
-func (e *Engine) Start(_ context.Context, _ *engine.ControlRequest) (*engine.ControlResult, error) {
-	return nil, fmt.Errorf("start not supported for planetscale engine: cancelled deploy requests cannot be restarted")
+// Start starts a deferred deploy request. Cancelled deploy requests cannot be restarted.
+func (e *Engine) Start(ctx context.Context, req *engine.ControlRequest) (*engine.ControlResult, error) {
+	meta, err := e.controlMeta(req)
+	if err != nil {
+		return nil, fmt.Errorf("decode control metadata: %w", err)
+	}
+
+	if !meta.DeferredDeploy {
+		return nil, fmt.Errorf("start not supported for planetscale engine: cancelled deploy requests cannot be restarted")
+	}
+
+	client, err := e.getClient(req.Credentials)
+	if err != nil {
+		return nil, fmt.Errorf("get planetscale client: %w", err)
+	}
+
+	e.logger.Info("starting deferred deploy",
+		"deploy_request", meta.DeployRequestID,
+		"instant_ddl", meta.IsInstant,
+	)
+	dr, deployErr := client.DeployDeployRequest(ctx, &ps.PerformDeployRequest{
+		Organization: credOrg(req.Credentials),
+		Database:     req.Database,
+		Number:       meta.DeployRequestID,
+		InstantDDL:   meta.IsInstant,
+	})
+	if deployErr != nil {
+		return nil, fmt.Errorf("deploy deploy request #%d: %w", meta.DeployRequestID, deployErr)
+	}
+	return &engine.ControlResult{
+		Accepted:    true,
+		Message:     fmt.Sprintf("Deploy initiated for deploy request #%d", dr.Number),
+		ResumeState: req.ResumeState,
+	}, nil
 }
 
-// Cutover completes the deploy request, triggering the final schema swap.
+// Cutover triggers the final schema swap via ApplyDeployRequest.
 func (e *Engine) Cutover(ctx context.Context, req *engine.ControlRequest) (*engine.ControlResult, error) {
 	meta, err := e.controlMeta(req)
 	if err != nil {

--- a/pkg/engine/planetscale/planetscale_test.go
+++ b/pkg/engine/planetscale/planetscale_test.go
@@ -170,6 +170,65 @@ func TestPSMetadataEncodeDecode(t *testing.T) {
 	assert.Equal(t, original.DeployRequestURL, decoded.DeployRequestURL)
 }
 
+func TestPSMetadataEncodeDecode_DeferredDeploy(t *testing.T) {
+	original := &psMetadata{
+		BranchName:       "schemabot-mydb-12345678",
+		DeployRequestID:  42,
+		DeployRequestURL: "https://app.planetscale.com/org/db/deploy-requests/42",
+		IsInstant:        true,
+		DeferredDeploy:   true,
+	}
+
+	encoded, err := encodePSMetadata(original)
+	require.NoError(t, err)
+
+	decoded, err := decodePSMetadata(encoded)
+	require.NoError(t, err)
+	assert.Equal(t, original.BranchName, decoded.BranchName)
+	assert.Equal(t, original.DeployRequestID, decoded.DeployRequestID)
+	assert.True(t, decoded.IsInstant)
+	assert.True(t, decoded.DeferredDeploy)
+}
+
+func TestStart_RejectsNonDeferredDeploy(t *testing.T) {
+	e := &Engine{}
+
+	// Non-deferred metadata — Start should return "not supported"
+	meta, err := encodePSMetadata(&psMetadata{
+		BranchName:      "schemabot-mydb-abc",
+		DeployRequestID: 1,
+		DeferredDeploy:  false,
+	})
+	require.NoError(t, err)
+
+	_, err = e.Start(t.Context(), &engine.ControlRequest{
+		ResumeState: &engine.ResumeState{Metadata: meta},
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not supported")
+}
+
+func TestStart_AcceptsDeferredDeploy(t *testing.T) {
+	// Start with DeferredDeploy=true should attempt to deploy
+	// (will fail because no PS client, but validates dispatch logic)
+	e := &Engine{}
+
+	meta, err := encodePSMetadata(&psMetadata{
+		BranchName:      "schemabot-mydb-abc",
+		DeployRequestID: 1,
+		IsInstant:       true,
+		DeferredDeploy:  true,
+	})
+	require.NoError(t, err)
+
+	_, err = e.Start(t.Context(), &engine.ControlRequest{
+		ResumeState: &engine.ResumeState{Metadata: meta},
+	})
+	// Fails because no PS client configured — but proves it didn't reject as "not supported"
+	assert.Error(t, err)
+	assert.NotContains(t, err.Error(), "not supported")
+}
+
 func TestDecodePSMetadata_Empty(t *testing.T) {
 	_, err := decodePSMetadata("")
 	assert.Error(t, err)

--- a/pkg/localscale/handlers_actions.go
+++ b/pkg/localscale/handlers_actions.go
@@ -321,8 +321,24 @@ func (s *Server) applyPendingVSchema(ctx context.Context, backend *databaseBacke
 		}
 	}
 
+	// Apply unsharded keyspaces first — they define sequence tables that
+	// sharded keyspaces reference via auto_increment. Vtgate's
+	// resolveAutoIncrement deletes tables with unresolvable sequence
+	// references, so the defining keyspace must be in the VSchema before
+	// the referencing keyspace is applied.
+	var unsharded, sharded []string
 	for keyspace, vschemaJSON := range vschemaByKeyspace {
-		if err := s.applyVSchemaInternal(ctx, backend, keyspace, vschemaJSON); err != nil {
+		var ks struct {
+			Sharded bool `json:"sharded"`
+		}
+		if json.Unmarshal(vschemaJSON, &ks) == nil && ks.Sharded {
+			sharded = append(sharded, keyspace)
+		} else {
+			unsharded = append(unsharded, keyspace)
+		}
+	}
+	for _, keyspace := range append(unsharded, sharded...) {
+		if err := s.applyVSchemaInternal(ctx, backend, keyspace, vschemaByKeyspace[keyspace]); err != nil {
 			return fmt.Errorf("apply vschema to %s: %w", keyspace, err)
 		}
 		s.logger.Info("applied vschema for deploy request", "number", ref.number, "keyspace", keyspace)

--- a/pkg/localscale/handlers_deploy.go
+++ b/pkg/localscale/handlers_deploy.go
@@ -469,9 +469,22 @@ func (s *Server) executeDeployRequest(ctx context.Context, p deployExecParams) e
 	// to route DDL correctly to multi-shard keyspaces. Without it, vtgate treats
 	// the keyspace as unsharded and rejects DDL with "Keyspace does not have
 	// exactly one shard".
+	//
+	// When there are DDLs, apply VSchema for routing but reset vschema_applied
+	// so the processor re-applies after DDL completes. Sequence tables (type:
+	// sequence) need their backing tables to exist before vtgate recognizes them.
 	if p.hasVSchema {
 		if err := s.applyPendingVSchema(ctx, p.backend, p.ref, p.vschemaData); err != nil {
 			return fmt.Errorf("apply vschema for deploy request %d: %w", p.ref.number, err)
+		}
+		if p.totalDDL > 0 {
+			// Reset so the processor re-applies VSchema after DDL completes
+			if _, err := s.metadataDB.ExecContext(ctx,
+				`UPDATE localscale_deploy_requests SET vschema_applied = FALSE
+				 WHERE org = ? AND database_name = ? AND number = ?`,
+				p.ref.org, p.ref.database, p.ref.number); err != nil {
+				s.logger.Warn("failed to reset vschema_applied", "number", p.ref.number, "error", err)
+			}
 		}
 	}
 

--- a/pkg/proto/tern.proto
+++ b/pkg/proto/tern.proto
@@ -214,6 +214,7 @@ enum State {
   STATE_PREPARING_BRANCH = 11;
   STATE_APPLYING_BRANCH_CHANGES = 12;
   STATE_CREATING_DEPLOY_REQUEST = 13;
+  STATE_WAITING_FOR_DEPLOY = 14;
 }
 
 // ChangeType represents the type of DDL change.

--- a/pkg/proto/ternv1/tern.pb.go
+++ b/pkg/proto/ternv1/tern.pb.go
@@ -87,6 +87,7 @@ const (
 	State_STATE_PREPARING_BRANCH        State = 11
 	State_STATE_APPLYING_BRANCH_CHANGES State = 12
 	State_STATE_CREATING_DEPLOY_REQUEST State = 13
+	State_STATE_WAITING_FOR_DEPLOY      State = 14
 )
 
 // Enum value maps for State.
@@ -106,6 +107,7 @@ var (
 		11: "STATE_PREPARING_BRANCH",
 		12: "STATE_APPLYING_BRANCH_CHANGES",
 		13: "STATE_CREATING_DEPLOY_REQUEST",
+		14: "STATE_WAITING_FOR_DEPLOY",
 	}
 	State_value = map[string]int32{
 		"STATE_NO_ACTIVE_CHANGE":        0,
@@ -122,6 +124,7 @@ var (
 		"STATE_PREPARING_BRANCH":        11,
 		"STATE_APPLYING_BRANCH_CHANGES": 12,
 		"STATE_CREATING_DEPLOY_REQUEST": 13,
+		"STATE_WAITING_FOR_DEPLOY":      14,
 	}
 )
 
@@ -2369,7 +2372,7 @@ const file_tern_proto_rawDesc = "" +
 	"new_volume\x18\x04 \x01(\x05R\tnewVolume*3\n" +
 	"\x06Engine\x12\x11\n" +
 	"\rENGINE_SPIRIT\x10\x00\x12\x16\n" +
-	"\x12ENGINE_PLANETSCALE\x10\x01*\xde\x02\n" +
+	"\x12ENGINE_PLANETSCALE\x10\x01*\xfc\x02\n" +
 	"\x05State\x12\x1a\n" +
 	"\x16STATE_NO_ACTIVE_CHANGE\x10\x00\x12\x11\n" +
 	"\rSTATE_PENDING\x10\x01\x12\x11\n" +
@@ -2385,7 +2388,8 @@ const file_tern_proto_rawDesc = "" +
 	"\x12\x1a\n" +
 	"\x16STATE_PREPARING_BRANCH\x10\v\x12!\n" +
 	"\x1dSTATE_APPLYING_BRANCH_CHANGES\x10\f\x12!\n" +
-	"\x1dSTATE_CREATING_DEPLOY_REQUEST\x10\r*h\n" +
+	"\x1dSTATE_CREATING_DEPLOY_REQUEST\x10\r\x12\x1c\n" +
+	"\x18STATE_WAITING_FOR_DEPLOY\x10\x0e*h\n" +
 	"\n" +
 	"ChangeType\x12\x15\n" +
 	"\x11CHANGE_TYPE_OTHER\x10\x00\x12\x16\n" +

--- a/pkg/schema/mysql/vitess_apply_data.sql
+++ b/pkg/schema/mysql/vitess_apply_data.sql
@@ -6,6 +6,7 @@ CREATE TABLE `vitess_apply_data` (
   `migration_context` varchar(255) DEFAULT NULL,
   `deploy_request_url` varchar(512) DEFAULT NULL,
   `is_instant` tinyint(1) NOT NULL DEFAULT '0',
+  `deferred_deploy` tinyint(1) NOT NULL DEFAULT '0',
   `revert_skipped_at` datetime DEFAULT NULL,
   `created_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `updated_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,

--- a/pkg/state/README.md
+++ b/pkg/state/README.md
@@ -19,6 +19,7 @@ Vitess OnlineDDL and Spirit report — and they are translated into Task and App
 |-------|-------|-------------|
 | Pending | `pending` | Apply created, no tasks started |
 | Running | `running` | At least one task is actively executing |
+| WaitingForDeploy | `waiting_for_deploy` | Deploy request ready, waiting for user to trigger deploy (PlanetScale only). Without `--defer-deploy`, auto-advances immediately. |
 | WaitingForCutover | `waiting_for_cutover` | All tasks ready, waiting for manual cutover (atomic mode only — in sequential mode each task cuts over independently) |
 | CuttingOver | `cutting_over` | Cutover in progress (atomic mode only) |
 | Completed | `completed` | All tasks finished successfully |
@@ -30,6 +31,8 @@ Vitess OnlineDDL and Spirit report — and they are translated into Task and App
 ```mermaid
 stateDiagram-v2
     pending --> running
+    pending --> waiting_for_deploy : PlanetScale
+    waiting_for_deploy --> running : deploy triggered
     running --> completed
     running --> failed
     running --> stopped : resumable (Spirit only)
@@ -44,7 +47,8 @@ stateDiagram-v2
     revert_window --> reverted : user-initiated
 ```
 
-- `waiting_for_cutover`/`cutting_over`: Only with `--defer-cutover` or atomic mode (Spirit)
+- `waiting_for_deploy`: PlanetScale only. The deploy request is created and ready, but not yet executed. With `--defer-deploy`, the user reviews the deploy request diff on PlanetScale and triggers via `schemabot cutover`. Without `--defer-deploy`, the system auto-advances through this state. For instant DDL, the deploy completes immediately after triggering. `--defer-deploy` and `--defer-cutover` compose: the first pauses before deploy, the second pauses before cutover.
+- `waiting_for_cutover`/`cutting_over`: Only with `--defer-cutover` or atomic mode (Spirit). Note: `--defer-cutover` is a no-op for instant DDL (no cutover exists).
 - `revert_window`: Only with `--enable-revert`. Spirit auto-advances through it; PlanetScale holds until expiry or user action. Maps from PlanetScale's `complete_pending_revert` deploy state
 - `stopped`: Spirit only — resumable via `schemabot start`. Spirit checkpoints progress for resume.
 - `cancelled`: PlanetScale only — permanent. Cancels the deploy request; the underlying Vitess migrations are cancelled. Not resumable — start a new apply instead.
@@ -76,9 +80,10 @@ Per-table execution state. Same state machine as Apply, plus `cancelled`:
 4. All tasks **completed** → apply `completed`
 5. Any task **cutting_over** → apply `cutting_over`
 6. All non-completed tasks **waiting_for_cutover** → apply `waiting_for_cutover`
-7. Any task **revert_window** → apply `revert_window`
-8. Any task **running** → apply `running`
-9. Otherwise → apply `pending`
+7. All non-completed tasks **waiting_for_deploy** → apply `waiting_for_deploy`
+8. Any task **revert_window** → apply `revert_window`
+9. Any task **running** → apply `running`
+10. Otherwise → apply `pending`
 
 Terminal states (`completed`, `failed`, `reverted`, `cancelled`) are checked via `IsTerminalApplyState()`. Note: `stopped` is NOT terminal at the task level — a stopped task can be resumed via Start.
 

--- a/pkg/state/apply.go
+++ b/pkg/state/apply.go
@@ -15,6 +15,7 @@ import "strings"
 var Apply = struct {
 	Pending           string
 	Running           string
+	WaitingForDeploy  string
 	WaitingForCutover string
 	CuttingOver       string
 	RevertWindow      string
@@ -33,6 +34,7 @@ var Apply = struct {
 }{
 	Pending:           "pending",
 	Running:           "running",
+	WaitingForDeploy:  "waiting_for_deploy",
 	WaitingForCutover: "waiting_for_cutover",
 	CuttingOver:       "cutting_over",
 	RevertWindow:      "revert_window",
@@ -56,9 +58,10 @@ var Apply = struct {
 //  4. All tasks COMPLETED → Apply COMPLETED
 //  5. Any task CUTTING_OVER → Apply CUTTING_OVER
 //  6. All non-completed tasks WAITING_FOR_CUTOVER → Apply WAITING_FOR_CUTOVER
-//  7. Any task REVERT_WINDOW → Apply REVERT_WINDOW
-//  8. Any task RUNNING → Apply RUNNING
-//  9. Otherwise → Apply PENDING
+//  7. All non-completed tasks WAITING_FOR_DEPLOY → Apply WAITING_FOR_DEPLOY
+//  8. Any task REVERT_WINDOW → Apply REVERT_WINDOW
+//  9. Any task RUNNING → Apply RUNNING
+//  10. Otherwise → Apply PENDING
 //
 // taskStates should be the State field from each Task. Empty slice returns PENDING.
 func DeriveApplyState(taskStates []string) string {
@@ -95,6 +98,10 @@ func DeriveApplyState(taskStates []string) string {
 	if waitingOrCompleted == total && counts[Apply.WaitingForCutover] > 0 {
 		return Apply.WaitingForCutover
 	}
+	waitingDeployOrCompleted := counts[Apply.WaitingForDeploy] + counts[Apply.Completed]
+	if waitingDeployOrCompleted == total && counts[Apply.WaitingForDeploy] > 0 {
+		return Apply.WaitingForDeploy
+	}
 	if counts[Apply.RevertWindow] > 0 {
 		return Apply.RevertWindow
 	}
@@ -111,6 +118,8 @@ func normalizeApplyState(raw string) string {
 		return Apply.Pending
 	case "RUNNING":
 		return Apply.Running
+	case "WAITING_FOR_DEPLOY":
+		return Apply.WaitingForDeploy
 	case "WAITING_FOR_CUTOVER":
 		return Apply.WaitingForCutover
 	case "CUTTING_OVER":
@@ -159,9 +168,10 @@ func IsTerminalApplyState(s string) bool {
 
 // IsBranchSetupPhase returns true if the apply state is a PlanetScale branch
 // lifecycle phase where per-table progress is not yet meaningful (all tables
-// are Queued). Used by the TUI to hide the table list during setup.
+// are Queued). Used by the TUI and CLI to hide the table list during setup.
+// WaitingForDeploy is included because the deploy hasn't started yet.
 func IsBranchSetupPhase(s string) bool {
-	return IsState(s, Apply.Pending, Apply.PreparingBranch, Apply.ApplyingBranchChanges, Apply.CreatingDeployRequest)
+	return IsState(s, Apply.Pending, Apply.PreparingBranch, Apply.ApplyingBranchChanges, Apply.CreatingDeployRequest, Apply.WaitingForDeploy)
 }
 
 // IsPlanetScaleEngine returns true if the engine string indicates PlanetScale/Vitess.

--- a/pkg/state/apply_test.go
+++ b/pkg/state/apply_test.go
@@ -72,6 +72,16 @@ func TestDeriveApplyState_AnyRunning(t *testing.T) {
 	}
 }
 
+func TestDeriveApplyState_AllWaitingForDeploy(t *testing.T) {
+	states := []string{"WAITING_FOR_DEPLOY", "WAITING_FOR_DEPLOY"}
+	assert.Equal(t, Apply.WaitingForDeploy, DeriveApplyState(states))
+}
+
+func TestDeriveApplyState_WaitingForDeployAndCompleted(t *testing.T) {
+	states := []string{"COMPLETED", "WAITING_FOR_DEPLOY"}
+	assert.Equal(t, Apply.WaitingForDeploy, DeriveApplyState(states))
+}
+
 func TestDeriveApplyState_AllWaitingForCutover(t *testing.T) {
 	states := []string{"WAITING_FOR_CUTOVER", "WAITING_FOR_CUTOVER", "WAITING_FOR_CUTOVER"}
 	assert.Equal(t, Apply.WaitingForCutover, DeriveApplyState(states))
@@ -177,6 +187,8 @@ func TestNormalizeState(t *testing.T) {
 		{"pending", Apply.Pending},
 		{"RUNNING", Apply.Running},
 		{"running", Apply.Running},
+		{"WAITING_FOR_DEPLOY", Apply.WaitingForDeploy},
+		{"waiting_for_deploy", Apply.WaitingForDeploy},
 		{"WAITING_FOR_CUTOVER", Apply.WaitingForCutover},
 		{"waiting_for_cutover", Apply.WaitingForCutover},
 		{"CUTTING_OVER", Apply.CuttingOver},

--- a/pkg/state/task.go
+++ b/pkg/state/task.go
@@ -12,6 +12,7 @@ import (
 var Task = struct {
 	Pending           string
 	Running           string
+	WaitingForDeploy  string
 	WaitingForCutover string
 	CuttingOver       string
 	RevertWindow      string
@@ -23,6 +24,7 @@ var Task = struct {
 }{
 	Pending:           "pending",
 	Running:           "running",
+	WaitingForDeploy:  "waiting_for_deploy",
 	WaitingForCutover: "waiting_for_cutover",
 	CuttingOver:       "cutting_over",
 	RevertWindow:      "revert_window",
@@ -109,7 +111,7 @@ func NormalizeTaskStatus(raw string) string {
 	// Pass-through for already-normalized values
 	case Task.Pending, Task.Running, Task.Completed, Task.Stopped, Task.Failed,
 		Task.RevertWindow, Task.Reverted,
-		Task.WaitingForCutover, Task.CuttingOver, Task.Cancelled:
+		Task.WaitingForDeploy, Task.WaitingForCutover, Task.CuttingOver, Task.Cancelled:
 		return s
 
 	default:

--- a/pkg/state/task_test.go
+++ b/pkg/state/task_test.go
@@ -54,7 +54,7 @@ func TestNormalizeTaskStatus_PassThrough(t *testing.T) {
 	for _, s := range []string{
 		Task.Pending, Task.Running, Task.Stopped, Task.Failed,
 		Task.RevertWindow, Task.Reverted,
-		Task.WaitingForCutover, Task.CuttingOver, Task.Cancelled,
+		Task.WaitingForDeploy, Task.WaitingForCutover, Task.CuttingOver, Task.Cancelled,
 	} {
 		assert.Equal(t, s, NormalizeTaskStatus(s), "NormalizeTaskStatus(%q)", s)
 	}

--- a/pkg/storage/mysqlstore/applies.go
+++ b/pkg/storage/mysqlstore/applies.go
@@ -178,7 +178,7 @@ func (s *applyStore) ClaimForRecovery(ctx context.Context) (*storage.Apply, erro
 	row := tx.QueryRowContext(ctx, `
 		SELECT `+applyColumns+`
 		FROM applies
-		WHERE state IN (?, ?, ?, ?, ?)
+		WHERE state IN (?, ?, ?, ?, ?, ?)
 		  AND updated_at < NOW() - INTERVAL 1 MINUTE
 		ORDER BY created_at
 		LIMIT 1
@@ -186,6 +186,7 @@ func (s *applyStore) ClaimForRecovery(ctx context.Context) (*storage.Apply, erro
 	`,
 		state.Apply.Pending,
 		state.Apply.Running,
+		state.Apply.WaitingForDeploy,
 		state.Apply.WaitingForCutover,
 		state.Apply.CuttingOver,
 		state.Apply.RevertWindow,

--- a/pkg/storage/mysqlstore/vitess_apply_data.go
+++ b/pkg/storage/mysqlstore/vitess_apply_data.go
@@ -15,16 +15,17 @@ type vitessApplyDataStore struct {
 
 func (s *vitessApplyDataStore) Save(ctx context.Context, data *storage.VitessApplyData) error {
 	_, err := s.db.ExecContext(ctx, `
-		INSERT INTO vitess_apply_data (apply_id, branch_name, deploy_request_id, migration_context, deploy_request_url, is_instant, revert_skipped_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?)
+		INSERT INTO vitess_apply_data (apply_id, branch_name, deploy_request_id, migration_context, deploy_request_url, is_instant, deferred_deploy, revert_skipped_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
 		ON DUPLICATE KEY UPDATE
 			branch_name = VALUES(branch_name),
 			deploy_request_id = VALUES(deploy_request_id),
 			migration_context = VALUES(migration_context),
 			deploy_request_url = VALUES(deploy_request_url),
 			is_instant = VALUES(is_instant),
+			deferred_deploy = VALUES(deferred_deploy),
 			revert_skipped_at = VALUES(revert_skipped_at)`,
-		data.ApplyID, data.BranchName, data.DeployRequestID, data.MigrationContext, data.DeployRequestURL, data.IsInstant, data.RevertSkippedAt,
+		data.ApplyID, data.BranchName, data.DeployRequestID, data.MigrationContext, data.DeployRequestURL, data.IsInstant, data.DeferredDeploy, data.RevertSkippedAt,
 	)
 	if err != nil {
 		return fmt.Errorf("save vitess apply data for apply %d: %w", data.ApplyID, err)
@@ -35,9 +36,9 @@ func (s *vitessApplyDataStore) Save(ctx context.Context, data *storage.VitessApp
 func (s *vitessApplyDataStore) GetByApplyID(ctx context.Context, applyID int64) (*storage.VitessApplyData, error) {
 	var data storage.VitessApplyData
 	err := s.db.QueryRowContext(ctx, `
-		SELECT apply_id, branch_name, deploy_request_id, migration_context, deploy_request_url, is_instant, revert_skipped_at
+		SELECT apply_id, branch_name, deploy_request_id, migration_context, deploy_request_url, is_instant, deferred_deploy, revert_skipped_at
 		FROM vitess_apply_data WHERE apply_id = ?`, applyID,
-	).Scan(&data.ApplyID, &data.BranchName, &data.DeployRequestID, &data.MigrationContext, &data.DeployRequestURL, &data.IsInstant, &data.RevertSkippedAt)
+	).Scan(&data.ApplyID, &data.BranchName, &data.DeployRequestID, &data.MigrationContext, &data.DeployRequestURL, &data.IsInstant, &data.DeferredDeploy, &data.RevertSkippedAt)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, storage.ErrVitessApplyDataNotFound

--- a/pkg/storage/types.go
+++ b/pkg/storage/types.go
@@ -323,6 +323,11 @@ type ApplyOptions struct {
 	// DeferCutover pauses at cutover and waits for explicit trigger.
 	DeferCutover bool `json:"defer_cutover,omitempty"`
 
+	// DeferDeploy pauses before deploying the deploy request and waits for
+	// explicit trigger (PlanetScale only). The user can review the deploy
+	// request diff on PlanetScale before proceeding.
+	DeferDeploy bool `json:"defer_deploy,omitempty"`
+
 	// SkipRevert skips the revert window after completion (Vitess only).
 	SkipRevert bool `json:"skip_revert,omitempty"`
 
@@ -479,6 +484,7 @@ const (
 	LogEventTaskUpdate          = "task_update"
 	LogEventStopRequested       = "stop_requested"
 	LogEventStartRequested      = "start_requested"
+	LogEventDeployTriggered     = "deploy_triggered"
 	LogEventCutoverTriggered    = "cutover_triggered"
 	LogEventSkipRevertTriggered = "skip_revert_triggered"
 	LogEventError               = "error"
@@ -546,6 +552,7 @@ type VitessApplyData struct {
 	MigrationContext string
 	DeployRequestURL string
 	IsInstant        bool // True when PlanetScale reported the deploy as instant-eligible
+	DeferredDeploy   bool // True when deploy was deferred (--defer-deploy flag)
 
 	// RevertSkippedAt records when skip-revert was dispatched. Non-nil means
 	// finalization is in progress — the deploy request is transitioning across

--- a/pkg/tern/local_apply.go
+++ b/pkg/tern/local_apply.go
@@ -2,6 +2,7 @@ package tern
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -315,6 +316,7 @@ func (c *LocalClient) executeApplyAtomic(ctx context.Context, apply *storage.App
 				MigrationContext: rs.MigrationContext,
 				DeployRequestURL: meta.DeployRequestURL,
 				IsInstant:        meta.IsInstant,
+				DeferredDeploy:   meta.DeferredDeploy,
 			}); saveErr != nil {
 				c.logger.Warn("OnStateChange: failed to persist resume state", "apply_id", apply.ApplyIdentifier, "error", saveErr)
 			}
@@ -367,6 +369,7 @@ func (c *LocalClient) executeApplyAtomic(ctx context.Context, apply *storage.App
 				MigrationContext: resumeState.MigrationContext,
 				DeployRequestURL: meta.DeployRequestURL,
 				IsInstant:        meta.IsInstant,
+				DeferredDeploy:   meta.DeferredDeploy,
 			}); saveErr != nil {
 				c.logger.Warn("failed to save vitess apply data", "apply_id", apply.ApplyIdentifier, "error", saveErr)
 			}
@@ -528,9 +531,9 @@ func (c *LocalClient) runEngineTask(ctx context.Context, task *storage.Task, pla
 
 // Timeouts for idle states where user action is expected.
 const (
-	// waitingForCutoverTimeout is how long to wait for a manual cutover trigger
-	// before auto-cancelling the apply.
-	waitingForCutoverTimeout = 14 * 24 * time.Hour
+	// waitingForManualActionTimeout is how long to wait for a manual trigger
+	// (deploy or cutover) before auto-cancelling the apply.
+	waitingForManualActionTimeout = 14 * 24 * time.Hour
 
 	// defaultRevertWindowDuration is the default revert window period.
 	// 30 minutes matches PlanetScale's default.
@@ -606,6 +609,14 @@ func (c *LocalClient) handleAtomicProgressTick(ctx context.Context, eng engine.E
 		ResumeState: resumeState,
 	})
 	if err != nil {
+		// Non-retryable errors (e.g., deploy request not found) — fail immediately.
+		var nonRetryable *engine.ErrNonRetryable
+		if errors.As(err, &nonRetryable) {
+			c.logger.Error("progress check failed with non-retryable error",
+				"error", err, "apply_id", apply.ApplyIdentifier)
+			c.failApplyWithTasks(ctx, apply, tasks, fmt.Sprintf("progress polling failed: %v", err))
+			return true
+		}
 		ps.consecutiveErrors++
 		c.logger.Warn("progress check failed",
 			"error", err, "apply_id", apply.ApplyIdentifier, "consecutive_errors", ps.consecutiveErrors)
@@ -649,6 +660,16 @@ func (c *LocalClient) handleAtomicProgressTick(ctx context.Context, eng engine.E
 		ResumeState: resumeState,
 	}
 
+	// Auto-trigger deploy if waiting and not in defer-deploy mode
+	if result.State == engine.StateWaitingForDeploy && !opts.DeferDeploy {
+		c.logger.Info("auto-triggering deploy (not in defer-deploy mode)", "apply_id", apply.ApplyIdentifier)
+		c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventDeployTriggered, storage.LogSourceSchemaBot,
+			"Auto-triggering deploy (defer_deploy not set)", "", "")
+		if _, err := eng.Start(ctx, controlReq); err != nil {
+			c.logger.Error("auto-deploy failed", "error", err, "apply_id", apply.ApplyIdentifier)
+		}
+	}
+
 	// Auto-trigger cutover if waiting and not in defer mode
 	if result.State == engine.StateWaitingForCutover && !opts.DeferCutover {
 		c.logger.Info("auto-triggering cutover (not in defer mode)", "apply_id", apply.ApplyIdentifier)
@@ -659,13 +680,25 @@ func (c *LocalClient) handleAtomicProgressTick(ctx context.Context, eng engine.E
 		}
 	}
 
+	// Timeout: cancel the apply if waiting for manual deploy too long.
+	if result.State == engine.StateWaitingForDeploy && opts.DeferDeploy &&
+		!ps.stateEnteredAt.IsZero() && time.Since(ps.stateEnteredAt) > waitingForManualActionTimeout {
+		c.logger.Info("waiting-for-deploy timed out, cancelling apply",
+			"apply_id", apply.ApplyIdentifier, "timeout", waitingForManualActionTimeout)
+		c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelWarn, storage.LogEventStateTransition, storage.LogSourceSchemaBot,
+			fmt.Sprintf("Waiting for deploy timed out after %s, cancelling", waitingForManualActionTimeout), "", "")
+		if _, err := eng.Stop(ctx, controlReq); err != nil {
+			c.logger.Error("timeout stop failed", "error", err, "apply_id", apply.ApplyIdentifier)
+		}
+	}
+
 	// Timeout: cancel the apply if waiting for manual cutover too long.
 	if result.State == engine.StateWaitingForCutover && opts.DeferCutover &&
-		!ps.stateEnteredAt.IsZero() && time.Since(ps.stateEnteredAt) > waitingForCutoverTimeout {
+		!ps.stateEnteredAt.IsZero() && time.Since(ps.stateEnteredAt) > waitingForManualActionTimeout {
 		c.logger.Info("waiting-for-cutover timed out, cancelling apply",
-			"apply_id", apply.ApplyIdentifier, "timeout", waitingForCutoverTimeout)
+			"apply_id", apply.ApplyIdentifier, "timeout", waitingForManualActionTimeout)
 		c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelWarn, storage.LogEventStateTransition, storage.LogSourceSchemaBot,
-			fmt.Sprintf("Waiting for cutover timed out after %s, cancelling", waitingForCutoverTimeout), "", "")
+			fmt.Sprintf("Waiting for cutover timed out after %s, cancelling", waitingForManualActionTimeout), "", "")
 		if _, err := eng.Stop(ctx, controlReq); err != nil {
 			c.logger.Error("timeout stop failed", "error", err, "apply_id", apply.ApplyIdentifier)
 		}

--- a/pkg/tern/local_client.go
+++ b/pkg/tern/local_client.go
@@ -476,8 +476,10 @@ func (c *LocalClient) Apply(ctx context.Context, req *ternv1.ApplyRequest) (*ter
 	// Build typed ApplyOptions for storage (booleans, not strings).
 	// Revert window is ON by default — only disabled when skip_revert is explicitly set.
 	skipRevert := options["skip_revert"] == "true"
+	deferDeploy := options["defer_deploy"] == "true"
 	applyOpts := storage.ApplyOptions{
 		DeferCutover: deferCutover,
+		DeferDeploy:  deferDeploy,
 		AllowUnsafe:  allowUnsafe,
 		SkipRevert:   skipRevert,
 	}
@@ -736,6 +738,7 @@ func (c *LocalClient) Progress(ctx context.Context, req *ternv1.ProgressRequest)
 					"deploy_request_id":  vad.DeployRequestID,
 					"deploy_request_url": vad.DeployRequestURL,
 					"is_instant":         vad.IsInstant,
+					"deferred_deploy":    vad.DeferredDeploy,
 				})
 				progressReq.ResumeState = &engine.ResumeState{
 					MigrationContext: vad.MigrationContext,

--- a/pkg/tern/local_control.go
+++ b/pkg/tern/local_control.go
@@ -304,6 +304,8 @@ func (c *LocalClient) buildControlRequest(ctx context.Context, task *storage.Tas
 				"branch_name":        vad.BranchName,
 				"deploy_request_id":  vad.DeployRequestID,
 				"deploy_request_url": vad.DeployRequestURL,
+				"is_instant":         vad.IsInstant,
+				"deferred_deploy":    vad.DeferredDeploy,
 			})
 			req.ResumeState = &engine.ResumeState{
 				MigrationContext: vad.MigrationContext,

--- a/pkg/tern/local_control_resume.go
+++ b/pkg/tern/local_control_resume.go
@@ -64,6 +64,37 @@ func (c *LocalClient) Start(ctx context.Context, req *ternv1.StartRequest) (*ter
 		return nil, fmt.Errorf("no stopped schema change to resume")
 	}
 
+	// Deferred deploy that isn't ready yet — reject with a clear message.
+	if apply.GetOptions().DeferDeploy && apply.State != state.Apply.WaitingForDeploy {
+		return nil, fmt.Errorf("schema change is not ready for deploy (current state: %s)", apply.State)
+	}
+
+	// Deferred deploy: call engine Start to trigger the deploy request.
+	// This is a separate path from the stopped-task resume flow below.
+	if apply.State == state.Apply.WaitingForDeploy {
+		applyTasks, taskErr := c.storage.Tasks().GetByApplyID(ctx, apply.ID)
+		if taskErr != nil || len(applyTasks) == 0 {
+			return nil, fmt.Errorf("no tasks found for apply %s", apply.ApplyIdentifier)
+		}
+		creds := c.credentials()
+		eng := c.getEngine()
+		if eng == nil {
+			return nil, fmt.Errorf("no engine configured for type: %s", c.config.Type)
+		}
+		controlReq := c.buildControlRequest(ctx, applyTasks[0], creds)
+		result, err := eng.Start(ctx, controlReq)
+		if err != nil {
+			return nil, fmt.Errorf("start deferred deploy: %w", err)
+		}
+		if !result.Accepted {
+			return nil, fmt.Errorf("deferred deploy not accepted: %s", result.Message)
+		}
+		return &ternv1.StartResponse{
+			Accepted:     true,
+			StartedCount: 1,
+		}, nil
+	}
+
 	// Second pass: collect stopped tasks ONLY from the target apply
 	var stoppedTasks []*storage.Task
 	for _, task := range tasks {

--- a/pkg/tern/state_converters.go
+++ b/pkg/tern/state_converters.go
@@ -20,6 +20,8 @@ func taskStateToApplyState(ts string) string {
 		return state.Apply.Pending
 	case state.Task.Running:
 		return state.Apply.Running
+	case state.Task.WaitingForDeploy:
+		return state.Apply.WaitingForDeploy
 	case state.Task.WaitingForCutover:
 		return state.Apply.WaitingForCutover
 	case state.Task.CuttingOver:
@@ -48,6 +50,8 @@ func engineStateToStorage(es engine.State) string {
 		return state.Task.Pending
 	case engine.StateRunning:
 		return state.Task.Running
+	case engine.StateWaitingForDeploy:
+		return state.Task.WaitingForDeploy
 	case engine.StateWaitingForCutover:
 		return state.Task.WaitingForCutover
 	case engine.StateCuttingOver:
@@ -74,6 +78,8 @@ func storageStateToProto(ts string) ternv1.State {
 		return ternv1.State_STATE_PENDING
 	case state.Task.Running:
 		return ternv1.State_STATE_RUNNING
+	case state.Task.WaitingForDeploy:
+		return ternv1.State_STATE_WAITING_FOR_DEPLOY
 	case state.Task.WaitingForCutover:
 		return ternv1.State_STATE_WAITING_FOR_CUTOVER
 	case state.Task.CuttingOver:
@@ -142,6 +148,8 @@ func ProtoStateToStorage(ps ternv1.State) string {
 		return state.Apply.Pending
 	case ternv1.State_STATE_RUNNING:
 		return state.Apply.Running
+	case ternv1.State_STATE_WAITING_FOR_DEPLOY:
+		return state.Apply.WaitingForDeploy
 	case ternv1.State_STATE_WAITING_FOR_CUTOVER:
 		return state.Apply.WaitingForCutover
 	case ternv1.State_STATE_CUTTING_OVER:
@@ -202,6 +210,7 @@ type psMetadataForStorage struct {
 	DeployRequestURL string     `json:"deploy_request_url,omitempty"`
 	DeployedAt       *time.Time `json:"deployed_at,omitempty"`
 	IsInstant        bool       `json:"is_instant,omitempty"`
+	DeferredDeploy   bool       `json:"deferred_deploy,omitempty"`
 }
 
 func decodePSMetadataForStorage(s string) (*psMetadataForStorage, error) {

--- a/pkg/webhook/templates/apply.go
+++ b/pkg/webhook/templates/apply.go
@@ -75,6 +75,8 @@ func writeApplyHeader(sb *strings.Builder, data ApplyStatusCommentData) {
 		sb.WriteString("## Schema Change Starting\n\n")
 	case state.Apply.Running:
 		sb.WriteString("## Schema Change In Progress\n\n")
+	case state.Apply.WaitingForDeploy:
+		sb.WriteString("## Schema Change — Waiting for Deploy\n\n")
 	case state.Apply.WaitingForCutover:
 		sb.WriteString("## Schema Change — Waiting for Cutover\n\n")
 	case state.Apply.CuttingOver:
@@ -361,6 +363,8 @@ func writeRowsAndETA(sb *strings.Builder, table TableProgressData) {
 // All actionable states follow the same pattern: --- separator + "To <verb>:" + command.
 func writeApplyFooter(sb *strings.Builder, data ApplyStatusCommentData) {
 	switch data.State {
+	case state.Apply.WaitingForDeploy:
+		writeFooterAction(sb, "To deploy:", fmt.Sprintf("schemabot cutover %s", data.ApplyID))
 	case state.Apply.WaitingForCutover:
 		writeFooterAction(sb, "To proceed with cutover:", fmt.Sprintf("schemabot cutover %s", data.ApplyID))
 	case state.Apply.CuttingOver:

--- a/scripts/seed-vitess.sh
+++ b/scripts/seed-vitess.sh
@@ -26,6 +26,13 @@ esac
 MYSQL="mysql -h 127.0.0.1 -P $VTGATE_PORT -u $VTGATE_USER --batch --skip-column-names"
 BATCH_SIZE=2000
 
+# Verify connectivity before starting
+if ! $MYSQL -e "SELECT 1" testapp_sharded >/dev/null 2>&1; then
+    echo "ERROR: Cannot connect to vtgate at 127.0.0.1:$VTGATE_PORT (user: $VTGATE_USER)"
+    echo "Skipping Vitess seeding."
+    exit 0
+fi
+
 # Bytes per row estimates (data + indexes, conservative).
 #   users:    ~163 bytes/row
 #   orders:   ~148 bytes/row


### PR DESCRIPTION
## New TUI feature that waits for confirmation to apply deploy request

Added a new `WaitingForDeploy` state across the full state machine (engine, proto, state, storage, tern, TUI, CLI, webhooks). In TUI mode, every PlanetScale apply pauses here automatically — the user sees the deploy request URL and presses Enter to proceed. Non-interactive modes auto-advance.

<img width="863" height="176" alt="image" src="https://github.com/user-attachments/assets/bc981f60-f84a-49a3-9630-0df824e7899c" />

## Other fixes
LocalScale fixes:
- Apply unsharded VSchema before sharded (sequence definitions must exist before auto_increment references)
- Fix missing `COMMENT='vitess_sequence'` on `users_seq.sql`

Engine/tern fixes:
- Fix instant DDL being disabled when `--defer-cutover` was set (`useInstant` was gated on `!deferCutover`)
- Fix `buildControlRequest` and progress metadata reconstruction dropping `is_instant` and `deferred_deploy` fields
- Add `ErrNonRetryable` sentinel — fail immediately on deploy request 404 instead of retrying 10 times
- Tern Start handler accepts `WaitingForDeploy` state (falls back to `DeferDeploy` option when apply state lags)

Demo reliability:
- Sequential apply/seed steps with progress messages (was parallel subshells that swallowed errors)
- `--remove-orphans` on docker compose down
- `--skip-revert` and `--allow-unsafe` on Vitess demo applies
- Connectivity check in `seed-vitess.sh`

Generated with [Claude Code](https://claude.ai/code)