### PR TITLE
fix(deploy): require AWS_PROFILE and add shell.sh commands

### DIFF
--- a/deploy/aws-multi-env/scripts/bootstrap.sh
+++ b/deploy/aws-multi-env/scripts/bootstrap.sh
@@ -16,7 +16,11 @@ set -euo pipefail
 # 4. App Runner service
 
 REGION="us-west-2"
-export AWS_PROFILE="${AWS_PROFILE:-schemabot-deployer}"
+if [ -z "${AWS_PROFILE:-}" ]; then
+    echo "❌ AWS_PROFILE is not set. Export it before running this script."
+    echo "   Example: AWS_PROFILE=my-profile ../scripts/bootstrap.sh"
+    exit 1
+fi
 
 AUTO_APPROVE=""
 while getopts "y" opt; do

--- a/deploy/aws-multi-env/scripts/bootstrap.sh
+++ b/deploy/aws-multi-env/scripts/bootstrap.sh
@@ -17,8 +17,8 @@ set -euo pipefail
 
 REGION="us-west-2"
 if [ -z "${AWS_PROFILE:-}" ]; then
-    echo "❌ AWS_PROFILE is not set. Export it before running this script."
-    echo "   Example: AWS_PROFILE=my-profile ../scripts/bootstrap.sh"
+    echo "❌ AWS_PROFILE is not set."
+    echo "   Example: export AWS_PROFILE=my-profile"
     exit 1
 fi
 

--- a/deploy/aws-multi-env/scripts/clear-data.sh
+++ b/deploy/aws-multi-env/scripts/clear-data.sh
@@ -11,8 +11,8 @@ set -e
 
 REGION="us-west-2"
 if [ -z "${AWS_PROFILE:-}" ]; then
-    echo "❌ AWS_PROFILE is not set. Export it before running this script."
-    echo "   Example: AWS_PROFILE=my-profile ../scripts/clear-data.sh"
+    echo "❌ AWS_PROFILE is not set."
+    echo "   Example: export AWS_PROFILE=my-profile"
     exit 1
 fi
 

--- a/deploy/aws-multi-env/scripts/clear-data.sh
+++ b/deploy/aws-multi-env/scripts/clear-data.sh
@@ -10,7 +10,11 @@
 set -e
 
 REGION="us-west-2"
-export AWS_PROFILE="${AWS_PROFILE:-schemabot-deployer}"
+if [ -z "${AWS_PROFILE:-}" ]; then
+    echo "❌ AWS_PROFILE is not set. Export it before running this script."
+    echo "   Example: AWS_PROFILE=my-profile ../scripts/clear-data.sh"
+    exit 1
+fi
 
 ENV=${1:-staging}
 TABLE=${2:-all}

--- a/deploy/aws-multi-env/scripts/deploy.sh
+++ b/deploy/aws-multi-env/scripts/deploy.sh
@@ -12,8 +12,8 @@ REGION="us-west-2"
 # AWS_PROFILE must be set by the caller. Each environment may use a different
 # AWS account and profile (e.g., staging and production on separate accounts).
 if [ -z "${AWS_PROFILE:-}" ]; then
-    echo "❌ AWS_PROFILE is not set. Export it before running deploy."
-    echo "   Example: AWS_PROFILE=my-profile ../scripts/deploy.sh"
+    echo "❌ AWS_PROFILE is not set."
+    echo "   Example: export AWS_PROFILE=my-profile"
     exit 1
 fi
 

--- a/deploy/aws-multi-env/scripts/deploy.sh
+++ b/deploy/aws-multi-env/scripts/deploy.sh
@@ -8,7 +8,14 @@ set -euo pipefail
 #   --skip-build    Skip Docker build, just trigger deployment
 
 REGION="us-west-2"
