### PR TITLE
fix(cli): handle Enter in watch TUI

### DIFF
--- a/pkg/cmd/commands/apply.go
+++ b/pkg/cmd/commands/apply.go
@@ -284,7 +284,7 @@ const (
 // WatchApplyProgressWithFormat polls the progress API by apply ID with the
 // specified output format. logHeartbeat controls the interval between progress
 // heartbeats in log mode (0 = default 10s).
-func WatchApplyProgressWithFormat(endpoint, applyID string, allowCutoverPrompt bool, format OutputFormat, logHeartbeat time.Duration) error {
+func WatchApplyProgressWithFormat(endpoint, applyID, environment string, allowControlActions bool, format OutputFormat, logHeartbeat time.Duration) error {
 	// Use log format for CI/server environments
 	if format == OutputFormatLog {
 		if logHeartbeat <= 0 {
@@ -297,7 +297,7 @@ func WatchApplyProgressWithFormat(endpoint, applyID string, allowCutoverPrompt b
 	}
 
 	// Interactive format: use Bubbletea TUI
-	return WatchApplyProgressByApplyID(endpoint, applyID, allowCutoverPrompt)
+	return watchApplyProgressByApplyIDWithEnvironment(endpoint, applyID, environment, allowControlActions)
 }
 
 // WatchApplyProgressAfterCutover polls the progress API after cutover has been triggered.

--- a/pkg/cmd/commands/common.go
+++ b/pkg/cmd/commands/common.go
@@ -310,7 +310,7 @@ func applyAndWatch(ep string, planResult *apitypes.PlanResponse, database, envir
 	}
 
 	fmt.Println("Watching progress...")
-	if err := WatchApplyProgressWithFormat(ep, applyID, true, format, logHeartbeat); err != nil {
+	if err := WatchApplyProgressWithFormat(ep, applyID, environment, true, format, logHeartbeat); err != nil {
 		return applyID, err
 	}
 

--- a/pkg/cmd/commands/progress.go
+++ b/pkg/cmd/commands/progress.go
@@ -26,7 +26,7 @@ func (cmd *ProgressCmd) Run(g *Globals) error {
 	}
 
 	if cmd.Watch {
-		return WatchApplyProgressByApplyID(ep, cmd.ApplyID, true)
+		return watchApplyProgressByApplyIDWithEnvironment(ep, cmd.ApplyID, cmd.Environment, true)
 	}
 
 	result, err := client.GetProgress(ep, cmd.ApplyID)

--- a/pkg/cmd/commands/watch_tui.go
+++ b/pkg/cmd/commands/watch_tui.go
@@ -22,7 +22,7 @@ type WatchModel struct {
 	database            string
 	environment         string
 	applyID             string // When set, fetches progress by apply ID instead of database/environment
-	allowCutover        bool
+	allowControlActions bool
 	maxTableNameLen     int
 	deployTriggered     bool
 	cutoverTriggered    bool
@@ -137,19 +137,19 @@ type volumeResultMsg struct {
 }
 
 // NewWatchModel creates a new WatchModel.
-func NewWatchModel(endpoint, database, environment string, allowCutover bool) WatchModel {
+func NewWatchModel(endpoint, database, environment string, allowControlActions bool) WatchModel {
 	s := spinner.New()
 	s.Spinner = spinner.Dot
 	s.Style = lipgloss.NewStyle().Foreground(lipgloss.Color("205"))
 
 	return WatchModel{
-		endpoint:      endpoint,
-		database:      database,
-		environment:   environment,
-		allowCutover:  allowCutover,
-		spinner:       s,
-		startedAt:     time.Now(),
-		currentVolume: 4, // Default Spirit volume
+		endpoint:            endpoint,
+		database:            database,
+		environment:         environment,
+		allowControlActions: allowControlActions,
+		spinner:             s,
+		startedAt:           time.Now(),
+		currentVolume:       4, // Default Spirit volume
 	}
 }
 
@@ -172,6 +172,10 @@ func (m WatchModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Handle volume mode inputs
 		if m.volumeMode {
 			return m.handleVolumeKeys(msg)
+		}
+
+		if isEnterKey(msg) {
+			return m.handleEnterKey()
 		}
 
 		switch msg.String() {
@@ -200,23 +204,6 @@ func (m WatchModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if state.IsState(m.state, state.Apply.Running) && !isCuttingOver {
 				m.volumeMode = true
 				return m, nil
-			}
-		case "enter":
-			// Trigger deploy if waiting for deploy and not already triggered
-			if state.IsState(m.state, state.Apply.WaitingForDeploy) && m.allowCutover && !m.deployTriggered {
-				m.deployTriggered = true
-				return m, m.triggerDeploy()
-			}
-			// Trigger cutover if waiting and not already triggered
-			if state.IsState(m.state, state.Apply.WaitingForCutover) && m.allowCutover && !m.cutoverTriggered {
-				m.cutoverTriggered = true
-				return m, m.triggerCutover()
-			}
-			// Trigger skip-revert if in revert window
-			if state.IsState(m.state, state.Apply.RevertWindow) && !m.skipRevertTriggered {
-				m.skipRevertTriggered = true
-				m.skipRevertAt = time.Now()
-				return m, m.triggerSkipRevert()
 			}
 		}
 
@@ -357,15 +344,46 @@ func (m WatchModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
+func isEnterKey(msg tea.KeyMsg) bool {
+	return msg.Type == tea.KeyEnter || msg.Type == tea.KeyCtrlJ ||
+		msg.String() == "enter" || msg.String() == "ctrl+j"
+}
+
+func (m WatchModel) handleEnterKey() (tea.Model, tea.Cmd) {
+	// Trigger deploy if waiting for deploy and not already triggered
+	if state.IsState(m.state, state.Apply.WaitingForDeploy) && m.allowControlActions && !m.deployTriggered {
+		m.deployTriggered = true
+		return m, m.triggerDeploy()
+	}
+	// Trigger cutover if waiting and not already triggered
+	if state.IsState(m.state, state.Apply.WaitingForCutover) && m.allowControlActions && !m.cutoverTriggered {
+		m.cutoverTriggered = true
+		return m, m.triggerCutover()
+	}
+	// Trigger skip-revert if in revert window
+	if state.IsState(m.state, state.Apply.RevertWindow) && !m.skipRevertTriggered {
+		m.skipRevertTriggered = true
+		m.skipRevertAt = time.Now()
+		return m, m.triggerSkipRevert()
+	}
+	return m, nil
+}
+
 // WatchApplyProgressTUI uses Bubbletea to display progress.
-func WatchApplyProgressTUI(endpoint, database, environment string, allowCutover bool) error {
-	model := NewWatchModel(endpoint, database, environment, allowCutover)
+func WatchApplyProgressTUI(endpoint, database, environment string, allowControlActions bool) error {
+	model := NewWatchModel(endpoint, database, environment, allowControlActions)
 	return runWatchModel(model)
 }
 
 // WatchApplyProgressByApplyID watches progress using an apply ID instead of database/environment.
-func WatchApplyProgressByApplyID(endpoint, applyID string, allowCutover bool) error {
-	model := NewWatchModel(endpoint, "", "", allowCutover)
+func WatchApplyProgressByApplyID(endpoint, applyID string, allowControlActions bool) error {
+	return watchApplyProgressByApplyIDWithEnvironment(endpoint, applyID, "", allowControlActions)
+}
+
+// watchApplyProgressByApplyIDWithEnvironment watches progress and keeps the
+// known environment available for control operations before the first progress payload.
+func watchApplyProgressByApplyIDWithEnvironment(endpoint, applyID, environment string, allowControlActions bool) error {
+	model := NewWatchModel(endpoint, "", environment, allowControlActions)
 	model.applyID = applyID
 	return runWatchModel(model)
 }
@@ -429,7 +447,7 @@ func formatExitContext(applyID, deployRequestURL, database, environment string) 
 	if deployRequestURL != "" {
 		fmt.Fprintf(&b, "  Deploy Request:  %s\n", deployRequestURL)
 	}
-	cmd := fmt.Sprintf("schemabot progress --apply-id %s", applyID)
+	cmd := fmt.Sprintf("schemabot progress %s", applyID)
 	if environment != "" {
 		cmd += " -e " + environment
 	}

--- a/pkg/cmd/commands/watch_tui_commands.go
+++ b/pkg/cmd/commands/watch_tui_commands.go
@@ -23,6 +23,8 @@ const pollInterval = 2 * time.Second
 // maxPollInterval is the ceiling for exponential backoff on consecutive errors.
 const maxPollInterval = 30 * time.Second
 
+var callStartAPI = client.CallStartAPI
+
 func (m WatchModel) tick() tea.Cmd {
 	d := pollInterval
 	if m.consecutiveErrors > 0 {
@@ -50,7 +52,7 @@ func (m WatchModel) fetchProgress() tea.Cmd {
 
 func (m WatchModel) triggerDeploy() tea.Cmd {
 	return func() tea.Msg {
-		result, err := client.CallStartAPI(m.endpoint, m.environment, m.applyID)
+		result, err := callStartAPI(m.endpoint, m.environment, m.applyID)
 		if err != nil {
 			return deployResultMsg{success: false, err: err}
 		}

--- a/pkg/cmd/commands/watch_tui_test.go
+++ b/pkg/cmd/commands/watch_tui_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/block/schemabot/pkg/apitypes"
 	"github.com/block/schemabot/pkg/cmd/client"
 	"github.com/block/schemabot/pkg/state"
 )
@@ -335,18 +336,114 @@ func TestWatchModel_ConsecutiveErrors_IncrementCounter(t *testing.T) {
 	assert.Empty(t, m.errorMsg, "error should be cleared on success")
 }
 
+func TestWatchModel_EnterTriggersDeferredDeploy(t *testing.T) {
+	tests := []struct {
+		name string
+		key  tea.KeyMsg
+	}{
+		{name: "carriage return", key: tea.KeyMsg{Type: tea.KeyEnter}},
+		{name: "line feed", key: tea.KeyMsg{Type: tea.KeyCtrlJ}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			originalCallStartAPI := callStartAPI
+			t.Cleanup(func() { callStartAPI = originalCallStartAPI })
+
+			var gotEndpoint string
+			var gotEnvironment string
+			var gotApplyID string
+			callStartAPI = func(endpoint, environment, applyID string) (*apitypes.StartResponse, error) {
+				gotEndpoint = endpoint
+				gotEnvironment = environment
+				gotApplyID = applyID
+				return &apitypes.StartResponse{Accepted: true, StartedCount: 1}, nil
+			}
+
+			m := NewWatchModel("https://schemabot.example", "inventory2", "staging", true)
+			m.applyID = "apply-abc123"
+			m.state = state.Apply.WaitingForDeploy
+			m.initialized = true
+
+			updated, cmd := m.Update(tt.key)
+			model := updated.(WatchModel)
+			require.NotNil(t, cmd)
+			assert.True(t, model.deployTriggered)
+
+			msg := cmd()
+			result, ok := msg.(deployResultMsg)
+			require.True(t, ok, "expected deployResultMsg, got %T", msg)
+			require.NoError(t, result.err)
+			assert.True(t, result.success)
+
+			assert.Equal(t, "https://schemabot.example", gotEndpoint)
+			assert.Equal(t, "apply-abc123", gotApplyID)
+			assert.Equal(t, "staging", gotEnvironment)
+		})
+	}
+}
+
+func TestWatchModel_EnterTriggersCutover(t *testing.T) {
+	tests := []struct {
+		name string
+		key  tea.KeyMsg
+	}{
+		{name: "carriage return", key: tea.KeyMsg{Type: tea.KeyEnter}},
+		{name: "line feed", key: tea.KeyMsg{Type: tea.KeyCtrlJ}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := NewWatchModel("https://schemabot.example", "inventory2", "staging", true)
+			m.applyID = "apply-abc123"
+			m.state = state.Apply.WaitingForCutover
+			m.initialized = true
+
+			updated, cmd := m.Update(tt.key)
+			model := updated.(WatchModel)
+			require.NotNil(t, cmd)
+			assert.True(t, model.cutoverTriggered)
+		})
+	}
+}
+
+func TestWatchModel_EnterTriggersSkipRevert(t *testing.T) {
+	tests := []struct {
+		name string
+		key  tea.KeyMsg
+	}{
+		{name: "carriage return", key: tea.KeyMsg{Type: tea.KeyEnter}},
+		{name: "line feed", key: tea.KeyMsg{Type: tea.KeyCtrlJ}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := NewWatchModel("https://schemabot.example", "inventory2", "staging", true)
+			m.applyID = "apply-abc123"
+			m.state = state.Apply.RevertWindow
+			m.initialized = true
+
+			updated, cmd := m.Update(tt.key)
+			model := updated.(WatchModel)
+			require.NotNil(t, cmd)
+			assert.True(t, model.skipRevertTriggered)
+			assert.False(t, model.skipRevertAt.IsZero())
+		})
+	}
+}
+
 func TestFormatExitContext(t *testing.T) {
 	t.Run("includes apply ID and resume command", func(t *testing.T) {
 		result := formatExitContext("apply-abc123", "", "mydb", "production")
 		assert.Contains(t, result, "apply-abc123")
-		assert.Contains(t, result, "schemabot progress --apply-id apply-abc123 -e production")
+		assert.Contains(t, result, "schemabot progress apply-abc123 -e production")
 	})
 
 	t.Run("includes deploy request URL when present", func(t *testing.T) {
 		result := formatExitContext("apply-abc123", "https://app.planetscale.com/org/db/deploy-requests/42", "mydb", "production")
 		assert.Contains(t, result, "apply-abc123")
 		assert.Contains(t, result, "https://app.planetscale.com/org/db/deploy-requests/42")
-		assert.Contains(t, result, "schemabot progress --apply-id apply-abc123 -e production")
+		assert.Contains(t, result, "schemabot progress apply-abc123 -e production")
 	})
 
 	t.Run("omits deploy URL when empty", func(t *testing.T) {
@@ -361,7 +458,7 @@ func TestFormatExitContext(t *testing.T) {
 
 	t.Run("omits environment flag when empty", func(t *testing.T) {
 		result := formatExitContext("apply-abc123", "", "mydb", "")
-		assert.Contains(t, result, "schemabot progress --apply-id apply-abc123")
+		assert.Contains(t, result, "schemabot progress apply-abc123")
 		assert.NotContains(t, result, "-e ")
 	})
 }

--- a/pkg/cmd/commands/watch_tui_view.go
+++ b/pkg/cmd/commands/watch_tui_view.go
@@ -190,7 +190,7 @@ func (m WatchModel) progressView() string {
 			b.WriteString("⚡ This change will be applied using instant mode.\n")
 		}
 		b.WriteString("\n")
-		if m.allowCutover {
+		if m.allowControlActions {
 			b.WriteString("Press Enter to deploy or proceed via the PlanetScale console (ESC to detach)\n")
 		} else {
 			if m.applyID != "" {
@@ -204,7 +204,7 @@ func (m WatchModel) progressView() string {
 		b.WriteString("\n\n")
 		b.WriteString("Row copy complete. All data has been copied and new writes\n")
 		b.WriteString("continue to be replicated to keep the shadow table in sync.\n\n")
-		if m.allowCutover {
+		if m.allowControlActions {
 			b.WriteString("Press Enter to proceed with cutover (or ESC to detach)\n")
 		} else {
 			if m.applyID != "" {


### PR DESCRIPTION
## Why
Some terminals surface Return as `ctrl+j` in Bubble Tea, so pressing Enter in the watch TUI could fail to trigger deferred deploy, cutover, or skip-revert. The apply-created watch session also needs known environment scope immediately so control requests are correctly scoped before the first progress payload arrives.

## What
- Normalize `enter` and `ctrl+j` through a shared watch TUI handler
- Seed environment into interactive apply/progress watch models without threading database through apply watch
- Fix the printed progress resume command to use positional apply ID syntax
- Add regression coverage for deploy, cutover, and skip-revert Enter handling

Generated with Amp
