### PR TITLE
refactor(webhook): improve summary reconciliation logic

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,6 +135,8 @@ Before handing a PR to the user, review it the way an operator will experience i
 
 **No PR/issue links in code comments.** Don't reference GitHub issues or PRs (e.g., `// fixes #147`) in code comments — they go stale and provide no value to future readers. The git history links commits to issues; code comments should describe *what* and *why*, not *when* or *which ticket*.
 
+**Preserve useful comments.** When moving or refactoring code, move the relevant comments with the code or update them to match the new structure. Delete comments only when they are truly out of date, misleading, or redundant after the change. Comments that explain operational behavior, invariants, or rationale should not be dropped just because the code moved.
+
 **No fragile comments.** Don't include specific counts, thresholds, external project names, or implementation details that will go stale when the code changes. For example, `// 100k rows` will be wrong when someone changes the count. `// uses the misk pattern` means nothing to someone who doesn't know misk. Comments should describe *intent* — the *what* and *why* — not restate the code or reference external context that may not persist.
 
 **No `nolint` directives.** Always fix the underlying lint issue rather than suppressing it with `//nolint:`. If the linter flags something, the code should be changed to satisfy it.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -330,11 +330,11 @@ Webhook handler: "someone commented schemabot apply"
   comments regardless of where the engine runs.
 
 **Missing summary recovery.** The `apply_comments` table tracks which comments
-were posted (`progress`, `summary`). On startup, the recovery worker checks for
-completed applies with a progress comment but no summary comment — this means
-`OnTerminal` was missed during a container restart. It reconstructs a
-`CommentObserver` from the apply record's stored GitHub context and calls
-`OnTerminal` to post the missing summary.
+were posted (`progress`, `summary`). On startup, the webhook runtime checks for
+completed applies with a progress comment but no summary comment. This means
+`OnTerminal` was interrupted after progress was posted. It reloads the apply's
+tasks, rebuilds the summary body, posts the missing summary, and records the
+summary comment ID so reconciliation is idempotent.
 
 ### Integration Modes
 

--- a/pkg/api/scheduler.go
+++ b/pkg/api/scheduler.go
@@ -44,12 +44,6 @@ func (s *Service) StartRecoveryWorker(ctx context.Context) {
 
 		s.logger.Info("started recovery worker", "interval", RecoveryPollInterval)
 
-		// On startup, find completed applies that have a progress comment but
-		// no summary comment — this means OnTerminal was missed during a
-		// container restart. Post the missing summary so the PR shows the
-		// completion result.
-		s.postMissingSummaryComments(ctx)
-
 		// Run immediately on startup, then on each tick
 		s.resumeInProgressApplies(ctx)
 
@@ -148,40 +142,5 @@ func (s *Service) resumeInProgressApplies(ctx context.Context) {
 		s.logger.Info("recovery worker: cycle complete",
 			"recovered", recovered,
 			"failed", failed)
-	}
-}
-
-// postMissingSummaryComments finds completed applies that have a progress comment
-// but no summary comment (the observer missed it during a container restart) and
-// posts the missing summary. Uses the OnMissingSummary callback which posts
-// the summary comment directly.
-func (s *Service) postMissingSummaryComments(ctx context.Context) {
-	applies, err := s.storage.Applies().FindMissingSummaryComment(ctx)
-	if err != nil {
-		s.logger.Error("recovery worker: failed to find applies missing summary comments", "error", err)
-		return
-	}
-
-	if len(applies) == 0 {
-		return
-	}
-
-	s.logger.Info("recovery worker: found applies missing summary comments", "count", len(applies))
-
-	for _, apply := range applies {
-		if apply.Repository == "" || apply.PullRequest == 0 || apply.InstallationID == 0 {
-			// CLI apply or missing GitHub context — can't post a PR comment.
-			continue
-		}
-
-		s.logger.Info("recovery worker: posting missing summary comment",
-			"apply_id", apply.ApplyIdentifier,
-			"repo", apply.Repository,
-			"pr", apply.PullRequest,
-			"state", apply.State)
-
-		if s.OnMissingSummary != nil {
-			s.OnMissingSummary(apply)
-		}
 	}
 }

