### PR TITLE
feat(observability): add remote deployment health metrics

### DIFF
--- a/pkg/api/remote_deployment_health.go
+++ b/pkg/api/remote_deployment_health.go
@@ -1,0 +1,183 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/block/schemabot/pkg/metrics"
+)
+
+const (
+	// RemoteDeploymentHealthCheckInterval is how often SchemaBot checks remote
+	// deployment health for steady-state availability metrics.
+	RemoteDeploymentHealthCheckInterval = 30 * time.Second
+
+	// RemoteDeploymentHealthCheckTimeout bounds a single remote deployment health
+	// check so an unhealthy deployment cannot stall other checks.
+	RemoteDeploymentHealthCheckTimeout = 5 * time.Second
+)
+
+type remoteDeploymentHealthTarget struct {
+	deployment  string
+	environment string
+}
+
+// StartRemoteDeploymentHealthMonitor starts a background loop that emits
+// steady-state health metrics for every configured remote deployment.
+func (s *Service) StartRemoteDeploymentHealthMonitor(ctx context.Context) {
+	if len(s.remoteDeploymentHealthTargets()) == 0 {
+		s.logger.Debug("remote deployment health monitor not started because no remote deployments are configured")
+		return
+	}
+
+	s.remoteHealthMu.Lock()
+	if s.remoteHealthCancel != nil {
+		s.remoteHealthMu.Unlock()
+		s.logger.Info("remote deployment health monitor already running")
+		return
+	}
+	monitorCtx, cancel := context.WithCancel(ctx)
+	s.remoteHealthCancel = cancel
+	interval := s.remoteHealthInterval
+	s.remoteHealthMu.Unlock()
+
+	s.remoteHealthWg.Go(func() {
+		s.remoteDeploymentHealthMonitor(monitorCtx, interval)
+	})
+	s.logger.Info("remote deployment health monitor started", "interval", interval, "timeout", RemoteDeploymentHealthCheckTimeout)
+}
+
+// StopRemoteDeploymentHealthMonitor stops the background remote deployment
+// health monitor. Safe to call multiple times.
+func (s *Service) StopRemoteDeploymentHealthMonitor() {
+	s.remoteHealthMu.Lock()
+	cancel := s.remoteHealthCancel
+	if cancel == nil {
+		s.remoteHealthMu.Unlock()
+		return
+	}
+	s.remoteHealthCancel = nil
+	s.remoteHealthMu.Unlock()
+
+	cancel()
+	s.remoteHealthWg.Wait()
+}
+
+// SetRemoteDeploymentHealthCheckInterval sets the background health check
+// interval. Call before StartRemoteDeploymentHealthMonitor.
+func (s *Service) SetRemoteDeploymentHealthCheckInterval(interval time.Duration) error {
+	if interval <= 0 {
+		return fmt.Errorf("remote deployment health check interval must be positive")
+	}
+	s.remoteHealthMu.Lock()
+	defer s.remoteHealthMu.Unlock()
+	if s.remoteHealthCancel != nil {
+		return fmt.Errorf("remote deployment health monitor already running")
+	}
+	s.remoteHealthInterval = interval
+	return nil
+}
+
+func (s *Service) remoteDeploymentHealthMonitor(ctx context.Context, interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	s.CheckRemoteDeploymentHealth(ctx)
+
+	for {
+		select {
+		case <-ctx.Done():
+			s.logger.Debug("remote deployment health monitor stopping", "error", ctx.Err())
+			return
+		case <-ticker.C:
+			s.CheckRemoteDeploymentHealth(ctx)
+		}
+	}
+}
+
+// CheckRemoteDeploymentHealth checks every configured remote deployment once
+// and records health metrics. It is exported so tests and diagnostics can run a
+// single synchronous check without starting the background monitor.
+func (s *Service) CheckRemoteDeploymentHealth(ctx context.Context) {
+	if err := ctx.Err(); err != nil {
+		s.logger.Debug("remote deployment health check skipped because context is done", "error", err)
+		return
+	}
+
+	targets := s.remoteDeploymentHealthTargets()
+	if len(targets) == 0 {
+		s.logger.Debug("remote deployment health check skipped because no remote deployments are configured")
+		return
+	}
+
+	for _, target := range targets {
+		s.checkRemoteDeploymentHealth(ctx, target)
+	}
+}
+
+func (s *Service) remoteDeploymentHealthTargets() []remoteDeploymentHealthTarget {
+	targets := make([]remoteDeploymentHealthTarget, 0)
+	for deployment, endpoints := range s.config.TernDeployments {
+		for environment := range endpoints {
+			targets = append(targets, remoteDeploymentHealthTarget{
+				deployment:  deployment,
+				environment: environment,
+			})
+		}
+	}
+	sort.Slice(targets, func(i, j int) bool {
+		if targets[i].deployment == targets[j].deployment {
+			return targets[i].environment < targets[j].environment
+		}
+		return targets[i].deployment < targets[j].deployment
+	})
+	return targets
+}
+
+func (s *Service) checkRemoteDeploymentHealth(ctx context.Context, target remoteDeploymentHealthTarget) {
+	client, err := s.TernClient(target.deployment, target.environment)
+	if err != nil {
+		s.logger.Warn("remote deployment health check failed because client could not be resolved",
+			"deployment", target.deployment,
+			"environment", target.environment,
+			"error", err)
+		metrics.RecordRemoteDeploymentHealth(ctx, target.deployment, target.environment, false)
+		metrics.RecordRemoteDeploymentHealthCheck(ctx, target.deployment, target.environment, "error", "client_config_error")
+		return
+	}
+
+	checkCtx, cancel := context.WithTimeout(ctx, RemoteDeploymentHealthCheckTimeout)
+	defer cancel()
+
+	if err := client.Health(checkCtx); err != nil {
+		if errors.Is(ctx.Err(), context.Canceled) || errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			s.logger.Debug("remote deployment health check stopped because context is done",
+				"deployment", target.deployment,
+				"environment", target.environment,
+				"error", ctx.Err())
+			return
+		}
+
+		reason := "unavailable"
+		if errors.Is(checkCtx.Err(), context.DeadlineExceeded) {
+			reason = "timeout"
+		}
+		s.logger.Warn("remote deployment health check failed",
+			"deployment", target.deployment,
+			"environment", target.environment,
+			"reason", reason,
+			"error", err)
+		metrics.RecordRemoteDeploymentHealth(ctx, target.deployment, target.environment, false)
+		metrics.RecordRemoteDeploymentHealthCheck(ctx, target.deployment, target.environment, "error", reason)
+		return
+	}
+
+	s.logger.Debug("remote deployment health check succeeded",
+		"deployment", target.deployment,
+		"environment", target.environment)
+	metrics.RecordRemoteDeploymentHealth(ctx, target.deployment, target.environment, true)
+	metrics.RecordRemoteDeploymentHealthCheck(ctx, target.deployment, target.environment, "success", "healthy")
+}

