### PR TITLE
feat(scheduler): dispatch local applies from workers

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -268,14 +268,19 @@ type ProgressObserver interface {
 Webhook handler: "someone commented schemabot apply"
     |
     +-- Creates CommentObserver (posts PR comments)
-    +-- Calls SetPendingObserver on the client
+    +-- Calls SetPendingObserver on the API service
     +-- Calls ExecuteApply
             |
             v
-        Client.Apply()
-            +-- Consumes pending observer
-            +-- Registers Observer on the apply before engine starts
-            +-- Starts engine goroutine
+        store pending apply + tasks
+            +-- Registers Observer on the apply before scheduler dispatch
+            +-- Wakes scheduler
+                    |
+                    v
+                Scheduler worker claims apply
+                    |
+                    v
+                Client.ResumeApply()
                     |
                     +-- Progress tick: poll engine, derive task/apply state
                     |   +-- Observer.OnProgress()
@@ -315,7 +320,7 @@ stored GitHub context, and errors never fail server startup.
 
 The scheduler is part of Tern orchestration. The API service starts it on server startup because the server owns process lifecycle, configuration, and the Tern client pool, but the scheduler's work is to coordinate applies: claim storage records, refresh their heartbeat lease, and call `ResumeApply()` on the right Tern client.
 
-Each scheduler worker runs immediately on startup, then polls every 10 seconds. The worker claims at most one apply per tick and resumes it through the Tern client for that apply's deployment and environment.
+Each scheduler worker runs immediately on startup, then polls every 10 seconds. The worker claims at most one apply per tick and resumes it through the Tern client for that apply's deployment and environment. Fresh local applies also send a best-effort wake signal after their apply and task rows are committed, so a worker can claim them immediately instead of waiting for the next poll tick.
 
 `scheduler_workers` controls scheduler concurrency. The default is four workers, so an untuned server can still make progress across independent databases and environments concurrently. More workers help larger installations with many independent schema changes because each worker can claim and resume a different target during the same scheduler tick.
 
@@ -327,13 +332,13 @@ In a multi-pod deployment, every SchemaBot pod runs its own scheduler. Each sche
 | Scheduler                |      | Scheduler                |
 | +----------------------+ |      | +----------------------+ |
 | | worker 0             | |      | | worker 0             | |
-| | claim stale apply    | |      | | claim stale apply    | |
+| | claim apply work     | |      | | claim apply work     | |
 | | attach Observer      | |      | | attach Observer      | |
 | | ResumeApply          | |      | | ResumeApply          | |
 | +----------------------+ |      | +----------------------+ |
 | +----------------------+ |      | +----------------------+ |
 | | worker 1             | |      | | worker 1             | |
-| | claim stale apply    | |      | | claim stale apply    | |
+| | claim apply work     | |      | | claim apply work     | |
 | | attach Observer      | |      | | attach Observer      | |
 | | ResumeApply          | |      | | ResumeApply          | |
 | +----------------------+ |      | +----------------------+ |
@@ -358,9 +363,30 @@ In a multi-pod deployment, every SchemaBot pod runs its own scheduler. Each sche
 
 The storage arrows represent scheduler coordination. The GitHub arrows represent optional observer notifications; CLI applies simply run without an observer.
 
-A **claim** is an atomic storage operation: it selects one stale apply and refreshes its `updated_at` heartbeat in the same transaction. That heartbeat refresh is the scheduler's lease while it reloads state and calls `ResumeApply()`. Claims use `FOR UPDATE SKIP LOCKED` so multiple scheduler workers can run concurrently without taking the same apply.
+A **claim** is an atomic storage operation: it selects one apply that needs work and refreshes its `updated_at` heartbeat in the same transaction. That heartbeat refresh is the scheduler's lease while it reloads state and calls `ResumeApply()`. Claims use `FOR UPDATE SKIP LOCKED` so multiple scheduler workers can run concurrently without taking the same apply.
 
-An apply becomes claimable after its heartbeat has been stale for more than one minute and it is in a state that can be resumed from persisted metadata. Terminal applies are already done, and stopped applies are not auto-resumed; the user must call `schemabot start`.
+A running apply becomes claimable after its heartbeat has been stale for more than one minute and it is in a state that can be resumed from persisted metadata. Terminal applies are already done, and stopped applies are not auto-resumed; the user must call `schemabot start`.
+
+Freshly queued local applies are also claimable once their task rows exist. `ExecuteApply` stores the pending apply and its initial tasks in one transaction, then sends a best-effort wake signal to the scheduler. The wake path is only a latency optimization: it nudges one worker to call the same claim path immediately instead of waiting for the next poll tick. It never bypasses storage claims or creates a second queue. If the scheduler is stopped or a wake is already pending, the signal is skipped and the normal poll loop still finds the apply.
+
+```
+HTTP apply request
+      |
+      v
+store pending apply + tasks
+      |
+      v
+best-effort scheduler wake
+      |
+      v
+worker calls FindNextApply()
+      |
+      v
+claim row + refresh heartbeat
+      |
+      v
+TernClient.ResumeApply()
+```
 
 SchemaBot has two different kinds of locking:
 

--- a/docs/spirit_progress.md
+++ b/docs/spirit_progress.md
@@ -100,7 +100,7 @@ Task fields updated during polling (`storage.Task` in `pkg/storage/types.go`):
 | `pollTaskToCompletion` (sequential mode) | Poller goroutine | Every 500ms | Same as above, plus `IsInstant` |
 | `LocalClient.Stop()` | Stop handler | Once, after `eng.Stop()` blocks | `State` → STOPPED (or COMPLETED if table finished), `RowsCopied`, `RowsTotal`, `ProgressPercent`, `ETASeconds`, `CompletedAt` |
 | `LocalClient.Progress()` | Progress handler | On each API call (if engine state changed and task is non-terminal) | `State`, `UpdatedAt`, `CompletedAt` |
-| `executeApplyAtomic` / `executeApplySequential` | Apply launcher | Once at start | `State` → RUNNING, `StartedAt` |
+| `executeGroupedApply` / `executeApplySequential` | Apply launcher | Once at start | `State` → RUNNING, `StartedAt` |
 
 The pollers are the primary write path during normal operation. The Stop handler is special:
 it calls `eng.Stop()` first (which blocks until Spirit's goroutine exits), THEN reads

--- a/integration/cli_test.go
+++ b/integration/cli_test.go
@@ -873,6 +873,7 @@ func startSchemaBotLocal(t *testing.T) string {
 	}
 
 	svc := schemabotapi.New(storage, config, ternClients, logger)
+	startTestScheduler(t, svc)
 	t.Cleanup(func() { utils.CloseAndLog(svc) })
 
 	// Start HTTP server
@@ -954,6 +955,7 @@ func startSchemaBotLocalDB(t *testing.T, dbName string) string {
 	}
 
 	svc := schemabotapi.New(storage, config, ternClients, logger)
+	startTestScheduler(t, svc)
 	t.Cleanup(func() { utils.CloseAndLog(svc) })
 
 	// Start HTTP server

--- a/integration/hybrid_mode_test.go
+++ b/integration/hybrid_mode_test.go
@@ -135,6 +135,7 @@ func TestHybridMode_LocalAndNamedRemoteTargets(t *testing.T) {
 	svc := schemabotapi.New(schemabotStorage, serverConfig, map[string]tern.Client{
 		remoteDeployment + "/staging": grpcClient,
 	}, logger)
+	startTestScheduler(t, svc)
 	t.Cleanup(func() { utils.CloseAndLog(svc) })
 
 	mux := http.NewServeMux()

--- a/integration/scheduler_test.go
+++ b/integration/scheduler_test.go
@@ -127,6 +127,7 @@ func TestScheduler_BasicClaimAndResume(t *testing.T) {
 	require.True(t, applyResp["accepted"] == true)
 	applyID, _ := applyResp["apply_id"].(string)
 	waitForState(t, "http://"+ts.Addr, applyID, "completed", 15*time.Second)
+	ts.Service.StopScheduler()
 
 	// Remove the table so the second plan contains DDL that recovery can resume.
 	targetConn, err := sql.Open("mysql", appDSN)
@@ -336,7 +337,7 @@ func TestScheduler_ClaimableStates(t *testing.T) {
 				applyIdentifier)
 			require.NoError(t, err)
 
-			// The scheduler should only claim stale applies in states that recovery can resume safely.
+			// The scheduler should claim only queued or stale applies in states it can resume safely.
 			claimed, err := stor.Applies().FindNextApply(ctx)
 			require.NoError(t, err)
 			if tc.wantClaim {

--- a/integration/workflow_test.go
+++ b/integration/workflow_test.go
@@ -63,6 +63,11 @@ func createTestDB(t *testing.T, prefix string) (appDBName, appDSN string) {
 // registered via t.Cleanup.
 func startTestServer(t *testing.T, appDBName, appDSN string) testServer {
 	t.Helper()
+	return startTestServerWithSchedulerInterval(t, appDBName, appDSN, 200*time.Millisecond)
+}
+
+func startTestServerWithSchedulerInterval(t *testing.T, appDBName, appDSN string, schedulerInterval time.Duration) testServer {
+	t.Helper()
 
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
 
@@ -91,6 +96,7 @@ func startTestServer(t *testing.T, appDBName, appDSN string) testServer {
 	svc := schemabotapi.New(storage, serverConfig, map[string]tern.Client{
 		appDBName + "/staging": localClient,
 	}, logger)
+	startTestSchedulerWithInterval(t, svc, schedulerInterval)
 
 	mux := http.NewServeMux()
 	svc.ConfigureRoutes(mux)
@@ -127,6 +133,18 @@ func startTestServer(t *testing.T, appDBName, appDSN string) testServer {
 	})
 
 	return testServer{Addr: addr, Storage: storage, Service: svc}
+}
+
+func startTestScheduler(t *testing.T, svc *schemabotapi.Service) {
+	t.Helper()
+	startTestSchedulerWithInterval(t, svc, 200*time.Millisecond)
+}
+
+func startTestSchedulerWithInterval(t *testing.T, svc *schemabotapi.Service, interval time.Duration) {
+	t.Helper()
+
+	require.NoError(t, svc.SetSchedulerPollInterval(interval))
+	svc.StartScheduler(t.Context())
 }
 
 // postJSON marshals body as JSON, POSTs to url, asserts HTTP 200,
@@ -1318,7 +1336,10 @@ func TestFullWorkflow_Spirit_PartialFailure(t *testing.T) {
 	ctx := t.Context()
 
 	appDBName, _ := createTestDB(t, "partialfail_")
-	ts := startTestServer(t, appDBName, strings.Replace(targetDSN, "/target_test", "/"+appDBName, 1))
+	// The first queued apply starts through a scheduler wake, so this test can
+	// use a slower poll interval to observe the retryable pause before the next
+	// scheduler retry consumes it.
+	ts := startTestServerWithSchedulerInterval(t, appDBName, strings.Replace(targetDSN, "/target_test", "/"+appDBName, 1), 5*time.Second)
 
 	endpoint := "http://" + ts.Addr
 

--- a/pkg/api/README.md
+++ b/pkg/api/README.md
@@ -81,13 +81,13 @@ request bodies that try to send database or deployment fields.
 
 ## Scheduler
 
-On startup, the service launches a background scheduler (`StartScheduler`) that claims apply work from storage. A claim means selecting one stale apply and refreshing its heartbeat in the same transaction so the worker has a lease while it resumes the apply.
+On startup, the service launches a background scheduler (`StartScheduler`) that claims apply work from storage. A claim means selecting one apply that needs work and refreshing its heartbeat in the same transaction so the worker has a lease while it starts or resumes the apply.
 
 1. Runs immediately, then polls every 10 seconds per configured worker
-2. Finds applies with stale heartbeats (no update for 1+ minute)
+2. Finds fresh queued applies or applies with stale heartbeats (no update for 1+ minute)
 3. Claims one apply atomically by selecting it and refreshing its heartbeat in the same transaction
 4. Gets the appropriate Tern client for the database/environment
-5. Calls `ResumeApply()` so execution continues from persisted engine state
+5. Calls `ResumeApply()` so execution starts from the queue or continues from persisted engine state
 
 Stopped applies (user called `schemabot stop`) are **not** auto-resumed. The user must explicitly call `schemabot start`.
 

--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -10,7 +10,9 @@ import (
 	"net/http/httptest"
 	"os"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -58,21 +60,20 @@ func (m *mockPlanLookupStore) GetByPR(context.Context, string, int) ([]*storage.
 func (m *mockPlanLookupStore) Delete(context.Context, int64) error           { return nil }
 func (m *mockPlanLookupStore) DeleteByPR(context.Context, string, int) error { return nil }
 
-type mockStorageWithPlanLookup struct {
-	mockStorage
-	plans storage.PlanStore
-}
-
-func (m *mockStorageWithPlanLookup) Plans() storage.PlanStore { return m.plans }
-
 type mockStorageWithApplyStores struct {
 	mockStorage
-	plans   storage.PlanStore
-	applies storage.ApplyStore
+	plans     storage.PlanStore
+	applies   storage.ApplyStore
+	tasks     storage.TaskStore
+	locks     storage.LockStore
+	applyLogs storage.ApplyLogStore
 }
 
-func (m *mockStorageWithApplyStores) Plans() storage.PlanStore    { return m.plans }
-func (m *mockStorageWithApplyStores) Applies() storage.ApplyStore { return m.applies }
+func (m *mockStorageWithApplyStores) Plans() storage.PlanStore         { return m.plans }
+func (m *mockStorageWithApplyStores) Applies() storage.ApplyStore      { return m.applies }
+func (m *mockStorageWithApplyStores) Tasks() storage.TaskStore         { return m.tasks }
+func (m *mockStorageWithApplyStores) Locks() storage.LockStore         { return m.locks }
+func (m *mockStorageWithApplyStores) ApplyLogs() storage.ApplyLogStore { return m.applyLogs }
 
 type staticPlanStore struct {
 	storage.PlanStore
@@ -103,6 +104,141 @@ func (s *staticApplyStore) GetByDatabase(context.Context, string, string, string
 	return []*storage.Apply{s.apply}, nil
 }
 
+type capturingApplyStore struct {
+	storage.ApplyStore
+	mu        sync.Mutex
+	apply     *storage.Apply
+	taskStore *capturingTaskStore
+	claimed   bool
+	findCh    chan struct{}
+	err       error
+}
+
+func (s *capturingApplyStore) Create(_ context.Context, apply *storage.Apply) (int64, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.apply = apply
+	if s.err != nil {
+		return 0, s.err
+	}
+	return 123, nil
+}
+
+func (s *capturingApplyStore) CreateWithTasks(ctx context.Context, apply *storage.Apply, tasks []*storage.Task) (int64, error) {
+	s.mu.Lock()
+	if s.err != nil {
+		err := s.err
+		s.mu.Unlock()
+		return 0, err
+	}
+	s.mu.Unlock()
+
+	applyID := int64(123)
+	previousTaskCount := 0
+	if s.taskStore != nil {
+		s.taskStore.mu.Lock()
+		previousTaskCount = len(s.taskStore.tasks)
+		s.taskStore.mu.Unlock()
+	}
+	for _, task := range tasks {
+		task.ApplyID = applyID
+		if s.taskStore != nil {
+			if _, err := s.taskStore.Create(ctx, task); err != nil {
+				s.taskStore.mu.Lock()
+				s.taskStore.tasks = s.taskStore.tasks[:previousTaskCount]
+				s.taskStore.mu.Unlock()
+				return 0, err
+			}
+		}
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.apply = apply
+	return applyID, nil
+}
+
+func (s *capturingApplyStore) Update(_ context.Context, apply *storage.Apply) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.apply = apply
+	return nil
+}
+
+func (s *capturingApplyStore) FindNextApply(context.Context) (*storage.Apply, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.findCh != nil {
+		select {
+		case s.findCh <- struct{}{}:
+		default:
+		}
+	}
+	if s.apply == nil || s.claimed {
+		return nil, nil
+	}
+	s.claimed = true
+	apply := *s.apply
+	apply.ID = 123
+	return &apply, nil
+}
+
+func (s *capturingApplyStore) ExpireRetryable(context.Context) ([]*storage.Apply, error) {
+	return nil, nil
+}
+
+type capturingTaskStore struct {
+	storage.TaskStore
+	mu           sync.Mutex
+	tasks        []*storage.Task
+	createCalls  int
+	failOnCreate int
+	err          error
+}
+
+func (s *capturingTaskStore) Create(_ context.Context, task *storage.Task) (int64, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.createCalls++
+	if s.failOnCreate == s.createCalls {
+		if s.err != nil {
+			return 0, s.err
+		}
+		return 0, errors.New("create task failed")
+	}
+	task.ID = int64(len(s.tasks) + 1)
+	s.tasks = append(s.tasks, task)
+	return int64(len(s.tasks)), nil
+}
+
+func (s *capturingTaskStore) Update(_ context.Context, task *storage.Task) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for i, storedTask := range s.tasks {
+		if storedTask.ID == task.ID || storedTask.TaskIdentifier == task.TaskIdentifier {
+			s.tasks[i] = task
+			return nil
+		}
+	}
+	return storage.ErrTaskNotFound
+}
+
+type emptyLockStore struct {
+	storage.LockStore
+}
+
+func (s *emptyLockStore) Get(context.Context, string, string) (*storage.Lock, error) {
+	return nil, nil
+}
+
+type noopApplyLogStore struct {
+	storage.ApplyLogStore
+}
+
+func (s *noopApplyLogStore) Append(context.Context, *storage.ApplyLog) error {
+	return nil
+}
+
 // mockTernClient implements tern.Client for testing.
 type mockTernClient struct {
 	healthErr      error
@@ -127,6 +263,10 @@ type mockTernClient struct {
 	skipRevertResp *ternv1.SkipRevertResponse
 	skipRevertErr  error
 	skipRevertReq  *ternv1.SkipRevertRequest // captured request
+	resumeMu       sync.Mutex
+	resumeErr      error
+	resumeApply    *storage.Apply
+	resumeCh       chan *storage.Apply
 	isRemote       bool
 }
 
@@ -190,7 +330,19 @@ func (m *mockTernClient) RollbackPlan(ctx context.Context, database string) (*te
 	return nil, nil
 }
 func (m *mockTernClient) ResumeApply(ctx context.Context, apply *storage.Apply) error {
-	return nil
+	m.resumeMu.Lock()
+	m.resumeApply = apply
+	resumeCh := m.resumeCh
+	resumeErr := m.resumeErr
+	m.resumeMu.Unlock()
+
+	if resumeCh != nil {
+		select {
+		case resumeCh <- apply:
+		default:
+		}
+	}
+	return resumeErr
 }
 func (m *mockTernClient) Endpoint() string                                  { return "mock" }
 func (m *mockTernClient) IsRemote() bool                                    { return m.isRemote }
@@ -248,14 +400,21 @@ func activeTestApply(applyID string) *storage.Apply {
 	}
 }
 
-func newExecuteApplyTestService(client tern.Client, applies storage.ApplyStore) *Service {
+func newExecuteApplyTestService(client tern.Client, applies storage.ApplyStore) (*Service, *capturingTaskStore) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	tasks := &capturingTaskStore{}
+	if capturingApplies, ok := applies.(*capturingApplyStore); ok {
+		capturingApplies.taskStore = tasks
+	}
 	return New(&mockStorageWithApplyStores{
-		plans:   &staticPlanStore{plan: executeApplyTestPlan()},
-		applies: applies,
+		plans:     &staticPlanStore{plan: executeApplyTestPlan()},
+		applies:   applies,
+		tasks:     tasks,
+		locks:     &emptyLockStore{},
+		applyLogs: &noopApplyLogStore{},
 	}, testServerConfig(), map[string]tern.Client{
 		"default/staging": client,
-	}, logger)
+	}, logger), tasks
 }
 
 func newControlTestService(client tern.Client, apply *storage.Apply) *Service {
@@ -272,42 +431,134 @@ func newTestService() *Service {
 	return New(&mockStorage{}, testServerConfig(), nil, logger)
 }
 
-func TestExecuteApplyRequiresApplyIDs(t *testing.T) {
-	t.Run("accepted response requires engine apply id", func(t *testing.T) {
-		svc := newExecuteApplyTestService(&mockTernClient{
-			applyResp: &ternv1.ApplyResponse{Accepted: true},
-		}, nil)
+func TestExecuteApplyRequiresRemoteApplyID(t *testing.T) {
+	svc, _ := newExecuteApplyTestService(&mockTernClient{
+		applyResp: &ternv1.ApplyResponse{Accepted: true},
+		isRemote:  true,
+	}, &capturingApplyStore{})
 
-		resp, applyID, err := svc.ExecuteApply(t.Context(), ApplyRequest{
-			PlanID:      "plan-1",
-			Environment: "staging",
-		})
-
-		require.Error(t, err)
-		assert.Nil(t, resp)
-		assert.Zero(t, applyID)
-		assert.Contains(t, err.Error(), "accepted apply missing apply_id")
+	resp, applyID, err := svc.ExecuteApply(t.Context(), ApplyRequest{
+		PlanID:      "plan-1",
+		Environment: "staging",
 	})
 
-	t.Run("accepted response requires stored apply id", func(t *testing.T) {
-		svc := newExecuteApplyTestService(&mockTernClient{
-			applyResp: &ternv1.ApplyResponse{Accepted: true, ApplyId: "apply-123"},
-		}, &staticApplyStore{
-			apply: &storage.Apply{
-				ApplyIdentifier: "apply-123",
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Zero(t, applyID)
+	assert.Contains(t, err.Error(), "accepted apply missing apply_id")
+}
+
+func TestExecuteApplyQueuesLocalApplyForScheduler(t *testing.T) {
+	applies := &capturingApplyStore{}
+	mock := &mockTernClient{}
+	svc, tasks := newExecuteApplyTestService(mock, applies)
+
+	resp, applyID, err := svc.ExecuteApply(t.Context(), ApplyRequest{
+		PlanID:      "plan-1",
+		Environment: "staging",
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.True(t, resp.Accepted)
+	assert.Equal(t, int64(123), applyID)
+	assert.NotEmpty(t, resp.ApplyID)
+	require.NotNil(t, applies.apply)
+	assert.Equal(t, state.Apply.Pending, applies.apply.State)
+	assert.Equal(t, storage.EngineSpirit, applies.apply.Engine)
+	assert.Equal(t, "testdb", applies.apply.GetOptions().Target)
+	assert.Nil(t, mock.applyReq, "request path should enqueue work without dispatching the engine")
+	require.Len(t, tasks.tasks, 1)
+	assert.Equal(t, state.Task.Pending, tasks.tasks[0].State)
+}
+
+func TestExecuteApplyDoesNotStorePartialQueueWhenTaskCreateFails(t *testing.T) {
+	plan := executeApplyTestPlan()
+	plan.Namespaces["testdb"].Tables = append(plan.Namespaces["testdb"].Tables, storage.TableChange{
+		Namespace: "testdb",
+		Table:     "orders",
+		DDL:       "ALTER TABLE orders ADD COLUMN status varchar(255)",
+		Operation: "alter",
+	})
+
+	applies := &capturingApplyStore{}
+	tasks := &capturingTaskStore{
+		failOnCreate: 2,
+		err:          errors.New("task insert failed"),
+	}
+	applies.taskStore = tasks
+	svc := New(&mockStorageWithApplyStores{
+		plans:     &staticPlanStore{plan: plan},
+		applies:   applies,
+		tasks:     tasks,
+		locks:     &emptyLockStore{},
+		applyLogs: &noopApplyLogStore{},
+	}, testServerConfig(), map[string]tern.Client{
+		"default/staging": &mockTernClient{},
+	}, slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError})))
+
+	resp, applyID, err := svc.ExecuteApply(t.Context(), ApplyRequest{
+		PlanID:      "plan-1",
+		Environment: "staging",
+	})
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Zero(t, applyID)
+	assert.Contains(t, err.Error(), "task insert failed")
+	assert.Nil(t, applies.apply)
+	assert.Empty(t, tasks.tasks)
+}
+
+func TestExecuteApplyWakesSchedulerForQueuedLocalApply(t *testing.T) {
+	applies := &capturingApplyStore{findCh: make(chan struct{}, 1)}
+	mock := &mockTernClient{resumeCh: make(chan *storage.Apply, 1)}
+	svc, _ := newExecuteApplyTestService(mock, applies)
+	svc.config.SchedulerWorkers = 1
+	require.NoError(t, svc.SetSchedulerPollInterval(time.Hour))
+	svc.StartScheduler(t.Context())
+	t.Cleanup(svc.StopScheduler)
+
+	select {
+	case <-applies.findCh:
+	case <-time.After(2 * time.Second):
+		require.Fail(t, "scheduler did not perform startup claim")
+	}
+
+	resp, applyID, err := svc.ExecuteApply(t.Context(), ApplyRequest{
+		PlanID:      "plan-1",
+		Environment: "staging",
+	})
+
+	require.NoError(t, err)
+	require.True(t, resp.Accepted)
+	assert.Equal(t, int64(123), applyID)
+
+	select {
+	case resumedApply := <-mock.resumeCh:
+		assert.Equal(t, int64(123), resumedApply.ID)
+		assert.Equal(t, state.Apply.Pending, resumedApply.State)
+		assert.Equal(t, "testdb", resumedApply.Database)
+	case <-time.After(2 * time.Second):
+		require.Fail(t, "scheduler did not resume queued apply after wake")
+	}
+}
+
+func TestProgressResponseFromProtoPreservesVSchemaChangeType(t *testing.T) {
+	resp := progressResponseFromProto(&ternv1.ProgressResponse{
+		State: ternv1.State_STATE_RUNNING,
+		Tables: []*ternv1.TableProgress{
+			{
+				TableName:  "VSchema: testapp",
+				Namespace:  "testapp",
+				ChangeType: ternv1.ChangeType_CHANGE_TYPE_VSCHEMA,
+				Status:     state.Task.Running,
 			},
-		})
-
-		resp, applyID, err := svc.ExecuteApply(t.Context(), ApplyRequest{
-			PlanID:      "plan-1",
-			Environment: "staging",
-		})
-
-		require.Error(t, err)
-		assert.Nil(t, resp)
-		assert.Zero(t, applyID)
-		assert.Contains(t, err.Error(), "accepted apply missing stored apply id")
+		},
 	})
+
+	require.Len(t, resp.Tables, 1)
+	assert.Equal(t, "vschema_update", resp.Tables[0].ChangeType)
 }
 
 func TestHealth(t *testing.T) {
@@ -363,12 +614,14 @@ func TestApplyHandler(t *testing.T) {
 			Target:         "testdb",
 			Environment:    "staging",
 		}
-		stor := &mockStorageWithPlanLookup{
-			plans: &mockPlanLookupStore{plan: plan},
+		stor := &mockStorageWithApplyStores{
+			plans:     &mockPlanLookupStore{plan: plan},
+			applies:   &capturingApplyStore{err: fmt.Errorf("create apply: %w", storage.ErrActiveApplyExists)},
+			tasks:     &capturingTaskStore{},
+			locks:     &emptyLockStore{},
+			applyLogs: &noopApplyLogStore{},
 		}
-		mock := &mockTernClient{
-			applyErr: fmt.Errorf("create apply: %w", storage.ErrActiveApplyExists),
-		}
+		mock := &mockTernClient{}
 		logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
 		ternClients := map[string]tern.Client{"default/staging": mock}
 		svc := New(stor, testServerConfig(), ternClients, logger)
@@ -382,9 +635,7 @@ func TestApplyHandler(t *testing.T) {
 		mux.ServeHTTP(w, req)
 
 		assert.Equal(t, http.StatusConflict, w.Code, w.Body.String())
-		require.NotNil(t, mock.applyReq)
-		assert.Equal(t, "testdb", mock.applyReq.Database)
-		assert.Equal(t, storage.DatabaseTypeMySQL, mock.applyReq.Type)
+		assert.Nil(t, mock.applyReq, "request path should not dispatch local apply work")
 
 		var resp apitypes.ErrorResponse
 		require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))

--- a/pkg/api/plan_handlers.go
+++ b/pkg/api/plan_handlers.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"net/http"
 	"strings"
 	"time"
@@ -245,25 +246,18 @@ func applyMetricStatusForError(err error) string {
 	return "error"
 }
 
-// ExecuteApply executes an apply request via the Tern client, stores the result,
-// and returns the apply response. This is the shared implementation used by both
-// the HTTP handler and the webhook handler.
+// ExecuteApply stores an apply request durably and returns the apply response.
+// Local clients are queued for scheduler dispatch so request cancellation cannot
+// orphan in-memory execution. Remote clients dispatch through the gRPC request
+// path.
 //
 // Flow:
 //  1. Load the plan from SchemaBot storage (source of truth for database, DDL changes).
-//  2. Build a ternv1.ApplyRequest with PlanId, DdlChanges, and options.
-//  3. Call client.Apply(ctx, ternReq):
-//     - LocalClient: looks up plan in same DB, creates apply + task records,
-//     starts Spirit in a background goroutine, returns ApplyId (its own UUID).
-//     - GRPCClient: passes the request to the remote Tern over gRPC. The remote
-//     Tern creates its own records and starts execution. Returns ApplyId
-//     (the remote engine's apply identifier).
-//  4. Store the result in SchemaBot's storage:
-//     - Local (IsRemote=false): the apply record already exists (LocalClient
-//     created it in step 3). Look it up and reuse it.
-//     - Remote (IsRemote=true): generate a SchemaBot-owned apply_identifier,
-//     store Tern's ApplyId as external_id, create apply + task records.
-//  5. Return the apply_identifier to the HTTP caller.
+//  2. Resolve the Tern client to validate deployment/environment routing.
+//  3. Local mode: create a pending Apply row and pending Task rows, attach any
+//     pending observer, wake the scheduler, and return the SchemaBot apply ID.
+//  4. gRPC mode: call remote Apply, store the remote apply ID in external_id,
+//     start progress polling, and return the SchemaBot apply ID.
 //
 // Returns the API response, the stored apply ID (0 if not stored), and any error.
 func (s *Service) ExecuteApply(ctx context.Context, req ApplyRequest) (*apitypes.ApplyResponse, int64, error) {
@@ -275,7 +269,7 @@ func (s *Service) ExecuteApply(ctx context.Context, req ApplyRequest) (*apitypes
 	)
 	defer span.End()
 
-	// Load plan first — it's the source of truth for database and type.
+	// Load plan first; it is the source of truth for database, type, and routing.
 	plan, err := s.storage.Plans().Get(ctx, req.PlanID)
 	if err != nil {
 		span.RecordError(err)
@@ -321,10 +315,59 @@ func (s *Service) ExecuteApply(ctx context.Context, req ApplyRequest) (*apitypes
 		return nil, 0, fmt.Errorf("database %q (%s): %w", plan.Database, req.Environment, err)
 	}
 
-	// Ensure options map exists and includes environment
-	options := req.Options
+	options := maps.Clone(req.Options)
 	if options == nil {
 		options = make(map[string]string)
+	}
+	options["target"] = plan.Target
+
+	applyStart := time.Now()
+	recordApplyResult := func(status string) {
+		metrics.RecordApply(ctx, plan.Database, req.Environment, status)
+		metrics.RecordApplyDuration(ctx, time.Since(applyStart), plan.Database, req.Environment, status)
+	}
+	recordApplyError := func(status string, err error) {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, status)
+		recordApplyResult(applyMetricStatusForError(err))
+	}
+
+	if !client.IsRemote() {
+		attachObserver := func(storedApplyID int64) {
+			observer := s.consumePendingObserver(plan.Database, deployment, req.Environment)
+			if observer != nil {
+				type applyIDSetter interface{ SetApplyID(int64) }
+				if setter, ok := observer.(applyIDSetter); ok {
+					setter.SetApplyID(storedApplyID)
+				}
+				client.SetObserver(storedApplyID, observer)
+			}
+		}
+
+		applyIdentifier, storedApplyID, err := s.enqueueApply(ctx, plan, req, deployment, options, attachObserver)
+		if err != nil {
+			recordApplyError("enqueue apply", err)
+			return nil, 0, err
+		}
+		if storedApplyID <= 0 {
+			applyErr := fmt.Errorf("accepted apply missing stored apply id")
+			recordApplyError("apply missing stored id", applyErr)
+			return nil, 0, applyErr
+		}
+
+		span.SetAttributes(attribute.String("apply_id", applyIdentifier), attribute.Bool("accepted", true))
+		recordApplyResult("success")
+		metrics.AdjustActiveApplies(ctx, 1, plan.Database, req.Environment)
+		s.wakeScheduler(applyIdentifier, plan.Database, req.Environment)
+
+		return &apitypes.ApplyResponse{
+			Accepted: true,
+			ApplyID:  applyIdentifier,
+		}, storedApplyID, nil
+	}
+
+	if observer := s.consumePendingObserver(plan.Database, deployment, req.Environment); observer != nil {
+		client.SetPendingObserver(observer)
 	}
 	ternReq := &ternv1.ApplyRequest{
 		PlanId:      req.PlanID,
@@ -337,18 +380,7 @@ func (s *Service) ExecuteApply(ctx context.Context, req ApplyRequest) (*apitypes
 		Caller:      req.Caller,
 	}
 
-	// Time only the client.Apply call, not plan lookup or client creation.
-	applyStart := time.Now()
 	resp, err := client.Apply(ctx, ternReq)
-	recordApplyResult := func(status string) {
-		metrics.RecordApply(ctx, plan.Database, req.Environment, status)
-		metrics.RecordApplyDuration(ctx, time.Since(applyStart), plan.Database, req.Environment, status)
-	}
-	recordApplyError := func(status string, err error) {
-		span.RecordError(err)
-		span.SetStatus(codes.Error, status)
-		recordApplyResult(applyMetricStatusForError(err))
-	}
 	if err != nil {
 		recordApplyError("apply failed", err)
 		return nil, 0, err
@@ -365,133 +397,21 @@ func (s *Service) ExecuteApply(ctx context.Context, req ApplyRequest) (*apitypes
 	}
 	span.SetAttributes(attribute.String("apply_id", resp.ApplyId), attribute.Bool("accepted", resp.Accepted))
 
-	// Store apply and task records in SchemaBot's storage.
-	//
-	// Local mode (client.IsRemote() == false):
-	//   LocalClient.Apply() already created the apply/task records in the same
-	//   database and started its own background poller. Look up the existing
-	//   record directly.
-	//
-	// gRPC mode (client.IsRemote() == true):
-	//   Remote Tern has separate storage. Create new apply/task records with a
-	//   SchemaBot-owned apply_identifier. Store Tern's apply_id as external_id
-	//   for resolveApplyID to translate in subsequent RPCs.
-	//
-	//   After creating the record, we call ResumeApply to start a background
-	//   poller (pollForCompletion) that syncs Tern's real state into local
-	//   storage. This must happen here — not in GRPCClient.Apply() — because
-	//   the poller needs the storage.Apply record which doesn't exist until
-	//   after the record is created above.
 	var storedApplyID int64
 	applyIdentifier := resp.ApplyId
 	if resp.Accepted {
-		if !client.IsRemote() {
-			// Local mode: LocalClient.Apply() already created the apply + task
-			// records in the same database. Just look up the existing record.
-			existing, lookupErr := s.storage.Applies().GetByApplyIdentifier(ctx, resp.ApplyId)
-			if lookupErr != nil {
-				applyErr := fmt.Errorf("lookup local apply %s: %w", resp.ApplyId, lookupErr)
-				recordApplyError("lookup local apply", applyErr)
-				return nil, 0, applyErr
-			}
-			if existing == nil {
-				applyErr := fmt.Errorf("local apply %s not found: LocalClient should have created it", resp.ApplyId)
-				s.logger.Error("local apply not found after LocalClient.Apply()",
-					"apply_id", resp.ApplyId,
-					"accepted", resp.Accepted,
-				)
-				recordApplyError("local apply missing", applyErr)
-				return nil, 0, applyErr
-			}
-			storedApplyID = existing.ID
-			applyIdentifier = existing.ApplyIdentifier
-		} else {
-			// gRPC mode: remote Tern has separate storage. Create apply + task
-			// records in SchemaBot's storage with a SchemaBot-owned identifier.
-			// resp.ApplyId is Tern's own ID (the remote engine's apply identifier) — stored as
-			// external_id for resolveApplyID to translate in subsequent RPCs.
-			applyIdentifier = "apply-" + strings.ReplaceAll(uuid.New().String(), "-", "")[:16]
-			now := time.Now()
+		applyIdentifier = "apply-" + strings.ReplaceAll(uuid.New().String(), "-", "")[:16]
+		apply, id, err := s.createStoredApply(ctx, plan, req, deployment, options, applyIdentifier, resp.ApplyId)
+		if err != nil {
+			recordApplyError("store apply", err)
+			return nil, 0, err
+		}
+		storedApplyID = id
 
-			deferCutover := options["defer_cutover"] == "true"
-			allowUnsafe := options["allow_unsafe"] == "true"
-			applyOpts := storage.ApplyOptions{
-				DeferCutover: deferCutover,
-				AllowUnsafe:  allowUnsafe,
-			}
-
-			var lockID int64
-			lock, err := s.storage.Locks().Get(ctx, plan.Database, plan.DatabaseType)
-			if err != nil {
-				applyErr := fmt.Errorf("lookup lock for %s/%s: %w", plan.Database, plan.DatabaseType, err)
-				recordApplyError("lookup lock", applyErr)
-				return nil, 0, applyErr
-			}
-			if lock != nil {
-				lockID = lock.ID
-			}
-
-			apply := &storage.Apply{
-				ApplyIdentifier: applyIdentifier,
-				LockID:          lockID,
-				PlanID:          plan.ID,
-				Database:        plan.Database,
-				DatabaseType:    plan.DatabaseType,
-				Repository:      plan.Repository,
-				PullRequest:     plan.PullRequest,
-				Environment:     req.Environment,
-				Deployment:      deployment,
-				Caller:          req.Caller,
-				InstallationID:  req.InstallationID,
-				ExternalID:      resp.ApplyId,
-				Engine:          storage.EngineSpirit,
-				State:           state.Apply.Pending,
-				Options:         storage.MarshalApplyOptions(applyOpts),
-				CreatedAt:       now,
-				UpdatedAt:       now,
-			}
-			storedApplyID, err = s.storage.Applies().Create(ctx, apply)
-			if err != nil {
-				applyErr := fmt.Errorf("store apply: %w", err)
-				recordApplyError("store apply", applyErr)
-				return nil, 0, applyErr
-			}
-
-			for _, ddlChange := range plan.FlatDDLChanges() {
-				task := &storage.Task{
-					TaskIdentifier: "task-" + strings.ReplaceAll(uuid.New().String(), "-", "")[:16],
-					ApplyID:        storedApplyID,
-					PlanID:         plan.ID,
-					Database:       plan.Database,
-					DatabaseType:   plan.DatabaseType,
-					Engine:         storage.EngineSpirit,
-					Repository:     plan.Repository,
-					PullRequest:    plan.PullRequest,
-					Environment:    req.Environment,
-					State:          state.Task.Pending,
-					Options:        storage.MarshalApplyOptions(applyOpts),
-					Namespace:      ddlChange.Namespace,
-					TableName:      ddlChange.Table,
-					DDL:            ddlChange.DDL,
-					DDLAction:      ddlChange.Operation,
-					CreatedAt:      now,
-					UpdatedAt:      now,
-				}
-				if _, err := s.storage.Tasks().Create(ctx, task); err != nil {
-					applyErr := fmt.Errorf("store task: %w", err)
-					recordApplyError("store task", applyErr)
-					return nil, 0, applyErr
-				}
-			}
-
-			// Start background poller to keep local storage in sync with Tern.
-			// ResumeApply spawns pollForCompletion which syncs Tern's real state
-			// into SchemaBot's storage — without this, status stays "pending".
-			// Must happen after task creation so the poller can sync task state.
-			apply.ID = storedApplyID
-			if err := client.ResumeApply(ctx, apply); err != nil {
-				s.logger.Warn("failed to start progress tracking", "apply_id", applyIdentifier, "error", err)
-			}
+		// Start background polling to sync Tern's real state into SchemaBot's
+		// storage.
+		if err := client.ResumeApply(ctx, apply); err != nil {
+			s.logger.Warn("failed to start progress tracking", "apply_id", applyIdentifier, "error", err)
 		}
 	}
 	if resp.Accepted && storedApplyID <= 0 {
@@ -518,6 +438,127 @@ func (s *Service) ExecuteApply(ctx context.Context, req ApplyRequest) (*apitypes
 		applyResp.ErrorCode = apitypes.ErrCodeEngineError
 	}
 	return applyResp, storedApplyID, nil
+}
+
+func (s *Service) enqueueApply(
+	ctx context.Context,
+	plan *storage.Plan,
+	req ApplyRequest,
+	deployment string,
+	options map[string]string,
+	onApplyCreated func(int64),
+) (string, int64, error) {
+	applyIdentifier := "apply-" + strings.ReplaceAll(uuid.New().String(), "-", "")[:16]
+	apply, storedApplyID, err := s.createStoredApply(ctx, plan, req, deployment, options, applyIdentifier, "")
+	if err != nil {
+		return "", 0, err
+	}
+	if onApplyCreated != nil {
+		onApplyCreated(storedApplyID)
+	}
+	return apply.ApplyIdentifier, storedApplyID, nil
+}
+
+func (s *Service) createStoredApply(
+	ctx context.Context,
+	plan *storage.Plan,
+	req ApplyRequest,
+	deployment string,
+	options map[string]string,
+	applyIdentifier string,
+	externalID string,
+) (*storage.Apply, int64, error) {
+	now := time.Now()
+	applyOpts := storage.ApplyOptionsFromMap(options)
+
+	var lockID int64
+	lock, err := s.storage.Locks().Get(ctx, plan.Database, plan.DatabaseType)
+	if err != nil {
+		return nil, 0, fmt.Errorf("lookup lock for %s/%s: %w", plan.Database, plan.DatabaseType, err)
+	}
+	if lock != nil {
+		lockID = lock.ID
+	}
+
+	apply := &storage.Apply{
+		ApplyIdentifier: applyIdentifier,
+		LockID:          lockID,
+		PlanID:          plan.ID,
+		Database:        plan.Database,
+		DatabaseType:    plan.DatabaseType,
+		Repository:      plan.Repository,
+		PullRequest:     plan.PullRequest,
+		Environment:     req.Environment,
+		Deployment:      deployment,
+		Caller:          req.Caller,
+		InstallationID:  req.InstallationID,
+		ExternalID:      externalID,
+		Engine:          storage.EngineForType(plan.DatabaseType),
+		State:           state.Apply.Pending,
+		Options:         storage.MarshalApplyOptions(applyOpts),
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+
+	taskChanges := applyTaskChanges(plan)
+	tasks := make([]*storage.Task, 0, len(taskChanges))
+	for _, ddlChange := range taskChanges {
+		task := &storage.Task{
+			TaskIdentifier: "task-" + strings.ReplaceAll(uuid.New().String(), "-", "")[:16],
+			PlanID:         plan.ID,
+			Database:       plan.Database,
+			DatabaseType:   plan.DatabaseType,
+			Engine:         storage.EngineForType(plan.DatabaseType),
+			Repository:     plan.Repository,
+			PullRequest:    plan.PullRequest,
+			Environment:    req.Environment,
+			State:          state.Task.Pending,
+			Options:        storage.MarshalApplyOptions(applyOpts),
+			Namespace:      ddlChange.Namespace,
+			TableName:      ddlChange.Table,
+			DDL:            ddlChange.DDL,
+			DDLAction:      ddlChange.Operation,
+			CreatedAt:      now,
+			UpdatedAt:      now,
+		}
+		tasks = append(tasks, task)
+	}
+
+	storedApplyID, err := s.storage.Applies().CreateWithTasks(ctx, apply, tasks)
+	if err != nil {
+		return nil, 0, fmt.Errorf("store apply and tasks: %w", err)
+	}
+	apply.ID = storedApplyID
+
+	if logStore := s.storage.ApplyLogs(); logStore != nil {
+		if err := logStore.Append(ctx, &storage.ApplyLog{
+			ApplyID:   storedApplyID,
+			Level:     storage.LogLevelInfo,
+			EventType: storage.LogEventInfo,
+			Source:    storage.LogSourceSchemaBot,
+			Message:   fmt.Sprintf("Apply queued: %s", applyIdentifier),
+			NewState:  state.Apply.Pending,
+			CreatedAt: now,
+		}); err != nil {
+			s.logger.Warn("failed to log queued apply", "apply_id", applyIdentifier, "error", err)
+		}
+	}
+
+	return apply, storedApplyID, nil
+}
+
+func applyTaskChanges(plan *storage.Plan) []storage.TableChange {
+	changes := append([]storage.TableChange{}, plan.FlatDDLChanges()...)
+	for namespace, nsData := range plan.Namespaces {
+		if len(nsData.VSchema) > 0 {
+			changes = append(changes, storage.TableChange{
+				Table:     "VSchema: " + namespace,
+				Namespace: namespace,
+				Operation: "vschema_update",
+			})
+		}
+	}
+	return changes
 }
 
 // ExecuteRollbackPlan generates a rollback plan via the Tern client.

--- a/pkg/api/progress_handlers.go
+++ b/pkg/api/progress_handlers.go
@@ -27,6 +27,8 @@ func changeTypeToString(ct ternv1.ChangeType) string {
 		return ddl.StatementTypeToOp(statement.StatementAlterTable)
 	case ternv1.ChangeType_CHANGE_TYPE_DROP:
 		return ddl.StatementTypeToOp(statement.StatementDropTable)
+	case ternv1.ChangeType_CHANGE_TYPE_VSCHEMA:
+		return "vschema_update"
 	default:
 		return ""
 	}

--- a/pkg/api/scheduler.go
+++ b/pkg/api/scheduler.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/block/schemabot/pkg/metrics"
@@ -27,13 +28,16 @@ const (
 //
 // Scheduler workers claim apply work from storage so one server can make
 // progress across independent databases and environments concurrently. This
-// currently includes crash recovery for applies with stale heartbeats.
+// includes queued applies, crash recovery for applies with stale heartbeats,
+// and retry recovery for transient engine failures.
 //
 // Launches N concurrent workers (configured via scheduler_workers in config).
 // Each worker independently claims applies using FOR UPDATE SKIP LOCKED.
 // Call StopScheduler to gracefully stop.
 func (s *Service) StartScheduler(ctx context.Context) {
+	s.schedulerMu.Lock()
 	if s.stopRecovery != nil {
+		s.schedulerMu.Unlock()
 		s.logger.Info("scheduler already running")
 		return
 	}
@@ -43,13 +47,18 @@ func (s *Service) StartScheduler(ctx context.Context) {
 		workers = DefaultSchedulerWorkers
 	}
 
-	s.stopRecovery = make(chan struct{})
+	stop := make(chan struct{})
+	wake := make(chan struct{}, workers)
+	workerCtx, cancel := context.WithCancel(ctx)
+	s.stopRecovery = stop
+	s.cancelRecovery = cancel
+	s.schedulerWake = wake
+	s.schedulerMu.Unlock()
 
 	for i := range workers {
 		workerID := i
-		stop := s.stopRecovery
 		s.recoveryWg.Go(func() {
-			s.schedulerWorker(ctx, workerID, stop)
+			s.schedulerWorker(workerCtx, workerID, stop, wake)
 		})
 	}
 
@@ -59,18 +68,57 @@ func (s *Service) StartScheduler(ctx context.Context) {
 // StopScheduler stops the background scheduler and waits for all workers to finish.
 // Safe to call multiple times.
 func (s *Service) StopScheduler() {
+	s.schedulerMu.Lock()
 	if s.stopRecovery == nil {
+		s.schedulerMu.Unlock()
 		return
 	}
 	stop := s.stopRecovery
-	close(stop)
-	s.recoveryWg.Wait()
+	cancel := s.cancelRecovery
 	s.stopRecovery = nil
+	s.cancelRecovery = nil
+	s.schedulerWake = nil
+	s.schedulerMu.Unlock()
+
+	close(stop)
+	if cancel != nil {
+		cancel()
+	}
+	s.recoveryWg.Wait()
+}
+
+func (s *Service) wakeScheduler(applyIdentifier, database, environment string) {
+	s.schedulerMu.Lock()
+	wake := s.schedulerWake
+	running := s.stopRecovery != nil
+	s.schedulerMu.Unlock()
+
+	if !running || wake == nil {
+		s.logger.Debug("scheduler wake skipped because scheduler is not running",
+			"apply_id", applyIdentifier,
+			"database", database,
+			"environment", environment)
+		return
+	}
+
+	select {
+	case wake <- struct{}{}:
+		s.logger.Debug("scheduler wake queued",
+			"apply_id", applyIdentifier,
+			"database", database,
+			"environment", environment)
+	default:
+		s.logger.Debug("scheduler wake already pending",
+			"apply_id", applyIdentifier,
+			"database", database,
+			"environment", environment)
+	}
 }
 
 // schedulerWorker is a single worker that claims at most one apply on startup
-// and on each scheduler poll tick.
-func (s *Service) schedulerWorker(ctx context.Context, workerID int, stop <-chan struct{}) {
+// and on each scheduler poll tick. Wake signals share the same claim path as
+// polling; storage locking decides whether a worker actually owns work.
+func (s *Service) schedulerWorker(ctx context.Context, workerID int, stop <-chan struct{}, wake <-chan struct{}) {
 	ticker := time.NewTicker(s.schedulerPollInterval)
 	defer ticker.Stop()
 
@@ -86,6 +134,9 @@ func (s *Service) schedulerWorker(ctx context.Context, workerID int, stop <-chan
 		case <-ctx.Done():
 			s.logger.Debug("scheduler worker context cancelled", "worker", workerID)
 			return
+		case <-wake:
+			s.logger.Debug("scheduler worker woke for queued apply", "worker", workerID)
+			s.recoverApplies(ctx, workerID)
 		case <-ticker.C:
 			s.recoverApplies(ctx, workerID)
 		}
@@ -166,6 +217,18 @@ func (s *Service) recoverApplies(ctx context.Context, workerID int) {
 		metrics.AdjustActiveApplies(ctx, 1, apply.Database, apply.Environment)
 	}
 	if err := client.ResumeApply(ctx, apply); err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) || ctx.Err() != nil {
+			s.logger.Debug("scheduler: stopped while running claimed apply",
+				"worker", workerID,
+				"apply_id", apply.ApplyIdentifier,
+				"database", apply.Database,
+				"environment", apply.Environment,
+				"error", err)
+			if retryableClaim {
+				metrics.AdjustActiveApplies(ctx, -1, apply.Database, apply.Environment)
+			}
+			return
+		}
 		s.logger.Error("scheduler: failed to resume apply",
 			"worker", workerID,
 			"apply_id", apply.ApplyIdentifier,

--- a/pkg/api/service.go
+++ b/pkg/api/service.go
@@ -98,6 +98,12 @@ func (c TernConfig) Endpoint(deployment, environment string) (string, error) {
 // The webhook handler uses this to start watching progress and posting PR comments.
 type RecoveryCallback func(apply *storage.Apply)
 
+type pendingObserverKey struct {
+	database    string
+	deployment  string
+	environment string
+}
+
 type Service struct {
 	storage     storage.Storage
 	config      *ServerConfig
@@ -106,7 +112,10 @@ type Service struct {
 	logger      *slog.Logger
 
 	// Scheduler loop management.
+	schedulerMu           sync.Mutex
 	stopRecovery          chan struct{}
+	cancelRecovery        context.CancelFunc
+	schedulerWake         chan struct{}
 	recoveryWg            sync.WaitGroup
 	schedulerPollInterval time.Duration
 
@@ -114,6 +123,9 @@ type Service struct {
 	// ResumeApply starts the engine/poller. Set by the webhook handler to attach
 	// an observer for PR comments.
 	OnApplyRecovered RecoveryCallback
+
+	pendingObserverMu sync.Mutex
+	pendingObservers  map[pendingObserverKey]tern.ProgressObserver
 }
 
 // SetApplyObserver sets a progress observer on the tern client for an apply.
@@ -134,9 +146,9 @@ func (s *Service) SetApplyObserver(database, deployment, environment string, app
 	client.SetObserver(applyID, observer)
 }
 
-// SetPendingObserver sets an observer that will be consumed by the next Apply()
-// call. The observer is registered before the engine starts, preventing the
-// race where the apply completes before the observer is set.
+// SetPendingObserver stores an observer for the next apply request for this
+// target. ExecuteApply registers it on the durable apply before scheduler
+// dispatch can start.
 func (s *Service) SetPendingObserver(database, deployment, environment string, observer tern.ProgressObserver) {
 	deployment, err := s.deploymentForDatabaseEnvironment(database, deployment, environment)
 	if err != nil {
@@ -144,13 +156,28 @@ func (s *Service) SetPendingObserver(database, deployment, environment string, o
 			"database", database, "deployment", deployment, "environment", environment, "error", err)
 		return
 	}
-	client, err := s.TernClient(deployment, environment)
-	if err != nil {
-		s.logger.Error("failed to get tern client for pending observer",
-			"database", database, "deployment", deployment, "environment", environment, "error", err)
-		return
+
+	key := pendingObserverKey{database: database, deployment: deployment, environment: environment}
+	s.pendingObserverMu.Lock()
+	defer s.pendingObserverMu.Unlock()
+	if s.pendingObservers == nil {
+		s.pendingObservers = make(map[pendingObserverKey]tern.ProgressObserver)
 	}
-	client.SetPendingObserver(observer)
+	if observer == nil {
+		delete(s.pendingObservers, key)
+	} else {
+		s.pendingObservers[key] = observer
+	}
+}
+
+func (s *Service) consumePendingObserver(database, deployment, environment string) tern.ProgressObserver {
+	key := pendingObserverKey{database: database, deployment: deployment, environment: environment}
+
+	s.pendingObserverMu.Lock()
+	defer s.pendingObserverMu.Unlock()
+	observer := s.pendingObservers[key]
+	delete(s.pendingObservers, key)
+	return observer
 }
 
 // New creates a new SchemaBot service.
@@ -170,6 +197,7 @@ func New(st storage.Storage, config *ServerConfig, ternClients map[string]tern.C
 		ternClients:           ternClients,
 		logger:                logger,
 		schedulerPollInterval: SchedulerPollInterval,
+		pendingObservers:      make(map[pendingObserverKey]tern.ProgressObserver),
 	}
 }
 
@@ -182,6 +210,8 @@ func (s *Service) SetSchedulerPollInterval(interval time.Duration) error {
 	if interval <= 0 {
 		return fmt.Errorf("scheduler poll interval must be positive")
 	}
+	s.schedulerMu.Lock()
+	defer s.schedulerMu.Unlock()
 	if s.stopRecovery != nil {
 		return fmt.Errorf("scheduler already running")
 	}
@@ -472,10 +502,9 @@ func (s *Service) ConfigureRoutes(mux *http.ServeMux) {
 //
 // Local mode (external_id is empty):
 //
-// LocalClient.Apply() creates the apply record in the same database as
-// the API layer. It never sets external_id because there is no remote
-// Tern — LocalClient IS the engine. ExecuteApply checks
-// client.IsRemote() == false and skips generating a new identifier.
+// API-created local applies are queued in the same database as the API layer.
+// They never set external_id because there is no remote Tern; scheduler workers
+// dispatch them through LocalClient.ResumeApply().
 //
 //	caller sends "apply-def456"
 //	  → storage lookup: apply_identifier="apply-def456", external_id=""

--- a/pkg/cmd/commands/serve.go
+++ b/pkg/cmd/commands/serve.go
@@ -147,8 +147,9 @@ func (cmd *ServeCmd) Run(g *Globals) error {
 	webhookRuntime.StartMissingSummaryReconciliation(ctx, logger)
 
 	// Start the scheduler worker pool after webhook callbacks are registered.
-	// This polls for stale applies every 10 seconds:
+	// This polls for apply work every 10 seconds:
 	// - Runs immediately on startup
+	// - Dispatches queued local applies
 	// - Recovers applies with stale heartbeats (> 1 minute) using FOR UPDATE SKIP LOCKED
 	// - STOPPED applies are NOT auto-resumed (user must call `schemabot start`)
 	svc.StartScheduler(ctx)

--- a/pkg/storage/mysqlstore/applies.go
+++ b/pkg/storage/mysqlstore/applies.go
@@ -345,6 +345,75 @@ func (s *applyStore) Create(ctx context.Context, apply *storage.Apply) (int64, e
 	return id, nil
 }
 
+// CreateWithTasks stores an apply and its initial tasks in one transaction.
+func (s *applyStore) CreateWithTasks(ctx context.Context, apply *storage.Apply, tasks []*storage.Task) (int64, error) {
+	// Ensure options has valid JSON (empty object if nil)
+	options := apply.Options
+	if len(options) == 0 {
+		options = []byte("{}")
+	}
+
+	lockTarget := isActiveApplyState(apply.State)
+	var writeTx *applyWriteTx
+	var err error
+	if lockTarget {
+		writeTx, err = beginApplyTargetWriteTx(ctx, s.db, "create apply with tasks", apply.Database, apply.DatabaseType, apply.Environment)
+		if err != nil {
+			return 0, err
+		}
+	} else {
+		writeTx, err = beginApplyWriteTx(ctx, s.db, "create apply with tasks")
+		if err != nil {
+			return 0, err
+		}
+	}
+	defer writeTx.close(ctx, "create apply with tasks")
+
+	if lockTarget {
+		if err := checkNoActiveApplyForTarget(ctx, writeTx.tx, apply.Database, apply.DatabaseType, apply.Environment, 0); err != nil {
+			return 0, err
+		}
+	}
+
+	result, err := writeTx.tx.ExecContext(ctx, `
+		INSERT INTO applies (
+			apply_identifier, lock_id, plan_id, database_name, database_type,
+			repository, pull_request, environment, deployment, caller, installation_id, external_id, engine,
+			state, error_message, options, attempt
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`,
+		apply.ApplyIdentifier, apply.LockID, apply.PlanID, apply.Database, apply.DatabaseType,
+		apply.Repository, apply.PullRequest, apply.Environment, apply.Deployment, apply.Caller, apply.InstallationID, apply.ExternalID, apply.Engine,
+		apply.State, apply.ErrorMessage, string(options), apply.Attempt,
+	)
+	if err != nil {
+		if isDuplicateKeyError(err) {
+			return 0, fmt.Errorf("create apply %s: %w", apply.ApplyIdentifier, storage.ErrApplyIDExists)
+		}
+		return 0, fmt.Errorf("insert apply %s: %w", apply.ApplyIdentifier, err)
+	}
+
+	id, err := result.LastInsertId()
+	if err != nil {
+		return 0, fmt.Errorf("read inserted apply id for %s: %w", apply.ApplyIdentifier, err)
+	}
+
+	for _, task := range tasks {
+		task.ApplyID = id
+		taskID, err := insertTask(ctx, writeTx.tx, task)
+		if err != nil {
+			return 0, fmt.Errorf("insert task %s for apply %s: %w", task.TaskIdentifier, apply.ApplyIdentifier, err)
+		}
+		task.ID = taskID
+	}
+
+	if err := writeTx.commit(); err != nil {
+		return 0, fmt.Errorf("commit create apply with tasks: %w", err)
+	}
+
+	return id, nil
+}
+
 // Get returns an apply by ID, or nil if not found.
 func (s *applyStore) Get(ctx context.Context, id int64) (*storage.Apply, error) {
 	row := s.db.QueryRowContext(ctx, `

--- a/pkg/storage/mysqlstore/applies_test.go
+++ b/pkg/storage/mysqlstore/applies_test.go
@@ -66,6 +66,79 @@ func TestApplyStore_CreateDuplicate(t *testing.T) {
 	require.ErrorIs(t, err, storage.ErrApplyIDExists)
 }
 
+func TestApplyStore_CreateWithTasksCommitsQueueAtomically(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", storage.DatabaseTypeMySQL, "staging")
+	now := time.Now()
+	apply := &storage.Apply{
+		ApplyIdentifier: "apply_create_with_tasks",
+		LockID:          lock.ID,
+		PlanID:          1,
+		Database:        "testdb",
+		DatabaseType:    storage.DatabaseTypeMySQL,
+		Repository:      "org/repo",
+		PullRequest:     123,
+		Environment:     "staging",
+		Engine:          storage.EngineSpirit,
+		State:           state.Apply.Pending,
+		Options:         []byte("{}"),
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+	tasks := []*storage.Task{
+		{
+			TaskIdentifier: "task_create_with_tasks_users",
+			PlanID:         1,
+			Database:       "testdb",
+			DatabaseType:   storage.DatabaseTypeMySQL,
+			Engine:         storage.EngineSpirit,
+			Environment:    "staging",
+			State:          state.Task.Pending,
+			TableName:      "users",
+			DDL:            "ALTER TABLE users ADD COLUMN email VARCHAR(255)",
+			DDLAction:      "alter",
+			Options:        []byte("{}"),
+			CreatedAt:      now,
+			UpdatedAt:      now,
+		},
+		{
+			TaskIdentifier: "task_create_with_tasks_orders",
+			PlanID:         1,
+			Database:       "testdb",
+			DatabaseType:   storage.DatabaseTypeMySQL,
+			Engine:         storage.EngineSpirit,
+			Environment:    "staging",
+			State:          state.Task.Pending,
+			TableName:      "orders",
+			DDL:            "ALTER TABLE orders ADD COLUMN status VARCHAR(255)",
+			DDLAction:      "alter",
+			Options:        []byte("{}"),
+			CreatedAt:      now,
+			UpdatedAt:      now,
+		},
+	}
+
+	applyID, err := store.Applies().CreateWithTasks(ctx, apply, tasks)
+	require.NoError(t, err)
+	require.NotZero(t, applyID)
+
+	storedTasks, err := store.Tasks().GetByApplyID(ctx, applyID)
+	require.NoError(t, err)
+	require.Len(t, storedTasks, 2)
+	assert.Equal(t, applyID, tasks[0].ApplyID)
+	assert.Equal(t, applyID, tasks[1].ApplyID)
+
+	// A pending apply created with its full task set is immediately ready for
+	// scheduler dispatch; workers never see a partially populated task list.
+	claimed, err := store.Applies().FindNextApply(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, claimed)
+	assert.Equal(t, apply.ApplyIdentifier, claimed.ApplyIdentifier)
+}
+
 func TestApplyStore_CreateBlocksActiveApplyForSameTarget(t *testing.T) {
 	clearTables(t)
 	ctx := t.Context()

--- a/pkg/storage/mysqlstore/tasks.go
+++ b/pkg/storage/mysqlstore/tasks.go
@@ -36,15 +36,23 @@ type taskStore struct {
 	db *sql.DB
 }
 
+type taskInserter interface {
+	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
+}
+
 // Create stores a new task.
 func (s *taskStore) Create(ctx context.Context, task *storage.Task) (int64, error) {
+	return insertTask(ctx, s.db, task)
+}
+
+func insertTask(ctx context.Context, execer taskInserter, task *storage.Task) (int64, error) {
 	// Ensure options has valid JSON (empty object if nil)
 	options := task.Options
 	if len(options) == 0 {
 		options = []byte("{}")
 	}
 
-	result, err := s.db.ExecContext(ctx, `
+	result, err := execer.ExecContext(ctx, `
 		INSERT INTO tasks (
 			task_identifier, apply_id, plan_id, database_name, database_type,
 			namespace, table_name, ddl, ddl_action,

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -168,6 +168,11 @@ type ApplyStore interface {
 	// the same database, database type, and environment.
 	Create(ctx context.Context, apply *Apply) (int64, error)
 
+	// CreateWithTasks stores a new apply and its initial tasks in one
+	// transaction. Pending applies become scheduler-claimable only after the
+	// task rows are committed.
+	CreateWithTasks(ctx context.Context, apply *Apply, tasks []*Task) (int64, error)
+
 	// Get returns an apply by ID, or nil if not found.
 	Get(ctx context.Context, id int64) (*Apply, error)
 
@@ -200,9 +205,9 @@ type ApplyStore interface {
 	GetInProgress(ctx context.Context) ([]*Apply, error)
 
 	// FindNextApply atomically claims the next apply that needs attention.
-	// A claim selects one stale apply and refreshes its heartbeat in the same
-	// transaction. That heartbeat is the scheduler's lease while it reloads
-	// state and resumes the apply.
+	// A claim selects one apply that needs work and refreshes its heartbeat in
+	// the same transaction. That heartbeat is the scheduler's lease while it
+	// reloads state and starts or resumes the apply.
 	// Returns the claimed apply, or nil if nothing needs work.
 	FindNextApply(ctx context.Context) (*Apply, error)
 

--- a/pkg/tern/README.md
+++ b/pkg/tern/README.md
@@ -55,12 +55,12 @@ In atomic mode with `--defer-cutover`, the schema change pauses at `WaitingForCu
 
 ## Recovery
 
-If the SchemaBot server crashes during an apply, the recovery mechanism resumes it:
+The scheduler starts queued local applies and resumes applies after a missed heartbeat:
 
-1. The API service scheduler polls every 10 seconds for applies with stale heartbeats (no update for 1+ minute)
+1. The API service scheduler polls every 10 seconds for queued applies and applies with stale heartbeats (no update for 1+ minute)
 2. It claims the apply by selecting it and refreshing its heartbeat in one transaction
 3. It calls `ResumeApply()` on the appropriate Tern client
-4. **LocalClient**: Calls `engine.Apply()` with the same DDL — Spirit auto-detects its checkpoint table and resumes from where it left off
+4. **LocalClient**: Starts queued work or calls `engine.Apply()` with the same DDL — Spirit auto-detects its checkpoint table and resumes from where it left off
 5. **GRPCClient**: Calls `Start()` on the remote Tern service, then spawns a local progress poller
 
 Stopped applies (user called `stop`) are not auto-resumed — the user must explicitly call `start`.

--- a/pkg/tern/client.go
+++ b/pkg/tern/client.go
@@ -51,10 +51,9 @@ type Client interface {
 	// Health checks the service health.
 	Health(ctx context.Context) error
 
-	// ResumeApply resumes an in-progress apply whose heartbeat has expired.
-	// Uses checkpoint/resume capabilities of the underlying engine.
-	// This is called by Service.RecoverInProgress on startup for applies
-	// with stale heartbeats (crashed workers).
+	// ResumeApply starts or resumes work claimed by a scheduler worker.
+	// Fresh pending applies are dispatched for the first time; stale applies
+	// use checkpoint/resume capabilities of the underlying engine.
 	ResumeApply(ctx context.Context, apply *storage.Apply) error
 
 	// Endpoint returns the address this client connects to.
@@ -64,12 +63,6 @@ type Client interface {
 
 	// IsRemote reports whether this client delegates to a separate Tern
 	// service with its own storage.
-	//
-	// When true (GRPCClient): ExecuteApply creates apply/task records in
-	// SchemaBot's storage and stores Tern's apply_id as external_id.
-	//
-	// When false (LocalClient): Apply() already created the records in the
-	// same database — ExecuteApply reuses them.
 	IsRemote() bool
 
 	// SetPendingObserver sets an observer that will be consumed by the next

--- a/pkg/tern/grpc_client.go
+++ b/pkg/tern/grpc_client.go
@@ -92,11 +92,9 @@ package tern
 // helper translates apply_identifier → external_id before calling Tern.
 //
 // In local mode (client.IsRemote() == false), the LocalClient runs in the
-// same process and writes to the same database as the API layer. It creates
-// the apply record (with no external_id) before ExecuteApply runs.
-// ExecuteApply sees IsRemote() == false and keeps applyIdentifier =
-// resp.ApplyId, leaving external_id empty. LocalClient uses apply_id
-// when provided, falling back to database lookup.
+// same process and writes to the same database as the API layer. API-created
+// applies are queued in SchemaBot storage with no external_id, then scheduler
+// workers dispatch them through LocalClient.ResumeApply().
 
 import (
 	"context"
@@ -355,12 +353,9 @@ func (c *GRPCClient) Health(ctx context.Context) error {
 
 // ResumeApply starts background progress tracking for an apply.
 //
-// Called from two places:
-//   - ExecuteApply (fresh apply): the apply was just created in SchemaBot's
-//     storage but the background poller hasn't started yet. State is "pending".
-//   - RecoverInProgress (crash recovery): the apply's heartbeat expired,
-//     indicating the previous poller died. State may be "stopped" (needs
-//     Start RPC) or still "running"/"pending" (just needs a new poller).
+// Called when a fresh remote apply needs progress tracking or when the apply's
+// heartbeat expired, indicating the previous poller died. State may be stopped
+// (needs a Start RPC) or already active (just needs a new poller).
 //
 // In contrast, LocalClient doesn't need this — it starts its own poller
 // inside LocalClient.Apply() because it shares the same storage.

--- a/pkg/tern/local_apply.go
+++ b/pkg/tern/local_apply.go
@@ -242,9 +242,49 @@ func groupedApplyModeDescription(apply *storage.Apply) string {
 	}
 }
 
-// executeApplyAtomic runs all DDLs in one engine operation. For Spirit with
+func (c *LocalClient) usesGroupedApply(apply *storage.Apply) bool {
+	if apply.DatabaseType == storage.DatabaseTypeVitess {
+		return true
+	}
+	return apply.DatabaseType == storage.DatabaseTypeMySQL && apply.GetOptions().DeferCutover
+}
+
+func (c *LocalClient) setApplyCancel(cancel context.CancelFunc) {
+	c.cancelMu.Lock()
+	c.cancelApply = cancel
+	c.cancelMu.Unlock()
+}
+
+func (c *LocalClient) clearApplyCancel() {
+	c.cancelMu.Lock()
+	c.cancelApply = nil
+	c.cancelMu.Unlock()
+}
+
+func (c *LocalClient) startApplyExecution(ctx context.Context, cancel context.CancelFunc, apply *storage.Apply, tasks []*storage.Task, plan *storage.Plan, options map[string]string) {
+	go func() {
+		defer c.clearApplyCancel()
+		defer cancel()
+		c.runApplyExecution(ctx, apply, tasks, plan, options)
+	}()
+}
+
+func (c *LocalClient) runApplyExecution(ctx context.Context, apply *storage.Apply, tasks []*storage.Task, plan *storage.Plan, options map[string]string) {
+	if c.usesGroupedApply(apply) {
+		c.runWithRecovery(ctx, apply, tasks, func() {
+			c.executeGroupedApply(ctx, apply, tasks, plan, options)
+		})
+		return
+	}
+
+	c.runWithRecovery(ctx, apply, tasks, func() {
+		c.executeApplySequential(ctx, apply, tasks, plan, options)
+	})
+}
+
+// executeGroupedApply runs all DDLs in one engine operation. For Spirit with
 // defer_cutover, this is atomic cutover; for Vitess, this is one deploy request.
-func (c *LocalClient) executeApplyAtomic(ctx context.Context, apply *storage.Apply, tasks []*storage.Task, plan *storage.Plan, options map[string]string) {
+func (c *LocalClient) executeGroupedApply(ctx context.Context, apply *storage.Apply, tasks []*storage.Task, plan *storage.Plan, options map[string]string) {
 	defer c.startApplyHeartbeat(ctx, apply)()
 	creds := c.credentials()
 	mode := groupedApplyMode(apply)

--- a/pkg/tern/local_client.go
+++ b/pkg/tern/local_client.go
@@ -140,7 +140,7 @@ type LocalClient struct {
 	heartbeatInterval time.Duration
 
 	// cancelApply cancels the background goroutine running executeApplySequential
-	// or executeApplyAtomic. Set when an apply starts, called by Stop().
+	// or executeGroupedApply. Set when an apply starts, called by Stop().
 	// Protected by cancelMu since Apply and Stop run on different goroutines.
 	cancelMu    sync.Mutex
 	cancelApply context.CancelFunc
@@ -151,8 +151,8 @@ type LocalClient struct {
 	observerMu sync.RWMutex
 	observers  map[int64]ProgressObserver // keyed by apply ID
 
-	// pendingObserver is consumed by the next Apply() call and registered
-	// before Spirit starts. Set by the webhook handler via SetPendingObserver.
+	// pendingObserver is consumed by the next direct Apply() call and registered
+	// before Spirit starts.
 	// Protected by observerMu.
 	pendingObserver ProgressObserver
 }
@@ -487,8 +487,6 @@ func (c *LocalClient) Apply(ctx context.Context, req *ternv1.ApplyRequest) (*ter
 		caller = options["caller"]
 	}
 
-	// Detect deferred cutover. Spirit uses this for atomic cutover; Vitess
-	// always uses the grouped engine apply path for deploy requests.
 	deferCutover := options["defer_cutover"] == "true"
 	allowUnsafe := options["allow_unsafe"] == "true"
 
@@ -588,9 +586,9 @@ func (c *LocalClient) Apply(ctx context.Context, req *ternv1.ApplyRequest) (*ter
 		tasks[i].ID = taskID
 	}
 
-	// Register pending observer before starting the engine — prevents race where
-	// the apply completes before the observer is set. The webhook handler calls
-	// SetPendingObserver before triggering the apply API call.
+	// Direct client calls can still register a pending observer before starting
+	// the engine. API-created applies use the service-level observer registry
+	// because scheduler workers dispatch them asynchronously.
 	if obs := c.consumePendingObserver(); obs != nil {
 		// Set the apply ID on the observer if it supports it (e.g., CommentObserver
 		// needs the ID to look up tracked comments for editing).
@@ -603,22 +601,8 @@ func (c *LocalClient) Apply(ctx context.Context, req *ternv1.ApplyRequest) (*ter
 
 	// Start apply in background with cancellable context (Stop() cancels this)
 	applyCtx, cancelApply := context.WithCancel(context.WithoutCancel(ctx))
-	c.cancelMu.Lock()
-	c.cancelApply = cancelApply
-	c.cancelMu.Unlock()
-	if deferCutover || c.config.Type == storage.DatabaseTypeVitess {
-		// Grouped mode: all DDLs are sent in one engine call. For Spirit this
-		// is atomic cutover when defer_cutover is enabled; for Vitess this
-		// creates one deploy request per apply.
-		go c.runWithRecovery(applyCtx, apply, tasks, func() {
-			c.executeApplyAtomic(applyCtx, apply, tasks, plan, options)
-		})
-	} else {
-		// Independent mode: each DDL runs separately, cuts over independently
-		go c.runWithRecovery(applyCtx, apply, tasks, func() {
-			c.executeApplySequential(applyCtx, apply, tasks, plan, options)
-		})
-	}
+	c.setApplyCancel(cancelApply)
+	c.startApplyExecution(applyCtx, cancelApply, apply, tasks, plan, options)
 
 	return &ternv1.ApplyResponse{
 		Accepted: true,

--- a/pkg/tern/local_control_resume.go
+++ b/pkg/tern/local_control_resume.go
@@ -162,7 +162,7 @@ func (c *LocalClient) Start(ctx context.Context, req *ternv1.StartRequest) (*ter
 
 	if apply.GetOptions().DeferCutover {
 		logMsg := fmt.Sprintf("Resume requested: %d tasks resumed, %d already completed", len(resumeTasks), completedCount)
-		if err := c.launchAtomicResume(ctx, apply, resumeTasks, plan, options, logMsg); err != nil {
+		if err := c.launchAtomicResume(ctx, apply, resumeTasks, plan, options, logMsg, false); err != nil {
 			return nil, err
 		}
 	} else {
@@ -183,8 +183,12 @@ func (c *LocalClient) Start(ctx context.Context, req *ternv1.StartRequest) (*ter
 			fmt.Sprintf("Resume requested (sequential): %d tasks to resume, %d already completed", len(resumeTasks), completedCount), oldApplyState, state.Apply.Running)
 
 		resumeCtx, cancelResume := context.WithCancel(context.Background())
-		c.cancelApply = cancelResume
-		go c.resumeApplySequential(resumeCtx, apply, resumeTasks, plan, options)
+		c.setApplyCancel(cancelResume)
+		go func() {
+			defer c.clearApplyCancel()
+			defer cancelResume()
+			c.resumeApplySequential(resumeCtx, apply, resumeTasks, plan, options)
+		}()
 	}
 
 	return &ternv1.StartResponse{
@@ -362,15 +366,7 @@ func (c *LocalClient) replanAndFilterTasks(ctx context.Context, apply *storage.A
 
 // buildApplyOptions converts apply options to the string map used by the engine.
 func buildApplyOptions(apply *storage.Apply) map[string]string {
-	opts := apply.GetOptions()
-	options := make(map[string]string)
-	if opts.DeferCutover {
-		options["defer_cutover"] = "true"
-	}
-	if opts.AllowUnsafe {
-		options["allow_unsafe"] = "true"
-	}
-	return options
+	return apply.GetOptions().Map()
 }
 
 // prepareRetryableTasksForResume queues only the task work that previously
@@ -394,10 +390,12 @@ func (c *LocalClient) prepareRetryableTasksForResume(ctx context.Context, apply 
 }
 
 // launchAtomicResume sends all DDLs to the engine in one call, marks tasks and
-// apply as RUNNING, logs the provided message, and starts pollForCompletionAtomic
-// in a background goroutine. Used by both Start() and ResumeApply().
+// apply as RUNNING, logs the provided message, and then polls for completion.
+// Scheduler-owned calls block so the worker owns the apply until terminal or
+// retry-waiting state; user start calls poll in the background and returns
+// after the engine accepts the resume.
 func (c *LocalClient) launchAtomicResume(ctx context.Context, apply *storage.Apply,
-	tasks []*storage.Task, plan *storage.Plan, options map[string]string, logMessage string) error {
+	tasks []*storage.Task, plan *storage.Plan, options map[string]string, logMessage string, block bool) error {
 
 	var ddls []string
 	for _, t := range tasks {
@@ -449,6 +447,13 @@ func (c *LocalClient) launchAtomicResume(ctx context.Context, apply *storage.App
 	c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventStateTransition, storage.LogSourceSchemaBot,
 		logMessage, oldApplyState, state.Apply.Running)
 
+	if block {
+		stopHeartbeat := c.startApplyHeartbeat(ctx, apply)
+		defer stopHeartbeat()
+		c.pollForCompletionAtomic(ctx, apply, tasks, creds, nil)
+		return nil
+	}
+
 	stopHeartbeat := c.startApplyHeartbeat(context.Background(), apply)
 	go func() {
 		defer stopHeartbeat()
@@ -464,9 +469,9 @@ func (c *LocalClient) notifyTerminalObserver(apply *storage.Apply, tasks []*stor
 	}
 }
 
-// ResumeApply resumes an in-progress apply whose heartbeat has expired.
-// This can happen after a server restart or if the worker goroutine crashed.
-// Spirit's checkpoint table allows resuming from where the schema change left off.
+// ResumeApply starts or resumes an apply claimed by a scheduler worker.
+// Pending applies are dispatched for the first time; stale applies use the
+// engine's resume metadata to continue after a missed heartbeat.
 func (c *LocalClient) ResumeApply(ctx context.Context, apply *storage.Apply) error {
 	// Get tasks for this apply
 	tasks, err := c.storage.Tasks().GetByApplyID(ctx, apply.ID)
@@ -499,6 +504,11 @@ func (c *LocalClient) ResumeApply(ctx context.Context, apply *storage.Apply) err
 		}
 		c.notifyTerminalObserver(apply, tasks)
 		return nil
+	}
+
+	if state.IsState(apply.State, state.Apply.Pending) {
+		c.dispatchQueuedApply(ctx, apply, tasks, plan)
+		return ctx.Err()
 	}
 
 	c.logger.Info("resuming apply (heartbeat expired)",
@@ -539,7 +549,11 @@ func (c *LocalClient) ResumeApply(ctx context.Context, apply *storage.Apply) err
 	options := buildApplyOptions(apply)
 
 	if apply.GetOptions().DeferCutover {
-		if err := c.launchAtomicResume(ctx, apply, activeTasks, plan, options, fmt.Sprintf("Apply resumed from checkpoint (%s)", groupedApplyModeDescription(apply))); err != nil {
+		resumeCtx, cancelResume := context.WithCancel(ctx)
+		c.setApplyCancel(cancelResume)
+		defer c.clearApplyCancel()
+		defer cancelResume()
+		if err := c.launchAtomicResume(resumeCtx, apply, activeTasks, plan, options, fmt.Sprintf("Apply resumed from checkpoint (%s)", groupedApplyModeDescription(apply)), true); err != nil {
 			if c.shouldRetryEngineError(err) {
 				c.logger.Warn("engine apply failed during recovery, pausing apply for scheduler retry",
 					"apply_id", apply.ApplyIdentifier,
@@ -566,8 +580,29 @@ func (c *LocalClient) ResumeApply(ctx context.Context, apply *storage.Apply) err
 		c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventStateTransition, storage.LogSourceSchemaBot,
 			"Apply resumed from checkpoint (sequential)", "", state.Apply.Running)
 
-		go c.resumeApplySequential(context.Background(), apply, activeTasks, plan, options)
+		resumeCtx, cancelResume := context.WithCancel(ctx)
+		c.setApplyCancel(cancelResume)
+		defer c.clearApplyCancel()
+		defer cancelResume()
+		c.resumeApplySequential(resumeCtx, apply, activeTasks, plan, options)
 	}
 
-	return nil
+	return ctx.Err()
+}
+
+func (c *LocalClient) dispatchQueuedApply(ctx context.Context, apply *storage.Apply, tasks []*storage.Task, plan *storage.Plan) {
+	options := buildApplyOptions(apply)
+	applyCtx, cancelApply := context.WithCancel(ctx)
+	c.setApplyCancel(cancelApply)
+	defer c.clearApplyCancel()
+	defer cancelApply()
+
+	c.logger.Info("dispatching queued apply",
+		"apply_id", apply.ApplyIdentifier,
+		"database", apply.Database,
+		"state", apply.State,
+		"task_count", len(tasks),
+	)
+
+	c.runApplyExecution(applyCtx, apply, tasks, plan, options)
 }

--- a/pkg/tern/observer.go
+++ b/pkg/tern/observer.go
@@ -29,16 +29,30 @@ type ProgressObserver interface {
 func (c *LocalClient) SetObserver(applyID int64, observer ProgressObserver) {
 	c.observerMu.Lock()
 	defer c.observerMu.Unlock()
+
+	if observer == nil {
+		delete(c.observers, applyID)
+		if c.logger != nil {
+			c.logger.Debug("cleared progress observer for apply", "apply_id", applyID)
+		}
+		return
+	}
+
 	if c.observers == nil {
 		c.observers = make(map[int64]ProgressObserver)
+	}
+	if _, exists := c.observers[applyID]; exists {
+		if c.logger != nil {
+			c.logger.Debug("progress observer already registered for apply", "apply_id", applyID)
+		}
+		return
 	}
 	c.observers[applyID] = observer
 }
 
-// SetPendingObserver sets an observer that will be consumed by the next Apply()
-// call. The observer is registered on the apply record before the engine starts,
-// preventing the race where the apply completes before the observer is set.
-// Called by the webhook handler before triggering the apply API call.
+// SetPendingObserver sets an observer that will be consumed by the next direct
+// client Apply() call. The API service uses its own pending-observer registry
+// because scheduler workers dispatch API-created applies asynchronously.
 func (c *LocalClient) SetPendingObserver(observer ProgressObserver) {
 	c.observerMu.Lock()
 	defer c.observerMu.Unlock()

--- a/pkg/webhook/apply_handlers.go
+++ b/pkg/webhook/apply_handlers.go
@@ -505,10 +505,8 @@ func (h *Handler) executeApply(
 
 	caller := fmt.Sprintf("github:%s@%s#%d", requestedBy, repo, pr)
 
-	// Set observer before starting the apply — consumed by Apply() before the
-	// engine starts, so the observer is registered before any progress events fire.
-	// ApplyID is set to 0 here; LocalClient.Apply() updates it after creating
-	// the apply record.
+	// Set observer before queuing the apply so ExecuteApply can register it on
+	// the durable apply row before scheduler dispatch starts.
 	observer := NewCommentObserver(CommentObserverConfig{
 		GHClient:       h.ghClient,
 		Storage:        h.service.Storage(),

--- a/pkg/webhook/apply_test.go
+++ b/pkg/webhook/apply_test.go
@@ -78,6 +78,15 @@ func TestFormatProgressComment_WithError(t *testing.T) {
 	assert.Contains(t, body, "Failed")
 }
 
+func TestCommentObserverShouldDeferCutoverUsesPersistedApplyOption(t *testing.T) {
+	apply := &storage.Apply{
+		Options: storage.MarshalApplyOptions(storage.ApplyOptions{DeferCutover: true}),
+	}
+	observer := &CommentObserver{}
+
+	assert.True(t, observer.shouldDeferCutover(apply))
+}
+
 func TestFormatCutoverComment(t *testing.T) {
 	apply := &storage.Apply{
 		ApplyIdentifier: "apply-abc123",

--- a/pkg/webhook/comment_observer.go
+++ b/pkg/webhook/comment_observer.go
@@ -70,7 +70,7 @@ type CommentObserverConfig struct {
 }
 
 // SetApplyID sets the apply ID after the apply record is created.
-// Called by LocalClient.Apply() when consuming a pending observer.
+// Called before the observer is registered for progress notifications.
 func (o *CommentObserver) SetApplyID(id int64) {
 	o.applyID = id
 }
@@ -116,7 +116,7 @@ func (o *CommentObserver) OnProgress(apply *storage.Apply, tasks []*storage.Task
 
 	// Post cutover comment when entering cutting_over with defer_cutover,
 	// but only if one hasn't been posted already.
-	if currentState == state.Apply.CuttingOver && o.deferCutover && !o.hasCutoverComment {
+	if currentState == state.Apply.CuttingOver && o.shouldDeferCutover(apply) && !o.hasCutoverComment {
 		body := formatCutoverComment(apply, tasks)
 		o.postAndTrackComment(state.Comment.Cutover, body)
 		o.hasCutoverComment = true
@@ -208,6 +208,10 @@ func (o *CommentObserver) OnTerminal(apply *storage.Apply, tasks []*storage.Task
 	if o.OnTerminalHook != nil {
 		o.OnTerminalHook(apply)
 	}
+}
+
+func (o *CommentObserver) shouldDeferCutover(apply *storage.Apply) bool {
+	return o.deferCutover || apply.GetOptions().DeferCutover
 }
 
 // editTrackedComment looks up a stored comment ID and edits it.

--- a/pkg/webhook/webhook_e2e_test.go
+++ b/pkg/webhook/webhook_e2e_test.go
@@ -195,6 +195,7 @@ func setupE2EService(t *testing.T, appDBName string) *api.Service {
 	t.Cleanup(func() { _ = localClient.Close() })
 
 	serverConfig := &api.ServerConfig{
+		SchedulerWorkers: 1,
 		Databases: map[string]api.DatabaseConfig{
 			appDBName: {
 				Type: "mysql",
@@ -208,6 +209,10 @@ func setupE2EService(t *testing.T, appDBName string) *api.Service {
 	svc := api.New(st, serverConfig, map[string]tern.Client{
 		appDBName + "/staging": localClient,
 	}, logger)
+	require.NoError(t, svc.SetSchedulerPollInterval(100*time.Millisecond))
+	// Webhook E2E helpers use the real service lifecycle. Local applies are
+	// durably queued by ExecuteApply, then dispatched by scheduler workers.
+	svc.StartScheduler(ctx)
 	t.Cleanup(func() { _ = svc.Close() })
 
 	return svc


### PR DESCRIPTION
Moves local apply execution out of the HTTP request path and into scheduler workers. Local `/api/apply` now commits the apply and its initial tasks together, returns once the work is durably queued, and wakes the scheduler as a fast path for immediate dispatch.

```text
POST /api/apply
      |
      v
applies + tasks committed together (pending)
      |
      +-- wake --> scheduler worker
                     |
                     v
                 claim apply
                     |
                     v
              LocalClient.ResumeApply
                     |
                     v
              Spirit / PlanetScale engine
```

This keeps local observers, options, task metadata, and retry/recovery state tied to the stored apply. The gRPC request-owned apply path is intentionally left in place for a later slice.

🤖 Generated with Codex (GPT-5).