### PR TITLE
feat(storage): add durable control requests

### DIFF
--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -34,6 +34,7 @@ func (m *mockStorage) Plans() storage.PlanStore                      { return ni
 func (m *mockStorage) Applies() storage.ApplyStore                   { return nil }
 func (m *mockStorage) Tasks() storage.TaskStore                      { return nil }
 func (m *mockStorage) ApplyLogs() storage.ApplyLogStore              { return nil }
+func (m *mockStorage) ControlRequests() storage.ControlRequestStore  { return nil }
 func (m *mockStorage) ApplyComments() storage.ApplyCommentStore      { return nil }
 func (m *mockStorage) VitessApplyData() storage.VitessApplyDataStore { return nil }
 func (m *mockStorage) Checks() storage.CheckStore                    { return nil }

--- a/pkg/schema/mysql/apply_control_requests.sql
+++ b/pkg/schema/mysql/apply_control_requests.sql
@@ -1,0 +1,15 @@
+CREATE TABLE `apply_control_requests` (
+  `id` bigint unsigned NOT NULL AUTO_INCREMENT,
+  `apply_id` bigint unsigned NOT NULL,
+  `operation` varchar(50) NOT NULL,
+  `status` varchar(50) NOT NULL,
+  `requested_by` varchar(255) NOT NULL DEFAULT '',
+  `error_message` text,
+  `metadata` json NOT NULL,
+  `completed_at` datetime DEFAULT NULL,
+  `created_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_apply_control_request_apply_operation` (`apply_id`,`operation`),
+  KEY `idx_apply_control_request_status` (`status`,`created_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci

--- a/pkg/storage/README.md
+++ b/pkg/storage/README.md
@@ -1,22 +1,23 @@
 # storage
 
-Package `storage` defines the persistence interfaces for SchemaBot. All state — locks, plans, applies, tasks, logs, settings — flows through these interfaces. The MySQL implementation lives in [`storage/mysqlstore`](./mysqlstore/).
+Package `storage` defines the persistence interfaces for SchemaBot. All state — locks, plans, applies, tasks, logs, control requests, settings — flows through these interfaces. The MySQL implementation lives in [`storage/mysqlstore`](./mysqlstore/).
 
 ## Interface Hierarchy
 
-`Storage` is the top-level interface that provides access to seven specialized stores:
+`Storage` is the top-level interface that provides access to specialized stores:
 
 ```go
 type Storage interface {
-    Locks()     LockStore
-    Plans()     PlanStore
-    Applies()   ApplyStore
-    Tasks()     TaskStore
-    ApplyLogs() ApplyLogStore
-    Checks()    CheckStore
-    Settings()  SettingsStore
-    Ping(ctx)   error
-    Close()     error
+    Locks()           LockStore
+    Plans()           PlanStore
+    Applies()         ApplyStore
+    Tasks()           TaskStore
+    ApplyLogs()       ApplyLogStore
+    ControlRequests() ControlRequestStore
+    Checks()          CheckStore
+    Settings()        SettingsStore
+    Ping(ctx)         error
+    Close()           error
 }
 ```
 
@@ -27,6 +28,7 @@ type Storage interface {
 | `ApplyStore` | Schema change execution state, heartbeat-based leasing |
 | `TaskStore` | Individual DDL tasks within an apply, progress tracking |
 | `ApplyLogStore` | Audit trail (state transitions, errors, progress events) |
+| `ControlRequestStore` | Durable user control intent that can be recovered by workers |
 | `CheckStore` | GitHub status check state |
 | `SettingsStore` | Admin-level key-value settings |
 
@@ -61,6 +63,7 @@ The apply store supports crash recovery through heartbeat-based leasing:
 - **Apply**: Links to plan and lock, state, environment, engine, options (defer_cutover, volume)
 - **Task**: Single DDL within an apply — table name, DDL, state, progress (rows copied/total, ETA)
 - **ApplyLog**: Level, event type, source (schemabot/spirit), message, state transitions
+- **ApplyControlRequest**: Durable control operation intent and processing status
 
 ## MySQL Implementation
 

--- a/pkg/storage/mysqlstore/control_requests.go
+++ b/pkg/storage/mysqlstore/control_requests.go
@@ -23,10 +23,20 @@ func (s *controlRequestStore) RequestPending(ctx context.Context, req *storage.A
 		return controlReq, alreadyPending, err
 	}
 
-	// At read committed, two first-time requests can both miss the row before
-	// one insert wins the unique key. Retry once so the loser reads the pending
-	// request and returns an already-requested response.
-	return s.requestPending(ctx, req)
+	slog.DebugContext(ctx, "retrying control request after duplicate insert",
+		"apply_id", req.ApplyID,
+		"operation", req.Operation)
+
+	// requestPending opens its transaction at READ COMMITTED. The unique key on
+	// apply_id + operation is the durable guard when two first-time callers both
+	// observe no row and race to insert. Retry once so the losing insert re-reads
+	// the winning row and returns "already requested"; if the retry also fails,
+	// return that storage error instead of hiding an unexpected conflict.
+	controlReq, alreadyPending, err = s.requestPending(ctx, req)
+	if err != nil {
+		return nil, false, fmt.Errorf("retry control request after duplicate insert for apply %d operation %s: %w", req.ApplyID, req.Operation, err)
+	}
+	return controlReq, alreadyPending, nil
 }
 
 func (s *controlRequestStore) requestPending(ctx context.Context, req *storage.ApplyControlRequest) (*storage.ApplyControlRequest, bool, error) {

--- a/pkg/storage/mysqlstore/control_requests.go
+++ b/pkg/storage/mysqlstore/control_requests.go
@@ -1,0 +1,179 @@
+package mysqlstore
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/block/schemabot/pkg/storage"
+)
+
+const controlRequestColumns = `id, apply_id, operation, status,
+	requested_by, error_message, metadata, completed_at, created_at, updated_at`
+
+type controlRequestStore struct {
+	db *sql.DB
+}
+
+func (s *controlRequestStore) RequestPending(ctx context.Context, req *storage.ApplyControlRequest) (*storage.ApplyControlRequest, bool, error) {
+	controlReq, alreadyPending, err := s.requestPending(ctx, req)
+	if err == nil || !isDuplicateKeyError(err) {
+		return controlReq, alreadyPending, err
+	}
+
+	// At read committed, two first-time requests can both miss the row before
+	// one insert wins the unique key. Retry once so the loser reads the pending
+	// request and returns an already-requested response.
+	return s.requestPending(ctx, req)
+}
+
+func (s *controlRequestStore) requestPending(ctx context.Context, req *storage.ApplyControlRequest) (*storage.ApplyControlRequest, bool, error) {
+	metadata := nullJSON(req.Metadata)
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelReadCommitted})
+	if err != nil {
+		return nil, false, fmt.Errorf("begin control request transaction for apply %d operation %s: %w", req.ApplyID, req.Operation, err)
+	}
+	defer rollbackControlRequestTx(ctx, tx, "request pending")
+
+	existing, err := s.getByApplyOperationForUpdate(ctx, tx, req.ApplyID, req.Operation)
+	if err != nil {
+		return nil, false, err
+	}
+	if existing != nil && existing.Status == storage.ControlRequestPending {
+		if err := tx.Commit(); err != nil {
+			return nil, false, fmt.Errorf("commit pending control request read for apply %d operation %s: %w", req.ApplyID, req.Operation, err)
+		}
+		return existing, true, nil
+	}
+	if existing != nil {
+		_, err := tx.ExecContext(ctx, `
+			UPDATE apply_control_requests
+			SET status = ?, requested_by = ?, error_message = NULL, metadata = ?,
+				completed_at = NULL, updated_at = NOW()
+			WHERE id = ?
+		`, storage.ControlRequestPending, req.RequestedBy, metadata, existing.ID)
+		if err != nil {
+			return nil, false, fmt.Errorf("reset control request for apply %d operation %s to pending: %w", req.ApplyID, req.Operation, err)
+		}
+		updated, err := s.getByIDForUpdate(ctx, tx, existing.ID)
+		if err != nil {
+			return nil, false, err
+		}
+		if err := tx.Commit(); err != nil {
+			return nil, false, fmt.Errorf("commit reset control request for apply %d operation %s: %w", req.ApplyID, req.Operation, err)
+		}
+		return updated, false, nil
+	}
+
+	result, err := tx.ExecContext(ctx, `
+		INSERT INTO apply_control_requests (
+			apply_id, operation, status, requested_by, error_message, metadata
+		) VALUES (?, ?, ?, ?, ?, ?)
+	`,
+		req.ApplyID, req.Operation, storage.ControlRequestPending,
+		req.RequestedBy, nullString(req.ErrorMessage), metadata,
+	)
+	if err != nil {
+		return nil, false, fmt.Errorf("create control request for apply %d operation %s: %w", req.ApplyID, req.Operation, err)
+	}
+	id, err := result.LastInsertId()
+	if err != nil {
+		return nil, false, fmt.Errorf("read control request id for apply %d operation %s: %w", req.ApplyID, req.Operation, err)
+	}
+	req.ID = id
+	created, err := s.getByIDForUpdate(ctx, tx, id)
+	if err != nil {
+		return nil, false, err
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, false, fmt.Errorf("commit control request for apply %d operation %s: %w", req.ApplyID, req.Operation, err)
+	}
+	return created, false, nil
+}
+
+func (s *controlRequestStore) GetPending(ctx context.Context, applyID int64, operation storage.ControlOperation) (*storage.ApplyControlRequest, error) {
+	row := s.db.QueryRowContext(ctx, `
+		SELECT `+controlRequestColumns+`
+		FROM apply_control_requests
+		WHERE apply_id = ? AND operation = ? AND status = ?
+	`, applyID, operation, storage.ControlRequestPending)
+	return scanControlRequest(row)
+}
+
+func (s *controlRequestStore) CompletePending(ctx context.Context, applyID int64, operation storage.ControlOperation) error {
+	_, err := s.db.ExecContext(ctx, `
+		UPDATE apply_control_requests
+		SET status = ?, completed_at = COALESCE(completed_at, NOW()), updated_at = NOW()
+		WHERE apply_id = ? AND operation = ? AND status = ?
+	`, storage.ControlRequestCompleted, applyID, operation, storage.ControlRequestPending)
+	if err != nil {
+		return fmt.Errorf("complete pending control requests for apply %d operation %s: %w", applyID, operation, err)
+	}
+	return nil
+}
+
+func (s *controlRequestStore) getByIDForUpdate(ctx context.Context, tx *sql.Tx, id int64) (*storage.ApplyControlRequest, error) {
+	row := tx.QueryRowContext(ctx, `
+		SELECT `+controlRequestColumns+`
+		FROM apply_control_requests
+		WHERE id = ?
+		FOR UPDATE
+	`, id)
+	req, err := scanControlRequest(row)
+	if err != nil {
+		return nil, fmt.Errorf("get control request %d: %w", id, err)
+	}
+	return req, nil
+}
+
+func (s *controlRequestStore) getByApplyOperationForUpdate(
+	ctx context.Context,
+	tx *sql.Tx,
+	applyID int64,
+	operation storage.ControlOperation,
+) (*storage.ApplyControlRequest, error) {
+	row := tx.QueryRowContext(ctx, `
+		SELECT `+controlRequestColumns+`
+		FROM apply_control_requests
+		WHERE apply_id = ? AND operation = ?
+		FOR UPDATE
+	`, applyID, operation)
+	req, err := scanControlRequest(row)
+	if err != nil {
+		return nil, fmt.Errorf("get control request for apply %d operation %s: %w", applyID, operation, err)
+	}
+	return req, nil
+}
+
+func rollbackControlRequestTx(ctx context.Context, tx *sql.Tx, operation string) {
+	if err := tx.Rollback(); err != nil && !errors.Is(err, sql.ErrTxDone) {
+		slog.WarnContext(ctx, "failed to roll back control request transaction", "operation", operation, "error", err)
+	}
+}
+
+func scanControlRequest(s scanner) (*storage.ApplyControlRequest, error) {
+	var req storage.ApplyControlRequest
+	var errorMessage sql.NullString
+	var completedAt sql.NullTime
+
+	err := s.Scan(
+		&req.ID, &req.ApplyID, &req.Operation, &req.Status,
+		&req.RequestedBy, &errorMessage, &req.Metadata, &completedAt,
+		&req.CreatedAt, &req.UpdatedAt,
+	)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if errorMessage.Valid {
+		req.ErrorMessage = errorMessage.String
+	}
+	if completedAt.Valid {
+		req.CompletedAt = &completedAt.Time
+	}
+	return &req, nil
+}

--- a/pkg/storage/mysqlstore/control_requests_test.go
+++ b/pkg/storage/mysqlstore/control_requests_test.go
@@ -3,6 +3,7 @@
 package mysqlstore
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -40,6 +41,69 @@ func TestControlRequestStore_RequestPendingReturnsExistingPending(t *testing.T) 
 
 	assert.Equal(t, first.ID, second.ID)
 	assert.JSONEq(t, string(first.Metadata), string(second.Metadata))
+}
+
+// Concurrent operator requests for the same apply operation should converge on
+// one durable pending row so retries and double-clicks do not create extra work.
+func TestControlRequestStore_RequestPendingConcurrentFirstRequests(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	applyID := createControlRequestTestApply(t, store, "apply_control_request_concurrent")
+	const requestCount = 8
+	type requestResult struct {
+		req            *storage.ApplyControlRequest
+		alreadyPending bool
+		err            error
+	}
+	start := make(chan struct{})
+	results := make(chan requestResult, requestCount)
+	var wg sync.WaitGroup
+	for range requestCount {
+		wg.Go(func() {
+			<-start
+			req, alreadyPending, err := store.ControlRequests().RequestPending(ctx, &storage.ApplyControlRequest{
+				ApplyID:     applyID,
+				Operation:   storage.ControlOperationStart,
+				Status:      storage.ControlRequestPending,
+				RequestedBy: "operator",
+				Metadata:    []byte(`{"started_count":1}`),
+			})
+			results <- requestResult{req: req, alreadyPending: alreadyPending, err: err}
+		})
+	}
+	close(start)
+	wg.Wait()
+	close(results)
+
+	var requestID int64
+	var createdCount int
+	var alreadyPendingCount int
+	for result := range results {
+		require.NoError(t, result.err)
+		require.NotNil(t, result.req)
+		assert.Equal(t, storage.ControlRequestPending, result.req.Status)
+		if requestID == 0 {
+			requestID = result.req.ID
+		}
+		assert.Equal(t, requestID, result.req.ID)
+		if result.alreadyPending {
+			alreadyPendingCount++
+		} else {
+			createdCount++
+		}
+	}
+	assert.Equal(t, 1, createdCount)
+	assert.Equal(t, requestCount-1, alreadyPendingCount)
+
+	var rowCount int
+	require.NoError(t, store.db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM apply_control_requests
+		WHERE apply_id = ? AND operation = ?
+	`, applyID, storage.ControlOperationStart).Scan(&rowCount))
+	assert.Equal(t, 1, rowCount)
 }
 
 func TestControlRequestStore_RequestPendingResetsCompletedRequest(t *testing.T) {

--- a/pkg/storage/mysqlstore/control_requests_test.go
+++ b/pkg/storage/mysqlstore/control_requests_test.go
@@ -1,0 +1,142 @@
+//go:build integration
+
+package mysqlstore
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/block/schemabot/pkg/state"
+	"github.com/block/schemabot/pkg/storage"
+)
+
+func TestControlRequestStore_RequestPendingReturnsExistingPending(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	applyID := createControlRequestTestApply(t, store, "apply_control_request_pending")
+	first, alreadyPending, err := store.ControlRequests().RequestPending(ctx, &storage.ApplyControlRequest{
+		ApplyID:     applyID,
+		Operation:   storage.ControlOperationStart,
+		Status:      storage.ControlRequestPending,
+		RequestedBy: "operator",
+		Metadata:    []byte(`{"started_count":1}`),
+	})
+	require.NoError(t, err)
+	require.False(t, alreadyPending)
+
+	second, alreadyPending, err := store.ControlRequests().RequestPending(ctx, &storage.ApplyControlRequest{
+		ApplyID:     applyID,
+		Operation:   storage.ControlOperationStart,
+		Status:      storage.ControlRequestPending,
+		RequestedBy: "operator",
+		Metadata:    []byte(`{"started_count":2}`),
+	})
+	require.NoError(t, err)
+	require.True(t, alreadyPending)
+
+	assert.Equal(t, first.ID, second.ID)
+	assert.JSONEq(t, string(first.Metadata), string(second.Metadata))
+}
+
+func TestControlRequestStore_RequestPendingResetsCompletedRequest(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	applyID := createControlRequestTestApply(t, store, "apply_control_request_restart")
+	first, alreadyPending, err := store.ControlRequests().RequestPending(ctx, &storage.ApplyControlRequest{
+		ApplyID:     applyID,
+		Operation:   storage.ControlOperationStart,
+		Status:      storage.ControlRequestPending,
+		RequestedBy: "operator-a",
+		Metadata:    []byte(`{"started_count":1}`),
+	})
+	require.NoError(t, err)
+	require.False(t, alreadyPending)
+
+	require.NoError(t, store.ControlRequests().CompletePending(ctx, applyID, storage.ControlOperationStart))
+
+	second, alreadyPending, err := store.ControlRequests().RequestPending(ctx, &storage.ApplyControlRequest{
+		ApplyID:     applyID,
+		Operation:   storage.ControlOperationStart,
+		Status:      storage.ControlRequestPending,
+		RequestedBy: "operator-b",
+		Metadata:    []byte(`{"started_count":2}`),
+	})
+	require.NoError(t, err)
+	require.False(t, alreadyPending)
+
+	assert.Equal(t, first.ID, second.ID)
+	assert.Equal(t, storage.ControlRequestPending, second.Status)
+	assert.Equal(t, "operator-b", second.RequestedBy)
+	assert.Nil(t, second.CompletedAt)
+	assert.JSONEq(t, `{"started_count":2}`, string(second.Metadata))
+}
+
+func TestControlRequestStore_CompletePending(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	applyID := createControlRequestTestApply(t, store, "apply_control_request_complete")
+	created, alreadyPending, err := store.ControlRequests().RequestPending(ctx, &storage.ApplyControlRequest{
+		ApplyID:   applyID,
+		Operation: storage.ControlOperationStart,
+		Status:    storage.ControlRequestPending,
+		Metadata:  []byte(`{}`),
+	})
+	require.NoError(t, err)
+	require.False(t, alreadyPending)
+
+	pending, err := store.ControlRequests().GetPending(ctx, applyID, storage.ControlOperationStart)
+	require.NoError(t, err)
+	require.NotNil(t, pending)
+	assert.Equal(t, created.ID, pending.ID)
+
+	require.NoError(t, store.ControlRequests().CompletePending(ctx, applyID, storage.ControlOperationStart))
+
+	pending, err = store.ControlRequests().GetPending(ctx, applyID, storage.ControlOperationStart)
+	require.NoError(t, err)
+	assert.Nil(t, pending)
+
+	completed := getControlRequestByID(t, store, created.ID)
+	require.NotNil(t, completed)
+	assert.Equal(t, storage.ControlRequestCompleted, completed.Status)
+	assert.NotNil(t, completed.CompletedAt)
+}
+
+func getControlRequestByID(t *testing.T, store *Storage, id int64) *storage.ApplyControlRequest {
+	t.Helper()
+	row := store.db.QueryRowContext(t.Context(), `
+		SELECT `+controlRequestColumns+`
+		FROM apply_control_requests
+		WHERE id = ?
+	`, id)
+	req, err := scanControlRequest(row)
+	require.NoError(t, err)
+	return req
+}
+
+func createControlRequestTestApply(t *testing.T, store *Storage, applyIdentifier string) int64 {
+	t.Helper()
+	lock := createTestLock(t, store, "testdb", "mysql", "staging")
+	applyID, err := store.Applies().Create(t.Context(), &storage.Apply{
+		ApplyIdentifier: applyIdentifier,
+		LockID:          lock.ID,
+		PlanID:          801,
+		Database:        "testdb",
+		DatabaseType:    "mysql",
+		Repository:      "org/repo",
+		PullRequest:     123,
+		Environment:     "staging",
+		Engine:          "spirit",
+		State:           state.Apply.Stopped,
+		Options:         []byte(`{}`),
+	})
+	require.NoError(t, err)
+	return applyID
+}

