### PR TITLE
fix(github): harden check ownership reconciliation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,6 +100,10 @@ The hook uses `--new-from-rev` to only flag issues introduced by the current bra
 - `_ = someFunc()` — never discard errors; check and propagate them
 - Background goroutines that cannot return errors to callers should transition to an error state (e.g., `dr.Error`) and return, not silently continue with partial results
 
+**Do not conflate causes in one branch.** Avoid guards like `if err != nil || value == nil` when the two cases have different meanings, severity, or log fields. Separate handling is always better for triage: operators should be able to tell whether storage failed, a row was missing, ownership changed, or an invariant was violated. This also avoids misleading logs such as `"error": nil`.
+
+**Name compound predicates.** When a conditional combines several checks, especially state-machine checks or 3+ boolean terms, consider extracting a small helper with a behavior-focused name. Keep error handling separate from state predicates so the caller can log or return the right cause, and the helper can read like the invariant being checked.
+
 **Wrap errors with context:** Always wrap errors with `fmt.Errorf("context: %w", err)` instead of returning bare `err`. The context should include *what was being done* and *key identifiers* — not just the method name. For example, `fmt.Errorf("proxy query %s: %w", query, err)` tells you which query failed, while `fmt.Errorf("exec query: %w", err)` just restates the function name. Include the data that will help someone debug the issue from the error message alone.
 
 **Info logging on critical paths:** Add `slog.Info` logging at key decision points and state transitions in critical-path code (server startup, request handling, background processors). Logs should include relevant identifiers (org, database, keyspace, branch) so operators can trace the flow. Don't log in hot loops or purely internal helpers — focus on boundaries and state changes.

--- a/pkg/api/telemetry_test.go
+++ b/pkg/api/telemetry_test.go
@@ -245,6 +245,36 @@ func TestRecordApplyMetrics(t *testing.T) {
 	assert.True(t, names["schemabot.apply.duration_seconds"], "expected schemabot.apply.duration_seconds")
 }
 
+func TestRecordCheckOwnershipMissMetric(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	prevMP := otel.GetMeterProvider()
+	otel.SetMeterProvider(mp)
+	t.Cleanup(func() {
+		otel.SetMeterProvider(prevMP)
+		require.NoError(t, mp.Shutdown(t.Context()))
+	})
+
+	metrics.RecordCheckOwnershipMiss(t.Context(), "complete_apply", "org/repo", "mydb", "mysql", "staging")
+	metrics.RecordCheckOwnershipMiss(t.Context(), "rollback_action_required", "org/repo", "mydb", "mysql", "staging")
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(t.Context(), &rm))
+
+	var found bool
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name == "schemabot.check_ownership_misses_total" {
+				found = true
+				sum, ok := m.Data.(metricdata.Sum[int64])
+				require.True(t, ok)
+				assert.Len(t, sum.DataPoints, 2, "expected one data point per operation")
+			}
+		}
+	}
+	assert.True(t, found, "schemabot.check_ownership_misses_total metric not found")
+}
+
 func TestRecordPlanDurationMetric(t *testing.T) {
 	reader := sdkmetric.NewManualReader()
 	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))

--- a/pkg/metrics/README.md
+++ b/pkg/metrics/README.md
@@ -11,6 +11,7 @@ SchemaBot exposes metrics via OpenTelemetry. All metrics are available at `GET /
 | `schemabot.applies.total` | Counter | database, environment, status | Total apply operations |
 | `schemabot.apply.duration_seconds` | Histogram | database, environment, status | Apply API call time |
 | `schemabot.active_applies` | UpDownCounter | database, environment | In-progress applies |
+| `schemabot.check_ownership_misses_total` | Counter | operation, repository, database, database_type, environment | Guarded check updates skipped because ownership changed |
 | `schemabot.webhook.events_total` | Counter | event_type, action, repository, status | GitHub webhook events |
 | `schemabot.control_operations_total` | Counter | operation, database, environment, status | Control operations (cutover, stop, start, etc.) |
 | `schemabot.lock_operations_total` | Counter | operation, database, status | Lock acquire/release operations |
@@ -21,6 +22,8 @@ SchemaBot exposes metrics via OpenTelemetry. All metrics are available at `GET /
 ### Attribute Values
 
 **status** (plans/applies): `success`, `error`, `rejected`
+
+**operation** (check ownership): `complete_apply`, `rollback_action_required`
 
 **operation** (control): `cutover`, `stop`, `start`, `volume`, `revert`, `skip_revert`, `rollback_plan`
 
@@ -35,6 +38,36 @@ SchemaBot exposes metrics via OpenTelemetry. All metrics are available at `GET /
 **action** (webhooks): `created`, `opened`, `synchronize`, `reopened`, `closed`, `requested`, `completed` (omitted for events without actions like `ping`)
 
 **status** (webhooks): `processed`, `invalid_signature`, `ignored`
+
+### Check Ownership Misses
+
+`schemabot.check_ownership_misses_total` should normally be near zero. A spike
+means an apply or rollback worker reached a terminal path after the stored check
+state had already moved to a different owner, usually because a new commit,
+newer apply, rollback, pod restart, or recovery path raced with the older worker.
+The guarded update prevented the stale worker from overwriting current merge-gate
+state, so the metric is a near-miss signal rather than proof that check state was
+corrupted.
+
+A spike is still dangerous because the live database can keep changing after the
+PR's desired schema has moved on. For example, an apply can start for commit A,
+an agent can push commit B that removes the schema change, and commit A's apply
+can still reach the database. The guard prevents the old apply worker from
+marking the current check successful, but it does not undo live-schema drift.
+
+Operator response:
+
+1. Group by `repository`, `environment`, `database_type`, `database`, and
+   `operation` to identify whether the spike is isolated or global.
+2. For an isolated PR/database, inspect the PR timeline for new commits while an
+   apply was running, then compare the current PR head, stored check state, and
+   active apply state before allowing merge.
+3. For a global spike, check recent deploys, pod restarts, recovery activity, and
+   webhook redeliveries. A broad spike can indicate duplicate workers or a
+   service-level race, not just user commit churn.
+4. If the live schema may now differ from the PR's current declarative schema,
+   re-plan the current head and decide whether to apply again, roll back, or
+   hold the PR until drift is resolved.
 
 ## HTTP Server Metrics
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -100,6 +100,40 @@ func RecordApplyDuration(ctx context.Context, duration time.Duration, database, 
 	)
 }
 
+// knownCheckOwnershipOperations limits metric cardinality to expected check
+// ownership miss paths.
+var knownCheckOwnershipOperations = map[string]bool{
+	"complete_apply":           true,
+	"rollback_action_required": true,
+}
+
+// RecordCheckOwnershipMiss increments the counter for guarded check updates
+// that did not apply because stored check state no longer belonged to the
+// apply being completed.
+func RecordCheckOwnershipMiss(ctx context.Context, operation, repository, database, databaseType, environment string) {
+	if !knownCheckOwnershipOperations[operation] {
+		operation = "unknown"
+	}
+	meter := otel.Meter(meterName)
+	counter, err := meter.Int64Counter("schemabot.check_ownership_misses_total",
+		otelmetric.WithDescription("Total stored check state ownership misses"),
+		otelmetric.WithUnit("{miss}"),
+	)
+	if err != nil {
+		slog.Warn("failed to create check ownership miss counter", "error", err)
+		return
+	}
+	counter.Add(ctx, 1,
+		otelmetric.WithAttributes(
+			attribute.String("operation", operation),
+			attribute.String("repository", repository),
+			attribute.String("database", database),
+			attribute.String("database_type", databaseType),
+			attribute.String("environment", environment),
+		),
+	)
+}
+
 // AdjustActiveApplies increments or decrements the active applies gauge.
 // Use delta=1 when an apply is accepted and delta=-1 when it reaches a terminal state.
 func AdjustActiveApplies(ctx context.Context, delta int64, database, environment string) {

--- a/pkg/schema/mysql/checks.sql
+++ b/pkg/schema/mysql/checks.sql
@@ -7,6 +7,7 @@ CREATE TABLE `checks` (
   `database_type` varchar(50) NOT NULL,
   `database_name` varchar(255) NOT NULL,
   `check_run_id` bigint DEFAULT NULL,
+  `apply_id` bigint unsigned DEFAULT NULL,
   `has_changes` tinyint(1) NOT NULL DEFAULT '1',
   `status` varchar(255) NOT NULL,
   `conclusion` varchar(255) DEFAULT NULL,
@@ -17,5 +18,6 @@ CREATE TABLE `checks` (
   UNIQUE KEY `idx_check_key` (`repository`,`pull_request`,`environment`,`database_type`,`database_name`),
   KEY `idx_repo_env_db` (`repository`,`environment`,`database_type`,`database_name`),
   KEY `idx_repo_pr` (`repository`,`pull_request`),
-  KEY `idx_check_run` (`check_run_id`)
+  KEY `idx_check_run` (`check_run_id`),
+  KEY `idx_apply_id` (`apply_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci

--- a/pkg/storage/mysqlstore/checks.go
+++ b/pkg/storage/mysqlstore/checks.go
@@ -1,5 +1,4 @@
-// checks.go implements CheckStore for GitHub status check tracking.
-// One check per (PR, environment, database) combination.
+// checks.go implements CheckStore for SchemaBot's stored check state.
 package mysqlstore
 
 import (
@@ -8,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/block/schemabot/pkg/state"
 	"github.com/block/schemabot/pkg/storage"
 	"github.com/block/spirit/pkg/utils"
 )
