### PR TITLE
feat(github): show PR head SHA in plan comments

### DIFF
--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -15,7 +15,7 @@ All templates rendered with sample data.
 
 **Database**: `testapp` | **Schema Name**: `testapp` | **Environment**: `staging`
 
-*Requested by @aparajon at 2026-01-01 00:00:00 UTC*
+*Requested by @aparajon at 2026-01-01 00:00:00 UTC · planned from [`abcdef1`](https://github.com/block/schemabot/commit/abcdef1234567890abcdef1234567890abcdef12)*
 
 ```sql
 CREATE TABLE `users` (
@@ -66,7 +66,7 @@ schemabot apply -e staging
 
 **Database**: `testapp` | **Schema Name**: `testapp` | **Environment**: `staging`
 
-*Requested by @aparajon at 2026-01-01 00:00:00 UTC*
+*Requested by @aparajon at 2026-01-01 00:00:00 UTC · planned from [`abcdef1`](https://github.com/block/schemabot/commit/abcdef1234567890abcdef1234567890abcdef12)*
 
 ✅ **No schema changes detected**
 
@@ -80,7 +80,7 @@ schemabot apply -e staging
 
 **Database**: `commerce` | **Environment**: `staging`
 
-*Requested by @aparajon at 2026-01-01 00:00:00 UTC*
+*Requested by @aparajon at 2026-01-01 00:00:00 UTC · planned from [`abcdef1`](https://github.com/block/schemabot/commit/abcdef1234567890abcdef1234567890abcdef12)*
 
 #### Keyspace: `commerce`
 #### VSchema
@@ -168,7 +168,7 @@ schemabot apply -e staging
 
 **Database**: `commerce` | **Environment**: `staging`
 
-*Requested by @aparajon at 2026-01-01 00:00:00 UTC*
+*Requested by @aparajon at 2026-01-01 00:00:00 UTC · planned from [`abcdef1`](https://github.com/block/schemabot/commit/abcdef1234567890abcdef1234567890abcdef12)*
 
 🔒 **Lock acquired by** `acme/myapp#42` at 2026-03-14 10:30:00 UTC
 
@@ -265,7 +265,7 @@ schemabot unlock
 
 **Database**: `myapp` | **Environment**: `staging`
 
-*Requested by @aparajon at 2026-01-01 00:00:00 UTC*
+*Requested by @aparajon at 2026-01-01 00:00:00 UTC · planned from [`abcdef1`](https://github.com/block/schemabot/commit/abcdef1234567890abcdef1234567890abcdef12)*
 
 #### Schema Name: `app_primary`
 ```sql
@@ -308,7 +308,7 @@ schemabot apply -e staging
 
 **Database**: `testapp`
 
-*Requested by @aparajon at 2026-01-01 00:00:00 UTC*
+*Requested by @aparajon at 2026-01-01 00:00:00 UTC · planned from [`abcdef1`](https://github.com/block/schemabot/commit/abcdef1234567890abcdef1234567890abcdef12)*
 
 ### Staging & Production
 
@@ -361,7 +361,7 @@ schemabot apply -e production
 
 **Database**: `testapp`
 
-*Requested by @aparajon at 2026-01-01 00:00:00 UTC*
+*Requested by @aparajon at 2026-01-01 00:00:00 UTC · planned from [`abcdef1`](https://github.com/block/schemabot/commit/abcdef1234567890abcdef1234567890abcdef12)*
 
 ### Staging
 
@@ -413,7 +413,7 @@ schemabot apply -e production
 
 **Database**: `testapp`
 
-*Requested by @aparajon at 2026-01-01 00:00:00 UTC*
+*Requested by @aparajon at 2026-01-01 00:00:00 UTC · planned from [`abcdef1`](https://github.com/block/schemabot/commit/abcdef1234567890abcdef1234567890abcdef12)*
 
 ### Staging
 
@@ -471,7 +471,7 @@ schemabot plan -e production
 
 **Database**: `testapp`
 
-*Started at 2026-01-01 00:00:00 UTC*
+*Started at 2026-01-01 00:00:00 UTC · planned from [`abcdef1`](https://github.com/block/schemabot/commit/abcdef1234567890abcdef1234567890abcdef12)*
 
 ### Staging & Production
 
@@ -1270,7 +1270,7 @@ No active locks.
 
 **Database**: `testapp` | **Schema Name**: `testapp` | **Environment**: `staging`
 
-*Requested by @aparajon at 2026-01-01 00:00:00 UTC*
+*Requested by @aparajon at 2026-01-01 00:00:00 UTC · planned from [`abcdef1`](https://github.com/block/schemabot/commit/abcdef1234567890abcdef1234567890abcdef12)*
 
 🔒 **Lock acquired by** `acme/myapp#42` at 2026-03-14 10:30:00 UTC
 
@@ -1324,7 +1324,7 @@ schemabot unlock
 
 **Database**: `testapp` | **Schema Name**: `testapp` | **Environment**: `staging`
 
-*Requested by @aparajon at 2026-01-01 00:00:00 UTC*
+*Requested by @aparajon at 2026-01-01 00:00:00 UTC · planned from [`abcdef1`](https://github.com/block/schemabot/commit/abcdef1234567890abcdef1234567890abcdef12)*
 
 🔒 **Lock acquired by** `acme/myapp#42` at 2026-03-14 10:30:00 UTC
 
@@ -1380,7 +1380,7 @@ schemabot unlock
 
 **Database**: `commerce` | **Environment**: `staging`
 
-*Requested by @aparajon at 2026-01-01 00:00:00 UTC*
+*Requested by @aparajon at 2026-01-01 00:00:00 UTC · planned from [`abcdef1`](https://github.com/block/schemabot/commit/abcdef1234567890abcdef1234567890abcdef12)*
 
 🔒 **Lock acquired by** `acme/myapp#42` at 2026-03-14 10:30:00 UTC
 
@@ -1498,7 +1498,7 @@ Schema changes are being applied. Progress updates will be posted as new comment
 - **`users`**: 🟦🟦🟦🟦🟦🟦🟦🟦🟦⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ 48%  
 
   ```sql
-  ALTER TABLE `users` ADD INDEX `idx_email_created` (`email`, `created_at`)
+  ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
   ```
   Rows: 3,500,000 / 7,200,000 · ETA: 5m 30s
 
@@ -1527,7 +1527,7 @@ schemabot stop apply-a1b2c3d4e5f6
 - **`users`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete  
 
   ```sql
-  ALTER TABLE `users` ADD INDEX `idx_email_created` (`email`, `created_at`)
+  ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
   ```
 
 
@@ -1548,7 +1548,7 @@ schemabot stop apply-a1b2c3d4e5f6
 - **`users`**: 🟥⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ ❌ Failed  
 
   ```sql
-  ALTER TABLE `users` ADD INDEX `idx_email_created` (`email`, `created_at`)
+  ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
   ```
 
 
@@ -1578,7 +1578,7 @@ schemabot apply -e staging
 - **`users`**: 🟧🟧🟧🟧🟧🟧🟧⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ ⏹️ Stopped at 39%  
 
   ```sql
-  ALTER TABLE `users` ADD INDEX `idx_email_created` (`email`, `created_at`)
+  ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
   ```
   Rows: 156,342 / 397,453
 
@@ -1609,19 +1609,19 @@ schemabot start apply-a1b2c3d4e5f6
 - **`orders`**: ⏳ Queued  
 
   ```sql
-  ALTER TABLE `orders` ADD INDEX `idx_user_id` (`user_id`)
+  ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
   ```
 
 - **`users`**: ⏳ Queued  
 
   ```sql
-  ALTER TABLE `users` ADD INDEX `idx_email` (`email`)
+  ALTER TABLE `users` ADD INDEX `idx_email`(`email`);
   ```
 
 - **`products`**: ⏳ Queued  
 
   ```sql
-  ALTER TABLE `products` ADD INDEX `idx_price` (`price_cents`)
+  ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
   ```
 
 
@@ -1651,20 +1651,20 @@ schemabot stop apply-a1b2c3d4e5f6
 - **`orders`**: 🟦🟦🟦🟦⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ 22%  
 
   ```sql
-  ALTER TABLE `orders` ADD INDEX `idx_user_id` (`user_id`)
+  ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
   ```
   Rows: 321,450 / 1,466,232 · ETA: 5m 40s
 
 - **`users`**: ⏳ Queued  
 
   ```sql
-  ALTER TABLE `users` ADD INDEX `idx_email` (`email`)
+  ALTER TABLE `users` ADD INDEX `idx_email`(`email`);
   ```
 
 - **`products`**: ⏳ Queued  
 
   ```sql
-  ALTER TABLE `products` ADD INDEX `idx_price` (`price_cents`)
+  ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
   ```
 
 
@@ -1694,20 +1694,20 @@ schemabot stop apply-a1b2c3d4e5f6
 - **`users`**: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦⬜⬜⬜⬜⬜⬜⬜⬜ 62%  
 
   ```sql
-  ALTER TABLE `users` ADD INDEX `idx_email` (`email`)
+  ALTER TABLE `users` ADD INDEX `idx_email`(`email`);
   ```
   Rows: 914,707 / 1,466,232 · ETA: 3m 15s
 
 - **`products`**: ⏳ Queued  
 
   ```sql
-  ALTER TABLE `products` ADD INDEX `idx_price` (`price_cents`)
+  ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
   ```
 
 - **`orders`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete  
 
   ```sql
-  ALTER TABLE `orders` ADD INDEX `idx_user_id` (`user_id`)
+  ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
   ```
 
 
@@ -1737,20 +1737,20 @@ schemabot stop apply-a1b2c3d4e5f6
 - **`products`**: 🟦🟦🟦⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ 17%  
 
   ```sql
-  ALTER TABLE `products` ADD INDEX `idx_price` (`price_cents`)
+  ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
   ```
   Rows: 87,231 / 523,140 · ETA: 7m 0s
 
 - **`orders`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete  
 
   ```sql
-  ALTER TABLE `orders` ADD INDEX `idx_user_id` (`user_id`)
+  ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
   ```
 
 - **`users`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete  
 
   ```sql
-  ALTER TABLE `users` ADD INDEX `idx_email` (`email`)
+  ALTER TABLE `users` ADD INDEX `idx_email`(`email`);
   ```
 
 
@@ -1780,19 +1780,19 @@ schemabot stop apply-a1b2c3d4e5f6
 - **`orders`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete  
 
   ```sql
-  ALTER TABLE `orders` ADD INDEX `idx_user_id` (`user_id`)
+  ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
   ```
 
 - **`users`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete  
 
   ```sql
-  ALTER TABLE `users` ADD INDEX `idx_email` (`email`)
+  ALTER TABLE `users` ADD INDEX `idx_email`(`email`);
   ```
 
 - **`products`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete  
 
   ```sql
-  ALTER TABLE `products` ADD INDEX `idx_price` (`price_cents`)
+  ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
   ```
 
 
@@ -1815,19 +1815,19 @@ schemabot stop apply-a1b2c3d4e5f6
 - **`orders`**: 🟥⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ ❌ Failed  
 
   ```sql
-  ALTER TABLE `orders` ADD INDEX `idx_user_id` (`user_id`)
+  ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
   ```
 
 - **`users`**: ⊘ Cancelled (not started)  
 
   ```sql
-  ALTER TABLE `users` ADD INDEX `idx_email` (`email`)
+  ALTER TABLE `users` ADD INDEX `idx_email`(`email`);
   ```
 
 - **`products`**: ⊘ Cancelled (not started)  
 
   ```sql
-  ALTER TABLE `products` ADD INDEX `idx_price` (`price_cents`)
+  ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
   ```
 
 
@@ -1859,19 +1859,19 @@ schemabot apply -e staging
 - **`users`**: 🟥🟥🟥🟥🟥🟥⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ ❌ Failed  
 
   ```sql
-  ALTER TABLE `users` ADD INDEX `idx_email` (`email`)
+  ALTER TABLE `users` ADD INDEX `idx_email`(`email`);
   ```
 
 - **`orders`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete  
 
   ```sql
-  ALTER TABLE `orders` ADD INDEX `idx_user_id` (`user_id`)
+  ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
   ```
 
 - **`products`**: ⊘ Cancelled (not started)  
 
   ```sql
-  ALTER TABLE `products` ADD INDEX `idx_price` (`price_cents`)
+  ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
   ```
 
 
@@ -1903,14 +1903,14 @@ schemabot apply -e staging
 - **`users`**: 🟧🟧🟧🟧🟧🟧🟧🟧🟧🟧🟧🟧🟧🟧⬜⬜⬜⬜⬜⬜ ⏹️ Stopped at 72%  
 
   ```sql
-  ALTER TABLE `users` ADD INDEX `idx_email` (`email`)
+  ALTER TABLE `users` ADD INDEX `idx_email`(`email`);
   ```
   Rows: 1,055,687 / 1,466,232
 
 - **`orders`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete  
 
   ```sql
-  ALTER TABLE `orders` ADD INDEX `idx_user_id` (`user_id`)
+  ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
   ```
 
 
@@ -1933,6 +1933,8 @@ schemabot start apply-a1b2c3d4e5f6
 
 *Applied by @aparajon at 2026-01-01 00:00:00 UTC*
 
+**0/3** table(s) ready for cutover — waiting on 3
+
 📊 3 waiting for cutover
 
 ### Table Progress
@@ -1940,19 +1942,19 @@ schemabot start apply-a1b2c3d4e5f6
 - **`orders`**: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 Waiting for cutover  
 
   ```sql
-  ALTER TABLE `orders` ADD INDEX `idx_user_id` (`user_id`)
+  ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
   ```
 
 - **`users`**: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 Waiting for cutover  
 
   ```sql
-  ALTER TABLE `users` ADD INDEX `idx_email` (`email`)
+  ALTER TABLE `users` ADD INDEX `idx_email`(`email`);
   ```
 
 - **`products`**: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 Waiting for cutover  
 
   ```sql
-  ALTER TABLE `products` ADD INDEX `idx_price` (`price_cents`)
+  ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
   ```
 
 
@@ -1975,6 +1977,8 @@ schemabot cutover apply-a1b2c3d4e5f6
 
 *Applied by @aparajon at 2026-01-01 00:00:00 UTC*
 
+**0/3** table(s) ready for cutover — waiting on 3
+
 📊 3 cutting over
 
 ### Table Progress
@@ -1982,19 +1986,19 @@ schemabot cutover apply-a1b2c3d4e5f6
 - **`orders`**: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 🔄 Cutting over...  
 
   ```sql
-  ALTER TABLE `orders` ADD INDEX `idx_user_id` (`user_id`)
+  ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
   ```
 
 - **`users`**: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 🔄 Cutting over...  
 
   ```sql
-  ALTER TABLE `users` ADD INDEX `idx_email` (`email`)
+  ALTER TABLE `users` ADD INDEX `idx_email`(`email`);
   ```
 
 - **`products`**: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 🔄 Cutting over...  
 
   ```sql
-  ALTER TABLE `products` ADD INDEX `idx_price` (`price_cents`)
+  ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
   ```
 
 
@@ -3821,7 +3825,7 @@ No schema changes found for database 'new-db'
 
 **Database**: `testapp` | **Schema Name**: `testapp` | **Environment**: `staging`
 
-*Requested by @aparajon at 2026-01-01 00:00:00 UTC*
+*Requested by @aparajon at 2026-01-01 00:00:00 UTC · planned from [`abcdef1`](https://github.com/block/schemabot/commit/abcdef1234567890abcdef1234567890abcdef12)*
 
 🔒 **Lock acquired by** `acme/myapp#42` at 2026-03-14 10:30:00 UTC
 
@@ -3876,7 +3880,7 @@ schemabot unlock
 
 **Database**: `testapp` | **Schema Name**: `testapp` | **Environment**: `staging`
 
-*Requested by @aparajon at 2026-01-01 00:00:00 UTC*
+*Requested by @aparajon at 2026-01-01 00:00:00 UTC · planned from [`abcdef1`](https://github.com/block/schemabot/commit/abcdef1234567890abcdef1234567890abcdef12)*
 
 🔒 **Lock acquired by** `acme/myapp#42` at 2026-03-14 10:30:00 UTC
 

--- a/pkg/webhook/plan.go
+++ b/pkg/webhook/plan.go
@@ -196,6 +196,8 @@ func (h *Handler) handleMultiEnvPlan(repo string, pr int, databaseName string, i
 		// Set database/type from first successful result
 		if multiEnvData.Database == "" {
 			multiEnvData.Database = schemaResult.Database
+			multiEnvData.HeadSHA = schemaResult.HeadSHA
+			multiEnvData.Repository = schemaResult.Repository
 			multiEnvData.IsMySQL = schemaResult.Type == "mysql"
 		}
 
@@ -309,6 +311,8 @@ func buildPlanCommentData(schema *ghclient.SchemaRequestResult, planResp *apityp
 	data := templates.PlanCommentData{
 		Database:    schema.Database,
 		Environment: environment,
+		HeadSHA:     schema.HeadSHA,
+		Repository:  schema.Repository,
 		RequestedBy: requestedBy,
 		IsMySQL:     schema.Type == "mysql",
 	}

--- a/pkg/webhook/plan_test.go
+++ b/pkg/webhook/plan_test.go
@@ -46,8 +46,10 @@ func TestBuildPlanCommentData_UnsafeChangesPopulated(t *testing.T) {
 
 func TestBuildPlanCommentData_NoUnsafeChanges(t *testing.T) {
 	schema := &ghclient.SchemaRequestResult{
-		Database: "testdb",
-		Type:     "mysql",
+		Database:   "testdb",
+		Type:       "mysql",
+		HeadSHA:    "abcdef1234567890",
+		Repository: "block/schemabot",
 	}
 
 	planResp := &apitypes.PlanResponse{
@@ -66,6 +68,8 @@ func TestBuildPlanCommentData_NoUnsafeChanges(t *testing.T) {
 
 	assert.False(t, data.HasUnsafeChanges)
 	assert.Empty(t, data.UnsafeChanges)
+	assert.Equal(t, "abcdef1234567890", data.HeadSHA)
+	assert.Equal(t, "block/schemabot", data.Repository)
 }
 
 func TestBuildPlanCommentData_MixedSafeAndUnsafe(t *testing.T) {
@@ -166,6 +170,44 @@ func TestRenderPlanComment_NoUnsafe_NoWarning(t *testing.T) {
 	rendered := templates.RenderPlanComment(data)
 
 	assert.NotContains(t, rendered, "Unsafe")
+}
+
+func TestRenderPlanComment_ShowsPRHeadSHA(t *testing.T) {
+	data := templates.PlanCommentData{
+		Database:    "testdb",
+		Environment: "staging",
+		HeadSHA:     "abcdef1234567890",
+		Repository:  "block/schemabot",
+		IsMySQL:     true,
+	}
+
+	rendered := templates.RenderPlanComment(data)
+
+	assert.Contains(t, rendered, "planned from [`abcdef1`](https://github.com/block/schemabot/commit/abcdef1234567890)")
+	assert.NotContains(t, rendered, "**PR head SHA**")
+}
+
+func TestRenderMultiEnvPlanComment_ShowsPRHeadSHA(t *testing.T) {
+	data := templates.MultiEnvPlanCommentData{
+		Database:     "testdb",
+		HeadSHA:      "abcdef1234567890",
+		Repository:   "block/schemabot",
+		IsMySQL:      true,
+		Environments: []string{"staging"},
+		Plans: map[string]*templates.PlanCommentData{
+			"staging": {
+				Database:    "testdb",
+				Environment: "staging",
+				IsMySQL:     true,
+			},
+		},
+		Errors: map[string]string{},
+	}
+
+	rendered := templates.RenderMultiEnvPlanComment(data)
+
+	assert.Contains(t, rendered, "planned from [`abcdef1`](https://github.com/block/schemabot/commit/abcdef1234567890)")
+	assert.NotContains(t, rendered, "**PR head SHA**")
 }
 
 func TestRenderUnsafeChangesBlocked_UsedByApplyFlow(t *testing.T) {

--- a/pkg/webhook/templates/apply_commands.go
+++ b/pkg/webhook/templates/apply_commands.go
@@ -41,7 +41,7 @@ func RenderUnsafeChangesBlocked(data PlanCommentData) string {
 	fmt.Fprintf(&sb, "## %s Schema Change Plan\n\n", dbTypeLabel)
 
 	writePlanMetadata(&sb, data)
-	writeRequesterOrTimestamp(&sb, data.RequestedBy)
+	writePlanAttribution(&sb, data)
 	sb.WriteString("\n")
 
 	// Count and show changes

--- a/pkg/webhook/templates/common.go
+++ b/pkg/webhook/templates/common.go
@@ -51,11 +51,15 @@ func writeAppliedByOrTimestamp(sb *strings.Builder, appliedBy string) {
 
 // writeAttributionLine writes a "*Verb by @user at timestamp*" line.
 func writeAttributionLine(sb *strings.Builder, verb, user string) {
+	writeAttributionLineWithSuffix(sb, verb, user, "")
+}
+
+func writeAttributionLineWithSuffix(sb *strings.Builder, verb, user, suffix string) {
 	ts := currentTimestamp()
 	if user != "" {
-		fmt.Fprintf(sb, "\n*%s by @%s at %s*\n", verb, user, ts)
+		fmt.Fprintf(sb, "\n*%s by @%s at %s%s*\n", verb, user, ts, suffix)
 	} else {
-		fmt.Fprintf(sb, "\n*Started at %s*\n", ts)
+		fmt.Fprintf(sb, "\n*Started at %s%s*\n", ts, suffix)
 	}
 }
 

--- a/pkg/webhook/templates/plan.go
+++ b/pkg/webhook/templates/plan.go
@@ -29,6 +29,8 @@ type PlanCommentData struct {
 	Database    string
 	SchemaName  string // Schema directory name (e.g. filepath.Base of schema dir)
 	Environment string
+	HeadSHA     string
+	Repository  string
 	RequestedBy string // Empty means auto-generated
 	IsMySQL     bool
 
@@ -79,7 +81,7 @@ func RenderPlanComment(data PlanCommentData) string {
 	}
 
 	writePlanMetadata(&sb, data)
-	writeRequesterOrTimestamp(&sb, data.RequestedBy)
+	writePlanAttribution(&sb, data)
 
 	if data.IsLocked && data.LockOwner != "" {
 		fmt.Fprintf(&sb, "\n🔒 **Lock acquired by** `%s`", data.LockOwner)
@@ -181,6 +183,32 @@ func writePlanMetadata(sb *strings.Builder, data PlanCommentData) {
 		parts = append(parts, fmt.Sprintf("**Environment**: `%s`", data.Environment))
 	}
 	fmt.Fprintf(sb, "%s\n", strings.Join(parts, " | "))
+}
+
+func writePlanAttribution(sb *strings.Builder, data PlanCommentData) {
+	writeAttributionLineWithSuffix(sb, "Requested", data.RequestedBy, planCommitSuffix(data.Repository, data.HeadSHA))
+}
+
+func planCommitSuffix(repository, sha string) string {
+	if sha == "" {
+		return ""
+	}
+	return fmt.Sprintf(" · planned from %s", formatCommitRef(repository, sha))
+}
+
+func formatCommitRef(repository, sha string) string {
+	short := shortSHA(sha)
+	if repository == "" {
+		return fmt.Sprintf("`%s`", short)
+	}
+	return fmt.Sprintf("[`%s`](https://github.com/%s/commit/%s)", short, repository, sha)
+}
+
+func shortSHA(sha string) string {
+	if len(sha) <= 7 {
+		return sha
+	}
+	return sha[:7]
 }
 
 // writeOptions writes the options line if any options are enabled.
@@ -358,6 +386,8 @@ func pluralize(singular string, count int) string {
 type MultiEnvPlanCommentData struct {
 	Database    string
 	SchemaName  string
+	HeadSHA     string
+	Repository  string
 	IsMySQL     bool
 	RequestedBy string
 
@@ -384,7 +414,11 @@ func RenderMultiEnvPlanComment(data MultiEnvPlanCommentData) string {
 	fmt.Fprintf(&sb, "## %s Schema Change Plan\n\n", dbTypeLabel)
 
 	writePlanMetadata(&sb, PlanCommentData{Database: data.Database, SchemaName: data.SchemaName})
-	writeRequesterOrTimestamp(&sb, data.RequestedBy)
+	writePlanAttribution(&sb, PlanCommentData{
+		HeadSHA:     data.HeadSHA,
+		Repository:  data.Repository,
+		RequestedBy: data.RequestedBy,
+	})
 	sb.WriteString("\n")
 
 	// Check which environments have changes

--- a/pkg/webhook/templates/preview.go
+++ b/pkg/webhook/templates/preview.go
@@ -12,6 +12,8 @@ import (
 const (
 	PreviewErrorFirstFailed  = "Error 1061: Duplicate key name 'idx_user_id'"
 	PreviewErrorMiddleFailed = "lock wait timeout exceeded; try restarting transaction"
+	previewRepository        = "block/schemabot"
+	previewHeadSHA           = "abcdef1234567890abcdef1234567890abcdef12"
 )
 
 // PreviewCommentPlan renders a sample plan comment with DDL changes and lint violations.
@@ -20,6 +22,8 @@ func PreviewCommentPlan() string {
 		Database:    "testapp",
 		SchemaName:  "testapp",
 		Environment: "staging",
+		HeadSHA:     previewHeadSHA,
+		Repository:  previewRepository,
 		RequestedBy: "aparajon",
 		IsMySQL:     true,
 		Changes: []KeyspaceChangeData{
@@ -45,6 +49,8 @@ func PreviewCommentPlanNoChanges() string {
 		Database:    "testapp",
 		SchemaName:  "testapp",
 		Environment: "staging",
+		HeadSHA:     previewHeadSHA,
+		Repository:  previewRepository,
 		RequestedBy: "aparajon",
 		IsMySQL:     true,
 		Changes:     nil,
@@ -243,6 +249,8 @@ func PreviewCommentUnsafeBlocked() string {
 		Database:    "testapp",
 		SchemaName:  "testapp",
 		Environment: "staging",
+		HeadSHA:     previewHeadSHA,
+		Repository:  previewRepository,
 		RequestedBy: "aparajon",
 		IsMySQL:     true,
 		Changes: []KeyspaceChangeData{
@@ -268,6 +276,8 @@ func PreviewCommentApplyPlan() string {
 		Database:     "testapp",
 		SchemaName:   "testapp",
 		Environment:  "staging",
+		HeadSHA:      previewHeadSHA,
+		Repository:   previewRepository,
 		RequestedBy:  "aparajon",
 		IsMySQL:      true,
 		Changes:      samplePlanChanges(),
@@ -283,6 +293,8 @@ func PreviewCommentApplyPlanOptions() string {
 		Database:     "testapp",
 		SchemaName:   "testapp",
 		Environment:  "staging",
+		HeadSHA:      previewHeadSHA,
+		Repository:   previewRepository,
 		RequestedBy:  "aparajon",
 		IsMySQL:      true,
 		Changes:      samplePlanChanges(),
@@ -300,6 +312,8 @@ func PreviewCommentApplyPlanUnsafe() string {
 		Database:    "testapp",
 		SchemaName:  "testapp",
 		Environment: "staging",
+		HeadSHA:     previewHeadSHA,
+		Repository:  previewRepository,
 		RequestedBy: "aparajon",
 		IsMySQL:     true,
 		Changes: []KeyspaceChangeData{
@@ -384,6 +398,8 @@ func PreviewCommentVitessPlan() string {
 		Database:    "commerce",
 		SchemaName:  "commerce",
 		Environment: "staging",
+		HeadSHA:     previewHeadSHA,
+		Repository:  previewRepository,
 		RequestedBy: "aparajon",
 		IsMySQL:     false,
 		Changes:     sampleVitessPlanChanges(),
@@ -396,6 +412,8 @@ func PreviewCommentVitessApplyPlan() string {
 		Database:     "commerce",
 		SchemaName:   "commerce",
 		Environment:  "staging",
+		HeadSHA:      previewHeadSHA,
+		Repository:   previewRepository,
 		RequestedBy:  "aparajon",
 		IsMySQL:      false,
 		Changes:      sampleVitessPlanChanges(),
@@ -412,6 +430,8 @@ func PreviewCommentMySQLMultiSchema() string {
 	return RenderPlanComment(PlanCommentData{
 		Database:    "myapp",
 		Environment: "staging",
+		HeadSHA:     previewHeadSHA,
+		Repository:  previewRepository,
 		RequestedBy: "aparajon",
 		IsMySQL:     true,
 		Changes: []KeyspaceChangeData{
@@ -443,6 +463,8 @@ func PreviewCommentMultiEnvPlan() string {
 	return RenderMultiEnvPlanComment(MultiEnvPlanCommentData{
 		Database:     "testapp",
 		SchemaName:   "testapp",
+		HeadSHA:      previewHeadSHA,
+		Repository:   previewRepository,
 		IsMySQL:      true,
 		RequestedBy:  "aparajon",
 		Environments: []string{"staging", "production"},
@@ -477,6 +499,8 @@ func PreviewCommentMultiEnvPlanLint() string {
 	return RenderMultiEnvPlanComment(MultiEnvPlanCommentData{
 		Database:     "testapp",
 		SchemaName:   "testapp",
+		HeadSHA:      previewHeadSHA,
+		Repository:   previewRepository,
 		IsMySQL:      true,
 		RequestedBy:  "",
 		Environments: []string{"staging", "production"},
@@ -495,6 +519,8 @@ func PreviewCommentMultiEnvPlanError() string {
 	return RenderMultiEnvPlanComment(MultiEnvPlanCommentData{
 		Database:     "testapp",
 		SchemaName:   "testapp",
+		HeadSHA:      previewHeadSHA,
+		Repository:   previewRepository,
 		IsMySQL:      true,
 		RequestedBy:  "aparajon",
 		Environments: []string{"staging", "production"},
@@ -519,6 +545,8 @@ func PreviewCommentMultiEnvPlanDiff() string {
 	return RenderMultiEnvPlanComment(MultiEnvPlanCommentData{
 		Database:     "testapp",
 		SchemaName:   "testapp",
+		HeadSHA:      previewHeadSHA,
+		Repository:   previewRepository,
 		IsMySQL:      true,
 		RequestedBy:  "aparajon",
 		Environments: []string{"staging", "production"},


### PR DESCRIPTION
## Summary

- Show the PR head SHA used to generate schema change plan comments
- Link the short SHA inline in the existing requested/started attribution line
- Update generated comment previews for the new provenance text

🤖 Generated by Codex on behalf of aparajon.
