### PR TITLE
test(webhook): replace non-deterministic select default with blocking receive in TestEnforcePassingChecks

### DIFF
--- a/pkg/webhook/apply_handlers_test.go
+++ b/pkg/webhook/apply_handlers_test.go
@@ -297,7 +297,8 @@ func TestEnforcePassingChecks(t *testing.T) {
 		case body := <-comments:
 			assert.Contains(t, body, "CI / tests")
 			assert.Contains(t, body, "failure")
-		default:
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out waiting for failing-checks comment")
 		}
 	})
 
@@ -359,7 +360,8 @@ func TestEnforcePassingChecks(t *testing.T) {
 		select {
 		case body := <-comments:
 			assert.Contains(t, body, "still running")
-		default:
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out waiting for in-progress-checks comment")
 		}
 	})
 


### PR DESCRIPTION
## What and Why ?
The "failing checks block apply" and "in-progress checks block apply" subtests asserted on the posted comment body via `select { case <-comments: ...; default: }`. If the goroutine posting the comment had not run by the time the select executed, the assertions silently no-op'd — the subtest still passed even though it verified nothing about the comment.

The other two subtests in the same function ("permission error blocks…" and "API failure blocks…") already use a blocking `select { case <-comments: ...; case <-time.After(2 * time.Second): t.Fatal(...) }` pattern. This change brings the remaining two in line so the comment-body assertions can no longer be skipped under load.

No production code touched; pure test hardening.