### PR TITLE
feat(github): support stop requests from PR comments

### DIFF
--- a/pkg/api/control_handlers.go
+++ b/pkg/api/control_handlers.go
@@ -54,6 +54,13 @@ func controlOperationHTTPStatus(err error) int {
 	return http.StatusInternalServerError
 }
 
+func controlHTTPErrorf(status int, format string, args ...any) error {
+	return &controlOperationHTTPError{
+		status: status,
+		err:    fmt.Errorf(format, args...),
+	}
+}
+
 func controlOperationCaller(caller string) string {
 	if caller == "" {
 		return "unknown"
@@ -219,6 +226,58 @@ func (s *Service) decodeControlRequest(w http.ResponseWriter, r *http.Request, d
 	return client, apply, resolvedApplyID, true
 }
 
+func (s *Service) controlTarget(ctx context.Context, operation, applyIdentifier, environment string) (tern.Client, *storage.Apply, string, error) {
+	if applyIdentifier == "" {
+		return nil, nil, "", controlHTTPErrorf(http.StatusBadRequest, "apply_id is required")
+	}
+	if environment == "" {
+		return nil, nil, "", controlHTTPErrorf(http.StatusBadRequest, "environment is required")
+	}
+	if s.storage == nil {
+		s.logger.Error("storage not available for control request", "operation", operation, "apply_id", applyIdentifier, "environment", environment)
+		return nil, nil, "", fmt.Errorf("storage is not available")
+	}
+	applyStore := s.storage.Applies()
+	if applyStore == nil {
+		s.logger.Error("apply store not available for control request", "operation", operation, "apply_id", applyIdentifier, "environment", environment)
+		return nil, nil, "", fmt.Errorf("apply store is not available")
+	}
+	apply, err := applyStore.GetByApplyIdentifier(ctx, applyIdentifier)
+	if err != nil {
+		s.logger.Error("failed to load apply for control request", "operation", operation, "apply_id", applyIdentifier, "environment", environment, "error", err)
+		return nil, nil, "", fmt.Errorf("failed to look up apply %q: %w", applyIdentifier, err)
+	}
+	if apply == nil {
+		return nil, nil, "", controlHTTPErrorf(http.StatusNotFound, "apply not found: %s", applyIdentifier)
+	}
+	if apply.Environment != environment {
+		return nil, apply, "", controlHTTPErrorf(http.StatusBadRequest,
+			"apply %q belongs to environment %q, not %q", applyIdentifier, apply.Environment, environment)
+	}
+	deployment, err := storedDeploymentForApply(apply)
+	if err != nil {
+		s.logger.Error("control request apply is missing stored deployment metadata",
+			"operation", operation,
+			"apply_id", applyIdentifier,
+			"database", apply.Database,
+			"database_type", apply.DatabaseType,
+			"environment", apply.Environment,
+			"error", err)
+		return nil, apply, "", err
+	}
+	client, err := s.TernClient(deployment, apply.Environment)
+	if err != nil {
+		s.logger.Error("failed to create Tern client",
+			"operation", operation,
+			"deployment", deployment,
+			"database", apply.Database,
+			"environment", apply.Environment,
+			"error", err)
+		return nil, apply, "", controlHTTPErrorf(http.StatusNotFound, "%s", err.Error())
+	}
+	return client, apply, ternApplyIDForStoredApply(apply), nil
+}
+
 // ternApplyIDForStoredApply returns the identifier that a Tern RPC expects for
 // an apply-scoped control or progress request.
 //
@@ -311,33 +370,51 @@ func (s *Service) handleStop(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
+	stopResp, httpStatus, err := s.executeStopForApply(r.Context(), client, apply, ternApplyID, req.Environment, req.Caller)
+	if err != nil {
+		s.writeControlError(w, "stop", apply, err)
+		return
+	}
+	s.writeJSON(w, httpStatus, stopResp)
+}
 
-	resp, responseStatus, err := s.queueStopForApplyOwner(r.Context(), apply, req.Caller)
+// ExecuteStop records durable stop intent for an apply. The scheduler owner is
+// responsible for completing the stop if the immediate local attempt cannot.
+func (s *Service) ExecuteStop(ctx context.Context, req apitypes.ControlRequest) (*apitypes.StopResponse, error) {
+	client, apply, ternApplyID, err := s.controlTarget(ctx, "stop", req.ApplyID, req.Environment)
+	if err != nil {
+		return nil, err
+	}
+	resp, _, err := s.executeStopForApply(ctx, client, apply, ternApplyID, req.Environment, req.Caller)
+	return resp, err
+}
+
+func (s *Service) executeStopForApply(ctx context.Context, client tern.Client, apply *storage.Apply, ternApplyID, environment, caller string) (*apitypes.StopResponse, int, error) {
+	resp, responseStatus, err := s.queueStopForApplyOwner(ctx, apply, caller)
 	if err != nil {
 		status := "error"
 		if controlOperationHTTPStatus(err) < http.StatusInternalServerError {
 			status = "rejected"
 		}
-		metrics.RecordControlOperation(r.Context(), "stop", apply.Database, apply.Deployment, apply.Environment, status)
-		s.writeControlError(w, "stop", apply, err)
-		return
+		metrics.RecordControlOperation(ctx, "stop", apply.Database, apply.Deployment, apply.Environment, status)
+		return nil, http.StatusOK, err
 	}
-	metrics.RecordControlOperation(r.Context(), "stop", apply.Database, apply.Deployment, apply.Environment, controlStatus(resp.Accepted))
+	metrics.RecordControlOperation(ctx, "stop", apply.Database, apply.Deployment, apply.Environment, controlStatus(resp.Accepted))
 	if resp.Accepted {
 		logMessage := "Stop requested by user"
 		if responseStatus == stopResponseStatusAlreadyRequested {
 			logMessage = "Stop requested by user while stop request already pending"
 		}
-		s.logControlOperation(r, apply.ApplyIdentifier, req.Caller, storage.LogEventStopRequested, logMessage)
+		s.logControlOperationForApply(ctx, apply, caller, storage.LogEventStopRequested, logMessage)
 		if responseStatus == stopResponseStatusAlreadyRequested {
 			s.logger.Info("immediate stop skipped because stop request is already pending",
 				"apply_id", apply.ApplyIdentifier,
 				"database", apply.Database,
 				"deployment", apply.Deployment,
 				"environment", apply.Environment,
-				"requested_by", req.Caller)
+				"requested_by", caller)
 		} else {
-			s.tryImmediateStopAfterQueue(r.Context(), client, apply, ternApplyID, req.Environment, req.Caller)
+			s.tryImmediateStopAfterQueue(ctx, client, apply, ternApplyID, environment, caller)
 		}
 		s.wakeScheduler(apply.ApplyIdentifier, apply.Database, apply.Environment)
 	}
@@ -346,13 +423,13 @@ func (s *Service) handleStop(w http.ResponseWriter, r *http.Request) {
 	if responseStatus == stopResponseStatusAlreadyRequested {
 		httpStatus = http.StatusAccepted
 	}
-	s.writeJSON(w, httpStatus, &apitypes.StopResponse{
+	return &apitypes.StopResponse{
 		Accepted:     resp.Accepted,
 		ErrorMessage: resp.ErrorMessage,
 		StoppedCount: resp.StoppedCount,
 		SkippedCount: resp.SkippedCount,
 		Status:       responseStatus,
-	})
+	}, httpStatus, nil
 }
 
 func (s *Service) tryImmediateStopAfterQueue(ctx context.Context, client tern.Client, apply *storage.Apply, ternApplyID, environment, caller string) {
@@ -647,7 +724,7 @@ func (s *Service) handleStart(w http.ResponseWriter, r *http.Request) {
 		if controlOperationHTTPStatus(err) < http.StatusInternalServerError {
 			status = "rejected"
 		}
-		metrics.RecordControlOperation(r.Context(), "start", apply.Database, apply.Environment, status)
+		metrics.RecordControlOperation(r.Context(), "start", apply.Database, apply.Deployment, apply.Environment, status)
 		s.writeControlError(w, "start", apply, err)
 		return
 	}

--- a/pkg/tern/local_control_resume.go
+++ b/pkg/tern/local_control_resume.go
@@ -476,7 +476,7 @@ func (c *LocalClient) launchAtomicResume(ctx context.Context, apply *storage.App
 			}
 		}
 		if !state.IsTerminalApplyState(oldApplyState) {
-			metrics.AdjustActiveApplies(ctx, -1, apply.Database, apply.Environment)
+			metrics.AdjustActiveApplies(ctx, -1, apply.Database, apply.Deployment, apply.Environment)
 		}
 		c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventStateTransition, storage.LogSourceSchemaBot,
 			"All tasks already completed on resume (final schema check shows no remaining changes)", oldApplyState, state.Apply.Completed)

--- a/pkg/webhook/actor_authorization_test.go
+++ b/pkg/webhook/actor_authorization_test.go
@@ -1,10 +1,12 @@
 package webhook
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -344,6 +346,99 @@ func TestHandleApplyCommandBlocksUnauthorizedActorBeforePlanning(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		require.FailNow(t, "timed out waiting for unauthorized apply comment")
 	}
+}
+
+// Stop is a mutating PR comment command, so the full webhook path uses the same
+// configured admin/operator authorization as apply before recording durable stop intent.
+func TestWebhookStopCommandBlocksUnauthorizedActor(t *testing.T) {
+	client, mux := setupGitHubServer(t)
+	comments := make(chan string, 2)
+	reactions := make(chan string, 2)
+	mux.HandleFunc("POST /repos/octocat/hello-world/issues/1/comments", func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Body string `json:"body"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		comments <- body.Body
+		w.WriteHeader(http.StatusCreated)
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{"id": 99}))
+	})
+	mux.HandleFunc("POST /repos/octocat/hello-world/issues/comments/42/reactions", func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Content string `json:"content"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		reactions <- body.Content
+		w.WriteHeader(http.StatusCreated)
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{"id": 1}))
+	})
+
+	apply := &storage.Apply{
+		ID:              42,
+		ApplyIdentifier: "apply_abcd1234",
+		Database:        "orders",
+		DatabaseType:    storage.DatabaseTypeMySQL,
+		Repository:      "octocat/hello-world",
+		PullRequest:     1,
+		Environment:     "staging",
+		Deployment:      "orders",
+	}
+	cfg := actorAuthTestConfig(true, func(cfg *api.ServerConfig) {
+		cfg.PRCommandAuthorization.AdminUsers = []string{"hubot"}
+	})
+	service := api.New(&stopActorAuthStorage{apply: apply}, cfg, nil, testLogger())
+	h := &Handler{
+		service:  service,
+		ghClient: &fakeClientFactory{client: ghclient.NewInstallationClient(client, testLogger())},
+		logger:   testLogger(),
+	}
+
+	req := buildWebhookRequest(t, webhookPayloadOpts{
+		comment:   "schemabot stop " + apply.ApplyIdentifier + " -e staging",
+		userLogin: "mona",
+		isPR:      true,
+	}, nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), "stop started")
+
+	select {
+	case reaction := <-reactions:
+		assert.Equal(t, "eyes", reaction)
+	case <-time.After(2 * time.Second):
+		require.FailNow(t, "timed out waiting for stop acknowledgement reaction")
+	}
+
+	select {
+	case body := <-comments:
+		assert.Contains(t, body, "SchemaBot Command Not Authorized")
+		assert.Contains(t, body, "@mona is not authorized")
+		assert.Contains(t, body, "`schemabot stop`")
+	case <-time.After(2 * time.Second):
+		require.FailNow(t, "timed out waiting for unauthorized stop comment")
+	}
+}
+
+type stopActorAuthStorage struct {
+	emptyStorage
+	apply *storage.Apply
+}
+
+func (s *stopActorAuthStorage) Applies() storage.ApplyStore {
+	return &stopActorAuthApplyStore{apply: s.apply}
+}
+
+type stopActorAuthApplyStore struct {
+	storage.ApplyStore
+	apply *storage.Apply
+}
+
+func (s *stopActorAuthApplyStore) GetByApplyIdentifier(_ context.Context, applyIdentifier string) (*storage.Apply, error) {
+	if s.apply == nil || s.apply.ApplyIdentifier != applyIdentifier {
+		return nil, nil
+	}
+	return s.apply, nil
 }
 
 func actorAuthTestConfig(enabled bool, opts ...func(*api.ServerConfig)) *api.ServerConfig {

--- a/pkg/webhook/commands.go
+++ b/pkg/webhook/commands.go
@@ -61,7 +61,7 @@ var commandSpecs = []CommandSpec{
 		SupportsSkipRevert: true, SupportsDeferCutover: true, SupportsAllowUnsafe: true},
 	{Name: action.Unlock},
 	{Name: action.FixLint, SupportsDB: true},
-	{Name: action.Stop, RequiresEnv: true},
+	{Name: action.Stop, RequiresEnv: true, HasApplyID: true},
 	{Name: action.Revert, RequiresEnv: true},
 	{Name: action.SkipRevert, RequiresEnv: true},
 	{Name: action.Cutover, RequiresEnv: true},

--- a/pkg/webhook/commands_test.go
+++ b/pkg/webhook/commands_test.go
@@ -55,7 +55,7 @@ func TestCommandSpecs_FlagsRespected(t *testing.T) {
 			supportsSkipRevert: true, supportsDefer: true, supportsAllowUnsafe: true},
 		{name: action.Unlock},
 		{name: action.FixLint, supportsDB: true},
-		{name: action.Stop, requiresEnv: true},
+		{name: action.Stop, requiresEnv: true, hasApplyID: true},
 		{name: action.Revert, requiresEnv: true},
 		{name: action.SkipRevert, requiresEnv: true},
 		{name: action.Cutover, requiresEnv: true},
@@ -282,9 +282,10 @@ func TestParseCommand(t *testing.T) {
 		},
 		{
 			name: "stop",
-			body: "schemabot stop -e production",
+			body: "schemabot stop apply_abc123 -e production",
 			expected: CommandResult{
 				Action:      "stop",
+				ApplyID:     "apply_abc123",
 				Environment: "production",
 				Found:       true,
 				IsMention:   true,

--- a/pkg/webhook/control.go
+++ b/pkg/webhook/control.go
@@ -1,0 +1,187 @@
+package webhook
+
+import (
+	"fmt"
+
+	"github.com/block/schemabot/pkg/apitypes"
+	ghclient "github.com/block/schemabot/pkg/github"
+	"github.com/block/schemabot/pkg/webhook/action"
+	"github.com/block/schemabot/pkg/webhook/templates"
+)
+
+// handleStopCommand handles the "schemabot stop <apply-id> -e <env>" PR
+// comment command by recording durable stop intent for the scheduler owner.
+func (h *Handler) handleStopCommand(repo string, pr int, installationID int64, requestedBy string, result CommandResult) {
+	ctx, cancel := h.commandContext(commandTimeout)
+	defer cancel()
+
+	if result.ApplyID == "" {
+		h.postComment(repo, pr, installationID, templates.RenderControlMissingApplyID(action.Stop))
+		return
+	}
+	if h.service == nil {
+		h.logger.Error("service not configured for stop PR command",
+			"repo", repo,
+			"pr", pr,
+			"apply_id", result.ApplyID,
+			"environment", result.Environment,
+			"requested_by", requestedBy)
+		h.postCommandError(repo, pr, installationID, action.Stop, result.Environment, requestedBy, "SchemaBot service is not configured for stop commands")
+		return
+	}
+	store := h.service.Storage()
+	if store == nil {
+		h.logger.Error("storage not configured for stop PR command",
+			"repo", repo,
+			"pr", pr,
+			"apply_id", result.ApplyID,
+			"environment", result.Environment,
+			"requested_by", requestedBy)
+		h.postCommandError(repo, pr, installationID, action.Stop, result.Environment, requestedBy, "SchemaBot storage is not configured for stop commands")
+		return
+	}
+	applyStore := store.Applies()
+	if applyStore == nil {
+		h.logger.Error("apply store not configured for stop PR command",
+			"repo", repo,
+			"pr", pr,
+			"apply_id", result.ApplyID,
+			"environment", result.Environment,
+			"requested_by", requestedBy)
+		h.postCommandError(repo, pr, installationID, action.Stop, result.Environment, requestedBy, "SchemaBot apply storage is not configured for stop commands")
+		return
+	}
+	apply, err := applyStore.GetByApplyIdentifier(ctx, result.ApplyID)
+	if err != nil {
+		h.logger.Error("failed to load apply for stop PR command",
+			"repo", repo,
+			"pr", pr,
+			"apply_id", result.ApplyID,
+			"environment", result.Environment,
+			"requested_by", requestedBy,
+			"error", err)
+		h.postCommandError(repo, pr, installationID, action.Stop, result.Environment, requestedBy, "Failed to look up apply: "+err.Error())
+		return
+	}
+	if apply == nil {
+		h.logger.Warn("stop PR command rejected because apply was not found",
+			"repo", repo,
+			"pr", pr,
+			"apply_id", result.ApplyID,
+			"environment", result.Environment,
+			"requested_by", requestedBy)
+		h.postCommandError(repo, pr, installationID, action.Stop, result.Environment, requestedBy, "Apply not found: "+result.ApplyID)
+		return
+	}
+	if apply.Repository != repo || apply.PullRequest != pr {
+		h.logger.Warn("stop PR command rejected because apply belongs to another PR",
+			"repo", repo,
+			"pr", pr,
+			"apply_id", result.ApplyID,
+			"apply_repo", apply.Repository,
+			"apply_pr", apply.PullRequest,
+			"environment", result.Environment,
+			"requested_by", requestedBy)
+		h.postCommandError(repo, pr, installationID, action.Stop, result.Environment, requestedBy, "Apply "+result.ApplyID+" is not associated with this PR")
+		return
+	}
+	if apply.Environment != result.Environment {
+		h.logger.Warn("stop PR command rejected because environment does not match apply",
+			"repo", repo,
+			"pr", pr,
+			"apply_id", result.ApplyID,
+			"apply_environment", apply.Environment,
+			"requested_environment", result.Environment,
+			"requested_by", requestedBy)
+		h.postCommandError(repo, pr, installationID, action.Stop, result.Environment, requestedBy,
+			fmt.Sprintf("Apply %s belongs to environment %q, not %q", result.ApplyID, apply.Environment, result.Environment))
+		return
+	}
+	var client *ghclient.InstallationClient
+	if h.service.Config().PRCommandAuthorizationEnabled() && h.ghClient != nil {
+		var clientErr error
+		client, clientErr = h.ghClient.ForInstallation(installationID)
+		if clientErr != nil {
+			h.logger.Warn("stop PR command blocked because actor authorization client could not be created",
+				"repo", repo,
+				"pr", pr,
+				"apply_id", result.ApplyID,
+				"database", apply.Database,
+				"database_type", apply.DatabaseType,
+				"environment", result.Environment,
+				"requested_by", requestedBy,
+				"error", clientErr)
+			h.postComment(repo, pr, installationID, templates.RenderPRCommandAuthorizationUnavailable(templates.ActorAuthorizationCommentData{
+				RequestedBy: requestedBy,
+				CommandName: action.Stop,
+				Database:    apply.Database,
+				Environment: result.Environment,
+			}))
+			return
+		}
+	}
+	if blocked := h.enforcePRCommandActorAuthorization(ctx, client, repo, pr, installationID, requestedBy, apply.Database, apply.DatabaseType, result.Environment, action.Stop); blocked {
+		return
+	}
+
+	caller := fmt.Sprintf("github:%s@%s#%d", requestedBy, repo, pr)
+	resp, err := h.service.ExecuteStop(ctx, apitypes.ControlRequest{
+		ApplyID:     result.ApplyID,
+		Environment: result.Environment,
+		Caller:      caller,
+	})
+	if err != nil {
+		h.logger.Warn("stop PR command rejected",
+			"repo", repo,
+			"pr", pr,
+			"apply_id", result.ApplyID,
+			"environment", result.Environment,
+			"requested_by", requestedBy,
+			"error", err)
+		h.postCommandError(repo, pr, installationID, action.Stop, result.Environment, requestedBy, err.Error())
+		return
+	}
+	if resp == nil {
+		h.logger.Error("stop PR command returned no response",
+			"repo", repo,
+			"pr", pr,
+			"apply_id", result.ApplyID,
+			"environment", result.Environment,
+			"requested_by", requestedBy)
+		h.postCommandError(repo, pr, installationID, action.Stop, result.Environment, requestedBy, "SchemaBot accepted the stop command but returned no response")
+		return
+	}
+	if !resp.Accepted {
+		detail := resp.ErrorMessage
+		if detail == "" {
+			detail = "Stop was not accepted"
+		}
+		h.logger.Warn("stop PR command was not accepted",
+			"repo", repo,
+			"pr", pr,
+			"apply_id", result.ApplyID,
+			"environment", result.Environment,
+			"requested_by", requestedBy,
+			"error_message", resp.ErrorMessage)
+		h.postCommandError(repo, pr, installationID, action.Stop, result.Environment, requestedBy, detail)
+		return
+	}
+
+	h.logger.Info("stop PR command accepted",
+		"repo", repo,
+		"pr", pr,
+		"apply_id", result.ApplyID,
+		"environment", result.Environment,
+		"requested_by", requestedBy,
+		"status", resp.Status,
+		"stopped_count", resp.StoppedCount,
+		"skipped_count", resp.SkippedCount)
+	h.postComment(repo, pr, installationID, templates.RenderStopCommandAccepted(templates.StopCommandAcceptedData{
+		ApplyID:      result.ApplyID,
+		Environment:  result.Environment,
+		RequestedBy:  requestedBy,
+		Status:       resp.Status,
+		StoppedCount: resp.StoppedCount,
+		SkippedCount: resp.SkippedCount,
+	}))
+}

--- a/pkg/webhook/control_e2e_test.go
+++ b/pkg/webhook/control_e2e_test.go
@@ -1,0 +1,417 @@
+//go:build integration
+
+package webhook
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/block/schemabot/pkg/api"
+	ghclient "github.com/block/schemabot/pkg/github"
+	ternv1 "github.com/block/schemabot/pkg/proto/ternv1"
+	"github.com/block/schemabot/pkg/state"
+	"github.com/block/schemabot/pkg/storage"
+	"github.com/block/schemabot/pkg/storage/mysqlstore"
+	"github.com/block/schemabot/pkg/tern"
+	"github.com/block/spirit/pkg/utils"
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestE2EStopCommandRecordsDurableRequest verifies that a PR comment stop
+// command records durable operator intent, acknowledges duplicate stop requests,
+// and preserves each caller in apply logs for incident triage.
+func TestE2EStopCommandRecordsDurableRequest(t *testing.T) {
+	ctx := t.Context()
+	schemabotDB, err := sql.Open("mysql", e2eSchemabotDSN)
+	require.NoError(t, err)
+	require.NoError(t, schemabotDB.PingContext(ctx))
+
+	store := mysqlstore.New(schemabotDB)
+	applyIdentifier := "apply_abcd1234"
+	database := "stop_pr_comments_db"
+	cleanupStopCommandTestRows(t, schemabotDB, applyIdentifier, database)
+	t.Cleanup(func() {
+		cleanupStopCommandTestRows(t, schemabotDB, applyIdentifier, database)
+		utils.CloseAndLog(schemabotDB)
+	})
+
+	now := time.Now().UTC()
+	apply := &storage.Apply{
+		ApplyIdentifier: applyIdentifier,
+		PlanID:          1,
+		Database:        database,
+		DatabaseType:    storage.DatabaseTypeMySQL,
+		Repository:      "octocat/hello-world",
+		PullRequest:     1,
+		Environment:     "staging",
+		Deployment:      database,
+		Caller:          "github:creator@octocat/hello-world#1",
+		Engine:          storage.EngineSpirit,
+		State:           state.Apply.Running,
+		Options:         []byte("{}"),
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+	tasks := []*storage.Task{
+		{
+			TaskIdentifier: "task_stop_pr_comments_users",
+			PlanID:         1,
+			Database:       database,
+			DatabaseType:   storage.DatabaseTypeMySQL,
+			Engine:         storage.EngineSpirit,
+			Repository:     "octocat/hello-world",
+			PullRequest:    1,
+			Environment:    "staging",
+			State:          state.Task.Running,
+			Namespace:      database,
+			TableName:      "users",
+			DDL:            "ALTER TABLE `users` ADD COLUMN `email` varchar(255)",
+			DDLAction:      "alter",
+			Options:        []byte("{}"),
+			CreatedAt:      now,
+			UpdatedAt:      now,
+		},
+	}
+	applyID, err := store.Applies().CreateWithTasks(ctx, apply, tasks)
+	require.NoError(t, err)
+
+	client, mux := setupGitHubServer(t)
+	comments := make(chan string, 10)
+	reactions := make(chan string, 10)
+	mux.HandleFunc("POST /repos/octocat/hello-world/issues/1/comments", func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Body string `json:"body"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		comments <- body.Body
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": 99})
+	})
+	mux.HandleFunc("POST /repos/octocat/hello-world/issues/comments/42/reactions", func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Content string `json:"content"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		reactions <- body.Content
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": 1})
+	})
+
+	service := apiServiceForStopCommandTest(t, store, database)
+	service.RegisterTernClient(database, "staging", &stopCommandTernClient{remote: true})
+	h := &Handler{
+		service:  service,
+		ghClient: &fakeClientFactory{client: ghclient.NewInstallationClient(client, testLogger())},
+		logger:   testLogger(),
+	}
+
+	postStopCommand(t, h, applyIdentifier, "alice")
+	firstComment := readComment(t, comments)
+	assert.Contains(t, firstComment, "Stop Request Accepted")
+	assert.Contains(t, firstComment, "`"+applyIdentifier+"`")
+	assert.Contains(t, firstComment, "@alice")
+
+	controlReq, err := store.ControlRequests().GetPending(ctx, applyID, storage.ControlOperationStop)
+	require.NoError(t, err)
+	require.NotNil(t, controlReq)
+	assert.Equal(t, "github:alice@octocat/hello-world#1", controlReq.RequestedBy)
+	assert.Equal(t, storage.ControlRequestPending, controlReq.Status)
+
+	postStopCommand(t, h, applyIdentifier, "bob")
+	secondComment := readComment(t, comments)
+	assert.Contains(t, secondComment, "Stop was already requested")
+	assert.Contains(t, secondComment, "@bob")
+
+	logs, err := store.ApplyLogs().List(ctx, storage.ApplyLogFilter{ApplyID: applyID, Limit: 20})
+	require.NoError(t, err)
+	assert.True(t, applyLogContains(logs, "Stop requested by user (caller: github:alice@octocat/hello-world#1)"))
+	assert.True(t, applyLogContains(logs, "Stop requested by user while stop request already pending (caller: github:bob@octocat/hello-world#1)"))
+
+	assertReactionEventually(t, reactions)
+	assertReactionEventually(t, reactions)
+}
+
+// TestE2EStopCommandStopsDeferredCutoverLocalApply verifies that a PR comment
+// stop command stops an active local schema change that is waiting for deferred
+// cutover instead of issuing cutover.
+func TestE2EStopCommandStopsDeferredCutoverLocalApply(t *testing.T) {
+	ctx := t.Context()
+	schemabotDB, err := sql.Open("mysql", e2eSchemabotDSN)
+	require.NoError(t, err)
+	require.NoError(t, schemabotDB.PingContext(ctx))
+
+	store := mysqlstore.New(schemabotDB)
+	applyIdentifier := "apply_bcde2345"
+	database := "stop_pr_comments_active_db"
+	cleanupStopCommandTestRows(t, schemabotDB, applyIdentifier, database)
+	t.Cleanup(func() {
+		cleanupStopCommandTestRows(t, schemabotDB, applyIdentifier, database)
+		utils.CloseAndLog(schemabotDB)
+	})
+
+	applyID := createStopCommandApply(t, store, applyIdentifier, database)
+	storedApply, err := store.Applies().GetByApplyIdentifier(ctx, applyIdentifier)
+	require.NoError(t, err)
+	require.NotNil(t, storedApply)
+	storedApply.State = state.Apply.WaitingForCutover
+	storedApply.SetOptions(storage.ApplyOptions{DeferCutover: true})
+	require.NoError(t, store.Applies().Update(ctx, storedApply))
+	storedTasks, err := store.Tasks().GetByApplyID(ctx, applyID)
+	require.NoError(t, err)
+	require.Len(t, storedTasks, 1)
+	storedTasks[0].State = state.Task.WaitingForCutover
+	storedTasks[0].UpdatedAt = time.Now().UTC()
+	require.NoError(t, store.Tasks().Update(ctx, storedTasks[0]))
+
+	client, mux := setupGitHubServer(t)
+	comments := make(chan string, 10)
+	reactions := make(chan string, 10)
+	mux.HandleFunc("POST /repos/octocat/hello-world/issues/1/comments", func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Body string `json:"body"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		comments <- body.Body
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": 99})
+	})
+	mux.HandleFunc("POST /repos/octocat/hello-world/issues/comments/42/reactions", func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Content string `json:"content"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		reactions <- body.Content
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": 1})
+	})
+
+	service := apiServiceForStopCommandTest(t, store, database)
+	localClient, err := tern.NewLocalClient(tern.LocalConfig{
+		Database:  database,
+		Type:      storage.DatabaseTypeMySQL,
+		TargetDSN: e2eTargetDSN,
+	}, store, testLogger())
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		utils.CloseAndLog(localClient)
+	})
+	service.RegisterTernClient(database, "staging", localClient)
+	h := &Handler{
+		service:  service,
+		ghClient: &fakeClientFactory{client: ghclient.NewInstallationClient(client, testLogger())},
+		logger:   testLogger(),
+	}
+
+	postStopCommand(t, h, applyIdentifier, "alice")
+	comment := readComment(t, comments)
+	assert.Contains(t, comment, "Stop Request Accepted")
+	assert.Contains(t, comment, "@alice")
+
+	storedApply, err = store.Applies().GetByApplyIdentifier(ctx, applyIdentifier)
+	require.NoError(t, err)
+	require.NotNil(t, storedApply)
+	assert.Equal(t, state.Apply.Stopped, storedApply.State)
+	assert.True(t, storedApply.GetOptions().DeferCutover)
+	storedTasks, err = store.Tasks().GetByApplyID(ctx, applyID)
+	require.NoError(t, err)
+	require.Len(t, storedTasks, 1)
+	assert.Equal(t, state.Task.Stopped, storedTasks[0].State)
+	pendingStop, err := store.ControlRequests().GetPending(ctx, applyID, storage.ControlOperationStop)
+	require.NoError(t, err)
+	assert.Nil(t, pendingStop)
+	assertReactionEventually(t, reactions)
+}
+
+func apiServiceForStopCommandTest(t *testing.T, store storage.Storage, database string) *api.Service {
+	t.Helper()
+	return api.New(store, &api.ServerConfig{
+		Databases: map[string]api.DatabaseConfig{
+			database: {
+				Type: storage.DatabaseTypeMySQL,
+				Environments: map[string]api.EnvironmentConfig{
+					"staging": {},
+				},
+			},
+		},
+	}, nil, testLogger())
+}
+
+func createStopCommandApply(t *testing.T, store storage.Storage, applyIdentifier, database string) int64 {
+	t.Helper()
+	now := time.Now().UTC()
+	apply := &storage.Apply{
+		ApplyIdentifier: applyIdentifier,
+		PlanID:          1,
+		Database:        database,
+		DatabaseType:    storage.DatabaseTypeMySQL,
+		Repository:      "octocat/hello-world",
+		PullRequest:     1,
+		Environment:     "staging",
+		Deployment:      database,
+		Caller:          "github:creator@octocat/hello-world#1",
+		Engine:          storage.EngineSpirit,
+		State:           state.Apply.Running,
+		Options:         []byte("{}"),
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+	tasks := []*storage.Task{
+		{
+			TaskIdentifier: "task_" + applyIdentifier,
+			PlanID:         1,
+			Database:       database,
+			DatabaseType:   storage.DatabaseTypeMySQL,
+			Engine:         storage.EngineSpirit,
+			Repository:     "octocat/hello-world",
+			PullRequest:    1,
+			Environment:    "staging",
+			State:          state.Task.Running,
+			Namespace:      database,
+			TableName:      "users",
+			DDL:            "ALTER TABLE `users` ADD COLUMN `email` varchar(255)",
+			DDLAction:      "alter",
+			Options:        []byte("{}"),
+			CreatedAt:      now,
+			UpdatedAt:      now,
+		},
+	}
+	applyID, err := store.Applies().CreateWithTasks(t.Context(), apply, tasks)
+	require.NoError(t, err)
+	return applyID
+}
+
+func cleanupStopCommandTestRows(t *testing.T, db *sql.DB, applyIdentifier, database string) {
+	t.Helper()
+	cleanupCtx := context.WithoutCancel(t.Context())
+	statements := []string{
+		"DELETE al FROM `apply_logs` al JOIN `applies` a ON al.`apply_id` = a.`id` WHERE a.`apply_identifier` = ?",
+		"DELETE acr FROM `apply_control_requests` acr JOIN `applies` a ON acr.`apply_id` = a.`id` WHERE a.`apply_identifier` = ?",
+		"DELETE FROM `tasks` WHERE `database_name` = ?",
+		"DELETE FROM `applies` WHERE `apply_identifier` = ?",
+	}
+	args := [][]any{{applyIdentifier}, {applyIdentifier}, {database}, {applyIdentifier}}
+	for i, stmt := range statements {
+		_, err := db.ExecContext(cleanupCtx, stmt, args[i]...)
+		require.NoError(t, err)
+	}
+}
+
+func postStopCommand(t *testing.T, h *Handler, applyIdentifier, user string) {
+	t.Helper()
+	req := buildWebhookRequest(t, webhookPayloadOpts{
+		comment:   "schemabot stop " + applyIdentifier + " -e staging",
+		userLogin: user,
+		isPR:      true,
+	}, nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), "stop started")
+}
+
+func readComment(t *testing.T, comments chan string) string {
+	t.Helper()
+	select {
+	case body := <-comments:
+		return body
+	case <-time.After(webhookIntegrationCheckRunDeadline):
+		t.Fatal("timed out waiting for stop command comment")
+		return ""
+	}
+}
+
+func assertReactionEventually(t *testing.T, reactions chan string) {
+	t.Helper()
+	select {
+	case reaction := <-reactions:
+		assert.Equal(t, "eyes", reaction)
+	case <-time.After(webhookIntegrationCheckRunDeadline):
+		t.Fatal("timed out waiting for acknowledgment reaction")
+	}
+}
+
+func applyLogContains(logs []*storage.ApplyLog, want string) bool {
+	for _, log := range logs {
+		if strings.Contains(log.Message, want) {
+			return true
+		}
+	}
+	return false
+}
+
+type stopCommandTernClient struct {
+	tern.Client
+	mu        sync.Mutex
+	remote    bool
+	stopCalls int
+	onStop    func(context.Context, *ternv1.StopRequest) (*ternv1.StopResponse, error)
+}
+
+func (c *stopCommandTernClient) Plan(context.Context, *ternv1.PlanRequest) (*ternv1.PlanResponse, error) {
+	return nil, nil
+}
+
+func (c *stopCommandTernClient) Apply(context.Context, *ternv1.ApplyRequest) (*ternv1.ApplyResponse, error) {
+	return nil, nil
+}
+
+func (c *stopCommandTernClient) Progress(context.Context, *ternv1.ProgressRequest) (*ternv1.ProgressResponse, error) {
+	return nil, nil
+}
+
+func (c *stopCommandTernClient) Cutover(context.Context, *ternv1.CutoverRequest) (*ternv1.CutoverResponse, error) {
+	return nil, nil
+}
+
+func (c *stopCommandTernClient) Stop(ctx context.Context, req *ternv1.StopRequest) (*ternv1.StopResponse, error) {
+	c.mu.Lock()
+	c.stopCalls++
+	c.mu.Unlock()
+	if c.onStop != nil {
+		return c.onStop(ctx, req)
+	}
+	return &ternv1.StopResponse{Accepted: true, StoppedCount: 1}, nil
+}
+
+func (c *stopCommandTernClient) Start(context.Context, *ternv1.StartRequest) (*ternv1.StartResponse, error) {
+	return nil, nil
+}
+
+func (c *stopCommandTernClient) Volume(context.Context, *ternv1.VolumeRequest) (*ternv1.VolumeResponse, error) {
+	return nil, nil
+}
+
+func (c *stopCommandTernClient) Revert(context.Context, *ternv1.RevertRequest) (*ternv1.RevertResponse, error) {
+	return nil, nil
+}
+
+func (c *stopCommandTernClient) SkipRevert(context.Context, *ternv1.SkipRevertRequest) (*ternv1.SkipRevertResponse, error) {
+	return nil, nil
+}
+
+func (c *stopCommandTernClient) RollbackPlan(context.Context, string) (*ternv1.PlanResponse, error) {
+	return nil, nil
+}
+
+func (c *stopCommandTernClient) Health(context.Context) error { return nil }
+
+func (c *stopCommandTernClient) ResumeApply(context.Context, *storage.Apply) error { return nil }
+
+func (c *stopCommandTernClient) Endpoint() string { return "stop-command-test" }
+
+func (c *stopCommandTernClient) IsRemote() bool { return c.remote }
+
+func (c *stopCommandTernClient) SetPendingObserver(tern.ProgressObserver) {}
+
+func (c *stopCommandTernClient) SetObserver(int64, tern.ProgressObserver) {}
+
+func (c *stopCommandTernClient) Close() error { return nil }

