### PR TITLE
fix(github): post aggregate check runs for all PR types

### DIFF
--- a/pkg/webhook/check_runs.go
+++ b/pkg/webhook/check_runs.go
@@ -463,6 +463,102 @@ func (h *Handler) upsertAggregateCheckRun(
 		"per_database_checks", len(dbChecks))
 }
 
+// postPassingAggregates posts a passing aggregate check for each allowed environment.
+// Called when this instance has no work to do for a PR — either because the PR doesn't
+// touch schema files, or because the databases don't have environments this instance
+// manages. Without this, branch protection would block indefinitely waiting for a
+// check that would never come.
+func (h *Handler) postPassingAggregates(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, headSHA, title, summary string) {
+	config := h.service.Config()
+
+	type envCheck struct {
+		name        string
+		environment string
+	}
+
+	var checks []envCheck
+	if len(config.AllowedEnvironments) > 0 {
+		for _, env := range config.AllowedEnvironments {
+			checks = append(checks, envCheck{
+				name:        aggregateCheckNameForEnv(env),
+				environment: env,
+			})
+		}
+	} else {
+		checks = append(checks, envCheck{
+			name:        aggregateCheckName,
+			environment: aggregateSentinel,
+		})
+	}
+
+	h.logger.Debug("posting passing aggregates", "repo", repo, "pr", pr, "head_sha", headSHA, "count", len(checks))
+
+	for _, ec := range checks {
+		checkName := ec.name
+
+		opts := ghclient.CheckRunOptions{
+			Name:       checkName,
+			Status:     checkStatusCompleted,
+			Conclusion: checkConclusionSuccess,
+			Output: &ghclient.CheckRunOutput{
+				Title:   title,
+				Summary: summary,
+			},
+		}
+
+		existing, err := h.service.Storage().Checks().Get(ctx, repo, pr, ec.environment, aggregateSentinel, aggregateSentinel)
+		if err != nil {
+			h.logger.Error("failed to look up aggregate check", "repo", repo, "pr", pr, "env", ec.environment, "error", err)
+			continue
+		}
+
+		// Skip if already passing for this SHA
+		if existing != nil && existing.HeadSHA == headSHA && existing.Conclusion == checkConclusionSuccess {
+			h.logger.Debug("passing aggregate already exists", "repo", repo, "pr", pr, "check_name", checkName)
+			continue
+		}
+
+		var checkRunID int64
+		if existing != nil && existing.CheckRunID != 0 && existing.HeadSHA == headSHA {
+			if err := client.UpdateCheckRun(ctx, repo, existing.CheckRunID, opts); err != nil {
+				h.logger.Error("failed to update passing aggregate", "error", err)
+				continue
+			}
+			checkRunID = existing.CheckRunID
+		} else {
+			id, err := client.CreateCheckRun(ctx, repo, headSHA, opts)
+			if err != nil {
+				h.logger.Error("failed to create passing aggregate", "error", err)
+				continue
+			}
+			checkRunID = id
+		}
+
+		aggCheck := &storage.Check{
+			Repository:   repo,
+			PullRequest:  pr,
+			HeadSHA:      headSHA,
+			Environment:  ec.environment,
+			DatabaseType: aggregateSentinel,
+			DatabaseName: aggregateSentinel,
+			CheckRunID:   checkRunID,
+			HasChanges:   false,
+			Status:       checkStatusCompleted,
+			Conclusion:   checkConclusionSuccess,
+		}
+		if err := h.service.Storage().Checks().Upsert(ctx, aggCheck); err != nil {
+			h.logger.Error("failed to store passing aggregate check", "error", err)
+		}
+
+		action := "created"
+		if existing != nil && existing.CheckRunID != 0 && existing.HeadSHA == headSHA {
+			action = "updated"
+		}
+		h.logger.Info("posted passing aggregate",
+			"repo", repo, "pr", pr, "check_name", checkName, "env", ec.environment, "action", action)
+	}
+}
+
 // computeAggregate determines the aggregate conclusion and status from per-database checks.
 func computeAggregate(checks []*storage.Check) (conclusion, status string) {
 	// in_progress takes precedence — the aggregate should show running

--- a/pkg/webhook/check_runs.go
+++ b/pkg/webhook/check_runs.go
@@ -559,6 +559,84 @@ func (h *Handler) postPassingAggregates(ctx context.Context, client *ghclient.In
 	}
 }
 
