### PR TITLE
feat(observability): add environment dimension to metrics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,8 @@ CI mirrors local dev exactly — each job runs the corresponding make target.
 
 Use `fix(github)` or `feat(github)` for changes that affect the GitHub PR UX (comments, check runs, reactions) — even if the code lives in `pkg/webhook/`. The scope describes *what the user sees*, not the package name.
 
+Use `fix(observability)` or `feat(observability)` for changes that affect telemetry, metrics, tracing, logging, dashboards, or operator-facing observability behavior — even if the code lives in another package. Use `feat(observability)` when adding or expanding observable signal, such as a new metric, label/dimension, trace attribute, or structured log field.
+
 ### Commit Checklist (MANDATORY — do these every time before `git commit`)
 
 1. `gofmt -w` on all changed `.go` files

--- a/pkg/api/telemetry_integration_test.go
+++ b/pkg/api/telemetry_integration_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/testcontainers/testcontainers-go/modules/mysql"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 
+	"github.com/block/schemabot/pkg/metrics"
 	"github.com/block/schemabot/pkg/storage/mysqlstore"
 	"github.com/block/schemabot/pkg/testutil"
 )
@@ -70,7 +71,11 @@ func TestMetricsAfterRequests(t *testing.T) {
 	mux := http.NewServeMux()
 	svc.ConfigureRoutes(mux)
 	mux.Handle("GET /metrics", tel.MetricsHandler)
-	handler := otelhttp.NewHandler(mux, "schemabot")
+	handler := otelhttp.NewHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		labeler, _ := otelhttp.LabelerFromContext(r.Context())
+		labeler.Add(metrics.EnvironmentAttribute(""))
+		mux.ServeHTTP(w, r)
+	}), "schemabot")
 
 	ts := httptest.NewServer(handler)
 	defer ts.Close()
@@ -116,6 +121,8 @@ func TestMetricsAfterRequests(t *testing.T) {
 		"/metrics should contain http_server_request_body_size")
 	assert.True(t, strings.Contains(metricsText, "http_server_response_body_size"),
 		"/metrics should contain http_server_response_body_size")
+	assert.True(t, strings.Contains(metricsText, `environment="unknown"`),
+		"/metrics should contain an environment label on HTTP server metrics")
 
 	// The custom plans counter only appears after its first increment,
 	// so we don't assert it here — it's tested in TestRecordPlanMetric.

--- a/pkg/api/telemetry_test.go
+++ b/pkg/api/telemetry_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -169,7 +170,11 @@ func TestOtelHTTPMetrics(t *testing.T) {
 	svc := newTestService()
 	mux := http.NewServeMux()
 	svc.ConfigureRoutes(mux)
-	handler := otelhttp.NewHandler(mux, "schemabot")
+	handler := otelhttp.NewHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		labeler, _ := otelhttp.LabelerFromContext(r.Context())
+		labeler.Add(metrics.EnvironmentAttribute(""))
+		mux.ServeHTTP(w, r)
+	}), "schemabot")
 
 	// Hit /health — the one route guaranteed to work with mock storage.
 	req := httptest.NewRequestWithContext(t.Context(), "GET", "/health", nil)
