### PR TITLE
feat(lint): add webhookheaders analyzer to prevent inline `## ...` regressions

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -42,3 +42,6 @@ jobs:
         with:
           version: v2.11.4
           args: ${{ matrix.args }}
+      - name: webhookheaders analyzer
+        if: matrix.name == 'default'
+        run: make check-webhookheaders

--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ help: ## Show this help message
 	@echo "$$HELP_HEADER"
 	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}'
 
-lint: check-closeandlog ## Run all linters (golangci-lint + closeandlog)
+lint: check-closeandlog check-webhookheaders ## Run all linters (golangci-lint + custom analyzers)
 	@echo "Running golangci-lint..."
 	@docker run --rm -v $$(pwd):/app -w /app golangci/golangci-lint:latest golangci-lint run --timeout=5m
 
@@ -131,6 +131,10 @@ check-closeandlog: ## Run closeandlog analyzer (flags _ = x.Close() patterns)
 	@echo "Running closeandlog analyzer..."
 	@go run ./cmd/closeandlog-check ./...
 	@go run -tags=integration ./cmd/closeandlog-check ./...
+
+check-webhookheaders: ## Run webhookheaders analyzer (flags inline `## ...` markdown headers in pkg/webhook handlers)
+	@echo "Running webhookheaders analyzer..."
+	@go run ./cmd/webhookheaders-check $$(go list ./pkg/webhook/... | grep -v '/templates$$')
 
 lint-fix: ## Run golangci-lint with auto-fix enabled
 	@echo "Running golangci-lint with auto-fix..."

--- a/cmd/webhookheaders-check/main.go
+++ b/cmd/webhookheaders-check/main.go
@@ -1,0 +1,20 @@
+// Command webhookheaders-check runs the webhookheaders analyzer as a
+// standalone tool.
+//
+// Usage:
+//
+//	go run ./cmd/webhookheaders-check ./pkg/webhook/...
+//
+// The analyzer itself is generic — it does not know about pkg/webhook. The
+// caller must pass the package set the rule should apply to (typically the
+// webhook handler packages, excluding pkg/webhook/templates).
+package main
+
+import (
+	"github.com/block/schemabot/pkg/analyzers/webhookheaders"
+	"golang.org/x/tools/go/analysis/singlechecker"
+)
+
+func main() {
+	singlechecker.Main(webhookheaders.Analyzer)
+}

--- a/cmd/webhookheaders-check/main.go
+++ b/cmd/webhookheaders-check/main.go
@@ -5,9 +5,9 @@
 //
 //	go run ./cmd/webhookheaders-check ./pkg/webhook/...
 //
