### PR TITLE
feat(github): authorize PR apply actors

### DIFF
--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -4128,6 +4128,38 @@ Schema changes require approval from a code owner before applying.
 </details>
 
 <details>
+<summary><a name="actor-authorization-not-authorized"></a><strong>Actor Authorization: Not Authorized</strong></summary>
+
+
+## SchemaBot Command Not Authorized
+
+**Database**: `orders` | **Environment**: `staging`
+**Requested by**: @mona
+
+@mona is not authorized to run `schemabot apply` for this database.
+
+A configured SchemaBot admin/database operator must run this command.
+
+
+</details>
+
+<details>
+<summary><a name="actor-authorization-unavailable"></a><strong>Actor Authorization: Unavailable</strong></summary>
+
+
+## SchemaBot Authorization Check Failed
+
+**Database**: `orders` | **Environment**: `production`
+**Requested by**: @mona
+
+SchemaBot could not verify authorization for `schemabot apply-confirm`. No schema change was started.
+
+A configured SchemaBot admin/database operator should inspect SchemaBot authorization logs before retrying.
+
+
+</details>
+
+<details>
 <summary><a name="checks-gate-failing"></a><strong>Checks Gate: Failing</strong></summary>
 
 

--- a/pkg/api/actor_authorization.go
+++ b/pkg/api/actor_authorization.go
@@ -1,0 +1,107 @@
+package api
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	ActorAuthReasonDisabled              = "disabled"
+	ActorAuthReasonAllowedAdminTeam      = "allowed_admin_team"
+	ActorAuthReasonAllowedAdminUser      = "allowed_admin_user"
+	ActorAuthReasonAllowedOperatorTeam   = "allowed_operator_team"
+	ActorAuthReasonAllowedOperatorUser   = "allowed_operator_user"
+	ActorAuthReasonMissingActor          = "missing_actor"
+	ActorAuthReasonMissingServerConfig   = "missing_server_config"
+	ActorAuthReasonMissingDatabaseConfig = "missing_database_config"
+	ActorAuthReasonNoConfiguredPrincipal = "no_configured_principal"
+	ActorAuthReasonNotAuthorized         = "not_authorized"
+	ActorAuthReasonGitHubError           = "github_error"
+	ActorAuthReasonUnknown               = "unknown"
+)
+
+// ActorAuthorizationResult describes the decision for a GitHub user running an
+// apply/apply-confirm PR comment command. Reason is stable for metrics;
+// MatchedPrincipal names the user or team that granted access on allow paths.
+type ActorAuthorizationResult struct {
+	Allowed          bool
+	Reason           string
+	MatchedPrincipal string
+}
+
+// PRCommandAuthorizationEnabled returns true when apply/apply-confirm PR
+// comment commands must pass actor authorization.
+func (c *ServerConfig) PRCommandAuthorizationEnabled() bool {
+	return c != nil && c.PRCommandAuthorization.Enabled
+}
+
+// ParseGitHubTeamPrincipal splits a configured team principal in "org/team-slug"
+// form. Team principals are optional; callers should only parse values that were
+// explicitly configured.
+func ParseGitHubTeamPrincipal(value string) (org, slug string, err error) {
+	if strings.TrimSpace(value) != value {
+		return "", "", fmt.Errorf("value has leading or trailing whitespace")
+	}
+	parts := strings.Split(value, "/")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", fmt.Errorf("value must be in org/team-slug form")
+	}
+	return parts[0], parts[1], nil
+}
+
+func validatePRCommandAuthorization(config PRCommandAuthorizationConfig) error {
+	if err := validateGitHubTeamPrincipals("pr_command_authorization.admin_teams", config.AdminTeams); err != nil {
+		return err
+	}
+	if err := validateGitHubUsers("pr_command_authorization.admin_users", config.AdminUsers); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateDatabaseActorAuthorization(database string, dbConfig DatabaseConfig) error {
+	if err := validateGitHubTeamPrincipals("databases."+database+".operator_teams", dbConfig.OperatorTeams); err != nil {
+		return err
+	}
+	if err := validateGitHubUsers("databases."+database+".operator_users", dbConfig.OperatorUsers); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateGitHubTeamPrincipals(field string, teams []string) error {
+	seen := make(map[string]struct{}, len(teams))
+	for _, team := range teams {
+		if _, _, err := ParseGitHubTeamPrincipal(team); err != nil {
+			return fmt.Errorf("%s contains invalid team %q: %w", field, team, err)
+		}
+		key := strings.ToLower(team)
+		if _, ok := seen[key]; ok {
+			return fmt.Errorf("%s contains duplicate value %q", field, team)
+		}
+		seen[key] = struct{}{}
+	}
+	return nil
+}
+
+func validateGitHubUsers(field string, users []string) error {
+	seen := make(map[string]struct{}, len(users))
+	for _, user := range users {
+		trimmed := strings.TrimSpace(user)
+		if trimmed == "" {
+			return fmt.Errorf("%s contains an empty value", field)
+		}
+		if trimmed != user {
+			return fmt.Errorf("%s contains value %q with leading or trailing whitespace", field, user)
+		}
+		if strings.Contains(user, "/") {
+			return fmt.Errorf("%s contains invalid user %q: users must not contain /", field, user)
+		}
+		key := strings.ToLower(user)
+		if _, ok := seen[key]; ok {
+			return fmt.Errorf("%s contains duplicate value %q", field, user)
+		}
+		seen[key] = struct{}{}
+	}
+	return nil
+}

--- a/pkg/api/actor_authorization_test.go
+++ b/pkg/api/actor_authorization_test.go
@@ -1,0 +1,178 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseGitHubTeamPrincipal(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    string
+		wantOrg  string
+		wantSlug string
+		wantErr  string
+	}{
+		{
+			name:     "valid org and team slug",
+			value:    "octocat/db-operators",
+			wantOrg:  "octocat",
+			wantSlug: "db-operators",
+		},
+		{
+			name:    "missing slash",
+			value:   "db-operators",
+			wantErr: "org/team-slug",
+		},
+		{
+			name:    "extra slash",
+			value:   "octocat/platform/db-operators",
+			wantErr: "org/team-slug",
+		},
+		{
+			name:    "leading whitespace",
+			value:   " octocat/db-operators",
+			wantErr: "whitespace",
+		},
+		{
+			name:    "empty org",
+			value:   "/db-operators",
+			wantErr: "org/team-slug",
+		},
+		{
+			name:    "empty team",
+			value:   "octocat/",
+			wantErr: "org/team-slug",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			org, slug, err := ParseGitHubTeamPrincipal(tt.value)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantOrg, org)
+			assert.Equal(t, tt.wantSlug, slug)
+		})
+	}
+}
+
+func TestServerConfigValidatePRCommandAuthorization(t *testing.T) {
+	baseConfig := func() ServerConfig {
+		return ServerConfig{
+			Databases: map[string]DatabaseConfig{
+				"orders": {
+					Type: "mysql",
+					Environments: map[string]EnvironmentConfig{
+						"staging": {DSN: "root@tcp(localhost)/orders"},
+					},
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name    string
+		mutate  func(*ServerConfig)
+		wantErr string
+	}{
+		{
+			name: "valid admin and database operators",
+			mutate: func(cfg *ServerConfig) {
+				cfg.PRCommandAuthorization = PRCommandAuthorizationConfig{
+					Enabled:    true,
+					AdminTeams: []string{"octocat/schema-admins"},
+					AdminUsers: []string{"hubot"},
+				}
+				cfg.Databases["orders"] = DatabaseConfig{
+					Type: "mysql",
+					Environments: map[string]EnvironmentConfig{
+						"staging": {DSN: "root@tcp(localhost)/orders"},
+					},
+					OperatorTeams: []string{"octocat/orders-operators"},
+					OperatorUsers: []string{"mona"},
+				}
+			},
+		},
+		{
+			name: "users only is valid",
+			mutate: func(cfg *ServerConfig) {
+				cfg.PRCommandAuthorization = PRCommandAuthorizationConfig{
+					Enabled:    true,
+					AdminUsers: []string{"hubot"},
+				}
+				db := cfg.Databases["orders"]
+				db.OperatorUsers = []string{"mona"}
+				cfg.Databases["orders"] = db
+			},
+		},
+		{
+			name: "invalid admin team",
+			mutate: func(cfg *ServerConfig) {
+				cfg.PRCommandAuthorization = PRCommandAuthorizationConfig{
+					Enabled:    true,
+					AdminTeams: []string{"schema-admins"},
+				}
+			},
+			wantErr: "pr_command_authorization.admin_teams",
+		},
+		{
+			name: "duplicate admin users are rejected case-insensitively",
+			mutate: func(cfg *ServerConfig) {
+				cfg.PRCommandAuthorization = PRCommandAuthorizationConfig{
+					Enabled:    true,
+					AdminUsers: []string{"Mona", "mona"},
+				}
+			},
+			wantErr: "duplicate",
+		},
+		{
+			name: "invalid database operator team",
+			mutate: func(cfg *ServerConfig) {
+				db := cfg.Databases["orders"]
+				db.OperatorTeams = []string{"orders-operators"}
+				cfg.Databases["orders"] = db
+			},
+			wantErr: "databases.orders.operator_teams",
+		},
+		{
+			name: "duplicate database operator users are rejected case-insensitively",
+			mutate: func(cfg *ServerConfig) {
+				db := cfg.Databases["orders"]
+				db.OperatorUsers = []string{"Mona", "mona"}
+				cfg.Databases["orders"] = db
+			},
+			wantErr: "duplicate",
+		},
+		{
+			name: "username cannot contain a slash",
+			mutate: func(cfg *ServerConfig) {
+				cfg.PRCommandAuthorization = PRCommandAuthorizationConfig{
+					Enabled:    true,
+					AdminUsers: []string{"octocat/mona"},
+				}
+			},
+			wantErr: "must not contain /",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := baseConfig()
+			tt.mutate(&cfg)
+			err := cfg.Validate()
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -35,6 +35,11 @@ type ServerConfig struct {
 	// Repos holds per-repository configuration.
 	Repos map[string]RepoConfig `yaml:"repos"`
 
+	// PRCommandAuthorization controls which GitHub users may run SchemaBot
+	// apply/apply-confirm PR comment commands. When disabled, existing OSS/local
+	// behavior is preserved.
+	PRCommandAuthorization PRCommandAuthorizationConfig `yaml:"pr_command_authorization,omitempty"`
+
 	// DefaultReviewers are GitHub teams/users required to review schema changes.
 	DefaultReviewers []string `yaml:"default_reviewers"`
 
@@ -176,6 +181,30 @@ type DatabaseConfig struct {
 	// directories may manage this database. Values match the directory itself
 	// and descendants. A literal "*" allows any trusted schema directory.
 	AllowedDirs []string `yaml:"allowed_dirs,omitempty"`
+
+	// OperatorTeams are GitHub teams whose members may run apply/apply-confirm
+	// PR comment commands for this database when PR command authorization is enabled.
+	OperatorTeams []string `yaml:"operator_teams,omitempty"`
+
+	// OperatorUsers are GitHub users who may run apply/apply-confirm PR comment
+	// commands for this database when PR command authorization is enabled.
+	OperatorUsers []string `yaml:"operator_users,omitempty"`
+}
+
+// PRCommandAuthorizationConfig configures actor authorization for SchemaBot
+// apply/apply-confirm GitHub PR comment commands.
+type PRCommandAuthorizationConfig struct {
+	// Enabled turns on fail-closed actor authorization for apply/apply-confirm
+	// PR commands.
+	Enabled bool `yaml:"enabled,omitempty"`
+
+	// AdminTeams are GitHub teams whose members may run apply/apply-confirm PR
+	// commands for any configured database.
+	AdminTeams []string `yaml:"admin_teams,omitempty"`
+
+	// AdminUsers are GitHub users who may run apply/apply-confirm PR commands
+	// for any configured database.
+	AdminUsers []string `yaml:"admin_users,omitempty"`
 }
 
 // EnvironmentConfig holds per-environment database configuration.
@@ -279,6 +308,9 @@ func (c *ServerConfig) Validate() error {
 	if err := validateUniqueNames("environment_order", c.EnvironmentOrder); err != nil {
 		return err
 	}
+	if err := validatePRCommandAuthorization(c.PRCommandAuthorization); err != nil {
+		return err
+	}
 
 	// Validate Databases if present. An environment is either local mode
 	// (direct DSN) or gRPC mode (server-side target + deployment).
@@ -287,6 +319,9 @@ func (c *ServerConfig) Validate() error {
 			return fmt.Errorf("database %q missing type", name)
 		}
 		if err := validateDatabaseSourcePolicy(name, dbConfig); err != nil {
+			return err
+		}
+		if err := validateDatabaseActorAuthorization(name, dbConfig); err != nil {
 			return err
 		}
 		if dbConfig.Type != storage.DatabaseTypeMySQL && dbConfig.Type != storage.DatabaseTypeVitess {

--- a/pkg/api/telemetry_test.go
+++ b/pkg/api/telemetry_test.go
@@ -319,6 +319,51 @@ func TestRecordSourcePolicyBlockMetric(t *testing.T) {
 	assert.True(t, sawUnknown, "expected unknown operation and reason to be normalized")
 }
 
+func TestRecordPRCommandActorAuthorizationMetric(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	prevMP := otel.GetMeterProvider()
+	otel.SetMeterProvider(mp)
+	t.Cleanup(func() {
+		otel.SetMeterProvider(prevMP)
+		require.NoError(t, mp.Shutdown(t.Context()))
+	})
+
+	metrics.RecordPRCommandActorAuthorization(t.Context(), "apply", "mydb", "staging", "org/repo", "allowed", "allowed_admin_user")
+	metrics.RecordPRCommandActorAuthorization(t.Context(), "apply_confirm", "mydb", "production", "org/repo", "denied", "not_authorized")
+	metrics.RecordPRCommandActorAuthorization(t.Context(), "not_real", "mydb", "staging", "org/repo", "not_real", "not_real")
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(t.Context(), &rm))
+
+	var found bool
+	var sawUnknown bool
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != "schemabot.pr_command_actor_authorization.total" {
+				continue
+			}
+			found = true
+			sum, ok := m.Data.(metricdata.Sum[int64])
+			require.True(t, ok)
+			assert.Len(t, sum.DataPoints, 3, "expected one data point per command/status/reason attribute set")
+			for _, dp := range sum.DataPoints {
+				command, hasCommand := dp.Attributes.Value(attribute.Key("command"))
+				status, hasStatus := dp.Attributes.Value(attribute.Key("status"))
+				reason, hasReason := dp.Attributes.Value(attribute.Key("reason"))
+				require.True(t, hasCommand)
+				require.True(t, hasStatus)
+				require.True(t, hasReason)
+				if command.AsString() == "unknown" && status.AsString() == "unknown" && reason.AsString() == "unknown" {
+					sawUnknown = true
+				}
+			}
+		}
+	}
+	assert.True(t, found, "schemabot.pr_command_actor_authorization.total metric not found")
+	assert.True(t, sawUnknown, "expected unknown command, status, and reason to be normalized")
+}
+
 func TestRecordStatusCheckOperationMetric(t *testing.T) {
 	reader := sdkmetric.NewManualReader()
 	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))

--- a/pkg/cmd/commands/preview.go
+++ b/pkg/cmd/commands/preview.go
@@ -91,7 +91,8 @@ func (cmd *PreviewCmd) Run(g *Globals) error {
 		templates.PreviewCommentApplyBlocked, templates.PreviewCommentApplyBlockedCLI,
 		templates.PreviewCommentApplyActive,
 		templates.PreviewCommentApplyNoLock, templates.PreviewCommentApplyAllType,
-		templates.PreviewCommentChecksGateFailing, templates.PreviewCommentChecksGateInProgress:
+		templates.PreviewCommentChecksGateFailing, templates.PreviewCommentChecksGateInProgress,
+		templates.PreviewCommentActorNotAuthorized, templates.PreviewCommentActorAuthUnavailable:
 		templates.PreviewCLIOutput(previewType)
 	// Paired aggregate types (PR + CLI subsections)
 	case templates.PreviewCommentPlanAll, templates.PreviewCommentLockingAll,
@@ -248,6 +249,8 @@ Apply Command Comments (GitHub PR apply commands):
   comment_apply_blocked_cli     Apply blocked by CLI session
   comment_apply_active          Apply already in progress
   comment_apply_no_lock         No lock found (need apply first)
+  comment_actor_not_authorized  Actor authorization denied
+  comment_actor_auth_unavailable Actor authorization fail-closed error
   comment_apply_all             Show all apply command previews
 
 Aggregate Types (grouped PR + CLI pairs):

--- a/pkg/cmd/templates/preview.go
+++ b/pkg/cmd/templates/preview.go
@@ -163,6 +163,8 @@ const (
 	PreviewCommentReviewGateError      PreviewType = "comment_review_gate_error"            // Review gate: fail-closed error
 	PreviewCommentChecksGateFailing    PreviewType = "comment_checks_gate_failing"          // Checks gate: failing CI/lint
 	PreviewCommentChecksGateInProgress PreviewType = "comment_checks_gate_in_progress"      // Checks gate: CI still running
+	PreviewCommentActorNotAuthorized   PreviewType = "comment_actor_not_authorized"         // Actor authorization: user is not allowed
+	PreviewCommentActorAuthUnavailable PreviewType = "comment_actor_auth_unavailable"       // Actor authorization: fail-closed error
 	PreviewCommentApplyAllType         PreviewType = "comment_apply_all"                    // Show all apply comment previews
 )
 
@@ -367,6 +369,10 @@ func PreviewCLIOutput(previewType PreviewType) {
 			{Name: "CI / unit-tests", State: "in_progress"},
 			{Name: "CI / integration-tests", State: "queued"},
 		}))
+	case PreviewCommentActorNotAuthorized:
+		fmt.Print(webhooktemplates.PreviewCommentPRCommandNotAuthorized())
+	case PreviewCommentActorAuthUnavailable:
+		fmt.Print(webhooktemplates.PreviewCommentPRCommandAuthorizationUnavailable())
 	case PreviewCommentApplyAllType:
 		previewApplyCommandAllOutput()
 	// Paired aggregate previews (PR + CLI subsections)
@@ -963,6 +969,8 @@ func previewApplyCommandAllOutput() {
 		{"BLOCKED BY PRIOR ENV (IN PROGRESS)", func() { fmt.Print(webhooktemplates.PreviewCommentApplyBlockedByPriorEnvInProgress()) }},
 		{"REVIEW REQUIRED (CODEOWNERS)", func() { fmt.Print(webhooktemplates.PreviewCommentReviewRequired()) }},
 		{"REVIEW GATE ERROR (FAIL-CLOSED)", func() { fmt.Print(webhooktemplates.PreviewCommentReviewGateError()) }},
+		{"ACTOR AUTHORIZATION: NOT AUTHORIZED", func() { fmt.Print(webhooktemplates.PreviewCommentPRCommandNotAuthorized()) }},
+		{"ACTOR AUTHORIZATION: UNAVAILABLE", func() { fmt.Print(webhooktemplates.PreviewCommentPRCommandAuthorizationUnavailable()) }},
 		{"CHECKS GATE: FAILING", func() {
 			fmt.Print(webhooktemplates.RenderApplyBlockedByFailingChecks("staging", []webhooktemplates.BlockingCheck{
 				{Name: "CI / unit-tests", State: "failure"},

--- a/pkg/github/reviews.go
+++ b/pkg/github/reviews.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"net/http"
 	"strings"
 	"time"
 
@@ -213,6 +214,24 @@ func (ic *InstallationClient) ListTeamMembers(ctx context.Context, org, slug str
 	}
 
 	return members, nil
+}
+
+// IsTeamMember returns true when login is an active member of org/slug.
+// GitHub returns 404 when the user is not a team member; that is an ordinary
+// negative authorization result. Other errors are returned so callers can fail
+// closed when GitHub membership cannot be verified.
+func (ic *InstallationClient) IsTeamMember(ctx context.Context, org, slug, login string) (bool, error) {
+	membership, resp, err := ic.client.Teams.GetTeamMembershipBySlug(ctx, org, slug, login)
+	if err != nil {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			return false, nil
+		}
+		return false, fmt.Errorf("get team membership %s/%s for %s: %w", org, slug, login, err)
+	}
+	if membership == nil {
+		return false, nil
+	}
+	return membership.GetState() == "active", nil
 }
 
 // RequestReviewers requests reviews from users and/or teams on a PR.

--- a/pkg/github/reviews_test.go
+++ b/pkg/github/reviews_test.go
@@ -1,6 +1,10 @@
 package github
 
 import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
 	"testing"
 	"time"
 
@@ -155,6 +159,60 @@ func TestGetApprovedReviewers(t *testing.T) {
 					assert.Contains(t, result, expected)
 				}
 			}
+		})
+	}
+}
+
+func TestIsTeamMember(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		body       map[string]string
+		wantMember bool
+		wantErr    bool
+	}{
+		{
+			name:       "active membership allows",
+			statusCode: http.StatusOK,
+			body:       map[string]string{"state": "active"},
+			wantMember: true,
+		},
+		{
+			name:       "pending membership does not allow",
+			statusCode: http.StatusOK,
+			body:       map[string]string{"state": "pending"},
+			wantMember: false,
+		},
+		{
+			name:       "not found is not a member",
+			statusCode: http.StatusNotFound,
+			wantMember: false,
+		},
+		{
+			name:       "server error is returned",
+			statusCode: http.StatusInternalServerError,
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client, mux := setupConfigTestGitHubServer(t)
+			mux.HandleFunc("GET /orgs/octocat/teams/db-operators/memberships/mona", func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tt.statusCode)
+				if tt.body != nil {
+					require.NoError(t, json.NewEncoder(w).Encode(tt.body))
+				}
+			})
+
+			ic := NewInstallationClient(client, slog.New(slog.NewTextHandler(io.Discard, nil)))
+			member, err := ic.IsTeamMember(t.Context(), "octocat", "db-operators", "mona")
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantMember, member)
 		})
 	}
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -178,6 +178,77 @@ func RecordSourcePolicyBlock(ctx context.Context, operation, database, environme
 	)
 }
 
