### PR TITLE
fix(grpc): reconcile remote apply lifecycle

### DIFF
--- a/e2e/k8s/k8s_test.go
+++ b/e2e/k8s/k8s_test.go
@@ -49,6 +49,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -58,6 +59,7 @@ import (
 	"github.com/block/schemabot/pkg/apitypes"
 	"github.com/block/schemabot/pkg/cmd/client"
 	"github.com/block/schemabot/pkg/state"
+	"github.com/block/schemabot/pkg/storage"
 	"github.com/block/spirit/pkg/lint"
 	"github.com/block/spirit/pkg/utils"
 	"github.com/stretchr/testify/assert"
@@ -174,20 +176,106 @@ func TestK8s_PlanApply_AddColumn(t *testing.T) {
 	require.NotEmpty(t, prog.Tables, "tables should be present in progress")
 	assert.Equal(t, tableName, prog.Tables[0].TableName, "progress should report the correct table")
 
-	// Verify external_id on the control plane's storage — this is set from the
-	// data plane's apply ID returned over gRPC. Its presence proves the gRPC
-	// Apply() call succeeded and the response was persisted.
+	// Verify lifecycle fields on the control plane's storage. external_id is
+	// the data-plane apply ID returned over gRPC, while started_at/completed_at
+	// prove the control-plane poller persisted the remote lifecycle to storage.
 	sbDB, err := sql.Open("mysql", testutil.SchemabotDSN(t))
 	require.NoError(t, err)
 	defer utils.CloseAndLog(sbDB)
 
-	var externalID string
-	err = sbDB.QueryRowContext(t.Context(),
-		"SELECT external_id FROM applies WHERE apply_identifier = ?",
-		applyResp.ApplyID,
-	).Scan(&externalID)
-	require.NoError(t, err, "query apply record on control plane")
+	externalID, startedAt, completedAt := waitForControlPlaneApplyLifecycle(t, sbDB, applyResp.ApplyID)
 	assert.NotEmpty(t, externalID, "external_id should be set — proves data plane returned its apply ID over gRPC")
+	assert.False(t, completedAt.Before(startedAt), "completed_at should not be before started_at")
+
+	// The control plane owns the operator-facing apply history even though the
+	// data plane executes the schema change. Logs should show dispatch to the
+	// data plane and the terminal state observed by the control-plane poller.
+	waitForControlPlaneApplyLogs(t, ep, applyResp.ApplyID, tableName)
+}
+
+func waitForControlPlaneApplyLifecycle(t *testing.T, db *sql.DB, applyID string) (string, time.Time, time.Time) {
+	t.Helper()
+
+	var externalID string
+	var startedAt, completedAt sql.NullTime
+	var lastErr error
+	testutil.Poll(t, testutil.PollDeadline, testutil.PollInterval,
+		func() bool {
+			lastErr = db.QueryRowContext(t.Context(),
+				"SELECT external_id, started_at, completed_at FROM applies WHERE apply_identifier = ?",
+				applyID,
+			).Scan(&externalID, &startedAt, &completedAt)
+			if lastErr != nil {
+				return false
+			}
+			return externalID != "" && startedAt.Valid && completedAt.Valid && !completedAt.Time.Before(startedAt.Time)
+		},
+		func() string {
+			return fmt.Sprintf("control-plane apply lifecycle was not persisted for %s: external_id=%q started_at=%v completed_at=%v last_err=%v",
+				applyID, externalID, startedAt, completedAt, lastErr)
+		})
+
+	return externalID, startedAt.Time, completedAt.Time
+}
+
+func waitForControlPlaneApplyLogs(t *testing.T, endpoint string, applyID, tableName string) {
+	t.Helper()
+
+	var logs []*client.LogEntry
+	var lastErr error
+	testutil.Poll(t, testutil.PollDeadline, testutil.PollInterval,
+		func() bool {
+			logs, lastErr = client.GetLogs(endpoint, "", "", applyID, 50)
+			return lastErr == nil &&
+				hasLogNewState(logs, "Apply queued", state.Apply.Pending) &&
+				hasLogTransition(logs, "Apply dispatched to remote Tern", state.Apply.Pending, state.Apply.Running) &&
+				hasLogTransition(logs, "Remote apply reached terminal state: completed", state.Apply.Running, state.Apply.Completed) &&
+				hasLogTransitionTo(logs, "Remote task "+tableName+" changed state", state.Task.Completed)
+		},
+		func() string {
+			return fmt.Sprintf("control-plane apply logs did not contain the full remote lifecycle for %s: api_logs=%s last_err=%v",
+				applyID, formatLogEntries(logs), lastErr)
+		})
+}
+
+func hasLogNewState(logs []*client.LogEntry, messageContains, newState string) bool {
+	for _, log := range logs {
+		if strings.Contains(log.Message, messageContains) && log.NewState == newState {
+			return true
+		}
+	}
+	return false
+}
+
+func hasLogTransition(logs []*client.LogEntry, messageContains, oldState, newState string) bool {
+	for _, log := range logs {
+		if strings.Contains(log.Message, messageContains) &&
+			log.EventType == storage.LogEventStateTransition &&
+			log.OldState == oldState &&
+			log.NewState == newState {
+			return true
+		}
+	}
+	return false
+}
+
+func hasLogTransitionTo(logs []*client.LogEntry, messageContains, newState string) bool {
+	for _, log := range logs {
+		if strings.Contains(log.Message, messageContains) &&
+			log.EventType == storage.LogEventStateTransition &&
+			log.NewState == newState {
+			return true
+		}
+	}
+	return false
+}
+
+func formatLogEntries(logs []*client.LogEntry) string {
+	parts := make([]string, 0, len(logs))
+	for _, log := range logs {
+		parts = append(parts, fmt.Sprintf("%s:%s:%s->%s", log.EventType, log.Message, log.OldState, log.NewState))
+	}
+	return strings.Join(parts, " | ")
 }
 
 // TestK8s_PlanApply_CreateTable tests creating a new table through the two-tier path.
@@ -265,7 +353,7 @@ func TestK8s_Scheduler_DataPlanePodRestartRecoversIndexAdd(t *testing.T) {
 
 	crashedPod := crashPod(t, "data-plane")
 
-	// The restarted data-plane scheduler claims stale local apply rows. Aging
+	// The restarted data-plane scheduler claims stale data-plane apply rows. Aging
 	// the heartbeat avoids waiting for the production staleness threshold.
 	markDataPlaneHeartbeatStale(t, fixture.DataPlaneApplyID)
 	waitForReplacementPodReady(t, "data-plane", crashedPod, 2*time.Minute)

--- a/pkg/tern/grpc_client.go
+++ b/pkg/tern/grpc_client.go
@@ -82,7 +82,7 @@ package tern
 //	GRPCClient.Progress(ApplyId: "tern-42")
 //	    │
 //	    ▼
-//	Remote Tern (Remote Tern)
+//	Remote Tern
 //	    │ looks up apply by id=42
 //	    ▼
 //	ProgressResponse
@@ -274,6 +274,58 @@ func (c *GRPCClient) clearObserver(applyID int64) {
 	delete(c.observers, applyID)
 }
 
+// logApplyEvent appends a control-plane apply log entry for gRPC applies. The
+// remote Tern service writes its own local logs, but operators read SchemaBot's
+// control-plane apply history from SchemaBot storage.
+func (c *GRPCClient) logApplyEvent(ctx context.Context, applyID int64, taskID *int64, level, eventType, source, message string, oldState, newState string) {
+	logStore := c.storage.ApplyLogs()
+	if logStore == nil {
+		slog.Error("missing apply log store for gRPC apply event",
+			"apply_id", applyID,
+			"event", eventType,
+			"message", message)
+		return
+	}
+	log := &storage.ApplyLog{
+		ApplyID:   applyID,
+		TaskID:    taskID,
+		Level:     level,
+		EventType: eventType,
+		Source:    source,
+		Message:   message,
+		OldState:  oldState,
+		NewState:  newState,
+		CreatedAt: time.Now(),
+	}
+	if err := logStore.Append(ctx, log); err != nil {
+		slog.Error("failed to log gRPC apply event",
+			"apply_id", applyID,
+			"event", eventType,
+			"message", message,
+			"error", err)
+	}
+}
+
+func (c *GRPCClient) logApplyStateTransition(ctx context.Context, apply *storage.Apply, level, message, oldState string) {
+	c.logApplyEvent(ctx, apply.ID, nil, level, storage.LogEventStateTransition, storage.LogSourceSchemaBot,
+		message, oldState, apply.State)
+}
+
+func (c *GRPCClient) logTaskStateTransition(ctx context.Context, applyID int64, task *storage.Task, message, oldState string) {
+	taskID := task.ID
+	c.logApplyEvent(ctx, applyID, &taskID, storage.LogLevelInfo, storage.LogEventStateTransition, storage.LogSourceSchemaBot,
+		message, oldState, task.State)
+}
+
+func (c *GRPCClient) logApplyWarning(ctx context.Context, apply *storage.Apply, message string) {
+	c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelWarn, storage.LogEventError, storage.LogSourceSchemaBot,
+		message, apply.State, apply.State)
+}
+
+func remoteApplyStateDescription(remoteState ternv1.State) string {
+	return fmt.Sprintf("%s(%d)", remoteState.String(), int32(remoteState))
+}
+
 // pollAndNotifyObserver polls storage for apply state changes and notifies the
 // observer. This is the GRPCClient equivalent of LocalClient's progress poller
 // calling the observer — but driven by storage reads instead of engine polling.
@@ -357,7 +409,7 @@ func (c *GRPCClient) Health(ctx context.Context) error {
 
 // ResumeApply runs work claimed by the scheduler. Fresh queued applies have no
 // external_id yet, so this method first dispatches them to remote Tern and
-// stores the returned ID. The call then polls until the apply reaches a durable
+// stores the returned ID. The call then polls until the apply reaches a stored
 // terminal state or the scheduler context is canceled.
 func (c *GRPCClient) ResumeApply(ctx context.Context, apply *storage.Apply) error {
 	if c.storage == nil {
@@ -372,7 +424,9 @@ func (c *GRPCClient) ResumeApply(ctx context.Context, apply *storage.Apply) erro
 	}
 	if hasAmbiguousRemoteDispatchState(apply) {
 		errMsg := fmt.Sprintf("gRPC apply %s is %s without external_id; remote dispatch state is ambiguous", apply.ApplyIdentifier, apply.State)
-		c.markRemoteApplyFailed(ctx, apply, nil, errMsg, false)
+		if err := c.markRemoteApplyFailed(ctx, apply, nil, errMsg, false); err != nil {
+			return fmt.Errorf("%s; persist failure state: %w", errMsg, err)
+		}
 		return errors.New(errMsg)
 	}
 
@@ -393,24 +447,67 @@ func (c *GRPCClient) ResumeApply(ctx context.Context, apply *storage.Apply) erro
 		if err := c.storage.Applies().Update(ctx, apply); err != nil {
 			return fmt.Errorf("update started gRPC apply %s: %w", apply.ApplyIdentifier, err)
 		}
+		c.logApplyStateTransition(ctx, apply, storage.LogLevelInfo, "Remote apply start requested by scheduler", state.Apply.Pending)
 	}
 
-	// Check the real state from Tern before deciding what to do. Local state
-	// may be stale (e.g. local says "stopped" but Tern already resumed).
-	if apply.State == state.Apply.Stopped {
+	// Check the real state from Tern before deciding what to do. Stored state
+	// may be stale (e.g. storage says "stopped" but Tern already resumed).
+	if state.IsState(apply.State, state.Apply.Stopped) {
+		oldState := apply.State
+		startRequested := false
 		resp, err := c.client.Progress(ctx, &ternv1.ProgressRequest{
-			ApplyId:  apply.ExternalID,
-			Database: apply.Database,
+			ApplyId:     apply.ExternalID,
+			Database:    apply.Database,
+			Environment: apply.Environment,
 		})
 		if err == nil {
-			remoteState := ProtoStateToStorage(resp.State)
-			if remoteState != "" {
-				apply.State = remoteState
+			if resp.State == ternv1.State_STATE_NO_ACTIVE_CHANGE {
+				message := fmt.Sprintf("Remote stopped-state check returned no active schema change for remote apply %s; scheduler will not request remote start", apply.ExternalID)
+				slog.Warn("remote gRPC stopped-state check returned no active schema change; scheduler will not request remote start",
+					"apply_id", apply.ApplyIdentifier,
+					"external_id", apply.ExternalID,
+					"database", apply.Database,
+					"environment", apply.Environment,
+					"stored_state", apply.State)
+				c.logApplyWarning(ctx, apply, message)
+				return fmt.Errorf("check stopped gRPC apply %s before start: no active schema change for remote apply %s", apply.ApplyIdentifier, apply.ExternalID)
 			}
+			remoteState := ProtoStateToStorage(resp.State)
+			if remoteState == "" {
+				message := fmt.Sprintf("Remote stopped-state check returned unmapped state %s; scheduler will not request remote start", remoteApplyStateDescription(resp.State))
+				slog.Warn("remote gRPC stopped-state check returned unmapped state; scheduler will not request remote start",
+					"apply_id", apply.ApplyIdentifier,
+					"external_id", apply.ExternalID,
+					"database", apply.Database,
+					"environment", apply.Environment,
+					"remote_state", resp.State.String(),
+					"remote_state_number", int32(resp.State),
+					"stored_state", apply.State)
+				c.logApplyWarning(ctx, apply, message)
+				return fmt.Errorf("check stopped gRPC apply %s before start: unmapped remote state %s", apply.ApplyIdentifier, remoteApplyStateDescription(resp.State))
+			}
+			apply.State = remoteState
+			if isTerminalProtoState(resp.State) && !state.IsState(remoteState, state.Apply.Stopped) {
+				now := time.Now()
+				if apply.StartedAt == nil && !state.IsState(remoteState, state.Apply.Pending) {
+					apply.StartedAt = &now
+				}
+				return c.reconcileTerminalRemoteProgress(ctx, apply, resp.Tables, now)
+			}
+		} else {
+			message := fmt.Sprintf("Remote stopped-state check failed before scheduler start: %v", err)
+			slog.Warn("remote gRPC stopped-state check failed; scheduler will not request remote start",
+				"apply_id", apply.ApplyIdentifier,
+				"external_id", apply.ExternalID,
+				"database", apply.Database,
+				"environment", apply.Environment,
+				"error", err)
+			c.logApplyWarning(ctx, apply, message)
+			return fmt.Errorf("check stopped gRPC apply %s before start: %w", apply.ApplyIdentifier, err)
 		}
 
 		// Only call Start if Tern confirms the apply is actually stopped.
-		if apply.State == state.Apply.Stopped {
+		if state.IsState(apply.State, state.Apply.Stopped) {
 			_, err := c.client.Start(ctx, &ternv1.StartRequest{
 				Database:    apply.Database,
 				Environment: apply.Environment,
@@ -424,10 +521,16 @@ func (c *GRPCClient) ResumeApply(ctx context.Context, apply *storage.Apply) erro
 			if apply.StartedAt == nil {
 				apply.StartedAt = &now
 			}
+			startRequested = true
 		}
 
 		if err := c.storage.Applies().Update(ctx, apply); err != nil {
 			return fmt.Errorf("update apply state: %w", err)
+		}
+		if startRequested {
+			c.logApplyStateTransition(ctx, apply, storage.LogLevelInfo, "Remote apply start requested by scheduler", oldState)
+		} else if oldState != apply.State {
+			c.logApplyStateTransition(ctx, apply, storage.LogLevelInfo, fmt.Sprintf("Remote apply state refreshed before scheduler start: %s -> %s", oldState, apply.State), oldState)
 		}
 	}
 
@@ -453,23 +556,31 @@ func hasAmbiguousRemoteDispatchState(apply *storage.Apply) bool {
 func (c *GRPCClient) dispatchPendingApply(ctx context.Context, apply *storage.Apply) error {
 	plan, err := c.storage.Plans().GetByID(ctx, apply.PlanID)
 	if err != nil {
-		c.markRemoteApplyFailed(ctx, apply, nil, fmt.Sprintf("queued gRPC apply failed: load plan %d: %v", apply.PlanID, err), false)
+		if markErr := c.markRemoteApplyFailed(ctx, apply, nil, fmt.Sprintf("queued gRPC apply failed: load plan %d: %v", apply.PlanID, err), false); markErr != nil {
+			return fmt.Errorf("mark queued gRPC apply %s failed after plan load error: %w", apply.ApplyIdentifier, markErr)
+		}
 		return fmt.Errorf("load plan %d for queued gRPC apply %s: %w", apply.PlanID, apply.ApplyIdentifier, err)
 	}
 	if plan == nil {
 		errMsg := fmt.Sprintf("queued gRPC apply failed: plan %d not found", apply.PlanID)
-		c.markRemoteApplyFailed(ctx, apply, nil, errMsg, false)
+		if markErr := c.markRemoteApplyFailed(ctx, apply, nil, errMsg, false); markErr != nil {
+			return fmt.Errorf("mark queued gRPC apply %s failed after missing plan: %w", apply.ApplyIdentifier, markErr)
+		}
 		return fmt.Errorf("queued gRPC apply %s: %s", apply.ApplyIdentifier, errMsg)
 	}
 
 	tasks, err := c.storage.Tasks().GetByApplyID(ctx, apply.ID)
 	if err != nil {
-		c.markRemoteApplyFailed(ctx, apply, nil, fmt.Sprintf("queued gRPC apply failed: load tasks: %v", err), false)
+		if markErr := c.markRemoteApplyFailed(ctx, apply, nil, fmt.Sprintf("queued gRPC apply failed: load tasks: %v", err), false); markErr != nil {
+			return fmt.Errorf("mark queued gRPC apply %s failed after task load error: %w", apply.ApplyIdentifier, markErr)
+		}
 		return fmt.Errorf("load tasks for queued gRPC apply %s: %w", apply.ApplyIdentifier, err)
 	}
 	if len(tasks) == 0 {
 		errMsg := "queued gRPC apply failed: no tasks found"
-		c.markRemoteApplyFailed(ctx, apply, nil, errMsg, false)
+		if markErr := c.markRemoteApplyFailed(ctx, apply, nil, errMsg, false); markErr != nil {
+			return fmt.Errorf("mark queued gRPC apply %s failed after missing tasks: %w", apply.ApplyIdentifier, markErr)
+		}
 		return fmt.Errorf("queued gRPC apply %s: %s", apply.ApplyIdentifier, errMsg)
 	}
 	if err := c.prepareDispatchTasks(ctx, apply, tasks); err != nil {
@@ -496,12 +607,16 @@ func (c *GRPCClient) dispatchPendingApply(ctx context.Context, apply *storage.Ap
 		if isAmbiguousRemoteApplyDispatchError(err) {
 			return fmt.Errorf("apply queued gRPC apply %s has ambiguous remote dispatch outcome: %w", apply.ApplyIdentifier, err)
 		}
-		c.markRemoteApplyFailed(ctx, apply, tasks, err.Error(), isRetryableRemoteApplyError(err))
+		if markErr := c.markRemoteApplyFailed(ctx, apply, tasks, err.Error(), isRetryableRemoteApplyError(err)); markErr != nil {
+			return fmt.Errorf("mark queued gRPC apply %s failed after remote apply error: %w", apply.ApplyIdentifier, markErr)
+		}
 		return fmt.Errorf("apply queued gRPC apply %s: %w", apply.ApplyIdentifier, err)
 	}
 	if resp == nil {
 		errMsg := "remote apply returned nil response"
-		c.markRemoteApplyFailed(ctx, apply, tasks, errMsg, false)
+		if markErr := c.markRemoteApplyFailed(ctx, apply, tasks, errMsg, false); markErr != nil {
+			return fmt.Errorf("mark queued gRPC apply %s failed after nil response: %w", apply.ApplyIdentifier, markErr)
+		}
 		return fmt.Errorf("apply queued gRPC apply %s: %s", apply.ApplyIdentifier, errMsg)
 	}
 	if !resp.Accepted {
@@ -509,15 +624,20 @@ func (c *GRPCClient) dispatchPendingApply(ctx context.Context, apply *storage.Ap
 		if errMsg == "" {
 			errMsg = "remote apply was not accepted"
 		}
-		c.markRemoteApplyFailed(ctx, apply, tasks, errMsg, false)
+		if markErr := c.markRemoteApplyFailed(ctx, apply, tasks, errMsg, false); markErr != nil {
+			return fmt.Errorf("mark queued gRPC apply %s failed after rejection: %w", apply.ApplyIdentifier, markErr)
+		}
 		return fmt.Errorf("apply queued gRPC apply %s: %s", apply.ApplyIdentifier, errMsg)
 	}
 	if resp.ApplyId == "" {
 		errMsg := "remote apply accepted without apply_id"
-		c.markRemoteApplyFailed(ctx, apply, tasks, errMsg, false)
+		if markErr := c.markRemoteApplyFailed(ctx, apply, tasks, errMsg, false); markErr != nil {
+			return fmt.Errorf("mark queued gRPC apply %s failed after missing remote apply id: %w", apply.ApplyIdentifier, markErr)
+		}
 		return fmt.Errorf("apply queued gRPC apply %s: %s", apply.ApplyIdentifier, errMsg)
 	}
 
+	oldApplyState := apply.State
 	now := time.Now()
 	apply.ExternalID = resp.ApplyId
 	apply.State = state.Apply.Running
@@ -530,6 +650,9 @@ func (c *GRPCClient) dispatchPendingApply(ctx context.Context, apply *storage.Ap
 	if err := c.storage.Applies().Update(ctx, apply); err != nil {
 		return fmt.Errorf("store remote apply id for %s: %w", apply.ApplyIdentifier, err)
 	}
+	c.logApplyStateTransition(ctx, apply, storage.LogLevelInfo,
+		fmt.Sprintf("Apply dispatched to remote Tern: target=%s deployment=%s remote_apply_id=%s", target, apply.Deployment, apply.ExternalID),
+		oldApplyState)
 
 	return c.pollForCompletion(ctx, apply)
 }
@@ -575,7 +698,7 @@ func isRetryableRemoteApplyError(err error) bool {
 
 func (c *GRPCClient) prepareDispatchTasks(ctx context.Context, apply *storage.Apply, tasks []*storage.Task) error {
 	for _, task := range tasks {
-		if task.State != state.Task.FailedRetryable {
+		if !state.IsState(task.State, state.Task.FailedRetryable) {
 			continue
 		}
 		task.State = state.Task.Pending
@@ -602,70 +725,74 @@ func tasksToProtoTableChanges(tasks []*storage.Task) []*ternv1.TableChange {
 	return changes
 }
 
-type remoteApplyTransitionSkipReason string
+// storedApplyTransitionStatus describes whether a worker may copy a remote
+// failure or terminal result into the stored apply row after reloading storage.
+// Only the ready status may mutate storage; every other status explains why the
+// write must be skipped or retried.
+type storedApplyTransitionStatus string
 
 const (
-	remoteApplyTransitionReady        remoteApplyTransitionSkipReason = ""
-	remoteApplyTransitionReloadFailed remoteApplyTransitionSkipReason = "reload_failed"
-	remoteApplyTransitionMissing      remoteApplyTransitionSkipReason = "apply_missing"
-	remoteApplyTransitionTerminal     remoteApplyTransitionSkipReason = "already_terminal"
+	storedApplyTransitionReady           storedApplyTransitionStatus = "ready"
+	storedApplyTransitionReloadFailed    storedApplyTransitionStatus = "reload_failed"
+	storedApplyTransitionMissing         storedApplyTransitionStatus = "apply_missing"
+	storedApplyTransitionAlreadyTerminal storedApplyTransitionStatus = "already_terminal"
 )
 
-func (c *GRPCClient) reloadRemoteApplyForTransition(ctx context.Context, apply *storage.Apply) (*storage.Apply, remoteApplyTransitionSkipReason, error) {
-	currentApply, err := c.storage.Applies().Get(ctx, apply.ID)
+func (c *GRPCClient) reloadStoredApplyForRemoteTransition(ctx context.Context, remoteApply *storage.Apply) (*storage.Apply, storedApplyTransitionStatus, error) {
+	storedApply, err := c.storage.Applies().Get(ctx, remoteApply.ID)
 	if err != nil {
-		return nil, remoteApplyTransitionReloadFailed, fmt.Errorf("reload remote gRPC apply %s: %w", apply.ApplyIdentifier, err)
+		return nil, storedApplyTransitionReloadFailed, fmt.Errorf("reload remote gRPC apply %s: %w", remoteApply.ApplyIdentifier, err)
 	}
-	if currentApply == nil {
-		return nil, remoteApplyTransitionMissing, nil
+	if storedApply == nil {
+		return nil, storedApplyTransitionMissing, nil
 	}
-	if state.IsTerminalApplyState(currentApply.State) {
-		*apply = *currentApply
-		return currentApply, remoteApplyTransitionTerminal, nil
+	if state.IsTerminalApplyState(storedApply.State) {
+		*remoteApply = *storedApply
+		return storedApply, storedApplyTransitionAlreadyTerminal, nil
 	}
-	return currentApply, remoteApplyTransitionReady, nil
+	return storedApply, storedApplyTransitionReady, nil
 }
 
-func logSkippedRemoteApplyTransition(operation string, apply, currentApply *storage.Apply, reason remoteApplyTransitionSkipReason, err error) {
+func logSkippedRemoteApplyTransition(operation string, remoteApply, storedApply *storage.Apply, status storedApplyTransitionStatus, err error) {
 	fields := []any{
 		"operation", operation,
-		"apply_id", apply.ApplyIdentifier,
-		"external_id", apply.ExternalID,
-		"reason", reason,
+		"apply_id", remoteApply.ApplyIdentifier,
+		"external_id", remoteApply.ExternalID,
+		"reason", status,
 	}
-	if currentApply != nil {
-		fields = append(fields, "state", currentApply.State)
+	if storedApply != nil {
+		fields = append(fields, "stored_state", storedApply.State)
 	}
 
-	switch reason {
-	case remoteApplyTransitionReloadFailed:
+	switch status {
+	case storedApplyTransitionReloadFailed:
 		fields = append(fields, "error", err)
 		slog.Error("skipping remote gRPC apply state transition", fields...)
-	case remoteApplyTransitionMissing:
+	case storedApplyTransitionMissing:
 		slog.Warn("skipping remote gRPC apply state transition", fields...)
-	case remoteApplyTransitionTerminal:
+	case storedApplyTransitionAlreadyTerminal:
 		slog.Debug("skipping remote gRPC apply state transition", fields...)
 	default:
 		slog.Warn("skipping remote gRPC apply state transition", fields...)
 	}
 }
 
-func (c *GRPCClient) markRemoteApplyFailed(ctx context.Context, apply *storage.Apply, tasks []*storage.Task, message string, retryable bool) {
-	currentApply, skipReason, err := c.reloadRemoteApplyForTransition(ctx, apply)
-	if skipReason != remoteApplyTransitionReady {
-		logSkippedRemoteApplyTransition("mark remote gRPC apply failed", apply, currentApply, skipReason, err)
-		return
+func (c *GRPCClient) markRemoteApplyFailed(ctx context.Context, remoteApply *storage.Apply, storedTasks []*storage.Task, message string, retryable bool) error {
+	storedApply, transitionStatus, err := c.reloadStoredApplyForRemoteTransition(ctx, remoteApply)
+	if transitionStatus != storedApplyTransitionReady {
+		logSkippedRemoteApplyTransition("mark remote gRPC apply failed", remoteApply, storedApply, transitionStatus, err)
+		if err != nil {
+			return err
+		}
+		return nil
 	}
 
 	now := time.Now()
-	if tasks == nil {
+	if storedTasks == nil {
 		var taskErr error
-		tasks, taskErr = c.storage.Tasks().GetByApplyID(ctx, currentApply.ID)
+		storedTasks, taskErr = c.storage.Tasks().GetByApplyID(ctx, storedApply.ID)
 		if taskErr != nil {
-			slog.Error("failed to load tasks after remote gRPC apply failed",
-				"apply_id", currentApply.ApplyIdentifier,
-				"external_id", currentApply.ExternalID,
-				"error", taskErr)
+			return fmt.Errorf("load tasks after remote gRPC apply failed %s: %w", storedApply.ApplyIdentifier, taskErr)
 		}
 	}
 
@@ -675,76 +802,181 @@ func (c *GRPCClient) markRemoteApplyFailed(ctx context.Context, apply *storage.A
 		taskState = state.Task.FailedRetryable
 		applyState = state.Apply.FailedRetryable
 	}
-	for _, task := range tasks {
-		if state.IsTerminalTaskState(task.State) {
+	for _, storedTask := range storedTasks {
+		if state.IsTerminalTaskState(storedTask.State) {
+			slog.Info("leaving terminal gRPC task unchanged after remote apply failure",
+				"apply_id", storedApply.ApplyIdentifier,
+				"task_id", storedTask.TaskIdentifier,
+				"table", storedTask.TableName,
+				"task_state", storedTask.State,
+				"failure_task_state", taskState)
 			continue
 		}
-		task.State = taskState
-		task.ErrorMessage = message
+		storedTask.State = taskState
+		storedTask.ErrorMessage = message
 		if retryable {
-			task.CompletedAt = nil
+			storedTask.CompletedAt = nil
 		} else {
-			task.CompletedAt = &now
+			storedTask.CompletedAt = &now
 		}
-		task.UpdatedAt = now
-		if err := c.storage.Tasks().Update(ctx, task); err != nil {
-			slog.Error("failed to update task after remote gRPC apply failure",
-				"apply_id", currentApply.ApplyIdentifier,
-				"task_id", task.TaskIdentifier,
-				"error", err)
+		storedTask.UpdatedAt = now
+		if err := c.storage.Tasks().Update(ctx, storedTask); err != nil {
+			return fmt.Errorf("update task %s after remote gRPC apply failure %s: %w", storedTask.TaskIdentifier, storedApply.ApplyIdentifier, err)
 		}
 	}
 
-	currentApply.State = applyState
-	currentApply.ErrorMessage = message
+	oldState := storedApply.State
+	storedApply.State = applyState
+	storedApply.ErrorMessage = message
 	if retryable {
-		currentApply.CompletedAt = nil
+		storedApply.CompletedAt = nil
 	} else {
-		currentApply.CompletedAt = &now
+		storedApply.CompletedAt = &now
 	}
-	currentApply.UpdatedAt = now
-	if err := c.storage.Applies().Update(ctx, currentApply); err != nil {
-		slog.Error("failed to update apply after remote gRPC apply failure",
-			"apply_id", currentApply.ApplyIdentifier,
-			"external_id", currentApply.ExternalID,
-			"error", err)
-		return
+	storedApply.UpdatedAt = now
+	if err := c.storage.Applies().Update(ctx, storedApply); err != nil {
+		return fmt.Errorf("update remote gRPC apply failure %s: %w", storedApply.ApplyIdentifier, err)
 	}
-	*apply = *currentApply
-	metrics.AdjustActiveApplies(ctx, -1, currentApply.Database, currentApply.Environment)
+	c.logApplyStateTransition(ctx, storedApply, storage.LogLevelError, fmt.Sprintf("Remote apply failed: %s", message), oldState)
+	*remoteApply = *storedApply
+	metrics.AdjustActiveApplies(ctx, -1, storedApply.Database, storedApply.Environment)
+	return nil
 }
 
-func (c *GRPCClient) failMissingRemoteApply(ctx context.Context, apply *storage.Apply, message string, cause error) error {
-	c.markRemoteApplyFailed(ctx, apply, nil, message, false)
+func (c *GRPCClient) failMissingRemoteApply(ctx context.Context, remoteApply *storage.Apply, message string, cause error) error {
+	if err := c.markRemoteApplyFailed(ctx, remoteApply, nil, message, false); err != nil {
+		return fmt.Errorf("mark missing remote apply %s failed: %w", remoteApply.ApplyIdentifier, err)
+	}
 	if cause != nil {
-		return fmt.Errorf("poll remote apply %s for %s: %w", apply.ExternalID, apply.ApplyIdentifier, cause)
+		return fmt.Errorf("poll remote apply %s for %s: %w", remoteApply.ExternalID, remoteApply.ApplyIdentifier, cause)
 	}
-	return fmt.Errorf("poll remote apply %s for %s: %s", apply.ExternalID, apply.ApplyIdentifier, message)
+	return fmt.Errorf("poll remote apply %s for %s: %s", remoteApply.ExternalID, remoteApply.ApplyIdentifier, message)
 }
 
-func (c *GRPCClient) persistRemoteTerminalApply(ctx context.Context, apply *storage.Apply, now time.Time) bool {
-	currentApply, skipReason, err := c.reloadRemoteApplyForTransition(ctx, apply)
-	if skipReason != remoteApplyTransitionReady {
-		logSkippedRemoteApplyTransition("persist remote terminal apply", apply, currentApply, skipReason, err)
-		return skipReason == remoteApplyTransitionMissing || skipReason == remoteApplyTransitionTerminal
+func (c *GRPCClient) reconcileTerminalRemoteProgress(ctx context.Context, remoteApply *storage.Apply, remoteTasks []*ternv1.TableProgress, now time.Time) error {
+	// reloadStoredApplyForRemoteTransition may overwrite remoteApply with the
+	// stored row when it finds an already-terminal stored apply. Keep the remote
+	// Progress result available for the stopped-row exception below.
+	remoteApplyFromProgress := *remoteApply
+	storedApply, transitionStatus, err := c.reloadStoredApplyForRemoteTransition(ctx, remoteApply)
+
+	// A scheduler claim can start from a stale stored "stopped" row. If the
+	// exact remote apply has already advanced to another terminal state, the
+	// remote result is the newer truth and should replace the stored stopped row.
+	if transitionStatus == storedApplyTransitionAlreadyTerminal && storedStoppedApplyCanAdoptRemoteTerminalState(storedApply, &remoteApplyFromProgress) {
+		*remoteApply = remoteApplyFromProgress
+		transitionStatus = storedApplyTransitionReady
 	}
 
-	currentApply.State = apply.State
-	currentApply.ErrorMessage = apply.ErrorMessage
-	currentApply.StartedAt = apply.StartedAt
-	currentApply.CompletedAt = &now
-	currentApply.UpdatedAt = now
-	if err := c.storage.Applies().Update(ctx, currentApply); err != nil {
-		slog.Error("failed to update terminal remote gRPC apply",
-			"apply_id", currentApply.ApplyIdentifier,
-			"external_id", currentApply.ExternalID,
-			"state", currentApply.State,
-			"error", err)
-		return false
+	if transitionStatus != storedApplyTransitionReady {
+		logSkippedRemoteApplyTransition("persist remote terminal apply", remoteApply, storedApply, transitionStatus, err)
+		if err != nil {
+			return err
+		}
+		return nil
 	}
-	*apply = *currentApply
-	metrics.AdjustActiveApplies(ctx, -1, currentApply.Database, currentApply.Environment)
-	return true
+
+	// Keep the stored apply active until stored task rows are written. If task
+	// storage is unavailable, the scheduler can retry this worker instead of
+	// treating a terminal apply as fully reconciled.
+	storedTasks, err := c.storage.Tasks().GetByApplyID(ctx, storedApply.ID)
+	if err != nil {
+		return fmt.Errorf("load tasks to sync terminal gRPC progress for %s: %w", storedApply.ApplyIdentifier, err)
+	}
+	if err := c.syncStoredTasksFromRemoteTasks(ctx, storedApply, storedTasks, remoteTasks, now); err != nil {
+		return err
+	}
+	if err := ensureStoredTasksResolvedForTerminalRemoteApply(remoteApply, storedTasks); err != nil {
+		return err
+	}
+	return c.persistTerminalStateFromRemote(ctx, storedApply, remoteApply, now)
+}
+
+func storedStoppedApplyCanAdoptRemoteTerminalState(storedApply, remoteApply *storage.Apply) bool {
+	return storedApply != nil &&
+		state.IsState(storedApply.State, state.Apply.Stopped) &&
+		!state.IsState(remoteApply.State, state.Apply.Stopped)
+}
+
+func (c *GRPCClient) persistTerminalStateFromRemote(ctx context.Context, storedApply, remoteApply *storage.Apply, now time.Time) error {
+	oldState := storedApply.State
+	storedApply.State = remoteApply.State
+	storedApply.ErrorMessage = remoteApply.ErrorMessage
+	storedApply.StartedAt = remoteApply.StartedAt
+	storedApply.CompletedAt = &now
+	storedApply.UpdatedAt = now
+	if err := c.storage.Applies().Update(ctx, storedApply); err != nil {
+		return fmt.Errorf("update terminal remote gRPC apply %s: %w", storedApply.ApplyIdentifier, err)
+	}
+	c.logApplyStateTransition(ctx, storedApply, storage.LogLevelInfo, fmt.Sprintf("Remote apply reached terminal state: %s", storedApply.State), oldState)
+	*remoteApply = *storedApply
+	metrics.AdjustActiveApplies(ctx, -1, storedApply.Database, storedApply.Environment)
+	return nil
+}
+
+// syncStoredTasksFromRemoteTasks mirrors the per-task table progress fields
+// returned by remote Tern. It only copies the remote task snapshot; terminal
+// remote applies are persisted only after those copied task states are resolved.
+func (c *GRPCClient) syncStoredTasksFromRemoteTasks(
+	ctx context.Context,
+	storedApply *storage.Apply,
+	storedTasks []*storage.Task,
+	remoteTasks []*ternv1.TableProgress,
+	now time.Time,
+) error {
+	for _, storedTask := range storedTasks {
+		for _, remoteTask := range remoteTasks {
+			if remoteTask.TableName != storedTask.TableName {
+				continue
+			}
+			oldTaskState := storedTask.State
+			storedTask.State = state.NormalizeTaskStatus(remoteTask.Status)
+			storedTask.RowsCopied = remoteTask.RowsCopied
+			storedTask.RowsTotal = remoteTask.RowsTotal
+			storedTask.ProgressPercent = int(remoteTask.PercentComplete)
+			if state.IsState(storedTask.State, state.Task.Completed) && storedTask.ProgressPercent != 100 {
+				storedTask.ProgressPercent = 100
+			}
+			if state.IsTerminalTaskState(storedTask.State) && storedTask.CompletedAt == nil {
+				storedTask.CompletedAt = &now
+			}
+			storedTask.UpdatedAt = now
+			if err := c.storage.Tasks().Update(ctx, storedTask); err != nil {
+				return fmt.Errorf("sync task %s from gRPC progress for %s: %w", storedTask.TaskIdentifier, storedApply.ApplyIdentifier, err)
+			}
+			if oldTaskState != storedTask.State {
+				c.logTaskStateTransition(ctx, storedApply.ID, storedTask, fmt.Sprintf("Remote task %s changed state: %s -> %s", storedTask.TableName, oldTaskState, storedTask.State), oldTaskState)
+			}
+			break
+		}
+	}
+	return nil
+}
+
+func ensureStoredTasksResolvedForTerminalRemoteApply(remoteApply *storage.Apply, storedTasks []*storage.Task) error {
+	for _, storedTask := range storedTasks {
+		if storedTaskResolvedForTerminalRemoteApply(remoteApply.State, storedTask.State) {
+			continue
+		}
+		slog.Warn("terminal remote gRPC apply still has unresolved stored task after syncing remote task progress",
+			"apply_id", remoteApply.ApplyIdentifier,
+			"external_id", remoteApply.ExternalID,
+			"remote_apply_state", remoteApply.State,
+			"task_id", storedTask.TaskIdentifier,
+			"table", storedTask.TableName,
+			"stored_task_state", storedTask.State)
+		return fmt.Errorf("terminal remote gRPC apply %s is %s but stored task %s is still %s after syncing remote task progress",
+			remoteApply.ApplyIdentifier, remoteApply.State, storedTask.TaskIdentifier, storedTask.State)
+	}
+	return nil
+}
+
+func storedTaskResolvedForTerminalRemoteApply(remoteApplyState, storedTaskState string) bool {
+	if state.IsTerminalTaskState(storedTaskState) {
+		return true
+	}
+	return state.IsState(remoteApplyState, state.Apply.Stopped) &&
+		state.IsState(storedTaskState, state.Task.Stopped)
 }
 
 // pollForCompletion polls the remote Tern for progress and updates SchemaBot's storage.
@@ -790,48 +1022,46 @@ func (c *GRPCClient) pollForCompletion(ctx context.Context, apply *storage.Apply
 				return c.failMissingRemoteApply(ctx, apply, message, nil)
 			}
 
-			// Update apply state based on response (skip if proto state is unspecified)
+			// Update apply state from the remote response. An exact apply-id poll
+			// must return a concrete state; unknown states are unsafe to reconcile.
 			now := time.Now()
-			if newState := ProtoStateToStorage(resp.State); newState != "" {
-				if apply.StartedAt == nil && newState != state.Apply.Pending {
-					apply.StartedAt = &now
-				}
-				apply.State = newState
+			oldApplyState := apply.State
+			newState := ProtoStateToStorage(resp.State)
+			if newState == "" {
+				message := fmt.Sprintf("Remote progress returned unmapped apply state %s; scheduler will retry without changing stored state", remoteApplyStateDescription(resp.State))
+				slog.Warn("remote gRPC progress returned unmapped apply state; scheduler will retry without changing stored state",
+					"apply_id", apply.ApplyIdentifier,
+					"external_id", apply.ExternalID,
+					"database", apply.Database,
+					"environment", apply.Environment,
+					"remote_state", resp.State.String(),
+					"remote_state_number", int32(resp.State),
+					"stored_state", apply.State)
+				c.logApplyWarning(ctx, apply, message)
+				return fmt.Errorf("poll remote gRPC apply %s: unmapped remote state %s", apply.ApplyIdentifier, remoteApplyStateDescription(resp.State))
 			}
+			if apply.StartedAt == nil && newState != state.Apply.Pending {
+				apply.StartedAt = &now
+			}
+			apply.State = newState
 			apply.UpdatedAt = now
-
-			// Update tasks from response. This must happen before the
-			// terminal check so task records get their final state synced
-			// before we return.
-			tasks, err := c.storage.Tasks().GetByApplyID(ctx, apply.ID)
-			if err != nil {
-				return fmt.Errorf("load tasks to sync gRPC progress for %s: %w", apply.ApplyIdentifier, err)
-			}
-			for _, task := range tasks {
-				for _, tp := range resp.Tables {
-					if tp.TableName == task.TableName {
-						task.State = state.NormalizeTaskStatus(tp.Status)
-						task.RowsCopied = tp.RowsCopied
-						task.RowsTotal = tp.RowsTotal
-						task.ProgressPercent = int(tp.PercentComplete)
-						task.UpdatedAt = now
-						if err := c.storage.Tasks().Update(ctx, task); err != nil {
-							return fmt.Errorf("sync task %s from gRPC progress for %s: %w", task.TaskIdentifier, apply.ApplyIdentifier, err)
-						}
-						break
-					}
-				}
-			}
 
 			terminal := isTerminalProtoState(resp.State)
 			if terminal {
-				if c.persistRemoteTerminalApply(ctx, apply, now) {
-					return nil
-				}
-				continue
+				return c.reconcileTerminalRemoteProgress(ctx, apply, resp.Tables, now)
+			}
+			storedTasks, err := c.storage.Tasks().GetByApplyID(ctx, apply.ID)
+			if err != nil {
+				return fmt.Errorf("load tasks to sync gRPC progress for %s: %w", apply.ApplyIdentifier, err)
+			}
+			if err := c.syncStoredTasksFromRemoteTasks(ctx, apply, storedTasks, resp.Tables, now); err != nil {
+				return err
 			}
 			if err := c.storage.Applies().Update(ctx, apply); err != nil {
 				return fmt.Errorf("sync apply %s from gRPC progress: %w", apply.ApplyIdentifier, err)
+			}
+			if oldApplyState != apply.State {
+				c.logApplyStateTransition(ctx, apply, storage.LogLevelInfo, fmt.Sprintf("Remote apply changed state: %s -> %s", oldApplyState, apply.State), oldApplyState)
 			}
 		}
 	}

--- a/pkg/tern/grpc_client_test.go
+++ b/pkg/tern/grpc_client_test.go
@@ -2,9 +2,11 @@ package tern
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"net"
 	"os"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -339,6 +341,8 @@ type capturingTernServer struct {
 	progressApplyID  string
 	progressState    ternv1.State // state returned by Progress; 0 = STATE_COMPLETED
 	progressStateSet bool
+	progressStates   []ternv1.State
+	progressTables   []*ternv1.TableProgress
 	progressErr      error
 	startCalled      bool // tracks whether Start was actually invoked
 }
@@ -373,6 +377,12 @@ func (s *capturingTernServer) Progress(_ context.Context, req *ternv1.ProgressRe
 	s.progressApplyID = req.ApplyId
 	ps := s.progressState
 	psSet := s.progressStateSet
+	if len(s.progressStates) > 0 {
+		ps = s.progressStates[0]
+		s.progressStates = s.progressStates[1:]
+		psSet = true
+	}
+	tables := s.progressTables
 	err := s.progressErr
 	s.mu.Unlock()
 	if err != nil {
@@ -381,7 +391,7 @@ func (s *capturingTernServer) Progress(_ context.Context, req *ternv1.ProgressRe
 	if !psSet {
 		ps = ternv1.State_STATE_COMPLETED
 	}
-	return &ternv1.ProgressResponse{State: ps}, nil
+	return &ternv1.ProgressResponse{State: ps, Tables: tables}, nil
 }
 
 func (s *capturingTernServer) getStartApplyID() string {
@@ -405,7 +415,8 @@ func (s *capturingTernServer) getApplyRequest() *ternv1.ApplyRequest {
 // mockApplyStore is a minimal ApplyStore for testing ResumeApply.
 type mockApplyStore struct {
 	storage.ApplyStore
-	apply *storage.Apply
+	apply     *storage.Apply
+	updateErr error
 }
 
 func (m *mockApplyStore) Get(context.Context, int64) (*storage.Apply, error) {
@@ -416,6 +427,9 @@ func (m *mockApplyStore) Get(context.Context, int64) (*storage.Apply, error) {
 	return &apply, nil
 }
 func (m *mockApplyStore) Update(_ context.Context, apply *storage.Apply) error {
+	if m.updateErr != nil {
+		return m.updateErr
+	}
 	stored := *apply
 	m.apply = &stored
 	return nil
@@ -425,13 +439,32 @@ func (m *mockApplyStore) Heartbeat(context.Context, int64) error { return nil }
 // mockTaskStore is a minimal TaskStore for testing pollForCompletion.
 type mockTaskStore struct {
 	storage.TaskStore
-	tasks []*storage.Task
+	tasks           []*storage.Task
+	getByApplyIDErr error
 }
 
 func (m *mockTaskStore) GetByApplyID(context.Context, int64) ([]*storage.Task, error) {
+	if m.getByApplyIDErr != nil {
+		return nil, m.getByApplyIDErr
+	}
 	return m.tasks, nil
 }
 func (m *mockTaskStore) Update(context.Context, *storage.Task) error { return nil }
+
+type mockApplyLogStore struct {
+	storage.ApplyLogStore
+	logs []*storage.ApplyLog
+}
+
+func (m *mockApplyLogStore) Append(_ context.Context, log *storage.ApplyLog) error {
+	stored := *log
+	m.logs = append(m.logs, &stored)
+	return nil
+}
+
+func (m *mockApplyLogStore) GetByApply(context.Context, int64) ([]*storage.ApplyLog, error) {
+	return m.logs, nil
+}
 
 type mockPlanStore struct {
 	storage.PlanStore
@@ -448,6 +481,7 @@ type mockStorage struct {
 	applies *mockApplyStore
 	tasks   *mockTaskStore
 	plans   *mockPlanStore
+	logs    *mockApplyLogStore
 }
 
 func (m *mockStorage) Applies() storage.ApplyStore {
@@ -467,6 +501,12 @@ func (m *mockStorage) Plans() storage.PlanStore {
 		return m.plans
 	}
 	return &mockPlanStore{}
+}
+func (m *mockStorage) ApplyLogs() storage.ApplyLogStore {
+	if m.logs != nil {
+		return m.logs
+	}
+	return &mockApplyLogStore{}
 }
 
 func testCapturingGRPCClient(t *testing.T, server *capturingTernServer) (*GRPCClient, func()) {
@@ -496,10 +536,17 @@ func testCapturingGRPCClient(t *testing.T, server *capturingTernServer) (*GRPCCl
 }
 
 func TestGRPCClient_ResumeApplyDispatchesQueuedRemoteApply(t *testing.T) {
-	// Scheduler claims start with a durable control-plane apply and pending
+	// Scheduler claims start with a stored control-plane apply row and pending
 	// tasks but no external_id. ResumeApply dispatches the queued work to
 	// remote Tern, stores the returned data-plane ID, then polls it to terminal.
-	server := &capturingTernServer{remoteApplyID: "remote-dispatched-123"}
+	server := &capturingTernServer{
+		remoteApplyID: "remote-dispatched-123",
+		progressTables: []*ternv1.TableProgress{{
+			TableName:       "users",
+			Status:          state.Task.Completed,
+			PercentComplete: 100,
+		}},
+	}
 	client, cleanup := testCapturingGRPCClient(t, server)
 	defer cleanup()
 
@@ -557,6 +604,408 @@ func TestGRPCClient_ResumeApplyDispatchesQueuedRemoteApply(t *testing.T) {
 	assert.Equal(t, "remote-dispatched-123", server.getProgressApplyID())
 }
 
+func TestGRPCClient_ResumeApplyLogsRemoteLifecycle(t *testing.T) {
+	// gRPC mode keeps the stored apply history in the control plane. When the
+	// scheduler dispatches work to a remote Tern service, operators should still
+	// see the dispatch and final state through SchemaBot apply logs.
+	server := &capturingTernServer{
+		remoteApplyID:  "remote-lifecycle-123",
+		progressStates: []ternv1.State{ternv1.State_STATE_RUNNING, ternv1.State_STATE_COMPLETED},
+		progressTables: []*ternv1.TableProgress{{
+			TableName:       "users",
+			Status:          state.Task.Completed,
+			PercentComplete: 100,
+		}},
+	}
+	client, cleanup := testCapturingGRPCClient(t, server)
+	defer cleanup()
+
+	apply := &storage.Apply{
+		ID:              17,
+		ApplyIdentifier: "apply-control-lifecycle",
+		PlanID:          109,
+		Database:        "testdb",
+		DatabaseType:    storage.DatabaseTypeMySQL,
+		Deployment:      "us-west",
+		Environment:     "staging",
+		State:           state.Apply.Pending,
+	}
+	apply.SetOptions(storage.ApplyOptions{Target: "testdb-target"})
+	task := &storage.Task{
+		ID:             21,
+		TaskIdentifier: "task-lifecycle",
+		ApplyID:        apply.ID,
+		TableName:      "users",
+		DDL:            "ALTER TABLE users ADD COLUMN email varchar(255)",
+		DDLAction:      "alter",
+		Namespace:      "default",
+		State:          state.Task.Pending,
+	}
+	logs := &mockApplyLogStore{}
+	client.storage = &mockStorage{
+		applies: &mockApplyStore{apply: apply},
+		tasks:   &mockTaskStore{tasks: []*storage.Task{task}},
+		plans: &mockPlanStore{plan: &storage.Plan{
+			ID:             apply.PlanID,
+			PlanIdentifier: "plan-remote-lifecycle",
+		}},
+		logs: logs,
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 3*time.Second)
+	defer cancel()
+	err := client.ResumeApply(ctx, apply)
+	require.NoError(t, err)
+
+	messages := make([]string, 0, len(logs.logs))
+	for _, log := range logs.logs {
+		messages = append(messages, log.Message)
+	}
+	assert.Contains(t, messages, "Apply dispatched to remote Tern: target=testdb-target deployment=us-west remote_apply_id=remote-lifecycle-123")
+	assert.Contains(t, messages, "Remote task users changed state: pending -> completed")
+	assert.True(t, hasLogMessageContaining(logs.logs, "Remote apply reached terminal state: completed"),
+		"expected final remote apply state in logs: %v", messages)
+	assert.Equal(t, state.Task.Completed, task.State)
+	require.NotNil(t, task.CompletedAt)
+
+	var dispatchLog *storage.ApplyLog
+	for _, log := range logs.logs {
+		if strings.Contains(log.Message, "Apply dispatched to remote Tern") {
+			dispatchLog = log
+			break
+		}
+	}
+	require.NotNil(t, dispatchLog, "dispatch log should be present")
+	assert.Equal(t, state.Apply.Pending, dispatchLog.OldState)
+	assert.Equal(t, state.Apply.Running, dispatchLog.NewState)
+}
+
+func TestGRPCClient_SyncStoredTasksFromRemoteTasksUsesRemoteTaskState(t *testing.T) {
+	// Remote task state is the source of truth for stored task rows. Apply-level
+	// terminal state must not invent task results when the remote task snapshot
+	// is missing or incomplete.
+	now := time.Date(2026, 5, 25, 12, 0, 0, 0, time.UTC)
+	testCases := []struct {
+		name                string
+		remoteTaskState     string
+		remoteProgress      int32
+		wantStoredTaskState string
+		wantProgress        int
+		wantCompletedAt     bool
+	}{
+		{
+			name:                "completed remote task completes stored task row",
+			remoteTaskState:     state.Task.Completed,
+			remoteProgress:      42,
+			wantStoredTaskState: state.Task.Completed,
+			wantProgress:        100,
+			wantCompletedAt:     true,
+		},
+		{
+			name:                "failed remote task fails stored task row",
+			remoteTaskState:     state.Task.Failed,
+			wantStoredTaskState: state.Task.Failed,
+			wantCompletedAt:     true,
+		},
+		{
+			name:                "cancelled remote task cancels stored task row",
+			remoteTaskState:     state.Task.Cancelled,
+			wantStoredTaskState: state.Task.Cancelled,
+			wantCompletedAt:     true,
+		},
+		{
+			name:                "reverted remote task reverts stored task row",
+			remoteTaskState:     state.Task.Reverted,
+			wantStoredTaskState: state.Task.Reverted,
+			wantCompletedAt:     true,
+		},
+		{
+			name:                "stopped remote task leaves stored task row resumable",
+			remoteTaskState:     state.Task.Stopped,
+			wantStoredTaskState: state.Task.Stopped,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			storedApply := &storage.Apply{
+				ID:              18,
+				ApplyIdentifier: "apply-remote-terminal",
+				State:           state.Apply.Running,
+			}
+			storedTask := &storage.Task{
+				ID:             22,
+				TaskIdentifier: "task-remote-terminal",
+				ApplyID:        storedApply.ID,
+				TableName:      "users",
+				State:          state.Task.Running,
+			}
+			logs := &mockApplyLogStore{}
+			client := &GRPCClient{
+				storage: &mockStorage{
+					tasks: &mockTaskStore{tasks: []*storage.Task{storedTask}},
+					logs:  logs,
+				},
+			}
+
+			err := client.syncStoredTasksFromRemoteTasks(t.Context(), storedApply, []*storage.Task{storedTask}, []*ternv1.TableProgress{{
+				TableName:       "users",
+				Status:          tc.remoteTaskState,
+				PercentComplete: tc.remoteProgress,
+			}}, now)
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.wantStoredTaskState, storedTask.State)
+			assert.Equal(t, tc.wantProgress, storedTask.ProgressPercent)
+			assert.Equal(t, tc.wantCompletedAt, storedTask.CompletedAt != nil)
+			assert.True(t, hasLogMessageContaining(logs.logs, "Remote task users changed state: running -> "+tc.wantStoredTaskState))
+		})
+	}
+}
+
+func TestGRPCClient_PollSetsTerminalTaskMetadataFromRemoteTaskProgress(t *testing.T) {
+	// Terminal remote task progress marks the stored task terminal and fills
+	// local metadata before the stored apply row is marked completed.
+	client, cleanup := testCapturingGRPCClient(t, &capturingTernServer{
+		progressState:    ternv1.State_STATE_COMPLETED,
+		progressStateSet: true,
+		progressTables: []*ternv1.TableProgress{{
+			TableName:       "users",
+			Status:          state.Task.Completed,
+			PercentComplete: 100,
+		}},
+	})
+	defer cleanup()
+
+	apply := &storage.Apply{
+		ID:              18,
+		ApplyIdentifier: "apply-remote-completed",
+		Database:        "testdb",
+		Environment:     "staging",
+		ExternalID:      "remote-completed",
+		State:           state.Apply.Running,
+	}
+	storedApply := *apply
+	task := &storage.Task{
+		ID:             22,
+		TaskIdentifier: "task-remote-completed",
+		ApplyID:        apply.ID,
+		TableName:      "users",
+		State:          state.Task.Running,
+	}
+	logs := &mockApplyLogStore{}
+	client.storage = &mockStorage{
+		applies: &mockApplyStore{apply: &storedApply},
+		tasks:   &mockTaskStore{tasks: []*storage.Task{task}},
+		logs:    logs,
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+	err := client.pollForCompletion(ctx, apply)
+	require.NoError(t, err)
+
+	assert.Equal(t, state.Task.Completed, task.State)
+	assert.Equal(t, 100, task.ProgressPercent)
+	require.NotNil(t, task.CompletedAt)
+}
+
+func TestGRPCClient_PollReturnsErrorWhenTerminalRemoteApplyLeavesStoredTaskActive(t *testing.T) {
+	// A terminal remote apply with no terminal remote task state is inconsistent.
+	// The control plane should retry instead of inventing a stored task result.
+	client, cleanup := testCapturingGRPCClient(t, &capturingTernServer{
+		progressState:    ternv1.State_STATE_COMPLETED,
+		progressStateSet: true,
+	})
+	defer cleanup()
+
+	apply := &storage.Apply{
+		ID:              18,
+		ApplyIdentifier: "apply-terminal-missing-task-state",
+		Database:        "testdb",
+		Environment:     "staging",
+		ExternalID:      "remote-terminal-missing-task-state",
+		State:           state.Apply.Running,
+	}
+	storedApply := *apply
+	task := &storage.Task{
+		ID:             22,
+		TaskIdentifier: "task-terminal-missing-state",
+		ApplyID:        apply.ID,
+		TableName:      "users",
+		State:          state.Task.Running,
+	}
+	applyStore := &mockApplyStore{apply: &storedApply}
+	client.storage = &mockStorage{
+		applies: applyStore,
+		tasks:   &mockTaskStore{tasks: []*storage.Task{task}},
+		logs:    &mockApplyLogStore{},
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+	err := client.pollForCompletion(ctx, apply)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "stored task task-terminal-missing-state is still running")
+	assert.Equal(t, state.Apply.Running, applyStore.apply.State)
+	assert.Nil(t, applyStore.apply.CompletedAt)
+}
+
+func hasLogMessageContaining(logs []*storage.ApplyLog, want string) bool {
+	for _, log := range logs {
+		if strings.Contains(log.Message, want) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestGRPCClient_PollReturnsTerminalStorageUpdateError(t *testing.T) {
+	// A terminal remote state is not enough by itself; the control plane must
+	// persist that terminal state to storage before the scheduler worker exits.
+	client, cleanup := testCapturingGRPCClient(t, &capturingTernServer{
+		progressState:    ternv1.State_STATE_COMPLETED,
+		progressStateSet: true,
+	})
+	defer cleanup()
+
+	apply := &storage.Apply{
+		ID:              18,
+		ApplyIdentifier: "apply-terminal-storage-error",
+		Database:        "testdb",
+		Environment:     "staging",
+		ExternalID:      "remote-terminal-storage-error",
+		State:           state.Apply.Running,
+	}
+	storedApply := *apply
+	client.storage = &mockStorage{
+		applies: &mockApplyStore{
+			apply:     &storedApply,
+			updateErr: errors.New("storage unavailable"),
+		},
+		tasks: &mockTaskStore{},
+		logs:  &mockApplyLogStore{},
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+	err := client.pollForCompletion(ctx, apply)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "update terminal remote gRPC apply")
+	assert.Contains(t, err.Error(), "storage unavailable")
+}
+
+func TestGRPCClient_PollKeepsApplyActiveWhenTerminalTaskLoadFails(t *testing.T) {
+	// Terminal remote progress is only fully reconciled once stored task rows are
+	// updated too. If task storage fails, the apply should remain active so a
+	// later scheduler attempt can finish reconciliation.
+	client, cleanup := testCapturingGRPCClient(t, &capturingTernServer{
+		progressState:    ternv1.State_STATE_COMPLETED,
+		progressStateSet: true,
+	})
+	defer cleanup()
+
+	apply := &storage.Apply{
+		ID:              19,
+		ApplyIdentifier: "apply-terminal-task-load-error",
+		Database:        "testdb",
+		Environment:     "staging",
+		ExternalID:      "remote-terminal-task-load-error",
+		State:           state.Apply.Running,
+	}
+	storedApply := *apply
+	applyStore := &mockApplyStore{apply: &storedApply}
+	client.storage = &mockStorage{
+		applies: applyStore,
+		tasks: &mockTaskStore{
+			getByApplyIDErr: errors.New("task storage unavailable"),
+		},
+		logs: &mockApplyLogStore{},
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+	err := client.pollForCompletion(ctx, apply)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "load tasks to sync terminal gRPC progress")
+	assert.Contains(t, err.Error(), "task storage unavailable")
+	assert.Equal(t, state.Apply.Running, applyStore.apply.State)
+	assert.Nil(t, applyStore.apply.CompletedAt)
+}
+
+func TestGRPCClient_PollSkipsTaskFinalizationWhenStoredApplyAlreadyTerminal(t *testing.T) {
+	// A stale worker can receive a terminal remote state after another worker
+	// has already terminalized the stored apply row. In that case the worker must
+	// not rewrite tasks from its stale in-memory apply state.
+	client, cleanup := testCapturingGRPCClient(t, &capturingTernServer{
+		progressState:    ternv1.State_STATE_COMPLETED,
+		progressStateSet: true,
+	})
+	defer cleanup()
+
+	apply := &storage.Apply{
+		ID:              19,
+		ApplyIdentifier: "apply-terminal-race",
+		Database:        "testdb",
+		Environment:     "staging",
+		ExternalID:      "remote-terminal-race",
+		State:           state.Apply.Running,
+	}
+	storedApply := *apply
+	storedApply.State = state.Apply.Failed
+	task := &storage.Task{
+		ID:             23,
+		TaskIdentifier: "task-terminal-race",
+		ApplyID:        apply.ID,
+		TableName:      "users",
+		State:          state.Task.Running,
+	}
+	client.storage = &mockStorage{
+		applies: &mockApplyStore{apply: &storedApply},
+		tasks:   &mockTaskStore{tasks: []*storage.Task{task}},
+		logs:    &mockApplyLogStore{},
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+	err := client.pollForCompletion(ctx, apply)
+	require.NoError(t, err)
+
+	assert.Equal(t, state.Apply.Failed, apply.State)
+	assert.Equal(t, state.Task.Running, task.State)
+	assert.Nil(t, task.CompletedAt)
+}
+
+func TestGRPCClient_MarkRemoteApplyFailedReturnsTaskLoadError(t *testing.T) {
+	// A remote failure is only safe to store after the control plane can update
+	// both apply and task rows. Task storage uncertainty should make the caller
+	// retry instead of leaving unfinished tasks behind.
+	apply := &storage.Apply{
+		ID:              20,
+		ApplyIdentifier: "apply-task-load-error",
+		Database:        "testdb",
+		Environment:     "staging",
+		ExternalID:      "remote-task-load-error",
+		State:           state.Apply.Running,
+	}
+	applyStore := &mockApplyStore{apply: apply}
+	client := &GRPCClient{
+		storage: &mockStorage{
+			applies: applyStore,
+			tasks: &mockTaskStore{
+				getByApplyIDErr: errors.New("task storage unavailable"),
+			},
+			logs: &mockApplyLogStore{},
+		},
+	}
+
+	err := client.markRemoteApplyFailed(t.Context(), apply, nil, "remote failed", false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "load tasks after remote gRPC apply failed")
+	assert.Contains(t, err.Error(), "task storage unavailable")
+	assert.Equal(t, state.Apply.Running, applyStore.apply.State)
+}
+
 func TestGRPCClient_ResumeApplyRejectsAmbiguousRemoteDispatchState(t *testing.T) {
 	// A stale active gRPC apply without an external_id is ambiguous: the prior
 	// worker may have sent the remote Apply RPC and crashed before persisting the
@@ -606,7 +1055,7 @@ func TestGRPCClient_ResumeApplyRejectsAmbiguousRemoteDispatchState(t *testing.T)
 
 func TestGRPCClient_ResumeApplyDoesNotFailStateWhenRemoteDispatchOutcomeIsAmbiguous(t *testing.T) {
 	// Cancellation or deadline from the remote Apply RPC does not prove whether
-	// the data plane accepted the schema change. Leave durable state unchanged
+	// the data plane accepted the schema change. Leave stored state unchanged
 	// so the scheduler does not record a false terminal failure.
 	server := &capturingTernServer{
 		applyErr: status.Error(codes.DeadlineExceeded, "deadline waiting for response"),
@@ -813,13 +1262,19 @@ func TestGRPCClient_ResumeApply_ThreadsExternalID(t *testing.T) {
 
 // TestGRPCClient_ResumeApply_SkipsStartWhenNotStopped verifies that ResumeApply
 // checks Tern's real state before calling Start. If Tern says the apply is already
-// completed (local state diverged), Start is skipped and the poller still runs.
+// completed (stored state diverged), Start is skipped and terminal state is
+// reconciled into stored rows.
 func TestGRPCClient_ResumeApply_SkipsStartWhenNotStopped(t *testing.T) {
 	// Progress returns COMPLETED — Tern already finished the apply even though
-	// local state says "stopped". Start should NOT be called.
+	// stored state says "stopped". Start should NOT be called.
 	server := &capturingTernServer{
 		progressState:    ternv1.State_STATE_COMPLETED,
 		progressStateSet: true,
+		progressTables: []*ternv1.TableProgress{{
+			TableName:       "users",
+			Status:          state.Task.Completed,
+			PercentComplete: 100,
+		}},
 	}
 
 	lis, err := (&net.ListenConfig{}).Listen(t.Context(), "tcp", "localhost:0")
@@ -841,11 +1296,25 @@ func TestGRPCClient_ResumeApply_SkipsStartWhenNotStopped(t *testing.T) {
 	defer utils.CloseAndLog(client)
 
 	apply := &storage.Apply{
-		ID:          1,
-		Database:    "testdb",
-		Environment: "staging",
-		ExternalID:  "remote_tern_xyz",
-		State:       state.Apply.Stopped, // local says stopped
+		ID:              1,
+		ApplyIdentifier: "apply-stopped-remote-completed",
+		Database:        "testdb",
+		Environment:     "staging",
+		ExternalID:      "remote_tern_xyz",
+		State:           state.Apply.Stopped, // storage says stopped
+	}
+	storedApply := *apply
+	task := &storage.Task{
+		ID:             11,
+		TaskIdentifier: "task-stopped-remote-completed",
+		ApplyID:        apply.ID,
+		TableName:      "users",
+		State:          state.Task.Stopped,
+	}
+	client.storage = &mockStorage{
+		applies: &mockApplyStore{apply: &storedApply},
+		tasks:   &mockTaskStore{tasks: []*storage.Task{task}},
+		logs:    &mockApplyLogStore{},
 	}
 
 	err = client.ResumeApply(t.Context(), apply)
@@ -860,12 +1329,92 @@ func TestGRPCClient_ResumeApply_SkipsStartWhenNotStopped(t *testing.T) {
 	// State should have been updated from Tern's response.
 	assert.Equal(t, state.Apply.Completed, apply.State,
 		"apply state should reflect Tern's real state")
+	assert.NotNil(t, apply.CompletedAt)
+	assert.Equal(t, state.Task.Completed, task.State)
+	assert.NotNil(t, task.CompletedAt)
+}
+
+func TestGRPCClient_ResumeApplyDoesNotStartWhenStoppedStateCheckFails(t *testing.T) {
+	// A stale stored stopped state is not enough to issue Start. If the remote
+	// state check fails, leave the apply stopped and let a later attempt retry
+	// with a fresh view of the data plane.
+	server := &capturingTernServer{
+		progressErr: status.Error(codes.Unavailable, "remote progress unavailable"),
+	}
+	client, cleanup := testCapturingGRPCClient(t, server)
+	defer cleanup()
+
+	logs := &mockApplyLogStore{}
+	client.storage = &mockStorage{logs: logs}
+	apply := &storage.Apply{
+		ID:              1,
+		ApplyIdentifier: "apply-stopped-check-error",
+		Database:        "testdb",
+		Environment:     "staging",
+		ExternalID:      "remote_tern_xyz",
+		State:           state.Apply.Stopped,
+	}
+
+	err := client.ResumeApply(t.Context(), apply)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "check stopped gRPC apply")
+
+	server.mu.Lock()
+	startCalled := server.startCalled
+	server.mu.Unlock()
+	assert.False(t, startCalled, "Start should not be called when the remote state check fails")
+	assert.Equal(t, state.Apply.Stopped, apply.State)
+	assert.True(t, hasLogMessageContaining(logs.logs, "Remote stopped-state check failed before scheduler start"))
+}
+
+func TestGRPCClient_ResumeApplyFailsWhenStoppedRemoteHasNoActiveProgress(t *testing.T) {
+	// STATE_NO_ACTIVE_CHANGE is inconsistent for an exact stopped apply ID. The
+	// scheduler should not fall back to Start because there is no remote stopped
+	// state to resume.
+	server := &capturingTernServer{
+		progressState:    ternv1.State_STATE_NO_ACTIVE_CHANGE,
+		progressStateSet: true,
+	}
+	client, cleanup := testCapturingGRPCClient(t, server)
+	defer cleanup()
+
+	apply := &storage.Apply{
+		ID:              1,
+		ApplyIdentifier: "apply-stopped-no-active",
+		Database:        "testdb",
+		Environment:     "staging",
+		ExternalID:      "remote-stopped-no-active",
+		State:           state.Apply.Stopped,
+	}
+	task := &storage.Task{
+		ID:             12,
+		TaskIdentifier: "task-stopped-no-active",
+		State:          state.Task.Stopped,
+	}
+	logs := &mockApplyLogStore{}
+	client.storage = &mockStorage{
+		applies: &mockApplyStore{apply: apply},
+		tasks:   &mockTaskStore{tasks: []*storage.Task{task}},
+		logs:    logs,
+	}
+
+	err := client.ResumeApply(t.Context(), apply)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no active schema change")
+
+	server.mu.Lock()
+	startCalled := server.startCalled
+	server.mu.Unlock()
+	assert.False(t, startCalled, "Start should not be called when the remote apply is missing")
+	assert.Equal(t, state.Apply.Stopped, apply.State)
+	assert.Equal(t, state.Task.Stopped, task.State)
+	assert.True(t, hasLogMessageContaining(logs.logs, "Remote stopped-state check returned no active schema change"))
 }
 
 func TestGRPCClient_PollFailsWhenRemoteApplyIsNotFound(t *testing.T) {
 	// A known remote apply ID returning NotFound means the data plane can no
 	// longer report progress for work the control plane believes exists. The
-	// local apply fails so workers do not keep polling a stale remote ID.
+	// stored apply fails so workers do not keep polling a stale remote ID.
 	client, cleanup := testCapturingGRPCClient(t, &capturingTernServer{
 		progressErr: status.Error(codes.NotFound, "apply not found"),
 	})
@@ -906,7 +1455,7 @@ func TestGRPCClient_PollFailsWhenRemoteApplyIsNotFound(t *testing.T) {
 func TestGRPCClient_PollFailsWhenExactRemoteApplyHasNoActiveProgress(t *testing.T) {
 	// STATE_NO_ACTIVE_CHANGE is only valid for database-scoped discovery. An
 	// exact apply-id progress request returning no active work is inconsistent
-	// cross-plane state and should fail the local apply.
+	// cross-plane state and should fail the stored apply.
 	client, cleanup := testCapturingGRPCClient(t, &capturingTernServer{
 		progressState:    ternv1.State_STATE_NO_ACTIVE_CHANGE,
 		progressStateSet: true,
@@ -945,8 +1494,41 @@ func TestGRPCClient_PollFailsWhenExactRemoteApplyHasNoActiveProgress(t *testing.
 	assert.NotNil(t, task.CompletedAt)
 }
 
+func TestGRPCClient_PollFailsWhenRemoteApplyStateIsUnmapped(t *testing.T) {
+	// Unknown remote apply states cannot be reconciled safely. Keep the stored
+	// state unchanged and surface the unmapped state instead of falling back to
+	// the previous stored state.
+	client, cleanup := testCapturingGRPCClient(t, &capturingTernServer{
+		progressState:    ternv1.State(999),
+		progressStateSet: true,
+	})
+	defer cleanup()
+
+	apply := &storage.Apply{
+		ID:              2,
+		ApplyIdentifier: "apply-unmapped-remote-state",
+		Database:        "testdb",
+		Environment:     "development",
+		ExternalID:      "remote-unmapped-state",
+		State:           state.Apply.Running,
+	}
+	logs := &mockApplyLogStore{}
+	client.storage = &mockStorage{
+		applies: &mockApplyStore{apply: apply},
+		logs:    logs,
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+	err := client.pollForCompletion(ctx, apply)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unmapped remote state")
+	assert.Equal(t, state.Apply.Running, apply.State)
+	assert.True(t, hasLogMessageContaining(logs.logs, "Remote progress returned unmapped apply state"))
+}
+
 func TestGRPCClient_RemoteProgressLossDoesNotOverwriteTerminalApply(t *testing.T) {
-	// Remote progress loss can fail the local apply only while the durable
+	// Remote progress loss can fail the stored apply only while the stored
 	// control-plane row is still non-terminal. If storage already has a terminal
 	// state, preserve it instead of overwriting it with a stale remote lookup
 	// failure.


### PR DESCRIPTION
## Summary

- Record gRPC remote apply lifecycle events in SchemaBot control-plane apply logs so dispatch, state transitions, and terminal outcomes are visible from SchemaBot storage.
- Fail closed when a stopped stored apply cannot be confirmed as stopped by remote progress, rather than issuing remote `Start` from stale stored state.
- Treat storage uncertainty while terminalizing remote applies or marking remote failures as a worker error instead of silently proceeding.
- Reconcile terminal remote progress in storage-safe order: copy remote task progress into stored task rows, verify copied task states are resolved, then mark the stored apply terminal.

## Core Flow

```text
Scheduler claims queued apply
        |
        v
SchemaBot control plane
  |-- dispatches Apply RPC to remote Tern
  |-- stores remote apply_id as external_id
  `-- logs dispatch: pending -> running
        |
        v
Remote Tern runs the schema change
        |
        v
SchemaBot polls remote progress
  |
  |-- stopped stored state
  |     |-- confirm the remote apply is stopped before Start
  |     `-- log and return an error when the remote state cannot be trusted
  |
  |-- syncStoredTasksFromRemoteTasks
  |     `-- copy remote task status, row counts, percent, and terminal metadata
  |
  |-- if remote apply is still active
  |     |-- sync apply state
  |     `-- log state transitions
  |
  `-- if remote apply is terminal
        |-- reload stored apply row
        |-- verify stored task rows were resolved from remote task states
        |-- fail/retry if remote task progress is missing or still active
        |-- persist terminal stored apply row
        `-- log terminal outcome

Storage uncertainty or incomplete terminal task progress returns an error so the
scheduler can retry instead of recording partially reconciled state as complete.
```

🤖 Generated by Codex on behalf of @aparajon.