### PR TITLE
fix(github): fail closed on unverifiable check state

### DIFF
--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
 	"path"
 	"strings"
@@ -149,6 +150,61 @@ func IsNotFoundError(err error) bool {
 	return false
 }
 
+// ErrGitHubUnavailable identifies GitHub API availability failures that should
+// be retried once GitHub becomes reachable again.
+var ErrGitHubUnavailable = errors.New("github unavailable")
+
+type githubUnavailableError struct {
+	err error
+}
+
+func (e *githubUnavailableError) Error() string {
+	return fmt.Sprintf("%s: %v", ErrGitHubUnavailable, e.err)
+}
+
+func (e *githubUnavailableError) Unwrap() error {
+	return e.err
+}
+
+func (e *githubUnavailableError) Is(target error) bool {
+	return target == ErrGitHubUnavailable
+}
+
+// IsUnavailableError returns true when the error chain contains a GitHub API
+// availability failure such as a network failure, timeout, or 5xx response.
+func IsUnavailableError(err error) bool {
+	return errors.Is(err, ErrGitHubUnavailable)
+}
+
+func classifyGitHubAPIError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if isGitHubUnavailable(err) {
+		return &githubUnavailableError{err: err}
+	}
+	return err
+}
+
+func isGitHubUnavailable(err error) bool {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+
+	var ghErr *gh.ErrorResponse
+	if errors.As(err, &ghErr) && ghErr.Response != nil {
+		status := ghErr.Response.StatusCode
+		return status >= http.StatusInternalServerError
+	}
+
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return true
+	}
+	var opErr *net.OpError
+	return errors.As(err, &opErr)
+}
+
 // splitRepo splits "owner/repo" into owner and repo parts.
 func splitRepo(repo string) (owner, repoName string) {
 	parts := strings.SplitN(repo, "/", 2)
@@ -206,7 +262,7 @@ func (ic *InstallationClient) FetchPullRequest(ctx context.Context, repo string,
 	owner, repoName := splitRepo(repo)
 	ghPR, _, err := ic.client.PullRequests.Get(ctx, owner, repoName, pr)
 	if err != nil {
-		return nil, fmt.Errorf("fetch pull request: %w", err)
+		return nil, fmt.Errorf("fetch pull request: %w", classifyGitHubAPIError(err))
 	}
 	return &PullRequestInfo{
 		HeadRef: ghPR.GetHead().GetRef(),
@@ -232,7 +288,7 @@ func (ic *InstallationClient) FetchPRFiles(ctx context.Context, repo string, pr 
 	for {
 		ghFiles, resp, err := ic.client.PullRequests.ListFiles(ctx, owner, repoName, pr, opts)
 		if err != nil {
-			return nil, fmt.Errorf("list PR files: %w", err)
+			return nil, fmt.Errorf("list PR files: %w", classifyGitHubAPIError(err))
 		}
 		for _, f := range ghFiles {
 			allFiles = append(allFiles, PRFile{
@@ -520,7 +576,7 @@ func (ic *InstallationClient) FetchGitTree(ctx context.Context, repo, treeSHA st
 	owner, repoName := splitRepo(repo)
 	ghTree, _, err := ic.client.Git.GetTree(ctx, owner, repoName, treeSHA, true)
 	if err != nil {
-		return nil, false, fmt.Errorf("fetch git tree: %w", err)
+		return nil, false, fmt.Errorf("fetch git tree: %w", classifyGitHubAPIError(err))
 	}
 
 	entries := make([]TreeEntry, len(ghTree.Entries))
@@ -541,7 +597,7 @@ func (ic *InstallationClient) FetchBlobContent(ctx context.Context, repo, blobSH
 	owner, repoName := splitRepo(repo)
 	blob, _, err := ic.client.Git.GetBlob(ctx, owner, repoName, blobSHA)
 	if err != nil {
-		return "", fmt.Errorf("fetch blob: %w", err)
+		return "", fmt.Errorf("fetch blob: %w", classifyGitHubAPIError(err))
 	}
 
 	content := blob.GetContent()
@@ -561,7 +617,7 @@ func (ic *InstallationClient) FetchFileContent(ctx context.Context, repo, filePa
 	opts := &gh.RepositoryContentGetOptions{Ref: ref}
 	fileContent, _, _, err := ic.client.Repositories.GetContents(ctx, owner, repoName, filePath, opts)
 	if err != nil {
-		return "", fmt.Errorf("fetch file content: %w", err)
+		return "", fmt.Errorf("fetch file content: %w", classifyGitHubAPIError(err))
 	}
 	if fileContent == nil {
 		return "", fmt.Errorf("file not found: %s", filePath)

--- a/pkg/github/config.go
+++ b/pkg/github/config.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path"
 	"slices"
@@ -385,7 +386,10 @@ func (ic *InstallationClient) FindAllConfigsForPR(ctx context.Context, repo stri
 
 	configsByPath := make(map[string]DiscoveredConfig)
 	for _, schemaFile := range schemaFiles {
-		config, configDir := ic.findNearestConfig(ctx, repo, prInfo.HeadSHA, schemaFile)
+		config, configDir, err := ic.findNearestConfig(ctx, repo, prInfo.HeadSHA, schemaFile)
+		if err != nil {
+			return nil, err
+		}
 		if config != nil {
 			if _, exists := configsByPath[configDir]; !exists {
 				configsByPath[configDir] = newDiscoveredConfig(config, configDir)
@@ -442,23 +446,29 @@ func filterSchemaFiles(files []string) []string {
 	return result
 }
 
-func (ic *InstallationClient) findNearestConfig(ctx context.Context, repo, ref, filePath string) (*SchemabotConfig, string) {
+func (ic *InstallationClient) findNearestConfig(ctx context.Context, repo, ref, filePath string) (*SchemabotConfig, string, error) {
 	dir := path.Dir(filePath)
 
-	// Check same directory (MySQL structure)
-	if config, err := ic.FetchConfig(ctx, repo, configPathForDir(dir), ref); err == nil {
-		return config, dir
-	}
-
-	// Check parent directory (Vitess structure with keyspace subdirectories)
-	parentDir := path.Dir(dir)
-	if parentDir != "" && parentDir != dir {
-		if config, err := ic.FetchConfig(ctx, repo, configPathForDir(parentDir), ref); err == nil {
-			return config, parentDir
+	for {
+		config, err := ic.FetchConfig(ctx, repo, configPathForDir(dir), ref)
+		if err == nil {
+			return config, dir, nil
 		}
+		if !errors.Is(err, ErrNoConfig) {
+			return nil, "", err
+		}
+
+		if dir == "." || dir == "" {
+			break
+		}
+		parentDir := path.Dir(dir)
+		if parentDir == dir {
+			break
+		}
+		dir = parentDir
 	}
 
-	return nil, ""
+	return nil, "", nil
 }
 
 func configPathForDir(dir string) string {

--- a/pkg/github/config_test.go
+++ b/pkg/github/config_test.go
@@ -1,8 +1,16 @@
 package github
 
 import (
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"testing"
 
+	gh "github.com/google/go-github/v68/github"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
@@ -116,4 +124,69 @@ environments:
 	assert.True(t, config.HasEnvironment("staging"))
 	assert.True(t, config.HasEnvironment("production"))
 	assert.False(t, config.HasEnvironment("dev"))
+}
+
+func TestFindAllConfigsForPRClassifiesGitHubUnavailable(t *testing.T) {
+	client, mux := setupConfigTestGitHubServer(t)
+	mux.HandleFunc("GET /repos/octocat/hello-world/pulls/1", func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "service unavailable", http.StatusServiceUnavailable)
+	})
+
+	ic := NewInstallationClient(client, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	_, err := ic.FindAllConfigsForPR(t.Context(), "octocat/hello-world", 1)
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrGitHubUnavailable)
+}
+
+func TestFindAllConfigsForPRDoesNotClassifyRateLimitAsGitHubUnavailable(t *testing.T) {
+	client, mux := setupConfigTestGitHubServer(t)
+	mux.HandleFunc("GET /repos/octocat/hello-world/pulls/1", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("X-RateLimit-Remaining", "0")
+		w.WriteHeader(http.StatusForbidden)
+		_, err := w.Write([]byte(`{"message":"API rate limit exceeded"}`))
+		require.NoError(t, err)
+	})
+
+	ic := NewInstallationClient(client, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	_, err := ic.FindAllConfigsForPR(t.Context(), "octocat/hello-world", 1)
+	require.Error(t, err)
+	assert.False(t, errors.Is(err, ErrGitHubUnavailable))
+}
+
+func TestFindAllConfigsForPRDoesNotClassifyMissingConfigAsGitHubUnavailable(t *testing.T) {
+	client, mux := setupConfigTestGitHubServer(t)
+	mux.HandleFunc("GET /repos/octocat/hello-world/pulls/1", func(w http.ResponseWriter, _ *http.Request) {
+		require.NoError(t, json.NewEncoder(w).Encode(gh.PullRequest{
+			Head: &gh.PullRequestBranch{SHA: new("abc123")},
+		}))
+	})
+	mux.HandleFunc("GET /repos/octocat/hello-world/pulls/1/files", func(w http.ResponseWriter, _ *http.Request) {
+		require.NoError(t, json.NewEncoder(w).Encode([]*gh.CommitFile{{
+			Filename: new("schema/users.sql"),
+			Status:   new("modified"),
+		}}))
+	})
+	mux.HandleFunc("GET /repos/octocat/hello-world/contents/", func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	})
+
+	ic := NewInstallationClient(client, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	configs, err := ic.FindAllConfigsForPR(t.Context(), "octocat/hello-world", 1)
+	require.NoError(t, err)
+	assert.Empty(t, configs)
+}
+
+func setupConfigTestGitHubServer(t *testing.T) (*gh.Client, *http.ServeMux) {
+	t.Helper()
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	client := gh.NewClient(nil)
+	baseURL, err := url.Parse(server.URL + "/")
+	require.NoError(t, err)
+	client.BaseURL = baseURL
+
+	return client, mux
 }

--- a/pkg/github/schema.go
+++ b/pkg/github/schema.go
@@ -20,6 +20,7 @@ type SchemaRequestResult struct {
 	Repository   string
 	PullRequest  int
 	SchemaPath   string
+	HeadSHA      string // Commit SHA used to fetch schema files
 	Target       string // Opaque endpoint discovery identifier from config
 }
 
@@ -71,6 +72,7 @@ func (ic *InstallationClient) CreateSchemaRequestFromPR(ctx context.Context, rep
 		Repository:   repo,
 		PullRequest:  pr,
 		SchemaPath:   configDir,
+		HeadSHA:      prInfo.HeadSHA,
 		Target:       config.GetTarget(environment),
 	}, nil
 }

--- a/pkg/storage/mysqlstore/checks.go
+++ b/pkg/storage/mysqlstore/checks.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/block/schemabot/pkg/state"
 	"github.com/block/schemabot/pkg/storage"
 	"github.com/block/spirit/pkg/utils"
 )
@@ -139,12 +138,10 @@ func (s *checkStore) CompleteForApply(ctx context.Context, check *storage.Check,
 		      AND newer.database_type = checks.database_type
 		      AND newer.database_name = checks.database_name
 		      AND newer.id > ?
-		      AND newer.state NOT IN (?, ?, ?, ?, ?)
 		  )
 	`, check.HeadSHA, checkRunID, apply.ID, check.HasChanges, check.Status, check.Conclusion, check.BlockingReason, check.ErrorMessage,
 		check.Repository, check.PullRequest, check.Environment, check.DatabaseType, check.DatabaseName,
-		checkStatusInProgress, apply.ID,
-		apply.ID, state.Apply.Completed, state.Apply.Failed, state.Apply.Stopped, state.Apply.Cancelled, state.Apply.Reverted)
+		checkStatusInProgress, apply.ID, apply.ID)
 	if err != nil {
 		return false, err
 	}
@@ -157,7 +154,8 @@ func (s *checkStore) CompleteForApply(ctx context.Context, check *storage.Check,
 }
 
 // MarkActionRequiredForApply marks stored check state action_required after a
-// rollback only if it still belongs to that rollback apply.
+// rollback only if it still belongs to that rollback apply and no newer apply
+// exists for the same PR/environment/database.
 func (s *checkStore) MarkActionRequiredForApply(ctx context.Context, check *storage.Check, apply *storage.Apply) (bool, error) {
 	var checkRunID any
 	if check.CheckRunID != 0 {
@@ -186,11 +184,10 @@ func (s *checkStore) MarkActionRequiredForApply(ctx context.Context, check *stor
 		      AND newer.database_type = checks.database_type
 		      AND newer.database_name = checks.database_name
 		      AND newer.id > ?
-		      AND newer.state NOT IN (?, ?, ?, ?, ?)
 		  )
 	`, check.HeadSHA, checkRunID, check.HasChanges, check.Status, check.Conclusion, check.BlockingReason, check.ErrorMessage,
 		check.Repository, check.PullRequest, check.Environment, check.DatabaseType, check.DatabaseName,
-		apply.ID, apply.ID, state.Apply.Completed, state.Apply.Failed, state.Apply.Stopped, state.Apply.Cancelled, state.Apply.Reverted)
+		apply.ID, apply.ID)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/storage/mysqlstore/checks_test.go
+++ b/pkg/storage/mysqlstore/checks_test.go
@@ -564,6 +564,43 @@ func TestCheckStore_CompleteForApplySkipsNewerRunningApply(t *testing.T) {
 	require.Equal(t, oldApply.ID, retrieved.ApplyID)
 }
 
+func TestCheckStore_CompleteForApplySkipsNewerTerminalApply(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	oldApply := createCheckStoreApply(t, store, "apply-old-terminal", state.Apply.Completed)
+	newApply := createCheckStoreApply(t, store, "apply-new-terminal", state.Apply.Failed)
+	require.Greater(t, newApply.ID, oldApply.ID)
+
+	check := &storage.Check{
+		Repository:   "org/repo",
+		PullRequest:  123,
+		HeadSHA:      "abc123",
+		Environment:  "staging",
+		DatabaseType: "mysql",
+		DatabaseName: "testdb",
+		ApplyID:      oldApply.ID,
+		HasChanges:   true,
+		Status:       "in_progress",
+	}
+	require.NoError(t, store.Checks().Upsert(ctx, check))
+
+	check.Status = "completed"
+	check.Conclusion = "success"
+	check.HasChanges = false
+	updated, err := store.Checks().CompleteForApply(ctx, check, oldApply)
+	require.NoError(t, err)
+	require.False(t, updated)
+
+	retrieved, err := store.Checks().Get(ctx, "org/repo", 123, "staging", "mysql", "testdb")
+	require.NoError(t, err)
+	require.NotNil(t, retrieved)
+	require.Equal(t, "in_progress", retrieved.Status)
+	require.Empty(t, retrieved.Conclusion)
+	require.Equal(t, oldApply.ID, retrieved.ApplyID)
+}
+
 func TestCheckStore_CompleteForApplySkipsUnownedCheck(t *testing.T) {
 	clearTables(t)
 	ctx := t.Context()
@@ -641,6 +678,44 @@ func TestCheckStore_MarkActionRequiredForApplySkipsNewerRunningApply(t *testing.
 
 	rollbackApply := createCheckStoreApply(t, store, "rollback-complete-old", state.Apply.Completed)
 	newApply := createCheckStoreApply(t, store, "apply-running-new", state.Apply.Running)
+	require.Greater(t, newApply.ID, rollbackApply.ID)
+
+	check := &storage.Check{
+		Repository:   "org/repo",
+		PullRequest:  123,
+		HeadSHA:      "abc123",
+		Environment:  "staging",
+		DatabaseType: "mysql",
+		DatabaseName: "testdb",
+		ApplyID:      rollbackApply.ID,
+		HasChanges:   false,
+		Status:       "completed",
+		Conclusion:   "success",
+	}
+	require.NoError(t, store.Checks().Upsert(ctx, check))
+
+	check.HasChanges = true
+	check.Conclusion = "action_required"
+	updated, err := store.Checks().MarkActionRequiredForApply(ctx, check, rollbackApply)
+	require.NoError(t, err)
+	require.False(t, updated)
+
+	retrieved, err := store.Checks().Get(ctx, "org/repo", 123, "staging", "mysql", "testdb")
+	require.NoError(t, err)
+	require.NotNil(t, retrieved)
+	require.Equal(t, "completed", retrieved.Status)
+	require.Equal(t, "success", retrieved.Conclusion)
+	require.False(t, retrieved.HasChanges)
+	require.Equal(t, rollbackApply.ID, retrieved.ApplyID)
+}
+
+func TestCheckStore_MarkActionRequiredForApplySkipsNewerTerminalApply(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	rollbackApply := createCheckStoreApply(t, store, "rollback-complete-old", state.Apply.Completed)
+	newApply := createCheckStoreApply(t, store, "apply-terminal-new", state.Apply.Failed)
 	require.Greater(t, newApply.ID, rollbackApply.ID)
 
 	check := &storage.Check{

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -84,15 +84,15 @@ type CheckStore interface {
 	UpsertPlanResult(ctx context.Context, check *Check) error
 
 	// CompleteForApply updates stored check state to a terminal state only if
-	// it still belongs to the given apply and no newer non-terminal apply exists
-	// for the same PR/environment/database. Returns false when another worker
-	// changed the stored state first.
+	// it still belongs to the given apply and no newer apply exists for the
+	// same PR/environment/database. Returns false when another worker changed
+	// the stored state first.
 	CompleteForApply(ctx context.Context, check *Check, apply *Apply) (bool, error)
 
 	// MarkActionRequiredForApply marks stored check state action_required after
 	// a rollback only if it still belongs to that rollback apply and no newer
-	// non-terminal apply exists for the same PR/environment/database. Returns
-	// false when another worker changed the stored state first.
+	// apply exists for the same PR/environment/database. Returns false when
+	// another worker changed the stored state first.
 	MarkActionRequiredForApply(ctx context.Context, check *Check, apply *Apply) (bool, error)
 
 	// Get returns stored check state by its unique key (PR + env + database), or nil if not found.

--- a/pkg/webhook/check_runs.go
+++ b/pkg/webhook/check_runs.go
@@ -66,6 +66,24 @@ var rollbackCompletedBlock = checkBlockReason{
 	message:        "Schema changes were rolled back in this environment; apply again before this check can pass.",
 }
 
+// githubConfigDiscoveryUnavailableBlock is used when GitHub is unavailable
+// while SchemaBot is discovering which managed schema changes exist. The
+// aggregate check must fail closed until SchemaBot can read PR metadata and
+// repository contents.
+var githubConfigDiscoveryUnavailableBlock = checkBlockReason{
+	blockingReason: "github_schema_config_discovery_unavailable",
+	message:        "SchemaBot failed this check closed because GitHub was unavailable while inspecting the PR schema files. Retry the check.",
+}
+
+// configDiscoveryFailedBlock is used when SchemaBot cannot inspect PR schema
+// files well enough to know which managed schema changes exist for a reason
+// other than GitHub availability. The aggregate check must fail closed until
+// SchemaBot can determine the managed schema configuration.
+var configDiscoveryFailedBlock = checkBlockReason{
+	blockingReason: "schema_config_discovery_failed",
+	message:        "SchemaBot failed this check closed because it could not determine the managed schema configuration for this PR. Review the SchemaBot configuration and retry the check.",
+}
+
 // aggregateCheckNameForEnv returns the environment-scoped aggregate check name.
 // e.g., "SchemaBot (staging)" or "SchemaBot (production)".
 func aggregateCheckNameForEnv(env string) string {
@@ -132,11 +150,45 @@ func hasBlockingCheckForEnvironment(checks []*storage.Check, environment string)
 // storePlanCheckRecord stores per-database check state after a plan is generated.
 // The state is used internally by the aggregate check to compute its overall status.
 // No per-database GitHub Check Run is created — only the aggregate is visible on the PR.
-// Returns the latest commit SHA on the PR branch. Failures are non-fatal.
+// Returns the commit SHA used for the plan. Failures are non-fatal.
 func (h *Handler) storePlanCheckRecord(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, schema *ghclient.SchemaRequestResult, planResp *apitypes.PlanResponse, environment string) (string, error) {
+	headSHA := schema.HeadSHA
+	if headSHA == "" {
+		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
+			Operation:    "plan_check_recorded",
+			Repository:   repo,
+			Database:     schema.Database,
+			DatabaseType: schema.Type,
+			Environment:  environment,
+			Status:       "error",
+		})
+		return "", fmt.Errorf("schema request missing head SHA for stored check state repo %s pr %d environment %s database_type %s database %s",
+			repo, pr, environment, schema.Type, schema.Database)
+	}
+
 	prInfo, err := client.FetchPullRequest(ctx, repo, pr)
 	if err != nil {
+		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
+			Operation:    "plan_check_recorded",
+			Repository:   repo,
+			Database:     schema.Database,
+			DatabaseType: schema.Type,
+			Environment:  environment,
+			Status:       "error",
+		})
 		return "", fmt.Errorf("fetch PR for stored check state: %w", err)
+	}
+	if prInfo.HeadSHA != headSHA {
+		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
+			Operation:    "plan_check_recorded",
+			Repository:   repo,
+			Database:     schema.Database,
+			DatabaseType: schema.Type,
+			Environment:  environment,
+			Status:       "stale",
+		})
+		return headSHA, fmt.Errorf("skip stale plan check record for repo %s pr %d environment %s database_type %s database %s: plan head SHA %s no longer matches current head SHA for PR %s",
+			repo, pr, environment, schema.Type, schema.Database, headSHA, prInfo.HeadSHA)
 	}
 
 	tables := planResp.FlatTables()
@@ -155,7 +207,7 @@ func (h *Handler) storePlanCheckRecord(ctx context.Context, client *ghclient.Ins
 	check := &storage.Check{
 		Repository:   repo,
 		PullRequest:  pr,
-		HeadSHA:      prInfo.HeadSHA,
+		HeadSHA:      headSHA,
 		Environment:  environment,
 		DatabaseType: schema.Type,
 		DatabaseName: schema.Database,
@@ -164,10 +216,26 @@ func (h *Handler) storePlanCheckRecord(ctx context.Context, client *ghclient.Ins
 		Conclusion:   conclusion,
 	}
 	if err := h.service.Storage().Checks().UpsertPlanResult(ctx, check); err != nil {
-		return prInfo.HeadSHA, fmt.Errorf("store check state: %w", err)
+		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
+			Operation:    "plan_check_recorded",
+			Repository:   repo,
+			Database:     schema.Database,
+			DatabaseType: schema.Type,
+			Environment:  environment,
+			Status:       "error",
+		})
+		return headSHA, fmt.Errorf("store check state: %w", err)
 	}
 
-	return prInfo.HeadSHA, nil
+	metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
+		Operation:    "plan_check_recorded",
+		Repository:   repo,
+		Database:     schema.Database,
+		DatabaseType: schema.Type,
+		Environment:  environment,
+		Status:       "success",
+	})
+	return headSHA, nil
 }
 
 type applyCheckKey struct {
@@ -207,11 +275,21 @@ func isApplyNewer(candidate, existing *storage.Apply) bool {
 func (h *Handler) reconcileStaleChecks(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int) error {
 	checks, err := h.service.Storage().Checks().GetByPR(ctx, repo, pr)
 	if err != nil {
+		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
+			Operation:  "stale_check_reconciliation",
+			Repository: repo,
+			Status:     "error",
+		})
 		return fmt.Errorf("fetch checks for stale reconciliation repo %s pr %d: %w", repo, pr, err)
 	}
 
 	applies, err := h.service.Storage().Applies().GetByPR(ctx, repo, pr)
 	if err != nil {
+		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
+			Operation:  "stale_check_reconciliation",
+			Repository: repo,
+			Status:     "error",
+		})
 		return fmt.Errorf("look up applies for stale checks repo %s pr %d: %w", repo, pr, err)
 	}
 	latestApplies := latestApplyByCheckKey(applies)
@@ -260,19 +338,45 @@ func (h *Handler) reconcileStaleChecks(ctx context.Context, client *ghclient.Ins
 
 		updated, err := h.updateCheckRecordForApplyResult(ctx, repo, pr, apply)
 		if err != nil {
+			metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
+				Operation:    "stale_check_reconciliation",
+				Repository:   repo,
+				Database:     check.DatabaseName,
+				DatabaseType: check.DatabaseType,
+				Environment:  check.Environment,
+				Status:       "error",
+			})
 			return err
 		}
 		if updated {
+			metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
+				Operation:    "stale_check_reconciliation",
+				Repository:   repo,
+				Database:     check.DatabaseName,
+				DatabaseType: check.DatabaseType,
+				Environment:  check.Environment,
+				Status:       "success",
+			})
 			reconciled = true
 		}
 	}
 
 	if !reconciled {
+		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
+			Operation:  "stale_check_reconciliation",
+			Repository: repo,
+			Status:     "noop",
+		})
 		return nil
 	}
 
 	prInfo, err := client.FetchPullRequest(ctx, repo, pr)
 	if err != nil {
+		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
+			Operation:  "stale_check_reconciliation",
+			Repository: repo,
+			Status:     "error",
+		})
 		return fmt.Errorf("fetch latest PR commit SHA for stale reconciliation aggregate repo %s pr %d: %w", repo, pr, err)
 	}
 	if prInfo.HeadSHA != "" {
@@ -287,10 +391,26 @@ func (h *Handler) reconcileStaleChecks(ctx context.Context, client *ghclient.Ins
 func (h *Handler) updateCheckRecordForApplyResult(ctx context.Context, repo string, pr int, apply *storage.Apply) (bool, error) {
 	check, err := h.service.Storage().Checks().Get(ctx, repo, pr, apply.Environment, apply.DatabaseType, apply.Database)
 	if err != nil {
+		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
+			Operation:    "apply_finished",
+			Repository:   repo,
+			Database:     apply.Database,
+			DatabaseType: apply.DatabaseType,
+			Environment:  apply.Environment,
+			Status:       "error",
+		})
 		return false, fmt.Errorf("look up check for apply result repo %s pr %d environment %s database_type %s database %s: %w",
 			repo, pr, apply.Environment, apply.DatabaseType, apply.Database, err)
 	}
 	if check == nil {
+		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
+			Operation:    "apply_finished",
+			Repository:   repo,
+			Database:     apply.Database,
+			DatabaseType: apply.DatabaseType,
+			Environment:  apply.Environment,
+			Status:       "error",
+		})
 		return false, fmt.Errorf("no stored check state found to update after apply repo %s pr %d environment %s database_type %s database %s",
 			repo, pr, apply.Environment, apply.DatabaseType, apply.Database)
 	}
@@ -310,13 +430,33 @@ func (h *Handler) updateCheckRecordForApplyResult(ctx context.Context, repo stri
 	check.Status = checkStatusCompleted
 	check.Conclusion = conclusion
 	check.HasChanges = conclusion != checkConclusionSuccess
+	if conclusion == checkConclusionSuccess {
+		check.BlockingReason = ""
+		check.ErrorMessage = ""
+	}
 	updated, err := h.service.Storage().Checks().CompleteForApply(ctx, check, apply)
 	if err != nil {
+		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
+			Operation:    "apply_finished",
+			Repository:   repo,
+			Database:     apply.Database,
+			DatabaseType: apply.DatabaseType,
+			Environment:  apply.Environment,
+			Status:       "error",
+		})
 		return false, fmt.Errorf("update stored check state after apply repo %s pr %d environment %s database_type %s database %s: %w",
 			repo, pr, apply.Environment, apply.DatabaseType, apply.Database, err)
 	}
 	if !updated {
 		metrics.RecordCheckOwnershipMiss(ctx, "apply_finished", repo, apply.Database, apply.DatabaseType, apply.Environment)
+		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
+			Operation:    "apply_finished",
+			Repository:   repo,
+			Database:     apply.Database,
+			DatabaseType: apply.DatabaseType,
+			Environment:  apply.Environment,
+			Status:       "skipped",
+		})
 		h.logger.Warn("skipping check state update because stored state no longer belongs to apply",
 			"repo", repo, "pr", pr, "database", apply.Database,
 			"database_type", apply.DatabaseType, "environment", apply.Environment,
@@ -332,6 +472,14 @@ func (h *Handler) updateCheckRecordForApplyResult(ctx context.Context, repo stri
 		"apply_id", apply.ID, "apply_identifier", apply.ApplyIdentifier,
 		"apply_state", apply.State, "conclusion", conclusion,
 		"blocking_reason", check.BlockingReason)
+	metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
+		Operation:    "apply_finished",
+		Repository:   repo,
+		Database:     apply.Database,
+		DatabaseType: apply.DatabaseType,
+		Environment:  apply.Environment,
+		Status:       "success",
+	})
 	return true, nil
 }
 
