### PR TITLE
feat: add $ENV substitution in namespace names

### DIFF
--- a/docs/namespaces.md
+++ b/docs/namespaces.md
@@ -109,6 +109,40 @@ SchemaBot plans all keyspaces together — a single plan can contain changes acr
 
 A plan can have DDL-only changes, VSchema-only changes, or both.
 
+## `$ENV` Substitution in Namespace Names
+
+Some infrastructure names schemas with an environment suffix: `bikeshare_staging` in staging, `bikeshare_production` in production. Rather than maintaining separate directories for each environment, you can use `$ENV` in the directory name. When an environment is specified (via `-e`), `$ENV` is replaced with the environment value.
+
+### Example
+
+Directory structure:
+
+```
+myapp/schema/
+├── schemabot.yaml
+└── bikeshare_$ENV/
+    ├── bikes.sql
+    └── stations.sql
+```
+
+Running against different environments resolves the namespace accordingly:
+
+```bash
+# Namespace becomes "bikeshare_staging"
+schemabot plan -s myapp/schema -e staging
+
+# Namespace becomes "bikeshare_production"
+schemabot plan -s myapp/schema -e production
+```
+
+### Rules
+
+- `$ENV` is replaced with the environment value from `-e` (e.g., `staging`, `production`).
+- If no environment is specified, `$ENV` is left as-is (no substitution).
+- Works in both flat layout (directory name = namespace) and subdirectory layout (subdirectory names = namespaces).
+- You can mix `$ENV` directories with regular directories in the subdirectory layout.
+- When creating the directory from a shell, quote the name to prevent shell expansion: `mkdir 'bikeshare_$ENV'`
+
 ## Summary
 
 | Scenario | schemabot.yaml | Namespaces | Example |
@@ -117,6 +151,7 @@ A plan can have DDL-only changes, VSchema-only changes, or both.
 | MySQL, multiple schema names | 1 | many | `app_primary/`, `app_analytics/` |
 | MySQL, different databases | 1 per database | 1 each | separate directories |
 | Vitess, multiple keyspaces | 1 | many | `commerce/`, `commerce_sharded/` |
+| Environment-specific namespace | 1 | 1 per env | `bikeshare_$ENV/` |
 
 ## How Namespaces Flow Through the System
 

