### PR TITLE
fix(github): ignore prose mentions in comment commands

### DIFF
--- a/pkg/webhook/commands.go
+++ b/pkg/webhook/commands.go
@@ -108,9 +108,9 @@ type CommandParser struct {
 // NewCommandParser creates a new command parser.
 func NewCommandParser() *CommandParser {
 	return &CommandParser{
-		commandRegex:      regexp.MustCompile(`(?i)schemabot\s+(` + commandNamePattern() + `)\b`),
-		mentionRegex:      regexp.MustCompile(`(?i)\bschemabot\b`),
-		helpRegex:         regexp.MustCompile(`(?i)schemabot\s+help\b`),
+		commandRegex:      regexp.MustCompile(`(?im)^ {0,3}schemabot[ \t]+(` + commandNamePattern() + `)\b`),
+		mentionRegex:      regexp.MustCompile(`(?im)^ {0,3}schemabot(?:[ \t]+|$)`),
+		helpRegex:         regexp.MustCompile(`(?im)^ {0,3}schemabot[ \t]+help\b`),
 		applyIDRegex:      regexp.MustCompile(`(?i)\b(apply[_-][a-f0-9]+)\b`),
 		environmentRegex:  regexp.MustCompile(`(?i)-e\s+(staging|production)`),
 		databaseRegex:     regexp.MustCompile(`(?i)-d\s+([a-zA-Z0-9_-]+)`),
@@ -144,11 +144,15 @@ type CommandResult struct {
 //     IsHelp=true so the dispatcher can branch on it without consulting the
 //     full spec table.
 //  2. The first registered command word that follows `schemabot ` is looked
-//     up in specByName and routed through applySpec.
-//  3. If `schemabot` appears but no registered command follows, the result is
-//     a bare IsMention so the dispatcher can post a friendly "invalid command"
-//     comment under the respond_to_unscoped policy.
+//     up in specByName and routed through applySpec. Commands must begin a
+//     non-code comment line so prose, filenames, URLs, and examples are not
+//     treated as directives.
+//  3. If a line starts with `schemabot` but no registered command follows, the
+//     result is a bare IsMention so the dispatcher can post a friendly
+//     "invalid command" comment under the respond_to_unscoped policy.
 func (p *CommandParser) ParseCommand(body string) CommandResult {
+	body = markdownDirectiveText(body)
+
 	if p.helpRegex.MatchString(body) {
 		return CommandResult{Action: action.Help, IsHelp: true, IsMention: true}
 	}
@@ -167,6 +171,27 @@ func (p *CommandParser) ParseCommand(body string) CommandResult {
 		return CommandResult{IsMention: true}
 	}
 	return p.applySpec(spec, body)
+}
+
+func markdownDirectiveText(body string) string {
+	var b strings.Builder
+	inFence := false
+	for line := range strings.Lines(body) {
+		leadingSpaces := len(line) - len(strings.TrimLeft(line, " "))
+		if leadingSpaces <= 3 && isMarkdownFence(line[leadingSpaces:]) {
+			inFence = !inFence
+			continue
+		}
+		if inFence || strings.HasPrefix(line, "    ") || strings.HasPrefix(line, "\t") {
+			continue
+		}
+		b.WriteString(line)
+	}
+	return b.String()
+}
+
+func isMarkdownFence(line string) bool {
+	return strings.HasPrefix(line, "```") || strings.HasPrefix(line, "~~~")
 }
 
 // applySpec populates CommandResult from a body using the per-command spec.

--- a/pkg/webhook/commands_test.go
+++ b/pkg/webhook/commands_test.go
@@ -185,9 +185,74 @@ func TestParseCommand(t *testing.T) {
 		},
 		{
 			name: "unknown mention",
-			body: "hey schemabot what's up",
+			body: "schemabot what's up",
 			expected: CommandResult{
 				IsMention: true,
+			},
+		},
+		{
+			name:     "inline prose mention ignored",
+			body:     "I onboarded schemabot in this repo.",
+			expected: CommandResult{},
+		},
+		{
+			name:     "schemabot filename ignored",
+			body:     "With `schemabot.yaml` sitting at `files/migrations/`, the app uses declarative schema changes.",
+			expected: CommandResult{},
+		},
+		{
+			name:     "schemabot url ignored",
+			body:     "See https://github.com/block/schemabot for details.",
+			expected: CommandResult{},
+		},
+		{
+			name:     "quoted command ignored",
+			body:     "> schemabot plan -e staging",
+			expected: CommandResult{},
+		},
+		{
+			name: "command after prose on new line",
+			body: "Please run this:\n\nschemabot plan -e staging",
+			expected: CommandResult{
+				Action:      "plan",
+				Environment: "staging",
+				Found:       true,
+				IsMention:   true,
+			},
+		},
+		{
+			name: "command with markdown indentation",
+			body: "  schemabot plan -e staging",
+			expected: CommandResult{
+				Action:      "plan",
+				Environment: "staging",
+				Found:       true,
+				IsMention:   true,
+			},
+		},
+		{
+			name:     "command in fenced code block ignored",
+			body:     "```sh\nschemabot plan -e staging\n```",
+			expected: CommandResult{},
+		},
+		{
+			name:     "command in tilde fenced code block ignored",
+			body:     "~~~\nschemabot apply -e staging\n~~~",
+			expected: CommandResult{},
+		},
+		{
+			name:     "command in indented code block ignored",
+			body:     "    schemabot plan -e staging",
+			expected: CommandResult{},
+		},
+		{
+			name: "command after fenced example",
+			body: "```sh\nschemabot plan -e staging\n```\n\nschemabot plan -e production",
+			expected: CommandResult{
+				Action:      "plan",
+				Environment: "production",
+				Found:       true,
+				IsMention:   true,
 			},
 		},
 		{

--- a/pkg/webhook/handler_test.go
+++ b/pkg/webhook/handler_test.go
@@ -293,6 +293,32 @@ func TestWebhookNoMention(t *testing.T) {
 	}
 }
 
+func TestWebhookIgnoresSchemaBotProse(t *testing.T) {
+	h, comments, _ := newTestHandler(t)
+
+	for _, comment := range []string{
+		"With `schemabot.yaml` at `files/migrations/`, the app uses declarative schema changes.",
+		"```sh\nschemabot plan -e staging\n```",
+	} {
+		req := buildWebhookRequest(t, webhookPayloadOpts{
+			comment: comment,
+			isPR:    true,
+		}, nil)
+
+		rr := httptest.NewRecorder()
+		h.ServeHTTP(rr, req)
+
+		require.Equal(t, http.StatusOK, rr.Code)
+		assert.Contains(t, rr.Body.String(), "no SchemaBot command")
+
+		select {
+		case <-comments:
+			t.Fatal("should not post a comment for prose or examples that mention SchemaBot")
+		default:
+		}
+	}
+}
+
 func TestWebhookEyesReaction(t *testing.T) {
 	h, _, reactions := newTestHandler(t)
 


### PR DESCRIPTION
Tightens PR comment command parsing so SchemaBot only treats line-start directives as commands. This prevents prose, filenames, URLs, and quoted examples that mention SchemaBot from triggering the invalid-command help response.

The parser still supports commands after introductory text when the command starts its own line, preserving the common copy/paste workflow for PR comments.

🤖 Generated by Codex (GPT-5).