### PR TITLE
feat: include version in all log entries

### DIFF
--- a/pkg/cmd/commands/serve.go
+++ b/pkg/cmd/commands/serve.go
@@ -33,7 +33,7 @@ type ServeCmd struct{}
 func (cmd *ServeCmd) Run(g *Globals) error {
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
 		Level: logLevel(),
-	})).With("version", g.Version)
+	})).With("schemabot_version", g.Version)
 	slog.SetDefault(logger)
 
 	// Load server configuration from YAML file

--- a/pkg/cmd/commands/serve.go
+++ b/pkg/cmd/commands/serve.go
@@ -33,7 +33,7 @@ type ServeCmd struct{}
 func (cmd *ServeCmd) Run(g *Globals) error {
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
 		Level: logLevel(),
-	}))
+	})).With("version", g.Version)
 
 	// Load server configuration from YAML file
 	serverConfig, err := api.LoadServerConfig()

--- a/pkg/cmd/commands/serve.go
+++ b/pkg/cmd/commands/serve.go
@@ -34,6 +34,7 @@ func (cmd *ServeCmd) Run(g *Globals) error {
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
 		Level: logLevel(),
 	})).With("version", g.Version)
+	slog.SetDefault(logger)
 
 	// Load server configuration from YAML file
 	serverConfig, err := api.LoadServerConfig()


### PR DESCRIPTION
## Summary

Add version as a default slog attribute so every log line includes the deployed version. One-line change — helps correlate logs with deployed code during incidents and across rolling deployments.