--- a/pkg/api/remote_deployment_health_test.go
+++ b/pkg/api/remote_deployment_health_test.go
@@ -1,0 +1,92 @@
+package api
+
+import (
+	"errors"
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/block/schemabot/pkg/tern"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+// Remote deployment health checks emit one steady-state gauge per configured
+// deployment/environment so dashboards can show status even when no schema
+// changes are running.
+func TestCheckRemoteDeploymentHealthRecordsEachDeployment(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	prevMP := otel.GetMeterProvider()
+	otel.SetMeterProvider(mp)
+	t.Cleanup(func() {
+		otel.SetMeterProvider(prevMP)
+		require.NoError(t, mp.Shutdown(t.Context()))
+	})
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	config := &ServerConfig{
+		TernDeployments: TernConfig{
+			"pie":  TernEndpoints{"staging": "pie-staging:9090"},
+			"sled": TernEndpoints{"staging": "sled-staging:9090"},
+		},
+	}
+	ternClients := map[string]tern.Client{
+		"pie/staging":  &mockTernClient{},
+		"sled/staging": &mockTernClient{healthErr: errors.New("connection refused")},
+	}
+	svc := New(&mockStorage{}, config, ternClients, logger)
+
+	svc.CheckRemoteDeploymentHealth(t.Context())
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(t.Context(), &rm))
+
+	healthByDeployment := make(map[string]int64)
+	checkStatusByDeployment := make(map[string]string)
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			switch m.Name {
+			case "schemabot.remote_deployment.health":
+				gauge, ok := m.Data.(metricdata.Gauge[int64])
+				require.True(t, ok)
+				for _, dp := range gauge.DataPoints {
+					deployment, ok := dp.Attributes.Value(attribute.Key("deployment"))
+					require.True(t, ok)
+					environment, ok := dp.Attributes.Value(attribute.Key("environment"))
+					require.True(t, ok)
+					assert.Equal(t, "staging", environment.AsString())
+					healthByDeployment[deployment.AsString()] = dp.Value
+				}
+			case "schemabot.remote_deployment.health_checks_total":
+				sum, ok := m.Data.(metricdata.Sum[int64])
+				require.True(t, ok)
+				for _, dp := range sum.DataPoints {
+					deployment, ok := dp.Attributes.Value(attribute.Key("deployment"))
+					require.True(t, ok)
+					status, ok := dp.Attributes.Value(attribute.Key("status"))
+					require.True(t, ok)
+					checkStatusByDeployment[deployment.AsString()] = status.AsString()
+				}
+			}
+		}
+	}
+
+	assert.Equal(t, map[string]int64{"pie": 1, "sled": 0}, healthByDeployment)
+	assert.Equal(t, map[string]string{"pie": "success", "sled": "error"}, checkStatusByDeployment)
+}
+
+func TestStartRemoteDeploymentHealthMonitorSkipsEmptyConfig(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	svc := New(&mockStorage{}, &ServerConfig{}, nil, logger)
+
+	svc.StartRemoteDeploymentHealthMonitor(t.Context())
+
+	svc.remoteHealthMu.Lock()
+	defer svc.remoteHealthMu.Unlock()
+	assert.Nil(t, svc.remoteHealthCancel)
+}

