### PR TITLE
feat(github): add -y auto-confirm flag for schemabot apply

### DIFF
--- a/pkg/webhook/apply_e2e_test.go
+++ b/pkg/webhook/apply_e2e_test.go
@@ -983,6 +983,118 @@ func TestE2EApplyProductionAllowedWhenStagingSuccess(t *testing.T) {
 	})
 }
 
+// TestE2EApplyAutoConfirmExecutes verifies that `schemabot apply -e staging -y`
+// plans, acquires a lock, and executes the apply in a single command.
+func TestE2EApplyAutoConfirmExecutes(t *testing.T) {
+	dbName := "webhook_auto_confirm"
+	svc := setupE2EService(t, dbName)
+
+	// Seed a check record with the correct HEAD SHA so the SHA verification passes
+	seedCheck(t, svc, dbName, "staging", checkConclusionActionRequired)
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	client := gh.NewClient(nil)
+	client.BaseURL, _ = url.Parse(server.URL + "/")
+
+	schemabotConfig := fmt.Sprintf("database: %s\ntype: mysql\n", dbName)
+	schemaFiles := map[string]string{
+		"users.sql": "CREATE TABLE `users` (\n  `id` bigint unsigned NOT NULL AUTO_INCREMENT,\n  `name` varchar(255) NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;",
+	}
+
+	result := setupFakeGitHubForPlan(t, mux, schemaFiles, schemabotConfig, dbName)
+	h := newE2EHandler(t, svc, client)
+
+	req := buildWebhookRequest(t, webhookPayloadOpts{
+		comment: "schemabot apply -e staging -y",
+		isPR:    true,
+	}, nil)
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	// First comment: plan with "Applying automatically"
+	select {
+	case body := <-result.comments:
+		assert.Contains(t, body, "Schema Change Plan (Apply)")
+		assert.Contains(t, body, "Applying automatically")
+		assert.Contains(t, body, "-y")
+	case <-time.After(30 * time.Second):
+		t.Fatal("timed out waiting for auto-confirm plan comment")
+	}
+
+	// Second comment: summary (apply completed or failed)
+	select {
+	case body := <-result.comments:
+		hasApplied := strings.Contains(body, "Schema Change Applied")
+		hasFailed := strings.Contains(body, "Schema Change Failed")
+		assert.True(t, hasApplied || hasFailed,
+			"expected apply summary comment, got: %s", body[:min(len(body), 200)])
+	case <-time.After(30 * time.Second):
+		t.Fatal("timed out waiting for apply summary comment")
+	}
+}
+
+// TestE2EApplyAutoConfirmDowngradesOnSHAMismatch verifies that -y downgrades to
+// manual confirmation when the HEAD SHA doesn't match the stored check record.
+func TestE2EApplyAutoConfirmDowngradesOnSHAMismatch(t *testing.T) {
+	dbName := "webhook_auto_confirm_sha"
+	svc := setupE2EService(t, dbName)
+
+	// Seed a check record with a DIFFERENT SHA than what FetchPullRequest returns ("abc123")
+	check := &storage.Check{
+		Repository:   "octocat/hello-world",
+		PullRequest:  1,
+		HeadSHA:      "oldsha999",
+		Environment:  "staging",
+		DatabaseType: "mysql",
+		DatabaseName: dbName,
+		CheckRunID:   1,
+		HasChanges:   true,
+		Status:       checkStatusCompleted,
+		Conclusion:   checkConclusionActionRequired,
+	}
+	require.NoError(t, svc.Storage().Checks().Upsert(t.Context(), check))
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	client := gh.NewClient(nil)
+	client.BaseURL, _ = url.Parse(server.URL + "/")
+
+	schemabotConfig := fmt.Sprintf("database: %s\ntype: mysql\n", dbName)
+	schemaFiles := map[string]string{
+		"users.sql": "CREATE TABLE `users` (\n  `id` bigint unsigned NOT NULL AUTO_INCREMENT,\n  `name` varchar(255) NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;",
+	}
+
+	result := setupFakeGitHubForPlan(t, mux, schemaFiles, schemabotConfig, dbName)
+	h := newE2EHandler(t, svc, client)
+
+	req := buildWebhookRequest(t, webhookPayloadOpts{
+		comment: "schemabot apply -e staging -y",
+		isPR:    true,
+	}, nil)
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	// Should get a plan comment with the downgrade warning, NOT "Applying automatically"
+	select {
+	case body := <-result.comments:
+		assert.Contains(t, body, "Auto-confirm skipped")
+		assert.Contains(t, body, "New commits pushed since auto-plan")
+		assert.NotContains(t, body, "Applying automatically")
+		assert.Contains(t, body, "apply-confirm", "should show manual confirm instructions")
+	case <-time.After(30 * time.Second):
+		t.Fatal("timed out waiting for downgraded plan comment")
+	}
+}
+
 // TestE2EApplyThreeEnvEnforcement verifies that checkPriorEnvironments checks ALL
 // prior environments, not just the immediately previous one. Uses 3 environments
 // (sandbox → staging → production) and calls checkPriorEnvironments directly