+// postFailingAggregates posts a failing aggregate check for each allowed environment
+// that has errors. Called when all environments fail during planning so branch
+// protection shows a clear failure instead of waiting indefinitely.
+func (h *Handler) postFailingAggregates(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, headSHA string, errors map[string]string) {
+	config := h.service.Config()
+
+	type envCheck struct {
+		name        string
+		environment string
+	}
+
+	var checks []envCheck
+	if len(config.AllowedEnvironments) > 0 {
+		for _, env := range config.AllowedEnvironments {
+			if _, hasError := errors[env]; hasError {
+				checks = append(checks, envCheck{
+					name:        aggregateCheckNameForEnv(env),
+					environment: env,
+				})
+			}
+		}
+	} else {
+		checks = append(checks, envCheck{
+			name:        aggregateCheckName,
+			environment: aggregateSentinel,
+		})
+	}
+
+	for _, ec := range checks {
+		// Build summary from the error for this environment
+		summary := "Plan failed"
+		if errMsg, ok := errors[ec.environment]; ok {
+			summary = errMsg
+		} else if len(errors) > 0 {
+			// Single-instance mode: use first error
+			for _, msg := range errors {
+				summary = msg
+				break
+			}
+		}
+
+		opts := ghclient.CheckRunOptions{
+			Name:       ec.name,
+			Status:     checkStatusCompleted,
+			Conclusion: checkConclusionFailure,
+			Output: &ghclient.CheckRunOutput{
+				Title:   "Plan failed",
+				Summary: summary,
+			},
+		}
+
+		id, err := client.CreateCheckRun(ctx, repo, headSHA, opts)
+		if err != nil {
+			h.logger.Error("failed to create failing aggregate", "repo", repo, "pr", pr, "error", err)
+			continue
+		}
+
+		aggCheck := &storage.Check{
+			Repository:   repo,
+			PullRequest:  pr,
+			HeadSHA:      headSHA,
+			Environment:  ec.environment,
+			DatabaseType: aggregateSentinel,
+			DatabaseName: aggregateSentinel,
+			CheckRunID:   id,
+			HasChanges:   false,
+			Status:       checkStatusCompleted,
+			Conclusion:   checkConclusionFailure,
+		}
+		if err := h.service.Storage().Checks().Upsert(ctx, aggCheck); err != nil {
+			h.logger.Error("failed to store failing aggregate check", "error", err)
+		}
+
+		h.logger.Info("posted failing aggregate",
+			"repo", repo, "pr", pr, "check_name", ec.name, "env", ec.environment)
+	}
+}
+
 // computeAggregate determines the aggregate conclusion and status from per-database checks.
 func computeAggregate(checks []*storage.Check) (conclusion, status string) {
 	// in_progress takes precedence — the aggregate should show running

--- a/pkg/webhook/plan.go
+++ b/pkg/webhook/plan.go
@@ -202,9 +202,19 @@ func (h *Handler) handleMultiEnvPlan(repo string, pr int, databaseName string, i
 		}
 	}
 
-	// Update aggregate check once after all environments are planned
+	// Update aggregate check once after all environments are planned.
+	// If all environments errored, no check records were stored and headSHA
+	// is empty. Post a failing aggregate so branch protection isn't stuck
+	// waiting for a check that will never arrive.
 	if headSHA != "" {
 		h.updateAggregateCheck(ctx, client, repo, pr, headSHA)
+	} else if len(multiEnvData.Errors) > 0 {
+		prInfo, fetchErr := client.FetchPullRequest(ctx, repo, pr)
+		if fetchErr != nil {
+			h.logger.Error("failed to fetch PR for error aggregate", "repo", repo, "pr", pr, "error", fetchErr)
+		} else {
+			h.postFailingAggregates(ctx, client, repo, pr, prInfo.HeadSHA, multiEnvData.Errors)
+		}
 	}
 
 	// Auto-plan: skip comment if no changes and no errors (reduce PR noise)

