### PR TITLE
feat(scheduler): add durable apply dispatch and retries

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -162,11 +162,37 @@ jobs:
           key: go-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('go.sum') }}
           restore-keys: go-${{ runner.os }}-${{ runner.arch }}-
       - name: "Test"
-        run: make test-e2e-mysql test-e2e-grpc
+        run: make test-e2e-mysql
       - name: "Container logs on failure"
         if: failure()
         run: |
           docker compose -f deploy/e2e/docker-compose.yml logs --tail=300 schemabot localscale 2>/dev/null || true
+
+  e2e-grpc:
+    name: "E2E gRPC Tests"
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # actions/checkout@v6
+      - name: "Configure Go"
+        uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # actions/setup-go@v6.1
+        with:
+          go-version-file: go.mod
+          cache: false
+      - name: "Restore Go cache"
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # actions/cache/restore@v4
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: go-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('go.sum') }}
+          restore-keys: go-${{ runner.os }}-${{ runner.arch }}-
+      - name: "Test"
+        run: make test-e2e-grpc
+      - name: "Container logs on failure"
+        if: failure()
+        run: |
+          docker compose -p schemabot-e2e-grpc -f deploy/local/docker-compose.grpc.yml logs --tail=300 2>/dev/null || true
 
   e2e-vitess-matrix:
     name: "E2E Vitess Matrix"
@@ -271,12 +297,12 @@ jobs:
   # Remove these after updating branch protection to use the new job names.
   e2e-rollup:
     name: "E2E Tests"
-    needs: [e2e-mysql, e2e-vitess]
+    needs: [e2e-mysql, e2e-grpc, e2e-vitess]
     runs-on: ubuntu-latest
     if: always()
     steps:
       - run: |
-          if [ "${{ needs.e2e-mysql.result }}" != "success" ] || [ "${{ needs.e2e-vitess.result }}" != "success" ]; then
+          if [ "${{ needs.e2e-mysql.result }}" != "success" ] || [ "${{ needs.e2e-grpc.result }}" != "success" ] || [ "${{ needs.e2e-vitess.result }}" != "success" ]; then
             exit 1
           fi
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -195,13 +195,21 @@ An **apply** executes a previously created plan. One apply can have multiple **t
 ```
 schemabot apply (after confirming plan)
 
-CLI → API → Tern.Apply(PlanID)
-               │
-               ├─ looks up Plan from storage
-               ├─ creates Apply record (links to Plan)
-               ├─ creates Task records (one per DDL statement)
-               └─ starts execution (mode depends on engine and flags)
+CLI → API → storage
+           │
+           ├─ looks up Plan
+           ├─ creates Apply record (pending)
+           ├─ creates Task records (pending, one per DDL statement)
+           └─ returns accepted once work is durably queued
+
+Scheduler worker → Tern.ResumeApply()
+                       │
+                       └─ starts execution (mode depends on engine and flags)
 ```
+
+The request path only queues durable work. Scheduler workers own dispatch so a
+request timeout or server restart after `/apply` cannot leave in-memory work
+orphaned.
 
 ### Apply vs Task
 