@@ -191,22 +196,25 @@ func TestOtelHTTPMetrics(t *testing.T) {
 	assert.True(t, metricNames["http.server.request.body.size"], "expected http.server.request.body.size metric")
 	assert.True(t, metricNames["http.server.response.body.size"], "expected http.server.response.body.size metric")
 
-	// Verify the duration histogram has data points with expected attributes.
+	// Verify HTTP server metrics have expected attributes.
 	for _, sm := range rm.ScopeMetrics {
 		for _, m := range sm.Metrics {
+			if !strings.HasPrefix(m.Name, "http.server.") {
+				continue
+			}
+			assertMetricDataPointsHaveEnvironment(t, m)
 			if m.Name != "http.server.request.duration" {
 				continue
 			}
 			hist, ok := m.Data.(metricdata.Histogram[float64])
 			require.True(t, ok)
-			assert.GreaterOrEqual(t, len(hist.DataPoints), 1, "expected at least one duration data point")
+			assert.GreaterOrEqual(t, len(hist.DataPoints), 1, "expected at least one data point for %s", m.Name)
 
-			// Verify data points have standard HTTP attributes.
 			for _, dp := range hist.DataPoints {
 				_, hasMethod := dp.Attributes.Value(attribute.Key("http.request.method"))
-				assert.True(t, hasMethod, "expected http.request.method attribute on duration data point")
+				assert.True(t, hasMethod, "expected http.request.method attribute on %s data point", m.Name)
 				_, hasStatus := dp.Attributes.Value(attribute.Key("http.response.status_code"))
-				assert.True(t, hasStatus, "expected http.response.status_code attribute on duration data point")
+				assert.True(t, hasStatus, "expected http.response.status_code attribute on %s data point", m.Name)
 			}
 		}
 	}
@@ -224,6 +232,102 @@ func collectMetricNames(t *testing.T, reader *sdkmetric.ManualReader) map[string
 		}
 	}
 	return names
