### PR TITLE
fix(scheduler): route stopped starts through durable requests

### DIFF
--- a/e2e/grpc/cli_test.go
+++ b/e2e/grpc/cli_test.go
@@ -189,7 +189,7 @@ func TestGRPCCLI_StopStart(t *testing.T) {
 		`CREATE TABLE %s (id INT NOT NULL AUTO_INCREMENT PRIMARY KEY, name VARCHAR(255) NOT NULL, data TEXT)`, tableName))
 
 	grpcSeedRows(t, "staging", tableName, "name, data",
-		"CONCAT('user_', seq), REPEAT('x', 500)", 100000)
+		"CONCAT('user_', seq), REPEAT('x', 500)", 500000)
 	grpcEnsureNoActiveChange(t, "testapp", "staging")
 
 	// Schema with INT->BIGINT PK change
@@ -246,6 +246,9 @@ func TestGRPCCLI_StopStart(t *testing.T) {
 			"--endpoint", endpoint,
 			"--watch=false",
 		)
+
+		testutil.WaitForAnyState(t, endpoint, applyID,
+			[]string{state.Apply.Running, state.Apply.Completed}, 30*time.Second)
 	}
 
 	// Wait for completion

--- a/e2e/grpc/grpc_test.go
+++ b/e2e/grpc/grpc_test.go
@@ -49,6 +49,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/block/schemabot/e2e/testutil"
 	"github.com/block/schemabot/pkg/state"
 	"github.com/block/spirit/pkg/utils"
 	_ "github.com/go-sql-driver/mysql"
@@ -267,6 +268,9 @@ func TestGRPC_StopStart(t *testing.T) {
 		var startResult grpcSimpleResponse
 		grpcDecodeJSON(t, startResp, &startResult)
 		require.True(t, startResult.Accepted, "start not accepted: %s", startResult.ErrorMessage)
+
+		testutil.WaitForAnyState(t, grpcSchemabotURL(t), apply.ApplyID,
+			[]string{state.Apply.Running, state.Apply.Completed}, 30*time.Second)
 	}
 
 	// Wait for completion

