### PR TITLE
feat(github): require passing PR checks before apply

### DIFF
--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -2030,7 +2030,7 @@ ALTER TABLE `users` ADD INDEX `idx_email`(`email`);
 ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
 ```
 
-*Apply ID: `apply-a1b2c3d4e5f6`*
+_Apply ID: apply-a1b2c3d4e5f6_
 
 </details>
 
@@ -2165,7 +2165,7 @@ ALTER TABLE `notifications` ADD INDEX `idx_user_status`(`user_id`, `status`);
 ```
 
 </details>
-*Apply ID: `apply-a1b2c3d4e5f6`*
+_Apply ID: apply-a1b2c3d4e5f6_
 
 </details>
 
@@ -2335,7 +2335,7 @@ ALTER TABLE `addresses` ADD INDEX `idx_zip`(`zip_code`);
 ALTER TABLE `events` ADD INDEX `idx_created_at`(`created_at`);
 ```
 
-*Apply ID: `apply-a1b2c3d4e5f6`*
+_Apply ID: apply-a1b2c3d4e5f6_
 </details>
 
 ### CLI Output
@@ -4166,6 +4166,7 @@ schemabot apply -e staging
 ```
 
 </details>
+
 ## Sequential Mode (CLI)
 
 <details>
@@ -4397,6 +4398,7 @@ Use 'schemabot start' to resume from checkpoint.
 ```
 </details>
 
+
 ## Defer Cutover (CLI)
 
 <details>
@@ -4608,6 +4610,7 @@ Cutover in progress. This typically completes within seconds.
 Tables are being renamed atomically...
 ```
 </details>
+
 
 ## Lint & Unsafe (CLI)
 

--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -1111,7 +1111,7 @@ Schema changes require approval from a code owner before applying.
 
 ### Error
 
-> Review gate check failed: expand team @acme/schema-reviewers: API rate limit exceeded. An admin can run schema changes directly via the CLI to bypass the review gate.
+> Review gate check failed: expand team @acme/schema-reviewers: API rate limit exceeded.
 </details>
 
 ### CLI Output
@@ -4118,7 +4118,7 @@ Schema changes require approval from a code owner before applying.
 
 ### Error
 
-> Review gate check failed: expand team @acme/schema-reviewers: API rate limit exceeded. An admin can run schema changes directly via the CLI to bypass the review gate.
+> Review gate check failed: expand team @acme/schema-reviewers: API rate limit exceeded.
 
 </details>
 

