### PR TITLE
feat(config): support structured DSN sources

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -20,6 +20,64 @@ databases:
         dsn: "file:/run/secrets/prod-dsn"
 ```
 
+### Building DSNs from separate secrets
+
+If your deployment stores database connection metadata separately from passwords,
+use `dsn_from` instead of a raw `dsn`. `config_ref` and `password_ref` support
+the same secret reference formats as `dsn`, including `env:`, `file:`, and
+`secretsmanager:`.
+
+```yaml
+storage:
+  dsn_from:
+    config_ref: "file:/run/secrets/storage-config.yaml"
+    username: "schemabot_user"
+    password_ref: "file:/run/secrets/storage-password"
+    endpoint: writer
+    params:
+      parseTime: "true"
+
+databases:
+  mydb:
+    type: mysql
+    environments:
+      staging:
+        dsn_from:
+          config_ref: "file:/run/secrets/mydb-config.yaml"
+          username: "mydb_user"
+          password_ref: "file:/run/secrets/mydb-password"
+          endpoint: writer
+```
+
+The referenced database config can be a simple endpoint document:
+
+```yaml
+writer:
+  host: writer.example.com
+  database: appdb
+reader:
+  host: reader.example.com
+  port: 3307
+  database: appdb
+```
+
+It can also contain named clusters. If there is more than one cluster, set
+`dsn_from.cluster` to choose one.
+
+```yaml
+data_source_clusters:
+  primary:
+    writer:
+      host: writer.example.com
+      database: appdb
+    reader:
+      host: reader.example.com
+      database: appdb
+```
+
+`dsn` and `dsn_from` are mutually exclusive for each storage or database
+environment entry.
+
 ## gRPC Mode
 
 SchemaBot delegates to remote services that implement the Tern proto. This is useful for distributed deployments where schema changes need to run in separate isolated environments.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -46,9 +46,9 @@ databases:
           username: "mydb_user"
           password_ref: "file:/run/secrets/mydb-password"
           config_paths:
-            host: connection.host
-            port: connection.port
-            database: connection.database
+            host: databases.mydb.host
+            port: databases.mydb.port
+            database: databases.mydb.database
 ```
 
 By default, the referenced database config is expected to contain top-level
@@ -66,12 +66,18 @@ contain the connection fields. SchemaBot does not assign meaning to path names;
 it only reads the configured values and builds one DSN.
 
 ```yaml
-connection:
-  primary:
+databases:
+  mydb:
     host: db.example.com
     port: 3307
     database: appdb
 ```
+
+With the `config_paths` example above, SchemaBot reads:
+
+- `databases.mydb.host` for the hostname
+- `databases.mydb.port` for the optional port
+- `databases.mydb.database` for the database name
 
 `dsn` and `dsn_from` are mutually exclusive for each storage or database
 environment entry.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -33,7 +33,6 @@ storage:
     config_ref: "file:/run/secrets/storage-config.yaml"
     username: "schemabot_user"
     password_ref: "file:/run/secrets/storage-password"
-    endpoint: writer
     params:
       parseTime: "true"
 
@@ -46,33 +45,32 @@ databases:
           config_ref: "file:/run/secrets/mydb-config.yaml"
           username: "mydb_user"
           password_ref: "file:/run/secrets/mydb-password"
-          endpoint: writer
+          config_paths:
+            host: connection.host
+            port: connection.port
+            database: connection.database
 ```
 
-The referenced database config can be a simple endpoint document:
+By default, the referenced database config is expected to contain top-level
+`host`, `port`, and `database` fields. `port` is optional and defaults to 3306
+when omitted.
 
 ```yaml
-writer:
-  host: writer.example.com
-  database: appdb
-reader:
-  host: reader.example.com
-  port: 3307
-  database: appdb
+host: db.example.com
+port: 3307
+database: appdb
 ```
 
-It can also contain named clusters. If there is more than one cluster, set
-`dsn_from.cluster` to choose one.
+For other config shapes, set `config_paths` to the dot-separated YAML paths that
+contain the connection fields. SchemaBot does not assign meaning to path names;
+it only reads the configured values and builds one DSN.
 
 ```yaml
-data_source_clusters:
+connection:
   primary:
-    writer:
-      host: writer.example.com
-      database: appdb
-    reader:
-      host: reader.example.com
-      database: appdb
+    host: db.example.com
+    port: 3307
+    database: appdb
 ```
 
 `dsn` and `dsn_from` are mutually exclusive for each storage or database

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"log/slog"
+	"net"
 	"os"
 	"slices"
 	"strconv"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/block/schemabot/pkg/secrets"
 	"github.com/block/schemabot/pkg/storage"
+	gomysql "github.com/go-sql-driver/mysql"
 	"gopkg.in/yaml.v3"
 )
 
@@ -172,6 +174,31 @@ type StorageConfig struct {
 	// DSN is the MySQL connection string for SchemaBot's internal database.
 	// Can be a direct DSN or a reference (e.g., "env:MYSQL_DSN" to read from env var).
 	DSN string `yaml:"dsn"`
+
+	// DSNFrom builds the MySQL connection string from separate database config
+	// and password references. It is mutually exclusive with DSN.
+	DSNFrom *DSNFromConfig `yaml:"dsn_from,omitempty"`
+}
+
+// DSNFromConfig configures a MySQL DSN assembled from separate secret values.
+type DSNFromConfig struct {
+	// ConfigRef is a secret reference containing database connection metadata.
+	ConfigRef string `yaml:"config_ref"`
+
+	// Username is the database user to include in the generated DSN.
+	Username string `yaml:"username"`
+
+	// PasswordRef is a secret reference containing the database user's password.
+	PasswordRef string `yaml:"password_ref"`
+
+	// Endpoint selects which configured endpoint to use. Defaults to writer.
+	Endpoint string `yaml:"endpoint,omitempty"`
+
+	// Cluster selects a named cluster when ConfigRef contains more than one.
+	Cluster string `yaml:"cluster,omitempty"`
+
+	// Params are appended as MySQL DSN query parameters.
+	Params map[string]string `yaml:"params,omitempty"`
 }
 
 // DatabaseConfig holds configuration for a registered database.
@@ -245,6 +272,10 @@ type EnvironmentConfig struct {
 	// Can be a direct DSN or a reference to a secret (e.g., "env:MYSQL_DSN").
 	DSN string `yaml:"dsn"`
 
+	// DSNFrom builds the database connection string for local mode from separate
+	// database config and password references. It is mutually exclusive with DSN.
+	DSNFrom *DSNFromConfig `yaml:"dsn_from,omitempty"`
+
 	// Target is the opaque Tern-facing target identifier for gRPC mode.
 	Target string `yaml:"target,omitempty"`
 
@@ -270,6 +301,26 @@ type EnvironmentConfig struct {
 	// When set, registers a named TLS config with the Go MySQL driver.
 	// Omit for LocalScale (no TLS) or set for real PlanetScale (mTLS with CA bundle).
 	TLS *TLSConfig `yaml:"tls,omitempty"`
+}
+
+type externalDatabaseConfig struct {
+	DataSourceClusters map[string]externalDataSourceCluster `yaml:"data_source_clusters"`
+	Writer             externalDatabaseEndpoint             `yaml:"writer"`
+	Reader             externalDatabaseEndpoint             `yaml:"reader"`
+	Host               string                               `yaml:"host"`
+	Port               int                                  `yaml:"port"`
+	Database           string                               `yaml:"database"`
+}
+
+type externalDataSourceCluster struct {
+	Writer externalDatabaseEndpoint `yaml:"writer"`
+	Reader externalDatabaseEndpoint `yaml:"reader"`
+}
+
+type externalDatabaseEndpoint struct {
+	Host     string `yaml:"host"`
+	Port     int    `yaml:"port"`
+	Database string `yaml:"database"`
 }
 
 // TLSConfig holds TLS certificate paths for MySQL connections to PlanetScale branches.
@@ -369,15 +420,18 @@ func (c *ServerConfig) Validate() error {
 			return fmt.Errorf("database %q has no environments configured", name)
 		}
 		for env, envConfig := range dbConfig.Environments {
-			hasDSN := envConfig.DSN != ""
+			hasDSN := envConfig.HasLocalDSN()
 			hasRemoteRouting := envConfig.Target != "" || envConfig.Deployment != ""
 			switch {
 			case hasDSN && hasRemoteRouting:
-				return fmt.Errorf("database %q environment %q cannot configure both dsn and target/deployment", name, env)
+				return fmt.Errorf("database %q environment %q cannot configure both local DSN and target/deployment", name, env)
 			case hasDSN:
+				if err := envConfig.validateLocalDSNConfig(fmt.Sprintf("database %q environment %q", name, env)); err != nil {
+					return err
+				}
 				continue
 			case !hasRemoteRouting:
-				return fmt.Errorf("database %q environment %q missing dsn or target/deployment", name, env)
+				return fmt.Errorf("database %q environment %q missing local DSN or target/deployment", name, env)
 			case envConfig.Target == "":
 				return fmt.Errorf("database %q environment %q missing target", name, env)
 			case envConfig.Deployment == "":
@@ -409,6 +463,10 @@ func (c *ServerConfig) Validate() error {
 		}
 	}
 
+	if err := c.Storage.validateLocalDSNConfig("storage"); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -422,7 +480,7 @@ func (c *ServerConfig) validateNoLocalRemoteRouteCollision() error {
 			continue
 		}
 		for environment, envConfig := range dbConfig.Environments {
-			if envConfig.DSN == "" {
+			if !envConfig.HasLocalDSN() {
 				continue
 			}
 			if remoteEnvironments[environment] == "" {
@@ -489,7 +547,7 @@ func (c *ServerConfig) ResolveDatabaseTarget(database, environment string) (Reso
 		return ResolvedDatabaseTarget{}, fmt.Errorf("database %q environment %q is not configured on this server", database, environment)
 	}
 
-	if envConfig.DSN != "" {
+	if envConfig.HasLocalDSN() {
 		return ResolvedDatabaseTarget{
 			DatabaseType: dbConfig.Type,
 			Deployment:   database,
@@ -601,8 +659,199 @@ func (c *ServerConfig) IsCheckRequired(name string) bool {
 }
 
 // StorageDSN returns the resolved storage DSN.
-// It handles special prefixes (env:, file:) to read from various sources.
+// It handles special prefixes (env:, file:) to read from various sources and
+// can build a DSN from separate config/password references.
 // Falls back to MYSQL_DSN environment variable if not configured.
 func (c *ServerConfig) StorageDSN() (string, error) {
+	if c.Storage.DSNFrom != nil {
+		return c.Storage.DSNFrom.Resolve()
+	}
 	return secrets.Resolve(c.Storage.DSN, "MYSQL_DSN")
+}
+
+func (c StorageConfig) validateLocalDSNConfig(context string) error {
+	if c.DSN != "" && c.DSNFrom != nil {
+		return fmt.Errorf("%s cannot configure both dsn and dsn_from", context)
+	}
+	if c.DSNFrom != nil {
+		return c.DSNFrom.Validate(context)
+	}
+	return nil
+}
+
+// HasLocalDSN returns true when the environment should use a local database connection.
+func (c EnvironmentConfig) HasLocalDSN() bool {
+	return c.DSN != "" || c.DSNFrom != nil
+}
+
+func (c EnvironmentConfig) validateLocalDSNConfig(context string) error {
+	if c.DSN != "" && c.DSNFrom != nil {
+		return fmt.Errorf("%s cannot configure both dsn and dsn_from", context)
+	}
+	if c.DSNFrom != nil {
+		return c.DSNFrom.Validate(context)
+	}
+	return nil
+}
+
+func (c EnvironmentConfig) ResolveDSN() (string, error) {
+	if c.DSNFrom != nil {
+		return c.DSNFrom.Resolve()
+	}
+	return secrets.Resolve(c.DSN, "")
+}
+
+func (c *DSNFromConfig) Validate(context string) error {
+	if c.ConfigRef == "" {
+		return fmt.Errorf("%s dsn_from missing config_ref", context)
+	}
+	if c.Username == "" {
+		return fmt.Errorf("%s dsn_from missing username", context)
+	}
+	if c.PasswordRef == "" {
+		return fmt.Errorf("%s dsn_from missing password_ref", context)
+	}
+	endpoint := c.endpoint()
+	if endpoint != "writer" && endpoint != "reader" {
+		return fmt.Errorf("%s dsn_from endpoint must be writer or reader", context)
+	}
+	return nil
+}
+
+func (c *DSNFromConfig) Resolve() (string, error) {
+	if err := c.Validate("database connection"); err != nil {
+		return "", err
+	}
+
+	configYAML, err := secrets.Resolve(c.ConfigRef, "")
+	if err != nil {
+		return "", fmt.Errorf("resolve database config reference: %w", err)
+	}
+
+	var config externalDatabaseConfig
+	if err := yaml.Unmarshal([]byte(configYAML), &config); err != nil {
+		return "", fmt.Errorf("parse database config: %w", err)
+	}
+
+	endpoint, err := config.endpoint(c.Cluster, c.endpoint())
+	if err != nil {
+		return "", err
+	}
+
+	password, err := secrets.Resolve(c.PasswordRef, "")
+	if err != nil {
+		return "", fmt.Errorf("resolve database password reference: %w", err)
+	}
+
+	mysqlConfig := gomysql.NewConfig()
+	mysqlConfig.Net = "tcp"
+	mysqlConfig.Addr = endpoint.address()
+	mysqlConfig.User = c.Username
+	mysqlConfig.Passwd = password
+	mysqlConfig.DBName = endpoint.Database
+	mysqlConfig.Params = c.Params
+
+	return mysqlConfig.FormatDSN(), nil
+}
+
+func (c *DSNFromConfig) endpoint() string {
+	if c.Endpoint == "" {
+		return "writer"
+	}
+	return c.Endpoint
+}
+
+func (c externalDatabaseConfig) endpoint(clusterName, endpointName string) (externalDatabaseEndpoint, error) {
+	if len(c.DataSourceClusters) > 0 {
+		cluster, err := c.cluster(clusterName)
+		if err != nil {
+			return externalDatabaseEndpoint{}, err
+		}
+		return cluster.endpoint(endpointName)
+	}
+
+	switch endpointName {
+	case "writer":
+		if !c.Writer.empty() {
+			if err := c.Writer.validate("writer"); err != nil {
+				return externalDatabaseEndpoint{}, err
+			}
+			return c.Writer, nil
+		}
+	case "reader":
+		if !c.Reader.empty() {
+			if err := c.Reader.validate("reader"); err != nil {
+				return externalDatabaseEndpoint{}, err
+			}
+			return c.Reader, nil
+		}
+	}
+
+	endpoint := externalDatabaseEndpoint{Host: c.Host, Port: c.Port, Database: c.Database}
+	if err := endpoint.validate(endpointName); err != nil {
+		return externalDatabaseEndpoint{}, fmt.Errorf("database config does not contain %s endpoint", endpointName)
+	}
+	return endpoint, nil
+}
+
+func (c externalDatabaseConfig) cluster(clusterName string) (externalDataSourceCluster, error) {
+	if clusterName != "" {
+		cluster, ok := c.DataSourceClusters[clusterName]
+		if !ok {
+			return externalDataSourceCluster{}, fmt.Errorf("database config does not contain cluster %q", clusterName)
+		}
+		return cluster, nil
+	}
+
+	if len(c.DataSourceClusters) != 1 {
+		return externalDataSourceCluster{}, fmt.Errorf("database config contains multiple clusters; set dsn_from.cluster")
+	}
+	for _, cluster := range c.DataSourceClusters {
+		return cluster, nil
+	}
+	return externalDataSourceCluster{}, fmt.Errorf("database config does not contain clusters")
+}
+
+func (c externalDataSourceCluster) endpoint(endpointName string) (externalDatabaseEndpoint, error) {
+	switch endpointName {
+	case "writer":
+		if err := c.Writer.validate("writer"); err != nil {
+			return externalDatabaseEndpoint{}, err
+		}
+		return c.Writer, nil
+	case "reader":
+		if err := c.Reader.validate("reader"); err != nil {
+			return externalDatabaseEndpoint{}, err
+		}
+		return c.Reader, nil
+	default:
+		return externalDatabaseEndpoint{}, fmt.Errorf("database config endpoint must be writer or reader")
+	}
+}
+
+func (e externalDatabaseEndpoint) empty() bool {
+	return e.Host == "" && e.Database == ""
+}
+
+func (e externalDatabaseEndpoint) validate(endpointName string) error {
+	if e.empty() {
+		return fmt.Errorf("database config %s endpoint is empty", endpointName)
+	}
+	if e.Host == "" {
+		return fmt.Errorf("database config %s endpoint missing host", endpointName)
+	}
+	if e.Database == "" {
+		return fmt.Errorf("database config %s endpoint missing database", endpointName)
+	}
+	return nil
+}
+
+func (e externalDatabaseEndpoint) address() string {
+	if _, _, err := net.SplitHostPort(e.Host); err == nil {
+		return e.Host
+	}
+	if e.Port == 0 {
+		return net.JoinHostPort(e.Host, "3306")
+	}
+	return net.JoinHostPort(e.Host, strconv.Itoa(e.Port))
 }

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -185,20 +186,25 @@ type DSNFromConfig struct {
 	// ConfigRef is a secret reference containing database connection metadata.
 	ConfigRef string `yaml:"config_ref"`
 
+	// ConfigPaths selects fields from the referenced config document. Paths are
+	// dot-separated YAML map keys and default to host, port, and database.
+	ConfigPaths DSNFromConfigPaths `yaml:"config_paths,omitempty"`
+
 	// Username is the database user to include in the generated DSN.
 	Username string `yaml:"username"`
 
 	// PasswordRef is a secret reference containing the database user's password.
 	PasswordRef string `yaml:"password_ref"`
 
-	// Endpoint selects which configured endpoint to use. Defaults to writer.
-	Endpoint string `yaml:"endpoint,omitempty"`
-
-	// Cluster selects a named cluster when ConfigRef contains more than one.
-	Cluster string `yaml:"cluster,omitempty"`
-
 	// Params are appended as MySQL DSN query parameters.
 	Params map[string]string `yaml:"params,omitempty"`
+}
+
+// DSNFromConfigPaths configures where to find connection fields in ConfigRef.
+type DSNFromConfigPaths struct {
+	Host     string `yaml:"host,omitempty"`
+	Port     string `yaml:"port,omitempty"`
+	Database string `yaml:"database,omitempty"`
 }
 
 // DatabaseConfig holds configuration for a registered database.
@@ -301,20 +307,6 @@ type EnvironmentConfig struct {
 	// When set, registers a named TLS config with the Go MySQL driver.
 	// Omit for LocalScale (no TLS) or set for real PlanetScale (mTLS with CA bundle).
 	TLS *TLSConfig `yaml:"tls,omitempty"`
-}
-
-type externalDatabaseConfig struct {
-	DataSourceClusters map[string]externalDataSourceCluster `yaml:"data_source_clusters"`
-	Writer             externalDatabaseEndpoint             `yaml:"writer"`
-	Reader             externalDatabaseEndpoint             `yaml:"reader"`
-	Host               string                               `yaml:"host"`
-	Port               int                                  `yaml:"port"`
-	Database           string                               `yaml:"database"`
-}
-
-type externalDataSourceCluster struct {
-	Writer externalDatabaseEndpoint `yaml:"writer"`
-	Reader externalDatabaseEndpoint `yaml:"reader"`
 }
 
 type externalDatabaseEndpoint struct {
@@ -705,15 +697,18 @@ func (c *DSNFromConfig) Validate(context string) error {
 	if c.ConfigRef == "" {
 		return fmt.Errorf("%s dsn_from missing config_ref", context)
 	}
+	paths := c.configPaths()
+	if paths.Host == "" {
+		return fmt.Errorf("%s dsn_from missing config_paths.host", context)
+	}
+	if paths.Database == "" {
+		return fmt.Errorf("%s dsn_from missing config_paths.database", context)
+	}
 	if c.Username == "" {
 		return fmt.Errorf("%s dsn_from missing username", context)
 	}
 	if c.PasswordRef == "" {
 		return fmt.Errorf("%s dsn_from missing password_ref", context)
-	}
-	endpoint := c.endpoint()
-	if endpoint != "writer" && endpoint != "reader" {
-		return fmt.Errorf("%s dsn_from endpoint must be writer or reader", context)
 	}
 	return nil
 }
@@ -728,15 +723,26 @@ func (c *DSNFromConfig) Resolve() (string, error) {
 		return "", fmt.Errorf("resolve database config reference: %w", err)
 	}
 
-	var config externalDatabaseConfig
-	dec := yaml.NewDecoder(strings.NewReader(configYAML))
-	dec.KnownFields(true)
-	if err := dec.Decode(&config); err != nil {
+	var config any
+	if err := yaml.Unmarshal([]byte(configYAML), &config); err != nil {
 		return "", fmt.Errorf("parse database config: %w", err)
 	}
 
-	endpoint, err := config.endpoint(c.Cluster, c.endpoint())
+	paths := c.configPaths()
+	host, err := stringAtPath(config, paths.Host)
 	if err != nil {
+		return "", fmt.Errorf("read database config host: %w", err)
+	}
+	database, err := stringAtPath(config, paths.Database)
+	if err != nil {
+		return "", fmt.Errorf("read database config database: %w", err)
+	}
+	port, err := optionalIntAtPath(config, paths.Port)
+	if err != nil {
+		return "", fmt.Errorf("read database config port: %w", err)
+	}
+	endpoint := externalDatabaseEndpoint{Host: host, Port: port, Database: database}
+	if err := endpoint.validate(); err != nil {
 		return "", err
 	}
 
@@ -756,94 +762,94 @@ func (c *DSNFromConfig) Resolve() (string, error) {
 	return mysqlConfig.FormatDSN(), nil
 }
 
-func (c *DSNFromConfig) endpoint() string {
-	if c.Endpoint == "" {
-		return "writer"
+func (c *DSNFromConfig) configPaths() DSNFromConfigPaths {
+	paths := c.ConfigPaths
+	if paths.Host == "" {
+		paths.Host = "host"
 	}
-	return c.Endpoint
+	if paths.Port == "" {
+		paths.Port = "port"
+	}
+	if paths.Database == "" {
+		paths.Database = "database"
+	}
+	return paths
 }
 
-func (c externalDatabaseConfig) endpoint(clusterName, endpointName string) (externalDatabaseEndpoint, error) {
-	if len(c.DataSourceClusters) > 0 {
-		cluster, err := c.cluster(clusterName)
+func stringAtPath(document any, path string) (string, error) {
+	value, err := valueAtPath(document, path)
+	if err != nil {
+		return "", err
+	}
+	text, ok := value.(string)
+	if !ok {
+		return "", fmt.Errorf("path %q must contain a string", path)
+	}
+	return text, nil
+}
+
+func optionalIntAtPath(document any, path string) (int, error) {
+	if path == "" {
+		return 0, nil
+	}
+	value, err := valueAtPath(document, path)
+	if err != nil {
+		if errors.Is(err, errPathNotFound) {
+			return 0, nil
+		}
+		return 0, err
+	}
+	switch v := value.(type) {
+	case int:
+		return v, nil
+	case int64:
+		return int(v), nil
+	case float64:
+		if v != float64(int(v)) {
+			return 0, fmt.Errorf("path %q must contain an integer", path)
+		}
+		return int(v), nil
+	case string:
+		if v == "" {
+			return 0, nil
+		}
+		port, err := strconv.Atoi(v)
 		if err != nil {
-			return externalDatabaseEndpoint{}, err
+			return 0, fmt.Errorf("path %q must contain an integer: %w", path, err)
 		}
-		return cluster.endpoint(endpointName)
-	}
-
-	switch endpointName {
-	case "writer":
-		if !c.Writer.empty() {
-			if err := c.Writer.validate("writer"); err != nil {
-				return externalDatabaseEndpoint{}, err
-			}
-			return c.Writer, nil
-		}
-	case "reader":
-		if !c.Reader.empty() {
-			if err := c.Reader.validate("reader"); err != nil {
-				return externalDatabaseEndpoint{}, err
-			}
-			return c.Reader, nil
-		}
-	}
-
-	endpoint := externalDatabaseEndpoint{Host: c.Host, Port: c.Port, Database: c.Database}
-	if err := endpoint.validate(endpointName); err != nil {
-		return externalDatabaseEndpoint{}, err
-	}
-	return endpoint, nil
-}
-
-func (c externalDatabaseConfig) cluster(clusterName string) (externalDataSourceCluster, error) {
-	if clusterName != "" {
-		cluster, ok := c.DataSourceClusters[clusterName]
-		if !ok {
-			return externalDataSourceCluster{}, fmt.Errorf("database config does not contain cluster %q", clusterName)
-		}
-		return cluster, nil
-	}
-
-	if len(c.DataSourceClusters) != 1 {
-		return externalDataSourceCluster{}, fmt.Errorf("database config contains multiple clusters; set dsn_from.cluster")
-	}
-	for _, cluster := range c.DataSourceClusters {
-		return cluster, nil
-	}
-	return externalDataSourceCluster{}, fmt.Errorf("database config does not contain clusters")
-}
-
-func (c externalDataSourceCluster) endpoint(endpointName string) (externalDatabaseEndpoint, error) {
-	switch endpointName {
-	case "writer":
-		if err := c.Writer.validate("writer"); err != nil {
-			return externalDatabaseEndpoint{}, err
-		}
-		return c.Writer, nil
-	case "reader":
-		if err := c.Reader.validate("reader"); err != nil {
-			return externalDatabaseEndpoint{}, err
-		}
-		return c.Reader, nil
+		return port, nil
 	default:
-		return externalDatabaseEndpoint{}, fmt.Errorf("database config endpoint must be writer or reader")
+		return 0, fmt.Errorf("path %q must contain an integer", path)
 	}
 }
 
-func (e externalDatabaseEndpoint) empty() bool {
-	return e.Host == "" && e.Database == ""
+var errPathNotFound = errors.New("path not found")
+
+func valueAtPath(document any, path string) (any, error) {
+	current := document
+	for segment := range strings.SplitSeq(path, ".") {
+		if segment == "" {
+			return nil, fmt.Errorf("path %q contains an empty segment", path)
+		}
+		m, ok := current.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("path %q segment %q does not select a map", path, segment)
+		}
+		next, ok := m[segment]
+		if !ok {
+			return nil, fmt.Errorf("%w: %s", errPathNotFound, path)
+		}
+		current = next
+	}
+	return current, nil
 }
 
-func (e externalDatabaseEndpoint) validate(endpointName string) error {
-	if e.empty() {
-		return fmt.Errorf("database config %s endpoint is empty", endpointName)
-	}
+func (e externalDatabaseEndpoint) validate() error {
 	if e.Host == "" {
-		return fmt.Errorf("database config %s endpoint missing host", endpointName)
+		return fmt.Errorf("database config missing host")
 	}
 	if e.Database == "" {
-		return fmt.Errorf("database config %s endpoint missing database", endpointName)
+		return fmt.Errorf("database config missing database")
 	}
 	return nil
 }

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -729,7 +729,9 @@ func (c *DSNFromConfig) Resolve() (string, error) {
 	}
 
 	var config externalDatabaseConfig
-	if err := yaml.Unmarshal([]byte(configYAML), &config); err != nil {
+	dec := yaml.NewDecoder(strings.NewReader(configYAML))
+	dec.KnownFields(true)
+	if err := dec.Decode(&config); err != nil {
 		return "", fmt.Errorf("parse database config: %w", err)
 	}
 
@@ -789,7 +791,7 @@ func (c externalDatabaseConfig) endpoint(clusterName, endpointName string) (exte
 
 	endpoint := externalDatabaseEndpoint{Host: c.Host, Port: c.Port, Database: c.Database}
 	if err := endpoint.validate(endpointName); err != nil {
-		return externalDatabaseEndpoint{}, fmt.Errorf("database config does not contain %s endpoint", endpointName)
+		return externalDatabaseEndpoint{}, err
 	}
 	return endpoint, nil
 }

--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -107,7 +107,10 @@ databases:
           config_ref: file:/run/secrets/testapp-config.yaml
           username: testapp_user
           password_ref: file:/run/secrets/testapp-password
-          endpoint: reader
+          config_paths:
+            host: endpoints.primary.host
+            port: endpoints.primary.port
+            database: endpoints.primary.database
           params:
             parseTime: "true"
 `