@@ -343,6 +491,14 @@ func (h *Handler) setCheckActionRequired(repo string, pr int, installationID int
 
 	check, err := h.service.Storage().Checks().Get(ctx, repo, pr, apply.Environment, apply.DatabaseType, apply.Database)
 	if err != nil {
+		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
+			Operation:    "rollback_finished",
+			Repository:   repo,
+			Database:     apply.Database,
+			DatabaseType: apply.DatabaseType,
+			Environment:  apply.Environment,
+			Status:       "error",
+		})
 		h.logger.Error("failed to look up stored check state after rollback",
 			"repo", repo, "pr", pr, "database", apply.Database,
 			"database_type", apply.DatabaseType, "environment", apply.Environment,
@@ -351,6 +507,14 @@ func (h *Handler) setCheckActionRequired(repo string, pr int, installationID int
 		return
 	}
 	if check == nil {
+		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
+			Operation:    "rollback_finished",
+			Repository:   repo,
+			Database:     apply.Database,
+			DatabaseType: apply.DatabaseType,
+			Environment:  apply.Environment,
+			Status:       "error",
+		})
 		h.logger.Warn("no stored check state to update after rollback",
 			"repo", repo, "pr", pr, "database", apply.Database,
 			"database_type", apply.DatabaseType, "environment", apply.Environment,
@@ -365,6 +529,14 @@ func (h *Handler) setCheckActionRequired(repo string, pr int, installationID int
 	check.ErrorMessage = rollbackCompletedBlock.message
 	updated, err := h.service.Storage().Checks().MarkActionRequiredForApply(ctx, check, apply)
 	if err != nil {
+		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
+			Operation:    "rollback_finished",
+			Repository:   repo,
+			Database:     apply.Database,
+			DatabaseType: apply.DatabaseType,
+			Environment:  apply.Environment,
+			Status:       "error",
+		})
 		h.logger.Error("failed to set check to action_required after rollback",
 			"repo", repo, "pr", pr, "database", apply.Database,
 			"database_type", apply.DatabaseType, "environment", apply.Environment,
@@ -375,6 +547,14 @@ func (h *Handler) setCheckActionRequired(repo string, pr int, installationID int
 	}
 	if !updated {
 		metrics.RecordCheckOwnershipMiss(ctx, "rollback_finished", repo, apply.Database, apply.DatabaseType, apply.Environment)
+		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
+			Operation:    "rollback_finished",
+			Repository:   repo,
+			Database:     apply.Database,
+			DatabaseType: apply.DatabaseType,
+			Environment:  apply.Environment,
+			Status:       "skipped",
+		})
 		h.logger.Warn("skipping rollback action_required update because check no longer belongs to apply",
 			"repo", repo, "pr", pr, "database", apply.Database,
 			"database_type", apply.DatabaseType, "environment", apply.Environment,
@@ -389,10 +569,24 @@ func (h *Handler) setCheckActionRequired(repo string, pr int, installationID int
 		"database_type", apply.DatabaseType, "environment", apply.Environment,
 		"apply_id", apply.ID, "apply_identifier", apply.ApplyIdentifier,
 		"apply_state", apply.State)
+	metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
+		Operation:    "rollback_finished",
+		Repository:   repo,
+		Database:     apply.Database,
+		DatabaseType: apply.DatabaseType,
+		Environment:  apply.Environment,
+		Status:       "success",
+	})
 
 	// Update the aggregate check to reflect the rollback
 	if aggClient, err := h.ghClient.ForInstallation(installationID); err == nil {
 		h.updateAggregateCheck(ctx, aggClient, repo, pr, check.HeadSHA)
+	} else {
+		h.logger.Error("failed to create GitHub client for rollback aggregate update",
+			"repo", repo, "pr", pr, "database", apply.Database,
+			"database_type", apply.DatabaseType, "environment", apply.Environment,
+			"apply_id", apply.ID, "apply_identifier", apply.ApplyIdentifier,
+			"error", err)
 	}
 }
 
