### PR TITLE
fix(scheduler): route stops through durable requests

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -149,6 +149,40 @@ Each engine uses shared external signals for control:
 These signals are durable and accessible from any instance — the engine running in
 the background detects the signal regardless of which SchemaBot instance triggered it.
 
+SchemaBot also stores durable control requests for operations whose accepted
+intent must survive API handler exits or process restarts. For example, `stop`
+and stopped-state `start` requests are recorded in `apply_control_requests`
+before the engine side effect is performed. The active scheduler-owned apply
+worker consumes the request, performs or forwards the engine control operation,
+syncs SchemaBot storage to the resulting state, and only then marks the control
+request completed.
+
+`stop` is the highest-priority control intent. Once SchemaBot accepts a stop
+request, no actor should knowingly advance that apply toward deploy, cutover, or
+completion until the stop request has been observed and processed. The API
+therefore records the durable stop request first, then immediately attempts a
+safe engine stop as a fast path for local/in-process Tern clients. If the
+immediate stop succeeds, the active engine is interrupted without waiting for the
+scheduler owner's next poll. If it fails or is not accepted, SchemaBot logs the
+result and leaves the durable request pending so the current owner, or a later
+recovered owner, can retry and reconcile final state. Remote gRPC Tern clients
+skip the API fast path because the scheduler owner must both stop the remote
+data plane and reconcile SchemaBot's local storage in one owner-controlled flow.
+
+Forward-progress controls must fail closed while a stop is pending. User-driven
+cutover is rejected when a pending stop request exists, and scheduler-owned
+pollers check for pending stops before continuing progress work. This avoids the
+unsafe interleaving where `/api/stop` returns accepted while another path moves
+the same apply from `waiting_for_cutover` into cutover or completion before the
+stop can be applied.
+
+This preserves single-owner semantics for running applies: a fresh running apply
+with a pending stop request is still owned by its current worker, not claimed by
+a second scheduler worker. If that worker or process exits before acting, the
+stale heartbeat makes the apply claimable through the normal scheduler recovery
+path, and the next worker processes the pending control request before resuming
+or dispatching more work.
+
 ## Tern Layer (Orchestrator)
 
 Tern is the orchestration layer. It manages the schema change lifecycle: creating records, calling the engine, polling for progress, and tracking state. It defines a proto interface (`Plan`, `Apply`, `Progress`, `Cutover`, `Stop`, `Start`, `Volume`, `Revert`, `SkipRevert`).

--- a/pkg/api/control_handlers.go
+++ b/pkg/api/control_handlers.go
@@ -54,6 +54,13 @@ func controlOperationHTTPStatus(err error) int {
 	return http.StatusInternalServerError
 }
 