--- a/pkg/api/service.go
+++ b/pkg/api/service.go
@@ -112,11 +112,6 @@ type Service struct {
 	// OnApplyRecovered is called after the recovery worker resumes an apply.
 	// Set by the webhook handler to set up an observer for PR comments.
 	OnApplyRecovered RecoveryCallback
-
-	// OnMissingSummary is called on startup for completed applies that have a
-	// progress comment but no summary comment (outbox gap from container restart).
-	// Set by the webhook handler to post the missing summary comment directly.
-	OnMissingSummary RecoveryCallback
 }
 
 // SetApplyObserver sets a progress observer on the tern client for an apply.

--- a/pkg/cmd/commands/serve.go
+++ b/pkg/cmd/commands/serve.go
@@ -26,6 +26,23 @@ import (
 	"github.com/block/schemabot/pkg/webhook"
 )
 
+type webhookRuntime struct {
+	handler                         http.Handler
+	reconcileMissingSummaryComments func(context.Context)
+}
+
+func (r webhookRuntime) StartMissingSummaryReconciliation(ctx context.Context, logger *slog.Logger) {
+	if r.reconcileMissingSummaryComments == nil {
+		logger.Debug("missing summary reconciliation disabled")
+		return
+	}
+
+	reconcileCtx := context.WithoutCancel(ctx)
+	go func() {
+		r.reconcileMissingSummaryComments(reconcileCtx)
+	}()
+}
+
 // ServeCmd starts the SchemaBot HTTP API server.
 type ServeCmd struct{}
 