@@ -460,19 +654,32 @@ func (h *Handler) checkPriorEnvViaLocal(
 	check, err := h.service.Storage().Checks().Get(ctx, repo, pr, priorEnv, dbType, database)
 	if err != nil {
 		h.logger.Error("failed to look up prior environment check",
-			"environment", priorEnv, "error", err)
-		// Graceful degradation: allow proceed if check lookup fails
-		return false
+			"repo", repo, "pr", pr,
+			"database", database, "database_type", dbType,
+			"environment", environment, "prior_environment", priorEnv,
+			"error", err)
+		h.postComment(repo, pr, installationID,
+			templates.RenderApplyBlockedByPriorEnvCheckError(priorEnv, "read SchemaBot storage", err))
+		return true
 	}
 
 	if check == nil {
 		// No check exists for this prior environment — it may not have changes.
 		// This is OK (e.g., staging has no changes but production does).
+		h.logger.Debug("no prior environment check found, allowing apply",
+			"repo", repo, "pr", pr,
+			"database", database, "database_type", dbType,
+			"environment", environment, "prior_environment", priorEnv)
 		return false
 	}
 
 	switch {
 	case check.Conclusion == checkConclusionSuccess:
+		h.logger.Debug("prior environment check passed, allowing apply",
+			"repo", repo, "pr", pr,
+			"database", database, "database_type", dbType,
+			"environment", environment, "prior_environment", priorEnv,
+			"check_status", check.Status, "check_conclusion", check.Conclusion)
 		return false
 	case check.Status == checkStatusInProgress:
 		h.postComment(repo, pr, installationID,
@@ -569,6 +776,46 @@ func (h *Handler) checkPriorEnvViaGitHub(
 	}
 }
 
+// verifyHeadSHAStillCurrentForPR returns false when writing status check state
+// for headSHA would be unsafe because the PR now points at a different commit
+// SHA. It records a metric and logs the reason before every false return so
+// callers can stop without adding duplicate log noise.
+func (h *Handler) verifyHeadSHAStillCurrentForPR(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, headSHA, operation string) bool {
+	if headSHA == "" {
+		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
+			Operation:  operation,
+			Repository: repo,
+			Status:     "error",
+		})
+		h.logger.Error("refusing to update status check without head SHA", "repo", repo, "pr", pr, "operation", operation)
+		return false
+	}
+
+	prInfo, err := client.FetchPullRequest(ctx, repo, pr)
+	if err != nil {
+		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
+			Operation:  operation,
+			Repository: repo,
+			Status:     "error",
+		})
+		h.logger.Error("failed to verify status check head SHA before update",
+			"repo", repo, "pr", pr, "head_sha", headSHA, "operation", operation, "error", err)
+		return false
+	}
+	if prInfo.HeadSHA != headSHA {
+		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
+			Operation:  operation,
+			Repository: repo,
+			Status:     "stale",
+		})
+		h.logger.Info("skipping stale status check update because head SHA is no longer current for PR",
+			"repo", repo, "pr", pr, "operation", operation,
+			"stale_head_sha", headSHA, "current_head_sha", prInfo.HeadSHA)
+		return false
+	}
+	return true
+}
+
 // updateAggregateCheck recomputes and creates/updates aggregate check runs that roll
 // up per-database checks for a PR.
 //
