### PR TITLE
fix(storage): use named apply target locks

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -343,7 +343,7 @@ In a multi-pod deployment, every SchemaBot pod runs its own scheduler. Each sche
              v                                  v
         +-----------------------------------------------+
         | Shared SchemaBot storage                      |
-        | applies, tasks, apply_target_locks            |
+        | applies, tasks, named apply-target locks      |
         | claims use FOR UPDATE SKIP LOCKED             |
         +-----------------------------------------------+
 
@@ -367,13 +367,11 @@ SchemaBot has two different kinds of locking:
 - **Database locks** are coordination state for users and automation. They make ownership visible in CLI/webhook flows and let a human intentionally hold, release, or force-release work for a database.
 - **Apply invariants** are correctness rules enforced by storage. They do not depend on a database lock being present, because direct API callers and `--no-lock` flows still must not create invalid concurrent work.
 
-SchemaBot enforces one active apply per database, database type, and environment when an apply record is created or moved back into an active state. The `applies` table is the tern-layer work table, but storage uses a small target-lock table as the serialization surface for this invariant.
+SchemaBot enforces one active apply per database, database type, and environment when an apply is created or moved back into an active state. Storage takes a per-target MySQL named lock, checks `applies`, writes the row, and releases the lock before returning.
 
-The target lock row lives in `apply_target_locks`. This table is internal storage infrastructure, not user-facing lock state and not apply lifecycle state. A row is created lazily the first time a target is used, then reused for every future apply for that same database/type/environment. Normal apply completion, failure, cancellation, or revert does not delete the row; the active lifecycle remains in `applies`.
+The named lock is internal storage infrastructure, not user-facing lock state or apply lifecycle state. It gives first writers a target-specific serialization point without creating mutex rows during the apply request. Same-target writers wait and re-check `applies`; different targets use different lock names and can proceed concurrently.
 
-`apply_target_locks` exists because the first active apply for a target has no existing `applies` row to lock. Locking the absence of an active row in `applies` requires InnoDB range locks over `idx_database_env`. Those range locks can deadlock independent first-writer transactions when multiple targets are creating applies concurrently. A persistent target row gives storage an exact mutex row before it reads or writes `applies`.
-
-The target row lock is transaction-local. Same-target writers wait on the same `apply_target_locks` row, then re-check `applies` after the earlier writer commits. If an active apply now exists, the later writer fails cleanly. Different targets lock different rows, so they can create or resume applies concurrently without depending on empty-range locks in `applies`.
+If storage cannot acquire the named lock within the bounded wait, the write fails before changing `applies`. If storage cannot confirm lock release, it discards the connection so MySQL releases the session-scoped lock.
 
 The scheduler relies on that invariant. Additional workers increase concurrency across independent targets; they do not make one database/environment run multiple applies at once.
 

--- a/pkg/storage/mysqlstore/applies.go
+++ b/pkg/storage/mysqlstore/applies.go
@@ -4,11 +4,15 @@ package mysqlstore
 
 import (
 	"context"
+	"crypto/sha256"
 	"database/sql"
+	"database/sql/driver"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
+	"time"
 
 	"github.com/block/schemabot/pkg/state"
 	"github.com/block/schemabot/pkg/storage"
@@ -26,17 +30,28 @@ const applyColumnsForApplyAlias = `a.id, a.apply_identifier, a.lock_id, a.plan_i
 	a.state, a.error_message, a.options,
 	a.created_at, a.started_at, a.completed_at, a.updated_at`
 
+const (
+	applyTargetLockWait           = 10 * time.Second
+	applyTargetLockReleaseTimeout = 5 * time.Second
+)
+
 // applyStore implements storage.ApplyStore using MySQL.
 type applyStore struct {
 	db *sql.DB
 }
 
 type applyWriteTx struct {
-	tx *sql.Tx
+	tx             *sql.Tx
+	targetLockConn *sql.Conn
+	targetLockName string
 }
 
 type queryRower interface {
 	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
+}
+
+type txBeginner interface {
+	BeginTx(ctx context.Context, opts *sql.TxOptions) (*sql.Tx, error)
 }
 
 // claimableApplyStates returns apply states where scheduler recovery can safely
@@ -98,13 +113,29 @@ func rollbackApplyTx(ctx context.Context, tx *sql.Tx, operation string) {
 	}
 }
 