@@ -119,7 +122,9 @@ databases:
 	assert.Equal(t, "schemabot_user", cfg.Storage.DSNFrom.Username)
 	require.NotNil(t, cfg.Databases["testapp"].Environments["staging"].DSNFrom)
 	targetDSNFrom := cfg.Databases["testapp"].Environments["staging"].DSNFrom
-	assert.Equal(t, "reader", targetDSNFrom.Endpoint)
+	assert.Equal(t, "endpoints.primary.host", targetDSNFrom.ConfigPaths.Host)
+	assert.Equal(t, "endpoints.primary.port", targetDSNFrom.ConfigPaths.Port)
+	assert.Equal(t, "endpoints.primary.database", targetDSNFrom.ConfigPaths.Database)
 	assert.Equal(t, map[string]string{"parseTime": "true"}, targetDSNFrom.Params)
 }
 
@@ -936,15 +941,11 @@ func TestDSNFromConfig_Resolve(t *testing.T) {
 	configPath := filepath.Join(dir, "database.yaml")
 	passwordPath := filepath.Join(dir, "password")
 	require.NoError(t, os.WriteFile(configPath, []byte(`
-data_source_clusters:
+connections:
   primary:
-    writer:
-      host: writer.example.com
-      database: appdb
-    reader:
-      host: reader.example.com
-      port: 3307
-      database: appdb
+    host: db.example.com
+    port: 3307
+    database: appdb
 `), 0644))
 	require.NoError(t, os.WriteFile(passwordPath, []byte("p@ss/word\n"), 0600))
 
@@ -952,7 +953,11 @@ data_source_clusters:
 		ConfigRef:   "file:" + configPath,
 		Username:    "app_ddl",
 		PasswordRef: "file:" + passwordPath,
-		Endpoint:    "reader",
+		ConfigPaths: DSNFromConfigPaths{
+			Host:     "connections.primary.host",
+			Port:     "connections.primary.port",
+			Database: "connections.primary.database",
+		},
 		Params: map[string]string{
 			"parseTime": "true",
 		},
@@ -962,21 +967,20 @@ data_source_clusters:
 	cfg, err := gomysql.ParseDSN(dsn)
 	require.NoError(t, err)
 	assert.Equal(t, "tcp", cfg.Net)
-	assert.Equal(t, "reader.example.com:3307", cfg.Addr)
+	assert.Equal(t, "db.example.com:3307", cfg.Addr)
 	assert.Equal(t, "app_ddl", cfg.User)
 	assert.Equal(t, "p@ss/word", cfg.Passwd)
 	assert.Equal(t, "appdb", cfg.DBName)
 	assert.True(t, cfg.ParseTime)
 }
 
