### PR TITLE
fix(github): render progress SQL fences at top level

### DIFF
--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -1495,12 +1495,12 @@ Schema changes are being applied. Progress updates will be posted as new comment
 
 ### Table Progress
 
-- **`users`**: 🟦🟦🟦🟦🟦🟦🟦🟦🟦⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ 48%  
+**`users`**: 🟦🟦🟦🟦🟦🟦🟦🟦🟦⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ 48%
 
-  ```sql
-  ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
-  ```
-  Rows: 3,500,000 / 7,200,000 · ETA: 5m 30s
+```sql
+ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
+```
+Rows: 3,500,000 / 7,200,000 · ETA: 5m 30s
 
 
 ---
@@ -1524,11 +1524,11 @@ schemabot stop apply-a1b2c3d4e5f6
 
 ### Table Progress
 
-- **`users`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete  
+**`users`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
 
-  ```sql
-  ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
-  ```
+```sql
+ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
+```
 
 
 </details>
@@ -1545,11 +1545,11 @@ schemabot stop apply-a1b2c3d4e5f6
 
 ### Table Progress
 
-- **`users`**: 🟥⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ ❌ Failed  
+**`users`**: 🟥⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ ❌ Failed
 
-  ```sql
-  ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
-  ```
+```sql
+ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
+```
 
 
 > ⚠️ **Error:** lock wait timeout exceeded; try restarting transaction
@@ -1575,12 +1575,12 @@ schemabot apply -e staging
 
 ### Table Progress
 
-- **`users`**: 🟧🟧🟧🟧🟧🟧🟧⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ ⏹️ Stopped at 39%  
+**`users`**: 🟧🟧🟧🟧🟧🟧🟧⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ ⏹️ Stopped at 39%
 
-  ```sql
-  ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
-  ```
-  Rows: 156,342 / 397,453
+```sql
+ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
+```
+Rows: 156,342 / 397,453
 
 
 ---
@@ -1606,23 +1606,23 @@ schemabot start apply-a1b2c3d4e5f6
 
 ### Table Progress
 
-- **`orders`**: ⏳ Queued  
+**`orders`**: ⏳ Queued
 
-  ```sql
-  ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
-  ```
+```sql
+ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
+```
 
-- **`users`**: ⏳ Queued  
+**`users`**: ⏳ Queued
 
-  ```sql
-  ALTER TABLE `users` ADD INDEX `idx_email`(`email`);
-  ```
+```sql
+ALTER TABLE `users` ADD INDEX `idx_email`(`email`);
+```
 
-- **`products`**: ⏳ Queued  
+**`products`**: ⏳ Queued
 
-  ```sql
-  ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
-  ```
+```sql
+ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
+```
 
 
 ---
@@ -1648,24 +1648,24 @@ schemabot stop apply-a1b2c3d4e5f6
 
 ### Table Progress
 
-- **`orders`**: 🟦🟦🟦🟦⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ 22%  
+**`orders`**: 🟦🟦🟦🟦⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ 22%
 
-  ```sql
-  ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
-  ```
-  Rows: 321,450 / 1,466,232 · ETA: 5m 40s
+```sql
+ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
+```
+Rows: 321,450 / 1,466,232 · ETA: 5m 40s
 
-- **`users`**: ⏳ Queued  
+**`users`**: ⏳ Queued
 
-  ```sql
-  ALTER TABLE `users` ADD INDEX `idx_email`(`email`);
-  ```
+```sql
+ALTER TABLE `users` ADD INDEX `idx_email`(`email`);
+```
 
-- **`products`**: ⏳ Queued  
+**`products`**: ⏳ Queued
 
-  ```sql
-  ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
-  ```
+```sql
+ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
+```
 
 
 ---
@@ -1691,24 +1691,24 @@ schemabot stop apply-a1b2c3d4e5f6
 
 ### Table Progress
 
-- **`users`**: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦⬜⬜⬜⬜⬜⬜⬜⬜ 62%  
+**`users`**: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦⬜⬜⬜⬜⬜⬜⬜⬜ 62%
 