--- a/e2e/grpc/helpers_test.go
+++ b/e2e/grpc/helpers_test.go
@@ -464,6 +464,9 @@ func grpcSeedRows(t *testing.T, env, tableName, columns, valueTemplate string, r
 	if rowCount >= 100000 {
 		seqGen += `, (SELECT 0 UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) e`
 	}
+	if rowCount > 100000 {
+		seqGen += `, (SELECT 0 UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) f`
+	}
 	seqGen += `, (SELECT @row := 0) r) nums`
 
 	query := fmt.Sprintf(`INSERT INTO %s (%s) SELECT %s FROM %s LIMIT %d`,

--- a/e2e/k8s/k8s_test.go
+++ b/e2e/k8s/k8s_test.go
@@ -348,6 +348,55 @@ func TestK8s_Progress(t *testing.T) {
 	testutil.WaitForState(t, ep, applyID, state.Apply.Completed, testutil.PollDeadline)
 }
 
+// TestK8s_StopStartThroughScheduler verifies that a stopped gRPC apply is
+// resumed through durable control-plane scheduler state. The API accepts the
+// start request before the data plane performs the resume, then the scheduler
+// completes the handoff and the schema change finishes on the target database.
+func TestK8s_StopStartThroughScheduler(t *testing.T) {
+	fixture := startRunningIndexAddApply(t, "k8s_stopstart")
+
+	stopResp, err := client.CallStopAPI(fixture.Endpoint, "staging", fixture.ApplyID)
+	require.NoError(t, err, "stop API call")
+	require.True(t, stopResp.Accepted, "stop not accepted: %s", stopResp.ErrorMessage)
+
+	testutil.WaitForState(t, fixture.Endpoint, fixture.ApplyID, state.Apply.Stopped, testutil.PollDeadline)
+
+	startResp, err := client.CallStartAPI(fixture.Endpoint, "staging", fixture.ApplyID)
+	require.NoError(t, err, "start API call")
+	require.True(t, startResp.Accepted, "start not accepted: %s", startResp.ErrorMessage)
+	assert.Equal(t, "queued", startResp.Status)
+
+	waitForControlPlaneStartControlRequestCompleted(t, fixture.ApplyID)
+	testutil.WaitForState(t, fixture.Endpoint, fixture.ApplyID, state.Apply.Completed, 3*time.Minute)
+	waitForIndex(t, fixture.TargetDSN, fixture.TableName, "idx_account_created", testutil.PollDeadline)
+}
+
+func waitForControlPlaneStartControlRequestCompleted(t *testing.T, applyID string) {
+	t.Helper()
+
+	db, err := sql.Open("mysql", testutil.SchemabotDSN(t))
+	require.NoError(t, err)
+	defer utils.CloseAndLog(db)
+	require.NoError(t, db.PingContext(t.Context()))
+
+	var status string
+	var lastErr error
+	testutil.Poll(t, testutil.PollDeadline, testutil.PollInterval,
+		func() bool {
+			lastErr = db.QueryRowContext(t.Context(), `
+				SELECT cr.status
+				FROM apply_control_requests cr
+				JOIN applies a ON a.id = cr.apply_id
+				WHERE a.apply_identifier = ? AND cr.operation = ?
+			`, applyID, storage.ControlOperationStart).Scan(&status)
+			return lastErr == nil && status == string(storage.ControlRequestCompleted)
+		},
+		func() string {
+			return fmt.Sprintf("start control request was not completed for %s: status=%q last_err=%v",
+				applyID, status, lastErr)
+		})
+}
+
 // TestK8s_ProgressStableAcrossDataPlaneReplicas verifies that gRPC progress is
 // stable when a data-plane service has multiple pods. Only one pod owns the
 // in-memory Spirit runner, but every pod must be able to answer Progress from

--- a/pkg/api/control_handlers.go
+++ b/pkg/api/control_handlers.go
@@ -318,14 +318,13 @@ func (s *Service) handleStart(w http.ResponseWriter, r *http.Request) {
 		resp, responseStatus, err = s.startResponseForPendingStartRequest(r.Context(), apply)
 		queuedForScheduler = err == nil && resp.Accepted
 	case storedApplyMayHaveStoppedTasksForStart(apply.State):
+		// A queued or scheduler-claimed start can leave the durable request
+		// pending while the stored apply is stopped or running. Treat retries in
+		// either state as idempotent duplicates instead of revalidating remote
+		// state or recording another request.
 		var foundPendingStart bool
-		if state.IsState(apply.State, state.Apply.Running) {
-			// A scheduler claim moves an accepted start request back to running
-			// before the worker necessarily completes the durable request. Treat
-			// client retries in that window as idempotent duplicates.
-			resp, responseStatus, foundPendingStart, err = s.pendingStartResponseIfPresent(r.Context(), apply)
-			queuedForScheduler = err == nil && foundPendingStart && resp.Accepted
-		}
+		resp, responseStatus, foundPendingStart, err = s.pendingStartResponseIfPresent(r.Context(), apply)
+		queuedForScheduler = err == nil && foundPendingStart && resp.Accepted
 		if err == nil && !foundPendingStart && client.IsRemote() && apply.ExternalID != "" {
 			resp, responseStatus, err = s.queueRemoteStoppedApplyForScheduler(r.Context(), client, apply, req.Caller)
 		} else if err == nil && !foundPendingStart {
@@ -370,7 +369,8 @@ func (s *Service) handleStart(w http.ResponseWriter, r *http.Request) {
 
 // queueStoppedApplyForScheduler makes a user start request claimable by a
 // scheduler worker. Resuming stopped table work can outlive the HTTP request,
-// so the handler only records intent and wakes the scheduler.
+// so the handler records intent, normalizes a lagging stored apply row to
+// stopped, and wakes the scheduler.
 func (s *Service) queueStoppedApplyForScheduler(ctx context.Context, apply *storage.Apply, caller string) (*ternv1.StartResponse, string, error) {
 	if !storedApplyMayHaveStoppedTasksForStart(apply.State) {
 		return nil, "", startNotAllowedForState(apply)
@@ -402,6 +402,9 @@ func (s *Service) queueStoppedApplyForScheduler(ctx context.Context, apply *stor
 			"environment", apply.Environment,
 			"stopped_count", startedCount,
 			"terminal_count", skippedCount)
+		if err := s.ensureStoredApplyStoppedForStartClaim(ctx, apply); err != nil {
+			return nil, "", err
+		}
 	}
 	return s.persistStartRequestForScheduler(ctx, apply, caller, startedCount, skippedCount)
 }
@@ -442,8 +445,32 @@ func (s *Service) queueRemoteStoppedApplyForScheduler(ctx context.Context, clien
 			"remote_state", remoteState,
 			"stopped_count", startedCount,
 			"terminal_count", skippedCount)
+		if err := s.ensureStoredApplyStoppedForStartClaim(ctx, apply); err != nil {
+			return nil, "", err
+		}
 	}
 	return s.persistStartRequestForScheduler(ctx, apply, caller, startedCount, skippedCount)
+}
+
+func (s *Service) ensureStoredApplyStoppedForStartClaim(ctx context.Context, apply *storage.Apply) error {
+	if !state.IsState(apply.State, state.Apply.Running) {
+		return nil
+	}
+	applyStore := s.storage.Applies()
+	if applyStore == nil {
+		return fmt.Errorf("apply store is not available")
+	}
+
+	previousApply := *apply
+	now := time.Now()
+	apply.State = state.Apply.Stopped
+	apply.CompletedAt = nil
+	apply.UpdatedAt = now
+	if err := applyStore.Update(ctx, apply); err != nil {
+		*apply = previousApply
+		return fmt.Errorf("mark stored apply %s stopped before scheduler start: %w", apply.ApplyIdentifier, err)
+	}
+	return nil
 }
 
 func remoteStoppedApplyStartCounts(tables []*ternv1.TableProgress) (int64, int64) {

--- a/pkg/api/control_handlers.go
+++ b/pkg/api/control_handlers.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -276,6 +277,19 @@ type StartRequest struct {
 	Caller      string `json:"caller,omitempty"`
 }
 
+type startControlRequestMetadata struct {
+	StartedCount int64 `json:"started_count,omitempty"`
+	// SkippedCount preserves how many task rows were already terminal when the
+	// start was accepted. Duplicate start calls use this metadata so clients see
+	// the same "already complete" count as the original request.
+	SkippedCount int64 `json:"skipped_count,omitempty"`
+}
+
+const (
+	startResponseStatusQueued           = "queued"
+	startResponseStatusAlreadyRequested = "already_requested"
+)
+
 // handleStart handles POST /api/start requests.
 func (s *Service) handleStart(w http.ResponseWriter, r *http.Request) {
 	var req StartRequest
@@ -290,31 +304,52 @@ func (s *Service) handleStart(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	resp, err := client.Start(r.Context(), &ternv1.StartRequest{
-		ApplyId:     applyID,
-		Environment: apply.Environment,
-	})
+	var resp *ternv1.StartResponse
+	var err error
+	responseStatus := ""
+	queuedForScheduler := false
+	switch {
+	case state.IsState(apply.State, state.Apply.WaitingForDeploy):
+		resp, err = client.Start(r.Context(), &ternv1.StartRequest{
+			ApplyId:     applyID,
+			Environment: apply.Environment,
+		})
+	case state.IsState(apply.State, state.Apply.Pending):
+		resp, responseStatus, err = s.startResponseForPendingStartRequest(r.Context(), apply)
+		queuedForScheduler = err == nil && resp.Accepted
+	case storedApplyMayHaveStoppedTasksForStart(apply.State):
+		var foundPendingStart bool
+		if state.IsState(apply.State, state.Apply.Running) {
+			// A scheduler claim moves an accepted start request back to running
+			// before the worker necessarily completes the durable request. Treat
+			// client retries in that window as idempotent duplicates.
+			resp, responseStatus, foundPendingStart, err = s.pendingStartResponseIfPresent(r.Context(), apply)
+			queuedForScheduler = err == nil && foundPendingStart && resp.Accepted
+		}
+		if err == nil && !foundPendingStart && client.IsRemote() && apply.ExternalID != "" {
+			resp, responseStatus, err = s.queueRemoteStoppedApplyForScheduler(r.Context(), client, apply, req.Caller)
+		} else if err == nil && !foundPendingStart {
+			resp, responseStatus, err = s.queueStoppedApplyForScheduler(r.Context(), apply, req.Caller)
+		}
+		queuedForScheduler = queuedForScheduler || (err == nil && resp.Accepted)
+	default:
+		err = startNotAllowedForState(apply)
+	}
 	if err != nil {
-		metrics.RecordControlOperation(r.Context(), "start", apply.Database, apply.Environment, "error")
+		status := "error"
+		if controlOperationHTTPStatus(err) < http.StatusInternalServerError {
+			status = "rejected"
+		}
+		metrics.RecordControlOperation(r.Context(), "start", apply.Database, apply.Environment, status)
 		s.writeControlError(w, "start", apply, err)
 		return
 	}
+
 	metrics.RecordControlOperation(r.Context(), "start", apply.Database, apply.Environment, controlStatus(resp.Accepted))
 	if resp.Accepted {
 		s.logControlOperation(r, apply.ApplyIdentifier, req.Caller, storage.LogEventStartRequested, "Start requested by user")
-	}
-
-	// For remote (gRPC) clients, update local apply state and restart the
-	// background progress poller. Without this, the local applies.state stays
-	// "stopped" permanently because the old poller exited when it saw the
-	// terminal state.
-	var syncErr string
-	if resp.Accepted && client.IsRemote() {
-		// Mark running before ResumeApply so it doesn't re-issue a Start RPC.
-		apply.State = state.Apply.Running
-		if resumeErr := client.ResumeApply(r.Context(), apply); resumeErr != nil {
-			s.logger.Error("failed to resume apply tracking after start", "apply_id", apply.ApplyIdentifier, "error", resumeErr)
-			syncErr = "schema change was started successfully, but the status and progress endpoints may show stale state until the next recovery cycle"
+		if queuedForScheduler {
+			s.wakeScheduler(apply.ApplyIdentifier, apply.Database, apply.Environment)
 		}
 	}
 
@@ -323,31 +358,262 @@ func (s *Service) handleStart(w http.ResponseWriter, r *http.Request) {
 		ErrorMessage: resp.ErrorMessage,
 		StartedCount: resp.StartedCount,
 		SkippedCount: resp.SkippedCount,
-	}
-	if syncErr != "" {
-		httpResp.ErrorCode = apitypes.ErrCodeStateSyncFailed
-		httpResp.ErrorMessage = syncErr
+		Status:       responseStatus,
 	}
 
-	s.writeJSON(w, http.StatusOK, httpResp)
+	httpStatus := http.StatusOK
+	if responseStatus == startResponseStatusAlreadyRequested {
+		httpStatus = http.StatusAccepted
+	}
+	s.writeJSON(w, httpStatus, httpResp)
+}
+
+// queueStoppedApplyForScheduler makes a user start request claimable by a
+// scheduler worker. Resuming stopped table work can outlive the HTTP request,
+// so the handler only records intent and wakes the scheduler.
+func (s *Service) queueStoppedApplyForScheduler(ctx context.Context, apply *storage.Apply, caller string) (*ternv1.StartResponse, string, error) {
+	if !storedApplyMayHaveStoppedTasksForStart(apply.State) {
+		return nil, "", startNotAllowedForState(apply)
+	}
+	tasks, err := s.storage.Tasks().GetByApplyID(ctx, apply.ID)
+	if err != nil {
+		return nil, "", fmt.Errorf("get tasks for apply %s: %w", apply.ApplyIdentifier, err)
+	}
+	var startedCount int64
+	var skippedCount int64
+	for _, task := range tasks {
+		switch {
+		case state.IsState(task.State, state.Task.Stopped):
+			startedCount++
+		case state.IsTerminalTaskState(task.State):
+			skippedCount++
+		}
+	}
+	if startedCount == 0 {
+		if state.IsState(apply.State, state.Apply.Stopped) {
+			return nil, "", controlConflictf("no stopped tasks for apply %s", apply.ApplyIdentifier)
+		}
+		return nil, "", startNotAllowedForState(apply)
+	}
+	if state.IsState(apply.State, state.Apply.Running) {
+		s.logger.Info("queueing start for stopped tasks while stored apply is still running",
+			"apply_id", apply.ApplyIdentifier,
+			"database", apply.Database,
+			"environment", apply.Environment,
+			"stopped_count", startedCount,
+			"terminal_count", skippedCount)
+	}
+	return s.persistStartRequestForScheduler(ctx, apply, caller, startedCount, skippedCount)
+}
+
+// queueRemoteStoppedApplyForScheduler validates remote stopped state before
+// recording scheduler work. In gRPC mode, progress can show the data plane as
+// stopped before the control-plane task rows have synced to stopped, so the
+// remote apply state is the start gate.
+func (s *Service) queueRemoteStoppedApplyForScheduler(ctx context.Context, client tern.Client, apply *storage.Apply, caller string) (*ternv1.StartResponse, string, error) {
+	if !storedApplyMayHaveStoppedTasksForStart(apply.State) {
+		return nil, "", startNotAllowedForState(apply)
+	}
+	resp, err := client.Progress(ctx, &ternv1.ProgressRequest{
+		ApplyId:     apply.ExternalID,
+		Database:    apply.Database,
+		Environment: apply.Environment,
+	})
+	if err != nil {
+		return nil, "", fmt.Errorf("check remote apply %s before start: %w", apply.ApplyIdentifier, err)
+	}
+	remoteState := tern.ProtoStateToStorage(resp.State)
+	if !state.IsState(remoteState, state.Apply.Stopped) {
+		if remoteState == "" {
+			remoteState = resp.State.String()
+		}
+		return nil, "", controlConflictf("schema change is not stopped (remote state: %s, current state: %s)", remoteState, apply.State)
+	}
+	startedCount, skippedCount := remoteStoppedApplyStartCounts(resp.Tables)
+	if startedCount == 0 {
+		startedCount = 1
+	}
+	if state.IsState(apply.State, state.Apply.Running) {
+		s.logger.Info("queueing remote start while stored apply is still running",
+			"apply_id", apply.ApplyIdentifier,
+			"external_id", apply.ExternalID,
+			"database", apply.Database,
+			"environment", apply.Environment,
+			"remote_state", remoteState,
+			"stopped_count", startedCount,
+			"terminal_count", skippedCount)
+	}
+	return s.persistStartRequestForScheduler(ctx, apply, caller, startedCount, skippedCount)
+}
+
+func remoteStoppedApplyStartCounts(tables []*ternv1.TableProgress) (int64, int64) {
+	var startedCount int64
+	var skippedCount int64
+	for _, table := range tables {
+		taskState := state.NormalizeTaskStatus(table.Status)
+		switch {
+		case state.IsState(taskState, state.Task.Stopped):
+			startedCount++
+		case state.IsTerminalTaskState(taskState):
+			skippedCount++
+		}
+	}
+	return startedCount, skippedCount
+}
+
+func (s *Service) persistStartRequestForScheduler(ctx context.Context, apply *storage.Apply, caller string, startedCount, skippedCount int64) (*ternv1.StartResponse, string, error) {
+	controlReq, alreadyPending, err := s.createStartControlRequest(ctx, apply, caller, startedCount, skippedCount)
+	if err != nil {
+		return nil, "", err
+	}
+	if alreadyPending {
+		// A duplicate request should not rewind a scheduler-claimed apply from
+		// running back to pending. Only requeue stopped applies, which can happen
+		// if a previous request recorded intent but failed before updating the
+		// apply row.
+		if state.IsState(apply.State, state.Apply.Stopped) {
+			if err := s.queueApplyForSchedulerStart(ctx, apply); err != nil {
+				return nil, "", err
+			}
+		}
+		resp, err := startResponseFromControlRequest(controlReq)
+		if err != nil {
+			return nil, "", err
+		}
+		return resp, startResponseStatusAlreadyRequested, nil
+	}
+
+	if err := s.queueApplyForSchedulerStart(ctx, apply); err != nil {
+		return nil, "", err
+	}
+	return &ternv1.StartResponse{
+		Accepted:     true,
+		StartedCount: startedCount,
+		SkippedCount: skippedCount,
+	}, startResponseStatusQueued, nil
+}
+
+func (s *Service) queueApplyForSchedulerStart(ctx context.Context, apply *storage.Apply) error {
+	apply.State = state.Apply.Pending
+	apply.CompletedAt = nil
+	now := time.Now()
+	if apply.StartedAt == nil {
+		apply.StartedAt = &now
+	}
+	apply.UpdatedAt = now
+	if err := s.storage.Applies().Update(ctx, apply); err != nil {
+		return fmt.Errorf("queue apply %s for scheduler start: %w", apply.ApplyIdentifier, err)
+	}
+	return nil
+}
+
+func (s *Service) createStartControlRequest(ctx context.Context, apply *storage.Apply, caller string, startedCount, skippedCount int64) (*storage.ApplyControlRequest, bool, error) {
+	controlStore := s.storage.ControlRequests()
+	if controlStore == nil {
+		return nil, false, fmt.Errorf("control request store is not available")
+	}
+	metadata, err := json.Marshal(startControlRequestMetadata{
+		StartedCount: startedCount,
+		SkippedCount: skippedCount,
+	})
+	if err != nil {
+		return nil, false, fmt.Errorf("marshal start control request metadata for apply %s: %w", apply.ApplyIdentifier, err)
+	}
+	controlReq, alreadyPending, err := controlStore.RequestPending(ctx, &storage.ApplyControlRequest{
+		ApplyID:     apply.ID,
+		Operation:   storage.ControlOperationStart,
+		Status:      storage.ControlRequestPending,
+		RequestedBy: caller,
+		Metadata:    metadata,
+	})
+	if err != nil {
+		return nil, false, fmt.Errorf("record start control request for apply %s: %w", apply.ApplyIdentifier, err)
+	}
+	return controlReq, alreadyPending, nil
+}
+
+func (s *Service) startResponseForPendingStartRequest(ctx context.Context, apply *storage.Apply) (*ternv1.StartResponse, string, error) {
+	resp, responseStatus, found, err := s.pendingStartResponseIfPresent(ctx, apply)
+	if err != nil {
+		return nil, "", err
+	}
+	if !found {
+		return nil, "", startNotAllowedForState(apply)
+	}
+	return resp, responseStatus, nil
+}
+
+func (s *Service) pendingStartResponseIfPresent(ctx context.Context, apply *storage.Apply) (*ternv1.StartResponse, string, bool, error) {
+	controlStore := s.storage.ControlRequests()
+	if controlStore == nil {
+		return nil, "", false, fmt.Errorf("control request store is not available")
+	}
+	controlReq, err := controlStore.GetPending(ctx, apply.ID, storage.ControlOperationStart)
+	if err != nil {
+		return nil, "", false, fmt.Errorf("load pending start control request for apply %s: %w", apply.ApplyIdentifier, err)
+	}
+	if controlReq == nil {
+		return nil, "", false, nil
+	}
+	resp, err := startResponseFromControlRequest(controlReq)
+	if err != nil {
+		return nil, "", false, err
+	}
+	return resp, startResponseStatusAlreadyRequested, true, nil
+}
+
+func startResponseFromControlRequest(controlReq *storage.ApplyControlRequest) (*ternv1.StartResponse, error) {
+	resp := &ternv1.StartResponse{}
+	if controlReq == nil {
+		return resp, nil
+	}
+	var metadata startControlRequestMetadata
+	if len(controlReq.Metadata) > 0 {
+		if err := json.Unmarshal(controlReq.Metadata, &metadata); err != nil {
+			return nil, fmt.Errorf("decode start control request metadata for request %d: %w", controlReq.ID, err)
+		}
+	}
+	resp.StartedCount = metadata.StartedCount
+	resp.SkippedCount = metadata.SkippedCount
+	switch controlReq.Status {
+	case storage.ControlRequestPending, storage.ControlRequestCompleted:
+		resp.Accepted = true
+	case storage.ControlRequestFailed:
+		resp.ErrorMessage = controlReq.ErrorMessage
+	default:
+		resp.ErrorMessage = fmt.Sprintf("start control request has unknown status: %s", controlReq.Status)
+	}
+	return resp, nil
+}
+
+// storedApplyMayHaveStoppedTasksForStart keeps start requests aligned with the
+// durable task rows, not only the derived apply row. Stop persists stopped task
+// rows before the apply row necessarily reflects the derived stopped state, so
+// a user can start after progress shows stopped while the stored apply still
+// says running.
+func storedApplyMayHaveStoppedTasksForStart(storedApplyState string) bool {
+	return state.IsState(storedApplyState, state.Apply.Stopped) ||
+		state.IsState(storedApplyState, state.Apply.Running)
 }
 
 func validateStartRequestState(apply *storage.Apply) error {
-	if apply.GetOptions().DeferDeploy && !state.IsState(apply.State, state.Apply.WaitingForDeploy) {
-		return controlConflictf("schema change is not ready for deploy (current state: %s)", apply.State)
-	}
 	if !isStartRequestAllowedState(apply.State) {
 		return startNotAllowedForState(apply)
+	}
+	if apply.GetOptions().DeferDeploy && !state.IsState(apply.State, state.Apply.WaitingForDeploy) {
+		return controlConflictf("schema change is not ready for deploy (current state: %s)", apply.State)
 	}
 	return nil
 }
 
 // isStartRequestAllowedState is an allowlist for states where /start has a
-// concrete action. New apply states must opt in here before they can reach Tern.
+// concrete action. New apply states must opt in here before they can reach the
+// scheduler or Tern start paths.
 func isStartRequestAllowedState(applyState string) bool {
 	return state.IsState(
 		applyState,
 		state.Apply.WaitingForDeploy,
+		state.Apply.Pending,
 		state.Apply.Running,
 		state.Apply.Stopped,
 	)
@@ -357,6 +623,11 @@ func startNotAllowedForState(apply *storage.Apply) error {
 	switch {
 	case state.IsState(apply.State, state.Apply.Pending):
 		return controlConflictf("schema change is pending and no start request is queued")
+	case state.IsState(apply.State, state.Apply.Running):
+		// Running applies may reach this helper after the handler checks for
+		// stopped task rows. Without stopped task rows, there is no scheduler
+		// start work to queue.
+		return controlConflictf("schema change is still running; stop it before starting it again")
 	case state.IsState(apply.State, state.Apply.WaitingForCutover):
 		return controlConflictf("schema change is waiting for cutover; use cutover instead of start")
 	case state.IsState(apply.State, state.Apply.CuttingOver):

--- a/pkg/api/control_handlers.go
+++ b/pkg/api/control_handlers.go
@@ -467,15 +467,6 @@ func (s *Service) persistStartRequestForScheduler(ctx context.Context, apply *st
 		return nil, "", err
 	}
 	if alreadyPending {
-		// A duplicate request should not rewind a scheduler-claimed apply from
-		// running back to pending. Only requeue stopped applies, which can happen
-		// if a previous request recorded intent but failed before updating the
-		// apply row.
-		if state.IsState(apply.State, state.Apply.Stopped) {
-			if err := s.queueApplyForSchedulerStart(ctx, apply); err != nil {
-				return nil, "", err
-			}
-		}
 		resp, err := startResponseFromControlRequest(controlReq)
 		if err != nil {
 			return nil, "", err
@@ -483,28 +474,11 @@ func (s *Service) persistStartRequestForScheduler(ctx context.Context, apply *st
 		return resp, startResponseStatusAlreadyRequested, nil
 	}
 
-	if err := s.queueApplyForSchedulerStart(ctx, apply); err != nil {
-		return nil, "", err
-	}
 	return &ternv1.StartResponse{
 		Accepted:     true,
 		StartedCount: startedCount,
 		SkippedCount: skippedCount,
 	}, startResponseStatusQueued, nil
-}
-
-func (s *Service) queueApplyForSchedulerStart(ctx context.Context, apply *storage.Apply) error {
-	apply.State = state.Apply.Pending
-	apply.CompletedAt = nil
-	now := time.Now()
-	if apply.StartedAt == nil {
-		apply.StartedAt = &now
-	}
-	apply.UpdatedAt = now
-	if err := s.storage.Applies().Update(ctx, apply); err != nil {
-		return fmt.Errorf("queue apply %s for scheduler start: %w", apply.ApplyIdentifier, err)
-	}
-	return nil
 }
 
 func (s *Service) createStartControlRequest(ctx context.Context, apply *storage.Apply, caller string, startedCount, skippedCount int64) (*storage.ApplyControlRequest, bool, error) {

--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -1893,7 +1893,7 @@ func TestStartHandler(t *testing.T) {
 		assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
 
 		assert.Nil(t, mock.startReq, "request path should queue scheduler work without calling Tern start")
-		assert.Equal(t, state.Apply.Pending, apply.State)
+		assert.Equal(t, state.Apply.Stopped, apply.State)
 		controlReq, err := svc.storage.ControlRequests().GetPending(t.Context(), apply.ID, storage.ControlOperationStart)
 		require.NoError(t, err)
 		require.NotNil(t, controlReq)
@@ -1989,7 +1989,7 @@ func TestStartHandler(t *testing.T) {
 		assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
 
 		assert.Nil(t, mock.startReq, "request path should queue scheduler work without calling Tern start")
-		assert.Equal(t, state.Apply.Pending, apply.State)
+		assert.Equal(t, state.Apply.Running, apply.State)
 		controlReq, err := svc.storage.ControlRequests().GetPending(t.Context(), apply.ID, storage.ControlOperationStart)
 		require.NoError(t, err)
 		require.NotNil(t, controlReq)
@@ -2030,7 +2030,7 @@ func TestStartHandler(t *testing.T) {
 		assert.Nil(t, mock.startReq, "request path should queue scheduler work without calling Tern start")
 		require.NotNil(t, mock.progressReq)
 		assert.Equal(t, "remote-apply-stoplag", mock.progressReq.ApplyId)
-		assert.Equal(t, state.Apply.Pending, apply.State)
+		assert.Equal(t, state.Apply.Running, apply.State)
 		controlReq, err := svc.storage.ControlRequests().GetPending(t.Context(), apply.ID, storage.ControlOperationStart)
 		require.NoError(t, err)
 		require.NotNil(t, controlReq)

--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -89,6 +89,7 @@ type mockStorageWithApplyStores struct {
 	tasks     storage.TaskStore
 	locks     storage.LockStore
 	applyLogs storage.ApplyLogStore
+	controls  storage.ControlRequestStore
 }
 
 func (m *mockStorageWithApplyStores) Plans() storage.PlanStore         { return m.plans }
@@ -96,6 +97,9 @@ func (m *mockStorageWithApplyStores) Applies() storage.ApplyStore      { return 
 func (m *mockStorageWithApplyStores) Tasks() storage.TaskStore         { return m.tasks }
 func (m *mockStorageWithApplyStores) Locks() storage.LockStore         { return m.locks }
 func (m *mockStorageWithApplyStores) ApplyLogs() storage.ApplyLogStore { return m.applyLogs }
+func (m *mockStorageWithApplyStores) ControlRequests() storage.ControlRequestStore {
+	return m.controls
+}
 
 type staticPlanStore struct {
 	storage.PlanStore
@@ -156,6 +160,70 @@ func (s *recentApplyStore) GetRecent(_ context.Context, filter storage.RecentApp
 		return applies[:filter.Limit], nil
 	}
 	return applies, nil
+}
+
+type memoryControlRequestStore struct {
+	storage.ControlRequestStore
+	mu       sync.Mutex
+	nextID   int64
+	requests []*storage.ApplyControlRequest
+}
+
+func (s *memoryControlRequestStore) RequestPending(_ context.Context, req *storage.ApplyControlRequest) (*storage.ApplyControlRequest, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, existing := range s.requests {
+		if existing.ApplyID == req.ApplyID && existing.Operation == req.Operation {
+			if existing.Status == storage.ControlRequestPending {
+				return cloneControlRequest(existing), true, nil
+			}
+			existing.Status = storage.ControlRequestPending
+			existing.RequestedBy = req.RequestedBy
+			existing.ErrorMessage = ""
+			existing.Metadata = append(existing.Metadata[:0], req.Metadata...)
+			existing.CompletedAt = nil
+			return cloneControlRequest(existing), false, nil
+		}
+	}
+	s.nextID++
+	stored := cloneControlRequest(req)
+	stored.ID = s.nextID
+	s.requests = append(s.requests, stored)
+	return cloneControlRequest(stored), false, nil
+}
+
+func (s *memoryControlRequestStore) GetPending(_ context.Context, applyID int64, operation storage.ControlOperation) (*storage.ApplyControlRequest, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for i := len(s.requests) - 1; i >= 0; i-- {
+		req := s.requests[i]
+		if req.ApplyID == applyID && req.Operation == operation && req.Status == storage.ControlRequestPending {
+			return cloneControlRequest(req), nil
+		}
+	}
+	return nil, nil
+}
+
+func (s *memoryControlRequestStore) CompletePending(_ context.Context, applyID int64, operation storage.ControlOperation) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, req := range s.requests {
+		if req.ApplyID == applyID && req.Operation == operation && req.Status == storage.ControlRequestPending {
+			req.Status = storage.ControlRequestCompleted
+		}
+	}
+	return nil
+}
+
+func cloneControlRequest(req *storage.ApplyControlRequest) *storage.ApplyControlRequest {
+	if req == nil {
+		return nil
+	}
+	clone := *req
+	if req.Metadata != nil {
+		clone.Metadata = append([]byte(nil), req.Metadata...)
+	}
+	return &clone
 }
 
 type capturingApplyStore struct {
@@ -479,6 +547,14 @@ func activeTestApply(applyID string) *storage.Apply {
 	}
 }
 
+func stoppedTestApply(applyID string) *storage.Apply {
+	apply := activeTestApply(applyID)
+	apply.State = state.Apply.Stopped
+	startedAt := time.Now().Add(-time.Minute)
+	apply.StartedAt = &startedAt
+	return apply
+}
+
 func newExecuteApplyTestService(client tern.Client, applies storage.ApplyStore) (*Service, *capturingTaskStore) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
 	tasks := &capturingTaskStore{}
@@ -491,6 +567,7 @@ func newExecuteApplyTestService(client tern.Client, applies storage.ApplyStore) 
 		tasks:     tasks,
 		locks:     &emptyLockStore{},
 		applyLogs: &noopApplyLogStore{},
+		controls:  &memoryControlRequestStore{},
 	}, testServerConfig(), map[string]tern.Client{
 		"default/staging": client,
 	}, logger), tasks
@@ -503,8 +580,9 @@ func newControlTestService(client tern.Client, apply *storage.Apply) *Service {
 func newControlTestServiceWithTasks(client tern.Client, apply *storage.Apply, tasks []*storage.Task) *Service {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
 	return New(&mockStorageWithApplyStores{
-		applies: &staticApplyStore{apply: apply},
-		tasks:   &capturingTaskStore{tasks: tasks},
+		applies:  &staticApplyStore{apply: apply},
+		tasks:    &capturingTaskStore{tasks: tasks},
+		controls: &memoryControlRequestStore{},
 	}, testServerConfig(), map[string]tern.Client{
 		"default/staging": client,
 	}, logger)
@@ -1767,14 +1845,16 @@ func TestStopHandler(t *testing.T) {
 }
 
 func TestStartHandler(t *testing.T) {
-	t.Run("passes apply_id to tern client", func(t *testing.T) {
+	t.Run("passes apply_id to tern client for deferred deploy", func(t *testing.T) {
 		mock := &mockTernClient{
 			startResp: &ternv1.StartResponse{
 				Accepted:     true,
 				StartedCount: 3,
 			},
 		}
-		svc := newControlTestService(mock, activeTestApply("apply-xyz789"))
+		apply := activeTestApply("apply-xyz789")
+		apply.State = state.Apply.WaitingForDeploy
+		svc := newControlTestService(mock, apply)
 		mux := http.NewServeMux()
 		svc.ConfigureRoutes(mux)
 
@@ -1791,24 +1871,255 @@ func TestStartHandler(t *testing.T) {
 		assert.Equal(t, "staging", mock.startReq.Environment)
 	})
 
-	t.Run("rejects deferred deploy before waiting for deploy", func(t *testing.T) {
+	t.Run("queues stopped apply for scheduler by apply_id", func(t *testing.T) {
 		mock := &mockTernClient{}
-		apply := activeTestApply("apply-start-deferred")
-		apply.State = state.Apply.Pending
-		apply.Options = []byte(`{"defer_deploy":true}`)
-		svc := newControlTestService(mock, apply)
+		apply := stoppedTestApply("apply-xyz789")
+		task := &storage.Task{
+			ID:             10,
+			TaskIdentifier: "task-start-xyz789",
+			ApplyID:        apply.ID,
+			State:          state.Task.Stopped,
+		}
+		svc := newControlTestServiceWithTasks(mock, apply, []*storage.Task{task})
 		mux := http.NewServeMux()
 		svc.ConfigureRoutes(mux)
 
-		body := `{"environment": "staging", "apply_id": "apply-start-deferred"}`
+		body := `{"environment": "staging", "apply_id": "apply-xyz789"}`
 		req := httptest.NewRequestWithContext(t.Context(), "POST", "/api/start", strings.NewReader(body))
 		req.Header.Set("Content-Type", "application/json")
 		w := httptest.NewRecorder()
 		mux.ServeHTTP(w, req)
 
-		assert.Equal(t, http.StatusConflict, w.Code, w.Body.String())
-		assert.Contains(t, w.Body.String(), "not ready for deploy")
+		assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+		assert.Nil(t, mock.startReq, "request path should queue scheduler work without calling Tern start")
+		assert.Equal(t, state.Apply.Pending, apply.State)
+		controlReq, err := svc.storage.ControlRequests().GetPending(t.Context(), apply.ID, storage.ControlOperationStart)
+		require.NoError(t, err)
+		require.NotNil(t, controlReq)
+		assert.Equal(t, state.Task.Stopped, task.State)
+
+		var resp apitypes.StartResponse
+		err = json.NewDecoder(w.Body).Decode(&resp)
+		require.NoError(t, err, "failed to decode response")
+		assert.True(t, resp.Accepted, "expected accepted=true")
+		assert.Equal(t, int64(1), resp.StartedCount)
+	})
+
+	t.Run("returns already requested for duplicate queued start", func(t *testing.T) {
+		mock := &mockTernClient{}
+		apply := stoppedTestApply("apply-start-already-requested")
+		task := &storage.Task{
+			ID:             12,
+			TaskIdentifier: "task-start-already-requested",
+			ApplyID:        apply.ID,
+			State:          state.Task.Stopped,
+		}
+		completedTask := &storage.Task{
+			ID:             13,
+			TaskIdentifier: "task-start-already-complete",
+			ApplyID:        apply.ID,
+			State:          state.Task.Completed,
+		}
+		svc := newControlTestServiceWithTasks(mock, apply, []*storage.Task{task, completedTask})
+		mux := http.NewServeMux()
+		svc.ConfigureRoutes(mux)
+
+		body := `{"environment": "staging", "apply_id": "apply-start-already-requested"}`
+		req := httptest.NewRequestWithContext(t.Context(), "POST", "/api/start", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, req)
+		require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+		var firstResp apitypes.StartResponse
+		err := json.NewDecoder(w.Body).Decode(&firstResp)
+		require.NoError(t, err)
+		assert.True(t, firstResp.Accepted)
+		assert.Equal(t, int64(1), firstResp.StartedCount)
+		assert.Equal(t, int64(1), firstResp.SkippedCount)
+
+		retryReq := httptest.NewRequestWithContext(t.Context(), "POST", "/api/start", strings.NewReader(body))
+		retryReq.Header.Set("Content-Type", "application/json")
+		retryW := httptest.NewRecorder()
+		mux.ServeHTTP(retryW, retryReq)
+
+		assert.Equal(t, http.StatusAccepted, retryW.Code, retryW.Body.String())
+		var resp apitypes.StartResponse
+		err = json.NewDecoder(retryW.Body).Decode(&resp)
+		require.NoError(t, err)
+		assert.True(t, resp.Accepted)
+		assert.Equal(t, "already_requested", resp.Status)
+		assert.Equal(t, int64(1), resp.StartedCount)
+		assert.Equal(t, int64(1), resp.SkippedCount)
+
+		apply.State = state.Apply.Running
+		task.State = state.Task.Pending
+		claimedRetryReq := httptest.NewRequestWithContext(t.Context(), "POST", "/api/start", strings.NewReader(body))
+		claimedRetryReq.Header.Set("Content-Type", "application/json")
+		claimedRetryW := httptest.NewRecorder()
+		mux.ServeHTTP(claimedRetryW, claimedRetryReq)
+
+		assert.Equal(t, http.StatusAccepted, claimedRetryW.Code, claimedRetryW.Body.String())
+		err = json.NewDecoder(claimedRetryW.Body).Decode(&resp)
+		require.NoError(t, err)
+		assert.True(t, resp.Accepted)
+		assert.Equal(t, "already_requested", resp.Status)
+		assert.Equal(t, state.Apply.Running, apply.State, "duplicate start must not rewind a scheduler-claimed apply")
+	})
+
+	t.Run("queues stopped tasks when stored apply row is still running", func(t *testing.T) {
+		mock := &mockTernClient{}
+		apply := activeTestApply("apply-running-stoplag")
+		task := &storage.Task{
+			ID:             11,
+			TaskIdentifier: "task-running-stoplag",
+			ApplyID:        apply.ID,
+			State:          state.Task.Stopped,
+		}
+		svc := newControlTestServiceWithTasks(mock, apply, []*storage.Task{task})
+		mux := http.NewServeMux()
+		svc.ConfigureRoutes(mux)
+
+		body := `{"environment": "staging", "apply_id": "apply-running-stoplag"}`
+		req := httptest.NewRequestWithContext(t.Context(), "POST", "/api/start", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+		assert.Nil(t, mock.startReq, "request path should queue scheduler work without calling Tern start")
+		assert.Equal(t, state.Apply.Pending, apply.State)
+		controlReq, err := svc.storage.ControlRequests().GetPending(t.Context(), apply.ID, storage.ControlOperationStart)
+		require.NoError(t, err)
+		require.NotNil(t, controlReq)
+		assert.Equal(t, state.Task.Stopped, task.State)
+
+		var resp apitypes.StartResponse
+		err = json.NewDecoder(w.Body).Decode(&resp)
+		require.NoError(t, err, "failed to decode response")
+		assert.True(t, resp.Accepted, "expected accepted=true")
+		assert.Equal(t, int64(1), resp.StartedCount)
+	})
+
+	t.Run("queues remote stopped apply when stored apply row is still running", func(t *testing.T) {
+		mock := &mockTernClient{
+			isRemote: true,
+			progressResp: &ternv1.ProgressResponse{
+				State: ternv1.State_STATE_STOPPED,
+				Tables: []*ternv1.TableProgress{{
+					TableName: "users",
+					Status:    state.Task.Stopped,
+				}},
+			},
+		}
+		apply := activeTestApply("apply-remote-stoplag")
+		apply.ExternalID = "remote-apply-stoplag"
+		svc := newControlTestServiceWithTasks(mock, apply, nil)
+		mux := http.NewServeMux()
+		svc.ConfigureRoutes(mux)
+
+		body := `{"environment": "staging", "apply_id": "apply-remote-stoplag"}`
+		req := httptest.NewRequestWithContext(t.Context(), "POST", "/api/start", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+		assert.Nil(t, mock.startReq, "request path should queue scheduler work without calling Tern start")
+		require.NotNil(t, mock.progressReq)
+		assert.Equal(t, "remote-apply-stoplag", mock.progressReq.ApplyId)
+		assert.Equal(t, state.Apply.Pending, apply.State)
+		controlReq, err := svc.storage.ControlRequests().GetPending(t.Context(), apply.ID, storage.ControlOperationStart)
+		require.NoError(t, err)
+		require.NotNil(t, controlReq)
+
+		var resp apitypes.StartResponse
+		err = json.NewDecoder(w.Body).Decode(&resp)
+		require.NoError(t, err, "failed to decode response")
+		assert.True(t, resp.Accepted, "expected accepted=true")
+		assert.Equal(t, int64(1), resp.StartedCount)
+	})
+
+	t.Run("returns already requested for remote duplicate after scheduler claim", func(t *testing.T) {
+		mock := &mockTernClient{
+			isRemote: true,
+			progressResp: &ternv1.ProgressResponse{
+				State: ternv1.State_STATE_STOPPED,
+				Tables: []*ternv1.TableProgress{{
+					TableName: "users",
+					Status:    state.Task.Stopped,
+				}},
+			},
+		}
+		apply := activeTestApply("apply-remote-already-requested")
+		apply.ExternalID = "remote-apply-already-requested"
+		svc := newControlTestServiceWithTasks(mock, apply, nil)
+		mux := http.NewServeMux()
+		svc.ConfigureRoutes(mux)
+
+		body := `{"environment": "staging", "apply_id": "apply-remote-already-requested"}`
+		req := httptest.NewRequestWithContext(t.Context(), "POST", "/api/start", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, req)
+		require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+		apply.State = state.Apply.Running
+		mock.progressReq = nil
+		mock.progressResp = &ternv1.ProgressResponse{State: ternv1.State_STATE_RUNNING}
+		retryReq := httptest.NewRequestWithContext(t.Context(), "POST", "/api/start", strings.NewReader(body))
+		retryReq.Header.Set("Content-Type", "application/json")
+		retryW := httptest.NewRecorder()
+		mux.ServeHTTP(retryW, retryReq)
+
+		assert.Equal(t, http.StatusAccepted, retryW.Code, retryW.Body.String())
+		var resp apitypes.StartResponse
+		err := json.NewDecoder(retryW.Body).Decode(&resp)
+		require.NoError(t, err)
+		assert.True(t, resp.Accepted)
+		assert.Equal(t, "already_requested", resp.Status)
+		assert.Nil(t, mock.progressReq, "duplicate start should not re-check remote state while durable request is pending")
 		assert.Nil(t, mock.startReq)
+		assert.Equal(t, state.Apply.Running, apply.State)
+	})
+
+	t.Run("requires apply_id", func(t *testing.T) {
+		mock := &mockTernClient{}
+		svc := newControlTestService(mock, activeTestApply("apply-active-start"))
+		mux := http.NewServeMux()
+		svc.ConfigureRoutes(mux)
+
+		body := `{"environment": "staging"}`
+		req := httptest.NewRequestWithContext(t.Context(), "POST", "/api/start", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
+		assert.Contains(t, w.Body.String(), "apply_id is required")
+		assert.Nil(t, mock.startReq)
+	})
+
+	t.Run("deferred deploy rejects start before waiting_for_deploy", func(t *testing.T) {
+		mock := &mockTernClient{}
+		apply := activeTestApply("apply-defer-pending")
+		apply.State = state.Apply.Pending
+		apply.SetOptions(storage.ApplyOptions{DeferDeploy: true})
+		svc := newControlTestServiceWithTasks(mock, apply, nil)
+		mux := http.NewServeMux()
+		svc.ConfigureRoutes(mux)
+
+		body := `{"environment": "staging", "apply_id": "apply-defer-pending"}`
+		req := httptest.NewRequestWithContext(t.Context(), "POST", "/api/start", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusConflict, w.Code)
+		assert.Contains(t, w.Body.String(), "not ready for deploy")
+		assert.Nil(t, mock.startReq, "start should only reach Tern after the apply is waiting for deploy")
 		assert.Equal(t, state.Apply.Pending, apply.State)
 	})
 
@@ -1819,7 +2130,12 @@ func TestStartHandler(t *testing.T) {
 			wantMessage string
 		}{
 			{
-				name:        "pending",
+				name:        "running with no stopped tasks",
+				applyState:  state.Apply.Running,
+				wantMessage: "still running",
+			},
+			{
+				name:        "pending with no pending start request",
 				applyState:  state.Apply.Pending,
 				wantMessage: "no start request is queued",
 			},
@@ -1900,7 +2216,7 @@ func TestStartHandler(t *testing.T) {
 				mock := &mockTernClient{}
 				apply := activeTestApply("apply-start-" + strings.ReplaceAll(tt.applyState, "_", "-"))
 				apply.State = tt.applyState
-				svc := newControlTestService(mock, apply)
+				svc := newControlTestServiceWithTasks(mock, apply, nil)
 				mux := http.NewServeMux()
 				svc.ConfigureRoutes(mux)
 
@@ -1913,25 +2229,9 @@ func TestStartHandler(t *testing.T) {
 				assert.Equal(t, http.StatusConflict, w.Code, w.Body.String())
 				assert.Contains(t, w.Body.String(), tt.wantMessage)
 				assert.Nil(t, mock.startReq)
+				assert.Nil(t, mock.progressReq)
 			})
 		}
-	})
-
-	t.Run("requires apply_id", func(t *testing.T) {
-		mock := &mockTernClient{}
-		svc := newControlTestService(mock, activeTestApply("apply-active-start"))
-		mux := http.NewServeMux()
-		svc.ConfigureRoutes(mux)
-
-		body := `{"environment": "staging"}`
-		req := httptest.NewRequestWithContext(t.Context(), "POST", "/api/start", strings.NewReader(body))
-		req.Header.Set("Content-Type", "application/json")
-		w := httptest.NewRecorder()
-		mux.ServeHTTP(w, req)
-
-		assert.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
-		assert.Contains(t, w.Body.String(), "apply_id is required")
-		assert.Nil(t, mock.startReq)
 	})
 
 	t.Run("missing environment", func(t *testing.T) {

--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -1989,7 +1989,7 @@ func TestStartHandler(t *testing.T) {
 		assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
 
 		assert.Nil(t, mock.startReq, "request path should queue scheduler work without calling Tern start")
-		assert.Equal(t, state.Apply.Running, apply.State)
+		assert.Equal(t, state.Apply.Stopped, apply.State)
 		controlReq, err := svc.storage.ControlRequests().GetPending(t.Context(), apply.ID, storage.ControlOperationStart)
 		require.NoError(t, err)
 		require.NotNil(t, controlReq)
@@ -2030,7 +2030,7 @@ func TestStartHandler(t *testing.T) {
 		assert.Nil(t, mock.startReq, "request path should queue scheduler work without calling Tern start")
 		require.NotNil(t, mock.progressReq)
 		assert.Equal(t, "remote-apply-stoplag", mock.progressReq.ApplyId)
-		assert.Equal(t, state.Apply.Running, apply.State)
+		assert.Equal(t, state.Apply.Stopped, apply.State)
 		controlReq, err := svc.storage.ControlRequests().GetPending(t.Context(), apply.ID, storage.ControlOperationStart)
 		require.NoError(t, err)
 		require.NotNil(t, controlReq)

--- a/pkg/apitypes/apitypes.go
+++ b/pkg/apitypes/apitypes.go
@@ -250,6 +250,7 @@ type StartResponse struct {
 	ErrorCode    string `json:"error_code,omitempty"`
 	ErrorMessage string `json:"error_message,omitempty"`
 	SkippedCount int64  `json:"skipped_count"`
+	Status       string `json:"status,omitempty"`
 	StartedCount int64  `json:"started_count"`
 }
 

--- a/pkg/storage/mysqlstore/applies.go
+++ b/pkg/storage/mysqlstore/applies.go
@@ -504,13 +504,23 @@ func (s *applyStore) Update(ctx context.Context, apply *storage.Apply) error {
 		}
 	}
 
-	_, err = writeTx.tx.ExecContext(ctx, `
+	optionsUpdate := ""
+	args := []any{
+		apply.State, apply.ErrorMessage, apply.Attempt,
+		apply.ExternalID,
+	}
+	if len(apply.Options) > 0 {
+		optionsUpdate = ", options = ?"
+		args = append(args, string(apply.Options))
+	}
+	args = append(args, apply.StartedAt, apply.CompletedAt, apply.ID)
+
+	_, err = writeTx.tx.ExecContext(ctx, fmt.Sprintf(`
 		UPDATE applies
 		SET state = ?, error_message = ?, attempt = ?,
-		    external_id = ?, started_at = ?, completed_at = ?, updated_at = NOW()
+		    external_id = ?%s, started_at = ?, completed_at = ?, updated_at = NOW()
 		WHERE id = ?
-	`, apply.State, apply.ErrorMessage, apply.Attempt,
-		apply.ExternalID, apply.StartedAt, apply.CompletedAt, apply.ID)
+	`, optionsUpdate), args...)
 	if err != nil {
 		return fmt.Errorf("update apply %d: %w", apply.ID, err)
 	}
@@ -575,11 +585,11 @@ func (s *applyStore) GetRecent(ctx context.Context, filter storage.RecentApplies
 // and resumes the apply.
 // Returns the claimed apply, or nil if nothing needs work.
 //
-// Matches queued pending applies with persisted tasks, stale active applies
-// where heartbeat expired > 1 minute, and recently failed_retryable applies
-// that still have retry budget. Apply creation/update enforces one active
-// apply per database/type/environment, so claims only need to lease one row
-// and avoid worker races on that row.
+// Matches queued pending applies with persisted tasks, pending applies with a
+// durable control request, stale active applies where heartbeat expired > 1
+// minute, and recently failed_retryable applies that still have retry budget.
+// Apply creation/update enforces one active apply per database/type/environment,
+// so claims only need to lease one row and avoid worker races on that row.
 func (s *applyStore) FindNextApply(ctx context.Context) (*storage.Apply, error) {
 	// Read committed keeps concurrent SKIP LOCKED claims from taking next-key
 	// range locks that can serialize workers across otherwise independent targets.
@@ -594,6 +604,9 @@ func (s *applyStore) FindNextApply(ctx context.Context) (*storage.Apply, error) 
 	queryArgs := []any{state.Apply.Pending}
 	queryArgs = append(queryArgs, stringArgs(activeStates)...)
 	queryArgs = append(queryArgs, state.Apply.FailedRetryable, maxRecoveryAttempts, retryableRecoveryFreshnessDays)
+	queryArgs = append(queryArgs,
+		state.Apply.Pending,
+		storage.ControlOperationStart, storage.ControlRequestPending)
 
 	// Apply creation/update enforces at most one active apply per
 	// database/type/environment. The claim query only needs to find stale work;
@@ -602,10 +615,18 @@ func (s *applyStore) FindNextApply(ctx context.Context) (*storage.Apply, error) 
 		SELECT %s
 		FROM applies a
 		WHERE (
-			(a.state = ? AND EXISTS (SELECT 1 FROM tasks t WHERE t.apply_id = a.id))
-			OR (a.state IN (%s) AND a.updated_at < NOW() - INTERVAL 1 MINUTE)
-			OR (a.state = ? AND a.attempt < ? AND a.updated_at >= NOW() - INTERVAL ? DAY)
-		)
+				(a.state = ? AND EXISTS (SELECT 1 FROM tasks t WHERE t.apply_id = a.id))
+				OR (a.state IN (%s) AND a.updated_at < NOW() - INTERVAL 1 MINUTE)
+				OR (a.state = ? AND a.attempt < ? AND a.updated_at >= NOW() - INTERVAL ? DAY)
+				OR (
+					a.state = ?
+					AND EXISTS (
+						SELECT 1
+						FROM apply_control_requests cr
+						WHERE cr.apply_id = a.id AND cr.operation = ? AND cr.status = ?
+					)
+				)
+			)
 		ORDER BY a.created_at
 		LIMIT 1
 		FOR UPDATE SKIP LOCKED

--- a/pkg/storage/mysqlstore/applies.go
+++ b/pkg/storage/mysqlstore/applies.go
@@ -585,9 +585,10 @@ func (s *applyStore) GetRecent(ctx context.Context, filter storage.RecentApplies
 // and resumes the apply.
 // Returns the claimed apply, or nil if nothing needs work.
 //
-// Matches queued pending applies with persisted tasks, pending applies with a
-// durable control request, stale active applies where heartbeat expired > 1
-// minute, and recently failed_retryable applies that still have retry budget.
+// Matches queued pending applies with persisted tasks, pending or stopped applies
+// with a pending start control request, stale active applies where heartbeat
+// expired > 1 minute, and recently failed_retryable applies that still have retry
+// budget.
 // Apply creation/update enforces one active apply per database/type/environment,
 // so claims only need to lease one row and avoid worker races on that row.
 func (s *applyStore) FindNextApply(ctx context.Context) (*storage.Apply, error) {
@@ -607,6 +608,9 @@ func (s *applyStore) FindNextApply(ctx context.Context) (*storage.Apply, error) 
 	queryArgs = append(queryArgs,
 		state.Apply.Pending,
 		storage.ControlOperationStart, storage.ControlRequestPending)
+	queryArgs = append(queryArgs,
+		state.Apply.Stopped,
+		storage.ControlOperationStart, storage.ControlRequestPending)
 
 	// Apply creation/update enforces at most one active apply per
 	// database/type/environment. The claim query only needs to find stale work;
@@ -618,6 +622,14 @@ func (s *applyStore) FindNextApply(ctx context.Context) (*storage.Apply, error) 
 				(a.state = ? AND EXISTS (SELECT 1 FROM tasks t WHERE t.apply_id = a.id))
 				OR (a.state IN (%s) AND a.updated_at < NOW() - INTERVAL 1 MINUTE)
 				OR (a.state = ? AND a.attempt < ? AND a.updated_at >= NOW() - INTERVAL ? DAY)
+				OR (
+					a.state = ?
+					AND EXISTS (
+						SELECT 1
+						FROM apply_control_requests cr
+						WHERE cr.apply_id = a.id AND cr.operation = ? AND cr.status = ?
+					)
+				)
 				OR (
 					a.state = ?
 					AND EXISTS (
@@ -641,10 +653,10 @@ func (s *applyStore) FindNextApply(ctx context.Context) (*storage.Apply, error) 
 	}
 
 	// Refresh the heartbeat as part of the claim before releasing the row lock.
-	// Pending and retryable applies become running while dispatch starts, so
-	// the leased row remains in the stale-recovery state family if the worker
-	// crashes before the engine starts.
-	if apply.State == state.Apply.Pending || apply.State == state.Apply.FailedRetryable {
+	// Pending, stopped-start, and retryable applies become running while the
+	// scheduler acts, so the leased row remains in the stale-recovery state
+	// family if the worker crashes before the engine starts.
+	if apply.State == state.Apply.Pending || apply.State == state.Apply.Stopped || apply.State == state.Apply.FailedRetryable {
 		var result sql.Result
 		nextState := state.Apply.Running
 		result, err = tx.ExecContext(ctx, `

--- a/pkg/storage/mysqlstore/applies_test.go
+++ b/pkg/storage/mysqlstore/applies_test.go
@@ -696,6 +696,38 @@ func TestApplyStore_FindNextApplyRequiresTasksForPendingApply(t *testing.T) {
 	assert.Equal(t, state.Apply.Running, persisted.State)
 }
 
+func TestApplyStore_FindNextApplyClaimsPendingControlRequestWithoutTasks(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", storage.DatabaseTypeMySQL, "staging")
+	apply := createTestApplyWithStateAndEnv(t, store, lock, "apply_pending_start_request", 503, state.Apply.Pending, "staging")
+	_, alreadyPending, err := store.ControlRequests().RequestPending(ctx, &storage.ApplyControlRequest{
+		ApplyID:   apply.ID,
+		Operation: storage.ControlOperationStart,
+		Status:    storage.ControlRequestPending,
+		Metadata:  []byte(`{}`),
+	})
+	require.NoError(t, err)
+	require.False(t, alreadyPending)
+
+	claimed, err := store.Applies().FindNextApply(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, claimed)
+	assert.Equal(t, apply.ApplyIdentifier, claimed.ApplyIdentifier)
+	assert.Equal(t, state.Apply.Pending, claimed.State)
+
+	persisted, err := store.Applies().Get(ctx, apply.ID)
+	require.NoError(t, err)
+	require.NotNil(t, persisted)
+	assert.Equal(t, state.Apply.Running, persisted.State)
+
+	claimedAgain, err := store.Applies().FindNextApply(ctx)
+	require.NoError(t, err)
+	assert.Nil(t, claimedAgain, "claim heartbeat should prevent another worker from immediately taking the same start request")
+}
+
 func TestApplyStore_FindNextApplyConcurrentPendingClaims(t *testing.T) {
 	clearTables(t)
 	ctx := t.Context()
@@ -1070,6 +1102,51 @@ func TestApplyStore_Options(t *testing.T) {
 	assert.True(t, opts.DeferCutover)
 	assert.False(t, opts.SkipRevert)
 	assert.Equal(t, 5, opts.Volume)
+}
+
+func TestApplyStore_UpdateOptions(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", "mysql", "staging")
+	apply := &storage.Apply{
+		ApplyIdentifier: "apply_update_options_test",
+		LockID:          lock.ID,
+		PlanID:          801,
+		Database:        "testdb",
+		DatabaseType:    "mysql",
+		Repository:      "org/repo",
+		PullRequest:     123,
+		Environment:     "staging",
+		Engine:          "spirit",
+		State:           state.Apply.Stopped,
+	}
+	apply.SetOptions(storage.ApplyOptions{Target: "testdb"})
+
+	id, err := store.Applies().Create(ctx, apply)
+	require.NoError(t, err)
+
+	retrieved, err := store.Applies().Get(ctx, id)
+	require.NoError(t, err)
+	retrieved.State = state.Apply.Pending
+
+	require.NoError(t, store.Applies().Update(ctx, retrieved))
+
+	updated, err := store.Applies().Get(ctx, id)
+	require.NoError(t, err)
+	updatedOpts := updated.GetOptions()
+	assert.Equal(t, "testdb", updatedOpts.Target)
+
+	partial := *updated
+	partial.Options = nil
+	partial.State = state.Apply.Running
+	require.NoError(t, store.Applies().Update(ctx, &partial))
+
+	preserved, err := store.Applies().Get(ctx, id)
+	require.NoError(t, err)
+	preservedOpts := preserved.GetOptions()
+	assert.Equal(t, "testdb", preservedOpts.Target)
 }
 
 func TestApplyStore_AllFields(t *testing.T) {

--- a/pkg/storage/mysqlstore/applies_test.go
+++ b/pkg/storage/mysqlstore/applies_test.go
@@ -728,6 +728,38 @@ func TestApplyStore_FindNextApplyClaimsPendingControlRequestWithoutTasks(t *test
 	assert.Nil(t, claimedAgain, "claim heartbeat should prevent another worker from immediately taking the same start request")
 }
 
+func TestApplyStore_FindNextApplyClaimsStoppedStartControlRequest(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", storage.DatabaseTypeMySQL, "staging")
+	apply := createTestApplyWithStateAndEnv(t, store, lock, "apply_stopped_start_request", 504, state.Apply.Stopped, "staging")
+	_, alreadyPending, err := store.ControlRequests().RequestPending(ctx, &storage.ApplyControlRequest{
+		ApplyID:   apply.ID,
+		Operation: storage.ControlOperationStart,
+		Status:    storage.ControlRequestPending,
+		Metadata:  []byte(`{}`),
+	})
+	require.NoError(t, err)
+	require.False(t, alreadyPending)
+
+	claimed, err := store.Applies().FindNextApply(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, claimed)
+	assert.Equal(t, apply.ApplyIdentifier, claimed.ApplyIdentifier)
+	assert.Equal(t, state.Apply.Stopped, claimed.State)
+
+	persisted, err := store.Applies().Get(ctx, apply.ID)
+	require.NoError(t, err)
+	require.NotNil(t, persisted)
+	assert.Equal(t, state.Apply.Running, persisted.State)
+
+	claimedAgain, err := store.Applies().FindNextApply(ctx)
+	require.NoError(t, err)
+	assert.Nil(t, claimedAgain, "claim transition should prevent another worker from taking the same stopped start request")
+}
+
 func TestApplyStore_FindNextApplyConcurrentPendingClaims(t *testing.T) {
 	clearTables(t)
 	ctx := t.Context()

--- a/pkg/tern/control_requests.go
+++ b/pkg/tern/control_requests.go
@@ -1,0 +1,37 @@
+package tern
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/block/schemabot/pkg/storage"
+)
+
+func pendingStartControlRequest(ctx context.Context, store storage.Storage, apply *storage.Apply) (*storage.ApplyControlRequest, error) {
+	if store == nil {
+		return nil, fmt.Errorf("storage is not available")
+	}
+	controlStore := store.ControlRequests()
+	if controlStore == nil {
+		return nil, fmt.Errorf("control request store is not available")
+	}
+	controlReq, err := controlStore.GetPending(ctx, apply.ID, storage.ControlOperationStart)
+	if err != nil {
+		return nil, fmt.Errorf("load pending start control request for apply %s: %w", apply.ApplyIdentifier, err)
+	}
+	return controlReq, nil
+}
+
+func completePendingStartControlRequests(ctx context.Context, store storage.Storage, apply *storage.Apply) error {
+	if store == nil {
+		return fmt.Errorf("storage is not available")
+	}
+	controlStore := store.ControlRequests()
+	if controlStore == nil {
+		return fmt.Errorf("control request store is not available")
+	}
+	if err := controlStore.CompletePending(ctx, apply.ID, storage.ControlOperationStart); err != nil {
+		return fmt.Errorf("complete pending start control request for apply %s: %w", apply.ApplyIdentifier, err)
+	}
+	return nil
+}

--- a/pkg/tern/grpc_client.go
+++ b/pkg/tern/grpc_client.go
@@ -917,8 +917,14 @@ func (c *GRPCClient) persistTerminalStateFromRemote(ctx context.Context, storedA
 	if err := c.storage.Applies().Update(ctx, storedApply); err != nil {
 		return fmt.Errorf("update terminal remote gRPC apply %s: %w", storedApply.ApplyIdentifier, err)
 	}
-	if err := completePendingStartControlRequests(ctx, c.storage, storedApply); err != nil {
-		return err
+	// Stopped is a terminal apply state, but it is not completion of a pending
+	// Start request. A start can be queued while the previous worker is still
+	// recording the stop; leave that request pending so the scheduler can claim
+	// the stopped row and perform the resume.
+	if !state.IsState(storedApply.State, state.Apply.Stopped) {
+		if err := completePendingStartControlRequests(ctx, c.storage, storedApply); err != nil {
+			return err
+		}
 	}
 	c.logApplyStateTransition(ctx, storedApply, storage.LogLevelInfo, fmt.Sprintf("Remote apply reached terminal state: %s", storedApply.State), oldState)
 	*remoteApply = *storedApply

--- a/pkg/tern/grpc_client.go
+++ b/pkg/tern/grpc_client.go
@@ -430,10 +430,16 @@ func (c *GRPCClient) ResumeApply(ctx context.Context, apply *storage.Apply) erro
 		return errors.New(errMsg)
 	}
 
-	if apply.ExternalID != "" && state.IsState(apply.State, state.Apply.Pending) {
+	startControlReq, err := pendingStartControlRequest(ctx, c.storage, apply)
+	if err != nil {
+		return err
+	}
+	startRequested := startControlReq != nil
+
+	if apply.ExternalID != "" && state.IsState(apply.State, state.Apply.Pending) && !startRequested {
 		_, err := c.client.Start(ctx, &ternv1.StartRequest{
-			Environment: apply.Environment,
 			ApplyId:     apply.ExternalID,
+			Environment: apply.Environment,
 		})
 		if err != nil {
 			return fmt.Errorf("start queued gRPC apply %s: %w", apply.ApplyIdentifier, err)
@@ -451,9 +457,9 @@ func (c *GRPCClient) ResumeApply(ctx context.Context, apply *storage.Apply) erro
 
 	// Check the real state from Tern before deciding what to do. Stored state
 	// may be stale (e.g. storage says "stopped" but Tern already resumed).
-	if state.IsState(apply.State, state.Apply.Stopped) {
+	if state.IsState(apply.State, state.Apply.Stopped) || startRequested {
 		oldState := apply.State
-		startRequested := false
+		remoteStartRequested := false
 		resp, err := c.client.Progress(ctx, &ternv1.ProgressRequest{
 			ApplyId:     apply.ExternalID,
 			Database:    apply.Database,
@@ -508,8 +514,8 @@ func (c *GRPCClient) ResumeApply(ctx context.Context, apply *storage.Apply) erro
 		// Only call Start if Tern confirms the apply is actually stopped.
 		if state.IsState(apply.State, state.Apply.Stopped) {
 			_, err := c.client.Start(ctx, &ternv1.StartRequest{
-				Environment: apply.Environment,
 				ApplyId:     apply.ExternalID,
+				Environment: apply.Environment,
 			})
 			if err != nil {
 				return fmt.Errorf("start via gRPC: %w", err)
@@ -519,13 +525,18 @@ func (c *GRPCClient) ResumeApply(ctx context.Context, apply *storage.Apply) erro
 			if apply.StartedAt == nil {
 				apply.StartedAt = &now
 			}
-			startRequested = true
+			remoteStartRequested = true
 		}
 
 		if err := c.storage.Applies().Update(ctx, apply); err != nil {
 			return fmt.Errorf("update apply state: %w", err)
 		}
 		if startRequested {
+			if err := completePendingStartControlRequests(ctx, c.storage, apply); err != nil {
+				return err
+			}
+		}
+		if remoteStartRequested {
 			c.logApplyStateTransition(ctx, apply, storage.LogLevelInfo, "Remote apply start requested by scheduler", oldState)
 		} else if oldState != apply.State {
 			c.logApplyStateTransition(ctx, apply, storage.LogLevelInfo, fmt.Sprintf("Remote apply state refreshed before scheduler start: %s -> %s", oldState, apply.State), oldState)
@@ -905,6 +916,9 @@ func (c *GRPCClient) persistTerminalStateFromRemote(ctx context.Context, storedA
 	storedApply.UpdatedAt = now
 	if err := c.storage.Applies().Update(ctx, storedApply); err != nil {
 		return fmt.Errorf("update terminal remote gRPC apply %s: %w", storedApply.ApplyIdentifier, err)
+	}
+	if err := completePendingStartControlRequests(ctx, c.storage, storedApply); err != nil {
+		return err
 	}
 	c.logApplyStateTransition(ctx, storedApply, storage.LogLevelInfo, fmt.Sprintf("Remote apply reached terminal state: %s", storedApply.State), oldState)
 	*remoteApply = *storedApply

--- a/pkg/tern/grpc_client_test.go
+++ b/pkg/tern/grpc_client_test.go
@@ -1616,6 +1616,58 @@ func TestGRPCClient_ResumeApplyCompletesQueuedStartWhenRemoteAlreadyActive(t *te
 	assert.Nil(t, controlReq)
 }
 
+func TestGRPCClient_ReconcileStoppedRemoteProgressKeepsQueuedStartPending(t *testing.T) {
+	// A Start request can be accepted while an older worker is still recording
+	// the remote stop. The stop sync must not consume the pending Start intent;
+	// the scheduler needs that durable request to claim and resume the apply.
+	now := time.Now()
+	remoteApply := &storage.Apply{
+		ID:              1,
+		ApplyIdentifier: "apply-stop-with-pending-start",
+		ExternalID:      "remote-stop-with-pending-start",
+		Database:        "testdb",
+		Environment:     "staging",
+		State:           state.Apply.Stopped,
+		StartedAt:       &now,
+	}
+	storedApply := *remoteApply
+	storedApply.State = state.Apply.Running
+	task := &storage.Task{
+		ID:             31,
+		TaskIdentifier: "task-stop-with-pending-start",
+		ApplyID:        remoteApply.ID,
+		TableName:      "users",
+		Namespace:      "default",
+		State:          state.Task.Running,
+	}
+	controlRequests := &testControlRequestStore{requests: []*storage.ApplyControlRequest{{
+		ApplyID:   remoteApply.ID,
+		Operation: storage.ControlOperationStart,
+		Status:    storage.ControlRequestPending,
+	}}}
+	client := &GRPCClient{
+		storage: &mockStorage{
+			applies:         &mockApplyStore{apply: &storedApply},
+			tasks:           &mockTaskStore{tasks: []*storage.Task{task}},
+			logs:            &mockApplyLogStore{},
+			controlRequests: controlRequests,
+		},
+	}
+
+	err := client.reconcileTerminalRemoteProgress(t.Context(), remoteApply, []*ternv1.TableProgress{{
+		Namespace: "default",
+		TableName: "users",
+		Status:    state.Task.Stopped,
+	}}, now)
+	require.NoError(t, err)
+
+	assert.Equal(t, state.Apply.Stopped, remoteApply.State)
+	assert.Equal(t, state.Task.Stopped, task.State)
+	controlReq, err := controlRequests.GetPending(t.Context(), remoteApply.ID, storage.ControlOperationStart)
+	require.NoError(t, err)
+	assert.NotNil(t, controlReq)
+}
+
 // TestGRPCClient_ResumeApply_SkipsStartWhenNotStopped verifies that ResumeApply
 // checks Tern's real state before calling Start. If Tern says the apply is already
 // completed (stored state diverged), Start is skipped and terminal state is

--- a/pkg/tern/grpc_client_test.go
+++ b/pkg/tern/grpc_client_test.go
@@ -487,10 +487,11 @@ func (m *mockPlanStore) GetByID(context.Context, int64) (*storage.Plan, error) {
 // mockStorage wires together the mock stores.
 type mockStorage struct {
 	storage.Storage
-	applies *mockApplyStore
-	tasks   *mockTaskStore
-	plans   *mockPlanStore
-	logs    *mockApplyLogStore
+	applies         *mockApplyStore
+	tasks           *mockTaskStore
+	plans           *mockPlanStore
+	logs            *mockApplyLogStore
+	controlRequests *testControlRequestStore
 }
 
 func (m *mockStorage) Applies() storage.ApplyStore {
@@ -516,6 +517,12 @@ func (m *mockStorage) ApplyLogs() storage.ApplyLogStore {
 		return m.logs
 	}
 	return &mockApplyLogStore{}
+}
+func (m *mockStorage) ControlRequests() storage.ControlRequestStore {
+	if m.controlRequests != nil {
+		return m.controlRequests
+	}
+	return &testControlRequestStore{}
 }
 
 func testCapturingGRPCClient(t *testing.T, server *capturingTernServer) (*GRPCClient, func()) {
@@ -1501,6 +1508,112 @@ func TestGRPCClient_ResumeApply_ThreadsExternalID(t *testing.T) {
 	// Progress returns STATE_COMPLETED after Start, so ResumeApply exits after
 	// syncing one terminal progress response.
 	assert.Equal(t, "remote_tern_xyz", server.getProgressApplyID())
+}
+
+func TestGRPCClient_ResumeApplyStartsQueuedStartAfterClaim(t *testing.T) {
+	// A scheduler claim can move the apply row before the worker calls remote
+	// Start. The durable control request lets a later worker recover that
+	// intent and validate the remote stopped state.
+	server := &capturingTernServer{
+		progressState:    ternv1.State_STATE_STOPPED,
+		progressStateSet: true,
+	}
+	client, cleanup := testCapturingGRPCClient(t, server)
+	defer cleanup()
+
+	apply := &storage.Apply{
+		ID:              1,
+		ApplyIdentifier: "apply-start-claimed",
+		Database:        "testdb",
+		Environment:     "staging",
+		ExternalID:      "remote-start-claimed",
+		State:           state.Apply.Running,
+	}
+	storedApply := *apply
+	controlRequests := &testControlRequestStore{requests: []*storage.ApplyControlRequest{{
+		ApplyID:   apply.ID,
+		Operation: storage.ControlOperationStart,
+		Status:    storage.ControlRequestPending,
+	}}}
+	client.storage = &mockStorage{
+		applies:         &mockApplyStore{apply: &storedApply},
+		tasks:           &mockTaskStore{},
+		logs:            &mockApplyLogStore{},
+		controlRequests: controlRequests,
+	}
+
+	err := client.ResumeApply(t.Context(), apply)
+	require.NoError(t, err)
+
+	assert.Equal(t, "remote-start-claimed", server.getStartApplyID())
+	controlReq, err := controlRequests.GetPending(t.Context(), apply.ID, storage.ControlOperationStart)
+	require.NoError(t, err)
+	assert.Nil(t, controlReq)
+}
+
+func TestGRPCClient_ResumeApplyCompletesQueuedStartWhenRemoteAlreadyActive(t *testing.T) {
+	// An operator can start the remote apply directly after SchemaBot records
+	// durable start intent. The scheduler adopts the active remote state instead
+	// of sending another Start request, then continues polling the exact apply ID.
+	server := &capturingTernServer{
+		progressStates: []ternv1.State{
+			ternv1.State_STATE_RUNNING,
+			ternv1.State_STATE_COMPLETED,
+		},
+		progressTables: []*ternv1.TableProgress{{
+			Namespace:       "default",
+			TableName:       "users",
+			Status:          state.Task.Completed,
+			PercentComplete: 100,
+		}},
+	}
+	client, cleanup := testCapturingGRPCClient(t, server)
+	defer cleanup()
+
+	apply := &storage.Apply{
+		ID:              1,
+		ApplyIdentifier: "apply-start-already-active",
+		Database:        "testdb",
+		Environment:     "staging",
+		ExternalID:      "remote-start-already-active",
+		State:           state.Apply.Running,
+	}
+	storedApply := *apply
+	task := &storage.Task{
+		ID:             31,
+		TaskIdentifier: "task-start-already-active",
+		ApplyID:        apply.ID,
+		TableName:      "users",
+		Namespace:      "default",
+		State:          state.Task.Running,
+	}
+	controlRequests := &testControlRequestStore{requests: []*storage.ApplyControlRequest{{
+		ApplyID:   apply.ID,
+		Operation: storage.ControlOperationStart,
+		Status:    storage.ControlRequestPending,
+	}}}
+	client.storage = &mockStorage{
+		applies:         &mockApplyStore{apply: &storedApply},
+		tasks:           &mockTaskStore{tasks: []*storage.Task{task}},
+		logs:            &mockApplyLogStore{},
+		controlRequests: controlRequests,
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 3*time.Second)
+	defer cancel()
+	err := client.ResumeApply(ctx, apply)
+	require.NoError(t, err)
+
+	server.mu.Lock()
+	startCalled := server.startCalled
+	server.mu.Unlock()
+	assert.False(t, startCalled, "Start should not be called after remote progress reports active work")
+	assert.Equal(t, "remote-start-already-active", server.getProgressApplyID())
+	assert.Equal(t, state.Apply.Completed, apply.State)
+	assert.Equal(t, state.Task.Completed, task.State)
+	controlReq, err := controlRequests.GetPending(t.Context(), apply.ID, storage.ControlOperationStart)
+	require.NoError(t, err)
+	assert.Nil(t, controlReq)
 }
 
 // TestGRPCClient_ResumeApply_SkipsStartWhenNotStopped verifies that ResumeApply

--- a/pkg/tern/local_client_test.go
+++ b/pkg/tern/local_client_test.go
@@ -36,14 +36,84 @@ func (s *exactProgressTaskStore) GetByApplyID(context.Context, int64) ([]*storag
 	return s.tasks, s.err
 }
 
+func (s *exactProgressTaskStore) Update(context.Context, *storage.Task) error {
+	return s.err
+}
+
 type exactProgressStorage struct {
 	storage.Storage
-	applies storage.ApplyStore
-	tasks   storage.TaskStore
+	applies         storage.ApplyStore
+	tasks           storage.TaskStore
+	logs            storage.ApplyLogStore
+	controlRequests storage.ControlRequestStore
 }
 
 func (s *exactProgressStorage) Applies() storage.ApplyStore { return s.applies }
 func (s *exactProgressStorage) Tasks() storage.TaskStore    { return s.tasks }
+func (s *exactProgressStorage) ApplyLogs() storage.ApplyLogStore {
+	if s.logs != nil {
+		return s.logs
+	}
+	return &mockApplyLogStore{}
+}
+func (s *exactProgressStorage) ControlRequests() storage.ControlRequestStore {
+	return s.controlRequests
+}
+
+type testControlRequestStore struct {
+	storage.ControlRequestStore
+	requests []*storage.ApplyControlRequest
+}
+
+func (s *testControlRequestStore) RequestPending(_ context.Context, req *storage.ApplyControlRequest) (*storage.ApplyControlRequest, bool, error) {
+	for _, existing := range s.requests {
+		if existing.ApplyID == req.ApplyID && existing.Operation == req.Operation {
+			if existing.Status == storage.ControlRequestPending {
+				return cloneTestControlRequest(existing), true, nil
+			}
+			existing.Status = storage.ControlRequestPending
+			existing.RequestedBy = req.RequestedBy
+			existing.ErrorMessage = ""
+			existing.Metadata = append(existing.Metadata[:0], req.Metadata...)
+			existing.CompletedAt = nil
+			return cloneTestControlRequest(existing), false, nil
+		}
+	}
+	stored := cloneTestControlRequest(req)
+	stored.ID = int64(len(s.requests) + 1)
+	s.requests = append(s.requests, stored)
+	return cloneTestControlRequest(stored), false, nil
+}
+
+func (s *testControlRequestStore) GetPending(_ context.Context, applyID int64, operation storage.ControlOperation) (*storage.ApplyControlRequest, error) {
+	for i := len(s.requests) - 1; i >= 0; i-- {
+		req := s.requests[i]
+		if req.ApplyID == applyID && req.Operation == operation && req.Status == storage.ControlRequestPending {
+			return cloneTestControlRequest(req), nil
+		}
+	}
+	return nil, nil
+}
+
+func (s *testControlRequestStore) CompletePending(_ context.Context, applyID int64, operation storage.ControlOperation) error {
+	for _, req := range s.requests {
+		if req.ApplyID == applyID && req.Operation == operation && req.Status == storage.ControlRequestPending {
+			req.Status = storage.ControlRequestCompleted
+		}
+	}
+	return nil
+}
+
+func cloneTestControlRequest(req *storage.ApplyControlRequest) *storage.ApplyControlRequest {
+	if req == nil {
+		return nil
+	}
+	clone := *req
+	if req.Metadata != nil {
+		clone.Metadata = append([]byte(nil), req.Metadata...)
+	}
+	return &clone
+}
 
 func TestLocalClient_Apply_RequiresEnvironmentField(t *testing.T) {
 	client, err := NewLocalClient(LocalConfig{
@@ -109,6 +179,66 @@ func TestTaskStateWithNoBackwardProgressPolicyCoversTaskStates(t *testing.T) {
 			"task state %s=%q must be terminal, scheduler/control-owned, or ranked as active progress",
 			taskName, taskState)
 	}
+}
+
+func TestPrepareStoppedTasksForResumeQueuesOnlyStoppedTasks(t *testing.T) {
+	completedAt := time.Date(2026, 5, 26, 20, 0, 0, 0, time.UTC)
+	for _, applyState := range []string{state.Apply.Pending, state.Apply.Running} {
+		t.Run(applyState, func(t *testing.T) {
+			stoppedTask := &storage.Task{
+				TaskIdentifier: "task-stopped",
+				State:          state.Task.Stopped,
+				CompletedAt:    &completedAt,
+			}
+			completedTask := &storage.Task{
+				TaskIdentifier: "task-completed",
+				State:          state.Task.Completed,
+				CompletedAt:    &completedAt,
+			}
+			client := &LocalClient{
+				storage: &exactProgressStorage{
+					tasks: &exactProgressTaskStore{tasks: []*storage.Task{stoppedTask, completedTask}},
+					controlRequests: &testControlRequestStore{requests: []*storage.ApplyControlRequest{{
+						ApplyID:   123,
+						Operation: storage.ControlOperationStart,
+						Status:    storage.ControlRequestPending,
+					}}},
+				},
+				logger: slog.Default(),
+			}
+			apply := &storage.Apply{ID: 123, State: applyState}
+
+			controlReq, err := pendingStartControlRequest(t.Context(), client.storage, apply)
+			require.NoError(t, err)
+			client.prepareStoppedTasksForResume(t.Context(), apply, []*storage.Task{stoppedTask, completedTask}, controlReq != nil)
+
+			assert.Equal(t, state.Task.Pending, stoppedTask.State)
+			assert.Nil(t, stoppedTask.CompletedAt)
+			assert.Equal(t, state.Task.Completed, completedTask.State)
+			assert.Equal(t, &completedAt, completedTask.CompletedAt)
+		})
+	}
+}
+
+func TestPrepareStoppedTasksForResumeIgnoresApplyWithoutStartRequest(t *testing.T) {
+	completedAt := time.Date(2026, 5, 26, 20, 0, 0, 0, time.UTC)
+	task := &storage.Task{
+		TaskIdentifier: "task-stopped",
+		State:          state.Task.Stopped,
+		CompletedAt:    &completedAt,
+	}
+	client := &LocalClient{
+		storage: &exactProgressStorage{
+			tasks:           &exactProgressTaskStore{tasks: []*storage.Task{task}},
+			controlRequests: &testControlRequestStore{},
+		},
+		logger: slog.Default(),
+	}
+
+	client.prepareStoppedTasksForResume(t.Context(), &storage.Apply{ID: 123, State: state.Apply.Running}, []*storage.Task{task}, false)
+
+	assert.Equal(t, state.Task.Stopped, task.State)
+	assert.Equal(t, &completedAt, task.CompletedAt)
 }
 
 func TestSyncStoredTaskProgressFromEngineTablePersistsRows(t *testing.T) {

--- a/pkg/tern/local_control.go
+++ b/pkg/tern/local_control.go
@@ -129,6 +129,8 @@ func (c *LocalClient) Stop(ctx context.Context, req *ternv1.StopRequest) (*ternv
 			// apply record reflects the true outcome. failApplyWithTasks skips
 			// tasks already in terminal state, so the cancelled tasks are preserved.
 			c.markApplyCancelled(ctx, applyID)
+		} else if err := c.markApplyStopped(ctx, applyID); err != nil {
+			return nil, err
 		}
 		c.logApplyEvent(ctx, applyID, nil, storage.LogLevelInfo, storage.LogEventStopRequested, storage.LogSourceSchemaBot,
 			eventMsg, "", "")
@@ -268,6 +270,30 @@ func (c *LocalClient) handleStopAllCompleted(ctx context.Context, applyID int64,
 		StoppedCount: 0,
 		SkippedCount: skippedCount,
 	}, nil
+}
+
+func (c *LocalClient) markApplyStopped(ctx context.Context, applyID int64) error {
+	apply, err := c.storage.Applies().Get(ctx, applyID)
+	if err != nil {
+		return fmt.Errorf("load apply %d for stopped state: %w", applyID, err)
+	}
+	if apply == nil {
+		return fmt.Errorf("load apply %d for stopped state: %w", applyID, storage.ErrApplyNotFound)
+	}
+	if state.IsTerminalApplyState(apply.State) && !state.IsState(apply.State, state.Apply.Stopped) {
+		c.logger.Info("apply already terminal after stop, not marking stopped",
+			"apply_id", apply.ApplyIdentifier,
+			"state", apply.State)
+		return nil
+	}
+
+	apply.State = state.Apply.Stopped
+	apply.CompletedAt = nil
+	apply.UpdatedAt = time.Now()
+	if err := c.storage.Applies().Update(ctx, apply); err != nil {
+		return fmt.Errorf("mark apply %s stopped: %w", apply.ApplyIdentifier, err)
+	}
+	return nil
 }
 
 // markApplyCancelled sets the apply to cancelled. Called by Stop() for Vitess

--- a/pkg/tern/local_control_resume.go
+++ b/pkg/tern/local_control_resume.go
@@ -392,6 +392,24 @@ func (c *LocalClient) prepareRetryableTasksForResume(ctx context.Context, apply 
 	}
 }
 
+// prepareStoppedTasksForResume turns a scheduler-claimed start request back into
+// runnable task work. The start intent stays pending until stopped task rows are
+// requeued and the apply is ready for execution, so a worker crash can still be
+// recovered by another scheduler worker.
+func (c *LocalClient) prepareStoppedTasksForResume(ctx context.Context, apply *storage.Apply, tasks []*storage.Task, startRequested bool) {
+	if !startRequested {
+		return
+	}
+	for _, task := range tasks {
+		if !state.IsState(task.State, state.Task.Stopped) {
+			continue
+		}
+		task.CompletedAt = nil
+		c.transitionTaskState(ctx, task, apply.ID, state.Task.Pending,
+			fmt.Sprintf("Task %s queued for start", task.TaskIdentifier))
+	}
+}
+
 // launchAtomicResume sends all DDLs to the engine in one call, marks tasks and
 // apply as RUNNING, logs the provided message, and then polls for completion.
 // Scheduler-owned calls block so the worker owns the apply until terminal or
@@ -509,7 +527,7 @@ func (c *LocalClient) ResumeApply(ctx context.Context, apply *storage.Apply) err
 		return nil
 	}
 
-	if state.IsState(apply.State, state.Apply.Pending) {
+	if state.IsState(apply.State, state.Apply.Pending) && apply.StartedAt == nil {
 		c.dispatchQueuedApply(ctx, apply, tasks, plan)
 		return ctx.Err()
 	}
@@ -532,6 +550,11 @@ func (c *LocalClient) ResumeApply(ctx context.Context, apply *storage.Apply) err
 	}
 
 	activeTasks := rp.ActiveTasks
+	startControlReq, err := pendingStartControlRequest(ctx, c.storage, apply)
+	if err != nil {
+		return err
+	}
+	startRequested := startControlReq != nil
 
 	if len(activeTasks) == 0 {
 		c.logger.Info("all tasks already completed, marking apply as completed",
@@ -543,11 +566,17 @@ func (c *LocalClient) ResumeApply(ctx context.Context, apply *storage.Apply) err
 		if err := c.storage.Applies().Update(ctx, apply); err != nil {
 			c.logger.Error("failed to update apply state", "apply_id", apply.ApplyIdentifier, "state", state.Apply.Completed, "error", err)
 		}
+		if startRequested {
+			if err := completePendingStartControlRequests(ctx, c.storage, apply); err != nil {
+				return err
+			}
+		}
 		c.notifyTerminalObserver(apply, tasks)
 		return nil
 	}
 
 	c.prepareRetryableTasksForResume(ctx, apply, activeTasks)
+	c.prepareStoppedTasksForResume(ctx, apply, activeTasks, startRequested)
 
 	options := buildApplyOptions(apply)
 
@@ -571,6 +600,11 @@ func (c *LocalClient) ResumeApply(ctx context.Context, apply *storage.Apply) err
 				fmt.Sprintf("Recovery failed: %v", err), apply.State, state.Apply.Failed)
 			return err
 		}
+		if startRequested {
+			if err := completePendingStartControlRequests(ctx, c.storage, apply); err != nil {
+				return err
+			}
+		}
 	} else {
 		// Sequential mode: process each task one at a time
 		now := time.Now()
@@ -578,6 +612,11 @@ func (c *LocalClient) ResumeApply(ctx context.Context, apply *storage.Apply) err
 		apply.UpdatedAt = now
 		if err := c.storage.Applies().Update(ctx, apply); err != nil {
 			c.logger.Error("failed to update apply state", "apply_id", apply.ApplyIdentifier, "state", state.Apply.Running, "error", err)
+		}
+		if startRequested {
+			if err := completePendingStartControlRequests(ctx, c.storage, apply); err != nil {
+				return err
+			}
 		}
 
 		c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventStateTransition, storage.LogSourceSchemaBot,

--- a/pkg/tern/local_control_resume.go
+++ b/pkg/tern/local_control_resume.go
@@ -577,6 +577,11 @@ func (c *LocalClient) ResumeApply(ctx context.Context, apply *storage.Apply) err
 
 	c.prepareRetryableTasksForResume(ctx, apply, activeTasks)
 	c.prepareStoppedTasksForResume(ctx, apply, activeTasks, startRequested)
+	if startRequested {
+		if err := completePendingStartControlRequests(ctx, c.storage, apply); err != nil {
+			return err
+		}
+	}
 
 	options := buildApplyOptions(apply)
 
@@ -600,11 +605,6 @@ func (c *LocalClient) ResumeApply(ctx context.Context, apply *storage.Apply) err
 				fmt.Sprintf("Recovery failed: %v", err), apply.State, state.Apply.Failed)
 			return err
 		}
-		if startRequested {
-			if err := completePendingStartControlRequests(ctx, c.storage, apply); err != nil {
-				return err
-			}
-		}
 	} else {
 		// Sequential mode: process each task one at a time
 		now := time.Now()
@@ -612,11 +612,6 @@ func (c *LocalClient) ResumeApply(ctx context.Context, apply *storage.Apply) err
 		apply.UpdatedAt = now
 		if err := c.storage.Applies().Update(ctx, apply); err != nil {
 			c.logger.Error("failed to update apply state", "apply_id", apply.ApplyIdentifier, "state", state.Apply.Running, "error", err)
-		}
-		if startRequested {
-			if err := completePendingStartControlRequests(ctx, c.storage, apply); err != nil {
-				return err
-			}
 		}
 
 		c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventStateTransition, storage.LogSourceSchemaBot,

--- a/pkg/tern/local_control_test.go
+++ b/pkg/tern/local_control_test.go
@@ -21,11 +21,23 @@ type controlTestApplyStore struct {
 	apply *storage.Apply
 }
 
+func (s *controlTestApplyStore) Get(_ context.Context, id int64) (*storage.Apply, error) {
+	if s.apply == nil || s.apply.ID != id {
+		return nil, nil
+	}
+	return s.apply, nil
+}
+
 func (s *controlTestApplyStore) GetByApplyIdentifier(_ context.Context, applyIdentifier string) (*storage.Apply, error) {
 	if s.apply == nil || s.apply.ApplyIdentifier != applyIdentifier {
 		return nil, nil
 	}
 	return s.apply, nil
+}
+
+func (s *controlTestApplyStore) Update(_ context.Context, apply *storage.Apply) error {
+	s.apply = apply
+	return nil
 }
 
 type controlTestTaskStore struct {
@@ -39,6 +51,16 @@ func (s *controlTestTaskStore) GetByApplyID(_ context.Context, _ int64) ([]*stor
 
 func (s *controlTestTaskStore) GetByDatabase(_ context.Context, _ string) ([]*storage.Task, error) {
 	return s.tasks, nil
+}
+
+func (s *controlTestTaskStore) Update(_ context.Context, task *storage.Task) error {
+	for i, storedTask := range s.tasks {
+		if storedTask.ID == task.ID || storedTask.TaskIdentifier == task.TaskIdentifier {
+			s.tasks[i] = task
+			return nil
+		}
+	}
+	return storage.ErrTaskNotFound
 }
 
 type controlTestApplyLogStore struct {
@@ -110,6 +132,26 @@ func (e *controlCaptureEngine) Stop(_ context.Context, req *engine.ControlReques
 	return &engine.ControlResult{Accepted: true}, nil
 }
 
+func (e *controlCaptureEngine) Progress(context.Context, *engine.ProgressRequest) (*engine.ProgressResult, error) {
+	return &engine.ProgressResult{}, nil
+}
+
+func newMySQLControlTestClient(apply *storage.Apply, tasks []*storage.Task, eng *controlCaptureEngine) *LocalClient {
+	return &LocalClient{
+		config: LocalConfig{
+			Database: "testdb",
+			Type:     storage.DatabaseTypeMySQL,
+		},
+		storage: &controlTestStorage{
+			applies:   &controlTestApplyStore{apply: apply},
+			tasks:     &controlTestTaskStore{tasks: tasks},
+			applyLogs: &controlTestApplyLogStore{},
+		},
+		spiritEngine: eng,
+		logger:       slog.Default(),
+	}
+}
+
 func newVitessControlTestClient(apply *storage.Apply, tasks []*storage.Task, vitessData *storage.VitessApplyData, vitessDataErr error, eng *controlCaptureEngine) *LocalClient {
 	return &LocalClient{
 		config: LocalConfig{
@@ -125,6 +167,39 @@ func newVitessControlTestClient(apply *storage.Apply, tasks []*storage.Task, vit
 		planetscaleEngine: eng,
 		logger:            slog.Default(),
 	}
+}
+
+// Local MySQL stop is resumable: stopped task rows and the stored apply row
+// should move to stopped together so a later scheduler-owned start can claim
+// the apply without waiting for stale heartbeat recovery.
+func TestLocalClient_StopMarksMySQLApplyStopped(t *testing.T) {
+	apply := &storage.Apply{
+		ID:              42,
+		ApplyIdentifier: "apply-mysql-stop",
+		State:           state.Apply.Running,
+		Database:        "testdb",
+		DatabaseType:    storage.DatabaseTypeMySQL,
+		Environment:     "staging",
+	}
+	task := &storage.Task{
+		ID:             7,
+		ApplyID:        apply.ID,
+		TaskIdentifier: "task-mysql-stop",
+		Database:       "testdb",
+		State:          state.Task.Running,
+	}
+	eng := &controlCaptureEngine{}
+	client := newMySQLControlTestClient(apply, []*storage.Task{task}, eng)
+
+	resp, err := client.Stop(t.Context(), &ternv1.StopRequest{ApplyId: apply.ApplyIdentifier})
+
+	require.NoError(t, err)
+	assert.True(t, resp.Accepted)
+	assert.Equal(t, int64(1), resp.StoppedCount)
+	assert.Equal(t, state.Task.Stopped, task.State)
+	assert.Equal(t, state.Apply.Stopped, apply.State)
+	assert.Nil(t, apply.CompletedAt)
+	require.NotNil(t, eng.stopReq, "stop should call the engine")
 }
 
 // PlanetScale cutover must include the durable deploy metadata recorded for the


### PR DESCRIPTION
Routes stopped `/start` requests through scheduler-owned durable control requests instead of doing recoverable work in the HTTP handler. The handler records one pending start request for the apply, normalizes stored stopped state when the apply row lags behind stopped work, and wakes workers; duplicate calls while the request is pending return `already_requested` without revalidating remote state or rewinding a worker-claimed apply.

Local workers complete the request after stopped task rows are requeued for resume. gRPC workers reload remote progress before sending Start: stopped remote applies receive Start, already-active remote applies are adopted and kept polling, terminal remote applies are reconciled locally, and uncertain remote states leave the control request pending for scheduler recovery.

```
POST /api/start
  |
  v
API handler
  | records apply_control_requests(start, pending)
  | if stored apply is still running but work is stopped,
  | stores the apply as stopped so the scheduler can claim it now
  v
scheduler FindNextApply
  | claims stopped + pending start request
  | leases the stored apply row as running
  v
worker ResumeApply
  | local: requeue stopped tasks and resume
  | grpc: confirm remote stopped, adopt active/terminal, or retry uncertainty
  v
apply_control_requests(start, completed)
```

🤖 Generated with Codex.