+}
+
+func TestSchemaBotMetricsIncludeEnvironmentAttribute(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	prevMP := otel.GetMeterProvider()
+	otel.SetMeterProvider(mp)
+	t.Cleanup(func() {
+		otel.SetMeterProvider(prevMP)
+		require.NoError(t, mp.Shutdown(t.Context()))
+	})
+
+	metrics.RecordPlan(t.Context(), "org/repo", "mydb", "staging", "success")
+	metrics.RecordPlanDuration(t.Context(), time.Second, "org/repo", "mydb", "staging", "success")
+	metrics.RecordApply(t.Context(), "org/repo", "mydb", "staging", "success")
+	metrics.RecordApplyDuration(t.Context(), time.Second, "org/repo", "mydb", "staging", "success")
+	metrics.RecordSchemaFreshnessRejected(t.Context(), "apply", "staging")
+	metrics.RecordStalePlanRejected(t.Context(), "staging")
+	metrics.RecordSourcePolicyBlock(t.Context(), "plan", "mydb", "staging", "unauthorized_repo")
+	metrics.RecordPRCommandActorAuthorization(t.Context(), "apply", "mydb", "staging", "org/repo", "allowed", "allowed_admin_user")
+	metrics.RecordCheckOwnershipMiss(t.Context(), "apply_finished", "org/repo", "mydb", "mysql", "staging")
+	metrics.AdjustActiveApplies(t.Context(), 1, "mydb", "staging")
+	metrics.RecordControlOperation(t.Context(), "stop", "mydb", "staging", "success")
+	metrics.RecordLockOperation(t.Context(), "acquire", "mydb", "success")
+	metrics.RecordSchedulerResume(t.Context(), "mydb", "staging", "running")
+	metrics.RecordSchedulerResumeFailure(t.Context(), "mydb", "staging", "no_client")
+	metrics.RecordSchedulerClaimFailure(t.Context(), "storage_error")
+	metrics.RecordSchedulerClaimDuration(t.Context(), time.Second, "mydb", "staging", "running")
+	metrics.RecordSchemaRequestError(t.Context(), "org/repo", "apply", "mydb", "staging", "invalid_config")
+	metrics.RecordGitHubRequest(t.Context(), metrics.GitHubRequestSample{
+		Operation:  metrics.GitHubOperationFetchPullRequest,
+		Category:   metrics.GitHubRequestCategoryRead,
+		Resource:   metrics.GitHubRateLimitResourceCore,
+		Status:     metrics.GitHubRequestStatusSuccess,
+		Repository: "org/repo",
+	})
+	metrics.RecordGitHubRateLimit(t.Context(), metrics.GitHubRateLimitSample{
+		Operation:  metrics.GitHubOperationFetchPullRequest,
+		Resource:   metrics.GitHubRateLimitResourceCore,
+		Repository: "org/repo",
+		Limit:      100,
+		Remaining:  99,
+		Used:       1,
+	})
+	metrics.RecordWebhookEvent(t.Context(), "issue_comment", "created", "org/repo", "processed")
+	metrics.RecordStatusCheckOperation(t.Context(), metrics.StatusCheckOperation{
+		Operation:  "aggregate_check_sync",
+		Repository: "org/repo",
+		Status:     "blocked",
+	})
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(t.Context(), &rm))
+
+	var checked int
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if !strings.HasPrefix(m.Name, "schemabot.") {
+				continue
+			}
+			checked++
+			assertMetricDataPointsHaveEnvironment(t, m)
+		}
+	}
+	require.NotZero(t, checked, "expected SchemaBot metrics to be collected")
+}
+
+func assertMetricDataPointsHaveEnvironment(t *testing.T, m metricdata.Metrics) {
+	t.Helper()
+	switch data := m.Data.(type) {
+	case metricdata.Sum[int64]:
+		for _, dp := range data.DataPoints {
+			assertMetricAttributesHaveEnvironment(t, m.Name, dp.Attributes)
+		}
+	case metricdata.Gauge[int64]:
+		for _, dp := range data.DataPoints {
+			assertMetricAttributesHaveEnvironment(t, m.Name, dp.Attributes)
+		}
+	case metricdata.Histogram[float64]:
+		for _, dp := range data.DataPoints {
+			assertMetricAttributesHaveEnvironment(t, m.Name, dp.Attributes)
+		}
+	case metricdata.Histogram[int64]:
+		for _, dp := range data.DataPoints {
+			assertMetricAttributesHaveEnvironment(t, m.Name, dp.Attributes)
+		}
+	default:
+		t.Fatalf("unsupported metric data type %T for %s", m.Data, m.Name)
+	}
+}
+
+func assertMetricAttributesHaveEnvironment(t *testing.T, metricName string, attrs attribute.Set) {
+	t.Helper()
+	environment, ok := attrs.Value(attribute.Key("environment"))
+	require.True(t, ok, "%s metric data point missing environment attribute: %v", metricName, attrs)
+	assert.NotEmpty(t, environment.AsString(), "%s metric environment attribute must be non-empty", metricName)
 }
 
 func TestRecordApplyMetrics(t *testing.T) {
@@ -529,13 +633,36 @@ func TestRecordSchedulerMetrics(t *testing.T) {
 	metrics.RecordSchedulerResume(t.Context(), "testdb", "staging", "running")
 	metrics.RecordSchedulerResumeFailure(t.Context(), "testdb", "staging", "no_client")
 	metrics.RecordSchedulerClaimFailure(t.Context(), "storage_error")
+	metrics.RecordSchedulerClaimFailure(t.Context(), "expire_retryable_error")
 	metrics.RecordSchedulerClaimDuration(t.Context(), 50*time.Millisecond, "testdb", "staging", "running")
 
-	names := collectMetricNames(t, reader)
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(t.Context(), &rm))
+
+	names := make(map[string]bool)
+	var sawExpireRetryableError bool
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			names[m.Name] = true
+			if m.Name != "schemabot.scheduler.claim_failures_total" {
+				continue
+			}
+			sum, ok := m.Data.(metricdata.Sum[int64])
+			require.True(t, ok)
+			for _, dp := range sum.DataPoints {
+				reason, hasReason := dp.Attributes.Value(attribute.Key("reason"))
+				require.True(t, hasReason)
+				if reason.AsString() == "expire_retryable_error" {
+					sawExpireRetryableError = true
+				}
+			}
+		}
+	}
 	assert.True(t, names["schemabot.scheduler.resumed_total"], "expected schemabot.scheduler.resumed_total")
 	assert.True(t, names["schemabot.scheduler.resume_failures_total"], "expected schemabot.scheduler.resume_failures_total")
 	assert.True(t, names["schemabot.scheduler.claim_failures_total"], "expected schemabot.scheduler.claim_failures_total")
 	assert.True(t, names["schemabot.scheduler.claim_duration_seconds"], "expected schemabot.scheduler.claim_duration_seconds")
+	assert.True(t, sawExpireRetryableError, "expected expire_retryable_error claim failure reason to be preserved")
 }
 
 // setupTraceTest creates an in-memory trace exporter and configures the global

