### PR TITLE
fix(grpc): fail missing remote apply progress

### DIFF
--- a/pkg/tern/grpc_client.go
+++ b/pkg/tern/grpc_client.go
@@ -107,8 +107,11 @@ import (
 	"time"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
 
+	"github.com/block/schemabot/pkg/metrics"
 	ternv1 "github.com/block/schemabot/pkg/proto/ternv1"
 	"github.com/block/schemabot/pkg/state"
 	"github.com/block/schemabot/pkg/storage"
@@ -408,6 +411,125 @@ func (c *GRPCClient) ResumeApply(ctx context.Context, apply *storage.Apply) erro
 	return nil
 }
 
+type remoteApplyTransitionSkipReason string
+
+const (
+	remoteApplyTransitionReady        remoteApplyTransitionSkipReason = ""
+	remoteApplyTransitionReloadFailed remoteApplyTransitionSkipReason = "reload_failed"
+	remoteApplyTransitionMissing      remoteApplyTransitionSkipReason = "apply_missing"
+	remoteApplyTransitionTerminal     remoteApplyTransitionSkipReason = "already_terminal"
+)
+
+func (c *GRPCClient) reloadRemoteApplyForTransition(ctx context.Context, apply *storage.Apply) (*storage.Apply, remoteApplyTransitionSkipReason, error) {
+	currentApply, err := c.storage.Applies().Get(ctx, apply.ID)
+	if err != nil {
+		return nil, remoteApplyTransitionReloadFailed, fmt.Errorf("reload remote gRPC apply %s: %w", apply.ApplyIdentifier, err)
+	}
+	if currentApply == nil {
+		return nil, remoteApplyTransitionMissing, nil
+	}
+	if state.IsTerminalApplyState(currentApply.State) {
+		*apply = *currentApply
+		return currentApply, remoteApplyTransitionTerminal, nil
+	}
+	return currentApply, remoteApplyTransitionReady, nil
+}
+
+func logSkippedRemoteApplyTransition(operation string, apply, currentApply *storage.Apply, reason remoteApplyTransitionSkipReason, err error) {
+	fields := []any{
+		"operation", operation,
+		"apply_id", apply.ApplyIdentifier,
+		"external_id", apply.ExternalID,
+		"reason", reason,
+	}
+	if currentApply != nil {
+		fields = append(fields, "state", currentApply.State)
+	}
+
+	switch reason {
+	case remoteApplyTransitionReloadFailed:
+		fields = append(fields, "error", err)
+		slog.Error("skipping remote gRPC apply state transition", fields...)
+	case remoteApplyTransitionMissing:
+		slog.Warn("skipping remote gRPC apply state transition", fields...)
+	case remoteApplyTransitionTerminal:
+		slog.Debug("skipping remote gRPC apply state transition", fields...)
+	default:
+		slog.Warn("skipping remote gRPC apply state transition", fields...)
+	}
+}
+
+func (c *GRPCClient) failApplyAfterRemoteProgressLoss(ctx context.Context, apply *storage.Apply, message string) {
+	currentApply, skipReason, err := c.reloadRemoteApplyForTransition(ctx, apply)
+	if skipReason != remoteApplyTransitionReady {
+		logSkippedRemoteApplyTransition("fail apply after remote progress loss", apply, currentApply, skipReason, err)
+		return
+	}
+
+	now := time.Now()
+	tasks, taskErr := c.storage.Tasks().GetByApplyID(ctx, currentApply.ID)
+	if taskErr != nil {
+		slog.Error("failed to load tasks after remote gRPC apply failed",
+			"apply_id", currentApply.ApplyIdentifier,
+			"external_id", currentApply.ExternalID,
+			"error", taskErr)
+	}
+	for _, task := range tasks {
+		if state.IsTerminalTaskState(task.State) {
+			continue
+		}
+		task.State = state.Task.Failed
+		task.ErrorMessage = message
+		task.CompletedAt = &now
+		task.UpdatedAt = now
+		if err := c.storage.Tasks().Update(ctx, task); err != nil {
+			slog.Error("failed to update task after remote gRPC apply failure",
+				"apply_id", currentApply.ApplyIdentifier,
+				"task_id", task.TaskIdentifier,
+				"error", err)
+		}
+	}
+
+	currentApply.State = state.Apply.Failed
+	currentApply.ErrorMessage = message
+	currentApply.CompletedAt = &now
+	currentApply.UpdatedAt = now
+	if err := c.storage.Applies().Update(ctx, currentApply); err != nil {
+		slog.Error("failed to update apply after remote gRPC apply failure",
+			"apply_id", currentApply.ApplyIdentifier,
+			"external_id", currentApply.ExternalID,
+			"error", err)
+		return
+	}
+	*apply = *currentApply
+	metrics.AdjustActiveApplies(ctx, -1, currentApply.Database, currentApply.Environment)
+}
+
+func (c *GRPCClient) persistRemoteTerminalApply(ctx context.Context, apply *storage.Apply, now time.Time) bool {
+	currentApply, skipReason, err := c.reloadRemoteApplyForTransition(ctx, apply)
+	if skipReason != remoteApplyTransitionReady {
+		logSkippedRemoteApplyTransition("persist remote terminal apply", apply, currentApply, skipReason, err)
+		return skipReason == remoteApplyTransitionMissing || skipReason == remoteApplyTransitionTerminal
+	}
+
+	currentApply.State = apply.State
+	currentApply.ErrorMessage = apply.ErrorMessage
+	currentApply.StartedAt = apply.StartedAt
+	currentApply.CompletedAt = &now
+	currentApply.UpdatedAt = now
+	if err := c.storage.Applies().Update(ctx, currentApply); err != nil {
+		slog.Error("failed to update terminal remote gRPC apply",
+			"apply_id", currentApply.ApplyIdentifier,
+			"external_id", currentApply.ExternalID,
+			"state", currentApply.State,
+			"error", err)
+		return false
+	}
+	*apply = *currentApply
+	metrics.AdjustActiveApplies(ctx, -1, currentApply.Database, currentApply.Environment)
+	return true
+}
+
 // pollForCompletion polls the remote Tern for progress and updates SchemaBot's storage.
 // Also maintains heartbeat to keep the lease on the apply.
 func (c *GRPCClient) pollForCompletion(ctx context.Context, apply *storage.Apply) {
@@ -432,7 +554,23 @@ func (c *GRPCClient) pollForCompletion(ctx context.Context, apply *storage.Apply
 				ApplyId:     apply.ExternalID,
 			})
 			if err != nil {
+				if status.Code(err) == codes.NotFound {
+					message := fmt.Sprintf("remote apply %s was not found by data plane", apply.ExternalID)
+					c.failApplyAfterRemoteProgressLoss(ctx, apply, message)
+					return
+				}
+				slog.Warn("remote gRPC progress poll failed",
+					"apply_id", apply.ApplyIdentifier,
+					"external_id", apply.ExternalID,
+					"database", apply.Database,
+					"environment", apply.Environment,
+					"error", err)
 				continue
+			}
+			if resp.State == ternv1.State_STATE_NO_ACTIVE_CHANGE {
+				message := fmt.Sprintf("remote apply %s returned no active schema change for exact apply_id", apply.ExternalID)
+				c.failApplyAfterRemoteProgressLoss(ctx, apply, message)
+				return
 			}
 
 			// Update apply state based on response (skip if proto state is unspecified)
