### PR TITLE
fix(observability): add logging, metrics, and repository dimension for webhook operations

### DIFF
--- a/pkg/api/plan_handlers.go
+++ b/pkg/api/plan_handlers.go
@@ -119,16 +119,16 @@ func (s *Service) ExecutePlan(ctx context.Context, req PlanRequest) (*apitypes.P
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "resolve target")
-		metrics.RecordPlan(ctx, req.Database, req.Environment, "error")
-		metrics.RecordPlanDuration(ctx, time.Since(planStart), req.Database, req.Environment, "error")
+		metrics.RecordPlan(ctx, req.Repository, req.Database, req.Environment, "error")
+		metrics.RecordPlanDuration(ctx, time.Since(planStart), req.Repository, req.Database, req.Environment, "error")
 		return nil, fmt.Errorf("resolve target for %s/%s: %w", req.Database, req.Environment, err)
 	}
 	if req.Type != resolvedTarget.DatabaseType {
 		typeErr := fmt.Errorf("database %q type %q does not match server config type %q", req.Database, req.Type, resolvedTarget.DatabaseType)
 		span.RecordError(typeErr)
 		span.SetStatus(codes.Error, "type mismatch")
-		metrics.RecordPlan(ctx, req.Database, req.Environment, "error")
-		metrics.RecordPlanDuration(ctx, time.Since(planStart), req.Database, req.Environment, "error")
+		metrics.RecordPlan(ctx, req.Repository, req.Database, req.Environment, "error")
+		metrics.RecordPlanDuration(ctx, time.Since(planStart), req.Repository, req.Database, req.Environment, "error")
 		return nil, typeErr
 	}
 	deployment := resolvedTarget.Deployment
@@ -160,8 +160,8 @@ func (s *Service) ExecutePlan(ctx context.Context, req PlanRequest) (*apitypes.P
 			reason := sourcePolicyReason(err)
 			span.RecordError(err)
 			span.SetStatus(codes.Error, "source policy")
-			metrics.RecordPlan(ctx, req.Database, req.Environment, "error")
-			metrics.RecordPlanDuration(ctx, time.Since(planStart), req.Database, req.Environment, "error")
+			metrics.RecordPlan(ctx, req.Repository, req.Database, req.Environment, "error")
+			metrics.RecordPlanDuration(ctx, time.Since(planStart), req.Repository, req.Database, req.Environment, "error")
 			metrics.RecordSourcePolicyBlock(ctx, "plan", req.Database, req.Environment, reason)
 			s.logger.Warn("plan blocked by source policy",
 				"database", req.Database,
@@ -179,8 +179,8 @@ func (s *Service) ExecutePlan(ctx context.Context, req PlanRequest) (*apitypes.P
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "tern client")
-		metrics.RecordPlan(ctx, req.Database, req.Environment, "error")
-		metrics.RecordPlanDuration(ctx, time.Since(planStart), req.Database, req.Environment, "error")
+		metrics.RecordPlan(ctx, req.Repository, req.Database, req.Environment, "error")
+		metrics.RecordPlanDuration(ctx, time.Since(planStart), req.Repository, req.Database, req.Environment, "error")
 		return nil, fmt.Errorf("database %q (%s): %w", req.Database, req.Environment, err)
 	}
 
@@ -210,13 +210,13 @@ func (s *Service) ExecutePlan(ctx context.Context, req PlanRequest) (*apitypes.P
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "plan failed")
-		metrics.RecordPlan(ctx, req.Database, req.Environment, "error")
-		metrics.RecordPlanDuration(ctx, time.Since(planStart), req.Database, req.Environment, "error")
+		metrics.RecordPlan(ctx, req.Repository, req.Database, req.Environment, "error")
+		metrics.RecordPlanDuration(ctx, time.Since(planStart), req.Repository, req.Database, req.Environment, "error")
 		return nil, err
 	}
 	span.SetAttributes(attribute.String("plan_id", resp.PlanId), attribute.Int("change_count", len(resp.Changes)))
