### PR TITLE
fix(grpc): classify retryable dispatch errors

### DIFF
--- a/pkg/tern/grpc_client.go
+++ b/pkg/tern/grpc_client.go
@@ -496,7 +496,7 @@ func (c *GRPCClient) dispatchPendingApply(ctx context.Context, apply *storage.Ap
 		if isAmbiguousRemoteApplyDispatchError(err) {
 			return fmt.Errorf("apply queued gRPC apply %s has ambiguous remote dispatch outcome: %w", apply.ApplyIdentifier, err)
 		}
-		c.markRemoteApplyFailed(ctx, apply, tasks, err.Error(), engine.IsRetryable(err))
+		c.markRemoteApplyFailed(ctx, apply, tasks, err.Error(), isRetryableRemoteApplyError(err))
 		return fmt.Errorf("apply queued gRPC apply %s: %w", apply.ApplyIdentifier, err)
 	}
 	if resp == nil {
@@ -539,6 +539,38 @@ func isAmbiguousRemoteApplyDispatchError(err error) bool {
 		errors.Is(err, context.DeadlineExceeded) ||
 		status.Code(err) == codes.Canceled ||
 		status.Code(err) == codes.DeadlineExceeded
+}
+
+// isRetryableRemoteApplyError classifies a definite remote Apply rejection.
+// Ambiguous cancellation/deadline errors are handled before this path because
+// the control plane cannot know whether the data plane accepted the request.
+func isRetryableRemoteApplyError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if isAmbiguousRemoteApplyDispatchError(err) {
+		return false
+	}
+
+	st, ok := status.FromError(err)
+	if !ok {
+		if engine.IsTransientTransportError(err) {
+			return true
+		}
+		return engine.IsRetryable(err)
+	}
+
+	switch st.Code() {
+	case codes.Internal, codes.Unknown, codes.Unavailable, codes.ResourceExhausted, codes.Aborted:
+		return true
+	case codes.Canceled, codes.DeadlineExceeded:
+		return false
+	case codes.OK, codes.InvalidArgument, codes.NotFound, codes.AlreadyExists, codes.PermissionDenied,
+		codes.Unauthenticated, codes.FailedPrecondition, codes.OutOfRange, codes.Unimplemented, codes.DataLoss:
+		return false
+	default:
+		return false
+	}
 }
 
 func (c *GRPCClient) prepareDispatchTasks(ctx context.Context, apply *storage.Apply, tasks []*storage.Task) error {

--- a/pkg/tern/grpc_client_test.go
+++ b/pkg/tern/grpc_client_test.go
@@ -652,6 +652,93 @@ func TestGRPCClient_ResumeApplyDoesNotFailStateWhenRemoteDispatchOutcomeIsAmbigu
 	assert.Empty(t, task.ErrorMessage)
 }
 
+func TestGRPCClient_ResumeApplyClassifiesRemoteDispatchErrors(t *testing.T) {
+	// When remote dispatch is rejected before the data plane accepts work, the
+	// control plane records the failure using the gRPC status code. Retryable
+	// status codes stay claimable for the scheduler; known-permanent status
+	// codes become terminal failures.
+	testCases := []struct {
+		name            string
+		code            codes.Code
+		message         string
+		wantApplyState  string
+		wantTaskState   string
+		wantCompletedAt bool
+	}{
+		{
+			name:           "retryable remote error",
+			code:           codes.Internal,
+			message:        "remote apply rejected",
+			wantApplyState: state.Apply.FailedRetryable,
+			wantTaskState:  state.Task.FailedRetryable,
+		},
+		{
+			name:            "permanent remote error",
+			code:            codes.FailedPrecondition,
+			message:         "remote apply rejected",
+			wantApplyState:  state.Apply.Failed,
+			wantTaskState:   state.Task.Failed,
+			wantCompletedAt: true,
+		},
+		{
+			name:            "permanent status with transient-looking message",
+			code:            codes.FailedPrecondition,
+			message:         "Too many requests for this deploy request",
+			wantApplyState:  state.Apply.Failed,
+			wantTaskState:   state.Task.Failed,
+			wantCompletedAt: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			server := &capturingTernServer{
+				applyErr: status.Error(tc.code, tc.message),
+			}
+			client, cleanup := testCapturingGRPCClient(t, server)
+			defer cleanup()
+
+			apply := &storage.Apply{
+				ID:              10,
+				ApplyIdentifier: "apply-classify-remote-error",
+				PlanID:          102,
+				Database:        "testdb",
+				DatabaseType:    storage.DatabaseTypeMySQL,
+				Environment:     "staging",
+				State:           state.Apply.Pending,
+			}
+			task := &storage.Task{
+				ID:             14,
+				TaskIdentifier: "task-classify-remote-error",
+				ApplyID:        apply.ID,
+				TableName:      "users",
+				State:          state.Task.Pending,
+			}
+			client.storage = &mockStorage{
+				applies: &mockApplyStore{apply: apply},
+				tasks:   &mockTaskStore{tasks: []*storage.Task{task}},
+				plans: &mockPlanStore{plan: &storage.Plan{
+					ID:             apply.PlanID,
+					PlanIdentifier: "plan-classify-remote-error",
+				}},
+			}
+
+			ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+			defer cancel()
+			err := client.ResumeApply(ctx, apply)
+			require.Error(t, err)
+
+			require.NotNil(t, server.getApplyRequest(), "expected Apply RPC to be attempted")
+			assert.Equal(t, tc.wantApplyState, apply.State)
+			assert.Contains(t, apply.ErrorMessage, tc.message)
+			assert.Equal(t, tc.wantCompletedAt, apply.CompletedAt != nil)
+			assert.Equal(t, tc.wantTaskState, task.State)
+			assert.Contains(t, task.ErrorMessage, tc.message)
+			assert.Equal(t, tc.wantCompletedAt, task.CompletedAt != nil)
+		})
+	}
+}
+
 func TestGRPCClient_QueuedRemoteDispatchPredicate(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/pkg/tern/server.go
+++ b/pkg/tern/server.go
@@ -8,6 +8,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/block/schemabot/pkg/engine"
 	ternv1 "github.com/block/schemabot/pkg/proto/ternv1"
 	"github.com/block/schemabot/pkg/storage"
 )