@@ -268,14 +276,17 @@ type ProgressObserver interface {
 Webhook handler: "someone commented schemabot apply"
     |
     +-- Creates CommentObserver (posts PR comments)
-    +-- Calls SetPendingObserver on the client
+    +-- Calls SetPendingObserver on the API service
     +-- Calls ExecuteApply
             |
             v
-        Client.Apply()
-            +-- Consumes pending observer
-            +-- Registers Observer on the apply before engine starts
-            +-- Starts engine goroutine
+        Queue Apply + Tasks
+            +-- Registers Observer on the stored apply
+            |
+            v
+        Scheduler claims queued apply
+            +-- Calls ResumeApply()
+            +-- Starts engine goroutine or remote Tern dispatch
                     |
                     +-- Progress tick: poll engine, derive task/apply state
                     |   +-- Observer.OnProgress()
@@ -315,7 +326,7 @@ stored GitHub context, and errors never fail server startup.
 
 The scheduler is part of Tern orchestration. The API service starts it on server startup because the server owns process lifecycle, configuration, and the Tern client pool, but the scheduler's work is to coordinate applies: claim storage records, refresh their heartbeat lease, and call `ResumeApply()` on the right Tern client.
 
-Each scheduler worker runs immediately on startup, then polls every 10 seconds. The worker claims at most one apply per tick and resumes it through the Tern client for that apply's deployment and environment.
+Each scheduler worker runs immediately on startup, wakes when new apply work is queued, and polls every 10 seconds as a fallback. The worker claims at most one apply per wake or tick and resumes it through the Tern client for that apply's deployment and environment. Worker 0 also expires retryable failures that have exhausted their retry budget.
 
 `scheduler_workers` controls scheduler concurrency. The default is four workers, so an untuned server can still make progress across independent databases and environments concurrently. More workers help larger installations with many independent schema changes because each worker can claim and resume a different target during the same scheduler tick.
 
@@ -327,13 +338,13 @@ In a multi-pod deployment, every SchemaBot pod runs its own scheduler. Each sche
 | Scheduler                |      | Scheduler                |
 | +----------------------+ |      | +----------------------+ |
 | | worker 0             | |      | | worker 0             | |
-| | claim stale apply    | |      | | claim stale apply    | |
+| | claim apply work     | |      | | claim apply work     | |
 | | attach Observer      | |      | | attach Observer      | |
 | | ResumeApply          | |      | | ResumeApply          | |
 | +----------------------+ |      | +----------------------+ |
 | +----------------------+ |      | +----------------------+ |
 | | worker 1             | |      | | worker 1             | |
-| | claim stale apply    | |      | | claim stale apply    | |
+| | claim apply work     | |      | | claim apply work     | |
 | | attach Observer      | |      | | attach Observer      | |
 | | ResumeApply          | |      | | ResumeApply          | |
 | +----------------------+ |      | +----------------------+ |
@@ -343,7 +354,7 @@ In a multi-pod deployment, every SchemaBot pod runs its own scheduler. Each sche
              v                                  v
         +-----------------------------------------------+
         | Shared SchemaBot storage                      |
-        | applies, tasks, apply_target_locks            |
+        | applies, tasks, MySQL named locks             |
         | claims use FOR UPDATE SKIP LOCKED             |
         +-----------------------------------------------+
 
@@ -358,26 +369,32 @@ In a multi-pod deployment, every SchemaBot pod runs its own scheduler. Each sche
 
 The storage arrows represent scheduler coordination. The GitHub arrows represent optional observer notifications; CLI applies simply run without an observer.
 
-A **claim** is an atomic storage operation: it selects one stale apply and refreshes its `updated_at` heartbeat in the same transaction. That heartbeat refresh is the scheduler's lease while it reloads state and calls `ResumeApply()`. Claims use `FOR UPDATE SKIP LOCKED` so multiple scheduler workers can run concurrently without taking the same apply.
+A **claim** is an atomic storage operation: it selects one apply that needs scheduler work and refreshes its `updated_at` heartbeat in the same transaction. That heartbeat refresh is the scheduler's lease while it reloads state and calls `ResumeApply()`. Claims use `FOR UPDATE SKIP LOCKED` so multiple scheduler workers can run concurrently without taking the same apply.
 
-An apply becomes claimable after its heartbeat has been stale for more than one minute and it is in a state that can be resumed from persisted metadata. Terminal applies are already done, and stopped applies are not auto-resumed; the user must call `schemabot start`.
+A queued `pending` apply is claimable as soon as its task rows exist. Claiming it moves the row to `running` and gives the worker a lease before dispatch. Already-running applies become claimable after their heartbeat has been stale for more than one minute and they are in a state that can be resumed from persisted metadata. A `failed_retryable` apply is also claimable while it still has retry budget; claiming it moves the row to `running`, increments the retry attempt counter, and gives the worker a fresh lease before re-dispatch. Terminal applies are already done, and stopped applies are not auto-resumed; the user must call `schemabot start`.
+
+Retryable failures are for engine errors that are expected to clear without user action, such as transient transport failures. Engines mark known permanent failures explicitly so they become `failed` immediately. When a retryable apply reaches the retry limit, the scheduler expires it to `failed` and updates retryable tasks to `failed` as well.
+
+Task and apply `failed_retryable` states are related but not identical. A retryable task marks the specific table work that needs another dispatch attempt. A retryable apply marks the whole apply as paused for scheduler recovery and carries the retry attempt count. Attempts are counted at the apply level, so one scheduler retry can include multiple pending or retryable tasks. Pending tasks are unfinished work that is not currently running; they stay attached to the apply until the next dispatch.
+
+The scheduler handles retryable work at the apply level. It claims the `failed_retryable` apply, reloads its tasks, resets only `failed_retryable` tasks back to `pending`, leaves `completed` tasks completed, and re-dispatches the apply through Tern. In sequential mode, this means a table that already completed is skipped on retry, the table that failed retryably is tried again, and later pending tables remain eligible to run after it.
 
 SchemaBot has two different kinds of locking:
 
 - **Database locks** are coordination state for users and automation. They make ownership visible in CLI/webhook flows and let a human intentionally hold, release, or force-release work for a database.
 - **Apply invariants** are correctness rules enforced by storage. They do not depend on a database lock being present, because direct API callers and `--no-lock` flows still must not create invalid concurrent work.
 
-SchemaBot enforces one active apply per database, database type, and environment when an apply record is created or moved back into an active state. The `applies` table is the tern-layer work table, but storage uses a small target-lock table as the serialization surface for this invariant.
+SchemaBot enforces one active apply per database, database type, and environment when an apply record is created or moved back into an active state. The `applies` table is the Tern-layer work table, but storage serializes active apply writes with a per-target MySQL named lock before it checks or writes `applies`.
 
-The target lock row lives in `apply_target_locks`. This table is internal storage infrastructure, not user-facing lock state and not apply lifecycle state. A row is created lazily the first time a target is used, then reused for every future apply for that same database/type/environment. Normal apply completion, failure, cancellation, or revert does not delete the row; the active lifecycle remains in `applies`.
+The named lock is internal storage infrastructure, not user-facing lock state and not apply lifecycle state. Storage holds the lock on a dedicated connection while it runs the active-apply transaction, then releases it before returning the connection to the pool.
 
-`apply_target_locks` exists because the first active apply for a target has no existing `applies` row to lock. Locking the absence of an active row in `applies` requires InnoDB range locks over `idx_database_env`. Those range locks can deadlock independent first-writer transactions when multiple targets are creating applies concurrently. A persistent target row gives storage an exact mutex row before it reads or writes `applies`.
+The storage schema may include an `apply_target_locks` table, but active apply serialization does not depend on rows in that table. The correctness boundary is the per-target named lock plus the active-apply check in `applies`.
 
-The target row lock is transaction-local. Same-target writers wait on the same `apply_target_locks` row, then re-check `applies` after the earlier writer commits. If an active apply now exists, the later writer fails cleanly. Different targets lock different rows, so they can create or resume applies concurrently without depending on empty-range locks in `applies`.
+The first active apply for a target has no existing `applies` row to lock. Locking the absence of an active row in `applies` requires InnoDB range locks over `idx_database_env`, and creating a separate mutex row on the apply hot path can block behind unrelated storage-table contention. A named lock gives storage a target-specific serialization point before it reads or writes `applies`, without bootstrapping rows during an apply request.
+
+Same-target writers wait on the same named lock, then re-check `applies` after the earlier writer commits. If an active apply now exists, the later writer fails cleanly. Different targets use different lock names, so they can create or resume applies concurrently without depending on empty-range locks in `applies`.
 
 The scheduler relies on that invariant. Additional workers increase concurrency across independent targets; they do not make one database/environment run multiple applies at once.
-
-If a worker finds no claimable apply, it waits briefly and retries once during the same tick. This lets another worker that lost a claim race pick up a different target without waiting for the next 10-second poll.
 
 ### Execution Modes
 
@@ -479,14 +496,18 @@ Used for: distributed deployments where SchemaBot and the database engine run on
 
 **Identity resolution (`apply_identifier` vs `external_id`):**
 
-In gRPC mode, SchemaBot and Tern maintain separate storage with separate IDs. When Apply succeeds, Tern returns its own ID (the remote engine's apply identifier). SchemaBot generates a separate `apply_identifier` for its HTTP callers and stores Tern's ID as `external_id`:
+In gRPC mode, SchemaBot and Tern maintain separate storage with separate IDs. The API request creates SchemaBot's local apply first and returns that `apply_identifier` to HTTP callers. When the scheduler dispatches the queued apply to remote Tern, Tern returns its own ID and SchemaBot stores it as `external_id`:
 
 ```
 Apply flow:
-  ExecuteApply → client.Apply() → Tern returns ApplyId:"tern-42"
-    → SchemaBot generates apply_identifier="apply-abc123"
-    → stores external_id="tern-42"
+  ExecuteApply
+    → stores apply_identifier="apply-abc123", external_id=""
     → returns apply_id="apply-abc123" to HTTP caller
+
+  Scheduler claims apply-abc123
+    → GRPCClient calls remote Tern Apply()
+    → Tern returns ApplyId:"tern-42"
+    → SchemaBot stores external_id="tern-42"
 
 Subsequent RPCs (Progress, Stop, Start, Cutover, Volume):
   HTTP caller sends apply_id="apply-abc123"
@@ -495,19 +516,16 @@ Subsequent RPCs (Progress, Stop, Start, Cutover, Volume):
     → GRPCClient sends ApplyId:"tern-42" to Tern
 ```
 
-In local mode (`client.IsRemote() == false`), `LocalClient` runs in the same process and writes to the same database as the API layer:
+In local mode, `LocalClient` runs in the same process and writes to the same database as the API layer. There is no remote ID, so `external_id` stays empty:
 
 ```
 Apply flow (local):
-  ExecuteApply checks client.IsRemote() → false
-  ExecuteApply → client.Apply()
-    → LocalClient creates apply in DB:
-        apply_identifier="apply-def456", external_id="" (not set — no remote Tern)
-    → returns ApplyId:"apply-def456"
-  ExecuteApply gets resp.ApplyId="apply-def456"
-    → IsRemote()==false, so looks up existing record directly
-    → reuses LocalClient's apply record
+  ExecuteApply
+    → stores apply_identifier="apply-def456", external_id=""
     → returns apply_id="apply-def456" to HTTP caller
+
+  Scheduler claims apply-def456
+    → LocalClient starts engine work from the stored apply/tasks
 
 Subsequent RPCs (local):
   HTTP caller sends apply_id="apply-def456"
@@ -517,8 +535,6 @@ Subsequent RPCs (local):
     → LocalClient receives ApplyId:"apply-def456"
     → scopes task lookup to that apply
 ```
-
-The `IsRemote()` method on the `tern.Client` interface makes this branching explicit.
 
 Both modes implement the same `tern.Client` interface — callers don't know which mode is active.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -71,7 +71,7 @@ scheduler_workers: 4
 
 Increase `scheduler_workers` when one SchemaBot server should make scheduler progress across independent databases or environments concurrently. More workers help high-scale installations with many schema changes because each worker can claim and resume a different target during the same scheduler tick. The scheduler still excludes overlapping work for the same database and environment, so this improves concurrency across independent targets, not parallel execution against one target.
 
-A scheduler claim means selecting one stale apply and refreshing its heartbeat in the same storage transaction. That heartbeat refresh is the worker's lease while it reloads state and resumes the apply.
+A scheduler claim means selecting one queued, stale, or retryable apply and refreshing its heartbeat in the same storage transaction. That heartbeat refresh is the worker's lease while it reloads state and starts or resumes the apply.
 
 ## Repository Allowlist
 

--- a/docs/spirit_progress.md
+++ b/docs/spirit_progress.md
@@ -269,10 +269,9 @@ The `⠋` is a Braille spinner (animated in the TUI, static here).
    `IsComplete`.
 
 4. **Crash recovery loses up to 500ms of progress.** The pollers write to storage every 500ms.
-   On crash, the last persisted snapshot may be up to 500ms stale. The recovery loop
-   (`Service.RecoverInProgress`) finds applies with stale heartbeats and calls
-   `Tern.ResumeApply()`, which re-plans against the actual DB state to determine what still needs
-   to be done.
+   On crash, the last persisted snapshot may be up to 500ms stale. Scheduler workers find
+   applies with stale heartbeats and call `Tern.ResumeApply()`, which re-plans against the
+   actual DB state to determine what still needs to be done.
 
 5. **ETA is only available via `ProgressDetail` parsing.** Spirit embeds ETA in its summary string.
    The engine layer doesn't extract it into a separate field — it flows through as `ProgressDetail`

--- a/e2e/local/local_test.go
+++ b/e2e/local/local_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/block/schemabot/e2e/testutil"
+	"github.com/block/schemabot/pkg/apitypes"
 	"github.com/block/schemabot/pkg/cmd/client"
 	"github.com/block/schemabot/pkg/e2eutil"
 	"github.com/block/schemabot/pkg/state"
@@ -439,6 +440,57 @@ CREATE TABLE %s (
 	`, tableName).Scan(&count)
 	require.NoError(t, err, "query for table")
 	assert.Equalf(t, 1, count, "table %s should exist after apply", tableName)
+}
+
+// TestLocal_Apply_SpiritEngineFailureIsRetryable exercises the local CLI/API
+// path with a real Spirit execution failure. The plan is valid when created,
+// but the live table changes before apply starts, so the engine failure should
+// be surfaced as retryable progress instead of a permanent apply failure.
+func TestLocal_Apply_SpiritEngineFailureIsRetryable(t *testing.T) {
+	clearSchemaBotState(t)
+	t.Cleanup(func() { clearSchemaBotState(t) })
+
+	endpoint := schemabotURL(t)
+	tableName := uniqueTableName("spirit_retry")
+	columnName := "retryable_col"
+	createTestTable(t, tableName, fmt.Sprintf(`
+CREATE TABLE %s (
+    id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(255) NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+`, tableName))
+
+	db := openTestappStaging(t)
+	schemaDir := newSchemaDir(t)
+	writeExistingTablesSchema(t, schemaDir)
+	e2eutil.WriteFile(t, filepath.Join(schemaDir, tableName+".sql"), fmt.Sprintf(`
+CREATE TABLE %s (
+    id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    %s BIGINT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+`, tableName, columnName))
+
+	planResp, err := client.CallPlanAPI(endpoint, "testapp", "mysql", "staging", schemaDir, "", 0)
+	require.NoError(t, err)
+	require.NotEmpty(t, planResp.PlanID)
+	require.NotEmpty(t, planResp.Changes)
+
+	// Mutate the live table after planning so the accepted apply fails while
+	// Spirit executes the planned DDL, not during plan generation.
+	_, err = db.ExecContext(t.Context(), fmt.Sprintf("ALTER TABLE `%s` ADD COLUMN `%s` BIGINT NULL", tableName, columnName))
+	require.NoError(t, err)
+
+	applyResp, err := client.CallApplyAPI(endpoint, planResp.PlanID, "testapp", "staging", "e2e-test", nil)
+	require.NoError(t, err)
+	require.True(t, applyResp.Accepted, "apply not accepted: %s", applyResp.ErrorMessage)
+
+	waitForApplyAnyState(t, endpoint, applyResp.ApplyID, []string{state.Apply.FailedRetryable}, 8*time.Second)
+	progress, err := client.GetProgress(endpoint, applyResp.ApplyID)
+	require.NoError(t, err)
+	assert.Equal(t, state.Apply.FailedRetryable, progress.State)
+	assert.Equal(t, apitypes.ErrCodeEngineErrorRetryable, progress.ErrorCode)
+	assert.Contains(t, progress.ErrorMessage, "Duplicate column")
 }
 
 func TestLocal_Apply_CreateMultipleTables(t *testing.T) {

--- a/e2e/local/vitess_test.go
+++ b/e2e/local/vitess_test.go
@@ -1610,6 +1610,43 @@ func TestVitess_Apply_DeferDeploy_StartTooEarly(t *testing.T) {
 	waitForApplyState(t, endpoint, applyResp.ApplyID, state.Apply.Completed, testutil.PollDeadline)
 }
 
+// TestVitess_Apply_MainBranchReuseFailsPermanently exercises a known permanent
+// PlanetScale validation failure. Reusing the main branch should fail the apply
+// without entering scheduler retry.
+func TestVitess_Apply_MainBranchReuseFailsPermanently(t *testing.T) {
+	vitessAvailable(t)
+	clearSchemaBotState(t)
+
+	endpoint := schemabotURL(t)
+	colName := fmt.Sprintf("main_branch_col_%d", time.Now().UnixMilli()%100000)
+	schemaDir := newVitessSchemaDir(t, vitessSchemaWithOverrides(map[string]string{
+		"testapp_sharded/users.sql": usersSchemaWithColumn(colName),
+	}))
+
+	planResp, err := client.CallPlanAPI(endpoint, vitessDB, "vitess", "staging", schemaDir, "", 0)
+	require.NoError(t, err)
+	require.NotEmpty(t, planResp.PlanID)
+	require.NotEmpty(t, planResp.Changes)
+
+	// Passing branch=main intentionally violates the engine's branch reuse
+	// rules so this path proves known permanent errors bypass retry handling.
+	applyResp, err := client.CallApplyAPI(endpoint, planResp.PlanID, vitessDB, "staging", "e2e-test",
+		map[string]string{"branch": "main", "skip_revert": "true"})
+	require.NoError(t, err)
+	require.NotEmpty(t, applyResp.ApplyID)
+
+	finalState := waitForApplyAnyState(t, endpoint, applyResp.ApplyID,
+		[]string{state.Apply.Failed, state.Apply.FailedRetryable}, testutil.PollDeadline)
+	assert.Equal(t, state.Apply.Failed, finalState)
+
+	progress, err := client.GetProgress(endpoint, applyResp.ApplyID)
+	require.NoError(t, err)
+	assert.True(t, state.IsState(progress.State, state.Apply.Failed))
+	assert.Equal(t, apitypes.ErrCodeEngineError, progress.ErrorCode)
+	assert.NotEqual(t, apitypes.ErrCodeEngineErrorRetryable, progress.ErrorCode)
+	assert.Contains(t, progress.ErrorMessage, "cannot reuse the main branch")
+}
+
 func TestVitess_Apply_BranchReuse(t *testing.T) {
 	vitessAvailable(t)
 	clearSchemaBotState(t)

--- a/integration/cli_test.go
+++ b/integration/cli_test.go
@@ -866,6 +866,7 @@ func startSchemaBotLocal(t *testing.T) string {
 
 	svc := schemabotapi.New(storage, config, ternClients, logger)
 	t.Cleanup(func() { utils.CloseAndLog(svc) })
+	startTestScheduler(t, svc)
 
 	// Start HTTP server
 	mux := http.NewServeMux()
@@ -947,6 +948,7 @@ func startSchemaBotLocalDB(t *testing.T, dbName string) string {
 
 	svc := schemabotapi.New(storage, config, ternClients, logger)
 	t.Cleanup(func() { utils.CloseAndLog(svc) })
+	startTestScheduler(t, svc)
 
 	// Start HTTP server
 	mux := http.NewServeMux()
@@ -985,7 +987,10 @@ func startSchemaBotWithGRPC(t *testing.T) string {
 	storage := mysqlstore.New(db)
 
 	// Create gRPC client to connect to the Tern gRPC server
-	ternClient, err := tern.NewGRPCClient(tern.Config{Address: grpcAddr})
+	ternClient, err := tern.NewGRPCClient(tern.Config{
+		Address: grpcAddr,
+		Storage: storage,
+	})
 	require.NoError(t, err, "create tern client")
 	t.Cleanup(func() { utils.CloseAndLog(ternClient) })
 
@@ -1006,6 +1011,7 @@ func startSchemaBotWithGRPC(t *testing.T) string {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	svc := schemabotapi.New(storage, config, ternClients, logger)
 	t.Cleanup(func() { utils.CloseAndLog(svc) })
+	startTestScheduler(t, svc)
 
 	// Start HTTP server
 	mux := http.NewServeMux()

--- a/integration/grpc_integration_test.go
+++ b/integration/grpc_integration_test.go
@@ -178,7 +178,10 @@ func TestGRPC_ExternalID_StoredOnApply(t *testing.T) {
 	defer utils.CloseAndLog(schemabotDB)
 	schemabotStorage := schemabotmysql.New(schemabotDB)
 
-	ternClient, err := tern.NewGRPCClient(tern.Config{Address: ternGRPCAddr})
+	ternClient, err := tern.NewGRPCClient(tern.Config{
+		Address: ternGRPCAddr,
+		Storage: schemabotStorage,
+	})
 	require.NoError(t, err, "create tern client")
 	defer utils.CloseAndLog(ternClient)
 
@@ -191,6 +194,7 @@ func TestGRPC_ExternalID_StoredOnApply(t *testing.T) {
 		"default/staging": ternClient,
 	}, logger)
 	defer utils.CloseAndLog(svc)
+	startTestScheduler(t, svc)
 
 	mux := http.NewServeMux()
 	svc.ConfigureRoutes(mux)
@@ -257,10 +261,19 @@ func TestGRPC_ExternalID_StoredOnApply(t *testing.T) {
 	applyID, ok := applyResult["apply_id"].(string)
 	require.True(t, ok && applyID != "", "apply response missing apply_id: %v", applyResult)
 
-	// Step 3: Verify external_id is stored in SchemaBot's storage
-	storedApply, err := schemabotStorage.Applies().GetByApplyIdentifier(ctx, applyID)
-	require.NoError(t, err, "get apply by identifier")
-	require.NotNil(t, storedApply, "apply %s not found in storage", applyID)
+	// Step 3: Scheduler dispatch stores the remote Tern ID after the worker
+	// claims the queued apply.
+	var storedApply *storage.Apply
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		storedApply, err = schemabotStorage.Applies().GetByApplyIdentifier(ctx, applyID)
+		require.NoError(t, err, "get apply by identifier")
+		require.NotNil(t, storedApply, "apply %s not found in storage", applyID)
+		if storedApply.ExternalID != "" {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
 
 	assert.NotEmpty(t, storedApply.ExternalID, "external_id is empty, expected it to be set from remote Tern's apply_id")
 	assert.NotEqual(t, applyID, storedApply.ExternalID,
@@ -317,6 +330,7 @@ func TestGRPC_TaskStateUpdatedOnCompletion(t *testing.T) {
 		"default/staging": ternClient,
 	}, logger)
 	defer utils.CloseAndLog(svc)
+	startTestScheduler(t, svc)
 
 	mux := http.NewServeMux()
 	svc.ConfigureRoutes(mux)
@@ -496,7 +510,10 @@ func TestGRPC_Deployment_StoredOnApply(t *testing.T) {
 	defer utils.CloseAndLog(schemabotDB)
 	schemabotStorage := schemabotmysql.New(schemabotDB)
 
-	ternClient, err := tern.NewGRPCClient(tern.Config{Address: ternGRPCAddr})
+	ternClient, err := tern.NewGRPCClient(tern.Config{
+		Address: ternGRPCAddr,
+		Storage: schemabotStorage,
+	})
 	require.NoError(t, err, "create tern client")
 	defer utils.CloseAndLog(ternClient)
 
@@ -510,6 +527,7 @@ func TestGRPC_Deployment_StoredOnApply(t *testing.T) {
 		"us-west/staging": ternClient,
 	}, logger)
 	defer utils.CloseAndLog(svc)
+	startTestScheduler(t, svc)
 
 	mux := http.NewServeMux()
 	svc.ConfigureRoutes(mux)

--- a/integration/hybrid_mode_test.go
+++ b/integration/hybrid_mode_test.go
@@ -131,6 +131,7 @@ func TestHybridMode_LocalAndGRPC(t *testing.T) {
 		"default/staging": grpcClient,
 	}, logger)
 	t.Cleanup(func() { utils.CloseAndLog(svc) })
+	startTestScheduler(t, svc)
 
 	mux := http.NewServeMux()
 	svc.ConfigureRoutes(mux)

--- a/integration/resolve_apply_id_test.go
+++ b/integration/resolve_apply_id_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	schemabotapi "github.com/block/schemabot/pkg/api"
+	"github.com/block/schemabot/pkg/storage"
 	schemabotmysql "github.com/block/schemabot/pkg/storage/mysqlstore"
 	"github.com/block/schemabot/pkg/tern"
 )
@@ -65,6 +66,7 @@ func TestResolveApplyID_ControlOperations(t *testing.T) {
 		"default/staging": ternClient,
 	}, logger)
 	t.Cleanup(func() { utils.CloseAndLog(svc) })
+	startTestScheduler(t, svc)
 
 	mux := http.NewServeMux()
 	svc.ConfigureRoutes(mux)
@@ -130,10 +132,18 @@ func TestResolveApplyID_ControlOperations(t *testing.T) {
 	applyIdentifier, ok := applyResult["apply_id"].(string)
 	require.True(t, ok && applyIdentifier != "", "apply response missing apply_id")
 
-	// 5. Verify apply_identifier != external_id.
-	storedApply, err := st.Applies().GetByApplyIdentifier(ctx, applyIdentifier)
-	require.NoError(t, err)
-	require.NotNil(t, storedApply, "apply not found in storage")
+	// 5. Scheduler dispatch stores the remote Tern ID after claiming the apply.
+	var storedApply *storage.Apply
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		storedApply, err = st.Applies().GetByApplyIdentifier(ctx, applyIdentifier)
+		require.NoError(t, err)
+		require.NotNil(t, storedApply, "apply not found in storage")
+		if storedApply.ExternalID != "" {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
 	require.NotEmpty(t, storedApply.ExternalID, "external_id should be set by remote Tern")
 	require.NotEqual(t, applyIdentifier, storedApply.ExternalID,
 		"apply_identifier and external_id must differ — resolveApplyID translates between them")

--- a/integration/scheduler_test.go
+++ b/integration/scheduler_test.go
@@ -24,6 +24,8 @@ import (
 	"github.com/block/schemabot/pkg/tern"
 )
 
+const schedulerTestPollInterval = 200 * time.Millisecond
+
 // These tests exercise scheduler behavior at two levels: the full worker loop
 // in the resume tests, and the atomic claim query through FindNextApply.
 // Scheduler workers use FindNextApply before calling ResumeApply, so direct
@@ -127,6 +129,7 @@ func TestScheduler_BasicClaimAndResume(t *testing.T) {
 	require.True(t, applyResp["accepted"] == true)
 	applyID, _ := applyResp["apply_id"].(string)
 	waitForState(t, "http://"+ts.Addr, applyID, "completed", 15*time.Second)
+	ts.Service.StopScheduler()
 
 	// Remove the table so the second plan contains DDL that recovery can resume.
 	targetConn, err := sql.Open("mysql", appDSN)
@@ -191,19 +194,127 @@ func TestScheduler_BasicClaimAndResume(t *testing.T) {
 	}
 
 	// Scheduler recovery should claim the stale apply and resume it to completion.
+	require.NoError(t, ts.Service.SetSchedulerPollInterval(schedulerTestPollInterval))
 	ts.Service.StartScheduler(t.Context())
 	defer ts.Service.StopScheduler()
 
-	deadline := time.Now().Add(20 * time.Second)
-	for time.Now().Before(deadline) {
-		apply, err := ts.Storage.Applies().Get(ctx, staleID)
-		require.NoError(t, err)
-		if apply != nil && apply.State == state.Apply.Completed {
-			return
-		}
-		time.Sleep(500 * time.Millisecond)
+	waitForSchedulerAppliesCompleted(t, ts.Storage, []int64{staleID}, schedulerTestPollInterval+5*time.Second)
+}
+
+func TestScheduler_QueuedApplyDispatchesToCompletion(t *testing.T) {
+	ctx := t.Context()
+	schemaSQL, err := os.ReadFile("testdata/myapp/mysql/schema/users.sql")
+	require.NoError(t, err)
+
+	appDBName, appDSN := createTestDB(t, "queued_sched_")
+	ts := startTestServer(t, appDBName, appDSN)
+	ts.Service.StopScheduler()
+
+	planResp := postJSON(t, "http://"+ts.Addr+"/api/plan", map[string]any{
+		"database": appDBName, "environment": "staging", "type": "mysql",
+		"schema_files": map[string]any{"default": map[string]any{"files": map[string]string{"users.sql": string(schemaSQL)}}},
+	})
+	planID, _ := planResp["plan_id"].(string)
+	require.NotEmpty(t, planID)
+
+	applyResp := postJSON(t, "http://"+ts.Addr+"/api/apply", map[string]any{
+		"plan_id": planID, "environment": "staging",
+	})
+	require.True(t, applyResp["accepted"] == true)
+	applyIdentifier, _ := applyResp["apply_id"].(string)
+	require.NotEmpty(t, applyIdentifier)
+
+	queuedApply, err := ts.Storage.Applies().GetByApplyIdentifier(ctx, applyIdentifier)
+	require.NoError(t, err)
+	require.NotNil(t, queuedApply)
+	assert.Equal(t, state.Apply.Pending, queuedApply.State)
+	assert.Nil(t, queuedApply.StartedAt)
+
+	tasks, err := ts.Storage.Tasks().GetByApplyID(ctx, queuedApply.ID)
+	require.NoError(t, err)
+	require.NotEmpty(t, tasks)
+	for _, task := range tasks {
+		assert.Equal(t, state.Task.Pending, task.State)
 	}
-	t.Fatal("timeout: scheduler did not resume stale apply")
+
+	// Once workers start, the scheduler should claim the queued apply,
+	// dispatch the local engine work, and drive the apply to completion.
+	require.NoError(t, ts.Service.SetSchedulerPollInterval(schedulerTestPollInterval))
+	ts.Service.StartScheduler(ctx)
+	defer ts.Service.StopScheduler()
+
+	waitForSchedulerAppliesCompleted(t, ts.Storage, []int64{queuedApply.ID}, schedulerTestPollInterval+5*time.Second)
+}
+
+func TestScheduler_PendingClaimCrashWindowDispatchesToCompletion(t *testing.T) {
+	ctx := t.Context()
+	schemaSQL, err := os.ReadFile("testdata/myapp/mysql/schema/users.sql")
+	require.NoError(t, err)
+
+	appDBName, appDSN := createTestDB(t, "pending_crash_")
+	ts := startTestServer(t, appDBName, appDSN)
+	ts.Service.StopScheduler()
+
+	planResp := postJSON(t, "http://"+ts.Addr+"/api/plan", map[string]any{
+		"database": appDBName, "environment": "staging", "type": "mysql",
+		"schema_files": map[string]any{"default": map[string]any{"files": map[string]string{"users.sql": string(schemaSQL)}}},
+	})
+	planID, _ := planResp["plan_id"].(string)
+	require.NotEmpty(t, planID)
+	plan, err := ts.Storage.Plans().Get(ctx, planID)
+	require.NoError(t, err)
+	require.NotNil(t, plan)
+
+	now := time.Now()
+	applyID, err := ts.Storage.Applies().Create(ctx, &storage.Apply{
+		ApplyIdentifier: fmt.Sprintf("apply-pending-crash-%d", now.UnixNano()%100000),
+		PlanID:          plan.ID,
+		Database:        appDBName,
+		DatabaseType:    storage.DatabaseTypeMySQL,
+		Engine:          storage.EngineSpirit,
+		State:           state.Apply.Running,
+		Options:         []byte("{}"),
+		Environment:     "staging",
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	})
+	require.NoError(t, err)
+
+	schemabotDB, err := sql.Open("mysql", schemabotDSN)
+	require.NoError(t, err)
+	require.NoError(t, schemabotDB.PingContext(ctx))
+	defer utils.CloseAndLog(schemabotDB)
+	_, err = schemabotDB.ExecContext(ctx, "UPDATE applies SET updated_at = NOW() - INTERVAL 2 MINUTE WHERE id = ?", applyID)
+	require.NoError(t, err)
+
+	for _, tc := range plan.FlatDDLChanges() {
+		_, err := ts.Storage.Tasks().Create(ctx, &storage.Task{
+			TaskIdentifier: fmt.Sprintf("task-pending-crash-%d", time.Now().UnixNano()%100000),
+			ApplyID:        applyID,
+			PlanID:         plan.ID,
+			Database:       appDBName,
+			DatabaseType:   storage.DatabaseTypeMySQL,
+			Engine:         storage.EngineSpirit,
+			State:          state.Task.Pending,
+			TableName:      tc.Table,
+			DDL:            tc.DDL,
+			DDLAction:      tc.Operation,
+			Options:        []byte("{}"),
+			Environment:    "staging",
+			CreatedAt:      now,
+			UpdatedAt:      now,
+		})
+		require.NoError(t, err)
+	}
+
+	// This is the durable state left if a worker claimed a queued apply and
+	// crashed before starting the engine. Recovery should dispatch it exactly
+	// like a fresh pending apply, not look for existing engine metadata.
+	require.NoError(t, ts.Service.SetSchedulerPollInterval(schedulerTestPollInterval))
+	ts.Service.StartScheduler(ctx)
+	defer ts.Service.StopScheduler()
+
+	waitForSchedulerAppliesCompleted(t, ts.Storage, []int64{applyID}, schedulerTestPollInterval+5*time.Second)
 }
 
 func TestScheduler_ClaimOrdering(t *testing.T) {
@@ -273,6 +384,7 @@ func TestScheduler_ClaimableStates(t *testing.T) {
 	}{
 		{name: "pending", applyState: state.Apply.Pending, databaseType: "mysql", engine: "spirit", wantClaim: true},
 		{name: "running", applyState: state.Apply.Running, databaseType: "mysql", engine: "spirit", wantClaim: true},
+		{name: "failed retryable", applyState: state.Apply.FailedRetryable, databaseType: "mysql", engine: "spirit", wantClaim: true},
 		{name: "waiting for deploy", applyState: state.Apply.WaitingForDeploy, databaseType: "vitess", engine: "planetscale", wantClaim: true},
 		{name: "waiting for cutover", applyState: state.Apply.WaitingForCutover, databaseType: "vitess", engine: "planetscale", wantClaim: true},
 		{name: "cutting over", applyState: state.Apply.CuttingOver, databaseType: "vitess", engine: "planetscale", wantClaim: true},
@@ -294,7 +406,7 @@ func TestScheduler_ClaimableStates(t *testing.T) {
 			fixture.resetStorage(t)
 
 			applyIdentifier := fmt.Sprintf("apply-claim-state-%d", i)
-			_, err := stor.Applies().Create(ctx, &storage.Apply{
+			applyID, err := stor.Applies().Create(ctx, &storage.Apply{
 				ApplyIdentifier: applyIdentifier,
 				Database:        appDBName,
 				DatabaseType:    tc.databaseType,
@@ -304,6 +416,25 @@ func TestScheduler_ClaimableStates(t *testing.T) {
 				Environment:     "staging",
 			})
 			require.NoError(t, err)
+			if tc.applyState == state.Apply.Pending {
+				// Pending represents a fully queued apply only after tasks are
+				// persisted; workers ignore partially written apply rows.
+				now := time.Now()
+				_, err = stor.Tasks().Create(ctx, &storage.Task{
+					TaskIdentifier: "task-" + applyIdentifier,
+					ApplyID:        applyID,
+					Database:       appDBName,
+					DatabaseType:   tc.databaseType,
+					Engine:         tc.engine,
+					State:          state.Task.Pending,
+					Environment:    "staging",
+					TableName:      "users",
+					DDLAction:      "CREATE",
+					CreatedAt:      now,
+					UpdatedAt:      now,
+				})
+				require.NoError(t, err)
+			}
 			_, err = schemabotDB.ExecContext(ctx,
 				"UPDATE applies SET updated_at = NOW() - INTERVAL 2 MINUTE WHERE apply_identifier = ?",
 				applyIdentifier)
@@ -361,6 +492,289 @@ func TestScheduler_ClaimRefreshesHeartbeat(t *testing.T) {
 	reclaimed, err := stor.Applies().FindNextApply(ctx)
 	require.NoError(t, err)
 	assert.Nil(t, reclaimed, "freshly claimed apply should not be claimable again")
+}
+
+// TestScheduler_RetryableApplyResumesToCompletion seeds storage with a
+// retryable apply and retryable task, then starts the scheduler. The scheduler
+// should claim the apply, reset retryable work, dispatch it through Tern, and
+// complete both the apply and task while incrementing attempt counters once.
+func TestScheduler_RetryableApplyResumesToCompletion(t *testing.T) {
+	ctx := t.Context()
+	schemaSQL, err := os.ReadFile("testdata/myapp/mysql/schema/users.sql")
+	require.NoError(t, err)
+
+	appDBName, appDSN := createTestDB(t, "retryable_sched_")
+	ts := startTestServer(t, appDBName, appDSN)
+	ts.Service.StopScheduler()
+
+	planResp := postJSON(t, "http://"+ts.Addr+"/api/plan", map[string]any{
+		"database": appDBName, "environment": "staging", "type": "mysql",
+		"schema_files": map[string]any{"default": map[string]any{"files": map[string]string{"users.sql": string(schemaSQL)}}},
+	})
+	planID, _ := planResp["plan_id"].(string)
+	require.NotEmpty(t, planID)
+	plan, err := ts.Storage.Plans().Get(ctx, planID)
+	require.NoError(t, err)
+	require.NotNil(t, plan)
+
+	// The persisted state represents an apply whose previous engine dispatch
+	// stopped on a retryable error before scheduler recovery picked it up.
+	now := time.Now()
+	retryApply := &storage.Apply{
+		ApplyIdentifier: fmt.Sprintf("apply-retryable-%d", now.UnixNano()%100000),
+		PlanID:          plan.ID,
+		Database:        appDBName,
+		DatabaseType:    storage.DatabaseTypeMySQL,
+		Engine:          storage.EngineSpirit,
+		State:           state.Apply.FailedRetryable,
+		ErrorMessage:    "transient engine error",
+		Options:         []byte("{}"),
+		Environment:     "staging",
+	}
+	applyID, err := ts.Storage.Applies().Create(ctx, retryApply)
+	require.NoError(t, err)
+
+	for _, tc := range plan.FlatDDLChanges() {
+		_, err := ts.Storage.Tasks().Create(ctx, &storage.Task{
+			TaskIdentifier: fmt.Sprintf("task-retryable-%d", time.Now().UnixNano()%100000),
+			ApplyID:        applyID,
+			PlanID:         plan.ID,
+			Database:       appDBName,
+			DatabaseType:   storage.DatabaseTypeMySQL,
+			Engine:         storage.EngineSpirit,
+			State:          state.Task.FailedRetryable,
+			ErrorMessage:   "transient engine error",
+			TableName:      tc.Table,
+			DDL:            tc.DDL,
+			DDLAction:      tc.Operation,
+			Options:        []byte("{}"),
+			Environment:    "staging",
+			CreatedAt:      now,
+			UpdatedAt:      now,
+		})
+		require.NoError(t, err)
+	}
+
+	require.NoError(t, ts.Service.SetSchedulerPollInterval(schedulerTestPollInterval))
+	ts.Service.StartScheduler(ctx)
+	defer ts.Service.StopScheduler()
+
+	waitForSchedulerAppliesCompleted(t, ts.Storage, []int64{applyID}, schedulerTestPollInterval+5*time.Second)
+
+	apply, err := ts.Storage.Applies().Get(ctx, applyID)
+	require.NoError(t, err)
+	require.NotNil(t, apply)
+	assert.Equal(t, 1, apply.Attempt)
+
+	tasks, err := ts.Storage.Tasks().GetByApplyID(ctx, applyID)
+	require.NoError(t, err)
+	require.NotEmpty(t, tasks)
+	for _, task := range tasks {
+		assert.Equal(t, state.Task.Completed, task.State)
+		assert.Equal(t, 1, task.Attempt)
+	}
+}
+
+// TestScheduler_RetryableApplyClaimCrashWindowResumesToCompletion models the
+// state left if a worker claims failed_retryable work and crashes before Tern
+// prepares the retry. The apply is already leased as running, but the task still
+// carries failed_retryable; recovery should still use the retry path.
+func TestScheduler_RetryableApplyClaimCrashWindowResumesToCompletion(t *testing.T) {
+	ctx := t.Context()
+	schemaSQL, err := os.ReadFile("testdata/myapp/mysql/schema/users.sql")
+	require.NoError(t, err)
+
+	appDBName, appDSN := createTestDB(t, "retry_crash_")
+	ts := startTestServer(t, appDBName, appDSN)
+	ts.Service.StopScheduler()
+
+	planResp := postJSON(t, "http://"+ts.Addr+"/api/plan", map[string]any{
+		"database": appDBName, "environment": "staging", "type": "mysql",
+		"schema_files": map[string]any{"default": map[string]any{"files": map[string]string{"users.sql": string(schemaSQL)}}},
+	})
+	planID, _ := planResp["plan_id"].(string)
+	require.NotEmpty(t, planID)
+	plan, err := ts.Storage.Plans().Get(ctx, planID)
+	require.NoError(t, err)
+	require.NotNil(t, plan)
+
+	now := time.Now()
+	applyID, err := ts.Storage.Applies().Create(ctx, &storage.Apply{
+		ApplyIdentifier: fmt.Sprintf("apply-retry-crash-%d", now.UnixNano()%100000),
+		PlanID:          plan.ID,
+		Database:        appDBName,
+		DatabaseType:    storage.DatabaseTypeMySQL,
+		Engine:          storage.EngineSpirit,
+		State:           state.Apply.Running,
+		ErrorMessage:    "transient engine error",
+		Attempt:         1,
+		Options:         []byte("{}"),
+		Environment:     "staging",
+		StartedAt:       &now,
+	})
+	require.NoError(t, err)
+
+	schemabotDB, err := sql.Open("mysql", schemabotDSN)
+	require.NoError(t, err)
+	require.NoError(t, schemabotDB.PingContext(ctx))
+	defer utils.CloseAndLog(schemabotDB)
+	_, err = schemabotDB.ExecContext(ctx, "UPDATE applies SET updated_at = NOW() - INTERVAL 2 MINUTE WHERE id = ?", applyID)
+	require.NoError(t, err)
+
+	for _, tc := range plan.FlatDDLChanges() {
+		_, err := ts.Storage.Tasks().Create(ctx, &storage.Task{
+			TaskIdentifier: fmt.Sprintf("task-retry-crash-%d", time.Now().UnixNano()%100000),
+			ApplyID:        applyID,
+			PlanID:         plan.ID,
+			Database:       appDBName,
+			DatabaseType:   storage.DatabaseTypeMySQL,
+			Engine:         storage.EngineSpirit,
+			State:          state.Task.FailedRetryable,
+			ErrorMessage:   "transient engine error",
+			TableName:      tc.Table,
+			DDL:            tc.DDL,
+			DDLAction:      tc.Operation,
+			Options:        []byte("{}"),
+			Environment:    "staging",
+			CreatedAt:      now,
+			UpdatedAt:      now,
+		})
+		require.NoError(t, err)
+	}
+
+	require.NoError(t, ts.Service.SetSchedulerPollInterval(schedulerTestPollInterval))
+	ts.Service.StartScheduler(ctx)
+	defer ts.Service.StopScheduler()
+
+	waitForSchedulerAppliesCompleted(t, ts.Storage, []int64{applyID}, schedulerTestPollInterval+5*time.Second)
+
+	apply, err := ts.Storage.Applies().Get(ctx, applyID)
+	require.NoError(t, err)
+	require.NotNil(t, apply)
+	assert.Equal(t, 1, apply.Attempt)
+
+	tasks, err := ts.Storage.Tasks().GetByApplyID(ctx, applyID)
+	require.NoError(t, err)
+	require.NotEmpty(t, tasks)
+	for _, task := range tasks {
+		assert.Equal(t, state.Task.Completed, task.State)
+		assert.Equal(t, 1, task.Attempt)
+	}
+}
+
+// TestScheduler_ExhaustedRetryableApplyExpiresToFailed seeds a retryable apply
+// at the retry limit. The scheduler should stop retrying it and finalize the
+// apply and unfinished tasks as failed.
+func TestScheduler_ExhaustedRetryableApplyExpiresToFailed(t *testing.T) {
+	ctx := t.Context()
+	schemaSQL, err := os.ReadFile("testdata/myapp/mysql/schema/users.sql")
+	require.NoError(t, err)
+
+	appDBName, appDSN := createTestDB(t, "retry_exhaust_")
+	ts := startTestServer(t, appDBName, appDSN)
+	ts.Service.StopScheduler()
+
+	planResp := postJSON(t, "http://"+ts.Addr+"/api/plan", map[string]any{
+		"database": appDBName, "environment": "staging", "type": "mysql",
+		"schema_files": map[string]any{"default": map[string]any{"files": map[string]string{"users.sql": string(schemaSQL)}}},
+	})
+	planID, _ := planResp["plan_id"].(string)
+	require.NotEmpty(t, planID)
+	plan, err := ts.Storage.Plans().Get(ctx, planID)
+	require.NoError(t, err)
+	require.NotNil(t, plan)
+
+	// Attempt is already at the retry limit, so this apply is eligible for
+	// expiration instead of another scheduler dispatch.
+	now := time.Now()
+	applyID, err := ts.Storage.Applies().Create(ctx, &storage.Apply{
+		ApplyIdentifier: fmt.Sprintf("apply-exhausted-%d", now.UnixNano()%100000),
+		PlanID:          plan.ID,
+		Database:        appDBName,
+		DatabaseType:    storage.DatabaseTypeMySQL,
+		Engine:          storage.EngineSpirit,
+		State:           state.Apply.FailedRetryable,
+		ErrorMessage:    "transient engine error after retries",
+		Attempt:         10,
+		Options:         []byte("{}"),
+		Environment:     "staging",
+	})
+	require.NoError(t, err)
+
+	taskID := fmt.Sprintf("task-exhausted-%d", time.Now().UnixNano()%100000)
+	_, err = ts.Storage.Tasks().Create(ctx, &storage.Task{
+		TaskIdentifier: taskID,
+		ApplyID:        applyID,
+		PlanID:         plan.ID,
+		Database:       appDBName,
+		DatabaseType:   storage.DatabaseTypeMySQL,
+		Engine:         storage.EngineSpirit,
+		State:          state.Task.FailedRetryable,
+		ErrorMessage:   "transient engine error after retries",
+		TableName:      "users",
+		DDL:            string(schemaSQL),
+		DDLAction:      "create",
+		Options:        []byte("{}"),
+		Environment:    "staging",
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, ts.Service.SetSchedulerPollInterval(schedulerTestPollInterval))
+	ts.Service.StartScheduler(ctx)
+	defer ts.Service.StopScheduler()
+
+	deadline := time.Now().Add(schedulerTestPollInterval + 5*time.Second)
+	for time.Now().Before(deadline) {
+		apply, err := ts.Storage.Applies().Get(ctx, applyID)
+		require.NoError(t, err)
+		if apply != nil && apply.State == state.Apply.Failed {
+			assert.NotNil(t, apply.CompletedAt)
+			task, err := ts.Storage.Tasks().Get(ctx, taskID)
+			require.NoError(t, err)
+			require.NotNil(t, task)
+			assert.Equal(t, state.Task.Failed, task.State)
+			assert.NotNil(t, task.CompletedAt)
+			return
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	require.Fail(t, "scheduler did not expire exhausted retryable apply")
+}
+
+// TestScheduler_FindNextApplyDoesNotReclaimRetryableImmediately verifies the
+// storage claim lease for retryable applies. After one worker claims the row,
+// the refreshed heartbeat should prevent another immediate claim of the same
+// apply.
+func TestScheduler_FindNextApplyDoesNotReclaimRetryableImmediately(t *testing.T) {
+	ctx := t.Context()
+
+	fixture := newSchedulerClaimFixture(t, "retry_claim_")
+	stor := fixture.store
+
+	_, err := stor.Applies().Create(ctx, &storage.Apply{
+		ApplyIdentifier: "apply-retryable-exclusive",
+		Database:        fixture.appDBName,
+		DatabaseType:    storage.DatabaseTypeMySQL,
+		Engine:          storage.EngineSpirit,
+		State:           state.Apply.FailedRetryable,
+		ErrorMessage:    "transient engine error",
+		Options:         []byte("{}"),
+		Environment:     "staging",
+	})
+	require.NoError(t, err)
+
+	claimed, err := stor.Applies().FindNextApply(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, claimed)
+	assert.Equal(t, "apply-retryable-exclusive", claimed.ApplyIdentifier)
+	assert.Equal(t, state.Apply.FailedRetryable, claimed.State)
+	assert.Equal(t, 1, claimed.Attempt)
+
+	claimedAgain, err := stor.Applies().FindNextApply(ctx)
+	require.NoError(t, err)
+	assert.Nil(t, claimedAgain, "claimed retryable apply should have a fresh active lease")
 }
 
 func TestScheduler_MultipleWorkersResumeDifferentTargets(t *testing.T) {
@@ -430,7 +844,7 @@ func TestScheduler_MultipleWorkersResumeDifferentTargets(t *testing.T) {
 		db2Name + "/staging": client2,
 	}, logger)
 
-	schedulerPollInterval := 500 * time.Millisecond
+	schedulerPollInterval := schedulerTestPollInterval
 	require.NoError(t, svc.SetSchedulerPollInterval(schedulerPollInterval))
 
 	svc.StartScheduler(ctx)

--- a/integration/workflow_test.go
+++ b/integration/workflow_test.go
@@ -36,6 +36,13 @@ type testServer struct {
 	Service *schemabotapi.Service
 }
 
+func startTestScheduler(t *testing.T, svc *schemabotapi.Service) {
+	t.Helper()
+
+	require.NoError(t, svc.SetSchedulerPollInterval(200*time.Millisecond))
+	svc.StartScheduler(t.Context())
+}
+
 // createTestDB creates a uniquely-named test database and returns its name and DSN.
 // Cleanup is registered via t.Cleanup.
 func createTestDB(t *testing.T, prefix string) (appDBName, appDSN string) {
@@ -91,6 +98,7 @@ func startTestServer(t *testing.T, appDBName, appDSN string) testServer {
 	svc := schemabotapi.New(storage, serverConfig, map[string]tern.Client{
 		appDBName + "/staging": localClient,
 	}, logger)
+	startTestScheduler(t, svc)
 
 	mux := http.NewServeMux()
 	svc.ConfigureRoutes(mux)
@@ -1310,8 +1318,9 @@ CREATE TABLE orders (
 	t.Logf("Correctly captured MySQL error: %s", errorMessage)
 }
 
-// TestFullWorkflow_Spirit_PartialFailure tests that when one task fails in sequential mode,
-// remaining tasks are marked as CANCELLED and the error is properly surfaced.
+// TestFullWorkflow_Spirit_PartialFailure tests that when one task fails retryably
+// in sequential mode, later tasks remain pending for scheduler recovery and the
+// error is properly surfaced.
 func TestFullWorkflow_Spirit_PartialFailure(t *testing.T) {
 	ctx := t.Context()
 
@@ -1322,8 +1331,8 @@ func TestFullWorkflow_Spirit_PartialFailure(t *testing.T) {
 
 	// Three tables in sequential mode (alphabetical order determines execution):
 	// 1. aaa_first - will succeed (simple table)
-	// 2. bbb_fails - will FAIL (FK to non-existent table)
-	// 3. ccc_cancelled - should be CANCELLED (never started)
+	// 2. bbb_fails - will fail retryably (FK to non-existent table)
+	// 3. ccc_cancelled - remains pending until scheduler retry
 	schemaFiles := map[string]string{
 		"aaa_first.sql": `
 CREATE TABLE aaa_first (
@@ -1425,9 +1434,9 @@ CREATE TABLE ccc_cancelled (
 		t.Logf("Table %s: %s", name, status)
 	}
 
-	assert.Equal(t, "completed", tableStates["aaa_first"], "aaa_first")
-	assert.Equal(t, "failed", tableStates["bbb_fails"], "bbb_fails")
-	assert.Equal(t, "cancelled", tableStates["ccc_cancelled"], "ccc_cancelled")
+	assert.Equal(t, state.Task.Completed, tableStates["aaa_first"], "aaa_first")
+	assert.Equal(t, state.Task.FailedRetryable, tableStates["bbb_fails"], "bbb_fails")
+	assert.Equal(t, state.Task.Pending, tableStates["ccc_cancelled"], "ccc_cancelled")
 
 	// Verify aaa_first table was actually created in DB (partial success committed)
 	targetDB, err := sql.Open("mysql", targetDSN+"&multiStatements=true")
@@ -1451,12 +1460,12 @@ CREATE TABLE ccc_cancelled (
 	`, appDBName).Scan(&tableName)
 	assert.Error(t, err, "bbb_fails table should NOT exist in DB")
 
-	// Verify ccc_cancelled table was NOT created
+	// Verify pending work was NOT created
 	err = targetDB.QueryRowContext(ctx, `
 		SELECT TABLE_NAME FROM information_schema.TABLES
 		WHERE TABLE_SCHEMA = ? AND TABLE_NAME = 'ccc_cancelled'
 	`, appDBName).Scan(&tableName)
 	assert.Error(t, err, "ccc_cancelled table should NOT exist in DB")
 
-	t.Log("Partial failure test passed: 1 completed, 1 failed, 1 cancelled")
+	t.Log("Partial failure test passed: 1 completed, 1 retryable failure, 1 pending retry")
 }

--- a/pkg/api/README.md
+++ b/pkg/api/README.md
@@ -75,13 +75,13 @@ Lazy creation means a connection failure to one database doesn't block startup o
 
 ## Scheduler
 
-On startup, the service launches a background scheduler (`StartScheduler`) that claims apply work from storage. A claim means selecting one stale apply and refreshing its heartbeat in the same transaction so the worker has a lease while it resumes the apply.
+On startup, the service launches a background scheduler (`StartScheduler`) that claims apply work from storage. `/api/apply` queues an apply and its tasks durably; scheduler workers own the actual local-engine or remote-Tern dispatch. A claim means selecting one queued, stale, or retryable apply and refreshing its heartbeat in the same transaction so the worker has a lease while it resumes the apply.
 
-1. Runs immediately, then polls every 10 seconds per configured worker
-2. Finds applies with stale heartbeats (no update for 1+ minute)
+1. Runs immediately, wakes when `/api/apply` queues new work, then polls every 10 seconds per configured worker as a fallback
+2. Finds queued pending applies with tasks, applies with stale heartbeats (no update for 1+ minute), or retryable failures with retry budget remaining
 3. Claims one apply atomically by selecting it and refreshing its heartbeat in the same transaction
 4. Gets the appropriate Tern client for the database/environment
-5. Calls `ResumeApply()` so execution continues from persisted engine state
+5. Calls `ResumeApply()` so execution starts or continues from persisted state
 
 Stopped applies (user called `schemabot stop`) are **not** auto-resumed. The user must explicitly call `schemabot start`.
 

--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -10,13 +10,16 @@ import (
 	"net/http/httptest"
 	"os"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/block/schemabot/pkg/apitypes"
 	ternv1 "github.com/block/schemabot/pkg/proto/ternv1"
+	"github.com/block/schemabot/pkg/state"
 	"github.com/block/schemabot/pkg/storage"
 	"github.com/block/schemabot/pkg/tern"
 )
@@ -57,21 +60,20 @@ func (m *mockPlanLookupStore) GetByPR(context.Context, string, int) ([]*storage.
 func (m *mockPlanLookupStore) Delete(context.Context, int64) error           { return nil }
 func (m *mockPlanLookupStore) DeleteByPR(context.Context, string, int) error { return nil }
 
-type mockStorageWithPlanLookup struct {
-	mockStorage
-	plans storage.PlanStore
-}
-
-func (m *mockStorageWithPlanLookup) Plans() storage.PlanStore { return m.plans }
-
 type mockStorageWithApplyStores struct {
 	mockStorage
-	plans   storage.PlanStore
-	applies storage.ApplyStore
+	plans     storage.PlanStore
+	applies   storage.ApplyStore
+	tasks     storage.TaskStore
+	locks     storage.LockStore
+	applyLogs storage.ApplyLogStore
 }
 
-func (m *mockStorageWithApplyStores) Plans() storage.PlanStore    { return m.plans }
-func (m *mockStorageWithApplyStores) Applies() storage.ApplyStore { return m.applies }
+func (m *mockStorageWithApplyStores) Plans() storage.PlanStore         { return m.plans }
+func (m *mockStorageWithApplyStores) Applies() storage.ApplyStore      { return m.applies }
+func (m *mockStorageWithApplyStores) Tasks() storage.TaskStore         { return m.tasks }
+func (m *mockStorageWithApplyStores) Locks() storage.LockStore         { return m.locks }
+func (m *mockStorageWithApplyStores) ApplyLogs() storage.ApplyLogStore { return m.applyLogs }
 
 type staticPlanStore struct {
 	storage.PlanStore
@@ -83,14 +85,75 @@ func (s *staticPlanStore) Get(context.Context, string) (*storage.Plan, error) {
 	return s.plan, s.err
 }
 
-type staticApplyStore struct {
+type capturingApplyStore struct {
 	storage.ApplyStore
-	apply *storage.Apply
+	mu      sync.Mutex
+	apply   *storage.Apply
+	claimed bool
+	findCh  chan struct{}
+	err     error
+}
+
+func (s *capturingApplyStore) Create(_ context.Context, apply *storage.Apply) (int64, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.apply = apply
+	if s.err != nil {
+		return 0, s.err
+	}
+	return 123, nil
+}
+
+func (s *capturingApplyStore) FindNextApply(context.Context) (*storage.Apply, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.findCh != nil {
+		select {
+		case s.findCh <- struct{}{}:
+		default:
+		}
+	}
+	if s.apply == nil || s.claimed {
+		return nil, nil
+	}
+	s.claimed = true
+	apply := *s.apply
+	apply.ID = 123
+	return &apply, nil
+}
+
+func (s *capturingApplyStore) ExpireRetryable(context.Context) ([]*storage.Apply, error) {
+	return nil, nil
+}
+
+type capturingTaskStore struct {
+	storage.TaskStore
+	tasks []*storage.Task
 	err   error
 }
 
-func (s *staticApplyStore) GetByApplyIdentifier(context.Context, string) (*storage.Apply, error) {
-	return s.apply, s.err
+func (s *capturingTaskStore) Create(_ context.Context, task *storage.Task) (int64, error) {
+	s.tasks = append(s.tasks, task)
+	if s.err != nil {
+		return 0, s.err
+	}
+	return int64(len(s.tasks)), nil
+}
+
+type emptyLockStore struct {
+	storage.LockStore
+}
+
+func (s *emptyLockStore) Get(context.Context, string, string) (*storage.Lock, error) {
+	return nil, nil
+}
+
+type noopApplyLogStore struct {
+	storage.ApplyLogStore
+}
+
+func (s *noopApplyLogStore) Append(context.Context, *storage.ApplyLog) error {
+	return nil
 }
 
 // mockTernClient implements tern.Client for testing.
@@ -116,6 +179,10 @@ type mockTernClient struct {
 	skipRevertResp *ternv1.SkipRevertResponse
 	skipRevertErr  error
 	skipRevertReq  *ternv1.SkipRevertRequest // captured request
+	resumeMu       sync.Mutex
+	resumeErr      error
+	resumeApply    *storage.Apply
+	resumeCh       chan *storage.Apply
 	isRemote       bool
 }
 
@@ -178,7 +245,19 @@ func (m *mockTernClient) RollbackPlan(ctx context.Context, database string) (*te
 	return nil, nil
 }
 func (m *mockTernClient) ResumeApply(ctx context.Context, apply *storage.Apply) error {
-	return nil
+	m.resumeMu.Lock()
+	m.resumeApply = apply
+	resumeCh := m.resumeCh
+	resumeErr := m.resumeErr
+	m.resumeMu.Unlock()
+
+	if resumeCh != nil {
+		select {
+		case resumeCh <- apply:
+		default:
+		}
+	}
+	return resumeErr
 }
 func (m *mockTernClient) Endpoint() string                                  { return "mock" }
 func (m *mockTernClient) IsRemote() bool                                    { return m.isRemote }
@@ -222,14 +301,18 @@ func executeApplyTestPlan() *storage.Plan {
 	}
 }
 
-func newExecuteApplyTestService(client tern.Client, applies storage.ApplyStore) *Service {
+func newExecuteApplyTestService(client tern.Client, applies storage.ApplyStore) (*Service, *capturingTaskStore) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	tasks := &capturingTaskStore{}
 	return New(&mockStorageWithApplyStores{
-		plans:   &staticPlanStore{plan: executeApplyTestPlan()},
-		applies: applies,
+		plans:     &staticPlanStore{plan: executeApplyTestPlan()},
+		applies:   applies,
+		tasks:     tasks,
+		locks:     &emptyLockStore{},
+		applyLogs: &noopApplyLogStore{},
 	}, testServerConfig(), map[string]tern.Client{
 		"default/staging": client,
-	}, logger)
+	}, logger), tasks
 }
 
 func newTestService() *Service {
@@ -237,42 +320,64 @@ func newTestService() *Service {
 	return New(&mockStorage{}, testServerConfig(), nil, logger)
 }
 
-func TestExecuteApplyRequiresApplyIDs(t *testing.T) {
-	t.Run("accepted response requires engine apply id", func(t *testing.T) {
-		svc := newExecuteApplyTestService(&mockTernClient{
-			applyResp: &ternv1.ApplyResponse{Accepted: true},
-		}, nil)
+func TestExecuteApplyQueuesApplyForScheduler(t *testing.T) {
+	applies := &capturingApplyStore{}
+	mock := &mockTernClient{}
+	svc, tasks := newExecuteApplyTestService(mock, applies)
 
-		resp, applyID, err := svc.ExecuteApply(t.Context(), ApplyRequest{
-			PlanID:      "plan-1",
-			Environment: "staging",
-		})
-
-		require.Error(t, err)
-		assert.Nil(t, resp)
-		assert.Zero(t, applyID)
-		assert.Contains(t, err.Error(), "accepted apply missing apply_id")
+	resp, applyID, err := svc.ExecuteApply(t.Context(), ApplyRequest{
+		PlanID:      "plan-1",
+		Environment: "staging",
+		Target:      "target-1",
 	})
 
-	t.Run("accepted response requires stored apply id", func(t *testing.T) {
-		svc := newExecuteApplyTestService(&mockTernClient{
-			applyResp: &ternv1.ApplyResponse{Accepted: true, ApplyId: "apply-123"},
-		}, &staticApplyStore{
-			apply: &storage.Apply{
-				ApplyIdentifier: "apply-123",
-			},
-		})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.True(t, resp.Accepted)
+	assert.Equal(t, int64(123), applyID)
+	assert.NotEmpty(t, resp.ApplyID)
+	require.NotNil(t, applies.apply)
+	assert.Equal(t, state.Apply.Pending, applies.apply.State)
+	assert.Equal(t, storage.EngineSpirit, applies.apply.Engine)
+	assert.Equal(t, "target-1", applies.apply.GetOptions().Target)
+	assert.Nil(t, mock.applyReq, "request path should enqueue work without dispatching the engine")
+	require.Len(t, tasks.tasks, 1)
+	assert.Equal(t, state.Task.Pending, tasks.tasks[0].State)
+}
 
-		resp, applyID, err := svc.ExecuteApply(t.Context(), ApplyRequest{
-			PlanID:      "plan-1",
-			Environment: "staging",
-		})
+func TestExecuteApplyWakesSchedulerForQueuedApply(t *testing.T) {
+	applies := &capturingApplyStore{findCh: make(chan struct{}, 1)}
+	mock := &mockTernClient{resumeCh: make(chan *storage.Apply, 1)}
+	svc, _ := newExecuteApplyTestService(mock, applies)
+	svc.config.SchedulerWorkers = 1
+	require.NoError(t, svc.SetSchedulerPollInterval(time.Hour))
+	svc.StartScheduler(t.Context())
+	t.Cleanup(svc.StopScheduler)
 
-		require.Error(t, err)
-		assert.Nil(t, resp)
-		assert.Zero(t, applyID)
-		assert.Contains(t, err.Error(), "accepted apply missing stored apply id")
+	select {
+	case <-applies.findCh:
+	case <-time.After(2 * time.Second):
+		require.Fail(t, "scheduler did not perform startup claim")
+	}
+
+	resp, applyID, err := svc.ExecuteApply(t.Context(), ApplyRequest{
+		PlanID:      "plan-1",
+		Environment: "staging",
+		Target:      "target-1",
 	})
+
+	require.NoError(t, err)
+	require.True(t, resp.Accepted)
+	assert.Equal(t, int64(123), applyID)
+
+	select {
+	case resumedApply := <-mock.resumeCh:
+		assert.Equal(t, int64(123), resumedApply.ID)
+		assert.Equal(t, state.Apply.Pending, resumedApply.State)
+		assert.Equal(t, "testdb", resumedApply.Database)
+	case <-time.After(2 * time.Second):
+		require.Fail(t, "scheduler did not resume queued apply after wake")
+	}
 }
 
 func TestHealth(t *testing.T) {
@@ -326,11 +431,13 @@ func TestApplyHandler(t *testing.T) {
 			DatabaseType:   storage.DatabaseTypeMySQL,
 			Environment:    "staging",
 		}
-		stor := &mockStorageWithPlanLookup{
-			plans: &mockPlanLookupStore{plan: plan},
-		}
-		mock := &mockTernClient{
-			applyErr: fmt.Errorf("create apply: %w", storage.ErrActiveApplyExists),
+		mock := &mockTernClient{}
+		stor := &mockStorageWithApplyStores{
+			plans:     &mockPlanLookupStore{plan: plan},
+			applies:   &capturingApplyStore{err: fmt.Errorf("create apply: %w", storage.ErrActiveApplyExists)},
+			tasks:     &capturingTaskStore{},
+			locks:     &emptyLockStore{},
+			applyLogs: &noopApplyLogStore{},
 		}
 		logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
 		ternClients := map[string]tern.Client{"default/staging": mock}
@@ -345,9 +452,7 @@ func TestApplyHandler(t *testing.T) {
 		mux.ServeHTTP(w, req)
 
 		assert.Equal(t, http.StatusConflict, w.Code, w.Body.String())
-		require.NotNil(t, mock.applyReq)
-		assert.Equal(t, "testdb", mock.applyReq.Database)
-		assert.Equal(t, storage.DatabaseTypeMySQL, mock.applyReq.Type)
+		assert.Nil(t, mock.applyReq, "request path should not dispatch apply work")
 
 		var resp apitypes.ErrorResponse
 		require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
@@ -824,6 +929,7 @@ func TestDeriveErrorCode(t *testing.T) {
 	}{
 		{"failed with error", "failed", "Spirit: table copy failed", apitypes.ErrCodeEngineError},
 		{"failed without error", "failed", "", ""},
+		{"retryable failed with error", state.Apply.FailedRetryable, "connection reset", apitypes.ErrCodeEngineErrorRetryable},
 		{"running with error", "running", "something", ""},
 		{"completed", "completed", "", ""},
 		{"stopped", "stopped", "", ""},

--- a/pkg/api/plan_handlers.go
+++ b/pkg/api/plan_handlers.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"net/http"
 	"strings"
 	"time"
@@ -231,25 +232,17 @@ func applyMetricStatusForError(err error) string {
 	return "error"
 }
 
-// ExecuteApply executes an apply request via the Tern client, stores the result,
-// and returns the apply response. This is the shared implementation used by both
-// the HTTP handler and the webhook handler.
+// ExecuteApply queues an apply request in storage and returns once the work is
+// durable. Scheduler workers own dispatching queued work through the Tern
+// client so request cancellation cannot orphan in-memory execution.
 //
 // Flow:
 //  1. Load the plan from SchemaBot storage (source of truth for database, DDL changes).
-//  2. Build a ternv1.ApplyRequest with PlanId, DdlChanges, and options.
-//  3. Call client.Apply(ctx, ternReq):
-//     - LocalClient: looks up plan in same DB, creates apply + task records,
-//     starts Spirit in a background goroutine, returns ApplyId (its own UUID).
-//     - GRPCClient: passes the request to the remote Tern over gRPC. The remote
-//     Tern creates its own records and starts execution. Returns ApplyId
-//     (the remote engine's apply identifier).
-//  4. Store the result in SchemaBot's storage:
-//     - Local (IsRemote=false): the apply record already exists (LocalClient
-//     created it in step 3). Look it up and reuse it.
-//     - Remote (IsRemote=true): generate a SchemaBot-owned apply_identifier,
-//     store Tern's ApplyId as external_id, create apply + task records.
-//  5. Return the apply_identifier to the HTTP caller.
+//  2. Resolve the Tern client to validate the deployment/environment.
+//  3. Create a pending Apply record and pending Task records from the plan.
+//  4. Attach any pending observer to the stored apply before dispatch can start.
+//  5. Wake a scheduler worker so queued work does not wait for the next poll.
+//  6. Return the SchemaBot apply_identifier to the HTTP caller.
 //
 // Returns the API response, the stored apply ID (0 if not stored), and any error.
 func (s *Service) ExecuteApply(ctx context.Context, req ApplyRequest) (*apitypes.ApplyResponse, int64, error) {
@@ -286,8 +279,10 @@ func (s *Service) ExecuteApply(ctx context.Context, req ApplyRequest) (*apitypes
 		return nil, 0, fmt.Errorf("database %q (%s): %w", plan.Database, req.Environment, err)
 	}
 
-	// Ensure options map exists and includes environment
-	options := req.Options
+	// Store the apply as durable queued work. Scheduler workers own dispatching
+	// both local engine work and remote gRPC Tern calls.
+	enqueueStart := time.Now()
+	options := maps.Clone(req.Options)
 	if options == nil {
 		options = make(map[string]string)
 	}
@@ -295,198 +290,156 @@ func (s *Service) ExecuteApply(ctx context.Context, req ApplyRequest) (*apitypes
 	if applyTarget == "" {
 		applyTarget = plan.Database
 	}
-	ternReq := &ternv1.ApplyRequest{
-		PlanId:      req.PlanID,
-		Options:     options,
-		Database:    plan.Database,
-		Type:        plan.DatabaseType,
-		DdlChanges:  storageToProtoTableChanges(plan.FlatDDLChanges()),
-		Environment: req.Environment,
-		Target:      applyTarget,
-		Caller:      req.Caller,
-	}
+	options["target"] = applyTarget
 
-	// Time only the client.Apply call, not plan lookup or client creation.
-	applyStart := time.Now()
-	resp, err := client.Apply(ctx, ternReq)
 	recordApplyResult := func(status string) {
 		metrics.RecordApply(ctx, plan.Database, req.Environment, status)
-		metrics.RecordApplyDuration(ctx, time.Since(applyStart), plan.Database, req.Environment, status)
+		metrics.RecordApplyDuration(ctx, time.Since(enqueueStart), plan.Database, req.Environment, status)
 	}
 	recordApplyError := func(status string, err error) {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, status)
 		recordApplyResult(applyMetricStatusForError(err))
 	}
+
+	applyIdentifier, storedApplyID, err := s.enqueueApply(ctx, plan, req, deployment, options)
 	if err != nil {
-		recordApplyError("apply failed", err)
+		recordApplyError("enqueue apply", err)
 		return nil, 0, err
 	}
-	if resp == nil {
-		applyErr := fmt.Errorf("apply returned nil response")
-		recordApplyError("apply missing response", applyErr)
-		return nil, 0, applyErr
-	}
-	if resp.Accepted && resp.ApplyId == "" {
-		applyErr := fmt.Errorf("accepted apply missing apply_id")
-		recordApplyError("apply missing id", applyErr)
-		return nil, 0, applyErr
-	}
-	span.SetAttributes(attribute.String("apply_id", resp.ApplyId), attribute.Bool("accepted", resp.Accepted))
-
-	// Store apply and task records in SchemaBot's storage.
-	//
-	// Local mode (client.IsRemote() == false):
-	//   LocalClient.Apply() already created the apply/task records in the same
-	//   database and started its own background poller. Look up the existing
-	//   record directly.
-	//
-	// gRPC mode (client.IsRemote() == true):
-	//   Remote Tern has separate storage. Create new apply/task records with a
-	//   SchemaBot-owned apply_identifier. Store Tern's apply_id as external_id
-	//   for resolveApplyID to translate in subsequent RPCs.
-	//
-	//   After creating the record, we call ResumeApply to start a background
-	//   poller (pollForCompletion) that syncs Tern's real state into local
-	//   storage. This must happen here — not in GRPCClient.Apply() — because
-	//   the poller needs the storage.Apply record which doesn't exist until
-	//   after the record is created above.
-	var storedApplyID int64
-	applyIdentifier := resp.ApplyId
-	if resp.Accepted {
-		if !client.IsRemote() {
-			// Local mode: LocalClient.Apply() already created the apply + task
-			// records in the same database. Just look up the existing record.
-			existing, lookupErr := s.storage.Applies().GetByApplyIdentifier(ctx, resp.ApplyId)
-			if lookupErr != nil {
-				applyErr := fmt.Errorf("lookup local apply %s: %w", resp.ApplyId, lookupErr)
-				recordApplyError("lookup local apply", applyErr)
-				return nil, 0, applyErr
-			}
-			if existing == nil {
-				applyErr := fmt.Errorf("local apply %s not found: LocalClient should have created it", resp.ApplyId)
-				s.logger.Error("local apply not found after LocalClient.Apply()",
-					"apply_id", resp.ApplyId,
-					"accepted", resp.Accepted,
-				)
-				recordApplyError("local apply missing", applyErr)
-				return nil, 0, applyErr
-			}
-			storedApplyID = existing.ID
-			applyIdentifier = existing.ApplyIdentifier
-		} else {
-			// gRPC mode: remote Tern has separate storage. Create apply + task
-			// records in SchemaBot's storage with a SchemaBot-owned identifier.
-			// resp.ApplyId is Tern's own ID (the remote engine's apply identifier) — stored as
-			// external_id for resolveApplyID to translate in subsequent RPCs.
-			applyIdentifier = "apply-" + strings.ReplaceAll(uuid.New().String(), "-", "")[:16]
-			now := time.Now()
-
-			deferCutover := options["defer_cutover"] == "true"
-			allowUnsafe := options["allow_unsafe"] == "true"
-			applyOpts := storage.ApplyOptions{
-				DeferCutover: deferCutover,
-				AllowUnsafe:  allowUnsafe,
-			}
-
-			var lockID int64
-			lock, err := s.storage.Locks().Get(ctx, plan.Database, plan.DatabaseType)
-			if err != nil {
-				applyErr := fmt.Errorf("lookup lock for %s/%s: %w", plan.Database, plan.DatabaseType, err)
-				recordApplyError("lookup lock", applyErr)
-				return nil, 0, applyErr
-			}
-			if lock != nil {
-				lockID = lock.ID
-			}
-
-			apply := &storage.Apply{
-				ApplyIdentifier: applyIdentifier,
-				LockID:          lockID,
-				PlanID:          plan.ID,
-				Database:        plan.Database,
-				DatabaseType:    plan.DatabaseType,
-				Repository:      plan.Repository,
-				PullRequest:     plan.PullRequest,
-				Environment:     req.Environment,
-				Deployment:      deployment,
-				Caller:          req.Caller,
-				InstallationID:  req.InstallationID,
-				ExternalID:      resp.ApplyId,
-				Engine:          storage.EngineSpirit,
-				State:           state.Apply.Pending,
-				Options:         storage.MarshalApplyOptions(applyOpts),
-				CreatedAt:       now,
-				UpdatedAt:       now,
-			}
-			storedApplyID, err = s.storage.Applies().Create(ctx, apply)
-			if err != nil {
-				applyErr := fmt.Errorf("store apply: %w", err)
-				recordApplyError("store apply", applyErr)
-				return nil, 0, applyErr
-			}
-
-			for _, ddlChange := range plan.FlatDDLChanges() {
-				task := &storage.Task{
-					TaskIdentifier: "task-" + strings.ReplaceAll(uuid.New().String(), "-", "")[:16],
-					ApplyID:        storedApplyID,
-					PlanID:         plan.ID,
-					Database:       plan.Database,
-					DatabaseType:   plan.DatabaseType,
-					Engine:         storage.EngineSpirit,
-					Repository:     plan.Repository,
-					PullRequest:    plan.PullRequest,
-					Environment:    req.Environment,
-					State:          state.Task.Pending,
-					Options:        storage.MarshalApplyOptions(applyOpts),
-					Namespace:      ddlChange.Namespace,
-					TableName:      ddlChange.Table,
-					DDL:            ddlChange.DDL,
-					DDLAction:      ddlChange.Operation,
-					CreatedAt:      now,
-					UpdatedAt:      now,
-				}
-				if _, err := s.storage.Tasks().Create(ctx, task); err != nil {
-					applyErr := fmt.Errorf("store task: %w", err)
-					recordApplyError("store task", applyErr)
-					return nil, 0, applyErr
-				}
-			}
-
-			// Start background poller to keep local storage in sync with Tern.
-			// ResumeApply spawns pollForCompletion which syncs Tern's real state
-			// into SchemaBot's storage — without this, status stays "pending".
-			// Must happen after task creation so the poller can sync task state.
-			apply.ID = storedApplyID
-			if err := client.ResumeApply(ctx, apply); err != nil {
-				s.logger.Warn("failed to start progress tracking", "apply_id", applyIdentifier, "error", err)
-			}
+	if observer := s.consumePendingObserver(plan.Database, deployment, req.Environment); observer != nil {
+		type applyIDSetter interface{ SetApplyID(int64) }
+		if setter, ok := observer.(applyIDSetter); ok {
+			setter.SetApplyID(storedApplyID)
 		}
+		client.SetObserver(storedApplyID, observer)
 	}
-	if resp.Accepted && storedApplyID <= 0 {
+
+	span.SetAttributes(attribute.String("apply_id", applyIdentifier), attribute.Bool("accepted", true))
+	if storedApplyID <= 0 {
 		applyErr := fmt.Errorf("accepted apply missing stored apply id")
 		recordApplyError("apply missing stored id", applyErr)
 		return nil, 0, applyErr
 	}
 
-	applyStatus := "success"
-	if !resp.Accepted {
-		applyStatus = "rejected"
-	}
-	recordApplyResult(applyStatus)
-	if resp.Accepted {
-		metrics.AdjustActiveApplies(ctx, 1, plan.Database, req.Environment)
-	}
+	recordApplyResult("success")
+	metrics.AdjustActiveApplies(ctx, 1, plan.Database, req.Environment)
+	s.wakeScheduler(applyIdentifier, plan.Database, req.Environment)
 
 	applyResp := &apitypes.ApplyResponse{
-		Accepted:     resp.Accepted,
-		ApplyID:      applyIdentifier,
-		ErrorMessage: resp.ErrorMessage,
-	}
-	if !resp.Accepted && resp.ErrorMessage != "" {
-		applyResp.ErrorCode = apitypes.ErrCodeEngineError
+		Accepted: true,
+		ApplyID:  applyIdentifier,
 	}
 	return applyResp, storedApplyID, nil
+}
+
+func (s *Service) enqueueApply(ctx context.Context, plan *storage.Plan, req ApplyRequest, deployment string, options map[string]string) (string, int64, error) {
+	applyIdentifier := "apply-" + strings.ReplaceAll(uuid.New().String(), "-", "")[:16]
+	now := time.Now()
+	applyOpts := storage.ApplyOptionsFromMap(options)
+
+	var lockID int64
+	lock, err := s.storage.Locks().Get(ctx, plan.Database, plan.DatabaseType)
+	if err != nil {
+		return "", 0, fmt.Errorf("lookup lock for %s/%s: %w", plan.Database, plan.DatabaseType, err)
+	}
+	if lock != nil {
+		lockID = lock.ID
+	}
+
+	apply := &storage.Apply{
+		ApplyIdentifier: applyIdentifier,
+		LockID:          lockID,
+		PlanID:          plan.ID,
+		Database:        plan.Database,
+		DatabaseType:    plan.DatabaseType,
+		Repository:      plan.Repository,
+		PullRequest:     plan.PullRequest,
+		Environment:     req.Environment,
+		Deployment:      deployment,
+		Caller:          req.Caller,
+		InstallationID:  req.InstallationID,
+		Engine:          storage.EngineForType(plan.DatabaseType),
+		State:           state.Apply.Pending,
+		Options:         storage.MarshalApplyOptions(applyOpts),
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+	storedApplyID, err := s.storage.Applies().Create(ctx, apply)
+	if err != nil {
+		return "", 0, fmt.Errorf("store apply: %w", err)
+	}
+
+	for _, ddlChange := range applyTaskChanges(plan) {
+		task := &storage.Task{
+			TaskIdentifier: "task-" + strings.ReplaceAll(uuid.New().String(), "-", "")[:16],
+			ApplyID:        storedApplyID,
+			PlanID:         plan.ID,
+			Database:       plan.Database,
+			DatabaseType:   plan.DatabaseType,
+			Engine:         storage.EngineForType(plan.DatabaseType),
+			Repository:     plan.Repository,
+			PullRequest:    plan.PullRequest,
+			Environment:    req.Environment,
+			State:          state.Task.Pending,
+			Options:        storage.MarshalApplyOptions(applyOpts),
+			Namespace:      ddlChange.Namespace,
+			TableName:      ddlChange.Table,
+			DDL:            ddlChange.DDL,
+			DDLAction:      ddlChange.Operation,
+			CreatedAt:      now,
+			UpdatedAt:      now,
+		}
+		if _, err := s.storage.Tasks().Create(ctx, task); err != nil {
+			s.failQueuedApply(ctx, apply, storedApplyID, fmt.Sprintf("store task for table %s: %v", ddlChange.Table, err))
+			return "", 0, fmt.Errorf("store task for table %s: %w", ddlChange.Table, err)
+		}
+	}
+
+	if err := s.storage.ApplyLogs().Append(ctx, &storage.ApplyLog{
+		ApplyID:   storedApplyID,
+		Level:     storage.LogLevelInfo,
+		EventType: storage.LogEventInfo,
+		Source:    storage.LogSourceSchemaBot,
+		Message:   fmt.Sprintf("Apply queued: %s", applyIdentifier),
+		NewState:  state.Apply.Pending,
+		CreatedAt: now,
+	}); err != nil {
+		s.logger.Warn("failed to log queued apply", "apply_id", applyIdentifier, "error", err)
+	}
+
+	return applyIdentifier, storedApplyID, nil
+}
+
+func (s *Service) failQueuedApply(ctx context.Context, apply *storage.Apply, storedApplyID int64, errMsg string) {
+	now := time.Now()
+	apply.ID = storedApplyID
+	apply.State = state.Apply.Failed
+	apply.ErrorMessage = errMsg
+	apply.CompletedAt = &now
+	apply.UpdatedAt = now
+	if err := s.storage.Applies().Update(ctx, apply); err != nil {
+		s.logger.Error("failed to mark partially queued apply failed",
+			"apply_id", apply.ApplyIdentifier,
+			"database", apply.Database,
+			"environment", apply.Environment,
+			"error", err)
+	}
+}
+
+func applyTaskChanges(plan *storage.Plan) []storage.TableChange {
+	changes := append([]storage.TableChange{}, plan.FlatDDLChanges()...)
+	for namespace, nsData := range plan.Namespaces {
+		if len(nsData.VSchema) == 0 {
+			continue
+		}
+		changes = append(changes, storage.TableChange{
+			Table:     "VSchema: " + namespace,
+			Namespace: namespace,
+			Operation: "vschema_update",
+		})
+	}
+	return changes
 }
 
 // ExecuteRollbackPlan generates a rollback plan via the Tern client.

--- a/pkg/api/progress_handlers.go
+++ b/pkg/api/progress_handlers.go
@@ -35,7 +35,13 @@ func changeTypeToString(ct ternv1.ChangeType) string {
 // deriveErrorCode returns an error code based on apply state
 // and error message. Returns empty string when no error code applies.
 func deriveErrorCode(applyState, errorMessage string) string {
-	if errorMessage != "" && state.IsState(applyState, state.Apply.Failed) {
+	if errorMessage == "" {
+		return ""
+	}
+	if state.IsState(applyState, state.Apply.FailedRetryable) {
+		return apitypes.ErrCodeEngineErrorRetryable
+	}
+	if state.IsState(applyState, state.Apply.Failed) {
 		return apitypes.ErrCodeEngineError
 	}
 	return ""
@@ -136,6 +142,9 @@ func (s *Service) GetProgress(ctx context.Context, database, environment string)
 	// Use deployment from the stored apply if available.
 	var storedDeployment string
 	if activeApply != nil {
+		if state.IsState(activeApply.State, state.Apply.FailedRetryable) {
+			return s.progressFromLocalStorage(ctx, activeApply)
+		}
 		storedDeployment = activeApply.Deployment
 	}
 	deployment := s.ResolveDeployment(database, storedDeployment)
@@ -202,6 +211,17 @@ func (s *Service) handleProgress(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	if activeApply != nil && state.IsState(activeApply.State, state.Apply.FailedRetryable) {
+		httpResp, err := s.progressFromLocalStorage(r.Context(), activeApply)
+		if err != nil {
+			s.logger.Error("failed to read retryable apply from storage", "apply_id", activeApply.ApplyIdentifier, "error", err)
+			s.writeErrorCode(w, http.StatusInternalServerError, apitypes.ErrCodeStorageError, "failed to read apply: "+err.Error())
+			return
+		}
+		s.writeJSON(w, http.StatusOK, httpResp)
+		return
+	}
+
 	// Deployment is a plan-time decision stored on the apply record.
 	// Use the stored deployment if an apply exists, otherwise fall back to default resolution.
 	var deployment string
@@ -261,8 +281,8 @@ func (s *Service) handleProgressByApplyID(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	// For terminal applies, serve from local storage (no RPC needed).
-	if state.IsTerminalApplyState(apply.State) {
+	// For terminal or retry-waiting applies, serve from local storage (no RPC needed).
+	if state.IsTerminalApplyState(apply.State) || state.IsState(apply.State, state.Apply.FailedRetryable) {
 		httpResp, err := s.progressFromLocalStorage(r.Context(), apply)
 		if err != nil {
 			s.logger.Error("failed to read tasks from storage for terminal apply", "apply_id", applyID, "error", err)
@@ -570,10 +590,12 @@ func (s *Service) progressFromLocalStorage(ctx context.Context, apply *storage.A
 	// Check if any tasks are stale (non-terminal and not matching the apply
 	// state). A stopped task on a stopped apply is expected, not stale.
 	stale := false
-	for _, task := range tasks {
-		if !state.IsTerminalTaskState(task.State) && task.State != apply.State {
-			stale = true
-			break
+	if !state.IsState(apply.State, state.Apply.FailedRetryable) {
+		for _, task := range tasks {
+			if !state.IsTerminalTaskState(task.State) && task.State != apply.State {
+				stale = true
+				break
+			}
 		}
 	}
 

--- a/pkg/api/proto_helpers.go
+++ b/pkg/api/proto_helpers.go
@@ -80,19 +80,6 @@ func protoChangesToNamespaces(changes []*ternv1.SchemaChange) map[string]*storag
 	return result
 }
 
-// storageToProtoTableChanges converts storage TableChange slice to proto TableChange slice.
-func storageToProtoTableChanges(changes []storage.TableChange) []*ternv1.TableChange {
-	tables := make([]*ternv1.TableChange, len(changes))
-	for i, c := range changes {
-		tables[i] = &ternv1.TableChange{
-			TableName:  c.Table,
-			Ddl:        c.DDL,
-			ChangeType: changeTypeToProto(c.Operation),
-		}
-	}
-	return tables
-}
-
 // protoChangeTypeToOperation converts a proto ChangeType enum to a storage operation string.
 func protoChangeTypeToOperation(ct ternv1.ChangeType) string {
 	switch ct {

--- a/pkg/api/scheduler.go
+++ b/pkg/api/scheduler.go
@@ -5,6 +5,8 @@ import (
 	"time"
 
 	"github.com/block/schemabot/pkg/metrics"
+	"github.com/block/schemabot/pkg/state"
+	"github.com/block/schemabot/pkg/storage"
 )
 
 // Scheduler constants.
@@ -26,13 +28,16 @@ const (
 //
 // Scheduler workers claim apply work from storage so one server can make
 // progress across independent databases and environments concurrently. This
-// currently includes crash recovery for applies with stale heartbeats.
+// includes crash recovery for applies with stale heartbeats and retry recovery
+// for transient engine failures.
 //
 // Launches N concurrent workers (configured via scheduler_workers in config).
 // Each worker independently claims applies using FOR UPDATE SKIP LOCKED.
 // Call StopScheduler to gracefully stop.
 func (s *Service) StartScheduler(ctx context.Context) {
+	s.schedulerMu.Lock()
 	if s.stopRecovery != nil {
+		s.schedulerMu.Unlock()
 		s.logger.Info("scheduler already running")
 		return
 	}
@@ -42,13 +47,16 @@ func (s *Service) StartScheduler(ctx context.Context) {
 		workers = DefaultSchedulerWorkers
 	}
 
-	s.stopRecovery = make(chan struct{})
+	stop := make(chan struct{})
+	wake := make(chan struct{}, workers)
+	s.stopRecovery = stop
+	s.schedulerWake = wake
+	s.schedulerMu.Unlock()
 
 	for i := range workers {
 		workerID := i
-		stop := s.stopRecovery
 		s.recoveryWg.Go(func() {
-			s.schedulerWorker(ctx, workerID, stop)
+			s.schedulerWorker(ctx, workerID, stop, wake)
 		})
 	}
 
@@ -58,24 +66,57 @@ func (s *Service) StartScheduler(ctx context.Context) {
 // StopScheduler stops the background scheduler and waits for all workers to finish.
 // Safe to call multiple times.
 func (s *Service) StopScheduler() {
+	s.schedulerMu.Lock()
 	if s.stopRecovery == nil {
+		s.schedulerMu.Unlock()
 		return
 	}
 	stop := s.stopRecovery
+	s.stopRecovery = nil
+	s.schedulerWake = nil
+	s.schedulerMu.Unlock()
+
 	close(stop)
 	s.recoveryWg.Wait()
-	s.stopRecovery = nil
+}
+
+func (s *Service) wakeScheduler(applyIdentifier, database, environment string) {
+	s.schedulerMu.Lock()
+	wake := s.schedulerWake
+	running := s.stopRecovery != nil
+	s.schedulerMu.Unlock()
+
+	if !running || wake == nil {
+		s.logger.Debug("scheduler wake skipped because scheduler is not running",
+			"apply_id", applyIdentifier,
+			"database", database,
+			"environment", environment)
+		return
+	}
+
+	select {
+	case wake <- struct{}{}:
+		s.logger.Debug("scheduler wake queued",
+			"apply_id", applyIdentifier,
+			"database", database,
+			"environment", environment)
+	default:
+		s.logger.Debug("scheduler wake already pending",
+			"apply_id", applyIdentifier,
+			"database", database,
+			"environment", environment)
+	}
 }
 
 // schedulerWorker is a single worker that claims at most one apply on startup
 // and on each scheduler poll tick.
-func (s *Service) schedulerWorker(ctx context.Context, workerID int, stop <-chan struct{}) {
+func (s *Service) schedulerWorker(ctx context.Context, workerID int, stop <-chan struct{}, wake <-chan struct{}) {
 	ticker := time.NewTicker(s.schedulerPollInterval)
 	defer ticker.Stop()
 
 	s.logger.Debug("scheduler worker started", "worker", workerID)
 
-	s.recoverApplies(ctx, workerID)
+	s.schedulerTick(ctx, workerID)
 
 	for {
 		select {
@@ -85,10 +126,46 @@ func (s *Service) schedulerWorker(ctx context.Context, workerID int, stop <-chan
 		case <-ctx.Done():
 			s.logger.Debug("scheduler worker context cancelled", "worker", workerID)
 			return
+		case <-wake:
+			s.logger.Debug("scheduler worker woke for queued apply", "worker", workerID)
+			s.schedulerTick(ctx, workerID)
 		case <-ticker.C:
-			s.recoverApplies(ctx, workerID)
+			s.schedulerTick(ctx, workerID)
 		}
 	}
+}
+
+// schedulerTick expires exhausted retries, then attempts one claim/resume.
+func (s *Service) schedulerTick(ctx context.Context, workerID int) {
+	if workerID == 0 {
+		s.expireExhaustedRetries(ctx)
+	}
+	s.recoverApplies(ctx, workerID)
+}
+
+// expireExhaustedRetries marks failed_retryable applies as permanently failed
+// after their scheduler retry budget is exhausted.
+func (s *Service) expireExhaustedRetries(ctx context.Context) {
+	expired, err := s.storage.Applies().ExpireRetryable(ctx)
+	if err != nil {
+		s.logger.Error("scheduler: failed to expire retryable applies", "error", err)
+		metrics.RecordSchedulerClaimFailure(ctx, "storage_error")
+		return
+	}
+	if len(expired) == 0 {
+		return
+	}
+	for _, apply := range expired {
+		metrics.AdjustActiveApplies(ctx, -1, apply.Database, apply.Environment)
+		s.logger.Warn("scheduler: retry budget exhausted, marking apply failed",
+			"apply_id", apply.ApplyIdentifier,
+			"database", apply.Database,
+			"environment", apply.Environment,
+			"attempt", apply.Attempt,
+			"error", apply.ErrorMessage)
+		metrics.RecordSchedulerExpired(ctx, apply.Database, apply.Environment)
+	}
+	s.logger.Info("scheduler: expired exhausted retryable applies", "count", len(expired))
 }
 
 // recoverApplies claims and resumes applies that need attention.
@@ -126,6 +203,9 @@ func (s *Service) recoverApplies(ctx context.Context, workerID int) {
 			"database", apply.Database,
 			"environment", apply.Environment,
 			"error", err)
+		if apply.State == state.Apply.FailedRetryable {
+			s.failApply(ctx, apply, "scheduler: no client available for retry")
+		}
 		metrics.RecordSchedulerResumeFailure(ctx, apply.Database, apply.Environment, "no_client")
 		return
 	}
@@ -154,4 +234,36 @@ func (s *Service) recoverApplies(ctx context.Context, workerID int) {
 		"duration", duration)
 	metrics.RecordSchedulerResume(ctx, apply.Database, apply.Environment, previousState)
 	metrics.RecordSchedulerClaimDuration(ctx, duration, apply.Database, apply.Environment, previousState)
+}
+
+// failApply permanently fails an apply that cannot be retried.
+func (s *Service) failApply(ctx context.Context, apply *storage.Apply, errMsg string) {
+	now := time.Now()
+	tasks, err := s.storage.Tasks().GetByApplyID(ctx, apply.ID)
+	if err != nil {
+		s.logger.Error("scheduler: failed to load tasks before failing apply",
+			"apply_id", apply.ApplyIdentifier, "error", err)
+	} else {
+		for _, task := range tasks {
+			if state.IsTerminalTaskState(task.State) {
+				continue
+			}
+			task.State = state.Task.Failed
+			task.ErrorMessage = errMsg
+			task.CompletedAt = &now
+			if err := s.storage.Tasks().Update(ctx, task); err != nil {
+				s.logger.Error("scheduler: failed to mark task permanently failed",
+					"task_id", task.TaskIdentifier, "apply_id", apply.ApplyIdentifier, "error", err)
+			}
+		}
+	}
+	apply.State = state.Apply.Failed
+	apply.ErrorMessage = errMsg
+	apply.CompletedAt = &now
+	apply.UpdatedAt = now
+	if err := s.storage.Applies().Update(ctx, apply); err != nil {
+		s.logger.Error("scheduler: failed to mark apply permanently failed",
+			"apply_id", apply.ApplyIdentifier, "error", err)
+	}
+	metrics.AdjustActiveApplies(ctx, -1, apply.Database, apply.Environment)
 }

--- a/pkg/api/service.go
+++ b/pkg/api/service.go
@@ -98,6 +98,12 @@ func (c TernConfig) Endpoint(deployment, environment string) (string, error) {
 // The webhook handler uses this to start watching progress and posting PR comments.
 type RecoveryCallback func(apply *storage.Apply)
 
+type pendingObserverKey struct {
+	database    string
+	deployment  string
+	environment string
+}
+
 type Service struct {
 	storage     storage.Storage
 	config      *ServerConfig
@@ -106,7 +112,9 @@ type Service struct {
 	logger      *slog.Logger
 
 	// Scheduler loop management.
+	schedulerMu           sync.Mutex
 	stopRecovery          chan struct{}
+	schedulerWake         chan struct{}
 	recoveryWg            sync.WaitGroup
 	schedulerPollInterval time.Duration
 
@@ -114,6 +122,9 @@ type Service struct {
 	// ResumeApply starts the engine/poller. Set by the webhook handler to attach
 	// an observer for PR comments.
 	OnApplyRecovered RecoveryCallback
+
+	pendingObserverMu sync.Mutex
+	pendingObservers  map[pendingObserverKey]tern.ProgressObserver
 }
 
 // SetApplyObserver sets a progress observer on the tern client for an apply.
@@ -128,17 +139,33 @@ func (s *Service) SetApplyObserver(database, deployment, environment string, app
 	client.SetObserver(applyID, observer)
 }
 
-// SetPendingObserver sets an observer that will be consumed by the next Apply()
-// call. The observer is registered before the engine starts, preventing the
-// race where the apply completes before the observer is set.
+// SetPendingObserver stores an observer for the next queued apply for this
+// target. ExecuteApply consumes it after creating the apply row and registers it
+// before a scheduler worker can start engine work.
 func (s *Service) SetPendingObserver(database, deployment, environment string, observer tern.ProgressObserver) {
 	deployment = s.ResolveDeployment(database, deployment)
-	client, err := s.TernClient(deployment, environment)
-	if err != nil {
-		s.logger.Error("failed to get tern client for pending observer", "error", err)
+	key := pendingObserverKey{database: database, deployment: deployment, environment: environment}
+
+	s.pendingObserverMu.Lock()
+	defer s.pendingObserverMu.Unlock()
+	if s.pendingObservers == nil {
+		s.pendingObservers = make(map[pendingObserverKey]tern.ProgressObserver)
+	}
+	if observer == nil {
+		delete(s.pendingObservers, key)
 		return
 	}
-	client.SetPendingObserver(observer)
+	s.pendingObservers[key] = observer
+}
+
+func (s *Service) consumePendingObserver(database, deployment, environment string) tern.ProgressObserver {
+	key := pendingObserverKey{database: database, deployment: deployment, environment: environment}
+
+	s.pendingObserverMu.Lock()
+	defer s.pendingObserverMu.Unlock()
+	observer := s.pendingObservers[key]
+	delete(s.pendingObservers, key)
+	return observer
 }
 
 // New creates a new SchemaBot service.
@@ -158,6 +185,7 @@ func New(st storage.Storage, config *ServerConfig, ternClients map[string]tern.C
 		ternClients:           ternClients,
 		logger:                logger,
 		schedulerPollInterval: SchedulerPollInterval,
+		pendingObservers:      make(map[pendingObserverKey]tern.ProgressObserver),
 	}
 }
 
@@ -170,6 +198,8 @@ func (s *Service) SetSchedulerPollInterval(interval time.Duration) error {
 	if interval <= 0 {
 		return fmt.Errorf("scheduler poll interval must be positive")
 	}
+	s.schedulerMu.Lock()
+	defer s.schedulerMu.Unlock()
 	if s.stopRecovery != nil {
 		return fmt.Errorf("scheduler already running")
 	}
@@ -447,7 +477,7 @@ func (s *Service) ConfigureRoutes(mux *http.ServeMux) {
 // resolveApplyID translates a SchemaBot apply_identifier into the ID that the
 // Tern backend expects.
 //
-// gRPC mode (external_id is set by ExecuteApply when Tern is remote):
+// gRPC mode (external_id is set after the scheduler dispatches remote Tern work):
 //
 //	caller sends "apply-abc123"
 //	  → storage lookup: apply_identifier="apply-abc123", external_id="tern-42"
@@ -456,10 +486,9 @@ func (s *Service) ConfigureRoutes(mux *http.ServeMux) {
 //
 // Local mode (external_id is empty):
 //
-// LocalClient.Apply() creates the apply record in the same database as
-// the API layer. It never sets external_id because there is no remote
-// Tern — LocalClient IS the engine. ExecuteApply checks
-// client.IsRemote() == false and skips generating a new identifier.
+// The API layer creates the local apply record and LocalClient dispatches it
+// from the same storage database. It never sets external_id because there is no
+// remote Tern.
 //
 //	caller sends "apply-def456"
 //	  → storage lookup: apply_identifier="apply-def456", external_id=""

--- a/pkg/api/telemetry_test.go
+++ b/pkg/api/telemetry_test.go
@@ -436,12 +436,14 @@ func TestRecordSchedulerMetrics(t *testing.T) {
 	metrics.RecordSchedulerResumeFailure(t.Context(), "testdb", "staging", "no_client")
 	metrics.RecordSchedulerClaimFailure(t.Context(), "storage_error")
 	metrics.RecordSchedulerClaimDuration(t.Context(), 50*time.Millisecond, "testdb", "staging", "running")
+	metrics.RecordSchedulerExpired(t.Context(), "testdb", "staging")
 
 	names := collectMetricNames(t, reader)
 	assert.True(t, names["schemabot.scheduler.resumed_total"], "expected schemabot.scheduler.resumed_total")
 	assert.True(t, names["schemabot.scheduler.resume_failures_total"], "expected schemabot.scheduler.resume_failures_total")
 	assert.True(t, names["schemabot.scheduler.claim_failures_total"], "expected schemabot.scheduler.claim_failures_total")
 	assert.True(t, names["schemabot.scheduler.claim_duration_seconds"], "expected schemabot.scheduler.claim_duration_seconds")
+	assert.True(t, names["schemabot.scheduler.expired_retryable_total"], "expected schemabot.scheduler.expired_retryable_total")
 }
 
 // setupTraceTest creates an in-memory trace exporter and configures the global

--- a/pkg/apitypes/apitypes.go
+++ b/pkg/apitypes/apitypes.go
@@ -11,20 +11,22 @@ package apitypes
 // constants rather than parsing error_message strings or HTTP status codes.
 // Use IsRetryableErrorCode to determine whether a given code is retryable.
 const (
-	ErrCodeInvalidRequest     = "invalid_request"      // Malformed request (missing params, bad values)
-	ErrCodeNotFound           = "not_found"            // Resource doesn't exist (unknown apply ID, database)
-	ErrCodeDeploymentNotFound = "deployment_not_found" // No tern deployment configured for database/environment
-	ErrCodeEngineError        = "engine_error"         // Schema change engine failure during execution
-	ErrCodeStorageError       = "storage_error"        // Storage backend (MySQL) read/write failure
-	ErrCodeEngineUnavailable  = "engine_unavailable"   // Schema change engine (Tern) unreachable or RPC error
-	ErrCodeStateSyncFailed    = "state_sync_failed"    // Operation succeeded but local state sync failed
-	ErrCodeActiveApplyExists  = "active_apply_exists"  // Another active apply already exists for the target
+	ErrCodeInvalidRequest       = "invalid_request"        // Malformed request (missing params, bad values)
+	ErrCodeNotFound             = "not_found"              // Resource doesn't exist (unknown apply ID, database)
+	ErrCodeDeploymentNotFound   = "deployment_not_found"   // No tern deployment configured for database/environment
+	ErrCodeEngineError          = "engine_error"           // Schema change engine failure during execution
+	ErrCodeEngineErrorRetryable = "engine_error_retryable" // Schema change engine failure that may recover on retry
+	ErrCodeStorageError         = "storage_error"          // Storage backend (MySQL) read/write failure
+	ErrCodeEngineUnavailable    = "engine_unavailable"     // Schema change engine (Tern) unreachable or RPC error
+	ErrCodeStateSyncFailed      = "state_sync_failed"      // Operation succeeded but local state sync failed
+	ErrCodeActiveApplyExists    = "active_apply_exists"    // Another active apply already exists for the target
 )
 
 var retryableErrorCodes = map[string]bool{
-	ErrCodeStorageError:      true,
-	ErrCodeEngineUnavailable: true,
-	ErrCodeStateSyncFailed:   true,
+	ErrCodeEngineErrorRetryable: true,
+	ErrCodeStorageError:         true,
+	ErrCodeEngineUnavailable:    true,
+	ErrCodeStateSyncFailed:      true,
 }
 
 // IsRetryableErrorCode reports whether the given API error code represents a

--- a/pkg/cmd/commands/serve.go
+++ b/pkg/cmd/commands/serve.go
@@ -147,10 +147,8 @@ func (cmd *ServeCmd) Run(g *Globals) error {
 	webhookRuntime.StartMissingSummaryReconciliation(ctx, logger)
 
 	// Start the scheduler worker pool after webhook callbacks are registered.
-	// This polls for stale applies every 10 seconds:
-	// - Runs immediately on startup
-	// - Recovers applies with stale heartbeats (> 1 minute) using FOR UPDATE SKIP LOCKED
-	// - STOPPED applies are NOT auto-resumed (user must call `schemabot start`)
+	// Workers claim queued applies, retryable failures, and stale in-progress
+	// applies using shared storage so every server instance can coordinate work.
 	svc.StartScheduler(ctx)
 
 	// Optionally start gRPC server for Tern proto (used by docker-compose.grpc.yml)

--- a/pkg/cmd/commands/watch_tui_test.go
+++ b/pkg/cmd/commands/watch_tui_test.go
@@ -228,6 +228,12 @@ func TestFetchProgress_ErrorCodeClassification(t *testing.T) {
 			retryable: true,
 		},
 		{
+			name:      "engine_error_retryable is retryable",
+			status:    http.StatusInternalServerError,
+			body:      `{"error":"transient engine error","error_code":"engine_error_retryable"}`,
+			retryable: true,
+		},
+		{
 			name:      "not_found is permanent",
 			status:    http.StatusNotFound,
 			body:      `{"error":"apply not found: abc123","error_code":"not_found"}`,

--- a/pkg/cmd/templates/progress.go
+++ b/pkg/cmd/templates/progress.go
@@ -396,6 +396,8 @@ func FormatProgressState(s string) string {
 		return ANSICyan + "🔄 Cutting over..." + ANSIReset
 	case state.Apply.Completed:
 		return ANSIGreen + "✓ Completed" + ANSIReset
+	case state.Apply.FailedRetryable:
+		return ANSIYellow + "↻ Retrying" + ANSIReset
 	case state.Apply.Failed:
 		return ANSIRed + "✗ Failed" + ANSIReset
 	case state.Apply.Stopped:
@@ -476,6 +478,15 @@ func FormatTableProgress(t TableProgress) string {
 	case state.Apply.Failed:
 		bar := ui.ProgressBarFailed(t.PercentComplete)
 		fmt.Fprintf(&b, indentTable+progressSymbol(t.ChangeType)+"%s: %s ❌ Failed\n", t.TableName, bar)
+		if t.DDL != "" {
+			b.WriteString(formatProgressDDL(t.DDL))
+		}
+		b.WriteString("\n")
+		b.WriteString(FormatShardProgress(t.Shards))
+		return b.String()
+	case state.Apply.FailedRetryable:
+		bar := ui.ProgressBarWaitingCutover()
+		fmt.Fprintf(&b, indentTable+progressSymbol(t.ChangeType)+"%s: %s Retrying\n", t.TableName, bar)
 		if t.DDL != "" {
 			b.WriteString(formatProgressDDL(t.DDL))
 		}
@@ -862,6 +873,8 @@ func StateLabel(s string) string {
 		return "Completed"
 	case state.Apply.Failed:
 		return "Failed"
+	case state.Apply.FailedRetryable:
+		return "Retrying"
 	case state.Apply.Running:
 		return "Running"
 	case state.Apply.WaitingForDeploy:
@@ -902,6 +915,8 @@ func stateColorFunc(s string) func(string) string {
 		return colorWrap(ANSIGreen)
 	case state.Apply.Failed:
 		return colorWrap(ANSIRed)
+	case state.Apply.FailedRetryable:
+		return colorWrap(ANSIYellow)
 	case state.Apply.Running:
 		return colorWrap(ANSICyan)
 	case state.Apply.WaitingForDeploy, state.Apply.WaitingForCutover, state.Apply.CuttingOver:

--- a/pkg/cmd/templates/progress_states_test.go
+++ b/pkg/cmd/templates/progress_states_test.go
@@ -15,6 +15,7 @@ func TestStateLabel_PlanetScalePhases(t *testing.T) {
 	assert.Equal(t, "Creating deploy request", StateLabel(state.Apply.CreatingDeployRequest))
 	assert.Equal(t, "Validating deploy request", StateLabel(state.Apply.ValidatingDeployRequest))
 	assert.Equal(t, "Cancelled", StateLabel(state.Apply.Cancelled))
+	assert.Equal(t, "Retrying", StateLabel(state.Apply.FailedRetryable))
 }
 
 func TestFormatProgressState_PlanetScalePhases(t *testing.T) {
@@ -24,6 +25,7 @@ func TestFormatProgressState_PlanetScalePhases(t *testing.T) {
 	assert.Contains(t, FormatProgressState(state.Apply.CreatingDeployRequest), "Creating deploy request")
 	assert.Contains(t, FormatProgressState(state.Apply.ValidatingDeployRequest), "Validating deploy request")
 	assert.Contains(t, FormatProgressState(state.Apply.Cancelled), "Cancelled")
+	assert.Contains(t, FormatProgressState(state.Apply.FailedRetryable), "Retrying")
 }
 
 func TestProgressSymbol(t *testing.T) {

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -269,6 +269,7 @@ type ProgressResult struct {
 	Progress     int    // 0-100 percent complete
 	Message      string // Human-readable status
 	ErrorMessage string // Error details when State is StateFailed
+	Retryable    bool   // True when a failed progress result can be retried
 	Tables       []TableProgress
 	ResumeState  *ResumeState // Updated resume state (engines may update MigrationContext/Metadata during polling)
 }

--- a/pkg/engine/spirit/spirit.go
+++ b/pkg/engine/spirit/spirit.go
@@ -531,6 +531,7 @@ func (e *Engine) Progress(ctx context.Context, req *engine.ProgressRequest) (*en
 		State:        state,
 		Message:      message,
 		ErrorMessage: rm.errorMessage,
+		Retryable:    state == engine.StateFailed,
 		Tables:       tableProgress,
 		ResumeState:  req.ResumeState,
 	}, nil

--- a/pkg/metrics/README.md
+++ b/pkg/metrics/README.md
@@ -20,6 +20,7 @@ SchemaBot exposes metrics via OpenTelemetry. All metrics are available at `GET /
 | `schemabot.scheduler.resume_failures_total` | Counter | database, environment, reason | Scheduler resume attempts that failed |
 | `schemabot.scheduler.claim_failures_total` | Counter | reason | Scheduler claim attempts that failed |
 | `schemabot.scheduler.claim_duration_seconds` | Histogram | database, environment, previous_state | Scheduler claim and resume duration |
+| `schemabot.scheduler.expired_retryable_total` | Counter | database, environment | Retryable applies expired after exhausting retry budget |
 
 ### Attribute Values
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -299,6 +299,26 @@ func RecordSchedulerClaimDuration(ctx context.Context, duration time.Duration, d
 	)
 }
 
+// RecordSchedulerExpired increments the counter for a retryable apply whose
+// retry budget was exhausted by the scheduler.
+func RecordSchedulerExpired(ctx context.Context, database, environment string) {
+	meter := otel.Meter(meterName)
+	counter, err := meter.Int64Counter("schemabot.scheduler.expired_retryable_total",
+		otelmetric.WithDescription("Total number of retryable applies expired by the scheduler"),
+		otelmetric.WithUnit("{apply}"),
+	)
+	if err != nil {
+		slog.Warn("failed to create scheduler expired retryable counter", "error", err)
+		return
+	}
+	counter.Add(ctx, 1,
+		otelmetric.WithAttributes(
+			attribute.String("database", database),
+			attribute.String("environment", environment),
+		),
+	)
+}
+
 // knownWebhookEvents limits metric cardinality to expected GitHub event types.
 var knownWebhookEvents = map[string]bool{
 	"issue_comment": true,

--- a/pkg/schema/mysql/applies.sql
+++ b/pkg/schema/mysql/applies.sql
@@ -16,6 +16,7 @@ CREATE TABLE `applies` (
   `state` varchar(100) NOT NULL,
   `error_message` text,
   `options` json NOT NULL,
+  `attempt` int NOT NULL DEFAULT '0',
   `started_at` datetime DEFAULT NULL,
   `completed_at` datetime DEFAULT NULL,
   `created_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,

--- a/pkg/schema/mysql/tasks.sql
+++ b/pkg/schema/mysql/tasks.sql
@@ -16,6 +16,7 @@ CREATE TABLE `tasks` (
   `state` varchar(100) NOT NULL,
   `error_message` text,
   `options` json DEFAULT NULL,
+  `attempt` int NOT NULL DEFAULT '0',
   `rows_copied` bigint DEFAULT '0',
   `rows_total` bigint DEFAULT '0',
   `progress_percent` int DEFAULT '0',

--- a/pkg/state/README.md
+++ b/pkg/state/README.md
@@ -26,6 +26,7 @@ Vitess OnlineDDL and Spirit report — and they are translated into Task and App
 | CuttingOver | `cutting_over` | Cutover in progress (atomic mode only) |
 | Completed | `completed` | All tasks finished successfully |
 | Failed | `failed` | At least one task failed |
+| FailedRetryable | `failed_retryable` | A retryable engine error occurred; scheduler recovery can retry it |
 | Stopped | `stopped` | User requested stop, resumable via start (engine-dependent) |
 | RevertWindow | `revert_window` | Schema change applied, revert available. Only meaningful for PlanetScale; Spirit doesn't support revert so SchemaBot auto-advances to completed |
 | Reverted | `reverted` | Schema change was reverted |
@@ -42,10 +43,13 @@ stateDiagram-v2
     waiting_for_deploy --> running : deploy triggered
     running --> completed
     running --> failed
+    running --> failed_retryable
     running --> stopped : resumable (Spirit only)
     running --> cancelled : permanent (PlanetScale only)
     running --> waiting_for_cutover : atomic mode
     running --> revert_window : PlanetScale only
+    failed_retryable --> running : scheduler retry
+    failed_retryable --> failed : retry budget exhausted
 
     waiting_for_cutover --> cutting_over
     cutting_over --> completed
@@ -58,6 +62,7 @@ stateDiagram-v2
 - `waiting_for_cutover`/`cutting_over`: Only with `--defer-cutover` or atomic mode (Spirit). Note: `--defer-cutover` is a no-op for instant DDL (no cutover exists).
 - `revert_window`: Only with `--enable-revert`. Spirit auto-advances through it; PlanetScale holds until expiry or user action. Maps from PlanetScale's `complete_pending_revert` deploy state
 - `stopped`: Spirit only — resumable via `schemabot start`. Spirit checkpoints progress for resume.
+- `failed_retryable`: transient engine failure. Scheduler workers retry while the retry budget remains, then move the apply to `failed`.
 - `cancelled`: PlanetScale only — permanent. Cancels the deploy request; the underlying Vitess migrations are cancelled. Not resumable — start a new apply instead.
 
 ## Task states
@@ -70,29 +75,75 @@ Per-table execution state. Same state machine as Apply, plus `cancelled`:
 | Running | `running` | Engine is actively executing (row copy, checksum, etc.) |
 | WaitingForCutover | `waiting_for_cutover` | Row copy complete, waiting for cutover signal |
 | CuttingOver | `cutting_over` | Table cutover in progress |
-| Completed | `complete` | Schema change applied successfully |
+| Completed | `completed` | Schema change applied successfully |
 | Failed | `failed` | Engine reported failure |
+| FailedRetryable | `failed_retryable` | Retryable engine error; reset to pending on scheduler retry |
 | Stopped | `stopped` | User requested stop, checkpoint saved |
 | RevertWindow | `revert_window` | Schema change applied, revert available (PlanetScale only) |
 | Reverted | `reverted` | Schema change was reverted |
 | Cancelled | `cancelled` | Task never executed due to earlier failure (sequential mode) |
+
+### Retryable failure relationship
+
+`failed_retryable` exists at both task and apply levels, but each level answers a different question:
+
+- A **task** in `failed_retryable` means one table's work hit a retryable engine error. The task is not terminal because scheduler recovery may run that table work again.
+- An **apply** in `failed_retryable` means the whole apply is paused and waiting for scheduler recovery. The apply owns the retry attempt counter and retry budget.
+- A **pending task** is unfinished work that is not currently running. It remains attached to the apply and is eligible to run the next time the apply is dispatched.
+
+The apply state rolls up from task state: any `failed_retryable` task makes the apply `failed_retryable` unless a permanent `failed` task is present. Atomic execution can also mark the apply `failed_retryable` while updating the affected tasks from the same retryable engine result.
+
+When the scheduler claims a retryable apply, it refreshes the apply heartbeat as a lease, increments the apply attempt, and re-dispatches the apply. That attempt count is the apply-level dispatch count for the whole retry cycle; it is not a per-task counter.
+
+The scheduler does not claim tasks directly. It claims the `failed_retryable` apply, reloads that apply's tasks, then prepares the retry by clearing only the tasks in `failed_retryable`. Those tasks move back to `pending`, their error message is cleared, and their task attempt count increments. Completed tasks are left alone because their table work already succeeded.
+
+On retry, tasks are handled by their current state:
+
+- `completed` tasks stay completed and are skipped.
+- `failed_retryable` tasks reset to `pending` so they can run again.
+- `pending` tasks remain pending and can run on the next dispatch.
+
+For example, in sequential mode, if table A completed, table B failed retryably, and table C never started, the retry starts from B/C work. Table A is not run again. If the retry budget is exhausted, the scheduler moves the apply to `failed` and converts unfinished tasks to `failed`.
+
+```text
+Before scheduler retry:
+
+  apply: failed_retryable
+
+  task A: completed          (already succeeded)
+  task B: failed_retryable   (retryable engine error)
+  task C: pending            (not reached yet)
+
+Scheduler retry preparation:
+
+  claim apply -> increment apply attempt -> reload tasks
+
+  task A: completed          -> completed   (skipped)
+  task B: failed_retryable   -> pending     (will run again)
+  task C: pending            -> pending     (still waiting)
+
+Next dispatch:
+
+  run pending work: task B, then task C
+```
 
 ## Deriving apply state
 
 `DeriveApplyState()` computes the apply state from the collective task states. Priority rules (highest to lowest):
 
 1. Any task **failed** → apply `failed`
-2. Any task **stopped** → apply `stopped`
-3. Any task **reverted** → apply `reverted`
-4. All tasks **completed** → apply `completed`
-5. Any task **cutting_over** → apply `cutting_over`
-6. All non-completed tasks **waiting_for_cutover** → apply `waiting_for_cutover`
-7. All non-completed tasks **waiting_for_deploy** → apply `waiting_for_deploy`
-8. Any task **revert_window** → apply `revert_window`
-9. Any task **running** → apply `running`
-10. Otherwise → apply `pending`
+2. Any task **failed_retryable** → apply `failed_retryable`
+3. Any task **stopped** → apply `stopped`
+4. Any task **reverted** → apply `reverted`
+5. All tasks **completed** → apply `completed`
+6. Any task **cutting_over** → apply `cutting_over`
+7. All non-completed tasks **waiting_for_cutover** → apply `waiting_for_cutover`
+8. All non-completed tasks **waiting_for_deploy** → apply `waiting_for_deploy`
+9. Any task **revert_window** → apply `revert_window`
+10. Any task **running** → apply `running`
+11. Otherwise → apply `pending`
 
-Terminal states (`completed`, `failed`, `reverted`, `cancelled`) are checked via `IsTerminalApplyState()`. Note: `stopped` is NOT terminal at the task level — a stopped task can be resumed via Start.
+Terminal states (`completed`, `failed`, `reverted`, `cancelled`) are checked via `IsTerminalApplyState()`. Note: `failed_retryable` is not terminal because scheduler recovery can retry it, and `stopped` is not terminal at the task level because a stopped task can be resumed via Start.
 
 ## Spirit states
 

--- a/pkg/state/apply.go
+++ b/pkg/state/apply.go
@@ -21,6 +21,7 @@ var Apply = struct {
 	RevertWindow      string
 	Completed         string
 	Failed            string
+	FailedRetryable   string
 	Stopped           string
 	Cancelled         string
 	Reverted          string
@@ -42,6 +43,7 @@ var Apply = struct {
 	RevertWindow:      "revert_window",
 	Completed:         "completed",
 	Failed:            "failed",
+	FailedRetryable:   "failed_retryable",
 	Stopped:           "stopped",
 	Cancelled:         "cancelled",
 	Reverted:          "reverted",
@@ -57,15 +59,16 @@ var Apply = struct {
 //
 // State priority (highest to lowest):
 //  1. Any task FAILED → Apply FAILED
-//  2. Any task STOPPED → Apply STOPPED
-//  3. Any task REVERTED → Apply REVERTED
-//  4. All tasks COMPLETED → Apply COMPLETED
-//  5. Any task CUTTING_OVER → Apply CUTTING_OVER
-//  6. All non-completed tasks WAITING_FOR_CUTOVER → Apply WAITING_FOR_CUTOVER
-//  7. All non-completed tasks WAITING_FOR_DEPLOY → Apply WAITING_FOR_DEPLOY
-//  8. Any task REVERT_WINDOW → Apply REVERT_WINDOW
-//  9. Any task RUNNING → Apply RUNNING
-//  10. Otherwise → Apply PENDING
+//  2. Any task FAILED_RETRYABLE → Apply FAILED_RETRYABLE
+//  3. Any task STOPPED → Apply STOPPED
+//  4. Any task REVERTED → Apply REVERTED
+//  5. All tasks COMPLETED → Apply COMPLETED
+//  6. Any task CUTTING_OVER → Apply CUTTING_OVER
+//  7. All non-completed tasks WAITING_FOR_CUTOVER → Apply WAITING_FOR_CUTOVER
+//  8. All non-completed tasks WAITING_FOR_DEPLOY → Apply WAITING_FOR_DEPLOY
+//  9. Any task REVERT_WINDOW → Apply REVERT_WINDOW
+//  10. Any task RUNNING → Apply RUNNING
+//  11. Otherwise → Apply PENDING
 //
 // taskStates should be the State field from each Task. Empty slice returns PENDING.
 func DeriveApplyState(taskStates []string) string {
@@ -82,6 +85,9 @@ func DeriveApplyState(taskStates []string) string {
 
 	if counts[Apply.Failed] > 0 {
 		return Apply.Failed
+	}
+	if counts[Apply.FailedRetryable] > 0 {
+		return Apply.FailedRetryable
 	}
 	if counts[Apply.Cancelled] > 0 {
 		return Apply.Cancelled
@@ -134,6 +140,8 @@ func normalizeApplyState(raw string) string {
 		return Apply.Completed
 	case "FAILED":
 		return Apply.Failed
+	case "FAILED_RETRYABLE":
+		return Apply.FailedRetryable
 	case "STOPPED":
 		return Apply.Stopped
 	case "CANCELLED":
@@ -164,7 +172,8 @@ func IsState(s string, expected ...string) bool {
 }
 
 // IsTerminalApplyState returns true if the state is a terminal state
-// where no further processing will occur.
+// where no further processing will occur. FailedRetryable is not terminal;
+// scheduler workers may claim and retry it.
 func IsTerminalApplyState(s string) bool {
 	switch s {
 	case Apply.Completed, Apply.Failed, Apply.Stopped, Apply.Cancelled, Apply.Reverted:

--- a/pkg/state/apply_test.go
+++ b/pkg/state/apply_test.go
@@ -24,6 +24,7 @@ func TestDeriveApplyState_AllCompleted(t *testing.T) {
 func TestDeriveApplyState_AnyFailed(t *testing.T) {
 	testCases := [][]string{
 		{"FAILED"},
+		{"FAILED", "FAILED_RETRYABLE"},
 		{"RUNNING", "FAILED"},
 		{"COMPLETED", "FAILED"},
 		{"WAITING_FOR_CUTOVER", "FAILED", "COMPLETED"},
@@ -32,6 +33,21 @@ func TestDeriveApplyState_AnyFailed(t *testing.T) {
 
 	for _, states := range testCases {
 		assert.Equal(t, Apply.Failed, DeriveApplyState(states), "input: %v", states)
+	}
+}
+
+// TestDeriveApplyState_FailedRetryable verifies that a retryable task failure
+// rolls the apply up to failed_retryable unless a permanent failed task exists.
+func TestDeriveApplyState_FailedRetryable(t *testing.T) {
+	testCases := [][]string{
+		{"FAILED_RETRYABLE"},
+		{"COMPLETED", "FAILED_RETRYABLE"},
+		{"PENDING", "FAILED_RETRYABLE"},
+		{"failed_retryable"},
+	}
+
+	for _, states := range testCases {
+		assert.Equal(t, Apply.FailedRetryable, DeriveApplyState(states), "input: %v", states)
 	}
 }
 
@@ -168,6 +184,7 @@ func TestIsTerminalApplyState(t *testing.T) {
 	nonTerminalStates := []string{
 		Apply.Pending,
 		Apply.Running,
+		Apply.FailedRetryable,
 		Apply.WaitingForCutover,
 		Apply.CuttingOver,
 		Apply.RevertWindow,
@@ -197,6 +214,8 @@ func TestNormalizeState(t *testing.T) {
 		{"completed", Apply.Completed},
 		{"FAILED", Apply.Failed},
 		{"failed", Apply.Failed},
+		{"FAILED_RETRYABLE", Apply.FailedRetryable},
+		{"failed_retryable", Apply.FailedRetryable},
 		{"STOPPED", Apply.Stopped},
 		{"stopped", Apply.Stopped},
 		{"REVERTED", Apply.Reverted},

--- a/pkg/state/task.go
+++ b/pkg/state/task.go
@@ -18,6 +18,7 @@ var Task = struct {
 	RevertWindow      string
 	Completed         string
 	Failed            string
+	FailedRetryable   string
 	Stopped           string
 	Reverted          string
 	Cancelled         string
@@ -30,6 +31,7 @@ var Task = struct {
 	RevertWindow:      "revert_window",
 	Completed:         "completed",
 	Failed:            "failed",
+	FailedRetryable:   "failed_retryable",
 	Stopped:           "stopped",
 	Reverted:          "reverted",
 	Cancelled:         "cancelled",
@@ -47,6 +49,7 @@ var TerminalTaskStates = []string{
 // IsTerminalTaskState returns true if the state is a terminal task state
 // where no further processing will occur.
 // Stopped is NOT terminal — a stopped task can be resumed via Start.
+// FailedRetryable is NOT terminal — scheduler workers may retry the task.
 func IsTerminalTaskState(s string) bool {
 	switch s {
 	case Task.Completed, Task.Failed, Task.Reverted, Task.Cancelled:
@@ -110,10 +113,16 @@ func NormalizeTaskStatus(raw string) string {
 
 	// Pass-through for already-normalized values
 	case Task.Pending, Task.Running, Task.Completed, Task.Stopped, Task.Failed,
-		Task.RevertWindow, Task.Reverted,
+		Task.FailedRetryable, Task.RevertWindow, Task.Reverted,
 		Task.WaitingForDeploy, Task.WaitingForCutover, Task.CuttingOver, Task.Cancelled:
 		return s
+	}
 
+	switch normalized := NormalizeState(s); normalized {
+	case Task.Pending, Task.Running, Task.Completed, Task.Stopped, Task.Failed,
+		Task.FailedRetryable, Task.RevertWindow, Task.Reverted,
+		Task.WaitingForDeploy, Task.WaitingForCutover, Task.CuttingOver, Task.Cancelled:
+		return normalized
 	default:
 		return Task.Running
 	}

--- a/pkg/state/task_test.go
+++ b/pkg/state/task_test.go
@@ -52,8 +52,8 @@ func TestNormalizeTaskStatus_VitessStates(t *testing.T) {
 
 func TestNormalizeTaskStatus_PassThrough(t *testing.T) {
 	for _, s := range []string{
-		Task.Pending, Task.Running, Task.Stopped, Task.Failed,
-		Task.RevertWindow, Task.Reverted,
+		Task.Pending, Task.Running, Task.Completed, Task.Stopped, Task.Failed,
+		Task.FailedRetryable, Task.RevertWindow, Task.Reverted,
 		Task.WaitingForDeploy, Task.WaitingForCutover, Task.CuttingOver, Task.Cancelled,
 	} {
 		assert.Equal(t, s, NormalizeTaskStatus(s), "NormalizeTaskStatus(%q)", s)
@@ -63,6 +63,9 @@ func TestNormalizeTaskStatus_PassThrough(t *testing.T) {
 func TestNormalizeTaskStatus_StatePrefix(t *testing.T) {
 	assert.Equal(t, Task.Running, NormalizeTaskStatus("STATE_running"))
 	assert.Equal(t, Task.Completed, NormalizeTaskStatus("state_complete"))
+	assert.Equal(t, Task.Completed, NormalizeTaskStatus("STATE_COMPLETED"))
+	assert.Equal(t, Task.FailedRetryable, NormalizeTaskStatus("STATE_FAILED_RETRYABLE"))
+	assert.Equal(t, Task.WaitingForCutover, NormalizeTaskStatus("STATE_WAITING_FOR_CUTOVER"))
 }
 
 func TestNormalizeTaskStatus_StorageCompleted(t *testing.T) {

--- a/pkg/storage/mysqlstore/applies.go
+++ b/pkg/storage/mysqlstore/applies.go
@@ -4,11 +4,15 @@ package mysqlstore
 
 import (
 	"context"
+	"crypto/sha256"
 	"database/sql"
+	"database/sql/driver"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
+	"time"
 
 	"github.com/block/schemabot/pkg/state"
 	"github.com/block/schemabot/pkg/storage"
@@ -18,13 +22,22 @@ import (
 // applyColumns lists all columns for SELECT queries.
 const applyColumns = `id, apply_identifier, lock_id, plan_id, database_name, database_type,
 	repository, pull_request, environment, deployment, caller, installation_id, external_id, engine,
-	state, error_message, options,
+	state, error_message, options, attempt,
 	created_at, started_at, completed_at, updated_at`
 
 const applyColumnsForApplyAlias = `a.id, a.apply_identifier, a.lock_id, a.plan_id, a.database_name, a.database_type,
 	a.repository, a.pull_request, a.environment, a.deployment, a.caller, a.installation_id, a.external_id, a.engine,
-	a.state, a.error_message, a.options,
+	a.state, a.error_message, a.options, a.attempt,
 	a.created_at, a.started_at, a.completed_at, a.updated_at`
+
+// maxRecoveryAttempts is the retry budget for failed_retryable applies. The
+// original apply attempt is separate; this counts scheduler redispatches.
+const maxRecoveryAttempts = 10
+
+const (
+	applyTargetLockWait           = 10 * time.Second
+	applyTargetLockReleaseTimeout = 5 * time.Second
+)
 
 // applyStore implements storage.ApplyStore using MySQL.
 type applyStore struct {
@@ -32,23 +45,28 @@ type applyStore struct {
 }
 
 type applyWriteTx struct {
-	tx *sql.Tx
+	tx             *sql.Tx
+	targetLockConn *sql.Conn
+	targetLockName string
 }
 
 type queryRower interface {
 	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
 }
 
-// claimableApplyStates returns apply states where scheduler recovery can safely
-// resume work after the heartbeat becomes stale. Pending and running states can
-// be orphaned by a server crash, and deploy/cutover/revert-window states have
-// already persisted enough engine metadata for recovery to continue from stored
-// state. Terminal states are already done, stopped requires an explicit user
-// start, and PlanetScale setup states are excluded until recovery can reload the
-// persisted branch/deploy metadata needed to resume them without restarting setup.
+type txBeginner interface {
+	BeginTx(ctx context.Context, opts *sql.TxOptions) (*sql.Tx, error)
+}
+
+// claimableApplyStates returns active apply states where scheduler recovery can
+// safely resume work after the heartbeat becomes stale. Pending has a separate
+// queue path and does not need to be stale before a worker claims it. Terminal
+// states are already done, failed_retryable has its own retry path, stopped
+// requires an explicit user start, and PlanetScale setup states are excluded
+// until recovery can reload the persisted branch/deploy metadata needed to
+// resume them without restarting setup.
 func claimableApplyStates() []string {
 	return []string{
-		state.Apply.Pending,
 		state.Apply.Running,
 		state.Apply.WaitingForDeploy,
 		state.Apply.WaitingForCutover,
@@ -98,13 +116,29 @@ func rollbackApplyTx(ctx context.Context, tx *sql.Tx, operation string) {
 	}
 }
 
-func beginApplyWriteTx(ctx context.Context, db *sql.DB, operation string) (*applyWriteTx, error) {
-	tx, err := db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelRepeatableRead})
+func beginApplyWriteTx(ctx context.Context, beginner txBeginner, operation string) (*applyWriteTx, error) {
+	tx, err := beginner.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelRepeatableRead})
 	if err != nil {
 		return nil, fmt.Errorf("begin %s transaction: %w", operation, err)
 	}
 
 	return &applyWriteTx{tx: tx}, nil
+}
+
+func beginApplyTargetWriteTx(ctx context.Context, db *sql.DB, operation, database, dbType, environment string) (*applyWriteTx, error) {
+	conn, lockName, err := acquireApplyTargetLockConn(ctx, db, database, dbType, environment)
+	if err != nil {
+		return nil, err
+	}
+
+	writeTx, err := beginApplyWriteTx(ctx, conn, operation)
+	if err != nil {
+		releaseApplyTargetLockConn(ctx, conn, lockName, operation)
+		return nil, err
+	}
+	writeTx.targetLockConn = conn
+	writeTx.targetLockName = lockName
+	return writeTx, nil
 }
 
 func (w *applyWriteTx) close(ctx context.Context, operation string) {
@@ -114,6 +148,10 @@ func (w *applyWriteTx) close(ctx context.Context, operation string) {
 	if w.tx != nil {
 		rollbackApplyTx(ctx, w.tx, operation)
 	}
+	if w.targetLockConn != nil {
+		releaseApplyTargetLockConn(ctx, w.targetLockConn, w.targetLockName, operation)
+		w.targetLockConn = nil
+	}
 }
 
 func (w *applyWriteTx) commit() error {
@@ -122,57 +160,69 @@ func (w *applyWriteTx) commit() error {
 	return err
 }
 
-// apply_target_locks rows are persistent mutex rows keyed by target. They are
-// created lazily and intentionally survive apply completion; the apply lifecycle
-// remains in applies, while this table gives first writers an exact row to lock.
-func ensureApplyTargetLockRow(ctx context.Context, db *sql.DB, database, dbType, environment string) error {
-	if !hasApplyTarget(database, dbType, environment) {
-		return fmt.Errorf("active apply target is required for %s/%s/%s", database, dbType, environment)
-	}
-
-	var id int64
-	err := db.QueryRowContext(ctx,
-		"SELECT `id` FROM `apply_target_locks` "+
-			"WHERE `database_name` = ? "+
-			"AND `database_type` = ? "+
-			"AND `environment` = ?",
-		database, dbType, environment,
-	).Scan(&id)
-	if err == nil {
-		return nil
-	}
-	if !errors.Is(err, sql.ErrNoRows) {
-		return fmt.Errorf("read apply target for %s/%s/%s: %w", database, dbType, environment, err)
-	}
-
-	_, err = db.ExecContext(ctx,
-		"INSERT IGNORE INTO `apply_target_locks` (`database_name`, `database_type`, `environment`) "+
-			"VALUES (?, ?, ?)",
-		database, dbType, environment,
-	)
-	if err != nil {
-		return fmt.Errorf("ensure apply target for %s/%s/%s: %w", database, dbType, environment, err)
-	}
-	return nil
+func applyTargetLockName(database, dbType, environment string) string {
+	sum := sha256.Sum256([]byte(database + "\x00" + dbType + "\x00" + environment))
+	return "schemabot_apply_" + hex.EncodeToString(sum[:16])
 }
 
-func lockApplyTargetRow(ctx context.Context, tx *sql.Tx, database, dbType, environment string) error {
-	var id int64
-	err := tx.QueryRowContext(ctx,
-		"SELECT `id` FROM `apply_target_locks` "+
-			"WHERE `database_name` = ? "+
-			"AND `database_type` = ? "+
-			"AND `environment` = ? "+
-			"FOR UPDATE",
-		database, dbType, environment,
-	).Scan(&id)
-	if errors.Is(err, sql.ErrNoRows) {
-		return fmt.Errorf("apply target missing for %s/%s/%s", database, dbType, environment)
+func acquireApplyTargetLockConn(ctx context.Context, db *sql.DB, database, dbType, environment string) (*sql.Conn, string, error) {
+	if !hasApplyTarget(database, dbType, environment) {
+		return nil, "", fmt.Errorf("active apply target is required for %s/%s/%s", database, dbType, environment)
 	}
+
+	conn, err := db.Conn(ctx)
 	if err != nil {
-		return fmt.Errorf("lock apply target for %s/%s/%s: %w", database, dbType, environment, err)
+		return nil, "", fmt.Errorf("get apply target connection for %s/%s/%s: %w", database, dbType, environment, err)
 	}
-	return nil
+
+	lockName := applyTargetLockName(database, dbType, environment)
+	var result sql.NullInt64
+	err = conn.QueryRowContext(ctx, "SELECT GET_LOCK(?, ?)", lockName, int(applyTargetLockWait.Seconds())).Scan(&result)
+	if err != nil {
+		closeApplyTargetLockConn(ctx, conn, lockName, "acquire apply target lock")
+		return nil, "", fmt.Errorf("acquire apply target lock for %s/%s/%s: %w", database, dbType, environment, err)
+	}
+	if !result.Valid || result.Int64 != 1 {
+		closeApplyTargetLockConn(ctx, conn, lockName, "acquire apply target lock")
+		return nil, "", fmt.Errorf("timed out waiting for apply target lock for %s/%s/%s", database, dbType, environment)
+	}
+	return conn, lockName, nil
+}
+
+func releaseApplyTargetLockConn(ctx context.Context, conn *sql.Conn, lockName, operation string) {
+	if conn == nil {
+		return
+	}
+
+	releaseCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), applyTargetLockReleaseTimeout)
+	defer cancel()
+
+	var result sql.NullInt64
+	err := conn.QueryRowContext(releaseCtx, "SELECT RELEASE_LOCK(?)", lockName).Scan(&result)
+	if err != nil || !result.Valid || result.Int64 != 1 {
+		slog.WarnContext(releaseCtx, "failed to release apply target lock; discarding connection",
+			"operation", operation,
+			"lock", lockName,
+			"result", result,
+			"error", err)
+		if rawErr := conn.Raw(func(any) error { return driver.ErrBadConn }); rawErr != nil && !errors.Is(rawErr, driver.ErrBadConn) {
+			slog.WarnContext(releaseCtx, "failed to discard apply target lock connection",
+				"operation", operation,
+				"lock", lockName,
+				"error", rawErr)
+		}
+	}
+
+	closeApplyTargetLockConn(releaseCtx, conn, lockName, operation)
+}
+
+func closeApplyTargetLockConn(ctx context.Context, conn *sql.Conn, lockName, operation string) {
+	if err := conn.Close(); err != nil {
+		slog.WarnContext(ctx, "failed to close apply target lock connection",
+			"operation", operation,
+			"lock", lockName,
+			"error", err)
+	}
 }
 
 func checkNoActiveApplyForTarget(ctx context.Context, tx *sql.Tx, database, dbType, environment string, excludeApplyID int64) error {
@@ -230,22 +280,22 @@ func (s *applyStore) Create(ctx context.Context, apply *storage.Apply) (int64, e
 	}
 
 	lockTarget := isActiveApplyState(apply.State)
+	var writeTx *applyWriteTx
+	var err error
 	if lockTarget {
-		if err := ensureApplyTargetLockRow(ctx, s.db, apply.Database, apply.DatabaseType, apply.Environment); err != nil {
+		writeTx, err = beginApplyTargetWriteTx(ctx, s.db, "create apply", apply.Database, apply.DatabaseType, apply.Environment)
+		if err != nil {
 			return 0, err
 		}
-	}
-
-	writeTx, err := beginApplyWriteTx(ctx, s.db, "create apply")
-	if err != nil {
-		return 0, err
+	} else {
+		writeTx, err = beginApplyWriteTx(ctx, s.db, "create apply")
+		if err != nil {
+			return 0, err
+		}
 	}
 	defer writeTx.close(ctx, "create apply")
 
 	if lockTarget {
-		if err := lockApplyTargetRow(ctx, writeTx.tx, apply.Database, apply.DatabaseType, apply.Environment); err != nil {
-			return 0, err
-		}
 		if err := checkNoActiveApplyForTarget(ctx, writeTx.tx, apply.Database, apply.DatabaseType, apply.Environment, 0); err != nil {
 			return 0, err
 		}
@@ -255,12 +305,12 @@ func (s *applyStore) Create(ctx context.Context, apply *storage.Apply) (int64, e
 		INSERT INTO applies (
 			apply_identifier, lock_id, plan_id, database_name, database_type,
 			repository, pull_request, environment, deployment, caller, installation_id, external_id, engine,
-			state, error_message, options
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			state, error_message, options, attempt
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`,
 		apply.ApplyIdentifier, apply.LockID, apply.PlanID, apply.Database, apply.DatabaseType,
 		apply.Repository, apply.PullRequest, apply.Environment, apply.Deployment, apply.Caller, apply.InstallationID, apply.ExternalID, apply.Engine,
-		apply.State, apply.ErrorMessage, string(options),
+		apply.State, apply.ErrorMessage, string(options), apply.Attempt,
 	)
 	if err != nil {
 		if isDuplicateKeyError(err) {
@@ -343,22 +393,21 @@ func (s *applyStore) Update(ctx context.Context, apply *storage.Apply) error {
 	}
 
 	shouldLockTarget := lockTarget && hasApplyTarget(database, dbType, environment)
+	var writeTx *applyWriteTx
 	if shouldLockTarget {
-		if err := ensureApplyTargetLockRow(ctx, s.db, database, dbType, environment); err != nil {
+		writeTx, err = beginApplyTargetWriteTx(ctx, s.db, "update apply", database, dbType, environment)
+		if err != nil {
 			return err
 		}
-	}
-
-	writeTx, err := beginApplyWriteTx(ctx, s.db, "update apply")
-	if err != nil {
-		return err
+	} else {
+		writeTx, err = beginApplyWriteTx(ctx, s.db, "update apply")
+		if err != nil {
+			return err
+		}
 	}
 	defer writeTx.close(ctx, "update apply")
 
 	if shouldLockTarget {
-		if err := lockApplyTargetRow(ctx, writeTx.tx, database, dbType, environment); err != nil {
-			return err
-		}
 		if err := checkNoActiveApplyForTarget(ctx, writeTx.tx, database, dbType, environment, apply.ID); err != nil {
 			return err
 		}
@@ -366,10 +415,10 @@ func (s *applyStore) Update(ctx context.Context, apply *storage.Apply) error {
 
 	_, err = writeTx.tx.ExecContext(ctx, `
 		UPDATE applies
-		SET state = ?, error_message = ?,
+		SET state = ?, error_message = ?, attempt = ?,
 		    external_id = ?, started_at = ?, completed_at = ?, updated_at = NOW()
 		WHERE id = ?
-	`, apply.State, apply.ErrorMessage,
+	`, apply.State, apply.ErrorMessage, apply.Attempt,
 		apply.ExternalID, apply.StartedAt, apply.CompletedAt, apply.ID)
 	if err != nil {
 		return fmt.Errorf("update apply %d: %w", apply.ID, err)
@@ -420,9 +469,11 @@ func (s *applyStore) GetRecent(ctx context.Context, limit int) ([]*storage.Apply
 // and resumes the apply.
 // Returns the claimed apply, or nil if nothing needs work.
 //
-// Matches stale active applies where heartbeat expired > 1 minute. Apply
-// creation/update enforces one active apply per database/type/environment, so
-// claims only need to lease one stale row and avoid worker races on that row.
+// Matches queued pending applies with persisted tasks, stale active applies
+// where heartbeat expired > 1 minute, and failed_retryable applies that still
+// have retry budget. Apply creation/update enforces one active apply per
+// database/type/environment, so claims only need to lease one row and avoid
+// worker races on that row.
 func (s *applyStore) FindNextApply(ctx context.Context) (*storage.Apply, error) {
 	// Read committed keeps concurrent SKIP LOCKED claims from taking next-key
 	// range locks that can serialize workers across otherwise independent targets.
@@ -434,7 +485,9 @@ func (s *applyStore) FindNextApply(ctx context.Context) (*storage.Apply, error) 
 
 	activeStates := claimableApplyStates()
 	activeStatePlaceholders := placeholders(len(activeStates))
-	queryArgs := stringArgs(activeStates)
+	queryArgs := []any{state.Apply.Pending}
+	queryArgs = append(queryArgs, stringArgs(activeStates)...)
+	queryArgs = append(queryArgs, state.Apply.FailedRetryable, maxRecoveryAttempts)
 
 	// Apply creation/update enforces at most one active apply per
 	// database/type/environment. The claim query only needs to find stale work;
@@ -442,8 +495,11 @@ func (s *applyStore) FindNextApply(ctx context.Context) (*storage.Apply, error) 
 	row := tx.QueryRowContext(ctx, fmt.Sprintf(`
 		SELECT %s
 		FROM applies a
-		WHERE a.state IN (%s)
-		AND a.updated_at < NOW() - INTERVAL 1 MINUTE
+		WHERE (
+			(a.state = ? AND EXISTS (SELECT 1 FROM tasks t WHERE t.apply_id = a.id))
+			OR (a.state IN (%s) AND a.updated_at < NOW() - INTERVAL 1 MINUTE)
+			OR (a.state = ? AND a.attempt < ?)
+		)
 		ORDER BY a.created_at
 		LIMIT 1
 		FOR UPDATE SKIP LOCKED
@@ -458,11 +514,39 @@ func (s *applyStore) FindNextApply(ctx context.Context) (*storage.Apply, error) 
 	}
 
 	// Refresh the heartbeat as part of the claim before releasing the row lock.
-	_, err = tx.ExecContext(ctx, `
-		UPDATE applies SET updated_at = NOW() WHERE id = ?
-	`, apply.ID)
-	if err != nil {
-		return nil, fmt.Errorf("refresh heartbeat for claimed apply %d: %w", apply.ID, err)
+	// Pending and retryable applies become running while dispatch starts, so
+	// the leased row remains in the stale-recovery state family if the worker
+	// crashes before the engine starts.
+	if apply.State == state.Apply.Pending || apply.State == state.Apply.FailedRetryable {
+		var result sql.Result
+		nextState := state.Apply.Running
+		result, err = tx.ExecContext(ctx, `
+			UPDATE applies
+			SET state = ?, updated_at = NOW(),
+			    attempt = CASE WHEN ? = ? THEN attempt + 1 ELSE attempt END,
+			    completed_at = NULL
+			WHERE id = ? AND state = ?
+		`, nextState, apply.State, state.Apply.FailedRetryable, apply.ID, apply.State)
+		if err != nil {
+			return nil, fmt.Errorf("claim apply %d in state %s: %w", apply.ID, apply.State, err)
+		}
+		rows, err := result.RowsAffected()
+		if err != nil {
+			return nil, fmt.Errorf("read claim rows affected for apply %d: %w", apply.ID, err)
+		}
+		if rows == 0 {
+			return nil, nil
+		}
+		if apply.State == state.Apply.FailedRetryable {
+			apply.Attempt++
+		}
+	} else {
+		_, err = tx.ExecContext(ctx, `
+			UPDATE applies SET updated_at = NOW() WHERE id = ?
+		`, apply.ID)
+		if err != nil {
+			return nil, fmt.Errorf("refresh heartbeat for claimed apply %d: %w", apply.ID, err)
+		}
 	}
 
 	if err := tx.Commit(); err != nil {
@@ -485,6 +569,68 @@ func (s *applyStore) Heartbeat(ctx context.Context, applyID int64) error {
 		return fmt.Errorf("heartbeat apply %d: %w", applyID, err)
 	}
 	return nil
+}
+
+// ExpireRetryable transitions failed_retryable applies that exhausted their
+// retry budget to permanent failed. Returns the applies updated.
+func (s *applyStore) ExpireRetryable(ctx context.Context) ([]*storage.Apply, error) {
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelReadCommitted})
+	if err != nil {
+		return nil, fmt.Errorf("begin expire retryable applies transaction: %w", err)
+	}
+	defer rollbackApplyTx(ctx, tx, "expire retryable applies")
+
+	rows, err := tx.QueryContext(ctx, `
+		SELECT `+applyColumns+`
+		FROM applies
+		WHERE state = ? AND attempt >= ?
+		FOR UPDATE
+	`, state.Apply.FailedRetryable, maxRecoveryAttempts)
+	if err != nil {
+		return nil, fmt.Errorf("query exhausted retryable applies: %w", err)
+	}
+	applies, err := scanApplies(rows)
+	utils.CloseAndLog(rows)
+	if err != nil {
+		return nil, fmt.Errorf("scan exhausted retryable applies: %w", err)
+	}
+	if len(applies) == 0 {
+		if err := tx.Commit(); err != nil {
+			return nil, fmt.Errorf("commit empty expire retryable applies: %w", err)
+		}
+		return nil, nil
+	}
+
+	applyIDs := make([]any, 0, len(applies))
+	for _, apply := range applies {
+		applyIDs = append(applyIDs, apply.ID)
+	}
+
+	taskArgs := []any{state.Task.Failed}
+	taskArgs = append(taskArgs, stringArgs(state.TerminalTaskStates)...)
+	taskArgs = append(taskArgs, applyIDs...)
+	_, err = tx.ExecContext(ctx, fmt.Sprintf(`
+		UPDATE tasks t
+		SET t.state = ?, t.completed_at = COALESCE(t.completed_at, NOW()), t.updated_at = NOW()
+		WHERE t.state NOT IN (%s) AND t.apply_id IN (%s)
+	`, placeholders(len(state.TerminalTaskStates)), placeholders(len(applyIDs))), taskArgs...)
+	if err != nil {
+		return nil, fmt.Errorf("expire retryable tasks: %w", err)
+	}
+
+	applyArgs := append([]any{state.Apply.Failed}, applyIDs...)
+	_, err = tx.ExecContext(ctx, fmt.Sprintf(`
+		UPDATE applies
+		SET state = ?, completed_at = COALESCE(completed_at, NOW()), updated_at = NOW()
+		WHERE id IN (%s)
+	`, placeholders(len(applyIDs))), applyArgs...)
+	if err != nil {
+		return nil, fmt.Errorf("expire retryable applies: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("commit expire retryable applies: %w", err)
+	}
+	return applies, nil
 }
 
 // GetByDatabase returns applies for a specific database and optionally filtered by dbType and environment.
@@ -617,7 +763,7 @@ func scanApplyInto(s scanner) (*storage.Apply, error) {
 		&apply.Database, &apply.DatabaseType,
 		&apply.Repository, &apply.PullRequest, &apply.Environment, &apply.Deployment,
 		&apply.Caller, &apply.InstallationID, &apply.ExternalID, &apply.Engine,
-		&apply.State, &apply.ErrorMessage, &options,
+		&apply.State, &apply.ErrorMessage, &options, &apply.Attempt,
 		&apply.CreatedAt, &startedAt, &completedAt, &apply.UpdatedAt,
 	)
 	if err != nil {

--- a/pkg/storage/mysqlstore/applies_test.go
+++ b/pkg/storage/mysqlstore/applies_test.go
@@ -3,6 +3,7 @@
 package mysqlstore
 
 import (
+	"context"
 	"database/sql"
 	"errors"
 	"strconv"
@@ -141,16 +142,13 @@ func TestApplyStore_CreateWaitsForApplyTargetLock(t *testing.T) {
 
 	lock := createTestLock(t, store, "testdb", "mysql", "staging")
 
-	guardTx, err := beginApplyWriteTx(ctx, testDB, "test active apply guard")
+	guardConn, guardLockName, err := acquireApplyTargetLockConn(ctx, testDB, "testdb", "mysql", "staging")
 	require.NoError(t, err)
-	t.Cleanup(func() { guardTx.close(ctx, "test active apply guard") })
-
-	// Hold the exact target mutex row open. Active apply creation locks this row
-	// before checking applies, so a same-target create waits without relying on
-	// an empty applies range lock.
-	require.NoError(t, ensureApplyTargetLockRow(ctx, testDB, "testdb", "mysql", "staging"))
-	require.NoError(t, lockApplyTargetRow(ctx, guardTx.tx, "testdb", "mysql", "staging"))
-	require.NoError(t, checkNoActiveApplyForTarget(ctx, guardTx.tx, "testdb", "mysql", "staging", 0))
+	t.Cleanup(func() {
+		if guardConn != nil {
+			releaseApplyTargetLockConn(ctx, guardConn, guardLockName, "test active apply guard")
+		}
+	})
 
 	type createResult struct {
 		id  int64
@@ -180,7 +178,8 @@ func TestApplyStore_CreateWaitsForApplyTargetLock(t *testing.T) {
 	case <-time.After(300 * time.Millisecond):
 	}
 
-	require.NoError(t, guardTx.commit())
+	releaseApplyTargetLockConn(ctx, guardConn, guardLockName, "test active apply guard")
+	guardConn = nil
 
 	select {
 	case result := <-resultCh:
@@ -193,6 +192,46 @@ func TestApplyStore_CreateWaitsForApplyTargetLock(t *testing.T) {
 	applies, err := store.Applies().GetByDatabase(ctx, "testdb", "mysql", "staging")
 	require.NoError(t, err)
 	assert.Len(t, applies, 1)
+}
+
+func TestApplyStore_CreateActiveApplyDoesNotWaitForTargetLockRowBootstrap(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "bootstrapdb", "mysql", "staging")
+
+	guardTx, err := testDB.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelRepeatableRead})
+	require.NoError(t, err)
+	t.Cleanup(func() { rollbackApplyTx(ctx, guardTx, "test apply target bootstrap guard") })
+
+	var id int64
+	err = guardTx.QueryRowContext(ctx, `
+		SELECT id FROM apply_target_locks FORCE INDEX (idx_apply_target)
+		WHERE database_name >= ?
+		ORDER BY database_name, database_type, environment
+		LIMIT 1
+		FOR UPDATE
+	`, "").Scan(&id)
+	require.ErrorIs(t, err, sql.ErrNoRows)
+
+	createCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
+	defer cancel()
+
+	id, err = store.Applies().Create(createCtx, &storage.Apply{
+		ApplyIdentifier: "apply_no_bootstrap_wait",
+		LockID:          lock.ID,
+		PlanID:          7,
+		Database:        "bootstrapdb",
+		DatabaseType:    "mysql",
+		Repository:      "org/repo",
+		PullRequest:     123,
+		Environment:     "staging",
+		Engine:          "spirit",
+		State:           state.Apply.Pending,
+	})
+	require.NoError(t, err)
+	assert.NotZero(t, id)
 }
 
 func TestApplyStore_CreateAllowsOneConcurrentActiveApplyForSameTarget(t *testing.T) {
@@ -292,10 +331,6 @@ func TestApplyStore_CreateAvoidsGapLockDeadlocksForDifferentTargets(t *testing.T
 		lock := locks[target.database+"/"+target.dbType]
 		wg.Go(func() {
 			<-start
-			// If storage protects first writers by locking empty ranges in applies,
-			// these concurrent inserts can deadlock even though every target is
-			// independent. The target-lock row gives each target an exact mutex
-			// before applies is checked, so callers should not see deadlock errors.
 			_, err := store.Applies().Create(ctx, &storage.Apply{
 				ApplyIdentifier: "apply_concurrent_target_" + strconv.Itoa(i),
 				LockID:          lock.ID,
@@ -531,6 +566,145 @@ func TestApplyStore_GetInProgress(t *testing.T) {
 	assert.True(t, applyIDs[running.ApplyIdentifier], "expected running apply")
 }
 
+// TestApplyStore_FindNextApplyClaimsRetryable verifies the storage-level retry
+// claim behavior. The caller sees the retryable state that was claimed, while
+// the stored row is leased as running with an incremented apply attempt.
+func TestApplyStore_FindNextApplyClaimsRetryable(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", storage.DatabaseTypeMySQL, "staging")
+	apply := createTestApplyWithStateAndEnv(t, store, lock, "apply_retryable_claim", 500, state.Apply.FailedRetryable, "staging")
+
+	claimed, err := store.Applies().FindNextApply(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, claimed)
+	assert.Equal(t, apply.ApplyIdentifier, claimed.ApplyIdentifier)
+	assert.Equal(t, state.Apply.FailedRetryable, claimed.State)
+	assert.Equal(t, 1, claimed.Attempt)
+
+	persisted, err := store.Applies().Get(ctx, apply.ID)
+	require.NoError(t, err)
+	require.NotNil(t, persisted)
+	assert.Equal(t, state.Apply.Running, persisted.State)
+	assert.Equal(t, 1, persisted.Attempt)
+
+	claimedAgain, err := store.Applies().FindNextApply(ctx)
+	require.NoError(t, err)
+	assert.Nil(t, claimedAgain)
+}
+
+func TestApplyStore_FindNextApplyRequiresTasksForPendingApply(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", storage.DatabaseTypeMySQL, "staging")
+	apply := createTestApplyWithStateAndEnv(t, store, lock, "apply_pending_claim", 502, state.Apply.Pending, "staging")
+
+	claimedBeforeTasks, err := store.Applies().FindNextApply(ctx)
+	require.NoError(t, err)
+	assert.Nil(t, claimedBeforeTasks, "pending applies are not ready for scheduler dispatch until their tasks are persisted")
+
+	now := time.Now()
+	_, err = store.Tasks().Create(ctx, &storage.Task{
+		TaskIdentifier: "task_pending_claim",
+		ApplyID:        apply.ID,
+		PlanID:         apply.PlanID,
+		Database:       apply.Database,
+		DatabaseType:   apply.DatabaseType,
+		Engine:         storage.EngineSpirit,
+		Environment:    apply.Environment,
+		State:          state.Task.Pending,
+		TableName:      "users",
+		DDL:            "CREATE TABLE users (id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY)",
+		DDLAction:      "CREATE",
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	})
+	require.NoError(t, err)
+
+	claimed, err := store.Applies().FindNextApply(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, claimed)
+	assert.Equal(t, apply.ApplyIdentifier, claimed.ApplyIdentifier)
+	assert.Equal(t, state.Apply.Pending, claimed.State)
+
+	persisted, err := store.Applies().Get(ctx, apply.ID)
+	require.NoError(t, err)
+	require.NotNil(t, persisted)
+	assert.Equal(t, state.Apply.Running, persisted.State)
+}
+
+// TestApplyStore_ExpireRetryable verifies retry budget exhaustion at the
+// storage layer. A retryable apply that has used all attempts becomes failed,
+// and unfinished tasks are finalized as failed with completion timestamps.
+func TestApplyStore_ExpireRetryable(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", storage.DatabaseTypeMySQL, "staging")
+	apply := createTestApplyWithStateAndEnv(t, store, lock, "apply_retryable_expired", 501, state.Apply.FailedRetryable, "staging")
+	apply.Attempt = maxRecoveryAttempts
+	require.NoError(t, store.Applies().Update(ctx, apply))
+
+	now := time.Now()
+	_, err := store.Tasks().Create(ctx, &storage.Task{
+		TaskIdentifier: "task_retryable_expired",
+		ApplyID:        apply.ID,
+		PlanID:         apply.PlanID,
+		Database:       apply.Database,
+		DatabaseType:   apply.DatabaseType,
+		Engine:         storage.EngineSpirit,
+		Environment:    apply.Environment,
+		State:          state.Task.FailedRetryable,
+		Options:        []byte("{}"),
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	})
+	require.NoError(t, err)
+	_, err = store.Tasks().Create(ctx, &storage.Task{
+		TaskIdentifier: "task_retryable_pending",
+		ApplyID:        apply.ID,
+		PlanID:         apply.PlanID,
+		Database:       apply.Database,
+		DatabaseType:   apply.DatabaseType,
+		Engine:         storage.EngineSpirit,
+		Environment:    apply.Environment,
+		State:          state.Task.Pending,
+		TableName:      "posts",
+		Options:        []byte("{}"),
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	})
+	require.NoError(t, err)
+
+	expired, err := store.Applies().ExpireRetryable(ctx)
+	require.NoError(t, err)
+	require.Len(t, expired, 1)
+	assert.Equal(t, apply.ApplyIdentifier, expired[0].ApplyIdentifier)
+
+	persisted, err := store.Applies().Get(ctx, apply.ID)
+	require.NoError(t, err)
+	require.NotNil(t, persisted)
+	assert.Equal(t, state.Apply.Failed, persisted.State)
+	assert.NotNil(t, persisted.CompletedAt)
+
+	task, err := store.Tasks().Get(ctx, "task_retryable_expired")
+	require.NoError(t, err)
+	require.NotNil(t, task)
+	assert.Equal(t, state.Task.Failed, task.State)
+	assert.NotNil(t, task.CompletedAt)
+
+	pendingTask, err := store.Tasks().Get(ctx, "task_retryable_pending")
+	require.NoError(t, err)
+	require.NotNil(t, pendingTask)
+	assert.Equal(t, state.Task.Failed, pendingTask.State)
+	assert.NotNil(t, pendingTask.CompletedAt)
+}
+
 func TestApplyStore_FindMissingSummaryComment_ExcludesAppliesWithoutGitHubDestination(t *testing.T) {
 	clearTables(t)
 	ctx := t.Context()
@@ -733,6 +907,7 @@ func TestApplyStore_AllFields(t *testing.T) {
 		Engine:          "spirit",
 		State:           state.Apply.WaitingForCutover,
 		ErrorMessage:    "test error",
+		Attempt:         3,
 	}
 	apply.SetOptions(storage.ApplyOptions{
 		AllowUnsafe:  true,
@@ -769,6 +944,7 @@ func TestApplyStore_AllFields(t *testing.T) {
 	assert.Equal(t, "spirit", retrieved.Engine)
 	assert.Equal(t, state.Apply.Completed, retrieved.State)
 	assert.Equal(t, "test error", retrieved.ErrorMessage)
+	assert.Equal(t, 3, retrieved.Attempt)
 	assert.NotNil(t, retrieved.StartedAt)
 	assert.NotNil(t, retrieved.CompletedAt)
 

--- a/pkg/storage/mysqlstore/tasks.go
+++ b/pkg/storage/mysqlstore/tasks.go
@@ -17,7 +17,7 @@ import (
 // taskColumns lists all columns for SELECT queries.
 const taskColumns = `id, task_identifier, apply_id, plan_id, database_name, database_type,
 	namespace, table_name, ddl, ddl_action,
-	engine, repository, pull_request, environment, state, error_message, options,
+	engine, repository, pull_request, environment, state, error_message, options, attempt,
 	rows_copied, rows_total, progress_percent, eta_seconds,
 	is_instant, ready_to_complete, engine_migration_id,
 	started_at, completed_at, created_at, updated_at`
@@ -48,16 +48,16 @@ func (s *taskStore) Create(ctx context.Context, task *storage.Task) (int64, erro
 		INSERT INTO tasks (
 			task_identifier, apply_id, plan_id, database_name, database_type,
 			namespace, table_name, ddl, ddl_action,
-			engine, repository, pull_request, environment, state, error_message, options,
+			engine, repository, pull_request, environment, state, error_message, options, attempt,
 			rows_copied, rows_total, progress_percent, eta_seconds,
 			is_instant, ready_to_complete, engine_migration_id,
 			started_at, completed_at, created_at, updated_at
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`,
 		task.TaskIdentifier, task.ApplyID, task.PlanID, task.Database, task.DatabaseType,
 		task.Namespace, nullString(task.TableName), nullString(task.DDL), nullString(task.DDLAction),
 		task.Engine, task.Repository, task.PullRequest, task.Environment,
-		task.State, nullString(task.ErrorMessage), string(options),
+		task.State, nullString(task.ErrorMessage), string(options), task.Attempt,
 		task.RowsCopied, task.RowsTotal, task.ProgressPercent, task.ETASeconds,
 		task.IsInstant, task.ReadyToComplete, nullString(task.EngineMigrationID),
 		task.StartedAt, task.CompletedAt, task.CreatedAt, task.UpdatedAt,
@@ -89,12 +89,12 @@ func (s *taskStore) Get(ctx context.Context, taskIdentifier string) (*storage.Ta
 func (s *taskStore) Update(ctx context.Context, task *storage.Task) error {
 	_, err := s.db.ExecContext(ctx, `
 		UPDATE tasks SET
-			state = ?, error_message = ?, options = ?,
+			state = ?, error_message = ?, options = ?, attempt = ?,
 			rows_copied = ?, rows_total = ?, progress_percent = ?, eta_seconds = ?,
 			is_instant = ?, ready_to_complete = ?, engine_migration_id = ?,
 			started_at = ?, completed_at = ?, updated_at = NOW()
 		WHERE id = ?
-	`, task.State, nullString(task.ErrorMessage), nullJSON(task.Options),
+	`, task.State, nullString(task.ErrorMessage), nullJSON(task.Options), task.Attempt,
 		task.RowsCopied, task.RowsTotal, task.ProgressPercent, task.ETASeconds,
 		task.IsInstant, task.ReadyToComplete, nullString(task.EngineMigrationID),
 		task.StartedAt, task.CompletedAt,
@@ -255,6 +255,7 @@ func scanTaskInto(s scanner) (*storage.Task, error) {
 		&task.State,
 		&errorMsg,
 		&options,
+		&task.Attempt,
 		&task.RowsCopied,
 		&task.RowsTotal,
 		&task.ProgressPercent,

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -211,6 +211,10 @@ type ApplyStore interface {
 	// If not called for > 1 minute, another worker can claim the apply.
 	Heartbeat(ctx context.Context, applyID int64) error
 
+	// ExpireRetryable transitions failed_retryable applies that exhausted their
+	// retry budget to permanent failed. Returns the applies updated.
+	ExpireRetryable(ctx context.Context) ([]*Apply, error)
+
 	// FindMissingSummaryComment returns GitHub-backed applies that should have
 	// a terminal summary comment but only have a progress comment. Used by
 	// startup reconciliation to post missing summary comments after restarts.

--- a/pkg/storage/types.go
+++ b/pkg/storage/types.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"maps"
 	"sort"
+	"strconv"
 	"time"
 
 	"github.com/block/schemabot/pkg/schema"
@@ -323,6 +324,10 @@ type Apply struct {
 	// Use ParseApplyOptions() to get typed access.
 	Options []byte
 
+	// Attempt tracks scheduler retry attempts for failed_retryable applies.
+	// Once the retry budget is exhausted, the apply becomes failed.
+	Attempt int
+
 	// CreatedAt is when the apply was created.
 	CreatedAt time.Time
 
@@ -360,6 +365,56 @@ type ApplyOptions struct {
 
 	// Volume controls schema change aggressiveness (1-11).
 	Volume int `json:"volume,omitempty"`
+
+	// Target is the opaque endpoint-discovery target forwarded to Tern.
+	// Defaults to the apply database when empty.
+	Target string `json:"target,omitempty"`
+}
+
+// ApplyOptionsFromMap converts API/proto option strings into typed storage options.
+func ApplyOptionsFromMap(options map[string]string) ApplyOptions {
+	opts := ApplyOptions{
+		AllowUnsafe:  options["allow_unsafe"] == "true",
+		Branch:       options["branch"],
+		DeferCutover: options["defer_cutover"] == "true",
+		DeferDeploy:  options["defer_deploy"] == "true",
+		SkipRevert:   options["skip_revert"] == "true",
+		Target:       options["target"],
+	}
+	if rawVolume := options["volume"]; rawVolume != "" {
+		volume, err := strconv.Atoi(rawVolume)
+		if err == nil && volume > 0 {
+			opts.Volume = volume
+		}
+	}
+	return opts
+}
+
+// Map converts typed storage options back into API/proto option strings.
+func (opts ApplyOptions) Map() map[string]string {
+	options := make(map[string]string)
+	if opts.AllowUnsafe {
+		options["allow_unsafe"] = "true"
+	}
+	if opts.Branch != "" {
+		options["branch"] = opts.Branch
+	}
+	if opts.DeferCutover {
+		options["defer_cutover"] = "true"
+	}
+	if opts.DeferDeploy {
+		options["defer_deploy"] = "true"
+	}
+	if opts.SkipRevert {
+		options["skip_revert"] = "true"
+	}
+	if opts.Volume > 0 {
+		options["volume"] = strconv.Itoa(opts.Volume)
+	}
+	if opts.Target != "" {
+		options["target"] = opts.Target
+	}
+	return options
 }
 
 // ParseApplyOptions parses the JSON options into ApplyOptions.
@@ -437,6 +492,9 @@ type Task struct {
 
 	// Options contains engine-specific options as JSON.
 	Options []byte
+
+	// Attempt tracks how many times this task has been retried by scheduler recovery.
+	Attempt int
 
 	// Namespace is the schema name (MySQL) or keyspace (Vitess) this table belongs to.
 	Namespace string

--- a/pkg/storage/types_test.go
+++ b/pkg/storage/types_test.go
@@ -1,0 +1,47 @@
+package storage
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestApplyOptionsFromMapRoundTrip verifies that user-facing apply options can
+// be decoded from API-style strings and encoded back without losing fields.
+func TestApplyOptionsFromMapRoundTrip(t *testing.T) {
+	options := ApplyOptionsFromMap(map[string]string{
+		"allow_unsafe":  "true",
+		"branch":        "schema-change-branch",
+		"defer_cutover": "true",
+		"defer_deploy":  "true",
+		"skip_revert":   "true",
+		"volume":        "7",
+	})
+
+	assert.Equal(t, ApplyOptions{
+		AllowUnsafe:  true,
+		Branch:       "schema-change-branch",
+		DeferCutover: true,
+		DeferDeploy:  true,
+		SkipRevert:   true,
+		Volume:       7,
+	}, options)
+
+	assert.Equal(t, map[string]string{
+		"allow_unsafe":  "true",
+		"branch":        "schema-change-branch",
+		"defer_cutover": "true",
+		"defer_deploy":  "true",
+		"skip_revert":   "true",
+		"volume":        "7",
+	}, options.Map())
+}
+
+// TestApplyOptionsFromMapIgnoresInvalidVolume verifies that malformed numeric
+// options are ignored instead of being persisted back into apply metadata.
+func TestApplyOptionsFromMapIgnoresInvalidVolume(t *testing.T) {
+	options := ApplyOptionsFromMap(map[string]string{"volume": "fast"})
+
+	assert.Zero(t, options.Volume)
+	assert.Empty(t, options.Map())
+}

--- a/pkg/tern/README.md
+++ b/pkg/tern/README.md
@@ -36,11 +36,11 @@ Request/response types are protobuf-generated (`pkg/proto/ternv1`).
 
 ### 1. Plan
 
-The CLI or API calls `Plan()` with the desired schema files. The Tern client passes them to the engine, which diffs against the live database and returns DDL statements with lint warnings. The plan is stored in SchemaBot's storage for later use by `Apply()`.
+The CLI or API calls `Plan()` with the desired schema files. The Tern client passes them to the engine, which diffs against the live database and returns DDL statements with lint warnings. The plan is stored in SchemaBot's storage for later apply dispatch.
 
 ### 2. Apply
 
-`Apply()` creates an Apply record (one Apply contains N Tasks, one per table) and launches background execution in one of two modes:
+The API apply path creates an Apply record plus Task records, then returns once that work is durably queued. Scheduler workers claim queued applies and call `ResumeApply()` on the appropriate Tern client, which launches background execution in one of two modes:
 
 - **Sequential mode** (default): Each table's DDL is executed one at a time. Each task runs through Spirit independently and cuts over before the next starts.
 - **Atomic mode** (`--defer-cutover`): All DDLs are passed to Spirit in a single call. All tables copy in parallel and cut over together when the user triggers cutover.
@@ -55,13 +55,13 @@ In atomic mode with `--defer-cutover`, the schema change pauses at `WaitingForCu
 
 ## Recovery
 
-If the SchemaBot server crashes during an apply, the recovery mechanism resumes it:
+If the SchemaBot server crashes during an apply, an apply is queued but not yet dispatched, or an engine error is classified as retryable, the recovery mechanism resumes it:
 
-1. The API service scheduler polls every 10 seconds for applies with stale heartbeats (no update for 1+ minute)
+1. The API service wakes a scheduler worker when new work is queued; workers also poll every 10 seconds for queued pending applies, applies with stale heartbeats (no update for 1+ minute), or retryable failures
 2. It claims the apply by selecting it and refreshing its heartbeat in one transaction
 3. It calls `ResumeApply()` on the appropriate Tern client
-4. **LocalClient**: Calls `engine.Apply()` with the same DDL — Spirit auto-detects its checkpoint table and resumes from where it left off
-5. **GRPCClient**: Calls `Start()` on the remote Tern service, then spawns a local progress poller
+4. **LocalClient**: Calls `engine.Apply()` with the same DDL. For fresh queued work this starts the engine; for stale work Spirit auto-detects its checkpoint table and resumes from where it left off
+5. **GRPCClient**: For fresh queued work, calls remote Tern `Apply()` and stores the remote apply ID as `external_id`; for stale remote work, resumes tracking or sends control RPCs as needed
 
 Stopped applies (user called `stop`) are not auto-resumed — the user must explicitly call `start`.
 

--- a/pkg/tern/apply_states_test.go
+++ b/pkg/tern/apply_states_test.go
@@ -244,6 +244,14 @@ func TestDeriveOverallState(t *testing.T) {
 			},
 			wantState: state.Task.Failed,
 		},
+		{
+			name: "retryable failure takes priority over pending",
+			tasks: []*storage.Task{
+				{State: state.Task.Pending},
+				{State: state.Task.FailedRetryable},
+			},
+			wantState: state.Task.FailedRetryable,
+		},
 	}
 
 	for _, tt := range tests {
@@ -252,6 +260,84 @@ func TestDeriveOverallState(t *testing.T) {
 			assert.Equal(t, tt.wantState, got)
 		})
 	}
+}
+
+func TestEngineResultTaskState_RetryableProgress(t *testing.T) {
+	c := &LocalClient{}
+
+	tests := []struct {
+		name   string
+		result *engine.ProgressResult
+		want   string
+	}{
+		{
+			name:   "failed retryable progress maps to failed_retryable task",
+			result: &engine.ProgressResult{State: engine.StateFailed, Retryable: true},
+			want:   state.Task.FailedRetryable,
+		},
+		{
+			name:   "failed permanent progress maps to failed task",
+			result: &engine.ProgressResult{State: engine.StateFailed},
+			want:   state.Task.Failed,
+		},
+		{
+			name:   "non-failed progress follows state conversion",
+			result: &engine.ProgressResult{State: engine.StateRunning},
+			want:   state.Task.Running,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, c.engineResultTaskState(tt.result))
+		})
+	}
+}
+
+// TestBuildApplyOptionsPreservesStoredOptions verifies that retry and resume
+// dispatches rebuild the engine option map from persisted apply metadata.
+func TestBuildApplyOptionsPreservesStoredOptions(t *testing.T) {
+	apply := &storage.Apply{}
+	apply.SetOptions(storage.ApplyOptions{
+		AllowUnsafe:  true,
+		Branch:       "schema-change-branch",
+		DeferCutover: true,
+		DeferDeploy:  true,
+		SkipRevert:   true,
+		Volume:       7,
+	})
+
+	assert.Equal(t, map[string]string{
+		"allow_unsafe":  "true",
+		"branch":        "schema-change-branch",
+		"defer_cutover": "true",
+		"defer_deploy":  "true",
+		"skip_revert":   "true",
+		"volume":        "7",
+	}, buildApplyOptions(apply))
+}
+
+// TestVitessApplyDataResumeState verifies that persisted Vitess metadata is
+// converted back into generic resume metadata before scheduler recovery calls
+// the engine.
+func TestVitessApplyDataResumeState(t *testing.T) {
+	resumeState, err := vitessApplyDataResumeState(&storage.VitessApplyData{
+		BranchName:       "schema-change-branch",
+		DeployRequestID:  42,
+		DeployRequestURL: "http://localhost/deploy-requests/42",
+		IsInstant:        true,
+		DeferredDeploy:   true,
+	}, "fallback-context")
+	require.NoError(t, err)
+
+	assert.Equal(t, "fallback-context", resumeState.MigrationContext)
+	var metadata map[string]any
+	require.NoError(t, json.Unmarshal([]byte(resumeState.Metadata), &metadata))
+	assert.Equal(t, "schema-change-branch", metadata["branch_name"])
+	assert.Equal(t, float64(42), metadata["deploy_request_id"])
+	assert.Equal(t, "http://localhost/deploy-requests/42", metadata["deploy_request_url"])
+	assert.Equal(t, true, metadata["is_instant"])
+	assert.Equal(t, true, metadata["deferred_deploy"])
 }
 
 func TestVSchemaTasksCreatedAlongsideDDL(t *testing.T) {

--- a/pkg/tern/client.go
+++ b/pkg/tern/client.go
@@ -51,10 +51,9 @@ type Client interface {
 	// Health checks the service health.
 	Health(ctx context.Context) error
 
-	// ResumeApply resumes an in-progress apply whose heartbeat has expired.
-	// Uses checkpoint/resume capabilities of the underlying engine.
-	// This is called by Service.RecoverInProgress on startup for applies
-	// with stale heartbeats (crashed workers).
+	// ResumeApply starts or resumes apply work claimed by the scheduler.
+	// Pending applies are fresh queued work. Stale active applies use
+	// checkpoint/resume capabilities of the underlying engine.
 	ResumeApply(ctx context.Context, apply *storage.Apply) error
 
 	// Endpoint returns the address this client connects to.
@@ -65,16 +64,15 @@ type Client interface {
 	// IsRemote reports whether this client delegates to a separate Tern
 	// service with its own storage.
 	//
-	// When true (GRPCClient): ExecuteApply creates apply/task records in
-	// SchemaBot's storage and stores Tern's apply_id as external_id.
+	// When true (GRPCClient): scheduler dispatch stores the remote Tern apply_id
+	// as external_id after remote Tern accepts the apply.
 	//
-	// When false (LocalClient): Apply() already created the records in the
-	// same database — ExecuteApply reuses them.
+	// When false (LocalClient): execution uses SchemaBot's local apply_id.
 	IsRemote() bool
 
-	// SetPendingObserver sets an observer that will be consumed by the next
-	// Apply() call. The observer is registered before the engine starts,
-	// preventing the race where the apply completes before the observer is set.
+	// SetPendingObserver sets an observer that direct client Apply callers can
+	// consume before engine work starts. API callers register observers through
+	// Service.SetPendingObserver.
 	SetPendingObserver(observer ProgressObserver)
 
 	// SetObserver registers a progress observer for an active apply.

--- a/pkg/tern/grpc_client.go
+++ b/pkg/tern/grpc_client.go
@@ -70,7 +70,7 @@ package tern
 //   - external_id: Tern's apply_id (the remote engine's apply identifier), used in all
 //     gRPC calls to the remote Tern (Progress, Stop, Start, Cutover, etc.).
 //
-// gRPC mode flow:
+// gRPC mode progress flow after scheduler dispatch:
 //
 //	CLI/caller
 //	    │ apply_identifier="apply-abc123"
@@ -87,16 +87,14 @@ package tern
 //	    ▼
 //	ProgressResponse
 //
-// The API layer (plan_handlers.go) generates apply_identifier as a SchemaBot
-// UUID and stores Tern's resp.ApplyId as external_id. The resolveApplyID
-// helper translates apply_identifier → external_id before calling Tern.
+// The API layer generates apply_identifier as a SchemaBot UUID when it queues
+// the apply. The scheduler later dispatches the queued apply to remote Tern and
+// stores Tern's ApplyId as external_id. The resolveApplyID helper translates
+// apply_identifier → external_id before calling Tern.
 //
-// In local mode (client.IsRemote() == false), the LocalClient runs in the
-// same process and writes to the same database as the API layer. It creates
-// the apply record (with no external_id) before ExecuteApply runs.
-// ExecuteApply sees IsRemote() == false and keeps applyIdentifier =
-// resp.ApplyId, leaving external_id empty. LocalClient uses apply_id
-// when provided, falling back to database lookup.
+// In local mode, LocalClient runs in the same process and writes to the same
+// database as the API layer. There is no remote Tern ID, so external_id stays
+// empty and resolveApplyID falls through to the SchemaBot apply_identifier.
 
 import (
 	"context"
@@ -109,6 +107,8 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
+	"github.com/block/schemabot/pkg/engine"
+	"github.com/block/schemabot/pkg/metrics"
 	ternv1 "github.com/block/schemabot/pkg/proto/ternv1"
 	"github.com/block/schemabot/pkg/state"
 	"github.com/block/schemabot/pkg/storage"
@@ -183,7 +183,7 @@ func (c *GRPCClient) IsRemote() bool { return true }
 // Endpoint returns the gRPC dial address for this client.
 func (c *GRPCClient) Endpoint() string { return c.address }
 
-// SetPendingObserver sets an observer consumed by the next Apply() call.
+// SetPendingObserver sets an observer consumed by direct Apply callers.
 func (c *GRPCClient) SetPendingObserver(observer ProgressObserver) {
 	c.observerMu.Lock()
 	defer c.observerMu.Unlock()
@@ -253,6 +253,16 @@ func (c *GRPCClient) consumePendingObserver() ProgressObserver {
 	obs := c.pendingObserver
 	c.pendingObserver = nil
 	return obs
+}
+
+func (c *GRPCClient) registerPendingObserver(applyID int64) {
+	if obs := c.consumePendingObserver(); obs != nil {
+		type applyIDSetter interface{ SetApplyID(int64) }
+		if setter, ok := obs.(applyIDSetter); ok {
+			setter.SetApplyID(applyID)
+		}
+		c.SetObserver(applyID, obs)
+	}
 }
 
 // getObserver returns the observer for an apply, or nil.
@@ -350,20 +360,18 @@ func (c *GRPCClient) Health(ctx context.Context) error {
 	return err
 }
 
-// ResumeApply starts background progress tracking for an apply.
-//
-// Called from two places:
-//   - ExecuteApply (fresh apply): the apply was just created in SchemaBot's
-//     storage but the background poller hasn't started yet. State is "pending".
-//   - RecoverInProgress (crash recovery): the apply's heartbeat expired,
-//     indicating the previous poller died. State may be "stopped" (needs
-//     Start RPC) or still "running"/"pending" (just needs a new poller).
-//
-// In contrast, LocalClient doesn't need this — it starts its own poller
-// inside LocalClient.Apply() because it shares the same storage.
+// ResumeApply starts or resumes background tracking for work claimed by the
+// scheduler. Fresh queued applies have no external_id yet, so this method first
+// dispatches them to remote Tern and stores the returned ID. Stale remote
+// applies already have external_id and only need progress tracking or control
+// RPCs restored.
 func (c *GRPCClient) ResumeApply(ctx context.Context, apply *storage.Apply) error {
 	if c.storage == nil {
 		return fmt.Errorf("storage not configured for GRPCClient")
+	}
+
+	if apply.ExternalID == "" && !state.IsTerminalApplyState(apply.State) {
+		return c.dispatchPendingApply(ctx, apply)
 	}
 
 	// Check the real state from Tern before deciding what to do. Local state
@@ -406,6 +414,159 @@ func (c *GRPCClient) ResumeApply(ctx context.Context, apply *storage.Apply) erro
 	go c.pollForCompletion(context.Background(), apply)
 
 	return nil
+}
+
+func (c *GRPCClient) dispatchPendingApply(ctx context.Context, apply *storage.Apply) error {
+	plan, err := c.storage.Plans().GetByID(ctx, apply.PlanID)
+	if err != nil {
+		c.markDispatchFailed(ctx, apply, nil, fmt.Sprintf("queued gRPC apply failed: load plan %d: %v", apply.PlanID, err), false)
+		return fmt.Errorf("load plan %d for queued gRPC apply %s: %w", apply.PlanID, apply.ApplyIdentifier, err)
+	}
+	if plan == nil {
+		errMsg := fmt.Sprintf("queued gRPC apply failed: plan %d not found", apply.PlanID)
+		c.markDispatchFailed(ctx, apply, nil, errMsg, false)
+		return fmt.Errorf("queued gRPC apply %s: %s", apply.ApplyIdentifier, errMsg)
+	}
+
+	tasks, err := c.storage.Tasks().GetByApplyID(ctx, apply.ID)
+	if err != nil {
+		c.markDispatchFailed(ctx, apply, nil, fmt.Sprintf("queued gRPC apply failed: load tasks: %v", err), false)
+		return fmt.Errorf("load tasks for queued gRPC apply %s: %w", apply.ApplyIdentifier, err)
+	}
+	if len(tasks) == 0 {
+		errMsg := "queued gRPC apply failed: no tasks found"
+		c.markDispatchFailed(ctx, apply, nil, errMsg, false)
+		return fmt.Errorf("queued gRPC apply %s: %s", apply.ApplyIdentifier, errMsg)
+	}
+	if err := c.prepareDispatchTasks(ctx, apply, tasks); err != nil {
+		return err
+	}
+
+	options := apply.GetOptions().Map()
+	target := options["target"]
+	if target == "" {
+		target = apply.Database
+	}
+
+	resp, err := c.client.Apply(ctx, &ternv1.ApplyRequest{
+		PlanId:      plan.PlanIdentifier,
+		Options:     options,
+		Database:    apply.Database,
+		Type:        apply.DatabaseType,
+		DdlChanges:  tasksToProtoTableChanges(tasks),
+		Environment: apply.Environment,
+		Target:      target,
+		Caller:      apply.Caller,
+	})
+	if err != nil {
+		c.markDispatchFailed(ctx, apply, tasks, err.Error(), engine.IsRetryable(err))
+		return fmt.Errorf("apply queued gRPC apply %s: %w", apply.ApplyIdentifier, err)
+	}
+	if resp == nil {
+		errMsg := "remote apply returned nil response"
+		c.markDispatchFailed(ctx, apply, tasks, errMsg, false)
+		return fmt.Errorf("apply queued gRPC apply %s: %s", apply.ApplyIdentifier, errMsg)
+	}
+	if !resp.Accepted {
+		errMsg := resp.ErrorMessage
+		if errMsg == "" {
+			errMsg = "remote apply was not accepted"
+		}
+		c.markDispatchFailed(ctx, apply, tasks, errMsg, false)
+		return fmt.Errorf("apply queued gRPC apply %s: %s", apply.ApplyIdentifier, errMsg)
+	}
+	if resp.ApplyId == "" {
+		errMsg := "remote apply accepted without apply_id"
+		c.markDispatchFailed(ctx, apply, tasks, errMsg, false)
+		return fmt.Errorf("apply queued gRPC apply %s: %s", apply.ApplyIdentifier, errMsg)
+	}
+
+	now := time.Now()
+	apply.ExternalID = resp.ApplyId
+	apply.State = state.Apply.Running
+	apply.ErrorMessage = ""
+	apply.CompletedAt = nil
+	if apply.StartedAt == nil {
+		apply.StartedAt = &now
+	}
+	apply.UpdatedAt = now
+	if err := c.storage.Applies().Update(ctx, apply); err != nil {
+		return fmt.Errorf("store remote apply id for %s: %w", apply.ApplyIdentifier, err)
+	}
+
+	c.registerPendingObserver(apply.ID)
+	go c.pollForCompletion(context.Background(), apply)
+	return nil
+}
+
+func (c *GRPCClient) prepareDispatchTasks(ctx context.Context, apply *storage.Apply, tasks []*storage.Task) error {
+	for _, task := range tasks {
+		if task.State != state.Task.FailedRetryable {
+			continue
+		}
+		task.State = state.Task.Pending
+		task.ErrorMessage = ""
+		task.CompletedAt = nil
+		task.Attempt++
+		if err := c.storage.Tasks().Update(ctx, task); err != nil {
+			return fmt.Errorf("reset retryable task %s for queued gRPC apply %s: %w", task.TaskIdentifier, apply.ApplyIdentifier, err)
+		}
+	}
+	return nil
+}
+
+func tasksToProtoTableChanges(tasks []*storage.Task) []*ternv1.TableChange {
+	changes := make([]*ternv1.TableChange, 0, len(tasks))
+	for _, task := range tasks {
+		changes = append(changes, &ternv1.TableChange{
+			TableName:  task.TableName,
+			Ddl:        task.DDL,
+			ChangeType: ddlActionToProtoChangeType(task.DDLAction),
+			Namespace:  task.Namespace,
+		})
+	}
+	return changes
+}
+
+func (c *GRPCClient) markDispatchFailed(ctx context.Context, apply *storage.Apply, tasks []*storage.Task, message string, retryable bool) {
+	now := time.Now()
+	taskState := state.Task.Failed
+	applyState := state.Apply.Failed
+	if retryable {
+		taskState = state.Task.FailedRetryable
+		applyState = state.Apply.FailedRetryable
+	}
+	for _, task := range tasks {
+		if state.IsTerminalTaskState(task.State) {
+			continue
+		}
+		task.State = taskState
+		task.ErrorMessage = message
+		if !retryable {
+			task.CompletedAt = &now
+		}
+		task.UpdatedAt = now
+		if err := c.storage.Tasks().Update(ctx, task); err != nil {
+			slog.Error("failed to update task after gRPC dispatch failure",
+				"apply_id", apply.ApplyIdentifier,
+				"task_id", task.TaskIdentifier,
+				"error", err)
+		}
+	}
+	apply.State = applyState
+	apply.ErrorMessage = message
+	if !retryable {
+		apply.CompletedAt = &now
+	}
+	apply.UpdatedAt = now
+	if err := c.storage.Applies().Update(ctx, apply); err != nil {
+		slog.Error("failed to update apply after gRPC dispatch failure",
+			"apply_id", apply.ApplyIdentifier,
+			"error", err)
+	}
+	if !retryable {
+		metrics.AdjustActiveApplies(ctx, -1, apply.Database, apply.Environment)
+	}
 }
 
 // pollForCompletion polls the remote Tern for progress and updates SchemaBot's storage.
@@ -471,6 +632,7 @@ func (c *GRPCClient) pollForCompletion(ctx context.Context, apply *storage.Apply
 			}
 			_ = c.storage.Applies().Update(ctx, apply)
 			if terminal {
+				metrics.AdjustActiveApplies(ctx, -1, apply.Database, apply.Environment)
 				return
 			}
 		}

--- a/pkg/tern/local_apply.go
+++ b/pkg/tern/local_apply.go
@@ -339,10 +339,14 @@ func (c *LocalClient) executeApplyAtomic(ctx context.Context, apply *storage.App
 	})
 
 	if err != nil {
-		c.failApplyWithTasks(ctx, apply, tasks, err.Error())
+		c.failApplyWithTasks(ctx, apply, tasks, err.Error(), err)
+		newState := state.Apply.Failed
+		if engine.IsRetryable(err) {
+			newState = state.Apply.FailedRetryable
+		}
 		c.logger.Error("atomic apply failed", "error", err, "apply_id", apply.ApplyIdentifier)
 		c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelError, storage.LogEventError, storage.LogSourceSchemaBot,
-			fmt.Sprintf("Engine apply failed: %v", err), state.Apply.Pending, state.Apply.Failed)
+			fmt.Sprintf("Engine apply failed: %v", err), state.Apply.Pending, newState)
 		return
 	}
 
@@ -531,7 +535,7 @@ func (c *LocalClient) runEngineTask(ctx context.Context, task *storage.Task, pla
 	})
 
 	if err != nil {
-		c.markTaskFailed(ctx, task, err.Error())
+		c.markTaskFailed(ctx, task, err.Error(), err)
 		c.logger.Error("task failed", "error", err, "task_id", task.TaskIdentifier, "table", task.TableName)
 		return taskFailed
 	}
@@ -551,7 +555,7 @@ func (c *LocalClient) runEngineTask(ctx context.Context, task *storage.Task, pla
 	c.pollTaskToCompletion(ctx, task, creds)
 
 	switch task.State {
-	case state.Task.Failed:
+	case state.Task.Failed, state.Task.FailedRetryable:
 		return taskFailed
 	case state.Task.Stopped:
 		return taskStopped
@@ -645,7 +649,7 @@ func (c *LocalClient) handleAtomicProgressTick(ctx context.Context, eng engine.E
 		if errors.As(err, &permanent) {
 			c.logger.Error("progress check failed with permanent error",
 				"error", err, "apply_id", apply.ApplyIdentifier)
-			c.failApplyWithTasks(ctx, apply, tasks, fmt.Sprintf("progress polling failed: %v", err))
+			c.failApplyWithTasks(ctx, apply, tasks, fmt.Sprintf("progress polling failed: %v", err), err)
 			return true
 		}
 		ps.consecutiveErrors++
@@ -654,7 +658,7 @@ func (c *LocalClient) handleAtomicProgressTick(ctx context.Context, eng engine.E
 		if ps.consecutiveErrors >= 10 {
 			c.logger.Error("progress polling failed repeatedly, failing apply",
 				"apply_id", apply.ApplyIdentifier, "consecutive_errors", ps.consecutiveErrors)
-			c.failApplyWithTasks(ctx, apply, tasks, fmt.Sprintf("progress polling failed after %d consecutive errors: %v", ps.consecutiveErrors, err))
+			c.failApplyWithTasks(ctx, apply, tasks, fmt.Sprintf("progress polling failed after %d consecutive errors: %v", ps.consecutiveErrors, err), err)
 			return true
 		}
 		return false
@@ -668,7 +672,7 @@ func (c *LocalClient) handleAtomicProgressTick(ctx context.Context, eng engine.E
 	}
 
 	now := time.Now()
-	newState := engineStateToStorage(result.State)
+	newState := c.engineResultTaskState(result)
 
 	// Log state transitions and track when waiting states are entered (for timeouts)
 	if newState != ps.lastTaskState {
@@ -781,20 +785,27 @@ func (c *LocalClient) handleAtomicProgressTick(ctx context.Context, eng engine.E
 	apply.State = taskStateToApplyState(newState)
 	apply.UpdatedAt = now
 
+	if isRetryableProgressFailure(result, newState) {
+		apply.CompletedAt = nil
+		apply.ErrorMessage = c.applyErrorMessage(result, tasks)
+		if err := c.storage.Applies().Update(ctx, apply); err != nil {
+			c.logger.Error("failed to update retryable apply state", "apply_id", apply.ApplyIdentifier, "state", apply.State, "error", err)
+		}
+		c.logger.Info("apply marked retryable for scheduler recovery",
+			"apply_id", apply.ApplyIdentifier, "source", "progress_poll", "error", apply.ErrorMessage)
+		c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventStateTransition, storage.LogSourceSchemaBot,
+			fmt.Sprintf("Apply failed with retryable engine error: %s", apply.ErrorMessage), ps.lastTaskState, apply.State)
+		if obs := c.getObserver(apply.ID); obs != nil {
+			obs.OnProgress(apply, tasks)
+		}
+		return true
+	}
+
 	if result.State.IsTerminal() {
 		apply.CompletedAt = &now
 		// Propagate error message from failed tasks to the apply record
 		if result.State == engine.StateFailed {
-			if result.ErrorMessage != "" {
-				apply.ErrorMessage = result.ErrorMessage
-			} else {
-				for _, task := range tasks {
-					if task.State == state.Task.Failed && task.ErrorMessage != "" {
-						apply.ErrorMessage = fmt.Sprintf("table %s failed: %s", task.TableName, task.ErrorMessage)
-						break
-					}
-				}
-			}
+			apply.ErrorMessage = c.applyErrorMessage(result, tasks)
 		}
 		if err := c.storage.Applies().Update(ctx, apply); err != nil {
 			c.logger.Error("failed to update apply state", "apply_id", apply.ApplyIdentifier, "state", apply.State, "error", err)
@@ -827,6 +838,33 @@ func (c *LocalClient) handleAtomicProgressTick(ctx context.Context, eng engine.E
 		obs.OnProgress(apply, tasks)
 	}
 	return false
+}
+
+func (c *LocalClient) applyErrorMessage(result *engine.ProgressResult, tasks []*storage.Task) string {
+	if result.ErrorMessage != "" {
+		return result.ErrorMessage
+	}
+	for _, task := range tasks {
+		if (task.State == state.Task.Failed || task.State == state.Task.FailedRetryable) && task.ErrorMessage != "" {
+			return fmt.Sprintf("table %s failed: %s", task.TableName, task.ErrorMessage)
+		}
+	}
+	return result.Message
+}
+
+func progressErrorMessage(result *engine.ProgressResult) string {
+	if result.ErrorMessage != "" {
+		return result.ErrorMessage
+	}
+	return result.Message
+}
+
+func (c *LocalClient) engineResultTaskState(result *engine.ProgressResult) string {
+	taskState := engineStateToStorage(result.State)
+	if result.State == engine.StateFailed && result.Retryable {
+		return state.Task.FailedRetryable
+	}
+	return taskState
 }
 
 // markRevertSkipped sets RevertSkippedAt on the VitessApplyData record so
@@ -934,7 +972,9 @@ func (c *LocalClient) syncAtomicTaskProgress(ctx context.Context, tasks []*stora
 		if task.StartedAt == nil && newState != state.Task.Pending {
 			task.StartedAt = &now
 		}
-		if result.State.IsTerminal() && task.CompletedAt == nil {
+		if isRetryableProgressFailure(result, newState) {
+			task.CompletedAt = nil
+		} else if result.State.IsTerminal() && task.CompletedAt == nil {
 			task.CompletedAt = &now
 		}
 		if result.State == engine.StateFailed && task.ErrorMessage == "" {
@@ -1018,7 +1058,7 @@ func (c *LocalClient) pollTaskToCompletion(ctx context.Context, task *storage.Ta
 
 			now := time.Now()
 			prevState := task.State
-			task.State = engineStateToStorage(result.State)
+			task.State = c.engineResultTaskState(result)
 			task.UpdatedAt = now
 
 			// Update progress fields from engine result
@@ -1030,6 +1070,29 @@ func (c *LocalClient) pollTaskToCompletion(ctx context.Context, task *storage.Ta
 				task.ProgressPercent = tp.Progress
 				task.ETASeconds = int(tp.ETASeconds)
 				task.IsInstant = tp.IsInstant
+			}
+
+			if isRetryableProgressFailure(result, task.State) {
+				task.CompletedAt = nil
+				if result.ErrorMessage != "" {
+					task.ErrorMessage = result.ErrorMessage
+				} else if result.Message != "" {
+					task.ErrorMessage = result.Message
+				}
+				logMsg := ""
+				if task.ApplyID > 0 {
+					logMsg = fmt.Sprintf("Task %s failed with retryable engine error: %s",
+						task.TaskIdentifier, task.ErrorMessage)
+				}
+				c.transitionTaskState(ctx, task, task.ApplyID, task.State, logMsg)
+				c.logger.Info("task marked retryable for scheduler recovery",
+					"task_id", task.TaskIdentifier,
+					"table", task.TableName,
+					"engine_state", result.State,
+					"engine_message", result.Message,
+					"prev_storage_state", prevState,
+				)
+				return
 			}
 
 			if result.State.IsTerminal() {
@@ -1049,7 +1112,7 @@ func (c *LocalClient) pollTaskToCompletion(ctx context.Context, task *storage.Ta
 					logMsg = fmt.Sprintf("Task %s completed: engine_state=%s message=%q rows=%d/%d",
 						task.TaskIdentifier, result.State, result.Message, task.RowsCopied, task.RowsTotal)
 				}
-				c.transitionTaskState(ctx, task, task.ApplyID, engineStateToStorage(result.State), logMsg)
+				c.transitionTaskState(ctx, task, task.ApplyID, task.State, logMsg)
 				c.logger.Info("task completed",
 					"task_id", task.TaskIdentifier,
 					"table", task.TableName,
@@ -1076,19 +1139,33 @@ func (c *LocalClient) pollTaskToCompletion(ctx context.Context, task *storage.Ta
 	}
 }
 
-// markTaskFailed sets a task to FAILED state with the given error message and persists it.
-func (c *LocalClient) markTaskFailed(ctx context.Context, task *storage.Task, errMsg string) {
+// markTaskFailed sets a task to the failed state that matches the engine error.
+func (c *LocalClient) markTaskFailed(ctx context.Context, task *storage.Task, errMsg string, originalErr ...error) {
 	now := time.Now()
+	taskState := state.Task.Failed
+	if len(originalErr) > 0 && originalErr[0] != nil && engine.IsRetryable(originalErr[0]) {
+		taskState = state.Task.FailedRetryable
+		task.CompletedAt = nil
+	} else {
+		task.CompletedAt = &now
+	}
 	task.ErrorMessage = errMsg
-	task.CompletedAt = &now
-	c.transitionTaskState(ctx, task, 0, state.Task.Failed, "")
+	c.transitionTaskState(ctx, task, 0, taskState, "")
 }
 
 // failApplyWithTasks marks all tasks and the apply as failed with the given error.
 // If the apply is already in a terminal state (e.g., cancelled by Stop()), the
 // apply state is not overwritten.
-func (c *LocalClient) failApplyWithTasks(ctx context.Context, apply *storage.Apply, tasks []*storage.Task, errMsg string) {
+func (c *LocalClient) failApplyWithTasks(ctx context.Context, apply *storage.Apply, tasks []*storage.Task, errMsg string, originalErr ...error) {
 	now := time.Now()
+	retryable := len(originalErr) > 0 && originalErr[0] != nil && engine.IsRetryable(originalErr[0])
+	taskState := state.Task.Failed
+	applyState := state.Apply.Failed
+	if retryable {
+		taskState = state.Task.FailedRetryable
+		applyState = state.Apply.FailedRetryable
+	}
+
 	for _, task := range tasks {
 		if state.IsTerminalTaskState(task.State) {
 			continue
@@ -1096,8 +1173,10 @@ func (c *LocalClient) failApplyWithTasks(ctx context.Context, apply *storage.App
 		if task.ErrorMessage == "" {
 			task.ErrorMessage = errMsg
 		}
-		task.CompletedAt = &now
-		c.transitionTaskState(ctx, task, 0, state.Task.Failed, "")
+		if !retryable {
+			task.CompletedAt = &now
+		}
+		c.transitionTaskState(ctx, task, 0, taskState, "")
 	}
 
 	// Re-read the apply from storage — Stop() may have already set a terminal
@@ -1109,12 +1188,21 @@ func (c *LocalClient) failApplyWithTasks(ctx context.Context, apply *storage.App
 		return
 	}
 
-	apply.State = state.Apply.Failed
+	apply.State = applyState
 	apply.ErrorMessage = errMsg
-	apply.CompletedAt = &now
+	if !retryable {
+		apply.CompletedAt = &now
+	} else {
+		apply.CompletedAt = nil
+	}
 	apply.UpdatedAt = now
 	if err := c.storage.Applies().Update(ctx, apply); err != nil {
-		c.logger.Error("failed to update apply state", "apply_id", apply.ApplyIdentifier, "state", state.Apply.Failed, "error", err)
+		c.logger.Error("failed to update apply state", "apply_id", apply.ApplyIdentifier, "state", applyState, "error", err)
+	}
+	if retryable {
+		c.logger.Info("apply marked retryable for scheduler recovery",
+			"apply_id", apply.ApplyIdentifier, "attempt", apply.Attempt, "error", errMsg)
+		return
 	}
 	metrics.AdjustActiveApplies(ctx, -1, apply.Database, apply.Environment)
 }
@@ -1125,12 +1213,16 @@ func (c *LocalClient) finalizeSequentialApply(ctx context.Context, apply *storag
 	now := time.Now()
 	switch {
 	case failedTask != nil:
-		apply.State = state.Apply.Failed
+		apply.State = taskStateToApplyState(failedTask.State)
 		apply.ErrorMessage = fmt.Sprintf("table %s failed: %s", failedTask.TableName, failedTask.ErrorMessage)
-		apply.CompletedAt = &now
-		for _, task := range tasks {
-			if task.State == state.Task.Pending {
-				c.transitionTaskState(ctx, task, 0, state.Task.Cancelled, "")
+		if failedTask.State == state.Task.FailedRetryable {
+			apply.CompletedAt = nil
+		} else {
+			apply.CompletedAt = &now
+			for _, task := range tasks {
+				if task.State == state.Task.Pending {
+					c.transitionTaskState(ctx, task, 0, state.Task.Cancelled, "")
+				}
 			}
 		}
 	case stoppedByUser:
@@ -1143,10 +1235,12 @@ func (c *LocalClient) finalizeSequentialApply(ctx context.Context, apply *storag
 	if err := c.storage.Applies().Update(ctx, apply); err != nil {
 		c.logger.Error("failed to update apply state", "apply_id", apply.ApplyIdentifier, "state", apply.State, "error", err)
 	}
-	metrics.AdjustActiveApplies(ctx, -1, apply.Database, apply.Environment)
+	if state.IsTerminalApplyState(apply.State) {
+		metrics.AdjustActiveApplies(ctx, -1, apply.Database, apply.Environment)
+	}
 
 	// Notify observer of terminal state, then clean up
-	if obs := c.getObserver(apply.ID); obs != nil {
+	if obs := c.getObserver(apply.ID); obs != nil && state.IsTerminalApplyState(apply.State) {
 		obs.OnTerminal(apply, tasks)
 		c.clearObserver(apply.ID)
 	}
@@ -1155,16 +1249,16 @@ func (c *LocalClient) finalizeSequentialApply(ctx context.Context, apply *storag
 // deriveOverallState determines the overall state from a list of tasks.
 // Priority order:
 // 1. RUNNING/WAITING_FOR_CUTOVER/CUTTING_OVER - active work in progress
-// 2. PENDING - more work queued
-// 3. STOPPED - apply was stopped (even if some tasks completed)
-// 4. FAILED - at least one task failed (CANCELLED tasks also indicate failure)
+// 2. FAILED/FAILED_RETRYABLE - work halted until user or scheduler action
+// 3. PENDING - more work queued
+// 4. STOPPED - apply was stopped (even if some tasks completed)
 // 5. COMPLETED - all tasks completed successfully
 func deriveOverallState(tasks []*storage.Task) string {
 	if len(tasks) == 0 {
 		return state.Task.Pending
 	}
 
-	var hasRunning, hasPending, hasStopped, hasFailed, hasCancelled, hasCompleted, hasRevertWindow bool
+	var hasRunning, hasPending, hasStopped, hasFailed, hasFailedRetryable, hasCancelled, hasCompleted, hasRevertWindow bool
 	var runningState string
 
 	for _, t := range tasks {
@@ -1184,6 +1278,8 @@ func deriveOverallState(tasks []*storage.Task) string {
 			hasStopped = true
 		case state.Task.Failed:
 			hasFailed = true
+		case state.Task.FailedRetryable:
+			hasFailedRetryable = true
 		case state.Task.Cancelled:
 			hasCancelled = true
 		case state.Task.Completed:
@@ -1197,16 +1293,23 @@ func deriveOverallState(tasks []*storage.Task) string {
 	if hasRunning {
 		return runningState
 	}
+	if hasFailed {
+		// A permanent task failure makes the whole apply permanently failed.
+		return state.Task.Failed
+	}
+	if hasCancelled {
+		// Sequential execution cancels later tasks after an earlier task fails.
+		// User-initiated Vitess cancellations set the apply state directly.
+		return state.Task.Failed
+	}
+	if hasFailedRetryable {
+		return state.Task.FailedRetryable
+	}
 	if hasPending {
 		return state.Task.Pending
 	}
 	if hasStopped {
 		return state.Task.Stopped
-	}
-	if hasFailed || hasCancelled {
-		// Cancelled implies a prior task failed (sequential mode), so overall is failed.
-		// For Vitess cancellation (user-initiated), the apply state is set directly.
-		return state.Task.Failed
 	}
 	if hasRevertWindow {
 		return state.Task.RevertWindow

--- a/pkg/tern/local_client.go
+++ b/pkg/tern/local_client.go
@@ -151,8 +151,8 @@ type LocalClient struct {
 	observerMu sync.RWMutex
 	observers  map[int64]ProgressObserver // keyed by apply ID
 
-	// pendingObserver is consumed by the next Apply() call and registered
-	// before Spirit starts. Set by the webhook handler via SetPendingObserver.
+	// pendingObserver is consumed by direct Apply callers and registered before
+	// Spirit starts.
 	// Protected by observerMu.
 	pendingObserver ProgressObserver
 }
@@ -478,20 +478,7 @@ func (c *LocalClient) Apply(ctx context.Context, req *ternv1.ApplyRequest) (*ter
 		caller = options["caller"]
 	}
 
-	// Detect atomic mode (--defer-cutover)
-	deferCutover := options["defer_cutover"] == "true"
-	allowUnsafe := options["allow_unsafe"] == "true"
-
-	// Build typed ApplyOptions for storage (booleans, not strings).
-	// Revert window is ON by default — only disabled when skip_revert is explicitly set.
-	skipRevert := options["skip_revert"] == "true"
-	deferDeploy := options["defer_deploy"] == "true"
-	applyOpts := storage.ApplyOptions{
-		DeferCutover: deferCutover,
-		DeferDeploy:  deferDeploy,
-		AllowUnsafe:  allowUnsafe,
-		SkipRevert:   skipRevert,
-	}
+	applyOpts := storage.ApplyOptionsFromMap(options)
 	optionsJSON := storage.MarshalApplyOptions(applyOpts)
 
 	// Create Apply record first (1 Apply -> N Tasks)
@@ -578,25 +565,16 @@ func (c *LocalClient) Apply(ctx context.Context, req *ternv1.ApplyRequest) (*ter
 		tasks[i].ID = taskID
 	}
 
-	// Register pending observer before starting the engine — prevents race where
-	// the apply completes before the observer is set. The webhook handler calls
-	// SetPendingObserver before triggering the apply API call.
-	if obs := c.consumePendingObserver(); obs != nil {
-		// Set the apply ID on the observer if it supports it (e.g., CommentObserver
-		// needs the ID to look up tracked comments for editing).
-		type applyIDSetter interface{ SetApplyID(int64) }
-		if setter, ok := obs.(applyIDSetter); ok {
-			setter.SetApplyID(apply.ID)
-		}
-		c.SetObserver(apply.ID, obs)
-	}
+	// Register pending observer before starting the engine to prevent the apply
+	// completing before the observer is set.
+	c.registerPendingObserver(apply.ID)
 
 	// Start apply in background with cancellable context (Stop() cancels this)
 	applyCtx, cancelApply := context.WithCancel(context.WithoutCancel(ctx))
 	c.cancelMu.Lock()
 	c.cancelApply = cancelApply
 	c.cancelMu.Unlock()
-	if deferCutover || c.config.Type == storage.DatabaseTypeVitess {
+	if applyOpts.DeferCutover || c.config.Type == storage.DatabaseTypeVitess {
 		// Atomic mode: all DDLs in one engine call.
 		// For Spirit: atomic cutover (--defer-cutover).
 		// For Vitess: always atomic — one deploy request per apply.
@@ -770,19 +748,15 @@ func (c *LocalClient) Progress(ctx context.Context, req *ternv1.ProgressRequest)
 		if err == nil {
 			engineResult = result
 			c.logger.Info("Progress: engine returned", "engine_state", result.State, "message", result.Message, "task_id", activeTask.TaskIdentifier, "storage_state", activeTask.State)
+			taskState := c.engineResultTaskState(result)
 
 			// Only update task state from engine if task is not already in a terminal state.
 			// Terminal states (CANCELLED, COMPLETED, FAILED, etc.) should be preserved -
 			// they represent the final state set by the apply execution.
 			if !state.IsTerminalTaskState(activeTask.State) {
-				activeTask.State = engineStateToStorage(result.State)
-				now := time.Now()
-				activeTask.UpdatedAt = now
-				if result.State.IsTerminal() && activeTask.CompletedAt == nil {
-					activeTask.CompletedAt = &now
-				}
-				if err := c.storage.Tasks().Update(ctx, activeTask); err != nil {
-					c.logger.Warn("failed to update task state from progress poll", "task_id", activeTask.TaskIdentifier, "state", activeTask.State, "error", err)
+				c.syncTaskFromEngineProgress(ctx, activeTask, result, taskState)
+				if isRetryableProgressFailure(result, taskState) {
+					c.syncRetryableApplyFromProgress(ctx, req.ApplyId, result)
 				}
 			}
 
@@ -790,7 +764,7 @@ func (c *LocalClient) Progress(ctx context.Context, req *ternv1.ProgressRequest)
 			// but the apply hasn't been updated yet. Only do this when ALL tasks
 			// for this apply are terminal — in sequential mode, the engine reports
 			// "completed" per-task, but the apply isn't done until all tasks finish.
-			if result.State.IsTerminal() {
+			if result.State.IsTerminal() && !isRetryableProgressFailure(result, taskState) {
 				allTerminal := true
 				for _, t := range currentApplyTasks {
 					if !state.IsTerminalTaskState(t.State) {
@@ -799,8 +773,15 @@ func (c *LocalClient) Progress(ctx context.Context, req *ternv1.ProgressRequest)
 					}
 				}
 				if allTerminal {
-					apply, _ := c.storage.Applies().GetByApplyIdentifier(ctx, req.ApplyId)
-					if apply != nil && !state.IsTerminalApplyState(apply.State) {
+					apply, applyErr := c.storage.Applies().GetByApplyIdentifier(ctx, req.ApplyId)
+					switch {
+					case applyErr != nil:
+						c.logger.Warn("failed to load apply for terminal progress update", "apply_id", req.ApplyId, "error", applyErr)
+					case apply == nil:
+						c.logger.Warn("apply not found for terminal progress update", "apply_id", req.ApplyId)
+					case state.IsTerminalApplyState(apply.State):
+						c.logger.Debug("skipping terminal progress update for terminal apply", "apply_id", apply.ApplyIdentifier, "state", apply.State)
+					default:
 						now := time.Now()
 						apply.State = engineStateToStorage(result.State)
 						apply.CompletedAt = &now
@@ -927,7 +908,7 @@ func (c *LocalClient) Progress(ctx context.Context, req *ternv1.ProgressRequest)
 	// If no error from engine, check stored task errors (for restart recovery)
 	if errorMessage == "" {
 		for _, t := range currentApplyTasks {
-			if t.State == state.Task.Failed && t.ErrorMessage != "" {
+			if (t.State == state.Task.Failed || t.State == state.Task.FailedRetryable) && t.ErrorMessage != "" {
 				errorMessage = t.ErrorMessage
 				break
 			}
@@ -981,6 +962,59 @@ func (c *LocalClient) Progress(ctx context.Context, req *ternv1.ProgressRequest)
 	}
 
 	return resp, nil
+}
+
+func (c *LocalClient) syncTaskFromEngineProgress(ctx context.Context, task *storage.Task, result *engine.ProgressResult, taskState string) {
+	now := time.Now()
+	task.State = taskState
+	task.UpdatedAt = now
+
+	if isRetryableProgressFailure(result, taskState) {
+		task.CompletedAt = nil
+		if task.ErrorMessage == "" {
+			if msg := progressErrorMessage(result); msg != "" {
+				task.ErrorMessage = msg
+			}
+		}
+	} else if result.State.IsTerminal() && task.CompletedAt == nil {
+		task.CompletedAt = &now
+	}
+
+	if err := c.storage.Tasks().Update(ctx, task); err != nil {
+		c.logger.Warn("failed to update task state from progress poll", "task_id", task.TaskIdentifier, "state", task.State, "error", err)
+	}
+}
+
+func isRetryableProgressFailure(result *engine.ProgressResult, taskState string) bool {
+	return result.State == engine.StateFailed && taskState == state.Task.FailedRetryable
+}
+
+func (c *LocalClient) syncRetryableApplyFromProgress(ctx context.Context, applyIdentifier string, result *engine.ProgressResult) {
+	apply, err := c.storage.Applies().GetByApplyIdentifier(ctx, applyIdentifier)
+	switch {
+	case err != nil:
+		c.logger.Warn("failed to load apply for retryable progress update", "apply_id", applyIdentifier, "error", err)
+		return
+	case apply == nil:
+		c.logger.Warn("apply not found for retryable progress update", "apply_id", applyIdentifier)
+		return
+	case state.IsTerminalApplyState(apply.State):
+		c.logger.Debug("skipping retryable progress update for terminal apply", "apply_id", apply.ApplyIdentifier, "state", apply.State)
+		return
+	}
+
+	now := time.Now()
+	apply.State = state.Apply.FailedRetryable
+	apply.CompletedAt = nil
+	apply.UpdatedAt = now
+	if msg := progressErrorMessage(result); msg != "" {
+		apply.ErrorMessage = msg
+	}
+	if err := c.storage.Applies().Update(ctx, apply); err != nil {
+		c.logger.Warn("failed to update retryable apply from progress poll", "apply_id", apply.ApplyIdentifier, "state", apply.State, "apply_db_id", apply.ID, "error", err)
+		return
+	}
+	c.logger.Info("retryable apply state updated from progress polling", "apply_id", apply.ApplyIdentifier, "state", apply.State)
 }
 
 func ensureMetadata(m map[string]string) map[string]string {

--- a/pkg/tern/local_client_integration_test.go
+++ b/pkg/tern/local_client_integration_test.go
@@ -1143,13 +1143,12 @@ func TestLocalClient_Apply_AtomicRejectsMultiNamespace(t *testing.T) {
 
 	// The apply should fail with multi-namespace error
 	require.Eventually(t, func() bool {
-		applies, err := stor.Applies().GetByDatabase(ctx, "testdb", "mysql", "")
-		if err != nil || len(applies) == 0 {
+		apply, err := stor.Applies().GetByApplyIdentifier(ctx, applyResp.ApplyId)
+		if err != nil || apply == nil {
 			return false
 		}
-		latest := applies[0]
-		return latest.State == state.Apply.Failed &&
-			strings.Contains(latest.ErrorMessage, "one namespace per apply")
+		return apply.State == state.Apply.Failed &&
+			strings.Contains(apply.ErrorMessage, "one namespace per apply")
 	}, 10*time.Second, 200*time.Millisecond, "apply should fail with multi-namespace error")
 }
 
@@ -1224,17 +1223,18 @@ func TestLocalClient_Apply_SequentialNamespaceMatchesTask(t *testing.T) {
 
 	// Wait for completion
 	require.Eventually(t, func() bool {
-		applies, _ := stor.Applies().GetByDatabase(ctx, "testdb", "mysql", "")
-		if len(applies) == 0 {
+		apply, err := stor.Applies().GetByApplyIdentifier(ctx, applyResp.ApplyId)
+		if err != nil || apply == nil {
 			return false
 		}
-		return applies[0].State == state.Apply.Completed
+		return apply.State == state.Apply.Completed
 	}, 30*time.Second, 500*time.Millisecond, "apply should complete")
 
 	// Verify task has correct namespace and progress was persisted
-	applies, _ := stor.Applies().GetByDatabase(ctx, "testdb", "mysql", "")
-	require.NotEmpty(t, applies)
-	tasks, err := stor.Tasks().GetByApplyID(ctx, applies[0].ID)
+	apply, err := stor.Applies().GetByApplyIdentifier(ctx, applyResp.ApplyId)
+	require.NoError(t, err)
+	require.NotNil(t, apply)
+	tasks, err := stor.Tasks().GetByApplyID(ctx, apply.ID)
 	require.NoError(t, err)
 	require.NotEmpty(t, tasks)
 
@@ -1244,9 +1244,10 @@ func TestLocalClient_Apply_SequentialNamespaceMatchesTask(t *testing.T) {
 	assert.Equal(t, state.Task.Completed, task.State)
 }
 
-// TestLocalClient_Apply_FailedAtomicHasErrorMessage verifies that when an atomic
-// apply fails, the error message propagates to the apply record. Uses a plan
-// with an invalid DDL (ALTER on nonexistent table) to trigger a Spirit failure.
+// TestLocalClient_Apply_FailedAtomicHasErrorMessage verifies that a retryable
+// atomic apply failure keeps the error message on the apply record. The plan
+// uses an ALTER on a nonexistent table so the failure happens during Spirit
+// execution.
 func TestLocalClient_Apply_FailedAtomicHasErrorMessage(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
@@ -1294,23 +1295,25 @@ func TestLocalClient_Apply_FailedAtomicHasErrorMessage(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, applyResp.Accepted, "apply should be accepted: %s", applyResp.ErrorMessage)
 
-	// Wait for failure
+	// Wait for the retryable failure state the scheduler can claim later.
 	require.Eventually(t, func() bool {
-		applies, _ := stor.Applies().GetByDatabase(ctx, "testdb", "mysql", "")
-		if len(applies) == 0 {
+		apply, err := stor.Applies().GetByApplyIdentifier(ctx, applyResp.ApplyId)
+		if err != nil || apply == nil {
 			return false
 		}
-		return applies[0].State == state.Apply.Failed
-	}, 30*time.Second, 500*time.Millisecond, "apply should fail")
+		return apply.State == state.Apply.FailedRetryable
+	}, 30*time.Second, 500*time.Millisecond, "apply should fail retryably")
 
-	applies, _ := stor.Applies().GetByDatabase(ctx, "testdb", "mysql", "")
-	require.NotEmpty(t, applies)
-	assert.NotEmpty(t, applies[0].ErrorMessage, "apply.ErrorMessage should contain the failure reason")
-	t.Logf("apply error: %s", applies[0].ErrorMessage)
+	apply, err := stor.Applies().GetByApplyIdentifier(ctx, applyResp.ApplyId)
+	require.NoError(t, err)
+	require.NotNil(t, apply)
+	assert.NotEmpty(t, apply.ErrorMessage, "apply.ErrorMessage should contain the failure reason")
+	t.Logf("apply error: %s", apply.ErrorMessage)
 
 	// Verify task also has error
-	tasks, err := stor.Tasks().GetByApplyID(ctx, applies[0].ID)
+	tasks, err := stor.Tasks().GetByApplyID(ctx, apply.ID)
 	require.NoError(t, err)
 	require.NotEmpty(t, tasks)
+	assert.Equal(t, state.Task.FailedRetryable, tasks[0].State)
 	assert.NotEmpty(t, tasks[0].ErrorMessage, "task.ErrorMessage should contain the failure reason")
 }

--- a/pkg/tern/local_control.go
+++ b/pkg/tern/local_control.go
@@ -2,7 +2,6 @@ package tern
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"time"
 
@@ -53,7 +52,13 @@ func (c *LocalClient) Cutover(ctx context.Context, req *ternv1.CutoverRequest) (
 	c.logApplyEvent(ctx, task.ApplyID, nil, storage.LogLevelInfo, storage.LogEventCutoverTriggered, storage.LogSourceSchemaBot,
 		"Cutover triggered", "", "")
 
-	_, err = eng.Cutover(ctx, c.buildControlRequest(ctx, task, creds))
+	controlReq, err := c.buildControlRequest(ctx, task, creds)
+	if err != nil {
+		c.logApplyEvent(ctx, task.ApplyID, nil, storage.LogLevelError, storage.LogEventError, storage.LogSourceSchemaBot,
+			fmt.Sprintf("Cutover failed: %v", err), "", "")
+		return nil, fmt.Errorf("cutover failed: %w", err)
+	}
+	_, err = eng.Cutover(ctx, controlReq)
 	if err != nil {
 		c.logApplyEvent(ctx, task.ApplyID, nil, storage.LogLevelError, storage.LogEventError, storage.LogSourceSchemaBot,
 			fmt.Sprintf("Cutover failed: %v", err), "", "")
@@ -166,7 +171,10 @@ func (c *LocalClient) stopEngineForTasks(ctx context.Context, eng engine.Engine,
 		if task.State == state.Task.Running ||
 			task.State == state.Task.WaitingForCutover ||
 			task.State == state.Task.CuttingOver {
-			req := c.buildControlRequest(ctx, task, creds)
+			req, err := c.buildControlRequest(ctx, task, creds)
+			if err != nil {
+				return err
+			}
 			if _, err := eng.Stop(ctx, req); err != nil {
 				c.logger.Warn("engine stop returned error (runner may have already exited)",
 					"task_id", task.TaskIdentifier, "error", err)
@@ -293,27 +301,23 @@ func (c *LocalClient) controlSetup(ctx context.Context) (*storage.Task, *engine.
 // buildControlRequest creates a ControlRequest with ResumeState from VitessApplyData.
 // For PlanetScale, the engine needs the deploy request ID (in ResumeState.Metadata)
 // to execute control operations (cutover, revert, skip-revert).
-func (c *LocalClient) buildControlRequest(ctx context.Context, task *storage.Task, creds *engine.Credentials) *engine.ControlRequest {
+func (c *LocalClient) buildControlRequest(ctx context.Context, task *storage.Task, creds *engine.Credentials) (*engine.ControlRequest, error) {
 	req := &engine.ControlRequest{
 		Database:    c.config.Database,
 		Credentials: creds,
 	}
 	if c.config.Type == storage.DatabaseTypeVitess {
-		if vad, err := c.storage.VitessApplyData().GetByApplyID(ctx, task.ApplyID); err == nil {
-			meta, _ := json.Marshal(map[string]any{
-				"branch_name":        vad.BranchName,
-				"deploy_request_id":  vad.DeployRequestID,
-				"deploy_request_url": vad.DeployRequestURL,
-				"is_instant":         vad.IsInstant,
-				"deferred_deploy":    vad.DeferredDeploy,
-			})
-			req.ResumeState = &engine.ResumeState{
-				MigrationContext: vad.MigrationContext,
-				Metadata:         string(meta),
-			}
+		vad, err := c.storage.VitessApplyData().GetByApplyID(ctx, task.ApplyID)
+		if err != nil {
+			return nil, fmt.Errorf("load Vitess apply data for control task %s: %w", task.TaskIdentifier, err)
 		}
+		resumeState, err := vitessApplyDataResumeState(vad, task.TaskIdentifier)
+		if err != nil {
+			return nil, fmt.Errorf("build Vitess resume state for control task %s: %w", task.TaskIdentifier, err)
+		}
+		req.ResumeState = resumeState
 	}
-	return req
+	return req, nil
 }
 
 // Volume modifies the schema change speed/concurrency in-flight.
@@ -350,7 +354,11 @@ func (c *LocalClient) Revert(ctx context.Context, req *ternv1.RevertRequest) (*t
 		return nil, err
 	}
 
-	if _, err = eng.Revert(ctx, c.buildControlRequest(ctx, task, creds)); err != nil {
+	controlReq, err := c.buildControlRequest(ctx, task, creds)
+	if err != nil {
+		return nil, fmt.Errorf("revert failed: %w", err)
+	}
+	if _, err = eng.Revert(ctx, controlReq); err != nil {
 		return nil, fmt.Errorf("revert failed: %w", err)
 	}
 	return &ternv1.RevertResponse{Accepted: true}, nil
@@ -363,7 +371,11 @@ func (c *LocalClient) SkipRevert(ctx context.Context, req *ternv1.SkipRevertRequ
 		return nil, err
 	}
 
-	if _, err = eng.SkipRevert(ctx, c.buildControlRequest(ctx, task, creds)); err != nil {
+	controlReq, err := c.buildControlRequest(ctx, task, creds)
+	if err != nil {
+		return nil, fmt.Errorf("skip revert failed: %w", err)
+	}
+	if _, err = eng.SkipRevert(ctx, controlReq); err != nil {
 		return nil, fmt.Errorf("skip revert failed: %w", err)
 	}
 	return &ternv1.SkipRevertResponse{Accepted: true}, nil

--- a/pkg/tern/local_control_resume.go
+++ b/pkg/tern/local_control_resume.go
@@ -2,10 +2,13 @@ package tern
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"sort"
 	"time"
 
 	"github.com/block/schemabot/pkg/engine"
+	"github.com/block/schemabot/pkg/metrics"
 	ternv1 "github.com/block/schemabot/pkg/proto/ternv1"
 	"github.com/block/schemabot/pkg/state"
 	"github.com/block/schemabot/pkg/storage"
@@ -81,7 +84,10 @@ func (c *LocalClient) Start(ctx context.Context, req *ternv1.StartRequest) (*ter
 		if eng == nil {
 			return nil, fmt.Errorf("no engine configured for type: %s", c.config.Type)
 		}
-		controlReq := c.buildControlRequest(ctx, applyTasks[0], creds)
+		controlReq, err := c.buildControlRequest(ctx, applyTasks[0], creds)
+		if err != nil {
+			return nil, fmt.Errorf("build deferred deploy request: %w", err)
+		}
 		result, err := eng.Start(ctx, controlReq)
 		if err != nil {
 			return nil, fmt.Errorf("start deferred deploy: %w", err)
@@ -160,7 +166,7 @@ func (c *LocalClient) Start(ctx context.Context, req *ternv1.StartRequest) (*ter
 	options := buildApplyOptions(apply)
 	oldApplyState := apply.State
 
-	if apply.GetOptions().DeferCutover {
+	if c.shouldUseAtomicResume(apply) {
 		logMsg := fmt.Sprintf("Resume requested: %d tasks resumed, %d already completed", len(resumeTasks), completedCount)
 		if err := c.launchAtomicResume(ctx, apply, resumeTasks, plan, options, logMsg); err != nil {
 			return nil, err
@@ -362,15 +368,43 @@ func (c *LocalClient) replanAndFilterTasks(ctx context.Context, apply *storage.A
 
 // buildApplyOptions converts apply options to the string map used by the engine.
 func buildApplyOptions(apply *storage.Apply) map[string]string {
-	opts := apply.GetOptions()
-	options := make(map[string]string)
-	if opts.DeferCutover {
-		options["defer_cutover"] = "true"
+	return apply.GetOptions().Map()
+}
+
+func (c *LocalClient) shouldUseAtomicResume(apply *storage.Apply) bool {
+	return apply.GetOptions().DeferCutover || c.config.Type == storage.DatabaseTypeVitess
+}
+
+func (c *LocalClient) buildVitessResumeState(ctx context.Context, apply *storage.Apply) (*engine.ResumeState, error) {
+	vad, err := c.storage.VitessApplyData().GetByApplyID(ctx, apply.ID)
+	if err != nil {
+		return nil, fmt.Errorf("load Vitess apply data for apply %s: %w", apply.ApplyIdentifier, err)
 	}
-	if opts.AllowUnsafe {
-		options["allow_unsafe"] = "true"
+	return vitessApplyDataResumeState(vad, apply.ApplyIdentifier)
+}
+
+func vitessApplyDataResumeState(vad *storage.VitessApplyData, fallbackContext string) (*engine.ResumeState, error) {
+	if vad == nil {
+		return nil, fmt.Errorf("missing Vitess apply data")
 	}
-	return options
+	resumeContext := vad.MigrationContext
+	if resumeContext == "" {
+		resumeContext = fallbackContext
+	}
+	meta, err := json.Marshal(map[string]any{
+		"branch_name":        vad.BranchName,
+		"deploy_request_id":  vad.DeployRequestID,
+		"deploy_request_url": vad.DeployRequestURL,
+		"is_instant":         vad.IsInstant,
+		"deferred_deploy":    vad.DeferredDeploy,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("encode Vitess resume metadata: %w", err)
+	}
+	return &engine.ResumeState{
+		MigrationContext: resumeContext,
+		Metadata:         string(meta),
+	}, nil
 }
 
 // launchAtomicResume sends all DDLs to the engine in one call, marks tasks and
@@ -378,31 +412,47 @@ func buildApplyOptions(apply *storage.Apply) map[string]string {
 // in a background goroutine. Used by both Start() and ResumeApply().
 func (c *LocalClient) launchAtomicResume(ctx context.Context, apply *storage.Apply,
 	tasks []*storage.Task, plan *storage.Plan, options map[string]string, logMessage string) error {
-
-	var ddls []string
-	for _, t := range tasks {
-		ddls = append(ddls, t.DDL)
-	}
-
 	creds := c.credentials()
 	eng := c.getEngine()
 
-	// Build table changes from the DDL list
-	var tableChanges []engine.TableChange
-	for _, ddl := range ddls {
-		tableChanges = append(tableChanges, engine.TableChange{DDL: ddl})
+	changesByNamespace := make(map[string][]engine.TableChange)
+	for _, task := range tasks {
+		namespace := task.Namespace
+		if namespace == "" {
+			namespace = plan.Database
+		}
+		changesByNamespace[namespace] = append(changesByNamespace[namespace], engine.TableChange{
+			Table: task.TableName,
+			DDL:   task.DDL,
+		})
+	}
+	namespaces := make([]string, 0, len(changesByNamespace))
+	for namespace := range changesByNamespace {
+		namespaces = append(namespaces, namespace)
+	}
+	sort.Strings(namespaces)
+	changes := make([]engine.SchemaChange, 0, len(namespaces))
+	for _, namespace := range namespaces {
+		changes = append(changes, engine.SchemaChange{
+			Namespace:    namespace,
+			TableChanges: changesByNamespace[namespace],
+		})
 	}
 
-	// Resume atomic apply after restart. Use apply identifier as MigrationContext
-	// so Spirit can find existing checkpoint tables from the original run.
+	resumeState := &engine.ResumeState{MigrationContext: apply.ApplyIdentifier}
+	if c.config.Type == storage.DatabaseTypeVitess {
+		var err error
+		resumeState, err = c.buildVitessResumeState(ctx, apply)
+		if err != nil {
+			return err
+		}
+	}
+
 	result, err := eng.Apply(ctx, &engine.ApplyRequest{
-		Database: apply.Database,
-		Changes: []engine.SchemaChange{{
-			Namespace:    apply.Database,
-			TableChanges: tableChanges,
-		}},
+		Database:    apply.Database,
+		Changes:     changes,
 		Options:     options,
-		ResumeState: &engine.ResumeState{MigrationContext: apply.ApplyIdentifier},
+		ResumeState: resumeState,
 		Credentials: creds,
 	})
 	if err != nil {
@@ -431,9 +481,129 @@ func (c *LocalClient) launchAtomicResume(ctx context.Context, apply *storage.App
 	stopHeartbeat := c.startApplyHeartbeat(context.Background(), apply)
 	go func() {
 		defer stopHeartbeat()
-		c.pollForCompletionAtomic(context.Background(), apply, tasks, creds, nil)
+		c.pollForCompletionAtomic(context.Background(), apply, tasks, creds, result.ResumeState)
 	}()
 	return nil
+}
+
+// retryFailedApply re-dispatches an apply after a retryable engine failure.
+// Completed tasks are preserved; retryable tasks are reset to pending.
+func (c *LocalClient) retryFailedApply(ctx context.Context, apply *storage.Apply) error {
+	plan, err := c.storage.Plans().GetByID(ctx, apply.PlanID)
+	if err != nil {
+		c.failApplyPermanently(ctx, apply, fmt.Sprintf("retry failed: load plan %d: %v", apply.PlanID, err))
+		return fmt.Errorf("load plan %d for retry apply %s: %w", apply.PlanID, apply.ApplyIdentifier, err)
+	}
+	if plan == nil {
+		errMsg := fmt.Sprintf("retry failed: plan %d not found", apply.PlanID)
+		c.failApplyPermanently(ctx, apply, errMsg)
+		return fmt.Errorf("retry apply %s: %s", apply.ApplyIdentifier, errMsg)
+	}
+
+	tasks, err := c.storage.Tasks().GetByApplyID(ctx, apply.ID)
+	if err != nil {
+		c.failApplyPermanently(ctx, apply, fmt.Sprintf("retry failed: load tasks: %v", err))
+		return fmt.Errorf("load tasks for retry apply %s: %w", apply.ApplyIdentifier, err)
+	}
+	if len(tasks) == 0 {
+		errMsg := "retry failed: no tasks found"
+		c.failApplyPermanently(ctx, apply, errMsg)
+		return fmt.Errorf("%s for apply %s", errMsg, apply.ApplyIdentifier)
+	}
+
+	resetTasks := 0
+	completedTasks := 0
+	pendingTasks := 0
+	for _, task := range tasks {
+		switch task.State {
+		case state.Task.Completed:
+			completedTasks++
+		case state.Task.Pending:
+			pendingTasks++
+		case state.Task.FailedRetryable:
+			resetTasks++
+		}
+		if task.State != state.Task.FailedRetryable {
+			continue
+		}
+		task.State = state.Task.Pending
+		task.ErrorMessage = ""
+		task.CompletedAt = nil
+		task.Attempt++
+		if err := c.storage.Tasks().Update(ctx, task); err != nil {
+			return fmt.Errorf("reset retryable task %s: %w", task.TaskIdentifier, err)
+		}
+	}
+
+	now := time.Now()
+	apply.State = state.Apply.Running
+	apply.ErrorMessage = ""
+	apply.CompletedAt = nil
+	apply.UpdatedAt = now
+	if err := c.storage.Applies().Update(ctx, apply); err != nil {
+		return fmt.Errorf("mark retry apply %s running: %w", apply.ApplyIdentifier, err)
+	}
+
+	c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventInfo, storage.LogSourceSchemaBot,
+		fmt.Sprintf("Retry attempt %d: re-dispatching apply", apply.Attempt), state.Apply.FailedRetryable, state.Apply.Running)
+	c.logger.Info("retrying failed apply",
+		"apply_id", apply.ApplyIdentifier,
+		"database", apply.Database,
+		"environment", apply.Environment,
+		"attempt", apply.Attempt,
+		"reset_tasks", resetTasks,
+		"pending_tasks", pendingTasks,
+		"completed_tasks", completedTasks,
+		"task_count", len(tasks))
+
+	options := buildApplyOptions(apply)
+	applyCtx, cancelApply := context.WithCancel(context.WithoutCancel(ctx))
+	c.cancelMu.Lock()
+	c.cancelApply = cancelApply
+	c.cancelMu.Unlock()
+	if c.shouldUseAtomicResume(apply) {
+		go c.runWithRecovery(applyCtx, apply, tasks, func() {
+			c.executeApplyAtomic(applyCtx, apply, tasks, plan, options)
+		})
+	} else {
+		go c.runWithRecovery(applyCtx, apply, tasks, func() {
+			c.executeApplySequential(applyCtx, apply, tasks, plan, options)
+		})
+	}
+
+	return nil
+}
+
+// failApplyPermanently marks an apply as permanently failed.
+func (c *LocalClient) failApplyPermanently(ctx context.Context, apply *storage.Apply, errMsg string) {
+	now := time.Now()
+	tasks, err := c.storage.Tasks().GetByApplyID(ctx, apply.ID)
+	if err != nil {
+		c.logger.Error("failed to load tasks before permanent apply failure",
+			"apply_id", apply.ApplyIdentifier, "error", err)
+	} else {
+		for _, task := range tasks {
+			if state.IsTerminalTaskState(task.State) {
+				continue
+			}
+			task.State = state.Task.Failed
+			task.ErrorMessage = errMsg
+			task.CompletedAt = &now
+			if err := c.storage.Tasks().Update(ctx, task); err != nil {
+				c.logger.Error("failed to mark task as permanently failed",
+					"task_id", task.TaskIdentifier, "apply_id", apply.ApplyIdentifier, "error", err)
+			}
+		}
+	}
+	apply.State = state.Apply.Failed
+	apply.ErrorMessage = errMsg
+	apply.CompletedAt = &now
+	apply.UpdatedAt = now
+	if err := c.storage.Applies().Update(ctx, apply); err != nil {
+		c.logger.Error("failed to mark apply as permanently failed",
+			"apply_id", apply.ApplyIdentifier, "error", err)
+	}
+	metrics.AdjustActiveApplies(ctx, -1, apply.Database, apply.Environment)
 }
 
 func (c *LocalClient) notifyTerminalObserver(apply *storage.Apply, tasks []*storage.Task) {
@@ -447,6 +617,21 @@ func (c *LocalClient) notifyTerminalObserver(apply *storage.Apply, tasks []*stor
 // This can happen after a server restart or if the worker goroutine crashed.
 // Spirit's checkpoint table allows resuming from where the schema change left off.
 func (c *LocalClient) ResumeApply(ctx context.Context, apply *storage.Apply) error {
+	claimedRetryable := apply.State == state.Apply.FailedRetryable
+
+	fresh, err := c.storage.Applies().Get(ctx, apply.ID)
+	if err != nil {
+		return fmt.Errorf("refresh apply %s: %w", apply.ApplyIdentifier, err)
+	}
+	if fresh == nil {
+		return fmt.Errorf("apply %s not found during refresh", apply.ApplyIdentifier)
+	}
+	apply = fresh
+
+	if claimedRetryable || apply.State == state.Apply.FailedRetryable {
+		return c.retryFailedApply(ctx, apply)
+	}
+
 	// Get tasks for this apply
 	tasks, err := c.storage.Tasks().GetByApplyID(ctx, apply.ID)
 	if err != nil {
@@ -463,6 +648,24 @@ func (c *LocalClient) ResumeApply(ctx context.Context, apply *storage.Apply) err
 		}
 		c.notifyTerminalObserver(apply, tasks)
 		return nil
+	}
+
+	if shouldDispatchPendingApply(apply, tasks) {
+		c.logger.Info("dispatching queued apply",
+			"apply_id", apply.ApplyIdentifier,
+			"database", apply.Database,
+			"environment", apply.Environment,
+			"task_count", len(tasks))
+		return c.dispatchPendingApply(ctx, apply, tasks)
+	}
+
+	if hasRetryableTask(tasks) {
+		c.logger.Info("retryable tasks found during apply recovery, using retry path",
+			"apply_id", apply.ApplyIdentifier,
+			"database", apply.Database,
+			"environment", apply.Environment,
+			"state", apply.State)
+		return c.retryFailedApply(ctx, apply)
 	}
 
 	// Get the plan to retrieve original DDLs
@@ -515,7 +718,7 @@ func (c *LocalClient) ResumeApply(ctx context.Context, apply *storage.Apply) err
 
 	options := buildApplyOptions(apply)
 
-	if apply.GetOptions().DeferCutover {
+	if c.shouldUseAtomicResume(apply) {
 		if err := c.launchAtomicResume(ctx, apply, activeTasks, plan, options, "Apply resumed from checkpoint (atomic)"); err != nil {
 			c.logger.Error("engine apply failed during recovery",
 				"apply_id", apply.ApplyIdentifier,
@@ -540,4 +743,59 @@ func (c *LocalClient) ResumeApply(ctx context.Context, apply *storage.Apply) err
 	}
 
 	return nil
+}
+
+func shouldDispatchPendingApply(apply *storage.Apply, tasks []*storage.Task) bool {
+	if apply.StartedAt != nil {
+		return false
+	}
+	if apply.State != state.Apply.Pending && apply.State != state.Apply.Running {
+		return false
+	}
+	for _, task := range tasks {
+		if task.State != state.Task.Pending {
+			return false
+		}
+	}
+	return true
+}
+
+func (c *LocalClient) dispatchPendingApply(ctx context.Context, apply *storage.Apply, tasks []*storage.Task) error {
+	plan, err := c.storage.Plans().GetByID(ctx, apply.PlanID)
+	if err != nil {
+		c.failApplyPermanently(ctx, apply, fmt.Sprintf("queued apply failed: load plan %d: %v", apply.PlanID, err))
+		return fmt.Errorf("load plan %d for queued apply %s: %w", apply.PlanID, apply.ApplyIdentifier, err)
+	}
+	if plan == nil {
+		errMsg := fmt.Sprintf("queued apply failed: plan %d not found", apply.PlanID)
+		c.failApplyPermanently(ctx, apply, errMsg)
+		return fmt.Errorf("queued apply %s: %s", apply.ApplyIdentifier, errMsg)
+	}
+
+	c.registerPendingObserver(apply.ID)
+
+	options := buildApplyOptions(apply)
+	applyCtx, cancelApply := context.WithCancel(context.WithoutCancel(ctx))
+	c.cancelMu.Lock()
+	c.cancelApply = cancelApply
+	c.cancelMu.Unlock()
+	if c.shouldUseAtomicResume(apply) {
+		go c.runWithRecovery(applyCtx, apply, tasks, func() {
+			c.executeApplyAtomic(applyCtx, apply, tasks, plan, options)
+		})
+	} else {
+		go c.runWithRecovery(applyCtx, apply, tasks, func() {
+			c.executeApplySequential(applyCtx, apply, tasks, plan, options)
+		})
+	}
+	return nil
+}
+
+func hasRetryableTask(tasks []*storage.Task) bool {
+	for _, task := range tasks {
+		if task.State == state.Task.FailedRetryable {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/tern/observer.go
+++ b/pkg/tern/observer.go
@@ -35,10 +35,8 @@ func (c *LocalClient) SetObserver(applyID int64, observer ProgressObserver) {
 	c.observers[applyID] = observer
 }
 
-// SetPendingObserver sets an observer that will be consumed by the next Apply()
-// call. The observer is registered on the apply record before the engine starts,
-// preventing the race where the apply completes before the observer is set.
-// Called by the webhook handler before triggering the apply API call.
+// SetPendingObserver sets an observer consumed by direct Apply callers. API
+// callers register observers through Service.SetPendingObserver.
 func (c *LocalClient) SetPendingObserver(observer ProgressObserver) {
 	c.observerMu.Lock()
 	defer c.observerMu.Unlock()
@@ -53,6 +51,16 @@ func (c *LocalClient) consumePendingObserver() ProgressObserver {
 	obs := c.pendingObserver
 	c.pendingObserver = nil
 	return obs
+}
+
+func (c *LocalClient) registerPendingObserver(applyID int64) {
+	if obs := c.consumePendingObserver(); obs != nil {
+		type applyIDSetter interface{ SetApplyID(int64) }
+		if setter, ok := obs.(applyIDSetter); ok {
+			setter.SetApplyID(applyID)
+		}
+		c.SetObserver(applyID, obs)
+	}
 }
 
 // getObserver returns the observer for an apply, or nil if none is set.

--- a/pkg/tern/state_converters.go
+++ b/pkg/tern/state_converters.go
@@ -35,6 +35,8 @@ func taskStateToApplyState(ts string) string {
 		return state.Apply.Completed
 	case state.Task.Failed:
 		return state.Apply.Failed
+	case state.Task.FailedRetryable:
+		return state.Apply.FailedRetryable
 	case state.Task.Stopped:
 		return state.Apply.Stopped
 	case state.Task.Reverted:
@@ -92,6 +94,8 @@ func storageStateToProto(ts string) ternv1.State {
 	case state.Task.Completed:
 		return ternv1.State_STATE_COMPLETED
 	case state.Task.Failed:
+		return ternv1.State_STATE_FAILED
+	case state.Task.FailedRetryable, state.Apply.FailedRetryable:
 		return ternv1.State_STATE_FAILED
 	case state.Task.Stopped:
 		return ternv1.State_STATE_STOPPED

--- a/pkg/webhook/apply_handlers.go
+++ b/pkg/webhook/apply_handlers.go
@@ -454,10 +454,9 @@ func (h *Handler) executeApply(
 
 	caller := fmt.Sprintf("github:%s@%s#%d", requestedBy, repo, pr)
 
-	// Set observer before starting the apply — consumed by Apply() before the
-	// engine starts, so the observer is registered before any progress events fire.
-	// ApplyID is set to 0 here; LocalClient.Apply() updates it after creating
-	// the apply record.
+	// Set observer before queueing the apply so ExecuteApply can attach it to
+	// the stored apply before any scheduler worker starts engine work.
+	// ApplyID is set after the apply record is created.
 	observer := NewCommentObserver(CommentObserverConfig{
 		GHClient:       h.ghClient,
 		Storage:        h.service.Storage(),

--- a/pkg/webhook/comment_observer.go
+++ b/pkg/webhook/comment_observer.go
@@ -70,7 +70,6 @@ type CommentObserverConfig struct {
 }
 
 // SetApplyID sets the apply ID after the apply record is created.
-// Called by LocalClient.Apply() when consuming a pending observer.
 func (o *CommentObserver) SetApplyID(id int64) {
 	o.applyID = id
 }

--- a/pkg/webhook/webhook_e2e_test.go
+++ b/pkg/webhook/webhook_e2e_test.go
@@ -208,6 +208,8 @@ func setupE2EService(t *testing.T, appDBName string) *api.Service {
 	svc := api.New(st, serverConfig, map[string]tern.Client{
 		appDBName + "/staging": localClient,
 	}, logger)
+	require.NoError(t, svc.SetSchedulerPollInterval(200*time.Millisecond))
+	svc.StartScheduler(t.Context())
 	t.Cleanup(func() { _ = svc.Close() })
 
 	return svc
@@ -1288,6 +1290,8 @@ func setupE2EServiceMultiEnv(t *testing.T, appDBName string) *api.Service {
 		appDBName + "/staging":    stagingClient,
 		appDBName + "/production": productionClient,
 	}, logger)
+	require.NoError(t, svc.SetSchedulerPollInterval(200*time.Millisecond))
+	svc.StartScheduler(t.Context())
 	t.Cleanup(func() { _ = svc.Close() })
 
 	return svc


### PR DESCRIPTION
## Summary

This makes apply execution durable and scheduler-owned: `/api/apply` persists apply/task records, wakes scheduler workers, and returns once work is queued. Workers claim applies from storage and resume local or remote Tern work, letting SchemaBot recover from request cancellation, server crashes, and retryable engine failures without restarting completed work.

- Add `failed_retryable` apply/task states, retry-budget expiration, progress/API state mapping, and scheduler retry behavior
- Extend local and gRPC Tern clients so `ResumeApply` handles queued dispatch, stale recovery, and retryable re-dispatch
- Enforce one active apply per database/type/environment with MySQL named locks and document scheduler claims, workers, and retry semantics
- Add integration/e2e coverage for queued dispatch, crash recovery, retryable Spirit failures, multi-worker scheduling, and split CI execution modes

🤖 Generated by Codex.