-	metrics.RecordPlan(ctx, req.Database, req.Environment, "success")
-	metrics.RecordPlanDuration(ctx, time.Since(planStart), req.Database, req.Environment, "success")
+	metrics.RecordPlan(ctx, req.Repository, req.Database, req.Environment, "success")
+	metrics.RecordPlanDuration(ctx, time.Since(planStart), req.Repository, req.Database, req.Environment, "success")
 
 	s.logger.Info("ExecutePlan: plan response",
 		"plan_id", resp.PlanId,
@@ -342,21 +342,21 @@ func (s *Service) ExecuteApply(ctx context.Context, req ApplyRequest) (*apitypes
 		applyErr := fmt.Errorf("plan %s was created for environment %q, not %q", req.PlanID, plan.Environment, req.Environment)
 		span.RecordError(applyErr)
 		span.SetStatus(codes.Error, "environment mismatch")
-		metrics.RecordApply(ctx, plan.Database, req.Environment, "error")
+		metrics.RecordApply(ctx, plan.Repository, plan.Database, req.Environment, "error")
 		return nil, 0, applyErr
 	}
 	if plan.Deployment == "" {
 		applyErr := fmt.Errorf("plan %s is missing server-side routing metadata field %q; create a new plan and retry apply", req.PlanID, "deployment")
 		span.RecordError(applyErr)
 		span.SetStatus(codes.Error, "missing stored deployment")
-		metrics.RecordApply(ctx, plan.Database, req.Environment, "error")
+		metrics.RecordApply(ctx, plan.Repository, plan.Database, req.Environment, "error")
 		return nil, 0, applyErr
 	}
 	if plan.Target == "" {
 		applyErr := fmt.Errorf("plan %s is missing server-side routing metadata field %q; create a new plan and retry apply", req.PlanID, "target")
 		span.RecordError(applyErr)
 		span.SetStatus(codes.Error, "missing stored target")
-		metrics.RecordApply(ctx, plan.Database, req.Environment, "error")
+		metrics.RecordApply(ctx, plan.Repository, plan.Database, req.Environment, "error")
 		return nil, 0, applyErr
 	}
 	// Source policy is evaluated for plans created from SchemaBot's trusted
@@ -380,7 +380,7 @@ func (s *Service) ExecuteApply(ctx context.Context, req ApplyRequest) (*apitypes
 			reason := sourcePolicyReason(err)
 			span.RecordError(err)
 			span.SetStatus(codes.Error, "source policy")
-			metrics.RecordApply(ctx, plan.Database, req.Environment, "error")
+			metrics.RecordApply(ctx, plan.Repository, plan.Database, req.Environment, "error")
 			metrics.RecordSourcePolicyBlock(ctx, "apply", plan.Database, req.Environment, reason)
 			s.logger.Warn("apply blocked by source policy",
 				"plan_id", req.PlanID,
@@ -401,7 +401,7 @@ func (s *Service) ExecuteApply(ctx context.Context, req ApplyRequest) (*apitypes
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "tern client")
-		metrics.RecordApply(ctx, plan.Database, req.Environment, "error")
+		metrics.RecordApply(ctx, plan.Repository, plan.Database, req.Environment, "error")
 		return nil, 0, fmt.Errorf("database %q (%s): %w", plan.Database, req.Environment, err)
 	}
 
@@ -413,8 +413,8 @@ func (s *Service) ExecuteApply(ctx context.Context, req ApplyRequest) (*apitypes
 
 	enqueueStart := time.Now()
 	recordApplyResult := func(status string) {
-		metrics.RecordApply(ctx, plan.Database, req.Environment, status)
-		metrics.RecordApplyDuration(ctx, time.Since(enqueueStart), plan.Database, req.Environment, status)
+		metrics.RecordApply(ctx, plan.Repository, plan.Database, req.Environment, status)
+		metrics.RecordApplyDuration(ctx, time.Since(enqueueStart), plan.Repository, plan.Database, req.Environment, status)
 	}
 	recordApplyError := func(status string, err error) {
 		span.RecordError(err)

--- a/pkg/api/telemetry_test.go
+++ b/pkg/api/telemetry_test.go
@@ -57,7 +57,7 @@ func TestSetupTelemetryWithOTLP(t *testing.T) {
 	assert.NotNil(t, tel.tracerProvider, "tracerProvider should be set with OTLP endpoint")
 
 	// Record a metric so there's data to push.
-	metrics.RecordPlan(t.Context(), "testdb", "staging", "success")
+	metrics.RecordPlan(t.Context(), "testrepo", "testdb", "staging", "success")
 
 	// Create a trace span so there's trace data to push.
 	tracer := otel.Tracer("test")
@@ -109,10 +109,10 @@ func TestRecordPlanMetric(t *testing.T) {
 		require.NoError(t, mp.Shutdown(t.Context()))
 	})
 
-	metrics.RecordPlan(t.Context(), "testdb", "staging", "success")
-	metrics.RecordPlan(t.Context(), "testdb", "staging", "success")
-	metrics.RecordPlan(t.Context(), "testdb", "staging", "error")
-	metrics.RecordPlan(t.Context(), "other", "production", "success")
+	metrics.RecordPlan(t.Context(), "testrepo", "testdb", "staging", "success")
+	metrics.RecordPlan(t.Context(), "testrepo", "testdb", "staging", "success")
+	metrics.RecordPlan(t.Context(), "testrepo", "testdb", "staging", "error")
+	metrics.RecordPlan(t.Context(), "testrepo", "other", "production", "success")
 
 	var rm metricdata.ResourceMetrics
 	require.NoError(t, reader.Collect(t.Context(), &rm))
@@ -140,15 +140,15 @@ func TestRecordPlanMetric(t *testing.T) {
 			DataPoints: []metricdata.DataPoint[int64]{
 				{
 					Value:      2,
-					Attributes: attribute.NewSet(attribute.String("database", "testdb"), attribute.String("environment", "staging"), attribute.String("status", "success")),
+					Attributes: attribute.NewSet(attribute.String("repository", "testrepo"), attribute.String("database", "testdb"), attribute.String("environment", "staging"), attribute.String("status", "success")),
 				},
 				{
 					Value:      1,
-					Attributes: attribute.NewSet(attribute.String("database", "testdb"), attribute.String("environment", "staging"), attribute.String("status", "error")),
+					Attributes: attribute.NewSet(attribute.String("repository", "testrepo"), attribute.String("database", "testdb"), attribute.String("environment", "staging"), attribute.String("status", "error")),
 				},
 				{
 					Value:      1,
-					Attributes: attribute.NewSet(attribute.String("database", "other"), attribute.String("environment", "production"), attribute.String("status", "success")),
+					Attributes: attribute.NewSet(attribute.String("repository", "testrepo"), attribute.String("database", "other"), attribute.String("environment", "production"), attribute.String("status", "success")),
 				},
 			},
 		},
@@ -236,10 +236,10 @@ func TestRecordApplyMetrics(t *testing.T) {
 		require.NoError(t, mp.Shutdown(t.Context()))
 	})
 
-	metrics.RecordApply(t.Context(), "mydb", "staging", "success")
-	metrics.RecordApply(t.Context(), "mydb", "staging", "error")
-	metrics.RecordApply(t.Context(), "mydb", "staging", "conflict")
-	metrics.RecordApplyDuration(t.Context(), 2*time.Second, "mydb", "staging", "success")
+	metrics.RecordApply(t.Context(), "testrepo", "mydb", "staging", "success")
+	metrics.RecordApply(t.Context(), "testrepo", "mydb", "staging", "error")
+	metrics.RecordApply(t.Context(), "testrepo", "mydb", "staging", "conflict")
+	metrics.RecordApplyDuration(t.Context(), 2*time.Second, "testrepo", "mydb", "staging", "success")
 
 	names := collectMetricNames(t, reader)
 	assert.True(t, names["schemabot.applies.total"], "expected schemabot.applies.total")
@@ -397,7 +397,7 @@ func TestRecordPlanDurationMetric(t *testing.T) {
 		require.NoError(t, mp.Shutdown(t.Context()))
 	})
 
-	metrics.RecordPlanDuration(t.Context(), 500*time.Millisecond, "mydb", "staging", "success")
+	metrics.RecordPlanDuration(t.Context(), 500*time.Millisecond, "testrepo", "mydb", "staging", "success")
 
 	names := collectMetricNames(t, reader)
 	assert.True(t, names["schemabot.plan.duration_seconds"], "expected schemabot.plan.duration_seconds")

--- a/pkg/metrics/README.md
+++ b/pkg/metrics/README.md
@@ -6,10 +6,11 @@ SchemaBot exposes metrics via OpenTelemetry. All metrics are available at `GET /
 
 | Metric | Type | Attributes | Description |
 |---|---|---|---|
-| `schemabot.plans.total` | Counter | database, environment, status | Total plan operations |
-| `schemabot.plan.duration_seconds` | Histogram | database, environment, status | Plan execution time |
-| `schemabot.applies.total` | Counter | database, environment, status | Total apply operations |
-| `schemabot.apply.duration_seconds` | Histogram | database, environment, status | Apply API call time |
+| `schemabot.plans.total` | Counter | repository, database, environment, status | Total plan operations |
+| `schemabot.plan.duration_seconds` | Histogram | repository, database, environment, status | Plan execution time |
+| `schemabot.applies.total` | Counter | repository, database, environment, status | Total apply operations |
+| `schemabot.apply.duration_seconds` | Histogram | repository, database, environment, status | Apply API call time |
+| `schemabot.schema_request.errors_total` | Counter | repository, command, database, environment, reason | Schema request errors by reason |
 | `schemabot.active_applies` | UpDownCounter | database, environment | In-progress applies |
 | `schemabot.check_ownership_misses_total` | Counter | operation, repository, database, database_type, environment | Guarded check updates skipped because ownership changed |
 | `schemabot.status_check_operations_total` | Counter | operation, status, repository, database, database_type, environment | Status-check storage and GitHub operations |

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -19,7 +19,7 @@ const meterName = "schemabot"
 //
 // The OTel SDK deduplicates instruments with the same name, so repeated calls
 // to Int64Counter are cheap after the first registration.
-func RecordPlan(ctx context.Context, database, environment, status string) {
+func RecordPlan(ctx context.Context, repo, database, environment, status string) {
 	meter := otel.Meter(meterName)
 	counter, err := meter.Int64Counter("schemabot.plans.total",
 		otelmetric.WithDescription("Total number of plan operations"),
@@ -31,6 +31,7 @@ func RecordPlan(ctx context.Context, database, environment, status string) {
 	}
 	counter.Add(ctx, 1,
 		otelmetric.WithAttributes(
+			attribute.String("repository", repo),
 			attribute.String("database", database),
 			attribute.String("environment", environment),
 			attribute.String("status", status),
@@ -39,7 +40,7 @@ func RecordPlan(ctx context.Context, database, environment, status string) {
 }
 
 // RecordPlanDuration records the duration of a plan operation.
-func RecordPlanDuration(ctx context.Context, duration time.Duration, database, environment, status string) {
+func RecordPlanDuration(ctx context.Context, duration time.Duration, repo, database, environment, status string) {
 	meter := otel.Meter(meterName)
 	hist, err := meter.Float64Histogram("schemabot.plan.duration_seconds",
 		otelmetric.WithDescription("Duration of plan operations"),
@@ -51,6 +52,7 @@ func RecordPlanDuration(ctx context.Context, duration time.Duration, database, e
 	}
 	hist.Record(ctx, duration.Seconds(),
 		otelmetric.WithAttributes(
+			attribute.String("repository", repo),
 			attribute.String("database", database),
 			attribute.String("environment", environment),
 			attribute.String("status", status),
@@ -60,7 +62,7 @@ func RecordPlanDuration(ctx context.Context, duration time.Duration, database, e
 
 // RecordApply increments the applies counter with database, environment, and status attributes.
 // Status should be "success", "error", "rejected", or "conflict".
-func RecordApply(ctx context.Context, database, environment, status string) {
+func RecordApply(ctx context.Context, repo, database, environment, status string) {
 	meter := otel.Meter(meterName)
 	counter, err := meter.Int64Counter("schemabot.applies.total",
 		otelmetric.WithDescription("Total number of apply operations"),
@@ -72,6 +74,7 @@ func RecordApply(ctx context.Context, database, environment, status string) {
 	}
 	counter.Add(ctx, 1,
 		otelmetric.WithAttributes(
+			attribute.String("repository", repo),
 			attribute.String("database", database),
 			attribute.String("environment", environment),
 			attribute.String("status", status),
@@ -81,7 +84,7 @@ func RecordApply(ctx context.Context, database, environment, status string) {
 
 // RecordApplyDuration records the duration of an apply operation (API call time,
 // not the full Spirit run which can take hours).
-func RecordApplyDuration(ctx context.Context, duration time.Duration, database, environment, status string) {
+func RecordApplyDuration(ctx context.Context, duration time.Duration, repo, database, environment, status string) {
 	meter := otel.Meter(meterName)
 	hist, err := meter.Float64Histogram("schemabot.apply.duration_seconds",
 		otelmetric.WithDescription("Duration of apply operations (API call time)"),
@@ -93,6 +96,7 @@ func RecordApplyDuration(ctx context.Context, duration time.Duration, database, 
 	}
 	hist.Record(ctx, duration.Seconds(),
 		otelmetric.WithAttributes(
+			attribute.String("repository", repo),
 			attribute.String("database", database),
 			attribute.String("environment", environment),
 			attribute.String("status", status),
@@ -395,6 +399,30 @@ var knownWebhookActions = map[string]bool{
 	"requested":   true, // check_run
 	"completed":   true, // check_run
 	"":            true, // events without actions (e.g., ping)
+}
+
+// RecordSchemaRequestError increments the schema request error counter.
+// Reason should be a stable string: "database_not_found", "invalid_config",
+// "no_config", "multiple_configs", or "unexpected".
+func RecordSchemaRequestError(ctx context.Context, repo, command, database, environment, reason string) {
+	meter := otel.Meter(meterName)
+	counter, err := meter.Int64Counter("schemabot.schema_request.errors_total",
+		otelmetric.WithDescription("Schema request errors by reason"),
+		otelmetric.WithUnit("{error}"),
+	)
+	if err != nil {
+		slog.Warn("failed to create schema request error counter", "error", err)
+		return
+	}
+	counter.Add(ctx, 1,
+		otelmetric.WithAttributes(
+			attribute.String("repository", repo),
+			attribute.String("command", command),
+			attribute.String("database", database),
+			attribute.String("environment", environment),
+			attribute.String("reason", reason),
+		),
+	)
 }
 
 // RecordWebhookEvent increments the webhook events counter.

--- a/pkg/webhook/issue_comment.go
+++ b/pkg/webhook/issue_comment.go
@@ -247,12 +247,14 @@ func (h *Handler) postComment(repo string, pr int, installationID int64, body st
 
 	client, err := h.ghClient.ForInstallation(installationID)
 	if err != nil {
-		h.logger.Error("failed to create GitHub client", "error", err)
+		h.logger.Error("failed to create GitHub client for comment",
+			"repo", repo, "pr", pr, "installation_id", installationID, "error", err)
 		return
 	}
 
 	if _, err := client.CreateIssueComment(ctx, repo, pr, body); err != nil {
-		h.logger.Error("failed to post comment", "repo", repo, "pr", pr, "error", err)
+		h.logger.Error("failed to post comment",
+			"repo", repo, "pr", pr, "installation_id", installationID, "error", err)
 	}
 }
 

--- a/pkg/webhook/plan.go
+++ b/pkg/webhook/plan.go
@@ -90,6 +90,7 @@ func (h *Handler) handlePlanCommand(w http.ResponseWriter, repo string, pr int, 
 	planResp, err := h.service.ExecutePlan(ctx, planReq)
 	if err != nil {
 		h.logger.Error("plan execution failed", "repo", repo, "pr", pr, "error", err)
+		metrics.RecordPlan(ctx, repo, schemaResult.Database, environment, "error")
 		h.postFailingAggregates(ctx, client, repo, pr, schemaResult.HeadSHA, map[string]string{
 			environment: userFacingError(err),
 		})
@@ -106,6 +107,8 @@ func (h *Handler) handlePlanCommand(w http.ResponseWriter, repo string, pr int, 
 
 	// Build plan comment data
 	commentData := buildPlanCommentData(schemaResult, planResp, environment, requestedBy)
+
+	metrics.RecordPlan(ctx, repo, schemaResult.Database, environment, "success")
 
 	// Post plan comment
 	h.postComment(repo, pr, installationID, templates.RenderPlanComment(commentData))
@@ -341,28 +344,45 @@ func (h *Handler) handleSchemaRequestError(repo string, pr int, installationID i
 		CommandName:  commandName,
 	}
 
+	logFields := []any{
+		"repo", repo, "pr", pr, "environment", environment,
+		"database", databaseName, "action", commandName, "error", err,
+	}
+
+	ctx := context.Background()
+
 	var dbNotFoundErr *ghclient.DatabaseNotFoundError
 	if errors.As(err, &dbNotFoundErr) {
+		h.logger.Warn("schema request: database not found", logFields...)
+		metrics.RecordSchemaRequestError(ctx, repo, commandName, databaseName, environment, "database_not_found")
 		h.postComment(repo, pr, installationID, templates.RenderDatabaseNotFound(data))
 		return
 	}
 
 	if errors.Is(err, ghclient.ErrInvalidConfig) {
+		h.logger.Warn("schema request: invalid config", logFields...)
+		metrics.RecordSchemaRequestError(ctx, repo, commandName, databaseName, environment, "invalid_config")
 		h.postComment(repo, pr, installationID, templates.RenderInvalidConfig(data))
 		return
 	}
 
 	if errors.Is(err, ghclient.ErrNoConfig) {
+		h.logger.Warn("schema request: no config found", logFields...)
+		metrics.RecordSchemaRequestError(ctx, repo, commandName, databaseName, environment, "no_config")
 		h.postComment(repo, pr, installationID, templates.RenderNoConfig(data))
 		return
 	}
 
 	if errors.Is(err, ghclient.ErrMultipleConfigs) {
+		h.logger.Warn("schema request: multiple configs found", logFields...)
+		metrics.RecordSchemaRequestError(ctx, repo, commandName, databaseName, environment, "multiple_configs")
 		data.AvailableDatabases = templates.FormatAvailableDatabases(err.Error())
 		h.postComment(repo, pr, installationID, templates.RenderMultipleConfigs(data))
 		return
 	}
 
+	h.logger.Error("schema request failed", logFields...)
+	metrics.RecordSchemaRequestError(ctx, repo, commandName, databaseName, environment, "unexpected")
 	data.ErrorDetail = err.Error()
 	h.postComment(repo, pr, installationID, templates.RenderGenericError(data))
 }


### PR DESCRIPTION
## Summary

- Add WARN/ERROR logging for all `handleSchemaRequestError` branches — schema request failures were posted as PR comments but never logged server-side
- Add `schemabot.schema_request.errors_total` counter with `repository`, `action`, `database`, `environment`, `reason` attributes
- Add `repository` dimension to `RecordPlan`, `RecordPlanDuration`, `RecordApply`, `RecordApplyDuration` — enables filtering/alerting per repo
- Add `installation_id` to `postComment` error logs for debugging token issues
- Update metrics README

Discovered when a 401 Bad Credentials error from `FetchPullRequest` during auto-plan was invisible in logs — only the PR comment showed the failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)