-func TestDSNFromConfig_ResolveSimpleEndpoint(t *testing.T) {
+func TestDSNFromConfig_ResolveDefaultPaths(t *testing.T) {
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, "database.yaml")
 	passwordPath := filepath.Join(dir, "password")
 	require.NoError(t, os.WriteFile(configPath, []byte(`
-writer:
-  host: 127.0.0.1:3307
-  database: appdb
+host: 127.0.0.1:3307
+database: appdb
 `), 0644))
 	require.NoError(t, os.WriteFile(passwordPath, []byte("secret\n"), 0600))
 
@@ -995,72 +999,13 @@ writer:
 	assert.Equal(t, "secret", cfg.Passwd)
 }
 
-func TestDSNFromConfig_ResolveNamedCluster(t *testing.T) {
-	dir := t.TempDir()
-	configPath := filepath.Join(dir, "database.yaml")
-	passwordPath := filepath.Join(dir, "password")
-	require.NoError(t, os.WriteFile(configPath, []byte(`
-data_source_clusters:
-  primary:
-    writer:
-      host: primary.example.com
-      database: primarydb
-  secondary:
-    writer:
-      host: secondary.example.com
-      database: secondarydb
-`), 0644))
-	require.NoError(t, os.WriteFile(passwordPath, []byte("secret\n"), 0600))
-
-	dsn, err := (&DSNFromConfig{
-		ConfigRef:   "file:" + configPath,
-		Username:    "app_user",
-		PasswordRef: "file:" + passwordPath,
-		Cluster:     "secondary",
-	}).Resolve()
-	require.NoError(t, err)
-
-	cfg, err := gomysql.ParseDSN(dsn)
-	require.NoError(t, err)
-	assert.Equal(t, "secondary.example.com:3306", cfg.Addr)
-	assert.Equal(t, "secondarydb", cfg.DBName)
-	assert.Equal(t, "app_user", cfg.User)
-}
-
 func TestDSNFromConfig_ResolveErrors(t *testing.T) {
-	t.Run("multiple clusters require cluster", func(t *testing.T) {
+	t.Run("missing configured host path", func(t *testing.T) {
 		dir := t.TempDir()
 		configPath := filepath.Join(dir, "database.yaml")
 		passwordPath := filepath.Join(dir, "password")
 		require.NoError(t, os.WriteFile(configPath, []byte(`
-data_source_clusters:
-  primary:
-    writer:
-      host: primary.example.com
-      database: primarydb
-  secondary:
-    writer:
-      host: secondary.example.com
-      database: secondarydb
-`), 0644))
-		require.NoError(t, os.WriteFile(passwordPath, []byte("secret\n"), 0600))
-
-		_, err := (&DSNFromConfig{
-			ConfigRef:   "file:" + configPath,
-			Username:    "app_user",
-			PasswordRef: "file:" + passwordPath,
-		}).Resolve()
-
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "set dsn_from.cluster")
-	})
-
-	t.Run("selected endpoint requires host", func(t *testing.T) {
-		dir := t.TempDir()
-		configPath := filepath.Join(dir, "database.yaml")
-		passwordPath := filepath.Join(dir, "password")
-		require.NoError(t, os.WriteFile(configPath, []byte(`
-writer:
+connection:
   database: appdb
 `), 0644))
 		require.NoError(t, os.WriteFile(passwordPath, []byte("secret\n"), 0600))
@@ -1069,21 +1014,24 @@ writer:
 			ConfigRef:   "file:" + configPath,
 			Username:    "app_user",
 			PasswordRef: "file:" + passwordPath,
+			ConfigPaths: DSNFromConfigPaths{
+				Host:     "connection.host",
+				Database: "connection.database",
+			},
 		}).Resolve()
 
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "missing host")
+		assert.Contains(t, err.Error(), "read database config host")
+		assert.Contains(t, err.Error(), "path not found")
 	})
 