@@ -109,12 +126,26 @@ func (cmd *ServeCmd) Run(g *Globals) error {
 	svc := api.New(storage, serverConfig, nil, logger)
 	defer utils.CloseAndLog(svc)
 
-	// Start the recovery worker.
-	// This unified approach polls for stale applies every 10 seconds:
+	ctx := context.Background()
+
+	// Build the webhook runtime before recovery starts so recovered applies can
+	// attach PR comment observers. If GitHub is not configured, the runtime
+	// serves a disabled webhook endpoint and skips comment reconciliation.
+	webhookRuntime, err := buildWebhookRuntime(serverConfig, svc, logger)
+	if err != nil {
+		return err
+	}
+
+	// On startup, find applies that have a progress comment but no summary
+	// comment. This means terminal comment handling was interrupted; reconcile
+	// in the background so GitHub repair does not block server startup.
+	webhookRuntime.StartMissingSummaryReconciliation(ctx, logger)
+
+	// Start the recovery worker after webhook callbacks are registered.
+	// This polls for stale applies every 10 seconds:
 	// - Runs immediately on startup
 	// - Recovers applies with stale heartbeats (> 1 minute) using FOR UPDATE SKIP LOCKED
 	// - STOPPED applies are NOT auto-resumed (user must call `schemabot start`)
-	ctx := context.Background()
 	svc.StartRecoveryWorker(ctx)
 
 	// Optionally start gRPC server for Tern proto (used by docker-compose.grpc.yml)
@@ -146,12 +177,7 @@ func (cmd *ServeCmd) Run(g *Globals) error {
 	svc.ConfigureRoutes(mux)
 	mux.Handle("GET /metrics", telemetry.MetricsHandler)
 
-	// Register GitHub webhook handler if GitHub App is configured
-	webhookHandler, err := buildWebhookHandler(serverConfig, svc, logger)
-	if err != nil {
-		return err
-	}
-	mux.Handle("POST /webhook", webhookHandler)
+	mux.Handle("POST /webhook", webhookRuntime.handler)
 
 	// Wrap mux with OTel HTTP instrumentation for automatic request
 	// duration, request body size, and response body size metrics.
@@ -250,35 +276,40 @@ func startGRPCServer(ctx context.Context, config *api.ServerConfig, st *mysqlsto
 	return grpcSrv, nil
 }
 
-func buildWebhookHandler(serverConfig *api.ServerConfig, svc *api.Service, logger *slog.Logger) (http.Handler, error) {
+func buildWebhookRuntime(serverConfig *api.ServerConfig, svc *api.Service, logger *slog.Logger) (webhookRuntime, error) {
 	if !serverConfig.GitHub.Configured() {
 		if serverConfig.GitHub.PrivateKey != "" {
 			logger.Warn("GitHub App config found but credentials not available yet — webhook endpoint disabled")
 		}
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		return webhookRuntime{handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusServiceUnavailable)
-			w.Write([]byte(`{"error":"GitHub App credentials not available — webhook endpoint is disabled"}`)) //nolint:errcheck
-		}), nil
+			if _, err := w.Write([]byte(`{"error":"GitHub App credentials not available — webhook endpoint is disabled"}`)); err != nil {
+				logger.Error("failed to write disabled webhook response", "error", err)
+			}
+		})}, nil
 	}
 
 	ghPrivateKey, err := serverConfig.GitHub.ResolvePrivateKey()
 	if err != nil {
-		return nil, fmt.Errorf("resolve GitHub private key: %w", err)
+		return webhookRuntime{}, fmt.Errorf("resolve GitHub private key: %w", err)
 	}
 	ghWebhookSecret, err := serverConfig.GitHub.ResolveWebhookSecret()
 	if err != nil {
-		return nil, fmt.Errorf("resolve GitHub webhook secret: %w", err)
+		return webhookRuntime{}, fmt.Errorf("resolve GitHub webhook secret: %w", err)
 	}
 	if ghWebhookSecret == "" {
-		return nil, fmt.Errorf("GitHub App is configured but webhook secret is empty — set github.webhook_secret to secure the /webhook endpoint")
+		return webhookRuntime{}, fmt.Errorf("GitHub App is configured but webhook secret is empty — set github.webhook_secret to secure the /webhook endpoint")
 	}
 
 	appID := serverConfig.GitHub.ResolveAppID()
 	ghClient := ghclient.NewClient(appID, []byte(ghPrivateKey), logger)
 	handler := webhook.NewHandler(svc, ghClient, []byte(ghWebhookSecret), logger)
 	logger.Info("GitHub webhook endpoint registered", "app_id", appID)
