### PR TITLE
fix(github): rollback check run update and multi-instance filtering

### DIFF
--- a/pkg/webhook/check_runs.go
+++ b/pkg/webhook/check_runs.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"time"
 
 	"github.com/block/schemabot/pkg/apitypes"
 	ghclient "github.com/block/schemabot/pkg/github"
@@ -148,6 +149,36 @@ func (h *Handler) updateCheckRecordForApplyResult(ctx context.Context, repo stri
 	h.logger.Info("check record updated after apply",
 		"repo", repo, "pr", pr, "database", apply.Database,
 		"environment", apply.Environment, "conclusion", conclusion)
+}
+
+// setCheckActionRequired sets the check for a database/environment back to action_required.
+// Used after a rollback completes — the PR's schema changes need to be re-applied.
+func (h *Handler) setCheckActionRequired(repo string, pr int, environment, dbType, database string, installationID int64) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	check, err := h.service.Storage().Checks().Get(ctx, repo, pr, environment, dbType, database)
+	if err != nil || check == nil {
+		h.logger.Warn("no check record to update after rollback",
+			"repo", repo, "pr", pr, "database", database, "environment", environment)
+		return
+	}
+
+	check.Status = checkStatusCompleted
+	check.Conclusion = checkConclusionActionRequired
+	check.HasChanges = true
+	if err := h.service.Storage().Checks().Upsert(ctx, check); err != nil {
+		h.logger.Error("failed to set check to action_required after rollback", "error", err)
+		return
+	}
+
+	h.logger.Info("check set to action_required after rollback",
+		"repo", repo, "pr", pr, "database", database, "environment", environment)
+
+	// Update the aggregate check to reflect the rollback
+	if aggClient, err := h.ghClient.ForInstallation(installationID); err == nil {
+		h.updateAggregateCheck(ctx, aggClient, repo, pr, check.HeadSHA)
+	}
 }
 
 // checkPriorEnvironments enforces environment ordering: all environments before

--- a/pkg/webhook/rollback.go
+++ b/pkg/webhook/rollback.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/block/schemabot/pkg/api"
+	"github.com/block/schemabot/pkg/state"
 	"github.com/block/schemabot/pkg/storage"
 	"github.com/block/schemabot/pkg/webhook/action"
 	"github.com/block/schemabot/pkg/webhook/templates"
@@ -55,6 +56,15 @@ func (h *Handler) handleRollbackCommand(repo string, pr int, installationID int6
 	database := apply.Database
 	environment := apply.Environment
 	dbType := apply.DatabaseType
+
+	// In multi-instance setups, only the instance that owns this environment
+	// should process the rollback. Without this check, both instances react
+	// to the rollback comment (since rollback has no -e flag to filter on).
+	if h.service != nil && !h.service.Config().IsEnvironmentAllowed(environment) {
+		h.logger.Info("ignoring rollback for non-allowed environment",
+			"repo", repo, "pr", pr, "applyID", applyID, "environment", environment)
+		return
+	}
 
 	// Check for existing lock
 	existingLock, err := h.service.Storage().Locks().Get(ctx, database, dbType)
@@ -283,13 +293,29 @@ func (h *Handler) handleRollbackConfirmCommand(repo string, pr int, environment,
 		return
 	}
 
-	// Spawn background progress watcher
+	// Spawn background progress watcher. After the rollback apply completes,
+	// set the check to action_required — the PR's schema changes need to be
+	// re-applied since the rollback undid them.
 	if applyID > 0 {
 		apply, err := h.service.Storage().Applies().Get(ctx, applyID)
 		if err != nil || apply == nil {
 			h.logger.Error("failed to load apply for progress watch", "applyID", applyID, "error", err)
 			return
 		}
-		go h.watchApplyProgress(context.Background(), repo, pr, installationID, apply)
+		go func() {
+			bgCtx := context.Background()
+			h.watchApplyProgress(bgCtx, repo, pr, installationID, apply)
+			// Re-fetch the apply to check its final state. Only set action_required
+			// if the rollback succeeded — a failed rollback should keep the failure
+			// conclusion set by watchApplyProgress.
+			final, err := h.service.Storage().Applies().Get(bgCtx, applyID)
+			if err != nil || final == nil {
+				h.logger.Error("failed to re-fetch apply after rollback", "applyID", applyID, "error", err)
+				return
+			}
+			if state.IsState(final.State, state.Apply.Completed) {
+				h.setCheckActionRequired(repo, pr, apply.Environment, apply.DatabaseType, apply.Database, installationID)
+			}
+		}()
 	}
 }