-	t.Run("database config rejects unknown fields", func(t *testing.T) {
+	t.Run("host path must contain string", func(t *testing.T) {
 		dir := t.TempDir()
 		configPath := filepath.Join(dir, "database.yaml")
 		passwordPath := filepath.Join(dir, "password")
 		require.NoError(t, os.WriteFile(configPath, []byte(`
-writer:
-  host: writer.example.com
-  database: appdb
-  datbase: typo
+host: 1234
+database: appdb
 `), 0644))
 		require.NoError(t, os.WriteFile(passwordPath, []byte("secret\n"), 0600))
 
@@ -1094,7 +1042,28 @@ writer:
 		}).Resolve()
 
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "field datbase not found")
+		assert.Contains(t, err.Error(), "must contain a string")
+	})
+
+	t.Run("port path must contain integer", func(t *testing.T) {
+		dir := t.TempDir()
+		configPath := filepath.Join(dir, "database.yaml")
+		passwordPath := filepath.Join(dir, "password")
+		require.NoError(t, os.WriteFile(configPath, []byte(`
+host: db.example.com
+port: not-a-port
+database: appdb
+`), 0644))
+		require.NoError(t, os.WriteFile(passwordPath, []byte("secret\n"), 0600))
+
+		_, err := (&DSNFromConfig{
+			ConfigRef:   "file:" + configPath,
+			Username:    "app_user",
+			PasswordRef: "file:" + passwordPath,
+		}).Resolve()
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must contain an integer")
 	})
 }
 