@@ -578,7 +825,7 @@ func (h *Handler) checkPriorEnvViaGitHub(
 // conflicting with each other.
 //
 // When allowed_environments is NOT configured, a single "SchemaBot" aggregate is
-// created that rolls up all per-database checks (backwards compatible).
+// created that rolls up all per-database checks.
 //
 // Aggregate logic (first match wins):
 //   - ANY check "in_progress"     → aggregate status "in_progress"
@@ -587,8 +834,17 @@ func (h *Handler) checkPriorEnvViaGitHub(
 //   - ALL checks "success"        → aggregate "success"
 //   - NO per-database checks      → no aggregate (PR doesn't touch schema)
 func (h *Handler) updateAggregateCheck(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, headSHA string) {
+	if !h.verifyHeadSHAStillCurrentForPR(ctx, client, repo, pr, headSHA, "aggregate_check_sync") {
+		return
+	}
+
 	checks, err := h.service.Storage().Checks().GetByPR(ctx, repo, pr)
 	if err != nil {
+		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
+			Operation:  "aggregate_check_sync",
+			Repository: repo,
+			Status:     "error",
+		})
 		h.logger.Error("failed to fetch checks for aggregate", "repo", repo, "pr", pr, "error", err)
 		return
 	}
@@ -604,6 +860,11 @@ func (h *Handler) updateAggregateCheck(ctx context.Context, client *ghclient.Ins
 	// No per-database checks means the PR doesn't touch schema files (or all check
 	// records were already deleted by PR close cleanup). No aggregate to create.
 	if len(dbChecks) == 0 {
+		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
+			Operation:  "aggregate_check_sync",
+			Repository: repo,
+			Status:     "noop",
+		})
 		h.logger.Debug("no per-database checks for aggregate", "repo", repo, "pr", pr)
 		return
 	}
