### PR TITLE
fix(spirit): keep volume restart progress running

### DIFF
--- a/pkg/engine/spirit/control.go
+++ b/pkg/engine/spirit/control.go
@@ -265,14 +265,14 @@ func (e *Engine) Volume(ctx context.Context, req *engine.VolumeRequest) (*engine
 	// Volume uses Stop to force a checkpoint before restarting with new settings.
 	// Keep the stored stopped state available for Start while reporting the
 	// adjustment as running to progress pollers.
-	e.setHideStoppedState(rm, true)
+	e.setVolumeRestartInProgress(rm, true)
 
 	_, err := e.Stop(ctx, &engine.ControlRequest{
 		Database:    req.Database,
 		Credentials: req.Credentials,
 	})
 	if err != nil {
-		e.setHideStoppedState(rm, false)
+		e.setVolumeRestartInProgress(rm, false)
 		return nil, fmt.Errorf("stop for volume change: %w", err)
 	}
 
@@ -290,10 +290,10 @@ func (e *Engine) Volume(ctx context.Context, req *engine.VolumeRequest) (*engine
 		Credentials: req.Credentials,
 	})
 	if err != nil {
-		e.setHideStoppedState(rm, false)
+		e.setVolumeRestartInProgress(rm, false)
 		return nil, fmt.Errorf("restart after volume change: %w", err)
 	}
-	e.setHideStoppedState(rm, false)
+	e.setVolumeRestartInProgress(rm, false)
 
 	// Log checkpoint state AFTER restart (should still be same - Spirit resumes from checkpoint)
 	e.mu.Lock()
@@ -311,11 +311,11 @@ func (e *Engine) Volume(ctx context.Context, req *engine.VolumeRequest) (*engine
 	}, nil
 }
 
-func (e *Engine) setHideStoppedState(rm *runningMigration, hide bool) {
+func (e *Engine) setVolumeRestartInProgress(rm *runningMigration, inProgress bool) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	if e.runningMigration == rm {
-		rm.hideStoppedState = hide
+		rm.volumeRestartInProgress = inProgress
 	}
 }
 

--- a/pkg/engine/spirit/control.go
+++ b/pkg/engine/spirit/control.go
@@ -262,26 +262,22 @@ func (e *Engine) Volume(ctx context.Context, req *engine.VolumeRequest) (*engine
 		"new_volume":      req.Volume,
 	})
 
-	// Stop the schema change
+	// Volume uses Stop to force a checkpoint before restarting with new settings.
+	// Keep the stored stopped state available for Start while reporting the
+	// adjustment as running to progress pollers.
+	e.setHideStoppedState(rm, true)
+
 	_, err := e.Stop(ctx, &engine.ControlRequest{
 		Database:    req.Database,
 		Credentials: req.Credentials,
 	})
 	if err != nil {
+		e.setHideStoppedState(rm, false)
 		return nil, fmt.Errorf("stop for volume change: %w", err)
 	}
 
 	// Log checkpoint state AFTER stopping (should be same as before)
 	e.logCheckpointState(rm, "after_stop", nil)
-
-	// Override the stopped state immediately. Stop() sets rm.state = StateStopped,
-	// but during a volume change this is a transient internal state. If the poller
-	// observes "stopped" it treats it as terminal and exits, leaving storage stuck.
-	// Setting it back to "running" before Start() ensures Progress() never exposes
-	// the intermediate stopped state.
-	e.mu.Lock()
-	rm.state = engine.StateRunning
-	e.mu.Unlock()
 
 	// Update engine configuration
 	e.threads = newThreads
@@ -294,8 +290,10 @@ func (e *Engine) Volume(ctx context.Context, req *engine.VolumeRequest) (*engine
 		Credentials: req.Credentials,
 	})
 	if err != nil {
+		e.setHideStoppedState(rm, false)
 		return nil, fmt.Errorf("restart after volume change: %w", err)
 	}
