### PR TITLE
feat(vitess): implement vitess_tasks for VSchema progress tracking

### DIFF
--- a/e2e/local/vitess_test.go
+++ b/e2e/local/vitess_test.go
@@ -1077,23 +1077,22 @@ func TestVitess_Apply_VSchemaTaskTracking(t *testing.T) {
 	applyID := extractApplyIDFromLog(applyOut)
 	require.NotEmpty(t, applyID)
 
-	// Poll progress until completion, verifying VSchema tasks appear
+	// Poll progress until completion, verifying VSchema tasks appear.
+	// VSchema tasks are identified by the "VSchema: " table name prefix
+	// (they're stored in vitess_tasks, not as regular DDL tasks).
 	var foundVSchemaTask bool
-	var vschemaChangeType string
 	var finalState string
 	deadline := time.Now().Add(testutil.PollDeadline)
 	for time.Now().Before(deadline) {
 		resp, err := client.GetProgress(endpoint, applyID)
 		if err == nil {
 			for _, tbl := range resp.Tables {
-				if tbl.ChangeType == "vschema_update" {
+				if strings.HasPrefix(tbl.TableName, "VSchema: ") {
 					foundVSchemaTask = true
-					vschemaChangeType = tbl.ChangeType
 				}
 			}
 			if state.IsTerminalApplyState(resp.State) {
 				finalState = resp.State
-				// Verify all tables (including VSchema) reached terminal state
 				for _, tbl := range resp.Tables {
 					assert.True(t, state.IsTerminalApplyState(state.NormalizeTaskStatus(tbl.Status)),
 						"table %s should be terminal, got %s", tbl.TableName, tbl.Status)
@@ -1105,7 +1104,6 @@ func TestVitess_Apply_VSchemaTaskTracking(t *testing.T) {
 	}
 
 	assert.True(t, foundVSchemaTask, "expected VSchema task in progress tables")
-	assert.Equal(t, "vschema_update", vschemaChangeType)
 	require.NotEmpty(t, finalState, "apply did not reach terminal state")
 	assert.Equal(t, state.Apply.Completed, finalState)
 }

--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -33,6 +33,7 @@ func (m *mockStorage) Tasks() storage.TaskStore                      { return ni
 func (m *mockStorage) ApplyLogs() storage.ApplyLogStore              { return nil }
 func (m *mockStorage) ApplyComments() storage.ApplyCommentStore      { return nil }
 func (m *mockStorage) VitessApplyData() storage.VitessApplyDataStore { return nil }
+func (m *mockStorage) VitessTasks() storage.VitessTaskStore          { return nil }
 func (m *mockStorage) Checks() storage.CheckStore                    { return nil }
 func (m *mockStorage) Settings() storage.SettingsStore               { return nil }
 func (m *mockStorage) Ping(ctx context.Context) error                { return m.pingErr }

--- a/pkg/api/proto_helpers.go
+++ b/pkg/api/proto_helpers.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"maps"
-	"strings"
 
 	"github.com/block/spirit/pkg/statement"
 
@@ -102,8 +101,6 @@ func protoChangeTypeToOperation(ct ternv1.ChangeType) string {
 		return ddl.StatementTypeToOp(statement.StatementAlterTable)
 	case ternv1.ChangeType_CHANGE_TYPE_DROP:
 		return ddl.StatementTypeToOp(statement.StatementDropTable)
-	case ternv1.ChangeType_CHANGE_TYPE_VSCHEMA:
-		return "vschema_update"
 	default:
 		return "other"
 	}
@@ -111,9 +108,6 @@ func protoChangeTypeToOperation(ct ternv1.ChangeType) string {
 
 // changeTypeToProto converts operation string to proto ChangeType enum.
 func changeTypeToProto(op string) ternv1.ChangeType {
-	if strings.EqualFold(op, "vschema_update") {
-		return ternv1.ChangeType_CHANGE_TYPE_VSCHEMA
-	}
 	switch ddl.OpToStatementType(op) {
 	case statement.StatementCreateTable:
 		return ternv1.ChangeType_CHANGE_TYPE_CREATE

--- a/pkg/api/proto_helpers_test.go
+++ b/pkg/api/proto_helpers_test.go
@@ -13,7 +13,6 @@ func TestChangeTypeRoundTrip(t *testing.T) {
 		ternv1.ChangeType_CHANGE_TYPE_CREATE,
 		ternv1.ChangeType_CHANGE_TYPE_ALTER,
 		ternv1.ChangeType_CHANGE_TYPE_DROP,
-		ternv1.ChangeType_CHANGE_TYPE_VSCHEMA,
 		ternv1.ChangeType_CHANGE_TYPE_OTHER,
 	} {
 		op := protoChangeTypeToOperation(ct)

--- a/pkg/cmd/commands/apply.go
+++ b/pkg/cmd/commands/apply.go
@@ -13,6 +13,7 @@ import (
 	"github.com/block/schemabot/pkg/cmd/client"
 	"github.com/block/schemabot/pkg/cmd/templates"
 	"github.com/block/schemabot/pkg/ddl"
+	"github.com/block/schemabot/pkg/engine"
 	"github.com/block/schemabot/pkg/state"
 	"github.com/block/schemabot/pkg/ui"
 )
@@ -786,7 +787,7 @@ func appendShardSummary(kvs []string, shards []*apitypes.ShardProgressResponse) 
 
 // isVSchemaTask returns true if this is a synthetic VSchema update task.
 func isVSchemaTask(tbl *apitypes.TableProgressResponse) bool {
-	return strings.HasPrefix(tbl.TableName, "vschema:")
+	return strings.HasPrefix(tbl.TableName, engine.VSchemaTablePrefix)
 }
 
 // emitTableStateChange emits a log line for a table state transition.

--- a/pkg/cmd/commands/watch_tui_view.go
+++ b/pkg/cmd/commands/watch_tui_view.go
@@ -113,7 +113,7 @@ func (m WatchModel) progressView() string {
 	case state.IsState(m.state, state.Apply.ValidatingDeployRequest):
 		msg := "Validating deploy request..."
 		if m.deployRequestURL != "" {
-			msg = fmt.Sprintf("Validating deploy request  %s", m.deployRequestURL)
+			msg = fmt.Sprintf("Validating deploy request %s", m.deployRequestURL)
 		}
 		b.WriteString(m.spinner.View() + msg + m.elapsed() + "\n")
 	case state.IsState(m.state, state.Apply.Pending) && !m.pastPending:

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -319,6 +319,10 @@ const (
 
 // MessageApplyingVSchema is the engine progress message emitted during the
 // VSchema application phase of a deploy. Used to detect VSchema task transitions.
+// VSchemaTablePrefix is used to name synthetic VSchema table entries in progress.
+// Consumers (CLI, TUI) use this prefix to detect VSchema tasks vs DDL tasks.
+const VSchemaTablePrefix = "VSchema: "
+
 const MessageApplyingVSchema = "Applying VSchema changes"
 
 // IsTerminal returns true if this is a final state.

--- a/pkg/engine/planetscale/planetscale.go
+++ b/pkg/engine/planetscale/planetscale.go
@@ -456,6 +456,7 @@ type psMetadata struct {
 	DeployedAt       *time.Time `json:"deployed_at,omitempty"`
 	IsInstant        bool       `json:"is_instant,omitempty"`
 	DeferredDeploy   bool       `json:"deferred_deploy,omitempty"`
+	VSchemaKeyspaces []string   `json:"vschema_keyspaces,omitempty"`
 }
 
 func encodePSMetadata(m *psMetadata) (string, error) {
@@ -934,8 +935,12 @@ func (e *Engine) Apply(ctx context.Context, req *engine.ApplyRequest) (*engine.A
 		return nil, fmt.Errorf("apply changes to branch: %w", err)
 	}
 	ddlCount := 0
+	var vschemaKeyspaces []string
 	for _, sc := range req.Changes {
 		ddlCount += len(sc.TableChanges)
+		if sc.Metadata["vschema_changed"] == "true" {
+			vschemaKeyspaces = append(vschemaKeyspaces, sc.Namespace)
+		}
 	}
 	emitEvent(engine.ApplyEvent{
 		Message:  fmt.Sprintf("Applied %d DDL changes to branch %s", ddlCount, branchName),
@@ -990,6 +995,7 @@ func (e *Engine) Apply(ctx context.Context, req *engine.ApplyRequest) (*engine.A
 		BranchName:       branchName,
 		DeployRequestID:  dr.Number,
 		DeployRequestURL: dr.HtmlURL,
+		VSchemaKeyspaces: vschemaKeyspaces,
 	})
 	for dr.DeploymentState == deployState.Pending {
 		select {
@@ -1171,6 +1177,7 @@ func (e *Engine) Apply(ctx context.Context, req *engine.ApplyRequest) (*engine.A
 		DeployRequestID:  dr.Number,
 		DeployRequestURL: dr.HtmlURL,
 		IsInstant:        useInstant,
+		VSchemaKeyspaces: vschemaKeyspaces,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("encode metadata for deploy request #%d: %w", dr.Number, err)
@@ -1776,6 +1783,33 @@ func (e *Engine) Progress(ctx context.Context, req *engine.ProgressRequest) (*en
 		)
 		for i := range result.Tables {
 			result.Tables[i].IsInstant = true
+		}
+	}
+
+	// Synthesize VSchema table entries. VSchema changes don't appear in
+	// SHOW VITESS_MIGRATIONS — they're tracked by PlanetScale's deploy state
+	// machine. Derive VSchema task state from the DR deployment state.
+	if len(meta.VSchemaKeyspaces) > 0 {
+		vsState := "pending"
+		switch dr.DeploymentState {
+		case deployState.InProgressVSchema:
+			vsState = "running"
+		case deployState.InProgress, deployState.Queued, deployState.Submitting:
+			vsState = "pending"
+		case deployState.Complete, deployState.CompletePendingRevert,
+			deployState.InProgressCutover, deployState.PendingCutover:
+			vsState = "complete"
+		case deployState.Error, deployState.CompleteError, deployState.Failed:
+			vsState = "failed"
+		case deployState.CompleteCancel, deployState.Cancelled, deployState.InProgressCancel:
+			vsState = "stopped"
+		}
+		for _, ks := range meta.VSchemaKeyspaces {
+			result.Tables = append(result.Tables, engine.TableProgress{
+				Table:     engine.VSchemaTablePrefix + ks,
+				Namespace: ks,
+				State:     vsState,
+			})
 		}
 	}
 

--- a/pkg/engine/planetscale/planetscale_test.go
+++ b/pkg/engine/planetscale/planetscale_test.go
@@ -741,3 +741,33 @@ func TestFormatDeployRequestError(t *testing.T) {
 		assert.Equal(t, "deploy request #99 failed during preparation (state: error)", msg)
 	})
 }
+
+func TestVSchemaProgressSynthesis(t *testing.T) {
+	// Verify VSchema keyspaces are encoded/decoded in metadata
+	t.Run("metadata round-trip", func(t *testing.T) {
+		meta := &psMetadata{
+			BranchName:       "test-branch",
+			DeployRequestID:  42,
+			VSchemaKeyspaces: []string{"ks_sharded", "ks_unsharded"},
+		}
+		encoded, err := encodePSMetadata(meta)
+		require.NoError(t, err)
+
+		decoded, err := decodePSMetadata(encoded)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"ks_sharded", "ks_unsharded"}, decoded.VSchemaKeyspaces)
+	})
+
+	t.Run("empty vschema keyspaces", func(t *testing.T) {
+		meta := &psMetadata{
+			BranchName:      "test-branch",
+			DeployRequestID: 42,
+		}
+		encoded, err := encodePSMetadata(meta)
+		require.NoError(t, err)
+
+		decoded, err := decodePSMetadata(encoded)
+		require.NoError(t, err)
+		assert.Empty(t, decoded.VSchemaKeyspaces)
+	})
+}

--- a/pkg/localscale/handlers_deploy.go
+++ b/pkg/localscale/handlers_deploy.go
@@ -220,9 +220,9 @@ func (s *Server) handleDeployDeployRequest(w http.ResponseWriter, r *http.Reques
 	migrationContext := fmt.Sprintf("localscale:%d_%d", number, time.Now().UnixMilli()%1000000)
 	result, err := s.metadataDB.ExecContext(r.Context(),
 		`UPDATE localscale_deploy_requests
-		 SET deployed = TRUE, migration_context = ?, deployment_state = ?
+		 SET deployed = TRUE, instant_ddl = ?, migration_context = ?, deployment_state = ?
 		 WHERE org = ? AND database_name = ? AND number = ? AND deployed = FALSE`,
-		migrationContext, dr.Submitting, org, database, number,
+		body.InstantDDL, migrationContext, dr.Submitting, org, database, number,
 	)
 	if err != nil {
 		return newHTTPError(http.StatusInternalServerError, "update deploy request: %v", err)

--- a/pkg/localscale/processor.go
+++ b/pkg/localscale/processor.go
@@ -65,6 +65,7 @@ type activeDeployRow struct {
 	vschemaApplied         bool
 	autoCutover            bool
 	instantDDLEligible     bool
+	instantDDL             bool
 	branch                 string
 	revertExpiresAtStr     sql.NullString
 	createdAtStr           string
@@ -75,7 +76,7 @@ type activeDeployRow struct {
 func (s *Server) processActiveDeployRequests(ctx context.Context) {
 	rows, err := s.metadataDB.QueryContext(ctx,
 		`SELECT org, database_name, number, deployment_state, migration_context, revert_migration_context,
-		        vschema_data, vschema_applied, auto_cutover, instant_ddl_eligible, branch, revert_expires_at, created_at
+		        vschema_data, vschema_applied, auto_cutover, instant_ddl_eligible, instant_ddl, branch, revert_expires_at, created_at
 		 FROM localscale_deploy_requests
 		 WHERE deployment_state IN ('submitting','queued','in_progress','pending_cutover','in_progress_cutover','in_progress_vschema','in_progress_cancel','in_progress_revert','in_progress_revert_vschema','complete_pending_revert')
 		 AND deployed = TRUE`)
@@ -88,7 +89,7 @@ func (s *Server) processActiveDeployRequests(ctx context.Context) {
 	for rows.Next() {
 		var r activeDeployRow
 		if err := rows.Scan(&r.org, &r.database, &r.number, &r.deployState, &r.migrationContext, &r.revertMigrationContext,
-			&r.vschemaDataSQL, &r.vschemaApplied, &r.autoCutover, &r.instantDDLEligible, &r.branch, &r.revertExpiresAtStr, &r.createdAtStr); err != nil {
+			&r.vschemaDataSQL, &r.vschemaApplied, &r.autoCutover, &r.instantDDLEligible, &r.instantDDL, &r.branch, &r.revertExpiresAtStr, &r.createdAtStr); err != nil {
 			s.logger.Warn("processor: scan deploy request row", "error", err)
 			continue
 		}
@@ -181,7 +182,7 @@ func (s *Server) processActiveDeployRequests(ctx context.Context) {
 				}
 			}
 
-			newState := deriveDeployState(migrations, cutoverRequested, r.instantDDLEligible)
+			newState := deriveDeployState(migrations, cutoverRequested, r.instantDDL)
 
 			// If the processor detects cancelled migrations while the deploy is
 			// still in queued/in_progress, route through the cancel flow instead

--- a/pkg/localscale/schema/localscale_deploy_requests.sql
+++ b/pkg/localscale/schema/localscale_deploy_requests.sql
@@ -23,6 +23,7 @@ CREATE TABLE `localscale_deploy_requests` (
   `throttle_ratio` double NOT NULL DEFAULT '0',
   `schema_before` mediumtext,
   `instant_ddl_eligible` tinyint(1) NOT NULL DEFAULT '0',
+  `instant_ddl` tinyint(1) NOT NULL DEFAULT '0',
   `revert_expires_at` timestamp NULL DEFAULT NULL,
   `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`),

--- a/pkg/localscale/server_deploy_integration_test.go
+++ b/pkg/localscale/server_deploy_integration_test.go
@@ -546,8 +546,7 @@ func TestDeploySubmittingToQueued(t *testing.T) {
 	require.NoError(t, err, "DeployDeployRequest")
 	assert.Equal(t, drState.Submitting, dr.DeploymentState, "initial deploy state should be submitting")
 
-	// Background goroutine should transition through queued → completion
-	waitForDeployState(t, ctx, dr.Number, drState.CompletePendingRevert)
+	// Instant DDL skips the revert window and transitions directly to complete.
 	waitForDeployState(t, ctx, dr.Number, drState.Complete)
 
 	t.Logf("Verified submitting → queued → complete transition for deploy request %d", dr.Number)
@@ -694,9 +693,9 @@ func TestCompleteRevertError(t *testing.T) {
 	)
 
 	dr := createDeploy(t, ctx, branchName, true)
-	deploy(t, ctx, dr.Number, true)
+	deploy(t, ctx, dr.Number, false)
 	dr = waitForDeployState(t, ctx, dr.Number, drState.CompletePendingRevert)
-	require.Equal(t, drState.CompletePendingRevert, dr.DeploymentState, "test uses 5s revert window, should reach complete_pending_revert")
+	require.Equal(t, drState.CompletePendingRevert, dr.DeploymentState, "non-instant deploy should reach complete_pending_revert")
 
 	// Revert should succeed with complete_revert (not complete_revert_error)
 	_, err := testClient.RevertDeployRequest(ctx, &ps.RevertDeployRequestRequest{

--- a/pkg/storage/mysqlstore/storage.go
+++ b/pkg/storage/mysqlstore/storage.go
@@ -20,6 +20,7 @@ type Storage struct {
 	checks          *checkStore
 	settings        *settingsStore
 	vitessApplyData *vitessApplyDataStore
+	vitessTasks     *vitessTaskStore
 }
 
 // New creates a new MySQL storage instance.
@@ -35,6 +36,7 @@ func New(db *sql.DB) *Storage {
 		checks:          &checkStore{db: db},
 		settings:        &settingsStore{db: db},
 		vitessApplyData: &vitessApplyDataStore{db: db},
+		vitessTasks:     &vitessTaskStore{db: db},
 	}
 }
 
@@ -91,4 +93,9 @@ func (s *Storage) Ping(ctx context.Context) error {
 // Close closes the database connection.
 func (s *Storage) Close() error {
 	return s.db.Close()
+}
+
+// VitessTasks returns the Vitess task store.
+func (s *Storage) VitessTasks() storage.VitessTaskStore {
+	return s.vitessTasks
 }

--- a/pkg/storage/mysqlstore/vitess_tasks.go
+++ b/pkg/storage/mysqlstore/vitess_tasks.go
@@ -1,0 +1,67 @@
+package mysqlstore
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/block/schemabot/pkg/storage"
+	"github.com/block/spirit/pkg/utils"
+)
+
+type vitessTaskStore struct {
+	db *sql.DB
+}
+
+func (s *vitessTaskStore) Create(ctx context.Context, task *storage.VitessTask) error {
+	result, err := s.db.ExecContext(ctx,
+		`INSERT INTO vitess_tasks (apply_id, keyspace, task_type, state, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, NOW(), NOW())`,
+		task.ApplyID, task.Keyspace, task.TaskType, task.State,
+	)
+	if err != nil {
+		return fmt.Errorf("insert vitess_task: %w", err)
+	}
+	id, err := result.LastInsertId()
+	if err != nil {
+		return fmt.Errorf("get vitess_task id: %w", err)
+	}
+	task.ID = id
+	return nil
+}
+
+func (s *vitessTaskStore) GetByApplyID(ctx context.Context, applyID int64) ([]*storage.VitessTask, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT id, apply_id, keyspace, task_type, state, created_at, updated_at
+		 FROM vitess_tasks WHERE apply_id = ? ORDER BY id`,
+		applyID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("query vitess_tasks: %w", err)
+	}
+	defer utils.CloseAndLog(rows)
+
+	var tasks []*storage.VitessTask
+	for rows.Next() {
+		t := &storage.VitessTask{}
+		if err := rows.Scan(&t.ID, &t.ApplyID, &t.Keyspace, &t.TaskType, &t.State, &t.CreatedAt, &t.UpdatedAt); err != nil {
+			return nil, fmt.Errorf("scan vitess_task: %w", err)
+		}
+		tasks = append(tasks, t)
+	}
+	return tasks, rows.Err()
+}
+
+func (s *vitessTaskStore) UpdateState(ctx context.Context, id int64, state string) error {
+	_, err := s.db.ExecContext(ctx,
+		`UPDATE vitess_tasks SET state = ?, updated_at = NOW() WHERE id = ?`,
+		state, id,
+	)
+	if err != nil {
+		return fmt.Errorf("update vitess_task state: %w", err)
+	}
+	return nil
+}
+
+// Ensure vitessTaskStore implements VitessTaskStore at compile time.
+var _ storage.VitessTaskStore = (*vitessTaskStore)(nil)

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -4,6 +4,7 @@ package storage
 
 import (
 	"context"
+	"time"
 )
 
 // Storage provides access to all stores.
@@ -34,6 +35,7 @@ type Storage interface {
 
 	// VitessApplyData returns the Vitess apply data store.
 	VitessApplyData() VitessApplyDataStore
+	VitessTasks() VitessTaskStore
 
 	// Ping verifies the database connection is alive.
 	Ping(ctx context.Context) error
@@ -299,4 +301,22 @@ type ApplyLogStore interface {
 
 	// List returns logs matching the filter criteria, ordered by created_at.
 	List(ctx context.Context, filter ApplyLogFilter) ([]*ApplyLog, error)
+}
+
+// VitessTaskStore manages Vitess-specific non-DDL tasks (VSchema changes, routing rules).
+type VitessTaskStore interface {
+	Create(ctx context.Context, task *VitessTask) error
+	GetByApplyID(ctx context.Context, applyID int64) ([]*VitessTask, error)
+	UpdateState(ctx context.Context, id int64, state string) error
+}
+
+// VitessTask represents a Vitess-specific task stored in the vitess_tasks table.
+type VitessTask struct {
+	ID        int64
+	ApplyID   int64
+	Keyspace  string
+	TaskType  string // "vschema", "routing_rules"
+	State     string
+	CreatedAt time.Time
+	UpdatedAt time.Time
 }

--- a/pkg/tern/apply_states_test.go
+++ b/pkg/tern/apply_states_test.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"strings"
 	"testing"
-	"time"
 
 	"github.com/block/spirit/pkg/statement"
 
@@ -254,7 +254,9 @@ func TestDeriveOverallState(t *testing.T) {
 	}
 }
 
-func TestVSchemaTasksCreatedAlongsideDDL(t *testing.T) {
+// TestVSchemaNotInFlatDDLChanges verifies that FlatDDLChanges only returns DDL,
+// not VSchema entries. VSchema changes are tracked in vitess_tasks separately.
+func TestVSchemaNotInFlatDDLChanges(t *testing.T) {
 	plan := &storage.Plan{
 		Namespaces: map[string]*storage.NamespacePlanData{
 			"myapp_sharded": {
@@ -268,84 +270,23 @@ func TestVSchemaTasksCreatedAlongsideDDL(t *testing.T) {
 	}
 
 	ddlChanges := plan.FlatDDLChanges()
-	require.Len(t, ddlChanges, 1, "should have 1 DDL change")
+	require.Len(t, ddlChanges, 1, "FlatDDLChanges should only return DDL, not VSchema")
+	assert.Equal(t, "users", ddlChanges[0].Table)
 
+	// Verify namespaces with VSchema are identifiable for vitess_tasks creation.
+	var vschemaKeyspaces []string
 	for ns, nsData := range plan.Namespaces {
 		if len(nsData.VSchema) > 0 {
-			ddlChanges = append(ddlChanges, storage.TableChange{
-				Table:     "VSchema: " + ns,
-				Namespace: ns,
-				Operation: "vschema_update",
-			})
+			vschemaKeyspaces = append(vschemaKeyspaces, ns)
 		}
 	}
-
-	assert.Len(t, ddlChanges, 3, "should have 1 DDL + 2 VSchema tasks")
-
-	var vschemaTasks []storage.TableChange
-	for _, c := range ddlChanges {
-		if c.Operation == "vschema_update" {
-			vschemaTasks = append(vschemaTasks, c)
-		}
-	}
-	assert.Len(t, vschemaTasks, 2, "should have 2 VSchema tasks (one per keyspace)")
-	for _, vt := range vschemaTasks {
-		assert.Contains(t, vt.Table, "VSchema: ")
-		assert.Equal(t, "vschema_update", vt.Operation)
-	}
+	assert.Len(t, vschemaKeyspaces, 2, "should detect 2 keyspaces with VSchema changes")
 }
 
-func TestDeriveVSchemaTaskState(t *testing.T) {
-	c := &LocalClient{}
-	now := time.Now()
-
-	t.Run("pending task stays pending when deploy is running", func(t *testing.T) {
-		task := &storage.Task{State: state.Task.Pending}
-		result := &engine.ProgressResult{State: engine.StateRunning, Message: "Deploying"}
-		got := c.deriveVSchemaTaskState(task, result, state.Task.Running, now)
-		assert.Equal(t, state.Task.Pending, got)
-	})
-
-	t.Run("transitions to running on VSchema apply message", func(t *testing.T) {
-		task := &storage.Task{State: state.Task.Pending}
-		result := &engine.ProgressResult{State: engine.StateRunning, Message: "Applying VSchema changes"}
-		got := c.deriveVSchemaTaskState(task, result, state.Task.Running, now)
-		assert.Equal(t, state.Task.Running, got)
-		assert.NotNil(t, task.StartedAt)
-	})
-
-	t.Run("transitions to revert_window when overall is revert_window", func(t *testing.T) {
-		task := &storage.Task{State: state.Task.Running}
-		result := &engine.ProgressResult{State: engine.StateRevertWindow}
-		got := c.deriveVSchemaTaskState(task, result, state.Task.RevertWindow, now)
-		assert.Equal(t, state.Task.RevertWindow, got)
-	})
-
-	t.Run("transitions to completed when overall is completed", func(t *testing.T) {
-		task := &storage.Task{State: state.Task.Running}
-		result := &engine.ProgressResult{State: engine.StateCompleted}
-		got := c.deriveVSchemaTaskState(task, result, state.Task.Completed, now)
-		assert.Equal(t, state.Task.Completed, got)
-	})
-
-	t.Run("transitions to failed on engine failure", func(t *testing.T) {
-		task := &storage.Task{State: state.Task.Running}
-		result := &engine.ProgressResult{State: engine.StateFailed}
-		got := c.deriveVSchemaTaskState(task, result, state.Task.Failed, now)
-		assert.Equal(t, state.Task.Failed, got)
-	})
-
-	t.Run("stays pending during cutover since VSchema is applied after", func(t *testing.T) {
-		task := &storage.Task{State: state.Task.Pending}
-		result := &engine.ProgressResult{State: engine.StateWaitingForCutover, Message: "Waiting for cutover"}
-		got := c.deriveVSchemaTaskState(task, result, state.Task.WaitingForCutover, now)
-		assert.Equal(t, state.Task.Pending, got)
-	})
-
-	t.Run("terminal task state is preserved", func(t *testing.T) {
-		task := &storage.Task{State: state.Task.Completed}
-		result := &engine.ProgressResult{State: engine.StateRunning, Message: "Applying VSchema changes"}
-		got := c.deriveVSchemaTaskState(task, result, state.Task.Running, now)
-		assert.Equal(t, state.Task.Completed, got)
-	})
+// TestVSchemaTablePrefix verifies that the VSchema table prefix is used
+// consistently for identifying VSchema entries in progress responses.
+func TestVSchemaTablePrefix(t *testing.T) {
+	prefix := engine.VSchemaTablePrefix
+	assert.Equal(t, "VSchema: ", prefix)
+	assert.True(t, strings.HasPrefix(prefix+"myapp", prefix))
 }

--- a/pkg/tern/local_apply.go
+++ b/pkg/tern/local_apply.go
@@ -189,14 +189,9 @@ func (c *LocalClient) transitionTaskState(ctx context.Context, task *storage.Tas
 }
 
 // markTasksRunning sets DDL tasks to running state with a start timestamp.
-// VSchema tasks are skipped — their state is driven by the deploy request
-// lifecycle (deriveVSchemaTaskState), not by apply start.
 func (c *LocalClient) markTasksRunning(ctx context.Context, tasks []*storage.Task) {
 	now := time.Now()
 	for _, task := range tasks {
-		if task.DDLAction == "vschema_update" {
-			continue
-		}
 		task.State = state.Task.Running
 		task.StartedAt = &now
 		task.UpdatedAt = now
@@ -901,18 +896,6 @@ func (c *LocalClient) syncAtomicTaskProgress(ctx context.Context, tasks []*stora
 	}
 
 	for _, task := range tasks {
-		// VSchema tasks follow deploy-request-level state, not per-migration state.
-		// They have no SHOW VITESS_MIGRATIONS rows. Their state transitions are:
-		// pending → running (during in_progress_vschema) → completed/failed.
-		if task.DDLAction == "vschema_update" {
-			vsState := c.deriveVSchemaTaskState(task, result, newState, now)
-			if vsState != task.State {
-				msg := fmt.Sprintf("VSchema %s → %s", task.State, vsState)
-				c.transitionTaskState(ctx, task, task.ApplyID, vsState, msg)
-			}
-			continue
-		}
-
 		if tp, ok := engineProgressForTask(tableProgress, task); ok {
 			task.RowsCopied = tp.RowsCopied
 			task.RowsTotal = tp.RowsTotal
@@ -948,41 +931,6 @@ func (c *LocalClient) syncAtomicTaskProgress(ctx context.Context, tasks []*stora
 			task.ProgressPercent = 100
 		}
 		c.transitionTaskState(ctx, task, 0, newState, "")
-	}
-}
-
-// deriveVSchemaTaskState determines the state for a VSchema task based on
-// the engine progress result. VSchema tasks have no per-migration rows in
-// SHOW VITESS_MIGRATIONS — their state tracks the deploy request's VSchema
-// application phase (in_progress_vschema).
-func (c *LocalClient) deriveVSchemaTaskState(task *storage.Task, result *engine.ProgressResult, taskState string, now time.Time) string {
-	if state.IsTerminalTaskState(task.State) {
-		return task.State
-	}
-
-	switch {
-	case result.Message == engine.MessageApplyingVSchema:
-		if task.StartedAt == nil {
-			task.StartedAt = &now
-		}
-		return state.Task.Running
-	case result.State == engine.StateFailed:
-		if task.CompletedAt == nil {
-			task.CompletedAt = &now
-		}
-		return state.Task.Failed
-	case state.IsState(taskState, state.Task.RevertWindow):
-		if task.CompletedAt == nil {
-			task.CompletedAt = &now
-		}
-		return state.Task.RevertWindow
-	case result.State.IsTerminal(), state.IsState(taskState, state.Task.Completed):
-		if task.CompletedAt == nil {
-			task.CompletedAt = &now
-		}
-		return state.Task.Completed
-	default:
-		return task.State
 	}
 }
 

--- a/pkg/tern/local_client.go
+++ b/pkg/tern/local_client.go
@@ -523,8 +523,6 @@ func (c *LocalClient) Apply(ctx context.Context, req *ternv1.ApplyRequest) (*ter
 		fmt.Sprintf("Apply started: %s", applyIdentifier), "", state.Apply.Pending)
 
 	// Create one Task per DDLChange in the plan.
-	// For VSchema-only deploys (0 DDL changes), create a synthetic task per
-	// keyspace with VSchema changes so the progress API has something to track.
 	c.logger.Info("Apply: creating tasks",
 		"plan_id", plan.PlanIdentifier,
 		"ddl_change_count", len(ddlChanges),
@@ -537,15 +535,25 @@ func (c *LocalClient) Apply(ctx context.Context, req *ternv1.ApplyRequest) (*ter
 		)
 	}
 
-	// Create VSchema tasks for namespaces with VSchema changes so the
-	// progress API and TUI can track VSchema application alongside DDL.
+	// Create vitess_tasks entries for namespaces with VSchema changes.
+	// These are tracked separately from DDL tasks because VSchema changes
+	// are metadata-only operations with their own lifecycle in PlanetScale.
 	for ns, nsData := range plan.Namespaces {
 		if len(nsData.VSchema) > 0 {
-			ddlChanges = append(ddlChanges, storage.TableChange{
-				Table:     "VSchema: " + ns,
-				Namespace: ns,
-				Operation: "vschema_update",
-			})
+			vt := &storage.VitessTask{
+				ApplyID:  applyID,
+				Keyspace: ns,
+				TaskType: "vschema",
+				State:    "pending",
+			}
+			if err := c.storage.VitessTasks().Create(ctx, vt); err != nil {
+				return nil, fmt.Errorf("create vitess_task for keyspace %s: %w", ns, err)
+			}
+			c.logger.Info("Apply: created vitess_task",
+				"apply_id", applyID,
+				"keyspace", ns,
+				"task_type", "vschema",
+			)
 		}
 	}
 
@@ -633,16 +641,17 @@ func (c *LocalClient) getEngine() engine.Engine {
 // If req.ApplyId is set, scopes to that specific apply. Otherwise queries by database.
 func (c *LocalClient) Progress(ctx context.Context, req *ternv1.ProgressRequest) (*ternv1.ProgressResponse, error) {
 	var tasks []*storage.Task
+	var applyRecord *storage.Apply
 	var err error
 
 	if req.ApplyId != "" {
 		// Scope to specific apply.
-		apply, lookupErr := c.storage.Applies().GetByApplyIdentifier(ctx, req.ApplyId)
-		if lookupErr != nil {
-			return nil, fmt.Errorf("get apply %s: %w", req.ApplyId, lookupErr)
+		applyRecord, err = c.storage.Applies().GetByApplyIdentifier(ctx, req.ApplyId)
+		if err != nil {
+			return nil, fmt.Errorf("get apply %s: %w", req.ApplyId, err)
 		}
-		if apply != nil {
-			tasks, err = c.storage.Tasks().GetByApplyID(ctx, apply.ID)
+		if applyRecord != nil {
+			tasks, err = c.storage.Tasks().GetByApplyID(ctx, applyRecord.ID)
 			if err != nil {
 				return nil, fmt.Errorf("get tasks for apply %s: %w", req.ApplyId, err)
 			}
@@ -717,40 +726,51 @@ func (c *LocalClient) Progress(ctx context.Context, req *ternv1.ProgressRequest)
 		activeTask = latestTask
 	}
 
-	if activeTask == nil {
+	if activeTask == nil && applyRecord == nil {
 		return &ternv1.ProgressResponse{
 			State:  ternv1.State_STATE_NO_ACTIVE_CHANGE,
 			Engine: c.protoEngine(),
 		}, nil
 	}
-	c.logger.Info("Progress: selected task", "task_id", activeTask.TaskIdentifier, "state", activeTask.State, "apply_id", activeTask.ApplyID)
+
+	// Resolve the apply ID — from the active task if available, otherwise from the apply record.
+	var applyID int64
+	if activeTask != nil {
+		applyID = activeTask.ApplyID
+		c.logger.Info("Progress: selected task", "task_id", activeTask.TaskIdentifier, "state", activeTask.State, "apply_id", applyID)
+		// Ensure applyRecord is populated for vitess_tasks lookup.
+		if applyRecord == nil {
+			applyRecord, _ = c.storage.Applies().Get(ctx, applyID)
+		}
+	} else {
+		applyID = applyRecord.ID
+		c.logger.Info("Progress: no DDL tasks, using apply record", "apply_id", applyID)
+	}
 
 	// Get ALL tasks for this apply (completed + running + pending)
-	currentApplyTasks := filterTasksByApply(tasks, activeTask.ApplyID)
+	currentApplyTasks := filterTasksByApply(tasks, applyID)
 
 	creds := c.credentials()
 	eng := c.getEngine()
 
-	// Get live progress from engine for the currently running task.
-	// For Vitess, reconstruct ResumeState from vitess_apply_data so the engine
-	// can poll the deploy request and query SHOW VITESS_MIGRATIONS.
+	// Get live progress from engine. For Vitess, reconstruct ResumeState from
+	// vitess_apply_data so the engine can poll the deploy request.
 	var engineResult *engine.ProgressResult
 	var vitessApplyIsInstant bool
-	// Query engine for live progress. For Vitess, also query during pending state
-	// to surface PlanetScale states (preparing branch, deploy request, etc.).
 	queryDuringPending := c.config.Type == storage.DatabaseTypeVitess
-	if eng != nil && (activeTask.State != state.Task.Pending || queryDuringPending) {
+	shouldQueryEngine := activeTask == nil || activeTask.State != state.Task.Pending || queryDuringPending
+	if eng != nil && shouldQueryEngine {
 		progressReq := &engine.ProgressRequest{
 			Database:    c.config.Database,
 			Credentials: creds,
 		}
 		if c.config.Type == storage.DatabaseTypeVitess {
-			vad, vadErr := c.storage.VitessApplyData().GetByApplyID(ctx, activeTask.ApplyID)
+			vad, vadErr := c.storage.VitessApplyData().GetByApplyID(ctx, applyID)
 			switch {
 			case vadErr != nil:
-				c.logger.Error("failed to load VitessApplyData for progress", "apply_id", activeTask.ApplyID, "error", vadErr)
+				c.logger.Error("failed to load VitessApplyData for progress", "apply_id", applyID, "error", vadErr)
 			case vad == nil:
-				c.logger.Warn("VitessApplyData not found for progress — apply may still be initializing", "apply_id", activeTask.ApplyID)
+				c.logger.Warn("VitessApplyData not found for progress — apply may still be initializing", "apply_id", applyID)
 			default:
 				vitessApplyIsInstant = vad.IsInstant
 				meta, _ := json.Marshal(map[string]any{
@@ -769,12 +789,10 @@ func (c *LocalClient) Progress(ctx context.Context, req *ternv1.ProgressRequest)
 		result, err := eng.Progress(ctx, progressReq)
 		if err == nil {
 			engineResult = result
-			c.logger.Info("Progress: engine returned", "engine_state", result.State, "message", result.Message, "task_id", activeTask.TaskIdentifier, "storage_state", activeTask.State)
+			c.logger.Info("Progress: engine returned", "engine_state", result.State, "message", result.Message, "apply_id", applyID)
 
-			// Only update task state from engine if task is not already in a terminal state.
-			// Terminal states (CANCELLED, COMPLETED, FAILED, etc.) should be preserved -
-			// they represent the final state set by the apply execution.
-			if !state.IsTerminalTaskState(activeTask.State) {
+			// Update the active DDL task state from engine if present and not terminal.
+			if activeTask != nil && !state.IsTerminalTaskState(activeTask.State) {
 				activeTask.State = engineStateToStorage(result.State)
 				now := time.Now()
 				activeTask.UpdatedAt = now
@@ -786,10 +804,8 @@ func (c *LocalClient) Progress(ctx context.Context, req *ternv1.ProgressRequest)
 				}
 			}
 
-			// Also update the apply record if the engine reports a terminal state
-			// but the apply hasn't been updated yet. Only do this when ALL tasks
-			// for this apply are terminal — in sequential mode, the engine reports
-			// "completed" per-task, but the apply isn't done until all tasks finish.
+			// Update the apply record if the engine reports a terminal state
+			// and all DDL tasks are terminal (or there are none).
 			if result.State.IsTerminal() {
 				allTerminal := true
 				for _, t := range currentApplyTasks {
@@ -799,16 +815,15 @@ func (c *LocalClient) Progress(ctx context.Context, req *ternv1.ProgressRequest)
 					}
 				}
 				if allTerminal {
-					apply, _ := c.storage.Applies().GetByApplyIdentifier(ctx, req.ApplyId)
-					if apply != nil && !state.IsTerminalApplyState(apply.State) {
+					if applyRecord != nil && !state.IsTerminalApplyState(applyRecord.State) {
 						now := time.Now()
-						apply.State = engineStateToStorage(result.State)
-						apply.CompletedAt = &now
-						apply.UpdatedAt = now
-						if err := c.storage.Applies().Update(ctx, apply); err != nil {
-							c.logger.Warn("failed to update apply from progress poll", "apply_id", apply.ApplyIdentifier, "state", apply.State, "apply_db_id", apply.ID, "error", err)
+						applyRecord.State = engineStateToStorage(result.State)
+						applyRecord.CompletedAt = &now
+						applyRecord.UpdatedAt = now
+						if err := c.storage.Applies().Update(ctx, applyRecord); err != nil {
+							c.logger.Warn("failed to update apply from progress poll", "apply_id", applyRecord.ApplyIdentifier, "state", applyRecord.State, "apply_db_id", applyRecord.ID, "error", err)
 						}
-						c.logger.Info("apply state updated from progress polling", "apply_id", apply.ApplyIdentifier, "state", apply.State)
+						c.logger.Info("apply state updated from progress polling", "apply_id", applyRecord.ApplyIdentifier, "state", applyRecord.State)
 					}
 				}
 			}
@@ -904,6 +919,52 @@ func (c *LocalClient) Progress(ctx context.Context, req *ternv1.ProgressRequest)
 		tables = append(tables, tp)
 	}
 
+	// Append VSchema tasks from vitess_tasks storage. These represent
+	// non-DDL operations (VSchema, routing rules) that don't appear in
+	// SHOW VITESS_MIGRATIONS but are tracked by PlanetScale's deploy state machine.
+	{
+		vtasks, vtErr := c.storage.VitessTasks().GetByApplyID(ctx, applyID)
+		if vtErr != nil {
+			c.logger.Warn("failed to query vitess_tasks", "error", vtErr)
+		}
+		for _, vt := range vtasks {
+			tp := &ternv1.TableProgress{
+				TableName: engine.VSchemaTablePrefix + vt.Keyspace,
+				Namespace: vt.Keyspace,
+				Status:    strings.ToUpper(vt.State),
+			}
+			// Enrich with live engine state and persist state changes.
+			if engineResult != nil {
+				for _, et := range engineResult.Tables {
+					if et.Table == tp.TableName {
+						newState := strings.ToLower(et.State)
+						if newState != vt.State {
+							if updateErr := c.storage.VitessTasks().UpdateState(ctx, vt.ID, newState); updateErr != nil {
+								c.logger.Warn("failed to update vitess_task state",
+									"vitess_task_id", vt.ID,
+									"keyspace", vt.Keyspace,
+									"old_state", vt.State,
+									"new_state", newState,
+									"error", updateErr,
+								)
+							} else {
+								c.logger.Debug("updated vitess_task state",
+									"vitess_task_id", vt.ID,
+									"keyspace", vt.Keyspace,
+									"old_state", vt.State,
+									"new_state", newState,
+								)
+							}
+						}
+						tp.Status = strings.ToUpper(et.State)
+						break
+					}
+				}
+			}
+			tables = append(tables, tp)
+		}
+	}
+
 	// Derive overall state from ALL tasks in this apply.
 	// If tasks are all pending, check the apply record for a more specific state
 	// (e.g., preparing_branch, creating_deploy_request during PlanetScale setup).
@@ -913,7 +974,7 @@ func (c *LocalClient) Progress(ctx context.Context, req *ternv1.ProgressRequest)
 	// than what task states alone can derive. Check the apply record when
 	// tasks are still pending or when the overall state doesn't yet reflect
 	// real progress (e.g., engine returns "running" during setup).
-	if applyRec, err := c.storage.Applies().Get(ctx, activeTask.ApplyID); err == nil && applyRec != nil {
+	if applyRec, err := c.storage.Applies().Get(ctx, applyID); err == nil && applyRec != nil {
 		switch {
 		case state.IsBranchSetupPhase(applyRec.State):
 			c.logger.Debug("Progress: overriding task-derived state with apply record setup phase",
@@ -955,7 +1016,7 @@ func (c *LocalClient) Progress(ctx context.Context, req *ternv1.ProgressRequest)
 
 	// Populate apply_id, engine, and volume from the apply record.
 	// The apply record's engine is the source of truth (set at apply creation time).
-	if apply, err := c.storage.Applies().Get(ctx, activeTask.ApplyID); err == nil && apply != nil {
+	if apply, err := c.storage.Applies().Get(ctx, applyID); err == nil && apply != nil {
 		resp.ApplyId = apply.ApplyIdentifier
 		if eng, err := engineNameToProto(apply.Engine); err != nil {
 			return nil, fmt.Errorf("invalid engine on apply %s: %w", apply.ApplyIdentifier, err)

--- a/pkg/tern/state_converters.go
+++ b/pkg/tern/state_converters.go
@@ -131,14 +131,8 @@ func changeTypeToProto(op statement.StatementType) ternv1.ChangeType {
 }
 
 // ddlActionToProtoChangeType converts a task's DDLAction string to a proto ChangeType.
-// Handles vschema_update which doesn't come from Spirit's statement parser.
 func ddlActionToProtoChangeType(action string) ternv1.ChangeType {
-	switch action {
-	case "vschema_update":
-		return ternv1.ChangeType_CHANGE_TYPE_VSCHEMA
-	default:
-		return changeTypeToProto(ddl.OpToStatementType(action))
-	}
+	return changeTypeToProto(ddl.OpToStatementType(action))
 }
 
 // filterTasksByApply returns only tasks belonging to the specified apply, sorted by ID (execution order).

--- a/pkg/webhook/review_gate_test.go
+++ b/pkg/webhook/review_gate_test.go
@@ -63,6 +63,7 @@ func (m *reviewGateMockStorage) Tasks() storage.TaskStore                      {
 func (m *reviewGateMockStorage) ApplyLogs() storage.ApplyLogStore              { return nil }
 func (m *reviewGateMockStorage) ApplyComments() storage.ApplyCommentStore      { return nil }
 func (m *reviewGateMockStorage) VitessApplyData() storage.VitessApplyDataStore { return nil }
+func (m *reviewGateMockStorage) VitessTasks() storage.VitessTaskStore          { return nil }
 func (m *reviewGateMockStorage) Checks() storage.CheckStore                    { return nil }
 func (m *reviewGateMockStorage) Settings() storage.SettingsStore               { return m.settings }
 func (m *reviewGateMockStorage) Ping(_ context.Context) error                  { return nil }


### PR DESCRIPTION
VSchema changes were invisible during deploy progress — the TUI only showed DDL table entries from SHOW VITESS_MIGRATIONS. VSchema updates are metadata-only operations tracked by PlanetScale's deploy state machine, not Vitess OnlineDDL.

- Track which keyspaces have VSchema changes in apply metadata
- Synthesize VSchema table entries in the engine Progress response with state derived from the deploy request deployment state
- Pass synthetic VSchema entries through the LocalClient proto conversion so they reach the CLI
- Add shared `VSchemaTablePrefix` constant used by both the engine and CLI for consistent detection
- Fix double-space typo in "Validating deploy request" TUI message