### PR TITLE
fix(tern): normalize local progress states

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -234,12 +234,14 @@ Poller reads current engine state
       |
       v
 Derive task state
+  - normalize raw engine state
+  - preserve stored task state if it is already ahead
   - one task per DDL
   - rows copied, rows total, percent complete
       |
       v
 Derive apply state
-  - aggregate task states
+  - aggregate stored task states
   - active, terminal, and control states
       |
       v
@@ -252,6 +254,10 @@ Persist applies + tasks
           - progress comment
           - terminal summary comment
 ```
+
+State authority is intentionally one-way: engine progress is an input, not the durable source of truth. Raw engine states are first normalized into canonical task states. The poller then reconciles that normalized engine task state with the stored task row: terminal stored tasks stay terminal, scheduler/control-owned states such as `stopped` and `failed_retryable` are not overwritten by stale active engine polls, and ordinary active states can move forward but not backward. Apply state is derived after task rows are coherent, so PR comments, CLI progress, and scheduler checks never need to reason about raw engine states directly.
+
+Unknown raw engine states normalize to `running`. This keeps unfamiliar in-flight work visible and blocking without leaking engine-specific strings into SchemaBot state or UI. Once the engine state is understood, update `NormalizeTaskStatus()` and the state-policy tests so the new state has an explicit task-state mapping and ordering policy.
 
 The `ProgressObserver` interface (`pkg/tern/observer.go`) enables external notifications from the apply progress poller. Observers see SchemaBot's derived apply/task state, not raw engine state.
 

--- a/pkg/state/README.md
+++ b/pkg/state/README.md
@@ -11,7 +11,8 @@ state.Apply     state.Task       vitess schema / spirit status
 
 An apply includes one or more tasks, where a task tracks the execution of a single table. Both `Apply` and `Task` are
 SchemaBot's internal states (stored in DB) that operate in a state machine. Engine states are external — what
-Vitess OnlineDDL and Spirit report — and they are translated into Task and Apply states.
+Vitess OnlineDDL and Spirit report — and they are translated into Task state before Apply state is derived from
+the stored task rows.
 
 ## Apply states
 
@@ -28,6 +29,7 @@ Vitess OnlineDDL and Spirit report — and they are translated into Task and App
 | Failed | `failed` | At least one task failed |
 | FailedRetryable | `failed_retryable` | A retryable engine error occurred; scheduler recovery can retry it |
 | Stopped | `stopped` | User requested stop, resumable via start (engine-dependent) |
+| Cancelled | `cancelled` | Apply was cancelled and is not resumable |
 | RevertWindow | `revert_window` | Schema change applied, revert available. Only meaningful for PlanetScale; Spirit doesn't support revert so SchemaBot auto-advances to completed |
 | Reverted | `reverted` | Schema change was reverted |
 
@@ -67,12 +69,13 @@ stateDiagram-v2
 
 ## Task states
 
-Per-table execution state. Same state machine as Apply, plus `cancelled`:
+Per-table execution state. Mostly mirrors Apply state, with per-table scheduler/control states:
 
 | State | Value | Description |
 |-------|-------|-------------|
 | Pending | `pending` | Task created, not yet started |
 | Running | `running` | Engine is actively executing (row copy, checksum, etc.) |
+| WaitingForDeploy | `waiting_for_deploy` | Deploy request ready, waiting for user to trigger deploy (PlanetScale only) |
 | WaitingForCutover | `waiting_for_cutover` | Row copy complete, waiting for cutover signal |
 | CuttingOver | `cutting_over` | Table cutover in progress |
 | Completed | `completed` | Schema change applied successfully |
@@ -133,17 +136,18 @@ Next dispatch:
 
 1. Any task **failed** → apply `failed`
 2. Any task **failed_retryable** → apply `failed_retryable`
-3. Any task **stopped** → apply `stopped`
-4. Any task **reverted** → apply `reverted`
-5. All tasks **completed** → apply `completed`
-6. Any task **cutting_over** → apply `cutting_over`
-7. All non-completed tasks **waiting_for_cutover** → apply `waiting_for_cutover`
-8. All non-completed tasks **waiting_for_deploy** → apply `waiting_for_deploy`
-9. Any task **revert_window** → apply `revert_window`
-10. Any task **running** → apply `running`
-11. Otherwise → apply `pending`
+3. Any task **cancelled** → apply `cancelled`
+4. Any task **stopped** → apply `stopped`
+5. Any task **reverted** → apply `reverted`
+6. All tasks **completed** → apply `completed`
+7. Any task **cutting_over** → apply `cutting_over`
+8. All non-completed tasks **waiting_for_cutover** → apply `waiting_for_cutover`
+9. All non-completed tasks **waiting_for_deploy** → apply `waiting_for_deploy`
+10. Any task **revert_window** → apply `revert_window`
+11. Any task **running** → apply `running`
+12. Otherwise → apply `pending`
 
-Terminal states (`completed`, `failed`, `reverted`, `cancelled`) are checked via `IsTerminalApplyState()`. Note: `failed_retryable` is not terminal because scheduler recovery can retry it, and `stopped` is not terminal at the task level because a stopped task can be resumed via Start.
+Apply terminal states (`completed`, `failed`, `stopped`, `cancelled`, `reverted`) are checked via `IsTerminalApplyState()`. Note: `failed_retryable` is not terminal because scheduler recovery can retry it, and `stopped` is not terminal at the task level because a stopped task can be resumed via Start.
 
 ## Spirit states
 
@@ -249,6 +253,8 @@ directly in the switch so it's clear where each status originates.
 
 What's common: Both engines produce completed, running, waiting_for_cutover, failed, pending equivalents.
 What's different: Spirit has granular sub-states → normalize to `running`. Vitess has queue lifecycle → normalize to `pending`.
+
+Unknown raw engine states normalize to `running`. This keeps unfamiliar in-flight work visible and blocking without leaking engine-specific strings into SchemaBot state or UI. After the state is understood, add an explicit mapping here and update the state-policy tests that guard task ordering.
 
 ## Progress rendering
 

--- a/pkg/state/task.go
+++ b/pkg/state/task.go
@@ -119,11 +119,15 @@ func NormalizeTaskStatus(raw string) string {
 	}
 
 	switch normalized := NormalizeState(s); normalized {
+	case NormalizeState(string(vitessstatus.OnlineDDLStatusComplete)):
+		return Task.Completed
 	case Task.Pending, Task.Running, Task.Completed, Task.Stopped, Task.Failed,
 		Task.FailedRetryable, Task.RevertWindow, Task.Reverted,
 		Task.WaitingForDeploy, Task.WaitingForCutover, Task.CuttingOver, Task.Cancelled:
 		return normalized
 	default:
+		// Unknown engine states represent in-flight work until proven otherwise.
+		// Keep them visible and blocking, and add an explicit mapping once known.
 		return Task.Running
 	}
 }

--- a/pkg/state/task_test.go
+++ b/pkg/state/task_test.go
@@ -40,6 +40,7 @@ func TestNormalizeTaskStatus_VitessStates(t *testing.T) {
 		{"ready", Task.Pending},
 		{"running", Task.Running},
 		{"complete", Task.Completed},
+		{"COMPLETE", Task.Completed},
 		{"failed", Task.Failed},
 		{"cancelled", Task.Cancelled},
 		{"ready_to_complete", Task.WaitingForCutover},

--- a/pkg/tern/apply_states_test.go
+++ b/pkg/tern/apply_states_test.go
@@ -111,6 +111,11 @@ func TestTaskStateFromProgressResult(t *testing.T) {
 		result := &engine.ProgressResult{State: engine.StateFailed}
 		assert.Equal(t, state.Task.Failed, taskStateFromProgressResult(result))
 	})
+
+	t.Run("unknown engine state stays visible as running", func(t *testing.T) {
+		result := &engine.ProgressResult{State: engine.State("something_new")}
+		assert.Equal(t, state.Task.Running, taskStateFromProgressResult(result))
+	})
 }
 
 func TestApplyEventStateTransition(t *testing.T) {

--- a/pkg/tern/local_client.go
+++ b/pkg/tern/local_client.go
@@ -776,16 +776,23 @@ func (c *LocalClient) Progress(ctx context.Context, req *ternv1.ProgressRequest)
 		if err == nil {
 			engineResult = result
 			c.logger.Info("Progress: engine returned", "engine_state", result.State, "message", result.Message, "task_id", activeTask.TaskIdentifier, "storage_state", activeTask.State)
-			taskState := taskStateFromProgressResult(result)
+			engineTaskState := taskStateFromProgressResult(result)
+			taskState := taskStateWithNoBackwardProgress(activeTask.State, engineTaskState)
+			if !state.IsState(taskState, engineTaskState) {
+				c.logger.Warn("keeping stored task state because engine progress reported earlier state",
+					"task_id", activeTask.TaskIdentifier,
+					"stored_state", activeTask.State,
+					"engine_task_state", engineTaskState)
+			}
 
-			// Only update task state from engine if task is not already in a terminal state.
-			// Terminal states (CANCELLED, COMPLETED, FAILED, etc.) should be preserved -
-			// they represent the final state set by the apply execution.
+			// Engine state is translated to task state first. Stored task state
+			// can stay ahead of a stale engine poll; apply state is derived after
+			// task rows are coherent.
 			if !state.IsTerminalTaskState(activeTask.State) {
 				activeTask.State = taskState
 				now := time.Now()
 				activeTask.UpdatedAt = now
-				if result.State.IsTerminal() && !state.IsState(taskState, state.Task.FailedRetryable) && activeTask.CompletedAt == nil {
+				if state.IsTerminalTaskState(taskState) && activeTask.CompletedAt == nil {
 					activeTask.CompletedAt = &now
 				}
 				if result.State == engine.StateFailed && activeTask.ErrorMessage == "" {
@@ -860,8 +867,7 @@ func (c *LocalClient) Progress(ctx context.Context, req *ternv1.ProgressRequest)
 
 		// Look up engine progress for this table
 		if et, ok := engineProgressForTask(engineTableProgress, t); ok {
-			// Use live progress from engine (uppercase to match storage convention)
-			tp.Status = strings.ToUpper(et.State)
+			tp.Status = progressTableStatus(t.State, et.State)
 			tp.PercentComplete = int32(et.Progress)
 			tp.RowsCopied = et.RowsCopied
 			tp.RowsTotal = et.RowsTotal
@@ -891,7 +897,7 @@ func (c *LocalClient) Progress(ctx context.Context, req *ternv1.ProgressRequest)
 			for j, sh := range et.Shards {
 				shards[j] = &ternv1.ShardProgress{
 					Shard:           sh.Shard,
-					Status:          sh.State,
+					Status:          state.NormalizeShardStatus(sh.State),
 					RowsCopied:      sh.RowsCopied,
 					RowsTotal:       sh.RowsTotal,
 					EtaSeconds:      sh.ETASeconds,
@@ -1001,6 +1007,81 @@ func (c *LocalClient) Progress(ctx context.Context, req *ternv1.ProgressRequest)
 	}
 
 	return resp, nil
+}
+
+func progressTableStatus(storedTaskState, engineTableState string) string {
+	return taskStateWithNoBackwardProgress(storedTaskState, state.NormalizeTaskStatus(engineTableState))
+}
+
+// taskStateWithNoBackwardProgress applies the engine -> task -> apply ordering:
+// raw engine progress is first translated into a canonical task state, but a
+// stale engine poll cannot move a stored task back to an earlier phase. This
+// happens after restarts and terminal races where durable task storage is ahead
+// of a lagging per-table progress snapshot.
+func taskStateWithNoBackwardProgress(storedTaskState, engineTaskState string) string {
+	storedTaskState = state.NormalizeTaskStatus(storedTaskState)
+	engineTaskState = state.NormalizeTaskStatus(engineTaskState)
+
+	// A terminal stored task is already the durable final answer.
+	if state.IsTerminalTaskState(storedTaskState) {
+		return storedTaskState
+	}
+
+	// Terminal engine results, stopped tasks, and retryable failures are real
+	// outcomes from the current engine poll and can advance active storage.
+	if state.IsTerminalTaskState(engineTaskState) ||
+		state.IsState(engineTaskState, state.Task.Stopped, state.Task.FailedRetryable) {
+		return engineTaskState
+	}
+
+	// Scheduler/control-owned states block stale active engine progress.
+	if blocksActiveEngineProgress(storedTaskState) {
+		return storedTaskState
+	}
+
+	engineProgressRank, engineProgressRanked := activeTaskProgressRank(engineTaskState)
+	storedProgressRank, storedProgressRanked := activeTaskProgressRank(storedTaskState)
+
+	// Unknown future canonical task states should not be ordered implicitly.
+	if !engineProgressRanked || !storedProgressRanked {
+		return storedTaskState
+	}
+
+	// For ordinary active phases, never let storage/display move backward.
+	if engineProgressRank < storedProgressRank {
+		return storedTaskState
+	}
+	return engineTaskState
+}
+
+// blocksActiveEngineProgress identifies durable scheduler/control states that
+// should not be overwritten by a stale active engine poll. For example, a user
+// can stop a task while the engine still reports running for a short window, or
+// the scheduler can mark a task failed_retryable before a retry claims it.
+func blocksActiveEngineProgress(taskState string) bool {
+	return state.IsState(taskState, state.Task.Stopped, state.Task.FailedRetryable)
+}
+
+// activeTaskProgressRank orders ordinary active task phases. Terminal states
+// and scheduler/control-owned states are handled before this helper, so new
+// task states must be consciously assigned to one of those policies.
+func activeTaskProgressRank(taskState string) (int, bool) {
+	switch state.NormalizeTaskStatus(taskState) {
+	case state.Task.Pending:
+		return 0, true
+	case state.Task.WaitingForDeploy:
+		return 1, true
+	case state.Task.Running:
+		return 2, true
+	case state.Task.WaitingForCutover:
+		return 3, true
+	case state.Task.CuttingOver:
+		return 4, true
+	case state.Task.RevertWindow:
+		return 5, true
+	default:
+		return 0, false
+	}
 }
 
 func ensureMetadata(m map[string]string) map[string]string {

--- a/pkg/tern/local_client_test.go
+++ b/pkg/tern/local_client_test.go
@@ -3,11 +3,14 @@ package tern
 import (
 	"context"
 	"log/slog"
+	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	ternv1 "github.com/block/schemabot/pkg/proto/ternv1"
+	"github.com/block/schemabot/pkg/state"
 	"github.com/block/schemabot/pkg/storage"
 )
 
@@ -84,6 +87,94 @@ func TestLocalClient_ProgressByApplyIDReturnsNotFoundForMissingApplyData(t *test
 
 			_, err := client.Progress(t.Context(), &ternv1.ProgressRequest{ApplyId: "apply-missing"})
 			require.ErrorIs(t, err, tc.wantError)
+		})
+	}
+}
+
+func TestTaskStateWithNoBackwardProgressPolicyCoversTaskStates(t *testing.T) {
+	taskValue := reflect.ValueOf(state.Task)
+	taskType := taskValue.Type()
+
+	for i := range taskValue.NumField() {
+		taskName := taskType.Field(i).Name
+		taskState := taskValue.Field(i).String()
+		_, hasProgressRank := activeTaskProgressRank(taskState)
+		hasPolicy := state.IsTerminalTaskState(taskState) ||
+			blocksActiveEngineProgress(taskState) ||
+			hasProgressRank
+
+		assert.Truef(t, hasPolicy,
+			"task state %s=%q must be terminal, scheduler/control-owned, or ranked as active progress",
+			taskName, taskState)
+	}
+}
+
+func TestProgressTableStatusNormalizesEngineStateAndKeepsStoredStateAhead(t *testing.T) {
+	tests := []struct {
+		name             string
+		storedTaskState  string
+		engineTableState string
+		expected         string
+	}{
+		{
+			name:             "running engine state stays canonical",
+			storedTaskState:  state.Task.Pending,
+			engineTableState: "copyRows",
+			expected:         state.Task.Running,
+		},
+		{
+			name:             "unknown engine state defaults to running",
+			storedTaskState:  state.Task.Pending,
+			engineTableState: "something_unknown",
+			expected:         state.Task.Running,
+		},
+		{
+			name:             "terminal stored state wins over stale engine state",
+			storedTaskState:  state.Task.Completed,
+			engineTableState: state.Task.Running,
+			expected:         state.Task.Completed,
+		},
+		{
+			name:             "stored cutover wait does not move backward to running",
+			storedTaskState:  state.Task.WaitingForCutover,
+			engineTableState: state.Task.Running,
+			expected:         state.Task.WaitingForCutover,
+		},
+		{
+			name:             "stored running does not move backward to pending",
+			storedTaskState:  state.Task.Running,
+			engineTableState: "queued",
+			expected:         state.Task.Running,
+		},
+		{
+			name:             "terminal engine state can advance active stored state",
+			storedTaskState:  state.Task.Running,
+			engineTableState: "complete",
+			expected:         state.Task.Completed,
+		},
+		{
+			name:             "stopped engine state can advance active stored state",
+			storedTaskState:  state.Task.Running,
+			engineTableState: state.Task.Stopped,
+			expected:         state.Task.Stopped,
+		},
+		{
+			name:             "deploy wait can advance to running after deploy starts",
+			storedTaskState:  state.Task.WaitingForDeploy,
+			engineTableState: state.Task.Running,
+			expected:         state.Task.Running,
+		},
+		{
+			name:             "scheduler retryable state is preserved against active engine state",
+			storedTaskState:  state.Task.FailedRetryable,
+			engineTableState: state.Task.Running,
+			expected:         state.Task.FailedRetryable,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, progressTableStatus(tc.storedTaskState, tc.engineTableState))
 		})
 	}
 }

--- a/pkg/tern/state_converters.go
+++ b/pkg/tern/state_converters.go
@@ -72,7 +72,9 @@ func engineStateToStorage(es engine.State) string {
 	case engine.StateReverted:
 		return state.Task.Reverted
 	default:
-		return state.Task.Pending
+		// Unknown engine states represent in-flight work until proven otherwise.
+		// Keep them visible and blocking, and add an explicit mapping once known.
+		return state.Task.Running
 	}
 }
 


### PR DESCRIPTION
## Why
Local progress responses should never surface raw engine table states, move a stored task backward when the durable task row is already ahead of a stale engine poll, or treat unknown engine states as completed/pending without an explicit policy.

## What
- Normalize engine and shard progress states through canonical task state helpers
- Preserve stored task state when live engine progress reports an earlier active phase
- Default unknown engine states to running so unfamiliar in-flight work stays visible and blocking
- Document the engine -> task -> apply authority model and guard task-state ordering with tests
- Cover uppercase Vitess completion and no-backward local progress behavior

Generated with Codex