@@ -1103,9 +1072,8 @@ func TestServerConfig_StorageDSNFromConfig(t *testing.T) {
 	databaseConfigPath := filepath.Join(dir, "storage.yaml")
 	passwordPath := filepath.Join(dir, "password")
 	require.NoError(t, os.WriteFile(databaseConfigPath, []byte(`
-writer:
-  host: storage.example.com
-  database: schemabot
+host: storage.example.com
+database: schemabot
 `), 0644))
 	require.NoError(t, os.WriteFile(passwordPath, []byte("secret\n"), 0600))
 

--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -1074,6 +1074,28 @@ writer:
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "missing host")
 	})
+
+	t.Run("database config rejects unknown fields", func(t *testing.T) {
+		dir := t.TempDir()
+		configPath := filepath.Join(dir, "database.yaml")
+		passwordPath := filepath.Join(dir, "password")
+		require.NoError(t, os.WriteFile(configPath, []byte(`
+writer:
+  host: writer.example.com
+  database: appdb
+  datbase: typo
+`), 0644))
+		require.NoError(t, os.WriteFile(passwordPath, []byte("secret\n"), 0600))
+
+		_, err := (&DSNFromConfig{
+			ConfigRef:   "file:" + configPath,
+			Username:    "app_user",
+			PasswordRef: "file:" + passwordPath,
+		}).Resolve()
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "field datbase not found")
+	})
 }
 
 func TestServerConfig_StorageDSNFromConfig(t *testing.T) {

--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	gomysql "github.com/go-sql-driver/mysql"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -88,6 +89,40 @@ repos:
 	assert.Contains(t, cfg.Repos, "org/repo")
 }
 