--- a/pkg/webhook/handler_test.go
+++ b/pkg/webhook/handler_test.go
@@ -226,6 +226,29 @@ func TestWebhookYesFlagRejectedOnNonApply(t *testing.T) {
 	}
 }
 
+func TestWebhookStopMissingApplyID(t *testing.T) {
+	h, comments, _ := newTestHandler(t)
+
+	req := buildWebhookRequest(t, webhookPayloadOpts{
+		comment: "schemabot stop -e staging",
+		isPR:    true,
+	}, nil)
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), "stop started")
+
+	select {
+	case body := <-comments:
+		assert.Contains(t, body, "Missing Apply ID")
+		assert.Contains(t, body, "schemabot stop <apply-id> -e <environment>")
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for missing apply ID comment")
+	}
+}
+
 func TestWebhookBotCommentIgnored(t *testing.T) {
 	h, comments, _ := newTestHandler(t)
 
@@ -345,13 +368,13 @@ func TestWebhookEyesReaction(t *testing.T) {
 func TestWebhookPhase2CommandNotYetAvailable(t *testing.T) {
 	h, comments, _ := newTestHandler(t)
 
-	// Test remaining Phase 2 commands (apply, apply-confirm, unlock are now implemented)
+	// Test remaining Phase 2 commands (apply, apply-confirm, unlock, and stop are now implemented)
 	cmds := []struct {
 		comment string
 		action  string
 	}{
-		{"schemabot stop -e staging", "stop"},
 		{"schemabot revert -e staging", "revert"},
+		{"schemabot skip-revert -e staging", "skip-revert"},
 		{"schemabot cutover -e staging", "cutover"},
 	}
 

--- a/pkg/webhook/issue_comment.go
+++ b/pkg/webhook/issue_comment.go
@@ -227,8 +227,13 @@ func (h *Handler) handleIssueComment(w http.ResponseWriter, body []byte) {
 			h.handleRollbackConfirmCommand(repo, pr, result.Environment, result.Database, installationID, requestedBy, result)
 		})
 		h.writeJSON(w, http.StatusOK, map[string]string{"message": "rollback-confirm started"})
+	case action.Stop:
+		h.goSafe(repo, pr, installationID, func() {
+			h.handleStopCommand(repo, pr, installationID, requestedBy, result)
+		})
+		h.writeJSON(w, http.StatusOK, map[string]string{"message": "stop started"})
 	// Phase 2 commands — acknowledge but not yet implemented
-	case action.Stop, action.Revert, action.SkipRevert, action.Cutover:
+	case action.Revert, action.SkipRevert, action.Cutover:
 		h.postComment(repo, pr, installationID,
 			templates.RenderCommandNotYetAvailable(result.Action, result.Environment))
 		h.writeJSON(w, http.StatusOK, map[string]string{

--- a/pkg/webhook/templates/issue_comment.go
+++ b/pkg/webhook/templates/issue_comment.go
@@ -32,6 +32,45 @@ func RenderUnsupportedAutoConfirm(action string) string {
 	return fmt.Sprintf("The `-y` flag is not supported for `%s`.", action)
 }
 
+// StopCommandAcceptedData contains data for a PR comment stop acknowledgement.
+type StopCommandAcceptedData struct {
+	ApplyID      string
+	Environment  string
+	RequestedBy  string
+	Status       string
+	StoppedCount int64
+	SkippedCount int64
+}
+
+// RenderControlMissingApplyID renders the message posted when an apply-scoped
+// control command is invoked without the required apply ID.
+func RenderControlMissingApplyID(action string) string {
+	return fmt.Sprintf("## Missing Apply ID\n\n"+
+		"Usage: `schemabot %s <apply-id> -e <environment>`\n\n"+
+		"Use `schemabot status -e <environment>` to find the apply ID.", action)
+}
+
+// RenderStopCommandAccepted renders the acknowledgement posted when a PR
+// comment stop command records durable stop intent.
+func RenderStopCommandAccepted(data StopCommandAcceptedData) string {
+	statusLine := "Stop request accepted. SchemaBot will stop this schema change; status remains available from the PR progress comment or CLI."
+	if data.Status == "already_requested" {
+		statusLine = "Stop was already requested. SchemaBot will keep the existing stop request pending until the scheduler owner finishes it."
+	}
+
+	body := "## Stop Request Accepted\n\n" +
+		fmt.Sprintf("**Apply**: `%s`\n", data.ApplyID) +
+		fmt.Sprintf("**Environment**: `%s`\n", data.Environment)
+	if data.RequestedBy != "" {
+		body += fmt.Sprintf("**Requested by**: @%s\n", data.RequestedBy)
+	}
+	body += "\n" + statusLine + "\n"
+	if data.StoppedCount > 0 || data.SkippedCount > 0 {
+		body += fmt.Sprintf("\n**Tasks selected for stop**: %d stopped, %d skipped.\n", data.StoppedCount, data.SkippedCount)
+	}
+	return body
+}
+
 // RenderCommandNotYetAvailable renders the acknowledgement posted when a
 // recognised but not-yet-implemented PR comment command is invoked. It points
 // the user at the CLI fallback for the same action.

--- a/pkg/webhook/templates/issue_comment_test.go
+++ b/pkg/webhook/templates/issue_comment_test.go
@@ -34,6 +34,37 @@ func TestRenderUnsupportedAutoConfirm(t *testing.T) {
 	assert.Equal(t, "The `-y` flag is not supported for `plan`.", rendered)
 }
 
+func TestRenderControlMissingApplyID(t *testing.T) {
+	rendered := RenderControlMissingApplyID("stop")
+	assert.Contains(t, rendered, "Missing Apply ID")
+	assert.Contains(t, rendered, "schemabot stop <apply-id> -e <environment>")
+	assert.Contains(t, rendered, "schemabot status")
+}
+
+func TestRenderStopCommandAccepted(t *testing.T) {
+	rendered := RenderStopCommandAccepted(StopCommandAcceptedData{
+		ApplyID:      "apply_abc123",
+		Environment:  "staging",
+		RequestedBy:  "alice",
+		StoppedCount: 1,
+		SkippedCount: 2,
+	})
+	assert.Contains(t, rendered, "Stop Request Accepted")
+	assert.Contains(t, rendered, "`apply_abc123`")
+	assert.Contains(t, rendered, "`staging`")
+	assert.Contains(t, rendered, "@alice")
+	assert.Contains(t, rendered, "1 stopped, 2 skipped")
+}
+
+func TestRenderStopCommandAcceptedAlreadyRequested(t *testing.T) {
+	rendered := RenderStopCommandAccepted(StopCommandAcceptedData{
+		ApplyID:     "apply_abc123",
+		Environment: "staging",
+		Status:      "already_requested",
+	})
+	assert.Contains(t, rendered, "Stop was already requested")
+}
+
 func TestRenderCommandNotYetAvailable(t *testing.T) {
 	rendered := RenderCommandNotYetAvailable("stop", "staging")
 	assert.Contains(t, rendered, "`stop` command is not yet available")


### PR DESCRIPTION
## Why
Operators should be able to stop an active SchemaBot schema change from the same PR comment workflow they use to apply it, without needing to switch to the CLI during an incident.

## What
- Add `schemabot stop <apply-id> -e <env>` handling for PR comments
- Reuse the durable stop API path so PR comments and CLI stop requests share the same safety behavior
- Enforce configured PR command actor authorization before accepting stop requests
- Validate apply ownership against the PR and preserve caller visibility in apply logs

```diagram
╭────────────╮     ╭──────────────╮     ╭──────────────────╮
│ PR comment │────▶│ webhook stop │────▶│ durable stop req │
╰────────────╯     ╰──────────────╯     ╰────────┬─────────╯
                                                  │
                                                  ▼
                                        ╭──────────────────╮
                                        │ apply owner stop │
                                        ╰──────────────────╯
```

## Risk Assessment
Medium — this adds a new GitHub-facing control path, but it delegates to the existing stop implementation and validates both actor authorization and target apply ownership before accepting the request.

Generated with Amp