--- a/e2e/testutil/apply.go
+++ b/e2e/testutil/apply.go
@@ -19,7 +19,7 @@ import (
 // subdirectory as the namespace.
 func groupFiles(t *testing.T, files map[string]string, database string) map[string]*apitypes.SchemaFiles {
 	t.Helper()
-	grouped, err := schema.GroupFilesByNamespace(files, database)
+	grouped, err := schema.GroupFilesByNamespace(files, database, "development")
 	require.NoError(t, err, "group schema files by namespace")
 	result := make(map[string]*apitypes.SchemaFiles, len(grouped))
 	for ns, nsFiles := range grouped {

--- a/pkg/cmd/client/client.go
+++ b/pkg/cmd/client/client.go
@@ -62,9 +62,9 @@ type PlanOptions struct {
 
 // CallPlanAPI calls the plan API by reading .sql files from schemaDir.
 // Files are grouped by namespace: subdirectories become namespace keys,
-// flat files use "default".
+// flat files use the directory name as the namespace.
 func CallPlanAPI(endpoint, database, dbType, environment, schemaDir, repo string, pr int, opts ...PlanOptions) (*apitypes.PlanResponse, error) {
-	schemaFiles, err := ReadSchemaFiles(schemaDir)
+	schemaFiles, err := ReadSchemaFiles(schemaDir, environment)
 	if err != nil {
 		return nil, fmt.Errorf("read schema files: %w", err)
 	}
@@ -203,7 +203,11 @@ func CheckActiveSchemaChange(endpoint, database, environment string) (*ActiveSch
 // Subdirectories become namespace keys; flat files use the directory name as the
 // namespace (the MySQL database name). Only one level of subdirectories is
 // supported (matching the webhook path behavior).
-func ReadSchemaFiles(dir string) (map[string]*apitypes.SchemaFiles, error) {
+//
+// The environment parameter enables $ENV substitution in namespace names.
+// If non-empty, any "$ENV" in directory names or the default namespace is
+// replaced with the environment value (e.g., "bikeshare_$ENV" → "bikeshare_staging").
+func ReadSchemaFiles(dir string, environment string) (map[string]*apitypes.SchemaFiles, error) {
 	// Collect all files as relativePath → content
 	rawFiles := make(map[string]string)
 
@@ -257,7 +261,7 @@ func ReadSchemaFiles(dir string) (map[string]*apitypes.SchemaFiles, error) {
 
 	// Group by namespace using the shared helper.
 	// For flat files, the directory name is the database name.
-	grouped, err := schema.GroupFilesByNamespace(rawFiles, filepath.Base(dir))
+	grouped, err := schema.GroupFilesByNamespace(rawFiles, filepath.Base(dir), environment)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/client/client_test.go
+++ b/pkg/cmd/client/client_test.go
@@ -19,7 +19,7 @@ func TestReadSchemaFiles_RegularDirectories(t *testing.T) {
 	require.NoError(t, os.MkdirAll(filepath.Join(dir, "ks_sharded"), 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "ks_sharded", "orders.sql"), []byte("CREATE TABLE orders (id INT)"), 0o644))
 
-	result, err := ReadSchemaFiles(dir)
+	result, err := ReadSchemaFiles(dir, "")
 	require.NoError(t, err)
 
 	require.Contains(t, result, "ks_unsharded")
@@ -40,7 +40,7 @@ func TestReadSchemaFiles_SymlinkedDirectories(t *testing.T) {
 	symlinkDir := filepath.Join(dir, "ks_symlink")
 	require.NoError(t, os.Symlink(realDir, symlinkDir))
 
-	result, err := ReadSchemaFiles(dir)
+	result, err := ReadSchemaFiles(dir, "")
 	require.NoError(t, err)
 
 	// Both the real directory and the symlink should be read
@@ -66,7 +66,7 @@ func TestReadSchemaFiles_MixedRealAndSymlinked(t *testing.T) {
 	require.NoError(t, os.Symlink(shardedDir, filepath.Join(dir, "commerce_sharded_001")))
 	require.NoError(t, os.Symlink(shardedDir, filepath.Join(dir, "commerce_sharded_002")))
 
-	result, err := ReadSchemaFiles(dir)
+	result, err := ReadSchemaFiles(dir, "")
 	require.NoError(t, err)
 
 	// All four keyspaces should be present
@@ -89,7 +89,7 @@ func TestReadSchemaFiles_SkipsNonSchemaFiles(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "mydb", "README.md"), []byte("ignore me"), 0o644))
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "mydb", "vschema.json"), []byte("{}"), 0o644))
 
-	result, err := ReadSchemaFiles(dir)
+	result, err := ReadSchemaFiles(dir, "")
 	require.NoError(t, err)
 
 	require.Contains(t, result, "mydb")

--- a/pkg/github/schema.go
+++ b/pkg/github/schema.go
@@ -58,7 +58,7 @@ func (ic *InstallationClient) CreateSchemaRequestFromPR(ctx context.Context, rep
 	}
 
 	// Group files by keyspace/namespace
-	schemaFiles, err := groupFilesByNamespace(files, configDir)
+	schemaFiles, err := groupFilesByNamespace(files, configDir, environment)
 	if err != nil {
 		return nil, err
 	}
@@ -79,7 +79,7 @@ func (ic *InstallationClient) CreateSchemaRequestFromPR(ctx context.Context, rep
 // Files in namespace subdirectories (schema/namespace/table.sql) use the
 // subdirectory name as the namespace. Flat files (schema/table.sql) use the
 // schema directory name as the namespace (the MySQL database name).
-func groupFilesByNamespace(files []GitHubFile, schemaPath string) (map[string]*ternv1.SchemaFiles, error) {
+func groupFilesByNamespace(files []GitHubFile, schemaPath, environment string) (map[string]*ternv1.SchemaFiles, error) {
 	// Build relativePath → content map for the shared helper.
 	// file.Path is the full path (e.g., "schema/payments/transactions.sql"),
 	// so trimming schemaPath+"/" gives the relative path ("payments/transactions.sql"
@@ -94,7 +94,7 @@ func groupFilesByNamespace(files []GitHubFile, schemaPath string) (map[string]*t
 		rawFiles[relPath] = file.Content
 	}
 
-	grouped, err := schema.GroupFilesByNamespace(rawFiles, path.Base(schemaPath))
+	grouped, err := schema.GroupFilesByNamespace(rawFiles, path.Base(schemaPath), environment)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/github/schema_test.go
+++ b/pkg/github/schema_test.go
@@ -21,7 +21,7 @@ func TestGroupFilesByNamespace_FlatLayout_UsesDirectoryName(t *testing.T) {
 		{Path: "schema/payments/refunds.sql", Name: "refunds.sql", Content: "CREATE TABLE refunds (...);"},
 	}
 
-	result, err := groupFilesByNamespace(files, "schema/payments")
+	result, err := groupFilesByNamespace(files, "schema/payments", "development")
 
 	require.NoError(t, err)
 	require.Len(t, result, 1)
@@ -45,7 +45,7 @@ func TestGroupFilesByNamespace_FlatLayout_IssueScenario(t *testing.T) {
 		{Path: "schema/aurora_coffeeshop_exemplar/customers.sql", Name: "customers.sql", Content: "CREATE TABLE customers (...);"},
 	}
 
-	result, err := groupFilesByNamespace(files, "schema/aurora_coffeeshop_exemplar")
+	result, err := groupFilesByNamespace(files, "schema/aurora_coffeeshop_exemplar", "development")
 
 	require.NoError(t, err)
 	require.Len(t, result, 1)
@@ -62,7 +62,7 @@ func TestGroupFilesByNamespace_FlatLayout_TopLevelSchemaDir(t *testing.T) {
 		{Path: "schema/orders.sql", Name: "orders.sql", Content: "CREATE TABLE orders (...);"},
 	}
 
-	result, err := groupFilesByNamespace(files, "schema")
+	result, err := groupFilesByNamespace(files, "schema", "development")
 
 	require.NoError(t, err)
 	require.Len(t, result, 1)
@@ -88,7 +88,7 @@ func TestGroupFilesByNamespace_SubdirLayout_MultipleNamespaces(t *testing.T) {
 		{Path: "schema/payments_audit/audit_log.sql", Name: "audit_log.sql", Content: "CREATE TABLE audit_log (...);"},
 	}
 
-	result, err := groupFilesByNamespace(files, "schema")
+	result, err := groupFilesByNamespace(files, "schema", "development")
 	require.NoError(t, err)
 
 	require.Len(t, result, 2)
@@ -106,7 +106,7 @@ func TestGroupFilesByNamespace_SubdirLayout_Monorepo(t *testing.T) {
 		{Path: "payments-service/mysql/schema/payments_audit/audit_log.sql", Name: "audit_log.sql", Content: "CREATE TABLE audit_log (...);"},
 	}
 
-	result, err := groupFilesByNamespace(files, "payments-service/mysql/schema")
+	result, err := groupFilesByNamespace(files, "payments-service/mysql/schema", "development")
 	require.NoError(t, err)
 
 	require.Len(t, result, 2)
@@ -123,7 +123,7 @@ func TestGroupFilesByNamespace_SubdirLayout_VitessKeyspaces(t *testing.T) {
 		{Path: "schema/customers/users.sql", Name: "users.sql", Content: "CREATE TABLE users (...);"},
 	}
 
-	result, err := groupFilesByNamespace(files, "schema")
+	result, err := groupFilesByNamespace(files, "schema", "development")
 	require.NoError(t, err)
 
 	require.Len(t, result, 2)
@@ -142,7 +142,7 @@ func TestGroupFilesByNamespace_MixedLayout_Rejected(t *testing.T) {
 		{Path: "schema/payments/transactions.sql", Name: "transactions.sql", Content: "CREATE TABLE transactions (...);"},
 	}
 
-	_, err := groupFilesByNamespace(files, "schema")
+	_, err := groupFilesByNamespace(files, "schema", "development")
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "both flat files and namespace subdirectories")

--- a/pkg/schema/namespace.go
+++ b/pkg/schema/namespace.go
@@ -37,7 +37,14 @@ import (
 // The input map keys are relative paths (e.g., "users.sql" or "payments/users.sql")
 // and values are file contents. Only .sql files and vschema.json are included;
 // other files (like schemabot.yaml) are skipped.
-func GroupFilesByNamespace(files map[string]string, defaultNamespace string) (SchemaFiles, error) {
+//
+// The environment parameter enables $ENV substitution in namespace names.
+// If environment is non-empty, any literal "$ENV" in namespace keys (from
+// directory names or defaultNamespace) is replaced with the environment value.
+// This allows a single directory like "bikeshare_$ENV/" to resolve to
+// "bikeshare_staging" or "bikeshare_production" depending on the target.
+// If environment is empty, "$ENV" is left as-is.
+func GroupFilesByNamespace(files map[string]string, defaultNamespace string, environment string) (SchemaFiles, error) {
 	result := make(SchemaFiles)
 	var hasFlatFile, hasNamespacedFile bool
 
@@ -55,6 +62,11 @@ func GroupFilesByNamespace(files map[string]string, defaultNamespace string) (Sc
 			hasFlatFile = true
 		} else {
 			hasNamespacedFile = true
+		}
+
+		// Replace $ENV in namespace keys when environment is known.
+		if environment != "" {
+			namespace = strings.ReplaceAll(namespace, "$ENV", environment)
 		}
 
 		if result[namespace] == nil {

--- a/pkg/schema/namespace_test.go
+++ b/pkg/schema/namespace_test.go
@@ -20,7 +20,7 @@ func TestGroupFilesByNamespace_FlatLayout_UsesDirectoryName(t *testing.T) {
 		"customers.sql": "CREATE TABLE customers (...);",
 	}
 
-	result, err := GroupFilesByNamespace(files, "aurora_coffeeshop_exemplar")
+	result, err := GroupFilesByNamespace(files, "aurora_coffeeshop_exemplar", "development")
 	require.NoError(t, err)
 
 	require.Len(t, result, 1)
@@ -39,7 +39,7 @@ func TestGroupFilesByNamespace_FlatLayout_SkipsNonSchemaFiles(t *testing.T) {
 		".gitkeep":       "",
 	}
 
-	result, err := GroupFilesByNamespace(files, "myapp")
+	result, err := GroupFilesByNamespace(files, "myapp", "development")
 	require.NoError(t, err)
 	require.Len(t, result, 1)
 	assert.Len(t, result["myapp"].Files, 1)
@@ -53,7 +53,7 @@ func TestGroupFilesByNamespace_FlatLayout_IncludesVSchemaJSON(t *testing.T) {
 		"vschema.json": `{"sharded": true}`,
 	}
 
-	result, err := GroupFilesByNamespace(files, "commerce")
+	result, err := GroupFilesByNamespace(files, "commerce", "development")
 	require.NoError(t, err)
 	require.Len(t, result, 1)
 	assert.Len(t, result["commerce"].Files, 2)
@@ -76,7 +76,7 @@ func TestGroupFilesByNamespace_SubdirLayout_UsesSubdirNames(t *testing.T) {
 		"payments_audit/audit_log.sql": "CREATE TABLE audit_log (...);",
 	}
 
-	result, err := GroupFilesByNamespace(files, "ignored_because_subdirs_exist")
+	result, err := GroupFilesByNamespace(files, "ignored_because_subdirs_exist", "development")
 	require.NoError(t, err)
 	require.Len(t, result, 2)
 	assert.Contains(t, result, "payments")
@@ -93,7 +93,7 @@ func TestGroupFilesByNamespace_SubdirLayout_VSchemaInSubdir(t *testing.T) {
 		"customers/users.sql":   "CREATE TABLE users (...);",
 	}
 
-	result, err := GroupFilesByNamespace(files, "ignored")
+	result, err := GroupFilesByNamespace(files, "ignored", "development")
 	require.NoError(t, err)
 	require.Len(t, result, 2)
 	assert.Len(t, result["commerce"].Files, 2)
@@ -110,7 +110,7 @@ func TestGroupFilesByNamespace_MixedLayout_Rejected(t *testing.T) {
 		"payments/transactions.sql": "CREATE TABLE transactions (...);",
 	}
 
-	_, err := GroupFilesByNamespace(files, "mydb")
+	_, err := GroupFilesByNamespace(files, "mydb", "development")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "both flat files and namespace subdirectories")
 }
@@ -123,7 +123,7 @@ func TestGroupFilesByNamespace_SubdirLayout_NameMatchesDefault(t *testing.T) {
 		"other/items.sql":   "CREATE TABLE items (...);",
 	}
 
-	result, err := GroupFilesByNamespace(files, "schema")
+	result, err := GroupFilesByNamespace(files, "schema", "development")
 	require.NoError(t, err)
 	require.Len(t, result, 2)
 	assert.Contains(t, result, "schema")
@@ -133,7 +133,7 @@ func TestGroupFilesByNamespace_SubdirLayout_NameMatchesDefault(t *testing.T) {
 // Edge cases.
 
 func TestGroupFilesByNamespace_EmptyInput(t *testing.T) {
-	result, err := GroupFilesByNamespace(map[string]string{}, "mydb")
+	result, err := GroupFilesByNamespace(map[string]string{}, "mydb", "development")
 	require.NoError(t, err)
 	assert.Empty(t, result)
 }
@@ -145,7 +145,71 @@ func TestGroupFilesByNamespace_OnlyNonSchemaFiles(t *testing.T) {
 		"README.md":      "# docs",
 	}
 
-	result, err := GroupFilesByNamespace(files, "myapp")
+	result, err := GroupFilesByNamespace(files, "myapp", "development")
 	require.NoError(t, err)
 	assert.Empty(t, result)
+}
+
+// $ENV substitution tests.
+
+func TestGroupFilesByNamespace_EnvSubstitution_SubdirLayout(t *testing.T) {
+	// Subdirectory named "bikeshare_$ENV" becomes "bikeshare_staging" when
+	// environment is "staging".
+	files := map[string]string{
+		"bikeshare_$ENV/bikes.sql":    "CREATE TABLE bikes (...);",
+		"bikeshare_$ENV/stations.sql": "CREATE TABLE stations (...);",
+	}
+
+	result, err := GroupFilesByNamespace(files, "ignored", "staging")
+	require.NoError(t, err)
+
+	require.Len(t, result, 1)
+	assert.Contains(t, result, "bikeshare_staging")
+	assert.Len(t, result["bikeshare_staging"].Files, 2)
+	assert.Equal(t, "CREATE TABLE bikes (...);", result["bikeshare_staging"].Files["bikes.sql"])
+	assert.Equal(t, "CREATE TABLE stations (...);", result["bikeshare_staging"].Files["stations.sql"])
+}
+
+func TestGroupFilesByNamespace_EnvSubstitution_FlatLayout(t *testing.T) {
+	// Flat layout where the defaultNamespace (directory name) contains $ENV.
+	// With environment="production", "bikeshare_$ENV" → "bikeshare_production".
+	files := map[string]string{
+		"bikes.sql":    "CREATE TABLE bikes (...);",
+		"stations.sql": "CREATE TABLE stations (...);",
+	}
+
+	result, err := GroupFilesByNamespace(files, "bikeshare_$ENV", "production")
+	require.NoError(t, err)
+
+	require.Len(t, result, 1)
+	assert.Contains(t, result, "bikeshare_production")
+	assert.Len(t, result["bikeshare_production"].Files, 2)
+}
+
+func TestGroupFilesByNamespace_EnvSubstitution_EmptyEnvNoChange(t *testing.T) {
+	// When environment is empty, $ENV is left as-is (no substitution).
+	files := map[string]string{
+		"bikeshare_$ENV/bikes.sql": "CREATE TABLE bikes (...);",
+	}
+
+	result, err := GroupFilesByNamespace(files, "ignored", "")
+	require.NoError(t, err)
+
+	require.Len(t, result, 1)
+	assert.Contains(t, result, "bikeshare_$ENV")
+}
+
+func TestGroupFilesByNamespace_EnvSubstitution_MultipleNamespaces(t *testing.T) {
+	// Multiple subdirectories, some with $ENV, some without.
+	files := map[string]string{
+		"app_$ENV/users.sql":   "CREATE TABLE users (...);",
+		"analytics/events.sql": "CREATE TABLE events (...);",
+	}
+
+	result, err := GroupFilesByNamespace(files, "ignored", "staging")
+	require.NoError(t, err)
+
+	require.Len(t, result, 2)
+	assert.Contains(t, result, "app_staging")
+	assert.Contains(t, result, "analytics")
 }


### PR DESCRIPTION
## Summary

Allow `$ENV` in schema directory names so a single directory works across environments where the MySQL schema name includes an environment suffix.

Some infrastructure conventions name schemas with environment suffixes (e.g., say we have a test app named `bikeshare` with schema names `bikeshare_staging` in staging and `bikeshare_production` in production). Previously, this required separate directories or manual workarounds. Now the directory can be named `bikeshare_$ENV/` and the namespace resolves automatically based on `-e`.

## Example

```
myapp/schema/
├── schemabot.yaml          # database: bikeshare, type: mysql
└── bikeshare_$ENV/
    ├── bikes.sql
    └── stations.sql
```

```bash
schemabot plan -s myapp/schema -e staging     # namespace → bikeshare_staging
schemabot plan -s myapp/schema -e production  # namespace → bikeshare_production
```

The `database:` field in `schemabot.yaml` remains the routing identifier (which cluster to target). The namespace (MySQL schema name) comes from the directory name with `$ENV` substituted.

## Rules

- `$ENV` is replaced with the environment value from `-e`
- If no environment is specified, `$ENV` is left as-is
- Works in both flat layout (directory name) and subdirectory layout
- Can mix `$ENV` directories with regular directories

🤖 Generated with [Claude Code](https://claude.com/claude-code)