### PR TITLE
feat(github): add configurable required checks

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -184,11 +184,13 @@ For repositories with many optional checks, `required_checks` can narrow the gat
 ```yaml
 require_passing_checks: true
 required_checks:
-  - "Owner Owl"
+  - "Required Review"
   - "CI / required-tests"
 ```
 
 When any configured check appears in the PR status rollup, only configured checks are evaluated. A configured check that is absent does not block apply. If none of the configured checks appear, SchemaBot falls back to the default behavior and evaluates all non-SchemaBot checks.
+
+`required_checks` names must exactly match GitHub check run names or commit status contexts. Matching is case-sensitive, and config validation rejects names with leading or trailing whitespace.
 
 When checks are failing, SchemaBot posts a comment listing the failing checks and instructs the user to fix them before retrying.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -179,6 +179,17 @@ require_passing_checks: true
 
 Apply is blocked in two cases: checks that have **failed** (`failure`, `error`, `timed_out`) and checks that are **still running** (`in_progress`, `queued`, `pending`). Each case shows a distinct message — failing checks prompt the user to fix them, while in-progress checks prompt the user to wait. Checks with conclusion `neutral` or `skipped` are ignored. SchemaBot's own checks (names starting with "SchemaBot") are always excluded.
 
+For repositories with many optional checks, `required_checks` can narrow the gate to specific check names:
+
+```yaml
+require_passing_checks: true
+required_checks:
+  - "Owner Owl"
+  - "CI / required-tests"
+```
+
+When any configured check appears in the PR status rollup, only configured checks are evaluated. A configured check that is absent does not block apply. If none of the configured checks appear, SchemaBot falls back to the default behavior and evaluates all non-SchemaBot checks.
+
 When checks are failing, SchemaBot posts a comment listing the failing checks and instructs the user to fix them before retrying.
 
 If the GitHub API is unreachable when checking statuses, the apply is blocked (fail-closed). SchemaBot posts a comment explaining the error and suggests retrying.

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -68,6 +68,11 @@ type ServerConfig struct {
 	// Defaults to true when not configured (nil = enabled).
 	RequirePassingChecks *bool `yaml:"require_passing_checks"`
 
+	// RequiredChecks narrows the PR checks gate to named checks when any of
+	// those checks are present in the GitHub status rollup. When empty, all
+	// non-SchemaBot checks are evaluated.
+	RequiredChecks []string `yaml:"required_checks"`
+
 	// RespondToUnscoped controls whether this instance responds to commands
 	// that are not scoped to a specific environment. In multi-instance
 	// deployments where each repo has multiple GitHub Apps installed, set
@@ -306,6 +311,9 @@ func (c *ServerConfig) Validate() error {
 	}
 
 	if err := validateUniqueNames("environment_order", c.EnvironmentOrder); err != nil {
+		return err
+	}
+	if err := validateUniqueNames("required_checks", c.RequiredChecks); err != nil {
 		return err
 	}
 	if err := validatePRCommandAuthorization(c.PRCommandAuthorization); err != nil {
@@ -547,6 +555,16 @@ func (c *ServerConfig) ShouldRequirePassingChecks() bool {
 		return true
 	}
 	return *c.RequirePassingChecks
+}
+
+// IsCheckRequired returns whether a PR check name is part of the configured
+// checks gate. When no names are configured, every non-SchemaBot check remains
+// in scope.
+func (c *ServerConfig) IsCheckRequired(name string) bool {
+	if c == nil || len(c.RequiredChecks) == 0 {
+		return true
+	}
+	return slices.Contains(c.RequiredChecks, name)
 }
 
 // StorageDSN returns the resolved storage DSN.

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"slices"
 	"strconv"
+	"strings"
 
 	"github.com/block/schemabot/pkg/secrets"
 	"github.com/block/schemabot/pkg/storage"
@@ -409,6 +410,9 @@ func validateUniqueNames(field string, names []string) error {
 	for _, name := range names {
 		if name == "" {
 			return fmt.Errorf("%s contains an empty value", field)
+		}
+		if strings.TrimSpace(name) != name {
+			return fmt.Errorf("%s contains value %q with leading or trailing whitespace", field, name)
 		}
 		if _, ok := seen[name]; ok {
 			return fmt.Errorf("%s contains duplicate value %q", field, name)

--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -246,6 +246,45 @@ func TestServerConfig_Validate(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "valid required checks",
+			cfg: ServerConfig{
+				Databases: map[string]DatabaseConfig{
+					"mydb": {
+						Type:         "mysql",
+						Environments: map[string]EnvironmentConfig{"staging": {DSN: "root@tcp(localhost)/mydb"}},
+					},
+				},
+				RequiredChecks: []string{"Owner Owl", "CI / lint"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "required checks reject empty values",
+			cfg: ServerConfig{
+				Databases: map[string]DatabaseConfig{
+					"mydb": {
+						Type:         "mysql",
+						Environments: map[string]EnvironmentConfig{"staging": {DSN: "root@tcp(localhost)/mydb"}},
+					},
+				},
+				RequiredChecks: []string{"Owner Owl", ""},
+			},
+			wantErr: true,
+		},
+		{
+			name: "required checks reject duplicate values",
+			cfg: ServerConfig{
+				Databases: map[string]DatabaseConfig{
+					"mydb": {
+						Type:         "mysql",
+						Environments: map[string]EnvironmentConfig{"staging": {DSN: "root@tcp(localhost)/mydb"}},
+					},
+				},
+				RequiredChecks: []string{"Owner Owl", "Owner Owl"},
+			},
+			wantErr: true,
+		},
+		{
 			name: "remote database target",
 			cfg: ServerConfig{
 				Databases: map[string]DatabaseConfig{
@@ -1073,6 +1112,51 @@ require_passing_checks: false
 		require.NoError(t, err)
 
 		assert.False(t, cfg.ShouldRequirePassingChecks())
+	})
+}
+
+func TestServerConfig_IsCheckRequired(t *testing.T) {
+	t.Run("nil receiver requires all checks", func(t *testing.T) {
+		var cfg *ServerConfig
+		assert.True(t, cfg.IsCheckRequired("CI / lint"))
+	})
+
+	t.Run("empty list requires all checks", func(t *testing.T) {
+		cfg := &ServerConfig{}
+		assert.True(t, cfg.IsCheckRequired("CI / lint"))
+	})
+
+	t.Run("configured list matches exact names only", func(t *testing.T) {
+		cfg := &ServerConfig{RequiredChecks: []string{"Owner Owl", "CI / lint"}}
+		assert.True(t, cfg.IsCheckRequired("Owner Owl"))
+		assert.True(t, cfg.IsCheckRequired("CI / lint"))
+		assert.False(t, cfg.IsCheckRequired("owner owl"))
+		assert.False(t, cfg.IsCheckRequired("CI / tests"))
+	})
+
+	t.Run("YAML deserialization", func(t *testing.T) {
+		dir := t.TempDir()
+		configPath := filepath.Join(dir, "config.yaml")
+		content := `
+databases:
+  testapp:
+    type: mysql
+    environments:
+      staging:
+        dsn: "root@tcp(localhost:3306)/testapp"
+required_checks:
+  - "Owner Owl"
+  - "CI / lint"
+`
+		err := os.WriteFile(configPath, []byte(content), 0644)
+		require.NoError(t, err)
+
+		cfg, err := LoadServerConfigFromFile(configPath)
+		require.NoError(t, err)
+
+		assert.Equal(t, []string{"Owner Owl", "CI / lint"}, cfg.RequiredChecks)
+		assert.True(t, cfg.IsCheckRequired("Owner Owl"))
+		assert.False(t, cfg.IsCheckRequired("CI / tests"))
 	})
 }
 

--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -254,7 +254,7 @@ func TestServerConfig_Validate(t *testing.T) {
 						Environments: map[string]EnvironmentConfig{"staging": {DSN: "root@tcp(localhost)/mydb"}},
 					},
 				},
-				RequiredChecks: []string{"Owner Owl", "CI / lint"},
+				RequiredChecks: []string{"Required Review", "CI / lint"},
 			},
 			wantErr: false,
 		},
@@ -267,7 +267,7 @@ func TestServerConfig_Validate(t *testing.T) {
 						Environments: map[string]EnvironmentConfig{"staging": {DSN: "root@tcp(localhost)/mydb"}},
 					},
 				},
-				RequiredChecks: []string{"Owner Owl", ""},
+				RequiredChecks: []string{"Required Review", ""},
 			},
 			wantErr: true,
 		},
