### PR TITLE
fix(github): re-evaluate checks gate against fresh HEAD on apply -y

### DIFF
--- a/pkg/webhook/apply_e2e_test.go
+++ b/pkg/webhook/apply_e2e_test.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1554,6 +1555,109 @@ func TestE2EPlanRejectsWhenHEADAdvanced(t *testing.T) {
 		assert.NotContains(t, body, "Schema Change Plan", "stale plan comment must not be posted")
 	case <-time.After(30 * time.Second):
 		t.Fatal("timed out waiting for rejection comment")
+	}
+}
+
+// TestE2EApplyAutoConfirmReGatesAgainstFreshHEADBeforeApply verifies that the
+// `apply -y` auto-confirm branch re-evaluates the PR checks gate against the
+// fresh HEAD immediately before executeApply, even when the HEAD has not
+// moved (so the schema-freshness check passes). This catches the case where
+// a required check transitioned to failing on the same SHA — e.g. CI re-ran
+// red, or a new required check was added — between the discovery-time early
+// gate and the apply itself.
+func TestE2EApplyAutoConfirmReGatesAgainstFreshHEADBeforeApply(t *testing.T) {
+	dbName := "webhook_auto_confirm_regate"
+	svc := setupE2EService(t, dbName)
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	client := gh.NewClient(nil)
+	client.BaseURL, _ = url.Parse(server.URL + "/")
+
+	schemabotConfig := fmt.Sprintf("database: %s\ntype: mysql\n", dbName)
+	schemaFiles := map[string]string{
+		"users.sql": "CREATE TABLE `users` (\n  `id` bigint unsigned NOT NULL AUTO_INCREMENT,\n  `name` varchar(255) NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;",
+	}
+
+	result := setupFakeGitHubForPlan(t, mux, schemaFiles, schemabotConfig, dbName)
+	// HEAD does not advance — both /pulls/1 calls return abc123 (default).
+	// The schema-freshness check therefore passes; the re-gate is the only
+	// thing that can still block the apply.
+
+	// GraphQL handler: PASS on the early gate call, FAIL on the fresh-HEAD
+	// re-gate call. Without the re-gate, this transition would be invisible
+	// to `apply -y` and the apply would proceed against red CI.
+	var graphqlCalls atomic.Int64
+	passing := rollupGraphQLHandler(nil)
+	failing := rollupGraphQLHandler([]rollupNode{
+		{
+			Typename:   "CheckRun",
+			Name:       "ci/lint",
+			Status:     "COMPLETED",
+			Conclusion: "FAILURE",
+			AppSlug:    "ci-bot",
+		},
+	})
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if graphqlCalls.Add(1) == 1 {
+			passing(w, r)
+			return
+		}
+		failing(w, r)
+	})
+	result.GraphQLHandler.Store(&handler)
+
+	h := newE2EHandler(t, svc, client)
+
+	req := buildWebhookRequest(t, webhookPayloadOpts{
+		comment: "schemabot apply -e staging -y",
+		isPR:    true,
+	}, nil)
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	// Expect a "Apply Blocked … checks failing" comment from the re-gate.
+	// Drain comments looking for the blocking message; fail if anything
+	// indicates the apply started.
+	deadline := time.After(30 * time.Second)
+	var blocked string
+	for blocked == "" {
+		select {
+		case body := <-result.comments:
+			assert.NotContains(t, body, "Schema Change In Progress", "apply must not have started")
+			assert.NotContains(t, body, "Schema Change Applied", "apply must not have completed")
+			if strings.Contains(body, "Apply Blocked") && strings.Contains(body, "ci/lint") {
+				blocked = body
+			}
+		case <-deadline:
+			t.Fatal("timed out waiting for fresh-HEAD checks-gate block comment")
+		}
+	}
+
+	assert.Contains(t, blocked, "failure", "block comment must show the failing conclusion")
+	assert.Contains(t, blocked, "staging", "retry hint must reference the env")
+
+	// Re-gate must have actually happened — at least two GraphQL calls
+	// (early gate + re-gate). The singleflight does not memoise across
+	// sequential calls so the second call hits the mock.
+	assert.GreaterOrEqual(t, graphqlCalls.Load(), int64(2),
+		"expected at least 2 GraphQL calls (early gate + fresh-HEAD re-gate)")
+
+	// Lock must be released so the user can re-run `apply -y` once checks recover.
+	require.Eventually(t, func() bool {
+		lock, err := svc.Storage().Locks().Get(t.Context(), dbName, "mysql")
+		return err == nil && lock == nil
+	}, 5*time.Second, 50*time.Millisecond, "lock must be released after fresh-HEAD checks-gate block")
+
+	// No apply record — executeApply must not have been reached.
+	applies, err := svc.Storage().Applies().GetByPR(t.Context(), "octocat/hello-world", 1)
+	require.NoError(t, err)
+	for _, a := range applies {
+		assert.NotEqual(t, dbName, a.Database, "no apply for %s should have been started", dbName)
 	}
 }
 