--- a/pkg/webhook/plan.go
+++ b/pkg/webhook/plan.go
@@ -132,6 +132,17 @@ func (h *Handler) handleMultiEnvPlan(repo string, pr int, databaseName string, i
 
 	if len(environments) == 0 {
 		h.logger.Info("no environments to plan after filtering", "repo", repo, "pr", pr)
+		// Post passing aggregates so branch protection isn't blocked waiting
+		// for checks from this instance when the database doesn't have
+		// environments this instance manages.
+		prInfo, err := client.FetchPullRequest(ctx, repo, pr)
+		if err != nil {
+			h.logger.Error("failed to fetch PR for passing aggregate", "repo", repo, "pr", pr, "error", err)
+			return
+		}
+		h.postPassingAggregates(ctx, client, repo, pr, prInfo.HeadSHA,
+			"No databases for this environment",
+			"This PR has schema changes, but none of the databases have environments managed by this instance.")
 		return
 	}
 

--- a/pkg/webhook/pull_request.go
+++ b/pkg/webhook/pull_request.go
@@ -135,8 +135,8 @@ func (h *Handler) handlePullRequest(w http.ResponseWriter, body []byte) {
 				return
 			}
 			h.postPassingAggregates(ctx, c, repo, pr, headSHA,
-				"No schema changes",
-				"This PR does not modify any schema files.")
+				"No managed schema changes",
+				"This PR does not contain schema changes managed by SchemaBot.")
 		})
 		h.writeJSON(w, http.StatusOK, map[string]string{"message": "no schema files in PR"})
 		return

--- a/pkg/webhook/pull_request.go
+++ b/pkg/webhook/pull_request.go
@@ -111,7 +111,33 @@ func (h *Handler) handlePullRequest(w http.ResponseWriter, body []byte) {
 	})
 
 	if len(configs) == 0 {
-		h.logger.Debug("no schema files in PR, skipping auto-plan", "repo", repo, "pr", pr)
+		h.logger.Info("no schema files in PR, skipping auto-plan", "repo", repo, "pr", pr)
+		// Post passing aggregates so branch protection isn't blocked on
+		// PRs that don't touch schema files. Only do this if there are no
+		// existing check records — if there are, cleanupStaleChecks already
+		// handles the aggregate update and running both would race.
+		h.goSafe(repo, pr, installationID, func() {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			existing, err := h.service.Storage().Checks().GetByPR(ctx, repo, pr)
+			if err != nil {
+				h.logger.Error("failed to check existing records", "repo", repo, "pr", pr, "error", err)
+				return
+			}
+			if len(existing) > 0 {
+				h.logger.Debug("existing check records found, cleanupStaleChecks will handle aggregate",
+					"repo", repo, "pr", pr, "count", len(existing))
+				return
+			}
+			c, err := h.ghClient.ForInstallation(installationID)
+			if err != nil {
+				h.logger.Error("failed to create GitHub client for passing aggregate", "error", err)
+				return
+			}
+			h.postPassingAggregates(ctx, c, repo, pr, headSHA,
+				"No schema changes",
+				"This PR does not modify any schema files.")
+		})
 		h.writeJSON(w, http.StatusOK, map[string]string{"message": "no schema files in PR"})
 		return
 	}

--- a/pkg/webhook/webhook_e2e_test.go
+++ b/pkg/webhook/webhook_e2e_test.go
@@ -2400,3 +2400,60 @@ func TestE2EPassingAggregateWithoutAllowedEnvs(t *testing.T) {
 		t.Fatal("timed out waiting for passing aggregate check run")
 	}
 }