--- a/pkg/api/service.go
+++ b/pkg/api/service.go
@@ -119,6 +119,10 @@ type Service struct {
 	schedulerWake         chan struct{}
 	recoveryWg            sync.WaitGroup
 	schedulerPollInterval time.Duration
+	remoteHealthMu        sync.Mutex
+	remoteHealthCancel    context.CancelFunc
+	remoteHealthWg        sync.WaitGroup
+	remoteHealthInterval  time.Duration
 
 	// OnApplyRecovered is called after the scheduler claims an apply and before
 	// ResumeApply starts the engine/poller. Set by the webhook handler to attach
@@ -199,6 +203,7 @@ func New(st storage.Storage, config *ServerConfig, ternClients map[string]tern.C
 		logger:                logger,
 		clock:                 clock.Real{},
 		schedulerPollInterval: SchedulerPollInterval,
+		remoteHealthInterval:  RemoteDeploymentHealthCheckInterval,
 		pendingObservers:      make(map[pendingObserverKey]tern.ProgressObserver),
 	}
 }
@@ -515,8 +520,9 @@ func (s *Service) Storage() storage.Storage {
 
 // Close closes the service and releases resources.
 func (s *Service) Close() error {
-	// Stop the scheduler first
+	// Stop background workers first.
 	s.StopScheduler()
+	s.StopRemoteDeploymentHealthMonitor()
 
 	s.ternMu.Lock()
 	var errs []error

--- a/pkg/api/telemetry_test.go
+++ b/pkg/api/telemetry_test.go
@@ -255,6 +255,8 @@ func TestSchemaBotMetricsIncludeEnvironmentAttribute(t *testing.T) {
 	metrics.RecordCheckOwnershipMiss(t.Context(), "apply_finished", "org/repo", "mydb", "mysql", "pie", "staging")
 	metrics.AdjustActiveApplies(t.Context(), 1, "mydb", "pie", "staging")
 	metrics.RecordControlOperation(t.Context(), "stop", "mydb", "pie", "staging", "success")
+	metrics.RecordRemoteDeploymentHealth(t.Context(), "pie", "staging", true)
+	metrics.RecordRemoteDeploymentHealthCheck(t.Context(), "pie", "staging", "success", "healthy")
 	metrics.RecordLockOperation(t.Context(), "acquire", "mydb", "success")
 	metrics.RecordSchedulerResume(t.Context(), "mydb", "pie", "staging", "running")
 	metrics.RecordSchedulerResumeFailure(t.Context(), "mydb", "pie", "staging", "no_client")
@@ -311,6 +313,8 @@ func metricHasDeploymentAttribute(metricName string) bool {
 		"schemabot.check_ownership_misses_total",
 		"schemabot.active_applies",
 		"schemabot.control_operations_total",
+		"schemabot.remote_deployment.health",
+		"schemabot.remote_deployment.health_checks_total",
 		"schemabot.scheduler.resumed_total",
 		"schemabot.scheduler.resume_failures_total",
 		"schemabot.scheduler.claim_duration_seconds":
@@ -715,6 +719,59 @@ func TestRecordSchedulerMetrics(t *testing.T) {
 	assert.True(t, names["schemabot.scheduler.claim_failures_total"], "expected schemabot.scheduler.claim_failures_total")
 	assert.True(t, names["schemabot.scheduler.claim_duration_seconds"], "expected schemabot.scheduler.claim_duration_seconds")
 	assert.True(t, sawExpireRetryableError, "expected expire_retryable_error claim failure reason to be preserved")
+}
+
+func TestRecordRemoteDeploymentHealthMetrics(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	prevMP := otel.GetMeterProvider()
+	otel.SetMeterProvider(mp)
+	t.Cleanup(func() {
+		otel.SetMeterProvider(prevMP)
+		require.NoError(t, mp.Shutdown(t.Context()))
+	})
+
+	metrics.RecordRemoteDeploymentHealth(t.Context(), "pie", "staging", true)
+	metrics.RecordRemoteDeploymentHealth(t.Context(), "sled", "staging", false)
+	metrics.RecordRemoteDeploymentHealthCheck(t.Context(), "pie", "staging", "success", "healthy")
+	metrics.RecordRemoteDeploymentHealthCheck(t.Context(), "sled", "staging", "error", "unavailable")
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(t.Context(), &rm))
+
+	var sawHealthyGauge, sawUnhealthyGauge, sawHealthCheckCounter bool
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			switch m.Name {
+			case "schemabot.remote_deployment.health":
+				gauge, ok := m.Data.(metricdata.Gauge[int64])
+				require.True(t, ok)
+				for _, dp := range gauge.DataPoints {
+					deployment, hasDeployment := dp.Attributes.Value(attribute.Key("deployment"))
+					require.True(t, hasDeployment)
+					environment, hasEnvironment := dp.Attributes.Value(attribute.Key("environment"))
+					require.True(t, hasEnvironment)
+					assert.Equal(t, "staging", environment.AsString())
+					switch deployment.AsString() {
+					case "pie":
+						assert.Equal(t, int64(1), dp.Value)
+						sawHealthyGauge = true
+					case "sled":
+						assert.Equal(t, int64(0), dp.Value)
+						sawUnhealthyGauge = true
+					}
+				}
+			case "schemabot.remote_deployment.health_checks_total":
+				sum, ok := m.Data.(metricdata.Sum[int64])
+				require.True(t, ok)
+				assert.Len(t, sum.DataPoints, 2)
+				sawHealthCheckCounter = true
+			}
+		}
+	}
+	assert.True(t, sawHealthyGauge, "expected healthy deployment gauge")
+	assert.True(t, sawUnhealthyGauge, "expected unhealthy deployment gauge")
+	assert.True(t, sawHealthCheckCounter, "expected health check counter")
 }
 
 // setupTraceTest creates an in-memory trace exporter and configures the global

--- a/pkg/cmd/commands/serve.go
+++ b/pkg/cmd/commands/serve.go
@@ -179,6 +179,12 @@ func (cmd *ServeCmd) Run(g *Globals) error {
 		}
 	}()
 