-export AWS_PROFILE="${AWS_PROFILE:-schemabot-deployer}"
+
+# AWS_PROFILE must be set by the caller. Each environment may use a different
+# AWS account and profile (e.g., staging and production on separate accounts).
+if [ -z "${AWS_PROFILE:-}" ]; then
+    echo "❌ AWS_PROFILE is not set. Export it before running deploy."
+    echo "   Example: AWS_PROFILE=my-profile ../scripts/deploy.sh"
+    exit 1
+fi
 
 SKIP_BUILD=false
 

--- a/deploy/aws-multi-env/scripts/destroy.sh
+++ b/deploy/aws-multi-env/scripts/destroy.sh
@@ -7,7 +7,11 @@ set -euo pipefail
 # Always requires interactive confirmation — no auto-approve flag.
 
 REGION="us-west-2"
-export AWS_PROFILE="${AWS_PROFILE:-schemabot-deployer}"
+if [ -z "${AWS_PROFILE:-}" ]; then
+    echo "❌ AWS_PROFILE is not set. Export it before running this script."
+    echo "   Example: AWS_PROFILE=my-profile ../scripts/destroy.sh"
+    exit 1
+fi
 
 cd "$(pwd)"
 

--- a/deploy/aws-multi-env/scripts/destroy.sh
+++ b/deploy/aws-multi-env/scripts/destroy.sh
@@ -8,8 +8,8 @@ set -euo pipefail
 
 REGION="us-west-2"
 if [ -z "${AWS_PROFILE:-}" ]; then
-    echo "❌ AWS_PROFILE is not set. Export it before running this script."
-    echo "   Example: AWS_PROFILE=my-profile ../scripts/destroy.sh"
+    echo "❌ AWS_PROFILE is not set."
+    echo "   Example: export AWS_PROFILE=my-profile"
     exit 1
 fi
 

--- a/deploy/aws-multi-env/scripts/logs.sh
+++ b/deploy/aws-multi-env/scripts/logs.sh
@@ -14,8 +14,8 @@ set -euo pipefail
 
 REGION="us-west-2"
 if [ -z "${AWS_PROFILE:-}" ]; then
-    echo "❌ AWS_PROFILE is not set. Export it before running this script."
-    echo "   Example: AWS_PROFILE=my-profile ../scripts/logs.sh"
+    echo "❌ AWS_PROFILE is not set."
+    echo "   Example: export AWS_PROFILE=my-profile"
     exit 1
 fi
 

--- a/deploy/aws-multi-env/scripts/logs.sh
+++ b/deploy/aws-multi-env/scripts/logs.sh
@@ -13,7 +13,11 @@ set -euo pipefail
 #   ../scripts/logs.sh --all         # Both application and service logs interleaved
 
 REGION="us-west-2"
-export AWS_PROFILE="${AWS_PROFILE:-schemabot-deployer}"
+if [ -z "${AWS_PROFILE:-}" ]; then
+    echo "❌ AWS_PROFILE is not set. Export it before running this script."
+    echo "   Example: AWS_PROFILE=my-profile ../scripts/logs.sh"
+    exit 1
+fi
 
 # Defaults
 DURATION="30m"

--- a/deploy/aws-multi-env/scripts/seed-large.sh
+++ b/deploy/aws-multi-env/scripts/seed-large.sh
@@ -10,7 +10,11 @@
 set -e
 
 REGION="us-west-2"
-export AWS_PROFILE="${AWS_PROFILE:-schemabot-deployer}"
+if [ -z "${AWS_PROFILE:-}" ]; then
+    echo "❌ AWS_PROFILE is not set. Export it before running this script."
+    echo "   Example: AWS_PROFILE=my-profile ../scripts/seed-large.sh"
+    exit 1
+fi
 
 TARGET_MB=${1:-100}
 ENV=${2:-staging}

--- a/deploy/aws-multi-env/scripts/seed-large.sh
+++ b/deploy/aws-multi-env/scripts/seed-large.sh
@@ -11,8 +11,8 @@ set -e
 
 REGION="us-west-2"
 if [ -z "${AWS_PROFILE:-}" ]; then
