### PR TITLE
feat(engine): classify retryable engine errors

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -12,28 +12,12 @@ package engine
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"time"
 
 	"github.com/block/spirit/pkg/statement"
 
 	"github.com/block/schemabot/pkg/schema"
 )
-
-// ErrNonRetryable wraps an error to indicate it should not be retried.
-// Engines return this from Progress when the error is permanent (e.g.,
-// deploy request not found after server restart).
-type ErrNonRetryable struct {
-	Err error
-}
-
-func (e *ErrNonRetryable) Error() string { return e.Err.Error() }
-func (e *ErrNonRetryable) Unwrap() error { return e.Err }
-
-// NewNonRetryableError wraps err as a non-retryable error.
-func NewNonRetryableError(msg string, args ...any) error {
-	return &ErrNonRetryable{Err: fmt.Errorf(msg, args...)}
-}
 
 // Engine defines the interface that all schema change backends must implement.
 //

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -112,4 +113,53 @@ func TestEncodeResumeState_Nil(t *testing.T) {
 	encoded, err := EncodeResumeState(nil)
 	require.NoError(t, err)
 	assert.Equal(t, "", encoded)
+}
+
+func TestIsRetryable(t *testing.T) {
+	t.Run("plain error is retryable by default", func(t *testing.T) {
+		err := fmt.Errorf("connection refused")
+		assert.True(t, IsRetryable(err))
+	})
+
+	t.Run("wrapped error is retryable by default", func(t *testing.T) {
+		err := fmt.Errorf("apply failed: %w", fmt.Errorf("network timeout"))
+		assert.True(t, IsRetryable(err))
+	})
+
+	t.Run("PermanentError is not retryable", func(t *testing.T) {
+		err := NewPermanentError("DDL syntax error")
+		assert.False(t, IsRetryable(err))
+	})
+
+	t.Run("wrapped PermanentError is not retryable", func(t *testing.T) {
+		err := fmt.Errorf("apply failed: %w", NewPermanentError("auth failure"))
+		assert.False(t, IsRetryable(err))
+	})
+
+	t.Run("nil is not retryable", func(t *testing.T) {
+		assert.False(t, IsRetryable(nil))
+	})
+
+}
+
+func TestIsTransientTransportError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "connection refused", err: fmt.Errorf("dial tcp: connection refused"), want: true},
+		{name: "connection reset", err: fmt.Errorf("read tcp: connection reset by peer"), want: true},
+		{name: "timeout", err: fmt.Errorf("proxy query: i/o timeout"), want: true},
+		{name: "deadline", err: fmt.Errorf("context deadline exceeded"), want: true},
+		{name: "rate limit", err: fmt.Errorf("Too many requests"), want: true},
+		{name: "syntax error", err: fmt.Errorf("DDL syntax error"), want: false},
+		{name: "nil", err: nil, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsTransientTransportError(tt.err))
+		})
+	}
 }

--- a/pkg/engine/errors.go
+++ b/pkg/engine/errors.go
@@ -1,0 +1,46 @@
+package engine
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// PermanentError wraps an error to indicate it should not be retried.
+// Engines return this when the error is permanent.
+type PermanentError struct {
+	Err error
+}
+
+func (e *PermanentError) Error() string { return e.Err.Error() }
+func (e *PermanentError) Unwrap() error { return e.Err }
+
+// NewPermanentError wraps err as a permanent error.
+func NewPermanentError(msg string, args ...any) error {
+	return &PermanentError{Err: fmt.Errorf(msg, args...)}
+}
+
+// IsRetryable returns true if the error should be retried by the scheduler.
+// All errors are retryable by default, and engines explicitly wrap only
+// permanent errors with PermanentError.
+func IsRetryable(err error) bool {
+	if err == nil {
+		return false
+	}
+	var permanent *PermanentError
+	return !errors.As(err, &permanent)
+}
+
+// IsTransientTransportError reports whether err matches common transport
+// failures that often resolve on a later attempt.
+func IsTransientTransportError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "connection refused") ||
+		strings.Contains(msg, "connection reset") ||
+		strings.Contains(msg, "i/o timeout") ||
+		strings.Contains(msg, "context deadline exceeded") ||
+		strings.Contains(msg, "Too many requests")
+}

