### PR TITLE
fix(github): add retry block to checks-error blocked-apply comment

### DIFF
--- a/pkg/webhook/templates/apply_commands.go
+++ b/pkg/webhook/templates/apply_commands.go
@@ -277,13 +277,19 @@ func RenderApplyBlockedByCheckStatusError(environment string, err error) string 
 		return sb.String()
 	}
 
-	sb.WriteString("Unable to verify PR check statuses:\n\n")
-	sb.WriteString("```\n")
 	if err != nil {
+		sb.WriteString("Unable to verify PR check statuses:\n\n")
+		sb.WriteString("```\n")
 		fmt.Fprintf(&sb, "%s\n", err)
+		sb.WriteString("```\n")
+		sb.WriteString("\nResolve the issue and retry:\n")
+	} else {
+		// Defensive: callers should always pass a non-nil error here, but
+		// rendering an empty fenced block followed by "Resolve the issue"
+		// would be confusing if a nil error ever slipped through.
+		sb.WriteString("Unable to verify PR check statuses.\n\n")
+		sb.WriteString("Retry:\n")
 	}
-	sb.WriteString("```\n")
-	sb.WriteString("\nResolve the issue and retry:\n")
 	fmt.Fprintf(&sb, "```\nschemabot apply -e %s\n```\n", environment)
 
 	return sb.String()

--- a/pkg/webhook/templates/apply_commands.go
+++ b/pkg/webhook/templates/apply_commands.go
@@ -262,7 +262,8 @@ func RenderApplyBlockedByFailingChecks(environment string, failing []BlockingChe
 // RenderApplyBlockedByCheckStatusError renders a comment when apply is blocked
 // because the GitHub API returned an error while fetching PR check statuses.
 // The function recognises the "Resource not accessible" permission error and
-// surfaces a targeted hint; all other errors are shown verbatim.
+// surfaces a targeted hint; all other errors are shown verbatim. Both branches
+// include a fenced retry command, matching the failing/in-progress siblings.
 func RenderApplyBlockedByCheckStatusError(environment string, err error) string {
 	var sb strings.Builder
 
@@ -271,7 +272,8 @@ func RenderApplyBlockedByCheckStatusError(environment string, err error) string 
 
 	if err != nil && strings.Contains(err.Error(), "Resource not accessible") {
 		sb.WriteString("The SchemaBot GitHub App does not have permission to read check statuses on this repository. ")
-		sb.WriteString("Grant the app **Commit statuses: Read** permission, then retry.\n")
+		sb.WriteString("Grant the app **Commit statuses: Read** permission, then retry:\n")
+		fmt.Fprintf(&sb, "```\nschemabot apply -e %s\n```\n", environment)
 		return sb.String()
 	}
 
@@ -281,6 +283,8 @@ func RenderApplyBlockedByCheckStatusError(environment string, err error) string 
 		fmt.Fprintf(&sb, "%s\n", err)
 	}
 	sb.WriteString("```\n")
+	sb.WriteString("\nResolve the issue and retry:\n")
+	fmt.Fprintf(&sb, "```\nschemabot apply -e %s\n```\n", environment)
 
 	return sb.String()
 }

