### PR TITLE
feat(auth): add OIDC authentication middleware

### DIFF
--- a/deploy/local/config/dex.yaml
+++ b/deploy/local/config/dex.yaml
@@ -1,0 +1,51 @@
+# Dex OIDC Provider Configuration (Local Development)
+#
+# Provides a local OIDC provider for testing SchemaBot's authentication.
+# Start with: docker compose --profile oidc up
+#
+# Test user:
+#   Email:    admin@example.com
+#   Password: password
+#   Groups:   admins
+#
+# Token endpoint (from host): http://localhost:5556/dex
+# JWKS endpoint:              http://localhost:5556/dex/keys
+
+issuer: http://localhost:5556/dex
+
+storage:
+  type: memory
+
+web:
+  http: 0.0.0.0:5556
+
+oauth2:
+  # Skip the "Grant access to ..." approval screen for faster dev iteration.
+  skipApprovalScreen: true
+
+staticClients:
+  - id: schemabot
+    name: SchemaBot CLI
+    public: true
+    redirectURIs:
+      - "http://localhost:5555/callback"
+      - "urn:ietf:wg:oauth:2.0:oob"
+
+enablePasswordDB: true
+
+staticPasswords:
+  - email: admin@example.com
+    # bcrypt hash of "password"
+    hash: "$2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W"
+    username: admin
+    userID: "admin-001"
+    groups:
+      - admins
+
+  - email: viewer@example.com
+    # bcrypt hash of "password"
+    hash: "$2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W"
+    username: viewer
+    userID: "viewer-001"
+    groups:
+      - viewers

--- a/deploy/local/config/local-oidc.yaml
+++ b/deploy/local/config/local-oidc.yaml
@@ -1,0 +1,42 @@
+# SchemaBot Configuration (Local Mode with OIDC Authentication)
+#
+# Extends the standard local config with OIDC authentication against a local
+# Dex instance. Start the Dex container with: docker compose --profile oidc up
+#
+# To use this config, set SCHEMABOT_CONFIG_FILE=/config/local-oidc.yaml in
+# the schemabot service environment (or use the schemabot-oidc service).
+
+# OIDC authentication against local Dex instance.
+# The issuer URL uses the Docker network hostname (container-to-container).
+auth:
+  type: oidc
+  issuer: "http://dex:5556/dex"
+  admin_group: admins
+
+# SchemaBot's own storage database
+storage:
+  dsn: "env:MYSQL_DSN"
+
+# Database configurations — same as local.yaml.
+databases:
+  testapp:
+    type: mysql
+    environments:
+      staging:
+        dsn: "root:testpassword@tcp(mysql-staging:3306)/testapp?parseTime=true"
+      production:
+        dsn: "root:testpassword@tcp(mysql-production:3306)/testapp?parseTime=true"
+
+  testapp-vitess:
+    type: vitess
+    environments:
+      staging:
+        dsn: "root@tcp(localscale:19101)/"
+        api_url: "http://localscale:8080"
+        organization: "localscale-staging"
+        token_secret_ref: "env:PS_TOKEN"
+      production:
+        dsn: "root@tcp(localscale:19100)/"
+        api_url: "http://localscale:8080"
+        organization: "localscale-production"
+        token_secret_ref: "env:PS_TOKEN"

--- a/deploy/local/docker-compose.yml
+++ b/deploy/local/docker-compose.yml
@@ -6,12 +6,18 @@
 #   make down       # Stop
 #   make logs       # View logs
 #
+# OIDC Authentication (opt-in):
+#   docker compose --profile oidc up
+#   See docs/configuration.md for test credentials and token helper script.
+#
 # Endpoints:
 #   SchemaBot API:     http://localhost:13370
+#   SchemaBot (OIDC):  http://localhost:13380 (--profile oidc)
 #   SchemaBot MySQL:   localhost:13371 (schemabot storage)
 #   Staging MySQL:     localhost:13372 (testapp database)
 #   Production MySQL:  localhost:13373 (testapp database)
 #   LocalScale API:    http://localhost:13374
+#   Dex OIDC:          http://localhost:5556 (--profile oidc)
 #   Branch Proxies:    localhost:19100-19199 (vtgate MySQL via branch passwords)
 #
 # For gRPC mode with separate Tern services, see docker-compose.grpc.yml.
@@ -119,6 +125,59 @@ services:
       mysql-production:
         condition: service_healthy
       localscale:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:8080/health"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  # Dex OIDC provider for local authentication testing.
+  # Only starts with: docker compose --profile oidc up
+  # Provides a local OIDC issuer with static test users.
+  # See config/dex.yaml for test credentials.
+  dex:
+    image: ghcr.io/dexidp/dex:latest
+    profiles: ["oidc"]
+    ports:
+      - "${DEX_PORT:-5556}:5556"
+    volumes:
+      - ./config/dex.yaml:/etc/dex/config.yaml:ro
+    command: ["dex", "serve", "/etc/dex/config.yaml"]
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:5556/dex/.well-known/openid-configuration"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  # SchemaBot with OIDC authentication enabled (uses local Dex).
+  # Only starts with: docker compose --profile oidc up
+  # Replaces the default schemabot service when testing auth.
+  schemabot-oidc:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    profiles: ["oidc"]
+    environment:
+      MYSQL_DSN: "root:testpassword@tcp(mysql-schemabot:3306)/schemabot?parseTime=true&multiStatements=true"
+      SCHEMABOT_CONFIG_FILE: "/config/local-oidc.yaml"
+      PS_TOKEN: "localscale:localscale"
+      PORT: "8080"
+      LOG_LEVEL: "debug"
+    volumes:
+      - ./config:/config:ro
+    ports:
+      - "${SCHEMABOT_OIDC_PORT:-13380}:8080"
+    depends_on:
+      mysql-schemabot:
+        condition: service_healthy
+      mysql-staging:
+        condition: service_healthy
+      mysql-production:
+        condition: service_healthy
+      localscale:
+        condition: service_healthy
+      dex:
         condition: service_healthy
     healthcheck:
       test: ["CMD", "wget", "-q", "--spider", "http://localhost:8080/health"]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -75,6 +75,70 @@ When a webhook arrives from an unlisted repository:
 
 If `repos` is not configured or empty, all repositories are allowed.
 