+var knownPRCommandActorAuthCommands = map[string]bool{
+	"apply":            true,
+	"apply_confirm":    true,
+	"rollback":         true,
+	"rollback_confirm": true,
+	"unlock":           true,
+	"cutover":          true,
+	"stop":             true,
+	"start":            true,
+	"volume":           true,
+	"revert":           true,
+	"skip_revert":      true,
+}
+
+var knownPRCommandActorAuthStatuses = map[string]bool{
+	"allowed": true,
+	"denied":  true,
+	"error":   true,
+	"skipped": true,
+}
+
+var knownPRCommandActorAuthReasons = map[string]bool{
+	"disabled":                true,
+	"allowed_admin_team":      true,
+	"allowed_admin_user":      true,
+	"allowed_operator_team":   true,
+	"allowed_operator_user":   true,
+	"missing_actor":           true,
+	"missing_server_config":   true,
+	"missing_database_config": true,
+	"no_configured_principal": true,
+	"not_authorized":          true,
+	"github_error":            true,
+	"unknown":                 true,
+}
+
+// RecordPRCommandActorAuthorization increments the counter for GitHub PR
+// comment actor authorization decisions. Command, status, and reason are
+// allowlisted to keep metric cardinality bounded.
+func RecordPRCommandActorAuthorization(ctx context.Context, command, database, environment, repository, status, reason string) {
+	if !knownPRCommandActorAuthCommands[command] {
+		command = "unknown"
+	}
+	if !knownPRCommandActorAuthStatuses[status] {
+		status = "unknown"
+	}
+	if !knownPRCommandActorAuthReasons[reason] {
+		reason = "unknown"
+	}
+
+	meter := otel.Meter(meterName)
+	counter, err := meter.Int64Counter("schemabot.pr_command_actor_authorization.total",
+		otelmetric.WithDescription("Total GitHub PR command actor authorization decisions"),
+		otelmetric.WithUnit("{decision}"),
+	)
+	if err != nil {
+		slog.Warn("failed to create PR command actor authorization counter", "error", err)
+		return
+	}
+	counter.Add(ctx, 1,
+		otelmetric.WithAttributes(
+			attribute.String("command", command),
+			attribute.String("database", database),
+			attribute.String("environment", environment),
+			attribute.String("repository", repository),
+			attribute.String("status", status),
+			attribute.String("reason", reason),
+		),
+	)
+}
+
 // knownCheckOwnershipOperations limits metric cardinality to expected check
 // ownership miss paths.
 var knownCheckOwnershipOperations = map[string]bool{

--- a/pkg/webhook/actor_authorization.go
+++ b/pkg/webhook/actor_authorization.go
@@ -1,0 +1,188 @@
+package webhook
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/block/schemabot/pkg/api"
+	ghclient "github.com/block/schemabot/pkg/github"
+	"github.com/block/schemabot/pkg/metrics"
+	"github.com/block/schemabot/pkg/webhook/templates"
+)
+
+func (h *Handler) enforcePRCommandActorAuthorization(
+	ctx context.Context,
+	client *ghclient.InstallationClient,
+	repo string,
+	pr int,
+	installationID int64,
+	requestedBy string,
+	database string,
+	databaseType string,
+	environment string,
+	commandName string,
+) bool {
+	result, err := h.authorizePRCommandActor(ctx, client, requestedBy, database)
+	status := actorAuthorizationMetricStatus(result, err)
+	metrics.RecordPRCommandActorAuthorization(ctx, metricActionKey(commandName), database, environment, repo, status, result.Reason)
+
+	if err != nil {
+		h.logger.Warn("PR command blocked by actor authorization error",
+			"repo", repo, "pr", pr, "database", database,
+			"database_type", databaseType, "environment", environment,
+			"command", commandName, "requested_by", requestedBy,
+			"reason", result.Reason, "error", err)
+		h.postComment(repo, pr, installationID, templates.RenderPRCommandAuthorizationUnavailable(templates.ActorAuthorizationCommentData{
+			RequestedBy: requestedBy,
+			CommandName: commandName,
+			Database:    database,
+			Environment: environment,
+		}))
+		return true
+	}
+	if !result.Allowed {
+		h.logger.Warn("PR command blocked by actor authorization",
+			"repo", repo, "pr", pr, "database", database,
+			"database_type", databaseType, "environment", environment,
+			"command", commandName, "requested_by", requestedBy,
+			"reason", result.Reason)
+		h.postComment(repo, pr, installationID, templates.RenderPRCommandNotAuthorized(templates.ActorAuthorizationCommentData{
+			RequestedBy: requestedBy,
+			CommandName: commandName,
+			Database:    database,
+			Environment: environment,
+		}))
+		return true
+	}
+	if result.Reason == api.ActorAuthReasonDisabled {
+		h.logger.Debug("skipping PR command actor authorization because it is disabled",
+			"repo", repo, "pr", pr, "database", database,
+			"database_type", databaseType, "environment", environment,
+			"command", commandName, "requested_by", requestedBy)
+		return false
+	}
+	h.logger.Debug("PR command actor authorization allowed",
+		"repo", repo, "pr", pr, "database", database,
+		"database_type", databaseType, "environment", environment,
+		"command", commandName, "requested_by", requestedBy,
+		"reason", result.Reason, "matched_principal", result.MatchedPrincipal)
+	return false
+}
+
+func (h *Handler) authorizePRCommandActor(
+	ctx context.Context,
+	client *ghclient.InstallationClient,
+	actor string,
+	database string,
+) (api.ActorAuthorizationResult, error) {
+	if h.service == nil {
+		return api.ActorAuthorizationResult{Reason: api.ActorAuthReasonMissingServerConfig}, fmt.Errorf("server config is unavailable")
+	}
+	config := h.service.Config()
+	if !config.PRCommandAuthorizationEnabled() {
+		return api.ActorAuthorizationResult{Allowed: true, Reason: api.ActorAuthReasonDisabled}, nil
+	}
+
+	if strings.TrimSpace(actor) == "" {
+		return api.ActorAuthorizationResult{Reason: api.ActorAuthReasonMissingActor}, nil
+	}
+
+	dbConfig := config.Database(database)
+	if dbConfig == nil {
+		return api.ActorAuthorizationResult{Reason: api.ActorAuthReasonMissingDatabaseConfig}, nil
+	}
+
+	authConfig := config.PRCommandAuthorization
+	if matched, principal := matchedUserPrincipal(authConfig.AdminUsers, actor); matched {
+		return api.ActorAuthorizationResult{
+			Allowed:          true,
+			Reason:           api.ActorAuthReasonAllowedAdminUser,
+			MatchedPrincipal: principal,
+		}, nil
+	}
+	if matched, principal := matchedUserPrincipal(dbConfig.OperatorUsers, actor); matched {
+		return api.ActorAuthorizationResult{
+			Allowed:          true,
+			Reason:           api.ActorAuthReasonAllowedOperatorUser,
+			MatchedPrincipal: principal,
+		}, nil
+	}
+
+	teamCount := len(authConfig.AdminTeams) + len(dbConfig.OperatorTeams)
+	principalCount := teamCount + len(authConfig.AdminUsers) + len(dbConfig.OperatorUsers)
+	if principalCount == 0 {
+		return api.ActorAuthorizationResult{Reason: api.ActorAuthReasonNoConfiguredPrincipal}, nil
+	}
+	if teamCount == 0 {
+		return api.ActorAuthorizationResult{Reason: api.ActorAuthReasonNotAuthorized}, nil
+	}
+	if client == nil {
+		return api.ActorAuthorizationResult{Reason: api.ActorAuthReasonGitHubError}, fmt.Errorf("github client is nil")
+	}
+
+	matched, principal, err := actorInAnyTeam(ctx, client, authConfig.AdminTeams, actor)
+	if err != nil {
+		return api.ActorAuthorizationResult{Reason: api.ActorAuthReasonGitHubError}, err
+	}
+	if matched {
+		return api.ActorAuthorizationResult{
+			Allowed:          true,
+			Reason:           api.ActorAuthReasonAllowedAdminTeam,
+			MatchedPrincipal: principal,
+		}, nil
+	}
+
+	matched, principal, err = actorInAnyTeam(ctx, client, dbConfig.OperatorTeams, actor)
+	if err != nil {
+		return api.ActorAuthorizationResult{Reason: api.ActorAuthReasonGitHubError}, err
+	}
+	if matched {
+		return api.ActorAuthorizationResult{
+			Allowed:          true,
+			Reason:           api.ActorAuthReasonAllowedOperatorTeam,
+			MatchedPrincipal: principal,
+		}, nil
+	}
+
+	return api.ActorAuthorizationResult{Reason: api.ActorAuthReasonNotAuthorized}, nil
+}
+
+func actorInAnyTeam(ctx context.Context, client *ghclient.InstallationClient, teams []string, actor string) (bool, string, error) {
+	for _, team := range teams {
+		org, slug, err := api.ParseGitHubTeamPrincipal(team)
+		if err != nil {
+			return false, "", fmt.Errorf("invalid configured GitHub team %q: %w", team, err)
+		}
+		member, err := client.IsTeamMember(ctx, org, slug, actor)
+		if err != nil {
+			return false, "", err
+		}
+		if member {
+			return true, team, nil
+		}
+	}
+	return false, "", nil
+}
+
+func matchedUserPrincipal(allowedUsers []string, actor string) (bool, string) {
+	for _, user := range allowedUsers {
+		if strings.EqualFold(user, actor) {
+			return true, user
+		}
+	}
+	return false, ""
+}
+
+func actorAuthorizationMetricStatus(result api.ActorAuthorizationResult, err error) string {
+	if err != nil {
+		return "error"
+	}
+	if result.Reason == api.ActorAuthReasonDisabled {
+		return "skipped"
+	}
+	if result.Allowed {
+		return "allowed"
+	}
+	return "denied"
+}