+func TestLoadServerConfigFromFile_DSNFrom(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+	content := `
+storage:
+  dsn_from:
+    config_ref: file:/run/secrets/storage-config.yaml
+    username: schemabot_user
+    password_ref: file:/run/secrets/storage-password
+databases:
+  testapp:
+    type: mysql
+    environments:
+      staging:
+        dsn_from:
+          config_ref: file:/run/secrets/testapp-config.yaml
+          username: testapp_user
+          password_ref: file:/run/secrets/testapp-password
+          endpoint: reader
+          params:
+            parseTime: "true"
+`
+	require.NoError(t, os.WriteFile(configPath, []byte(content), 0644), "write config file")
+
+	cfg, err := LoadServerConfigFromFile(configPath)
+	require.NoError(t, err)
+	require.NotNil(t, cfg.Storage.DSNFrom)
+	assert.Equal(t, "schemabot_user", cfg.Storage.DSNFrom.Username)
+	require.NotNil(t, cfg.Databases["testapp"].Environments["staging"].DSNFrom)
+	targetDSNFrom := cfg.Databases["testapp"].Environments["staging"].DSNFrom
+	assert.Equal(t, "reader", targetDSNFrom.Endpoint)
+	assert.Equal(t, map[string]string{"parseTime": "true"}, targetDSNFrom.Params)
+}
+
 func TestLoadServerConfigFromFile_NotFound(t *testing.T) {
 	_, err := LoadServerConfigFromFile("/nonexistent/config.yaml")
 	assert.Error(t, err, "expected error for nonexistent file")
@@ -138,6 +173,21 @@ databases:
       staging:
         dsn: "root@tcp(localhost:3306)/testdb"
         extra_field: ignored
+`,
+		},
+		{
+			name: "dsn_from field",
+			content: `
+databases:
+  testdb:
+    type: mysql
+    environments:
+      staging:
+        dsn_from:
+          config_ref: file:/run/secrets/database.yaml
+          username: test_user
+          password_ref: file:/run/secrets/password
+          extra_field: ignored
 `,
 		},
 	}
@@ -726,6 +776,18 @@ func TestServerConfig_ResolveDatabaseTarget(t *testing.T) {
 					"staging": {DSN: "root@tcp(localhost)/localdb"},
 				},
 			},
+			"structuredlocaldb": {
+				Type: "mysql",
+				Environments: map[string]EnvironmentConfig{
+					"staging": {
+						DSNFrom: &DSNFromConfig{
+							ConfigRef:   "file:/run/secrets/database.yaml",
+							Username:    "test_user",
+							PasswordRef: "file:/run/secrets/password",
+						},
+					},
+				},
+			},
 			"remotedb": {
 				Type: "vitess",
 				Environments: map[string]EnvironmentConfig{
@@ -743,6 +805,12 @@ func TestServerConfig_ResolveDatabaseTarget(t *testing.T) {
 	assert.Equal(t, "mysql", local.DatabaseType)
 	assert.Equal(t, "localdb", local.Deployment)
 	assert.Equal(t, "localdb", local.Target)
+
+	structuredLocal, err := cfg.ResolveDatabaseTarget("structuredlocaldb", "staging")
+	require.NoError(t, err)
+	assert.Equal(t, "mysql", structuredLocal.DatabaseType)
+	assert.Equal(t, "structuredlocaldb", structuredLocal.Deployment)
+	assert.Equal(t, "structuredlocaldb", structuredLocal.Target)
 
 	remote, err := cfg.ResolveDatabaseTarget("remotedb", "production")
 	require.NoError(t, err)
@@ -861,6 +929,259 @@ repos:
 
 	_, err = LoadServerConfigFromFile(configPath)
 	assert.Error(t, err, "expected error for invalid config")
+}
+
+func TestDSNFromConfig_Resolve(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "database.yaml")
+	passwordPath := filepath.Join(dir, "password")
+	require.NoError(t, os.WriteFile(configPath, []byte(`
+data_source_clusters:
+  primary:
+    writer:
+      host: writer.example.com
+      database: appdb
+    reader:
+      host: reader.example.com
+      port: 3307
+      database: appdb
+`), 0644))
+	require.NoError(t, os.WriteFile(passwordPath, []byte("p@ss/word\n"), 0600))
+
+	dsn, err := (&DSNFromConfig{
+		ConfigRef:   "file:" + configPath,
+		Username:    "app_ddl",
+		PasswordRef: "file:" + passwordPath,
+		Endpoint:    "reader",
+		Params: map[string]string{
+			"parseTime": "true",
+		},
+	}).Resolve()
+	require.NoError(t, err)
+
+	cfg, err := gomysql.ParseDSN(dsn)
+	require.NoError(t, err)
+	assert.Equal(t, "tcp", cfg.Net)
+	assert.Equal(t, "reader.example.com:3307", cfg.Addr)
+	assert.Equal(t, "app_ddl", cfg.User)
+	assert.Equal(t, "p@ss/word", cfg.Passwd)
+	assert.Equal(t, "appdb", cfg.DBName)
+	assert.True(t, cfg.ParseTime)
+}
+
+func TestDSNFromConfig_ResolveSimpleEndpoint(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "database.yaml")
+	passwordPath := filepath.Join(dir, "password")
+	require.NoError(t, os.WriteFile(configPath, []byte(`
+writer:
+  host: 127.0.0.1:3307
+  database: appdb
+`), 0644))
+	require.NoError(t, os.WriteFile(passwordPath, []byte("secret\n"), 0600))
+
+	dsn, err := (&DSNFromConfig{
+		ConfigRef:   "file:" + configPath,
+		Username:    "app_user",
+		PasswordRef: "file:" + passwordPath,
+	}).Resolve()
+	require.NoError(t, err)
+
+	cfg, err := gomysql.ParseDSN(dsn)
+	require.NoError(t, err)
+	assert.Equal(t, "127.0.0.1:3307", cfg.Addr)
+	assert.Equal(t, "appdb", cfg.DBName)
+	assert.Equal(t, "app_user", cfg.User)
+	assert.Equal(t, "secret", cfg.Passwd)
+}
+
+func TestDSNFromConfig_ResolveNamedCluster(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "database.yaml")
+	passwordPath := filepath.Join(dir, "password")
+	require.NoError(t, os.WriteFile(configPath, []byte(`
+data_source_clusters:
+  primary:
+    writer:
+      host: primary.example.com
+      database: primarydb
+  secondary:
+    writer:
+      host: secondary.example.com
+      database: secondarydb
+`), 0644))
+	require.NoError(t, os.WriteFile(passwordPath, []byte("secret\n"), 0600))
+
+	dsn, err := (&DSNFromConfig{
+		ConfigRef:   "file:" + configPath,
+		Username:    "app_user",
+		PasswordRef: "file:" + passwordPath,
+		Cluster:     "secondary",
+	}).Resolve()
+	require.NoError(t, err)
+
+	cfg, err := gomysql.ParseDSN(dsn)
+	require.NoError(t, err)
+	assert.Equal(t, "secondary.example.com:3306", cfg.Addr)
+	assert.Equal(t, "secondarydb", cfg.DBName)
+	assert.Equal(t, "app_user", cfg.User)
+}
+
+func TestDSNFromConfig_ResolveErrors(t *testing.T) {
+	t.Run("multiple clusters require cluster", func(t *testing.T) {
+		dir := t.TempDir()
+		configPath := filepath.Join(dir, "database.yaml")
+		passwordPath := filepath.Join(dir, "password")
+		require.NoError(t, os.WriteFile(configPath, []byte(`
+data_source_clusters:
+  primary:
+    writer:
+      host: primary.example.com
+      database: primarydb
+  secondary:
+    writer:
+      host: secondary.example.com
+      database: secondarydb
+`), 0644))
+		require.NoError(t, os.WriteFile(passwordPath, []byte("secret\n"), 0600))
+
+		_, err := (&DSNFromConfig{
+			ConfigRef:   "file:" + configPath,
+			Username:    "app_user",
+			PasswordRef: "file:" + passwordPath,
+		}).Resolve()
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "set dsn_from.cluster")
+	})
+
+	t.Run("selected endpoint requires host", func(t *testing.T) {
+		dir := t.TempDir()
+		configPath := filepath.Join(dir, "database.yaml")
+		passwordPath := filepath.Join(dir, "password")
+		require.NoError(t, os.WriteFile(configPath, []byte(`
+writer:
+  database: appdb
+`), 0644))
+		require.NoError(t, os.WriteFile(passwordPath, []byte("secret\n"), 0600))
+
+		_, err := (&DSNFromConfig{
+			ConfigRef:   "file:" + configPath,
+			Username:    "app_user",
+			PasswordRef: "file:" + passwordPath,
+		}).Resolve()
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "missing host")
+	})
+}
+
+func TestServerConfig_StorageDSNFromConfig(t *testing.T) {
+	dir := t.TempDir()
+	databaseConfigPath := filepath.Join(dir, "storage.yaml")
+	passwordPath := filepath.Join(dir, "password")
+	require.NoError(t, os.WriteFile(databaseConfigPath, []byte(`
+writer:
+  host: storage.example.com
+  database: schemabot
+`), 0644))
+	require.NoError(t, os.WriteFile(passwordPath, []byte("secret\n"), 0600))
+
+	cfg := ServerConfig{
+		Storage: StorageConfig{
+			DSNFrom: &DSNFromConfig{
+				ConfigRef:   "file:" + databaseConfigPath,
+				Username:    "schemabot_user",
+				PasswordRef: "file:" + passwordPath,
+			},
+		},
+	}
+
+	dsn, err := cfg.StorageDSN()
+	require.NoError(t, err)
+
+	mysqlCfg, err := gomysql.ParseDSN(dsn)
+	require.NoError(t, err)
+	assert.Equal(t, "storage.example.com:3306", mysqlCfg.Addr)
+	assert.Equal(t, "schemabot", mysqlCfg.DBName)
+	assert.Equal(t, "schemabot_user", mysqlCfg.User)
+	assert.Equal(t, "secret", mysqlCfg.Passwd)
+}
+
+func TestServerConfig_ValidateDSNFrom(t *testing.T) {
+	t.Run("database cannot set both dsn and dsn_from", func(t *testing.T) {
+		cfg := ServerConfig{
+			Databases: map[string]DatabaseConfig{
+				"testapp": {
+					Type: storage.DatabaseTypeMySQL,
+					Environments: map[string]EnvironmentConfig{
+						"staging": {
+							DSN: "root@tcp(localhost:3306)/testapp",
+							DSNFrom: &DSNFromConfig{
+								ConfigRef:   "file:/secrets/database.yaml",
+								Username:    "testapp_user",
+								PasswordRef: "file:/secrets/password",
+							},
+						},
+					},
+				},
+			},
+		}
+
+		err := cfg.Validate()
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot configure both dsn and dsn_from")
+	})
+
+	t.Run("database dsn_from requires config ref", func(t *testing.T) {
+		cfg := ServerConfig{
+			Databases: map[string]DatabaseConfig{
+				"testapp": {
+					Type: storage.DatabaseTypeMySQL,
+					Environments: map[string]EnvironmentConfig{
+						"staging": {
+							DSNFrom: &DSNFromConfig{
+								Username:    "testapp_user",
+								PasswordRef: "file:/secrets/password",
+							},
+						},
+					},
+				},
+			},
+		}
+
+		err := cfg.Validate()
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "missing config_ref")
+	})
+
+	t.Run("storage cannot set both dsn and dsn_from", func(t *testing.T) {
+		cfg := ServerConfig{
+			Storage: StorageConfig{
+				DSN: "root@tcp(localhost:3306)/schemabot",
+				DSNFrom: &DSNFromConfig{
+					ConfigRef:   "file:/secrets/database.yaml",
+					Username:    "schemabot_user",
+					PasswordRef: "file:/secrets/password",
+				},
+			},
+			Databases: map[string]DatabaseConfig{
+				"testapp": {
+					Type: storage.DatabaseTypeMySQL,
+					Environments: map[string]EnvironmentConfig{
+						"staging": {DSN: "root@tcp(localhost:3306)/testapp"},
+					},
+				},
+			},
+		}
+
+		err := cfg.Validate()
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "storage cannot configure both dsn and dsn_from")
+	})
 }
 
 func TestGitHubConfig_YAMLKeys(t *testing.T) {

--- a/pkg/api/service.go
+++ b/pkg/api/service.go
@@ -272,7 +272,7 @@ func (s *Service) TernClient(deployment, environment string) (tern.Client, error
 		case !ok:
 			s.logger.Debug("database config does not contain this environment, using remote tern deployment",
 				"database", deployment, "environment", environment)
-		case envConfig.DSN == "":
+		case !envConfig.HasLocalDSN():
 			s.logger.Debug("database config does not contain a local DSN, using remote tern deployment",
 				"database", deployment, "environment", environment)
 		default:
@@ -323,8 +323,8 @@ func (s *Service) RegisterTernClient(deployment, environment string, client tern
 }
 
 func (s *Service) newLocalTernClient(key, database, dbType string, envConfig EnvironmentConfig) (tern.Client, error) {
-	// Resolve target DSN (handles env:, file: prefixes)
-	targetDSN, err := secrets.Resolve(envConfig.DSN, "")
+	// Resolve target DSN (handles env:, file: prefixes and structured DSN sources)
+	targetDSN, err := envConfig.ResolveDSN()
 	if err != nil {
 		return nil, fmt.Errorf("resolve DSN for %s: %w", key, err)
 	}

--- a/pkg/cmd/commands/serve.go
+++ b/pkg/cmd/commands/serve.go
@@ -21,7 +21,6 @@ import (
 	"github.com/block/schemabot/pkg/api"
 	ghclient "github.com/block/schemabot/pkg/github"
 	"github.com/block/schemabot/pkg/metrics"
-	"github.com/block/schemabot/pkg/secrets"
 	"github.com/block/schemabot/pkg/storage/mysqlstore"
 	"github.com/block/schemabot/pkg/tern"
 	"github.com/block/schemabot/pkg/webhook"
@@ -254,7 +253,10 @@ func startGRPCServer(ctx context.Context, config *api.ServerConfig, st *mysqlsto
 		if !ok {
 			continue
 		}
-		targetDSN, err := secrets.Resolve(envConfig.DSN, "")
+		if !envConfig.HasLocalDSN() {
+			continue
+		}
+		targetDSN, err := envConfig.ResolveDSN()
 		if err != nil {
 			return nil, fmt.Errorf("resolve DSN for %s/%s: %w", dbName, env, err)
 		}


### PR DESCRIPTION
## Why
Some deployments keep database connection metadata and passwords in separate secret files instead of storing complete DSN strings. SchemaBot should support that layout without requiring operators to pre-render or duplicate DSN secrets.

## What
- Add `dsn_from` config for storage and local database environments
- Build MySQL DSNs from config/password references using explicit, generic YAML field paths
- Document the generic config-file shapes and keep existing `dsn` behavior unchanged

## Example
Given a mounted config file like:

```yaml
# /run/secrets/mydb-config.yaml
databases:
  mydb:
    host: db.example.com
    port: 3306
    database: appdb
```

SchemaBot can build the DSN from that config plus a separately mounted password:

```yaml
databases:
  mydb:
    type: mysql
    environments:
      staging:
        dsn_from:
          config_ref: "file:/run/secrets/mydb-config.yaml"
          username: "mydb_user"
          password_ref: "file:/run/secrets/mydb-password"
          config_paths:
            host: databases.mydb.host
            port: databases.mydb.port
            database: databases.mydb.database
```

`config_paths` are just dot-separated YAML paths; SchemaBot does not attach semantics to names like writer/reader/primary.

## Risk Assessment
Low — this is opt-in config support and existing `dsn` configurations continue to validate and resolve as before.

Generated with Amp