--- a/pkg/webhook/apply_e2e_test.go
+++ b/pkg/webhook/apply_e2e_test.go
@@ -1661,6 +1661,109 @@ func TestE2EApplyAutoConfirmReGatesAgainstFreshHEADBeforeApply(t *testing.T) {
 	}
 }
 
+// TestE2EApplyAutoConfirmFreshHEADBlockPreservesOtherPRLock verifies that when
+// the fresh-HEAD checks gate blocks `apply -y` and the per-target lock has
+// changed owner to a different PR between acquisition and the block, the
+// owner-scoped Release leaves the other PR's lock intact. ForceRelease here
+// would inadvertently clear that lock and remove the concurrency safety gate.
+func TestE2EApplyAutoConfirmFreshHEADBlockPreservesOtherPRLock(t *testing.T) {
+	dbName := "webhook_auto_confirm_regate_otherlock"
+	svc := setupE2EService(t, dbName)
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	client := gh.NewClient(nil)
+	client.BaseURL, _ = url.Parse(server.URL + "/")
+
+	schemabotConfig := fmt.Sprintf("database: %s\ntype: mysql\n", dbName)
+	schemaFiles := map[string]string{
+		"users.sql": "CREATE TABLE `users` (\n  `id` bigint unsigned NOT NULL AUTO_INCREMENT,\n  `name` varchar(255) NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;",
+	}
+
+	result := setupFakeGitHubForPlan(t, mux, schemaFiles, schemabotConfig, dbName)
+	// HEAD does not advance — schema-freshness check passes; the re-gate is
+	// the only thing that can still block.
+
+	otherOwner := "octocat/hello-world#999"
+	t.Cleanup(func() {
+		_ = svc.Storage().Locks().ForceRelease(context.WithoutCancel(t.Context()), dbName, "mysql")
+	})
+
+	// GraphQL handler: PASS on the early gate call; on the re-gate call,
+	// FIRST swap the lock owner to a different PR (#999), THEN return FAILURE.
+	// The swap simulates an unrelated `schemabot unlock` + another PR
+	// acquiring the lock in the window between our acquire and our re-gate.
+	var graphqlCalls atomic.Int64
+	passing := rollupGraphQLHandler(nil)
+	failing := rollupGraphQLHandler([]rollupNode{
+		{
+			Typename:   "CheckRun",
+			Name:       "ci/lint",
+			Status:     "COMPLETED",
+			Conclusion: "FAILURE",
+			AppSlug:    "ci-bot",
+		},
+	})
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if graphqlCalls.Add(1) == 1 {
+			passing(w, r)
+			return
+		}
+		// Re-gate call: swap the lock to PR #999 before responding FAILURE.
+		// ForceRelease then re-Acquire is the closest analogue to "another
+		// caller cleared and reacquired" within a single test process.
+		_ = svc.Storage().Locks().ForceRelease(r.Context(), dbName, "mysql")
+		_ = svc.Storage().Locks().Acquire(r.Context(), &storage.Lock{
+			DatabaseName: dbName,
+			DatabaseType: "mysql",
+			Repository:   "octocat/hello-world",
+			PullRequest:  999,
+			Owner:        otherOwner,
+		})
+		failing(w, r)
+	})
+	result.GraphQLHandler.Store(&handler)
+
+	h := newE2EHandler(t, svc, client)
+
+	req := buildWebhookRequest(t, webhookPayloadOpts{
+		comment: "schemabot apply -e staging -y",
+		isPR:    true,
+	}, nil)
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	// Drain comments until the blocking message lands; fail if the apply started.
+	deadline := time.After(30 * time.Second)
+	var blocked string
+	for blocked == "" {
+		select {
+		case body := <-result.comments:
+			assert.NotContains(t, body, "Schema Change In Progress", "apply must not have started")
+			assert.NotContains(t, body, "Schema Change Applied", "apply must not have completed")
+			if strings.Contains(body, "Apply Blocked") && strings.Contains(body, "ci/lint") {
+				blocked = body
+			}
+		case <-deadline:
+			t.Fatal("timed out waiting for fresh-HEAD checks-gate block comment")
+		}
+	}
+
+	// The other PR's lock must remain intact through the full polling window —
+	// long enough for the gate-block path's owner-scoped Release attempt to
+	// land (and silently no-op as ErrLockNotOwned) before t.Cleanup tears
+	// down. require.Never both asserts the lock is preserved and synchronises
+	// with the async handler so we don't race shutdown.
+	require.Never(t, func() bool {
+		lock, err := svc.Storage().Locks().Get(t.Context(), dbName, "mysql")
+		return err != nil || lock == nil || lock.Owner != otherOwner
+	}, 1*time.Second, 50*time.Millisecond, "other PR's lock must remain intact after fresh-HEAD gate block on PR #1")
+}
+
 // TestE2EApplyThreeEnvEnforcement verifies that checkPriorEnvironments checks ALL
 // prior environments, not just the immediately previous one. Uses 3 environments
 // (sandbox → staging → production) and calls checkPriorEnvironments directly