-	return handler, nil
+	return webhookRuntime{
+		handler:                         handler,
+		reconcileMissingSummaryComments: handler.ReconcileMissingSummaryComments,
+	}, nil
 }
 
 func getEnv(key, defaultValue string) string {

--- a/pkg/schema/mysql/applies.sql
+++ b/pkg/schema/mysql/applies.sql
@@ -26,5 +26,6 @@ CREATE TABLE `applies` (
   KEY `idx_plan_id` (`plan_id`),
   KEY `idx_database_env` (`database_name`,`database_type`,`environment`),
   KEY `idx_repo_pr` (`repository`,`pull_request`),
+  KEY `idx_completed_at_state` (`completed_at`,`state`),
   KEY `idx_state` (`state`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci

--- a/pkg/storage/mysqlstore/applies.go
+++ b/pkg/storage/mysqlstore/applies.go
@@ -19,6 +19,11 @@ const applyColumns = `id, apply_identifier, lock_id, plan_id, database_name, dat
 	state, error_message, options,
 	created_at, started_at, completed_at, updated_at`
 
+const applyColumnsForApplyAlias = `a.id, a.apply_identifier, a.lock_id, a.plan_id, a.database_name, a.database_type,
+	a.repository, a.pull_request, a.environment, a.deployment, a.caller, a.installation_id, a.external_id, a.engine,
+	a.state, a.error_message, a.options,
+	a.created_at, a.started_at, a.completed_at, a.updated_at`
+
 // applyStore implements storage.ApplyStore using MySQL.
 type applyStore struct {
 	db *sql.DB
@@ -255,15 +260,19 @@ func (s *applyStore) GetByDatabase(ctx context.Context, database, dbType, enviro
 	return scanApplies(rows)
 }
 
-// FindMissingSummaryComment returns completed/failed applies that have a progress
-// comment but no summary comment. Used to post missing summaries after restart.
+// FindMissingSummaryComment returns GitHub-backed applies that should have a
+// terminal summary comment but only have a progress comment. Used to post missing
+// summaries after restart.
 func (s *applyStore) FindMissingSummaryComment(ctx context.Context) ([]*storage.Apply, error) {
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT `+applyColumns+`
+		SELECT `+applyColumnsForApplyAlias+`
 		FROM applies a
 		JOIN apply_comments acp ON acp.apply_id = a.id AND acp.comment_state = 'progress'
 		LEFT JOIN apply_comments acs ON acs.apply_id = a.id AND acs.comment_state = 'summary'
 		WHERE a.state IN (?, ?, ?, ?)
+		  AND a.repository != ''
+		  AND a.pull_request > 0
+		  AND a.installation_id > 0
 		  AND a.completed_at > NOW() - INTERVAL 1 HOUR
 		  AND acs.id IS NULL
 		ORDER BY a.completed_at DESC

--- a/pkg/storage/mysqlstore/applies_test.go
+++ b/pkg/storage/mysqlstore/applies_test.go
@@ -247,6 +247,76 @@ func TestApplyStore_GetInProgress(t *testing.T) {
 	assert.True(t, applyIDs[running.ApplyIdentifier], "expected running apply")
 }
 
+func TestApplyStore_FindMissingSummaryComment_ExcludesAppliesWithoutGitHubDestination(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	now := time.Now()
+	startedAt := now.Add(-time.Minute)
+
+	githubLock := createTestLockWithPR(t, store, "github_db", storage.DatabaseTypeMySQL, "staging", "org/repo", 123)
+	githubApply := &storage.Apply{
+		ApplyIdentifier: "apply_missing_summary_github",
+		LockID:          githubLock.ID,
+		PlanID:          600,
+		Database:        githubLock.DatabaseName,
+		DatabaseType:    githubLock.DatabaseType,
+		Repository:      githubLock.Repository,
+		PullRequest:     githubLock.PullRequest,
+		Environment:     "staging",
+		Caller:          "org/repo#123",
+		InstallationID:  12345,
+		Engine:          storage.EngineSpirit,
+		State:           state.Apply.Completed,
+	}
+	githubApplyID, err := store.Applies().Create(ctx, githubApply)
+	require.NoError(t, err)
+	githubApply.ID = githubApplyID
+	githubApply.StartedAt = &startedAt
+	githubApply.CompletedAt = &now
+	require.NoError(t, store.Applies().Update(ctx, githubApply))
+	require.NoError(t, store.ApplyComments().Upsert(ctx, &storage.ApplyComment{
+		ApplyID:         githubApply.ID,
+		CommentState:    state.Comment.Progress,
+		GitHubCommentID: 1001,
+	}))
+
+	cliLock := createTestLockWithPR(t, store, "cli_db", storage.DatabaseTypeMySQL, "staging", "", 0)
+	cliApply := &storage.Apply{
+		ApplyIdentifier: "apply_missing_summary_cli",
+		LockID:          cliLock.ID,
+		PlanID:          601,
+		Database:        cliLock.DatabaseName,
+		DatabaseType:    cliLock.DatabaseType,
+		Repository:      cliLock.Repository,
+		PullRequest:     cliLock.PullRequest,
+		Environment:     "staging",
+		Caller:          "cli:user@host",
+		Engine:          storage.EngineSpirit,
+		State:           state.Apply.Completed,
+	}
+	cliApplyID, err := store.Applies().Create(ctx, cliApply)
+	require.NoError(t, err)
+	cliApply.ID = cliApplyID
+	cliApply.StartedAt = &startedAt
+	cliApply.CompletedAt = &now
+	require.NoError(t, store.Applies().Update(ctx, cliApply))
+
+	// Even if a CLI-style apply somehow has a progress marker, it cannot be
+	// reconciled into a GitHub summary without repository, PR, and installation ID.
+	require.NoError(t, store.ApplyComments().Upsert(ctx, &storage.ApplyComment{
+		ApplyID:         cliApply.ID,
+		CommentState:    state.Comment.Progress,
+		GitHubCommentID: 1002,
+	}))
+
+	applies, err := store.Applies().FindMissingSummaryComment(ctx)
+	require.NoError(t, err)
+	require.Len(t, applies, 1)
+	assert.Equal(t, githubApply.ApplyIdentifier, applies[0].ApplyIdentifier)
+}
+
 func TestApplyStore_GetByPR(t *testing.T) {
 	clearTables(t)
 	ctx := t.Context()

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -206,9 +206,9 @@ type ApplyStore interface {
 	// If not called for > 1 minute, another worker can claim the apply.
 	Heartbeat(ctx context.Context, applyID int64) error
 
-	// FindMissingSummaryComment returns completed/failed applies that have a
-	// progress comment but no summary comment. Used by the recovery worker on
-	// startup to post missing summary comments after container restarts.
+	// FindMissingSummaryComment returns GitHub-backed applies that should have
+	// a terminal summary comment but only have a progress comment. Used by
+	// startup reconciliation to post missing summary comments after restarts.
 	FindMissingSummaryComment(ctx context.Context) ([]*Apply, error)
 
 	// GetByPR returns all applies for a PR.

--- a/pkg/webhook/apply_comment_e2e_test.go
+++ b/pkg/webhook/apply_comment_e2e_test.go
@@ -20,6 +20,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/block/spirit/pkg/utils"
+
 	"github.com/block/schemabot/pkg/api"
 	ghclient "github.com/block/schemabot/pkg/github"
 	"github.com/block/schemabot/pkg/state"
@@ -121,7 +123,7 @@ func TestE2EApplyCommentLifecycle(t *testing.T) {
 	// Set up SchemaBot storage
 	schemabotDB, err := sql.Open("mysql", e2eSchemabotDSN)
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = schemabotDB.Close() })
+	t.Cleanup(func() { utils.CloseAndLog(schemabotDB) })
 
 	st := mysqlstore.New(schemabotDB)
 
@@ -294,6 +296,129 @@ func TestE2EApplyCommentLifecycle(t *testing.T) {
 	assert.Equal(t, progressCommentID, commentStates[state.Comment.Progress])
 	assert.Equal(t, cutoverCommentID, commentStates[state.Comment.Cutover])
 	assert.Equal(t, summaryCommentID, commentStates[state.Comment.Summary])
+}
+
+func TestE2EReconcileMissingSummaryCommentsPostsSummary(t *testing.T) {
+	ctx := t.Context()
+
+	schemabotDB, err := sql.Open("mysql", e2eSchemabotDSN)
+	require.NoError(t, err)
+	t.Cleanup(func() { utils.CloseAndLog(schemabotDB) })
+
+	st := mysqlstore.New(schemabotDB)
+
+	// The storage database is shared by this integration package. Clear the
+	// rows this scenario owns so the missing-summary query only sees this apply.
+	_, err = schemabotDB.ExecContext(ctx, "DELETE FROM apply_comments")
+	require.NoError(t, err)
+	_, err = schemabotDB.ExecContext(ctx, "DELETE FROM tasks WHERE repository = 'org/reconcile-summary'")
+	require.NoError(t, err)
+	_, err = schemabotDB.ExecContext(ctx, "DELETE FROM applies WHERE repository = 'org/reconcile-summary'")
+	require.NoError(t, err)
+	_, err = schemabotDB.ExecContext(ctx, "DELETE FROM locks WHERE repository = 'org/reconcile-summary'")
+	require.NoError(t, err)
+
+	lock := &storage.Lock{
+		DatabaseName: "e2e_reconcile_summary_db",
+		DatabaseType: storage.DatabaseTypeMySQL,
+		Repository:   "org/reconcile-summary",
+		PullRequest:  44,
+		Owner:        "org/reconcile-summary#44",
+	}
+	require.NoError(t, st.Locks().Acquire(ctx, lock))
+	lock, err = st.Locks().Get(ctx, "e2e_reconcile_summary_db", storage.DatabaseTypeMySQL)
+	require.NoError(t, err)
+
+	// Startup reconciliation only posts summaries for GitHub-backed applies.
+	// CLI applies normally do not create apply_comments rows, and any candidate
+	// row still needs repository, pull request number, and installation ID so
+	// the reconciler knows where to post.
+	now := time.Now()
+	startedAt := now.Add(-time.Minute)
+	applyIdentifier := fmt.Sprintf("apply_reconcile_summary_%d", now.UnixNano())
+	apply := &storage.Apply{
+		ApplyIdentifier: applyIdentifier,
+		LockID:          lock.ID,
+		PlanID:          1,
+		Database:        "e2e_reconcile_summary_db",
+		DatabaseType:    storage.DatabaseTypeMySQL,
+		Repository:      "org/reconcile-summary",
+		PullRequest:     44,
+		Environment:     "staging",
+		Caller:          "org/reconcile-summary#44",
+		InstallationID:  12345,
+		Engine:          storage.EngineSpirit,
+		State:           state.Apply.Completed,
+	}
+	applyID, err := st.Applies().Create(ctx, apply)
+	require.NoError(t, err)
+	apply.ID = applyID
+	apply.StartedAt = &startedAt
+	apply.CompletedAt = &now
+	require.NoError(t, st.Applies().Update(ctx, apply))
+
+	// The reconciler reloads tasks from storage to render the summary comment,
+	// so seed the task state that should appear in the posted body.
+	task := &storage.Task{
+		TaskIdentifier: fmt.Sprintf("task_reconcile_summary_%d", now.UnixNano()),
+		ApplyID:        applyID,
+		PlanID:         1,
+		Database:       "e2e_reconcile_summary_db",
+		DatabaseType:   storage.DatabaseTypeMySQL,
+		Engine:         storage.EngineSpirit,
+		Repository:     "org/reconcile-summary",
+		PullRequest:    44,
+		Environment:    "staging",
+		State:          state.Task.Completed,
+		TableName:      "reconcile_users",
+		DDL:            "ALTER TABLE reconcile_users ADD COLUMN email VARCHAR(255)",
+		DDLAction:      "alter",
+		RowsCopied:     10,
+		RowsTotal:      10,
+		CreatedAt:      startedAt,
+		UpdatedAt:      now,
+		StartedAt:      &startedAt,
+		CompletedAt:    &now,
+	}
+	_, err = st.Tasks().Create(ctx, task)
+	require.NoError(t, err)
+
+	// A progress marker without a summary marker represents a process restart
+	// between progress comment posting and terminal summary comment posting.
+	require.NoError(t, st.ApplyComments().Upsert(ctx, &storage.ApplyComment{
+		ApplyID:         applyID,
+		CommentState:    state.Comment.Progress,
+		GitHubCommentID: 9001,
+	}))
+
+	installClient, capture := setupFakeGitHubForComments(t)
+	factory := &fakeClientFactory{client: installClient}
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	svc := api.New(st, &api.ServerConfig{}, map[string]tern.Client{}, logger)
+	t.Cleanup(func() { utils.CloseAndLog(svc) })
+
+	h := NewHandler(svc, factory, nil, logger)
+	// Run startup reconciliation directly; the fake GitHub server captures the
+	// summary comment that would be posted during server startup.
+	h.ReconcileMissingSummaryComments(ctx)
+
+	var created commentCreate
+	select {
+	case created = <-capture.creates:
+	case <-time.After(5 * time.Second):
+		require.FailNow(t, "timed out waiting for missing summary comment")
+	}
+	assert.Contains(t, created.Body, "Schema Change Applied")
+	assert.Contains(t, created.Body, "reconcile_users")
+	assert.Contains(t, created.Body, applyIdentifier)
+
+	// Recording the summary marker keeps future startup reconciliation passes
+	// from posting a duplicate terminal summary comment.
+	summaryComment, err := st.ApplyComments().Get(ctx, applyID, state.Comment.Summary)
+	require.NoError(t, err)
+	require.NotNil(t, summaryComment)
+	assert.Equal(t, created.ID, summaryComment.GitHubCommentID)
 }
 
 // TestE2EApplyCommentUpsertOnResume tests that Start/resume replaces old comment IDs.

--- a/pkg/webhook/handler.go
+++ b/pkg/webhook/handler.go
@@ -23,6 +23,7 @@ import (
 	"github.com/block/schemabot/pkg/api"
 	"github.com/block/schemabot/pkg/github"
 	"github.com/block/schemabot/pkg/metrics"
+	"github.com/block/schemabot/pkg/state"
 	"github.com/block/schemabot/pkg/storage"
 )
 
@@ -84,23 +85,49 @@ func NewHandler(service *api.Service, ghClient github.GitHubClientFactory, webho
 				}))
 		}
 
-		// Post missing summary comments for applies that completed during
-		// a container restart (outbox pattern).
-		service.OnMissingSummary = func(apply *storage.Apply) {
-			if apply.Repository == "" || apply.PullRequest == 0 || apply.InstallationID == 0 {
-				return
-			}
-			tasks, err := service.Storage().Tasks().GetByApplyID(context.Background(), apply.ID)
-			if err != nil {
-				logger.Error("failed to load tasks for missing summary", "apply_id", apply.ApplyIdentifier, "error", err)
-				return
-			}
-			summaryBody := formatSummaryComment(apply, tasks)
-			h.postAndTrackComment(context.Background(), apply.Repository, apply.PullRequest, apply.InstallationID, apply.ID, "summary", summaryBody)
-		}
 	}
 
 	return h
+}
+
+// ReconcileMissingSummaryComments repairs the apply_comments outbox on startup.
+// It finds applies with a progress comment but no summary comment, then posts
+// the missing summary so the PR shows the final result after a restart.
+func (h *Handler) ReconcileMissingSummaryComments(ctx context.Context) {
+	if h.service == nil {
+		h.logger.Debug("skipping missing summary reconciliation without service")
+		return
+	}
+
+	applies, err := h.service.Storage().Applies().FindMissingSummaryComment(ctx)
+	if err != nil {
+		h.logger.Error("failed to find applies missing summary comments", "error", err)
+		return
+	}
+
+	if len(applies) == 0 {
+		h.logger.Debug("no missing summary comments found")
+		return
+	}
+
+	h.logger.Info("found applies missing summary comments", "count", len(applies))
+
+	for _, apply := range applies {
+		tasks, err := h.service.Storage().Tasks().GetByApplyID(ctx, apply.ID)
+		if err != nil {
+			h.logger.Error("failed to load tasks for missing summary reconciliation", "apply_id", apply.ApplyIdentifier, "error", err)
+			continue
+		}
+
+		h.logger.Info("posting missing summary comment",
+			"apply_id", apply.ApplyIdentifier,
+			"repo", apply.Repository,
+			"pr", apply.PullRequest,
+			"state", apply.State)
+
+		summaryBody := formatSummaryComment(apply, tasks)
+		h.postAndTrackComment(ctx, apply.Repository, apply.PullRequest, apply.InstallationID, apply.ID, state.Comment.Summary, summaryBody)
+	}
 }
 
 // ServeHTTP handles incoming webhook requests.


### PR DESCRIPTION
## Summary

- Move missing summary comment reconciliation out of the scheduler and into webhook startup runtime
- Keep reconciliation non-blocking and preserve the recovery/reconciliation rationale in the new ownership points
- Filter missing-summary candidates to GitHub-backed applies in storage and add an index for recent terminal applies
- Add integration regression tests for posting/tracking missing summaries and excluding CLI-style applies
- Document that agents should move useful comments during refactors instead of deleting them

🤖 Generated by Codex.