### PR TITLE
fix(github): always set Timestamp on generic error PR comments + centralize construction

### DIFF
--- a/pkg/webhook/apply_handlers.go
+++ b/pkg/webhook/apply_handlers.go
@@ -63,6 +63,7 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 		h.logger.Error("failed to fetch PR for checks gate", "error", err)
 		h.postComment(repo, pr, installationID, templates.RenderGenericError(templates.SchemaErrorData{
 			RequestedBy: requestedBy,
+			Timestamp:   time.Now().UTC().Format("2006-01-02 15:04:05"),
 			Environment: environment,
 			CommandName: action.Apply,
 			ErrorDetail: "Failed to fetch PR info: " + err.Error(),
@@ -90,6 +91,7 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 		h.logger.Error("failed to check lock", "error", err)
 		h.postComment(repo, pr, installationID, templates.RenderGenericError(templates.SchemaErrorData{
 			RequestedBy: requestedBy,
+			Timestamp:   time.Now().UTC().Format("2006-01-02 15:04:05"),
 			Environment: environment,
 			CommandName: action.Apply,
 			ErrorDetail: "Failed to check lock status: " + err.Error(),
@@ -164,6 +166,7 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 		h.logger.Error("plan execution failed", "repo", repo, "pr", pr, "error", err)
 		h.postComment(repo, pr, installationID, templates.RenderGenericError(templates.SchemaErrorData{
 			RequestedBy: requestedBy,
+			Timestamp:   time.Now().UTC().Format("2006-01-02 15:04:05"),
 			Environment: environment,
 			CommandName: action.Apply,
 			ErrorDetail: err.Error(),
@@ -201,6 +204,7 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 		h.logger.Error("failed to acquire lock", "error", err)
 		h.postComment(repo, pr, installationID, templates.RenderGenericError(templates.SchemaErrorData{
 			RequestedBy: requestedBy,
+			Timestamp:   time.Now().UTC().Format("2006-01-02 15:04:05"),
 			Environment: environment,
 			CommandName: action.Apply,
 			ErrorDetail: "Failed to acquire lock: " + err.Error(),
@@ -233,6 +237,7 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 				"repo", repo, "pr", pr, "database", database, "error", prErr)
 			h.postComment(repo, pr, installationID, templates.RenderGenericError(templates.SchemaErrorData{
 				RequestedBy: requestedBy,
+				Timestamp:   time.Now().UTC().Format("2006-01-02 15:04:05"),
 				Environment: environment,
 				CommandName: action.Apply,
 				ErrorDetail: "Failed to verify PR HEAD before auto-confirm: " + prErr.Error(),
@@ -329,6 +334,7 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 			"repo", repo, "pr", pr, "database", database, "error", prErr)
 		h.postComment(repo, pr, installationID, templates.RenderGenericError(templates.SchemaErrorData{
 			RequestedBy: requestedBy,
+			Timestamp:   time.Now().UTC().Format("2006-01-02 15:04:05"),
 			Environment: environment,
 			CommandName: action.Apply,
 			ErrorDetail: "Failed to verify PR HEAD before posting plan: " + prErr.Error(),
@@ -400,6 +406,7 @@ func (h *Handler) handleApplyConfirmCommand(repo string, pr int, environment, da
 		h.logger.Error("failed to fetch PR for checks gate", "error", err)
 		h.postComment(repo, pr, installationID, templates.RenderGenericError(templates.SchemaErrorData{
 			RequestedBy: requestedBy,
+			Timestamp:   time.Now().UTC().Format("2006-01-02 15:04:05"),
 			Environment: environment,
 			CommandName: action.ApplyConfirm,
 			ErrorDetail: "Failed to fetch PR info: " + err.Error(),
@@ -441,6 +448,7 @@ func (h *Handler) handleApplyConfirmCommand(repo string, pr int, environment, da
 		h.logger.Error("failed to check lock", "error", err)
 		h.postComment(repo, pr, installationID, templates.RenderGenericError(templates.SchemaErrorData{
 			RequestedBy: requestedBy,
+			Timestamp:   time.Now().UTC().Format("2006-01-02 15:04:05"),
 			Environment: environment,
 			CommandName: action.ApplyConfirm,
 			ErrorDetail: "Failed to check lock status: " + err.Error(),
@@ -493,6 +501,7 @@ func (h *Handler) handleApplyConfirmCommand(repo string, pr int, environment, da
 			"pending_plan_id", existingLock.PendingPlanID, "error", planLoadErr)
 		h.postComment(repo, pr, installationID, templates.RenderGenericError(templates.SchemaErrorData{
 			RequestedBy: requestedBy,
+			Timestamp:   time.Now().UTC().Format("2006-01-02 15:04:05"),
 			Environment: environment,
 			CommandName: action.ApplyConfirm,
 			ErrorDetail: "Failed to load confirmation plan: " + planLoadErr.Error(),
@@ -545,6 +554,7 @@ func (h *Handler) executeApply(
 		h.logger.Error("plan execution failed on confirm", "repo", repo, "pr", pr, "error", err)
 		h.postComment(repo, pr, installationID, templates.RenderGenericError(templates.SchemaErrorData{
 			RequestedBy: requestedBy,
+			Timestamp:   time.Now().UTC().Format("2006-01-02 15:04:05"),
 			Environment: environment,
 			CommandName: action.Apply,
 			ErrorDetail: err.Error(),
@@ -665,6 +675,7 @@ func (h *Handler) executeApply(
 		h.logger.Error("apply execution failed", "repo", repo, "pr", pr, "error", err)
 		h.postComment(repo, pr, installationID, templates.RenderGenericError(templates.SchemaErrorData{
 			RequestedBy: requestedBy,
+			Timestamp:   time.Now().UTC().Format("2006-01-02 15:04:05"),
 			Environment: environment,
 			CommandName: action.Apply,
 			ErrorDetail: "Failed to execute apply: " + err.Error(),
@@ -677,6 +688,7 @@ func (h *Handler) executeApply(
 		h.logger.Info("apply rejected by engine", "repo", repo, "pr", pr, "database", database, "environment", environment, "error", applyResp.ErrorMessage)
 		h.postComment(repo, pr, installationID, templates.RenderGenericError(templates.SchemaErrorData{
 			RequestedBy: requestedBy,
+			Timestamp:   time.Now().UTC().Format("2006-01-02 15:04:05"),
 			Environment: environment,
 			CommandName: action.Apply,
 			ErrorDetail: "Apply was not accepted: " + applyResp.ErrorMessage,
@@ -895,6 +907,7 @@ func (h *Handler) handleUnlockCommand(repo string, pr int, installationID int64,
 		h.logger.Error("failed to look up locks", "repo", repo, "pr", pr, "error", err)
 		h.postComment(repo, pr, installationID, templates.RenderGenericError(templates.SchemaErrorData{
 			RequestedBy: requestedBy,
+			Timestamp:   time.Now().UTC().Format("2006-01-02 15:04:05"),
 			CommandName: action.Unlock,
 			ErrorDetail: "Failed to look up locks: " + err.Error(),
 		}))

--- a/pkg/webhook/apply_handlers.go
+++ b/pkg/webhook/apply_handlers.go
@@ -41,13 +41,7 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 	// is authorized to run apply for this database.
 	if err := h.reconcileStaleChecks(ctx, client, repo, pr); err != nil {
 		h.logger.Error("failed to reconcile stale status checks", "repo", repo, "pr", pr, "error", err)
-		h.postComment(repo, pr, installationID, templates.RenderGenericError(templates.SchemaErrorData{
-			RequestedBy: requestedBy,
-			Timestamp:   time.Now().UTC().Format("2006-01-02 15:04:05"),
-			Environment: environment,
-			CommandName: action.Apply,
-			ErrorDetail: "Failed to reconcile stale status checks: " + err.Error(),
-		}))
+		h.postCommandError(repo, pr, installationID, action.Apply, environment, requestedBy, "Failed to reconcile stale status checks: "+err.Error())
 		return
 	}
 
@@ -61,13 +55,7 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 	prInfo, err := client.FetchPullRequest(ctx, repo, pr)
 	if err != nil {
 		h.logger.Error("failed to fetch PR for checks gate", "error", err)
-		h.postComment(repo, pr, installationID, templates.RenderGenericError(templates.SchemaErrorData{
-			RequestedBy: requestedBy,
-			Timestamp:   time.Now().UTC().Format("2006-01-02 15:04:05"),
-			Environment: environment,
-			CommandName: action.Apply,
-			ErrorDetail: "Failed to fetch PR info: " + err.Error(),
-		}))
+		h.postCommandError(repo, pr, installationID, action.Apply, environment, requestedBy, "Failed to fetch PR info: "+err.Error())
 		return
 	}
 	if blocked := h.enforcePassingChecks(ctx, client, repo, pr, installationID, prInfo.HeadSHA, environment); blocked {
@@ -89,13 +77,7 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 	existingLock, err := h.service.Storage().Locks().Get(ctx, database, dbType)
 	if err != nil {
 		h.logger.Error("failed to check lock", "error", err)
-		h.postComment(repo, pr, installationID, templates.RenderGenericError(templates.SchemaErrorData{
-			RequestedBy: requestedBy,
-			Timestamp:   time.Now().UTC().Format("2006-01-02 15:04:05"),
-			Environment: environment,
-			CommandName: action.Apply,
-			ErrorDetail: "Failed to check lock status: " + err.Error(),
-		}))
+		h.postCommandError(repo, pr, installationID, action.Apply, environment, requestedBy, "Failed to check lock status: "+err.Error())
 		return
 	}
 
@@ -164,13 +146,7 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 	planResp, err := h.service.ExecutePlan(ctx, planReq)
 	if err != nil {
 		h.logger.Error("plan execution failed", "repo", repo, "pr", pr, "error", err)
-		h.postComment(repo, pr, installationID, templates.RenderGenericError(templates.SchemaErrorData{
-			RequestedBy: requestedBy,
-			Timestamp:   time.Now().UTC().Format("2006-01-02 15:04:05"),
-			Environment: environment,
-			CommandName: action.Apply,
-			ErrorDetail: err.Error(),
-		}))
+		h.postCommandError(repo, pr, installationID, action.Apply, environment, requestedBy, err.Error())
 		return
 	}
 
@@ -202,13 +178,7 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 	}
 	if err := h.service.Storage().Locks().Acquire(ctx, lock); err != nil {
 		h.logger.Error("failed to acquire lock", "error", err)
-		h.postComment(repo, pr, installationID, templates.RenderGenericError(templates.SchemaErrorData{
-			RequestedBy: requestedBy,
-			Timestamp:   time.Now().UTC().Format("2006-01-02 15:04:05"),
-			Environment: environment,
-			CommandName: action.Apply,
-			ErrorDetail: "Failed to acquire lock: " + err.Error(),
-		}))
+		h.postCommandError(repo, pr, installationID, action.Apply, environment, requestedBy, "Failed to acquire lock: "+err.Error())
 		return
 	}
 
@@ -235,13 +205,7 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 		if prErr != nil {
 			h.logger.Error("failed to fetch PR for stale-schema check, releasing lock",
 				"repo", repo, "pr", pr, "database", database, "error", prErr)
-			h.postComment(repo, pr, installationID, templates.RenderGenericError(templates.SchemaErrorData{
-				RequestedBy: requestedBy,
-				Timestamp:   time.Now().UTC().Format("2006-01-02 15:04:05"),
-				Environment: environment,
-				CommandName: action.Apply,
-				ErrorDetail: "Failed to verify PR HEAD before auto-confirm: " + prErr.Error(),
-			}))
+			h.postCommandError(repo, pr, installationID, action.Apply, environment, requestedBy, "Failed to verify PR HEAD before auto-confirm: "+prErr.Error())
 			relErr := h.service.Storage().Locks().Release(ctx, database, dbType, lockOwner)
 			if relErr != nil && !errors.Is(relErr, storage.ErrLockNotFound) && !errors.Is(relErr, storage.ErrLockNotOwned) {
 				h.logger.Error("failed to release lock after PR fetch failure",
@@ -332,13 +296,7 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 	if prErr != nil {
 		h.logger.Error("failed to fetch PR for stale-schema check, releasing lock",
 			"repo", repo, "pr", pr, "database", database, "error", prErr)
-		h.postComment(repo, pr, installationID, templates.RenderGenericError(templates.SchemaErrorData{
-			RequestedBy: requestedBy,
-			Timestamp:   time.Now().UTC().Format("2006-01-02 15:04:05"),
-			Environment: environment,
-			CommandName: action.Apply,
-			ErrorDetail: "Failed to verify PR HEAD before posting plan: " + prErr.Error(),
-		}))
+		h.postCommandError(repo, pr, installationID, action.Apply, environment, requestedBy, "Failed to verify PR HEAD before posting plan: "+prErr.Error())
 		relErr := h.service.Storage().Locks().Release(ctx, database, dbType, lockOwner)
 		if relErr != nil && !errors.Is(relErr, storage.ErrLockNotFound) && !errors.Is(relErr, storage.ErrLockNotOwned) {
 			h.logger.Error("failed to release lock after PR fetch failure",
@@ -404,13 +362,7 @@ func (h *Handler) handleApplyConfirmCommand(repo string, pr int, environment, da
 	confirmPRInfo, err := client.FetchPullRequestNoCache(ctx, repo, pr)
 	if err != nil {
 		h.logger.Error("failed to fetch PR for checks gate", "error", err)
-		h.postComment(repo, pr, installationID, templates.RenderGenericError(templates.SchemaErrorData{
-			RequestedBy: requestedBy,
-			Timestamp:   time.Now().UTC().Format("2006-01-02 15:04:05"),
-			Environment: environment,
-			CommandName: action.ApplyConfirm,
-			ErrorDetail: "Failed to fetch PR info: " + err.Error(),
-		}))
+		h.postCommandError(repo, pr, installationID, action.ApplyConfirm, environment, requestedBy, "Failed to fetch PR info: "+err.Error())
 		return
 	}
 
@@ -446,13 +398,7 @@ func (h *Handler) handleApplyConfirmCommand(repo string, pr int, environment, da
 	existingLock, err := h.service.Storage().Locks().Get(ctx, database, dbType)
 	if err != nil {
 		h.logger.Error("failed to check lock", "error", err)
-		h.postComment(repo, pr, installationID, templates.RenderGenericError(templates.SchemaErrorData{
-			RequestedBy: requestedBy,
-			Timestamp:   time.Now().UTC().Format("2006-01-02 15:04:05"),
-			Environment: environment,
-			CommandName: action.ApplyConfirm,
-			ErrorDetail: "Failed to check lock status: " + err.Error(),
-		}))
+		h.postCommandError(repo, pr, installationID, action.ApplyConfirm, environment, requestedBy, "Failed to check lock status: "+err.Error())
 		return
 	}
 	if existingLock == nil {
@@ -499,13 +445,7 @@ func (h *Handler) handleApplyConfirmCommand(repo string, pr int, environment, da
 		h.logger.Error("failed to load confirmation plan for cross-delivery freshness check",
 			"repo", repo, "pr", pr, "database", database, "database_type", dbType, "environment", environment,
 			"pending_plan_id", existingLock.PendingPlanID, "error", planLoadErr)
-		h.postComment(repo, pr, installationID, templates.RenderGenericError(templates.SchemaErrorData{
-			RequestedBy: requestedBy,
-			Timestamp:   time.Now().UTC().Format("2006-01-02 15:04:05"),
-			Environment: environment,
-			CommandName: action.ApplyConfirm,
-			ErrorDetail: "Failed to load confirmation plan: " + planLoadErr.Error(),
-		}))
+		h.postCommandError(repo, pr, installationID, action.ApplyConfirm, environment, requestedBy, "Failed to load confirmation plan: "+planLoadErr.Error())
 		return
 	}
 	if rejected := h.assertPlanStillCurrent(ctx, repo, pr, installationID, storedPlan, confirmPRInfo.HeadSHA, environment, requestedBy); rejected {
@@ -552,13 +492,7 @@ func (h *Handler) executeApply(
 	planResp, err := h.service.ExecutePlan(ctx, planReq)
 	if err != nil {
 		h.logger.Error("plan execution failed on confirm", "repo", repo, "pr", pr, "error", err)
-		h.postComment(repo, pr, installationID, templates.RenderGenericError(templates.SchemaErrorData{
-			RequestedBy: requestedBy,
-			Timestamp:   time.Now().UTC().Format("2006-01-02 15:04:05"),
-			Environment: environment,
-			CommandName: action.Apply,
-			ErrorDetail: err.Error(),
-		}))
+		h.postCommandError(repo, pr, installationID, action.Apply, environment, requestedBy, err.Error())
 		return
 	}
 
@@ -673,26 +607,14 @@ func (h *Handler) executeApply(
 	if err != nil {
 		h.service.SetPendingObserver(database, "", environment, nil)
 		h.logger.Error("apply execution failed", "repo", repo, "pr", pr, "error", err)
-		h.postComment(repo, pr, installationID, templates.RenderGenericError(templates.SchemaErrorData{
-			RequestedBy: requestedBy,
-			Timestamp:   time.Now().UTC().Format("2006-01-02 15:04:05"),
-			Environment: environment,
-			CommandName: action.Apply,
-			ErrorDetail: "Failed to execute apply: " + err.Error(),
-		}))
+		h.postCommandError(repo, pr, installationID, action.Apply, environment, requestedBy, "Failed to execute apply: "+err.Error())
 		return
 	}
 
 	if !applyResp.Accepted {
 		h.service.SetPendingObserver(database, "", environment, nil)
 		h.logger.Info("apply rejected by engine", "repo", repo, "pr", pr, "database", database, "environment", environment, "error", applyResp.ErrorMessage)
-		h.postComment(repo, pr, installationID, templates.RenderGenericError(templates.SchemaErrorData{
-			RequestedBy: requestedBy,
-			Timestamp:   time.Now().UTC().Format("2006-01-02 15:04:05"),
-			Environment: environment,
-			CommandName: action.Apply,
-			ErrorDetail: "Apply was not accepted: " + applyResp.ErrorMessage,
-		}))
+		h.postCommandError(repo, pr, installationID, action.Apply, environment, requestedBy, "Apply was not accepted: "+applyResp.ErrorMessage)
 		return
 	}
 
@@ -703,13 +625,7 @@ func (h *Handler) executeApply(
 		h.logger.Error("accepted apply did not return an apply id",
 			"repo", repo, "pr", pr, "database", database,
 			"database_type", schemaResult.Type, "environment", environment)
-		h.postComment(repo, pr, installationID, templates.RenderGenericError(templates.SchemaErrorData{
-			RequestedBy: requestedBy,
-			Timestamp:   time.Now().UTC().Format("2006-01-02 15:04:05"),
-			Environment: environment,
-			CommandName: action.Apply,
-			ErrorDetail: "Apply was accepted, but SchemaBot did not receive a stored apply ID. SchemaBot cannot safely track progress or update required status checks. An operator must reconcile the apply state before retrying.",
-		}))
+		h.postCommandError(repo, pr, installationID, action.Apply, environment, requestedBy, "Apply was accepted, but SchemaBot did not receive a stored apply ID. SchemaBot cannot safely track progress or update required status checks. An operator must reconcile the apply state before retrying.")
 		return
 	}
 
@@ -749,13 +665,7 @@ func (h *Handler) executeApply(
 			"repo", repo, "pr", pr, "database", database,
 			"database_type", schemaResult.Type, "environment", environment,
 			"apply_id", applyID, "error", err)
-		h.postComment(repo, pr, installationID, templates.RenderGenericError(templates.SchemaErrorData{
-			RequestedBy: requestedBy,
-			Timestamp:   time.Now().UTC().Format("2006-01-02 15:04:05"),
-			Environment: environment,
-			CommandName: action.Apply,
-			ErrorDetail: "Apply was accepted, but SchemaBot could not update the required status check: " + err.Error(),
-		}))
+		h.postCommandError(repo, pr, installationID, action.Apply, environment, requestedBy, "Apply was accepted, but SchemaBot could not update the required status check: "+err.Error())
 		return
 	}
 }
@@ -905,12 +815,7 @@ func (h *Handler) handleUnlockCommand(repo string, pr int, installationID int64,
 	locks, err := h.service.Storage().Locks().GetByPR(ctx, repo, pr)
 	if err != nil {
 		h.logger.Error("failed to look up locks", "repo", repo, "pr", pr, "error", err)
-		h.postComment(repo, pr, installationID, templates.RenderGenericError(templates.SchemaErrorData{
-			RequestedBy: requestedBy,
-			Timestamp:   time.Now().UTC().Format("2006-01-02 15:04:05"),
-			CommandName: action.Unlock,
-			ErrorDetail: "Failed to look up locks: " + err.Error(),
-		}))
+		h.postCommandError(repo, pr, installationID, action.Unlock, "", requestedBy, "Failed to look up locks: "+err.Error())
 		return
 	}
 

--- a/pkg/webhook/error_comment.go
+++ b/pkg/webhook/error_comment.go
@@ -1,0 +1,32 @@
+package webhook
+
+import (
+	"time"
+
+	"github.com/block/schemabot/pkg/webhook/templates"
+)
+
+// postCommandError posts a generic command-failure comment to the PR with a
+// consistent UTC timestamp.
+//
+// Centralized so handlers cannot accidentally omit Timestamp, which previously
+// caused the comment footer to render as "Requested by @<user> at  UTC"
+// (empty timestamp). See block/schemabot#163.
+//
+// Specialized error templates (RenderDatabaseNotFound, RenderInvalidConfig,
+// RenderNoConfig, RenderMultipleConfigs, RenderReviewRequired,
+// RenderUnsafeChangesBlocked, etc.) are intentionally not routed through this
+// helper — they have additional fields or distinct rendering and remain
+// constructed explicitly by their handlers.
+func (h *Handler) postCommandError(
+	repo string, pr int, installationID int64,
+	commandName, environment, requestedBy, errorDetail string,
+) {
+	h.postComment(repo, pr, installationID, templates.RenderGenericError(templates.SchemaErrorData{
+		RequestedBy: requestedBy,
+		Timestamp:   time.Now().UTC().Format("2006-01-02 15:04:05"),
+		Environment: environment,
+		CommandName: commandName,
+		ErrorDetail: errorDetail,
+	}))
+}

--- a/pkg/webhook/error_comment.go
+++ b/pkg/webhook/error_comment.go
@@ -1,8 +1,6 @@
 package webhook
 
 import (
-	"time"
-
 	"github.com/block/schemabot/pkg/webhook/templates"
 )
 
@@ -11,7 +9,10 @@ import (
 //
 // Centralized so handlers cannot accidentally omit Timestamp, which previously
 // caused the comment footer to render as "Requested by @<user> at  UTC"
-// (empty timestamp). See block/schemabot#163.
+// (empty timestamp).
+//
+// Uses templates.NowFunc so previews and tests can substitute a deterministic
+// clock — the same hook used by templates that already render UTC timestamps.
 //
 // Specialized error templates (RenderDatabaseNotFound, RenderInvalidConfig,
 // RenderNoConfig, RenderMultipleConfigs, RenderReviewRequired,
@@ -24,7 +25,7 @@ func (h *Handler) postCommandError(
 ) {
 	h.postComment(repo, pr, installationID, templates.RenderGenericError(templates.SchemaErrorData{
 		RequestedBy: requestedBy,
-		Timestamp:   time.Now().UTC().Format("2006-01-02 15:04:05"),
+		Timestamp:   templates.NowFunc().UTC().Format("2006-01-02 15:04:05"),
 		Environment: environment,
 		CommandName: commandName,
 		ErrorDetail: errorDetail,

--- a/pkg/webhook/error_comment_test.go
+++ b/pkg/webhook/error_comment_test.go
@@ -1,0 +1,62 @@
+package webhook
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	ghclient "github.com/block/schemabot/pkg/github"
+	"github.com/block/schemabot/pkg/webhook/templates"
+)
+
+// postCommandError must always render a non-empty timestamp in the comment
+// footer. A regression of the original bug renders "at  UTC" (two spaces) and
+// is what the helper exists to prevent.
+func TestPostCommandError_RendersTimestamp(t *testing.T) {
+	original := templates.NowFunc
+	t.Cleanup(func() { templates.NowFunc = original })
+	templates.NowFunc = func() time.Time {
+		return time.Date(2026, 5, 26, 12, 34, 56, 0, time.UTC)
+	}
+
+	client, mux := setupGitHubServer(t)
+	bodies := make(chan string, 1)
+	mux.HandleFunc("POST /repos/octocat/hello-world/issues/1/comments", func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Body string `json:"body"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		bodies <- body.Body
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": 99})
+	})
+
+	h := &Handler{
+		ghClient: &fakeClientFactory{client: ghclient.NewInstallationClient(client, testLogger())},
+		logger:   testLogger(),
+	}
+
+	h.postCommandError(
+		"octocat/hello-world", 1, 12345,
+		"plan", "staging", "alice",
+		"boom",
+	)
+
+	select {
+	case body := <-bodies:
+		assert.NotContains(t, body, "at  UTC",
+			"comment must not render empty timestamp")
+		assert.Contains(t, body, "at 2026-05-26 12:34:56 UTC",
+			"comment must render the stubbed timestamp from templates.NowFunc")
+		assert.Contains(t, body, "*Requested by @alice")
+		assert.Contains(t, body, "Plan Failed")
+		assert.Contains(t, body, "`staging`")
+		assert.Contains(t, body, "> boom")
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for posted comment")
+	}
+}

--- a/pkg/webhook/plan.go
+++ b/pkg/webhook/plan.go
@@ -27,13 +27,7 @@ func (h *Handler) handlePlanCommand(w http.ResponseWriter, repo string, pr int, 
 	// Fix checks stuck at "in_progress" from crashed applies
 	if err := h.reconcileStaleChecks(ctx, client, repo, pr); err != nil {
 		h.logger.Error("failed to reconcile stale status checks", "repo", repo, "pr", pr, "error", err)
-		h.postComment(repo, pr, installationID, templates.RenderGenericError(templates.SchemaErrorData{
-			RequestedBy: requestedBy,
-			Timestamp:   time.Now().UTC().Format("2006-01-02 15:04:05"),
-			Environment: environment,
-			CommandName: action.Plan,
-			ErrorDetail: "Failed to reconcile stale status checks: " + err.Error(),
-		}))
+		h.postCommandError(repo, pr, installationID, action.Plan, environment, requestedBy, "Failed to reconcile stale status checks: "+err.Error())
 		h.writeJSON(w, http.StatusOK, map[string]string{"message": "status check reconciliation failed"})
 		return
 	}
@@ -54,13 +48,7 @@ func (h *Handler) handlePlanCommand(w http.ResponseWriter, repo string, pr int, 
 	freshPRInfo, err := client.FetchPullRequestNoCache(ctx, repo, pr)
 	if err != nil {
 		h.logger.Error("failed to fetch PR for stale-schema check", "repo", repo, "pr", pr, "error", err)
-		h.postComment(repo, pr, installationID, templates.RenderGenericError(templates.SchemaErrorData{
-			RequestedBy: requestedBy,
-			Timestamp:   time.Now().UTC().Format("2006-01-02 15:04:05"),
-			Environment: environment,
-			CommandName: action.Plan,
-			ErrorDetail: "Failed to verify PR HEAD: " + err.Error(),
-		}))
+		h.postCommandError(repo, pr, installationID, action.Plan, environment, requestedBy, "Failed to verify PR HEAD: "+err.Error())
 		h.writeJSON(w, http.StatusOK, map[string]string{"message": "PR fetch failed"})
 		return
 	}
@@ -91,13 +79,7 @@ func (h *Handler) handlePlanCommand(w http.ResponseWriter, repo string, pr int, 
 		h.postFailingAggregates(ctx, client, repo, pr, schemaResult.HeadSHA, map[string]string{
 			environment: userFacingError(err),
 		})
-		h.postComment(repo, pr, installationID, templates.RenderGenericError(templates.SchemaErrorData{
-			RequestedBy: requestedBy,
-			Timestamp:   time.Now().UTC().Format("2006-01-02 15:04:05"),
-			Environment: environment,
-			CommandName: action.Plan,
-			ErrorDetail: err.Error(),
-		}))
+		h.postCommandError(repo, pr, installationID, action.Plan, environment, requestedBy, err.Error())
 		h.writeJSON(w, http.StatusOK, map[string]string{"message": "plan failed"})
 		return
 	}
@@ -138,12 +120,7 @@ func (h *Handler) handleMultiEnvPlan(repo string, pr int, databaseName string, i
 	// Fix checks stuck at "in_progress" from crashed applies
 	if err := h.reconcileStaleChecks(ctx, client, repo, pr); err != nil {
 		h.logger.Error("failed to reconcile stale status checks", "repo", repo, "pr", pr, "error", err)
-		h.postComment(repo, pr, installationID, templates.RenderGenericError(templates.SchemaErrorData{
-			RequestedBy: requestedBy,
-			Timestamp:   time.Now().UTC().Format("2006-01-02 15:04:05"),
-			CommandName: action.Plan,
-			ErrorDetail: "Failed to reconcile stale status checks: " + err.Error(),
-		}))
+		h.postCommandError(repo, pr, installationID, action.Plan, "", requestedBy, "Failed to reconcile stale status checks: "+err.Error())
 		return
 	}
 
@@ -245,12 +222,7 @@ func (h *Handler) handleMultiEnvPlan(repo string, pr int, databaseName string, i
 				if prErr != nil {
 					h.logger.Error("failed to fetch PR for stale-schema check",
 						"repo", repo, "pr", pr, "error", prErr)
-					h.postComment(repo, pr, installationID, templates.RenderGenericError(templates.SchemaErrorData{
-						RequestedBy: requestedBy,
-						Timestamp:   time.Now().UTC().Format("2006-01-02 15:04:05"),
-						CommandName: action.Plan,
-						ErrorDetail: "Failed to verify PR HEAD: " + prErr.Error(),
-					}))
+					h.postCommandError(repo, pr, installationID, action.Plan, "", requestedBy, "Failed to verify PR HEAD: "+prErr.Error())
 					return
 				}
 				if rejected := h.assertSchemaStillCurrent(ctx, repo, pr, installationID, schemaResult, freshPRInfo.HeadSHA, env, requestedBy, action.Plan); rejected {

--- a/pkg/webhook/review_gate.go
+++ b/pkg/webhook/review_gate.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hmarr/codeowners"
 
@@ -27,6 +28,7 @@ func (h *Handler) enforceReviewGate(ctx context.Context, client *ghclient.Instal
 		h.logger.Error("review gate check failed", "error", err)
 		h.postComment(repo, pr, installationID, templates.RenderGenericError(templates.SchemaErrorData{
 			RequestedBy: requestedBy,
+			Timestamp:   time.Now().UTC().Format("2006-01-02 15:04:05"),
 			Environment: environment,
 			CommandName: commandName,
 			ErrorDetail: reviewGateErrorDetail(err),

--- a/pkg/webhook/review_gate.go
+++ b/pkg/webhook/review_gate.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/hmarr/codeowners"
 
@@ -26,13 +25,7 @@ func (h *Handler) enforceReviewGate(ctx context.Context, client *ghclient.Instal
 	gateResult, err := h.checkReviewGate(ctx, client, repo, pr, schemaResult.SchemaPath)
 	if err != nil {
 		h.logger.Error("review gate check failed", "error", err)
-		h.postComment(repo, pr, installationID, templates.RenderGenericError(templates.SchemaErrorData{
-			RequestedBy: requestedBy,
-			Timestamp:   time.Now().UTC().Format("2006-01-02 15:04:05"),
-			Environment: environment,
-			CommandName: commandName,
-			ErrorDetail: reviewGateErrorDetail(err),
-		}))
+		h.postCommandError(repo, pr, installationID, commandName, environment, requestedBy, reviewGateErrorDetail(err))
 		return true
 	}
 	if gateResult != nil && !gateResult.Approved {

--- a/pkg/webhook/rollback.go
+++ b/pkg/webhook/rollback.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/block/schemabot/pkg/api"
 	"github.com/block/schemabot/pkg/state"
@@ -35,12 +34,7 @@ func (h *Handler) handleRollbackCommand(repo string, pr int, installationID int6
 	apply, err := h.service.Storage().Applies().GetByApplyIdentifier(ctx, applyID)
 	if err != nil {
 		h.logger.Error("failed to look up apply", "applyID", applyID, "error", err)
-		h.postComment(repo, pr, installationID, templates.RenderGenericError(templates.SchemaErrorData{
-			RequestedBy: requestedBy,
-			Timestamp:   time.Now().UTC().Format("2006-01-02 15:04:05"),
-			CommandName: action.Rollback,
-			ErrorDetail: "Failed to look up apply: " + err.Error(),
-		}))
+		h.postCommandError(repo, pr, installationID, action.Rollback, "", requestedBy, "Failed to look up apply: "+err.Error())
 		return
 	}
 	if apply == nil {
@@ -65,13 +59,7 @@ func (h *Handler) handleRollbackCommand(repo string, pr int, installationID int6
 	existingLock, err := h.service.Storage().Locks().Get(ctx, database, dbType)
 	if err != nil {
 		h.logger.Error("failed to check lock", "error", err)
-		h.postComment(repo, pr, installationID, templates.RenderGenericError(templates.SchemaErrorData{
-			RequestedBy: requestedBy,
-			Timestamp:   time.Now().UTC().Format("2006-01-02 15:04:05"),
-			Environment: environment,
-			CommandName: action.Rollback,
-			ErrorDetail: "Failed to check lock status: " + err.Error(),
-		}))
+		h.postCommandError(repo, pr, installationID, action.Rollback, environment, requestedBy, "Failed to check lock status: "+err.Error())
 		return
 	}
 
@@ -93,13 +81,7 @@ func (h *Handler) handleRollbackCommand(repo string, pr int, installationID int6
 			return
 		}
 		h.logger.Error("rollback plan failed", "repo", repo, "pr", pr, "applyID", applyID, "error", err)
-		h.postComment(repo, pr, installationID, templates.RenderGenericError(templates.SchemaErrorData{
-			RequestedBy: requestedBy,
-			Timestamp:   time.Now().UTC().Format("2006-01-02 15:04:05"),
-			Environment: environment,
-			CommandName: action.Rollback,
-			ErrorDetail: errMsg,
-		}))
+		h.postCommandError(repo, pr, installationID, action.Rollback, environment, requestedBy, errMsg)
 		return
 	}
 
@@ -119,13 +101,7 @@ func (h *Handler) handleRollbackCommand(repo string, pr int, installationID int6
 	}
 	if err := h.service.Storage().Locks().Acquire(ctx, lock); err != nil {
 		h.logger.Error("failed to acquire lock", "error", err)
-		h.postComment(repo, pr, installationID, templates.RenderGenericError(templates.SchemaErrorData{
-			RequestedBy: requestedBy,
-			Timestamp:   time.Now().UTC().Format("2006-01-02 15:04:05"),
-			Environment: environment,
-			CommandName: action.Rollback,
-			ErrorDetail: "Failed to acquire lock: " + err.Error(),
-		}))
+		h.postCommandError(repo, pr, installationID, action.Rollback, environment, requestedBy, "Failed to acquire lock: "+err.Error())
 		return
 	}
 
@@ -187,13 +163,7 @@ func (h *Handler) handleRollbackConfirmCommand(repo string, pr int, environment,
 	existingLock, err := h.service.Storage().Locks().Get(ctx, database, dbType)
 	if err != nil {
 		h.logger.Error("failed to check lock", "error", err)
-		h.postComment(repo, pr, installationID, templates.RenderGenericError(templates.SchemaErrorData{
-			RequestedBy: requestedBy,
-			Timestamp:   time.Now().UTC().Format("2006-01-02 15:04:05"),
-			Environment: environment,
-			CommandName: action.RollbackConfirm,
-			ErrorDetail: "Failed to check lock status: " + err.Error(),
-		}))
+		h.postCommandError(repo, pr, installationID, action.RollbackConfirm, environment, requestedBy, "Failed to check lock status: "+err.Error())
 		return
 	}
 	if existingLock == nil {
@@ -210,13 +180,7 @@ func (h *Handler) handleRollbackConfirmCommand(repo string, pr int, environment,
 	planResp, err := h.service.ExecuteRollbackPlan(ctx, database, environment, "")
 	if err != nil {
 		h.logger.Error("rollback plan failed on confirm", "repo", repo, "pr", pr, "error", err)
-		h.postComment(repo, pr, installationID, templates.RenderGenericError(templates.SchemaErrorData{
-			RequestedBy: requestedBy,
-			Timestamp:   time.Now().UTC().Format("2006-01-02 15:04:05"),
-			Environment: environment,
-			CommandName: action.RollbackConfirm,
-			ErrorDetail: err.Error(),
-		}))
+		h.postCommandError(repo, pr, installationID, action.RollbackConfirm, environment, requestedBy, err.Error())
 		return
 	}
 
@@ -248,13 +212,7 @@ func (h *Handler) handleRollbackConfirmCommand(repo string, pr int, environment,
 	applyResp, applyID, err := h.service.ExecuteApply(ctx, applyReq)
 	if err != nil {
 		h.logger.Error("rollback apply failed", "repo", repo, "pr", pr, "error", err)
-		h.postComment(repo, pr, installationID, templates.RenderGenericError(templates.SchemaErrorData{
-			RequestedBy: requestedBy,
-			Timestamp:   time.Now().UTC().Format("2006-01-02 15:04:05"),
-			Environment: environment,
-			CommandName: action.RollbackConfirm,
-			ErrorDetail: "Failed to execute rollback: " + err.Error(),
-		}))
+		h.postCommandError(repo, pr, installationID, action.RollbackConfirm, environment, requestedBy, "Failed to execute rollback: "+err.Error())
 		return
 	}
 
@@ -272,13 +230,7 @@ func (h *Handler) handleRollbackConfirmCommand(repo string, pr int, environment,
 		h.logger.Error("accepted rollback did not return an apply id",
 			"repo", repo, "pr", pr, "database", database,
 			"database_type", dbType, "environment", environment)
-		h.postComment(repo, pr, installationID, templates.RenderGenericError(templates.SchemaErrorData{
-			RequestedBy: requestedBy,
-			Timestamp:   time.Now().UTC().Format("2006-01-02 15:04:05"),
-			Environment: environment,
-			CommandName: action.RollbackConfirm,
-			ErrorDetail: "Rollback was accepted, but SchemaBot did not receive a stored apply ID. SchemaBot cannot safely track progress or update required status checks. An operator must reconcile the apply state before retrying.",
-		}))
+		h.postCommandError(repo, pr, installationID, action.RollbackConfirm, environment, requestedBy, "Rollback was accepted, but SchemaBot did not receive a stored apply ID. SchemaBot cannot safely track progress or update required status checks. An operator must reconcile the apply state before retrying.")
 		return
 	}
 
@@ -302,13 +254,7 @@ func (h *Handler) handleRollbackConfirmCommand(repo string, pr int, environment,
 			"repo", repo, "pr", pr, "database", database,
 			"database_type", dbType, "environment", environment,
 			"apply_id", applyID, "error", err)
-		h.postComment(repo, pr, installationID, templates.RenderGenericError(templates.SchemaErrorData{
-			RequestedBy: requestedBy,
-			Timestamp:   time.Now().UTC().Format("2006-01-02 15:04:05"),
-			Environment: environment,
-			CommandName: action.RollbackConfirm,
-			ErrorDetail: "Rollback was accepted, but SchemaBot could not update the required status check: " + err.Error(),
-		}))
+		h.postCommandError(repo, pr, installationID, action.RollbackConfirm, environment, requestedBy, "Rollback was accepted, but SchemaBot could not update the required status check: "+err.Error())
 		return
 	}
 

--- a/pkg/webhook/rollback.go
+++ b/pkg/webhook/rollback.go
@@ -37,6 +37,7 @@ func (h *Handler) handleRollbackCommand(repo string, pr int, installationID int6
 		h.logger.Error("failed to look up apply", "applyID", applyID, "error", err)
 		h.postComment(repo, pr, installationID, templates.RenderGenericError(templates.SchemaErrorData{
 			RequestedBy: requestedBy,
+			Timestamp:   time.Now().UTC().Format("2006-01-02 15:04:05"),
 			CommandName: action.Rollback,
 			ErrorDetail: "Failed to look up apply: " + err.Error(),
 		}))
@@ -66,6 +67,7 @@ func (h *Handler) handleRollbackCommand(repo string, pr int, installationID int6
 		h.logger.Error("failed to check lock", "error", err)
 		h.postComment(repo, pr, installationID, templates.RenderGenericError(templates.SchemaErrorData{
 			RequestedBy: requestedBy,
+			Timestamp:   time.Now().UTC().Format("2006-01-02 15:04:05"),
 			Environment: environment,
 			CommandName: action.Rollback,
 			ErrorDetail: "Failed to check lock status: " + err.Error(),
@@ -93,6 +95,7 @@ func (h *Handler) handleRollbackCommand(repo string, pr int, installationID int6
 		h.logger.Error("rollback plan failed", "repo", repo, "pr", pr, "applyID", applyID, "error", err)
 		h.postComment(repo, pr, installationID, templates.RenderGenericError(templates.SchemaErrorData{
 			RequestedBy: requestedBy,
+			Timestamp:   time.Now().UTC().Format("2006-01-02 15:04:05"),
 			Environment: environment,
 			CommandName: action.Rollback,
 			ErrorDetail: errMsg,
@@ -118,6 +121,7 @@ func (h *Handler) handleRollbackCommand(repo string, pr int, installationID int6
 		h.logger.Error("failed to acquire lock", "error", err)
 		h.postComment(repo, pr, installationID, templates.RenderGenericError(templates.SchemaErrorData{
 			RequestedBy: requestedBy,
+			Timestamp:   time.Now().UTC().Format("2006-01-02 15:04:05"),
 			Environment: environment,
 			CommandName: action.Rollback,
 			ErrorDetail: "Failed to acquire lock: " + err.Error(),
@@ -185,6 +189,7 @@ func (h *Handler) handleRollbackConfirmCommand(repo string, pr int, environment,
 		h.logger.Error("failed to check lock", "error", err)
 		h.postComment(repo, pr, installationID, templates.RenderGenericError(templates.SchemaErrorData{
 			RequestedBy: requestedBy,
+			Timestamp:   time.Now().UTC().Format("2006-01-02 15:04:05"),
 			Environment: environment,
 			CommandName: action.RollbackConfirm,
 			ErrorDetail: "Failed to check lock status: " + err.Error(),


### PR DESCRIPTION
## What and Why ?

Closes #163.

1. **`fix(webhook): always set Timestamp on generic error comments`** — adds `Timestamp: time.Now().UTC().Format(...)` to the 19 of 31 `RenderGenericError(SchemaErrorData{...})` sites that were silently omitting it. Closes the user-visible bug where the comment footer rendered as `*Requested by @<user> at  UTC*` (two spaces, no time).

2. **`refactor(webhook): centralize generic error comment construction`** — introduces `postCommandError` on `*Handler` in `pkg/webhook/error_comment.go` and converts all 31 sites. The helper always sets `Timestamp`, so the bug can't be reintroduced structurally — handlers no longer construct the `SchemaErrorData` literal themselves.

Specialized error templates (`RenderDatabaseNotFound`, `RenderInvalidConfig`, `RenderNoConfig`, `RenderMultipleConfigs`, `RenderReviewRequired`, `RenderUnsafeChangesBlocked`, etc.) remain untouched — they have additional fields or distinct rendering and stay constructed explicitly by their handlers.

Each former 6-line error literal collapses to one helper call.
