### PR TITLE
fix(api): serialize EnsureSchema cleanup under lock

### DIFF
--- a/pkg/api/ensure_schema.go
+++ b/pkg/api/ensure_schema.go
@@ -26,8 +26,9 @@ const EnsureSchemaTimeout = 1 * time.Minute
 // Uses the same differ/Spirit mechanism as LocalClient for consistency.
 //
 // Concurrency-safe across pods: plans first without a lock (read-only diff),
-// and returns immediately if no changes are needed. When changes are detected,
-// acquires a MySQL advisory lock to serialize Spirit execution, then re-plans
+// and returns immediately if no changes are needed and no stale Spirit tables
+// are present. When changes or stale Spirit tables are detected, acquires a
+// MySQL advisory lock to serialize cleanup and Spirit execution, then re-plans
 // under the lock to confirm changes are still needed (another pod may have
 // applied them while we waited for the lock).
 func EnsureSchema(dsn string, logger *slog.Logger) error {
@@ -59,14 +60,6 @@ func EnsureSchema(dsn string, logger *slog.Logger) error {
 		"files", schemaFileNames(schemaFiles),
 	)
 
-	// Clean up stale Spirit internal tables before planning. These are
-	// leftover from a previous interrupted schema change (e.g., pod killed
-	// mid-apply). Must happen before Plan so the diff sees the actual table
-	// state without stale artifacts like _tablename_new or _tablename_old.
-	if err := cleanStaleSpiritTables(ctx, dsn, logger); err != nil {
-		return fmt.Errorf("clean stale Spirit tables: %w", err)
-	}
-
 	// Use a quiet logger for Spirit — its internal operational messages
 	// (table locks, checksums, metadata lock release) are noise for
 	// EnsureSchema's small bootstrap DDL. SchemaBot logs the actual DDL
@@ -88,28 +81,54 @@ func EnsureSchema(dsn string, logger *slog.Logger) error {
 		return fmt.Errorf("plan schema: %w", err)
 	}
 	if planResult.NoChanges {
-		logger.Info("storage schema up-to-date")
-		return nil
+		staleTables, err := staleSpiritTableNames(ctx, dsn)
+		if err != nil {
+			return fmt.Errorf("check stale Spirit tables: %w", err)
+		}
+		if len(staleTables) > 0 {
+			logger.Info("stale Spirit tables found with storage schema up-to-date",
+				"tables", staleTables,
+			)
+		} else {
+			logger.Info("storage schema up-to-date")
+			return nil
+		}
+	} else {
+		// Log what the fast-path plan found before acquiring the lock.
+		for _, tc := range planResult.FlatTableChanges() {
+			logger.Info("schema change detected (pre-lock)",
+				"table", tc.Table,
+				"operation", tc.Operation,
+				"ddl", tc.DDL,
+			)
+		}
 	}
 
-	// Log what the fast-path plan found before acquiring the lock.
-	for _, tc := range planResult.FlatTableChanges() {
-		logger.Info("schema change detected (pre-lock)",
-			"table", tc.Table,
-			"operation", tc.Operation,
-			"ddl", tc.DDL,
-		)
+	if planResult.NoChanges {
+		logger.Info("acquiring EnsureSchema advisory lock to clean stale Spirit tables")
+	} else {
+		logger.Info("acquiring EnsureSchema advisory lock to apply storage schema changes")
 	}
 
-	// Changes detected — acquire advisory lock to serialize across pods.
+	// Changes or stale Spirit tables detected — acquire advisory lock to
+	// serialize cleanup and Spirit execution across pods.
 	lockConn, err := acquireEnsureSchemaLock(ctx, dsn, logger)
 	if err != nil {
 		return fmt.Errorf("acquire schema lock: %w", err)
 	}
 	defer utils.CloseAndLog(lockConn)
 
+	// Clean up stale Spirit internal tables only while holding the advisory
+	// lock. During a rolling deploy, another pod may be actively applying
+	// SchemaBot storage DDL; cleaning before the lock can delete that pod's
+	// shadow tables and make Spirit cancel with "table definition changed".
+	if err := cleanStaleSpiritTables(ctx, dsn, logger); err != nil {
+		return fmt.Errorf("clean stale Spirit tables: %w", err)
+	}
+
 	// Re-plan under the lock — another pod may have applied the changes
-	// while we were waiting for the lock.
+	// while we were waiting for the lock, or stale Spirit tables may have been
+	// removed above.
 	eng = spirit.New(spirit.Config{Logger: spiritLogger})
 	planResult, err = eng.Plan(ctx, &engine.PlanRequest{
 		Database:    "schemabot",
@@ -120,7 +139,7 @@ func EnsureSchema(dsn string, logger *slog.Logger) error {
 		return fmt.Errorf("plan schema: %w", err)
 	}
 	if planResult.NoChanges {
-		logger.Info("storage schema up-to-date (applied by another pod)")
+		logger.Info("storage schema up-to-date")
 		return nil
 	}
 
@@ -175,6 +194,34 @@ func EnsureSchema(dsn string, logger *slog.Logger) error {
 
 	logger.Info("storage schema applied successfully")
 	return nil
+}
+
+func staleSpiritTableNames(ctx context.Context, dsn string) ([]string, error) {
+	db, err := sql.Open("mysql", dsn)
+	if err != nil {
+		return nil, fmt.Errorf("open database: %w", err)
+	}
+	defer utils.CloseAndLog(db)
+
+	if err := db.PingContext(ctx); err != nil {
+		return nil, fmt.Errorf("ping database: %w", err)
+	}
+
+	// Load all tables here. table.WithoutUnderscoreTables would hide the
+	// Spirit internal tables this path needs to detect.
+	tables, err := table.LoadSchemaFromDB(ctx, db)
+	if err != nil {
+		return nil, fmt.Errorf("load schema: %w", err)
+	}
+
+	var names []string
+	for _, t := range tables {
+		if ddl.IsSpiritInternalTable(t.Name) {
+			names = append(names, t.Name)
+		}
+	}
+	sort.Strings(names)
+	return names, nil
 }
 
 // readEmbeddedSchemaFiles reads the embedded MySQL schema files into a SchemaFiles map.
@@ -316,7 +363,8 @@ func acquireEnsureSchemaLock(ctx context.Context, dsn string, logger *slog.Logge
 }
 
 // cleanStaleSpiritTables drops any Spirit internal tables left behind by a
-// previous interrupted schema change on the SchemaBot storage database. These
+// previous interrupted schema change on the SchemaBot storage database. Callers
+// must hold the EnsureSchema advisory lock before invoking this helper. These
 // are temporary tables (_tablename_new, _tablename_old, _tablename_chkpnt,
 // _spirit_sentinel, _spirit_checkpoint) that Spirit normally cleans up after
 // cutover. If a pod is killed mid-apply, they persist until the next startup.
@@ -340,6 +388,8 @@ func cleanStaleSpiritTables(ctx context.Context, dsn string, logger *slog.Logger
 		return fmt.Errorf("ping database: %w", err)
 	}
 
+	// Load all tables here. table.WithoutUnderscoreTables would hide the
+	// Spirit internal tables this cleanup path needs to drop.
 	tables, err := table.LoadSchemaFromDB(ctx, db)
 	if err != nil {
 		return fmt.Errorf("load schema: %w", err)

--- a/pkg/api/ensure_schema_integration_test.go
+++ b/pkg/api/ensure_schema_integration_test.go
@@ -35,10 +35,7 @@ func TestEnsureSchema(t *testing.T) {
 	// Verify tables exist
 	tables := []string{"tasks", "plans", "locks", "checks", "settings", "vitess_apply_data", "vitess_tasks"}
 	for _, table := range tables {
-		var count int
-		err := db.QueryRowContext(ctx, "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = 'schemabot' AND table_name = ?", table).Scan(&count)
-		require.NoError(t, err, "Failed to check table %s", table)
-		assert.Equal(t, 1, count, "Table %s not found", table)
+		assert.True(t, testutil.TableExists(t, db, "schemabot", table), "Table %s not found", table)
 	}
 }
 
@@ -89,21 +86,62 @@ func TestEnsureSchema_CleansStaleSpiritTables(t *testing.T) {
 
 	// Verify all stale tables were dropped.
 	for _, tbl := range staleTables {
-		var count int
-		err := db.QueryRowContext(ctx,
-			"SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = 'schemabot' AND table_name = ?", tbl,
-		).Scan(&count)
-		require.NoError(t, err)
-		assert.Equal(t, 0, count, "stale Spirit table %s should have been dropped", tbl)
+		assert.False(t, testutil.TableExists(t, db, "schemabot", tbl),
+			"stale Spirit table %s should have been dropped", tbl)
 	}
 
 	// Verify real tables still exist.
-	var count int
-	err := db.QueryRowContext(ctx,
-		"SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = 'schemabot' AND table_name = 'tasks'",
-	).Scan(&count)
+	assert.True(t, testutil.TableExists(t, db, "schemabot", "tasks"),
+		"real tasks table should still exist")
+
+	assertEnsureSchemaDoesNotCleanSpiritTablesWhileWaitingForLock(t, ctx, dsn, db, logger)
+}
+
+func assertEnsureSchemaDoesNotCleanSpiritTablesWhileWaitingForLock(
+	t *testing.T,
+	ctx context.Context,
+	dsn string,
+	db *sql.DB,
+	logger *slog.Logger,
+) {
+	t.Helper()
+	// Simulate pod A actively running EnsureSchema. The lock is the production
+	// coordination mechanism, and the shadow table represents Spirit work that
+	// must not be cleaned up by a second pod before it acquires the lock.
+	lockConn, err := acquireEnsureSchemaLock(ctx, dsn, logger)
 	require.NoError(t, err)
-	assert.Equal(t, 1, count, "real tasks table should still exist")
+	lockReleased := false
+	defer func() {
+		if !lockReleased {
+			utils.CloseAndLog(lockConn)
+		}
+	}()
+
+	const shadowTable = "_tasks_new"
+	_, err = db.ExecContext(ctx, fmt.Sprintf("CREATE TABLE `%s` (id INT PRIMARY KEY)", shadowTable))
+	require.NoError(t, err)
+
+	errs := make(chan error, 1)
+	go func() {
+		errs <- EnsureSchema(dsn, logger)
+	}()
+
+	waitForEnsureSchemaLockWaiter(t, db)
+	assert.True(t, testutil.TableExists(t, db, "schemabot", shadowTable),
+		"Spirit shadow table should not be cleaned while another pod holds the EnsureSchema lock")
+
+	utils.CloseAndLog(lockConn)
+	lockReleased = true
+
+	select {
+	case err := <-errs:
+		require.NoError(t, err)
+	case <-time.After(30 * time.Second):
+		t.Fatal("timed out waiting for EnsureSchema to finish after releasing lock")
+	}
+
+	assert.False(t, testutil.TableExists(t, db, "schemabot", shadowTable),
+		"stale Spirit shadow table should be cleaned after EnsureSchema acquires the lock")
 }
 
 func TestEnsureSchema_ConcurrentPods(t *testing.T) {
@@ -129,12 +167,23 @@ func TestEnsureSchema_ConcurrentPods(t *testing.T) {
 	}
 
 	// Verify tables exist after concurrent execution.
+	assert.True(t, testutil.TableExists(t, db, "schemabot", "tasks"),
+		"tasks table should exist after concurrent EnsureSchema")
+}
+
+func waitForEnsureSchemaLockWaiter(t *testing.T, db *sql.DB) {
+	t.Helper()
 	var count int
-	err := db.QueryRowContext(ctx,
-		"SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = 'schemabot' AND table_name = 'tasks'",
-	).Scan(&count)
-	require.NoError(t, err)
-	assert.Equal(t, 1, count, "tasks table should exist after concurrent EnsureSchema")
+	require.Eventually(t, func() bool {
+		err := db.QueryRowContext(t.Context(),
+			`SELECT COUNT(*) FROM information_schema.PROCESSLIST
+			 WHERE ID <> CONNECTION_ID()
+			   AND INFO LIKE '%GET_LOCK%'`,
+		).Scan(&count)
+		require.NoError(t, err)
+		return count > 0
+	}, 10*time.Second, 100*time.Millisecond,
+		"expected EnsureSchema to wait for the advisory lock, waiter count: %d", count)
 }
 
 // startEnsureSchemaContainer starts a MySQL container and returns the container, DSN, and DB.

--- a/pkg/testutil/container.go
+++ b/pkg/testutil/container.go
@@ -3,10 +3,13 @@ package testutil
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
+	"testing"
 	"time"
 
 	"github.com/docker/go-connections/nat"
+	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
 )
 
@@ -52,6 +55,19 @@ func ContainerConnectionString(ctx context.Context, c interface {
 	return retryContainerOp(ctx, "ConnectionString", func() (string, error) {
 		return c.ConnectionString(ctx, args...)
 	})
+}
+
+// TableExists reports whether tableName exists in schemaName.
+func TableExists(t *testing.T, db *sql.DB, schemaName, tableName string) bool {
+	t.Helper()
+
+	var count int
+	err := db.QueryRowContext(t.Context(),
+		"SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = ? AND table_name = ?",
+		schemaName, tableName,
+	).Scan(&count)
+	require.NoError(t, err)
+	return count > 0
 }
 
 func retryContainerOp(ctx context.Context, opName string, op func() (string, error)) (string, error) {


### PR DESCRIPTION
## Summary
Serialize stale Spirit table cleanup with the existing EnsureSchema advisory lock. Concurrent callers now wait before cleanup, and the no-change path still cleans stale Spirit tables instead of returning early.

```text
Before:
  caller A: GET_LOCK -> Spirit schema change creates _table_new
  caller B: cleanup _table_new -> wait for GET_LOCK

  up-to-date schema + stale tables -> return early

After:
  caller A: GET_LOCK -> Spirit schema change creates _table_new
  caller B: wait for GET_LOCK -> cleanup stale tables -> re-plan/apply

  up-to-date schema + stale tables -> wait for GET_LOCK -> cleanup -> re-plan
```

The change also adds a MySQL integration regression for the lock-wait path.

## Risk
Low to medium. This narrows cleanup to an already serialized path and preserves the no-change fast path when no stale Spirit tables are present.

Generated with Codex