### PR TITLE
refactor(github): route remaining inline PR comments through templates

### DIFF
--- a/pkg/webhook/check_runs.go
+++ b/pkg/webhook/check_runs.go
@@ -296,7 +296,7 @@ func (h *Handler) checkPriorEnvViaGitHub(
 		h.logger.Error("failed to create GitHub client for prior env check, blocking apply",
 			"prior_env", priorEnv, "error", err)
 		h.postComment(repo, pr, installationID,
-			fmt.Sprintf("## ❌ Apply Blocked\n\nCould not verify %s status: failed to create GitHub client. Retry the apply command.\n\n_Error: %v_", priorEnv, err))
+			templates.RenderApplyBlockedByPriorEnvCheckError(priorEnv, "create GitHub client", err))
 		return true
 	}
 
@@ -305,7 +305,7 @@ func (h *Handler) checkPriorEnvViaGitHub(
 		h.logger.Error("failed to fetch PR for prior env check, blocking apply",
 			"prior_env", priorEnv, "error", err)
 		h.postComment(repo, pr, installationID,
-			fmt.Sprintf("## ❌ Apply Blocked\n\nCould not verify %s status: failed to fetch PR details. Retry the apply command.\n\n_Error: %v_", priorEnv, err))
+			templates.RenderApplyBlockedByPriorEnvCheckError(priorEnv, "fetch PR details", err))
 		return true
 	}
 
@@ -315,7 +315,7 @@ func (h *Handler) checkPriorEnvViaGitHub(
 		h.logger.Error("failed to query GitHub check for prior environment, blocking apply",
 			"prior_env", priorEnv, "check_name", checkName, "error", err)
 		h.postComment(repo, pr, installationID,
-			fmt.Sprintf("## ❌ Apply Blocked\n\nCould not verify %s status: failed to query check runs. Retry the apply command.\n\n_Error: %v_", priorEnv, err))
+			templates.RenderApplyBlockedByPriorEnvCheckError(priorEnv, "query check runs", err))
 		return true
 	}
 

