### PR TITLE
feat(github): add repo check publishing toggle

### DIFF
--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -285,7 +285,12 @@ type TLSConfig struct {
 }
 
 // RepoConfig holds configuration for a specific repository.
-type RepoConfig struct{}
+type RepoConfig struct {
+	// EnableChecks controls whether SchemaBot publishes GitHub Check Runs for
+	// this repository. Stored check state is still maintained for SchemaBot's
+	// own safety gates. Defaults to true when not configured.
+	EnableChecks *bool `yaml:"enable_checks,omitempty"`
+}
 
 // ResolvedDatabaseTarget is the server-owned routing decision for plan/apply.
 type ResolvedDatabaseTarget struct {
@@ -518,6 +523,20 @@ func (c *ServerConfig) IsRepoAllowed(repo string) bool {
 	}
 	_, ok := c.Repos[repo]
 	return ok
+}
+
+// AreChecksEnabled returns whether SchemaBot should publish GitHub Check Runs
+// for the given repository. Repositories not present in the server-side repo
+// config use the default enabled behavior.
+func (c *ServerConfig) AreChecksEnabled(repo string) bool {
+	if c == nil || len(c.Repos) == 0 {
+		return true
+	}
+	repoConfig, ok := c.Repos[repo]
+	if !ok || repoConfig.EnableChecks == nil {
+		return true
+	}
+	return *repoConfig.EnableChecks
 }
 
 // IsEnvironmentAllowed returns whether the given environment is handled by this

--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -76,7 +76,8 @@ tern_deployments:
   secondary:
     staging: "tern-staging:9090"
 repos:
