### PR TITLE
fix(github): reject apply/plan when PR head advances after discovery

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -100,30 +100,31 @@ func RecordApplyDuration(ctx context.Context, duration time.Duration, database, 
 	)
 }
 
-// knownStaleSchemaActions limits metric cardinality on the
-// schemabot.apply.rejected_stale_schema counter to the three handlers that
+// knownSchemaFreshnessActions limits metric cardinality on the
+// schemabot.schema_freshness.rejected counter to the three handlers that
 // load a schema snapshot at discovery and reuse it at execution.
-var knownStaleSchemaActions = map[string]bool{
+var knownSchemaFreshnessActions = map[string]bool{
 	"plan":          true,
 	"apply":         true,
 	"apply_confirm": true,
 }
 
-// RecordApplyRejectedStaleSchema increments the counter for plan/apply/apply-confirm
+// RecordSchemaFreshnessRejected increments the counter for plan/apply/apply-confirm
 // commands rejected because the PR branch HEAD advanced after discovery loaded the
-// schema files. A spike indicates aggressive force-pushing, webhook replay, or a
-// regression in the schema-freshness guard.
-func RecordApplyRejectedStaleSchema(ctx context.Context, action string) {
-	if !knownStaleSchemaActions[action] {
+// schema files. The metric name is action-neutral because the same rejection fires
+// for read-only plan as well as mutating apply paths. A spike indicates aggressive
+// force-pushing, webhook replay, or a regression in the schema-freshness guard.
+func RecordSchemaFreshnessRejected(ctx context.Context, action string) {
+	if !knownSchemaFreshnessActions[action] {
 		action = "unknown"
 	}
 	meter := otel.Meter(meterName)
-	counter, err := meter.Int64Counter("schemabot.apply.rejected_stale_schema.total",
+	counter, err := meter.Int64Counter("schemabot.schema_freshness.rejected.total",
 		otelmetric.WithDescription("Plan/apply/apply-confirm rejected because PR HEAD advanced after discovery loaded schema files"),
 		otelmetric.WithUnit("{rejection}"),
 	)
 	if err != nil {
-		slog.Warn("failed to create apply rejected stale schema counter", "error", err)
+		slog.Warn("failed to create schema freshness rejected counter", "error", err)
 		return
 	}
 	counter.Add(ctx, 1,

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -100,6 +100,39 @@ func RecordApplyDuration(ctx context.Context, duration time.Duration, database, 
 	)
 }
 
+// knownStaleSchemaActions limits metric cardinality on the
+// schemabot.apply.rejected_stale_schema counter to the three handlers that
+// load a schema snapshot at discovery and reuse it at execution.
+var knownStaleSchemaActions = map[string]bool{
+	"plan":          true,
+	"apply":         true,
+	"apply_confirm": true,
+}
+
+// RecordApplyRejectedStaleSchema increments the counter for plan/apply/apply-confirm
+// commands rejected because the PR branch HEAD advanced after discovery loaded the
+// schema files. A spike indicates aggressive force-pushing, webhook replay, or a
+// regression in the schema-freshness guard.
+func RecordApplyRejectedStaleSchema(ctx context.Context, action string) {
+	if !knownStaleSchemaActions[action] {
+		action = "unknown"
+	}
+	meter := otel.Meter(meterName)
+	counter, err := meter.Int64Counter("schemabot.apply.rejected_stale_schema.total",
+		otelmetric.WithDescription("Plan/apply/apply-confirm rejected because PR HEAD advanced after discovery loaded schema files"),
+		otelmetric.WithUnit("{rejection}"),
+	)
+	if err != nil {
+		slog.Warn("failed to create apply rejected stale schema counter", "error", err)
+		return
+	}
+	counter.Add(ctx, 1,
+		otelmetric.WithAttributes(
+			attribute.String("action", action),
+		),
+	)
+}
+
 // knownCheckOwnershipOperations limits metric cardinality to expected check
 // ownership miss paths.
 var knownCheckOwnershipOperations = map[string]bool{

--- a/pkg/webhook/apply_e2e_test.go
+++ b/pkg/webhook/apply_e2e_test.go
@@ -1178,26 +1178,14 @@ func TestE2EApplyAutoConfirmExecutes(t *testing.T) {
 		"expected apply summary comment")
 }
 
-// TestE2EApplyAutoConfirmDowngradesOnSHAMismatch verifies that -y downgrades to
-// manual confirmation when the HEAD SHA doesn't match the stored check record.
-func TestE2EApplyAutoConfirmDowngradesOnSHAMismatch(t *testing.T) {
-	dbName := "webhook_auto_confirm_sha"
+// TestE2EApplyAutoConfirmRejectsWhenHEADAdvanced verifies that `apply -y`
+// rejects (does NOT apply, releases the lock) when the PR HEAD advances
+// between discovery (cached FetchPullRequest) and the fresh
+// FetchPullRequestNoCache fetch inside the auto-confirm branch. The user
+// must re-run the command so discovery picks up the new HEAD.
+func TestE2EApplyAutoConfirmRejectsWhenHEADAdvanced(t *testing.T) {
+	dbName := "webhook_auto_confirm_stale"
 	svc := setupE2EService(t, dbName)
-
-	// Seed a check record with a DIFFERENT SHA than what FetchPullRequest returns ("abc123")
-	check := &storage.Check{
-		Repository:   "octocat/hello-world",
-		PullRequest:  1,
-		HeadSHA:      "oldsha999",
-		Environment:  "staging",
-		DatabaseType: "mysql",
-		DatabaseName: dbName,
-		CheckRunID:   1,
-		HasChanges:   true,
-		Status:       checkStatusCompleted,
-		Conclusion:   checkConclusionActionRequired,
-	}
-	require.NoError(t, svc.Storage().Checks().Upsert(t.Context(), check))
 
 	mux := http.NewServeMux()
 	server := httptest.NewServer(mux)
@@ -1212,6 +1200,9 @@ func TestE2EApplyAutoConfirmDowngradesOnSHAMismatch(t *testing.T) {
 	}
 
 	result := setupFakeGitHubForPlan(t, mux, schemaFiles, schemabotConfig, dbName)
+	// Discovery (cached FetchPullRequest) sees abc123; the NoCache fetch
+	// inside the auto-confirm branch sees a new commit at newsha456.
+	result.HeadSHAs = []string{"abc123", "newsha456"}
 	h := newE2EHandler(t, svc, client)
 
 	req := buildWebhookRequest(t, webhookPayloadOpts{
@@ -1223,15 +1214,160 @@ func TestE2EApplyAutoConfirmDowngradesOnSHAMismatch(t *testing.T) {
 	h.ServeHTTP(rr, req)
 	require.Equal(t, http.StatusOK, rr.Code)
 
-	// Should get a plan comment with the downgrade warning, NOT "Applying automatically"
+	// Drain all comments posted during the delivery: we expect at least one
+	// rejection comment and zero "Applying automatically" comments.
+	deadline := time.After(30 * time.Second)
+	var rejection string
+	for {
+		select {
+		case body := <-result.comments:
+			assert.NotContains(t, body, "Applying automatically", "apply must not auto-confirm on stale schema")
+			if strings.Contains(body, "Rejected") && strings.Contains(body, "new commits since discovery") {
+				rejection = body
+			}
+		case <-deadline:
+			t.Fatal("timed out waiting for rejection comment")
+		}
+		if rejection != "" {
+			break
+		}
+	}
+
+	assert.Contains(t, rejection, "abc123", "rejection must show discovery SHA")
+	assert.Contains(t, rejection, "newsha456", "rejection must show current SHA")
+	assert.Contains(t, rejection, "schemabot apply -e staging", "retry hint must reference the env")
+
+	// Lock acquired earlier in handleApplyCommand must be released so the user
+	// can re-run `schemabot apply` cleanly. The release runs in the handler
+	// goroutine after postComment returns, so poll briefly.
+	require.Eventually(t, func() bool {
+		lock, err := svc.Storage().Locks().Get(t.Context(), dbName, "mysql")
+		return err == nil && lock == nil
+	}, 5*time.Second, 50*time.Millisecond, "lock must be released after stale-schema rejection")
+
+	// No apply record should exist — executeApply must not have been reached.
+	applies, err := svc.Storage().Applies().GetByPR(t.Context(), "octocat/hello-world", 1)
+	require.NoError(t, err)
+	for _, a := range applies {
+		assert.NotEqual(t, dbName, a.Database, "no apply for %s should have been started", dbName)
+	}
+}
+
+// TestE2EApplyConfirmRejectsWhenHEADAdvanced verifies that `apply-confirm`
+// rejects (does NOT apply, releases the lock) when the PR HEAD advances
+// between discovery (cached FetchPullRequest) and the fresh
+// FetchPullRequestNoCache fetch used by the checks gate.
+func TestE2EApplyConfirmRejectsWhenHEADAdvanced(t *testing.T) {
+	dbName := "webhook_confirm_stale"
+	svc := setupE2EService(t, dbName)
+
+	// apply-confirm requires a pre-existing lock from a prior `apply`.
+	require.NoError(t, svc.Storage().Locks().Acquire(t.Context(), &storage.Lock{
+		DatabaseName: dbName,
+		DatabaseType: "mysql",
+		Repository:   "octocat/hello-world",
+		PullRequest:  1,
+		Owner:        "octocat/hello-world#1",
+	}))
+	t.Cleanup(func() {
+		_ = svc.Storage().Locks().ForceRelease(context.WithoutCancel(t.Context()), dbName, "mysql")
+	})
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	client := gh.NewClient(nil)
+	client.BaseURL, _ = url.Parse(server.URL + "/")
+
+	schemabotConfig := fmt.Sprintf("database: %s\ntype: mysql\n", dbName)
+	schemaFiles := map[string]string{
+		"users.sql": "CREATE TABLE `users` (\n  `id` bigint unsigned NOT NULL AUTO_INCREMENT,\n  `name` varchar(255) NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;",
+	}
+
+	result := setupFakeGitHubForPlan(t, mux, schemaFiles, schemabotConfig, dbName)
+	result.HeadSHAs = []string{"abc123", "newsha456"}
+	h := newE2EHandler(t, svc, client)
+
+	req := buildWebhookRequest(t, webhookPayloadOpts{
+		comment: "schemabot apply-confirm -e staging",
+		isPR:    true,
+	}, nil)
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+
 	select {
 	case body := <-result.comments:
-		assert.Contains(t, body, "Auto-confirm skipped")
-		assert.Contains(t, body, "New commits pushed since auto-plan")
-		assert.NotContains(t, body, "Applying automatically")
-		assert.Contains(t, body, "apply-confirm", "should show manual confirm instructions")
+		assert.Contains(t, body, "Rejected")
+		assert.Contains(t, body, "new commits since discovery")
+		assert.Contains(t, body, "abc123", "must show discovery SHA")
+		assert.Contains(t, body, "newsha456", "must show current SHA")
+		assert.Contains(t, body, "schemabot apply-confirm -e staging", "retry hint must show full retry command")
+		assert.NotContains(t, body, "Schema Change In Progress", "apply must not have started")
+		assert.NotContains(t, body, "Schema Change Applied", "apply must not have completed")
 	case <-time.After(30 * time.Second):
-		t.Fatal("timed out waiting for downgraded plan comment")
+		t.Fatal("timed out waiting for rejection comment")
+	}
+
+	// Lock must be released after rejection so the user can re-run `apply`.
+	// The release runs in the handler goroutine after postComment returns,
+	// so poll briefly.
+	require.Eventually(t, func() bool {
+		lock, err := svc.Storage().Locks().Get(t.Context(), dbName, "mysql")
+		return err == nil && lock == nil
+	}, 5*time.Second, 50*time.Millisecond, "lock must be released after stale-schema rejection")
+
+	applies, err := svc.Storage().Applies().GetByPR(t.Context(), "octocat/hello-world", 1)
+	require.NoError(t, err)
+	for _, a := range applies {
+		assert.NotEqual(t, dbName, a.Database, "no apply for %s should have been started", dbName)
+	}
+}
+
+// TestE2EPlanRejectsWhenHEADAdvanced verifies that `schemabot plan` rejects
+// (does NOT post a plan comment rendered against stale schema files) when
+// the PR HEAD advances between discovery and the freshness check.
+func TestE2EPlanRejectsWhenHEADAdvanced(t *testing.T) {
+	dbName := "webhook_plan_stale"
+	svc := setupE2EService(t, dbName)
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	client := gh.NewClient(nil)
+	client.BaseURL, _ = url.Parse(server.URL + "/")
+
+	schemabotConfig := fmt.Sprintf("database: %s\ntype: mysql\n", dbName)
+	schemaFiles := map[string]string{
+		"users.sql": "CREATE TABLE `users` (\n  `id` bigint unsigned NOT NULL AUTO_INCREMENT,\n  `name` varchar(255) NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;",
+	}
+
+	result := setupFakeGitHubForPlan(t, mux, schemaFiles, schemabotConfig, dbName)
+	result.HeadSHAs = []string{"abc123", "newsha456"}
+	h := newE2EHandler(t, svc, client)
+
+	req := buildWebhookRequest(t, webhookPayloadOpts{
+		comment: "schemabot plan -e staging",
+		isPR:    true,
+	}, nil)
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	select {
+	case body := <-result.comments:
+		assert.Contains(t, body, "Rejected")
+		assert.Contains(t, body, "new commits since discovery")
+		assert.Contains(t, body, "abc123")
+		assert.Contains(t, body, "newsha456")
+		assert.Contains(t, body, "schemabot plan -e staging")
+		assert.NotContains(t, body, "Schema Change Plan", "stale plan comment must not be posted")
+	case <-time.After(30 * time.Second):
+		t.Fatal("timed out waiting for rejection comment")
 	}
 }
 

--- a/pkg/webhook/apply_e2e_test.go
+++ b/pkg/webhook/apply_e2e_test.go
@@ -1326,6 +1326,75 @@ func TestE2EApplyConfirmRejectsWhenHEADAdvanced(t *testing.T) {
 	}
 }
 
+// TestE2EApplyConfirmStaleSchemaPreservesOtherPRLock verifies that when
+// `apply-confirm` runs on PR #1 and the schema-freshness check rejects, the
+// per-target lock held by a different PR (#999) is NOT released. Using
+// owner-scoped Release rather than ForceRelease ensures stale-schema
+// rejections cannot inadvertently clear an unrelated PR's lock.
+func TestE2EApplyConfirmStaleSchemaPreservesOtherPRLock(t *testing.T) {
+	dbName := "webhook_confirm_stale_otherlock"
+	svc := setupE2EService(t, dbName)
+
+	// Pre-seed a lock owned by a different PR (#999).
+	otherOwner := "octocat/hello-world#999"
+	require.NoError(t, svc.Storage().Locks().Acquire(t.Context(), &storage.Lock{
+		DatabaseName: dbName,
+		DatabaseType: "mysql",
+		Repository:   "octocat/hello-world",
+		PullRequest:  999,
+		Owner:        otherOwner,
+	}))
+	t.Cleanup(func() {
+		_ = svc.Storage().Locks().ForceRelease(context.WithoutCancel(t.Context()), dbName, "mysql")
+	})
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	client := gh.NewClient(nil)
+	client.BaseURL, _ = url.Parse(server.URL + "/")
+
+	schemabotConfig := fmt.Sprintf("database: %s\ntype: mysql\n", dbName)
+	schemaFiles := map[string]string{
+		"users.sql": "CREATE TABLE `users` (\n  `id` bigint unsigned NOT NULL AUTO_INCREMENT,\n  `name` varchar(255) NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;",
+	}
+
+	result := setupFakeGitHubForPlan(t, mux, schemaFiles, schemabotConfig, dbName)
+	// HEAD advances between cached discovery and NoCache fetch, triggering
+	// the stale-schema rejection on PR #1.
+	result.HeadSHAs = []string{"abc123", "newsha456"}
+	h := newE2EHandler(t, svc, client)
+
+	// Webhook delivery for PR #1 — but the lock is held by PR #999.
+	req := buildWebhookRequest(t, webhookPayloadOpts{
+		comment: "schemabot apply-confirm -e staging",
+		isPR:    true,
+	}, nil)
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	select {
+	case body := <-result.comments:
+		assert.Contains(t, body, "Rejected", "stale-schema rejection must still post the rejection comment")
+		assert.Contains(t, body, "new commits since discovery")
+	case <-time.After(30 * time.Second):
+		t.Fatal("timed out waiting for rejection comment")
+	}
+
+	// The other PR's lock must remain intact for the full polling window —
+	// long enough for the handler's owner-scoped Release attempt to land
+	// (and silently no-op as ErrLockNotOwned) before t.Cleanup tears down
+	// the containers. require.Never both asserts the lock is preserved and
+	// synchronises with the async handler so we don't race shutdown.
+	require.Never(t, func() bool {
+		lock, err := svc.Storage().Locks().Get(t.Context(), dbName, "mysql")
+		return err != nil || lock == nil || lock.Owner != otherOwner
+	}, 1*time.Second, 50*time.Millisecond, "other PR's lock must remain intact after stale-schema rejection on PR #1")
+}
+
 // TestE2EPlanRejectsWhenHEADAdvanced verifies that `schemabot plan` rejects
 // (does NOT post a plan comment rendered against stale schema files) when
 // the PR HEAD advances between discovery and the freshness check.

--- a/pkg/webhook/apply_e2e_test.go
+++ b/pkg/webhook/apply_e2e_test.go
@@ -1326,6 +1326,76 @@ func TestE2EApplyConfirmRejectsWhenHEADAdvanced(t *testing.T) {
 	}
 }
 
+// TestE2EApplyManualRejectsWhenHEADAdvanced verifies that `schemabot apply`
+// (without -y) rejects and releases the lock when the PR HEAD advances
+// between discovery and the freshness check, instead of posting a stale
+// confirmation plan that the user might `apply-confirm` against. Symmetric
+// to TestE2EApplyAutoConfirmRejectsWhenHEADAdvanced but covers the manual
+// (non-auto-confirm) path that aparajon flagged in PR #134 review.
+//
+// Without this guard, a fresh discovery at apply-confirm time would see the
+// new HEAD and the confirm-time freshness check would pass — but the plan
+// the user reviewed was rendered for the old commit.
+func TestE2EApplyManualRejectsWhenHEADAdvanced(t *testing.T) {
+	dbName := "webhook_manual_apply_stale"
+	svc := setupE2EService(t, dbName)
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	client := gh.NewClient(nil)
+	client.BaseURL, _ = url.Parse(server.URL + "/")
+
+	schemabotConfig := fmt.Sprintf("database: %s\ntype: mysql\n", dbName)
+	schemaFiles := map[string]string{
+		"users.sql": "CREATE TABLE `users` (\n  `id` bigint unsigned NOT NULL AUTO_INCREMENT,\n  `name` varchar(255) NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;",
+	}
+
+	result := setupFakeGitHubForPlan(t, mux, schemaFiles, schemabotConfig, dbName)
+	// Discovery (cached FetchPullRequest) sees abc123; the NoCache fetch
+	// just before posting the manual plan sees a new commit at newsha456.
+	result.HeadSHAs = []string{"abc123", "newsha456"}
+	h := newE2EHandler(t, svc, client)
+
+	req := buildWebhookRequest(t, webhookPayloadOpts{
+		comment: "schemabot apply -e staging",
+		isPR:    true,
+	}, nil)
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	// Drain comments looking for the rejection. The handler must not post a
+	// plan comment (with or without the confirmation footer).
+	deadline := time.After(30 * time.Second)
+	var rejection string
+	for rejection == "" {
+		select {
+		case body := <-result.comments:
+			assert.NotContains(t, body, "Schema Change Plan", "manual apply must not post a stale plan comment")
+			assert.NotContains(t, body, "Applying automatically", "manual apply must never auto-confirm")
+			if strings.Contains(body, "Rejected") && strings.Contains(body, "new commits since discovery") {
+				rejection = body
+			}
+		case <-deadline:
+			t.Fatal("timed out waiting for rejection comment")
+		}
+	}
+
+	assert.Contains(t, rejection, "abc123", "rejection must show discovery SHA")
+	assert.Contains(t, rejection, "newsha456", "rejection must show current SHA")
+	assert.Contains(t, rejection, "schemabot apply -e staging", "retry hint must reference the env")
+
+	// Lock acquired earlier in handleApplyCommand must be released so the
+	// user can re-run cleanly. Release runs after postComment; poll briefly.
+	require.Eventually(t, func() bool {
+		lock, err := svc.Storage().Locks().Get(t.Context(), dbName, "mysql")
+		return err == nil && lock == nil
+	}, 5*time.Second, 50*time.Millisecond, "lock must be released after stale-schema rejection")
+}
+
 // TestE2EApplyConfirmStaleSchemaPreservesOtherPRLock verifies that when
 // `apply-confirm` runs on PR #1 and the schema-freshness check rejects, the
 // per-target lock held by a different PR (#999) is NOT released. Using

--- a/pkg/webhook/apply_handlers.go
+++ b/pkg/webhook/apply_handlers.go
@@ -206,34 +206,34 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 
 	// Auto-confirm (-y): check safety conditions before proceeding
 	if result.AutoConfirm {
-		// Check 1: HEAD SHA hasn't changed since auto-plan.
-		// Fail closed: if we can't verify the SHA (missing check record, API error),
-		// downgrade to manual confirmation rather than proceeding with stale data.
+		// Reject if the PR HEAD advanced after discovery loaded schema files.
+		// Running against the loaded files would execute DDL derived from an
+		// older commit than the branch is on right now. Release the lock
+		// acquired above so the user can re-run `schemabot apply -e <env>`
+		// cleanly without a manual unlock.
 		//
-		// Use FetchPullRequestNoCache here — correctness requires the *current*
-		// GitHub HEAD. The dedupe-friendly FetchPullRequest used by discovery
-		// above would return the cached HeadSHA from CreateSchemaRequestFromPR,
-		// making the SHA gate silently pass against a stale snapshot if a new
-		// commit landed between discovery and this re-check.
-		check, checkErr := h.service.Storage().Checks().Get(ctx, repo, pr, environment, dbType, database)
+		// Use FetchPullRequestNoCache: the cached FetchPullRequest used by
+		// discovery would return the discovery-time HeadSHA, masking the race.
 		prInfo, prErr := client.FetchPullRequestNoCache(ctx, repo, pr)
-
-		shaVerified := checkErr == nil && prErr == nil && check != nil && prInfo != nil && check.HeadSHA == prInfo.HeadSHA
-		if !shaVerified {
-			reason := "Could not verify HEAD SHA — confirm manually"
-			if checkErr == nil && prErr == nil && check != nil && prInfo != nil {
-				reason = "New commits pushed since auto-plan"
+		if prErr != nil {
+			h.logger.Error("failed to fetch PR for stale-schema check, releasing lock",
+				"repo", repo, "pr", pr, "database", database, "error", prErr)
+			h.postComment(repo, pr, installationID, templates.RenderGenericError(templates.SchemaErrorData{
+				RequestedBy: requestedBy,
+				Environment: environment,
+				CommandName: action.Apply,
+				ErrorDetail: "Failed to verify PR HEAD before auto-confirm: " + prErr.Error(),
+			}))
+			if relErr := h.service.Storage().Locks().ForceRelease(ctx, database, dbType); relErr != nil {
+				h.logger.Error("failed to release lock after PR fetch failure",
+					"repo", repo, "pr", pr, "database", database, "database_type", dbType, "error", relErr)
 			}
-			h.logger.Info("auto-confirm downgraded",
-				"repo", repo, "pr", pr, "database", database, "reason", reason)
-			commentData.AutoConfirmDowngradeReason = reason
-			h.postComment(repo, pr, installationID, templates.RenderPlanComment(commentData))
-			headSHA, checkRunErr := h.storeApplyPlanCheckRecord(ctx, client, repo, pr, schemaResult, planResp, environment)
-			if checkRunErr != nil {
-				h.logger.Error("failed to create apply plan check run", "repo", repo, "pr", pr, "error", checkRunErr)
-			}
-			if headSHA != "" {
-				h.updateAggregateCheck(ctx, client, repo, pr, headSHA)
+			return
+		}
+		if rejected := h.assertSchemaStillCurrent(ctx, repo, pr, installationID, schemaResult, prInfo.HeadSHA, environment, requestedBy, action.Apply); rejected {
+			if relErr := h.service.Storage().Locks().ForceRelease(ctx, database, dbType); relErr != nil {
+				h.logger.Error("failed to release lock after stale-schema rejection",
+					"repo", repo, "pr", pr, "database", database, "database_type", dbType, "error", relErr)
 			}
 			return
 		}
@@ -329,6 +329,19 @@ func (h *Handler) handleApplyConfirmCommand(repo string, pr int, environment, da
 		}))
 		return
 	}
+
+	// Reject if the PR HEAD advanced after discovery loaded schema files.
+	// Running against the loaded files would execute DDL derived from an older
+	// commit than the branch is on right now. Release the lock so the user can
+	// re-run `schemabot apply -e <env>` cleanly.
+	if rejected := h.assertSchemaStillCurrent(ctx, repo, pr, installationID, schemaResult, confirmPRInfo.HeadSHA, environment, requestedBy, action.ApplyConfirm); rejected {
+		if relErr := h.service.Storage().Locks().ForceRelease(ctx, schemaResult.Database, schemaResult.Type); relErr != nil {
+			h.logger.Error("failed to release lock after stale-schema rejection",
+				"repo", repo, "pr", pr, "database", schemaResult.Database, "database_type", schemaResult.Type, "error", relErr)
+		}
+		return
+	}
+
 	if blocked := h.enforcePassingChecks(ctx, client, repo, pr, installationID, confirmPRInfo.HeadSHA, environment); blocked {
 		return
 	}

--- a/pkg/webhook/apply_handlers.go
+++ b/pkg/webhook/apply_handlers.go
@@ -2,6 +2,7 @@ package webhook
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -331,11 +332,19 @@ func (h *Handler) handleApplyConfirmCommand(repo string, pr int, environment, da
 	}
 
 	// Reject if the PR HEAD advanced after discovery loaded schema files.
-	// Running against the loaded files would execute DDL derived from an older
-	// commit than the branch is on right now. Release the lock so the user can
-	// re-run `schemabot apply -e <env>` cleanly.
+	// Running against the loaded files would render a plan against an older
+	// commit than the branch is on right now. Release the lock so the user
+	// can re-run `schemabot apply -e <env>` cleanly.
+	//
+	// Use owner-scoped Release rather than ForceRelease: this handler runs on
+	// every PR comment, so a stale-schema rejection on PR #2 must never clear
+	// a lock held by PR #1 for the same target. Release deletes only when
+	// owner matches; ErrLockNotFound / ErrLockNotOwned are expected here
+	// (lock may be absent or held by another PR) and are not logged as errors.
 	if rejected := h.assertSchemaStillCurrent(ctx, repo, pr, installationID, schemaResult, confirmPRInfo.HeadSHA, environment, requestedBy, action.ApplyConfirm); rejected {
-		if relErr := h.service.Storage().Locks().ForceRelease(ctx, schemaResult.Database, schemaResult.Type); relErr != nil {
+		lockOwner := fmt.Sprintf("%s#%d", repo, pr)
+		relErr := h.service.Storage().Locks().Release(ctx, schemaResult.Database, schemaResult.Type, lockOwner)
+		if relErr != nil && !errors.Is(relErr, storage.ErrLockNotFound) && !errors.Is(relErr, storage.ErrLockNotOwned) {
 			h.logger.Error("failed to release lock after stale-schema rejection",
 				"repo", repo, "pr", pr, "database", schemaResult.Database, "database_type", schemaResult.Type, "error", relErr)
 		}

--- a/pkg/webhook/apply_handlers.go
+++ b/pkg/webhook/apply_handlers.go
@@ -273,6 +273,40 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 		return
 	}
 
+	// Manual apply: reject if the PR HEAD advanced after discovery loaded
+	// schema files. Posting the confirmation plan against the loaded files
+	// would render DDL for a commit the branch is no longer on — and the
+	// user's subsequent `apply-confirm` does its own fresh discovery, so the
+	// confirm-time freshness check passes against the new HEAD even though
+	// the plan the user reviewed was rendered for the old commit. Catching
+	// it here is the symmetric guard to the auto-confirm branch above.
+	// Use FetchPullRequestNoCache; the cached fetch returns the discovery
+	// SHA. The lock was acquired by this handler invocation, so ForceRelease
+	// is safe.
+	prInfo, prErr := client.FetchPullRequestNoCache(ctx, repo, pr)
+	if prErr != nil {
+		h.logger.Error("failed to fetch PR for stale-schema check, releasing lock",
+			"repo", repo, "pr", pr, "database", database, "error", prErr)
+		h.postComment(repo, pr, installationID, templates.RenderGenericError(templates.SchemaErrorData{
+			RequestedBy: requestedBy,
+			Environment: environment,
+			CommandName: action.Apply,
+			ErrorDetail: "Failed to verify PR HEAD before posting plan: " + prErr.Error(),
+		}))
+		if relErr := h.service.Storage().Locks().ForceRelease(ctx, database, dbType); relErr != nil {
+			h.logger.Error("failed to release lock after PR fetch failure",
+				"repo", repo, "pr", pr, "database", database, "database_type", dbType, "error", relErr)
+		}
+		return
+	}
+	if rejected := h.assertSchemaStillCurrent(ctx, repo, pr, installationID, schemaResult, prInfo.HeadSHA, environment, requestedBy, action.Apply); rejected {
+		if relErr := h.service.Storage().Locks().ForceRelease(ctx, database, dbType); relErr != nil {
+			h.logger.Error("failed to release lock after stale-schema rejection",
+				"repo", repo, "pr", pr, "database", database, "database_type", dbType, "error", relErr)
+		}
+		return
+	}
+
 	h.postComment(repo, pr, installationID, templates.RenderPlanComment(commentData))
 
 	// Create check run (action_required — waiting for apply-confirm) and update aggregate

--- a/pkg/webhook/plan.go
+++ b/pkg/webhook/plan.go
@@ -50,6 +50,29 @@ func (h *Handler) handlePlanCommand(w http.ResponseWriter, repo string, pr int, 
 		return
 	}
 
+	// Reject if the PR HEAD advanced after discovery loaded schema files.
+	// Rendering a plan comment against stale files would mislead the user
+	// (and feed directly into apply-confirm against the wrong artifact).
+	// Use FetchPullRequestNoCache: the cached FetchPullRequest used by
+	// discovery would return the discovery-time HeadSHA, masking the race.
+	freshPRInfo, err := client.FetchPullRequestNoCache(ctx, repo, pr)
+	if err != nil {
+		h.logger.Error("failed to fetch PR for stale-schema check", "repo", repo, "pr", pr, "error", err)
+		h.postComment(repo, pr, installationID, templates.RenderGenericError(templates.SchemaErrorData{
+			RequestedBy: requestedBy,
+			Timestamp:   time.Now().UTC().Format("2006-01-02 15:04:05"),
+			Environment: environment,
+			CommandName: action.Plan,
+			ErrorDetail: "Failed to verify PR HEAD: " + err.Error(),
+		}))
+		h.writeJSON(w, http.StatusOK, map[string]string{"message": "PR fetch failed"})
+		return
+	}
+	if rejected := h.assertSchemaStillCurrent(ctx, repo, pr, installationID, schemaResult, freshPRInfo.HeadSHA, environment, requestedBy, action.Plan); rejected {
+		h.writeJSON(w, http.StatusOK, map[string]string{"message": "plan rejected: schema discovery stale"})
+		return
+	}
+
 	// Build PlanRequest in the format expected by the API service
 	prNumber := int32(pr)
 	planReq := api.PlanRequest{
@@ -208,6 +231,30 @@ func (h *Handler) handleMultiEnvPlan(repo string, pr int, databaseName string, i
 			multiEnvData.HeadSHA = schemaResult.HeadSHA
 			multiEnvData.Repository = schemaResult.Repository
 			multiEnvData.IsMySQL = schemaResult.Type == "mysql"
+
+			// Stale-schema gate for user-triggered `schemabot plan` only.
+			// Auto-plan from pull_request webhooks is covered by the next
+			// synchronize delivery superseding any stale comment; gating it
+			// here is out of scope. All per-env schemaResults share the same
+			// HeadSHA (cached FetchPullRequest within this delivery), so one
+			// check on the first successful result covers every env.
+			if !isAutoPlan {
+				freshPRInfo, prErr := client.FetchPullRequestNoCache(ctx, repo, pr)
+				if prErr != nil {
+					h.logger.Error("failed to fetch PR for stale-schema check",
+						"repo", repo, "pr", pr, "error", prErr)
+					h.postComment(repo, pr, installationID, templates.RenderGenericError(templates.SchemaErrorData{
+						RequestedBy: requestedBy,
+						Timestamp:   time.Now().UTC().Format("2006-01-02 15:04:05"),
+						CommandName: action.Plan,
+						ErrorDetail: "Failed to verify PR HEAD: " + prErr.Error(),
+					}))
+					return
+				}
+				if rejected := h.assertSchemaStillCurrent(ctx, repo, pr, installationID, schemaResult, freshPRInfo.HeadSHA, env, requestedBy, action.Plan); rejected {
+					return
+				}
+			}
 		}
 
 		prNumber := int32(pr)

--- a/pkg/webhook/schema_freshness.go
+++ b/pkg/webhook/schema_freshness.go
@@ -22,7 +22,7 @@ import (
 // If the two SHAs disagree, the discovery snapshot is stale: any plan rendered
 // or apply executed against schema.SchemaFiles would be derived from a commit
 // the branch is no longer on. The helper logs with operator-triage fields,
-// increments schemabot.apply.rejected_stale_schema.total, posts a rejection
+// increments schemabot.schema_freshness.rejected.total, posts a rejection
 // comment, and returns true so the caller can release any locks and stop.
 //
 // Returns true to mean "rejected — caller must stop". Returns false when the
@@ -54,7 +54,7 @@ func (h *Handler) assertSchemaStillCurrent(
 		"requested_by", requestedBy,
 	)
 
-	metrics.RecordApplyRejectedStaleSchema(ctx, metricActionKey(action))
+	metrics.RecordSchemaFreshnessRejected(ctx, metricActionKey(action))
 
 	h.postComment(repo, pr, installationID, templates.RenderStaleSchemaRejection(templates.StaleSchemaRejectionData{
 		RequestedBy:  requestedBy,

--- a/pkg/webhook/schema_freshness.go
+++ b/pkg/webhook/schema_freshness.go
@@ -1,0 +1,75 @@
+package webhook
+
+import (
+	"context"
+	"strings"
+
+	ghclient "github.com/block/schemabot/pkg/github"
+	"github.com/block/schemabot/pkg/metrics"
+	"github.com/block/schemabot/pkg/webhook/templates"
+)
+
+// assertSchemaStillCurrent enforces the invariant that the schema files loaded
+// at discovery still match the current PR HEAD on GitHub before any mutating
+// (apply) or comment-rendering (plan) work runs.
+//
+// Discovery (CreateSchemaRequestFromPR) reads the PR HEAD once via the
+// request-scoped cached FetchPullRequest and loads schema files at that SHA.
+// Callers must pass freshHeadSHA from a separate FetchPullRequestNoCache call
+// taken close to the point of use — that fresh SHA is the only TOCTOU-safe
+// reference for "what is on the branch right now".
+//
+// If the two SHAs disagree, the discovery snapshot is stale: any plan rendered
+// or apply executed against schema.SchemaFiles would be derived from a commit
+// the branch is no longer on. The helper logs with operator-triage fields,
+// increments schemabot.apply.rejected_stale_schema.total, posts a rejection
+// comment, and returns true so the caller can release any locks and stop.
+//
+// Returns true to mean "rejected — caller must stop". Returns false when the
+// snapshot is still current and execution may proceed.
+func (h *Handler) assertSchemaStillCurrent(
+	ctx context.Context,
+	repo string,
+	pr int,
+	installationID int64,
+	schema *ghclient.SchemaRequestResult,
+	freshHeadSHA string,
+	environment string,
+	requestedBy string,
+	action string,
+) bool {
+	if schema.HeadSHA == freshHeadSHA {
+		return false
+	}
+
+	h.logger.Warn("rejected: schema discovery stale, PR HEAD advanced",
+		"repo", repo,
+		"pr", pr,
+		"environment", environment,
+		"database", schema.Database,
+		"database_type", schema.Type,
+		"discovery_sha", schema.HeadSHA,
+		"current_sha", freshHeadSHA,
+		"action", action,
+		"requested_by", requestedBy,
+	)
+
+	metrics.RecordApplyRejectedStaleSchema(ctx, metricActionKey(action))
+
+	h.postComment(repo, pr, installationID, templates.RenderStaleSchemaRejection(templates.StaleSchemaRejectionData{
+		RequestedBy:  requestedBy,
+		Database:     schema.Database,
+		Environment:  environment,
+		DiscoverySHA: schema.HeadSHA,
+		CurrentSHA:   freshHeadSHA,
+		Action:       action,
+	}))
+
+	return true
+}
+
+// metricActionKey converts a command-line action ("apply-confirm") to the
+// underscore form expected by the metric's cardinality allowlist ("apply_confirm").
+func metricActionKey(action string) string {
+	return strings.ReplaceAll(action, "-", "_")
+}

--- a/pkg/webhook/schema_freshness_test.go
+++ b/pkg/webhook/schema_freshness_test.go
@@ -1,0 +1,88 @@
+package webhook
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	ghclient "github.com/block/schemabot/pkg/github"
+)
+
+func TestAssertSchemaStillCurrent_MatchProceeds(t *testing.T) {
+	h, comments, _ := newTestHandler(t)
+
+	schema := &ghclient.SchemaRequestResult{
+		Repository: "octocat/hello-world",
+		Database:   "testdb",
+		Type:       "mysql",
+		HeadSHA:    "sha-abc",
+	}
+
+	rejected := h.assertSchemaStillCurrent(
+		t.Context(),
+		"octocat/hello-world", 1, int64(12345),
+		schema,
+		"sha-abc",
+		"staging",
+		"alice",
+		"apply-confirm",
+	)
+
+	assert.False(t, rejected, "matching SHAs must not reject")
+
+	select {
+	case body := <-comments:
+		t.Fatalf("no comment should be posted on a match; got: %s", body)
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func TestAssertSchemaStillCurrent_MismatchRejectsAndPostsComment(t *testing.T) {
+	h, comments, _ := newTestHandler(t)
+
+	schema := &ghclient.SchemaRequestResult{
+		Repository: "octocat/hello-world",
+		Database:   "testdb",
+		Type:       "mysql",
+		HeadSHA:    "discovery-sha",
+	}
+
+	rejected := h.assertSchemaStillCurrent(
+		t.Context(),
+		"octocat/hello-world", 1, int64(12345),
+		schema,
+		"current-sha",
+		"staging",
+		"alice",
+		"apply-confirm",
+	)
+
+	require.True(t, rejected, "differing SHAs must reject")
+
+	select {
+	case body := <-comments:
+		assert.Contains(t, body, "Rejected", "title should call out rejection")
+		assert.Contains(t, body, "new commits since discovery", "should explain why")
+		assert.Contains(t, body, "discovery-sha", "must include discovery SHA")
+		assert.Contains(t, body, "current-sha", "must include current SHA")
+		assert.Contains(t, body, "testdb", "must include database")
+		assert.Contains(t, body, "staging", "must include environment")
+		assert.Contains(t, body, "schemabot apply-confirm -e staging", "retry hint must use the action and env")
+		assert.Contains(t, body, "alice", "must attribute the requester")
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for rejection comment")
+	}
+}
+
+func TestMetricActionKey(t *testing.T) {
+	cases := map[string]string{
+		"plan":          "plan",
+		"apply":         "apply",
+		"apply-confirm": "apply_confirm",
+	}
+	for in, want := range cases {
+		assert.Equal(t, want, metricActionKey(in), "input=%q", in)
+	}
+}

--- a/pkg/webhook/templates/apply_commands.go
+++ b/pkg/webhook/templates/apply_commands.go
@@ -204,6 +204,39 @@ func RenderApplyConfirmNoChanges(database, environment string) string {
 	return sb.String()
 }
 
+// StaleSchemaRejectionData contains data for the stale-schema rejection comment
+// posted when the PR HEAD advanced after discovery loaded the schema files.
+type StaleSchemaRejectionData struct {
+	RequestedBy  string
+	Database     string
+	Environment  string
+	DiscoverySHA string
+	CurrentSHA   string
+	Action       string // "plan", "apply", or "apply-confirm" — shown in the retry hint
+}
+
+// RenderStaleSchemaRejection renders a comment when plan/apply/apply-confirm is
+// rejected because the PR branch HEAD advanced after the schema files were loaded
+// at discovery. Tells the user which SHAs were involved and how to retry so
+// discovery picks up the new HEAD.
+func RenderStaleSchemaRejection(data StaleSchemaRejectionData) string {
+	var sb strings.Builder
+
+	sb.WriteString("## ⚠️ Rejected — new commits since discovery\n\n")
+	writeDBEnvLine(&sb, data.Database, data.Environment)
+	sb.WriteString("\n")
+	fmt.Fprintf(&sb, "Schema files were loaded at `%s`, but the current PR HEAD is `%s`. ", data.DiscoverySHA, data.CurrentSHA)
+	sb.WriteString("Running against the loaded files would apply DDL derived from an older commit than the branch is on right now.\n\n")
+	sb.WriteString("Re-run the command to plan against the current HEAD:\n\n")
+	fmt.Fprintf(&sb, "```\nschemabot %s -e %s\n```\n", data.Action, data.Environment)
+
+	if data.RequestedBy != "" {
+		fmt.Fprintf(&sb, "\n_Requested by @%s_\n", data.RequestedBy)
+	}
+
+	return sb.String()
+}
+
 // RenderApplyConfirmNoLock renders a comment when apply-confirm is run without a lock.
 func RenderApplyConfirmNoLock(database, environment string) string {
 	var sb strings.Builder

--- a/pkg/webhook/templates/apply_commands.go
+++ b/pkg/webhook/templates/apply_commands.go
@@ -226,8 +226,8 @@ func RenderStaleSchemaRejection(data StaleSchemaRejectionData) string {
 	writeDBEnvLine(&sb, data.Database, data.Environment)
 	sb.WriteString("\n")
 	fmt.Fprintf(&sb, "Schema files were loaded at `%s`, but the current PR HEAD is `%s`. ", data.DiscoverySHA, data.CurrentSHA)
-	sb.WriteString("Running against the loaded files would apply DDL derived from an older commit than the branch is on right now.\n\n")
-	sb.WriteString("Re-run the command to plan against the current HEAD:\n\n")
+	sb.WriteString("These files no longer match what is on the branch.\n\n")
+	sb.WriteString("Re-run the command to use the current HEAD:\n\n")
 	fmt.Fprintf(&sb, "```\nschemabot %s -e %s\n```\n", data.Action, data.Environment)
 
 	if data.RequestedBy != "" {

--- a/pkg/webhook/webhook_e2e_test.go
+++ b/pkg/webhook/webhook_e2e_test.go
@@ -249,6 +249,27 @@ type planFlowResult struct {
 	comments  chan string
 	reactions chan string
 	checkRuns chan checkRunCapture
+
+	// HeadSHAs drives the SHA returned by /pulls/1 on each successive call.
+	// Empty (the default) means the handler always returns "abc123" — the
+	// historical behavior preserved for all existing tests. Tests that need
+	// to simulate the PR HEAD advancing between the cached FetchPullRequest
+	// call and a later FetchPullRequestNoCache call populate this slice
+	// (e.g. {"abc123", "newsha456"}). Out-of-range calls return the last
+	// element.
+	HeadSHAs    []string
+	headSHACall atomic.Int64
+}
+
+func (p *planFlowResult) nextHeadSHA() string {
+	if len(p.HeadSHAs) == 0 {
+		return "abc123"
+	}
+	idx := int(p.headSHACall.Add(1) - 1)
+	if idx >= len(p.HeadSHAs) {
+		idx = len(p.HeadSHAs) - 1
+	}
+	return p.HeadSHAs[idx]
 }
 
 type checkRunCapture struct {
@@ -287,12 +308,14 @@ func setupFakeGitHubForPlan(t *testing.T, mux *http.ServeMux, schemaSQL map[stri
 		checkRuns: make(chan checkRunCapture, 10),
 	}
 
-	// PR info
+	// PR info — head SHA can shift across calls via result.HeadSHAs (default
+	// preserves the historical "abc123" for every existing test).
 	mux.HandleFunc("GET /repos/octocat/hello-world/pulls/1", func(w http.ResponseWriter, r *http.Request) {
+		sha := result.nextHeadSHA()
 		_ = json.NewEncoder(w).Encode(gh.PullRequest{
 			Head: &gh.PullRequestBranch{
 				Ref: new("feature-branch"),
-				SHA: new("abc123"),
+				SHA: &sha,
 			},
 			Base: &gh.PullRequestBranch{
 				Ref: new("main"),


### PR DESCRIPTION
## What and Why ?
Fixes - https://github.com/block/schemabot/issues/132

Discovery (`CreateSchemaRequestFromPR`) loads schema files at the cached PR HEAD. If a new commit lands before execution, the previous behaviour silently ran `executeApply` or rendered a plan comment against stale bytes — DDL derived from a commit the branch was no longer on.

`assertSchemaStillCurrent` compares the discovery `HeadSHA` against a fresh `FetchPullRequestNoCache` result immediately before `plan`, `apply` (auto-confirm `-y`), and `apply-confirm`. On mismatch: log, increment `schemabot.apply.rejected_stale_schema`, post a rejection comment, and (for the apply paths) release the per-target lock so the user can re-run cleanly.

The previous `shaVerified` check in the auto-confirm branch compared a stored prior-render `HeadSHA` against the fresh fetch — a coincidence-check across deliveries that could pass while `schemaResult.HeadSHA` differed. Replaced by the helper.

Closes #132.

The sibling `apply -y` gate-freshness window (#133) is intentionally out of scope.