@@ -15,17 +15,51 @@ import (
 // checkColumns lists all columns for SELECT queries.
 const checkColumns = `id, repository, pull_request, head_sha,
 	environment, database_type, database_name,
-	check_run_id, has_changes, status, conclusion,
+	check_run_id, apply_id, has_changes, status, conclusion,
 	error_message, created_at, updated_at`
+
+const checkStatusInProgress = "in_progress"
 
 // checkStore implements storage.CheckStore using MySQL.
 type checkStore struct {
 	db *sql.DB
 }
 
-// Upsert creates or updates a check record.
+// Upsert creates or updates stored check state.
 func (s *checkStore) Upsert(ctx context.Context, check *storage.Check) error {
 	// Convert CheckRunID=0 to NULL (0 is Go's zero value, not a valid check run ID)
+	var checkRunID any
+	if check.CheckRunID != 0 {
+		checkRunID = check.CheckRunID
+	}
+	var applyID any
+	if check.ApplyID != 0 {
+		applyID = check.ApplyID
+	}
+
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO checks (
+			repository, pull_request, head_sha,
+			environment, database_type, database_name,
+			check_run_id, apply_id, has_changes, status, conclusion, error_message
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON DUPLICATE KEY UPDATE
+			head_sha = VALUES(head_sha),
+			check_run_id = VALUES(check_run_id),
+			apply_id = VALUES(apply_id),
+			has_changes = VALUES(has_changes),
+			status = VALUES(status),
+			conclusion = VALUES(conclusion),
+			error_message = VALUES(error_message)
+	`, check.Repository, check.PullRequest, check.HeadSHA,
+		check.Environment, check.DatabaseType, check.DatabaseName,
+		checkRunID, applyID, check.HasChanges, check.Status, check.Conclusion, check.ErrorMessage)
+	return err
+}
+
+// UpsertPlanResult stores plan-derived check state without overwriting
+// in-progress apply state for the same PR/environment/database/head SHA.
+func (s *checkStore) UpsertPlanResult(ctx context.Context, check *storage.Check) error {
 	var checkRunID any
 	if check.CheckRunID != 0 {
 		checkRunID = check.CheckRunID
@@ -35,19 +69,132 @@ func (s *checkStore) Upsert(ctx context.Context, check *storage.Check) error {
 		INSERT INTO checks (
 			repository, pull_request, head_sha,
 			environment, database_type, database_name,
-			check_run_id, has_changes, status, conclusion, error_message
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-		ON DUPLICATE KEY UPDATE
-			head_sha = VALUES(head_sha),
-			check_run_id = VALUES(check_run_id),
-			has_changes = VALUES(has_changes),
-			status = VALUES(status),
-			conclusion = VALUES(conclusion),
-			error_message = VALUES(error_message)
+			check_run_id, apply_id, has_changes, status, conclusion, error_message
+		) VALUES (?, ?, ?, ?, ?, ?, ?, NULL, ?, ?, ?, ?)
 	`, check.Repository, check.PullRequest, check.HeadSHA,
 		check.Environment, check.DatabaseType, check.DatabaseName,
 		checkRunID, check.HasChanges, check.Status, check.Conclusion, check.ErrorMessage)
+	// Fast path: no existing check state for this PR/environment/database, so the
+	// insert is the complete write. Any non-duplicate error is a real storage
+	// failure; duplicate key means the row exists and needs the guarded update
+	// below.
+	if err == nil {
+		return nil
+	}
+	if !isDuplicateKeyError(err) {
+		return err
+	}
+
+	// Preserve same-head in-progress apply-owned state. A plan result for that
+	// same PR head is stale relative to the apply that already started.
+	_, err = s.db.ExecContext(ctx, `
+		UPDATE checks
+		SET head_sha = ?,
+		    check_run_id = ?,
+		    apply_id = NULL,
+		    has_changes = ?,
+		    status = ?,
+		    conclusion = ?,
+		    error_message = ?
+		WHERE repository = ? AND pull_request = ?
+		  AND environment = ? AND database_type = ? AND database_name = ?
+		  AND NOT (status = ? AND head_sha = ? AND apply_id IS NOT NULL)
+	`, check.HeadSHA, checkRunID, check.HasChanges, check.Status, check.Conclusion, check.ErrorMessage,
+		check.Repository, check.PullRequest, check.Environment, check.DatabaseType, check.DatabaseName,
+		checkStatusInProgress, check.HeadSHA)
 	return err
+}
+
+// CompleteForApply updates stored check state to a terminal state only if it
+// still belongs to the apply being completed.
+func (s *checkStore) CompleteForApply(ctx context.Context, check *storage.Check, apply *storage.Apply) (bool, error) {
+	var checkRunID any
+	if check.CheckRunID != 0 {
+		checkRunID = check.CheckRunID
+	}
+
+	result, err := s.db.ExecContext(ctx, `
+		UPDATE checks
+		SET head_sha = ?,
+		    check_run_id = ?,
+		    apply_id = ?,
+		    has_changes = ?,
+		    status = ?,
+		    conclusion = ?,
+		    error_message = ?
+		WHERE repository = ? AND pull_request = ?
+		  AND environment = ? AND database_type = ? AND database_name = ?
+		  AND status = ?
+		  AND apply_id = ?
+		  AND NOT EXISTS (
+		    SELECT 1
+		    FROM applies newer
+		    WHERE newer.repository = checks.repository
+		      AND newer.pull_request = checks.pull_request
+		      AND newer.environment = checks.environment
+		      AND newer.database_type = checks.database_type
+		      AND newer.database_name = checks.database_name
+		      AND newer.id > ?
+		      AND newer.state NOT IN (?, ?, ?, ?, ?)
+		  )
+	`, check.HeadSHA, checkRunID, apply.ID, check.HasChanges, check.Status, check.Conclusion, check.ErrorMessage,
+		check.Repository, check.PullRequest, check.Environment, check.DatabaseType, check.DatabaseName,
+		checkStatusInProgress, apply.ID,
+		apply.ID, state.Apply.Completed, state.Apply.Failed, state.Apply.Stopped, state.Apply.Cancelled, state.Apply.Reverted)
+	if err != nil {
+		return false, err
+	}
+
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	return rows > 0, nil
+}
+
+// MarkActionRequiredForApply marks stored check state action_required after a
+// rollback only if it still belongs to that rollback apply.
+func (s *checkStore) MarkActionRequiredForApply(ctx context.Context, check *storage.Check, apply *storage.Apply) (bool, error) {
+	var checkRunID any
+	if check.CheckRunID != 0 {
+		checkRunID = check.CheckRunID
+	}
+
+	result, err := s.db.ExecContext(ctx, `
+		UPDATE checks
+		SET head_sha = ?,
+		    check_run_id = ?,
+		    apply_id = NULL,
+		    has_changes = ?,
+		    status = ?,
+		    conclusion = ?,
+		    error_message = ?
+		WHERE repository = ? AND pull_request = ?
+		  AND environment = ? AND database_type = ? AND database_name = ?
+		  AND apply_id = ?
+		  AND NOT EXISTS (
+		    SELECT 1
+		    FROM applies newer
+		    WHERE newer.repository = checks.repository
+		      AND newer.pull_request = checks.pull_request
+		      AND newer.environment = checks.environment
+		      AND newer.database_type = checks.database_type
+		      AND newer.database_name = checks.database_name
+		      AND newer.id > ?
+		      AND newer.state NOT IN (?, ?, ?, ?, ?)
+		  )
+	`, check.HeadSHA, checkRunID, check.HasChanges, check.Status, check.Conclusion, check.ErrorMessage,
+		check.Repository, check.PullRequest, check.Environment, check.DatabaseType, check.DatabaseName,
+		apply.ID, apply.ID, state.Apply.Completed, state.Apply.Failed, state.Apply.Stopped, state.Apply.Cancelled, state.Apply.Reverted)
+	if err != nil {
+		return false, err
+	}
+
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	return rows > 0, nil
 }
 
 // Get returns a check by its unique key (PR + env + database), or nil if not found.
@@ -107,7 +254,7 @@ func (s *checkStore) GetByDatabase(ctx context.Context, repo, environment, dbTyp
 	return scanChecks(rows)
 }
 
-// Delete removes a check record by ID.
+// Delete removes stored check state by ID.
 func (s *checkStore) Delete(ctx context.Context, id int64) error {
 	result, err := s.db.ExecContext(ctx, `DELETE FROM checks WHERE id = ?`, id)
 	if err != nil {
@@ -117,7 +264,7 @@ func (s *checkStore) Delete(ctx context.Context, id int64) error {
 	return checkRowsAffected(result, storage.ErrCheckNotFound)
 }
 
-// DeleteByPR removes all check records for a PR.
+// DeleteByPR removes all stored check state for a PR.
 func (s *checkStore) DeleteByPR(ctx context.Context, repo string, pr int) error {
 	_, err := s.db.ExecContext(ctx, `DELETE FROM checks WHERE repository = ? AND pull_request = ?`, repo, pr)
 	return err
@@ -148,13 +295,13 @@ func scanChecks(rows *sql.Rows) ([]*storage.Check, error) {
 // scanCheckInto scans check data from any scanner (Row or Rows).
 func scanCheckInto(s scanner) (*storage.Check, error) {
 	var check storage.Check
-	var checkRunID sql.NullInt64
+	var checkRunID, applyID sql.NullInt64
 	var conclusion, errorMessage sql.NullString
 
 	err := s.Scan(
 		&check.ID, &check.Repository, &check.PullRequest, &check.HeadSHA,
 		&check.Environment, &check.DatabaseType, &check.DatabaseName,
-		&checkRunID, &check.HasChanges, &check.Status, &conclusion,
+		&checkRunID, &applyID, &check.HasChanges, &check.Status, &conclusion,
 		&errorMessage, &check.CreatedAt, &check.UpdatedAt,
 	)
 	if err != nil {
@@ -163,6 +310,9 @@ func scanCheckInto(s scanner) (*storage.Check, error) {
 
 	if checkRunID.Valid {
 		check.CheckRunID = checkRunID.Int64
+	}
+	if applyID.Valid {
+		check.ApplyID = applyID.Int64
 	}
 	if conclusion.Valid {
 		check.Conclusion = conclusion.String

--- a/pkg/storage/mysqlstore/checks_test.go
+++ b/pkg/storage/mysqlstore/checks_test.go
@@ -9,6 +9,7 @@ import (
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/stretchr/testify/require"
 
+	"github.com/block/schemabot/pkg/state"
 	"github.com/block/schemabot/pkg/storage"
 )
 
@@ -290,4 +291,396 @@ func TestCheckStore_CheckRunIDZeroIsNull(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, retrieved)
 	require.Equal(t, int64(0), retrieved.CheckRunID)
+}
+
+func TestCheckStore_ApplyIDRoundTrip(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	check := &storage.Check{
+		Repository:   "org/repo",
+		PullRequest:  123,
+		HeadSHA:      "abc123",
+		Environment:  "staging",
+		DatabaseType: "vitess",
+		DatabaseName: "testdb",
+		ApplyID:      42,
+		HasChanges:   true,
+		Status:       "in_progress",
+	}
+
+	require.NoError(t, store.Checks().Upsert(ctx, check))
+
+	retrieved, err := store.Checks().Get(ctx, "org/repo", 123, "staging", "vitess", "testdb")
+	require.NoError(t, err)
+	require.NotNil(t, retrieved)
+	require.Equal(t, int64(42), retrieved.ApplyID)
+
+	check.ApplyID = 0
+	require.NoError(t, store.Checks().Upsert(ctx, check))
+
+	retrieved, err = store.Checks().Get(ctx, "org/repo", 123, "staging", "vitess", "testdb")
+	require.NoError(t, err)
+	require.NotNil(t, retrieved)
+	require.Equal(t, int64(0), retrieved.ApplyID)
+}
+
+func TestCheckStore_UpsertPlanResultPreservesInProgressApply(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	apply := createCheckStoreApply(t, store, "apply-running", state.Apply.Running)
+	require.NoError(t, store.Checks().Upsert(ctx, &storage.Check{
+		Repository:   "org/repo",
+		PullRequest:  123,
+		HeadSHA:      "same-sha",
+		Environment:  "staging",
+		DatabaseType: "mysql",
+		DatabaseName: "testdb",
+		ApplyID:      apply.ID,
+		HasChanges:   true,
+		Status:       "in_progress",
+		Conclusion:   "",
+	}))
+
+	require.NoError(t, store.Checks().UpsertPlanResult(ctx, &storage.Check{
+		Repository:   "org/repo",
+		PullRequest:  123,
+		HeadSHA:      "same-sha",
+		Environment:  "staging",
+		DatabaseType: "mysql",
+		DatabaseName: "testdb",
+		HasChanges:   true,
+		Status:       "completed",
+		Conclusion:   "action_required",
+	}))
+
+	retrieved, err := store.Checks().Get(ctx, "org/repo", 123, "staging", "mysql", "testdb")
+	require.NoError(t, err)
+	require.NotNil(t, retrieved)
+	require.Equal(t, "same-sha", retrieved.HeadSHA)
+	require.Equal(t, "in_progress", retrieved.Status)
+	require.Empty(t, retrieved.Conclusion)
+	require.Equal(t, apply.ID, retrieved.ApplyID)
+}
+
+func TestCheckStore_UpsertPlanResultReplacesUnownedInProgressCheck(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	require.NoError(t, store.Checks().Upsert(ctx, &storage.Check{
+		Repository:   "org/repo",
+		PullRequest:  123,
+		HeadSHA:      "same-sha",
+		Environment:  "staging",
+		DatabaseType: "mysql",
+		DatabaseName: "testdb",
+		HasChanges:   true,
+		Status:       "in_progress",
+		Conclusion:   "",
+	}))
+
+	require.NoError(t, store.Checks().UpsertPlanResult(ctx, &storage.Check{
+		Repository:   "org/repo",
+		PullRequest:  123,
+		HeadSHA:      "same-sha",
+		Environment:  "staging",
+		DatabaseType: "mysql",
+		DatabaseName: "testdb",
+		HasChanges:   true,
+		Status:       "completed",
+		Conclusion:   "action_required",
+	}))
+
+	retrieved, err := store.Checks().Get(ctx, "org/repo", 123, "staging", "mysql", "testdb")
+	require.NoError(t, err)
+	require.NotNil(t, retrieved)
+	require.Equal(t, "same-sha", retrieved.HeadSHA)
+	require.Equal(t, "completed", retrieved.Status)
+	require.Equal(t, "action_required", retrieved.Conclusion)
+	require.Equal(t, int64(0), retrieved.ApplyID)
+}
+
+func TestCheckStore_UpsertPlanResultReplacesInProgressApplyOnNewHead(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	apply := createCheckStoreApply(t, store, "apply-running-old-head", state.Apply.Running)
+	require.NoError(t, store.Checks().Upsert(ctx, &storage.Check{
+		Repository:   "org/repo",
+		PullRequest:  123,
+		HeadSHA:      "oldsha",
+		Environment:  "staging",
+		DatabaseType: "mysql",
+		DatabaseName: "testdb",
+		ApplyID:      apply.ID,
+		HasChanges:   true,
+		Status:       "in_progress",
+		Conclusion:   "",
+	}))
+
+	require.NoError(t, store.Checks().UpsertPlanResult(ctx, &storage.Check{
+		Repository:   "org/repo",
+		PullRequest:  123,
+		HeadSHA:      "newsha",
+		Environment:  "staging",
+		DatabaseType: "mysql",
+		DatabaseName: "testdb",
+		HasChanges:   true,
+		Status:       "completed",
+		Conclusion:   "action_required",
+	}))
+
+	retrieved, err := store.Checks().Get(ctx, "org/repo", 123, "staging", "mysql", "testdb")
+	require.NoError(t, err)
+	require.NotNil(t, retrieved)
+	require.Equal(t, "newsha", retrieved.HeadSHA)
+	require.Equal(t, "completed", retrieved.Status)
+	require.Equal(t, "action_required", retrieved.Conclusion)
+	require.Equal(t, int64(0), retrieved.ApplyID)
+}
+
+func TestCheckStore_UpsertPlanResultClearsApplyIDWhenNotInProgress(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	apply := createCheckStoreApply(t, store, "apply-completed-plan", state.Apply.Completed)
+	require.NoError(t, store.Checks().Upsert(ctx, &storage.Check{
+		Repository:   "org/repo",
+		PullRequest:  123,
+		HeadSHA:      "oldsha",
+		Environment:  "staging",
+		DatabaseType: "mysql",
+		DatabaseName: "testdb",
+		ApplyID:      apply.ID,
+		HasChanges:   false,
+		Status:       "completed",
+		Conclusion:   "success",
+	}))
+
+	require.NoError(t, store.Checks().UpsertPlanResult(ctx, &storage.Check{
+		Repository:   "org/repo",
+		PullRequest:  123,
+		HeadSHA:      "newsha",
+		Environment:  "staging",
+		DatabaseType: "mysql",
+		DatabaseName: "testdb",
+		HasChanges:   true,
+		Status:       "completed",
+		Conclusion:   "action_required",
+	}))
+
+	retrieved, err := store.Checks().Get(ctx, "org/repo", 123, "staging", "mysql", "testdb")
+	require.NoError(t, err)
+	require.NotNil(t, retrieved)
+	require.Equal(t, "newsha", retrieved.HeadSHA)
+	require.Equal(t, "completed", retrieved.Status)
+	require.Equal(t, "action_required", retrieved.Conclusion)
+	require.Equal(t, int64(0), retrieved.ApplyID)
+}
+
+func TestCheckStore_CompleteForApply(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	apply := createCheckStoreApply(t, store, "apply-complete", state.Apply.Completed)
+
+	check := &storage.Check{
+		Repository:   "org/repo",
+		PullRequest:  123,
+		HeadSHA:      "abc123",
+		Environment:  "staging",
+		DatabaseType: "mysql",
+		DatabaseName: "testdb",
+		ApplyID:      apply.ID,
+		HasChanges:   true,
+		Status:       "in_progress",
+	}
+	require.NoError(t, store.Checks().Upsert(ctx, check))
+
+	check.Status = "completed"
+	check.Conclusion = "success"
+	check.HasChanges = false
+	updated, err := store.Checks().CompleteForApply(ctx, check, apply)
+	require.NoError(t, err)
+	require.True(t, updated)
+
+	retrieved, err := store.Checks().Get(ctx, "org/repo", 123, "staging", "mysql", "testdb")
+	require.NoError(t, err)
+	require.NotNil(t, retrieved)
+	require.Equal(t, "completed", retrieved.Status)
+	require.Equal(t, "success", retrieved.Conclusion)
+	require.Equal(t, apply.ID, retrieved.ApplyID)
+}
+
+func TestCheckStore_CompleteForApplySkipsNewerRunningApply(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	oldApply := createCheckStoreApply(t, store, "apply-old", state.Apply.Completed)
+	newApply := createCheckStoreApply(t, store, "apply-new", state.Apply.Running)
+	require.Greater(t, newApply.ID, oldApply.ID)
+
+	check := &storage.Check{
+		Repository:   "org/repo",
+		PullRequest:  123,
+		HeadSHA:      "abc123",
+		Environment:  "staging",
+		DatabaseType: "mysql",
+		DatabaseName: "testdb",
+		ApplyID:      oldApply.ID,
+		HasChanges:   true,
+		Status:       "in_progress",
+	}
+	require.NoError(t, store.Checks().Upsert(ctx, check))
+
+	check.Status = "completed"
+	check.Conclusion = "success"
+	check.HasChanges = false
+	updated, err := store.Checks().CompleteForApply(ctx, check, oldApply)
+	require.NoError(t, err)
+	require.False(t, updated)
+
+	retrieved, err := store.Checks().Get(ctx, "org/repo", 123, "staging", "mysql", "testdb")
+	require.NoError(t, err)
+	require.NotNil(t, retrieved)
+	require.Equal(t, "in_progress", retrieved.Status)
+	require.Empty(t, retrieved.Conclusion)
+	require.Equal(t, oldApply.ID, retrieved.ApplyID)
+}
+
+func TestCheckStore_CompleteForApplySkipsUnownedCheck(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	apply := createCheckStoreApply(t, store, "apply-unowned", state.Apply.Completed)
+
+	check := &storage.Check{
+		Repository:   "org/repo",
+		PullRequest:  123,
+		HeadSHA:      "abc123",
+		Environment:  "staging",
+		DatabaseType: "mysql",
+		DatabaseName: "testdb",
+		HasChanges:   true,
+		Status:       "in_progress",
+	}
+	require.NoError(t, store.Checks().Upsert(ctx, check))
+
+	check.Status = "completed"
+	check.Conclusion = "success"
+	check.HasChanges = false
+	updated, err := store.Checks().CompleteForApply(ctx, check, apply)
+	require.NoError(t, err)
+	require.False(t, updated)
+
+	retrieved, err := store.Checks().Get(ctx, "org/repo", 123, "staging", "mysql", "testdb")
+	require.NoError(t, err)
+	require.NotNil(t, retrieved)
+	require.Equal(t, "in_progress", retrieved.Status)
+	require.Empty(t, retrieved.Conclusion)
+	require.Equal(t, int64(0), retrieved.ApplyID)
+}
+
+func TestCheckStore_MarkActionRequiredForApply(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	apply := createCheckStoreApply(t, store, "rollback-complete", state.Apply.Completed)
+
+	check := &storage.Check{
+		Repository:   "org/repo",
+		PullRequest:  123,
+		HeadSHA:      "abc123",
+		Environment:  "staging",
+		DatabaseType: "mysql",
+		DatabaseName: "testdb",
+		ApplyID:      apply.ID,
+		HasChanges:   false,
+		Status:       "completed",
+		Conclusion:   "success",
+	}
+	require.NoError(t, store.Checks().Upsert(ctx, check))
+
+	check.HasChanges = true
+	check.Conclusion = "action_required"
+	updated, err := store.Checks().MarkActionRequiredForApply(ctx, check, apply)
+	require.NoError(t, err)
+	require.True(t, updated)
+
+	retrieved, err := store.Checks().Get(ctx, "org/repo", 123, "staging", "mysql", "testdb")
+	require.NoError(t, err)
+	require.NotNil(t, retrieved)
+	require.Equal(t, "completed", retrieved.Status)
+	require.Equal(t, "action_required", retrieved.Conclusion)
+	require.True(t, retrieved.HasChanges)
+	require.Equal(t, int64(0), retrieved.ApplyID)
+}
+
+func TestCheckStore_MarkActionRequiredForApplySkipsNewerRunningApply(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	rollbackApply := createCheckStoreApply(t, store, "rollback-complete-old", state.Apply.Completed)
+	newApply := createCheckStoreApply(t, store, "apply-running-new", state.Apply.Running)
+	require.Greater(t, newApply.ID, rollbackApply.ID)
+
+	check := &storage.Check{
+		Repository:   "org/repo",
+		PullRequest:  123,
+		HeadSHA:      "abc123",
+		Environment:  "staging",
+		DatabaseType: "mysql",
+		DatabaseName: "testdb",
+		ApplyID:      rollbackApply.ID,
+		HasChanges:   false,
+		Status:       "completed",
+		Conclusion:   "success",
+	}
+	require.NoError(t, store.Checks().Upsert(ctx, check))
+
+	check.HasChanges = true
+	check.Conclusion = "action_required"
+	updated, err := store.Checks().MarkActionRequiredForApply(ctx, check, rollbackApply)
+	require.NoError(t, err)
+	require.False(t, updated)
+
+	retrieved, err := store.Checks().Get(ctx, "org/repo", 123, "staging", "mysql", "testdb")
+	require.NoError(t, err)
+	require.NotNil(t, retrieved)
+	require.Equal(t, "completed", retrieved.Status)
+	require.Equal(t, "success", retrieved.Conclusion)
+	require.False(t, retrieved.HasChanges)
+	require.Equal(t, rollbackApply.ID, retrieved.ApplyID)
+}
+
+func createCheckStoreApply(t *testing.T, store storage.Storage, applyIdentifier, applyState string) *storage.Apply {
+	t.Helper()
+	apply := &storage.Apply{
+		ApplyIdentifier: applyIdentifier,
+		Database:        "testdb",
+		DatabaseType:    "mysql",
+		Repository:      "org/repo",
+		PullRequest:     123,
+		Environment:     "staging",
+		Engine:          storage.EngineSpirit,
+		State:           applyState,
+	}
+	id, err := store.Applies().Create(t.Context(), apply)
+	require.NoError(t, err)
+
+	created, err := store.Applies().Get(t.Context(), id)
+	require.NoError(t, err)
+	require.NotNil(t, created)
+	return created
 }

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -72,31 +72,47 @@ type LockStore interface {
 	GetByPR(ctx context.Context, repo string, pr int) ([]*Lock, error)
 }
 
-// CheckStore manages GitHub status check state.
-// One check per (PR, environment, database) combination.
-// Check name format: "SchemaBot: {env}/{type}/{database}"
+// CheckStore manages SchemaBot's stored check state.
+// Per-database rows track internal status for a PR/environment/database.
+// Aggregate rows store the GitHub check_run_id for the visible GitHub Check Run.
 type CheckStore interface {
-	// Upsert creates or updates a check record.
+	// Upsert creates or updates stored check state.
 	Upsert(ctx context.Context, check *Check) error
 
-	// Get returns a check by its unique key (PR + env + database), or nil if not found.
+	// UpsertPlanResult creates or updates stored check state from a plan result,
+	// but preserves in-progress apply state for the same PR/environment/database/head SHA.
+	UpsertPlanResult(ctx context.Context, check *Check) error
+
+	// CompleteForApply updates stored check state to a terminal state only if
+	// it still belongs to the given apply and no newer non-terminal apply exists
+	// for the same PR/environment/database. Returns false when another worker
+	// changed the stored state first.
+	CompleteForApply(ctx context.Context, check *Check, apply *Apply) (bool, error)
+
+	// MarkActionRequiredForApply marks stored check state action_required after
+	// a rollback only if it still belongs to that rollback apply and no newer
+	// non-terminal apply exists for the same PR/environment/database. Returns
+	// false when another worker changed the stored state first.
+	MarkActionRequiredForApply(ctx context.Context, check *Check, apply *Apply) (bool, error)
+
+	// Get returns stored check state by its unique key (PR + env + database), or nil if not found.
 	Get(ctx context.Context, repo string, pr int, environment, dbType, database string) (*Check, error)
 
-	// GetByCheckRunID returns a check by GitHub's check run ID, or nil if not found.
+	// GetByCheckRunID returns stored check state by GitHub's check run ID, or nil if not found.
 	// Used for handling check_run webhooks from GitHub.
 	GetByCheckRunID(ctx context.Context, checkRunID int64) (*Check, error)
 
-	// GetByPR returns all checks for a PR (for PR cleanup on close).
+	// GetByPR returns all stored check state for a PR (for PR cleanup on close).
 	GetByPR(ctx context.Context, repo string, pr int) ([]*Check, error)
 
-	// GetByDatabase returns all checks for a database across all PRs.
+	// GetByDatabase returns all stored check state for a database across all PRs.
 	// Used for cross-PR coordination (blocking other PRs when one is applying).
 	GetByDatabase(ctx context.Context, repo, environment, dbType, database string) ([]*Check, error)
 
-	// Delete removes a check record by ID.
+	// Delete removes stored check state by ID.
 	Delete(ctx context.Context, id int64) error
 
-	// DeleteByPR removes all check records for a PR.
+	// DeleteByPR removes all stored check state for a PR.
 	// Used for cleanup when a PR is closed or merged.
 	DeleteByPR(ctx context.Context, repo string, pr int) error
 }

--- a/pkg/storage/types.go
+++ b/pkg/storage/types.go
@@ -40,9 +40,26 @@ type Lock struct {
 	UpdatedAt time.Time
 }
 
-// Check represents a GitHub status check record.
-// One check per (PR, environment, database) combination.
-// Check name format: "SchemaBot: {env}/{type}/{database}"
+// Check terminology:
+//   - GitHub Check Run: the external GitHub Checks API object visible on a PR.
+//   - Stored check state: a row in SchemaBot's checks table.
+//
+// Check represents stored check state. SchemaBot writes per-database stored
+// state when planning, starting an apply, completing an apply, reconciling stale
+// applies, or processing rollback completion. Those per-database rows do not
+// create per-database GitHub Check Runs; they are internal inputs to aggregate
+// calculation.
+//
+// SchemaBot stores this state because GitHub only owns the visible merge-gate
+// object, not SchemaBot's per-database workflow state. Durable stored state lets
+// SchemaBot recompute aggregates, survive restarts, reconcile stale applies,
+// enforce ordering rules, clean up on PR close, and answer internal safety
+// checks without treating the GitHub API as the source of truth.
+//
+// The aggregate check path reads the per-database stored state, creates or
+// updates the visible GitHub Check Run, then writes an aggregate stored state
+// row whose CheckRunID points at that GitHub object. Later GitHub check_run
+// webhooks use CheckRunID to find the matching stored state.
 type Check struct {
 	// ID is the unique identifier (BIGINT AUTO_INCREMENT).
 	ID int64
@@ -65,20 +82,25 @@ type Check struct {
 	// DatabaseName is the name of the database.
 	DatabaseName string
 
-	// CheckRunID is the GitHub Check Run ID used to update the check status via the GitHub API.
+	// CheckRunID is the GitHub Check Run ID used to update GitHub via the Checks API.
 	CheckRunID int64
+
+	// ApplyID is the storage apply ID this stored state currently represents.
+	// It is set while apply state is in_progress so terminal updates cannot
+	// overwrite a newer apply's stored check state.
+	ApplyID int64
 
 	// HasChanges indicates whether schema changes were detected.
 	HasChanges bool
 
-	// Status is the internal check status: "pending_apply", "applying", "completed", etc.
+	// Status is SchemaBot's stored status: "pending_apply", "applying", "completed", etc.
 	Status string
 
 	// Conclusion is the GitHub Check Run conclusion set when the check completes.
 	// Values: "success", "failure", "action_required", "neutral", "cancelled", "skipped".
 	Conclusion string
 
-	// ErrorMessage contains a human-readable explanation when the check fails.
+	// ErrorMessage contains a human-readable explanation when the check state fails.
 	// Displayed in the GitHub Check Run details and PR comment.
 	ErrorMessage string
 

--- a/pkg/webhook/apply.go
+++ b/pkg/webhook/apply.go
@@ -102,7 +102,18 @@ func (h *Handler) watchApplyProgress(ctx context.Context, repo string, pr int, i
 			h.postAndTrackComment(ctx, repo, pr, installationID, applyID, state.Comment.Summary, summaryBody)
 
 			// Update the GitHub check run to reflect the terminal state
-			h.updateCheckRecordForApplyResult(ctx, repo, pr, current)
+			updated, err := h.updateCheckRecordForApplyResult(ctx, repo, pr, current)
+			if err != nil {
+				h.logger.Error("failed to update stored check state after apply", "repo", repo, "pr", pr, "apply_id", applyID, "error", err)
+				return
+			}
+			if !updated {
+				h.logger.Debug("skipping aggregate check update because apply no longer owns stored check state",
+					"repo", repo, "pr", pr, "database", current.Database,
+					"database_type", current.DatabaseType, "environment", current.Environment,
+					"apply_id", applyID, "apply_identifier", current.ApplyIdentifier)
+				return
+			}
 			if aggClient, err := h.ghClient.ForInstallation(installationID); err == nil {
 				// Look up the head SHA from the check record
 				if checkRecord, err := h.service.Storage().Checks().Get(ctx, repo, pr, current.Environment, current.DatabaseType, current.Database); err == nil && checkRecord != nil {

--- a/pkg/webhook/apply_handlers.go
+++ b/pkg/webhook/apply_handlers.go
@@ -26,6 +26,19 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 		return
 	}
 
+	// Fix checks stuck at "in_progress" from crashed applies
+	if err := h.reconcileStaleChecks(ctx, client, repo, pr); err != nil {
+		h.logger.Error("failed to reconcile stale status checks", "repo", repo, "pr", pr, "error", err)
+		h.postComment(repo, pr, installationID, templates.RenderGenericError(templates.SchemaErrorData{
+			RequestedBy: requestedBy,
+			Timestamp:   time.Now().UTC().Format("2006-01-02 15:04:05"),
+			Environment: environment,
+			CommandName: action.Apply,
+			ErrorDetail: "Failed to reconcile stale status checks: " + err.Error(),
+		}))
+		return
+	}
+
 	// Discover config and fetch schema files from PR
 	schemaResult, err := client.CreateSchemaRequestFromPR(ctx, repo, pr, environment, databaseName)
 	if err != nil {
@@ -457,26 +470,47 @@ func (h *Handler) executeApply(
 		return
 	}
 
-	// Update check run to in-progress (transitions action_required → in_progress)
-	h.updateCheckRecordForApplyStart(ctx, client, repo, pr, schemaResult, environment)
-
 	if applyID <= 0 {
+		h.logger.Error("apply accepted without stored apply id", "repo", repo, "pr", pr, "database", database, "environment", environment)
 		return
 	}
 
 	apply, err := h.service.Storage().Applies().Get(ctx, applyID)
-	if err != nil || apply == nil {
-		h.logger.Error("failed to load apply for progress watch", "applyID", applyID, "error", err)
+	if err != nil {
+		h.logger.Error("failed to load apply for progress watch",
+			"repo", repo, "pr", pr, "database", database,
+			"database_type", schemaResult.Type, "environment", environment,
+			"apply_id", applyID, "error", err)
 		return
 	}
+	if apply == nil {
+		h.logger.Error("apply missing after accepted apply",
+			"repo", repo, "pr", pr, "database", database,
+			"database_type", schemaResult.Type, "environment", environment,
+			"apply_id", applyID)
+		return
+	}
+
+	// Update check run to in-progress (transitions action_required → in_progress)
+	h.updateCheckRecordForApplyStart(ctx, client, repo, pr, schemaResult, environment, applyID)
 
 	// Wait briefly for fast results (instant DDL, immediate failures)
 	// before deciding whether to go async.
 	time.Sleep(2 * time.Second)
 
 	apply, err = h.service.Storage().Applies().Get(ctx, applyID)
-	if err != nil || apply == nil {
-		h.logger.Error("failed to reload apply after wait", "applyID", applyID, "error", err)
+	if err != nil {
+		h.logger.Error("failed to reload apply after wait",
+			"repo", repo, "pr", pr, "database", database,
+			"database_type", schemaResult.Type, "environment", environment,
+			"apply_id", applyID, "error", err)
+		return
+	}
+	if apply == nil {
+		h.logger.Error("apply missing after wait",
+			"repo", repo, "pr", pr, "database", database,
+			"database_type", schemaResult.Type, "environment", environment,
+			"apply_id", applyID)
 		return
 	}
 
@@ -485,7 +519,18 @@ func (h *Handler) executeApply(
 		tasks, _ := h.service.Storage().Tasks().GetByApplyID(ctx, applyID)
 		summaryBody := formatSummaryComment(apply, tasks)
 		h.postComment(repo, pr, installationID, summaryBody)
-		h.updateCheckRecordForApplyResult(ctx, repo, pr, apply)
+		updated, err := h.updateCheckRecordForApplyResult(ctx, repo, pr, apply)
+		if err != nil {
+			h.logger.Error("failed to update stored check state after apply", "repo", repo, "pr", pr, "apply_id", applyID, "error", err)
+			return
+		}
+		if !updated {
+			h.logger.Debug("skipping aggregate check update because apply no longer owns stored check state",
+				"repo", repo, "pr", pr, "database", apply.Database,
+				"database_type", apply.DatabaseType, "environment", apply.Environment,
+				"apply_id", applyID, "apply_identifier", apply.ApplyIdentifier)
+			return
+		}
 		if checkRecord, err := h.service.Storage().Checks().Get(ctx, repo, pr, apply.Environment, apply.DatabaseType, apply.Database); err == nil && checkRecord != nil {
 			h.updateAggregateCheck(ctx, client, repo, pr, checkRecord.HeadSHA)
 		}
@@ -679,10 +724,13 @@ func (h *Handler) storeApplyPlanCheckRecord(ctx context.Context, client *ghclien
 
 // updateCheckRecordForApplyStart updates the stored check record to "in_progress"
 // when an apply begins execution. The aggregate check is updated to reflect the state.
-func (h *Handler) updateCheckRecordForApplyStart(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, schema *ghclient.SchemaRequestResult, environment string) {
+func (h *Handler) updateCheckRecordForApplyStart(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, schema *ghclient.SchemaRequestResult, environment string, applyID int64) {
 	check, err := h.service.Storage().Checks().Get(ctx, repo, pr, environment, schema.Type, schema.Database)
 	if err != nil {
-		h.logger.Error("failed to look up check record", "error", err)
+		h.logger.Error("failed to look up check record for apply start",
+			"repo", repo, "pr", pr, "database", schema.Database,
+			"database_type", schema.Type, "environment", environment,
+			"apply_id", applyID, "error", err)
 		return
 	}
 
@@ -690,7 +738,10 @@ func (h *Handler) updateCheckRecordForApplyStart(ctx context.Context, client *gh
 		// No existing record — create one
 		prInfo, err := client.FetchPullRequest(ctx, repo, pr)
 		if err != nil {
-			h.logger.Error("failed to fetch PR for check record", "error", err)
+			h.logger.Error("failed to fetch PR for apply start check record",
+				"repo", repo, "pr", pr, "database", schema.Database,
+				"database_type", schema.Type, "environment", environment,
+				"apply_id", applyID, "error", err)
 			return
 		}
 		check = &storage.Check{
@@ -700,18 +751,28 @@ func (h *Handler) updateCheckRecordForApplyStart(ctx context.Context, client *gh
 			Environment:  environment,
 			DatabaseType: schema.Type,
 			DatabaseName: schema.Database,
+			ApplyID:      applyID,
 			HasChanges:   true,
 			Status:       checkStatusInProgress,
 			Conclusion:   "",
 		}
 	} else {
+		check.ApplyID = applyID
 		check.Status = checkStatusInProgress
 		check.Conclusion = ""
 	}
 
 	if err := h.service.Storage().Checks().Upsert(ctx, check); err != nil {
-		h.logger.Error("failed to upsert check record", "error", err)
+		h.logger.Error("failed to upsert check record for apply start",
+			"repo", repo, "pr", pr, "database", schema.Database,
+			"database_type", schema.Type, "environment", environment,
+			"apply_id", applyID, "head_sha", check.HeadSHA, "error", err)
+		return
 	}
+	h.logger.Info("check record marked in_progress for apply",
+		"repo", repo, "pr", pr, "database", schema.Database,
+		"database_type", schema.Type, "environment", environment,
+		"apply_id", applyID, "head_sha", check.HeadSHA)
 
 	h.updateAggregateCheck(ctx, client, repo, pr, check.HeadSHA)
 }

--- a/pkg/webhook/check_runs.go
+++ b/pkg/webhook/check_runs.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/block/schemabot/pkg/apitypes"
 	ghclient "github.com/block/schemabot/pkg/github"
+	"github.com/block/schemabot/pkg/metrics"
 	"github.com/block/schemabot/pkg/state"
 	"github.com/block/schemabot/pkg/storage"
 	"github.com/block/schemabot/pkg/webhook/templates"
@@ -31,14 +32,14 @@ const (
 	checkConclusionNeutral        = "neutral"
 )
 
-// aggregateCheckName is the check name to require in branch protection.
-// Per-database checks (e.g., "SchemaBot: staging/mysql/orders") provide granular
-// visibility per environment and database; the aggregate rolls them into a single
-// conclusion so branch protection only needs one stable name.
+// aggregateCheckName is the GitHub Check Run name to require in branch protection.
+// Per-database stored check state provides granular internal status per
+// environment and database; the aggregate rolls it into one visible conclusion so
+// branch protection only needs one stable name.
 const aggregateCheckName = "SchemaBot"
 
 // aggregateSentinel is used for database type and database name when storing
-// aggregate check records in the checks table. For the environment field,
+// aggregate check state in the checks table. For the environment field,
 // per-environment aggregates use the real environment name while the global
 // aggregate (no allowed_environments) uses aggregateSentinel.
 const aggregateSentinel = "_aggregate"
@@ -49,8 +50,8 @@ func aggregateCheckNameForEnv(env string) string {
 	return fmt.Sprintf("SchemaBot (%s)", env)
 }
 
-// filterChecksByEnvironment returns only checks that belong to the given environment.
-// Aggregate checks are excluded.
+// filterChecksByEnvironment returns only stored check state for the given environment.
+// Aggregate state is excluded.
 func filterChecksByEnvironment(checks []*storage.Check, env string) []*storage.Check {
 	var filtered []*storage.Check
 	for _, c := range checks {
@@ -64,8 +65,8 @@ func filterChecksByEnvironment(checks []*storage.Check, env string) []*storage.C
 	return filtered
 }
 
-// isAggregateCheck returns true if the check is an aggregate (not a per-database check).
-// Aggregate checks use the sentinel value for DatabaseType and DatabaseName.
+// isAggregateCheck returns true if stored check state is aggregate, not per-database.
+// Aggregate state uses the sentinel value for DatabaseType and DatabaseName.
 // The Environment field is either aggregateSentinel (global aggregate) or a real
 // environment name (per-environment aggregate when allowed_environments is configured).
 func isAggregateCheck(c *storage.Check) bool {
@@ -73,14 +74,14 @@ func isAggregateCheck(c *storage.Check) bool {
 		c.DatabaseName == aggregateSentinel
 }
 
-// storePlanCheckRecord stores a per-database check record after a plan is generated.
-// The record is used internally by the aggregate check to compute its overall status.
+// storePlanCheckRecord stores per-database check state after a plan is generated.
+// The state is used internally by the aggregate check to compute its overall status.
 // No per-database GitHub Check Run is created — only the aggregate is visible on the PR.
 // Returns the PR head SHA. Failures are non-fatal.
 func (h *Handler) storePlanCheckRecord(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, schema *ghclient.SchemaRequestResult, planResp *apitypes.PlanResponse, environment string) (string, error) {
 	prInfo, err := client.FetchPullRequest(ctx, repo, pr)
 	if err != nil {
-		return "", fmt.Errorf("fetch PR for check record: %w", err)
+		return "", fmt.Errorf("fetch PR for stored check state: %w", err)
 	}
 
 	tables := planResp.FlatTables()
@@ -107,26 +108,136 @@ func (h *Handler) storePlanCheckRecord(ctx context.Context, client *ghclient.Ins
 		Status:       checkStatusCompleted,
 		Conclusion:   conclusion,
 	}
-	if err := h.service.Storage().Checks().Upsert(ctx, check); err != nil {
-		return prInfo.HeadSHA, fmt.Errorf("store check record: %w", err)
+	if err := h.service.Storage().Checks().UpsertPlanResult(ctx, check); err != nil {
+		return prInfo.HeadSHA, fmt.Errorf("store check state: %w", err)
 	}
 
 	return prInfo.HeadSHA, nil
 }
 
-// updateCheckRecordForApplyResult updates the stored check record after an apply
+type applyCheckKey struct {
+	environment  string
+	databaseType string
+	databaseName string
+}
+
+func latestApplyByCheckKey(applies []*storage.Apply) map[applyCheckKey]*storage.Apply {
+	latest := make(map[applyCheckKey]*storage.Apply, len(applies))
+	for _, apply := range applies {
+		key := applyCheckKey{
+			environment:  apply.Environment,
+			databaseType: apply.DatabaseType,
+			databaseName: apply.Database,
+		}
+		if existing, ok := latest[key]; !ok || isApplyNewer(apply, existing) {
+			latest[key] = apply
+		}
+	}
+	return latest
+}
+
+func isApplyNewer(candidate, existing *storage.Apply) bool {
+	// Apply IDs reflect storage insertion order; reconciliation wants the
+	// newest stored apply row, not wall-clock ordering.
+	return candidate.ID > existing.ID
+}
+
+// reconcileStaleChecks repairs stored check state from authoritative apply
+// state. The visible GitHub Check Run is the PR merge gate, but the apply row is
+// the source of truth for whether a schema change is still running. If a worker
+// dies after the apply reaches a terminal state but before it updates stored
+// check state, the PR can be left with an in_progress aggregate forever.
+// Reconciliation runs before plan and apply commands so normal user activity can
+// close that gap without operators manually editing stored check state.
+func (h *Handler) reconcileStaleChecks(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int) error {
+	checks, err := h.service.Storage().Checks().GetByPR(ctx, repo, pr)
+	if err != nil {
+		return fmt.Errorf("fetch checks for stale reconciliation repo %s pr %d: %w", repo, pr, err)
+	}
+
+	applies, err := h.service.Storage().Applies().GetByPR(ctx, repo, pr)
+	if err != nil {
+		return fmt.Errorf("look up applies for stale checks repo %s pr %d: %w", repo, pr, err)
+	}
+	latestApplies := latestApplyByCheckKey(applies)
+
+	reconciled := false
+	for _, check := range checks {
+		if check.Status != checkStatusInProgress {
+			continue
+		}
+		if isAggregateCheck(check) {
+			continue
+		}
+
+		key := applyCheckKey{
+			environment:  check.Environment,
+			databaseType: check.DatabaseType,
+			databaseName: check.DatabaseName,
+		}
+		apply := latestApplies[key]
+		if apply == nil {
+			h.logger.Debug("skipping in_progress check without matching apply",
+				"repo", repo, "pr", pr,
+				"database", check.DatabaseName, "database_type", check.DatabaseType,
+				"environment", check.Environment, "check_apply_id", check.ApplyID,
+				"check_head_sha", check.HeadSHA)
+			continue
+		}
+		if !state.IsTerminalApplyState(apply.State) {
+			h.logger.Debug("skipping in_progress check because latest apply is not terminal",
+				"repo", repo, "pr", pr,
+				"database", check.DatabaseName, "database_type", check.DatabaseType,
+				"environment", check.Environment,
+				"apply_id", apply.ID, "apply_identifier", apply.ApplyIdentifier,
+				"apply_state", apply.State, "check_apply_id", check.ApplyID,
+				"check_head_sha", check.HeadSHA)
+			continue
+		}
+
+		h.logger.Info("reconciling stale in_progress check",
+			"repo", repo, "pr", pr,
+			"database", check.DatabaseName, "database_type", check.DatabaseType,
+			"environment", check.Environment,
+			"apply_id", apply.ID, "apply_identifier", apply.ApplyIdentifier,
+			"apply_state", apply.State, "check_apply_id", check.ApplyID,
+			"check_head_sha", check.HeadSHA)
+
+		updated, err := h.updateCheckRecordForApplyResult(ctx, repo, pr, apply)
+		if err != nil {
+			return err
+		}
+		if updated {
+			reconciled = true
+		}
+	}
+
+	if !reconciled {
+		return nil
+	}
+
+	prInfo, err := client.FetchPullRequest(ctx, repo, pr)
+	if err != nil {
+		return fmt.Errorf("fetch PR head SHA for stale reconciliation aggregate repo %s pr %d: %w", repo, pr, err)
+	}
+	if prInfo.HeadSHA != "" {
+		h.updateAggregateCheck(ctx, client, repo, pr, prInfo.HeadSHA)
+	}
+	return nil
+}
+
+// updateCheckRecordForApplyResult updates stored check state after an apply
 // reaches a terminal state. The aggregate check is updated separately to reflect
 // the new status on the PR.
-func (h *Handler) updateCheckRecordForApplyResult(ctx context.Context, repo string, pr int, apply *storage.Apply) {
+func (h *Handler) updateCheckRecordForApplyResult(ctx context.Context, repo string, pr int, apply *storage.Apply) (bool, error) {
 	check, err := h.service.Storage().Checks().Get(ctx, repo, pr, apply.Environment, apply.DatabaseType, apply.Database)
 	if err != nil {
-		h.logger.Error("failed to look up check for apply result", "error", err)
-		return
+		return false, fmt.Errorf("look up check for apply result repo %s pr %d environment %s database_type %s database %s: %w",
+			repo, pr, apply.Environment, apply.DatabaseType, apply.Database, err)
 	}
 	if check == nil {
-		h.logger.Warn("no check record found to update after apply",
-			"repo", repo, "pr", pr, "database", apply.Database, "environment", apply.Environment)
-		return
+		return false, fmt.Errorf("no stored check state found to update after apply repo %s pr %d environment %s database_type %s database %s",
+			repo, pr, apply.Environment, apply.DatabaseType, apply.Database)
 	}
 
 	var conclusion string
@@ -142,38 +253,82 @@ func (h *Handler) updateCheckRecordForApplyResult(ctx context.Context, repo stri
 	check.Status = checkStatusCompleted
 	check.Conclusion = conclusion
 	check.HasChanges = conclusion != checkConclusionSuccess
-	if err := h.service.Storage().Checks().Upsert(ctx, check); err != nil {
-		h.logger.Error("failed to update check record after apply", "error", err)
+	updated, err := h.service.Storage().Checks().CompleteForApply(ctx, check, apply)
+	if err != nil {
+		return false, fmt.Errorf("update stored check state after apply repo %s pr %d environment %s database_type %s database %s: %w",
+			repo, pr, apply.Environment, apply.DatabaseType, apply.Database, err)
+	}
+	if !updated {
+		metrics.RecordCheckOwnershipMiss(ctx, "complete_apply", repo, apply.Database, apply.DatabaseType, apply.Environment)
+		h.logger.Warn("skipping check state update because stored state no longer belongs to apply",
+			"repo", repo, "pr", pr, "database", apply.Database,
+			"database_type", apply.DatabaseType, "environment", apply.Environment,
+			"apply_id", apply.ID, "apply_identifier", apply.ApplyIdentifier,
+			"apply_state", apply.State, "check_apply_id", check.ApplyID,
+			"check_status", check.Status, "check_head_sha", check.HeadSHA)
+		return false, nil
 	}
 
-	h.logger.Info("check record updated after apply",
+	h.logger.Info("stored check state updated after apply",
 		"repo", repo, "pr", pr, "database", apply.Database,
-		"environment", apply.Environment, "conclusion", conclusion)
+		"database_type", apply.DatabaseType, "environment", apply.Environment,
+		"apply_id", apply.ID, "apply_identifier", apply.ApplyIdentifier,
+		"apply_state", apply.State, "conclusion", conclusion)
+	return true, nil
 }
 
-// setCheckActionRequired sets the check for a database/environment back to action_required.
-// Used after a rollback completes — the PR's schema changes need to be re-applied.
-func (h *Handler) setCheckActionRequired(repo string, pr int, environment, dbType, database string, installationID int64) {
+// setCheckActionRequired sets the rollback apply's check back to action_required.
+// Used after a rollback completes because the PR's schema changes need to be re-applied.
+func (h *Handler) setCheckActionRequired(repo string, pr int, installationID int64, apply *storage.Apply) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	check, err := h.service.Storage().Checks().Get(ctx, repo, pr, environment, dbType, database)
-	if err != nil || check == nil {
-		h.logger.Warn("no check record to update after rollback",
-			"repo", repo, "pr", pr, "database", database, "environment", environment)
+	check, err := h.service.Storage().Checks().Get(ctx, repo, pr, apply.Environment, apply.DatabaseType, apply.Database)
+	if err != nil {
+		h.logger.Error("failed to look up stored check state after rollback",
+			"repo", repo, "pr", pr, "database", apply.Database,
+			"database_type", apply.DatabaseType, "environment", apply.Environment,
+			"apply_id", apply.ID, "apply_identifier", apply.ApplyIdentifier,
+			"error", err)
+		return
+	}
+	if check == nil {
+		h.logger.Warn("no stored check state to update after rollback",
+			"repo", repo, "pr", pr, "database", apply.Database,
+			"database_type", apply.DatabaseType, "environment", apply.Environment,
+			"apply_id", apply.ID, "apply_identifier", apply.ApplyIdentifier)
 		return
 	}
 
 	check.Status = checkStatusCompleted
 	check.Conclusion = checkConclusionActionRequired
 	check.HasChanges = true
-	if err := h.service.Storage().Checks().Upsert(ctx, check); err != nil {
-		h.logger.Error("failed to set check to action_required after rollback", "error", err)
+	updated, err := h.service.Storage().Checks().MarkActionRequiredForApply(ctx, check, apply)
+	if err != nil {
+		h.logger.Error("failed to set check to action_required after rollback",
+			"repo", repo, "pr", pr, "database", apply.Database,
+			"database_type", apply.DatabaseType, "environment", apply.Environment,
+			"apply_id", apply.ID, "apply_identifier", apply.ApplyIdentifier,
+			"check_apply_id", check.ApplyID, "check_status", check.Status,
+			"check_head_sha", check.HeadSHA, "error", err)
+		return
+	}
+	if !updated {
+		metrics.RecordCheckOwnershipMiss(ctx, "rollback_action_required", repo, apply.Database, apply.DatabaseType, apply.Environment)
+		h.logger.Warn("skipping rollback action_required update because check no longer belongs to apply",
+			"repo", repo, "pr", pr, "database", apply.Database,
+			"database_type", apply.DatabaseType, "environment", apply.Environment,
+			"apply_id", apply.ID, "apply_identifier", apply.ApplyIdentifier,
+			"apply_state", apply.State, "check_apply_id", check.ApplyID,
+			"check_status", check.Status, "check_head_sha", check.HeadSHA)
 		return
 	}
 
 	h.logger.Info("check set to action_required after rollback",
-		"repo", repo, "pr", pr, "database", database, "environment", environment)
+		"repo", repo, "pr", pr, "database", apply.Database,
+		"database_type", apply.DatabaseType, "environment", apply.Environment,
+		"apply_id", apply.ID, "apply_identifier", apply.ApplyIdentifier,
+		"apply_state", apply.State)
 
 	// Update the aggregate check to reflect the rollback
 	if aggClient, err := h.ghClient.ForInstallation(installationID); err == nil {
@@ -441,7 +596,7 @@ func (h *Handler) upsertAggregateCheckRun(
 		opts.Conclusion = conclusion
 	}
 
-	// Look up existing aggregate check record using the environment-specific key
+	// Look up existing aggregate check state using the environment-specific key.
 	existing, err := h.service.Storage().Checks().Get(ctx, repo, pr, environment, aggregateSentinel, aggregateSentinel)
 	if err != nil {
 		h.logger.Error("failed to look up aggregate check", "repo", repo, "pr", pr, "environment", environment, "error", err)
@@ -485,7 +640,7 @@ func (h *Handler) upsertAggregateCheckRun(
 		Conclusion:   conclusion,
 	}
 	if err := h.service.Storage().Checks().Upsert(ctx, aggCheck); err != nil {
-		h.logger.Error("failed to store aggregate check record", "error", err)
+		h.logger.Error("failed to store aggregate check state", "error", err)
 	}
 
 	h.logger.Info("aggregate check updated",

--- a/pkg/webhook/check_runs_test.go
+++ b/pkg/webhook/check_runs_test.go
@@ -1,6 +1,7 @@
 package webhook
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -11,8 +12,37 @@ import (
 
 	"github.com/block/schemabot/pkg/api"
 	ghclient "github.com/block/schemabot/pkg/github"
+	"github.com/block/schemabot/pkg/state"
 	"github.com/block/schemabot/pkg/storage"
 )
+
+type emptyStorage struct {
+	storage.Storage
+}
+
+func (s *emptyStorage) Checks() storage.CheckStore {
+	return &emptyCheckStore{}
+}
+
+func (s *emptyStorage) Applies() storage.ApplyStore {
+	return &emptyApplyStore{}
+}
+
+type emptyCheckStore struct {
+	storage.CheckStore
+}
+
+func (s *emptyCheckStore) GetByPR(ctx context.Context, repo string, pr int) ([]*storage.Check, error) {
+	return nil, nil
+}
+
+type emptyApplyStore struct {
+	storage.ApplyStore
+}
+
+func (s *emptyApplyStore) GetByPR(ctx context.Context, repo string, pr int) ([]*storage.Apply, error) {
+	return nil, nil
+}
 
 func TestComputeAggregate(t *testing.T) {
 	tests := []struct {
@@ -190,6 +220,61 @@ func TestFilterChecksByEnvironment(t *testing.T) {
 	})
 }
 
+func TestLatestApplyByCheckKey(t *testing.T) {
+	applies := []*storage.Apply{
+		{
+			ID:           1,
+			Database:     "orders",
+			DatabaseType: "mysql",
+			Environment:  "staging",
+			State:        state.Apply.Completed,
+		},
+		{
+			ID:           2,
+			Database:     "orders",
+			DatabaseType: "mysql",
+			Environment:  "staging",
+			State:        state.Apply.Running,
+		},
+		{
+			ID:           3,
+			Database:     "orders",
+			DatabaseType: "vitess",
+			Environment:  "staging",
+			State:        state.Apply.Completed,
+		},
+		{
+			ID:           5,
+			Database:     "users",
+			DatabaseType: "mysql",
+			Environment:  "staging",
+			State:        state.Apply.Failed,
+		},
+		{
+			ID:           4,
+			Database:     "users",
+			DatabaseType: "mysql",
+			Environment:  "staging",
+			State:        state.Apply.Completed,
+		},
+	}
+
+	latest := latestApplyByCheckKey(applies)
+
+	mysqlOrders := latest[applyCheckKey{environment: "staging", databaseType: "mysql", databaseName: "orders"}]
+	require.NotNil(t, mysqlOrders)
+	assert.Equal(t, state.Apply.Running, mysqlOrders.State)
+
+	vitessOrders := latest[applyCheckKey{environment: "staging", databaseType: "vitess", databaseName: "orders"}]
+	require.NotNil(t, vitessOrders)
+	assert.Equal(t, state.Apply.Completed, vitessOrders.State)
+
+	mysqlUsers := latest[applyCheckKey{environment: "staging", databaseType: "mysql", databaseName: "users"}]
+	require.NotNil(t, mysqlUsers)
+	assert.Equal(t, int64(5), mysqlUsers.ID)
+	assert.Equal(t, state.Apply.Failed, mysqlUsers.State)
+}
+
 func TestCheckPriorEnvViaGitHub(t *testing.T) {
 	const (
 		repo    = "octocat/hello-world"
@@ -331,7 +416,7 @@ func TestCheckPriorEnvViaGitHub(t *testing.T) {
 }
 
 func TestWebhookEnvironmentFiltering(t *testing.T) {
-	t.Run("non-allowed environment silently ignored", func(t *testing.T) {
+	t.Run("non-allowed environment ignored with explicit response", func(t *testing.T) {
 		client, mux := setupGitHubServer(t)
 		mux.HandleFunc("POST /repos/octocat/hello-world/issues/comments/42/reactions", func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusCreated)
@@ -341,7 +426,7 @@ func TestWebhookEnvironmentFiltering(t *testing.T) {
 		installClient := ghclient.NewInstallationClient(client, testLogger())
 		factory := &fakeClientFactory{client: installClient}
 
-		service := api.New(nil, &api.ServerConfig{
+		service := api.New(&emptyStorage{}, &api.ServerConfig{
 			AllowedEnvironments: []string{"staging"},
 			Repos:               map[string]api.RepoConfig{},
 		}, nil, testLogger())
@@ -352,8 +437,8 @@ func TestWebhookEnvironmentFiltering(t *testing.T) {
 			logger:   testLogger(),
 		}
 
-		// Plan targeting production should be silently ignored by this instance
-		// because only staging is in allowed_environments.
+		// Plan targeting production should be ignored by this instance because
+		// only staging is in allowed_environments.
 		req := buildWebhookRequest(t, webhookPayloadOpts{
 			comment: "schemabot plan -e production",
 			isPR:    true,
@@ -380,7 +465,7 @@ func TestWebhookEnvironmentFiltering(t *testing.T) {
 		installClient := ghclient.NewInstallationClient(client, testLogger())
 		factory := &fakeClientFactory{client: installClient}
 
-		service := api.New(nil, &api.ServerConfig{
+		service := api.New(&emptyStorage{}, &api.ServerConfig{
 			AllowedEnvironments: []string{"staging"},
 			Repos:               map[string]api.RepoConfig{},
 		}, nil, testLogger())
@@ -422,7 +507,7 @@ func TestWebhookEnvironmentFiltering(t *testing.T) {
 		installClient := ghclient.NewInstallationClient(client, testLogger())
 		factory := &fakeClientFactory{client: installClient}
 
-		service := api.New(nil, &api.ServerConfig{
+		service := api.New(&emptyStorage{}, &api.ServerConfig{
 			Repos: map[string]api.RepoConfig{},
 		}, nil, testLogger())
 

--- a/pkg/webhook/handler_test.go
+++ b/pkg/webhook/handler_test.go
@@ -116,8 +116,12 @@ func newTestHandler(t *testing.T) (*Handler, chan string, chan string) {
 
 	installClient := ghclient.NewInstallationClient(client, testLogger())
 	factory := &fakeClientFactory{client: installClient}
+	service := api.New(&emptyStorage{}, &api.ServerConfig{
+		Repos: map[string]api.RepoConfig{},
+	}, nil, testLogger())
 
 	h := &Handler{
+		service:  service,
 		ghClient: factory,
 		logger:   testLogger(),
 	}

--- a/pkg/webhook/plan.go
+++ b/pkg/webhook/plan.go
@@ -25,6 +25,20 @@ func (h *Handler) handlePlanCommand(w http.ResponseWriter, repo string, pr int, 
 		return
 	}
 
+	// Fix checks stuck at "in_progress" from crashed applies
+	if err := h.reconcileStaleChecks(ctx, client, repo, pr); err != nil {
+		h.logger.Error("failed to reconcile stale status checks", "repo", repo, "pr", pr, "error", err)
+		h.postComment(repo, pr, installationID, templates.RenderGenericError(templates.SchemaErrorData{
+			RequestedBy: requestedBy,
+			Timestamp:   time.Now().UTC().Format("2006-01-02 15:04:05"),
+			Environment: environment,
+			CommandName: action.Plan,
+			ErrorDetail: "Failed to reconcile stale status checks: " + err.Error(),
+		}))
+		h.writeJSON(w, http.StatusOK, map[string]string{"message": "status check reconciliation failed"})
+		return
+	}
+
 	// Discover config and fetch schema files from PR
 	schemaResult, err := client.CreateSchemaRequestFromPR(ctx, repo, pr, environment, databaseName)
 	if err != nil {
@@ -92,6 +106,18 @@ func (h *Handler) handleMultiEnvPlan(repo string, pr int, databaseName string, i
 	client, err := h.ghClient.ForInstallation(installationID)
 	if err != nil {
 		h.logger.Error("failed to create GitHub client", "error", err)
+		return
+	}
+
+	// Fix checks stuck at "in_progress" from crashed applies
+	if err := h.reconcileStaleChecks(ctx, client, repo, pr); err != nil {
+		h.logger.Error("failed to reconcile stale status checks", "repo", repo, "pr", pr, "error", err)
+		h.postComment(repo, pr, installationID, templates.RenderGenericError(templates.SchemaErrorData{
+			RequestedBy: requestedBy,
+			Timestamp:   time.Now().UTC().Format("2006-01-02 15:04:05"),
+			CommandName: action.Plan,
+			ErrorDetail: "Failed to reconcile stale status checks: " + err.Error(),
+		}))
 		return
 	}
 

--- a/pkg/webhook/rollback.go
+++ b/pkg/webhook/rollback.go
@@ -261,29 +261,56 @@ func (h *Handler) handleRollbackConfirmCommand(repo string, pr int, environment,
 		return
 	}
 
+	if applyID <= 0 {
+		h.logger.Error("rollback apply accepted without storage apply id",
+			"repo", repo, "pr", pr, "database", database, "database_type", dbType, "environment", environment)
+		return
+	}
+
 	// Spawn background progress watcher. After the rollback apply completes,
 	// set the check to action_required — the PR's schema changes need to be
 	// re-applied since the rollback undid them.
-	if applyID > 0 {
-		apply, err := h.service.Storage().Applies().Get(ctx, applyID)
-		if err != nil || apply == nil {
-			h.logger.Error("failed to load apply for progress watch", "applyID", applyID, "error", err)
+	apply, err := h.service.Storage().Applies().Get(ctx, applyID)
+	if err != nil {
+		h.logger.Error("failed to load rollback apply for progress watch",
+			"repo", repo, "pr", pr, "database", database,
+			"database_type", dbType, "environment", environment,
+			"apply_id", applyID, "error", err)
+		return
+	}
+	if apply == nil {
+		h.logger.Error("rollback apply missing after accepted apply",
+			"repo", repo, "pr", pr, "database", database,
+			"database_type", dbType, "environment", environment,
+			"apply_id", applyID)
+		return
+	}
+	h.updateCheckRecordForApplyStart(ctx, client, repo, pr, schemaResult, environment, applyID)
+
+	go func() {
+		bgCtx := context.Background()
+		h.watchApplyProgress(bgCtx, repo, pr, installationID, apply)
+		// Re-fetch the apply to check its final state. Only set action_required
+		// if the rollback succeeded — a failed rollback should keep the failure
+		// conclusion set by watchApplyProgress.
+		final, err := h.service.Storage().Applies().Get(bgCtx, applyID)
+		if err != nil {
+			h.logger.Error("failed to re-fetch apply after rollback",
+				"repo", repo, "pr", pr, "database", apply.Database,
+				"database_type", apply.DatabaseType, "environment", apply.Environment,
+				"apply_id", applyID, "apply_identifier", apply.ApplyIdentifier,
+				"error", err)
 			return
 		}
-		go func() {
-			bgCtx := context.Background()
-			h.watchApplyProgress(bgCtx, repo, pr, installationID, apply)
-			// Re-fetch the apply to check its final state. Only set action_required
-			// if the rollback succeeded — a failed rollback should keep the failure
-			// conclusion set by watchApplyProgress.
-			final, err := h.service.Storage().Applies().Get(bgCtx, applyID)
-			if err != nil || final == nil {
-				h.logger.Error("failed to re-fetch apply after rollback", "applyID", applyID, "error", err)
-				return
-			}
-			if state.IsState(final.State, state.Apply.Completed) {
-				h.setCheckActionRequired(repo, pr, apply.Environment, apply.DatabaseType, apply.Database, installationID)
-			}
-		}()
-	}
+		if final == nil {
+			h.logger.Error("rollback apply missing after progress watch",
+				"repo", repo, "pr", pr, "database", apply.Database,
+				"database_type", apply.DatabaseType, "environment", apply.Environment,
+				"apply_id", applyID, "apply_identifier", apply.ApplyIdentifier)
+			return
+		}
+		if state.IsState(final.State, state.Apply.Completed) {
+			h.setCheckActionRequired(repo, pr, installationID, final)
+		}
+	}()
 }

--- a/pkg/webhook/webhook_e2e_test.go
+++ b/pkg/webhook/webhook_e2e_test.go
@@ -1832,6 +1832,7 @@ func TestE2ERollbackConfirmUpdatesCheckToActionRequired(t *testing.T) {
 		DatabaseType: "mysql",
 		DatabaseName: dbName,
 		CheckRunID:   42,
+		ApplyID:      applyID,
 		HasChanges:   false,
 		Status:       checkStatusCompleted,
 		Conclusion:   checkConclusionSuccess,
@@ -1883,9 +1884,21 @@ func TestE2ERollbackConfirmUpdatesCheckToActionRequired(t *testing.T) {
 	// Wait for the rollback apply to complete and check to be updated
 	require.Eventually(t, func() bool {
 		check, err := svc.Storage().Checks().Get(ctx, "octocat/hello-world", 1, "staging", "mysql", dbName)
-		return err == nil && check != nil && check.Conclusion == checkConclusionActionRequired
+		if err != nil {
+			return false
+		}
+		return isActionRequiredWithoutApplyOwnership(check)
 	}, 30*time.Second, 500*time.Millisecond,
-		"check should transition to action_required after rollback")
+		"check should transition to action_required without active apply ownership after rollback")
+}
+
+func isActionRequiredWithoutApplyOwnership(check *storage.Check) bool {
+	if check == nil {
+		return false
+	}
+	return check.Status == checkStatusCompleted &&
+		check.Conclusion == checkConclusionActionRequired &&
+		check.ApplyID == 0
 }
 
 // TestE2ERollbackIgnoredByNonOwningInstance verifies that in a multi-instance
@@ -2076,6 +2089,100 @@ func TestE2EStaleCheckCleanup(t *testing.T) {
 	check, err := svc.Storage().Checks().Get(t.Context(), "octocat/hello-world", 1, "staging", "mysql", dbName)
 	require.NoError(t, err)
 	require.NotNil(t, check, "active check should still exist")
+}
+
+// TestE2EReconcileStaleInProgressCheck verifies that when a check is stuck at
+// "in_progress" from a crashed apply, the next plan or apply command reconciles
+// it to the apply's terminal state. This prevents branch protection from being
+// blocked indefinitely after a server crash mid-apply.
+func TestE2EReconcileStaleInProgressCheck(t *testing.T) {
+	dbName := "webhook_stale_inprogress"
+	svc := setupE2EService(t, dbName)
+	ctx := t.Context()
+
+	// Seed a completed apply (simulates an apply that finished but the goroutine died)
+	apply := &storage.Apply{
+		ApplyIdentifier: "apply-stale-test",
+		Database:        dbName,
+		DatabaseType:    "mysql",
+		Environment:     "staging",
+		Repository:      "octocat/hello-world",
+		PullRequest:     1,
+		State:           state.Apply.Completed,
+		Engine:          "spirit",
+	}
+	applyID, err := svc.Storage().Applies().Create(ctx, apply)
+	require.NoError(t, err)
+	apply.ID = applyID
+
+	// Seed a check stuck at "in_progress" (the goroutine died before updating it)
+	err = svc.Storage().Checks().Upsert(ctx, &storage.Check{
+		Repository:   "octocat/hello-world",
+		PullRequest:  1,
+		HeadSHA:      "oldsha999",
+		Environment:  "staging",
+		DatabaseType: "mysql",
+		DatabaseName: dbName,
+		CheckRunID:   42,
+		ApplyID:      applyID,
+		HasChanges:   true,
+		Status:       checkStatusInProgress,
+		Conclusion:   "",
+	})
+	require.NoError(t, err)
+
+	// Seed an aggregate also stuck at in_progress
+	err = svc.Storage().Checks().Upsert(ctx, &storage.Check{
+		Repository:   "octocat/hello-world",
+		PullRequest:  1,
+		HeadSHA:      "oldsha999",
+		Environment:  aggregateSentinel,
+		DatabaseType: aggregateSentinel,
+		DatabaseName: aggregateSentinel,
+		CheckRunID:   100,
+		HasChanges:   true,
+		Status:       checkStatusInProgress,
+		Conclusion:   "",
+	})
+	require.NoError(t, err)
+
+	// Set up fake GitHub
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	client := gh.NewClient(nil)
+	client.BaseURL, _ = url.Parse(server.URL + "/")
+
+	result := setupFakeGitHubForPlan(t, mux, nil, "", dbName)
+	h := newE2EHandler(t, svc, client)
+	installClient := ghclient.NewInstallationClient(client, h.logger)
+
+	require.NoError(t, h.reconcileStaleChecks(ctx, installClient, "octocat/hello-world", 1))
+
+	check, err := svc.Storage().Checks().Get(ctx, "octocat/hello-world", 1, "staging", "mysql", dbName)
+	require.NoError(t, err)
+	require.NotNil(t, check)
+	assert.Equal(t, checkStatusCompleted, check.Status)
+	assert.Equal(t, checkConclusionSuccess, check.Conclusion)
+	assert.Equal(t, applyID, check.ApplyID)
+
+	select {
+	case checkRun := <-result.checkRuns:
+		assert.Equal(t, aggregateCheckName, checkRun.Name)
+		assert.Equal(t, "abc123", checkRun.HeadSHA)
+		assert.Equal(t, checkStatusCompleted, checkRun.Status)
+		assert.Equal(t, checkConclusionSuccess, checkRun.Conclusion)
+	case <-time.After(30 * time.Second):
+		t.Fatal("timed out waiting for aggregate check run")
+	}
+
+	aggregate, err := svc.Storage().Checks().Get(ctx, "octocat/hello-world", 1, aggregateSentinel, aggregateSentinel, aggregateSentinel)
+	require.NoError(t, err)
+	require.NotNil(t, aggregate)
+	assert.Equal(t, "abc123", aggregate.HeadSHA)
+	assert.Equal(t, checkStatusCompleted, aggregate.Status)
+	assert.Equal(t, checkConclusionSuccess, aggregate.Conclusion)
 }
 
 // TestE2EMultiAppAutoPlan simulates a monorepo with multiple apps, each with their


### PR DESCRIPTION
## Summary

- Track check ownership with `apply_id` and conditional storage updates so old apply, rollback, and recovery paths cannot overwrite newer check state.
- Reconcile stale `in_progress` checks from authoritative apply state before plan/apply, and fail closed when reconciliation cannot safely read or update storage.
- Preserve running check ownership only for the matching PR head and apply, use apply row IDs for newest-apply ordering, and avoid claiming unowned stored check state.
- Make rollback `action_required`, apply completion, and aggregate updates ownership-aware so stale watchers do not overwrite newer merge-gate state.
- Add Warn-level ownership-miss logs, `schemabot.check_ownership_misses_total`, and operator guidance for treating spikes as near-miss signals for stale check writes and possible live-schema drift.
- Clarify GitHub Check Run vs stored check state terminology, add triage context to critical logs, and split distinct error/missing-row branches for clearer production debugging.
- Document agent guidance for avoiding silent skips, TOCTOU-prone updates, conflated error causes, and dense compound predicates.