+	// Emit steady-state availability metrics for every configured remote Tern
+	// deployment so dashboards can show deployment-specific health even when no
+	// schema changes are running.
+	svc.StartRemoteDeploymentHealthMonitor(ctx)
+	defer svc.StopRemoteDeploymentHealthMonitor()
+
 	// Configure routes
 	mux := http.NewServeMux()
 	svc.ConfigureRoutes(mux)

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -134,6 +134,75 @@ func RecordApplyDuration(ctx context.Context, duration time.Duration, repo, data
 	)
 }
 
+// RecordRemoteDeploymentHealth records the latest observed health for a remote
+// deployment/environment pair. A value of 1 means the latest health check
+// succeeded; 0 means SchemaBot could not reach or validate the remote
+// deployment.
+func RecordRemoteDeploymentHealth(ctx context.Context, deployment, environment string, healthy bool) {
+	value := int64(0)
+	if healthy {
+		value = 1
+	}
+
+	meter := otel.Meter(meterName)
+	gauge, err := meter.Int64Gauge("schemabot.remote_deployment.health",
+		otelmetric.WithDescription("Latest remote deployment health check result"),
+		otelmetric.WithUnit("1"),
+	)
+	if err != nil {
+		slog.Warn("failed to create remote deployment health gauge", "error", err)
+		return
+	}
+	gauge.Record(ctx, value,
+		otelmetric.WithAttributes(
+			DeploymentAttribute(deployment),
+			EnvironmentAttribute(environment),
+		),
+	)
+}
+
+var knownRemoteDeploymentHealthCheckStatuses = map[string]bool{
+	"success": true,
+	"error":   true,
+}
+
+var knownRemoteDeploymentHealthCheckReasons = map[string]bool{
+	"healthy":             true,
+	"client_config_error": true,
+	"timeout":             true,
+	"unavailable":         true,
+}
+
+// RecordRemoteDeploymentHealthCheck increments health check attempts for remote
+// deployments. Status and reason are allowlisted to keep metric cardinality
+// bounded.
+func RecordRemoteDeploymentHealthCheck(ctx context.Context, deployment, environment, status, reason string) {
+	if !knownRemoteDeploymentHealthCheckStatuses[status] {
+		status = "error"
+	}
+	if !knownRemoteDeploymentHealthCheckReasons[reason] {
+		reason = "unavailable"
+	}
+
+	meter := otel.Meter(meterName)
+	counter, err := meter.Int64Counter("schemabot.remote_deployment.health_checks_total",
+		otelmetric.WithDescription("Total number of remote deployment health checks"),
+		otelmetric.WithUnit("{check}"),
+	)
+	if err != nil {
+		slog.Warn("failed to create remote deployment health check counter", "error", err)
+		return
+	}
+	counter.Add(ctx, 1,
+		otelmetric.WithAttributes(
+			DeploymentAttribute(deployment),
+			EnvironmentAttribute(environment),
+			attribute.String("status", status),
+			attribute.String("reason", reason),
+		),
+	)
+}
+
 // knownSchemaFreshnessActions limits metric cardinality on the
 // schemabot.schema_freshness.rejected counter to the three handlers that
 // load a schema snapshot at discovery and reuse it at execution.


### PR DESCRIPTION
Adds a steady-state health monitor for configured remote Tern deployments. When remote deployments are configured, SchemaBot records a per-deployment health gauge and bounded health-check counter so operators can see remote availability even when no schema changes are running.

Generated with Amp
