### PR TITLE
refactor(github): use GraphQL statusCheckRollup for PR check gate

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/planetscale/planetscale-go v0.155.0
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
 	github.com/prometheus/client_golang v1.23.2
+	github.com/shurcooL/githubv4 v0.0.0-20260209031235-2402fdf4a9ed
 	github.com/stretchr/testify v1.11.1
 	github.com/testcontainers/testcontainers-go v0.40.0
 	github.com/testcontainers/testcontainers-go/modules/localstack v0.40.0
@@ -36,8 +37,10 @@ require (
 	go.opentelemetry.io/otel/metric v1.43.0
 	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/sdk/metric v1.43.0
+	go.opentelemetry.io/otel/trace v1.43.0
 	golang.org/x/net v0.52.0
 	golang.org/x/sync v0.20.0
+	golang.org/x/sys v0.42.0
 	golang.org/x/text v0.35.0
 	golang.org/x/tools v0.43.0
 	google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9
@@ -203,6 +206,7 @@ require (
 	github.com/secure-systems-lab/go-securesystemslib v0.9.1 // indirect
 	github.com/shirou/gopsutil/v4 v4.25.8 // indirect
 	github.com/shopspring/decimal v1.3.1 // indirect
+	github.com/shurcooL/graphql v0.0.0-20240915155400-7ee5256398cf // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect
@@ -231,7 +235,6 @@ require (
 	go.opentelemetry.io/contrib/bridges/otelzap v0.13.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0 // indirect
 	go.opentelemetry.io/otel/log v0.14.0 // indirect
-	go.opentelemetry.io/otel/trace v1.43.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
@@ -242,7 +245,6 @@ require (
 	golang.org/x/exp v0.0.0-20250911091902-df9299821621 // indirect
 	golang.org/x/mod v0.34.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
-	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/time v0.13.0 // indirect
 	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260401024825-9d38bb4040a9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -552,6 +552,10 @@ github.com/shirou/gopsutil/v4 v4.25.8 h1:NnAsw9lN7587WHxjJA9ryDnqhJpFH6A+wagYWTO
 github.com/shirou/gopsutil/v4 v4.25.8/go.mod h1:q9QdMmfAOVIw7a+eF86P7ISEU6ka+NLgkUxlopV4RwI=
 github.com/shopspring/decimal v1.3.1 h1:2Usl1nmF/WZucqkFZhnfFYxxxu8LG21F6nPQBE5gKV8=
 github.com/shopspring/decimal v1.3.1/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
+github.com/shurcooL/githubv4 v0.0.0-20260209031235-2402fdf4a9ed h1:KT7hI8vYXgU0s2qaMkrfq9tCA1w/iEPgfredVP+4Tzw=
+github.com/shurcooL/githubv4 v0.0.0-20260209031235-2402fdf4a9ed/go.mod h1:zqMwyHmnN/eDOZOdiTohqIUKUrTFX62PNlu7IJdu0q8=
+github.com/shurcooL/graphql v0.0.0-20240915155400-7ee5256398cf h1:o1uxfymjZ7jZ4MsgCErcwWGtVKSiNAXtS59Lhs6uI/g=
+github.com/shurcooL/graphql v0.0.0-20240915155400-7ee5256398cf/go.mod h1:9dIRpgIY7hVhoqfe0/FcYp0bpInZaT7dc3BYOprrIUE=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=

--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -426,7 +426,8 @@ func (ic *InstallationClient) GetPRCheckStatuses(ctx context.Context, repo strin
 		if !contexts.PageInfo.HasNextPage {
 			break
 		}
-		vars["after"] = githubv4.NewString(contexts.PageInfo.EndCursor)
+		after := contexts.PageInfo.EndCursor
+		vars["after"] = &after
 	}
 	return out, nil
 }

--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/bradleyfalzon/ghinstallation/v2"
 	gh "github.com/google/go-github/v68/github"
+	"github.com/shurcooL/githubv4"
 )
 
 // GitHubClientFactory creates installation-scoped GitHub clients.
@@ -49,21 +50,38 @@ func (c *Client) ForInstallation(installationID int64) (*InstallationClient, err
 	if err != nil {
 		return nil, fmt.Errorf("create installation transport: %w", err)
 	}
+	httpc := &http.Client{Transport: transport, Timeout: 30 * time.Second}
+	ghClient := gh.NewClient(httpc)
 	return &InstallationClient{
-		client: gh.NewClient(&http.Client{Transport: transport, Timeout: 30 * time.Second}),
+		client: ghClient,
+		gql:    githubv4.NewEnterpriseClient(graphQLURLFor(ghClient), httpc),
 		logger: c.logger,
 	}, nil
 }
 
 // NewInstallationClient creates an InstallationClient from a pre-configured go-github client.
 // Used in tests to point at httptest.Server; production uses Client.ForInstallation().
+// The GraphQL endpoint is derived from the go-github client's BaseURL so the same
+// httptest mux serves both REST and GraphQL.
 func NewInstallationClient(client *gh.Client, logger *slog.Logger) *InstallationClient {
-	return &InstallationClient{client: client, logger: logger}
+	return &InstallationClient{
+		client: client,
+		gql:    githubv4.NewEnterpriseClient(graphQLURLFor(client), client.Client()),
+		logger: logger,
+	}
+}
+
+// graphQLURLFor returns the GraphQL endpoint for a given go-github client by
+// appending "graphql" to its REST BaseURL. Works for both api.github.com and
+// httptest servers used in tests.
+func graphQLURLFor(client *gh.Client) string {
+	return strings.TrimRight(client.BaseURL.String(), "/") + "/graphql"
 }
 
 // InstallationClient wraps a go-github client scoped to a specific GitHub App installation.
 type InstallationClient struct {
 	client *gh.Client
+	gql    *githubv4.Client
 	logger *slog.Logger
 }
 
@@ -324,79 +342,111 @@ type PRCheckStatus struct {
 	IsSchemaBot bool   // true if this is a SchemaBot check
 }
 
-// GetPRCheckStatuses fetches all check runs and commit statuses for a ref,
-// combining them into a unified list. SchemaBot's own checks are marked with
-// IsSchemaBot=true so callers can filter them out.
+// schemaBotAppSlug is the GitHub App slug used to identify SchemaBot's own
+// check runs via checkSuite.app.slug from the GraphQL statusCheckRollup.
+const schemaBotAppSlug = "schemabot"
+
+// statusCheckRollupQuery is the GraphQL query used by GetPRCheckStatuses.
+// statusCheckRollup returns check runs and commit statuses already deduped
+// and filtered to the latest run per check name.
+type statusCheckRollupQuery struct {
+	Repository struct {
+		Object struct {
+			Commit struct {
+				StatusCheckRollup struct {
+					Contexts struct {
+						PageInfo struct {
+							HasNextPage bool
+							EndCursor   githubv4.String
+						}
+						Nodes []struct {
+							Typename string `graphql:"__typename"`
+							CheckRun struct {
+								Name       string
+								Status     string
+								Conclusion string
+								CheckSuite struct {
+									App struct {
+										Slug string
+									}
+								}
+							} `graphql:"... on CheckRun"`
+							StatusContext struct {
+								Context string
+								State   string
+							} `graphql:"... on StatusContext"`
+						}
+					} `graphql:"contexts(first: 100, after: $after)"`
+				}
+			} `graphql:"... on Commit"`
+		} `graphql:"object(oid: $oid)"`
+	} `graphql:"repository(owner: $owner, name: $repo)"`
+}
+
+// GetPRCheckStatuses fetches all check runs and commit statuses for a ref via
+// the GraphQL Commit.statusCheckRollup, which returns already-deduped, latest-only
+// results in a single round trip. SchemaBot's own check runs are identified via
+// the GitHub App slug (more reliable than name matching).
 func (ic *InstallationClient) GetPRCheckStatuses(ctx context.Context, repo string, ref string) ([]PRCheckStatus, error) {
 	owner, repoName := splitRepo(repo)
 
-	var statuses []PRCheckStatus
-
-	// Fetch check runs (Checks API). Filter to "latest" to avoid stale reruns
-	// where an old failure could block apply even though the latest run passed.
-	latestFilter := "latest"
-	checkOpts := &gh.ListCheckRunsOptions{
-		Filter:      &latestFilter,
-		ListOptions: gh.ListOptions{PerPage: 100},
+	vars := map[string]any{
+		"owner": githubv4.String(owner),
+		"repo":  githubv4.String(repoName),
+		"oid":   githubv4.GitObjectID(ref),
+		"after": (*githubv4.String)(nil),
 	}
+
+	var out []PRCheckStatus
 	for {
-		result, resp, err := ic.client.Checks.ListCheckRunsForRef(ctx, owner, repoName, ref, checkOpts)
-		if err != nil {
-			return nil, fmt.Errorf("list check runs for ref %s: %w", ref, err)
+		var q statusCheckRollupQuery
+		if err := ic.gql.Query(ctx, &q, vars); err != nil {
+			return nil, fmt.Errorf("graphql statusCheckRollup ref %s: %w", ref, err)
 		}
-		for _, cr := range result.CheckRuns {
-			name := cr.GetName()
-			statuses = append(statuses, PRCheckStatus{
-				Name:        name,
-				Status:      cr.GetStatus(),
-				Conclusion:  cr.GetConclusion(),
-				IsSchemaBot: strings.HasPrefix(strings.ToLower(name), "schemabot"),
-			})
+		contexts := q.Repository.Object.Commit.StatusCheckRollup.Contexts
+		for _, n := range contexts.Nodes {
+			switch n.Typename {
+			case "CheckRun":
+				out = append(out, PRCheckStatus{
+					Name:        n.CheckRun.Name,
+					Status:      strings.ToLower(n.CheckRun.Status),
+					Conclusion:  strings.ToLower(n.CheckRun.Conclusion),
+					IsSchemaBot: strings.EqualFold(n.CheckRun.CheckSuite.App.Slug, schemaBotAppSlug),
+				})
+			case "StatusContext":
+				status, conclusion := mapLegacyStatusState(n.StatusContext.State)
+				out = append(out, PRCheckStatus{
+					Name:        n.StatusContext.Context,
+					Status:      status,
+					Conclusion:  conclusion,
+					IsSchemaBot: strings.HasPrefix(strings.ToLower(n.StatusContext.Context), schemaBotAppSlug),
+				})
+			}
 		}
-		if resp.NextPage == 0 {
+		if !contexts.PageInfo.HasNextPage {
 			break
 		}
-		checkOpts.Page = resp.NextPage
+		vars["after"] = githubv4.NewString(contexts.PageInfo.EndCursor)
 	}
+	return out, nil
+}
 
-	// Fetch commit statuses (legacy Status API). The API returns statuses
-	// newest-first, so deduplicate by context to keep only the latest per context.
-	seenContexts := make(map[string]bool)
-	statusOpts := &gh.ListOptions{PerPage: 100}
-	for {
-		repoStatuses, resp, err := ic.client.Repositories.ListStatuses(ctx, owner, repoName, ref, statusOpts)
-		if err != nil {
-			return nil, fmt.Errorf("list commit statuses for ref %s: %w", ref, err)
-		}
-		for _, s := range repoStatuses {
-			statusCtx := s.GetContext()
-			if seenContexts[statusCtx] {
-				continue
-			}
-			seenContexts[statusCtx] = true
-
-			// Map legacy status states to check run equivalents
-			ghState := s.GetState()
-			status := "completed"
-			conclusion := ghState
-			if ghState == "pending" {
-				status = "in_progress"
-				conclusion = ""
-			}
-			statuses = append(statuses, PRCheckStatus{
-				Name:        statusCtx,
-				Status:      status,
-				Conclusion:  conclusion,
-				IsSchemaBot: strings.HasPrefix(strings.ToLower(statusCtx), "schemabot"),
-			})
-		}
-		if resp.NextPage == 0 {
-			break
-		}
-		statusOpts.Page = resp.NextPage
+// mapLegacyStatusState maps a GraphQL StatusState enum (EXPECTED, ERROR, FAILURE,
+// PENDING, SUCCESS) to the (status, conclusion) pair used by PRCheckStatus, so
+// downstream filters can treat check runs and legacy statuses uniformly.
+func mapLegacyStatusState(state string) (status, conclusion string) {
+	switch strings.ToUpper(state) {
+	case "PENDING", "EXPECTED":
+		return "in_progress", ""
+	case "SUCCESS":
+		return "completed", "success"
+	case "FAILURE":
+		return "completed", "failure"
+	case "ERROR":
+		return "completed", "error"
+	default:
+		return "completed", strings.ToLower(state)
 	}
-
-	return statuses, nil
 }
 
 // TreeEntry represents a single entry in a Git tree.

--- a/pkg/webhook/apply_handlers_test.go
+++ b/pkg/webhook/apply_handlers_test.go
@@ -125,13 +125,55 @@ func TestFilterInProgressNonSchemaBotChecks(t *testing.T) {
 	assert.Equal(t, "pending", inProgress[2].Conclusion)
 }
 
+// rollupNode is a single GraphQL statusCheckRollup contexts node, used by tests
+// to build mock GraphQL responses. Set Typename to "CheckRun" or "StatusContext"
+// and populate the matching fields.
+type rollupNode struct {
+	Typename   string
+	Name       string // CheckRun.name
+	Status     string // CheckRun.status (uppercase: COMPLETED, IN_PROGRESS, ...)
+	Conclusion string // CheckRun.conclusion (uppercase: SUCCESS, FAILURE, ...)
+	AppSlug    string // CheckRun.checkSuite.app.slug
+	Context    string // StatusContext.context
+	State      string // StatusContext.state (uppercase)
+}
+
+// rollupGraphQLHandler returns an http.HandlerFunc that responds to a GraphQL
+// statusCheckRollup query with the supplied contexts.
+func rollupGraphQLHandler(nodes []rollupNode) http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		out := make([]map[string]any, 0, len(nodes))
+		for _, n := range nodes {
+			node := map[string]any{"__typename": n.Typename}
+			switch n.Typename {
+			case "CheckRun":
+				node["name"] = n.Name
+				node["status"] = n.Status
+				node["conclusion"] = n.Conclusion
+				node["checkSuite"] = map[string]any{"app": map[string]any{"slug": n.AppSlug}}
+			case "StatusContext":
+				node["context"] = n.Context
+				node["state"] = n.State
+			}
+			out = append(out, node)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": map[string]any{"repository": map[string]any{"object": map[string]any{
+				"statusCheckRollup": map[string]any{"contexts": map[string]any{
+					"pageInfo": map[string]any{"hasNextPage": false, "endCursor": ""},
+					"nodes":    out,
+				}},
+			}}},
+		})
+	}
+}
+
 func TestEnforcePassingChecks(t *testing.T) {
 	t.Run("API failure blocks apply (fail-closed)", func(t *testing.T) {
 		client, mux := setupGitHubServer(t)
 		comments := make(chan string, 10)
 
-		// Return 500 for check runs API
-		mux.HandleFunc("GET /repos/octocat/hello-world/commits/abc123/check-runs", func(w http.ResponseWriter, r *http.Request) {
+		mux.HandleFunc("POST /graphql", func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusInternalServerError)
 		})
 
@@ -172,19 +214,10 @@ func TestEnforcePassingChecks(t *testing.T) {
 		client, mux := setupGitHubServer(t)
 		comments := make(chan string, 10)
 
-		mux.HandleFunc("GET /repos/octocat/hello-world/commits/abc123/check-runs", func(w http.ResponseWriter, r *http.Request) {
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"total_count": 2,
-				"check_runs": []map[string]any{
-					{"name": "CI / tests", "status": "completed", "conclusion": "failure"},
-					{"name": "CI / lint", "status": "completed", "conclusion": "success"},
-				},
-			})
-		})
-
-		mux.HandleFunc("GET /repos/octocat/hello-world/commits/abc123/statuses", func(w http.ResponseWriter, r *http.Request) {
-			_ = json.NewEncoder(w).Encode([]map[string]any{})
-		})
+		mux.HandleFunc("POST /graphql", rollupGraphQLHandler([]rollupNode{
+			{Typename: "CheckRun", Name: "CI / tests", Status: "COMPLETED", Conclusion: "FAILURE", AppSlug: "github-actions"},
+			{Typename: "CheckRun", Name: "CI / lint", Status: "COMPLETED", Conclusion: "SUCCESS", AppSlug: "github-actions"},
+		}))
 
 		mux.HandleFunc("POST /repos/octocat/hello-world/issues/1/comments", func(w http.ResponseWriter, r *http.Request) {
 			var body struct {
@@ -221,19 +254,10 @@ func TestEnforcePassingChecks(t *testing.T) {
 	t.Run("all passing allows apply", func(t *testing.T) {
 		client, mux := setupGitHubServer(t)
 
-		mux.HandleFunc("GET /repos/octocat/hello-world/commits/abc123/check-runs", func(w http.ResponseWriter, r *http.Request) {
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"total_count": 2,
-				"check_runs": []map[string]any{
-					{"name": "CI / tests", "status": "completed", "conclusion": "success"},
-					{"name": "SchemaBot (staging)", "status": "completed", "conclusion": "action_required"},
-				},
-			})
-		})
-
-		mux.HandleFunc("GET /repos/octocat/hello-world/commits/abc123/statuses", func(w http.ResponseWriter, r *http.Request) {
-			_ = json.NewEncoder(w).Encode([]map[string]any{})
-		})
+		mux.HandleFunc("POST /graphql", rollupGraphQLHandler([]rollupNode{
+			{Typename: "CheckRun", Name: "CI / tests", Status: "COMPLETED", Conclusion: "SUCCESS", AppSlug: "github-actions"},
+			{Typename: "CheckRun", Name: "SchemaBot (staging)", Status: "COMPLETED", Conclusion: "ACTION_REQUIRED", AppSlug: "schemabot"},
+		}))
 
 		installClient := ghclient.NewInstallationClient(client, testLogger())
 		factory := &fakeClientFactory{client: installClient}
@@ -254,18 +278,9 @@ func TestEnforcePassingChecks(t *testing.T) {
 		client, mux := setupGitHubServer(t)
 		comments := make(chan string, 10)
 
-		mux.HandleFunc("GET /repos/octocat/hello-world/commits/abc123/check-runs", func(w http.ResponseWriter, r *http.Request) {
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"total_count": 1,
-				"check_runs": []map[string]any{
-					{"name": "CI / tests", "status": "in_progress", "conclusion": nil},
-				},
-			})
-		})
-
-		mux.HandleFunc("GET /repos/octocat/hello-world/commits/abc123/statuses", func(w http.ResponseWriter, r *http.Request) {
-			_ = json.NewEncoder(w).Encode([]map[string]any{})
-		})
+		mux.HandleFunc("POST /graphql", rollupGraphQLHandler([]rollupNode{
+			{Typename: "CheckRun", Name: "CI / tests", Status: "IN_PROGRESS", Conclusion: "", AppSlug: "github-actions"},
+		}))
 
 		mux.HandleFunc("POST /repos/octocat/hello-world/issues/1/comments", func(w http.ResponseWriter, r *http.Request) {
 			var body struct {

--- a/pkg/webhook/webhook_e2e_test.go
+++ b/pkg/webhook/webhook_e2e_test.go
@@ -252,18 +252,19 @@ type checkRunCapture struct {
 	Conclusion string `json:"conclusion"`
 }
 
-// registerPassingChecks adds mock endpoints for PR check statuses that return
-// all-passing results. This prevents enforcePassingChecks from blocking apply
-// commands in e2e tests.
+// registerPassingChecks adds a mock GraphQL endpoint for PR check statuses that
+// returns an empty rollup (no checks). This prevents enforcePassingChecks from
+// blocking apply commands in e2e tests.
 func registerPassingChecks(mux *http.ServeMux) {
-	mux.HandleFunc("GET /repos/octocat/hello-world/commits/abc123/check-runs", func(w http.ResponseWriter, _ *http.Request) {
+	mux.HandleFunc("POST /graphql", func(w http.ResponseWriter, _ *http.Request) {
 		_ = json.NewEncoder(w).Encode(map[string]any{
-			"total_count": 0,
-			"check_runs":  []map[string]any{},
+			"data": map[string]any{"repository": map[string]any{"object": map[string]any{
+				"statusCheckRollup": map[string]any{"contexts": map[string]any{
+					"pageInfo": map[string]any{"hasNextPage": false, "endCursor": ""},
+					"nodes":    []map[string]any{},
+				}},
+			}}},
 		})
-	})
-	mux.HandleFunc("GET /repos/octocat/hello-world/commits/abc123/statuses", func(w http.ResponseWriter, _ *http.Request) {
-		_ = json.NewEncoder(w).Encode([]map[string]any{})
 	})
 }
 


### PR DESCRIPTION
Recommendation on top of #74. Replaces the two paginated REST loops in `GetPRCheckStatuses` with a single GraphQL `Commit.statusCheckRollup` query.

**Why**
- 1 round trip vs 2+ paginated REST calls.
- GitHub already dedupes contexts and returns the latest run per check name — removes the manual `seenContexts` map for legacy statuses and matches the prior `?filter=latest` behaviour for check runs.
- SchemaBot's own check runs are identified via `checkSuite.app.slug == "schemabot"` instead of `strings.HasPrefix(name, "schemabot")` — no false positives from user-named checks.
- Tests collapse from two REST mocks per case to a single `/graphql` mock.

**How it slots in**
- New dep: `github.com/shurcooL/githubv4`.
- GraphQL endpoint is derived from the go-github client's `BaseURL` so the existing `httptest` mux serves both REST and GraphQL.
- GraphQL enums (`SUCCESS`, `IN_PROGRESS`, …) are lowercased at the boundary, so `PRCheckStatus` shape and the `filterFailingNonSchemaBotChecks` / `filterInProgressNonSchemaBotChecks` helpers are unchanged.

**Verification**
- `go build ./...` ✅
- `make test-unit` ✅
- `make test-integration` ✅ for `pkg/webhook` (only failure is `pkg/localscale` due to a missing local Docker image, unrelated).