+## Authentication
+
+SchemaBot supports OIDC-based authentication for API endpoints. When enabled, read endpoints require a valid JWT Bearer token, and write endpoints (plan, apply, cutover, stop, start) additionally require membership in a configured admin group.
+
+```yaml
+auth:
+  type: oidc
+  issuer: "https://your-oidc-provider.example.com"
+  audience: "schemabot"       # optional — skip audience validation if empty
+  admin_group: "schema-admins"
+  groups_claim: "groups"      # optional — defaults to "groups"
+```
+
+When `auth.type` is empty or `"none"`, authentication is disabled and all API requests are allowed (the default for backwards compatibility).
+
+### Testing OIDC Locally with Dex
+
+The local development stack includes an optional [Dex](https://dexidp.io/) OIDC provider for testing authentication end-to-end without external dependencies.
+
+**Start the stack with OIDC:**
+
+```bash
+docker compose --profile oidc up
+```
+
+This starts a Dex instance alongside the standard services, plus a `schemabot-oidc` service that validates tokens against Dex. The OIDC-enabled SchemaBot runs on port `13380` (the standard SchemaBot on `13370` remains available without auth).
+
+**Dex endpoints (from host):**
+
+| Endpoint | URL |
+|---|---|
+| Discovery | `http://localhost:5556/dex/.well-known/openid-configuration` |
+| JWKS | `http://localhost:5556/dex/keys` |
+| Authorization | `http://localhost:5556/dex/auth` |
+| Token | `http://localhost:5556/dex/token` |
+
+**Test users** (defined in `deploy/local/config/dex.yaml`):
+
+| Email | Password | Groups | Access |
+|---|---|---|---|
+| `admin@example.com` | `password` | `admins` | Read + Write |
+| `viewer@example.com` | `password` | `viewers` | Read only |
+
+**Get a test token:**
+
+```bash
+# Interactive browser flow — opens Dex login page, returns a JWT.
+TOKEN=$(./scripts/get-oidc-token.sh)
+
+# Verify auth is working on read endpoints:
+curl -H "Authorization: Bearer $TOKEN" http://localhost:13380/api/databases
+
+# Verify write access (admin user):
+curl -X POST -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  http://localhost:13380/api/databases/testapp/environments/staging/plan
+
+# Verify unauthenticated requests are rejected:
+curl http://localhost:13380/api/databases
+# => {"error":"invalid or missing authentication token"}
+```
+
+The Dex configuration is at `deploy/local/config/dex.yaml` and the OIDC-enabled SchemaBot config is at `deploy/local/config/local-oidc.yaml`.
+
 ## Secret Resolution
 
 DSN values support secret resolution prefixes:

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,9 @@ require (
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
+	github.com/coreos/go-oidc/v3 v3.18.0
 	github.com/docker/go-connections v0.6.0
+	github.com/go-jose/go-jose/v4 v4.1.4
 	github.com/go-mysql-org/go-mysql v1.13.0
 	github.com/go-sql-driver/mysql v1.9.3
 	github.com/google/go-github/v68 v68.0.0

--- a/go.sum
+++ b/go.sum
@@ -165,6 +165,8 @@ github.com/containerd/log v0.1.0 h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I=
 github.com/containerd/log v0.1.0/go.mod h1:VRRf09a7mHDIRezVKTRCrOq78v577GXq3bSa3EhrzVo=
 github.com/containerd/platforms v0.2.1 h1:zvwtM3rz2YHPQsF2CHYM8+KtB5dvhISiXh5ZpSBQv6A=
 github.com/containerd/platforms v0.2.1/go.mod h1:XHCb+2/hzowdiut9rkudds9bE5yJ7npe7dG/wG+uFPw=
+github.com/coreos/go-oidc/v3 v3.18.0 h1:V9orjXynvu5wiC9SemFTWnG4F45v403aIcjWo0d41+A=
+github.com/coreos/go-oidc/v3 v3.18.0/go.mod h1:DYCf24+ncYi+XkIH97GY1+dqoRlbaSI26KVTCI9SrY4=
 github.com/coreos/go-semver v0.3.1 h1:yi21YpKnrx1gt5R+la8n5WgS0kCrsPp33dmEyHReZr4=
 github.com/coreos/go-semver v0.3.1/go.mod h1:irMmmIw/7yzSRPWryHsK7EYSg09caPQL03VsM8rvUec=
 github.com/coreos/go-systemd/v22 v22.6.0 h1:aGVa/v8B7hpb0TKl0MWoAavPDmHvobFe5R5zn0bCJWo=
@@ -217,6 +219,8 @@ github.com/gammazero/deque v1.1.0 h1:OyiyReBbnEG2PP0Bnv1AASLIYvyKqIFN5xfl1t8oGLo
 github.com/gammazero/deque v1.1.0/go.mod h1:JVrR+Bj1NMQbPnYclvDlvSX0nVGReLrQZ0aUMuWLctg=
 github.com/go-ini/ini v1.67.0 h1:z6ZrTEZqSWOTyH2FlglNbNgARyHG8oLW9gMELqKr06A=
 github.com/go-ini/ini v1.67.0/go.mod h1:ByCAeIL28uOIIG0E3PJtZPDL8WnHpFKFOtgjp+3Ies8=
+github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=
+github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/log v0.1.0/go.mod h1:zbhenjAZHb184qTLMA9ZjW7ThYL0H2mk7Q6pNt4vbaY=

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -18,6 +18,11 @@ type ServerConfig struct {
 	// If not specified, falls back to MYSQL_DSN environment variable.
 	Storage StorageConfig `yaml:"storage"`
 
+	// Auth configures API authentication and authorization.
+	// When Type is "oidc", requests must include a valid JWT Bearer token.
+	// When Type is empty (default), all requests are allowed (backwards compatible).
+	Auth AuthConfig `yaml:"auth"`
+
 	// GitHub configures the GitHub App integration for webhook-driven schema changes.
 	// If not set, the webhook endpoint is not registered.
 	GitHub GitHubConfig `yaml:"github"`
@@ -35,6 +40,30 @@ type ServerConfig struct {
 
 	// DefaultReviewers are GitHub teams/users required to review schema changes.
 	DefaultReviewers []string `yaml:"default_reviewers"`
+}
+
+// AuthConfig configures API authentication and authorization.
+type AuthConfig struct {
+	// Type is the authentication type: "oidc" or "" (none).
+	// When empty, authentication is disabled and all requests are allowed.
+	Type string `yaml:"type"`
+
+	// Issuer is the OIDC provider's issuer URL (e.g., "https://accounts.google.com").
+	// Required when Type is "oidc".
+	Issuer string `yaml:"issuer"`
+
+	// Audience is the expected audience (aud) claim in the JWT.
+	// Optional — if empty, audience validation is skipped.
+	Audience string `yaml:"audience"`
+
+	// AdminGroup is the group required for write operations
+	// (e.g., plan, apply, cutover, stop, start).
+	// Required when Type is "oidc".
+	AdminGroup string `yaml:"admin_group"`
+
+	// GroupsClaim is the JWT claim containing group memberships.
+	// Defaults to "groups" if not set.
+	GroupsClaim string `yaml:"groups_claim"`
 }
 
 // GitHubConfig configures the GitHub App used for webhook-driven schema changes.
@@ -243,7 +272,32 @@ func (c *ServerConfig) Validate() error {
 		}
 	}
 
+	// Validate auth config
+	if err := c.Auth.Validate(); err != nil {
+		return fmt.Errorf("auth config: %w", err)
+	}
+
 	return nil
+}
+
+// Validate checks the auth configuration for consistency.
+// When Type is "oidc", Issuer and AdminGroup are required.
+// When Type is empty, no validation is needed (auth disabled).
+func (a *AuthConfig) Validate() error {
+	switch a.Type {
+	case "", "none":
+		return nil
+	case "oidc":
+		if a.Issuer == "" {
+			return fmt.Errorf("issuer is required when auth type is oidc")
+		}
+		if a.AdminGroup == "" {
+			return fmt.Errorf("admin_group is required when auth type is oidc")
+		}
+		return nil
+	default:
+		return fmt.Errorf("unknown auth type %q (supported: oidc)", a.Type)
+	}
 }
 
 // Database returns the database configuration for the given name.

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -1,0 +1,13 @@
+package auth
+
+import "net/http"
+
+// Authorizer provides HTTP middleware that authenticates and authorizes
+// incoming requests. Implementations set the authenticated User in the
+// request context for downstream handlers.
+type Authorizer interface {
+	// Middleware returns HTTP middleware that authenticates requests.
+	// It sets the authenticated User in the request context on success.
+	// On failure, it writes an HTTP error response and does not call next.
+	Middleware(next http.Handler) http.Handler
+}

--- a/pkg/auth/config_test.go
+++ b/pkg/auth/config_test.go
@@ -1,0 +1,58 @@
+package auth_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/block/schemabot/pkg/api"
+)
+
+func TestAuthConfigValidation(t *testing.T) {
+	t.Run("empty type is valid", func(t *testing.T) {
+		cfg := api.AuthConfig{}
+		require.NoError(t, cfg.Validate())
+	})
+
+	t.Run("none type is valid", func(t *testing.T) {
+		cfg := api.AuthConfig{Type: "none"}
+		require.NoError(t, cfg.Validate())
+	})
+
+	t.Run("oidc requires issuer", func(t *testing.T) {
+		cfg := api.AuthConfig{
+			Type:       "oidc",
+			AdminGroup: "admins",
+		}
+		err := cfg.Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "issuer")
+	})
+
+	t.Run("oidc requires admin_group", func(t *testing.T) {
+		cfg := api.AuthConfig{
+			Type:   "oidc",
+			Issuer: "https://accounts.google.com",
+		}
+		err := cfg.Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "admin_group")
+	})
+
+	t.Run("valid oidc config", func(t *testing.T) {
+		cfg := api.AuthConfig{
+			Type:       "oidc",
+			Issuer:     "https://accounts.google.com",
+			AdminGroup: "schema-admins",
+		}
+		require.NoError(t, cfg.Validate())
+	})
+
+	t.Run("unknown type", func(t *testing.T) {
+		cfg := api.AuthConfig{Type: "ldap"}
+		err := cfg.Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unknown auth type")
+	})
+}