-  ```sql
-  ALTER TABLE `users` ADD INDEX `idx_email`(`email`);
-  ```
-  Rows: 914,707 / 1,466,232 · ETA: 3m 15s
+```sql
+ALTER TABLE `users` ADD INDEX `idx_email`(`email`);
+```
+Rows: 914,707 / 1,466,232 · ETA: 3m 15s
 
-- **`products`**: ⏳ Queued  
+**`products`**: ⏳ Queued
 
-  ```sql
-  ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
-  ```
+```sql
+ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
+```
 
-- **`orders`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete  
+**`orders`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
 
-  ```sql
-  ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
-  ```
+```sql
+ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
+```
 
 
 ---
@@ -1734,24 +1734,24 @@ schemabot stop apply-a1b2c3d4e5f6
 
 ### Table Progress
 
-- **`products`**: 🟦🟦🟦⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ 17%  
+**`products`**: 🟦🟦🟦⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ 17%
 
-  ```sql
-  ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
-  ```
-  Rows: 87,231 / 523,140 · ETA: 7m 0s
+```sql
+ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
+```
+Rows: 87,231 / 523,140 · ETA: 7m 0s
 
-- **`orders`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete  
+**`orders`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
 
-  ```sql
-  ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
-  ```
+```sql
+ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
+```
 
-- **`users`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete  
+**`users`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
 
-  ```sql
-  ALTER TABLE `users` ADD INDEX `idx_email`(`email`);
-  ```
+```sql
+ALTER TABLE `users` ADD INDEX `idx_email`(`email`);
+```
 
 
 ---
@@ -1777,23 +1777,23 @@ schemabot stop apply-a1b2c3d4e5f6
 
 ### Table Progress
 
-- **`orders`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete  
+**`orders`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
 
-  ```sql
-  ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
-  ```
+```sql
+ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
+```
 
-- **`users`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete  
+**`users`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
 
-  ```sql
-  ALTER TABLE `users` ADD INDEX `idx_email`(`email`);
-  ```
+```sql
+ALTER TABLE `users` ADD INDEX `idx_email`(`email`);
+```
 
-- **`products`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete  
+**`products`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
 
-  ```sql
-  ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
-  ```
+```sql
+ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
+```
 
 
 </details>
@@ -1812,23 +1812,23 @@ schemabot stop apply-a1b2c3d4e5f6
 
 ### Table Progress
 
-- **`orders`**: 🟥⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ ❌ Failed  
+**`orders`**: 🟥⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ ❌ Failed
 
-  ```sql
-  ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
-  ```
+```sql
+ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
+```
 
-- **`users`**: ⊘ Cancelled (not started)  
+**`users`**: ⊘ Cancelled (not started)
 
-  ```sql
-  ALTER TABLE `users` ADD INDEX `idx_email`(`email`);
-  ```
+```sql
+ALTER TABLE `users` ADD INDEX `idx_email`(`email`);
+```
 
-- **`products`**: ⊘ Cancelled (not started)  
+**`products`**: ⊘ Cancelled (not started)
 
-  ```sql
-  ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
-  ```
+```sql
+ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
+```
 
 
 > ⚠️ **Error:** Error 1061: Duplicate key name 'idx_user_id'
@@ -1856,23 +1856,23 @@ schemabot apply -e staging
 
 ### Table Progress
 
-- **`users`**: 🟥🟥🟥🟥🟥🟥⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ ❌ Failed  
+**`users`**: 🟥🟥🟥🟥🟥🟥⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ ❌ Failed
 
-  ```sql
-  ALTER TABLE `users` ADD INDEX `idx_email`(`email`);
-  ```
+```sql
+ALTER TABLE `users` ADD INDEX `idx_email`(`email`);
+```
 
-- **`orders`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete  
+**`orders`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
 
-  ```sql
-  ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
-  ```
+```sql
+ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
+```
 
-- **`products`**: ⊘ Cancelled (not started)  
+**`products`**: ⊘ Cancelled (not started)
 
-  ```sql
-  ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
-  ```
+```sql
+ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
+```
 
 
 > ⚠️ **Error:** lock wait timeout exceeded; try restarting transaction
@@ -1900,18 +1900,18 @@ schemabot apply -e staging
 
 ### Table Progress
 