--- a/pkg/webhook/actor_authorization.go
+++ b/pkg/webhook/actor_authorization.go
@@ -99,26 +99,6 @@ func (h *Handler) authorizePRCommandActor(
 	}
 
 	authConfig := config.PRCommandAuthorization
-	// User allowlists are local config checks, so evaluate them before making
-	// GitHub API calls for team membership.
-	if matched, principal := matchedUserPrincipal(authConfig.AdminUsers, actor); matched {
-		return api.ActorAuthorizationResult{
-			Allowed:          true,
-			Reason:           api.ActorAuthReasonAllowedAdminUser,
-			MatchedPrincipal: principal,
-		}, nil
-	}
-	// Database operator users are allowed only for this database.
-	if matched, principal := matchedUserPrincipal(dbConfig.OperatorUsers, actor); matched {
-		return api.ActorAuthorizationResult{
-			Allowed:          true,
-			Reason:           api.ActorAuthReasonAllowedOperatorUser,
-			MatchedPrincipal: principal,
-		}, nil
-	}
-
-	// At this point no user principal matched. Decide whether there are any team
-	// principals left to check, or whether the policy can be denied locally.
 	teamCount := len(authConfig.AdminTeams) + len(dbConfig.OperatorTeams)
 	principalCount := teamCount + len(authConfig.AdminUsers) + len(dbConfig.OperatorUsers)
 	// Actor auth is enabled but no admin/operator principals exist for this
