### PR TITLE
fix(api): reject invalid start states

### DIFF
--- a/pkg/api/control_handlers.go
+++ b/pkg/api/control_handlers.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -20,6 +21,36 @@ func controlStatus(accepted bool) string {
 		return "success"
 	}
 	return "rejected"
+}
+
+type controlOperationHTTPError struct {
+	status int
+	err    error
+}
+
+func (e *controlOperationHTTPError) Error() string {
+	return e.err.Error()
+}
+
+func (e *controlOperationHTTPError) Unwrap() error {
+	return e.err
+}
+
+// controlConflictf marks an operator request as rejected rather than failed.
+// Storage, Tern, and scheduler errors still fall back to 500s.
+func controlConflictf(format string, args ...any) error {
+	return &controlOperationHTTPError{
+		status: http.StatusConflict,
+		err:    fmt.Errorf(format, args...),
+	}
+}
+
+func controlOperationHTTPStatus(err error) int {
+	var httpErr *controlOperationHTTPError
+	if errors.As(err, &httpErr) {
+		return httpErr.status
+	}
+	return http.StatusInternalServerError
 }
 
 // logControlOperation appends an apply log entry for a control operation (cutover, stop, start, revert, etc.).
@@ -61,6 +92,7 @@ func (s *Service) logControlOperation(r *http.Request, applyID, caller, eventTyp
 
 // writeControlError logs and writes an HTTP error for a control operation.
 func (s *Service) writeControlError(w http.ResponseWriter, opName string, apply *storage.Apply, err error) {
+	status := controlOperationHTTPStatus(err)
 	attrs := []any{"error", err}
 	if apply != nil {
 		attrs = append(attrs,
@@ -71,8 +103,13 @@ func (s *Service) writeControlError(w http.ResponseWriter, opName string, apply 
 			"environment", apply.Environment,
 		)
 	}
-	s.logger.Error(opName+" failed", attrs...)
-	s.writeError(w, http.StatusInternalServerError, opName+" failed: "+err.Error())
+	if status >= http.StatusInternalServerError {
+		s.logger.Error(opName+" failed", attrs...)
+		s.writeError(w, status, opName+" failed: "+err.Error())
+	} else {
+		s.logger.Warn(opName+" rejected", attrs...)
+		s.writeError(w, status, opName+" rejected: "+err.Error())
+	}
 }
 
 // decodeControlRequest decodes a control request (stop/start/cutover/volume),
@@ -247,6 +284,12 @@ func (s *Service) handleStart(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if err := validateStartRequestState(apply); err != nil {
+		metrics.RecordControlOperation(r.Context(), "start", apply.Database, apply.Environment, "rejected")
+		s.writeControlError(w, "start", apply, err)
+		return
+	}
+
 	resp, err := client.Start(r.Context(), &ternv1.StartRequest{
 		ApplyId:     applyID,
 		Environment: apply.Environment,
@@ -287,6 +330,62 @@ func (s *Service) handleStart(w http.ResponseWriter, r *http.Request) {
 	}
 
 	s.writeJSON(w, http.StatusOK, httpResp)
+}
+
+func validateStartRequestState(apply *storage.Apply) error {
+	if apply.GetOptions().DeferDeploy && !state.IsState(apply.State, state.Apply.WaitingForDeploy) {
+		return controlConflictf("schema change is not ready for deploy (current state: %s)", apply.State)
+	}
+	if !isStartRequestAllowedState(apply.State) {
+		return startNotAllowedForState(apply)
+	}
+	return nil
+}
+
+// isStartRequestAllowedState is an allowlist for states where /start has a
+// concrete action. New apply states must opt in here before they can reach Tern.
+func isStartRequestAllowedState(applyState string) bool {
+	return state.IsState(
+		applyState,
+		state.Apply.WaitingForDeploy,
+		state.Apply.Running,
+		state.Apply.Stopped,
+	)
+}
+
+func startNotAllowedForState(apply *storage.Apply) error {
+	switch {
+	case state.IsState(apply.State, state.Apply.Pending):
+		return controlConflictf("schema change is pending and no start request is queued")
+	case state.IsState(apply.State, state.Apply.Running):
+		return controlConflictf("schema change is still running; stop it before starting it again")
+	case state.IsState(apply.State, state.Apply.WaitingForCutover):
+		return controlConflictf("schema change is waiting for cutover; use cutover instead of start")
+	case state.IsState(apply.State, state.Apply.CuttingOver):
+		return controlConflictf("schema change is cutting over; start is not allowed")
+	case state.IsState(apply.State, state.Apply.RevertWindow):
+		return controlConflictf("schema change is in revert window; use revert or skip-revert instead of start")
+	case state.IsState(apply.State, state.Apply.FailedRetryable):
+		return controlConflictf("schema change is waiting for scheduler retry; start is not allowed")
+	case state.IsState(apply.State, state.Apply.Failed):
+		return controlConflictf("schema change failed and cannot be started")
+	case state.IsState(apply.State, state.Apply.Completed):
+		return controlConflictf("schema change already completed and cannot be started")
+	case state.IsState(apply.State, state.Apply.Cancelled):
+		return controlConflictf("schema change was cancelled and cannot be started")
+	case state.IsState(apply.State, state.Apply.Reverted):
+		return controlConflictf("schema change was reverted and cannot be started")
+	case state.IsState(apply.State,
+		state.Apply.PreparingBranch,
+		state.Apply.ApplyingBranchChanges,
+		state.Apply.ValidatingBranch,
+		state.Apply.CreatingDeployRequest,
+		state.Apply.ValidatingDeployRequest,
+	):
+		return controlConflictf("schema change is in setup state %s; start is not allowed", state.NormalizeState(apply.State))
+	default:
+		return controlConflictf("schema change is not stopped (current state: %s)", apply.State)
+	}
 }
 
 // VolumeRequest is the HTTP request body for POST /api/volume.

--- a/pkg/api/control_handlers.go
+++ b/pkg/api/control_handlers.go
@@ -357,8 +357,6 @@ func startNotAllowedForState(apply *storage.Apply) error {
 	switch {
 	case state.IsState(apply.State, state.Apply.Pending):
 		return controlConflictf("schema change is pending and no start request is queued")
-	case state.IsState(apply.State, state.Apply.Running):
-		return controlConflictf("schema change is still running; stop it before starting it again")
 	case state.IsState(apply.State, state.Apply.WaitingForCutover):
 		return controlConflictf("schema change is waiting for cutover; use cutover instead of start")
 	case state.IsState(apply.State, state.Apply.CuttingOver):

--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -1791,6 +1791,132 @@ func TestStartHandler(t *testing.T) {
 		assert.Equal(t, "staging", mock.startReq.Environment)
 	})
 
+	t.Run("rejects deferred deploy before waiting for deploy", func(t *testing.T) {
+		mock := &mockTernClient{}
+		apply := activeTestApply("apply-start-deferred")
+		apply.State = state.Apply.Pending
+		apply.Options = []byte(`{"defer_deploy":true}`)
+		svc := newControlTestService(mock, apply)
+		mux := http.NewServeMux()
+		svc.ConfigureRoutes(mux)
+
+		body := `{"environment": "staging", "apply_id": "apply-start-deferred"}`
+		req := httptest.NewRequestWithContext(t.Context(), "POST", "/api/start", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusConflict, w.Code, w.Body.String())
+		assert.Contains(t, w.Body.String(), "not ready for deploy")
+		assert.Nil(t, mock.startReq)
+		assert.Equal(t, state.Apply.Pending, apply.State)
+	})
+
+	t.Run("rejects start for states without a start action", func(t *testing.T) {
+		tests := []struct {
+			name        string
+			applyState  string
+			wantMessage string
+		}{
+			{
+				name:        "pending",
+				applyState:  state.Apply.Pending,
+				wantMessage: "no start request is queued",
+			},
+			{
+				name:        "failed retryable",
+				applyState:  state.Apply.FailedRetryable,
+				wantMessage: "scheduler retry",
+			},
+			{
+				name:        "failed",
+				applyState:  state.Apply.Failed,
+				wantMessage: "failed and cannot be started",
+			},
+			{
+				name:        "cancelled",
+				applyState:  state.Apply.Cancelled,
+				wantMessage: "cancelled and cannot be started",
+			},
+			{
+				name:        "completed",
+				applyState:  state.Apply.Completed,
+				wantMessage: "already completed",
+			},
+			{
+				name:        "reverted",
+				applyState:  state.Apply.Reverted,
+				wantMessage: "reverted and cannot be started",
+			},
+			{
+				name:        "waiting for cutover",
+				applyState:  state.Apply.WaitingForCutover,
+				wantMessage: "use cutover",
+			},
+			{
+				name:        "cutting over",
+				applyState:  state.Apply.CuttingOver,
+				wantMessage: "cutting over",
+			},
+			{
+				name:        "revert window",
+				applyState:  state.Apply.RevertWindow,
+				wantMessage: "use revert or skip-revert",
+			},
+			{
+				name:        "preparing branch",
+				applyState:  state.Apply.PreparingBranch,
+				wantMessage: "setup state preparing_branch",
+			},
+			{
+				name:        "applying branch changes",
+				applyState:  state.Apply.ApplyingBranchChanges,
+				wantMessage: "setup state applying_branch_changes",
+			},
+			{
+				name:        "validating branch",
+				applyState:  state.Apply.ValidatingBranch,
+				wantMessage: "setup state validating_branch",
+			},
+			{
+				name:        "creating deploy request",
+				applyState:  state.Apply.CreatingDeployRequest,
+				wantMessage: "setup state creating_deploy_request",
+			},
+			{
+				name:        "validating deploy request",
+				applyState:  state.Apply.ValidatingDeployRequest,
+				wantMessage: "setup state validating_deploy_request",
+			},
+			{
+				name:        "unknown future state",
+				applyState:  "new_future_state",
+				wantMessage: "not stopped",
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				mock := &mockTernClient{}
+				apply := activeTestApply("apply-start-" + strings.ReplaceAll(tt.applyState, "_", "-"))
+				apply.State = tt.applyState
+				svc := newControlTestService(mock, apply)
+				mux := http.NewServeMux()
+				svc.ConfigureRoutes(mux)
+
+				body := fmt.Sprintf(`{"environment": "staging", "apply_id": %q}`, apply.ApplyIdentifier)
+				req := httptest.NewRequestWithContext(t.Context(), "POST", "/api/start", strings.NewReader(body))
+				req.Header.Set("Content-Type", "application/json")
+				w := httptest.NewRecorder()
+				mux.ServeHTTP(w, req)
+
+				assert.Equal(t, http.StatusConflict, w.Code, w.Body.String())
+				assert.Contains(t, w.Body.String(), tt.wantMessage)
+				assert.Nil(t, mock.startReq)
+			})
+		}
+	})
+
 	t.Run("requires apply_id", func(t *testing.T) {
 		mock := &mockTernClient{}
 		svc := newControlTestService(mock, activeTestApply("apply-active-start"))


### PR DESCRIPTION
Adds an explicit `/start` state allowlist so operator requests only reach Tern when the stored apply state has a concrete start action. Invalid states now return `409 Conflict` with state-specific messages instead of falling through to engine calls or generic 500 responses.

The allowlist keeps the existing stopped, waiting-for-deploy, and stored-running paths. Stored `running` remains valid because stop can persist stopped task rows before the derived apply row flips to stopped, and existing stop/start flows rely on that compatibility.

Stacked on #182.

🤖 Generated with Codex.