--- a/pkg/webhook/apply_handlers.go
+++ b/pkg/webhook/apply_handlers.go
@@ -172,6 +172,68 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 	commentData.SkipRevert = result.SkipRevert
 	commentData.AllowUnsafe = result.AllowUnsafe
 
+	// Auto-confirm (-y): check safety conditions before proceeding
+	if result.AutoConfirm {
+		// Check 1: HEAD SHA hasn't changed since auto-plan.
+		// Fail closed: if we can't verify the SHA (missing check record, API error),
+		// downgrade to manual confirmation rather than proceeding with stale data.
+		check, checkErr := h.service.Storage().Checks().Get(ctx, repo, pr, environment, dbType, database)
+		prInfo, prErr := client.FetchPullRequest(ctx, repo, pr)
+
+		shaVerified := checkErr == nil && prErr == nil && check != nil && prInfo != nil && check.HeadSHA == prInfo.HeadSHA
+		if !shaVerified {
+			reason := "Could not verify HEAD SHA — confirm manually"
+			if checkErr == nil && prErr == nil && check != nil && prInfo != nil {
+				reason = "New commits pushed since auto-plan"
+			}
+			h.logger.Info("auto-confirm downgraded",
+				"repo", repo, "pr", pr, "database", database, "reason", reason)
+			commentData.AutoConfirmDowngradeReason = reason
+			h.postComment(repo, pr, installationID, templates.RenderPlanComment(commentData))
+			headSHA, checkRunErr := h.createApplyPlanCheckRun(ctx, client, repo, pr, schemaResult, planResp, environment, installationID)
+			if checkRunErr != nil {
+				h.logger.Error("failed to create apply plan check run", "repo", repo, "pr", pr, "error", checkRunErr)
+			}
+			if headSHA != "" {
+				h.updateAggregateCheck(ctx, client, repo, pr, headSHA)
+			}
+			return
+		}
+
+		// Look up the plan we just created for DDL comparison in executeApply.
+		// Fail closed: if we can't load the plan, downgrade to manual confirmation
+		// rather than skipping the DDL drift check entirely.
+		storedPlan, planErr := h.service.Storage().Plans().Get(ctx, planResp.PlanID)
+		if planErr != nil || storedPlan == nil {
+			h.logger.Info("auto-confirm downgraded: could not load plan for DDL comparison",
+				"repo", repo, "pr", pr, "planID", planResp.PlanID, "error", planErr)
+			commentData.AutoConfirmDowngradeReason = "Could not verify plan — confirm manually"
+			h.postComment(repo, pr, installationID, templates.RenderPlanComment(commentData))
+			headSHA, checkRunErr := h.createApplyPlanCheckRun(ctx, client, repo, pr, schemaResult, planResp, environment, installationID)
+			if checkRunErr != nil {
+				h.logger.Error("failed to create apply plan check run", "repo", repo, "pr", pr, "error", checkRunErr)
+			}
+			if headSHA != "" {
+				h.updateAggregateCheck(ctx, client, repo, pr, headSHA)
+			}
+			return
+		}
+
+		commentData.AutoConfirm = true
+		h.postComment(repo, pr, installationID, templates.RenderPlanComment(commentData))
+		headSHA, checkErr := h.createApplyPlanCheckRun(ctx, client, repo, pr, schemaResult, planResp, environment, installationID)
+		if checkErr != nil {
+			h.logger.Error("failed to create apply plan check run", "repo", repo, "pr", pr, "error", checkErr)
+		}
+		if headSHA != "" {
+			h.updateAggregateCheck(ctx, client, repo, pr, headSHA)
+		}
+
+		// Check 2 (DDL drift) happens inside executeApply after re-plan
+		h.executeApply(ctx, client, repo, pr, schemaResult, environment, installationID, requestedBy, result, storedPlan)
+		return
+	}
+
 	h.postComment(repo, pr, installationID, templates.RenderPlanComment(commentData))
 
 	// Create check run (action_required — waiting for apply-confirm) and update aggregate