--- a/pkg/storage/mysqlstore/storage.go
+++ b/pkg/storage/mysqlstore/storage.go
@@ -16,6 +16,7 @@ type Storage struct {
 	applies         *applyStore
 	tasks           *taskStore
 	applyLogs       *applyLogStore
+	controlRequests *controlRequestStore
 	applyComments   *applyCommentStore
 	checks          *checkStore
 	settings        *settingsStore
@@ -31,6 +32,7 @@ func New(db *sql.DB) *Storage {
 		applies:         &applyStore{db: db},
 		tasks:           &taskStore{db: db},
 		applyLogs:       &applyLogStore{db: db},
+		controlRequests: &controlRequestStore{db: db},
 		applyComments:   &applyCommentStore{db: db},
 		checks:          &checkStore{db: db},
 		settings:        &settingsStore{db: db},
@@ -61,6 +63,11 @@ func (s *Storage) Tasks() storage.TaskStore {
 // ApplyLogs returns the apply logs store.
 func (s *Storage) ApplyLogs() storage.ApplyLogStore {
 	return s.applyLogs
+}
+
+// ControlRequests returns the control request store.
+func (s *Storage) ControlRequests() storage.ControlRequestStore {
+	return s.controlRequests
 }
 
 // ApplyComments returns the apply comment store.

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -23,6 +23,9 @@ type Storage interface {
 	// ApplyLogs returns the apply logs store.
 	ApplyLogs() ApplyLogStore
 
+	// ControlRequests returns the apply control request store.
+	ControlRequests() ControlRequestStore
+
 	// ApplyComments returns the apply comment store.
 	ApplyComments() ApplyCommentStore
 
@@ -324,4 +327,20 @@ type ApplyLogStore interface {
 
 	// List returns logs matching the filter criteria, ordered by created_at.
 	List(ctx context.Context, filter ApplyLogFilter) ([]*ApplyLog, error)
+}
+
+// ControlRequestStore manages durable user control requests.
+// A control request is behavioral state, not just audit: scheduler workers use
+// pending rows to recover accepted operations after process restarts.
+type ControlRequestStore interface {
+	// RequestPending records a pending request for an apply operation. If the
+	// same operation is already pending for the apply, the existing request is
+	// returned with alreadyPending=true.
+	RequestPending(ctx context.Context, req *ApplyControlRequest) (*ApplyControlRequest, bool, error)
+
+	// GetPending returns the pending request for an apply operation.
+	GetPending(ctx context.Context, applyID int64, operation ControlOperation) (*ApplyControlRequest, error)
+
+	// CompletePending marks the pending request for an apply operation completed.
+	CompletePending(ctx context.Context, applyID int64, operation ControlOperation) error
 }

--- a/pkg/storage/types.go
+++ b/pkg/storage/types.go
@@ -352,7 +352,7 @@ type Apply struct {
 	// ErrorMessage contains error details if state is failed.
 	ErrorMessage string
 
-	// Options contains engine-specific options as JSON.
+	// Options contains durable apply options and scheduler metadata as JSON.
 	// Use ParseApplyOptions() to get typed access.
 	Options []byte
 
@@ -373,7 +373,7 @@ type Apply struct {
 	UpdatedAt time.Time
 }
 
-// ApplyOptions contains engine-specific options for an apply.
+// ApplyOptions contains durable user and engine options for an apply.
 // Stored as JSON in the database for flexibility across engine types.
 type ApplyOptions struct {
 	// AllowUnsafe permits destructive changes (DROP TABLE, DROP COLUMN).
@@ -401,6 +401,42 @@ type ApplyOptions struct {
 	// Target is the opaque endpoint-discovery target forwarded to Tern.
 	// Defaults to the apply database when empty.
 	Target string `json:"target,omitempty"`
+}
+
+// ControlOperation identifies a user-requested control operation.
+type ControlOperation string
+
+const (
+	// ControlOperationStart resumes a stopped apply.
+	ControlOperationStart ControlOperation = "start"
+)
+
+// ControlRequestStatus is the durable processing status for a control request.
+type ControlRequestStatus string
+
+const (
+	// ControlRequestPending means a scheduler worker still needs to act.
+	ControlRequestPending ControlRequestStatus = "pending"
+	// ControlRequestCompleted means the requested operation has been accepted.
+	ControlRequestCompleted ControlRequestStatus = "completed"
+	// ControlRequestFailed means the requested operation reached a terminal error.
+	ControlRequestFailed ControlRequestStatus = "failed"
+)
+
+// ApplyControlRequest records durable user control intent.
+// Use this when an HTTP control operation can be accepted before the engine has
+// actually performed the operation.
+type ApplyControlRequest struct {
+	ID           int64
+	ApplyID      int64
+	Operation    ControlOperation
+	Status       ControlRequestStatus
+	RequestedBy  string
+	ErrorMessage string
+	Metadata     []byte
+	CompletedAt  *time.Time
+	CreatedAt    time.Time
+	UpdatedAt    time.Time
 }
 
 // ApplyOptionsFromMap converts API/proto option strings into typed storage options.


### PR DESCRIPTION
Adds a reusable storage layer for durable apply control requests. The new table and MySQL store record one operation row per apply, support pending/completed status transitions, and let callers treat duplicate pending requests as already requested instead of creating more work. This PR only adds the persistence contract, implementation, tests, and storage docs; scheduler behavior is handled in follow-up PRs.

🤖 Generated with Codex.