### PR TITLE
refactor(checks-gate): rename FailingCheck to BlockingCheck with State field

### DIFF
--- a/pkg/cmd/templates/preview.go
+++ b/pkg/cmd/templates/preview.go
@@ -351,14 +351,14 @@ func PreviewCLIOutput(previewType PreviewType) {
 	case PreviewCommentReviewGateError:
 		fmt.Print(webhooktemplates.PreviewCommentReviewGateError())
 	case PreviewCommentChecksGateFailing:
-		fmt.Print(webhooktemplates.RenderApplyBlockedByFailingChecks("staging", []webhooktemplates.FailingCheck{
-			{Name: "CI / unit-tests", Conclusion: "failure"},
-			{Name: "CI / lint", Conclusion: "timed_out"},
+		fmt.Print(webhooktemplates.RenderApplyBlockedByFailingChecks("staging", []webhooktemplates.BlockingCheck{
+			{Name: "CI / unit-tests", State: "failure"},
+			{Name: "CI / lint", State: "timed_out"},
 		}))
 	case PreviewCommentChecksGateInProgress:
-		fmt.Print(webhooktemplates.RenderApplyBlockedByInProgressChecks("staging", []webhooktemplates.FailingCheck{
-			{Name: "CI / unit-tests", Conclusion: "in_progress"},
-			{Name: "CI / integration-tests", Conclusion: "queued"},
+		fmt.Print(webhooktemplates.RenderApplyBlockedByInProgressChecks("staging", []webhooktemplates.BlockingCheck{
+			{Name: "CI / unit-tests", State: "in_progress"},
+			{Name: "CI / integration-tests", State: "queued"},
 		}))
 	case PreviewCommentApplyAllType:
 		previewApplyCommandAllOutput()
@@ -957,15 +957,15 @@ func previewApplyCommandAllOutput() {
 		{"REVIEW REQUIRED (CODEOWNERS)", func() { fmt.Print(webhooktemplates.PreviewCommentReviewRequired()) }},
 		{"REVIEW GATE ERROR (FAIL-CLOSED)", func() { fmt.Print(webhooktemplates.PreviewCommentReviewGateError()) }},
 		{"CHECKS GATE: FAILING", func() {
-			fmt.Print(webhooktemplates.RenderApplyBlockedByFailingChecks("staging", []webhooktemplates.FailingCheck{
-				{Name: "CI / unit-tests", Conclusion: "failure"},
-				{Name: "CI / lint", Conclusion: "timed_out"},
+			fmt.Print(webhooktemplates.RenderApplyBlockedByFailingChecks("staging", []webhooktemplates.BlockingCheck{
+				{Name: "CI / unit-tests", State: "failure"},
+				{Name: "CI / lint", State: "timed_out"},
 			}))
 		}},
 		{"CHECKS GATE: IN PROGRESS", func() {
-			fmt.Print(webhooktemplates.RenderApplyBlockedByInProgressChecks("staging", []webhooktemplates.FailingCheck{
-				{Name: "CI / unit-tests", Conclusion: "in_progress"},
-				{Name: "CI / integration-tests", Conclusion: "queued"},
+			fmt.Print(webhooktemplates.RenderApplyBlockedByInProgressChecks("staging", []webhooktemplates.BlockingCheck{
+				{Name: "CI / unit-tests", State: "in_progress"},
+				{Name: "CI / integration-tests", State: "queued"},
 			}))
 		}},
 	}

--- a/pkg/webhook/apply_handlers.go
+++ b/pkg/webhook/apply_handlers.go
@@ -533,8 +533,8 @@ func ddlMatchesStoredPlan(planResp *apitypes.PlanResponse, storedPlan *storage.P
 // SchemaBot's own checks and checks with conclusion "neutral", "skipped", or "success".
 // Only checks with completed status and conclusion "failure", "error", or "timed_out"
 // are considered failing.
-func filterFailingNonSchemaBotChecks(statuses []ghclient.PRCheckStatus) []templates.FailingCheck {
-	var failing []templates.FailingCheck
+func filterFailingNonSchemaBotChecks(statuses []ghclient.PRCheckStatus) []templates.BlockingCheck {
+	var failing []templates.BlockingCheck
 	for _, s := range statuses {
 		if s.IsSchemaBot {
 			continue
@@ -544,9 +544,9 @@ func filterFailingNonSchemaBotChecks(statuses []ghclient.PRCheckStatus) []templa
 		}
 		switch s.Conclusion {
 		case "failure", "error", "timed_out":
-			failing = append(failing, templates.FailingCheck{
-				Name:       s.Name,
-				Conclusion: s.Conclusion,
+			failing = append(failing, templates.BlockingCheck{
+				Name:  s.Name,
+				State: s.Conclusion,
 			})
 		}
 	}
@@ -603,17 +603,17 @@ func (h *Handler) enforcePassingChecks(ctx context.Context, client *ghclient.Ins
 
 // filterInProgressNonSchemaBotChecks returns checks that are still running,
 // excluding SchemaBot's own checks.
-func filterInProgressNonSchemaBotChecks(statuses []ghclient.PRCheckStatus) []templates.FailingCheck {
-	var inProgress []templates.FailingCheck
+func filterInProgressNonSchemaBotChecks(statuses []ghclient.PRCheckStatus) []templates.BlockingCheck {
+	var inProgress []templates.BlockingCheck
 	for _, s := range statuses {
 		if s.IsSchemaBot {
 			continue
 		}
 		switch s.Status {
 		case "in_progress", "queued", "pending":
-			inProgress = append(inProgress, templates.FailingCheck{
-				Name:       s.Name,
-				Conclusion: s.Status,
+			inProgress = append(inProgress, templates.BlockingCheck{
+				Name:  s.Name,
+				State: s.Status,
 			})
 		}
 	}

--- a/pkg/webhook/apply_handlers_test.go
+++ b/pkg/webhook/apply_handlers_test.go
@@ -119,11 +119,11 @@ func TestFilterInProgressNonSchemaBotChecks(t *testing.T) {
 	inProgress := filterInProgressNonSchemaBotChecks(statuses)
 	require.Len(t, inProgress, 3)
 	assert.Equal(t, "CI / tests", inProgress[0].Name)
-	assert.Equal(t, "in_progress", inProgress[0].Conclusion)
+	assert.Equal(t, "in_progress", inProgress[0].State)
 	assert.Equal(t, "Security scan", inProgress[1].Name)
-	assert.Equal(t, "queued", inProgress[1].Conclusion)
+	assert.Equal(t, "queued", inProgress[1].State)
 	assert.Equal(t, "Deploy preview", inProgress[2].Name)
-	assert.Equal(t, "pending", inProgress[2].Conclusion)
+	assert.Equal(t, "pending", inProgress[2].State)
 }
 
 // rollupNode is a single GraphQL statusCheckRollup contexts node, used by tests

--- a/pkg/webhook/templates/apply_commands.go
+++ b/pkg/webhook/templates/apply_commands.go
@@ -231,15 +231,18 @@ func RenderApplyBlockedByPriorEnv(database, environment, priorEnv, status, actio
 	return sb.String()
 }
 
-// FailingCheck represents a PR check that is blocking apply.
-type FailingCheck struct {
-	Name       string
-	Conclusion string // "failure", "error", "timed_out"
+// BlockingCheck represents a PR check that is blocking apply, either because
+// it failed or because it is still running. State holds the GitHub-reported
+// conclusion (e.g. "failure", "error", "timed_out") for failed checks, or the
+// status (e.g. "in_progress", "queued", "pending") for in-progress checks.
+type BlockingCheck struct {
+	Name  string
+	State string
 }
 
 // RenderApplyBlockedByFailingChecks renders a comment when apply is blocked
 // because non-SchemaBot PR checks are failing.
-func RenderApplyBlockedByFailingChecks(environment string, failing []FailingCheck) string {
+func RenderApplyBlockedByFailingChecks(environment string, failing []BlockingCheck) string {
 	var sb strings.Builder
 
 	sb.WriteString("## ❌ Apply Blocked\n\n")
@@ -248,7 +251,7 @@ func RenderApplyBlockedByFailingChecks(environment string, failing []FailingChec
 	sb.WriteString("| Check | Status |\n")
 	sb.WriteString("|-------|--------|\n")
 	for _, f := range failing {
-		fmt.Fprintf(&sb, "| `%s` | %s |\n", f.Name, f.Conclusion)
+		fmt.Fprintf(&sb, "| `%s` | %s |\n", f.Name, f.State)
 	}
 	sb.WriteString("\nFix the failing checks and retry:\n")
 	fmt.Fprintf(&sb, "```\nschemabot apply -e %s\n```\n", environment)
@@ -258,7 +261,7 @@ func RenderApplyBlockedByFailingChecks(environment string, failing []FailingChec
 
 // RenderApplyBlockedByInProgressChecks renders a comment when apply is blocked
 // because non-SchemaBot PR checks are still running.
-func RenderApplyBlockedByInProgressChecks(environment string, inProgress []FailingCheck) string {
+func RenderApplyBlockedByInProgressChecks(environment string, inProgress []BlockingCheck) string {
 	var sb strings.Builder
 
 	sb.WriteString("## ⏳ Apply Blocked\n\n")
@@ -267,7 +270,7 @@ func RenderApplyBlockedByInProgressChecks(environment string, inProgress []Faili
 	sb.WriteString("| Check | Status |\n")
 	sb.WriteString("|-------|--------|\n")
 	for _, c := range inProgress {
-		fmt.Fprintf(&sb, "| `%s` | %s |\n", c.Name, c.Conclusion)
+		fmt.Fprintf(&sb, "| `%s` | %s |\n", c.Name, c.State)
 	}
 	sb.WriteString("\nWait for checks to complete and retry:\n")
 	fmt.Fprintf(&sb, "```\nschemabot apply -e %s\n```\n", environment)

--- a/pkg/webhook/templates/apply_test.go
+++ b/pkg/webhook/templates/apply_test.go
@@ -318,9 +318,9 @@ func TestPreviewCommentSummaryStopped(t *testing.T) {
 }
 
 func TestRenderApplyBlockedByFailingChecks(t *testing.T) {
-	failing := []FailingCheck{
-		{Name: "CI / unit-tests", Conclusion: "failure"},
-		{Name: "CI / lint", Conclusion: "timed_out"},
+	failing := []BlockingCheck{
+		{Name: "CI / unit-tests", State: "failure"},
+		{Name: "CI / lint", State: "timed_out"},
 	}
 
 	result := RenderApplyBlockedByFailingChecks("staging", failing)
@@ -335,8 +335,8 @@ func TestRenderApplyBlockedByFailingChecks(t *testing.T) {
 }
 
 func TestRenderApplyBlockedByFailingChecks_SingleCheck(t *testing.T) {
-	failing := []FailingCheck{
-		{Name: "security-scan", Conclusion: "error"},
+	failing := []BlockingCheck{
+		{Name: "security-scan", State: "error"},
 	}
 
 	result := RenderApplyBlockedByFailingChecks("production", failing)
@@ -347,9 +347,9 @@ func TestRenderApplyBlockedByFailingChecks_SingleCheck(t *testing.T) {
 }
 
 func TestRenderApplyBlockedByInProgressChecks(t *testing.T) {
-	inProgress := []FailingCheck{
-		{Name: "CI / unit-tests", Conclusion: "in_progress"},
-		{Name: "CI / integration", Conclusion: "queued"},
+	inProgress := []BlockingCheck{
+		{Name: "CI / unit-tests", State: "in_progress"},
+		{Name: "CI / integration", State: "queued"},
 	}
 
 	result := RenderApplyBlockedByInProgressChecks("staging", inProgress)


### PR DESCRIPTION
## What and Why ?
The `FailingCheck` struct was used for both failing and in-progress checks, and its `Conclusion` field carried either a check-run conclusion (`failure`/`error`/`timed_out`) or a status (`in_progress`/`queued`/`pending`) depending on the caller. This forced callers to overload the field's meaning and made the type misleading.

**Changes**
- Rename struct `FailingCheck` → `BlockingCheck` to reflect that it represents any check blocking apply.
- Rename field `Conclusion` → `State`, a neutral name that fits both conclusions and statuses.
- Update call sites in apply handlers, templates, tests, and CLI preview scenarios.

**No client changes required.** Zero references in `pkg/apitypes/`, `pkg/proto/`, `pkg/tern/`, or `pkg/engine/`.

## Affected surfaces

| Surface | Touched? | Why |
|---|---|---|
| **tern** (`pkg/proto/ternv1`) | ❌ | Engine-agnostic gRPC proto — never knew about checks. |
| **API types** (`pkg/apitypes`) | ❌ | HTTP/JSON DTOs — checks gate is an internal webhook concern. |
| **schemabot CLI** (binary consumers) | ❌ | Only `pkg/cmd/templates/preview.go` touches `BlockingCheck` for the dev-only `schemabot preview` subcommand. Real CLI commands (`apply`, `plan`, `unlock`, etc.) talk over HTTP/gRPC and don't import this struct. |
| **PR comment markdown** | ❌ | Rendered output is byte-identical (only the Go field name changed; the table content is still `failure` / `timed_out` / `in_progress` / etc.). |
| **Webhook event consumers** | ❌ | The struct is never marshaled — it's a transient render-time helper. |

## Scope of the change

All 23 references are in two server-side packages:

- `pkg/webhook/...` — the gate logic that builds the comment.
- `pkg/cmd/templates/preview.go` — the `schemabot preview` dev command (compile-time only).

This is a pure internal-naming refactor — no semver concerns, no migration notes for downstream consumers, no proto bump. Safe to ship as-is.