### PR TITLE
fix(planetscale): improve branch DDL reliability

### DIFF
--- a/pkg/engine/planetscale/apply.go
+++ b/pkg/engine/planetscale/apply.go
@@ -560,6 +560,7 @@ func (e *Engine) applyKeyspaceChangesOnce(ctx context.Context, sc engine.SchemaC
 	mysqlCfg.Passwd = password.PlainText
 	mysqlCfg.Net = "tcp"
 	mysqlCfg.Addr = password.Hostname
+	mysqlCfg.DBName = sc.Namespace
 	mysqlCfg.InterpolateParams = true
 	if mtlsRegistered.Load() {
 		mysqlCfg.TLSConfig = mtlsConfigName
@@ -574,11 +575,6 @@ func (e *Engine) applyKeyspaceChangesOnce(ctx context.Context, sc engine.SchemaC
 
 	if err := db.PingContext(ctx); err != nil {
 		return fmt.Errorf("ping branch for %s: %w", sc.Namespace, err)
-	}
-
-	// USE the keyspace — vtgate branch proxy routes based on the database name.
-	if _, err := db.ExecContext(ctx, "USE `"+sc.Namespace+"`"); err != nil {
-		return fmt.Errorf("use keyspace %s: %w", sc.Namespace, err)
 	}
 
 	for _, tc := range sc.TableChanges {

--- a/pkg/engine/planetscale/planetscale.go
+++ b/pkg/engine/planetscale/planetscale.go
@@ -387,6 +387,7 @@ package planetscale
 import (
 	"context"
 	"database/sql"
+	"database/sql/driver"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -660,7 +661,11 @@ func mainBranch(creds *engine.Credentials) string {
 // isRetryableEngineError returns true if the error is a transient condition
 // that may succeed on a future attempt.
 func isRetryableEngineError(err error) bool {
-	return isRetryablePSError(err) || engine.IsTransientTransportError(err)
+	return isRetryablePSError(err) || isRetryableMySQLConnectionError(err) || engine.IsTransientTransportError(err)
+}
+
+func isRetryableMySQLConnectionError(err error) bool {
+	return errors.Is(err, mysql.ErrInvalidConn) || errors.Is(err, driver.ErrBadConn)
 }
 
 // isSnapshotInProgress returns true if the error indicates PlanetScale is

--- a/pkg/engine/planetscale/planetscale_test.go
+++ b/pkg/engine/planetscale/planetscale_test.go
@@ -1,10 +1,12 @@
 package planetscale
 
 import (
+	"database/sql/driver"
 	"fmt"
 	"testing"
 	"time"
 
+	mysql "github.com/go-sql-driver/mysql"
 	ps "github.com/planetscale/planetscale-go/planetscale"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -237,6 +239,15 @@ func TestIsRetryableEngineError(t *testing.T) {
 
 	t.Run("wrapped network error is retryable", func(t *testing.T) {
 		err := fmt.Errorf("apply failed: %w", fmt.Errorf("i/o timeout"))
+		assert.True(t, isRetryableEngineError(err))
+	})
+
+	t.Run("MySQL invalid connection is retryable", func(t *testing.T) {
+		assert.True(t, isRetryableEngineError(mysql.ErrInvalidConn))
+	})
+
+	t.Run("wrapped bad connection is retryable", func(t *testing.T) {
+		err := fmt.Errorf("execute DDL: %w", driver.ErrBadConn)
 		assert.True(t, isRetryableEngineError(err))
 	})
 


### PR DESCRIPTION
## Why
PlanetScale branch DDL apply should target the intended keyspace consistently and recover from transient MySQL connection resets during branch setup.

## What
- Target branch DDL connections by keyspace in the MySQL DSN
- Retry transient MySQL bad-connection errors during engine retry loops
- Cover MySQL connection reset classification in focused tests

## Risk Assessment
Low — this is scoped to PlanetScale branch DDL apply and narrows connection targeting while expanding retries only for transient connection errors.

Generated with Amp
