### PR TITLE
fix(grpc): stabilize remote progress sync

### DIFF
--- a/e2e/k8s/data-plane-values.yaml
+++ b/e2e/k8s/data-plane-values.yaml
@@ -8,6 +8,8 @@ image:
   tag: test
   pullPolicy: Never
 
+replicaCount: 2
+
 grpc:
   enabled: true
   port: 13370

--- a/e2e/k8s/k8s_test.go
+++ b/e2e/k8s/k8s_test.go
@@ -49,6 +49,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -58,6 +59,7 @@ import (
 	"github.com/block/schemabot/pkg/apitypes"
 	"github.com/block/schemabot/pkg/cmd/client"
 	"github.com/block/schemabot/pkg/state"
+	"github.com/block/schemabot/pkg/storage"
 	"github.com/block/spirit/pkg/lint"
 	"github.com/block/spirit/pkg/utils"
 	"github.com/stretchr/testify/assert"
@@ -174,20 +176,106 @@ func TestK8s_PlanApply_AddColumn(t *testing.T) {
 	require.NotEmpty(t, prog.Tables, "tables should be present in progress")
 	assert.Equal(t, tableName, prog.Tables[0].TableName, "progress should report the correct table")
 
-	// Verify external_id on the control plane's storage — this is set from the
-	// data plane's apply ID returned over gRPC. Its presence proves the gRPC
-	// Apply() call succeeded and the response was persisted.
+	// Verify lifecycle fields on the control plane's storage. external_id is
+	// the data-plane apply ID returned over gRPC, while started_at/completed_at
+	// prove the control-plane poller persisted the remote lifecycle to storage.
 	sbDB, err := sql.Open("mysql", testutil.SchemabotDSN(t))
 	require.NoError(t, err)
 	defer utils.CloseAndLog(sbDB)
 
-	var externalID string
-	err = sbDB.QueryRowContext(t.Context(),
-		"SELECT external_id FROM applies WHERE apply_identifier = ?",
-		applyResp.ApplyID,
-	).Scan(&externalID)
-	require.NoError(t, err, "query apply record on control plane")
+	externalID, startedAt, completedAt := waitForControlPlaneApplyLifecycle(t, sbDB, applyResp.ApplyID)
 	assert.NotEmpty(t, externalID, "external_id should be set — proves data plane returned its apply ID over gRPC")
+	assert.False(t, completedAt.Before(startedAt), "completed_at should not be before started_at")
+
+	// The control plane owns the operator-facing apply history even though the
+	// data plane executes the schema change. Logs should show dispatch to the
+	// data plane and the terminal state observed by the control-plane poller.
+	waitForControlPlaneApplyLogs(t, ep, applyResp.ApplyID, tableName)
+}
+
+func waitForControlPlaneApplyLifecycle(t *testing.T, db *sql.DB, applyID string) (string, time.Time, time.Time) {
+	t.Helper()
+
+	var externalID string
+	var startedAt, completedAt sql.NullTime
+	var lastErr error
+	testutil.Poll(t, testutil.PollDeadline, testutil.PollInterval,
+		func() bool {
+			lastErr = db.QueryRowContext(t.Context(),
+				"SELECT external_id, started_at, completed_at FROM applies WHERE apply_identifier = ?",
+				applyID,
+			).Scan(&externalID, &startedAt, &completedAt)
+			if lastErr != nil {
+				return false
+			}
+			return externalID != "" && startedAt.Valid && completedAt.Valid && !completedAt.Time.Before(startedAt.Time)
+		},
+		func() string {
+			return fmt.Sprintf("control-plane apply lifecycle was not persisted for %s: external_id=%q started_at=%v completed_at=%v last_err=%v",
+				applyID, externalID, startedAt, completedAt, lastErr)
+		})
+
+	return externalID, startedAt.Time, completedAt.Time
+}
+
+func waitForControlPlaneApplyLogs(t *testing.T, endpoint string, applyID, tableName string) {
+	t.Helper()
+
+	var logs []*client.LogEntry
+	var lastErr error
+	testutil.Poll(t, testutil.PollDeadline, testutil.PollInterval,
+		func() bool {
+			logs, lastErr = client.GetLogs(endpoint, "", "", applyID, 50)
+			return lastErr == nil &&
+				hasLogNewState(logs, "Apply queued", state.Apply.Pending) &&
+				hasLogTransition(logs, "Apply dispatched to remote Tern", state.Apply.Pending, state.Apply.Running) &&
+				hasLogTransition(logs, "Remote apply reached terminal state: completed", state.Apply.Running, state.Apply.Completed) &&
+				hasLogTransitionTo(logs, "Remote task "+tableName+" changed state", state.Task.Completed)
+		},
+		func() string {
+			return fmt.Sprintf("control-plane apply logs did not contain the full remote lifecycle for %s: api_logs=%s last_err=%v",
+				applyID, formatLogEntries(logs), lastErr)
+		})
+}
+
+func hasLogNewState(logs []*client.LogEntry, messageContains, newState string) bool {
+	for _, log := range logs {
+		if strings.Contains(log.Message, messageContains) && log.NewState == newState {
+			return true
+		}
+	}
+	return false
+}
+
+func hasLogTransition(logs []*client.LogEntry, messageContains, oldState, newState string) bool {
+	for _, log := range logs {
+		if strings.Contains(log.Message, messageContains) &&
+			log.EventType == storage.LogEventStateTransition &&
+			log.OldState == oldState &&
+			log.NewState == newState {
+			return true
+		}
+	}
+	return false
+}
+
+func hasLogTransitionTo(logs []*client.LogEntry, messageContains, newState string) bool {
+	for _, log := range logs {
+		if strings.Contains(log.Message, messageContains) &&
+			log.EventType == storage.LogEventStateTransition &&
+			log.NewState == newState {
+			return true
+		}
+	}
+	return false
+}
+
+func formatLogEntries(logs []*client.LogEntry) string {
+	parts := make([]string, 0, len(logs))
+	for _, log := range logs {
+		parts = append(parts, fmt.Sprintf("%s:%s:%s->%s", log.EventType, log.Message, log.OldState, log.NewState))
+	}
+	return strings.Join(parts, " | ")
 }
 
 // TestK8s_PlanApply_CreateTable tests creating a new table through the two-tier path.

--- a/e2e/k8s/k8s_test.go
+++ b/e2e/k8s/k8s_test.go
@@ -45,6 +45,7 @@
 package k8s
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
 	"fmt"
@@ -58,12 +59,15 @@ import (
 	"github.com/block/schemabot/e2e/testutil"
 	"github.com/block/schemabot/pkg/apitypes"
 	"github.com/block/schemabot/pkg/cmd/client"
+	ternv1 "github.com/block/schemabot/pkg/proto/ternv1"
 	"github.com/block/schemabot/pkg/state"
 	"github.com/block/schemabot/pkg/storage"
 	"github.com/block/spirit/pkg/lint"
 	"github.com/block/spirit/pkg/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 func storageDSNs(t *testing.T) []string {
@@ -342,6 +346,83 @@ func TestK8s_Progress(t *testing.T) {
 	assert.Contains(t, prog.Tables[0].DDL, "idx_email", "progress DDL should reference the index being added")
 
 	testutil.WaitForState(t, ep, applyID, state.Apply.Completed, testutil.PollDeadline)
+}
+
+// TestK8s_ProgressStableAcrossDataPlaneReplicas verifies that gRPC progress is
+// stable when a data-plane service has multiple pods. Only one pod owns the
+// in-memory Spirit runner, but every pod must be able to answer Progress from
+// shared storage without downgrading row-copy progress.
+func TestK8s_ProgressStableAcrossDataPlaneReplicas(t *testing.T) {
+	fixture := startRunningIndexAddApply(t, "k8s_dp_replicas")
+	waitForControlPlaneRowCopyProgress(t, fixture.Endpoint, fixture.ApplyID, fixture.TableName)
+
+	pods := podNamesForInstance(t, "data-plane")
+	require.GreaterOrEqual(t, len(pods), 2, "expected k8s e2e data plane to run at least two replicas")
+
+	for _, pod := range pods {
+		addr := startDataPlanePodGRPCPortForward(t, pod)
+		table := waitForDataPlanePodProgress(t, addr, fixture.DataPlaneApplyID, fixture.TableName)
+		assert.Equal(t, fixture.TableName, table.TableName, "data-plane pod %s should report the target table", pod)
+		assert.Positive(t, table.RowsTotal, "data-plane pod %s should preserve row-copy totals", pod)
+		assert.True(t, hasRowCopyProgress(table.RowsTotal, table.RowsCopied, table.PercentComplete), "data-plane pod %s should preserve row-copy progress", pod)
+	}
+
+	testutil.WaitForState(t, fixture.Endpoint, fixture.ApplyID, state.Apply.Completed, 3*time.Minute)
+	waitForIndex(t, fixture.TargetDSN, fixture.TableName, "idx_account_created", testutil.PollDeadline)
+}
+
+func waitForControlPlaneRowCopyProgress(t *testing.T, endpoint, applyID, tableName string) {
+	t.Helper()
+	deadline := time.Now().Add(testutil.PollDeadline)
+	var lastProgress *apitypes.ProgressResponse
+	var lastErr error
+	for time.Now().Before(deadline) {
+		lastProgress, lastErr = testutil.FetchProgress(endpoint, applyID)
+		if lastErr == nil {
+			for _, table := range lastProgress.Tables {
+				if table.TableName == tableName && hasRowCopyProgress(table.RowsTotal, table.RowsCopied, table.PercentComplete) {
+					return
+				}
+			}
+		}
+		time.Sleep(300 * time.Millisecond)
+	}
+	require.Failf(t, "timeout", "timeout waiting for row-copy progress on %s: last_progress=%+v last_err=%v", tableName, lastProgress, lastErr)
+}
+
+func waitForDataPlanePodProgress(t *testing.T, address, applyID, tableName string) *ternv1.TableProgress {
+	t.Helper()
+	conn, err := grpc.NewClient(address, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	defer utils.CloseAndLog(conn)
+	client := ternv1.NewTernClient(conn)
+
+	deadline := time.Now().Add(testutil.PollDeadline)
+	var lastResp *ternv1.ProgressResponse
+	var lastErr error
+	for time.Now().Before(deadline) {
+		ctx, cancel := context.WithTimeout(t.Context(), testutil.ProgressTimeout)
+		lastResp, lastErr = client.Progress(ctx, &ternv1.ProgressRequest{
+			ApplyId:     applyID,
+			Database:    "testapp",
+			Environment: "staging",
+		})
+		cancel()
+		if lastErr == nil {
+			for _, table := range lastResp.Tables {
+				if table.TableName == tableName && hasRowCopyProgress(table.RowsTotal, table.RowsCopied, table.PercentComplete) {
+					return table
+				}
+			}
+		}
+		time.Sleep(300 * time.Millisecond)
+	}
+	require.Failf(t, "timeout", "timeout waiting for data-plane pod %s to preserve row-copy progress for %s: last_resp=%+v last_err=%v", address, tableName, lastResp, lastErr)
+	return nil
+}
+
+func hasRowCopyProgress(rowsTotal, rowsCopied int64, percentComplete int32) bool {
+	return rowsTotal > 0 && (rowsCopied > 0 || percentComplete > 0)
 }
 
 // TestK8s_Scheduler_DataPlanePodRestartRecoversIndexAdd verifies scheduler

--- a/e2e/k8s/kubectl_test.go
+++ b/e2e/k8s/kubectl_test.go
@@ -40,6 +40,20 @@ func crashPod(t *testing.T, instance string) string {
 	return pod
 }
 
+func podNamesForInstance(t *testing.T, instance string) []string {
+	t.Helper()
+	selector := "app.kubernetes.io/instance=" + instance
+	output := runKubectl(t, "get", "pod", "-n", k8sNamespace, "-l", selector, "-o", "jsonpath={range .items[*]}{.metadata.name}{\"\\n\"}{end}")
+	var pods []string
+	for line := range strings.SplitSeq(output, "\n") {
+		pod := strings.TrimSpace(line)
+		if pod != "" {
+			pods = append(pods, pod)
+		}
+	}
+	return pods
+}
+
 func waitForReplacementPodReady(t *testing.T, instance, previousPod string, timeout time.Duration) {
 	t.Helper()
 	selector := "app.kubernetes.io/instance=" + instance
@@ -140,4 +154,21 @@ func startControlPlanePortForward(t *testing.T) string {
 	endpoint := fmt.Sprintf("http://localhost:%d", port)
 	waitForHTTPStatus(t, endpoint+"/health", http.StatusOK, testutil.PollDeadline)
 	return endpoint
+}
+
+func startDataPlanePodGRPCPortForward(t *testing.T, pod string) string {
+	t.Helper()
+	port := freeLocalPort(t)
+	ctx, cancel := context.WithCancel(context.WithoutCancel(t.Context()))
+	cmd := exec.CommandContext(ctx, "kubectl", "port-forward", "-n", k8sNamespace, "pod/"+pod, fmt.Sprintf("%d:13370", port))
+	require.NoError(t, cmd.Start())
+	t.Cleanup(func() {
+		cancel()
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+		}
+		_ = cmd.Wait()
+	})
+
+	return fmt.Sprintf("127.0.0.1:%d", port)
 }

--- a/pkg/tern/grpc_client.go
+++ b/pkg/tern/grpc_client.go
@@ -988,27 +988,85 @@ func (c *GRPCClient) syncStoredTasksFromRemoteTasks(
 	remoteTasks []*ternv1.TableProgress,
 	now time.Time,
 ) error {
+	remoteTaskIndex := indexProtoTableProgress(remoteTasks)
+	missingProgressTasks := 0
 	for _, storedTask := range storedTasks {
-		for _, remoteTask := range remoteTasks {
-			if remoteTask.TableName != storedTask.TableName {
-				continue
-			}
-			oldTaskState := storedTask.State
-			storedTask.State = state.NormalizeTaskStatus(remoteTask.Status)
+		remoteTask, ok := protoProgressForTask(remoteTaskIndex, storedTask)
+		if !ok {
+			missingProgressTasks++
+			continue
+		}
+		oldTaskState := storedTask.State
+		newTaskState := state.NormalizeTaskStatus(remoteTask.Status)
+		if isRemoteTaskStateRegression(storedTask.State, newTaskState) {
+			newTaskState = storedTask.State
+		}
+		storedTask.State = newTaskState
+		if !isWeakerRemoteTaskProgress(storedTask, remoteTask, newTaskState) {
 			storedTask.RowsCopied = remoteTask.RowsCopied
 			storedTask.RowsTotal = remoteTask.RowsTotal
 			storedTask.ProgressPercent = int(remoteTask.PercentComplete)
-			storedTask.UpdatedAt = now
-			if err := c.storage.Tasks().Update(ctx, storedTask); err != nil {
-				return fmt.Errorf("sync task %s from gRPC progress for %s: %w", storedTask.TaskIdentifier, storedApply.ApplyIdentifier, err)
-			}
-			if oldTaskState != storedTask.State {
-				c.logTaskStateTransition(ctx, storedApply.ID, storedTask, fmt.Sprintf("Remote task %s changed state: %s -> %s", storedTask.TableName, oldTaskState, storedTask.State), oldTaskState)
-			}
-			break
+		}
+		storedTask.UpdatedAt = now
+		if err := c.storage.Tasks().Update(ctx, storedTask); err != nil {
+			return fmt.Errorf("sync task %s from gRPC progress for %s: %w", storedTask.TaskIdentifier, storedApply.ApplyIdentifier, err)
+		}
+		if oldTaskState != storedTask.State {
+			c.logTaskStateTransition(ctx, storedApply.ID, storedTask, fmt.Sprintf("Remote task %s changed state: %s -> %s", storedTask.TableName, oldTaskState, storedTask.State), oldTaskState)
 		}
 	}
+	if missingProgressTasks > 0 {
+		slog.Debug("remote gRPC progress omitted stored tasks",
+			"apply_id", storedApply.ApplyIdentifier,
+			"external_id", storedApply.ExternalID,
+			"database", storedApply.Database,
+			"environment", storedApply.Environment,
+			"missing_count", missingProgressTasks)
+	}
 	return nil
+}
+
+func isRemoteTaskStateRegression(currentState, remoteState string) bool {
+	return isProgressedTaskState(currentState) && state.IsState(remoteState, state.Task.Pending)
+}
+
+func isRemoteApplyStateRegression(currentState, remoteState string) bool {
+	return isProgressedApplyState(currentState) && state.IsState(remoteState, state.Apply.Pending)
+}
+
+func isWeakerRemoteTaskProgress(storedTask *storage.Task, remoteTask *ternv1.TableProgress, effectiveRemoteState string) bool {
+	if storedTask == nil || remoteTask == nil {
+		return false
+	}
+	if storedTask.RowsTotal <= 0 || remoteTask.RowsTotal > 0 {
+		return false
+	}
+	return isProgressedTaskState(effectiveRemoteState)
+}
+
+func isProgressedApplyState(applyState string) bool {
+	return state.IsState(applyState,
+		state.Apply.Running,
+		state.Apply.WaitingForDeploy,
+		state.Apply.WaitingForCutover,
+		state.Apply.CuttingOver,
+		state.Apply.RevertWindow,
+		state.Apply.PreparingBranch,
+		state.Apply.ApplyingBranchChanges,
+		state.Apply.ValidatingBranch,
+		state.Apply.CreatingDeployRequest,
+		state.Apply.ValidatingDeployRequest,
+	)
+}
+
+func isProgressedTaskState(taskState string) bool {
+	return state.IsState(taskState,
+		state.Task.Running,
+		state.Task.WaitingForDeploy,
+		state.Task.WaitingForCutover,
+		state.Task.CuttingOver,
+		state.Task.RevertWindow,
+	)
 }
 
 // pollForCompletion polls the remote Tern for progress and updates SchemaBot's storage.
@@ -1071,6 +1129,9 @@ func (c *GRPCClient) pollForCompletion(ctx context.Context, apply *storage.Apply
 					"stored_state", apply.State)
 				c.logApplyWarning(ctx, apply, message)
 				return fmt.Errorf("poll remote gRPC apply %s: unmapped remote state %s", apply.ApplyIdentifier, remoteApplyStateDescription(resp.State))
+			}
+			if isRemoteApplyStateRegression(apply.State, newState) {
+				newState = apply.State
 			}
 			if apply.StartedAt == nil && newState != state.Apply.Pending {
 				apply.StartedAt = &now

--- a/pkg/tern/grpc_client.go
+++ b/pkg/tern/grpc_client.go
@@ -274,6 +274,58 @@ func (c *GRPCClient) clearObserver(applyID int64) {
 	delete(c.observers, applyID)
 }
 
+// logApplyEvent appends a control-plane apply log entry for gRPC applies. The
+// remote Tern service writes its own local logs, but operators read SchemaBot's
+// control-plane apply history from SchemaBot storage.
+func (c *GRPCClient) logApplyEvent(ctx context.Context, applyID int64, taskID *int64, level, eventType, source, message string, oldState, newState string) {
+	logStore := c.storage.ApplyLogs()
+	if logStore == nil {
+		slog.Error("missing apply log store for gRPC apply event",
+			"apply_id", applyID,
+			"event", eventType,
+			"message", message)
+		return
+	}
+	log := &storage.ApplyLog{
+		ApplyID:   applyID,
+		TaskID:    taskID,
+		Level:     level,
+		EventType: eventType,
+		Source:    source,
+		Message:   message,
+		OldState:  oldState,
+		NewState:  newState,
+		CreatedAt: time.Now(),
+	}
+	if err := logStore.Append(ctx, log); err != nil {
+		slog.Error("failed to log gRPC apply event",
+			"apply_id", applyID,
+			"event", eventType,
+			"message", message,
+			"error", err)
+	}
+}
+
+func (c *GRPCClient) logApplyStateTransition(ctx context.Context, apply *storage.Apply, level, message, oldState string) {
+	c.logApplyEvent(ctx, apply.ID, nil, level, storage.LogEventStateTransition, storage.LogSourceSchemaBot,
+		message, oldState, apply.State)
+}
+
+func (c *GRPCClient) logTaskStateTransition(ctx context.Context, applyID int64, task *storage.Task, message, oldState string) {
+	taskID := task.ID
+	c.logApplyEvent(ctx, applyID, &taskID, storage.LogLevelInfo, storage.LogEventStateTransition, storage.LogSourceSchemaBot,
+		message, oldState, task.State)
+}
+
+func (c *GRPCClient) logApplyWarning(ctx context.Context, apply *storage.Apply, message string) {
+	c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelWarn, storage.LogEventError, storage.LogSourceSchemaBot,
+		message, apply.State, apply.State)
+}
+
+func remoteApplyStateDescription(remoteState ternv1.State) string {
+	return fmt.Sprintf("%s(%d)", remoteState.String(), int32(remoteState))
+}
+
 // pollAndNotifyObserver polls storage for apply state changes and notifies the
 // observer. This is the GRPCClient equivalent of LocalClient's progress poller
 // calling the observer — but driven by storage reads instead of engine polling.
@@ -357,7 +409,7 @@ func (c *GRPCClient) Health(ctx context.Context) error {
 
 // ResumeApply runs work claimed by the scheduler. Fresh queued applies have no
 // external_id yet, so this method first dispatches them to remote Tern and
-// stores the returned ID. The call then polls until the apply reaches a durable
+// stores the returned ID. The call then polls until the apply reaches a stored
 // terminal state or the scheduler context is canceled.
 func (c *GRPCClient) ResumeApply(ctx context.Context, apply *storage.Apply) error {
 	if c.storage == nil {
@@ -372,7 +424,9 @@ func (c *GRPCClient) ResumeApply(ctx context.Context, apply *storage.Apply) erro
 	}
 	if hasAmbiguousRemoteDispatchState(apply) {
 		errMsg := fmt.Sprintf("gRPC apply %s is %s without external_id; remote dispatch state is ambiguous", apply.ApplyIdentifier, apply.State)
-		c.markRemoteApplyFailed(ctx, apply, nil, errMsg, false)
+		if err := c.markRemoteApplyFailed(ctx, apply, nil, errMsg, false); err != nil {
+			return fmt.Errorf("%s; persist failure state: %w", errMsg, err)
+		}
 		return errors.New(errMsg)
 	}
 
@@ -393,20 +447,63 @@ func (c *GRPCClient) ResumeApply(ctx context.Context, apply *storage.Apply) erro
 		if err := c.storage.Applies().Update(ctx, apply); err != nil {
 			return fmt.Errorf("update started gRPC apply %s: %w", apply.ApplyIdentifier, err)
 		}
+		c.logApplyStateTransition(ctx, apply, storage.LogLevelInfo, "Remote apply start requested by scheduler", state.Apply.Pending)
 	}
 
-	// Check the real state from Tern before deciding what to do. Local state
-	// may be stale (e.g. local says "stopped" but Tern already resumed).
+	// Check the real state from Tern before deciding what to do. Stored state
+	// may be stale (e.g. storage says "stopped" but Tern already resumed).
 	if apply.State == state.Apply.Stopped {
+		oldState := apply.State
+		startRequested := false
 		resp, err := c.client.Progress(ctx, &ternv1.ProgressRequest{
-			ApplyId:  apply.ExternalID,
-			Database: apply.Database,
+			ApplyId:     apply.ExternalID,
+			Database:    apply.Database,
+			Environment: apply.Environment,
 		})
 		if err == nil {
-			remoteState := ProtoStateToStorage(resp.State)
-			if remoteState != "" {
-				apply.State = remoteState
+			if resp.State == ternv1.State_STATE_NO_ACTIVE_CHANGE {
+				message := fmt.Sprintf("Remote stopped-state check returned no active schema change for remote apply %s; scheduler will not request remote start", apply.ExternalID)
+				slog.Warn("remote gRPC stopped-state check returned no active schema change; scheduler will not request remote start",
+					"apply_id", apply.ApplyIdentifier,
+					"external_id", apply.ExternalID,
+					"database", apply.Database,
+					"environment", apply.Environment,
+					"stored_state", apply.State)
+				c.logApplyWarning(ctx, apply, message)
+				return fmt.Errorf("check stopped gRPC apply %s before start: no active schema change for remote apply %s", apply.ApplyIdentifier, apply.ExternalID)
 			}
+			remoteState := ProtoStateToStorage(resp.State)
+			if remoteState == "" {
+				message := fmt.Sprintf("Remote stopped-state check returned unmapped state %s; scheduler will not request remote start", remoteApplyStateDescription(resp.State))
+				slog.Warn("remote gRPC stopped-state check returned unmapped state; scheduler will not request remote start",
+					"apply_id", apply.ApplyIdentifier,
+					"external_id", apply.ExternalID,
+					"database", apply.Database,
+					"environment", apply.Environment,
+					"remote_state", resp.State.String(),
+					"remote_state_number", int32(resp.State),
+					"stored_state", apply.State)
+				c.logApplyWarning(ctx, apply, message)
+				return fmt.Errorf("check stopped gRPC apply %s before start: unmapped remote state %s", apply.ApplyIdentifier, remoteApplyStateDescription(resp.State))
+			}
+			apply.State = remoteState
+			if isTerminalProtoState(resp.State) && !state.IsState(remoteState, state.Apply.Stopped) {
+				now := time.Now()
+				if apply.StartedAt == nil && remoteState != state.Apply.Pending {
+					apply.StartedAt = &now
+				}
+				return c.handleTerminalRemoteProgress(ctx, apply, resp.Tables, now)
+			}
+		} else {
+			message := fmt.Sprintf("Remote stopped-state check failed before scheduler start: %v", err)
+			slog.Warn("remote gRPC stopped-state check failed; scheduler will not request remote start",
+				"apply_id", apply.ApplyIdentifier,
+				"external_id", apply.ExternalID,
+				"database", apply.Database,
+				"environment", apply.Environment,
+				"error", err)
+			c.logApplyWarning(ctx, apply, message)
+			return fmt.Errorf("check stopped gRPC apply %s before start: %w", apply.ApplyIdentifier, err)
 		}
 
 		// Only call Start if Tern confirms the apply is actually stopped.
@@ -424,10 +521,16 @@ func (c *GRPCClient) ResumeApply(ctx context.Context, apply *storage.Apply) erro
 			if apply.StartedAt == nil {
 				apply.StartedAt = &now
 			}
+			startRequested = true
 		}
 
 		if err := c.storage.Applies().Update(ctx, apply); err != nil {
 			return fmt.Errorf("update apply state: %w", err)
+		}
+		if startRequested {
+			c.logApplyStateTransition(ctx, apply, storage.LogLevelInfo, "Remote apply start requested by scheduler", oldState)
+		} else if oldState != apply.State {
+			c.logApplyStateTransition(ctx, apply, storage.LogLevelInfo, fmt.Sprintf("Remote apply state refreshed before scheduler start: %s -> %s", oldState, apply.State), oldState)
 		}
 	}
 
@@ -453,23 +556,31 @@ func hasAmbiguousRemoteDispatchState(apply *storage.Apply) bool {
 func (c *GRPCClient) dispatchPendingApply(ctx context.Context, apply *storage.Apply) error {
 	plan, err := c.storage.Plans().GetByID(ctx, apply.PlanID)
 	if err != nil {
-		c.markRemoteApplyFailed(ctx, apply, nil, fmt.Sprintf("queued gRPC apply failed: load plan %d: %v", apply.PlanID, err), false)
+		if markErr := c.markRemoteApplyFailed(ctx, apply, nil, fmt.Sprintf("queued gRPC apply failed: load plan %d: %v", apply.PlanID, err), false); markErr != nil {
+			return fmt.Errorf("mark queued gRPC apply %s failed after plan load error: %w", apply.ApplyIdentifier, markErr)
+		}
 		return fmt.Errorf("load plan %d for queued gRPC apply %s: %w", apply.PlanID, apply.ApplyIdentifier, err)
 	}
 	if plan == nil {
 		errMsg := fmt.Sprintf("queued gRPC apply failed: plan %d not found", apply.PlanID)
-		c.markRemoteApplyFailed(ctx, apply, nil, errMsg, false)
+		if markErr := c.markRemoteApplyFailed(ctx, apply, nil, errMsg, false); markErr != nil {
+			return fmt.Errorf("mark queued gRPC apply %s failed after missing plan: %w", apply.ApplyIdentifier, markErr)
+		}
 		return fmt.Errorf("queued gRPC apply %s: %s", apply.ApplyIdentifier, errMsg)
 	}
 
 	tasks, err := c.storage.Tasks().GetByApplyID(ctx, apply.ID)
 	if err != nil {
-		c.markRemoteApplyFailed(ctx, apply, nil, fmt.Sprintf("queued gRPC apply failed: load tasks: %v", err), false)
+		if markErr := c.markRemoteApplyFailed(ctx, apply, nil, fmt.Sprintf("queued gRPC apply failed: load tasks: %v", err), false); markErr != nil {
+			return fmt.Errorf("mark queued gRPC apply %s failed after task load error: %w", apply.ApplyIdentifier, markErr)
+		}
 		return fmt.Errorf("load tasks for queued gRPC apply %s: %w", apply.ApplyIdentifier, err)
 	}
 	if len(tasks) == 0 {
 		errMsg := "queued gRPC apply failed: no tasks found"
-		c.markRemoteApplyFailed(ctx, apply, nil, errMsg, false)
+		if markErr := c.markRemoteApplyFailed(ctx, apply, nil, errMsg, false); markErr != nil {
+			return fmt.Errorf("mark queued gRPC apply %s failed after missing tasks: %w", apply.ApplyIdentifier, markErr)
+		}
 		return fmt.Errorf("queued gRPC apply %s: %s", apply.ApplyIdentifier, errMsg)
 	}
 	if err := c.prepareDispatchTasks(ctx, apply, tasks); err != nil {
@@ -496,12 +607,16 @@ func (c *GRPCClient) dispatchPendingApply(ctx context.Context, apply *storage.Ap
 		if isAmbiguousRemoteApplyDispatchError(err) {
 			return fmt.Errorf("apply queued gRPC apply %s has ambiguous remote dispatch outcome: %w", apply.ApplyIdentifier, err)
 		}
-		c.markRemoteApplyFailed(ctx, apply, tasks, err.Error(), isRetryableRemoteApplyError(err))
+		if markErr := c.markRemoteApplyFailed(ctx, apply, tasks, err.Error(), isRetryableRemoteApplyError(err)); markErr != nil {
+			return fmt.Errorf("mark queued gRPC apply %s failed after remote apply error: %w", apply.ApplyIdentifier, markErr)
+		}
 		return fmt.Errorf("apply queued gRPC apply %s: %w", apply.ApplyIdentifier, err)
 	}
 	if resp == nil {
 		errMsg := "remote apply returned nil response"
-		c.markRemoteApplyFailed(ctx, apply, tasks, errMsg, false)
+		if markErr := c.markRemoteApplyFailed(ctx, apply, tasks, errMsg, false); markErr != nil {
+			return fmt.Errorf("mark queued gRPC apply %s failed after nil response: %w", apply.ApplyIdentifier, markErr)
+		}
 		return fmt.Errorf("apply queued gRPC apply %s: %s", apply.ApplyIdentifier, errMsg)
 	}
 	if !resp.Accepted {
@@ -509,15 +624,20 @@ func (c *GRPCClient) dispatchPendingApply(ctx context.Context, apply *storage.Ap
 		if errMsg == "" {
 			errMsg = "remote apply was not accepted"
 		}
-		c.markRemoteApplyFailed(ctx, apply, tasks, errMsg, false)
+		if markErr := c.markRemoteApplyFailed(ctx, apply, tasks, errMsg, false); markErr != nil {
+			return fmt.Errorf("mark queued gRPC apply %s failed after rejection: %w", apply.ApplyIdentifier, markErr)
+		}
 		return fmt.Errorf("apply queued gRPC apply %s: %s", apply.ApplyIdentifier, errMsg)
 	}
 	if resp.ApplyId == "" {
 		errMsg := "remote apply accepted without apply_id"
-		c.markRemoteApplyFailed(ctx, apply, tasks, errMsg, false)
+		if markErr := c.markRemoteApplyFailed(ctx, apply, tasks, errMsg, false); markErr != nil {
+			return fmt.Errorf("mark queued gRPC apply %s failed after missing remote apply id: %w", apply.ApplyIdentifier, markErr)
+		}
 		return fmt.Errorf("apply queued gRPC apply %s: %s", apply.ApplyIdentifier, errMsg)
 	}
 
+	oldApplyState := apply.State
 	now := time.Now()
 	apply.ExternalID = resp.ApplyId
 	apply.State = state.Apply.Running
@@ -530,6 +650,9 @@ func (c *GRPCClient) dispatchPendingApply(ctx context.Context, apply *storage.Ap
 	if err := c.storage.Applies().Update(ctx, apply); err != nil {
 		return fmt.Errorf("store remote apply id for %s: %w", apply.ApplyIdentifier, err)
 	}
+	c.logApplyStateTransition(ctx, apply, storage.LogLevelInfo,
+		fmt.Sprintf("Apply dispatched to remote Tern: target=%s deployment=%s remote_apply_id=%s", target, apply.Deployment, apply.ExternalID),
+		oldApplyState)
 
 	return c.pollForCompletion(ctx, apply)
 }
@@ -602,6 +725,9 @@ func tasksToProtoTableChanges(tasks []*storage.Task) []*ternv1.TableChange {
 	return changes
 }
 
+// reloadStoredApplyForRemoteTransition reloads the stored apply row before a worker
+// writes a failure or terminal state. Only the ready case may mutate storage;
+// missing or already-terminal rows mean another worker resolved the apply.
 type remoteApplyTransitionSkipReason string
 
 const (
@@ -611,30 +737,30 @@ const (
 	remoteApplyTransitionTerminal     remoteApplyTransitionSkipReason = "already_terminal"
 )
 
-func (c *GRPCClient) reloadRemoteApplyForTransition(ctx context.Context, apply *storage.Apply) (*storage.Apply, remoteApplyTransitionSkipReason, error) {
-	currentApply, err := c.storage.Applies().Get(ctx, apply.ID)
+func (c *GRPCClient) reloadStoredApplyForRemoteTransition(ctx context.Context, remoteApply *storage.Apply) (*storage.Apply, remoteApplyTransitionSkipReason, error) {
+	storedApply, err := c.storage.Applies().Get(ctx, remoteApply.ID)
 	if err != nil {
-		return nil, remoteApplyTransitionReloadFailed, fmt.Errorf("reload remote gRPC apply %s: %w", apply.ApplyIdentifier, err)
+		return nil, remoteApplyTransitionReloadFailed, fmt.Errorf("reload remote gRPC apply %s: %w", remoteApply.ApplyIdentifier, err)
 	}
-	if currentApply == nil {
+	if storedApply == nil {
 		return nil, remoteApplyTransitionMissing, nil
 	}
-	if state.IsTerminalApplyState(currentApply.State) {
-		*apply = *currentApply
-		return currentApply, remoteApplyTransitionTerminal, nil
+	if state.IsTerminalApplyState(storedApply.State) {
+		*remoteApply = *storedApply
+		return storedApply, remoteApplyTransitionTerminal, nil
 	}
-	return currentApply, remoteApplyTransitionReady, nil
+	return storedApply, remoteApplyTransitionReady, nil
 }
 
-func logSkippedRemoteApplyTransition(operation string, apply, currentApply *storage.Apply, reason remoteApplyTransitionSkipReason, err error) {
+func logSkippedRemoteApplyTransition(operation string, remoteApply, storedApply *storage.Apply, reason remoteApplyTransitionSkipReason, err error) {
 	fields := []any{
 		"operation", operation,
-		"apply_id", apply.ApplyIdentifier,
-		"external_id", apply.ExternalID,
+		"apply_id", remoteApply.ApplyIdentifier,
+		"external_id", remoteApply.ExternalID,
 		"reason", reason,
 	}
-	if currentApply != nil {
-		fields = append(fields, "state", currentApply.State)
+	if storedApply != nil {
+		fields = append(fields, "stored_state", storedApply.State)
 	}
 
 	switch reason {
@@ -650,22 +776,22 @@ func logSkippedRemoteApplyTransition(operation string, apply, currentApply *stor
 	}
 }
 
-func (c *GRPCClient) markRemoteApplyFailed(ctx context.Context, apply *storage.Apply, tasks []*storage.Task, message string, retryable bool) {
-	currentApply, skipReason, err := c.reloadRemoteApplyForTransition(ctx, apply)
+func (c *GRPCClient) markRemoteApplyFailed(ctx context.Context, remoteApply *storage.Apply, storedTasks []*storage.Task, message string, retryable bool) error {
+	storedApply, skipReason, err := c.reloadStoredApplyForRemoteTransition(ctx, remoteApply)
 	if skipReason != remoteApplyTransitionReady {
-		logSkippedRemoteApplyTransition("mark remote gRPC apply failed", apply, currentApply, skipReason, err)
-		return
+		logSkippedRemoteApplyTransition("mark remote gRPC apply failed", remoteApply, storedApply, skipReason, err)
+		if err != nil {
+			return err
+		}
+		return nil
 	}
 
 	now := time.Now()
-	if tasks == nil {
+	if storedTasks == nil {
 		var taskErr error
-		tasks, taskErr = c.storage.Tasks().GetByApplyID(ctx, currentApply.ID)
+		storedTasks, taskErr = c.storage.Tasks().GetByApplyID(ctx, storedApply.ID)
 		if taskErr != nil {
-			slog.Error("failed to load tasks after remote gRPC apply failed",
-				"apply_id", currentApply.ApplyIdentifier,
-				"external_id", currentApply.ExternalID,
-				"error", taskErr)
+			return fmt.Errorf("load tasks after remote gRPC apply failed %s: %w", storedApply.ApplyIdentifier, taskErr)
 		}
 	}
 
@@ -675,76 +801,214 @@ func (c *GRPCClient) markRemoteApplyFailed(ctx context.Context, apply *storage.A
 		taskState = state.Task.FailedRetryable
 		applyState = state.Apply.FailedRetryable
 	}
-	for _, task := range tasks {
-		if state.IsTerminalTaskState(task.State) {
+	for _, storedTask := range storedTasks {
+		if state.IsTerminalTaskState(storedTask.State) {
+			slog.Info("leaving terminal gRPC task unchanged after remote apply failure",
+				"apply_id", storedApply.ApplyIdentifier,
+				"task_id", storedTask.TaskIdentifier,
+				"table", storedTask.TableName,
+				"task_state", storedTask.State,
+				"failure_task_state", taskState)
 			continue
 		}
-		task.State = taskState
-		task.ErrorMessage = message
+		storedTask.State = taskState
+		storedTask.ErrorMessage = message
 		if retryable {
-			task.CompletedAt = nil
+			storedTask.CompletedAt = nil
 		} else {
-			task.CompletedAt = &now
+			storedTask.CompletedAt = &now
 		}
-		task.UpdatedAt = now
-		if err := c.storage.Tasks().Update(ctx, task); err != nil {
-			slog.Error("failed to update task after remote gRPC apply failure",
-				"apply_id", currentApply.ApplyIdentifier,
-				"task_id", task.TaskIdentifier,
-				"error", err)
+		storedTask.UpdatedAt = now
+		if err := c.storage.Tasks().Update(ctx, storedTask); err != nil {
+			return fmt.Errorf("update task %s after remote gRPC apply failure %s: %w", storedTask.TaskIdentifier, storedApply.ApplyIdentifier, err)
 		}
 	}
 
-	currentApply.State = applyState
-	currentApply.ErrorMessage = message
+	oldState := storedApply.State
+	storedApply.State = applyState
+	storedApply.ErrorMessage = message
 	if retryable {
-		currentApply.CompletedAt = nil
+		storedApply.CompletedAt = nil
 	} else {
-		currentApply.CompletedAt = &now
+		storedApply.CompletedAt = &now
 	}
-	currentApply.UpdatedAt = now
-	if err := c.storage.Applies().Update(ctx, currentApply); err != nil {
-		slog.Error("failed to update apply after remote gRPC apply failure",
-			"apply_id", currentApply.ApplyIdentifier,
-			"external_id", currentApply.ExternalID,
-			"error", err)
-		return
+	storedApply.UpdatedAt = now
+	if err := c.storage.Applies().Update(ctx, storedApply); err != nil {
+		return fmt.Errorf("update remote gRPC apply failure %s: %w", storedApply.ApplyIdentifier, err)
 	}
-	*apply = *currentApply
-	metrics.AdjustActiveApplies(ctx, -1, currentApply.Database, currentApply.Environment)
+	c.logApplyStateTransition(ctx, storedApply, storage.LogLevelError, fmt.Sprintf("Remote apply failed: %s", message), oldState)
+	*remoteApply = *storedApply
+	metrics.AdjustActiveApplies(ctx, -1, storedApply.Database, storedApply.Environment)
+	return nil
 }
 
-func (c *GRPCClient) failMissingRemoteApply(ctx context.Context, apply *storage.Apply, message string, cause error) error {
-	c.markRemoteApplyFailed(ctx, apply, nil, message, false)
+func (c *GRPCClient) failMissingRemoteApply(ctx context.Context, remoteApply *storage.Apply, message string, cause error) error {
+	if err := c.markRemoteApplyFailed(ctx, remoteApply, nil, message, false); err != nil {
+		return fmt.Errorf("mark missing remote apply %s failed: %w", remoteApply.ApplyIdentifier, err)
+	}
 	if cause != nil {
-		return fmt.Errorf("poll remote apply %s for %s: %w", apply.ExternalID, apply.ApplyIdentifier, cause)
+		return fmt.Errorf("poll remote apply %s for %s: %w", remoteApply.ExternalID, remoteApply.ApplyIdentifier, cause)
 	}
-	return fmt.Errorf("poll remote apply %s for %s: %s", apply.ExternalID, apply.ApplyIdentifier, message)
+	return fmt.Errorf("poll remote apply %s for %s: %s", remoteApply.ExternalID, remoteApply.ApplyIdentifier, message)
 }
 
-func (c *GRPCClient) persistRemoteTerminalApply(ctx context.Context, apply *storage.Apply, now time.Time) bool {
-	currentApply, skipReason, err := c.reloadRemoteApplyForTransition(ctx, apply)
-	if skipReason != remoteApplyTransitionReady {
-		logSkippedRemoteApplyTransition("persist remote terminal apply", apply, currentApply, skipReason, err)
-		return skipReason == remoteApplyTransitionMissing || skipReason == remoteApplyTransitionTerminal
+func (c *GRPCClient) handleTerminalRemoteProgress(ctx context.Context, remoteApply *storage.Apply, remoteTasks []*ternv1.TableProgress, now time.Time) error {
+	remoteApplySnapshot := *remoteApply
+	storedApply, skipReason, err := c.reloadStoredApplyForRemoteTransition(ctx, remoteApply)
+	if skipReason == remoteApplyTransitionTerminal && storedStoppedApplyCanAdoptRemoteApplyState(storedApply, &remoteApplySnapshot) {
+		*remoteApply = remoteApplySnapshot
+		skipReason = remoteApplyTransitionReady
+	}
+	switch skipReason {
+	case remoteApplyTransitionReady:
+		// Keep the stored apply active until stored task rows are written. If
+		// task storage is unavailable, the scheduler can retry this worker
+		// instead of treating a terminal apply as fully reconciled.
+		storedTasks, err := c.storage.Tasks().GetByApplyID(ctx, storedApply.ID)
+		if err != nil {
+			return fmt.Errorf("load tasks to sync terminal gRPC progress for %s: %w", storedApply.ApplyIdentifier, err)
+		}
+		if err := c.syncStoredTasksFromRemoteTasks(ctx, storedApply, storedTasks, remoteTasks, now); err != nil {
+			return err
+		}
+		if err := c.finalizeStoredTasksForTerminalRemoteApply(ctx, remoteApply, storedTasks, now); err != nil {
+			return err
+		}
+		return c.persistTerminalStateFromRemote(ctx, storedApply, remoteApply, now)
+	case remoteApplyTransitionReloadFailed:
+		logSkippedRemoteApplyTransition("persist remote terminal apply", remoteApply, storedApply, skipReason, err)
+		if err != nil {
+			return err
+		}
+		return nil
+	case remoteApplyTransitionMissing, remoteApplyTransitionTerminal:
+		logSkippedRemoteApplyTransition("persist remote terminal apply", remoteApply, storedApply, skipReason, nil)
+		return nil
+	default:
+		logSkippedRemoteApplyTransition("persist remote terminal apply", remoteApply, storedApply, skipReason, nil)
+		return nil
+	}
+}
+
+func storedStoppedApplyCanAdoptRemoteApplyState(storedApply, remoteApply *storage.Apply) bool {
+	return storedApply != nil &&
+		state.IsState(storedApply.State, state.Apply.Stopped) &&
+		!state.IsState(remoteApply.State, state.Apply.Stopped)
+}
+
+func (c *GRPCClient) persistTerminalStateFromRemote(ctx context.Context, storedApply, remoteApply *storage.Apply, now time.Time) error {
+	oldState := storedApply.State
+	storedApply.State = remoteApply.State
+	storedApply.ErrorMessage = remoteApply.ErrorMessage
+	storedApply.StartedAt = remoteApply.StartedAt
+	storedApply.CompletedAt = &now
+	storedApply.UpdatedAt = now
+	if err := c.storage.Applies().Update(ctx, storedApply); err != nil {
+		return fmt.Errorf("update terminal remote gRPC apply %s: %w", storedApply.ApplyIdentifier, err)
+	}
+	c.logApplyStateTransition(ctx, storedApply, storage.LogLevelInfo, fmt.Sprintf("Remote apply reached terminal state: %s", storedApply.State), oldState)
+	*remoteApply = *storedApply
+	metrics.AdjustActiveApplies(ctx, -1, storedApply.Database, storedApply.Environment)
+	return nil
+}
+
+// finalizeStoredTasksForTerminalRemoteApply makes SchemaBot's stored task rows
+// match a terminal remote apply before the stored apply row is marked
+// terminal. remoteApply is the in-memory SchemaBot apply after remote progress
+// supplied a terminal state; it is not a separate remote storage row.
+func (c *GRPCClient) finalizeStoredTasksForTerminalRemoteApply(ctx context.Context, remoteApply *storage.Apply, storedTasks []*storage.Task, now time.Time) error {
+	terminalTaskState := taskStateForTerminalApplyState(remoteApply.State)
+	if terminalTaskState == "" {
+		return nil
 	}
 
-	currentApply.State = apply.State
-	currentApply.ErrorMessage = apply.ErrorMessage
-	currentApply.StartedAt = apply.StartedAt
-	currentApply.CompletedAt = &now
-	currentApply.UpdatedAt = now
-	if err := c.storage.Applies().Update(ctx, currentApply); err != nil {
-		slog.Error("failed to update terminal remote gRPC apply",
-			"apply_id", currentApply.ApplyIdentifier,
-			"external_id", currentApply.ExternalID,
-			"state", currentApply.State,
-			"error", err)
-		return false
+	// Remote Tern reports apply-level finality, plus a best-effort per-table
+	// snapshot. SchemaBot still owns the stored task rows shown in
+	// progress and logs, so this pass makes those rows coherent before the apply
+	// row becomes terminal. For example:
+	// - completed remote apply: unfinished stored task rows become completed, get
+	//   100% progress, and receive completed_at.
+	// - failed/cancelled/reverted remote apply: unfinished stored task rows
+	//   receive the same terminal outcome, so progress does not show active work
+	//   under a terminal apply.
+	// - stopped remote apply: unfinished stored task rows become stopped but remain
+	//   resumable, so completed_at is not set.
+	// A stored task row already terminal with a different result is left
+	// unchanged and logged; another worker or control path has already recorded a
+	// final answer.
+	for _, storedTask := range storedTasks {
+		sameState := state.IsState(storedTask.State, terminalTaskState)
+		if state.IsTerminalTaskState(storedTask.State) && !sameState {
+			slog.Warn("skipping remote gRPC task finalization because task is already terminal with a different state",
+				"apply_id", remoteApply.ApplyIdentifier,
+				"task_id", storedTask.TaskIdentifier,
+				"table", storedTask.TableName,
+				"remote_apply_state", remoteApply.State,
+				"stored_task_state", storedTask.State,
+				"target_task_state", terminalTaskState)
+			continue
+		}
+
+		oldTaskState := storedTask.State
+		changed := false
+		if !sameState {
+			storedTask.State = terminalTaskState
+			changed = true
+		}
+		if terminalTaskState == state.Task.Completed && storedTask.ProgressPercent != 100 {
+			storedTask.ProgressPercent = 100
+			changed = true
+		}
+		if state.IsTerminalTaskState(terminalTaskState) && storedTask.CompletedAt == nil {
+			storedTask.CompletedAt = &now
+			changed = true
+		}
+		if !changed {
+			continue
+		}
+
+		storedTask.UpdatedAt = now
+		if err := c.storage.Tasks().Update(ctx, storedTask); err != nil {
+			return fmt.Errorf("finalize task %s from terminal gRPC apply %s: %w", storedTask.TaskIdentifier, remoteApply.ApplyIdentifier, err)
+		}
+		if oldTaskState != storedTask.State {
+			c.logTaskStateTransition(ctx, remoteApply.ID, storedTask, fmt.Sprintf("Remote task %s changed state: %s -> %s", storedTask.TableName, oldTaskState, storedTask.State), oldTaskState)
+		}
 	}
-	*apply = *currentApply
-	metrics.AdjustActiveApplies(ctx, -1, currentApply.Database, currentApply.Environment)
-	return true
+	return nil
+}
+
+// syncStoredTasksFromRemoteTasks mirrors the per-task table progress fields
+// returned by remote Tern. It only copies the remote task snapshot; terminal
+// apply-level cleanup happens in finalizeStoredTasksForTerminalRemoteApply.
+func (c *GRPCClient) syncStoredTasksFromRemoteTasks(
+	ctx context.Context,
+	storedApply *storage.Apply,
+	storedTasks []*storage.Task,
+	remoteTasks []*ternv1.TableProgress,
+	now time.Time,
+) error {
+	for _, storedTask := range storedTasks {
+		for _, remoteTask := range remoteTasks {
+			if remoteTask.TableName != storedTask.TableName {
+				continue
+			}
+			oldTaskState := storedTask.State
+			storedTask.State = state.NormalizeTaskStatus(remoteTask.Status)
+			storedTask.RowsCopied = remoteTask.RowsCopied
+			storedTask.RowsTotal = remoteTask.RowsTotal
+			storedTask.ProgressPercent = int(remoteTask.PercentComplete)
+			storedTask.UpdatedAt = now
+			if err := c.storage.Tasks().Update(ctx, storedTask); err != nil {
+				return fmt.Errorf("sync task %s from gRPC progress for %s: %w", storedTask.TaskIdentifier, storedApply.ApplyIdentifier, err)
+			}
+			if oldTaskState != storedTask.State {
+				c.logTaskStateTransition(ctx, storedApply.ID, storedTask, fmt.Sprintf("Remote task %s changed state: %s -> %s", storedTask.TableName, oldTaskState, storedTask.State), oldTaskState)
+			}
+			break
+		}
+	}
+	return nil
 }
 
 // pollForCompletion polls the remote Tern for progress and updates SchemaBot's storage.
@@ -790,48 +1054,46 @@ func (c *GRPCClient) pollForCompletion(ctx context.Context, apply *storage.Apply
 				return c.failMissingRemoteApply(ctx, apply, message, nil)
 			}
 
-			// Update apply state based on response (skip if proto state is unspecified)
+			// Update apply state from the remote response. An exact apply-id poll
+			// must return a concrete state; unknown states are unsafe to reconcile.
 			now := time.Now()
-			if newState := ProtoStateToStorage(resp.State); newState != "" {
-				if apply.StartedAt == nil && newState != state.Apply.Pending {
-					apply.StartedAt = &now
-				}
-				apply.State = newState
+			oldApplyState := apply.State
+			newState := ProtoStateToStorage(resp.State)
+			if newState == "" {
+				message := fmt.Sprintf("Remote progress returned unmapped apply state %s; scheduler will retry without changing stored state", remoteApplyStateDescription(resp.State))
+				slog.Warn("remote gRPC progress returned unmapped apply state; scheduler will retry without changing stored state",
+					"apply_id", apply.ApplyIdentifier,
+					"external_id", apply.ExternalID,
+					"database", apply.Database,
+					"environment", apply.Environment,
+					"remote_state", resp.State.String(),
+					"remote_state_number", int32(resp.State),
+					"stored_state", apply.State)
+				c.logApplyWarning(ctx, apply, message)
+				return fmt.Errorf("poll remote gRPC apply %s: unmapped remote state %s", apply.ApplyIdentifier, remoteApplyStateDescription(resp.State))
 			}
+			if apply.StartedAt == nil && newState != state.Apply.Pending {
+				apply.StartedAt = &now
+			}
+			apply.State = newState
 			apply.UpdatedAt = now
-
-			// Update tasks from response. This must happen before the
-			// terminal check so task records get their final state synced
-			// before we return.
-			tasks, err := c.storage.Tasks().GetByApplyID(ctx, apply.ID)
-			if err != nil {
-				return fmt.Errorf("load tasks to sync gRPC progress for %s: %w", apply.ApplyIdentifier, err)
-			}
-			for _, task := range tasks {
-				for _, tp := range resp.Tables {
-					if tp.TableName == task.TableName {
-						task.State = state.NormalizeTaskStatus(tp.Status)
-						task.RowsCopied = tp.RowsCopied
-						task.RowsTotal = tp.RowsTotal
-						task.ProgressPercent = int(tp.PercentComplete)
-						task.UpdatedAt = now
-						if err := c.storage.Tasks().Update(ctx, task); err != nil {
-							return fmt.Errorf("sync task %s from gRPC progress for %s: %w", task.TaskIdentifier, apply.ApplyIdentifier, err)
-						}
-						break
-					}
-				}
-			}
 
 			terminal := isTerminalProtoState(resp.State)
 			if terminal {
-				if c.persistRemoteTerminalApply(ctx, apply, now) {
-					return nil
-				}
-				continue
+				return c.handleTerminalRemoteProgress(ctx, apply, resp.Tables, now)
+			}
+			storedTasks, err := c.storage.Tasks().GetByApplyID(ctx, apply.ID)
+			if err != nil {
+				return fmt.Errorf("load tasks to sync gRPC progress for %s: %w", apply.ApplyIdentifier, err)
+			}
+			if err := c.syncStoredTasksFromRemoteTasks(ctx, apply, storedTasks, resp.Tables, now); err != nil {
+				return err
 			}
 			if err := c.storage.Applies().Update(ctx, apply); err != nil {
 				return fmt.Errorf("sync apply %s from gRPC progress: %w", apply.ApplyIdentifier, err)
+			}
+			if oldApplyState != apply.State {
+				c.logApplyStateTransition(ctx, apply, storage.LogLevelInfo, fmt.Sprintf("Remote apply changed state: %s -> %s", oldApplyState, apply.State), oldApplyState)
 			}
 		}
 	}

--- a/pkg/tern/grpc_client_test.go
+++ b/pkg/tern/grpc_client_test.go
@@ -825,6 +825,172 @@ func TestGRPCClient_PollFinalizesTaskAlreadyTerminalFromRemoteProgress(t *testin
 	require.NotNil(t, task.CompletedAt)
 }
 
+func TestGRPCClient_SyncRemoteProgressByNamespace(t *testing.T) {
+	// Multi-keyspace Vitess applies can report the same table name from more
+	// than one namespace. The control plane must update each task from the
+	// matching namespace/table progress row so PR comments and logs do not show
+	// one keyspace's row-copy progress on another keyspace's task.
+	apply := &storage.Apply{
+		ID:              19,
+		ApplyIdentifier: "apply-namespace-progress",
+		Database:        "testdb",
+		Environment:     "staging",
+		ExternalID:      "remote-namespace-progress",
+		State:           state.Apply.Running,
+	}
+	firstTask := &storage.Task{
+		ID:             31,
+		TaskIdentifier: "task-commerce-orders",
+		ApplyID:        apply.ID,
+		Namespace:      "commerce_sharded",
+		TableName:      "orders",
+		State:          state.Task.Pending,
+	}
+	secondTask := &storage.Task{
+		ID:             32,
+		TaskIdentifier: "task-commerce-006-orders",
+		ApplyID:        apply.ID,
+		Namespace:      "commerce_sharded_006",
+		TableName:      "orders",
+		State:          state.Task.Pending,
+	}
+	client := &GRPCClient{
+		storage: &mockStorage{
+			applies: &mockApplyStore{apply: apply},
+			tasks:   &mockTaskStore{tasks: []*storage.Task{firstTask, secondTask}},
+			logs:    &mockApplyLogStore{},
+		},
+	}
+
+	err := client.syncStoredTasksFromRemoteTasks(t.Context(), apply, []*storage.Task{firstTask, secondTask}, []*ternv1.TableProgress{
+		{
+			Namespace:       "commerce_sharded",
+			TableName:       "orders",
+			Status:          state.Task.Running,
+			RowsCopied:      100,
+			RowsTotal:       1000,
+			PercentComplete: 10,
+		},
+		{
+			Namespace:       "commerce_sharded_006",
+			TableName:       "orders",
+			Status:          state.Task.Running,
+			RowsCopied:      800,
+			RowsTotal:       1000,
+			PercentComplete: 80,
+		},
+	}, time.Now())
+	require.NoError(t, err)
+
+	assert.Equal(t, state.Task.Running, firstTask.State)
+	assert.Equal(t, int64(100), firstTask.RowsCopied)
+	assert.Equal(t, 10, firstTask.ProgressPercent)
+	assert.Equal(t, state.Task.Running, secondTask.State)
+	assert.Equal(t, int64(800), secondTask.RowsCopied)
+	assert.Equal(t, 80, secondTask.ProgressPercent)
+}
+
+func TestGRPCClient_SyncRemoteProgressKeepsLastUsefulRows(t *testing.T) {
+	// Remote gRPC progress is a lossy signal: a different data-plane pod, or a
+	// momentary engine response without table counters, can report the task as
+	// running without row-copy totals. The control plane keeps the last durable
+	// row-copy progress so PR comments do not regress from a progress bar to a
+	// generic running line.
+	apply := &storage.Apply{
+		ID:              20,
+		ApplyIdentifier: "apply-progress-regression",
+		Database:        "testdb",
+		Environment:     "staging",
+		ExternalID:      "remote-progress-regression",
+		State:           state.Apply.Running,
+	}
+	task := &storage.Task{
+		ID:              33,
+		TaskIdentifier:  "task-progress-regression",
+		ApplyID:         apply.ID,
+		Namespace:       "default",
+		TableName:       "orders",
+		State:           state.Task.Running,
+		RowsCopied:      950,
+		RowsTotal:       1000,
+		ProgressPercent: 95,
+	}
+	client := &GRPCClient{
+		storage: &mockStorage{
+			tasks: &mockTaskStore{tasks: []*storage.Task{task}},
+			logs:  &mockApplyLogStore{},
+		},
+	}
+
+	err := client.syncStoredTasksFromRemoteTasks(t.Context(), apply, []*storage.Task{task}, []*ternv1.TableProgress{
+		{
+			Namespace:       "default",
+			TableName:       "orders",
+			Status:          state.Task.Running,
+			RowsCopied:      0,
+			RowsTotal:       0,
+			PercentComplete: 0,
+		},
+	}, time.Now())
+	require.NoError(t, err)
+
+	assert.Equal(t, state.Task.Running, task.State)
+	assert.Equal(t, int64(950), task.RowsCopied)
+	assert.Equal(t, int64(1000), task.RowsTotal)
+	assert.Equal(t, 95, task.ProgressPercent)
+}
+
+func TestGRPCClient_SyncRemoteProgressDoesNotMoveActiveTaskBackToPending(t *testing.T) {
+	// Multi-pod data planes can answer progress from a pod that sees the
+	// stored task row but does not own the in-memory engine runner. A weaker
+	// pending response must not move an already-running control-plane task
+	// backward in the state machine.
+	apply := &storage.Apply{
+		ID:              21,
+		ApplyIdentifier: "apply-state-regression",
+		Database:        "testdb",
+		Environment:     "staging",
+		ExternalID:      "remote-state-regression",
+		State:           state.Apply.Running,
+	}
+	task := &storage.Task{
+		ID:             34,
+		TaskIdentifier: "task-state-regression",
+		ApplyID:        apply.ID,
+		Namespace:      "default",
+		TableName:      "orders",
+		State:          state.Task.Running,
+		RowsCopied:     950,
+		RowsTotal:      1000,
+	}
+	client := &GRPCClient{
+		storage: &mockStorage{
+			tasks: &mockTaskStore{tasks: []*storage.Task{task}},
+			logs:  &mockApplyLogStore{},
+		},
+	}
+
+	err := client.syncStoredTasksFromRemoteTasks(t.Context(), apply, []*storage.Task{task}, []*ternv1.TableProgress{
+		{
+			Namespace: "default",
+			TableName: "orders",
+			Status:    state.Task.Pending,
+		},
+	}, time.Now())
+	require.NoError(t, err)
+
+	assert.Equal(t, state.Task.Running, task.State)
+	assert.Equal(t, int64(950), task.RowsCopied)
+	assert.Equal(t, int64(1000), task.RowsTotal)
+}
+
+func TestGRPCClient_RemoteApplyStateRegression(t *testing.T) {
+	assert.True(t, isRemoteApplyStateRegression(state.Apply.Running, state.Apply.Pending))
+	assert.True(t, isRemoteApplyStateRegression(state.Apply.WaitingForCutover, state.Apply.Pending))
+	assert.False(t, isRemoteApplyStateRegression(state.Apply.Pending, state.Apply.Pending))
+	assert.False(t, isRemoteApplyStateRegression(state.Apply.Running, state.Apply.Completed))
+}
+
 func hasLogMessageContaining(logs []*storage.ApplyLog, want string) bool {
 	for _, log := range logs {
 		if strings.Contains(log.Message, want) {

--- a/pkg/tern/grpc_client_test.go
+++ b/pkg/tern/grpc_client_test.go
@@ -2,9 +2,11 @@ package tern
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"net"
 	"os"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -339,6 +341,8 @@ type capturingTernServer struct {
 	progressApplyID  string
 	progressState    ternv1.State // state returned by Progress; 0 = STATE_COMPLETED
 	progressStateSet bool
+	progressStates   []ternv1.State
+	progressTables   []*ternv1.TableProgress
 	progressErr      error
 	startCalled      bool // tracks whether Start was actually invoked
 }
@@ -373,6 +377,12 @@ func (s *capturingTernServer) Progress(_ context.Context, req *ternv1.ProgressRe
 	s.progressApplyID = req.ApplyId
 	ps := s.progressState
 	psSet := s.progressStateSet
+	if len(s.progressStates) > 0 {
+		ps = s.progressStates[0]
+		s.progressStates = s.progressStates[1:]
+		psSet = true
+	}
+	tables := s.progressTables
 	err := s.progressErr
 	s.mu.Unlock()
 	if err != nil {
@@ -381,7 +391,7 @@ func (s *capturingTernServer) Progress(_ context.Context, req *ternv1.ProgressRe
 	if !psSet {
 		ps = ternv1.State_STATE_COMPLETED
 	}
-	return &ternv1.ProgressResponse{State: ps}, nil
+	return &ternv1.ProgressResponse{State: ps, Tables: tables}, nil
 }
 
 func (s *capturingTernServer) getStartApplyID() string {
@@ -405,7 +415,8 @@ func (s *capturingTernServer) getApplyRequest() *ternv1.ApplyRequest {
 // mockApplyStore is a minimal ApplyStore for testing ResumeApply.
 type mockApplyStore struct {
 	storage.ApplyStore
-	apply *storage.Apply
+	apply     *storage.Apply
+	updateErr error
 }
 
 func (m *mockApplyStore) Get(context.Context, int64) (*storage.Apply, error) {
@@ -416,6 +427,9 @@ func (m *mockApplyStore) Get(context.Context, int64) (*storage.Apply, error) {
 	return &apply, nil
 }
 func (m *mockApplyStore) Update(_ context.Context, apply *storage.Apply) error {
+	if m.updateErr != nil {
+		return m.updateErr
+	}
 	stored := *apply
 	m.apply = &stored
 	return nil
@@ -425,13 +439,32 @@ func (m *mockApplyStore) Heartbeat(context.Context, int64) error { return nil }
 // mockTaskStore is a minimal TaskStore for testing pollForCompletion.
 type mockTaskStore struct {
 	storage.TaskStore
-	tasks []*storage.Task
+	tasks           []*storage.Task
+	getByApplyIDErr error
 }
 
 func (m *mockTaskStore) GetByApplyID(context.Context, int64) ([]*storage.Task, error) {
+	if m.getByApplyIDErr != nil {
+		return nil, m.getByApplyIDErr
+	}
 	return m.tasks, nil
 }
 func (m *mockTaskStore) Update(context.Context, *storage.Task) error { return nil }
+
+type mockApplyLogStore struct {
+	storage.ApplyLogStore
+	logs []*storage.ApplyLog
+}
+
+func (m *mockApplyLogStore) Append(_ context.Context, log *storage.ApplyLog) error {
+	stored := *log
+	m.logs = append(m.logs, &stored)
+	return nil
+}
+
+func (m *mockApplyLogStore) GetByApply(context.Context, int64) ([]*storage.ApplyLog, error) {
+	return m.logs, nil
+}
 
 type mockPlanStore struct {
 	storage.PlanStore
@@ -448,6 +481,7 @@ type mockStorage struct {
 	applies *mockApplyStore
 	tasks   *mockTaskStore
 	plans   *mockPlanStore
+	logs    *mockApplyLogStore
 }
 
 func (m *mockStorage) Applies() storage.ApplyStore {
@@ -467,6 +501,12 @@ func (m *mockStorage) Plans() storage.PlanStore {
 		return m.plans
 	}
 	return &mockPlanStore{}
+}
+func (m *mockStorage) ApplyLogs() storage.ApplyLogStore {
+	if m.logs != nil {
+		return m.logs
+	}
+	return &mockApplyLogStore{}
 }
 
 func testCapturingGRPCClient(t *testing.T, server *capturingTernServer) (*GRPCClient, func()) {
@@ -496,7 +536,7 @@ func testCapturingGRPCClient(t *testing.T, server *capturingTernServer) (*GRPCCl
 }
 
 func TestGRPCClient_ResumeApplyDispatchesQueuedRemoteApply(t *testing.T) {
-	// Scheduler claims start with a durable control-plane apply and pending
+	// Scheduler claims start with a stored control-plane apply row and pending
 	// tasks but no external_id. ResumeApply dispatches the queued work to
 	// remote Tern, stores the returned data-plane ID, then polls it to terminal.
 	server := &capturingTernServer{remoteApplyID: "remote-dispatched-123"}
@@ -557,6 +597,389 @@ func TestGRPCClient_ResumeApplyDispatchesQueuedRemoteApply(t *testing.T) {
 	assert.Equal(t, "remote-dispatched-123", server.getProgressApplyID())
 }
 
+func TestGRPCClient_ResumeApplyLogsRemoteLifecycle(t *testing.T) {
+	// gRPC mode keeps the stored apply history in the control plane. When the
+	// scheduler dispatches work to a remote Tern service, operators should still
+	// see the dispatch and final state through SchemaBot apply logs.
+	server := &capturingTernServer{
+		remoteApplyID:  "remote-lifecycle-123",
+		progressStates: []ternv1.State{ternv1.State_STATE_RUNNING, ternv1.State_STATE_COMPLETED},
+	}
+	client, cleanup := testCapturingGRPCClient(t, server)
+	defer cleanup()
+
+	apply := &storage.Apply{
+		ID:              17,
+		ApplyIdentifier: "apply-control-lifecycle",
+		PlanID:          109,
+		Database:        "testdb",
+		DatabaseType:    storage.DatabaseTypeMySQL,
+		Deployment:      "us-west",
+		Environment:     "staging",
+		State:           state.Apply.Pending,
+	}
+	apply.SetOptions(storage.ApplyOptions{Target: "testdb-target"})
+	task := &storage.Task{
+		ID:             21,
+		TaskIdentifier: "task-lifecycle",
+		ApplyID:        apply.ID,
+		TableName:      "users",
+		DDL:            "ALTER TABLE users ADD COLUMN email varchar(255)",
+		DDLAction:      "alter",
+		Namespace:      "default",
+		State:          state.Task.Pending,
+	}
+	logs := &mockApplyLogStore{}
+	client.storage = &mockStorage{
+		applies: &mockApplyStore{apply: apply},
+		tasks:   &mockTaskStore{tasks: []*storage.Task{task}},
+		plans: &mockPlanStore{plan: &storage.Plan{
+			ID:             apply.PlanID,
+			PlanIdentifier: "plan-remote-lifecycle",
+		}},
+		logs: logs,
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 3*time.Second)
+	defer cancel()
+	err := client.ResumeApply(ctx, apply)
+	require.NoError(t, err)
+
+	messages := make([]string, 0, len(logs.logs))
+	for _, log := range logs.logs {
+		messages = append(messages, log.Message)
+	}
+	assert.Contains(t, messages, "Apply dispatched to remote Tern: target=testdb-target deployment=us-west remote_apply_id=remote-lifecycle-123")
+	assert.Contains(t, messages, "Remote task users changed state: pending -> completed")
+	assert.True(t, hasLogMessageContaining(logs.logs, "Remote apply reached terminal state: completed"),
+		"expected final remote apply state in logs: %v", messages)
+	assert.Equal(t, state.Task.Completed, task.State)
+	require.NotNil(t, task.CompletedAt)
+
+	var dispatchLog *storage.ApplyLog
+	for _, log := range logs.logs {
+		if strings.Contains(log.Message, "Apply dispatched to remote Tern") {
+			dispatchLog = log
+			break
+		}
+	}
+	require.NotNil(t, dispatchLog, "dispatch log should be present")
+	assert.Equal(t, state.Apply.Pending, dispatchLog.OldState)
+	assert.Equal(t, state.Apply.Running, dispatchLog.NewState)
+}
+
+func TestGRPCClient_FinalizeStoredTasksForTerminalRemoteApplyScenarios(t *testing.T) {
+	// Terminal remote apply states must leave SchemaBot's stored task rows in a
+	// coherent operator-facing state before the stored apply row becomes terminal.
+	now := time.Date(2026, 5, 25, 12, 0, 0, 0, time.UTC)
+	alreadyCompletedAt := now.Add(-time.Minute)
+	testCases := []struct {
+		name                   string
+		remoteApplyState       string
+		initialStoredTaskState string
+		initialProgress        int
+		initialCompleted       *time.Time
+		wantStoredTaskState    string
+		wantProgress           int
+		wantCompletedAt        bool
+		wantLogMessage         string
+	}{
+		{
+			name:                   "completed remote apply finalizes unfinished stored task row",
+			remoteApplyState:       state.Apply.Completed,
+			initialStoredTaskState: state.Task.Running,
+			initialProgress:        42,
+			wantStoredTaskState:    state.Task.Completed,
+			wantProgress:           100,
+			wantCompletedAt:        true,
+			wantLogMessage:         "Remote task users changed state: running -> completed",
+		},
+		{
+			name:                   "failed remote apply fails unfinished stored task row",
+			remoteApplyState:       state.Apply.Failed,
+			initialStoredTaskState: state.Task.Pending,
+			wantStoredTaskState:    state.Task.Failed,
+			wantCompletedAt:        true,
+			wantLogMessage:         "Remote task users changed state: pending -> failed",
+		},
+		{
+			name:                   "cancelled remote apply cancels unfinished stored task row",
+			remoteApplyState:       state.Apply.Cancelled,
+			initialStoredTaskState: state.Task.Running,
+			wantStoredTaskState:    state.Task.Cancelled,
+			wantCompletedAt:        true,
+			wantLogMessage:         "Remote task users changed state: running -> cancelled",
+		},
+		{
+			name:                   "reverted remote apply reverts unfinished stored task row",
+			remoteApplyState:       state.Apply.Reverted,
+			initialStoredTaskState: state.Task.Running,
+			wantStoredTaskState:    state.Task.Reverted,
+			wantCompletedAt:        true,
+			wantLogMessage:         "Remote task users changed state: running -> reverted",
+		},
+		{
+			name:                   "stopped remote apply leaves stored task row resumable",
+			remoteApplyState:       state.Apply.Stopped,
+			initialStoredTaskState: state.Task.Running,
+			wantStoredTaskState:    state.Task.Stopped,
+			wantCompletedAt:        false,
+			wantLogMessage:         "Remote task users changed state: running -> stopped",
+		},
+		{
+			name:                   "terminal stored task row keeps result despite different remote apply state",
+			remoteApplyState:       state.Apply.Failed,
+			initialStoredTaskState: state.Task.Completed,
+			initialProgress:        100,
+			initialCompleted:       &alreadyCompletedAt,
+			wantStoredTaskState:    state.Task.Completed,
+			wantProgress:           100,
+			wantCompletedAt:        true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			remoteApply := &storage.Apply{
+				ID:              18,
+				ApplyIdentifier: "apply-remote-terminal",
+				State:           tc.remoteApplyState,
+			}
+			storedTask := &storage.Task{
+				ID:              22,
+				TaskIdentifier:  "task-remote-terminal",
+				ApplyID:         remoteApply.ID,
+				TableName:       "users",
+				State:           tc.initialStoredTaskState,
+				ProgressPercent: tc.initialProgress,
+				CompletedAt:     tc.initialCompleted,
+			}
+			logs := &mockApplyLogStore{}
+			client := &GRPCClient{
+				storage: &mockStorage{
+					tasks: &mockTaskStore{tasks: []*storage.Task{storedTask}},
+					logs:  logs,
+				},
+			}
+
+			err := client.finalizeStoredTasksForTerminalRemoteApply(t.Context(), remoteApply, []*storage.Task{storedTask}, now)
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.wantStoredTaskState, storedTask.State)
+			assert.Equal(t, tc.wantProgress, storedTask.ProgressPercent)
+			assert.Equal(t, tc.wantCompletedAt, storedTask.CompletedAt != nil)
+			if tc.wantLogMessage == "" {
+				assert.Empty(t, logs.logs)
+			} else {
+				assert.True(t, hasLogMessageContaining(logs.logs, tc.wantLogMessage))
+			}
+		})
+	}
+}
+
+func TestGRPCClient_PollFinalizesTaskAlreadyTerminalFromRemoteProgress(t *testing.T) {
+	// Terminal remote task progress can mark a stored task completed before the
+	// terminalization pass. The control plane still owns stored terminal
+	// metadata for the task row before the apply is marked completed.
+	client, cleanup := testCapturingGRPCClient(t, &capturingTernServer{
+		progressState:    ternv1.State_STATE_COMPLETED,
+		progressStateSet: true,
+		progressTables: []*ternv1.TableProgress{{
+			TableName:       "users",
+			Status:          state.Task.Completed,
+			PercentComplete: 100,
+		}},
+	})
+	defer cleanup()
+
+	apply := &storage.Apply{
+		ID:              18,
+		ApplyIdentifier: "apply-remote-completed",
+		Database:        "testdb",
+		Environment:     "staging",
+		ExternalID:      "remote-completed",
+		State:           state.Apply.Running,
+	}
+	storedApply := *apply
+	task := &storage.Task{
+		ID:             22,
+		TaskIdentifier: "task-remote-completed",
+		ApplyID:        apply.ID,
+		TableName:      "users",
+		State:          state.Task.Running,
+	}
+	logs := &mockApplyLogStore{}
+	client.storage = &mockStorage{
+		applies: &mockApplyStore{apply: &storedApply},
+		tasks:   &mockTaskStore{tasks: []*storage.Task{task}},
+		logs:    logs,
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+	err := client.pollForCompletion(ctx, apply)
+	require.NoError(t, err)
+
+	assert.Equal(t, state.Task.Completed, task.State)
+	assert.Equal(t, 100, task.ProgressPercent)
+	require.NotNil(t, task.CompletedAt)
+}
+
+func hasLogMessageContaining(logs []*storage.ApplyLog, want string) bool {
+	for _, log := range logs {
+		if strings.Contains(log.Message, want) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestGRPCClient_PollReturnsTerminalStorageUpdateError(t *testing.T) {
+	// A terminal remote state is not enough by itself; the control plane must
+	// persist that terminal state locally before the scheduler worker exits.
+	client, cleanup := testCapturingGRPCClient(t, &capturingTernServer{
+		progressState:    ternv1.State_STATE_COMPLETED,
+		progressStateSet: true,
+	})
+	defer cleanup()
+
+	apply := &storage.Apply{
+		ID:              18,
+		ApplyIdentifier: "apply-terminal-storage-error",
+		Database:        "testdb",
+		Environment:     "staging",
+		ExternalID:      "remote-terminal-storage-error",
+		State:           state.Apply.Running,
+	}
+	storedApply := *apply
+	client.storage = &mockStorage{
+		applies: &mockApplyStore{
+			apply:     &storedApply,
+			updateErr: errors.New("storage unavailable"),
+		},
+		tasks: &mockTaskStore{},
+		logs:  &mockApplyLogStore{},
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+	err := client.pollForCompletion(ctx, apply)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "update terminal remote gRPC apply")
+	assert.Contains(t, err.Error(), "storage unavailable")
+}
+
+func TestGRPCClient_PollKeepsApplyActiveWhenTerminalTaskLoadFails(t *testing.T) {
+	// Terminal remote progress is only fully reconciled once stored task rows are
+	// updated too. If task storage fails, the apply should remain active so a
+	// later scheduler attempt can finish reconciliation.
+	client, cleanup := testCapturingGRPCClient(t, &capturingTernServer{
+		progressState:    ternv1.State_STATE_COMPLETED,
+		progressStateSet: true,
+	})
+	defer cleanup()
+
+	apply := &storage.Apply{
+		ID:              19,
+		ApplyIdentifier: "apply-terminal-task-load-error",
+		Database:        "testdb",
+		Environment:     "staging",
+		ExternalID:      "remote-terminal-task-load-error",
+		State:           state.Apply.Running,
+	}
+	storedApply := *apply
+	applyStore := &mockApplyStore{apply: &storedApply}
+	client.storage = &mockStorage{
+		applies: applyStore,
+		tasks: &mockTaskStore{
+			getByApplyIDErr: errors.New("task storage unavailable"),
+		},
+		logs: &mockApplyLogStore{},
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+	err := client.pollForCompletion(ctx, apply)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "load tasks to sync terminal gRPC progress")
+	assert.Contains(t, err.Error(), "task storage unavailable")
+	assert.Equal(t, state.Apply.Running, applyStore.apply.State)
+	assert.Nil(t, applyStore.apply.CompletedAt)
+}
+
+func TestGRPCClient_PollSkipsTaskFinalizationWhenStoredApplyAlreadyTerminal(t *testing.T) {
+	// A stale worker can receive a terminal remote state after another worker
+	// has already terminalized the stored apply row. In that case the worker must
+	// not rewrite tasks from its stale in-memory apply state.
+	client, cleanup := testCapturingGRPCClient(t, &capturingTernServer{
+		progressState:    ternv1.State_STATE_COMPLETED,
+		progressStateSet: true,
+	})
+	defer cleanup()
+
+	apply := &storage.Apply{
+		ID:              19,
+		ApplyIdentifier: "apply-terminal-race",
+		Database:        "testdb",
+		Environment:     "staging",
+		ExternalID:      "remote-terminal-race",
+		State:           state.Apply.Running,
+	}
+	storedApply := *apply
+	storedApply.State = state.Apply.Failed
+	task := &storage.Task{
+		ID:             23,
+		TaskIdentifier: "task-terminal-race",
+		ApplyID:        apply.ID,
+		TableName:      "users",
+		State:          state.Task.Running,
+	}
+	client.storage = &mockStorage{
+		applies: &mockApplyStore{apply: &storedApply},
+		tasks:   &mockTaskStore{tasks: []*storage.Task{task}},
+		logs:    &mockApplyLogStore{},
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+	err := client.pollForCompletion(ctx, apply)
+	require.NoError(t, err)
+
+	assert.Equal(t, state.Apply.Failed, apply.State)
+	assert.Equal(t, state.Task.Running, task.State)
+	assert.Nil(t, task.CompletedAt)
+}
+
+func TestGRPCClient_MarkRemoteApplyFailedReturnsTaskLoadError(t *testing.T) {
+	// A remote failure is only safe to store after the control plane can update
+	// both apply and task rows. Task storage uncertainty should make the caller
+	// retry instead of leaving unfinished tasks behind.
+	apply := &storage.Apply{
+		ID:              20,
+		ApplyIdentifier: "apply-task-load-error",
+		Database:        "testdb",
+		Environment:     "staging",
+		ExternalID:      "remote-task-load-error",
+		State:           state.Apply.Running,
+	}
+	applyStore := &mockApplyStore{apply: apply}
+	client := &GRPCClient{
+		storage: &mockStorage{
+			applies: applyStore,
+			tasks: &mockTaskStore{
+				getByApplyIDErr: errors.New("task storage unavailable"),
+			},
+			logs: &mockApplyLogStore{},
+		},
+	}
+
+	err := client.markRemoteApplyFailed(t.Context(), apply, nil, "remote failed", false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "load tasks after remote gRPC apply failed")
+	assert.Contains(t, err.Error(), "task storage unavailable")
+	assert.Equal(t, state.Apply.Running, applyStore.apply.State)
+}
+
 func TestGRPCClient_ResumeApplyRejectsAmbiguousRemoteDispatchState(t *testing.T) {
 	// A stale active gRPC apply without an external_id is ambiguous: the prior
 	// worker may have sent the remote Apply RPC and crashed before persisting the
@@ -606,7 +1029,7 @@ func TestGRPCClient_ResumeApplyRejectsAmbiguousRemoteDispatchState(t *testing.T)
 
 func TestGRPCClient_ResumeApplyDoesNotFailStateWhenRemoteDispatchOutcomeIsAmbiguous(t *testing.T) {
 	// Cancellation or deadline from the remote Apply RPC does not prove whether
-	// the data plane accepted the schema change. Leave durable state unchanged
+	// the data plane accepted the schema change. Leave stored state unchanged
 	// so the scheduler does not record a false terminal failure.
 	server := &capturingTernServer{
 		applyErr: status.Error(codes.DeadlineExceeded, "deadline waiting for response"),
@@ -813,10 +1236,11 @@ func TestGRPCClient_ResumeApply_ThreadsExternalID(t *testing.T) {
 
 // TestGRPCClient_ResumeApply_SkipsStartWhenNotStopped verifies that ResumeApply
 // checks Tern's real state before calling Start. If Tern says the apply is already
-// completed (local state diverged), Start is skipped and the poller still runs.
+// completed (stored state diverged), Start is skipped and terminal state is
+// reconciled into stored rows.
 func TestGRPCClient_ResumeApply_SkipsStartWhenNotStopped(t *testing.T) {
 	// Progress returns COMPLETED — Tern already finished the apply even though
-	// local state says "stopped". Start should NOT be called.
+	// stored state says "stopped". Start should NOT be called.
 	server := &capturingTernServer{
 		progressState:    ternv1.State_STATE_COMPLETED,
 		progressStateSet: true,
@@ -841,11 +1265,25 @@ func TestGRPCClient_ResumeApply_SkipsStartWhenNotStopped(t *testing.T) {
 	defer utils.CloseAndLog(client)
 
 	apply := &storage.Apply{
-		ID:          1,
-		Database:    "testdb",
-		Environment: "staging",
-		ExternalID:  "remote_tern_xyz",
-		State:       state.Apply.Stopped, // local says stopped
+		ID:              1,
+		ApplyIdentifier: "apply-stopped-remote-completed",
+		Database:        "testdb",
+		Environment:     "staging",
+		ExternalID:      "remote_tern_xyz",
+		State:           state.Apply.Stopped, // storage says stopped
+	}
+	storedApply := *apply
+	task := &storage.Task{
+		ID:             11,
+		TaskIdentifier: "task-stopped-remote-completed",
+		ApplyID:        apply.ID,
+		TableName:      "users",
+		State:          state.Task.Stopped,
+	}
+	client.storage = &mockStorage{
+		applies: &mockApplyStore{apply: &storedApply},
+		tasks:   &mockTaskStore{tasks: []*storage.Task{task}},
+		logs:    &mockApplyLogStore{},
 	}
 
 	err = client.ResumeApply(t.Context(), apply)
@@ -860,12 +1298,92 @@ func TestGRPCClient_ResumeApply_SkipsStartWhenNotStopped(t *testing.T) {
 	// State should have been updated from Tern's response.
 	assert.Equal(t, state.Apply.Completed, apply.State,
 		"apply state should reflect Tern's real state")
+	assert.NotNil(t, apply.CompletedAt)
+	assert.Equal(t, state.Task.Completed, task.State)
+	assert.NotNil(t, task.CompletedAt)
+}
+
+func TestGRPCClient_ResumeApplyDoesNotStartWhenStoppedStateCheckFails(t *testing.T) {
+	// A stale stored stopped state is not enough to issue Start. If the remote
+	// state check fails, leave the apply stopped and let a later attempt retry
+	// with a fresh view of the data plane.
+	server := &capturingTernServer{
+		progressErr: status.Error(codes.Unavailable, "remote progress unavailable"),
+	}
+	client, cleanup := testCapturingGRPCClient(t, server)
+	defer cleanup()
+
+	logs := &mockApplyLogStore{}
+	client.storage = &mockStorage{logs: logs}
+	apply := &storage.Apply{
+		ID:              1,
+		ApplyIdentifier: "apply-stopped-check-error",
+		Database:        "testdb",
+		Environment:     "staging",
+		ExternalID:      "remote_tern_xyz",
+		State:           state.Apply.Stopped,
+	}
+
+	err := client.ResumeApply(t.Context(), apply)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "check stopped gRPC apply")
+
+	server.mu.Lock()
+	startCalled := server.startCalled
+	server.mu.Unlock()
+	assert.False(t, startCalled, "Start should not be called when the remote state check fails")
+	assert.Equal(t, state.Apply.Stopped, apply.State)
+	assert.True(t, hasLogMessageContaining(logs.logs, "Remote stopped-state check failed before scheduler start"))
+}
+
+func TestGRPCClient_ResumeApplyFailsWhenStoppedRemoteHasNoActiveProgress(t *testing.T) {
+	// STATE_NO_ACTIVE_CHANGE is inconsistent for an exact stopped apply ID. The
+	// scheduler should not fall back to Start because there is no remote stopped
+	// state to resume.
+	server := &capturingTernServer{
+		progressState:    ternv1.State_STATE_NO_ACTIVE_CHANGE,
+		progressStateSet: true,
+	}
+	client, cleanup := testCapturingGRPCClient(t, server)
+	defer cleanup()
+
+	apply := &storage.Apply{
+		ID:              1,
+		ApplyIdentifier: "apply-stopped-no-active",
+		Database:        "testdb",
+		Environment:     "staging",
+		ExternalID:      "remote-stopped-no-active",
+		State:           state.Apply.Stopped,
+	}
+	task := &storage.Task{
+		ID:             12,
+		TaskIdentifier: "task-stopped-no-active",
+		State:          state.Task.Stopped,
+	}
+	logs := &mockApplyLogStore{}
+	client.storage = &mockStorage{
+		applies: &mockApplyStore{apply: apply},
+		tasks:   &mockTaskStore{tasks: []*storage.Task{task}},
+		logs:    logs,
+	}
+
+	err := client.ResumeApply(t.Context(), apply)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no active schema change")
+
+	server.mu.Lock()
+	startCalled := server.startCalled
+	server.mu.Unlock()
+	assert.False(t, startCalled, "Start should not be called when the remote apply is missing")
+	assert.Equal(t, state.Apply.Stopped, apply.State)
+	assert.Equal(t, state.Task.Stopped, task.State)
+	assert.True(t, hasLogMessageContaining(logs.logs, "Remote stopped-state check returned no active schema change"))
 }
 
 func TestGRPCClient_PollFailsWhenRemoteApplyIsNotFound(t *testing.T) {
 	// A known remote apply ID returning NotFound means the data plane can no
 	// longer report progress for work the control plane believes exists. The
-	// local apply fails so workers do not keep polling a stale remote ID.
+	// stored apply fails so workers do not keep polling a stale remote ID.
 	client, cleanup := testCapturingGRPCClient(t, &capturingTernServer{
 		progressErr: status.Error(codes.NotFound, "apply not found"),
 	})
@@ -906,7 +1424,7 @@ func TestGRPCClient_PollFailsWhenRemoteApplyIsNotFound(t *testing.T) {
 func TestGRPCClient_PollFailsWhenExactRemoteApplyHasNoActiveProgress(t *testing.T) {
 	// STATE_NO_ACTIVE_CHANGE is only valid for database-scoped discovery. An
 	// exact apply-id progress request returning no active work is inconsistent
-	// cross-plane state and should fail the local apply.
+	// cross-plane state and should fail the stored apply.
 	client, cleanup := testCapturingGRPCClient(t, &capturingTernServer{
 		progressState:    ternv1.State_STATE_NO_ACTIVE_CHANGE,
 		progressStateSet: true,
@@ -945,8 +1463,41 @@ func TestGRPCClient_PollFailsWhenExactRemoteApplyHasNoActiveProgress(t *testing.
 	assert.NotNil(t, task.CompletedAt)
 }
 
+func TestGRPCClient_PollFailsWhenRemoteApplyStateIsUnmapped(t *testing.T) {
+	// Unknown remote apply states cannot be reconciled safely. Keep the stored
+	// state unchanged and surface the unmapped state instead of falling back to
+	// the previous stored state.
+	client, cleanup := testCapturingGRPCClient(t, &capturingTernServer{
+		progressState:    ternv1.State(999),
+		progressStateSet: true,
+	})
+	defer cleanup()
+
+	apply := &storage.Apply{
+		ID:              2,
+		ApplyIdentifier: "apply-unmapped-remote-state",
+		Database:        "testdb",
+		Environment:     "development",
+		ExternalID:      "remote-unmapped-state",
+		State:           state.Apply.Running,
+	}
+	logs := &mockApplyLogStore{}
+	client.storage = &mockStorage{
+		applies: &mockApplyStore{apply: apply},
+		logs:    logs,
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+	err := client.pollForCompletion(ctx, apply)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unmapped remote state")
+	assert.Equal(t, state.Apply.Running, apply.State)
+	assert.True(t, hasLogMessageContaining(logs.logs, "Remote progress returned unmapped apply state"))
+}
+
 func TestGRPCClient_RemoteProgressLossDoesNotOverwriteTerminalApply(t *testing.T) {
-	// Remote progress loss can fail the local apply only while the durable
+	// Remote progress loss can fail the stored apply only while the stored
 	// control-plane row is still non-terminal. If storage already has a terminal
 	// state, preserve it instead of overwriting it with a stale remote lookup
 	// failure.

--- a/pkg/tern/local_apply.go
+++ b/pkg/tern/local_apply.go
@@ -101,7 +101,7 @@ func (c *LocalClient) tryResolveStaleTask(ctx context.Context, t *storage.Task, 
 
 	// Spirit has no active schema change but task isn't terminal — task is stale.
 	// Crashed or failed without updating storage.
-	if result.Message == "No active schema change" {
+	if result.Message == noActiveSchemaChangeMessage {
 		c.logger.Info("conflict check: cleaning up stale task (no active schema change in engine)",
 			"task_id", t.TaskIdentifier, "storage_state", t.State, "started_at", t.StartedAt)
 		now := time.Now()

--- a/pkg/tern/local_client.go
+++ b/pkg/tern/local_client.go
@@ -106,6 +106,8 @@ import (
 	"github.com/block/schemabot/pkg/storage"
 )
 
+const noActiveSchemaChangeMessage = "No active schema change"
+
 // LocalConfig holds configuration for the local Tern client.
 type LocalConfig struct {
 	// Database is the name of this database.
@@ -774,59 +776,73 @@ func (c *LocalClient) Progress(ctx context.Context, req *ternv1.ProgressRequest)
 		}
 		result, err := eng.Progress(ctx, progressReq)
 		if err == nil {
-			engineResult = result
-			c.logger.Info("Progress: engine returned", "engine_state", result.State, "message", result.Message, "task_id", activeTask.TaskIdentifier, "storage_state", activeTask.State)
-			taskState := taskStateFromProgressResult(result)
+			if isInactiveLocalEngineProgress(c.config.Type, result, activeTask.State) {
+				c.logger.Debug("Progress: ignoring inactive local engine response for active task",
+					"task_id", activeTask.TaskIdentifier,
+					"task_state", activeTask.State,
+					"engine_state", result.State,
+					"message", result.Message)
+			} else {
+				engineResult = result
+				c.logger.Info("Progress: engine returned", "engine_state", result.State, "message", result.Message, "task_id", activeTask.TaskIdentifier, "storage_state", activeTask.State)
+				taskState := taskStateFromProgressResult(result)
 
-			// Only update task state from engine if task is not already in a terminal state.
-			// Terminal states (CANCELLED, COMPLETED, FAILED, etc.) should be preserved -
-			// they represent the final state set by the apply execution.
-			if !state.IsTerminalTaskState(activeTask.State) {
-				activeTask.State = taskState
-				now := time.Now()
-				activeTask.UpdatedAt = now
-				if result.State.IsTerminal() && !state.IsState(taskState, state.Task.FailedRetryable) && activeTask.CompletedAt == nil {
-					activeTask.CompletedAt = &now
-				}
-				if result.State == engine.StateFailed && activeTask.ErrorMessage == "" {
-					activeTask.ErrorMessage = progressFailureMessage(result)
-				}
-				if err := c.storage.Tasks().Update(ctx, activeTask); err != nil {
-					c.logger.Warn("failed to update task state from progress poll", "task_id", activeTask.TaskIdentifier, "state", activeTask.State, "error", err)
-				}
-			}
-
-			// Also update the apply record if the engine reports a terminal state
-			// but the apply hasn't been updated yet. Only do this when ALL tasks
-			// for this apply are terminal — in sequential mode, the engine reports
-			// "completed" per-task, but the apply isn't done until all tasks finish.
-			if result.State.IsTerminal() {
-				retryableFailure := state.IsState(taskState, state.Task.FailedRetryable)
-				allTerminal := !retryableFailure
-				for _, t := range currentApplyTasks {
-					if !state.IsTerminalTaskState(t.State) {
-						allTerminal = false
-						break
+				// Only update task state from engine if task is not already in a terminal state.
+				// Terminal states (CANCELLED, COMPLETED, FAILED, etc.) should be preserved -
+				// they represent the final state set by the apply execution.
+				if !state.IsTerminalTaskState(activeTask.State) {
+					activeTask.State = taskState
+					now := time.Now()
+					activeTask.UpdatedAt = now
+					if result.State.IsTerminal() && !state.IsState(taskState, state.Task.FailedRetryable) && activeTask.CompletedAt == nil {
+						activeTask.CompletedAt = &now
+					}
+					if result.State == engine.StateFailed && activeTask.ErrorMessage == "" {
+						activeTask.ErrorMessage = progressFailureMessage(result)
+					}
+					if err := c.storage.Tasks().Update(ctx, activeTask); err != nil {
+						c.logger.Warn("failed to update task state from progress poll", "task_id", activeTask.TaskIdentifier, "state", activeTask.State, "error", err)
 					}
 				}
-				if retryableFailure || allTerminal {
-					apply, _ := c.storage.Applies().GetByApplyIdentifier(ctx, req.ApplyId)
-					if apply != nil && !state.IsTerminalApplyState(apply.State) {
-						now := time.Now()
-						apply.State = taskStateToApplyState(taskState)
-						if retryableFailure {
-							apply.CompletedAt = nil
-						} else {
-							apply.CompletedAt = &now
+
+				// Also update the apply record if the engine reports a terminal state
+				// but the apply hasn't been updated yet. Only do this when ALL tasks
+				// for this apply are terminal — in sequential mode, the engine reports
+				// "completed" per-task, but the apply isn't done until all tasks finish.
+				if result.State.IsTerminal() {
+					retryableFailure := state.IsState(taskState, state.Task.FailedRetryable)
+					allTerminal := !retryableFailure
+					for _, t := range currentApplyTasks {
+						if !state.IsTerminalTaskState(t.State) {
+							allTerminal = false
+							break
 						}
-						if result.State == engine.StateFailed {
-							apply.ErrorMessage = progressFailureMessage(result)
+					}
+					if retryableFailure || allTerminal {
+						apply, applyErr := c.storage.Applies().Get(ctx, activeTask.ApplyID)
+						if applyErr != nil {
+							return nil, fmt.Errorf("load apply %d after terminal progress: %w", activeTask.ApplyID, applyErr)
 						}
-						apply.UpdatedAt = now
-						if err := c.storage.Applies().Update(ctx, apply); err != nil {
-							c.logger.Warn("failed to update apply from progress poll", "apply_id", apply.ApplyIdentifier, "state", apply.State, "apply_db_id", apply.ID, "error", err)
+						if apply == nil {
+							return nil, fmt.Errorf("load apply %d after terminal progress: %w", activeTask.ApplyID, storage.ErrApplyNotFound)
 						}
-						c.logger.Info("apply state updated from progress polling", "apply_id", apply.ApplyIdentifier, "state", apply.State)
+						if !state.IsTerminalApplyState(apply.State) {
+							now := time.Now()
+							apply.State = taskStateToApplyState(taskState)
+							if retryableFailure {
+								apply.CompletedAt = nil
+							} else {
+								apply.CompletedAt = &now
+							}
+							if result.State == engine.StateFailed {
+								apply.ErrorMessage = progressFailureMessage(result)
+							}
+							apply.UpdatedAt = now
+							if err := c.storage.Applies().Update(ctx, apply); err != nil {
+								c.logger.Warn("failed to update apply from progress poll", "apply_id", apply.ApplyIdentifier, "state", apply.State, "apply_db_id", apply.ID, "error", err)
+							}
+							c.logger.Info("apply state updated from progress polling", "apply_id", apply.ApplyIdentifier, "state", apply.State)
+						}
 					}
 				}
 			}
@@ -1001,6 +1017,15 @@ func (c *LocalClient) Progress(ctx context.Context, req *ternv1.ProgressRequest)
 	}
 
 	return resp, nil
+}
+
+func isInactiveLocalEngineProgress(dbType string, result *engine.ProgressResult, taskState string) bool {
+	if dbType != storage.DatabaseTypeMySQL || result == nil {
+		return false
+	}
+	return result.State == engine.StatePending &&
+		result.Message == noActiveSchemaChangeMessage &&
+		!state.IsState(taskState, state.Task.Pending)
 }
 
 func ensureMetadata(m map[string]string) map[string]string {

--- a/pkg/tern/local_client_test.go
+++ b/pkg/tern/local_client_test.go
@@ -7,7 +7,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/block/schemabot/pkg/engine"
 	ternv1 "github.com/block/schemabot/pkg/proto/ternv1"
+	"github.com/block/schemabot/pkg/state"
 	"github.com/block/schemabot/pkg/storage"
 )
 
@@ -86,4 +88,21 @@ func TestLocalClient_ProgressByApplyIDReturnsNotFoundForMissingApplyData(t *test
 			require.ErrorIs(t, err, tc.wantError)
 		})
 	}
+}
+
+func TestIsInactiveLocalEngineProgress(t *testing.T) {
+	require.True(t, isInactiveLocalEngineProgress(storage.DatabaseTypeMySQL, &engine.ProgressResult{
+		State:   engine.StatePending,
+		Message: noActiveSchemaChangeMessage,
+	}, state.Task.Running))
+
+	require.False(t, isInactiveLocalEngineProgress(storage.DatabaseTypeMySQL, &engine.ProgressResult{
+		State:   engine.StatePending,
+		Message: noActiveSchemaChangeMessage,
+	}, state.Task.Pending))
+
+	require.False(t, isInactiveLocalEngineProgress(storage.DatabaseTypeVitess, &engine.ProgressResult{
+		State:   engine.StatePending,
+		Message: noActiveSchemaChangeMessage,
+	}, state.Task.Running))
 }

--- a/pkg/tern/progress_keys.go
+++ b/pkg/tern/progress_keys.go
@@ -2,6 +2,7 @@ package tern
 
 import (
 	"github.com/block/schemabot/pkg/engine"
+	ternv1 "github.com/block/schemabot/pkg/proto/ternv1"
 	"github.com/block/schemabot/pkg/storage"
 )
 
@@ -21,6 +22,22 @@ func indexEngineTableProgress(tables []engine.TableProgress) map[string]*engine.
 }
 
 func engineProgressForTask(index map[string]*engine.TableProgress, task *storage.Task) (*engine.TableProgress, bool) {
+	tp, ok := index[progressTableKey(task.Namespace, task.TableName)]
+	return tp, ok
+}
+
+func indexProtoTableProgress(tables []*ternv1.TableProgress) map[string]*ternv1.TableProgress {
+	index := make(map[string]*ternv1.TableProgress, len(tables))
+	for _, tp := range tables {
+		if tp == nil {
+			continue
+		}
+		index[progressTableKey(tp.Namespace, tp.TableName)] = tp
+	}
+	return index
+}
+
+func protoProgressForTask(index map[string]*ternv1.TableProgress, task *storage.Task) (*ternv1.TableProgress, bool) {
 	tp, ok := index[progressTableKey(task.Namespace, task.TableName)]
 	return tp, ok
 }

--- a/pkg/tern/state_converters.go
+++ b/pkg/tern/state_converters.go
@@ -48,6 +48,23 @@ func taskStateToApplyState(ts string) string {
 	}
 }
 
+func taskStateForTerminalApplyState(applyState string) string {
+	switch applyState {
+	case state.Apply.Completed:
+		return state.Task.Completed
+	case state.Apply.Failed:
+		return state.Task.Failed
+	case state.Apply.Stopped:
+		return state.Task.Stopped
+	case state.Apply.Cancelled:
+		return state.Task.Cancelled
+	case state.Apply.Reverted:
+		return state.Task.Reverted
+	default:
+		return ""
+	}
+}
+
 // engineStateToStorage converts engine State to a canonical task state string.
 func engineStateToStorage(es engine.State) string {
 	switch es {


### PR DESCRIPTION
## Summary

- Stabilize gRPC progress sync by matching remote table progress with namespace/table keys and avoiding weaker pending responses from downgrading durable state.
- Preserve row-copy counters when remote table progress omits totals, and ignore inactive local MySQL engine progress for tasks that are already active.
- Add unit and k8s e2e coverage for progress stability across multiple data-plane replicas.

🤖 Generated by Codex.