@@ -126,40 +106,61 @@ func (h *Handler) authorizePRCommandActor(
 	if principalCount == 0 {
 		return api.ActorAuthorizationResult{Reason: api.ActorAuthReasonNoConfiguredPrincipal}, nil
 	}
-	// With user-only policy, reaching this point means the actor was not in any
-	// configured user allowlist. No GitHub client is needed to deny.
-	if teamCount == 0 {
-		return api.ActorAuthorizationResult{Reason: api.ActorAuthReasonNotAuthorized}, nil
-	}
-	// Team policy requires GitHub membership lookups. If the client is missing,
-	// the command cannot be authorized safely.
-	if client == nil {
-		return api.ActorAuthorizationResult{Reason: api.ActorAuthReasonGitHubError}, fmt.Errorf("github client is nil")
+
+	// Global admin teams have the highest precedence and can approve any
+	// configured database. A non-member result falls through to admin users.
+	if len(authConfig.AdminTeams) > 0 {
+		if client == nil {
+			return api.ActorAuthorizationResult{Reason: api.ActorAuthReasonGitHubError}, fmt.Errorf("github client is nil")
+		}
+		matched, principal, err := actorInAnyTeam(ctx, client, authConfig.AdminTeams, actor)
+		if err != nil {
+			return api.ActorAuthorizationResult{Reason: api.ActorAuthReasonGitHubError}, err
+		}
+		if matched {
+			return api.ActorAuthorizationResult{
+				Allowed:          true,
+				Reason:           api.ActorAuthReasonAllowedAdminTeam,
+				MatchedPrincipal: principal,
+			}, nil
+		}
 	}
 
-	// Global admin teams can approve any configured database.
-	matched, principal, err := actorInAnyTeam(ctx, client, authConfig.AdminTeams, actor)
-	if err != nil {
-		return api.ActorAuthorizationResult{Reason: api.ActorAuthReasonGitHubError}, err
-	}
-	if matched {
+	// Global admin users are checked after admin teams and before any
+	// database-scoped operator policy.
+	if matched, principal := matchedUserPrincipal(authConfig.AdminUsers, actor); matched {
 		return api.ActorAuthorizationResult{
 			Allowed:          true,
-			Reason:           api.ActorAuthReasonAllowedAdminTeam,
+			Reason:           api.ActorAuthReasonAllowedAdminUser,
 			MatchedPrincipal: principal,
 		}, nil
 	}
 
-	// Database operator teams only authorize the database currently being
+	// Database operator teams authorize only the database currently being
 	// mutated by this PR command.
-	matched, principal, err = actorInAnyTeam(ctx, client, dbConfig.OperatorTeams, actor)
-	if err != nil {
-		return api.ActorAuthorizationResult{Reason: api.ActorAuthReasonGitHubError}, err
+	if len(dbConfig.OperatorTeams) > 0 {
+		if client == nil {
+			return api.ActorAuthorizationResult{Reason: api.ActorAuthReasonGitHubError}, fmt.Errorf("github client is nil")
+		}
+		matched, principal, err := actorInAnyTeam(ctx, client, dbConfig.OperatorTeams, actor)
+		if err != nil {
+			return api.ActorAuthorizationResult{Reason: api.ActorAuthReasonGitHubError}, err
+		}
+		if matched {
+			return api.ActorAuthorizationResult{
+				Allowed:          true,
+				Reason:           api.ActorAuthReasonAllowedOperatorTeam,
+				MatchedPrincipal: principal,
+			}, nil
+		}
 	}
-	if matched {
+
+	// Database operator users are the final allowlist and are scoped to this
+	// database.
+	if matched, principal := matchedUserPrincipal(dbConfig.OperatorUsers, actor); matched {
 		return api.ActorAuthorizationResult{
 			Allowed:          true,
-			Reason:           api.ActorAuthReasonAllowedOperatorTeam,
+			Reason:           api.ActorAuthReasonAllowedOperatorUser,
 			MatchedPrincipal: principal,
 		}, nil
 	}

--- a/pkg/webhook/actor_authorization.go
+++ b/pkg/webhook/actor_authorization.go
@@ -76,24 +76,31 @@ func (h *Handler) authorizePRCommandActor(
 	actor string,
 	database string,
 ) (api.ActorAuthorizationResult, error) {
+	// Without server config, SchemaBot cannot know the trusted actor policy.
 	if h.service == nil {
 		return api.ActorAuthorizationResult{Reason: api.ActorAuthReasonMissingServerConfig}, fmt.Errorf("server config is unavailable")
 	}
 	config := h.service.Config()
+	// The feature is opt-in; disabled auth preserves existing PR command behavior.
 	if !config.PRCommandAuthorizationEnabled() {
 		return api.ActorAuthorizationResult{Allowed: true, Reason: api.ActorAuthReasonDisabled}, nil
 	}
 
+	// GitHub should provide a comment actor. Missing actor identity is unsafe for
+	// a mutating PR command, so deny instead of guessing.
 	if strings.TrimSpace(actor) == "" {
 		return api.ActorAuthorizationResult{Reason: api.ActorAuthReasonMissingActor}, nil
 	}
 
+	// Authorization is scoped to the resolved server-side database config.
 	dbConfig := config.Database(database)
 	if dbConfig == nil {
 		return api.ActorAuthorizationResult{Reason: api.ActorAuthReasonMissingDatabaseConfig}, nil
 	}
 
 	authConfig := config.PRCommandAuthorization
+	// User allowlists are local config checks, so evaluate them before making
+	// GitHub API calls for team membership.
 	if matched, principal := matchedUserPrincipal(authConfig.AdminUsers, actor); matched {
 		return api.ActorAuthorizationResult{
 			Allowed:          true,
@@ -101,6 +108,7 @@ func (h *Handler) authorizePRCommandActor(
 			MatchedPrincipal: principal,
 		}, nil
 	}
+	// Database operator users are allowed only for this database.
 	if matched, principal := matchedUserPrincipal(dbConfig.OperatorUsers, actor); matched {
 		return api.ActorAuthorizationResult{
 			Allowed:          true,
@@ -109,18 +117,27 @@ func (h *Handler) authorizePRCommandActor(
 		}, nil
 	}
 
+	// At this point no user principal matched. Decide whether there are any team
+	// principals left to check, or whether the policy can be denied locally.
 	teamCount := len(authConfig.AdminTeams) + len(dbConfig.OperatorTeams)
 	principalCount := teamCount + len(authConfig.AdminUsers) + len(dbConfig.OperatorUsers)
+	// Actor auth is enabled but no admin/operator principals exist for this
+	// database. Fail closed instead of treating an empty policy as "allow all".
 	if principalCount == 0 {
 		return api.ActorAuthorizationResult{Reason: api.ActorAuthReasonNoConfiguredPrincipal}, nil
 	}
+	// With user-only policy, reaching this point means the actor was not in any
+	// configured user allowlist. No GitHub client is needed to deny.
 	if teamCount == 0 {
 		return api.ActorAuthorizationResult{Reason: api.ActorAuthReasonNotAuthorized}, nil
 	}
+	// Team policy requires GitHub membership lookups. If the client is missing,
+	// the command cannot be authorized safely.
 	if client == nil {
 		return api.ActorAuthorizationResult{Reason: api.ActorAuthReasonGitHubError}, fmt.Errorf("github client is nil")
 	}
 
+	// Global admin teams can approve any configured database.
 	matched, principal, err := actorInAnyTeam(ctx, client, authConfig.AdminTeams, actor)
 	if err != nil {
 		return api.ActorAuthorizationResult{Reason: api.ActorAuthReasonGitHubError}, err
@@ -133,6 +150,8 @@ func (h *Handler) authorizePRCommandActor(
 		}, nil
 	}
 
+	// Database operator teams only authorize the database currently being
+	// mutated by this PR command.
 	matched, principal, err = actorInAnyTeam(ctx, client, dbConfig.OperatorTeams, actor)
 	if err != nil {
 		return api.ActorAuthorizationResult{Reason: api.ActorAuthReasonGitHubError}, err
@@ -145,6 +164,7 @@ func (h *Handler) authorizePRCommandActor(
 		}, nil
 	}
 
+	// No configured user or team authorized this actor.
 	return api.ActorAuthorizationResult{Reason: api.ActorAuthReasonNotAuthorized}, nil
 }
 

--- a/pkg/webhook/actor_authorization_test.go
+++ b/pkg/webhook/actor_authorization_test.go
@@ -130,6 +130,29 @@ func TestAuthorizePRCommandActorTeams(t *testing.T) {
 			wantMatch:  "octocat/schema-admins",
 		},
 		{
+			name: "admin team takes precedence over admin user",
+			configure: func(cfg *api.ServerConfig) {
+				cfg.PRCommandAuthorization.AdminTeams = []string{"octocat/schema-admins"}
+				cfg.PRCommandAuthorization.AdminUsers = []string{"mona"}
+			},
+			statusCode: http.StatusOK,
+			state:      "active",
+			wantAllow:  true,
+			wantReason: api.ActorAuthReasonAllowedAdminTeam,
+			wantMatch:  "octocat/schema-admins",
+		},
+		{
+			name: "admin user allows after admin team non-member",
+			configure: func(cfg *api.ServerConfig) {
+				cfg.PRCommandAuthorization.AdminTeams = []string{"octocat/schema-admins"}
+				cfg.PRCommandAuthorization.AdminUsers = []string{"mona"}
+			},
+			statusCode: http.StatusNotFound,
+			wantAllow:  true,
+			wantReason: api.ActorAuthReasonAllowedAdminUser,
+			wantMatch:  "mona",
+		},
+		{
 			name: "operator team allows",
 			configure: func(cfg *api.ServerConfig) {
 				db := cfg.Databases["orders"]

--- a/pkg/webhook/actor_authorization_test.go
+++ b/pkg/webhook/actor_authorization_test.go
@@ -1,0 +1,366 @@
+package webhook
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/block/schemabot/pkg/api"
+	ghclient "github.com/block/schemabot/pkg/github"
+	"github.com/block/schemabot/pkg/storage"
+	"github.com/block/schemabot/pkg/webhook/action"
+)
+
+func TestAuthorizePRCommandActor(t *testing.T) {
+	tests := []struct {
+		name       string
+		config     *api.ServerConfig
+		actor      string
+		database   string
+		wantAllow  bool
+		wantReason string
+		wantMatch  string
+	}{
+		{
+			name:       "disabled authorization allows without checking principals",
+			config:     actorAuthTestConfig(false),
+			actor:      "mona",
+			database:   "orders",
+			wantAllow:  true,
+			wantReason: api.ActorAuthReasonDisabled,
+		},
+		{
+			name: "admin user allows any configured database",
+			config: actorAuthTestConfig(true, func(cfg *api.ServerConfig) {
+				cfg.PRCommandAuthorization.AdminUsers = []string{"mona"}
+			}),
+			actor:      "Mona",
+			database:   "orders",
+			wantAllow:  true,
+			wantReason: api.ActorAuthReasonAllowedAdminUser,
+			wantMatch:  "mona",
+		},
+		{
+			name: "database operator user allows that database",
+			config: actorAuthTestConfig(true, func(cfg *api.ServerConfig) {
+				db := cfg.Databases["orders"]
+				db.OperatorUsers = []string{"mona"}
+				cfg.Databases["orders"] = db
+			}),
+			actor:      "mona",
+			database:   "orders",
+			wantAllow:  true,
+			wantReason: api.ActorAuthReasonAllowedOperatorUser,
+			wantMatch:  "mona",
+		},
+		{
+			name: "missing actor denies",
+			config: actorAuthTestConfig(true, func(cfg *api.ServerConfig) {
+				cfg.PRCommandAuthorization.AdminUsers = []string{"mona"}
+			}),
+			database:   "orders",
+			wantReason: api.ActorAuthReasonMissingActor,
+		},
+		{
+			name: "missing database config denies",
+			config: actorAuthTestConfig(true, func(cfg *api.ServerConfig) {
+				cfg.PRCommandAuthorization.AdminUsers = []string{"mona"}
+			}),
+			actor:      "mona",
+			database:   "unknown",
+			wantReason: api.ActorAuthReasonMissingDatabaseConfig,
+		},
+		{
+			name:       "enabled with no principals denies",
+			config:     actorAuthTestConfig(true),
+			actor:      "mona",
+			database:   "orders",
+			wantReason: api.ActorAuthReasonNoConfiguredPrincipal,
+		},
+		{
+			name: "users only denial does not need GitHub",
+			config: actorAuthTestConfig(true, func(cfg *api.ServerConfig) {
+				cfg.PRCommandAuthorization.AdminUsers = []string{"hubot"}
+			}),
+			actor:      "mona",
+			database:   "orders",
+			wantReason: api.ActorAuthReasonNotAuthorized,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := actorAuthTestHandler(tt.config, nil)
+			result, err := h.authorizePRCommandActor(t.Context(), nil, tt.actor, tt.database)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantAllow, result.Allowed)
+			assert.Equal(t, tt.wantReason, result.Reason)
+			assert.Equal(t, tt.wantMatch, result.MatchedPrincipal)
+		})
+	}
+}
+
+func TestAuthorizePRCommandActorTeams(t *testing.T) {
+	tests := []struct {
+		name       string
+		configure  func(*api.ServerConfig)
+		statusCode int
+		state      string
+		wantAllow  bool
+		wantReason string
+		wantMatch  string
+		wantErr    bool
+	}{
+		{
+			name: "admin team allows",
+			configure: func(cfg *api.ServerConfig) {
+				cfg.PRCommandAuthorization.AdminTeams = []string{"octocat/schema-admins"}
+			},
+			statusCode: http.StatusOK,
+			state:      "active",
+			wantAllow:  true,
+			wantReason: api.ActorAuthReasonAllowedAdminTeam,
+			wantMatch:  "octocat/schema-admins",
+		},
+		{
+			name: "operator team allows",
+			configure: func(cfg *api.ServerConfig) {
+				db := cfg.Databases["orders"]
+				db.OperatorTeams = []string{"octocat/orders-operators"}
+				cfg.Databases["orders"] = db
+			},
+			statusCode: http.StatusOK,
+			state:      "active",
+			wantAllow:  true,
+			wantReason: api.ActorAuthReasonAllowedOperatorTeam,
+			wantMatch:  "octocat/orders-operators",
+		},
+		{
+			name: "not a member denies",
+			configure: func(cfg *api.ServerConfig) {
+				cfg.PRCommandAuthorization.AdminTeams = []string{"octocat/schema-admins"}
+			},
+			statusCode: http.StatusNotFound,
+			wantReason: api.ActorAuthReasonNotAuthorized,
+		},
+		{
+			name: "GitHub error fails closed",
+			configure: func(cfg *api.ServerConfig) {
+				cfg.PRCommandAuthorization.AdminTeams = []string{"octocat/schema-admins"}
+			},
+			statusCode: http.StatusInternalServerError,
+			wantReason: api.ActorAuthReasonGitHubError,
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client, mux := setupGitHubServer(t)
+			mux.HandleFunc("GET /orgs/octocat/teams/schema-admins/memberships/mona", membershipHandler(t, tt.statusCode, tt.state))
+			mux.HandleFunc("GET /orgs/octocat/teams/orders-operators/memberships/mona", membershipHandler(t, tt.statusCode, tt.state))
+			installClient := ghclient.NewInstallationClient(client, testLogger())
+
+			cfg := actorAuthTestConfig(true, tt.configure)
+			h := actorAuthTestHandler(cfg, installClient)
+			result, err := h.authorizePRCommandActor(t.Context(), installClient, "mona", "orders")
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tt.wantAllow, result.Allowed)
+			assert.Equal(t, tt.wantReason, result.Reason)
+			assert.Equal(t, tt.wantMatch, result.MatchedPrincipal)
+		})
+	}
+}
+
+func TestAuthorizePRCommandActorUsersOnlyDoesNotCallGitHub(t *testing.T) {
+	client, mux := setupGitHubServer(t)
+	var teamCalls atomic.Int32
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		teamCalls.Add(1)
+		http.NotFound(w, r)
+	})
+	installClient := ghclient.NewInstallationClient(client, testLogger())
+
+	cfg := actorAuthTestConfig(true, func(cfg *api.ServerConfig) {
+		cfg.PRCommandAuthorization.AdminUsers = []string{"hubot"}
+	})
+	h := actorAuthTestHandler(cfg, installClient)
+
+	result, err := h.authorizePRCommandActor(t.Context(), installClient, "mona", "orders")
+	require.NoError(t, err)
+	assert.False(t, result.Allowed)
+	assert.Equal(t, api.ActorAuthReasonNotAuthorized, result.Reason)
+	assert.Equal(t, int32(0), teamCalls.Load(), "users-only config should not query GitHub team membership")
+}
+
+func TestAuthorizePRCommandActorMissingServiceFailsClosed(t *testing.T) {
+	h := &Handler{logger: testLogger()}
+	result, err := h.authorizePRCommandActor(t.Context(), nil, "mona", "orders")
+	require.Error(t, err)
+	assert.False(t, result.Allowed)
+	assert.Equal(t, api.ActorAuthReasonMissingServerConfig, result.Reason)
+}
+
+func TestEnforcePRCommandActorAuthorizationComments(t *testing.T) {
+	client, mux := setupGitHubServer(t)
+	comments := make(chan string, 2)
+	mux.HandleFunc("POST /repos/octocat/hello-world/issues/1/comments", func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Body string `json:"body"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		comments <- body.Body
+		w.WriteHeader(http.StatusCreated)
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{"id": 99}))
+	})
+	installClient := ghclient.NewInstallationClient(client, testLogger())
+	cfg := actorAuthTestConfig(true, func(cfg *api.ServerConfig) {
+		cfg.PRCommandAuthorization.AdminUsers = []string{"hubot"}
+	})
+	h := actorAuthTestHandler(cfg, installClient)
+
+	blocked := h.enforcePRCommandActorAuthorization(t.Context(), installClient, "octocat/hello-world", 1, 12345, "mona", "orders", storage.DatabaseTypeMySQL, "staging", action.Apply)
+	assert.True(t, blocked)
+
+	select {
+	case body := <-comments:
+		assert.Contains(t, body, "SchemaBot Command Not Authorized")
+		assert.Contains(t, body, "@mona is not authorized")
+		assert.Contains(t, body, "`schemabot apply`")
+	case <-time.After(2 * time.Second):
+		require.FailNow(t, "timed out waiting for authorization comment")
+	}
+}
+
+// TestHandleApplyCommandBlocksUnauthorizedActorBeforePlanning exercises the
+// PR apply flow through schema discovery and actor authorization. An actor who
+// is not a configured admin/operator should receive a denial comment before
+// SchemaBot reconciles checks, creates a plan, or acquires a lock.
+func TestHandleApplyCommandBlocksUnauthorizedActorBeforePlanning(t *testing.T) {
+	client, mux := setupGitHubServer(t)
+	registerApplyDiscoveryEndpoints(t, mux, "orders")
+
+	comments := make(chan string, 2)
+	mux.HandleFunc("POST /repos/octocat/hello-world/issues/1/comments", func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Body string `json:"body"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		comments <- body.Body
+		w.WriteHeader(http.StatusCreated)
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{"id": 99}))
+	})
+
+	installClient := ghclient.NewInstallationClient(client, testLogger())
+	cfg := actorAuthTestConfig(true, func(cfg *api.ServerConfig) {
+		cfg.PRCommandAuthorization.AdminUsers = []string{"hubot"}
+	})
+	h := actorAuthTestHandler(cfg, installClient)
+
+	h.handleApplyCommand("octocat/hello-world", 1, "staging", "", 12345, "mona", CommandResult{Action: action.Apply})
+
+	select {
+	case body := <-comments:
+		assert.Contains(t, body, "SchemaBot Command Not Authorized")
+		assert.Contains(t, body, "@mona is not authorized")
+	case <-time.After(2 * time.Second):
+		require.FailNow(t, "timed out waiting for unauthorized apply comment")
+	}
+}
+
+func actorAuthTestConfig(enabled bool, opts ...func(*api.ServerConfig)) *api.ServerConfig {
+	cfg := &api.ServerConfig{
+		PRCommandAuthorization: api.PRCommandAuthorizationConfig{Enabled: enabled},
+		Databases: map[string]api.DatabaseConfig{
+			"orders": {
+				Type: storage.DatabaseTypeMySQL,
+				Environments: map[string]api.EnvironmentConfig{
+					"staging": {DSN: "root@tcp(localhost)/orders"},
+				},
+			},
+		},
+	}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+	return cfg
+}
+
+func actorAuthTestHandler(cfg *api.ServerConfig, installClient *ghclient.InstallationClient) *Handler {
+	service := api.New(nil, cfg, nil, testLogger())
+	return &Handler{
+		service:  service,
+		ghClient: &fakeClientFactory{client: installClient},
+		logger:   testLogger(),
+	}
+}
+
+func membershipHandler(t *testing.T, statusCode int, state string) http.HandlerFunc {
+	t.Helper()
+	return func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(statusCode)
+		if statusCode == http.StatusOK {
+			require.NoError(t, json.NewEncoder(w).Encode(map[string]string{"state": state}))
+		}
+		if statusCode >= http.StatusBadRequest {
+			_, err := fmt.Fprint(w, http.StatusText(statusCode))
+			require.NoError(t, err)
+		}
+	}
+}
+
+func registerApplyDiscoveryEndpoints(t *testing.T, mux *http.ServeMux, database string) {
+	t.Helper()
+
+	schemabotConfig := fmt.Sprintf("database: %s\ntype: mysql\nenvironments:\n  - staging\n", database)
+	schemaSQL := "CREATE TABLE `users` (`id` bigint unsigned NOT NULL AUTO_INCREMENT, PRIMARY KEY (`id`))"
+
+	mux.HandleFunc("GET /repos/octocat/hello-world/pulls/1", func(w http.ResponseWriter, _ *http.Request) {
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+			"head": map[string]any{"sha": "abc123", "ref": "feature-branch"},
+			"base": map[string]any{"sha": "def456", "ref": "main"},
+			"user": map[string]any{"login": "testuser"},
+		}))
+	})
+	mux.HandleFunc("GET /repos/octocat/hello-world/pulls/1/files", func(w http.ResponseWriter, _ *http.Request) {
+		require.NoError(t, json.NewEncoder(w).Encode([]map[string]string{{
+			"filename": "schema/" + database + "/users.sql",
+			"status":   "added",
+		}}))
+	})
+	mux.HandleFunc("GET /repos/octocat/hello-world/contents/schema/"+database+"/schemabot.yaml", func(w http.ResponseWriter, _ *http.Request) {
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]string{
+			"content":  base64.StdEncoding.EncodeToString([]byte(schemabotConfig)),
+			"encoding": "base64",
+		}))
+	})
+	mux.HandleFunc("GET /repos/octocat/hello-world/git/trees/abc123", func(w http.ResponseWriter, _ *http.Request) {
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+			"tree": []map[string]any{{
+				"path": "schema/" + database + "/users.sql",
+				"mode": "100644",
+				"type": "blob",
+				"sha":  "userssha",
+				"size": len(schemaSQL),
+			}},
+			"truncated": false,
+		}))
+	})
+	mux.HandleFunc("GET /repos/octocat/hello-world/git/blobs/userssha", func(w http.ResponseWriter, _ *http.Request) {
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]string{
+			"content":  base64.StdEncoding.EncodeToString([]byte(schemaSQL)),
+			"encoding": "base64",
+		}))
+	})
+}

