### PR TITLE
fix(vitess): surface PlanetScale deploy request lint errors

### DIFF
--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -2974,6 +2974,7 @@ Use 'schemabot start' to resume from checkpoint.
 └────────────────────────────────────────────────────────────────────────────────┘
 
   deploy request #42 failed during preparation (state: error)
+  [INVALID_VSCHEMA] vschema_error: table users has a changed column vindex (keyspace: myapp_sharded, table: users)
 
 
   ── myapp_sharded ──

--- a/pkg/cmd/templates/preview_progress.go
+++ b/pkg/cmd/templates/preview_progress.go
@@ -425,7 +425,7 @@ func previewVitessFailedOutput() {
 		ApplyID:      "apply-a1b2c3d4e5f6",
 		Database:     "myapp",
 		Environment:  "staging",
-		ErrorMessage: "deploy request #42 failed during preparation (state: error)",
+		ErrorMessage: "deploy request #42 failed during preparation (state: error)\n  [INVALID_VSCHEMA] vschema_error: table users has a changed column vindex (keyspace: myapp_sharded, table: users)",
 		StartedAt:    previewTime.Add(-60 * time.Second).Format(time.RFC3339),
 		Metadata: map[string]string{
 			"branch_name":        "schemabot-myapp-28471035",

--- a/pkg/engine/planetscale/planetscale.go
+++ b/pkg/engine/planetscale/planetscale.go
@@ -434,6 +434,20 @@ const (
 // deployState is a shorthand alias for PlanetScale deploy request state constants.
 var deployState = state.DeployRequest
 
+// formatDeployRequestError builds a detailed error message for a failed deploy request,
+// including any lint errors from PlanetScale's validation.
+func formatDeployRequestError(dr *ps.DeployRequest) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "deploy request #%d failed during preparation (state: %s)", dr.Number, dr.DeploymentState)
+	if dr.Deployment != nil && len(dr.Deployment.LintErrors) > 0 {
+		for _, le := range dr.Deployment.LintErrors {
+			fmt.Fprintf(&b, "\n  [%s] %s: %s (keyspace: %s, table: %s)",
+				le.LintError, le.SubjectType, le.ErrorDescription, le.Keyspace, le.Table)
+		}
+	}
+	return b.String()
+}
+
 // psMetadata holds PlanetScale-specific state stored as JSON in ResumeState.Metadata.
 type psMetadata struct {
 	BranchName       string     `json:"branch_name"`
@@ -989,7 +1003,12 @@ func (e *Engine) Apply(ctx context.Context, req *engine.ApplyRequest) (*engine.A
 		}
 	}
 	if dr.DeploymentState == deployState.Error {
-		return nil, fmt.Errorf("deploy request #%d failed during preparation (state: %s)", dr.Number, dr.DeploymentState)
+		errMsg := formatDeployRequestError(dr)
+		emitEvent(engine.ApplyEvent{
+			Message:  errMsg,
+			Metadata: map[string]string{"deploy_request_id": fmt.Sprintf("%d", dr.Number)},
+		})
+		return nil, fmt.Errorf("%s", errMsg)
 	}
 	if dr.DeploymentState == deployState.NoChanges {
 		emitEvent(engine.ApplyEvent{

--- a/pkg/engine/planetscale/planetscale_test.go
+++ b/pkg/engine/planetscale/planetscale_test.go
@@ -549,3 +549,76 @@ func TestIsRetryablePSError(t *testing.T) {
 		assert.False(t, isRetryablePSError(nil))
 	})
 }
+
+func TestFormatDeployRequestError(t *testing.T) {
+	t.Run("without lint errors", func(t *testing.T) {
+		dr := &ps.DeployRequest{
+			Number:          42,
+			DeploymentState: "error",
+		}
+		msg := formatDeployRequestError(dr)
+		assert.Equal(t, "deploy request #42 failed during preparation (state: error)", msg)
+	})
+
+	t.Run("with lint errors", func(t *testing.T) {
+		dr := &ps.DeployRequest{
+			Number:          102,
+			DeploymentState: "error",
+			Deployment: &ps.Deployment{
+				LintErrors: []*ps.DeploymentLintError{
+					{
+						LintError:        "INVALID_VSCHEMA",
+						SubjectType:      "vschema_error",
+						ErrorDescription: "table t1 has a changed column vindex",
+						Keyspace:         "ks_sharded",
+						Table:            "t1",
+					},
+				},
+			},
+		}
+		msg := formatDeployRequestError(dr)
+		assert.Contains(t, msg, "deploy request #102 failed during preparation")
+		assert.Contains(t, msg, "INVALID_VSCHEMA")
+		assert.Contains(t, msg, "table t1 has a changed column vindex")
+		assert.Contains(t, msg, "keyspace: ks_sharded")
+		assert.Contains(t, msg, "table: t1")
+	})
+
+	t.Run("with multiple lint errors", func(t *testing.T) {
+		dr := &ps.DeployRequest{
+			Number:          200,
+			DeploymentState: "error",
+			Deployment: &ps.Deployment{
+				LintErrors: []*ps.DeploymentLintError{
+					{
+						LintError:        "INVALID_VSCHEMA",
+						SubjectType:      "vschema_error",
+						ErrorDescription: "changed vindex on t1",
+						Keyspace:         "ks1",
+						Table:            "t1",
+					},
+					{
+						LintError:        "INVALID_VSCHEMA",
+						SubjectType:      "vschema_error",
+						ErrorDescription: "changed vindex on t2",
+						Keyspace:         "ks1",
+						Table:            "t2",
+					},
+				},
+			},
+		}
+		msg := formatDeployRequestError(dr)
+		assert.Contains(t, msg, "changed vindex on t1")
+		assert.Contains(t, msg, "changed vindex on t2")
+	})
+
+	t.Run("with nil deployment", func(t *testing.T) {
+		dr := &ps.DeployRequest{
+			Number:          99,
+			DeploymentState: "error",
+			Deployment:      nil,
+		}
+		msg := formatDeployRequestError(dr)
+		assert.Equal(t, "deploy request #99 failed during preparation (state: error)", msg)
+	})
+}


### PR DESCRIPTION
When a deploy request fails during PlanetScale's validation phase, the API returns structured lint errors with details about what went wrong (e.g., invalid vschema changes). Previously, the error message only included the deploy request number and state — the actual validation errors were silently dropped.

This extracts a `formatDeployRequestError` helper that includes lint error details (error type, description, keyspace, table) in both the error message and apply event log. Users now see the full validation error in CLI output and `schemabot logs`.