### PR TITLE
feat(policy): authorize trusted PR schema sources

### DIFF
--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -166,6 +166,16 @@ type DatabaseConfig struct {
 
 	// Environments contains per-environment configuration.
 	Environments map[string]EnvironmentConfig `yaml:"environments"`
+
+	// AllowedRepos restricts which trusted GitHub PR repositories may manage
+	// this database. Values are exact owner/repo names. A literal "*" allows
+	// any trusted repo.
+	AllowedRepos []string `yaml:"allowed_repos,omitempty"`
+
+	// AllowedDirs restricts which trusted GitHub PR repo-relative schema
+	// directories may manage this database. Values match the directory itself
+	// and descendants. A literal "*" allows any trusted schema directory.
+	AllowedDirs []string `yaml:"allowed_dirs,omitempty"`
 }
 
 // EnvironmentConfig holds per-environment database configuration.
@@ -275,6 +285,9 @@ func (c *ServerConfig) Validate() error {
 	for name, dbConfig := range c.Databases {
 		if dbConfig.Type == "" {
 			return fmt.Errorf("database %q missing type", name)
+		}
+		if err := validateDatabaseSourcePolicy(name, dbConfig); err != nil {
+			return err
 		}
 		if dbConfig.Type != storage.DatabaseTypeMySQL && dbConfig.Type != storage.DatabaseTypeVitess {
 			return fmt.Errorf("database %q has invalid type %q (must be %s or %s)", name, dbConfig.Type, storage.DatabaseTypeMySQL, storage.DatabaseTypeVitess)

--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -1,12 +1,15 @@
 package api
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/block/schemabot/pkg/storage"
 )
 
 func TestLoadServerConfig(t *testing.T) {
@@ -404,6 +407,262 @@ func TestServerConfig_ValidateRejectsLocalRemoteRouteCollision(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), `database "primary" environment "staging" uses a local dsn`)
 	assert.Contains(t, err.Error(), `tern_deployments also defines deployment "primary"`)
+}
+
+func TestServerConfig_ValidateSourcePolicy(t *testing.T) {
+	baseConfig := func(allowedDirs []string) ServerConfig {
+		return ServerConfig{
+			Databases: map[string]DatabaseConfig{
+				"payments": {
+					Type: storage.DatabaseTypeMySQL,
+					Environments: map[string]EnvironmentConfig{
+						"staging": {DSN: "root@tcp(localhost)/payments"},
+					},
+					AllowedRepos: []string{"octocat/hello-world"},
+					AllowedDirs:  allowedDirs,
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name       string
+		config     ServerConfig
+		wantErr    bool
+		wantErrMsg string
+	}{
+		{
+			name:    "valid source policy",
+			config:  baseConfig([]string{"schema/payments", "db/payments/"}),
+			wantErr: false,
+		},
+		{
+			name:       "empty schema dir",
+			config:     baseConfig([]string{""}),
+			wantErr:    true,
+			wantErrMsg: "path is empty",
+		},
+		{
+			name:       "absolute schema dir",
+			config:     baseConfig([]string{"/schema/payments"}),
+			wantErr:    true,
+			wantErrMsg: "repo-relative",
+		},
+		{
+			name:       "escaping schema dir",
+			config:     baseConfig([]string{"../payments"}),
+			wantErr:    true,
+			wantErrMsg: "must not escape",
+		},
+		{
+			name:       "duplicate normalized schema dir",
+			config:     baseConfig([]string{"schema/payments", "schema/payments/"}),
+			wantErr:    true,
+			wantErrMsg: "duplicate",
+		},
+		{
+			name: "duplicate repo",
+			config: ServerConfig{
+				Databases: map[string]DatabaseConfig{
+					"payments": {
+						Type: storage.DatabaseTypeMySQL,
+						Environments: map[string]EnvironmentConfig{
+							"staging": {DSN: "root@tcp(localhost)/payments"},
+						},
+						AllowedRepos: []string{"octocat/hello-world", "octocat/hello-world"},
+					},
+				},
+			},
+			wantErr:    true,
+			wantErrMsg: "duplicate",
+		},
+		{
+			name: "empty repo after trimming whitespace",
+			config: ServerConfig{
+				Databases: map[string]DatabaseConfig{
+					"payments": {
+						Type: storage.DatabaseTypeMySQL,
+						Environments: map[string]EnvironmentConfig{
+							"staging": {DSN: "root@tcp(localhost)/payments"},
+						},
+						AllowedRepos: []string{" "},
+					},
+				},
+			},
+			wantErr:    true,
+			wantErrMsg: "empty value",
+		},
+		{
+			name: "repo with surrounding whitespace",
+			config: ServerConfig{
+				Databases: map[string]DatabaseConfig{
+					"payments": {
+						Type: storage.DatabaseTypeMySQL,
+						Environments: map[string]EnvironmentConfig{
+							"staging": {DSN: "root@tcp(localhost)/payments"},
+						},
+						AllowedRepos: []string{"octocat/hello-world "},
+					},
+				},
+			},
+			wantErr:    true,
+			wantErrMsg: "leading or trailing whitespace",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.Validate()
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErrMsg)
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestServerConfig_AuthorizePlanSource(t *testing.T) {
+	cfg := &ServerConfig{
+		Databases: map[string]DatabaseConfig{
+			"payments": {
+				Type: storage.DatabaseTypeMySQL,
+				Environments: map[string]EnvironmentConfig{
+					"staging": {DSN: "root@tcp(localhost)/payments"},
+				},
+				AllowedRepos: []string{"octocat/hello-world"},
+				AllowedDirs:  []string{"schema/payments"},
+			},
+			"open": {
+				Type: storage.DatabaseTypeMySQL,
+				Environments: map[string]EnvironmentConfig{
+					"staging": {DSN: "root@tcp(localhost)/open"},
+				},
+			},
+		},
+	}
+
+	t.Run("missing server config blocks trusted source", func(t *testing.T) {
+		var nilConfig *ServerConfig
+		err := nilConfig.AuthorizePlanSource(PlanSourcePolicyRequest{
+			Database:    "payments",
+			Repository:  "octocat/hello-world",
+			PullRequest: 1,
+			SchemaPath:  "schema/payments",
+		})
+
+		require.Error(t, err)
+		var policyErr *SourcePolicyError
+		require.True(t, errors.As(err, &policyErr), "expected SourcePolicyError")
+		assert.Equal(t, SourcePolicyReasonMissingServerConfig, policyErr.Reason)
+	})
+
+	tests := []struct {
+		name       string
+		req        PlanSourcePolicyRequest
+		wantReason string
+	}{
+		{
+			name: "database without source policy allows trusted source",
+			req: PlanSourcePolicyRequest{
+				Database:    "open",
+				Repository:  "octocat/hello-world",
+				PullRequest: 1,
+				SchemaPath:  "schema/open",
+			},
+		},
+		{
+			name: "missing database config blocks trusted source",
+			req: PlanSourcePolicyRequest{
+				Database:    "missing",
+				Repository:  "octocat/hello-world",
+				PullRequest: 1,
+				SchemaPath:  "schema/payments",
+			},
+			wantReason: SourcePolicyReasonMissingDatabaseConfig,
+		},
+		{
+			name: "trusted source is allowed",
+			req: PlanSourcePolicyRequest{
+				Database:    "payments",
+				Repository:  "octocat/hello-world",
+				PullRequest: 1,
+				SchemaPath:  "schema/payments",
+			},
+		},
+		{
+			name: "trusted descendant dir is allowed",
+			req: PlanSourcePolicyRequest{
+				Database:    "payments",
+				Repository:  "octocat/hello-world",
+				PullRequest: 1,
+				SchemaPath:  "schema/payments/archive",
+			},
+		},
+		{
+			name: "missing repository is blocked",
+			req: PlanSourcePolicyRequest{
+				Database:    "payments",
+				PullRequest: 1,
+				SchemaPath:  "schema/payments",
+			},
+			wantReason: SourcePolicyReasonMissingRepository,
+		},
+		{
+			name: "missing pull request is blocked",
+			req: PlanSourcePolicyRequest{
+				Database:   "payments",
+				Repository: "octocat/hello-world",
+				SchemaPath: "schema/payments",
+			},
+			wantReason: SourcePolicyReasonMissingPullRequest,
+		},
+		{
+			name: "missing schema path is blocked",
+			req: PlanSourcePolicyRequest{
+				Database:    "payments",
+				Repository:  "octocat/hello-world",
+				PullRequest: 1,
+			},
+			wantReason: SourcePolicyReasonMissingSchemaPath,
+		},
+		{
+			name: "unauthorized repo is blocked",
+			req: PlanSourcePolicyRequest{
+				Database:    "payments",
+				Repository:  "octocat/orders",
+				PullRequest: 1,
+				SchemaPath:  "schema/payments",
+			},
+			wantReason: SourcePolicyReasonUnauthorizedRepo,
+		},
+		{
+			name: "sibling directory is blocked",
+			req: PlanSourcePolicyRequest{
+				Database:    "payments",
+				Repository:  "octocat/hello-world",
+				PullRequest: 1,
+				SchemaPath:  "schema/payments-archive",
+			},
+			wantReason: SourcePolicyReasonUnauthorizedSchemaDir,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := cfg.AuthorizePlanSource(tt.req)
+			if tt.wantReason == "" {
+				assert.NoError(t, err)
+				return
+			}
+
+			require.Error(t, err)
+			var policyErr *SourcePolicyError
+			require.True(t, errors.As(err, &policyErr), "expected SourcePolicyError")
+			assert.Equal(t, tt.wantReason, policyErr.Reason)
+		})
+	}
 }
 
 func TestServerConfig_ResolveDatabaseTarget(t *testing.T) {

--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -60,6 +60,27 @@ func (m *mockPlanLookupStore) GetByPR(context.Context, string, int) ([]*storage.
 func (m *mockPlanLookupStore) Delete(context.Context, int64) error           { return nil }
 func (m *mockPlanLookupStore) DeleteByPR(context.Context, string, int) error { return nil }
 
+type capturingPlanStore struct {
+	mockPlanLookupStore
+	created   *storage.Plan
+	createErr error
+}
+
+func (s *capturingPlanStore) Create(_ context.Context, plan *storage.Plan) (int64, error) {
+	s.created = plan
+	if s.createErr != nil {
+		return 0, s.createErr
+	}
+	return 1, nil
+}
+
+type mockStorageWithPlanLookup struct {
+	mockStorage
+	plans storage.PlanStore
+}
+
+func (m *mockStorageWithPlanLookup) Plans() storage.PlanStore { return m.plans }
+
 type mockStorageWithApplyStores struct {
 	mockStorage
 	plans     storage.PlanStore
@@ -242,6 +263,9 @@ func (s *noopApplyLogStore) Append(context.Context, *storage.ApplyLog) error {
 // mockTernClient implements tern.Client for testing.
 type mockTernClient struct {
 	healthErr      error
+	planResp       *ternv1.PlanResponse
+	planErr        error
+	planReq        *ternv1.PlanRequest
 	applyResp      *ternv1.ApplyResponse
 	applyErr       error
 	applyReq       *ternv1.ApplyRequest
@@ -272,7 +296,11 @@ type mockTernClient struct {
 
 func (m *mockTernClient) Health(ctx context.Context) error { return m.healthErr }
 func (m *mockTernClient) Plan(ctx context.Context, req *ternv1.PlanRequest) (*ternv1.PlanResponse, error) {
-	return nil, nil
+	m.planReq = req
+	if m.planResp != nil {
+		return m.planResp, m.planErr
+	}
+	return nil, m.planErr
 }
 func (m *mockTernClient) Apply(ctx context.Context, req *ternv1.ApplyRequest) (*ternv1.ApplyResponse, error) {
 	m.applyReq = req
@@ -429,6 +457,322 @@ func newControlTestService(client tern.Client, apply *storage.Apply) *Service {
 func newTestService() *Service {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
 	return New(&mockStorage{}, testServerConfig(), nil, logger)
+}
+
+func TestExecutePlanSourcePolicy(t *testing.T) {
+	newPolicyService := func() (*Service, *mockTernClient, *capturingPlanStore) {
+		t.Helper()
+		plans := &capturingPlanStore{}
+		mockClient := &mockTernClient{
+			planResp: &ternv1.PlanResponse{PlanId: "plan-source-policy"},
+		}
+		cfg := &ServerConfig{
+			Databases: map[string]DatabaseConfig{
+				"payments": {
+					Type: storage.DatabaseTypeMySQL,
+					Environments: map[string]EnvironmentConfig{
+						"staging": {Target: "payments-staging-target", Deployment: DefaultDeployment},
+					},
+					AllowedRepos: []string{"octocat/hello-world"},
+					AllowedDirs:  []string{"schema/payments"},
+				},
+			},
+			TernDeployments: TernConfig{
+				DefaultDeployment: {"staging": "localhost:9090"},
+			},
+		}
+		logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+		svc := New(&mockStorageWithPlanLookup{plans: plans}, cfg, map[string]tern.Client{
+			DefaultDeployment + "/staging": mockClient,
+		}, logger)
+		return svc, mockClient, plans
+	}
+
+	schemaFiles := map[string]*ternv1.SchemaFiles{
+		"payments": {Files: map[string]string{"users.sql": "CREATE TABLE users (id bigint primary key)"}},
+	}
+
+	t.Run("trusted GitHub source is authorized and persisted", func(t *testing.T) {
+		svc, mockClient, plans := newPolicyService()
+		pr := int32(1)
+
+		resp, err := svc.ExecutePlan(t.Context(), PlanRequest{
+			Database:      "payments",
+			Environment:   "staging",
+			Type:          storage.DatabaseTypeMySQL,
+			SchemaFiles:   schemaFiles,
+			Repository:    "octocat/hello-world",
+			PullRequest:   &pr,
+			SchemaPath:    "schema/payments",
+			SourceTrusted: true,
+		})
+
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		assert.Equal(t, "plan-source-policy", resp.PlanID)
+		require.NotNil(t, mockClient.planReq, "expected source-authorized plan to call Tern")
+		assert.Equal(t, "payments-staging-target", mockClient.planReq.Target)
+		assert.Equal(t, "schema/payments", mockClient.planReq.SchemaPath)
+		require.NotNil(t, plans.created, "expected source-authorized plan to be stored")
+		assert.Equal(t, "schema/payments", plans.created.SchemaPath)
+		assert.Equal(t, "octocat/hello-world", plans.created.Repository)
+	})
+
+	t.Run("direct API source keeps operator path working", func(t *testing.T) {
+		svc, mockClient, plans := newPolicyService()
+		pr := int32(1)
+
+		resp, err := svc.ExecutePlan(t.Context(), PlanRequest{
+			Database:    "payments",
+			Environment: "staging",
+			Type:        storage.DatabaseTypeMySQL,
+			SchemaFiles: schemaFiles,
+			Repository:  "octocat/hello-world",
+			PullRequest: &pr,
+		})
+
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		assert.Equal(t, "plan-source-policy", resp.PlanID)
+		require.NotNil(t, mockClient.planReq, "direct API planning should still call Tern")
+		assert.Empty(t, mockClient.planReq.SchemaPath)
+		require.NotNil(t, plans.created, "direct API planning should still store the plan")
+		assert.Empty(t, plans.created.SchemaPath)
+	})
+
+	t.Run("duplicate plan identifier is tolerated", func(t *testing.T) {
+		svc, _, plans := newPolicyService()
+		plans.createErr = storage.ErrPlanIDExists
+		pr := int32(1)
+
+		resp, err := svc.ExecutePlan(t.Context(), PlanRequest{
+			Database:      "payments",
+			Environment:   "staging",
+			Type:          storage.DatabaseTypeMySQL,
+			SchemaFiles:   schemaFiles,
+			Repository:    "octocat/hello-world",
+			PullRequest:   &pr,
+			SchemaPath:    "schema/payments",
+			SourceTrusted: true,
+		})
+
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.NotNil(t, plans.created)
+		assert.Equal(t, "schema/payments", plans.created.SchemaPath)
+	})
+}
+
+func TestExecuteApplySourcePolicyAllowsDirectPlan(t *testing.T) {
+	plan := &storage.Plan{
+		ID:             42,
+		PlanIdentifier: "plan-old-direct",
+		Database:       "payments",
+		DatabaseType:   storage.DatabaseTypeMySQL,
+		Deployment:     DefaultDeployment,
+		Target:         "payments-staging-target",
+		Repository:     "octocat/hello-world",
+		PullRequest:    1,
+		Environment:    "staging",
+	}
+	cfg := &ServerConfig{
+		Databases: map[string]DatabaseConfig{
+			"payments": {
+				Type: storage.DatabaseTypeMySQL,
+				Environments: map[string]EnvironmentConfig{
+					"staging": {Target: "payments-staging-target", Deployment: DefaultDeployment},
+				},
+				AllowedRepos: []string{"octocat/hello-world"},
+			},
+		},
+		TernDeployments: TernConfig{
+			DefaultDeployment: {"staging": "localhost:9090"},
+		},
+	}
+	mockClient := &mockTernClient{
+		applyResp: &ternv1.ApplyResponse{Accepted: false, ErrorMessage: "engine rejected"},
+		isRemote:  true,
+	}
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	svc := New(&mockStorageWithPlanLookup{
+		plans: &mockPlanLookupStore{plan: plan},
+	}, cfg, map[string]tern.Client{
+		DefaultDeployment + "/staging": mockClient,
+	}, logger)
+
+	resp, applyID, err := svc.ExecuteApply(t.Context(), ApplyRequest{
+		PlanID:      "plan-old-direct",
+		Environment: "staging",
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Zero(t, applyID)
+	assert.False(t, resp.Accepted)
+	require.NotNil(t, mockClient.applyReq, "direct API apply should still call Tern")
+	assert.Equal(t, "payments-staging-target", mockClient.applyReq.Target)
+}
+
+func TestExecuteApplySourcePolicyBlocksStoredTrustedPlan(t *testing.T) {
+	plan := &storage.Plan{
+		ID:             42,
+		PlanIdentifier: "plan-untrusted-repo",
+		Database:       "payments",
+		DatabaseType:   storage.DatabaseTypeMySQL,
+		Deployment:     DefaultDeployment,
+		Target:         "payments-staging-target",
+		Repository:     "octocat/orders",
+		PullRequest:    1,
+		SchemaPath:     "schema/payments",
+		Environment:    "staging",
+	}
+	cfg := &ServerConfig{
+		Databases: map[string]DatabaseConfig{
+			"payments": {
+				Type: storage.DatabaseTypeMySQL,
+				Environments: map[string]EnvironmentConfig{
+					"staging": {Target: "payments-staging-target", Deployment: DefaultDeployment},
+				},
+				AllowedRepos: []string{"octocat/hello-world"},
+			},
+		},
+		TernDeployments: TernConfig{
+			DefaultDeployment: {"staging": "localhost:9090"},
+		},
+	}
+	mockClient := &mockTernClient{
+		applyResp: &ternv1.ApplyResponse{Accepted: false, ErrorMessage: "engine rejected"},
+	}
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	svc := New(&mockStorageWithPlanLookup{
+		plans: &mockPlanLookupStore{plan: plan},
+	}, cfg, map[string]tern.Client{
+		DefaultDeployment + "/staging": mockClient,
+	}, logger)
+
+	resp, applyID, err := svc.ExecuteApply(t.Context(), ApplyRequest{
+		PlanID:      "plan-untrusted-repo",
+		Environment: "staging",
+	})
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Zero(t, applyID)
+	assert.Nil(t, mockClient.applyReq, "stored trusted plan with unauthorized source should not call Tern")
+	var policyErr *SourcePolicyError
+	require.True(t, errors.As(err, &policyErr), "expected SourcePolicyError")
+	assert.Equal(t, SourcePolicyReasonUnauthorizedRepo, policyErr.Reason)
+}
+
+func TestExecuteApplySourcePolicyBlocksMissingDatabaseConfig(t *testing.T) {
+	plan := &storage.Plan{
+		ID:             42,
+		PlanIdentifier: "plan-missing-database-config",
+		Database:       "payments",
+		DatabaseType:   storage.DatabaseTypeMySQL,
+		Deployment:     DefaultDeployment,
+		Target:         "payments-staging-target",
+		Repository:     "octocat/hello-world",
+		PullRequest:    1,
+		SchemaPath:     "schema/payments",
+		Environment:    "staging",
+	}
+	cfg := &ServerConfig{
+		TernDeployments: TernConfig{
+			DefaultDeployment: {"staging": "localhost:9090"},
+		},
+	}
+	mockClient := &mockTernClient{
+		applyResp: &ternv1.ApplyResponse{Accepted: false, ErrorMessage: "engine rejected"},
+	}
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	svc := New(&mockStorageWithPlanLookup{
+		plans: &mockPlanLookupStore{plan: plan},
+	}, cfg, map[string]tern.Client{
+		DefaultDeployment + "/staging": mockClient,
+	}, logger)
+
+	resp, applyID, err := svc.ExecuteApply(t.Context(), ApplyRequest{
+		PlanID:      "plan-missing-database-config",
+		Environment: "staging",
+	})
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Zero(t, applyID)
+	assert.Nil(t, mockClient.applyReq, "stored trusted plan without database config should not call Tern")
+	var policyErr *SourcePolicyError
+	require.True(t, errors.As(err, &policyErr), "expected SourcePolicyError")
+	assert.Equal(t, SourcePolicyReasonMissingDatabaseConfig, policyErr.Reason)
+}
+
+func TestPlanHandlerRejectsClientSuppliedSchemaPath(t *testing.T) {
+	svc := newTestService()
+	mux := http.NewServeMux()
+	svc.ConfigureRoutes(mux)
+
+	body := `{
+		"database": "payments",
+		"environment": "staging",
+		"type": "mysql",
+		"schema_path": "schema/payments",
+		"schema_files": {"payments": {"files": {"users.sql": "CREATE TABLE users (id bigint primary key)"}}}
+	}`
+	req := httptest.NewRequestWithContext(t.Context(), "POST", "/api/plan", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	mux.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "unknown field")
+	assert.Contains(t, w.Body.String(), "schema_path")
+}
+
+func TestPlanHandlerSourcePolicyAllowsDirectSource(t *testing.T) {
+	cfg := &ServerConfig{
+		Databases: map[string]DatabaseConfig{
+			"payments": {
+				Type: storage.DatabaseTypeMySQL,
+				Environments: map[string]EnvironmentConfig{
+					"staging": {Target: "payments-staging-target", Deployment: DefaultDeployment},
+				},
+				AllowedRepos: []string{"octocat/hello-world"},
+				AllowedDirs:  []string{"schema/payments"},
+			},
+		},
+		TernDeployments: TernConfig{
+			DefaultDeployment: {"staging": "localhost:9090"},
+		},
+	}
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	mockClient := &mockTernClient{planResp: &ternv1.PlanResponse{PlanId: "plan-source-policy"}}
+	svc := New(&mockStorageWithPlanLookup{plans: &capturingPlanStore{}}, cfg, map[string]tern.Client{
+		DefaultDeployment + "/staging": mockClient,
+	}, logger)
+	mux := http.NewServeMux()
+	svc.ConfigureRoutes(mux)
+
+	body := `{
+		"database": "payments",
+		"environment": "staging",
+		"type": "mysql",
+		"repository": "octocat/hello-world",
+		"pull_request": 1,
+		"schema_files": {"payments": {"files": {"users.sql": "CREATE TABLE users (id bigint primary key)"}}}
+	}`
+	req := httptest.NewRequestWithContext(t.Context(), "POST", "/api/plan", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	mux.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	require.NotNil(t, mockClient.planReq, "direct HTTP planning should still call Tern")
+	assert.Empty(t, mockClient.planReq.SchemaPath)
+	var resp apitypes.PlanResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Equal(t, "plan-source-policy", resp.PlanID)
 }
 
 func TestExecuteApplyRequiresRemoteApplyID(t *testing.T) {
@@ -641,6 +985,60 @@ func TestApplyHandler(t *testing.T) {
 		require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
 		assert.Equal(t, apitypes.ErrCodeActiveApplyExists, resp.ErrorCode)
 		assert.Contains(t, resp.Error, storage.ErrActiveApplyExists.Error())
+	})
+
+	t.Run("allows direct stored plans without source metadata", func(t *testing.T) {
+		plan := &storage.Plan{
+			ID:             42,
+			PlanIdentifier: "plan-old-direct",
+			Database:       "payments",
+			DatabaseType:   storage.DatabaseTypeMySQL,
+			Deployment:     DefaultDeployment,
+			Target:         "payments-staging-target",
+			Repository:     "octocat/hello-world",
+			PullRequest:    1,
+			Environment:    "staging",
+		}
+		cfg := &ServerConfig{
+			Databases: map[string]DatabaseConfig{
+				"payments": {
+					Type: storage.DatabaseTypeMySQL,
+					Environments: map[string]EnvironmentConfig{
+						"staging": {Target: "payments-staging-target", Deployment: DefaultDeployment},
+					},
+					AllowedRepos: []string{"octocat/hello-world"},
+				},
+			},
+			TernDeployments: TernConfig{
+				DefaultDeployment: {"staging": "localhost:9090"},
+			},
+		}
+		stor := &mockStorageWithPlanLookup{
+			plans: &mockPlanLookupStore{plan: plan},
+		}
+		mock := &mockTernClient{
+			applyResp: &ternv1.ApplyResponse{Accepted: false, ErrorMessage: "engine rejected"},
+			isRemote:  true,
+		}
+		logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+		ternClients := map[string]tern.Client{DefaultDeployment + "/staging": mock}
+		svc := New(stor, cfg, ternClients, logger)
+		mux := http.NewServeMux()
+		svc.ConfigureRoutes(mux)
+
+		body := `{"plan_id": "plan-old-direct", "environment": "staging"}`
+		req := httptest.NewRequestWithContext(t.Context(), "POST", "/api/apply", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
+		require.NotNil(t, mock.applyReq, "direct HTTP apply should still call Tern")
+
+		var resp apitypes.ApplyResponse
+		require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+		assert.False(t, resp.Accepted)
+		assert.Equal(t, apitypes.ErrCodeEngineError, resp.ErrorCode)
 	})
 }
 

--- a/pkg/api/plan_handlers.go
+++ b/pkg/api/plan_handlers.go
@@ -31,6 +31,12 @@ type PlanRequest struct {
 	SchemaFiles map[string]*ternv1.SchemaFiles `json:"schema_files"`
 	Repository  string                         `json:"repository,omitempty"`
 	PullRequest *int32                         `json:"pull_request,omitempty"`
+	SchemaPath  string                         `json:"-"`
+
+	// SourceTrusted is set by the GitHub webhook path after SchemaBot has
+	// discovered the PR source itself. It is deliberately not JSON-decodable:
+	// direct API clients cannot attest repo/path ownership.
+	SourceTrusted bool `json:"-"`
 }
 
 // ApplyRequest is the HTTP request body for POST /api/apply.
@@ -73,6 +79,11 @@ func (s *Service) handlePlan(w http.ResponseWriter, r *http.Request) {
 
 	resp, err := s.ExecutePlan(r.Context(), req)
 	if err != nil {
+		var policyErr *SourcePolicyError
+		if errors.As(err, &policyErr) {
+			s.writeErrorCode(w, http.StatusForbidden, apitypes.ErrCodeSourcePolicyDenied, "plan failed: "+err.Error())
+			return
+		}
 		s.logger.Error("plan failed", "database", req.Database, "error", err)
 		s.writeError(w, http.StatusInternalServerError, "plan failed: "+err.Error())
 		return
@@ -122,6 +133,48 @@ func (s *Service) ExecutePlan(ctx context.Context, req PlanRequest) (*apitypes.P
 	}
 	deployment := resolvedTarget.Deployment
 
+	prInt := 0
+	if req.PullRequest != nil {
+		prInt = int(*req.PullRequest)
+	}
+	trustedSchemaPath := ""
+	if req.SourceTrusted {
+		trustedSchemaPath = req.SchemaPath
+	}
+	// Source policy checks only apply to SchemaBot-discovered PR sources. Direct
+	// operator/API plans remain available through the existing endpoint access
+	// model until the dedicated auth layer is added.
+	if !req.SourceTrusted {
+		s.logger.Debug("skipping source policy for direct plan request",
+			"database", req.Database,
+			"environment", req.Environment,
+			"repository", req.Repository,
+			"pull_request", prInt)
+	} else {
+		if err := s.config.AuthorizePlanSource(PlanSourcePolicyRequest{
+			Database:    req.Database,
+			Repository:  req.Repository,
+			PullRequest: prInt,
+			SchemaPath:  trustedSchemaPath,
+		}); err != nil {
+			reason := sourcePolicyReason(err)
+			span.RecordError(err)
+			span.SetStatus(codes.Error, "source policy")
+			metrics.RecordPlan(ctx, req.Database, req.Environment, "error")
+			metrics.RecordPlanDuration(ctx, time.Since(planStart), req.Database, req.Environment, "error")
+			metrics.RecordSourcePolicyBlock(ctx, "plan", req.Database, req.Environment, reason)
+			s.logger.Warn("plan blocked by source policy",
+				"database", req.Database,
+				"environment", req.Environment,
+				"repository", req.Repository,
+				"pull_request", prInt,
+				"schema_path", req.SchemaPath,
+				"reason", reason,
+				"error", err)
+			return nil, fmt.Errorf("source policy: %w", err)
+		}
+	}
+
 	client, err := s.TernClient(deployment, req.Environment)
 	if err != nil {
 		span.RecordError(err)
@@ -138,6 +191,7 @@ func (s *Service) ExecutePlan(ctx context.Context, req PlanRequest) (*apitypes.P
 		Repository:  req.Repository,
 		Environment: req.Environment,
 		Target:      resolvedTarget.Target,
+		SchemaPath:  trustedSchemaPath,
 	}
 	if req.PullRequest != nil {
 		ternReq.PullRequest = *req.PullRequest
@@ -179,10 +233,6 @@ func (s *Service) ExecutePlan(ctx context.Context, req PlanRequest) (*apitypes.P
 	}
 
 	// Store plan in SchemaBot's storage (idempotent — duplicate is ignored)
-	prInt := 0
-	if req.PullRequest != nil {
-		prInt = int(*req.PullRequest)
-	}
 	storedPlan := &storage.Plan{
 		PlanIdentifier: resp.PlanId,
 		Database:       req.Database,
@@ -191,6 +241,7 @@ func (s *Service) ExecutePlan(ctx context.Context, req PlanRequest) (*apitypes.P
 		Target:         resolvedTarget.Target,
 		Repository:     req.Repository,
 		PullRequest:    prInt,
+		SchemaPath:     trustedSchemaPath,
 		Environment:    req.Environment,
 		SchemaFiles:    protoToSchemaFiles(req.SchemaFiles),
 		Namespaces:     protoChangesToNamespaces(resp.Changes),
@@ -227,6 +278,11 @@ func (s *Service) handleApply(w http.ResponseWriter, r *http.Request) {
 		if errors.Is(err, storage.ErrActiveApplyExists) {
 			s.logger.Warn("apply blocked by active apply", "plan_id", req.PlanID, "environment", req.Environment, "error", err)
 			s.writeErrorCode(w, http.StatusConflict, apitypes.ErrCodeActiveApplyExists, "apply blocked by active apply: "+err.Error())
+			return
+		}
+		var policyErr *SourcePolicyError
+		if errors.As(err, &policyErr) {
+			s.writeErrorCode(w, http.StatusForbidden, apitypes.ErrCodeSourcePolicyDenied, "apply failed: "+err.Error())
 			return
 		}
 		s.logger.Error("apply failed", "plan_id", req.PlanID, "error", err)
@@ -303,6 +359,41 @@ func (s *Service) ExecuteApply(ctx context.Context, req ApplyRequest) (*apitypes
 		span.SetStatus(codes.Error, "missing stored target")
 		metrics.RecordApply(ctx, plan.Database, req.Environment, "error")
 		return nil, 0, applyErr
+	}
+	// Source policy is evaluated for plans created from SchemaBot's trusted
+	// GitHub PR discovery path. Direct operator/API plans do not have a
+	// server-discovered schema path today; those remain governed by endpoint
+	// access until the dedicated auth layer is added.
+	if plan.SchemaPath == "" {
+		s.logger.Debug("skipping source policy for apply because stored plan has no trusted schema path",
+			"plan_id", req.PlanID,
+			"database", plan.Database,
+			"environment", req.Environment,
+			"repository", plan.Repository,
+			"pull_request", plan.PullRequest)
+	} else {
+		if err := s.config.AuthorizePlanSource(PlanSourcePolicyRequest{
+			Database:    plan.Database,
+			Repository:  plan.Repository,
+			PullRequest: plan.PullRequest,
+			SchemaPath:  plan.SchemaPath,
+		}); err != nil {
+			reason := sourcePolicyReason(err)
+			span.RecordError(err)
+			span.SetStatus(codes.Error, "source policy")
+			metrics.RecordApply(ctx, plan.Database, req.Environment, "error")
+			metrics.RecordSourcePolicyBlock(ctx, "apply", plan.Database, req.Environment, reason)
+			s.logger.Warn("apply blocked by source policy",
+				"plan_id", req.PlanID,
+				"database", plan.Database,
+				"environment", req.Environment,
+				"repository", plan.Repository,
+				"pull_request", plan.PullRequest,
+				"schema_path", plan.SchemaPath,
+				"reason", reason,
+				"error", err)
+			return nil, 0, fmt.Errorf("source policy for plan %s: %w", req.PlanID, err)
+		}
 	}
 
 	deployment := plan.Deployment

--- a/pkg/api/source_policy.go
+++ b/pkg/api/source_policy.go
@@ -1,0 +1,214 @@
+package api
+
+import (
+	"errors"
+	"fmt"
+	"path"
+	"strings"
+)
+
+const (
+	SourcePolicyReasonUnknown               = "unknown"
+	SourcePolicyReasonMissingServerConfig   = "missing_server_config"
+	SourcePolicyReasonMissingDatabaseConfig = "missing_database_config"
+	SourcePolicyReasonMissingRepository     = "missing_repository"
+	SourcePolicyReasonMissingPullRequest    = "missing_pull_request"
+	SourcePolicyReasonMissingSchemaPath     = "missing_schema_path"
+	SourcePolicyReasonUnauthorizedRepo      = "unauthorized_repo"
+	SourcePolicyReasonUnauthorizedSchemaDir = "unauthorized_schema_dir"
+)
+
+// SourcePolicyError is returned when server-side source policy blocks a plan or
+// apply. Reason is stable for metrics and API clients; Message is the
+// operator-facing text shown by PR comments and direct API errors.
+type SourcePolicyError struct {
+	Reason  string
+	Message string
+}
+
+func (e *SourcePolicyError) Error() string {
+	return e.Message
+}
+
+func sourcePolicyReason(err error) string {
+	var policyErr *SourcePolicyError
+	if errors.As(err, &policyErr) {
+		return policyErr.Reason
+	}
+	return SourcePolicyReasonUnknown
+}
+
+// PlanSourcePolicyRequest is the source metadata used for database ownership
+// checks.
+type PlanSourcePolicyRequest struct {
+	Database    string
+	Repository  string
+	PullRequest int
+	SchemaPath  string
+}
+
+// AuthorizePlanSource verifies that a trusted GitHub PR source is allowed to
+// manage the requested database. Direct operator/API paths skip this helper at
+// the caller because they do not have SchemaBot-discovered source metadata.
+func (c *ServerConfig) AuthorizePlanSource(req PlanSourcePolicyRequest) error {
+	if c == nil {
+		return &SourcePolicyError{
+			Reason:  SourcePolicyReasonMissingServerConfig,
+			Message: fmt.Sprintf("database %q source policy could not be evaluated because server config is missing", req.Database),
+		}
+	}
+
+	dbConfig := c.Database(req.Database)
+	if dbConfig == nil {
+		return &SourcePolicyError{
+			Reason:  SourcePolicyReasonMissingDatabaseConfig,
+			Message: fmt.Sprintf("database %q source policy could not be evaluated because database config is missing", req.Database),
+		}
+	}
+	if !dbConfig.hasSourcePolicy() {
+		return nil
+	}
+
+	if strings.TrimSpace(req.Repository) == "" {
+		return &SourcePolicyError{
+			Reason:  SourcePolicyReasonMissingRepository,
+			Message: fmt.Sprintf("database %q has source policy configured, but the plan source repository is missing", req.Database),
+		}
+	}
+	if req.PullRequest <= 0 {
+		return &SourcePolicyError{
+			Reason:  SourcePolicyReasonMissingPullRequest,
+			Message: fmt.Sprintf("database %q has source policy configured, but the plan source pull request is missing", req.Database),
+		}
+	}
+	if strings.TrimSpace(req.SchemaPath) == "" {
+		return &SourcePolicyError{
+			Reason:  SourcePolicyReasonMissingSchemaPath,
+			Message: fmt.Sprintf("database %q has source policy configured, but the plan source schema path is missing", req.Database),
+		}
+	}
+
+	if len(dbConfig.AllowedRepos) > 0 {
+		if !repoAllowed(dbConfig.AllowedRepos, req.Repository) {
+			return &SourcePolicyError{
+				Reason: SourcePolicyReasonUnauthorizedRepo,
+				Message: fmt.Sprintf(
+					"repo %q is not authorized for database %q; update databases.%s.allowed_repos in server config if this is intentional",
+					req.Repository, req.Database, req.Database,
+				),
+			}
+		}
+	}
+
+	if len(dbConfig.AllowedDirs) > 0 {
+		if !schemaPathAllowed(dbConfig.AllowedDirs, req.SchemaPath) {
+			return &SourcePolicyError{
+				Reason: SourcePolicyReasonUnauthorizedSchemaDir,
+				Message: fmt.Sprintf(
+					"schema path %q is not authorized for database %q; update databases.%s.allowed_dirs in server config if this is intentional",
+					req.SchemaPath, req.Database, req.Database,
+				),
+			}
+		}
+	}
+
+	return nil
+}
+
+func (d DatabaseConfig) hasSourcePolicy() bool {
+	return len(d.AllowedRepos) > 0 || len(d.AllowedDirs) > 0
+}
+
+func validateDatabaseSourcePolicy(database string, dbConfig DatabaseConfig) error {
+	if err := validateAllowedRepos("databases."+database+".allowed_repos", dbConfig.AllowedRepos); err != nil {
+		return err
+	}
+
+	normalizedDirs := make(map[string]struct{}, len(dbConfig.AllowedDirs))
+	for _, dir := range dbConfig.AllowedDirs {
+		normalized, err := normalizeSchemaPath(dir)
+		if err != nil {
+			return fmt.Errorf("databases.%s.allowed_dirs contains invalid value %q: %w", database, dir, err)
+		}
+		if _, ok := normalizedDirs[normalized]; ok {
+			return fmt.Errorf("databases.%s.allowed_dirs contains duplicate value %q", database, normalized)
+		}
+		normalizedDirs[normalized] = struct{}{}
+	}
+
+	return nil
+}
+
+func validateAllowedRepos(field string, repos []string) error {
+	seen := make(map[string]struct{}, len(repos))
+	for _, repo := range repos {
+		trimmed := strings.TrimSpace(repo)
+		if trimmed == "" {
+			return fmt.Errorf("%s contains an empty value", field)
+		}
+		if trimmed != repo {
+			return fmt.Errorf("%s contains value %q with leading or trailing whitespace", field, repo)
+		}
+		if _, ok := seen[trimmed]; ok {
+			return fmt.Errorf("%s contains duplicate value %q", field, trimmed)
+		}
+		seen[trimmed] = struct{}{}
+	}
+	return nil
+}
+
+func repoAllowed(allowedRepos []string, repo string) bool {
+	repo = strings.TrimSpace(repo)
+	for _, allowed := range allowedRepos {
+		switch strings.TrimSpace(allowed) {
+		case "*":
+			return true
+		case repo:
+			return true
+		}
+	}
+	return false
+}
+
+func schemaPathAllowed(allowedDirs []string, schemaPath string) bool {
+	cleanSchemaPath, err := normalizeSchemaPath(schemaPath)
+	if err != nil {
+		return false
+	}
+
+	for _, allowedDir := range allowedDirs {
+		cleanAllowedDir, err := normalizeSchemaPath(allowedDir)
+		if err != nil {
+			return false
+		}
+		if cleanAllowedDir == "*" {
+			return true
+		}
+		if cleanSchemaPath == cleanAllowedDir {
+			return true
+		}
+		if cleanAllowedDir != "." && strings.HasPrefix(cleanSchemaPath, cleanAllowedDir+"/") {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizeSchemaPath(value string) (string, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", fmt.Errorf("path is empty")
+	}
+	if value == "*" {
+		return "*", nil
+	}
+	if strings.HasPrefix(value, "/") {
+		return "", fmt.Errorf("path must be repo-relative")
+	}
+
+	cleaned := path.Clean(value)
+	if cleaned == ".." || strings.HasPrefix(cleaned, "../") {
+		return "", fmt.Errorf("path must not escape the repository")
+	}
+	return cleaned, nil
+}

--- a/pkg/api/source_policy_test.go
+++ b/pkg/api/source_policy_test.go
@@ -1,0 +1,189 @@
+package api
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSourcePolicyReason(t *testing.T) {
+	policyErr := &SourcePolicyError{
+		Reason:  SourcePolicyReasonUnauthorizedRepo,
+		Message: "repo is not authorized",
+	}
+
+	assert.Equal(t, SourcePolicyReasonUnauthorizedRepo, sourcePolicyReason(policyErr))
+	assert.Equal(t, SourcePolicyReasonUnauthorizedRepo, sourcePolicyReason(fmt.Errorf("wrapped: %w", policyErr)))
+	assert.Equal(t, SourcePolicyReasonUnknown, sourcePolicyReason(errors.New("storage failed")))
+}
+
+func TestRepoAllowed(t *testing.T) {
+	tests := []struct {
+		name         string
+		allowedRepos []string
+		repository   string
+		want         bool
+	}{
+		{
+			name:         "exact match",
+			allowedRepos: []string{"octocat/hello-world"},
+			repository:   "octocat/hello-world",
+			want:         true,
+		},
+		{
+			name:         "wildcard allows any repo",
+			allowedRepos: []string{"*"},
+			repository:   "octocat/orders",
+			want:         true,
+		},
+		{
+			name:         "request repository is trimmed",
+			allowedRepos: []string{"octocat/hello-world"},
+			repository:   " octocat/hello-world ",
+			want:         true,
+		},
+		{
+			name:         "similar repo name is blocked",
+			allowedRepos: []string{"octocat/hello-world"},
+			repository:   "octocat/hello-world-archive",
+			want:         false,
+		},
+		{
+			name:         "empty policy blocks",
+			allowedRepos: nil,
+			repository:   "octocat/hello-world",
+			want:         false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, repoAllowed(tt.allowedRepos, tt.repository))
+		})
+	}
+}
+
+func TestSchemaPathAllowed(t *testing.T) {
+	tests := []struct {
+		name        string
+		allowedDirs []string
+		schemaPath  string
+		want        bool
+	}{
+		{
+			name:        "exact directory is allowed",
+			allowedDirs: []string{"schema/payments"},
+			schemaPath:  "schema/payments",
+			want:        true,
+		},
+		{
+			name:        "descendant directory is allowed",
+			allowedDirs: []string{"schema/payments"},
+			schemaPath:  "schema/payments/archive",
+			want:        true,
+		},
+		{
+			name:        "dot segments are normalized before matching",
+			allowedDirs: []string{"schema/payments"},
+			schemaPath:  "schema/./payments/archive",
+			want:        true,
+		},
+		{
+			name:        "wildcard allows any repo-relative path",
+			allowedDirs: []string{"*"},
+			schemaPath:  "schema/orders",
+			want:        true,
+		},
+		{
+			name:        "sibling directory is blocked",
+			allowedDirs: []string{"schema/payments"},
+			schemaPath:  "schema/payments-archive",
+			want:        false,
+		},
+		{
+			name:        "path escape is blocked",
+			allowedDirs: []string{"schema/payments"},
+			schemaPath:  "../schema/payments",
+			want:        false,
+		},
+		{
+			name:        "absolute path is blocked",
+			allowedDirs: []string{"schema/payments"},
+			schemaPath:  "/schema/payments",
+			want:        false,
+		},
+		{
+			name:        "empty allowed dirs block",
+			allowedDirs: nil,
+			schemaPath:  "schema/payments",
+			want:        false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, schemaPathAllowed(tt.allowedDirs, tt.schemaPath))
+		})
+	}
+}
+
+func TestNormalizeSchemaPath(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		want    string
+		wantErr string
+	}{
+		{
+			name:  "cleans relative path",
+			value: "schema//payments/./archive",
+			want:  "schema/payments/archive",
+		},
+		{
+			name:  "trims surrounding whitespace",
+			value: " schema/payments ",
+			want:  "schema/payments",
+		},
+		{
+			name:  "wildcard is preserved",
+			value: "*",
+			want:  "*",
+		},
+		{
+			name:    "empty path is invalid",
+			value:   " ",
+			wantErr: "path is empty",
+		},
+		{
+			name:    "absolute path is invalid",
+			value:   "/schema/payments",
+			wantErr: "path must be repo-relative",
+		},
+		{
+			name:    "escape path is invalid",
+			value:   "../schema/payments",
+			wantErr: "path must not escape the repository",
+		},
+		{
+			name:    "cleaned escape path is invalid",
+			value:   "schema/../../payments",
+			wantErr: "path must not escape the repository",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := normalizeSchemaPath(tt.value)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/api/telemetry_test.go
+++ b/pkg/api/telemetry_test.go
@@ -276,6 +276,49 @@ func TestRecordCheckOwnershipMissMetric(t *testing.T) {
 	assert.True(t, found, "schemabot.check_ownership_misses_total metric not found")
 }
 
+func TestRecordSourcePolicyBlockMetric(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	prevMP := otel.GetMeterProvider()
+	otel.SetMeterProvider(mp)
+	t.Cleanup(func() {
+		otel.SetMeterProvider(prevMP)
+		require.NoError(t, mp.Shutdown(t.Context()))
+	})
+
+	metrics.RecordSourcePolicyBlock(t.Context(), "plan", "mydb", "staging", "unauthorized_repo")
+	metrics.RecordSourcePolicyBlock(t.Context(), "apply", "mydb", "production", "missing_database_config")
+	metrics.RecordSourcePolicyBlock(t.Context(), "not_real", "mydb", "staging", "not_real")
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(t.Context(), &rm))
+
+	var found bool
+	var sawUnknown bool
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != "schemabot.source_policy.blocks_total" {
+				continue
+			}
+			found = true
+			sum, ok := m.Data.(metricdata.Sum[int64])
+			require.True(t, ok)
+			assert.Len(t, sum.DataPoints, 3, "expected one data point per operation/reason attribute set")
+			for _, dp := range sum.DataPoints {
+				operation, hasOperation := dp.Attributes.Value(attribute.Key("operation"))
+				reason, hasReason := dp.Attributes.Value(attribute.Key("reason"))
+				require.True(t, hasOperation)
+				require.True(t, hasReason)
+				if operation.AsString() == "unknown" && reason.AsString() == "unknown" {
+					sawUnknown = true
+				}
+			}
+		}
+	}
+	assert.True(t, found, "schemabot.source_policy.blocks_total metric not found")
+	assert.True(t, sawUnknown, "expected unknown operation and reason to be normalized")
+}
+
 func TestRecordStatusCheckOperationMetric(t *testing.T) {
 	reader := sdkmetric.NewManualReader()
 	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))

--- a/pkg/apitypes/apitypes.go
+++ b/pkg/apitypes/apitypes.go
@@ -20,6 +20,7 @@ const (
 	ErrCodeEngineUnavailable    = "engine_unavailable"     // Schema change engine (Tern) unreachable or RPC error
 	ErrCodeStateSyncFailed      = "state_sync_failed"      // Operation succeeded but local state sync failed
 	ErrCodeActiveApplyExists    = "active_apply_exists"    // Another active apply already exists for the target
+	ErrCodeSourcePolicyDenied   = "source_policy_denied"   // Source repo/path is not authorized for the database
 )
 
 var retryableErrorCodes = map[string]bool{

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -134,6 +134,50 @@ func RecordSchemaFreshnessRejected(ctx context.Context, action string) {
 	)
 }
 
+var knownSourcePolicyOperations = map[string]bool{
+	"plan":  true,
+	"apply": true,
+}
+
+var knownSourcePolicyBlockReasons = map[string]bool{
+	"missing_server_config":   true,
+	"missing_database_config": true,
+	"missing_repository":      true,
+	"missing_pull_request":    true,
+	"missing_schema_path":     true,
+	"unauthorized_repo":       true,
+	"unauthorized_schema_dir": true,
+	"unknown":                 true,
+}
+
+// RecordSourcePolicyBlock increments the counter for source-policy decisions
+// that block a trusted GitHub source before planning or applying.
+func RecordSourcePolicyBlock(ctx context.Context, operation, database, environment, reason string) {
+	if !knownSourcePolicyOperations[operation] {
+		operation = "unknown"
+	}
+	if !knownSourcePolicyBlockReasons[reason] {
+		reason = "unknown"
+	}
+	meter := otel.Meter(meterName)
+	counter, err := meter.Int64Counter("schemabot.source_policy.blocks_total",
+		otelmetric.WithDescription("Total trusted-source plan/apply requests blocked by source policy"),
+		otelmetric.WithUnit("{block}"),
+	)
+	if err != nil {
+		slog.Warn("failed to create source policy block counter", "error", err)
+		return
+	}
+	counter.Add(ctx, 1,
+		otelmetric.WithAttributes(
+			attribute.String("operation", operation),
+			attribute.String("database", database),
+			attribute.String("environment", environment),
+			attribute.String("reason", reason),
+		),
+	)
+}
+
 // knownCheckOwnershipOperations limits metric cardinality to expected check
 // ownership miss paths.
 var knownCheckOwnershipOperations = map[string]bool{

--- a/pkg/proto/tern.proto
+++ b/pkg/proto/tern.proto
@@ -252,6 +252,8 @@ message PlanRequest {
   // Opaque identifier for endpoint discovery (e.g., database identifier).
   // Forwarded to Tern for provider-based resolution. Defaults to database if empty.
   string target = 8;
+  // Repo-relative schema directory discovered by SchemaBot from the PR.
+  string schema_path = 9;
 }
 
 // TableChange represents a DDL change to a table.
@@ -502,4 +504,3 @@ message VolumeResponse {
   // New volume level.
   int32 new_volume = 4;
 }
-

--- a/pkg/proto/ternv1/tern.pb.go
+++ b/pkg/proto/ternv1/tern.pb.go
@@ -280,7 +280,9 @@ type PlanRequest struct {
 	Environment string `protobuf:"bytes,6,opt,name=environment,proto3" json:"environment,omitempty"`
 	// Opaque identifier for endpoint discovery (e.g., database identifier).
 	// Forwarded to Tern for provider-based resolution. Defaults to database if empty.
-	Target        string `protobuf:"bytes,8,opt,name=target,proto3" json:"target,omitempty"`
+	Target string `protobuf:"bytes,8,opt,name=target,proto3" json:"target,omitempty"`
+	// Repo-relative schema directory discovered by SchemaBot from the PR.
+	SchemaPath    string `protobuf:"bytes,9,opt,name=schema_path,json=schemaPath,proto3" json:"schema_path,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -360,6 +362,13 @@ func (x *PlanRequest) GetEnvironment() string {
 func (x *PlanRequest) GetTarget() string {
 	if x != nil {
 		return x.Target
+	}
+	return ""
+}
+
+func (x *PlanRequest) GetSchemaPath() string {
+	if x != nil {
+		return x.SchemaPath
 	}
 	return ""
 }
@@ -2201,7 +2210,7 @@ const file_tern_proto_rawDesc = "" +
 	"\n" +
 	"FilesEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xe0\x02\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x81\x03\n" +
 	"\vPlanRequest\x12\x1a\n" +
 	"\bdatabase\x18\x01 \x01(\tR\bdatabase\x12\x12\n" +
 	"\x04type\x18\x02 \x01(\tR\x04type\x12H\n" +
@@ -2211,7 +2220,9 @@ const file_tern_proto_rawDesc = "" +
 	"repository\x12!\n" +
 	"\fpull_request\x18\x05 \x01(\x05R\vpullRequest\x12 \n" +
 	"\venvironment\x18\x06 \x01(\tR\venvironment\x12\x16\n" +
-	"\x06target\x18\b \x01(\tR\x06target\x1aT\n" +
+	"\x06target\x18\b \x01(\tR\x06target\x12\x1f\n" +
+	"\vschema_path\x18\t \x01(\tR\n" +
+	"schemaPath\x1aT\n" +
 	"\x10SchemaFilesEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12*\n" +
 	"\x05value\x18\x02 \x01(\v2\x14.tern.v1.SchemaFilesR\x05value:\x028\x01J\x04\b\a\x10\b\"\xd4\x01\n" +

--- a/pkg/schema/mysql/plans.sql
+++ b/pkg/schema/mysql/plans.sql
@@ -7,6 +7,7 @@ CREATE TABLE `plans` (
   `target` varchar(255) NOT NULL DEFAULT '',
   `repository` varchar(255) NOT NULL,
   `pull_request` int unsigned NOT NULL,
+  `schema_path` varchar(1024) NOT NULL DEFAULT '',
   `environment` varchar(50) NOT NULL DEFAULT '',
   `schema_files` json NOT NULL,
   `plan_data` json NOT NULL,

--- a/pkg/storage/mysqlstore/mysql_test.go
+++ b/pkg/storage/mysqlstore/mysql_test.go
@@ -21,8 +21,9 @@ import (
 )
 
 var (
-	testDB  *sql.DB
-	testDSN string
+	testDB             *sql.DB
+	testDSN            string
+	testDSNChangedRows string
 )
 
 func TestMain(m *testing.M) {
@@ -51,6 +52,7 @@ func TestMain(m *testing.M) {
 	// the value if called within the same second, but we still want to know
 	// if the row was found.
 	testDSN = fmt.Sprintf("root:testpassword@tcp(%s:%d)/schemabot_test?parseTime=true&clientFoundRows=true&multiStatements=true", host, port)
+	testDSNChangedRows = fmt.Sprintf("root:testpassword@tcp(%s:%d)/schemabot_test?parseTime=true&multiStatements=true", host, port)
 
 	testDB, err = sql.Open("mysql", testDSN)
 	if err != nil {

--- a/pkg/storage/mysqlstore/plans.go
+++ b/pkg/storage/mysqlstore/plans.go
@@ -15,7 +15,7 @@ import (
 
 // planColumns lists all columns for SELECT queries.
 const planColumns = `id, plan_identifier, database_name, database_type,
-	deployment, target, repository, pull_request, environment, schema_files, plan_data, created_at`
+	deployment, target, repository, pull_request, schema_path, environment, schema_files, plan_data, created_at`
 
 // planStore implements storage.PlanStore using MySQL.
 type planStore struct {
@@ -35,9 +35,9 @@ func (s *planStore) Create(ctx context.Context, plan *storage.Plan) (int64, erro
 	}
 
 	result, err := s.db.ExecContext(ctx, `
-		INSERT INTO plans (plan_identifier, database_name, database_type, deployment, target, repository, pull_request, environment, schema_files, plan_data, created_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-	`, plan.PlanIdentifier, plan.Database, plan.DatabaseType, plan.Deployment, plan.Target, plan.Repository, plan.PullRequest, plan.Environment, string(schemaFilesJSON), string(planDataJSON), plan.CreatedAt)
+		INSERT INTO plans (plan_identifier, database_name, database_type, deployment, target, repository, pull_request, schema_path, environment, schema_files, plan_data, created_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`, plan.PlanIdentifier, plan.Database, plan.DatabaseType, plan.Deployment, plan.Target, plan.Repository, plan.PullRequest, plan.SchemaPath, plan.Environment, string(schemaFilesJSON), string(planDataJSON), plan.CreatedAt)
 	if err != nil {
 		if isDuplicateKeyError(err) {
 			return 0, storage.ErrPlanIDExists
@@ -150,6 +150,7 @@ func scanPlanInto(s scanner) (*storage.Plan, error) {
 		&plan.Target,
 		&plan.Repository,
 		&plan.PullRequest,
+		&plan.SchemaPath,
 		&plan.Environment,
 		&schemaFilesJSON,
 		&planDataJSON,

--- a/pkg/storage/types.go
+++ b/pkg/storage/types.go
@@ -213,6 +213,9 @@ type Plan struct {
 	// PullRequest is the PR number that generated this plan.
 	PullRequest int
 
+	// SchemaPath is the repo-relative directory that generated this plan.
+	SchemaPath string
+
 	// Environment is "staging" or "production".
 	Environment string
 

--- a/pkg/tern/local_client.go
+++ b/pkg/tern/local_client.go
@@ -367,6 +367,7 @@ func (c *LocalClient) Plan(ctx context.Context, req *ternv1.PlanRequest) (*ternv
 		Target:         localPlanTarget(req, c.config.Database),
 		Repository:     req.Repository,
 		PullRequest:    int(req.PullRequest),
+		SchemaPath:     req.SchemaPath,
 		Environment:    req.Environment,
 		SchemaFiles:    schemaFiles,
 		Namespaces:     namespaces,

--- a/pkg/webhook/apply_handlers.go
+++ b/pkg/webhook/apply_handlers.go
@@ -141,12 +141,14 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 	// Generate plan
 	prNumber := int32(pr)
 	planReq := api.PlanRequest{
-		Database:    schemaResult.Database,
-		Environment: environment,
-		Type:        schemaResult.Type,
-		SchemaFiles: schemaResult.SchemaFiles,
-		Repository:  repo,
-		PullRequest: &prNumber,
+		Database:      schemaResult.Database,
+		Environment:   environment,
+		Type:          schemaResult.Type,
+		SchemaFiles:   schemaResult.SchemaFiles,
+		Repository:    repo,
+		PullRequest:   &prNumber,
+		SchemaPath:    schemaResult.SchemaPath,
+		SourceTrusted: true,
 	}
 
 	planResp, err := h.service.ExecutePlan(ctx, planReq)
@@ -444,12 +446,14 @@ func (h *Handler) executeApply(
 	// Re-plan for drift detection
 	prNumber := int32(pr)
 	planReq := api.PlanRequest{
-		Database:    schemaResult.Database,
-		Environment: environment,
-		Type:        schemaResult.Type,
-		SchemaFiles: schemaResult.SchemaFiles,
-		Repository:  repo,
-		PullRequest: &prNumber,
+		Database:      schemaResult.Database,
+		Environment:   environment,
+		Type:          schemaResult.Type,
+		SchemaFiles:   schemaResult.SchemaFiles,
+		Repository:    repo,
+		PullRequest:   &prNumber,
+		SchemaPath:    schemaResult.SchemaPath,
+		SourceTrusted: true,
 	}
 
 	planResp, err := h.service.ExecutePlan(ctx, planReq)

--- a/pkg/webhook/plan.go
+++ b/pkg/webhook/plan.go
@@ -76,18 +76,23 @@ func (h *Handler) handlePlanCommand(w http.ResponseWriter, repo string, pr int, 
 	// Build PlanRequest in the format expected by the API service
 	prNumber := int32(pr)
 	planReq := api.PlanRequest{
-		Database:    schemaResult.Database,
-		Environment: environment,
-		Type:        schemaResult.Type,
-		SchemaFiles: schemaResult.SchemaFiles,
-		Repository:  repo,
-		PullRequest: &prNumber,
+		Database:      schemaResult.Database,
+		Environment:   environment,
+		Type:          schemaResult.Type,
+		SchemaFiles:   schemaResult.SchemaFiles,
+		Repository:    repo,
+		PullRequest:   &prNumber,
+		SchemaPath:    schemaResult.SchemaPath,
+		SourceTrusted: true,
 	}
 
 	// Execute plan via the service
 	planResp, err := h.service.ExecutePlan(ctx, planReq)
 	if err != nil {
 		h.logger.Error("plan execution failed", "repo", repo, "pr", pr, "error", err)
+		h.postFailingAggregates(ctx, client, repo, pr, schemaResult.HeadSHA, map[string]string{
+			environment: userFacingError(err),
+		})
 		h.postComment(repo, pr, installationID, templates.RenderGenericError(templates.SchemaErrorData{
 			RequestedBy: requestedBy,
 			Timestamp:   time.Now().UTC().Format("2006-01-02 15:04:05"),
@@ -260,12 +265,14 @@ func (h *Handler) handleMultiEnvPlan(repo string, pr int, databaseName string, i
 
 		prNumber := int32(pr)
 		planReq := api.PlanRequest{
-			Database:    schemaResult.Database,
-			Environment: env,
-			Type:        schemaResult.Type,
-			SchemaFiles: schemaResult.SchemaFiles,
-			Repository:  repo,
-			PullRequest: &prNumber,
+			Database:      schemaResult.Database,
+			Environment:   env,
+			Type:          schemaResult.Type,
+			SchemaFiles:   schemaResult.SchemaFiles,
+			Repository:    repo,
+			PullRequest:   &prNumber,
+			SchemaPath:    schemaResult.SchemaPath,
+			SourceTrusted: true,
 		}
 
 		planResp, err := h.service.ExecutePlan(ctx, planReq)

--- a/pkg/webhook/webhook_e2e_test.go
+++ b/pkg/webhook/webhook_e2e_test.go
@@ -460,6 +460,10 @@ func setupFakeGitHubForPlan(t *testing.T, mux *http.ServeMux, schemaSQL map[stri
 func TestE2EPlanWithChanges(t *testing.T) {
 	dbName := "webhook_plan_changes"
 	svc := setupE2EService(t, dbName)
+	dbConfig := svc.Config().Databases[dbName]
+	dbConfig.AllowedRepos = []string{"octocat/hello-world"}
+	dbConfig.AllowedDirs = []string{"schema"}
+	svc.Config().Databases[dbName] = dbConfig
 
 	mux := http.NewServeMux()
 	server := httptest.NewServer(mux)
@@ -532,6 +536,7 @@ func TestE2EPlanWithChanges(t *testing.T) {
 	assert.Equal(t, "staging", plan.Environment)
 	assert.Equal(t, "octocat/hello-world", plan.Repository)
 	assert.Equal(t, 1, plan.PullRequest)
+	assert.Equal(t, "schema", plan.SchemaPath)
 	assert.NotEmpty(t, plan.PlanIdentifier, "plan should have an identifier")
 	assert.NotNil(t, plan.Namespaces, "plan should have namespace data")
 	assert.NotEmpty(t, plan.Namespaces[dbName].Tables, "plan should have DDL changes")
@@ -549,6 +554,84 @@ func TestE2EPlanWithChanges(t *testing.T) {
 	assert.True(t, check.HasChanges, "check should indicate changes detected")
 	assert.Equal(t, "completed", check.Status)
 	assert.Equal(t, "action_required", check.Conclusion)
+}
+
+// TestE2EPlanSourcePolicyBlocksUnauthorizedRepo verifies the trusted GitHub
+// discovery path enforces server-side source policy before a plan is stored.
+// The manual command path should also write a failing aggregate check so the
+// Checks UI matches the failure comment.
+func TestE2EPlanSourcePolicyBlocksUnauthorizedRepo(t *testing.T) {
+	dbName := "webhook_source_policy_block"
+	svc := setupE2EService(t, dbName)
+	dbConfig := svc.Config().Databases[dbName]
+	dbConfig.AllowedRepos = []string{"octocat/orders"}
+	dbConfig.AllowedDirs = []string{"schema"}
+	svc.Config().Databases[dbName] = dbConfig
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	client := gh.NewClient(nil)
+	client.BaseURL, _ = url.Parse(server.URL + "/")
+
+	schemabotConfig := fmt.Sprintf("database: %s\ntype: mysql\n", dbName)
+	schemaFiles := map[string]string{
+		"users.sql": "CREATE TABLE `users` (\n  `id` bigint unsigned NOT NULL AUTO_INCREMENT,\n  `name` varchar(255) NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;",
+	}
+
+	result := setupFakeGitHubForPlan(t, mux, schemaFiles, schemabotConfig, dbName)
+
+	h := newE2EHandler(t, svc, client)
+
+	req := buildWebhookRequest(t, webhookPayloadOpts{
+		comment: "schemabot plan -e staging",
+		isPR:    true,
+	}, nil)
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), "plan failed")
+
+	select {
+	case body := <-result.comments:
+		assert.Contains(t, body, "## ❌ Plan Failed")
+		assert.Contains(t, body, "source policy")
+		assert.Contains(t, body, "repo \"octocat/hello-world\" is not authorized")
+	case <-time.After(webhookIntegrationPollDeadline):
+		t.Fatal("timed out waiting for source policy failure comment")
+	}
+
+	plans, err := svc.Storage().Plans().GetByPR(t.Context(), "octocat/hello-world", 1)
+	require.NoError(t, err)
+	for _, plan := range plans {
+		assert.NotEqual(t, dbName, plan.Database, "source-policy-blocked plan should not be stored")
+	}
+
+	check, err := svc.Storage().Checks().Get(t.Context(), "octocat/hello-world", 1, "staging", "mysql", dbName)
+	require.NoError(t, err)
+	assert.Nil(t, check, "source-policy-blocked plan should not store a per-database check")
+
+	var aggregateCheck checkRunCapture
+	select {
+	case aggregateCheck = <-result.checkRuns:
+	case <-time.After(webhookIntegrationCheckRunDeadline):
+		t.Fatal("timed out waiting for source policy aggregate check run")
+	}
+	assert.Equal(t, aggregateCheckName, aggregateCheck.Name)
+	assert.Equal(t, checkStatusCompleted, aggregateCheck.Status)
+	assert.Equal(t, checkConclusionFailure, aggregateCheck.Conclusion)
+	require.NotNil(t, aggregateCheck.Output)
+	assert.Contains(t, aggregateCheck.Output.Summary, "source policy")
+
+	aggregate, err := svc.Storage().Checks().Get(t.Context(), "octocat/hello-world", 1, aggregateSentinel, aggregateSentinel, aggregateSentinel)
+	require.NoError(t, err)
+	require.NotNil(t, aggregate, "source-policy-blocked plan should store a failing aggregate check")
+	assert.Equal(t, "abc123", aggregate.HeadSHA)
+	assert.Equal(t, checkStatusCompleted, aggregate.Status)
+	assert.Equal(t, checkConclusionFailure, aggregate.Conclusion)
 }
 
 func TestE2EPlanNoChanges(t *testing.T) {
@@ -862,6 +945,80 @@ func TestE2EAutoPlan(t *testing.T) {
 		assert.Equal(t, "action_required", cr.Conclusion)
 	case <-time.After(10 * time.Second):
 		t.Fatal("timed out waiting for check run")
+	}
+}
+
+// TestE2EAutoPlanSourcePolicyBlocksWithFailingAggregate verifies auto-plan
+// source-policy failures create a failing aggregate Check Run for branch
+// protection instead of only posting a PR comment.
+func TestE2EAutoPlanSourcePolicyBlocksWithFailingAggregate(t *testing.T) {
+	dbName := "webhook_autoplan_source_policy_block"
+	svc := setupE2EService(t, dbName)
+	dbConfig := svc.Config().Databases[dbName]
+	dbConfig.AllowedRepos = []string{"octocat/orders"}
+	dbConfig.AllowedDirs = []string{"schema"}
+	svc.Config().Databases[dbName] = dbConfig
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	client := gh.NewClient(nil)
+	client.BaseURL, _ = url.Parse(server.URL + "/")
+
+	schemabotConfig := fmt.Sprintf("database: %s\ntype: mysql\n", dbName)
+	schemaFiles := map[string]string{
+		"users.sql": "CREATE TABLE `users` (\n  `id` bigint unsigned NOT NULL AUTO_INCREMENT,\n  `name` varchar(255) NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;",
+	}
+
+	result := setupFakeGitHubForPlan(t, mux, schemaFiles, schemabotConfig, dbName)
+
+	h := newE2EHandler(t, svc, client)
+
+	req := buildPRWebhookRequest(t, prWebhookPayloadOpts{
+		action:  "opened",
+		headSHA: "abc123",
+		headRef: "feature-branch",
+	}, nil)
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), "auto-plan started")
+
+	select {
+	case body := <-result.comments:
+		assert.Contains(t, body, "failed to plan")
+		assert.Contains(t, body, "source policy")
+		assert.Contains(t, body, "repo \"octocat/hello-world\" is not authorized")
+	case <-time.After(webhookIntegrationPollDeadline):
+		t.Fatal("timed out waiting for source policy auto-plan comment")
+	}
+
+	var aggregateCheck checkRunCapture
+	select {
+	case aggregateCheck = <-result.checkRuns:
+	case <-time.After(webhookIntegrationCheckRunDeadline):
+		t.Fatal("timed out waiting for source policy aggregate check run")
+	}
+	assert.Equal(t, aggregateCheckName, aggregateCheck.Name)
+	assert.Equal(t, "completed", aggregateCheck.Status)
+	assert.Equal(t, "failure", aggregateCheck.Conclusion)
+	require.NotNil(t, aggregateCheck.Output)
+	assert.Contains(t, aggregateCheck.Output.Summary, "source policy")
+
+	check, err := svc.Storage().Checks().Get(t.Context(), "octocat/hello-world", 1, aggregateSentinel, aggregateSentinel, aggregateSentinel)
+	require.NoError(t, err)
+	require.NotNil(t, check, "source-policy-blocked auto-plan should store a failing aggregate check")
+	assert.Equal(t, "abc123", check.HeadSHA)
+	assert.Equal(t, "completed", check.Status)
+	assert.Equal(t, "failure", check.Conclusion)
+
+	plans, err := svc.Storage().Plans().GetByPR(t.Context(), "octocat/hello-world", 1)
+	require.NoError(t, err)
+	for _, plan := range plans {
+		assert.NotEqual(t, dbName, plan.Database, "source-policy-blocked auto-plan should not store a plan")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add per-database source-policy config fields with validation for `allowed_repos` and `allowed_dirs`.
- Authorize SchemaBot-discovered GitHub PR schema sources at plan time and store repo, PR number, repo-relative `schema_path`, and server-side route metadata on plan rows.
- Re-check stored GitHub source metadata before apply when a plan has trusted `schema_path` metadata, and fail closed if the database config needed to evaluate that source is missing.
- Keep direct HTTP/CLI operator workflows working for now; those requests cannot set trusted `schema_path` through JSON and remain governed by endpoint access, such as kubectl port-forward access.
- Add explicit source-policy block logs and the `schemabot.source_policy.blocks_total` metric with normalized `operation` and `reason` attributes.

## Flow

```text
GitHub PR discovery
  -> webhook sets repo + PR + schema_path
  -> ExecutePlan verifies allowed_repos / allowed_dirs
  -> plan row stores source metadata + target route
  -> ExecuteApply re-checks stored source metadata
  -> Tern apply

Direct HTTP / CLI
  -> cannot set trusted schema_path through JSON
  -> plan/apply continues to work through existing endpoint access
  -> future OIDC/auth work can gate this path more explicitly
```

🤖 Generated by Codex.