+	e.setHideStoppedState(rm, false)
 
 	// Log checkpoint state AFTER restart (should still be same - Spirit resumes from checkpoint)
 	e.mu.Lock()
@@ -311,6 +309,14 @@ func (e *Engine) Volume(ctx context.Context, req *engine.VolumeRequest) (*engine
 		NewVolume:      req.Volume,
 		Message:        fmt.Sprintf("Volume changed: %d -> %d (%d threads, %v chunks)", previousVolume, req.Volume, newThreads, newChunkTime),
 	}, nil
+}
+
+func (e *Engine) setHideStoppedState(rm *runningMigration, hide bool) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.runningMigration == rm {
+		rm.hideStoppedState = hide
+	}
 }
 
 // minThreads is the lower bound for CPU-scaled volumes (6-11).

--- a/pkg/engine/spirit/control_test.go
+++ b/pkg/engine/spirit/control_test.go
@@ -235,11 +235,13 @@ func TestVolumeReportsRunningWhileStoredStoppedStateRestarts(t *testing.T) {
 		database:       "testdb",
 		tableNamespace: map[string]string{},
 		state:          engine.StateRunning,
-		host:           "127.0.0.1",
+		host:           "127.0.0.1:1",
 		username:       "root",
 	}
 	rm.wg.Add(1)
+	eng.mu.Lock()
 	eng.runningMigration = rm
