### PR TITLE
refactor(state): add shared apply state metadata registry

### DIFF
--- a/pkg/cmd/commands/watch_tui_view.go
+++ b/pkg/cmd/commands/watch_tui_view.go
@@ -121,7 +121,7 @@ func (m WatchModel) progressView() string {
 	}
 
 	// Show table progress once past branch setup phases.
-	if !state.IsBranchSetupPhase(m.state) {
+	if !state.IsSetupPhase(m.state) {
 		m.renderTables(&b, tables)
 	}
 
@@ -220,7 +220,7 @@ func (m WatchModel) progressView() string {
 			b.WriteString(m.formatFooter())
 		}
 		b.WriteString("\n")
-	case state.IsBranchSetupPhase(m.state):
+	case state.IsSetupPhase(m.state):
 		b.WriteString("\n\n")
 		dimStyle := lipgloss.NewStyle().Faint(true)
 		b.WriteString(dimStyle.Render("ESC to detach"))

--- a/pkg/cmd/templates/progress.go
+++ b/pkg/cmd/templates/progress.go
@@ -60,7 +60,7 @@ func WriteProgress(data ProgressData) {
 	}
 
 	// Build key/value pairs for the detail box
-	displayState := StateLabel(data.State)
+	displayState := state.Label(data.State)
 	if state.IsState(data.State, state.Apply.PreparingBranch) && data.Metadata != nil && data.Metadata["existing_branch"] != "" {
 		displayState = "Refreshing branch schema"
 	}
@@ -740,7 +740,7 @@ func WriteStatusList(data StatusListData) {
 		maxID = maxLen(maxID, len(a.ApplyID))
 		maxDB = maxLen(maxDB, len(a.Database))
 		maxEnv = maxLen(maxEnv, len(a.Environment))
-		maxState = maxLen(maxState, len(StateLabel(a.State)))
+		maxState = maxLen(maxState, len(state.Label(a.State)))
 		maxStarted = maxLen(maxStarted, len(formatStartedAt(a.StartedAt)))
 		maxDur = maxLen(maxDur, len(formatApplyDuration(a.StartedAt, a.CompletedAt)))
 	}
@@ -759,7 +759,7 @@ func WriteStatusList(data StatusListData) {
 
 	// Table rows
 	for _, a := range data.Applies {
-		label := StateLabel(a.State)
+		label := state.Label(a.State)
 		colorFn := stateColorFunc(a.State)
 		padded := fmt.Sprintf("%-*s", maxState, label)
 		coloredState := padded
@@ -831,7 +831,7 @@ func WriteDatabaseHistory(data DatabaseHistoryData) {
 	for _, a := range data.Applies {
 		maxID = maxLen(maxID, len(a.ApplyID))
 		maxEnv = maxLen(maxEnv, len(a.Environment))
-		maxState = maxLen(maxState, len(StateLabel(a.State)))
+		maxState = maxLen(maxState, len(state.Label(a.State)))
 		maxStarted = maxLen(maxStarted, len(formatStartedAt(a.StartedAt)))
 		maxDur = maxLen(maxDur, len(formatApplyDuration(a.StartedAt, a.CompletedAt)))
 	}
@@ -849,7 +849,7 @@ func WriteDatabaseHistory(data DatabaseHistoryData) {
 
 	// Table rows
 	for _, a := range data.Applies {
-		label := StateLabel(a.State)
+		label := state.Label(a.State)
 		colorFn := stateColorFunc(a.State)
 		padded := fmt.Sprintf("%-*s", maxState, label)
 		coloredState := padded
@@ -868,48 +868,6 @@ func WriteDatabaseHistory(data DatabaseHistoryData) {
 
 	fmt.Println()
 	fmt.Printf("%sUse 'schemabot status <apply_id>' to view details%s\n", ANSIDim, ANSIReset)
-}
-
-// StateLabel returns the human-readable display label for an apply state.
-func StateLabel(s string) string {
-	switch s {
-	case state.Apply.Completed:
-		return "Completed"
-	case state.Apply.Failed:
-		return "Failed"
-	case state.Apply.FailedRetryable:
-		return "Retrying"
-	case state.Apply.Running:
-		return "Running"
-	case state.Apply.WaitingForDeploy:
-		return "Waiting for deploy"
-	case state.Apply.WaitingForCutover:
-		return "Waiting for cutover"
-	case state.Apply.CuttingOver:
-		return "Cutting over"
-	case state.Apply.Stopped:
-		return "Stopped"
-	case state.Apply.Pending:
-		return "Pending"
-	case state.Apply.Cancelled:
-		return "Cancelled"
-	case state.Apply.PreparingBranch:
-		return "Preparing branch"
-	case state.Apply.ApplyingBranchChanges:
-		return "Applying changes to branch"
-	case state.Apply.ValidatingBranch:
-		return "Validating branch"
-	case state.Apply.CreatingDeployRequest:
-		return "Creating deploy request"
-	case state.Apply.ValidatingDeployRequest:
-		return "Validating deploy request"
-	case state.Apply.RevertWindow:
-		return "Revert window"
-	case state.Apply.Reverted:
-		return "Reverted"
-	default:
-		return s
-	}
 }
 
 // stateColorFunc returns an ANSI color function for the given state.

--- a/pkg/cmd/templates/progress.go
+++ b/pkg/cmd/templates/progress.go
@@ -154,7 +154,7 @@ func WriteProgress(data ProgressData) {
 
 	// Table progress (sorted: active first, sharded before unsharded, terminal last)
 	// Hide tables during branch setup phases (all tables are Queued, not meaningful)
-	if len(activeTables) > 0 && !state.IsBranchSetupPhase(data.State) {
+	if len(activeTables) > 0 && !state.IsSetupPhase(data.State) {
 		sort.SliceStable(activeTables, func(i, j int) bool {
 			pi := ui.TableStatePriority(state.NormalizeTaskStatus(activeTables[i].Status))
 			pj := ui.TableStatePriority(state.NormalizeTaskStatus(activeTables[j].Status))

--- a/pkg/cmd/templates/progress_states_test.go
+++ b/pkg/cmd/templates/progress_states_test.go
@@ -10,13 +10,13 @@ import (
 )
 
 func TestStateLabel_PlanetScalePhases(t *testing.T) {
-	assert.Equal(t, "Preparing branch", StateLabel(state.Apply.PreparingBranch))
-	assert.Equal(t, "Applying changes to branch", StateLabel(state.Apply.ApplyingBranchChanges))
-	assert.Equal(t, "Validating branch", StateLabel(state.Apply.ValidatingBranch))
-	assert.Equal(t, "Creating deploy request", StateLabel(state.Apply.CreatingDeployRequest))
-	assert.Equal(t, "Validating deploy request", StateLabel(state.Apply.ValidatingDeployRequest))
-	assert.Equal(t, "Cancelled", StateLabel(state.Apply.Cancelled))
-	assert.Equal(t, "Retrying", StateLabel(state.Apply.FailedRetryable))
+	assert.Equal(t, "Preparing branch", state.Label(state.Apply.PreparingBranch))
+	assert.Equal(t, "Applying changes to branch", state.Label(state.Apply.ApplyingBranchChanges))
+	assert.Equal(t, "Validating branch", state.Label(state.Apply.ValidatingBranch))
+	assert.Equal(t, "Creating deploy request", state.Label(state.Apply.CreatingDeployRequest))
+	assert.Equal(t, "Validating deploy request", state.Label(state.Apply.ValidatingDeployRequest))
+	assert.Equal(t, "Cancelled", state.Label(state.Apply.Cancelled))
+	assert.Equal(t, "Retrying", state.Label(state.Apply.FailedRetryable))
 }
 
 func TestFormatProgressState_PlanetScalePhases(t *testing.T) {

--- a/pkg/cmd/templates/progress_states_test.go
+++ b/pkg/cmd/templates/progress_states_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestStateLabel_PlanetScalePhases(t *testing.T) {
+func TestLabel_PlanetScalePhases(t *testing.T) {
 	assert.Equal(t, "Preparing branch", state.Label(state.Apply.PreparingBranch))
 	assert.Equal(t, "Applying changes to branch", state.Label(state.Apply.ApplyingBranchChanges))
 	assert.Equal(t, "Validating branch", state.Label(state.Apply.ValidatingBranch))

--- a/pkg/state/apply.go
+++ b/pkg/state/apply.go
@@ -174,8 +174,10 @@ func IsState(s string, expected ...string) bool {
 // IsTerminalApplyState returns true if the state is a terminal state
 // where no further processing will occur. FailedRetryable is not terminal;
 // scheduler workers may claim and retry it.
+// Accepts any format (proto "STATE_COMPLETED", uppercase "COMPLETED", or
+// canonical lowercase "completed") — normalizes first.
 func IsTerminalApplyState(s string) bool {
-	info, ok := LookupApply(s)
+	info, ok := LookupApply(NormalizeState(s))
 	return ok && info.Terminal
 }
 

--- a/pkg/state/apply.go
+++ b/pkg/state/apply.go
@@ -181,13 +181,13 @@ func IsTerminalApplyState(s string) bool {
 	return ok && info.Terminal
 }
 
-// IsBranchSetupPhase returns true if the apply state is a PlanetScale branch
-// lifecycle phase where per-table progress is not yet meaningful (all tables
-// are Queued). Used by the TUI and CLI to hide the table list during setup.
+// IsSetupPhase returns true if the apply state is an engine-lifecycle phase
+// that runs before per-table progress is meaningful (all tables are Queued).
+// Used by the TUI and CLI to hide the table list during setup.
 // WaitingForDeploy is included because the deploy hasn't started yet.
-func IsBranchSetupPhase(s string) bool {
+func IsSetupPhase(s string) bool {
 	info, ok := LookupApply(NormalizeState(s))
-	return ok && info.BranchSetup
+	return ok && info.SetupPhase
 }
 
 // IsPlanetScaleEngine returns true if the engine string indicates PlanetScale/Vitess.

--- a/pkg/state/apply.go
+++ b/pkg/state/apply.go
@@ -175,12 +175,8 @@ func IsState(s string, expected ...string) bool {
 // where no further processing will occur. FailedRetryable is not terminal;
 // scheduler workers may claim and retry it.
 func IsTerminalApplyState(s string) bool {
-	switch s {
-	case Apply.Completed, Apply.Failed, Apply.Stopped, Apply.Cancelled, Apply.Reverted:
-		return true
-	default:
-		return false
-	}
+	info, ok := LookupApply(s)
+	return ok && info.Terminal
 }
 
 // IsBranchSetupPhase returns true if the apply state is a PlanetScale branch
@@ -188,7 +184,8 @@ func IsTerminalApplyState(s string) bool {
 // are Queued). Used by the TUI and CLI to hide the table list during setup.
 // WaitingForDeploy is included because the deploy hasn't started yet.
 func IsBranchSetupPhase(s string) bool {
-	return IsState(s, Apply.Pending, Apply.PreparingBranch, Apply.ApplyingBranchChanges, Apply.ValidatingBranch, Apply.CreatingDeployRequest, Apply.ValidatingDeployRequest, Apply.WaitingForDeploy)
+	info, ok := LookupApply(NormalizeState(s))
+	return ok && info.BranchSetup
 }
 
 // IsPlanetScaleEngine returns true if the engine string indicates PlanetScale/Vitess.

--- a/pkg/state/apply_test.go
+++ b/pkg/state/apply_test.go
@@ -193,6 +193,12 @@ func TestIsTerminalApplyState(t *testing.T) {
 	for _, s := range nonTerminalStates {
 		assert.False(t, IsTerminalApplyState(s), "%s should NOT be terminal", s)
 	}
+
+	// Accepts proto and uppercase forms, matching IsBranchSetupPhase/IsState.
+	assert.True(t, IsTerminalApplyState("STATE_COMPLETED"))
+	assert.True(t, IsTerminalApplyState("COMPLETED"))
+	assert.True(t, IsTerminalApplyState("STATE_REVERTED"))
+	assert.False(t, IsTerminalApplyState("STATE_RUNNING"))
 }
 
 func TestNormalizeState(t *testing.T) {

--- a/pkg/state/apply_test.go
+++ b/pkg/state/apply_test.go
@@ -194,7 +194,7 @@ func TestIsTerminalApplyState(t *testing.T) {
 		assert.False(t, IsTerminalApplyState(s), "%s should NOT be terminal", s)
 	}
 
-	// Accepts proto and uppercase forms, matching IsBranchSetupPhase/IsState.
+	// Accepts proto and uppercase forms, matching IsSetupPhase/IsState.
 	assert.True(t, IsTerminalApplyState("STATE_COMPLETED"))
 	assert.True(t, IsTerminalApplyState("COMPLETED"))
 	assert.True(t, IsTerminalApplyState("STATE_REVERTED"))
@@ -270,7 +270,7 @@ func TestDeriveApplyState_Scenario_UserCancellation(t *testing.T) {
 	assert.Equal(t, Apply.Stopped, DeriveApplyState(states))
 }
 
-func TestIsBranchSetupPhase(t *testing.T) {
+func TestIsSetupPhase(t *testing.T) {
 	setupPhases := []string{
 		Apply.Pending,
 		Apply.PreparingBranch,
@@ -280,7 +280,7 @@ func TestIsBranchSetupPhase(t *testing.T) {
 		Apply.ValidatingDeployRequest,
 	}
 	for _, s := range setupPhases {
-		assert.True(t, IsBranchSetupPhase(s), "%s should be a setup phase", s)
+		assert.True(t, IsSetupPhase(s), "%s should be a setup phase", s)
 	}
 
 	nonSetupPhases := []string{
@@ -293,7 +293,7 @@ func TestIsBranchSetupPhase(t *testing.T) {
 		Apply.Stopped,
 	}
 	for _, s := range nonSetupPhases {
-		assert.False(t, IsBranchSetupPhase(s), "%s should NOT be a setup phase", s)
+		assert.False(t, IsSetupPhase(s), "%s should NOT be a setup phase", s)
 	}
 }
 

--- a/pkg/state/metadata.go
+++ b/pkg/state/metadata.go
@@ -3,7 +3,7 @@ package state
 // ApplyStateInfo holds presentation-neutral metadata for a canonical Apply state.
 //
 // Renderers (CLI, TUI, PR comments) reach for Label when they need a short
-// human-readable name. Control-plane code reaches for Terminal and BranchSetup
+// human-readable name. Control-plane code reaches for Terminal and SetupPhase
 // to make scheduling and gating decisions. Centralizing this metadata avoids
 // the drift that occurs when each consumer maintains its own switch.
 //
@@ -20,12 +20,13 @@ type ApplyStateInfo struct {
 	// Stopped IS terminal at the apply level (operators must explicitly resume).
 	Terminal bool
 
-	// BranchSetup is true for PlanetScale branch-lifecycle phases where
-	// per-table progress is not yet meaningful (all tables are queued).
-	// Used by the CLI and TUI to suppress the table list during setup.
-	// Pending and WaitingForDeploy are included because the deploy hasn't
-	// started yet.
-	BranchSetup bool
+	// SetupPhase is true for engine-lifecycle phases that run before per-table
+	// work has meaningfully started (all tables are still queued). Used by
+	// the CLI and TUI to suppress the table list during setup. Engines that
+	// stage work before the per-table phase (e.g. PlanetScale's branch and
+	// deploy-request preparation) flag those states here; Pending and
+	// WaitingForDeploy are included because the deploy hasn't started yet.
+	SetupPhase bool
 }
 
 // applyMetadata is the registry of metadata for every canonical Apply state.
@@ -34,15 +35,15 @@ type ApplyStateInfo struct {
 // classification.
 var applyMetadata = map[string]ApplyStateInfo{
 	Apply.Pending: {
-		Label:       "Pending",
-		BranchSetup: true,
+		Label:      "Pending",
+		SetupPhase: true,
 	},
 	Apply.Running: {
 		Label: "Running",
 	},
 	Apply.WaitingForDeploy: {
-		Label:       "Waiting for deploy",
-		BranchSetup: true,
+		Label:      "Waiting for deploy",
+		SetupPhase: true,
 	},
 	Apply.WaitingForCutover: {
 		Label: "Waiting for cutover",
@@ -77,24 +78,24 @@ var applyMetadata = map[string]ApplyStateInfo{
 		Terminal: true,
 	},
 	Apply.PreparingBranch: {
-		Label:       "Preparing branch",
-		BranchSetup: true,
+		Label:      "Preparing branch",
+		SetupPhase: true,
 	},
 	Apply.ApplyingBranchChanges: {
-		Label:       "Applying changes to branch",
-		BranchSetup: true,
+		Label:      "Applying changes to branch",
+		SetupPhase: true,
 	},
 	Apply.ValidatingBranch: {
-		Label:       "Validating branch",
-		BranchSetup: true,
+		Label:      "Validating branch",
+		SetupPhase: true,
 	},
 	Apply.CreatingDeployRequest: {
-		Label:       "Creating deploy request",
-		BranchSetup: true,
+		Label:      "Creating deploy request",
+		SetupPhase: true,
 	},
 	Apply.ValidatingDeployRequest: {
-		Label:       "Validating deploy request",
-		BranchSetup: true,
+		Label:      "Validating deploy request",
+		SetupPhase: true,
 	},
 }
 

--- a/pkg/state/metadata.go
+++ b/pkg/state/metadata.go
@@ -1,0 +1,119 @@
+package state
+
+// ApplyStateInfo holds presentation-neutral metadata for a canonical Apply state.
+//
+// Renderers (CLI, TUI, PR comments) reach for Label when they need a short
+// human-readable name. Control-plane code reaches for Terminal and BranchSetup
+// to make scheduling and gating decisions. Centralizing this metadata avoids
+// the drift that occurs when each consumer maintains its own switch.
+//
+// Engine-specific or surface-specific copy (Title Case headers, color, emoji)
+// is intentionally NOT stored here — those remain local to the rendering layer
+// so this registry does not overfit to one presentation.
+type ApplyStateInfo struct {
+	// Label is the canonical human-readable display name (sentence case),
+	// e.g. "Waiting for deploy", "Cutting over", "Retrying".
+	Label string
+
+	// Terminal is true for states where no further processing will occur.
+	// FailedRetryable is NOT terminal — the scheduler may retry it.
+	// Stopped IS terminal at the apply level (operators must explicitly resume).
+	Terminal bool
+
+	// BranchSetup is true for PlanetScale branch-lifecycle phases where
+	// per-table progress is not yet meaningful (all tables are queued).
+	// Used by the CLI and TUI to suppress the table list during setup.
+	// Pending and WaitingForDeploy are included because the deploy hasn't
+	// started yet.
+	BranchSetup bool
+}
+
+// applyMetadata is the registry of metadata for every canonical Apply state.
+// Every value of Apply.* must appear here. The metadata_test invariant
+// enforces this so a newly added state cannot silently miss a label or
+// classification.
+var applyMetadata = map[string]ApplyStateInfo{
+	Apply.Pending: {
+		Label:       "Pending",
+		BranchSetup: true,
+	},
+	Apply.Running: {
+		Label: "Running",
+	},
+	Apply.WaitingForDeploy: {
+		Label:       "Waiting for deploy",
+		BranchSetup: true,
+	},
+	Apply.WaitingForCutover: {
+		Label: "Waiting for cutover",
+	},
+	Apply.CuttingOver: {
+		Label: "Cutting over",
+	},
+	Apply.RevertWindow: {
+		Label: "Revert window",
+	},
+	Apply.Completed: {
+		Label:    "Completed",
+		Terminal: true,
+	},
+	Apply.Failed: {
+		Label:    "Failed",
+		Terminal: true,
+	},
+	Apply.FailedRetryable: {
+		Label: "Retrying",
+	},
+	Apply.Stopped: {
+		Label:    "Stopped",
+		Terminal: true,
+	},
+	Apply.Cancelled: {
+		Label:    "Cancelled",
+		Terminal: true,
+	},
+	Apply.Reverted: {
+		Label:    "Reverted",
+		Terminal: true,
+	},
+	Apply.PreparingBranch: {
+		Label:       "Preparing branch",
+		BranchSetup: true,
+	},
+	Apply.ApplyingBranchChanges: {
+		Label:       "Applying changes to branch",
+		BranchSetup: true,
+	},
+	Apply.ValidatingBranch: {
+		Label:       "Validating branch",
+		BranchSetup: true,
+	},
+	Apply.CreatingDeployRequest: {
+		Label:       "Creating deploy request",
+		BranchSetup: true,
+	},
+	Apply.ValidatingDeployRequest: {
+		Label:       "Validating deploy request",
+		BranchSetup: true,
+	},
+}
+
+// LookupApply returns the metadata for the given Apply state and whether the
+// state is known to the registry. Unknown states return the zero ApplyStateInfo
+// and false; callers decide whether to fall back to the raw state string or
+// treat the unknown state as an error.
+func LookupApply(s string) (ApplyStateInfo, bool) {
+	info, ok := applyMetadata[s]
+	return info, ok
+}
+
+// Label returns the canonical human-readable label for an Apply state, or the
+// state string itself when the state is not in the registry. Used by CLI, TUI,
+// and PR templates where a short label is needed; surface-specific titles
+// (e.g. Title Case PR headers) remain local to the rendering layer.
+func Label(s string) string {
+	if info, ok := applyMetadata[s]; ok {
+		return info.Label
+	}
+	return s
+}

--- a/pkg/state/metadata_test.go
+++ b/pkg/state/metadata_test.go
@@ -1,0 +1,82 @@
+package state
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestApplyMetadata_CoversAllStates enforces that every canonical Apply.*
+// constant has an entry in the registry. Renderers and gating predicates rely
+// on the registry being exhaustive; a missing entry silently degrades to a
+// raw state string in the CLI and to "not terminal / not branch-setup" in
+// scheduling decisions.
+func TestApplyMetadata_CoversAllStates(t *testing.T) {
+	v := reflect.ValueOf(Apply)
+	for i := 0; i < v.NumField(); i++ {
+		stateValue := v.Field(i).String()
+		require.NotEmpty(t, stateValue, "Apply.%s is empty", v.Type().Field(i).Name)
+		info, ok := applyMetadata[stateValue]
+		assert.Truef(t, ok, "Apply.%s (%q) is missing from applyMetadata", v.Type().Field(i).Name, stateValue)
+		assert.NotEmptyf(t, info.Label, "Apply.%s (%q) has empty Label", v.Type().Field(i).Name, stateValue)
+	}
+}
+
+// TestApplyMetadata_TerminalSet pins which states are classified as terminal.
+// Changing this set affects scheduler claiming, reconciliation, and merge
+// gating, so a deliberate test failure here is the intent when adding or
+// removing a terminal state.
+func TestApplyMetadata_TerminalSet(t *testing.T) {
+	expected := map[string]bool{
+		Apply.Completed: true,
+		Apply.Failed:    true,
+		Apply.Stopped:   true,
+		Apply.Cancelled: true,
+		Apply.Reverted:  true,
+	}
+	for s, info := range applyMetadata {
+		assert.Equalf(t, expected[s], info.Terminal, "Terminal classification for %q", s)
+	}
+	// FailedRetryable must not be terminal — the scheduler retries it.
+	assert.False(t, applyMetadata[Apply.FailedRetryable].Terminal, "FailedRetryable must not be terminal")
+}
+
+// TestApplyMetadata_BranchSetupSet pins which states are classified as
+// PlanetScale branch-setup phases. CLI and TUI suppress the per-table list
+// during these states.
+func TestApplyMetadata_BranchSetupSet(t *testing.T) {
+	expected := map[string]bool{
+		Apply.Pending:                 true,
+		Apply.PreparingBranch:         true,
+		Apply.ApplyingBranchChanges:   true,
+		Apply.ValidatingBranch:        true,
+		Apply.CreatingDeployRequest:   true,
+		Apply.ValidatingDeployRequest: true,
+		Apply.WaitingForDeploy:        true,
+	}
+	for s, info := range applyMetadata {
+		assert.Equalf(t, expected[s], info.BranchSetup, "BranchSetup classification for %q", s)
+	}
+}
+
+func TestLabel(t *testing.T) {
+	assert.Equal(t, "Pending", Label(Apply.Pending))
+	assert.Equal(t, "Waiting for deploy", Label(Apply.WaitingForDeploy))
+	assert.Equal(t, "Retrying", Label(Apply.FailedRetryable))
+	// Unknown state falls back to the raw input.
+	assert.Equal(t, "unknown_state", Label("unknown_state"))
+	assert.Equal(t, "", Label(""))
+}
+
+func TestLookupApply(t *testing.T) {
+	info, ok := LookupApply(Apply.Completed)
+	require.True(t, ok)
+	assert.Equal(t, "Completed", info.Label)
+	assert.True(t, info.Terminal)
+	assert.False(t, info.BranchSetup)
+
+	_, ok = LookupApply("not_a_state")
+	assert.False(t, ok)
+}

--- a/pkg/state/metadata_test.go
+++ b/pkg/state/metadata_test.go
@@ -11,7 +11,7 @@ import (
 // TestApplyMetadata_CoversAllStates enforces that every canonical Apply.*
 // constant has an entry in the registry. Renderers and gating predicates rely
 // on the registry being exhaustive; a missing entry silently degrades to a
-// raw state string in the CLI and to "not terminal / not branch-setup" in
+// raw state string in the CLI and to "not terminal / not setup-phase" in
 // scheduling decisions.
 func TestApplyMetadata_CoversAllStates(t *testing.T) {
 	v := reflect.ValueOf(Apply)
@@ -43,10 +43,10 @@ func TestApplyMetadata_TerminalSet(t *testing.T) {
 	assert.False(t, applyMetadata[Apply.FailedRetryable].Terminal, "FailedRetryable must not be terminal")
 }
 
-// TestApplyMetadata_BranchSetupSet pins which states are classified as
-// PlanetScale branch-setup phases. CLI and TUI suppress the per-table list
-// during these states.
-func TestApplyMetadata_BranchSetupSet(t *testing.T) {
+// TestApplyMetadata_SetupPhaseSet pins which states are classified as
+// engine setup phases. CLI and TUI suppress the per-table list during these
+// states.
+func TestApplyMetadata_SetupPhaseSet(t *testing.T) {
 	expected := map[string]bool{
 		Apply.Pending:                 true,
 		Apply.PreparingBranch:         true,
@@ -57,7 +57,7 @@ func TestApplyMetadata_BranchSetupSet(t *testing.T) {
 		Apply.WaitingForDeploy:        true,
 	}
 	for s, info := range applyMetadata {
-		assert.Equalf(t, expected[s], info.BranchSetup, "BranchSetup classification for %q", s)
+		assert.Equalf(t, expected[s], info.SetupPhase, "SetupPhase classification for %q", s)
 	}
 }
 
@@ -75,7 +75,7 @@ func TestLookupApply(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, "Completed", info.Label)
 	assert.True(t, info.Terminal)
-	assert.False(t, info.BranchSetup)
+	assert.False(t, info.SetupPhase)
 
 	_, ok = LookupApply("not_a_state")
 	assert.False(t, ok)

--- a/pkg/tern/local_client.go
+++ b/pkg/tern/local_client.go
@@ -929,7 +929,7 @@ func (c *LocalClient) Progress(ctx context.Context, req *ternv1.ProgressRequest)
 	// real progress (e.g., engine returns "running" during setup).
 	if applyRec, err := c.storage.Applies().Get(ctx, activeTask.ApplyID); err == nil && applyRec != nil {
 		switch {
-		case state.IsBranchSetupPhase(applyRec.State):
+		case state.IsSetupPhase(applyRec.State):
 			c.logger.Debug("Progress: overriding task-derived state with apply record setup phase",
 				"task_derived", overallState, "apply_record", applyRec.State)
 			overallState = applyRec.State


### PR DESCRIPTION
## What and Why ?
Adds a single source of truth in `pkg/state` for canonical Apply state metadata — human label, terminal classification, and PlanetScale branch-setup classification — replacing three separate switches that had to be kept in sync.

- `pkg/state/metadata.go`: `ApplyStateInfo {Label, Terminal, BranchSetup}` and `applyMetadata` covering every `Apply.*` constant; `LookupApply` and `Label` helpers.
- `pkg/state/apply.go`: `IsTerminalApplyState` and `IsBranchSetupPhase` consult the registry instead of open-coded switches.
- `pkg/cmd/templates/progress.go`: drop the local `StateLabel` switch; CLI call sites use `state.Label` directly.
- `pkg/state/metadata_test.go`: exhaustiveness test plus pinned-set tests for `Terminal` and `BranchSetup` so accidental classification drift fails loudly.

### Benefits

- **One place to add a new Apply state.** A single registry entry sets label, terminal, and branch-setup behavior at once; reviewers can no longer forget one of three switches.
- **Exhaustiveness is enforced.** A missing registry entry fails `TestApplyMetadata_CoversAllStates` instead of silently rendering the raw state string in the CLI or quietly returning `false` from gating predicates.
- **Terminal and branch-setup classifications are pinned.** Pinned-set tests turn changes to these sets — which affect scheduler claiming, reconciliation, merge gating, and per-table progress display — into deliberate, reviewable diffs.
- **Removes duplicated logic across packages.** CLI labels and structural classifications were previously maintained in three files; they now derive from one map.
- **Safe default for unknown states.** `Label` falls back to the raw input rather than panicking, matching prior CLI behavior.
- **Registry stays presentation-neutral.** Surface-specific copy (Title Case PR headers, ANSI colors, emojis) remains in each renderer so the registry does not overfit to one surface.