### PR TITLE
feat(github): cache FetchPullRequest per (repo, pr) and reuse InstallationClient

### DIFF
--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -34,17 +34,11 @@ type Client struct {
 	appSlug         string    // fetched from GitHub API at startup, used to identify own check runs
 	lastSlugAttempt time.Time // rate-limits slug fetch retries
 
-	// prInfoCache memoises FetchPullRequest results across every
-	// InstallationClient produced by ForInstallation, so back-to-back
-	// webhook deliveries and command bursts targeting the same (repo, pr)
-	// collapse to a single upstream GitHub call.
-	prInfoCache *PRInfoCache
-
 	// installations caches per-installation clients keyed by installationID
 	// so the underlying http.Client, gh.Client, githubv4.Client, and
 	// ghinstallation transport (and its installation-token cache) are
 	// reused across webhook deliveries instead of being reconstructed on
-	// every call. This also keeps any per-InstallationClient state warm.
+	// every call.
 	installationsMu sync.Mutex
 	installations   map[int64]*InstallationClient
 }
@@ -57,21 +51,15 @@ const slugFetchRetryCooldown = 5 * time.Second
 // If the slug can't be fetched (e.g., GitHub is down), the server still starts but
 // PR applies are blocked by the check gate since we can't identify our own checks.
 //