--- a/pkg/webhook/apply_handlers.go
+++ b/pkg/webhook/apply_handlers.go
@@ -132,9 +132,15 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 			}
 		}
 
-		// Stale lock from this PR (no active applies) — release it so we can re-plan
-		if err := h.service.Storage().Locks().ForceRelease(ctx, database, dbType); err != nil {
-			h.logger.Error("failed to release stale lock", "error", err)
+		// Stale lock from this PR (no active applies) — release it so we can re-plan.
+		// Use owner-scoped Release: ownership can change between the Get above
+		// and this Release (e.g. an unrelated `schemabot unlock` clears the lock
+		// and another PR acquires it). ErrLockNotFound / ErrLockNotOwned are
+		// expected and silently no-op'd — the loop below will reacquire if free.
+		relErr := h.service.Storage().Locks().Release(ctx, database, dbType, lockOwner)
+		if relErr != nil && !errors.Is(relErr, storage.ErrLockNotFound) && !errors.Is(relErr, storage.ErrLockNotOwned) {
+			h.logger.Error("failed to release stale lock",
+				"repo", repo, "pr", pr, "database", database, "database_type", dbType, "error", relErr)
 		}
 	}
 
@@ -224,14 +230,16 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 				CommandName: action.Apply,
 				ErrorDetail: "Failed to verify PR HEAD before auto-confirm: " + prErr.Error(),
 			}))
