### PR TITLE
test: consolidate polling and wait helpers

### DIFF
--- a/e2e/grpc/helpers_test.go
+++ b/e2e/grpc/helpers_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/block/schemabot/e2e/testutil"
 	"github.com/block/schemabot/pkg/state"
 	"github.com/block/spirit/pkg/utils"
 	_ "github.com/go-sql-driver/mysql"
@@ -247,35 +248,39 @@ func grpcProgressByApplyID(t *testing.T, applyID string) grpcProgressResponse {
 
 func grpcWaitForState(t *testing.T, database, env, expectedState string, timeout time.Duration) {
 	t.Helper()
-	deadline := time.Now().Add(timeout)
 	var lastState string
-	for time.Now().Before(deadline) {
-		prog := grpcProgress(t, database, env)
-		lastState = prog.State
-		if state.IsState(prog.State, expectedState) {
-			return
-		}
-		time.Sleep(500 * time.Millisecond)
-	}
-	require.Failf(t, "timeout", "waiting for state %q, last state: %s", expectedState, lastState)
+	testutil.Poll(t, timeout, 500*time.Millisecond,
+		func() bool {
+			prog := grpcProgress(t, database, env)
+			lastState = prog.State
+			return state.IsState(prog.State, expectedState)
+		},
+		func() string {
+			return fmt.Sprintf("waiting for state %q, last state: %s", expectedState, lastState)
+		},
+	)
 }
 
 func grpcWaitForAnyState(t *testing.T, database, env string, expectedStates []string, timeout time.Duration) string {
 	t.Helper()
-	deadline := time.Now().Add(timeout)
-	var lastState string
-	for time.Now().Before(deadline) {
-		prog := grpcProgress(t, database, env)
-		lastState = prog.State
-		for _, expectedState := range expectedStates {
-			if state.IsState(prog.State, expectedState) {
-				return prog.State
+	var lastState, matched string
+	testutil.Poll(t, timeout, 500*time.Millisecond,
+		func() bool {
+			prog := grpcProgress(t, database, env)
+			lastState = prog.State
+			for _, expectedState := range expectedStates {
+				if state.IsState(prog.State, expectedState) {
+					matched = prog.State
+					return true
+				}
 			}
-		}
-		time.Sleep(500 * time.Millisecond)
-	}
-	require.Failf(t, "timeout", "waiting for any of states %v, last state: %s", expectedStates, lastState)
-	return ""
+			return false
+		},
+		func() string {
+			return fmt.Sprintf("waiting for any of states %v, last state: %s", expectedStates, lastState)
+		},
+	)
+	return matched
 }
 
 // grpcEnsureNoActiveChange cleans up any active schema change for the given database.
@@ -522,26 +527,28 @@ func grpcStatus(t *testing.T) grpcStatusResponse {
 // Set negate to true to wait until the state is NOT the expected state.
 func grpcWaitForStatusState(t *testing.T, applyID, expectedState string, negate bool, timeout time.Duration) {
 	t.Helper()
-	deadline := time.Now().Add(timeout)
 	var lastState string
-	for time.Now().Before(deadline) {
-		s := grpcStatus(t)
-		for i := range s.Applies {
-			if s.Applies[i].ApplyID == applyID {
-				lastState = s.Applies[i].State
-				matched := state.IsState(lastState, expectedState)
-				if (!negate && matched) || (negate && !matched) {
-					return
+	testutil.Poll(t, timeout, 500*time.Millisecond,
+		func() bool {
+			s := grpcStatus(t)
+			for i := range s.Applies {
+				if s.Applies[i].ApplyID == applyID {
+					lastState = s.Applies[i].State
+					matched := state.IsState(lastState, expectedState)
+					if (!negate && matched) || (negate && !matched) {
+						return true
+					}
 				}
 			}
-		}
-		time.Sleep(500 * time.Millisecond)
-	}
-	if negate {
-		require.Failf(t, "timeout", "status still shows %q for apply %s, expected NOT %q", lastState, applyID, expectedState)
-	} else {
-		require.Failf(t, "timeout", "status shows %q for apply %s, expected %q", lastState, applyID, expectedState)
-	}
+			return false
+		},
+		func() string {
+			if negate {
+				return fmt.Sprintf("status still shows %q for apply %s, expected NOT %q", lastState, applyID, expectedState)
+			}
+			return fmt.Sprintf("status shows %q for apply %s, expected %q", lastState, applyID, expectedState)
+		},
+	)
 }
 
 // uniqueGRPCTableName generates a unique table name for test isolation.

--- a/e2e/k8s/kubectl_test.go
+++ b/e2e/k8s/kubectl_test.go
@@ -43,37 +43,40 @@ func crashPod(t *testing.T, instance string) string {
 func waitForReplacementPodReady(t *testing.T, instance, previousPod string, timeout time.Duration) {
 	t.Helper()
 	selector := "app.kubernetes.io/instance=" + instance
-	deadline := time.Now().Add(timeout)
-	for time.Now().Before(deadline) {
-		output := runKubectl(t, "get", "pod", "-n", k8sNamespace, "-l", selector, "-o", "json")
+	testutil.Poll(t, timeout, 500*time.Millisecond,
+		func() bool {
+			output := runKubectl(t, "get", "pod", "-n", k8sNamespace, "-l", selector, "-o", "json")
 
-		var podList struct {
-			Items []struct {
-				Metadata struct {
-					Name string `json:"name"`
-				} `json:"metadata"`
-				Status struct {
-					Conditions []struct {
-						Type   string `json:"type"`
-						Status string `json:"status"`
-					} `json:"conditions"`
-				} `json:"status"`
-			} `json:"items"`
-		}
-		require.NoError(t, json.Unmarshal([]byte(output), &podList))
+			var podList struct {
+				Items []struct {
+					Metadata struct {
+						Name string `json:"name"`
+					} `json:"metadata"`
+					Status struct {
+						Conditions []struct {
+							Type   string `json:"type"`
+							Status string `json:"status"`
+						} `json:"conditions"`
+					} `json:"status"`
+				} `json:"items"`
+			}
+			require.NoError(t, json.Unmarshal([]byte(output), &podList))
 
-		for _, pod := range podList.Items {
-			if pod.Metadata.Name != previousPod {
-				for _, condition := range pod.Status.Conditions {
-					if condition.Type == "Ready" && condition.Status == "True" {
-						return
+			for _, pod := range podList.Items {
+				if pod.Metadata.Name != previousPod {
+					for _, condition := range pod.Status.Conditions {
+						if condition.Type == "Ready" && condition.Status == "True" {
+							return true
+						}
 					}
 				}
 			}
-		}
-		time.Sleep(500 * time.Millisecond)
-	}
-	require.Failf(t, "timeout", "timeout waiting for replacement %s pod after deleting %s", instance, previousPod)
+			return false
+		},
+		func() string {
+			return fmt.Sprintf("timeout waiting for replacement %s pod after deleting %s", instance, previousPod)
+		},
+	)
 }
 
 func waitForTernHealth(t *testing.T, endpoint, deployment, environment string, timeout time.Duration) {
@@ -84,29 +87,29 @@ func waitForTernHealth(t *testing.T, endpoint, deployment, environment string, t
 
 func waitForHTTPStatus(t *testing.T, url string, expectedStatus int, timeout time.Duration) {
 	t.Helper()
-	deadline := time.Now().Add(timeout)
-	var lastStatus int
-	var lastErr error
-	for time.Now().Before(deadline) {
-		ctx, cancel := context.WithTimeout(t.Context(), 3*time.Second)
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-		require.NoError(t, err)
-		resp, err := http.DefaultClient.Do(req)
-		if err == nil {
-			lastStatus = resp.StatusCode
-			closeErr := resp.Body.Close()
-			cancel()
-			require.NoError(t, closeErr)
-			if lastStatus == expectedStatus {
-				return
+	var (
+		lastStatus int
+		lastErr    error
+	)
+	testutil.Poll(t, timeout, 500*time.Millisecond,
+		func() bool {
+			ctx, cancel := context.WithTimeout(t.Context(), 3*time.Second)
+			defer cancel()
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+			require.NoError(t, err)
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				lastErr = err
+				return false
 			}
-		} else {
-			cancel()
-			lastErr = err
-		}
-		time.Sleep(500 * time.Millisecond)
-	}
-	require.Failf(t, "timeout", "timeout waiting for %s to return status %d, last status: %d, last error: %v", url, expectedStatus, lastStatus, lastErr)
+			lastStatus = resp.StatusCode
+			require.NoError(t, resp.Body.Close())
+			return lastStatus == expectedStatus
+		},
+		func() string {
+			return fmt.Sprintf("timeout waiting for %s to return status %d, last status: %d, last error: %v", url, expectedStatus, lastStatus, lastErr)
+		},
+	)
 }
 
 func freeLocalPort(t *testing.T) int {

--- a/e2e/k8s/scheduler_fixtures_test.go
+++ b/e2e/k8s/scheduler_fixtures_test.go
@@ -21,25 +21,24 @@ func waitForIndex(t *testing.T, dsn, tableName, indexName string, timeout time.D
 	defer utils.CloseAndLog(db)
 	require.NoError(t, db.PingContext(t.Context()))
 
-	deadline := time.Now().Add(timeout)
 	var lastErr error
-	for time.Now().Before(deadline) {
-		rows, err := db.QueryContext(t.Context(), fmt.Sprintf("SHOW INDEX FROM `%s` WHERE Key_name = ?", tableName), indexName)
-		if err == nil {
+	testutil.Poll(t, timeout, 500*time.Millisecond,
+		func() bool {
+			rows, err := db.QueryContext(t.Context(), fmt.Sprintf("SHOW INDEX FROM `%s` WHERE Key_name = ?", tableName), indexName)
+			if err != nil {
+				lastErr = err
+				return false
+			}
 			found := rows.Next()
 			require.NoError(t, rows.Close())
-			if found {
-				return
-			}
-		} else {
-			lastErr = err
-		}
-		time.Sleep(500 * time.Millisecond)
-	}
-
-	var tblName, createStmt string
-	_ = db.QueryRowContext(t.Context(), fmt.Sprintf("SHOW CREATE TABLE `%s`", tableName)).Scan(&tblName, &createStmt)
-	require.Failf(t, "timeout", "timeout waiting for index %s on %s, last query error: %v, table structure: %s", indexName, tableName, lastErr, createStmt)
+			return found
+		},
+		func() string {
+			var tblName, createStmt string
+			_ = db.QueryRowContext(t.Context(), fmt.Sprintf("SHOW CREATE TABLE `%s`", tableName)).Scan(&tblName, &createStmt)
+			return fmt.Sprintf("timeout waiting for index %s on %s, last query error: %v, table structure: %s", indexName, tableName, lastErr, createStmt)
+		},
+	)
 }
 
 func markApplyHeartbeatStale(t *testing.T, dsn, applyID, storageName string) {
@@ -75,22 +74,23 @@ func waitForApplyExternalID(t *testing.T, applyID string, timeout time.Duration)
 	defer utils.CloseAndLog(db)
 	require.NoError(t, db.PingContext(t.Context()))
 
-	deadline := time.Now().Add(timeout)
-	var lastErr error
-	for time.Now().Before(deadline) {
-		var externalID string
-		err = db.QueryRowContext(t.Context(),
-			"SELECT external_id FROM applies WHERE apply_identifier = ?",
-			applyID,
-		).Scan(&externalID)
-		if err == nil && externalID != "" {
-			return externalID
-		}
-		lastErr = err
-		time.Sleep(300 * time.Millisecond)
-	}
-	require.Failf(t, "timeout", "timeout waiting for control-plane apply %s to reference the data-plane apply, last error: %v", applyID, lastErr)
-	return ""
+	var (
+		lastErr    error
+		externalID string
+	)
+	testutil.Poll(t, timeout, 300*time.Millisecond,
+		func() bool {
+			lastErr = db.QueryRowContext(t.Context(),
+				"SELECT external_id FROM applies WHERE apply_identifier = ?",
+				applyID,
+			).Scan(&externalID)
+			return lastErr == nil && externalID != ""
+		},
+		func() string {
+			return fmt.Sprintf("timeout waiting for control-plane apply %s to reference the data-plane apply, last error: %v", applyID, lastErr)
+		},
+	)
+	return externalID
 }
 
 type runningIndexApply struct {

--- a/e2e/local/apply_wait_test.go
+++ b/e2e/local/apply_wait_test.go
@@ -5,6 +5,7 @@ package local
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -47,51 +48,33 @@ func fetchApplyState(endpoint, applyID string) (string, error) {
 func waitForApplyState(t *testing.T, endpoint, applyID, expectedState string, timeout time.Duration) {
 	t.Helper()
 	expected := strings.ToLower(expectedState)
-	deadline := time.Now().Add(timeout)
 	var lastState, lastError string
 	start := time.Now()
-	for time.Now().Before(deadline) {
-		ctx, cancel := context.WithTimeout(t.Context(), testutil.ProgressTimeout)
-		result, err := client.GetProgressCtx(ctx, endpoint, applyID)
-		cancel()
-		if err == nil {
+	testutil.Poll(t, timeout, 300*time.Millisecond,
+		func() bool {
+			ctx, cancel := context.WithTimeout(t.Context(), testutil.ProgressTimeout)
+			result, err := client.GetProgressCtx(ctx, endpoint, applyID)
+			cancel()
+			if err != nil {
+				t.Logf("waitForApplyState: %s poll error: %v (elapsed=%s)", applyID, err, time.Since(start))
+				return false
+			}
 			newState := state.NormalizeState(result.State)
 			if newState != lastState {
 				t.Logf("waitForApplyState: %s state=%s (elapsed=%s)", applyID, newState, time.Since(start))
 			}
 			lastState = newState
 			lastError = result.ErrorMessage
-			if lastState == expected {
-				return
-			}
-		} else {
-			t.Logf("waitForApplyState: %s poll error: %v (elapsed=%s)", applyID, err, time.Since(start))
-		}
-		time.Sleep(300 * time.Millisecond)
-	}
-	require.Failf(t, "timeout", "timeout waiting for apply %s state %q after %s, last API state: %q, error: %q", applyID, expectedState, time.Since(start), lastState, lastError)
+			return lastState == expected
+		},
+		func() string {
+			return fmt.Sprintf("timeout waiting for apply %s state %q after %s, last API state: %q, error: %q",
+				applyID, expectedState, time.Since(start), lastState, lastError)
+		},
+	)
 }
 
 func waitForApplyAnyState(t *testing.T, endpoint, applyID string, expectedStates []string, timeout time.Duration) string {
 	t.Helper()
-	expected := make([]string, len(expectedStates))
-	for i, s := range expectedStates {
-		expected[i] = strings.ToLower(s)
-	}
-	deadline := time.Now().Add(timeout)
-	var lastState string
-	for time.Now().Before(deadline) {
-		s, err := fetchApplyState(endpoint, applyID)
-		if err == nil {
-			lastState = s
-			for i, exp := range expected {
-				if s == exp {
-					return expectedStates[i]
-				}
-			}
-		}
-		time.Sleep(300 * time.Millisecond)
-	}
-	require.Failf(t, "timeout", "timeout waiting for apply %s any of states %v, last API state: %q", applyID, expectedStates, lastState)
-	return ""
+	return testutil.WaitForAnyState(t, endpoint, applyID, expectedStates, timeout)
 }

--- a/e2e/local/helpers_test.go
+++ b/e2e/local/helpers_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/block/schemabot/e2e/testutil"
 	"github.com/block/schemabot/pkg/cmd/client"
 	"github.com/block/schemabot/pkg/e2eutil"
 	"github.com/block/schemabot/pkg/state"
@@ -162,46 +163,49 @@ func startE2ESchemaBotServer(t *testing.T, endpoint string) {
 func waitForSchemaBotHealth(t *testing.T, endpoint string, timeout time.Duration) {
 	t.Helper()
 
-	deadline := time.Now().Add(timeout)
 	var lastErr error
-	for time.Now().Before(deadline) {
-		ctx, cancel := context.WithTimeout(t.Context(), 3*time.Second)
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint+"/health", nil)
-		require.NoError(t, err)
-		resp, err := http.DefaultClient.Do(req)
-		cancel()
-		if err == nil {
+	testutil.Poll(t, timeout, 500*time.Millisecond,
+		func() bool {
+			ctx, cancel := context.WithTimeout(t.Context(), 3*time.Second)
+			defer cancel()
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint+"/health", nil)
+			require.NoError(t, err)
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				lastErr = err
+				return false
+			}
 			statusCode := resp.StatusCode
 			require.NoError(t, resp.Body.Close())
 			if statusCode == http.StatusOK {
-				return
+				return true
 			}
 			lastErr = fmt.Errorf("health returned status %d", statusCode)
-		} else {
-			lastErr = err
-		}
-		time.Sleep(500 * time.Millisecond)
-	}
-	require.Failf(t, "timeout", "SchemaBot did not become healthy within %s: %v", timeout, lastErr)
+			return false
+		},
+		func() string {
+			return fmt.Sprintf("SchemaBot did not become healthy within %s: %v", timeout, lastErr)
+		},
+	)
 }
 
 func waitForTableInProgress(t *testing.T, binPath, schemaDir, endpoint, applyID, tableName string, timeout time.Duration) {
 	t.Helper()
-	deadline := time.Now().Add(timeout)
 	var lastOut string
-	for time.Now().Before(deadline) {
-		out, _ := e2eutil.RunCLIWithErrorInDir(t, binPath, schemaDir, "progress",
-			applyID,
-			"--endpoint", endpoint,
-			"--watch=false",
-		)
-		lastOut = out
-		if strings.Contains(e2eutil.StripANSI(out), tableName) {
-			return
-		}
-		time.Sleep(300 * time.Millisecond)
-	}
-	require.Failf(t, "timeout", "timeout waiting for table %s in progress, last output: %s", tableName, lastOut)
+	testutil.Poll(t, timeout, 300*time.Millisecond,
+		func() bool {
+			out, _ := e2eutil.RunCLIWithErrorInDir(t, binPath, schemaDir, "progress",
+				applyID,
+				"--endpoint", endpoint,
+				"--watch=false",
+			)
+			lastOut = out
+			return strings.Contains(e2eutil.StripANSI(out), tableName)
+		},
+		func() string {
+			return fmt.Sprintf("timeout waiting for table %s in progress, last output: %s", tableName, lastOut)
+		},
+	)
 }
 
 func ensureNoActiveChange(t *testing.T, endpoint string) {
@@ -454,21 +458,22 @@ func writeExistingTablesSchema(t *testing.T, schemaDir string) {
 
 func waitForIndex(t *testing.T, db *sql.DB, tableName, indexName string, timeout time.Duration) {
 	t.Helper()
-	deadline := time.Now().Add(timeout)
-	for time.Now().Before(deadline) {
-		rows, err := db.QueryContext(t.Context(), fmt.Sprintf("SHOW INDEX FROM %s WHERE Key_name = ?", tableName), indexName)
-		if err == nil {
-			if rows.Next() {
-				_ = rows.Close()
-				return
+	testutil.Poll(t, timeout, 500*time.Millisecond,
+		func() bool {
+			rows, err := db.QueryContext(t.Context(), fmt.Sprintf("SHOW INDEX FROM %s WHERE Key_name = ?", tableName), indexName)
+			if err != nil {
+				return false
 			}
+			found := rows.Next()
 			_ = rows.Close()
-		}
-		time.Sleep(500 * time.Millisecond)
-	}
-	var tblName, createStmt string
-	_ = db.QueryRowContext(t.Context(), fmt.Sprintf("SHOW CREATE TABLE %s", tableName)).Scan(&tblName, &createStmt)
-	require.Failf(t, "timeout", "timeout waiting for index %s on %s, table structure: %s", indexName, tableName, createStmt)
+			return found
+		},
+		func() string {
+			var tblName, createStmt string
+			_ = db.QueryRowContext(t.Context(), fmt.Sprintf("SHOW CREATE TABLE %s", tableName)).Scan(&tblName, &createStmt)
+			return fmt.Sprintf("timeout waiting for index %s on %s, table structure: %s", indexName, tableName, createStmt)
+		},
+	)
 }
 
 func seedTestRows(t *testing.T, db *sql.DB, tableName string, columns string, valueTemplate string, rowCount int) {

--- a/e2e/local/vitess_test.go
+++ b/e2e/local/vitess_test.go
@@ -1490,24 +1490,25 @@ func createBranchViaLocalScale(t *testing.T, branchName string) {
 	require.Equal(t, http.StatusOK, resp.StatusCode, "CreateBranch failed")
 
 	// Poll until branch is ready
-	deadline := time.Now().Add(testutil.PollDeadline)
-	for time.Now().Before(deadline) {
-		getReq, _ := http.NewRequestWithContext(ctx, http.MethodGet,
-			localscaleURL+"/v1/organizations/localscale-staging/databases/"+vitessDB+"/branches/"+branchName, nil)
-		resp, err := http.DefaultClient.Do(getReq)
-		if err == nil {
+	testutil.Poll(t, testutil.PollDeadline, 500*time.Millisecond,
+		func() bool {
+			getReq, _ := http.NewRequestWithContext(ctx, http.MethodGet,
+				localscaleURL+"/v1/organizations/localscale-staging/databases/"+vitessDB+"/branches/"+branchName, nil)
+			resp, err := http.DefaultClient.Do(getReq)
+			if err != nil {
+				return false
+			}
 			var branch struct {
 				Ready bool `json:"ready"`
 			}
 			_ = json.NewDecoder(resp.Body).Decode(&branch)
 			resp.Body.Close()
-			if branch.Ready {
-				return
-			}
-		}
-		time.Sleep(500 * time.Millisecond)
-	}
-	t.Fatalf("branch %s not ready within deadline", branchName)
+			return branch.Ready
+		},
+		func() string {
+			return fmt.Sprintf("branch %s not ready within deadline", branchName)
+		},
+	)
 }
 
 // TestVitess_Apply_BranchReuse tests the --branch flag for reusing an existing

--- a/e2e/testutil/wait.go
+++ b/e2e/testutil/wait.go
@@ -7,6 +7,7 @@ package testutil
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -22,6 +23,26 @@ const ProgressTimeout = 5 * time.Second
 
 // PollDeadline is the maximum time to wait when polling for a state transition.
 const PollDeadline = 30 * time.Second
+
+// PollInterval is the default sleep between polling attempts for state
+// transitions observed via the progress API.
+const PollInterval = 300 * time.Millisecond
+
+// Poll repeatedly invokes cond every interval until cond returns true or the
+// timeout expires. On timeout the test fails with failureMsg's return value,
+// which is computed lazily so callers can reference state captured by cond via
+// closure (e.g. the most recent observed value).
+func Poll(t *testing.T, timeout, interval time.Duration, cond func() bool, failureMsg func() string) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(interval)
+	}
+	require.Fail(t, "timeout", failureMsg())
+}
 
 // FetchProgress calls the progress API by apply ID and returns the
 // full ProgressResponse with its State normalized.
@@ -41,19 +62,20 @@ func FetchProgress(endpoint, applyID string) (*apitypes.ProgressResponse, error)
 func WaitForState(t *testing.T, endpoint, applyID, expectedState string, timeout time.Duration) {
 	t.Helper()
 	expected := state.NormalizeState(expectedState)
-	deadline := time.Now().Add(timeout)
 	var lastState string
-	for time.Now().Before(deadline) {
-		result, err := FetchProgress(endpoint, applyID)
-		if err == nil {
-			lastState = result.State
-			if result.State == expected {
-				return
+	Poll(t, timeout, PollInterval,
+		func() bool {
+			result, err := FetchProgress(endpoint, applyID)
+			if err != nil {
+				return false
 			}
-		}
-		time.Sleep(300 * time.Millisecond)
-	}
-	require.Failf(t, "timeout", "timeout waiting for apply %s state %q, last state: %q", applyID, expectedState, lastState)
+			lastState = result.State
+			return result.State == expected
+		},
+		func() string {
+			return fmt.Sprintf("timeout waiting for apply %s state %q, last state: %q", applyID, expectedState, lastState)
+		},
+	)
 }
 
 // WaitForAnyState polls the progress API by apply ID until any of the expected
@@ -64,20 +86,25 @@ func WaitForAnyState(t *testing.T, endpoint, applyID string, expectedStates []st
 	for i, s := range expectedStates {
 		expected[i] = state.NormalizeState(s)
 	}
-	deadline := time.Now().Add(timeout)
-	var lastState string
-	for time.Now().Before(deadline) {
-		result, err := FetchProgress(endpoint, applyID)
-		if err == nil {
+	var lastState, matched string
+	Poll(t, timeout, PollInterval,
+		func() bool {
+			result, err := FetchProgress(endpoint, applyID)
+			if err != nil {
+				return false
+			}
 			lastState = result.State
 			for i, exp := range expected {
 				if lastState == exp {
-					return expectedStates[i]
+					matched = expectedStates[i]
+					return true
 				}
 			}
-		}
-		time.Sleep(300 * time.Millisecond)
-	}
-	require.Failf(t, "timeout", "timeout waiting for apply %s any of states %v, last state: %q", applyID, expectedStates, lastState)
-	return ""
+			return false
+		},
+		func() string {
+			return fmt.Sprintf("timeout waiting for apply %s any of states %v, last state: %q", applyID, expectedStates, lastState)
+		},
+	)
+	return matched
 }

--- a/integration/cli_test.go
+++ b/integration/cli_test.go
@@ -14,7 +14,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
-	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -24,8 +23,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/block/schemabot/e2e/testutil"
 	schemabotapi "github.com/block/schemabot/pkg/api"
-	"github.com/block/schemabot/pkg/state"
 	"github.com/block/schemabot/pkg/storage/mysqlstore"
 	"github.com/block/schemabot/pkg/tern"
 )
@@ -809,23 +808,7 @@ func waitForApplyFromOutput(t *testing.T, endpoint, cliOutput, expectedState str
 // waitForAnyStateByApplyID polls the progress API until any of the expected states is reached or timeout.
 func waitForAnyStateByApplyID(t *testing.T, endpoint, applyID string, expectedStates []string, timeout time.Duration) {
 	t.Helper()
-	normalized := make([]string, len(expectedStates))
-	for i, s := range expectedStates {
-		normalized[i] = state.NormalizeState(s)
-	}
-	deadline := time.Now().Add(timeout)
-	var lastState string
-	for time.Now().Before(deadline) {
-		s, err := fetchProgressState(endpoint, applyID)
-		if err == nil {
-			lastState = s
-			if slices.Contains(normalized, s) {
-				return
-			}
-		}
-		time.Sleep(300 * time.Millisecond)
-	}
-	require.Failf(t, "timeout", "timeout waiting for apply %s state %v, last state: %q", applyID, expectedStates, lastState)
+	testutil.WaitForAnyState(t, endpoint, applyID, expectedStates, timeout)
 }
 
 // startSchemaBotLocal starts a SchemaBot server with embedded LocalClient (no gRPC).
@@ -1117,21 +1100,19 @@ func clearStorageDB(t *testing.T, db *sql.DB) {
 
 func waitForHTTP(t *testing.T, url string, timeout time.Duration) {
 	t.Helper()
-
-	deadline := time.Now().Add(timeout)
-	for time.Now().Before(deadline) {
-		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, url, nil)
-		require.NoError(t, err, "create request")
-		resp, err := http.DefaultClient.Do(req)
-		if err == nil {
-			_ = resp.Body.Close()
-			if resp.StatusCode == http.StatusOK {
-				return
+	testutil.Poll(t, timeout, 50*time.Millisecond,
+		func() bool {
+			req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, url, nil)
+			require.NoError(t, err, "create request")
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				return false
 			}
-		}
-		time.Sleep(50 * time.Millisecond)
-	}
-	require.Failf(t, "timeout", "timeout waiting for %s", url)
+			_ = resp.Body.Close()
+			return resp.StatusCode == http.StatusOK
+		},
+		func() string { return "timeout waiting for " + url },
+	)
 }
 
 // TestCLI_Volume tests the volume command validates inputs correctly.

--- a/integration/grpc_integration_test.go
+++ b/integration/grpc_integration_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/block/schemabot/e2e/testutil"
 	schemabotapi "github.com/block/schemabot/pkg/api"
 	ternv1 "github.com/block/schemabot/pkg/proto/ternv1"
 	"github.com/block/schemabot/pkg/state"
@@ -162,20 +163,22 @@ func startSchemaBot(t *testing.T, ternGRPCAddr string) string {
 func waitForStoredExternalID(t *testing.T, applies storage.ApplyStore, applyIdentifier string, timeout time.Duration) *storage.Apply {
 	t.Helper()
 
-	deadline := time.Now().Add(timeout)
-	var storedApply *storage.Apply
-	for time.Now().Before(deadline) {
-		apply, err := applies.GetByApplyIdentifier(t.Context(), applyIdentifier)
-		require.NoError(t, err, "get apply by identifier")
-		if apply != nil && apply.ExternalID != "" {
-			return apply
-		}
-		storedApply = apply
-		time.Sleep(20 * time.Millisecond)
-	}
-	require.NotNil(t, storedApply, "apply %s not found in storage", applyIdentifier)
-	require.Failf(t, "timeout waiting for external_id", "apply %s was not dispatched within %s", applyIdentifier, timeout)
-	return storedApply
+	var result *storage.Apply
+	testutil.Poll(t, timeout, 20*time.Millisecond,
+		func() bool {
+			apply, err := applies.GetByApplyIdentifier(t.Context(), applyIdentifier)
+			require.NoError(t, err, "get apply by identifier")
+			result = apply
+			return apply != nil && apply.ExternalID != ""
+		},
+		func() string {
+			if result == nil {
+				return fmt.Sprintf("apply %s not found in storage within %s", applyIdentifier, timeout)
+			}
+			return fmt.Sprintf("apply %s was not dispatched within %s", applyIdentifier, timeout)
+		},
+	)
+	return result
 }
 
 // TestGRPC_ExternalID_StoredOnApply verifies that when SchemaBot calls a remote
@@ -379,19 +382,19 @@ func TestGRPC_TaskStateUpdatedOnCompletion(t *testing.T) {
 	schemabotAddr := listener.Addr().String()
 
 	// Wait for HTTP server readiness
-	healthDeadline := time.Now().Add(5 * time.Second)
-	for time.Now().Before(healthDeadline) {
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://"+schemabotAddr+"/health", nil)
-		require.NoError(t, err)
-		resp, err := http.DefaultClient.Do(req)
-		if err == nil {
-			_ = resp.Body.Close()
-			if resp.StatusCode == http.StatusOK {
-				break
+	testutil.Poll(t, 5*time.Second, 10*time.Millisecond,
+		func() bool {
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://"+schemabotAddr+"/health", nil)
+			require.NoError(t, err)
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				return false
 			}
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
+			_ = resp.Body.Close()
+			return resp.StatusCode == http.StatusOK
+		},
+		func() string { return "schemabot HTTP server did not become healthy" },
+	)
 
 	// Step 1: Plan — create a new table
 	schemaSQL := `CREATE TABLE task_state_test (
@@ -431,18 +434,17 @@ func TestGRPC_TaskStateUpdatedOnCompletion(t *testing.T) {
 	// waitForState polls the HTTP API (which calls remote Tern's Progress
 	// RPC), but the local storage update happens asynchronously in the poller goroutine.
 	var storedApply *storage.Apply
-	deadline := time.Now().Add(5 * time.Second)
-	for time.Now().Before(deadline) {
-		storedApply, err = schemabotStorage.Applies().GetByApplyIdentifier(ctx, applyID)
-		require.NoError(t, err, "get apply by identifier")
-		require.NotNil(t, storedApply, "apply not found")
-		if storedApply.State == state.Apply.Completed {
-			break
-		}
-		time.Sleep(100 * time.Millisecond)
-	}
-	require.Equal(t, state.Apply.Completed, storedApply.State,
-		"apply record should be completed in local storage")
+	testutil.Poll(t, 5*time.Second, 100*time.Millisecond,
+		func() bool {
+			storedApply, err = schemabotStorage.Applies().GetByApplyIdentifier(ctx, applyID)
+			require.NoError(t, err, "get apply by identifier")
+			require.NotNil(t, storedApply, "apply not found")
+			return storedApply.State == state.Apply.Completed
+		},
+		func() string {
+			return fmt.Sprintf("apply record should be completed in local storage, last state: %q", storedApply.State)
+		},
+	)
 
 	// Step 5: Verify task records in SchemaBot's storage have terminal state.
 	tasks, err := schemabotStorage.Tasks().GetByApplyID(ctx, storedApply.ID)

--- a/integration/hybrid_mode_test.go
+++ b/integration/hybrid_mode_test.go
@@ -22,6 +22,7 @@ import (
 	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/credentials/insecure"
 
+	"github.com/block/schemabot/e2e/testutil"
 	schemabotapi "github.com/block/schemabot/pkg/api"
 	"github.com/block/schemabot/pkg/state"
 	"github.com/block/schemabot/pkg/storage/mysqlstore"
@@ -149,7 +150,7 @@ func TestHybridMode_LocalAndNamedRemoteTargets(t *testing.T) {
 	addr := listener.Addr().String()
 
 	// Wait for server readiness
-	waitForHTTPReady(t, addr, 5*time.Second)
+	waitForHTTP(t, "http://"+addr+"/health", 5*time.Second)
 
 	// =========================================================================
 	// Test 1: Plan for local-mode database (uses LocalClient)
@@ -282,15 +283,16 @@ func TestHybridMode_LocalAndNamedRemoteTargets(t *testing.T) {
 	t.Logf("gRPC apply: external_id=%q (non-empty = gRPC mode confirmed)", grpcApply.ExternalID)
 
 	// Wait for pollForCompletion to sync gRPC apply state to storage
-	deadline := time.Now().Add(5 * time.Second)
-	for time.Now().Before(deadline) {
-		grpcApply, err = schemabotStorage.Applies().GetByApplyIdentifier(ctx, grpcApplyID)
-		require.NoError(t, err, "refresh grpc apply")
-		if grpcApply.State == state.Apply.Completed {
-			break
-		}
-		time.Sleep(100 * time.Millisecond)
-	}
+	testutil.Poll(t, 5*time.Second, 100*time.Millisecond,
+		func() bool {
+			grpcApply, err = schemabotStorage.Applies().GetByApplyIdentifier(ctx, grpcApplyID)
+			require.NoError(t, err, "refresh grpc apply")
+			return grpcApply.State == state.Apply.Completed
+		},
+		func() string {
+			return fmt.Sprintf("gRPC apply should be completed in local storage, last state: %q", grpcApply.State)
+		},
+	)
 	assert.Equal(t, state.Apply.Completed, grpcApply.State,
 		"gRPC apply should be completed in local storage")
 
@@ -435,26 +437,4 @@ func startTernGRPCForDB(t *testing.T, appDSN, dbName string) (string, error) {
 	}
 
 	return grpcAddress, nil
-}
-
-// waitForHTTPReady polls the health endpoint until it returns 200 or the
-// timeout expires.
-func waitForHTTPReady(t *testing.T, addr string, timeout time.Duration) {
-	t.Helper()
-	deadline := time.Now().Add(timeout)
-	for {
-		if time.Now().After(deadline) {
-			require.Fail(t, "timeout waiting for HTTP server readiness")
-		}
-		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://"+addr+"/health", nil)
-		require.NoError(t, err)
-		resp, err := http.DefaultClient.Do(req)
-		if err == nil {
-			_ = resp.Body.Close()
-			if resp.StatusCode == http.StatusOK {
-				return
-			}
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
 }

--- a/integration/resolve_apply_id_test.go
+++ b/integration/resolve_apply_id_test.go
@@ -84,18 +84,8 @@ func TestResolveApplyID_ControlOperations(t *testing.T) {
 	t.Cleanup(func() { utils.CloseAndLog(httpSrv) })
 	baseURL := "http://" + httpLis.Addr().String()
 
-	// Wait for HTTP server to be ready (poll, no sleep).
-	readyDeadline := time.Now().Add(5 * time.Second)
-	for time.Now().Before(readyDeadline) {
-		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/health", nil)
-		if resp, err := http.DefaultClient.Do(req); err == nil {
-			_ = resp.Body.Close()
-			if resp.StatusCode == http.StatusOK {
-				break
-			}
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
+	// Wait for HTTP server to be ready.
+	waitForHTTP(t, baseURL+"/health", 5*time.Second)
 
 	// 3. Plan: create a table with a unique name to avoid conflicts with other tests.
 	tableName := fmt.Sprintf("resolve_%d", time.Now().UnixNano()%100000)

--- a/integration/scheduler_test.go
+++ b/integration/scheduler_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/block/schemabot/e2e/testutil"
 	schemabotapi "github.com/block/schemabot/pkg/api"
 	"github.com/block/schemabot/pkg/proto/ternv1"
 	"github.com/block/schemabot/pkg/state"
@@ -196,16 +197,20 @@ func TestScheduler_BasicClaimAndResume(t *testing.T) {
 	ts.Service.StartScheduler(t.Context())
 	defer ts.Service.StopScheduler()
 
-	deadline := time.Now().Add(20 * time.Second)
-	for time.Now().Before(deadline) {
-		apply, err := ts.Storage.Applies().Get(ctx, staleID)
-		require.NoError(t, err)
-		if apply != nil && apply.State == state.Apply.Completed {
-			return
-		}
-		time.Sleep(500 * time.Millisecond)
-	}
-	t.Fatal("timeout: scheduler did not resume stale apply")
+	var lastState string
+	testutil.Poll(t, 20*time.Second, 500*time.Millisecond,
+		func() bool {
+			apply, err := ts.Storage.Applies().Get(ctx, staleID)
+			require.NoError(t, err)
+			if apply != nil {
+				lastState = apply.State
+			}
+			return apply != nil && apply.State == state.Apply.Completed
+		},
+		func() string {
+			return fmt.Sprintf("scheduler did not resume stale apply %d, last state: %q", staleID, lastState)
+		},
+	)
 }
 
 func TestScheduler_ClaimOrdering(t *testing.T) {
@@ -635,34 +640,33 @@ func seedStaleSchedulerApply(
 func waitForSchedulerAppliesCompleted(t *testing.T, stor *mysqlstore.Storage, applyIDs []int64, timeout time.Duration) {
 	t.Helper()
 
-	deadline := time.Now().Add(timeout)
 	completed := make(map[int64]bool, len(applyIDs))
-	for time.Now().Before(deadline) {
-		for _, applyID := range applyIDs {
-			if completed[applyID] {
-				continue
+	testutil.Poll(t, timeout, 100*time.Millisecond,
+		func() bool {
+			for _, applyID := range applyIDs {
+				if completed[applyID] {
+					continue
+				}
+				apply, err := stor.Applies().Get(t.Context(), applyID)
+				require.NoError(t, err)
+				if apply != nil && apply.State == state.Apply.Completed {
+					completed[applyID] = true
+				}
 			}
-			apply, err := stor.Applies().Get(t.Context(), applyID)
-			require.NoError(t, err)
-			if apply != nil && apply.State == state.Apply.Completed {
-				completed[applyID] = true
+			return len(completed) == len(applyIDs)
+		},
+		func() string {
+			states := make(map[int64]string, len(applyIDs))
+			for _, applyID := range applyIDs {
+				apply, err := stor.Applies().Get(t.Context(), applyID)
+				require.NoError(t, err)
+				if apply != nil {
+					states[applyID] = apply.State
+				}
 			}
-		}
-		if len(completed) == len(applyIDs) {
-			return
-		}
-		time.Sleep(100 * time.Millisecond)
-	}
-
-	states := make(map[int64]string, len(applyIDs))
-	for _, applyID := range applyIDs {
-		apply, err := stor.Applies().Get(t.Context(), applyID)
-		require.NoError(t, err)
-		if apply != nil {
-			states[applyID] = apply.State
-		}
-	}
-	require.Failf(t, "timeout", "scheduler did not complete all applies within %s; states: %v", timeout, states)
+			return fmt.Sprintf("scheduler did not complete all applies within %s; states: %v", timeout, states)
+		},
+	)
 }
 
 func TestScheduler_DatabaseExclusionScopedByEnvironment(t *testing.T) {

--- a/integration/shared_wait_helpers_test.go
+++ b/integration/shared_wait_helpers_test.go
@@ -3,46 +3,15 @@
 package integration
 
 import (
-	"context"
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
-
-	"github.com/block/schemabot/pkg/cmd/client"
-	"github.com/block/schemabot/pkg/state"
+	"github.com/block/schemabot/e2e/testutil"
 )
-
-// progressTimeout is the per-request timeout for progress API polling.
-const progressTimeout = 5 * time.Second
-
-// fetchProgressState calls the progress API by apply ID and returns the normalized state.
-func fetchProgressState(endpoint, applyID string) (string, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), progressTimeout)
-	defer cancel()
-	result, err := client.GetProgressCtx(ctx, endpoint, applyID)
-	if err != nil {
-		return "", err
-	}
-	return state.NormalizeState(result.State), nil
-}
 
 // waitForState polls the progress API by apply ID until the overall state
 // matches expectedState or the timeout expires.
 func waitForState(t *testing.T, endpoint, applyID, expectedState string, timeout time.Duration) {
 	t.Helper()
-	expected := state.NormalizeState(expectedState)
-	deadline := time.Now().Add(timeout)
-	var lastState string
-	for time.Now().Before(deadline) {
-		s, err := fetchProgressState(endpoint, applyID)
-		if err == nil {
-			lastState = s
-			if s == expected {
-				return
-			}
-		}
-		time.Sleep(300 * time.Millisecond)
-	}
-	require.Failf(t, "timeout", "timeout waiting for apply %s state %q, last state: %q", applyID, expectedState, lastState)
+	testutil.WaitForState(t, endpoint, applyID, expectedState, timeout)
 }

--- a/integration/workflow_test.go
+++ b/integration/workflow_test.go
@@ -108,22 +108,7 @@ func startTestServerWithSchedulerInterval(t *testing.T, appDBName, appDSN string
 	addr := listener.Addr().String()
 
 	// Wait for HTTP server readiness
-	deadline := time.Now().Add(5 * time.Second)
-	for {
-		if time.Now().After(deadline) {
-			require.Fail(t, "timeout waiting for HTTP server")
-		}
-		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://"+addr+"/health", nil)
-		require.NoError(t, err)
-		resp, err := http.DefaultClient.Do(req)
-		if err == nil {
-			_ = resp.Body.Close()
-			if resp.StatusCode == http.StatusOK {
-				break
-			}
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
+	waitForHTTP(t, "http://"+addr+"/health", 5*time.Second)
 
 	t.Cleanup(func() {
 		_ = server.Close()

--- a/pkg/localscale/approval_integration_test.go
+++ b/pkg/localscale/approval_integration_test.go
@@ -9,6 +9,8 @@ import (
 	ps "github.com/planetscale/planetscale-go/planetscale"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/block/schemabot/e2e/testutil"
 )
 
 // TestApply_RequireApproval_RejectsDeployment verifies that LocalScale rejects
@@ -32,16 +34,15 @@ func TestApply_RequireApproval_RejectsDeployment(t *testing.T) {
 	require.NoError(t, err)
 
 	// Wait for branch to be ready.
-	deadline := time.Now().Add(15 * time.Second)
-	for time.Now().Before(deadline) {
-		br, brErr := testClient.GetBranch(ctx, &ps.GetDatabaseBranchRequest{
-			Organization: testOrg, Database: "approvaldb", Branch: branchName,
-		})
-		if brErr == nil && br.Ready {
-			break
-		}
-		time.Sleep(500 * time.Millisecond)
-	}
+	testutil.Poll(t, 15*time.Second, 500*time.Millisecond,
+		func() bool {
+			br, brErr := testClient.GetBranch(ctx, &ps.GetDatabaseBranchRequest{
+				Organization: testOrg, Database: "approvaldb", Branch: branchName,
+			})
+			return brErr == nil && br.Ready
+		},
+		func() string { return "branch " + branchName + " did not become ready" },
+	)
 
 	// Apply DDL on branch
 	require.NoError(t, testContainer.SeedDDL(ctx, testOrg, "approvaldb", "testkeyspace",
@@ -58,16 +59,15 @@ func TestApply_RequireApproval_RejectsDeployment(t *testing.T) {
 	require.NotNil(t, dr)
 
 	// Wait for deploy request to be ready (diff computed).
-	deadline = time.Now().Add(15 * time.Second)
-	for time.Now().Before(deadline) {
-		got, getErr := testClient.GetDeployRequest(ctx, &ps.GetDeployRequestRequest{
-			Organization: testOrg, Database: "approvaldb", Number: dr.Number,
-		})
-		if getErr == nil && (got.DeploymentState == "ready" || got.DeploymentState == "no_changes") {
-			break
-		}
-		time.Sleep(500 * time.Millisecond)
-	}
+	testutil.Poll(t, 15*time.Second, 500*time.Millisecond,
+		func() bool {
+			got, getErr := testClient.GetDeployRequest(ctx, &ps.GetDeployRequestRequest{
+				Organization: testOrg, Database: "approvaldb", Number: dr.Number,
+			})
+			return getErr == nil && (got.DeploymentState == "ready" || got.DeploymentState == "no_changes")
+		},
+		func() string { return "deploy request did not become ready" },
+	)
 
 	// Try to deploy — should fail with approval error
 	_, err = testClient.DeployDeployRequest(ctx, &ps.PerformDeployRequest{

--- a/pkg/localscale/server_integration_test.go
+++ b/pkg/localscale/server_integration_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/block/schemabot/e2e/testutil"
 	"github.com/block/schemabot/pkg/localscale"
 	"github.com/block/schemabot/pkg/psclient"
 )
@@ -252,19 +253,18 @@ func TestBranchLifecycle(t *testing.T) {
 	}
 
 	// Wait for branch to become ready
-	deadline := time.Now().Add(10 * time.Second)
-	for time.Now().Before(deadline) {
-		got, err := testClient.GetBranch(ctx, &ps.GetDatabaseBranchRequest{
-			Organization: testOrg,
-			Database:     testDB,
-			Branch:       branchName,
-		})
-		require.NoError(t, err, "GetBranch error")
-		if got.Ready {
-			break
-		}
-		time.Sleep(500 * time.Millisecond)
-	}
+	testutil.Poll(t, 10*time.Second, 500*time.Millisecond,
+		func() bool {
+			got, err := testClient.GetBranch(ctx, &ps.GetDatabaseBranchRequest{
+				Organization: testOrg,
+				Database:     testDB,
+				Branch:       branchName,
+			})
+			require.NoError(t, err, "GetBranch error")
+			return got.Ready
+		},
+		func() string { return "branch " + branchName + " did not become ready" },
+	)
 
 	// Verify it's ready now
 	got, err := testClient.GetBranch(ctx, &ps.GetDatabaseBranchRequest{
@@ -348,17 +348,17 @@ func verifyColumnExists(t *testing.T, table, column string, keyspace ...string) 
 // Retries for up to 5s to account for vtgate schema cache refresh delay.
 func verifyColumnNotExists(t *testing.T, table, column string) {
 	t.Helper()
-	deadline := time.Now().Add(5 * time.Second)
-	for time.Now().Before(deadline) {
-		result, err := testContainer.VtgateExec(t.Context(), testOrg, testDB, "testapp_sharded",
-			fmt.Sprintf("SHOW COLUMNS FROM %s LIKE '%s'", table, column))
-		require.NoError(t, err, "verify column not exists %s.%s", table, column)
-		if len(result.Rows) == 0 {
-			return
-		}
-		time.Sleep(500 * time.Millisecond)
-	}
-	assert.Failf(t, "column still exists", "column '%s' still exists in table '%s' after waiting for schema cache refresh", column, table)
+	testutil.Poll(t, 5*time.Second, 500*time.Millisecond,
+		func() bool {
+			result, err := testContainer.VtgateExec(t.Context(), testOrg, testDB, "testapp_sharded",
+				fmt.Sprintf("SHOW COLUMNS FROM %s LIKE '%s'", table, column))
+			require.NoError(t, err, "verify column not exists %s.%s", table, column)
+			return len(result.Rows) == 0
+		},
+		func() string {
+			return fmt.Sprintf("column '%s' still exists in table '%s' after waiting for schema cache refresh", column, table)
+		},
+	)
 }
 
 // --- Branch database test helpers ---
@@ -379,40 +379,45 @@ const (
 // waitForBranchReady polls until a branch is ready or the deadline is exceeded.
 func waitForBranchReady(t *testing.T, ctx context.Context, branchName string) {
 	t.Helper()
-	deadline := time.Now().Add(shortPollTimeout)
-	for time.Now().Before(deadline) {
-		got, err := testClient.GetBranch(ctx, &ps.GetDatabaseBranchRequest{
-			Organization: testOrg,
-			Database:     testDB,
-			Branch:       branchName,
-		})
-		require.NoError(t, err, "GetBranch(%s)", branchName)
-		if got.Ready {
-			return
-		}
-		time.Sleep(500 * time.Millisecond)
-	}
-	require.Failf(t, "branch not ready", "branch %q not ready after %v", branchName, shortPollTimeout)
+	testutil.Poll(t, shortPollTimeout, 500*time.Millisecond,
+		func() bool {
+			got, err := testClient.GetBranch(ctx, &ps.GetDatabaseBranchRequest{
+				Organization: testOrg,
+				Database:     testDB,
+				Branch:       branchName,
+			})
+			require.NoError(t, err, "GetBranch(%s)", branchName)
+			return got.Ready
+		},
+		func() string {
+			return fmt.Sprintf("branch %q not ready after %v", branchName, shortPollTimeout)
+		},
+	)
 }
 
 // waitForDeployReady polls until a deploy request reaches "ready" or "no_changes" state.
 func waitForDeployReady(t *testing.T, ctx context.Context, number uint64) *ps.DeployRequest {
 	t.Helper()
-	deadline := time.Now().Add(shortPollTimeout)
-	for time.Now().Before(deadline) {
-		dr, err := testClient.GetDeployRequest(ctx, &ps.GetDeployRequestRequest{
-			Organization: testOrg,
-			Database:     testDB,
-			Number:       number,
-		})
-		require.NoError(t, err, "GetDeployRequest(%d)", number)
-		if dr.DeploymentState == drState.Ready || dr.DeploymentState == drState.NoChanges {
-			return dr
-		}
-		time.Sleep(500 * time.Millisecond)
-	}
-	require.Failf(t, "deploy not ready", "deploy request %d not ready after %v", number, shortPollTimeout)
-	return nil
+	var result *ps.DeployRequest
+	testutil.Poll(t, shortPollTimeout, 500*time.Millisecond,
+		func() bool {
+			dr, err := testClient.GetDeployRequest(ctx, &ps.GetDeployRequestRequest{
+				Organization: testOrg,
+				Database:     testDB,
+				Number:       number,
+			})
+			require.NoError(t, err, "GetDeployRequest(%d)", number)
+			if dr.DeploymentState == drState.Ready || dr.DeploymentState == drState.NoChanges {
+				result = dr
+				return true
+			}
+			return false
+		},
+		func() string {
+			return fmt.Sprintf("deploy request %d not ready after %v", number, shortPollTimeout)
+		},
+	)
+	return result
 }
 
 // waitForDeployState polls until a deploy request reaches one of the specified states.
@@ -423,33 +428,40 @@ func waitForDeployState(t *testing.T, ctx context.Context, number uint64, wantSt
 		wantSet[s] = true
 	}
 	start := time.Now()
-	deadline := time.Now().Add(longPollTimeout)
-	var lastState string
-	for time.Now().Before(deadline) {
-		dr, err := testClient.GetDeployRequest(ctx, &ps.GetDeployRequestRequest{
-			Organization: testOrg,
-			Database:     testDB,
-			Number:       number,
-		})
-		require.NoError(t, err, "GetDeployRequest(%d)", number)
-		if dr.DeploymentState != lastState {
-			t.Logf("deploy %d: %s → %s (%s elapsed)", number, lastState, dr.DeploymentState, time.Since(start).Round(time.Millisecond))
-		}
-		lastState = dr.DeploymentState
-		if wantSet[lastState] {
-			return dr
-		}
-		// Fail fast on terminal error states (unless we're specifically waiting for them)
-		if lastState == drState.CompleteError && !wantSet[drState.CompleteError] {
-			require.Failf(t, "deploy failed", "deploy %d reached complete_error", number)
-		}
-		if lastState == drState.Error && !wantSet[drState.Error] {
-			require.Failf(t, "deploy failed", "deploy %d reached error", number)
-		}
-		time.Sleep(500 * time.Millisecond)
-	}
-	require.Failf(t, "deploy state timeout", "deploy %d: expected one of %v, last state was %q", number, wantStates, lastState)
-	return nil
+	var (
+		lastState string
+		result    *ps.DeployRequest
+	)
+	testutil.Poll(t, longPollTimeout, 500*time.Millisecond,
+		func() bool {
+			dr, err := testClient.GetDeployRequest(ctx, &ps.GetDeployRequestRequest{
+				Organization: testOrg,
+				Database:     testDB,
+				Number:       number,
+			})
+			require.NoError(t, err, "GetDeployRequest(%d)", number)
+			if dr.DeploymentState != lastState {
+				t.Logf("deploy %d: %s → %s (%s elapsed)", number, lastState, dr.DeploymentState, time.Since(start).Round(time.Millisecond))
+			}
+			lastState = dr.DeploymentState
+			if wantSet[lastState] {
+				result = dr
+				return true
+			}
+			// Fail fast on terminal error states (unless we're specifically waiting for them)
+			if lastState == drState.CompleteError && !wantSet[drState.CompleteError] {
+				require.Failf(t, "deploy failed", "deploy %d reached complete_error", number)
+			}
+			if lastState == drState.Error && !wantSet[drState.Error] {
+				require.Failf(t, "deploy failed", "deploy %d reached error", number)
+			}
+			return false
+		},
+		func() string {
+			return fmt.Sprintf("deploy %d: expected one of %v, last state was %q", number, wantStates, lastState)
+		},
+	)
+	return result
 }
 
 // cleanupActiveDeployRequests skips-revert or cancels any active deploy requests

--- a/pkg/localscale/tls_integration_test.go
+++ b/pkg/localscale/tls_integration_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/block/schemabot/e2e/testutil"
 	"github.com/block/schemabot/pkg/localscale"
 	"github.com/block/schemabot/pkg/psclient"
 )
@@ -74,16 +75,15 @@ func TestMTLS_BranchConnection(t *testing.T) {
 	require.NoError(t, err)
 
 	// Wait for the branch snapshot to complete before requesting credentials.
-	deadline := time.Now().Add(15 * time.Second)
-	for time.Now().Before(deadline) {
-		br, brErr := client.GetBranch(ctx, &ps.GetDatabaseBranchRequest{
-			Organization: "test-org", Database: "testdb", Branch: "tls-test-branch",
-		})
-		if brErr == nil && br.Ready {
-			break
-		}
-		time.Sleep(500 * time.Millisecond)
-	}
+	testutil.Poll(t, 15*time.Second, 500*time.Millisecond,
+		func() bool {
+			br, brErr := client.GetBranch(ctx, &ps.GetDatabaseBranchRequest{
+				Organization: "test-org", Database: "testdb", Branch: "tls-test-branch",
+			})
+			return brErr == nil && br.Ready
+		},
+		func() string { return "branch tls-test-branch did not become ready" },
+	)
 
 	pw, err := client.CreateBranchPassword(ctx, &ps.DatabaseBranchPasswordRequest{
 		Organization: "test-org",

--- a/pkg/tern/local_client_integration_test.go
+++ b/pkg/tern/local_client_integration_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go/modules/mysql"
 
+	waitutil "github.com/block/schemabot/e2e/testutil"
 	"github.com/block/schemabot/pkg/engine"
 	"github.com/block/schemabot/pkg/engine/spirit"
 	ternv1 "github.com/block/schemabot/pkg/proto/ternv1"
@@ -224,37 +225,35 @@ func buildSchemaWithAllTables(t *testing.T, dsn string, testTableSchemas map[str
 func waitForApplyComplete(t *testing.T, client *LocalClient, ctx context.Context, applyID string) {
 	t.Helper()
 	sawRunning := false
-	deadline := time.Now().Add(30 * time.Second)
-	for time.Now().Before(deadline) {
-		progress, err := client.Progress(ctx, &ternv1.ProgressRequest{
-			Type:     "mysql",
-			Database: "testdb",
-			ApplyId:  applyID,
-		})
-		if err != nil {
-			t.Logf("Progress() error: %v", err)
-			time.Sleep(500 * time.Millisecond)
-			continue
-		}
-		switch progress.State {
-		case ternv1.State_STATE_COMPLETED:
-			return
-		case ternv1.State_STATE_FAILED:
-			t.Fatalf("apply %s failed: %s", applyID, progress.ErrorMessage)
-		case ternv1.State_STATE_NO_ACTIVE_CHANGE:
-			// NO_ACTIVE_CHANGE means "no tasks found for this database" — either
-			// the background goroutine hasn't created tasks yet, or they've
-			// been cleaned up after completion. Only treat as done if we
-			// previously saw the apply in progress.
-			if sawRunning {
-				return
+	waitutil.Poll(t, 30*time.Second, 500*time.Millisecond,
+		func() bool {
+			progress, err := client.Progress(ctx, &ternv1.ProgressRequest{
+				Type:     "mysql",
+				Database: "testdb",
+				ApplyId:  applyID,
+			})
+			if err != nil {
+				t.Logf("Progress() error: %v", err)
+				return false
 			}
-		default:
-			sawRunning = true
-		}
-		time.Sleep(500 * time.Millisecond)
-	}
-	t.Fatal("apply did not complete within 30s")
+			switch progress.State {
+			case ternv1.State_STATE_COMPLETED:
+				return true
+			case ternv1.State_STATE_FAILED:
+				t.Fatalf("apply %s failed: %s", applyID, progress.ErrorMessage)
+			case ternv1.State_STATE_NO_ACTIVE_CHANGE:
+				// NO_ACTIVE_CHANGE means "no tasks found for this database" — either
+				// the background goroutine hasn't created tasks yet, or they've
+				// been cleaned up after completion. Only treat as done if we
+				// previously saw the apply in progress.
+				return sawRunning
+			default:
+				sawRunning = true
+			}
+			return false
+		},
+		func() string { return fmt.Sprintf("apply %s did not complete within 30s", applyID) },
+	)
 }
 
 type retryableFailureEngine struct {
@@ -891,23 +890,22 @@ func TestLocalClient_Apply_MultiTableSequential(t *testing.T) {
 
 	// Wait for schema changes to complete (both tables should be modified)
 	// Poll for completion rather than fixed sleep
-	deadline := time.Now().Add(30 * time.Second)
-	for time.Now().Before(deadline) {
-		progress, err := client.Progress(ctx, &ternv1.ProgressRequest{
-			Type:     "mysql",
-			Database: "testdb",
-		})
-		if err != nil {
-			t.Logf("Progress() error: %v", err)
-		} else {
-			t.Logf("Progress state: %v", progress.State)
-			if progress.State == ternv1.State_STATE_COMPLETED ||
-				progress.State == ternv1.State_STATE_NO_ACTIVE_CHANGE {
-				break
+	waitutil.Poll(t, 30*time.Second, 500*time.Millisecond,
+		func() bool {
+			progress, err := client.Progress(ctx, &ternv1.ProgressRequest{
+				Type:     "mysql",
+				Database: "testdb",
+			})
+			if err != nil {
+				t.Logf("Progress() error: %v", err)
+				return false
 			}
-		}
-		time.Sleep(500 * time.Millisecond)
-	}
+			t.Logf("Progress state: %v", progress.State)
+			return progress.State == ternv1.State_STATE_COMPLETED ||
+				progress.State == ternv1.State_STATE_NO_ACTIVE_CHANGE
+		},
+		func() string { return "schema changes did not complete within 30s" },
+	)
 
 	// Verify BOTH tables were modified
 
@@ -1067,15 +1065,16 @@ func TestLocalClient_Apply_AtomicHeartbeat(t *testing.T) {
 	require.True(t, applyResp.Accepted, "apply rejected: %s", applyResp.ErrorMessage)
 
 	// Wait for waiting_for_cutover — the apply sits here while heartbeat keeps running
-	deadline := time.Now().Add(30 * time.Second)
 	var st string
-	for time.Now().Before(deadline) {
-		err = db.QueryRowContext(ctx, "SELECT state FROM applies WHERE apply_identifier = ?", applyResp.ApplyId).Scan(&st)
-		if err == nil && (st == state.Apply.WaitingForCutover || st == state.Apply.Completed || st == state.Apply.Failed) {
-			break
-		}
-		time.Sleep(500 * time.Millisecond)
-	}
+	waitutil.Poll(t, 30*time.Second, 500*time.Millisecond,
+		func() bool {
+			err = db.QueryRowContext(ctx, "SELECT state FROM applies WHERE apply_identifier = ?", applyResp.ApplyId).Scan(&st)
+			return err == nil && (st == state.Apply.WaitingForCutover || st == state.Apply.Completed || st == state.Apply.Failed)
+		},
+		func() string {
+			return fmt.Sprintf("apply %s did not reach a stable state, last: %q", applyResp.ApplyId, st)
+		},
+	)
 	require.Equal(t, state.Apply.WaitingForCutover, st, "apply should reach waiting_for_cutover")
 
 	// Snapshot updated_at while in waiting_for_cutover
@@ -1102,14 +1101,15 @@ func TestLocalClient_Apply_AtomicHeartbeat(t *testing.T) {
 	require.NoError(t, err, "cutover")
 
 	// Wait for completion with a fresh deadline
-	cutoverDeadline := time.Now().Add(30 * time.Second)
-	for time.Now().Before(cutoverDeadline) {
-		err = db.QueryRowContext(ctx, "SELECT state FROM applies WHERE apply_identifier = ?", applyResp.ApplyId).Scan(&st)
-		if err == nil && (st == state.Apply.Completed || st == state.Apply.Failed) {
-			break
-		}
-		time.Sleep(500 * time.Millisecond)
-	}
+	waitutil.Poll(t, 30*time.Second, 500*time.Millisecond,
+		func() bool {
+			err = db.QueryRowContext(ctx, "SELECT state FROM applies WHERE apply_identifier = ?", applyResp.ApplyId).Scan(&st)
+			return err == nil && (st == state.Apply.Completed || st == state.Apply.Failed)
+		},
+		func() string {
+			return fmt.Sprintf("apply %s did not reach terminal state, last: %q", applyResp.ApplyId, st)
+		},
+	)
 
 	assert.Equal(t, state.Apply.Completed, st, "apply should be completed")
 }


### PR DESCRIPTION
## What and Why ?

Centralizes the repeated `deadline := time.Now().Add(...); for time.Now().Before(...)` polling loops across integration, e2e, and package-level integration tests behind a single `testutil.Poll(t, timeout, interval, cond, failureMsg)` helper in `e2e/testutil/wait.go`. The `failureMsg` argument is a closure so call sites can still include the most recent observed value (last state, last error, last response) captured via closure.

`WaitForState` and `WaitForAnyState` in `e2e/testutil` are rewritten in terms of `Poll`. The duplicate `waitForState` / `fetchProgressState` body in `integration/shared_wait_helpers_test.go` and the duplicate `waitForHTTPReady` helper in `integration/hybrid_mode_test.go` are removed in favor of the shared helpers.

Two silent-fall-through loops (where the test continued past timeout without failing) are now hard failures, matching the AGENTS.md rule that all timeouts must hard-fail.

Verified:
- `go build` / `go vet` clean across default, `-tags=integration`, and `-tags=e2e`
- `golangci-lint` clean
- Unit tests pass (`go test -short ./...`)
- Integration `TestScheduler*`, `TestGRPC*`, `TestHybrid*`, `TestResolve*`, `TestWorkflow*`, and `TestCLI*` pass