### PR TITLE
feat(observability): add trace spans for plan, apply, and webhook operations

### DIFF
--- a/pkg/api/plan_handlers.go
+++ b/pkg/api/plan_handlers.go
@@ -10,6 +10,10 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/block/schemabot/pkg/apitypes"
 	"github.com/block/schemabot/pkg/metrics"
@@ -83,7 +87,18 @@ func (s *Service) handlePlan(w http.ResponseWriter, r *http.Request) {
 // and returns the plan response. This is the shared implementation used by both
 // the HTTP handler and the webhook handler.
 func (s *Service) ExecutePlan(ctx context.Context, req PlanRequest) (*apitypes.PlanResponse, error) {
+	ctx, span := otel.Tracer("schemabot").Start(ctx, "ExecutePlan",
+		trace.WithAttributes(
+			attribute.String("database", req.Database),
+			attribute.String("environment", req.Environment),
+			attribute.String("type", req.Type),
+		),
+	)
+	defer span.End()
+
 	if warning, err := validateSchemaFiles(req.SchemaFiles); err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "invalid schema files")
 		return nil, err
 	} else if warning != "" {
 		s.logger.Warn("plan request has empty schema files", "warning", warning, "database", req.Database)
@@ -95,6 +110,8 @@ func (s *Service) ExecutePlan(ctx context.Context, req PlanRequest) (*apitypes.P
 
 	client, err := s.TernClient(deployment, req.Environment)
 	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "tern client")
 		metrics.RecordPlan(ctx, req.Database, req.Environment, "error")
 		metrics.RecordPlanDuration(ctx, time.Since(planStart), req.Database, req.Environment, "error")
 		return nil, fmt.Errorf("tern client: %w", err)
@@ -126,10 +143,13 @@ func (s *Service) ExecutePlan(ctx context.Context, req PlanRequest) (*apitypes.P
 
 	resp, err := client.Plan(ctx, ternReq)
 	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "plan failed")
 		metrics.RecordPlan(ctx, req.Database, req.Environment, "error")
 		metrics.RecordPlanDuration(ctx, time.Since(planStart), req.Database, req.Environment, "error")
 		return nil, err
 	}
+	span.SetAttributes(attribute.String("plan_id", resp.PlanId), attribute.Int("change_count", len(resp.Changes)))
 	metrics.RecordPlan(ctx, req.Database, req.Environment, "success")
 	metrics.RecordPlanDuration(ctx, time.Since(planStart), req.Database, req.Environment, "success")
 
@@ -221,19 +241,35 @@ func (s *Service) handleApply(w http.ResponseWriter, r *http.Request) {
 //
 // Returns the API response, the stored apply ID (0 if not stored), and any error.
 func (s *Service) ExecuteApply(ctx context.Context, req ApplyRequest) (*apitypes.ApplyResponse, int64, error) {
+	ctx, span := otel.Tracer("schemabot").Start(ctx, "ExecuteApply",
+		trace.WithAttributes(
+			attribute.String("plan_id", req.PlanID),
+			attribute.String("environment", req.Environment),
+		),
+	)
+	defer span.End()
+
 	// Load plan first — it's the source of truth for database and type.
 	plan, err := s.storage.Plans().Get(ctx, req.PlanID)
 	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "get plan")
 		return nil, 0, fmt.Errorf("get plan: %w", err)
 	}
 	if plan == nil {
-		return nil, 0, fmt.Errorf("plan not found: %s", req.PlanID)
+		planErr := fmt.Errorf("plan not found: %s", req.PlanID)
+		span.RecordError(planErr)
+		span.SetStatus(codes.Error, "plan not found")
+		return nil, 0, planErr
 	}
+	span.SetAttributes(attribute.String("database", plan.Database))
 
 	deployment := s.resolveDeployment(plan.Database, req.Deployment)
 
 	client, err := s.TernClient(deployment, req.Environment)
 	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "tern client")
 		metrics.RecordApply(ctx, plan.Database, req.Environment, "error")
 		return nil, 0, fmt.Errorf("tern client: %w", err)
 	}