--- a/pkg/cmd/commands/serve.go
+++ b/pkg/cmd/commands/serve.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/block/schemabot/pkg/api"
 	ghclient "github.com/block/schemabot/pkg/github"
+	"github.com/block/schemabot/pkg/metrics"
 	"github.com/block/schemabot/pkg/secrets"
 	"github.com/block/schemabot/pkg/storage/mysqlstore"
 	"github.com/block/schemabot/pkg/tern"
@@ -187,7 +188,12 @@ func (cmd *ServeCmd) Run(g *Globals) error {
 
 	// Wrap mux with OTel HTTP instrumentation for automatic request
 	// duration, request body size, and response body size metrics.
-	handler := otelhttp.NewHandler(mux, "schemabot")
+	metricHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		labeler, _ := otelhttp.LabelerFromContext(r.Context())
+		labeler.Add(metrics.EnvironmentAttribute(""))
+		mux.ServeHTTP(w, r)
+	})
+	handler := otelhttp.NewHandler(metricHandler, "schemabot")
 
 	// Create server
 	server := &http.Server{

--- a/pkg/metrics/README.md
+++ b/pkg/metrics/README.md
@@ -4,26 +4,35 @@ SchemaBot exposes metrics via OpenTelemetry. All metrics are available at `GET /
 
 ## Custom Metrics
 
+Every SchemaBot-owned metric emits a non-empty `environment` attribute. Metrics
+that are not scoped to one schema-change environment use `environment="unknown"`.
+Some attributes listed below are optional and only appear when that context is
+available, such as `repository`, `github_app`, and `installation_id`.
+
 | Metric | Type | Attributes | Description |
 |---|---|---|---|
 | `schemabot.plans.total` | Counter | repository, database, environment, status | Total plan operations |
 | `schemabot.plan.duration_seconds` | Histogram | repository, database, environment, status | Plan execution time |
 | `schemabot.applies.total` | Counter | repository, database, environment, status | Total apply operations |
 | `schemabot.apply.duration_seconds` | Histogram | repository, database, environment, status | Apply API call time |
+| `schemabot.schema_freshness.rejected.total` | Counter | action, environment | Plan/apply/apply-confirm rejected because PR HEAD advanced after discovery loaded schema files |
+| `schemabot.command.rejected_stale_plan.total` | Counter | action, environment | Apply-confirm rejected because PR HEAD advanced after the confirmation plan was posted |
+| `schemabot.source_policy.blocks_total` | Counter | operation, database, environment, reason | Trusted-source plan/apply requests blocked by source policy |
+| `schemabot.pr_command_actor_authorization.total` | Counter | command, database, environment, repository, status, reason | GitHub PR command actor authorization decisions |
 | `schemabot.schema_request.errors_total` | Counter | repository, command, database, environment, reason | Schema request errors by reason |
 | `schemabot.active_applies` | UpDownCounter | database, environment | In-progress applies |
 | `schemabot.check_ownership_misses_total` | Counter | operation, repository, database, database_type, environment | Guarded check updates skipped because ownership changed |
 | `schemabot.status_check_operations_total` | Counter | operation, status, repository, database, database_type, environment | Status-check storage and GitHub operations |
-| `schemabot.webhook.events_total` | Counter | event_type, action, repository, status | GitHub webhook events |
-| `schemabot.github.requests_total` | Counter | operation, category, resource, status, repository, github_app, installation_id | GitHub API responses observed by SchemaBot |
-| `schemabot.github.rate_limit.limit` | Gauge | operation, resource, repository, github_app, installation_id | GitHub primary rate limit for the observed API resource |
-| `schemabot.github.rate_limit.remaining` | Gauge | operation, resource, repository, github_app, installation_id | GitHub primary rate limit requests remaining for the observed API resource |
-| `schemabot.github.rate_limit.used` | Gauge | operation, resource, repository, github_app, installation_id | GitHub primary rate limit requests used for the observed API resource |
+| `schemabot.webhook.events_total` | Counter | environment, event_type, action, repository, status | GitHub webhook events |
+| `schemabot.github.requests_total` | Counter | environment, operation, category, resource, status, repository, github_app, installation_id | GitHub API responses observed by SchemaBot |
+| `schemabot.github.rate_limit.limit` | Gauge | environment, operation, resource, repository, github_app, installation_id | GitHub primary rate limit for the observed API resource |
+| `schemabot.github.rate_limit.remaining` | Gauge | environment, operation, resource, repository, github_app, installation_id | GitHub primary rate limit requests remaining for the observed API resource |
+| `schemabot.github.rate_limit.used` | Gauge | environment, operation, resource, repository, github_app, installation_id | GitHub primary rate limit requests used for the observed API resource |
 | `schemabot.control_operations_total` | Counter | operation, database, environment, status | Control operations (cutover, stop, start, etc.) |
-| `schemabot.lock_operations_total` | Counter | operation, database, status | Lock acquire/release operations |
+| `schemabot.lock_operations_total` | Counter | operation, database, environment, status | Lock acquire/release operations |
 | `schemabot.scheduler.resumed_total` | Counter | database, environment, previous_state | Applies resumed by the scheduler |
 | `schemabot.scheduler.resume_failures_total` | Counter | database, environment, reason | Scheduler resume attempts that failed |
-| `schemabot.scheduler.claim_failures_total` | Counter | reason | Scheduler claim attempts that failed |
+| `schemabot.scheduler.claim_failures_total` | Counter | environment, reason | Scheduler claim attempts that failed |
 | `schemabot.scheduler.claim_duration_seconds` | Histogram | database, environment, previous_state | Scheduler claim and resume duration |
 
 ### Attribute Values
@@ -31,6 +40,20 @@ SchemaBot exposes metrics via OpenTelemetry. All metrics are available at `GET /
 **status** (plans): `success`, `error`
 
 **status** (applies): `success`, `error`, `rejected`, `conflict`
+
+**action** (schema freshness): `plan`, `apply`, `apply_confirm`, `unknown`
+
+**action** (stale plan): `apply_confirm`
+
+**operation** (source policy): `plan`, `apply`, `unknown`
+
+**reason** (source policy): `missing_server_config`, `missing_database_config`, `missing_repository`, `missing_pull_request`, `missing_schema_path`, `unauthorized_repo`, `unauthorized_schema_dir`, `unknown`
+
+**command** (PR command actor authorization): `apply`, `apply_confirm`, `rollback`, `rollback_confirm`, `unlock`, `cutover`, `stop`, `start`, `volume`, `revert`, `skip_revert`, `unknown`
+
+**status** (PR command actor authorization): `allowed`, `denied`, `error`, `skipped`, `unknown`
+
+**reason** (PR command actor authorization): `disabled`, `allowed_admin_team`, `allowed_admin_user`, `allowed_operator_team`, `allowed_operator_user`, `missing_actor`, `missing_server_config`, `missing_database_config`, `no_configured_principal`, `not_authorized`, `github_error`, `unknown`
 
 **operation** (check ownership): `apply_finished`, `rollback_finished`
 
@@ -192,18 +215,22 @@ Operation values:
 
 The `otelhttp` middleware automatically produces standard HTTP metrics for every endpoint:
 
-| Metric | Type | Description |
-|---|---|---|
-| `http.server.request.duration` | Histogram | Request latency by method and status code |
-| `http.server.request.body.size` | Histogram | Request body sizes |
-| `http.server.response.body.size` | Histogram | Response body sizes |
+| Metric | Type | Attributes | Description |
+|---|---|---|---|
+| `http.server.request.duration` | Histogram | environment, http.request.method, http.response.status_code | Request latency by method and status code |
+| `http.server.request.body.size` | Histogram | environment | Request body sizes |
+| `http.server.response.body.size` | Histogram | environment | Response body sizes |
+
+SchemaBot attaches `environment="unknown"` to these process-wide HTTP metrics
+because routing-level request metrics do not belong to one schema-change
+environment. Environment-specific operation metrics use the real environment.
 
 ## Adding New Metrics
 
 Define recording functions in `metrics.go` following the existing pattern:
 
 ```go
-func RecordXxx(ctx context.Context, attrs ...string) {
+func RecordXxx(ctx context.Context, database, environment, status string) {
     meter := otel.Meter(meterName)
     counter, err := meter.Int64Counter("schemabot.xxx.total",
         otelmetric.WithDescription("Description"),
@@ -213,7 +240,11 @@ func RecordXxx(ctx context.Context, attrs ...string) {
         slog.Warn("failed to create counter", "error", err)
         return
     }
-    counter.Add(ctx, 1, otelmetric.WithAttributes(...))
+    counter.Add(ctx, 1, otelmetric.WithAttributes(
+        attribute.String("database", database),
+        EnvironmentAttribute(environment),
+        attribute.String("status", status),
+    ))
 }
 ```
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -16,6 +16,18 @@ import (
 // Meter name used for all SchemaBot metrics.
 const meterName = "schemabot"
 
+const unknownEnvironment = "unknown"
+
+// EnvironmentAttribute returns the canonical environment metric attribute.
+// Use "unknown" for process-wide or integration metrics that do not belong to
+// a single SchemaBot environment.
+func EnvironmentAttribute(environment string) attribute.KeyValue {
+	if environment == "" {
+		environment = unknownEnvironment
+	}
+	return attribute.String("environment", environment)
+}
+
 // RecordPlan increments the plans counter with database, environment, and status attributes.
 // Status should be "success" or "error".
 //
@@ -35,7 +47,7 @@ func RecordPlan(ctx context.Context, repo, database, environment, status string)
 		otelmetric.WithAttributes(
 			attribute.String("repository", repo),
 			attribute.String("database", database),
-			attribute.String("environment", environment),
+			EnvironmentAttribute(environment),
 			attribute.String("status", status),
 		),
 	)
@@ -56,7 +68,7 @@ func RecordPlanDuration(ctx context.Context, duration time.Duration, repo, datab
 		otelmetric.WithAttributes(
 			attribute.String("repository", repo),
 			attribute.String("database", database),
-			attribute.String("environment", environment),
+			EnvironmentAttribute(environment),
 			attribute.String("status", status),
 		),
 	)
@@ -78,7 +90,7 @@ func RecordApply(ctx context.Context, repo, database, environment, status string
 		otelmetric.WithAttributes(
 			attribute.String("repository", repo),
 			attribute.String("database", database),
-			attribute.String("environment", environment),
+			EnvironmentAttribute(environment),
 			attribute.String("status", status),
 		),
 	)
@@ -100,7 +112,7 @@ func RecordApplyDuration(ctx context.Context, duration time.Duration, repo, data
 		otelmetric.WithAttributes(
 			attribute.String("repository", repo),
 			attribute.String("database", database),
-			attribute.String("environment", environment),
+			EnvironmentAttribute(environment),
 			attribute.String("status", status),
 		),
 	)
@@ -120,7 +132,7 @@ var knownSchemaFreshnessActions = map[string]bool{
 // schema files. The metric name is action-neutral because the same rejection fires
 // for read-only plan as well as mutating apply paths. A spike indicates aggressive
 // force-pushing, webhook replay, or a regression in the schema-freshness guard.
-func RecordSchemaFreshnessRejected(ctx context.Context, action string) {
+func RecordSchemaFreshnessRejected(ctx context.Context, action, environment string) {
 	if !knownSchemaFreshnessActions[action] {
 		action = "unknown"
 	}
@@ -136,6 +148,7 @@ func RecordSchemaFreshnessRejected(ctx context.Context, action string) {
 	counter.Add(ctx, 1,
 		otelmetric.WithAttributes(
 			attribute.String("action", action),
+			EnvironmentAttribute(environment),
 		),
 	)
 }
@@ -151,7 +164,7 @@ func RecordSchemaFreshnessRejected(ctx context.Context, action string) {
 // across deliveries. A spike here indicates humans pushing aggressively
 // during PR review; sustained activity suggests reviewers need a tighter
 // "freeze the branch" workflow during apply confirmation.
-func RecordStalePlanRejected(ctx context.Context) {
+func RecordStalePlanRejected(ctx context.Context, environment string) {
 	meter := otel.Meter(meterName)
 	counter, err := meter.Int64Counter("schemabot.command.rejected_stale_plan.total",
 		otelmetric.WithDescription("apply-confirm rejected because PR HEAD advanced after the confirmation plan was posted"),
@@ -164,6 +177,7 @@ func RecordStalePlanRejected(ctx context.Context) {
 	counter.Add(ctx, 1,
 		otelmetric.WithAttributes(
 			attribute.String("action", "apply_confirm"),
+			EnvironmentAttribute(environment),
 		),
 	)
 }
@@ -206,7 +220,7 @@ func RecordSourcePolicyBlock(ctx context.Context, operation, database, environme
 		otelmetric.WithAttributes(
 			attribute.String("operation", operation),
 			attribute.String("database", database),
-			attribute.String("environment", environment),
+			EnvironmentAttribute(environment),
 			attribute.String("reason", reason),
 		),
 	)
@@ -275,7 +289,7 @@ func RecordPRCommandActorAuthorization(ctx context.Context, command, database, e
 		otelmetric.WithAttributes(
 			attribute.String("command", command),
 			attribute.String("database", database),
-			attribute.String("environment", environment),
+			EnvironmentAttribute(environment),
 			attribute.String("repository", repository),
 			attribute.String("status", status),
 			attribute.String("reason", reason),
@@ -312,7 +326,7 @@ func RecordCheckOwnershipMiss(ctx context.Context, operation, repository, databa
 			attribute.String("repository", repository),
 			attribute.String("database", database),
 			attribute.String("database_type", databaseType),
-			attribute.String("environment", environment),
+			EnvironmentAttribute(environment),
 		),
 	)
 }
@@ -332,7 +346,7 @@ func AdjustActiveApplies(ctx context.Context, delta int64, database, environment
 	counter.Add(ctx, delta,
 		otelmetric.WithAttributes(
 			attribute.String("database", database),
-			attribute.String("environment", environment),
+			EnvironmentAttribute(environment),
 		),
 	)
 }
@@ -368,7 +382,7 @@ func RecordControlOperation(ctx context.Context, operation, database, environmen
 		otelmetric.WithAttributes(
 			attribute.String("operation", operation),
 			attribute.String("database", database),
-			attribute.String("environment", environment),
+			EnvironmentAttribute(environment),
 			attribute.String("status", status),
 		),
 	)
@@ -391,6 +405,7 @@ func RecordLockOperation(ctx context.Context, operation, database, status string
 		otelmetric.WithAttributes(
 			attribute.String("operation", operation),
 			attribute.String("database", database),
+			EnvironmentAttribute(""),
 			attribute.String("status", status),
 		),
 	)
@@ -411,7 +426,7 @@ func RecordSchedulerResume(ctx context.Context, database, environment, previousS
 	counter.Add(ctx, 1,
 		otelmetric.WithAttributes(
 			attribute.String("database", database),
-			attribute.String("environment", environment),
+			EnvironmentAttribute(environment),
 			attribute.String("previous_state", previousState),
 		),
 	)
@@ -431,14 +446,15 @@ func RecordSchedulerResumeFailure(ctx context.Context, database, environment, re
 	counter.Add(ctx, 1,
 		otelmetric.WithAttributes(
 			attribute.String("database", database),
-			attribute.String("environment", environment),
+			EnvironmentAttribute(environment),
 			attribute.String("reason", reason),
 		),
 	)
 }
 
 var knownSchedulerClaimFailureReasons = map[string]bool{
-	"storage_error": true,
+	"expire_retryable_error": true,
+	"storage_error":          true,
 }
 
 // RecordSchedulerClaimFailure increments the scheduler claim failure counter.
@@ -457,6 +473,7 @@ func RecordSchedulerClaimFailure(ctx context.Context, reason string) {
 	}
 	counter.Add(ctx, 1,
 		otelmetric.WithAttributes(
+			EnvironmentAttribute(""),
 			attribute.String("reason", reason),
 		),
 	)
@@ -476,7 +493,7 @@ func RecordSchedulerClaimDuration(ctx context.Context, duration time.Duration, d
 	hist.Record(ctx, duration.Seconds(),
 		otelmetric.WithAttributes(
 			attribute.String("database", database),
-			attribute.String("environment", environment),
+			EnvironmentAttribute(environment),
 			attribute.String("previous_state", previousState),
 		),
 	)
@@ -520,7 +537,7 @@ func RecordSchemaRequestError(ctx context.Context, repo, command, database, envi
 			attribute.String("repository", repo),
 			attribute.String("command", command),
 			attribute.String("database", database),
-			attribute.String("environment", environment),
+			EnvironmentAttribute(environment),
 			attribute.String("reason", reason),
 		),
 	)
@@ -675,6 +692,7 @@ func RecordGitHubRateLimit(ctx context.Context, sample GitHubRateLimitSample) {
 func gitHubMetricAttributes(operation, resource, repository, githubApp string, installationID int64) []attribute.KeyValue {
 	attrs := []attribute.KeyValue{
 		attribute.String("operation", operation),
+		EnvironmentAttribute(""),
 		attribute.String("resource", resource),
 	}
 	if repository != "" {
@@ -819,6 +837,7 @@ func RecordWebhookEvent(ctx context.Context, eventType, action, repo, status str
 		return
 	}
 	attrs := []attribute.KeyValue{
+		EnvironmentAttribute(""),
 		attribute.String("event_type", eventType),
 		attribute.String("status", status),
 	}
@@ -881,6 +900,7 @@ func RecordStatusCheckOperation(ctx context.Context, op StatusCheckOperation) {
 		return
 	}
 	attrs := []attribute.KeyValue{
+		EnvironmentAttribute(op.Environment),
 		attribute.String("operation", op.Operation),
 		attribute.String("status", op.Status),
 	}
@@ -889,9 +909,6 @@ func RecordStatusCheckOperation(ctx context.Context, op StatusCheckOperation) {
 	}
 	if op.DatabaseType != "" {
 		attrs = append(attrs, attribute.String("database_type", op.DatabaseType))
-	}
-	if op.Environment != "" {
-		attrs = append(attrs, attribute.String("environment", op.Environment))
 	}
 	if op.Repository != "" {
 		attrs = append(attrs, attribute.String("repository", op.Repository))

--- a/pkg/webhook/plan_freshness.go
+++ b/pkg/webhook/plan_freshness.go
@@ -91,7 +91,7 @@ func (h *Handler) assertPlanStillCurrent(
 		"requested_by", requestedBy,
 	)
 
-	metrics.RecordStalePlanRejected(ctx)
+	metrics.RecordStalePlanRejected(ctx, environment)
 
 	h.postComment(repo, pr, installationID, templates.RenderStalePlanRejection(templates.StalePlanRejectionData{
 		RequestedBy: requestedBy,

--- a/pkg/webhook/schema_freshness.go
+++ b/pkg/webhook/schema_freshness.go
@@ -54,7 +54,7 @@ func (h *Handler) assertSchemaStillCurrent(
 		"requested_by", requestedBy,
 	)
 
-	metrics.RecordSchemaFreshnessRejected(ctx, metricActionKey(action))
+	metrics.RecordSchemaFreshnessRejected(ctx, metricActionKey(action), environment)
 
 	h.postComment(repo, pr, installationID, templates.RenderStaleSchemaRejection(templates.StaleSchemaRejectionData{
 		RequestedBy:  requestedBy,


### PR DESCRIPTION
Ensure SchemaBot metrics always emit a non-empty `environment` attribute, using `unknown` for process-wide signals that do not have environment-specific context. This keeps dashboards and alerts consistently scoped across apply, planning, scheduler, webhook, GitHub, status-check, lock, and HTTP server metrics.

The change also threads real environment context into stale schema and stale plan rejection metrics, documents the environment-label convention, and adds coverage that records every custom SchemaBot metric path plus the standard HTTP server metrics to assert each data point includes `environment`.

Generated with Amp.