--- a/pkg/webhook/apply_handlers.go
+++ b/pkg/webhook/apply_handlers.go
@@ -30,7 +30,19 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 		return
 	}
 
-	// Fix checks stuck at "in_progress" from crashed applies
+	// Discover config and fetch schema files from PR
+	schemaResult, err := client.CreateSchemaRequestFromPR(ctx, repo, pr, environment, databaseName)
+	if err != nil {
+		h.handleSchemaRequestError(repo, pr, installationID, environment, databaseName, requestedBy, action.Apply, err)
+		return
+	}
+
+	if blocked := h.enforcePRCommandActorAuthorization(ctx, client, repo, pr, installationID, requestedBy, schemaResult.Database, schemaResult.Type, environment, action.Apply); blocked {
+		return
+	}
+
+	// Fix checks stuck at "in_progress" from crashed applies after the actor
+	// is authorized to run apply for this database.
 	if err := h.reconcileStaleChecks(ctx, client, repo, pr); err != nil {
 		h.logger.Error("failed to reconcile stale status checks", "repo", repo, "pr", pr, "error", err)
 		h.postComment(repo, pr, installationID, templates.RenderGenericError(templates.SchemaErrorData{
@@ -40,13 +52,6 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 			CommandName: action.Apply,
 			ErrorDetail: "Failed to reconcile stale status checks: " + err.Error(),
 		}))
-		return
-	}
-
-	// Discover config and fetch schema files from PR
-	schemaResult, err := client.CreateSchemaRequestFromPR(ctx, repo, pr, environment, databaseName)
-	if err != nil {
-		h.handleSchemaRequestError(repo, pr, installationID, environment, databaseName, requestedBy, action.Apply, err)
 		return
 	}
 