+	eng.mu.Unlock()
 
 	errCh := make(chan error, 1)
 	go func() {

--- a/pkg/engine/spirit/control_test.go
+++ b/pkg/engine/spirit/control_test.go
@@ -258,7 +258,7 @@ func TestVolumeReportsRunningWhileStoredStoppedStateRestarts(t *testing.T) {
 	require.Eventually(t, func() bool {
 		eng.mu.Lock()
 		defer eng.mu.Unlock()
-		return rm.state == engine.StateStopped && rm.hideStoppedState
+		return rm.state == engine.StateStopped && rm.volumeRestartInProgress
 	}, time.Second, 10*time.Millisecond)
 
 	progress, err := eng.Progress(t.Context(), &engine.ProgressRequest{})

--- a/pkg/engine/spirit/control_test.go
+++ b/pkg/engine/spirit/control_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/block/schemabot/pkg/engine"
 )
 
 func TestVolumeToSpiritSettings(t *testing.T) {
@@ -222,4 +224,51 @@ func TestSettingsToVolume(t *testing.T) {
 	assert.Equal(t, int32(6), settingsToVolume(8, 5*time.Second))
 	assert.Equal(t, int32(8), settingsToVolume(12, 5*time.Second))
 	assert.Equal(t, int32(10), settingsToVolume(maxThreads, 5*time.Second))
+}
+
+// Volume adjustments store a stopped state so Spirit can resume from checkpoint
+// with new settings. Progress should still report running during that window so
+// the scheduler keeps polling the active schema change.
+func TestVolumeReportsRunningWhileStoredStoppedStateRestarts(t *testing.T) {
+	eng := New(Config{})
+	rm := &runningMigration{
+		database:       "testdb",
+		tableNamespace: map[string]string{},
+		state:          engine.StateRunning,
+		host:           "127.0.0.1",
+		username:       "root",
+	}
+	rm.wg.Add(1)
+	eng.runningMigration = rm
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := eng.Volume(t.Context(), &engine.VolumeRequest{
+			Database: "testdb",
+			Volume:   4,
+			Credentials: &engine.Credentials{
+				DSN: "root@tcp(127.0.0.1:1)/testdb",
+			},
+		})
+		errCh <- err
+	}()
+
+	require.Eventually(t, func() bool {
+		eng.mu.Lock()
+		defer eng.mu.Unlock()
+		return rm.state == engine.StateStopped && rm.hideStoppedState
+	}, time.Second, 10*time.Millisecond)
+
+	progress, err := eng.Progress(t.Context(), &engine.ProgressRequest{})
+	require.NoError(t, err)
+	assert.Equal(t, engine.StateRunning, progress.State)
+
+	rm.wg.Done()
+	select {
+	case err := <-errCh:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for volume change")
+	}
+	eng.Drain()
 }

--- a/pkg/engine/spirit/spirit.go
+++ b/pkg/engine/spirit/spirit.go
@@ -78,6 +78,7 @@ type runningMigration struct {
 	errorMessage      string // Error details when state is StateFailed
 	started           time.Time
 	deferCutover      bool // Whether to defer cutover until manual trigger
+	hideStoppedState  bool // Set while stored stopped state should still be exposed as running progress.
 
 	// For resume support
 	cancelFunc context.CancelFunc
@@ -510,6 +511,9 @@ func (e *Engine) Progress(ctx context.Context, req *engine.ProgressRequest) (*en
 	// Determine overall state from Spirit's state
 	// Preserve terminal states (stopped, failed) - don't overwrite them
 	state := rm.state
+	if state == engine.StateStopped && rm.hideStoppedState {
+		state = engine.StateRunning
+	}
 	if state != engine.StateStopped && state != engine.StateFailed {
 		switch spiritState {
 		case status.WaitingOnSentinelTable:

--- a/pkg/engine/spirit/spirit.go
+++ b/pkg/engine/spirit/spirit.go
@@ -67,18 +67,18 @@ type Engine struct {
 
 // runningMigration tracks the state of an in-progress schema change.
 type runningMigration struct {
-	database          string            // MySQL database name parsed from DSN
-	tableNamespace    map[string]string // table name → namespace (from ApplyRequest.Changes)
-	tables            []string
-	ddls              []string // DDL statement for each table
-	combinedStatement string   // Original combined statement passed to Spirit (for checkpoint-safe restart)
-	runners           []*spiritmigration.Runner
-	progressCallback  func() string // returns Summary from Spirit's Progress API
-	state             engine.State
-	errorMessage      string // Error details when state is StateFailed
-	started           time.Time
-	deferCutover      bool // Whether to defer cutover until manual trigger
-	hideStoppedState  bool // Set while stored stopped state should still be exposed as running progress.
+	database                string            // MySQL database name parsed from DSN
+	tableNamespace          map[string]string // table name → namespace (from ApplyRequest.Changes)
+	tables                  []string
+	ddls                    []string // DDL statement for each table
+	combinedStatement       string   // Original combined statement passed to Spirit (for checkpoint-safe restart)
+	runners                 []*spiritmigration.Runner
+	progressCallback        func() string // returns Summary from Spirit's Progress API
+	state                   engine.State
+	errorMessage            string // Error details when state is StateFailed
+	started                 time.Time
+	deferCutover            bool // Whether to defer cutover until manual trigger
+	volumeRestartInProgress bool // Set while stored stopped state should still be exposed as running progress.
 
 	// For resume support
 	cancelFunc context.CancelFunc
@@ -511,7 +511,7 @@ func (e *Engine) Progress(ctx context.Context, req *engine.ProgressRequest) (*en
 	// Determine overall state from Spirit's state
 	// Preserve terminal states (stopped, failed) - don't overwrite them
 	state := rm.state
-	if state == engine.StateStopped && rm.hideStoppedState {
+	if state == engine.StateStopped && rm.volumeRestartInProgress {
 		state = engine.StateRunning
 	}
 	if state != engine.StateStopped && state != engine.StateFailed {


### PR DESCRIPTION
## Why
Spirit volume changes stop the stored runner state to force a checkpoint before restarting with new settings. During that stored stopped window, progress polling should still expose the schema change as running so the scheduler keeps polling instead of treating the volume adjustment as terminal.

## What
- Track when a stored stopped state should be exposed as running progress during a Spirit volume restart
- Preserve the stopped state for resume while returning running from progress polling
- Clear the marker after restart or stop/start errors
- Add focused coverage for the stored stopped restart window

```text
volume request
   |
   v
store stopped state for checkpoint
   |
   +--> Progress reports running
   |
   v
Start resumes from checkpoint
   |
   v
clear progress override
```

Generated with Codex