-// The analyzer itself is generic — it does not know about pkg/webhook. The
-// caller must pass the package set the rule should apply to (typically the
-// webhook handler packages, excluding pkg/webhook/templates).
+// The analyzer reports on every package it is given. The caller is
+// responsible for excluding ./pkg/webhook/templates (the templates package
+// is the legitimate home for `## ...` header strings).
 package main
 
 import (

--- a/pkg/analyzers/webhookheaders/testdata/src/example/example.go
+++ b/pkg/analyzers/webhookheaders/testdata/src/example/example.go
@@ -1,0 +1,44 @@
+package example
+
+import "fmt"
+
+// Bad: simple inline header.
+func bad() string {
+	return "## ❌ Apply Blocked\n\nDetails here." // want `inline markdown header`
+}
+
+// Bad: header concatenated with body.
+func badConcat(name string) string {
+	return "## Missing Argument\n\n" + // want `inline markdown header`
+		"You must supply " + name + "."
+}
+
+// Bad: header inside fmt.Sprintf.
+func badSprintf(env string) string {
+	return fmt.Sprintf("## Apply Blocked\n\nEnvironment: %s", env) // want `inline markdown header`
+}
+
+// Bad: raw-string-literal header.
+func badRaw() string {
+	return `## Lock Held` // want `inline markdown header`
+}
+
+// Good: bold prefix is not a header.
+func goodBold() string {
+	return "**Repository not registered.** No `## ` markers up front."
+}
+
+// Good: header substring inside the string but not at the start.
+func goodSubstring() string {
+	return "see the section ## Configuration in the README"
+}
+
+// Good: hash without the required trailing space.
+func goodNoSpace() string {
+	return "##NotAHeader"
+}
+
+// Good: empty string.
+func goodEmpty() string {
+	return ""
+}

--- a/pkg/analyzers/webhookheaders/testdata/src/example/example_test.go
+++ b/pkg/analyzers/webhookheaders/testdata/src/example/example_test.go
@@ -1,0 +1,9 @@
+package example
+
+// _test.go files are deliberately not flagged — assertions on rendered comment
+// bodies legitimately contain `## ...` substrings and should not be moved into
+// the templates package.
+
+func unusedTestFixture() string {
+	return "## Apply Blocked"
+}

--- a/pkg/analyzers/webhookheaders/webhookheaders.go
+++ b/pkg/analyzers/webhookheaders/webhookheaders.go
@@ -1,0 +1,62 @@
+// Package webhookheaders provides a go/analysis analyzer that flags inline
+// markdown header strings (`## ...`) in Go source files. The project
+// convention is for all PR-comment markdown to live in pkg/webhook/templates/
+// and be rendered through a templates.Render… helper, so handler code that
+// embeds a `## ...` header is almost always a missed extraction.
+//
+// The analyzer itself is generic — it does not know about pkg/webhook. The
+// caller (Makefile / CI / pre-commit script) is responsible for invoking it
+// only against the packages where the rule should apply.
+package webhookheaders
+
+import (
+	"go/ast"
+	"go/token"
+	"strconv"
+	"strings"
+
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/inspect"
+	"golang.org/x/tools/go/ast/inspector"
+)
+
+const message = "inline markdown header `## ...` in handler code — move this body into pkg/webhook/templates and call templates.Render…"
+
+// Analyzer flags string literals that begin with "## " in non-test source
+// files. Test files are skipped because assertions on rendered comment bodies
+// legitimately contain `## ...` substrings.
+var Analyzer = &analysis.Analyzer{
+	Name:     "webhookheaders",
+	Doc:      "flags inline `## ...` markdown header strings; move them to pkg/webhook/templates and render via templates.Render…",
+	Requires: []*analysis.Analyzer{inspect.Analyzer},
+	Run:      run,
+}
+
+func run(pass *analysis.Pass) (any, error) {
+	insp := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
+
+	nodeFilter := []ast.Node{(*ast.BasicLit)(nil)}
+
+	insp.Preorder(nodeFilter, func(n ast.Node) {
+		lit := n.(*ast.BasicLit)
+		if lit.Kind != token.STRING {
+			return
+		}
+		if isTestFile(pass, lit.Pos()) {
+			return
+		}
+		val, err := strconv.Unquote(lit.Value)
+		if err != nil {
+			return
+		}
+		if strings.HasPrefix(val, "## ") {
+			pass.Reportf(lit.Pos(), message)
+		}
+	})
+
+	return nil, nil
+}
+
+func isTestFile(pass *analysis.Pass, pos token.Pos) bool {
+	return strings.HasSuffix(pass.Fset.Position(pos).Filename, "_test.go")
+}

--- a/pkg/analyzers/webhookheaders/webhookheaders.go
+++ b/pkg/analyzers/webhookheaders/webhookheaders.go
@@ -1,12 +1,14 @@
 // Package webhookheaders provides a go/analysis analyzer that flags inline
-// markdown header strings (`## ...`) in Go source files. The project
+// markdown header strings (`## ...`) in webhook handler code. The project
 // convention is for all PR-comment markdown to live in pkg/webhook/templates/
-// and be rendered through a templates.Render… helper, so handler code that
-// embeds a `## ...` header is almost always a missed extraction.
+// and be rendered through a templates.Render… helper; a `## ...` literal in
+// handler code is almost always a missed extraction.
 //
-// The analyzer itself is generic — it does not know about pkg/webhook. The
-// caller (Makefile / CI / pre-commit script) is responsible for invoking it
-// only against the packages where the rule should apply.
+// The analyzer reports on every matching string literal in every package it
+// is invoked against — it does not filter by import path. Callers (Makefile,
+// CI, pre-commit script) are responsible for passing only the package set
+// where the rule should apply: today, ./pkg/webhook/... excluding
+// ./pkg/webhook/templates.
 package webhookheaders
 
 import (

--- a/pkg/analyzers/webhookheaders/webhookheaders_test.go
+++ b/pkg/analyzers/webhookheaders/webhookheaders_test.go
@@ -1,0 +1,13 @@
+package webhookheaders_test
+
+import (
+	"testing"
+
+	"github.com/block/schemabot/pkg/analyzers/webhookheaders"
+	"golang.org/x/tools/go/analysis/analysistest"
+)
+
+func TestAnalyzer(t *testing.T) {
+	testdata := analysistest.TestData()
+	analysistest.Run(t, testdata, webhookheaders.Analyzer, "example")
+}

--- a/scripts/lint-fix.sh
+++ b/scripts/lint-fix.sh
@@ -142,4 +142,20 @@ fi
 # e2e packages are test-only (_test.go) so singlechecker can't analyze them.
 # The e2e tests reuse the same patterns caught by the default + integration runs.
 
+# Run webhookheaders analyzer when any pkg/webhook/ source (excluding templates)
+# is staged. Flags inline `## ...` markdown headers that should live in
+# pkg/webhook/templates/ and render via templates.Render…
+if [ -n "$PKG_FILES" ]; then
+    WEBHOOK_FILES=$(echo "$PKG_FILES" | grep '^pkg/webhook/' | grep -v '^pkg/webhook/templates/' || true)
+    if [ -n "$WEBHOOK_FILES" ]; then
+        echo "Running webhookheaders analyzer..."
+        WEBHOOK_PKGS=$(go list ./pkg/webhook/... | grep -v '/templates$')
+        if ! go run ./cmd/webhookheaders-check $WEBHOOK_PKGS 2>&1; then
+            echo ""
+            echo 'webhookheaders: move the `## ...` body into pkg/webhook/templates/ and render it via a templates.Render… helper.'
+            exit 1
+        fi
+    fi
+fi
+
 echo "All lint checks passed!"

--- a/scripts/lint-fix.sh
+++ b/scripts/lint-fix.sh
@@ -148,12 +148,19 @@ fi
 if [ -n "$PKG_FILES" ]; then
     WEBHOOK_FILES=$(echo "$PKG_FILES" | grep '^pkg/webhook/' | grep -v '^pkg/webhook/templates/' || true)
     if [ -n "$WEBHOOK_FILES" ]; then
-        echo "Running webhookheaders analyzer..."
-        WEBHOOK_PKGS=$(go list ./pkg/webhook/... | grep -v '/templates$')
-        if ! go run ./cmd/webhookheaders-check $WEBHOOK_PKGS 2>&1; then
-            echo ""
-            echo 'webhookheaders: move the `## ...` body into pkg/webhook/templates/ and render it via a templates.Render… helper.'
-            exit 1
+        # `grep -v` exits non-zero (and would trip `set -e`) when every package
+        # is filtered out, so suppress that exit and fall through to a clear
+        # message instead of dying silently.
+        WEBHOOK_PKGS=$(go list ./pkg/webhook/... | grep -v '/templates$' || true)
+        if [ -z "$WEBHOOK_PKGS" ]; then
+            echo "webhookheaders: no packages to check (only pkg/webhook/templates exists), skipping."
+        else
+            echo "Running webhookheaders analyzer..."
+            if ! go run ./cmd/webhookheaders-check $WEBHOOK_PKGS 2>&1; then
+                echo ""
+                echo 'webhookheaders: move the `## ...` body into pkg/webhook/templates/ and render it via a templates.Render… helper.'
+                exit 1
+            fi
         fi
     fi
 fi


### PR DESCRIPTION
## What and Why ?

Adds a custom go/analysis analyzer that flags string literals beginning with "## " in non-test source files. The project convention is for all PR-comment markdown to live in pkg/webhook/templates/ and render through a templates.Render… helper, so a `## ...` literal in handler code is almost always a missed extraction. PR #100 cleaned up the existing inline headers; this lint locks the audit in.

The analyzer is generic — it does not know about pkg/webhook. The caller (Makefile / CI / pre-commit script) controls scope by passing the package set the rule should apply to:

- `make check-webhookheaders` runs it against ./pkg/webhook/... excluding the templates subpackage.
- The lint CI workflow runs `make check-webhookheaders` once per push (default matrix entry only).
- The pre-commit script runs it whenever a staged file under pkg/webhook/ (outside templates/) changes.

Mirrors the existing closeandlog analyzer layout: the analyzer lives in pkg/analyzers/webhookheaders/, with a singlechecker entry point at cmd/webhookheaders-check/ and analysistest fixtures under testdata/.