### PR TITLE
feat(storage): add deployment column + composite indexes for active-apply key 

### DIFF
--- a/pkg/schema/mysql/applies.sql
+++ b/pkg/schema/mysql/applies.sql
@@ -26,6 +26,7 @@ CREATE TABLE `applies` (
   KEY `idx_lock_id` (`lock_id`),
   KEY `idx_plan_id` (`plan_id`),
   KEY `idx_database_env` (`database_name`,`database_type`,`environment`),
+  KEY `idx_database_env_deployment` (`database_name`,`database_type`,`environment`,`deployment`),
   KEY `idx_repo_pr` (`repository`,`pull_request`),
   KEY `idx_created_id` (`created_at`,`id`),
   KEY `idx_environment_created_id` (`environment`,`created_at`,`id`),

--- a/pkg/schema/mysql/apply_target_locks.sql
+++ b/pkg/schema/mysql/apply_target_locks.sql
@@ -3,8 +3,10 @@ CREATE TABLE `apply_target_locks` (
   `database_name` varchar(255) NOT NULL,
   `database_type` varchar(50) NOT NULL,
   `environment` varchar(50) NOT NULL,
+  `deployment` varchar(255) NOT NULL DEFAULT '',
   `created_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `updated_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`),
-  UNIQUE KEY `idx_apply_target` (`database_name`,`database_type`,`environment`)
+  UNIQUE KEY `idx_apply_target` (`database_name`,`database_type`,`environment`),
+  UNIQUE KEY `idx_apply_target_v2` (`database_name`,`database_type`,`environment`,`deployment`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci


### PR DESCRIPTION
## What

Additive schema for the active-apply key — zero behaviour change.

- `apply_target_locks`: add `deployment VARCHAR(255) NOT NULL DEFAULT ''` and `UNIQUE KEY idx_apply_target_v2 (database_name, database_type, environment, deployment)` alongside the existing `idx_apply_target`.
- `applies`: add non-unique `idx_database_env_deployment (database_name, database_type, environment, deployment)` alongside `idx_database_env`.

`EnsureSchema` applies the diff on startup; the empty-string default keeps every legacy row valid.

## Why

Lays the schema foundation for making the active-apply identity deployment-aware. The behavioural work — moving the active-apply lock down to per-row granularity and eventually dropping the redundant 3-column indexes — is being delivered through the **Multi-Deployment Apply** workstream:

- #205 — `apply_operations` table + CRUD + `tasks.apply_operation_id` (merged)
- #213 — multi-deployment config + `ResolveDatabaseTargets` (merged)
- #214 — apply-create dual-writes one `apply_operations` row alongside the apply and its tasks (merged)
- #220 — `apply_operations` claim primitives (`FindNextApplyOperation` + `Heartbeat`) (in review)
- **upcoming** — per-deployment operator claim loop that acquires the 4-tuple `(database, type, environment, deployment)` lock per `apply_operations` row. **This is the PR that needs the schema landed here.** Splitting the schema in now keeps that upcoming PR focused on the claim-loop behaviour rather than carrying schema + behaviour in one diff.

Tracking issue: #192.

## Verification

`go build ./...`, `go vet ./...`, and the non-integration unit suites for `pkg/schema`, `pkg/storage`, `pkg/api` all pass. `EnsureSchema` integration coverage (testcontainers MySQL) exercises the new schema on startup; idempotent re-apply is covered by `TestEnsureSchema_Idempotent`.