### PR TITLE
feat(cli): expand status history controls

### DIFF
--- a/integration/status_cli_test.go
+++ b/integration/status_cli_test.go
@@ -24,6 +24,7 @@ import (
 )
 
 var statusApplyRowRE = regexp.MustCompile(`(?m)^  apply-\S+`)
+var statusFollowUpCommandRE = regexp.MustCompile(`(?m)^schemabot status apply-\S+`)
 
 // TestCLI_Status_DefaultLimitShowsTwentyMostRecent verifies that the no-flag
 // recent status view uses the operator-facing default and tells users how to
@@ -76,7 +77,8 @@ func TestCLI_Status_LimitShowsRequestedRecentApplies(t *testing.T) {
 }
 
 // TestCLI_Status_FailedShowsOnlyFailedApplies verifies that --failed switches
-// to the failure-focused view and excludes successful terminal history.
+// to the failure-focused view with follow-up commands and excludes successful
+// terminal history.
 func TestCLI_Status_FailedShowsOnlyFailedApplies(t *testing.T) {
 	binPath := buildBinary(t, "schemabot", "./pkg/cmd")
 	endpoint, store := startStatusOnlySchemaBot(t)
@@ -91,6 +93,7 @@ func TestCLI_Status_FailedShowsOnlyFailedApplies(t *testing.T) {
 		ApplyID:      "apply-status-failed-permanent",
 		Database:     "status_failed_permanent",
 		State:        state.Apply.Failed,
+		ExternalID:   "remote-failed-permanent",
 		ErrorMessage: "syntax error near column definition",
 	})
 	seedStatusApply(t, store, statusApplySeed{
@@ -103,14 +106,23 @@ func TestCLI_Status_FailedShowsOnlyFailedApplies(t *testing.T) {
 	out := runCLI(t, binPath, "status", "--endpoint", endpoint, "--failed")
 	stripped := stripANSI(out)
 
-	assert.Equal(t, 2, statusApplyRowCount(out))
+	assert.Equal(t, 2, statusFollowUpCommandCount(out))
 	assert.Contains(t, stripped, "Recent failed schema changes")
-	assert.Contains(t, stripped, "apply-status-failed-permanent")
+	assert.Contains(t, stripped, "status_failed_permanent staging: Failed (github:tester) [")
 	assert.Contains(t, stripped, "syntax error near column definition")
-	assert.Contains(t, stripped, "apply-status-failed-retryable")
+	assert.Contains(t, stripped, "schemabot status apply-status-failed-permanent")
+	assert.Contains(t, stripped, "status_failed_retryable staging: Retrying (github:tester) [")
 	assert.Contains(t, stripped, "temporary engine failure")
+	assert.Contains(t, stripped, "schemabot status apply-status-failed-retryable")
+	assert.NotContains(t, stripped, "REASON")
 	assert.NotContains(t, stripped, "apply-status-failed-success")
 	assert.NotContains(t, stripped, "this should not render")
+
+	externalOut := runCLI(t, binPath, "status", "--endpoint", endpoint, "--failed", "--external-id")
+	external := stripANSI(externalOut)
+
+	assert.Equal(t, 2, statusFollowUpCommandCount(externalOut))
+	assert.Contains(t, external, "status_failed_permanent staging: Failed (github:tester; external_id=remote-failed-permanent) [")
 }
 
 // TestCLI_Status_ExternalIDShowsRemoteApplyIDs verifies that --external-id adds
@@ -271,4 +283,8 @@ func seedStatusApply(t *testing.T, store *schemabotmysql.Storage, seed statusApp
 
 func statusApplyRowCount(output string) int {
 	return len(statusApplyRowRE.FindAllString(stripANSI(output), -1))
+}
+
+func statusFollowUpCommandCount(output string) int {
+	return len(statusFollowUpCommandRE.FindAllString(stripANSI(output), -1))
 }

--- a/integration/status_cli_test.go
+++ b/integration/status_cli_test.go
@@ -1,0 +1,274 @@
+//go:build integration
+
+package integration
+
+import (
+	"database/sql"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"os"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/block/spirit/pkg/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	schemabotapi "github.com/block/schemabot/pkg/api"
+	"github.com/block/schemabot/pkg/state"
+	"github.com/block/schemabot/pkg/storage"
+	schemabotmysql "github.com/block/schemabot/pkg/storage/mysqlstore"
+)
+
+var statusApplyRowRE = regexp.MustCompile(`(?m)^  apply-\S+`)
+
+// TestCLI_Status_DefaultLimitShowsTwentyMostRecent verifies that the no-flag
+// recent status view uses the operator-facing default and tells users how to
+// request more rows when history is truncated.
+func TestCLI_Status_DefaultLimitShowsTwentyMostRecent(t *testing.T) {
+	binPath := buildBinary(t, "schemabot", "./pkg/cmd")
+	endpoint, store := startStatusOnlySchemaBot(t)
+
+	for i := 1; i <= 21; i++ {
+		seedStatusApply(t, store, statusApplySeed{
+			ApplyID:  fmt.Sprintf("apply-status-default-%02d", i),
+			Database: "status_default",
+			State:    state.Apply.Completed,
+		})
+	}
+
+	out := runCLI(t, binPath, "status", "--endpoint", endpoint)
+	stripped := stripANSI(out)
+
+	assert.Equal(t, 20, statusApplyRowCount(out))
+	assert.Contains(t, stripped, "apply-status-default-21")
+	assert.Contains(t, stripped, "apply-status-default-02")
+	assert.NotContains(t, stripped, "apply-status-default-01")
+	assert.Contains(t, stripped, "Showing the 20 most recent schema changes. Use --limit N to show more.")
+}
+
+// TestCLI_Status_LimitShowsRequestedRecentApplies verifies that --limit changes
+// the recent status window without changing the newest-first ordering.
+func TestCLI_Status_LimitShowsRequestedRecentApplies(t *testing.T) {
+	binPath := buildBinary(t, "schemabot", "./pkg/cmd")
+	endpoint, store := startStatusOnlySchemaBot(t)
+
+	for i := 1; i <= 5; i++ {
+		seedStatusApply(t, store, statusApplySeed{
+			ApplyID:  fmt.Sprintf("apply-status-limit-%02d", i),
+			Database: "status_limit",
+			State:    state.Apply.Completed,
+		})
+	}
+
+	out := runCLI(t, binPath, "status", "--endpoint", endpoint, "--limit", "3")
+	stripped := stripANSI(out)
+
+	assert.Equal(t, 3, statusApplyRowCount(out))
+	assert.Contains(t, stripped, "apply-status-limit-05")
+	assert.Contains(t, stripped, "apply-status-limit-04")
+	assert.Contains(t, stripped, "apply-status-limit-03")
+	assert.NotContains(t, stripped, "apply-status-limit-02")
+	assert.Contains(t, stripped, "Showing the 3 most recent schema changes. Use --limit N to show more.")
+}
+
+// TestCLI_Status_FailedShowsOnlyFailedApplies verifies that --failed switches
+// to the failure-focused view and excludes successful terminal history.
+func TestCLI_Status_FailedShowsOnlyFailedApplies(t *testing.T) {
+	binPath := buildBinary(t, "schemabot", "./pkg/cmd")
+	endpoint, store := startStatusOnlySchemaBot(t)
+
+	seedStatusApply(t, store, statusApplySeed{
+		ApplyID:      "apply-status-failed-success",
+		Database:     "status_failed_success",
+		State:        state.Apply.Completed,
+		ErrorMessage: "this should not render",
+	})
+	seedStatusApply(t, store, statusApplySeed{
+		ApplyID:      "apply-status-failed-permanent",
+		Database:     "status_failed_permanent",
+		State:        state.Apply.Failed,
+		ErrorMessage: "syntax error near column definition",
+	})
+	seedStatusApply(t, store, statusApplySeed{
+		ApplyID:      "apply-status-failed-retryable",
+		Database:     "status_failed_retryable",
+		State:        state.Apply.FailedRetryable,
+		ErrorMessage: "temporary engine failure",
+	})
+
+	out := runCLI(t, binPath, "status", "--endpoint", endpoint, "--failed")
+	stripped := stripANSI(out)
+
+	assert.Equal(t, 2, statusApplyRowCount(out))
+	assert.Contains(t, stripped, "Recent failed schema changes")
+	assert.Contains(t, stripped, "apply-status-failed-permanent")
+	assert.Contains(t, stripped, "syntax error near column definition")
+	assert.Contains(t, stripped, "apply-status-failed-retryable")
+	assert.Contains(t, stripped, "temporary engine failure")
+	assert.NotContains(t, stripped, "apply-status-failed-success")
+	assert.NotContains(t, stripped, "this should not render")
+}
+
+// TestCLI_Status_ExternalIDShowsRemoteApplyIDs verifies that --external-id adds
+// the remote apply identifier column to the regular status table.
+func TestCLI_Status_ExternalIDShowsRemoteApplyIDs(t *testing.T) {
+	binPath := buildBinary(t, "schemabot", "./pkg/cmd")
+	endpoint, store := startStatusOnlySchemaBot(t)
+
+	seedStatusApply(t, store, statusApplySeed{
+		ApplyID:    "apply-status-external-local",
+		Database:   "status_external_local",
+		State:      state.Apply.Completed,
+		ExternalID: "",
+	})
+	seedStatusApply(t, store, statusApplySeed{
+		ApplyID:    "apply-status-external-remote",
+		Database:   "status_external_remote",
+		State:      state.Apply.Completed,
+		ExternalID: "remote-apply-123",
+	})
+
+	regularOut := runCLI(t, binPath, "status", "--endpoint", endpoint, "--limit", "2")
+	regular := stripANSI(regularOut)
+	assert.NotContains(t, regular, "EXTERNAL ID")
+	assert.NotContains(t, regular, "remote-apply-123")
+
+	out := runCLI(t, binPath, "status", "--endpoint", endpoint, "--limit", "2", "--external-id")
+	stripped := stripANSI(out)
+
+	assert.Equal(t, 2, statusApplyRowCount(out))
+	assert.Contains(t, stripped, "EXTERNAL ID")
+	assert.Contains(t, stripped, "apply-status-external-remote")
+	assert.Contains(t, stripped, "remote-apply-123")
+	assert.Contains(t, stripped, "apply-status-external-local")
+}
+
+// TestCLI_Status_MaxLimitFooterDoesNotSuggestHigherLimit verifies that a
+// clamped request tells operators they are at the server maximum instead of
+// suggesting an impossible larger --limit value.
+func TestCLI_Status_MaxLimitFooterDoesNotSuggestHigherLimit(t *testing.T) {
+	binPath := buildBinary(t, "schemabot", "./pkg/cmd")
+	endpoint, store := startStatusOnlySchemaBot(t)
+
+	for i := 1; i <= 1001; i++ {
+		seedStatusApply(t, store, statusApplySeed{
+			ApplyID:  fmt.Sprintf("apply-status-cap-%04d", i),
+			Database: "status_cap",
+			State:    state.Apply.Completed,
+		})
+	}
+
+	out := runCLI(t, binPath, "status", "--endpoint", endpoint, "--limit", "2000")
+	stripped := stripANSI(out)
+
+	assert.Equal(t, 1000, statusApplyRowCount(out))
+	assert.Contains(t, stripped, "apply-status-cap-1001")
+	assert.Contains(t, stripped, "Showing the 1000 most recent schema changes. This server caps status history at 1000.")
+	assert.NotContains(t, stripped, "Use --limit N to show more.")
+}
+
+type statusApplySeed struct {
+	ApplyID      string
+	Database     string
+	Environment  string
+	State        string
+	ExternalID   string
+	ErrorMessage string
+}
+
+func startStatusOnlySchemaBot(t *testing.T) (string, *schemabotmysql.Storage) {
+	t.Helper()
+
+	db, err := sql.Open("mysql", schemabotDSN)
+	require.NoError(t, err, "open schemabot db")
+	clearStorageDB(t, db)
+
+	store := schemabotmysql.New(db)
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	svc := schemabotapi.New(store, &schemabotapi.ServerConfig{}, nil, logger)
+	t.Cleanup(func() { utils.CloseAndLog(svc) })
+
+	mux := http.NewServeMux()
+	svc.ConfigureRoutes(mux)
+
+	listener, err := (&net.ListenConfig{}).Listen(t.Context(), "tcp", "127.0.0.1:0")
+	require.NoError(t, err, "listen")
+
+	server := &http.Server{Handler: mux}
+	go func() { _ = server.Serve(listener) }()
+	t.Cleanup(func() { utils.CloseAndLog(server) })
+
+	addr := listener.Addr().String()
+	waitForHTTP(t, "http://"+addr+"/health", 5*time.Second)
+
+	return "http://" + addr, store
+}
+
+func seedStatusApply(t *testing.T, store *schemabotmysql.Storage, seed statusApplySeed) {
+	t.Helper()
+
+	environment := seed.Environment
+	if environment == "" {
+		environment = "staging"
+	}
+	applyState := seed.State
+	if applyState == "" {
+		applyState = state.Apply.Completed
+	}
+
+	ctx := t.Context()
+	lock := &storage.Lock{
+		DatabaseName: seed.Database,
+		DatabaseType: storage.DatabaseTypeMySQL,
+		Repository:   "example/repo",
+		PullRequest:  123,
+		Owner:        "status-cli-test",
+	}
+	require.NoError(t, store.Locks().Acquire(ctx, lock))
+
+	storedLock, err := store.Locks().Get(ctx, seed.Database, storage.DatabaseTypeMySQL)
+	require.NoError(t, err)
+	require.NotNil(t, storedLock)
+
+	planID, err := store.Plans().Create(ctx, &storage.Plan{
+		PlanIdentifier: "plan-" + seed.ApplyID,
+		Database:       seed.Database,
+		DatabaseType:   storage.DatabaseTypeMySQL,
+		Deployment:     seed.Database,
+		Target:         seed.Database,
+		Repository:     "example/repo",
+		PullRequest:    123,
+		SchemaPath:     "schema",
+		Environment:    environment,
+		HeadSHA:        "status-test-head",
+		CreatedAt:      time.Now(),
+	})
+	require.NoError(t, err)
+
+	_, err = store.Applies().Create(ctx, &storage.Apply{
+		ApplyIdentifier: seed.ApplyID,
+		LockID:          storedLock.ID,
+		PlanID:          planID,
+		Database:        seed.Database,
+		DatabaseType:    storage.DatabaseTypeMySQL,
+		Repository:      "example/repo",
+		PullRequest:     123,
+		Environment:     environment,
+		Deployment:      seed.Database,
+		Caller:          "github:tester",
+		ExternalID:      seed.ExternalID,
+		Engine:          storage.EngineSpirit,
+		State:           applyState,
+		ErrorMessage:    seed.ErrorMessage,
+		Options:         []byte("{}"),
+	})
+	require.NoError(t, err)
+}
+
+func statusApplyRowCount(output string) int {
+	return len(statusApplyRowRE.FindAllString(stripANSI(output), -1))
+}

--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -129,6 +129,24 @@ func (s *staticApplyStore) Update(_ context.Context, apply *storage.Apply) error
 	return s.err
 }
 
+type recentApplyStore struct {
+	storage.ApplyStore
+	filter  storage.RecentAppliesFilter
+	applies []*storage.Apply
+	err     error
+}
+
+func (s *recentApplyStore) GetRecent(_ context.Context, filter storage.RecentAppliesFilter) ([]*storage.Apply, error) {
+	s.filter = filter
+	if s.err != nil {
+		return nil, s.err
+	}
+	if filter.Limit > 0 && len(s.applies) > filter.Limit {
+		return s.applies[:filter.Limit], nil
+	}
+	return s.applies, nil
+}
+
 type capturingApplyStore struct {
 	storage.ApplyStore
 	mu        sync.Mutex
@@ -1046,6 +1064,92 @@ func TestProgressResponseFromProtoPreservesVSchemaChangeType(t *testing.T) {
 
 	require.Len(t, resp.Tables, 1)
 	assert.Equal(t, "vschema_update", resp.Tables[0].ChangeType)
+}
+
+func TestHandleStatusLimitAndEnvironment(t *testing.T) {
+	now := time.Now().UTC()
+	applies := &recentApplyStore{
+		applies: []*storage.Apply{
+			{
+				ApplyIdentifier: "apply-one",
+				Database:        "orders",
+				Environment:     "staging",
+				Engine:          storage.EngineSpirit,
+				State:           state.Apply.Completed,
+				Caller:          "cli",
+				CreatedAt:       now,
+				UpdatedAt:       now,
+			},
+			{
+				ApplyIdentifier: "apply-two",
+				Database:        "payments",
+				Environment:     "staging",
+				Engine:          storage.EngineSpirit,
+				State:           state.Apply.Running,
+				Caller:          "cli",
+				CreatedAt:       now.Add(-time.Minute),
+				UpdatedAt:       now.Add(-time.Minute),
+			},
+			{
+				ApplyIdentifier: "apply-three",
+				Database:        "inventory",
+				Environment:     "staging",
+				Engine:          storage.EngineSpirit,
+				State:           state.Apply.Completed,
+				Caller:          "cli",
+				CreatedAt:       now.Add(-2 * time.Minute),
+				UpdatedAt:       now.Add(-2 * time.Minute),
+			},
+		},
+	}
+	stor := &mockStorageWithApplyStores{applies: applies}
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	svc := New(stor, testServerConfig(), nil, logger)
+	mux := http.NewServeMux()
+	svc.ConfigureRoutes(mux)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/status?limit=2&environment=staging", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp apitypes.StatusResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	assert.Equal(t, 3, applies.filter.Limit, "server should request one extra row to detect truncation")
+	assert.Equal(t, "staging", applies.filter.Environment)
+	assert.Equal(t, 2, resp.Limit)
+	assert.True(t, resp.HasMore)
+	assert.Equal(t, 1, resp.ActiveCount)
+	require.Len(t, resp.Applies, 2)
+	assert.Equal(t, "apply-one", resp.Applies[0].ApplyID)
+	assert.Equal(t, "apply-two", resp.Applies[1].ApplyID)
+}
+
+func TestParseStatusLimit(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		target    string
+		want      int
+		wantError bool
+	}{
+		{name: "default", target: "/api/status", want: defaultStatusLimit},
+		{name: "custom", target: "/api/status?limit=50", want: 50},
+		{name: "clamped", target: "/api/status?limit=5000", want: maxStatusLimit},
+		{name: "zero", target: "/api/status?limit=0", wantError: true},
+		{name: "not a number", target: "/api/status?limit=lots", wantError: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, tt.target, nil)
+			got, err := parseStatusLimit(req)
+			if tt.wantError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
 }
 
 func TestHealth(t *testing.T) {

--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -1119,6 +1119,7 @@ func TestHandleStatusLimitAndEnvironment(t *testing.T) {
 	assert.Equal(t, 3, applies.filter.Limit, "server should request one extra row to detect truncation")
 	assert.Equal(t, "staging", applies.filter.Environment)
 	assert.Equal(t, 2, resp.Limit)
+	assert.Equal(t, maxStatusLimit, resp.MaxLimit)
 	assert.True(t, resp.HasMore)
 	assert.Equal(t, 1, resp.ActiveCount)
 	require.Len(t, resp.Applies, 2)

--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -131,20 +131,30 @@ func (s *staticApplyStore) Update(_ context.Context, apply *storage.Apply) error
 
 type recentApplyStore struct {
 	storage.ApplyStore
-	filter  storage.RecentAppliesFilter
+	filters []storage.RecentAppliesFilter
 	applies []*storage.Apply
 	err     error
 }
 
 func (s *recentApplyStore) GetRecent(_ context.Context, filter storage.RecentAppliesFilter) ([]*storage.Apply, error) {
-	s.filter = filter
+	s.filters = append(s.filters, filter)
 	if s.err != nil {
 		return nil, s.err
 	}
-	if filter.Limit > 0 && len(s.applies) > filter.Limit {
-		return s.applies[:filter.Limit], nil
+	applies := make([]*storage.Apply, 0, len(s.applies))
+	for _, apply := range s.applies {
+		if filter.Environment != "" && apply.Environment != filter.Environment {
+			continue
+		}
+		if len(filter.States) > 0 && !state.IsState(apply.State, filter.States...) {
+			continue
+		}
+		applies = append(applies, apply)
 	}
-	return s.applies, nil
+	if filter.Limit > 0 && len(applies) > filter.Limit {
+		return applies[:filter.Limit], nil
+	}
+	return applies, nil
 }
 
 type capturingApplyStore struct {
@@ -1072,6 +1082,7 @@ func TestHandleStatusLimitAndEnvironment(t *testing.T) {
 		applies: []*storage.Apply{
 			{
 				ApplyIdentifier: "apply-one",
+				ExternalID:      "external-one",
 				Database:        "orders",
 				Environment:     "staging",
 				Engine:          storage.EngineSpirit,
@@ -1089,6 +1100,17 @@ func TestHandleStatusLimitAndEnvironment(t *testing.T) {
 				Caller:          "cli",
 				CreatedAt:       now.Add(-time.Minute),
 				UpdatedAt:       now.Add(-time.Minute),
+			},
+			{
+				ApplyIdentifier: "apply-failed",
+				Database:        "orders",
+				Environment:     "staging",
+				Engine:          storage.EngineSpirit,
+				State:           state.Apply.Failed,
+				Caller:          "github:alice",
+				ErrorMessage:    "duplicate column name 'status'",
+				CreatedAt:       now.Add(-90 * time.Second),
+				UpdatedAt:       now.Add(-90 * time.Second),
 			},
 			{
 				ApplyIdentifier: "apply-three",
@@ -1116,15 +1138,73 @@ func TestHandleStatusLimitAndEnvironment(t *testing.T) {
 	var resp apitypes.StatusResponse
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 
-	assert.Equal(t, 3, applies.filter.Limit, "server should request one extra row to detect truncation")
-	assert.Equal(t, "staging", applies.filter.Environment)
+	require.Len(t, applies.filters, 1)
+	assert.Equal(t, 3, applies.filters[0].Limit, "server should request one extra row to detect truncation")
+	assert.Equal(t, "staging", applies.filters[0].Environment)
+	assert.Empty(t, applies.filters[0].States)
 	assert.Equal(t, 2, resp.Limit)
 	assert.Equal(t, maxStatusLimit, resp.MaxLimit)
 	assert.True(t, resp.HasMore)
+	assert.False(t, resp.FailuresOnly)
 	assert.Equal(t, 1, resp.ActiveCount)
 	require.Len(t, resp.Applies, 2)
 	assert.Equal(t, "apply-one", resp.Applies[0].ApplyID)
+	assert.Equal(t, "external-one", resp.Applies[0].ExternalID)
 	assert.Equal(t, "apply-two", resp.Applies[1].ApplyID)
+}
+
+func TestHandleStatusFailedFilter(t *testing.T) {
+	now := time.Now().UTC()
+	applies := &recentApplyStore{
+		applies: []*storage.Apply{
+			{
+				ApplyIdentifier: "apply-completed",
+				Database:        "orders",
+				Environment:     "staging",
+				Engine:          storage.EngineSpirit,
+				State:           state.Apply.Completed,
+				Caller:          "cli",
+				CreatedAt:       now,
+				UpdatedAt:       now,
+			},
+			{
+				ApplyIdentifier: "apply-failed",
+				ExternalID:      "external-failed",
+				Database:        "payments",
+				Environment:     "staging",
+				Engine:          storage.EngineSpirit,
+				State:           state.Apply.Failed,
+				Caller:          "github:alice",
+				ErrorMessage:    "duplicate column name 'status'",
+				CreatedAt:       now.Add(-time.Minute),
+				UpdatedAt:       now.Add(-time.Minute),
+			},
+		},
+	}
+	stor := &mockStorageWithApplyStores{applies: applies}
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	svc := New(stor, testServerConfig(), nil, logger)
+	mux := http.NewServeMux()
+	svc.ConfigureRoutes(mux)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/status?limit=2&environment=staging&failed=true", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp apitypes.StatusResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	require.Len(t, applies.filters, 1)
+	assert.Equal(t, 3, applies.filters[0].Limit)
+	assert.Equal(t, "staging", applies.filters[0].Environment)
+	assert.Equal(t, []string{state.Apply.Failed, state.Apply.FailedRetryable}, applies.filters[0].States)
+	assert.True(t, resp.FailuresOnly)
+	assert.Equal(t, 0, resp.ActiveCount)
+	require.Len(t, resp.Applies, 1)
+	assert.Equal(t, "apply-failed", resp.Applies[0].ApplyID)
+	assert.Equal(t, "external-failed", resp.Applies[0].ExternalID)
+	assert.Equal(t, "duplicate column name 'status'", resp.Applies[0].ErrorMessage)
 }
 
 func TestParseStatusLimit(t *testing.T) {
@@ -1143,6 +1223,31 @@ func TestParseStatusLimit(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, tt.target, nil)
 			got, err := parseStatusLimit(req)
+			if tt.wantError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestParseStatusFailuresOnly(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		target    string
+		want      bool
+		wantError bool
+	}{
+		{name: "default", target: "/api/status"},
+		{name: "true", target: "/api/status?failed=true", want: true},
+		{name: "false", target: "/api/status?failed=false"},
+		{name: "invalid", target: "/api/status?failed=maybe", wantError: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, tt.target, nil)
+			got, err := parseStatusFailuresOnly(req)
 			if tt.wantError {
 				require.Error(t, err)
 				return

--- a/pkg/api/progress_handlers.go
+++ b/pkg/api/progress_handlers.go
@@ -631,6 +631,7 @@ func (s *Service) handleStatus(w http.ResponseWriter, r *http.Request) {
 	resp := &apitypes.StatusResponse{
 		ActiveCount: activeCount,
 		Limit:       limit,
+		MaxLimit:    maxStatusLimit,
 		HasMore:     hasMore,
 		Applies:     make([]*apitypes.ActiveApplyResponse, 0, len(applies)),
 	}

--- a/pkg/api/progress_handlers.go
+++ b/pkg/api/progress_handlers.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"net/http"
 	"sort"
+	"strconv"
 	"time"
 
 	"github.com/block/spirit/pkg/statement"
@@ -16,6 +17,11 @@ import (
 	"github.com/block/schemabot/pkg/state"
 	"github.com/block/schemabot/pkg/storage"
 	"github.com/block/schemabot/pkg/tern"
+)
+
+const (
+	defaultStatusLimit = 20
+	maxStatusLimit     = 1000
 )
 
 // changeTypeToString converts a proto ChangeType enum to a lowercase string.
@@ -592,13 +598,27 @@ func (s *Service) handleDatabaseEnvironments(w http.ResponseWriter, r *http.Requ
 }
 
 // handleStatus handles GET /api/status requests.
-// Returns recent schema changes (active first, then completed/failed).
+// Returns recent schema changes.
 func (s *Service) handleStatus(w http.ResponseWriter, r *http.Request) {
-	applies, err := s.storage.Applies().GetRecent(r.Context(), 20)
+	limit, err := parseStatusLimit(r)
+	if err != nil {
+		s.writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	filter := storage.RecentAppliesFilter{
+		Limit:       limit + 1,
+		Environment: r.URL.Query().Get("environment"),
+	}
+	applies, err := s.storage.Applies().GetRecent(r.Context(), filter)
 	if err != nil {
 		s.logger.Error("get recent applies failed", "error", err)
 		s.writeError(w, http.StatusInternalServerError, "failed to get recent applies")
 		return
+	}
+	hasMore := len(applies) > limit
+	if hasMore {
+		applies = applies[:limit]
 	}
 
 	activeCount := 0
@@ -610,6 +630,8 @@ func (s *Service) handleStatus(w http.ResponseWriter, r *http.Request) {
 
 	resp := &apitypes.StatusResponse{
 		ActiveCount: activeCount,
+		Limit:       limit,
+		HasMore:     hasMore,
 		Applies:     make([]*apitypes.ActiveApplyResponse, 0, len(applies)),
 	}
 
@@ -645,6 +667,21 @@ func (s *Service) handleStatus(w http.ResponseWriter, r *http.Request) {
 	}
 
 	s.writeJSON(w, http.StatusOK, resp)
+}
+
+func parseStatusLimit(r *http.Request) (int, error) {
+	raw := r.URL.Query().Get("limit")
+	if raw == "" {
+		return defaultStatusLimit, nil
+	}
+	limit, err := strconv.Atoi(raw)
+	if err != nil || limit <= 0 {
+		return 0, fmt.Errorf("limit must be a positive integer")
+	}
+	if limit > maxStatusLimit {
+		return maxStatusLimit, nil
+	}
+	return limit, nil
 }
 
 // progressFromLocalStorage builds a ProgressResponse from local apply + task

--- a/pkg/api/progress_handlers.go
+++ b/pkg/api/progress_handlers.go
@@ -605,10 +605,18 @@ func (s *Service) handleStatus(w http.ResponseWriter, r *http.Request) {
 		s.writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
+	failuresOnly, err := parseStatusFailuresOnly(r)
+	if err != nil {
+		s.writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
 
 	filter := storage.RecentAppliesFilter{
 		Limit:       limit + 1,
 		Environment: r.URL.Query().Get("environment"),
+	}
+	if failuresOnly {
+		filter.States = []string{state.Apply.Failed, state.Apply.FailedRetryable}
 	}
 	applies, err := s.storage.Applies().GetRecent(r.Context(), filter)
 	if err != nil {
@@ -623,51 +631,58 @@ func (s *Service) handleStatus(w http.ResponseWriter, r *http.Request) {
 
 	activeCount := 0
 	for _, apply := range applies {
-		if !state.IsTerminalApplyState(apply.State) {
+		if !failuresOnly && !state.IsTerminalApplyState(apply.State) {
 			activeCount++
 		}
 	}
 
 	resp := &apitypes.StatusResponse{
-		ActiveCount: activeCount,
-		Limit:       limit,
-		MaxLimit:    maxStatusLimit,
-		HasMore:     hasMore,
-		Applies:     make([]*apitypes.ActiveApplyResponse, 0, len(applies)),
+		ActiveCount:  activeCount,
+		Limit:        limit,
+		MaxLimit:     maxStatusLimit,
+		HasMore:      hasMore,
+		FailuresOnly: failuresOnly,
+		Applies:      make([]*apitypes.ActiveApplyResponse, 0, len(applies)),
 	}
 
 	for _, apply := range applies {
-		caller := apply.Caller
-		if caller == "" {
-			caller = "cli"
-			if apply.PullRequest > 0 && apply.Repository != "" {
-				caller = fmt.Sprintf("%s#%d", apply.Repository, apply.PullRequest)
-			}
-		}
-
-		active := &apitypes.ActiveApplyResponse{
-			ApplyID:     apply.ApplyIdentifier,
-			Database:    apply.Database,
-			Environment: apply.Environment,
-			State:       apply.State,
-			Engine:      apply.Engine,
-			Caller:      caller,
-			UpdatedAt:   apply.UpdatedAt.Format("2006-01-02T15:04:05Z07:00"),
-		}
-		if apply.StartedAt != nil {
-			active.StartedAt = apply.StartedAt.Format("2006-01-02T15:04:05Z07:00")
-		}
-		if apply.CompletedAt != nil {
-			active.CompletedAt = apply.CompletedAt.Format("2006-01-02T15:04:05Z07:00")
-		}
-		opts := storage.ParseApplyOptions(apply.Options)
-		if opts.Volume > 0 {
-			active.Volume = opts.Volume
-		}
-		resp.Applies = append(resp.Applies, active)
+		resp.Applies = append(resp.Applies, activeApplyResponseFromStorage(apply))
 	}
 
 	s.writeJSON(w, http.StatusOK, resp)
+}
+
+func activeApplyResponseFromStorage(apply *storage.Apply) *apitypes.ActiveApplyResponse {
+	caller := apply.Caller
+	if caller == "" {
+		caller = "cli"
+		if apply.PullRequest > 0 && apply.Repository != "" {
+			caller = fmt.Sprintf("%s#%d", apply.Repository, apply.PullRequest)
+		}
+	}
+
+	active := &apitypes.ActiveApplyResponse{
+		ApplyID:      apply.ApplyIdentifier,
+		ExternalID:   apply.ExternalID,
+		Database:     apply.Database,
+		Environment:  apply.Environment,
+		State:        apply.State,
+		Engine:       apply.Engine,
+		Caller:       caller,
+		ErrorMessage: apply.ErrorMessage,
+		UpdatedAt:    apply.UpdatedAt.Format("2006-01-02T15:04:05Z07:00"),
+	}
+	if apply.StartedAt != nil {
+		active.StartedAt = apply.StartedAt.Format("2006-01-02T15:04:05Z07:00")
+	}
+	if apply.CompletedAt != nil {
+		active.CompletedAt = apply.CompletedAt.Format("2006-01-02T15:04:05Z07:00")
+	}
+	opts := storage.ParseApplyOptions(apply.Options)
+	if opts.Volume > 0 {
+		active.Volume = opts.Volume
+	}
+	return active
 }
 
 func parseStatusLimit(r *http.Request) (int, error) {
@@ -683,6 +698,18 @@ func parseStatusLimit(r *http.Request) (int, error) {
 		return maxStatusLimit, nil
 	}
 	return limit, nil
+}
+
+func parseStatusFailuresOnly(r *http.Request) (bool, error) {
+	raw := r.URL.Query().Get("failed")
+	if raw == "" {
+		return false, nil
+	}
+	failed, err := strconv.ParseBool(raw)
+	if err != nil {
+		return false, fmt.Errorf("failed must be a boolean")
+	}
+	return failed, nil
 }
 
 // progressFromLocalStorage builds a ProgressResponse from local apply + task

--- a/pkg/apitypes/apitypes.go
+++ b/pkg/apitypes/apitypes.go
@@ -350,5 +350,7 @@ type ActiveApplyResponse struct {
 // StatusResponse is the HTTP response for GET /api/status.
 type StatusResponse struct {
 	ActiveCount int                    `json:"active_count"`
+	Limit       int                    `json:"limit,omitempty"`
+	HasMore     bool                   `json:"has_more,omitempty"`
 	Applies     []*ActiveApplyResponse `json:"applies"`
 }

--- a/pkg/apitypes/apitypes.go
+++ b/pkg/apitypes/apitypes.go
@@ -351,6 +351,7 @@ type ActiveApplyResponse struct {
 type StatusResponse struct {
 	ActiveCount int                    `json:"active_count"`
 	Limit       int                    `json:"limit,omitempty"`
+	MaxLimit    int                    `json:"max_limit,omitempty"`
 	HasMore     bool                   `json:"has_more,omitempty"`
 	Applies     []*ActiveApplyResponse `json:"applies"`
 }

--- a/pkg/apitypes/apitypes.go
+++ b/pkg/apitypes/apitypes.go
@@ -335,23 +335,26 @@ type DatabaseHistoryResponse struct {
 
 // ActiveApplyResponse represents a schema change in the status list.
 type ActiveApplyResponse struct {
-	ApplyID     string `json:"apply_id"`
-	Database    string `json:"database"`
-	Environment string `json:"environment"`
-	State       string `json:"state"`
-	Engine      string `json:"engine"`
-	Caller      string `json:"caller"`
-	StartedAt   string `json:"started_at,omitempty"`
-	CompletedAt string `json:"completed_at,omitempty"`
-	UpdatedAt   string `json:"updated_at"`
-	Volume      int    `json:"volume,omitempty"`
+	ApplyID      string `json:"apply_id"`
+	ExternalID   string `json:"external_id,omitempty"`
+	Database     string `json:"database"`
+	Environment  string `json:"environment"`
+	State        string `json:"state"`
+	Engine       string `json:"engine"`
+	Caller       string `json:"caller"`
+	ErrorMessage string `json:"error_message,omitempty"`
+	StartedAt    string `json:"started_at,omitempty"`
+	CompletedAt  string `json:"completed_at,omitempty"`
+	UpdatedAt    string `json:"updated_at"`
+	Volume       int    `json:"volume,omitempty"`
 }
 
 // StatusResponse is the HTTP response for GET /api/status.
 type StatusResponse struct {
-	ActiveCount int                    `json:"active_count"`
-	Limit       int                    `json:"limit,omitempty"`
-	MaxLimit    int                    `json:"max_limit,omitempty"`
-	HasMore     bool                   `json:"has_more,omitempty"`
-	Applies     []*ActiveApplyResponse `json:"applies"`
+	ActiveCount  int                    `json:"active_count"`
+	Limit        int                    `json:"limit,omitempty"`
+	MaxLimit     int                    `json:"max_limit,omitempty"`
+	HasMore      bool                   `json:"has_more,omitempty"`
+	FailuresOnly bool                   `json:"failures_only,omitempty"`
+	Applies      []*ActiveApplyResponse `json:"applies"`
 }

--- a/pkg/cmd/client/client.go
+++ b/pkg/cmd/client/client.go
@@ -480,6 +480,7 @@ var (
 type StatusOptions struct {
 	Limit       int
 	Environment string
+	Failed      bool
 }
 
 // GetStatus fetches recent schema changes.
@@ -493,6 +494,9 @@ func GetStatus(endpoint string, opts ...StatusOptions) (*apitypes.StatusResponse
 		}
 		if opts[0].Environment != "" {
 			values.Set("environment", opts[0].Environment)
+		}
+		if opts[0].Failed {
+			values.Set("failed", "true")
 		}
 		if encoded := values.Encode(); encoded != "" {
 			requestPath += "?" + encoded

--- a/pkg/cmd/client/client.go
+++ b/pkg/cmd/client/client.go
@@ -14,6 +14,7 @@ import (
 	"os/user"
 	"path"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -475,10 +476,29 @@ var (
 	ErrLockNotFound = fmt.Errorf("lock not found")
 )
 
-// GetStatus fetches all active schema changes.
-func GetStatus(endpoint string) (*apitypes.StatusResponse, error) {
+// StatusOptions controls the status list request.
+type StatusOptions struct {
+	Limit       int
+	Environment string
+}
+
+// GetStatus fetches recent schema changes.
+func GetStatus(endpoint string, opts ...StatusOptions) (*apitypes.StatusResponse, error) {
 	var result apitypes.StatusResponse
-	if err := doGetInto(endpoint, "/api/status", &result); err != nil {
+	requestPath := "/api/status"
+	if len(opts) > 0 {
+		values := url.Values{}
+		if opts[0].Limit > 0 {
+			values.Set("limit", strconv.Itoa(opts[0].Limit))
+		}
+		if opts[0].Environment != "" {
+			values.Set("environment", opts[0].Environment)
+		}
+		if encoded := values.Encode(); encoded != "" {
+			requestPath += "?" + encoded
+		}
+	}
+	if err := doGetInto(endpoint, requestPath, &result); err != nil {
 		return nil, err
 	}
 	return &result, nil

--- a/pkg/cmd/client/client_test.go
+++ b/pkg/cmd/client/client_test.go
@@ -1,6 +1,8 @@
 package client
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
@@ -8,6 +10,28 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestGetStatusWithOptions(t *testing.T) {
+	var gotLimit, gotEnvironment string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotLimit = r.URL.Query().Get("limit")
+		gotEnvironment = r.URL.Query().Get("environment")
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`{"active_count":0,"limit":50,"applies":[]}`))
+		require.NoError(t, err)
+	}))
+	t.Cleanup(server.Close)
+
+	result, err := GetStatus(server.URL, StatusOptions{
+		Limit:       50,
+		Environment: "staging",
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "50", gotLimit)
+	assert.Equal(t, "staging", gotEnvironment)
+	assert.Equal(t, 50, result.Limit)
+}
 
 func TestReadSchemaFiles_RegularDirectories(t *testing.T) {
 	dir := t.TempDir()

--- a/pkg/cmd/client/client_test.go
+++ b/pkg/cmd/client/client_test.go
@@ -12,10 +12,11 @@ import (
 )
 
 func TestGetStatusWithOptions(t *testing.T) {
-	var gotLimit, gotEnvironment string
+	var gotLimit, gotEnvironment, gotFailed string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotLimit = r.URL.Query().Get("limit")
 		gotEnvironment = r.URL.Query().Get("environment")
+		gotFailed = r.URL.Query().Get("failed")
 		w.Header().Set("Content-Type", "application/json")
 		_, err := w.Write([]byte(`{"active_count":0,"limit":50,"applies":[]}`))
 		require.NoError(t, err)
@@ -25,11 +26,13 @@ func TestGetStatusWithOptions(t *testing.T) {
 	result, err := GetStatus(server.URL, StatusOptions{
 		Limit:       50,
 		Environment: "staging",
+		Failed:      true,
 	})
 	require.NoError(t, err)
 
 	assert.Equal(t, "50", gotLimit)
 	assert.Equal(t, "staging", gotEnvironment)
+	assert.Equal(t, "true", gotFailed)
 	assert.Equal(t, 50, result.Limit)
 }
 

--- a/pkg/cmd/commands/status.go
+++ b/pkg/cmd/commands/status.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"fmt"
 
+	"github.com/block/schemabot/pkg/apitypes"
 	"github.com/block/schemabot/pkg/cmd/client"
 	"github.com/block/schemabot/pkg/cmd/internal/templates"
 	"github.com/block/schemabot/pkg/state"
@@ -14,6 +15,8 @@ type StatusCmd struct {
 	Database    string `short:"d" help:"Database name (show apply history)"`
 	Environment string `short:"e" help:"Environment filter"`
 	Limit       int    `short:"n" help:"Maximum recent applies to show (default 20, max 1000)"`
+	Failed      bool   `help:"Show only failed recent applies" name:"failed"`
+	ExternalID  bool   `help:"Show external engine apply IDs" name:"external-id"`
 	JSON        bool   `help:"Output as JSON"`
 }
 
@@ -38,6 +41,7 @@ func (cmd *StatusCmd) Run(g *Globals) error {
 	result, err := client.GetStatus(ep, client.StatusOptions{
 		Limit:       cmd.Limit,
 		Environment: cmd.Environment,
+		Failed:      cmd.Failed,
 	})
 	if err != nil {
 		return err
@@ -50,29 +54,37 @@ func (cmd *StatusCmd) Run(g *Globals) error {
 	// Convert to template format
 	applies := make([]templates.ActiveApplyData, 0, len(result.Applies))
 	for _, a := range result.Applies {
-		applies = append(applies, templates.ActiveApplyData{
-			ApplyID:     a.ApplyID,
-			Database:    a.Database,
-			Environment: a.Environment,
-			State:       a.State,
-			Engine:      a.Engine,
-			Caller:      a.Caller,
-			StartedAt:   a.StartedAt,
-			CompletedAt: a.CompletedAt,
-			UpdatedAt:   a.UpdatedAt,
-			Volume:      a.Volume,
-		})
+		applies = append(applies, activeApplyDataFromResponse(a))
 	}
 
 	templates.WriteStatusList(templates.StatusListData{
-		ActiveCount: result.ActiveCount,
-		Limit:       result.Limit,
-		MaxLimit:    result.MaxLimit,
-		HasMore:     result.HasMore,
-		Applies:     applies,
+		ActiveCount:    result.ActiveCount,
+		Limit:          result.Limit,
+		MaxLimit:       result.MaxLimit,
+		HasMore:        result.HasMore,
+		FailuresOnly:   result.FailuresOnly,
+		ShowExternalID: cmd.ExternalID,
+		Applies:        applies,
 	})
 
 	return nil
+}
+
+func activeApplyDataFromResponse(a *apitypes.ActiveApplyResponse) templates.ActiveApplyData {
+	return templates.ActiveApplyData{
+		ApplyID:      a.ApplyID,
+		ExternalID:   a.ExternalID,
+		Database:     a.Database,
+		Environment:  a.Environment,
+		State:        a.State,
+		Engine:       a.Engine,
+		Caller:       a.Caller,
+		ErrorMessage: a.ErrorMessage,
+		StartedAt:    a.StartedAt,
+		CompletedAt:  a.CompletedAt,
+		UpdatedAt:    a.UpdatedAt,
+		Volume:       a.Volume,
+	}
 }
 
 // showApplyByID shows details for a specific apply by its ID.

--- a/pkg/cmd/commands/status.go
+++ b/pkg/cmd/commands/status.go
@@ -12,7 +12,8 @@ import (
 type StatusCmd struct {
 	ApplyIDArg  string `arg:"" optional:"" help:"Apply ID to show details for" name:"apply_id"`
 	Database    string `short:"d" help:"Database name (show apply history)"`
-	Environment string `short:"e" help:"Environment filter (with -d)"`
+	Environment string `short:"e" help:"Environment filter"`
+	Limit       int    `short:"n" help:"Maximum recent applies to show (default 20, max 1000)"`
 	JSON        bool   `help:"Output as JSON"`
 }
 
@@ -33,8 +34,11 @@ func (cmd *StatusCmd) Run(g *Globals) error {
 		return showDatabaseHistory(ep, cmd.Database, cmd.Environment, cmd.JSON)
 	}
 
-	// Mode 3: List all active applies
-	result, err := client.GetStatus(ep)
+	// Mode 3: List recent applies
+	result, err := client.GetStatus(ep, client.StatusOptions{
+		Limit:       cmd.Limit,
+		Environment: cmd.Environment,
+	})
 	if err != nil {
 		return err
 	}
@@ -62,6 +66,8 @@ func (cmd *StatusCmd) Run(g *Globals) error {
 
 	templates.WriteStatusList(templates.StatusListData{
 		ActiveCount: result.ActiveCount,
+		Limit:       result.Limit,
+		HasMore:     result.HasMore,
 		Applies:     applies,
 	})
 

--- a/pkg/cmd/commands/status.go
+++ b/pkg/cmd/commands/status.go
@@ -67,6 +67,7 @@ func (cmd *StatusCmd) Run(g *Globals) error {
 	templates.WriteStatusList(templates.StatusListData{
 		ActiveCount: result.ActiveCount,
 		Limit:       result.Limit,
+		MaxLimit:    result.MaxLimit,
 		HasMore:     result.HasMore,
 		Applies:     applies,
 	})

--- a/pkg/cmd/internal/templates/progress.go
+++ b/pkg/cmd/internal/templates/progress.go
@@ -13,6 +13,8 @@ import (
 	"github.com/block/schemabot/pkg/ui"
 )
 
+const maxStatusFailureReasonWidth = 120
+
 // Indentation for progress rendering.
 // indentTable is the prefix for table names. Aligns with keyspace name after "── " in headers.
 const indentTable = "     " // 5 spaces — matches "  ── " in FormatKeyspaceHeader
@@ -692,31 +694,44 @@ func WriteStartNoWatch(applyID, database, environment string) {
 
 // ActiveApplyData contains data for a single apply in the status list.
 type ActiveApplyData struct {
-	ApplyID     string
-	Database    string
-	Environment string
-	State       string
-	Engine      string
-	Caller      string
-	StartedAt   string
-	CompletedAt string
-	UpdatedAt   string
-	Volume      int
+	ApplyID      string
+	ExternalID   string
+	Database     string
+	Environment  string
+	State        string
+	Engine       string
+	Caller       string
+	ErrorMessage string
+	StartedAt    string
+	CompletedAt  string
+	UpdatedAt    string
+	Volume       int
 }
 
 // StatusListData contains data for rendering the status list.
 type StatusListData struct {
-	ActiveCount int
-	Limit       int
-	MaxLimit    int
-	HasMore     bool
-	Applies     []ActiveApplyData
+	ActiveCount    int
+	Limit          int
+	MaxLimit       int
+	HasMore        bool
+	FailuresOnly   bool
+	ShowExternalID bool
+	Applies        []ActiveApplyData
 }
 
 // WriteStatusList writes the status list output.
 func WriteStatusList(data StatusListData) {
 	if len(data.Applies) == 0 {
-		fmt.Printf("%sNo recent schema changes%s\n", ANSIDim, ANSIReset)
+		if data.FailuresOnly {
+			fmt.Printf("%sNo recent failed schema changes%s\n", ANSIDim, ANSIReset)
+		} else {
+			fmt.Printf("%sNo recent schema changes%s\n", ANSIDim, ANSIReset)
+		}
+		return
+	}
+	if data.FailuresOnly {
+		writeFailedStatusList(data)
+		writeStatusListFooter(data)
 		return
 	}
 
@@ -733,14 +748,18 @@ func WriteStatusList(data StatusListData) {
 	fmt.Println()
 
 	// Calculate column widths from data
-	maxID := 8      // "APPLY ID"
-	maxDB := 8      // "DATABASE"
-	maxEnv := 3     // "ENV"
-	maxState := 5   // "STATE"
-	maxStarted := 7 // "STARTED"
-	maxDur := 8     // "DURATION"
+	maxID := 8        // "APPLY ID"
+	maxExternal := 11 // "EXTERNAL ID"
+	maxDB := 8        // "DATABASE"
+	maxEnv := 3       // "ENV"
+	maxState := 5     // "STATE"
+	maxStarted := 7   // "STARTED"
+	maxDur := 8       // "DURATION"
 	for _, a := range data.Applies {
 		maxID = maxLen(maxID, len(a.ApplyID))
+		if data.ShowExternalID {
+			maxExternal = maxLen(maxExternal, len(statusExternalID(a)))
+		}
 		maxDB = maxLen(maxDB, len(a.Database))
 		maxEnv = maxLen(maxEnv, len(a.Environment))
 		maxState = maxLen(maxState, len(state.Label(a.State)))
@@ -749,16 +768,30 @@ func WriteStatusList(data StatusListData) {
 	}
 
 	// Table header
-	fmt.Printf("  %s%-*s  %-*s  %-*s  %-*s  %-*s  %-*s  %s%s\n",
-		ANSIDim,
-		maxID, "APPLY ID",
-		maxDB, "DATABASE",
-		maxEnv, "ENV",
-		maxState, "STATE",
-		maxStarted, "STARTED",
-		maxDur, "DURATION",
-		"CALLER",
-		ANSIReset)
+	if data.ShowExternalID {
+		fmt.Printf("  %s%-*s  %-*s  %-*s  %-*s  %-*s  %-*s  %-*s  %s%s\n",
+			ANSIDim,
+			maxID, "APPLY ID",
+			maxExternal, "EXTERNAL ID",
+			maxDB, "DATABASE",
+			maxEnv, "ENV",
+			maxState, "STATE",
+			maxStarted, "STARTED",
+			maxDur, "DURATION",
+			"CALLER",
+			ANSIReset)
+	} else {
+		fmt.Printf("  %s%-*s  %-*s  %-*s  %-*s  %-*s  %-*s  %s%s\n",
+			ANSIDim,
+			maxID, "APPLY ID",
+			maxDB, "DATABASE",
+			maxEnv, "ENV",
+			maxState, "STATE",
+			maxStarted, "STARTED",
+			maxDur, "DURATION",
+			"CALLER",
+			ANSIReset)
+	}
 
 	// Table rows
 	for _, a := range data.Applies {
@@ -770,25 +803,155 @@ func WriteStatusList(data StatusListData) {
 			coloredState = colorFn(padded)
 		}
 
-		fmt.Printf("  %-*s  %-*s  %-*s  %s  %-*s  %-*s  %s\n",
-			maxID, a.ApplyID,
-			maxDB, a.Database,
-			maxEnv, a.Environment,
-			coloredState,
-			maxStarted, formatStartedAt(a.StartedAt),
-			maxDur, formatApplyDuration(a.StartedAt, a.CompletedAt),
-			shortCaller(a.Caller))
+		if data.ShowExternalID {
+			fmt.Printf("  %-*s  %-*s  %-*s  %-*s  %s  %-*s  %-*s  %s\n",
+				maxID, a.ApplyID,
+				maxExternal, statusExternalID(a),
+				maxDB, a.Database,
+				maxEnv, a.Environment,
+				coloredState,
+				maxStarted, formatStartedAt(a.StartedAt),
+				maxDur, formatApplyDuration(a.StartedAt, a.CompletedAt),
+				shortCaller(a.Caller))
+		} else {
+			fmt.Printf("  %-*s  %-*s  %-*s  %s  %-*s  %-*s  %s\n",
+				maxID, a.ApplyID,
+				maxDB, a.Database,
+				maxEnv, a.Environment,
+				coloredState,
+				maxStarted, formatStartedAt(a.StartedAt),
+				maxDur, formatApplyDuration(a.StartedAt, a.CompletedAt),
+				shortCaller(a.Caller))
+		}
 	}
 
+	writeStatusListFooter(data)
+}
+
+func writeStatusListFooter(data StatusListData) {
 	fmt.Println()
 	if data.HasMore && data.Limit > 0 {
+		item := "schema changes"
+		if data.FailuresOnly {
+			item = "failed schema changes"
+		}
 		if data.MaxLimit > 0 && data.Limit >= data.MaxLimit {
-			fmt.Printf("%sShowing the %d most recent schema changes. This server caps status history at %d.%s\n", ANSIDim, data.Limit, data.MaxLimit, ANSIReset)
+			fmt.Printf("%sShowing the %d most recent %s. This server caps status history at %d.%s\n", ANSIDim, data.Limit, item, data.MaxLimit, ANSIReset)
 		} else {
-			fmt.Printf("%sShowing the %d most recent schema changes. Use --limit N to show more.%s\n", ANSIDim, data.Limit, ANSIReset)
+			fmt.Printf("%sShowing the %d most recent %s. Use --limit N to show more.%s\n", ANSIDim, data.Limit, item, ANSIReset)
 		}
 	}
 	fmt.Printf("%sUse 'schemabot status <apply_id>' to view details%s\n", ANSIDim, ANSIReset)
+}
+
+func writeFailedStatusList(data StatusListData) {
+	fmt.Printf("%sRecent failed schema changes%s\n", ANSIBold, ANSIReset)
+	fmt.Println()
+
+	maxID := 8        // "APPLY ID"
+	maxExternal := 11 // "EXTERNAL ID"
+	maxDB := 8        // "DATABASE"
+	maxEnv := 3       // "ENV"
+	maxState := 5     // "STATE"
+	maxFailed := 6    // "FAILED"
+	maxCaller := 6    // "CALLER"
+	maxReason := 6    // "REASON"
+	for _, a := range data.Applies {
+		maxID = maxLen(maxID, len(a.ApplyID))
+		if data.ShowExternalID {
+			maxExternal = maxLen(maxExternal, len(statusExternalID(a)))
+		}
+		maxDB = maxLen(maxDB, len(a.Database))
+		maxEnv = maxLen(maxEnv, len(a.Environment))
+		maxState = maxLen(maxState, len(state.Label(a.State)))
+		maxFailed = maxLen(maxFailed, len(formatFailureAt(a)))
+		maxCaller = maxLen(maxCaller, len(shortCaller(a.Caller)))
+		maxReason = maxLen(maxReason, len(compactStatusFailureReason(a.ErrorMessage)))
+	}
+
+	if data.ShowExternalID {
+		fmt.Printf("  %s%-*s  %-*s  %-*s  %-*s  %-*s  %-*s  %-*s  %-*s%s\n",
+			ANSIDim,
+			maxID, "APPLY ID",
+			maxExternal, "EXTERNAL ID",
+			maxDB, "DATABASE",
+			maxEnv, "ENV",
+			maxState, "STATE",
+			maxFailed, "FAILED",
+			maxCaller, "CALLER",
+			maxReason, "REASON",
+			ANSIReset)
+	} else {
+		fmt.Printf("  %s%-*s  %-*s  %-*s  %-*s  %-*s  %-*s  %-*s%s\n",
+			ANSIDim,
+			maxID, "APPLY ID",
+			maxDB, "DATABASE",
+			maxEnv, "ENV",
+			maxState, "STATE",
+			maxFailed, "FAILED",
+			maxCaller, "CALLER",
+			maxReason, "REASON",
+			ANSIReset)
+	}
+
+	for _, a := range data.Applies {
+		label := state.Label(a.State)
+		colorFn := stateColorFunc(a.State)
+		padded := fmt.Sprintf("%-*s", maxState, label)
+		coloredState := padded
+		if colorFn != nil {
+			coloredState = colorFn(padded)
+		}
+
+		if data.ShowExternalID {
+			fmt.Printf("  %-*s  %-*s  %-*s  %-*s  %s  %-*s  %-*s  %s\n",
+				maxID, a.ApplyID,
+				maxExternal, statusExternalID(a),
+				maxDB, a.Database,
+				maxEnv, a.Environment,
+				coloredState,
+				maxFailed, formatFailureAt(a),
+				maxCaller, shortCaller(a.Caller),
+				compactStatusFailureReason(a.ErrorMessage))
+		} else {
+			fmt.Printf("  %-*s  %-*s  %-*s  %s  %-*s  %-*s  %s\n",
+				maxID, a.ApplyID,
+				maxDB, a.Database,
+				maxEnv, a.Environment,
+				coloredState,
+				maxFailed, formatFailureAt(a),
+				maxCaller, shortCaller(a.Caller),
+				compactStatusFailureReason(a.ErrorMessage))
+		}
+	}
+}
+
+func statusExternalID(a ActiveApplyData) string {
+	if a.ExternalID == "" {
+		return "-"
+	}
+	return a.ExternalID
+}
+
+func formatFailureAt(a ActiveApplyData) string {
+	if a.CompletedAt != "" {
+		return formatStartedAt(a.CompletedAt)
+	}
+	if a.UpdatedAt != "" {
+		return formatStartedAt(a.UpdatedAt)
+	}
+	return formatStartedAt(a.StartedAt)
+}
+
+func compactStatusFailureReason(reason string) string {
+	reason = strings.Join(strings.Fields(reason), " ")
+	if reason == "" {
+		return "-"
+	}
+	if len(reason) <= maxStatusFailureReasonWidth {
+		return reason
+	}
+	return reason[:maxStatusFailureReasonWidth-3] + "..."
 }
 
 // formatStartedAt formats the started_at timestamp for display.

--- a/pkg/cmd/internal/templates/progress.go
+++ b/pkg/cmd/internal/templates/progress.go
@@ -708,6 +708,7 @@ type ActiveApplyData struct {
 type StatusListData struct {
 	ActiveCount int
 	Limit       int
+	MaxLimit    int
 	HasMore     bool
 	Applies     []ActiveApplyData
 }
@@ -781,7 +782,11 @@ func WriteStatusList(data StatusListData) {
 
 	fmt.Println()
 	if data.HasMore && data.Limit > 0 {
-		fmt.Printf("%sShowing the %d most recent schema changes. Use --limit N to show more.%s\n", ANSIDim, data.Limit, ANSIReset)
+		if data.MaxLimit > 0 && data.Limit >= data.MaxLimit {
+			fmt.Printf("%sShowing the %d most recent schema changes. This server caps status history at %d.%s\n", ANSIDim, data.Limit, data.MaxLimit, ANSIReset)
+		} else {
+			fmt.Printf("%sShowing the %d most recent schema changes. Use --limit N to show more.%s\n", ANSIDim, data.Limit, ANSIReset)
+		}
 	}
 	fmt.Printf("%sUse 'schemabot status <apply_id>' to view details%s\n", ANSIDim, ANSIReset)
 }

--- a/pkg/cmd/internal/templates/progress.go
+++ b/pkg/cmd/internal/templates/progress.go
@@ -13,7 +13,7 @@ import (
 	"github.com/block/schemabot/pkg/ui"
 )
 
-const maxStatusFailureReasonWidth = 120
+const maxStatusFailureReasonWidth = 240
 
 // Indentation for progress rendering.
 // indentTable is the prefix for table names. Aligns with keyspace name after "── " in headers.
@@ -731,7 +731,6 @@ func WriteStatusList(data StatusListData) {
 	}
 	if data.FailuresOnly {
 		writeFailedStatusList(data)
-		writeStatusListFooter(data)
 		return
 	}
 
@@ -848,80 +847,27 @@ func writeFailedStatusList(data StatusListData) {
 	fmt.Printf("%sRecent failed schema changes%s\n", ANSIBold, ANSIReset)
 	fmt.Println()
 
-	maxID := 8        // "APPLY ID"
-	maxExternal := 11 // "EXTERNAL ID"
-	maxDB := 8        // "DATABASE"
-	maxEnv := 3       // "ENV"
-	maxState := 5     // "STATE"
-	maxFailed := 6    // "FAILED"
-	maxCaller := 6    // "CALLER"
-	maxReason := 6    // "REASON"
-	for _, a := range data.Applies {
-		maxID = maxLen(maxID, len(a.ApplyID))
-		if data.ShowExternalID {
-			maxExternal = maxLen(maxExternal, len(statusExternalID(a)))
+	for i, a := range data.Applies {
+		if i > 0 {
+			fmt.Println()
 		}
-		maxDB = maxLen(maxDB, len(a.Database))
-		maxEnv = maxLen(maxEnv, len(a.Environment))
-		maxState = maxLen(maxState, len(state.Label(a.State)))
-		maxFailed = maxLen(maxFailed, len(formatFailureAt(a)))
-		maxCaller = maxLen(maxCaller, len(shortCaller(a.Caller)))
-		maxReason = maxLen(maxReason, len(compactStatusFailureReason(a.ErrorMessage)))
+		fmt.Printf("%s %s: %s (%s) [%s] %s\n",
+			a.Database,
+			a.Environment,
+			state.Label(a.State),
+			statusFailureActor(a, data.ShowExternalID),
+			formatFailureTimestamp(a),
+			compactStatusFailureReason(a.ErrorMessage))
+		fmt.Printf("schemabot status %s\n", a.ApplyID)
 	}
 
-	if data.ShowExternalID {
-		fmt.Printf("  %s%-*s  %-*s  %-*s  %-*s  %-*s  %-*s  %-*s  %-*s%s\n",
-			ANSIDim,
-			maxID, "APPLY ID",
-			maxExternal, "EXTERNAL ID",
-			maxDB, "DATABASE",
-			maxEnv, "ENV",
-			maxState, "STATE",
-			maxFailed, "FAILED",
-			maxCaller, "CALLER",
-			maxReason, "REASON",
-			ANSIReset)
-	} else {
-		fmt.Printf("  %s%-*s  %-*s  %-*s  %-*s  %-*s  %-*s  %-*s%s\n",
-			ANSIDim,
-			maxID, "APPLY ID",
-			maxDB, "DATABASE",
-			maxEnv, "ENV",
-			maxState, "STATE",
-			maxFailed, "FAILED",
-			maxCaller, "CALLER",
-			maxReason, "REASON",
-			ANSIReset)
-	}
-
-	for _, a := range data.Applies {
-		label := state.Label(a.State)
-		colorFn := stateColorFunc(a.State)
-		padded := fmt.Sprintf("%-*s", maxState, label)
-		coloredState := padded
-		if colorFn != nil {
-			coloredState = colorFn(padded)
-		}
-
-		if data.ShowExternalID {
-			fmt.Printf("  %-*s  %-*s  %-*s  %-*s  %s  %-*s  %-*s  %s\n",
-				maxID, a.ApplyID,
-				maxExternal, statusExternalID(a),
-				maxDB, a.Database,
-				maxEnv, a.Environment,
-				coloredState,
-				maxFailed, formatFailureAt(a),
-				maxCaller, shortCaller(a.Caller),
-				compactStatusFailureReason(a.ErrorMessage))
+	if data.HasMore && data.Limit > 0 {
+		fmt.Println()
+		item := "failed schema changes"
+		if data.MaxLimit > 0 && data.Limit >= data.MaxLimit {
+			fmt.Printf("%sShowing the %d most recent %s. This server caps status history at %d.%s\n", ANSIDim, data.Limit, item, data.MaxLimit, ANSIReset)
 		} else {
-			fmt.Printf("  %-*s  %-*s  %-*s  %s  %-*s  %-*s  %s\n",
-				maxID, a.ApplyID,
-				maxDB, a.Database,
-				maxEnv, a.Environment,
-				coloredState,
-				maxFailed, formatFailureAt(a),
-				maxCaller, shortCaller(a.Caller),
-				compactStatusFailureReason(a.ErrorMessage))
+			fmt.Printf("%sShowing the %d most recent %s. Use --limit N to show more.%s\n", ANSIDim, data.Limit, item, ANSIReset)
 		}
 	}
 }
@@ -933,14 +879,30 @@ func statusExternalID(a ActiveApplyData) string {
 	return a.ExternalID
 }
 
-func formatFailureAt(a ActiveApplyData) string {
-	if a.CompletedAt != "" {
-		return formatStartedAt(a.CompletedAt)
+func statusFailureActor(a ActiveApplyData, showExternalID bool) string {
+	caller := shortCaller(a.Caller)
+	if !showExternalID {
+		return caller
 	}
-	if a.UpdatedAt != "" {
-		return formatStartedAt(a.UpdatedAt)
+	return caller + "; external_id=" + statusExternalID(a)
+}
+
+func formatFailureTimestamp(a ActiveApplyData) string {
+	timestamp := a.CompletedAt
+	if timestamp == "" {
+		timestamp = a.UpdatedAt
 	}
-	return formatStartedAt(a.StartedAt)
+	if timestamp == "" {
+		timestamp = a.StartedAt
+	}
+	if timestamp == "" {
+		return "-"
+	}
+	t, err := time.Parse(time.RFC3339, timestamp)
+	if err != nil {
+		return timestamp
+	}
+	return t.UTC().Format("2006-01-02 15:04:05 UTC")
 }
 
 func compactStatusFailureReason(reason string) string {

--- a/pkg/cmd/internal/templates/progress.go
+++ b/pkg/cmd/internal/templates/progress.go
@@ -707,6 +707,8 @@ type ActiveApplyData struct {
 // StatusListData contains data for rendering the status list.
 type StatusListData struct {
 	ActiveCount int
+	Limit       int
+	HasMore     bool
 	Applies     []ActiveApplyData
 }
 
@@ -778,6 +780,9 @@ func WriteStatusList(data StatusListData) {
 	}
 
 	fmt.Println()
+	if data.HasMore && data.Limit > 0 {
+		fmt.Printf("%sShowing the %d most recent schema changes. Use --limit N to show more.%s\n", ANSIDim, data.Limit, ANSIReset)
+	}
 	fmt.Printf("%sUse 'schemabot status <apply_id>' to view details%s\n", ANSIDim, ANSIReset)
 }
 

--- a/pkg/cmd/internal/templates/progress_states_test.go
+++ b/pkg/cmd/internal/templates/progress_states_test.go
@@ -84,6 +84,64 @@ func TestWriteStatusListHasMoreFooterAtMaxLimit(t *testing.T) {
 	assert.NotContains(t, output, "Use --limit N to show more.")
 }
 
+func TestWriteStatusListExternalID(t *testing.T) {
+	output := captureStdout(t, func() {
+		WriteStatusList(StatusListData{
+			ActiveCount:    0,
+			Limit:          20,
+			MaxLimit:       1000,
+			HasMore:        false,
+			ShowExternalID: true,
+			Applies: []ActiveApplyData{
+				{
+					ApplyID:     "apply-complete",
+					ExternalID:  "external-123",
+					Database:    "orders",
+					Environment: "staging",
+					State:       state.Apply.Completed,
+					StartedAt:   "2026-05-28T12:00:00Z",
+					CompletedAt: "2026-05-28T12:00:02Z",
+					Caller:      "cli",
+				},
+			},
+		})
+	})
+
+	assert.Contains(t, output, "EXTERNAL ID")
+	assert.Contains(t, output, "external-123")
+	assert.Contains(t, output, "apply-complete")
+}
+
+func TestWriteStatusListFailedOnly(t *testing.T) {
+	output := captureStdout(t, func() {
+		WriteStatusList(StatusListData{
+			Limit:        20,
+			MaxLimit:     1000,
+			FailuresOnly: true,
+			Applies: []ActiveApplyData{
+				{
+					ApplyID:      "apply-failed",
+					ExternalID:   "external-failed",
+					Database:     "payments",
+					Environment:  "staging",
+					State:        state.Apply.Failed,
+					StartedAt:    "2026-05-28T11:00:00Z",
+					CompletedAt:  "2026-05-28T11:00:03Z",
+					Caller:       "github:alice",
+					ErrorMessage: "failed to apply schema change\nbecause duplicate column name 'status'",
+				},
+			},
+		})
+	})
+
+	assert.Contains(t, output, "Recent failed schema changes")
+	assert.Contains(t, output, "apply-failed")
+	assert.Contains(t, output, "payments")
+	assert.Contains(t, output, "github:alice")
+	assert.Contains(t, output, "failed to apply schema change because duplicate column name 'status'")
+	assert.Contains(t, output, "Use 'schemabot status <apply_id>' to view details")
+}
+
 func captureStdout(t *testing.T, fn func()) string {
 	t.Helper()
 

--- a/pkg/cmd/internal/templates/progress_states_test.go
+++ b/pkg/cmd/internal/templates/progress_states_test.go
@@ -37,6 +37,7 @@ func TestWriteStatusListHasMoreFooter(t *testing.T) {
 		WriteStatusList(StatusListData{
 			ActiveCount: 0,
 			Limit:       20,
+			MaxLimit:    1000,
 			HasMore:     true,
 			Applies: []ActiveApplyData{
 				{
@@ -56,6 +57,31 @@ func TestWriteStatusListHasMoreFooter(t *testing.T) {
 	assert.Contains(t, output, "apply-example")
 	assert.Contains(t, output, "Showing the 20 most recent schema changes. Use --limit N to show more.")
 	assert.Contains(t, output, "Use 'schemabot status <apply_id>' to view details")
+}
+
+func TestWriteStatusListHasMoreFooterAtMaxLimit(t *testing.T) {
+	output := captureStdout(t, func() {
+		WriteStatusList(StatusListData{
+			ActiveCount: 0,
+			Limit:       1000,
+			MaxLimit:    1000,
+			HasMore:     true,
+			Applies: []ActiveApplyData{
+				{
+					ApplyID:     "apply-example",
+					Database:    "orders",
+					Environment: "staging",
+					State:       state.Apply.Completed,
+					StartedAt:   "2026-05-28T12:00:00Z",
+					CompletedAt: "2026-05-28T12:00:02Z",
+					Caller:      "cli",
+				},
+			},
+		})
+	})
+
+	assert.Contains(t, output, "Showing the 1000 most recent schema changes. This server caps status history at 1000.")
+	assert.NotContains(t, output, "Use --limit N to show more.")
 }
 
 func captureStdout(t *testing.T, fn func()) string {

--- a/pkg/cmd/internal/templates/progress_states_test.go
+++ b/pkg/cmd/internal/templates/progress_states_test.go
@@ -115,9 +115,10 @@ func TestWriteStatusListExternalID(t *testing.T) {
 func TestWriteStatusListFailedOnly(t *testing.T) {
 	output := captureStdout(t, func() {
 		WriteStatusList(StatusListData{
-			Limit:        20,
-			MaxLimit:     1000,
-			FailuresOnly: true,
+			Limit:          20,
+			MaxLimit:       1000,
+			FailuresOnly:   true,
+			ShowExternalID: true,
 			Applies: []ActiveApplyData{
 				{
 					ApplyID:      "apply-failed",
@@ -135,11 +136,12 @@ func TestWriteStatusListFailedOnly(t *testing.T) {
 	})
 
 	assert.Contains(t, output, "Recent failed schema changes")
-	assert.Contains(t, output, "apply-failed")
-	assert.Contains(t, output, "payments")
-	assert.Contains(t, output, "github:alice")
+	assert.Contains(t, output, "payments staging: Failed (github:alice; external_id=external-failed) [2026-05-28 11:00:03 UTC]")
 	assert.Contains(t, output, "failed to apply schema change because duplicate column name 'status'")
-	assert.Contains(t, output, "Use 'schemabot status <apply_id>' to view details")
+	assert.Contains(t, output, "schemabot status apply-failed")
+	assert.NotContains(t, output, "APPLY ID")
+	assert.NotContains(t, output, "REASON")
+	assert.NotContains(t, output, "Use 'schemabot status <apply_id>' to view details")
 }
 
 func captureStdout(t *testing.T, fn func()) string {

--- a/pkg/cmd/internal/templates/progress_states_test.go
+++ b/pkg/cmd/internal/templates/progress_states_test.go
@@ -1,12 +1,15 @@
 package templates
 
 import (
+	"io"
+	"os"
 	"strings"
 	"testing"
 
 	"github.com/block/schemabot/pkg/state"
 	"github.com/block/schemabot/pkg/ui"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestLabel_PlanetScalePhases(t *testing.T) {
@@ -27,6 +30,53 @@ func TestFormatProgressState_PlanetScalePhases(t *testing.T) {
 	assert.Contains(t, FormatProgressState(state.Apply.ValidatingDeployRequest), "Validating deploy request")
 	assert.Contains(t, FormatProgressState(state.Apply.Cancelled), "Cancelled")
 	assert.Contains(t, FormatProgressState(state.Apply.FailedRetryable), "Retrying")
+}
+
+func TestWriteStatusListHasMoreFooter(t *testing.T) {
+	output := captureStdout(t, func() {
+		WriteStatusList(StatusListData{
+			ActiveCount: 0,
+			Limit:       20,
+			HasMore:     true,
+			Applies: []ActiveApplyData{
+				{
+					ApplyID:     "apply-example",
+					Database:    "orders",
+					Environment: "staging",
+					State:       state.Apply.Completed,
+					StartedAt:   "2026-05-28T12:00:00Z",
+					CompletedAt: "2026-05-28T12:00:02Z",
+					Caller:      "cli",
+				},
+			},
+		})
+	})
+
+	assert.Contains(t, output, "Recent schema changes")
+	assert.Contains(t, output, "apply-example")
+	assert.Contains(t, output, "Showing the 20 most recent schema changes. Use --limit N to show more.")
+	assert.Contains(t, output, "Use 'schemabot status <apply_id>' to view details")
+}
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	original := os.Stdout
+	read, write, err := os.Pipe()
+	require.NoError(t, err)
+	defer func() {
+		os.Stdout = original
+	}()
+
+	os.Stdout = write
+	fn()
+	require.NoError(t, write.Close())
+
+	output, err := io.ReadAll(read)
+	require.NoError(t, err)
+	require.NoError(t, read.Close())
+
+	return string(output)
 }
 
 func TestProgressSymbol(t *testing.T) {

--- a/pkg/schema/mysql/applies.sql
+++ b/pkg/schema/mysql/applies.sql
@@ -27,6 +27,8 @@ CREATE TABLE `applies` (
   KEY `idx_plan_id` (`plan_id`),
   KEY `idx_database_env` (`database_name`,`database_type`,`environment`),
   KEY `idx_repo_pr` (`repository`,`pull_request`),
+  KEY `idx_created_id` (`created_at`,`id`),
+  KEY `idx_environment_created_id` (`environment`,`created_at`,`id`),
   KEY `idx_completed_at_state` (`completed_at`,`state`),
   KEY `idx_state` (`state`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci

--- a/pkg/schema/mysql/applies.sql
+++ b/pkg/schema/mysql/applies.sql
@@ -29,6 +29,7 @@ CREATE TABLE `applies` (
   KEY `idx_repo_pr` (`repository`,`pull_request`),
   KEY `idx_created_id` (`created_at`,`id`),
   KEY `idx_environment_created_id` (`environment`,`created_at`,`id`),
-  KEY `idx_completed_at_state` (`completed_at`,`state`),
-  KEY `idx_state` (`state`)
+  KEY `idx_state_created_id` (`state`,`created_at`,`id`),
+  KEY `idx_environment_state_created_id` (`environment`,`state`,`created_at`,`id`),
+  KEY `idx_completed_at_state` (`completed_at`,`state`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci

--- a/pkg/storage/mysqlstore/applies.go
+++ b/pkg/storage/mysqlstore/applies.go
@@ -538,14 +538,21 @@ func (s *applyStore) GetInProgress(ctx context.Context) ([]*storage.Apply, error
 	return scanApplies(rows)
 }
 
-// GetRecent returns the most recent applies across all databases, ordered by start time desc.
-func (s *applyStore) GetRecent(ctx context.Context, limit int) ([]*storage.Apply, error) {
-	rows, err := s.db.QueryContext(ctx, `
-		SELECT `+applyColumns+`
+// GetRecent returns the most recent applies across all databases, ordered by creation time desc.
+func (s *applyStore) GetRecent(ctx context.Context, filter storage.RecentAppliesFilter) ([]*storage.Apply, error) {
+	query := `
+		SELECT ` + applyColumns + `
 		FROM applies
-		ORDER BY COALESCE(started_at, created_at) DESC
-		LIMIT ?
-	`, limit)
+	`
+	var args []any
+	if filter.Environment != "" {
+		query += " WHERE environment = ?"
+		args = append(args, filter.Environment)
+	}
+	query += " ORDER BY created_at DESC, id DESC LIMIT ?"
+	args = append(args, filter.Limit)
+
+	rows, err := s.db.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storage/mysqlstore/applies.go
+++ b/pkg/storage/mysqlstore/applies.go
@@ -545,9 +545,17 @@ func (s *applyStore) GetRecent(ctx context.Context, filter storage.RecentApplies
 		FROM applies
 	`
 	var args []any
+	var where []string
 	if filter.Environment != "" {
-		query += " WHERE environment = ?"
+		where = append(where, "environment = ?")
 		args = append(args, filter.Environment)
+	}
+	if len(filter.States) > 0 {
+		where = append(where, fmt.Sprintf("state IN (%s)", placeholders(len(filter.States))))
+		args = append(args, stringArgs(filter.States)...)
+	}
+	if len(where) > 0 {
+		query += " WHERE " + strings.Join(where, " AND ")
 	}
 	query += " ORDER BY created_at DESC, id DESC LIMIT ?"
 	args = append(args, filter.Limit)

--- a/pkg/storage/mysqlstore/applies_test.go
+++ b/pkg/storage/mysqlstore/applies_test.go
@@ -468,6 +468,31 @@ func TestApplyStore_GetByDatabase(t *testing.T) {
 	require.Equal(t, "apply_db1", applies[0].ApplyIdentifier)
 }
 
+func TestApplyStore_GetRecentLimitAndEnvironment(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "recentdb", "mysql", "staging")
+	createTestApplyWithStateAndEnv(t, store, lock, "apply_recent_staging_old", 210, state.Apply.Completed, "staging")
+	createTestApplyWithStateAndEnv(t, store, lock, "apply_recent_production", 211, state.Apply.Completed, "production")
+	createTestApplyWithStateAndEnv(t, store, lock, "apply_recent_staging_new", 212, state.Apply.Completed, "staging")
+
+	applies, err := store.Applies().GetRecent(ctx, storage.RecentAppliesFilter{
+		Limit:       1,
+		Environment: "staging",
+	})
+	require.NoError(t, err)
+	require.Len(t, applies, 1)
+	assert.Equal(t, "apply_recent_staging_new", applies[0].ApplyIdentifier)
+
+	applies, err = store.Applies().GetRecent(ctx, storage.RecentAppliesFilter{Limit: 2})
+	require.NoError(t, err)
+	require.Len(t, applies, 2)
+	assert.Equal(t, "apply_recent_staging_new", applies[0].ApplyIdentifier)
+	assert.Equal(t, "apply_recent_production", applies[1].ApplyIdentifier)
+}
+
 func TestApplyStore_Update(t *testing.T) {
 	clearTables(t)
 	ctx := t.Context()

--- a/pkg/storage/mysqlstore/applies_test.go
+++ b/pkg/storage/mysqlstore/applies_test.go
@@ -477,6 +477,7 @@ func TestApplyStore_GetRecentLimitAndEnvironment(t *testing.T) {
 	createTestApplyWithStateAndEnv(t, store, lock, "apply_recent_staging_old", 210, state.Apply.Completed, "staging")
 	createTestApplyWithStateAndEnv(t, store, lock, "apply_recent_production", 211, state.Apply.Completed, "production")
 	createTestApplyWithStateAndEnv(t, store, lock, "apply_recent_staging_new", 212, state.Apply.Completed, "staging")
+	createTestApplyWithStateAndEnv(t, store, lock, "apply_recent_staging_failed", 213, state.Apply.Failed, "staging")
 
 	applies, err := store.Applies().GetRecent(ctx, storage.RecentAppliesFilter{
 		Limit:       1,
@@ -484,13 +485,22 @@ func TestApplyStore_GetRecentLimitAndEnvironment(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Len(t, applies, 1)
-	assert.Equal(t, "apply_recent_staging_new", applies[0].ApplyIdentifier)
+	assert.Equal(t, "apply_recent_staging_failed", applies[0].ApplyIdentifier)
 
 	applies, err = store.Applies().GetRecent(ctx, storage.RecentAppliesFilter{Limit: 2})
 	require.NoError(t, err)
 	require.Len(t, applies, 2)
-	assert.Equal(t, "apply_recent_staging_new", applies[0].ApplyIdentifier)
-	assert.Equal(t, "apply_recent_production", applies[1].ApplyIdentifier)
+	assert.Equal(t, "apply_recent_staging_failed", applies[0].ApplyIdentifier)
+	assert.Equal(t, "apply_recent_staging_new", applies[1].ApplyIdentifier)
+
+	applies, err = store.Applies().GetRecent(ctx, storage.RecentAppliesFilter{
+		Limit:       10,
+		Environment: "staging",
+		States:      []string{state.Apply.Failed, state.Apply.FailedRetryable},
+	})
+	require.NoError(t, err)
+	require.Len(t, applies, 1)
+	assert.Equal(t, "apply_recent_staging_failed", applies[0].ApplyIdentifier)
 }
 
 func TestApplyStore_Update(t *testing.T) {

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -240,6 +240,7 @@ type ApplyStore interface {
 type RecentAppliesFilter struct {
 	Limit       int
 	Environment string
+	States      []string
 }
 
 // RetryableExpirationReason identifies why scheduler retry recovery stopped.

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -196,9 +196,9 @@ type ApplyStore interface {
 	// and environment.
 	Update(ctx context.Context, apply *Apply) error
 
-	// GetRecent returns the most recent applies across all databases, ordered by start time desc.
+	// GetRecent returns the most recent applies across all databases, ordered by creation time desc.
 	// Used by `schemabot status` (no args) to show recent activity.
-	GetRecent(ctx context.Context, limit int) ([]*Apply, error)
+	GetRecent(ctx context.Context, filter RecentAppliesFilter) ([]*Apply, error)
 
 	// GetInProgress returns all applies in non-terminal states.
 	// Note: For recovery, use FindNextApply which handles locking.
@@ -234,6 +234,12 @@ type ApplyStore interface {
 
 	// DeleteByPR removes all applies for a PR (cleanup on PR close/merge).
 	DeleteByPR(ctx context.Context, repo string, pr int) error
+}
+
+// RecentAppliesFilter controls recent apply queries for status views.
+type RecentAppliesFilter struct {
+	Limit       int
+	Environment string
 }
 
 // RetryableExpirationReason identifies why scheduler retry recovery stopped.


### PR DESCRIPTION
Bumps the default `schemabot status` recent-history window from 10 to 20 applies and adds bounded controls for browsing recent activity. Operators can use `--limit`/`-n` for more history, `--failed` to focus on failed or retrying applies, and `--external-id` when they need to correlate rows with remote apply identifiers.

The `--failed` view now renders a triage list instead of a dense table, keeping the failure reason next to the apply and showing the follow-up command inline.

```text
Recent failed schema changes

orders staging: Retrying (github:operator) [2026-05-28 16:45:00 UTC] temporary engine error while applying schema change
schemabot status apply-1111222233334444

billing staging: Failed (github:operator) [2026-05-28 15:12:03 UTC] duplicate column name status
schemabot status apply-5555666677778888
```

The status output tells operators when more rows exist and when they have already reached the server's maximum history window. Recent-history reads use indexes that cover global, environment-filtered, and state-filtered status views, with CLI integration coverage for each status mode.

🤖 Generated by Codex (GPT-5).