+func controlOperationCaller(caller string) string {
+	if caller == "" {
+		return "unknown"
+	}
+	return caller
+}
+
 // logControlOperation appends an apply log entry for a control operation (cutover, stop, start, revert, etc.).
 func (s *Service) logControlOperation(r *http.Request, applyID, caller, eventType, message string) {
 	if applyID == "" {
@@ -74,13 +81,17 @@ func (s *Service) logControlOperation(r *http.Request, applyID, caller, eventTyp
 		s.logger.Warn("apply not found for control operation log", "apply_id", applyID, "event", eventType)
 		return
 	}
+	s.logControlOperationForApply(r.Context(), apply, caller, eventType, message)
+}
+
+func (s *Service) logControlOperationForApply(ctx context.Context, apply *storage.Apply, caller, eventType, message string) {
 	logStore := s.storage.ApplyLogs()
 	if logStore == nil {
-		s.logger.Error("apply log store not available for control operation log", "apply_id", applyID, "event", eventType)
+		s.logger.Error("apply log store not available for control operation log", "apply_id", apply.ApplyIdentifier, "event", eventType)
 		return
 	}
-	logMessage := fmt.Sprintf("%s (caller: %s)", message, caller)
-	if err := logStore.Append(r.Context(), &storage.ApplyLog{
+	logMessage := fmt.Sprintf("%s (caller: %s)", message, controlOperationCaller(caller))
+	if err := logStore.Append(ctx, &storage.ApplyLog{
 		ApplyID:   apply.ID,
 		Level:     storage.LogLevelInfo,
 		EventType: eventType,
@@ -111,6 +122,23 @@ func (s *Service) writeControlError(w http.ResponseWriter, opName string, apply 
 		s.logger.Warn(opName+" rejected", attrs...)
 		s.writeError(w, status, opName+" rejected: "+err.Error())
 	}
+}
+
+func (s *Service) rejectControlIfStopPending(ctx context.Context, opName string, apply *storage.Apply) error {
+	controlStore := s.storage.ControlRequests()
+	if controlStore == nil {
+		return fmt.Errorf("control request store is not available")
+	}
+	controlReq, err := controlStore.GetPending(ctx, apply.ID, storage.ControlOperationStop)
+	if err != nil {
+		return fmt.Errorf("load pending stop control request for apply %s before %s: %w", apply.ApplyIdentifier, opName, err)
+	}
+	if controlReq == nil {
+		return nil
+	}
+	s.logControlOperationForApply(ctx, apply, controlReq.RequestedBy, storage.LogEventStopRequested,
+		fmt.Sprintf("Pending stop request blocked %s", opName))
+	return controlConflictf("schema change has a pending stop request; %s is blocked until stop is processed", opName)
 }
 
 // decodeControlRequest decodes a control request (stop/start/cutover/volume),
@@ -221,6 +249,25 @@ func (s *Service) handleCutover(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if err := s.rejectControlIfStopPending(r.Context(), "cutover", apply); err != nil {
+		status := "error"
+		if controlOperationHTTPStatus(err) < http.StatusInternalServerError {
+			status = "rejected"
+		}
+		metrics.RecordControlOperation(r.Context(), "cutover", apply.Database, apply.Environment, status)
+		s.writeControlError(w, "cutover", apply, err)
+		return
+	}
+	if err := s.rejectControlIfStopPending(r.Context(), "cutover dispatch", apply); err != nil {
+		status := "error"
+		if controlOperationHTTPStatus(err) < http.StatusInternalServerError {
+			status = "rejected"
+		}
+		metrics.RecordControlOperation(r.Context(), "cutover", apply.Database, apply.Environment, status)
+		s.writeControlError(w, "cutover", apply, err)
+		return
+	}
+
 	resp, err := client.Cutover(r.Context(), &ternv1.CutoverRequest{
 		ApplyId:     applyID,
 		Environment: apply.Environment,
@@ -248,35 +295,308 @@ type StopRequest struct {
 	Caller      string `json:"caller,omitempty"`
 }
 
+type stopControlRequestMetadata struct {
+	StoppedCount int64 `json:"stopped_count,omitempty"`
+	SkippedCount int64 `json:"skipped_count,omitempty"`
+}
+
+const stopResponseStatusAlreadyRequested = "already_requested"
+
 // handleStop handles POST /api/stop requests.
-// Stops all non-terminal tasks for the database.
+// Records durable stop intent for the apply owner to process.
 func (s *Service) handleStop(w http.ResponseWriter, r *http.Request) {
 	var req StopRequest
-	client, apply, applyID, ok := s.decodeControlRequest(w, r, &req, &req.ApplyID, &req.Environment)
+	client, apply, ternApplyID, ok := s.decodeControlRequest(w, r, &req, &req.ApplyID, &req.Environment)
 	if !ok {
 		return
 	}
 
-	resp, err := client.Stop(r.Context(), &ternv1.StopRequest{
-		ApplyId:     applyID,
-		Environment: apply.Environment,
-	})
+	resp, responseStatus, err := s.queueStopForApplyOwner(r.Context(), apply, req.Caller)
 	if err != nil {
-		metrics.RecordControlOperation(r.Context(), "stop", apply.Database, apply.Environment, "error")
+		status := "error"
+		if controlOperationHTTPStatus(err) < http.StatusInternalServerError {
+			status = "rejected"
+		}
+		metrics.RecordControlOperation(r.Context(), "stop", apply.Database, apply.Environment, status)
 		s.writeControlError(w, "stop", apply, err)
 		return
 	}
 	metrics.RecordControlOperation(r.Context(), "stop", apply.Database, apply.Environment, controlStatus(resp.Accepted))
 	if resp.Accepted {
-		s.logControlOperation(r, apply.ApplyIdentifier, req.Caller, storage.LogEventStopRequested, "Stop requested by user")
+		logMessage := "Stop requested by user"
+		if responseStatus == stopResponseStatusAlreadyRequested {
+			logMessage = "Stop requested by user while stop request already pending"
+		}
+		s.logControlOperation(r, apply.ApplyIdentifier, req.Caller, storage.LogEventStopRequested, logMessage)
+		if responseStatus == stopResponseStatusAlreadyRequested {
+			s.logger.Info("immediate stop skipped because stop request is already pending",
+				"apply_id", apply.ApplyIdentifier,
+				"database", apply.Database,
+				"environment", apply.Environment,
+				"requested_by", req.Caller)
+		} else {
+			s.tryImmediateStopAfterQueue(r.Context(), client, apply, ternApplyID, req.Environment, req.Caller)
+		}
+		s.wakeScheduler(apply.ApplyIdentifier, apply.Database, apply.Environment)
 	}
 
-	s.writeJSON(w, http.StatusOK, &apitypes.StopResponse{
+	httpStatus := http.StatusOK
+	if responseStatus == stopResponseStatusAlreadyRequested {
+		httpStatus = http.StatusAccepted
+	}
+	s.writeJSON(w, httpStatus, &apitypes.StopResponse{
 		Accepted:     resp.Accepted,
 		ErrorMessage: resp.ErrorMessage,
 		StoppedCount: resp.StoppedCount,
 		SkippedCount: resp.SkippedCount,
+		Status:       responseStatus,
 	})
+}
+
+func (s *Service) tryImmediateStopAfterQueue(ctx context.Context, client tern.Client, apply *storage.Apply, ternApplyID, environment, caller string) {
+	if client == nil {
+		s.logger.Warn("immediate stop not attempted because Tern client is unavailable; durable stop request remains pending for apply owner retry",
+			"apply_id", apply.ApplyIdentifier,
+			"database", apply.Database,
+			"environment", apply.Environment,
+			"requested_by", caller)
+		return
+	}
+	if client.IsRemote() {
+		s.logger.Info("immediate stop skipped for remote Tern client; durable stop request remains pending for scheduler-owned reconciliation",
+			"apply_id", apply.ApplyIdentifier,
+			"tern_apply_id", ternApplyID,
+			"database", apply.Database,
+			"environment", apply.Environment,
+			"requested_by", caller)
+		s.logControlOperationForApply(ctx, apply, caller, storage.LogEventStopRequested,
+			"Immediate stop skipped for remote Tern client; durable scheduler owner will reconcile stop state")
+		return
+	}
+	resp, err := client.Stop(ctx, &ternv1.StopRequest{
+		ApplyId:     ternApplyID,
+		Environment: environment,
+	})
+	if err != nil {
+		s.logger.Warn("immediate stop failed; durable stop request remains pending for apply owner retry",
+			"apply_id", apply.ApplyIdentifier,
+			"tern_apply_id", ternApplyID,
+			"database", apply.Database,
+			"environment", apply.Environment,
+			"requested_by", caller,
+			"error", err)
+		s.logControlOperationForApply(ctx, apply, caller, storage.LogEventStopRequested,
+			fmt.Sprintf("Immediate stop attempt failed; durable stop request remains pending: %v", err))
+		return
+	}
+	if resp == nil {
+		s.logger.Warn("immediate stop returned nil response; durable stop request remains pending for apply owner retry",
+			"apply_id", apply.ApplyIdentifier,
+			"tern_apply_id", ternApplyID,
+			"database", apply.Database,
+			"environment", apply.Environment,
+			"requested_by", caller)
+		s.logControlOperationForApply(ctx, apply, caller, storage.LogEventStopRequested,
+			"Immediate stop attempt returned no response; durable stop request remains pending")
+		return
+	}
+	if !resp.Accepted {
+		s.logger.Warn("immediate stop was not accepted; durable stop request remains pending for apply owner retry",
+			"apply_id", apply.ApplyIdentifier,
+			"tern_apply_id", ternApplyID,
+			"database", apply.Database,
+			"environment", apply.Environment,
+			"requested_by", caller,
+			"error_message", resp.ErrorMessage,
+			"stopped_count", resp.StoppedCount,
+			"skipped_count", resp.SkippedCount)
+		s.logControlOperationForApply(ctx, apply, caller, storage.LogEventStopRequested,
+			fmt.Sprintf("Immediate stop attempt was not accepted; durable stop request remains pending: %s", resp.ErrorMessage))
+		return
+	}
+	stopCompleted, err := s.completeImmediateStopRequestIfStopped(ctx, apply, caller)
+	if err != nil {
+		s.logger.Warn("immediate stop accepted but durable stop request completion failed; durable stop request remains pending for apply owner retry",
+			"apply_id", apply.ApplyIdentifier,
+			"tern_apply_id", ternApplyID,
+			"database", apply.Database,
+			"environment", apply.Environment,
+			"requested_by", caller,
+			"stopped_count", resp.StoppedCount,
+			"skipped_count", resp.SkippedCount,
+			"error", err)
+		s.logControlOperationForApply(ctx, apply, caller, storage.LogEventStopRequested,
+			fmt.Sprintf("Immediate stop accepted but durable stop request completion failed; durable stop request remains pending: %v", err))
+		return
+	}
+	if !stopCompleted {
+		s.logger.Info("immediate stop accepted; durable apply owner will reconcile final stop state",
+			"apply_id", apply.ApplyIdentifier,
+			"tern_apply_id", ternApplyID,
+			"database", apply.Database,
+			"environment", apply.Environment,
+			"requested_by", caller,
+			"stopped_count", resp.StoppedCount,
+			"skipped_count", resp.SkippedCount)
+		s.logControlOperationForApply(ctx, apply, caller, storage.LogEventStopRequested,
+			"Immediate stop accepted; durable apply owner will reconcile final stop state")
+		return
+	}
+	s.logger.Info("immediate stop accepted and durable stop request completed",
+		"apply_id", apply.ApplyIdentifier,
+		"tern_apply_id", ternApplyID,
+		"database", apply.Database,
+		"environment", apply.Environment,
+		"requested_by", caller,
+		"stopped_count", resp.StoppedCount,
+		"skipped_count", resp.SkippedCount)
+	s.logControlOperationForApply(ctx, apply, caller, storage.LogEventStopRequested,
+		"Immediate stop accepted and durable stop request completed")
+}
+
+func (s *Service) completeImmediateStopRequestIfStopped(ctx context.Context, apply *storage.Apply, caller string) (bool, error) {
+	storedApply, err := s.storage.Applies().Get(ctx, apply.ID)
+	if err != nil {
+		return false, fmt.Errorf("load apply %s after immediate stop: %w", apply.ApplyIdentifier, err)
+	}
+	if storedApply == nil {
+		return false, fmt.Errorf("load apply %s after immediate stop: %w", apply.ApplyIdentifier, storage.ErrApplyNotFound)
+	}
+	if !stopRequestCompletedByApplyState(storedApply.State) {
+		s.logger.Info("immediate stop accepted but stored apply is not stopped; durable stop request remains pending for apply owner retry",
+			"apply_id", apply.ApplyIdentifier,
+			"database", apply.Database,
+			"environment", apply.Environment,
+			"requested_by", caller,
+			"state", storedApply.State)
+		return false, nil
+	}
+	controlStore := s.storage.ControlRequests()
+	if controlStore == nil {
+		return false, fmt.Errorf("control request store is not available")
+	}
+	if err := controlStore.CompletePending(ctx, apply.ID, storage.ControlOperationStop); err != nil {
+		return false, fmt.Errorf("complete pending stop control request for apply %s after immediate stop: %w", apply.ApplyIdentifier, err)
+	}
+	return true, nil
+}
+
+func stopRequestCompletedByApplyState(applyState string) bool {
+	return state.IsState(applyState, state.Apply.Stopped, state.Apply.Cancelled) || state.IsTerminalApplyState(applyState)
+}
+
+func (s *Service) queueStopForApplyOwner(ctx context.Context, apply *storage.Apply, caller string) (*ternv1.StopResponse, string, error) {
+	if resp, responseStatus, found, err := s.pendingStopResponseIfPresent(ctx, apply); err != nil || found {
+		return resp, responseStatus, err
+	}
+	if state.IsTerminalApplyState(apply.State) {
+		return nil, "", controlConflictf("schema change is already terminal (current state: %s)", apply.State)
+	}
+	tasks, err := s.storage.Tasks().GetByApplyID(ctx, apply.ID)
+	if err != nil {
+		return nil, "", fmt.Errorf("get tasks for apply %s: %w", apply.ApplyIdentifier, err)
+	}
+	stoppedCount, skippedCount := stopRequestCounts(tasks)
+	if stoppedCount == 0 && skippedCount == 0 {
+		return nil, "", controlConflictf("no active schema change for apply %s", apply.ApplyIdentifier)
+	}
+	controlReq, alreadyPending, err := s.createStopControlRequest(ctx, apply, caller, stoppedCount, skippedCount)
+	if err != nil {
+		return nil, "", err
+	}
+	if alreadyPending {
+		resp, err := stopResponseFromControlRequest(controlReq)
+		if err != nil {
+			return nil, "", err
+		}
+		return resp, stopResponseStatusAlreadyRequested, nil
+	}
+	return &ternv1.StopResponse{
+		Accepted:     true,
+		StoppedCount: stoppedCount,
+		SkippedCount: skippedCount,
+	}, "", nil
+}
+
+func stopRequestCounts(tasks []*storage.Task) (int64, int64) {
+	var stoppedCount int64
+	var skippedCount int64
+	for _, task := range tasks {
+		if state.IsTerminalTaskState(task.State) {
+			skippedCount++
+			continue
+		}
+		stoppedCount++
+	}
+	return stoppedCount, skippedCount
+}
+
+func (s *Service) createStopControlRequest(ctx context.Context, apply *storage.Apply, caller string, stoppedCount, skippedCount int64) (*storage.ApplyControlRequest, bool, error) {
+	controlStore := s.storage.ControlRequests()
+	if controlStore == nil {
+		return nil, false, fmt.Errorf("control request store is not available")
+	}
+	metadata, err := json.Marshal(stopControlRequestMetadata{
+		StoppedCount: stoppedCount,
+		SkippedCount: skippedCount,
+	})
+	if err != nil {
+		return nil, false, fmt.Errorf("marshal stop control request metadata for apply %s: %w", apply.ApplyIdentifier, err)
+	}
+	controlReq, alreadyPending, err := controlStore.RequestPending(ctx, &storage.ApplyControlRequest{
+		ApplyID:     apply.ID,
+		Operation:   storage.ControlOperationStop,
+		Status:      storage.ControlRequestPending,
+		RequestedBy: caller,
+		Metadata:    metadata,
+	})
+	if err != nil {
+		return nil, false, fmt.Errorf("record stop control request for apply %s: %w", apply.ApplyIdentifier, err)
+	}
+	return controlReq, alreadyPending, nil
+}
+
+func (s *Service) pendingStopResponseIfPresent(ctx context.Context, apply *storage.Apply) (*ternv1.StopResponse, string, bool, error) {
+	controlStore := s.storage.ControlRequests()
+	if controlStore == nil {
+		return nil, "", false, fmt.Errorf("control request store is not available")
+	}
+	controlReq, err := controlStore.GetPending(ctx, apply.ID, storage.ControlOperationStop)
+	if err != nil {
+		return nil, "", false, fmt.Errorf("load pending stop control request for apply %s: %w", apply.ApplyIdentifier, err)
+	}
+	if controlReq == nil {
+		return nil, "", false, nil
+	}
+	resp, err := stopResponseFromControlRequest(controlReq)
+	if err != nil {
+		return nil, "", false, err
+	}
+	return resp, stopResponseStatusAlreadyRequested, true, nil
+}
+
+func stopResponseFromControlRequest(controlReq *storage.ApplyControlRequest) (*ternv1.StopResponse, error) {
+	resp := &ternv1.StopResponse{}
+	if controlReq == nil {
+		return resp, nil
+	}
+	var metadata stopControlRequestMetadata
+	if len(controlReq.Metadata) > 0 {
+		if err := json.Unmarshal(controlReq.Metadata, &metadata); err != nil {
+			return nil, fmt.Errorf("decode stop control request metadata for request %d: %w", controlReq.ID, err)
+		}
+	}
+	resp.StoppedCount = metadata.StoppedCount
+	resp.SkippedCount = metadata.SkippedCount
+	switch controlReq.Status {
+	case storage.ControlRequestPending, storage.ControlRequestCompleted:
+		resp.Accepted = true
+	case storage.ControlRequestFailed:
+		resp.ErrorMessage = controlReq.ErrorMessage
+	default:
+		resp.ErrorMessage = fmt.Sprintf("stop control request has unknown status: %s", controlReq.Status)
+	}
+	return resp, nil
 }
 
 // StartRequest is the HTTP request body for POST /api/start.
@@ -312,6 +632,15 @@ func (s *Service) handleStart(w http.ResponseWriter, r *http.Request) {
 		s.writeControlError(w, "start", apply, err)
 		return
 	}
+	if err := s.rejectControlIfStopPending(r.Context(), "start", apply); err != nil {
+		status := "error"
+		if controlOperationHTTPStatus(err) < http.StatusInternalServerError {
+			status = "rejected"
+		}
+		metrics.RecordControlOperation(r.Context(), "start", apply.Database, apply.Environment, status)
+		s.writeControlError(w, "start", apply, err)
+		return
+	}
 
 	var resp *ternv1.StartResponse
 	var err error
@@ -319,6 +648,15 @@ func (s *Service) handleStart(w http.ResponseWriter, r *http.Request) {
 	queuedForScheduler := false
 	switch {
 	case state.IsState(apply.State, state.Apply.WaitingForDeploy):
+		if err := s.rejectControlIfStopPending(r.Context(), "start dispatch", apply); err != nil {
+			status := "error"
+			if controlOperationHTTPStatus(err) < http.StatusInternalServerError {
+				status = "rejected"
+			}
+			metrics.RecordControlOperation(r.Context(), "start", apply.Database, apply.Environment, status)
+			s.writeControlError(w, "start", apply, err)
+			return
+		}
 		resp, err = client.Start(r.Context(), &ternv1.StartRequest{
 			ApplyId:     applyID,
 			Environment: apply.Environment,

--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -120,6 +120,9 @@ type staticApplyStore struct {
 func (s *staticApplyStore) GetByApplyIdentifier(context.Context, string) (*storage.Apply, error) {
 	return s.apply, s.err
 }
+func (s *staticApplyStore) Get(context.Context, int64) (*storage.Apply, error) {
+	return s.apply, s.err
+}
 func (s *staticApplyStore) GetByDatabase(context.Context, string, string, string) ([]*storage.Apply, error) {
 	if s.err != nil {
 		return nil, s.err
@@ -372,6 +375,26 @@ func (s *noopApplyLogStore) Append(context.Context, *storage.ApplyLog) error {
 	return nil
 }
 
+type capturingApplyLogStore struct {
+	storage.ApplyLogStore
+	logs []*storage.ApplyLog
+}
+
+func (s *capturingApplyLogStore) Append(_ context.Context, log *storage.ApplyLog) error {
+	stored := *log
+	s.logs = append(s.logs, &stored)
+	return nil
+}
+
+func hasApplyLogMessageContaining(logs []*storage.ApplyLog, want string) bool {
+	for _, log := range logs {
+		if strings.Contains(log.Message, want) {
+			return true
+		}
+	}
+	return false
+}
+
 // mockTernClient implements tern.Client for testing.
 type mockTernClient struct {
 	healthErr      error
@@ -390,6 +413,7 @@ type mockTernClient struct {
 	stopResp       *ternv1.StopResponse
 	stopErr        error
 	stopReq        *ternv1.StopRequest // captured request
+	stopHook       func()
 	startResp      *ternv1.StartResponse
 	startErr       error
 	startReq       *ternv1.StartRequest // captured request
@@ -440,6 +464,9 @@ func (m *mockTernClient) Cutover(ctx context.Context, req *ternv1.CutoverRequest
 }
 func (m *mockTernClient) Stop(ctx context.Context, req *ternv1.StopRequest) (*ternv1.StopResponse, error) {
 	m.stopReq = req
+	if m.stopHook != nil {
+		m.stopHook()
+	}
 	if m.stopResp != nil {
 		return m.stopResp, m.stopErr
 	}
@@ -1800,14 +1827,24 @@ func TestControlHandlerRejectsApplyEnvironmentMismatch(t *testing.T) {
 }
 
 func TestStopHandler(t *testing.T) {
-	t.Run("passes apply_id to tern client", func(t *testing.T) {
-		mock := &mockTernClient{
-			stopResp: &ternv1.StopResponse{
-				Accepted:     true,
-				StoppedCount: 2,
+	t.Run("queues stop request for apply owner", func(t *testing.T) {
+		mock := &mockTernClient{stopResp: &ternv1.StopResponse{Accepted: true, StoppedCount: 1, SkippedCount: 1}}
+		apply := activeTestApply("apply-abc123")
+		tasks := []*storage.Task{
+			{
+				ID:             20,
+				TaskIdentifier: "task-stop-abc123",
+				ApplyID:        apply.ID,
+				State:          state.Task.Running,
+			},
+			{
+				ID:             21,
+				TaskIdentifier: "task-stop-completed",
+				ApplyID:        apply.ID,
+				State:          state.Task.Completed,
 			},
 		}
-		svc := newControlTestService(mock, activeTestApply("apply-abc123"))
+		svc := newControlTestServiceWithTasks(mock, apply, tasks)
 		mux := http.NewServeMux()
 		svc.ConfigureRoutes(mux)
 
@@ -1819,9 +1856,133 @@ func TestStopHandler(t *testing.T) {
 
 		assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
 
-		require.NotNil(t, mock.stopReq, "expected stop request to be captured")
+		require.NotNil(t, mock.stopReq, "handler should persist durable intent and issue immediate stop")
 		assert.Equal(t, "apply-abc123", mock.stopReq.ApplyId)
 		assert.Equal(t, "staging", mock.stopReq.Environment)
+		controlReq, err := svc.storage.ControlRequests().GetPending(t.Context(), apply.ID, storage.ControlOperationStop)
+		require.NoError(t, err)
+		require.NotNil(t, controlReq)
+
+		var resp apitypes.StopResponse
+		err = json.NewDecoder(w.Body).Decode(&resp)
+		require.NoError(t, err, "failed to decode response")
+		assert.True(t, resp.Accepted)
+		assert.Equal(t, int64(1), resp.StoppedCount)
+		assert.Equal(t, int64(1), resp.SkippedCount)
+		assert.Empty(t, resp.Status)
+	})
+
+	t.Run("completes durable stop request when immediate local stop stores stopped state", func(t *testing.T) {
+		apply := activeTestApply("apply-local-stop-completes")
+		mock := &mockTernClient{
+			stopResp: &ternv1.StopResponse{Accepted: true, StoppedCount: 1},
+			stopHook: func() {
+				apply.State = state.Apply.Stopped
+			},
+		}
+		task := &storage.Task{
+			ID:             23,
+			TaskIdentifier: "task-local-stop-completes",
+			ApplyID:        apply.ID,
+			State:          state.Task.Running,
+		}
+		svc := newControlTestServiceWithTasks(mock, apply, []*storage.Task{task})
+		mux := http.NewServeMux()
+		svc.ConfigureRoutes(mux)
+
+		body := `{"environment": "staging", "apply_id": "apply-local-stop-completes", "caller": "cli:local"}`
+		req := httptest.NewRequestWithContext(t.Context(), "POST", "/api/stop", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
+		require.NotNil(t, mock.stopReq)
+		controlReq, err := svc.storage.ControlRequests().GetPending(t.Context(), apply.ID, storage.ControlOperationStop)
+		require.NoError(t, err)
+		assert.Nil(t, controlReq)
+
+		var resp apitypes.StopResponse
+		err = json.NewDecoder(w.Body).Decode(&resp)
+		require.NoError(t, err)
+		assert.True(t, resp.Accepted)
+		assert.Equal(t, int64(1), resp.StoppedCount)
+	})
+
+	t.Run("remote stop queues durable request without immediate remote stop", func(t *testing.T) {
+		mock := &mockTernClient{isRemote: true, stopResp: &ternv1.StopResponse{Accepted: true}}
+		apply := activeTestApply("apply-remote-stop")
+		apply.ExternalID = "remote-apply-stop"
+		task := &storage.Task{
+			ID:             23,
+			TaskIdentifier: "task-remote-stop",
+			ApplyID:        apply.ID,
+			State:          state.Task.Running,
+		}
+		svc := newControlTestServiceWithTasks(mock, apply, []*storage.Task{task})
+		mux := http.NewServeMux()
+		svc.ConfigureRoutes(mux)
+
+		body := `{"environment": "staging", "apply_id": "apply-remote-stop", "caller": "cli:remote"}`
+		req := httptest.NewRequestWithContext(t.Context(), "POST", "/api/stop", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
+		assert.Nil(t, mock.stopReq, "remote stop must be reconciled by the scheduler owner")
+		controlReq, err := svc.storage.ControlRequests().GetPending(t.Context(), apply.ID, storage.ControlOperationStop)
+		require.NoError(t, err)
+		require.NotNil(t, controlReq)
+
+		var resp apitypes.StopResponse
+		err = json.NewDecoder(w.Body).Decode(&resp)
+		require.NoError(t, err)
+		assert.True(t, resp.Accepted)
+		assert.Equal(t, int64(1), resp.StoppedCount)
+	})
+
+	t.Run("returns already requested for duplicate queued stop", func(t *testing.T) {
+		mock := &mockTernClient{stopResp: &ternv1.StopResponse{Accepted: true, StoppedCount: 1}}
+		apply := activeTestApply("apply-stop-already-requested")
+		task := &storage.Task{
+			ID:             22,
+			TaskIdentifier: "task-stop-already-requested",
+			ApplyID:        apply.ID,
+			State:          state.Task.Running,
+		}
+		svc := newControlTestServiceWithTasks(mock, apply, []*storage.Task{task})
+		mux := http.NewServeMux()
+		svc.ConfigureRoutes(mux)
+
+		logs := &capturingApplyLogStore{}
+		require.IsType(t, &mockStorageWithApplyStores{}, svc.storage)
+		svc.storage.(*mockStorageWithApplyStores).applyLogs = logs
+
+		body := `{"environment": "staging", "apply_id": "apply-stop-already-requested", "caller": "cli:first"}`
+		req := httptest.NewRequestWithContext(t.Context(), "POST", "/api/stop", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, req)
+		require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+		retryBody := `{"environment": "staging", "apply_id": "apply-stop-already-requested", "caller": "cli:second"}`
+		retryReq := httptest.NewRequestWithContext(t.Context(), "POST", "/api/stop", strings.NewReader(retryBody))
+		retryReq.Header.Set("Content-Type", "application/json")
+		retryW := httptest.NewRecorder()
+		mux.ServeHTTP(retryW, retryReq)
+
+		assert.Equal(t, http.StatusAccepted, retryW.Code, retryW.Body.String())
+		require.NotNil(t, mock.stopReq)
+		assert.Equal(t, "apply-stop-already-requested", mock.stopReq.ApplyId)
+		var resp apitypes.StopResponse
+		err := json.NewDecoder(retryW.Body).Decode(&resp)
+		require.NoError(t, err)
+		assert.True(t, resp.Accepted)
+		assert.Equal(t, int64(1), resp.StoppedCount)
+		assert.Equal(t, "already_requested", resp.Status)
+		assert.True(t, hasApplyLogMessageContaining(logs.logs, "Stop requested by user (caller: cli:first)"))
+		assert.True(t, hasApplyLogMessageContaining(logs.logs, "Stop requested by user while stop request already pending (caller: cli:second)"))
 	})
 
 	t.Run("requires apply_id", func(t *testing.T) {
@@ -1882,6 +2043,33 @@ func TestStartHandler(t *testing.T) {
 		require.NotNil(t, mock.startReq, "expected start request to be captured")
 		assert.Equal(t, "apply-xyz789", mock.startReq.ApplyId)
 		assert.Equal(t, "staging", mock.startReq.Environment)
+	})
+
+	t.Run("rejects start while stop request is pending", func(t *testing.T) {
+		mock := &mockTernClient{startResp: &ternv1.StartResponse{Accepted: true}}
+		apply := activeTestApply("apply-start-stop-pending")
+		apply.State = state.Apply.WaitingForDeploy
+		svc := newControlTestService(mock, apply)
+		_, alreadyPending, err := svc.storage.ControlRequests().RequestPending(t.Context(), &storage.ApplyControlRequest{
+			ApplyID:     apply.ID,
+			Operation:   storage.ControlOperationStop,
+			Status:      storage.ControlRequestPending,
+			RequestedBy: "cli:stopper",
+		})
+		require.NoError(t, err)
+		require.False(t, alreadyPending)
+		mux := http.NewServeMux()
+		svc.ConfigureRoutes(mux)
+
+		body := `{"environment": "staging", "apply_id": "apply-start-stop-pending", "caller": "cli:starter"}`
+		req := httptest.NewRequestWithContext(t.Context(), "POST", "/api/start", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusConflict, w.Code, w.Body.String())
+		assert.Nil(t, mock.startReq)
+		assert.Contains(t, w.Body.String(), "pending stop request")
 	})
 
 	t.Run("queues stopped apply for scheduler by apply_id", func(t *testing.T) {
@@ -2285,6 +2473,38 @@ func TestCutoverHandler(t *testing.T) {
 		require.NotNil(t, mock.cutoverReq, "expected cutover request to be captured")
 		assert.Equal(t, "apply-cut123", mock.cutoverReq.ApplyId)
 		assert.Equal(t, "staging", mock.cutoverReq.Environment)
+	})
+
+	t.Run("rejects cutover while stop request is pending", func(t *testing.T) {
+		mock := &mockTernClient{
+			cutoverResp: &ternv1.CutoverResponse{Accepted: true},
+		}
+		apply := activeTestApply("apply-cutover-stop-pending")
+		logs := &capturingApplyLogStore{}
+		controlRequests := &memoryControlRequestStore{requests: []*storage.ApplyControlRequest{{
+			ApplyID:     apply.ID,
+			Operation:   storage.ControlOperationStop,
+			Status:      storage.ControlRequestPending,
+			RequestedBy: "cli:stopper",
+		}}}
+		svc := newControlTestService(mock, apply)
+		require.IsType(t, &mockStorageWithApplyStores{}, svc.storage)
+		store := svc.storage.(*mockStorageWithApplyStores)
+		store.controls = controlRequests
+		store.applyLogs = logs
+		mux := http.NewServeMux()
+		svc.ConfigureRoutes(mux)
+
+		body := `{"environment": "staging", "apply_id": "apply-cutover-stop-pending", "caller": "cli:cutter"}`
+		req := httptest.NewRequestWithContext(t.Context(), "POST", "/api/cutover", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusConflict, w.Code, w.Body.String())
+		assert.Nil(t, mock.cutoverReq)
+		assert.Contains(t, w.Body.String(), "pending stop request")
+		assert.True(t, hasApplyLogMessageContaining(logs.logs, "Pending stop request blocked cutover (caller: cli:stopper)"))
 	})
 
 	t.Run("requires apply_id", func(t *testing.T) {

--- a/pkg/apitypes/apitypes.go
+++ b/pkg/apitypes/apitypes.go
@@ -242,6 +242,7 @@ type StopResponse struct {
 	ErrorMessage string `json:"error_message,omitempty"`
 	StoppedCount int64  `json:"stopped_count"`
 	SkippedCount int64  `json:"skipped_count"`
+	Status       string `json:"status,omitempty"`
 }
 
 // StartResponse is the HTTP response for POST /api/start.

--- a/pkg/storage/mysqlstore/applies_test.go
+++ b/pkg/storage/mysqlstore/applies_test.go
@@ -760,6 +760,27 @@ func TestApplyStore_FindNextApplyClaimsStoppedStartControlRequest(t *testing.T) 
 	assert.Nil(t, claimedAgain, "claim transition should prevent another worker from taking the same stopped start request")
 }
 
+func TestApplyStore_FindNextApplyDoesNotClaimFreshRunningStopControlRequest(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", storage.DatabaseTypeMySQL, "staging")
+	apply := createTestApplyWithStateAndEnv(t, store, lock, "apply_running_stop_request", 505, state.Apply.Running, "staging")
+	_, alreadyPending, err := store.ControlRequests().RequestPending(ctx, &storage.ApplyControlRequest{
+		ApplyID:   apply.ID,
+		Operation: storage.ControlOperationStop,
+		Status:    storage.ControlRequestPending,
+		Metadata:  []byte(`{}`),
+	})
+	require.NoError(t, err)
+	require.False(t, alreadyPending)
+
+	claimed, err := store.Applies().FindNextApply(ctx)
+	require.NoError(t, err)
+	assert.Nil(t, claimed, "fresh running applies are owned by their active worker; pending stop must not create a second owner")
+}
+
 func TestApplyStore_FindNextApplyConcurrentPendingClaims(t *testing.T) {
 	clearTables(t)
 	ctx := t.Context()

--- a/pkg/storage/types.go
+++ b/pkg/storage/types.go
@@ -409,6 +409,8 @@ type ControlOperation string
 const (
 	// ControlOperationStart resumes a stopped apply.
 	ControlOperationStart ControlOperation = "start"
+	// ControlOperationStop stops an active apply.
+	ControlOperationStop ControlOperation = "stop"
 )
 
 // ControlRequestStatus is the durable processing status for a control request.

--- a/pkg/tern/control_requests.go
+++ b/pkg/tern/control_requests.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/block/schemabot/pkg/state"
 	"github.com/block/schemabot/pkg/storage"
 )
 
@@ -34,4 +35,68 @@ func completePendingStartControlRequests(ctx context.Context, store storage.Stor
 		return fmt.Errorf("complete pending start control request for apply %s: %w", apply.ApplyIdentifier, err)
 	}
 	return nil
+}
+
+func pendingStopControlRequest(ctx context.Context, store storage.Storage, apply *storage.Apply) (*storage.ApplyControlRequest, error) {
+	if store == nil {
+		return nil, fmt.Errorf("storage is not available")
+	}
+	controlStore := store.ControlRequests()
+	if controlStore == nil {
+		return nil, fmt.Errorf("control request store is not available")
+	}
+	controlReq, err := controlStore.GetPending(ctx, apply.ID, storage.ControlOperationStop)
+	if err != nil {
+		return nil, fmt.Errorf("load pending stop control request for apply %s: %w", apply.ApplyIdentifier, err)
+	}
+	return controlReq, nil
+}
+
+func completePendingStopControlRequests(ctx context.Context, store storage.Storage, apply *storage.Apply) error {
+	if store == nil {
+		return fmt.Errorf("storage is not available")
+	}
+	controlStore := store.ControlRequests()
+	if controlStore == nil {
+		return fmt.Errorf("control request store is not available")
+	}
+	if err := controlStore.CompletePending(ctx, apply.ID, storage.ControlOperationStop); err != nil {
+		return fmt.Errorf("complete pending stop control request for apply %s: %w", apply.ApplyIdentifier, err)
+	}
+	return nil
+}
+
+func completePendingStopIfStoredApplyResolved(ctx context.Context, store storage.Storage, apply *storage.Apply) (bool, error) {
+	if store == nil {
+		return false, fmt.Errorf("storage is not available")
+	}
+	storedApply, err := store.Applies().Get(ctx, apply.ID)
+	if err != nil {
+		return false, fmt.Errorf("load apply %s before completing pending stop: %w", apply.ApplyIdentifier, err)
+	}
+	if storedApply == nil {
+		return false, fmt.Errorf("load apply %s before completing pending stop: %w", apply.ApplyIdentifier, storage.ErrApplyNotFound)
+	}
+	if !state.IsTerminalApplyState(storedApply.State) {
+		return false, nil
+	}
+	if err := completePendingStopControlRequests(ctx, store, storedApply); err != nil {
+		return false, err
+	}
+	*apply = *storedApply
+	return true, nil
+}
+
+func controlRequestCaller(req *storage.ApplyControlRequest) string {
+	if req == nil || req.RequestedBy == "" {
+		return "unknown"
+	}
+	return req.RequestedBy
+}
+
+func callerApplyLogSuffix(caller string) string {
+	if caller == "" {
+		caller = "unknown"
+	}
+	return fmt.Sprintf(" (caller: %s)", caller)
 }

--- a/pkg/tern/grpc_client.go
+++ b/pkg/tern/grpc_client.go
@@ -381,6 +381,209 @@ func (c *GRPCClient) Stop(ctx context.Context, req *ternv1.StopRequest) (*ternv1
 	return c.client.Stop(ctx, req)
 }
 
+func (c *GRPCClient) processPendingStopControlRequest(ctx context.Context, apply *storage.Apply) (bool, error) {
+	controlReq, err := pendingStopControlRequest(ctx, c.storage, apply)
+	if err != nil {
+		return false, err
+	}
+	if controlReq == nil {
+		return false, nil
+	}
+	if completed, err := completePendingStopIfStoredApplyResolved(ctx, c.storage, apply); err != nil {
+		return true, err
+	} else if completed {
+		slog.Info("completing pending gRPC stop request for resolved apply",
+			"apply_id", apply.ApplyIdentifier,
+			"external_id", apply.ExternalID,
+			"database", apply.Database,
+			"environment", apply.Environment,
+			"requested_by", controlRequestCaller(controlReq),
+			"state", apply.State)
+		c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventStopRequested, storage.LogSourceSchemaBot,
+			fmt.Sprintf("Pending remote stop request completed for resolved apply%s", callerApplyLogSuffix(controlRequestCaller(controlReq))), "", "")
+		return true, nil
+	}
+	if state.IsTerminalApplyState(apply.State) {
+		slog.Info("completing pending gRPC stop request for terminal apply",
+			"apply_id", apply.ApplyIdentifier,
+			"external_id", apply.ExternalID,
+			"database", apply.Database,
+			"environment", apply.Environment,
+			"requested_by", controlRequestCaller(controlReq),
+			"state", apply.State)
+		c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventStopRequested, storage.LogSourceSchemaBot,
+			fmt.Sprintf("Pending remote stop request completed for terminal apply%s", callerApplyLogSuffix(controlRequestCaller(controlReq))), "", "")
+		if err := completePendingStopControlRequests(ctx, c.storage, apply); err != nil {
+			return true, err
+		}
+		return true, nil
+	}
+	if apply.ExternalID == "" {
+		if err := c.stopUndispatchedApply(ctx, apply, controlRequestCaller(controlReq)); err != nil {
+			return true, err
+		}
+		if err := completePendingStopControlRequests(ctx, c.storage, apply); err != nil {
+			return true, err
+		}
+		return true, nil
+	}
+
+	resp, err := c.client.Stop(ctx, &ternv1.StopRequest{
+		ApplyId:     apply.ExternalID,
+		Environment: apply.Environment,
+	})
+	if err != nil {
+		if completed, completeErr := c.completeRemoteStopFromTerminalProgress(ctx, apply, controlReq); completeErr == nil && completed {
+			return true, nil
+		} else if completeErr != nil {
+			return true, fmt.Errorf("request remote gRPC stop for apply %s remote %s: %w; terminal progress reconciliation also failed: %w", apply.ApplyIdentifier, apply.ExternalID, err, completeErr)
+		}
+		return true, fmt.Errorf("request remote gRPC stop for apply %s remote %s: %w", apply.ApplyIdentifier, apply.ExternalID, err)
+	}
+	if resp == nil || !resp.Accepted {
+		errorMessage := "not accepted"
+		if resp != nil && resp.ErrorMessage != "" {
+			errorMessage = resp.ErrorMessage
+		}
+		return true, fmt.Errorf("request remote gRPC stop for apply %s remote %s: %s", apply.ApplyIdentifier, apply.ExternalID, errorMessage)
+	}
+	c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventStopRequested, storage.LogSourceSchemaBot,
+		fmt.Sprintf("Remote stop accepted for apply %s%s", apply.ExternalID, callerApplyLogSuffix(controlRequestCaller(controlReq))), "", "")
+
+	progress, err := c.client.Progress(ctx, &ternv1.ProgressRequest{
+		ApplyId:     apply.ExternalID,
+		Environment: apply.Environment,
+	})
+	if err != nil {
+		return true, fmt.Errorf("sync remote gRPC stop for apply %s remote %s: %w", apply.ApplyIdentifier, apply.ExternalID, err)
+	}
+	if progress.State == ternv1.State_STATE_NO_ACTIVE_CHANGE {
+		return true, fmt.Errorf("sync remote gRPC stop for apply %s remote %s: no active schema change", apply.ApplyIdentifier, apply.ExternalID)
+	}
+	remoteState := ProtoStateToStorage(progress.State)
+	if remoteState == "" {
+		return true, fmt.Errorf("sync remote gRPC stop for apply %s remote %s: unmapped remote state %s", apply.ApplyIdentifier, apply.ExternalID, remoteApplyStateDescription(progress.State))
+	}
+	now := time.Now()
+	if apply.StartedAt == nil && !state.IsState(remoteState, state.Apply.Pending) {
+		apply.StartedAt = &now
+	}
+	apply.State = applyStateFromRemoteProgress(apply.State, remoteState)
+	apply.UpdatedAt = now
+	if isTerminalProtoState(progress.State) {
+		if err := c.reconcileTerminalRemoteProgress(ctx, apply, progress.Tables, now); err != nil {
+			return true, err
+		}
+		if err := completePendingStopControlRequests(ctx, c.storage, apply); err != nil {
+			return true, err
+		}
+		return true, nil
+	}
+
+	storedTasks, err := c.storage.Tasks().GetByApplyID(ctx, apply.ID)
+	if err != nil {
+		return true, fmt.Errorf("load tasks to sync remote gRPC stop for %s: %w", apply.ApplyIdentifier, err)
+	}
+	if err := c.syncStoredTasksFromRemoteTasks(ctx, apply, storedTasks, progress.Tables, now); err != nil {
+		return true, err
+	}
+	if err := c.storage.Applies().Update(ctx, apply); err != nil {
+		return true, fmt.Errorf("sync nonterminal remote gRPC stop state for %s: %w", apply.ApplyIdentifier, err)
+	}
+	return true, fmt.Errorf("remote gRPC stop for apply %s accepted but remote state is still %s", apply.ApplyIdentifier, remoteState)
+}
+
+func (c *GRPCClient) completeRemoteStopFromTerminalProgress(ctx context.Context, apply *storage.Apply, controlReq *storage.ApplyControlRequest) (bool, error) {
+	progress, err := c.client.Progress(ctx, &ternv1.ProgressRequest{
+		ApplyId:     apply.ExternalID,
+		Environment: apply.Environment,
+	})
+	if err != nil {
+		slog.Warn("remote gRPC stop error could not be reconciled from progress",
+			"apply_id", apply.ApplyIdentifier,
+			"external_id", apply.ExternalID,
+			"database", apply.Database,
+			"environment", apply.Environment,
+			"requested_by", controlRequestCaller(controlReq),
+			"error", err)
+		return false, nil
+	}
+	if progress.State == ternv1.State_STATE_NO_ACTIVE_CHANGE || !isTerminalProtoState(progress.State) {
+		slog.Warn("remote gRPC stop error found nonterminal progress; durable stop request remains pending for scheduler retry",
+			"apply_id", apply.ApplyIdentifier,
+			"external_id", apply.ExternalID,
+			"database", apply.Database,
+			"environment", apply.Environment,
+			"requested_by", controlRequestCaller(controlReq),
+			"remote_state", progress.State.String(),
+			"remote_state_number", int32(progress.State))
+		return false, nil
+	}
+	remoteState := ProtoStateToStorage(progress.State)
+	if remoteState == "" {
+		return false, fmt.Errorf("sync remote gRPC stop for apply %s remote %s after stop error: unmapped remote state %s", apply.ApplyIdentifier, apply.ExternalID, remoteApplyStateDescription(progress.State))
+	}
+	now := time.Now()
+	if apply.StartedAt == nil && !state.IsState(remoteState, state.Apply.Pending) {
+		apply.StartedAt = &now
+	}
+	apply.State = applyStateFromRemoteProgress(apply.State, remoteState)
+	apply.UpdatedAt = now
+	if err := c.reconcileTerminalRemoteProgress(ctx, apply, progress.Tables, now); err != nil {
+		return false, err
+	}
+	if err := completePendingStopControlRequests(ctx, c.storage, apply); err != nil {
+		return false, err
+	}
+	c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventStopRequested, storage.LogSourceSchemaBot,
+		fmt.Sprintf("Remote stop request completed from terminal progress after stop error%s", callerApplyLogSuffix(controlRequestCaller(controlReq))), "", "")
+	return true, nil
+}
+
+func (c *GRPCClient) stopUndispatchedApply(ctx context.Context, apply *storage.Apply, caller string) error {
+	now := time.Now()
+	taskState := state.Task.Stopped
+	applyState := state.Apply.Stopped
+	if apply.DatabaseType == storage.DatabaseTypeVitess {
+		taskState = state.Task.Cancelled
+		applyState = state.Apply.Cancelled
+	}
+	tasks, err := c.storage.Tasks().GetByApplyID(ctx, apply.ID)
+	if err != nil {
+		return fmt.Errorf("load tasks for undispatched stop %s: %w", apply.ApplyIdentifier, err)
+	}
+	for _, task := range tasks {
+		if state.IsTerminalTaskState(task.State) {
+			slog.Info("leaving terminal gRPC task unchanged during undispatched stop",
+				"apply_id", apply.ApplyIdentifier,
+				"task_id", task.TaskIdentifier,
+				"table", task.TableName,
+				"task_state", task.State)
+			continue
+		}
+		task.State = taskState
+		if state.IsState(taskState, state.Task.Cancelled) {
+			task.CompletedAt = &now
+		}
+		task.UpdatedAt = now
+		if err := c.storage.Tasks().Update(ctx, task); err != nil {
+			return fmt.Errorf("update task %s for undispatched stop %s: %w", task.TaskIdentifier, apply.ApplyIdentifier, err)
+		}
+	}
+	oldState := apply.State
+	apply.State = applyState
+	apply.CompletedAt = nil
+	if state.IsState(applyState, state.Apply.Cancelled) {
+		apply.CompletedAt = &now
+	}
+	apply.UpdatedAt = now
+	if err := c.storage.Applies().Update(ctx, apply); err != nil {
+		return fmt.Errorf("update undispatched stopped gRPC apply %s: %w", apply.ApplyIdentifier, err)
+	}
+	c.logApplyStateTransition(ctx, apply, storage.LogLevelInfo, fmt.Sprintf("Remote apply stopped before dispatch: %s%s", apply.State, callerApplyLogSuffix(caller)), oldState)
+	return nil
+}
+
 func (c *GRPCClient) Start(ctx context.Context, req *ternv1.StartRequest) (*ternv1.StartResponse, error) {
 	return c.client.Start(ctx, req)
 }
@@ -420,6 +623,9 @@ func (c *GRPCClient) ResumeApply(ctx context.Context, apply *storage.Apply) erro
 	if apply == nil {
 		return fmt.Errorf("apply is required")
 	}
+	if handled, err := c.processPendingStopControlRequest(ctx, apply); handled || err != nil {
+		return err
+	}
 
 	if shouldDispatchQueuedRemoteApply(apply) {
 		return c.dispatchPendingApply(ctx, apply)
@@ -439,6 +645,9 @@ func (c *GRPCClient) ResumeApply(ctx context.Context, apply *storage.Apply) erro
 	startRequested := startControlReq != nil
 
 	if apply.ExternalID != "" && state.IsState(apply.State, state.Apply.Pending) && !startRequested {
+		if handled, err := c.processPendingStopControlRequest(ctx, apply); handled || err != nil {
+			return err
+		}
 		_, err := c.client.Start(ctx, &ternv1.StartRequest{
 			ApplyId:     apply.ExternalID,
 			Environment: apply.Environment,
@@ -525,6 +734,9 @@ func (c *GRPCClient) ResumeApply(ctx context.Context, apply *storage.Apply) erro
 
 		// Only call Start if Tern confirms the apply is actually stopped.
 		if state.IsState(apply.State, state.Apply.Stopped) {
+			if handled, err := c.processPendingStopControlRequest(ctx, apply); handled || err != nil {
+				return err
+			}
 			_, err := c.client.Start(ctx, &ternv1.StartRequest{
 				ApplyId:     apply.ExternalID,
 				Environment: apply.Environment,
@@ -612,6 +824,9 @@ func (c *GRPCClient) dispatchPendingApply(ctx context.Context, apply *storage.Ap
 	target := options["target"]
 	if target == "" {
 		target = apply.Database
+	}
+	if handled, err := c.processPendingStopControlRequest(ctx, apply); handled || err != nil {
+		return err
 	}
 
 	resp, err := c.client.Apply(ctx, &ternv1.ApplyRequest{
@@ -947,6 +1162,11 @@ func (c *GRPCClient) reconcileTerminalRemoteProgress(ctx context.Context, remote
 		if err != nil {
 			return err
 		}
+		if storedApply != nil && state.IsTerminalApplyState(storedApply.State) {
+			if err := completePendingStopControlRequests(ctx, c.storage, storedApply); err != nil {
+				return err
+			}
+		}
 		return nil
 	}
 
@@ -981,6 +1201,9 @@ func (c *GRPCClient) persistTerminalStateFromRemote(ctx context.Context, storedA
 	storedApply.UpdatedAt = now
 	if err := c.storage.Applies().Update(ctx, storedApply); err != nil {
 		return fmt.Errorf("update terminal remote gRPC apply %s: %w", storedApply.ApplyIdentifier, err)
+	}
+	if err := completePendingStopControlRequests(ctx, c.storage, storedApply); err != nil {
+		return err
 	}
 	// Stopped is a terminal apply state, but it is not completion of a pending
 	// Start request. A start can be queued while the previous worker is still
@@ -1204,6 +1427,18 @@ func (c *GRPCClient) pollForCompletion(ctx context.Context, apply *storage.Apply
 				return fmt.Errorf("heartbeat gRPC apply %s: %w", apply.ApplyIdentifier, err)
 			}
 		case <-ticker.C:
+			if handled, err := c.processPendingStopControlRequest(ctx, apply); err != nil {
+				slog.Warn("pending gRPC stop request processing failed; current apply owner will exit for scheduler retry",
+					"apply_id", apply.ApplyIdentifier,
+					"external_id", apply.ExternalID,
+					"database", apply.Database,
+					"environment", apply.Environment,
+					"error", err)
+				return err
+			} else if handled {
+				return nil
+			}
+
 			// Poll progress from remote Tern
 			resp, err := c.client.Progress(ctx, &ternv1.ProgressRequest{
 				ApplyId:     apply.ExternalID,

--- a/pkg/tern/grpc_client_test.go
+++ b/pkg/tern/grpc_client_test.go
@@ -345,6 +345,7 @@ type capturingTernServer struct {
 	applyReq         *ternv1.ApplyRequest
 	applyErr         error
 	remoteApplyID    string
+	stopApplyID      string
 	startApplyID     string
 	progressApplyID  string
 	progressReq      *ternv1.ProgressRequest
@@ -382,6 +383,13 @@ func (s *capturingTernServer) Start(_ context.Context, req *ternv1.StartRequest)
 	return &ternv1.StartResponse{Accepted: true}, nil
 }
 
+func (s *capturingTernServer) Stop(_ context.Context, req *ternv1.StopRequest) (*ternv1.StopResponse, error) {
+	s.mu.Lock()
+	s.stopApplyID = req.ApplyId
+	s.mu.Unlock()
+	return &ternv1.StopResponse{Accepted: true}, nil
+}
+
 func (s *capturingTernServer) Progress(_ context.Context, req *ternv1.ProgressRequest) (*ternv1.ProgressResponse, error) {
 	s.mu.Lock()
 	s.progressReq = &ternv1.ProgressRequest{
@@ -413,6 +421,12 @@ func (s *capturingTernServer) getStartApplyID() string {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.startApplyID
+}
+
+func (s *capturingTernServer) getStopApplyID() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.stopApplyID
 }
 
 func (s *capturingTernServer) getProgressApplyID() string {
@@ -1742,6 +1756,65 @@ func TestGRPCClient_ResumeApplyStartsQueuedStartAfterClaim(t *testing.T) {
 	controlReq, err := controlRequests.GetPending(t.Context(), apply.ID, storage.ControlOperationStart)
 	require.NoError(t, err)
 	assert.Nil(t, controlReq)
+}
+
+func TestGRPCClient_ResumeApplyProcessesQueuedStop(t *testing.T) {
+	// A pending durable stop is processed by the scheduler-owned worker before
+	// resume/start work. The worker mirrors remote stopped progress to storage
+	// before completing the durable request.
+	server := &capturingTernServer{
+		progressState:    ternv1.State_STATE_STOPPED,
+		progressStateSet: true,
+		progressTables: []*ternv1.TableProgress{{
+			TableName: "users",
+			Status:    state.Task.Stopped,
+		}},
+	}
+	client, cleanup := testCapturingGRPCClient(t, server)
+	defer cleanup()
+
+	apply := &storage.Apply{
+		ID:              1,
+		ApplyIdentifier: "apply-stop-claimed",
+		Database:        "testdb",
+		DatabaseType:    storage.DatabaseTypeMySQL,
+		Environment:     "staging",
+		ExternalID:      "remote-stop-claimed",
+		State:           state.Apply.Running,
+	}
+	storedApply := *apply
+	task := &storage.Task{
+		ID:             1,
+		ApplyID:        apply.ID,
+		TaskIdentifier: "task-stop-claimed",
+		TableName:      "users",
+		State:          state.Task.Running,
+	}
+	controlRequests := &testControlRequestStore{requests: []*storage.ApplyControlRequest{{
+		ApplyID:     apply.ID,
+		Operation:   storage.ControlOperationStop,
+		Status:      storage.ControlRequestPending,
+		RequestedBy: "cli:alice",
+	}}}
+	logs := &mockApplyLogStore{}
+	client.storage = &mockStorage{
+		applies:         &mockApplyStore{apply: &storedApply},
+		tasks:           &mockTaskStore{tasks: []*storage.Task{task}},
+		logs:            logs,
+		controlRequests: controlRequests,
+	}
+
+	err := client.ResumeApply(t.Context(), apply)
+	require.NoError(t, err)
+
+	assert.Equal(t, "remote-stop-claimed", server.getStopApplyID())
+	assert.Equal(t, "remote-stop-claimed", server.getProgressApplyID())
+	assert.Equal(t, state.Apply.Stopped, apply.State)
+	assert.Equal(t, state.Task.Stopped, task.State)
+	controlReq, err := controlRequests.GetPending(t.Context(), apply.ID, storage.ControlOperationStop)
+	require.NoError(t, err)
+	assert.Nil(t, controlReq)
+	assert.True(t, hasLogMessageContaining(logs.logs, "Remote stop accepted for apply remote-stop-claimed (caller: cli:alice)"))
 }
 
 func TestGRPCClient_ResumeApplyCompletesQueuedStartWhenRemoteAlreadyActive(t *testing.T) {

--- a/pkg/tern/local_apply_grouped.go
+++ b/pkg/tern/local_apply_grouped.go
@@ -79,6 +79,13 @@ func (c *LocalClient) executeGroupedApply(ctx context.Context, apply *storage.Ap
 	if err := c.storage.Applies().Update(ctx, apply); err != nil {
 		c.logger.Error("failed to set started_at", "apply_id", apply.ApplyIdentifier, "error", err)
 	}
+	if handled, err := c.processPendingStopControlRequest(ctx, apply); err != nil {
+		c.logger.Warn("pending stop request processing failed before grouped engine apply; current apply owner will exit for scheduler retry",
+			"apply_id", apply.ApplyIdentifier, "error", err)
+		return
+	} else if handled {
+		return
+	}
 
 	// Grouped mode: all DDLs in one engine call. Use the apply identifier as
 	// MigrationContext so all table work shares one context for progress tracking.
@@ -232,8 +239,17 @@ func (c *LocalClient) pollForCompletionAtomic(ctx context.Context, apply *storag
 }
 
 // handleAtomicProgressTick processes a single progress poll tick in atomic mode.
-// Returns true when the apply has reached a terminal state.
+// Returns true when polling should stop because the apply reached a terminal state
+// or this owner attempt must exit for scheduler retry.
 func (c *LocalClient) handleAtomicProgressTick(ctx context.Context, eng engine.Engine, apply *storage.Apply, tasks []*storage.Task, creds *engine.Credentials, resumeState *engine.ResumeState, ps *atomicPollState) bool {
+	if handled, err := c.processPendingStopControlRequest(ctx, apply); err != nil {
+		c.logger.Warn("pending stop request processing failed; current apply owner will exit for scheduler retry",
+			"apply_id", apply.ApplyIdentifier, "error", err)
+		return true
+	} else if handled {
+		return true
+	}
+
 	result, err := eng.Progress(ctx, &engine.ProgressRequest{
 		Database:    apply.Database,
 		Credentials: creds,
@@ -293,6 +309,13 @@ func (c *LocalClient) handleAtomicProgressTick(ctx context.Context, eng engine.E
 
 	// Update all tasks with engine progress
 	c.syncAtomicTaskProgress(ctx, tasks, result, newState, now)
+	if handled, err := c.processPendingStopControlRequest(ctx, apply); err != nil {
+		c.logger.Warn("pending stop request processing failed after progress sync; current apply owner will exit for scheduler retry",
+			"apply_id", apply.ApplyIdentifier, "error", err)
+		return true
+	} else if handled {
+		return true
+	}
 
 	opts := apply.GetOptions()
 	controlReq := &engine.ControlRequest{
@@ -386,6 +409,22 @@ func (c *LocalClient) handleAtomicProgressTick(ctx context.Context, eng engine.E
 	// Update apply state
 	apply.State = taskStateToApplyState(newState)
 	apply.UpdatedAt = now
+	if freshApply, err := c.storage.Applies().Get(ctx, apply.ID); err != nil {
+		c.logger.Error("failed to reload apply before progress state update", "apply_id", apply.ApplyIdentifier, "error", err)
+		return true
+	} else if freshApply != nil && state.IsTerminalApplyState(freshApply.State) {
+		c.logger.Info("apply already terminal in storage, not overwriting with stale progress state",
+			"apply_id", apply.ApplyIdentifier,
+			"stored_state", freshApply.State,
+			"progress_state", apply.State)
+		*apply = *freshApply
+		if err := completePendingStopControlRequests(ctx, c.storage, apply); err != nil {
+			c.logger.Warn("failed to complete pending stop request for terminal apply; current apply owner will exit for scheduler retry",
+				"apply_id", apply.ApplyIdentifier, "error", err)
+			return true
+		}
+		return true
+	}
 
 	if result.State.IsTerminal() {
 		retryableFailure := state.IsState(newState, state.Task.FailedRetryable)
@@ -409,6 +448,11 @@ func (c *LocalClient) handleAtomicProgressTick(ctx context.Context, eng engine.E
 		}
 		if err := c.storage.Applies().Update(ctx, apply); err != nil {
 			c.logger.Error("failed to update apply state", "apply_id", apply.ApplyIdentifier, "state", apply.State, "error", err)
+		}
+		if err := completePendingStopControlRequests(ctx, c.storage, apply); err != nil {
+			c.logger.Warn("failed to complete pending stop request after terminal progress reconciliation; current apply owner will exit for scheduler retry",
+				"apply_id", apply.ApplyIdentifier, "error", err)
+			return true
 		}
 		metrics.AdjustActiveApplies(ctx, -1, apply.Database, apply.Environment)
 		switch {

--- a/pkg/tern/local_apply_sequential.go
+++ b/pkg/tern/local_apply_sequential.go
@@ -38,6 +38,15 @@ func (c *LocalClient) executeApplySequential(ctx context.Context, apply *storage
 	var stoppedByUser bool
 
 	for i, task := range tasks {
+		if handled, err := c.processPendingStopControlRequest(ctx, apply); err != nil {
+			c.logger.Warn("pending stop request processing failed; current apply owner will exit for scheduler retry",
+				"apply_id", apply.ApplyIdentifier, "error", err)
+			return
+		} else if handled {
+			stoppedByUser = true
+			break
+		}
+
 		action := c.checkTaskReady(ctx, task)
 		if action == taskStopped {
 			stoppedByUser = true
@@ -53,7 +62,7 @@ func (c *LocalClient) executeApplySequential(ctx context.Context, apply *storage
 			"elapsed_ms", time.Since(seqStart).Milliseconds(),
 		)
 
-		action = c.runEngineTask(ctx, task, plan, options, creds)
+		action = c.runEngineTask(ctx, apply, task, plan, options, creds)
 
 		// Notify observer after each task completes
 		if obs := c.getObserver(apply.ID); obs != nil {
@@ -63,6 +72,9 @@ func (c *LocalClient) executeApplySequential(ctx context.Context, apply *storage
 		if action == taskFailed {
 			failedTask = task
 			break
+		}
+		if action == taskAbort {
+			return
 		}
 		if action == taskStopped {
 			stoppedByUser = true
@@ -89,6 +101,7 @@ const (
 	taskFailed                     // Task failed, stop processing
 	taskStopped                    // Task/apply was stopped by user, stop processing
 	taskSkip                       // Task should be skipped (error fetching state)
+	taskAbort                      // Current owner should exit without changing final state
 )
 
 // checkTaskReady verifies a task is ready to execute by checking context cancellation
@@ -122,7 +135,15 @@ func (c *LocalClient) checkTaskReady(ctx context.Context, task *storage.Task) ta
 
 // runEngineTask calls the engine for a single DDL, marks the task running, and polls to completion.
 // Returns the outcome: taskContinue (completed), taskFailed, or taskStopped.
-func (c *LocalClient) runEngineTask(ctx context.Context, task *storage.Task, plan *storage.Plan, options map[string]string, creds *engine.Credentials) taskAction {
+func (c *LocalClient) runEngineTask(ctx context.Context, apply *storage.Apply, task *storage.Task, plan *storage.Plan, options map[string]string, creds *engine.Credentials) taskAction {
+	if handled, err := c.processPendingStopControlRequest(ctx, apply); err != nil {
+		c.logger.Warn("pending stop request processing failed before sequential engine apply; current apply owner will exit for scheduler retry",
+			"apply_id", apply.ApplyIdentifier, "task_id", task.TaskIdentifier, "error", err)
+		return taskAbort
+	} else if handled {
+		return taskStopped
+	}
+
 	// Sequential mode: one DDL per engine call. Use the task identifier as
 	// MigrationContext so each table's schema change is tracked independently.
 	result, err := c.getEngine().Apply(ctx, &engine.ApplyRequest{
@@ -158,7 +179,10 @@ func (c *LocalClient) runEngineTask(ctx context.Context, task *storage.Task, pla
 	c.logger.Info("task running", "task_id", task.TaskIdentifier, "table", task.TableName)
 
 	// Poll to completion
-	c.pollTaskToCompletion(ctx, task, creds)
+	pollAction := c.pollTaskToCompletion(ctx, apply, task, creds)
+	if pollAction == taskAbort || pollAction == taskStopped {
+		return pollAction
+	}
 
 	switch task.State {
 	case state.Task.Failed, state.Task.FailedRetryable:
@@ -224,7 +248,7 @@ func (c *LocalClient) startApplyHeartbeat(ctx context.Context, apply *storage.Ap
 // pollForCompletionAtomic polls the engine for progress in atomic mode (all tasks share state).
 
 // pollTaskToCompletion polls a single task to completion (sequential mode).
-func (c *LocalClient) pollTaskToCompletion(ctx context.Context, task *storage.Task, creds *engine.Credentials) {
+func (c *LocalClient) pollTaskToCompletion(ctx context.Context, apply *storage.Apply, task *storage.Task, creds *engine.Credentials) taskAction {
 	eng := c.getEngine()
 	ticker := time.NewTicker(500 * time.Millisecond)
 	defer ticker.Stop()
@@ -232,8 +256,17 @@ func (c *LocalClient) pollTaskToCompletion(ctx context.Context, task *storage.Ta
 	for {
 		select {
 		case <-ctx.Done():
-			return
+			return taskStopped
 		case <-ticker.C:
+			if handled, err := c.processPendingStopControlRequest(ctx, apply); err != nil {
+				c.logger.Warn("pending stop request processing failed; current apply owner will exit for scheduler retry",
+					"apply_id", apply.ApplyIdentifier, "task_id", task.TaskIdentifier, "error", err)
+				return taskAbort
+			} else if handled {
+				task.State = state.Task.Stopped
+				return taskStopped
+			}
+
 			// Re-fetch task state from storage to detect external changes (e.g., Stop).
 			// This also guards against a race where a new apply starts and the engine's
 			// runningMigration no longer corresponds to this task.
@@ -241,7 +274,7 @@ func (c *LocalClient) pollTaskToCompletion(ctx context.Context, task *storage.Ta
 			if fetchErr == nil && freshTask != nil && state.IsTerminalTaskState(freshTask.State) {
 				// Task was already marked terminal externally — stop polling
 				task.State = freshTask.State
-				return
+				return taskContinue
 			}
 
 			result, err := eng.Progress(ctx, &engine.ProgressRequest{
@@ -299,7 +332,7 @@ func (c *LocalClient) pollTaskToCompletion(ctx context.Context, task *storage.Ta
 					"rows_copied", task.RowsCopied,
 					"rows_total", task.RowsTotal,
 				)
-				return
+				return taskContinue
 			}
 
 			c.transitionTaskState(ctx, task, 0, task.State, "")
@@ -344,6 +377,20 @@ func (c *LocalClient) shouldRetryEngineError(err error) bool {
 // pending tasks queued for scheduler recovery.
 func (c *LocalClient) finalizeSequentialApply(ctx context.Context, apply *storage.Apply, tasks []*storage.Task, failedTask *storage.Task, stoppedByUser bool) {
 	now := time.Now()
+	if freshApply, err := c.storage.Applies().Get(ctx, apply.ID); err != nil {
+		c.logger.Error("failed to reload apply before sequential finalization", "apply_id", apply.ApplyIdentifier, "error", err)
+		return
+	} else if freshApply != nil && state.IsTerminalApplyState(freshApply.State) {
+		c.logger.Info("apply already terminal in storage, not overwriting during sequential finalization",
+			"apply_id", apply.ApplyIdentifier,
+			"stored_state", freshApply.State)
+		*apply = *freshApply
+		if err := completePendingStopControlRequests(ctx, c.storage, apply); err != nil {
+			c.logger.Warn("failed to complete pending stop request for terminal sequential apply",
+				"apply_id", apply.ApplyIdentifier, "error", err)
+		}
+		return
+	}
 	switch {
 	case failedTask != nil && failedTask.State == state.Task.FailedRetryable:
 		apply.State = state.Apply.FailedRetryable
@@ -367,6 +414,13 @@ func (c *LocalClient) finalizeSequentialApply(ctx context.Context, apply *storag
 	apply.UpdatedAt = now
 	if err := c.storage.Applies().Update(ctx, apply); err != nil {
 		c.logger.Error("failed to update apply state", "apply_id", apply.ApplyIdentifier, "state", apply.State, "error", err)
+	}
+	if state.IsTerminalApplyState(apply.State) {
+		if err := completePendingStopControlRequests(ctx, c.storage, apply); err != nil {
+			c.logger.Warn("failed to complete pending stop request after sequential finalization",
+				"apply_id", apply.ApplyIdentifier, "error", err)
+			return
+		}
 	}
 	metrics.AdjustActiveApplies(ctx, -1, apply.Database, apply.Environment)
 

--- a/pkg/tern/local_client_test.go
+++ b/pkg/tern/local_client_test.go
@@ -22,8 +22,20 @@ type exactProgressApplyStore struct {
 	err   error
 }
 
+func (s *exactProgressApplyStore) Get(context.Context, int64) (*storage.Apply, error) {
+	return s.apply, s.err
+}
+
 func (s *exactProgressApplyStore) GetByApplyIdentifier(context.Context, string) (*storage.Apply, error) {
 	return s.apply, s.err
+}
+
+func (s *exactProgressApplyStore) Update(_ context.Context, apply *storage.Apply) error {
+	if s.err != nil {
+		return s.err
+	}
+	s.apply = apply
+	return nil
 }
 
 type exactProgressTaskStore struct {
@@ -36,8 +48,68 @@ func (s *exactProgressTaskStore) GetByApplyID(context.Context, int64) ([]*storag
 	return s.tasks, s.err
 }
 
+func (s *exactProgressTaskStore) Get(_ context.Context, taskIdentifier string) (*storage.Task, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	for _, task := range s.tasks {
+		if task.TaskIdentifier == taskIdentifier {
+			return task, nil
+		}
+	}
+	return nil, nil
+}
+
+func (s *exactProgressTaskStore) GetByDatabase(context.Context, string) ([]*storage.Task, error) {
+	return s.tasks, s.err
+}
+
 func (s *exactProgressTaskStore) Update(context.Context, *storage.Task) error {
 	return s.err
+}
+
+type fakeControlEngine struct {
+	engine.Engine
+	stopCount int
+}
+
+func (e *fakeControlEngine) Name() string { return "fake" }
+
+func (e *fakeControlEngine) Plan(context.Context, *engine.PlanRequest) (*engine.PlanResult, error) {
+	return nil, nil
+}
+
+func (e *fakeControlEngine) Apply(context.Context, *engine.ApplyRequest) (*engine.ApplyResult, error) {
+	return nil, nil
+}
+
+func (e *fakeControlEngine) Progress(context.Context, *engine.ProgressRequest) (*engine.ProgressResult, error) {
+	return &engine.ProgressResult{State: engine.StateRunning}, nil
+}
+
+func (e *fakeControlEngine) Stop(context.Context, *engine.ControlRequest) (*engine.ControlResult, error) {
+	e.stopCount++
+	return &engine.ControlResult{Accepted: true}, nil
+}
+
+func (e *fakeControlEngine) Start(context.Context, *engine.ControlRequest) (*engine.ControlResult, error) {
+	return &engine.ControlResult{Accepted: true}, nil
+}
+
+func (e *fakeControlEngine) Cutover(context.Context, *engine.ControlRequest) (*engine.ControlResult, error) {
+	return &engine.ControlResult{Accepted: true}, nil
+}
+
+func (e *fakeControlEngine) Revert(context.Context, *engine.ControlRequest) (*engine.ControlResult, error) {
+	return &engine.ControlResult{Accepted: true}, nil
+}
+
+func (e *fakeControlEngine) SkipRevert(context.Context, *engine.ControlRequest) (*engine.ControlResult, error) {
+	return &engine.ControlResult{Accepted: true}, nil
+}
+
+func (e *fakeControlEngine) Volume(context.Context, *engine.VolumeRequest) (*engine.VolumeResult, error) {
+	return &engine.VolumeResult{Accepted: true}, nil
 }
 
 type exactProgressStorage struct {
@@ -173,6 +245,104 @@ func TestLocalClient_ProgressByApplyIDReturnsNotFoundForMissingApplyData(t *test
 			require.ErrorIs(t, err, tc.wantError)
 		})
 	}
+}
+
+func TestLocalClient_ProcessPendingStopControlRequest(t *testing.T) {
+	apply := &storage.Apply{
+		ID:              123,
+		ApplyIdentifier: "apply-stop-local",
+		Database:        "testdb",
+		DatabaseType:    storage.DatabaseTypeMySQL,
+		Environment:     "staging",
+		State:           state.Apply.Running,
+	}
+	task := &storage.Task{
+		ID:             456,
+		ApplyID:        apply.ID,
+		TaskIdentifier: "task-stop-local",
+		Database:       "testdb",
+		DatabaseType:   storage.DatabaseTypeMySQL,
+		TableName:      "users",
+		State:          state.Task.Running,
+	}
+	controlRequests := &testControlRequestStore{requests: []*storage.ApplyControlRequest{{
+		ApplyID:     apply.ID,
+		Operation:   storage.ControlOperationStop,
+		Status:      storage.ControlRequestPending,
+		RequestedBy: "cli:alice",
+	}}}
+	fakeEngine := &fakeControlEngine{}
+	logs := &mockApplyLogStore{}
+	client := &LocalClient{
+		config: LocalConfig{
+			Database: "testdb",
+			Type:     storage.DatabaseTypeMySQL,
+		},
+		storage: &exactProgressStorage{
+			applies:         &exactProgressApplyStore{apply: apply},
+			tasks:           &exactProgressTaskStore{tasks: []*storage.Task{task}},
+			logs:            logs,
+			controlRequests: controlRequests,
+		},
+		spiritEngine: fakeEngine,
+		logger:       slog.Default(),
+	}
+
+	handled, err := client.processPendingStopControlRequest(t.Context(), apply)
+	require.NoError(t, err)
+	assert.True(t, handled)
+	assert.Equal(t, 1, fakeEngine.stopCount)
+	assert.Equal(t, state.Task.Stopped, task.State)
+	assert.Equal(t, state.Apply.Stopped, apply.State)
+	controlReq, err := controlRequests.GetPending(t.Context(), apply.ID, storage.ControlOperationStop)
+	require.NoError(t, err)
+	assert.Nil(t, controlReq)
+	assert.True(t, hasLogMessageContaining(logs.logs, "Stop requested: 1 tasks stopped, 0 skipped (caller: cli:alice)"))
+}
+
+func TestLocalClient_StopPreservesTerminalCancelledApply(t *testing.T) {
+	apply := &storage.Apply{
+		ID:              124,
+		ApplyIdentifier: "apply-cancelled-local",
+		Database:        "testdb",
+		DatabaseType:    storage.DatabaseTypeVitess,
+		Environment:     "staging",
+		State:           state.Apply.Cancelled,
+	}
+	task := &storage.Task{
+		ID:             457,
+		ApplyID:        apply.ID,
+		TaskIdentifier: "task-cancelled-local",
+		Database:       "testdb",
+		DatabaseType:   storage.DatabaseTypeVitess,
+		TableName:      "users",
+		State:          state.Task.Cancelled,
+	}
+	fakeEngine := &fakeControlEngine{}
+	client := &LocalClient{
+		config: LocalConfig{
+			Database: "testdb",
+			Type:     storage.DatabaseTypeVitess,
+		},
+		storage: &exactProgressStorage{
+			applies: &exactProgressApplyStore{apply: apply},
+			tasks:   &exactProgressTaskStore{tasks: []*storage.Task{task}},
+		},
+		planetscaleEngine: fakeEngine,
+		logger:            slog.Default(),
+	}
+
+	resp, err := client.stop(t.Context(), &ternv1.StopRequest{
+		ApplyId:     apply.ApplyIdentifier,
+		Environment: apply.Environment,
+	}, "cli:second")
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.True(t, resp.Accepted)
+	assert.Equal(t, int64(0), resp.StoppedCount)
+	assert.Equal(t, int64(1), resp.SkippedCount)
+	assert.Equal(t, 0, fakeEngine.stopCount)
+	assert.Equal(t, state.Apply.Cancelled, apply.State)
 }
 
 func TestTaskStateWithNoBackwardProgressPolicyCoversTaskStates(t *testing.T) {

--- a/pkg/tern/local_control.go
+++ b/pkg/tern/local_control.go
@@ -15,10 +15,12 @@ import (
 // Cutover triggers the cutover phase when defer_cutover was used.
 func (c *LocalClient) Cutover(ctx context.Context, req *ternv1.CutoverRequest) (*ternv1.CutoverResponse, error) {
 	var task *storage.Task
+	var apply *storage.Apply
 	var err error
 
 	if req.ApplyId != "" {
-		apply, lookupErr := c.storage.Applies().GetByApplyIdentifier(ctx, req.ApplyId)
+		var lookupErr error
+		apply, lookupErr = c.storage.Applies().GetByApplyIdentifier(ctx, req.ApplyId)
 		if lookupErr != nil || apply == nil {
 			return nil, fmt.Errorf("apply %s not found", req.ApplyId)
 		}
@@ -41,6 +43,23 @@ func (c *LocalClient) Cutover(ctx context.Context, req *ternv1.CutoverRequest) (
 
 	if task == nil {
 		return nil, fmt.Errorf("no active schema change")
+	}
+	if apply == nil {
+		apply, err = c.storage.Applies().Get(ctx, task.ApplyID)
+		if err != nil {
+			return nil, fmt.Errorf("load apply %d before cutover: %w", task.ApplyID, err)
+		}
+		if apply == nil {
+			return nil, fmt.Errorf("load apply %d before cutover: %w", task.ApplyID, storage.ErrApplyNotFound)
+		}
+	}
+	if controlReq, err := pendingStopControlRequest(ctx, c.storage, apply); err != nil {
+		return nil, fmt.Errorf("check pending stop request before cutover for apply %s: %w", apply.ApplyIdentifier, err)
+	} else if controlReq != nil {
+		c.logger.Info("cutover blocked because stop request is pending",
+			"apply_id", apply.ApplyIdentifier,
+			"requested_by", controlRequestCaller(controlReq))
+		return nil, fmt.Errorf("schema change has a pending stop request; cutover is blocked until stop is processed")
 	}
 
 	creds := c.credentials()
@@ -69,6 +88,10 @@ func (c *LocalClient) Cutover(ctx context.Context, req *ternv1.CutoverRequest) (
 
 // Stop pauses an in-progress schema change.
 func (c *LocalClient) Stop(ctx context.Context, req *ternv1.StopRequest) (*ternv1.StopResponse, error) {
+	return c.stop(ctx, req, "")
+}
+
+func (c *LocalClient) stop(ctx context.Context, req *ternv1.StopRequest, caller string) (*ternv1.StopResponse, error) {
 	c.logger.Info("Stop requested", "database", c.config.Database, "type", c.config.Type, "apply_id", req.ApplyId)
 	tasks, err := c.storage.Tasks().GetByDatabase(ctx, c.config.Database)
 	if err != nil {
@@ -77,12 +100,14 @@ func (c *LocalClient) Stop(ctx context.Context, req *ternv1.StopRequest) (*ternv
 
 	// If an apply_id was specified, resolve it and filter tasks to that apply only.
 	var targetApplyID int64
+	var targetApply *storage.Apply
 	if req.ApplyId != "" {
 		apply, err := c.storage.Applies().GetByApplyIdentifier(ctx, req.ApplyId)
 		if err != nil || apply == nil {
 			return nil, fmt.Errorf("apply %s not found", req.ApplyId)
 		}
 		targetApplyID = apply.ID
+		targetApply = apply
 	}
 
 	creds := c.credentials()
@@ -128,9 +153,14 @@ func (c *LocalClient) Stop(ctx context.Context, req *ternv1.StopRequest) (*ternv
 			// and call failApplyWithTasks, but we set cancelled first so the
 			// apply record reflects the true outcome. failApplyWithTasks skips
 			// tasks already in terminal state, so the cancelled tasks are preserved.
-			c.markApplyCancelled(ctx, applyID)
+			if err := c.markApplyCancelled(ctx, applyID); err != nil {
+				return nil, err
+			}
 		} else if err := c.markApplyStopped(ctx, applyID); err != nil {
 			return nil, err
+		}
+		if caller != "" {
+			eventMsg += callerApplyLogSuffix(caller)
 		}
 		c.logApplyEvent(ctx, applyID, nil, storage.LogLevelInfo, storage.LogEventStopRequested, storage.LogSourceSchemaBot,
 			eventMsg, "", "")
@@ -143,6 +173,17 @@ func (c *LocalClient) Stop(ctx context.Context, req *ternv1.StopRequest) (*ternv
 	// Edge case: stop was requested but all tasks had already completed.
 	// Mark the apply as completed so the TUI sees a clean terminal state.
 	if stoppedCount == 0 && skippedCount > 0 && applyID > 0 {
+		if targetApply != nil && state.IsTerminalApplyState(targetApply.State) && !state.IsState(targetApply.State, state.Apply.Completed) {
+			c.logger.Info("all tasks are terminal and apply is already terminal; preserving apply state during stop",
+				"apply_id", targetApply.ApplyIdentifier,
+				"state", targetApply.State,
+				"skipped_count", skippedCount)
+			return &ternv1.StopResponse{
+				Accepted:     true,
+				StoppedCount: 0,
+				SkippedCount: skippedCount,
+			}, nil
+		}
 		return c.handleStopAllCompleted(ctx, applyID, skippedCount)
 	}
 
@@ -151,6 +192,63 @@ func (c *LocalClient) Stop(ctx context.Context, req *ternv1.StopRequest) (*ternv
 		StoppedCount: stoppedCount,
 		SkippedCount: skippedCount,
 	}, nil
+}
+
+func (c *LocalClient) processPendingStopControlRequest(ctx context.Context, apply *storage.Apply) (bool, error) {
+	controlReq, err := pendingStopControlRequest(ctx, c.storage, apply)
+	if err != nil {
+		return false, err
+	}
+	if controlReq == nil {
+		return false, nil
+	}
+	if completed, err := completePendingStopIfStoredApplyResolved(ctx, c.storage, apply); err != nil {
+		return true, err
+	} else if completed {
+		c.logger.Info("completing pending stop request for resolved apply",
+			"apply_id", apply.ApplyIdentifier,
+			"requested_by", controlRequestCaller(controlReq),
+			"state", apply.State)
+		c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventStopRequested, storage.LogSourceSchemaBot,
+			fmt.Sprintf("Pending stop request completed for resolved apply%s", callerApplyLogSuffix(controlRequestCaller(controlReq))), "", "")
+		return true, nil
+	}
+	if state.IsTerminalApplyState(apply.State) {
+		c.logger.Info("completing pending stop request for terminal apply",
+			"apply_id", apply.ApplyIdentifier,
+			"requested_by", controlRequestCaller(controlReq),
+			"state", apply.State)
+		c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventStopRequested, storage.LogSourceSchemaBot,
+			fmt.Sprintf("Pending stop request completed for terminal apply%s", callerApplyLogSuffix(controlRequestCaller(controlReq))), "", "")
+		if err := completePendingStopControlRequests(ctx, c.storage, apply); err != nil {
+			return true, err
+		}
+		return true, nil
+	}
+
+	stopCtx := context.WithoutCancel(ctx)
+	resp, err := c.stop(stopCtx, &ternv1.StopRequest{
+		ApplyId:     apply.ApplyIdentifier,
+		Environment: apply.Environment,
+	}, controlRequestCaller(controlReq))
+	if err != nil {
+		return true, fmt.Errorf("process pending stop for apply %s: %w", apply.ApplyIdentifier, err)
+	}
+	if resp == nil || !resp.Accepted {
+		errorMessage := "not accepted"
+		if resp != nil && resp.ErrorMessage != "" {
+			errorMessage = resp.ErrorMessage
+		}
+		return true, fmt.Errorf("process pending stop for apply %s: %s", apply.ApplyIdentifier, errorMessage)
+	}
+	completed, err := completePendingStopIfStoredApplyResolved(stopCtx, c.storage, apply)
+	if err != nil {
+		return true, err
+	}
+	if !completed {
+		return true, fmt.Errorf("process pending stop for apply %s: storage did not reach a resolved stop state", apply.ApplyIdentifier)
+	}
+	return true, nil
 }
 
 // stopEngineForTasks calls eng.Stop() if any targeted task is actively running.
@@ -300,19 +398,22 @@ func (c *LocalClient) markApplyStopped(ctx context.Context, applyID int64) error
 // databases where cancelling the deploy request is permanent. This runs before
 // the apply goroutine sees the context cancellation, so failApplyWithTasks
 // will find the apply already terminal and leave it alone.
-func (c *LocalClient) markApplyCancelled(ctx context.Context, applyID int64) {
+func (c *LocalClient) markApplyCancelled(ctx context.Context, applyID int64) error {
 	apply, err := c.storage.Applies().Get(ctx, applyID)
-	if err != nil || apply == nil {
-		c.logger.Error("failed to load apply for cancellation", "apply_id", applyID, "error", err)
-		return
+	if err != nil {
+		return fmt.Errorf("load apply %d for cancelled state: %w", applyID, err)
+	}
+	if apply == nil {
+		return fmt.Errorf("load apply %d for cancelled state: %w", applyID, storage.ErrApplyNotFound)
 	}
 	now := time.Now()
 	apply.State = state.Apply.Cancelled
 	apply.CompletedAt = &now
 	apply.UpdatedAt = now
 	if err := c.storage.Applies().Update(ctx, apply); err != nil {
-		c.logger.Error("failed to mark apply as cancelled", "apply_id", apply.ApplyIdentifier, "error", err)
+		return fmt.Errorf("mark apply %s cancelled: %w", apply.ApplyIdentifier, err)
 	}
+	return nil
 }
 
 // controlSetup resolves the active task, credentials, and engine for a control operation.

--- a/pkg/tern/local_control_resume.go
+++ b/pkg/tern/local_control_resume.go
@@ -85,6 +85,14 @@ func (c *LocalClient) Start(ctx context.Context, req *ternv1.StartRequest) (*ter
 		if err != nil {
 			return nil, fmt.Errorf("build deferred deploy request for task %s: %w", applyTasks[0].TaskIdentifier, err)
 		}
+		if controlReq, err := pendingStopControlRequest(ctx, c.storage, apply); err != nil {
+			return nil, fmt.Errorf("check pending stop before deferred deploy start for apply %s: %w", apply.ApplyIdentifier, err)
+		} else if controlReq != nil {
+			c.logger.Info("deferred deploy start blocked because stop request is pending",
+				"apply_id", apply.ApplyIdentifier,
+				"requested_by", controlRequestCaller(controlReq))
+			return nil, fmt.Errorf("schema change has a pending stop request; start is blocked until stop is processed")
+		}
 		result, err := eng.Start(ctx, controlReq)
 		if err != nil {
 			return nil, fmt.Errorf("start deferred deploy: %w", err)
@@ -213,6 +221,15 @@ func (c *LocalClient) resumeApplySequential(ctx context.Context, apply *storage.
 	var stoppedByUser bool
 
 	for i, task := range tasks {
+		if handled, err := c.processPendingStopControlRequest(ctx, apply); err != nil {
+			c.logger.Warn("pending stop request processing failed; current apply owner will exit for scheduler retry",
+				"apply_id", apply.ApplyIdentifier, "error", err)
+			return
+		} else if handled {
+			stoppedByUser = true
+			break
+		}
+
 		action := c.checkTaskReady(ctx, task)
 		if action == taskStopped {
 			stoppedByUser = true
@@ -253,7 +270,7 @@ func (c *LocalClient) resumeApplySequential(ctx context.Context, apply *storage.
 			continue
 		}
 
-		action = c.runEngineTask(ctx, task, plan, options, creds)
+		action = c.runEngineTask(ctx, apply, task, plan, options, creds)
 
 		taskID := task.ID
 		c.logApplyEvent(ctx, apply.ID, &taskID, storage.LogLevelInfo, storage.LogEventStateTransition, storage.LogSourceSchemaBot,
@@ -263,6 +280,9 @@ func (c *LocalClient) resumeApplySequential(ctx context.Context, apply *storage.
 		if action == taskFailed {
 			failedTask = task
 			break
+		}
+		if action == taskAbort {
+			return
 		}
 		if action == taskStopped {
 			stoppedByUser = true
@@ -510,6 +530,10 @@ func (c *LocalClient) ResumeApply(ctx context.Context, apply *storage.Apply) err
 		}
 		c.notifyTerminalObserver(apply, tasks)
 		return nil
+	}
+
+	if handled, err := c.processPendingStopControlRequest(ctx, apply); handled || err != nil {
+		return err
 	}
 
 	// Get the plan to retrieve original DDLs

--- a/pkg/tern/local_control_test.go
+++ b/pkg/tern/local_control_test.go
@@ -90,6 +90,7 @@ type controlTestStorage struct {
 	tasks           storage.TaskStore
 	applyLogs       storage.ApplyLogStore
 	vitessApplyData storage.VitessApplyDataStore
+	controlRequests storage.ControlRequestStore
 }
 
 func (s *controlTestStorage) Applies() storage.ApplyStore {
@@ -106,6 +107,13 @@ func (s *controlTestStorage) ApplyLogs() storage.ApplyLogStore {
 
 func (s *controlTestStorage) VitessApplyData() storage.VitessApplyDataStore {
 	return s.vitessApplyData
+}
+
+func (s *controlTestStorage) ControlRequests() storage.ControlRequestStore {
+	if s.controlRequests != nil {
+		return s.controlRequests
+	}
+	return &testControlRequestStore{}
 }
 
 type controlCaptureEngine struct {


### PR DESCRIPTION
## Why
Stop requests currently depend on the HTTP handler completing engine side effects synchronously. Persisting stop intent lets the scheduler recover accepted operator requests after handler or process uncertainty without introducing a second owner for actively running applies.

## What
- Record `/api/stop` as a durable `stop` control request keyed by apply
- Let the active local or gRPC apply owner consume pending stop requests and complete them only after storage reflects the stopped or cancelled outcome
- Keep fresh running applies out of immediate scheduler stop claims to avoid racing the current lease owner
- Fail closed when stop-request processing errors so the current owner exits and retry/recovery preserves the durable stop intent
- Document durable control-request ownership in the architecture guide
- Cover duplicate stop requests, local owner processing, gRPC stop sync, and claim-safety behavior

```
/api/stop
   |
   v
store apply_control_requests(stop, pending)
   |
   v
active apply owner observes pending stop
   |
   +--> LocalClient: stop engine + persist stopped/cancelled state
   |
   +--> GRPCClient: remote Stop + Progress sync + persist state
   |
   v
complete durable stop request
```

Generated with Amp
