### PR TITLE
fix(github): surface team authorization lookup errors

### DIFF
--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -1111,7 +1111,7 @@ Schema changes require approval from a code owner before applying.
 
 ### Error
 
-> Review gate check failed: expand team @acme/schema-reviewers: API rate limit exceeded.
+> Review gate check failed: expand team @acme/schema-reviewers: team membership cannot be read. If approval is granted through a GitHub team, verify the GitHub App can read organization members and team membership.
 </details>
 
 ### CLI Output
@@ -4123,7 +4123,7 @@ Schema changes require approval from a code owner before applying.
 
 ### Error
 
-> Review gate check failed: expand team @acme/schema-reviewers: API rate limit exceeded.
+> Review gate check failed: expand team @acme/schema-reviewers: team membership cannot be read. If approval is granted through a GitHub team, verify the GitHub App can read organization members and team membership.
 
 </details>
 
@@ -4134,7 +4134,6 @@ Schema changes require approval from a code owner before applying.
 ## SchemaBot Command Not Authorized
 
 **Database**: `orders` | **Environment**: `staging`
-**Requested by**: @mona
 
 @mona is not authorized to run `schemabot apply` for this database.
 
@@ -4153,6 +4152,8 @@ A configured SchemaBot admin/database operator must run this command.
 **Requested by**: @mona
 
 SchemaBot could not verify authorization for `schemabot apply-confirm`. No schema change was started.
+
+If access is granted through a GitHub team, verify the GitHub App can read organization members and team membership.
 
 A configured SchemaBot admin/database operator should inspect SchemaBot authorization logs before retrying.
 

--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -41,7 +41,11 @@ Under **Repository permissions**, grant:
 | **Metadata** | Read | Required (granted automatically) |
 | **Pull requests** | Read & Write | Fetch PR info (head SHA, changed files) |
 
-No organization or account permissions are needed.
+Under **Organization permissions**, grant:
+
+| Permission | Access | Used For |
+|-----------|--------|----------|
+| **Members** | Read | Verify GitHub team membership for CODEOWNERS review gates and PR command authorization |
 
 ### Subscribe to Events
 

--- a/docs/review-gate.md
+++ b/docs/review-gate.md
@@ -23,7 +23,7 @@ Repo-specific settings take precedence over the global setting.
 
 When enabled, `schemabot apply` and `schemabot apply-confirm` check for PR approval before proceeding:
 
-1. **CODEOWNERS check**: If the repo has a CODEOWNERS file (checked from the base branch), SchemaBot requires approval from a listed code owner. Team slugs (`@org/team`) are expanded to individual members via the GitHub Teams API.
+1. **CODEOWNERS check**: If the repo has a CODEOWNERS file (checked from the base branch), SchemaBot requires approval from a listed code owner. Team slugs (`@org/team`) are expanded to individual members via the GitHub Teams API, which requires the GitHub App's **Members** organization permission with read access.
 
 2. **Fallback**: If no CODEOWNERS file exists, any non-self approval satisfies the gate.
 

--- a/pkg/github/reviews.go
+++ b/pkg/github/reviews.go
@@ -3,6 +3,7 @@ package github
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -19,6 +20,8 @@ const (
 	ReviewCommented        = "COMMENTED"
 	ReviewDismissed        = "DISMISSED"
 )