-    echo "❌ AWS_PROFILE is not set. Export it before running this script."
-    echo "   Example: AWS_PROFILE=my-profile ../scripts/seed-large.sh"
+    echo "❌ AWS_PROFILE is not set."
+    echo "   Example: export AWS_PROFILE=my-profile"
     exit 1
 fi
 

--- a/deploy/aws-multi-env/scripts/setup-github-app.sh
+++ b/deploy/aws-multi-env/scripts/setup-github-app.sh
@@ -9,11 +9,6 @@ set -euo pipefail
 # Use --deploy to build and deploy the service afterwards.
 
 DEPLOY=false
-if [ -z "${AWS_PROFILE:-}" ]; then
-    echo "❌ AWS_PROFILE is not set. Export it before running this script."
-    echo "   Example: AWS_PROFILE=my-profile ../scripts/setup-github-app.sh"
-    exit 1
-fi
 GITHUB_APP_SECRET_ID="${GITHUB_APP_SECRET_ID:-}"
 
 while [ $# -gt 0 ]; do
@@ -24,6 +19,12 @@ while [ $# -gt 0 ]; do
         *) echo "Unknown option: $1"; exit 1 ;;
     esac
 done
+
+if [ -z "${AWS_PROFILE:-}" ]; then
+    echo "❌ AWS_PROFILE is not set."
+    echo "   Example: export AWS_PROFILE=my-profile"
+    exit 1
+fi
 export AWS_PROFILE
 
 REGION="us-west-2"

--- a/deploy/aws-multi-env/scripts/setup-github-app.sh
+++ b/deploy/aws-multi-env/scripts/setup-github-app.sh
@@ -9,7 +9,11 @@ set -euo pipefail
 # Use --deploy to build and deploy the service afterwards.
 
 DEPLOY=false
-AWS_PROFILE="${AWS_PROFILE:-schemabot-deployer}"
+if [ -z "${AWS_PROFILE:-}" ]; then
+    echo "❌ AWS_PROFILE is not set. Export it before running this script."
+    echo "   Example: AWS_PROFILE=my-profile ../scripts/setup-github-app.sh"
+    exit 1
+fi
 GITHUB_APP_SECRET_ID="${GITHUB_APP_SECRET_ID:-}"
 
 while [ $# -gt 0 ]; do

--- a/deploy/aws-multi-env/scripts/shell.sh
+++ b/deploy/aws-multi-env/scripts/shell.sh
@@ -2,10 +2,12 @@
 set -euo pipefail
 
 # Connect to RDS MySQL via SSM port forwarding
-# Usage: cd deploy/aws-multi-env/staging && ../scripts/shell.sh [-e staging|production|schemabot]
+# Usage: cd deploy/aws-multi-env/staging && ../scripts/shell.sh [-e staging|production|schemabot] [-c SQL]
 #
 # Options:
 #   -e, --env       Database (staging|production|schemabot), default: staging
+#   -c, --command   Execute SQL and exit (non-interactive)
+#   --reset-schema  Drop and recreate the database (prompts for confirmation)
 #
 # Prerequisites:
 #   - AWS CLI v2.12+
@@ -14,6 +16,8 @@ set -euo pipefail
 
 REGION="us-west-2"
 DATABASE="staging"
+SQL_COMMAND=""
+RESET_SCHEMA=false
 
 # Parse arguments
 while [[ $# -gt 0 ]]; do
@@ -27,16 +31,28 @@ while [[ $# -gt 0 ]]; do
             fi
             shift 2
             ;;
+        -c|--command)
+            SQL_COMMAND="$2"
+            shift 2
+            ;;
+        --reset-schema)
+            RESET_SCHEMA=true
+            shift
+            ;;
         *)
             echo "Unknown option: $1"
-            echo "Usage: ../scripts/shell.sh [-e staging|production|schemabot]"
+            echo "Usage: ../scripts/shell.sh [-e staging|production|schemabot] [-c SQL] [--reset-schema]"
             exit 1
             ;;
     esac
 done
 
 # Set AWS profile
-export AWS_PROFILE="${AWS_PROFILE:-schemabot-deployer}"
+if [ -z "${AWS_PROFILE:-}" ]; then
+    echo "❌ AWS_PROFILE is not set. Export it before running this script."
+    echo "   Example: AWS_PROFILE=my-profile ../scripts/shell.sh"
+    exit 1
+fi
 
 DATABASE_UPPER=$(echo "$DATABASE" | tr '[:lower:]' '[:upper:]')
 echo "🔌 RDS MySQL Shell (via SSM) - ${DATABASE_UPPER}"
@@ -196,6 +212,29 @@ done
 
 echo "   ✅ Tunnel established"
 echo ""
+# Handle --reset-schema
+if [ "$RESET_SCHEMA" = true ]; then
+    echo "⚠️  This will DROP and recreate the '$DB_NAME' database."
+    echo "   All data will be lost. EnsureSchema will rebuild tables on next server restart."
+    echo ""
+    read -r -p "   Type the database name to confirm: " CONFIRM
+    if [ "$CONFIRM" != "$DB_NAME" ]; then
+        echo "❌ Confirmation failed. Aborting."
+        exit 1
+    fi
+    echo ""
+    echo "🗑️  Dropping and recreating $DB_NAME..."
+    mysql --defaults-extra-file="$MYSQL_CNF" -h 127.0.0.1 -P "$LOCAL_PORT" -e "DROP DATABASE \`$DB_NAME\`; CREATE DATABASE \`$DB_NAME\`;"
+    echo "   ✅ Database reset. Restart the service to trigger EnsureSchema."
+    exit 0
+fi
+
+# Handle -c (non-interactive SQL command)
+if [ -n "$SQL_COMMAND" ]; then
+    mysql --defaults-extra-file="$MYSQL_CNF" -h 127.0.0.1 -P "$LOCAL_PORT" "$DB_NAME" -e "$SQL_COMMAND"
+    exit 0
+fi
+
 echo "🚀 Connecting to MySQL..."
 echo "   (Use 'exit' or Ctrl+D to disconnect)"
 echo ""

--- a/deploy/aws-multi-env/scripts/shell.sh
+++ b/deploy/aws-multi-env/scripts/shell.sh
@@ -32,6 +32,11 @@ while [[ $# -gt 0 ]]; do
             shift 2
             ;;
         -c|--command)
+            if [ -z "${2:-}" ]; then
+                echo "❌ --command requires a SQL string"
+                echo "   Example: ../scripts/shell.sh -e schemabot -c 'SHOW TABLES'"
+                exit 1
+            fi
             SQL_COMMAND="$2"
             shift 2
             ;;
@@ -47,10 +52,15 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-# Set AWS profile
+# Validate flags
+if [ "$RESET_SCHEMA" = true ] && [ -n "$SQL_COMMAND" ]; then
+    echo "❌ --reset-schema and -c/--command are mutually exclusive."
+    exit 1
+fi
+
 if [ -z "${AWS_PROFILE:-}" ]; then
-    echo "❌ AWS_PROFILE is not set. Export it before running this script."
-    echo "   Example: AWS_PROFILE=my-profile ../scripts/shell.sh"
+    echo "❌ AWS_PROFILE is not set."
+    echo "   Example: export AWS_PROFILE=my-profile"
     exit 1
 fi
 


### PR DESCRIPTION
## Summary

- Remove hardcoded `AWS_PROFILE=schemabot-deployer` default from all deploy scripts — require callers to set it explicitly since different environments use different AWS accounts
- Add `-c`/`--command` flag to `shell.sh` for non-interactive SQL execution
- Add `--reset-schema` flag to `shell.sh` for dropping and recreating a database (with confirmation prompt)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>