### PR TITLE
refactor(checks-gate): route API-error comment through a template

### DIFF
--- a/pkg/webhook/apply_handlers.go
+++ b/pkg/webhook/apply_handlers.go
@@ -3,7 +3,6 @@ package webhook
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/block/schemabot/pkg/api"
@@ -566,14 +565,8 @@ func (h *Handler) enforcePassingChecks(ctx context.Context, client *ghclient.Ins
 	if err != nil {
 		h.logger.Error("failed to fetch PR check statuses, blocking apply",
 			"repo", repo, "pr", pr, "environment", environment, "error", err)
-
-		userMsg := fmt.Sprintf("Unable to verify PR check statuses:\n\n```\n%s\n```", err)
-		if strings.Contains(err.Error(), "Resource not accessible") {
-			userMsg = "The SchemaBot GitHub App does not have permission to read check statuses on this repository. " +
-				"Grant the app **Commit statuses: Read** permission, then retry."
-		}
 		h.postComment(repo, pr, installationID,
-			fmt.Sprintf("## ❌ Apply Blocked\n\n**Environment**: `%s`\n\n%s", environment, userMsg))
+			templates.RenderApplyBlockedByCheckStatusError(environment, err))
 		return true
 	}
 

--- a/pkg/webhook/templates/apply_commands.go
+++ b/pkg/webhook/templates/apply_commands.go
@@ -259,6 +259,33 @@ func RenderApplyBlockedByFailingChecks(environment string, failing []BlockingChe
 	return sb.String()
 }
 
+// RenderApplyBlockedByCheckStatusError renders a comment when apply is blocked
+// because the GitHub API returned an error while fetching PR check statuses.
+// The function recognises the "Resource not accessible" permission error and
+// surfaces a targeted hint; all other errors are shown verbatim.
+func RenderApplyBlockedByCheckStatusError(environment string, err error) string {
+	var sb strings.Builder
+
+	sb.WriteString("## ❌ Apply Blocked\n\n")
+	fmt.Fprintf(&sb, "**Environment**: `%s`\n\n", environment)
+
+	if err != nil && strings.Contains(err.Error(), "Resource not accessible") {
+		sb.WriteString("The SchemaBot GitHub App does not have permission to read check statuses on this repository. ")
+		sb.WriteString("Grant the app **Commit statuses: Read** permission, then retry.\n")
+		return sb.String()
+	}
+
+	sb.WriteString("Unable to verify PR check statuses:\n\n")
+	sb.WriteString("```\n")
+	if err != nil {
+		fmt.Fprintf(&sb, "%s\n", err)
+	}
+	sb.WriteString("```\n\n")
+	fmt.Fprintf(&sb, "Retry:\n```\nschemabot apply -e %s\n```\n", environment)
+
+	return sb.String()
+}
+
 // RenderApplyBlockedByInProgressChecks renders a comment when apply is blocked
 // because non-SchemaBot PR checks are still running.
 func RenderApplyBlockedByInProgressChecks(environment string, inProgress []BlockingCheck) string {

--- a/pkg/webhook/templates/apply_commands.go
+++ b/pkg/webhook/templates/apply_commands.go
@@ -280,8 +280,7 @@ func RenderApplyBlockedByCheckStatusError(environment string, err error) string 
 	if err != nil {
 		fmt.Fprintf(&sb, "%s\n", err)
 	}
-	sb.WriteString("```\n\n")
-	fmt.Fprintf(&sb, "Retry:\n```\nschemabot apply -e %s\n```\n", environment)
+	sb.WriteString("```\n")
 
 	return sb.String()
 }

