### PR TITLE
feat: include endpoint address in tern health check error logs

### DIFF
--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -116,8 +116,9 @@ func (m *mockTernClient) RollbackPlan(ctx context.Context, database string) (*te
 func (m *mockTernClient) ResumeApply(ctx context.Context, apply *storage.Apply) error {
 	return nil
 }
-func (m *mockTernClient) IsRemote() bool { return false }
-func (m *mockTernClient) Close() error   { return nil }
+func (m *mockTernClient) Endpoint() string { return "mock" }
+func (m *mockTernClient) IsRemote() bool   { return false }
+func (m *mockTernClient) Close() error     { return nil }
 
 // testServerConfig returns a minimal valid ServerConfig for testing.
 // Only includes "staging" environment - tests that need "production"

--- a/pkg/api/health_handlers.go
+++ b/pkg/api/health_handlers.go
@@ -27,7 +27,7 @@ func (s *Service) handleTernHealth(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := client.Health(r.Context()); err != nil {
-		s.logger.Error("tern health check failed", "deployment", deployment, "environment", environment, "error", err)
+		s.logger.Error("tern health check failed", "deployment", deployment, "environment", environment, "endpoint", client.Endpoint(), "error", err)
 		s.writeError(w, http.StatusServiceUnavailable, "tern unavailable")
 		return
 	}

--- a/pkg/tern/client.go
+++ b/pkg/tern/client.go
@@ -57,6 +57,11 @@ type Client interface {
 	// with stale heartbeats (crashed workers).
 	ResumeApply(ctx context.Context, apply *storage.Apply) error
 
+	// Endpoint returns the address this client connects to.
+	// For GRPCClient, this is the dial address (e.g., "tern-staging:9090").
+	// For LocalClient, this is the database name.
+	Endpoint() string
+
 	// IsRemote reports whether this client delegates to a separate Tern
 	// service with its own storage.
 	//

--- a/pkg/tern/grpc_client.go
+++ b/pkg/tern/grpc_client.go
@@ -119,6 +119,7 @@ import (
 type GRPCClient struct {
 	conn    *grpc.ClientConn
 	client  ternv1.TernClient
+	address string          // dial address for logging/debugging
 	storage storage.Storage // SchemaBot's storage for apply/task management
 }
 
@@ -148,6 +149,7 @@ func NewGRPCClient(config Config) (*GRPCClient, error) {
 	return &GRPCClient{
 		conn:    conn,
 		client:  ternv1.NewTernClient(conn),
+		address: config.Address,
 		storage: config.Storage,
 	}, nil
 }
@@ -156,6 +158,9 @@ func NewGRPCClient(config Config) (*GRPCClient, error) {
 // with its own storage. SchemaBot must create its own apply/task records
 // and store Tern's apply_id as external_id.
 func (c *GRPCClient) IsRemote() bool { return true }
+
+// Endpoint returns the gRPC dial address for this client.
+func (c *GRPCClient) Endpoint() string { return c.address }
 
 // Close closes the gRPC connection.
 func (c *GRPCClient) Close() error {

--- a/pkg/tern/local_client.go
+++ b/pkg/tern/local_client.go
@@ -176,6 +176,9 @@ func NewLocalClient(cfg LocalConfig, stor storage.Storage, logger *slog.Logger) 
 // apply/task records in the same database as the API layer.
 func (c *LocalClient) IsRemote() bool { return false }
 
+// Endpoint returns the database name for this local client.
+func (c *LocalClient) Endpoint() string { return c.config.Database }
+
 // protoEngine returns the proto engine type based on database configuration.
 func (c *LocalClient) protoEngine() ternv1.Engine {
 	if c.config.Type == storage.DatabaseTypeVitess {


### PR DESCRIPTION
## Summary

- Add `Endpoint() string` to the `tern.Client` interface
- `GRPCClient` returns the dial address, `LocalClient` returns the database name
- Include endpoint in the `handleTernHealth` error log

Before:
```json
{"msg":"tern health check failed","deployment":"ski","environment":"staging","error":"rpc error: code = Unavailable ..."}
```

After:
```json
{"msg":"tern health check failed","deployment":"ski","environment":"staging","endpoint":"tern-staging:9090","error":"rpc error: code = Unavailable ..."}
```

Makes it much easier to debug connectivity/TLS issues when multiple Tern deployments are configured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)