+
+// TestE2EFailingAggregateOnPlanError verifies that when a plan fails for all
+// environments (e.g., database not configured), a failing aggregate check is
+// posted so branch protection shows a clear failure instead of waiting forever.
+func TestE2EFailingAggregateOnPlanError(t *testing.T) {
+	svc := setupE2EServiceWithAllowedEnvs(t, []string{"staging"})
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	client := gh.NewClient(nil)
+	client.BaseURL, _ = url.Parse(server.URL + "/")
+
+	// schemabot.yaml references a database not configured on the server
+	schemabotConfig := "database: unconfigured-db\ntype: mysql\n"
+	schemaFiles := map[string]string{
+		"users.sql": "CREATE TABLE `users` (\n  `id` bigint unsigned NOT NULL AUTO_INCREMENT,\n  `name` varchar(255) NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;",
+	}
+
+	result := setupFakeGitHubForPlan(t, mux, schemaFiles, schemabotConfig, "unconfigured-db")
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	installClient := ghclient.NewInstallationClient(client, logger)
+	factory := &fakeClientFactory{client: installClient}
+
+	h := NewHandler(svc, factory, nil, logger)
+
+	req := buildPRWebhookRequest(t, prWebhookPayloadOpts{
+		action:  "opened",
+		headSHA: "abc123",
+		headRef: "feature-branch",
+	}, nil)
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	// Should get a comment with the error
+	select {
+	case body := <-result.comments:
+		assert.Contains(t, body, "Error")
+		assert.Contains(t, body, "unconfigured-db")
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for error comment")
+	}
+
+	// Should also get a failing aggregate check run
+	select {
+	case cr := <-result.checkRuns:
+		assert.Equal(t, "SchemaBot (staging)", cr.Name)
+		assert.Equal(t, "completed", cr.Status)
+		assert.Equal(t, "failure", cr.Conclusion)
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for failing aggregate check run")
+	}
+}

--- a/pkg/webhook/webhook_e2e_test.go
+++ b/pkg/webhook/webhook_e2e_test.go
@@ -2129,3 +2129,274 @@ func TestE2EWebhookMetrics(t *testing.T) {
 	assert.True(t, observedEvents["issue_comment/created"], "expected issue_comment/created metric")
 	assert.True(t, observedEvents["pull_request/opened"], "expected pull_request/opened metric")
 }
