### PR TITLE
fix(vitess): fail closed on missing control metadata

### DIFF
--- a/e2e/local/vitess_test.go
+++ b/e2e/local/vitess_test.go
@@ -146,6 +146,15 @@ func usersSchemaWithColumn(colName string) string {
 		1)
 }
 
+func usersSchemaWithIndex(indexName string) string {
+	base := vitessBaseSchema()
+	original := base["testapp_sharded/users.sql"]
+	return strings.Replace(original,
+		"  KEY `idx_email` (`email`)",
+		fmt.Sprintf("  KEY `idx_email` (`email`),\n  KEY `%s` (`full_name`)", indexName),
+		1)
+}
+
 // localscaleAdminPost delegates to the shared e2eutil helper.
 func localscaleAdminPost(t *testing.T, endpoint string, body string) ([]byte, error) {
 	t.Helper()
@@ -1429,13 +1438,11 @@ func TestVitess_Apply_Cancel(t *testing.T) {
 	defer vitessRestoreBaseSchema(t, "staging")
 
 	endpoint := schemabotURL(t)
-	// Use a column addition (instant DDL) with --defer-deploy so the apply
-	// holds at waiting_for_deploy — a stable state we can reliably cancel
-	// from without racing against completion. --defer-cutover doesn't work
-	// for instant DDL since there's no cutover phase.
-	colName := fmt.Sprintf("cancel_col_%d", time.Now().UnixMilli()%100000)
+	// Use a non-instant DDL with deferred cutover so the deploy request reaches
+	// a stable actionable state before cancellation.
+	indexName := fmt.Sprintf("idx_cancel_%d", time.Now().UnixMilli()%100000)
 	schemaDir := newVitessSchemaDir(t, vitessSchemaWithOverrides(map[string]string{
-		"testapp_sharded/users.sql": usersSchemaWithColumn(colName),
+		"testapp_sharded/users.sql": usersSchemaWithIndex(indexName),
 	}))
 
 	binPath := buildCLI(t)
@@ -1443,15 +1450,13 @@ func TestVitess_Apply_Cancel(t *testing.T) {
 		"-s", ".",
 		"-e", "staging",
 		"--endpoint", endpoint,
-		"-y", "-o", "log", "--no-watch", "--allow-unsafe", "--defer-deploy",
+		"-y", "-o", "log", "--no-watch", "--allow-unsafe", "--defer-cutover",
 	)
 	applyID := extractApplyIDFromLog(applyOut)
 	require.NotEmpty(t, applyID, "expected apply ID in output")
 
-	// Wait for waiting_for_deploy — deterministic pause point
-	waitForApplyState(t, endpoint, applyID, state.Apply.WaitingForDeploy, testutil.PollDeadline)
+	waitForApplyState(t, endpoint, applyID, state.Apply.WaitingForCutover, testutil.PollDeadline)
 
-	// Cancel from the stable waiting_for_deploy state
 	t.Logf("calling stop API: endpoint=%s applyID=%s", endpoint, applyID)
 	stopResult, err := client.CallStopAPI(endpoint, "staging", applyID)
 	require.NoError(t, err, "stop/cancel API call")

--- a/pkg/engine/planetscale/planetscale.go
+++ b/pkg/engine/planetscale/planetscale.go
@@ -458,6 +458,62 @@ type psMetadata struct {
 	DeferredDeploy   bool       `json:"deferred_deploy,omitempty"`
 }
 
+// ResumeData is PlanetScale deploy metadata persisted by the tern layer and
+// encoded into engine.ResumeState.Metadata for engine control and progress calls.
+type ResumeData struct {
+	BranchName       string
+	DeployRequestID  uint64
+	DeployRequestURL string
+	MigrationContext string
+	DeployedAt       *time.Time
+	IsInstant        bool
+	DeferredDeploy   bool
+}
+
+// BuildResumeState encodes PlanetScale resume metadata into the opaque
+// engine.ResumeState contract. Partial metadata is allowed because setup states
+// can persist branch information before the deploy request exists.
+func BuildResumeState(data ResumeData) (*engine.ResumeState, error) {
+	metadata, err := encodePSMetadata(&psMetadata{
+		BranchName:       data.BranchName,
+		DeployRequestID:  data.DeployRequestID,
+		DeployRequestURL: data.DeployRequestURL,
+		DeployedAt:       data.DeployedAt,
+		IsInstant:        data.IsInstant,
+		DeferredDeploy:   data.DeferredDeploy,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &engine.ResumeState{
+		MigrationContext: data.MigrationContext,
+		Metadata:         metadata,
+	}, nil
+}
+
+// BuildControlResumeState encodes PlanetScale resume metadata for control
+// operations that act on an existing deploy request.
+func BuildControlResumeState(data ResumeData) (*engine.ResumeState, error) {
+	if missing := missingControlResumeData(data); len(missing) > 0 {
+		return nil, fmt.Errorf("deploy request metadata is incomplete (missing %s)", strings.Join(missing, ", "))
+	}
+	return BuildResumeState(data)
+}
+
+func missingControlResumeData(data ResumeData) []string {
+	var missing []string
+	if data.BranchName == "" {
+		missing = append(missing, "branch_name")
+	}
+	if data.DeployRequestID == 0 {
+		missing = append(missing, "deploy_request_id")
+	}
+	if data.DeployRequestURL == "" {
+		missing = append(missing, "deploy_request_url")
+	}
+	return missing
+}
+
 func encodePSMetadata(m *psMetadata) (string, error) {
 	data, err := json.Marshal(m)
 	if err != nil {

--- a/pkg/tern/local_client.go
+++ b/pkg/tern/local_client.go
@@ -759,16 +759,11 @@ func (c *LocalClient) Progress(ctx context.Context, req *ternv1.ProgressRequest)
 				c.logger.Warn("VitessApplyData not found for progress — apply may still be initializing", "apply_id", activeTask.ApplyID)
 			default:
 				vitessApplyIsInstant = vad.IsInstant
-				meta, _ := json.Marshal(map[string]any{
-					"branch_name":        vad.BranchName,
-					"deploy_request_id":  vad.DeployRequestID,
-					"deploy_request_url": vad.DeployRequestURL,
-					"is_instant":         vad.IsInstant,
-					"deferred_deploy":    vad.DeferredDeploy,
-				})
-				progressReq.ResumeState = &engine.ResumeState{
-					MigrationContext: vad.MigrationContext,
-					Metadata:         string(meta),
+				resumeState, resumeErr := planetscale.BuildResumeState(planetscaleResumeData(vad))
+				if resumeErr != nil {
+					c.logger.Error("failed to build Vitess resume state for progress", "apply_id", activeTask.ApplyID, "error", resumeErr)
+				} else {
+					progressReq.ResumeState = resumeState
 				}
 			}
 		}

--- a/pkg/tern/local_control.go
+++ b/pkg/tern/local_control.go
@@ -2,11 +2,11 @@ package tern
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"time"
 
 	"github.com/block/schemabot/pkg/engine"
+	"github.com/block/schemabot/pkg/engine/planetscale"
 	ternv1 "github.com/block/schemabot/pkg/proto/ternv1"
 	"github.com/block/schemabot/pkg/state"
 	"github.com/block/schemabot/pkg/storage"
@@ -49,11 +49,15 @@ func (c *LocalClient) Cutover(ctx context.Context, req *ternv1.CutoverRequest) (
 		return nil, fmt.Errorf("no engine configured for type: %s", c.config.Type)
 	}
 
-	// Log cutover triggered
+	controlReq, err := c.buildControlRequest(ctx, task, creds)
+	if err != nil {
+		return nil, fmt.Errorf("build cutover request for apply %d: %w", task.ApplyID, err)
+	}
+
 	c.logApplyEvent(ctx, task.ApplyID, nil, storage.LogLevelInfo, storage.LogEventCutoverTriggered, storage.LogSourceSchemaBot,
 		"Cutover triggered", "", "")
 
-	_, err = eng.Cutover(ctx, c.buildControlRequest(ctx, task, creds))
+	_, err = eng.Cutover(ctx, controlReq)
 	if err != nil {
 		c.logApplyEvent(ctx, task.ApplyID, nil, storage.LogLevelError, storage.LogEventError, storage.LogSourceSchemaBot,
 			fmt.Sprintf("Cutover failed: %v", err), "", "")
@@ -101,14 +105,15 @@ func (c *LocalClient) Stop(ctx context.Context, req *ternv1.StopRequest) (*ternv
 	}
 	c.cancelMu.Unlock()
 
-	// Snapshot progress AFTER Spirit has fully stopped to preserve row copy progress.
-	engineTableProgress := c.snapshotEngineProgress(ctx, eng, creds)
-
 	// For Vitess/PlanetScale, stopping means cancelling the deploy request —
 	// this is permanent (not resumable). Use "cancelled" instead of "stopped".
 	terminalState := state.Task.Stopped
+	var engineTableProgress map[string]*engine.TableProgress
 	if c.config.Type == storage.DatabaseTypeVitess {
 		terminalState = state.Task.Cancelled
+	} else {
+		// Snapshot progress AFTER Spirit has fully stopped to preserve row copy progress.
+		engineTableProgress = c.snapshotEngineProgress(ctx, eng, creds)
 	}
 
 	stoppedCount, skippedCount, applyID := c.markTasksWithState(ctx, tasks, targetApplyID, engineTableProgress, terminalState)
@@ -166,8 +171,14 @@ func (c *LocalClient) stopEngineForTasks(ctx context.Context, eng engine.Engine,
 		if task.State == state.Task.Running ||
 			task.State == state.Task.WaitingForCutover ||
 			task.State == state.Task.CuttingOver {
-			req := c.buildControlRequest(ctx, task, creds)
+			req, err := c.buildControlRequest(ctx, task, creds)
+			if err != nil {
+				return fmt.Errorf("build stop request for task %s: %w", task.TaskIdentifier, err)
+			}
 			if _, err := eng.Stop(ctx, req); err != nil {
+				if c.config.Type == storage.DatabaseTypeVitess {
+					return fmt.Errorf("cancel deploy request for task %s: %w", task.TaskIdentifier, err)
+				}
 				c.logger.Warn("engine stop returned error (runner may have already exited)",
 					"task_id", task.TaskIdentifier, "error", err)
 			}
@@ -183,10 +194,15 @@ func (c *LocalClient) snapshotEngineProgress(ctx context.Context, eng engine.Eng
 		c.logger.Error("snapshotEngineProgress: engine is nil")
 		return nil
 	}
-	progress, _ := eng.Progress(ctx, &engine.ProgressRequest{
+	progress, err := eng.Progress(ctx, &engine.ProgressRequest{
 		Database:    c.config.Database,
 		Credentials: creds,
 	})
+	if err != nil {
+		c.logger.Warn("failed to snapshot engine progress after stop",
+			"database", c.config.Database, "type", c.config.Type, "error", err)
+		return nil
+	}
 	if progress != nil {
 		return indexEngineTableProgress(progress.Tables)
 	}
@@ -290,30 +306,47 @@ func (c *LocalClient) controlSetup(ctx context.Context) (*storage.Task, *engine.
 	return task, c.credentials(), eng, nil
 }
 
-// buildControlRequest creates a ControlRequest with ResumeState from VitessApplyData.
-// For PlanetScale, the engine needs the deploy request ID (in ResumeState.Metadata)
-// to execute control operations (cutover, revert, skip-revert).
-func (c *LocalClient) buildControlRequest(ctx context.Context, task *storage.Task, creds *engine.Credentials) *engine.ControlRequest {
+// buildControlRequest creates a ControlRequest with persisted Vitess deploy data.
+// PlanetScale control operations identify the server-side deploy request from
+// ResumeState.Metadata, so missing stored data must fail before calling the engine.
+func (c *LocalClient) buildControlRequest(ctx context.Context, task *storage.Task, creds *engine.Credentials) (*engine.ControlRequest, error) {
 	req := &engine.ControlRequest{
 		Database:    c.config.Database,
 		Credentials: creds,
 	}
 	if c.config.Type == storage.DatabaseTypeVitess {
-		if vad, err := c.storage.VitessApplyData().GetByApplyID(ctx, task.ApplyID); err == nil {
-			meta, _ := json.Marshal(map[string]any{
-				"branch_name":        vad.BranchName,
-				"deploy_request_id":  vad.DeployRequestID,
-				"deploy_request_url": vad.DeployRequestURL,
-				"is_instant":         vad.IsInstant,
-				"deferred_deploy":    vad.DeferredDeploy,
-			})
-			req.ResumeState = &engine.ResumeState{
-				MigrationContext: vad.MigrationContext,
-				Metadata:         string(meta),
-			}
+		store := c.storage.VitessApplyData()
+		if store == nil {
+			return nil, fmt.Errorf("vitess apply data store is not configured")
 		}
+		vad, err := store.GetByApplyID(ctx, task.ApplyID)
+		if err != nil {
+			return nil, fmt.Errorf("load Vitess apply data for apply %d: %w", task.ApplyID, err)
+		}
+		if vad == nil {
+			return nil, fmt.Errorf("load Vitess apply data for apply %d: %w", task.ApplyID, storage.ErrVitessApplyDataNotFound)
+		}
+		resumeState, err := planetscale.BuildControlResumeState(planetscaleResumeData(vad))
+		if err != nil {
+			return nil, fmt.Errorf("build Vitess control resume state for apply %d: %w", task.ApplyID, err)
+		}
+		req.ResumeState = resumeState
 	}
-	return req
+	return req, nil
+}
+
+func planetscaleResumeData(vad *storage.VitessApplyData) planetscale.ResumeData {
+	if vad == nil {
+		return planetscale.ResumeData{}
+	}
+	return planetscale.ResumeData{
+		BranchName:       vad.BranchName,
+		DeployRequestID:  vad.DeployRequestID,
+		DeployRequestURL: vad.DeployRequestURL,
+		MigrationContext: vad.MigrationContext,
+		IsInstant:        vad.IsInstant,
+		DeferredDeploy:   vad.DeferredDeploy,
+	}
 }
 
 // Volume modifies the schema change speed/concurrency in-flight.
@@ -322,15 +355,20 @@ func (c *LocalClient) Volume(ctx context.Context, req *ternv1.VolumeRequest) (*t
 		return nil, fmt.Errorf("volume must be between 1 and 11")
 	}
 
-	_, creds, eng, err := c.controlSetup(ctx)
+	task, creds, eng, err := c.controlSetup(ctx)
 	if err != nil {
 		return nil, err
+	}
+	controlReq, err := c.buildControlRequest(ctx, task, creds)
+	if err != nil {
+		return nil, fmt.Errorf("build volume request for task %s: %w", task.TaskIdentifier, err)
 	}
 
 	result, err := eng.Volume(ctx, &engine.VolumeRequest{
 		Database:    c.config.Database,
 		Volume:      req.Volume,
-		Credentials: creds,
+		ResumeState: controlReq.ResumeState,
+		Credentials: controlReq.Credentials,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("volume failed: %w", err)
@@ -350,7 +388,11 @@ func (c *LocalClient) Revert(ctx context.Context, req *ternv1.RevertRequest) (*t
 		return nil, err
 	}
 
-	if _, err = eng.Revert(ctx, c.buildControlRequest(ctx, task, creds)); err != nil {
+	controlReq, err := c.buildControlRequest(ctx, task, creds)
+	if err != nil {
+		return nil, fmt.Errorf("build revert request for task %s: %w", task.TaskIdentifier, err)
+	}
+	if _, err = eng.Revert(ctx, controlReq); err != nil {
 		return nil, fmt.Errorf("revert failed: %w", err)
 	}
 	return &ternv1.RevertResponse{Accepted: true}, nil
@@ -363,7 +405,11 @@ func (c *LocalClient) SkipRevert(ctx context.Context, req *ternv1.SkipRevertRequ
 		return nil, err
 	}
 
-	if _, err = eng.SkipRevert(ctx, c.buildControlRequest(ctx, task, creds)); err != nil {
+	controlReq, err := c.buildControlRequest(ctx, task, creds)
+	if err != nil {
+		return nil, fmt.Errorf("build skip-revert request for task %s: %w", task.TaskIdentifier, err)
+	}
+	if _, err = eng.SkipRevert(ctx, controlReq); err != nil {
 		return nil, fmt.Errorf("skip revert failed: %w", err)
 	}
 	return &ternv1.SkipRevertResponse{Accepted: true}, nil

--- a/pkg/tern/local_control_resume.go
+++ b/pkg/tern/local_control_resume.go
@@ -81,7 +81,10 @@ func (c *LocalClient) Start(ctx context.Context, req *ternv1.StartRequest) (*ter
 		if eng == nil {
 			return nil, fmt.Errorf("no engine configured for type: %s", c.config.Type)
 		}
-		controlReq := c.buildControlRequest(ctx, applyTasks[0], creds)
+		controlReq, err := c.buildControlRequest(ctx, applyTasks[0], creds)
+		if err != nil {
+			return nil, fmt.Errorf("build deferred deploy request for task %s: %w", applyTasks[0].TaskIdentifier, err)
+		}
 		result, err := eng.Start(ctx, controlReq)
 		if err != nil {
 			return nil, fmt.Errorf("start deferred deploy: %w", err)

--- a/pkg/tern/local_control_test.go
+++ b/pkg/tern/local_control_test.go
@@ -1,0 +1,285 @@
+package tern
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/block/schemabot/pkg/engine"
+	ternv1 "github.com/block/schemabot/pkg/proto/ternv1"
+	"github.com/block/schemabot/pkg/state"
+	"github.com/block/schemabot/pkg/storage"
+)
+
+type controlTestApplyStore struct {
+	storage.ApplyStore
+	apply *storage.Apply
+}
+
+func (s *controlTestApplyStore) GetByApplyIdentifier(_ context.Context, applyIdentifier string) (*storage.Apply, error) {
+	if s.apply == nil || s.apply.ApplyIdentifier != applyIdentifier {
+		return nil, nil
+	}
+	return s.apply, nil
+}
+
+type controlTestTaskStore struct {
+	storage.TaskStore
+	tasks []*storage.Task
+}
+
+func (s *controlTestTaskStore) GetByApplyID(_ context.Context, _ int64) ([]*storage.Task, error) {
+	return s.tasks, nil
+}
+
+func (s *controlTestTaskStore) GetByDatabase(_ context.Context, _ string) ([]*storage.Task, error) {
+	return s.tasks, nil
+}
+
+type controlTestApplyLogStore struct {
+	storage.ApplyLogStore
+}
+
+func (s *controlTestApplyLogStore) Append(context.Context, *storage.ApplyLog) error {
+	return nil
+}
+
+type controlTestVitessApplyDataStore struct {
+	storage.VitessApplyDataStore
+	data *storage.VitessApplyData
+	err  error
+}
+
+func (s *controlTestVitessApplyDataStore) GetByApplyID(context.Context, int64) (*storage.VitessApplyData, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.data, nil
+}
+
+type controlTestStorage struct {
+	storage.Storage
+	applies         storage.ApplyStore
+	tasks           storage.TaskStore
+	applyLogs       storage.ApplyLogStore
+	vitessApplyData storage.VitessApplyDataStore
+}
+
+func (s *controlTestStorage) Applies() storage.ApplyStore {
+	return s.applies
+}
+
+func (s *controlTestStorage) Tasks() storage.TaskStore {
+	return s.tasks
+}
+
+func (s *controlTestStorage) ApplyLogs() storage.ApplyLogStore {
+	return s.applyLogs
+}
+
+func (s *controlTestStorage) VitessApplyData() storage.VitessApplyDataStore {
+	return s.vitessApplyData
+}
+
+type controlCaptureEngine struct {
+	engine.Engine
+	cutoverReq *engine.ControlRequest
+	stopReq    *engine.ControlRequest
+	stopErr    error
+}
+
+func (e *controlCaptureEngine) Name() string {
+	return "control-capture"
+}
+
+func (e *controlCaptureEngine) Cutover(_ context.Context, req *engine.ControlRequest) (*engine.ControlResult, error) {
+	e.cutoverReq = req
+	return &engine.ControlResult{Accepted: true}, nil
+}
+
+func (e *controlCaptureEngine) Stop(_ context.Context, req *engine.ControlRequest) (*engine.ControlResult, error) {
+	e.stopReq = req
+	if e.stopErr != nil {
+		return nil, e.stopErr
+	}
+	return &engine.ControlResult{Accepted: true}, nil
+}
+
+func newVitessControlTestClient(apply *storage.Apply, tasks []*storage.Task, vitessData *storage.VitessApplyData, vitessDataErr error, eng *controlCaptureEngine) *LocalClient {
+	return &LocalClient{
+		config: LocalConfig{
+			Database: "testdb",
+			Type:     storage.DatabaseTypeVitess,
+		},
+		storage: &controlTestStorage{
+			applies:         &controlTestApplyStore{apply: apply},
+			tasks:           &controlTestTaskStore{tasks: tasks},
+			applyLogs:       &controlTestApplyLogStore{},
+			vitessApplyData: &controlTestVitessApplyDataStore{data: vitessData, err: vitessDataErr},
+		},
+		planetscaleEngine: eng,
+		logger:            slog.Default(),
+	}
+}
+
+// PlanetScale cutover must include the durable deploy metadata recorded for the
+// apply. If that metadata is missing, LocalClient returns an error before
+// invoking the engine so the storage invariant violation is visible.
+func TestLocalClient_CutoverRequiresVitessApplyData(t *testing.T) {
+	apply := &storage.Apply{ID: 42, ApplyIdentifier: "apply-vitess-control"}
+	task := &storage.Task{
+		ID:             7,
+		ApplyID:        apply.ID,
+		TaskIdentifier: "task-vitess-control",
+		State:          state.Task.WaitingForCutover,
+	}
+	eng := &controlCaptureEngine{}
+	client := newVitessControlTestClient(apply, []*storage.Task{task}, nil, storage.ErrVitessApplyDataNotFound, eng)
+
+	_, err := client.Cutover(t.Context(), &ternv1.CutoverRequest{ApplyId: apply.ApplyIdentifier})
+
+	require.ErrorIs(t, err, storage.ErrVitessApplyDataNotFound)
+	assert.Nil(t, eng.cutoverReq, "cutover should not call the engine without deploy metadata")
+}
+
+// PlanetScale stores an initial VitessApplyData row before a deploy request is
+// created. Control operations must wait until the row has the full deploy
+// request metadata needed to address the server-side deploy request.
+func TestLocalClient_CutoverRequiresCompleteVitessApplyData(t *testing.T) {
+	testCases := []struct {
+		name        string
+		vitessData  *storage.VitessApplyData
+		missingPart string
+	}{
+		{
+			name: "branch setup before deploy request",
+			vitessData: &storage.VitessApplyData{
+				ApplyID:          42,
+				BranchName:       "branch-123",
+				MigrationContext: "ctx-123",
+			},
+			missingPart: "deploy_request_id",
+		},
+		{
+			name: "missing branch",
+			vitessData: &storage.VitessApplyData{
+				ApplyID:          42,
+				DeployRequestID:  321,
+				MigrationContext: "ctx-123",
+				DeployRequestURL: "https://example.test/deploys/321",
+			},
+			missingPart: "branch_name",
+		},
+		{
+			name: "missing deploy request URL",
+			vitessData: &storage.VitessApplyData{
+				ApplyID:          42,
+				BranchName:       "branch-123",
+				DeployRequestID:  321,
+				MigrationContext: "ctx-123",
+			},
+			missingPart: "deploy_request_url",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			apply := &storage.Apply{ID: 42, ApplyIdentifier: "apply-vitess-control"}
+			task := &storage.Task{
+				ID:             7,
+				ApplyID:        apply.ID,
+				TaskIdentifier: "task-vitess-control",
+				State:          state.Task.WaitingForCutover,
+			}
+			eng := &controlCaptureEngine{}
+			client := newVitessControlTestClient(apply, []*storage.Task{task}, tc.vitessData, nil, eng)
+
+			_, err := client.Cutover(t.Context(), &ternv1.CutoverRequest{ApplyId: apply.ApplyIdentifier})
+
+			require.ErrorContains(t, err, "deploy request metadata is incomplete")
+			require.ErrorContains(t, err, tc.missingPart)
+			assert.Nil(t, eng.cutoverReq, "cutover should not call the engine without deploy request metadata")
+		})
+	}
+}
+
+// PlanetScale cutover uses the stored deploy metadata to address the correct
+// server-side deploy request. LocalClient should pass that metadata through to
+// the engine without requiring a live progress poll first.
+func TestLocalClient_CutoverPassesVitessApplyData(t *testing.T) {
+	apply := &storage.Apply{ID: 42, ApplyIdentifier: "apply-vitess-control"}
+	task := &storage.Task{
+		ID:             7,
+		ApplyID:        apply.ID,
+		TaskIdentifier: "task-vitess-control",
+		State:          state.Task.WaitingForCutover,
+	}
+	vitessData := &storage.VitessApplyData{
+		ApplyID:          apply.ID,
+		BranchName:       "branch-123",
+		DeployRequestID:  321,
+		MigrationContext: "ctx-123",
+		DeployRequestURL: "https://example.test/deploys/321",
+		IsInstant:        true,
+		DeferredDeploy:   true,
+	}
+	eng := &controlCaptureEngine{}
+	client := newVitessControlTestClient(apply, []*storage.Task{task}, vitessData, nil, eng)
+
+	resp, err := client.Cutover(t.Context(), &ternv1.CutoverRequest{ApplyId: apply.ApplyIdentifier})
+
+	require.NoError(t, err)
+	assert.True(t, resp.Accepted)
+	require.NotNil(t, eng.cutoverReq, "cutover should call the engine")
+	require.NotNil(t, eng.cutoverReq.ResumeState)
+	assert.Equal(t, "testdb", eng.cutoverReq.Database)
+	assert.Equal(t, vitessData.MigrationContext, eng.cutoverReq.ResumeState.MigrationContext)
+
+	var metadata struct {
+		BranchName       string `json:"branch_name"`
+		DeployRequestID  uint64 `json:"deploy_request_id"`
+		DeployRequestURL string `json:"deploy_request_url"`
+		IsInstant        bool   `json:"is_instant"`
+		DeferredDeploy   bool   `json:"deferred_deploy"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(eng.cutoverReq.ResumeState.Metadata), &metadata))
+	assert.Equal(t, vitessData.BranchName, metadata.BranchName)
+	assert.Equal(t, vitessData.DeployRequestID, metadata.DeployRequestID)
+	assert.Equal(t, vitessData.DeployRequestURL, metadata.DeployRequestURL)
+	assert.Equal(t, vitessData.IsInstant, metadata.IsInstant)
+	assert.Equal(t, vitessData.DeferredDeploy, metadata.DeferredDeploy)
+}
+
+// PlanetScale stop maps to permanent deploy-request cancellation. If the engine
+// cannot cancel the deploy request, LocalClient should return the error instead
+// of marking the apply cancelled locally.
+func TestLocalClient_StopReturnsVitessEngineStopError(t *testing.T) {
+	apply := &storage.Apply{ID: 42, ApplyIdentifier: "apply-vitess-control"}
+	task := &storage.Task{
+		ID:             7,
+		ApplyID:        apply.ID,
+		TaskIdentifier: "task-vitess-control",
+		State:          state.Task.Running,
+	}
+	vitessData := &storage.VitessApplyData{
+		ApplyID:          apply.ID,
+		BranchName:       "branch-123",
+		DeployRequestID:  321,
+		MigrationContext: "ctx-123",
+		DeployRequestURL: "https://example.test/deploys/321",
+	}
+	stopErr := errors.New("cancel deploy request failed")
+	eng := &controlCaptureEngine{stopErr: stopErr}
+	client := newVitessControlTestClient(apply, []*storage.Task{task}, vitessData, nil, eng)
+
+	_, err := client.Stop(t.Context(), &ternv1.StopRequest{ApplyId: apply.ApplyIdentifier})
+
+	require.ErrorIs(t, err, stopErr)
+	require.NotNil(t, eng.stopReq, "stop should call the engine with deploy metadata")
+	assert.Equal(t, state.Task.Running, task.State)
+}


### PR DESCRIPTION
## Why
Vitess control operations must address the durable deploy request created for the apply. If that stored deploy metadata is missing or incomplete, SchemaBot should fail closed before calling the engine instead of sending an underspecified control request.

## What
- Move PlanetScale resume metadata encoding and control-readiness validation into the PlanetScale engine package
- Build Vitess control requests through one error-returning resume-state path
- Use that path for cutover, stop, deferred deploy start, revert, skip-revert, and volume
- Return deploy cancel failures before marking local state cancelled, and log stop progress snapshot errors
- Add focused regression coverage for missing, incomplete, and present Vitess deploy metadata

```text
control op
   |
   v
load vitess_apply_data
   |
   v
PlanetScale BuildControlResumeState
   | missing required deploy metadata
   v
return error, no engine call

PlanetScale BuildControlResumeState
   | metadata complete
   v
engine control request
```

Generated with Codex