### PR TITLE
feat(scheduler): cap retryable recovery freshness

### DIFF
--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -208,7 +208,7 @@ func (s *capturingApplyStore) FindNextApply(context.Context) (*storage.Apply, er
 	return &apply, nil
 }
 
-func (s *capturingApplyStore) ExpireRetryable(context.Context) ([]*storage.Apply, error) {
+func (s *capturingApplyStore) ExpireRetryable(context.Context) ([]*storage.RetryableApplyExpiration, error) {
 	return nil, nil
 }
 

--- a/pkg/api/scheduler.go
+++ b/pkg/api/scheduler.go
@@ -152,14 +152,16 @@ func (s *Service) recoverApplies(ctx context.Context, workerID int) {
 		metrics.RecordSchedulerClaimFailure(ctx, "expire_retryable_error")
 		return
 	}
-	for _, apply := range expired {
-		s.logger.Error("scheduler: retry budget exhausted",
+	for _, expiration := range expired {
+		apply := expiration.Apply
+		s.logger.Error("scheduler: retryable apply expired",
 			"worker", workerID,
 			"apply_id", apply.ApplyIdentifier,
 			"database", apply.Database,
 			"environment", apply.Environment,
-			"attempt", apply.Attempt)
-		metrics.RecordSchedulerResumeFailure(ctx, apply.Database, apply.Environment, "retry_budget_exhausted")
+			"attempt", apply.Attempt,
+			"reason", expiration.Reason)
+		metrics.RecordSchedulerResumeFailure(ctx, apply.Database, apply.Environment, string(expiration.Reason))
 	}
 
 	apply, err := s.storage.Applies().FindNextApply(ctx)

--- a/pkg/metrics/README.md
+++ b/pkg/metrics/README.md
@@ -62,7 +62,7 @@ SchemaBot exposes metrics via OpenTelemetry. All metrics are available at `GET /
 
 **reason** (scheduler claim failures): `storage_error`, `expire_retryable_error`, `unknown`
 
-**reason** (scheduler resume failures): `missing_deployment`, `no_client`, `resume_error`, `retry_budget_exhausted`
+**reason** (scheduler resume failures): `missing_deployment`, `no_client`, `resume_error`, `retry_budget_exhausted`, `recovery_window_expired`
 
 ### Check Ownership Misses
 

--- a/pkg/state/README.md
+++ b/pkg/state/README.md
@@ -51,7 +51,7 @@ stateDiagram-v2
     running --> waiting_for_cutover : atomic mode
     running --> revert_window : PlanetScale only
     failed_retryable --> running : scheduler retry
-    failed_retryable --> failed : retry budget exhausted
+    failed_retryable --> failed : retry budget or recovery window exhausted
 
     waiting_for_cutover --> cutting_over
     cutting_over --> completed

--- a/pkg/storage/mysqlstore/applies.go
+++ b/pkg/storage/mysqlstore/applies.go
@@ -30,9 +30,17 @@ const applyColumnsForApplyAlias = `a.id, a.apply_identifier, a.lock_id, a.plan_i
 	a.state, a.error_message, a.options, a.attempt,
 	a.created_at, a.started_at, a.completed_at, a.updated_at`
 
-// maxRecoveryAttempts is the retry budget for failed_retryable applies. The
-// original apply attempt is separate; this counts scheduler redispatches.
-const maxRecoveryAttempts = 10
+const (
+	// maxRecoveryAttempts is the retry budget for failed_retryable applies. The
+	// original apply attempt is separate; this counts scheduler redispatches.
+	maxRecoveryAttempts = 10
+
+	// retryableRecoveryFreshnessDays prevents old retryable failures from
+	// being redispatched unexpectedly after retry policy or attempt budgets
+	// change. Old failures require deliberate operator action instead of
+	// automatic scheduler pickup.
+	retryableRecoveryFreshnessDays = 1
+)
 
 const (
 	applyTargetLockWait           = 10 * time.Second
@@ -553,10 +561,10 @@ func (s *applyStore) GetRecent(ctx context.Context, limit int) ([]*storage.Apply
 // Returns the claimed apply, or nil if nothing needs work.
 //
 // Matches queued pending applies with persisted tasks, stale active applies
-// where heartbeat expired > 1 minute, and failed_retryable applies that still
-// have retry budget. Apply creation/update enforces one active apply per
-// database/type/environment, so claims only need to lease one row and avoid
-// worker races on that row.
+// where heartbeat expired > 1 minute, and recently failed_retryable applies
+// that still have retry budget. Apply creation/update enforces one active
+// apply per database/type/environment, so claims only need to lease one row
+// and avoid worker races on that row.
 func (s *applyStore) FindNextApply(ctx context.Context) (*storage.Apply, error) {
 	// Read committed keeps concurrent SKIP LOCKED claims from taking next-key
 	// range locks that can serialize workers across otherwise independent targets.
@@ -570,7 +578,7 @@ func (s *applyStore) FindNextApply(ctx context.Context) (*storage.Apply, error) 
 	activeStatePlaceholders := placeholders(len(activeStates))
 	queryArgs := []any{state.Apply.Pending}
 	queryArgs = append(queryArgs, stringArgs(activeStates)...)
-	queryArgs = append(queryArgs, state.Apply.FailedRetryable, maxRecoveryAttempts)
+	queryArgs = append(queryArgs, state.Apply.FailedRetryable, maxRecoveryAttempts, retryableRecoveryFreshnessDays)
 
 	// Apply creation/update enforces at most one active apply per
 	// database/type/environment. The claim query only needs to find stale work;
@@ -581,7 +589,7 @@ func (s *applyStore) FindNextApply(ctx context.Context) (*storage.Apply, error) 
 		WHERE (
 			(a.state = ? AND EXISTS (SELECT 1 FROM tasks t WHERE t.apply_id = a.id))
 			OR (a.state IN (%s) AND a.updated_at < NOW() - INTERVAL 1 MINUTE)
-			OR (a.state = ? AND a.attempt < ?)
+			OR (a.state = ? AND a.attempt < ? AND a.updated_at >= NOW() - INTERVAL ? DAY)
 		)
 		ORDER BY a.created_at
 		LIMIT 1
@@ -657,8 +665,9 @@ func (s *applyStore) Heartbeat(ctx context.Context, applyID int64) error {
 }
 
 // ExpireRetryable transitions failed_retryable applies that exhausted their
-// retry budget to permanent failed. Returns the applies updated.
-func (s *applyStore) ExpireRetryable(ctx context.Context) ([]*storage.Apply, error) {
+// retry budget or recovery freshness window to permanent failed. Returns the
+// applies updated.
+func (s *applyStore) ExpireRetryable(ctx context.Context) ([]*storage.RetryableApplyExpiration, error) {
 	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelReadCommitted})
 	if err != nil {
 		return nil, fmt.Errorf("begin expire retryable applies transaction: %w", err)
@@ -668,16 +677,19 @@ func (s *applyStore) ExpireRetryable(ctx context.Context) ([]*storage.Apply, err
 	rows, err := tx.QueryContext(ctx, `
 		SELECT `+applyColumns+`
 		FROM applies
-		WHERE state = ? AND attempt >= ?
+		WHERE state = ? AND (
+			attempt >= ?
+			OR updated_at < NOW() - INTERVAL ? DAY
+		)
 		FOR UPDATE
-	`, state.Apply.FailedRetryable, maxRecoveryAttempts)
+	`, state.Apply.FailedRetryable, maxRecoveryAttempts, retryableRecoveryFreshnessDays)
 	if err != nil {
-		return nil, fmt.Errorf("query exhausted retryable applies: %w", err)
+		return nil, fmt.Errorf("query expired retryable applies: %w", err)
 	}
 	applies, err := scanApplies(rows)
 	utils.CloseAndLog(rows)
 	if err != nil {
-		return nil, fmt.Errorf("scan exhausted retryable applies: %w", err)
+		return nil, fmt.Errorf("scan expired retryable applies: %w", err)
 	}
 	if len(applies) == 0 {
 		if err := tx.Commit(); err != nil {
@@ -687,8 +699,13 @@ func (s *applyStore) ExpireRetryable(ctx context.Context) ([]*storage.Apply, err
 	}
 
 	applyIDs := make([]any, 0, len(applies))
+	expirations := make([]*storage.RetryableApplyExpiration, 0, len(applies))
 	for _, apply := range applies {
 		applyIDs = append(applyIDs, apply.ID)
+		expirations = append(expirations, &storage.RetryableApplyExpiration{
+			Apply:  apply,
+			Reason: retryableExpirationReason(apply),
+		})
 	}
 
 	taskArgs := []any{state.Task.Failed}
@@ -721,7 +738,14 @@ func (s *applyStore) ExpireRetryable(ctx context.Context) ([]*storage.Apply, err
 		apply.CompletedAt = &now
 		apply.UpdatedAt = now
 	}
-	return applies, nil
+	return expirations, nil
+}
+
+func retryableExpirationReason(apply *storage.Apply) storage.RetryableExpirationReason {
+	if apply.Attempt >= maxRecoveryAttempts {
+		return storage.RetryableExpirationAttemptBudget
+	}
+	return storage.RetryableExpirationRecoveryWindow
 }
 
 // GetByDatabase returns applies for a specific database and optionally filtered by dbType and environment.

--- a/pkg/storage/mysqlstore/applies_test.go
+++ b/pkg/storage/mysqlstore/applies_test.go
@@ -585,6 +585,35 @@ func TestApplyStore_FindNextApplyClaimsRetryable(t *testing.T) {
 	assert.Nil(t, claimedAgain)
 }
 
+// TestApplyStore_FindNextApplySkipsOldRetryable verifies that automatic
+// scheduler recovery only redispatches recently updated retryable failures.
+// Old failures require deliberate operator action instead of being picked up
+// later by a policy or retry-budget change.
+func TestApplyStore_FindNextApplySkipsOldRetryable(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", storage.DatabaseTypeMySQL, "staging")
+	apply := createTestApplyWithStateAndEnv(t, store, lock, "apply_old_retryable_claim", 501, state.Apply.FailedRetryable, "staging")
+	_, err := testDB.ExecContext(ctx, `
+		UPDATE applies
+		SET updated_at = NOW() - INTERVAL 2 DAY
+		WHERE id = ?
+	`, apply.ID)
+	require.NoError(t, err)
+
+	claimed, err := store.Applies().FindNextApply(ctx)
+	require.NoError(t, err)
+	assert.Nil(t, claimed)
+
+	persisted, err := store.Applies().Get(ctx, apply.ID)
+	require.NoError(t, err)
+	require.NotNil(t, persisted)
+	assert.Equal(t, state.Apply.FailedRetryable, persisted.State)
+	assert.Equal(t, 0, persisted.Attempt)
+}
+
 func TestApplyStore_FindNextApplyRequiresTasksForPendingApply(t *testing.T) {
 	clearTables(t)
 	ctx := t.Context()
@@ -726,9 +755,9 @@ func TestApplyStore_FindNextApplyConcurrentPendingClaims(t *testing.T) {
 	assert.Equal(t, state.Apply.Running, persisted.State)
 }
 
-// TestApplyStore_ExpireRetryable verifies retry budget exhaustion at the
-// storage layer. A retryable apply that has used all attempts becomes failed,
-// and unfinished tasks are finalized as failed with completion timestamps.
+// TestApplyStore_ExpireRetryable verifies retryable expiry at the storage
+// layer. A retryable apply that has used all attempts becomes failed, and
+// unfinished tasks are finalized as failed with completion timestamps.
 func TestApplyStore_ExpireRetryable(t *testing.T) {
 	clearTables(t)
 	ctx := t.Context()
@@ -773,9 +802,10 @@ func TestApplyStore_ExpireRetryable(t *testing.T) {
 	expired, err := store.Applies().ExpireRetryable(ctx)
 	require.NoError(t, err)
 	require.Len(t, expired, 1)
-	assert.Equal(t, apply.ApplyIdentifier, expired[0].ApplyIdentifier)
-	assert.Equal(t, state.Apply.Failed, expired[0].State)
-	assert.NotNil(t, expired[0].CompletedAt)
+	assert.Equal(t, storage.RetryableExpirationAttemptBudget, expired[0].Reason)
+	assert.Equal(t, apply.ApplyIdentifier, expired[0].Apply.ApplyIdentifier)
+	assert.Equal(t, state.Apply.Failed, expired[0].Apply.State)
+	assert.NotNil(t, expired[0].Apply.CompletedAt)
 
 	persisted, err := store.Applies().Get(ctx, apply.ID)
 	require.NoError(t, err)
@@ -794,6 +824,37 @@ func TestApplyStore_ExpireRetryable(t *testing.T) {
 	require.NotNil(t, pendingTask)
 	assert.Equal(t, state.Task.Failed, pendingTask.State)
 	assert.NotNil(t, pendingTask.CompletedAt)
+}
+
+// TestApplyStore_ExpireRetryableExpiresOldFailures verifies that retryable
+// failures are not kept non-terminal forever after their recovery window passes.
+func TestApplyStore_ExpireRetryableExpiresOldFailures(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", storage.DatabaseTypeMySQL, "staging")
+	apply := createTestApplyWithStateAndEnv(t, store, lock, "apply_retryable_old_expired", 502, state.Apply.FailedRetryable, "staging")
+	_, err := testDB.ExecContext(ctx, `
+		UPDATE applies
+		SET updated_at = NOW() - INTERVAL 2 DAY
+		WHERE id = ?
+	`, apply.ID)
+	require.NoError(t, err)
+
+	expired, err := store.Applies().ExpireRetryable(ctx)
+	require.NoError(t, err)
+	require.Len(t, expired, 1)
+	assert.Equal(t, storage.RetryableExpirationRecoveryWindow, expired[0].Reason)
+	assert.Equal(t, apply.ApplyIdentifier, expired[0].Apply.ApplyIdentifier)
+	assert.Equal(t, state.Apply.Failed, expired[0].Apply.State)
+	assert.Equal(t, 0, expired[0].Apply.Attempt)
+
+	persisted, err := store.Applies().Get(ctx, apply.ID)
+	require.NoError(t, err)
+	require.NotNil(t, persisted)
+	assert.Equal(t, state.Apply.Failed, persisted.State)
+	assert.NotNil(t, persisted.CompletedAt)
 }
 
 func TestApplyStore_FindMissingSummaryComment_ExcludesAppliesWithoutGitHubDestination(t *testing.T) {

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -217,8 +217,9 @@ type ApplyStore interface {
 	Heartbeat(ctx context.Context, applyID int64) error
 
 	// ExpireRetryable transitions failed_retryable applies that exhausted their
-	// retry budget to permanent failed. Returns the applies updated.
-	ExpireRetryable(ctx context.Context) ([]*Apply, error)
+	// retry budget or recovery freshness window to permanent failed. Returns the
+	// applies updated.
+	ExpireRetryable(ctx context.Context) ([]*RetryableApplyExpiration, error)
 
 	// FindMissingSummaryComment returns GitHub-backed applies that should have
 	// a terminal summary comment but only have a progress comment. Used by
@@ -233,6 +234,21 @@ type ApplyStore interface {
 
 	// DeleteByPR removes all applies for a PR (cleanup on PR close/merge).
 	DeleteByPR(ctx context.Context, repo string, pr int) error
+}
+
+// RetryableExpirationReason identifies why scheduler retry recovery stopped.
+type RetryableExpirationReason string
+
+const (
+	RetryableExpirationAttemptBudget  RetryableExpirationReason = "retry_budget_exhausted"
+	RetryableExpirationRecoveryWindow RetryableExpirationReason = "recovery_window_expired"
+)
+
+// RetryableApplyExpiration is a failed_retryable apply that was made permanent
+// because scheduler recovery should no longer retry it automatically.
+type RetryableApplyExpiration struct {
+	Apply  *Apply
+	Reason RetryableExpirationReason
 }
 
 // TaskStore manages schema change tasks (individual DDLs within an apply).


### PR DESCRIPTION
Summary:
- Adds a 1-day freshness window for automatic `failed_retryable` scheduler recovery, so old retryable rows are not redispatched unexpectedly after retry policy or attempt-budget changes.
- Keeps fresh `failed_retryable` applies retryable immediately while attempts remain.
- Extends retryable expiry so applies become permanently `failed` when either the attempt budget or recovery freshness window is exhausted, avoiding stale non-terminal target blockers.
- Reports expiry reasons separately as `retry_budget_exhausted` and `recovery_window_expired` in scheduler logs and metrics.

```
failed_retryable
  |
  | fresh + attempts remain
  v
running
  |
  | attempts exhausted
  |   reason=retry_budget_exhausted
  |
  | recovery window expired
  |   reason=recovery_window_expired
  v
failed
```

🤖 Generated with Codex.