### PR TITLE
fix(github): propagate auth errors in FindConfigForPR

### DIFF
--- a/pkg/github/config.go
+++ b/pkg/github/config.go
@@ -310,7 +310,13 @@ func (ic *InstallationClient) FindConfigForPR(ctx context.Context, repo string, 
 
 		config, err := ic.FetchConfig(ctx, repo, configPath, prInfo.HeadSHA)
 		if err != nil {
-			continue
+			if errors.Is(err, ErrNoConfig) {
+				continue
+			}
+			// Config not found at this path is expected — the search
+			// walks up parent directories. Other errors (auth failures,
+			// rate limits, server errors) must propagate.
+			return nil, "", err
 		}
 
 		depth := strings.Count(dir, "/")

--- a/pkg/github/config_test.go
+++ b/pkg/github/config_test.go
@@ -129,6 +129,36 @@ func TestFindAllConfigsForPRDoesNotClassifyMissingConfigAsGitHubUnavailable(t *t
 	assert.Empty(t, configs)
 }
 
+// TestFindConfigForPR_AuthFailureDoesNotFallThroughToNoConfig verifies that
+// auth errors propagate instead of being swallowed as ErrNoConfig.
+func TestFindConfigForPR_AuthFailureDoesNotFallThroughToNoConfig(t *testing.T) {
+	client, mux := setupConfigTestGitHubServer(t)
+
+	mux.HandleFunc("GET /repos/octocat/hello-world/pulls/1", func(w http.ResponseWriter, _ *http.Request) {
+		require.NoError(t, json.NewEncoder(w).Encode(gh.PullRequest{
+			Head: &gh.PullRequestBranch{SHA: new("abc123")},
+		}))
+	})
+	mux.HandleFunc("GET /repos/octocat/hello-world/pulls/1/files", func(w http.ResponseWriter, _ *http.Request) {
+		require.NoError(t, json.NewEncoder(w).Encode([]*gh.CommitFile{{
+			Filename: new("schema/mydb/orders.sql"),
+			Status:   new("modified"),
+		}}))
+	})
+	// Config fetch returns 401 (simulates stale installation token)
+	mux.HandleFunc("GET /repos/octocat/hello-world/contents/", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"message":"Bad credentials"}`))
+	})
+
+	ic := NewInstallationClient(client, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	_, _, err := ic.FindConfigForPR(t.Context(), "octocat/hello-world", 1)
+
+	require.Error(t, err)
+	assert.False(t, errors.Is(err, ErrNoConfig))
+	assert.Contains(t, err.Error(), "401")
+}
+
 func setupConfigTestGitHubServer(t *testing.T) (*gh.Client, *http.ServeMux) {
 	t.Helper()
 


### PR DESCRIPTION
## Summary

`FindConfigForPR` silently continued on any `FetchConfig` error, including 401 auth failures. When all directories failed with 401, the function returned `ErrNoConfig` instead of the actual error. This caused `CreateSchemaRequestFromPR` to fall through to `FindConfigInRepo`, which found all configs in the repo and produced a spurious "Multiple Databases Detected" error.

- Only continue searching parent directories on `ErrNoConfig`
- Propagate all other errors immediately
- Add regression test simulating a 401 during config discovery

🤖 Generated with [Claude Code](https://claude.com/claude-code)