-			if relErr := h.service.Storage().Locks().ForceRelease(ctx, database, dbType); relErr != nil {
+			relErr := h.service.Storage().Locks().Release(ctx, database, dbType, lockOwner)
+			if relErr != nil && !errors.Is(relErr, storage.ErrLockNotFound) && !errors.Is(relErr, storage.ErrLockNotOwned) {
 				h.logger.Error("failed to release lock after PR fetch failure",
 					"repo", repo, "pr", pr, "database", database, "database_type", dbType, "error", relErr)
 			}
 			return
 		}
 		if rejected := h.assertSchemaStillCurrent(ctx, repo, pr, installationID, schemaResult, prInfo.HeadSHA, environment, requestedBy, action.Apply); rejected {
-			if relErr := h.service.Storage().Locks().ForceRelease(ctx, database, dbType); relErr != nil {
+			relErr := h.service.Storage().Locks().Release(ctx, database, dbType, lockOwner)
+			if relErr != nil && !errors.Is(relErr, storage.ErrLockNotFound) && !errors.Is(relErr, storage.ErrLockNotOwned) {
 				h.logger.Error("failed to release lock after stale-schema rejection",
 					"repo", repo, "pr", pr, "database", database, "database_type", dbType, "error", relErr)
 			}
@@ -246,8 +254,17 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 		// new required check was added) would otherwise sneak past. Release
 		// the lock on block so the user can re-run `schemabot apply -e <env>`
 		// once the checks recover, without a manual unlock.
+		//
+		// Use owner-scoped Release rather than ForceRelease: although this
+		// handler invocation acquired the lock earlier, ownership can change
+		// between acquisition and this point (e.g. `schemabot unlock` clears
+		// the lock and another PR acquires it). Release deletes only when
+		// owner matches; ErrLockNotFound / ErrLockNotOwned are expected here
+		// (lock may be absent or now held by another PR) and are not logged
+		// as errors.
 		if blocked := h.enforcePassingChecks(ctx, client, repo, pr, installationID, prInfo.HeadSHA, environment); blocked {
-			if relErr := h.service.Storage().Locks().ForceRelease(ctx, database, dbType); relErr != nil {
+			relErr := h.service.Storage().Locks().Release(ctx, database, dbType, lockOwner)
+			if relErr != nil && !errors.Is(relErr, storage.ErrLockNotFound) && !errors.Is(relErr, storage.ErrLockNotOwned) {
 				h.logger.Error("failed to release lock after fresh-HEAD checks gate block",
 					"repo", repo, "pr", pr, "database", database, "database_type", dbType, "error", relErr)
 			}
@@ -296,8 +313,9 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 	// the plan the user reviewed was rendered for the old commit. Catching
 	// it here is the symmetric guard to the auto-confirm branch above.
 	// Use FetchPullRequestNoCache; the cached fetch returns the discovery
-	// SHA. The lock was acquired by this handler invocation, so ForceRelease
-	// is safe.
+	// SHA. Release the lock with owner-scoped Release so a concurrent
+	// `schemabot unlock` + re-acquire by another PR doesn't get its lock
+	// clobbered here; ErrLockNotFound / ErrLockNotOwned are expected.
 	prInfo, prErr := client.FetchPullRequestNoCache(ctx, repo, pr)
 	if prErr != nil {
 		h.logger.Error("failed to fetch PR for stale-schema check, releasing lock",
@@ -308,14 +326,16 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 			CommandName: action.Apply,
 			ErrorDetail: "Failed to verify PR HEAD before posting plan: " + prErr.Error(),
 		}))
-		if relErr := h.service.Storage().Locks().ForceRelease(ctx, database, dbType); relErr != nil {
+		relErr := h.service.Storage().Locks().Release(ctx, database, dbType, lockOwner)
+		if relErr != nil && !errors.Is(relErr, storage.ErrLockNotFound) && !errors.Is(relErr, storage.ErrLockNotOwned) {
 			h.logger.Error("failed to release lock after PR fetch failure",
 				"repo", repo, "pr", pr, "database", database, "database_type", dbType, "error", relErr)
 		}
 		return
 	}
 	if rejected := h.assertSchemaStillCurrent(ctx, repo, pr, installationID, schemaResult, prInfo.HeadSHA, environment, requestedBy, action.Apply); rejected {
-		if relErr := h.service.Storage().Locks().ForceRelease(ctx, database, dbType); relErr != nil {
+		relErr := h.service.Storage().Locks().Release(ctx, database, dbType, lockOwner)
+		if relErr != nil && !errors.Is(relErr, storage.ErrLockNotFound) && !errors.Is(relErr, storage.ErrLockNotOwned) {
 			h.logger.Error("failed to release lock after stale-schema rejection",
 				"repo", repo, "pr", pr, "database", database, "database_type", dbType, "error", relErr)
 		}
@@ -480,9 +500,16 @@ func (h *Handler) executeApply(
 		return
 	}
 
-	// No changes — release lock and notify
+	// No changes — release lock and notify. Use owner-scoped Release so we
+	// can't clobber a lock that has changed ownership since this handler
+	// acquired it; ErrLockNotFound / ErrLockNotOwned are expected.
 	if len(planResp.FlatTables()) == 0 {
-		_ = h.service.Storage().Locks().ForceRelease(ctx, database, dbType)
+		lockOwner := fmt.Sprintf("%s#%d", repo, pr)
+		relErr := h.service.Storage().Locks().Release(ctx, database, dbType, lockOwner)
+		if relErr != nil && !errors.Is(relErr, storage.ErrLockNotFound) && !errors.Is(relErr, storage.ErrLockNotOwned) {
+			h.logger.Error("failed to release lock after no-changes confirm",
+				"repo", repo, "pr", pr, "database", database, "database_type", dbType, "error", relErr)
+		}
 		h.postComment(repo, pr, installationID, templates.RenderApplyConfirmNoChanges(database, environment))
 		return
 	}

--- a/pkg/webhook/apply_handlers.go
+++ b/pkg/webhook/apply_handlers.go
@@ -238,6 +238,22 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 			return
 		}
 
+		// Re-evaluate the checks gate against the fresh HEAD before executing.
+		// The early gate at the top of handleApplyCommand ran against the
+		// discovery-time HeadSHA. On the auto-confirm path there is no second
+		// user action between plan and apply, so a required check that
+		// transitioned to failing on the same SHA (e.g. CI re-ran red, or a
+		// new required check was added) would otherwise sneak past. Release
+		// the lock on block so the user can re-run `schemabot apply -e <env>`
+		// once the checks recover, without a manual unlock.
+		if blocked := h.enforcePassingChecks(ctx, client, repo, pr, installationID, prInfo.HeadSHA, environment); blocked {
+			if relErr := h.service.Storage().Locks().ForceRelease(ctx, database, dbType); relErr != nil {
+				h.logger.Error("failed to release lock after fresh-HEAD checks gate block",
+					"repo", repo, "pr", pr, "database", database, "database_type", dbType, "error", relErr)
+			}
+			return
+		}
+
 		// Look up the plan we just created for DDL comparison in executeApply.
 		// Fail closed: if we can't load the plan, downgrade to manual confirmation
 		// rather than skipping the DDL drift check entirely.

--- a/pkg/webhook/webhook_e2e_test.go
+++ b/pkg/webhook/webhook_e2e_test.go
@@ -259,6 +259,14 @@ type planFlowResult struct {
 	// element.
 	HeadSHAs    []string
 	headSHACall atomic.Int64
+
+	// GraphQLHandler optionally overrides the default passing-checks
+	// GraphQL handler installed by setupFakeGitHubForPlan. Tests that need
+	// to drive different check-gate responses across consecutive calls
+	// (e.g. PASS at the early gate, FAIL at the fresh-HEAD re-gate) install
+	// their own handler here before issuing the webhook request. Nil
+	// preserves the default "no checks → passing" behavior.
+	GraphQLHandler atomic.Pointer[http.HandlerFunc]
 }
 
 func (p *planFlowResult) nextHeadSHA() string {
@@ -446,8 +454,24 @@ func setupFakeGitHubForPlan(t *testing.T, mux *http.ServeMux, schemaSQL map[stri
 		_ = json.NewEncoder(w).Encode(map[string]any{"id": 1})
 	})
 
-	// PR check statuses (all passing) for enforcePassingChecks
-	registerPassingChecks(mux)
+	// PR check statuses for enforcePassingChecks. Defaults to all passing
+	// (empty rollup) so existing tests are unaffected. Tests that need to
+	// drive different responses across calls install a handler in
+	// result.GraphQLHandler before issuing the webhook request.
+	mux.HandleFunc("POST /graphql", func(w http.ResponseWriter, r *http.Request) {
+		if h := result.GraphQLHandler.Load(); h != nil {
+			(*h)(w, r)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": map[string]any{"repository": map[string]any{"object": map[string]any{
+				"statusCheckRollup": map[string]any{"contexts": map[string]any{
+					"pageInfo": map[string]any{"hasNextPage": false, "endCursor": ""},
+					"nodes":    []map[string]any{},
+				}},
+			}}},
+		})
+	})
 
 	return result
 }