-func beginApplyWriteTx(ctx context.Context, db *sql.DB, operation string) (*applyWriteTx, error) {
-	tx, err := db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelRepeatableRead})
+func beginApplyWriteTx(ctx context.Context, beginner txBeginner, operation string) (*applyWriteTx, error) {
+	tx, err := beginner.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelRepeatableRead})
 	if err != nil {
 		return nil, fmt.Errorf("begin %s transaction: %w", operation, err)
 	}
 
 	return &applyWriteTx{tx: tx}, nil
+}
+
+func beginApplyTargetWriteTx(ctx context.Context, db *sql.DB, operation, database, dbType, environment string) (*applyWriteTx, error) {
+	conn, lockName, err := acquireApplyTargetLockConn(ctx, db, database, dbType, environment)
+	if err != nil {
+		return nil, err
+	}
+
+	writeTx, err := beginApplyWriteTx(ctx, conn, operation)
+	if err != nil {
+		releaseApplyTargetLockConn(ctx, conn, lockName, operation)
+		return nil, err
+	}
+	writeTx.targetLockConn = conn
+	writeTx.targetLockName = lockName
+	return writeTx, nil
 }
 
 func (w *applyWriteTx) close(ctx context.Context, operation string) {
@@ -114,6 +145,10 @@ func (w *applyWriteTx) close(ctx context.Context, operation string) {
 	if w.tx != nil {
 		rollbackApplyTx(ctx, w.tx, operation)
 	}
+	if w.targetLockConn != nil {
+		releaseApplyTargetLockConn(ctx, w.targetLockConn, w.targetLockName, operation)
+		w.targetLockConn = nil
+	}
 }
 
 func (w *applyWriteTx) commit() error {
@@ -122,57 +157,83 @@ func (w *applyWriteTx) commit() error {
 	return err
 }
 
-// apply_target_locks rows are persistent mutex rows keyed by target. They are
-// created lazily and intentionally survive apply completion; the apply lifecycle
-// remains in applies, while this table gives first writers an exact row to lock.
-func ensureApplyTargetLockRow(ctx context.Context, db *sql.DB, database, dbType, environment string) error {
-	if !hasApplyTarget(database, dbType, environment) {
-		return fmt.Errorf("active apply target is required for %s/%s/%s", database, dbType, environment)
-	}
-
-	var id int64
-	err := db.QueryRowContext(ctx,
-		"SELECT `id` FROM `apply_target_locks` "+
-			"WHERE `database_name` = ? "+
-			"AND `database_type` = ? "+
-			"AND `environment` = ?",
-		database, dbType, environment,
-	).Scan(&id)
-	if err == nil {
-		return nil
-	}
-	if !errors.Is(err, sql.ErrNoRows) {
-		return fmt.Errorf("read apply target for %s/%s/%s: %w", database, dbType, environment, err)
-	}
-
-	_, err = db.ExecContext(ctx,
-		"INSERT IGNORE INTO `apply_target_locks` (`database_name`, `database_type`, `environment`) "+
-			"VALUES (?, ?, ?)",
-		database, dbType, environment,
-	)
-	if err != nil {
-		return fmt.Errorf("ensure apply target for %s/%s/%s: %w", database, dbType, environment, err)
-	}
-	return nil
+func applyTargetLockName(database, dbType, environment string) string {
+	sum := sha256.Sum256([]byte(database + "\x00" + dbType + "\x00" + environment))
+	return "schemabot_apply_" + hex.EncodeToString(sum[:16])
 }
 
-func lockApplyTargetRow(ctx context.Context, tx *sql.Tx, database, dbType, environment string) error {
-	var id int64
-	err := tx.QueryRowContext(ctx,
-		"SELECT `id` FROM `apply_target_locks` "+
-			"WHERE `database_name` = ? "+
-			"AND `database_type` = ? "+
-			"AND `environment` = ? "+
-			"FOR UPDATE",
-		database, dbType, environment,
-	).Scan(&id)
-	if errors.Is(err, sql.ErrNoRows) {
-		return fmt.Errorf("apply target missing for %s/%s/%s", database, dbType, environment)
+func acquireApplyTargetLockConn(ctx context.Context, db *sql.DB, database, dbType, environment string) (*sql.Conn, string, error) {
+	if !hasApplyTarget(database, dbType, environment) {
+		return nil, "", fmt.Errorf("active apply target is required for %s/%s/%s", database, dbType, environment)
 	}
+
+	conn, err := db.Conn(ctx)
 	if err != nil {
-		return fmt.Errorf("lock apply target for %s/%s/%s: %w", database, dbType, environment, err)
+		return nil, "", fmt.Errorf("get apply target connection for %s/%s/%s: %w", database, dbType, environment, err)
 	}
-	return nil
+
+	lockName := applyTargetLockName(database, dbType, environment)
+	var result sql.NullInt64
+	err = conn.QueryRowContext(ctx, "SELECT GET_LOCK(?, ?)", lockName, int(applyTargetLockWait.Seconds())).Scan(&result)
+	if err != nil {
+		slog.WarnContext(ctx, "failed to acquire apply target lock",
+			"database", database,
+			"database_type", dbType,
+			"environment", environment,
+			"lock", lockName,
+			"wait", applyTargetLockWait,
+			"error", err)
+		closeApplyTargetLockConn(ctx, conn, lockName, "acquire apply target lock")
+		return nil, "", fmt.Errorf("acquire apply target lock for %s/%s/%s: %w", database, dbType, environment, err)
+	}
+	if !result.Valid || result.Int64 != 1 {
+		slog.WarnContext(ctx, "timed out waiting for apply target lock",
+			"database", database,
+			"database_type", dbType,
+			"environment", environment,
+			"lock", lockName,
+			"wait", applyTargetLockWait,
+			"result", result)
+		closeApplyTargetLockConn(ctx, conn, lockName, "acquire apply target lock")
+		return nil, "", fmt.Errorf("timed out waiting for apply target lock for %s/%s/%s", database, dbType, environment)
+	}
+	return conn, lockName, nil
+}
+
+func releaseApplyTargetLockConn(ctx context.Context, conn *sql.Conn, lockName, operation string) {
+	if conn == nil {
+		return
+	}
+
+	releaseCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), applyTargetLockReleaseTimeout)
+	defer cancel()
+
+	var result sql.NullInt64
+	err := conn.QueryRowContext(releaseCtx, "SELECT RELEASE_LOCK(?)", lockName).Scan(&result)
+	if err != nil || !result.Valid || result.Int64 != 1 {
+		slog.WarnContext(releaseCtx, "failed to release apply target lock; discarding connection",
+			"operation", operation,
+			"lock", lockName,
+			"result", result,
+			"error", err)
+		if rawErr := conn.Raw(func(any) error { return driver.ErrBadConn }); rawErr != nil && !errors.Is(rawErr, driver.ErrBadConn) {
+			slog.WarnContext(releaseCtx, "failed to discard apply target lock connection",
+				"operation", operation,
+				"lock", lockName,
+				"error", rawErr)
+		}
+	}
+
+	closeApplyTargetLockConn(releaseCtx, conn, lockName, operation)
+}
+
+func closeApplyTargetLockConn(ctx context.Context, conn *sql.Conn, lockName, operation string) {
+	if err := conn.Close(); err != nil {
+		slog.WarnContext(ctx, "failed to close apply target lock connection",
+			"operation", operation,
+			"lock", lockName,
+			"error", err)
+	}
 }
 
 func checkNoActiveApplyForTarget(ctx context.Context, tx *sql.Tx, database, dbType, environment string, excludeApplyID int64) error {
@@ -230,22 +291,22 @@ func (s *applyStore) Create(ctx context.Context, apply *storage.Apply) (int64, e
 	}
 
 	lockTarget := isActiveApplyState(apply.State)
+	var writeTx *applyWriteTx
+	var err error
 	if lockTarget {
-		if err := ensureApplyTargetLockRow(ctx, s.db, apply.Database, apply.DatabaseType, apply.Environment); err != nil {
+		writeTx, err = beginApplyTargetWriteTx(ctx, s.db, "create apply", apply.Database, apply.DatabaseType, apply.Environment)
+		if err != nil {
 			return 0, err
 		}
-	}
-
-	writeTx, err := beginApplyWriteTx(ctx, s.db, "create apply")
-	if err != nil {
-		return 0, err
+	} else {
+		writeTx, err = beginApplyWriteTx(ctx, s.db, "create apply")
+		if err != nil {
+			return 0, err
+		}
 	}
 	defer writeTx.close(ctx, "create apply")
 
 	if lockTarget {
-		if err := lockApplyTargetRow(ctx, writeTx.tx, apply.Database, apply.DatabaseType, apply.Environment); err != nil {
-			return 0, err
-		}
 		if err := checkNoActiveApplyForTarget(ctx, writeTx.tx, apply.Database, apply.DatabaseType, apply.Environment, 0); err != nil {
 			return 0, err
 		}
@@ -343,22 +404,21 @@ func (s *applyStore) Update(ctx context.Context, apply *storage.Apply) error {
 	}
 
 	shouldLockTarget := lockTarget && hasApplyTarget(database, dbType, environment)
+	var writeTx *applyWriteTx
 	if shouldLockTarget {
-		if err := ensureApplyTargetLockRow(ctx, s.db, database, dbType, environment); err != nil {
+		writeTx, err = beginApplyTargetWriteTx(ctx, s.db, "update apply", database, dbType, environment)
+		if err != nil {
 			return err
 		}
-	}
-
-	writeTx, err := beginApplyWriteTx(ctx, s.db, "update apply")
-	if err != nil {
-		return err
+	} else {
+		writeTx, err = beginApplyWriteTx(ctx, s.db, "update apply")
+		if err != nil {
+			return err
+		}
 	}
 	defer writeTx.close(ctx, "update apply")
 
 	if shouldLockTarget {
-		if err := lockApplyTargetRow(ctx, writeTx.tx, database, dbType, environment); err != nil {
-			return err
-		}
 		if err := checkNoActiveApplyForTarget(ctx, writeTx.tx, database, dbType, environment, apply.ID); err != nil {
 			return err
 		}

--- a/pkg/storage/mysqlstore/applies_test.go
+++ b/pkg/storage/mysqlstore/applies_test.go
@@ -3,8 +3,8 @@
 package mysqlstore
 
 import (
+	"context"
 	"database/sql"
-	"errors"
 	"strconv"
 	"sync"
 	"testing"
@@ -141,116 +141,64 @@ func TestApplyStore_CreateWaitsForApplyTargetLock(t *testing.T) {
 
 	lock := createTestLock(t, store, "testdb", "mysql", "staging")
 
-	guardTx, err := beginApplyWriteTx(ctx, testDB, "test active apply guard")
+	// Hold the same target lock that the create path must acquire. The creates
+	// below use the public store API; a result before release means active
+	// apply writes are not serialized by the per-target lock.
+	guardConn, guardLockName, err := acquireApplyTargetLockConn(ctx, testDB, "testdb", "mysql", "staging")
 	require.NoError(t, err)
-	t.Cleanup(func() { guardTx.close(ctx, "test active apply guard") })
-
-	// Hold the exact target mutex row open. Active apply creation locks this row
-	// before checking applies, so a same-target create waits without relying on
-	// an empty applies range lock.
-	require.NoError(t, ensureApplyTargetLockRow(ctx, testDB, "testdb", "mysql", "staging"))
-	require.NoError(t, lockApplyTargetRow(ctx, guardTx.tx, "testdb", "mysql", "staging"))
-	require.NoError(t, checkNoActiveApplyForTarget(ctx, guardTx.tx, "testdb", "mysql", "staging", 0))
-
-	type createResult struct {
-		id  int64
-		err error
-	}
-	resultCh := make(chan createResult, 1)
-	go func() {
-		id, err := store.Applies().Create(ctx, &storage.Apply{
-			ApplyIdentifier: "apply_concurrent_same_target",
-			LockID:          lock.ID,
-			PlanID:          6,
-			Database:        "testdb",
-			DatabaseType:    "mysql",
-			Repository:      "org/repo",
-			PullRequest:     123,
-			Environment:     "staging",
-			Engine:          "spirit",
-			State:           state.Apply.Pending,
-		})
-		resultCh <- createResult{id: id, err: err}
-	}()
-
-	select {
-	case result := <-resultCh:
-		require.NoError(t, result.err)
-		require.Fail(t, "apply create completed before the target lock was released")
-	case <-time.After(300 * time.Millisecond):
-	}
-
-	require.NoError(t, guardTx.commit())
-
-	select {
-	case result := <-resultCh:
-		require.NoError(t, result.err)
-		assert.NotZero(t, result.id)
-	case <-time.After(5 * time.Second):
-		require.Fail(t, "apply create did not complete after the target lock was released")
-	}
-
-	applies, err := store.Applies().GetByDatabase(ctx, "testdb", "mysql", "staging")
-	require.NoError(t, err)
-	assert.Len(t, applies, 1)
-}
-
-func TestApplyStore_CreateAllowsOneConcurrentActiveApplyForSameTarget(t *testing.T) {
-	clearTables(t)
-	ctx := t.Context()
-	store := New(testDB)
-
-	lock := createTestLock(t, store, "testdb", "mysql", "staging")
-
-	const concurrentCreates = 8
-	start := make(chan struct{})
-	errs := make(chan error, concurrentCreates)
-
-	var wg sync.WaitGroup
-	for i := range concurrentCreates {
-		wg.Go(func() {
-			<-start
-			_, err := store.Applies().Create(ctx, &storage.Apply{
-				ApplyIdentifier: "apply_concurrent_winner_" + strconv.Itoa(i),
-				LockID:          lock.ID,
-				PlanID:          int64(10 + i),
-				Database:        "testdb",
-				DatabaseType:    "mysql",
-				Repository:      "org/repo",
-				PullRequest:     123,
-				Environment:     "staging",
-				Engine:          "spirit",
-				State:           state.Apply.Pending,
-			})
-			errs <- err
-		})
-	}
-
-	close(start)
-	wg.Wait()
-	close(errs)
-
-	var successes, conflicts int
-	for err := range errs {
-		switch {
-		case err == nil:
-			successes++
-		case errors.Is(err, storage.ErrActiveApplyExists):
-			conflicts++
-		default:
-			require.NoError(t, err)
+	releaseGuard := func() {
+		if guardConn == nil {
+			return
 		}
+		releaseApplyTargetLockConn(ctx, guardConn, guardLockName, "test active apply guard")
+		guardConn = nil
 	}
+	t.Cleanup(releaseGuard)
 
-	assert.Equal(t, 1, successes)
-	assert.Equal(t, concurrentCreates-1, conflicts)
+	createCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
+	defer cancel()
+
+	_, err = store.Applies().Create(createCtx, &storage.Apply{
+		ApplyIdentifier: "apply_waiting_same_target",
+		LockID:          lock.ID,
+		PlanID:          6,
+		Database:        "testdb",
+		DatabaseType:    "mysql",
+		Repository:      "org/repo",
+		PullRequest:     123,
+		Environment:     "staging",
+		Engine:          "spirit",
+		State:           state.Apply.Pending,
+	})
+	require.ErrorIs(t, err, context.DeadlineExceeded)
 
 	applies, err := store.Applies().GetByDatabase(ctx, "testdb", "mysql", "staging")
+	require.NoError(t, err)
+	assert.Empty(t, applies)
+
+	releaseGuard()
+
+	id, err := store.Applies().Create(ctx, &storage.Apply{
+		ApplyIdentifier: "apply_after_target_lock_release",
+		LockID:          lock.ID,
+		PlanID:          7,
+		Database:        "testdb",
+		DatabaseType:    "mysql",
+		Repository:      "org/repo",
+		PullRequest:     123,
+		Environment:     "staging",
+		Engine:          "spirit",
+		State:           state.Apply.Pending,
+	})
+	require.NoError(t, err)
+	assert.NotZero(t, id)
+
+	applies, err = store.Applies().GetByDatabase(ctx, "testdb", "mysql", "staging")
 	require.NoError(t, err)
 	assert.Len(t, applies, 1)
 }
 
-func TestApplyStore_CreateAvoidsGapLockDeadlocksForDifferentTargets(t *testing.T) {
+func TestApplyStore_CreateAllowsConcurrentActiveAppliesForDifferentTargets(t *testing.T) {
 	clearTables(t)
 	ctx := t.Context()
 	store := New(testDB)
@@ -292,10 +240,10 @@ func TestApplyStore_CreateAvoidsGapLockDeadlocksForDifferentTargets(t *testing.T
 		lock := locks[target.database+"/"+target.dbType]
 		wg.Go(func() {
 			<-start
-			// If storage protects first writers by locking empty ranges in applies,
-			// these concurrent inserts can deadlock even though every target is
-			// independent. The target-lock row gives each target an exact mutex
-			// before applies is checked, so callers should not see deadlock errors.
+			// These creates all start at the same time, but every apply targets
+			// a different database/type/environment. Storage should serialize
+			// only same-target active applies, so every independent target can
+			// create its first active apply successfully.
 			_, err := store.Applies().Create(ctx, &storage.Apply{
 				ApplyIdentifier: "apply_concurrent_target_" + strconv.Itoa(i),
 				LockID:          lock.ID,


### PR DESCRIPTION
## Summary

- Serialize active apply writes with per-target MySQL named locks before checking `applies`
- Keep user-facing database locks separate from storage-enforced apply invariants
- Cover target-lock waits and independent-target concurrency in storage integration tests

## Locking Model

The invariant is one active apply per `database_name`, `database_type`, and `environment`.

Without a serialization point, two writers can both observe an empty target before either insert commits:

```text
Writer A                         Writer B
--------                         --------
check active applies -> none     check active applies -> none
insert active apply              insert active apply
commit                           commit
```

With the named lock, the check and write are serialized per target:

```text
Writer A                         Writer B
--------                         --------
GET_LOCK(target)                 waits on GET_LOCK(target)
check active applies -> none
insert active apply
commit
RELEASE_LOCK(target)             GET_LOCK(target)
                                 check active applies -> sees A
                                 fail active_apply_exists
```

This avoids bootstrapping mutex rows during the apply write path. Same-target writers wait and re-check `applies`; different targets use different lock names and can proceed concurrently.

If storage cannot acquire the named lock within the bounded wait, the write fails before changing `applies`. If storage cannot confirm lock release, it discards the connection so MySQL releases the session-scoped lock.

🤖 Generated by Codex.