@@ -338,6 +343,10 @@ func (h *Handler) handleApplyConfirmCommand(repo string, pr int, environment, da
 	schemaResult, err := client.CreateSchemaRequestFromPR(ctx, repo, pr, environment, databaseName)
 	if err != nil {
 		h.handleSchemaRequestError(repo, pr, installationID, environment, databaseName, requestedBy, action.ApplyConfirm, err)
+		return
+	}
+
+	if blocked := h.enforcePRCommandActorAuthorization(ctx, client, repo, pr, installationID, requestedBy, schemaResult.Database, schemaResult.Type, environment, action.ApplyConfirm); blocked {
 		return
 	}
 

--- a/pkg/webhook/templates/apply_commands.go
+++ b/pkg/webhook/templates/apply_commands.go
@@ -26,6 +26,53 @@ type ApplyLockConflictData struct {
 	ApplyState string
 }
 
+// ActorAuthorizationCommentData contains data for PR command actor
+// authorization comments.
+type ActorAuthorizationCommentData struct {
+	RequestedBy string
+	CommandName string
+	Database    string
+	Environment string
+}
+
+// RenderPRCommandNotAuthorized renders a comment when a GitHub PR command
+// actor is not allowed to run SchemaBot apply/apply-confirm for the database.
+func RenderPRCommandNotAuthorized(data ActorAuthorizationCommentData) string {
+	var sb strings.Builder
+
+	sb.WriteString("## SchemaBot Command Not Authorized\n\n")
+	writeDBEnvLine(&sb, data.Database, data.Environment)
+	if data.RequestedBy != "" {
+		fmt.Fprintf(&sb, "**Requested by**: @%s\n", data.RequestedBy)
+	}
+	sb.WriteString("\n")
+	if data.RequestedBy != "" {
+		fmt.Fprintf(&sb, "@%s is not authorized to run `schemabot %s` for this database.\n\n", data.RequestedBy, data.CommandName)
+	} else {
+		fmt.Fprintf(&sb, "The requester is not authorized to run `schemabot %s` for this database.\n\n", data.CommandName)
+	}
+	sb.WriteString("A configured SchemaBot admin/database operator must run this command.\n")
+
+	return sb.String()
+}
+
+// RenderPRCommandAuthorizationUnavailable renders a comment when SchemaBot
+// cannot verify actor authorization for apply/apply-confirm.
+func RenderPRCommandAuthorizationUnavailable(data ActorAuthorizationCommentData) string {
+	var sb strings.Builder
+
+	sb.WriteString("## SchemaBot Authorization Check Failed\n\n")
+	writeDBEnvLine(&sb, data.Database, data.Environment)
+	if data.RequestedBy != "" {
+		fmt.Fprintf(&sb, "**Requested by**: @%s\n", data.RequestedBy)
+	}
+	sb.WriteString("\n")
+	fmt.Fprintf(&sb, "SchemaBot could not verify GitHub team membership for `schemabot %s`. No schema change was started.\n\n", data.CommandName)
+	sb.WriteString("A configured SchemaBot admin/database operator should retry after membership checks are available.\n")
+
+	return sb.String()
+}
+
 // RenderUnsafeChangesBlocked renders a comment when unsafe changes are detected
 // and --allow-unsafe was not specified. Shows the plan DDL plus a blocking message
 // instructing the user to re-run with --allow-unsafe.

--- a/pkg/webhook/templates/apply_commands.go
+++ b/pkg/webhook/templates/apply_commands.go
@@ -67,8 +67,8 @@ func RenderPRCommandAuthorizationUnavailable(data ActorAuthorizationCommentData)
 		fmt.Fprintf(&sb, "**Requested by**: @%s\n", data.RequestedBy)
 	}
 	sb.WriteString("\n")