@@ -623,8 +884,8 @@ func (h *Handler) updateAggregateCheck(ctx context.Context, client *ghclient.Ins
 			h.upsertAggregateCheckRun(ctx, client, repo, pr, headSHA, envChecks, checkName, env)
 		}
 	} else {
-		// Single aggregate: backwards-compatible behavior. Uses aggregateSentinel
-		// for the environment field since there is no per-environment scoping.
+		// Single aggregate. Uses aggregateSentinel for the environment field
+		// since there is no per-environment scoping.
 		h.upsertAggregateCheckRun(ctx, client, repo, pr, headSHA, dbChecks, aggregateCheckName, aggregateSentinel)
 	}
 }
@@ -759,6 +1020,10 @@ func (h *Handler) upsertAggregateCheckRun(
 // check that would never come. It does not publish success over existing
 // per-database state that still needs operator attention.
 func (h *Handler) postPassingAggregates(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, headSHA, title, summary string) {
+	if !h.verifyHeadSHAStillCurrentForPR(ctx, client, repo, pr, headSHA, "aggregate_check_sync") {
+		return
+	}
+
 	config := h.service.Config()
 	storedChecks, err := h.service.Storage().Checks().GetByPR(ctx, repo, pr)
 	if err != nil {
@@ -920,6 +1185,16 @@ func (h *Handler) postPassingAggregates(ctx context.Context, client *ghclient.In
 // that has errors. Called when all environments fail during planning so branch
 // protection shows a clear failure instead of waiting indefinitely.
 func (h *Handler) postFailingAggregates(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, headSHA string, errors map[string]string) {
+	h.postFailingAggregatesWithBlock(ctx, client, repo, pr, headSHA, errors, checkBlockReason{})
+}
+
+// postFailingAggregatesWithBlock stores a blocking reason only for callers with
+// a stable failure class. Generic plan errors should use postFailingAggregates.
+func (h *Handler) postFailingAggregatesWithBlock(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, headSHA string, errors map[string]string, block checkBlockReason) {
+	if !h.verifyHeadSHAStillCurrentForPR(ctx, client, repo, pr, headSHA, "aggregate_check_sync") {
+		return
+	}
+
 	config := h.service.Config()
 
 	type envCheck struct {
@@ -942,6 +1217,16 @@ func (h *Handler) postFailingAggregates(ctx context.Context, client *ghclient.In
 			name:        aggregateCheckName,
 			environment: aggregateSentinel,
 		})
+	}
+
+	if len(checks) == 0 {
+		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
+			Operation:  "aggregate_check_sync",
+			Repository: repo,
+			Status:     "noop",
+		})
+		h.logger.Debug("no failing aggregate checks to post", "repo", repo, "pr", pr)
+		return
 	}
 
 	for _, ec := range checks {
@@ -969,6 +1254,12 @@ func (h *Handler) postFailingAggregates(ctx context.Context, client *ghclient.In
 
 		id, err := client.CreateCheckRun(ctx, repo, headSHA, opts)
 		if err != nil {
+			metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
+				Operation:   "aggregate_check_sync",
+				Repository:  repo,
+				Environment: ec.environment,
+				Status:      "error",
+			})
 			h.logger.Error("failed to create failing aggregate", "repo", repo, "pr", pr, "error", err)
 			continue
 		}
@@ -985,10 +1276,27 @@ func (h *Handler) postFailingAggregates(ctx context.Context, client *ghclient.In
 			Status:       checkStatusCompleted,
 			Conclusion:   checkConclusionFailure,
 		}
+		if block.blockingReason != "" {
+			aggCheck.BlockingReason = block.blockingReason
+			aggCheck.ErrorMessage = summary
+		}
 		if err := h.service.Storage().Checks().Upsert(ctx, aggCheck); err != nil {
+			metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
+				Operation:   "aggregate_check_sync",
+				Repository:  repo,
+				Environment: ec.environment,
+				Status:      "error",
+			})
 			h.logger.Error("failed to store failing aggregate check", "error", err)
+			continue
 		}
 