@@ -467,11 +605,17 @@ func (c *GRPCClient) pollForCompletion(ctx context.Context, apply *storage.Apply
 
 			terminal := isTerminalProtoState(resp.State)
 			if terminal {
-				apply.CompletedAt = &now
+				if c.persistRemoteTerminalApply(ctx, apply, now) {
+					return
+				}
+				continue
 			}
-			_ = c.storage.Applies().Update(ctx, apply)
-			if terminal {
-				return
+			if err := c.storage.Applies().Update(ctx, apply); err != nil {
+				slog.Error("failed to update remote gRPC apply progress",
+					"apply_id", apply.ApplyIdentifier,
+					"external_id", apply.ExternalID,
+					"state", apply.State,
+					"error", err)
 			}
 		}
 	}

--- a/pkg/tern/grpc_client_test.go
+++ b/pkg/tern/grpc_client_test.go
@@ -327,14 +327,17 @@ func TestGRPCClient_Close(t *testing.T) {
 }
 
 // capturingTernServer records the apply_id from Start and Progress requests.
-// progressState controls what Progress returns (defaults to STATE_COMPLETED).
+// progressState is returned only when progressStateSet is true; otherwise the
+// server defaults to STATE_COMPLETED.
 type capturingTernServer struct {
 	ternv1.UnimplementedTernServer
-	mu              sync.Mutex
-	startApplyID    string
-	progressApplyID string
-	progressState   ternv1.State // state returned by Progress; 0 = STATE_COMPLETED
-	startCalled     bool         // tracks whether Start was actually invoked
+	mu               sync.Mutex
+	startApplyID     string
+	progressApplyID  string
+	progressState    ternv1.State // state returned by Progress; 0 = STATE_COMPLETED
+	progressStateSet bool
+	progressErr      error
+	startCalled      bool // tracks whether Start was actually invoked
 }
 
 func (s *capturingTernServer) Start(_ context.Context, req *ternv1.StartRequest) (*ternv1.StartResponse, error) {
@@ -351,8 +354,13 @@ func (s *capturingTernServer) Progress(_ context.Context, req *ternv1.ProgressRe
 	s.mu.Lock()
 	s.progressApplyID = req.ApplyId
 	ps := s.progressState
+	psSet := s.progressStateSet
+	err := s.progressErr
 	s.mu.Unlock()
-	if ps == 0 {
+	if err != nil {
+		return nil, err
+	}
+	if !psSet {
 		ps = ternv1.State_STATE_COMPLETED
 	}
 	return &ternv1.ProgressResponse{State: ps}, nil
@@ -371,30 +379,84 @@ func (s *capturingTernServer) getProgressApplyID() string {
 }
 
 // mockApplyStore is a minimal ApplyStore for testing ResumeApply.
-type mockApplyStore struct{ storage.ApplyStore }
-
-func (m *mockApplyStore) Update(context.Context, *storage.Apply) error { return nil }
-func (m *mockApplyStore) Heartbeat(context.Context, int64) error       { return nil }
-
-// mockTaskStore is a minimal TaskStore for testing pollForCompletion.
-type mockTaskStore struct{ storage.TaskStore }
-
-func (m *mockTaskStore) GetByApplyID(context.Context, int64) ([]*storage.Task, error) {
-	return nil, nil
+type mockApplyStore struct {
+	storage.ApplyStore
+	apply *storage.Apply
 }
 
-// mockStorage wires together the mock stores.
-type mockStorage struct{ storage.Storage }
+func (m *mockApplyStore) Get(context.Context, int64) (*storage.Apply, error) {
+	return m.apply, nil
+}
+func (m *mockApplyStore) Update(_ context.Context, apply *storage.Apply) error {
+	m.apply = apply
+	return nil
+}
+func (m *mockApplyStore) Heartbeat(context.Context, int64) error { return nil }
 
-func (m *mockStorage) Applies() storage.ApplyStore { return &mockApplyStore{} }
-func (m *mockStorage) Tasks() storage.TaskStore    { return &mockTaskStore{} }
+// mockTaskStore is a minimal TaskStore for testing pollForCompletion.
+type mockTaskStore struct {
+	storage.TaskStore
+	tasks []*storage.Task
+}
+
+func (m *mockTaskStore) GetByApplyID(context.Context, int64) ([]*storage.Task, error) {
+	return m.tasks, nil
+}
+func (m *mockTaskStore) Update(context.Context, *storage.Task) error { return nil }
+
+// mockStorage wires together the mock stores.
+type mockStorage struct {
+	storage.Storage
+	applies *mockApplyStore
+	tasks   *mockTaskStore
+}
+
+func (m *mockStorage) Applies() storage.ApplyStore {
+	if m.applies != nil {
+		return m.applies
+	}
+	return &mockApplyStore{}
+}
+func (m *mockStorage) Tasks() storage.TaskStore {
+	if m.tasks != nil {
+		return m.tasks
+	}
+	return &mockTaskStore{}
+}
+
+func testCapturingGRPCClient(t *testing.T, server *capturingTernServer) (*GRPCClient, func()) {
+	t.Helper()
+
+	lis, err := (&net.ListenConfig{}).Listen(t.Context(), "tcp", "localhost:0")
+	require.NoError(t, err, "failed to listen")
+
+	grpcServer := grpc.NewServer()
+	ternv1.RegisterTernServer(grpcServer, server)
+	go func() { _ = grpcServer.Serve(lis) }()
+
+	conn, err := grpc.NewClient(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err, "failed to dial")
+
+	client := &GRPCClient{
+		conn:    conn,
+		client:  ternv1.NewTernClient(conn),
+		storage: &mockStorage{},
+	}
+	cleanup := func() {
+		utils.CloseAndLog(client)
+		grpcServer.Stop()
+		utils.CloseAndLog(lis)
+	}
+	return client, cleanup
+}
 
 func TestGRPCClient_ResumeApply_ThreadsExternalID(t *testing.T) {
 	// Progress returns STOPPED initially so ResumeApply checks remote state,
 	// confirms the apply is stopped, and calls Start. After Start, the mock
 	// transitions to COMPLETED so the poller exits.
 	server := &capturingTernServer{
-		progressState: ternv1.State_STATE_STOPPED,
+		progressState:    ternv1.State_STATE_STOPPED,
+		progressStateSet: true,
 	}
 
 	// Start a test gRPC server
@@ -452,7 +514,8 @@ func TestGRPCClient_ResumeApply_SkipsStartWhenNotStopped(t *testing.T) {
 	// Progress returns COMPLETED — Tern already finished the apply even though
 	// local state says "stopped". Start should NOT be called.
 	server := &capturingTernServer{
-		progressState: ternv1.State_STATE_COMPLETED,
+		progressState:    ternv1.State_STATE_COMPLETED,
+		progressStateSet: true,
 	}
 
 	lis, err := (&net.ListenConfig{}).Listen(t.Context(), "tcp", "localhost:0")
@@ -493,6 +556,128 @@ func TestGRPCClient_ResumeApply_SkipsStartWhenNotStopped(t *testing.T) {
 	// State should have been updated from Tern's response.
 	assert.Equal(t, state.Apply.Completed, apply.State,
 		"apply state should reflect Tern's real state")
+}
+
+func TestGRPCClient_PollFailsWhenRemoteApplyIsNotFound(t *testing.T) {
+	// A known remote apply ID returning NotFound means the data plane can no
+	// longer report progress for work the control plane believes exists. The
+	// local apply fails so workers do not keep polling a stale remote ID.
+	client, cleanup := testCapturingGRPCClient(t, &capturingTernServer{
+		progressErr: status.Error(codes.NotFound, "apply not found"),
+	})
+	defer cleanup()
+
+	task := &storage.Task{
+		ID:             11,
+		TaskIdentifier: "task-missing-remote",
+		State:          state.Task.Running,
+	}
+	apply := &storage.Apply{
+		ID:              1,
+		ApplyIdentifier: "apply-control-plane",
+		Database:        "testdb",
+		Environment:     "development",
+		ExternalID:      "remote-not-found",
+		State:           state.Apply.Running,
+	}
+	client.storage = &mockStorage{
+		applies: &mockApplyStore{apply: apply},
+		tasks:   &mockTaskStore{tasks: []*storage.Task{task}},
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+	client.pollForCompletion(ctx, apply)
+
+	assert.Equal(t, state.Apply.Failed, apply.State)
+	assert.Contains(t, apply.ErrorMessage, "remote-not-found")
+	assert.NotNil(t, apply.CompletedAt)
+	assert.Equal(t, state.Task.Failed, task.State)
+	assert.Contains(t, task.ErrorMessage, "remote-not-found")
+	assert.NotNil(t, task.CompletedAt)
+}
+
+func TestGRPCClient_PollFailsWhenExactRemoteApplyHasNoActiveProgress(t *testing.T) {
+	// STATE_NO_ACTIVE_CHANGE is only valid for database-scoped discovery. An
+	// exact apply-id progress request returning no active work is inconsistent
+	// cross-plane state and should fail the local apply.
+	client, cleanup := testCapturingGRPCClient(t, &capturingTernServer{
+		progressState:    ternv1.State_STATE_NO_ACTIVE_CHANGE,
+		progressStateSet: true,
+	})
+	defer cleanup()
+
+	task := &storage.Task{
+		ID:             12,
+		TaskIdentifier: "task-no-active",
+		State:          state.Task.Running,
+	}
+	apply := &storage.Apply{
+		ID:              2,
+		ApplyIdentifier: "apply-no-active",
+		Database:        "testdb",
+		Environment:     "development",
+		ExternalID:      "remote-no-active",
+		State:           state.Apply.Running,
+	}
+	client.storage = &mockStorage{
+		applies: &mockApplyStore{apply: apply},
+		tasks:   &mockTaskStore{tasks: []*storage.Task{task}},
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+	client.pollForCompletion(ctx, apply)
+
+	assert.Equal(t, state.Apply.Failed, apply.State)
+	assert.Contains(t, apply.ErrorMessage, "no active schema change")
+	assert.NotNil(t, apply.CompletedAt)
+	assert.Equal(t, state.Task.Failed, task.State)
+	assert.Contains(t, task.ErrorMessage, "no active schema change")
+	assert.NotNil(t, task.CompletedAt)
+}
+
+func TestGRPCClient_RemoteProgressLossDoesNotOverwriteTerminalApply(t *testing.T) {
+	// Remote progress loss can fail the local apply only while the durable
+	// control-plane row is still non-terminal. If storage already has a terminal
+	// state, preserve it instead of overwriting it with a stale remote lookup
+	// failure.
+	client, cleanup := testCapturingGRPCClient(t, &capturingTernServer{
+		progressErr: status.Error(codes.NotFound, "apply not found"),
+	})
+	defer cleanup()
+
+	storedApply := &storage.Apply{
+		ID:              3,
+		ApplyIdentifier: "apply-already-complete",
+		Database:        "testdb",
+		Environment:     "development",
+		ExternalID:      "remote-already-complete",
+		State:           state.Apply.Completed,
+	}
+	client.storage = &mockStorage{
+		applies: &mockApplyStore{apply: storedApply},
+		tasks: &mockTaskStore{tasks: []*storage.Task{{
+			ID:             13,
+			TaskIdentifier: "task-already-complete",
+			State:          state.Task.Completed,
+		}}},
+	}
+	apply := &storage.Apply{
+		ID:              3,
+		ApplyIdentifier: "apply-already-complete",
+		Database:        "testdb",
+		Environment:     "development",
+		ExternalID:      "remote-already-complete",
+		State:           state.Apply.Running,
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+	client.pollForCompletion(ctx, apply)
+
+	assert.Equal(t, state.Apply.Completed, apply.State)
+	assert.Empty(t, apply.ErrorMessage)
 }
 
 func TestNewGRPCClient(t *testing.T) {

--- a/pkg/tern/local_client.go
+++ b/pkg/tern/local_client.go
@@ -651,11 +651,15 @@ func (c *LocalClient) Progress(ctx context.Context, req *ternv1.ProgressRequest)
 		if lookupErr != nil {
 			return nil, fmt.Errorf("get apply %s: %w", req.ApplyId, lookupErr)
 		}
-		if apply != nil {
-			tasks, err = c.storage.Tasks().GetByApplyID(ctx, apply.ID)
-			if err != nil {
-				return nil, fmt.Errorf("get tasks for apply %s: %w", req.ApplyId, err)
-			}
+		if apply == nil {
+			return nil, fmt.Errorf("get apply %s: %w", req.ApplyId, storage.ErrApplyNotFound)
+		}
+		tasks, err = c.storage.Tasks().GetByApplyID(ctx, apply.ID)
+		if err != nil {
+			return nil, fmt.Errorf("get tasks for apply %s: %w", req.ApplyId, err)
+		}
+		if len(tasks) == 0 {
+			return nil, fmt.Errorf("get tasks for apply %s: %w", req.ApplyId, storage.ErrTaskNotFound)
 		}
 	} else {
 		// Fall back to database lookup — this means the caller didn't provide

--- a/pkg/tern/local_client_test.go
+++ b/pkg/tern/local_client_test.go
@@ -1,6 +1,7 @@
 package tern
 
 import (
+	"context"
 	"log/slog"
 	"testing"
 
@@ -9,6 +10,35 @@ import (
 	ternv1 "github.com/block/schemabot/pkg/proto/ternv1"
 	"github.com/block/schemabot/pkg/storage"
 )
+
+type exactProgressApplyStore struct {
+	storage.ApplyStore
+	apply *storage.Apply
+	err   error
+}
+
+func (s *exactProgressApplyStore) GetByApplyIdentifier(context.Context, string) (*storage.Apply, error) {
+	return s.apply, s.err
+}
+
+type exactProgressTaskStore struct {
+	storage.TaskStore
+	tasks []*storage.Task
+	err   error
+}
+
+func (s *exactProgressTaskStore) GetByApplyID(context.Context, int64) ([]*storage.Task, error) {
+	return s.tasks, s.err
+}
+
+type exactProgressStorage struct {
+	storage.Storage
+	applies storage.ApplyStore
+	tasks   storage.TaskStore
+}
+
+func (s *exactProgressStorage) Applies() storage.ApplyStore { return s.applies }
+func (s *exactProgressStorage) Tasks() storage.TaskStore    { return s.tasks }
 
 func TestLocalClient_Apply_RequiresEnvironmentField(t *testing.T) {
 	client, err := NewLocalClient(LocalConfig{
@@ -22,4 +52,38 @@ func TestLocalClient_Apply_RequiresEnvironmentField(t *testing.T) {
 		Options: map[string]string{"environment": "development"},
 	})
 	require.ErrorContains(t, err, "environment is required")
+}
+
+func TestLocalClient_ProgressByApplyIDReturnsNotFoundForMissingApplyData(t *testing.T) {
+	testCases := []struct {
+		name      string
+		apply     *storage.Apply
+		tasks     []*storage.Task
+		wantError error
+	}{
+		{
+			name:      "missing apply",
+			wantError: storage.ErrApplyNotFound,
+		},
+		{
+			name:      "missing tasks",
+			apply:     &storage.Apply{ID: 42, ApplyIdentifier: "apply-missing-tasks"},
+			wantError: storage.ErrTaskNotFound,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			client := &LocalClient{
+				storage: &exactProgressStorage{
+					applies: &exactProgressApplyStore{apply: tc.apply},
+					tasks:   &exactProgressTaskStore{tasks: tc.tasks},
+				},
+				logger: slog.Default(),
+			}
+
+			_, err := client.Progress(t.Context(), &ternv1.ProgressRequest{ApplyId: "apply-missing"})
+			require.ErrorIs(t, err, tc.wantError)
+		})
+	}
 }

--- a/pkg/tern/server.go
+++ b/pkg/tern/server.go
@@ -2,12 +2,14 @@ package tern
 
 import (
 	"context"
+	"errors"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
 	ternv1 "github.com/block/schemabot/pkg/proto/ternv1"
+	"github.com/block/schemabot/pkg/storage"
 )
 
 // Server wraps a Client as a gRPC TernServer.
@@ -54,6 +56,9 @@ func (s *Server) Apply(ctx context.Context, req *ternv1.ApplyRequest) (*ternv1.A
 func (s *Server) Progress(ctx context.Context, req *ternv1.ProgressRequest) (*ternv1.ProgressResponse, error) {
 	resp, err := s.client.Progress(ctx, req)
 	if err != nil {
+		if errors.Is(err, storage.ErrApplyNotFound) || errors.Is(err, storage.ErrTaskNotFound) {
+			return nil, status.Error(codes.NotFound, err.Error())
+		}
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 	return resp, nil

--- a/pkg/tern/server_test.go
+++ b/pkg/tern/server_test.go
@@ -1,0 +1,50 @@
+package tern
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	ternv1 "github.com/block/schemabot/pkg/proto/ternv1"
+	"github.com/block/schemabot/pkg/storage"
+)
+
+type progressErrorClient struct {
+	Client
+	err error
+}
+
+func (c progressErrorClient) Progress(context.Context, *ternv1.ProgressRequest) (*ternv1.ProgressResponse, error) {
+	return nil, c.err
+}
+
+func TestServerProgressMapsMissingApplyDataToNotFound(t *testing.T) {
+	testCases := []struct {
+		name string
+		err  error
+	}{
+		{
+			name: "missing apply",
+			err:  fmt.Errorf("get apply missing: %w", storage.ErrApplyNotFound),
+		},
+		{
+			name: "missing tasks",
+			err:  fmt.Errorf("get tasks for apply missing: %w", storage.ErrTaskNotFound),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			server := NewServer(progressErrorClient{err: tc.err})
+
+			_, err := server.Progress(t.Context(), &ternv1.ProgressRequest{ApplyId: "missing"})
+			require.Error(t, err)
+			assert.Equal(t, codes.NotFound, status.Code(err))
+		})
+	}
+}


### PR DESCRIPTION
## Summary

This makes exact apply-id progress in gRPC mode fail closed when control-plane storage points at a remote apply that the data plane can no longer report.

```text
Control plane apply
  apply_id=apply-123
  external_id=remote-456
        |
        | Progress(apply_id=remote-456)
        v
Data plane Tern
  missing apply/tasks -> gRPC NotFound
        |
        v
Control plane poller
  reload durable apply row
  if still active: mark failed and stop polling
  if already terminal: preserve stored terminal state
```

The PR also makes exact apply-id progress return explicit missing-data errors on the data plane, maps those errors to gRPC NotFound, and decrements active-apply metrics only after a terminal transition is successfully stored.

🤖 Generated by Codex.