-  org/repo: {}
+  org/repo:
+    enable_checks: false
 `
 	err := os.WriteFile(configPath, []byte(content), 0644)
 	require.NoError(t, err, "write config file")
@@ -86,6 +87,7 @@ repos:
 
 	assert.Equal(t, 2, len(cfg.TernDeployments))
 	assert.Contains(t, cfg.Repos, "org/repo")
+	assert.False(t, cfg.AreChecksEnabled("org/repo"))
 }
 
 func TestLoadServerConfigFromFile_NotFound(t *testing.T) {
@@ -1021,6 +1023,57 @@ func TestServerConfig_IsRepoAllowed(t *testing.T) {
 		}
 		assert.True(t, cfg.IsRepoAllowed("myorg/payments-service"))
 		assert.False(t, cfg.IsRepoAllowed("myorg/other-repo"))
+	})
+}
+
+func TestServerConfig_AreChecksEnabled(t *testing.T) {
+	t.Run("nil config defaults to enabled", func(t *testing.T) {
+		var cfg *ServerConfig
+		assert.True(t, cfg.AreChecksEnabled("org/repo"))
+	})
+
+	t.Run("nil repos defaults to enabled", func(t *testing.T) {
+		cfg := ServerConfig{Repos: nil}
+		assert.True(t, cfg.AreChecksEnabled("org/repo"))
+	})
+
+	t.Run("listed repo without override defaults to enabled", func(t *testing.T) {
+		cfg := ServerConfig{
+			Repos: map[string]RepoConfig{
+				"org/repo": {},
+			},
+		}
+		assert.True(t, cfg.AreChecksEnabled("org/repo"))
+	})
+
+	t.Run("unlisted repo defaults to enabled", func(t *testing.T) {
+		enableChecks := false
+		cfg := ServerConfig{
+			Repos: map[string]RepoConfig{
+				"org/repo": {EnableChecks: &enableChecks},
+			},
+		}
+		assert.True(t, cfg.AreChecksEnabled("org/other-repo"))
+	})
+
+	t.Run("explicit false disables checks", func(t *testing.T) {
+		enableChecks := false
+		cfg := ServerConfig{
+			Repos: map[string]RepoConfig{
+				"org/repo": {EnableChecks: &enableChecks},
+			},
+		}
+		assert.False(t, cfg.AreChecksEnabled("org/repo"))
+	})
+
+	t.Run("explicit true enables checks", func(t *testing.T) {
+		enableChecks := true
+		cfg := ServerConfig{
+			Repos: map[string]RepoConfig{
+				"org/repo": {EnableChecks: &enableChecks},
+			},
+		}
+		assert.True(t, cfg.AreChecksEnabled("org/repo"))
 	})
 }
 

--- a/pkg/webhook/check_publisher.go
+++ b/pkg/webhook/check_publisher.go
@@ -8,6 +8,19 @@ import (
 	"github.com/block/schemabot/pkg/storage"
 )
 
+func (h *Handler) shouldPublishChecks(ctx context.Context, repo string, operation string) bool {
+	if h.service == nil || h.service.Config().AreChecksEnabled(repo) {
+		return true
+	}
+	metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
+		Operation:  operation,
+		Repository: repo,
+		Status:     "skipped",
+	})
+	h.logger.Info("status check publishing disabled for repository", "repo", repo, "operation", operation)
+	return false
+}
+
 // verifyHeadSHAStillCurrentForPR returns false when writing status check state
 // for headSHA would be unsafe because the PR now points at a different commit
 // SHA. It records a metric and logs the reason before every false return so
@@ -66,6 +79,10 @@ func (h *Handler) verifyHeadSHAStillCurrentForPR(ctx context.Context, client *gh
 //   - ALL checks "success"        → aggregate "success"
 //   - NO per-database checks      → no aggregate (PR doesn't touch schema)
 func (h *Handler) updateAggregateCheck(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, headSHA string) {
+	if !h.shouldPublishChecks(ctx, repo, "aggregate_check_sync") {
+		return
+	}
+
 	if !h.verifyHeadSHAStillCurrentForPR(ctx, client, repo, pr, headSHA, "aggregate_check_sync") {
 		return
 	}
@@ -252,6 +269,10 @@ func (h *Handler) upsertAggregateCheckRun(
 // check that would never come. It does not publish success over existing
 // per-database state that still needs operator attention.
 func (h *Handler) postPassingAggregates(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, headSHA, title, summary string) {
+	if !h.shouldPublishChecks(ctx, repo, "aggregate_check_sync") {
+		return
+	}
+
 	if !h.verifyHeadSHAStillCurrentForPR(ctx, client, repo, pr, headSHA, "aggregate_check_sync") {
 		return
 	}
@@ -423,6 +444,10 @@ func (h *Handler) postFailingAggregates(ctx context.Context, client *ghclient.In
 // postFailingAggregatesWithBlock stores a blocking reason only for callers with
 // a stable failure class. Generic plan errors should use postFailingAggregates.
 func (h *Handler) postFailingAggregatesWithBlock(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, headSHA string, errors map[string]string, block checkBlockReason) {
+	if !h.shouldPublishChecks(ctx, repo, "aggregate_check_sync") {
+		return
+	}
+
 	if !h.verifyHeadSHAStillCurrentForPR(ctx, client, repo, pr, headSHA, "aggregate_check_sync") {
 		return
 	}

--- a/pkg/webhook/webhook_e2e_test.go
+++ b/pkg/webhook/webhook_e2e_test.go
@@ -3657,6 +3657,70 @@ func TestE2EAggregateUpdateSkipsStaleHeadSHA(t *testing.T) {
 	assert.Nil(t, aggregate)
 }
 
+// TestE2EDisabledRepoChecksSkipAggregatePublishing verifies that a server-side
+// repository safety hatch suppresses GitHub Check Runs while preserving stored
+// per-database check state for SchemaBot's own safety decisions.
+func TestE2EDisabledRepoChecksSkipAggregatePublishing(t *testing.T) {
+	dbName := "webhook_disabled_repo_checks"
+	svc := setupE2EService(t, dbName)
+	ctx := t.Context()
+
+	enableChecks := false
+	svc.Config().Repos = map[string]api.RepoConfig{
+		"octocat/hello-world": {EnableChecks: &enableChecks},
+	}
+
+	require.NoError(t, svc.Storage().Checks().Upsert(ctx, &storage.Check{
+		Repository:   "octocat/hello-world",
+		PullRequest:  1,
+		HeadSHA:      "abc123",
+		Environment:  "staging",
+		DatabaseType: "mysql",
+		DatabaseName: dbName,
+		HasChanges:   true,
+		Status:       checkStatusCompleted,
+		Conclusion:   checkConclusionActionRequired,
+	}))
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	var githubCalls atomic.Int64
+	mux.HandleFunc("GET /repos/octocat/hello-world/pulls/1", func(w http.ResponseWriter, _ *http.Request) {
+		githubCalls.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	mux.HandleFunc("POST /repos/octocat/hello-world/check-runs", func(w http.ResponseWriter, _ *http.Request) {
+		githubCalls.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	client := gh.NewClient(nil)
+	client.BaseURL, _ = url.Parse(server.URL + "/")
+	h := newE2EHandler(t, svc, client)
+	installClient := ghclient.NewInstallationClient(client, h.logger)
+
+	h.updateAggregateCheck(ctx, installClient, "octocat/hello-world", 1, "abc123")
+	h.postPassingAggregates(ctx, installClient, "octocat/hello-world", 1, "abc123",
+		"No managed schema changes",
+		"This PR does not contain schema changes managed by SchemaBot.")
+	h.postFailingAggregates(ctx, installClient, "octocat/hello-world", 1, "abc123", map[string]string{
+		"staging": "Plan failed",
+	})
+
+	assert.Equal(t, int64(0), githubCalls.Load(), "disabled check publishing should not call GitHub")
+
+	storedCheck, err := svc.Storage().Checks().Get(ctx, "octocat/hello-world", 1, "staging", "mysql", dbName)
+	require.NoError(t, err)
+	require.NotNil(t, storedCheck, "per-database check state should remain available")
+	assert.Equal(t, checkConclusionActionRequired, storedCheck.Conclusion)
+
+	aggregate, err := svc.Storage().Checks().Get(ctx, "octocat/hello-world", 1, aggregateSentinel, aggregateSentinel, aggregateSentinel)
+	require.NoError(t, err)
+	assert.Nil(t, aggregate, "disabled check publishing should not store aggregate check state")
+}
+
 // TestE2EPassingAggregateRequiresGitHubHeadVerification verifies that passing
 // aggregate paths still verify the current PR commit before publishing a check.
 func TestE2EPassingAggregateRequiresGitHubHeadVerification(t *testing.T) {


### PR DESCRIPTION
## Why
Operators need a server-side safety hatch to temporarily stop SchemaBot from publishing GitHub Check Runs for selected repositories without disabling schema change planning or apply safety state.

## What
- Add an optional repo-level `enable_checks` setting that defaults to enabled
- Skip aggregate Check Run publishing when a repository disables checks
- Keep stored per-database check state available for SchemaBot safety decisions

## Risk Assessment
Low — default behavior is unchanged unless a repository explicitly sets `enable_checks: false`.

Generated with Amp