### PR TITLE
fix(github): guard empty-list checks-gate templates against rendering an empty Markdown table

### DIFF
--- a/pkg/webhook/templates/apply_commands.go
+++ b/pkg/webhook/templates/apply_commands.go
@@ -247,6 +247,15 @@ func RenderApplyBlockedByFailingChecks(environment string, failing []BlockingChe
 
 	sb.WriteString("## ❌ Apply Blocked\n\n")
 	fmt.Fprintf(&sb, "**Environment**: `%s`\n\n", environment)
+	if len(failing) == 0 {
+		// Defensive: callers should only invoke this template when at least
+		// one failing check has been identified. Render a generic message
+		// rather than an empty Markdown table with column headers but no rows.
+		sb.WriteString("Cannot apply while PR checks are failing.\n\n")
+		sb.WriteString("Fix the failing checks and retry:\n")
+		fmt.Fprintf(&sb, "```\nschemabot apply -e %s\n```\n", environment)
+		return sb.String()
+	}
 	sb.WriteString("Cannot apply while PR checks are failing:\n\n")
 	sb.WriteString("| Check | Status |\n")
 	sb.WriteString("|-------|--------|\n")
@@ -302,6 +311,15 @@ func RenderApplyBlockedByInProgressChecks(environment string, inProgress []Block
 
 	sb.WriteString("## ⏳ Apply Blocked\n\n")
 	fmt.Fprintf(&sb, "**Environment**: `%s`\n\n", environment)
+	if len(inProgress) == 0 {
+		// Defensive: callers should only invoke this template when at least
+		// one in-progress check has been identified. Render a generic message
+		// rather than an empty Markdown table with column headers but no rows.
+		sb.WriteString("Cannot apply while PR checks are still running.\n\n")
+		sb.WriteString("Wait for checks to complete and retry:\n")
+		fmt.Fprintf(&sb, "```\nschemabot apply -e %s\n```\n", environment)
+		return sb.String()
+	}
 	sb.WriteString("Cannot apply while PR checks are still running:\n\n")
 	sb.WriteString("| Check | Status |\n")
 	sb.WriteString("|-------|--------|\n")

--- a/pkg/webhook/templates/apply_test.go
+++ b/pkg/webhook/templates/apply_test.go
@@ -347,6 +347,26 @@ func TestRenderApplyBlockedByFailingChecks_SingleCheck(t *testing.T) {
 	assert.Contains(t, result, "schemabot apply -e production")
 }
 
+func TestRenderApplyBlockedByFailingChecks_EmptyList(t *testing.T) {
+	// Defensive guard: rendering with an empty slice must not emit an empty
+	// Markdown table (header row with zero data rows). It should fall back
+	// to a generic message that still preserves the header, environment,
+	// and retry block.
+	for _, failing := range [][]BlockingCheck{nil, {}} {
+		result := RenderApplyBlockedByFailingChecks("staging", failing)
+
+		assert.Contains(t, result, "## ❌ Apply Blocked")
+		assert.Contains(t, result, "**Environment**: `staging`")
+		assert.Contains(t, result, "Cannot apply while PR checks are failing.")
+		assert.Contains(t, result, "Fix the failing checks and retry:\n```\nschemabot apply -e staging\n```",
+			"retry command must be inside a fenced code block immediately after the retry copy")
+		assert.NotContains(t, result, "| Check | Status |",
+			"empty-list branch must not emit a table header with no data rows")
+		assert.NotContains(t, result, "|-------|--------|",
+			"empty-list branch must not emit a table separator with no data rows")
+	}
+}
+
 func TestRenderApplyBlockedByCheckStatusError(t *testing.T) {
 	t.Run("generic error is shown verbatim with retry block", func(t *testing.T) {
 		err := errors.New("graphql query failed: 500 Internal Server Error")
@@ -446,6 +466,26 @@ func TestRenderApplyBlockedByInProgressChecks(t *testing.T) {
 	assert.Contains(t, result, "| `CI / integration` | queued |")
 	assert.Contains(t, result, "Wait for checks to complete")
 	assert.Contains(t, result, "schemabot apply -e staging")
+}
+
+func TestRenderApplyBlockedByInProgressChecks_EmptyList(t *testing.T) {
+	// Defensive guard: rendering with an empty slice must not emit an empty
+	// Markdown table (header row with zero data rows). It should fall back
+	// to a generic message that still preserves the header, environment,
+	// and retry block.
+	for _, inProgress := range [][]BlockingCheck{nil, {}} {
+		result := RenderApplyBlockedByInProgressChecks("staging", inProgress)
+
+		assert.Contains(t, result, "## ⏳ Apply Blocked")
+		assert.Contains(t, result, "**Environment**: `staging`")
+		assert.Contains(t, result, "Cannot apply while PR checks are still running.")
+		assert.Contains(t, result, "Wait for checks to complete and retry:\n```\nschemabot apply -e staging\n```",
+			"retry command must be inside a fenced code block immediately after the retry copy")
+		assert.NotContains(t, result, "| Check | Status |",
+			"empty-list branch must not emit a table header with no data rows")
+		assert.NotContains(t, result, "|-------|--------|",
+			"empty-list branch must not emit a table separator with no data rows")
+	}
 }
 
 func TestTruncateDDL(t *testing.T) {


### PR DESCRIPTION
`RenderApplyBlockedByFailingChecks` and `RenderApplyBlockedByInProgressChecks` previously emitted a Markdown table header with zero data rows when called with a nil or empty slice — confusing output for any caller that bypassed the existing `len > 0` guards in `pkg/webhook`.

This change special-cases the empty-slice path on both templates to emit a generic "Cannot apply while PR checks are failing/still running." sentence followed by the usual retry block, mirroring the defensive nil-error branch already present in `RenderApplyBlockedByCheckStatusError`. Two new tests parametrize over `nil` and `[]BlockingCheck{}` and assert no empty table is emitted.

No production behavior change today (callers still guard on `len > 0`); this is purely template hardening so a future caller cannot trigger the empty-table failure mode.