-// The returned Client owns a shared PRInfoCache with DefaultPRInfoCacheTTL that
-// is handed to every InstallationClient produced by ForInstallation. Use
-// NewClientWithCacheTTL to override the TTL (e.g., to 0 to disable caching).
+// The returned Client memoises the *InstallationClient it produces by
+// installationID so the underlying http.Client, gh.Client, githubv4.Client, and
+// ghinstallation transport (and its installation-token cache) are reused across
+// webhook deliveries.
 func NewClient(appID int64, privateKey []byte, logger *slog.Logger) *Client {
-	return NewClientWithCacheTTL(appID, privateKey, logger, DefaultPRInfoCacheTTL)
-}
-
-// NewClientWithCacheTTL constructs a Client with an explicit PRInfoCache TTL.
-// A non-positive TTL disables the cache: FetchPullRequest hits GitHub on every call.
-func NewClientWithCacheTTL(appID int64, privateKey []byte, logger *slog.Logger, prInfoCacheTTL time.Duration) *Client {
 	c := &Client{
 		appID:         appID,
 		privateKey:    privateKey,
 		logger:        logger,
-		prInfoCache:   NewPRInfoCache(prInfoCacheTTL),
 		installations: make(map[int64]*InstallationClient),
 	}
 
@@ -145,11 +133,10 @@ func (c *Client) ForInstallation(installationID int64) (*InstallationClient, err
 	httpc := &http.Client{Transport: transport, Timeout: 30 * time.Second}
 	ghClient := gh.NewClient(httpc)
 	ic := &InstallationClient{
-		client:      ghClient,
-		gql:         githubv4.NewEnterpriseClient(graphQLURLFor(ghClient), httpc),
-		logger:      c.logger,
-		appSlug:     c.appSlug,
-		prInfoCache: c.prInfoCache,
+		client:  ghClient,
+		gql:     githubv4.NewEnterpriseClient(graphQLURLFor(ghClient), httpc),
+		logger:  c.logger,
+		appSlug: c.appSlug,
 	}
 	c.installations[installationID] = ic
 	c.logger.Info("constructed installation client",
@@ -184,11 +171,10 @@ func graphQLURLFor(client *gh.Client) string {
 
 // InstallationClient wraps a go-github client scoped to a specific GitHub App installation.
 type InstallationClient struct {
-	client      *gh.Client
-	gql         *githubv4.Client
-	logger      *slog.Logger
-	appSlug     string // the app's slug, used to identify own check runs
-	prInfoCache *PRInfoCache
+	client  *gh.Client
+	gql     *githubv4.Client
+	logger  *slog.Logger
+	appSlug string // the app's slug, used to identify own check runs
 }
 
 // IsNotFoundError checks if an error is a GitHub API 404 Not Found error.
@@ -254,19 +240,34 @@ type PullRequestInfo struct {
 
 // FetchPullRequest gets PR information.
 //
-// Results are served from the Client-shared per-(repo, pr) cache when one
-// is configured, so back-to-back webhook deliveries and command bursts
-// targeting the same PR collapse to a single upstream GitHub call across
-// every InstallationClient spawned in that window. PullRequestInfo has no
-// identity-dependent fields, so cross-instance cache reuse is structurally
-// safe without any per-call re-derivation.
+// When ctx carries a request-scoped PR-info cache (attached via
+// WithPRInfoCache at a webhook entry point), repeated calls for the same
+// (repo, pr) within that scope collapse to a single upstream GitHub call.
+// The cache is intentionally NOT shared across webhook deliveries — a
+// PR's HeadSHA can change between deliveries, and a cross-delivery cache
+// would risk returning a stale HeadSHA to downstream checks-gate and
+// schema-discovery paths. A fresh cache per delivery cannot go stale by
+// construction.
+//
+// Callers without a request-scoped cache on ctx (tests, ad-hoc usage)
+// fall through to a raw fetch on every call.
 func (ic *InstallationClient) FetchPullRequest(ctx context.Context, repo string, pr int) (*PullRequestInfo, error) {
-	if ic.prInfoCache == nil {
+	cache := prInfoCacheFromContext(ctx)
+	if cache == nil {
 		return ic.fetchPullRequest(ctx, repo, pr)
 	}
-	return ic.prInfoCache.Do(ctx, repo, pr, func() (*PullRequestInfo, error) {
-		return ic.fetchPullRequest(ctx, repo, pr)
-	})
+	if info, ok := cache.get(repo, pr); ok {
+		// Hand each caller its own copy so a caller mutating the returned
+		// struct cannot affect another caller's view within the same scope.
+		copyOf := *info
+		return &copyOf, nil
+	}
+	info, err := ic.fetchPullRequest(ctx, repo, pr)
+	if err != nil {
+		return nil, err
+	}
+	cache.set(repo, pr, info)
+	return info, nil
 }
 
 func (ic *InstallationClient) fetchPullRequest(ctx context.Context, repo string, pr int) (*PullRequestInfo, error) {

--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -353,16 +353,21 @@ type PullRequestInfo struct {
 	User    string
 }
 
-// FetchPullRequest gets PR information.
+// FetchPullRequest is the dedupe-friendly variant. It honours the
+// request-scoped PR-info cache attached to ctx via WithPRInfoCache, so
+// repeated calls for the same (repo, pr) within one webhook delivery
+// collapse to a single upstream GitHub round trip. Use this for
+// discovery / gate work where consistency-within-a-delivery is required
+// and the cached snapshot is by construction not stale (the cache lives
+// and dies with the delivery's ctx, and a new commit triggers a new
+// delivery with its own fresh cache).
 //
-// When ctx carries a request-scoped PR-info cache (attached via
-// WithPRInfoCache at a webhook entry point), repeated calls for the same
-// (repo, pr) within that scope collapse to a single upstream GitHub call.
-// The cache is intentionally NOT shared across webhook deliveries — a
-// PR's HeadSHA can change between deliveries, and a cross-delivery cache
-// would risk returning a stale HeadSHA to downstream checks-gate and
-// schema-discovery paths. A fresh cache per delivery cannot go stale by
-// construction.
+// For safety re-checks where correctness requires the *current* GitHub
+// HEAD — e.g. the auto-confirm / apply-confirm revalidation, where a
+// new commit pushed after discovery must downgrade to manual
+// confirmation — call FetchPullRequestNoCache instead. Picking the
+// right method at the call site keeps the intent explicit and avoids
+// hidden ctx flags.
 //
 // Callers without a request-scoped cache on ctx (tests, ad-hoc usage)
 // fall through to a raw fetch on every call.
@@ -383,6 +388,21 @@ func (ic *InstallationClient) FetchPullRequest(ctx context.Context, repo string,
 	}
 	cache.set(repo, pr, info)
 	return info, nil
+}
+
+// FetchPullRequestNoCache is the revalidation-friendly variant. It always
+// issues a fresh GitHub request, bypassing any request-scoped PR-info
+// cache attached via WithPRInfoCache. Use this where correctness requires
+// the current GitHub HEAD — for example, the apply -y auto-confirm and
+// apply-confirm SHA re-checks, where a stale cached HeadSHA would let
+// the apply proceed against schema files fetched at an earlier commit
+// instead of downgrading to manual confirmation.
+//
+// Paired with FetchPullRequest (dedupe-friendly) so the call site
+// declares its intent without any hidden ctx-flag magic: discovery work
+// calls FetchPullRequest, safety re-checks call FetchPullRequestNoCache.
+func (ic *InstallationClient) FetchPullRequestNoCache(ctx context.Context, repo string, pr int) (*PullRequestInfo, error) {
+	return ic.fetchPullRequest(ctx, repo, pr)
 }
 
 func (ic *InstallationClient) fetchPullRequest(ctx context.Context, repo string, pr int) (*PullRequestInfo, error) {

--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -33,6 +33,20 @@ type Client struct {
 	logger          *slog.Logger
 	appSlug         string    // fetched from GitHub API at startup, used to identify own check runs
 	lastSlugAttempt time.Time // rate-limits slug fetch retries
+
+	// prInfoCache memoises FetchPullRequest results across every
+	// InstallationClient produced by ForInstallation, so back-to-back
+	// webhook deliveries and command bursts targeting the same (repo, pr)
+	// collapse to a single upstream GitHub call.
+	prInfoCache *PRInfoCache
+
+	// installations caches per-installation clients keyed by installationID
+	// so the underlying http.Client, gh.Client, githubv4.Client, and
+	// ghinstallation transport (and its installation-token cache) are
+	// reused across webhook deliveries instead of being reconstructed on
+	// every call. This also keeps any per-InstallationClient state warm.
+	installationsMu sync.Mutex
+	installations   map[int64]*InstallationClient
 }
 
 // slugFetchRetryCooldown is how long to wait between retry attempts when the
@@ -42,11 +56,23 @@ const slugFetchRetryCooldown = 5 * time.Second
 // NewClient creates a new GitHub App client and fetches the app's slug from GitHub.
 // If the slug can't be fetched (e.g., GitHub is down), the server still starts but
 // PR applies are blocked by the check gate since we can't identify our own checks.
+//
+// The returned Client owns a shared PRInfoCache with DefaultPRInfoCacheTTL that
+// is handed to every InstallationClient produced by ForInstallation. Use
+// NewClientWithCacheTTL to override the TTL (e.g., to 0 to disable caching).
 func NewClient(appID int64, privateKey []byte, logger *slog.Logger) *Client {
+	return NewClientWithCacheTTL(appID, privateKey, logger, DefaultPRInfoCacheTTL)
+}
+
+// NewClientWithCacheTTL constructs a Client with an explicit PRInfoCache TTL.
+// A non-positive TTL disables the cache: FetchPullRequest hits GitHub on every call.
+func NewClientWithCacheTTL(appID int64, privateKey []byte, logger *slog.Logger, prInfoCacheTTL time.Duration) *Client {
 	c := &Client{
-		appID:      appID,
-		privateKey: privateKey,
-		logger:     logger,
+		appID:         appID,
+		privateKey:    privateKey,
+		logger:        logger,
+		prInfoCache:   NewPRInfoCache(prInfoCacheTTL),
+		installations: make(map[int64]*InstallationClient),
 	}
 
 	// Fetch the app slug so we can identify our own check runs in statusCheckRollup.
@@ -77,9 +103,16 @@ func (c *Client) fetchAppSlug() {
 	c.logger.Info("fetched GitHub App slug", "slug", c.appSlug)
 }
 
-// ForInstallation creates a GitHub client scoped to a specific installation.
+// ForInstallation returns a GitHub client scoped to a specific installation,
+// reusing the cached client for that installationID when one already exists.
 // The ghinstallation library handles JWT generation, token exchange, caching,
-// and refresh automatically.
+// and refresh automatically; reusing the InstallationClient additionally
+// preserves HTTP keep-alive, the ghinstallation token cache, and any shared
+// per-installation state (such as PR-info cache hits) across webhook deliveries.
+//
+// The cached client's appSlug is refreshed on every call so a Client that
+// recovers its slug after a startup failure does not strand existing
+// InstallationClients with an empty slug.
 func (c *Client) ForInstallation(installationID int64) (*InstallationClient, error) {
 	// Retry slug fetch if it failed at startup (e.g., GitHub was down).
 	// Rate-limited to once per 5 seconds to avoid hammering GitHub during
@@ -93,18 +126,35 @@ func (c *Client) ForInstallation(installationID int64) (*InstallationClient, err
 			c.logger.Error("app slug unavailable — check gate will block PR applies if own checks are failing")
 		}
 	}
+
+	c.installationsMu.Lock()
+	defer c.installationsMu.Unlock()
+
+	if existing, ok := c.installations[installationID]; ok {
+		// Refresh the cached client's slug snapshot so a slug recovery
+		// during the lifetime of this process propagates to clients
+		// constructed before recovery.
+		existing.appSlug = c.appSlug
+		return existing, nil
+	}
+
 	transport, err := ghinstallation.New(http.DefaultTransport, c.appID, installationID, c.privateKey)
 	if err != nil {
-		return nil, fmt.Errorf("create installation transport: %w", err)
+		return nil, fmt.Errorf("create installation transport for installation %d: %w", installationID, err)
 	}
 	httpc := &http.Client{Transport: transport, Timeout: 30 * time.Second}
 	ghClient := gh.NewClient(httpc)
-	return &InstallationClient{
-		client:  ghClient,
-		gql:     githubv4.NewEnterpriseClient(graphQLURLFor(ghClient), httpc),
-		logger:  c.logger,
-		appSlug: c.appSlug,
-	}, nil
+	ic := &InstallationClient{
+		client:      ghClient,
+		gql:         githubv4.NewEnterpriseClient(graphQLURLFor(ghClient), httpc),
+		logger:      c.logger,
+		appSlug:     c.appSlug,
+		prInfoCache: c.prInfoCache,
+	}
+	c.installations[installationID] = ic
+	c.logger.Info("constructed installation client",
+		"installation_id", installationID, "app_slug", c.appSlug)
+	return ic, nil
 }
 
 // NewInstallationClient creates an InstallationClient from a pre-configured go-github client.
@@ -134,10 +184,11 @@ func graphQLURLFor(client *gh.Client) string {
 
 // InstallationClient wraps a go-github client scoped to a specific GitHub App installation.
 type InstallationClient struct {
-	client  *gh.Client
-	gql     *githubv4.Client
-	logger  *slog.Logger
-	appSlug string // the app's slug, used to identify own check runs
+	client      *gh.Client
+	gql         *githubv4.Client
+	logger      *slog.Logger
+	appSlug     string // the app's slug, used to identify own check runs
+	prInfoCache *PRInfoCache
 }
 
 // IsNotFoundError checks if an error is a GitHub API 404 Not Found error.
@@ -202,11 +253,27 @@ type PullRequestInfo struct {
 }
 
 // FetchPullRequest gets PR information.
+//
+// Results are served from the Client-shared per-(repo, pr) cache when one
+// is configured, so back-to-back webhook deliveries and command bursts
+// targeting the same PR collapse to a single upstream GitHub call across
+// every InstallationClient spawned in that window. PullRequestInfo has no
+// identity-dependent fields, so cross-instance cache reuse is structurally
+// safe without any per-call re-derivation.
 func (ic *InstallationClient) FetchPullRequest(ctx context.Context, repo string, pr int) (*PullRequestInfo, error) {
+	if ic.prInfoCache == nil {
+		return ic.fetchPullRequest(ctx, repo, pr)
+	}
+	return ic.prInfoCache.Do(ctx, repo, pr, func() (*PullRequestInfo, error) {
+		return ic.fetchPullRequest(ctx, repo, pr)
+	})
+}
+
+func (ic *InstallationClient) fetchPullRequest(ctx context.Context, repo string, pr int) (*PullRequestInfo, error) {
 	owner, repoName := splitRepo(repo)
 	ghPR, _, err := ic.client.PullRequests.Get(ctx, owner, repoName, pr)
 	if err != nil {
-		return nil, fmt.Errorf("fetch pull request: %w", err)
+		return nil, fmt.Errorf("fetch pull request %s#%d: %w", repo, pr, err)
 	}
 	return &PullRequestInfo{
 		HeadRef: ghPR.GetHead().GetRef(),

--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -13,6 +13,7 @@ import (
 	"path"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/bradleyfalzon/ghinstallation/v2"
@@ -28,11 +29,23 @@ type GitHubClientFactory interface {
 
 // Client handles GitHub App-level operations and creates per-installation clients.
 type Client struct {
-	appID           int64
-	privateKey      []byte
-	logger          *slog.Logger
-	appSlug         string    // fetched from GitHub API at startup, used to identify own check runs
-	lastSlugAttempt time.Time // rate-limits slug fetch retries
+	appID      int64
+	privateKey []byte
+	logger     *slog.Logger
+
+	// appSlug is the GitHub App's slug, fetched from GitHub at startup
+	// (best-effort — may be empty if the initial fetch failed). It is
+	// stored as atomic.Pointer[string] so concurrent ForInstallation and
+	// InstallationClient.isOwnAppSlug calls observe consistent values
+	// without holding a lock on the hot read path. The pointer is non-nil
+	// after NewClient returns (holds the empty string if the fetch failed).
+	appSlug atomic.Pointer[string]
+
+	// slugFetchMu serialises slug-fetch attempts so concurrent
+	// ForInstallation callers do not thundering-herd retry on startup
+	// failure. lastSlugAttempt is read+written only under this mutex.
+	slugFetchMu     sync.Mutex
+	lastSlugAttempt time.Time
 
 	// installations caches per-installation clients keyed by installationID
 	// so the underlying http.Client, gh.Client, githubv4.Client, and
@@ -41,6 +54,19 @@ type Client struct {
 	// every call.
 	installationsMu sync.Mutex
 	installations   map[int64]*InstallationClient
+}
+
+// loadAppSlug returns the current app slug, or empty if not yet fetched.
+func (c *Client) loadAppSlug() string {
+	if p := c.appSlug.Load(); p != nil {
+		return *p
+	}
+	return ""
+}
+
+// storeAppSlug atomically updates the app slug.
+func (c *Client) storeAppSlug(slug string) {
+	c.appSlug.Store(&slug)
 }
 
 // slugFetchRetryCooldown is how long to wait between retry attempts when the
@@ -62,6 +88,9 @@ func NewClient(appID int64, privateKey []byte, logger *slog.Logger) *Client {
 		logger:        logger,
 		installations: make(map[int64]*InstallationClient),
 	}
+	// Seed the atomic with the empty string so loadAppSlug never returns
+	// from a nil pointer.
+	c.storeAppSlug("")
 
 	// Fetch the app slug so we can identify our own check runs in statusCheckRollup.
 	// Non-fatal: if GitHub is down, the server still starts but the check gate won't
@@ -74,7 +103,10 @@ func NewClient(appID int64, privateKey []byte, logger *slog.Logger) *Client {
 // fetchAppSlug fetches the app slug from GitHub via GET /app.
 // On failure, logs an error and leaves appSlug empty.
 func (c *Client) fetchAppSlug() {
+	c.slugFetchMu.Lock()
 	c.lastSlugAttempt = time.Now()
+	c.slugFetchMu.Unlock()
+
 	transport, err := ghinstallation.NewAppsTransport(http.DefaultTransport, c.appID, c.privateKey)
 	if err != nil {
 		c.logger.Error("failed to create app transport for slug fetch", "error", err)
@@ -87,8 +119,9 @@ func (c *Client) fetchAppSlug() {
 			"app_id", c.appID, "error", err)
 		return
 	}
-	c.appSlug = app.GetSlug()
-	c.logger.Info("fetched GitHub App slug", "slug", c.appSlug)
+	slug := app.GetSlug()
+	c.storeAppSlug(slug)
+	c.logger.Info("fetched GitHub App slug", "slug", slug)
 }
 
 // ForInstallation returns a GitHub client scoped to a specific installation,
@@ -105,24 +138,30 @@ func (c *Client) ForInstallation(installationID int64) (*InstallationClient, err
 	// Retry slug fetch if it failed at startup (e.g., GitHub was down).
 	// Rate-limited to once per 5 seconds to avoid hammering GitHub during
 	// an outage while still recovering quickly once it's back.
-	if c.appSlug == "" {
-		if time.Since(c.lastSlugAttempt) > slugFetchRetryCooldown {
+	if c.loadAppSlug() == "" {
+		c.slugFetchMu.Lock()
+		shouldRetry := time.Since(c.lastSlugAttempt) > slugFetchRetryCooldown
+		c.slugFetchMu.Unlock()
+		if shouldRetry {
 			c.logger.Info("app slug not yet fetched, retrying")
 			c.fetchAppSlug()
 		}
-		if c.appSlug == "" {
+		if c.loadAppSlug() == "" {
 			c.logger.Error("app slug unavailable — check gate will block PR applies if own checks are failing")
 		}
 	}
+
+	slug := c.loadAppSlug()
 
 	c.installationsMu.Lock()
 	defer c.installationsMu.Unlock()
 
 	if existing, ok := c.installations[installationID]; ok {
-		// Refresh the cached client's slug snapshot so a slug recovery
-		// during the lifetime of this process propagates to clients
-		// constructed before recovery.
-		existing.appSlug = c.appSlug
+		// Refresh the cached client's slug snapshot atomically so a slug
+		// recovery during the lifetime of this process propagates to
+		// clients constructed before recovery — without racing concurrent
+		// isOwnAppSlug reads on the same InstallationClient.
+		existing.storeAppSlug(slug)
 		return existing, nil
 	}
 
@@ -133,14 +172,14 @@ func (c *Client) ForInstallation(installationID int64) (*InstallationClient, err
 	httpc := &http.Client{Transport: transport, Timeout: 30 * time.Second}
 	ghClient := gh.NewClient(httpc)
 	ic := &InstallationClient{
-		client:  ghClient,
-		gql:     githubv4.NewEnterpriseClient(graphQLURLFor(ghClient), httpc),
-		logger:  c.logger,
-		appSlug: c.appSlug,
+		client: ghClient,
+		gql:    githubv4.NewEnterpriseClient(graphQLURLFor(ghClient), httpc),
+		logger: c.logger,
 	}
+	ic.storeAppSlug(slug)
 	c.installations[installationID] = ic
 	c.logger.Info("constructed installation client",
-		"installation_id", installationID, "app_slug", c.appSlug)
+		"installation_id", installationID, "app_slug", slug)
 	return ic, nil
 }
 
@@ -154,12 +193,13 @@ func NewInstallationClient(client *gh.Client, logger *slog.Logger) *Installation
 
 // NewInstallationClientWithSlug creates an InstallationClient with an explicit app slug.
 func NewInstallationClientWithSlug(client *gh.Client, logger *slog.Logger, appSlug string) *InstallationClient {
-	return &InstallationClient{
-		client:  client,
-		gql:     githubv4.NewEnterpriseClient(graphQLURLFor(client), client.Client()),
-		logger:  logger,
-		appSlug: appSlug,
+	ic := &InstallationClient{
+		client: client,
+		gql:    githubv4.NewEnterpriseClient(graphQLURLFor(client), client.Client()),
+		logger: logger,
 	}
+	ic.storeAppSlug(appSlug)
+	return ic
 }
 
 // graphQLURLFor returns the GraphQL endpoint for a given go-github client by
@@ -171,10 +211,29 @@ func graphQLURLFor(client *gh.Client) string {
 
 // InstallationClient wraps a go-github client scoped to a specific GitHub App installation.
 type InstallationClient struct {
-	client  *gh.Client
-	gql     *githubv4.Client
-	logger  *slog.Logger
-	appSlug string // the app's slug, used to identify own check runs
+	client *gh.Client
+	gql    *githubv4.Client
+	logger *slog.Logger
+
+	// appSlug is the GitHub App's slug used to identify own check runs.
+	// Stored as atomic.Pointer[string] because cached InstallationClients
+	// are reused across webhook deliveries and ForInstallation may refresh
+	// this field after a slug recovery while concurrent isOwnAppSlug reads
+	// run on other goroutines.
+	appSlug atomic.Pointer[string]
+}
+
+// loadAppSlug returns the current app slug, or empty if not yet set.
+func (ic *InstallationClient) loadAppSlug() string {
+	if p := ic.appSlug.Load(); p != nil {
+		return *p
+	}
+	return ""
+}
+
+// storeAppSlug atomically updates the app slug.
+func (ic *InstallationClient) storeAppSlug(slug string) {
+	ic.appSlug.Store(&slug)
 }
 
 // IsNotFoundError checks if an error is a GitHub API 404 Not Found error.
@@ -503,8 +562,17 @@ type statusCheckRollupQuery struct {
 }
 
 // isOwnAppSlug returns true if the given slug belongs to this SchemaBot instance.
+// Returns false on empty slug (defends against StatusContext rows and clients
+// whose appSlug has not yet been fetched).
 func (ic *InstallationClient) isOwnAppSlug(slug string) bool {
-	return strings.EqualFold(slug, ic.appSlug)
+	if slug == "" {
+		return false
+	}
+	own := ic.loadAppSlug()
+	if own == "" {
+		return false
+	}
+	return strings.EqualFold(slug, own)
 }
 
 // GetPRCheckStatuses fetches all check runs and commit statuses for a ref via

--- a/pkg/github/pr_info_cache.go
+++ b/pkg/github/pr_info_cache.go
@@ -4,156 +4,68 @@ import (
 	"context"
 	"strconv"
 	"sync"
-	"time"
-
-	"golang.org/x/sync/singleflight"
 )
 
-// DefaultPRInfoCacheTTL is the default TTL used when NewClient constructs
-// the shared PRInfoCache. 30s is long enough to absorb webhook retries
-// and tight back-to-back command bursts targeting the same (repo, pr),
-// but short enough that staleness is irrelevant for human-paced PR
-// comment flows.
-const DefaultPRInfoCacheTTL = 30 * time.Second
-
-// PRInfoCache memoises FetchPullRequest results keyed by (repo, pr) with
-// a fixed TTL. Concurrent fetches for the same key collapse into a single
-// upstream request via singleflight. Errors are not cached — each failure
-// re-attempts fresh so transient GitHub outages do not pin a bad state
-// for the TTL window.
+// requestPRInfoCache memoises FetchPullRequest results for the lifetime
+// of a single webhook delivery (or any other ctx-bounded operation it is
+// attached to). A fresh cache is constructed at every entry point via
+// WithPRInfoCache, so the cached value cannot outlive the scope it was
+// created for — eliminating the staleness risk that a TTL'd cross-delivery
+// cache would have for mutable PR head data (HeadSHA can change between
+// deliveries when a new commit is pushed).
 //
-// One cache is owned by the Client factory and shared across every
-// InstallationClient it produces, so cache hits actually accrue across
-// the short-lived InstallationClients spawned per webhook delivery —
-// which is the dedup pattern that justifies the cache.
-//
-// Unlike CheckStatusCache, the cached value is stored directly as
-// PullRequestInfo: it has no identity-dependent fields (HeadRef, HeadSHA,
-// BaseRef, BaseSHA, User), so cross-instance reuse is structurally safe
-// without any per-call re-derivation.
-type PRInfoCache struct {
-	ttl   time.Duration
-	mu    sync.RWMutex
-	m     map[string]prInfoCacheEntry
-	group singleflight.Group
-	now   func() time.Time // overridable for tests
+// Within one scope, multiple handlers calling FetchPullRequest for the
+// same (repo, pr) collapse to a single upstream GitHub call. Concurrent
+// callers from spawned goroutines that share the ctx see the populated
+// entry once the first fetch completes.
+type requestPRInfoCache struct {
+	mu sync.Mutex
+	m  map[string]*PullRequestInfo
 }
 
-type prInfoCacheEntry struct {
-	info    PullRequestInfo
-	fetched time.Time
-}
+type prInfoCacheCtxKey struct{}
 
-// NewPRInfoCache constructs a cache with the given TTL. A non-positive
-// TTL disables caching: Do always invokes fetch.
-func NewPRInfoCache(ttl time.Duration) *PRInfoCache {
-	return &PRInfoCache{
-		ttl: ttl,
-		m:   make(map[string]prInfoCacheEntry),
-		now: time.Now,
-	}
-}
-
-// Do returns the cached PR info for (repo, pr) if a fresh entry exists,
-// otherwise invokes fetch and stores its result. Concurrent callers for
-// the same (repo, pr) collapse into a single fetch invocation.
+// WithPRInfoCache returns a new context carrying a fresh request-scoped
+// PR-info cache. Webhook entry points should wrap their per-operation
+// ctx with this so FetchPullRequest calls within that scope dedupe.
 //
-// Each caller observes its own ctx for cancellation/deadline: a caller
-// whose ctx fires while waiting on another caller's in-flight fetch
-// returns promptly with ctx.Err(), without aborting the shared fetch
-// (other waiters and future callers can still receive its result).
-//
-// When the cache's TTL is non-positive, fetch is invoked on every call
-// and no result is stored.
-//
-// The returned *PullRequestInfo points to a fresh copy of the cached
-// value, so callers can read or mutate it freely without affecting
-// other readers.
-func (c *PRInfoCache) Do(ctx context.Context, repo string, pr int, fetch func() (*PullRequestInfo, error)) (*PullRequestInfo, error) {
-	if c.ttl <= 0 {
-		return fetch()
-	}
-
-	key := repo + "#" + strconv.Itoa(pr)
-
-	if info, ok := c.lookup(key); ok {
-		return info, nil
-	}
-
-	ch := c.group.DoChan(key, func() (any, error) {
-		// Re-check inside the single-flight critical section: a concurrent
-		// caller may have populated the entry between our miss and here.
-		if info, ok := c.lookup(key); ok {
-			return info, nil
-		}
-		info, err := fetch()
-		if err != nil {
-			return nil, err
-		}
-		if info == nil {
-			return nil, nil
-		}
-		c.store(key, *info)
-		// Return a fresh copy so subsequent waiters/callers each get their
-		// own pointer.
-		stored := *info
-		return &stored, nil
+// Calling WithPRInfoCache twice on the same ctx replaces the previous
+// cache with a fresh one; nested scopes thus get their own clean cache.
+func WithPRInfoCache(ctx context.Context) context.Context {
+	return context.WithValue(ctx, prInfoCacheCtxKey{}, &requestPRInfoCache{
+		m: make(map[string]*PullRequestInfo),
 	})
-
-	select {
-	case res := <-ch:
-		if res.Err != nil {
-			return nil, res.Err
-		}
-		if res.Val == nil {
-			return nil, nil
-		}
-		// Single-flight broadcasts the same value to every waiter. Hand
-		// each one its own copy so a caller mutating the returned struct
-		// cannot affect another caller's view.
-		shared := res.Val.(*PullRequestInfo)
-		copyOf := *shared
-		return &copyOf, nil
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	}
 }
 
-func (c *PRInfoCache) lookup(key string) (*PullRequestInfo, bool) {
-	c.mu.RLock()
-	entry, ok := c.m[key]
-	c.mu.RUnlock()
-	if !ok {
-		return nil, false
-	}
-	if c.now().Sub(entry.fetched) >= c.ttl {
-		// Opportunistically evict on read so a key that is repeatedly
-		// looked up after expiry does not occupy memory until something
-		// happens to write to it.
-		c.mu.Lock()
-		if cur, stillThere := c.m[key]; stillThere && c.now().Sub(cur.fetched) >= c.ttl {
-			delete(c.m, key)
-		}
-		c.mu.Unlock()
-		return nil, false
-	}
-	info := entry.info
-	return &info, true
+// prInfoCacheFromContext returns the request-scoped cache attached to ctx,
+// or nil if none has been attached. Returning nil lets FetchPullRequest
+// fall through to a raw fetch for callers (tests, ad-hoc usage) that did
+// not set up a cache scope.
+func prInfoCacheFromContext(ctx context.Context) *requestPRInfoCache {
+	c, _ := ctx.Value(prInfoCacheCtxKey{}).(*requestPRInfoCache)
+	return c
 }
 
-func (c *PRInfoCache) store(key string, info PullRequestInfo) {
+// get returns the cached PR info for (repo, pr) if present.
+func (c *requestPRInfoCache) get(repo string, pr int) (*PullRequestInfo, bool) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	// Sweep expired entries so the map stays bounded by the active
-	// working set within the TTL window, not the total distinct keys
-	// ever seen. Keys that are written once and never looked up again
-	// (e.g. an inactive PR) would otherwise occupy memory for the
-	// lifetime of the process.
-	now := c.now()
-	for k, entry := range c.m {
-		if now.Sub(entry.fetched) >= c.ttl {
-			delete(c.m, k)
-		}
+	info, ok := c.m[cacheKey(repo, pr)]
+	return info, ok
+}
+
+// set stores PR info for (repo, pr). A copy is stored so callers
+// mutating the returned struct cannot affect the cached value.
+func (c *requestPRInfoCache) set(repo string, pr int, info *PullRequestInfo) {
+	if info == nil {
+		return
 	}
-	c.m[key] = prInfoCacheEntry{info: info, fetched: now}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	stored := *info
+	c.m[cacheKey(repo, pr)] = &stored
+}
+
+func cacheKey(repo string, pr int) string {
+	return repo + "#" + strconv.Itoa(pr)
 }

--- a/pkg/github/pr_info_cache.go
+++ b/pkg/github/pr_info_cache.go
@@ -1,0 +1,159 @@
+package github
+
+import (
+	"context"
+	"strconv"
+	"sync"
+	"time"
+
+	"golang.org/x/sync/singleflight"
+)
+
+// DefaultPRInfoCacheTTL is the default TTL used when NewClient constructs
+// the shared PRInfoCache. 30s is long enough to absorb webhook retries
+// and tight back-to-back command bursts targeting the same (repo, pr),
+// but short enough that staleness is irrelevant for human-paced PR
+// comment flows.
+const DefaultPRInfoCacheTTL = 30 * time.Second
+
+// PRInfoCache memoises FetchPullRequest results keyed by (repo, pr) with
+// a fixed TTL. Concurrent fetches for the same key collapse into a single
+// upstream request via singleflight. Errors are not cached — each failure
+// re-attempts fresh so transient GitHub outages do not pin a bad state
+// for the TTL window.
+//
+// One cache is owned by the Client factory and shared across every
+// InstallationClient it produces, so cache hits actually accrue across
+// the short-lived InstallationClients spawned per webhook delivery —
+// which is the dedup pattern that justifies the cache.
+//
+// Unlike CheckStatusCache, the cached value is stored directly as
+// PullRequestInfo: it has no identity-dependent fields (HeadRef, HeadSHA,
+// BaseRef, BaseSHA, User), so cross-instance reuse is structurally safe
+// without any per-call re-derivation.
+type PRInfoCache struct {
+	ttl   time.Duration
+	mu    sync.RWMutex
+	m     map[string]prInfoCacheEntry
+	group singleflight.Group
+	now   func() time.Time // overridable for tests
+}
+
+type prInfoCacheEntry struct {
+	info    PullRequestInfo
+	fetched time.Time
+}
+
+// NewPRInfoCache constructs a cache with the given TTL. A non-positive
+// TTL disables caching: Do always invokes fetch.
+func NewPRInfoCache(ttl time.Duration) *PRInfoCache {
+	return &PRInfoCache{
+		ttl: ttl,
+		m:   make(map[string]prInfoCacheEntry),
+		now: time.Now,
+	}
+}
+
+// Do returns the cached PR info for (repo, pr) if a fresh entry exists,
+// otherwise invokes fetch and stores its result. Concurrent callers for
+// the same (repo, pr) collapse into a single fetch invocation.
+//
+// Each caller observes its own ctx for cancellation/deadline: a caller
+// whose ctx fires while waiting on another caller's in-flight fetch
+// returns promptly with ctx.Err(), without aborting the shared fetch
+// (other waiters and future callers can still receive its result).
+//
+// When the cache's TTL is non-positive, fetch is invoked on every call
+// and no result is stored.
+//
+// The returned *PullRequestInfo points to a fresh copy of the cached
+// value, so callers can read or mutate it freely without affecting
+// other readers.
+func (c *PRInfoCache) Do(ctx context.Context, repo string, pr int, fetch func() (*PullRequestInfo, error)) (*PullRequestInfo, error) {
+	if c.ttl <= 0 {
+		return fetch()
+	}
+
+	key := repo + "#" + strconv.Itoa(pr)
+
+	if info, ok := c.lookup(key); ok {
+		return info, nil
+	}
+
+	ch := c.group.DoChan(key, func() (any, error) {
+		// Re-check inside the single-flight critical section: a concurrent
+		// caller may have populated the entry between our miss and here.
+		if info, ok := c.lookup(key); ok {
+			return info, nil
+		}
+		info, err := fetch()
+		if err != nil {
+			return nil, err
+		}
+		if info == nil {
+			return nil, nil
+		}
+		c.store(key, *info)
+		// Return a fresh copy so subsequent waiters/callers each get their
+		// own pointer.
+		stored := *info
+		return &stored, nil
+	})
+
+	select {
+	case res := <-ch:
+		if res.Err != nil {
+			return nil, res.Err
+		}
+		if res.Val == nil {
+			return nil, nil
+		}
+		// Single-flight broadcasts the same value to every waiter. Hand
+		// each one its own copy so a caller mutating the returned struct
+		// cannot affect another caller's view.
+		shared := res.Val.(*PullRequestInfo)
+		copyOf := *shared
+		return &copyOf, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+func (c *PRInfoCache) lookup(key string) (*PullRequestInfo, bool) {
+	c.mu.RLock()
+	entry, ok := c.m[key]
+	c.mu.RUnlock()
+	if !ok {
+		return nil, false
+	}
+	if c.now().Sub(entry.fetched) >= c.ttl {
+		// Opportunistically evict on read so a key that is repeatedly
+		// looked up after expiry does not occupy memory until something
+		// happens to write to it.
+		c.mu.Lock()
+		if cur, stillThere := c.m[key]; stillThere && c.now().Sub(cur.fetched) >= c.ttl {
+			delete(c.m, key)
+		}
+		c.mu.Unlock()
+		return nil, false
+	}
+	info := entry.info
+	return &info, true
+}
+
+func (c *PRInfoCache) store(key string, info PullRequestInfo) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	// Sweep expired entries so the map stays bounded by the active
+	// working set within the TTL window, not the total distinct keys
+	// ever seen. Keys that are written once and never looked up again
+	// (e.g. an inactive PR) would otherwise occupy memory for the
+	// lifetime of the process.
+	now := c.now()
+	for k, entry := range c.m {
+		if now.Sub(entry.fetched) >= c.ttl {
+			delete(c.m, k)
+		}
+	}
+	c.m[key] = prInfoCacheEntry{info: info, fetched: now}
+}

--- a/pkg/github/pr_info_cache_test.go
+++ b/pkg/github/pr_info_cache_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -161,10 +162,10 @@ func TestForInstallation_CachesByInstallationID(t *testing.T) {
 	c := &Client{
 		appID:         12345,
 		logger:        slog.New(slog.NewTextHandler(prDiscardWriter{}, &slog.HandlerOptions{Level: slog.LevelError})),
-		appSlug:       "schemabot", // bypass the slug-fetch retry path
 		installations: make(map[int64]*InstallationClient),
 		privateKey:    testRSAKeyPEM(t),
 	}
+	c.storeAppSlug("schemabot") // bypass the slug-fetch retry path
 
 	a1, err := c.ForInstallation(100)
 	require.NoError(t, err)
@@ -186,24 +187,85 @@ func TestForInstallation_RefreshesSlugOnCachedClient(t *testing.T) {
 	c := &Client{
 		appID:         12345,
 		logger:        slog.New(slog.NewTextHandler(prDiscardWriter{}, &slog.HandlerOptions{Level: slog.LevelError})),
-		appSlug:       "", // slug was unavailable at construction time
 		installations: make(map[int64]*InstallationClient),
 		privateKey:    testRSAKeyPEM(t),
 	}
+	c.storeAppSlug("") // slug was unavailable at construction time
 	// Bypass the slug-fetch retry by claiming we just tried.
 	c.lastSlugAttempt = time.Now()
 
 	ic1, err := c.ForInstallation(100)
 	require.NoError(t, err)
-	assert.Equal(t, "", ic1.appSlug, "client constructed before recovery must start with empty slug")
+	assert.Equal(t, "", ic1.loadAppSlug(), "client constructed before recovery must start with empty slug")
 
 	// Simulate the slug becoming available later.
-	c.appSlug = "schemabot"
+	c.storeAppSlug("schemabot")
 
 	ic2, err := c.ForInstallation(100)
 	require.NoError(t, err)
 	assert.Same(t, ic1, ic2, "same InstallationClient should be returned (no rebuild)")
-	assert.Equal(t, "schemabot", ic2.appSlug, "cached InstallationClient must adopt the recovered slug")
+	assert.Equal(t, "schemabot", ic2.loadAppSlug(), "cached InstallationClient must adopt the recovered slug")
+}
+
+// TestForInstallation_AppSlugIsRaceFreeUnderConcurrency locks in the
+// invariant that concurrent ForInstallation calls refreshing the cached
+// InstallationClient's appSlug do not race with concurrent isOwnAppSlug
+// reads on that same client. Without atomic.Pointer access, the race
+// detector would flag the unsynchronised string mutation here.
+func TestForInstallation_AppSlugIsRaceFreeUnderConcurrency(t *testing.T) {
+	c := &Client{
+		appID:         12345,
+		logger:        slog.New(slog.NewTextHandler(prDiscardWriter{}, &slog.HandlerOptions{Level: slog.LevelError})),
+		installations: make(map[int64]*InstallationClient),
+		privateKey:    testRSAKeyPEM(t),
+	}
+	c.storeAppSlug("schemabot")
+
+	// Prime the cache so subsequent ForInstallation calls hit the
+	// refresh path that writes existing.appSlug.
+	ic, err := c.ForInstallation(100)
+	require.NoError(t, err)
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+
+	// Writers: drive ForInstallation, which refreshes existing.appSlug.
+	for range 4 {
+		wg.Go(func() {
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					// Alternate slug values to maximise the chance of a
+					// torn read if access were unsynchronised.
+					c.storeAppSlug("schemabot")
+					_, _ = c.ForInstallation(100)
+					c.storeAppSlug("schemabot-alt")
+					_, _ = c.ForInstallation(100)
+				}
+			}
+		})
+	}
+
+	// Readers: pound isOwnAppSlug on the cached client.
+	for range 4 {
+		wg.Go(func() {
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					ic.isOwnAppSlug("schemabot")
+					ic.isOwnAppSlug("other")
+				}
+			}
+		})
+	}
+
+	time.Sleep(100 * time.Millisecond)
+	close(stop)
+	wg.Wait()
 }
 
 // newPRFakeGitHubServer returns an httptest server that responds to

--- a/pkg/github/pr_info_cache_test.go
+++ b/pkg/github/pr_info_cache_test.go
@@ -133,6 +133,90 @@ func TestFetchPullRequest_ErrorsAreNotCached(t *testing.T) {
 	assert.Equal(t, int32(3), calls.Load())
 }
 
+// TestFetchPullRequestNoCache_AlwaysHitsGitHubAndDoesNotPoisonCache locks
+// in the dedupe-friendly vs revalidation-friendly contract: the cached
+// variant (FetchPullRequest) returns the request-scoped cached value;
+// the bypassing variant (FetchPullRequestNoCache) always issues a fresh
+// GitHub request even when a cached value exists for the same scope and
+// (repo, pr). The bypassing variant must NOT write its fresh result
+// back into the cache — otherwise discovery sites within the same scope
+// would observe a phantom "second SHA" mid-delivery and lose internal
+// consistency.
+//
+// This is the invariant that defends the auto-confirm / apply-confirm
+// SHA re-checks against the staleness Codex flagged on PR #114: if a
+// new commit lands after CreateSchemaRequestFromPR populates the cache,
+// the revalidation fetch must see the current GitHub HEAD instead of
+// the cached snapshot.
+func TestFetchPullRequestNoCache_AlwaysHitsGitHubAndDoesNotPoisonCache(t *testing.T) {
+	var calls atomic.Int32
+	var headSHA atomic.Value
+	headSHA.Store("abc")
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/octo/repo/pulls/42", func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"head": map[string]string{"ref": "feature", "sha": headSHA.Load().(string)},
+			"base": map[string]string{"ref": "main", "sha": "base"},
+			"user": map[string]string{"login": "octocat"},
+		})
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	ic := newPRTestInstallationClient(t, server)
+	ctx := WithPRInfoCache(t.Context())
+
+	// Discovery phase: populate the cache with HeadSHA=abc.
+	got, err := ic.FetchPullRequest(ctx, "octo/repo", 42)
+	require.NoError(t, err)
+	assert.Equal(t, "abc", got.HeadSHA)
+	assert.Equal(t, int32(1), calls.Load(), "first FetchPullRequest must hit GitHub")
+
+	// Dedupe-friendly second call: cache HIT, no GitHub round trip.
+	got, err = ic.FetchPullRequest(ctx, "octo/repo", 42)
+	require.NoError(t, err)
+	assert.Equal(t, "abc", got.HeadSHA)
+	assert.Equal(t, int32(1), calls.Load(), "second FetchPullRequest must dedupe via the cache")
+
+	// Simulate a new commit landing on the PR branch between discovery
+	// and the auto-confirm / apply-confirm revalidation.
+	headSHA.Store("def")
+
+	// Revalidation-friendly call: must bypass the cache and return def.
+	fresh, err := ic.FetchPullRequestNoCache(ctx, "octo/repo", 42)
+	require.NoError(t, err)
+	assert.Equal(t, "def", fresh.HeadSHA,
+		"FetchPullRequestNoCache must bypass the cache and return the current GitHub HEAD")
+	assert.Equal(t, int32(2), calls.Load(), "FetchPullRequestNoCache must always hit GitHub")
+
+	// Subsequent dedupe-friendly call must still observe the original
+	// cached abc — FetchPullRequestNoCache must NOT have written def
+	// back into the cache and corrupted other discovery callers' view.
+	got, err = ic.FetchPullRequest(ctx, "octo/repo", 42)
+	require.NoError(t, err)
+	assert.Equal(t, "abc", got.HeadSHA,
+		"FetchPullRequestNoCache must not poison the cache with its fresh result")
+	assert.Equal(t, int32(2), calls.Load(), "post-bypass FetchPullRequest must still HIT the original cache entry")
+}
+
+// TestFetchPullRequestNoCache_NoCacheOnContextStillFetches verifies that
+// the bypassing variant works the same way whether or not a request-scoped
+// cache is attached — it always issues a fresh GitHub request.
+func TestFetchPullRequestNoCache_NoCacheOnContextStillFetches(t *testing.T) {
+	server, calls := newPRFakeGitHubServer(t)
+	defer server.Close()
+
+	ic := newPRTestInstallationClient(t, server)
+
+	for range 3 {
+		_, err := ic.FetchPullRequestNoCache(t.Context(), "octo/repo", 42)
+		require.NoError(t, err)
+	}
+	assert.Equal(t, int32(3), calls.Load(), "FetchPullRequestNoCache must hit GitHub on every call regardless of ctx cache state")
+}
+
 // TestFetchPullRequest_ReturnsIndependentCopies verifies that callers
 // within a single scope receive independent *PullRequestInfo values —
 // mutating one must not affect another caller's view.

--- a/pkg/github/pr_info_cache_test.go
+++ b/pkg/github/pr_info_cache_test.go
@@ -1,0 +1,477 @@
+package github
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	gh "github.com/google/go-github/v68/github"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPRInfoCache_HitsCacheWithinTTL(t *testing.T) {
+	clock := newPRInfoFakeClock()
+	c := NewPRInfoCache(time.Minute)
+	c.now = clock.Now
+
+	var calls atomic.Int32
+	fetch := func() (*PullRequestInfo, error) {
+		calls.Add(1)
+		return &PullRequestInfo{HeadSHA: "abc123", User: "octocat"}, nil
+	}
+
+	first, err := c.Do(t.Context(), "octo/repo", 42, fetch)
+	require.NoError(t, err)
+
+	clock.Advance(30 * time.Second) // still inside TTL
+
+	second, err := c.Do(t.Context(), "octo/repo", 42, fetch)
+	require.NoError(t, err)
+
+	assert.Equal(t, *first, *second, "second call should return the cached value")
+	assert.Equal(t, int32(1), calls.Load(), "fetch should be invoked only once within the TTL")
+}
+
+func TestPRInfoCache_RefetchesAfterTTL(t *testing.T) {
+	clock := newPRInfoFakeClock()
+	c := NewPRInfoCache(time.Minute)
+	c.now = clock.Now
+
+	var calls atomic.Int32
+	fetch := func() (*PullRequestInfo, error) {
+		calls.Add(1)
+		return &PullRequestInfo{HeadSHA: "abc123"}, nil
+	}
+
+	_, err := c.Do(t.Context(), "octo/repo", 42, fetch)
+	require.NoError(t, err)
+
+	clock.Advance(time.Minute + time.Second) // outside TTL
+
+	_, err = c.Do(t.Context(), "octo/repo", 42, fetch)
+	require.NoError(t, err)
+
+	assert.Equal(t, int32(2), calls.Load(), "expired entry should trigger a fresh fetch")
+}
+
+func TestPRInfoCache_KeysAreIndependent(t *testing.T) {
+	c := NewPRInfoCache(time.Minute)
+	c.now = newPRInfoFakeClock().Now
+
+	var calls atomic.Int32
+	fetch := func() (*PullRequestInfo, error) {
+		calls.Add(1)
+		return &PullRequestInfo{}, nil
+	}
+
+	_, err := c.Do(t.Context(), "octo/repo", 1, fetch)
+	require.NoError(t, err)
+	_, err = c.Do(t.Context(), "octo/repo", 2, fetch)
+	require.NoError(t, err)
+	_, err = c.Do(t.Context(), "octo/other", 1, fetch)
+	require.NoError(t, err)
+
+	assert.Equal(t, int32(3), calls.Load(), "each unique (repo, pr) should miss the cache")
+}
+
+func TestPRInfoCache_ErrorsAreNotCached(t *testing.T) {
+	c := NewPRInfoCache(time.Minute)
+	c.now = newPRInfoFakeClock().Now
+
+	var calls atomic.Int32
+	wantErr := errors.New("boom")
+	fetch := func() (*PullRequestInfo, error) {
+		n := calls.Add(1)
+		if n < 3 {
+			return nil, wantErr
+		}
+		return &PullRequestInfo{HeadSHA: "abc123"}, nil
+	}
+
+	_, err := c.Do(t.Context(), "octo/repo", 42, fetch)
+	assert.ErrorIs(t, err, wantErr)
+	_, err = c.Do(t.Context(), "octo/repo", 42, fetch)
+	assert.ErrorIs(t, err, wantErr, "second call should also miss and refetch — errors are not cached")
+
+	got, err := c.Do(t.Context(), "octo/repo", 42, fetch)
+	require.NoError(t, err)
+	assert.Equal(t, &PullRequestInfo{HeadSHA: "abc123"}, got)
+	assert.Equal(t, int32(3), calls.Load())
+}
+
+func TestPRInfoCache_SingleFlightCollapsesConcurrentFetches(t *testing.T) {
+	c := NewPRInfoCache(time.Minute)
+	c.now = newPRInfoFakeClock().Now
+
+	const concurrency = 25
+	var calls atomic.Int32
+	release := make(chan struct{})
+	fetch := func() (*PullRequestInfo, error) {
+		calls.Add(1)
+		<-release // hold open until all goroutines have joined the flight
+		return &PullRequestInfo{HeadSHA: "abc123"}, nil
+	}
+
+	var wg sync.WaitGroup
+	results := make([]*PullRequestInfo, concurrency)
+	errs := make([]error, concurrency)
+	for i := range concurrency {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			res, err := c.Do(t.Context(), "octo/repo", 42, fetch)
+			results[i] = res
+			errs[i] = err
+		}(i)
+	}
+
+	// Give all goroutines time to enqueue on the singleflight group, then
+	// release the in-flight fetch.
+	time.Sleep(50 * time.Millisecond)
+	close(release)
+	wg.Wait()
+
+	assert.Equal(t, int32(1), calls.Load(), "all concurrent callers should collapse to one fetch")
+	for i := range concurrency {
+		require.NoError(t, errs[i])
+		require.NotNil(t, results[i])
+		assert.Equal(t, "abc123", results[i].HeadSHA)
+	}
+
+	// Each caller must receive its own pointer — mutating one must not
+	// affect another.
+	results[0].HeadSHA = "mutated"
+	assert.Equal(t, "abc123", results[1].HeadSHA, "callers must receive independent copies")
+}
+
+// TestPRInfoCache_WaiterRespectsItsOwnContext locks in the invariant
+// that a caller waiting on another caller's in-flight singleflight fetch
+// returns promptly when its own ctx is cancelled, rather than blocking
+// until the shared fetch completes. The shared fetch is not aborted —
+// the first caller still receives its result.
+func TestPRInfoCache_WaiterRespectsItsOwnContext(t *testing.T) {
+	c := NewPRInfoCache(time.Minute)
+	c.now = newPRInfoFakeClock().Now
+
+	var calls atomic.Int32
+	fetchEntered := make(chan struct{})
+	releaseFetch := make(chan struct{})
+	fetch := func() (*PullRequestInfo, error) {
+		calls.Add(1)
+		close(fetchEntered)
+		<-releaseFetch
+		return &PullRequestInfo{HeadSHA: "abc123"}, nil
+	}
+
+	// First caller: long-lived ctx, owns the in-flight fetch.
+	firstDone := make(chan struct{})
+	var firstResult *PullRequestInfo
+	var firstErr error
+	go func() {
+		defer close(firstDone)
+		firstResult, firstErr = c.Do(t.Context(), "octo/repo", 42, fetch)
+	}()
+
+	// Wait until the fetch is actually in flight before launching the
+	// second caller, so we know it will join the singleflight group as a
+	// waiter rather than running the fetch itself.
+	<-fetchEntered
+
+	// Second caller: its own cancellable ctx. Cancel before the fetch
+	// completes and assert the caller returns promptly with ctx.Err().
+	secondCtx, secondCancel := context.WithCancel(t.Context())
+	secondDone := make(chan struct{})
+	var secondErr error
+	go func() {
+		defer close(secondDone)
+		_, secondErr = c.Do(secondCtx, "octo/repo", 42, fetch)
+	}()
+	secondCancel()
+
+	select {
+	case <-secondDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("second caller did not return promptly after its ctx was cancelled — likely still blocked on the shared singleflight fetch")
+	}
+	assert.ErrorIs(t, secondErr, context.Canceled, "second caller should return its own ctx.Err()")
+
+	// First caller must still get the shared fetch's result — its ctx is
+	// alive and the second caller's cancellation must not have aborted
+	// the shared fetch.
+	close(releaseFetch)
+	<-firstDone
+	require.NoError(t, firstErr)
+	require.NotNil(t, firstResult)
+	assert.Equal(t, "abc123", firstResult.HeadSHA)
+	assert.Equal(t, int32(1), calls.Load(), "fetch should still be invoked exactly once")
+}
+
+// prInfoCacheLen returns the current size of the cache map under the lock.
+func prInfoCacheLen(c *PRInfoCache) int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return len(c.m)
+}
+
+func TestPRInfoCache_StoreEvictsExpiredEntries(t *testing.T) {
+	clock := newPRInfoFakeClock()
+	c := NewPRInfoCache(time.Minute)
+	c.now = clock.Now
+
+	fetch := func() (*PullRequestInfo, error) {
+		return &PullRequestInfo{HeadSHA: "abc"}, nil
+	}
+
+	// Seed five distinct (repo, pr) entries.
+	for i := range 5 {
+		_, err := c.Do(t.Context(), "octo/repo", i+1, fetch)
+		require.NoError(t, err)
+	}
+	require.Equal(t, 5, prInfoCacheLen(c), "all five fresh entries should be cached")
+
+	// Advance past the TTL — all five are now expired but still in the map.
+	clock.Advance(time.Minute + time.Second)
+
+	// A single store should sweep every expired entry before inserting,
+	// keeping the map bounded by the active working set within the TTL.
+	_, err := c.Do(t.Context(), "octo/repo", 99, fetch)
+	require.NoError(t, err)
+	assert.Equal(t, 1, prInfoCacheLen(c), "store should sweep expired entries so the map holds only the live ones")
+}
+
+func TestPRInfoCache_LookupEvictsExpiredEntry(t *testing.T) {
+	clock := newPRInfoFakeClock()
+	c := NewPRInfoCache(time.Minute)
+	c.now = clock.Now
+
+	fetch := func() (*PullRequestInfo, error) {
+		return &PullRequestInfo{HeadSHA: "abc"}, nil
+	}
+
+	// Seed one entry, then expire it without ever writing again.
+	_, err := c.Do(t.Context(), "octo/repo", 42, fetch)
+	require.NoError(t, err)
+	require.Equal(t, 1, prInfoCacheLen(c))
+
+	clock.Advance(time.Minute + time.Second)
+
+	// Lookup it directly (do not go through Do, which would re-fetch and
+	// re-store). The expired entry must be evicted so it does not occupy
+	// memory forever for a key that is never written again.
+	_, ok := c.lookup("octo/repo#42")
+	assert.False(t, ok, "expired entry must be reported as a miss")
+	assert.Equal(t, 0, prInfoCacheLen(c), "lookup must evict the expired entry")
+}
+
+// TestFetchPullRequest_CacheCollapsesDuplicateCalls locks in the
+// integration wiring between InstallationClient.FetchPullRequest and the
+// Client-shared PRInfoCache: repeated calls for the same (repo, pr)
+// within the TTL must hit GitHub exactly once, even when issued through
+// different InstallationClients backed by the same Client.
+func TestFetchPullRequest_CacheCollapsesDuplicateCalls(t *testing.T) {
+	var calls atomic.Int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/octo/repo/pulls/42", func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintln(w, `{
+			"head": {"ref": "feature", "sha": "abc123"},
+			"base": {"ref": "main",    "sha": "def456"},
+			"user": {"login": "octocat"}
+		}`)
+	})
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	cache := NewPRInfoCache(time.Minute)
+	logger := slog.New(slog.NewTextHandler(httptestDiscardWriter{}, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	newIC := func() *InstallationClient {
+		ghc := gh.NewClient(nil)
+		ghc.BaseURL, _ = url.Parse(server.URL + "/")
+		return &InstallationClient{
+			client:      ghc,
+			logger:      logger,
+			prInfoCache: cache,
+		}
+	}
+
+	ic1 := newIC()
+	ic2 := newIC()
+
+	want := &PullRequestInfo{HeadRef: "feature", HeadSHA: "abc123", BaseRef: "main", BaseSHA: "def456", User: "octocat"}
+
+	got, err := ic1.FetchPullRequest(t.Context(), "octo/repo", 42)
+	require.NoError(t, err)
+	assert.Equal(t, want, got)
+
+	got, err = ic1.FetchPullRequest(t.Context(), "octo/repo", 42)
+	require.NoError(t, err)
+	assert.Equal(t, want, got)
+
+	got, err = ic2.FetchPullRequest(t.Context(), "octo/repo", 42)
+	require.NoError(t, err)
+	assert.Equal(t, want, got, "second InstallationClient sharing the same cache must also see the cached result")
+
+	assert.Equal(t, int32(1), calls.Load(),
+		"all three FetchPullRequest calls (two on ic1, one on ic2) must collapse to one upstream GitHub call")
+}
+
+// TestFetchPullRequest_NoCacheFallsThrough verifies that an InstallationClient
+// with a nil prInfoCache (e.g., constructed via NewInstallationClient in tests)
+// still works correctly, hitting GitHub on every call.
+func TestFetchPullRequest_NoCacheFallsThrough(t *testing.T) {
+	var calls atomic.Int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/octo/repo/pulls/42", func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintln(w, `{"head": {"sha": "abc123"}, "base": {}, "user": {}}`)
+	})
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	ghc := gh.NewClient(nil)
+	ghc.BaseURL, _ = url.Parse(server.URL + "/")
+	ic := &InstallationClient{
+		client: ghc,
+		logger: slog.New(slog.NewTextHandler(httptestDiscardWriter{}, &slog.HandlerOptions{Level: slog.LevelError})),
+		// prInfoCache deliberately nil
+	}
+
+	for range 3 {
+		_, err := ic.FetchPullRequest(t.Context(), "octo/repo", 42)
+		require.NoError(t, err)
+	}
+	assert.Equal(t, int32(3), calls.Load(), "nil cache should not memoise — every call must hit GitHub")
+}
+
+// httptestDiscardWriter swallows slog output so test logs stay quiet.
+type httptestDiscardWriter struct{}
+
+func (httptestDiscardWriter) Write(p []byte) (int, error) { return len(p), nil }
+
+// TestForInstallation_CachesByInstallationID locks in the invariant that
+// repeat ForInstallation calls for the same installationID return the
+// same InstallationClient instance, so the underlying http.Client,
+// ghinstallation transport (and its installation-token cache), and any
+// per-InstallationClient state survive across webhook deliveries.
+// Different installationIDs must still receive distinct clients.
+func TestForInstallation_CachesByInstallationID(t *testing.T) {
+	c := &Client{
+		appID:         12345,
+		logger:        slog.New(slog.NewTextHandler(httptestDiscardWriter{}, &slog.HandlerOptions{Level: slog.LevelError})),
+		appSlug:       "schemabot", // bypass the slug-fetch retry path
+		prInfoCache:   NewPRInfoCache(time.Minute),
+		installations: make(map[int64]*InstallationClient),
+		privateKey:    testRSAKeyPEM(t),
+	}
+
+	a1, err := c.ForInstallation(100)
+	require.NoError(t, err)
+	a2, err := c.ForInstallation(100)
+	require.NoError(t, err)
+	b, err := c.ForInstallation(200)
+	require.NoError(t, err)
+
+	assert.Same(t, a1, a2, "same installationID must return the cached InstallationClient")
+	assert.NotSame(t, a1, b, "distinct installationIDs must return distinct InstallationClients")
+	assert.Same(t, c.prInfoCache, a1.prInfoCache, "cached InstallationClient must carry the Client-shared PRInfoCache")
+	assert.Same(t, c.prInfoCache, b.prInfoCache, "every InstallationClient must share the same PRInfoCache instance")
+}
+
+// TestForInstallation_RefreshesSlugOnCachedClient covers the slug recovery
+// path: an InstallationClient constructed before slug recovery (with an
+// empty appSlug) must observe the recovered slug on the next
+// ForInstallation call, so it does not stay stranded with an empty slug
+// for the lifetime of the process.
+func TestForInstallation_RefreshesSlugOnCachedClient(t *testing.T) {
+	c := &Client{
+		appID:         12345,
+		logger:        slog.New(slog.NewTextHandler(httptestDiscardWriter{}, &slog.HandlerOptions{Level: slog.LevelError})),
+		appSlug:       "", // slug was unavailable at construction time
+		prInfoCache:   NewPRInfoCache(time.Minute),
+		installations: make(map[int64]*InstallationClient),
+		privateKey:    testRSAKeyPEM(t),
+	}
+	// Bypass the slug-fetch retry by claiming we just tried.
+	c.lastSlugAttempt = time.Now()
+
+	ic1, err := c.ForInstallation(100)
+	require.NoError(t, err)
+	assert.Equal(t, "", ic1.appSlug, "client constructed before recovery must start with empty slug")
+
+	// Simulate the slug becoming available later.
+	c.appSlug = "schemabot"
+
+	ic2, err := c.ForInstallation(100)
+	require.NoError(t, err)
+	assert.Same(t, ic1, ic2, "same InstallationClient should be returned (no rebuild)")
+	assert.Equal(t, "schemabot", ic2.appSlug, "cached InstallationClient must adopt the recovered slug")
+}
+
+// testRSAKeyPEM generates a fresh 2048-bit RSA private key and returns it
+// PEM-encoded. ghinstallation.New requires a parseable RSA private key
+// even though no JWT is actually exercised here.
+func testRSAKeyPEM(t *testing.T) []byte {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	return pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(key),
+	})
+}
+
+func TestPRInfoCache_NonPositiveTTLDisablesCaching(t *testing.T) {
+	c := NewPRInfoCache(0)
+
+	var calls atomic.Int32
+	fetch := func() (*PullRequestInfo, error) {
+		calls.Add(1)
+		return &PullRequestInfo{}, nil
+	}
+
+	for range 5 {
+		_, err := c.Do(t.Context(), "octo/repo", 42, fetch)
+		require.NoError(t, err)
+	}
+	assert.Equal(t, int32(5), calls.Load(), "TTL<=0 should bypass the cache entirely")
+}
+
+// prInfoFakeClock returns a controllable time source for cache TTL tests.
+// Named distinctly so it does not collide with other in-package cache
+// test files that may carry their own fake clock.
+type prInfoFakeClock struct {
+	mu  sync.Mutex
+	now time.Time
+}
+
+func newPRInfoFakeClock() *prInfoFakeClock {
+	return &prInfoFakeClock{now: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)}
+}
+
+func (f *prInfoFakeClock) Now() time.Time {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.now
+}
+
+func (f *prInfoFakeClock) Advance(d time.Duration) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.now = f.now.Add(d)
+}

--- a/pkg/github/pr_info_cache_test.go
+++ b/pkg/github/pr_info_cache_test.go
@@ -5,9 +5,9 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
+	"encoding/json"
 	"encoding/pem"
 	"errors"
-	"fmt"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -287,11 +287,11 @@ func TestFetchPullRequest_CacheCollapsesDuplicateCalls(t *testing.T) {
 	mux.HandleFunc("/repos/octo/repo/pulls/42", func(w http.ResponseWriter, r *http.Request) {
 		calls.Add(1)
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprintln(w, `{
-			"head": {"ref": "feature", "sha": "abc123"},
-			"base": {"ref": "main",    "sha": "def456"},
-			"user": {"login": "octocat"}
-		}`)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"head": map[string]string{"ref": "feature", "sha": "abc123"},
+			"base": map[string]string{"ref": "main", "sha": "def456"},
+			"user": map[string]string{"login": "octocat"},
+		})
 	})
 	server := httptest.NewServer(mux)
 	t.Cleanup(server.Close)
@@ -339,7 +339,11 @@ func TestFetchPullRequest_NoCacheFallsThrough(t *testing.T) {
 	mux.HandleFunc("/repos/octo/repo/pulls/42", func(w http.ResponseWriter, r *http.Request) {
 		calls.Add(1)
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprintln(w, `{"head": {"sha": "abc123"}, "base": {}, "user": {}}`)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"head": map[string]string{"sha": "abc123"},
+			"base": map[string]string{},
+			"user": map[string]string{},
+		})
 	})
 	server := httptest.NewServer(mux)
 	t.Cleanup(server.Close)

--- a/pkg/github/pr_info_cache_test.go
+++ b/pkg/github/pr_info_cache_test.go
@@ -1,18 +1,15 @@
 package github
 
 import (
-	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/json"
 	"encoding/pem"
-	"errors"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -22,322 +19,94 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestPRInfoCache_HitsCacheWithinTTL(t *testing.T) {
-	clock := newPRInfoFakeClock()
-	c := NewPRInfoCache(time.Minute)
-	c.now = clock.Now
+// TestFetchPullRequest_CacheCollapsesDuplicateCallsWithinScope locks in the
+// request-scoped dedup invariant: every FetchPullRequest call inside a
+// single ctx scope (one WithPRInfoCache wrap) for the same (repo, pr)
+// must hit GitHub exactly once, even when issued through different
+// InstallationClients sharing that ctx.
+func TestFetchPullRequest_CacheCollapsesDuplicateCallsWithinScope(t *testing.T) {
+	server, calls := newPRFakeGitHubServer(t)
+	defer server.Close()
 
-	var calls atomic.Int32
-	fetch := func() (*PullRequestInfo, error) {
-		calls.Add(1)
-		return &PullRequestInfo{HeadSHA: "abc123", User: "octocat"}, nil
-	}
+	ic1 := newPRTestInstallationClient(t, server)
+	ic2 := newPRTestInstallationClient(t, server)
 
-	first, err := c.Do(t.Context(), "octo/repo", 42, fetch)
-	require.NoError(t, err)
-
-	clock.Advance(30 * time.Second) // still inside TTL
-
-	second, err := c.Do(t.Context(), "octo/repo", 42, fetch)
-	require.NoError(t, err)
-
-	assert.Equal(t, *first, *second, "second call should return the cached value")
-	assert.Equal(t, int32(1), calls.Load(), "fetch should be invoked only once within the TTL")
-}
-
-func TestPRInfoCache_RefetchesAfterTTL(t *testing.T) {
-	clock := newPRInfoFakeClock()
-	c := NewPRInfoCache(time.Minute)
-	c.now = clock.Now
-
-	var calls atomic.Int32
-	fetch := func() (*PullRequestInfo, error) {
-		calls.Add(1)
-		return &PullRequestInfo{HeadSHA: "abc123"}, nil
-	}
-
-	_, err := c.Do(t.Context(), "octo/repo", 42, fetch)
-	require.NoError(t, err)
-
-	clock.Advance(time.Minute + time.Second) // outside TTL
-
-	_, err = c.Do(t.Context(), "octo/repo", 42, fetch)
-	require.NoError(t, err)
-
-	assert.Equal(t, int32(2), calls.Load(), "expired entry should trigger a fresh fetch")
-}
-
-func TestPRInfoCache_KeysAreIndependent(t *testing.T) {
-	c := NewPRInfoCache(time.Minute)
-	c.now = newPRInfoFakeClock().Now
-
-	var calls atomic.Int32
-	fetch := func() (*PullRequestInfo, error) {
-		calls.Add(1)
-		return &PullRequestInfo{}, nil
-	}
-
-	_, err := c.Do(t.Context(), "octo/repo", 1, fetch)
-	require.NoError(t, err)
-	_, err = c.Do(t.Context(), "octo/repo", 2, fetch)
-	require.NoError(t, err)
-	_, err = c.Do(t.Context(), "octo/other", 1, fetch)
-	require.NoError(t, err)
-
-	assert.Equal(t, int32(3), calls.Load(), "each unique (repo, pr) should miss the cache")
-}
-
-func TestPRInfoCache_ErrorsAreNotCached(t *testing.T) {
-	c := NewPRInfoCache(time.Minute)
-	c.now = newPRInfoFakeClock().Now
-
-	var calls atomic.Int32
-	wantErr := errors.New("boom")
-	fetch := func() (*PullRequestInfo, error) {
-		n := calls.Add(1)
-		if n < 3 {
-			return nil, wantErr
-		}
-		return &PullRequestInfo{HeadSHA: "abc123"}, nil
-	}
-
-	_, err := c.Do(t.Context(), "octo/repo", 42, fetch)
-	assert.ErrorIs(t, err, wantErr)
-	_, err = c.Do(t.Context(), "octo/repo", 42, fetch)
-	assert.ErrorIs(t, err, wantErr, "second call should also miss and refetch — errors are not cached")
-
-	got, err := c.Do(t.Context(), "octo/repo", 42, fetch)
-	require.NoError(t, err)
-	assert.Equal(t, &PullRequestInfo{HeadSHA: "abc123"}, got)
-	assert.Equal(t, int32(3), calls.Load())
-}
-
-func TestPRInfoCache_SingleFlightCollapsesConcurrentFetches(t *testing.T) {
-	c := NewPRInfoCache(time.Minute)
-	c.now = newPRInfoFakeClock().Now
-
-	const concurrency = 25
-	var calls atomic.Int32
-	release := make(chan struct{})
-	fetch := func() (*PullRequestInfo, error) {
-		calls.Add(1)
-		<-release // hold open until all goroutines have joined the flight
-		return &PullRequestInfo{HeadSHA: "abc123"}, nil
-	}
-
-	var wg sync.WaitGroup
-	results := make([]*PullRequestInfo, concurrency)
-	errs := make([]error, concurrency)
-	for i := range concurrency {
-		wg.Add(1)
-		go func(i int) {
-			defer wg.Done()
-			res, err := c.Do(t.Context(), "octo/repo", 42, fetch)
-			results[i] = res
-			errs[i] = err
-		}(i)
-	}
-
-	// Give all goroutines time to enqueue on the singleflight group, then
-	// release the in-flight fetch.
-	time.Sleep(50 * time.Millisecond)
-	close(release)
-	wg.Wait()
-
-	assert.Equal(t, int32(1), calls.Load(), "all concurrent callers should collapse to one fetch")
-	for i := range concurrency {
-		require.NoError(t, errs[i])
-		require.NotNil(t, results[i])
-		assert.Equal(t, "abc123", results[i].HeadSHA)
-	}
-
-	// Each caller must receive its own pointer — mutating one must not
-	// affect another.
-	results[0].HeadSHA = "mutated"
-	assert.Equal(t, "abc123", results[1].HeadSHA, "callers must receive independent copies")
-}
-
-// TestPRInfoCache_WaiterRespectsItsOwnContext locks in the invariant
-// that a caller waiting on another caller's in-flight singleflight fetch
-// returns promptly when its own ctx is cancelled, rather than blocking
-// until the shared fetch completes. The shared fetch is not aborted —
-// the first caller still receives its result.
-func TestPRInfoCache_WaiterRespectsItsOwnContext(t *testing.T) {
-	c := NewPRInfoCache(time.Minute)
-	c.now = newPRInfoFakeClock().Now
-
-	var calls atomic.Int32
-	fetchEntered := make(chan struct{})
-	releaseFetch := make(chan struct{})
-	fetch := func() (*PullRequestInfo, error) {
-		calls.Add(1)
-		close(fetchEntered)
-		<-releaseFetch
-		return &PullRequestInfo{HeadSHA: "abc123"}, nil
-	}
-
-	// First caller: long-lived ctx, owns the in-flight fetch.
-	firstDone := make(chan struct{})
-	var firstResult *PullRequestInfo
-	var firstErr error
-	go func() {
-		defer close(firstDone)
-		firstResult, firstErr = c.Do(t.Context(), "octo/repo", 42, fetch)
-	}()
-
-	// Wait until the fetch is actually in flight before launching the
-	// second caller, so we know it will join the singleflight group as a
-	// waiter rather than running the fetch itself.
-	<-fetchEntered
-
-	// Second caller: its own cancellable ctx. Cancel before the fetch
-	// completes and assert the caller returns promptly with ctx.Err().
-	secondCtx, secondCancel := context.WithCancel(t.Context())
-	secondDone := make(chan struct{})
-	var secondErr error
-	go func() {
-		defer close(secondDone)
-		_, secondErr = c.Do(secondCtx, "octo/repo", 42, fetch)
-	}()
-	secondCancel()
-
-	select {
-	case <-secondDone:
-	case <-time.After(2 * time.Second):
-		t.Fatal("second caller did not return promptly after its ctx was cancelled — likely still blocked on the shared singleflight fetch")
-	}
-	assert.ErrorIs(t, secondErr, context.Canceled, "second caller should return its own ctx.Err()")
-
-	// First caller must still get the shared fetch's result — its ctx is
-	// alive and the second caller's cancellation must not have aborted
-	// the shared fetch.
-	close(releaseFetch)
-	<-firstDone
-	require.NoError(t, firstErr)
-	require.NotNil(t, firstResult)
-	assert.Equal(t, "abc123", firstResult.HeadSHA)
-	assert.Equal(t, int32(1), calls.Load(), "fetch should still be invoked exactly once")
-}
-
-// prInfoCacheLen returns the current size of the cache map under the lock.
-func prInfoCacheLen(c *PRInfoCache) int {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	return len(c.m)
-}
-
-func TestPRInfoCache_StoreEvictsExpiredEntries(t *testing.T) {
-	clock := newPRInfoFakeClock()
-	c := NewPRInfoCache(time.Minute)
-	c.now = clock.Now
-
-	fetch := func() (*PullRequestInfo, error) {
-		return &PullRequestInfo{HeadSHA: "abc"}, nil
-	}
-
-	// Seed five distinct (repo, pr) entries.
-	for i := range 5 {
-		_, err := c.Do(t.Context(), "octo/repo", i+1, fetch)
-		require.NoError(t, err)
-	}
-	require.Equal(t, 5, prInfoCacheLen(c), "all five fresh entries should be cached")
-
-	// Advance past the TTL — all five are now expired but still in the map.
-	clock.Advance(time.Minute + time.Second)
-
-	// A single store should sweep every expired entry before inserting,
-	// keeping the map bounded by the active working set within the TTL.
-	_, err := c.Do(t.Context(), "octo/repo", 99, fetch)
-	require.NoError(t, err)
-	assert.Equal(t, 1, prInfoCacheLen(c), "store should sweep expired entries so the map holds only the live ones")
-}
-
-func TestPRInfoCache_LookupEvictsExpiredEntry(t *testing.T) {
-	clock := newPRInfoFakeClock()
-	c := NewPRInfoCache(time.Minute)
-	c.now = clock.Now
-
-	fetch := func() (*PullRequestInfo, error) {
-		return &PullRequestInfo{HeadSHA: "abc"}, nil
-	}
-
-	// Seed one entry, then expire it without ever writing again.
-	_, err := c.Do(t.Context(), "octo/repo", 42, fetch)
-	require.NoError(t, err)
-	require.Equal(t, 1, prInfoCacheLen(c))
-
-	clock.Advance(time.Minute + time.Second)
-
-	// Lookup it directly (do not go through Do, which would re-fetch and
-	// re-store). The expired entry must be evicted so it does not occupy
-	// memory forever for a key that is never written again.
-	_, ok := c.lookup("octo/repo#42")
-	assert.False(t, ok, "expired entry must be reported as a miss")
-	assert.Equal(t, 0, prInfoCacheLen(c), "lookup must evict the expired entry")
-}
-
-// TestFetchPullRequest_CacheCollapsesDuplicateCalls locks in the
-// integration wiring between InstallationClient.FetchPullRequest and the
-// Client-shared PRInfoCache: repeated calls for the same (repo, pr)
-// within the TTL must hit GitHub exactly once, even when issued through
-// different InstallationClients backed by the same Client.
-func TestFetchPullRequest_CacheCollapsesDuplicateCalls(t *testing.T) {
-	var calls atomic.Int32
-	mux := http.NewServeMux()
-	mux.HandleFunc("/repos/octo/repo/pulls/42", func(w http.ResponseWriter, r *http.Request) {
-		calls.Add(1)
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]any{
-			"head": map[string]string{"ref": "feature", "sha": "abc123"},
-			"base": map[string]string{"ref": "main", "sha": "def456"},
-			"user": map[string]string{"login": "octocat"},
-		})
-	})
-	server := httptest.NewServer(mux)
-	t.Cleanup(server.Close)
-
-	cache := NewPRInfoCache(time.Minute)
-	logger := slog.New(slog.NewTextHandler(httptestDiscardWriter{}, &slog.HandlerOptions{Level: slog.LevelError}))
-
-	newIC := func() *InstallationClient {
-		ghc := gh.NewClient(nil)
-		ghc.BaseURL, _ = url.Parse(server.URL + "/")
-		return &InstallationClient{
-			client:      ghc,
-			logger:      logger,
-			prInfoCache: cache,
-		}
-	}
-
-	ic1 := newIC()
-	ic2 := newIC()
+	ctx := WithPRInfoCache(t.Context())
 
 	want := &PullRequestInfo{HeadRef: "feature", HeadSHA: "abc123", BaseRef: "main", BaseSHA: "def456", User: "octocat"}
 
-	got, err := ic1.FetchPullRequest(t.Context(), "octo/repo", 42)
+	got, err := ic1.FetchPullRequest(ctx, "octo/repo", 42)
 	require.NoError(t, err)
 	assert.Equal(t, want, got)
 
-	got, err = ic1.FetchPullRequest(t.Context(), "octo/repo", 42)
+	got, err = ic1.FetchPullRequest(ctx, "octo/repo", 42)
 	require.NoError(t, err)
 	assert.Equal(t, want, got)
 
-	got, err = ic2.FetchPullRequest(t.Context(), "octo/repo", 42)
+	got, err = ic2.FetchPullRequest(ctx, "octo/repo", 42)
 	require.NoError(t, err)
-	assert.Equal(t, want, got, "second InstallationClient sharing the same cache must also see the cached result")
+	assert.Equal(t, want, got, "second InstallationClient sharing the same ctx-scoped cache must also see the cached result")
 
 	assert.Equal(t, int32(1), calls.Load(),
-		"all three FetchPullRequest calls (two on ic1, one on ic2) must collapse to one upstream GitHub call")
+		"three FetchPullRequest calls inside one ctx scope must collapse to one upstream GitHub call")
 }
 
-// TestFetchPullRequest_NoCacheFallsThrough verifies that an InstallationClient
-// with a nil prInfoCache (e.g., constructed via NewInstallationClient in tests)
-// still works correctly, hitting GitHub on every call.
+// TestFetchPullRequest_FreshCachePerScope locks in the structural safety
+// invariant: a new WithPRInfoCache wrap (simulating a new webhook
+// delivery) gets a fresh cache. Even if an earlier scope cached a result
+// for (repo, pr), the next scope must refetch from GitHub. This is the
+// property that prevents stale HeadSHA across deliveries.
+func TestFetchPullRequest_FreshCachePerScope(t *testing.T) {
+	server, calls := newPRFakeGitHubServer(t)
+	defer server.Close()
+
+	ic := newPRTestInstallationClient(t, server)
+
+	// First scope (simulating delivery #1).
+	ctx1 := WithPRInfoCache(t.Context())
+	_, err := ic.FetchPullRequest(ctx1, "octo/repo", 42)
+	require.NoError(t, err)
+	_, err = ic.FetchPullRequest(ctx1, "octo/repo", 42)
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), calls.Load(), "two calls in one scope should dedupe to one fetch")
+
+	// Second scope (simulating delivery #2 — e.g., a synchronize event
+	// after a new commit was pushed). Must NOT reuse the first scope's
+	// cache.
+	ctx2 := WithPRInfoCache(t.Context())
+	_, err = ic.FetchPullRequest(ctx2, "octo/repo", 42)
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), calls.Load(), "second scope must refetch — caches are not shared across scopes")
+}
+
+// TestFetchPullRequest_NoCacheFallsThrough verifies that a ctx without a
+// request-scoped cache (tests or ad-hoc callers) falls through to a raw
+// fetch on every call. No memoisation, no panic.
 func TestFetchPullRequest_NoCacheFallsThrough(t *testing.T) {
+	server, calls := newPRFakeGitHubServer(t)
+	defer server.Close()
+
+	ic := newPRTestInstallationClient(t, server)
+
+	for range 3 {
+		_, err := ic.FetchPullRequest(t.Context(), "octo/repo", 42)
+		require.NoError(t, err)
+	}
+	assert.Equal(t, int32(3), calls.Load(), "no cache on ctx → every call must hit GitHub")
+}
+
+// TestFetchPullRequest_ErrorsAreNotCached verifies that a failed fetch
+// does not poison the request-scoped cache: a subsequent call within the
+// same scope must retry rather than return the stale error.
+func TestFetchPullRequest_ErrorsAreNotCached(t *testing.T) {
 	var calls atomic.Int32
 	mux := http.NewServeMux()
 	mux.HandleFunc("/repos/octo/repo/pulls/42", func(w http.ResponseWriter, r *http.Request) {
-		calls.Add(1)
+		n := calls.Add(1)
+		if n < 3 {
+			http.Error(w, "boom", http.StatusInternalServerError)
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"head": map[string]string{"sha": "abc123"},
@@ -346,40 +115,53 @@ func TestFetchPullRequest_NoCacheFallsThrough(t *testing.T) {
 		})
 	})
 	server := httptest.NewServer(mux)
-	t.Cleanup(server.Close)
+	defer server.Close()
 
-	ghc := gh.NewClient(nil)
-	ghc.BaseURL, _ = url.Parse(server.URL + "/")
-	ic := &InstallationClient{
-		client: ghc,
-		logger: slog.New(slog.NewTextHandler(httptestDiscardWriter{}, &slog.HandlerOptions{Level: slog.LevelError})),
-		// prInfoCache deliberately nil
-	}
+	ic := newPRTestInstallationClient(t, server)
+	ctx := WithPRInfoCache(t.Context())
 
-	for range 3 {
-		_, err := ic.FetchPullRequest(t.Context(), "octo/repo", 42)
-		require.NoError(t, err)
-	}
-	assert.Equal(t, int32(3), calls.Load(), "nil cache should not memoise — every call must hit GitHub")
+	_, err := ic.FetchPullRequest(ctx, "octo/repo", 42)
+	require.Error(t, err)
+	_, err = ic.FetchPullRequest(ctx, "octo/repo", 42)
+	require.Error(t, err, "second call should re-attempt — errors must not be cached")
+
+	got, err := ic.FetchPullRequest(ctx, "octo/repo", 42)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "abc123", got.HeadSHA)
+	assert.Equal(t, int32(3), calls.Load())
 }
 
-// httptestDiscardWriter swallows slog output so test logs stay quiet.
-type httptestDiscardWriter struct{}
+// TestFetchPullRequest_ReturnsIndependentCopies verifies that callers
+// within a single scope receive independent *PullRequestInfo values —
+// mutating one must not affect another caller's view.
+func TestFetchPullRequest_ReturnsIndependentCopies(t *testing.T) {
+	server, _ := newPRFakeGitHubServer(t)
+	defer server.Close()
 
-func (httptestDiscardWriter) Write(p []byte) (int, error) { return len(p), nil }
+	ic := newPRTestInstallationClient(t, server)
+	ctx := WithPRInfoCache(t.Context())
+
+	first, err := ic.FetchPullRequest(ctx, "octo/repo", 42)
+	require.NoError(t, err)
+	second, err := ic.FetchPullRequest(ctx, "octo/repo", 42)
+	require.NoError(t, err)
+
+	first.HeadSHA = "mutated"
+	assert.Equal(t, "abc123", second.HeadSHA, "second caller must not observe the first caller's mutation")
+}
 
 // TestForInstallation_CachesByInstallationID locks in the invariant that
 // repeat ForInstallation calls for the same installationID return the
 // same InstallationClient instance, so the underlying http.Client,
 // ghinstallation transport (and its installation-token cache), and any
-// per-InstallationClient state survive across webhook deliveries.
+// shared per-installation state survive across webhook deliveries.
 // Different installationIDs must still receive distinct clients.
 func TestForInstallation_CachesByInstallationID(t *testing.T) {
 	c := &Client{
 		appID:         12345,
-		logger:        slog.New(slog.NewTextHandler(httptestDiscardWriter{}, &slog.HandlerOptions{Level: slog.LevelError})),
+		logger:        slog.New(slog.NewTextHandler(prDiscardWriter{}, &slog.HandlerOptions{Level: slog.LevelError})),
 		appSlug:       "schemabot", // bypass the slug-fetch retry path
-		prInfoCache:   NewPRInfoCache(time.Minute),
 		installations: make(map[int64]*InstallationClient),
 		privateKey:    testRSAKeyPEM(t),
 	}
@@ -393,8 +175,6 @@ func TestForInstallation_CachesByInstallationID(t *testing.T) {
 
 	assert.Same(t, a1, a2, "same installationID must return the cached InstallationClient")
 	assert.NotSame(t, a1, b, "distinct installationIDs must return distinct InstallationClients")
-	assert.Same(t, c.prInfoCache, a1.prInfoCache, "cached InstallationClient must carry the Client-shared PRInfoCache")
-	assert.Same(t, c.prInfoCache, b.prInfoCache, "every InstallationClient must share the same PRInfoCache instance")
 }
 
 // TestForInstallation_RefreshesSlugOnCachedClient covers the slug recovery
@@ -405,9 +185,8 @@ func TestForInstallation_CachesByInstallationID(t *testing.T) {
 func TestForInstallation_RefreshesSlugOnCachedClient(t *testing.T) {
 	c := &Client{
 		appID:         12345,
-		logger:        slog.New(slog.NewTextHandler(httptestDiscardWriter{}, &slog.HandlerOptions{Level: slog.LevelError})),
+		logger:        slog.New(slog.NewTextHandler(prDiscardWriter{}, &slog.HandlerOptions{Level: slog.LevelError})),
 		appSlug:       "", // slug was unavailable at construction time
-		prInfoCache:   NewPRInfoCache(time.Minute),
 		installations: make(map[int64]*InstallationClient),
 		privateKey:    testRSAKeyPEM(t),
 	}
@@ -427,6 +206,43 @@ func TestForInstallation_RefreshesSlugOnCachedClient(t *testing.T) {
 	assert.Equal(t, "schemabot", ic2.appSlug, "cached InstallationClient must adopt the recovered slug")
 }
 
+// newPRFakeGitHubServer returns an httptest server that responds to
+// GET /repos/octo/repo/pulls/42 with a canonical PR payload, and the
+// counter of how many times the endpoint has been hit.
+func newPRFakeGitHubServer(t *testing.T) (*httptest.Server, *atomic.Int32) {
+	t.Helper()
+	var calls atomic.Int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/octo/repo/pulls/42", func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"head": map[string]string{"ref": "feature", "sha": "abc123"},
+			"base": map[string]string{"ref": "main", "sha": "def456"},
+			"user": map[string]string{"login": "octocat"},
+		})
+	})
+	return httptest.NewServer(mux), &calls
+}
+
+// newPRTestInstallationClient constructs an InstallationClient pointed at
+// the given httptest server. No cache is attached at the client level —
+// the request-scoped cache (if any) lives on ctx.
+func newPRTestInstallationClient(t *testing.T, server *httptest.Server) *InstallationClient {
+	t.Helper()
+	ghc := gh.NewClient(nil)
+	ghc.BaseURL, _ = url.Parse(server.URL + "/")
+	return &InstallationClient{
+		client: ghc,
+		logger: slog.New(slog.NewTextHandler(prDiscardWriter{}, &slog.HandlerOptions{Level: slog.LevelError})),
+	}
+}
+
+// prDiscardWriter swallows slog output so test logs stay quiet.
+type prDiscardWriter struct{}
+
+func (prDiscardWriter) Write(p []byte) (int, error) { return len(p), nil }
+
 // testRSAKeyPEM generates a fresh 2048-bit RSA private key and returns it
 // PEM-encoded. ghinstallation.New requires a parseable RSA private key
 // even though no JWT is actually exercised here.
@@ -438,44 +254,4 @@ func testRSAKeyPEM(t *testing.T) []byte {
 		Type:  "RSA PRIVATE KEY",
 		Bytes: x509.MarshalPKCS1PrivateKey(key),
 	})
-}
-
-func TestPRInfoCache_NonPositiveTTLDisablesCaching(t *testing.T) {
-	c := NewPRInfoCache(0)
-
-	var calls atomic.Int32
-	fetch := func() (*PullRequestInfo, error) {
-		calls.Add(1)
-		return &PullRequestInfo{}, nil
-	}
-
-	for range 5 {
-		_, err := c.Do(t.Context(), "octo/repo", 42, fetch)
-		require.NoError(t, err)
-	}
-	assert.Equal(t, int32(5), calls.Load(), "TTL<=0 should bypass the cache entirely")
-}
-
-// prInfoFakeClock returns a controllable time source for cache TTL tests.
-// Named distinctly so it does not collide with other in-package cache
-// test files that may carry their own fake clock.
-type prInfoFakeClock struct {
-	mu  sync.Mutex
-	now time.Time
-}
-
-func newPRInfoFakeClock() *prInfoFakeClock {
-	return &prInfoFakeClock{now: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)}
-}
-
-func (f *prInfoFakeClock) Now() time.Time {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	return f.now
-}
-
-func (f *prInfoFakeClock) Advance(d time.Duration) {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	f.now = f.now.Add(d)
 }

--- a/pkg/webhook/apply_handlers.go
+++ b/pkg/webhook/apply_handlers.go
@@ -19,6 +19,8 @@ import (
 func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseName string, installationID int64, requestedBy string, result CommandResult) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
+	// Dedupe FetchPullRequest calls within this command invocation.
+	ctx = ghclient.WithPRInfoCache(ctx)
 
 	client, err := h.ghClient.ForInstallation(installationID)
 	if err != nil {
@@ -282,6 +284,8 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 func (h *Handler) handleApplyConfirmCommand(repo string, pr int, environment, databaseName string, installationID int64, requestedBy string, result CommandResult) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
+	// Dedupe FetchPullRequest calls within this command invocation.
+	ctx = ghclient.WithPRInfoCache(ctx)
 
 	client, err := h.ghClient.ForInstallation(installationID)
 	if err != nil {

--- a/pkg/webhook/apply_handlers.go
+++ b/pkg/webhook/apply_handlers.go
@@ -210,8 +210,14 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 		// Check 1: HEAD SHA hasn't changed since auto-plan.
 		// Fail closed: if we can't verify the SHA (missing check record, API error),
 		// downgrade to manual confirmation rather than proceeding with stale data.
+		//
+		// Use FetchPullRequestNoCache here — correctness requires the *current*
+		// GitHub HEAD. The dedupe-friendly FetchPullRequest used by discovery
+		// above would return the cached HeadSHA from CreateSchemaRequestFromPR,
+		// making the SHA gate silently pass against a stale snapshot if a new
+		// commit landed between discovery and this re-check.
 		check, checkErr := h.service.Storage().Checks().Get(ctx, repo, pr, environment, dbType, database)
-		prInfo, prErr := client.FetchPullRequest(ctx, repo, pr)
+		prInfo, prErr := client.FetchPullRequestNoCache(ctx, repo, pr)
 
 		shaVerified := checkErr == nil && prErr == nil && check != nil && prInfo != nil && check.HeadSHA == prInfo.HeadSHA
 		if !shaVerified {
@@ -306,8 +312,14 @@ func (h *Handler) handleApplyConfirmCommand(repo string, pr int, environment, da
 		return
 	}
 
-	// Tier 2: PR checks gate — re-check on confirm to prevent bypass
-	confirmPRInfo, err := client.FetchPullRequest(ctx, repo, pr)
+	// Tier 2: PR checks gate — re-check on confirm to prevent bypass.
+	//
+	// Use FetchPullRequestNoCache here — the whole point of re-checking on
+	// confirm is to use the *current* GitHub HEAD. The dedupe-friendly
+	// FetchPullRequest would return the cached HeadSHA populated by
+	// CreateSchemaRequestFromPR above, making enforcePassingChecks run
+	// against a stale HeadSHA if a new commit landed during this delivery.
+	confirmPRInfo, err := client.FetchPullRequestNoCache(ctx, repo, pr)
 	if err != nil {
 		h.logger.Error("failed to fetch PR for checks gate", "error", err)
 		h.postComment(repo, pr, installationID, templates.RenderGenericError(templates.SchemaErrorData{

--- a/pkg/webhook/plan.go
+++ b/pkg/webhook/plan.go
@@ -17,6 +17,8 @@ import (
 func (h *Handler) handlePlanCommand(w http.ResponseWriter, repo string, pr int, environment, databaseName string, installationID int64, requestedBy string) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
+	// Dedupe FetchPullRequest calls within this command invocation.
+	ctx = ghclient.WithPRInfoCache(ctx)
 
 	client, err := h.ghClient.ForInstallation(installationID)
 	if err != nil {
@@ -102,6 +104,8 @@ func (h *Handler) handlePlanCommand(w http.ResponseWriter, repo string, pr int, 
 func (h *Handler) handleMultiEnvPlan(repo string, pr int, databaseName string, installationID int64, requestedBy string, isAutoPlan bool) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
+	// Dedupe FetchPullRequest calls within this plan invocation.
+	ctx = ghclient.WithPRInfoCache(ctx)
 
 	client, err := h.ghClient.ForInstallation(installationID)
 	if err != nil {

--- a/pkg/webhook/pull_request.go
+++ b/pkg/webhook/pull_request.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"time"
 
+	ghclient "github.com/block/schemabot/pkg/github"
 	"github.com/block/schemabot/pkg/metrics"
 	"github.com/block/schemabot/pkg/storage"
 )
@@ -85,6 +86,8 @@ func (h *Handler) handlePullRequest(w http.ResponseWriter, body []byte) {
 	// Discover all configs matching changed schema files in this PR
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
+	// Dedupe FetchPullRequest calls within this webhook delivery.
+	ctx = ghclient.WithPRInfoCache(ctx)
 
 	client, err := h.ghClient.ForInstallation(installationID)
 	if err != nil {


### PR DESCRIPTION
## Why

Multiple call sites in `pkg/webhook` re-fetch the same `PullRequestInfo` within a single webhook delivery just to read `HeadSHA` (`handleApplyCommand`, `handleApplyConfirmCommand`, `handlePullRequest`, `handlePlanCommand`, `handleMultiEnvPlan`, plus downstream helpers `enforceReviewGate`, `enforcePassingChecks`, `checkPriorEnvironments`, `CreateSchemaRequestFromPR`, `FindAllConfigsForPR`). Every `ForInstallation` call also constructs a fresh `http.Client`, `gh.Client`, `githubv4.Client`, and `ghinstallation` transport, throwing away HTTP keep-alive and the `ghinstallation` installation-token cache every delivery.

## What

- **Request-scoped PR-info cache** (`pkg/github/pr_info_cache.go`). `WithPRInfoCache(ctx)` attaches a fresh `(repo, pr) -> *PullRequestInfo` map to ctx; `FetchPullRequest` checks the map first and stores on miss. The cache lives and dies with one ctx, so it can never outlive the delivery that created it — `HeadSHA` is structurally guaranteed not to leak across deliveries (each delivery starts with an empty cache and re-fetches).
- **Wrapped at 5 webhook entry points**: `handleApplyCommand`, `handleApplyConfirmCommand`, `handlePullRequest`, `handlePlanCommand`, `handleMultiEnvPlan`. Downstream helpers (`enforceReviewGate`, `enforcePassingChecks`, `checkPriorEnvironments`, `CreateSchemaRequestFromPR`, `FindAllConfigsForPR`) call `FetchPullRequest` transparently — they dedupe to one GitHub round trip per delivery without needing changes.
- **`Client.ForInstallation` caches `*InstallationClient` by `installationID`** so HTTP keep-alive and the `ghinstallation` installation-token cache survive across deliveries (avoiding the ~50–200 ms token-exchange round trip per delivery).
- **`Client.appSlug` and `InstallationClient.appSlug` as `atomic.Pointer[string]`** with `loadAppSlug`/`storeAppSlug` helpers; `lastSlugAttempt` is guarded by a dedicated mutex. Necessary because cached `InstallationClient`s are now reused across concurrent webhook deliveries, and a slug recovery after a startup fetch failure must propagate race-free to clients constructed before recovery. `isOwnAppSlug` hardened (empty slug returns false).
- **Sibling API `FetchPullRequestNoCache`** that always issues a fresh GitHub request, bypassing the request-scoped cache. Used at the auto-confirm (`apply -y`) SHA re-check and the apply-confirm checks-gate re-check, where correctness requires the *current* GitHub HEAD. The call site declares its intent — `FetchPullRequest` (dedupe-friendly) vs `FetchPullRequestNoCache` (revalidation-friendly) — with no hidden ctx flags. `FetchPullRequestNoCache` reads from GitHub but never writes back into the cache, so it cannot corrupt the discovery snapshot the rest of the delivery is consistent with.

## Design notes

- **Why request-scoped, not TTL.** An earlier revision used a TTL cache keyed on `(repo, pr)`. Review feedback flagged that `PullRequestInfo.HeadSHA` is mutable per `(repo, pr)` (a new push changes it), so any cache that outlived a single delivery could hand a stale `HeadSHA` to the checks gate or schema discovery on a later delivery — exactly the kind of safety drift the gate is supposed to prevent. Pivoting to a ctx-attached cache makes the staleness category structurally impossible across deliveries: a fresh cache per delivery means cross-delivery reuse cannot occur.
- **Why a separate `FetchPullRequestNoCache` for SHA re-checks.** Even within one delivery, the auto-confirm and apply-confirm flows do a *fresh-head re-check* whose entire purpose is to compare the stored check record against the current GitHub HEAD and downgrade to manual confirmation if a new commit landed during the delivery. Reading from the request-scoped cache at those sites would defeat the gate (the cached snapshot equals the stored check record by construction). Adding a sibling API for the bypass — instead of a ctx flag or scope-narrowing — keeps the intent explicit at every call site.
- **Why no singleflight on this cache.** The realistic load shape inside one delivery is **sequential** fan-out (`enforceReviewGate` → direct fetch → `enforcePassingChecks` → `checkPriorEnvironments`), not overlapping concurrent fetches; the request-scoped map already dedupes those. Across deliveries, sharing an in-flight fetch would risk returning the wrong `HeadSHA` to whichever delivery did not start it. This contrasts with #112 (`GetPRCheckStatuses`), where concurrent fan-out across deliveries is the dominant load shape and result mutability across the cache window is the dominant risk.

## References

Companion to #112 (`GetPRCheckStatuses` caching). Different load shape, different safety property, different tool.