### PR TITLE
refactor(api): require apply IDs for control operations

### DIFF
--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -2445,7 +2445,7 @@ The new apply will only process tables that haven't completed.
        ALTER TABLE `orders` ADD INDEX `idx_total_cents`(`total_cents`);
 
 
-Stopped. Use 'schemabot start --apply-id <apply_id>' to resume from checkpoint.
+Stopped. Use 'schemabot start -e staging <apply_id>' to resume from checkpoint.
 
 ```
 </details>
@@ -2487,7 +2487,7 @@ Press Enter to proceed with cutover (or Ctrl+C to detach): _
 Row copy complete. All data has been copied and new writes
 continue to be replicated to keep the shadow table in sync.
 
-To proceed: schemabot cutover --apply-id <apply_id>
+To proceed: schemabot cutover -e staging <apply_id>
 Watching for cutover... (Ctrl+C to detach)
 
 ```
@@ -3639,7 +3639,7 @@ ESC detach • s stop • v volume
 
 ```
 
-Stop command: User runs 'schemabot stop --apply-id <apply_id>'
+Stop command: User runs 'schemabot stop -e staging <apply_id>'
 
 ⏸️  Schema change stopped
 
@@ -3648,7 +3648,7 @@ Environment: staging
 Stopped:     2 table(s)
 Skipped:     1 table(s) (already complete)
 
-Checkpoint saved. Use 'schemabot start --apply-id apply-a1b2c3d4e5f67890' to resume.
+Checkpoint saved. Use 'schemabot start -e staging apply-a1b2c3d4e5f67890' to resume.
 
 ```
 </details>
@@ -3687,7 +3687,7 @@ Checkpoint saved. Use 'schemabot start --apply-id apply-a1b2c3d4e5f67890' to res
 
 ```
 
-Start command: User runs 'schemabot start --apply-id <apply_id>'
+Start command: User runs 'schemabot start -e staging <apply_id>'
 
 ▶️  Schema change resumed
 
@@ -4557,7 +4557,7 @@ Defer cutover: Stopped by user (s)
        ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
        • Rows: 6,400,000 / 7,200,000
 
-Use 'schemabot start --apply-id <apply_id>' to resume.
+Use 'schemabot start -e staging <apply_id>' to resume.
 
 ```
 </details>
@@ -4578,10 +4578,10 @@ To check status:
   schemabot status <apply_id>
 
 To proceed with cutover:
-  schemabot cutover --apply-id <apply_id>
+  schemabot cutover -e staging <apply_id>
 
 To abort the schema change:
-  schemabot stop --apply-id <apply_id>
+  schemabot stop -e staging <apply_id>
 
 ```
 </details>

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -61,13 +61,13 @@ Users interact with SchemaBot through three interfaces:
 ```
 schemabot plan -s ./schema -e staging       # Preview changes
 schemabot apply -s ./schema -e staging -y   # Apply changes