@@ -280,7 +280,20 @@ func TestServerConfig_Validate(t *testing.T) {
 						Environments: map[string]EnvironmentConfig{"staging": {DSN: "root@tcp(localhost)/mydb"}},
 					},
 				},
-				RequiredChecks: []string{"Owner Owl", "Owner Owl"},
+				RequiredChecks: []string{"Required Review", "Required Review"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "required checks reject leading and trailing whitespace",
+			cfg: ServerConfig{
+				Databases: map[string]DatabaseConfig{
+					"mydb": {
+						Type:         "mysql",
+						Environments: map[string]EnvironmentConfig{"staging": {DSN: "root@tcp(localhost)/mydb"}},
+					},
+				},
+				RequiredChecks: []string{"Required Review "},
 			},
 			wantErr: true,
 		},
@@ -1127,10 +1140,10 @@ func TestServerConfig_IsCheckRequired(t *testing.T) {
 	})
 
 	t.Run("configured list matches exact names only", func(t *testing.T) {
-		cfg := &ServerConfig{RequiredChecks: []string{"Owner Owl", "CI / lint"}}
-		assert.True(t, cfg.IsCheckRequired("Owner Owl"))
+		cfg := &ServerConfig{RequiredChecks: []string{"Required Review", "CI / lint"}}
+		assert.True(t, cfg.IsCheckRequired("Required Review"))
 		assert.True(t, cfg.IsCheckRequired("CI / lint"))
-		assert.False(t, cfg.IsCheckRequired("owner owl"))
+		assert.False(t, cfg.IsCheckRequired("required review"))
 		assert.False(t, cfg.IsCheckRequired("CI / tests"))
 	})
 
