### PR TITLE
fix(localscale): harden vitess control targeting

### DIFF
--- a/pkg/localscale/handlers_actions.go
+++ b/pkg/localscale/handlers_actions.go
@@ -392,31 +392,56 @@ func (s *Server) alterVitessMigrations(ctx context.Context, backend *databaseBac
 	if err != nil {
 		return err
 	}
-	var firstErr error
+	targets := make(map[string][]string)
 	for _, m := range migrations {
 		uuid := m["migration_uuid"]
 		keyspace := m["_keyspace"]
-		if uuid == "" || keyspace == "" {
-			s.logger.Warn("skipping migration with missing uuid or keyspace", "uuid", uuid, "keyspace", keyspace)
-			continue
+		shard := m["shard"]
+		if uuid == "" {
+			err := fmt.Errorf("migration for context %s is missing uuid: keyspace=%q shard=%q", migrationContext, keyspace, shard)
+			s.logger.Warn("migration control will fail because migration row is missing uuid", "keyspace", keyspace, "shard", shard, "error", err)
+			return err
+		}
+		if keyspace == "" {
+			err := fmt.Errorf("migration for context %s is missing keyspace: uuid=%q shard=%q", migrationContext, uuid, shard)
+			s.logger.Warn("migration control will fail because migration row is missing keyspace", "uuid", uuid, "shard", shard, "error", err)
+			return err
+		}
+		if shard == "" {
+			err := fmt.Errorf("migration for context %s is missing shard: uuid=%q keyspace=%q", migrationContext, uuid, keyspace)
+			s.logger.Warn("migration control will fail because migration row is missing shard", "uuid", uuid, "keyspace", keyspace, "error", err)
+			return err
 		}
 		if err := validateSessionString(uuid); err != nil {
 			s.logger.Warn("skipping migration with invalid UUID", "uuid", uuid, "error", err)
 			continue
 		}
-		db, ok := backend.vtgateDBs[keyspace]
-		if !ok {
+		if _, ok := backend.vtgateDBs[keyspace]; !ok {
 			s.logger.Warn("unknown keyspace for migration", "uuid", uuid, "keyspace", keyspace)
 			continue
 		}
-		stmt := fmt.Sprintf("ALTER VITESS_MIGRATION '%s' %s", uuid, action)
-		if _, err := db.ExecContext(ctx, stmt); err != nil {
-			s.logger.Warn("alter vitess_migration failed", "keyspace", keyspace, "action", action, "uuid", uuid, "error", err)
+		targets[keyspace] = append(targets[keyspace], uuid)
+	}
+
+	var firstErr error
+	for keyspace, uuids := range targets {
+		db := backend.vtgateDBs[keyspace]
+		err := func() error {
+			for _, uuid := range uuids {
+				stmt := fmt.Sprintf("ALTER VITESS_MIGRATION '%s' %s", uuid, action)
+				if _, err := db.ExecContext(ctx, stmt); err != nil {
+					return fmt.Errorf("alter vitess_migration %s %s: %w", uuid, action, err)
+				}
+			}
+			return nil
+		}()
+		if err != nil {
+			s.logger.Warn("alter vitess_migration failed", "keyspace", keyspace, "action", action, "migration_count", len(uuids), "error", err)
 			if firstErr == nil {
-				firstErr = fmt.Errorf("alter vitess_migration %s %s on %s: %w", uuid, action, keyspace, err)
+				firstErr = fmt.Errorf("alter vitess_migration %s on %s: %w", action, keyspace, err)
 			}
 		} else {
-			s.logger.Info("alter vitess_migration", "keyspace", keyspace, "action", action, "uuid", uuid)
+			s.logger.Info("alter vitess_migration", "keyspace", keyspace, "action", action, "migration_count", len(uuids))
 		}
 	}
 	return firstErr

--- a/pkg/localscale/helpers.go
+++ b/pkg/localscale/helpers.go
@@ -239,6 +239,17 @@ func (s *Server) vtgateShardConn(ctx context.Context, backend *databaseBackend, 
 		return nil, nil, fmt.Errorf("no shards found for keyspace %s", keyspace)
 	}
 
+	return s.vtgateTargetConn(ctx, backend, keyspace, firstShard)
+}
+
+func (s *Server) vtgateTargetConn(ctx context.Context, backend *databaseBackend, keyspace, shard string) (_ *sql.Conn, cleanup func(), _ error) {
+	if err := validateIdentifier(keyspace); err != nil {
+		return nil, nil, fmt.Errorf("invalid keyspace %s: %w", keyspace, err)
+	}
+	if err := validateIdentifier(shard); err != nil {
+		return nil, nil, fmt.Errorf("invalid shard %s: %w", shard, err)
+	}
+
 	conn, err := backend.unscopedVtgateDB.Conn(ctx)
 	if err != nil {
 		return nil, nil, fmt.Errorf("get vtgate connection: %w", err)
@@ -246,7 +257,7 @@ func (s *Server) vtgateShardConn(ctx context.Context, backend *databaseBackend, 
 
 	// Target the shard. After USE keyspace:shard, all queries on this connection
 	// bypass vtgate's planner and go directly to the tablet.
-	target := fmt.Sprintf("%s:%s", keyspace, firstShard)
+	target := fmt.Sprintf("%s:%s", keyspace, shard)
 	if err := validateIdentifier(target); err != nil {
 		utils.CloseAndLog(conn)
 		return nil, nil, fmt.Errorf("invalid shard target %s: %w", target, err)
@@ -260,8 +271,8 @@ func (s *Server) vtgateShardConn(ctx context.Context, backend *databaseBackend, 
 }
 
 // forEachShard executes fn on a shard-targeted connection for each shard of a keyspace.
-// This is needed for commands like ALTER VITESS_MIGRATION CANCEL ALL and SHOW
-// VITESS_MIGRATIONS which fail on keyspace-scoped connections for multi-shard keyspaces.
+// This is used by LocalScale cleanup and inspection paths that need shard-local
+// visibility rather than keyspace-routed vtgate behavior.
 func (s *Server) forEachShard(ctx context.Context, backend *databaseBackend, keyspace string, fn func(conn *sql.Conn) error) error {
 	resp, err := backend.vtctld.FindAllShardsInKeyspace(ctx, &vtctldatapb.FindAllShardsInKeyspaceRequest{
 		Keyspace: keyspace,
@@ -270,19 +281,14 @@ func (s *Server) forEachShard(ctx context.Context, backend *databaseBackend, key
 		return fmt.Errorf("find shards for %s: %w", keyspace, err)
 	}
 	for shard := range resp.Shards {
-		conn, err := backend.unscopedVtgateDB.Conn(ctx)
+		conn, cleanup, err := s.vtgateTargetConn(ctx, backend, keyspace, shard)
 		if err != nil {
-			return fmt.Errorf("get connection: %w", err)
-		}
-		target := fmt.Sprintf("%s:%s", keyspace, shard)
-		if _, err := conn.ExecContext(ctx, "USE "+quoteIdentifier(target)); err != nil {
-			utils.CloseAndLog(conn)
-			return fmt.Errorf("target %s: %w", target, err)
+			return fmt.Errorf("connect shard %s: %w", shard, err)
 		}
 		fnErr := fn(conn)
-		utils.CloseAndLog(conn)
+		cleanup()
 		if fnErr != nil {
-			return fnErr
+			return fmt.Errorf("run on shard %s: %w", shard, fnErr)
 		}
 	}
 	return nil


### PR DESCRIPTION
## Why
LocalScale Vitess control operations need to be precise when a deploy request has rows across multiple shards. The control path should keep Vitess's keyspace-targeted `ALTER VITESS_MIGRATION` behavior while avoiding broad `ALL` operations for deploy-scoped cancel/complete actions.

## What
- Run cancel/complete per matching migration UUID on the owning keyspace connection
- Fail closed when a deploy-scoped Vitess row is missing UUID, keyspace, or shard metadata
- Add a reusable shard-targeted connection helper for LocalScale cleanup and inspection paths

## Risk Assessment
Low — this is scoped to LocalScale's Vitess deploy-request control path and preserves keyspace-targeted Vitess control semantics while tightening deploy scoping.

Generated with Amp