--- a/pkg/auth/context.go
+++ b/pkg/auth/context.go
@@ -1,0 +1,30 @@
+// Package auth provides authentication and authorization middleware for the
+// SchemaBot API. It supports OIDC JWT validation against any standards-compliant
+// identity provider (Google, Auth0, Keycloak, etc.) and a no-op mode for local
+// development where all requests are allowed.
+package auth
+
+import "context"
+
+type contextKey struct{}
+
+// User represents an authenticated user extracted from a JWT token.
+type User struct {
+	// Subject is the unique identifier for the user (e.g., "user@example.com").
+	Subject string
+
+	// Groups are the group memberships from the token's groups claim.
+	Groups []string
+}
+
+// WithUser returns a new context with the given user attached.
+func WithUser(ctx context.Context, user *User) context.Context {
+	return context.WithValue(ctx, contextKey{}, user)
+}
+
+// UserFromContext returns the authenticated user from the context, or nil if
+// no user is present.
+func UserFromContext(ctx context.Context) *User {
+	user, _ := ctx.Value(contextKey{}).(*User)
+	return user
+}

--- a/pkg/auth/context_test.go
+++ b/pkg/auth/context_test.go
@@ -1,0 +1,28 @@
+package auth_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/block/schemabot/pkg/auth"
+)
+
+func TestWithUserAndUserFromContext(t *testing.T) {
+	user := &auth.User{
+		Subject: "user@example.com",
+		Groups:  []string{"admins", "developers"},
+	}
+
+	ctx := auth.WithUser(t.Context(), user)
+	got := auth.UserFromContext(ctx)
+	require.NotNil(t, got)
+	assert.Equal(t, "user@example.com", got.Subject)
+	assert.Equal(t, []string{"admins", "developers"}, got.Groups)
+}
+
+func TestUserFromContextReturnsNilWhenNotSet(t *testing.T) {
+	got := auth.UserFromContext(t.Context())
+	assert.Nil(t, got)
+}

--- a/pkg/auth/none.go
+++ b/pkg/auth/none.go
@@ -1,0 +1,16 @@
+package auth
+
+import "net/http"
+
+// NoneAuthorizer is a no-op authorizer that allows all requests through.
+// It sets a synthetic anonymous user in the request context.
+// Used when auth is not configured (local development, testing).
+type NoneAuthorizer struct{}
+
+// Middleware passes all requests through with an anonymous user in context.
+func (NoneAuthorizer) Middleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := WithUser(r.Context(), &User{Subject: "anonymous"})
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}

--- a/pkg/auth/none_test.go
+++ b/pkg/auth/none_test.go
@@ -1,0 +1,49 @@
+package auth_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/block/schemabot/pkg/auth"
+)
+
+func TestNoneAuthorizerSetsAnonymousUser(t *testing.T) {
+	var captured *auth.User
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured = auth.UserFromContext(r.Context())
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := auth.NoneAuthorizer{}.Middleware(inner)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/status", nil)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	require.NotNil(t, captured)
+	assert.Equal(t, "anonymous", captured.Subject)
+}
+
+func TestNoneAuthorizerPassesAllMethods(t *testing.T) {
+	methods := []string{http.MethodGet, http.MethodPost, http.MethodDelete}
+	for _, method := range methods {
+		t.Run(method, func(t *testing.T) {
+			inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			})
+
+			handler := auth.NoneAuthorizer{}.Middleware(inner)
+			req := httptest.NewRequestWithContext(t.Context(), method, "/api/plan", nil)
+			rec := httptest.NewRecorder()
+
+			handler.ServeHTTP(rec, req)
+			assert.Equal(t, http.StatusOK, rec.Code)
+		})
+	}
+}