+
+// setupE2EServiceWithAllowedEnvs creates a service with AllowedEnvironments set.
+// Uses the shared SchemaBot storage DB but no target databases (for testing check run
+// posting without needing to plan).
+func setupE2EServiceWithAllowedEnvs(t *testing.T, allowedEnvs []string) *api.Service {
+	t.Helper()
+
+	schemabotDB, err := sql.Open("mysql", e2eSchemabotDSN)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = schemabotDB.Close() })
+
+	st := mysqlstore.New(schemabotDB)
+
+	// Clean up stale data
+	_, _ = schemabotDB.ExecContext(t.Context(),
+		"DELETE FROM checks WHERE repository = 'octocat/hello-world' AND pull_request = 1")
+
+	serverConfig := &api.ServerConfig{
+		AllowedEnvironments: allowedEnvs,
+	}
+
+	svc := api.New(st, serverConfig, nil, slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError})))
+	t.Cleanup(func() { _ = svc.Close() })
+
+	return svc
+}
+
+// TestE2EPassingAggregateOnNonSchemaPR verifies that when a PR doesn't touch schema
+// files and allowed_environments is configured, passing aggregate checks are posted
+// so branch protection isn't blocked.
+func TestE2EPassingAggregateOnNonSchemaPR(t *testing.T) {
+	svc := setupE2EServiceWithAllowedEnvs(t, []string{"staging", "production"})
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	client := gh.NewClient(nil)
+	client.BaseURL, _ = url.Parse(server.URL + "/")
+
+	// PR info
+	mux.HandleFunc("GET /repos/octocat/hello-world/pulls/1", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(gh.PullRequest{
+			Head: &gh.PullRequestBranch{Ref: new("feature-branch"), SHA: new("abc123")},
+			Base: &gh.PullRequestBranch{Ref: new("main"), SHA: new("def456")},
+			User: &gh.User{Login: new("testuser")},
+		})
+	})
+
+	// PR changed files — no schema files
+	mux.HandleFunc("GET /repos/octocat/hello-world/pulls/1/files", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode([]*gh.CommitFile{
+			{Filename: new("README.md"), Status: new("modified")},
+		})
+	})
+
+	// Git tree — no schemabot.yaml
+	mux.HandleFunc("GET /repos/octocat/hello-world/git/trees/abc123", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(gh.Tree{
+			SHA:       new("abc123"),
+			Entries:   []*gh.TreeEntry{},
+			Truncated: new(false),
+		})
+	})
+
+	// Capture check runs
+	checkRuns := make(chan checkRunCapture, 10)
+	mux.HandleFunc("POST /repos/octocat/hello-world/check-runs", func(w http.ResponseWriter, r *http.Request) {
+		var body checkRunCapture
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		checkRuns <- body
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": 1})
+	})
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	installClient := ghclient.NewInstallationClient(client, logger)
+	factory := &fakeClientFactory{client: installClient}
+
+	h := NewHandler(svc, factory, nil, logger)
+
+	req := buildPRWebhookRequest(t, prWebhookPayloadOpts{
+		action:  "opened",
+		headSHA: "abc123",
+		headRef: "feature-branch",
+	}, nil)
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), "no schema files in PR")
+
+	// Wait for both passing aggregates (staging + production)
+	seen := map[string]bool{}
+	for i := range 2 {
+		select {
+		case cr := <-checkRuns:
+			seen[cr.Name] = true
+			assert.Equal(t, "completed", cr.Status)
+			assert.Equal(t, "success", cr.Conclusion)
+		case <-time.After(10 * time.Second):
+			t.Fatalf("timed out waiting for passing aggregate check run %d/2, seen: %v", i+1, seen)
+		}
+	}
+	assert.True(t, seen["SchemaBot (staging)"], "expected SchemaBot (staging) check")
+	assert.True(t, seen["SchemaBot (production)"], "expected SchemaBot (production) check")
+}
+
+// TestE2EPassingAggregateOnSQLWithoutSchemabotYAML verifies that when a PR touches
+// .sql files but the directory has no schemabot.yaml (not onboarded), passing
+// aggregate checks are still posted.
+func TestE2EPassingAggregateOnSQLWithoutSchemabotYAML(t *testing.T) {
+	svc := setupE2EServiceWithAllowedEnvs(t, []string{"staging"})
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	client := gh.NewClient(nil)
+	client.BaseURL, _ = url.Parse(server.URL + "/")
+
+	// PR info
+	mux.HandleFunc("GET /repos/octocat/hello-world/pulls/1", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(gh.PullRequest{
+			Head: &gh.PullRequestBranch{Ref: new("feature-branch"), SHA: new("abc123")},
+			Base: &gh.PullRequestBranch{Ref: new("main"), SHA: new("def456")},
+			User: &gh.User{Login: new("testuser")},
+		})
+	})
+
+	// PR changed files — .sql file but in a directory without schemabot.yaml
+	mux.HandleFunc("GET /repos/octocat/hello-world/pulls/1/files", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode([]*gh.CommitFile{
+			{Filename: new("legacy-service/schema/users.sql"), Status: new("modified")},
+		})
+	})
+
+	// Git tree — has the .sql file but no schemabot.yaml anywhere
+	mux.HandleFunc("GET /repos/octocat/hello-world/git/trees/abc123", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(gh.Tree{
+			SHA: new("abc123"),
+			Entries: []*gh.TreeEntry{
+				{
+					Path: new("legacy-service/schema/users.sql"),
+					Mode: new("100644"),
+					Type: new("blob"),
+					SHA:  new("blobsha001"),
+					Size: new(100),
+				},
+			},
+			Truncated: new(false),
+		})
+	})
+
+	// Capture check runs
+	checkRuns := make(chan checkRunCapture, 10)
+	mux.HandleFunc("POST /repos/octocat/hello-world/check-runs", func(w http.ResponseWriter, r *http.Request) {
+		var body checkRunCapture
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		checkRuns <- body
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": 1})
+	})
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	installClient := ghclient.NewInstallationClient(client, logger)
+	factory := &fakeClientFactory{client: installClient}
+
+	h := NewHandler(svc, factory, nil, logger)
+
+	req := buildPRWebhookRequest(t, prWebhookPayloadOpts{
+		action:  "opened",
+		headSHA: "abc123",
+		headRef: "feature-branch",
+	}, nil)
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), "no schema files in PR")
+
+	// Should post passing aggregate even though .sql files changed
+	select {
+	case cr := <-checkRuns:
+		assert.Equal(t, "SchemaBot (staging)", cr.Name)
+		assert.Equal(t, "completed", cr.Status)
+		assert.Equal(t, "success", cr.Conclusion)
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for passing aggregate check run")
+	}
+}
+
+// TestE2EPassingAggregateWithoutAllowedEnvs verifies that when allowed_environments
+// is not configured (single instance mode), a global "SchemaBot" passing aggregate
+// is posted for non-schema PRs.
+func TestE2EPassingAggregateWithoutAllowedEnvs(t *testing.T) {
+	dbName := "webhook_no_aggregate"
+	svc := setupE2EService(t, dbName)
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	client := gh.NewClient(nil)
+	client.BaseURL, _ = url.Parse(server.URL + "/")
+
+	// PR info
+	mux.HandleFunc("GET /repos/octocat/hello-world/pulls/1", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(gh.PullRequest{
+			Head: &gh.PullRequestBranch{Ref: new("feature-branch"), SHA: new("abc123")},
+			Base: &gh.PullRequestBranch{Ref: new("main"), SHA: new("def456")},
+			User: &gh.User{Login: new("testuser")},
+		})
+	})
+
+	// PR changed files — no schema files
+	mux.HandleFunc("GET /repos/octocat/hello-world/pulls/1/files", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode([]*gh.CommitFile{
+			{Filename: new("README.md"), Status: new("modified")},
+		})
+	})
+
+	// Git tree — empty
+	mux.HandleFunc("GET /repos/octocat/hello-world/git/trees/abc123", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(gh.Tree{
+			SHA:       new("abc123"),
+			Entries:   []*gh.TreeEntry{},
+			Truncated: new(false),
+		})
+	})
+
+	// Capture check runs
+	checkRuns := make(chan checkRunCapture, 10)
+	mux.HandleFunc("POST /repos/octocat/hello-world/check-runs", func(w http.ResponseWriter, r *http.Request) {
+		var body checkRunCapture
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		checkRuns <- body
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": 1})
+	})
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	installClient := ghclient.NewInstallationClient(client, logger)
+	factory := &fakeClientFactory{client: installClient}
+
+	h := NewHandler(svc, factory, nil, logger)
+
+	req := buildPRWebhookRequest(t, prWebhookPayloadOpts{
+		action:  "opened",
+		headSHA: "abc123",
+		headRef: "feature-branch",
+	}, nil)
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), "no schema files in PR")
+
+	// Single-instance mode posts a global "SchemaBot" passing aggregate
+	select {
+	case cr := <-checkRuns:
+		assert.Equal(t, "SchemaBot", cr.Name)
+		assert.Equal(t, "completed", cr.Status)
+		assert.Equal(t, "success", cr.Conclusion)
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for passing aggregate check run")
+	}
+}


### PR DESCRIPTION
## Summary

Ensure SchemaBot always posts aggregate check runs so branch protection required checks are satisfied on every PR type:

- **No schema files**: post passing aggregates immediately
- **Schema files without schemabot.yaml** (not onboarded): post passing aggregates with "No managed schema changes"
- **Schema files, wrong environment**: post passing aggregate for environments this instance doesn't manage (e.g., production instance sees a staging-only database)
- **Plan errors** (e.g., database not configured): post failing aggregates so branch protection shows a red check instead of waiting forever
- **Single-instance mode**: post global "SchemaBot" aggregate (not just per-environment)
- **Race prevention**: skip passing aggregates when existing check records are found (cleanupStaleChecks handles that case)
- **Short-circuit**: skip API calls when existing aggregate already passes for current SHA

🤖 Generated with [Claude Code](https://claude.com/claude-code)