--- a/pkg/webhook/issue_comment.go
+++ b/pkg/webhook/issue_comment.go
@@ -91,8 +91,7 @@ func (h *Handler) handleIssueComment(w http.ResponseWriter, body []byte) {
 	// Reject commands from repositories not in the configured allowlist
 	if h.service != nil && !h.service.Config().IsRepoAllowed(repo) {
 		h.logger.Warn("webhook from unregistered repository", "repo", repo, "pr", pr)
-		h.postComment(repo, pr, installationID,
-			"**Repository not registered.** This repository is not in SchemaBot's configuration. To onboard, add it to the `repos` section of SchemaBot's config and redeploy.")
+		h.postComment(repo, pr, installationID, templates.RenderRepositoryNotRegistered())
 		h.writeJSON(w, http.StatusOK, map[string]string{
 			"message": "repository not registered",
 		})
@@ -123,17 +122,11 @@ func (h *Handler) handleIssueComment(w http.ResponseWriter, body []byte) {
 		}
 		if result.Action == action.Rollback {
 			if result.ApplyID == "" {
-				h.postComment(repo, pr, installationID,
-					"## Missing Arguments\n\n"+
-						"Usage: `schemabot rollback <apply-id> -e <environment>`\n\n"+
-						"Rollback requires both an apply ID and the `-e` flag to select the target environment.")
+				h.postComment(repo, pr, installationID, templates.RenderRollbackMissingArguments())
 				h.writeJSON(w, http.StatusOK, map[string]string{"message": "missing rollback arguments"})
 				return
 			}
-			h.postComment(repo, pr, installationID,
-				"## Missing Environment\n\n"+
-					"Usage: `schemabot rollback <apply-id> -e <environment>`\n\n"+
-					"The `-e` flag is required to select the target environment.")
+			h.postComment(repo, pr, installationID, templates.RenderRollbackMissingEnv())
 			h.writeJSON(w, http.StatusOK, map[string]string{"message": "missing environment flag"})
 			return
 		}
@@ -191,8 +184,7 @@ func (h *Handler) handleIssueComment(w http.ResponseWriter, body []byte) {
 
 	// Reject -y/--yes on commands that don't support it
 	if result.Action != action.Apply && parser.autoConfirmRegex.MatchString(payload.Comment.Body) {
-		h.postComment(repo, pr, installationID,
-			fmt.Sprintf("The `-y` flag is not supported for `%s`.", result.Action))
+		h.postComment(repo, pr, installationID, templates.RenderUnsupportedAutoConfirm(result.Action))
 		h.writeJSON(w, http.StatusOK, map[string]string{"message": "unsupported flag"})
 		return
 	}
@@ -238,8 +230,7 @@ func (h *Handler) handleIssueComment(w http.ResponseWriter, body []byte) {
 	// Phase 2 commands — acknowledge but not yet implemented
 	case action.Stop, action.Revert, action.SkipRevert, action.Cutover:
 		h.postComment(repo, pr, installationID,
-			fmt.Sprintf("The `%s` command is not yet available via PR comments. Use the CLI instead:\n```\nschemabot %s -e %s\n```",
-				result.Action, result.Action, result.Environment))
+			templates.RenderCommandNotYetAvailable(result.Action, result.Environment))
 		h.writeJSON(w, http.StatusOK, map[string]string{
 			"message": fmt.Sprintf("%s command not yet implemented", result.Action),
 		})

--- a/pkg/webhook/rollback.go
+++ b/pkg/webhook/rollback.go
@@ -22,11 +22,7 @@ func (h *Handler) handleRollbackCommand(repo string, pr int, installationID int6
 
 	applyID := result.ApplyID
 	if applyID == "" {
-		h.postComment(repo, pr, installationID,
-			"## Missing Apply ID\n\n"+
-				"Usage: `schemabot rollback <apply-id> -e <environment>`\n\n"+
-				"You can find the apply ID in the summary comment of a completed apply, "+
-				"or by running `schemabot status`.")
+		h.postComment(repo, pr, installationID, templates.RenderRollbackMissingApplyID())
 		return
 	}
 
@@ -47,9 +43,7 @@ func (h *Handler) handleRollbackCommand(repo string, pr int, installationID int6
 		return
 	}
 	if apply == nil {
-		h.postComment(repo, pr, installationID, fmt.Sprintf(
-			"## Apply Not Found\n\n"+
-				"No apply found with ID `%s`. Check the ID and try again.", applyID))
+		h.postComment(repo, pr, installationID, templates.RenderRollbackApplyNotFound(applyID))
 		return
 	}
 
@@ -82,23 +76,9 @@ func (h *Handler) handleRollbackCommand(repo string, pr int, installationID int6
 	lockOwner := fmt.Sprintf("%s#%d", repo, pr)
 
 	if existingLock != nil && existingLock.Owner != lockOwner {
-		if existingLock.PullRequest > 0 && existingLock.Repository != "" {
-			h.postComment(repo, pr, installationID, fmt.Sprintf(
-				"## Rollback Blocked\n\n"+
-					"**Database**: `%s` | **Environment**: `%s`\n\n"+
-					"A lock is currently held by [%s#%d](https://github.com/%s/pull/%d).\n\n"+
-					"Wait for that operation to complete, or ask the lock owner to run `schemabot unlock`.",
-				database, environment,
-				existingLock.Repository, existingLock.PullRequest,
-				existingLock.Repository, existingLock.PullRequest))
-		} else {
-			h.postComment(repo, pr, installationID, fmt.Sprintf(
-				"## Rollback Blocked\n\n"+
-					"**Database**: `%s` | **Environment**: `%s`\n\n"+
-					"A lock is currently held by `%s`.\n\n"+
-					"Wait for that operation to complete, or ask the lock owner to release it.",
-				database, environment, existingLock.Owner))
-		}
+		h.postComment(repo, pr, installationID, templates.RenderRollbackBlockedByLock(
+			database, environment,
+			existingLock.Owner, existingLock.Repository, existingLock.PullRequest))
 		return
 	}
 
@@ -121,11 +101,8 @@ func (h *Handler) handleRollbackCommand(repo string, pr int, installationID int6
 	}
 
 	if len(planResp.FlatTables()) == 0 {
-		h.postComment(repo, pr, installationID, fmt.Sprintf(
-			"## Nothing to Rollback\n\n"+
-				"**Database**: `%s` | **Environment**: `%s`\n\n"+
-				"The database schema already matches the state before apply `%s`. No rollback needed.",
-			database, environment, applyID))
+		h.postComment(repo, pr, installationID,
+			templates.RenderRollbackNothingToDo(database, environment, applyID))
 		return
 	}
 
@@ -221,11 +198,8 @@ func (h *Handler) handleRollbackConfirmCommand(repo string, pr int, environment,
 		return
 	}
 	if existingLock.Owner != lockOwner {
-		h.postComment(repo, pr, installationID, fmt.Sprintf(
-			"## Lock Not Owned\n\n"+
-				"**Database**: `%s` | **Environment**: `%s`\n\n"+
-				"The lock is held by `%s`, not this PR. Cannot confirm rollback.",
-			database, environment, existingLock.Owner))
+		h.postComment(repo, pr, installationID,
+			templates.RenderRollbackLockNotOwned(database, environment, existingLock.Owner))
 		return
 	}
 
@@ -246,11 +220,8 @@ func (h *Handler) handleRollbackConfirmCommand(repo string, pr int, environment,
 	// If no changes remain, release lock and notify
 	if len(planResp.FlatTables()) == 0 {
 		_ = h.service.Storage().Locks().Release(ctx, database, dbType, lockOwner)
-		h.postComment(repo, pr, installationID, fmt.Sprintf(
-			"## Already Rolled Back\n\n"+
-				"**Database**: `%s` | **Environment**: `%s`\n\n"+
-				"The database schema already matches the original state. Lock released.",
-			database, environment))
+		h.postComment(repo, pr, installationID,
+			templates.RenderRollbackAlreadyRolledBack(database, environment))
 		return
 	}
 
@@ -285,11 +256,8 @@ func (h *Handler) handleRollbackConfirmCommand(repo string, pr int, environment,
 	}
 
 	if !applyResp.Accepted {
-		h.postComment(repo, pr, installationID, fmt.Sprintf(
-			"## Rollback Not Accepted\n\n"+
-				"**Database**: `%s` | **Environment**: `%s`\n\n"+
-				"The rollback was not accepted: %s",
-			database, environment, applyResp.ErrorMessage))
+		h.postComment(repo, pr, installationID,
+			templates.RenderRollbackNotAccepted(database, environment, applyResp.ErrorMessage))
 		return
 	}
 

--- a/pkg/webhook/templates/apply_commands.go
+++ b/pkg/webhook/templates/apply_commands.go
@@ -304,6 +304,20 @@ func RenderApplyBlockedByInProgressChecks(environment string, inProgress []Block
 	return sb.String()
 }
 
+// RenderApplyBlockedByPriorEnvCheckError renders a comment when apply is blocked
+// because the GitHub API returned an error while verifying a prior environment's
+// aggregate check status. Reason describes the operation that failed (e.g.
+// "create GitHub client", "fetch PR details", "query check runs").
+func RenderApplyBlockedByPriorEnvCheckError(priorEnv, reason string, err error) string {
+	var sb strings.Builder
+
+	sb.WriteString("## ❌ Apply Blocked\n\n")
+	fmt.Fprintf(&sb, "Could not verify %s status: failed to %s. Retry the apply command.\n\n", priorEnv, reason)
+	fmt.Fprintf(&sb, "_Error: %v_", err)
+
+	return sb.String()
+}
+
 // RenderApplyBlockedByPriorEnvInProgress renders a comment when an apply is blocked
 // because a prior environment's apply is currently running.
 func RenderApplyBlockedByPriorEnvInProgress(database, environment, priorEnv string) string {

--- a/pkg/webhook/templates/apply_test.go
+++ b/pkg/webhook/templates/apply_test.go
@@ -383,6 +383,44 @@ func TestRenderApplyBlockedByCheckStatusError(t *testing.T) {
 	})
 }
 
+func TestRenderApplyBlockedByPriorEnvCheckError(t *testing.T) {
+	t.Run("renders reason and wrapped error verbatim", func(t *testing.T) {
+		err := errors.New("404 Not Found")
+
+		result := RenderApplyBlockedByPriorEnvCheckError("staging", "fetch PR details", err)
+
+		assert.Contains(t, result, "## ❌ Apply Blocked")
+		assert.Contains(t, result, "Could not verify staging status: failed to fetch PR details. Retry the apply command.")
+		assert.Contains(t, result, "_Error: 404 Not Found_")
+	})
+
+	t.Run("each reason variant produces matching body", func(t *testing.T) {
+		err := errors.New("boom")
+
+		for _, reason := range []string{"create GitHub client", "fetch PR details", "query check runs"} {
+			result := RenderApplyBlockedByPriorEnvCheckError("production", reason, err)
+			assert.Contains(t, result, "Could not verify production status: failed to "+reason+". Retry the apply command.")
+		}
+	})
+
+	t.Run("nil error renders <nil>", func(t *testing.T) {
+		result := RenderApplyBlockedByPriorEnvCheckError("staging", "query check runs", nil)
+
+		assert.Contains(t, result, "## ❌ Apply Blocked")
+		assert.Contains(t, result, "_Error: <nil>_")
+	})
+
+	t.Run("output matches prior inline rendering byte-for-byte", func(t *testing.T) {
+		err := errors.New("rate limited")
+		priorEnv := "staging"
+		reason := "create GitHub client"
+
+		expected := "## ❌ Apply Blocked\n\nCould not verify " + priorEnv + " status: failed to " + reason + ". Retry the apply command.\n\n_Error: " + err.Error() + "_"
+
+		assert.Equal(t, expected, RenderApplyBlockedByPriorEnvCheckError(priorEnv, reason, err))
+	})
+}
+
 func TestRenderApplyBlockedByInProgressChecks(t *testing.T) {
 	inProgress := []BlockingCheck{
 		{Name: "CI / unit-tests", State: "in_progress"},

--- a/pkg/webhook/templates/issue_comment.go
+++ b/pkg/webhook/templates/issue_comment.go
@@ -1,0 +1,42 @@
+package templates
+
+import "fmt"
+
+// RenderRepositoryNotRegistered renders the message posted when a SchemaBot
+// command arrives from a repository that is not in the configured allowlist.
+func RenderRepositoryNotRegistered() string {
+	return "**Repository not registered.** This repository is not in SchemaBot's configuration. " +
+		"To onboard, add it to the `repos` section of SchemaBot's config and redeploy."
+}
+
+// RenderRollbackMissingArguments renders the message posted when `schemabot rollback`
+// is invoked without an apply ID and without an `-e` flag.
+func RenderRollbackMissingArguments() string {
+	return "## Missing Arguments\n\n" +
+		"Usage: `schemabot rollback <apply-id> -e <environment>`\n\n" +
+		"Rollback requires both an apply ID and the `-e` flag to select the target environment."
+}
+
+// RenderRollbackMissingEnv renders the message posted when `schemabot rollback`
+// is invoked with an apply ID but no `-e` flag. Distinct from RenderMissingEnv —
+// the rollback variant tailors the example usage to rollback semantics.
+func RenderRollbackMissingEnv() string {
+	return "## Missing Environment\n\n" +
+		"Usage: `schemabot rollback <apply-id> -e <environment>`\n\n" +
+		"The `-e` flag is required to select the target environment."
+}
+
+// RenderUnsupportedAutoConfirm renders the message posted when the `-y` /
+// `--yes` auto-confirm flag is supplied to a command that does not support it.
+func RenderUnsupportedAutoConfirm(action string) string {
+	return fmt.Sprintf("The `-y` flag is not supported for `%s`.", action)
+}
+
+// RenderCommandNotYetAvailable renders the acknowledgement posted when a
+// recognised but not-yet-implemented PR comment command is invoked. It points
+// the user at the CLI fallback for the same action.
+func RenderCommandNotYetAvailable(action, environment string) string {
+	return fmt.Sprintf("The `%s` command is not yet available via PR comments. "+
+		"Use the CLI instead:\n```\nschemabot %s -e %s\n```",
+		action, action, environment)
+}

--- a/pkg/webhook/templates/issue_comment_test.go
+++ b/pkg/webhook/templates/issue_comment_test.go
@@ -1,0 +1,42 @@
+package templates
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRenderRepositoryNotRegistered(t *testing.T) {
+	rendered := RenderRepositoryNotRegistered()
+	assert.Contains(t, rendered, "**Repository not registered.**")
+	assert.Contains(t, rendered, "`repos`")
+	assert.Contains(t, rendered, "redeploy")
+}
+
+func TestRenderRollbackMissingArguments(t *testing.T) {
+	rendered := RenderRollbackMissingArguments()
+	assert.Contains(t, rendered, "## Missing Arguments")
+	assert.Contains(t, rendered, "schemabot rollback <apply-id> -e <environment>")
+	assert.Contains(t, rendered, "both an apply ID and the `-e` flag")
+}
+
+func TestRenderRollbackMissingEnv(t *testing.T) {
+	rendered := RenderRollbackMissingEnv()
+	assert.Contains(t, rendered, "## Missing Environment")
+	assert.Contains(t, rendered, "schemabot rollback <apply-id> -e <environment>")
+	assert.Contains(t, rendered, "The `-e` flag is required")
+	assert.NotContains(t, rendered, "both an apply ID",
+		"missing-env variant should not say both args are missing")
+}
+
+func TestRenderUnsupportedAutoConfirm(t *testing.T) {
+	rendered := RenderUnsupportedAutoConfirm("plan")
+	assert.Equal(t, "The `-y` flag is not supported for `plan`.", rendered)
+}
+
+func TestRenderCommandNotYetAvailable(t *testing.T) {
+	rendered := RenderCommandNotYetAvailable("stop", "staging")
+	assert.Contains(t, rendered, "`stop` command is not yet available")
+	assert.Contains(t, rendered, "Use the CLI instead")
+	assert.Contains(t, rendered, "schemabot stop -e staging")
+}

--- a/pkg/webhook/templates/rollback.go
+++ b/pkg/webhook/templates/rollback.go
@@ -78,3 +78,77 @@ func RenderRollbackConfirmNoLock(database, environment string) string {
 		"No rollback lock is held. Run `schemabot rollback <apply-id> -e %s` first to generate a rollback plan.",
 		database, environment, environment)
 }
+
+// RenderRollbackMissingApplyID renders the message posted when `schemabot rollback`
+// is invoked without an apply ID argument.
+func RenderRollbackMissingApplyID() string {
+	return "## Missing Apply ID\n\n" +
+		"Usage: `schemabot rollback <apply-id> -e <environment>`\n\n" +
+		"You can find the apply ID in the summary comment of a completed apply, " +
+		"or by running `schemabot status`."
+}
+
+// RenderRollbackApplyNotFound renders the message posted when the supplied apply ID
+// does not match any stored apply.
+func RenderRollbackApplyNotFound(applyID string) string {
+	return fmt.Sprintf("## Apply Not Found\n\n"+
+		"No apply found with ID `%s`. Check the ID and try again.", applyID)
+}
+
+// RenderRollbackBlockedByLock renders the message posted when a rollback cannot
+// acquire the database lock because another caller holds it. When lockRepo and
+// lockPR are populated, the holder is rendered as a PR link; otherwise the bare
+// owner string is shown.
+func RenderRollbackBlockedByLock(database, environment, lockOwner, lockRepo string, lockPR int) string {
+	if lockPR > 0 && lockRepo != "" {
+		return fmt.Sprintf("## Rollback Blocked\n\n"+
+			"**Database**: `%s` | **Environment**: `%s`\n\n"+
+			"A lock is currently held by [%s#%d](https://github.com/%s/pull/%d).\n\n"+
+			"Wait for that operation to complete, or ask the lock owner to run `schemabot unlock`.",
+			database, environment,
+			lockRepo, lockPR,
+			lockRepo, lockPR)
+	}
+	return fmt.Sprintf("## Rollback Blocked\n\n"+
+		"**Database**: `%s` | **Environment**: `%s`\n\n"+
+		"A lock is currently held by `%s`.\n\n"+
+		"Wait for that operation to complete, or ask the lock owner to release it.",
+		database, environment, lockOwner)
+}
+
+// RenderRollbackNothingToDo renders the message posted when a rollback plan
+// produces no schema changes for the supplied apply ID.
+func RenderRollbackNothingToDo(database, environment, applyID string) string {
+	return fmt.Sprintf("## Nothing to Rollback\n\n"+
+		"**Database**: `%s` | **Environment**: `%s`\n\n"+
+		"The database schema already matches the state before apply `%s`. No rollback needed.",
+		database, environment, applyID)
+}
+
+// RenderRollbackLockNotOwned renders the message posted when rollback-confirm is
+// invoked against a lock held by a different caller.
+func RenderRollbackLockNotOwned(database, environment, lockOwner string) string {
+	return fmt.Sprintf("## Lock Not Owned\n\n"+
+		"**Database**: `%s` | **Environment**: `%s`\n\n"+
+		"The lock is held by `%s`, not this PR. Cannot confirm rollback.",
+		database, environment, lockOwner)
+}
+
+// RenderRollbackAlreadyRolledBack renders the message posted when rollback-confirm
+// re-plans and finds no changes remain — typically because the rollback already
+// ran in a separate path.
+func RenderRollbackAlreadyRolledBack(database, environment string) string {
+	return fmt.Sprintf("## Already Rolled Back\n\n"+
+		"**Database**: `%s` | **Environment**: `%s`\n\n"+
+		"The database schema already matches the original state. Lock released.",
+		database, environment)
+}
+
+// RenderRollbackNotAccepted renders the message posted when the apply service
+// rejects a rollback request (e.g. plan not found, validation error).
+func RenderRollbackNotAccepted(database, environment, errorMessage string) string {
+	return fmt.Sprintf("## Rollback Not Accepted\n\n"+
+		"**Database**: `%s` | **Environment**: `%s`\n\n"+
+		"The rollback was not accepted: %s",
+		database, environment, errorMessage)
+}

--- a/pkg/webhook/templates/rollback_test.go
+++ b/pkg/webhook/templates/rollback_test.go
@@ -1,6 +1,7 @@
 package templates
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -105,4 +106,98 @@ func TestRenderRollbackConfirmNoLock(t *testing.T) {
 	assert.Contains(t, rendered, "`testapp`")
 	assert.Contains(t, rendered, "`staging`")
 	assert.Contains(t, rendered, "schemabot rollback <apply-id> -e staging")
+}
+
+func TestRenderRollbackMissingApplyID(t *testing.T) {
+	rendered := RenderRollbackMissingApplyID()
+	assert.Contains(t, rendered, "## Missing Apply ID")
+	assert.Contains(t, rendered, "schemabot rollback <apply-id> -e <environment>")
+	assert.Contains(t, rendered, "schemabot status")
+}
+
+func TestRenderRollbackApplyNotFound(t *testing.T) {
+	rendered := RenderRollbackApplyNotFound("apply-abc123")
+	assert.Contains(t, rendered, "## Apply Not Found")
+	assert.Contains(t, rendered, "`apply-abc123`")
+	assert.Contains(t, rendered, "Check the ID and try again")
+}
+
+func TestRenderRollbackBlockedByLock(t *testing.T) {
+	t.Run("PR-owned lock renders as link", func(t *testing.T) {
+		rendered := RenderRollbackBlockedByLock("testapp", "staging", "block/myapp#42", "block/myapp", 42)
+
+		assert.Contains(t, rendered, "## Rollback Blocked")
+		assert.Contains(t, rendered, "`testapp`")
+		assert.Contains(t, rendered, "`staging`")
+		assert.Contains(t, rendered, "[block/myapp#42](https://github.com/block/myapp/pull/42)")
+		assert.Contains(t, rendered, "schemabot unlock")
+		assert.NotContains(t, rendered, "`block/myapp#42`",
+			"PR-link variant should not render the owner as a bare backticked string")
+	})
+
+	t.Run("non-PR lock renders bare owner", func(t *testing.T) {
+		rendered := RenderRollbackBlockedByLock("testapp", "staging", "cli:alice@laptop", "", 0)
+
+		assert.Contains(t, rendered, "## Rollback Blocked")
+		assert.Contains(t, rendered, "`cli:alice@laptop`")
+		assert.Contains(t, rendered, "ask the lock owner to release it")
+		assert.NotContains(t, rendered, "github.com",
+			"bare-owner variant should not include any github.com link")
+		assert.NotContains(t, rendered, "schemabot unlock",
+			"bare-owner variant should not suggest schemabot unlock")
+	})
+
+	t.Run("missing repo falls back to bare owner even with PR > 0", func(t *testing.T) {
+		rendered := RenderRollbackBlockedByLock("testapp", "staging", "stale-owner", "", 99)
+		assert.Contains(t, rendered, "`stale-owner`")
+		assert.NotContains(t, rendered, "github.com")
+	})
+}
+
+func TestRenderRollbackNothingToDo(t *testing.T) {
+	rendered := RenderRollbackNothingToDo("testapp", "staging", "apply-xyz")
+	assert.Contains(t, rendered, "## Nothing to Rollback")
+	assert.Contains(t, rendered, "`testapp`")
+	assert.Contains(t, rendered, "`staging`")
+	assert.Contains(t, rendered, "before apply `apply-xyz`")
+}
+
+func TestRenderRollbackLockNotOwned(t *testing.T) {
+	rendered := RenderRollbackLockNotOwned("testapp", "production", "block/other#7")
+	assert.Contains(t, rendered, "## Lock Not Owned")
+	assert.Contains(t, rendered, "`testapp`")
+	assert.Contains(t, rendered, "`production`")
+	assert.Contains(t, rendered, "held by `block/other#7`, not this PR")
+}
+
+func TestRenderRollbackAlreadyRolledBack(t *testing.T) {
+	rendered := RenderRollbackAlreadyRolledBack("testapp", "staging")
+	assert.Contains(t, rendered, "## Already Rolled Back")
+	assert.Contains(t, rendered, "`testapp`")
+	assert.Contains(t, rendered, "`staging`")
+	assert.Contains(t, rendered, "Lock released")
+}
+
+func TestRenderRollbackNotAccepted(t *testing.T) {
+	rendered := RenderRollbackNotAccepted("testapp", "staging", "plan not found")
+	assert.Contains(t, rendered, "## Rollback Not Accepted")
+	assert.Contains(t, rendered, "`testapp`")
+	assert.Contains(t, rendered, "`staging`")
+	assert.Contains(t, rendered, "plan not found")
+}
+
+func TestRollbackTemplates_NoStrayWhitespace(t *testing.T) {
+	for name, body := range map[string]string{
+		"MissingApplyID":     RenderRollbackMissingApplyID(),
+		"ApplyNotFound":      RenderRollbackApplyNotFound("a"),
+		"BlockedByLockPR":    RenderRollbackBlockedByLock("d", "e", "o", "r", 1),
+		"BlockedByLockOwner": RenderRollbackBlockedByLock("d", "e", "o", "", 0),
+		"NothingToDo":        RenderRollbackNothingToDo("d", "e", "a"),
+		"LockNotOwned":       RenderRollbackLockNotOwned("d", "e", "o"),
+		"AlreadyRolledBack":  RenderRollbackAlreadyRolledBack("d", "e"),
+		"NotAccepted":        RenderRollbackNotAccepted("d", "e", "x"),
+	} {
+		assert.False(t, strings.HasPrefix(body, " ") || strings.HasPrefix(body, "\n"),
+			"%s body should not start with whitespace", name)
+	}
 }


### PR DESCRIPTION
## What and Why ?
Completes the audit started in #94 by routing every inline `## …` comment body in `pkg/webhook/` through a `templates.Render…` helper. After this PR, the `templates` package owns all webhook PR comment markdown — direct `fmt.Sprintf` "## …" bodies in handler code are gone.

**`check_runs.go` (3 sites)** — new `RenderApplyBlockedByPriorEnvCheckError(priorEnv, reason, err)` next to the existing prior-env helpers. Byte-for-byte equivalent to the prior inline rendering; locked in with an equality assertion.

**`issue_comment.go` (5 sites)** — repository-not-registered, rollback missing-arguments / missing-environment, unsupported `-y`, and the "command not yet available" stub for Stop/Revert/SkipRevert/Cutover.

**`rollback.go` (8 sites)** — missing apply ID, apply not found, rollback blocked by lock (PR-link and bare-owner variants share one template), nothing to rollback, lock not owned, already rolled back, rollback not accepted.

Each new template has a unit test. `RenderRollbackBlockedByLock` covers PR-link, bare-owner, and missing-repo-fallback branches.
