### PR TITLE
fix(scheduler): stabilize gRPC progress reconciliation

### DIFF
--- a/e2e/k8s/data-plane-values.yaml
+++ b/e2e/k8s/data-plane-values.yaml
@@ -8,6 +8,8 @@ image:
   tag: test
   pullPolicy: Never
 
+replicaCount: 2
+
 grpc:
   enabled: true
   port: 13370

--- a/e2e/k8s/k8s_test.go
+++ b/e2e/k8s/k8s_test.go
@@ -45,6 +45,7 @@
 package k8s
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
 	"fmt"
@@ -58,12 +59,15 @@ import (
 	"github.com/block/schemabot/e2e/testutil"
 	"github.com/block/schemabot/pkg/apitypes"
 	"github.com/block/schemabot/pkg/cmd/client"
+	ternv1 "github.com/block/schemabot/pkg/proto/ternv1"
 	"github.com/block/schemabot/pkg/state"
 	"github.com/block/schemabot/pkg/storage"
 	"github.com/block/spirit/pkg/lint"
 	"github.com/block/spirit/pkg/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 func storageDSNs(t *testing.T) []string {
@@ -344,19 +348,127 @@ func TestK8s_Progress(t *testing.T) {
 	testutil.WaitForState(t, ep, applyID, state.Apply.Completed, testutil.PollDeadline)
 }
 
+// TestK8s_ProgressStableAcrossDataPlaneReplicas verifies that gRPC progress is
+// stable when a data-plane service has multiple pods. Only one pod owns the
+// in-memory Spirit runner, but every pod must be able to answer Progress from
+// shared storage without downgrading row-copy progress.
+func TestK8s_ProgressStableAcrossDataPlaneReplicas(t *testing.T) {
+	pods := podNamesForInstance(t, "data-plane")
+	require.GreaterOrEqual(t, len(pods), 2, "expected k8s e2e data plane to run at least two replicas")
+
+	endpoints := make([]dataPlanePodEndpoint, 0, len(pods))
+	for _, pod := range pods {
+		endpoints = append(endpoints, dataPlanePodEndpoint{
+			pod:     pod,
+			address: startDataPlanePodGRPCPortForward(t, pod),
+		})
+	}
+
+	fixture := startIndexAddApply(t, "k8s_dp_replicas", false)
+	tablesByPod := waitForDataPlanePodsRowCopyProgress(t, endpoints, fixture.DataPlaneApplyID, fixture.TableName)
+
+	for _, pod := range pods {
+		table := tablesByPod[pod]
+		require.NotNil(t, table, "data-plane pod %s should report row-copy progress", pod)
+		assert.Equal(t, fixture.TableName, table.TableName, "data-plane pod %s should report the target table", pod)
+		assert.Positive(t, table.RowsTotal, "data-plane pod %s should preserve row-copy totals", pod)
+		assert.True(t, hasRowCopyProgress(table.RowsTotal, table.RowsCopied, table.PercentComplete), "data-plane pod %s should preserve row-copy progress", pod)
+	}
+
+	testutil.WaitForState(t, fixture.Endpoint, fixture.ApplyID, state.Apply.Completed, 3*time.Minute)
+	waitForIndex(t, fixture.TargetDSN, fixture.TableName, "idx_account_created", testutil.PollDeadline)
+}
+
+type dataPlanePodEndpoint struct {
+	pod     string
+	address string
+}
+
+func waitForDataPlanePodsRowCopyProgress(t *testing.T, endpoints []dataPlanePodEndpoint, applyID, tableName string) map[string]*ternv1.TableProgress {
+	t.Helper()
+
+	clients := make(map[string]ternv1.TernClient, len(endpoints))
+	for _, endpoint := range endpoints {
+		conn, err := grpc.NewClient(endpoint.address, grpc.WithTransportCredentials(insecure.NewCredentials()))
+		require.NoError(t, err)
+		defer utils.CloseAndLog(conn)
+		clients[endpoint.pod] = ternv1.NewTernClient(conn)
+	}
+
+	matchedTables := make(map[string]*ternv1.TableProgress, len(endpoints))
+	lastResponses := make(map[string]*ternv1.ProgressResponse, len(endpoints))
+	lastErrors := make(map[string]error, len(endpoints))
+	testutil.Poll(t, testutil.PollDeadline, testutil.PollInterval,
+		func() bool {
+			for _, endpoint := range endpoints {
+				if matchedTables[endpoint.pod] != nil {
+					continue
+				}
+				ctx, cancel := context.WithTimeout(t.Context(), testutil.ProgressTimeout)
+				resp, err := clients[endpoint.pod].Progress(ctx, &ternv1.ProgressRequest{
+					ApplyId:     applyID,
+					Database:    "testapp",
+					Environment: "staging",
+				})
+				cancel()
+				lastErrors[endpoint.pod] = err
+				if err != nil {
+					continue
+				}
+				lastResponses[endpoint.pod] = resp
+				for _, table := range resp.Tables {
+					if table.TableName == tableName && hasRowCopyProgress(table.RowsTotal, table.RowsCopied, table.PercentComplete) {
+						matchedTables[endpoint.pod] = table
+						break
+					}
+				}
+			}
+			return len(matchedTables) == len(endpoints)
+		},
+		func() string {
+			return fmt.Sprintf("timeout waiting for all data-plane pods to preserve row-copy progress for %s: matched=%s last_responses=%s last_errors=%v",
+				tableName, formatMatchedPods(matchedTables), formatPodProgressResponses(lastResponses), lastErrors)
+		})
+	return matchedTables
+}
+
+func formatMatchedPods(matchedTables map[string]*ternv1.TableProgress) string {
+	pods := make([]string, 0, len(matchedTables))
+	for pod := range matchedTables {
+		pods = append(pods, pod)
+	}
+	return strings.Join(pods, ",")
+}
+
+func formatPodProgressResponses(responses map[string]*ternv1.ProgressResponse) string {
+	parts := make([]string, 0, len(responses))
+	for pod, resp := range responses {
+		var tableParts []string
+		for _, table := range resp.Tables {
+			tableParts = append(tableParts, fmt.Sprintf("%s status=%s rows=%d/%d percent=%d",
+				table.TableName, table.Status, table.RowsCopied, table.RowsTotal, table.PercentComplete))
+		}
+		parts = append(parts, fmt.Sprintf("%s state=%s tables=[%s]", pod, resp.State, strings.Join(tableParts, "; ")))
+	}
+	return strings.Join(parts, " | ")
+}
+
+func hasRowCopyProgress(rowsTotal, rowsCopied int64, percentComplete int32) bool {
+	return rowsTotal > 0 && (rowsCopied > 0 || percentComplete > 0)
+}
+
 // TestK8s_Scheduler_DataPlanePodRestartRecoversIndexAdd verifies scheduler
 // recovery across the two-tier Kubernetes deployment. The control plane keeps
-// the user-facing apply alive while the data plane pod, which owns the Spirit
-// worker and target database access, is replaced mid-apply.
+// the user-facing apply alive while the data-plane pods are replaced mid-apply.
 func TestK8s_Scheduler_DataPlanePodRestartRecoversIndexAdd(t *testing.T) {
 	fixture := startRunningIndexAddApply(t, "k8s_sched_dp")
 
-	crashedPod := crashPod(t, "data-plane")
+	crashedPods := crashPods(t, "data-plane")
 
-	// The restarted data-plane scheduler claims stale data-plane apply rows. Aging
+	// The restarted data-plane scheduler claims stale local apply rows. Aging
 	// the heartbeat avoids waiting for the production staleness threshold.
 	markDataPlaneHeartbeatStale(t, fixture.DataPlaneApplyID)
-	waitForReplacementPodReady(t, "data-plane", crashedPod, 2*time.Minute)
+	waitForPodsReadyAfterDeletion(t, "data-plane", crashedPods, 2*time.Minute)
 	waitForTernHealth(t, fixture.Endpoint, "data-plane", "staging", testutil.PollDeadline)
 
 	testutil.WaitForState(t, fixture.Endpoint, fixture.ApplyID, state.Apply.Completed, 3*time.Minute)

--- a/e2e/k8s/kubectl_test.go
+++ b/e2e/k8s/kubectl_test.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/http"
 	"os/exec"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -32,19 +33,63 @@ func runKubectl(t *testing.T, args ...string) string {
 
 func crashPod(t *testing.T, instance string) string {
 	t.Helper()
-	selector := "app.kubernetes.io/instance=" + instance
-	pod := strings.TrimSpace(runKubectl(t, "get", "pod", "-n", k8sNamespace, "-l", selector, "-o", "jsonpath={.items[0].metadata.name}"))
-	require.NotEmpty(t, pod, "expected pod for %s", instance)
+	pods := podNamesForInstance(t, instance)
+	require.NotEmpty(t, pods, "expected pod for %s", instance)
+	pod := pods[0]
 
 	runKubectl(t, "delete", "pod", "-n", k8sNamespace, pod, "--grace-period=0", "--force", "--wait=false")
 	return pod
 }
 
-func waitForReplacementPodReady(t *testing.T, instance, previousPod string, timeout time.Duration) {
+func crashPods(t *testing.T, instance string) []string {
+	t.Helper()
+	pods := podNamesForInstance(t, instance)
+	require.NotEmpty(t, pods, "expected pods for %s", instance)
+
+	args := []string{"delete", "pod", "-n", k8sNamespace}
+	args = append(args, pods...)
+	args = append(args, "--grace-period=0", "--force", "--wait=false")
+	runKubectl(t, args...)
+	return pods
+}
+
+func podNamesForInstance(t *testing.T, instance string) []string {
 	t.Helper()
 	selector := "app.kubernetes.io/instance=" + instance
+	output := runKubectl(t, "get", "pod", "-n", k8sNamespace, "-l", selector, "-o", "jsonpath={range .items[*]}{.metadata.name}{\"\\n\"}{end}")
+	var pods []string
+	for line := range strings.SplitSeq(output, "\n") {
+		pod := strings.TrimSpace(line)
+		if pod != "" {
+			pods = append(pods, pod)
+		}
+	}
+	return pods
+}
+
+func desiredReplicasForInstance(t *testing.T, instance string) int {
+	t.Helper()
+	selector := "app.kubernetes.io/instance=" + instance
+	output := strings.TrimSpace(runKubectl(t, "get", "deployment", "-n", k8sNamespace, "-l", selector, "-o", "jsonpath={.items[0].spec.replicas}"))
+	replicas, err := strconv.Atoi(output)
+	require.NoError(t, err, "parse desired replicas for %s", instance)
+	require.Positive(t, replicas, "expected desired replicas for %s", instance)
+	return replicas
+}
+
+func waitForPodsReadyAfterDeletion(t *testing.T, instance string, previousPods []string, timeout time.Duration) {
+	t.Helper()
+	desiredReplicas := desiredReplicasForInstance(t, instance)
+	previous := make(map[string]bool, len(previousPods))
+	for _, pod := range previousPods {
+		previous[pod] = true
+	}
+
+	selector := "app.kubernetes.io/instance=" + instance
+	var readyPods []string
 	testutil.Poll(t, timeout, 500*time.Millisecond,
 		func() bool {
+			readyPods = readyPods[:0]
 			output := runKubectl(t, "get", "pod", "-n", k8sNamespace, "-l", selector, "-o", "json")
 
 			var podList struct {
@@ -63,20 +108,37 @@ func waitForReplacementPodReady(t *testing.T, instance, previousPod string, time
 			require.NoError(t, json.Unmarshal([]byte(output), &podList))
 
 			for _, pod := range podList.Items {
-				if pod.Metadata.Name != previousPod {
-					for _, condition := range pod.Status.Conditions {
-						if condition.Type == "Ready" && condition.Status == "True" {
-							return true
-						}
-					}
+				if previous[pod.Metadata.Name] {
+					continue
+				}
+				if podReady(pod.Status.Conditions) {
+					readyPods = append(readyPods, pod.Metadata.Name)
 				}
 			}
-			return false
+			return len(readyPods) >= desiredReplicas
 		},
 		func() string {
-			return fmt.Sprintf("timeout waiting for replacement %s pod after deleting %s", instance, previousPod)
+			return fmt.Sprintf("timeout waiting for %d ready replacement %s pods after deleting %s, ready replacements: %s",
+				desiredReplicas, instance, strings.Join(previousPods, ","), strings.Join(readyPods, ","))
 		},
 	)
+}
+
+func podReady(conditions []struct {
+	Type   string `json:"type"`
+	Status string `json:"status"`
+}) bool {
+	for _, condition := range conditions {
+		if condition.Type == "Ready" && condition.Status == "True" {
+			return true
+		}
+	}
+	return false
+}
+
+func waitForReplacementPodReady(t *testing.T, instance, previousPod string, timeout time.Duration) {
+	t.Helper()
+	waitForPodsReadyAfterDeletion(t, instance, []string{previousPod}, timeout)
 }
 
 func waitForTernHealth(t *testing.T, endpoint, deployment, environment string, timeout time.Duration) {
@@ -140,4 +202,21 @@ func startControlPlanePortForward(t *testing.T) string {
 	endpoint := fmt.Sprintf("http://localhost:%d", port)
 	waitForHTTPStatus(t, endpoint+"/health", http.StatusOK, testutil.PollDeadline)
 	return endpoint
+}
+
+func startDataPlanePodGRPCPortForward(t *testing.T, pod string) string {
+	t.Helper()
+	port := freeLocalPort(t)
+	ctx, cancel := context.WithCancel(context.WithoutCancel(t.Context()))
+	cmd := exec.CommandContext(ctx, "kubectl", "port-forward", "-n", k8sNamespace, "pod/"+pod, fmt.Sprintf("%d:13370", port))
+	require.NoError(t, cmd.Start())
+	t.Cleanup(func() {
+		cancel()
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+		}
+		_ = cmd.Wait()
+	})
+
+	return fmt.Sprintf("127.0.0.1:%d", port)
 }

--- a/e2e/k8s/scheduler_fixtures_test.go
+++ b/e2e/k8s/scheduler_fixtures_test.go
@@ -103,6 +103,11 @@ type runningIndexApply struct {
 
 func startRunningIndexAddApply(t *testing.T, tablePrefix string) runningIndexApply {
 	t.Helper()
+	return startIndexAddApply(t, tablePrefix, true)
+}
+
+func startIndexAddApply(t *testing.T, tablePrefix string, waitForRunning bool) runningIndexApply {
+	t.Helper()
 	ep, dsn := testutil.Endpoint(t), testutil.TernStagingDSN(t)
 	tableName := testutil.UniqueTableName(tablePrefix)
 
@@ -121,9 +126,11 @@ func startRunningIndexAddApply(t *testing.T, tablePrefix string) runningIndexApp
 	_, applyID := testutil.PlanAndApply(t, ep, "testapp", "mysql", "staging", schemaFiles, nil)
 	dataPlaneApplyID := waitForApplyExternalID(t, applyID, testutil.PollDeadline)
 
-	// The index add keeps Spirit observable long enough for the test to replace
-	// one tier while the other tier continues running.
-	testutil.WaitForState(t, ep, applyID, state.Apply.Running, testutil.PollDeadline)
+	if waitForRunning {
+		// The index add keeps Spirit observable long enough for the test to replace
+		// one tier while the other tier continues running.
+		testutil.WaitForState(t, ep, applyID, state.Apply.Running, testutil.PollDeadline)
+	}
 
 	return runningIndexApply{
 		Endpoint:         ep,

--- a/pkg/storage/mysqlstore/applies_test.go
+++ b/pkg/storage/mysqlstore/applies_test.go
@@ -632,6 +632,100 @@ func TestApplyStore_FindNextApplyRequiresTasksForPendingApply(t *testing.T) {
 	assert.Equal(t, state.Apply.Running, persisted.State)
 }
 
+func TestApplyStore_FindNextApplyConcurrentPendingClaims(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", storage.DatabaseTypeMySQL, "staging")
+	now := time.Now()
+	apply := &storage.Apply{
+		ApplyIdentifier: "apply_concurrent_pending_claim",
+		LockID:          lock.ID,
+		PlanID:          503,
+		Database:        "testdb",
+		DatabaseType:    storage.DatabaseTypeMySQL,
+		Repository:      "org/repo",
+		PullRequest:     123,
+		Environment:     "staging",
+		Engine:          storage.EngineSpirit,
+		State:           state.Apply.Pending,
+		Options:         []byte("{}"),
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+	tasks := []*storage.Task{
+		{
+			TaskIdentifier: "task_concurrent_pending_claim",
+			PlanID:         503,
+			Database:       "testdb",
+			DatabaseType:   storage.DatabaseTypeMySQL,
+			Engine:         storage.EngineSpirit,
+			Environment:    "staging",
+			State:          state.Task.Pending,
+			TableName:      "users",
+			DDL:            "ALTER TABLE users ADD COLUMN email VARCHAR(255)",
+			DDLAction:      "alter",
+			Options:        []byte("{}"),
+			CreatedAt:      now,
+			UpdatedAt:      now,
+		},
+	}
+	applyID, err := store.Applies().CreateWithTasks(ctx, apply, tasks)
+	require.NoError(t, err)
+	apply.ID = applyID
+
+	const workers = 16
+	stores := make([]*Storage, workers)
+	for i := range workers {
+		db, openErr := sql.Open("mysql", testDSNChangedRows)
+		require.NoError(t, openErr)
+		db.SetMaxOpenConns(1)
+		db.SetMaxIdleConns(1)
+		t.Cleanup(func() {
+			require.NoError(t, db.Close())
+		})
+		stores[i] = New(db)
+	}
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	var claimed []*storage.Apply
+	var claimErrors []error
+
+	for i := range workers {
+		workerStore := stores[i]
+		wg.Go(func() {
+			<-start
+			got, claimErr := workerStore.Applies().FindNextApply(ctx)
+
+			mu.Lock()
+			defer mu.Unlock()
+			if claimErr != nil {
+				claimErrors = append(claimErrors, claimErr)
+				return
+			}
+			if got != nil {
+				claimed = append(claimed, got)
+			}
+		})
+	}
+
+	close(start)
+	wg.Wait()
+
+	require.Empty(t, claimErrors)
+	require.Len(t, claimed, 1, "only one scheduler worker should claim a pending apply")
+	assert.Equal(t, apply.ApplyIdentifier, claimed[0].ApplyIdentifier)
+	assert.Equal(t, state.Apply.Pending, claimed[0].State)
+
+	persisted, err := store.Applies().Get(ctx, apply.ID)
+	require.NoError(t, err)
+	require.NotNil(t, persisted)
+	assert.Equal(t, state.Apply.Running, persisted.State)
+}
+
 // TestApplyStore_ExpireRetryable verifies retry budget exhaustion at the
 // storage layer. A retryable apply that has used all attempts becomes failed,
 // and unfinished tasks are finalized as failed with completion timestamps.

--- a/pkg/tern/grpc_client.go
+++ b/pkg/tern/grpc_client.go
@@ -930,7 +930,21 @@ func (c *GRPCClient) syncStoredTasksFromRemoteTasks(
 				continue
 			}
 			oldTaskState := storedTask.State
-			storedTask.State = state.NormalizeTaskStatus(remoteTask.Status)
+			remoteTaskState := state.NormalizeTaskStatus(remoteTask.Status)
+			if state.IsState(remoteTaskState, state.Task.Stopped) {
+				storedTask.State = remoteTaskState
+			} else {
+				storedTask.State = taskStateWithNoBackwardProgress(storedTask.State, remoteTaskState)
+			}
+			if !state.IsState(storedTask.State, remoteTaskState) {
+				slog.Debug("keeping stored gRPC task state because remote progress reported earlier state",
+					"apply_id", storedApply.ApplyIdentifier,
+					"external_id", storedApply.ExternalID,
+					"task_id", storedTask.TaskIdentifier,
+					"table", storedTask.TableName,
+					"stored_task_state", oldTaskState,
+					"remote_task_state", remoteTaskState)
+			}
 			storedTask.RowsCopied = remoteTask.RowsCopied
 			storedTask.RowsTotal = remoteTask.RowsTotal
 			storedTask.ProgressPercent = int(remoteTask.PercentComplete)
@@ -977,6 +991,59 @@ func storedTaskResolvedForTerminalRemoteApply(remoteApplyState, storedTaskState 
 	}
 	return state.IsState(remoteApplyState, state.Apply.Stopped) &&
 		state.IsState(storedTaskState, state.Task.Stopped)
+}
+
+// applyStateWithNoBackwardProgress keeps the control-plane apply row from
+// moving back to an earlier active phase when remote progress lags behind the
+// stored scheduler claim. A remote apply may briefly report pending after
+// SchemaBot has already claimed and dispatched it; writing pending locally would
+// make the same apply claimable by another scheduler worker.
+func applyStateWithNoBackwardProgress(storedApplyState, remoteApplyState string) string {
+	if remoteApplyState == "" {
+		return ""
+	}
+	if state.IsTerminalApplyState(remoteApplyState) {
+		return remoteApplyState
+	}
+	if state.IsTerminalApplyState(storedApplyState) {
+		return storedApplyState
+	}
+	if state.IsState(storedApplyState, state.Apply.FailedRetryable) {
+		return storedApplyState
+	}
+	if applyProgressRank(remoteApplyState) < applyProgressRank(storedApplyState) {
+		return storedApplyState
+	}
+	return remoteApplyState
+}
+
+func applyProgressRank(applyState string) int {
+	switch applyState {
+	case state.Apply.Pending:
+		return 0
+	case state.Apply.PreparingBranch:
+		return 1
+	case state.Apply.ApplyingBranchChanges:
+		return 2
+	case state.Apply.ValidatingBranch:
+		return 3
+	case state.Apply.CreatingDeployRequest:
+		return 4
+	case state.Apply.ValidatingDeployRequest:
+		return 5
+	case state.Apply.WaitingForDeploy:
+		return 6
+	case state.Apply.Running:
+		return 7
+	case state.Apply.WaitingForCutover:
+		return 8
+	case state.Apply.CuttingOver:
+		return 9
+	case state.Apply.RevertWindow:
+		return 10
+	default:
+		return 0
+	}
 }
 
 // pollForCompletion polls the remote Tern for progress and updates SchemaBot's storage.
@@ -1042,6 +1109,17 @@ func (c *GRPCClient) pollForCompletion(ctx context.Context, apply *storage.Apply
 			}
 			if apply.StartedAt == nil && newState != state.Apply.Pending {
 				apply.StartedAt = &now
+			}
+			remoteApplyState := newState
+			newState = applyStateWithNoBackwardProgress(apply.State, remoteApplyState)
+			if !state.IsState(newState, remoteApplyState) {
+				slog.Debug("keeping stored gRPC apply state because remote progress reported earlier state",
+					"apply_id", apply.ApplyIdentifier,
+					"external_id", apply.ExternalID,
+					"database", apply.Database,
+					"environment", apply.Environment,
+					"stored_state", apply.State,
+					"remote_state", remoteApplyState)
 			}
 			apply.State = newState
 			apply.UpdatedAt = now

--- a/pkg/tern/grpc_client.go
+++ b/pkg/tern/grpc_client.go
@@ -924,47 +924,77 @@ func (c *GRPCClient) syncStoredTasksFromRemoteTasks(
 	remoteTasks []*ternv1.TableProgress,
 	now time.Time,
 ) error {
+	remoteTaskIndex := indexProtoTableProgress(remoteTasks)
+	missingProgressTasks := 0
 	for _, storedTask := range storedTasks {
-		for _, remoteTask := range remoteTasks {
-			if remoteTask.TableName != storedTask.TableName {
-				continue
-			}
-			oldTaskState := storedTask.State
-			remoteTaskState := state.NormalizeTaskStatus(remoteTask.Status)
-			if state.IsState(remoteTaskState, state.Task.Stopped) {
-				storedTask.State = remoteTaskState
-			} else {
-				storedTask.State = taskStateWithNoBackwardProgress(storedTask.State, remoteTaskState)
-			}
-			if !state.IsState(storedTask.State, remoteTaskState) {
-				slog.Debug("keeping stored gRPC task state because remote progress reported earlier state",
-					"apply_id", storedApply.ApplyIdentifier,
-					"external_id", storedApply.ExternalID,
-					"task_id", storedTask.TaskIdentifier,
-					"table", storedTask.TableName,
-					"stored_task_state", oldTaskState,
-					"remote_task_state", remoteTaskState)
-			}
+		remoteTask, ok := protoProgressForTask(remoteTaskIndex, storedTask)
+		if !ok {
+			missingProgressTasks++
+			continue
+		}
+		oldTaskState := storedTask.State
+		remoteTaskState := state.NormalizeTaskStatus(remoteTask.Status)
+		if state.IsState(remoteTaskState, state.Task.Stopped) {
+			storedTask.State = remoteTaskState
+		} else {
+			storedTask.State = taskStateWithNoBackwardProgress(storedTask.State, remoteTaskState)
+		}
+		if !state.IsState(storedTask.State, remoteTaskState) {
+			slog.Debug("keeping stored gRPC task state because remote progress reported earlier state",
+				"apply_id", storedApply.ApplyIdentifier,
+				"external_id", storedApply.ExternalID,
+				"task_id", storedTask.TaskIdentifier,
+				"table", storedTask.TableName,
+				"stored_task_state", oldTaskState,
+				"remote_task_state", remoteTaskState)
+		}
+		if remoteTaskOmittedRowTotals(storedTask, remoteTask) {
+			slog.Debug("keeping stored gRPC task row-copy progress because remote progress omitted row totals",
+				"apply_id", storedApply.ApplyIdentifier,
+				"external_id", storedApply.ExternalID,
+				"task_id", storedTask.TaskIdentifier,
+				"namespace", storedTask.Namespace,
+				"table", storedTask.TableName,
+				"stored_rows_copied", storedTask.RowsCopied,
+				"stored_rows_total", storedTask.RowsTotal,
+				"stored_progress_percent", storedTask.ProgressPercent,
+				"remote_rows_copied", remoteTask.RowsCopied,
+				"remote_progress_percent", remoteTask.PercentComplete)
+		} else {
 			storedTask.RowsCopied = remoteTask.RowsCopied
 			storedTask.RowsTotal = remoteTask.RowsTotal
 			storedTask.ProgressPercent = int(remoteTask.PercentComplete)
-			if state.IsState(storedTask.State, state.Task.Completed) && storedTask.ProgressPercent != 100 {
-				storedTask.ProgressPercent = 100
-			}
-			if state.IsTerminalTaskState(storedTask.State) && storedTask.CompletedAt == nil {
-				storedTask.CompletedAt = &now
-			}
-			storedTask.UpdatedAt = now
-			if err := c.storage.Tasks().Update(ctx, storedTask); err != nil {
-				return fmt.Errorf("sync task %s from gRPC progress for %s: %w", storedTask.TaskIdentifier, storedApply.ApplyIdentifier, err)
-			}
-			if oldTaskState != storedTask.State {
-				c.logTaskStateTransition(ctx, storedApply.ID, storedTask, fmt.Sprintf("Remote task %s changed state: %s -> %s", storedTask.TableName, oldTaskState, storedTask.State), oldTaskState)
-			}
-			break
+		}
+		if state.IsState(storedTask.State, state.Task.Completed) && storedTask.ProgressPercent != 100 {
+			storedTask.ProgressPercent = 100
+		}
+		if state.IsTerminalTaskState(storedTask.State) && storedTask.CompletedAt == nil {
+			storedTask.CompletedAt = &now
+		}
+		storedTask.UpdatedAt = now
+		if err := c.storage.Tasks().Update(ctx, storedTask); err != nil {
+			return fmt.Errorf("sync task %s from gRPC progress for %s: %w", storedTask.TaskIdentifier, storedApply.ApplyIdentifier, err)
+		}
+		if oldTaskState != storedTask.State {
+			c.logTaskStateTransition(ctx, storedApply.ID, storedTask, fmt.Sprintf("Remote task %s changed state: %s -> %s", storedTask.TableName, oldTaskState, storedTask.State), oldTaskState)
 		}
 	}
+	if missingProgressTasks > 0 {
+		slog.Debug("remote gRPC progress omitted stored tasks",
+			"apply_id", storedApply.ApplyIdentifier,
+			"external_id", storedApply.ExternalID,
+			"database", storedApply.Database,
+			"environment", storedApply.Environment,
+			"missing_count", missingProgressTasks)
+	}
 	return nil
+}
+
+func remoteTaskOmittedRowTotals(storedTask *storage.Task, remoteTask *ternv1.TableProgress) bool {
+	if storedTask == nil || remoteTask == nil {
+		return false
+	}
+	return storedTask.RowsTotal > 0 && remoteTask.RowsTotal <= 0
 }
 
 func ensureStoredTasksResolvedForTerminalRemoteApply(remoteApply *storage.Apply, storedTasks []*storage.Task) error {

--- a/pkg/tern/grpc_client.go
+++ b/pkg/tern/grpc_client.go
@@ -980,7 +980,7 @@ func (c *GRPCClient) syncStoredTasksFromRemoteTasks(
 		}
 	}
 	if missingProgressTasks > 0 {
-		slog.Debug("remote gRPC progress omitted stored tasks",
+		slog.Warn("remote gRPC progress omitted stored tasks",
 			"apply_id", storedApply.ApplyIdentifier,
 			"external_id", storedApply.ExternalID,
 			"database", storedApply.Database,
@@ -1023,14 +1023,14 @@ func storedTaskResolvedForTerminalRemoteApply(remoteApplyState, storedTaskState 
 		state.IsState(storedTaskState, state.Task.Stopped)
 }
 
-// applyStateWithNoBackwardProgress keeps the control-plane apply row from
-// moving back to an earlier active phase when remote progress lags behind the
-// stored scheduler claim. A remote apply may briefly report pending after
-// SchemaBot has already claimed and dispatched it; writing pending locally would
-// make the same apply claimable by another scheduler worker.
-func applyStateWithNoBackwardProgress(storedApplyState, remoteApplyState string) string {
+// applyStateFromRemoteProgress is the apply-level counterpart to
+// taskStateWithNoBackwardProgress in LocalClient. Local mode translates engine
+// progress into task state first, then derives apply state from stored tasks.
+// gRPC mode receives an apply state directly from the remote data plane, so the
+// control plane needs the same no-backward policy at the apply row boundary.
+func applyStateFromRemoteProgress(storedApplyState, remoteApplyState string) string {
 	if remoteApplyState == "" {
-		return ""
+		return storedApplyState
 	}
 	if state.IsTerminalApplyState(remoteApplyState) {
 		return remoteApplyState
@@ -1141,7 +1141,7 @@ func (c *GRPCClient) pollForCompletion(ctx context.Context, apply *storage.Apply
 				apply.StartedAt = &now
 			}
 			remoteApplyState := newState
-			newState = applyStateWithNoBackwardProgress(apply.State, remoteApplyState)
+			newState = applyStateFromRemoteProgress(apply.State, remoteApplyState)
 			if !state.IsState(newState, remoteApplyState) {
 				slog.Debug("keeping stored gRPC apply state because remote progress reported earlier state",
 					"apply_id", apply.ApplyIdentifier,

--- a/pkg/tern/grpc_client_test.go
+++ b/pkg/tern/grpc_client_test.go
@@ -544,6 +544,7 @@ func TestGRPCClient_ResumeApplyDispatchesQueuedRemoteApply(t *testing.T) {
 	server := &capturingTernServer{
 		remoteApplyID: "remote-dispatched-123",
 		progressTables: []*ternv1.TableProgress{{
+			Namespace:       "default",
 			TableName:       "users",
 			Status:          state.Task.Completed,
 			PercentComplete: 100,
@@ -614,6 +615,7 @@ func TestGRPCClient_ResumeApplyLogsRemoteLifecycle(t *testing.T) {
 		remoteApplyID:  "remote-lifecycle-123",
 		progressStates: []ternv1.State{ternv1.State_STATE_RUNNING, ternv1.State_STATE_COMPLETED},
 		progressTables: []*ternv1.TableProgress{{
+			Namespace:       "default",
 			TableName:       "users",
 			Status:          state.Task.Completed,
 			PercentComplete: 100,
@@ -694,6 +696,7 @@ func TestGRPCClient_ResumeApplyDoesNotRegressRunningApplyToPendingProgress(t *te
 			ternv1.State_STATE_COMPLETED,
 		},
 		progressTables: []*ternv1.TableProgress{{
+			Namespace:       "default",
 			TableName:       "users",
 			Status:          state.Task.Completed,
 			PercentComplete: 100,
@@ -828,6 +831,120 @@ func TestGRPCClient_SyncStoredTasksFromRemoteTasksUsesRemoteTaskState(t *testing
 			assert.True(t, hasLogMessageContaining(logs.logs, "Remote task users changed state: running -> "+tc.wantStoredTaskState))
 		})
 	}
+}
+
+func TestGRPCClient_SyncRemoteProgressByNamespace(t *testing.T) {
+	// Multi-keyspace Vitess applies can report the same table name from more
+	// than one namespace. The control plane must update each stored task from
+	// the matching namespace/table progress row.
+	apply := &storage.Apply{
+		ID:              19,
+		ApplyIdentifier: "apply-namespace-progress",
+		Database:        "testdb",
+		Environment:     "staging",
+		ExternalID:      "remote-namespace-progress",
+		State:           state.Apply.Running,
+	}
+	firstTask := &storage.Task{
+		ID:             31,
+		TaskIdentifier: "task-commerce-orders",
+		ApplyID:        apply.ID,
+		Namespace:      "commerce_sharded",
+		TableName:      "orders",
+		State:          state.Task.Pending,
+	}
+	secondTask := &storage.Task{
+		ID:             32,
+		TaskIdentifier: "task-commerce-006-orders",
+		ApplyID:        apply.ID,
+		Namespace:      "commerce_sharded_006",
+		TableName:      "orders",
+		State:          state.Task.Pending,
+	}
+	client := &GRPCClient{
+		storage: &mockStorage{
+			tasks: &mockTaskStore{tasks: []*storage.Task{firstTask, secondTask}},
+			logs:  &mockApplyLogStore{},
+		},
+	}
+
+	err := client.syncStoredTasksFromRemoteTasks(t.Context(), apply, []*storage.Task{firstTask, secondTask}, []*ternv1.TableProgress{
+		{
+			Namespace:       "commerce_sharded",
+			TableName:       "orders",
+			Status:          state.Task.Running,
+			RowsCopied:      100,
+			RowsTotal:       1000,
+			PercentComplete: 10,
+		},
+		{
+			Namespace:       "commerce_sharded_006",
+			TableName:       "orders",
+			Status:          state.Task.Running,
+			RowsCopied:      800,
+			RowsTotal:       1000,
+			PercentComplete: 80,
+		},
+	}, time.Now())
+	require.NoError(t, err)
+
+	assert.Equal(t, state.Task.Running, firstTask.State)
+	assert.Equal(t, int64(100), firstTask.RowsCopied)
+	assert.Equal(t, int64(1000), firstTask.RowsTotal)
+	assert.Equal(t, 10, firstTask.ProgressPercent)
+	assert.Equal(t, state.Task.Running, secondTask.State)
+	assert.Equal(t, int64(800), secondTask.RowsCopied)
+	assert.Equal(t, int64(1000), secondTask.RowsTotal)
+	assert.Equal(t, 80, secondTask.ProgressPercent)
+}
+
+func TestGRPCClient_SyncRemoteProgressKeepsLastUsefulRows(t *testing.T) {
+	// Remote progress is lossy when a data-plane pod can see the stored task but
+	// does not own the in-memory engine runner. If that response omits row
+	// totals, keep the last durable row-copy progress instead of clearing the
+	// operator-facing progress bar.
+	apply := &storage.Apply{
+		ID:              20,
+		ApplyIdentifier: "apply-progress-regression",
+		Database:        "testdb",
+		Environment:     "staging",
+		ExternalID:      "remote-progress-regression",
+		State:           state.Apply.Running,
+	}
+	task := &storage.Task{
+		ID:              33,
+		TaskIdentifier:  "task-progress-regression",
+		ApplyID:         apply.ID,
+		Namespace:       "default",
+		TableName:       "orders",
+		State:           state.Task.Running,
+		RowsCopied:      950,
+		RowsTotal:       1000,
+		ProgressPercent: 95,
+	}
+	client := &GRPCClient{
+		storage: &mockStorage{
+			tasks: &mockTaskStore{tasks: []*storage.Task{task}},
+			logs:  &mockApplyLogStore{},
+		},
+	}
+
+	err := client.syncStoredTasksFromRemoteTasks(t.Context(), apply, []*storage.Task{task}, []*ternv1.TableProgress{
+		{
+			Namespace:       "default",
+			TableName:       "orders",
+			Status:          state.Task.Running,
+			RowsCopied:      0,
+			RowsTotal:       0,
+			PercentComplete: 0,
+		},
+	}, time.Now())
+	require.NoError(t, err)
+
+	assert.Equal(t, state.Task.Running, task.State)
+	assert.Equal(t, int64(950), task.RowsCopied)
+	assert.Equal(t, int64(1000), task.RowsTotal)
+	assert.Equal(t, 95, task.ProgressPercent)
 }
 
 func TestGRPCClient_PollSetsTerminalTaskMetadataFromRemoteTaskProgress(t *testing.T) {

--- a/pkg/tern/grpc_client_test.go
+++ b/pkg/tern/grpc_client_test.go
@@ -750,6 +750,58 @@ func TestGRPCClient_ResumeApplyDoesNotRegressRunningApplyToPendingProgress(t *te
 	assert.Equal(t, state.Apply.Completed, storedStates[len(storedStates)-1])
 }
 
+func TestApplyStateFromRemoteProgress(t *testing.T) {
+	tests := []struct {
+		name        string
+		storedState string
+		remoteState string
+		expected    string
+	}{
+		{
+			name:        "empty remote state keeps stored state",
+			storedState: state.Apply.Running,
+			remoteState: "",
+			expected:    state.Apply.Running,
+		},
+		{
+			name:        "remote terminal state wins",
+			storedState: state.Apply.Running,
+			remoteState: state.Apply.Completed,
+			expected:    state.Apply.Completed,
+		},
+		{
+			name:        "stored terminal state is final",
+			storedState: state.Apply.Completed,
+			remoteState: state.Apply.Running,
+			expected:    state.Apply.Completed,
+		},
+		{
+			name:        "stored retryable failure blocks active progress",
+			storedState: state.Apply.FailedRetryable,
+			remoteState: state.Apply.Running,
+			expected:    state.Apply.FailedRetryable,
+		},
+		{
+			name:        "stale pending remote state does not reopen running apply",
+			storedState: state.Apply.Running,
+			remoteState: state.Apply.Pending,
+			expected:    state.Apply.Running,
+		},
+		{
+			name:        "newer active remote state advances stored state",
+			storedState: state.Apply.Running,
+			remoteState: state.Apply.WaitingForCutover,
+			expected:    state.Apply.WaitingForCutover,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, applyStateFromRemoteProgress(tc.storedState, tc.remoteState))
+		})
+	}
+}
+
 func TestGRPCClient_SyncStoredTasksFromRemoteTasksUsesRemoteTaskState(t *testing.T) {
 	// Remote task state is the source of truth for stored task rows. Apply-level
 	// terminal state must not invent task results when the remote task snapshot

--- a/pkg/tern/grpc_client_test.go
+++ b/pkg/tern/grpc_client_test.go
@@ -417,6 +417,7 @@ type mockApplyStore struct {
 	storage.ApplyStore
 	apply     *storage.Apply
 	updateErr error
+	updates   []*storage.Apply
 }
 
 func (m *mockApplyStore) Get(context.Context, int64) (*storage.Apply, error) {
@@ -432,6 +433,7 @@ func (m *mockApplyStore) Update(_ context.Context, apply *storage.Apply) error {
 	}
 	stored := *apply
 	m.apply = &stored
+	m.updates = append(m.updates, &stored)
 	return nil
 }
 func (m *mockApplyStore) Heartbeat(context.Context, int64) error { return nil }
@@ -678,6 +680,71 @@ func TestGRPCClient_ResumeApplyLogsRemoteLifecycle(t *testing.T) {
 	require.NotNil(t, dispatchLog, "dispatch log should be present")
 	assert.Equal(t, state.Apply.Pending, dispatchLog.OldState)
 	assert.Equal(t, state.Apply.Running, dispatchLog.NewState)
+}
+
+func TestGRPCClient_ResumeApplyDoesNotRegressRunningApplyToPendingProgress(t *testing.T) {
+	// A freshly dispatched remote apply can report pending before the remote
+	// engine starts copying rows. SchemaBot has already claimed the queued apply
+	// locally, so progress polling must not write pending back to the stored
+	// apply row and make it claimable by another scheduler worker.
+	server := &capturingTernServer{
+		remoteApplyID: "remote-pending-first",
+		progressStates: []ternv1.State{
+			ternv1.State_STATE_PENDING,
+			ternv1.State_STATE_COMPLETED,
+		},
+		progressTables: []*ternv1.TableProgress{{
+			TableName:       "users",
+			Status:          state.Task.Completed,
+			PercentComplete: 100,
+		}},
+	}
+	client, cleanup := testCapturingGRPCClient(t, server)
+	defer cleanup()
+
+	apply := &storage.Apply{
+		ID:              23,
+		ApplyIdentifier: "apply-pending-progress",
+		PlanID:          123,
+		Database:        "testdb",
+		DatabaseType:    storage.DatabaseTypeMySQL,
+		Environment:     "staging",
+		State:           state.Apply.Pending,
+	}
+	task := &storage.Task{
+		ID:             29,
+		TaskIdentifier: "task-pending-progress",
+		ApplyID:        apply.ID,
+		TableName:      "users",
+		DDL:            "ALTER TABLE users ADD COLUMN email varchar(255)",
+		DDLAction:      "alter",
+		Namespace:      "default",
+		State:          state.Task.Pending,
+	}
+	applyStore := &mockApplyStore{apply: apply}
+	client.storage = &mockStorage{
+		applies: applyStore,
+		tasks:   &mockTaskStore{tasks: []*storage.Task{task}},
+		plans: &mockPlanStore{plan: &storage.Plan{
+			ID:             apply.PlanID,
+			PlanIdentifier: "plan-pending-progress",
+		}},
+		logs: &mockApplyLogStore{},
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 3*time.Second)
+	defer cancel()
+	err := client.ResumeApply(ctx, apply)
+	require.NoError(t, err)
+
+	var storedStates []string
+	for _, updatedApply := range applyStore.updates {
+		storedStates = append(storedStates, updatedApply.State)
+	}
+	require.NotEmpty(t, storedStates)
+	assert.Equal(t, state.Apply.Running, storedStates[0])
+	assert.NotContains(t, storedStates[1:], state.Apply.Pending)
+	assert.Equal(t, state.Apply.Completed, storedStates[len(storedStates)-1])
 }
 
 func TestGRPCClient_SyncStoredTasksFromRemoteTasksUsesRemoteTaskState(t *testing.T) {

--- a/pkg/tern/local_client.go
+++ b/pkg/tern/local_client.go
@@ -875,20 +875,15 @@ func (c *LocalClient) Progress(ctx context.Context, req *ternv1.ProgressRequest)
 			tp.IsInstant = et.IsInstant
 			tp.ProgressDetail = et.ProgressDetail
 
-			// Update task timestamps from engine if not already set.
-			updated := false
-			if et.StartedAt != nil && t.StartedAt == nil {
-				t.StartedAt = et.StartedAt
-				updated = true
-			}
-			if et.CompletedAt != nil && t.CompletedAt == nil {
-				t.CompletedAt = et.CompletedAt
-				updated = true
-			}
-			if updated {
-				t.UpdatedAt = time.Now()
+			if syncStoredTaskProgressFromEngineTable(t, et, time.Now()) {
 				if err := c.storage.Tasks().Update(ctx, t); err != nil {
-					c.logger.Error("failed to update task timestamps", "task_id", t.TaskIdentifier, "error", err)
+					c.logger.Error("failed to update task progress from engine",
+						"task_id", t.TaskIdentifier,
+						"table", t.TableName,
+						"rows_copied", t.RowsCopied,
+						"rows_total", t.RowsTotal,
+						"progress_percent", t.ProgressPercent,
+						"error", err)
 				}
 			}
 
@@ -1007,6 +1002,55 @@ func (c *LocalClient) Progress(ctx context.Context, req *ternv1.ProgressRequest)
 	}
 
 	return resp, nil
+}
+
+func syncStoredTaskProgressFromEngineTable(task *storage.Task, progress *engine.TableProgress, now time.Time) bool {
+	if task == nil || progress == nil {
+		return false
+	}
+
+	changed := false
+	if !engineTableProgressOmittedRowTotals(task, progress) {
+		if task.RowsCopied != progress.RowsCopied {
+			task.RowsCopied = progress.RowsCopied
+			changed = true
+		}
+		if task.RowsTotal != progress.RowsTotal {
+			task.RowsTotal = progress.RowsTotal
+			changed = true
+		}
+		if task.ProgressPercent != progress.Progress {
+			task.ProgressPercent = progress.Progress
+			changed = true
+		}
+		if task.ETASeconds != int(progress.ETASeconds) {
+			task.ETASeconds = int(progress.ETASeconds)
+			changed = true
+		}
+	}
+	if task.IsInstant != progress.IsInstant {
+		task.IsInstant = progress.IsInstant
+		changed = true
+	}
+	if progress.StartedAt != nil && task.StartedAt == nil {
+		task.StartedAt = progress.StartedAt
+		changed = true
+	}
+	if progress.CompletedAt != nil && task.CompletedAt == nil {
+		task.CompletedAt = progress.CompletedAt
+		changed = true
+	}
+	if changed {
+		task.UpdatedAt = now
+	}
+	return changed
+}
+
+func engineTableProgressOmittedRowTotals(task *storage.Task, progress *engine.TableProgress) bool {
+	if task == nil || progress == nil {
+		return false
+	}
+	return task.RowsTotal > 0 && progress.RowsTotal <= 0
 }
 
 func progressTableStatus(storedTaskState, engineTableState string) string {

--- a/pkg/tern/local_client_test.go
+++ b/pkg/tern/local_client_test.go
@@ -5,10 +5,12 @@ import (
 	"log/slog"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/block/schemabot/pkg/engine"
 	ternv1 "github.com/block/schemabot/pkg/proto/ternv1"
 	"github.com/block/schemabot/pkg/state"
 	"github.com/block/schemabot/pkg/storage"
@@ -107,6 +109,58 @@ func TestTaskStateWithNoBackwardProgressPolicyCoversTaskStates(t *testing.T) {
 			"task state %s=%q must be terminal, scheduler/control-owned, or ranked as active progress",
 			taskName, taskState)
 	}
+}
+
+func TestSyncStoredTaskProgressFromEngineTablePersistsRows(t *testing.T) {
+	now := time.Date(2026, 5, 25, 17, 45, 0, 0, time.UTC)
+	startedAt := now.Add(-time.Minute)
+	task := &storage.Task{
+		TaskIdentifier: "task-progress",
+		State:          state.Task.Running,
+	}
+
+	changed := syncStoredTaskProgressFromEngineTable(task, &engine.TableProgress{
+		Table:      "users",
+		State:      state.Task.Running,
+		Progress:   42,
+		RowsCopied: 420,
+		RowsTotal:  1000,
+		ETASeconds: 12,
+		StartedAt:  &startedAt,
+	}, now)
+
+	require.True(t, changed)
+	assert.Equal(t, int64(420), task.RowsCopied)
+	assert.Equal(t, int64(1000), task.RowsTotal)
+	assert.Equal(t, 42, task.ProgressPercent)
+	assert.Equal(t, 12, task.ETASeconds)
+	assert.Equal(t, &startedAt, task.StartedAt)
+	assert.Equal(t, now, task.UpdatedAt)
+}
+
+func TestSyncStoredTaskProgressFromEngineTablePreservesRowsWhenEngineOmitsTotals(t *testing.T) {
+	now := time.Date(2026, 5, 25, 17, 45, 0, 0, time.UTC)
+	task := &storage.Task{
+		TaskIdentifier:  "task-progress",
+		State:           state.Task.Running,
+		RowsCopied:      950,
+		RowsTotal:       1000,
+		ProgressPercent: 95,
+		ETASeconds:      3,
+	}
+
+	changed := syncStoredTaskProgressFromEngineTable(task, &engine.TableProgress{
+		Table:    "users",
+		State:    state.Task.Running,
+		Progress: 0,
+	}, now)
+
+	require.False(t, changed)
+	assert.Equal(t, int64(950), task.RowsCopied)
+	assert.Equal(t, int64(1000), task.RowsTotal)
+	assert.Equal(t, 95, task.ProgressPercent)
+	assert.Equal(t, 3, task.ETASeconds)
+	assert.True(t, task.UpdatedAt.IsZero())
 }
 
 func TestProgressTableStatusNormalizesEngineStateAndKeepsStoredStateAhead(t *testing.T) {

--- a/pkg/tern/progress_keys.go
+++ b/pkg/tern/progress_keys.go
@@ -2,6 +2,7 @@ package tern
 
 import (
 	"github.com/block/schemabot/pkg/engine"
+	ternv1 "github.com/block/schemabot/pkg/proto/ternv1"
 	"github.com/block/schemabot/pkg/storage"
 )
 
@@ -21,6 +22,22 @@ func indexEngineTableProgress(tables []engine.TableProgress) map[string]*engine.
 }
 
 func engineProgressForTask(index map[string]*engine.TableProgress, task *storage.Task) (*engine.TableProgress, bool) {
+	tp, ok := index[progressTableKey(task.Namespace, task.TableName)]
+	return tp, ok
+}
+
+func indexProtoTableProgress(tables []*ternv1.TableProgress) map[string]*ternv1.TableProgress {
+	index := make(map[string]*ternv1.TableProgress, len(tables))
+	for _, tp := range tables {
+		if tp == nil {
+			continue
+		}
+		index[progressTableKey(tp.Namespace, tp.TableName)] = tp
+	}
+	return index
+}
+
+func protoProgressForTask(index map[string]*ternv1.TableProgress, task *storage.Task) (*ternv1.TableProgress, bool) {
 	tp, ok := index[progressTableKey(task.Namespace, task.TableName)]
 	return tp, ok
 }


### PR DESCRIPTION
Stabilizes gRPC progress reconciliation when scheduler workers recover or when progress is served by multiple data-plane replicas.

- Keeps stored apply and task rows from moving backward when remote progress is stale, so a claimed remote apply is not made claimable again.
- Preserves the last useful row-copy progress when a replica can see storage but not in-memory engine totals, and matches task progress by namespace and table.
- Adds concurrent scheduler-claim coverage and k8s multi-replica progress coverage.

Core flow:

```text
scheduler claim -> stored apply: running
        |
        v
remote progress poll
        |
        +-- newer/terminal state --> persist forward
        |
        +-- stale active state ----> keep stored state
        |
        +-- missing row totals ----> keep last copied/total rows
```

🤖 Generated by Codex on behalf of @aparajon.