### PR TITLE
fix(github): require -e flag on rollback command

### DIFF
--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -535,8 +535,8 @@ schemabot apply -e production
 | `schemabot stop <apply-id>` | Stop an in-progress deployment |
 | `schemabot start <apply-id>` | Resume a stopped deployment |
 | `schemabot cutover <apply-id>` | Complete a deferred cutover |
-| `schemabot rollback <apply-id>` | Generate a rollback plan |
-| `schemabot rollback-confirm <apply-id>` | Execute a rollback |
+| `schemabot rollback <apply-id> -e <env>` | Generate a rollback plan |
+| `schemabot rollback-confirm -e <env>` | Execute a rollback |
 
 **Options**: `-e <env>` environment, `-d <db>` database, `--defer-cutover`, `--allow-unsafe`, `--skip-revert` (Vitess)
 
@@ -682,8 +682,8 @@ That command wasn't recognized. Available commands:
 | `schemabot stop <apply-id>` | Stop an in-progress deployment |
 | `schemabot start <apply-id>` | Resume a stopped deployment |
 | `schemabot cutover <apply-id>` | Complete a deferred cutover |
-| `schemabot rollback <apply-id>` | Generate a rollback plan |
-| `schemabot rollback-confirm <apply-id>` | Execute a rollback |
+| `schemabot rollback <apply-id> -e <env>` | Generate a rollback plan |
+| `schemabot rollback-confirm -e <env>` | Execute a rollback |
 
 **Options**: `-e <env>` environment, `-d <db>` database, `--defer-cutover`, `--allow-unsafe`, `--skip-revert` (Vitess)
 

--- a/pkg/checks/README.md
+++ b/pkg/checks/README.md
@@ -210,7 +210,7 @@ No staging check is created. Production apply is allowed directly.
 
 ### Rollback (emergency)
 
-`schemabot rollback <apply-id>` is NOT gated by staging-first. Rollbacks are emergency operations that need to execute immediately regardless of staging state.
+`schemabot rollback <apply-id> -e <environment>` is NOT gated by staging-first. Rollbacks are emergency operations that need to execute immediately regardless of staging state.
 
 ### Staging in progress
 