@@ -1145,7 +1158,7 @@ databases:
       staging:
         dsn: "root@tcp(localhost:3306)/testapp"
 required_checks:
-  - "Owner Owl"
+  - "Required Review"
   - "CI / lint"
 `
 		err := os.WriteFile(configPath, []byte(content), 0644)
@@ -1154,8 +1167,8 @@ required_checks:
 		cfg, err := LoadServerConfigFromFile(configPath)
 		require.NoError(t, err)
 
-		assert.Equal(t, []string{"Owner Owl", "CI / lint"}, cfg.RequiredChecks)
-		assert.True(t, cfg.IsCheckRequired("Owner Owl"))
+		assert.Equal(t, []string{"Required Review", "CI / lint"}, cfg.RequiredChecks)
+		assert.True(t, cfg.IsCheckRequired("Required Review"))
 		assert.False(t, cfg.IsCheckRequired("CI / tests"))
 	})
 }

--- a/pkg/webhook/apply_handlers.go
+++ b/pkg/webhook/apply_handlers.go
@@ -786,10 +786,14 @@ func ddlMatchesStoredPlan(planResp *apitypes.PlanResponse, storedPlan *storage.P
 // SchemaBot's own checks and checks with conclusion "neutral", "skipped", or "success".
 // Only checks with completed status and conclusion "failure", "error", or "timed_out"
 // are considered failing.
-func filterFailingNonSchemaBotChecks(statuses []ghclient.PRCheckStatus) []templates.BlockingCheck {
+func filterFailingNonSchemaBotChecks(statuses []ghclient.PRCheckStatus, config *api.ServerConfig) []templates.BlockingCheck {
 	var failing []templates.BlockingCheck
+	filterRequiredChecks := statusRollupContainsRequiredCheck(statuses, config)
 	for _, s := range statuses {
 		if s.IsSchemaBot {
+			continue
+		}
+		if filterRequiredChecks && !config.IsCheckRequired(s.Name) {
 			continue
 		}
 		if s.Status != "completed" {
@@ -810,7 +814,8 @@ func filterFailingNonSchemaBotChecks(statuses []ghclient.PRCheckStatus) []templa
 // Returns true if apply was blocked (caller should return), false if it may proceed.
 // Blocks on both failing checks and in-progress checks with distinct messages.
 func (h *Handler) enforcePassingChecks(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, installationID int64, headSHA, environment string) bool {
-	if !h.service.Config().ShouldRequirePassingChecks() {
+	config := h.service.Config()
+	if !config.ShouldRequirePassingChecks() {
 		h.logger.Debug("passing checks gate disabled", "repo", repo, "pr", pr)
 		return false
 	}
@@ -824,8 +829,8 @@ func (h *Handler) enforcePassingChecks(ctx context.Context, client *ghclient.Ins
 		return true
 	}
 
-	failing := filterFailingNonSchemaBotChecks(statuses)
-	inProgress := filterInProgressNonSchemaBotChecks(statuses)
+	failing := filterFailingNonSchemaBotChecks(statuses, config)
+	inProgress := filterInProgressNonSchemaBotChecks(statuses, config)
 
 	if len(failing) > 0 {
 		h.logger.Info("apply blocked by failing PR checks",
@@ -850,10 +855,14 @@ func (h *Handler) enforcePassingChecks(ctx context.Context, client *ghclient.Ins
 
 // filterInProgressNonSchemaBotChecks returns checks that are still running,
 // excluding SchemaBot's own checks.
-func filterInProgressNonSchemaBotChecks(statuses []ghclient.PRCheckStatus) []templates.BlockingCheck {
+func filterInProgressNonSchemaBotChecks(statuses []ghclient.PRCheckStatus, config *api.ServerConfig) []templates.BlockingCheck {
 	var inProgress []templates.BlockingCheck
+	filterRequiredChecks := statusRollupContainsRequiredCheck(statuses, config)
 	for _, s := range statuses {
 		if s.IsSchemaBot {
+			continue
+		}
+		if filterRequiredChecks && !config.IsCheckRequired(s.Name) {
 			continue
 		}
 		switch s.Status {
@@ -865,6 +874,21 @@ func filterInProgressNonSchemaBotChecks(statuses []ghclient.PRCheckStatus) []tem
 		}
 	}
 	return inProgress
+}
+
+func statusRollupContainsRequiredCheck(statuses []ghclient.PRCheckStatus, config *api.ServerConfig) bool {
+	if config == nil || len(config.RequiredChecks) == 0 {
+		return false
+	}
+	for _, s := range statuses {
+		if s.IsSchemaBot {
+			continue
+		}
+		if config.IsCheckRequired(s.Name) {
+			return true
+		}
+	}
+	return false
 }
 
 // handleUnlockCommand handles the "schemabot unlock" PR comment command.

--- a/pkg/webhook/apply_handlers_test.go
+++ b/pkg/webhook/apply_handlers_test.go
@@ -98,8 +98,72 @@ func TestFilterFailingNonSchemaBotChecks(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			failing := filterFailingNonSchemaBotChecks(tt.statuses)
+			failing := filterFailingNonSchemaBotChecks(tt.statuses, nil)
 			require.Len(t, failing, tt.wantLen)
+			for i, name := range tt.wantNames {
+				assert.Equal(t, name, failing[i].Name)
+			}
+		})
+	}
+}
+
+func TestFilterFailingNonSchemaBotChecks_RequiredChecks(t *testing.T) {
+	tests := []struct {
+		name      string
+		config    *api.ServerConfig
+		statuses  []ghclient.PRCheckStatus
+		wantNames []string
+	}{
+		{
+			name:   "configured failing check blocks when present",
+			config: &api.ServerConfig{RequiredChecks: []string{"Owner Owl"}},
+			statuses: []ghclient.PRCheckStatus{
+				{Name: "Owner Owl", Status: "completed", Conclusion: "failure"},
+				{Name: "CI / lint", Status: "completed", Conclusion: "failure"},
+			},
+			wantNames: []string{"Owner Owl"},
+		},
+		{
+			name:   "unlisted failing check is ignored when configured check is present",
+			config: &api.ServerConfig{RequiredChecks: []string{"Owner Owl", "Security scan"}},
+			statuses: []ghclient.PRCheckStatus{
+				{Name: "Owner Owl", Status: "completed", Conclusion: "success"},
+				{Name: "CI / lint", Status: "completed", Conclusion: "failure"},
+			},
+			wantNames: nil,
+		},
+		{
+			name:   "all checks apply when no configured check is present",
+			config: &api.ServerConfig{RequiredChecks: []string{"Owner Owl"}},
+			statuses: []ghclient.PRCheckStatus{
+				{Name: "CI / lint", Status: "completed", Conclusion: "failure"},
+				{Name: "Security scan", Status: "completed", Conclusion: "error"},
+			},
+			wantNames: []string{"CI / lint", "Security scan"},
+		},
+		{
+			name:   "SchemaBot check does not activate required check filter",
+			config: &api.ServerConfig{RequiredChecks: []string{"SchemaBot (staging)"}},
+			statuses: []ghclient.PRCheckStatus{
+				{Name: "SchemaBot (staging)", Status: "completed", Conclusion: "failure", IsSchemaBot: true},
+				{Name: "CI / lint", Status: "completed", Conclusion: "failure"},
+			},
+			wantNames: []string{"CI / lint"},
+		},
+		{
+			name:   "empty required checks preserves default behavior",
+			config: &api.ServerConfig{RequiredChecks: []string{}},
+			statuses: []ghclient.PRCheckStatus{
+				{Name: "CI / lint", Status: "completed", Conclusion: "failure"},
+			},
+			wantNames: []string{"CI / lint"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			failing := filterFailingNonSchemaBotChecks(tt.statuses, tt.config)
+			require.Len(t, failing, len(tt.wantNames))
 			for i, name := range tt.wantNames {
 				assert.Equal(t, name, failing[i].Name)
 			}
@@ -116,7 +180,7 @@ func TestFilterInProgressNonSchemaBotChecks(t *testing.T) {
 		{Name: "Deploy preview", Status: "pending", Conclusion: ""},
 	}
 
-	inProgress := filterInProgressNonSchemaBotChecks(statuses)
+	inProgress := filterInProgressNonSchemaBotChecks(statuses, nil)
 	require.Len(t, inProgress, 3)
 	assert.Equal(t, "CI / tests", inProgress[0].Name)
 	assert.Equal(t, "in_progress", inProgress[0].State)
@@ -124,6 +188,53 @@ func TestFilterInProgressNonSchemaBotChecks(t *testing.T) {
 	assert.Equal(t, "queued", inProgress[1].State)
 	assert.Equal(t, "Deploy preview", inProgress[2].Name)
 	assert.Equal(t, "pending", inProgress[2].State)
+}
+
+func TestFilterInProgressNonSchemaBotChecks_RequiredChecks(t *testing.T) {
+	tests := []struct {
+		name      string
+		config    *api.ServerConfig
+		statuses  []ghclient.PRCheckStatus
+		wantNames []string
+	}{
+		{
+			name:   "configured in-progress check blocks when present",
+			config: &api.ServerConfig{RequiredChecks: []string{"Owner Owl"}},
+			statuses: []ghclient.PRCheckStatus{
+				{Name: "Owner Owl", Status: "queued", Conclusion: ""},
+				{Name: "CI / tests", Status: "in_progress", Conclusion: ""},
+			},
+			wantNames: []string{"Owner Owl"},
+		},
+		{
+			name:   "unlisted in-progress check is ignored when configured check is present",
+			config: &api.ServerConfig{RequiredChecks: []string{"Owner Owl"}},
+			statuses: []ghclient.PRCheckStatus{
+				{Name: "Owner Owl", Status: "completed", Conclusion: "success"},
+				{Name: "CI / tests", Status: "in_progress", Conclusion: ""},
+			},
+			wantNames: nil,
+		},
+		{
+			name:   "all checks apply when no configured check is present",
+			config: &api.ServerConfig{RequiredChecks: []string{"Owner Owl"}},
+			statuses: []ghclient.PRCheckStatus{
+				{Name: "CI / tests", Status: "in_progress", Conclusion: ""},
+				{Name: "Deploy preview", Status: "pending", Conclusion: ""},
+			},
+			wantNames: []string{"CI / tests", "Deploy preview"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			inProgress := filterInProgressNonSchemaBotChecks(tt.statuses, tt.config)
+			require.Len(t, inProgress, len(tt.wantNames))
+			for i, name := range tt.wantNames {
+				assert.Equal(t, name, inProgress[i].Name)
+			}
+		})
+	}
 }
 
 // rollupNode is a single GraphQL statusCheckRollup contexts node, used by tests
@@ -292,6 +403,70 @@ func TestEnforcePassingChecks(t *testing.T) {
 		ctx := t.Context()
 		blocked := h.enforcePassingChecks(ctx, installClient, "octocat/hello-world", 1, 12345, "abc123", "staging")
 		assert.True(t, blocked, "should block when checks are failing")
+
+		select {
+		case body := <-comments:
+			assert.Contains(t, body, "CI / tests")
+			assert.Contains(t, body, "failure")
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out waiting for failing-checks comment")
+		}
+	})
+
+	t.Run("required checks ignore unlisted failures when configured check is present", func(t *testing.T) {
+		client, mux := setupGitHubServer(t)
+
+		mux.HandleFunc("POST /graphql", rollupGraphQLHandler([]rollupNode{
+			{Typename: "CheckRun", Name: "Owner Owl", Status: "COMPLETED", Conclusion: "SUCCESS", AppSlug: "owner-owl"},
+			{Typename: "CheckRun", Name: "CI / tests", Status: "COMPLETED", Conclusion: "FAILURE", AppSlug: "github-actions"},
+		}))
+
+		installClient := ghclient.NewInstallationClient(client, testLogger())
+		factory := &fakeClientFactory{client: installClient}
+
+		service := api.New(nil, &api.ServerConfig{RequiredChecks: []string{"Owner Owl"}}, nil, testLogger())
+		h := &Handler{
+			service:  service,
+			ghClient: factory,
+			logger:   testLogger(),
+		}
+
+		ctx := t.Context()
+		blocked := h.enforcePassingChecks(ctx, installClient, "octocat/hello-world", 1, 12345, "abc123", "staging")
+		assert.False(t, blocked, "should allow when configured checks pass")
+	})
+
+	t.Run("required checks fall back to all checks when none are present", func(t *testing.T) {
+		client, mux := setupGitHubServer(t)
+		comments := make(chan string, 10)
+
+		mux.HandleFunc("POST /graphql", rollupGraphQLHandler([]rollupNode{
+			{Typename: "CheckRun", Name: "CI / tests", Status: "COMPLETED", Conclusion: "FAILURE", AppSlug: "github-actions"},
+		}))
+
+		mux.HandleFunc("POST /repos/octocat/hello-world/issues/1/comments", func(w http.ResponseWriter, r *http.Request) {
+			var body struct {
+				Body string `json:"body"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			comments <- body.Body
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": 99})
+		})
+
+		installClient := ghclient.NewInstallationClient(client, testLogger())
+		factory := &fakeClientFactory{client: installClient}
+
+		service := api.New(nil, &api.ServerConfig{RequiredChecks: []string{"Owner Owl"}}, nil, testLogger())
+		h := &Handler{
+			service:  service,
+			ghClient: factory,
+			logger:   testLogger(),
+		}
+
+		ctx := t.Context()
+		blocked := h.enforcePassingChecks(ctx, installClient, "octocat/hello-world", 1, 12345, "abc123", "staging")
+		assert.True(t, blocked, "should block on all checks when configured checks are absent")
 
 		select {
 		case body := <-comments:

--- a/pkg/webhook/apply_handlers_test.go
+++ b/pkg/webhook/apply_handlers_test.go
@@ -116,25 +116,25 @@ func TestFilterFailingNonSchemaBotChecks_RequiredChecks(t *testing.T) {
 	}{
 		{
 			name:   "configured failing check blocks when present",
-			config: &api.ServerConfig{RequiredChecks: []string{"Owner Owl"}},
+			config: &api.ServerConfig{RequiredChecks: []string{"Required Review"}},
 			statuses: []ghclient.PRCheckStatus{
-				{Name: "Owner Owl", Status: "completed", Conclusion: "failure"},
+				{Name: "Required Review", Status: "completed", Conclusion: "failure"},
 				{Name: "CI / lint", Status: "completed", Conclusion: "failure"},
 			},
-			wantNames: []string{"Owner Owl"},
+			wantNames: []string{"Required Review"},
 		},
 		{
 			name:   "unlisted failing check is ignored when configured check is present",
-			config: &api.ServerConfig{RequiredChecks: []string{"Owner Owl", "Security scan"}},
+			config: &api.ServerConfig{RequiredChecks: []string{"Required Review", "Security scan"}},
 			statuses: []ghclient.PRCheckStatus{
-				{Name: "Owner Owl", Status: "completed", Conclusion: "success"},
+				{Name: "Required Review", Status: "completed", Conclusion: "success"},
 				{Name: "CI / lint", Status: "completed", Conclusion: "failure"},
 			},
 			wantNames: nil,
 		},
 		{
 			name:   "all checks apply when no configured check is present",
-			config: &api.ServerConfig{RequiredChecks: []string{"Owner Owl"}},
+			config: &api.ServerConfig{RequiredChecks: []string{"Required Review"}},
 			statuses: []ghclient.PRCheckStatus{
 				{Name: "CI / lint", Status: "completed", Conclusion: "failure"},
 				{Name: "Security scan", Status: "completed", Conclusion: "error"},
@@ -199,25 +199,25 @@ func TestFilterInProgressNonSchemaBotChecks_RequiredChecks(t *testing.T) {
 	}{
 		{
 			name:   "configured in-progress check blocks when present",
-			config: &api.ServerConfig{RequiredChecks: []string{"Owner Owl"}},
+			config: &api.ServerConfig{RequiredChecks: []string{"Required Review"}},
 			statuses: []ghclient.PRCheckStatus{
-				{Name: "Owner Owl", Status: "queued", Conclusion: ""},
+				{Name: "Required Review", Status: "queued", Conclusion: ""},
 				{Name: "CI / tests", Status: "in_progress", Conclusion: ""},
 			},
-			wantNames: []string{"Owner Owl"},
+			wantNames: []string{"Required Review"},
 		},
 		{
 			name:   "unlisted in-progress check is ignored when configured check is present",
-			config: &api.ServerConfig{RequiredChecks: []string{"Owner Owl"}},
+			config: &api.ServerConfig{RequiredChecks: []string{"Required Review"}},
 			statuses: []ghclient.PRCheckStatus{
-				{Name: "Owner Owl", Status: "completed", Conclusion: "success"},
+				{Name: "Required Review", Status: "completed", Conclusion: "success"},
 				{Name: "CI / tests", Status: "in_progress", Conclusion: ""},
 			},
 			wantNames: nil,
 		},
 		{
 			name:   "all checks apply when no configured check is present",
-			config: &api.ServerConfig{RequiredChecks: []string{"Owner Owl"}},
+			config: &api.ServerConfig{RequiredChecks: []string{"Required Review"}},
 			statuses: []ghclient.PRCheckStatus{
 				{Name: "CI / tests", Status: "in_progress", Conclusion: ""},
 				{Name: "Deploy preview", Status: "pending", Conclusion: ""},
@@ -417,14 +417,14 @@ func TestEnforcePassingChecks(t *testing.T) {
 		client, mux := setupGitHubServer(t)
 
 		mux.HandleFunc("POST /graphql", rollupGraphQLHandler([]rollupNode{
-			{Typename: "CheckRun", Name: "Owner Owl", Status: "COMPLETED", Conclusion: "SUCCESS", AppSlug: "owner-owl"},
+			{Typename: "CheckRun", Name: "Required Review", Status: "COMPLETED", Conclusion: "SUCCESS", AppSlug: "review-gate"},
 			{Typename: "CheckRun", Name: "CI / tests", Status: "COMPLETED", Conclusion: "FAILURE", AppSlug: "github-actions"},
 		}))
 
 		installClient := ghclient.NewInstallationClient(client, testLogger())
 		factory := &fakeClientFactory{client: installClient}
 
-		service := api.New(nil, &api.ServerConfig{RequiredChecks: []string{"Owner Owl"}}, nil, testLogger())
+		service := api.New(nil, &api.ServerConfig{RequiredChecks: []string{"Required Review"}}, nil, testLogger())
 		h := &Handler{
 			service:  service,
 			ghClient: factory,
@@ -457,7 +457,7 @@ func TestEnforcePassingChecks(t *testing.T) {
 		installClient := ghclient.NewInstallationClient(client, testLogger())
 		factory := &fakeClientFactory{client: installClient}
 
-		service := api.New(nil, &api.ServerConfig{RequiredChecks: []string{"Owner Owl"}}, nil, testLogger())
+		service := api.New(nil, &api.ServerConfig{RequiredChecks: []string{"Required Review"}}, nil, testLogger())
 		h := &Handler{
 			service:  service,
 			ghClient: factory,


### PR DESCRIPTION
## Why
SchemaBot currently blocks PR-comment applies on every non-SchemaBot check, which is too broad for repos with many optional or slow checks. Operators need a way to require only the checks that should gate schema changes while preserving the current fail-closed default.

## What
- Add `required_checks` server config with exact-name validation
- Narrow the apply checks gate when configured checks appear in the PR rollup
- Fall back to the current all-check behavior when no configured checks are present
- Document exact matching semantics and generic required-check examples

## Core Scenarios
```text
PR checks gate
|-- required_checks unset or empty
|   `-- evaluate every non-SchemaBot check
`-- required_checks configured
    |-- none of those names appear in the PR rollup
    |   `-- evaluate every non-SchemaBot check
    `-- at least one configured name appears in the PR rollup
        `-- evaluate configured names only
            |-- any present configured check failed or running -> block apply
            `-- no present configured check failed or running -> continue apply
```

🤖 Generated by Codex on behalf of @aparajon.