### PR TITLE
fix(api): reject ambiguous hybrid routes

### DIFF
--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -296,6 +296,10 @@ func (c *ServerConfig) Validate() error {
 		}
 	}
 
+	if err := c.validateNoLocalRemoteRouteCollision(); err != nil {
+		return err
+	}
+
 	// Validate TernDeployments if present (gRPC mode)
 	for name, endpoints := range c.TernDeployments {
 		if len(endpoints) == 0 {
@@ -308,6 +312,28 @@ func (c *ServerConfig) Validate() error {
 		}
 	}
 
+	return nil
+}
+
+// TernClient uses the same deployment/environment key for remote deployments
+// and local database clients. Reject ambiguous config before runtime routing can
+// choose the wrong backend.
+func (c *ServerConfig) validateNoLocalRemoteRouteCollision() error {
+	for database, dbConfig := range c.Databases {
+		remoteEnvironments, ok := c.TernDeployments[database]
+		if !ok {
+			continue
+		}
+		for environment, envConfig := range dbConfig.Environments {
+			if envConfig.DSN == "" {
+				continue
+			}
+			if remoteEnvironments[environment] == "" {
+				continue
+			}
+			return fmt.Errorf("database %q environment %q uses a local dsn but tern_deployments also defines deployment %q for that environment; rename the database or deployment to avoid ambiguous routing", database, environment, database)
+		}
+	}
 	return nil
 }
 

--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -379,6 +379,33 @@ func TestServerConfig_Validate(t *testing.T) {
 	}
 }
 
+func TestServerConfig_ValidateRejectsLocalRemoteRouteCollision(t *testing.T) {
+	cfg := ServerConfig{
+		Databases: map[string]DatabaseConfig{
+			"primary": {
+				Type: "mysql",
+				Environments: map[string]EnvironmentConfig{
+					"staging": {DSN: "root@tcp(localhost)/primary"},
+				},
+			},
+			"payments": {
+				Type: "mysql",
+				Environments: map[string]EnvironmentConfig{
+					"staging": {Target: "payments-staging", Deployment: "primary"},
+				},
+			},
+		},
+		TernDeployments: TernConfig{
+			"primary": {"staging": "localhost:9090"},
+		},
+	}
+
+	err := cfg.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `database "primary" environment "staging" uses a local dsn`)
+	assert.Contains(t, err.Error(), `tern_deployments also defines deployment "primary"`)
+}
+
 func TestServerConfig_ResolveDatabaseTarget(t *testing.T) {
 	cfg := ServerConfig{
 		Databases: map[string]DatabaseConfig{

--- a/pkg/webhook/README.md
+++ b/pkg/webhook/README.md
@@ -134,10 +134,10 @@ The webhook handler calls `service.ExecutePlan()` — the same code path as the 
 
 ```
 ExecutePlan(ctx, PlanRequest)
-  ├─ Resolve Tern deployment from database name
+  ├─ Resolve database + environment through server config
   ├─ Get or create Tern client (local or gRPC)
   ├─ Call client.Plan() → DDL diff against live database
-  ├─ Store plan in storage.Plans (idempotent)
+  ├─ Store plan and route metadata in storage.Plans (idempotent)
   └─ Return PlanResponse with tables, lint warnings, errors
 ```
 


### PR DESCRIPTION
## Why
Hybrid server configs can define both local database DSNs and remote Tern deployments. If a local database name matches a remote deployment name for the same environment, SchemaBot can create a local Tern client when the route intended to use gRPC.

## What
- Reject local database and remote deployment name collisions for the same environment during server config validation
- Add a regression test for the ambiguous `primary/staging` route shape
- Update the webhook README to describe server-side database/environment route resolution

## Ambiguous Config Example
This config is ambiguous because `payments/staging` routes to remote deployment `primary`, but `primary/staging` is also a local database route with a DSN:

```yaml
databases:
  primary:
    type: mysql
    environments:
      staging:
        dsn: root@tcp(localhost:3306)/primary
  payments:
    type: mysql
    environments:
      staging:
        target: payments-staging
        deployment: primary
tern_deployments:
  primary:
    staging: tern-primary-staging:9090
```

Before this fix, `TernClient("primary", "staging")` could choose the local `primary` client instead of the intended gRPC deployment. SchemaBot now rejects this config during validation.

Generated with Codex