@@ -262,6 +298,8 @@ func (s *Service) ExecuteApply(ctx context.Context, req ApplyRequest) (*apitypes
 	applyStart := time.Now()
 	resp, err := client.Apply(ctx, ternReq)
 	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "apply failed")
 		metrics.RecordApply(ctx, plan.Database, req.Environment, "error")
 		metrics.RecordApplyDuration(ctx, time.Since(applyStart), plan.Database, req.Environment, "error")
 		return nil, 0, err
@@ -270,6 +308,7 @@ func (s *Service) ExecuteApply(ctx context.Context, req ApplyRequest) (*apitypes
 	if !resp.Accepted {
 		applyStatus = "rejected"
 	}
+	span.SetAttributes(attribute.String("apply_id", resp.ApplyId), attribute.Bool("accepted", resp.Accepted))
 	metrics.RecordApply(ctx, plan.Database, req.Environment, applyStatus)
 	metrics.RecordApplyDuration(ctx, time.Since(applyStart), plan.Database, req.Environment, applyStatus)
 	if resp.Accepted {

--- a/pkg/api/telemetry_test.go
+++ b/pkg/api/telemetry_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -10,6 +11,7 @@ import (
 	"time"
 
 	"github.com/block/schemabot/pkg/metrics"
+	"github.com/block/schemabot/pkg/storage"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
@@ -18,6 +20,8 @@ import (
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata/metricdatatest"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 )
 
 func TestSetupTelemetry(t *testing.T) {
@@ -341,4 +345,105 @@ func TestRecordRecoveryCycleMetric(t *testing.T) {
 	assert.True(t, names["schemabot.recovery.cycles_total"], "expected schemabot.recovery.cycles_total")
 	assert.True(t, names["schemabot.recovery.recovered_total"], "expected schemabot.recovery.recovered_total")
 	assert.True(t, names["schemabot.recovery.failed_total"], "expected schemabot.recovery.failed_total")
+}
+
+// setupTraceTest creates an in-memory trace exporter and configures the global
+// TracerProvider. Returns the exporter for span inspection.
+func setupTraceTest(t *testing.T) *tracetest.InMemoryExporter {
+	t.Helper()
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+	prevTP := otel.GetTracerProvider()
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() {
+		otel.SetTracerProvider(prevTP)
+		if err := tp.Shutdown(t.Context()); err != nil {
+			t.Logf("tracer shutdown: %v", err)
+		}
+	})
+	return exporter
+}
+
+// findSpan returns the first span with the given name, or nil.
+func findSpan(spans tracetest.SpanStubs, name string) *tracetest.SpanStub {
+	for i := range spans {
+		if spans[i].Name == name {
+			return &spans[i]
+		}
+	}
+	return nil
+}
+
+// spanAttrs returns a map of string attribute values from a span.
+func spanAttrs(s *tracetest.SpanStub) map[string]string {
+	attrs := make(map[string]string)
+	for _, a := range s.Attributes {
+		attrs[string(a.Key)] = a.Value.Emit()
+	}
+	return attrs
+}
+
+func TestExecutePlanTrace(t *testing.T) {
+	exporter := setupTraceTest(t)
+
+	svc := newTestService()
+
+	// ExecutePlan will fail (mock tern client), but the span is still recorded.
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+	_, _ = svc.ExecutePlan(ctx, PlanRequest{
+		Database:    "testdb",
+		Environment: "staging",
+		Type:        "mysql",
+	})
+
+	s := findSpan(exporter.GetSpans(), "ExecutePlan")
+	require.NotNil(t, s, "expected ExecutePlan span")
+
+	attrs := spanAttrs(s)
+	assert.Equal(t, "testdb", attrs["database"])
+	assert.Equal(t, "staging", attrs["environment"])
+	assert.Equal(t, "mysql", attrs["type"])
+}
+
+// mockPlanStore returns nil for all lookups, simulating "plan not found".
+type mockPlanStore struct{}
+
+func (m *mockPlanStore) Create(context.Context, *storage.Plan) (int64, error)      { return 0, nil }
+func (m *mockPlanStore) Get(context.Context, string) (*storage.Plan, error)        { return nil, nil }
+func (m *mockPlanStore) GetByID(context.Context, int64) (*storage.Plan, error)     { return nil, nil }
+func (m *mockPlanStore) GetByLock(context.Context, int64) ([]*storage.Plan, error) { return nil, nil }
+func (m *mockPlanStore) GetByPR(context.Context, string, int) ([]*storage.Plan, error) {
+	return nil, nil
+}
+func (m *mockPlanStore) Delete(context.Context, int64) error           { return nil }
+func (m *mockPlanStore) DeleteByPR(context.Context, string, int) error { return nil }
+
+// mockStorageWithPlans wraps mockStorage but returns a real PlanStore.
+type mockStorageWithPlans struct {
+	mockStorage
+}
+
+func (m *mockStorageWithPlans) Plans() storage.PlanStore { return &mockPlanStore{} }
+
+func TestExecuteApplyTrace(t *testing.T) {
+	exporter := setupTraceTest(t)
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	svc := New(&mockStorageWithPlans{}, testServerConfig(), nil, logger)
+
+	// ExecuteApply returns "plan not found" — no panic, span is recorded cleanly.
+	_, _, err := svc.ExecuteApply(t.Context(), ApplyRequest{
+		PlanID:      "nonexistent",
+		Environment: "staging",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "plan not found")
+
+	s := findSpan(exporter.GetSpans(), "ExecuteApply")
+	require.NotNil(t, s, "expected ExecuteApply span")
+
+	attrs := spanAttrs(s)
+	assert.Equal(t, "nonexistent", attrs["plan_id"])
+	assert.Equal(t, "staging", attrs["environment"])
 }

--- a/pkg/webhook/handler.go
+++ b/pkg/webhook/handler.go
@@ -15,6 +15,10 @@ import (
 	"runtime/debug"
 	"strings"
 
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
 	"github.com/block/schemabot/pkg/api"
 	"github.com/block/schemabot/pkg/github"
 	"github.com/block/schemabot/pkg/metrics"
@@ -60,24 +64,34 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	eventType := r.Header.Get("X-GitHub-Event")
 	action, repo := webhookMetadata(body)
+
+	ctx, span := otel.Tracer("schemabot").Start(r.Context(), "webhook",
+		trace.WithAttributes(
+			attribute.String("event_type", eventType),
+			attribute.String("action", action),
+			attribute.String("repository", repo),
+		),
+	)
+	defer span.End()
+
 	h.logger.Debug("webhook received", "event", eventType, "action", action, "repo", repo)
 
 	switch eventType {
 	case "issue_comment":
 		h.handleIssueComment(w, body)
-		metrics.RecordWebhookEvent(r.Context(), eventType, action, repo, "processed")
+		metrics.RecordWebhookEvent(ctx, eventType, action, repo, "processed")
 	case "check_run":
 		// Phase 2: h.handleCheckRun(w, body)
 		h.writeJSON(w, http.StatusOK, map[string]string{"message": "check_run events not yet implemented"})
-		metrics.RecordWebhookEvent(r.Context(), eventType, action, repo, "ignored")
+		metrics.RecordWebhookEvent(ctx, eventType, action, repo, "ignored")
 	case "pull_request":
 		h.handlePullRequest(w, body)
-		metrics.RecordWebhookEvent(r.Context(), eventType, action, repo, "processed")
+		metrics.RecordWebhookEvent(ctx, eventType, action, repo, "processed")
 	default:
 		h.writeJSON(w, http.StatusOK, map[string]string{
 			"message": fmt.Sprintf("event type '%s' ignored", eventType),
 		})
-		metrics.RecordWebhookEvent(r.Context(), eventType, action, repo, "ignored")
+		metrics.RecordWebhookEvent(ctx, eventType, action, repo, "ignored")
 	}
 }
 


### PR DESCRIPTION
Adds OTel trace spans to the three core SchemaBot operations: plan, apply, and webhook processing. When an OTLP endpoint is configured, trace backends (Grafana Tempo, Datadog APM, Jaeger) will show waterfall views of where time is spent within each request.

- **ExecutePlan** — span with database/environment/type attributes, records plan_id and change_count on success
- **ExecuteApply** — span with plan_id/environment attributes, records apply_id and accepted status
- **Webhook handler** — span with event_type/action/repository attributes

Errors are recorded on spans with status codes. The existing `otelhttp` middleware creates root HTTP spans; these are child spans providing operation-level detail.

No impact when OTLP is not configured — spans are silently discarded by the no-op tracer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)