--- a/pkg/engine/planetscale/planetscale.go
+++ b/pkg/engine/planetscale/planetscale.go
@@ -829,7 +829,7 @@ func (e *Engine) Apply(ctx context.Context, req *engine.ApplyRequest) (*engine.A
 		// Reuse existing branch: wait for ready, refresh schema from main, wait again
 		branchName = existingBranch
 		if branchName == main {
-			return nil, fmt.Errorf("cannot reuse the %s branch — use a development branch", main)
+			return nil, engine.NewPermanentError("cannot reuse the %s branch: use a development branch", main)
 		}
 		persistState(&psMetadata{BranchName: branchName})
 		emitEvent(engine.ApplyEvent{
@@ -1258,6 +1258,9 @@ func (e *Engine) applyKeyspaceChanges(ctx context.Context, sc engine.SchemaChang
 		if err := e.applyKeyspaceChangesOnce(ctx, sc, schemaFiles, password, client, org, database, branchName); err != nil {
 			lastErr = err
 			e.logger.Error(fmt.Sprintf("keyspace %s apply attempt %d failed", sc.Namespace, attempt+1), "keyspace", sc.Namespace, "attempt", attempt+1, "error", err)
+			if !isRetryableEngineError(err) {
+				return engine.NewPermanentError("apply keyspace %s: %w", sc.Namespace, err)
+			}
 			if isSnapshotInProgress(err) && maxAttempts == maxRetries {
 				maxAttempts = maxSnapshotRetries
 				e.logger.Info("schema snapshot in progress, extending retries",
@@ -1268,7 +1271,14 @@ func (e *Engine) applyKeyspaceChanges(ctx context.Context, sc engine.SchemaChang
 		e.logger.Info(fmt.Sprintf("keyspace %s changes applied (%s)", sc.Namespace, time.Since(start).Round(time.Second)), "keyspace", sc.Namespace, "elapsed", time.Since(start).Round(time.Second))
 		return nil
 	}
-	return fmt.Errorf("apply keyspace %s (after %d attempts): %w", sc.Namespace, maxAttempts, lastErr)
+	finalErr := fmt.Errorf("apply keyspace %s (after %d attempts): %w", sc.Namespace, maxAttempts, lastErr)
+	return finalErr
+}
+
+// isRetryableEngineError returns true if the error is a transient condition
+// that may succeed on a future attempt.
+func isRetryableEngineError(err error) bool {
+	return isRetryablePSError(err) || engine.IsTransientTransportError(err)
 }
 
 // isSnapshotInProgress returns true if the error indicates PlanetScale is
@@ -1681,11 +1691,11 @@ func (e *Engine) Progress(ctx context.Context, req *engine.ProgressRequest) (*en
 
 	dr, err := e.getDeployRequest(ctx, client, credOrg(req.Credentials), req.Database, meta.DeployRequestID)
 	if err != nil {
-		// Deploy request not found is non-retryable (e.g., server restarted
+		// Deploy request not found is permanent (e.g., server restarted
 		// with fresh LocalScale state but stale apply record).
 		var psErr *ps.Error
 		if errors.As(err, &psErr) && psErr.Code == ps.ErrNotFound {
-			return nil, engine.NewNonRetryableError("deploy request #%d not found: %w", meta.DeployRequestID, err)
+			return nil, engine.NewPermanentError("deploy request #%d not found: %w", meta.DeployRequestID, err)
 		}
 		return nil, fmt.Errorf("get deploy request: %w", err)
 	}

--- a/pkg/engine/planetscale/planetscale_test.go
+++ b/pkg/engine/planetscale/planetscale_test.go
@@ -1,6 +1,7 @@
 package planetscale
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"os"
@@ -15,10 +16,23 @@ import (
 	"github.com/block/schemabot/pkg/ddl"
 	"github.com/block/schemabot/pkg/engine"
 	"github.com/block/schemabot/pkg/lint"
+	"github.com/block/schemabot/pkg/psclient"
 	"github.com/block/schemabot/pkg/schema"
 	"github.com/block/schemabot/pkg/state"
 	"github.com/block/spirit/pkg/table"
 )
+
+type permanentVSchemaErrorClient struct {
+	psclient.PSClient
+	updateCalls int
+}
+
+var _ psclient.PSClient = (*permanentVSchemaErrorClient)(nil)
+
+func (c *permanentVSchemaErrorClient) UpdateKeyspaceVSchema(context.Context, *ps.UpdateKeyspaceVSchemaRequest) (*ps.VSchema, error) {
+	c.updateCalls++
+	return nil, &ps.Error{Code: ps.ErrInvalid}
+}
 
 func TestDeployStateToEngineState(t *testing.T) {
 	tests := []struct {
@@ -410,6 +424,111 @@ func TestIsSnapshotInProgress(t *testing.T) {
 	assert.True(t, isSnapshotInProgress(fmt.Errorf("wrapped: schema snapshot is in progress")))
 	assert.False(t, isSnapshotInProgress(fmt.Errorf("connection refused")))
 	assert.False(t, isSnapshotInProgress(nil))
+}
+
+func TestIsRetryableEngineError(t *testing.T) {
+	t.Run("PS SDK ErrRetry is retryable", func(t *testing.T) {
+		err := &ps.Error{Code: ps.ErrRetry}
+		assert.True(t, isRetryableEngineError(err))
+	})
+
+	t.Run("PS SDK ErrInternal is retryable", func(t *testing.T) {
+		err := &ps.Error{Code: ps.ErrInternal}
+		assert.True(t, isRetryableEngineError(err))
+	})
+
+	t.Run("PS SDK ErrResponseMalformed is retryable", func(t *testing.T) {
+		err := &ps.Error{Code: ps.ErrResponseMalformed}
+		assert.True(t, isRetryableEngineError(err))
+	})
+
+	t.Run("PS SDK ErrNotFound is NOT retryable", func(t *testing.T) {
+		err := &ps.Error{Code: ps.ErrNotFound}
+		assert.False(t, isRetryableEngineError(err))
+	})
+
+	t.Run("PS SDK ErrPermission is NOT retryable", func(t *testing.T) {
+		err := &ps.Error{Code: ps.ErrPermission}
+		assert.False(t, isRetryableEngineError(err))
+	})
+
+	t.Run("PS SDK ErrInvalid is NOT retryable", func(t *testing.T) {
+		err := &ps.Error{Code: ps.ErrInvalid}
+		assert.False(t, isRetryableEngineError(err))
+	})
+
+	t.Run("snapshot in progress is retryable", func(t *testing.T) {
+		err := fmt.Errorf("Cannot update VSchema while a schema snapshot is in progress.")
+		assert.True(t, isRetryableEngineError(err))
+	})
+
+	t.Run("connection refused is retryable", func(t *testing.T) {
+		err := fmt.Errorf("connection refused")
+		assert.True(t, isRetryableEngineError(err))
+	})
+
+	t.Run("wrapped network error is retryable", func(t *testing.T) {
+		err := fmt.Errorf("apply failed: %w", fmt.Errorf("i/o timeout"))
+		assert.True(t, isRetryableEngineError(err))
+	})
+
+	t.Run("DDL syntax error is NOT retryable", func(t *testing.T) {
+		err := fmt.Errorf("Error 1064 (42000): You have an error in your SQL syntax")
+		assert.False(t, isRetryableEngineError(err))
+	})
+
+	t.Run("nil is NOT retryable", func(t *testing.T) {
+		assert.False(t, isRetryableEngineError(nil))
+	})
+}
+
+func TestApply_MainBranchReuseIsPermanent(t *testing.T) {
+	e := NewWithClient(slog.New(slog.NewTextHandler(os.Stdout, nil)), func(_, _ string) (psclient.PSClient, error) {
+		return nil, nil
+	})
+
+	_, err := e.Apply(t.Context(), &engine.ApplyRequest{
+		Database: "testdb",
+		Options: map[string]string{
+			"branch": "main",
+		},
+		Credentials: &engine.Credentials{
+			Metadata: map[string]string{
+				"organization": "org",
+				"token_name":   "token",
+				"token_value":  "secret",
+				"main_branch":  "main",
+			},
+		},
+	})
+
+	require.Error(t, err)
+	assert.False(t, engine.IsRetryable(err))
+	assert.Contains(t, err.Error(), "cannot reuse the main branch")
+}
+
+func TestApplyKeyspaceChanges_PermanentVSchemaErrorIsPermanent(t *testing.T) {
+	e := New(slog.New(slog.NewTextHandler(os.Stdout, nil)))
+	client := &permanentVSchemaErrorClient{}
+
+	err := e.applyKeyspaceChanges(t.Context(),
+		engine.SchemaChange{
+			Namespace: "testapp",
+			Metadata:  map[string]string{"vschema_changed": "true"},
+		},
+		schema.SchemaFiles{
+			"testapp": &schema.Namespace{Files: map[string]string{"vschema.json": "{}"}},
+		},
+		&ps.DatabaseBranchPassword{},
+		client,
+		"org",
+		"database",
+		"branch",
+	)
+
+	require.Error(t, err)
+	assert.False(t, engine.IsRetryable(err))
+	assert.Equal(t, 1, client.updateCalls)
 }
 
 func TestRetryDelay(t *testing.T) {

--- a/pkg/tern/local_apply.go
+++ b/pkg/tern/local_apply.go
@@ -634,10 +634,10 @@ func (c *LocalClient) handleAtomicProgressTick(ctx context.Context, eng engine.E
 		ResumeState: resumeState,
 	})
 	if err != nil {
-		// Non-retryable errors (e.g., deploy request not found) — fail immediately.
-		var nonRetryable *engine.ErrNonRetryable
-		if errors.As(err, &nonRetryable) {
-			c.logger.Error("progress check failed with non-retryable error",
+		// Permanent errors (e.g., deploy request not found) fail immediately.
+		var permanent *engine.PermanentError
+		if errors.As(err, &permanent) {
+			c.logger.Error("progress check failed with permanent error",
 				"error", err, "apply_id", apply.ApplyIdentifier)
 			c.failApplyWithTasks(ctx, apply, tasks, fmt.Sprintf("progress polling failed: %v", err))
 			return true


### PR DESCRIPTION
## Summary

- Default engine errors to retryable unless an engine explicitly marks them permanent
- Add `IsRetryable`, `PermanentError`, and shared transient transport helpers with focused tests around retry behavior
- Reuse the existing PlanetScale SDK error-code classifier while marking known permanent PlanetScale failures so they stop retrying

🤖 Generated by Codex.