### PR TITLE
feat(observability): add metrics for control operations, locks, and recovery

### DIFF
--- a/pkg/api/control_handlers.go
+++ b/pkg/api/control_handlers.go
@@ -7,11 +7,20 @@ import (
 	"time"
 
 	"github.com/block/schemabot/pkg/apitypes"
+	"github.com/block/schemabot/pkg/metrics"
 	ternv1 "github.com/block/schemabot/pkg/proto/ternv1"
 	"github.com/block/schemabot/pkg/state"
 	"github.com/block/schemabot/pkg/storage"
 	"github.com/block/schemabot/pkg/tern"
 )
+
+// controlStatus returns "success" if accepted, "rejected" otherwise.
+func controlStatus(accepted bool) string {
+	if accepted {
+		return "success"
+	}
+	return "rejected"
+}
 
 // writeControlError logs and writes an HTTP error for a control operation.
 func (s *Service) writeControlError(w http.ResponseWriter, opName, database string, err error) {
@@ -111,9 +120,11 @@ func (s *Service) handleCutover(w http.ResponseWriter, r *http.Request) {
 		Environment: req.Environment,
 	})
 	if err != nil {
+		metrics.RecordControlOperation(r.Context(), "cutover", req.Database, req.Environment, "error")
 		s.writeControlError(w, "cutover", req.Database, err)
 		return
 	}