--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -3812,6 +3812,360 @@ No schema changes found for database 'new-db'
 ```
 </details>
 
+<details>
+<summary><a name="apply-plan-lock--confirm"></a><strong>Apply Plan (Lock + Confirm)</strong></summary>
+
+
+## MySQL Schema Change Plan (Apply)
+
+**Database**: `testapp` | **Schema Name**: `testapp` | **Environment**: `staging`
+
+*Requested by @aparajon at 2026-01-01 00:00:00 UTC*
+
+🔒 **Lock acquired by** `acme/myapp#42` at 2026-03-14 10:30:00 UTC
+
+```sql
+CREATE TABLE `users` (
+    `id` bigint unsigned NOT NULL AUTO_INCREMENT,
+    `email` varchar(255) NOT NULL,
+    `created_at` timestamp DEFAULT current_timestamp(),
+    PRIMARY KEY(`id`),
+    INDEX `idx_email`(`email`)
+) ENGINE InnoDB,
+  CHARSET utf8mb4,
+  COLLATE utf8mb4_0900_ai_ci;
+
+CREATE TABLE `orders` (
+    `id` bigint unsigned NOT NULL AUTO_INCREMENT,
+    `user_id` bigint NOT NULL,
+    `total_cents` bigint NOT NULL,
+    `status` varchar(50) NOT NULL DEFAULT 'pending',
+    PRIMARY KEY(`id`),
+    INDEX `idx_user_id`(`user_id`)
+) ENGINE InnoDB,
+  CHARSET utf8mb4,
+  COLLATE utf8mb4_0900_ai_ci;
+
+ALTER TABLE `products` ADD INDEX `idx_category_price`(`category`, `price`);
+```
+
+📋 **Plan**: **2** tables to create, **1** table to alter
+
+
+---
+
+💡 **To apply** all schema changes from this PR, comment:
+```
+schemabot apply-confirm -e staging
+```
+
+🔓 To discard this plan and unlock, comment:
+```
+schemabot unlock
+```
+
+
+</details>
+
+<details>
+<summary><a name="apply-plan-with-options"></a><strong>Apply Plan (With Options)</strong></summary>
+
+
+## MySQL Schema Change Plan (Apply)
+
+**Database**: `testapp` | **Schema Name**: `testapp` | **Environment**: `staging`
+
+*Requested by @aparajon at 2026-01-01 00:00:00 UTC*
+
+🔒 **Lock acquired by** `acme/myapp#42` at 2026-03-14 10:30:00 UTC
+
+```sql
+CREATE TABLE `users` (
+    `id` bigint unsigned NOT NULL AUTO_INCREMENT,
+    `email` varchar(255) NOT NULL,
+    `created_at` timestamp DEFAULT current_timestamp(),
+    PRIMARY KEY(`id`),
+    INDEX `idx_email`(`email`)
+) ENGINE InnoDB,
+  CHARSET utf8mb4,
+  COLLATE utf8mb4_0900_ai_ci;
+
+CREATE TABLE `orders` (
+    `id` bigint unsigned NOT NULL AUTO_INCREMENT,
+    `user_id` bigint NOT NULL,
+    `total_cents` bigint NOT NULL,
+    `status` varchar(50) NOT NULL DEFAULT 'pending',
+    PRIMARY KEY(`id`),
+    INDEX `idx_user_id`(`user_id`)
+) ENGINE InnoDB,
+  CHARSET utf8mb4,
+  COLLATE utf8mb4_0900_ai_ci;
+
+ALTER TABLE `products` ADD INDEX `idx_category_price`(`category`, `price`);
+```
+
+📋 **Plan**: **2** tables to create, **1** table to alter
+
+
+**Options**: ⏸️ Defer Cutover | ⏩ Skip Revert
+
+---
+
+💡 **To apply** all schema changes from this PR, comment:
+```
+schemabot apply-confirm -e staging --defer-cutover --skip-revert
+```
+
+🔓 To discard this plan and unlock, comment:
+```
+schemabot unlock
+```
+
+
+</details>
+
+<details>
+<summary><a name="apply-started"></a><strong>Apply Started</strong></summary>
+
+
+## Schema Change In Progress
+
+**Database**: `testapp` | **Environment**: `staging` | **Apply ID**: `apply-a1b2c3d4e5f6`
+
+*Applied by @aparajon at 2026-01-01 00:00:00 UTC*
+
+Schema changes are being applied. Progress updates will be posted as new comments.
+
+
+</details>
+
+<details>
+<summary><a name="unlock-success"></a><strong>Unlock Success</strong></summary>
+
+
+## 🔓 Lock Released
+
+**Database**: `testapp` | **Environment**: `staging`
+
+*Released by @aparajon at 2026-01-01 00:00:00 UTC*
+
+The database is now available for schema changes.
+
+
+</details>
+
+<details>
+<summary><a name="apply-blocked-by-other-pr"></a><strong>Apply Blocked By Other PR</strong></summary>
+
+
+## 🔒 Apply Blocked
+
+**Database**: `testapp` | **Environment**: `staging`
+
+*Requested by @aparajon at 2026-01-01 00:00:00 UTC*
+
+Another PR currently holds the lock for this database.
+
+**Locked by**: [block/myapp#42](https://github.com/block/myapp/pull/42)
+**Since**: 2026-03-15 12:30:00 UTC
+
+Wait for the other PR to complete or ask the lock holder to run `schemabot unlock`.
+
+
+</details>
+
+<details>
+<summary><a name="apply-blocked-by-cli"></a><strong>Apply Blocked By CLI</strong></summary>
+
+
+## 🔒 Apply Blocked
+
+**Database**: `testapp` | **Environment**: `staging`
+
+*Requested by @aparajon at 2026-01-01 00:00:00 UTC*
+
+A CLI session currently holds the lock for this database.
+
+**Locked by**: `cli:aparajon@macbook.local`
+**Since**: 2026-03-15 14:00:00 UTC
+
+Ask the lock holder to run `schemabot unlock` from their CLI, or force-unlock with:
+```
+schemabot unlock -d testapp -e staging --force
+```
+
+
+</details>
+
+<details>
+<summary><a name="apply-already-in-progress"></a><strong>Apply Already In Progress</strong></summary>
+
+
+## ⚠️ Apply Already In Progress
+
+**Database**: `testapp` | **Environment**: `staging`
+
+*Requested by @aparajon at 2026-01-01 00:00:00 UTC*
+
+An apply is already running for this PR (apply ID: `apply-a1b2c3d4e5f6`, state: `running`).
+
+Wait for it to complete or stop it first.
+
+
+</details>
+
+<details>
+<summary><a name="no-lock-found"></a><strong>No Lock Found</strong></summary>
+
+
+## 🔒 No Lock Found
+
+**Database**: `testapp` | **Environment**: `staging`
+
+No apply lock is held for this database. Run `apply` first to generate a plan and acquire the lock.
+
+```
+schemabot apply -e staging
+```
+
+
+</details>
+
+<details>
+<summary><a name="blocked-by-prior-env-pending"></a><strong>Blocked By Prior Env (Pending)</strong></summary>
+
+
+## ❌ Apply Blocked
+
+**Database**: `testapp` | **Environment**: `production`
+
+Staging has pending changes. Apply staging first before applying to production.
+
+```
+schemabot apply -e staging
+```
+
+
+</details>
+
+<details>
+<summary><a name="blocked-by-prior-env-failed"></a><strong>Blocked By Prior Env (Failed)</strong></summary>
+
+
+## ❌ Apply Blocked
+
+**Database**: `testapp` | **Environment**: `production`
+
+Staging failed. Fix the issue and re-apply staging before applying to production.
+
+```
+schemabot apply -e staging
+```
+
+
+</details>
+
+<details>
+<summary><a name="blocked-by-prior-env-in-progress"></a><strong>Blocked By Prior Env (In Progress)</strong></summary>
+
+
+## ⏳ Apply Blocked
+
+**Database**: `testapp` | **Environment**: `production`
+
+Staging is currently in progress. Wait for it to complete before applying to production.
+
+Once staging completes, retry:
+```
+schemabot apply -e production
+```
+
+
+</details>
+
+<details>
+<summary><a name="review-required-codeowners"></a><strong>Review Required (Codeowners)</strong></summary>
+
+
+## Review Required
+
+**Database**: `testapp` | **Environment**: `staging`
+
+*Requested by @aparajon at 2026-01-01 00:00:00 UTC*
+
+Schema changes require approval from a code owner before applying.
+
+**Code owners** (from CODEOWNERS):
+- @acme/schema-reviewers
+- @jdoe
+
+### Next steps
+1. Request a review from a code owner above
+2. Once approved, run `schemabot apply -e staging` again
+
+
+</details>
+
+<details>
+<summary><a name="review-gate-error-failclosed"></a><strong>Review Gate Error (Fail-closed)</strong></summary>
+
+
+## ❌ Apply Failed
+
+**Environment**: `staging`
+
+*Requested by @aparajon at  UTC*
+
+### Error
+
+> Review gate check failed: expand team @acme/schema-reviewers: API rate limit exceeded. An admin can run schema changes directly via the CLI to bypass the review gate.
+
+</details>
+
+<details>
+<summary><a name="checks-gate-failing"></a><strong>Checks Gate: Failing</strong></summary>
+
+
+## ❌ Apply Blocked
+
+**Environment**: `staging`
+
+Cannot apply while PR checks are failing:
+
+| Check | Status |
+|-------|--------|
+| `CI / unit-tests` | failure |
+| `CI / lint` | timed_out |
+
+Fix the failing checks and retry:
+```
+schemabot apply -e staging
+```
+
+
+</details>
+
+<details>
+<summary><a name="checks-gate-in-progress"></a><strong>Checks Gate: In Progress</strong></summary>
+
+
+## ⏳ Apply Blocked
+
+**Environment**: `staging`
+
+Cannot apply while PR checks are still running:
+
+| Check | Status |
+|-------|--------|
+| `CI / unit-tests` | in_progress |
+| `CI / integration-tests` | queued |
+
+Wait for checks to complete and retry:
+```
+schemabot apply -e staging
+```
+
+</details>
 ## Sequential Mode (CLI)
 
 <details>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -113,7 +113,7 @@ A check is considered "failing" if its status is `completed` and its conclusion 
 
 When checks are failing, SchemaBot posts a comment listing the failing checks and instructs the user to fix them before retrying.
 
-If the GitHub API is unreachable when checking statuses, SchemaBot logs a warning and allows the apply to proceed (graceful degradation).
+If the GitHub API is unreachable when checking statuses, the apply is blocked (fail-closed). SchemaBot posts a comment explaining the error and suggests retrying.
 
 Set `require_passing_checks: false` to disable this gate.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -100,6 +100,23 @@ When a webhook arrives from an unlisted repository:
 
 If `repos` is not configured or empty, all repositories are allowed.
 
+## PR Checks Gate
+
+By default, SchemaBot blocks `apply` and `apply-confirm` when non-SchemaBot PR checks are failing. This prevents applying schema changes on a PR with broken CI, linters, or security scans.
+
+```yaml
+# Block apply when PR checks are failing (default: true)
+require_passing_checks: true
+```
+
+A check is considered "failing" if its status is `completed` and its conclusion is `failure`, `error`, or `timed_out`. Checks that are still running (`in_progress`, `queued`) do not block apply. Checks with conclusion `neutral` or `skipped` are ignored. SchemaBot's own checks (names starting with "SchemaBot") are always excluded.
+
+When checks are failing, SchemaBot posts a comment listing the failing checks and instructs the user to fix them before retrying.
+
+If the GitHub API is unreachable when checking statuses, SchemaBot logs a warning and allows the apply to proceed (graceful degradation).
+
+Set `require_passing_checks: false` to disable this gate.
+
 ## Multi-Environment Deployment
 
 For organizations that need isolated infrastructure per environment (e.g., separate staging and production deployments with their own GitHub Apps and databases), SchemaBot supports scoping each instance to a subset of environments using `allowed_environments`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -109,7 +109,7 @@ By default, SchemaBot blocks `apply` and `apply-confirm` when non-SchemaBot PR c
 require_passing_checks: true
 ```
 
-A check is considered "failing" if its status is `completed` and its conclusion is `failure`, `error`, or `timed_out`. Checks that are still running (`in_progress`, `queued`) do not block apply. Checks with conclusion `neutral` or `skipped` are ignored. SchemaBot's own checks (names starting with "SchemaBot") are always excluded.
+Apply is blocked in two cases: checks that have **failed** (`failure`, `error`, `timed_out`) and checks that are **still running** (`in_progress`, `queued`, `pending`). Each case shows a distinct message — failing checks prompt the user to fix them, while in-progress checks prompt the user to wait. Checks with conclusion `neutral` or `skipped` are ignored. SchemaBot's own checks (names starting with "SchemaBot") are always excluded.
 
 When checks are failing, SchemaBot posts a comment listing the failing checks and instructs the user to fix them before retrying.
 

--- a/docs/review-gate.md
+++ b/docs/review-gate.md
@@ -29,7 +29,7 @@ When enabled, `schemabot apply` and `schemabot apply-confirm` check for PR appro
 
 3. **Self-approval blocked**: The PR author's own approval never counts, even if they're a code owner.
 
-4. **Fail closed**: If the GitHub API fails during the review check, SchemaBot blocks the apply and posts an error comment. Admins can run schema changes directly via the CLI to bypass the review gate.
+4. **Fail closed**: If the GitHub API fails during the review check, SchemaBot blocks the apply and posts an error comment.
 
 If the gate blocks, SchemaBot posts a comment listing the required reviewers and instructions.
 

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -43,6 +43,15 @@ type ServerConfig struct {
 	// When empty or nil, all environments are allowed (backwards compatible).
 	AllowedEnvironments []string `yaml:"allowed_environments"`
 
+	// RequirePassingChecks blocks apply when non-SchemaBot PR checks are failing.
+	// When enabled (default), SchemaBot verifies that all other checks (CI, linters,
+	// security scans) have passed before executing a schema change. Checks with
+	// conclusion "neutral" or "skipped" are ignored. SchemaBot's own checks are
+	// excluded from the evaluation.
+	//
+	// Defaults to true when not configured (nil = enabled).
+	RequirePassingChecks *bool `yaml:"require_passing_checks"`
+
 	// RespondToUnscoped controls whether this instance responds to commands
 	// that are not scoped to a specific environment. In multi-instance
 	// deployments where each repo has multiple GitHub Apps installed, set
@@ -334,6 +343,15 @@ func (c *ServerConfig) ShouldRespondToUnscoped() bool {
 		return true
 	}
 	return *c.RespondToUnscoped
+}
+
+// ShouldRequirePassingChecks returns whether apply should be blocked when
+// non-SchemaBot PR checks are failing. Defaults to true when not configured.
+func (c *ServerConfig) ShouldRequirePassingChecks() bool {
+	if c == nil || c.RequirePassingChecks == nil {
+		return true
+	}
+	return *c.RequirePassingChecks
 }
 
 // StorageDSN returns the resolved storage DSN.

--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -484,6 +484,46 @@ allowed_environments:
 	})
 }
 
+func TestServerConfig_ShouldRequirePassingChecks(t *testing.T) {
+	t.Run("nil receiver defaults to true", func(t *testing.T) {
+		var cfg *ServerConfig
+		assert.True(t, cfg.ShouldRequirePassingChecks())
+	})
+
+	t.Run("nil field defaults to true", func(t *testing.T) {
+		cfg := &ServerConfig{}
+		assert.True(t, cfg.ShouldRequirePassingChecks())
+	})
+
+	t.Run("explicitly true", func(t *testing.T) {
+		cfg := &ServerConfig{RequirePassingChecks: new(true)}
+		assert.True(t, cfg.ShouldRequirePassingChecks())
+	})
+
+	t.Run("explicitly false", func(t *testing.T) {
+		cfg := &ServerConfig{RequirePassingChecks: new(false)}
+		assert.False(t, cfg.ShouldRequirePassingChecks())
+	})
+
+	t.Run("YAML deserialization", func(t *testing.T) {
+		dir := t.TempDir()
+		configPath := filepath.Join(dir, "config.yaml")
+		content := `
+tern_deployments:
+  default:
+    staging: "localhost:9090"
+require_passing_checks: false
+`
+		err := os.WriteFile(configPath, []byte(content), 0644)
+		require.NoError(t, err)
+
+		cfg, err := LoadServerConfigFromFile(configPath)
+		require.NoError(t, err)
+
+		assert.False(t, cfg.ShouldRequirePassingChecks())
+	})
+}
+
 func TestGitHubConfig_ResolveWebhookSecret(t *testing.T) {
 	t.Run("resolves direct value", func(t *testing.T) {
 		g := GitHubConfig{WebhookSecret: "my-secret"}

--- a/pkg/cmd/commands/preview.go
+++ b/pkg/cmd/commands/preview.go
@@ -90,7 +90,8 @@ func (cmd *PreviewCmd) Run(g *Globals) error {
 		templates.PreviewCommentApplyWaiting, templates.PreviewCommentUnlock,
 		templates.PreviewCommentApplyBlocked, templates.PreviewCommentApplyBlockedCLI,
 		templates.PreviewCommentApplyActive,
-		templates.PreviewCommentApplyNoLock, templates.PreviewCommentApplyAllType:
+		templates.PreviewCommentApplyNoLock, templates.PreviewCommentApplyAllType,
+		templates.PreviewCommentChecksGateFailing, templates.PreviewCommentChecksGateInProgress:
 		templates.PreviewCLIOutput(previewType)
 	// Paired aggregate types (PR + CLI subsections)
 	case templates.PreviewCommentPlanAll, templates.PreviewCommentLockingAll,

--- a/pkg/cmd/templates/preview.go
+++ b/pkg/cmd/templates/preview.go
@@ -154,6 +154,8 @@ const (
 	PreviewCommentBlockedByPriorInProg PreviewType = "comment_blocked_prior_env_inprogress" // Blocked by staging (in progress)
 	PreviewCommentReviewRequired       PreviewType = "comment_review_required"              // Review gate: CODEOWNERS approval needed
 	PreviewCommentReviewGateError      PreviewType = "comment_review_gate_error"            // Review gate: fail-closed error
+	PreviewCommentChecksGateFailing    PreviewType = "comment_checks_gate_failing"          // Checks gate: failing CI/lint
+	PreviewCommentChecksGateInProgress PreviewType = "comment_checks_gate_in_progress"      // Checks gate: CI still running
 	PreviewCommentApplyAllType         PreviewType = "comment_apply_all"                    // Show all apply comment previews
 )
 
@@ -348,6 +350,16 @@ func PreviewCLIOutput(previewType PreviewType) {
 		fmt.Print(webhooktemplates.PreviewCommentReviewRequired())
 	case PreviewCommentReviewGateError:
 		fmt.Print(webhooktemplates.PreviewCommentReviewGateError())
+	case PreviewCommentChecksGateFailing:
+		fmt.Print(webhooktemplates.RenderApplyBlockedByFailingChecks("staging", []webhooktemplates.FailingCheck{
+			{Name: "CI / unit-tests", Conclusion: "failure"},
+			{Name: "CI / lint", Conclusion: "timed_out"},
+		}))
+	case PreviewCommentChecksGateInProgress:
+		fmt.Print(webhooktemplates.RenderApplyBlockedByInProgressChecks("staging", []webhooktemplates.FailingCheck{
+			{Name: "CI / unit-tests", Conclusion: "in_progress"},
+			{Name: "CI / integration-tests", Conclusion: "queued"},
+		}))
 	case PreviewCommentApplyAllType:
 		previewApplyCommandAllOutput()
 	// Paired aggregate previews (PR + CLI subsections)
@@ -944,6 +956,18 @@ func previewApplyCommandAllOutput() {
 		{"BLOCKED BY PRIOR ENV (IN PROGRESS)", func() { fmt.Print(webhooktemplates.PreviewCommentApplyBlockedByPriorEnvInProgress()) }},
 		{"REVIEW REQUIRED (CODEOWNERS)", func() { fmt.Print(webhooktemplates.PreviewCommentReviewRequired()) }},
 		{"REVIEW GATE ERROR (FAIL-CLOSED)", func() { fmt.Print(webhooktemplates.PreviewCommentReviewGateError()) }},
+		{"CHECKS GATE: FAILING", func() {
+			fmt.Print(webhooktemplates.RenderApplyBlockedByFailingChecks("staging", []webhooktemplates.FailingCheck{
+				{Name: "CI / unit-tests", Conclusion: "failure"},
+				{Name: "CI / lint", Conclusion: "timed_out"},
+			}))
+		}},
+		{"CHECKS GATE: IN PROGRESS", func() {
+			fmt.Print(webhooktemplates.RenderApplyBlockedByInProgressChecks("staging", []webhooktemplates.FailingCheck{
+				{Name: "CI / unit-tests", Conclusion: "in_progress"},
+				{Name: "CI / integration-tests", Conclusion: "queued"},
+			}))
+		}},
 	}
 
 	for i, s := range sections {

--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -332,8 +332,11 @@ func (ic *InstallationClient) GetPRCheckStatuses(ctx context.Context, repo strin
 
 	var statuses []PRCheckStatus
 
-	// Fetch check runs (Checks API)
+	// Fetch check runs (Checks API). Filter to "latest" to avoid stale reruns
+	// where an old failure could block apply even though the latest run passed.
+	latestFilter := "latest"
 	checkOpts := &gh.ListCheckRunsOptions{
+		Filter:      &latestFilter,
 		ListOptions: gh.ListOptions{PerPage: 100},
 	}
 	for {
@@ -356,7 +359,9 @@ func (ic *InstallationClient) GetPRCheckStatuses(ctx context.Context, repo strin
 		checkOpts.ListOptions.Page = resp.NextPage
 	}
 
-	// Fetch commit statuses (legacy Status API)
+	// Fetch commit statuses (legacy Status API). The API returns statuses
+	// newest-first, so deduplicate by context to keep only the latest per context.
+	seenContexts := make(map[string]bool)
 	statusOpts := &gh.ListOptions{PerPage: 100}
 	for {
 		repoStatuses, resp, err := ic.client.Repositories.ListStatuses(ctx, owner, repoName, ref, statusOpts)
@@ -364,7 +369,12 @@ func (ic *InstallationClient) GetPRCheckStatuses(ctx context.Context, repo strin
 			return nil, fmt.Errorf("list commit statuses for ref %s: %w", ref, err)
 		}
 		for _, s := range repoStatuses {
-			ctx := s.GetContext()
+			statusCtx := s.GetContext()
+			if seenContexts[statusCtx] {
+				continue
+			}
+			seenContexts[statusCtx] = true
+
 			// Map legacy status states to check run equivalents
 			ghState := s.GetState()
 			status := "completed"
@@ -374,10 +384,10 @@ func (ic *InstallationClient) GetPRCheckStatuses(ctx context.Context, repo strin
 				conclusion = ""
 			}
 			statuses = append(statuses, PRCheckStatus{
-				Name:        ctx,
+				Name:        statusCtx,
 				Status:      status,
 				Conclusion:  conclusion,
-				IsSchemaBot: strings.HasPrefix(strings.ToLower(ctx), "schemabot"),
+				IsSchemaBot: strings.HasPrefix(strings.ToLower(statusCtx), "schemabot"),
 			})
 		}
 		if resp.NextPage == 0 {

--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -316,6 +316,79 @@ func (ic *InstallationClient) FindCheckRunByName(ctx context.Context, repo, head
 	}, nil
 }
 
+// PRCheckStatus represents the status of a single PR check (check run or commit status).
+type PRCheckStatus struct {
+	Name        string
+	Status      string // "completed", "in_progress", "queued"
+	Conclusion  string // "success", "failure", "neutral", "skipped", etc.
+	IsSchemaBot bool   // true if this is a SchemaBot check
+}
+
+// GetPRCheckStatuses fetches all check runs and commit statuses for a ref,
+// combining them into a unified list. SchemaBot's own checks are marked with
+// IsSchemaBot=true so callers can filter them out.
+func (ic *InstallationClient) GetPRCheckStatuses(ctx context.Context, repo string, ref string) ([]PRCheckStatus, error) {
+	owner, repoName := splitRepo(repo)
+
+	var statuses []PRCheckStatus
+
+	// Fetch check runs (Checks API)
+	checkOpts := &gh.ListCheckRunsOptions{
+		ListOptions: gh.ListOptions{PerPage: 100},
+	}
+	for {
+		result, resp, err := ic.client.Checks.ListCheckRunsForRef(ctx, owner, repoName, ref, checkOpts)
+		if err != nil {
+			return nil, fmt.Errorf("list check runs for ref %s: %w", ref, err)
+		}
+		for _, cr := range result.CheckRuns {
+			name := cr.GetName()
+			statuses = append(statuses, PRCheckStatus{
+				Name:        name,
+				Status:      cr.GetStatus(),
+				Conclusion:  cr.GetConclusion(),
+				IsSchemaBot: strings.HasPrefix(strings.ToLower(name), "schemabot"),
+			})
+		}
+		if resp.NextPage == 0 {
+			break
+		}
+		checkOpts.ListOptions.Page = resp.NextPage
+	}
+
+	// Fetch commit statuses (legacy Status API)
+	statusOpts := &gh.ListOptions{PerPage: 100}
+	for {
+		repoStatuses, resp, err := ic.client.Repositories.ListStatuses(ctx, owner, repoName, ref, statusOpts)
+		if err != nil {
+			return nil, fmt.Errorf("list commit statuses for ref %s: %w", ref, err)
+		}
+		for _, s := range repoStatuses {
+			ctx := s.GetContext()
+			// Map legacy status states to check run equivalents
+			ghState := s.GetState()
+			status := "completed"
+			conclusion := ghState
+			if ghState == "pending" {
+				status = "in_progress"
+				conclusion = ""
+			}
+			statuses = append(statuses, PRCheckStatus{
+				Name:        ctx,
+				Status:      status,
+				Conclusion:  conclusion,
+				IsSchemaBot: strings.HasPrefix(strings.ToLower(ctx), "schemabot"),
+			})
+		}
+		if resp.NextPage == 0 {
+			break
+		}
+		statusOpts.Page = resp.NextPage
+	}
+
+	return statuses, nil
+}
+
 // TreeEntry represents a single entry in a Git tree.
 type TreeEntry struct {
 	Path string

--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -356,7 +356,7 @@ func (ic *InstallationClient) GetPRCheckStatuses(ctx context.Context, repo strin
 		if resp.NextPage == 0 {
 			break
 		}
-		checkOpts.ListOptions.Page = resp.NextPage
+		checkOpts.Page = resp.NextPage
 	}
 
 	// Fetch commit statuses (legacy Status API). The API returns statuses

--- a/pkg/webhook/apply_handlers.go
+++ b/pkg/webhook/apply_handlers.go
@@ -554,6 +554,7 @@ func filterFailingNonSchemaBotChecks(statuses []ghclient.PRCheckStatus) []templa
 
 // enforcePassingChecks verifies that all non-SchemaBot PR checks are passing.
 // Returns true if apply was blocked (caller should return), false if it may proceed.
+// Blocks on both failing checks and in-progress checks with distinct messages.
 func (h *Handler) enforcePassingChecks(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, installationID int64, headSHA, environment string) bool {
 	if !h.service.Config().ShouldRequirePassingChecks() {
 		h.logger.Debug("passing checks gate disabled", "repo", repo, "pr", pr)
@@ -569,6 +570,8 @@ func (h *Handler) enforcePassingChecks(ctx context.Context, client *ghclient.Ins
 	}
 
 	failing := filterFailingNonSchemaBotChecks(statuses)
+	inProgress := filterInProgressNonSchemaBotChecks(statuses)
+
 	if len(failing) > 0 {
 		h.logger.Info("apply blocked by failing PR checks",
 			"repo", repo, "pr", pr, "environment", environment,
@@ -578,7 +581,35 @@ func (h *Handler) enforcePassingChecks(ctx context.Context, client *ghclient.Ins
 		return true
 	}
 
+	if len(inProgress) > 0 {
+		h.logger.Info("apply blocked by in-progress PR checks",
+			"repo", repo, "pr", pr, "environment", environment,
+			"in_progress_count", len(inProgress))
+		h.postComment(repo, pr, installationID,
+			templates.RenderApplyBlockedByInProgressChecks(environment, inProgress))
+		return true
+	}
+
 	return false
+}
+
+// filterInProgressNonSchemaBotChecks returns checks that are still running,
+// excluding SchemaBot's own checks.
+func filterInProgressNonSchemaBotChecks(statuses []ghclient.PRCheckStatus) []templates.FailingCheck {
+	var inProgress []templates.FailingCheck
+	for _, s := range statuses {
+		if s.IsSchemaBot {
+			continue
+		}
+		switch s.Status {
+		case "in_progress", "queued", "pending":
+			inProgress = append(inProgress, templates.FailingCheck{
+				Name:       s.Name,
+				Conclusion: s.Status,
+			})
+		}
+	}
+	return inProgress
 }
 
 // handleUnlockCommand handles the "schemabot unlock" PR comment command.

--- a/pkg/webhook/apply_handlers.go
+++ b/pkg/webhook/apply_handlers.go
@@ -39,6 +39,22 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 		return
 	}
 
+	// Tier 2: PR checks gate — block if non-SchemaBot checks are failing
+	prInfo, err := client.FetchPullRequest(ctx, repo, pr)
+	if err != nil {
+		h.logger.Error("failed to fetch PR for checks gate", "error", err)
+		h.postComment(repo, pr, installationID, templates.RenderGenericError(templates.SchemaErrorData{
+			RequestedBy: requestedBy,
+			Environment: environment,
+			CommandName: action.Apply,
+			ErrorDetail: "Failed to fetch PR info: " + err.Error(),
+		}))
+		return
+	}
+	if blocked := h.enforcePassingChecks(ctx, client, repo, pr, installationID, prInfo.HeadSHA, environment); blocked {
+		return
+	}
+
 	database := schemaResult.Database
 	dbType := schemaResult.Type
 	lockOwner := fmt.Sprintf("%s#%d", repo, pr)
@@ -272,6 +288,22 @@ func (h *Handler) handleApplyConfirmCommand(repo string, pr int, environment, da
 		return
 	}
 
+	// Tier 2: PR checks gate — re-check on confirm to prevent bypass
+	confirmPRInfo, err := client.FetchPullRequest(ctx, repo, pr)
+	if err != nil {
+		h.logger.Error("failed to fetch PR for checks gate", "error", err)
+		h.postComment(repo, pr, installationID, templates.RenderGenericError(templates.SchemaErrorData{
+			RequestedBy: requestedBy,
+			Environment: environment,
+			CommandName: action.ApplyConfirm,
+			ErrorDetail: "Failed to fetch PR info: " + err.Error(),
+		}))
+		return
+	}
+	if blocked := h.enforcePassingChecks(ctx, client, repo, pr, installationID, confirmPRInfo.HeadSHA, environment); blocked {
+		return
+	}
+
 	database := schemaResult.Database
 	dbType := schemaResult.Type
 	lockOwner := fmt.Sprintf("%s#%d", repo, pr)
@@ -494,6 +526,59 @@ func ddlMatchesStoredPlan(planResp *apitypes.PlanResponse, storedPlan *storage.P
 		storedSet[n.DDL]--
 	}
 	return true
+}
+
+// filterFailingNonSchemaBotChecks returns checks that are failing, excluding
+// SchemaBot's own checks and checks with conclusion "neutral", "skipped", or "success".
+// Only checks with completed status and conclusion "failure", "error", or "timed_out"
+// are considered failing.
+func filterFailingNonSchemaBotChecks(statuses []ghclient.PRCheckStatus) []templates.FailingCheck {
+	var failing []templates.FailingCheck
+	for _, s := range statuses {
+		if s.IsSchemaBot {
+			continue
+		}
+		if s.Status != "completed" {
+			continue
+		}
+		switch s.Conclusion {
+		case "failure", "error", "timed_out":
+			failing = append(failing, templates.FailingCheck{
+				Name:       s.Name,
+				Conclusion: s.Conclusion,
+			})
+		}
+	}
+	return failing
+}
+
+// enforcePassingChecks verifies that all non-SchemaBot PR checks are passing.
+// Returns true if apply was blocked (caller should return), false if it may proceed.
+func (h *Handler) enforcePassingChecks(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, installationID int64, headSHA, environment string) bool {
+	if !h.service.Config().ShouldRequirePassingChecks() {
+		h.logger.Debug("passing checks gate disabled", "repo", repo, "pr", pr)
+		return false
+	}
+
+	statuses, err := client.GetPRCheckStatuses(ctx, repo, headSHA)
+	if err != nil {
+		// Graceful degradation: log the error but allow the apply to proceed.
+		// Blocking applies when the GitHub API is unreachable would be too disruptive.
+		h.logger.Warn("failed to fetch PR check statuses, skipping checks gate", "repo", repo, "pr", pr, "error", err)
+		return false
+	}
+
+	failing := filterFailingNonSchemaBotChecks(statuses)
+	if len(failing) > 0 {
+		h.logger.Info("apply blocked by failing PR checks",
+			"repo", repo, "pr", pr, "environment", environment,
+			"failing_count", len(failing))
+		h.postComment(repo, pr, installationID,
+			templates.RenderApplyBlockedByFailingChecks(environment, failing))
+		return true
+	}
+
+	return false
 }
 
 // handleUnlockCommand handles the "schemabot unlock" PR comment command.

--- a/pkg/webhook/apply_handlers.go
+++ b/pkg/webhook/apply_handlers.go
@@ -563,10 +563,10 @@ func (h *Handler) enforcePassingChecks(ctx context.Context, client *ghclient.Ins
 
 	statuses, err := client.GetPRCheckStatuses(ctx, repo, headSHA)
 	if err != nil {
-		// Graceful degradation: log the error but allow the apply to proceed.
-		// Blocking applies when the GitHub API is unreachable would be too disruptive.
-		h.logger.Warn("failed to fetch PR check statuses, skipping checks gate", "repo", repo, "pr", pr, "error", err)
-		return false
+		h.logger.Error("failed to fetch PR check statuses, blocking apply", "repo", repo, "pr", pr, "error", err)
+		h.postComment(repo, pr, installationID,
+			fmt.Sprintf("## ❌ Apply Blocked\n\n**Environment**: `%s`\n\nCould not verify PR check statuses. Retry the apply command.\n\n_Error: %v_", environment, err))
+		return true
 	}
 
 	failing := filterFailingNonSchemaBotChecks(statuses)

--- a/pkg/webhook/apply_handlers_test.go
+++ b/pkg/webhook/apply_handlers_test.go
@@ -4,10 +4,104 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/block/schemabot/pkg/apitypes"
+	ghclient "github.com/block/schemabot/pkg/github"
 	"github.com/block/schemabot/pkg/storage"
 )
+
+func TestFilterFailingNonSchemaBotChecks(t *testing.T) {
+	tests := []struct {
+		name      string
+		statuses  []ghclient.PRCheckStatus
+		wantLen   int
+		wantNames []string
+	}{
+		{
+			name:     "empty statuses returns nil",
+			statuses: nil,
+			wantLen:  0,
+		},
+		{
+			name: "all passing checks returns no failures",
+			statuses: []ghclient.PRCheckStatus{
+				{Name: "CI / unit-tests", Status: "completed", Conclusion: "success"},
+				{Name: "CI / lint", Status: "completed", Conclusion: "success"},
+			},
+			wantLen: 0,
+		},
+		{
+			name: "failure is caught",
+			statuses: []ghclient.PRCheckStatus{
+				{Name: "CI / unit-tests", Status: "completed", Conclusion: "failure"},
+				{Name: "CI / lint", Status: "completed", Conclusion: "success"},
+			},
+			wantLen:   1,
+			wantNames: []string{"CI / unit-tests"},
+		},
+		{
+			name: "error and timed_out are caught",
+			statuses: []ghclient.PRCheckStatus{
+				{Name: "security-scan", Status: "completed", Conclusion: "error"},
+				{Name: "CI / integration", Status: "completed", Conclusion: "timed_out"},
+			},
+			wantLen:   2,
+			wantNames: []string{"security-scan", "CI / integration"},
+		},
+		{
+			name: "SchemaBot checks are excluded",
+			statuses: []ghclient.PRCheckStatus{
+				{Name: "SchemaBot Apply: /mysql/payments", Status: "completed", Conclusion: "failure", IsSchemaBot: true},
+				{Name: "SchemaBot (staging)", Status: "completed", Conclusion: "failure", IsSchemaBot: true},
+				{Name: "CI / unit-tests", Status: "completed", Conclusion: "failure"},
+			},
+			wantLen:   1,
+			wantNames: []string{"CI / unit-tests"},
+		},
+		{
+			name: "neutral and skipped are ignored",
+			statuses: []ghclient.PRCheckStatus{
+				{Name: "informational-check", Status: "completed", Conclusion: "neutral"},
+				{Name: "optional-check", Status: "completed", Conclusion: "skipped"},
+				{Name: "CI / lint", Status: "completed", Conclusion: "failure"},
+			},
+			wantLen:   1,
+			wantNames: []string{"CI / lint"},
+		},
+		{
+			name: "in-progress checks are not considered failing",
+			statuses: []ghclient.PRCheckStatus{
+				{Name: "CI / unit-tests", Status: "in_progress", Conclusion: ""},
+				{Name: "CI / lint", Status: "queued", Conclusion: ""},
+			},
+			wantLen: 0,
+		},
+		{
+			name: "mixed statuses",
+			statuses: []ghclient.PRCheckStatus{
+				{Name: "CI / unit-tests", Status: "completed", Conclusion: "success"},
+				{Name: "CI / lint", Status: "completed", Conclusion: "failure"},
+				{Name: "CI / integration", Status: "in_progress", Conclusion: ""},
+				{Name: "SchemaBot Apply: /mysql/db", Status: "completed", Conclusion: "action_required", IsSchemaBot: true},
+				{Name: "optional", Status: "completed", Conclusion: "neutral"},
+				{Name: "security", Status: "completed", Conclusion: "error"},
+			},
+			wantLen:   2,
+			wantNames: []string{"CI / lint", "security"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			failing := filterFailingNonSchemaBotChecks(tt.statuses)
+			require.Len(t, failing, tt.wantLen)
+			for i, name := range tt.wantNames {
+				assert.Equal(t, name, failing[i].Name)
+			}
+		})
+	}
+}
 
 func TestDDLMatchesStoredPlan(t *testing.T) {
 	tests := []struct {

--- a/pkg/webhook/apply_handlers_test.go
+++ b/pkg/webhook/apply_handlers_test.go
@@ -1,11 +1,14 @@
 package webhook
 
 import (
+	"encoding/json"
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/block/schemabot/pkg/api"
 	"github.com/block/schemabot/pkg/apitypes"
 	ghclient "github.com/block/schemabot/pkg/github"
 	"github.com/block/schemabot/pkg/storage"
@@ -120,6 +123,196 @@ func TestFilterInProgressNonSchemaBotChecks(t *testing.T) {
 	assert.Equal(t, "queued", inProgress[1].Conclusion)
 	assert.Equal(t, "Deploy preview", inProgress[2].Name)
 	assert.Equal(t, "pending", inProgress[2].Conclusion)
+}
+
+func TestEnforcePassingChecks(t *testing.T) {
+	t.Run("API failure blocks apply (fail-closed)", func(t *testing.T) {
+		client, mux := setupGitHubServer(t)
+		comments := make(chan string, 10)
+
+		// Return 500 for check runs API
+		mux.HandleFunc("GET /repos/octocat/hello-world/commits/abc123/check-runs", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		})
+
+		mux.HandleFunc("POST /repos/octocat/hello-world/issues/1/comments", func(w http.ResponseWriter, r *http.Request) {
+			var body struct {
+				Body string `json:"body"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			comments <- body.Body
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": 99})
+		})
+
+		installClient := ghclient.NewInstallationClient(client, testLogger())
+		factory := &fakeClientFactory{client: installClient}
+
+		service := api.New(nil, &api.ServerConfig{}, nil, testLogger())
+		h := &Handler{
+			service:  service,
+			ghClient: factory,
+			logger:   testLogger(),
+		}
+
+		ctx := t.Context()
+		blocked := h.enforcePassingChecks(ctx, installClient, "octocat/hello-world", 1, 12345, "abc123", "staging")
+		assert.True(t, blocked, "should block when API fails")
+
+		select {
+		case body := <-comments:
+			assert.Contains(t, body, "Apply Blocked")
+			assert.Contains(t, body, "Could not verify")
+		default:
+			// Comment may be posted async — the key assertion is blocked=true
+		}
+	})
+
+	t.Run("failing checks block apply", func(t *testing.T) {
+		client, mux := setupGitHubServer(t)
+		comments := make(chan string, 10)
+
+		mux.HandleFunc("GET /repos/octocat/hello-world/commits/abc123/check-runs", func(w http.ResponseWriter, r *http.Request) {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"total_count": 2,
+				"check_runs": []map[string]any{
+					{"name": "CI / tests", "status": "completed", "conclusion": "failure"},
+					{"name": "CI / lint", "status": "completed", "conclusion": "success"},
+				},
+			})
+		})
+
+		mux.HandleFunc("GET /repos/octocat/hello-world/commits/abc123/statuses", func(w http.ResponseWriter, r *http.Request) {
+			_ = json.NewEncoder(w).Encode([]map[string]any{})
+		})
+
+		mux.HandleFunc("POST /repos/octocat/hello-world/issues/1/comments", func(w http.ResponseWriter, r *http.Request) {
+			var body struct {
+				Body string `json:"body"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			comments <- body.Body
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": 99})
+		})
+
+		installClient := ghclient.NewInstallationClient(client, testLogger())
+		factory := &fakeClientFactory{client: installClient}
+
+		service := api.New(nil, &api.ServerConfig{}, nil, testLogger())
+		h := &Handler{
+			service:  service,
+			ghClient: factory,
+			logger:   testLogger(),
+		}
+
+		ctx := t.Context()
+		blocked := h.enforcePassingChecks(ctx, installClient, "octocat/hello-world", 1, 12345, "abc123", "staging")
+		assert.True(t, blocked, "should block when checks are failing")
+
+		select {
+		case body := <-comments:
+			assert.Contains(t, body, "CI / tests")
+			assert.Contains(t, body, "failure")
+		default:
+		}
+	})
+
+	t.Run("all passing allows apply", func(t *testing.T) {
+		client, mux := setupGitHubServer(t)
+
+		mux.HandleFunc("GET /repos/octocat/hello-world/commits/abc123/check-runs", func(w http.ResponseWriter, r *http.Request) {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"total_count": 2,
+				"check_runs": []map[string]any{
+					{"name": "CI / tests", "status": "completed", "conclusion": "success"},
+					{"name": "SchemaBot (staging)", "status": "completed", "conclusion": "action_required"},
+				},
+			})
+		})
+
+		mux.HandleFunc("GET /repos/octocat/hello-world/commits/abc123/statuses", func(w http.ResponseWriter, r *http.Request) {
+			_ = json.NewEncoder(w).Encode([]map[string]any{})
+		})
+
+		installClient := ghclient.NewInstallationClient(client, testLogger())
+		factory := &fakeClientFactory{client: installClient}
+
+		service := api.New(nil, &api.ServerConfig{}, nil, testLogger())
+		h := &Handler{
+			service:  service,
+			ghClient: factory,
+			logger:   testLogger(),
+		}
+
+		ctx := t.Context()
+		blocked := h.enforcePassingChecks(ctx, installClient, "octocat/hello-world", 1, 12345, "abc123", "staging")
+		assert.False(t, blocked, "should allow when all non-SchemaBot checks pass")
+	})
+
+	t.Run("in-progress checks block apply", func(t *testing.T) {
+		client, mux := setupGitHubServer(t)
+		comments := make(chan string, 10)
+
+		mux.HandleFunc("GET /repos/octocat/hello-world/commits/abc123/check-runs", func(w http.ResponseWriter, r *http.Request) {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"total_count": 1,
+				"check_runs": []map[string]any{
+					{"name": "CI / tests", "status": "in_progress", "conclusion": nil},
+				},
+			})
+		})
+
+		mux.HandleFunc("GET /repos/octocat/hello-world/commits/abc123/statuses", func(w http.ResponseWriter, r *http.Request) {
+			_ = json.NewEncoder(w).Encode([]map[string]any{})
+		})
+
+		mux.HandleFunc("POST /repos/octocat/hello-world/issues/1/comments", func(w http.ResponseWriter, r *http.Request) {
+			var body struct {
+				Body string `json:"body"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			comments <- body.Body
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": 99})
+		})
+
+		installClient := ghclient.NewInstallationClient(client, testLogger())
+		factory := &fakeClientFactory{client: installClient}
+
+		service := api.New(nil, &api.ServerConfig{}, nil, testLogger())
+		h := &Handler{
+			service:  service,
+			ghClient: factory,
+			logger:   testLogger(),
+		}
+
+		ctx := t.Context()
+		blocked := h.enforcePassingChecks(ctx, installClient, "octocat/hello-world", 1, 12345, "abc123", "staging")
+		assert.True(t, blocked, "should block when checks are in-progress")
+
+		select {
+		case body := <-comments:
+			assert.Contains(t, body, "still running")
+		default:
+		}
+	})
+
+	t.Run("disabled by config", func(t *testing.T) {
+		client, _ := setupGitHubServer(t)
+		installClient := ghclient.NewInstallationClient(client, testLogger())
+
+		falseVal := false
+		service := api.New(nil, &api.ServerConfig{RequirePassingChecks: &falseVal}, nil, testLogger())
+		h := &Handler{
+			service: service,
+			logger:  testLogger(),
+		}
+
+		ctx := t.Context()
+		blocked := h.enforcePassingChecks(ctx, installClient, "octocat/hello-world", 1, 12345, "abc123", "staging")
+		assert.False(t, blocked, "should not block when disabled")
+	})
 }
 
 func TestDDLMatchesStoredPlan(t *testing.T) {

--- a/pkg/webhook/apply_handlers_test.go
+++ b/pkg/webhook/apply_handlers_test.go
@@ -103,6 +103,25 @@ func TestFilterFailingNonSchemaBotChecks(t *testing.T) {
 	}
 }
 
