### PR TITLE
Surface remote apply failures in gRPC status

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -259,6 +259,95 @@ State authority is intentionally one-way: engine progress is an input, not the d
 
 Unknown raw engine states normalize to `running`. This keeps unfamiliar in-flight work visible and blocking without leaking engine-specific strings into SchemaBot state or UI. Once the engine state is understood, update `NormalizeTaskStatus()` and the state-policy tests so the new state has an explicit task-state mapping and ordering policy.
 
+#### Remote gRPC Progress Synchronization
+
+Remote gRPC progress is core Tern scheduler behavior. In gRPC mode, the
+SchemaBot API queues and tracks applies in control-plane storage, while a remote
+Tern deployment executes the schema change and reports progress for its own
+apply ID. The scheduler worker that claims the stored apply also owns the
+durable progress polling loop for that remote apply.
+
+```
+CLI / webhook apply request
+        |
+        v
+SchemaBot API creates stored apply + tasks
+        |
+        v
+Scheduler worker claims apply
+        |
+        v
+GRPCClient.ResumeApply()
+        |
+        +-- no external_id yet -> dispatch Apply to remote Tern
+        |                        and store remote apply_id as external_id
+        |
+        v
+Same scheduler worker polls Progress(apply_id=external_id, environment)
+        |
+        v
+Stored apply/task rows are updated for status, logs, recovery, and UI
+```
+
+HTTP progress endpoints and the CLI/TUI may also request progress, but those
+request-time reads are not the durable synchronization path. The scheduler
+worker's polling loop is what keeps SchemaBot storage reconciled with the remote
+data plane.
+
+Remote progress requests are scoped by apply ID and environment only:
+
+```
+ProgressRequest{
+  apply_id:     <remote external_id for gRPC, SchemaBot apply_id for local>
+  environment:  <environment>
+}
+```
+
+The public HTTP API continues to return SchemaBot's `apply_id`. In gRPC mode the
+API resolves that stored apply to `external_id` before calling remote Tern;
+local mode has no external ID and uses the SchemaBot apply ID directly.
+
+##### Repeated Remote Progress Errors
+
+Transient progress RPC errors do not cause SchemaBot to send a remote `Stop`
+request. A progress outage only proves the control plane cannot observe the
+remote apply; it does not prove the remote apply should be stopped.
+
+Instead, the scheduler worker counts consecutive progress polling errors:
+
+```
+Scheduler worker polls remote Progress
+        |
+        +-- NotFound / no active change
+        |       |
+        |       v
+        |   fail stored apply/tasks
+        |
+        +-- permanent progress RPC error
+        |       |
+        |       v
+        |   fail stored apply/tasks
+        |
+        +-- transient progress RPC error
+        |       |
+        |       v
+        |   increment consecutive error count
+        |       |
+        |       +-- below limit -> keep polling
+        |       |
+        |       +-- at limit -> mark stored apply/tasks failed_retryable
+        |
+        +-- successful progress response
+                |
+                v
+            reset consecutive error count and sync storage
+```
+
+`failed_retryable` pauses the current scheduler attempt and keeps the apply
+visible and blocking until recovery retries it. The remote data-plane apply may
+still be running; SchemaBot deliberately avoids issuing a stop command when the
+only problem is repeated inability to read progress.
+
 The `ProgressObserver` interface (`pkg/tern/observer.go`) enables external notifications from the apply progress poller. Observers see SchemaBot's derived apply/task state, not raw engine state.
 
 ```go

--- a/e2e/k8s/k8s_test.go
+++ b/e2e/k8s/k8s_test.go
@@ -62,6 +62,7 @@ import (
 	ternv1 "github.com/block/schemabot/pkg/proto/ternv1"
 	"github.com/block/schemabot/pkg/state"
 	"github.com/block/schemabot/pkg/storage"
+	"github.com/block/schemabot/pkg/storage/mysqlstore"
 	"github.com/block/spirit/pkg/lint"
 	"github.com/block/spirit/pkg/utils"
 	"github.com/stretchr/testify/assert"
@@ -238,6 +239,130 @@ func waitForControlPlaneApplyLogs(t *testing.T, endpoint string, applyID, tableN
 		},
 		func() string {
 			return fmt.Sprintf("control-plane apply logs did not contain the full remote lifecycle for %s: api_logs=%s last_err=%v",
+				applyID, formatLogEntries(logs), lastErr)
+		})
+}
+
+// TestK8s_RemoteFailureErrorVisibleInControlPlaneStatus verifies that a remote
+// terminal failure observed over gRPC is copied into the control plane's status
+// and logs. Operators should not need data-plane access to see why the apply
+// failed.
+func TestK8s_RemoteFailureErrorVisibleInControlPlaneStatus(t *testing.T) {
+	cleanupState(t)
+
+	endpoint := testutil.Endpoint(t)
+	failureMessage := "remote schema change failed while checking target connectivity"
+	tableName := testutil.UniqueTableName("k8s_remote_failure")
+
+	dataPlaneApplyID := createStoredK8sApplyWithTask(t, storageDSNs(t)[0], &storage.Apply{
+		ApplyIdentifier: testutil.UniqueTableName("apply-remote-failed"),
+		Database:        "testapp",
+		DatabaseType:    storage.DatabaseTypeMySQL,
+		Deployment:      "testapp",
+		Environment:     "staging",
+		Caller:          "e2e",
+		Engine:          storage.EngineSpirit,
+		State:           state.Apply.Failed,
+		ErrorMessage:    failureMessage,
+	}, &storage.Task{
+		TaskIdentifier: testutil.UniqueTableName("task-remote-failed"),
+		Database:       "testapp",
+		DatabaseType:   storage.DatabaseTypeMySQL,
+		Namespace:      "testapp",
+		TableName:      tableName,
+		DDL:            fmt.Sprintf("ALTER TABLE `%s` ADD COLUMN `status_flag` int NULL", tableName),
+		DDLAction:      "alter",
+		Engine:         storage.EngineSpirit,
+		Environment:    "staging",
+		State:          state.Task.Failed,
+		ErrorMessage:   failureMessage,
+	})
+
+	controlPlaneApplyID := createStoredK8sApplyWithTask(t, testutil.SchemabotDSN(t), &storage.Apply{
+		ApplyIdentifier: testutil.UniqueTableName("apply-control-failed"),
+		Database:        "testapp",
+		DatabaseType:    storage.DatabaseTypeMySQL,
+		Deployment:      "data-plane",
+		Environment:     "staging",
+		Caller:          "e2e",
+		ExternalID:      dataPlaneApplyID,
+		Engine:          storage.EngineSpirit,
+		State:           state.Apply.Running,
+	}, &storage.Task{
+		TaskIdentifier: testutil.UniqueTableName("task-control-failed"),
+		Database:       "testapp",
+		DatabaseType:   storage.DatabaseTypeMySQL,
+		Namespace:      "testapp",
+		TableName:      tableName,
+		DDL:            fmt.Sprintf("ALTER TABLE `%s` ADD COLUMN `status_flag` int NULL", tableName),
+		DDLAction:      "alter",
+		Engine:         storage.EngineSpirit,
+		Environment:    "staging",
+		State:          state.Task.Running,
+	})
+	markControlPlaneHeartbeatStale(t, controlPlaneApplyID)
+
+	var (
+		progress *apitypes.ProgressResponse
+		lastErr  error
+	)
+	testutil.Poll(t, testutil.PollDeadline, testutil.PollInterval,
+		func() bool {
+			progress, lastErr = testutil.FetchProgress(endpoint, controlPlaneApplyID)
+			return lastErr == nil &&
+				state.IsState(progress.State, state.Apply.Failed) &&
+				progress.ErrorMessage == failureMessage
+		},
+		func() string {
+			if progress == nil {
+				return fmt.Sprintf("timeout waiting for remote failure to appear in control-plane status for %s: last_err=%v", controlPlaneApplyID, lastErr)
+			}
+			return fmt.Sprintf("timeout waiting for remote failure to appear in control-plane status for %s: state=%s error=%q last_err=%v",
+				controlPlaneApplyID, progress.State, progress.ErrorMessage, lastErr)
+		})
+
+	require.Len(t, progress.Tables, 1)
+	assert.Equal(t, tableName, progress.Tables[0].TableName)
+	assert.Equal(t, state.Task.Failed, progress.Tables[0].Status)
+	waitForControlPlaneFailureLog(t, endpoint, controlPlaneApplyID, failureMessage)
+}
+
+func createStoredK8sApplyWithTask(t *testing.T, dsn string, apply *storage.Apply, task *storage.Task) string {
+	t.Helper()
+
+	db, err := sql.Open("mysql", dsn)
+	require.NoError(t, err)
+	defer utils.CloseAndLog(db)
+	require.NoError(t, db.PingContext(t.Context()))
+
+	now := time.Now()
+	task.CreatedAt = now
+	task.UpdatedAt = now
+	if task.StartedAt == nil && !state.IsState(task.State, state.Task.Pending) {
+		task.StartedAt = &now
+	}
+	if task.CompletedAt == nil && state.IsTerminalTaskState(task.State) {
+		task.CompletedAt = &now
+	}
+
+	store := mysqlstore.New(db)
+	_, err = store.Applies().CreateWithTasks(t.Context(), apply, []*storage.Task{task})
+	require.NoError(t, err)
+	return apply.ApplyIdentifier
+}
+
+func waitForControlPlaneFailureLog(t *testing.T, endpoint, applyID, failureMessage string) {
+	t.Helper()
+
+	var logs []*client.LogEntry
+	var lastErr error
+	testutil.Poll(t, testutil.PollDeadline, testutil.PollInterval,
+		func() bool {
+			logs, lastErr = client.GetLogs(endpoint, "", "", applyID, 50)
+			return lastErr == nil && hasLogTransitionTo(logs, "Remote apply reached terminal state: failed: "+failureMessage, state.Apply.Failed)
+		},
+		func() string {
+			return fmt.Sprintf("control-plane apply logs did not contain remote failure for %s: api_logs=%s last_err=%v",
 				applyID, formatLogEntries(logs), lastErr)
 		})
 }

--- a/pkg/api/control_handlers.go
+++ b/pkg/api/control_handlers.go
@@ -428,7 +428,6 @@ func (s *Service) queueRemoteStoppedApplyForScheduler(ctx context.Context, clien
 	}
 	resp, err := client.Progress(ctx, &ternv1.ProgressRequest{
 		ApplyId:     apply.ExternalID,
-		Database:    apply.Database,
 		Environment: apply.Environment,
 	})
 	if err != nil {

--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -1029,6 +1029,34 @@ func TestProgressByApplyIDResolvesExternalIDForRemoteApply(t *testing.T) {
 	assert.Equal(t, state.Apply.Running, resp.State)
 }
 
+func TestProgressByApplyIDIncludesDatabaseType(t *testing.T) {
+	// Remote progress requests include the stored database type so the data plane
+	// can route progress even when an apply ID is the only stable identifier.
+	mock := &mockTernClient{
+		isRemote: true,
+		progressResp: &ternv1.ProgressResponse{
+			State: ternv1.State_STATE_RUNNING,
+		},
+	}
+	apply := activeTestApply("apply-active-remote")
+	apply.DatabaseType = storage.DatabaseTypeVitess
+	apply.ExternalID = "remote-active-remote"
+	svc := newControlTestService(mock, apply)
+	mux := http.NewServeMux()
+	svc.ConfigureRoutes(mux)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/progress/apply/apply-active-remote", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	require.NotNil(t, mock.progressReq)
+	assert.Equal(t, "remote-active-remote", mock.progressReq.ApplyId)
+	assert.Equal(t, "testdb", mock.progressReq.Database)
+	assert.Equal(t, storage.DatabaseTypeVitess, mock.progressReq.Type)
+	assert.Equal(t, "staging", mock.progressReq.Environment)
+}
+
 func TestExecuteApplyQueuesLocalApplyForScheduler(t *testing.T) {
 	applies := &capturingApplyStore{}
 	mock := &mockTernClient{}

--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -1029,9 +1029,9 @@ func TestProgressByApplyIDResolvesExternalIDForRemoteApply(t *testing.T) {
 	assert.Equal(t, state.Apply.Running, resp.State)
 }
 
-func TestProgressByApplyIDIncludesDatabaseType(t *testing.T) {
-	// Remote progress requests include the stored database type so the data plane
-	// can route progress even when an apply ID is the only stable identifier.
+func TestProgressByApplyIDDoesNotSendDatabaseType(t *testing.T) {
+	// Remote progress lookups use the apply ID as the stable routing key. The
+	// data plane should not need a database type hint to interpret that ID.
 	mock := &mockTernClient{
 		isRemote: true,
 		progressResp: &ternv1.ProgressResponse{
@@ -1053,7 +1053,7 @@ func TestProgressByApplyIDIncludesDatabaseType(t *testing.T) {
 	require.NotNil(t, mock.progressReq)
 	assert.Equal(t, "remote-active-remote", mock.progressReq.ApplyId)
 	assert.Equal(t, "testdb", mock.progressReq.Database)
-	assert.Equal(t, storage.DatabaseTypeVitess, mock.progressReq.Type)
+	assert.Empty(t, mock.progressReq.Type)
 	assert.Equal(t, "staging", mock.progressReq.Environment)
 }
 

--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -1029,9 +1029,9 @@ func TestProgressByApplyIDResolvesExternalIDForRemoteApply(t *testing.T) {
 	assert.Equal(t, state.Apply.Running, resp.State)
 }
 
-func TestProgressByApplyIDDoesNotSendDatabaseType(t *testing.T) {
+func TestProgressByApplyIDOnlySendsApplyIDAndEnvironment(t *testing.T) {
 	// Remote progress lookups use the apply ID as the stable routing key. The
-	// data plane should not need a database type hint to interpret that ID.
+	// data plane should not need database routing hints to interpret that ID.
 	mock := &mockTernClient{
 		isRemote: true,
 		progressResp: &ternv1.ProgressResponse{
@@ -1052,8 +1052,6 @@ func TestProgressByApplyIDDoesNotSendDatabaseType(t *testing.T) {
 	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
 	require.NotNil(t, mock.progressReq)
 	assert.Equal(t, "remote-active-remote", mock.progressReq.ApplyId)
-	assert.Equal(t, "testdb", mock.progressReq.Database)
-	assert.Empty(t, mock.progressReq.Type)
 	assert.Equal(t, "staging", mock.progressReq.Environment)
 }
 

--- a/pkg/api/progress_handlers.go
+++ b/pkg/api/progress_handlers.go
@@ -132,32 +132,6 @@ func (s *Service) deploymentForDatabaseEnvironment(database, deployment, environ
 	return resolved.Deployment, nil
 }
 
-// progressTargetForDatabaseEnvironment resolves the routing metadata needed for
-// progress RPCs. Stored apply metadata stays authoritative for active work.
-func (s *Service) progressTargetForDatabaseEnvironment(database string, apply *storage.Apply, environment string) (ResolvedDatabaseTarget, error) {
-	target := ResolvedDatabaseTarget{}
-	if apply != nil {
-		target.DatabaseType = apply.DatabaseType
-		target.Deployment = apply.Deployment
-	}
-	if target.DatabaseType != "" && target.Deployment != "" {
-		return target, nil
-	}
-
-	resolved, err := s.config.ResolveDatabaseTarget(database, environment)
-	if err != nil {
-		return target, err
-	}
-	if target.DatabaseType == "" {
-		target.DatabaseType = resolved.DatabaseType
-	}
-	if target.Deployment == "" {
-		target.Deployment = resolved.Deployment
-	}
-	target.Target = resolved.Target
-	return target, nil
-}
-
 // progressResponseFromProto converts a protobuf ProgressResponse to an HTTP ProgressResponse.
 func progressResponseFromProto(resp *ternv1.ProgressResponse) *apitypes.ProgressResponse {
 	progressState := tern.ProtoStateToStorage(resp.State)

--- a/pkg/api/progress_handlers.go
+++ b/pkg/api/progress_handlers.go
@@ -132,6 +132,32 @@ func (s *Service) deploymentForDatabaseEnvironment(database, deployment, environ
 	return resolved.Deployment, nil
 }
 
+// progressTargetForDatabaseEnvironment resolves the routing metadata needed for
+// progress RPCs. Stored apply metadata stays authoritative for active work.
+func (s *Service) progressTargetForDatabaseEnvironment(database string, apply *storage.Apply, environment string) (ResolvedDatabaseTarget, error) {
+	target := ResolvedDatabaseTarget{}
+	if apply != nil {
+		target.DatabaseType = apply.DatabaseType
+		target.Deployment = apply.Deployment
+	}
+	if target.DatabaseType != "" && target.Deployment != "" {
+		return target, nil
+	}
+
+	resolved, err := s.config.ResolveDatabaseTarget(database, environment)
+	if err != nil {
+		return target, err
+	}
+	if target.DatabaseType == "" {
+		target.DatabaseType = resolved.DatabaseType
+	}
+	if target.Deployment == "" {
+		target.Deployment = resolved.Deployment
+	}
+	target.Target = resolved.Target
+	return target, nil
+}
+
 // progressResponseFromProto converts a protobuf ProgressResponse to an HTTP ProgressResponse.
 func progressResponseFromProto(resp *ternv1.ProgressResponse) *apitypes.ProgressResponse {
 	progressState := tern.ProtoStateToStorage(resp.State)

--- a/pkg/tern/grpc_client.go
+++ b/pkg/tern/grpc_client.go
@@ -490,6 +490,7 @@ func (c *GRPCClient) ResumeApply(ctx context.Context, apply *storage.Apply) erro
 				return fmt.Errorf("check stopped gRPC apply %s before start: unmapped remote state %s", apply.ApplyIdentifier, remoteApplyStateDescription(resp.State))
 			}
 			apply.State = remoteState
+			apply.ErrorMessage = remoteProgressErrorMessage(apply.State, resp.ErrorMessage, apply.ErrorMessage)
 			if isTerminalProtoState(resp.State) && !state.IsState(remoteState, state.Apply.Stopped) {
 				now := time.Now()
 				if apply.StartedAt == nil && !state.IsState(remoteState, state.Apply.Pending) {
@@ -924,10 +925,35 @@ func (c *GRPCClient) persistTerminalStateFromRemote(ctx context.Context, storedA
 			return err
 		}
 	}
-	c.logApplyStateTransition(ctx, storedApply, storage.LogLevelInfo, fmt.Sprintf("Remote apply reached terminal state: %s", storedApply.State), oldState)
+	c.logApplyStateTransition(ctx, storedApply, remoteTerminalApplyLogLevel(storedApply), remoteTerminalApplyLogMessage(storedApply), oldState)
 	*remoteApply = *storedApply
 	metrics.AdjustActiveApplies(ctx, -1, storedApply.Database, storedApply.Environment)
 	return nil
+}
+
+func remoteTerminalApplyLogLevel(apply *storage.Apply) string {
+	if apply != nil && state.IsState(apply.State, state.Apply.Failed) {
+		return storage.LogLevelError
+	}
+	return storage.LogLevelInfo
+}
+
+func remoteTerminalApplyLogMessage(apply *storage.Apply) string {
+	message := fmt.Sprintf("Remote apply reached terminal state: %s", apply.State)
+	if state.IsState(apply.State, state.Apply.Failed) && apply.ErrorMessage != "" {
+		return fmt.Sprintf("%s: %s", message, apply.ErrorMessage)
+	}
+	return message
+}
+
+func remoteProgressErrorMessage(applyState, remoteErrorMessage, existingErrorMessage string) string {
+	if state.IsState(applyState, state.Apply.Failed, state.Apply.FailedRetryable) {
+		if remoteErrorMessage == "" {
+			return existingErrorMessage
+		}
+		return remoteErrorMessage
+	}
+	return ""
 }
 
 // syncStoredTasksFromRemoteTasks mirrors the per-task table progress fields
@@ -1167,6 +1193,7 @@ func (c *GRPCClient) pollForCompletion(ctx context.Context, apply *storage.Apply
 					"remote_state", remoteApplyState)
 			}
 			apply.State = newState
+			apply.ErrorMessage = remoteProgressErrorMessage(apply.State, resp.ErrorMessage, apply.ErrorMessage)
 			apply.UpdatedAt = now
 
 			terminal := isTerminalProtoState(resp.State)

--- a/pkg/tern/grpc_client.go
+++ b/pkg/tern/grpc_client.go
@@ -116,7 +116,10 @@ import (
 	"github.com/block/schemabot/pkg/storage"
 )
 
-const grpcProgressPollInterval = 500 * time.Millisecond
+const (
+	grpcProgressPollInterval       = 500 * time.Millisecond
+	maxGRPCProgressPollErrorStreak = 10
+)
 
 // GRPCClient implements Client using gRPC.
 // It delegates execution to a remote Tern service but SchemaBot still manages
@@ -704,6 +707,27 @@ func isRetryableRemoteApplyError(err error) bool {
 	}
 }
 
+func isTerminalRemoteProgressError(err error) bool {
+	if err == nil {
+		return false
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		return false
+	}
+
+	switch st.Code() {
+	case codes.InvalidArgument, codes.AlreadyExists, codes.PermissionDenied, codes.Unauthenticated,
+		codes.FailedPrecondition, codes.OutOfRange, codes.Unimplemented, codes.DataLoss:
+		return true
+	case codes.OK, codes.NotFound, codes.Internal, codes.Unknown, codes.Unavailable, codes.ResourceExhausted,
+		codes.Aborted, codes.Canceled, codes.DeadlineExceeded:
+		return false
+	default:
+		return false
+	}
+}
+
 func (c *GRPCClient) prepareDispatchTasks(ctx context.Context, apply *storage.Apply, tasks []*storage.Task) error {
 	for _, task := range tasks {
 		if !state.IsState(task.State, state.Task.FailedRetryable) {
@@ -1127,6 +1151,7 @@ func (c *GRPCClient) pollForCompletion(ctx context.Context, apply *storage.Apply
 	heartbeatTicker := time.NewTicker(10 * time.Second)
 	defer heartbeatTicker.Stop()
 
+	consecutiveProgressErrors := 0
 	for {
 		select {
 		case <-ctx.Done():
@@ -1147,14 +1172,33 @@ func (c *GRPCClient) pollForCompletion(ctx context.Context, apply *storage.Apply
 					message := fmt.Sprintf("remote apply %s was not found by data plane", apply.ExternalID)
 					return c.failMissingRemoteApply(ctx, apply, message, err)
 				}
+				if isTerminalRemoteProgressError(err) {
+					message := fmt.Sprintf("remote progress failed for remote apply %s: %v", apply.ExternalID, err)
+					if markErr := c.markRemoteApplyFailed(ctx, apply, nil, message, false); markErr != nil {
+						return fmt.Errorf("mark remote apply %s failed after terminal progress error: %w", apply.ApplyIdentifier, markErr)
+					}
+					return fmt.Errorf("poll remote apply %s for %s: %w", apply.ExternalID, apply.ApplyIdentifier, err)
+				}
+				consecutiveProgressErrors++
 				slog.Warn("remote gRPC progress poll failed",
 					"apply_id", apply.ApplyIdentifier,
 					"external_id", apply.ExternalID,
 					"database", apply.Database,
 					"environment", apply.Environment,
+					"consecutive_errors", consecutiveProgressErrors,
+					"max_consecutive_errors", maxGRPCProgressPollErrorStreak,
 					"error", err)
+				if consecutiveProgressErrors >= maxGRPCProgressPollErrorStreak {
+					message := fmt.Sprintf("remote progress polling failed after %d consecutive errors for remote apply %s: %v",
+						consecutiveProgressErrors, apply.ExternalID, err)
+					if markErr := c.markRemoteApplyFailed(ctx, apply, nil, message, true); markErr != nil {
+						return fmt.Errorf("mark remote apply %s retryable after progress polling errors: %w", apply.ApplyIdentifier, markErr)
+					}
+					return fmt.Errorf("poll remote apply %s for %s: %w", apply.ExternalID, apply.ApplyIdentifier, err)
+				}
 				continue
 			}
+			consecutiveProgressErrors = 0
 			if resp.State == ternv1.State_STATE_NO_ACTIVE_CHANGE {
 				message := fmt.Sprintf("remote apply %s returned no active schema change for exact apply_id", apply.ExternalID)
 				return c.failMissingRemoteApply(ctx, apply, message, nil)

--- a/pkg/tern/grpc_client.go
+++ b/pkg/tern/grpc_client.go
@@ -788,11 +788,25 @@ func (c *GRPCClient) reloadStoredApplyForRemoteTransition(ctx context.Context, r
 	if storedApply == nil {
 		return nil, storedApplyTransitionMissing, nil
 	}
-	if state.IsTerminalApplyState(storedApply.State) && (!allowStoppedStoredApply || !state.IsState(storedApply.State, state.Apply.Stopped)) {
+	if storedTerminalApplyBlocksRemoteTransition(storedApply, allowStoppedStoredApply) {
 		*remoteApply = *storedApply
 		return storedApply, storedApplyTransitionAlreadyTerminal, nil
 	}
 	return storedApply, storedApplyTransitionReady, nil
+}
+
+// A terminal stored apply is usually authoritative: a stale worker must not
+// overwrite a newer completed/failed/reverted result. Stopped is the one
+// terminal state that may still be superseded when the caller is reconciling an
+// exact remote apply ID that is missing or no longer active.
+func storedTerminalApplyBlocksRemoteTransition(storedApply *storage.Apply, allowStoppedStoredApply bool) bool {
+	if storedApply == nil || !state.IsTerminalApplyState(storedApply.State) {
+		return false
+	}
+	if allowStoppedStoredApply && state.IsState(storedApply.State, state.Apply.Stopped) {
+		return false
+	}
+	return true
 }
 
 func logSkippedRemoteApplyTransition(operation string, remoteApply, storedApply *storage.Apply, status storedApplyTransitionStatus, err error) {

--- a/pkg/tern/grpc_client.go
+++ b/pkg/tern/grpc_client.go
@@ -468,15 +468,14 @@ func (c *GRPCClient) ResumeApply(ctx context.Context, apply *storage.Apply) erro
 		})
 		if err == nil {
 			if resp.State == ternv1.State_STATE_NO_ACTIVE_CHANGE {
-				message := fmt.Sprintf("Remote stopped-state check returned no active schema change for remote apply %s; scheduler will not request remote start", apply.ExternalID)
+				message := fmt.Sprintf("remote apply %s returned no active schema change for exact apply_id during stopped-state check", apply.ExternalID)
 				slog.Warn("remote gRPC stopped-state check returned no active schema change; scheduler will not request remote start",
 					"apply_id", apply.ApplyIdentifier,
 					"external_id", apply.ExternalID,
 					"database", apply.Database,
 					"environment", apply.Environment,
 					"stored_state", apply.State)
-				c.logApplyWarning(ctx, apply, message)
-				return fmt.Errorf("check stopped gRPC apply %s before start: no active schema change for remote apply %s", apply.ApplyIdentifier, apply.ExternalID)
+				return c.failMissingStoppedRemoteApply(ctx, apply, message, nil)
 			}
 			remoteState := ProtoStateToStorage(resp.State)
 			if remoteState == "" {
@@ -502,6 +501,17 @@ func (c *GRPCClient) ResumeApply(ctx context.Context, apply *storage.Apply) erro
 				return c.reconcileTerminalRemoteProgress(ctx, apply, resp.Tables, now)
 			}
 		} else {
+			if status.Code(err) == codes.NotFound {
+				message := fmt.Sprintf("remote apply %s was not found by data plane during stopped-state check", apply.ExternalID)
+				return c.failMissingStoppedRemoteApply(ctx, apply, message, err)
+			}
+			if isTerminalRemoteProgressError(err) {
+				message := fmt.Sprintf("remote stopped-state check failed for remote apply %s: %v", apply.ExternalID, err)
+				if markErr := c.markStoppedRemoteApplyFailed(ctx, apply, message, false); markErr != nil {
+					return fmt.Errorf("mark remote apply %s failed after stopped-state check error: %w", apply.ApplyIdentifier, markErr)
+				}
+				return fmt.Errorf("check stopped gRPC apply %s before start: %w", apply.ApplyIdentifier, err)
+			}
 			message := fmt.Sprintf("Remote stopped-state check failed before scheduler start: %v", err)
 			slog.Warn("remote gRPC stopped-state check failed; scheduler will not request remote start",
 				"apply_id", apply.ApplyIdentifier,
@@ -770,7 +780,7 @@ const (
 	storedApplyTransitionAlreadyTerminal storedApplyTransitionStatus = "already_terminal"
 )
 
-func (c *GRPCClient) reloadStoredApplyForRemoteTransition(ctx context.Context, remoteApply *storage.Apply) (*storage.Apply, storedApplyTransitionStatus, error) {
+func (c *GRPCClient) reloadStoredApplyForRemoteTransition(ctx context.Context, remoteApply *storage.Apply, allowStoppedStoredApply bool) (*storage.Apply, storedApplyTransitionStatus, error) {
 	storedApply, err := c.storage.Applies().Get(ctx, remoteApply.ID)
 	if err != nil {
 		return nil, storedApplyTransitionReloadFailed, fmt.Errorf("reload remote gRPC apply %s: %w", remoteApply.ApplyIdentifier, err)
@@ -778,7 +788,7 @@ func (c *GRPCClient) reloadStoredApplyForRemoteTransition(ctx context.Context, r
 	if storedApply == nil {
 		return nil, storedApplyTransitionMissing, nil
 	}
-	if state.IsTerminalApplyState(storedApply.State) {
+	if state.IsTerminalApplyState(storedApply.State) && (!allowStoppedStoredApply || !state.IsState(storedApply.State, state.Apply.Stopped)) {
 		*remoteApply = *storedApply
 		return storedApply, storedApplyTransitionAlreadyTerminal, nil
 	}
@@ -810,7 +820,15 @@ func logSkippedRemoteApplyTransition(operation string, remoteApply, storedApply 
 }
 
 func (c *GRPCClient) markRemoteApplyFailed(ctx context.Context, remoteApply *storage.Apply, storedTasks []*storage.Task, message string, retryable bool) error {
-	storedApply, transitionStatus, err := c.reloadStoredApplyForRemoteTransition(ctx, remoteApply)
+	return c.markRemoteApplyFailedWithOptions(ctx, remoteApply, storedTasks, message, retryable, false)
+}
+
+func (c *GRPCClient) markStoppedRemoteApplyFailed(ctx context.Context, remoteApply *storage.Apply, message string, retryable bool) error {
+	return c.markRemoteApplyFailedWithOptions(ctx, remoteApply, nil, message, retryable, true)
+}
+
+func (c *GRPCClient) markRemoteApplyFailedWithOptions(ctx context.Context, remoteApply *storage.Apply, storedTasks []*storage.Task, message string, retryable, allowStoppedStoredApply bool) error {
+	storedApply, transitionStatus, err := c.reloadStoredApplyForRemoteTransition(ctx, remoteApply, allowStoppedStoredApply)
 	if transitionStatus != storedApplyTransitionReady {
 		logSkippedRemoteApplyTransition("mark remote gRPC apply failed", remoteApply, storedApply, transitionStatus, err)
 		if err != nil {
@@ -885,12 +903,22 @@ func (c *GRPCClient) failMissingRemoteApply(ctx context.Context, remoteApply *st
 	return fmt.Errorf("poll remote apply %s for %s: %s", remoteApply.ExternalID, remoteApply.ApplyIdentifier, message)
 }
 
+func (c *GRPCClient) failMissingStoppedRemoteApply(ctx context.Context, remoteApply *storage.Apply, message string, cause error) error {
+	if err := c.markStoppedRemoteApplyFailed(ctx, remoteApply, message, false); err != nil {
+		return fmt.Errorf("mark missing stopped remote apply %s failed: %w", remoteApply.ApplyIdentifier, err)
+	}
+	if cause != nil {
+		return fmt.Errorf("check stopped remote apply %s for %s: %w", remoteApply.ExternalID, remoteApply.ApplyIdentifier, cause)
+	}
+	return fmt.Errorf("check stopped remote apply %s for %s: %s", remoteApply.ExternalID, remoteApply.ApplyIdentifier, message)
+}
+
 func (c *GRPCClient) reconcileTerminalRemoteProgress(ctx context.Context, remoteApply *storage.Apply, remoteTasks []*ternv1.TableProgress, now time.Time) error {
 	// reloadStoredApplyForRemoteTransition may overwrite remoteApply with the
 	// stored row when it finds an already-terminal stored apply. Keep the remote
 	// Progress result available for the stopped-row exception below.
 	remoteApplyFromProgress := *remoteApply
-	storedApply, transitionStatus, err := c.reloadStoredApplyForRemoteTransition(ctx, remoteApply)
+	storedApply, transitionStatus, err := c.reloadStoredApplyForRemoteTransition(ctx, remoteApply, false)
 
 	// A scheduler claim can start from a stale stored "stopped" row. If the
 	// exact remote apply has already advanced to another terminal state, the

--- a/pkg/tern/grpc_client_test.go
+++ b/pkg/tern/grpc_client_test.go
@@ -799,6 +799,102 @@ func TestGRPCClient_ResumeApplyPersistsRemoteFailureMessage(t *testing.T) {
 	assert.Contains(t, terminalLog.Message, "failed to connect to target database")
 }
 
+func TestGRPCClient_ProgressPollTerminalErrorFailsApply(t *testing.T) {
+	// Permanent progress RPC errors mean the control plane cannot observe the
+	// remote apply. The apply should fail with that error instead of polling
+	// forever and leaving operators with an in-progress status.
+	server := &capturingTernServer{
+		progressErr: status.Error(codes.InvalidArgument, `invalid apply_id "apply-remote": strconv.ParseInt: invalid syntax`),
+	}
+	client, cleanup := testCapturingGRPCClient(t, server)
+	defer cleanup()
+
+	apply := &storage.Apply{
+		ID:              24,
+		ApplyIdentifier: "apply-terminal-progress-error",
+		Database:        "testdb",
+		DatabaseType:    storage.DatabaseTypeVitess,
+		Deployment:      "us-west",
+		Environment:     "staging",
+		ExternalID:      "apply-remote",
+		State:           state.Apply.Running,
+	}
+	task := &storage.Task{
+		ID:             30,
+		TaskIdentifier: "task-terminal-progress-error",
+		ApplyID:        apply.ID,
+		TableName:      "users",
+		State:          state.Task.Running,
+	}
+	logs := &mockApplyLogStore{}
+	client.storage = &mockStorage{
+		applies: &mockApplyStore{apply: apply},
+		tasks:   &mockTaskStore{tasks: []*storage.Task{task}},
+		logs:    logs,
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 3*time.Second)
+	defer cancel()
+	err := client.pollForCompletion(ctx, apply)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid apply_id")
+
+	assert.Equal(t, state.Apply.Failed, apply.State)
+	assert.Contains(t, apply.ErrorMessage, "invalid apply_id")
+	assert.Equal(t, state.Task.Failed, task.State)
+	assert.Contains(t, task.ErrorMessage, "invalid apply_id")
+	assert.True(t, hasLogMessageContaining(logs.logs, "Remote apply failed: remote progress failed"))
+}
+
+func TestGRPCClient_ProgressPollRepeatedRetryableErrorsPauseApply(t *testing.T) {
+	// Retryable progress RPC errors can happen while the remote service is
+	// unavailable. After repeated failures, the apply should pause for scheduler
+	// recovery and expose the polling error through status and logs.
+	server := &capturingTernServer{
+		progressErr: status.Error(codes.Unavailable, "remote service unavailable"),
+	}
+	client, cleanup := testCapturingGRPCClient(t, server)
+	defer cleanup()
+
+	apply := &storage.Apply{
+		ID:              25,
+		ApplyIdentifier: "apply-retryable-progress-error",
+		Database:        "testdb",
+		DatabaseType:    storage.DatabaseTypeMySQL,
+		Deployment:      "us-west",
+		Environment:     "staging",
+		ExternalID:      "remote-retryable",
+		State:           state.Apply.Running,
+	}
+	task := &storage.Task{
+		ID:             31,
+		TaskIdentifier: "task-retryable-progress-error",
+		ApplyID:        apply.ID,
+		TableName:      "users",
+		State:          state.Task.Running,
+	}
+	logs := &mockApplyLogStore{}
+	client.storage = &mockStorage{
+		applies: &mockApplyStore{apply: apply},
+		tasks:   &mockTaskStore{tasks: []*storage.Task{task}},
+		logs:    logs,
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 7*time.Second)
+	defer cancel()
+	err := client.pollForCompletion(ctx, apply)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "remote service unavailable")
+
+	assert.Equal(t, state.Apply.FailedRetryable, apply.State)
+	assert.Contains(t, apply.ErrorMessage, "remote progress polling failed after 10 consecutive errors")
+	assert.Nil(t, apply.CompletedAt)
+	assert.Equal(t, state.Task.FailedRetryable, task.State)
+	assert.Contains(t, task.ErrorMessage, "remote progress polling failed after 10 consecutive errors")
+	assert.Nil(t, task.CompletedAt)
+	assert.True(t, hasLogMessageContaining(logs.logs, "Remote apply failed: remote progress polling failed after 10 consecutive errors"))
+}
+
 func TestGRPCClient_ResumeApplyDoesNotRegressRunningApplyToPendingProgress(t *testing.T) {
 	// A freshly dispatched remote apply can report pending before the remote
 	// engine starts copying rows. SchemaBot has already claimed the queued apply

--- a/pkg/tern/grpc_client_test.go
+++ b/pkg/tern/grpc_client_test.go
@@ -645,7 +645,7 @@ func TestGRPCClient_ResumeApplyDispatchesQueuedRemoteApply(t *testing.T) {
 	assert.Equal(t, "remote-dispatched-123", server.getProgressApplyID())
 	progressReq := server.getProgressRequest()
 	require.NotNil(t, progressReq)
-	assert.Equal(t, storage.DatabaseTypeMySQL, progressReq.Type)
+	assert.Empty(t, progressReq.Type)
 	assert.Equal(t, "staging", progressReq.Environment)
 }
 
@@ -784,7 +784,7 @@ func TestGRPCClient_ResumeApplyPersistsRemoteFailureMessage(t *testing.T) {
 	assert.Equal(t, state.Task.Failed, task.State)
 	progressReq := server.getProgressRequest()
 	require.NotNil(t, progressReq)
-	assert.Equal(t, storage.DatabaseTypeVitess, progressReq.Type)
+	assert.Empty(t, progressReq.Type)
 	assert.Equal(t, "staging", progressReq.Environment)
 
 	var terminalLog *storage.ApplyLog

--- a/pkg/tern/grpc_client_test.go
+++ b/pkg/tern/grpc_client_test.go
@@ -2007,9 +2007,53 @@ func TestGRPCClient_ResumeApplyFailsWhenStoppedRemoteHasNoActiveProgress(t *test
 	startCalled := server.startCalled
 	server.mu.Unlock()
 	assert.False(t, startCalled, "Start should not be called when the remote apply is missing")
-	assert.Equal(t, state.Apply.Stopped, apply.State)
-	assert.Equal(t, state.Task.Stopped, task.State)
-	assert.True(t, hasLogMessageContaining(logs.logs, "Remote stopped-state check returned no active schema change"))
+	assert.Equal(t, state.Apply.Failed, apply.State)
+	assert.Contains(t, apply.ErrorMessage, "no active schema change")
+	assert.Equal(t, state.Task.Failed, task.State)
+	assert.Contains(t, task.ErrorMessage, "no active schema change")
+	assert.True(t, hasLogMessageContaining(logs.logs, "Remote apply failed: remote apply remote-stopped-no-active returned no active schema change"))
+}
+
+func TestGRPCClient_ResumeApplyFailsWhenStoppedRemoteIsNotFound(t *testing.T) {
+	// A stored stopped apply with a missing exact remote apply ID is inconsistent
+	// cross-plane state. Fail the stored apply instead of leaving it resumable.
+	server := &capturingTernServer{
+		progressErr: status.Error(codes.NotFound, "apply not found"),
+	}
+	client, cleanup := testCapturingGRPCClient(t, server)
+	defer cleanup()
+
+	apply := &storage.Apply{
+		ID:              1,
+		ApplyIdentifier: "apply-stopped-not-found",
+		Database:        "testdb",
+		Environment:     "staging",
+		ExternalID:      "remote-stopped-not-found",
+		State:           state.Apply.Stopped,
+	}
+	task := &storage.Task{
+		ID:             12,
+		TaskIdentifier: "task-stopped-not-found",
+		State:          state.Task.Stopped,
+	}
+	client.storage = &mockStorage{
+		applies: &mockApplyStore{apply: apply},
+		tasks:   &mockTaskStore{tasks: []*storage.Task{task}},
+		logs:    &mockApplyLogStore{},
+	}
+
+	err := client.ResumeApply(t.Context(), apply)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "apply not found")
+
+	server.mu.Lock()
+	startCalled := server.startCalled
+	server.mu.Unlock()
+	assert.False(t, startCalled, "Start should not be called when the remote apply is missing")
+	assert.Equal(t, state.Apply.Failed, apply.State)
+	assert.Contains(t, apply.ErrorMessage, "remote-stopped-not-found")
+	assert.Equal(t, state.Task.Failed, task.State)
+	assert.Contains(t, task.ErrorMessage, "remote-stopped-not-found")
 }
 
 func TestGRPCClient_PollFailsWhenRemoteApplyIsNotFound(t *testing.T) {

--- a/pkg/tern/grpc_client_test.go
+++ b/pkg/tern/grpc_client_test.go
@@ -385,8 +385,8 @@ func (s *capturingTernServer) Start(_ context.Context, req *ternv1.StartRequest)
 func (s *capturingTernServer) Progress(_ context.Context, req *ternv1.ProgressRequest) (*ternv1.ProgressResponse, error) {
 	s.mu.Lock()
 	s.progressReq = &ternv1.ProgressRequest{
-		Environment: req.Environment,
 		ApplyId:     req.ApplyId,
+		Environment: req.Environment,
 	}
 	s.progressApplyID = req.ApplyId
 	ps := s.progressState
@@ -428,8 +428,8 @@ func (s *capturingTernServer) getProgressRequest() *ternv1.ProgressRequest {
 		return nil
 	}
 	return &ternv1.ProgressRequest{
-		Environment: s.progressReq.Environment,
 		ApplyId:     s.progressReq.ApplyId,
+		Environment: s.progressReq.Environment,
 	}
 }
 

--- a/pkg/tern/grpc_client_test.go
+++ b/pkg/tern/grpc_client_test.go
@@ -385,8 +385,6 @@ func (s *capturingTernServer) Start(_ context.Context, req *ternv1.StartRequest)
 func (s *capturingTernServer) Progress(_ context.Context, req *ternv1.ProgressRequest) (*ternv1.ProgressResponse, error) {
 	s.mu.Lock()
 	s.progressReq = &ternv1.ProgressRequest{
-		Database:    req.Database,
-		Type:        req.Type,
 		Environment: req.Environment,
 		ApplyId:     req.ApplyId,
 	}
@@ -430,8 +428,6 @@ func (s *capturingTernServer) getProgressRequest() *ternv1.ProgressRequest {
 		return nil
 	}
 	return &ternv1.ProgressRequest{
-		Database:    s.progressReq.Database,
-		Type:        s.progressReq.Type,
 		Environment: s.progressReq.Environment,
 		ApplyId:     s.progressReq.ApplyId,
 	}
@@ -645,7 +641,7 @@ func TestGRPCClient_ResumeApplyDispatchesQueuedRemoteApply(t *testing.T) {
 	assert.Equal(t, "remote-dispatched-123", server.getProgressApplyID())
 	progressReq := server.getProgressRequest()
 	require.NotNil(t, progressReq)
-	assert.Empty(t, progressReq.Type)
+	assert.Equal(t, "remote-dispatched-123", progressReq.ApplyId)
 	assert.Equal(t, "staging", progressReq.Environment)
 }
 
@@ -784,7 +780,7 @@ func TestGRPCClient_ResumeApplyPersistsRemoteFailureMessage(t *testing.T) {
 	assert.Equal(t, state.Task.Failed, task.State)
 	progressReq := server.getProgressRequest()
 	require.NotNil(t, progressReq)
-	assert.Empty(t, progressReq.Type)
+	assert.Equal(t, "remote-failed-123", progressReq.ApplyId)
 	assert.Equal(t, "staging", progressReq.Environment)
 
 	var terminalLog *storage.ApplyLog

--- a/pkg/tern/grpc_client_test.go
+++ b/pkg/tern/grpc_client_test.go
@@ -347,10 +347,12 @@ type capturingTernServer struct {
 	remoteApplyID    string
 	startApplyID     string
 	progressApplyID  string
+	progressReq      *ternv1.ProgressRequest
 	progressState    ternv1.State // state returned by Progress; 0 = STATE_COMPLETED
 	progressStateSet bool
 	progressStates   []ternv1.State
 	progressTables   []*ternv1.TableProgress
+	progressError    string
 	progressErr      error
 	startCalled      bool // tracks whether Start was actually invoked
 }
@@ -382,6 +384,12 @@ func (s *capturingTernServer) Start(_ context.Context, req *ternv1.StartRequest)
 
 func (s *capturingTernServer) Progress(_ context.Context, req *ternv1.ProgressRequest) (*ternv1.ProgressResponse, error) {
 	s.mu.Lock()
+	s.progressReq = &ternv1.ProgressRequest{
+		Database:    req.Database,
+		Type:        req.Type,
+		Environment: req.Environment,
+		ApplyId:     req.ApplyId,
+	}
 	s.progressApplyID = req.ApplyId
 	ps := s.progressState
 	psSet := s.progressStateSet
@@ -391,6 +399,7 @@ func (s *capturingTernServer) Progress(_ context.Context, req *ternv1.ProgressRe
 		psSet = true
 	}
 	tables := s.progressTables
+	errorMessage := s.progressError
 	err := s.progressErr
 	s.mu.Unlock()
 	if err != nil {
@@ -399,7 +408,7 @@ func (s *capturingTernServer) Progress(_ context.Context, req *ternv1.ProgressRe
 	if !psSet {
 		ps = ternv1.State_STATE_COMPLETED
 	}
-	return &ternv1.ProgressResponse{State: ps, Tables: tables}, nil
+	return &ternv1.ProgressResponse{State: ps, Tables: tables, ErrorMessage: errorMessage}, nil
 }
 
 func (s *capturingTernServer) getStartApplyID() string {
@@ -412,6 +421,20 @@ func (s *capturingTernServer) getProgressApplyID() string {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.progressApplyID
+}
+
+func (s *capturingTernServer) getProgressRequest() *ternv1.ProgressRequest {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.progressReq == nil {
+		return nil
+	}
+	return &ternv1.ProgressRequest{
+		Database:    s.progressReq.Database,
+		Type:        s.progressReq.Type,
+		Environment: s.progressReq.Environment,
+		ApplyId:     s.progressReq.ApplyId,
+	}
 }
 
 func (s *capturingTernServer) getApplyRequest() *ternv1.ApplyRequest {
@@ -620,6 +643,10 @@ func TestGRPCClient_ResumeApplyDispatchesQueuedRemoteApply(t *testing.T) {
 	assert.Equal(t, "users", req.DdlChanges[0].TableName)
 	assert.Equal(t, ternv1.ChangeType_CHANGE_TYPE_ALTER, req.DdlChanges[0].ChangeType)
 	assert.Equal(t, "remote-dispatched-123", server.getProgressApplyID())
+	progressReq := server.getProgressRequest()
+	require.NotNil(t, progressReq)
+	assert.Equal(t, storage.DatabaseTypeMySQL, progressReq.Type)
+	assert.Equal(t, "staging", progressReq.Environment)
 }
 
 func TestGRPCClient_ResumeApplyLogsRemoteLifecycle(t *testing.T) {
@@ -697,6 +724,79 @@ func TestGRPCClient_ResumeApplyLogsRemoteLifecycle(t *testing.T) {
 	require.NotNil(t, dispatchLog, "dispatch log should be present")
 	assert.Equal(t, state.Apply.Pending, dispatchLog.OldState)
 	assert.Equal(t, state.Apply.Running, dispatchLog.NewState)
+}
+
+func TestGRPCClient_ResumeApplyPersistsRemoteFailureMessage(t *testing.T) {
+	// Remote Tern failures should be copied into control-plane storage and logs
+	// so status and logs explain the failed schema change without data-plane logs.
+	server := &capturingTernServer{
+		remoteApplyID:    "remote-failed-123",
+		progressState:    ternv1.State_STATE_FAILED,
+		progressStateSet: true,
+		progressError:    "failed to connect to target database",
+		progressTables: []*ternv1.TableProgress{{
+			Namespace: "default",
+			TableName: "users",
+			Status:    state.Task.Failed,
+		}},
+	}
+	client, cleanup := testCapturingGRPCClient(t, server)
+	defer cleanup()
+
+	apply := &storage.Apply{
+		ID:              18,
+		ApplyIdentifier: "apply-control-failed",
+		PlanID:          110,
+		Database:        "testdb",
+		DatabaseType:    storage.DatabaseTypeVitess,
+		Deployment:      "us-west",
+		Environment:     "staging",
+		State:           state.Apply.Pending,
+	}
+	task := &storage.Task{
+		ID:             22,
+		TaskIdentifier: "task-failed",
+		ApplyID:        apply.ID,
+		TableName:      "users",
+		DDL:            "ALTER TABLE users ADD COLUMN email varchar(255)",
+		DDLAction:      "alter",
+		Namespace:      "default",
+		State:          state.Task.Pending,
+	}
+	logs := &mockApplyLogStore{}
+	client.storage = &mockStorage{
+		applies: &mockApplyStore{apply: apply},
+		tasks:   &mockTaskStore{tasks: []*storage.Task{task}},
+		plans: &mockPlanStore{plan: &storage.Plan{
+			ID:             apply.PlanID,
+			PlanIdentifier: "plan-remote-failed",
+		}},
+		logs: logs,
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 3*time.Second)
+	defer cancel()
+	err := client.ResumeApply(ctx, apply)
+	require.NoError(t, err)
+
+	assert.Equal(t, state.Apply.Failed, apply.State)
+	assert.Equal(t, "failed to connect to target database", apply.ErrorMessage)
+	assert.Equal(t, state.Task.Failed, task.State)
+	progressReq := server.getProgressRequest()
+	require.NotNil(t, progressReq)
+	assert.Equal(t, storage.DatabaseTypeVitess, progressReq.Type)
+	assert.Equal(t, "staging", progressReq.Environment)
+
+	var terminalLog *storage.ApplyLog
+	for _, log := range logs.logs {
+		if strings.Contains(log.Message, "Remote apply reached terminal state: failed") {
+			terminalLog = log
+			break
+		}
+	}
+	require.NotNil(t, terminalLog, "expected failed terminal state log")
+	assert.Equal(t, storage.LogLevelError, terminalLog.Level)
+	assert.Contains(t, terminalLog.Message, "failed to connect to target database")
 }
 
 func TestGRPCClient_ResumeApplyDoesNotRegressRunningApplyToPendingProgress(t *testing.T) {


### PR DESCRIPTION
## Summary
Remote gRPC applies now preserve failure context in stored apply and task state plus apply logs, so status views can show why a remote apply failed.

Progress polling also distinguishes permanent RPC errors from transient ones: permanent errors fail the apply immediately, while repeated transient errors pause the apply as retryable instead of polling forever.

```text
remote Tern Progress
        |
        v
terminal failed response -> persist error -> status/logs show reason
permanent RPC error     -> fail apply
transient RPC errors    -> failed_retryable after bounded streak
```

🤖 Generated by Codex.