### PR TITLE
fix(localscale): harden reset state cleanup

### DIFF
--- a/e2e/local/helpers_test.go
+++ b/e2e/local/helpers_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -278,8 +279,13 @@ func ensureNoActiveChange(t *testing.T, endpoint string) {
 
 func clearSchemaBotState(t *testing.T) {
 	t.Helper()
-	clearSchemaBotStateImpl()
+	clearSchemaBotStorage(t)
 	resetLocalScaleState(t)
+}
+
+func clearSchemaBotStorage(t *testing.T) {
+	t.Helper()
+	clearSchemaBotStateImpl()
 }
 
 func clearSchemaBotStateImpl() {
@@ -329,49 +335,51 @@ func markApplyHeartbeatStale(t *testing.T, applyID string) {
 	require.Equal(t, int64(1), rowsAffected, "expected to mark one apply heartbeat stale")
 }
 
-// localscaleMetadataQuery sends a query to the LocalScale metadata endpoint.
-// Returns an error instead of failing — callers decide how to handle.
-func localscaleMetadataQuery(query string) error {
-	localscaleURL := os.Getenv("LOCALSCALE_URL")
-	if localscaleURL == "" {
-		return fmt.Errorf("LOCALSCALE_URL not set")
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	body := strings.NewReader(fmt.Sprintf(`{"query":%q}`, query))
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, localscaleURL+"/admin/metadata-query", body)
-	if err != nil {
-		return fmt.Errorf("create request: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/json")
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return fmt.Errorf("execute request: %w", err)
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("unexpected status %d", resp.StatusCode)
-	}
-	return nil
-}
-
-const resetDeployRequestsQuery = "UPDATE localscale_deploy_requests SET deployment_state = 'complete', deployed = FALSE, cancelled = TRUE WHERE deployment_state != 'complete'"
-
-// resetLocalScaleState clears LocalScale deploy request state via the metadata-query
-// admin endpoint. Marks all deploy requests as closed (not DELETE — preserves the
-// auto-increment counter so new deploy requests get unique numbers, which ensures
-// unique migration_context values for SHOW VITESS_MIGRATIONS discovery).
+// resetLocalScaleState resets LocalScale through its admin API so active deploy
+// execution and Vitess state are cancelled before metadata is cleared.
 func resetLocalScaleState(t *testing.T) {
 	t.Helper()
-	err := localscaleMetadataQuery(resetDeployRequestsQuery)
-	require.NoError(t, err, "reset LocalScale deploy requests")
+
+	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
+	defer cancel()
+	err := resetLocalScaleStateWithContext(ctx)
+	require.NoError(t, err, "reset LocalScale state")
 }
 
 // resetLocalScaleStateOrFatal is the TestMain variant (no *testing.T).
 func resetLocalScaleStateOrFatal() {
-	if err := localscaleMetadataQuery(resetDeployRequestsQuery); err != nil {
-		log.Fatalf("reset LocalScale deploy requests: %v", err)
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	err := resetLocalScaleStateWithContext(ctx)
+	cancel()
+	if err != nil {
+		log.Fatalf("reset LocalScale state: %v", err)
 	}
+}
+
+func resetLocalScaleStateWithContext(ctx context.Context) error {
+	localscaleURL := os.Getenv("LOCALSCALE_URL")
+	if localscaleURL == "" {
+		return fmt.Errorf("LOCALSCALE_URL not set")
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, localscaleURL+"/admin/reset-state", strings.NewReader("{}"))
+	if err != nil {
+		return fmt.Errorf("create reset request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("execute reset request: %w", err)
+	}
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("read reset response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("reset state status %d: %s", resp.StatusCode, strings.TrimSpace(string(respBody)))
+	}
+	return nil
 }
 
 func uniqueTableName(prefix string) string {

--- a/e2e/local/vitess_test.go
+++ b/e2e/local/vitess_test.go
@@ -197,7 +197,7 @@ func vitessRestoreBaseSchema(t *testing.T, _ string) {
 		t.Logf("vitessRestoreBaseSchema: reset-state failed (non-fatal): %v", err)
 	}
 	t.Logf("vitessRestoreBaseSchema: resetState done (elapsed=%s)", time.Since(start))
-	clearSchemaBotState(t)
+	clearSchemaBotStorage(t)
 	t.Logf("vitessRestoreBaseSchema: clearState done (elapsed=%s)", time.Since(start))
 	vitessCleanupSchema(t)
 	t.Logf("vitessRestoreBaseSchema: cleanup done (elapsed=%s)", time.Since(start))
@@ -1654,7 +1654,7 @@ func TestVitess_Apply_BranchReuse(t *testing.T) {
 	assert.True(t, foundRefresh, "expected 'Refreshing schema for branch' in apply logs")
 
 	// Second apply on the same branch: add another column
-	clearSchemaBotState(t)
+	clearSchemaBotStorage(t)
 	col2 := fmt.Sprintf("reuse_col2_%d", time.Now().UnixMilli()%100000)
 	schemaDir2 := newVitessSchemaDir(t, vitessSchemaWithOverrides(map[string]string{
 		"testapp_sharded/users.sql": fmt.Sprintf(`CREATE TABLE `+"`users`"+` (

--- a/pkg/localscale/handlers_deploy.go
+++ b/pkg/localscale/handlers_deploy.go
@@ -235,14 +235,19 @@ func (s *Server) handleDeployDeployRequest(w http.ResponseWriter, r *http.Reques
 	resp := deployResponse(number, branch, dr.Submitting)
 	resp["approved"] = true
 	resp["html_url"] = fmt.Sprintf("%s/%s/%s/deploy-requests/%d", s.baseURL, org, database, number)
+
+	ref := deployRequest{org: org, database: database, number: number}
+	execCtx, unregisterDeploy := s.registerActiveDeployExecution(ref)
+
 	s.writeJSON(w, resp)
 
 	// Background goroutine: apply VSchema, snapshot schema, submit DDL, advance state.
 	instantDDL := body.InstantDDL
 	s.wg.Go(func() {
+		defer unregisterDeploy()
 		params := deployExecParams{
 			backend:          backend,
-			ref:              deployRequest{org: org, database: database, number: number},
+			ref:              ref,
 			hasVSchema:       hasVSchema,
 			vschemaData:      vschemaDataSQL.String,
 			totalDDL:         totalDDL,
@@ -251,7 +256,11 @@ func (s *Server) handleDeployDeployRequest(w http.ResponseWriter, r *http.Reques
 			migrationContext: migrationContext,
 			autoCutover:      autoCutover,
 		}
-		if err := s.executeDeployRequest(s.shutdownCtx, params); err != nil {
+		if err := s.executeDeployRequest(execCtx, params); err != nil {
+			if execCtx.Err() != nil {
+				s.logger.Info("deploy execution cancelled", "number", number, "error", err)
+				return
+			}
 			s.logger.Error("deploy execution failed", "number", number, "error", err)
 			if stateErr := s.updateDeployState(s.shutdownCtx, params.ref, dr.Error); stateErr != nil {
 				s.logger.Error("failed to set error state", "number", number, "error", stateErr)

--- a/pkg/localscale/server.go
+++ b/pkg/localscale/server.go
@@ -86,8 +86,11 @@ type Server struct {
 	processorCancel      context.CancelFunc
 	processorDone        chan struct{}
 	wg                   sync.WaitGroup // tracks background goroutines
-	revertWindowDuration time.Duration  // how long the revert window stays open after deploy completes
-	defaultThrottleRatio float64        // default throttle ratio applied to new deploys (0.0 = no throttle, max 0.95)
+	activeDeployMu       sync.Mutex
+	activeDeploySeq      uint64
+	activeDeployCancels  map[deployRequest]activeDeployExecution
+	revertWindowDuration time.Duration // how long the revert window stays open after deploy completes
+	defaultThrottleRatio float64       // default throttle ratio applied to new deploys (0.0 = no throttle, max 0.95)
 
 	// proxies maps branch name → TCP proxy. Each proxy gives a branch its own
 	// network endpoint by rewriting MySQL database names in the handshake.
@@ -330,6 +333,7 @@ func New(ctx context.Context, cfg Config) (*Server, error) {
 		deployRequestDelay:    cfg.DeployRequestDelay,
 		processorTickInterval: cfg.ProcessorTickInterval,
 		proxies:               make(map[string]*branchProxy),
+		activeDeployCancels:   make(map[deployRequest]activeDeployExecution),
 		proxyHost:             proxyHost,
 		proxyAdvertiseHost:    proxyAdvertiseHost,
 		portAlloc:             pa,
@@ -509,46 +513,70 @@ func (s *Server) applyVSchemaInternal(ctx context.Context, backend *databaseBack
 	return nil
 }
 
-// ResetState cancels all running Vitess migrations, waits for them to reach
+// ResetState cancels all running Vitess schema changes, waits for them to reach
 // terminal state, and truncates metadata tables. This is used by tests to clean
 // up stale state from previous test runs (since vtcombo persists data).
 func (s *Server) ResetState(ctx context.Context) error {
-	// Cancel all running Vitess migrations across all backends.
+	s.logger.Info("resetting LocalScale state")
+	if err := s.cancelActiveDeployExecutions(ctx); err != nil {
+		return fmt.Errorf("cancel active deploy executions: %w", err)
+	}
+	s.closeBranchProxies()
+
+	for _, backend := range s.backends {
+		for keyspace := range backend.vtgateDBs {
+			if err := s.forEachShard(ctx, backend, keyspace, func(conn *sql.Conn) error {
+				if _, err := conn.ExecContext(ctx, "ALTER VITESS_MIGRATION UNTHROTTLE ALL"); err != nil {
+					return fmt.Errorf("unthrottle Vitess schema changes: %w", err)
+				}
+				return nil
+			}); err != nil {
+				return fmt.Errorf("unthrottle schema changes for %s: %w", keyspace, err)
+			}
+		}
+	}
+
+	// Cancel all running Vitess schema changes across all backends.
 	// Uses shard-targeted connections because ALTER VITESS_MIGRATION CANCEL ALL
 	// fails on keyspace-scoped connections for multi-shard keyspaces.
 	for _, backend := range s.backends {
 		for keyspace := range backend.vtgateDBs {
 			if err := s.forEachShard(ctx, backend, keyspace, func(conn *sql.Conn) error {
 				if _, err := conn.ExecContext(ctx, "ALTER VITESS_MIGRATION CANCEL ALL"); err != nil {
-					return fmt.Errorf("cancel all vitess migrations: %w", err)
+					return fmt.Errorf("cancel all Vitess schema changes: %w", err)
 				}
 				return nil
 			}); err != nil {
-				s.logger.Warn("cancel all migrations failed", "keyspace", keyspace, "error", err)
+				s.logger.Warn("cancel all Vitess schema changes failed", "keyspace", keyspace, "error", err)
 			}
 		}
 	}
-	// Wait for all migrations to reach terminal state so table locks are released.
+	// Wait for all Vitess schema changes to reach terminal state so table locks are released.
 	// Uses shard-targeted connections for the same reason as above.
-	// Short timeout: after CANCEL ALL, migrations should transition quickly.
+	// Short timeout: after CANCEL ALL, schema changes should transition quickly.
 	ticker := time.NewTicker(100 * time.Millisecond)
 	defer ticker.Stop()
 	timer := time.NewTimer(10 * time.Second)
 	defer timer.Stop()
+	var lastCheckErr error
 	for {
 		allTerminal := true
 		for _, backend := range s.backends {
 			for keyspace := range backend.vtgateDBs {
-				_ = s.forEachShard(ctx, backend, keyspace, func(conn *sql.Conn) error {
+				if err := s.forEachShard(ctx, backend, keyspace, func(conn *sql.Conn) error {
 					rows, err := conn.QueryContext(ctx, "SHOW VITESS_MIGRATIONS")
 					if err != nil {
-						s.logger.Warn("show migrations failed", "keyspace", keyspace, "error", err)
+						s.logger.Warn("show Vitess schema changes failed", "keyspace", keyspace, "error", err)
+						allTerminal = false
+						lastCheckErr = fmt.Errorf("show Vitess schema changes for %s: %w", keyspace, err)
 						return nil // non-fatal, continue checking other shards
 					}
 					rowMaps, err := scanDynamicRows(rows)
 					utils.CloseAndLog(rows)
 					if err != nil {
-						s.logger.Warn("scan migrations failed", "keyspace", keyspace, "error", err)
+						s.logger.Warn("scan Vitess schema changes failed", "keyspace", keyspace, "error", err)
+						allTerminal = false
+						lastCheckErr = fmt.Errorf("scan Vitess schema changes for %s: %w", keyspace, err)
 						return nil
 					}
 					for _, colMap := range rowMaps {
@@ -561,7 +589,11 @@ func (s *Server) ResetState(ctx context.Context) error {
 						}
 					}
 					return nil
-				})
+				}); err != nil {
+					s.logger.Warn("check Vitess schema changes failed", "keyspace", keyspace, "error", err)
+					allTerminal = false
+					lastCheckErr = fmt.Errorf("check Vitess schema changes for %s: %w", keyspace, err)
+				}
 			}
 		}
 		if allTerminal {
@@ -569,14 +601,24 @@ func (s *Server) ResetState(ctx context.Context) error {
 		}
 		select {
 		case <-ctx.Done():
-			return fmt.Errorf("waiting for migrations to cancel: %w", ctx.Err())
+			return fmt.Errorf("waiting for schema changes to cancel: %w; %s", ctx.Err(), s.resetStateDiagnosticsWithLastError(ctx, lastCheckErr))
 		case <-timer.C:
-			return fmt.Errorf("timed out waiting for migrations to reach terminal state")
+			return fmt.Errorf("timed out waiting for schema changes to reach terminal state; %s", s.resetStateDiagnosticsWithLastError(ctx, lastCheckErr))
 		case <-ticker.C:
 		}
 	}
-	// Shut down all branch proxies.
-	s.closeAllProxies()
+	for _, backend := range s.backends {
+		for keyspace := range backend.vtgateDBs {
+			if err := s.forEachShard(ctx, backend, keyspace, func(conn *sql.Conn) error {
+				if _, err := conn.ExecContext(ctx, "ALTER VITESS_MIGRATION CLEANUP ALL"); err != nil {
+					return fmt.Errorf("cleanup terminal Vitess schema changes: %w", err)
+				}
+				return nil
+			}); err != nil {
+				return fmt.Errorf("cleanup terminal schema changes for %s: %w", keyspace, err)
+			}
+		}
+	}
 
 	// Drop all branch databases (branch_*) from the metadata MySQL.
 	// Branch databases persist across container reuse and contain stale schema
@@ -610,7 +652,159 @@ func (s *Server) ResetState(ctx context.Context) error {
 		"INSERT IGNORE INTO localscale_branches (org, database_name, name, parent_branch, ready) VALUES ('', '', 'main', '', TRUE)"); err != nil {
 		return fmt.Errorf("insert default branch: %w", err)
 	}
+	s.logger.Info("reset LocalScale state complete")
 	return nil
+}
+
+func (s *Server) registerActiveDeployExecution(ref deployRequest) (context.Context, func()) {
+	ctx, cancel := context.WithCancel(s.shutdownCtx)
+	done := make(chan struct{})
+
+	s.activeDeployMu.Lock()
+	s.activeDeploySeq++
+	id := s.activeDeploySeq
+	s.activeDeployCancels[ref] = activeDeployExecution{id: id, cancel: cancel, done: done}
+	s.activeDeployMu.Unlock()
+
+	return ctx, func() {
+		defer close(done)
+		s.activeDeployMu.Lock()
+		if current, ok := s.activeDeployCancels[ref]; ok && current.id == id {
+			delete(s.activeDeployCancels, ref)
+		} else {
+			s.logger.Info("deploy execution already replaced before unregister", "number", ref.number, "org", ref.org, "database", ref.database)
+		}
+		s.activeDeployMu.Unlock()
+		cancel()
+	}
+}
+
+func (s *Server) cancelActiveDeployExecutions(ctx context.Context) error {
+	s.activeDeployMu.Lock()
+	executions := make([]activeDeployExecution, 0, len(s.activeDeployCancels))
+	for _, execution := range s.activeDeployCancels {
+		executions = append(executions, execution)
+	}
+	s.activeDeployMu.Unlock()
+
+	for _, execution := range executions {
+		execution.cancel()
+	}
+	if len(executions) == 0 {
+		s.logger.Debug("no active deploy executions to cancel for reset")
+		return nil
+	}
+	s.logger.Info("cancelled active deploy executions for reset", "count", len(executions))
+
+	timer := time.NewTimer(5 * time.Second)
+	defer timer.Stop()
+	for i, execution := range executions {
+		select {
+		case <-execution.done:
+		case <-ctx.Done():
+			s.logger.Warn("reset cancelled while waiting for deploy execution to stop", "remaining", len(executions)-i, "error", ctx.Err())
+			return fmt.Errorf("wait for active deploy execution to stop: %w", ctx.Err())
+		case <-timer.C:
+			s.logger.Warn("reset timed out waiting for deploy execution to stop", "remaining", len(executions)-i)
+			return fmt.Errorf("timed out waiting for active deploy execution to stop")
+		}
+	}
+	return nil
+}
+
+type activeDeployExecution struct {
+	id     uint64
+	cancel context.CancelFunc
+	done   chan struct{}
+}
+
+func (s *Server) resetStateDiagnosticsWithLastError(ctx context.Context, lastCheckErr error) string {
+	diagCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 2*time.Second)
+	defer cancel()
+
+	var parts []string
+	if lastCheckErr != nil {
+		parts = append(parts, "last status check error: "+lastCheckErr.Error())
+	}
+	deployRows, err := s.activeDeployRequestDiagnostics(diagCtx)
+	if err != nil {
+		parts = append(parts, "active deploy requests unavailable: "+err.Error())
+	} else if len(deployRows) > 0 {
+		parts = append(parts, "active deploy requests: "+strings.Join(deployRows, "; "))
+	}
+
+	schemaChangeRows, err := s.vitessSchemaChangeDiagnostics(diagCtx)
+	if err != nil {
+		parts = append(parts, "Vitess schema changes unavailable: "+err.Error())
+	} else if len(schemaChangeRows) > 0 {
+		parts = append(parts, "Vitess schema changes: "+strings.Join(schemaChangeRows, "; "))
+	}
+
+	if len(parts) == 0 {
+		return "no active deploy requests or non-terminal Vitess schema changes found"
+	}
+	return strings.Join(parts, "; ")
+}
+
+func (s *Server) activeDeployRequestDiagnostics(ctx context.Context) ([]string, error) {
+	rows, err := s.metadataDB.QueryContext(ctx,
+		`SELECT number, org, database_name, branch, deployment_state, deployed, migration_context
+		 FROM localscale_deploy_requests
+		 WHERE deployment_state IN ('submitting','queued','in_progress','pending_cutover','in_progress_cutover','in_progress_vschema','in_progress_cancel','in_progress_revert','in_progress_revert_vschema','complete_pending_revert')
+		 ORDER BY org, database_name, number`)
+	if err != nil {
+		return nil, fmt.Errorf("query active deploy requests: %w", err)
+	}
+	defer utils.CloseAndLog(rows)
+
+	var result []string
+	for rows.Next() {
+		var number uint64
+		var org, database, branch, deployState, deployContext string
+		var deployed bool
+		if err := rows.Scan(&number, &org, &database, &branch, &deployState, &deployed, &deployContext); err != nil {
+			return nil, fmt.Errorf("scan active deploy request: %w", err)
+		}
+		result = append(result, fmt.Sprintf("number=%d org=%s database=%s branch=%s state=%s deployed=%t deploy_context=%s",
+			number, org, database, branch, deployState, deployed, deployContext))
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate active deploy requests: %w", err)
+	}
+	return result, nil
+}
+
+func (s *Server) vitessSchemaChangeDiagnostics(ctx context.Context) ([]string, error) {
+	var result []string
+	for _, backend := range s.backends {
+		for keyspace := range backend.vtgateDBs {
+			if err := s.forEachShard(ctx, backend, keyspace, func(conn *sql.Conn) error {
+				rows, err := conn.QueryContext(ctx, "SHOW VITESS_MIGRATIONS")
+				if err != nil {
+					return fmt.Errorf("show Vitess schema changes for %s: %w", keyspace, err)
+				}
+				rowMaps, err := scanDynamicRows(rows)
+				utils.CloseAndLog(rows)
+				if err != nil {
+					return fmt.Errorf("scan Vitess schema changes for %s: %w", keyspace, err)
+				}
+				for _, colMap := range rowMaps {
+					status := colMap["migration_status"]
+					switch status {
+					case state.Vitess.Complete, state.Vitess.Failed, state.Vitess.Cancelled:
+						s.logger.Debug("terminal Vitess schema change omitted from reset diagnostics", "keyspace", keyspace, "uuid", colMap["uuid"], "status", status)
+						continue
+					}
+					result = append(result, fmt.Sprintf("keyspace=%s uuid=%s status=%s context=%s message=%s",
+						keyspace, colMap["uuid"], status, colMap["migration_context"], colMap["message"]))
+				}
+				return nil
+			}); err != nil {
+				return nil, err
+			}
+		}
+	}
+	return result, nil
 }
 
 // proxyListenAddr returns the next bind address for a branch proxy.
@@ -717,7 +911,30 @@ func (s *Server) closeProxy(branch string) {
 	}
 }
 
-// closeAllProxies shuts down all branch TCP proxies.
+// closeBranchProxies shuts down branch password proxies while preserving edge
+// proxies that SchemaBot uses as long-lived vtgate endpoints.
+func (s *Server) closeBranchProxies() {
+	s.proxyMu.Lock()
+	old := make(map[string]*branchProxy, len(s.proxies))
+	for name, p := range s.proxies {
+		if strings.HasPrefix(name, "edge:") {
+			continue
+		}
+		old[name] = p
+		delete(s.proxies, name)
+	}
+	s.proxyMu.Unlock()
+
+	for _, p := range old {
+		s.releaseProxyPort(p)
+		utils.CloseAndLog(p)
+	}
+	if len(old) > 0 {
+		s.logger.Info("closed branch proxies for reset", "count", len(old))
+	}
+}
+
+// closeAllProxies shuts down all TCP proxies.
 func (s *Server) closeAllProxies() {
 	// Snapshot and clear under lock, then close outside the lock.
 	// proxy.Close() blocks on <-p.done (waits for serve() to exit),

--- a/pkg/localscale/server_deploy_integration_test.go
+++ b/pkg/localscale/server_deploy_integration_test.go
@@ -74,6 +74,52 @@ func TestDeployRequestDiffCreateTable(t *testing.T) {
 	require.Greater(t, len(result.Rows), 0, "expected 'diff_new_table' in vtgate after deploy")
 }
 
+// TestResetStateCanRunImmediatelyAfterDeploySubmit verifies reset-state cancels
+// in-flight LocalScale work before clearing metadata, so the next deploy request
+// starts from a clean state and can apply successfully.
+func TestResetStateCanRunImmediatelyAfterDeploySubmit(t *testing.T) {
+	cleanupActiveDeployRequests(t, t.Context())
+	t.Cleanup(func() { cleanupActiveDeployRequests(t, t.Context()) })
+	ctx := t.Context()
+
+	indexName := fmt.Sprintf("idx_reset_%d", time.Now().UnixNano())
+	branchName := createBranchWithDDL(t, ctx, "reset-submit",
+		map[string][]string{
+			"testapp_sharded": {
+				fmt.Sprintf("ALTER TABLE `users` ADD INDEX `%s` (`full_name`)", indexName),
+			},
+		},
+		nil,
+	)
+
+	dr := createDeploy(t, ctx, branchName, false)
+	require.Equal(t, drState.Ready, dr.DeploymentState, "expected changes")
+
+	deploy(t, ctx, dr.Number, false)
+	require.NoError(t, testContainer.ResetState(ctx), "reset LocalScale state after deploy submit")
+	_, err := testClient.GetDeployRequest(ctx, &ps.GetDeployRequestRequest{
+		Organization: testOrg,
+		Database:     testDB,
+		Number:       dr.Number,
+	})
+	require.Error(t, err, "reset-state should clear deploy request metadata")
+
+	nextCol := fmt.Sprintf("reset_next_%d", time.Now().UnixNano())
+	nextBranch := createBranchWithDDL(t, ctx, "reset-next",
+		map[string][]string{
+			"testapp_sharded": {
+				fmt.Sprintf("ALTER TABLE `users` ADD COLUMN `%s` varchar(50)", nextCol),
+			},
+		},
+		nil,
+	)
+	nextDR := createDeploy(t, ctx, nextBranch, true)
+	require.Equal(t, drState.Ready, nextDR.DeploymentState, "expected changes after reset")
+
+	deploy(t, ctx, nextDR.Number, true)
+	waitForDeployState(t, ctx, nextDR.Number, drState.CompletePendingRevert, drState.Complete)
+}
+
 // TestBranchDatabaseCleanupOnSkipRevert verifies that branch databases are dropped
 // after skip-revert closes the revert window.
 func TestBranchDatabaseCleanupOnSkipRevert(t *testing.T) {


### PR DESCRIPTION
## Why
Vitess e2e cleanup needs `/admin/reset-state` to be the isolation boundary, not direct metadata mutation. Reset must stop in-flight LocalScale work and clear Vitess state before the next test starts.

## What
- Cancel active deploy execution goroutines before clearing LocalScale metadata
- Reset Vitess online DDL state by unthrottling, cancelling, waiting for terminal state, and cleaning up
- Preserve edge proxies while closing branch proxies and dropping persisted branch databases
- Route e2e cleanup through `/admin/reset-state` and add a focused reset-after-deploy-submit scenario

## Risk Assessment
Low — scoped to LocalScale test infrastructure and e2e cleanup behavior. The main risk is stricter reset failures surfacing existing stale Vitess state instead of silently continuing.

Generated with Amp