@@ -244,6 +306,24 @@ func (h *Handler) handleApplyConfirmCommand(repo string, pr int, environment, da
 		return
 	}
 
+	h.executeApply(ctx, client, repo, pr, schemaResult, environment, installationID, requestedBy, result, nil)
+}
+
+// executeApply re-plans for drift detection and executes the apply. This is the shared
+// execution core used by both handleApplyConfirmCommand and handleApplyCommand (with -y).
+//
+// When storedPlan is non-nil (auto-confirm path), the re-plan DDL is compared against it.
+// If the DDL differs, execution is downgraded to manual confirmation — a plan comment is
+// posted with a warning and the user must run apply-confirm separately.
+func (h *Handler) executeApply(
+	ctx context.Context, client *ghclient.InstallationClient,
+	repo string, pr int, schemaResult *ghclient.SchemaRequestResult,
+	environment string, installationID int64, requestedBy string,
+	result CommandResult, storedPlan *storage.Plan,
+) {
+	database := schemaResult.Database
+	dbType := schemaResult.Type
+
 	// Re-plan for drift detection
 	prNumber := int32(pr)
 	planReq := api.PlanRequest{
@@ -262,7 +342,7 @@ func (h *Handler) handleApplyConfirmCommand(repo string, pr int, environment, da
 		h.postComment(repo, pr, installationID, templates.RenderGenericError(templates.SchemaErrorData{
 			RequestedBy: requestedBy,
 			Environment: environment,
-			CommandName: "apply-confirm",
+			CommandName: "apply",
 			ErrorDetail: err.Error(),
 		}))
 		return
@@ -275,10 +355,22 @@ func (h *Handler) handleApplyConfirmCommand(repo string, pr int, environment, da
 		return
 	}
 
+	// Auto-confirm DDL drift check: if the re-plan DDL differs from the stored auto-plan,
+	// downgrade to manual confirmation so the user reviews the new plan.
+	if storedPlan != nil && !ddlMatchesStoredPlan(planResp, storedPlan) {
+		h.logger.Info("auto-confirm downgraded: DDL drift detected",
+			"repo", repo, "pr", pr, "database", database, "environment", environment)
+		commentData := buildPlanCommentData(schemaResult, planResp, environment, requestedBy)
+		commentData.IsLocked = true
+		commentData.AutoConfirmDowngradeReason = "Schema changes differ from auto-plan — review and confirm manually"
+		h.postComment(repo, pr, installationID, templates.RenderPlanComment(commentData))
+		return
+	}
+
 	// Block unsafe changes on confirm (re-plan may have detected new unsafe changes)
 	if len(planResp.UnsafeChanges()) > 0 && !result.AllowUnsafe {
 		commentData := buildPlanCommentData(schemaResult, planResp, environment, requestedBy)
-		h.logger.Info("apply-confirm blocked by unsafe changes", "repo", repo, "pr", pr, "database", database, "environment", environment)
+		h.logger.Info("apply blocked by unsafe changes", "repo", repo, "pr", pr, "database", database, "environment", environment)
 		h.postComment(repo, pr, installationID, templates.RenderUnsafeChangesBlocked(commentData))
 		return
 	}
@@ -311,18 +403,18 @@ func (h *Handler) handleApplyConfirmCommand(repo string, pr int, environment, da
 		h.postComment(repo, pr, installationID, templates.RenderGenericError(templates.SchemaErrorData{
 			RequestedBy: requestedBy,
 			Environment: environment,
-			CommandName: "apply-confirm",
+			CommandName: "apply",
 			ErrorDetail: "Failed to execute apply: " + err.Error(),
 		}))
 		return
 	}
 
 	if !applyResp.Accepted {
-		h.logger.Info("apply-confirm rejected by engine", "repo", repo, "pr", pr, "database", database, "environment", environment, "error", applyResp.ErrorMessage)
+		h.logger.Info("apply rejected by engine", "repo", repo, "pr", pr, "database", database, "environment", environment, "error", applyResp.ErrorMessage)
 		h.postComment(repo, pr, installationID, templates.RenderGenericError(templates.SchemaErrorData{
 			RequestedBy: requestedBy,
 			Environment: environment,
-			CommandName: "apply-confirm",
+			CommandName: "apply",
 			ErrorDetail: "Apply was not accepted: " + applyResp.ErrorMessage,
 		}))
 		return
@@ -372,6 +464,32 @@ func (h *Handler) handleApplyConfirmCommand(repo string, pr int, environment, da
 	h.postAndTrackComment(ctx, repo, pr, installationID, applyID, state.Comment.Progress, progressBody)
 
 	go h.watchApplyProgress(context.Background(), repo, pr, installationID, apply, true)
+}
+
+// ddlMatchesStoredPlan compares the re-plan DDL against a previously stored plan.
+// Uses order-independent comparison since FlatTables() and FlatDDLChanges() may
+// return statements in different order.
+func ddlMatchesStoredPlan(planResp *apitypes.PlanResponse, storedPlan *storage.Plan) bool {
+	newDDL := planResp.FlatTables()
+	storedDDL := storedPlan.FlatDDLChanges()
+
+	if len(newDDL) != len(storedDDL) {
+		return false
+	}
+
+	// Build a set of DDL strings from the stored plan
+	storedSet := make(map[string]int, len(storedDDL))
+	for _, s := range storedDDL {
+		storedSet[s.DDL]++
+	}
+
+	for _, n := range newDDL {
+		if storedSet[n.DDL] <= 0 {
+			return false
+		}
+		storedSet[n.DDL]--
+	}
+	return true
 }
 
 // handleUnlockCommand handles the "schemabot unlock" PR comment command.

--- a/pkg/webhook/apply_handlers_test.go
+++ b/pkg/webhook/apply_handlers_test.go
@@ -1,0 +1,111 @@
+package webhook
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/block/schemabot/pkg/apitypes"
+	"github.com/block/schemabot/pkg/storage"
+)
+
+func TestDDLMatchesStoredPlan(t *testing.T) {
+	tests := []struct {
+		name       string
+		planResp   *apitypes.PlanResponse
+		storedPlan *storage.Plan
+		wantMatch  bool
+	}{
+		{
+			name: "identical DDL matches",
+			planResp: &apitypes.PlanResponse{
+				Changes: []*apitypes.SchemaChangeResponse{
+					{TableChanges: []*apitypes.TableChangeResponse{
+						{DDL: "ALTER TABLE `users` ADD COLUMN `email` varchar(255)"},
+					}},
+				},
+			},
+			storedPlan: &storage.Plan{
+				Namespaces: map[string]*storage.NamespacePlanData{
+					"mydb": {Tables: []storage.TableChange{
+						{DDL: "ALTER TABLE `users` ADD COLUMN `email` varchar(255)"},
+					}},
+				},
+			},
+			wantMatch: true,
+		},
+		{
+			name: "different DDL does not match",
+			planResp: &apitypes.PlanResponse{
+				Changes: []*apitypes.SchemaChangeResponse{
+					{TableChanges: []*apitypes.TableChangeResponse{
+						{DDL: "ALTER TABLE `users` ADD COLUMN `email` varchar(255)"},
+						{DDL: "ALTER TABLE `users` DROP COLUMN `old_field`"},
+					}},
+				},
+			},
+			storedPlan: &storage.Plan{
+				Namespaces: map[string]*storage.NamespacePlanData{
+					"mydb": {Tables: []storage.TableChange{
+						{DDL: "ALTER TABLE `users` ADD COLUMN `email` varchar(255)"},
+					}},
+				},
+			},
+			wantMatch: false,
+		},
+		{
+			name: "different DDL content does not match",
+			planResp: &apitypes.PlanResponse{
+				Changes: []*apitypes.SchemaChangeResponse{
+					{TableChanges: []*apitypes.TableChangeResponse{
+						{DDL: "ALTER TABLE `users` ADD COLUMN `email` varchar(500)"},
+					}},
+				},
+			},
+			storedPlan: &storage.Plan{
+				Namespaces: map[string]*storage.NamespacePlanData{
+					"mydb": {Tables: []storage.TableChange{
+						{DDL: "ALTER TABLE `users` ADD COLUMN `email` varchar(255)"},
+					}},
+				},
+			},
+			wantMatch: false,
+		},
+		{
+			name: "same DDL in different order matches",
+			planResp: &apitypes.PlanResponse{
+				Changes: []*apitypes.SchemaChangeResponse{
+					{TableChanges: []*apitypes.TableChangeResponse{
+						{DDL: "ALTER TABLE `orders` ADD INDEX `idx_status` (`status`)"},
+						{DDL: "ALTER TABLE `users` ADD COLUMN `email` varchar(255)"},
+					}},
+				},
+			},
+			storedPlan: &storage.Plan{
+				Namespaces: map[string]*storage.NamespacePlanData{
+					"mydb": {Tables: []storage.TableChange{
+						{DDL: "ALTER TABLE `users` ADD COLUMN `email` varchar(255)"},
+						{DDL: "ALTER TABLE `orders` ADD INDEX `idx_status` (`status`)"},
+					}},
+				},
+			},
+			wantMatch: true,
+		},
+		{
+			name: "empty plans match",
+			planResp: &apitypes.PlanResponse{
+				Changes: []*apitypes.SchemaChangeResponse{},
+			},
+			storedPlan: &storage.Plan{
+				Namespaces: map[string]*storage.NamespacePlanData{},
+			},
+			wantMatch: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.wantMatch, ddlMatchesStoredPlan(tt.planResp, tt.storedPlan))
+		})
+	}
+}

--- a/pkg/webhook/commands.go
+++ b/pkg/webhook/commands.go
@@ -16,6 +16,7 @@ type CommandParser struct {
 	skipRevertRegex        *regexp.Regexp
 	deferCutoverRegex      *regexp.Regexp
 	allowUnsafeRegex       *regexp.Regexp
+	autoConfirmRegex       *regexp.Regexp
 }
 
 // NewCommandParser creates a new command parser.
@@ -30,6 +31,7 @@ func NewCommandParser() *CommandParser {
 		skipRevertRegex:        regexp.MustCompile(`(?i)--skip-revert\b`),
 		deferCutoverRegex:      regexp.MustCompile(`(?i)--defer-cutover\b`),
 		allowUnsafeRegex:       regexp.MustCompile(`(?i)--allow-unsafe\b`),
+		autoConfirmRegex:       regexp.MustCompile(`(?i)(?:--yes\b|-y\b)`),
 	}
 }
 