-- **`users`**: 🟧🟧🟧🟧🟧🟧🟧🟧🟧🟧🟧🟧🟧🟧⬜⬜⬜⬜⬜⬜ ⏹️ Stopped at 72%  
+**`users`**: 🟧🟧🟧🟧🟧🟧🟧🟧🟧🟧🟧🟧🟧🟧⬜⬜⬜⬜⬜⬜ ⏹️ Stopped at 72%
 
-  ```sql
-  ALTER TABLE `users` ADD INDEX `idx_email`(`email`);
-  ```
-  Rows: 1,055,687 / 1,466,232
+```sql
+ALTER TABLE `users` ADD INDEX `idx_email`(`email`);
+```
+Rows: 1,055,687 / 1,466,232
 
-- **`orders`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete  
+**`orders`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
 
-  ```sql
-  ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
-  ```
+```sql
+ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
+```
 
 
 ---
@@ -1939,23 +1939,23 @@ schemabot start apply-a1b2c3d4e5f6
 
 ### Table Progress
 
-- **`orders`**: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 Waiting for cutover  
+**`orders`**: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 Waiting for cutover
 
-  ```sql
-  ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
-  ```
+```sql
+ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
+```
 
-- **`users`**: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 Waiting for cutover  
+**`users`**: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 Waiting for cutover
 
-  ```sql
-  ALTER TABLE `users` ADD INDEX `idx_email`(`email`);
-  ```
+```sql
+ALTER TABLE `users` ADD INDEX `idx_email`(`email`);
+```
 
-- **`products`**: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 Waiting for cutover  
+**`products`**: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 Waiting for cutover
 
-  ```sql
-  ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
-  ```
+```sql
+ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
+```
 
 
 ---
@@ -1983,23 +1983,23 @@ schemabot cutover apply-a1b2c3d4e5f6
 
 ### Table Progress
 
-- **`orders`**: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 🔄 Cutting over...  
+**`orders`**: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 🔄 Cutting over...
 
-  ```sql
-  ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
-  ```
+```sql
+ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
+```
 
-- **`users`**: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 🔄 Cutting over...  
+**`users`**: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 🔄 Cutting over...
 
-  ```sql
-  ALTER TABLE `users` ADD INDEX `idx_email`(`email`);
-  ```
+```sql
+ALTER TABLE `users` ADD INDEX `idx_email`(`email`);
+```
 
-- **`products`**: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 🔄 Cutting over...  
+**`products`**: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 🔄 Cutting over...
 
-  ```sql
-  ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
-  ```
+```sql
+ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
+```
 
 
 ---