--- a/pkg/webhook/webhook_e2e_test.go
+++ b/pkg/webhook/webhook_e2e_test.go
@@ -1779,6 +1779,179 @@ func TestE2ERollbackConfirmExecutesAndPostsComments(t *testing.T) {
 	}
 }
 
+// TestE2ERollbackConfirmUpdatesCheckToActionRequired verifies that after a
+// rollback-confirm completes, the check run transitions to action_required
+// (not success) since the PR's schema changes have been undone.
+func TestE2ERollbackConfirmUpdatesCheckToActionRequired(t *testing.T) {
+	dbName := "webhook_rb_check"
+	svc := setupE2EService(t, dbName)
+	ctx := t.Context()
+
+	// Step 1: Create initial table
+	cfg, err := mysql.ParseDSN(e2eTargetDSN)
+	require.NoError(t, err)
+	cfg.DBName = dbName
+	cfg.MultiStatements = true
+	db, err := sql.Open("mysql", cfg.FormatDSN())
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, "CREATE TABLE `users` (\n  `id` bigint unsigned NOT NULL AUTO_INCREMENT,\n  `name` varchar(255) NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci")
+	require.NoError(t, err)
+	_ = db.Close()
+
+	// Step 2: Plan + apply adding an index
+	schemaWithIndex := "CREATE TABLE `users` (\n  `id` bigint unsigned NOT NULL AUTO_INCREMENT,\n  `name` varchar(255) NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `idx_name` (`name`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;"
+	planResp, err := svc.ExecutePlan(ctx, api.PlanRequest{
+		Database:    dbName,
+		Environment: "staging",
+		Type:        "mysql",
+		SchemaFiles: map[string]*ternv1.SchemaFiles{
+			dbName: {Files: map[string]string{"users.sql": schemaWithIndex}},
+		},
+	})
+	require.NoError(t, err)
+
+	applyResp, applyID, err := svc.ExecuteApply(ctx, api.ApplyRequest{
+		PlanID:      planResp.PlanID,
+		Environment: "staging",
+		Options:     map[string]string{"allow_unsafe": "true"},
+	})
+	require.NoError(t, err)
+	require.True(t, applyResp.Accepted)
+
+	require.Eventually(t, func() bool {
+		a, err := svc.Storage().Applies().Get(ctx, applyID)
+		return err == nil && a != nil && a.State == "completed"
+	}, 30*time.Second, 500*time.Millisecond, "initial apply should complete")
+
+	// Step 3: Seed a check record (simulates what plan/apply creates)
+	err = svc.Storage().Checks().Upsert(ctx, &storage.Check{
+		Repository:   "octocat/hello-world",
+		PullRequest:  1,
+		HeadSHA:      "abc123",
+		Environment:  "staging",
+		DatabaseType: "mysql",
+		DatabaseName: dbName,
+		CheckRunID:   42,
+		HasChanges:   false,
+		Status:       checkStatusCompleted,
+		Conclusion:   checkConclusionSuccess,
+	})
+	require.NoError(t, err)
+
+	// Step 4: Set up fake GitHub and run rollback + rollback-confirm
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	client := gh.NewClient(nil)
+	client.BaseURL, _ = url.Parse(server.URL + "/")
+
+	schemabotConfig := fmt.Sprintf("database: %s\ntype: mysql\n", dbName)
+	result := setupFakeGitHubForPlan(t, mux, map[string]string{
+		"users.sql": schemaWithIndex,
+	}, schemabotConfig, dbName)
+
+	h := newE2EHandler(t, svc, client)
+
+	storedApply, err := svc.Storage().Applies().Get(ctx, applyID)
+	require.NoError(t, err)
+
+	// Run rollback
+	req := buildWebhookRequest(t, webhookPayloadOpts{
+		comment: fmt.Sprintf("schemabot rollback %s", storedApply.ApplyIdentifier),
+		isPR:    true,
+	}, nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	select {
+	case <-result.comments:
+	case <-time.After(30 * time.Second):
+		t.Fatal("timed out waiting for rollback plan comment")
+	}
+
+	// Run rollback-confirm
+	req = buildWebhookRequest(t, webhookPayloadOpts{
+		comment: "schemabot rollback-confirm -e staging",
+		isPR:    true,
+	}, nil)
+	rr = httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	// Wait for the rollback apply to complete and check to be updated
+	require.Eventually(t, func() bool {
+		check, err := svc.Storage().Checks().Get(ctx, "octocat/hello-world", 1, "staging", "mysql", dbName)
+		return err == nil && check != nil && check.Conclusion == checkConclusionActionRequired
+	}, 30*time.Second, 500*time.Millisecond,
+		"check should transition to action_required after rollback")
+}
+
+// TestE2ERollbackIgnoredByNonOwningInstance verifies that in a multi-instance
+// setup, an instance that doesn't own the apply's environment silently ignores
+// the rollback command instead of posting "Apply Not Found".
+func TestE2ERollbackIgnoredByNonOwningInstance(t *testing.T) {
+	dbName := "webhook_rb_multienv"
+	svc := setupE2EServiceWithAllowedEnvs(t, []string{"production"})
+	ctx := t.Context()
+
+	// Seed a completed apply for staging (owned by the other instance)
+	_, err := svc.Storage().Applies().Create(ctx, &storage.Apply{
+		ApplyIdentifier: "apply-aabbccdd0011",
+		Database:        dbName,
+		DatabaseType:    "mysql",
+		Environment:     "staging",
+		Repository:      "octocat/hello-world",
+		PullRequest:     1,
+		State:           "completed",
+		Engine:          "spirit",
+	})
+	require.NoError(t, err)
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	client := gh.NewClient(nil)
+	client.BaseURL, _ = url.Parse(server.URL + "/")
+
+	comments := make(chan string, 10)
+	mux.HandleFunc("POST /repos/octocat/hello-world/issues/1/comments", func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Body string `json:"body"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		comments <- body.Body
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": 99})
+	})
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	installClient := ghclient.NewInstallationClient(client, logger)
+	factory := &fakeClientFactory{client: installClient}
+
+	h := NewHandler(svc, factory, nil, logger)
+
+	// Send rollback command for the staging apply to the production instance
+	req := buildWebhookRequest(t, webhookPayloadOpts{
+		comment: "schemabot rollback apply-aabbccdd0011",
+		isPR:    true,
+	}, nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	// The production instance should NOT post any comment (it silently ignores
+	// the staging rollback). Wait long enough for any async handler to fire.
+	select {
+	case body := <-comments:
+		t.Fatalf("production instance should not post a comment for staging rollback, got: %s", body)
+	case <-time.After(2 * time.Second):
+		// Expected: no comment posted
+	}
+}
+
 // TestE2EPRCloseCleanup verifies that closing a PR releases locks and deletes checks.
 func TestE2EPRCloseCleanup(t *testing.T) {
 	dbName := "webhook_pr_close"


### PR DESCRIPTION
## Summary

- After rollback-confirm completes, set the check to `action_required` instead of `success`. The PR's schema changes have been undone, so the check should signal that changes need to be re-applied.
- In multi-instance setups, only the instance that owns the apply's environment processes the rollback. Previously both instances reacted since rollback commands don't have an `-e` flag for environment filtering.