+func TestFilterInProgressNonSchemaBotChecks(t *testing.T) {
+	statuses := []ghclient.PRCheckStatus{
+		{Name: "CI / tests", Status: "in_progress", Conclusion: ""},
+		{Name: "CI / lint", Status: "completed", Conclusion: "success"},
+		{Name: "Security scan", Status: "queued", Conclusion: ""},
+		{Name: "SchemaBot (staging)", Status: "in_progress", Conclusion: "", IsSchemaBot: true},
+		{Name: "Deploy preview", Status: "pending", Conclusion: ""},
+	}
+
+	inProgress := filterInProgressNonSchemaBotChecks(statuses)
+	require.Len(t, inProgress, 3)
+	assert.Equal(t, "CI / tests", inProgress[0].Name)
+	assert.Equal(t, "in_progress", inProgress[0].Conclusion)
+	assert.Equal(t, "Security scan", inProgress[1].Name)
+	assert.Equal(t, "queued", inProgress[1].Conclusion)
+	assert.Equal(t, "Deploy preview", inProgress[2].Name)
+	assert.Equal(t, "pending", inProgress[2].Conclusion)
+}
+
 func TestDDLMatchesStoredPlan(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/pkg/webhook/review_gate.go
+++ b/pkg/webhook/review_gate.go
@@ -28,7 +28,7 @@ func (h *Handler) enforceReviewGate(ctx context.Context, client *ghclient.Instal
 			RequestedBy: requestedBy,
 			Environment: environment,
 			CommandName: commandName,
-			ErrorDetail: "Review gate check failed: " + err.Error() + ". An admin can run schema changes directly via the CLI to bypass the review gate.",
+			ErrorDetail: "Review gate check failed: " + err.Error(),
 		}))
 		return true
 	}

