### PR TITLE
feat(github): add PR comment cutover command + cutover fixes

### DIFF
--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -1498,7 +1498,7 @@ Schema changes are being applied. Progress updates will be posted as new comment
 - **`users`**: 🟦🟦🟦🟦🟦🟦🟦🟦🟦⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ 48%  
 
   ```sql
-  ALTER TABLE `users` ADD INDEX `idx_email_created` (`email`, `created_at`)
+  ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
   ```
   Rows: 3,500,000 / 7,200,000 · ETA: 5m 30s
 
@@ -1516,7 +1516,7 @@ schemabot stop apply-a1b2c3d4e5f6
 <summary><a name="single-table-completed"></a><strong>Single Table: Completed</strong></summary>
 
 
-## ✅ Schema Change Applied
+## Schema Change Completed
 
 **Database**: `testapp` | **Environment**: `staging` | **Apply ID**: `apply-a1b2c3d4e5f6` | **Elapsed**: 8m
 
@@ -1527,9 +1527,13 @@ schemabot stop apply-a1b2c3d4e5f6
 - **`users`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete  
 
   ```sql
-  ALTER TABLE `users` ADD INDEX `idx_email_created` (`email`, `created_at`)
+  ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
   ```
 
+
+---
+
+*See completion summary below*
 
 </details>
 
@@ -1548,7 +1552,7 @@ schemabot stop apply-a1b2c3d4e5f6
 - **`users`**: 🟥⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ ❌ Failed  
 
   ```sql
-  ALTER TABLE `users` ADD INDEX `idx_email_created` (`email`, `created_at`)
+  ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
   ```
 
 
@@ -1578,7 +1582,7 @@ schemabot apply -e staging
 - **`users`**: 🟧🟧🟧🟧🟧🟧🟧⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ ⏹️ Stopped at 39%  
 
   ```sql
-  ALTER TABLE `users` ADD INDEX `idx_email_created` (`email`, `created_at`)
+  ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
   ```
   Rows: 156,342 / 397,453
 
@@ -1609,19 +1613,19 @@ schemabot start apply-a1b2c3d4e5f6
 - **`orders`**: ⏳ Queued  
 
   ```sql
-  ALTER TABLE `orders` ADD INDEX `idx_user_id` (`user_id`)
+  ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
   ```
 
 - **`users`**: ⏳ Queued  
 
   ```sql
-  ALTER TABLE `users` ADD INDEX `idx_email` (`email`)
+  ALTER TABLE `users` ADD INDEX `idx_email`(`email`);
   ```
 
 - **`products`**: ⏳ Queued  
 
   ```sql
-  ALTER TABLE `products` ADD INDEX `idx_price` (`price_cents`)
+  ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
   ```
 
 
@@ -1651,20 +1655,20 @@ schemabot stop apply-a1b2c3d4e5f6
 - **`orders`**: 🟦🟦🟦🟦⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ 22%  
 
   ```sql
-  ALTER TABLE `orders` ADD INDEX `idx_user_id` (`user_id`)
+  ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
   ```
   Rows: 321,450 / 1,466,232 · ETA: 5m 40s
 
 - **`users`**: ⏳ Queued  
 
   ```sql
-  ALTER TABLE `users` ADD INDEX `idx_email` (`email`)
+  ALTER TABLE `users` ADD INDEX `idx_email`(`email`);
   ```
 
 - **`products`**: ⏳ Queued  
 
   ```sql
-  ALTER TABLE `products` ADD INDEX `idx_price` (`price_cents`)
+  ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
   ```
 
 
@@ -1694,20 +1698,20 @@ schemabot stop apply-a1b2c3d4e5f6
 - **`users`**: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦⬜⬜⬜⬜⬜⬜⬜⬜ 62%  
 
   ```sql
-  ALTER TABLE `users` ADD INDEX `idx_email` (`email`)
+  ALTER TABLE `users` ADD INDEX `idx_email`(`email`);
   ```
   Rows: 914,707 / 1,466,232 · ETA: 3m 15s
 
 - **`products`**: ⏳ Queued  
 
   ```sql
-  ALTER TABLE `products` ADD INDEX `idx_price` (`price_cents`)
+  ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
   ```
 
 - **`orders`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete  
 
   ```sql
-  ALTER TABLE `orders` ADD INDEX `idx_user_id` (`user_id`)
+  ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
   ```
 
 
@@ -1737,20 +1741,20 @@ schemabot stop apply-a1b2c3d4e5f6
 - **`products`**: 🟦🟦🟦⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ 17%  
 
   ```sql
-  ALTER TABLE `products` ADD INDEX `idx_price` (`price_cents`)
+  ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
   ```
   Rows: 87,231 / 523,140 · ETA: 7m 0s
 
 - **`orders`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete  
 
   ```sql
-  ALTER TABLE `orders` ADD INDEX `idx_user_id` (`user_id`)
+  ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
   ```
 
 - **`users`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete  
 
   ```sql
-  ALTER TABLE `users` ADD INDEX `idx_email` (`email`)
+  ALTER TABLE `users` ADD INDEX `idx_email`(`email`);
   ```
 
 
@@ -1767,7 +1771,7 @@ schemabot stop apply-a1b2c3d4e5f6
 <summary><a name="all-completed"></a><strong>All Completed</strong></summary>
 
 
-## ✅ Schema Change Applied
+## Schema Change Completed
 
 **Database**: `testapp` | **Environment**: `staging` | **Apply ID**: `apply-a1b2c3d4e5f6` | **Elapsed**: 8m
 
@@ -1780,21 +1784,25 @@ schemabot stop apply-a1b2c3d4e5f6
 - **`orders`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete  
 
   ```sql
-  ALTER TABLE `orders` ADD INDEX `idx_user_id` (`user_id`)
+  ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
   ```
 
 - **`users`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete  
 
   ```sql
-  ALTER TABLE `users` ADD INDEX `idx_email` (`email`)
+  ALTER TABLE `users` ADD INDEX `idx_email`(`email`);
   ```
 
 - **`products`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete  
 
   ```sql
-  ALTER TABLE `products` ADD INDEX `idx_price` (`price_cents`)
+  ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
   ```
 
+
+---
+
+*See completion summary below*
 
 </details>
 
@@ -1815,19 +1823,19 @@ schemabot stop apply-a1b2c3d4e5f6
 - **`orders`**: 🟥⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ ❌ Failed  
 
   ```sql
-  ALTER TABLE `orders` ADD INDEX `idx_user_id` (`user_id`)
+  ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
   ```
 
 - **`users`**: ⊘ Cancelled (not started)  
 
   ```sql
-  ALTER TABLE `users` ADD INDEX `idx_email` (`email`)
+  ALTER TABLE `users` ADD INDEX `idx_email`(`email`);
   ```
 
 - **`products`**: ⊘ Cancelled (not started)  
 
   ```sql
-  ALTER TABLE `products` ADD INDEX `idx_price` (`price_cents`)
+  ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
   ```
 
 
@@ -1859,19 +1867,19 @@ schemabot apply -e staging
 - **`users`**: 🟥🟥🟥🟥🟥🟥⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ ❌ Failed  
 
   ```sql
-  ALTER TABLE `users` ADD INDEX `idx_email` (`email`)
+  ALTER TABLE `users` ADD INDEX `idx_email`(`email`);
   ```
 
 - **`orders`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete  
 
   ```sql
-  ALTER TABLE `orders` ADD INDEX `idx_user_id` (`user_id`)
+  ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
   ```
 
 - **`products`**: ⊘ Cancelled (not started)  
 
   ```sql
-  ALTER TABLE `products` ADD INDEX `idx_price` (`price_cents`)
+  ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
   ```
 
 
@@ -1903,14 +1911,14 @@ schemabot apply -e staging
 - **`users`**: 🟧🟧🟧🟧🟧🟧🟧🟧🟧🟧🟧🟧🟧🟧⬜⬜⬜⬜⬜⬜ ⏹️ Stopped at 72%  
 
   ```sql
-  ALTER TABLE `users` ADD INDEX `idx_email` (`email`)
+  ALTER TABLE `users` ADD INDEX `idx_email`(`email`);
   ```
   Rows: 1,055,687 / 1,466,232
 
 - **`orders`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete  
 
   ```sql
-  ALTER TABLE `orders` ADD INDEX `idx_user_id` (`user_id`)
+  ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
   ```
 
 
@@ -1933,6 +1941,8 @@ schemabot start apply-a1b2c3d4e5f6
 
 *Applied by @aparajon at 2026-01-01 00:00:00 UTC*
 
+**0/3** table(s) ready for cutover — waiting on 3
+
 📊 3 waiting for cutover
 
 ### Table Progress
@@ -1940,27 +1950,27 @@ schemabot start apply-a1b2c3d4e5f6
 - **`orders`**: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 Waiting for cutover  
 
   ```sql
-  ALTER TABLE `orders` ADD INDEX `idx_user_id` (`user_id`)
+  ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
   ```
 
 - **`users`**: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 Waiting for cutover  
 
   ```sql
-  ALTER TABLE `users` ADD INDEX `idx_email` (`email`)
+  ALTER TABLE `users` ADD INDEX `idx_email`(`email`);
   ```
 
 - **`products`**: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 Waiting for cutover  
 
   ```sql
-  ALTER TABLE `products` ADD INDEX `idx_price` (`price_cents`)
+  ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
   ```
 
 
 ---
 
-To proceed with cutover:
+To proceed with the cutover:
 ```
-schemabot cutover apply-a1b2c3d4e5f6
+schemabot cutover apply-a1b2c3d4e5f6 -e staging
 ```
 
 </details>
@@ -1975,6 +1985,8 @@ schemabot cutover apply-a1b2c3d4e5f6
 
 *Applied by @aparajon at 2026-01-01 00:00:00 UTC*
 
+**0/3** table(s) ready for cutover — waiting on 3
+
 📊 3 cutting over
 
 ### Table Progress
@@ -1982,19 +1994,19 @@ schemabot cutover apply-a1b2c3d4e5f6
 - **`orders`**: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 🔄 Cutting over...  
 
   ```sql
-  ALTER TABLE `orders` ADD INDEX `idx_user_id` (`user_id`)
+  ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
   ```
 
 - **`users`**: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 🔄 Cutting over...  
 
   ```sql
-  ALTER TABLE `users` ADD INDEX `idx_email` (`email`)
+  ALTER TABLE `users` ADD INDEX `idx_email`(`email`);
   ```
 
 - **`products`**: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 🔄 Cutting over...  
 
   ```sql
-  ALTER TABLE `products` ADD INDEX `idx_price` (`price_cents`)
+  ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
   ```
 
 