-	fmt.Fprintf(&sb, "SchemaBot could not verify GitHub team membership for `schemabot %s`. No schema change was started.\n\n", data.CommandName)
-	sb.WriteString("A configured SchemaBot admin/database operator should retry after membership checks are available.\n")
+	fmt.Fprintf(&sb, "SchemaBot could not verify authorization for `schemabot %s`. No schema change was started.\n\n", data.CommandName)
+	sb.WriteString("A configured SchemaBot admin/database operator should inspect SchemaBot authorization logs before retrying.\n")
 
 	return sb.String()
 }

--- a/pkg/webhook/templates/apply_test.go
+++ b/pkg/webhook/templates/apply_test.go
@@ -224,9 +224,9 @@ func TestRenderPRCommandAuthorizationUnavailable(t *testing.T) {
 	assert.Contains(t, result, "SchemaBot Authorization Check Failed")
 	assert.Contains(t, result, "`orders`")
 	assert.Contains(t, result, "`production`")
-	assert.Contains(t, result, "could not verify GitHub team membership")
+	assert.Contains(t, result, "could not verify authorization")
 	assert.Contains(t, result, "No schema change was started")
-	assert.Contains(t, result, "membership checks are available")
+	assert.Contains(t, result, "inspect SchemaBot authorization logs")
 }
 
 func TestApplyStatusFromProgress(t *testing.T) {

--- a/pkg/webhook/templates/apply_test.go
+++ b/pkg/webhook/templates/apply_test.go
@@ -197,6 +197,38 @@ func TestRenderApplyStatusComment_NoRequestedBy(t *testing.T) {
 	assert.NotContains(t, result, "@")
 }
 
+func TestRenderPRCommandNotAuthorized(t *testing.T) {
+	result := RenderPRCommandNotAuthorized(ActorAuthorizationCommentData{
+		RequestedBy: "mona",
+		CommandName: "apply",
+		Database:    "orders",
+		Environment: "staging",
+	})
+
+	assert.Contains(t, result, "SchemaBot Command Not Authorized")
+	assert.Contains(t, result, "`orders`")
+	assert.Contains(t, result, "`staging`")
+	assert.Contains(t, result, "@mona is not authorized")
+	assert.Contains(t, result, "`schemabot apply`")
+	assert.Contains(t, result, "SchemaBot admin/database operator")
+}
+
+func TestRenderPRCommandAuthorizationUnavailable(t *testing.T) {
+	result := RenderPRCommandAuthorizationUnavailable(ActorAuthorizationCommentData{
+		RequestedBy: "mona",
+		CommandName: "apply-confirm",
+		Database:    "orders",
+		Environment: "production",
+	})
+
+	assert.Contains(t, result, "SchemaBot Authorization Check Failed")
+	assert.Contains(t, result, "`orders`")
+	assert.Contains(t, result, "`production`")
+	assert.Contains(t, result, "could not verify GitHub team membership")
+	assert.Contains(t, result, "No schema change was started")
+	assert.Contains(t, result, "membership checks are available")
+}
+
 func TestApplyStatusFromProgress(t *testing.T) {
 	resp := &apitypes.ProgressResponse{
 		State:       "running",

--- a/pkg/webhook/templates/preview.go
+++ b/pkg/webhook/templates/preview.go
@@ -209,6 +209,28 @@ func PreviewCommentReviewGateError() string {
 	})
 }
 
+// PreviewCommentPRCommandNotAuthorized renders a sample actor authorization
+// denial for apply/apply-confirm PR comments.
+func PreviewCommentPRCommandNotAuthorized() string {
+	return RenderPRCommandNotAuthorized(ActorAuthorizationCommentData{
+		RequestedBy: "mona",
+		CommandName: action.Apply,
+		Database:    "orders",
+		Environment: "staging",
+	})
+}
+
+// PreviewCommentPRCommandAuthorizationUnavailable renders a sample fail-closed
+// actor authorization error for apply/apply-confirm PR comments.
+func PreviewCommentPRCommandAuthorizationUnavailable() string {
+	return RenderPRCommandAuthorizationUnavailable(ActorAuthorizationCommentData{
+		RequestedBy: "mona",
+		CommandName: action.ApplyConfirm,
+		Database:    "orders",
+		Environment: "production",
+	})
+}
+
 // PreviewCommentApplyBlockedByPriorEnv renders a sample "production blocked by staging" comment.
 func PreviewCommentApplyBlockedByPriorEnv() string {
 	return RenderApplyBlockedByPriorEnv("testapp", "production", "staging", "has pending changes", "Apply staging first")


### PR DESCRIPTION
## Why

SchemaBot PR applies currently rely on repo/path policy and review gates, but do not verify that the comment author is allowed to mutate the target database. This adds an optional server-owned actor gate for mutating PR commands, starting with `apply` and `apply-confirm`.

## Flow

```text
PR comment
  schemabot apply / schemabot apply-confirm
        |
        v
Load server-owned actor policy
        |
        +-- no actor policy configured
        |       |
        |       v
        |   keep existing behavior
        |
        v
Check comment actor
        |
        +-- database missing from server config
        |       |
        |       v
        |   fail closed
        |
        +-- no admin/operator principals configured
        |       |
        |       v
        |   fail closed
        |
        v
Authorization order
  1. global admin team membership
  2. global admin user
  3. database operator team membership
  4. database operator user
        |
        +-- matched
        |       |
        |       v
        |   continue existing apply flow
        |
        +-- no match
        |       |
        |       v
        |   post PR comment and stop
        |
        +-- GitHub membership unavailable
                |
                v
            fail closed with PR comment, logs, and metrics
```

## What

- Add optional server config for PR command actor authorization.
- Support global admins and per-database operators.
- Allow operators/admins to be configured as GitHub users or GitHub teams.
- Verify GitHub team membership through the GitHub API and require active membership.
- Gate `schemabot apply` and `schemabot apply-confirm` before they can start or confirm a schema apply from a PR comment.
- Fail closed when authorization cannot be verified, with a clear PR comment for the developer and structured logs/metrics for operators.
- Add `TEMPLATES.md` preview scenarios for denied and fail-closed authorization comments.
- Add focused test coverage for config validation, GitHub team membership checks, webhook authorization behavior, PR comment templates, and metric normalization.

## Config Example

Actor authorization is configured in SchemaBot's server config, not in repo-owned `schemabot.yaml`.

```yaml
pr_command_authorization:
  enabled: true
  admin_teams:
    - example-org/schema-admins
  admin_users:
    - release-bot

databases:
  orders:
    type: mysql
    operator_teams:
      - example-org/orders-db-operators
    operator_users:
      - mona
    environments:
      staging:
        dsn: env:ORDERS_STAGING_DSN
      production:
        dsn: env:ORDERS_PRODUCTION_DSN
```

With this config:
- members of `example-org/schema-admins` and user `release-bot` can run `apply` / `apply-confirm` for any configured database.
- members of `example-org/orders-db-operators` and user `mona` can run `apply` / `apply-confirm` for the `orders` database.
- team values must use `org/team-slug` form so SchemaBot can check active GitHub membership.

## Rollout Notes

- Disabled unless server config opts into actor authorization.
- Direct CLI/API behavior is unchanged in this PR; CLI/direct API auth is a follow-up.
- `plan` and read-only PR commands remain broadly available.
- This is the first slice of PR command auth. Follow-ups can extend the same pattern to rollback, unlock, and other mutating commands.

🤖 Generated with Codex