-schemabot progress -d mydb -e staging       # Watch progress
-schemabot cutover -d mydb -e staging        # Trigger cutover
-schemabot stop -d mydb -e staging           # Pause execution
-schemabot start -d mydb -e staging          # Resume execution
-schemabot volume -d mydb -e staging -v 8    # Adjust speed
-schemabot revert -d mydb -e staging         # Roll back (Vitess)
-schemabot skip-revert -d mydb -e staging    # Finalize (Vitess)
+schemabot progress <apply_id>               # Watch progress
+schemabot cutover -e staging <apply_id>     # Trigger cutover
+schemabot stop -e staging <apply_id>        # Pause execution
+schemabot start -e staging <apply_id>       # Resume execution
+schemabot volume -e staging <apply_id> -v 8 # Adjust speed
+schemabot revert -e staging <apply_id>      # Revert during the revert window (Vitess)
+schemabot skip-revert -e staging <apply_id> # Finalize (Vitess)
 ```
 
 **PR Comments** — SchemaBot is a GitHub app installed on repos. The PR workflow:

--- a/docs/spirit_progress.md
+++ b/docs/spirit_progress.md
@@ -249,9 +249,9 @@ The `⠋` is a Braille spinner (animated in the TUI, static here).
 | Running | `ESC detach · s stop · v volume` |
 | Running (volume mode) | `Volume: ████████░░░ 8/11` / `↑↓ adjust · 1-9 direct · ESC done` |
 | Waiting for cutover (with `--cutover`) | `Press Enter to proceed with cutover (or ESC to detach)` |
-| Waiting for cutover (no `--cutover`) | `To proceed: schemabot cutover --apply-id <id>` |
+| Waiting for cutover (no `--cutover`) | `To proceed: schemabot cutover -e <env> <id>` |
 | Cutting over | `Cutover in progress - please wait...` |
-| Stopped | `Use 'schemabot start --apply-id <id>' to resume.` |
+| Stopped | `Use 'schemabot start -e <env> <id>' to resume.` |
 
 ## Key behaviors
 

--- a/e2e/grpc/cli_test.go
+++ b/e2e/grpc/cli_test.go
@@ -165,6 +165,7 @@ func TestGRPCCLI_DeferCutover(t *testing.T) {
 		// Trigger cutover via CLI
 		out = e2eutil.RunCLIInDir(t, bin, schemaDir, "cutover",
 			applyID,
+			"-e", "staging",
 			"--endpoint", endpoint,
 			"--watch=false",
 		)
@@ -223,6 +224,7 @@ func TestGRPCCLI_StopStart(t *testing.T) {
 		// Stop via CLI
 		e2eutil.RunCLIInDir(t, bin, schemaDir, "stop",
 			applyID,
+			"-e", "staging",
 			"--endpoint", endpoint,
 		)
 
@@ -240,6 +242,7 @@ func TestGRPCCLI_StopStart(t *testing.T) {
 		// Start via CLI
 		e2eutil.RunCLIInDir(t, bin, schemaDir, "start",
 			applyID,
+			"-e", "staging",
 			"--endpoint", endpoint,
 			"--watch=false",
 		)
@@ -296,6 +299,7 @@ func TestGRPCCLI_Volume(t *testing.T) {
 	if !strings.Contains(e2eutil.StripANSI(progOut), "Completed") {
 		volOut, err := e2eutil.RunCLIWithErrorInDir(t, bin, schemaDir, "volume",
 			applyID,
+			"-e", "staging",
 			"-v", "5",
 			"--endpoint", endpoint,
 		)

--- a/e2e/grpc/grpc_test.go
+++ b/e2e/grpc/grpc_test.go
@@ -207,7 +207,7 @@ func TestGRPC_PlanApply_AddColumn(t *testing.T) {
 	require.True(t, apply.Accepted, "apply not accepted: %s", apply.ErrorMessage)
 
 	// Wait for completion
-	grpcWaitForState(t, "testapp", "staging", "COMPLETED", 3*time.Minute)
+	grpcWaitForState(t, "testapp", "staging", state.Apply.Completed, 3*time.Minute)
 
 	// Verify column exists
 	assert.True(t, grpcColumnExists(t, "staging", tableName, "email"),
@@ -240,15 +240,15 @@ func TestGRPC_StopStart(t *testing.T) {
 	require.True(t, apply.Accepted, "apply not accepted: %s", apply.ErrorMessage)
 
 	// Wait for it to be running (not just planned)
-	grpcWaitForAnyState(t, "testapp", "staging", []string{"APPLYING", "COPY", "COMPLETED"}, 60*time.Second)
+	grpcWaitForAnyState(t, "testapp", "staging", []string{state.Apply.Running, state.Apply.Completed}, 60*time.Second)
 
 	// If already completed, Spirit was too fast -- skip stop/start verification
 	prog := grpcProgress(t, "testapp", "staging")
-	if !strings.Contains(strings.ToUpper(prog.State), "COMPLETED") {
+	if !state.IsState(prog.State, state.Apply.Completed) {
 		// Stop
 		stopResp := grpcPost(t, "/api/stop", map[string]string{ //nolint:bodyclose // closed via utils.CloseAndLog
-			"database":    "testapp",
 			"environment": "staging",
+			"apply_id":    apply.ApplyID,
 		})
 		defer utils.CloseAndLog(stopResp.Body)
 		var stopResult grpcSimpleResponse
@@ -256,12 +256,12 @@ func TestGRPC_StopStart(t *testing.T) {
 		require.True(t, stopResult.Accepted, "stop not accepted: %s", stopResult.ErrorMessage)
 
 		// Verify stopped
-		grpcWaitForState(t, "testapp", "staging", "STOPPED", 30*time.Second)
+		grpcWaitForState(t, "testapp", "staging", state.Apply.Stopped, 30*time.Second)
 
 		// Start
 		startResp := grpcPost(t, "/api/start", map[string]string{ //nolint:bodyclose // closed via utils.CloseAndLog
-			"database":    "testapp",
 			"environment": "staging",
+			"apply_id":    apply.ApplyID,
 		})
 		defer utils.CloseAndLog(startResp.Body)
 		var startResult grpcSimpleResponse
@@ -270,7 +270,7 @@ func TestGRPC_StopStart(t *testing.T) {
 	}
 
 	// Wait for completion
-	grpcWaitForState(t, "testapp", "staging", "COMPLETED", 5*time.Minute)
+	grpcWaitForState(t, "testapp", "staging", state.Apply.Completed, 5*time.Minute)
 
 	grpcEnsureNoActiveChange(t, "testapp", "staging")
 }
@@ -301,7 +301,7 @@ func TestGRPC_StopStart_LocalStateSync(t *testing.T) {
 	require.NotEmpty(t, apply.ApplyID, "expected non-empty apply_id")
 
 	// Wait for it to be running (not just planned)
-	grpcWaitForAnyState(t, "testapp", "staging", []string{"APPLYING", "COPY", "RUNNING", "COMPLETED"}, 60*time.Second)
+	grpcWaitForAnyState(t, "testapp", "staging", []string{state.Apply.Running, state.Apply.Completed}, 60*time.Second)
 
 	// If already completed, Spirit was too fast -- skip stop/start verification
 	prog := grpcProgress(t, "testapp", "staging")
@@ -311,7 +311,6 @@ func TestGRPC_StopStart_LocalStateSync(t *testing.T) {
 
 	// Stop
 	stopResp := grpcPost(t, "/api/stop", map[string]string{
-		"database":    "testapp",
 		"environment": "staging",
 		"apply_id":    apply.ApplyID,
 	})
@@ -321,13 +320,12 @@ func TestGRPC_StopStart_LocalStateSync(t *testing.T) {
 	require.True(t, stopResult.Accepted, "stop not accepted: %s", stopResult.ErrorMessage)
 
 	// Verify stopped via database-based progress (calls Tern directly)
-	grpcWaitForState(t, "testapp", "staging", "STOPPED", 30*time.Second)
+	grpcWaitForState(t, "testapp", "staging", state.Apply.Stopped, 30*time.Second)
 
 	// Wait for the background poller to sync the stopped state to local storage.
 	grpcWaitForStatusState(t, apply.ApplyID, state.Apply.Stopped, false, 30*time.Second)
 
 	startResp := grpcPost(t, "/api/start", map[string]string{
-		"database":    "testapp",
 		"environment": "staging",
 		"apply_id":    apply.ApplyID,
 	})
@@ -349,7 +347,7 @@ func TestGRPC_StopStart_LocalStateSync(t *testing.T) {
 		"progress by apply_id must not show stopped after start")
 
 	// Wait for completion
-	grpcWaitForState(t, "testapp", "staging", "COMPLETED", 5*time.Minute)
+	grpcWaitForState(t, "testapp", "staging", state.Apply.Completed, 5*time.Minute)
 
 	grpcEnsureNoActiveChange(t, "testapp", "staging")
 }
@@ -375,14 +373,14 @@ func TestGRPC_Volume(t *testing.T) {
 	apply := grpcApply(t, plan.PlanID, "staging", nil)
 	require.True(t, apply.Accepted, "apply not accepted: %s", apply.ErrorMessage)
 
-	grpcWaitForAnyState(t, "testapp", "staging", []string{"APPLYING", "COPY", "COMPLETED"}, 60*time.Second)
+	grpcWaitForAnyState(t, "testapp", "staging", []string{state.Apply.Running, state.Apply.Completed}, 60*time.Second)
 
 	// Try to adjust volume (may fail if Spirit completed too fast -- that's OK)
 	prog := grpcProgress(t, "testapp", "staging")
-	if !strings.Contains(strings.ToUpper(prog.State), "COMPLETED") {
+	if !state.IsState(prog.State, state.Apply.Completed) {
 		resp := grpcPost(t, "/api/volume", map[string]any{ //nolint:bodyclose // closed via utils.CloseAndLog
-			"database":    "testapp",
 			"environment": "staging",
+			"apply_id":    apply.ApplyID,
 			"volume":      5,
 		})
 		defer utils.CloseAndLog(resp.Body)
@@ -398,7 +396,7 @@ func TestGRPC_Volume(t *testing.T) {
 	}
 
 	// Wait for completion
-	grpcWaitForState(t, "testapp", "staging", "COMPLETED", 5*time.Minute)
+	grpcWaitForState(t, "testapp", "staging", state.Apply.Completed, 5*time.Minute)
 
 	grpcEnsureNoActiveChange(t, "testapp", "staging")
 }
@@ -432,13 +430,13 @@ func TestGRPC_DeferCutover(t *testing.T) {
 
 	// Wait for waiting_for_cutover or completed (Spirit may be too fast even with copy-swap)
 	finalState := grpcWaitForAnyState(t, "testapp", "staging",
-		[]string{"WAITING_FOR_CUTOVER", "COMPLETED"}, 3*time.Minute)
+		[]string{state.Apply.WaitingForCutover, state.Apply.Completed}, 3*time.Minute)
 
-	if strings.Contains(strings.ToUpper(finalState), "WAITING_FOR_CUTOVER") {
+	if state.IsState(finalState, state.Apply.WaitingForCutover) {
 		// Trigger cutover
 		resp := grpcPost(t, "/api/cutover", map[string]string{ //nolint:bodyclose // closed via utils.CloseAndLog
-			"database":    "testapp",
 			"environment": "staging",
+			"apply_id":    apply.ApplyID,
 		})
 		defer utils.CloseAndLog(resp.Body)
 		var cutoverResp grpcSimpleResponse
@@ -446,7 +444,7 @@ func TestGRPC_DeferCutover(t *testing.T) {
 		require.True(t, cutoverResp.Accepted, "cutover not accepted: %s", cutoverResp.ErrorMessage)
 
 		// Wait for completion
-		grpcWaitForState(t, "testapp", "staging", "COMPLETED", 2*time.Minute)
+		grpcWaitForState(t, "testapp", "staging", state.Apply.Completed, 2*time.Minute)
 	}
 
 	grpcEnsureNoActiveChange(t, "testapp", "staging")
@@ -482,7 +480,7 @@ func TestGRPC_Status_StaleState(t *testing.T) {
 	require.True(t, apply.Accepted, "apply not accepted: %s", apply.ErrorMessage)
 
 	// Wait for completion via progress (this calls Tern's Progress RPC)
-	grpcWaitForState(t, "testapp", "staging", "COMPLETED", 3*time.Minute)
+	grpcWaitForState(t, "testapp", "staging", state.Apply.Completed, 3*time.Minute)
 
 	// Status reads from local storage, which is updated asynchronously by the
 	// background poller. Poll until the poller has synced the completed state.
@@ -496,15 +494,15 @@ func TestGRPC_Status_StaleState(t *testing.T) {
 			}
 		}
 		return found != nil &&
-			strings.Contains(strings.ToUpper(found.State), "COMPLETED") &&
+			state.IsState(found.State, state.Apply.Completed) &&
 			status.ActiveCount == 0
 	}, 30*time.Second, 500*time.Millisecond,
 		"status did not reflect completed state before timeout")
 
 	// Regression guard: status must not remain pending after Tern completes.
-	assert.NotEqual(t, "pending", found.State,
+	assert.False(t, state.IsState(found.State, state.Apply.Pending),
 		"status must reflect Tern's completed state, not stale pending")
-	assert.Contains(t, strings.ToUpper(found.State), "COMPLETED",
+	assert.True(t, state.IsState(found.State, state.Apply.Completed),
 		"status should show completed state after Tern finishes the apply")
 
 	grpcEnsureNoActiveChange(t, "testapp", "staging")
@@ -534,7 +532,7 @@ func TestGRPC_CrossService_PlanApply_Production(t *testing.T) {
 	require.True(t, apply.Accepted, "apply not accepted: %s", apply.ErrorMessage)
 
 	// Wait for completion
-	grpcWaitForState(t, "testapp", "production", "COMPLETED", 3*time.Minute)
+	grpcWaitForState(t, "testapp", "production", state.Apply.Completed, 3*time.Minute)
 
 	// Verify column exists
 	assert.True(t, grpcColumnExists(t, "production", tableName, colName),

--- a/e2e/grpc/helpers_test.go
+++ b/e2e/grpc/helpers_test.go
@@ -147,6 +147,7 @@ type grpcApplyResponse struct {
 type grpcProgressResponse struct {
 	State        string              `json:"state"`
 	Engine       string              `json:"engine"`
+	ApplyID      string              `json:"apply_id,omitempty"`
 	Tables       []grpcTableProgress `json:"tables"`
 	ErrorMessage string              `json:"error_message,omitempty"`
 	Summary      string              `json:"summary,omitempty"`
@@ -244,36 +245,36 @@ func grpcProgressByApplyID(t *testing.T, applyID string) grpcProgressResponse {
 	return result
 }
 
-func grpcWaitForState(t *testing.T, database, env, state string, timeout time.Duration) {
+func grpcWaitForState(t *testing.T, database, env, expectedState string, timeout time.Duration) {
 	t.Helper()
 	deadline := time.Now().Add(timeout)
 	var lastState string
 	for time.Now().Before(deadline) {
 		prog := grpcProgress(t, database, env)
 		lastState = prog.State
-		if strings.Contains(strings.ToUpper(prog.State), strings.ToUpper(state)) {
+		if state.IsState(prog.State, expectedState) {
 			return
 		}
 		time.Sleep(500 * time.Millisecond)
 	}
-	require.Failf(t, "timeout", "waiting for state %q, last state: %s", state, lastState)
+	require.Failf(t, "timeout", "waiting for state %q, last state: %s", expectedState, lastState)
 }
 
-func grpcWaitForAnyState(t *testing.T, database, env string, states []string, timeout time.Duration) string {
+func grpcWaitForAnyState(t *testing.T, database, env string, expectedStates []string, timeout time.Duration) string {
 	t.Helper()
 	deadline := time.Now().Add(timeout)
 	var lastState string
 	for time.Now().Before(deadline) {
 		prog := grpcProgress(t, database, env)
 		lastState = prog.State
-		for _, s := range states {
-			if strings.Contains(strings.ToUpper(prog.State), strings.ToUpper(s)) {
+		for _, expectedState := range expectedStates {
+			if state.IsState(prog.State, expectedState) {
 				return prog.State
 			}
 		}
 		time.Sleep(500 * time.Millisecond)
 	}
-	require.Failf(t, "timeout", "waiting for any of states %v, last state: %s", states, lastState)
+	require.Failf(t, "timeout", "waiting for any of states %v, last state: %s", expectedStates, lastState)
 	return ""
 }
 
@@ -284,13 +285,11 @@ func grpcEnsureNoActiveChange(t *testing.T, database, env string) {
 	deadline := time.Now().Add(60 * time.Second)
 	for time.Now().Before(deadline) {
 		prog := grpcProgress(t, database, env)
-		upper := strings.ToUpper(prog.State)
 
-		// No active change — includes STATE_COMPLETED because in gRPC mode,
+		// No active change includes completed because in gRPC mode,
 		// completed tasks are terminal and don't hold locks. The Tern service's
 		// SkipRevert requires a non-terminal task, so we clear storage directly instead.
-		if upper == "" || upper == "STATE_NO_ACTIVE_CHANGE" || strings.Contains(upper, "NO_ACTIVE") ||
-			strings.Contains(upper, "COMPLETED") || strings.Contains(upper, "REVERT_WINDOW") || strings.Contains(upper, "REVERTABLE") {
+		if state.IsState(prog.State, state.NoActiveChange, state.Apply.Completed, state.Apply.RevertWindow, state.Apply.Reverted) {
 			// Clean up Tern storage so the next test starts with a fresh state
 			grpcClearTernStorage(t, env)
 			grpcClearSchemabotState(t)
@@ -298,7 +297,7 @@ func grpcEnsureNoActiveChange(t *testing.T, database, env string) {
 		}
 
 		// Failed - clear all state
-		if strings.Contains(upper, "FAILED") {
+		if state.IsState(prog.State, state.Apply.Failed, state.Apply.FailedRetryable) {
 			grpcClearTernStorage(t, env)
 			grpcClearSchemabotState(t)
 			time.Sleep(500 * time.Millisecond)
@@ -306,10 +305,15 @@ func grpcEnsureNoActiveChange(t *testing.T, database, env string) {
 		}
 
 		// Stopped - start it so it can reach completion
-		if strings.Contains(upper, "STOPPED") {
+		if state.IsState(prog.State, state.Apply.Stopped) {
+			if prog.ApplyID == "" {
+				grpcClearTernStorage(t, env)
+				grpcClearSchemabotState(t)
+				return
+			}
 			resp := grpcPost(t, "/api/start", map[string]string{
-				"database":    database,
 				"environment": env,
+				"apply_id":    prog.ApplyID,
 			})
 			_ = resp.Body.Close()
 			time.Sleep(1 * time.Second)
@@ -317,10 +321,15 @@ func grpcEnsureNoActiveChange(t *testing.T, database, env string) {
 		}
 
 		// Waiting for cutover - trigger it
-		if strings.Contains(upper, "WAITING_FOR_CUTOVER") {
+		if state.IsState(prog.State, state.Apply.WaitingForCutover) {
+			if prog.ApplyID == "" {
+				grpcClearTernStorage(t, env)
+				grpcClearSchemabotState(t)
+				return
+			}
 			resp := grpcPost(t, "/api/cutover", map[string]string{
-				"database":    database,
 				"environment": env,
+				"apply_id":    prog.ApplyID,
 			})
 			_ = resp.Body.Close()
 			time.Sleep(1 * time.Second)

--- a/e2e/local/helpers_test.go
+++ b/e2e/local/helpers_test.go
@@ -243,7 +243,7 @@ func ensureNoActiveChange(t *testing.T, endpoint string) {
 
 		if s == state.Apply.Stopped {
 			log.Printf("Found stopped schema change (%s), restarting...", applyID)
-			resp, err := client.CallStartAPI(endpoint, "testapp", "staging", applyID)
+			resp, err := client.CallStartAPI(endpoint, "staging", applyID)
 			if err != nil {
 				log.Printf("Start failed for %s: %v", applyID, err)
 			} else if !resp.Accepted {
@@ -257,7 +257,7 @@ func ensureNoActiveChange(t *testing.T, endpoint string) {
 			// Cutover is async — triggers sentinel drop, Spirit completes in background.
 			// Poll loop will pick up completion on next iteration.
 			log.Printf("Found schema change waiting for cutover (%s), cutting over...", applyID)
-			resp, err := client.CallCutoverAPI(endpoint, "testapp", "staging", applyID)
+			resp, err := client.CallCutoverAPI(endpoint, "staging", applyID)
 			if err != nil {
 				log.Printf("Cutover failed for %s: %v", applyID, err)
 			} else if !resp.Accepted {

--- a/e2e/local/local_test.go
+++ b/e2e/local/local_test.go
@@ -826,7 +826,7 @@ CREATE TABLE %s (
 	})
 
 	t.Run("trigger_cutover", func(t *testing.T) {
-		out, err := e2eutil.RunCLIWithErrorInDir(t, binPath, schemaDir, "cutover", applyID, "--endpoint", endpoint, "--watch=false")
+		out, err := e2eutil.RunCLIWithErrorInDir(t, binPath, schemaDir, "cutover", applyID, "-e", "staging", "--endpoint", endpoint, "--watch=false")
 		if err != nil {
 			stripped := e2eutil.StripANSI(out)
 			if !strings.Contains(strings.ToLower(stripped), "complete") && !strings.Contains(strings.ToLower(stripped), "nothing to cutover") {
@@ -867,7 +867,7 @@ func TestLocal_Stop_NoActiveChange(t *testing.T) {
 	binPath := buildCLI(t)
 	endpoint := schemabotURL(t)
 
-	out, _ := runCLIWithError(t, binPath, "stop", "apply-nonexistent", "--endpoint", endpoint)
+	out, _ := runCLIWithError(t, binPath, "stop", "apply-nonexistent", "-e", "staging", "--endpoint", endpoint)
 	if !strings.Contains(out, "No") && !strings.Contains(out, "not found") && !strings.Contains(out, "error") {
 		t.Logf("Stop output: %s", out)
 	}
@@ -877,7 +877,7 @@ func TestLocal_Start_NoStoppedChange(t *testing.T) {
 	binPath := buildCLI(t)
 	endpoint := schemabotURL(t)
 
-	out, _ := runCLIWithError(t, binPath, "start", "apply-nonexistent", "--endpoint", endpoint, "--watch=false")
+	out, _ := runCLIWithError(t, binPath, "start", "apply-nonexistent", "-e", "staging", "--endpoint", endpoint, "--watch=false")
 	if !strings.Contains(out, "No") && !strings.Contains(out, "not found") && !strings.Contains(out, "error") {
 		t.Logf("Start output: %s", out)
 	}
@@ -931,17 +931,17 @@ CREATE TABLE %s (
 	applyState, _ := fetchApplyState(endpoint, applyID)
 
 	if applyState != state.Apply.Completed {
-		stopOut, stopErr := e2eutil.RunCLIWithErrorInDir(t, binPath, schemaDir, "stop", applyID, "--endpoint", endpoint)
+		stopOut, stopErr := e2eutil.RunCLIWithErrorInDir(t, binPath, schemaDir, "stop", applyID, "-e", "staging", "--endpoint", endpoint)
 		if stopErr == nil && strings.Contains(e2eutil.StripANSI(stopOut), "stopped") {
 			waitForApplyState(t, endpoint, applyID, state.Apply.Stopped, 30*time.Second)
-			startOut := e2eutil.RunCLIInDir(t, binPath, schemaDir, "start", applyID, "--endpoint", endpoint, "--watch=false")
+			startOut := e2eutil.RunCLIInDir(t, binPath, schemaDir, "start", applyID, "-e", "staging", "--endpoint", endpoint, "--watch=false")
 			e2eutil.AssertContains(t, startOut, "resumed")
 		}
 	}
 
 	waitForApplyAnyState(t, endpoint, applyID, []string{state.Apply.WaitingForCutover, state.Apply.Completed}, 30*time.Second)
 
-	cutoverOut, cutoverErr := e2eutil.RunCLIWithErrorInDir(t, binPath, schemaDir, "cutover", applyID, "--endpoint", endpoint, "--watch=false")
+	cutoverOut, cutoverErr := e2eutil.RunCLIWithErrorInDir(t, binPath, schemaDir, "cutover", applyID, "-e", "staging", "--endpoint", endpoint, "--watch=false")
 	if cutoverErr != nil {
 		stripped := e2eutil.StripANSI(cutoverOut)
 		if !strings.Contains(strings.ToLower(stripped), "complete") && !strings.Contains(strings.ToLower(stripped), "nothing to cutover") {
@@ -1089,7 +1089,7 @@ CREATE TABLE %s (
 	t.Run("stop_mid_flight", func(t *testing.T) {
 		waitForApplyState(t, endpoint, applyID, state.Apply.Running, 3*time.Second)
 
-		stopOut, stopErr := e2eutil.RunCLIWithErrorInDir(t, binPath, schemaDir, "stop", applyID, "--endpoint", endpoint)
+		stopOut, stopErr := e2eutil.RunCLIWithErrorInDir(t, binPath, schemaDir, "stop", applyID, "-e", "staging", "--endpoint", endpoint)
 		stripped := e2eutil.StripANSI(stopOut)
 		if stopErr != nil && !strings.Contains(strings.ToLower(stripped), "stopped") {
 			// If the apply already completed (tables too small), skip the stop/start test
@@ -1106,7 +1106,7 @@ CREATE TABLE %s (
 
 	// Resume — this should re-plan, find remaining tables, and process them sequentially
 	t.Run("start_resumes", func(t *testing.T) {
-		startOut := e2eutil.RunCLIInDir(t, binPath, schemaDir, "start", applyID, "--endpoint", endpoint, "--watch=false")
+		startOut := e2eutil.RunCLIInDir(t, binPath, schemaDir, "start", applyID, "-e", "staging", "--endpoint", endpoint, "--watch=false")
 		e2eutil.AssertContains(t, startOut, "resumed")
 	})
 
@@ -1141,12 +1141,11 @@ func TestLocal_Volume_Help(t *testing.T) {
 func TestLocal_Volume_InvalidLevel(t *testing.T) {
 	binPath := buildCLI(t)
 
-	// Volume validation happens after apply_id resolution, so these will fail
-	// at the resolution step (no such apply), which is still an error.
-	_, err := runCLIWithError(t, binPath, "volume", "apply-fake", "-v", "0", "--endpoint", "http://localhost:9999")
+	// Volume is rejected before the CLI contacts the API.
+	_, err := runCLIWithError(t, binPath, "volume", "apply-fake", "-e", "staging", "-v", "0", "--endpoint", "http://localhost:9999")
 	require.Error(t, err, "expected error for volume=0")
 
-	_, err = runCLIWithError(t, binPath, "volume", "apply-fake", "-v", "12", "--endpoint", "http://localhost:9999")
+	_, err = runCLIWithError(t, binPath, "volume", "apply-fake", "-e", "staging", "-v", "12", "--endpoint", "http://localhost:9999")
 	require.Error(t, err, "expected error for volume=12")
 }
 
@@ -1154,7 +1153,7 @@ func TestLocal_Volume_NoActiveChange(t *testing.T) {
 	binPath := buildCLI(t)
 	endpoint := schemabotURL(t)
 
-	_, err := runCLIWithError(t, binPath, "volume", "apply-nonexistent", "-v", "5", "--endpoint", endpoint)
+	_, err := runCLIWithError(t, binPath, "volume", "apply-nonexistent", "-e", "staging", "-v", "5", "--endpoint", endpoint)
 	if err == nil {
 		t.Log("volume with no active change didn't error - may be acceptable if there's a leftover state")
 	}
@@ -1209,7 +1208,7 @@ CREATE TABLE %s (
 	// Volume adjustment during "Waiting for cutover" stops but can't restart properly
 	prog, _ := testutil.FetchProgress(endpoint, applyID)
 	if prog != nil && prog.State == state.Apply.Running {
-		volumeOut, volumeErr := e2eutil.RunCLIWithErrorInDir(t, binPath, schemaDir, "volume", applyID, "-v", "8", "--endpoint", endpoint, "--watch=false")
+		volumeOut, volumeErr := e2eutil.RunCLIWithErrorInDir(t, binPath, schemaDir, "volume", applyID, "-e", "staging", "-v", "8", "--endpoint", endpoint, "--watch=false")
 		if volumeErr == nil {
 			t.Logf("Volume adjustment succeeded: %s", volumeOut)
 		} else {
@@ -1302,7 +1301,7 @@ CREATE TABLE %s (
 
 		prog, _ = testutil.FetchProgress(endpoint, applyID)
 		if prog != nil && prog.State == state.Apply.WaitingForCutover {
-			e2eutil.RunCLIInDir(t, binPath, schemaDir, "cutover", applyID, "--endpoint", endpoint, "--watch=false")
+			e2eutil.RunCLIInDir(t, binPath, schemaDir, "cutover", applyID, "-e", "staging", "--endpoint", endpoint, "--watch=false")
 			testutil.WaitForState(t, endpoint, applyID, state.Apply.Completed, 10*time.Second)
 		}
 	}

--- a/e2e/local/vitess_test.go
+++ b/e2e/local/vitess_test.go
@@ -1417,7 +1417,7 @@ func TestVitess_Apply_RevertWindow(t *testing.T) {
 	require.True(t, sawRevertWindow, "expected revert_window state (revert enabled by default), but apply jumped to completed")
 
 	// Clean up: skip-revert to finalize
-	_, _ = client.CallSkipRevertAPI(endpoint, vitessDB, "staging")
+	_, _ = client.CallSkipRevertAPI(endpoint, "staging", applyID)
 	waitForApplyState(t, endpoint, applyID, state.Apply.Completed, testutil.PollDeadline)
 }
 
@@ -1452,8 +1452,8 @@ func TestVitess_Apply_Cancel(t *testing.T) {
 	waitForApplyState(t, endpoint, applyID, state.Apply.WaitingForDeploy, testutil.PollDeadline)
 
 	// Cancel from the stable waiting_for_deploy state
-	t.Logf("calling stop API: endpoint=%s database=%s applyID=%s", endpoint, vitessDB, applyID)
-	stopResult, err := client.CallStopAPI(endpoint, vitessDB, "staging", applyID)
+	t.Logf("calling stop API: endpoint=%s applyID=%s", endpoint, applyID)
+	stopResult, err := client.CallStopAPI(endpoint, "staging", applyID)
 	require.NoError(t, err, "stop/cancel API call")
 	t.Logf("stop API returned: accepted=%v stopped=%d skipped=%d error=%q",
 		stopResult.Accepted, stopResult.StoppedCount, stopResult.SkippedCount, stopResult.ErrorMessage)
@@ -1553,7 +1553,7 @@ func TestVitess_Apply_DeferDeploy(t *testing.T) {
 	// return WaitingForDeploy before the apply record in storage catches up.
 	var startResp *apitypes.StartResponse
 	for range 10 {
-		startResp, err = client.CallStartAPI(endpoint, vitessDB, "staging", applyResp.ApplyID)
+		startResp, err = client.CallStartAPI(endpoint, "staging", applyResp.ApplyID)
 		if err == nil && startResp.Accepted {
 			break
 		}
@@ -1591,7 +1591,7 @@ func TestVitess_Apply_DeferDeploy_StartTooEarly(t *testing.T) {
 	require.NotEmpty(t, applyResp.ApplyID)
 
 	// Call Start immediately — apply hasn't reached WaitingForDeploy yet
-	_, startErr := client.CallStartAPI(endpoint, vitessDB, "staging", applyResp.ApplyID)
+	_, startErr := client.CallStartAPI(endpoint, "staging", applyResp.ApplyID)
 	require.Error(t, startErr)
 	assert.Contains(t, startErr.Error(), "not ready for deploy")
 
@@ -1599,7 +1599,7 @@ func TestVitess_Apply_DeferDeploy_StartTooEarly(t *testing.T) {
 	waitForApplyState(t, endpoint, applyResp.ApplyID, state.Apply.WaitingForDeploy, testutil.PollDeadline)
 	var startResp *apitypes.StartResponse
 	for range 10 {
-		startResp, err = client.CallStartAPI(endpoint, vitessDB, "staging", applyResp.ApplyID)
+		startResp, err = client.CallStartAPI(endpoint, "staging", applyResp.ApplyID)
 		if err == nil && startResp.Accepted {
 			break
 		}

--- a/integration/cli_test.go
+++ b/integration/cli_test.go
@@ -234,6 +234,7 @@ CREATE TABLE orders (
 	t.Run("cutover_completes_change", func(t *testing.T) {
 		out := runCLIInDir(t, binPath, schemaDir, "cutover",
 			applyID,
+			"-e", "staging",
 			"--endpoint", endpoint,
 			"--watch=false",
 		)
@@ -463,6 +464,7 @@ func TestCLI_Stop_NoActiveSchemaChange(t *testing.T) {
 		// Stop with a non-existent apply ID should fail
 		_, err := runCLIWithError(t, binPath, "stop",
 			"apply-nonexistent",
+			"-e", "staging",
 			"--endpoint", endpoint,
 		)
 		require.Error(t, err, "expected error for stop with non-existent apply ID")
@@ -481,6 +483,7 @@ func TestCLI_Start_NoStoppedSchemaChange(t *testing.T) {
 		// Start with a non-existent apply ID should fail
 		_, err := runCLIWithError(t, binPath, "start",
 			"apply-nonexistent",
+			"-e", "staging",
 			"--endpoint", endpoint,
 			"--watch=false",
 		)
@@ -595,6 +598,7 @@ CREATE TABLE items (
 	t.Run("stop_schema_change", func(t *testing.T) {
 		out := runCLIInDir(t, binPath, schemaDir, "stop",
 			applyID,
+			"-e", "staging",
 			"--endpoint", endpoint,
 		)
 		assertContains(t, out, "Schema change stopped")
@@ -617,6 +621,7 @@ CREATE TABLE items (
 	t.Run("start_schema_change", func(t *testing.T) {
 		out := runCLIInDir(t, binPath, schemaDir, "start",
 			applyID,
+			"-e", "staging",
 			"--endpoint", endpoint,
 			"--watch=false",
 		)
@@ -632,6 +637,7 @@ CREATE TABLE items (
 	t.Run("cutover", func(t *testing.T) {
 		out := runCLIInDir(t, binPath, schemaDir, "cutover",
 			applyID,
+			"-e", "staging",
 			"--endpoint", endpoint,
 			"--watch=false",
 		)
@@ -660,7 +666,7 @@ CREATE TABLE items (
 	t.Log("Stop/start flow completed successfully")
 }
 
-// TestCLI_StopStartByApplyID tests stop and start using --apply-id instead of --database/--environment.
+// TestCLI_StopStartByApplyID tests stop and start with explicit apply ID and environment scope.
 func TestCLI_StopStartByApplyID(t *testing.T) {
 	binPath := buildBinary(t, "schemabot", "./pkg/cmd")
 
@@ -752,6 +758,7 @@ CREATE TABLE items (
 	t.Run("stop_by_apply_id", func(t *testing.T) {
 		out := runCLIInDir(t, binPath, schemaDir, "stop",
 			applyID,
+			"-e", "staging",
 			"--endpoint", endpoint,
 		)
 		assertContains(t, out, "Schema change stopped")
@@ -762,6 +769,7 @@ CREATE TABLE items (
 	t.Run("start_by_apply_id", func(t *testing.T) {
 		out := runCLIInDir(t, binPath, schemaDir, "start",
 			applyID,
+			"-e", "staging",
 			"--endpoint", endpoint,
 			"--watch=false",
 		)
@@ -775,6 +783,7 @@ CREATE TABLE items (
 	t.Run("cutover", func(t *testing.T) {
 		out := runCLIInDir(t, binPath, schemaDir, "cutover",
 			applyID,
+			"-e", "staging",
 			"--endpoint", endpoint,
 			"--watch=false",
 		)
@@ -1158,6 +1167,7 @@ func TestCLI_Volume_NoActiveSchemaChange(t *testing.T) {
 		// Volume with a non-existent apply ID should fail
 		_, err := runCLIWithError(t, binPath, "volume",
 			"apply-nonexistent",
+			"-e", "staging",
 			"-v", "5",
 			"--endpoint", endpoint,
 		)

--- a/integration/locks_test.go
+++ b/integration/locks_test.go
@@ -659,10 +659,10 @@ CREATE TABLE users (
 	})
 
 	t.Run("cutover_works_while_locked", func(t *testing.T) {
-		// Cutover should work while locked (it's for the lock owner's schema change)
-		// It may fail because there's no active schema change, but NOT because of locking
+		// Control operations are scoped by apply_id and should not be rejected by repo locks.
+		// This may fail because the apply does not exist, but not because of locking.
 		out, _ := runCLIWithErrorInDir(t, binPath, schemaDir, "cutover",
-			"-d", dbName,
+			"apply-lock-test",
 			"-e", "staging",
 			"--endpoint", endpoint,
 			"--watch=false",
@@ -672,9 +672,9 @@ CREATE TABLE users (
 	})
 
 	t.Run("stop_works_while_locked", func(t *testing.T) {
-		// Stop should work while locked (it's for controlling the owner's schema change)
+		// Stop should not be blocked by repo locks.
 		out, _ := runCLIWithErrorInDir(t, binPath, schemaDir, "stop",
-			"-d", dbName,
+			"apply-lock-test",
 			"-e", "staging",
 			"--endpoint", endpoint,
 		)
@@ -683,9 +683,9 @@ CREATE TABLE users (
 	})
 
 	t.Run("start_works_while_locked", func(t *testing.T) {
-		// Start should work while locked
+		// Start should not be blocked by repo locks.
 		out, _ := runCLIWithErrorInDir(t, binPath, schemaDir, "start",
-			"-d", dbName,
+			"apply-lock-test",
 			"-e", "staging",
 			"--endpoint", endpoint,
 			"--watch=false",
@@ -695,9 +695,9 @@ CREATE TABLE users (
 	})
 
 	t.Run("volume_works_while_locked", func(t *testing.T) {
-		// Volume should work while locked
+		// Volume should not be blocked by repo locks.
 		out, _ := runCLIWithErrorInDir(t, binPath, schemaDir, "volume",
-			"-d", dbName,
+			"apply-lock-test",
 			"-e", "staging",
 			"-v", "5",
 			"--endpoint", endpoint,
@@ -862,6 +862,7 @@ CREATE TABLE orders (
 	t.Run("cleanup", func(t *testing.T) {
 		runCLIInDir(t, binPath, schemaDir, "cutover",
 			applyID,
+			"-e", "staging",
 			"--endpoint", endpoint,
 			"--watch=false",
 		)

--- a/pkg/api/README.md
+++ b/pkg/api/README.md
@@ -39,6 +39,10 @@ Plan requests resolve `database + environment` through server config, then store
 
 ### Control Operations
 
+Control requests are scoped by `apply_id` and `environment`. The API loads the
+stored apply row, derives database and routing metadata from storage, and rejects
+request bodies that try to send database or deployment fields.
+
 | Method | Path | Handler | Description |
 |--------|------|---------|-------------|
 | POST | `/api/cutover` | `handleCutover` | Trigger cutover |

--- a/pkg/api/control_handlers.go
+++ b/pkg/api/control_handlers.go
@@ -60,132 +60,133 @@ func (s *Service) logControlOperation(r *http.Request, applyID, caller, eventTyp
 }
 
 // writeControlError logs and writes an HTTP error for a control operation.
-func (s *Service) writeControlError(w http.ResponseWriter, opName, database string, err error) {
-	s.logger.Error(opName+" failed", "database", database, "error", err)
+func (s *Service) writeControlError(w http.ResponseWriter, opName string, apply *storage.Apply, err error) {
+	attrs := []any{"error", err}
+	if apply != nil {
+		attrs = append(attrs,
+			"apply_id", apply.ApplyIdentifier,
+			"external_apply_id", apply.ExternalID,
+			"database", apply.Database,
+			"database_type", apply.DatabaseType,
+			"environment", apply.Environment,
+		)
+	}
+	s.logger.Error(opName+" failed", attrs...)
 	s.writeError(w, http.StatusInternalServerError, opName+" failed: "+err.Error())
 }
 
 // decodeControlRequest decodes a control request (stop/start/cutover/volume),
-// resolves the apply ID, and returns a Tern client using the deployment stored
-// on the apply record. Deployment is a plan-time decision — control operations
-// always use the stored deployment, never a caller-provided one.
+// loads the apply record, and returns a Tern client using the deployment stored
+// on that apply. Control operations are scoped by apply_id + environment; the
+// database is derived from storage so callers cannot target a different
+// database than the one originally planned.
 func (s *Service) decodeControlRequest(w http.ResponseWriter, r *http.Request, dest any,
-	database, environment, applyID *string) (tern.Client, string, bool) {
+	environment, applyID *string) (tern.Client, *storage.Apply, string, bool) {
 
 	decoder := json.NewDecoder(r.Body)
 	decoder.DisallowUnknownFields()
 	if err := decoder.Decode(dest); err != nil {
 		s.writeError(w, http.StatusBadRequest, "invalid request body: "+err.Error())
-		return nil, "", false
+		return nil, nil, "", false
 	}
-	if *database == "" {
-		s.writeError(w, http.StatusBadRequest, "database is required")
-		return nil, "", false
+	if *applyID == "" {
+		s.writeError(w, http.StatusBadRequest, "apply_id is required")
+		return nil, nil, "", false
 	}
 	if *environment == "" {
-		*environment = "staging"
+		s.writeError(w, http.StatusBadRequest, "environment is required")
+		return nil, nil, "", false
 	}
 
-	// Resolve the apply — either from explicit apply_id or by finding the active
-	// apply for the database/environment. This ensures we always use the deployment
-	// stored on the apply, even when the caller only provides database+environment.
-	var resolvedApplyID string
-	var apply *storage.Apply
 	applyIdentifier := *applyID
-	if applyIdentifier == "" {
-		// No explicit apply_id — find the active apply for this database/environment.
-		ternApplyID, activeApply, err := s.findActiveApplyID(r.Context(), *database, *environment)
-		if err != nil {
-			s.writeError(w, http.StatusNotFound, fmt.Sprintf("no active schema change for %s/%s: %v", *database, *environment, err))
-			return nil, "", false
-		}
-		if activeApply == nil {
-			s.writeError(w, http.StatusNotFound, fmt.Sprintf("no active schema change for %s/%s", *database, *environment))
-			return nil, "", false
-		}
-		apply = activeApply
-		applyIdentifier = activeApply.ApplyIdentifier
-		resolvedApplyID = ternApplyID
-	} else {
-		applyStore := s.storage.Applies()
-		if applyStore == nil {
-			s.writeError(w, http.StatusInternalServerError, "apply store is not available")
-			return nil, "", false
-		}
-		var err error
-		apply, err = applyStore.GetByApplyIdentifier(r.Context(), applyIdentifier)
-		if err != nil {
-			s.writeError(w, http.StatusInternalServerError, fmt.Sprintf("failed to look up apply %q: %v", applyIdentifier, err))
-			return nil, "", false
-		}
-		if apply == nil {
-			s.writeError(w, http.StatusNotFound, "apply not found: "+applyIdentifier)
-			return nil, "", false
-		}
-		resolvedApplyID = apply.ApplyIdentifier
-		if apply.ExternalID != "" {
-			resolvedApplyID = apply.ExternalID
-		}
+	if s.storage == nil {
+		s.logger.Error("storage not available for control request", "path", r.URL.Path, "apply_id", applyIdentifier, "environment", *environment)
+		s.writeError(w, http.StatusInternalServerError, "storage is not available")
+		return nil, nil, "", false
 	}
-	if apply.Database != *database || apply.Environment != *environment {
+	applyStore := s.storage.Applies()
+	if applyStore == nil {
+		s.logger.Error("apply store not available for control request", "path", r.URL.Path, "apply_id", applyIdentifier, "environment", *environment)
+		s.writeError(w, http.StatusInternalServerError, "apply store is not available")
+		return nil, nil, "", false
+	}
+	apply, err := applyStore.GetByApplyIdentifier(r.Context(), applyIdentifier)
+	if err != nil {
+		s.logger.Error("failed to load apply for control request", "path", r.URL.Path, "apply_id", applyIdentifier, "environment", *environment, "error", err)
+		s.writeError(w, http.StatusInternalServerError, fmt.Sprintf("failed to look up apply %q: %v", applyIdentifier, err))
+		return nil, nil, "", false
+	}
+	if apply == nil {
+		s.writeError(w, http.StatusNotFound, "apply not found: "+applyIdentifier)
+		return nil, nil, "", false
+	}
+	resolvedApplyID := ternApplyIDForStoredApply(apply)
+	if apply.Environment != *environment {
 		s.writeError(w, http.StatusBadRequest,
-			fmt.Sprintf("apply %q belongs to %s/%s, not %s/%s", applyIdentifier, apply.Database, apply.Environment, *database, *environment))
-		return nil, "", false
+			fmt.Sprintf("apply %q belongs to environment %q, not %q", applyIdentifier, apply.Environment, *environment))
+		return nil, nil, "", false
 	}
 	deployment, err := storedDeploymentForApply(apply)
 	if err != nil {
 		s.logger.Error("control request apply is missing stored deployment metadata",
 			"apply_id", applyIdentifier,
-			"database", *database,
-			"environment", *environment,
+			"database", apply.Database,
+			"database_type", apply.DatabaseType,
+			"environment", apply.Environment,
 			"error", err)
 		s.writeError(w, http.StatusInternalServerError, err.Error())
-		return nil, "", false
+		return nil, nil, "", false
 	}
 
-	client, err := s.TernClient(deployment, *environment)
+	client, err := s.TernClient(deployment, apply.Environment)
 	if err != nil {
 		s.logger.Error("failed to create Tern client",
 			"deployment", deployment,
-			"database", *database,
-			"environment", *environment,
+			"database", apply.Database,
+			"environment", apply.Environment,
 			"error", err)
 		s.writeError(w, http.StatusNotFound, err.Error())
-		return nil, "", false
+		return nil, nil, "", false
 	}
 
-	return client, resolvedApplyID, true
+	return client, apply, resolvedApplyID, true
+}
+
+func ternApplyIDForStoredApply(apply *storage.Apply) string {
+	if apply.ExternalID != "" {
+		return apply.ExternalID
+	}
+	return apply.ApplyIdentifier
 }
 
 // CutoverRequest is the HTTP request body for POST /api/cutover.
 type CutoverRequest struct {
-	Database    string `json:"database"`
 	Environment string `json:"environment"`
-	ApplyID     string `json:"apply_id,omitempty"`
+	ApplyID     string `json:"apply_id"`
 	Caller      string `json:"caller,omitempty"`
 }
 
 // handleCutover handles POST /api/cutover requests.
 func (s *Service) handleCutover(w http.ResponseWriter, r *http.Request) {
 	var req CutoverRequest
-	client, applyID, ok := s.decodeControlRequest(w, r, &req, &req.Database, &req.Environment, &req.ApplyID)
+	client, apply, applyID, ok := s.decodeControlRequest(w, r, &req, &req.Environment, &req.ApplyID)
 	if !ok {
 		return
 	}
 
 	resp, err := client.Cutover(r.Context(), &ternv1.CutoverRequest{
 		ApplyId:     applyID,
-		Database:    req.Database,
-		Environment: req.Environment,
+		Database:    apply.Database,
+		Environment: apply.Environment,
 	})
 	if err != nil {
-		metrics.RecordControlOperation(r.Context(), "cutover", req.Database, req.Environment, "error")
-		s.writeControlError(w, "cutover", req.Database, err)
+		metrics.RecordControlOperation(r.Context(), "cutover", apply.Database, apply.Environment, "error")
+		s.writeControlError(w, "cutover", apply, err)
 		return
 	}
-	metrics.RecordControlOperation(r.Context(), "cutover", req.Database, req.Environment, controlStatus(resp.Accepted))
+	metrics.RecordControlOperation(r.Context(), "cutover", apply.Database, apply.Environment, controlStatus(resp.Accepted))
 	if resp.Accepted {
-		s.logControlOperation(r, applyID, req.Caller, storage.LogEventCutoverTriggered, "Cutover triggered by user")
+		s.logControlOperation(r, apply.ApplyIdentifier, req.Caller, storage.LogEventCutoverTriggered, "Cutover triggered by user")
 	}
 
 	s.writeJSON(w, http.StatusOK, &apitypes.ControlResponse{
@@ -196,9 +197,8 @@ func (s *Service) handleCutover(w http.ResponseWriter, r *http.Request) {
 
 // StopRequest is the HTTP request body for POST /api/stop.
 type StopRequest struct {
-	Database    string `json:"database"`
 	Environment string `json:"environment"`
-	ApplyID     string `json:"apply_id,omitempty"`
+	ApplyID     string `json:"apply_id"`
 	Caller      string `json:"caller,omitempty"`
 }
 
@@ -206,24 +206,24 @@ type StopRequest struct {
 // Stops all non-terminal tasks for the database.
 func (s *Service) handleStop(w http.ResponseWriter, r *http.Request) {
 	var req StopRequest
-	client, applyID, ok := s.decodeControlRequest(w, r, &req, &req.Database, &req.Environment, &req.ApplyID)
+	client, apply, applyID, ok := s.decodeControlRequest(w, r, &req, &req.Environment, &req.ApplyID)
 	if !ok {
 		return
 	}
 
 	resp, err := client.Stop(r.Context(), &ternv1.StopRequest{
 		ApplyId:     applyID,
-		Database:    req.Database,
-		Environment: req.Environment,
+		Database:    apply.Database,
+		Environment: apply.Environment,
 	})
 	if err != nil {
-		metrics.RecordControlOperation(r.Context(), "stop", req.Database, req.Environment, "error")
-		s.writeControlError(w, "stop", req.Database, err)
+		metrics.RecordControlOperation(r.Context(), "stop", apply.Database, apply.Environment, "error")
+		s.writeControlError(w, "stop", apply, err)
 		return
 	}
-	metrics.RecordControlOperation(r.Context(), "stop", req.Database, req.Environment, controlStatus(resp.Accepted))
+	metrics.RecordControlOperation(r.Context(), "stop", apply.Database, apply.Environment, controlStatus(resp.Accepted))
 	if resp.Accepted {
-		s.logControlOperation(r, applyID, req.Caller, storage.LogEventStopRequested, "Stop requested by user")
+		s.logControlOperation(r, apply.ApplyIdentifier, req.Caller, storage.LogEventStopRequested, "Stop requested by user")
 	}
 
 	s.writeJSON(w, http.StatusOK, &apitypes.StopResponse{
@@ -236,33 +236,32 @@ func (s *Service) handleStop(w http.ResponseWriter, r *http.Request) {
 
 // StartRequest is the HTTP request body for POST /api/start.
 type StartRequest struct {
-	Database    string `json:"database"`
 	Environment string `json:"environment"`
-	ApplyID     string `json:"apply_id,omitempty"`
+	ApplyID     string `json:"apply_id"`
 	Caller      string `json:"caller,omitempty"`
 }
 
 // handleStart handles POST /api/start requests.
 func (s *Service) handleStart(w http.ResponseWriter, r *http.Request) {
 	var req StartRequest
-	client, applyID, ok := s.decodeControlRequest(w, r, &req, &req.Database, &req.Environment, &req.ApplyID)
+	client, apply, applyID, ok := s.decodeControlRequest(w, r, &req, &req.Environment, &req.ApplyID)
 	if !ok {
 		return
 	}
 
 	resp, err := client.Start(r.Context(), &ternv1.StartRequest{
 		ApplyId:     applyID,
-		Database:    req.Database,
-		Environment: req.Environment,
+		Database:    apply.Database,
+		Environment: apply.Environment,
 	})
 	if err != nil {
-		metrics.RecordControlOperation(r.Context(), "start", req.Database, req.Environment, "error")
-		s.writeControlError(w, "start", req.Database, err)
+		metrics.RecordControlOperation(r.Context(), "start", apply.Database, apply.Environment, "error")
+		s.writeControlError(w, "start", apply, err)
 		return
 	}
-	metrics.RecordControlOperation(r.Context(), "start", req.Database, req.Environment, controlStatus(resp.Accepted))
+	metrics.RecordControlOperation(r.Context(), "start", apply.Database, apply.Environment, controlStatus(resp.Accepted))
 	if resp.Accepted {
-		s.logControlOperation(r, applyID, req.Caller, storage.LogEventStartRequested, "Start requested by user")
+		s.logControlOperation(r, apply.ApplyIdentifier, req.Caller, storage.LogEventStartRequested, "Start requested by user")
 	}
 
 	// For remote (gRPC) clients, update local apply state and restart the
@@ -270,18 +269,12 @@ func (s *Service) handleStart(w http.ResponseWriter, r *http.Request) {
 	// "stopped" permanently because the old poller exited when it saw the
 	// terminal state.
 	var syncErr string
-	if resp.Accepted && client.IsRemote() && req.ApplyID != "" {
-		apply, lookupErr := s.storage.Applies().GetByApplyIdentifier(r.Context(), req.ApplyID)
-		if lookupErr != nil {
-			s.logger.Error("failed to look up apply for post-start sync", "apply_id", req.ApplyID, "error", lookupErr)
+	if resp.Accepted && client.IsRemote() {
+		// Mark running before ResumeApply so it doesn't re-issue a Start RPC.
+		apply.State = state.Apply.Running
+		if resumeErr := client.ResumeApply(r.Context(), apply); resumeErr != nil {
+			s.logger.Error("failed to resume apply tracking after start", "apply_id", apply.ApplyIdentifier, "error", resumeErr)
 			syncErr = "schema change was started successfully, but the status and progress endpoints may show stale state until the next recovery cycle"
-		} else if apply != nil {
-			// Mark running before ResumeApply so it doesn't re-issue a Start RPC.
-			apply.State = state.Apply.Running
-			if resumeErr := client.ResumeApply(r.Context(), apply); resumeErr != nil {
-				s.logger.Error("failed to resume apply tracking after start", "apply_id", req.ApplyID, "error", resumeErr)
-				syncErr = "schema change was started successfully, but the status and progress endpoints may show stale state until the next recovery cycle"
-			}
 		}
 	}
 
@@ -301,8 +294,7 @@ func (s *Service) handleStart(w http.ResponseWriter, r *http.Request) {
 
 // VolumeRequest is the HTTP request body for POST /api/volume.
 type VolumeRequest struct {
-	ApplyID     string `json:"apply_id,omitempty"`
-	Database    string `json:"database"`
+	ApplyID     string `json:"apply_id"`
 	Environment string `json:"environment"`
 	Volume      int32  `json:"volume"` // 1-11 (1=conservative, 11=aggressive)
 }
@@ -310,7 +302,7 @@ type VolumeRequest struct {
 // handleVolume handles POST /api/volume requests.
 func (s *Service) handleVolume(w http.ResponseWriter, r *http.Request) {
 	var req VolumeRequest
-	client, applyID, ok := s.decodeControlRequest(w, r, &req, &req.Database, &req.Environment, &req.ApplyID)
+	client, apply, applyID, ok := s.decodeControlRequest(w, r, &req, &req.Environment, &req.ApplyID)
 	if !ok {
 		return
 	}
@@ -321,16 +313,17 @@ func (s *Service) handleVolume(w http.ResponseWriter, r *http.Request) {
 	}
 
 	resp, err := client.Volume(r.Context(), &ternv1.VolumeRequest{
-		ApplyId:  applyID,
-		Database: req.Database,
-		Volume:   req.Volume,
+		ApplyId:     applyID,
+		Database:    apply.Database,
+		Environment: apply.Environment,
+		Volume:      req.Volume,
 	})
 	if err != nil {
-		metrics.RecordControlOperation(r.Context(), "volume", req.Database, req.Environment, "error")
-		s.writeControlError(w, "volume", req.Database, err)
+		metrics.RecordControlOperation(r.Context(), "volume", apply.Database, apply.Environment, "error")
+		s.writeControlError(w, "volume", apply, err)
 		return
 	}
-	metrics.RecordControlOperation(r.Context(), "volume", req.Database, req.Environment, controlStatus(resp.Accepted))
+	metrics.RecordControlOperation(r.Context(), "volume", apply.Database, apply.Environment, controlStatus(resp.Accepted))
 
 	s.writeJSON(w, http.StatusOK, &apitypes.VolumeResponse{
 		Accepted:       resp.Accepted,
@@ -342,32 +335,31 @@ func (s *Service) handleVolume(w http.ResponseWriter, r *http.Request) {
 
 // RevertRequest is the HTTP request body for POST /api/revert.
 type RevertRequest struct {
-	Database    string `json:"database"`
 	Environment string `json:"environment"`
-	ApplyID     string `json:"apply_id,omitempty"`
+	ApplyID     string `json:"apply_id"`
 	Caller      string `json:"caller,omitempty"`
 }
 
 // handleRevert handles POST /api/revert requests.
 func (s *Service) handleRevert(w http.ResponseWriter, r *http.Request) {
 	var req RevertRequest
-	client, applyID, ok := s.decodeControlRequest(w, r, &req, &req.Database, &req.Environment, &req.ApplyID)
+	client, apply, applyID, ok := s.decodeControlRequest(w, r, &req, &req.Environment, &req.ApplyID)
 	if !ok {
 		return
 	}
 
 	resp, err := client.Revert(r.Context(), &ternv1.RevertRequest{
 		ApplyId:  applyID,
-		Database: req.Database,
+		Database: apply.Database,
 	})
 	if err != nil {
-		metrics.RecordControlOperation(r.Context(), "revert", req.Database, req.Environment, "error")
-		s.writeControlError(w, "revert", req.Database, err)
+		metrics.RecordControlOperation(r.Context(), "revert", apply.Database, apply.Environment, "error")
+		s.writeControlError(w, "revert", apply, err)
 		return
 	}
-	metrics.RecordControlOperation(r.Context(), "revert", req.Database, req.Environment, controlStatus(resp.Accepted))
+	metrics.RecordControlOperation(r.Context(), "revert", apply.Database, apply.Environment, controlStatus(resp.Accepted))
 	if resp.Accepted {
-		s.logControlOperation(r, applyID, req.Caller, storage.LogEventRevertTriggered, "Revert triggered by user")
+		s.logControlOperation(r, apply.ApplyIdentifier, req.Caller, storage.LogEventRevertTriggered, "Revert triggered by user")
 	}
 
 	s.writeJSON(w, http.StatusOK, &apitypes.ControlResponse{
@@ -378,47 +370,53 @@ func (s *Service) handleRevert(w http.ResponseWriter, r *http.Request) {
 
 // SkipRevertRequest is the HTTP request body for POST /api/skip-revert.
 type SkipRevertRequest struct {
-	Database    string `json:"database"`
 	Environment string `json:"environment"`
-	ApplyID     string `json:"apply_id,omitempty"`
+	ApplyID     string `json:"apply_id"`
 	Caller      string `json:"caller,omitempty"`
 }
 
 // handleSkipRevert handles POST /api/skip-revert requests.
 func (s *Service) handleSkipRevert(w http.ResponseWriter, r *http.Request) {
 	var req SkipRevertRequest
-	client, applyID, ok := s.decodeControlRequest(w, r, &req, &req.Database, &req.Environment, &req.ApplyID)
+	client, apply, applyID, ok := s.decodeControlRequest(w, r, &req, &req.Environment, &req.ApplyID)
 	if !ok {
 		return
 	}
 
 	resp, err := client.SkipRevert(r.Context(), &ternv1.SkipRevertRequest{
 		ApplyId:  applyID,
-		Database: req.Database,
+		Database: apply.Database,
 	})
 	if err != nil {
-		metrics.RecordControlOperation(r.Context(), "skip_revert", req.Database, req.Environment, "error")
-		s.writeControlError(w, "skip-revert", req.Database, err)
+		metrics.RecordControlOperation(r.Context(), "skip_revert", apply.Database, apply.Environment, "error")
+		s.writeControlError(w, "skip-revert", apply, err)
 		return
 	}
-	metrics.RecordControlOperation(r.Context(), "skip_revert", req.Database, req.Environment, controlStatus(resp.Accepted))
+	metrics.RecordControlOperation(r.Context(), "skip_revert", apply.Database, apply.Environment, controlStatus(resp.Accepted))
 
 	// Record skip-revert on VitessApplyData for progress visibility
-	if resp.Accepted && req.ApplyID != "" && s.storage != nil && s.storage.Applies() != nil {
-		if apply, _ := s.storage.Applies().GetByApplyIdentifier(r.Context(), req.ApplyID); apply != nil {
-			if apply.Engine == storage.EnginePlanetScale {
+	if resp.Accepted && apply.Engine == storage.EnginePlanetScale {
+		vitessDataStore := s.storage.VitessApplyData()
+		if vitessDataStore == nil {
+			s.logger.Error("vitess apply data store not available after skip-revert", "apply_id", apply.ID, "apply_identifier", apply.ApplyIdentifier)
+		} else {
+			vad, err := vitessDataStore.GetByApplyID(r.Context(), apply.ID)
+			switch {
+			case err != nil:
+				s.logger.Error("failed to load vitess apply data after skip-revert", "apply_id", apply.ID, "apply_identifier", apply.ApplyIdentifier, "error", err)
+			case vad == nil:
+				s.logger.Warn("vitess apply data missing after skip-revert", "apply_id", apply.ID, "apply_identifier", apply.ApplyIdentifier)
+			default:
 				now := time.Now()
-				if vad, err := s.storage.VitessApplyData().GetByApplyID(r.Context(), apply.ID); err == nil {
-					vad.RevertSkippedAt = &now
-					if err := s.storage.VitessApplyData().Save(r.Context(), vad); err != nil {
-						s.logger.Error("failed to save vitess apply data", "apply_id", apply.ID, "error", err)
-					}
+				vad.RevertSkippedAt = &now
+				if err := vitessDataStore.Save(r.Context(), vad); err != nil {
+					s.logger.Error("failed to save vitess apply data after skip-revert", "apply_id", apply.ID, "apply_identifier", apply.ApplyIdentifier, "error", err)
 				}
 			}
 		}
 	}
 	if resp.Accepted {
-		s.logControlOperation(r, applyID, req.Caller, storage.LogEventSkipRevertTriggered, "Skip-revert triggered by user")
+		s.logControlOperation(r, apply.ApplyIdentifier, req.Caller, storage.LogEventSkipRevertTriggered, "Skip-revert triggered by user")
 	}
 
 	s.writeJSON(w, http.StatusOK, &apitypes.ControlResponse{
@@ -462,7 +460,7 @@ func (s *Service) handleRollbackPlan(w http.ResponseWriter, r *http.Request) {
 	resp, err := s.ExecuteRollbackPlan(r.Context(), apply.Database, apply.Environment, apply.Deployment)
 	if err != nil {
 		metrics.RecordControlOperation(r.Context(), "rollback_plan", apply.Database, apply.Environment, "error")
-		s.writeControlError(w, "rollback plan", apply.Database, err)
+		s.writeControlError(w, "rollback plan", apply, err)
 		return
 	}
 	metrics.RecordControlOperation(r.Context(), "rollback_plan", apply.Database, apply.Environment, "success")

--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -111,6 +111,7 @@ type mockTernClient struct {
 	applyReq       *ternv1.ApplyRequest
 	volumeResp     *ternv1.VolumeResponse
 	volumeErr      error
+	volumeReq      *ternv1.VolumeRequest // captured request
 	stopResp       *ternv1.StopResponse
 	stopErr        error
 	stopReq        *ternv1.StopRequest // captured request
@@ -165,6 +166,7 @@ func (m *mockTernClient) Start(ctx context.Context, req *ternv1.StartRequest) (*
 	return nil, m.startErr
 }
 func (m *mockTernClient) Volume(ctx context.Context, req *ternv1.VolumeRequest) (*ternv1.VolumeResponse, error) {
+	m.volumeReq = req
 	if m.volumeResp != nil {
 		return m.volumeResp, m.volumeErr
 	}
@@ -487,7 +489,7 @@ func TestVolumeHandler(t *testing.T) {
 		mux := http.NewServeMux()
 		svc.ConfigureRoutes(mux)
 
-		body := `{"database": "testdb", "environment": "staging", "volume": 11}`
+		body := `{"environment": "staging", "apply_id": "apply-vol123", "volume": 11}`
 		req := httptest.NewRequestWithContext(t.Context(), "POST", "/api/volume", strings.NewReader(body))
 		req.Header.Set("Content-Type", "application/json")
 		w := httptest.NewRecorder()
@@ -505,6 +507,11 @@ func TestVolumeHandler(t *testing.T) {
 		newVol, _ := resp["new_volume"].(float64)
 		assert.Equal(t, float64(3), prevVol)
 		assert.Equal(t, float64(11), newVol)
+
+		require.NotNil(t, mock.volumeReq, "expected volume request to be captured")
+		assert.Equal(t, "apply-vol123", mock.volumeReq.ApplyId)
+		assert.Equal(t, "testdb", mock.volumeReq.Database)
+		assert.Equal(t, "staging", mock.volumeReq.Environment)
 	})
 
 	t.Run("invalid volume range", func(t *testing.T) {
@@ -512,7 +519,7 @@ func TestVolumeHandler(t *testing.T) {
 		mux := http.NewServeMux()
 		svc.ConfigureRoutes(mux)
 
-		body := `{"database": "testdb", "environment": "staging", "volume": 0}`
+		body := `{"environment": "staging", "apply_id": "apply-vol123", "volume": 0}`
 		req := httptest.NewRequestWithContext(t.Context(), "POST", "/api/volume", strings.NewReader(body))
 		req.Header.Set("Content-Type", "application/json")
 		w := httptest.NewRecorder()
@@ -526,7 +533,7 @@ func TestVolumeHandler(t *testing.T) {
 		assert.NotEmpty(t, resp["error"], "expected error message for invalid volume")
 	})
 
-	t.Run("missing database", func(t *testing.T) {
+	t.Run("missing apply_id", func(t *testing.T) {
 		svc := newTestService()
 		mux := http.NewServeMux()
 		svc.ConfigureRoutes(mux)
@@ -538,6 +545,7 @@ func TestVolumeHandler(t *testing.T) {
 		mux.ServeHTTP(w, req)
 
 		assert.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Contains(t, w.Body.String(), "apply_id is required")
 	})
 }
 
@@ -550,32 +558,32 @@ func TestControlHandlersRejectClientDeployment(t *testing.T) {
 		{
 			name: "stop",
 			path: "/api/stop",
-			body: `{"database": "testdb", "environment": "staging", "deployment": "default"}`,
+			body: `{"environment": "staging", "apply_id": "apply-123", "deployment": "default"}`,
 		},
 		{
 			name: "start",
 			path: "/api/start",
-			body: `{"database": "testdb", "environment": "staging", "deployment": "default"}`,
+			body: `{"environment": "staging", "apply_id": "apply-123", "deployment": "default"}`,
 		},
 		{
 			name: "cutover",
 			path: "/api/cutover",
-			body: `{"database": "testdb", "environment": "staging", "deployment": "default"}`,
+			body: `{"environment": "staging", "apply_id": "apply-123", "deployment": "default"}`,
 		},
 		{
 			name: "volume",
 			path: "/api/volume",
-			body: `{"database": "testdb", "environment": "staging", "deployment": "default", "volume": 5}`,
+			body: `{"environment": "staging", "apply_id": "apply-123", "deployment": "default", "volume": 5}`,
 		},
 		{
 			name: "revert",
 			path: "/api/revert",
-			body: `{"database": "testdb", "environment": "staging", "deployment": "default"}`,
+			body: `{"environment": "staging", "apply_id": "apply-123", "deployment": "default"}`,
 		},
 		{
 			name: "skip-revert",
 			path: "/api/skip-revert",
-			body: `{"database": "testdb", "environment": "staging", "deployment": "default"}`,
+			body: `{"environment": "staging", "apply_id": "apply-123", "deployment": "default"}`,
 		},
 		{
 			name: "rollback plan",
@@ -602,20 +610,79 @@ func TestControlHandlersRejectClientDeployment(t *testing.T) {
 	}
 }
 
-func TestControlHandlerRejectsApplyDatabaseMismatch(t *testing.T) {
+func TestControlHandlersRejectClientDatabase(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		body string
+	}{
+		{
+			name: "stop",
+			path: "/api/stop",
+			body: `{"database": "testdb", "environment": "staging", "apply_id": "apply-123"}`,
+		},
+		{
+			name: "start",
+			path: "/api/start",
+			body: `{"database": "testdb", "environment": "staging", "apply_id": "apply-123"}`,
+		},
+		{
+			name: "cutover",
+			path: "/api/cutover",
+			body: `{"database": "testdb", "environment": "staging", "apply_id": "apply-123"}`,
+		},
+		{
+			name: "volume",
+			path: "/api/volume",
+			body: `{"database": "testdb", "environment": "staging", "apply_id": "apply-123", "volume": 5}`,
+		},
+		{
+			name: "revert",
+			path: "/api/revert",
+			body: `{"database": "testdb", "environment": "staging", "apply_id": "apply-123"}`,
+		},
+		{
+			name: "skip-revert",
+			path: "/api/skip-revert",
+			body: `{"database": "testdb", "environment": "staging", "apply_id": "apply-123"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := newTestService()
+			mux := http.NewServeMux()
+			svc.ConfigureRoutes(mux)
+
+			req := httptest.NewRequestWithContext(t.Context(), "POST", tt.path, strings.NewReader(tt.body))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+			mux.ServeHTTP(w, req)
+
+			assert.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
+			assert.Contains(t, w.Body.String(), "unknown field")
+			assert.Contains(t, w.Body.String(), "database")
+		})
+	}
+}
+
+func TestControlHandlerRejectsApplyEnvironmentMismatch(t *testing.T) {
 	svc := newControlTestService(&mockTernClient{}, activeTestApply("apply-abc123"))
 	mux := http.NewServeMux()
 	svc.ConfigureRoutes(mux)
 
-	body := `{"database": "otherdb", "environment": "staging", "apply_id": "apply-abc123"}`
+	body := `{"environment": "production", "apply_id": "apply-abc123"}`
 	req := httptest.NewRequestWithContext(t.Context(), "POST", "/api/stop", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 	mux.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
-	assert.Contains(t, w.Body.String(), "belongs to testdb/staging")
-	assert.Contains(t, w.Body.String(), "not otherdb/staging")
+	var resp apitypes.ErrorResponse
+	err := json.NewDecoder(w.Body).Decode(&resp)
+	require.NoError(t, err, "failed to decode response")
+	assert.Contains(t, resp.Error, `belongs to environment "staging"`)
+	assert.Contains(t, resp.Error, `not "production"`)
 }
 
 func TestStopHandler(t *testing.T) {
@@ -630,7 +697,7 @@ func TestStopHandler(t *testing.T) {
 		mux := http.NewServeMux()
 		svc.ConfigureRoutes(mux)
 
-		body := `{"database": "testdb", "environment": "staging", "apply_id": "apply-abc123"}`
+		body := `{"environment": "staging", "apply_id": "apply-abc123"}`
 		req := httptest.NewRequestWithContext(t.Context(), "POST", "/api/stop", strings.NewReader(body))
 		req.Header.Set("Content-Type", "application/json")
 		w := httptest.NewRecorder()
@@ -638,42 +705,15 @@ func TestStopHandler(t *testing.T) {
 
 		assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
 
-		// Verify apply_id was passed through to the tern client
 		require.NotNil(t, mock.stopReq, "expected stop request to be captured")
 		assert.Equal(t, "apply-abc123", mock.stopReq.ApplyId)
 		assert.Equal(t, "testdb", mock.stopReq.Database)
+		assert.Equal(t, "staging", mock.stopReq.Environment)
 	})
 
-	t.Run("works without apply_id", func(t *testing.T) {
-		mock := &mockTernClient{
-			stopResp: &ternv1.StopResponse{
-				Accepted:     true,
-				StoppedCount: 1,
-			},
-		}
+	t.Run("requires apply_id", func(t *testing.T) {
+		mock := &mockTernClient{}
 		svc := newControlTestService(mock, activeTestApply("apply-active-stop"))
-		mux := http.NewServeMux()
-		svc.ConfigureRoutes(mux)
-
-		body := `{"database": "testdb", "environment": "staging"}`
-		req := httptest.NewRequestWithContext(t.Context(), "POST", "/api/stop", strings.NewReader(body))
-		req.Header.Set("Content-Type", "application/json")
-		w := httptest.NewRecorder()
-		mux.ServeHTTP(w, req)
-
-		assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
-		require.NotNil(t, mock.stopReq, "expected stop request to be captured")
-		assert.Equal(t, "apply-active-stop", mock.stopReq.ApplyId)
-
-		var resp apitypes.StopResponse
-		err := json.NewDecoder(w.Body).Decode(&resp)
-		require.NoError(t, err, "failed to decode response")
-		assert.True(t, resp.Accepted, "expected accepted=true")
-		assert.Equal(t, int64(1), resp.StoppedCount)
-	})
-
-	t.Run("missing database", func(t *testing.T) {
-		svc := newTestService()
 		mux := http.NewServeMux()
 		svc.ConfigureRoutes(mux)
 
@@ -683,7 +723,24 @@ func TestStopHandler(t *testing.T) {
 		w := httptest.NewRecorder()
 		mux.ServeHTTP(w, req)
 
+		assert.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
+		assert.Contains(t, w.Body.String(), "apply_id is required")
+		assert.Nil(t, mock.stopReq)
+	})
+
+	t.Run("missing environment", func(t *testing.T) {
+		svc := newTestService()
+		mux := http.NewServeMux()
+		svc.ConfigureRoutes(mux)
+
+		body := `{"apply_id": "apply-abc123"}`
+		req := httptest.NewRequestWithContext(t.Context(), "POST", "/api/stop", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, req)
+
 		assert.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Contains(t, w.Body.String(), "environment is required")
 	})
 }
 
@@ -699,7 +756,7 @@ func TestStartHandler(t *testing.T) {
 		mux := http.NewServeMux()
 		svc.ConfigureRoutes(mux)
 
-		body := `{"database": "testdb", "environment": "staging", "apply_id": "apply-xyz789"}`
+		body := `{"environment": "staging", "apply_id": "apply-xyz789"}`
 		req := httptest.NewRequestWithContext(t.Context(), "POST", "/api/start", strings.NewReader(body))
 		req.Header.Set("Content-Type", "application/json")
 		w := httptest.NewRecorder()
@@ -707,42 +764,15 @@ func TestStartHandler(t *testing.T) {
 
 		assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
 
-		// Verify apply_id was passed through to the tern client
 		require.NotNil(t, mock.startReq, "expected start request to be captured")
 		assert.Equal(t, "apply-xyz789", mock.startReq.ApplyId)
 		assert.Equal(t, "testdb", mock.startReq.Database)
+		assert.Equal(t, "staging", mock.startReq.Environment)
 	})
 
-	t.Run("works without apply_id", func(t *testing.T) {
-		mock := &mockTernClient{
-			startResp: &ternv1.StartResponse{
-				Accepted:     true,
-				StartedCount: 1,
-			},
-		}
+	t.Run("requires apply_id", func(t *testing.T) {
+		mock := &mockTernClient{}
 		svc := newControlTestService(mock, activeTestApply("apply-active-start"))
-		mux := http.NewServeMux()
-		svc.ConfigureRoutes(mux)
-
-		body := `{"database": "testdb", "environment": "staging"}`
-		req := httptest.NewRequestWithContext(t.Context(), "POST", "/api/start", strings.NewReader(body))
-		req.Header.Set("Content-Type", "application/json")
-		w := httptest.NewRecorder()
-		mux.ServeHTTP(w, req)
-
-		assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
-		require.NotNil(t, mock.startReq, "expected start request to be captured")
-		assert.Equal(t, "apply-active-start", mock.startReq.ApplyId)
-
-		var resp apitypes.StartResponse
-		err := json.NewDecoder(w.Body).Decode(&resp)
-		require.NoError(t, err, "failed to decode response")
-		assert.True(t, resp.Accepted, "expected accepted=true")
-		assert.Equal(t, int64(1), resp.StartedCount)
-	})
-
-	t.Run("missing database", func(t *testing.T) {
-		svc := newTestService()
 		mux := http.NewServeMux()
 		svc.ConfigureRoutes(mux)
 
@@ -752,7 +782,24 @@ func TestStartHandler(t *testing.T) {
 		w := httptest.NewRecorder()
 		mux.ServeHTTP(w, req)
 
+		assert.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
+		assert.Contains(t, w.Body.String(), "apply_id is required")
+		assert.Nil(t, mock.startReq)
+	})
+
+	t.Run("missing environment", func(t *testing.T) {
+		svc := newTestService()
+		mux := http.NewServeMux()
+		svc.ConfigureRoutes(mux)
+
+		body := `{"apply_id": "apply-xyz789"}`
+		req := httptest.NewRequestWithContext(t.Context(), "POST", "/api/start", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, req)
+
 		assert.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Contains(t, w.Body.String(), "environment is required")
 	})
 }
 
@@ -767,7 +814,7 @@ func TestCutoverHandler(t *testing.T) {
 		mux := http.NewServeMux()
 		svc.ConfigureRoutes(mux)
 
-		body := `{"database": "testdb", "environment": "staging", "apply_id": "apply-cut123"}`
+		body := `{"environment": "staging", "apply_id": "apply-cut123"}`
 		req := httptest.NewRequestWithContext(t.Context(), "POST", "/api/cutover", strings.NewReader(body))
 		req.Header.Set("Content-Type", "application/json")
 		w := httptest.NewRecorder()
@@ -777,31 +824,13 @@ func TestCutoverHandler(t *testing.T) {
 
 		require.NotNil(t, mock.cutoverReq, "expected cutover request to be captured")
 		assert.Equal(t, "apply-cut123", mock.cutoverReq.ApplyId)
+		assert.Equal(t, "testdb", mock.cutoverReq.Database)
+		assert.Equal(t, "staging", mock.cutoverReq.Environment)
 	})
 
-	t.Run("works without apply_id", func(t *testing.T) {
-		mock := &mockTernClient{
-			cutoverResp: &ternv1.CutoverResponse{
-				Accepted: true,
-			},
-		}
+	t.Run("requires apply_id", func(t *testing.T) {
+		mock := &mockTernClient{}
 		svc := newControlTestService(mock, activeTestApply("apply-active-cutover"))
-		mux := http.NewServeMux()
-		svc.ConfigureRoutes(mux)
-
-		body := `{"database": "testdb", "environment": "staging"}`
-		req := httptest.NewRequestWithContext(t.Context(), "POST", "/api/cutover", strings.NewReader(body))
-		req.Header.Set("Content-Type", "application/json")
-		w := httptest.NewRecorder()
-		mux.ServeHTTP(w, req)
-
-		assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
-		require.NotNil(t, mock.cutoverReq, "expected cutover request to be captured")
-		assert.Equal(t, "apply-active-cutover", mock.cutoverReq.ApplyId)
-	})
-
-	t.Run("missing database", func(t *testing.T) {
-		svc := newTestService()
 		mux := http.NewServeMux()
 		svc.ConfigureRoutes(mux)
 
@@ -811,7 +840,24 @@ func TestCutoverHandler(t *testing.T) {
 		w := httptest.NewRecorder()
 		mux.ServeHTTP(w, req)
 
+		assert.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
+		assert.Contains(t, w.Body.String(), "apply_id is required")
+		assert.Nil(t, mock.cutoverReq)
+	})
+
+	t.Run("missing environment", func(t *testing.T) {
+		svc := newTestService()
+		mux := http.NewServeMux()
+		svc.ConfigureRoutes(mux)
+
+		body := `{"apply_id": "apply-cut123"}`
+		req := httptest.NewRequestWithContext(t.Context(), "POST", "/api/cutover", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, req)
+
 		assert.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Contains(t, w.Body.String(), "environment is required")
 	})
 }
 
@@ -824,7 +870,7 @@ func TestRevertHandler(t *testing.T) {
 		mux := http.NewServeMux()
 		svc.ConfigureRoutes(mux)
 
-		body := `{"database": "testdb", "environment": "staging", "apply_id": "apply-rev123"}`
+		body := `{"environment": "staging", "apply_id": "apply-rev123"}`
 		req := httptest.NewRequestWithContext(t.Context(), "POST", "/api/revert", strings.NewReader(body))
 		req.Header.Set("Content-Type", "application/json")
 		w := httptest.NewRecorder()
@@ -836,23 +882,21 @@ func TestRevertHandler(t *testing.T) {
 		assert.Equal(t, "testdb", mock.revertReq.Database)
 	})
 
-	t.Run("works without apply_id", func(t *testing.T) {
-		mock := &mockTernClient{
-			revertResp: &ternv1.RevertResponse{Accepted: true},
-		}
+	t.Run("requires apply_id", func(t *testing.T) {
+		mock := &mockTernClient{}
 		svc := newControlTestService(mock, activeTestApply("apply-active-revert"))
 		mux := http.NewServeMux()
 		svc.ConfigureRoutes(mux)
 
-		body := `{"database": "testdb", "environment": "staging"}`
+		body := `{"environment": "staging"}`
 		req := httptest.NewRequestWithContext(t.Context(), "POST", "/api/revert", strings.NewReader(body))
 		req.Header.Set("Content-Type", "application/json")
 		w := httptest.NewRecorder()
 		mux.ServeHTTP(w, req)
 
-		assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
-		require.NotNil(t, mock.revertReq, "expected revert request to be captured")
-		assert.Equal(t, "apply-active-revert", mock.revertReq.ApplyId)
+		assert.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
+		assert.Contains(t, w.Body.String(), "apply_id is required")
+		assert.Nil(t, mock.revertReq)
 	})
 }
 
@@ -865,7 +909,7 @@ func TestSkipRevertHandler(t *testing.T) {
 		mux := http.NewServeMux()
 		svc.ConfigureRoutes(mux)
 
-		body := `{"database": "testdb", "environment": "staging", "apply_id": "apply-skip456"}`
+		body := `{"environment": "staging", "apply_id": "apply-skip456"}`
 		req := httptest.NewRequestWithContext(t.Context(), "POST", "/api/skip-revert", strings.NewReader(body))
 		req.Header.Set("Content-Type", "application/json")
 		w := httptest.NewRecorder()
@@ -877,23 +921,21 @@ func TestSkipRevertHandler(t *testing.T) {
 		assert.Equal(t, "testdb", mock.skipRevertReq.Database)
 	})
 
-	t.Run("works without apply_id", func(t *testing.T) {
-		mock := &mockTernClient{
-			skipRevertResp: &ternv1.SkipRevertResponse{Accepted: true},
-		}
+	t.Run("requires apply_id", func(t *testing.T) {
+		mock := &mockTernClient{}
 		svc := newControlTestService(mock, activeTestApply("apply-active-skip"))
 		mux := http.NewServeMux()
 		svc.ConfigureRoutes(mux)
 
-		body := `{"database": "testdb", "environment": "staging"}`
+		body := `{"environment": "staging"}`
 		req := httptest.NewRequestWithContext(t.Context(), "POST", "/api/skip-revert", strings.NewReader(body))
 		req.Header.Set("Content-Type", "application/json")
 		w := httptest.NewRecorder()
 		mux.ServeHTTP(w, req)
 
-		assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
-		require.NotNil(t, mock.skipRevertReq, "expected skip-revert request to be captured")
-		assert.Equal(t, "apply-active-skip", mock.skipRevertReq.ApplyId)
+		assert.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
+		assert.Contains(t, w.Body.String(), "apply_id is required")
+		assert.Nil(t, mock.skipRevertReq)
 	})
 }
 

--- a/pkg/apitypes/apitypes.go
+++ b/pkg/apitypes/apitypes.go
@@ -74,16 +74,14 @@ type ApplyRequest struct {
 // ControlRequest is the HTTP request body for control operations
 // (stop, start, cutover, revert, skip-revert).
 type ControlRequest struct {
-	Database    string `json:"database"`
 	Environment string `json:"environment"`
-	ApplyID     string `json:"apply_id,omitempty"`
+	ApplyID     string `json:"apply_id"`
 	Caller      string `json:"caller,omitempty"`
 }
 
 // VolumeRequest is the HTTP request body for POST /api/volume.
 type VolumeRequest struct {
-	ApplyID     string `json:"apply_id,omitempty"`
-	Database    string `json:"database"`
+	ApplyID     string `json:"apply_id"`
 	Environment string `json:"environment"`
 	Volume      int32  `json:"volume"`
 }

--- a/pkg/cmd/client/client.go
+++ b/pkg/cmd/client/client.go
@@ -114,8 +114,8 @@ func CallApplyAPI(endpoint, planID, environment, caller string, options map[stri
 }
 
 // CallCutoverAPI calls the cutover API and returns the typed result.
-func CallCutoverAPI(endpoint, database, environment, applyID string) (*apitypes.ControlResponse, error) {
-	req := apitypes.ControlRequest{Database: database, Environment: environment, ApplyID: applyID, Caller: GenerateCLIOwner()}
+func CallCutoverAPI(endpoint, environment, applyID string) (*apitypes.ControlResponse, error) {
+	req := apitypes.ControlRequest{Environment: environment, ApplyID: applyID, Caller: GenerateCLIOwner()}
 	var result apitypes.ControlResponse
 	if err := doPostInto(endpoint, "/api/cutover", req, &result); err != nil {
 		return nil, err
@@ -253,8 +253,8 @@ func isSchemaFile(name string) bool {
 }
 
 // CallStopAPI calls the stop API and returns the typed result.
-func CallStopAPI(endpoint, database, environment, applyID string) (*apitypes.StopResponse, error) {
-	req := apitypes.ControlRequest{Database: database, Environment: environment, ApplyID: applyID, Caller: GenerateCLIOwner()}
+func CallStopAPI(endpoint, environment, applyID string) (*apitypes.StopResponse, error) {
+	req := apitypes.ControlRequest{Environment: environment, ApplyID: applyID, Caller: GenerateCLIOwner()}
 	var result apitypes.StopResponse
 	if err := doPostInto(endpoint, "/api/stop", req, &result); err != nil {
 		return nil, err
@@ -263,8 +263,8 @@ func CallStopAPI(endpoint, database, environment, applyID string) (*apitypes.Sto
 }
 
 // CallStartAPI calls the start API and returns the typed result.
-func CallStartAPI(endpoint, database, environment, applyID string) (*apitypes.StartResponse, error) {
-	req := apitypes.ControlRequest{Database: database, Environment: environment, ApplyID: applyID, Caller: GenerateCLIOwner()}
+func CallStartAPI(endpoint, environment, applyID string) (*apitypes.StartResponse, error) {
+	req := apitypes.ControlRequest{Environment: environment, ApplyID: applyID, Caller: GenerateCLIOwner()}
 	var result apitypes.StartResponse
 	if err := doPostInto(endpoint, "/api/start", req, &result); err != nil {
 		return nil, err
@@ -273,8 +273,8 @@ func CallStartAPI(endpoint, database, environment, applyID string) (*apitypes.St
 }
 
 // CallVolumeAPI calls the volume API and returns the typed result.
-func CallVolumeAPI(endpoint, database, environment, applyID string, volume int) (*apitypes.VolumeResponse, error) {
-	req := apitypes.VolumeRequest{Database: database, Environment: environment, Volume: int32(volume), ApplyID: applyID}
+func CallVolumeAPI(endpoint, environment, applyID string, volume int) (*apitypes.VolumeResponse, error) {
+	req := apitypes.VolumeRequest{Environment: environment, Volume: int32(volume), ApplyID: applyID}
 	var result apitypes.VolumeResponse
 	if err := doPostInto(endpoint, "/api/volume", req, &result); err != nil {
 		return nil, err
@@ -283,8 +283,8 @@ func CallVolumeAPI(endpoint, database, environment, applyID string, volume int) 
 }
 
 // CallRevertAPI calls the revert API and returns the typed result.
-func CallRevertAPI(endpoint, database, environment string) (*apitypes.ControlResponse, error) {
-	req := apitypes.ControlRequest{Database: database, Environment: environment, Caller: GenerateCLIOwner()}
+func CallRevertAPI(endpoint, environment, applyID string) (*apitypes.ControlResponse, error) {
+	req := apitypes.ControlRequest{Environment: environment, ApplyID: applyID, Caller: GenerateCLIOwner()}
 	var result apitypes.ControlResponse
 	if err := doPostInto(endpoint, "/api/revert", req, &result); err != nil {
 		return nil, err
@@ -293,8 +293,8 @@ func CallRevertAPI(endpoint, database, environment string) (*apitypes.ControlRes
 }
 
 // CallSkipRevertAPI calls the skip-revert API and returns the typed result.
-func CallSkipRevertAPI(endpoint, database, environment string) (*apitypes.ControlResponse, error) {
-	req := apitypes.ControlRequest{Database: database, Environment: environment, Caller: GenerateCLIOwner()}
+func CallSkipRevertAPI(endpoint, environment, applyID string) (*apitypes.ControlResponse, error) {
+	req := apitypes.ControlRequest{Environment: environment, ApplyID: applyID, Caller: GenerateCLIOwner()}
 	var result apitypes.ControlResponse
 	if err := doPostInto(endpoint, "/api/skip-revert", req, &result); err != nil {
 		return nil, err

--- a/pkg/cmd/commands/apply.go
+++ b/pkg/cmd/commands/apply.go
@@ -67,7 +67,7 @@ func (cmd *ApplyCmd) Run(g *Globals) error {
 	} else if active != nil && active.State != "" && !state.IsState(active.State, state.NoActiveChange) {
 		progressCmd := fmt.Sprintf("schemabot status %s", active.ApplyID)
 		if active.ApplyID == "" {
-			progressCmd = fmt.Sprintf("schemabot progress -d %s -e %s", cfg.Database, cmd.Environment)
+			progressCmd = fmt.Sprintf("schemabot status -d %s -e %s", cfg.Database, cmd.Environment)
 		}
 		var stateMsg string
 		switch {
@@ -91,9 +91,9 @@ func (cmd *ApplyCmd) Run(g *Globals) error {
 			fmt.Println()
 			if state.IsState(active.State, state.Apply.WaitingForDeploy, state.Apply.WaitingForCutover) {
 				if active.ApplyID != "" {
-					fmt.Printf("To trigger cutover:  schemabot cutover --apply-id %s\n", active.ApplyID)
+					fmt.Printf("To trigger cutover:  schemabot cutover -e %s %s\n", cmd.Environment, active.ApplyID)
 				} else {
-					fmt.Printf("To trigger cutover:  schemabot cutover -d %s -e %s\n", cfg.Database, cmd.Environment)
+					fmt.Printf("To find the apply ID: schemabot status -d %s -e %s\n", cfg.Database, cmd.Environment)
 				}
 			}
 			fmt.Printf("To watch and manage: %s\n", progressCmd)

--- a/pkg/cmd/commands/common.go
+++ b/pkg/cmd/commands/common.go
@@ -39,14 +39,13 @@ func (g *Globals) Resolve() (string, error) {
 // ControlFlags holds flags for commands that target a specific schema change.
 type ControlFlags struct {
 	ApplyID     string `arg:"" optional:"" help:"Apply ID to target"`
-	Database    string `short:"d" help:"Database name"`
+	Database    string `kong:"-"`
 	Environment string `short:"e" help:"Target environment"`
 }
 
-// Resolve resolves the control flags using the standard resolution chain:
-// endpoint → apply-id → require database+environment.
+// Resolve resolves the endpoint and verifies the explicit control-operation scope.
 func (cf *ControlFlags) Resolve(g *Globals) (string, error) {
-	return resolveControlFlags(g.Endpoint, g.Profile, &cf.ApplyID, &cf.Database, &cf.Environment)
+	return resolveControlFlags(g.Endpoint, g.Profile, cf.ApplyID, cf.Environment)
 }
 
 // RequireApplyID returns an error if ApplyID is not set.
@@ -117,22 +116,6 @@ func resolveEndpoint(endpoint, profile string) (string, error) {
 	return ep, nil
 }
 
-// resolveApplyID resolves an apply ID to database and environment by calling the progress API.
-// Returns (database, environment, error).
-func resolveApplyID(endpoint, applyID string) (string, string, error) {
-	result, err := client.GetProgress(endpoint, applyID)
-	if err != nil {
-		if client.IsNotFound(err) {
-			return "", "", fmt.Errorf("no schema change found for apply ID '%s'", applyID)
-		}
-		return "", "", err
-	}
-	if result.Database == "" || result.Environment == "" {
-		return "", "", fmt.Errorf("could not resolve database/environment for apply ID '%s'", applyID)
-	}
-	return result.Database, result.Environment, nil
-}
-
 // confirmAction prompts the user for "yes" confirmation. Returns true if confirmed.
 func confirmAction(prompt, cancelMsg string) (bool, error) {
 	fmt.Print(prompt)
@@ -181,29 +164,13 @@ func writeJSON(v any) error {
 	return enc.Encode(v)
 }
 
-// resolveDBEnvFromApplyID resolves an apply-id flag to database/environment.
-// If applyID is empty, this is a no-op. Otherwise it calls the progress API
-// and overwrites the database and environment pointers.
-func resolveDBEnvFromApplyID(ep string, applyID *string, database, environment *string) error {
-	if *applyID == "" {
-		return nil
-	}
-	db, env, err := resolveApplyID(ep, *applyID)
-	if err != nil {
-		return err
-	}
-	*database = db
-	*environment = env
-	return nil
-}
-
-// requireDatabaseEnvironment validates that database and environment are set.
-func requireDatabaseEnvironment(database, environment string) error {
-	if database == "" {
-		return fmt.Errorf("--database is required (or use --apply-id)")
+// requireControlScope validates the explicit fields that scope a control operation.
+func requireControlScope(applyID, environment string) error {
+	if applyID == "" {
+		return fmt.Errorf("apply_id is required")
 	}
 	if environment == "" {
-		return fmt.Errorf("--environment is required (or use --apply-id)")
+		return fmt.Errorf("--environment is required")
 	}
 	return nil
 }
@@ -249,26 +216,34 @@ func checkAccepted(result acceptedResponse, operation string) error {
 	return nil
 }
 
-// autoResolveApplyID sets applyID from the progress response if not already set.
-// This ensures control operations are scoped to a specific apply.
-func autoResolveApplyID(applyID *string, progressResult *apitypes.ProgressResponse) {
-	if *applyID == "" && progressResult.ApplyID != "" {
-		*applyID = progressResult.ApplyID
+// populateControlDisplayFields fills fields used for CLI output from progress.
+// The control API still derives database from apply_id; this is only display data.
+func populateControlDisplayFields(database *string, progressResult *apitypes.ProgressResponse) {
+	if progressResult == nil {
+		return
+	}
+	if *database == "" {
+		*database = progressResult.Database
 	}
 }
 
-// resolveControlFlags resolves endpoint, database, and environment from the
-// common control command flags (endpoint, profile, applyID, database, environment).
-// Returns the resolved endpoint.
-func resolveControlFlags(endpoint, profile string, applyID, database, environment *string) (string, error) {
+func formatControlTarget(applyID, database, environment string) string {
+	if database != "" {
+		return fmt.Sprintf("%s/%s (apply %s)", database, environment, applyID)
+	}
+	if environment != "" {
+		return fmt.Sprintf("apply %s in %s", applyID, environment)
+	}
+	return fmt.Sprintf("apply %s", applyID)
+}
+
+// resolveControlFlags resolves the endpoint and validates apply_id + environment.
+func resolveControlFlags(endpoint, profile, applyID, environment string) (string, error) {
 	ep, err := resolveEndpoint(endpoint, profile)
 	if err != nil {
 		return "", err
 	}
-	if err := resolveDBEnvFromApplyID(ep, applyID, database, environment); err != nil {
-		return "", err
-	}
-	if err := requireDatabaseEnvironment(*database, *environment); err != nil {
+	if err := requireControlScope(applyID, environment); err != nil {
 		return "", err
 	}
 	return ep, nil
@@ -345,8 +320,8 @@ func applyAndWatch(ep string, planResult *apitypes.PlanResponse, database, envir
 // printWatchInstructions prints the "To watch and manage" hint.
 func printWatchInstructions(applyID, database, environment string) {
 	if applyID != "" {
-		fmt.Printf("To watch and manage: schemabot progress --apply-id %s\n", applyID)
+		fmt.Printf("To watch and manage: schemabot progress %s\n", applyID)
 	} else {
-		fmt.Printf("To watch and manage: schemabot progress -d %s -e %s\n", database, environment)
+		fmt.Printf("To watch and manage: schemabot status -d %s -e %s\n", database, environment)
 	}
 }

--- a/pkg/cmd/commands/cutover.go
+++ b/pkg/cmd/commands/cutover.go
@@ -27,6 +27,7 @@ func (cmd *CutoverCmd) Run(g *Globals) error {
 	// Check current state first
 	result, err := client.GetProgress(ep, cmd.ApplyID)
 	if err == nil {
+		populateControlDisplayFields(&cmd.Database, result)
 		if state.IsState(result.State, state.Apply.Completed) {
 			fmt.Println("✓ Schema change already complete")
 			tables := ddl.FilterInternalTablesTyped(result.Tables)
@@ -42,13 +43,8 @@ func (cmd *CutoverCmd) Run(g *Globals) error {
 		}
 	}
 
-	// Always scope cutover to the specific apply to avoid cross-apply contamination.
-	if result != nil {
-		autoResolveApplyID(&cmd.ApplyID, result)
-	}
-
 	// Trigger cutover
-	cutoverResult, err := client.CallCutoverAPI(ep, cmd.Database, cmd.Environment, cmd.ApplyID)
+	cutoverResult, err := client.CallCutoverAPI(ep, cmd.Environment, cmd.ApplyID)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/commands/progress.go
+++ b/pkg/cmd/commands/progress.go
@@ -17,7 +17,7 @@ type ProgressCmd struct {
 // Run executes the progress command.
 func (cmd *ProgressCmd) Run(g *Globals) error {
 	if cmd.ApplyID == "" {
-		return fmt.Errorf("--apply-id is required (use 'schemabot status -d <database>' to find active applies)")
+		return fmt.Errorf("apply_id is required (use 'schemabot status -d <database>' to find active applies)")
 	}
 
 	ep, err := g.Resolve()

--- a/pkg/cmd/commands/revert.go
+++ b/pkg/cmd/commands/revert.go
@@ -26,20 +26,22 @@ func (cmd *RevertCmd) Run(g *Globals) error {
 	// Check current state
 	result, err := client.GetProgress(ep, cmd.ApplyID)
 	if err == nil {
+		populateControlDisplayFields(&cmd.Database, result)
 		if !state.IsState(result.State, state.Apply.RevertWindow) {
 			return fmt.Errorf("cannot revert: apply is in state %q (expected revert_window)", result.State)
 		}
 	} else {
-		slog.Warn("could not verify apply state before revert, proceeding anyway", "error", err)
+		slog.Warn("could not verify apply state before revert, proceeding anyway",
+			"apply_id", cmd.ApplyID, "environment", cmd.Environment, "error", err)
 	}
 
-	resp, err := client.CallRevertAPI(ep, cmd.Database, cmd.Environment)
+	resp, err := client.CallRevertAPI(ep, cmd.Environment, cmd.ApplyID)
 	if err != nil {
 		return fmt.Errorf("revert failed: %w", err)
 	}
 
 	if resp.Accepted {
-		fmt.Printf("Revert initiated for %s/%s\n", cmd.Database, cmd.Environment)
+		fmt.Printf("Revert initiated for %s\n", formatControlTarget(cmd.ApplyID, cmd.Database, cmd.Environment))
 	} else {
 		fmt.Printf("Revert not accepted: %s\n", resp.ErrorMessage)
 	}

--- a/pkg/cmd/commands/skip_revert.go
+++ b/pkg/cmd/commands/skip_revert.go
@@ -26,20 +26,22 @@ func (cmd *SkipRevertCmd) Run(g *Globals) error {
 	// Check current state
 	result, err := client.GetProgress(ep, cmd.ApplyID)
 	if err == nil {
+		populateControlDisplayFields(&cmd.Database, result)
 		if !state.IsState(result.State, state.Apply.RevertWindow) {
 			return fmt.Errorf("cannot skip revert: apply is in state %q (expected revert_window)", result.State)
 		}
 	} else {
-		slog.Warn("could not verify apply state before skip-revert, proceeding anyway", "error", err)
+		slog.Warn("could not verify apply state before skip-revert, proceeding anyway",
+			"apply_id", cmd.ApplyID, "environment", cmd.Environment, "error", err)
 	}
 
-	resp, err := client.CallSkipRevertAPI(ep, cmd.Database, cmd.Environment)
+	resp, err := client.CallSkipRevertAPI(ep, cmd.Environment, cmd.ApplyID)
 	if err != nil {
 		return fmt.Errorf("skip-revert failed: %w", err)
 	}
 
 	if resp.Accepted {
-		fmt.Printf("Revert window skipped for %s/%s — schema change finalized\n", cmd.Database, cmd.Environment)
+		fmt.Printf("Revert window skipped for %s — schema change finalized\n", formatControlTarget(cmd.ApplyID, cmd.Database, cmd.Environment))
 	} else {
 		fmt.Printf("Skip-revert not accepted: %s\n", resp.ErrorMessage)
 	}

--- a/pkg/cmd/commands/start.go
+++ b/pkg/cmd/commands/start.go
@@ -29,6 +29,7 @@ func (cmd *StartCmd) Run(g *Globals) error {
 	if err != nil {
 		return fmt.Errorf("get progress: %w", err)
 	}
+	populateControlDisplayFields(&cmd.Database, result)
 
 	curState := result.State
 	if state.IsState(curState, state.Apply.Completed) {
@@ -46,11 +47,8 @@ func (cmd *StartCmd) Run(g *Globals) error {
 		return fmt.Errorf("cannot start schema change in state: %s", curState)
 	}
 
-	// Always scope start to the specific apply to avoid cross-apply contamination.
-	autoResolveApplyID(&cmd.ApplyID, result)
-
 	// Call start API
-	startResult, err := client.CallStartAPI(ep, cmd.Database, cmd.Environment, cmd.ApplyID)
+	startResult, err := client.CallStartAPI(ep, cmd.Environment, cmd.ApplyID)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/commands/stop.go
+++ b/pkg/cmd/commands/stop.go
@@ -26,17 +26,13 @@ func (cmd *StopCmd) Run(g *Globals) error {
 	// Check current state first
 	result, err := client.GetProgress(ep, cmd.ApplyID)
 	if err != nil {
-		// Check if this is a "not found" error - likely means no active schema change
-		if client.IsNotFound(err) {
-			fmt.Printf("No active schema change found for database '%s' environment '%s'\n", cmd.Database, cmd.Environment)
-			return nil
-		}
-		return fmt.Errorf("get progress: %w", err)
+		return fmt.Errorf("get progress for apply %s: %w", cmd.ApplyID, err)
 	}
+	populateControlDisplayFields(&cmd.Database, result)
 
 	curState := result.State
 	if state.IsState(curState, state.NoActiveChange) || curState == "" {
-		fmt.Printf("No active schema change for database '%s' environment '%s'\n", cmd.Database, cmd.Environment)
+		fmt.Printf("No active schema change for %s\n", formatControlTarget(cmd.ApplyID, cmd.Database, cmd.Environment))
 		return nil
 	}
 	if state.IsState(curState, state.Apply.Completed) {
@@ -51,11 +47,8 @@ func (cmd *StopCmd) Run(g *Globals) error {
 		return fmt.Errorf("cannot stop schema change in state: %s", curState)
 	}
 
-	// Always scope stop to the specific apply to avoid cross-apply contamination.
-	autoResolveApplyID(&cmd.ApplyID, result)
-
 	// Call stop API
-	stopResult, err := client.CallStopAPI(ep, cmd.Database, cmd.Environment, cmd.ApplyID)
+	stopResult, err := client.CallStopAPI(ep, cmd.Environment, cmd.ApplyID)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/commands/volume.go
+++ b/pkg/cmd/commands/volume.go
@@ -33,6 +33,7 @@ func (cmd *VolumeCmd) Run(g *Globals) error {
 	if err != nil {
 		return fmt.Errorf("get progress: %w", err)
 	}
+	populateControlDisplayFields(&cmd.Database, result)
 
 	curState := result.State
 	if state.IsState(curState, state.Apply.Completed) {
@@ -46,11 +47,8 @@ func (cmd *VolumeCmd) Run(g *Globals) error {
 		return fmt.Errorf("cannot adjust volume in state: %s", curState)
 	}
 
-	// Auto-resolve apply_id from progress response
-	autoResolveApplyID(&cmd.ApplyID, result)
-
 	// Call volume API
-	volumeResult, err := client.CallVolumeAPI(ep, cmd.Database, cmd.Environment, cmd.ApplyID, cmd.Volume)
+	volumeResult, err := client.CallVolumeAPI(ep, cmd.Environment, cmd.ApplyID, cmd.Volume)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/commands/watch_tui_commands.go
+++ b/pkg/cmd/commands/watch_tui_commands.go
@@ -50,7 +50,7 @@ func (m WatchModel) fetchProgress() tea.Cmd {
 
 func (m WatchModel) triggerDeploy() tea.Cmd {
 	return func() tea.Msg {
-		result, err := client.CallStartAPI(m.endpoint, m.database, m.environment, m.applyID)
+		result, err := client.CallStartAPI(m.endpoint, m.environment, m.applyID)
 		if err != nil {
 			return deployResultMsg{success: false, err: err}
 		}
@@ -69,7 +69,7 @@ func (m WatchModel) triggerDeploy() tea.Cmd {
 
 func (m WatchModel) triggerCutover() tea.Cmd {
 	return func() tea.Msg {
-		result, err := client.CallCutoverAPI(m.endpoint, m.database, m.environment, m.applyID)
+		result, err := client.CallCutoverAPI(m.endpoint, m.environment, m.applyID)
 		if err != nil {
 			return cutoverResultMsg{success: false, err: err}
 		}
@@ -88,7 +88,7 @@ func (m WatchModel) triggerCutover() tea.Cmd {
 
 func (m WatchModel) triggerStop() tea.Cmd {
 	return func() tea.Msg {
-		result, err := client.CallStopAPI(m.endpoint, m.database, m.environment, m.applyID)
+		result, err := client.CallStopAPI(m.endpoint, m.environment, m.applyID)
 		if err != nil {
 			return stopResultMsg{success: false, err: err}
 		}
@@ -108,7 +108,7 @@ func (m WatchModel) triggerStop() tea.Cmd {
 
 func (m WatchModel) triggerSkipRevert() tea.Cmd {
 	return func() tea.Msg {
-		result, err := client.CallSkipRevertAPI(m.endpoint, m.database, m.environment)
+		result, err := client.CallSkipRevertAPI(m.endpoint, m.environment, m.applyID)
 		if err != nil {
 			return stopResultMsg{success: false, err: err}
 		}
@@ -199,7 +199,7 @@ func (m WatchModel) handleVolumeKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 func (m WatchModel) triggerVolumeChange(volume int) tea.Cmd {
 	return func() tea.Msg {
-		result, err := client.CallVolumeAPI(m.endpoint, m.database, m.environment, m.applyID, volume)
+		result, err := client.CallVolumeAPI(m.endpoint, m.environment, m.applyID, volume)
 		if err != nil {
 			return volumeResultMsg{success: false, err: err}
 		}

--- a/pkg/cmd/commands/watch_tui_test.go
+++ b/pkg/cmd/commands/watch_tui_test.go
@@ -242,7 +242,7 @@ func TestFetchProgress_ErrorCodeClassification(t *testing.T) {
 		{
 			name:      "invalid_request is permanent",
 			status:    http.StatusBadRequest,
-			body:      `{"error":"database is required","error_code":"invalid_request"}`,
+			body:      `{"error":"apply_id is required","error_code":"invalid_request"}`,
 			retryable: false,
 		},
 		{

--- a/pkg/cmd/commands/watch_tui_view.go
+++ b/pkg/cmd/commands/watch_tui_view.go
@@ -162,9 +162,9 @@ func (m WatchModel) progressView() string {
 		b.WriteString(templates.FormatApplyStopped())
 		b.WriteString("\n")
 		if m.applyID != "" {
-			fmt.Fprintf(&b, "Use 'schemabot start --apply-id %s' to resume.\n", m.applyID)
+			fmt.Fprintf(&b, "Use 'schemabot start -e %s %s' to resume.\n", m.environment, m.applyID)
 		} else {
-			fmt.Fprintf(&b, "Use 'schemabot start -d %s -e %s' to resume.\n", m.database, m.environment)
+			fmt.Fprintf(&b, "Use 'schemabot status -d %s -e %s' to find the apply ID.\n", m.database, m.environment)
 		}
 	case isCuttingOver:
 		// During cutover, show minimal footer - no detach/stop allowed
@@ -190,9 +190,9 @@ func (m WatchModel) progressView() string {
 			b.WriteString("Press Enter to deploy or proceed via the PlanetScale console (ESC to detach)\n")
 		} else {
 			if m.applyID != "" {
-				fmt.Fprintf(&b, "To proceed: schemabot start --apply-id %s\n", m.applyID)
+				fmt.Fprintf(&b, "To proceed: schemabot start -e %s %s\n", m.environment, m.applyID)
 			} else {
-				fmt.Fprintf(&b, "To proceed: schemabot start -d %s -e %s\n", m.database, m.environment)
+				fmt.Fprintf(&b, "To find the apply ID: schemabot status -d %s -e %s\n", m.database, m.environment)
 			}
 			b.WriteString("Watching for deploy... (ESC to detach)\n")
 		}
@@ -204,9 +204,9 @@ func (m WatchModel) progressView() string {
 			b.WriteString("Press Enter to proceed with cutover (or ESC to detach)\n")
 		} else {
 			if m.applyID != "" {
-				fmt.Fprintf(&b, "To proceed: schemabot cutover --apply-id %s\n", m.applyID)
+				fmt.Fprintf(&b, "To proceed: schemabot cutover -e %s %s\n", m.environment, m.applyID)
 			} else {
-				fmt.Fprintf(&b, "To proceed: schemabot cutover -d %s -e %s\n", m.database, m.environment)
+				fmt.Fprintf(&b, "To find the apply ID: schemabot status -d %s -e %s\n", m.database, m.environment)
 			}
 			b.WriteString("Watching for cutover... (ESC to detach)\n")
 		}
@@ -369,15 +369,11 @@ func (m WatchModel) detachedView() string {
 	if m.applyID != "" {
 		fmt.Fprintf(&b, "To reattach: schemabot progress %s\n", m.applyID)
 		if state.IsState(m.state, state.Apply.WaitingForDeploy) {
-			fmt.Fprintf(&b, "To deploy:   schemabot start %s\n", m.applyID)
+			fmt.Fprintf(&b, "To deploy:   schemabot start -e %s %s\n", m.environment, m.applyID)
 		}
-		fmt.Fprintf(&b, "To stop:     schemabot stop %s\n", m.applyID)
+		fmt.Fprintf(&b, "To stop:     schemabot stop -e %s %s\n", m.environment, m.applyID)
 	} else {
-		fmt.Fprintf(&b, "To reattach: schemabot progress -d %s -e %s\n", m.database, m.environment)
-		if state.IsState(m.state, state.Apply.WaitingForDeploy) {
-			fmt.Fprintf(&b, "To deploy:   schemabot start -d %s -e %s\n", m.database, m.environment)
-		}
-		fmt.Fprintf(&b, "To stop:     schemabot stop -d %s -e %s\n", m.database, m.environment)
+		fmt.Fprintf(&b, "Find apply:  schemabot status -d %s -e %s\n", m.database, m.environment)
 	}
 	return b.String()
 }

--- a/pkg/cmd/templates/preview_defer.go
+++ b/pkg/cmd/templates/preview_defer.go
@@ -186,7 +186,7 @@ func previewDeferStoppedOutput() {
 	}
 	WriteProgress(data)
 
-	fmt.Println("Use 'schemabot start --apply-id <apply_id>' to resume.")
+	fmt.Println("Use 'schemabot start -e staging <apply_id>' to resume.")
 }
 
 func previewDeferDetachedOutput() {
@@ -201,10 +201,10 @@ func previewDeferDetachedOutput() {
 	fmt.Println("  schemabot status <apply_id>")
 	fmt.Println()
 	fmt.Println("To proceed with cutover:")
-	fmt.Println("  schemabot cutover --apply-id <apply_id>")
+	fmt.Println("  schemabot cutover -e staging <apply_id>")
 	fmt.Println()
 	fmt.Println("To abort the schema change:")
-	fmt.Println("  schemabot stop --apply-id <apply_id>")
+	fmt.Println("  schemabot stop -e staging <apply_id>")
 }
 
 func previewDeferCuttingOutput() {

--- a/pkg/cmd/templates/preview_progress.go
+++ b/pkg/cmd/templates/preview_progress.go
@@ -776,7 +776,7 @@ func previewWaitingForCutoverOutput() {
 	fmt.Println("Row copy complete. All data has been copied and new writes")
 	fmt.Println("continue to be replicated to keep the shadow table in sync.")
 	fmt.Println()
-	fmt.Println("To proceed: schemabot cutover --apply-id <apply_id>")
+	fmt.Println("To proceed: schemabot cutover -e staging <apply_id>")
 	fmt.Println("Watching for cutover... (Ctrl+C to detach)")
 }
 
@@ -874,7 +874,7 @@ func previewStoppedOutput() {
 		},
 	}
 	WriteProgress(data)
-	fmt.Println("\nStopped. Use 'schemabot start --apply-id <apply_id>' to resume from checkpoint.")
+	fmt.Println("\nStopped. Use 'schemabot start -e staging <apply_id>' to resume from checkpoint.")
 }
 
 func previewApplyWatchOutput() {
@@ -952,7 +952,7 @@ func previewApplyStoppedOutput() {
 	WriteProgress(data)
 
 	fmt.Printf("%s\n", FormatApplyStopped())
-	fmt.Println("Use 'schemabot start --apply-id <apply_id>' to resume.")
+	fmt.Println("Use 'schemabot start -e staging <apply_id>' to resume.")
 }
 
 // =============================================================================
@@ -960,7 +960,7 @@ func previewApplyStoppedOutput() {
 // =============================================================================
 
 func previewStopCommandOutput() {
-	fmt.Println("Stop command: User runs 'schemabot stop --apply-id <apply_id>'")
+	fmt.Println("Stop command: User runs 'schemabot stop -e staging <apply_id>'")
 	fmt.Println()
 
 	WriteStopSuccess(StopData{
@@ -997,7 +997,7 @@ func previewStopCommandOutput() {
 }
 
 func previewStartCommandOutput() {
-	fmt.Println("Start command: User runs 'schemabot start --apply-id <apply_id>'")
+	fmt.Println("Start command: User runs 'schemabot start -e staging <apply_id>'")
 	fmt.Println()
 
 	WriteStartSuccess(StartData{

--- a/pkg/cmd/templates/progress.go
+++ b/pkg/cmd/templates/progress.go
@@ -648,7 +648,7 @@ func WriteStopSuccess(data StopData) {
 	}
 	fmt.Println()
 	if data.ApplyID != "" {
-		fmt.Printf("%sCheckpoint saved. Use 'schemabot start --apply-id %s' to resume.%s\n", ANSIDim, data.ApplyID, ANSIReset)
+		fmt.Printf("%sCheckpoint saved. Use 'schemabot start -e %s %s' to resume.%s\n", ANSIDim, data.Environment, data.ApplyID, ANSIReset)
 	} else {
 		fmt.Printf("%sCheckpoint saved. Use 'schemabot start' to resume from where you left off.%s\n", ANSIDim, ANSIReset)
 	}
@@ -684,9 +684,9 @@ func WriteStartNoWatch(applyID, database, environment string) {
 	fmt.Printf("%s%s▶️  Schema change resumed%s\n", ANSIBold, ANSIGreen, ANSIReset)
 	fmt.Println()
 	if applyID != "" {
-		fmt.Printf("To watch and manage: schemabot progress --apply-id %s\n", applyID)
+		fmt.Printf("To watch and manage: schemabot progress %s\n", applyID)
 	} else {
-		fmt.Printf("To watch and manage: schemabot progress -d %s -e %s\n", database, environment)
+		fmt.Printf("To watch and manage: schemabot status -d %s -e %s\n", database, environment)
 	}
 }
 

--- a/pkg/tern/local_client.go
+++ b/pkg/tern/local_client.go
@@ -749,7 +749,13 @@ func (c *LocalClient) Progress(ctx context.Context, req *ternv1.ProgressRequest)
 	// Query engine for live progress. For Vitess, also query during pending state
 	// to surface PlanetScale states (preparing branch, deploy request, etc.).
 	queryDuringPending := c.config.Type == storage.DatabaseTypeVitess
-	if eng != nil && (activeTask.State != state.Task.Pending || queryDuringPending) {
+	// A stopped task is SchemaBot-owned state. Do not let a stale engine poll
+	// report an older active state such as waiting_for_cutover and overwrite it.
+	queryLiveProgress := activeTask.State != state.Task.Pending && activeTask.State != state.Task.Stopped
+	if queryDuringPending && activeTask.State == state.Task.Pending {
+		queryLiveProgress = true
+	}
+	if eng != nil && queryLiveProgress {
 		progressReq := &engine.ProgressRequest{
 			Database:    c.config.Database,
 			Credentials: creds,


### PR DESCRIPTION
## Why
Control operations should target a specific stored apply, not whatever active work happens to match a database and environment. Requiring an apply ID keeps storage as the source of truth for the database, route, and Tern apply identifier.

## What
- Require apply_id and environment for cutover, stop, start, volume, revert, and skip-revert
- Derive database, deployment, and Tern apply ID from the stored apply record
- Remove database from control CLI/API payloads and update operator-facing command hints
- Cover rejected client-supplied database/deployment fields and derived Tern requests in tests

Generated with Codex