### PR TITLE
fix(observability): add deployment context to remote failures

### DIFF
--- a/pkg/api/control_handlers.go
+++ b/pkg/api/control_handlers.go
@@ -112,6 +112,7 @@ func (s *Service) writeControlError(w http.ResponseWriter, opName string, apply 
 			"external_apply_id", apply.ExternalID,
 			"database", apply.Database,
 			"database_type", apply.DatabaseType,
+			"deployment", apply.Deployment,
 			"environment", apply.Environment,
 		)
 	}
@@ -332,6 +333,7 @@ func (s *Service) handleStop(w http.ResponseWriter, r *http.Request) {
 			s.logger.Info("immediate stop skipped because stop request is already pending",
 				"apply_id", apply.ApplyIdentifier,
 				"database", apply.Database,
+				"deployment", apply.Deployment,
 				"environment", apply.Environment,
 				"requested_by", req.Caller)
 		} else {
@@ -358,6 +360,7 @@ func (s *Service) tryImmediateStopAfterQueue(ctx context.Context, client tern.Cl
 		s.logger.Warn("immediate stop not attempted because Tern client is unavailable; durable stop request remains pending for apply owner retry",
 			"apply_id", apply.ApplyIdentifier,
 			"database", apply.Database,
+			"deployment", apply.Deployment,
 			"environment", apply.Environment,
 			"requested_by", caller)
 		return
@@ -367,6 +370,7 @@ func (s *Service) tryImmediateStopAfterQueue(ctx context.Context, client tern.Cl
 			"apply_id", apply.ApplyIdentifier,
 			"tern_apply_id", ternApplyID,
 			"database", apply.Database,
+			"deployment", apply.Deployment,
 			"environment", apply.Environment,
 			"requested_by", caller)
 		s.logControlOperationForApply(ctx, apply, caller, storage.LogEventStopRequested,
@@ -382,6 +386,7 @@ func (s *Service) tryImmediateStopAfterQueue(ctx context.Context, client tern.Cl
 			"apply_id", apply.ApplyIdentifier,
 			"tern_apply_id", ternApplyID,
 			"database", apply.Database,
+			"deployment", apply.Deployment,
 			"environment", apply.Environment,
 			"requested_by", caller,
 			"error", err)
@@ -394,6 +399,7 @@ func (s *Service) tryImmediateStopAfterQueue(ctx context.Context, client tern.Cl
 			"apply_id", apply.ApplyIdentifier,
 			"tern_apply_id", ternApplyID,
 			"database", apply.Database,
+			"deployment", apply.Deployment,
 			"environment", apply.Environment,
 			"requested_by", caller)
 		s.logControlOperationForApply(ctx, apply, caller, storage.LogEventStopRequested,
@@ -405,6 +411,7 @@ func (s *Service) tryImmediateStopAfterQueue(ctx context.Context, client tern.Cl
 			"apply_id", apply.ApplyIdentifier,
 			"tern_apply_id", ternApplyID,
 			"database", apply.Database,
+			"deployment", apply.Deployment,
 			"environment", apply.Environment,
 			"requested_by", caller,
 			"error_message", resp.ErrorMessage,
@@ -420,6 +427,7 @@ func (s *Service) tryImmediateStopAfterQueue(ctx context.Context, client tern.Cl
 			"apply_id", apply.ApplyIdentifier,
 			"tern_apply_id", ternApplyID,
 			"database", apply.Database,
+			"deployment", apply.Deployment,
 			"environment", apply.Environment,
 			"requested_by", caller,
 			"stopped_count", resp.StoppedCount,
@@ -434,6 +442,7 @@ func (s *Service) tryImmediateStopAfterQueue(ctx context.Context, client tern.Cl
 			"apply_id", apply.ApplyIdentifier,
 			"tern_apply_id", ternApplyID,
 			"database", apply.Database,
+			"deployment", apply.Deployment,
 			"environment", apply.Environment,
 			"requested_by", caller,
 			"stopped_count", resp.StoppedCount,
@@ -446,6 +455,7 @@ func (s *Service) tryImmediateStopAfterQueue(ctx context.Context, client tern.Cl
 		"apply_id", apply.ApplyIdentifier,
 		"tern_apply_id", ternApplyID,
 		"database", apply.Database,
+		"deployment", apply.Deployment,
 		"environment", apply.Environment,
 		"requested_by", caller,
 		"stopped_count", resp.StoppedCount,
@@ -746,6 +756,7 @@ func (s *Service) queueStoppedApplyForScheduler(ctx context.Context, apply *stor
 		s.logger.Info("queueing start for stopped tasks while stored apply is still running",
 			"apply_id", apply.ApplyIdentifier,
 			"database", apply.Database,
+			"deployment", apply.Deployment,
 			"environment", apply.Environment,
 			"stopped_count", startedCount,
 			"terminal_count", skippedCount)
@@ -787,6 +798,7 @@ func (s *Service) queueRemoteStoppedApplyForScheduler(ctx context.Context, clien
 			"apply_id", apply.ApplyIdentifier,
 			"external_id", apply.ExternalID,
 			"database", apply.Database,
+			"deployment", apply.Deployment,
 			"environment", apply.Environment,
 			"remote_state", remoteState,
 			"stopped_count", startedCount,

--- a/pkg/api/control_handlers.go
+++ b/pkg/api/control_handlers.go
@@ -254,7 +254,7 @@ func (s *Service) handleCutover(w http.ResponseWriter, r *http.Request) {
 		if controlOperationHTTPStatus(err) < http.StatusInternalServerError {
 			status = "rejected"
 		}
-		metrics.RecordControlOperation(r.Context(), "cutover", apply.Database, apply.Environment, status)
+		metrics.RecordControlOperation(r.Context(), "cutover", apply.Database, apply.Deployment, apply.Environment, status)
 		s.writeControlError(w, "cutover", apply, err)
 		return
 	}
@@ -263,7 +263,7 @@ func (s *Service) handleCutover(w http.ResponseWriter, r *http.Request) {
 		if controlOperationHTTPStatus(err) < http.StatusInternalServerError {
 			status = "rejected"
 		}
-		metrics.RecordControlOperation(r.Context(), "cutover", apply.Database, apply.Environment, status)
+		metrics.RecordControlOperation(r.Context(), "cutover", apply.Database, apply.Deployment, apply.Environment, status)
 		s.writeControlError(w, "cutover", apply, err)
 		return
 	}
@@ -273,11 +273,11 @@ func (s *Service) handleCutover(w http.ResponseWriter, r *http.Request) {
 		Environment: apply.Environment,
 	})
 	if err != nil {
-		metrics.RecordControlOperation(r.Context(), "cutover", apply.Database, apply.Environment, "error")
+		metrics.RecordControlOperation(r.Context(), "cutover", apply.Database, apply.Deployment, apply.Environment, "error")
 		s.writeControlError(w, "cutover", apply, err)
 		return
 	}
-	metrics.RecordControlOperation(r.Context(), "cutover", apply.Database, apply.Environment, controlStatus(resp.Accepted))
+	metrics.RecordControlOperation(r.Context(), "cutover", apply.Database, apply.Deployment, apply.Environment, controlStatus(resp.Accepted))
 	if resp.Accepted {
 		s.logControlOperation(r, apply.ApplyIdentifier, req.Caller, storage.LogEventCutoverTriggered, "Cutover triggered by user")
 	}
@@ -317,11 +317,11 @@ func (s *Service) handleStop(w http.ResponseWriter, r *http.Request) {
 		if controlOperationHTTPStatus(err) < http.StatusInternalServerError {
 			status = "rejected"
 		}
-		metrics.RecordControlOperation(r.Context(), "stop", apply.Database, apply.Environment, status)
+		metrics.RecordControlOperation(r.Context(), "stop", apply.Database, apply.Deployment, apply.Environment, status)
 		s.writeControlError(w, "stop", apply, err)
 		return
 	}
-	metrics.RecordControlOperation(r.Context(), "stop", apply.Database, apply.Environment, controlStatus(resp.Accepted))
+	metrics.RecordControlOperation(r.Context(), "stop", apply.Database, apply.Deployment, apply.Environment, controlStatus(resp.Accepted))
 	if resp.Accepted {
 		logMessage := "Stop requested by user"
 		if responseStatus == stopResponseStatusAlreadyRequested {
@@ -628,7 +628,7 @@ func (s *Service) handleStart(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := validateStartRequestState(apply); err != nil {
-		metrics.RecordControlOperation(r.Context(), "start", apply.Database, apply.Environment, "rejected")
+		metrics.RecordControlOperation(r.Context(), "start", apply.Database, apply.Deployment, apply.Environment, "rejected")
 		s.writeControlError(w, "start", apply, err)
 		return
 	}
@@ -637,7 +637,7 @@ func (s *Service) handleStart(w http.ResponseWriter, r *http.Request) {
 		if controlOperationHTTPStatus(err) < http.StatusInternalServerError {
 			status = "rejected"
 		}
-		metrics.RecordControlOperation(r.Context(), "start", apply.Database, apply.Environment, status)
+		metrics.RecordControlOperation(r.Context(), "start", apply.Database, apply.Deployment, apply.Environment, status)
 		s.writeControlError(w, "start", apply, err)
 		return
 	}
@@ -653,7 +653,7 @@ func (s *Service) handleStart(w http.ResponseWriter, r *http.Request) {
 			if controlOperationHTTPStatus(err) < http.StatusInternalServerError {
 				status = "rejected"
 			}
-			metrics.RecordControlOperation(r.Context(), "start", apply.Database, apply.Environment, status)
+			metrics.RecordControlOperation(r.Context(), "start", apply.Database, apply.Deployment, apply.Environment, status)
 			s.writeControlError(w, "start", apply, err)
 			return
 		}
@@ -686,12 +686,12 @@ func (s *Service) handleStart(w http.ResponseWriter, r *http.Request) {
 		if controlOperationHTTPStatus(err) < http.StatusInternalServerError {
 			status = "rejected"
 		}
-		metrics.RecordControlOperation(r.Context(), "start", apply.Database, apply.Environment, status)
+		metrics.RecordControlOperation(r.Context(), "start", apply.Database, apply.Deployment, apply.Environment, status)
 		s.writeControlError(w, "start", apply, err)
 		return
 	}
 
-	metrics.RecordControlOperation(r.Context(), "start", apply.Database, apply.Environment, controlStatus(resp.Accepted))
+	metrics.RecordControlOperation(r.Context(), "start", apply.Database, apply.Deployment, apply.Environment, controlStatus(resp.Accepted))
 	if resp.Accepted {
 		s.logControlOperation(r, apply.ApplyIdentifier, req.Caller, storage.LogEventStartRequested, "Start requested by user")
 		if queuedForScheduler {
@@ -1030,11 +1030,11 @@ func (s *Service) handleVolume(w http.ResponseWriter, r *http.Request) {
 		Volume:      req.Volume,
 	})
 	if err != nil {
-		metrics.RecordControlOperation(r.Context(), "volume", apply.Database, apply.Environment, "error")
+		metrics.RecordControlOperation(r.Context(), "volume", apply.Database, apply.Deployment, apply.Environment, "error")
 		s.writeControlError(w, "volume", apply, err)
 		return
 	}
-	metrics.RecordControlOperation(r.Context(), "volume", apply.Database, apply.Environment, controlStatus(resp.Accepted))
+	metrics.RecordControlOperation(r.Context(), "volume", apply.Database, apply.Deployment, apply.Environment, controlStatus(resp.Accepted))
 
 	s.writeJSON(w, http.StatusOK, &apitypes.VolumeResponse{
 		Accepted:       resp.Accepted,
@@ -1064,11 +1064,11 @@ func (s *Service) handleRevert(w http.ResponseWriter, r *http.Request) {
 		Environment: apply.Environment,
 	})
 	if err != nil {
-		metrics.RecordControlOperation(r.Context(), "revert", apply.Database, apply.Environment, "error")
+		metrics.RecordControlOperation(r.Context(), "revert", apply.Database, apply.Deployment, apply.Environment, "error")
 		s.writeControlError(w, "revert", apply, err)
 		return
 	}
-	metrics.RecordControlOperation(r.Context(), "revert", apply.Database, apply.Environment, controlStatus(resp.Accepted))
+	metrics.RecordControlOperation(r.Context(), "revert", apply.Database, apply.Deployment, apply.Environment, controlStatus(resp.Accepted))
 	if resp.Accepted {
 		s.logControlOperation(r, apply.ApplyIdentifier, req.Caller, storage.LogEventRevertTriggered, "Revert triggered by user")
 	}
@@ -1099,11 +1099,11 @@ func (s *Service) handleSkipRevert(w http.ResponseWriter, r *http.Request) {
 		Environment: apply.Environment,
 	})
 	if err != nil {
-		metrics.RecordControlOperation(r.Context(), "skip_revert", apply.Database, apply.Environment, "error")
+		metrics.RecordControlOperation(r.Context(), "skip_revert", apply.Database, apply.Deployment, apply.Environment, "error")
 		s.writeControlError(w, "skip-revert", apply, err)
 		return
 	}
-	metrics.RecordControlOperation(r.Context(), "skip_revert", apply.Database, apply.Environment, controlStatus(resp.Accepted))
+	metrics.RecordControlOperation(r.Context(), "skip_revert", apply.Database, apply.Deployment, apply.Environment, controlStatus(resp.Accepted))
 
 	// Record skip-revert on VitessApplyData for progress visibility
 	if resp.Accepted && apply.Engine == storage.EnginePlanetScale {
@@ -1170,11 +1170,11 @@ func (s *Service) handleRollbackPlan(w http.ResponseWriter, r *http.Request) {
 
 	resp, err := s.ExecuteRollbackPlan(r.Context(), apply.Database, apply.Environment, apply.Deployment)
 	if err != nil {
-		metrics.RecordControlOperation(r.Context(), "rollback_plan", apply.Database, apply.Environment, "error")
+		metrics.RecordControlOperation(r.Context(), "rollback_plan", apply.Database, apply.Deployment, apply.Environment, "error")
 		s.writeControlError(w, "rollback plan", apply, err)
 		return
 	}
-	metrics.RecordControlOperation(r.Context(), "rollback_plan", apply.Database, apply.Environment, "success")
+	metrics.RecordControlOperation(r.Context(), "rollback_plan", apply.Database, apply.Deployment, apply.Environment, "success")
 
 	// Include database metadata so the caller doesn't need to look it up separately
 	resp.Database = apply.Database

--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -760,7 +760,7 @@ func TestExecutePlanUnavailableRemoteErrorIncludesDeployment(t *testing.T) {
 		Repository: "example/app",
 	})
 
-	var remoteErr *RemoteSchemaServiceUnavailableError
+	var remoteErr *RemoteDeploymentUnavailableError
 	require.ErrorAs(t, err, &remoteErr)
 	assert.Equal(t, "pie", remoteErr.Deployment)
 	assert.Equal(t, "orders-staging", remoteErr.Target)

--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -16,6 +16,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/block/schemabot/pkg/apitypes"
 	ternv1 "github.com/block/schemabot/pkg/proto/ternv1"
@@ -722,6 +724,47 @@ func TestExecutePlanSourcePolicy(t *testing.T) {
 		require.NotNil(t, plans.created)
 		assert.Equal(t, "schema/payments", plans.created.SchemaPath)
 	})
+}
+
+func TestExecutePlanUnavailableRemoteErrorIncludesDeployment(t *testing.T) {
+	plans := &capturingPlanStore{}
+	mockClient := &mockTernClient{
+		planErr:  status.Error(codes.Unavailable, "no healthy upstream"),
+		isRemote: true,
+	}
+	cfg := &ServerConfig{
+		Databases: map[string]DatabaseConfig{
+			"orders": {
+				Type: storage.DatabaseTypeMySQL,
+				Environments: map[string]EnvironmentConfig{
+					"staging": {Target: "orders-staging", Deployment: "pie"},
+				},
+			},
+		},
+		TernDeployments: TernConfig{
+			"pie": {"staging": "tern.example.com:80"},
+		},
+	}
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	svc := New(&mockStorageWithPlanLookup{plans: plans}, cfg, map[string]tern.Client{
+		"pie/staging": mockClient,
+	}, logger)
+
+	_, err := svc.ExecutePlan(t.Context(), PlanRequest{
+		Database:    "orders",
+		Environment: "staging",
+		Type:        storage.DatabaseTypeMySQL,
+		SchemaFiles: map[string]*ternv1.SchemaFiles{
+			"orders": {Files: map[string]string{"users.sql": "CREATE TABLE users (id bigint primary key)"}},
+		},
+		Repository: "example/app",
+	})
+
+	var remoteErr *RemoteSchemaServiceUnavailableError
+	require.ErrorAs(t, err, &remoteErr)
+	assert.Equal(t, "pie", remoteErr.Deployment)
+	assert.Equal(t, "orders-staging", remoteErr.Target)
+	assert.Equal(t, codes.Unavailable, status.Code(err))
 }
 
 func TestExecuteApplySourcePolicyAllowsDirectPlan(t *testing.T) {

--- a/pkg/api/plan_handlers.go
+++ b/pkg/api/plan_handlers.go
@@ -13,8 +13,10 @@ import (
 	"github.com/google/uuid"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/codes"
+	otelcodes "go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
 
 	"github.com/block/schemabot/pkg/apitypes"
 	"github.com/block/schemabot/pkg/metrics"
@@ -42,6 +44,26 @@ type PlanRequest struct {
 	// discovered the PR source itself. It is deliberately not JSON-decodable:
 	// direct API clients cannot attest repo/path ownership.
 	SourceTrusted bool `json:"-"`
+}
+
+// RemoteSchemaServiceUnavailableError carries routing metadata for remote
+// schema change service availability failures so callers can render actionable
+// operator-facing errors without parsing strings.
+type RemoteSchemaServiceUnavailableError struct {
+	Deployment string
+	Target     string
+	Err        error
+}
+
+func (e *RemoteSchemaServiceUnavailableError) Error() string {
+	if e.Target == "" {
+		return fmt.Sprintf("remote deployment %q unavailable: %v", e.Deployment, e.Err)
+	}
+	return fmt.Sprintf("remote deployment %q target %q unavailable: %v", e.Deployment, e.Target, e.Err)
+}
+
+func (e *RemoteSchemaServiceUnavailableError) Unwrap() error {
+	return e.Err
 }
 
 // ApplyRequest is the HTTP request body for POST /api/apply.
@@ -112,7 +134,7 @@ func (s *Service) ExecutePlan(ctx context.Context, req PlanRequest) (*apitypes.P
 
 	if warning, err := validateSchemaFiles(req.SchemaFiles); err != nil {
 		span.RecordError(err)
-		span.SetStatus(codes.Error, "invalid schema files")
+		span.SetStatus(otelcodes.Error, "invalid schema files")
 		return nil, err
 	} else if warning != "" {
 		s.logger.Warn("plan request has empty schema files", "warning", warning, "database", req.Database)
@@ -123,7 +145,7 @@ func (s *Service) ExecutePlan(ctx context.Context, req PlanRequest) (*apitypes.P
 	resolvedTarget, err := s.config.ResolveDatabaseTarget(req.Database, req.Environment)
 	if err != nil {
 		span.RecordError(err)
-		span.SetStatus(codes.Error, "resolve target")
+		span.SetStatus(otelcodes.Error, "resolve target")
 		metrics.RecordPlan(ctx, req.Repository, req.Database, req.Environment, "error")
 		metrics.RecordPlanDuration(ctx, time.Since(planStart), req.Repository, req.Database, req.Environment, "error")
 		return nil, fmt.Errorf("resolve target for %s/%s: %w", req.Database, req.Environment, err)
@@ -131,7 +153,7 @@ func (s *Service) ExecutePlan(ctx context.Context, req PlanRequest) (*apitypes.P
 	if req.Type != resolvedTarget.DatabaseType {
 		typeErr := fmt.Errorf("database %q type %q does not match server config type %q", req.Database, req.Type, resolvedTarget.DatabaseType)
 		span.RecordError(typeErr)
-		span.SetStatus(codes.Error, "type mismatch")
+		span.SetStatus(otelcodes.Error, "type mismatch")
 		metrics.RecordPlan(ctx, req.Repository, req.Database, req.Environment, "error")
 		metrics.RecordPlanDuration(ctx, time.Since(planStart), req.Repository, req.Database, req.Environment, "error")
 		return nil, typeErr
@@ -164,7 +186,7 @@ func (s *Service) ExecutePlan(ctx context.Context, req PlanRequest) (*apitypes.P
 		}); err != nil {
 			reason := sourcePolicyReason(err)
 			span.RecordError(err)
-			span.SetStatus(codes.Error, "source policy")
+			span.SetStatus(otelcodes.Error, "source policy")
 			metrics.RecordPlan(ctx, req.Repository, req.Database, req.Environment, "error")
 			metrics.RecordPlanDuration(ctx, time.Since(planStart), req.Repository, req.Database, req.Environment, "error")
 			metrics.RecordSourcePolicyBlock(ctx, "plan", req.Database, req.Environment, reason)
@@ -183,7 +205,7 @@ func (s *Service) ExecutePlan(ctx context.Context, req PlanRequest) (*apitypes.P
 	client, err := s.TernClient(deployment, req.Environment)
 	if err != nil {
 		span.RecordError(err)
-		span.SetStatus(codes.Error, "tern client")
+		span.SetStatus(otelcodes.Error, "tern client")
 		metrics.RecordPlan(ctx, req.Repository, req.Database, req.Environment, "error")
 		metrics.RecordPlanDuration(ctx, time.Since(planStart), req.Repository, req.Database, req.Environment, "error")
 		return nil, fmt.Errorf("database %q (%s): %w", req.Database, req.Environment, err)
@@ -217,9 +239,16 @@ func (s *Service) ExecutePlan(ctx context.Context, req PlanRequest) (*apitypes.P
 	resp, err := client.Plan(ctx, ternReq)
 	if err != nil {
 		span.RecordError(err)
-		span.SetStatus(codes.Error, "plan failed")
+		span.SetStatus(otelcodes.Error, "plan failed")
 		metrics.RecordPlan(ctx, req.Repository, req.Database, req.Environment, "error")
 		metrics.RecordPlanDuration(ctx, time.Since(planStart), req.Repository, req.Database, req.Environment, "error")
+		if client.IsRemote() && grpcstatus.Code(err) == grpccodes.Unavailable {
+			return nil, &RemoteSchemaServiceUnavailableError{
+				Deployment: deployment,
+				Target:     resolvedTarget.Target,
+				Err:        err,
+			}
+		}
 		return nil, err
 	}
 	span.SetAttributes(attribute.String("plan_id", resp.PlanId), attribute.Int("change_count", len(resp.Changes)))
@@ -337,34 +366,34 @@ func (s *Service) ExecuteApply(ctx context.Context, req ApplyRequest) (*apitypes
 	plan, err := s.storage.Plans().Get(ctx, req.PlanID)
 	if err != nil {
 		span.RecordError(err)
-		span.SetStatus(codes.Error, "get plan")
+		span.SetStatus(otelcodes.Error, "get plan")
 		return nil, 0, fmt.Errorf("get plan: %w", err)
 	}
 	if plan == nil {
 		planErr := fmt.Errorf("plan not found: %s", req.PlanID)
 		span.RecordError(planErr)
-		span.SetStatus(codes.Error, "plan not found")
+		span.SetStatus(otelcodes.Error, "plan not found")
 		return nil, 0, planErr
 	}
 	span.SetAttributes(attribute.String("database", plan.Database))
 	if plan.Environment != req.Environment {
 		applyErr := fmt.Errorf("plan %s was created for environment %q, not %q", req.PlanID, plan.Environment, req.Environment)
 		span.RecordError(applyErr)
-		span.SetStatus(codes.Error, "environment mismatch")
+		span.SetStatus(otelcodes.Error, "environment mismatch")
 		metrics.RecordApply(ctx, plan.Repository, plan.Database, req.Environment, "error")
 		return nil, 0, applyErr
 	}
 	if plan.Deployment == "" {
 		applyErr := fmt.Errorf("plan %s is missing server-side routing metadata field %q; create a new plan and retry apply", req.PlanID, "deployment")
 		span.RecordError(applyErr)
-		span.SetStatus(codes.Error, "missing stored deployment")
+		span.SetStatus(otelcodes.Error, "missing stored deployment")
 		metrics.RecordApply(ctx, plan.Repository, plan.Database, req.Environment, "error")
 		return nil, 0, applyErr
 	}
 	if plan.Target == "" {
 		applyErr := fmt.Errorf("plan %s is missing server-side routing metadata field %q; create a new plan and retry apply", req.PlanID, "target")
 		span.RecordError(applyErr)
-		span.SetStatus(codes.Error, "missing stored target")
+		span.SetStatus(otelcodes.Error, "missing stored target")
 		metrics.RecordApply(ctx, plan.Repository, plan.Database, req.Environment, "error")
 		return nil, 0, applyErr
 	}
@@ -388,7 +417,7 @@ func (s *Service) ExecuteApply(ctx context.Context, req ApplyRequest) (*apitypes
 		}); err != nil {
 			reason := sourcePolicyReason(err)
 			span.RecordError(err)
-			span.SetStatus(codes.Error, "source policy")
+			span.SetStatus(otelcodes.Error, "source policy")
 			metrics.RecordApply(ctx, plan.Repository, plan.Database, req.Environment, "error")
 			metrics.RecordSourcePolicyBlock(ctx, "apply", plan.Database, req.Environment, reason)
 			s.logger.Warn("apply blocked by source policy",
@@ -409,7 +438,7 @@ func (s *Service) ExecuteApply(ctx context.Context, req ApplyRequest) (*apitypes
 	client, err := s.TernClient(deployment, req.Environment)
 	if err != nil {
 		span.RecordError(err)
-		span.SetStatus(codes.Error, "tern client")
+		span.SetStatus(otelcodes.Error, "tern client")
 		metrics.RecordApply(ctx, plan.Repository, plan.Database, req.Environment, "error")
 		return nil, 0, fmt.Errorf("database %q (%s): %w", plan.Database, req.Environment, err)
 	}
@@ -427,7 +456,7 @@ func (s *Service) ExecuteApply(ctx context.Context, req ApplyRequest) (*apitypes
 	}
 	recordApplyError := func(status string, err error) {
 		span.RecordError(err)
-		span.SetStatus(codes.Error, status)
+		span.SetStatus(otelcodes.Error, status)
 		recordApplyResult(applyMetricStatusForError(err))
 	}
 

--- a/pkg/api/plan_handlers.go
+++ b/pkg/api/plan_handlers.go
@@ -418,6 +418,7 @@ func (s *Service) ExecuteApply(ctx context.Context, req ApplyRequest) (*apitypes
 		s.logger.Debug("skipping source policy for apply because stored plan has no trusted schema path",
 			"plan_id", req.PlanID,
 			"database", plan.Database,
+			"deployment", plan.Deployment,
 			"environment", req.Environment,
 			"repository", plan.Repository,
 			"pull_request", plan.PullRequest)
@@ -436,6 +437,7 @@ func (s *Service) ExecuteApply(ctx context.Context, req ApplyRequest) (*apitypes
 			s.logger.Warn("apply blocked by source policy",
 				"plan_id", req.PlanID,
 				"database", plan.Database,
+				"deployment", plan.Deployment,
 				"environment", req.Environment,
 				"repository", plan.Repository,
 				"pull_request", plan.PullRequest,

--- a/pkg/api/plan_handlers.go
+++ b/pkg/api/plan_handlers.go
@@ -46,23 +46,23 @@ type PlanRequest struct {
 	SourceTrusted bool `json:"-"`
 }
 
-// RemoteSchemaServiceUnavailableError carries routing metadata for remote
+// RemoteDeploymentUnavailableError carries routing metadata for remote
 // schema change service availability failures so callers can render actionable
 // operator-facing errors without parsing strings.
-type RemoteSchemaServiceUnavailableError struct {
+type RemoteDeploymentUnavailableError struct {
 	Deployment string
 	Target     string
 	Err        error
 }
 
-func (e *RemoteSchemaServiceUnavailableError) Error() string {
+func (e *RemoteDeploymentUnavailableError) Error() string {
 	if e.Target == "" {
 		return fmt.Sprintf("remote deployment %q unavailable: %v", e.Deployment, e.Err)
 	}
 	return fmt.Sprintf("remote deployment %q target %q unavailable: %v", e.Deployment, e.Target, e.Err)
 }
 
-func (e *RemoteSchemaServiceUnavailableError) Unwrap() error {
+func (e *RemoteDeploymentUnavailableError) Unwrap() error {
 	return e.Err
 }
 
@@ -244,7 +244,7 @@ func (s *Service) ExecutePlan(ctx context.Context, req PlanRequest) (*apitypes.P
 		metrics.RecordPlan(ctx, req.Repository, req.Database, deployment, req.Environment, "error")
 		metrics.RecordPlanDuration(ctx, time.Since(planStart), req.Repository, req.Database, deployment, req.Environment, "error")
 		if client.IsRemote() && grpcstatus.Code(err) == grpccodes.Unavailable {
-			return nil, &RemoteSchemaServiceUnavailableError{
+			return nil, &RemoteDeploymentUnavailableError{
 				Deployment: deployment,
 				Target:     resolvedTarget.Target,
 				Err:        err,

--- a/pkg/api/plan_handlers.go
+++ b/pkg/api/plan_handlers.go
@@ -393,21 +393,21 @@ func (s *Service) ExecuteApply(ctx context.Context, req ApplyRequest) (*apitypes
 		applyErr := fmt.Errorf("plan %s was created for environment %q, not %q", req.PlanID, plan.Environment, req.Environment)
 		span.RecordError(applyErr)
 		span.SetStatus(otelcodes.Error, "environment mismatch")
-		metrics.RecordApply(ctx, plan.Repository, plan.Database, req.Environment, "error")
+		metrics.RecordApply(ctx, plan.Repository, plan.Database, plan.Deployment, req.Environment, "error")
 		return nil, 0, applyErr
 	}
 	if plan.Deployment == "" {
 		applyErr := fmt.Errorf("plan %s is missing server-side routing metadata field %q; create a new plan and retry apply", req.PlanID, "deployment")
 		span.RecordError(applyErr)
 		span.SetStatus(otelcodes.Error, "missing stored deployment")
-		metrics.RecordApply(ctx, plan.Repository, plan.Database, req.Environment, "error")
+		metrics.RecordApply(ctx, plan.Repository, plan.Database, plan.Deployment, req.Environment, "error")
 		return nil, 0, applyErr
 	}
 	if plan.Target == "" {
 		applyErr := fmt.Errorf("plan %s is missing server-side routing metadata field %q; create a new plan and retry apply", req.PlanID, "target")
 		span.RecordError(applyErr)
 		span.SetStatus(otelcodes.Error, "missing stored target")
-		metrics.RecordApply(ctx, plan.Repository, plan.Database, req.Environment, "error")
+		metrics.RecordApply(ctx, plan.Repository, plan.Database, plan.Deployment, req.Environment, "error")
 		return nil, 0, applyErr
 	}
 	// Source policy is evaluated for plans created from SchemaBot's trusted
@@ -431,7 +431,7 @@ func (s *Service) ExecuteApply(ctx context.Context, req ApplyRequest) (*apitypes
 			reason := sourcePolicyReason(err)
 			span.RecordError(err)
 			span.SetStatus(otelcodes.Error, "source policy")
-			metrics.RecordApply(ctx, plan.Repository, plan.Database, req.Environment, "error")
+			metrics.RecordApply(ctx, plan.Repository, plan.Database, plan.Deployment, req.Environment, "error")
 			metrics.RecordSourcePolicyBlock(ctx, "apply", plan.Database, req.Environment, reason)
 			s.logger.Warn("apply blocked by source policy",
 				"plan_id", req.PlanID,
@@ -452,7 +452,7 @@ func (s *Service) ExecuteApply(ctx context.Context, req ApplyRequest) (*apitypes
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(otelcodes.Error, "tern client")
-		metrics.RecordApply(ctx, plan.Repository, plan.Database, req.Environment, "error")
+		metrics.RecordApply(ctx, plan.Repository, plan.Database, plan.Deployment, req.Environment, "error")
 		return nil, 0, fmt.Errorf("database %q (%s): %w", plan.Database, req.Environment, err)
 	}
 
@@ -464,8 +464,8 @@ func (s *Service) ExecuteApply(ctx context.Context, req ApplyRequest) (*apitypes
 
 	enqueueStart := time.Now()
 	recordApplyResult := func(status string) {
-		metrics.RecordApply(ctx, plan.Repository, plan.Database, req.Environment, status)
-		metrics.RecordApplyDuration(ctx, time.Since(enqueueStart), plan.Repository, plan.Database, req.Environment, status)
+		metrics.RecordApply(ctx, plan.Repository, plan.Database, plan.Deployment, req.Environment, status)
+		metrics.RecordApplyDuration(ctx, time.Since(enqueueStart), plan.Repository, plan.Database, plan.Deployment, req.Environment, status)
 	}
 	recordApplyError := func(status string, err error) {
 		span.RecordError(err)
@@ -498,7 +498,7 @@ func (s *Service) ExecuteApply(ctx context.Context, req ApplyRequest) (*apitypes
 
 	span.SetAttributes(attribute.String("apply_id", applyIdentifier), attribute.Bool("accepted", true))
 	recordApplyResult("success")
-	metrics.AdjustActiveApplies(ctx, 1, plan.Database, req.Environment)
+	metrics.AdjustActiveApplies(ctx, 1, plan.Database, plan.Deployment, req.Environment)
 	s.wakeScheduler(applyIdentifier, plan.Database, req.Environment)
 
 	return &apitypes.ApplyResponse{

--- a/pkg/api/plan_handlers.go
+++ b/pkg/api/plan_handlers.go
@@ -141,24 +141,25 @@ func (s *Service) ExecutePlan(ctx context.Context, req PlanRequest) (*apitypes.P
 	}
 
 	planStart := time.Now()
+	deployment := ""
 
 	resolvedTarget, err := s.config.ResolveDatabaseTarget(req.Database, req.Environment)
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(otelcodes.Error, "resolve target")
-		metrics.RecordPlan(ctx, req.Repository, req.Database, req.Environment, "error")
-		metrics.RecordPlanDuration(ctx, time.Since(planStart), req.Repository, req.Database, req.Environment, "error")
+		metrics.RecordPlan(ctx, req.Repository, req.Database, deployment, req.Environment, "error")
+		metrics.RecordPlanDuration(ctx, time.Since(planStart), req.Repository, req.Database, deployment, req.Environment, "error")
 		return nil, fmt.Errorf("resolve target for %s/%s: %w", req.Database, req.Environment, err)
 	}
+	deployment = resolvedTarget.Deployment
 	if req.Type != resolvedTarget.DatabaseType {
 		typeErr := fmt.Errorf("database %q type %q does not match server config type %q", req.Database, req.Type, resolvedTarget.DatabaseType)
 		span.RecordError(typeErr)
 		span.SetStatus(otelcodes.Error, "type mismatch")
-		metrics.RecordPlan(ctx, req.Repository, req.Database, req.Environment, "error")
-		metrics.RecordPlanDuration(ctx, time.Since(planStart), req.Repository, req.Database, req.Environment, "error")
+		metrics.RecordPlan(ctx, req.Repository, req.Database, deployment, req.Environment, "error")
+		metrics.RecordPlanDuration(ctx, time.Since(planStart), req.Repository, req.Database, deployment, req.Environment, "error")
 		return nil, typeErr
 	}
-	deployment := resolvedTarget.Deployment
 
 	prInt := 0
 	if req.PullRequest != nil {
@@ -187,8 +188,8 @@ func (s *Service) ExecutePlan(ctx context.Context, req PlanRequest) (*apitypes.P
 			reason := sourcePolicyReason(err)
 			span.RecordError(err)
 			span.SetStatus(otelcodes.Error, "source policy")
-			metrics.RecordPlan(ctx, req.Repository, req.Database, req.Environment, "error")
-			metrics.RecordPlanDuration(ctx, time.Since(planStart), req.Repository, req.Database, req.Environment, "error")
+			metrics.RecordPlan(ctx, req.Repository, req.Database, deployment, req.Environment, "error")
+			metrics.RecordPlanDuration(ctx, time.Since(planStart), req.Repository, req.Database, deployment, req.Environment, "error")
 			metrics.RecordSourcePolicyBlock(ctx, "plan", req.Database, req.Environment, reason)
 			s.logger.Warn("plan blocked by source policy",
 				"database", req.Database,
@@ -206,8 +207,8 @@ func (s *Service) ExecutePlan(ctx context.Context, req PlanRequest) (*apitypes.P
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(otelcodes.Error, "tern client")
-		metrics.RecordPlan(ctx, req.Repository, req.Database, req.Environment, "error")
-		metrics.RecordPlanDuration(ctx, time.Since(planStart), req.Repository, req.Database, req.Environment, "error")
+		metrics.RecordPlan(ctx, req.Repository, req.Database, deployment, req.Environment, "error")
+		metrics.RecordPlanDuration(ctx, time.Since(planStart), req.Repository, req.Database, deployment, req.Environment, "error")
 		return nil, fmt.Errorf("database %q (%s): %w", req.Database, req.Environment, err)
 	}
 
@@ -240,8 +241,8 @@ func (s *Service) ExecutePlan(ctx context.Context, req PlanRequest) (*apitypes.P
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(otelcodes.Error, "plan failed")
-		metrics.RecordPlan(ctx, req.Repository, req.Database, req.Environment, "error")
-		metrics.RecordPlanDuration(ctx, time.Since(planStart), req.Repository, req.Database, req.Environment, "error")
+		metrics.RecordPlan(ctx, req.Repository, req.Database, deployment, req.Environment, "error")
+		metrics.RecordPlanDuration(ctx, time.Since(planStart), req.Repository, req.Database, deployment, req.Environment, "error")
 		if client.IsRemote() && grpcstatus.Code(err) == grpccodes.Unavailable {
 			return nil, &RemoteSchemaServiceUnavailableError{
 				Deployment: deployment,
@@ -252,8 +253,8 @@ func (s *Service) ExecutePlan(ctx context.Context, req PlanRequest) (*apitypes.P
 		return nil, err
 	}
 	span.SetAttributes(attribute.String("plan_id", resp.PlanId), attribute.Int("change_count", len(resp.Changes)))
-	metrics.RecordPlan(ctx, req.Repository, req.Database, req.Environment, "success")
-	metrics.RecordPlanDuration(ctx, time.Since(planStart), req.Repository, req.Database, req.Environment, "success")
+	metrics.RecordPlan(ctx, req.Repository, req.Database, deployment, req.Environment, "success")
+	metrics.RecordPlanDuration(ctx, time.Since(planStart), req.Repository, req.Database, deployment, req.Environment, "success")
 
 	s.logger.Info("ExecutePlan: plan response",
 		"plan_id", resp.PlanId,

--- a/pkg/api/plan_handlers.go
+++ b/pkg/api/plan_handlers.go
@@ -243,6 +243,18 @@ func (s *Service) ExecutePlan(ctx context.Context, req PlanRequest) (*apitypes.P
 		span.SetStatus(otelcodes.Error, "plan failed")
 		metrics.RecordPlan(ctx, req.Repository, req.Database, deployment, req.Environment, "error")
 		metrics.RecordPlanDuration(ctx, time.Since(planStart), req.Repository, req.Database, deployment, req.Environment, "error")
+		s.logger.Error("ExecutePlan: client.Plan failed",
+			"database", req.Database,
+			"type", resolvedTarget.DatabaseType,
+			"deployment", deployment,
+			"target", resolvedTarget.Target,
+			"environment", req.Environment,
+			"repository", req.Repository,
+			"pull_request", prInt,
+			"endpoint", client.Endpoint(),
+			"is_remote", client.IsRemote(),
+			"error", err,
+		)
 		if client.IsRemote() && grpcstatus.Code(err) == grpccodes.Unavailable {
 			return nil, &RemoteDeploymentUnavailableError{
 				Deployment: deployment,

--- a/pkg/api/scheduler.go
+++ b/pkg/api/scheduler.go
@@ -161,7 +161,7 @@ func (s *Service) recoverApplies(ctx context.Context, workerID int) {
 			"environment", apply.Environment,
 			"attempt", apply.Attempt,
 			"reason", expiration.Reason)
-		metrics.RecordSchedulerResumeFailure(ctx, apply.Database, apply.Environment, string(expiration.Reason))
+		metrics.RecordSchedulerResumeFailure(ctx, apply.Database, apply.Deployment, apply.Environment, string(expiration.Reason))
 	}
 
 	apply, err := s.storage.Applies().FindNextApply(ctx)
@@ -195,7 +195,7 @@ func (s *Service) recoverApplies(ctx context.Context, workerID int) {
 			"database", apply.Database,
 			"environment", apply.Environment,
 			"error", err)
-		metrics.RecordSchedulerResumeFailure(ctx, apply.Database, apply.Environment, "missing_deployment")
+		metrics.RecordSchedulerResumeFailure(ctx, apply.Database, "", apply.Environment, "missing_deployment")
 		return
 	}
 	client, err := s.TernClient(deployment, apply.Environment)
@@ -206,7 +206,7 @@ func (s *Service) recoverApplies(ctx context.Context, workerID int) {
 			"database", apply.Database,
 			"environment", apply.Environment,
 			"error", err)
-		metrics.RecordSchedulerResumeFailure(ctx, apply.Database, apply.Environment, "no_client")
+		metrics.RecordSchedulerResumeFailure(ctx, apply.Database, deployment, apply.Environment, "no_client")
 		return
 	}
 
@@ -216,7 +216,7 @@ func (s *Service) recoverApplies(ctx context.Context, workerID int) {
 
 	retryableClaim := previousState == state.Apply.FailedRetryable
 	if retryableClaim {
-		metrics.AdjustActiveApplies(ctx, 1, apply.Database, apply.Environment)
+		metrics.AdjustActiveApplies(ctx, 1, apply.Database, deployment, apply.Environment)
 	}
 	if err := client.ResumeApply(ctx, apply); err != nil {
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) || ctx.Err() != nil {
@@ -227,7 +227,7 @@ func (s *Service) recoverApplies(ctx context.Context, workerID int) {
 				"environment", apply.Environment,
 				"error", err)
 			if retryableClaim {
-				metrics.AdjustActiveApplies(ctx, -1, apply.Database, apply.Environment)
+				metrics.AdjustActiveApplies(ctx, -1, apply.Database, deployment, apply.Environment)
 			}
 			return
 		}
@@ -236,9 +236,9 @@ func (s *Service) recoverApplies(ctx context.Context, workerID int) {
 			"apply_id", apply.ApplyIdentifier,
 			"database", apply.Database,
 			"error", err)
-		metrics.RecordSchedulerResumeFailure(ctx, apply.Database, apply.Environment, "resume_error")
+		metrics.RecordSchedulerResumeFailure(ctx, apply.Database, deployment, apply.Environment, "resume_error")
 		if retryableClaim {
-			metrics.AdjustActiveApplies(ctx, -1, apply.Database, apply.Environment)
+			metrics.AdjustActiveApplies(ctx, -1, apply.Database, deployment, apply.Environment)
 		}
 		return
 	}
@@ -251,6 +251,6 @@ func (s *Service) recoverApplies(ctx context.Context, workerID int) {
 		"environment", apply.Environment,
 		"previous_state", previousState,
 		"duration", duration)
-	metrics.RecordSchedulerResume(ctx, apply.Database, apply.Environment, previousState)
-	metrics.RecordSchedulerClaimDuration(ctx, duration, apply.Database, apply.Environment, previousState)
+	metrics.RecordSchedulerResume(ctx, apply.Database, deployment, apply.Environment, previousState)
+	metrics.RecordSchedulerClaimDuration(ctx, duration, apply.Database, deployment, apply.Environment, previousState)
 }

--- a/pkg/api/scheduler.go
+++ b/pkg/api/scheduler.go
@@ -181,6 +181,7 @@ func (s *Service) recoverApplies(ctx context.Context, workerID int) {
 		"worker", workerID,
 		"apply_id", apply.ApplyIdentifier,
 		"database", apply.Database,
+		"deployment", apply.Deployment,
 		"environment", apply.Environment,
 		"state", apply.State,
 		"last_heartbeat", apply.UpdatedAt)
@@ -204,6 +205,7 @@ func (s *Service) recoverApplies(ctx context.Context, workerID int) {
 			"worker", workerID,
 			"apply_id", apply.ApplyIdentifier,
 			"database", apply.Database,
+			"deployment", deployment,
 			"environment", apply.Environment,
 			"error", err)
 		metrics.RecordSchedulerResumeFailure(ctx, apply.Database, deployment, apply.Environment, "no_client")
@@ -224,6 +226,7 @@ func (s *Service) recoverApplies(ctx context.Context, workerID int) {
 				"worker", workerID,
 				"apply_id", apply.ApplyIdentifier,
 				"database", apply.Database,
+				"deployment", deployment,
 				"environment", apply.Environment,
 				"error", err)
 			if retryableClaim {
@@ -235,6 +238,8 @@ func (s *Service) recoverApplies(ctx context.Context, workerID int) {
 			"worker", workerID,
 			"apply_id", apply.ApplyIdentifier,
 			"database", apply.Database,
+			"deployment", deployment,
+			"environment", apply.Environment,
 			"error", err)
 		metrics.RecordSchedulerResumeFailure(ctx, apply.Database, deployment, apply.Environment, "resume_error")
 		if retryableClaim {
@@ -248,6 +253,7 @@ func (s *Service) recoverApplies(ctx context.Context, workerID int) {
 		"worker", workerID,
 		"apply_id", apply.ApplyIdentifier,
 		"database", apply.Database,
+		"deployment", deployment,
 		"environment", apply.Environment,
 		"previous_state", previousState,
 		"duration", duration)

--- a/pkg/api/telemetry_test.go
+++ b/pkg/api/telemetry_test.go
@@ -58,7 +58,7 @@ func TestSetupTelemetryWithOTLP(t *testing.T) {
 	assert.NotNil(t, tel.tracerProvider, "tracerProvider should be set with OTLP endpoint")
 
 	// Record a metric so there's data to push.
-	metrics.RecordPlan(t.Context(), "testrepo", "testdb", "staging", "success")
+	metrics.RecordPlan(t.Context(), "testrepo", "testdb", "pie", "staging", "success")
 
 	// Create a trace span so there's trace data to push.
 	tracer := otel.Tracer("test")
@@ -110,10 +110,10 @@ func TestRecordPlanMetric(t *testing.T) {
 		require.NoError(t, mp.Shutdown(t.Context()))
 	})
 
-	metrics.RecordPlan(t.Context(), "testrepo", "testdb", "staging", "success")
-	metrics.RecordPlan(t.Context(), "testrepo", "testdb", "staging", "success")
-	metrics.RecordPlan(t.Context(), "testrepo", "testdb", "staging", "error")
-	metrics.RecordPlan(t.Context(), "testrepo", "other", "production", "success")
+	metrics.RecordPlan(t.Context(), "testrepo", "testdb", "pie", "staging", "success")
+	metrics.RecordPlan(t.Context(), "testrepo", "testdb", "pie", "staging", "success")
+	metrics.RecordPlan(t.Context(), "testrepo", "testdb", "pie", "staging", "error")
+	metrics.RecordPlan(t.Context(), "testrepo", "other", "bakery", "production", "success")
 
 	var rm metricdata.ResourceMetrics
 	require.NoError(t, reader.Collect(t.Context(), &rm))
@@ -141,15 +141,15 @@ func TestRecordPlanMetric(t *testing.T) {
 			DataPoints: []metricdata.DataPoint[int64]{
 				{
 					Value:      2,
-					Attributes: attribute.NewSet(attribute.String("repository", "testrepo"), attribute.String("database", "testdb"), attribute.String("environment", "staging"), attribute.String("status", "success")),
+					Attributes: attribute.NewSet(attribute.String("repository", "testrepo"), attribute.String("database", "testdb"), attribute.String("deployment", "pie"), attribute.String("environment", "staging"), attribute.String("status", "success")),
 				},
 				{
 					Value:      1,
-					Attributes: attribute.NewSet(attribute.String("repository", "testrepo"), attribute.String("database", "testdb"), attribute.String("environment", "staging"), attribute.String("status", "error")),
+					Attributes: attribute.NewSet(attribute.String("repository", "testrepo"), attribute.String("database", "testdb"), attribute.String("deployment", "pie"), attribute.String("environment", "staging"), attribute.String("status", "error")),
 				},
 				{
 					Value:      1,
-					Attributes: attribute.NewSet(attribute.String("repository", "testrepo"), attribute.String("database", "other"), attribute.String("environment", "production"), attribute.String("status", "success")),
+					Attributes: attribute.NewSet(attribute.String("repository", "testrepo"), attribute.String("database", "other"), attribute.String("deployment", "bakery"), attribute.String("environment", "production"), attribute.String("status", "success")),
 				},
 			},
 		},
@@ -244,8 +244,8 @@ func TestSchemaBotMetricsIncludeEnvironmentAttribute(t *testing.T) {
 		require.NoError(t, mp.Shutdown(t.Context()))
 	})
 
-	metrics.RecordPlan(t.Context(), "org/repo", "mydb", "staging", "success")
-	metrics.RecordPlanDuration(t.Context(), time.Second, "org/repo", "mydb", "staging", "success")
+	metrics.RecordPlan(t.Context(), "org/repo", "mydb", "pie", "staging", "success")
+	metrics.RecordPlanDuration(t.Context(), time.Second, "org/repo", "mydb", "pie", "staging", "success")
 	metrics.RecordApply(t.Context(), "org/repo", "mydb", "staging", "success")
 	metrics.RecordApplyDuration(t.Context(), time.Second, "org/repo", "mydb", "staging", "success")
 	metrics.RecordSchemaFreshnessRejected(t.Context(), "apply", "staging")
@@ -546,7 +546,7 @@ func TestRecordPlanDurationMetric(t *testing.T) {
 		require.NoError(t, mp.Shutdown(t.Context()))
 	})
 
-	metrics.RecordPlanDuration(t.Context(), 500*time.Millisecond, "testrepo", "mydb", "staging", "success")
+	metrics.RecordPlanDuration(t.Context(), 500*time.Millisecond, "testrepo", "mydb", "pie", "staging", "success")
 
 	names := collectMetricNames(t, reader)
 	assert.True(t, names["schemabot.plan.duration_seconds"], "expected schemabot.plan.duration_seconds")

--- a/pkg/api/telemetry_test.go
+++ b/pkg/api/telemetry_test.go
@@ -246,20 +246,20 @@ func TestSchemaBotMetricsIncludeEnvironmentAttribute(t *testing.T) {
 
 	metrics.RecordPlan(t.Context(), "org/repo", "mydb", "pie", "staging", "success")
 	metrics.RecordPlanDuration(t.Context(), time.Second, "org/repo", "mydb", "pie", "staging", "success")
-	metrics.RecordApply(t.Context(), "org/repo", "mydb", "staging", "success")
-	metrics.RecordApplyDuration(t.Context(), time.Second, "org/repo", "mydb", "staging", "success")
+	metrics.RecordApply(t.Context(), "org/repo", "mydb", "pie", "staging", "success")
+	metrics.RecordApplyDuration(t.Context(), time.Second, "org/repo", "mydb", "pie", "staging", "success")
 	metrics.RecordSchemaFreshnessRejected(t.Context(), "apply", "staging")
 	metrics.RecordStalePlanRejected(t.Context(), "staging")
 	metrics.RecordSourcePolicyBlock(t.Context(), "plan", "mydb", "staging", "unauthorized_repo")
 	metrics.RecordPRCommandActorAuthorization(t.Context(), "apply", "mydb", "staging", "org/repo", "allowed", "allowed_admin_user")
-	metrics.RecordCheckOwnershipMiss(t.Context(), "apply_finished", "org/repo", "mydb", "mysql", "staging")
-	metrics.AdjustActiveApplies(t.Context(), 1, "mydb", "staging")
-	metrics.RecordControlOperation(t.Context(), "stop", "mydb", "staging", "success")
+	metrics.RecordCheckOwnershipMiss(t.Context(), "apply_finished", "org/repo", "mydb", "mysql", "pie", "staging")
+	metrics.AdjustActiveApplies(t.Context(), 1, "mydb", "pie", "staging")
+	metrics.RecordControlOperation(t.Context(), "stop", "mydb", "pie", "staging", "success")
 	metrics.RecordLockOperation(t.Context(), "acquire", "mydb", "success")
-	metrics.RecordSchedulerResume(t.Context(), "mydb", "staging", "running")
-	metrics.RecordSchedulerResumeFailure(t.Context(), "mydb", "staging", "no_client")
+	metrics.RecordSchedulerResume(t.Context(), "mydb", "pie", "staging", "running")
+	metrics.RecordSchedulerResumeFailure(t.Context(), "mydb", "pie", "staging", "no_client")
 	metrics.RecordSchedulerClaimFailure(t.Context(), "storage_error")
-	metrics.RecordSchedulerClaimDuration(t.Context(), time.Second, "mydb", "staging", "running")
+	metrics.RecordSchedulerClaimDuration(t.Context(), time.Second, "mydb", "pie", "staging", "running")
 	metrics.RecordSchemaRequestError(t.Context(), "org/repo", "apply", "mydb", "staging", "invalid_config")
 	metrics.RecordGitHubRequest(t.Context(), metrics.GitHubRequestSample{
 		Operation:  metrics.GitHubOperationFetchPullRequest,
@@ -294,9 +294,30 @@ func TestSchemaBotMetricsIncludeEnvironmentAttribute(t *testing.T) {
 			}
 			checked++
 			assertMetricDataPointsHaveEnvironment(t, m)
+			if metricHasDeploymentAttribute(m.Name) {
+				assertMetricDataPointsHaveDeployment(t, m)
+			}
 		}
 	}
 	require.NotZero(t, checked, "expected SchemaBot metrics to be collected")
+}
+
+func metricHasDeploymentAttribute(metricName string) bool {
+	switch metricName {
+	case "schemabot.plans.total",
+		"schemabot.plan.duration_seconds",
+		"schemabot.applies.total",
+		"schemabot.apply.duration_seconds",
+		"schemabot.check_ownership_misses_total",
+		"schemabot.active_applies",
+		"schemabot.control_operations_total",
+		"schemabot.scheduler.resumed_total",
+		"schemabot.scheduler.resume_failures_total",
+		"schemabot.scheduler.claim_duration_seconds":
+		return true
+	default:
+		return false
+	}
 }
 
 func assertMetricDataPointsHaveEnvironment(t *testing.T, m metricdata.Metrics) {
@@ -330,6 +351,37 @@ func assertMetricAttributesHaveEnvironment(t *testing.T, metricName string, attr
 	assert.NotEmpty(t, environment.AsString(), "%s metric environment attribute must be non-empty", metricName)
 }
 
+func assertMetricDataPointsHaveDeployment(t *testing.T, m metricdata.Metrics) {
+	t.Helper()
+	switch data := m.Data.(type) {
+	case metricdata.Sum[int64]:
+		for _, dp := range data.DataPoints {
+			assertMetricAttributesHaveDeployment(t, m.Name, dp.Attributes)
+		}
+	case metricdata.Gauge[int64]:
+		for _, dp := range data.DataPoints {
+			assertMetricAttributesHaveDeployment(t, m.Name, dp.Attributes)
+		}
+	case metricdata.Histogram[float64]:
+		for _, dp := range data.DataPoints {
+			assertMetricAttributesHaveDeployment(t, m.Name, dp.Attributes)
+		}
+	case metricdata.Histogram[int64]:
+		for _, dp := range data.DataPoints {
+			assertMetricAttributesHaveDeployment(t, m.Name, dp.Attributes)
+		}
+	default:
+		t.Fatalf("unsupported metric data type %T for %s", m.Data, m.Name)
+	}
+}
+
+func assertMetricAttributesHaveDeployment(t *testing.T, metricName string, attrs attribute.Set) {
+	t.Helper()
+	deployment, ok := attrs.Value(attribute.Key("deployment"))
+	require.True(t, ok, "%s metric data point missing deployment attribute: %v", metricName, attrs)
+	assert.NotEmpty(t, deployment.AsString(), "%s metric deployment attribute must be non-empty", metricName)
+}
+
 func TestRecordApplyMetrics(t *testing.T) {
 	reader := sdkmetric.NewManualReader()
 	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
@@ -340,10 +392,10 @@ func TestRecordApplyMetrics(t *testing.T) {
 		require.NoError(t, mp.Shutdown(t.Context()))
 	})
 
-	metrics.RecordApply(t.Context(), "testrepo", "mydb", "staging", "success")
-	metrics.RecordApply(t.Context(), "testrepo", "mydb", "staging", "error")
-	metrics.RecordApply(t.Context(), "testrepo", "mydb", "staging", "conflict")
-	metrics.RecordApplyDuration(t.Context(), 2*time.Second, "testrepo", "mydb", "staging", "success")
+	metrics.RecordApply(t.Context(), "testrepo", "mydb", "pie", "staging", "success")
+	metrics.RecordApply(t.Context(), "testrepo", "mydb", "pie", "staging", "error")
+	metrics.RecordApply(t.Context(), "testrepo", "mydb", "pie", "staging", "conflict")
+	metrics.RecordApplyDuration(t.Context(), 2*time.Second, "testrepo", "mydb", "pie", "staging", "success")
 
 	names := collectMetricNames(t, reader)
 	assert.True(t, names["schemabot.applies.total"], "expected schemabot.applies.total")
@@ -360,8 +412,8 @@ func TestRecordCheckOwnershipMissMetric(t *testing.T) {
 		require.NoError(t, mp.Shutdown(t.Context()))
 	})
 
-	metrics.RecordCheckOwnershipMiss(t.Context(), "apply_finished", "org/repo", "mydb", "mysql", "staging")
-	metrics.RecordCheckOwnershipMiss(t.Context(), "rollback_finished", "org/repo", "mydb", "mysql", "staging")
+	metrics.RecordCheckOwnershipMiss(t.Context(), "apply_finished", "org/repo", "mydb", "mysql", "pie", "staging")
+	metrics.RecordCheckOwnershipMiss(t.Context(), "rollback_finished", "org/repo", "mydb", "mysql", "pie", "staging")
 
 	var rm metricdata.ResourceMetrics
 	require.NoError(t, reader.Collect(t.Context(), &rm))
@@ -594,9 +646,9 @@ func TestRecordControlOperationMetric(t *testing.T) {
 		require.NoError(t, mp.Shutdown(t.Context()))
 	})
 
-	metrics.RecordControlOperation(t.Context(), "cutover", "mydb", "staging", "success")
-	metrics.RecordControlOperation(t.Context(), "stop", "mydb", "staging", "success")
-	metrics.RecordControlOperation(t.Context(), "start", "mydb", "staging", "error")
+	metrics.RecordControlOperation(t.Context(), "cutover", "mydb", "pie", "staging", "success")
+	metrics.RecordControlOperation(t.Context(), "stop", "mydb", "pie", "staging", "success")
+	metrics.RecordControlOperation(t.Context(), "start", "mydb", "pie", "staging", "error")
 
 	names := collectMetricNames(t, reader)
 	assert.True(t, names["schemabot.control_operations_total"], "expected schemabot.control_operations_total")
@@ -630,11 +682,11 @@ func TestRecordSchedulerMetrics(t *testing.T) {
 		require.NoError(t, mp.Shutdown(t.Context()))
 	})
 
-	metrics.RecordSchedulerResume(t.Context(), "testdb", "staging", "running")
-	metrics.RecordSchedulerResumeFailure(t.Context(), "testdb", "staging", "no_client")
+	metrics.RecordSchedulerResume(t.Context(), "testdb", "pie", "staging", "running")
+	metrics.RecordSchedulerResumeFailure(t.Context(), "testdb", "pie", "staging", "no_client")
 	metrics.RecordSchedulerClaimFailure(t.Context(), "storage_error")
 	metrics.RecordSchedulerClaimFailure(t.Context(), "expire_retryable_error")
-	metrics.RecordSchedulerClaimDuration(t.Context(), 50*time.Millisecond, "testdb", "staging", "running")
+	metrics.RecordSchedulerClaimDuration(t.Context(), 50*time.Millisecond, "testdb", "pie", "staging", "running")
 
 	var rm metricdata.ResourceMetrics
 	require.NoError(t, reader.Collect(t.Context(), &rm))

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -88,9 +88,9 @@ func RecordPlanDuration(ctx context.Context, duration time.Duration, repo, datab
 	)
 }
 
-// RecordApply increments the applies counter with database, environment, and status attributes.
+// RecordApply increments the applies counter with database, deployment, environment, and status attributes.
 // Status should be "success", "error", "rejected", or "conflict".
-func RecordApply(ctx context.Context, repo, database, environment, status string) {
+func RecordApply(ctx context.Context, repo, database, deployment, environment, status string) {
 	meter := otel.Meter(meterName)
 	counter, err := meter.Int64Counter("schemabot.applies.total",
 		otelmetric.WithDescription("Total number of apply operations"),
@@ -104,6 +104,7 @@ func RecordApply(ctx context.Context, repo, database, environment, status string
 		otelmetric.WithAttributes(
 			attribute.String("repository", repo),
 			attribute.String("database", database),
+			DeploymentAttribute(deployment),
 			EnvironmentAttribute(environment),
 			attribute.String("status", status),
 		),
@@ -112,7 +113,7 @@ func RecordApply(ctx context.Context, repo, database, environment, status string
 
 // RecordApplyDuration records the duration of an apply operation (API call time,
 // not the full Spirit run which can take hours).
-func RecordApplyDuration(ctx context.Context, duration time.Duration, repo, database, environment, status string) {
+func RecordApplyDuration(ctx context.Context, duration time.Duration, repo, database, deployment, environment, status string) {
 	meter := otel.Meter(meterName)
 	hist, err := meter.Float64Histogram("schemabot.apply.duration_seconds",
 		otelmetric.WithDescription("Duration of apply operations (API call time)"),
@@ -126,6 +127,7 @@ func RecordApplyDuration(ctx context.Context, duration time.Duration, repo, data
 		otelmetric.WithAttributes(
 			attribute.String("repository", repo),
 			attribute.String("database", database),
+			DeploymentAttribute(deployment),
 			EnvironmentAttribute(environment),
 			attribute.String("status", status),
 		),
@@ -321,7 +323,7 @@ var knownCheckOwnershipOperations = map[string]bool{
 // RecordCheckOwnershipMiss increments the counter for guarded check updates
 // that did not apply because stored check state no longer belonged to the
 // apply being completed.
-func RecordCheckOwnershipMiss(ctx context.Context, operation, repository, database, databaseType, environment string) {
+func RecordCheckOwnershipMiss(ctx context.Context, operation, repository, database, databaseType, deployment, environment string) {
 	if !knownCheckOwnershipOperations[operation] {
 		operation = "unknown"
 	}
@@ -340,6 +342,7 @@ func RecordCheckOwnershipMiss(ctx context.Context, operation, repository, databa
 			attribute.String("repository", repository),
 			attribute.String("database", database),
 			attribute.String("database_type", databaseType),
+			DeploymentAttribute(deployment),
 			EnvironmentAttribute(environment),
 		),
 	)
@@ -347,7 +350,7 @@ func RecordCheckOwnershipMiss(ctx context.Context, operation, repository, databa
 
 // AdjustActiveApplies increments or decrements the active applies gauge.
 // Use delta=1 when an apply is accepted and delta=-1 when it reaches a terminal state.
-func AdjustActiveApplies(ctx context.Context, delta int64, database, environment string) {
+func AdjustActiveApplies(ctx context.Context, delta int64, database, deployment, environment string) {
 	meter := otel.Meter(meterName)
 	counter, err := meter.Int64UpDownCounter("schemabot.active_applies",
 		otelmetric.WithDescription("Number of currently in-progress applies"),
@@ -360,6 +363,7 @@ func AdjustActiveApplies(ctx context.Context, delta int64, database, environment
 	counter.Add(ctx, delta,
 		otelmetric.WithAttributes(
 			attribute.String("database", database),
+			DeploymentAttribute(deployment),
 			EnvironmentAttribute(environment),
 		),
 	)
@@ -379,7 +383,7 @@ var knownControlOperations = map[string]bool{
 // RecordControlOperation increments the control operations counter.
 // Operation should be one of: cutover, stop, start, volume, revert, skip_revert, rollback_plan.
 // Status should be "success" or "error".
-func RecordControlOperation(ctx context.Context, operation, database, environment, status string) {
+func RecordControlOperation(ctx context.Context, operation, database, deployment, environment, status string) {
 	if !knownControlOperations[operation] {
 		operation = "unknown"
 	}
@@ -396,6 +400,7 @@ func RecordControlOperation(ctx context.Context, operation, database, environmen
 		otelmetric.WithAttributes(
 			attribute.String("operation", operation),
 			attribute.String("database", database),
+			DeploymentAttribute(deployment),
 			EnvironmentAttribute(environment),
 			attribute.String("status", status),
 		),
@@ -427,7 +432,7 @@ func RecordLockOperation(ctx context.Context, operation, database, status string
 
 // RecordSchedulerResume increments the scheduler resumed counter when an apply is
 // successfully claimed and resumed.
-func RecordSchedulerResume(ctx context.Context, database, environment, previousState string) {
+func RecordSchedulerResume(ctx context.Context, database, deployment, environment, previousState string) {
 	meter := otel.Meter(meterName)
 	counter, err := meter.Int64Counter("schemabot.scheduler.resumed_total",
 		otelmetric.WithDescription("Total number of applies resumed by the scheduler"),
@@ -440,6 +445,7 @@ func RecordSchedulerResume(ctx context.Context, database, environment, previousS
 	counter.Add(ctx, 1,
 		otelmetric.WithAttributes(
 			attribute.String("database", database),
+			DeploymentAttribute(deployment),
 			EnvironmentAttribute(environment),
 			attribute.String("previous_state", previousState),
 		),
@@ -447,7 +453,7 @@ func RecordSchedulerResume(ctx context.Context, database, environment, previousS
 }
 
 // RecordSchedulerResumeFailure increments the scheduler resume failure counter.
-func RecordSchedulerResumeFailure(ctx context.Context, database, environment, reason string) {
+func RecordSchedulerResumeFailure(ctx context.Context, database, deployment, environment, reason string) {
 	meter := otel.Meter(meterName)
 	counter, err := meter.Int64Counter("schemabot.scheduler.resume_failures_total",
 		otelmetric.WithDescription("Total number of scheduler resume attempts that failed"),
@@ -460,6 +466,7 @@ func RecordSchedulerResumeFailure(ctx context.Context, database, environment, re
 	counter.Add(ctx, 1,
 		otelmetric.WithAttributes(
 			attribute.String("database", database),
+			DeploymentAttribute(deployment),
 			EnvironmentAttribute(environment),
 			attribute.String("reason", reason),
 		),
@@ -494,7 +501,7 @@ func RecordSchedulerClaimFailure(ctx context.Context, reason string) {
 }
 
 // RecordSchedulerClaimDuration records how long it took to claim and resume an apply.
-func RecordSchedulerClaimDuration(ctx context.Context, duration time.Duration, database, environment, previousState string) {
+func RecordSchedulerClaimDuration(ctx context.Context, duration time.Duration, database, deployment, environment, previousState string) {
 	meter := otel.Meter(meterName)
 	hist, err := meter.Float64Histogram("schemabot.scheduler.claim_duration_seconds",
 		otelmetric.WithDescription("Duration of scheduler claim + resume operations"),
@@ -507,6 +514,7 @@ func RecordSchedulerClaimDuration(ctx context.Context, duration time.Duration, d
 	hist.Record(ctx, duration.Seconds(),
 		otelmetric.WithAttributes(
 			attribute.String("database", database),
+			DeploymentAttribute(deployment),
 			EnvironmentAttribute(environment),
 			attribute.String("previous_state", previousState),
 		),

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -16,7 +16,19 @@ import (
 // Meter name used for all SchemaBot metrics.
 const meterName = "schemabot"
 
-const unknownEnvironment = "unknown"
+const (
+	unknownDeployment  = "unknown"
+	unknownEnvironment = "unknown"
+)
+
+// DeploymentAttribute returns the canonical deployment metric attribute.
+// Use "unknown" when the request fails before SchemaBot resolves routing.
+func DeploymentAttribute(deployment string) attribute.KeyValue {
+	if deployment == "" {
+		deployment = unknownDeployment
+	}
+	return attribute.String("deployment", deployment)
+}
 
 // EnvironmentAttribute returns the canonical environment metric attribute.
 // Use "unknown" for process-wide or integration metrics that do not belong to
@@ -28,12 +40,12 @@ func EnvironmentAttribute(environment string) attribute.KeyValue {
 	return attribute.String("environment", environment)
 }
 
-// RecordPlan increments the plans counter with database, environment, and status attributes.
+// RecordPlan increments the plans counter with database, deployment, environment, and status attributes.
 // Status should be "success" or "error".
 //
 // The OTel SDK deduplicates instruments with the same name, so repeated calls
 // to Int64Counter are cheap after the first registration.
-func RecordPlan(ctx context.Context, repo, database, environment, status string) {
+func RecordPlan(ctx context.Context, repo, database, deployment, environment, status string) {
 	meter := otel.Meter(meterName)
 	counter, err := meter.Int64Counter("schemabot.plans.total",
 		otelmetric.WithDescription("Total number of plan operations"),
@@ -47,6 +59,7 @@ func RecordPlan(ctx context.Context, repo, database, environment, status string)
 		otelmetric.WithAttributes(
 			attribute.String("repository", repo),
 			attribute.String("database", database),
+			DeploymentAttribute(deployment),
 			EnvironmentAttribute(environment),
 			attribute.String("status", status),
 		),
@@ -54,7 +67,7 @@ func RecordPlan(ctx context.Context, repo, database, environment, status string)
 }
 
 // RecordPlanDuration records the duration of a plan operation.
-func RecordPlanDuration(ctx context.Context, duration time.Duration, repo, database, environment, status string) {
+func RecordPlanDuration(ctx context.Context, duration time.Duration, repo, database, deployment, environment, status string) {
 	meter := otel.Meter(meterName)
 	hist, err := meter.Float64Histogram("schemabot.plan.duration_seconds",
 		otelmetric.WithDescription("Duration of plan operations"),
@@ -68,6 +81,7 @@ func RecordPlanDuration(ctx context.Context, duration time.Duration, repo, datab
 		otelmetric.WithAttributes(
 			attribute.String("repository", repo),
 			attribute.String("database", database),
+			DeploymentAttribute(deployment),
 			EnvironmentAttribute(environment),
 			attribute.String("status", status),
 		),

--- a/pkg/tern/grpc_client.go
+++ b/pkg/tern/grpc_client.go
@@ -1118,7 +1118,7 @@ func (c *GRPCClient) markRemoteApplyFailedWithOptions(ctx context.Context, remot
 	}
 	c.logApplyStateTransition(ctx, storedApply, storage.LogLevelError, fmt.Sprintf("Remote apply failed: %s", message), oldState)
 	*remoteApply = *storedApply
-	metrics.AdjustActiveApplies(ctx, -1, storedApply.Database, storedApply.Environment)
+	metrics.AdjustActiveApplies(ctx, -1, storedApply.Database, storedApply.Deployment, storedApply.Environment)
 	return nil
 }
 
@@ -1216,7 +1216,7 @@ func (c *GRPCClient) persistTerminalStateFromRemote(ctx context.Context, storedA
 	}
 	c.logApplyStateTransition(ctx, storedApply, remoteTerminalApplyLogLevel(storedApply), remoteTerminalApplyLogMessage(storedApply), oldState)
 	*remoteApply = *storedApply
-	metrics.AdjustActiveApplies(ctx, -1, storedApply.Database, storedApply.Environment)
+	metrics.AdjustActiveApplies(ctx, -1, storedApply.Database, storedApply.Deployment, storedApply.Environment)
 	return nil
 }
 

--- a/pkg/tern/local_apply_failure.go
+++ b/pkg/tern/local_apply_failure.go
@@ -41,7 +41,7 @@ func (c *LocalClient) failApplyWithTasks(ctx context.Context, apply *storage.App
 	if err := c.storage.Applies().Update(ctx, apply); err != nil {
 		c.logger.Error("failed to update apply state", "apply_id", apply.ApplyIdentifier, "state", state.Apply.Failed, "error", err)
 	}
-	metrics.AdjustActiveApplies(ctx, -1, apply.Database, apply.Environment)
+	metrics.AdjustActiveApplies(ctx, -1, apply.Database, apply.Deployment, apply.Environment)
 }
 
 // markApplyRetryableWithTasks pauses an apply after a retryable engine failure.
@@ -75,7 +75,7 @@ func (c *LocalClient) markApplyRetryableWithTasks(ctx context.Context, apply *st
 	if err := c.storage.Applies().Update(ctx, apply); err != nil {
 		c.logger.Error("failed to update apply state", "apply_id", apply.ApplyIdentifier, "state", state.Apply.FailedRetryable, "error", err)
 	}
-	metrics.AdjustActiveApplies(ctx, -1, apply.Database, apply.Environment)
+	metrics.AdjustActiveApplies(ctx, -1, apply.Database, apply.Deployment, apply.Environment)
 	if obs := c.getObserver(apply.ID); obs != nil {
 		obs.OnProgress(apply, tasks)
 	}

--- a/pkg/tern/local_apply_grouped.go
+++ b/pkg/tern/local_apply_grouped.go
@@ -454,7 +454,7 @@ func (c *LocalClient) handleAtomicProgressTick(ctx context.Context, eng engine.E
 				"apply_id", apply.ApplyIdentifier, "error", err)
 			return true
 		}
-		metrics.AdjustActiveApplies(ctx, -1, apply.Database, apply.Environment)
+		metrics.AdjustActiveApplies(ctx, -1, apply.Database, apply.Deployment, apply.Environment)
 		switch {
 		case retryableFailure:
 			c.logger.Warn("apply paused for scheduler retry",

--- a/pkg/tern/local_apply_sequential.go
+++ b/pkg/tern/local_apply_sequential.go
@@ -422,7 +422,7 @@ func (c *LocalClient) finalizeSequentialApply(ctx context.Context, apply *storag
 			return
 		}
 	}
-	metrics.AdjustActiveApplies(ctx, -1, apply.Database, apply.Environment)
+	metrics.AdjustActiveApplies(ctx, -1, apply.Database, apply.Deployment, apply.Environment)
 
 	if apply.State == state.Apply.FailedRetryable {
 		if obs := c.getObserver(apply.ID); obs != nil {

--- a/pkg/webhook/check_records.go
+++ b/pkg/webhook/check_records.go
@@ -313,7 +313,7 @@ func (h *Handler) updateCheckRecordForApplyResult(ctx context.Context, repo stri
 			repo, pr, apply.Environment, apply.DatabaseType, apply.Database, err)
 	}
 	if !updated {
-		metrics.RecordCheckOwnershipMiss(ctx, "apply_finished", repo, apply.Database, apply.DatabaseType, apply.Environment)
+		metrics.RecordCheckOwnershipMiss(ctx, "apply_finished", repo, apply.Database, apply.DatabaseType, apply.Deployment, apply.Environment)
 		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
 			Operation:    "apply_finished",
 			Repository:   repo,
@@ -411,7 +411,7 @@ func (h *Handler) setCheckActionRequired(repo string, pr int, installationID int
 		return
 	}
 	if !updated {
-		metrics.RecordCheckOwnershipMiss(ctx, "rollback_finished", repo, apply.Database, apply.DatabaseType, apply.Environment)
+		metrics.RecordCheckOwnershipMiss(ctx, "rollback_finished", repo, apply.Database, apply.DatabaseType, apply.Deployment, apply.Environment)
 		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
 			Operation:    "rollback_finished",
 			Repository:   repo,

--- a/pkg/webhook/error_comment.go
+++ b/pkg/webhook/error_comment.go
@@ -1,8 +1,16 @@
 package webhook
 
 import (
+	"errors"
+	"strings"
+
+	"github.com/block/schemabot/pkg/api"
 	"github.com/block/schemabot/pkg/webhook/templates"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
+
+const remoteSchemaServiceUnavailableMessage = "SchemaBot could not reach the remote schema change service for this environment."
 
 // postCommandError posts a generic command-failure comment to the PR with a
 // consistent UTC timestamp.
@@ -28,6 +36,47 @@ func (h *Handler) postCommandError(
 		Timestamp:   templates.NowFunc().UTC().Format("2006-01-02 15:04:05"),
 		Environment: environment,
 		CommandName: commandName,
-		ErrorDetail: errorDetail,
+		ErrorDetail: userFacingErrorDetail(errorDetail),
 	}))
+}
+
+func userFacingError(err error) string {
+	var remoteErr *api.RemoteSchemaServiceUnavailableError
+	if errors.As(err, &remoteErr) {
+		return userFacingRemoteUnavailableError(remoteErr.Deployment, remoteErr.Target, err.Error())
+	}
+	if status.Code(err) == codes.Unavailable {
+		return userFacingRemoteUnavailableError("", "", err.Error())
+	}
+	return err.Error()
+}
+
+func userFacingErrorDetail(errorDetail string) string {
+	lowerDetail := strings.ToLower(errorDetail)
+	if strings.Contains(lowerDetail, strings.ToLower(remoteSchemaServiceUnavailableMessage)) {
+		return errorDetail
+	}
+	if strings.Contains(lowerDetail, "schemabot could not reach the remote deployment") {
+		return errorDetail
+	}
+	if strings.Contains(lowerDetail, "schemabot could not reach the remote schema change service") {
+		return errorDetail
+	}
+	if strings.Contains(lowerDetail, "rpc error: code = unavailable") {
+		return userFacingRemoteUnavailableError("", "", errorDetail)
+	}
+	return errorDetail
+}
+
+func userFacingRemoteUnavailableError(deployment, target, rawError string) string {
+	service := "remote schema change service"
+	if deployment != "" && target != "" {
+		service = "remote deployment `" + deployment + "` for target `" + target + "`"
+	} else if deployment != "" {
+		service = "remote deployment `" + deployment + "`"
+	}
+	if strings.Contains(strings.ToLower(rawError), "no healthy upstream") {
+		return "SchemaBot could not reach the " + service + ". No healthy upstream is available. The service or network path is unavailable; retry after the upstream is healthy. Raw error: " + rawError
+	}
+	return "SchemaBot could not reach the " + service + ". Retry after the service is healthy. Raw error: " + rawError
 }

--- a/pkg/webhook/error_comment.go
+++ b/pkg/webhook/error_comment.go
@@ -41,7 +41,7 @@ func (h *Handler) postCommandError(
 }
 
 func userFacingError(err error) string {
-	var remoteErr *api.RemoteSchemaServiceUnavailableError
+	var remoteErr *api.RemoteDeploymentUnavailableError
 	if errors.As(err, &remoteErr) {
 		return userFacingRemoteUnavailableError(remoteErr.Deployment, remoteErr.Target, err.Error())
 	}
@@ -53,19 +53,20 @@ func userFacingError(err error) string {
 
 func userFacingErrorDetail(errorDetail string) string {
 	lowerDetail := strings.ToLower(errorDetail)
+	if isUserFacingRemoteUnavailableError(lowerDetail) {
+		return errorDetail
+	}
 	if strings.Contains(lowerDetail, strings.ToLower(remoteSchemaServiceUnavailableMessage)) {
-		return errorDetail
-	}
-	if strings.Contains(lowerDetail, "schemabot could not reach the remote deployment") {
-		return errorDetail
-	}
-	if strings.Contains(lowerDetail, "schemabot could not reach the remote schema change service") {
 		return errorDetail
 	}
 	if strings.Contains(lowerDetail, "rpc error: code = unavailable") {
 		return userFacingRemoteUnavailableError("", "", errorDetail)
 	}
 	return errorDetail
+}
+
+func isUserFacingRemoteUnavailableError(lowerDetail string) bool {
+	return strings.Contains(lowerDetail, "schemabot could not reach the remote ") && strings.Contains(lowerDetail, "raw error:")
 }
 
 func userFacingRemoteUnavailableError(deployment, target, rawError string) string {

--- a/pkg/webhook/error_comment_test.go
+++ b/pkg/webhook/error_comment_test.go
@@ -60,3 +60,37 @@ func TestPostCommandError_RendersTimestamp(t *testing.T) {
 		t.Fatal("timed out waiting for posted comment")
 	}
 }
+
+func TestPostCommandErrorExplainsRemoteUnavailable(t *testing.T) {
+	client, mux := setupGitHubServer(t)
+	bodies := make(chan string, 1)
+	mux.HandleFunc("POST /repos/octocat/hello-world/issues/1/comments", func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Body string `json:"body"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		bodies <- body.Body
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": 99})
+	})
+
+	h := &Handler{
+		ghClient: &fakeClientFactory{client: ghclient.NewInstallationClient(client, testLogger())},
+		logger:   testLogger(),
+	}
+
+	h.postCommandError(
+		"octocat/hello-world", 1, 12345,
+		"plan", "staging", "alice",
+		"rpc error: code = Unavailable desc = no healthy upstream",
+	)
+
+	select {
+	case body := <-bodies:
+		assert.Contains(t, body, "SchemaBot could not reach the remote schema change service")
+		assert.Contains(t, body, "No healthy upstream is available")
+		assert.Contains(t, body, "Raw error: rpc error: code = Unavailable desc = no healthy upstream")
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for posted comment")
+	}
+}

--- a/pkg/webhook/plan.go
+++ b/pkg/webhook/plan.go
@@ -76,10 +76,11 @@ func (h *Handler) handlePlanCommand(w http.ResponseWriter, repo string, pr int, 
 	if err != nil {
 		h.logger.Error("plan execution failed", "repo", repo, "pr", pr, "error", err)
 		metrics.RecordPlan(ctx, repo, schemaResult.Database, environment, "error")
+		userError := userFacingError(err)
 		h.postFailingAggregates(ctx, client, repo, pr, schemaResult.HeadSHA, map[string]string{
-			environment: userFacingError(err),
+			environment: userError,
 		})
-		h.postCommandError(repo, pr, installationID, action.Plan, environment, requestedBy, err.Error())
+		h.postCommandError(repo, pr, installationID, action.Plan, environment, requestedBy, userError)
 		h.writeJSON(w, http.StatusOK, map[string]string{"message": "plan failed"})
 		return
 	}
@@ -403,10 +404,4 @@ func buildPlanCommentData(schema *ghclient.SchemaRequestResult, planResp *apityp
 	data.Errors = planResp.Errors
 
 	return data
-}
-
-// userFacingError returns the error message as-is. Detailed errors are logged
-// server-side; the PR comment shows the full chain so users can report issues.
-func userFacingError(err error) string {
-	return err.Error()
 }

--- a/pkg/webhook/plan.go
+++ b/pkg/webhook/plan.go
@@ -59,6 +59,17 @@ func (h *Handler) handlePlanCommand(w http.ResponseWriter, repo string, pr int, 
 
 	// Build PlanRequest in the format expected by the API service
 	prNumber := int32(pr)
+	deployment := ""
+	if resolvedTarget, err := h.service.Config().ResolveDatabaseTarget(schemaResult.Database, environment); err != nil {
+		h.logger.Warn("plan metric deployment is unknown because target resolution failed",
+			"repo", repo,
+			"pr", pr,
+			"database", schemaResult.Database,
+			"environment", environment,
+			"error", err)
+	} else {
+		deployment = resolvedTarget.Deployment
+	}
 	planReq := api.PlanRequest{
 		Database:      schemaResult.Database,
 		Environment:   environment,
@@ -75,7 +86,7 @@ func (h *Handler) handlePlanCommand(w http.ResponseWriter, repo string, pr int, 
 	planResp, err := h.service.ExecutePlan(ctx, planReq)
 	if err != nil {
 		h.logger.Error("plan execution failed", "repo", repo, "pr", pr, "error", err)
-		metrics.RecordPlan(ctx, repo, schemaResult.Database, environment, "error")
+		metrics.RecordPlan(ctx, repo, schemaResult.Database, deployment, environment, "error")
 		userError := userFacingError(err)
 		h.postFailingAggregates(ctx, client, repo, pr, schemaResult.HeadSHA, map[string]string{
 			environment: userError,
@@ -88,7 +99,7 @@ func (h *Handler) handlePlanCommand(w http.ResponseWriter, repo string, pr int, 
 	// Build plan comment data
 	commentData := buildPlanCommentData(schemaResult, planResp, environment, requestedBy)
 
-	metrics.RecordPlan(ctx, repo, schemaResult.Database, environment, "success")
+	metrics.RecordPlan(ctx, repo, schemaResult.Database, deployment, environment, "success")
 
 	// Post plan comment
 	h.postComment(repo, pr, installationID, templates.RenderPlanComment(commentData))

--- a/pkg/webhook/plan.go
+++ b/pkg/webhook/plan.go
@@ -85,7 +85,7 @@ func (h *Handler) handlePlanCommand(w http.ResponseWriter, repo string, pr int, 
 	// Execute plan via the service
 	planResp, err := h.service.ExecutePlan(ctx, planReq)
 	if err != nil {
-		h.logger.Error("plan execution failed", "repo", repo, "pr", pr, "error", err)
+		h.logger.Error("plan execution failed", "repo", repo, "pr", pr, "database", schemaResult.Database, "deployment", deployment, "environment", environment, "error", err)
 		metrics.RecordPlan(ctx, repo, schemaResult.Database, deployment, environment, "error")
 		userError := userFacingError(err)
 		h.postFailingAggregates(ctx, client, repo, pr, schemaResult.HeadSHA, map[string]string{
@@ -107,7 +107,7 @@ func (h *Handler) handlePlanCommand(w http.ResponseWriter, repo string, pr int, 
 	// Store per-database check record and update aggregate
 	headSHA, checkErr := h.storePlanCheckRecord(ctx, client, repo, pr, schemaResult, planResp, environment)
 	if checkErr != nil {
-		h.logger.Error("failed to store plan check record", "repo", repo, "pr", pr, "error", checkErr)
+		h.logger.Error("failed to store plan check record", "repo", repo, "pr", pr, "database", schemaResult.Database, "deployment", deployment, "environment", environment, "error", checkErr)
 	}
 	if headSHA != "" {
 		h.updateAggregateCheck(ctx, client, repo, pr, headSHA)

--- a/pkg/webhook/plan_test.go
+++ b/pkg/webhook/plan_test.go
@@ -1,11 +1,15 @@
 package webhook
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
+	"github.com/block/schemabot/pkg/api"
 	"github.com/block/schemabot/pkg/apitypes"
 	ghclient "github.com/block/schemabot/pkg/github"
 	"github.com/block/schemabot/pkg/webhook/templates"
@@ -208,6 +212,37 @@ func TestRenderMultiEnvPlanComment_ShowsPRHeadSHA(t *testing.T) {
 
 	assert.Contains(t, rendered, "planned from [`abcdef1`](https://github.com/block/schemabot/commit/abcdef1234567890)")
 	assert.NotContains(t, rendered, "**PR head SHA**")
+}
+
+func TestUserFacingErrorExplainsNoHealthyUpstream(t *testing.T) {
+	err := &api.RemoteSchemaServiceUnavailableError{
+		Deployment: "pie",
+		Target:     "orders-staging",
+		Err:        status.Error(codes.Unavailable, "no healthy upstream"),
+	}
+
+	got := userFacingError(err)
+
+	assert.Contains(t, got, "SchemaBot could not reach the remote deployment `pie`")
+	assert.Contains(t, got, "target `orders-staging`")
+	assert.Contains(t, got, "service or network path is unavailable")
+	assert.Contains(t, got, "Raw error: remote deployment \"pie\" target \"orders-staging\" unavailable: rpc error: code = Unavailable desc = no healthy upstream")
+}
+
+func TestUserFacingErrorPreservesNonGRPCErrors(t *testing.T) {
+	err := errors.New("invalid DDL")
+
+	got := userFacingError(err)
+
+	assert.Equal(t, "invalid DDL", got)
+}
+
+func TestUserFacingErrorDetailDoesNotWrapFormattedRemoteErrors(t *testing.T) {
+	formatted := "SchemaBot could not reach the remote deployment `pie`. Raw error: rpc error: code = Unavailable desc = no healthy upstream"
+
+	got := userFacingErrorDetail(formatted)
+
+	assert.Equal(t, formatted, got)
 }
 
 func TestRenderUnsafeChangesBlocked_UsedByApplyFlow(t *testing.T) {

--- a/pkg/webhook/plan_test.go
+++ b/pkg/webhook/plan_test.go
@@ -2,6 +2,7 @@ package webhook
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -215,7 +216,7 @@ func TestRenderMultiEnvPlanComment_ShowsPRHeadSHA(t *testing.T) {
 }
 
 func TestUserFacingErrorExplainsNoHealthyUpstream(t *testing.T) {
-	err := &api.RemoteSchemaServiceUnavailableError{
+	err := &api.RemoteDeploymentUnavailableError{
 		Deployment: "pie",
 		Target:     "orders-staging",
 		Err:        status.Error(codes.Unavailable, "no healthy upstream"),
@@ -238,11 +239,13 @@ func TestUserFacingErrorPreservesNonGRPCErrors(t *testing.T) {
 }
 
 func TestUserFacingErrorDetailDoesNotWrapFormattedRemoteErrors(t *testing.T) {
-	formatted := "SchemaBot could not reach the remote deployment `pie`. Raw error: rpc error: code = Unavailable desc = no healthy upstream"
+	formatted := "SchemaBot could not reach the remote deployment `pie` for target `orders-staging`. No healthy upstream is available. Raw error: rpc error: code = Unavailable desc = no healthy upstream"
 
 	got := userFacingErrorDetail(formatted)
 
 	assert.Equal(t, formatted, got)
+	assert.Equal(t, 1, strings.Count(got, "SchemaBot could not reach"))
+	assert.Equal(t, 1, strings.Count(got, "Raw error:"))
 }
 
 func TestRenderUnsafeChangesBlocked_UsedByApplyFlow(t *testing.T) {


### PR DESCRIPTION
## Why
Remote Tern availability failures currently surface raw gRPC transport messages that do not tell users which remote deployment failed.

## What
- Preserve remote deployment and target metadata on Tern unavailable errors
- Render clearer PR comments and failing checks for remote availability failures
- Keep already-formatted remote availability errors idempotent in generic error comments
- Add structured deployment fields to failed remote plan logs and runtime apply/control/scheduler logs
- Add the resolved deployment dimension to plan and runtime metrics where routing is known
- Keep the raw RPC error attached for operator debugging

## Risk Assessment
Low — this changes error wrapping, user-facing failure text for failed remote plan calls, structured runtime logs, and metric attributes; successful plan and apply behavior is unchanged.

Generated with Amp