--- a/pkg/webhook/review_gate_e2e_test.go
+++ b/pkg/webhook/review_gate_e2e_test.go
@@ -185,6 +185,9 @@ func setupFakeGitHubForReviewGate(
 		_ = json.NewEncoder(w).Encode(map[string]any{"id": 1})
 	})
 
+	// PR check statuses (all passing) for enforcePassingChecks
+	registerPassingChecks(mux)
+
 	return result
 }
 

--- a/pkg/webhook/templates/apply.go
+++ b/pkg/webhook/templates/apply.go
@@ -434,7 +434,7 @@ func writeSummaryCompleted(sb *strings.Builder, data ApplyStatusCommentData, tot
 	writeSuccessBlock(sb, msg)
 	writeSummaryTableList(sb, data)
 	if data.ApplyID != "" {
-		fmt.Fprintf(sb, "*Apply ID: `%s`*\n", data.ApplyID)
+		fmt.Fprintf(sb, "_Apply ID: %s_\n", data.ApplyID)
 	}
 }
 

--- a/pkg/webhook/templates/apply_commands.go
+++ b/pkg/webhook/templates/apply_commands.go
@@ -231,6 +231,31 @@ func RenderApplyBlockedByPriorEnv(database, environment, priorEnv, status, actio
 	return sb.String()
 }
 