@@ -48,9 +49,21 @@ func (s *Server) Plan(ctx context.Context, req *ternv1.PlanRequest) (*ternv1.Pla
 func (s *Server) Apply(ctx context.Context, req *ternv1.ApplyRequest) (*ternv1.ApplyResponse, error) {
 	resp, err := s.client.Apply(ctx, req)
 	if err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
+		return nil, status.Error(applyErrorCode(err), err.Error())
 	}
 	return resp, nil
+}
+
+// applyErrorCode preserves engine retryability across the gRPC boundary for
+// scheduler-driven dispatch.
+func applyErrorCode(err error) codes.Code {
+	if err == nil {
+		return codes.OK
+	}
+	if !engine.IsRetryable(err) {
+		return codes.FailedPrecondition
+	}
+	return codes.Internal
 }
 
 func (s *Server) Progress(ctx context.Context, req *ternv1.ProgressRequest) (*ternv1.ProgressResponse, error) {

--- a/pkg/tern/server_test.go
+++ b/pkg/tern/server_test.go
@@ -2,6 +2,7 @@ package tern
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -10,6 +11,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/block/schemabot/pkg/engine"
 	ternv1 "github.com/block/schemabot/pkg/proto/ternv1"
 	"github.com/block/schemabot/pkg/storage"
 )
@@ -20,6 +22,15 @@ type progressErrorClient struct {
 }
 
 func (c progressErrorClient) Progress(context.Context, *ternv1.ProgressRequest) (*ternv1.ProgressResponse, error) {
+	return nil, c.err
+}
+
+type applyErrorClient struct {
+	Client
+	err error
+}
+
+func (c applyErrorClient) Apply(context.Context, *ternv1.ApplyRequest) (*ternv1.ApplyResponse, error) {
 	return nil, c.err
 }
 
@@ -45,6 +56,38 @@ func TestServerProgressMapsMissingApplyDataToNotFound(t *testing.T) {
 			_, err := server.Progress(t.Context(), &ternv1.ProgressRequest{ApplyId: "missing"})
 			require.Error(t, err)
 			assert.Equal(t, codes.NotFound, status.Code(err))
+		})
+	}
+}
+
+func TestServerApplyMapsEngineRetryabilityToStatusCode(t *testing.T) {
+	// The data plane must preserve engine retryability across gRPC so the
+	// control-plane scheduler can pause retryable errors without retrying
+	// known-permanent engine failures.
+	testCases := []struct {
+		name string
+		err  error
+		want codes.Code
+	}{
+		{
+			name: "retryable engine error",
+			err:  errors.New("engine temporarily unavailable"),
+			want: codes.Internal,
+		},
+		{
+			name: "permanent engine error",
+			err:  engine.NewPermanentError("schema change cannot be applied"),
+			want: codes.FailedPrecondition,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			server := NewServer(applyErrorClient{err: tc.err})
+
+			_, err := server.Apply(t.Context(), &ternv1.ApplyRequest{PlanId: "plan-123"})
+			require.Error(t, err)
+			assert.Equal(t, tc.want, status.Code(err))
 		})
 	}
 }


### PR DESCRIPTION
## Why
Remote Tern Apply errors lost engine retryability at the gRPC boundary: every data-plane error became `Internal`, and the scheduler treated unwrapped status errors as retryable. Known-permanent engine failures should stop instead of looping through recovery.

## What
- Map non-retryable engine Apply errors to `FailedPrecondition` from the Tern gRPC server
- Classify scheduler dispatch failures from gRPC status codes before marking the apply `failed` or `failed_retryable`
- Add regression tests for server status mapping and control-plane task/apply state transitions

```
remote engine error
   |
   +-- retryable  -> gRPC Internal           -> failed_retryable -> scheduler can retry
   |
   +-- permanent  -> gRPC FailedPrecondition -> failed           -> terminal
```

Generated with Codex