### PR DESCRIPTION
Closes #133.

The `apply -y` auto-confirm branch ran `enforcePassingChecks`
once at the top of `handleApplyCommand` against the discovery
PR HEAD, then never re-checked the gate against the fresh HEAD
before `executeApply`. A required check that flipped to failing
on the same SHA between discovery and apply — or a new required
check that appeared in that window — would not be observed; the
apply proceeded against stale gate state. `apply-confirm` was
already safe because PR #114 placed a fresh-HEAD fetch
immediately before its gate.

This adds a second `enforcePassingChecks` call in the
auto-confirm branch, immediately after the
`assertSchemaStillCurrent` freshness gate (PR #134), using the
fresh `prInfo.HeadSHA` from the same `FetchPullRequestNoCache`.
PR #112's singleflight makes the second gate call on the same
SHA effectively free. On block, the lock acquired earlier in
the same handler invocation is released so the user can re-run
`schemabot apply -e <env>` once checks recover without a manual
unlock.

Sibling to #134 (schema-file freshness): same root cause —
discovery-time data being reused at execution time — but
structurally distinct (gate authorisation vs schema bytes).

### Follow-up commit — owner-scoped lock release

Addresses a Codex P1 review on the original commit and applies
the same fix to symmetric sites. ForceRelease assumed the same
handler invocation that acquired the lock still owned it at
release time, but ownership can change in between (e.g. an
unrelated `schemabot unlock` clears the lock and another PR
acquires it). A ForceRelease in that race would clobber the
other PR's lock and remove the concurrency safety gate.

Every post-acquire lock-release site in `handleApplyCommand` and
`executeApply` now uses owner-scoped `Release(database, type,
lockOwner)` — `ErrLockNotFound` / `ErrLockNotOwned` are expected
outcomes and silently no-op'd. Pattern mirrors the precedent set
in `handleApplyConfirmCommand`'s stale-schema rejection (PR
#134 review). `handleUnlockCommand`'s ForceRelease is
intentionally retained — its entire purpose is to force-clear
unconditionally.

New regression test
`TestE2EApplyAutoConfirmFreshHEADBlockPreservesOtherPRLock`
swaps the lock owner mid-handler (inside the GraphQL re-gate
mock) and asserts an unrelated PR's lock survives the gate
block. Companion to the existing
`TestE2EApplyConfirmStaleSchemaPreservesOtherPRLock` from #134.

---

*Drafted with Amp; commits signed and verified by the author.*
