### PR TITLE
chore: bump chart version to 0.1.3

### DIFF
--- a/charts/schemabot/Chart.yaml
+++ b/charts/schemabot/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: schemabot
 description: GitOps for database schemas
 type: application
-version: 0.1.2
-appVersion: "v0.1.2"
+version: 0.1.3
+appVersion: "v0.1.3"
 maintainers:
   - name: aparajon
     url: https://github.com/aparajon


### PR DESCRIPTION
## Why
Docker build workflow validates that the tag matches Chart.yaml appVersion. Need to bump before tagging v0.1.3.

## What
- Bump chart `version` and `appVersion` from 0.1.2 to 0.1.3

Generated with [Claude Code](https://claude.ai/code)