### PR TITLE
feat(metrics): allow schema config environment validation

### DIFF
--- a/pkg/api/telemetry_test.go
+++ b/pkg/api/telemetry_test.go
@@ -301,6 +301,12 @@ func TestRecordStatusCheckOperationMetric(t *testing.T) {
 		Status:       "success",
 	})
 	metrics.RecordStatusCheckOperation(t.Context(), metrics.StatusCheckOperation{
+		Operation:   "schema_config_environment_validation",
+		Repository:  "org/repo",
+		Environment: "staging",
+		Status:      "error",
+	})
+	metrics.RecordStatusCheckOperation(t.Context(), metrics.StatusCheckOperation{
 		Operation:    "not_real",
 		Repository:   "org/repo",
 		Database:     "mydb",
@@ -322,7 +328,7 @@ func TestRecordStatusCheckOperationMetric(t *testing.T) {
 			found = true
 			sum, ok := m.Data.(metricdata.Sum[int64])
 			require.True(t, ok)
-			assert.Len(t, sum.DataPoints, 3, "expected one data point per operation/status attribute set")
+			assert.Len(t, sum.DataPoints, 4, "expected one data point per operation/status attribute set")
 			for _, dp := range sum.DataPoints {
 				operation, hasOperation := dp.Attributes.Value(attribute.Key("operation"))
 				status, hasStatus := dp.Attributes.Value(attribute.Key("status"))

--- a/pkg/metrics/README.md
+++ b/pkg/metrics/README.md
@@ -29,7 +29,7 @@ SchemaBot exposes metrics via OpenTelemetry. All metrics are available at `GET /
 
 **operation** (check ownership): `apply_finished`, `rollback_finished`
 
-**operation** (status checks): `plan_check_recorded`, `apply_started`, `apply_finished`, `rollback_finished`, `aggregate_check_sync`, `stale_check_cleanup`, `stale_check_reconciliation`, `schema_config_discovery`
+**operation** (status checks): `plan_check_recorded`, `apply_started`, `apply_finished`, `rollback_finished`, `aggregate_check_sync`, `stale_check_cleanup`, `stale_check_reconciliation`, `schema_config_discovery`, `schema_config_environment_validation`
 
 **status** (status checks): `success`, `error`, `skipped`, `stale`, `noop`, `blocked` (operation outcome, not GitHub Check Run conclusion)
 
@@ -106,6 +106,7 @@ Operation values:
 | `stale_check_cleanup` | SchemaBot handled stored check state for a database that is no longer touched by the latest commit on the PR branch. Plan-only state can be cleared; apply-owned state stays blocked. |
 | `stale_check_reconciliation` | SchemaBot repaired stale `in_progress` stored check state by comparing it with authoritative apply state after a worker restart, crash, or race. |
 | `schema_config_discovery` | SchemaBot discovered managed schema configs for the PR before deciding what to plan or which aggregate checks to publish. |
+| `schema_config_environment_validation` | SchemaBot found schema changes but none of the environments declared by `schemabot.yaml` are allowed for this deployment, so it failed the aggregate check closed. |
 
 A spike in `status="blocked"` for `operation="aggregate_check_sync"` or
 `operation="stale_check_cleanup"` means SchemaBot is fail-closing instead of

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -352,14 +352,15 @@ func RecordWebhookEvent(ctx context.Context, eventType, action, repo, status str
 }
 
 var knownStatusCheckOperations = map[string]bool{
-	"plan_check_recorded":        true,
-	"apply_started":              true,
-	"apply_finished":             true,
-	"rollback_finished":          true,
-	"aggregate_check_sync":       true,
-	"stale_check_cleanup":        true,
-	"stale_check_reconciliation": true,
-	"schema_config_discovery":    true,
+	"plan_check_recorded":                  true,
+	"apply_started":                        true,
+	"apply_finished":                       true,
+	"rollback_finished":                    true,
+	"aggregate_check_sync":                 true,
+	"stale_check_cleanup":                  true,
+	"stale_check_reconciliation":           true,
+	"schema_config_discovery":              true,
+	"schema_config_environment_validation": true,
 }
 
 var knownStatusCheckStatuses = map[string]bool{


### PR DESCRIPTION
## Summary

- Add `schema_config_environment_validation` to the status-check operation allowlist so the fail-closed environment validation path does not report as `unknown`.
- Update the metrics README with the new operation.
- Extend telemetry coverage for the allowlisted operation.