+		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
+			Operation:   "aggregate_check_sync",
+			Repository:  repo,
+			Environment: ec.environment,
+			Status:      "success",
+		})
 		h.logger.Info("posted failing aggregate",
 			"repo", repo, "pr", pr, "check_name", ec.name, "env", ec.environment)
 	}

--- a/pkg/webhook/check_runs_test.go
+++ b/pkg/webhook/check_runs_test.go
@@ -3,12 +3,16 @@ package webhook
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/block/spirit/pkg/utils"
 
 	"github.com/block/schemabot/pkg/api"
 	ghclient "github.com/block/schemabot/pkg/github"
@@ -42,6 +46,26 @@ type emptyApplyStore struct {
 
 func (s *emptyApplyStore) GetByPR(ctx context.Context, repo string, pr int) ([]*storage.Apply, error) {
 	return nil, nil
+}
+
+type failingStorage struct {
+	emptyStorage
+}
+
+func (s *failingStorage) Close() error {
+	return nil
+}
+
+func (s *failingStorage) Checks() storage.CheckStore {
+	return &failingCheckStore{}
+}
+
+type failingCheckStore struct {
+	storage.CheckStore
+}
+
+func (s *failingCheckStore) Get(ctx context.Context, repo string, pr int, environment, dbType, database string) (*storage.Check, error) {
+	return nil, errors.New("storage read failed")
 }
 
 func TestComputeAggregate(t *testing.T) {
@@ -113,6 +137,47 @@ func TestComputeAggregate(t *testing.T) {
 			assert.Equal(t, tt.wantConclusion, conclusion)
 			assert.Equal(t, tt.wantStatus, status)
 		})
+	}
+}
+
+func TestCheckPriorEnvViaLocalFailsClosedOnStorageError(t *testing.T) {
+	const (
+		repo = "octocat/hello-world"
+		pr   = 1
+	)
+
+	client, mux := setupGitHubServer(t)
+	comments := make(chan string, 1)
+	mux.HandleFunc("POST /repos/octocat/hello-world/issues/1/comments", func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Body string `json:"body"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		comments <- body.Body
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": 99})
+	})
+
+	installClient := ghclient.NewInstallationClient(client, testLogger())
+	service := api.New(&failingStorage{}, &api.ServerConfig{}, nil, testLogger())
+	t.Cleanup(func() { utils.CloseAndLog(service) })
+
+	h := &Handler{
+		service:  service,
+		ghClient: &fakeClientFactory{client: installClient},
+		logger:   testLogger(),
+	}
+
+	blocked := h.checkPriorEnvViaLocal(t.Context(), repo, pr, "orders", "mysql", "production", "staging", 12345)
+	assert.True(t, blocked, "storage read failure should block apply")
+
+	select {
+	case body := <-comments:
+		assert.Contains(t, body, "Apply Blocked")
+		assert.Contains(t, body, "Could not verify staging status")
+		assert.Contains(t, body, "storage read failed")
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for fail-closed comment")
 	}
 }
 

--- a/pkg/webhook/pull_request.go
+++ b/pkg/webhook/pull_request.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"time"
 
+	ghclient "github.com/block/schemabot/pkg/github"
 	"github.com/block/schemabot/pkg/metrics"
 	"github.com/block/schemabot/pkg/storage"
 )
@@ -65,6 +66,7 @@ func (h *Handler) handlePullRequest(w http.ResponseWriter, body []byte) {
 
 	repo := payload.Repository.FullName
 	pr := payload.PullRequest.Number
+	headSHA := payload.PullRequest.Head.SHA
 
 	// Reject webhooks from repositories not in the configured allowlist
 	if h.service != nil && !h.service.Config().IsRepoAllowed(repo) {
@@ -79,7 +81,7 @@ func (h *Handler) handlePullRequest(w http.ResponseWriter, body []byte) {
 		"action", payload.Action,
 		"repo", repo,
 		"pr", pr,
-		"head_sha", payload.PullRequest.Head.SHA,
+		"head_sha", headSHA,
 	)
 
 	// Discover all configs matching changed schema files in this PR
@@ -96,6 +98,7 @@ func (h *Handler) handlePullRequest(w http.ResponseWriter, body []byte) {
 	configs, err := client.FindAllConfigsForPR(ctx, repo, pr)
 	if err != nil {
 		h.logger.Error("failed to discover configs for PR", "repo", repo, "pr", pr, "error", err)
+		h.postConfigDiscoveryFailure(ctx, client, repo, pr, headSHA, err)
 		h.writeJSON(w, http.StatusOK, map[string]string{"message": "config discovery failed"})
 		return
 	}
@@ -108,7 +111,6 @@ func (h *Handler) handlePullRequest(w http.ResponseWriter, body []byte) {
 
 	// Clean up stale checks from databases no longer in the PR.
 	// Pass the new HEAD SHA so cleanup can create new check runs on the correct commit.
-	headSHA := payload.PullRequest.Head.SHA
 	h.goSafe(repo, pr, installationID, func() {
 		h.cleanupStaleChecks(repo, pr, headSHA, installationID, affectedDatabases)
 	})
@@ -146,6 +148,37 @@ func (h *Handler) handlePullRequest(w http.ResponseWriter, body []byte) {
 	}
 
 	h.writeJSON(w, http.StatusOK, map[string]string{"message": "auto-plan started"})
+}
+
+func (h *Handler) postConfigDiscoveryFailure(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, headSHA string, discoveryErr error) {
+	metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
+		Operation:  "schema_config_discovery",
+		Repository: repo,
+		Status:     "error",
+	})
+
+	block := configDiscoveryFailedBlock
+	if ghclient.IsUnavailableError(discoveryErr) {
+		block = githubConfigDiscoveryUnavailableBlock
+	}
+	h.logger.Info("posting failing aggregate for config discovery failure",
+		"repo", repo, "pr", pr, "head_sha", headSHA,
+		"blocking_reason", block.blockingReason)
+	h.postFailingAggregatesWithBlock(ctx, client, repo, pr, headSHA,
+		h.aggregateMessagesForAllEnvironments(block.message), block)
+}
+
+func (h *Handler) aggregateMessagesForAllEnvironments(message string) map[string]string {
+	allowed := h.service.Config().AllowedEnvironments
+	if len(allowed) == 0 {
+		return map[string]string{aggregateSentinel: message}
+	}
+
+	messages := make(map[string]string, len(allowed))
+	for _, env := range allowed {
+		messages[env] = message
+	}
+	return messages
 }
 
 // handlePRClosed cleans up resources when a PR is closed (merged or unmerged).
@@ -187,8 +220,11 @@ func (h *Handler) handlePRClosed(repo string, pr int, _ int64) {
 // as new check runs on this SHA (not updated on the old SHA) so GitHub shows them
 // on the current commit.
 func (h *Handler) cleanupStaleChecks(repo string, pr int, headSHA string, installationID int64, affectedDatabases map[string]bool) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
 	if h.service == nil {
-		metrics.RecordStatusCheckOperation(context.Background(), metrics.StatusCheckOperation{
+		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
 			Operation:  "stale_check_cleanup",
 			Repository: repo,
 			Status:     "error",
@@ -196,9 +232,29 @@ func (h *Handler) cleanupStaleChecks(repo string, pr int, headSHA string, instal
 		h.logger.Error("cannot clean up stale checks without service", "repo", repo, "pr", pr, "head_sha", headSHA)
 		return
 	}
+	if h.service.Storage() == nil {
+		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
+			Operation:  "stale_check_cleanup",
+			Repository: repo,
+			Status:     "error",
+		})
+		h.logger.Error("cannot clean up stale checks without storage", "repo", repo, "pr", pr, "head_sha", headSHA)
+		return
+	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
+	client, clientErr := h.ghClient.ForInstallation(installationID)
+	if clientErr != nil {
+		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
+			Operation:  "stale_check_cleanup",
+			Repository: repo,
+			Status:     "error",
+		})
+		h.logger.Error("failed to create GitHub client for stale cleanup", "repo", repo, "pr", pr, "head_sha", headSHA, "error", clientErr)
+		return
+	}
+	if !h.verifyHeadSHAStillCurrentForPR(ctx, client, repo, pr, headSHA, "stale_check_cleanup") {
+		return
+	}
 
 	checks, err := h.service.Storage().Checks().GetByPR(ctx, repo, pr)
 	if err != nil {
@@ -251,18 +307,13 @@ func (h *Handler) cleanupStaleChecks(repo string, pr int, headSHA string, instal
 
 	// Recompute aggregate on the new HEAD SHA after cleaning up stale checks
 	if cleaned {
-		client, clientErr := h.ghClient.ForInstallation(installationID)
-		if clientErr != nil {
-			metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
-				Operation:  "aggregate_check_sync",
-				Repository: repo,
-				Status:     "error",
-			})
-			h.logger.Error("failed to create GitHub client for aggregate update after stale cleanup",
-				"repo", repo, "pr", pr, "head_sha", headSHA, "error", clientErr)
-			return
-		}
 		h.updateAggregateCheck(ctx, client, repo, pr, headSHA)
+	} else {
+		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
+			Operation:  "stale_check_cleanup",
+			Repository: repo,
+			Status:     "noop",
+		})
 	}
 }
 

--- a/pkg/webhook/webhook_e2e_test.go
+++ b/pkg/webhook/webhook_e2e_test.go
@@ -2737,10 +2737,15 @@ func TestE2EPassingAggregateSynchronizeUpdatesNewSHA(t *testing.T) {
 	client := gh.NewClient(nil)
 	client.BaseURL, _ = url.Parse(server.URL + "/")
 
-	// PR info
+	var currentHead atomic.Value
+	currentHead.Store("sha1aaa")
+
+	// PR info. This endpoint represents the current head SHA for the PR, so
+	// update it before sending each webhook event.
 	mux.HandleFunc("GET /repos/octocat/hello-world/pulls/1", func(w http.ResponseWriter, _ *http.Request) {
+		headSHA := currentHead.Load().(string)
 		_ = json.NewEncoder(w).Encode(gh.PullRequest{
-			Head: &gh.PullRequestBranch{Ref: new("feature-branch"), SHA: new("sha1aaa")},
+			Head: &gh.PullRequestBranch{Ref: new("feature-branch"), SHA: &headSHA},
 			Base: &gh.PullRequestBranch{Ref: new("main"), SHA: new("def456")},
 			User: &gh.User{Login: new("testuser")},
 		})
@@ -2799,6 +2804,7 @@ func TestE2EPassingAggregateSynchronizeUpdatesNewSHA(t *testing.T) {
 	}
 
 	// Step 2: synchronize with sha2 (force push)
+	currentHead.Store("sha2bbb")
 	req = buildPRWebhookRequest(t, prWebhookPayloadOpts{
 		action:  "synchronize",
 		headSHA: "sha2bbb",


### PR DESCRIPTION
## Summary

Part 1 of the fail-closed status-check split. This PR makes SchemaBot conservative about merge-gating status: it only publishes or updates Check Runs when it can prove the status belongs to the current PR commit and current stored apply state.

1. **Schema planning is tied to the commit that SchemaBot inspected.** SchemaBot records the commit SHA used to read schema files, then refuses to store plan-derived check state if the PR branch moved before the check update.

2. **Aggregate Check Runs are only written for the current PR commit.** Before publishing passing, failing, or recomputed aggregate checks, SchemaBot verifies that the SHA it is about to update is still the current head SHA for the PR.

3. **Config discovery failures now block the PR explicitly.** If SchemaBot cannot inspect schema config or schema files, it posts a failing aggregate check instead of leaving branch protection waiting or accidentally allowing the PR through. GitHub availability failures get a separate message from generic config discovery failures.

4. **Prior-environment storage errors now fail closed.** If SchemaBot cannot read stored check state to verify that an earlier environment passed, it blocks the apply instead of assuming it is safe to continue.

5. **Older apply and rollback completions cannot overwrite newer check state.** Stored check-state updates now require the completing apply to still own the check state, and they refuse to write when a newer apply exists for the same repo, PR, environment, and database.

6. **Stale-check cleanup is safer on new commits.** Cleanup now verifies the current PR commit before mutating stored check state or recomputing aggregates, so a stale webhook cannot publish status onto the wrong commit.

7. **The critical paths now have clearer logs, metrics, and tests.** The PR adds observability for status-check operations, stale skips, ownership misses, config discovery failures, and storage errors, plus focused unit and storage coverage for the new fail-closed behavior.

Follow-up: #117 contains the apply/rollback handler changes and heavier webhook integration coverage.