--- a/pkg/webhook/README.md
+++ b/pkg/webhook/README.md
@@ -154,7 +154,7 @@ schemabot <command> [-e <environment>] [-d <database>] [--enable-revert] [--defe
 | `cutover` | Yes | Complete deferred cutover |
 | `revert` | Yes | Revert (within revert window) |
 | `skip-revert` | Yes | Make changes permanent |
-| `rollback` | No (runs all envs) | Generate rollback plan |
+| `rollback` | Yes | Generate rollback plan |
 | `rollback-confirm` | Yes | Execute rollback |
 | `fix-lint` | No | Auto-fix lint warnings |
 | `help` | No | Show command reference |

--- a/pkg/webhook/commands.go
+++ b/pkg/webhook/commands.go
@@ -13,6 +13,7 @@ type CommandParser struct {
 	mentionRegex           *regexp.Regexp
 	helpRegex              *regexp.Regexp
 	commandWithoutEnvRegex *regexp.Regexp
+	rollbackCommandRegex   *regexp.Regexp
 	rollbackRegex          *regexp.Regexp // rollback <apply-id>
 	environmentRegex       *regexp.Regexp // -e <env>
 	databaseRegex          *regexp.Regexp
@@ -29,6 +30,7 @@ func NewCommandParser() *CommandParser {
 		mentionRegex:           regexp.MustCompile(`(?i)\bschemabot\b`),
 		helpRegex:              regexp.MustCompile(`(?i)schemabot\s+help\b`),
 		commandWithoutEnvRegex: regexp.MustCompile(`(?i)schemabot\s+(plan|apply|apply-confirm|unlock|stop|revert|skip-revert|cutover|rollback|rollback-confirm|fix-lint)\b`),
+		rollbackCommandRegex:   regexp.MustCompile(`(?i)schemabot\s+rollback(?:\s|$)`),
 		rollbackRegex:          regexp.MustCompile(`(?i)schemabot\s+rollback\s+(apply[_-][a-f0-9]+)`),
 		environmentRegex:       regexp.MustCompile(`(?i)-e\s+(staging|production)`),
 		databaseRegex:          regexp.MustCompile(`(?i)-d\s+([a-zA-Z0-9_-]+)`),
@@ -63,22 +65,25 @@ func (p *CommandParser) ParseCommand(body string) CommandResult {
 	}
 
 	// Check rollback <apply-id> -e <env>
-	rollbackMatches := p.rollbackRegex.FindStringSubmatch(body)
-	if len(rollbackMatches) >= 2 {
+	if p.rollbackCommandRegex.MatchString(body) {
 		result := CommandResult{
 			Action:       action.Rollback,
-			ApplyID:      rollbackMatches[1],
 			IsMention:    true,
 			DeferCutover: p.deferCutoverRegex.MatchString(body),
+		}
+		rollbackMatches := p.rollbackRegex.FindStringSubmatch(body)
+		if len(rollbackMatches) >= 2 {
+			result.ApplyID = rollbackMatches[1]
 		}
 		dbMatches := p.databaseRegex.FindStringSubmatch(body)
 		if len(dbMatches) >= 2 {
 			result.Database = dbMatches[1]
 		}
-		// Require -e flag so the environment filter routes to the correct instance
 		envMatches := p.environmentRegex.FindStringSubmatch(body)
 		if len(envMatches) >= 2 {
 			result.Environment = envMatches[1]
+		}
+		if result.Environment != "" {
 			result.Found = true
 		} else {
 			result.MissingEnv = true

--- a/pkg/webhook/commands.go
+++ b/pkg/webhook/commands.go
@@ -81,7 +81,7 @@ func (p *CommandParser) ParseCommand(body string) CommandResult {
 		}
 		envMatches := p.environmentRegex.FindStringSubmatch(body)
 		if len(envMatches) >= 2 {
-			result.Environment = envMatches[1]
+			result.Environment = strings.ToLower(envMatches[1])
 		}
 		if result.Environment != "" {
 			result.Found = true

--- a/pkg/webhook/commands.go
+++ b/pkg/webhook/commands.go
@@ -14,6 +14,7 @@ type CommandParser struct {
 	helpRegex              *regexp.Regexp
 	commandWithoutEnvRegex *regexp.Regexp
 	rollbackRegex          *regexp.Regexp // rollback <apply-id>
+	environmentRegex       *regexp.Regexp // -e <env>
 	databaseRegex          *regexp.Regexp
 	skipRevertRegex        *regexp.Regexp
 	deferCutoverRegex      *regexp.Regexp
@@ -29,6 +30,7 @@ func NewCommandParser() *CommandParser {
 		helpRegex:              regexp.MustCompile(`(?i)schemabot\s+help\b`),
 		commandWithoutEnvRegex: regexp.MustCompile(`(?i)schemabot\s+(plan|apply|apply-confirm|unlock|stop|revert|skip-revert|cutover|rollback|rollback-confirm|fix-lint)\b`),
 		rollbackRegex:          regexp.MustCompile(`(?i)schemabot\s+rollback\s+(apply[_-][a-f0-9]+)`),
+		environmentRegex:       regexp.MustCompile(`(?i)-e\s+(staging|production)`),
 		databaseRegex:          regexp.MustCompile(`(?i)-d\s+([a-zA-Z0-9_-]+)`),
 		skipRevertRegex:        regexp.MustCompile(`(?i)--skip-revert\b`),
 		deferCutoverRegex:      regexp.MustCompile(`(?i)--defer-cutover\b`),
@@ -60,19 +62,26 @@ func (p *CommandParser) ParseCommand(body string) CommandResult {
 		return CommandResult{Action: action.Help, IsHelp: true, IsMention: true}
 	}
 
-	// Check rollback <apply-id> (positional arg, no -e flag)
+	// Check rollback <apply-id> -e <env>
 	rollbackMatches := p.rollbackRegex.FindStringSubmatch(body)
 	if len(rollbackMatches) >= 2 {
 		result := CommandResult{
 			Action:       action.Rollback,
 			ApplyID:      rollbackMatches[1],
-			Found:        true,
 			IsMention:    true,
 			DeferCutover: p.deferCutoverRegex.MatchString(body),
 		}
 		dbMatches := p.databaseRegex.FindStringSubmatch(body)
 		if len(dbMatches) >= 2 {
 			result.Database = dbMatches[1]
+		}
+		// Require -e flag so the environment filter routes to the correct instance
+		envMatches := p.environmentRegex.FindStringSubmatch(body)
+		if len(envMatches) >= 2 {
+			result.Environment = envMatches[1]
+			result.Found = true
+		} else {
+			result.MissingEnv = true
 		}
 		return result
 	}

--- a/pkg/webhook/commands_test.go
+++ b/pkg/webhook/commands_test.go
@@ -198,6 +198,16 @@ func TestParseCommand(t *testing.T) {
 		},
 		{
 			name: "rollback without apply ID",
+			body: "schemabot rollback -e staging",
+			expected: CommandResult{
+				Action:      "rollback",
+				Environment: "staging",
+				Found:       true,
+				IsMention:   true,
+			},
+		},
+		{
+			name: "rollback without apply ID or env",
 			body: "schemabot rollback",
 			expected: CommandResult{
 				Action:     "rollback",

--- a/pkg/webhook/commands_test.go
+++ b/pkg/webhook/commands_test.go
@@ -176,13 +176,24 @@ func TestParseCommand(t *testing.T) {
 			},
 		},
 		{
-			name: "rollback with apply ID",
+			name: "rollback with apply ID and env",
+			body: "schemabot rollback apply_abc123 -e staging",
+			expected: CommandResult{
+				Action:      "rollback",
+				ApplyID:     "apply_abc123",
+				Environment: "staging",
+				Found:       true,
+				IsMention:   true,
+			},
+		},
+		{
+			name: "rollback with apply ID missing env",
 			body: "schemabot rollback apply_abc123",
 			expected: CommandResult{
-				Action:    "rollback",
-				ApplyID:   "apply_abc123",
-				Found:     true,
-				IsMention: true,
+				Action:     "rollback",
+				ApplyID:    "apply_abc123",
+				IsMention:  true,
+				MissingEnv: true,
 			},
 		},
 		{

--- a/pkg/webhook/commands_test.go
+++ b/pkg/webhook/commands_test.go
@@ -177,7 +177,7 @@ func TestParseCommand(t *testing.T) {
 		},
 		{
 			name: "rollback with apply ID and env",
-			body: "schemabot rollback apply_abc123 -e staging",
+			body: "schemabot rollback apply_abc123 -e Staging",
 			expected: CommandResult{
 				Action:      "rollback",
 				ApplyID:     "apply_abc123",
@@ -198,7 +198,7 @@ func TestParseCommand(t *testing.T) {
 		},
 		{
 			name: "rollback without apply ID",
-			body: "schemabot rollback -e staging",
+			body: "schemabot rollback -e Staging",
 			expected: CommandResult{
 				Action:      "rollback",
 				Environment: "staging",

--- a/pkg/webhook/issue_comment.go
+++ b/pkg/webhook/issue_comment.go
@@ -122,9 +122,11 @@ func (h *Handler) handleIssueComment(w http.ResponseWriter, body []byte) {
 			return
 		}
 		if result.Action == action.Rollback {
-			// Rollback without apply ID — handler will post usage message
-			go h.handleRollbackCommand(repo, pr, installationID, requestedBy, result)
-			h.writeJSON(w, http.StatusOK, map[string]string{"message": "rollback started"})
+			h.postComment(repo, pr, installationID,
+				"## Missing Environment\n\n"+
+					"Usage: `schemabot rollback <apply-id> -e <environment>`\n\n"+
+					"The `-e` flag is required so the correct SchemaBot instance handles the rollback.")
+			h.writeJSON(w, http.StatusOK, map[string]string{"message": "missing environment flag"})
 			return
 		}
 		h.postComment(repo, pr, installationID, templates.RenderMissingEnv(result.Action))

--- a/pkg/webhook/issue_comment.go
+++ b/pkg/webhook/issue_comment.go
@@ -122,6 +122,14 @@ func (h *Handler) handleIssueComment(w http.ResponseWriter, body []byte) {
 			return
 		}
 		if result.Action == action.Rollback {
+			if result.ApplyID == "" {
+				h.postComment(repo, pr, installationID,
+					"## Missing Arguments\n\n"+
+						"Usage: `schemabot rollback <apply-id> -e <environment>`\n\n"+
+						"Rollback requires both an apply ID and the `-e` flag so the correct SchemaBot instance handles it.")
+				h.writeJSON(w, http.StatusOK, map[string]string{"message": "missing rollback arguments"})
+				return
+			}
 			h.postComment(repo, pr, installationID,
 				"## Missing Environment\n\n"+
 					"Usage: `schemabot rollback <apply-id> -e <environment>`\n\n"+

--- a/pkg/webhook/issue_comment.go
+++ b/pkg/webhook/issue_comment.go
@@ -126,14 +126,14 @@ func (h *Handler) handleIssueComment(w http.ResponseWriter, body []byte) {
 				h.postComment(repo, pr, installationID,
 					"## Missing Arguments\n\n"+
 						"Usage: `schemabot rollback <apply-id> -e <environment>`\n\n"+
-						"Rollback requires both an apply ID and the `-e` flag so the correct SchemaBot instance handles it.")
+						"Rollback requires both an apply ID and the `-e` flag to select the target environment.")
 				h.writeJSON(w, http.StatusOK, map[string]string{"message": "missing rollback arguments"})
 				return
 			}
 			h.postComment(repo, pr, installationID,
 				"## Missing Environment\n\n"+
 					"Usage: `schemabot rollback <apply-id> -e <environment>`\n\n"+
-					"The `-e` flag is required so the correct SchemaBot instance handles the rollback.")
+					"The `-e` flag is required to select the target environment.")
 			h.writeJSON(w, http.StatusOK, map[string]string{"message": "missing environment flag"})
 			return
 		}

--- a/pkg/webhook/rollback.go
+++ b/pkg/webhook/rollback.go
@@ -13,7 +13,7 @@ import (
 	"github.com/block/schemabot/pkg/webhook/templates"
 )
 
-// handleRollbackCommand handles the "schemabot rollback <apply-id>" PR comment command.
+// handleRollbackCommand handles the "schemabot rollback <apply-id> -e <env>" PR comment command.
 // It looks up the specified apply, generates a rollback plan from its original schema,
 // acquires a lock, and posts the plan for confirmation.
 func (h *Handler) handleRollbackCommand(repo string, pr int, installationID int64, requestedBy string, result CommandResult) {
@@ -24,7 +24,7 @@ func (h *Handler) handleRollbackCommand(repo string, pr int, installationID int6
 	if applyID == "" {
 		h.postComment(repo, pr, installationID,
 			"## Missing Apply ID\n\n"+
-				"Usage: `schemabot rollback <apply-id>`\n\n"+
+				"Usage: `schemabot rollback <apply-id> -e <environment>`\n\n"+
 				"You can find the apply ID in the summary comment of a completed apply, "+
 				"or by running `schemabot status`.")
 		return

--- a/pkg/webhook/rollback_test.go
+++ b/pkg/webhook/rollback_test.go
@@ -67,7 +67,7 @@ func TestWebhookRollbackMissingApplyID(t *testing.T) {
 	h, comments, _ := newTestHandler(t)
 
 	req := buildWebhookRequest(t, webhookPayloadOpts{
-		comment: "schemabot rollback",
+		comment: "schemabot rollback -e staging",
 		isPR:    true,
 	}, nil)
 
@@ -78,7 +78,8 @@ func TestWebhookRollbackMissingApplyID(t *testing.T) {
 
 	select {
 	case body := <-comments:
-		assert.Contains(t, body, "Missing Environment")
+		assert.Contains(t, body, "Missing Apply ID")
+		assert.Contains(t, body, "schemabot rollback <apply-id> -e <environment>")
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out waiting for comment")
 	}

--- a/pkg/webhook/rollback_test.go
+++ b/pkg/webhook/rollback_test.go
@@ -85,6 +85,29 @@ func TestWebhookRollbackMissingApplyID(t *testing.T) {
 	}
 }
 
+func TestWebhookRollbackMissingApplyIDAndEnv(t *testing.T) {
+	h, comments, _ := newTestHandler(t)
+
+	req := buildWebhookRequest(t, webhookPayloadOpts{
+		comment: "schemabot rollback",
+		isPR:    true,
+	}, nil)
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), "missing rollback arguments")
+
+	select {
+	case body := <-comments:
+		assert.Contains(t, body, "Missing Arguments")
+		assert.Contains(t, body, "schemabot rollback <apply-id> -e <environment>")
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for comment")
+	}
+}
+
 func TestWebhookApplyDispatch(t *testing.T) {
 	h, _, _ := newTestHandler(t)
 

--- a/pkg/webhook/rollback_test.go
+++ b/pkg/webhook/rollback_test.go
@@ -14,7 +14,7 @@ func TestWebhookRollbackDispatch(t *testing.T) {
 	h, _, _ := newTestHandler(t)
 
 	req := buildWebhookRequest(t, webhookPayloadOpts{
-		comment: "schemabot rollback apply_abc123",
+		comment: "schemabot rollback apply_abc123 -e staging",
 		isPR:    true,
 	}, nil)
 
@@ -23,6 +23,29 @@ func TestWebhookRollbackDispatch(t *testing.T) {
 
 	require.Equal(t, http.StatusOK, rr.Code)
 	assert.Contains(t, rr.Body.String(), "rollback started")
+}
+
+func TestWebhookRollbackMissingEnv(t *testing.T) {
+	h, comments, _ := newTestHandler(t)
+
+	req := buildWebhookRequest(t, webhookPayloadOpts{
+		comment: "schemabot rollback apply_abc123",
+		isPR:    true,
+	}, nil)
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), "missing environment flag")
+
+	select {
+	case body := <-comments:
+		assert.Contains(t, body, "Missing Environment")
+		assert.Contains(t, body, "-e")
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for comment")
+	}
 }
 
 func TestWebhookRollbackConfirmDispatch(t *testing.T) {
@@ -55,8 +78,7 @@ func TestWebhookRollbackMissingApplyID(t *testing.T) {
 
 	select {
 	case body := <-comments:
-		assert.Contains(t, body, "Missing Apply ID")
-		assert.Contains(t, body, "schemabot rollback <apply-id>")
+		assert.Contains(t, body, "Missing Environment")
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out waiting for comment")
 	}

--- a/pkg/webhook/templates/help.go
+++ b/pkg/webhook/templates/help.go
@@ -12,8 +12,8 @@ func commandReference() string {
 | ` + "`schemabot stop <apply-id>`" + ` | Stop an in-progress deployment |
 | ` + "`schemabot start <apply-id>`" + ` | Resume a stopped deployment |
 | ` + "`schemabot cutover <apply-id>`" + ` | Complete a deferred cutover |
-| ` + "`schemabot rollback <apply-id>`" + ` | Generate a rollback plan |
-| ` + "`schemabot rollback-confirm <apply-id>`" + ` | Execute a rollback |
+| ` + "`schemabot rollback <apply-id> -e <env>`" + ` | Generate a rollback plan |
+| ` + "`schemabot rollback-confirm -e <env>`" + ` | Execute a rollback |
 
 **Options**: ` + "`-e <env>`" + ` environment, ` + "`-d <db>`" + ` database, ` + "`--defer-cutover`" + `, ` + "`--allow-unsafe`" + `, ` + "`--skip-revert`" + ` (Vitess)
 

--- a/pkg/webhook/templates/rollback.go
+++ b/pkg/webhook/templates/rollback.go
@@ -75,6 +75,6 @@ func RenderRollbackNoCompletedApply(database, environment string) string {
 func RenderRollbackConfirmNoLock(database, environment string) string {
 	return fmt.Sprintf("## 🔒 No Lock Found\n\n"+
 		"**Database**: `%s` | **Environment**: `%s`\n\n"+
-		"No rollback lock is held. Run `schemabot rollback -e %s` first to generate a rollback plan.",
+		"No rollback lock is held. Run `schemabot rollback <apply-id> -e %s` first to generate a rollback plan.",
 		database, environment, environment)
 }

--- a/pkg/webhook/templates/rollback_test.go
+++ b/pkg/webhook/templates/rollback_test.go
@@ -104,5 +104,5 @@ func TestRenderRollbackConfirmNoLock(t *testing.T) {
 	assert.Contains(t, rendered, "## 🔒 No Lock Found")
 	assert.Contains(t, rendered, "`testapp`")
 	assert.Contains(t, rendered, "`staging`")
-	assert.Contains(t, rendered, "schemabot rollback -e staging")
+	assert.Contains(t, rendered, "schemabot rollback <apply-id> -e staging")
 }

--- a/pkg/webhook/webhook_e2e_test.go
+++ b/pkg/webhook/webhook_e2e_test.go
@@ -1501,7 +1501,7 @@ func applyEmbeddedSchema(db *sql.DB, schemaFS embed.FS) error {
 
 // TestE2ERollbackPlanViaWebhook tests the full rollback flow:
 // 1. Plan + apply a schema change via the service (simulating a prior apply)
-// 2. Run "schemabot rollback -e staging" via webhook
+// 2. Run "schemabot rollback <apply-id> -e staging" via webhook
 // 3. Verify the rollback plan comment is posted with reverse DDL
 func TestE2ERollbackPlanViaWebhook(t *testing.T) {
 	dbName := "webhook_rollback"
@@ -1576,7 +1576,7 @@ func TestE2ERollbackPlanViaWebhook(t *testing.T) {
 
 	// Step 4: Send rollback command with the apply ID
 	req := buildWebhookRequest(t, webhookPayloadOpts{
-		comment: fmt.Sprintf("schemabot rollback %s", storedApply.ApplyIdentifier),
+		comment: fmt.Sprintf("schemabot rollback %s -e staging", storedApply.ApplyIdentifier),
 		isPR:    true,
 	}, nil)
 
@@ -1612,7 +1612,7 @@ func TestE2ERollbackApplyNotFound(t *testing.T) {
 	h.service = svc
 
 	req := buildWebhookRequest(t, webhookPayloadOpts{
-		comment: "schemabot rollback apply_deadbeef0000",
+		comment: "schemabot rollback apply_deadbeef0000 -e staging",
 		isPR:    true,
 	}, nil)
 
@@ -1665,7 +1665,7 @@ func TestE2ERollbackConfirmNoLock(t *testing.T) {
 	select {
 	case body := <-result.comments:
 		assert.Contains(t, body, "No Lock Found")
-		assert.Contains(t, body, "schemabot rollback -e staging")
+		assert.Contains(t, body, "schemabot rollback <apply-id> -e staging")
 	case <-time.After(30 * time.Second):
 		t.Fatal("timed out waiting for no-lock comment")
 	}
@@ -1736,7 +1736,7 @@ func TestE2ERollbackConfirmExecutesAndPostsComments(t *testing.T) {
 	require.NoError(t, err)
 
 	req := buildWebhookRequest(t, webhookPayloadOpts{
-		comment: fmt.Sprintf("schemabot rollback %s", storedApply.ApplyIdentifier),
+		comment: fmt.Sprintf("schemabot rollback %s -e staging", storedApply.ApplyIdentifier),
 		isPR:    true,
 	}, nil)
 	rr := httptest.NewRecorder()
@@ -1858,7 +1858,7 @@ func TestE2ERollbackConfirmUpdatesCheckToActionRequired(t *testing.T) {
 
 	// Run rollback
 	req := buildWebhookRequest(t, webhookPayloadOpts{
-		comment: fmt.Sprintf("schemabot rollback %s", storedApply.ApplyIdentifier),
+		comment: fmt.Sprintf("schemabot rollback %s -e staging", storedApply.ApplyIdentifier),
 		isPR:    true,
 	}, nil)
 	rr := httptest.NewRecorder()
@@ -1935,7 +1935,7 @@ func TestE2ERollbackIgnoredByNonOwningInstance(t *testing.T) {
 
 	// Send rollback command for the staging apply to the production instance
 	req := buildWebhookRequest(t, webhookPayloadOpts{
-		comment: "schemabot rollback apply-aabbccdd0011",
+		comment: "schemabot rollback apply-aabbccdd0011 -e staging",
 		isPR:    true,
 	}, nil)
 	rr := httptest.NewRecorder()


### PR DESCRIPTION
## Summary

- Require `-e <environment>` flag on `schemabot rollback <apply-id>` so the environment filter routes to the correct instance
- Without `-e`, both staging and production bots react to the rollback comment since the environment filter only triggers when the environment is set
- Posts a usage message when `-e` is missing: `schemabot rollback <apply-id> -e <environment>`