### PR TITLE
fix(tern): use hostname-only authority for gRPC client

### DIFF
--- a/pkg/tern/grpc_client.go
+++ b/pkg/tern/grpc_client.go
@@ -101,6 +101,7 @@ package tern
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"time"
 
 	"google.golang.org/grpc"
@@ -137,10 +138,25 @@ type Config struct {
 }
 
 // NewGRPCClient creates a new gRPC client connected to the given address.
+//
+// The address may include a port (e.g. "tern.example.com:80"). The full
+// address is used to dial, but the :authority pseudo-header is set to the
+// hostname only (without the port) so that intermediaries route based on
+// hostname rather than host:port.
 func NewGRPCClient(config Config) (*GRPCClient, error) {
+	// Parse the address to extract the hostname for the :authority header.
+	// url.Parse requires a scheme, so prepend a placeholder if missing.
+	parseTarget := config.Address
+	if u, err := url.Parse("//" + parseTarget); err == nil && u.Hostname() != "" {
+		parseTarget = u.Hostname()
+	} else {
+		return nil, fmt.Errorf("parse address %s: %w", config.Address, err)
+	}
+
 	conn, err := grpc.NewClient(
 		config.Address,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithAuthority(parseTarget),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("dial %s: %w", config.Address, err)

--- a/pkg/tern/grpc_client.go
+++ b/pkg/tern/grpc_client.go
@@ -101,7 +101,7 @@ package tern
 import (
 	"context"
 	"fmt"
-	"net/url"
+	"net"
 	"time"
 
 	"google.golang.org/grpc"
@@ -144,19 +144,15 @@ type Config struct {
 // hostname only (without the port) so that intermediaries route based on
 // hostname rather than host:port.
 func NewGRPCClient(config Config) (*GRPCClient, error) {
-	// Parse the address to extract the hostname for the :authority header.
-	// url.Parse requires a scheme, so prepend a placeholder if missing.
-	parseTarget := config.Address
-	if u, err := url.Parse("//" + parseTarget); err == nil && u.Hostname() != "" {
-		parseTarget = u.Hostname()
-	} else {
-		return nil, fmt.Errorf("parse address %s: %w", config.Address, err)
+	host, _, err := net.SplitHostPort(config.Address)
+	if err != nil {
+		return nil, fmt.Errorf("split host:port from address %s: %w", config.Address, err)
 	}
 
 	conn, err := grpc.NewClient(
 		config.Address,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithAuthority(parseTarget),
+		grpc.WithAuthority(host),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("dial %s: %w", config.Address, err)


### PR DESCRIPTION
Parse the configured tern_deployments address with `net/url` so we can dial the full `host:port` while setting the gRPC `:authority` pseudo-header to the hostname only. This lets intermediaries route based on hostname while the config still carries the explicit port (e.g. `tern.example.com:80`).