--- a/docs/cutover.md
+++ b/docs/cutover.md
@@ -1,0 +1,188 @@
+# Cutover
+
+Cutover is the final step of an online schema change — the atomic swap from the old
+table to the new table.
+
+## Why defer cutover?
+
+By default, cutover happens automatically as soon as the schema change is ready.
+The `--defer-cutover` flag pauses before this step, letting the operator choose
+when to commit.
+
+This matters because cutover requires a brief metadata lock (MDL) on the table.
+While the lock is held, new queries against the table are blocked. For most tables
+this is milliseconds. But for very busy tables with long-running queries, acquiring
+the MDL can take longer — the lock request waits behind all in-flight transactions.
+If long-running queries don't finish in time, the engine may force-kill them to
+proceed (see [Force-killing blocking queries](#force-killing-blocking-queries)).
+
+The main reason to defer is to **schedule cutover during off-peak hours**,
+minimizing the impact of metadata lock acquisition on application traffic.
+
+## How it works
+
+When `--defer-cutover` is set, the apply pauses after row copy (and checksum for
+Spirit) is complete. The schema change is fully prepared but not yet live. The operator
+triggers cutover explicitly:
+
+```
+schemabot cutover <apply-id> -e <environment>
+```
+
+This can be done via the CLI or as a PR comment.
+
+Without `--defer-cutover`, cutover happens automatically — no pause, no manual step.
+
+## State transitions
+
+With `--defer-cutover`:
+```
+running → waiting_for_cutover → cutting_over → completed
+```
+
+Without `--defer-cutover`:
+```
+running → cutting_over → completed
+```
+
+| State | Meaning |
+|-------|---------|
+| `running` | Row copy and binlog streaming in progress |
+| `waiting_for_cutover` | Preparation done, paused, waiting for operator to trigger cutover |
+| `cutting_over` | Engine is executing the table swap |
+| `completed` | Schema change is live |
+
+**Note on `waiting_for_cutover` without defer:** Spirit always enters
+`WaitingOnSentinelTable` status internally (controlled by `RespectSentinel`,
+which defaults to `true`). But without `--defer-cutover`, no sentinel table
+is created, so Spirit advances through this state in milliseconds. SchemaBot's
+5-second progress poll typically doesn't observe it — the task transitions
+directly from `running` to `completed` from SchemaBot's perspective.
+
+## Entry points
+
+Both the CLI and PR comments resolve to the same tern client `Cutover()` call:
+
+```
+CLI:        schemabot cutover <apply-id> -e staging
+            → POST /api/cutover → client.Cutover()
+
+PR comment: schemabot cutover <apply-id> -e staging
+            → webhook → handleCutoverCommand() → client.Cutover()
+```
+
+The tern client delegates to the engine, which handles cutover differently per engine.
+
+## Spirit (MySQL)
+
+Spirit uses a **sentinel table** as the coordination mechanism for deferred cutover.
+
+### Sentinel table
+
+The sentinel table is a dummy table that acts as a gate. Its existence means
+"don't cut over yet." Dropping it means "proceed."
+
+| Phase | What happens |
+|-------|-------------|
+| **Creation** | Spirit creates `_spirit_sentinel` (`id int NOT NULL PRIMARY KEY`) in the target database before row copy starts |
+| **Waiting** | After row copy + checksum, Spirit enters `WaitingOnSentinelTable` and polls `INFORMATION_SCHEMA.TABLES` every 1 second (max 48 hours) |
+| **Trigger** | SchemaBot executes `DROP TABLE IF EXISTS db._spirit_sentinel` |
+| **Detection** | Spirit's next poll (within 1 second) sees the table is gone and proceeds to cutover |
+
+Spirit has no cutover RPC. The `DROP TABLE` is the signal. SchemaBot wraps this
+in the engine interface.
+
+### Cutover algorithm
+
+Spirit uses "rename under lock" (`pkg/migration/cutover.go`):
+
+1. **LOCK TABLES** — acquire metadata lock on both the original and shadow (`_new`) tables. New queries against these tables are blocked until the lock is released.
+2. **Flush binlog** — replay remaining binlog events under the lock, ensuring the shadow table is fully caught up.
+3. **RENAME TABLE** — single atomic statement:
+   ```sql
+   RENAME TABLE `original` TO `_original_old`, `_original_new` TO `original`
+   ```
+4. **UNLOCK TABLES** — locks released, queries resume against the new table.
+
+The rename is atomic — both swaps succeed or both fail. Write downtime is
+typically milliseconds.
+
+### Force-killing blocking queries
+
+Acquiring the metadata lock at step 1 can be blocked by long-running queries or
+transactions that hold locks on the table. Spirit handles this with **targeted
+force-killing**, which is **enabled by default**.
+
+How it works:
+
+1. Spirit attempts to acquire the metadata lock with a configurable timeout
+   (`--lock-wait-timeout`, default 30 seconds)
+2. At **90% of the timeout** (27 seconds by default), Spirit starts killing
+   blocking transactions
+3. Spirit reads `performance_schema` to identify only the specific connections
+   holding metadata locks on the migrating table
+4. Those connections are killed with `KILL <pid>`
+
+Safety guardrails:
+
+| Check | Behavior |
+|-------|----------|
+| **Explicit `LOCK TABLES`** | Spirit refuses to kill these and fails immediately — they indicate an operator error and are not safely retryable |
+| **Heavy transactions** (> 1M rows modified) | Skipped to avoid rollback storms that could cause more damage than the lock wait |
+| **Spirit's own connection** | Excluded from kill candidates |
+
+The `--skip-force-kill` flag disables this behavior entirely. However, Spirit's
+docs warn that repeatedly failing to acquire metadata locks without force-kill
+is itself dangerous — the retried lock attempts can queue up and bring down
+production. Targeted killing is actually safer for busy systems.
+
+Force-kill also applies during the **checksum phase**, which requires a similar
+metadata lock to create consistent read views.
+
+Required MySQL privileges for force-kill: `CONNECTION_ADMIN` (or `SUPER`),
+`PROCESS` on `*.*`, and `SELECT` on `performance_schema.*`.
+
+### State persistence
+
+Spirit's migration state (`WaitingOnSentinelTable`, `CopyRows`, etc.) is
+**in-memory only** — it lives on the `Runner` struct as an atomic int32.
+The checkpoint table persists copier watermark and binlog position for crash
+recovery, but not the state machine position.
+
+After a container restart, a new Runner reports `Initial` regardless of where
+the previous run was. SchemaBot handles this by checking whether the
+`_spirit_sentinel` table still exists in the target database. If it does,
+the task enters a `recovering` state that blocks cutover until Spirit
+re-reaches `WaitingOnSentinelTable`. See `reconcileTaskStateFromEngine`
+in `pkg/tern/local_client.go`.
+
+## PlanetScale (Vitess)
+
+_TODO: Document PlanetScale/Vitess cutover flow (deploy request lifecycle, VReplication mechanism, force cutover, etc)._
+
+## PR comment UX
+
+When a task enters `waiting_for_cutover`, the `ReadyToComplete` flag is set
+(via `transitionTaskState`). The PR comment renders:
+
+```
+1/1 table(s) ready for cutover
+
+⏸️ Ready for cutover
+
+To proceed with the cutover:
+  schemabot cutover <apply-id> -e <environment>
+```
+
+### Error comments
+
+All error cases are rendered via `pkg/webhook/templates/cutover.go`:
+
+| Error | When |
+|-------|------|
+| Missing Apply ID | `schemabot cutover -e staging` (no apply ID) |
+| Missing Environment | `schemabot cutover apply_123` (no `-e` flag) |
+| Apply Not Found | Apply ID doesn't exist in storage |
+| Cutover Not Available | Apply is not in `waiting_for_cutover` state |
+| Cutover Failed | Tern client connection or RPC failure |
+| Cutover Not Accepted | Engine rejected the cutover |

--- a/integration/workflow_test.go
+++ b/integration/workflow_test.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -20,7 +21,9 @@ import (
 	"github.com/stretchr/testify/require"
 
 	schemabotapi "github.com/block/schemabot/pkg/api"
+	ternv1 "github.com/block/schemabot/pkg/proto/ternv1"
 	"github.com/block/schemabot/pkg/state"
+	storageTypes "github.com/block/schemabot/pkg/storage"
 	"github.com/block/schemabot/pkg/storage/mysqlstore"
 	"github.com/block/schemabot/pkg/tern"
 )
@@ -1458,4 +1461,513 @@ CREATE TABLE ccc_cancelled (
 	assert.Error(t, err, "ccc_cancelled table should NOT exist in DB")
 
 	t.Log("Partial failure test passed: 1 completed, 1 failed, 1 cancelled")
+}
+
+// =============================================================================
+// Sentinel Recovery Test
+// Tests crash recovery during waiting_for_cutover state:
+// 1. Apply with --defer-cutover, wait for waiting_for_cutover
+// 2. Simulate crash by closing the LocalClient (kills Spirit)
+// 3. Verify sentinel table still exists in the target database
+// 4. Start a new Service with recovery worker
+// 5. Verify task transitions: waiting_for_cutover → recovering → waiting_for_cutover
+// 6. Trigger cutover, verify completion
+// =============================================================================
+
+func TestSentinelRecovery_DeferCutover(t *testing.T) {
+	ctx := t.Context()
+
+	appDBName, appDSN := createTestDB(t, "recov_")
+
+	// Create the base table first so the apply triggers an ALTER (not CREATE).
+	// CREATE TABLE doesn't use defer-cutover — only ALTER TABLE goes through
+	// Spirit's row copy → sentinel → cutover flow.
+	baseDB, err := sql.Open("mysql", appDSN)
+	require.NoError(t, err)
+	_, err = baseDB.ExecContext(ctx, `CREATE TABLE users (
+		id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+		email VARCHAR(255) NOT NULL,
+		name VARCHAR(100),
+		created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+		UNIQUE KEY uk_email (email)
+	) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci`)
+	require.NoError(t, err, "create base table")
+	// Seed some rows so Spirit does actual row copy
+	for range 100 {
+		_, _ = baseDB.ExecContext(ctx, "INSERT INTO users (email, name) VALUES (CONCAT(UUID(), '@test.com'), 'test')")
+	}
+	_ = baseDB.Close()
+
+	// The desired schema adds an index — triggers an ALTER TABLE
+	desiredSchema := `CREATE TABLE users (
+		id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+		email VARCHAR(255) NOT NULL,
+		name VARCHAR(100),
+		created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+		UNIQUE KEY uk_email (email),
+		KEY idx_created_at (created_at)
+	) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;`
+
+	ts := startTestServer(t, appDBName, appDSN)
+
+	// Step 1: Plan — desired schema has idx_created_at, base doesn't
+	planResp := postJSON(t, "http://"+ts.Addr+"/api/plan", map[string]any{
+		"database":    appDBName,
+		"environment": "staging",
+		"type":        "mysql",
+		"schema_files": map[string]any{
+			"default": map[string]any{
+				"files": map[string]string{
+					"users.sql": desiredSchema,
+				},
+			},
+		},
+		"repository":   "myorg/myapp",
+		"pull_request": 99,
+	})
+	planID, ok := planResp["plan_id"].(string)
+	require.True(t, ok && planID != "", "expected plan_id")
+	t.Logf("Plan created: %s", planID)
+
+	// Step 2: Apply with defer-cutover
+	applyResp := postJSON(t, "http://"+ts.Addr+"/api/apply", map[string]any{
+		"plan_id":     planID,
+		"environment": "staging",
+		"options": map[string]string{
+			"defer_cutover": "true",
+		},
+	})
+	require.True(t, applyResp["accepted"] == true, "apply not accepted: %v", applyResp)
+	applyID, _ := applyResp["apply_id"].(string)
+	require.NotEmpty(t, applyID)
+	t.Logf("Apply started: %s", applyID)
+
+	// Step 3: Wait for waiting_for_cutover
+	waitForState(t, "http://"+ts.Addr, applyID, state.Apply.WaitingForCutover, 30*time.Second)
+	t.Log("Apply reached waiting_for_cutover")
+
+	// Step 4: Verify sentinel table exists
+	targetDB, err := sql.Open("mysql", appDSN)
+	require.NoError(t, err)
+	defer func() { _ = targetDB.Close() }()
+
+	var sentinelExists int
+	err = targetDB.QueryRowContext(ctx,
+		"SELECT 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = ? AND TABLE_NAME = '_spirit_sentinel'",
+		appDBName).Scan(&sentinelExists)
+	require.NoError(t, err, "sentinel table should exist in target database")
+	t.Log("Sentinel table exists")
+
+	// Step 5: Make the apply's heartbeat stale by updating updated_at in storage.
+	// This simulates a crash — the heartbeat stops updating and becomes stale.
+	schemabotDB, err := sql.Open("mysql", schemabotDSN)
+	require.NoError(t, err)
+	defer func() { _ = schemabotDB.Close() }()
+
+	_, err = schemabotDB.ExecContext(ctx,
+		"UPDATE applies SET updated_at = NOW() - INTERVAL 2 MINUTE WHERE apply_identifier = ?", applyID)
+	require.NoError(t, err, "make heartbeat stale")
+	t.Log("Heartbeat made stale (simulating crash)")
+
+	// Also make task heartbeats stale
+	_, err = schemabotDB.ExecContext(ctx,
+		`UPDATE tasks SET updated_at = NOW() - INTERVAL 2 MINUTE
+		 WHERE apply_id = (SELECT id FROM applies WHERE apply_identifier = ?)`, applyID)
+	require.NoError(t, err)
+
+	// Step 6: Start a NEW service with recovery worker (simulates container restart).
+	// The new service creates a fresh LocalClient + engine — no runningMigration.
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	stor2 := mysqlstore.New(schemabotDB)
+
+	localClient2, err := tern.NewLocalClient(tern.LocalConfig{
+		Database:  appDBName,
+		Type:      "mysql",
+		TargetDSN: appDSN,
+	}, stor2, logger)
+	require.NoError(t, err)
+	defer func() { _ = localClient2.Close() }()
+
+	serverConfig2 := &schemabotapi.ServerConfig{
+		Databases: map[string]schemabotapi.DatabaseConfig{
+			appDBName: {
+				Type: "mysql",
+				Environments: map[string]schemabotapi.EnvironmentConfig{
+					"staging": {DSN: appDSN},
+				},
+			},
+		},
+	}
+	svc2 := schemabotapi.New(stor2, serverConfig2, map[string]tern.Client{
+		appDBName + "/staging": localClient2,
+	}, logger)
+	defer func() { _ = svc2.Close() }()
+
+	// Start recovery worker — this should detect the stale apply and resume it
+	svc2.StartRecoveryWorker(ctx)
+	t.Log("Recovery worker started on new service")
+
+	// Step 7: Wait for the apply to return to waiting_for_cutover.
+	// The recovery path: waiting_for_cutover → recovering → waiting_for_cutover
+	// (Spirit resumes from checkpoint, re-reaches WaitingOnSentinelTable)
+	deadline := time.Now().Add(30 * time.Second)
+	var lastState string
+	for time.Now().Before(deadline) {
+		apply, err := stor2.Applies().GetByApplyIdentifier(ctx, applyID)
+		if err == nil && apply != nil {
+			lastState = apply.State
+			t.Logf("Apply state: %s", apply.State)
+			if apply.State == state.Apply.WaitingForCutover {
+				// Check that it went through recovering (not stuck at the old state)
+				break
+			}
+		}
+		time.Sleep(2 * time.Second)
+	}
+	require.Equal(t, state.Apply.WaitingForCutover, lastState,
+		"apply should return to waiting_for_cutover after recovery")
+
+	// Step 8: Sentinel should still exist (cutover not yet triggered)
+	err = targetDB.QueryRowContext(ctx,
+		"SELECT 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = ? AND TABLE_NAME = '_spirit_sentinel'",
+		appDBName).Scan(&sentinelExists)
+	require.NoError(t, err, "sentinel table should still exist before cutover")
+
+	// Step 9: Trigger cutover via API on the new service
+	mux2 := http.NewServeMux()
+	svc2.ConfigureRoutes(mux2)
+	listener2, err := (&net.ListenConfig{}).Listen(ctx, "tcp", "localhost:0")
+	require.NoError(t, err)
+	server2 := &http.Server{Handler: mux2}
+	go func() { _ = server2.Serve(listener2) }()
+	defer func() { _ = server2.Close() }()
+	addr2 := listener2.Addr().String()
+
+	cutoverResp := postJSON(t, "http://"+addr2+"/api/cutover", map[string]any{
+		"database":    appDBName,
+		"environment": "staging",
+		"apply_id":    applyID,
+	})
+	require.True(t, cutoverResp["accepted"] == true, "cutover not accepted: %v", cutoverResp)
+	t.Log("Cutover triggered")
+
+	// Step 10: Wait for completion
+	waitForState(t, "http://"+addr2, applyID, state.Apply.Completed, 30*time.Second)
+	t.Log("Apply completed after recovery + cutover")
+
+	// Step 11: Verify table exists in target
+	var tableName string
+	err = targetDB.QueryRowContext(ctx,
+		"SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = ? AND TABLE_NAME = 'users'",
+		appDBName).Scan(&tableName)
+	require.NoError(t, err, "users table should exist after cutover")
+	t.Logf("Verified: table '%s' exists after recovery + cutover", tableName)
+}
+
+// =============================================================================
+// Observer Test
+// Tests that the ProgressObserver receives OnProgress and OnTerminal callbacks
+// during a normal apply. Verifies that the observer is set before the engine
+// starts and notified throughout execution.
+// =============================================================================
+
+func TestObserver_NormalApply(t *testing.T) {
+	ctx := t.Context()
+
+	appDBName, appDSN := createTestDB(t, "obs_")
+
+	// Create base table so the plan produces an ALTER (not CREATE)
+	baseDB, err := sql.Open("mysql", appDSN)
+	require.NoError(t, err)
+	_, err = baseDB.ExecContext(ctx, `CREATE TABLE users (
+		id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+		email VARCHAR(255) NOT NULL,
+		UNIQUE KEY uk_email (email)
+	) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci`)
+	require.NoError(t, err)
+	for range 50 {
+		_, _ = baseDB.ExecContext(ctx, "INSERT INTO users (email) VALUES (CONCAT(UUID(), '@test.com'))")
+	}
+	_ = baseDB.Close()
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	schemabotDB, err := sql.Open("mysql", schemabotDSN)
+	require.NoError(t, err)
+	clearStorageDB(t, schemabotDB)
+	storage := mysqlstore.New(schemabotDB)
+	defer func() { _ = schemabotDB.Close() }()
+
+	localClient, err := tern.NewLocalClient(tern.LocalConfig{
+		Database:  appDBName,
+		Type:      "mysql",
+		TargetDSN: appDSN,
+	}, storage, logger)
+	require.NoError(t, err)
+	defer func() { _ = localClient.Close() }()
+
+	// Create a mock observer that tracks calls
+	var mu sync.Mutex
+	var progressCalls int
+	var terminalCalled bool
+	var terminalState string
+
+	observer := &testObserver{
+		onProgress: func(apply *storageTypes.Apply, tasks []*storageTypes.Task) {
+			mu.Lock()
+			defer mu.Unlock()
+			progressCalls++
+		},
+		onTerminal: func(apply *storageTypes.Apply, tasks []*storageTypes.Task) {
+			mu.Lock()
+			defer mu.Unlock()
+			terminalCalled = true
+			terminalState = apply.State
+		},
+	}
+
+	// Set pending observer — will be consumed by Apply()
+	localClient.SetPendingObserver(observer)
+
+	// Plan
+	desiredSchema := `CREATE TABLE users (
+		id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+		email VARCHAR(255) NOT NULL,
+		UNIQUE KEY uk_email (email),
+		KEY idx_email_prefix (email(10))
+	) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;`
+
+	planResp, err := localClient.Plan(ctx, &ternv1.PlanRequest{
+		Database: appDBName,
+		Type:     "mysql",
+		SchemaFiles: map[string]*ternv1.SchemaFiles{
+			"default": {Files: map[string]string{"users.sql": desiredSchema}},
+		},
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, planResp.PlanId)
+
+	// Apply
+	applyResp, err := localClient.Apply(ctx, &ternv1.ApplyRequest{
+		PlanId:      planResp.PlanId,
+		Environment: "staging",
+	})
+	require.NoError(t, err)
+	require.True(t, applyResp.Accepted)
+
+	// Wait for completion
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		apply, err := storage.Applies().GetByApplyIdentifier(ctx, applyResp.ApplyId)
+		if err == nil && apply != nil && state.IsTerminalApplyState(apply.State) {
+			break
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+
+	// Verify observer was called
+	mu.Lock()
+	defer mu.Unlock()
+
+	assert.True(t, progressCalls > 0, "observer.OnProgress should have been called at least once, got %d", progressCalls)
+	assert.True(t, terminalCalled, "observer.OnTerminal should have been called")
+	assert.Equal(t, state.Apply.Completed, terminalState, "terminal state should be completed")
+	t.Logf("Observer received %d progress calls and terminal=%v state=%s", progressCalls, terminalCalled, terminalState)
+}
+
+// TestObserver_ApplyIDSet verifies that the observer's SetApplyID is called
+// by LocalClient.Apply() when consuming a pending observer. If applyID stays
+// at 0, the observer can't look up tracked comments for editing.
+func TestObserver_ApplyIDSet(t *testing.T) {
+	ctx := t.Context()
+
+	appDBName, appDSN := createTestDB(t, "obsid_")
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	schemabotDB, err := sql.Open("mysql", schemabotDSN)
+	require.NoError(t, err)
+	clearStorageDB(t, schemabotDB)
+	stor := mysqlstore.New(schemabotDB)
+	defer func() { _ = schemabotDB.Close() }()
+
+	localClient, err := tern.NewLocalClient(tern.LocalConfig{
+		Database:  appDBName,
+		Type:      "mysql",
+		TargetDSN: appDSN,
+	}, stor, logger)
+	require.NoError(t, err)
+	defer func() { _ = localClient.Close() }()
+
+	// Track SetApplyID calls
+	var capturedApplyID int64
+	observer := &applyIDTrackingObserver{
+		onSetApplyID: func(id int64) {
+			capturedApplyID = id
+		},
+	}
+
+	localClient.SetPendingObserver(observer)
+
+	// Plan a CREATE TABLE (fast, no Spirit row copy)
+	schemaSQL, err := os.ReadFile("testdata/myapp/mysql/schema/users.sql")
+	require.NoError(t, err)
+
+	planResp, err := localClient.Plan(ctx, &ternv1.PlanRequest{
+		Database: appDBName,
+		Type:     "mysql",
+		SchemaFiles: map[string]*ternv1.SchemaFiles{
+			"default": {Files: map[string]string{"users.sql": string(schemaSQL)}},
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = localClient.Apply(ctx, &ternv1.ApplyRequest{
+		PlanId:      planResp.PlanId,
+		Environment: "staging",
+	})
+	require.NoError(t, err)
+
+	assert.Greater(t, capturedApplyID, int64(0),
+		"SetApplyID should be called with a non-zero ID; got %d", capturedApplyID)
+	t.Logf("Observer received applyID=%d", capturedApplyID)
+}
+
+// applyIDTrackingObserver tracks SetApplyID calls.
+type applyIDTrackingObserver struct {
+	onSetApplyID func(int64)
+}
+
+func (o *applyIDTrackingObserver) OnProgress(*storageTypes.Apply, []*storageTypes.Task) {}
+func (o *applyIDTrackingObserver) OnTerminal(*storageTypes.Apply, []*storageTypes.Task) {}
+func (o *applyIDTrackingObserver) SetApplyID(id int64) {
+	if o.onSetApplyID != nil {
+		o.onSetApplyID(id)
+	}
+}
+
+// TestObserver_ViaServiceLayer verifies the observer works when set through the
+// Service layer (same code path as the webhook handler). This catches the
+// deployment key mismatch bug where SetPendingObserver and ExecuteApply resolve
+// to different TernClient instances.
+func TestObserver_ViaServiceLayer(t *testing.T) {
+	ctx := t.Context()
+
+	appDBName, appDSN := createTestDB(t, "obssvc_")
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	schemabotDB, err := sql.Open("mysql", schemabotDSN)
+	require.NoError(t, err)
+	clearStorageDB(t, schemabotDB)
+	stor := mysqlstore.New(schemabotDB)
+	defer func() { _ = schemabotDB.Close() }()
+
+	serverConfig := &schemabotapi.ServerConfig{
+		Databases: map[string]schemabotapi.DatabaseConfig{
+			appDBName: {
+				Type: "mysql",
+				Environments: map[string]schemabotapi.EnvironmentConfig{
+					"staging": {DSN: appDSN},
+				},
+			},
+		},
+	}
+	// Let the Service create clients lazily — tests that SetPendingObserver
+	// and ExecuteApply resolve to the same client instance.
+	svc := schemabotapi.New(stor, serverConfig, nil, logger)
+	defer func() { _ = svc.Close() }()
+
+	// Set up HTTP server for the plan/apply API
+	mux := http.NewServeMux()
+	svc.ConfigureRoutes(mux)
+	listener, err := (&net.ListenConfig{}).Listen(ctx, "tcp", "localhost:0")
+	require.NoError(t, err)
+	server := &http.Server{Handler: mux}
+	go func() { _ = server.Serve(listener) }()
+	defer func() { _ = server.Close() }()
+	addr := listener.Addr().String()
+
+	// Wait for readiness
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, "http://"+addr+"/health", nil)
+		resp, err := http.DefaultClient.Do(req)
+		if err == nil && resp.StatusCode == 200 {
+			_ = resp.Body.Close()
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// Plan via API
+	schemaSQL, err := os.ReadFile("testdata/myapp/mysql/schema/users.sql")
+	require.NoError(t, err)
+	planResp := postJSON(t, "http://"+addr+"/api/plan", map[string]any{
+		"database":    appDBName,
+		"environment": "staging",
+		"type":        "mysql",
+		"schema_files": map[string]any{
+			"default": map[string]any{
+				"files": map[string]string{"users.sql": string(schemaSQL)},
+			},
+		},
+	})
+	planID, _ := planResp["plan_id"].(string)
+	require.NotEmpty(t, planID)
+
+	// Track observer calls
+	var mu sync.Mutex
+	var terminalCalled bool
+
+	observer := &testObserver{
+		onTerminal: func(apply *storageTypes.Apply, tasks []*storageTypes.Task) {
+			mu.Lock()
+			defer mu.Unlock()
+			terminalCalled = true
+		},
+	}
+
+	// Set observer through the Service layer — same path as webhook handler.
+	// Uses empty deployment (same as TernDeployment returns for local mode).
+	svc.SetPendingObserver(appDBName, "", "staging", observer)
+
+	// Apply via Service layer — same path as webhook handler
+	applyResp, _, err := svc.ExecuteApply(ctx, schemabotapi.ApplyRequest{
+		PlanID:      planID,
+		Environment: "staging",
+	})
+	require.NoError(t, err)
+	require.True(t, applyResp.Accepted)
+
+	// Wait for completion
+	waitDeadline := time.Now().Add(15 * time.Second)
+	for time.Now().Before(waitDeadline) {
+		s, _ := fetchProgressState("http://"+addr, applyResp.ApplyID)
+		if s == "completed" {
+			break
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.True(t, terminalCalled,
+		"observer.OnTerminal should be called when going through Service layer; "+
+			"if this fails, SetPendingObserver and ExecuteApply are using different TernClient instances")
+}
+
+// testObserver is a simple ProgressObserver for testing.
+type testObserver struct {
+	onProgress func(apply *storageTypes.Apply, tasks []*storageTypes.Task)
+	onTerminal func(apply *storageTypes.Apply, tasks []*storageTypes.Task)
+}
+
+func (o *testObserver) OnProgress(apply *storageTypes.Apply, tasks []*storageTypes.Task) {
+	if o.onProgress != nil {
+		o.onProgress(apply, tasks)
+	}
+}
+
+func (o *testObserver) OnTerminal(apply *storageTypes.Apply, tasks []*storageTypes.Task) {
+	if o.onTerminal != nil {
+		o.onTerminal(apply, tasks)
+	}
 }

--- a/pkg/api/scheduler.go
+++ b/pkg/api/scheduler.go
@@ -44,10 +44,8 @@ func (s *Service) StartRecoveryWorker(ctx context.Context) {
 
 		s.logger.Info("started recovery worker", "interval", RecoveryPollInterval)
 
-		// On startup, find completed applies that have a progress comment but
-		// no summary comment — this means OnTerminal was missed during a
-		// container restart. Post the missing summary so the PR shows the
-		// completion result.
+		// Post missing summary comments for applies that completed during a
+		// container restart (outbox pattern — see pkg/state/README.md).
 		s.postMissingSummaryComments(ctx)
 
 		// Run immediately on startup, then on each tick
@@ -153,8 +151,8 @@ func (s *Service) resumeInProgressApplies(ctx context.Context) {
 
 // postMissingSummaryComments finds completed applies that have a progress comment
 // but no summary comment (the observer missed it during a container restart) and
-// posts the missing summary. Uses the OnMissingSummary callback which posts
-// the summary comment directly.
+// posts the missing summary. Uses the OnApplyRecovered callback which sets up
+// an observer that calls OnTerminal to post the summary.
 func (s *Service) postMissingSummaryComments(ctx context.Context) {
 	applies, err := s.storage.Applies().FindMissingSummaryComment(ctx)
 	if err != nil {
@@ -170,7 +168,6 @@ func (s *Service) postMissingSummaryComments(ctx context.Context) {
 
 	for _, apply := range applies {
 		if apply.Repository == "" || apply.PullRequest == 0 || apply.InstallationID == 0 {
-			// CLI apply or missing GitHub context — can't post a PR comment.
 			continue
 		}
 

--- a/pkg/api/service_test.go
+++ b/pkg/api/service_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"log/slog"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -152,4 +153,82 @@ func TestTernConfig_Endpoint_EmptyEndpoint(t *testing.T) {
 
 	_, err := config.Endpoint("", "production")
 	assert.Error(t, err)
+}
+
+// TestDeploymentResolution_ConsistentAcrossHandlers verifies that the recovery
+// worker and webhook handlers resolve to the same TernClient cache key for a
+// given database. This prevents the bug where different code paths created
+// separate LocalClient instances with separate Spirit engine instances, causing
+// "no active schema change to cutover" after crash recovery.
+func TestDeploymentResolution_ConsistentAcrossHandlers(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(nil, nil))
+
+	// Local mode: database registered in config, no TernDeployments
+	svc := New(nil, &ServerConfig{
+		Databases: map[string]DatabaseConfig{
+			"orders": {Type: "mysql"},
+		},
+	}, nil, logger)
+
+	// Recovery worker path: ResolveDeployment(database, "")
+	recoveryDeployment := svc.ResolveDeployment("orders", "")
+
+	// Webhook cutover path: TernDeployment(repo) → "" → ResolveDeployment(database, "")
+	webhookDeployment := svc.TernDeployment("myorg/myrepo")
+	cutoverDeployment := svc.ResolveDeployment("orders", webhookDeployment)
+
+	assert.Equal(t, recoveryDeployment, cutoverDeployment,
+		"recovery worker and cutover handler must resolve to the same deployment key; "+
+			"different keys create separate Spirit engine instances that don't share runningMigration state")
+
+	// Also verify the actual key value
+	assert.Equal(t, "orders", recoveryDeployment,
+		"in local mode, deployment should be the database name")
+}
+
+// TestDeploymentResolution_WithExplicitDeployment verifies that when an apply
+// has an explicit deployment stored, both paths use it directly.
+func TestDeploymentResolution_WithExplicitDeployment(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(nil, nil))
+
+	svc := New(nil, &ServerConfig{
+		Databases: map[string]DatabaseConfig{
+			"orders": {Type: "mysql"},
+		},
+	}, nil, logger)
+
+	// Both paths should use the explicit deployment directly
+	assert.Equal(t,
+		svc.ResolveDeployment("orders", "my-cluster"),
+		svc.ResolveDeployment("orders", "my-cluster"),
+	)
+	assert.Equal(t, "my-cluster", svc.ResolveDeployment("orders", "my-cluster"))
+}
+
+// TestDeploymentResolution_GRPCMode verifies deployment resolution when
+// TernDeployments is configured (gRPC mode).
+func TestDeploymentResolution_GRPCMode(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(nil, nil))
+
+	svc := New(nil, &ServerConfig{
+		TernDeployments: TernConfig{
+			"tern-prod": {
+				"staging": "http://tern:8080",
+			},
+		},
+		Repos: map[string]RepoConfig{
+			"myorg/myrepo": {DefaultTernDeployment: "tern-prod"},
+		},
+	}, nil, logger)
+
+	// In gRPC mode, TernDeployment uses the repo mapping
+	webhookDeployment := svc.TernDeployment("myorg/myrepo")
+	assert.Equal(t, "tern-prod", webhookDeployment)
+
+	// Recovery worker uses ResolveDeployment with the stored deployment from the apply
+	recoveryDeployment := svc.ResolveDeployment("orders", "tern-prod")
+	assert.Equal(t, "tern-prod", recoveryDeployment)
+
+	assert.Equal(t, webhookDeployment, recoveryDeployment,
+		"gRPC mode: recovery and webhook should resolve to the same deployment")
 }

--- a/pkg/cmd/commands/serve.go
+++ b/pkg/cmd/commands/serve.go
@@ -109,13 +109,7 @@ func (cmd *ServeCmd) Run(g *Globals) error {
 	svc := api.New(storage, serverConfig, nil, logger)
 	defer utils.CloseAndLog(svc)
 
-	// Start the recovery worker.
-	// This unified approach polls for stale applies every 10 seconds:
-	// - Runs immediately on startup
-	// - Recovers applies with stale heartbeats (> 1 minute) using FOR UPDATE SKIP LOCKED
-	// - STOPPED applies are NOT auto-resumed (user must call `schemabot start`)
 	ctx := context.Background()
-	svc.StartRecoveryWorker(ctx)
 
 	// Optionally start gRPC server for Tern proto (used by docker-compose.grpc.yml)
 	var grpcServer *grpc.Server
@@ -152,6 +146,11 @@ func (cmd *ServeCmd) Run(g *Globals) error {
 		return err
 	}
 	mux.Handle("POST /webhook", webhookHandler)
+
+	// Start the recovery worker AFTER the webhook handler is registered.
+	// The webhook handler sets svc.OnApplyRecovered so recovered applies
+	// get PR comment progress watchers. Starting before would miss the callback.
+	svc.StartRecoveryWorker(ctx)
 
 	// Wrap mux with OTel HTTP instrumentation for automatic request
 	// duration, request body size, and response body size metrics.

--- a/pkg/cmd/templates/progress.go
+++ b/pkg/cmd/templates/progress.go
@@ -459,6 +459,19 @@ func FormatTableProgress(t TableProgress) string {
 		b.WriteString("\n")
 		b.WriteString(FormatShardProgress(t.Shards))
 		return b.String()
+	case state.Apply.Recovering:
+		if t.PercentComplete > 0 {
+			bar := ui.ProgressBarWaitingCutover() // yellow — last known state
+			fmt.Fprintf(&b, indentTable+progressSymbol(t.ChangeType)+"%s: %s 🔄 Recovering...\n", t.TableName, bar)
+		} else {
+			fmt.Fprintf(&b, indentTable+progressSymbol(t.ChangeType)+"%s: 🔄 Recovering...\n", t.TableName)
+		}
+		if t.DDL != "" {
+			b.WriteString(formatProgressDDL(t.DDL))
+		}
+		b.WriteString("\n")
+		b.WriteString(FormatShardProgress(t.Shards))
+		return b.String()
 	case state.Apply.CuttingOver:
 		bar := ui.ProgressBarRowCopy(100) // blue — still in progress
 		label := "Cutting over..."
@@ -870,6 +883,8 @@ func StateLabel(s string) string {
 		return "Waiting for cutover"
 	case state.Apply.CuttingOver:
 		return "Cutting over"
+	case state.Apply.Recovering:
+		return "Recovering"
 	case state.Apply.Stopped:
 		return "Stopped"
 	case state.Apply.Pending:
@@ -904,7 +919,7 @@ func stateColorFunc(s string) func(string) string {
 		return colorWrap(ANSIRed)
 	case state.Apply.Running:
 		return colorWrap(ANSICyan)
-	case state.Apply.WaitingForDeploy, state.Apply.WaitingForCutover, state.Apply.CuttingOver:
+	case state.Apply.WaitingForDeploy, state.Apply.WaitingForCutover, state.Apply.CuttingOver, state.Apply.Recovering:
 		return colorWrap(ANSIYellow)
 	case state.Apply.Stopped:
 		return colorWrap(ANSIOrange)

--- a/pkg/cmd/templates/progress_states_test.go
+++ b/pkg/cmd/templates/progress_states_test.go
@@ -118,6 +118,40 @@ func TestIsVSchemaTask_Variants(t *testing.T) {
 	assert.False(t, isVSchemaTask(TableProgress{TableName: "users"}))
 }
 
+func TestStateLabel_Recovering(t *testing.T) {
+	assert.Equal(t, "Recovering", StateLabel(state.Apply.Recovering))
+}
+
+func TestFormatTableProgress_RecoveringWithProgress(t *testing.T) {
+	tp := TableProgress{
+		TableName:       "orders",
+		ChangeType:      "alter",
+		Status:          state.Apply.Recovering,
+		PercentComplete: 100,
+		DDL:             "ALTER TABLE orders ADD INDEX idx_status (status)",
+	}
+	output := FormatTableProgress(tp)
+	assert.Contains(t, output, "Recovering...")
+	assert.Contains(t, output, "🟨", "should show yellow progress bar at last known progress")
+	assert.Contains(t, output, "orders")
+}
+
+func TestFormatTableProgress_RecoveringWithoutProgress(t *testing.T) {
+	tp := TableProgress{
+		TableName:  "orders",
+		ChangeType: "alter",
+		Status:     state.Apply.Recovering,
+	}
+	output := FormatTableProgress(tp)
+	assert.Contains(t, output, "Recovering...")
+	assert.NotContains(t, output, "🟨", "should not show progress bar when no progress recorded")
+}
+
+func TestStateColorFunc_Recovering(t *testing.T) {
+	fn := stateColorFunc(state.Apply.Recovering)
+	assert.NotNil(t, fn, "recovering should have a color function (yellow)")
+}
+
 func TestStateColorFunc_PlanetScalePhases(t *testing.T) {
 	for _, s := range []string{
 		state.Apply.PreparingBranch,

--- a/pkg/engine/spirit/spirit_integration_test.go
+++ b/pkg/engine/spirit/spirit_integration_test.go
@@ -448,6 +448,113 @@ func TestEngine_Cutover_NoActiveMigration(t *testing.T) {
 	require.Error(t, err, "expected error for cutover without active schema change")
 }
 
+// TestEngine_DeferCutover_CutoverWhileWaiting tests the full defer-cutover flow:
+// Apply with defer_cutover → wait for WaitingOnSentinelTable → Cutover → Completed.
+// This verifies that runningMigration is set and eng.Cutover() works while
+// Spirit is waiting on the sentinel table.
+func TestEngine_DeferCutover_CutoverWhileWaiting(t *testing.T) {
+	ctx := t.Context()
+
+	dbName := fmt.Sprintf("cutover_%d", time.Now().UnixNano()%100000)
+	db, err := sql.Open("mysql", sharedDSN)
+	require.NoError(t, err)
+	defer utils.CloseAndLog(db)
+
+	_, err = db.ExecContext(ctx, "CREATE DATABASE IF NOT EXISTS `"+dbName+"`")
+	require.NoError(t, err)
+	t.Cleanup(func() { _, _ = db.ExecContext(ctx, "DROP DATABASE IF EXISTS `"+dbName+"`") })
+
+	// Create base table with some rows
+	dsn := strings.Replace(sharedDSN, "/testdb", "/"+dbName, 1)
+	appDB, err := sql.Open("mysql", dsn)
+	require.NoError(t, err)
+	defer utils.CloseAndLog(appDB)
+
+	_, err = appDB.ExecContext(ctx, `CREATE TABLE users (
+		id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+		email VARCHAR(255) NOT NULL
+	) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci`)
+	require.NoError(t, err)
+	for range 50 {
+		_, _ = appDB.ExecContext(ctx, "INSERT INTO users (email) VALUES (CONCAT(UUID(), '@test.com'))")
+	}
+
+	eng := New(Config{Logger: slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))})
+	defer eng.Drain()
+
+	creds := &engine.Credentials{DSN: dsn}
+
+	// Apply with defer_cutover
+	result, err := eng.Apply(ctx, &engine.ApplyRequest{
+		Database: dbName,
+		Changes: []engine.SchemaChange{{
+			Namespace:    dbName,
+			TableChanges: []engine.TableChange{{DDL: "ALTER TABLE users ADD INDEX idx_email (email)"}},
+		}},
+		Options:     map[string]string{"defer_cutover": "true"},
+		Credentials: creds,
+	})
+	require.NoError(t, err)
+	require.True(t, result.Accepted)
+	t.Log("Apply accepted")
+
+	// Poll until WaitingOnSentinelTable
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		progress, err := eng.Progress(ctx, &engine.ProgressRequest{
+			Database:    dbName,
+			Credentials: creds,
+		})
+		require.NoError(t, err)
+		t.Logf("Progress: state=%s message=%q", progress.State, progress.Message)
+
+		if progress.State == engine.StateWaitingForCutover {
+			t.Log("Spirit reached WaitingOnSentinelTable")
+			break
+		}
+		if progress.State == engine.StateFailed {
+			t.Fatalf("Spirit failed: %s", progress.ErrorMessage)
+		}
+		if progress.State == engine.StateCompleted {
+			t.Fatal("Spirit completed without waiting for cutover — defer_cutover not respected")
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+
+	// Verify runningMigration is set
+	eng.mu.Lock()
+	hasRM := eng.runningMigration != nil
+	eng.mu.Unlock()
+	require.True(t, hasRM, "runningMigration should be set while waiting on sentinel")
+
+	// Now trigger cutover — this is the critical test
+	cutoverResp, err := eng.Cutover(ctx, &engine.ControlRequest{
+		Database:    dbName,
+		Credentials: creds,
+	})
+	require.NoError(t, err, "eng.Cutover() should succeed while Spirit is waiting on sentinel")
+	require.True(t, cutoverResp.Accepted, "cutover should be accepted")
+	t.Log("Cutover triggered successfully")
+
+	// Wait for completion
+	for time.Now().Before(deadline) {
+		progress, err := eng.Progress(ctx, &engine.ProgressRequest{
+			Database:    dbName,
+			Credentials: creds,
+		})
+		require.NoError(t, err)
+		if progress.State == engine.StateCompleted {
+			t.Log("Spirit completed after cutover")
+			return
+		}
+		if progress.State == engine.StateFailed {
+			t.Fatalf("Spirit failed after cutover: %s", progress.ErrorMessage)
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	t.Fatal("timeout waiting for completion after cutover")
+}
+
 func TestEngine_Revert_NotSupported(t *testing.T) {
 	eng := New(Config{})
 

--- a/pkg/proto/tern.proto
+++ b/pkg/proto/tern.proto
@@ -361,6 +361,7 @@ message TableProgress {
   repeated ShardProgress shards = 11;
   string progress_detail = 12;
   ChangeType change_type = 13;
+  bool ready_to_complete = 14;
 }
 
 // ProgressResponse contains detailed progress information.

--- a/pkg/proto/ternv1/tern.pb.go
+++ b/pkg/proto/ternv1/tern.pb.go
@@ -1044,6 +1044,7 @@ type TableProgress struct {
 	Shards          []*ShardProgress       `protobuf:"bytes,11,rep,name=shards,proto3" json:"shards,omitempty"`
 	ProgressDetail  string                 `protobuf:"bytes,12,opt,name=progress_detail,json=progressDetail,proto3" json:"progress_detail,omitempty"`
 	ChangeType      ChangeType             `protobuf:"varint,13,opt,name=change_type,json=changeType,proto3,enum=tern.v1.ChangeType" json:"change_type,omitempty"`
+	ReadyToComplete bool                   `protobuf:"varint,14,opt,name=ready_to_complete,json=readyToComplete,proto3" json:"ready_to_complete,omitempty"`
 	unknownFields   protoimpl.UnknownFields
 	sizeCache       protoimpl.SizeCache
 }
@@ -1167,6 +1168,13 @@ func (x *TableProgress) GetChangeType() ChangeType {
 		return x.ChangeType
 	}
 	return ChangeType_CHANGE_TYPE_OTHER
+}
+
+func (x *TableProgress) GetReadyToComplete() bool {
+	if x != nil {
+		return x.ReadyToComplete
+	}
+	return false
 }
 
 // ProgressResponse contains detailed progress information.
@@ -2281,7 +2289,7 @@ const file_tern_proto_rawDesc = "" +
 	"etaSeconds\x12)\n" +
 	"\x10cutover_attempts\x18\x06 \x01(\x05R\x0fcutoverAttempts\x120\n" +
 	"\x14last_cutover_attempt\x18\a \x01(\tR\x12lastCutoverAttempt\x12*\n" +
-	"\x11ready_to_complete\x18\b \x01(\bR\x0freadyToComplete\"\xc9\x03\n" +
+	"\x11ready_to_complete\x18\b \x01(\bR\x0freadyToComplete\"\xf5\x03\n" +
 	"\rTableProgress\x12\x17\n" +
 	"\atask_id\x18\x01 \x01(\tR\x06taskId\x12\x1c\n" +
 	"\tnamespace\x18\x02 \x01(\tR\tnamespace\x12\x1d\n" +
@@ -2302,7 +2310,8 @@ const file_tern_proto_rawDesc = "" +
 	"\x06shards\x18\v \x03(\v2\x16.tern.v1.ShardProgressR\x06shards\x12'\n" +
 	"\x0fprogress_detail\x18\f \x01(\tR\x0eprogressDetail\x124\n" +
 	"\vchange_type\x18\r \x01(\x0e2\x13.tern.v1.ChangeTypeR\n" +
-	"changeType\"\xc7\x03\n" +
+	"changeType\x12*\n" +
+	"\x11ready_to_complete\x18\x0e \x01(\bR\x0freadyToComplete\"\xc7\x03\n" +
 	"\x10ProgressResponse\x12\x19\n" +
 	"\bapply_id\x18\x01 \x01(\tR\aapplyId\x12$\n" +
 	"\x05state\x18\x02 \x01(\x0e2\x0e.tern.v1.StateR\x05state\x12'\n" +

--- a/pkg/state/README.md
+++ b/pkg/state/README.md
@@ -23,6 +23,7 @@ Vitess OnlineDDL and Spirit report — and they are translated into Task and App
 | ValidatingDeployRequest | `validating_deploy_request` | PlanetScale is validating the deploy request diff (PlanetScale only) |
 | WaitingForDeploy | `waiting_for_deploy` | Deploy request ready, waiting for user to trigger deploy (PlanetScale only). Without `--defer-deploy`, auto-advances immediately. |
 | WaitingForCutover | `waiting_for_cutover` | All tasks ready, waiting for manual cutover (atomic mode only — in sequential mode each task cuts over independently) |
+| Recovering | `recovering` | Engine recovering from a restart. Blocks control operations (cutover, etc.) until the engine re-establishes its state. |
 | CuttingOver | `cutting_over` | Cutover in progress (atomic mode only) |
 | Completed | `completed` | All tasks finished successfully |
 | Failed | `failed` | At least one task failed |
@@ -48,6 +49,9 @@ stateDiagram-v2
     running --> revert_window : PlanetScale only
 
     waiting_for_cutover --> cutting_over
+    waiting_for_cutover --> recovering : container restart
+    recovering --> waiting_for_cutover : Spirit catches up
+    recovering --> failed : Spirit fails during recovery
     cutting_over --> completed
 
     revert_window --> completed : auto-expires or skip-revert
@@ -69,6 +73,7 @@ Per-table execution state. Same state machine as Apply, plus `cancelled`:
 | Pending | `pending` | Task created, not yet started |
 | Running | `running` | Engine is actively executing (row copy, checksum, etc.) |
 | WaitingForCutover | `waiting_for_cutover` | Row copy complete, waiting for cutover signal |
+| Recovering | `recovering` | Engine recovering from a restart, blocks control operations until state is re-established |
 | CuttingOver | `cutting_over` | Table cutover in progress |
 | Completed | `complete` | Schema change applied successfully |
 | Failed | `failed` | Engine reported failure |
@@ -85,12 +90,13 @@ Per-table execution state. Same state machine as Apply, plus `cancelled`:
 2. Any task **stopped** → apply `stopped`
 3. Any task **reverted** → apply `reverted`
 4. All tasks **completed** → apply `completed`
-5. Any task **cutting_over** → apply `cutting_over`
-6. All non-completed tasks **waiting_for_cutover** → apply `waiting_for_cutover`
-7. All non-completed tasks **waiting_for_deploy** → apply `waiting_for_deploy`
-8. Any task **revert_window** → apply `revert_window`
-9. Any task **running** → apply `running`
-10. Otherwise → apply `pending`
+5. Any task **recovering** → apply `recovering`
+6. Any task **cutting_over** → apply `cutting_over`
+7. All non-completed tasks **waiting_for_cutover** → apply `waiting_for_cutover`
+8. All non-completed tasks **waiting_for_deploy** → apply `waiting_for_deploy`
+9. Any task **revert_window** → apply `revert_window`
+10. Any task **running** → apply `running`
+11. Otherwise → apply `pending`
 
 Terminal states (`completed`, `failed`, `reverted`, `cancelled`) are checked via `IsTerminalApplyState()`. Note: `stopped` is NOT terminal at the task level — a stopped task can be resumed via Start.
 
@@ -225,6 +231,7 @@ The rendering layer (`WriteProgress`) uses normalized states to select progress 
 | Waiting for cutover | Yellow | `🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 Waiting for cutover` |
 | Cutting over | Yellow | `🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 🔄 Cutting over...` |
 | Completed | Green | `🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete` |
+| Recovering | — | `🔄 Recovering...` (no progress bar) |
 | Stopped | Orange | `🟧🟧🟧🟧🟧🟧🟧⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ ⏹️ Stopped at 35%` |
 | Failed | Red | `🟥🟥🟥🟥🟥⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ ❌ Failed` |
 
@@ -263,6 +270,8 @@ PR comment tracking for applies. Each apply can have up to 3 comments, one per c
 | Summary | `summary` | Final summary comment, created when the apply reaches a terminal state |
 
 Stored in the `apply_comments` table with `UNIQUE(apply_id, comment_state)`. Upsert semantics allow Start/resume to replace old comment IDs with fresh ones.
+
+**Outbox pattern:** The `apply_comments` table doubles as an outbox — the existence of a row indicates that a comment was successfully posted. On startup, the recovery worker checks for completed applies that have a `progress` row but no `summary` row. This means the apply completed but the summary comment was missed (e.g., container died during rolling deployment). The recovery worker posts the missing summary comment. This is idempotent — if the summary row exists, it's already posted.
 
 ### How it works
 
@@ -363,6 +372,11 @@ In both cases:
   SchemaBot marks the task as failed with an abandonment message.
 - **`stopped` and `cancelled` are SchemaBot-owned.** These are set by user action (stop command) or
   SchemaBot logic (earlier failure cancels remaining tasks in sequential mode), not reported by engines.
+- **Recovery after restart.** When a task was in `waiting_for_cutover` and the engine reports a
+  different state after a restart, SchemaBot checks for durable signals (e.g., Spirit's sentinel
+  table) to determine whether the engine is recovering or the operation already completed. If
+  recovering, the task enters `recovering` state which blocks control operations until the engine
+  re-establishes its state. See `reconcileTaskStateFromEngine()` in `pkg/tern/local_client.go`.
 - **Stop checkpoints conservatively.** When a user requests stop, SchemaBot marks all non-terminal
   tasks as `stopped` regardless of engine sub-state — even if row copy is 100% done. A schema
   change isn't complete until cutover finishes, so SchemaBot won't promote a task to `completed`

--- a/pkg/state/apply.go
+++ b/pkg/state/apply.go
@@ -17,6 +17,7 @@ var Apply = struct {
 	Running           string
 	WaitingForDeploy  string
 	WaitingForCutover string
+	Recovering        string
 	CuttingOver       string
 	RevertWindow      string
 	Completed         string
@@ -38,6 +39,7 @@ var Apply = struct {
 	Running:           "running",
 	WaitingForDeploy:  "waiting_for_deploy",
 	WaitingForCutover: "waiting_for_cutover",
+	Recovering:        "recovering",
 	CuttingOver:       "cutting_over",
 	RevertWindow:      "revert_window",
 	Completed:         "completed",

--- a/pkg/state/task.go
+++ b/pkg/state/task.go
@@ -14,6 +14,7 @@ var Task = struct {
 	Running           string
 	WaitingForDeploy  string
 	WaitingForCutover string
+	Recovering        string
 	CuttingOver       string
 	RevertWindow      string
 	Completed         string
@@ -26,6 +27,7 @@ var Task = struct {
 	Running:           "running",
 	WaitingForDeploy:  "waiting_for_deploy",
 	WaitingForCutover: "waiting_for_cutover",
+	Recovering:        "recovering",
 	CuttingOver:       "cutting_over",
 	RevertWindow:      "revert_window",
 	Completed:         "completed",
@@ -110,7 +112,7 @@ func NormalizeTaskStatus(raw string) string {
 
 	// Pass-through for already-normalized values
 	case Task.Pending, Task.Running, Task.Completed, Task.Stopped, Task.Failed,
-		Task.RevertWindow, Task.Reverted,
+		Task.RevertWindow, Task.Reverted, Task.Recovering,
 		Task.WaitingForDeploy, Task.WaitingForCutover, Task.CuttingOver, Task.Cancelled:
 		return s
 

--- a/pkg/tern/local_apply.go
+++ b/pkg/tern/local_apply.go
@@ -178,6 +178,9 @@ func (c *LocalClient) transitionTaskState(ctx context.Context, task *storage.Tas
 	oldState := task.State
 	task.State = newState
 	task.UpdatedAt = time.Now()
+	if newState == state.Task.WaitingForCutover {
+		task.ReadyToComplete = true
+	}
 	if err := c.storage.Tasks().Update(ctx, task); err != nil {
 		c.logger.Error("failed to update task state", "task_id", task.TaskIdentifier, "state", newState, "error", err)
 	}
@@ -1178,6 +1181,9 @@ func deriveOverallState(tasks []*storage.Task) string {
 		case state.Task.CuttingOver:
 			hasRunning = true
 			runningState = state.Task.CuttingOver
+		case state.Task.Recovering:
+			hasRunning = true
+			runningState = state.Task.Recovering
 		case state.Task.Pending:
 			hasPending = true
 		case state.Task.Stopped:

--- a/pkg/tern/local_client.go
+++ b/pkg/tern/local_client.go
@@ -87,13 +87,16 @@ package tern
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/block/spirit/pkg/utils"
 	"github.com/google/uuid"
 
 	"github.com/block/schemabot/pkg/ddl"
@@ -149,7 +152,7 @@ type LocalClient struct {
 	// the observer on state changes and terminal state. Cleared on terminal state.
 	// Protected by observerMu.
 	observerMu sync.RWMutex
-	observers  map[int64]ProgressObserver // keyed by apply ID
+	observers  map[int64]ProgressObserver // keyed by apply DB ID
 
 	// pendingObserver is consumed by the next Apply() call and registered
 	// before Spirit starts. Set by the webhook handler via SetPendingObserver.
@@ -223,6 +226,136 @@ func (c *LocalClient) credentials() *engine.Credentials {
 		DSN:      c.config.TargetDSN,
 		Metadata: c.config.Metadata,
 	}
+}
+
+// sentinelTableExists checks whether Spirit's _spirit_sentinel table exists
+// in the target database. Used during progress polling to determine whether a
+// task in waiting_for_cutover should enter the recovering state after a restart.
+func (c *LocalClient) sentinelTableExists(ctx context.Context) (bool, error) {
+	db, err := sql.Open("mysql", c.config.TargetDSN)
+	if err != nil {
+		return false, fmt.Errorf("open target database: %w", err)
+	}
+	defer utils.CloseAndLog(db)
+
+	var exists int
+	err = db.QueryRowContext(ctx,
+		"SELECT 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = ? AND TABLE_NAME = '_spirit_sentinel'",
+		c.config.Database,
+	).Scan(&exists)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("query sentinel table: %w", err)
+	}
+	return true, nil
+}
+
+// reconcileTaskStateFromEngine decides whether to update the stored task state
+// based on what the engine reports. For early states (pending/running), the engine
+// is always trusted. For waiting_for_cutover, the sentinel table is checked to
+// distinguish "Spirit is recovering from restart" from "cutover already happened".
+// The recovering state blocks cutover until Spirit re-reaches WaitingOnSentinelTable.
+//
+// Why the sentinel check: Spirit's migration state is in-memory only (atomic int32
+// on the Runner struct). After a container restart, Spirit resumes from its checkpoint
+// table and briefly reports CopyRows/Initial before re-reaching WaitingOnSentinelTable.
+// The sentinel table (_spirit_sentinel) is the durable on-disk signal — if it exists,
+// Spirit was in deferred cutover mode and will re-reach WaitingOnSentinelTable.
+// If it's gone, cutover already happened.
+//
+// Future: block/spirit#844 will add a `resume` field to the progress API, providing
+// a cleaner signal directly from Spirit. Once available, the sentinel table check
+// can be replaced with the resume field.
+func (c *LocalClient) reconcileTaskStateFromEngine(ctx context.Context, task *storage.Task, result *engine.ProgressResult) {
+	engineState := engineStateToStorage(result.State)
+
+	switch {
+	case task.State == state.Task.Pending || task.State == state.Task.Running:
+		// Early states — always trust engine
+		task.State = engineState
+		now := time.Now()
+		task.UpdatedAt = now
+		if result.State.IsTerminal() && task.CompletedAt == nil {
+			task.CompletedAt = &now
+		}
+		if err := c.storage.Tasks().Update(ctx, task); err != nil {
+			c.logger.Warn("failed to update task state from engine", "task_id", task.TaskIdentifier, "state", task.State, "error", err)
+		}
+
+	case task.State == state.Task.WaitingForCutover && engineState != state.Task.WaitingForCutover:
+		// Task was waiting for cutover but engine disagrees.
+		// For Spirit/MySQL: check sentinel to decide recovery vs completion.
+		if c.config.Type == storage.DatabaseTypeMySQL {
+			exists, err := c.sentinelTableExists(ctx)
+			if err != nil {
+				c.logger.Warn("sentinel check failed, keeping stored state",
+					"task_id", task.TaskIdentifier, "error", err)
+				return
+			}
+			if exists {
+				// Sentinel exists + engine not at WaitingOnSentinelTable → recovering.
+				// Block cutover until Spirit catches up.
+				c.transitionTaskState(ctx, task, task.ApplyID, state.Task.Recovering,
+					"Entering recovery: sentinel table exists but engine not ready")
+				c.logger.Info("entering recovery: sentinel exists, Spirit not ready",
+					"task_id", task.TaskIdentifier, "engine_state", result.State)
+			} else {
+				// Sentinel gone → cutover already happened. Trust engine.
+				task.State = engineState
+				now := time.Now()
+				task.UpdatedAt = now
+				if result.State.IsTerminal() && task.CompletedAt == nil {
+					task.CompletedAt = &now
+				}
+				if err := c.storage.Tasks().Update(ctx, task); err != nil {
+					c.logger.Warn("failed to update task state from engine", "task_id", task.TaskIdentifier, "state", task.State, "error", err)
+				}
+			}
+		}
+		// Vitess: keep stored state (no sentinel mechanism)
+
+	case task.State == state.Task.Recovering:
+		// Already in recovery — poll until Spirit catches up or fails.
+		if engineState == state.Task.WaitingForCutover {
+			// Spirit caught up → transition back to waiting_for_cutover
+			c.transitionTaskState(ctx, task, task.ApplyID, state.Task.WaitingForCutover,
+				"Recovery complete: engine reached WaitingOnSentinelTable")
+			c.logger.Info("recovery complete: Spirit reached WaitingOnSentinelTable",
+				"task_id", task.TaskIdentifier)
+		} else if state.IsTerminalTaskState(engineState) {
+			// Spirit failed during recovery → trust terminal state
+			task.State = engineState
+			now := time.Now()
+			task.UpdatedAt = now
+			task.CompletedAt = &now
+			if result.ErrorMessage != "" {
+				task.ErrorMessage = result.ErrorMessage
+			}
+			if err := c.storage.Tasks().Update(ctx, task); err != nil {
+				c.logger.Warn("failed to update task state from engine", "task_id", task.TaskIdentifier, "state", task.State, "error", err)
+			}
+		}
+		// Otherwise: still recovering, keep polling.
+
+	case state.IsTerminalTaskState(engineState) && !state.IsTerminalTaskState(task.State):
+		// Engine reports terminal and task is not already terminal.
+		// Catches Spirit fatalError() during recovery.
+		task.State = engineState
+		now := time.Now()
+		task.UpdatedAt = now
+		if task.CompletedAt == nil {
+			task.CompletedAt = &now
+		}
+		if result.ErrorMessage != "" {
+			task.ErrorMessage = result.ErrorMessage
+		}
+		if err := c.storage.Tasks().Update(ctx, task); err != nil {
+			c.logger.Warn("failed to update task state from engine", "task_id", task.TaskIdentifier, "state", task.State, "error", err)
+		}
+	}
+	// All other stored states (cutting_over, revert_window, etc.): keep stored state
 }
 
 // Health checks the service health.
@@ -777,20 +910,7 @@ func (c *LocalClient) Progress(ctx context.Context, req *ternv1.ProgressRequest)
 			engineResult = result
 			c.logger.Info("Progress: engine returned", "engine_state", result.State, "message", result.Message, "task_id", activeTask.TaskIdentifier, "storage_state", activeTask.State)
 
-			// Only update task state from engine if task is not already in a terminal state.
-			// Terminal states (CANCELLED, COMPLETED, FAILED, etc.) should be preserved -
-			// they represent the final state set by the apply execution.
-			if !state.IsTerminalTaskState(activeTask.State) {
-				activeTask.State = engineStateToStorage(result.State)
-				now := time.Now()
-				activeTask.UpdatedAt = now
-				if result.State.IsTerminal() && activeTask.CompletedAt == nil {
-					activeTask.CompletedAt = &now
-				}
-				if err := c.storage.Tasks().Update(ctx, activeTask); err != nil {
-					c.logger.Warn("failed to update task state from progress poll", "task_id", activeTask.TaskIdentifier, "state", activeTask.State, "error", err)
-				}
-			}
+			c.reconcileTaskStateFromEngine(ctx, activeTask, result)
 
 			// Also update the apply record if the engine reports a terminal state
 			// but the apply hasn't been updated yet. Only do this when ALL tasks
@@ -837,19 +957,20 @@ func (c *LocalClient) Progress(ctx context.Context, req *ternv1.ProgressRequest)
 
 	for _, t := range currentApplyTasks {
 		tp := &ternv1.TableProgress{
-			TableName:  t.TableName,
-			Ddl:        t.DDL,
-			Namespace:  t.Namespace,
-			Status:     t.State,
-			TaskId:     t.TaskIdentifier,
-			IsInstant:  t.IsInstant || vitessApplyIsInstant,
-			ChangeType: ddlActionToProtoChangeType(t.DDLAction),
+			TableName:       t.TableName,
+			Ddl:             t.DDL,
+			Namespace:       t.Namespace,
+			Status:          t.State,
+			TaskId:          t.TaskIdentifier,
+			IsInstant:       t.IsInstant || vitessApplyIsInstant,
+			ChangeType:      ddlActionToProtoChangeType(t.DDLAction),
+			ReadyToComplete: t.ReadyToComplete,
 		}
 
 		// Look up engine progress for this table
 		if et, ok := engineProgressForTask(engineTableProgress, t); ok {
-			// Use live progress from engine (uppercase to match storage convention)
-			tp.Status = strings.ToUpper(et.State)
+			// Use live progress from engine, normalized to canonical task state
+			tp.Status = state.NormalizeTaskStatus(et.State)
 			tp.PercentComplete = int32(et.Progress)
 			tp.RowsCopied = et.RowsCopied
 			tp.RowsTotal = et.RowsTotal

--- a/pkg/tern/local_client_integration_test.go
+++ b/pkg/tern/local_client_integration_test.go
@@ -1308,3 +1308,218 @@ func TestLocalClient_Apply_FailedAtomicHasErrorMessage(t *testing.T) {
 	require.NotEmpty(t, tasks)
 	assert.NotEmpty(t, tasks[0].ErrorMessage, "task.ErrorMessage should contain the failure reason")
 }
+
+// TestLocalClient_Progress_WaitingForCutoverState verifies the sentinel-based
+// recovery logic: when a task is in waiting_for_cutover and the sentinel table
+// exists but Spirit reports a non-WaitingOnSentinelTable state (e.g., after a
+// restart), the task transitions to recovering.
+func TestLocalClient_Progress_WaitingForCutoverState(t *testing.T) {
+	_, dsn := setupMySQLContainer(t)
+	setupStorageSchema(t, dsn)
+	cleanupTasks(t, dsn)
+
+	ctx := t.Context()
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	stor := createStorage(t, dsn)
+
+	// Use a unique database name to isolate from setupStorageSchema's Spirit DDL
+	dbName := fmt.Sprintf("wfc_%d", time.Now().UnixNano()%100000)
+
+	// Create the database and sentinel table so the reconciliation logic
+	// recognizes the task as legitimately waiting for cutover (not stale).
+	targetDB, err := sql.Open("mysql", dsn)
+	require.NoError(t, err)
+	defer utils.CloseAndLog(targetDB)
+	_, err = targetDB.ExecContext(ctx, fmt.Sprintf("CREATE DATABASE IF NOT EXISTS `%s`", dbName))
+	require.NoError(t, err)
+	_, err = targetDB.ExecContext(ctx, fmt.Sprintf("CREATE TABLE `%s`.`_spirit_sentinel` (id int NOT NULL PRIMARY KEY)", dbName))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, _ = targetDB.ExecContext(ctx, fmt.Sprintf("DROP DATABASE IF EXISTS `%s`", dbName))
+	})
+
+	client, err := NewLocalClient(LocalConfig{
+		Database:  dbName,
+		Type:      "mysql",
+		TargetDSN: dsn,
+	}, stor, logger)
+	require.NoError(t, err)
+	defer utils.CloseAndLog(client)
+
+	// Create a task in waiting_for_cutover state (simulates post-row-copy)
+	taskID := fmt.Sprintf("task-%d", time.Now().UnixNano())
+	applyID := fmt.Sprintf("apply-%d", time.Now().UnixNano())
+	now := time.Now()
+	apply := &storage.Apply{
+		ApplyIdentifier: applyID,
+		Database:        dbName,
+		DatabaseType:    "mysql",
+		Environment:     "staging",
+		Repository:      "test/repo",
+		PullRequest:     1,
+		State:           state.Apply.WaitingForCutover,
+		Engine:          "spirit",
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+	dbApplyID, err := stor.Applies().Create(ctx, apply)
+	require.NoError(t, err)
+
+	task := &storage.Task{
+		TaskIdentifier:  taskID,
+		ApplyID:         dbApplyID,
+		Database:        dbName,
+		DatabaseType:    "mysql",
+		Namespace:       dbName,
+		TableName:       "orders",
+		DDL:             "ALTER TABLE orders ADD INDEX idx_test (id)",
+		DDLAction:       "alter",
+		Engine:          "spirit",
+		Repository:      "test/repo",
+		PullRequest:     1,
+		Environment:     "staging",
+		State:           state.Task.WaitingForCutover,
+		ProgressPercent: 100,
+		ReadyToComplete: true,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+	_, err = stor.Tasks().Create(ctx, task)
+	require.NoError(t, err)
+
+	// Call Progress with the apply ID — with no active engine, it reads from storage
+	resp, err := client.Progress(ctx, &ternv1.ProgressRequest{
+		Type:     "mysql",
+		Database: dbName,
+		ApplyId:  applyID,
+	})
+	require.NoError(t, err)
+
+	require.NotEmpty(t, resp.Tables, "expected at least one table in progress response")
+
+	// With sentinel existing and engine not at WaitingOnSentinelTable, the task
+	// transitions to recovering (blocking cutover until Spirit catches up).
+	updatedTask, err := stor.Tasks().Get(ctx, task.TaskIdentifier)
+	require.NoError(t, err)
+	assert.Equal(t, state.Task.Recovering, updatedTask.State,
+		"task should transition to recovering when sentinel exists but engine not at WaitingOnSentinelTable")
+}
+
+// TestLocalClient_SentinelRecovery_CutoverBlockedDuringRecovery verifies that
+// Cutover() is rejected when a task is in the recovering state.
+func TestLocalClient_SentinelRecovery_CutoverBlockedDuringRecovery(t *testing.T) {
+	_, dsn := setupMySQLContainer(t)
+	setupStorageSchema(t, dsn)
+	cleanupTasks(t, dsn)
+
+	ctx := t.Context()
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	stor := createStorage(t, dsn)
+
+	dbName := fmt.Sprintf("recov_%d", time.Now().UnixNano()%100000)
+
+	client, err := NewLocalClient(LocalConfig{
+		Database:  dbName,
+		Type:      "mysql",
+		TargetDSN: dsn,
+	}, stor, logger)
+	require.NoError(t, err)
+	defer utils.CloseAndLog(client)
+
+	now := time.Now()
+	applyID := fmt.Sprintf("apply-recov-%d", now.UnixNano())
+	apply := &storage.Apply{
+		ApplyIdentifier: applyID,
+		Database:        dbName,
+		DatabaseType:    "mysql",
+		Environment:     "staging",
+		Repository:      "test/repo",
+		PullRequest:     1,
+		State:           state.Apply.Recovering,
+		Engine:          "spirit",
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+	dbApplyID, err := stor.Applies().Create(ctx, apply)
+	require.NoError(t, err)
+
+	task := &storage.Task{
+		TaskIdentifier:  fmt.Sprintf("task-recov-%d", now.UnixNano()),
+		ApplyID:         dbApplyID,
+		Database:        dbName,
+		DatabaseType:    "mysql",
+		Namespace:       dbName,
+		TableName:       "orders",
+		DDL:             "ALTER TABLE orders ADD INDEX idx_test (id)",
+		DDLAction:       "alter",
+		Engine:          "spirit",
+		Repository:      "test/repo",
+		PullRequest:     1,
+		Environment:     "staging",
+		State:           state.Task.Recovering,
+		ProgressPercent: 100,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+	_, err = stor.Tasks().Create(ctx, task)
+	require.NoError(t, err)
+
+	// Verify task persisted correctly
+	freshTask, err := stor.Tasks().Get(ctx, task.TaskIdentifier)
+	require.NoError(t, err)
+	require.Equal(t, state.Task.Recovering, freshTask.State, "task should persist as recovering")
+
+	// Cutover should be rejected — task is recovering.
+	resp, err := client.Cutover(ctx, &ternv1.CutoverRequest{
+		ApplyId:     applyID,
+		Database:    dbName,
+		Environment: "staging",
+	})
+	require.NoError(t, err, "recovering guard should return a response, not an error")
+	require.NotNil(t, resp)
+	assert.False(t, resp.Accepted, "cutover should be rejected during recovery")
+	assert.Contains(t, resp.ErrorMessage, "recovering from a restart")
+}
+
+// TestLocalClient_SentinelRecovery_SentinelTableExists verifies the sentinel
+// table check helper works correctly against a real MySQL instance.
+func TestLocalClient_SentinelRecovery_SentinelTableExists(t *testing.T) {
+	_, dsn := setupMySQLContainer(t)
+	setupStorageSchema(t, dsn)
+
+	ctx := t.Context()
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	stor := createStorage(t, dsn)
+
+	client, err := NewLocalClient(LocalConfig{
+		Database:  "testdb",
+		Type:      "mysql",
+		TargetDSN: dsn,
+	}, stor, logger)
+	require.NoError(t, err)
+	defer utils.CloseAndLog(client)
+
+	// No sentinel table initially
+	exists, err := client.sentinelTableExists(ctx)
+	require.NoError(t, err)
+	assert.False(t, exists, "sentinel should not exist initially")
+
+	// Create sentinel table
+	targetDB, err := sql.Open("mysql", dsn)
+	require.NoError(t, err)
+	defer utils.CloseAndLog(targetDB)
+	_, err = targetDB.ExecContext(ctx, "CREATE TABLE `testdb`.`_spirit_sentinel` (id int NOT NULL PRIMARY KEY)")
+	require.NoError(t, err)
+
+	exists, err = client.sentinelTableExists(ctx)
+	require.NoError(t, err)
+	assert.True(t, exists, "sentinel should exist after creation")
+
+	// Drop sentinel table
+	_, err = targetDB.ExecContext(ctx, "DROP TABLE `testdb`.`_spirit_sentinel`")
+	require.NoError(t, err)
+
+	exists, err = client.sentinelTableExists(ctx)
+	require.NoError(t, err)
+	assert.False(t, exists, "sentinel should not exist after drop")
+}

--- a/pkg/tern/local_control.go
+++ b/pkg/tern/local_control.go
@@ -43,10 +43,35 @@ func (c *LocalClient) Cutover(ctx context.Context, req *ternv1.CutoverRequest) (
 		return nil, fmt.Errorf("no active schema change")
 	}
 
+	if task.State == state.Task.Recovering {
+		return &ternv1.CutoverResponse{
+			Accepted:     false,
+			ErrorMessage: "Schema change is recovering from a restart. Cutover will be available once recovery completes.",
+		}, nil
+	}
+
 	creds := c.credentials()
 	eng := c.getEngine()
 	if eng == nil {
 		return nil, fmt.Errorf("no engine configured for type: %s", c.config.Type)
+	}
+
+	// Verify the engine has an active migration before triggering cutover.
+	// After a container restart or rolling deployment, Spirit's in-memory state
+	// is gone until the recovery worker resumes it (heartbeat timeout + poll
+	// interval). If the engine reports no active migration but storage says
+	// waiting_for_cutover, recovery is still in progress.
+	if task.State == state.Task.WaitingForCutover && c.config.Type == storage.DatabaseTypeMySQL {
+		progress, _ := eng.Progress(ctx, &engine.ProgressRequest{
+			Database:    c.config.Database,
+			Credentials: creds,
+		})
+		if progress != nil && progress.State == engine.StatePending {
+			return &ternv1.CutoverResponse{
+				Accepted:     false,
+				ErrorMessage: "Schema change is being recovered after a restart. The recovery worker will resume it shortly — try again in a moment.",
+			}, nil
+		}
 	}
 
 	// Log cutover triggered

--- a/pkg/tern/local_control_resume.go
+++ b/pkg/tern/local_control_resume.go
@@ -482,6 +482,46 @@ func (c *LocalClient) ResumeApply(ctx context.Context, apply *storage.Apply) err
 	c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventInfo, storage.LogSourceSchemaBot,
 		fmt.Sprintf("Recovering apply (heartbeat expired, was in %s state)", apply.State), "", "")
 
+	// If the apply was waiting for cutover and the sentinel table still exists,
+	// Spirit just needs to resume from checkpoint and re-reach WaitingOnSentinelTable.
+	// Skip the re-plan — row copy was already done. Transition to recovering state
+	// which blocks cutover until Spirit catches up.
+	if apply.State == state.Apply.WaitingForCutover && c.config.Type == storage.DatabaseTypeMySQL {
+		exists, err := c.sentinelTableExists(ctx)
+		if err != nil {
+			c.logger.Warn("sentinel check failed during recovery, falling through to re-plan",
+				"apply_id", apply.ApplyIdentifier, "error", err)
+		} else if exists {
+			c.logger.Info("sentinel table exists — entering recovery state",
+				"apply_id", apply.ApplyIdentifier)
+
+			// Transition tasks and apply to recovering
+			for _, task := range tasks {
+				if task.State == state.Task.WaitingForCutover {
+					c.transitionTaskState(ctx, task, apply.ID, state.Task.Recovering,
+						"Entering recovery: sentinel table exists, resuming from checkpoint")
+				}
+			}
+			apply.State = state.Apply.Recovering
+			apply.UpdatedAt = time.Now()
+			if err := c.storage.Applies().Update(ctx, apply); err != nil {
+				c.logger.Error("failed to update apply to recovering",
+					"apply_id", apply.ApplyIdentifier, "error", err)
+			}
+
+			// Launch Spirit resume — it will re-reach WaitingOnSentinelTable from checkpoint.
+			// The Progress poller will transition recovering → waiting_for_cutover when Spirit catches up.
+			options := buildApplyOptions(apply)
+			if err := c.launchAtomicResume(ctx, apply, tasks, plan, options,
+				"Recovering from restart: resuming from checkpoint"); err != nil {
+				c.logger.Error("engine resume failed during sentinel recovery",
+					"apply_id", apply.ApplyIdentifier, "error", err)
+				return fmt.Errorf("sentinel recovery resume failed: %w", err)
+			}
+			return nil
+		}
+	}
+
 	rp, err := c.replanAndFilterTasks(ctx, apply, tasks, plan)
 	if err != nil {
 		c.logger.Error("re-plan failed during recovery", "apply_id", apply.ApplyIdentifier, "error", err)

--- a/pkg/tern/state_converters.go
+++ b/pkg/tern/state_converters.go
@@ -27,6 +27,8 @@ func taskStateToApplyState(ts string) string {
 		return state.Apply.WaitingForDeploy
 	case state.Task.WaitingForCutover:
 		return state.Apply.WaitingForCutover
+	case state.Task.Recovering:
+		return state.Apply.Recovering
 	case state.Task.CuttingOver:
 		return state.Apply.CuttingOver
 	case state.Task.RevertWindow:

--- a/pkg/webhook/apply_comment_e2e_test.go
+++ b/pkg/webhook/apply_comment_e2e_test.go
@@ -211,7 +211,7 @@ func TestE2EApplyCommentLifecycle(t *testing.T) {
 	require.NotNil(t, comment)
 	assert.Equal(t, progressCommentID, comment.GitHubCommentID)
 
-	// Step 2: Edit the progress comment via observer
+	// Step 2: Edit the progress comment via observer OnProgress
 	obs := NewCommentObserver(CommentObserverConfig{
 		GHClient:       factory,
 		Storage:        st,
@@ -221,12 +221,15 @@ func TestE2EApplyCommentLifecycle(t *testing.T) {
 		ApplyID:        applyID,
 		Logger:         logger,
 	})
-	obs.editTrackedComment(state.Comment.Progress, "Updated progress: running 45%")
+	obs.OnProgress(
+		&storage.Apply{ID: applyID, State: state.Apply.Running},
+		[]*storage.Task{{RowsCopied: 45000, RowsTotal: 100000}},
+	)
 
 	select {
 	case edited := <-capture.edits:
 		assert.Equal(t, progressCommentID, edited.CommentID)
-		assert.Equal(t, "Updated progress: running 45%", edited.Body)
+		assert.Contains(t, edited.Body, "Schema Change")
 	case <-time.After(5 * time.Second):
 		t.Fatal("timed out waiting for progress comment edit")
 	}
@@ -260,18 +263,34 @@ func TestE2EApplyCommentLifecycle(t *testing.T) {
 	assert.Equal(t, state.Comment.Cutover, active.CommentState)
 	assert.Equal(t, cutoverCommentID, active.GitHubCommentID)
 
-	// Step 6: Edit cutover comment via observer
-	obs.editTrackedComment(state.Comment.Cutover, "Cutover in progress")
+	// Step 6: Verify progress comment is frozen after cutover.
+	// OnProgress returns early when hasCutoverComment=true — the progress
+	// comment stays at its last state. Cutover comment editing happens in OnTerminal.
+	obsWithCutover := NewCommentObserver(CommentObserverConfig{
+		GHClient:       factory,
+		Storage:        st,
+		Repo:           "org/repo",
+		PR:             42,
+		InstallationID: 12345,
+		ApplyID:        applyID,
+		DeferCutover:   true,
+		Logger:         logger,
+	})
+	obsWithCutover.hasCutoverComment = true // already created
+	obsWithCutover.lastState = state.Apply.CuttingOver
+	obsWithCutover.OnProgress(
+		&storage.Apply{ID: applyID, State: state.Apply.CuttingOver},
+		[]*storage.Task{},
+	)
 
 	select {
-	case edited := <-capture.edits:
-		assert.Equal(t, cutoverCommentID, edited.CommentID)
-		assert.Equal(t, "Cutover in progress", edited.Body)
-	case <-time.After(5 * time.Second):
-		t.Fatal("timed out waiting for cutover comment edit")
+	case <-capture.edits:
+		t.Fatal("progress comment should be frozen after cutover — no edits expected")
+	case <-time.After(500 * time.Millisecond):
+		// expected: no edit
 	}
 
-	// Step 7: Post summary comment (terminal state)
+	// Step 7: Post summary comment directly (testing storage tracking)
 	summaryCommentID := h.postAndTrackComment(ctx, "org/repo", 42, 12345, applyID, state.Comment.Summary, "Schema change completed")
 
 	select {
@@ -396,6 +415,243 @@ func TestE2EApplyCommentUpsertOnResume(t *testing.T) {
 	assert.Len(t, allComments, 2, "upsert should not create duplicate entries")
 }
 
+// TestE2ECutoverCommentFreezesProgress tests the full deferred cutover comment lifecycle:
+// 1. Progress comment is posted and edited during row copy
+// 2. When cutover is triggered, progress comment stops being edited (frozen)
+// 3. On terminal state, the cutover comment is edited to summary format
+// 4. No separate summary comment is posted — the cutover comment IS the summary
+// 5. Edit counts reflect the behavior
+func TestE2ECutoverCommentFreezesProgress(t *testing.T) {
+	ctx := t.Context()
+
+	schemabotDB, err := sql.Open("mysql", e2eSchemabotDSN)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = schemabotDB.Close() })
+
+	st := mysqlstore.New(schemabotDB)
+
+	// Clean up stale data
+	_, _ = schemabotDB.ExecContext(ctx, "DELETE FROM apply_comments")
+	_, _ = schemabotDB.ExecContext(ctx, "DELETE FROM tasks WHERE repository = 'org/cutover-test'")
+	_, _ = schemabotDB.ExecContext(ctx, "DELETE FROM applies WHERE repository = 'org/cutover-test'")
+	_, _ = schemabotDB.ExecContext(ctx, "DELETE FROM locks WHERE repository = 'org/cutover-test'")
+
+	// Create lock and apply
+	lock := &storage.Lock{
+		DatabaseName: "e2e_cutover_db",
+		DatabaseType: "mysql",
+		Repository:   "org/cutover-test",
+		PullRequest:  99,
+		Owner:        "org/cutover-test#99",
+	}
+	require.NoError(t, st.Locks().Acquire(ctx, lock))
+	lock, err = st.Locks().Get(ctx, "e2e_cutover_db", "mysql")
+	require.NoError(t, err)
+
+	apply := &storage.Apply{
+		ApplyIdentifier: fmt.Sprintf("apply_cutover_%d", time.Now().UnixNano()),
+		LockID:          lock.ID,
+		PlanID:          1,
+		Database:        "e2e_cutover_db",
+		DatabaseType:    "mysql",
+		Repository:      "org/cutover-test",
+		PullRequest:     99,
+		Environment:     "staging",
+		InstallationID:  12345,
+		Engine:          "spirit",
+		State:           state.Apply.Pending,
+	}
+	applyID, err := st.Applies().Create(ctx, apply)
+	require.NoError(t, err)
+	apply.ID = applyID
+
+	now := time.Now()
+	task := &storage.Task{
+		TaskIdentifier: fmt.Sprintf("task_cutover_%d", now.UnixNano()),
+		ApplyID:        applyID,
+		PlanID:         1,
+		Database:       "e2e_cutover_db",
+		DatabaseType:   "mysql",
+		Engine:         "spirit",
+		Repository:     "org/cutover-test",
+		PullRequest:    99,
+		Environment:    "staging",
+		State:          state.Task.Pending,
+		TableName:      "orders",
+		DDL:            "ALTER TABLE orders ADD COLUMN status VARCHAR(32)",
+		DDLAction:      "alter",
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+	_, err = st.Tasks().Create(ctx, task)
+	require.NoError(t, err)
+
+	// Set up fake GitHub
+	installClient, capture := setupFakeGitHubForComments(t)
+	factory := &fakeClientFactory{client: installClient}
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	serverConfig := &api.ServerConfig{}
+	svc := api.New(st, serverConfig, map[string]tern.Client{}, logger)
+	t.Cleanup(func() { _ = svc.Close() })
+
+	h := NewHandler(svc, factory, nil, logger)
+
+	// Step 1: Post initial progress comment (simulates what apply_handlers does)
+	progressCommentID := h.postAndTrackComment(ctx, "org/cutover-test", 99, 12345, applyID, state.Comment.Progress, "Schema Change Starting")
+
+	select {
+	case created := <-capture.creates:
+		assert.Equal(t, progressCommentID, created.ID)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for progress comment create")
+	}
+
+	// Step 2: Create observer with defer_cutover=true (simulates the real flow)
+	obs := NewCommentObserver(CommentObserverConfig{
+		GHClient:       factory,
+		Storage:        st,
+		Repo:           "org/cutover-test",
+		PR:             99,
+		InstallationID: 12345,
+		ApplyID:        applyID,
+		DeferCutover:   true,
+		Logger:         logger,
+	})
+
+	// Step 3: Simulate progress during row copy — observer should edit the progress comment
+	obs.OnProgress(
+		&storage.Apply{ID: applyID, State: state.Apply.Running},
+		[]*storage.Task{{RowsCopied: 25000, RowsTotal: 100000}},
+	)
+
+	select {
+	case edited := <-capture.edits:
+		assert.Equal(t, progressCommentID, edited.CommentID, "should edit progress comment")
+		assert.Contains(t, edited.Body, "Schema Change")
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for progress edit during row copy")
+	}
+
+	// Verify edit was tracked
+	progressComment, err := st.ApplyComments().Get(ctx, applyID, state.Comment.Progress)
+	require.NoError(t, err)
+	assert.Equal(t, 1, progressComment.EditCount, "progress edit count should be 1 after first edit")
+
+	// Step 4: Simulate more progress — second edit
+	time.Sleep(6 * time.Second) // exceed the 5s active interval
+	obs.OnProgress(
+		&storage.Apply{ID: applyID, State: state.Apply.Running},
+		[]*storage.Task{{RowsCopied: 75000, RowsTotal: 100000}},
+	)
+
+	select {
+	case edited := <-capture.edits:
+		assert.Equal(t, progressCommentID, edited.CommentID)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for second progress edit")
+	}
+
+	progressComment, err = st.ApplyComments().Get(ctx, applyID, state.Comment.Progress)
+	require.NoError(t, err)
+	assert.Equal(t, 2, progressComment.EditCount, "progress edit count should be 2 after second edit")
+
+	// Step 5: Cutover is triggered — post cutover comment via handler (simulates cutover.go)
+	cutoverCommentID := h.postAndTrackComment(ctx, "org/cutover-test", 99, 12345, applyID, state.Comment.Cutover, "Cutover Triggered")
+
+	select {
+	case created := <-capture.creates:
+		assert.Equal(t, cutoverCommentID, created.ID)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for cutover comment create")
+	}
+
+	// Step 6: Progress continues — observer should detect cutover comment and FREEZE progress
+	time.Sleep(6 * time.Second) // exceed interval
+	obs.OnProgress(
+		&storage.Apply{ID: applyID, State: state.Apply.CuttingOver},
+		[]*storage.Task{{RowsCopied: 100000, RowsTotal: 100000}},
+	)
+
+	// Verify no edit was made — progress comment is frozen
+	select {
+	case edited := <-capture.edits:
+		t.Fatalf("progress comment should be frozen after cutover, but got edit to comment %d: %s",
+			edited.CommentID, edited.Body[:min(50, len(edited.Body))])
+	case <-time.After(1 * time.Second):
+		// expected: no edit, progress comment is frozen
+	}
+
+	// Verify progress edit count stayed at 2 (no new edits)
+	progressComment, err = st.ApplyComments().Get(ctx, applyID, state.Comment.Progress)
+	require.NoError(t, err)
+	assert.Equal(t, 2, progressComment.EditCount, "progress edit count should still be 2 after freeze")
+
+	// Step 7: Terminal state — OnTerminal should edit cutover comment to summary format
+	completedAt := time.Now()
+	obs.OnTerminal(
+		&storage.Apply{
+			ID:              applyID,
+			ApplyIdentifier: apply.ApplyIdentifier,
+			Database:        "e2e_cutover_db",
+			Environment:     "staging",
+			Engine:          "spirit",
+			State:           state.Apply.Completed,
+			CompletedAt:     &completedAt,
+		},
+		[]*storage.Task{{
+			TableName:  "orders",
+			DDL:        "ALTER TABLE orders ADD COLUMN status VARCHAR(32)",
+			State:      state.Task.Completed,
+			RowsCopied: 100000,
+			RowsTotal:  100000,
+		}},
+	)
+
+	// Verify the cutover comment was edited to summary format
+	select {
+	case edited := <-capture.edits:
+		assert.Equal(t, cutoverCommentID, edited.CommentID, "terminal should edit cutover comment, not progress")
+		assert.Contains(t, edited.Body, "Schema Change Applied", "cutover comment should show summary format")
+		assert.Contains(t, edited.Body, apply.ApplyIdentifier, "summary should include Apply ID")
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for cutover comment to be edited to summary")
+	}
+
+	// Step 8: Verify NO separate summary comment was created
+	select {
+	case created := <-capture.creates:
+		t.Fatalf("no separate summary comment should be created when cutover comment exists, but got: %s",
+			created.Body[:min(50, len(created.Body))])
+	case <-time.After(1 * time.Second):
+		// expected: no summary comment created
+	}
+
+	// Step 9: Verify final state in storage
+	allComments, err := st.ApplyComments().ListByApply(ctx, applyID)
+	require.NoError(t, err)
+	assert.Len(t, allComments, 3, "should have 3 records: progress + cutover + summary marker")
+
+	commentsByState := make(map[string]*storage.ApplyComment)
+	for _, c := range allComments {
+		commentsByState[c.CommentState] = c
+	}
+
+	// Progress comment: 2 edits then frozen
+	assert.Equal(t, progressCommentID, commentsByState[state.Comment.Progress].GitHubCommentID)
+	assert.Equal(t, 2, commentsByState[state.Comment.Progress].EditCount, "progress frozen at 2 edits")
+
+	// Cutover comment: 1 edit (terminal summary)
+	assert.Equal(t, cutoverCommentID, commentsByState[state.Comment.Cutover].GitHubCommentID)
+	assert.Equal(t, 1, commentsByState[state.Comment.Cutover].EditCount, "cutover edited once for summary")
+	assert.NotNil(t, commentsByState[state.Comment.Cutover].LastEditedAt, "cutover last_edited_at should be set")
+
+	// Summary marker exists — same GitHub comment ID as cutover (the edited comment)
+	require.NotNil(t, commentsByState[state.Comment.Summary], "summary marker should exist")
+	assert.Equal(t, cutoverCommentID, commentsByState[state.Comment.Summary].GitHubCommentID,
+		"summary marker should reference the cutover comment")
+}
+
 // TestE2EEditTrackedCommentNotFound tests that editing a non-existent comment is handled gracefully.
 func TestE2EEditTrackedCommentNotFound(t *testing.T) {
 	schemabotDB, err := sql.Open("mysql", e2eSchemabotDSN)
@@ -411,8 +667,6 @@ func TestE2EEditTrackedCommentNotFound(t *testing.T) {
 	serverConfig := &api.ServerConfig{}
 	svc := api.New(st, serverConfig, map[string]tern.Client{}, logger)
 	t.Cleanup(func() { _ = svc.Close() })
-
-	_ = NewHandler(svc, factory, nil, logger)
 
 	// Try to edit a comment for a non-existent apply via observer — should be a no-op
 	obs := NewCommentObserver(CommentObserverConfig{

--- a/pkg/webhook/commands.go
+++ b/pkg/webhook/commands.go
@@ -15,6 +15,7 @@ type CommandParser struct {
 	commandWithoutEnvRegex *regexp.Regexp
 	rollbackCommandRegex   *regexp.Regexp
 	rollbackRegex          *regexp.Regexp // rollback <apply-id>
+	cutoverRegex           *regexp.Regexp // cutover [apply-id]
 	environmentRegex       *regexp.Regexp // -e <env>
 	databaseRegex          *regexp.Regexp
 	skipRevertRegex        *regexp.Regexp
@@ -26,12 +27,13 @@ type CommandParser struct {
 // NewCommandParser creates a new command parser.
 func NewCommandParser() *CommandParser {
 	return &CommandParser{
-		commandRegex:           regexp.MustCompile(`(?i)schemabot\s+(plan|apply|apply-confirm|unlock|stop|revert|skip-revert|cutover|rollback-confirm)\s+(?:.*?-e\s+(staging|production))`),
+		commandRegex:           regexp.MustCompile(`(?i)schemabot\s+(plan|apply|apply-confirm|unlock|stop|revert|skip-revert|rollback-confirm)\s+(?:.*?-e\s+(staging|production))`),
 		mentionRegex:           regexp.MustCompile(`(?i)\bschemabot\b`),
 		helpRegex:              regexp.MustCompile(`(?i)schemabot\s+help\b`),
-		commandWithoutEnvRegex: regexp.MustCompile(`(?i)schemabot\s+(plan|apply|apply-confirm|unlock|stop|revert|skip-revert|cutover|rollback|rollback-confirm|fix-lint)\b`),
+		commandWithoutEnvRegex: regexp.MustCompile(`(?i)schemabot\s+(plan|apply|apply-confirm|unlock|stop|revert|skip-revert|rollback|rollback-confirm|fix-lint)\b`),
 		rollbackCommandRegex:   regexp.MustCompile(`(?i)schemabot\s+rollback(?:\s|$)`),
 		rollbackRegex:          regexp.MustCompile(`(?i)schemabot\s+rollback\s+(apply[_-][a-f0-9]+)`),
+		cutoverRegex:           regexp.MustCompile(`(?i)schemabot\s+cutover(?:\s+(apply[_-][a-f0-9]+))?(?:\s|$)`),
 		environmentRegex:       regexp.MustCompile(`(?i)-e\s+(staging|production)`),
 		databaseRegex:          regexp.MustCompile(`(?i)-d\s+([a-zA-Z0-9_-]+)`),
 		skipRevertRegex:        regexp.MustCompile(`(?i)--skip-revert\b`),
@@ -87,6 +89,31 @@ func (p *CommandParser) ParseCommand(body string) CommandResult {
 			result.Found = true
 		} else {
 			result.MissingEnv = true
+		}
+		return result
+	}
+
+	// Check cutover — requires <apply-id> and -e <env>
+	cutoverMatches := p.cutoverRegex.FindStringSubmatch(body)
+	if len(cutoverMatches) >= 2 {
+		applyID := cutoverMatches[1] // empty when apply ID omitted
+		result := CommandResult{
+			Action:    action.Cutover,
+			ApplyID:   applyID,
+			IsMention: true,
+		}
+		envMatches := p.environmentRegex.FindStringSubmatch(body)
+		if len(envMatches) >= 2 {
+			result.Environment = envMatches[1]
+		}
+		switch {
+		case applyID == "":
+			// Missing apply ID — always an error, but parse -e for instance routing
+			result.MissingEnv = true
+		case result.Environment == "":
+			result.MissingEnv = true
+		default:
+			result.Found = true
 		}
 		return result
 	}

--- a/pkg/webhook/commands_test.go
+++ b/pkg/webhook/commands_test.go
@@ -146,13 +146,43 @@ func TestParseCommand(t *testing.T) {
 			},
 		},
 		{
-			name: "cutover",
+			name: "cutover with apply ID and env",
+			body: "schemabot cutover apply_abc123 -e staging",
+			expected: CommandResult{
+				Action:      "cutover",
+				ApplyID:     "apply_abc123",
+				Environment: "staging",
+				Found:       true,
+				IsMention:   true,
+			},
+		},
+		{
+			name: "cutover missing env",
+			body: "schemabot cutover apply_abc123",
+			expected: CommandResult{
+				Action:     "cutover",
+				ApplyID:    "apply_abc123",
+				IsMention:  true,
+				MissingEnv: true,
+			},
+		},
+		{
+			name: "cutover without apply ID",
 			body: "schemabot cutover -e staging",
 			expected: CommandResult{
 				Action:      "cutover",
 				Environment: "staging",
-				Found:       true,
 				IsMention:   true,
+				MissingEnv:  true,
+			},
+		},
+		{
+			name: "cutover bare (no apply ID, no env)",
+			body: "schemabot cutover",
+			expected: CommandResult{
+				Action:     "cutover",
+				IsMention:  true,
+				MissingEnv: true,
 			},
 		},
 		{

--- a/pkg/webhook/comment_observer.go
+++ b/pkg/webhook/comment_observer.go
@@ -100,22 +100,20 @@ func (o *CommentObserver) OnProgress(apply *storage.Apply, tasks []*storage.Task
 	now := time.Now()
 	currentState := apply.State
 
-	// Check if a cutover comment was posted by an external handler.
+	// Check if a cutover comment was posted by the cutover handler.
 	// This must happen before the CuttingOver branch below — without it,
-	// the observer would post a duplicate cutover comment.
+	// the observer would post a duplicate cutover comment because it doesn't
+	// know the handler already posted one.
 	if !o.hasCutoverComment {
 		checkCtx, checkCancel := context.WithTimeout(context.Background(), 2*time.Second)
-		cutover, err := o.stor.ApplyComments().Get(checkCtx, o.applyID, state.Comment.Cutover)
-		if err != nil {
-			o.logger.Error("observer: failed to check for cutover comment", "error", err)
-		} else if cutover != nil {
+		if cutover, _ := o.stor.ApplyComments().Get(checkCtx, o.applyID, state.Comment.Cutover); cutover != nil {
 			o.hasCutoverComment = true
 		}
 		checkCancel()
 	}
 
-	// Post cutover comment when entering cutting_over with defer_cutover,
-	// but only if one hasn't been posted already.
+	// Create cutover comment when entering cutting_over with defer_cutover,
+	// but only if one hasn't been posted already (by the cutover handler).
 	if currentState == state.Apply.CuttingOver && o.deferCutover && !o.hasCutoverComment {
 		body := formatCutoverComment(apply, tasks)
 		o.postAndTrackComment(state.Comment.Cutover, body)
@@ -171,15 +169,13 @@ func (o *CommentObserver) OnProgress(apply *storage.Apply, tasks []*storage.Task
 // and updates check runs.
 func (o *CommentObserver) OnTerminal(apply *storage.Apply, tasks []*storage.Task) {
 	// Determine which comment to edit to final state.
-	// If a cutover comment exists, edit that and leave the progress comment
-	// frozen at its last state. Otherwise edit the progress comment.
+	// If a cutover comment exists (from the cutover handler), edit that and
+	// leave the progress comment frozen at its last state.
+	// Otherwise edit the progress comment.
 	activeCommentState := state.Comment.Progress
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	cutover, err := o.stor.ApplyComments().Get(ctx, o.applyID, state.Comment.Cutover)
-	if err != nil {
-		o.logger.Error("observer: failed to check for cutover comment on terminal", "error", err)
-	} else if cutover != nil {
+	if cutover, _ := o.stor.ApplyComments().Get(ctx, o.applyID, state.Comment.Cutover); cutover != nil {
 		activeCommentState = state.Comment.Cutover
 	}
 
@@ -216,14 +212,7 @@ func (o *CommentObserver) editTrackedComment(commentState string, body string) {
 	defer cancel()
 
 	comment, err := o.stor.ApplyComments().Get(ctx, o.applyID, commentState)
-	if err != nil {
-		o.logger.Error("observer: failed to look up comment for edit", "error", err, "comment_state", commentState)
-		return
-	}
-	if comment == nil {
-		// No tracked comment for this state — nothing to edit.
-		// This is expected when the progress comment hasn't been posted yet
-		// (e.g., first OnProgress tick before the handler posts it).
+	if err != nil || comment == nil {
 		return
 	}
 
@@ -272,23 +261,15 @@ func (o *CommentObserver) postAndTrackComment(commentState string, body string) 
 }
 
 // markSummaryPosted upserts a summary marker record in apply_comments.
-// Used for cutover applies where the cutover comment serves as the summary —
-// no separate summary is posted, but the marker satisfies the
-// FindMissingSummaryComment outbox query.
+// The marker uses the same GitHub comment ID as the edited comment so
+// FindMissingSummaryComment knows OnTerminal ran. Used for cutover applies
+// where no separate summary comment is posted.
 func (o *CommentObserver) markSummaryPosted(editedCommentState string) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
 	edited, err := o.stor.ApplyComments().Get(ctx, o.applyID, editedCommentState)
-	if err != nil {
-		o.logger.Error("observer: failed to look up comment for summary marker", "error", err)
-		return
-	}
-	if edited == nil {
-		// The edited comment doesn't exist in storage — can't create a marker
-		// without a GitHub comment ID to reference.
-		o.logger.Error("observer: no comment found to create summary marker from",
-			"comment_state", editedCommentState, "apply_id", o.applyID)
+	if err != nil || edited == nil {
 		return
 	}
 

--- a/pkg/webhook/cutover.go
+++ b/pkg/webhook/cutover.go
@@ -1,0 +1,78 @@
+package webhook
+
+import (
+	"context"
+	"time"
+
+	ternv1 "github.com/block/schemabot/pkg/proto/ternv1"
+	"github.com/block/schemabot/pkg/state"
+	"github.com/block/schemabot/pkg/webhook/templates"
+)
+
+// handleCutoverCommand handles the "schemabot cutover <apply-id> -e <env>" PR comment command.
+func (h *Handler) handleCutoverCommand(repo string, pr int, applyID, environment string, installationID int64, requestedBy string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	if h.service == nil {
+		h.logger.Error("service not configured for cutover")
+		return
+	}
+
+	// Look up the apply
+	apply, err := h.service.Storage().Applies().GetByApplyIdentifier(ctx, applyID)
+	if err != nil {
+		h.logger.Error("failed to look up apply for cutover", "apply_id", applyID, "error", err)
+		h.postComment(repo, pr, installationID, templates.RenderCutoverLookupError(applyID, err))
+		return
+	}
+	if apply == nil {
+		h.postComment(repo, pr, installationID, templates.RenderCutoverApplyNotFound(applyID))
+		return
+	}
+
+	if !state.IsState(apply.State, state.Apply.WaitingForCutover) {
+		h.postComment(repo, pr, installationID,
+			templates.RenderCutoverNotAvailable(apply.Database, apply.Environment, applyID, apply.State))
+		return
+	}
+
+	// Get tern client using the same deployment resolution as the recovery worker.
+	// This ensures the cutover uses the same LocalClient (and Spirit engine) instance
+	// that holds the runningMigration from the original apply or recovery resume.
+	deployment := h.service.ResolveDeployment(apply.Database, apply.Deployment)
+	client, err := h.service.TernClient(deployment, environment)
+	if err != nil {
+		h.logger.Error("failed to get tern client for cutover", "error", err,
+			"database", apply.Database, "deployment", deployment, "environment", environment)
+		h.postComment(repo, pr, installationID,
+			templates.RenderCutoverTernError(apply.Database, environment, err))
+		return
+	}
+
+	resp, err := client.Cutover(ctx, &ternv1.CutoverRequest{
+		ApplyId:     applyID,
+		Database:    apply.Database,
+		Environment: environment,
+	})
+	if err != nil {
+		h.logger.Error("cutover failed", "apply_id", applyID, "error", err)
+		h.postComment(repo, pr, installationID,
+			templates.RenderCutoverFailed(apply.Database, environment, err))
+		return
+	}
+
+	if !resp.Accepted {
+		h.postComment(repo, pr, installationID,
+			templates.RenderCutoverNotAccepted(apply.Database, environment, resp.ErrorMessage))
+		return
+	}
+
+	h.logger.Info("cutover triggered via PR comment",
+		"repo", repo, "pr", pr, "apply_id", applyID,
+		"database", apply.Database, "environment", environment,
+		"requested_by", requestedBy)
+
+	h.postAndTrackComment(ctx, repo, pr, installationID, apply.ID, state.Comment.Cutover,
+		templates.RenderCutoverTriggered(apply.Database, environment, applyID))
+}

--- a/pkg/webhook/handler_test.go
+++ b/pkg/webhook/handler_test.go
@@ -316,6 +316,50 @@ func TestWebhookEyesReaction(t *testing.T) {
 	}
 }
 
+func TestWebhookCutoverMissingApplyID(t *testing.T) {
+	h, comments, _ := newTestHandler(t)
+
+	req := buildWebhookRequest(t, webhookPayloadOpts{
+		comment: "schemabot cutover -e staging",
+		isPR:    true,
+	}, nil)
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	select {
+	case body := <-comments:
+		assert.Contains(t, body, "Missing Apply ID")
+		assert.Contains(t, body, "schemabot cutover <apply-id> -e <environment>")
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for error comment")
+	}
+}
+
+func TestWebhookCutoverMissingEnv(t *testing.T) {
+	h, comments, _ := newTestHandler(t)
+
+	req := buildWebhookRequest(t, webhookPayloadOpts{
+		comment: "schemabot cutover apply_abc123",
+		isPR:    true,
+	}, nil)
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	select {
+	case body := <-comments:
+		assert.Contains(t, body, "Missing Environment")
+		assert.Contains(t, body, "-e")
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for error comment")
+	}
+}
+
 func TestWebhookPhase2CommandNotYetAvailable(t *testing.T) {
 	h, comments, _ := newTestHandler(t)
 
@@ -326,7 +370,6 @@ func TestWebhookPhase2CommandNotYetAvailable(t *testing.T) {
 	}{
 		{"schemabot stop -e staging", "stop"},
 		{"schemabot revert -e staging", "revert"},
-		{"schemabot cutover -e staging", "cutover"},
 	}
 
 	for _, cmd := range cmds {

--- a/pkg/webhook/issue_comment.go
+++ b/pkg/webhook/issue_comment.go
@@ -130,6 +130,21 @@ func (h *Handler) handleIssueComment(w http.ResponseWriter, body []byte) {
 			h.writeJSON(w, http.StatusOK, map[string]string{"message": "missing environment flag"})
 			return
 		}
+		if result.Action == action.Cutover {
+			// If we have -e, check if this instance owns the environment before responding
+			if result.Environment != "" && h.service != nil && !h.service.Config().IsEnvironmentAllowed(result.Environment) {
+				h.writeJSON(w, http.StatusOK, map[string]string{"message": "environment handled by another instance"})
+				return
+			}
+			h.addReaction(payload.Comment.ID, installationID, repo)
+			if result.ApplyID == "" {
+				h.postComment(repo, pr, installationID, templates.RenderCutoverMissingApplyID())
+			} else {
+				h.postComment(repo, pr, installationID, templates.RenderCutoverMissingEnvironment())
+			}
+			h.writeJSON(w, http.StatusOK, map[string]string{"message": "missing cutover arguments"})
+			return
+		}
 		h.postComment(repo, pr, installationID, templates.RenderMissingEnv(result.Action))
 		h.writeJSON(w, http.StatusOK, map[string]string{"message": "missing environment flag"})
 		return
@@ -167,20 +182,7 @@ func (h *Handler) handleIssueComment(w http.ResponseWriter, body []byte) {
 	// Add acknowledgment reaction now that we know this instance will handle
 	// the command. Placed after all skip/filter checks so only the owning
 	// instance reacts — avoids duplicate reactions in multi-instance setups.
-	if payload.Comment.ID > 0 && h.ghClient != nil {
-		go func() {
-			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-			defer cancel()
-			client, err := h.ghClient.ForInstallation(installationID)
-			if err != nil {
-				h.logger.Error("failed to create GitHub client for reaction", "error", err)
-				return
-			}
-			if err := client.AddReactionToComment(ctx, repo, payload.Comment.ID, "eyes"); err != nil {
-				h.logger.Error("failed to add acknowledgment reaction", "error", err)
-			}
-		}()
-	}
+	h.addReaction(payload.Comment.ID, installationID, repo)
 
 	// Reject -y/--yes on commands that don't support it
 	if result.Action != action.Apply && parser.autoConfirmRegex.MatchString(payload.Comment.Body) {
@@ -227,8 +229,13 @@ func (h *Handler) handleIssueComment(w http.ResponseWriter, body []byte) {
 			h.handleRollbackConfirmCommand(repo, pr, result.Environment, result.Database, installationID, requestedBy, result)
 		})
 		h.writeJSON(w, http.StatusOK, map[string]string{"message": "rollback-confirm started"})
+	case action.Cutover:
+		h.goSafe(repo, pr, installationID, func() {
+			h.handleCutoverCommand(repo, pr, result.ApplyID, result.Environment, installationID, requestedBy)
+		})
+		h.writeJSON(w, http.StatusOK, map[string]string{"message": "cutover started"})
 	// Phase 2 commands — acknowledge but not yet implemented
-	case action.Stop, action.Revert, action.SkipRevert, action.Cutover:
+	case action.Stop, action.Revert, action.SkipRevert:
 		h.postComment(repo, pr, installationID,
 			templates.RenderCommandNotYetAvailable(result.Action, result.Environment))
 		h.writeJSON(w, http.StatusOK, map[string]string{
@@ -238,6 +245,25 @@ func (h *Handler) handleIssueComment(w http.ResponseWriter, body []byte) {
 		h.postComment(repo, pr, installationID, templates.RenderInvalidCommand())
 		h.writeJSON(w, http.StatusOK, map[string]string{"message": "invalid command"})
 	}
+}
+
+// addReaction adds an eyes reaction to a comment. Safe to call when ghClient is nil.
+func (h *Handler) addReaction(commentID int64, installationID int64, repo string) {
+	if commentID <= 0 || h.ghClient == nil {
+		return
+	}
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		client, err := h.ghClient.ForInstallation(installationID)
+		if err != nil {
+			h.logger.Error("failed to create GitHub client for reaction", "error", err)
+			return
+		}
+		if err := client.AddReactionToComment(ctx, repo, commentID, "eyes"); err != nil {
+			h.logger.Error("failed to add acknowledgment reaction", "error", err)
+		}
+	}()
 }
 
 // postComment posts a comment on a PR.

--- a/pkg/webhook/rollback.go
+++ b/pkg/webhook/rollback.go
@@ -233,6 +233,41 @@ func (h *Handler) handleRollbackConfirmCommand(repo string, pr int, environment,
 		options["defer_cutover"] = "true"
 	}
 
+	// Set observer before starting the apply — consumed by Apply() before the
+	// engine starts, preventing the race where a fast apply completes before
+	// the observer is registered.
+	observer := NewCommentObserver(CommentObserverConfig{
+		GHClient:       h.ghClient,
+		Storage:        h.service.Storage(),
+		Repo:           repo,
+		PR:             pr,
+		InstallationID: installationID,
+		DeferCutover:   result.DeferCutover,
+		Logger:         h.logger,
+		OnTerminalHook: func(a *storage.Apply) {
+			updated, err := h.updateCheckRecordForApplyResult(context.Background(), repo, pr, a)
+			if err != nil {
+				h.logger.Error("observer: failed to update check record for rollback",
+					"repo", repo, "pr", pr, "apply_id", a.ID, "error", err)
+				return
+			}
+			if !updated {
+				h.logger.Debug("observer: skipping aggregate check update for rollback, apply no longer owns check state",
+					"repo", repo, "pr", pr, "apply_id", a.ID, "apply_identifier", a.ApplyIdentifier)
+				return
+			}
+			if state.IsState(a.State, state.Apply.Completed) {
+				h.setCheckActionRequired(repo, pr, installationID, a)
+			}
+			if ghInstClient, err := h.ghClient.ForInstallation(installationID); err == nil {
+				if checkRecord, err := h.service.Storage().Checks().Get(context.Background(), repo, pr, a.Environment, a.DatabaseType, a.Database); err == nil && checkRecord != nil {
+					h.updateAggregateCheck(context.Background(), ghInstClient, repo, pr, checkRecord.HeadSHA)
+				}
+			}
+		},
+	})
+	h.service.SetPendingObserver(database, "", environment, observer)
+
 	// Execute apply with the rollback plan
 	applyReq := api.ApplyRequest{
 		PlanID:         planResp.PlanID,
@@ -244,6 +279,7 @@ func (h *Handler) handleRollbackConfirmCommand(repo string, pr int, environment,
 
 	applyResp, applyID, err := h.service.ExecuteApply(ctx, applyReq)
 	if err != nil {
+		h.service.SetPendingObserver(database, "", environment, nil)
 		h.logger.Error("rollback apply failed", "repo", repo, "pr", pr, "error", err)
 		h.postComment(repo, pr, installationID, templates.RenderGenericError(templates.SchemaErrorData{
 			RequestedBy: requestedBy,
@@ -256,14 +292,12 @@ func (h *Handler) handleRollbackConfirmCommand(repo string, pr int, environment,
 	}
 
 	if !applyResp.Accepted {
+		h.service.SetPendingObserver(database, "", environment, nil)
 		h.postComment(repo, pr, installationID,
 			templates.RenderRollbackNotAccepted(database, environment, applyResp.ErrorMessage))
 		return
 	}
 
-	// Spawn background progress watcher. After the rollback apply completes,
-	// set the check to action_required — the PR's schema changes need to be
-	// re-applied since the rollback undid them.
 	if applyID > 0 {
 		apply, err := h.service.Storage().Applies().Get(ctx, applyID)
 		if err != nil {
@@ -277,41 +311,8 @@ func (h *Handler) handleRollbackConfirmCommand(repo string, pr int, environment,
 
 		h.updateCheckRecordForApplyStart(ctx, client, repo, pr, schemaResult, environment, applyID)
 
-		// Post initial progress comment for the observer to edit
+		// Post progress comment for the observer to edit
 		progressBody := formatProgressComment(apply, nil)
 		h.postAndTrackComment(ctx, repo, pr, installationID, applyID, state.Comment.Progress, progressBody)
-
-		// Set observer for rollback progress and check run updates.
-		// On successful rollback, set check to action_required (PR changes need re-applying).
-		h.service.SetApplyObserver(apply.Database, apply.Deployment, apply.Environment, applyID,
-			NewCommentObserver(CommentObserverConfig{
-				GHClient:       h.ghClient,
-				Storage:        h.service.Storage(),
-				Repo:           repo,
-				PR:             pr,
-				InstallationID: installationID,
-				ApplyID:        applyID,
-				Logger:         h.logger,
-				OnTerminalHook: func(a *storage.Apply) {
-					updated, err := h.updateCheckRecordForApplyResult(context.Background(), repo, pr, a)
-					if err != nil {
-						h.logger.Error("observer: failed to update check record for rollback", "error", err)
-						return
-					}
-					if !updated {
-						h.logger.Debug("observer: skipping aggregate check update for rollback, apply no longer owns check state",
-							"apply_id", a.ID, "apply_identifier", a.ApplyIdentifier)
-						return
-					}
-					if state.IsState(a.State, state.Apply.Completed) {
-						h.setCheckActionRequired(repo, pr, installationID, a)
-					}
-					if ghInstClient, err := h.ghClient.ForInstallation(installationID); err == nil {
-						if checkRecord, err := h.service.Storage().Checks().Get(context.Background(), repo, pr, a.Environment, a.DatabaseType, a.Database); err == nil && checkRecord != nil {
-							h.updateAggregateCheck(context.Background(), ghInstClient, repo, pr, checkRecord.HeadSHA)
-						}
-					}
-				},
-			}))
 	}
 }

--- a/pkg/webhook/templates/apply.go
+++ b/pkg/webhook/templates/apply.go
@@ -90,7 +90,7 @@ func writeApplyHeader(sb *strings.Builder, data ApplyStatusCommentData) {
 	case state.Apply.RevertWindow:
 		sb.WriteString("## Schema Change Applied (Pending Revert)\n\n")
 	case state.Apply.Completed:
-		sb.WriteString("## ✅ Schema Change Applied\n\n")
+		sb.WriteString("## Schema Change Completed\n\n")
 	case state.Apply.Failed:
 		sb.WriteString("## ❌ Schema Change Failed\n\n")
 	case state.Apply.Stopped:
@@ -198,6 +198,8 @@ func writeProgressSummary(sb *strings.Builder, tables []TableProgressData) {
 			queued++
 		case state.Task.WaitingForCutover:
 			waiting++
+		case state.Task.Recovering:
+			running++
 		case state.Task.CuttingOver:
 			cutting++
 		case state.Task.Failed:
@@ -308,9 +310,18 @@ func renderTableProgress(sb *strings.Builder, table TableProgressData, globalSta
 	case state.Task.WaitingForCutover:
 		bar := ui.ProgressBarWaitingCutover()
 		if table.ReadyToComplete {
-			fmt.Fprintf(sb, "- **`%s`**: %s \u2705 Ready for cutover  \n", table.TableName, bar)
+			fmt.Fprintf(sb, "- **`%s`**: %s \u23f8\ufe0f Ready for cutover  \n", table.TableName, bar)
 		} else {
 			fmt.Fprintf(sb, "- **`%s`**: %s Waiting for cutover  \n", table.TableName, bar)
+		}
+		writeDDLLine(sb, table.DDL)
+
+	case state.Task.Recovering:
+		if table.PercentComplete > 0 {
+			bar := ui.ProgressBarWaitingCutover()
+			fmt.Fprintf(sb, "- **`%s`**: %s \U0001f504 Recovering...  \n", table.TableName, bar)
+		} else {
+			fmt.Fprintf(sb, "- **`%s`**: \U0001f504 Recovering...  \n", table.TableName)
 		}
 		writeDDLLine(sb, table.DDL)
 
@@ -415,9 +426,9 @@ func writeRowsAndETA(sb *strings.Builder, table TableProgressData) {
 func writeApplyFooter(sb *strings.Builder, data ApplyStatusCommentData) {
 	switch data.State {
 	case state.Apply.WaitingForDeploy:
-		writeFooterAction(sb, "To deploy:", fmt.Sprintf("schemabot cutover %s", data.ApplyID))
+		writeFooterAction(sb, "To deploy:", fmt.Sprintf("schemabot cutover %s -e %s", data.ApplyID, data.Environment))
 	case state.Apply.WaitingForCutover:
-		writeFooterAction(sb, "To proceed with cutover:", fmt.Sprintf("schemabot cutover %s", data.ApplyID))
+		writeFooterAction(sb, "To proceed with the cutover:", fmt.Sprintf("schemabot cutover %s -e %s", data.ApplyID, data.Environment))
 	case state.Apply.CuttingOver:
 		sb.WriteString("\n---\n\n")
 		sb.WriteString("Cutover in progress — typically completes within seconds.\n")
@@ -430,6 +441,8 @@ func writeApplyFooter(sb *strings.Builder, data ApplyStatusCommentData) {
 	case state.Apply.RevertWindow:
 		writeFooterAction(sb, "To revert:", fmt.Sprintf("schemabot revert %s", data.ApplyID))
 		fmt.Fprintf(sb, "\nTo skip revert and keep changes:\n```\nschemabot skip-revert %s\n```\n", data.ApplyID)
+	case state.Apply.Completed:
+		sb.WriteString("\n---\n\n*See completion summary below*\n")
 	}
 }
 
@@ -477,7 +490,7 @@ func countTableOutcomes(tables []TableProgressData) (completed, failed int) {
 }
 
 func writeSummaryCompleted(sb *strings.Builder, data ApplyStatusCommentData, totalTables int) {
-	writeApplyHeader(sb, data)
+	sb.WriteString("## ✅ Schema Change Applied\n\n")
 	writeSummaryCompletedMetadata(sb, data)
 	var msg string
 	if totalTables == 1 {

--- a/pkg/webhook/templates/apply_test.go
+++ b/pkg/webhook/templates/apply_test.go
@@ -67,12 +67,13 @@ func TestRenderApplyStatusComment_Completed(t *testing.T) {
 
 	result := RenderApplyStatusComment(data)
 
-	assert.Contains(t, result, "## ✅ Schema Change Applied")
+	assert.Contains(t, result, "## Schema Change Completed")
 	assert.Contains(t, result, "### Table Progress")
 	// Progress summary line
 	assert.Contains(t, result, "📊 2/2 complete")
-	// Each table has "✓ Complete" = 2 total
-	assert.Equal(t, 2, strings.Count(result, "Complete"))
+	// Each table has "✓ Complete" + header "Completed" + footer "completion" = check table instances
+	assert.Contains(t, result, "✓ Complete")
+	assert.Contains(t, result, "See completion summary below")
 }
 
 func TestRenderApplyStatusComment_Failed(t *testing.T) {
@@ -249,8 +250,9 @@ func TestPreviewCommentApplyProgress(t *testing.T) {
 func TestPreviewCommentApplyCompleted(t *testing.T) {
 	result := PreviewCommentApplyCompleted()
 
-	assert.Contains(t, result, "Schema Change Applied")
+	assert.Contains(t, result, "Schema Change Completed")
 	assert.Contains(t, result, "### Table Progress")
+	assert.Contains(t, result, "See completion summary below")
 }
 
 func TestPreviewCommentApplyFailed(t *testing.T) {
@@ -505,6 +507,41 @@ func TestRenderApplyStatusComment_WaitingForCutover_AllReady(t *testing.T) {
 
 	assert.Contains(t, result, "2/2")
 	assert.NotContains(t, result, "waiting on")
+}
+
+func TestRenderApplyStatusComment_Recovering(t *testing.T) {
+	data := ApplyStatusCommentData{
+		ApplyID:     "apply-abc123",
+		Database:    "testapp",
+		Environment: "staging",
+		State:       state.Apply.Recovering,
+		Tables: []TableProgressData{
+			{TableName: "orders", Status: state.Task.Recovering, PercentComplete: 100, DDL: "ALTER TABLE orders ADD INDEX idx_status (status)"},
+		},
+	}
+
+	result := RenderApplyStatusComment(data)
+
+	assert.Contains(t, result, "Recovering...")
+	assert.Contains(t, result, "🟨", "should show yellow bar at last known progress")
+	assert.Contains(t, result, "orders")
+}
+
+func TestRenderApplyStatusComment_RecoveringNoProgress(t *testing.T) {
+	data := ApplyStatusCommentData{
+		ApplyID:     "apply-abc123",
+		Database:    "testapp",
+		Environment: "staging",
+		State:       state.Apply.Recovering,
+		Tables: []TableProgressData{
+			{TableName: "orders", Status: state.Task.Recovering, DDL: "ALTER TABLE orders ADD INDEX idx_status (status)"},
+		},
+	}
+
+	result := RenderApplyStatusComment(data)
+
+	assert.Contains(t, result, "Recovering...")
+	assert.NotContains(t, result, "🟨", "should not show progress bar without prior progress")
 }
 
 func TestRenderApplyStatusComment_RevertWindow(t *testing.T) {

--- a/pkg/webhook/templates/cutover.go
+++ b/pkg/webhook/templates/cutover.go
@@ -1,0 +1,75 @@
+package templates
+
+import (
+	"fmt"
+)
+
+// RenderCutoverLookupError renders a comment when the apply lookup fails.
+func RenderCutoverLookupError(applyID string, err error) string {
+	return fmt.Sprintf("## Cutover Failed\n\nFailed to look up apply `%s`: %s", applyID, err)
+}
+
+// RenderCutoverApplyNotFound renders a comment when no apply matches the ID.
+func RenderCutoverApplyNotFound(applyID string) string {
+	return fmt.Sprintf("## Apply Not Found\n\nNo apply found with ID `%s`.", applyID)
+}
+
+// RenderCutoverNotAvailable renders a comment when the apply isn't in waiting_for_cutover.
+func RenderCutoverNotAvailable(database, environment, applyID, applyState string) string {
+	return fmt.Sprintf("## Cutover Not Available\n\n"+
+		"**Database**: `%s` | **Environment**: `%s`\n\n"+
+		"Apply `%s` is in state `%s`, not waiting for cutover.",
+		database, environment, applyID, applyState)
+}
+
+// RenderCutoverTernError renders a comment when the tern client connection fails.
+func RenderCutoverTernError(database, environment string, err error) string {
+	return fmt.Sprintf("## Cutover Failed\n\n"+
+		"**Database**: `%s` | **Environment**: `%s`\n\n"+
+		"Failed to connect to tern: %s", database, environment, err)
+}
+
+// RenderCutoverFailed renders a comment when the cutover RPC fails.
+func RenderCutoverFailed(database, environment string, err error) string {
+	return fmt.Sprintf("## Cutover Failed\n\n"+
+		"**Database**: `%s` | **Environment**: `%s`\n\n"+
+		"Failed to trigger cutover: %s", database, environment, err)
+}
+
+// RenderCutoverNotAccepted renders a comment when the tern server rejects the cutover.
+func RenderCutoverNotAccepted(database, environment, errorMessage string) string {
+	return fmt.Sprintf("## Cutover Not Accepted\n\n"+
+		"**Database**: `%s` | **Environment**: `%s`\n\n"+
+		"%s", database, environment, errorMessage)
+}
+
+// RenderCutoverRecovering renders a comment when cutover is attempted during recovery.
+func RenderCutoverRecovering(database, environment string) string {
+	return fmt.Sprintf("## Cutover — Recovery In Progress\n\n"+
+		"**Database**: `%s` | **Environment**: `%s`\n\n"+
+		"The schema change is being recovered after a server restart. "+
+		"The recovery worker will resume it shortly — try again in a moment.",
+		database, environment)
+}
+
+// RenderCutoverMissingApplyID renders a comment when cutover is called without an apply ID.
+func RenderCutoverMissingApplyID() string {
+	return "## Missing Apply ID\n\n" +
+		"Usage: `schemabot cutover <apply-id> -e <environment>`\n\n" +
+		"You can find the apply ID in the progress comment above."
+}
+
+// RenderCutoverTriggered renders a comment acknowledging the cutover was triggered.
+func RenderCutoverTriggered(database, environment, applyID string) string {
+	return fmt.Sprintf("## Cutover Triggered\n\n"+
+		"**Database**: `%s` | **Environment**: `%s`\n\n"+
+		"Cutover has been triggered for apply `%s`. The table swap will complete shortly.",
+		database, environment, applyID)
+}
+
+// RenderCutoverMissingEnvironment renders a comment when cutover is called without -e.
+func RenderCutoverMissingEnvironment() string {
+	return "## Missing Environment\n\n" +
+		"Usage: `schemabot cutover <apply-id> -e <environment>`\n\n" +
+		"The `-e` flag is required to specify the target environment."
+}


### PR DESCRIPTION
## Summary

Add cutover via PR comment command, sentinel-based crash recovery, and cutover state fixes.

**Cutover via PR comment** — new \`schemabot cutover <apply-id> -e <env>\` command. Validates apply state, resolves tern client via stored deployment, triggers cutover, posts acknowledgment comment. Error handling for missing apply ID, missing environment, and environment-based instance routing.

**Sentinel-based crash recovery** — when a container restarts while a task is in \`waiting_for_cutover\`, check whether Spirit's \`_spirit_sentinel\` table exists in the target database. If it does, transition to a new \`recovering\` state that blocks cutover until Spirit re-reaches \`WaitingOnSentinelTable\` from its checkpoint. Replaces the previous blanket \`CanEngineOverrideTaskState\` guard with evidence-based recovery. Future: block/spirit#844 will add a \`resume\` field to replace the sentinel check.

**ReadyToComplete centralized** — set in \`transitionTaskState\` so both atomic and sequential modes mark tasks ready when entering \`waiting_for_cutover\`.

**Engine state normalization** — \`NormalizeTaskStatus\` converts camelCase Spirit states to canonical snake_case. Fixes CLI and PR comment rendering.

**State downgrade prevention** — Progress API only overwrites task state when the task is still pending or running, using sentinel-aware reconciliation.

**Cutover UX** — yellow progress bars and \`⏸️ Ready for cutover\` (green reserved for completions). Cutover footer includes apply ID and environment. Recovering state shows \`🔄 Recovering...\` with last known progress bar.

**Templates** — all cutover PR comments rendered via \`pkg/webhook/templates/cutover.go\`. AGENTS.md guideline: all PR comments must use templates.

**Documentation** — new \`docs/cutover.md\` covering the cutover lifecycle, sentinel table mechanism, Spirit's rename-under-lock algorithm, force-kill behavior, and recovery state. Updated \`pkg/state/README.md\` with recovering state.