### PR TITLE
fix(tern): require explicit apply environment

### DIFF
--- a/pkg/tern/local_client.go
+++ b/pkg/tern/local_client.go
@@ -432,6 +432,9 @@ func (c *LocalClient) Apply(ctx context.Context, req *ternv1.ApplyRequest) (*ter
 	if req.PlanId == "" {
 		return nil, fmt.Errorf("plan_id is required")
 	}
+	if req.Environment == "" {
+		return nil, fmt.Errorf("environment is required")
+	}
 
 	// Look up the plan
 	plan, err := c.storage.Plans().Get(ctx, req.PlanId)
@@ -468,17 +471,8 @@ func (c *LocalClient) Apply(ctx context.Context, req *ternv1.ApplyRequest) (*ter
 
 	now := time.Now()
 
-	// Options come directly as a map from proto
 	options := req.Options
-	if options == nil {
-		options = make(map[string]string)
-	}
 
-	// Read environment and caller from proto fields (preferred), fall back to options.
-	environment := req.Environment
-	if environment == "" {
-		environment = options["environment"]
-	}
 	caller := req.Caller
 	if caller == "" {
 		caller = options["caller"]
@@ -510,7 +504,7 @@ func (c *LocalClient) Apply(ctx context.Context, req *ternv1.ApplyRequest) (*ter
 		Deployment:      c.config.Database,
 		Repository:      plan.Repository,
 		PullRequest:     plan.PullRequest,
-		Environment:     environment,
+		Environment:     req.Environment,
 		Caller:          caller,
 		Engine:          eng.Name(),
 		State:           state.Apply.Pending,
@@ -567,7 +561,7 @@ func (c *LocalClient) Apply(ctx context.Context, req *ternv1.ApplyRequest) (*ter
 			Engine:         eng.Name(),
 			Repository:     plan.Repository,
 			PullRequest:    plan.PullRequest,
-			Environment:    options["environment"],
+			Environment:    req.Environment,
 			State:          state.Task.Pending,
 			Options:        optionsJSON,
 			TableName:      ddlChange.Table,

--- a/pkg/tern/local_client_integration_test.go
+++ b/pkg/tern/local_client_integration_test.go
@@ -36,6 +36,8 @@ var (
 	sharedDSN       string
 )
 
+const localClientTestEnvironment = "development"
+
 func TestMain(m *testing.M) {
 	ctx := context.Background()
 
@@ -436,7 +438,8 @@ func TestLocalClient_Apply_PlanNotFound(t *testing.T) {
 
 	ctx := t.Context()
 	resp, err := client.Apply(ctx, &ternv1.ApplyRequest{
-		PlanId: "nonexistent-plan-id",
+		PlanId:      "nonexistent-plan-id",
+		Environment: localClientTestEnvironment,
 	})
 	require.NoError(t, err, "Apply() returned error")
 	assert.False(t, resp.Accepted, "expected apply to be rejected for nonexistent plan")
@@ -494,7 +497,8 @@ func TestLocalClient_Apply(t *testing.T) {
 
 	// Now apply the plan
 	applyResp, err := client.Apply(ctx, &ternv1.ApplyRequest{
-		PlanId: planResp.PlanId,
+		PlanId:      planResp.PlanId,
+		Environment: localClientTestEnvironment,
 	})
 	require.NoError(t, err, "Apply() returned error")
 
@@ -850,7 +854,8 @@ func TestLocalClient_Apply_MultiTableSequential(t *testing.T) {
 
 	// Apply the plan in sequential mode (no defer_cutover)
 	applyResp, err := client.Apply(ctx, &ternv1.ApplyRequest{
-		PlanId: planResp.PlanId,
+		PlanId:      planResp.PlanId,
+		Environment: localClientTestEnvironment,
 		// No options means sequential mode
 	})
 	require.NoError(t, err, "Apply() returned error")
@@ -1026,8 +1031,9 @@ func TestLocalClient_Apply_AtomicHeartbeat(t *testing.T) {
 	require.NotEmpty(t, planResp.PlanId)
 
 	applyResp, err := client.Apply(ctx, &ternv1.ApplyRequest{
-		PlanId:  planResp.PlanId,
-		Options: map[string]string{"defer_cutover": "true"},
+		PlanId:      planResp.PlanId,
+		Environment: localClientTestEnvironment,
+		Options:     map[string]string{"defer_cutover": "true"},
 	})
 	require.NoError(t, err)
 	require.True(t, applyResp.Accepted, "apply rejected: %s", applyResp.ErrorMessage)
@@ -1063,7 +1069,7 @@ func TestLocalClient_Apply_AtomicHeartbeat(t *testing.T) {
 	// Trigger cutover to complete the apply
 	_, err = client.Cutover(ctx, &ternv1.CutoverRequest{
 		Database:    "testdb",
-		Environment: "",
+		Environment: localClientTestEnvironment,
 	})
 	require.NoError(t, err, "cutover")
 

--- a/pkg/tern/local_client_test.go
+++ b/pkg/tern/local_client_test.go
@@ -1,0 +1,25 @@
+package tern
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	ternv1 "github.com/block/schemabot/pkg/proto/ternv1"
+	"github.com/block/schemabot/pkg/storage"
+)
+
+func TestLocalClient_Apply_RequiresEnvironmentField(t *testing.T) {
+	client, err := NewLocalClient(LocalConfig{
+		Database: "testdb",
+		Type:     storage.DatabaseTypeMySQL,
+	}, nil, slog.Default())
+	require.NoError(t, err)
+
+	_, err = client.Apply(t.Context(), &ternv1.ApplyRequest{
+		PlanId:  "plan-123",
+		Options: map[string]string{"environment": "development"},
+	})
+	require.ErrorContains(t, err, "environment is required")
+}


### PR DESCRIPTION
## Summary

- Require `ApplyRequest.Environment` before LocalClient creates apply and task records
- Stop treating environment as a generic apply option
- Update direct LocalClient tests to pass `development` explicitly

🤖 Generated by Codex.