+// FailingCheck represents a PR check that is blocking apply.
+type FailingCheck struct {
+	Name       string
+	Conclusion string // "failure", "error", "timed_out"
+}
+
+// RenderApplyBlockedByFailingChecks renders a comment when apply is blocked
+// because non-SchemaBot PR checks are failing.
+func RenderApplyBlockedByFailingChecks(environment string, failing []FailingCheck) string {
+	var sb strings.Builder
+
+	sb.WriteString("## ❌ Apply Blocked\n\n")
+	fmt.Fprintf(&sb, "**Environment**: `%s`\n\n", environment)
+	sb.WriteString("Cannot apply while PR checks are failing:\n\n")
+	sb.WriteString("| Check | Status |\n")
+	sb.WriteString("|-------|--------|\n")
+	for _, f := range failing {
+		fmt.Fprintf(&sb, "| `%s` | %s |\n", f.Name, f.Conclusion)
+	}
+	sb.WriteString("\nFix the failing checks and retry:\n")
+	fmt.Fprintf(&sb, "```\nschemabot apply -e %s\n```\n", environment)
+
+	return sb.String()
+}
+
 // RenderApplyBlockedByPriorEnvInProgress renders a comment when an apply is blocked
 // because a prior environment's apply is currently running.
 func RenderApplyBlockedByPriorEnvInProgress(database, environment, priorEnv string) string {

--- a/pkg/webhook/templates/apply_commands.go
+++ b/pkg/webhook/templates/apply_commands.go
@@ -256,6 +256,25 @@ func RenderApplyBlockedByFailingChecks(environment string, failing []FailingChec
 	return sb.String()
 }
 
+// RenderApplyBlockedByInProgressChecks renders a comment when apply is blocked
+// because non-SchemaBot PR checks are still running.
+func RenderApplyBlockedByInProgressChecks(environment string, inProgress []FailingCheck) string {
+	var sb strings.Builder
+
+	sb.WriteString("## ⏳ Apply Blocked\n\n")
+	fmt.Fprintf(&sb, "**Environment**: `%s`\n\n", environment)
+	sb.WriteString("Cannot apply while PR checks are still running:\n\n")
+	sb.WriteString("| Check | Status |\n")
+	sb.WriteString("|-------|--------|\n")
+	for _, c := range inProgress {
+		fmt.Fprintf(&sb, "| `%s` | %s |\n", c.Name, c.Conclusion)
+	}
+	sb.WriteString("\nWait for checks to complete and retry:\n")
+	fmt.Fprintf(&sb, "```\nschemabot apply -e %s\n```\n", environment)
+
+	return sb.String()
+}
+
 // RenderApplyBlockedByPriorEnvInProgress renders a comment when an apply is blocked
 // because a prior environment's apply is currently running.
 func RenderApplyBlockedByPriorEnvInProgress(database, environment, priorEnv string) string {

--- a/pkg/webhook/templates/apply_test.go
+++ b/pkg/webhook/templates/apply_test.go
@@ -346,6 +346,23 @@ func TestRenderApplyBlockedByFailingChecks_SingleCheck(t *testing.T) {
 	assert.Contains(t, result, "schemabot apply -e production")
 }
 
+func TestRenderApplyBlockedByInProgressChecks(t *testing.T) {
+	inProgress := []FailingCheck{
+		{Name: "CI / unit-tests", Conclusion: "in_progress"},
+		{Name: "CI / integration", Conclusion: "queued"},
+	}
+
+	result := RenderApplyBlockedByInProgressChecks("staging", inProgress)
+
+	assert.Contains(t, result, "⏳ Apply Blocked")
+	assert.Contains(t, result, "`staging`")
+	assert.Contains(t, result, "still running")
+	assert.Contains(t, result, "| `CI / unit-tests` | in_progress |")
+	assert.Contains(t, result, "| `CI / integration` | queued |")
+	assert.Contains(t, result, "Wait for checks to complete")
+	assert.Contains(t, result, "schemabot apply -e staging")
+}
+
 func TestTruncateDDL(t *testing.T) {
 	assert.Equal(t, "ALTER TABLE orders ADD INDEX idx_user_id (user_id)", truncateDDL("ALTER TABLE `orders` ADD INDEX `idx_user_id` (`user_id`)", 80))
 	assert.Equal(t, "short", truncateDDL("short", 80))

--- a/pkg/webhook/templates/apply_test.go
+++ b/pkg/webhook/templates/apply_test.go
@@ -317,6 +317,35 @@ func TestPreviewCommentSummaryStopped(t *testing.T) {
 	assert.Contains(t, result, "**`orders`**")
 }
 
+func TestRenderApplyBlockedByFailingChecks(t *testing.T) {
+	failing := []FailingCheck{
+		{Name: "CI / unit-tests", Conclusion: "failure"},
+		{Name: "CI / lint", Conclusion: "timed_out"},
+	}
+
+	result := RenderApplyBlockedByFailingChecks("staging", failing)
+
+	assert.Contains(t, result, "## ❌ Apply Blocked")
+	assert.Contains(t, result, "`staging`")
+	assert.Contains(t, result, "Cannot apply while PR checks are failing")
+	assert.Contains(t, result, "| Check | Status |")
+	assert.Contains(t, result, "| `CI / unit-tests` | failure |")
+	assert.Contains(t, result, "| `CI / lint` | timed_out |")
+	assert.Contains(t, result, "schemabot apply -e staging")
+}
+
+func TestRenderApplyBlockedByFailingChecks_SingleCheck(t *testing.T) {
+	failing := []FailingCheck{
+		{Name: "security-scan", Conclusion: "error"},
+	}
+
+	result := RenderApplyBlockedByFailingChecks("production", failing)
+
+	assert.Contains(t, result, "`production`")
+	assert.Contains(t, result, "| `security-scan` | error |")
+	assert.Contains(t, result, "schemabot apply -e production")
+}
+
 func TestTruncateDDL(t *testing.T) {
 	assert.Equal(t, "ALTER TABLE orders ADD INDEX idx_user_id (user_id)", truncateDDL("ALTER TABLE `orders` ADD INDEX `idx_user_id` (`user_id`)", 80))
 	assert.Equal(t, "short", truncateDDL("short", 80))

--- a/pkg/webhook/templates/preview.go
+++ b/pkg/webhook/templates/preview.go
@@ -199,7 +199,7 @@ func PreviewCommentReviewGateError() string {
 		RequestedBy: "aparajon",
 		Environment: "staging",
 		CommandName: action.Apply,
-		ErrorDetail: "Review gate check failed: expand team @acme/schema-reviewers: API rate limit exceeded. An admin can run schema changes directly via the CLI to bypass the review gate.",
+		ErrorDetail: "Review gate check failed: expand team @acme/schema-reviewers: API rate limit exceeded.",
 	})
 }
 

--- a/pkg/webhook/testhelpers_test.go
+++ b/pkg/webhook/testhelpers_test.go
@@ -98,6 +98,21 @@ func buildPRWebhookRequest(t *testing.T, opts prWebhookPayloadOpts, secret []byt
 	return req
 }
 
+// registerPassingChecks adds mock endpoints for PR check statuses that return
+// all-passing results. This prevents enforcePassingChecks from blocking apply
+// commands in e2e tests.
+func registerPassingChecks(mux *http.ServeMux) {
+	mux.HandleFunc("GET /repos/octocat/hello-world/commits/abc123/check-runs", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"total_count": 0,
+			"check_runs":  []map[string]any{},
+		})
+	})
+	mux.HandleFunc("GET /repos/octocat/hello-world/commits/abc123/statuses", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode([]map[string]any{})
+	})
+}
+
 // webhookPayloadOpts configures how buildWebhookRequest constructs the payload.
 type webhookPayloadOpts struct {
 	comment   string

--- a/pkg/webhook/testhelpers_test.go
+++ b/pkg/webhook/testhelpers_test.go
@@ -98,21 +98,6 @@ func buildPRWebhookRequest(t *testing.T, opts prWebhookPayloadOpts, secret []byt
 	return req
 }
 
-// registerPassingChecks adds mock endpoints for PR check statuses that return
-// all-passing results. This prevents enforcePassingChecks from blocking apply
-// commands in e2e tests.
-func registerPassingChecks(mux *http.ServeMux) {
-	mux.HandleFunc("GET /repos/octocat/hello-world/commits/abc123/check-runs", func(w http.ResponseWriter, _ *http.Request) {
-		_ = json.NewEncoder(w).Encode(map[string]any{
-			"total_count": 0,
-			"check_runs":  []map[string]any{},
-		})
-	})
-	mux.HandleFunc("GET /repos/octocat/hello-world/commits/abc123/statuses", func(w http.ResponseWriter, _ *http.Request) {
-		_ = json.NewEncoder(w).Encode([]map[string]any{})
-	})
-}
-
 // webhookPayloadOpts configures how buildWebhookRequest constructs the payload.
 type webhookPayloadOpts struct {
 	comment   string

--- a/pkg/webhook/webhook_e2e_test.go
+++ b/pkg/webhook/webhook_e2e_test.go
@@ -400,6 +400,9 @@ func setupFakeGitHubForPlan(t *testing.T, mux *http.ServeMux, schemaSQL map[stri
 		_ = json.NewEncoder(w).Encode(map[string]any{"id": 1})
 	})
 
+	// PR check statuses (all passing) for enforcePassingChecks
+	registerPassingChecks(mux)
+
 	return result
 }
 

--- a/pkg/webhook/webhook_e2e_test.go
+++ b/pkg/webhook/webhook_e2e_test.go
@@ -252,6 +252,21 @@ type checkRunCapture struct {
 	Conclusion string `json:"conclusion"`
 }
 
+// registerPassingChecks adds mock endpoints for PR check statuses that return
+// all-passing results. This prevents enforcePassingChecks from blocking apply
+// commands in e2e tests.
+func registerPassingChecks(mux *http.ServeMux) {
+	mux.HandleFunc("GET /repos/octocat/hello-world/commits/abc123/check-runs", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"total_count": 0,
+			"check_runs":  []map[string]any{},
+		})
+	})
+	mux.HandleFunc("GET /repos/octocat/hello-world/commits/abc123/statuses", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode([]map[string]any{})
+	})
+}
+
 // setupFakeGitHubForPlan sets up a fake GitHub server for plan flows.
 // schemaSQL maps filename -> content. Files are placed under schema/{namespace}/.
 // namespace is the MySQL schema name (required).