+	metrics.RecordControlOperation(r.Context(), "cutover", req.Database, req.Environment, controlStatus(resp.Accepted))
 
 	s.writeJSON(w, http.StatusOK, &apitypes.ControlResponse{
 		Accepted:     resp.Accepted,
@@ -143,9 +154,11 @@ func (s *Service) handleStop(w http.ResponseWriter, r *http.Request) {
 		Environment: req.Environment,
 	})
 	if err != nil {
+		metrics.RecordControlOperation(r.Context(), "stop", req.Database, req.Environment, "error")
 		s.writeControlError(w, "stop", req.Database, err)
 		return
 	}
+	metrics.RecordControlOperation(r.Context(), "stop", req.Database, req.Environment, controlStatus(resp.Accepted))
 
 	s.writeJSON(w, http.StatusOK, &apitypes.StopResponse{
 		Accepted:     resp.Accepted,
@@ -176,9 +189,11 @@ func (s *Service) handleStart(w http.ResponseWriter, r *http.Request) {
 		Environment: req.Environment,
 	})
 	if err != nil {
+		metrics.RecordControlOperation(r.Context(), "start", req.Database, req.Environment, "error")
 		s.writeControlError(w, "start", req.Database, err)
 		return
 	}
+	metrics.RecordControlOperation(r.Context(), "start", req.Database, req.Environment, controlStatus(resp.Accepted))
 
 	// For remote (gRPC) clients, update local apply state and restart the
 	// background progress poller. Without this, the local applies.state stays
@@ -241,9 +256,11 @@ func (s *Service) handleVolume(w http.ResponseWriter, r *http.Request) {
 		Volume:   req.Volume,
 	})
 	if err != nil {
+		metrics.RecordControlOperation(r.Context(), "volume", req.Database, req.Environment, "error")
 		s.writeControlError(w, "volume", req.Database, err)
 		return
 	}
+	metrics.RecordControlOperation(r.Context(), "volume", req.Database, req.Environment, controlStatus(resp.Accepted))
 
 	s.writeJSON(w, http.StatusOK, &apitypes.VolumeResponse{
 		Accepted:       resp.Accepted,
@@ -273,9 +290,11 @@ func (s *Service) handleRevert(w http.ResponseWriter, r *http.Request) {
 		Database: req.Database,
 	})
 	if err != nil {
+		metrics.RecordControlOperation(r.Context(), "revert", req.Database, req.Environment, "error")
 		s.writeControlError(w, "revert", req.Database, err)
 		return
 	}
+	metrics.RecordControlOperation(r.Context(), "revert", req.Database, req.Environment, controlStatus(resp.Accepted))
 
 	s.writeJSON(w, http.StatusOK, &apitypes.ControlResponse{
 		Accepted:     resp.Accepted,
@@ -303,9 +322,11 @@ func (s *Service) handleSkipRevert(w http.ResponseWriter, r *http.Request) {
 		Database: req.Database,
 	})
 	if err != nil {
+		metrics.RecordControlOperation(r.Context(), "skip_revert", req.Database, req.Environment, "error")
 		s.writeControlError(w, "skip-revert", req.Database, err)
 		return
 	}
+	metrics.RecordControlOperation(r.Context(), "skip_revert", req.Database, req.Environment, controlStatus(resp.Accepted))
 
 	// Record skip-revert on VitessApplyData for progress visibility
 	if resp.Accepted && req.ApplyID != "" && s.storage != nil && s.storage.Applies() != nil {
@@ -369,9 +390,11 @@ func (s *Service) handleRollbackPlan(w http.ResponseWriter, r *http.Request) {
 
 	resp, err := s.ExecuteRollbackPlan(r.Context(), apply.Database, apply.Environment, apply.Deployment)
 	if err != nil {
+		metrics.RecordControlOperation(r.Context(), "rollback_plan", apply.Database, apply.Environment, "error")
 		s.writeControlError(w, "rollback plan", apply.Database, err)
 		return
 	}
+	metrics.RecordControlOperation(r.Context(), "rollback_plan", apply.Database, apply.Environment, "success")
 
 	// Include database metadata so the caller doesn't need to look it up separately
 	resp.Database = apply.Database

--- a/pkg/api/lock_handlers.go
+++ b/pkg/api/lock_handlers.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http"
 
+	"github.com/block/schemabot/pkg/metrics"
 	"github.com/block/schemabot/pkg/storage"
 )
 
@@ -76,6 +77,7 @@ func (s *Service) handleLockAcquire(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	err := s.storage.Locks().Acquire(ctx, lock)
 	if errors.Is(err, storage.ErrLockHeld) {
+		metrics.RecordLockOperation(ctx, "acquire", req.Database, "conflict")
 		// Lock is held by someone else - return the current lock info
 		existing, getErr := s.storage.Locks().Get(ctx, req.Database, req.DatabaseType)
 		if getErr != nil || existing == nil {
@@ -90,10 +92,12 @@ func (s *Service) handleLockAcquire(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err != nil {
+		metrics.RecordLockOperation(ctx, "acquire", req.Database, "error")
 		s.logger.Error("acquire lock failed", "error", err)
 		s.writeError(w, http.StatusInternalServerError, "internal error")
 		return
 	}
+	metrics.RecordLockOperation(ctx, "acquire", req.Database, "success")
 
 	// Refetch to get created_at
 	acquired, err := s.storage.Locks().Get(ctx, req.Database, req.DatabaseType)
@@ -129,14 +133,17 @@ func (s *Service) handleLockRelease(w http.ResponseWriter, r *http.Request) {
 		// Force release - no ownership check
 		err := s.storage.Locks().ForceRelease(ctx, req.Database, req.DatabaseType)
 		if errors.Is(err, storage.ErrLockNotFound) {
+			metrics.RecordLockOperation(ctx, "release", req.Database, "not_found")
 			s.writeError(w, http.StatusNotFound, "lock not found")
 			return
 		}
 		if err != nil {
+			metrics.RecordLockOperation(ctx, "release", req.Database, "error")
 			s.logger.Error("force release lock failed", "error", err)
 			s.writeError(w, http.StatusInternalServerError, "internal error")
 			return
 		}
+		metrics.RecordLockOperation(ctx, "release", req.Database, "success")
 
 		s.writeJSON(w, http.StatusOK, map[string]string{"status": "released"})
 		return
@@ -150,18 +157,22 @@ func (s *Service) handleLockRelease(w http.ResponseWriter, r *http.Request) {
 
 	err := s.storage.Locks().Release(ctx, req.Database, req.DatabaseType, req.Owner)
 	if errors.Is(err, storage.ErrLockNotFound) {
+		metrics.RecordLockOperation(ctx, "release", req.Database, "not_found")
 		s.writeError(w, http.StatusNotFound, "lock not found")
 		return
 	}
 	if errors.Is(err, storage.ErrLockNotOwned) {
+		metrics.RecordLockOperation(ctx, "release", req.Database, "not_owned")
 		s.writeError(w, http.StatusForbidden, "lock is not owned by you")
 		return
 	}
 	if err != nil {
+		metrics.RecordLockOperation(ctx, "release", req.Database, "error")
 		s.logger.Error("release lock failed", "error", err)
 		s.writeError(w, http.StatusInternalServerError, "internal error")
 		return
 	}
+	metrics.RecordLockOperation(ctx, "release", req.Database, "success")
 
 	s.writeJSON(w, http.StatusOK, map[string]string{"status": "released"})
 }

--- a/pkg/api/scheduler.go
+++ b/pkg/api/scheduler.go
@@ -3,6 +3,8 @@ package api
 import (
 	"context"
 	"time"
+
+	"github.com/block/schemabot/pkg/metrics"
 )
 
 // Recovery worker constants.
@@ -126,6 +128,8 @@ func (s *Service) resumeInProgressApplies(ctx context.Context) {
 			"previous_state", apply.State)
 		recovered++
 	}
+
+	metrics.RecordRecoveryCycle(ctx, recovered, failed)
 
 	if recovered > 0 || failed > 0 {
 		s.logger.Info("recovery worker: cycle complete",

--- a/pkg/api/telemetry_test.go
+++ b/pkg/api/telemetry_test.go
@@ -288,3 +288,57 @@ func TestRecordWebhookEventMetric(t *testing.T) {
 	}
 	assert.True(t, found, "schemabot.webhook.events_total metric not found")
 }
+
+func TestRecordControlOperationMetric(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	prevMP := otel.GetMeterProvider()
+	otel.SetMeterProvider(mp)
+	t.Cleanup(func() {
+		otel.SetMeterProvider(prevMP)
+		require.NoError(t, mp.Shutdown(t.Context()))
+	})
+
+	metrics.RecordControlOperation(t.Context(), "cutover", "mydb", "staging", "success")
+	metrics.RecordControlOperation(t.Context(), "stop", "mydb", "staging", "success")
+	metrics.RecordControlOperation(t.Context(), "start", "mydb", "staging", "error")
+
+	names := collectMetricNames(t, reader)
+	assert.True(t, names["schemabot.control_operations_total"], "expected schemabot.control_operations_total")
+}
+
+func TestRecordLockOperationMetric(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	prevMP := otel.GetMeterProvider()
+	otel.SetMeterProvider(mp)
+	t.Cleanup(func() {
+		otel.SetMeterProvider(prevMP)
+		require.NoError(t, mp.Shutdown(t.Context()))
+	})
+
+	metrics.RecordLockOperation(t.Context(), "acquire", "mydb", "success")
+	metrics.RecordLockOperation(t.Context(), "acquire", "mydb", "conflict")
+	metrics.RecordLockOperation(t.Context(), "release", "mydb", "success")
+
+	names := collectMetricNames(t, reader)
+	assert.True(t, names["schemabot.lock_operations_total"], "expected schemabot.lock_operations_total")
+}
+
+func TestRecordRecoveryCycleMetric(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	prevMP := otel.GetMeterProvider()
+	otel.SetMeterProvider(mp)
+	t.Cleanup(func() {
+		otel.SetMeterProvider(prevMP)
+		require.NoError(t, mp.Shutdown(t.Context()))
+	})
+
+	metrics.RecordRecoveryCycle(t.Context(), 2, 1)
+
+	names := collectMetricNames(t, reader)
+	assert.True(t, names["schemabot.recovery.cycles_total"], "expected schemabot.recovery.cycles_total")
+	assert.True(t, names["schemabot.recovery.recovered_total"], "expected schemabot.recovery.recovered_total")
+	assert.True(t, names["schemabot.recovery.failed_total"], "expected schemabot.recovery.failed_total")
+}

--- a/pkg/metrics/README.md
+++ b/pkg/metrics/README.md
@@ -12,10 +12,23 @@ SchemaBot exposes metrics via OpenTelemetry. All metrics are available at `GET /
 | `schemabot.apply.duration_seconds` | Histogram | database, environment, status | Apply API call time |
 | `schemabot.active_applies` | UpDownCounter | database, environment | In-progress applies |
 | `schemabot.webhook.events_total` | Counter | event_type, action, repository, status | GitHub webhook events |
+| `schemabot.control_operations_total` | Counter | operation, database, environment, status | Control operations (cutover, stop, start, etc.) |
+| `schemabot.lock_operations_total` | Counter | operation, database, status | Lock acquire/release operations |
+| `schemabot.recovery.cycles_total` | Counter | — | Recovery worker polling cycles |
+| `schemabot.recovery.recovered_total` | Counter | — | Applies recovered by the recovery worker |
+| `schemabot.recovery.failed_total` | Counter | — | Recovery attempts that failed |
 
 ### Attribute Values
 
 **status** (plans/applies): `success`, `error`, `rejected`
+
+**operation** (control): `cutover`, `stop`, `start`, `volume`, `revert`, `skip_revert`, `rollback_plan`
+
+**status** (control): `success`, `error`, `rejected`
+
+**operation** (locks): `acquire`, `release`
+
+**status** (locks): `success`, `conflict`, `not_found`, `not_owned`, `error`
 
 **event_type** (webhooks): `issue_comment`, `pull_request`, `check_run`, `ping`
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -120,6 +120,104 @@ func AdjustActiveApplies(ctx context.Context, delta int64, database, environment
 	)
 }
 
+// knownControlOperations limits metric cardinality to expected control operations.
+var knownControlOperations = map[string]bool{
+	"cutover":       true,
+	"stop":          true,
+	"start":         true,
+	"volume":        true,
+	"revert":        true,
+	"skip_revert":   true,
+	"rollback_plan": true,
+}
+
+// RecordControlOperation increments the control operations counter.
+// Operation should be one of: cutover, stop, start, volume, revert, skip_revert, rollback_plan.
+// Status should be "success" or "error".
+func RecordControlOperation(ctx context.Context, operation, database, environment, status string) {
+	if !knownControlOperations[operation] {
+		operation = "unknown"
+	}
+	meter := otel.Meter(meterName)
+	counter, err := meter.Int64Counter("schemabot.control_operations_total",
+		otelmetric.WithDescription("Total number of control operations (cutover, stop, start, etc.)"),
+		otelmetric.WithUnit("{operation}"),
+	)
+	if err != nil {
+		slog.Warn("failed to create control operations counter", "error", err)
+		return
+	}
+	counter.Add(ctx, 1,
+		otelmetric.WithAttributes(
+			attribute.String("operation", operation),
+			attribute.String("database", database),
+			attribute.String("environment", environment),
+			attribute.String("status", status),
+		),
+	)
+}
+
+// RecordLockOperation increments the lock operations counter.
+// Operation should be "acquire" or "release".
+// Status should be "success", "conflict", "not_found", "not_owned", or "error".
+func RecordLockOperation(ctx context.Context, operation, database, status string) {
+	meter := otel.Meter(meterName)
+	counter, err := meter.Int64Counter("schemabot.lock_operations_total",
+		otelmetric.WithDescription("Total number of lock acquire/release operations"),
+		otelmetric.WithUnit("{operation}"),
+	)
+	if err != nil {
+		slog.Warn("failed to create lock operations counter", "error", err)
+		return
+	}
+	counter.Add(ctx, 1,
+		otelmetric.WithAttributes(
+			attribute.String("operation", operation),
+			attribute.String("database", database),
+			attribute.String("status", status),
+		),
+	)
+}
+
+// RecordRecoveryCycle increments the recovery cycle counter and records
+// how many applies were recovered and how many failed in this cycle.
+func RecordRecoveryCycle(ctx context.Context, recovered, failed int) {
+	meter := otel.Meter(meterName)
+	cycleCounter, err := meter.Int64Counter("schemabot.recovery.cycles_total",
+		otelmetric.WithDescription("Total number of recovery worker cycles"),
+		otelmetric.WithUnit("{cycle}"),
+	)
+	if err != nil {
+		slog.Warn("failed to create recovery cycles counter", "error", err)
+		return
+	}
+	cycleCounter.Add(ctx, 1)
+
+	if recovered > 0 {
+		recoveredCounter, err := meter.Int64Counter("schemabot.recovery.recovered_total",
+			otelmetric.WithDescription("Total number of applies recovered by the recovery worker"),
+			otelmetric.WithUnit("{apply}"),
+		)
+		if err != nil {
+			slog.Warn("failed to create recovery recovered counter", "error", err)
+			return
+		}
+		recoveredCounter.Add(ctx, int64(recovered))
+	}
+
+	if failed > 0 {
+		failedCounter, err := meter.Int64Counter("schemabot.recovery.failed_total",
+			otelmetric.WithDescription("Total number of recovery attempts that failed"),
+			otelmetric.WithUnit("{apply}"),
+		)
+		if err != nil {
+			slog.Warn("failed to create recovery failed counter", "error", err)
+			return
+		}
+		failedCounter.Add(ctx, int64(failed))
+	}
+}
+
 // knownWebhookEvents limits metric cardinality to expected GitHub event types.
 var knownWebhookEvents = map[string]bool{
 	"issue_comment": true,


### PR DESCRIPTION
Adds custom metrics covering:

- **schemabot.control_operations_total** — counter for cutover, stop, start, volume, revert, and skip_revert with operation/database/environment/status attributes
- **schemabot.lock_operations_total** — counter for lock acquire/release with granular status tracking (success, conflict, not_found, not_owned, error)
- **schemabot.recovery.cycles_total** — counter for recovery worker polling cycles
- **schemabot.recovery.recovered_total** — counter for applies successfully recovered
- **schemabot.recovery.failed_total** — counter for failed recovery attempts

🤖 Generated with [Claude Code](https://claude.com/claude-code)