### PR TITLE
chore: bump Spirit to v0.13.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.32.7
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.7
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.1
-	github.com/block/spirit v0.12.1-0.20260428210128-cd4aecfd2fcd
+	github.com/block/spirit v0.13.0
 	github.com/bradleyfalzon/ghinstallation/v2 v2.17.0
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
@@ -256,3 +256,6 @@ require (
 
 // needed for Strata and vtcombo OnlineDDL suppport
 replace vitess.io/vitess => github.com/block/vitess v0.0.0-20260312213147-c2d162972c2d
+
+// needed for SPATIAL index support in Spirit v0.13.0
+replace github.com/pingcap/tidb/pkg/parser => github.com/block/tidb/pkg/parser v0.0.0-20260506200501-e528fd979fc8

--- a/go.sum
+++ b/go.sum
@@ -107,8 +107,10 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/block/spirit v0.12.1-0.20260428210128-cd4aecfd2fcd h1:KGwjKbjDe5fAWQHXoButCeAIoqeuzOptBoUZFUVmoN0=
-github.com/block/spirit v0.12.1-0.20260428210128-cd4aecfd2fcd/go.mod h1:TpxEit7CjSLSrhDG21K5ORu3abMED5OipGLDAadjX5Y=
+github.com/block/spirit v0.13.0 h1:tGmd+FYdmrUxBig0dk7UdMPECqu4+MeXmcirXIpDu7A=
+github.com/block/spirit v0.13.0/go.mod h1:J58p5DPNRvwjY8r266sPGzoczuoIiZ02r7eqOtezlNs=
+github.com/block/tidb/pkg/parser v0.0.0-20260506200501-e528fd979fc8 h1:+OfdTacrEyjlqcRUpBFX9uJ6ROBq6cUjwY4DClhnsdU=
+github.com/block/tidb/pkg/parser v0.0.0-20260506200501-e528fd979fc8/go.mod h1:zDLDsfNBU5+L6T4J9/OgWAHc/WZvMUjbpgHqQ/t3yKo=
 github.com/block/vitess v0.0.0-20260312213147-c2d162972c2d h1:IUsLaXSDLqBWN/5KiuGwhP8GOKVSY3ORkZuqoQnryrI=
 github.com/block/vitess v0.0.0-20260312213147-c2d162972c2d/go.mod h1:Q6qWoQw3mAEBOMg0Hn28sb5EWi7pRJ9885zrVtU6MGM=
 github.com/bndr/gotabulate v1.1.2 h1:yC9izuZEphojb9r+KYL4W9IJKO/ceIO8HDwxMA24U4c=
@@ -486,8 +488,6 @@ github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86 h1:tdMsjOqUR7YXH
 github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86/go.mod h1:exzhVYca3WRtd6gclGNErRWb1qEgff3LYta0LvRmON4=
 github.com/pingcap/log v1.1.1-0.20250917021125-19901e015dc9 h1:qG9BSvlWFEE5otQGamuWedx9LRm0nrHvsQRQiW8SxEs=
 github.com/pingcap/log v1.1.1-0.20250917021125-19901e015dc9/go.mod h1:ORfBOFp1eteu2odzsyaxI+b8TzJwgjwyQcGhI+9SfEA=
-github.com/pingcap/tidb/pkg/parser v0.0.0-20250811102254-4230cf349b01 h1:n3qowTSsPQ6PwOqEmrmVHvlsuW3Ig2i2yRbjE7vd2Fg=
-github.com/pingcap/tidb/pkg/parser v0.0.0-20250811102254-4230cf349b01/go.mod h1:mpCcwRdMnmvNkBxcT4AqiE0yuvfJTdmCJs7cfznJw1w=
 github.com/pires/go-proxyproto v0.8.1 h1:9KEixbdJfhrbtjpz/ZwCdWDD2Xem0NZ38qMYaASJgp0=
 github.com/pires/go-proxyproto v0.8.1/go.mod h1:ZKAAyp3cgy5Y5Mo4n9AlScrkCZwUy0g3Jf+slqQVcuU=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=


### PR DESCRIPTION
## Summary

Bump Spirit from v0.12.1 pre-release to v0.13.0. Adds a `replace` directive for `block/tidb` parser fork (required for SPATIAL index support).

See [Spirit v0.13.0 release notes](https://github.com/block/spirit/releases/tag/v0.13.0).