--- a/pkg/auth/oidc.go
+++ b/pkg/auth/oidc.go
@@ -1,0 +1,213 @@
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"slices"
+	"strings"
+
+	"github.com/coreos/go-oidc/v3/oidc"
+)
+
+// OIDCConfig holds configuration for the OIDC authorizer.
+type OIDCConfig struct {
+	// Issuer is the OIDC provider's issuer URL (e.g., "https://accounts.google.com").
+	Issuer string
+
+	// Audience is the expected audience claim. If empty, audience is not validated.
+	Audience string
+
+	// AdminGroup is the group required for write operations (e.g., "schema-admins").
+	AdminGroup string
+
+	// GroupsClaim is the JWT claim containing group memberships (default: "groups").
+	GroupsClaim string
+}
+
+// OIDCAuthorizer validates OIDC JWT tokens on incoming API requests.
+// It uses JWKS discovery to verify token signatures and checks group
+// memberships for write authorization.
+type OIDCAuthorizer struct {
+	verifier    *oidc.IDTokenVerifier
+	adminGroup  string
+	groupsClaim string
+	logger      *slog.Logger
+}
+
+// NewOIDCAuthorizer creates a new OIDC authorizer that validates JWTs against
+// the given issuer's JWKS endpoint. The JWKS keys are cached and refreshed
+// automatically by the go-oidc library on key rotation.
+func NewOIDCAuthorizer(ctx context.Context, cfg OIDCConfig, logger *slog.Logger) (*OIDCAuthorizer, error) {
+	if cfg.Issuer == "" {
+		return nil, fmt.Errorf("OIDC issuer is required")
+	}
+	if cfg.AdminGroup == "" {
+		return nil, fmt.Errorf("OIDC admin_group is required")
+	}
+
+	groupsClaim := cfg.GroupsClaim
+	if groupsClaim == "" {
+		groupsClaim = "groups"
+	}
+
+	provider, err := oidc.NewProvider(ctx, cfg.Issuer)
+	if err != nil {
+		return nil, fmt.Errorf("discover OIDC provider %s: %w", cfg.Issuer, err)
+	}
+
+	verifierConfig := &oidc.Config{
+		// If no audience is configured, skip audience validation.
+		// Some OIDC providers issue tokens without a specific audience for
+		// device auth flows.
+		SkipClientIDCheck: cfg.Audience == "",
+		ClientID:          cfg.Audience,
+	}
+
+	return &OIDCAuthorizer{
+		verifier:    provider.Verifier(verifierConfig),
+		adminGroup:  cfg.AdminGroup,
+		groupsClaim: groupsClaim,
+		logger:      logger,
+	}, nil
+}
+
+// Middleware returns HTTP middleware that validates OIDC JWT tokens.
+// Requests to paths that bypass auth (webhooks, health, metrics) are passed
+// through without validation. Read endpoints require a valid token. Write
+// endpoints additionally require admin_group membership.
+func (a *OIDCAuthorizer) Middleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Skip auth for paths that have their own authentication (webhooks use
+		// HMAC) or are unauthenticated by design (health, metrics).
+		if skipAuth(r.URL.Path) {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		// Extract and validate the Bearer token.
+		user, err := a.authenticate(r.Context(), r)
+		if err != nil {
+			a.logger.Warn("authentication failed", "path", r.URL.Path, "error", err)
+			writeAuthError(w, http.StatusUnauthorized, "invalid or missing authentication token")
+			return
+		}
+
+		// Check authorization for write endpoints.
+		if isWriteEndpoint(r.Method, r.URL.Path) {
+			if !a.hasAdminGroup(user) {
+				a.logger.Warn("authorization denied for write endpoint",
+					"path", r.URL.Path,
+					"subject", user.Subject,
+					"required_group", a.adminGroup,
+				)
+				writeAuthError(w, http.StatusForbidden, fmt.Sprintf("write access requires membership in group %q", a.adminGroup))
+				return
+			}
+		}
+
+		ctx := WithUser(r.Context(), user)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+// authenticate extracts the Bearer token from the Authorization header,
+// verifies it against the OIDC provider's JWKS, and returns the authenticated
+// user with their group memberships.
+func (a *OIDCAuthorizer) authenticate(ctx context.Context, r *http.Request) (*User, error) {
+	authHeader := r.Header.Get("Authorization")
+	if authHeader == "" {
+		return nil, fmt.Errorf("missing Authorization header")
+	}
+
+	// Must be "Bearer <token>"
+	parts := strings.SplitN(authHeader, " ", 2)
+	if len(parts) != 2 || !strings.EqualFold(parts[0], "Bearer") {
+		return nil, fmt.Errorf("authorization header must use Bearer scheme")
+	}
+	rawToken := parts[1]
+
+	// Verify the JWT against the OIDC provider's JWKS.
+	idToken, err := a.verifier.Verify(ctx, rawToken)
+	if err != nil {
+		return nil, fmt.Errorf("verify token: %w", err)
+	}
+
+	// Extract groups from the configured claim.
+	groups, err := a.extractGroups(idToken)
+	if err != nil {
+		return nil, fmt.Errorf("extract groups from token: %w", err)
+	}
+
+	return &User{
+		Subject: idToken.Subject,
+		Groups:  groups,
+	}, nil
+}
+
+// extractGroups reads the groups claim from the token. The claim may contain
+// a JSON array of strings. If the claim is missing, an empty slice is returned.
+func (a *OIDCAuthorizer) extractGroups(token *oidc.IDToken) ([]string, error) {
+	var claims map[string]json.RawMessage
+	if err := token.Claims(&claims); err != nil {
+		return nil, fmt.Errorf("parse token claims: %w", err)
+	}
+
+	raw, ok := claims[a.groupsClaim]
+	if !ok {
+		// Groups claim not present — the user has no group memberships.
+		return nil, nil
+	}
+
+	var groups []string
+	if err := json.Unmarshal(raw, &groups); err != nil {
+		return nil, fmt.Errorf("parse %s claim as string array: %w", a.groupsClaim, err)
+	}
+
+	return groups, nil
+}
+
+// hasAdminGroup checks if the user is a member of the configured admin group.
+func (a *OIDCAuthorizer) hasAdminGroup(user *User) bool {
+	return slices.Contains(user.Groups, a.adminGroup)
+}
+
+// skipAuth returns true for paths that bypass OIDC authentication.
+// Webhooks have their own HMAC authentication. Health and metrics are
+// unauthenticated infrastructure endpoints.
+func skipAuth(path string) bool {
+	switch {
+	case path == "/health":
+		return true
+	case path == "/metrics":
+		return true
+	case strings.HasPrefix(path, "/webhook"):
+		return true
+	case strings.HasPrefix(path, "/tern-health/"):
+		return true
+	default:
+		return false
+	}
+}
+
+// isWriteEndpoint returns true for API endpoints that modify state and require
+// admin group membership. Read-only GET endpoints only require a valid token.
+func isWriteEndpoint(method, path string) bool {
+	// All POST and DELETE requests to the API are write operations.
+	if method == http.MethodPost || method == http.MethodDelete {
+		return strings.HasPrefix(path, "/api/")
+	}
+	return false
+}
+
+// writeAuthError writes a JSON error response for authentication/authorization failures.
+func writeAuthError(w http.ResponseWriter, status int, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	resp := map[string]string{"error": message}
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		slog.Error("failed to write auth error response", "error", err)
+	}
+}

--- a/pkg/auth/oidc_test.go
+++ b/pkg/auth/oidc_test.go
@@ -1,0 +1,536 @@
+package auth_test
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/block/schemabot/pkg/auth"
+)
+
+// testOIDCProvider is a minimal OIDC provider that serves discovery and JWKS
+// endpoints for testing JWT validation.
+type testOIDCProvider struct {
+	server *httptest.Server
+	key    *rsa.PrivateKey
+	keyID  string
+}
+
+func newTestOIDCProvider(t *testing.T) *testOIDCProvider {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	p := &testOIDCProvider{
+		key:   key,
+		keyID: "test-key-1",
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/openid-configuration", p.handleDiscovery)
+	mux.HandleFunc("/keys", p.handleJWKS)
+
+	p.server = httptest.NewServer(mux)
+	t.Cleanup(p.server.Close)
+
+	return p
+}
+
+func (p *testOIDCProvider) handleDiscovery(w http.ResponseWriter, _ *http.Request) {
+	discovery := map[string]string{
+		"issuer":                 p.server.URL,
+		"jwks_uri":               p.server.URL + "/keys",
+		"authorization_endpoint": p.server.URL + "/authorize",
+		"token_endpoint":         p.server.URL + "/token",
+	}
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(discovery); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+func (p *testOIDCProvider) handleJWKS(w http.ResponseWriter, _ *http.Request) {
+	jwk := jose.JSONWebKey{
+		Key:       &p.key.PublicKey,
+		KeyID:     p.keyID,
+		Algorithm: string(jose.RS256),
+		Use:       "sig",
+	}
+	jwks := jose.JSONWebKeySet{Keys: []jose.JSONWebKey{jwk}}
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(jwks); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+// issueToken creates a signed JWT with the given claims.
+func (p *testOIDCProvider) issueToken(t *testing.T, subject string, groups []string, expiry time.Time) string {
+	t.Helper()
+
+	signer, err := jose.NewSigner(jose.SigningKey{
+		Algorithm: jose.RS256,
+		Key:       p.key,
+	}, (&jose.SignerOptions{}).WithType("JWT").WithHeader(jose.HeaderKey("kid"), p.keyID))
+	require.NoError(t, err)
+
+	now := time.Now()
+	claims := map[string]any{
+		"iss":    p.server.URL,
+		"sub":    subject,
+		"aud":    "schemabot",
+		"iat":    now.Unix(),
+		"exp":    expiry.Unix(),
+		"groups": groups,
+	}
+
+	raw, err := jwt.Signed(signer).Claims(claims).Serialize()
+	require.NoError(t, err)
+	return raw
+}
+
+// issueTokenWithCustomClaim creates a signed JWT with groups under a custom claim name.
+func (p *testOIDCProvider) issueTokenWithCustomClaim(t *testing.T, subject string, claimName string, groups []string, expiry time.Time) string {
+	t.Helper()
+
+	signer, err := jose.NewSigner(jose.SigningKey{
+		Algorithm: jose.RS256,
+		Key:       p.key,
+	}, (&jose.SignerOptions{}).WithType("JWT").WithHeader(jose.HeaderKey("kid"), p.keyID))
+	require.NoError(t, err)
+
+	now := time.Now()
+	claims := map[string]any{
+		"iss":     p.server.URL,
+		"sub":     subject,
+		"aud":     "schemabot",
+		"iat":     now.Unix(),
+		"exp":     expiry.Unix(),
+		claimName: groups,
+	}
+
+	raw, err := jwt.Signed(signer).Claims(claims).Serialize()
+	require.NoError(t, err)
+	return raw
+}
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
+}
+
+func TestOIDCAuthorizerValidToken(t *testing.T) {
+	provider := newTestOIDCProvider(t)
+
+	authz, err := auth.NewOIDCAuthorizer(t.Context(), auth.OIDCConfig{
+		Issuer:     provider.server.URL,
+		Audience:   "schemabot",
+		AdminGroup: "schema-admins",
+	}, testLogger())
+	require.NoError(t, err)
+
+	token := provider.issueToken(t, "user@example.com", []string{"schema-admins", "developers"}, time.Now().Add(time.Hour))
+
+	var captured *auth.User
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured = auth.UserFromContext(r.Context())
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := authz.Middleware(inner)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/status", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	require.NotNil(t, captured)
+	assert.Equal(t, "user@example.com", captured.Subject)
+	assert.Contains(t, captured.Groups, "schema-admins")
+	assert.Contains(t, captured.Groups, "developers")
+}
+
+func TestOIDCAuthorizerMissingToken(t *testing.T) {
+	provider := newTestOIDCProvider(t)
+
+	authz, err := auth.NewOIDCAuthorizer(t.Context(), auth.OIDCConfig{
+		Issuer:     provider.server.URL,
+		Audience:   "schemabot",
+		AdminGroup: "schema-admins",
+	}, testLogger())
+	require.NoError(t, err)
+
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("handler should not be called")
+	})
+
+	handler := authz.Middleware(inner)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/status", nil)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+
+	var body map[string]string
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&body))
+	assert.Contains(t, body["error"], "invalid or missing authentication token")
+}
+
+func TestOIDCAuthorizerExpiredToken(t *testing.T) {
+	provider := newTestOIDCProvider(t)
+
+	authz, err := auth.NewOIDCAuthorizer(t.Context(), auth.OIDCConfig{
+		Issuer:     provider.server.URL,
+		Audience:   "schemabot",
+		AdminGroup: "schema-admins",
+	}, testLogger())
+	require.NoError(t, err)
+
+	token := provider.issueToken(t, "user@example.com", []string{"schema-admins"}, time.Now().Add(-time.Hour))
+
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("handler should not be called for expired token")
+	})
+
+	handler := authz.Middleware(inner)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/status", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+func TestOIDCAuthorizerWriteEndpointRequiresAdminGroup(t *testing.T) {
+	provider := newTestOIDCProvider(t)
+
+	authz, err := auth.NewOIDCAuthorizer(t.Context(), auth.OIDCConfig{
+		Issuer:     provider.server.URL,
+		Audience:   "schemabot",
+		AdminGroup: "schema-admins",
+	}, testLogger())
+	require.NoError(t, err)
+
+	// Token without the admin group
+	token := provider.issueToken(t, "reader@example.com", []string{"developers"}, time.Now().Add(time.Hour))
+
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("handler should not be called without admin group on write endpoint")
+	})
+
+	handler := authz.Middleware(inner)
+
+	// POST to a write endpoint
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/plan", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+
+	var body map[string]string
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&body))
+	assert.Contains(t, body["error"], "schema-admins")
+}
+
+func TestOIDCAuthorizerWriteEndpointAllowedWithAdminGroup(t *testing.T) {
+	provider := newTestOIDCProvider(t)
+
+	authz, err := auth.NewOIDCAuthorizer(t.Context(), auth.OIDCConfig{
+		Issuer:     provider.server.URL,
+		Audience:   "schemabot",
+		AdminGroup: "schema-admins",
+	}, testLogger())
+	require.NoError(t, err)
+
+	token := provider.issueToken(t, "admin@example.com", []string{"schema-admins"}, time.Now().Add(time.Hour))
+
+	var called bool
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := authz.Middleware(inner)
+
+	writeEndpoints := []struct {
+		method string
+		path   string
+	}{
+		{http.MethodPost, "/api/plan"},
+		{http.MethodPost, "/api/apply"},
+		{http.MethodPost, "/api/cutover"},
+		{http.MethodPost, "/api/revert"},
+		{http.MethodPost, "/api/skip-revert"},
+		{http.MethodPost, "/api/stop"},
+		{http.MethodPost, "/api/start"},
+		{http.MethodPost, "/api/volume"},
+		{http.MethodDelete, "/api/locks"},
+		{http.MethodPost, "/api/locks/acquire"},
+		{http.MethodPost, "/api/settings"},
+		{http.MethodPost, "/api/rollback/plan"},
+	}
+
+	for _, ep := range writeEndpoints {
+		t.Run(fmt.Sprintf("%s %s", ep.method, ep.path), func(t *testing.T) {
+			called = false
+			req := httptest.NewRequestWithContext(t.Context(), ep.method, ep.path, nil)
+			req.Header.Set("Authorization", "Bearer "+token)
+			rec := httptest.NewRecorder()
+
+			handler.ServeHTTP(rec, req)
+			assert.Equal(t, http.StatusOK, rec.Code)
+			assert.True(t, called, "handler should be called for admin user")
+		})
+	}
+}
+
+func TestOIDCAuthorizerReadEndpointAllowedWithAnyValidToken(t *testing.T) {
+	provider := newTestOIDCProvider(t)
+
+	authz, err := auth.NewOIDCAuthorizer(t.Context(), auth.OIDCConfig{
+		Issuer:     provider.server.URL,
+		Audience:   "schemabot",
+		AdminGroup: "schema-admins",
+	}, testLogger())
+	require.NoError(t, err)
+
+	// Token without admin group — should still work for read endpoints.
+	token := provider.issueToken(t, "reader@example.com", []string{"developers"}, time.Now().Add(time.Hour))
+
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := authz.Middleware(inner)
+
+	readEndpoints := []string{
+		"/api/status",
+		"/api/progress/mydb",
+		"/api/progress/apply/apply-123",
+		"/api/logs/mydb",
+		"/api/logs",
+		"/api/locks",
+		"/api/locks/mydb/mysql",
+		"/api/databases/mydb/environments",
+		"/api/settings",
+		"/api/settings/some-key",
+		"/api/history/mydb",
+	}
+
+	for _, path := range readEndpoints {
+		t.Run("GET "+path, func(t *testing.T) {
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, path, nil)
+			req.Header.Set("Authorization", "Bearer "+token)
+			rec := httptest.NewRecorder()
+
+			handler.ServeHTTP(rec, req)
+			assert.Equal(t, http.StatusOK, rec.Code)
+		})
+	}
+}
+
+func TestOIDCAuthorizerSkipsAuthForExcludedPaths(t *testing.T) {
+	provider := newTestOIDCProvider(t)
+
+	authz, err := auth.NewOIDCAuthorizer(t.Context(), auth.OIDCConfig{
+		Issuer:     provider.server.URL,
+		Audience:   "schemabot",
+		AdminGroup: "schema-admins",
+	}, testLogger())
+	require.NoError(t, err)
+
+	var called bool
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := authz.Middleware(inner)
+
+	excludedPaths := []struct {
+		method string
+		path   string
+	}{
+		{http.MethodGet, "/health"},
+		{http.MethodGet, "/metrics"},
+		{http.MethodPost, "/webhook"},
+		{http.MethodPost, "/webhook/github"},
+		{http.MethodGet, "/tern-health/default/staging"},
+	}
+
+	for _, ep := range excludedPaths {
+		t.Run(fmt.Sprintf("%s %s", ep.method, ep.path), func(t *testing.T) {
+			called = false
+			// No Authorization header — these paths skip auth.
+			req := httptest.NewRequestWithContext(t.Context(), ep.method, ep.path, nil)
+			rec := httptest.NewRecorder()
+
+			handler.ServeHTTP(rec, req)
+			assert.Equal(t, http.StatusOK, rec.Code)
+			assert.True(t, called, "handler should be called for excluded path")
+		})
+	}
+}
+
+func TestOIDCAuthorizerInvalidBearerScheme(t *testing.T) {
+	provider := newTestOIDCProvider(t)
+
+	authz, err := auth.NewOIDCAuthorizer(t.Context(), auth.OIDCConfig{
+		Issuer:     provider.server.URL,
+		Audience:   "schemabot",
+		AdminGroup: "schema-admins",
+	}, testLogger())
+	require.NoError(t, err)
+
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("handler should not be called")
+	})
+
+	handler := authz.Middleware(inner)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/status", nil)
+	req.Header.Set("Authorization", "Basic dXNlcjpwYXNz")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+func TestOIDCAuthorizerCustomGroupsClaim(t *testing.T) {
+	provider := newTestOIDCProvider(t)
+
+	authz, err := auth.NewOIDCAuthorizer(t.Context(), auth.OIDCConfig{
+		Issuer:      provider.server.URL,
+		Audience:    "schemabot",
+		AdminGroup:  "dba-team",
+		GroupsClaim: "custom_groups",
+	}, testLogger())
+	require.NoError(t, err)
+
+	token := provider.issueTokenWithCustomClaim(t, "admin@example.com", "custom_groups", []string{"dba-team"}, time.Now().Add(time.Hour))
+
+	var captured *auth.User
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured = auth.UserFromContext(r.Context())
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := authz.Middleware(inner)
+
+	// Test a write endpoint to verify the custom groups claim is used for authorization.
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/plan", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	require.NotNil(t, captured)
+	assert.Contains(t, captured.Groups, "dba-team")
+}
+
+func TestOIDCAuthorizerNoAudienceValidation(t *testing.T) {
+	provider := newTestOIDCProvider(t)
+
+	// No audience configured — should accept tokens regardless of aud claim.
+	authz, err := auth.NewOIDCAuthorizer(t.Context(), auth.OIDCConfig{
+		Issuer:     provider.server.URL,
+		AdminGroup: "schema-admins",
+	}, testLogger())
+	require.NoError(t, err)
+
+	token := provider.issueToken(t, "user@example.com", []string{"schema-admins"}, time.Now().Add(time.Hour))
+
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := authz.Middleware(inner)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/status", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestNewOIDCAuthorizerValidation(t *testing.T) {
+	t.Run("missing issuer", func(t *testing.T) {
+		_, err := auth.NewOIDCAuthorizer(t.Context(), auth.OIDCConfig{
+			AdminGroup: "admins",
+		}, testLogger())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "issuer")
+	})
+
+	t.Run("missing admin_group", func(t *testing.T) {
+		_, err := auth.NewOIDCAuthorizer(t.Context(), auth.OIDCConfig{
+			Issuer: "https://example.com",
+		}, testLogger())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "admin_group")
+	})
+}
+
+func TestOIDCAuthorizerTokenWithoutGroups(t *testing.T) {
+	provider := newTestOIDCProvider(t)
+
+	authz, err := auth.NewOIDCAuthorizer(t.Context(), auth.OIDCConfig{
+		Issuer:     provider.server.URL,
+		Audience:   "schemabot",
+		AdminGroup: "schema-admins",
+	}, testLogger())
+	require.NoError(t, err)
+
+	// Issue a token without any groups claim.
+	signer, err := jose.NewSigner(jose.SigningKey{
+		Algorithm: jose.RS256,
+		Key:       provider.key,
+	}, (&jose.SignerOptions{}).WithType("JWT").WithHeader(jose.HeaderKey("kid"), provider.keyID))
+	require.NoError(t, err)
+
+	claims := map[string]any{
+		"iss": provider.server.URL,
+		"sub": "nogroupuser@example.com",
+		"aud": "schemabot",
+		"iat": time.Now().Unix(),
+		"exp": time.Now().Add(time.Hour).Unix(),
+	}
+	token, err := jwt.Signed(signer).Claims(claims).Serialize()
+	require.NoError(t, err)
+
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := authz.Middleware(inner)
+
+	// Read endpoint should succeed with no groups.
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/status", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	// Write endpoint should be denied — no groups means no admin group membership.
+	req = httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/plan", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+}

--- a/pkg/cmd/commands/serve.go
+++ b/pkg/cmd/commands/serve.go
@@ -19,6 +19,7 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/block/schemabot/pkg/api"
+	"github.com/block/schemabot/pkg/auth"
 	ghclient "github.com/block/schemabot/pkg/github"
 	"github.com/block/schemabot/pkg/secrets"
 	"github.com/block/schemabot/pkg/storage/mysqlstore"
@@ -136,9 +137,18 @@ func (cmd *ServeCmd) Run(g *Globals) error {
 	}
 	mux.Handle("POST /webhook", webhookHandler)
 
+	// Set up authentication middleware based on config.
+	// The auth middleware wraps the mux so it runs before any handler.
+	// Webhook/health/metrics endpoints are excluded within the middleware itself.
+	authz, err := buildAuthorizer(ctx, serverConfig.Auth, logger)
+	if err != nil {
+		return fmt.Errorf("setup auth: %w", err)
+	}
+	authedHandler := authz.Middleware(mux)
+
 	// Wrap mux with OTel HTTP instrumentation for automatic request
 	// duration, request body size, and response body size metrics.
-	handler := otelhttp.NewHandler(mux, "schemabot")
+	handler := otelhttp.NewHandler(authedHandler, "schemabot")
 
 	// Create server
 	server := &http.Server{
@@ -269,6 +279,33 @@ func getEnv(key, defaultValue string) string {
 		return value
 	}
 	return defaultValue
+}
+
+// buildAuthorizer creates the appropriate Authorizer based on config.
+// When auth.type is "oidc", it performs OIDC provider discovery and sets up
+// JWT validation. When auth.type is empty, it returns a NoneAuthorizer that
+// allows all requests.
+func buildAuthorizer(ctx context.Context, cfg api.AuthConfig, logger *slog.Logger) (auth.Authorizer, error) {
+	switch cfg.Type {
+	case "oidc":
+		logger.Info("initializing OIDC authentication", "issuer", cfg.Issuer, "admin_group", cfg.AdminGroup)
+		authz, err := auth.NewOIDCAuthorizer(ctx, auth.OIDCConfig{
+			Issuer:      cfg.Issuer,
+			Audience:    cfg.Audience,
+			AdminGroup:  cfg.AdminGroup,
+			GroupsClaim: cfg.GroupsClaim,
+		}, logger)
+		if err != nil {
+			return nil, err
+		}
+		logger.Info("OIDC authentication enabled", "issuer", cfg.Issuer)
+		return authz, nil
+	case "", "none":
+		logger.Info("authentication disabled — all API requests allowed")
+		return auth.NoneAuthorizer{}, nil
+	default:
+		return nil, fmt.Errorf("unknown auth type %q", cfg.Type)
+	}
 }
 
 func logLevel() slog.Level {

--- a/scripts/get-oidc-token.sh
+++ b/scripts/get-oidc-token.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+#
+# Obtain an OIDC token from the local Dex instance for testing.
+#
+# This uses the OAuth2 authorization code flow with a temporary HTTP server
+# to capture the callback. It opens the browser for login, the user signs in
+# with static credentials, and the script exchanges the code for a token.
+#
+# Usage:
+#   ./scripts/get-oidc-token.sh                    # prints the access token
+#   TOKEN=$(./scripts/get-oidc-token.sh)            # capture for use
+#   curl -H "Authorization: Bearer $TOKEN" ...      # use with API
+#
+# Prerequisites:
+#   - Local Dex running: docker compose --profile oidc up
+#   - curl and python3 available
+#
+# Test credentials (from deploy/local/config/dex.yaml):
+#   Admin:  admin@example.com  / password   (group: admins — read+write)
+#   Viewer: viewer@example.com / password   (group: viewers — read only)
+#
+set -euo pipefail
+
+DEX_URL="${DEX_URL:-http://localhost:5556/dex}"
+CLIENT_ID="${CLIENT_ID:-schemabot}"
+REDIRECT_PORT="${REDIRECT_PORT:-5555}"
+REDIRECT_URI="http://localhost:${REDIRECT_PORT}/callback"
+SCOPES="openid email groups profile offline_access"
+
+# Verify Dex is running.
+if ! curl -sf "${DEX_URL}/.well-known/openid-configuration" > /dev/null 2>&1; then
+    echo "Error: Dex is not running at ${DEX_URL}" >&2
+    echo "Start it with: docker compose --profile oidc up" >&2
+    exit 1
+fi
+
+# Generate a random state parameter for CSRF protection.
+STATE=$(python3 -c "import secrets; print(secrets.token_urlsafe(16))")
+
+# Build the authorization URL.
+AUTH_URL="${DEX_URL}/auth?client_id=${CLIENT_ID}&redirect_uri=${REDIRECT_URI}&response_type=code&scope=$(echo "${SCOPES}" | tr ' ' '+')&state=${STATE}"
+
+echo "Opening browser for Dex login..." >&2
+echo "Sign in with: admin@example.com / password" >&2
+echo "" >&2
+
+# Open the browser (macOS: open, Linux: xdg-open).
+if command -v open > /dev/null 2>&1; then
+    open "${AUTH_URL}"
+elif command -v xdg-open > /dev/null 2>&1; then
+    xdg-open "${AUTH_URL}"
+else
+    echo "Open this URL in your browser:" >&2
+    echo "${AUTH_URL}" >&2
+fi
+
+# Start a temporary HTTP server to capture the OAuth callback.
+# Python serves exactly one request, extracts the authorization code, and exits.
+RESPONSE=$(python3 -c "
+import http.server
+import urllib.parse
+import sys
+
+class CallbackHandler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        parsed = urllib.parse.urlparse(self.path)
+        params = urllib.parse.parse_qs(parsed.query)
+
+        if 'code' not in params:
+            self.send_response(400)
+            self.end_headers()
+            self.wfile.write(b'No authorization code received.')
+            print('ERROR:no_code', file=sys.stderr)
+            return
+
+        code = params['code'][0]
+        state = params.get('state', [''])[0]
+
+        self.send_response(200)
+        self.send_header('Content-Type', 'text/html')
+        self.end_headers()
+        self.wfile.write(b'<html><body><h2>Login successful!</h2><p>You can close this tab.</p></body></html>')
+
+        # Write code to stdout for the parent script to capture.
+        print(f'{code}|{state}', flush=True)
+
+    def log_message(self, format, *args):
+        pass  # Suppress HTTP server logs.
+
+server = http.server.HTTPServer(('localhost', ${REDIRECT_PORT}), CallbackHandler)
+# Handle exactly one request.
+server.handle_request()
+server.server_close()
+" 2>/dev/null)
+
+# Parse the response.
+AUTH_CODE=$(echo "${RESPONSE}" | cut -d'|' -f1)
+RETURNED_STATE=$(echo "${RESPONSE}" | cut -d'|' -f2)
+
+if [ -z "${AUTH_CODE}" ]; then
+    echo "Error: No authorization code received." >&2
+    exit 1
+fi
+
+if [ "${RETURNED_STATE}" != "${STATE}" ]; then
+    echo "Error: State mismatch (possible CSRF)." >&2
+    exit 1
+fi
+
+# Exchange the authorization code for tokens.
+if ! TOKEN_RESPONSE=$(curl -sf -X POST "${DEX_URL}/token" \
+    -H "Content-Type: application/x-www-form-urlencoded" \
+    -d "grant_type=authorization_code" \
+    -d "code=${AUTH_CODE}" \
+    -d "client_id=${CLIENT_ID}" \
+    -d "redirect_uri=${REDIRECT_URI}"); then
+    echo "Error: Token exchange failed." >&2
+    exit 1
+fi
+
+# Extract the ID token (Dex returns id_token for OIDC flows).
+ID_TOKEN=$(echo "${TOKEN_RESPONSE}" | python3 -c "import sys, json; print(json.load(sys.stdin)['id_token'])")
+
+if [ -z "${ID_TOKEN}" ]; then
+    echo "Error: No id_token in response." >&2
+    exit 1
+fi
+
+# Print token claims to stderr for visibility.
+echo "" >&2
+echo "Token claims:" >&2
+echo "${ID_TOKEN}" | cut -d'.' -f2 | python3 -c "
+import sys, base64, json
+payload = sys.stdin.read().strip()
+# Add padding if needed.
+payload += '=' * (4 - len(payload) % 4)
+claims = json.loads(base64.urlsafe_b64decode(payload))
+for key in ('sub', 'email', 'groups', 'exp'):
+    if key in claims:
+        print(f'  {key}: {claims[key]}', file=sys.stderr)
+" 2>&1 >&2
+
+# Print only the token to stdout so it can be captured with $().
+echo "${ID_TOKEN}"


### PR DESCRIPTION
## Summary

Add optional OIDC authentication middleware for SchemaBot's API endpoints, with a local Dex OIDC provider for testing.

**Server-side auth (`pkg/auth/`):**
- `Authorizer` interface with `NoneAuthorizer` (default) and `OIDCAuthorizer`
- JWT validation via JWKS discovery (`coreos/go-oidc/v3`) — works with any OIDC provider
- Read endpoints (status, logs, progress) require any valid token
- Write endpoints (plan, apply, cutover) require admin group membership
- Webhook and health endpoints bypass auth
- Backwards compatible — disabled when `auth` config is not set

**Local testing with Dex:**
- `docker compose --profile oidc up` starts Dex + auth-enabled SchemaBot
- Two test users: `admin@example.com` (write access) and `viewer@example.com` (read-only)
- Token helper script: `./scripts/get-oidc-token.sh`
- Auth-enabled SchemaBot on port 13380, unauthenticated on 13370 (side by side)

```yaml
# Enable OIDC (optional)
auth:
  type: oidc
  issuer: "https://accounts.google.com"
  admin_group: schema-admins
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)