### PR TITLE
feat(clock): add Clock abstraction and inject into scheduler / observer

### DIFF
--- a/pkg/api/scheduler.go
+++ b/pkg/api/scheduler.go
@@ -176,7 +176,7 @@ func (s *Service) recoverApplies(ctx context.Context, workerID int) {
 		return
 	}
 
-	start := time.Now()
+	start := s.clock.Now()
 	s.logger.Info("scheduler: claimed apply",
 		"worker", workerID,
 		"apply_id", apply.ApplyIdentifier,
@@ -243,7 +243,7 @@ func (s *Service) recoverApplies(ctx context.Context, workerID int) {
 		return
 	}
 
-	duration := time.Since(start)
+	duration := s.clock.Now().Sub(start)
 	s.logger.Info("scheduler: resumed apply",
 		"worker", workerID,
 		"apply_id", apply.ApplyIdentifier,

--- a/pkg/api/service.go
+++ b/pkg/api/service.go
@@ -205,14 +205,20 @@ func New(st storage.Storage, config *ServerConfig, ternClients map[string]tern.C
 }
 
 // SetClock overrides the time source used by orchestration loops (currently
-// the scheduler claim-duration measurement). Call before StartScheduler.
+// the scheduler claim-duration measurement). Must be called before
+// StartScheduler — once scheduler workers are running they read s.clock
+// concurrently, so swapping the field is rejected to avoid a data race.
 // Production callers should leave the default clock.Real{} in place; tests
-// use clock.NewFake to make timing observable.
-func (s *Service) SetClock(c clock.Clock) {
-	if c == nil {
-		return
+// use clock.NewFake to make timing observable. A nil or typed-nil c is
+// coalesced to clock.Real{} via clock.Default.
+func (s *Service) SetClock(c clock.Clock) error {
+	s.schedulerMu.Lock()
+	defer s.schedulerMu.Unlock()
+	if s.stopRecovery != nil {
+		return fmt.Errorf("cannot change clock while scheduler is running")
 	}
-	s.clock = c
+	s.clock = clock.Default(c)
+	return nil
 }
 
 // SetSchedulerPollInterval sets the scheduler worker poll interval.

--- a/pkg/api/service.go
+++ b/pkg/api/service.go
@@ -15,6 +15,7 @@ import (
 
 	gomysql "github.com/go-sql-driver/mysql"
 
+	"github.com/block/schemabot/pkg/clock"
 	"github.com/block/schemabot/pkg/secrets"
 	"github.com/block/schemabot/pkg/state"
 	"github.com/block/schemabot/pkg/storage"
@@ -110,6 +111,7 @@ type Service struct {
 	ternClients map[string]tern.Client // keyed by "deployment/environment", lazily created
 	ternMu      sync.Mutex             // protects ternClients
 	logger      *slog.Logger
+	clock       clock.Clock
 
 	// Scheduler loop management.
 	schedulerMu           sync.Mutex
@@ -196,9 +198,21 @@ func New(st storage.Storage, config *ServerConfig, ternClients map[string]tern.C
 		config:                config,
 		ternClients:           ternClients,
 		logger:                logger,
+		clock:                 clock.Real{},
 		schedulerPollInterval: SchedulerPollInterval,
 		pendingObservers:      make(map[pendingObserverKey]tern.ProgressObserver),
 	}
+}
+
+// SetClock overrides the time source used by orchestration loops (currently
+// the scheduler claim-duration measurement). Call before StartScheduler.
+// Production callers should leave the default clock.Real{} in place; tests
+// use clock.NewFake to make timing observable.
+func (s *Service) SetClock(c clock.Clock) {
+	if c == nil {
+		return
+	}
+	s.clock = c
 }
 
 // SetSchedulerPollInterval sets the scheduler worker poll interval.

--- a/pkg/clock/clock.go
+++ b/pkg/clock/clock.go
@@ -1,0 +1,55 @@
+// Package clock provides a minimal time source abstraction so orchestration
+// code (scheduler, comment observer) can be exercised deterministically in
+// tests without sleeping or racing against the wall clock.
+package clock
+
+import (
+	"sync"
+	"time"
+)
+
+// Clock is the minimal time source orchestration code depends on. Production
+// callers use Real; tests use Fake to advance time explicitly.
+type Clock interface {
+	Now() time.Time
+}
+
+// Real is a Clock backed by the operating system wall clock.
+type Real struct{}
+
+// Now returns the current wall-clock time.
+func (Real) Now() time.Time { return time.Now() }
+
+// Fake is a deterministic Clock for tests. The zero value is unsafe; use
+// NewFake. Now is safe to call from multiple goroutines; Advance and Set
+// serialize updates with a mutex.
+type Fake struct {
+	mu  sync.Mutex
+	now time.Time
+}
+
+// NewFake returns a Fake clock pinned to start.
+func NewFake(start time.Time) *Fake {
+	return &Fake{now: start}
+}
+
+// Now returns the current fake time.
+func (f *Fake) Now() time.Time {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.now
+}
+
+// Advance moves the fake clock forward by d.
+func (f *Fake) Advance(d time.Duration) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.now = f.now.Add(d)
+}
+
+// Set pins the fake clock to t.
+func (f *Fake) Set(t time.Time) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.now = t
+}

--- a/pkg/clock/clock.go
+++ b/pkg/clock/clock.go
@@ -4,6 +4,7 @@
 package clock
 
 import (
+	"reflect"
 	"sync"
 	"time"
 )
@@ -52,4 +53,22 @@ func (f *Fake) Set(t time.Time) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.now = t
+}
+
+// Default returns c if it is a usable Clock, otherwise Real{}. This guards
+// against both a plain nil interface and a typed-nil implementation
+// (e.g., a nil *Fake stored in a Clock interface), either of which would
+// otherwise panic on a later Now() call.
+func Default(c Clock) Clock {
+	if c == nil {
+		return Real{}
+	}
+	v := reflect.ValueOf(c)
+	switch v.Kind() {
+	case reflect.Pointer, reflect.Interface, reflect.Map, reflect.Slice, reflect.Chan, reflect.Func:
+		if v.IsNil() {
+			return Real{}
+		}
+	}
+	return c
 }

--- a/pkg/clock/clock_test.go
+++ b/pkg/clock/clock_test.go
@@ -1,0 +1,51 @@
+package clock
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReal_NowAdvances(t *testing.T) {
+	r := Real{}
+	first := r.Now()
+	// Real clock is monotonic and should not jump backward.
+	second := r.Now()
+	assert.False(t, second.Before(first), "Real.Now must be monotonic non-decreasing")
+}
+
+func TestFake_NowReturnsPinnedStart(t *testing.T) {
+	start := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	f := NewFake(start)
+	assert.Equal(t, start, f.Now())
+	assert.Equal(t, start, f.Now(), "Fake.Now must not advance on its own")
+}
+
+func TestFake_AdvanceMovesForward(t *testing.T) {
+	start := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	f := NewFake(start)
+	f.Advance(7 * time.Second)
+	assert.Equal(t, start.Add(7*time.Second), f.Now())
+	f.Advance(2 * time.Minute)
+	assert.Equal(t, start.Add(7*time.Second+2*time.Minute), f.Now())
+}
+
+func TestFake_SetPinsToTime(t *testing.T) {
+	f := NewFake(time.Unix(0, 0))
+	pin := time.Date(2030, 6, 15, 12, 0, 0, 0, time.UTC)
+	f.Set(pin)
+	assert.Equal(t, pin, f.Now())
+}
+
+func TestFake_ConcurrentAdvanceAndNowIsRaceFree(t *testing.T) {
+	f := NewFake(time.Unix(0, 0))
+	var wg sync.WaitGroup
+	for range 100 {
+		wg.Go(func() { f.Advance(time.Millisecond) })
+		wg.Go(func() { _ = f.Now() })
+	}
+	wg.Wait()
+	assert.Equal(t, time.Unix(0, 0).Add(100*time.Millisecond), f.Now())
+}

--- a/pkg/clock/clock_test.go
+++ b/pkg/clock/clock_test.go
@@ -39,6 +39,25 @@ func TestFake_SetPinsToTime(t *testing.T) {
 	assert.Equal(t, pin, f.Now())
 }
 
+func TestDefault_NilInterfaceReturnsReal(t *testing.T) {
+	got := Default(nil)
+	assert.IsType(t, Real{}, got)
+	assert.NotPanics(t, func() { _ = got.Now() })
+}
+
+func TestDefault_TypedNilFakeReturnsReal(t *testing.T) {
+	var f *Fake // typed-nil
+	got := Default(f)
+	assert.IsType(t, Real{}, got)
+	assert.NotPanics(t, func() { _ = got.Now() })
+}
+
+func TestDefault_NonNilPassesThrough(t *testing.T) {
+	f := NewFake(time.Unix(42, 0))
+	got := Default(f)
+	assert.Same(t, f, got)
+}
+
 func TestFake_ConcurrentAdvanceAndNowIsRaceFree(t *testing.T) {
 	f := NewFake(time.Unix(0, 0))
 	var wg sync.WaitGroup

--- a/pkg/webhook/comment_observer.go
+++ b/pkg/webhook/comment_observer.go
@@ -37,7 +37,8 @@ type CommentObserver struct {
 	OnTerminalHook func(apply *storage.Apply)
 
 	// clock is the time source used for adaptive rate-limit math. Defaults
-	// to clock.Real{} in NewCommentObserver; tests may inject clock.Fake.
+	// to clock.Real{} in NewCommentObserver; tests may inject a *clock.Fake
+	// via clock.NewFake(start).
 	clock clock.Clock
 
 	mu                sync.Mutex
@@ -74,7 +75,8 @@ type CommentObserverConfig struct {
 	OnTerminalHook func(apply *storage.Apply)
 
 	// Clock is the time source for adaptive rate-limit math. Optional —
-	// nil defaults to clock.Real{}. Tests inject clock.Fake to make the
+	// nil or typed-nil defaults to clock.Real{} (via clock.Default). Tests
+	// inject a *clock.Fake via clock.NewFake(start) to make the
 	// stagnant / active transition observable without sleeping.
 	Clock clock.Clock
 }
@@ -87,10 +89,7 @@ func (o *CommentObserver) SetApplyID(id int64) {
 
 // NewCommentObserver creates a new CommentObserver for posting PR comments.
 func NewCommentObserver(cfg CommentObserverConfig) *CommentObserver {
-	clk := cfg.Clock
-	if clk == nil {
-		clk = clock.Real{}
-	}
+	clk := clock.Default(cfg.Clock)
 	return &CommentObserver{
 		ghClient:       cfg.GHClient,
 		stor:           cfg.Storage,

--- a/pkg/webhook/comment_observer.go
+++ b/pkg/webhook/comment_observer.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/block/schemabot/pkg/clock"
 	"github.com/block/schemabot/pkg/github"
 	"github.com/block/schemabot/pkg/state"
 	"github.com/block/schemabot/pkg/storage"
@@ -34,6 +35,10 @@ type CommentObserver struct {
 	// Used by the webhook handler to update check runs on terminal state.
 	// Optional — nil means no hook.
 	OnTerminalHook func(apply *storage.Apply)
+
+	// clock is the time source used for adaptive rate-limit math. Defaults
+	// to clock.Real{} in NewCommentObserver; tests may inject clock.Fake.
+	clock clock.Clock
 
 	mu                sync.Mutex
 	lastProgressPost  time.Time
@@ -67,6 +72,11 @@ type CommentObserverConfig struct {
 	// OnTerminalHook is called after the summary comment is posted.
 	// Used to update check runs on terminal state.
 	OnTerminalHook func(apply *storage.Apply)
+
+	// Clock is the time source for adaptive rate-limit math. Optional —
+	// nil defaults to clock.Real{}. Tests inject clock.Fake to make the
+	// stagnant / active transition observable without sleeping.
+	Clock clock.Clock
 }
 
 // SetApplyID sets the apply ID after the apply record is created.
@@ -77,6 +87,10 @@ func (o *CommentObserver) SetApplyID(id int64) {
 
 // NewCommentObserver creates a new CommentObserver for posting PR comments.
 func NewCommentObserver(cfg CommentObserverConfig) *CommentObserver {
+	clk := cfg.Clock
+	if clk == nil {
+		clk = clock.Real{}
+	}
 	return &CommentObserver{
 		ghClient:       cfg.GHClient,
 		stor:           cfg.Storage,
@@ -87,6 +101,7 @@ func NewCommentObserver(cfg CommentObserverConfig) *CommentObserver {
 		deferCutover:   cfg.DeferCutover,
 		logger:         cfg.Logger,
 		OnTerminalHook: cfg.OnTerminalHook,
+		clock:          clk,
 	}
 }
 
@@ -97,7 +112,7 @@ func (o *CommentObserver) OnProgress(apply *storage.Apply, tasks []*storage.Task
 	o.mu.Lock()
 	defer o.mu.Unlock()
 
-	now := time.Now()
+	now := o.clock.Now()
 	currentState := apply.State
 
 	// Check if a cutover comment was posted by an external handler.


### PR DESCRIPTION
## What and Why ?
Adds a small `pkg/clock` package (`Clock` interface, `Real`, `Fake`, `Default`) and wires it into the two orchestration loops where timing materially affects behavior — without changing production behavior or any public constructor signatures.

### Wiring

| Site | Field | How it's set |
| --- | --- | --- |
| `api.Service` | `clock` (used by the scheduler claim-duration metric) | Defaults to `clock.Real{}` in `api.New`; tests can override via `s.SetClock(...)` before `StartScheduler` (returns an error if the scheduler is already running) |
| `webhook.CommentObserver` | `clock` (used by the adaptive `OnProgress` rate-limit math) | Optional `CommentObserverConfig.Clock`; defaults to `clock.Real{}` when nil |

Both injection points route through `clock.Default(c)`, which coalesces both a plain nil interface and a typed-nil implementation (e.g., a nil `*clock.Fake`) to `clock.Real{}` so a misconfigured caller cannot panic at `Now()`.

### Benefits

- New `pkg/clock` package gives the rest of the codebase a single, minimal time source it can swap in tests.
- Makes scheduler / observer timing **testable without sleeping** — once call sites are converted to `f := clock.NewFake(start); f.Advance(d)`, eliminating a class of wall-clock flakes.
- **Unlocks** deterministic timing tests for the scheduler / observer; a follow-up PR can rewrite wall-clock dependent tests to use `clock.NewFake`. No existing tests are switched over in this PR.
- Keeps the abstraction minimal: only `Now() time.Time` today. No `Sleep`, `After`, or `Tick` until a caller actually needs them.
- Zero production behavior change — `Real{}` delegates to `time.Now()`.
- No constructor signature breakage; all existing callers of `api.New` and `NewCommentObserver` keep working.

### Validation

- `go build ./...`
- `go test -count=1 -race ./pkg/clock/... ./pkg/api/... ./pkg/webhook/...`
- `make test-unit` — all packages pass
- `golangci-lint run --new-from-rev=origin/main ./pkg/...` — 0 issues