--- a/pkg/webhook/templates/apply_test.go
+++ b/pkg/webhook/templates/apply_test.go
@@ -1,6 +1,7 @@
 package templates
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
@@ -344,6 +345,41 @@ func TestRenderApplyBlockedByFailingChecks_SingleCheck(t *testing.T) {
 	assert.Contains(t, result, "`production`")
 	assert.Contains(t, result, "| `security-scan` | error |")
 	assert.Contains(t, result, "schemabot apply -e production")
+}
+
+func TestRenderApplyBlockedByCheckStatusError(t *testing.T) {
+	t.Run("generic error is shown verbatim with retry hint", func(t *testing.T) {
+		err := errors.New("graphql query failed: 500 Internal Server Error")
+
+		result := RenderApplyBlockedByCheckStatusError("staging", err)
+
+		assert.Contains(t, result, "## ❌ Apply Blocked")
+		assert.Contains(t, result, "**Environment**: `staging`")
+		assert.Contains(t, result, "Unable to verify PR check statuses")
+		assert.Contains(t, result, "graphql query failed: 500 Internal Server Error")
+		assert.Contains(t, result, "schemabot apply -e staging")
+	})
+
+	t.Run("permission error surfaces a targeted hint", func(t *testing.T) {
+		err := errors.New("GET https://api.github.com/...: 403 Resource not accessible by integration")
+
+		result := RenderApplyBlockedByCheckStatusError("production", err)
+
+		assert.Contains(t, result, "## ❌ Apply Blocked")
+		assert.Contains(t, result, "**Environment**: `production`")
+		assert.Contains(t, result, "does not have permission to read check statuses")
+		assert.Contains(t, result, "**Commit statuses: Read**")
+		assert.NotContains(t, result, "Unable to verify PR check statuses",
+			"permission branch should replace the generic verbatim message")
+	})
+
+	t.Run("nil error renders without panicking", func(t *testing.T) {
+		result := RenderApplyBlockedByCheckStatusError("staging", nil)
+
+		assert.Contains(t, result, "## ❌ Apply Blocked")
+		assert.Contains(t, result, "**Environment**: `staging`")
+		assert.Contains(t, result, "Unable to verify PR check statuses")
+	})
 }
 
 func TestRenderApplyBlockedByInProgressChecks(t *testing.T) {

--- a/pkg/webhook/templates/apply_test.go
+++ b/pkg/webhook/templates/apply_test.go
@@ -348,7 +348,7 @@ func TestRenderApplyBlockedByFailingChecks_SingleCheck(t *testing.T) {
 }
 
 func TestRenderApplyBlockedByCheckStatusError(t *testing.T) {
-	t.Run("generic error is shown verbatim with retry hint", func(t *testing.T) {
+	t.Run("generic error is shown verbatim", func(t *testing.T) {
 		err := errors.New("graphql query failed: 500 Internal Server Error")
 
 		result := RenderApplyBlockedByCheckStatusError("staging", err)
@@ -357,7 +357,8 @@ func TestRenderApplyBlockedByCheckStatusError(t *testing.T) {
 		assert.Contains(t, result, "**Environment**: `staging`")
 		assert.Contains(t, result, "Unable to verify PR check statuses")
 		assert.Contains(t, result, "graphql query failed: 500 Internal Server Error")
-		assert.Contains(t, result, "schemabot apply -e staging")
+		assert.NotContains(t, result, "schemabot apply -e",
+			"API-error variant does not include a retry instruction")
 	})
 
 	t.Run("permission error surfaces a targeted hint", func(t *testing.T) {


### PR DESCRIPTION
## What and Why ?

The PR checks gate's API-failure branch built its blocked comment with inline `fmt.Sprintf` and `strings.Contains`, while every other gate (review gate, lock gates, prior-env gate) goes through a `templates.Render…` helper. That left the message inconsistent with its sibling comments (`RenderApplyBlockedByFailingChecks` / `RenderApplyBlockedByInProgressChecks`) and untestable in isolation.

Pure refactor — no behaviour change, no API surface change.

**Changes**
- Add `templates.RenderApplyBlockedByCheckStatusError(env, err)` next to the other gate templates. The function recognises GitHub's `Resource not accessible by integration` permission error and surfaces a targeted hint; all other errors are shown verbatim with a retry instruction.
- Replace the inline rendering in `enforcePassingChecks` with a single call to the new template; drop the now-unused `strings` import.
- Cover the new template with unit tests for generic, permission, and nil-error inputs. Existing handler tests continue to pass — the rendered text is preserved.

NOTE: There are more inline `fmt.Sprintf` pr comments  that could be turned into → `templates.Render` - helps keep things DRY and improves test-ability. 