### PR TITLE
feat(scheduler): add retryable apply claims

### DIFF
--- a/docs/spirit_progress.md
+++ b/docs/spirit_progress.md
@@ -269,10 +269,9 @@ The `⠋` is a Braille spinner (animated in the TUI, static here).
    `IsComplete`.
 
 4. **Crash recovery loses up to 500ms of progress.** The pollers write to storage every 500ms.
-   On crash, the last persisted snapshot may be up to 500ms stale. The recovery loop
-   (`Service.RecoverInProgress`) finds applies with stale heartbeats and calls
-   `Tern.ResumeApply()`, which re-plans against the actual DB state to determine what still needs
-   to be done.
+   On crash, the last persisted snapshot may be up to 500ms stale. Scheduler workers find
+   applies with stale heartbeats and call `Tern.ResumeApply()`, which re-plans against the
+   actual DB state to determine what still needs to be done.
 
 5. **ETA is only available via `ProgressDetail` parsing.** Spirit embeds ETA in its summary string.
    The engine layer doesn't extract it into a separate field — it flows through as `ProgressDetail`

--- a/integration/scheduler_test.go
+++ b/integration/scheduler_test.go
@@ -297,7 +297,8 @@ func TestScheduler_ClaimableStates(t *testing.T) {
 			fixture.resetStorage(t)
 
 			applyIdentifier := fmt.Sprintf("apply-claim-state-%d", i)
-			_, err := stor.Applies().Create(ctx, &storage.Apply{
+			now := time.Now()
+			applyID, err := stor.Applies().Create(ctx, &storage.Apply{
 				ApplyIdentifier: applyIdentifier,
 				Database:        appDBName,
 				DatabaseType:    tc.databaseType,
@@ -306,8 +307,30 @@ func TestScheduler_ClaimableStates(t *testing.T) {
 				State:           tc.applyState,
 				Options:         []byte("{}"),
 				Environment:     "staging",
+				CreatedAt:       now,
+				UpdatedAt:       now,
 			})
 			require.NoError(t, err)
+			if tc.applyState == state.Apply.Pending {
+				// Pending applies become scheduler work only after task creation
+				// finishes; a bare pending apply is still in request setup.
+				_, err := stor.Tasks().Create(ctx, &storage.Task{
+					TaskIdentifier: fmt.Sprintf("task-%s", applyIdentifier),
+					ApplyID:        applyID,
+					Database:       appDBName,
+					DatabaseType:   tc.databaseType,
+					Engine:         tc.engine,
+					State:          state.Task.Pending,
+					TableName:      "claimable_pending",
+					DDL:            "ALTER TABLE claimable_pending ADD COLUMN note VARCHAR(255)",
+					DDLAction:      "alter",
+					Options:        []byte("{}"),
+					Environment:    "staging",
+					CreatedAt:      now,
+					UpdatedAt:      now,
+				})
+				require.NoError(t, err)
+			}
 			_, err = schemabotDB.ExecContext(ctx,
 				"UPDATE applies SET updated_at = NOW() - INTERVAL 2 MINUTE WHERE apply_identifier = ?",
 				applyIdentifier)
@@ -366,6 +389,68 @@ func TestScheduler_ClaimRefreshesHeartbeat(t *testing.T) {
 	reclaimed, err := stor.Applies().FindNextApply(ctx)
 	require.NoError(t, err)
 	assert.Nil(t, reclaimed, "freshly claimed apply should not be claimable again")
+}
+
+func TestScheduler_ExpiresRetryableBudget(t *testing.T) {
+	ctx := t.Context()
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	fixture := newSchedulerClaimFixture(t, "retry_budget_")
+	appDBName := fixture.appDBName
+	stor := fixture.store
+
+	now := time.Now()
+	applyID, err := stor.Applies().Create(ctx, &storage.Apply{
+		ApplyIdentifier: "apply-retry-budget-exhausted",
+		Database:        appDBName,
+		DatabaseType:    storage.DatabaseTypeMySQL,
+		Deployment:      appDBName,
+		Engine:          storage.EngineSpirit,
+		State:           state.Apply.FailedRetryable,
+		ErrorMessage:    "temporary engine failure",
+		Options:         []byte("{}"),
+		Attempt:         999,
+		Environment:     "staging",
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	})
+	require.NoError(t, err)
+	_, err = stor.Tasks().Create(ctx, &storage.Task{
+		TaskIdentifier: "task-retry-budget-exhausted",
+		ApplyID:        applyID,
+		Database:       appDBName,
+		DatabaseType:   storage.DatabaseTypeMySQL,
+		Engine:         storage.EngineSpirit,
+		State:          state.Task.FailedRetryable,
+		ErrorMessage:   "temporary engine failure",
+		TableName:      "users",
+		Namespace:      appDBName,
+		DDL:            "ALTER TABLE users ADD COLUMN retry_note VARCHAR(255)",
+		DDLAction:      "alter",
+		Options:        []byte("{}"),
+		Environment:    "staging",
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	})
+	require.NoError(t, err)
+
+	svc := schemabotapi.New(stor, &schemabotapi.ServerConfig{SchedulerWorkers: 1}, nil, logger)
+	require.NoError(t, svc.SetSchedulerPollInterval(50*time.Millisecond))
+	svc.StartScheduler(ctx)
+	defer svc.StopScheduler()
+
+	// The scheduler should convert retry-waiting work to permanent failure once
+	// the retry budget is exhausted, instead of leaving it claimable forever.
+	require.Eventually(t, func() bool {
+		apply, err := stor.Applies().Get(ctx, applyID)
+		require.NoError(t, err)
+		return apply != nil && apply.State == state.Apply.Failed
+	}, 5*time.Second, 100*time.Millisecond)
+
+	tasks, err := stor.Tasks().GetByApplyID(ctx, applyID)
+	require.NoError(t, err)
+	require.Len(t, tasks, 1)
+	assert.Equal(t, state.Task.Failed, tasks[0].State)
 }
 
 func TestScheduler_MultipleWorkersResumeDifferentTargets(t *testing.T) {

--- a/integration/workflow_test.go
+++ b/integration/workflow_test.go
@@ -1310,8 +1310,10 @@ CREATE TABLE orders (
 	t.Logf("Correctly captured MySQL error: %s", errorMessage)
 }
 
-// TestFullWorkflow_Spirit_PartialFailure tests that when one task fails in sequential mode,
-// remaining tasks are marked as CANCELLED and the error is properly surfaced.
+// TestFullWorkflow_Spirit_PartialFailure verifies sequential apply behavior
+// when one table fails with a retryable Spirit error. Completed work remains
+// completed, the failed table pauses in failed_retryable, and later table work
+// stays pending for the scheduler retry.
 func TestFullWorkflow_Spirit_PartialFailure(t *testing.T) {
 	ctx := t.Context()
 
@@ -1320,10 +1322,10 @@ func TestFullWorkflow_Spirit_PartialFailure(t *testing.T) {
 
 	endpoint := "http://" + ts.Addr
 
-	// Three tables in sequential mode (alphabetical order determines execution):
-	// 1. aaa_first - will succeed (simple table)
-	// 2. bbb_fails - will FAIL (FK to non-existent table)
-	// 3. ccc_cancelled - should be CANCELLED (never started)
+	// Three tables in sequential mode. Alphabetical order determines execution:
+	// 1. aaa_first runs first and completes.
+	// 2. bbb_fails fails with a retryable Spirit error.
+	// 3. ccc_cancelled is not reached, so it stays pending for the retry.
 	schemaFiles := map[string]string{
 		"aaa_first.sql": `
 CREATE TABLE aaa_first (
@@ -1371,11 +1373,13 @@ CREATE TABLE ccc_cancelled (
 	})
 	t.Logf("Apply started: %v", applyResp["apply_id"])
 
-	// Step 3: Poll progress until we see failed state
+	// Step 3: Poll progress until the retryable failure is durable in storage.
+	// The request that observes the engine failure can briefly return failed
+	// before the background worker persists failed_retryable.
 	var lastState string
 	var errorMessage string
 	var finalTables []any
-	for range 60 { // Longer timeout for 3 tables
+	for range 60 {
 		progressHTTPReq, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint+"/api/progress/"+appDBName+"?environment=staging", nil)
 		require.NoError(t, err, "create progress request")
 		resp, err := http.DefaultClient.Do(progressHTTPReq)
@@ -1398,18 +1402,18 @@ CREATE TABLE ccc_cancelled (
 
 		t.Logf("Progress state: %s", lastState)
 
-		if lastState == state.Apply.Failed {
+		if lastState == state.Apply.FailedRetryable {
 			break
 		}
 		if lastState == state.Apply.Completed {
-			require.Fail(t, "expected failed but got completed")
+			require.Fail(t, "expected retryable failure but got completed")
 		}
 
 		time.Sleep(300 * time.Millisecond)
 	}
 
 	// Verify overall state
-	assert.Equal(t, state.Apply.Failed, lastState)
+	assert.Equal(t, state.Apply.FailedRetryable, lastState)
 	assert.NotEmpty(t, errorMessage, "expected error_message to be set")
 	t.Logf("Error message: %s", errorMessage)
 
@@ -1426,8 +1430,8 @@ CREATE TABLE ccc_cancelled (
 	}
 
 	assert.Equal(t, "completed", tableStates["aaa_first"], "aaa_first")
-	assert.Equal(t, "failed", tableStates["bbb_fails"], "bbb_fails")
-	assert.Equal(t, "cancelled", tableStates["ccc_cancelled"], "ccc_cancelled")
+	assert.Equal(t, state.Task.FailedRetryable, tableStates["bbb_fails"], "bbb_fails")
+	assert.Equal(t, state.Task.Pending, tableStates["ccc_cancelled"], "ccc_cancelled")
 
 	// Verify aaa_first table was actually created in DB (partial success committed)
 	targetDB, err := sql.Open("mysql", targetDSN+"&multiStatements=true")
@@ -1458,5 +1462,5 @@ CREATE TABLE ccc_cancelled (
 	`, appDBName).Scan(&tableName)
 	assert.Error(t, err, "ccc_cancelled table should NOT exist in DB")
 
-	t.Log("Partial failure test passed: 1 completed, 1 failed, 1 cancelled")
+	t.Log("Partial failure test passed: 1 completed, 1 retryable failed, 1 pending")
 }

--- a/pkg/api/progress_handlers.go
+++ b/pkg/api/progress_handlers.go
@@ -35,10 +35,22 @@ func changeTypeToString(ct ternv1.ChangeType) string {
 // deriveErrorCode returns an error code based on apply state
 // and error message. Returns empty string when no error code applies.
 func deriveErrorCode(applyState, errorMessage string) string {
-	if errorMessage != "" && state.IsState(applyState, state.Apply.Failed) {
+	if errorMessage == "" {
+		return ""
+	}
+	if state.IsState(applyState, state.Apply.FailedRetryable) {
+		return apitypes.ErrCodeEngineErrorRetryable
+	}
+	if state.IsState(applyState, state.Apply.Failed) {
 		return apitypes.ErrCodeEngineError
 	}
 	return ""
+}
+
+// shouldServeProgressFromStorage returns true when storage has the authoritative
+// progress state and there is no active Tern work to poll.
+func shouldServeProgressFromStorage(applyState string) bool {
+	return state.IsTerminalApplyState(applyState) || state.IsState(applyState, state.Apply.FailedRetryable)
 }
 
 // engineName converts a protobuf Engine enum to a display-friendly name.
@@ -146,6 +158,9 @@ func (s *Service) GetProgress(ctx context.Context, database, environment string)
 	// the server-side database target registry for this environment.
 	deployment := ""
 	if activeApply != nil {
+		if shouldServeProgressFromStorage(activeApply.State) {
+			return s.progressFromLocalStorage(ctx, activeApply)
+		}
 		deployment = activeApply.Deployment
 	}
 	deployment, err = s.deploymentForDatabaseEnvironment(database, deployment, environment)
@@ -215,6 +230,17 @@ func (s *Service) handleProgress(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	if activeApply != nil && shouldServeProgressFromStorage(activeApply.State) {
+		httpResp, err := s.progressFromLocalStorage(r.Context(), activeApply)
+		if err != nil {
+			s.logger.Error("failed to read apply progress from storage", "apply_id", activeApply.ApplyIdentifier, "state", activeApply.State, "error", err)
+			s.writeErrorCode(w, http.StatusInternalServerError, apitypes.ErrCodeStorageError, "failed to read apply: "+err.Error())
+			return
+		}
+		s.writeJSON(w, http.StatusOK, httpResp)
+		return
+	}
+
 	// Deployment is a plan-time decision stored on the apply record. If no
 	// apply record exists yet, route by the server-side database target config.
 	var deployment string
@@ -278,11 +304,10 @@ func (s *Service) handleProgressByApplyID(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	// For terminal applies, serve from local storage (no RPC needed).
-	if state.IsTerminalApplyState(apply.State) {
+	if shouldServeProgressFromStorage(apply.State) {
 		httpResp, err := s.progressFromLocalStorage(r.Context(), apply)
 		if err != nil {
-			s.logger.Error("failed to read tasks from storage for terminal apply", "apply_id", applyID, "error", err)
+			s.logger.Error("failed to read apply progress from storage", "apply_id", applyID, "state", apply.State, "error", err)
 			s.writeErrorCode(w, http.StatusInternalServerError, apitypes.ErrCodeStorageError, "failed to read tasks: "+err.Error())
 			return
 		}
@@ -567,7 +592,7 @@ func (s *Service) handleStatus(w http.ResponseWriter, r *http.Request) {
 }
 
 // progressFromLocalStorage builds a ProgressResponse from local apply + task
-// records. Used for terminal applies where the Tern RPC is unnecessary.
+// records when there is no active Tern work to poll.
 //
 // If any local task records are stale (non-terminal state on a terminal apply),
 // this method syncs them from a one-time Tern RPC before building the response.
@@ -581,10 +606,12 @@ func (s *Service) progressFromLocalStorage(ctx context.Context, apply *storage.A
 	// Check if any tasks are stale (non-terminal and not matching the apply
 	// state). A stopped task on a stopped apply is expected, not stale.
 	stale := false
-	for _, task := range tasks {
-		if !state.IsTerminalTaskState(task.State) && task.State != apply.State {
-			stale = true
-			break
+	if !state.IsState(apply.State, state.Apply.FailedRetryable) {
+		for _, task := range tasks {
+			if !state.IsTerminalTaskState(task.State) && task.State != apply.State {
+				stale = true
+				break
+			}
 		}
 	}
 

--- a/pkg/api/scheduler.go
+++ b/pkg/api/scheduler.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/block/schemabot/pkg/metrics"
+	"github.com/block/schemabot/pkg/state"
 )
 
 // Scheduler constants.
@@ -94,6 +95,22 @@ func (s *Service) schedulerWorker(ctx context.Context, workerID int, stop <-chan
 // recoverApplies claims and resumes applies that need attention.
 // Each call claims one apply (if available) to keep the scheduling loop responsive.
 func (s *Service) recoverApplies(ctx context.Context, workerID int) {
+	expired, err := s.storage.Applies().ExpireRetryable(ctx)
+	if err != nil {
+		s.logger.Error("scheduler: failed to expire retryable applies", "worker", workerID, "error", err)
+		metrics.RecordSchedulerClaimFailure(ctx, "expire_retryable_error")
+		return
+	}
+	for _, apply := range expired {
+		s.logger.Error("scheduler: retry budget exhausted",
+			"worker", workerID,
+			"apply_id", apply.ApplyIdentifier,
+			"database", apply.Database,
+			"environment", apply.Environment,
+			"attempt", apply.Attempt)
+		metrics.RecordSchedulerResumeFailure(ctx, apply.Database, apply.Environment, "retry_budget_exhausted")
+	}
+
 	apply, err := s.storage.Applies().FindNextApply(ctx)
 	if err != nil {
 		s.logger.Error("scheduler: failed to claim apply", "worker", workerID, "error", err)
@@ -144,6 +161,10 @@ func (s *Service) recoverApplies(ctx context.Context, workerID int) {
 		s.OnApplyRecovered(apply)
 	}
 
+	retryableClaim := previousState == state.Apply.FailedRetryable
+	if retryableClaim {
+		metrics.AdjustActiveApplies(ctx, 1, apply.Database, apply.Environment)
+	}
 	if err := client.ResumeApply(ctx, apply); err != nil {
 		s.logger.Error("scheduler: failed to resume apply",
 			"worker", workerID,
@@ -151,6 +172,9 @@ func (s *Service) recoverApplies(ctx context.Context, workerID int) {
 			"database", apply.Database,
 			"error", err)
 		metrics.RecordSchedulerResumeFailure(ctx, apply.Database, apply.Environment, "resume_error")
+		if retryableClaim {
+			metrics.AdjustActiveApplies(ctx, -1, apply.Database, apply.Environment)
+		}
 		return
 	}
 

--- a/pkg/apitypes/apitypes.go
+++ b/pkg/apitypes/apitypes.go
@@ -11,20 +11,22 @@ package apitypes
 // constants rather than parsing error_message strings or HTTP status codes.
 // Use IsRetryableErrorCode to determine whether a given code is retryable.
 const (
-	ErrCodeInvalidRequest     = "invalid_request"      // Malformed request (missing params, bad values)
-	ErrCodeNotFound           = "not_found"            // Resource doesn't exist (unknown apply ID, database)
-	ErrCodeDeploymentNotFound = "deployment_not_found" // No tern deployment configured for database/environment
-	ErrCodeEngineError        = "engine_error"         // Schema change engine failure during execution
-	ErrCodeStorageError       = "storage_error"        // Storage backend (MySQL) read/write failure
-	ErrCodeEngineUnavailable  = "engine_unavailable"   // Schema change engine (Tern) unreachable or RPC error
-	ErrCodeStateSyncFailed    = "state_sync_failed"    // Operation succeeded but local state sync failed
-	ErrCodeActiveApplyExists  = "active_apply_exists"  // Another active apply already exists for the target
+	ErrCodeInvalidRequest       = "invalid_request"        // Malformed request (missing params, bad values)
+	ErrCodeNotFound             = "not_found"              // Resource doesn't exist (unknown apply ID, database)
+	ErrCodeDeploymentNotFound   = "deployment_not_found"   // No tern deployment configured for database/environment
+	ErrCodeEngineError          = "engine_error"           // Schema change engine failure during execution
+	ErrCodeEngineErrorRetryable = "engine_error_retryable" // Schema change engine failure that may recover on retry
+	ErrCodeStorageError         = "storage_error"          // Storage backend (MySQL) read/write failure
+	ErrCodeEngineUnavailable    = "engine_unavailable"     // Schema change engine (Tern) unreachable or RPC error
+	ErrCodeStateSyncFailed      = "state_sync_failed"      // Operation succeeded but local state sync failed
+	ErrCodeActiveApplyExists    = "active_apply_exists"    // Another active apply already exists for the target
 )
 
 var retryableErrorCodes = map[string]bool{
-	ErrCodeStorageError:      true,
-	ErrCodeEngineUnavailable: true,
-	ErrCodeStateSyncFailed:   true,
+	ErrCodeEngineErrorRetryable: true,
+	ErrCodeStorageError:         true,
+	ErrCodeEngineUnavailable:    true,
+	ErrCodeStateSyncFailed:      true,
 }
 
 // IsRetryableErrorCode reports whether the given API error code represents a

--- a/pkg/cmd/templates/progress.go
+++ b/pkg/cmd/templates/progress.go
@@ -396,6 +396,8 @@ func FormatProgressState(s string) string {
 		return ANSICyan + "🔄 Cutting over..." + ANSIReset
 	case state.Apply.Completed:
 		return ANSIGreen + "✓ Completed" + ANSIReset
+	case state.Apply.FailedRetryable:
+		return ANSIYellow + "↻ Retrying" + ANSIReset
 	case state.Apply.Failed:
 		return ANSIRed + "✗ Failed" + ANSIReset
 	case state.Apply.Stopped:
@@ -476,6 +478,19 @@ func FormatTableProgress(t TableProgress) string {
 	case state.Apply.Failed:
 		bar := ui.ProgressBarFailed(t.PercentComplete)
 		fmt.Fprintf(&b, indentTable+progressSymbol(t.ChangeType)+"%s: %s ❌ Failed\n", t.TableName, bar)
+		if t.DDL != "" {
+			b.WriteString(formatProgressDDL(t.DDL))
+		}
+		b.WriteString("\n")
+		b.WriteString(FormatShardProgress(t.Shards))
+		return b.String()
+	case state.Apply.FailedRetryable:
+		if t.PercentComplete > 0 {
+			bar := ui.ProgressBar(t.PercentComplete, ui.ColorYellow)
+			fmt.Fprintf(&b, indentTable+progressSymbol(t.ChangeType)+"%s: %s Retrying\n", t.TableName, bar)
+		} else {
+			fmt.Fprintf(&b, indentTable+progressSymbol(t.ChangeType)+"%s: Retrying\n", t.TableName)
+		}
 		if t.DDL != "" {
 			b.WriteString(formatProgressDDL(t.DDL))
 		}
@@ -862,6 +877,8 @@ func StateLabel(s string) string {
 		return "Completed"
 	case state.Apply.Failed:
 		return "Failed"
+	case state.Apply.FailedRetryable:
+		return "Retrying"
 	case state.Apply.Running:
 		return "Running"
 	case state.Apply.WaitingForDeploy:
@@ -902,6 +919,8 @@ func stateColorFunc(s string) func(string) string {
 		return colorWrap(ANSIGreen)
 	case state.Apply.Failed:
 		return colorWrap(ANSIRed)
+	case state.Apply.FailedRetryable:
+		return colorWrap(ANSIYellow)
 	case state.Apply.Running:
 		return colorWrap(ANSICyan)
 	case state.Apply.WaitingForDeploy, state.Apply.WaitingForCutover, state.Apply.CuttingOver:

--- a/pkg/cmd/templates/progress_states_test.go
+++ b/pkg/cmd/templates/progress_states_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/block/schemabot/pkg/state"
+	"github.com/block/schemabot/pkg/ui"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -15,6 +16,7 @@ func TestStateLabel_PlanetScalePhases(t *testing.T) {
 	assert.Equal(t, "Creating deploy request", StateLabel(state.Apply.CreatingDeployRequest))
 	assert.Equal(t, "Validating deploy request", StateLabel(state.Apply.ValidatingDeployRequest))
 	assert.Equal(t, "Cancelled", StateLabel(state.Apply.Cancelled))
+	assert.Equal(t, "Retrying", StateLabel(state.Apply.FailedRetryable))
 }
 
 func TestFormatProgressState_PlanetScalePhases(t *testing.T) {
@@ -24,6 +26,7 @@ func TestFormatProgressState_PlanetScalePhases(t *testing.T) {
 	assert.Contains(t, FormatProgressState(state.Apply.CreatingDeployRequest), "Creating deploy request")
 	assert.Contains(t, FormatProgressState(state.Apply.ValidatingDeployRequest), "Validating deploy request")
 	assert.Contains(t, FormatProgressState(state.Apply.Cancelled), "Cancelled")
+	assert.Contains(t, FormatProgressState(state.Apply.FailedRetryable), "Retrying")
 }
 
 func TestProgressSymbol(t *testing.T) {
@@ -85,6 +88,32 @@ func TestFormatTableProgress_CreateDropLabels(t *testing.T) {
 	}
 	output := FormatTableProgress(tp)
 	assert.Contains(t, output, "Cutting over...")
+}
+
+func TestFormatTableProgress_FailedRetryableKeepsProgress(t *testing.T) {
+	t.Run("with progress", func(t *testing.T) {
+		tp := TableProgress{
+			TableName:       "users",
+			ChangeType:      "alter",
+			Status:          state.Apply.FailedRetryable,
+			PercentComplete: 45,
+		}
+
+		output := FormatTableProgress(tp)
+		assert.Contains(t, output, ui.ProgressBar(45, ui.ColorYellow)+" Retrying")
+	})
+
+	t.Run("without progress", func(t *testing.T) {
+		tp := TableProgress{
+			TableName:  "users",
+			ChangeType: "alter",
+			Status:     state.Apply.FailedRetryable,
+		}
+
+		output := FormatTableProgress(tp)
+		assert.Contains(t, output, "users: Retrying")
+		assert.NotContains(t, output, ui.ColorYellow)
+	})
 }
 
 func TestVSchemaStatusLabel(t *testing.T) {

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -269,6 +269,7 @@ type ProgressResult struct {
 	Progress     int    // 0-100 percent complete
 	Message      string // Human-readable status
 	ErrorMessage string // Error details when State is StateFailed
+	Retryable    bool   // True when a failed progress result can be retried
 	Tables       []TableProgress
 	ResumeState  *ResumeState // Updated resume state (engines may update MigrationContext/Metadata during polling)
 }

--- a/pkg/engine/spirit/spirit.go
+++ b/pkg/engine/spirit/spirit.go
@@ -531,6 +531,7 @@ func (e *Engine) Progress(ctx context.Context, req *engine.ProgressRequest) (*en
 		State:        state,
 		Message:      message,
 		ErrorMessage: rm.errorMessage,
+		Retryable:    state == engine.StateFailed,
 		Tables:       tableProgress,
 		ResumeState:  req.ResumeState,
 	}, nil

--- a/pkg/metrics/README.md
+++ b/pkg/metrics/README.md
@@ -47,7 +47,9 @@ SchemaBot exposes metrics via OpenTelemetry. All metrics are available at `GET /
 
 **status** (webhooks): `processed`, `invalid_signature`, `ignored`
 
-**reason** (scheduler claim failures): `storage_error`, `unknown`
+**reason** (scheduler claim failures): `storage_error`, `expire_retryable_error`, `unknown`
+
+**reason** (scheduler resume failures): `missing_deployment`, `no_client`, `resume_error`, `retry_budget_exhausted`
 
 ### Check Ownership Misses
 

--- a/pkg/schema/mysql/applies.sql
+++ b/pkg/schema/mysql/applies.sql
@@ -16,6 +16,7 @@ CREATE TABLE `applies` (
   `state` varchar(100) NOT NULL,
   `error_message` text,
   `options` json NOT NULL,
+  `attempt` int NOT NULL DEFAULT '0',
   `started_at` datetime DEFAULT NULL,
   `completed_at` datetime DEFAULT NULL,
   `created_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,

--- a/pkg/schema/mysql/tasks.sql
+++ b/pkg/schema/mysql/tasks.sql
@@ -16,6 +16,7 @@ CREATE TABLE `tasks` (
   `state` varchar(100) NOT NULL,
   `error_message` text,
   `options` json DEFAULT NULL,
+  `attempt` int NOT NULL DEFAULT '0',
   `rows_copied` bigint DEFAULT '0',
   `rows_total` bigint DEFAULT '0',
   `progress_percent` int DEFAULT '0',

--- a/pkg/state/README.md
+++ b/pkg/state/README.md
@@ -26,6 +26,7 @@ Vitess OnlineDDL and Spirit report — and they are translated into Task and App
 | CuttingOver | `cutting_over` | Cutover in progress (atomic mode only) |
 | Completed | `completed` | All tasks finished successfully |
 | Failed | `failed` | At least one task failed |
+| FailedRetryable | `failed_retryable` | A retryable engine error occurred; scheduler recovery can retry it |
 | Stopped | `stopped` | User requested stop, resumable via start (engine-dependent) |
 | RevertWindow | `revert_window` | Schema change applied, revert available. Only meaningful for PlanetScale; Spirit doesn't support revert so SchemaBot auto-advances to completed |
 | Reverted | `reverted` | Schema change was reverted |
@@ -42,10 +43,13 @@ stateDiagram-v2
     waiting_for_deploy --> running : deploy triggered
     running --> completed
     running --> failed
+    running --> failed_retryable
     running --> stopped : resumable (Spirit only)
     running --> cancelled : permanent (PlanetScale only)
     running --> waiting_for_cutover : atomic mode
     running --> revert_window : PlanetScale only
+    failed_retryable --> running : scheduler retry
+    failed_retryable --> failed : retry budget exhausted
 
     waiting_for_cutover --> cutting_over
     cutting_over --> completed
@@ -58,6 +62,7 @@ stateDiagram-v2
 - `waiting_for_cutover`/`cutting_over`: Only with `--defer-cutover` or atomic mode (Spirit). Note: `--defer-cutover` is a no-op for instant DDL (no cutover exists).
 - `revert_window`: Only with `--enable-revert`. Spirit auto-advances through it; PlanetScale holds until expiry or user action. Maps from PlanetScale's `complete_pending_revert` deploy state
 - `stopped`: Spirit only — resumable via `schemabot start`. Spirit checkpoints progress for resume.
+- `failed_retryable`: transient engine failure. Scheduler workers retry while the retry budget remains, then move the apply to `failed`.
 - `cancelled`: PlanetScale only — permanent. Cancels the deploy request; the underlying Vitess migrations are cancelled. Not resumable — start a new apply instead.
 
 ## Task states
@@ -70,29 +75,75 @@ Per-table execution state. Same state machine as Apply, plus `cancelled`:
 | Running | `running` | Engine is actively executing (row copy, checksum, etc.) |
 | WaitingForCutover | `waiting_for_cutover` | Row copy complete, waiting for cutover signal |
 | CuttingOver | `cutting_over` | Table cutover in progress |
-| Completed | `complete` | Schema change applied successfully |
+| Completed | `completed` | Schema change applied successfully |
 | Failed | `failed` | Engine reported failure |
+| FailedRetryable | `failed_retryable` | Retryable engine error; reset to pending on scheduler retry |
 | Stopped | `stopped` | User requested stop, checkpoint saved |
 | RevertWindow | `revert_window` | Schema change applied, revert available (PlanetScale only) |
 | Reverted | `reverted` | Schema change was reverted |
 | Cancelled | `cancelled` | Task never executed due to earlier failure (sequential mode) |
+
+### Retryable failure relationship
+
+`failed_retryable` exists at both task and apply levels, but each level answers a different question:
+
+- A **task** in `failed_retryable` means one table's work hit a retryable engine error. The task is not terminal because scheduler recovery may run that table work again.
+- An **apply** in `failed_retryable` means the whole apply is paused and waiting for scheduler recovery. The apply owns the retry attempt counter and retry budget.
+- A **pending task** is unfinished work that is not currently running. It remains attached to the apply and is eligible to run the next time the apply is dispatched.
+
+The apply state rolls up from task state: any `failed_retryable` task makes the apply `failed_retryable` unless a permanent `failed` task is present. Atomic execution can also mark the apply `failed_retryable` while updating the affected tasks from the same retryable engine result.
+
+When the scheduler claims a retryable apply, it refreshes the apply heartbeat as a lease, increments the apply attempt, and re-dispatches the apply. That attempt count is the apply-level dispatch count for the whole retry cycle; it is not a per-task counter.
+
+The scheduler does not claim tasks directly. It claims the `failed_retryable` apply, reloads that apply's tasks, then prepares the retry by clearing only the tasks in `failed_retryable`. Those tasks move back to `pending`, their error message is cleared, and their task attempt count increments. Completed tasks are left alone because their table work already succeeded.
+
+On retry, tasks are handled by their current state:
+
+- `completed` tasks stay completed and are skipped.
+- `failed_retryable` tasks reset to `pending` so they can run again.
+- `pending` tasks remain pending and can run on the next dispatch.
+
+For example, in sequential mode, if table A completed, table B failed retryably, and table C never started, the retry starts from B/C work. Table A is not run again. If the retry budget is exhausted, the scheduler moves the apply to `failed` and converts unfinished tasks to `failed`.
+
+```text
+Before scheduler retry:
+
+  apply: failed_retryable
+
+  task A: completed          (already succeeded)
+  task B: failed_retryable   (retryable engine error)
+  task C: pending            (not reached yet)
+
+Scheduler retry preparation:
+
+  claim apply -> increment apply attempt -> reload tasks
+
+  task A: completed          -> completed   (skipped)
+  task B: failed_retryable   -> pending     (will run again)
+  task C: pending            -> pending     (still waiting)
+
+Next dispatch:
+
+  run pending work: task B, then task C
+```
 
 ## Deriving apply state
 
 `DeriveApplyState()` computes the apply state from the collective task states. Priority rules (highest to lowest):
 
 1. Any task **failed** → apply `failed`
-2. Any task **stopped** → apply `stopped`
-3. Any task **reverted** → apply `reverted`
-4. All tasks **completed** → apply `completed`
-5. Any task **cutting_over** → apply `cutting_over`
-6. All non-completed tasks **waiting_for_cutover** → apply `waiting_for_cutover`
-7. All non-completed tasks **waiting_for_deploy** → apply `waiting_for_deploy`
-8. Any task **revert_window** → apply `revert_window`
-9. Any task **running** → apply `running`
-10. Otherwise → apply `pending`
+2. Any task **failed_retryable** → apply `failed_retryable`
+3. Any task **stopped** → apply `stopped`
+4. Any task **reverted** → apply `reverted`
+5. All tasks **completed** → apply `completed`
+6. Any task **cutting_over** → apply `cutting_over`
+7. All non-completed tasks **waiting_for_cutover** → apply `waiting_for_cutover`
+8. All non-completed tasks **waiting_for_deploy** → apply `waiting_for_deploy`
+9. Any task **revert_window** → apply `revert_window`
+10. Any task **running** → apply `running`
+11. Otherwise → apply `pending`
 
-Terminal states (`completed`, `failed`, `reverted`, `cancelled`) are checked via `IsTerminalApplyState()`. Note: `stopped` is NOT terminal at the task level — a stopped task can be resumed via Start.
+Terminal states (`completed`, `failed`, `reverted`, `cancelled`) are checked via `IsTerminalApplyState()`. Note: `failed_retryable` is not terminal because scheduler recovery can retry it, and `stopped` is not terminal at the task level because a stopped task can be resumed via Start.
 
 ## Spirit states
 

--- a/pkg/state/apply.go
+++ b/pkg/state/apply.go
@@ -21,6 +21,7 @@ var Apply = struct {
 	RevertWindow      string
 	Completed         string
 	Failed            string
+	FailedRetryable   string
 	Stopped           string
 	Cancelled         string
 	Reverted          string
@@ -42,6 +43,7 @@ var Apply = struct {
 	RevertWindow:      "revert_window",
 	Completed:         "completed",
 	Failed:            "failed",
+	FailedRetryable:   "failed_retryable",
 	Stopped:           "stopped",
 	Cancelled:         "cancelled",
 	Reverted:          "reverted",
@@ -57,15 +59,16 @@ var Apply = struct {
 //
 // State priority (highest to lowest):
 //  1. Any task FAILED → Apply FAILED
-//  2. Any task STOPPED → Apply STOPPED
-//  3. Any task REVERTED → Apply REVERTED
-//  4. All tasks COMPLETED → Apply COMPLETED
-//  5. Any task CUTTING_OVER → Apply CUTTING_OVER
-//  6. All non-completed tasks WAITING_FOR_CUTOVER → Apply WAITING_FOR_CUTOVER
-//  7. All non-completed tasks WAITING_FOR_DEPLOY → Apply WAITING_FOR_DEPLOY
-//  8. Any task REVERT_WINDOW → Apply REVERT_WINDOW
-//  9. Any task RUNNING → Apply RUNNING
-//  10. Otherwise → Apply PENDING
+//  2. Any task FAILED_RETRYABLE → Apply FAILED_RETRYABLE
+//  3. Any task STOPPED → Apply STOPPED
+//  4. Any task REVERTED → Apply REVERTED
+//  5. All tasks COMPLETED → Apply COMPLETED
+//  6. Any task CUTTING_OVER → Apply CUTTING_OVER
+//  7. All non-completed tasks WAITING_FOR_CUTOVER → Apply WAITING_FOR_CUTOVER
+//  8. All non-completed tasks WAITING_FOR_DEPLOY → Apply WAITING_FOR_DEPLOY
+//  9. Any task REVERT_WINDOW → Apply REVERT_WINDOW
+//  10. Any task RUNNING → Apply RUNNING
+//  11. Otherwise → Apply PENDING
 //
 // taskStates should be the State field from each Task. Empty slice returns PENDING.
 func DeriveApplyState(taskStates []string) string {
@@ -82,6 +85,9 @@ func DeriveApplyState(taskStates []string) string {
 
 	if counts[Apply.Failed] > 0 {
 		return Apply.Failed
+	}
+	if counts[Apply.FailedRetryable] > 0 {
+		return Apply.FailedRetryable
 	}
 	if counts[Apply.Cancelled] > 0 {
 		return Apply.Cancelled
@@ -134,6 +140,8 @@ func normalizeApplyState(raw string) string {
 		return Apply.Completed
 	case "FAILED":
 		return Apply.Failed
+	case "FAILED_RETRYABLE":
+		return Apply.FailedRetryable
 	case "STOPPED":
 		return Apply.Stopped
 	case "CANCELLED":
@@ -164,7 +172,8 @@ func IsState(s string, expected ...string) bool {
 }
 
 // IsTerminalApplyState returns true if the state is a terminal state
-// where no further processing will occur.
+// where no further processing will occur. FailedRetryable is not terminal;
+// scheduler workers may claim and retry it.
 func IsTerminalApplyState(s string) bool {
 	switch s {
 	case Apply.Completed, Apply.Failed, Apply.Stopped, Apply.Cancelled, Apply.Reverted:

--- a/pkg/state/apply_test.go
+++ b/pkg/state/apply_test.go
@@ -24,6 +24,7 @@ func TestDeriveApplyState_AllCompleted(t *testing.T) {
 func TestDeriveApplyState_AnyFailed(t *testing.T) {
 	testCases := [][]string{
 		{"FAILED"},
+		{"FAILED", "FAILED_RETRYABLE"},
 		{"RUNNING", "FAILED"},
 		{"COMPLETED", "FAILED"},
 		{"WAITING_FOR_CUTOVER", "FAILED", "COMPLETED"},
@@ -32,6 +33,21 @@ func TestDeriveApplyState_AnyFailed(t *testing.T) {
 
 	for _, states := range testCases {
 		assert.Equal(t, Apply.Failed, DeriveApplyState(states), "input: %v", states)
+	}
+}
+
+// TestDeriveApplyState_FailedRetryable verifies that a retryable task failure
+// rolls the apply up to failed_retryable unless a permanent failed task exists.
+func TestDeriveApplyState_FailedRetryable(t *testing.T) {
+	testCases := [][]string{
+		{"FAILED_RETRYABLE"},
+		{"COMPLETED", "FAILED_RETRYABLE"},
+		{"PENDING", "FAILED_RETRYABLE"},
+		{"failed_retryable"},
+	}
+
+	for _, states := range testCases {
+		assert.Equal(t, Apply.FailedRetryable, DeriveApplyState(states), "input: %v", states)
 	}
 }
 
@@ -168,6 +184,7 @@ func TestIsTerminalApplyState(t *testing.T) {
 	nonTerminalStates := []string{
 		Apply.Pending,
 		Apply.Running,
+		Apply.FailedRetryable,
 		Apply.WaitingForCutover,
 		Apply.CuttingOver,
 		Apply.RevertWindow,
@@ -197,6 +214,8 @@ func TestNormalizeState(t *testing.T) {
 		{"completed", Apply.Completed},
 		{"FAILED", Apply.Failed},
 		{"failed", Apply.Failed},
+		{"FAILED_RETRYABLE", Apply.FailedRetryable},
+		{"failed_retryable", Apply.FailedRetryable},
 		{"STOPPED", Apply.Stopped},
 		{"stopped", Apply.Stopped},
 		{"REVERTED", Apply.Reverted},

--- a/pkg/state/task.go
+++ b/pkg/state/task.go
@@ -18,6 +18,7 @@ var Task = struct {
 	RevertWindow      string
 	Completed         string
 	Failed            string
+	FailedRetryable   string
 	Stopped           string
 	Reverted          string
 	Cancelled         string
@@ -30,6 +31,7 @@ var Task = struct {
 	RevertWindow:      "revert_window",
 	Completed:         "completed",
 	Failed:            "failed",
+	FailedRetryable:   "failed_retryable",
 	Stopped:           "stopped",
 	Reverted:          "reverted",
 	Cancelled:         "cancelled",
@@ -47,6 +49,7 @@ var TerminalTaskStates = []string{
 // IsTerminalTaskState returns true if the state is a terminal task state
 // where no further processing will occur.
 // Stopped is NOT terminal — a stopped task can be resumed via Start.
+// FailedRetryable is NOT terminal — scheduler workers may retry the task.
 func IsTerminalTaskState(s string) bool {
 	switch s {
 	case Task.Completed, Task.Failed, Task.Reverted, Task.Cancelled:
@@ -110,10 +113,16 @@ func NormalizeTaskStatus(raw string) string {
 
 	// Pass-through for already-normalized values
 	case Task.Pending, Task.Running, Task.Completed, Task.Stopped, Task.Failed,
-		Task.RevertWindow, Task.Reverted,
+		Task.FailedRetryable, Task.RevertWindow, Task.Reverted,
 		Task.WaitingForDeploy, Task.WaitingForCutover, Task.CuttingOver, Task.Cancelled:
 		return s
+	}
 
+	switch normalized := NormalizeState(s); normalized {
+	case Task.Pending, Task.Running, Task.Completed, Task.Stopped, Task.Failed,
+		Task.FailedRetryable, Task.RevertWindow, Task.Reverted,
+		Task.WaitingForDeploy, Task.WaitingForCutover, Task.CuttingOver, Task.Cancelled:
+		return normalized
 	default:
 		return Task.Running
 	}

--- a/pkg/state/task_test.go
+++ b/pkg/state/task_test.go
@@ -52,8 +52,8 @@ func TestNormalizeTaskStatus_VitessStates(t *testing.T) {
 
 func TestNormalizeTaskStatus_PassThrough(t *testing.T) {
 	for _, s := range []string{
-		Task.Pending, Task.Running, Task.Stopped, Task.Failed,
-		Task.RevertWindow, Task.Reverted,
+		Task.Pending, Task.Running, Task.Completed, Task.Stopped, Task.Failed,
+		Task.FailedRetryable, Task.RevertWindow, Task.Reverted,
 		Task.WaitingForDeploy, Task.WaitingForCutover, Task.CuttingOver, Task.Cancelled,
 	} {
 		assert.Equal(t, s, NormalizeTaskStatus(s), "NormalizeTaskStatus(%q)", s)
@@ -63,6 +63,9 @@ func TestNormalizeTaskStatus_PassThrough(t *testing.T) {
 func TestNormalizeTaskStatus_StatePrefix(t *testing.T) {
 	assert.Equal(t, Task.Running, NormalizeTaskStatus("STATE_running"))
 	assert.Equal(t, Task.Completed, NormalizeTaskStatus("state_complete"))
+	assert.Equal(t, Task.Completed, NormalizeTaskStatus("STATE_COMPLETED"))
+	assert.Equal(t, Task.FailedRetryable, NormalizeTaskStatus("STATE_FAILED_RETRYABLE"))
+	assert.Equal(t, Task.WaitingForCutover, NormalizeTaskStatus("STATE_WAITING_FOR_CUTOVER"))
 }
 
 func TestNormalizeTaskStatus_StorageCompleted(t *testing.T) {

--- a/pkg/storage/mysqlstore/applies.go
+++ b/pkg/storage/mysqlstore/applies.go
@@ -22,13 +22,17 @@ import (
 // applyColumns lists all columns for SELECT queries.
 const applyColumns = `id, apply_identifier, lock_id, plan_id, database_name, database_type,
 	repository, pull_request, environment, deployment, caller, installation_id, external_id, engine,
-	state, error_message, options,
+	state, error_message, options, attempt,
 	created_at, started_at, completed_at, updated_at`
 
 const applyColumnsForApplyAlias = `a.id, a.apply_identifier, a.lock_id, a.plan_id, a.database_name, a.database_type,
 	a.repository, a.pull_request, a.environment, a.deployment, a.caller, a.installation_id, a.external_id, a.engine,
-	a.state, a.error_message, a.options,
+	a.state, a.error_message, a.options, a.attempt,
 	a.created_at, a.started_at, a.completed_at, a.updated_at`
+
+// maxRecoveryAttempts is the retry budget for failed_retryable applies. The
+// original apply attempt is separate; this counts scheduler redispatches.
+const maxRecoveryAttempts = 10
 
 const (
 	applyTargetLockWait           = 10 * time.Second
@@ -54,16 +58,15 @@ type txBeginner interface {
 	BeginTx(ctx context.Context, opts *sql.TxOptions) (*sql.Tx, error)
 }
 
-// claimableApplyStates returns apply states where scheduler recovery can safely
-// resume work after the heartbeat becomes stale. Pending and running states can
-// be orphaned by a server crash, and deploy/cutover/revert-window states have
-// already persisted enough engine metadata for recovery to continue from stored
-// state. Terminal states are already done, stopped requires an explicit user
-// start, and PlanetScale setup states are excluded until recovery can reload the
-// persisted branch/deploy metadata needed to resume them without restarting setup.
+// claimableApplyStates returns active apply states where scheduler recovery can
+// safely resume work after the heartbeat becomes stale. Pending has a separate
+// queue path and does not need to be stale before a worker claims it. Terminal
+// states are already done, failed_retryable has its own retry path, stopped
+// requires an explicit user start, and PlanetScale setup states are excluded
+// until recovery can reload the persisted branch/deploy metadata needed to
+// resume them without restarting setup.
 func claimableApplyStates() []string {
 	return []string{
-		state.Apply.Pending,
 		state.Apply.Running,
 		state.Apply.WaitingForDeploy,
 		state.Apply.WaitingForCutover,
@@ -316,12 +319,12 @@ func (s *applyStore) Create(ctx context.Context, apply *storage.Apply) (int64, e
 		INSERT INTO applies (
 			apply_identifier, lock_id, plan_id, database_name, database_type,
 			repository, pull_request, environment, deployment, caller, installation_id, external_id, engine,
-			state, error_message, options
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			state, error_message, options, attempt
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`,
 		apply.ApplyIdentifier, apply.LockID, apply.PlanID, apply.Database, apply.DatabaseType,
 		apply.Repository, apply.PullRequest, apply.Environment, apply.Deployment, apply.Caller, apply.InstallationID, apply.ExternalID, apply.Engine,
-		apply.State, apply.ErrorMessage, string(options),
+		apply.State, apply.ErrorMessage, string(options), apply.Attempt,
 	)
 	if err != nil {
 		if isDuplicateKeyError(err) {
@@ -426,10 +429,10 @@ func (s *applyStore) Update(ctx context.Context, apply *storage.Apply) error {
 
 	_, err = writeTx.tx.ExecContext(ctx, `
 		UPDATE applies
-		SET state = ?, error_message = ?,
+		SET state = ?, error_message = ?, attempt = ?,
 		    external_id = ?, started_at = ?, completed_at = ?, updated_at = NOW()
 		WHERE id = ?
-	`, apply.State, apply.ErrorMessage,
+	`, apply.State, apply.ErrorMessage, apply.Attempt,
 		apply.ExternalID, apply.StartedAt, apply.CompletedAt, apply.ID)
 	if err != nil {
 		return fmt.Errorf("update apply %d: %w", apply.ID, err)
@@ -480,9 +483,11 @@ func (s *applyStore) GetRecent(ctx context.Context, limit int) ([]*storage.Apply
 // and resumes the apply.
 // Returns the claimed apply, or nil if nothing needs work.
 //
-// Matches stale active applies where heartbeat expired > 1 minute. Apply
-// creation/update enforces one active apply per database/type/environment, so
-// claims only need to lease one stale row and avoid worker races on that row.
+// Matches queued pending applies with persisted tasks, stale active applies
+// where heartbeat expired > 1 minute, and failed_retryable applies that still
+// have retry budget. Apply creation/update enforces one active apply per
+// database/type/environment, so claims only need to lease one row and avoid
+// worker races on that row.
 func (s *applyStore) FindNextApply(ctx context.Context) (*storage.Apply, error) {
 	// Read committed keeps concurrent SKIP LOCKED claims from taking next-key
 	// range locks that can serialize workers across otherwise independent targets.
@@ -494,7 +499,9 @@ func (s *applyStore) FindNextApply(ctx context.Context) (*storage.Apply, error) 
 
 	activeStates := claimableApplyStates()
 	activeStatePlaceholders := placeholders(len(activeStates))
-	queryArgs := stringArgs(activeStates)
+	queryArgs := []any{state.Apply.Pending}
+	queryArgs = append(queryArgs, stringArgs(activeStates)...)
+	queryArgs = append(queryArgs, state.Apply.FailedRetryable, maxRecoveryAttempts)
 
 	// Apply creation/update enforces at most one active apply per
 	// database/type/environment. The claim query only needs to find stale work;
@@ -502,8 +509,11 @@ func (s *applyStore) FindNextApply(ctx context.Context) (*storage.Apply, error) 
 	row := tx.QueryRowContext(ctx, fmt.Sprintf(`
 		SELECT %s
 		FROM applies a
-		WHERE a.state IN (%s)
-		AND a.updated_at < NOW() - INTERVAL 1 MINUTE
+		WHERE (
+			(a.state = ? AND EXISTS (SELECT 1 FROM tasks t WHERE t.apply_id = a.id))
+			OR (a.state IN (%s) AND a.updated_at < NOW() - INTERVAL 1 MINUTE)
+			OR (a.state = ? AND a.attempt < ?)
+		)
 		ORDER BY a.created_at
 		LIMIT 1
 		FOR UPDATE SKIP LOCKED
@@ -518,11 +528,41 @@ func (s *applyStore) FindNextApply(ctx context.Context) (*storage.Apply, error) 
 	}
 
 	// Refresh the heartbeat as part of the claim before releasing the row lock.
-	_, err = tx.ExecContext(ctx, `
-		UPDATE applies SET updated_at = NOW() WHERE id = ?
-	`, apply.ID)
-	if err != nil {
-		return nil, fmt.Errorf("refresh heartbeat for claimed apply %d: %w", apply.ID, err)
+	// Pending and retryable applies become running while dispatch starts, so
+	// the leased row remains in the stale-recovery state family if the worker
+	// crashes before the engine starts.
+	if apply.State == state.Apply.Pending || apply.State == state.Apply.FailedRetryable {
+		var result sql.Result
+		nextState := state.Apply.Running
+		result, err = tx.ExecContext(ctx, `
+			UPDATE applies
+			SET state = ?, updated_at = NOW(),
+			    attempt = CASE WHEN ? = ? THEN attempt + 1 ELSE attempt END,
+			    completed_at = NULL,
+			    error_message = CASE WHEN ? = ? THEN '' ELSE error_message END
+			WHERE id = ? AND state = ?
+		`, nextState, apply.State, state.Apply.FailedRetryable, apply.State, state.Apply.FailedRetryable, apply.ID, apply.State)
+		if err != nil {
+			return nil, fmt.Errorf("claim apply %d in state %s: %w", apply.ID, apply.State, err)
+		}
+		rows, err := result.RowsAffected()
+		if err != nil {
+			return nil, fmt.Errorf("read claim rows affected for apply %d: %w", apply.ID, err)
+		}
+		if rows == 0 {
+			return nil, nil
+		}
+		if apply.State == state.Apply.FailedRetryable {
+			apply.Attempt++
+			apply.ErrorMessage = ""
+		}
+	} else {
+		_, err = tx.ExecContext(ctx, `
+			UPDATE applies SET updated_at = NOW() WHERE id = ?
+		`, apply.ID)
+		if err != nil {
+			return nil, fmt.Errorf("refresh heartbeat for claimed apply %d: %w", apply.ID, err)
+		}
 	}
 
 	if err := tx.Commit(); err != nil {
@@ -545,6 +585,74 @@ func (s *applyStore) Heartbeat(ctx context.Context, applyID int64) error {
 		return fmt.Errorf("heartbeat apply %d: %w", applyID, err)
 	}
 	return nil
+}
+
+// ExpireRetryable transitions failed_retryable applies that exhausted their
+// retry budget to permanent failed. Returns the applies updated.
+func (s *applyStore) ExpireRetryable(ctx context.Context) ([]*storage.Apply, error) {
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelReadCommitted})
+	if err != nil {
+		return nil, fmt.Errorf("begin expire retryable applies transaction: %w", err)
+	}
+	defer rollbackApplyTx(ctx, tx, "expire retryable applies")
+
+	rows, err := tx.QueryContext(ctx, `
+		SELECT `+applyColumns+`
+		FROM applies
+		WHERE state = ? AND attempt >= ?
+		FOR UPDATE
+	`, state.Apply.FailedRetryable, maxRecoveryAttempts)
+	if err != nil {
+		return nil, fmt.Errorf("query exhausted retryable applies: %w", err)
+	}
+	applies, err := scanApplies(rows)
+	utils.CloseAndLog(rows)
+	if err != nil {
+		return nil, fmt.Errorf("scan exhausted retryable applies: %w", err)
+	}
+	if len(applies) == 0 {
+		if err := tx.Commit(); err != nil {
+			return nil, fmt.Errorf("commit empty expire retryable applies: %w", err)
+		}
+		return nil, nil
+	}
+
+	applyIDs := make([]any, 0, len(applies))
+	for _, apply := range applies {
+		applyIDs = append(applyIDs, apply.ID)
+	}
+
+	taskArgs := []any{state.Task.Failed}
+	taskArgs = append(taskArgs, stringArgs(state.TerminalTaskStates)...)
+	taskArgs = append(taskArgs, applyIDs...)
+	_, err = tx.ExecContext(ctx, fmt.Sprintf(`
+		UPDATE tasks t
+		SET t.state = ?, t.completed_at = COALESCE(t.completed_at, NOW()), t.updated_at = NOW()
+		WHERE t.state NOT IN (%s) AND t.apply_id IN (%s)
+	`, placeholders(len(state.TerminalTaskStates)), placeholders(len(applyIDs))), taskArgs...)
+	if err != nil {
+		return nil, fmt.Errorf("expire retryable tasks: %w", err)
+	}
+
+	applyArgs := append([]any{state.Apply.Failed}, applyIDs...)
+	_, err = tx.ExecContext(ctx, fmt.Sprintf(`
+		UPDATE applies
+		SET state = ?, completed_at = COALESCE(completed_at, NOW()), updated_at = NOW()
+		WHERE id IN (%s)
+	`, placeholders(len(applyIDs))), applyArgs...)
+	if err != nil {
+		return nil, fmt.Errorf("expire retryable applies: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("commit expire retryable applies: %w", err)
+	}
+	now := time.Now()
+	for _, apply := range applies {
+		apply.State = state.Apply.Failed
+		apply.CompletedAt = &now
+		apply.UpdatedAt = now
+	}
+	return applies, nil
 }
 
 // GetByDatabase returns applies for a specific database and optionally filtered by dbType and environment.
@@ -677,7 +785,7 @@ func scanApplyInto(s scanner) (*storage.Apply, error) {
 		&apply.Database, &apply.DatabaseType,
 		&apply.Repository, &apply.PullRequest, &apply.Environment, &apply.Deployment,
 		&apply.Caller, &apply.InstallationID, &apply.ExternalID, &apply.Engine,
-		&apply.State, &apply.ErrorMessage, &options,
+		&apply.State, &apply.ErrorMessage, &options, &apply.Attempt,
 		&apply.CreatedAt, &startedAt, &completedAt, &apply.UpdatedAt,
 	)
 	if err != nil {

--- a/pkg/storage/mysqlstore/applies_test.go
+++ b/pkg/storage/mysqlstore/applies_test.go
@@ -479,6 +479,156 @@ func TestApplyStore_GetInProgress(t *testing.T) {
 	assert.True(t, applyIDs[running.ApplyIdentifier], "expected running apply")
 }
 
+// TestApplyStore_FindNextApplyClaimsRetryable verifies the storage-level retry
+// claim behavior. The caller sees the retryable state that was claimed, while
+// the stored row is leased as running with an incremented apply attempt.
+func TestApplyStore_FindNextApplyClaimsRetryable(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", storage.DatabaseTypeMySQL, "staging")
+	apply := createTestApplyWithStateAndEnv(t, store, lock, "apply_retryable_claim", 500, state.Apply.FailedRetryable, "staging")
+	apply.ErrorMessage = "transient engine failure"
+	require.NoError(t, store.Applies().Update(ctx, apply))
+
+	claimed, err := store.Applies().FindNextApply(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, claimed)
+	assert.Equal(t, apply.ApplyIdentifier, claimed.ApplyIdentifier)
+	assert.Equal(t, state.Apply.FailedRetryable, claimed.State)
+	assert.Equal(t, 1, claimed.Attempt)
+	assert.Empty(t, claimed.ErrorMessage)
+
+	persisted, err := store.Applies().Get(ctx, apply.ID)
+	require.NoError(t, err)
+	require.NotNil(t, persisted)
+	assert.Equal(t, state.Apply.Running, persisted.State)
+	assert.Equal(t, 1, persisted.Attempt)
+	assert.Empty(t, persisted.ErrorMessage)
+
+	claimedAgain, err := store.Applies().FindNextApply(ctx)
+	require.NoError(t, err)
+	assert.Nil(t, claimedAgain)
+}
+
+func TestApplyStore_FindNextApplyRequiresTasksForPendingApply(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", storage.DatabaseTypeMySQL, "staging")
+	apply := createTestApplyWithStateAndEnv(t, store, lock, "apply_pending_claim", 502, state.Apply.Pending, "staging")
+
+	// A pending apply record can be visible before its task rows are written.
+	// The scheduler must wait for the task list so dispatch has concrete table
+	// work to run.
+	claimedBeforeTasks, err := store.Applies().FindNextApply(ctx)
+	require.NoError(t, err)
+	assert.Nil(t, claimedBeforeTasks, "pending applies are not ready for scheduler dispatch until their tasks are persisted")
+
+	now := time.Now()
+	_, err = store.Tasks().Create(ctx, &storage.Task{
+		TaskIdentifier: "task_pending_claim",
+		ApplyID:        apply.ID,
+		PlanID:         apply.PlanID,
+		Database:       apply.Database,
+		DatabaseType:   apply.DatabaseType,
+		Engine:         storage.EngineSpirit,
+		Environment:    apply.Environment,
+		State:          state.Task.Pending,
+		TableName:      "users",
+		DDL:            "CREATE TABLE users (id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY)",
+		DDLAction:      "CREATE",
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	})
+	require.NoError(t, err)
+
+	// Once at least one task exists, the pending apply is ready to claim. The
+	// caller sees the state it claimed, and the stored row is leased as running.
+	claimed, err := store.Applies().FindNextApply(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, claimed)
+	assert.Equal(t, apply.ApplyIdentifier, claimed.ApplyIdentifier)
+	assert.Equal(t, state.Apply.Pending, claimed.State)
+
+	persisted, err := store.Applies().Get(ctx, apply.ID)
+	require.NoError(t, err)
+	require.NotNil(t, persisted)
+	assert.Equal(t, state.Apply.Running, persisted.State)
+}
+
+// TestApplyStore_ExpireRetryable verifies retry budget exhaustion at the
+// storage layer. A retryable apply that has used all attempts becomes failed,
+// and unfinished tasks are finalized as failed with completion timestamps.
+func TestApplyStore_ExpireRetryable(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", storage.DatabaseTypeMySQL, "staging")
+	apply := createTestApplyWithStateAndEnv(t, store, lock, "apply_retryable_expired", 501, state.Apply.FailedRetryable, "staging")
+	apply.Attempt = maxRecoveryAttempts
+	require.NoError(t, store.Applies().Update(ctx, apply))
+
+	now := time.Now()
+	_, err := store.Tasks().Create(ctx, &storage.Task{
+		TaskIdentifier: "task_retryable_expired",
+		ApplyID:        apply.ID,
+		PlanID:         apply.PlanID,
+		Database:       apply.Database,
+		DatabaseType:   apply.DatabaseType,
+		Engine:         storage.EngineSpirit,
+		Environment:    apply.Environment,
+		State:          state.Task.FailedRetryable,
+		Options:        []byte("{}"),
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	})
+	require.NoError(t, err)
+	_, err = store.Tasks().Create(ctx, &storage.Task{
+		TaskIdentifier: "task_retryable_pending",
+		ApplyID:        apply.ID,
+		PlanID:         apply.PlanID,
+		Database:       apply.Database,
+		DatabaseType:   apply.DatabaseType,
+		Engine:         storage.EngineSpirit,
+		Environment:    apply.Environment,
+		State:          state.Task.Pending,
+		TableName:      "posts",
+		Options:        []byte("{}"),
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	})
+	require.NoError(t, err)
+
+	expired, err := store.Applies().ExpireRetryable(ctx)
+	require.NoError(t, err)
+	require.Len(t, expired, 1)
+	assert.Equal(t, apply.ApplyIdentifier, expired[0].ApplyIdentifier)
+	assert.Equal(t, state.Apply.Failed, expired[0].State)
+	assert.NotNil(t, expired[0].CompletedAt)
+
+	persisted, err := store.Applies().Get(ctx, apply.ID)
+	require.NoError(t, err)
+	require.NotNil(t, persisted)
+	assert.Equal(t, state.Apply.Failed, persisted.State)
+	assert.NotNil(t, persisted.CompletedAt)
+
+	task, err := store.Tasks().Get(ctx, "task_retryable_expired")
+	require.NoError(t, err)
+	require.NotNil(t, task)
+	assert.Equal(t, state.Task.Failed, task.State)
+	assert.NotNil(t, task.CompletedAt)
+
+	pendingTask, err := store.Tasks().Get(ctx, "task_retryable_pending")
+	require.NoError(t, err)
+	require.NotNil(t, pendingTask)
+	assert.Equal(t, state.Task.Failed, pendingTask.State)
+	assert.NotNil(t, pendingTask.CompletedAt)
+}
+
 func TestApplyStore_FindMissingSummaryComment_ExcludesAppliesWithoutGitHubDestination(t *testing.T) {
 	clearTables(t)
 	ctx := t.Context()
@@ -681,6 +831,7 @@ func TestApplyStore_AllFields(t *testing.T) {
 		Engine:          "spirit",
 		State:           state.Apply.WaitingForCutover,
 		ErrorMessage:    "test error",
+		Attempt:         3,
 	}
 	apply.SetOptions(storage.ApplyOptions{
 		AllowUnsafe:  true,
@@ -717,6 +868,7 @@ func TestApplyStore_AllFields(t *testing.T) {
 	assert.Equal(t, "spirit", retrieved.Engine)
 	assert.Equal(t, state.Apply.Completed, retrieved.State)
 	assert.Equal(t, "test error", retrieved.ErrorMessage)
+	assert.Equal(t, 3, retrieved.Attempt)
 	assert.NotNil(t, retrieved.StartedAt)
 	assert.NotNil(t, retrieved.CompletedAt)
 

--- a/pkg/storage/mysqlstore/tasks.go
+++ b/pkg/storage/mysqlstore/tasks.go
@@ -17,7 +17,7 @@ import (
 // taskColumns lists all columns for SELECT queries.
 const taskColumns = `id, task_identifier, apply_id, plan_id, database_name, database_type,
 	namespace, table_name, ddl, ddl_action,
-	engine, repository, pull_request, environment, state, error_message, options,
+	engine, repository, pull_request, environment, state, error_message, options, attempt,
 	rows_copied, rows_total, progress_percent, eta_seconds,
 	is_instant, ready_to_complete, engine_migration_id,
 	started_at, completed_at, created_at, updated_at`
@@ -48,16 +48,16 @@ func (s *taskStore) Create(ctx context.Context, task *storage.Task) (int64, erro
 		INSERT INTO tasks (
 			task_identifier, apply_id, plan_id, database_name, database_type,
 			namespace, table_name, ddl, ddl_action,
-			engine, repository, pull_request, environment, state, error_message, options,
+			engine, repository, pull_request, environment, state, error_message, options, attempt,
 			rows_copied, rows_total, progress_percent, eta_seconds,
 			is_instant, ready_to_complete, engine_migration_id,
 			started_at, completed_at, created_at, updated_at
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`,
 		task.TaskIdentifier, task.ApplyID, task.PlanID, task.Database, task.DatabaseType,
 		task.Namespace, nullString(task.TableName), nullString(task.DDL), nullString(task.DDLAction),
 		task.Engine, task.Repository, task.PullRequest, task.Environment,
-		task.State, nullString(task.ErrorMessage), string(options),
+		task.State, nullString(task.ErrorMessage), string(options), task.Attempt,
 		task.RowsCopied, task.RowsTotal, task.ProgressPercent, task.ETASeconds,
 		task.IsInstant, task.ReadyToComplete, nullString(task.EngineMigrationID),
 		task.StartedAt, task.CompletedAt, task.CreatedAt, task.UpdatedAt,
@@ -89,12 +89,12 @@ func (s *taskStore) Get(ctx context.Context, taskIdentifier string) (*storage.Ta
 func (s *taskStore) Update(ctx context.Context, task *storage.Task) error {
 	_, err := s.db.ExecContext(ctx, `
 		UPDATE tasks SET
-			state = ?, error_message = ?, options = ?,
+			state = ?, error_message = ?, options = ?, attempt = ?,
 			rows_copied = ?, rows_total = ?, progress_percent = ?, eta_seconds = ?,
 			is_instant = ?, ready_to_complete = ?, engine_migration_id = ?,
 			started_at = ?, completed_at = ?, updated_at = NOW()
 		WHERE id = ?
-	`, task.State, nullString(task.ErrorMessage), nullJSON(task.Options),
+	`, task.State, nullString(task.ErrorMessage), nullJSON(task.Options), task.Attempt,
 		task.RowsCopied, task.RowsTotal, task.ProgressPercent, task.ETASeconds,
 		task.IsInstant, task.ReadyToComplete, nullString(task.EngineMigrationID),
 		task.StartedAt, task.CompletedAt,
@@ -255,6 +255,7 @@ func scanTaskInto(s scanner) (*storage.Task, error) {
 		&task.State,
 		&errorMsg,
 		&options,
+		&task.Attempt,
 		&task.RowsCopied,
 		&task.RowsTotal,
 		&task.ProgressPercent,

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -211,6 +211,10 @@ type ApplyStore interface {
 	// If not called for > 1 minute, another worker can claim the apply.
 	Heartbeat(ctx context.Context, applyID int64) error
 
+	// ExpireRetryable transitions failed_retryable applies that exhausted their
+	// retry budget to permanent failed. Returns the applies updated.
+	ExpireRetryable(ctx context.Context) ([]*Apply, error)
+
 	// FindMissingSummaryComment returns GitHub-backed applies that should have
 	// a terminal summary comment but only have a progress comment. Used by
 	// startup reconciliation to post missing summary comments after restarts.

--- a/pkg/storage/types.go
+++ b/pkg/storage/types.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"maps"
 	"sort"
+	"strconv"
 	"time"
 
 	"github.com/block/schemabot/pkg/schema"
@@ -330,6 +331,10 @@ type Apply struct {
 	// Use ParseApplyOptions() to get typed access.
 	Options []byte
 
+	// Attempt tracks scheduler retry attempts for failed_retryable applies.
+	// Once the retry budget is exhausted, the apply becomes failed.
+	Attempt int
+
 	// CreatedAt is when the apply was created.
 	CreatedAt time.Time
 
@@ -367,6 +372,56 @@ type ApplyOptions struct {
 
 	// Volume controls schema change aggressiveness (1-11).
 	Volume int `json:"volume,omitempty"`
+
+	// Target is the opaque endpoint-discovery target forwarded to Tern.
+	// Defaults to the apply database when empty.
+	Target string `json:"target,omitempty"`
+}
+
+// ApplyOptionsFromMap converts API/proto option strings into typed storage options.
+func ApplyOptionsFromMap(options map[string]string) ApplyOptions {
+	opts := ApplyOptions{
+		AllowUnsafe:  options["allow_unsafe"] == "true",
+		Branch:       options["branch"],
+		DeferCutover: options["defer_cutover"] == "true",
+		DeferDeploy:  options["defer_deploy"] == "true",
+		SkipRevert:   options["skip_revert"] == "true",
+		Target:       options["target"],
+	}
+	if rawVolume := options["volume"]; rawVolume != "" {
+		volume, err := strconv.Atoi(rawVolume)
+		if err == nil && volume >= 1 && volume <= 11 {
+			opts.Volume = volume
+		}
+	}
+	return opts
+}
+
+// Map converts typed storage options back into API/proto option strings.
+func (opts ApplyOptions) Map() map[string]string {
+	options := make(map[string]string)
+	if opts.AllowUnsafe {
+		options["allow_unsafe"] = "true"
+	}
+	if opts.Branch != "" {
+		options["branch"] = opts.Branch
+	}
+	if opts.DeferCutover {
+		options["defer_cutover"] = "true"
+	}
+	if opts.DeferDeploy {
+		options["defer_deploy"] = "true"
+	}
+	if opts.SkipRevert {
+		options["skip_revert"] = "true"
+	}
+	if opts.Volume > 0 {
+		options["volume"] = strconv.Itoa(opts.Volume)
+	}
+	if opts.Target != "" {
+		options["target"] = opts.Target
+	}
+	return options
 }
 
 // ParseApplyOptions parses the JSON options into ApplyOptions.
@@ -444,6 +499,9 @@ type Task struct {
 
 	// Options contains engine-specific options as JSON.
 	Options []byte
+
+	// Attempt tracks how many times this task has been retried by scheduler recovery.
+	Attempt int
 
 	// Namespace is the schema name (MySQL) or keyspace (Vitess) this table belongs to.
 	Namespace string

--- a/pkg/storage/types_test.go
+++ b/pkg/storage/types_test.go
@@ -1,0 +1,50 @@
+package storage
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestApplyOptionsFromMapRoundTrip verifies that user-facing apply options can
+// be decoded from API-style strings and encoded back without losing fields.
+func TestApplyOptionsFromMapRoundTrip(t *testing.T) {
+	options := ApplyOptionsFromMap(map[string]string{
+		"allow_unsafe":  "true",
+		"branch":        "schema-change-branch",
+		"defer_cutover": "true",
+		"defer_deploy":  "true",
+		"skip_revert":   "true",
+		"volume":        "7",
+	})
+
+	assert.Equal(t, ApplyOptions{
+		AllowUnsafe:  true,
+		Branch:       "schema-change-branch",
+		DeferCutover: true,
+		DeferDeploy:  true,
+		SkipRevert:   true,
+		Volume:       7,
+	}, options)
+
+	assert.Equal(t, map[string]string{
+		"allow_unsafe":  "true",
+		"branch":        "schema-change-branch",
+		"defer_cutover": "true",
+		"defer_deploy":  "true",
+		"skip_revert":   "true",
+		"volume":        "7",
+	}, options.Map())
+}
+
+// TestApplyOptionsFromMapIgnoresInvalidVolume verifies that malformed numeric
+// options and out-of-range volumes are ignored instead of being persisted back
+// into apply metadata.
+func TestApplyOptionsFromMapIgnoresInvalidVolume(t *testing.T) {
+	for _, volume := range []string{"fast", "0", "-1", "12"} {
+		options := ApplyOptionsFromMap(map[string]string{"volume": volume})
+
+		assert.Zero(t, options.Volume)
+		assert.Empty(t, options.Map())
+	}
+}

--- a/pkg/tern/apply_states_test.go
+++ b/pkg/tern/apply_states_test.go
@@ -101,6 +101,18 @@ func TestDeriveApplyPhase(t *testing.T) {
 	}
 }
 
+func TestTaskStateFromProgressResult(t *testing.T) {
+	t.Run("retryable failed result becomes scheduler-retryable task state", func(t *testing.T) {
+		result := &engine.ProgressResult{State: engine.StateFailed, Retryable: true}
+		assert.Equal(t, state.Task.FailedRetryable, taskStateFromProgressResult(result))
+	})
+
+	t.Run("failed result without retry hint stays permanent", func(t *testing.T) {
+		result := &engine.ProgressResult{State: engine.StateFailed}
+		assert.Equal(t, state.Task.Failed, taskStateFromProgressResult(result))
+	})
+}
+
 func TestApplyEventStateTransition(t *testing.T) {
 	logger := slog.Default()
 	succeedUpdate := func(_ *storage.Apply) error { return nil }
@@ -244,6 +256,22 @@ func TestDeriveOverallState(t *testing.T) {
 			},
 			wantState: state.Task.Failed,
 		},
+		{
+			name: "retryable failed waits for scheduler with completed work",
+			tasks: []*storage.Task{
+				{State: state.Task.FailedRetryable},
+				{State: state.Task.Completed},
+			},
+			wantState: state.Task.FailedRetryable,
+		},
+		{
+			name: "retryable failed waits for scheduler with pending work",
+			tasks: []*storage.Task{
+				{State: state.Task.FailedRetryable},
+				{State: state.Task.Pending},
+			},
+			wantState: state.Task.FailedRetryable,
+		},
 	}
 
 	for _, tt := range tests {
@@ -333,6 +361,15 @@ func TestDeriveVSchemaTaskState(t *testing.T) {
 		result := &engine.ProgressResult{State: engine.StateFailed}
 		got := c.deriveVSchemaTaskState(task, result, state.Task.Failed, now)
 		assert.Equal(t, state.Task.Failed, got)
+	})
+
+	t.Run("transitions to retryable failure when scheduler can recover", func(t *testing.T) {
+		task := &storage.Task{State: state.Task.Running}
+		result := &engine.ProgressResult{State: engine.StateFailed, Retryable: true, ErrorMessage: "temporary engine failure"}
+		got := c.deriveVSchemaTaskState(task, result, state.Task.FailedRetryable, now)
+		assert.Equal(t, state.Task.FailedRetryable, got)
+		assert.Equal(t, "temporary engine failure", task.ErrorMessage)
+		assert.Nil(t, task.CompletedAt)
 	})
 
 	t.Run("stays pending during cutover since VSchema is applied after", func(t *testing.T) {

--- a/pkg/tern/local_apply.go
+++ b/pkg/tern/local_apply.go
@@ -219,11 +219,36 @@ func (c *LocalClient) runWithRecovery(ctx context.Context, apply *storage.Apply,
 	fn()
 }
 
-// executeApplyAtomic runs all DDLs in one Spirit call for atomic cutover (--defer-cutover).
-// All tables copy together and cut over atomically.
+func groupedApplyMode(apply *storage.Apply) string {
+	opts := apply.GetOptions()
+	switch {
+	case apply.DatabaseType == storage.DatabaseTypeMySQL && opts.DeferCutover:
+		return "spirit_atomic_cutover"
+	case apply.DatabaseType == storage.DatabaseTypeVitess:
+		return "vitess_deploy_request"
+	default:
+		return "grouped_engine_apply"
+	}
+}
+
+func groupedApplyModeDescription(apply *storage.Apply) string {
+	switch groupedApplyMode(apply) {
+	case "spirit_atomic_cutover":
+		return "Spirit atomic cutover"
+	case "vitess_deploy_request":
+		return "Vitess deploy request"
+	default:
+		return "grouped engine apply"
+	}
+}
+
+// executeApplyAtomic runs all DDLs in one engine operation. For Spirit with
+// defer_cutover, this is atomic cutover; for Vitess, this is one deploy request.
 func (c *LocalClient) executeApplyAtomic(ctx context.Context, apply *storage.Apply, tasks []*storage.Task, plan *storage.Plan, options map[string]string) {
 	defer c.startApplyHeartbeat(ctx, apply)()
 	creds := c.credentials()
+	mode := groupedApplyMode(apply)
+	modeDescription := groupedApplyModeDescription(apply)
 
 	// Extract all DDLs and table names from tasks
 	ddl := make([]string, len(tasks))
@@ -233,16 +258,8 @@ func (c *LocalClient) executeApplyAtomic(ctx context.Context, apply *storage.App
 		tableNames[i] = t.TableName
 	}
 
-	// Log atomic mode start
-	deferCutover := options["defer_cutover"] == "true"
-	var modeDesc string
-	if deferCutover {
-		modeDesc = "atomic mode (defer-cutover)"
-	} else {
-		modeDesc = "atomic mode"
-	}
 	c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventInfo, storage.LogSourceSchemaBot,
-		fmt.Sprintf("Starting %s with %d tables: %v", modeDesc, len(tasks), tableNames), "", "")
+		fmt.Sprintf("Starting %s with %d tables: %v", modeDescription, len(tasks), tableNames), "", "")
 
 	eng := c.getEngine()
 	defer c.setupSpiritLogging(ctx, apply, tasks)()
@@ -291,8 +308,8 @@ func (c *LocalClient) executeApplyAtomic(ctx context.Context, apply *storage.App
 		c.logger.Error("failed to set started_at", "apply_id", apply.ApplyIdentifier, "error", err)
 	}
 
-	// Atomic mode: all DDLs in one engine call. Use the apply identifier as
-	// MigrationContext so all migrations share one context for progress tracking.
+	// Grouped mode: all DDLs in one engine call. Use the apply identifier as
+	// MigrationContext so all table work shares one context for progress tracking.
 	result, err := eng.Apply(ctx, &engine.ApplyRequest{
 		Database:    apply.Database,
 		PlanID:      plan.PlanIdentifier,
@@ -339,10 +356,24 @@ func (c *LocalClient) executeApplyAtomic(ctx context.Context, apply *storage.App
 	})
 
 	if err != nil {
-		c.failApplyWithTasks(ctx, apply, tasks, err.Error())
-		c.logger.Error("atomic apply failed", "error", err, "apply_id", apply.ApplyIdentifier)
-		c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelError, storage.LogEventError, storage.LogSourceSchemaBot,
-			fmt.Sprintf("Engine apply failed: %v", err), state.Apply.Pending, state.Apply.Failed)
+		newState := state.Apply.Failed
+		if c.shouldRetryEngineError(err) {
+			c.markApplyRetryableWithTasks(ctx, apply, tasks, err.Error())
+			newState = state.Apply.FailedRetryable
+		} else {
+			c.failApplyWithTasks(ctx, apply, tasks, err.Error())
+		}
+		if newState == state.Apply.FailedRetryable {
+			c.logger.Warn("apply paused for scheduler retry", "mode", mode, "error", err, "apply_id", apply.ApplyIdentifier)
+		} else {
+			c.logger.Error("apply failed", "mode", mode, "error", err, "apply_id", apply.ApplyIdentifier)
+		}
+		logLevel := storage.LogLevelError
+		if newState == state.Apply.FailedRetryable {
+			logLevel = storage.LogLevelWarn
+		}
+		c.logApplyEvent(ctx, apply.ID, nil, logLevel, storage.LogEventError, storage.LogSourceSchemaBot,
+			fmt.Sprintf("Engine apply failed: %v", err), state.Apply.Pending, newState)
 		return
 	}
 
@@ -397,7 +428,7 @@ func (c *LocalClient) executeApplyAtomic(ctx context.Context, apply *storage.App
 	if err := c.storage.Applies().Update(ctx, apply); err != nil {
 		c.logger.Error("failed to update apply state", "apply_id", apply.ApplyIdentifier, "state", state.Apply.Running, "error", err)
 	}
-	c.logger.Info("atomic apply started", "apply_id", apply.ApplyIdentifier, "task_count", len(tasks))
+	c.logger.Info("apply started", "mode", mode, "apply_id", apply.ApplyIdentifier, "task_count", len(tasks))
 	c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventStateTransition, storage.LogSourceSchemaBot,
 		fmt.Sprintf("All %d tables started copying in parallel", len(tasks)), state.Apply.Pending, apply.State)
 
@@ -531,7 +562,11 @@ func (c *LocalClient) runEngineTask(ctx context.Context, task *storage.Task, pla
 	})
 
 	if err != nil {
-		c.markTaskFailed(ctx, task, err.Error())
+		if c.shouldRetryEngineError(err) {
+			c.markTaskRetryable(ctx, task, err.Error())
+		} else {
+			c.markTaskFailed(ctx, task, err.Error())
+		}
 		c.logger.Error("task failed", "error", err, "task_id", task.TaskIdentifier, "table", task.TableName)
 		return taskFailed
 	}
@@ -551,7 +586,7 @@ func (c *LocalClient) runEngineTask(ctx context.Context, task *storage.Task, pla
 	c.pollTaskToCompletion(ctx, task, creds)
 
 	switch task.State {
-	case state.Task.Failed:
+	case state.Task.Failed, state.Task.FailedRetryable:
 		return taskFailed
 	case state.Task.Stopped:
 		return taskStopped
@@ -652,6 +687,12 @@ func (c *LocalClient) handleAtomicProgressTick(ctx context.Context, eng engine.E
 		c.logger.Warn("progress check failed",
 			"error", err, "apply_id", apply.ApplyIdentifier, "consecutive_errors", ps.consecutiveErrors)
 		if ps.consecutiveErrors >= 10 {
+			if c.shouldRetryEngineError(err) {
+				c.logger.Warn("progress polling failed repeatedly, pausing apply for scheduler retry",
+					"apply_id", apply.ApplyIdentifier, "consecutive_errors", ps.consecutiveErrors)
+				c.markApplyRetryableWithTasks(ctx, apply, tasks, fmt.Sprintf("progress polling failed after %d consecutive errors: %v", ps.consecutiveErrors, err))
+				return true
+			}
 			c.logger.Error("progress polling failed repeatedly, failing apply",
 				"apply_id", apply.ApplyIdentifier, "consecutive_errors", ps.consecutiveErrors)
 			c.failApplyWithTasks(ctx, apply, tasks, fmt.Sprintf("progress polling failed after %d consecutive errors: %v", ps.consecutiveErrors, err))
@@ -668,7 +709,7 @@ func (c *LocalClient) handleAtomicProgressTick(ctx context.Context, eng engine.E
 	}
 
 	now := time.Now()
-	newState := engineStateToStorage(result.State)
+	newState := taskStateFromProgressResult(result)
 
 	// Log state transitions and track when waiting states are entered (for timeouts)
 	if newState != ps.lastTaskState {
@@ -782,14 +823,19 @@ func (c *LocalClient) handleAtomicProgressTick(ctx context.Context, eng engine.E
 	apply.UpdatedAt = now
 
 	if result.State.IsTerminal() {
-		apply.CompletedAt = &now
+		retryableFailure := state.IsState(newState, state.Task.FailedRetryable)
+		if retryableFailure {
+			apply.CompletedAt = nil
+		} else {
+			apply.CompletedAt = &now
+		}
 		// Propagate error message from failed tasks to the apply record
 		if result.State == engine.StateFailed {
-			if result.ErrorMessage != "" {
-				apply.ErrorMessage = result.ErrorMessage
+			if msg := progressFailureMessage(result); msg != "" {
+				apply.ErrorMessage = msg
 			} else {
 				for _, task := range tasks {
-					if task.State == state.Task.Failed && task.ErrorMessage != "" {
+					if (task.State == state.Task.Failed || task.State == state.Task.FailedRetryable) && task.ErrorMessage != "" {
 						apply.ErrorMessage = fmt.Sprintf("table %s failed: %s", task.TableName, task.ErrorMessage)
 						break
 					}
@@ -800,15 +846,30 @@ func (c *LocalClient) handleAtomicProgressTick(ctx context.Context, eng engine.E
 			c.logger.Error("failed to update apply state", "apply_id", apply.ApplyIdentifier, "state", apply.State, "error", err)
 		}
 		metrics.AdjustActiveApplies(ctx, -1, apply.Database, apply.Environment)
-		if result.State == engine.StateFailed {
-			c.logger.Error("atomic apply failed",
-				"apply_id", apply.ApplyIdentifier, "error", apply.ErrorMessage, "task_count", len(tasks))
-		} else {
-			c.logger.Info("atomic apply completed",
-				"apply_id", apply.ApplyIdentifier, "state", result.State, "task_count", len(tasks))
+		switch {
+		case retryableFailure:
+			c.logger.Warn("apply paused for scheduler retry",
+				"mode", groupedApplyMode(apply), "apply_id", apply.ApplyIdentifier, "error", apply.ErrorMessage, "task_count", len(tasks))
+		case result.State == engine.StateFailed:
+			c.logger.Error("apply failed",
+				"mode", groupedApplyMode(apply), "apply_id", apply.ApplyIdentifier, "error", apply.ErrorMessage, "task_count", len(tasks))
+		default:
+			c.logger.Info("apply completed",
+				"mode", groupedApplyMode(apply), "apply_id", apply.ApplyIdentifier, "state", result.State, "task_count", len(tasks))
+		}
+		eventMessage := fmt.Sprintf("Apply completed with state: %s", result.State)
+		if retryableFailure {
+			eventMessage = "Apply paused for scheduler retry after retryable engine failure"
 		}
 		c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventStateTransition, storage.LogSourceSchemaBot,
-			fmt.Sprintf("Apply completed with state: %s", result.State), ps.lastTaskState, apply.State)
+			eventMessage, ps.lastTaskState, apply.State)
+
+		if retryableFailure {
+			if obs := c.getObserver(apply.ID); obs != nil {
+				obs.OnProgress(apply, tasks)
+			}
+			return true
+		}
 
 		// Notify observer of terminal state, then clean up
 		if obs := c.getObserver(apply.ID); obs != nil {
@@ -893,6 +954,7 @@ func (c *LocalClient) logAtomicProgress(ctx context.Context, apply *storage.Appl
 // syncAtomicTaskProgress updates all tasks with engine state and per-table progress.
 func (c *LocalClient) syncAtomicTaskProgress(ctx context.Context, tasks []*storage.Task, result *engine.ProgressResult, newState string, now time.Time) {
 	tableProgress := indexEngineTableProgress(result.Tables)
+	retryableFailure := state.IsState(newState, state.Task.FailedRetryable)
 	instantFromMetadata := false
 	if result.ResumeState != nil && result.ResumeState.Metadata != "" {
 		if meta, err := decodePSMetadataForStorage(result.ResumeState.Metadata); err == nil && meta != nil {
@@ -901,6 +963,9 @@ func (c *LocalClient) syncAtomicTaskProgress(ctx context.Context, tasks []*stora
 	}
 
 	for _, task := range tasks {
+		if retryableFailure && state.IsTerminalTaskState(task.State) {
+			continue
+		}
 		// VSchema tasks follow deploy-request-level state, not per-migration state.
 		// They have no SHOW VITESS_MIGRATIONS rows. Their state transitions are:
 		// pending → running (during in_progress_vschema) → completed/failed.
@@ -922,26 +987,24 @@ func (c *LocalClient) syncAtomicTaskProgress(ctx context.Context, tasks []*stora
 			if tp.StartedAt != nil && task.StartedAt == nil {
 				task.StartedAt = tp.StartedAt
 			}
-			if tp.CompletedAt != nil && task.CompletedAt == nil {
+			if tp.CompletedAt != nil && !retryableFailure && task.CompletedAt == nil {
 				task.CompletedAt = tp.CompletedAt
 			}
 		} else if instantFromMetadata {
 			task.IsInstant = true
-			if result.State.IsTerminal() {
+			if result.State.IsTerminal() && !retryableFailure {
 				task.ProgressPercent = 100
 			}
 		}
 		if task.StartedAt == nil && newState != state.Task.Pending {
 			task.StartedAt = &now
 		}
-		if result.State.IsTerminal() && task.CompletedAt == nil {
+		if result.State.IsTerminal() && !retryableFailure && task.CompletedAt == nil {
 			task.CompletedAt = &now
 		}
 		if result.State == engine.StateFailed && task.ErrorMessage == "" {
-			if result.ErrorMessage != "" {
-				task.ErrorMessage = result.ErrorMessage
-			} else if result.Message != "" {
-				task.ErrorMessage = result.Message
+			if msg := progressFailureMessage(result); msg != "" {
+				task.ErrorMessage = msg
 			}
 		}
 		if result.State == engine.StateCompleted {
@@ -961,6 +1024,11 @@ func (c *LocalClient) deriveVSchemaTaskState(task *storage.Task, result *engine.
 	}
 
 	switch {
+	case state.IsState(taskState, state.Task.FailedRetryable):
+		if task.ErrorMessage == "" {
+			task.ErrorMessage = progressFailureMessage(result)
+		}
+		return state.Task.FailedRetryable
 	case result.Message == engine.MessageApplyingVSchema:
 		if task.StartedAt == nil {
 			task.StartedAt = &now
@@ -1018,8 +1086,9 @@ func (c *LocalClient) pollTaskToCompletion(ctx context.Context, task *storage.Ta
 
 			now := time.Now()
 			prevState := task.State
-			task.State = engineStateToStorage(result.State)
+			task.State = taskStateFromProgressResult(result)
 			task.UpdatedAt = now
+			retryableFailure := state.IsState(task.State, state.Task.FailedRetryable)
 
 			// Update progress fields from engine result
 			if len(result.Tables) > 0 {
@@ -1033,24 +1102,26 @@ func (c *LocalClient) pollTaskToCompletion(ctx context.Context, task *storage.Ta
 			}
 
 			if result.State.IsTerminal() {
-				task.CompletedAt = &now
+				if retryableFailure {
+					task.CompletedAt = nil
+				} else {
+					task.CompletedAt = &now
+				}
 				if result.State == engine.StateCompleted {
 					task.ProgressPercent = 100
 				}
 				if result.State == engine.StateFailed {
-					if result.ErrorMessage != "" {
-						task.ErrorMessage = result.ErrorMessage
-					} else if result.Message != "" {
-						task.ErrorMessage = result.Message
+					if msg := progressFailureMessage(result); msg != "" {
+						task.ErrorMessage = msg
 					}
 				}
 				logMsg := ""
 				if task.ApplyID > 0 {
-					logMsg = fmt.Sprintf("Task %s completed: engine_state=%s message=%q rows=%d/%d",
+					logMsg = fmt.Sprintf("Task %s finished: engine_state=%s message=%q rows=%d/%d",
 						task.TaskIdentifier, result.State, result.Message, task.RowsCopied, task.RowsTotal)
 				}
-				c.transitionTaskState(ctx, task, task.ApplyID, engineStateToStorage(result.State), logMsg)
-				c.logger.Info("task completed",
+				c.transitionTaskState(ctx, task, task.ApplyID, task.State, logMsg)
+				c.logger.Info("task finished",
 					"task_id", task.TaskIdentifier,
 					"table", task.TableName,
 					"engine_state", result.State,
@@ -1062,7 +1133,7 @@ func (c *LocalClient) pollTaskToCompletion(ctx context.Context, task *storage.Ta
 				return
 			}
 
-			c.transitionTaskState(ctx, task, 0, engineStateToStorage(result.State), "")
+			c.transitionTaskState(ctx, task, 0, task.State, "")
 
 			// Notify observer with full apply + tasks context
 			if obs := c.getObserver(task.ApplyID); obs != nil {
@@ -1082,6 +1153,17 @@ func (c *LocalClient) markTaskFailed(ctx context.Context, task *storage.Task, er
 	task.ErrorMessage = errMsg
 	task.CompletedAt = &now
 	c.transitionTaskState(ctx, task, 0, state.Task.Failed, "")
+}
+
+// markTaskRetryable records a task failure that scheduler recovery may retry.
+func (c *LocalClient) markTaskRetryable(ctx context.Context, task *storage.Task, errMsg string) {
+	task.ErrorMessage = errMsg
+	task.CompletedAt = nil
+	c.transitionTaskState(ctx, task, 0, state.Task.FailedRetryable, "")
+}
+
+func (c *LocalClient) shouldRetryEngineError(err error) bool {
+	return c.config.Type == storage.DatabaseTypeMySQL && engine.IsRetryable(err)
 }
 
 // failApplyWithTasks marks all tasks and the apply as failed with the given error.
@@ -1119,11 +1201,53 @@ func (c *LocalClient) failApplyWithTasks(ctx context.Context, apply *storage.App
 	metrics.AdjustActiveApplies(ctx, -1, apply.Database, apply.Environment)
 }
 
+// markApplyRetryableWithTasks pauses an apply after a retryable engine failure.
+// Non-terminal tasks move to failed_retryable so scheduler recovery can decide
+// which work to re-dispatch on the next attempt.
+func (c *LocalClient) markApplyRetryableWithTasks(ctx context.Context, apply *storage.Apply, tasks []*storage.Task, errMsg string) {
+	for _, task := range tasks {
+		if state.IsTerminalTaskState(task.State) {
+			continue
+		}
+		if task.ErrorMessage == "" {
+			task.ErrorMessage = errMsg
+		}
+		task.CompletedAt = nil
+		c.transitionTaskState(ctx, task, 0, state.Task.FailedRetryable, "")
+	}
+
+	// Re-read the apply from storage; Stop() may have already moved it to a
+	// terminal state between the engine error and this update.
+	fresh, err := c.storage.Applies().Get(ctx, apply.ID)
+	if err == nil && fresh != nil && state.IsTerminalApplyState(fresh.State) {
+		c.logger.Debug("apply already in terminal state, not marking retryable",
+			"apply_id", apply.ApplyIdentifier, "state", fresh.State)
+		return
+	}
+
+	apply.State = state.Apply.FailedRetryable
+	apply.ErrorMessage = errMsg
+	apply.CompletedAt = nil
+	apply.UpdatedAt = time.Now()
+	if err := c.storage.Applies().Update(ctx, apply); err != nil {
+		c.logger.Error("failed to update apply state", "apply_id", apply.ApplyIdentifier, "state", state.Apply.FailedRetryable, "error", err)
+	}
+	metrics.AdjustActiveApplies(ctx, -1, apply.Database, apply.Environment)
+	if obs := c.getObserver(apply.ID); obs != nil {
+		obs.OnProgress(apply, tasks)
+	}
+}
+
 // finalizeSequentialApply updates the apply state based on sequential task outcomes.
-// On failure, remaining PENDING tasks are cancelled.
+// Permanent failures cancel remaining pending tasks; retryable failures leave
+// pending tasks queued for scheduler recovery.
 func (c *LocalClient) finalizeSequentialApply(ctx context.Context, apply *storage.Apply, tasks []*storage.Task, failedTask *storage.Task, stoppedByUser bool) {
 	now := time.Now()
 	switch {
+	case failedTask != nil && failedTask.State == state.Task.FailedRetryable:
+		apply.State = state.Apply.FailedRetryable
+		apply.ErrorMessage = fmt.Sprintf("table %s failed: %s", failedTask.TableName, failedTask.ErrorMessage)
+		apply.CompletedAt = nil
 	case failedTask != nil:
 		apply.State = state.Apply.Failed
 		apply.ErrorMessage = fmt.Sprintf("table %s failed: %s", failedTask.TableName, failedTask.ErrorMessage)
@@ -1145,6 +1269,13 @@ func (c *LocalClient) finalizeSequentialApply(ctx context.Context, apply *storag
 	}
 	metrics.AdjustActiveApplies(ctx, -1, apply.Database, apply.Environment)
 
+	if apply.State == state.Apply.FailedRetryable {
+		if obs := c.getObserver(apply.ID); obs != nil {
+			obs.OnProgress(apply, tasks)
+		}
+		return
+	}
+
 	// Notify observer of terminal state, then clean up
 	if obs := c.getObserver(apply.ID); obs != nil {
 		obs.OnTerminal(apply, tasks)
@@ -1155,16 +1286,17 @@ func (c *LocalClient) finalizeSequentialApply(ctx context.Context, apply *storag
 // deriveOverallState determines the overall state from a list of tasks.
 // Priority order:
 // 1. RUNNING/WAITING_FOR_CUTOVER/CUTTING_OVER - active work in progress
-// 2. PENDING - more work queued
-// 3. STOPPED - apply was stopped (even if some tasks completed)
-// 4. FAILED - at least one task failed (CANCELLED tasks also indicate failure)
-// 5. COMPLETED - all tasks completed successfully
+// 2. FAILED - at least one task failed (CANCELLED tasks also indicate failure)
+// 3. FAILED_RETRYABLE - scheduler recovery may retry failed task work
+// 4. PENDING - more work queued
+// 5. STOPPED - apply was stopped (even if some tasks completed)
+// 6. COMPLETED - all tasks completed successfully
 func deriveOverallState(tasks []*storage.Task) string {
 	if len(tasks) == 0 {
 		return state.Task.Pending
 	}
 
-	var hasRunning, hasPending, hasStopped, hasFailed, hasCancelled, hasCompleted, hasRevertWindow bool
+	var hasRunning, hasPending, hasStopped, hasFailed, hasRetryableFailed, hasCancelled, hasCompleted, hasRevertWindow bool
 	var runningState string
 
 	for _, t := range tasks {
@@ -1184,6 +1316,8 @@ func deriveOverallState(tasks []*storage.Task) string {
 			hasStopped = true
 		case state.Task.Failed:
 			hasFailed = true
+		case state.Task.FailedRetryable:
+			hasRetryableFailed = true
 		case state.Task.Cancelled:
 			hasCancelled = true
 		case state.Task.Completed:
@@ -1197,16 +1331,19 @@ func deriveOverallState(tasks []*storage.Task) string {
 	if hasRunning {
 		return runningState
 	}
+	if hasFailed || hasCancelled {
+		// Cancelled implies a prior task failed (sequential mode), so overall is failed.
+		// For Vitess cancellation (user-initiated), the apply state is set directly.
+		return state.Task.Failed
+	}
+	if hasRetryableFailed {
+		return state.Task.FailedRetryable
+	}
 	if hasPending {
 		return state.Task.Pending
 	}
 	if hasStopped {
 		return state.Task.Stopped
-	}
-	if hasFailed || hasCancelled {
-		// Cancelled implies a prior task failed (sequential mode), so overall is failed.
-		// For Vitess cancellation (user-initiated), the apply state is set directly.
-		return state.Task.Failed
 	}
 	if hasRevertWindow {
 		return state.Task.RevertWindow

--- a/pkg/tern/local_client.go
+++ b/pkg/tern/local_client.go
@@ -487,7 +487,8 @@ func (c *LocalClient) Apply(ctx context.Context, req *ternv1.ApplyRequest) (*ter
 		caller = options["caller"]
 	}
 
-	// Detect atomic mode (--defer-cutover)
+	// Detect deferred cutover. Spirit uses this for atomic cutover; Vitess
+	// always uses the grouped engine apply path for deploy requests.
 	deferCutover := options["defer_cutover"] == "true"
 	allowUnsafe := options["allow_unsafe"] == "true"
 
@@ -606,9 +607,9 @@ func (c *LocalClient) Apply(ctx context.Context, req *ternv1.ApplyRequest) (*ter
 	c.cancelApply = cancelApply
 	c.cancelMu.Unlock()
 	if deferCutover || c.config.Type == storage.DatabaseTypeVitess {
-		// Atomic mode: all DDLs in one engine call.
-		// For Spirit: atomic cutover (--defer-cutover).
-		// For Vitess: always atomic — one deploy request per apply.
+		// Grouped mode: all DDLs are sent in one engine call. For Spirit this
+		// is atomic cutover when defer_cutover is enabled; for Vitess this
+		// creates one deploy request per apply.
 		go c.runWithRecovery(applyCtx, apply, tasks, func() {
 			c.executeApplyAtomic(applyCtx, apply, tasks, plan, options)
 		})
@@ -779,16 +780,20 @@ func (c *LocalClient) Progress(ctx context.Context, req *ternv1.ProgressRequest)
 		if err == nil {
 			engineResult = result
 			c.logger.Info("Progress: engine returned", "engine_state", result.State, "message", result.Message, "task_id", activeTask.TaskIdentifier, "storage_state", activeTask.State)
+			taskState := taskStateFromProgressResult(result)
 
 			// Only update task state from engine if task is not already in a terminal state.
 			// Terminal states (CANCELLED, COMPLETED, FAILED, etc.) should be preserved -
 			// they represent the final state set by the apply execution.
 			if !state.IsTerminalTaskState(activeTask.State) {
-				activeTask.State = engineStateToStorage(result.State)
+				activeTask.State = taskState
 				now := time.Now()
 				activeTask.UpdatedAt = now
-				if result.State.IsTerminal() && activeTask.CompletedAt == nil {
+				if result.State.IsTerminal() && !state.IsState(taskState, state.Task.FailedRetryable) && activeTask.CompletedAt == nil {
 					activeTask.CompletedAt = &now
+				}
+				if result.State == engine.StateFailed && activeTask.ErrorMessage == "" {
+					activeTask.ErrorMessage = progressFailureMessage(result)
 				}
 				if err := c.storage.Tasks().Update(ctx, activeTask); err != nil {
 					c.logger.Warn("failed to update task state from progress poll", "task_id", activeTask.TaskIdentifier, "state", activeTask.State, "error", err)
@@ -800,19 +805,27 @@ func (c *LocalClient) Progress(ctx context.Context, req *ternv1.ProgressRequest)
 			// for this apply are terminal — in sequential mode, the engine reports
 			// "completed" per-task, but the apply isn't done until all tasks finish.
 			if result.State.IsTerminal() {
-				allTerminal := true
+				retryableFailure := state.IsState(taskState, state.Task.FailedRetryable)
+				allTerminal := !retryableFailure
 				for _, t := range currentApplyTasks {
 					if !state.IsTerminalTaskState(t.State) {
 						allTerminal = false
 						break
 					}
 				}
-				if allTerminal {
+				if retryableFailure || allTerminal {
 					apply, _ := c.storage.Applies().GetByApplyIdentifier(ctx, req.ApplyId)
 					if apply != nil && !state.IsTerminalApplyState(apply.State) {
 						now := time.Now()
-						apply.State = engineStateToStorage(result.State)
-						apply.CompletedAt = &now
+						apply.State = taskStateToApplyState(taskState)
+						if retryableFailure {
+							apply.CompletedAt = nil
+						} else {
+							apply.CompletedAt = &now
+						}
+						if result.State == engine.StateFailed {
+							apply.ErrorMessage = progressFailureMessage(result)
+						}
 						apply.UpdatedAt = now
 						if err := c.storage.Applies().Update(ctx, apply); err != nil {
 							c.logger.Warn("failed to update apply from progress poll", "apply_id", apply.ApplyIdentifier, "state", apply.State, "apply_db_id", apply.ID, "error", err)
@@ -928,6 +941,8 @@ func (c *LocalClient) Progress(ctx context.Context, req *ternv1.ProgressRequest)
 			c.logger.Debug("Progress: overriding task-derived state with apply record setup phase",
 				"task_derived", overallState, "apply_record", applyRec.State)
 			overallState = applyRec.State
+		case state.IsState(applyRec.State, state.Apply.FailedRetryable):
+			overallState = applyRec.State
 		case state.IsTerminalApplyState(applyRec.State):
 			overallState = applyRec.State
 		}
@@ -936,7 +951,7 @@ func (c *LocalClient) Progress(ctx context.Context, req *ternv1.ProgressRequest)
 	// If no error from engine, check stored task errors (for restart recovery)
 	if errorMessage == "" {
 		for _, t := range currentApplyTasks {
-			if t.State == state.Task.Failed && t.ErrorMessage != "" {
+			if (t.State == state.Task.Failed || t.State == state.Task.FailedRetryable) && t.ErrorMessage != "" {
 				errorMessage = t.ErrorMessage
 				break
 			}
@@ -944,8 +959,8 @@ func (c *LocalClient) Progress(ctx context.Context, req *ternv1.ProgressRequest)
 	}
 
 	// Clamp per-table status to match overall state. Engine per-table progress
-	// can report individual migrations as completed while the deploy request is
-	// still in revert window. All tasks share one deploy request in atomic mode.
+	// can report individual table work as completed while the grouped apply is
+	// still in revert window.
 	if state.IsState(overallState, state.Apply.RevertWindow) {
 		for _, tp := range tables {
 			if state.IsState(tp.Status, state.Apply.Completed) {

--- a/pkg/tern/local_client_integration_test.go
+++ b/pkg/tern/local_client_integration_test.go
@@ -257,6 +257,34 @@ func waitForApplyComplete(t *testing.T, client *LocalClient, ctx context.Context
 	t.Fatal("apply did not complete within 30s")
 }
 
+type retryableFailureEngine struct {
+	engine.Engine
+}
+
+func (e *retryableFailureEngine) Name() string { return "retryable-failure" }
+
+func (e *retryableFailureEngine) Plan(context.Context, *engine.PlanRequest) (*engine.PlanResult, error) {
+	return &engine.PlanResult{}, nil
+}
+
+func (e *retryableFailureEngine) Apply(context.Context, *engine.ApplyRequest) (*engine.ApplyResult, error) {
+	return &engine.ApplyResult{Accepted: true}, nil
+}
+
+func (e *retryableFailureEngine) Progress(context.Context, *engine.ProgressRequest) (*engine.ProgressResult, error) {
+	return &engine.ProgressResult{
+		State:        engine.StateFailed,
+		Retryable:    true,
+		ErrorMessage: "temporary engine failure",
+		Tables: []engine.TableProgress{{
+			Namespace: "testdb",
+			Table:     "users",
+			State:     state.Task.FailedRetryable,
+			Progress:  45,
+		}},
+	}, nil
+}
+
 func TestLocalClient_NewLocalClient(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
@@ -1244,9 +1272,9 @@ func TestLocalClient_Apply_SequentialNamespaceMatchesTask(t *testing.T) {
 	assert.Equal(t, state.Task.Completed, task.State)
 }
 
-// TestLocalClient_Apply_FailedAtomicHasErrorMessage verifies that when an atomic
-// apply fails, the error message propagates to the apply record. Uses a plan
-// with an invalid DDL (ALTER on nonexistent table) to trigger a Spirit failure.
+// TestLocalClient_Apply_FailedAtomicHasErrorMessage verifies that when Spirit
+// reports an atomic apply failure, the apply pauses for scheduler retry and the
+// failure reason is persisted on both the apply and task records.
 func TestLocalClient_Apply_FailedAtomicHasErrorMessage(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
@@ -1294,14 +1322,15 @@ func TestLocalClient_Apply_FailedAtomicHasErrorMessage(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, applyResp.Accepted, "apply should be accepted: %s", applyResp.ErrorMessage)
 
-	// Wait for failure
+	// Spirit failures are retryable by default. The first failure should pause
+	// in failed_retryable instead of becoming permanently failed.
 	require.Eventually(t, func() bool {
 		applies, _ := stor.Applies().GetByDatabase(ctx, "testdb", "mysql", "")
 		if len(applies) == 0 {
 			return false
 		}
-		return applies[0].State == state.Apply.Failed
-	}, 30*time.Second, 500*time.Millisecond, "apply should fail")
+		return applies[0].State == state.Apply.FailedRetryable
+	}, 30*time.Second, 500*time.Millisecond, "apply should pause for scheduler retry")
 
 	applies, _ := stor.Applies().GetByDatabase(ctx, "testdb", "mysql", "")
 	require.NotEmpty(t, applies)
@@ -1312,5 +1341,166 @@ func TestLocalClient_Apply_FailedAtomicHasErrorMessage(t *testing.T) {
 	tasks, err := stor.Tasks().GetByApplyID(ctx, applies[0].ID)
 	require.NoError(t, err)
 	require.NotEmpty(t, tasks)
+	assert.Equal(t, state.Task.FailedRetryable, tasks[0].State)
+	assert.Nil(t, tasks[0].CompletedAt)
 	assert.NotEmpty(t, tasks[0].ErrorMessage, "task.ErrorMessage should contain the failure reason")
+}
+
+func TestLocalClient_AtomicRetryableFailureQueuesSchedulerRetry(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	_, dsn := setupMySQLContainer(t)
+	setupStorageSchema(t, dsn)
+	cleanupTasks(t, dsn)
+	cleanupTestTables(t, dsn)
+
+	ctx := t.Context()
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	stor := createStorage(t, dsn)
+	defer utils.CloseAndLog(stor)
+
+	client, err := NewLocalClient(LocalConfig{
+		Database:  "testdb",
+		Type:      storage.DatabaseTypeMySQL,
+		TargetDSN: dsn,
+	}, stor, logger)
+	require.NoError(t, err)
+	defer utils.CloseAndLog(client)
+	client.spiritEngine = &retryableFailureEngine{}
+
+	plan := &storage.Plan{
+		PlanIdentifier: fmt.Sprintf("plan-retryable-%d", time.Now().UnixNano()),
+		Database:       "testdb",
+		DatabaseType:   storage.DatabaseTypeMySQL,
+		Deployment:     "testdb",
+		Environment:    "development",
+		CreatedAt:      time.Now(),
+		Namespaces: map[string]*storage.NamespacePlanData{
+			"testdb": {
+				Tables: []storage.TableChange{
+					{Namespace: "testdb", Table: "users", DDL: "ALTER TABLE `users` ADD COLUMN retry_note VARCHAR(255)", Operation: "alter"},
+				},
+			},
+		},
+	}
+	planID, err := stor.Plans().Create(ctx, plan)
+	require.NoError(t, err)
+	plan.ID = planID
+
+	now := time.Now()
+	apply := &storage.Apply{
+		ApplyIdentifier: fmt.Sprintf("apply-retryable-%d", time.Now().UnixNano()),
+		PlanID:          planID,
+		Database:        "testdb",
+		DatabaseType:    storage.DatabaseTypeMySQL,
+		Deployment:      "testdb",
+		Engine:          storage.EngineSpirit,
+		State:           state.Apply.Running,
+		Options:         storage.MarshalApplyOptions(storage.ApplyOptions{DeferCutover: true}),
+		Environment:     "development",
+		StartedAt:       &now,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+	applyID, err := stor.Applies().Create(ctx, apply)
+	require.NoError(t, err)
+	apply.ID = applyID
+
+	tasks := []*storage.Task{
+		{
+			TaskIdentifier: fmt.Sprintf("task-retryable-users-%d", time.Now().UnixNano()),
+			ApplyID:        applyID,
+			PlanID:         planID,
+			Database:       "testdb",
+			DatabaseType:   storage.DatabaseTypeMySQL,
+			Engine:         storage.EngineSpirit,
+			State:          state.Task.Running,
+			TableName:      "users",
+			Namespace:      "testdb",
+			DDL:            "ALTER TABLE `users` ADD COLUMN retry_note VARCHAR(255)",
+			DDLAction:      "alter",
+			Options:        []byte("{}"),
+			Environment:    "development",
+			CreatedAt:      now,
+			UpdatedAt:      now,
+		},
+		{
+			TaskIdentifier:  fmt.Sprintf("task-retryable-orders-%d", time.Now().UnixNano()),
+			ApplyID:         applyID,
+			PlanID:          planID,
+			Database:        "testdb",
+			DatabaseType:    storage.DatabaseTypeMySQL,
+			Engine:          storage.EngineSpirit,
+			State:           state.Task.Completed,
+			TableName:       "orders",
+			Namespace:       "testdb",
+			DDL:             "ALTER TABLE `orders` ADD COLUMN retry_note VARCHAR(255)",
+			DDLAction:       "alter",
+			ProgressPercent: 100,
+			Options:         []byte("{}"),
+			Environment:     "development",
+			CompletedAt:     &now,
+			CreatedAt:       now,
+			UpdatedAt:       now,
+		},
+	}
+	for _, task := range tasks {
+		taskID, err := stor.Tasks().Create(ctx, task)
+		require.NoError(t, err)
+		task.ID = taskID
+	}
+
+	// The engine reports a failed result with Retryable=true. The local Tern
+	// worker should stop this attempt, keep the apply non-terminal, and leave
+	// already-completed task work untouched for the scheduler retry.
+	client.pollForCompletionAtomic(ctx, apply, tasks, &engine.Credentials{DSN: dsn}, nil)
+
+	failedApply, err := stor.Applies().Get(ctx, applyID)
+	require.NoError(t, err)
+	require.NotNil(t, failedApply)
+	assert.Equal(t, state.Apply.FailedRetryable, failedApply.State)
+	assert.Nil(t, failedApply.CompletedAt)
+	assert.Equal(t, "temporary engine failure", failedApply.ErrorMessage)
+
+	failedTasks, err := stor.Tasks().GetByApplyID(ctx, applyID)
+	require.NoError(t, err)
+	require.Len(t, failedTasks, 2)
+	var retryTask, completedTask *storage.Task
+	for _, task := range failedTasks {
+		switch task.TableName {
+		case "users":
+			retryTask = task
+		case "orders":
+			completedTask = task
+		}
+	}
+	require.NotNil(t, retryTask)
+	require.NotNil(t, completedTask)
+	assert.Equal(t, state.Task.FailedRetryable, retryTask.State)
+	assert.Nil(t, retryTask.CompletedAt)
+	assert.Equal(t, "temporary engine failure", retryTask.ErrorMessage)
+	assert.Equal(t, state.Task.Completed, completedTask.State)
+	assert.NotNil(t, completedTask.CompletedAt)
+
+	// When the scheduler claims this apply, retryable tasks are queued for the
+	// next dispatch attempt. Completed tasks stay completed so successful table
+	// work is not repeated.
+	client.prepareRetryableTasksForResume(ctx, failedApply, failedTasks)
+
+	preparedTasks, err := stor.Tasks().GetByApplyID(ctx, applyID)
+	require.NoError(t, err)
+	for _, task := range preparedTasks {
+		switch task.TableName {
+		case "users":
+			assert.Equal(t, state.Task.Pending, task.State)
+			assert.Empty(t, task.ErrorMessage)
+			assert.Nil(t, task.CompletedAt)
+			assert.Equal(t, 1, task.Attempt)
+		case "orders":
+			assert.Equal(t, state.Task.Completed, task.State)
+			assert.Equal(t, 0, task.Attempt)
+		}
+	}
 }

--- a/pkg/tern/local_control_resume.go
+++ b/pkg/tern/local_control_resume.go
@@ -373,6 +373,26 @@ func buildApplyOptions(apply *storage.Apply) map[string]string {
 	return options
 }
 
+// prepareRetryableTasksForResume queues only the task work that previously
+// stopped on a retryable engine failure. Completed tasks remain completed, and
+// pending tasks remain queued behind the retried work.
+func (c *LocalClient) prepareRetryableTasksForResume(ctx context.Context, apply *storage.Apply, tasks []*storage.Task) {
+	if !state.IsState(apply.State, state.Apply.FailedRetryable) {
+		return
+	}
+	apply.ErrorMessage = ""
+	for _, task := range tasks {
+		if !state.IsState(task.State, state.Task.FailedRetryable) {
+			continue
+		}
+		task.Attempt++
+		task.ErrorMessage = ""
+		task.CompletedAt = nil
+		c.transitionTaskState(ctx, task, apply.ID, state.Task.Pending,
+			fmt.Sprintf("Task %s queued for retry", task.TaskIdentifier))
+	}
+}
+
 // launchAtomicResume sends all DDLs to the engine in one call, marks tasks and
 // apply as RUNNING, logs the provided message, and starts pollForCompletionAtomic
 // in a background goroutine. Used by both Start() and ResumeApply().
@@ -393,8 +413,9 @@ func (c *LocalClient) launchAtomicResume(ctx context.Context, apply *storage.App
 		tableChanges = append(tableChanges, engine.TableChange{DDL: ddl})
 	}
 
-	// Resume atomic apply after restart. Use apply identifier as MigrationContext
-	// so Spirit can find existing checkpoint tables from the original run.
+	// Resume the grouped apply after restart. Use apply identifier as
+	// MigrationContext so Spirit can find existing checkpoint tables from the
+	// original run.
 	result, err := eng.Apply(ctx, &engine.ApplyRequest{
 		Database: apply.Database,
 		Changes: []engine.SchemaChange{{
@@ -513,10 +534,19 @@ func (c *LocalClient) ResumeApply(ctx context.Context, apply *storage.Apply) err
 		return nil
 	}
 
+	c.prepareRetryableTasksForResume(ctx, apply, activeTasks)
+
 	options := buildApplyOptions(apply)
 
 	if apply.GetOptions().DeferCutover {
-		if err := c.launchAtomicResume(ctx, apply, activeTasks, plan, options, "Apply resumed from checkpoint (atomic)"); err != nil {
+		if err := c.launchAtomicResume(ctx, apply, activeTasks, plan, options, fmt.Sprintf("Apply resumed from checkpoint (%s)", groupedApplyModeDescription(apply))); err != nil {
+			if c.shouldRetryEngineError(err) {
+				c.logger.Warn("engine apply failed during recovery, pausing apply for scheduler retry",
+					"apply_id", apply.ApplyIdentifier,
+					"error", err)
+				c.markApplyRetryableWithTasks(ctx, apply, activeTasks, err.Error())
+				return nil
+			}
 			c.logger.Error("engine apply failed during recovery",
 				"apply_id", apply.ApplyIdentifier,
 				"error", err)

--- a/pkg/tern/state_converters.go
+++ b/pkg/tern/state_converters.go
@@ -35,6 +35,8 @@ func taskStateToApplyState(ts string) string {
 		return state.Apply.Completed
 	case state.Task.Failed:
 		return state.Apply.Failed
+	case state.Task.FailedRetryable:
+		return state.Apply.FailedRetryable
 	case state.Task.Stopped:
 		return state.Apply.Stopped
 	case state.Task.Reverted:
@@ -74,6 +76,29 @@ func engineStateToStorage(es engine.State) string {
 	}
 }
 
+// taskStateFromProgressResult converts an engine progress result to the task
+// state Tern should persist. Engines use Retryable to opt a failed result into
+// scheduler recovery instead of permanent failure.
+func taskStateFromProgressResult(result *engine.ProgressResult) string {
+	if result == nil {
+		return state.Task.Pending
+	}
+	if result.State == engine.StateFailed && result.Retryable {
+		return state.Task.FailedRetryable
+	}
+	return engineStateToStorage(result.State)
+}
+
+func progressFailureMessage(result *engine.ProgressResult) string {
+	if result == nil {
+		return ""
+	}
+	if result.ErrorMessage != "" {
+		return result.ErrorMessage
+	}
+	return result.Message
+}
+
 // storageStateToProto converts a task state string to proto State enum.
 func storageStateToProto(ts string) ternv1.State {
 	switch ts {
@@ -92,6 +117,8 @@ func storageStateToProto(ts string) ternv1.State {
 	case state.Task.Completed:
 		return ternv1.State_STATE_COMPLETED
 	case state.Task.Failed:
+		return ternv1.State_STATE_FAILED
+	case state.Task.FailedRetryable, state.Apply.FailedRetryable:
 		return ternv1.State_STATE_FAILED
 	case state.Task.Stopped:
 		return ternv1.State_STATE_STOPPED


### PR DESCRIPTION
## Summary

This PR adds the durable retry state for engine failures that are safe to re-dispatch. Engines can mark a failed progress result retryable; Tern persists the task/apply as `failed_retryable` instead of terminal, preserves completed task work, and scheduler workers claim the apply while retry budget remains.

```text
engine reports failed + retryable
        |
        v
task/apply: failed_retryable
        |
        v
scheduler claim increments attempt
        |
        +--> completed tasks stay completed
        +--> failed_retryable tasks queue back to pending
        +--> pending tasks remain queued
        |
        v
worker re-dispatches remaining work
        |
        +--> success -> completed
        +--> retry budget exhausted -> failed
```

The claim path also keeps pending applies out of scheduler work until tasks exist, leaves PlanetScale setup states unclaimed until resume metadata exists, and serves retry-waiting progress from storage so API, CLI, and GitHub surfaces consistently show the retrying state.

🤖 Generated by Codex.