--- a/scripts/update-templates.sh
+++ b/scripts/update-templates.sh
@@ -128,6 +128,16 @@ render_paired_section "Plan & Status"  "comment_plan_all"       "cli_plan_all"
 render_paired_section "Locking"        "comment_locking_all"    "cli_locking_all"
 render_paired_section "Apply Flow"     "comment_apply_flow_all" "cli_apply_all"
 
+# === PR-only sections ===
+{
+    echo ""
+    echo "## Apply Gates"
+    echo ""
+    echo "### PR Comments"
+    echo ""
+    "$BINARY" preview "comment_apply_all" 2>&1 | wrap_sections >> "$SNAPSHOT"
+}
+
 # === CLI-only sections ===
 render_cli_section "Sequential Mode (CLI)" "sequential_all"
 render_cli_section "Defer Cutover (CLI)"   "defer_all"

--- a/scripts/update-templates.sh
+++ b/scripts/update-templates.sh
@@ -117,6 +117,7 @@ render_cli_section() {
     local heading="$1"
     local preview_type="$2"
 
+    echo "" >> "$SNAPSHOT"
     echo "## ${heading}" >> "$SNAPSHOT"
     echo "" >> "$SNAPSHOT"
     "$BINARY" preview "$preview_type" 2>&1 | strip_ansi | wrap_sections 1 >> "$SNAPSHOT"


### PR DESCRIPTION
## Summary

Block `schemabot apply` when non-SchemaBot PR checks are failing or still running. Prevents applying schema changes on PRs with broken CI, failing linters, or pending reviews.

- `require_passing_checks` config (default: **true**, on by default)
- Fetches both GitHub Check Runs API and legacy Status API
- Excludes SchemaBot's own checks and neutral/skipped checks
- Three distinct states with different messages:
  - **Failing** → ❌ "Fix the failing checks and retry" (with table of failures)
  - **In-progress** → ⏳ "Wait for checks to complete and retry" (with table of running checks)
  - **API unreachable** → ❌ "Could not verify PR check statuses" (fail-closed)
- Preview scenarios: `comment_checks_gate_failing`, `comment_checks_gate_in_progress`

```yaml
# Disable if needed (default: true)
require_passing_checks: false
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)