### PR TITLE
chore: improve release changelog grouping

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -29,9 +29,13 @@ checksum:
   name_template: "checksums.txt"
 
 changelog:
-  sort: asc
-  filters:
-    exclude:
-      - "^docs:"
-      - "^test:"
-      - "^ci:"
+  use: github
+  groups:
+    - title: Features
+      regexp: '^feat'
+      order: 0
+    - title: Bug Fixes
+      regexp: '^fix'
+      order: 1
+    - title: Other
+      order: 999

--- a/charts/schemabot/Chart.yaml
+++ b/charts/schemabot/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: schemabot
 description: GitOps for database schemas
 type: application
-version: 0.1.2
-appVersion: "v0.1.2"
+version: 0.1.3
+appVersion: "v0.1.3"
 maintainers:
   - name: aparajon
     url: https://github.com/aparajon


### PR DESCRIPTION
## Why
Release changelogs are sorted alphabetically by commit message, making them hard to scan. 

## What
- Switch GoReleaser changelog to use GitHub's auto-generated notes
- Group entries by conventional commit prefix: Features (`feat`), Bug Fixes (`fix`), Other

Generated with [Claude Code](https://claude.ai/code)