--- a/pkg/webhook/templates/apply_test.go
+++ b/pkg/webhook/templates/apply_test.go
@@ -348,7 +348,7 @@ func TestRenderApplyBlockedByFailingChecks_SingleCheck(t *testing.T) {
 }
 
 func TestRenderApplyBlockedByCheckStatusError(t *testing.T) {
-	t.Run("generic error is shown verbatim", func(t *testing.T) {
+	t.Run("generic error is shown verbatim with retry block", func(t *testing.T) {
 		err := errors.New("graphql query failed: 500 Internal Server Error")
 
 		result := RenderApplyBlockedByCheckStatusError("staging", err)
@@ -357,11 +357,11 @@ func TestRenderApplyBlockedByCheckStatusError(t *testing.T) {
 		assert.Contains(t, result, "**Environment**: `staging`")
 		assert.Contains(t, result, "Unable to verify PR check statuses")
 		assert.Contains(t, result, "graphql query failed: 500 Internal Server Error")
-		assert.NotContains(t, result, "schemabot apply -e",
-			"API-error variant does not include a retry instruction")
+		assert.Contains(t, result, "Resolve the issue and retry:")
+		assert.Contains(t, result, "schemabot apply -e staging")
 	})
 
-	t.Run("permission error surfaces a targeted hint", func(t *testing.T) {
+	t.Run("permission error surfaces a targeted hint with retry block", func(t *testing.T) {
 		err := errors.New("GET https://api.github.com/...: 403 Resource not accessible by integration")
 
 		result := RenderApplyBlockedByCheckStatusError("production", err)
@@ -370,16 +370,22 @@ func TestRenderApplyBlockedByCheckStatusError(t *testing.T) {
 		assert.Contains(t, result, "**Environment**: `production`")
 		assert.Contains(t, result, "does not have permission to read check statuses")
 		assert.Contains(t, result, "**Commit statuses: Read**")
+		assert.Contains(t, result, "permission, then retry:")
+		assert.Contains(t, result, "schemabot apply -e production")
 		assert.NotContains(t, result, "Unable to verify PR check statuses",
 			"permission branch should replace the generic verbatim message")
+		assert.NotContains(t, result, "Resolve the issue and retry:",
+			"permission branch should not also emit the generic-branch retry copy")
 	})
 
-	t.Run("nil error renders without panicking", func(t *testing.T) {
+	t.Run("nil error renders without panicking and includes retry block", func(t *testing.T) {
 		result := RenderApplyBlockedByCheckStatusError("staging", nil)
 
 		assert.Contains(t, result, "## ❌ Apply Blocked")
 		assert.Contains(t, result, "**Environment**: `staging`")
 		assert.Contains(t, result, "Unable to verify PR check statuses")
+		assert.Contains(t, result, "Resolve the issue and retry:")
+		assert.Contains(t, result, "schemabot apply -e staging")
 	})
 }
 

--- a/pkg/webhook/templates/apply_test.go
+++ b/pkg/webhook/templates/apply_test.go
@@ -357,8 +357,8 @@ func TestRenderApplyBlockedByCheckStatusError(t *testing.T) {
 		assert.Contains(t, result, "**Environment**: `staging`")
 		assert.Contains(t, result, "Unable to verify PR check statuses")
 		assert.Contains(t, result, "graphql query failed: 500 Internal Server Error")
-		assert.Contains(t, result, "Resolve the issue and retry:")
-		assert.Contains(t, result, "schemabot apply -e staging")
+		assert.Contains(t, result, "Resolve the issue and retry:\n```\nschemabot apply -e staging\n```",
+			"retry command must be inside a fenced code block immediately after the retry copy")
 	})
 
 	t.Run("permission error surfaces a targeted hint with retry block", func(t *testing.T) {
@@ -370,8 +370,8 @@ func TestRenderApplyBlockedByCheckStatusError(t *testing.T) {
 		assert.Contains(t, result, "**Environment**: `production`")
 		assert.Contains(t, result, "does not have permission to read check statuses")
 		assert.Contains(t, result, "**Commit statuses: Read**")
-		assert.Contains(t, result, "permission, then retry:")
-		assert.Contains(t, result, "schemabot apply -e production")
+		assert.Contains(t, result, "permission, then retry:\n```\nschemabot apply -e production\n```",
+			"retry command must be inside a fenced code block immediately after the retry copy")
 		assert.NotContains(t, result, "Unable to verify PR check statuses",
 			"permission branch should replace the generic verbatim message")
 		assert.NotContains(t, result, "Resolve the issue and retry:",
@@ -384,8 +384,8 @@ func TestRenderApplyBlockedByCheckStatusError(t *testing.T) {
 		assert.Contains(t, result, "## ❌ Apply Blocked")
 		assert.Contains(t, result, "**Environment**: `staging`")
 		assert.Contains(t, result, "Unable to verify PR check statuses.")
-		assert.Contains(t, result, "Retry:")
-		assert.Contains(t, result, "schemabot apply -e staging")
+		assert.Contains(t, result, "Retry:\n```\nschemabot apply -e staging\n```",
+			"retry command must be inside a fenced code block immediately after the retry copy")
 		assert.NotContains(t, result, "```\n```",
 			"nil-error branch should not emit an empty fenced code block")
 		assert.NotContains(t, result, "Resolve the issue and retry:",

--- a/pkg/webhook/templates/apply_test.go
+++ b/pkg/webhook/templates/apply_test.go
@@ -378,14 +378,18 @@ func TestRenderApplyBlockedByCheckStatusError(t *testing.T) {
 			"permission branch should not also emit the generic-branch retry copy")
 	})
 
-	t.Run("nil error renders without panicking and includes retry block", func(t *testing.T) {
+	t.Run("nil error skips empty fence and uses concise retry copy", func(t *testing.T) {
 		result := RenderApplyBlockedByCheckStatusError("staging", nil)
 
 		assert.Contains(t, result, "## ❌ Apply Blocked")
 		assert.Contains(t, result, "**Environment**: `staging`")
-		assert.Contains(t, result, "Unable to verify PR check statuses")
-		assert.Contains(t, result, "Resolve the issue and retry:")
+		assert.Contains(t, result, "Unable to verify PR check statuses.")
+		assert.Contains(t, result, "Retry:")
 		assert.Contains(t, result, "schemabot apply -e staging")
+		assert.NotContains(t, result, "```\n```",
+			"nil-error branch should not emit an empty fenced code block")
+		assert.NotContains(t, result, "Resolve the issue and retry:",
+			"nil-error branch should not reference an issue that was not surfaced")
 	})
 }
 


### PR DESCRIPTION
## What and Why ?
`RenderApplyBlockedByCheckStatusError` was the only checks-gate "Apply Blocked" template without a fenced retry command. The failing and in-progress siblings both end with a "…and retry:" sentence followed by `schemabot apply -e <env>`, so users blocked by an API error could see the error but had to remember the retry incantation themselves.

This was a deliberate omission in #94 to keep that PR a true byte-for-byte refactor of the prior inline rendering. Re-adding the retry block now as its own change so the UX intent stays explicit:

- Permission branch ends with "…then retry:" + fenced apply command.
- Generic branch appends "Resolve the issue and retry:" + fenced apply command after the surfaced error message.

Drops the `NotContains` assertion that locked in the absence of a retry command and adds positive coverage for the new copy in all three existing subtests (generic, permission, nil-error).

Rendered output (generic branch):

> ## ❌ Apply Blocked
>
> **Environment**: `staging`
>
> Unable to verify PR check statuses:
>
> ```
> graphql query failed: 500 Internal Server Error
> ```
>
> Resolve the issue and retry:
> ```
> schemabot apply -e staging
> 