--- a/pkg/webhook/templates/apply.go
+++ b/pkg/webhook/templates/apply.go
@@ -297,40 +297,40 @@ func renderTableProgress(sb *strings.Builder, table TableProgressData, globalSta
 
 	switch status {
 	case state.Task.Pending:
-		fmt.Fprintf(sb, "- **`%s`**: \u23f3 Queued  \n", table.TableName)
+		fmt.Fprintf(sb, "**`%s`**: \u23f3 Queued\n", table.TableName)
 		writeDDLLine(sb, table.DDL)
 
 	case state.Task.Completed:
 		bar := ui.ProgressBarComplete()
-		fmt.Fprintf(sb, "- **`%s`**: %s \u2713 Complete  \n", table.TableName, bar)
+		fmt.Fprintf(sb, "**`%s`**: %s \u2713 Complete\n", table.TableName, bar)
 		writeDDLLine(sb, table.DDL)
 
 	case state.Task.WaitingForCutover:
 		bar := ui.ProgressBarWaitingCutover()
 		if table.ReadyToComplete {
-			fmt.Fprintf(sb, "- **`%s`**: %s \u2705 Ready for cutover  \n", table.TableName, bar)
+			fmt.Fprintf(sb, "**`%s`**: %s \u2705 Ready for cutover\n", table.TableName, bar)
 		} else {
-			fmt.Fprintf(sb, "- **`%s`**: %s Waiting for cutover  \n", table.TableName, bar)
+			fmt.Fprintf(sb, "**`%s`**: %s Waiting for cutover\n", table.TableName, bar)
 		}
 		writeDDLLine(sb, table.DDL)
 
 	case state.Task.CuttingOver:
 		bar := ui.ProgressBarWaitingCutover()
-		fmt.Fprintf(sb, "- **`%s`**: %s \U0001f504 Cutting over...  \n", table.TableName, bar)
+		fmt.Fprintf(sb, "**`%s`**: %s \U0001f504 Cutting over...\n", table.TableName, bar)
 		writeDDLLine(sb, table.DDL)
 
 	case state.Task.Failed:
 		bar := ui.ProgressBarFailed(table.PercentComplete)
-		fmt.Fprintf(sb, "- **`%s`**: %s \u274c Failed  \n", table.TableName, bar)
+		fmt.Fprintf(sb, "**`%s`**: %s \u274c Failed\n", table.TableName, bar)
 		writeDDLLine(sb, table.DDL)
 
 	case state.Task.Cancelled:
-		fmt.Fprintf(sb, "- **`%s`**: \u2298 Cancelled (not started)  \n", table.TableName)
+		fmt.Fprintf(sb, "**`%s`**: \u2298 Cancelled (not started)\n", table.TableName)
 		writeDDLLine(sb, table.DDL)
 
 	case state.Task.RevertWindow:
 		bar := ui.ProgressBarWaitingCutover()
-		fmt.Fprintf(sb, "- **`%s`**: %s \u2713 Complete (pending revert)  \n", table.TableName, bar)
+		fmt.Fprintf(sb, "**`%s`**: %s \u2713 Complete (pending revert)\n", table.TableName, bar)
 		writeDDLLine(sb, table.DDL)
 
 	case state.Task.Stopped:
@@ -349,12 +349,12 @@ func renderRunningTable(sb *strings.Builder, table TableProgressData) {
 	if table.RowsTotal > 0 {
 		pct := ui.ClampPercent(table.PercentComplete)
 		bar := ui.ProgressBarRowCopy(pct)
-		fmt.Fprintf(sb, "- **`%s`**: %s %d%%  \n", table.TableName, bar, pct)
+		fmt.Fprintf(sb, "**`%s`**: %s %d%%\n", table.TableName, bar, pct)
 		writeDDLLine(sb, table.DDL)
 		writeRowsAndETA(sb, table)
 	} else {
 		// No row data yet (initializing or instant DDL)
-		fmt.Fprintf(sb, "- **`%s`**: Running...  \n", table.TableName)
+		fmt.Fprintf(sb, "**`%s`**: Running...\n", table.TableName)
 		writeDDLLine(sb, table.DDL)
 	}
 }
@@ -364,31 +364,29 @@ func renderStoppedTable(sb *strings.Builder, table TableProgressData) {
 	switch {
 	case table.PercentComplete >= 100:
 		bar := ui.ProgressBarStopped(100)
-		fmt.Fprintf(sb, "- **`%s`**: %s \u23f9\ufe0f Stopped (was waiting for cutover)  \n", table.TableName, bar)
+		fmt.Fprintf(sb, "**`%s`**: %s \u23f9\ufe0f Stopped (was waiting for cutover)\n", table.TableName, bar)
 	case table.PercentComplete > 0:
 		pct := ui.ClampPercent(table.PercentComplete)
 		bar := ui.ProgressBarStopped(pct)
-		fmt.Fprintf(sb, "- **`%s`**: %s \u23f9\ufe0f Stopped at %d%%  \n", table.TableName, bar, pct)
+		fmt.Fprintf(sb, "**`%s`**: %s \u23f9\ufe0f Stopped at %d%%\n", table.TableName, bar, pct)
 	default:
-		fmt.Fprintf(sb, "- **`%s`**: \u23f9\ufe0f Stopped (not started)  \n", table.TableName)
+		fmt.Fprintf(sb, "**`%s`**: \u23f9\ufe0f Stopped (not started)\n", table.TableName)
 	}
 
 	writeDDLLine(sb, table.DDL)
 
 	// Show rows (no ETA) for stopped tables with progress
 	if table.RowsTotal > 0 && table.PercentComplete > 0 {
-		fmt.Fprintf(sb, "  Rows: %s / %s\n",
+		fmt.Fprintf(sb, "Rows: %s / %s\n",
 			ui.FormatNumber(ui.ClampRows(table.RowsCopied, table.RowsTotal)),
 			ui.FormatNumber(table.RowsTotal))
 	}
 }
 
 // writeDDLLine writes the DDL statement as a sql code block below the table name.
-// A blank line before the code fence is required for GitHub to render it as a
-// proper code block inside a list item (GFM spec).
 func writeDDLLine(sb *strings.Builder, rawDDL string) {
 	if rawDDL != "" {
-		fmt.Fprintf(sb, "\n  ```sql\n  %s\n  ```\n", ddl.FormatDDL(rawDDL))
+		fmt.Fprintf(sb, "\n```sql\n%s\n```\n", ddl.FormatDDL(rawDDL))
 	}
 }
 
@@ -399,12 +397,12 @@ func writeRowsAndETA(sb *strings.Builder, table TableProgressData) {
 	}
 	copied := ui.ClampRows(table.RowsCopied, table.RowsTotal)
 	if table.ETASeconds > 0 {
-		fmt.Fprintf(sb, "  Rows: %s / %s \u00b7 ETA: %s\n",
+		fmt.Fprintf(sb, "Rows: %s / %s \u00b7 ETA: %s\n",
 			ui.FormatNumber(copied),
 			ui.FormatNumber(table.RowsTotal),
 			ui.FormatETA(table.ETASeconds))
 	} else {
-		fmt.Fprintf(sb, "  Rows: %s / %s\n",
+		fmt.Fprintf(sb, "Rows: %s / %s\n",
 			ui.FormatNumber(copied),
 			ui.FormatNumber(table.RowsTotal))
 	}

--- a/pkg/webhook/templates/apply_test.go
+++ b/pkg/webhook/templates/apply_test.go
@@ -75,6 +75,41 @@ func TestRenderApplyStatusComment_Completed(t *testing.T) {
 	assert.Equal(t, 2, strings.Count(result, "Complete"))
 }
 
+func TestRenderApplyStatusComment_SQLFencesAreTopLevel(t *testing.T) {
+	data := ApplyStatusCommentData{
+		Database:    "testapp",
+		Environment: "staging",
+		State:       state.Apply.Completed,
+		Tables: []TableProgressData{
+			{
+				TableName: "example_cursor",
+				DDL: "CREATE TABLE `example_cursor` (" +
+					"`id` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT, " +
+					"`source` VARCHAR(64) NOT NULL, " +
+					"PRIMARY KEY (`id`)" +
+					") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci",
+				Status: state.Task.Completed,
+			},
+			{
+				TableName: "example_state",
+				DDL:       "ALTER TABLE `example_state` MODIFY COLUMN `version` VARCHAR(100) NOT NULL",
+				Status:    state.Task.Completed,
+			},
+		},
+	}
+
+	result := RenderApplyStatusComment(data)
+
+	assert.Contains(t, result, "### Table Progress")
+	assert.NotContains(t, result, "\n- **`")
+	assert.NotContains(t, result, "\n  ```sql")
+	assert.NotContains(t, result, "\n  CREATE TABLE")
+	assert.Contains(t, result, "**`example_cursor`**:")
+	assert.Contains(t, result, "\n```sql\nCREATE TABLE `example_cursor`")
+	assert.Contains(t, result, "\n```\n\n**`example_state`**:")
+	assert.Contains(t, result, "\n```sql\nALTER TABLE `example_state`")
+}
+
 func TestRenderApplyStatusComment_Failed(t *testing.T) {
 	data := ApplyStatusCommentData{
 		Database:     "testapp",


### PR DESCRIPTION
Progress comments previously rendered each table as a Markdown list item containing a nested SQL fence. GitHub can render nested fences inconsistently, so this updates progress comments to use top-level table labels and SQL fences, matching the terminal summary style. A renderer regression test locks in the top-level SQL fence shape.

🤖 Generated by Codex (GPT-5).