+
+var ErrTeamMembershipUnreadable = errors.New("team membership cannot be read")
 
 // ReviewInfo holds a single PR review.
 type ReviewInfo struct {
@@ -194,7 +197,7 @@ func OwnerNames(owners []codeowners.Owner) []string {
 
 // ListTeamMembers returns the login names of all members of a GitHub team.
 // The owner parameter is the org slug (e.g. "octocat"), and slug is the team
-// slug (e.g. "dba-team"). Returns an error if the team is not found.
+// slug (e.g. "dba-team"). Returns an error if team membership cannot be read.
 func (ic *InstallationClient) ListTeamMembers(ctx context.Context, org, slug string) ([]string, error) {
 	opts := &gh.TeamListTeamMembersOptions{ListOptions: gh.ListOptions{PerPage: 100}}
 	var members []string
@@ -202,7 +205,7 @@ func (ic *InstallationClient) ListTeamMembers(ctx context.Context, org, slug str
 	for {
 		users, resp, err := ic.client.Teams.ListTeamMembersBySlug(ctx, org, slug, opts)
 		if err != nil {
-			return nil, fmt.Errorf("list team members %s/%s: %w", org, slug, err)
+			return nil, teamMembershipReadError("list team members", org, slug, err)
 		}
 		for _, u := range users {
 			members = append(members, u.GetLogin())
@@ -216,22 +219,46 @@ func (ic *InstallationClient) ListTeamMembers(ctx context.Context, org, slug str
 	return members, nil
 }
 
-// IsTeamMember returns true when login is an active member of org/slug.
-// GitHub returns 404 when the user is not a team member; that is an ordinary
-// negative authorization result. Other errors are returned so callers can fail
-// closed when GitHub membership cannot be verified.
+// IsTeamMember returns true when login is a member of org/slug. It relies on
+// the same team-member listing used by CODEOWNERS review checks so the only
+// negative result is a readable team list that does not contain the actor.
 func (ic *InstallationClient) IsTeamMember(ctx context.Context, org, slug, login string) (bool, error) {
-	membership, resp, err := ic.client.Teams.GetTeamMembershipBySlug(ctx, org, slug, login)
+	members, err := ic.ListTeamMembers(ctx, org, slug)
 	if err != nil {
-		if resp != nil && resp.StatusCode == http.StatusNotFound {
-			return false, nil
+		return false, fmt.Errorf("check team membership %s/%s for %s: %w", org, slug, login, err)
+	}
+	for _, member := range members {
+		if strings.EqualFold(member, login) {
+			return true, nil
 		}
-		return false, fmt.Errorf("get team membership %s/%s for %s: %w", org, slug, login, err)
 	}
-	if membership == nil {
-		return false, nil
+	return false, nil
+}
+
+func teamMembershipReadError(operation, org, slug string, err error) error {
+	if isTeamMembershipVisibilityError(err) {
+		return fmt.Errorf("%w: %s %s/%s: %w", ErrTeamMembershipUnreadable, operation, org, slug, err)
 	}
-	return membership.GetState() == "active", nil
+	return fmt.Errorf("%s %s/%s: %w", operation, org, slug, err)
+}
+
+func isTeamMembershipVisibilityError(err error) bool {
+	var rateLimitErr *gh.RateLimitError
+	if errors.As(err, &rateLimitErr) {
+		return false
+	}
+	var abuseRateLimitErr *gh.AbuseRateLimitError
+	if errors.As(err, &abuseRateLimitErr) {
+		return false
+	}
+	var responseErr *gh.ErrorResponse
+	if !errors.As(err, &responseErr) || responseErr.Response == nil {
+		return false
+	}
+	statusCode := responseErr.Response.StatusCode
+	return statusCode >= http.StatusBadRequest &&
+		statusCode < http.StatusInternalServerError &&
+		statusCode != http.StatusTooManyRequests
 }
 
 // RequestReviewers requests reviews from users and/or teams on a PR.

--- a/pkg/github/reviews_test.go
+++ b/pkg/github/reviews_test.go
@@ -165,43 +165,57 @@ func TestGetApprovedReviewers(t *testing.T) {
 
 func TestIsTeamMember(t *testing.T) {
 	tests := []struct {
-		name       string
-		statusCode int
-		body       map[string]string
-		wantMember bool
-		wantErr    bool
+		name            string
+		statusCode      int
+		members         []string
+		wantMember      bool
+		wantErr         bool
+		wantErrContains string
+		wantUnreadable  bool
 	}{
 		{
-			name:       "active membership allows",
+			name:       "listed member allows",
 			statusCode: http.StatusOK,
-			body:       map[string]string{"state": "active"},
+			members:    []string{"mona"},
 			wantMember: true,
 		},
 		{
-			name:       "pending membership does not allow",
+			name:       "listed member allows case-insensitively",
 			statusCode: http.StatusOK,
-			body:       map[string]string{"state": "pending"},
-			wantMember: false,
+			members:    []string{"Mona"},
+			wantMember: true,
 		},
 		{
-			name:       "not found is not a member",
-			statusCode: http.StatusNotFound,
-			wantMember: false,
+			name:       "readable team without actor is not a member",
+			statusCode: http.StatusOK,
+			members:    []string{"hubot"},
 		},
 		{
-			name:       "server error is returned",
-			statusCode: http.StatusInternalServerError,
-			wantErr:    true,
+			name:            "unreadable team returns sentinel error",
+			statusCode:      http.StatusNotFound,
+			wantErr:         true,
+			wantErrContains: "check team membership",
+			wantUnreadable:  true,
+		},
+		{
+			name:            "server error returns generic error",
+			statusCode:      http.StatusInternalServerError,
+			wantErr:         true,
+			wantErrContains: "check team membership",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			client, mux := setupConfigTestGitHubServer(t)
-			mux.HandleFunc("GET /orgs/octocat/teams/db-operators/memberships/mona", func(w http.ResponseWriter, _ *http.Request) {
+			mux.HandleFunc("GET /orgs/octocat/teams/db-operators/members", func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(tt.statusCode)
-				if tt.body != nil {
-					require.NoError(t, json.NewEncoder(w).Encode(tt.body))
+				if tt.statusCode == http.StatusOK {
+					users := make([]map[string]string, 0, len(tt.members))
+					for _, member := range tt.members {
+						users = append(users, map[string]string{"login": member})
+					}
+					require.NoError(t, json.NewEncoder(w).Encode(users))
 				}
 			})
 
@@ -209,10 +223,68 @@ func TestIsTeamMember(t *testing.T) {
 			member, err := ic.IsTeamMember(t.Context(), "octocat", "db-operators", "mona")
 			if tt.wantErr {
 				require.Error(t, err)
+				if tt.wantUnreadable {
+					assert.ErrorIs(t, err, ErrTeamMembershipUnreadable)
+				} else {
+					assert.NotErrorIs(t, err, ErrTeamMembershipUnreadable)
+				}
+				if tt.wantErrContains != "" {
+					assert.Contains(t, err.Error(), tt.wantErrContains)
+				}
 				return
 			}
 			require.NoError(t, err)
 			assert.Equal(t, tt.wantMember, member)
+		})
+	}
+}
+
+func TestListTeamMembersErrorClassification(t *testing.T) {
+	tests := []struct {
+		name           string
+		statusCode     int
+		wantUnreadable bool
+	}{
+		{
+			name:           "not found is unreadable",
+			statusCode:     http.StatusNotFound,
+			wantUnreadable: true,
+		},
+		{
+			name:           "unauthorized is unreadable",
+			statusCode:     http.StatusUnauthorized,
+			wantUnreadable: true,
+		},
+		{
+			name:           "forbidden is unreadable",
+			statusCode:     http.StatusForbidden,
+			wantUnreadable: true,
+		},
+		{
+			name:       "too many requests is generic",
+			statusCode: http.StatusTooManyRequests,
+		},
+		{
+			name:       "server error is generic",
+			statusCode: http.StatusInternalServerError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client, mux := setupConfigTestGitHubServer(t)
+			mux.HandleFunc("GET /orgs/octocat/teams/db-operators/members", func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tt.statusCode)
+			})
+
+			ic := NewInstallationClient(client, slog.New(slog.NewTextHandler(io.Discard, nil)))
+			_, err := ic.ListTeamMembers(t.Context(), "octocat", "db-operators")
+			require.Error(t, err)
+			if tt.wantUnreadable {
+				assert.ErrorIs(t, err, ErrTeamMembershipUnreadable)
+			} else {
+				assert.NotErrorIs(t, err, ErrTeamMembershipUnreadable)
+			}
 		})
 	}
 }

--- a/pkg/webhook/actor_authorization_test.go
+++ b/pkg/webhook/actor_authorization_test.go
@@ -109,25 +109,24 @@ func TestAuthorizePRCommandActor(t *testing.T) {
 
 func TestAuthorizePRCommandActorTeams(t *testing.T) {
 	tests := []struct {
-		name       string
-		configure  func(*api.ServerConfig)
-		statusCode int
-		state      string
-		wantAllow  bool
-		wantReason string
-		wantMatch  string
-		wantErr    bool
+		name                  string
+		configure             func(*api.ServerConfig)
+		teamMembersStatusCode int
+		teamMembers           []string
+		wantAllow             bool
+		wantReason            string
+		wantMatch             string
+		wantErr               bool
 	}{
 		{
 			name: "admin team allows",
 			configure: func(cfg *api.ServerConfig) {
 				cfg.PRCommandAuthorization.AdminTeams = []string{"octocat/schema-admins"}
 			},
-			statusCode: http.StatusOK,
-			state:      "active",
-			wantAllow:  true,
-			wantReason: api.ActorAuthReasonAllowedAdminTeam,
-			wantMatch:  "octocat/schema-admins",
+			teamMembers: []string{"mona"},
+			wantAllow:   true,
+			wantReason:  api.ActorAuthReasonAllowedAdminTeam,
+			wantMatch:   "octocat/schema-admins",
 		},
 		{
 			name: "admin team takes precedence over admin user",
@@ -135,11 +134,10 @@ func TestAuthorizePRCommandActorTeams(t *testing.T) {
 				cfg.PRCommandAuthorization.AdminTeams = []string{"octocat/schema-admins"}
 				cfg.PRCommandAuthorization.AdminUsers = []string{"mona"}
 			},
-			statusCode: http.StatusOK,
-			state:      "active",
-			wantAllow:  true,
-			wantReason: api.ActorAuthReasonAllowedAdminTeam,
-			wantMatch:  "octocat/schema-admins",
+			teamMembers: []string{"mona"},
+			wantAllow:   true,
+			wantReason:  api.ActorAuthReasonAllowedAdminTeam,
+			wantMatch:   "octocat/schema-admins",
 		},
 		{
 			name: "admin user allows after admin team non-member",
@@ -147,10 +145,10 @@ func TestAuthorizePRCommandActorTeams(t *testing.T) {
 				cfg.PRCommandAuthorization.AdminTeams = []string{"octocat/schema-admins"}
 				cfg.PRCommandAuthorization.AdminUsers = []string{"mona"}
 			},
-			statusCode: http.StatusNotFound,
-			wantAllow:  true,
-			wantReason: api.ActorAuthReasonAllowedAdminUser,
-			wantMatch:  "mona",
+			teamMembers: []string{"hubot"},
+			wantAllow:   true,
+			wantReason:  api.ActorAuthReasonAllowedAdminUser,
+			wantMatch:   "mona",
 		},
 		{
 			name: "operator team allows",
@@ -159,36 +157,48 @@ func TestAuthorizePRCommandActorTeams(t *testing.T) {
 				db.OperatorTeams = []string{"octocat/orders-operators"}
 				cfg.Databases["orders"] = db
 			},
-			statusCode: http.StatusOK,
-			state:      "active",
-			wantAllow:  true,
-			wantReason: api.ActorAuthReasonAllowedOperatorTeam,
-			wantMatch:  "octocat/orders-operators",
+			teamMembers: []string{"mona"},
+			wantAllow:   true,
+			wantReason:  api.ActorAuthReasonAllowedOperatorTeam,
+			wantMatch:   "octocat/orders-operators",
 		},
 		{
 			name: "not a member denies",
 			configure: func(cfg *api.ServerConfig) {
 				cfg.PRCommandAuthorization.AdminTeams = []string{"octocat/schema-admins"}
 			},
-			statusCode: http.StatusNotFound,
-			wantReason: api.ActorAuthReasonNotAuthorized,
+			teamMembers: []string{"hubot"},
+			wantReason:  api.ActorAuthReasonNotAuthorized,
+		},
+		{
+			name: "admin team membership visibility error fails closed",
+			configure: func(cfg *api.ServerConfig) {
+				cfg.PRCommandAuthorization.AdminTeams = []string{"octocat/schema-admins"}
+			},
+			teamMembersStatusCode: http.StatusForbidden,
+			wantReason:            api.ActorAuthReasonGitHubError,
+			wantErr:               true,
 		},
 		{
 			name: "GitHub error fails closed",
 			configure: func(cfg *api.ServerConfig) {
 				cfg.PRCommandAuthorization.AdminTeams = []string{"octocat/schema-admins"}
 			},
-			statusCode: http.StatusInternalServerError,
-			wantReason: api.ActorAuthReasonGitHubError,
-			wantErr:    true,
+			teamMembersStatusCode: http.StatusInternalServerError,
+			wantReason:            api.ActorAuthReasonGitHubError,
+			wantErr:               true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			client, mux := setupGitHubServer(t)
-			mux.HandleFunc("GET /orgs/octocat/teams/schema-admins/memberships/mona", membershipHandler(t, tt.statusCode, tt.state))
-			mux.HandleFunc("GET /orgs/octocat/teams/orders-operators/memberships/mona", membershipHandler(t, tt.statusCode, tt.state))
+			teamMembersStatusCode := tt.teamMembersStatusCode
+			if teamMembersStatusCode == 0 {
+				teamMembersStatusCode = http.StatusOK
+			}
+			mux.HandleFunc("GET /orgs/octocat/teams/schema-admins/members", teamMembersHandler(t, teamMembersStatusCode, tt.teamMembers...))
+			mux.HandleFunc("GET /orgs/octocat/teams/orders-operators/members", teamMembersHandler(t, teamMembersStatusCode, tt.teamMembers...))
 			installClient := ghclient.NewInstallationClient(client, testLogger())
 
 			cfg := actorAuthTestConfig(true, tt.configure)
@@ -266,6 +276,40 @@ func TestEnforcePRCommandActorAuthorizationComments(t *testing.T) {
 	}
 }
 
+func TestEnforcePRCommandActorAuthorizationTeamLookupErrorComment(t *testing.T) {
+	client, mux := setupGitHubServer(t)
+	comments := make(chan string, 2)
+	mux.HandleFunc("GET /orgs/octocat/teams/schema-admins/members", teamMembersHandler(t, http.StatusForbidden))
+	mux.HandleFunc("POST /repos/octocat/hello-world/issues/1/comments", func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Body string `json:"body"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		comments <- body.Body
+		w.WriteHeader(http.StatusCreated)
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{"id": 99}))
+	})
+	installClient := ghclient.NewInstallationClient(client, testLogger())
+	cfg := actorAuthTestConfig(true, func(cfg *api.ServerConfig) {
+		cfg.PRCommandAuthorization.AdminTeams = []string{"octocat/schema-admins"}
+	})
+	h := actorAuthTestHandler(cfg, installClient)
+
+	blocked := h.enforcePRCommandActorAuthorization(t.Context(), installClient, "octocat/hello-world", 1, 12345, "mona", "orders", storage.DatabaseTypeMySQL, "staging", action.Apply)
+	assert.True(t, blocked)
+
+	select {
+	case body := <-comments:
+		assert.Contains(t, body, "SchemaBot Authorization Check Failed")
+		assert.Contains(t, body, "could not verify authorization")
+		assert.Contains(t, body, "No schema change was started")
+		assert.Contains(t, body, "GitHub App can read organization members")
+		assert.NotContains(t, body, "is not authorized")
+	case <-time.After(2 * time.Second):
+		require.FailNow(t, "timed out waiting for authorization failure comment")
+	}
+}
+
 // TestHandleApplyCommandBlocksUnauthorizedActorBeforePlanning exercises the
 // PR apply flow through schema discovery and actor authorization. An actor who
 // is not a configured admin/operator should receive a denial comment before
@@ -329,12 +373,16 @@ func actorAuthTestHandler(cfg *api.ServerConfig, installClient *ghclient.Install
 	}
 }
 
-func membershipHandler(t *testing.T, statusCode int, state string) http.HandlerFunc {
+func teamMembersHandler(t *testing.T, statusCode int, members ...string) http.HandlerFunc {
 	t.Helper()
 	return func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(statusCode)
 		if statusCode == http.StatusOK {
-			require.NoError(t, json.NewEncoder(w).Encode(map[string]string{"state": state}))
+			users := make([]map[string]string, 0, len(members))
+			for _, member := range members {
+				users = append(users, map[string]string{"login": member})
+			}
+			require.NoError(t, json.NewEncoder(w).Encode(users))
 		}
 		if statusCode >= http.StatusBadRequest {
 			_, err := fmt.Fprint(w, http.StatusText(statusCode))

--- a/pkg/webhook/review_gate.go
+++ b/pkg/webhook/review_gate.go
@@ -2,6 +2,7 @@ package webhook
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -28,7 +29,7 @@ func (h *Handler) enforceReviewGate(ctx context.Context, client *ghclient.Instal
 			RequestedBy: requestedBy,
 			Environment: environment,
 			CommandName: commandName,
-			ErrorDetail: "Review gate check failed: " + err.Error(),
+			ErrorDetail: reviewGateErrorDetail(err),
 		}))
 		return true
 	}
@@ -43,6 +44,14 @@ func (h *Handler) enforceReviewGate(ctx context.Context, client *ghclient.Instal
 		return true
 	}
 	return false
+}
+
+func reviewGateErrorDetail(err error) string {
+	detail := "Review gate check failed: " + err.Error()
+	if errors.Is(err, ghclient.ErrTeamMembershipUnreadable) {
+		detail += ". If approval is granted through a GitHub team, verify the GitHub App can read organization members and team membership."
+	}
+	return detail
 }
 
 // checkReviewGate checks if the PR has CODEOWNERS approval for the given schema path.

--- a/pkg/webhook/review_gate_test.go
+++ b/pkg/webhook/review_gate_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -20,6 +21,23 @@ import (
 	ghclient "github.com/block/schemabot/pkg/github"
 	"github.com/block/schemabot/pkg/storage"
 )
+
+func TestReviewGateErrorDetailTeamMembership(t *testing.T) {
+	err := fmt.Errorf("expand team @octocat/schema-admins: %w", ghclient.ErrTeamMembershipUnreadable)
+
+	detail := reviewGateErrorDetail(err)
+
+	assert.Contains(t, detail, "Review gate check failed")
+	assert.Contains(t, detail, "team membership cannot be read")
+	assert.Contains(t, detail, "GitHub App can read organization members")
+}
+
+func TestReviewGateErrorDetailGeneric(t *testing.T) {
+	detail := reviewGateErrorDetail(assert.AnError)
+
+	assert.Contains(t, detail, "Review gate check failed")
+	assert.NotContains(t, detail, "GitHub App can read organization members")
+}
 
 // mockSettingsStore implements storage.SettingsStore for testing.
 type mockSettingsStore struct {

--- a/pkg/webhook/templates/apply_commands.go
+++ b/pkg/webhook/templates/apply_commands.go
@@ -42,9 +42,6 @@ func RenderPRCommandNotAuthorized(data ActorAuthorizationCommentData) string {
 
 	sb.WriteString("## SchemaBot Command Not Authorized\n\n")
 	writeDBEnvLine(&sb, data.Database, data.Environment)
-	if data.RequestedBy != "" {
-		fmt.Fprintf(&sb, "**Requested by**: @%s\n", data.RequestedBy)
-	}
 	sb.WriteString("\n")
 	if data.RequestedBy != "" {
 		fmt.Fprintf(&sb, "@%s is not authorized to run `schemabot %s` for this database.\n\n", data.RequestedBy, data.CommandName)
@@ -68,6 +65,7 @@ func RenderPRCommandAuthorizationUnavailable(data ActorAuthorizationCommentData)
 	}
 	sb.WriteString("\n")
 	fmt.Fprintf(&sb, "SchemaBot could not verify authorization for `schemabot %s`. No schema change was started.\n\n", data.CommandName)
+	sb.WriteString("If access is granted through a GitHub team, verify the GitHub App can read organization members and team membership.\n\n")
 	sb.WriteString("A configured SchemaBot admin/database operator should inspect SchemaBot authorization logs before retrying.\n")
 
 	return sb.String()

--- a/pkg/webhook/templates/apply_test.go
+++ b/pkg/webhook/templates/apply_test.go
@@ -226,6 +226,7 @@ func TestRenderPRCommandAuthorizationUnavailable(t *testing.T) {
 	assert.Contains(t, result, "`production`")
 	assert.Contains(t, result, "could not verify authorization")
 	assert.Contains(t, result, "No schema change was started")
+	assert.Contains(t, result, "GitHub App can read organization members")
 	assert.Contains(t, result, "inspect SchemaBot authorization logs")
 }
 

--- a/pkg/webhook/templates/preview.go
+++ b/pkg/webhook/templates/preview.go
@@ -205,7 +205,7 @@ func PreviewCommentReviewGateError() string {
 		RequestedBy: "aparajon",
 		Environment: "staging",
 		CommandName: action.Apply,
-		ErrorDetail: "Review gate check failed: expand team @acme/schema-reviewers: API rate limit exceeded.",
+		ErrorDetail: "Review gate check failed: expand team @acme/schema-reviewers: team membership cannot be read. If approval is granted through a GitHub team, verify the GitHub App can read organization members and team membership.",
 	})
 }
 


### PR DESCRIPTION
## Summary
- Fail closed when GitHub team membership cannot be inspected instead of reporting the actor as unauthorized
- Document the GitHub App Members read permission required for team-based authorization and review gates
- Remove duplicate requester text from the not-authorized PR comment

Generated with Codex