@@ -42,6 +44,7 @@ type CommandResult struct {
 	SkipRevert   bool
 	DeferCutover bool
 	AllowUnsafe  bool
+	AutoConfirm  bool
 	Found        bool
 	IsHelp       bool
 	IsMention    bool
@@ -75,14 +78,16 @@ func (p *CommandParser) ParseCommand(body string) CommandResult {
 	// Check valid command with environment
 	matches := p.commandRegex.FindStringSubmatch(body)
 	if len(matches) >= 3 {
+		action := strings.ToLower(matches[1])
 		result := CommandResult{
-			Action:       strings.ToLower(matches[1]),
+			Action:       action,
 			Environment:  strings.ToLower(matches[2]),
 			Found:        true,
 			IsMention:    true,
 			SkipRevert:   p.skipRevertRegex.MatchString(body),
 			DeferCutover: p.deferCutoverRegex.MatchString(body),
 			AllowUnsafe:  p.allowUnsafeRegex.MatchString(body),
+			AutoConfirm:  action == "apply" && p.autoConfirmRegex.MatchString(body),
 		}
 
 		dbMatches := p.databaseRegex.FindStringSubmatch(body)

--- a/pkg/webhook/commands_test.go
+++ b/pkg/webhook/commands_test.go
@@ -259,6 +259,60 @@ func TestParseCommand(t *testing.T) {
 				AllowUnsafe:  true,
 			},
 		},
+		{
+			name: "apply with -y short flag",
+			body: "schemabot apply -e staging -y",
+			expected: CommandResult{
+				Action:      "apply",
+				Environment: "staging",
+				Found:       true,
+				IsMention:   true,
+				AutoConfirm: true,
+			},
+		},
+		{
+			name: "apply with --yes long flag",
+			body: "schemabot apply -e staging --yes",
+			expected: CommandResult{
+				Action:      "apply",
+				Environment: "staging",
+				Found:       true,
+				IsMention:   true,
+				AutoConfirm: true,
+			},
+		},
+		{
+			name: "apply with -y and --allow-unsafe",
+			body: "schemabot apply -e production --allow-unsafe -y",
+			expected: CommandResult{
+				Action:      "apply",
+				Environment: "production",
+				Found:       true,
+				IsMention:   true,
+				AllowUnsafe: true,
+				AutoConfirm: true,
+			},
+		},
+		{
+			name: "-y ignored on apply-confirm (already a confirmation)",
+			body: "schemabot apply-confirm -e staging -y",
+			expected: CommandResult{
+				Action:      "apply-confirm",
+				Environment: "staging",
+				Found:       true,
+				IsMention:   true,
+			},
+		},
+		{
+			name: "-y ignored on plan",
+			body: "schemabot plan -e staging -y",
+			expected: CommandResult{
+				Action:      "plan",
+				Environment: "staging",
+				Found:       true,
+				IsMention:   true,
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/webhook/handler_test.go
+++ b/pkg/webhook/handler_test.go
@@ -191,6 +191,36 @@ func TestWebhookMissingEnvForApply(t *testing.T) {
 	}
 }
 
+func TestWebhookYesFlagRejectedOnNonApply(t *testing.T) {
+	h, comments, _ := newTestHandler(t)
+
+	for _, cmd := range []string{
+		"schemabot plan -e staging -y",
+		"schemabot apply-confirm -e staging -y",
+	} {
+		t.Run(cmd, func(t *testing.T) {
+			req := buildWebhookRequest(t, webhookPayloadOpts{
+				comment: cmd,
+				isPR:    true,
+			}, nil)
+
+			rr := httptest.NewRecorder()
+			h.ServeHTTP(rr, req)
+
+			require.Equal(t, http.StatusOK, rr.Code)
+			assert.Contains(t, rr.Body.String(), "unsupported flag")
+
+			select {
+			case body := <-comments:
+				assert.Contains(t, body, "-y")
+				assert.Contains(t, body, "not supported for")
+			case <-time.After(2 * time.Second):
+				t.Fatal("timed out waiting for error comment")
+			}
+		})
+	}
+}
+
 func TestWebhookBotCommentIgnored(t *testing.T) {
 	h, comments, _ := newTestHandler(t)
 

--- a/pkg/webhook/issue_comment.go
+++ b/pkg/webhook/issue_comment.go
@@ -143,6 +143,14 @@ func (h *Handler) handleIssueComment(w http.ResponseWriter, body []byte) {
 		return
 	}
 
+	// Reject -y/--yes on commands that don't support it
+	if result.Action != "apply" && parser.autoConfirmRegex.MatchString(payload.Comment.Body) {
+		h.postComment(repo, pr, installationID,
+			fmt.Sprintf("The `-y` flag is not supported for `%s`.", result.Action))
+		h.writeJSON(w, http.StatusOK, map[string]string{"message": "unsupported flag"})
+		return
+	}
+
 	h.logger.Info("processing command",
 		"action", result.Action,
 		"environment", result.Environment,

--- a/pkg/webhook/templates/plan.go
+++ b/pkg/webhook/templates/plan.go
@@ -47,6 +47,10 @@ type PlanCommentData struct {
 	IsLocked     bool
 	LockOwner    string
 	LockAcquired string // formatted timestamp
+
+	// Auto-confirm state
+	AutoConfirm                bool   // -y flag was used, will auto-execute
+	AutoConfirmDowngradeReason string // Non-empty: -y was downgraded to manual, this is the reason
 }
 
 // KeyspaceChangeData contains changes for a single keyspace/schema.
@@ -121,7 +125,6 @@ func RenderPlanComment(data PlanCommentData) string {
 	sb.WriteString("\n---\n\n")
 
 	if data.IsLocked {
-		// Apply-plan footer: confirm instructions + cancel
 		applyConfirmCmd := fmt.Sprintf("schemabot apply-confirm -e %s", data.Environment)
 		if data.AllowUnsafe {
 			applyConfirmCmd += " --allow-unsafe"
@@ -132,9 +135,26 @@ func RenderPlanComment(data PlanCommentData) string {
 		if data.SkipRevert {
 			applyConfirmCmd += " --skip-revert"
 		}
-		writeApplyHint(&sb, applyConfirmCmd)
-		sb.WriteString("\n🔓 To discard this plan and unlock, comment:\n")
-		sb.WriteString("```\nschemabot unlock\n```\n")
+
+		switch {
+		case data.AutoConfirmDowngradeReason != "":
+			// -y was downgraded to manual confirmation — show unlock since user needs to act
+			fmt.Fprintf(&sb, "⚠️ **Auto-confirm skipped**: %s\n\n", data.AutoConfirmDowngradeReason)
+			sb.WriteString("Review the plan above, then confirm manually:\n")
+			fmt.Fprintf(&sb, "```\n%s\n```\n", applyConfirmCmd)
+			sb.WriteString("\n🔓 To discard this plan and unlock, comment:\n")
+			sb.WriteString("```\nschemabot unlock\n```\n")
+		case data.AutoConfirm:
+			// -y is proceeding — include unlock hint in case the apply fails before starting
+			sb.WriteString("**Applying automatically** (`-y` flag)\n")
+			sb.WriteString("\n🔓 If the apply fails, unlock with:\n")
+			sb.WriteString("```\nschemabot unlock\n```\n")
+		default:
+			// Normal two-step flow: confirm instructions + unlock option
+			writeApplyHint(&sb, applyConfirmCmd)
+			sb.WriteString("\n🔓 To discard this plan and unlock, comment:\n")
+			sb.WriteString("```\nschemabot unlock\n```\n")
+		}
 	} else {
 		writeApplyHint(&sb, fmt.Sprintf("schemabot apply -e %s", data.Environment))
 	}


### PR DESCRIPTION
Allows `schemabot apply -e {env} -y` to plan and execute in a single command, skipping the separate `apply-confirm` step. The apply still re-plans for drift detection before executing.

When conditions change since the auto-plan, `-y` downgrades to the normal two-step flow with a warning rather than hard-rejecting:
- New commits pushed since auto-plan (HEAD SHA mismatch)
- DDL drift between re-plan and stored plan

Extracts `executeApply` as shared execution core used by both `handleApplyConfirmCommand` and the `-y` path. Hides the unlock footer and lock info when `-y` is active since the apply proceeds immediately.