### PR TITLE
fix(localscale): harden proxy lifecycle

### DIFF
--- a/pkg/localscale/handlers_branches.go
+++ b/pkg/localscale/handlers_branches.go
@@ -7,9 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"maps"
-	"net"
 	"net/http"
-	"strconv"
 	"strings"
 	"time"
 
@@ -442,10 +440,6 @@ func (s *Server) handleCreateBranchPassword(w http.ResponseWriter, r *http.Reque
 	for ks := range backend.vtgateDBs {
 		keyspaces = append(keyspaces, ks)
 	}
-	listenAddr, err := s.proxyListenAddr()
-	if err != nil {
-		return newHTTPError(http.StatusInternalServerError, "allocate proxy port: %v", err)
-	}
 
 	var upstreamDSN string
 	var proxyBranch string
@@ -461,16 +455,8 @@ func (s *Server) handleCreateBranchPassword(w http.ResponseWriter, r *http.Reque
 	if s.tlsBundle != nil {
 		branchTLS = s.tlsBundle.TLSConfig
 	}
-	proxy, err := newBranchProxy(r.Context(), listenAddr, upstreamDSN, proxyBranch, keyspaces, s.logger, branchTLS)
+	proxy, err := s.newBranchProxyWithRetry(r.Context(), upstreamDSN, proxyBranch, keyspaces, branchTLS)
 	if err != nil {
-		if s.portAlloc != nil {
-			// Return port to pool on failure.
-			if _, portStr, splitErr := net.SplitHostPort(listenAddr); splitErr == nil {
-				if port, convErr := strconv.Atoi(portStr); convErr == nil {
-					s.portAlloc.release(port)
-				}
-			}
-		}
 		return newHTTPError(http.StatusInternalServerError, "create branch proxy: %v", err)
 	}
 	s.trackProxy(branch, proxy)

--- a/pkg/localscale/proxy.go
+++ b/pkg/localscale/proxy.go
@@ -48,8 +48,9 @@ func defaultMySQLServer() *server.Server {
 // portAllocator manages a pool of ports from a fixed range.
 // Used to give branch proxies predictable ports that can be exposed in Docker.
 type portAllocator struct {
-	mu   sync.Mutex
-	free []int
+	mu    sync.Mutex
+	free  []int
+	inUse map[int]struct{}
 }
 
 func newPortAllocator(start, end int) *portAllocator {
@@ -57,23 +58,34 @@ func newPortAllocator(start, end int) *portAllocator {
 	for p := start; p <= end; p++ {
 		ports = append(ports, p)
 	}
-	return &portAllocator{free: ports}
+	return &portAllocator{free: ports, inUse: make(map[int]struct{}, len(ports))}
 }
 
 func (a *portAllocator) acquire() (int, error) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
+	if a.inUse == nil {
+		a.inUse = make(map[int]struct{}, len(a.free))
+	}
 	if len(a.free) == 0 {
 		return 0, fmt.Errorf("proxy port range exhausted")
 	}
 	port := a.free[0]
 	a.free = a.free[1:]
+	a.inUse[port] = struct{}{}
 	return port, nil
 }
 
 func (a *portAllocator) release(port int) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
+	if a.inUse == nil {
+		return
+	}
+	if _, ok := a.inUse[port]; !ok {
+		return
+	}
+	delete(a.inUse, port)
 	a.free = append(a.free, port)
 }
 
@@ -91,6 +103,9 @@ type branchProxy struct {
 	logger      *slog.Logger
 	done        chan struct{}
 	connWg      sync.WaitGroup // tracks in-flight connections
+	connMu      sync.Mutex
+	conns       map[net.Conn]struct{}
+	closing     bool
 }
 
 func newBranchProxy(ctx context.Context, listenAddr, upstreamDSN string, branchName string, keyspaces []string, logger *slog.Logger, tlsCfg *tls.Config) (*branchProxy, error) {
@@ -135,6 +150,7 @@ func newBranchProxy(ctx context.Context, listenAddr, upstreamDSN string, branchN
 		mysqlServer: mysqlSrv,
 		logger:      logger,
 		done:        make(chan struct{}),
+		conns:       make(map[net.Conn]struct{}),
 	}
 	go p.serve()
 	return p, nil
@@ -148,7 +164,9 @@ func (p *branchProxy) Addr() string {
 // Close shuts down the proxy listener, waits for serve to exit, and drains
 // in-flight connections.
 func (p *branchProxy) Close() error {
+	p.beginClose()
 	err := p.listener.Close()
+	p.closeClientConns()
 	<-p.done
 	p.connWg.Wait()
 	return err
@@ -161,9 +179,51 @@ func (p *branchProxy) serve() {
 		if err != nil {
 			return
 		}
+		untrack, ok := p.trackClientConn(client)
+		if !ok {
+			p.logger.Debug("proxy: closing accepted connection during shutdown")
+			utils.CloseAndLog(client)
+			continue
+		}
 		p.connWg.Go(func() {
+			defer untrack()
 			p.handleConn(client)
 		})
+	}
+}
+
+func (p *branchProxy) beginClose() {
+	p.connMu.Lock()
+	p.closing = true
+	p.connMu.Unlock()
+}
+
+func (p *branchProxy) trackClientConn(conn net.Conn) (func(), bool) {
+	p.connMu.Lock()
+	if p.closing {
+		p.connMu.Unlock()
+		return func() {}, false
+	}
+	p.conns[conn] = struct{}{}
+	p.connMu.Unlock()
+
+	return func() {
+		p.connMu.Lock()
+		delete(p.conns, conn)
+		p.connMu.Unlock()
+	}, true
+}
+
+func (p *branchProxy) closeClientConns() {
+	p.connMu.Lock()
+	conns := make([]net.Conn, 0, len(p.conns))
+	for conn := range p.conns {
+		conns = append(conns, conn)
+	}
+	p.connMu.Unlock()
+
+	for _, conn := range conns {
+		utils.CloseAndLog(conn)
 	}
 }
 

--- a/pkg/localscale/proxy_test.go
+++ b/pkg/localscale/proxy_test.go
@@ -1,0 +1,208 @@
+package localscale
+
+import (
+	"io"
+	"log/slog"
+	"net"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/block/spirit/pkg/utils"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCloseBranchProxiesPreservesEdgeProxies(t *testing.T) {
+	s := &Server{
+		logger:  slog.New(slog.NewTextHandler(io.Discard, nil)),
+		proxies: make(map[string]*branchProxy),
+	}
+	edge := newTestBranchProxy(t)
+	branch := newTestBranchProxy(t)
+	s.proxies["edge:org/database"] = edge
+	s.proxies["feature-branch"] = branch
+
+	s.closeBranchProxies()
+
+	require.Contains(t, s.proxies, "edge:org/database")
+	require.NotContains(t, s.proxies, "feature-branch")
+}
+
+func TestBranchProxyCloseClosesTrackedClientConnections(t *testing.T) {
+	p := newTestBranchProxy(t)
+	client, server := net.Pipe()
+	t.Cleanup(func() {
+		utils.CloseAndLog(client)
+		utils.CloseAndLog(server)
+	})
+	untrack, ok := p.trackClientConn(server)
+	require.True(t, ok)
+	t.Cleanup(untrack)
+
+	errCh := make(chan error, 1)
+	go func() {
+		buf := make([]byte, 1)
+		_, err := client.Read(buf)
+		errCh <- err
+	}()
+
+	p.closeClientConns()
+
+	select {
+	case err := <-errCh:
+		require.Error(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for proxy close to close client connection")
+	}
+}
+
+func TestBranchProxyRejectsNewClientConnectionsAfterCloseStarts(t *testing.T) {
+	p := newTestBranchProxy(t)
+	client, server := net.Pipe()
+	t.Cleanup(func() {
+		utils.CloseAndLog(client)
+		utils.CloseAndLog(server)
+	})
+
+	p.beginClose()
+	untrack, ok := p.trackClientConn(server)
+
+	require.False(t, ok)
+	untrack()
+}
+
+func TestTrackProxyDoesNotReleaseOldPortBeforeCloseCompletes(t *testing.T) {
+	port1 := freeTCPPort(t)
+	port2 := freeTCPPort(t)
+	require.NotEqual(t, port1, port2)
+
+	s := &Server{
+		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+		proxies:   make(map[string]*branchProxy),
+		proxyHost: "127.0.0.1",
+		portAlloc: newTestPortAllocator(port1, port2),
+	}
+
+	listenAddr, err := s.proxyListenAddr()
+	require.NoError(t, err)
+	old := newTestBranchProxyAtAddr(t, listenAddr)
+	s.trackProxy("feature-branch", old)
+
+	var releaseOld sync.Once
+	old.connWg.Add(1)
+	releaseOldConn := func() {
+		releaseOld.Do(func() {
+			old.connWg.Done()
+		})
+	}
+	t.Cleanup(releaseOldConn)
+
+	replacementAddr, err := s.proxyListenAddr()
+	require.NoError(t, err)
+	replacement := newTestBranchProxyAtAddr(t, replacementAddr)
+	s.trackProxy("feature-branch", replacement)
+
+	_, err = s.portAlloc.acquire()
+	require.Error(t, err, "old proxy port must not be reusable until the listener has closed")
+
+	releaseOldConn()
+	s.wg.Wait()
+}
+
+func TestPortAllocatorIgnoresDuplicateRelease(t *testing.T) {
+	port1 := freeTCPPort(t)
+	port2 := freeTCPPort(t)
+	require.NotEqual(t, port1, port2)
+
+	alloc := newTestPortAllocator(port1, port2)
+	acquired, err := alloc.acquire()
+	require.NoError(t, err)
+	require.Equal(t, port1, acquired)
+
+	alloc.release(acquired)
+	alloc.release(acquired)
+
+	next, err := alloc.acquire()
+	require.NoError(t, err)
+	require.Equal(t, port2, next)
+	next, err = alloc.acquire()
+	require.NoError(t, err)
+	require.Equal(t, port1, next)
+	_, err = alloc.acquire()
+	require.Error(t, err)
+}
+
+func TestNewBranchProxyWithRetrySkipsOccupiedPort(t *testing.T) {
+	port1 := freeTCPPort(t)
+	port2 := freeTCPPort(t)
+	require.NotEqual(t, port1, port2)
+
+	held, err := (&net.ListenConfig{}).Listen(t.Context(), "tcp", net.JoinHostPort("127.0.0.1", strconv.Itoa(port1)))
+	require.NoError(t, err)
+	defer utils.CloseAndLog(held)
+
+	s := &Server{
+		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+		proxyHost: "127.0.0.1",
+		portAlloc: newTestPortAllocator(port1, port2),
+	}
+
+	proxy, err := s.newBranchProxyWithRetry(t.Context(), "root@tcp(127.0.0.1:1)/", "", nil, nil)
+	require.NoError(t, err)
+	defer utils.CloseAndLog(proxy)
+
+	_, portStr, err := net.SplitHostPort(proxy.Addr())
+	require.NoError(t, err)
+	require.Equal(t, strconv.Itoa(port2), portStr)
+
+	_, err = s.portAlloc.acquire()
+	require.Error(t, err, "occupied port should stay out of the free pool")
+}
+
+func newTestBranchProxy(t *testing.T) *branchProxy {
+	t.Helper()
+	return newTestBranchProxyAtAddr(t, "127.0.0.1:0")
+}
+
+func newTestBranchProxyAtAddr(t *testing.T, listenAddr string) *branchProxy {
+	t.Helper()
+	ln, err := (&net.ListenConfig{}).Listen(t.Context(), "tcp", listenAddr)
+	require.NoError(t, err)
+
+	p := &branchProxy{
+		listener: ln,
+		logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+		done:     make(chan struct{}),
+		conns:    make(map[net.Conn]struct{}),
+	}
+	go p.serve()
+
+	var closeOnce sync.Once
+	t.Cleanup(func() {
+		closeOnce.Do(func() {
+			utils.CloseAndLog(p)
+		})
+	})
+	return p
+}
+
+func freeTCPPort(t *testing.T) int {
+	t.Helper()
+	ln, err := (&net.ListenConfig{}).Listen(t.Context(), "tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer utils.CloseAndLog(ln)
+
+	_, portStr, err := net.SplitHostPort(ln.Addr().String())
+	require.NoError(t, err)
+	port, err := strconv.Atoi(portStr)
+	require.NoError(t, err)
+	return port
+}
+
+func newTestPortAllocator(ports ...int) *portAllocator {
+	return &portAllocator{
+		free:  append([]int(nil), ports...),
+		inUse: make(map[int]struct{}, len(ports)),
+	}
+}

--- a/pkg/localscale/server.go
+++ b/pkg/localscale/server.go
@@ -16,8 +16,10 @@ package localscale
 
 import (
 	"context"
+	"crypto/tls"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -28,6 +30,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/block/spirit/pkg/table"
@@ -386,14 +389,9 @@ func New(ctx context.Context, cfg Config) (*Server, error) {
 	})
 	for _, key := range sortedKeys {
 		backend := backends[key]
-		listenAddr, err := s.proxyListenAddr()
-		if err != nil {
-			s.Close()
-			return nil, fmt.Errorf("allocate edge port for %s/%s: %w", key.org, key.database, err)
-		}
 		// Empty branch name + nil keyspaces = pure passthrough (no DB name rewriting).
 		edgeDSN := fmt.Sprintf("root@tcp(%s)/", backend.vtgateMySQLAddr)
-		proxy, err := newBranchProxy(ctx, listenAddr, edgeDSN, "", nil, cfg.Logger, nil)
+		proxy, err := s.newBranchProxyWithRetry(ctx, edgeDSN, "", nil, nil)
 		if err != nil {
 			s.Close()
 			return nil, fmt.Errorf("start edge proxy for %s/%s: %w", key.org, key.database, err)
@@ -821,6 +819,31 @@ func (s *Server) proxyListenAddr() (string, error) {
 	return net.JoinHostPort(s.proxyHost, "0"), nil
 }
 
+func (s *Server) newBranchProxyWithRetry(ctx context.Context, upstreamDSN string, branchName string, keyspaces []string, tlsCfg *tls.Config) (*branchProxy, error) {
+	var lastAddrInUseErr error
+	for {
+		listenAddr, err := s.proxyListenAddr()
+		if err != nil {
+			if lastAddrInUseErr != nil {
+				return nil, fmt.Errorf("%w after skipping ports already in use: %w", err, lastAddrInUseErr)
+			}
+			return nil, err
+		}
+
+		proxy, err := newBranchProxy(ctx, listenAddr, upstreamDSN, branchName, keyspaces, s.logger, tlsCfg)
+		if err == nil {
+			return proxy, nil
+		}
+		if errors.Is(err, syscall.EADDRINUSE) {
+			lastAddrInUseErr = err
+			s.logger.Warn("proxy port already in use, trying next port", "listen_addr", listenAddr, "error", err)
+			continue
+		}
+		s.releaseProxyPortByAddr(listenAddr)
+		return nil, err
+	}
+}
+
 // proxyAdvertiseAddr returns the address clients should use to connect to a proxy.
 // When proxyAdvertiseHost is set explicitly, it uses that. Otherwise, it derives
 // the host from the HTTP request's Host header — so if a client reaches the API at
@@ -869,10 +892,14 @@ func (s *Server) proxyAdvertiseAddr(proxy *branchProxy, r *http.Request) string 
 
 // releaseProxyPort returns a proxy's port to the allocator pool, if applicable.
 func (s *Server) releaseProxyPort(proxy *branchProxy) {
+	s.releaseProxyPortByAddr(proxy.Addr())
+}
+
+func (s *Server) releaseProxyPortByAddr(addr string) {
 	if s.portAlloc == nil {
 		return
 	}
-	_, portStr, err := net.SplitHostPort(proxy.Addr())
+	_, portStr, err := net.SplitHostPort(addr)
 	if err != nil {
 		return
 	}
@@ -889,25 +916,29 @@ func (s *Server) releaseProxyPort(proxy *branchProxy) {
 func (s *Server) trackProxy(branch string, proxy *branchProxy) {
 	s.proxyMu.Lock()
 	old := s.proxies[branch]
-	if old != nil {
-		s.releaseProxyPort(old)
-	}
 	s.proxies[branch] = proxy
 	s.proxyMu.Unlock()
 
 	if old != nil {
-		s.wg.Go(func() { utils.CloseAndLog(old) })
+		s.wg.Go(func() {
+			utils.CloseAndLog(old)
+			s.releaseProxyPort(old)
+		})
 	}
 }
 
 // closeProxy shuts down and removes the TCP proxy for a branch.
 func (s *Server) closeProxy(branch string) {
 	s.proxyMu.Lock()
-	defer s.proxyMu.Unlock()
-	if p, ok := s.proxies[branch]; ok {
-		s.releaseProxyPort(p)
-		utils.CloseAndLog(p)
+	p, ok := s.proxies[branch]
+	if ok {
 		delete(s.proxies, branch)
+	}
+	s.proxyMu.Unlock()
+
+	if ok {
+		utils.CloseAndLog(p)
+		s.releaseProxyPort(p)
 	}
 }
 
@@ -926,8 +957,8 @@ func (s *Server) closeBranchProxies() {
 	s.proxyMu.Unlock()
 
 	for _, p := range old {
-		s.releaseProxyPort(p)
 		utils.CloseAndLog(p)
+		s.releaseProxyPort(p)
 	}
 	if len(old) > 0 {
 		s.logger.Info("closed branch proxies for reset", "count", len(old))
@@ -949,8 +980,8 @@ func (s *Server) closeAllProxies() {
 	s.proxyMu.Unlock()
 
 	for _, p := range old {
-		s.releaseProxyPort(p)
 		utils.CloseAndLog(p)
+		s.releaseProxyPort(p)
 	}
 }
 


### PR DESCRIPTION
## Why
LocalScale branch proxies can outlive reset and branch-password churn, which makes fixed proxy port ranges vulnerable to stale listeners and premature port reuse.

## What
- Track active proxy client connections and close them during proxy shutdown
- Release allocated proxy ports only after the old proxy has fully closed
- Retry proxy creation on ports that are already in use instead of failing the request
- Add focused proxy lifecycle and allocator tests

## Risk Assessment
Low — scoped to LocalScale proxy lifecycle and test infrastructure. The change is intended to make repeated LocalScale and e2e runs more reliable under port reuse and cleanup races.

Generated with Amp
