### PR TITLE
feat(config): multi-deployment environments + ResolveDatabaseTargets

### DIFF
--- a/charts/schemabot/Chart.yaml
+++ b/charts/schemabot/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: schemabot
 description: GitOps for database schemas
 type: application
-version: 0.1.4
+version: 0.1.5
 appVersion: "v0.1.3"
 maintainers:
   - name: aparajon

--- a/charts/schemabot/values.yaml
+++ b/charts/schemabot/values.yaml
@@ -49,7 +49,11 @@ grpc:
 #         staging: "tern-staging:9090"
 #         production: "tern-production:9090"
 #
-# Example (gRPC mode, multi-deployment environment):
+# Example (gRPC mode, multi-deployment environment — PREVIEW):
+# NOTE: multi-entry deployments maps are rejected at config load until the
+# plan/apply orchestration path is wired through ResolveDatabaseTargets.
+# A single-entry deployments map is accepted and behaves identically to the
+# scalar target / deployment shape.
 #   config:
 #     storage:
 #       dsn: "secretsmanager:schemabot-db#dsn"

--- a/charts/schemabot/values.yaml
+++ b/charts/schemabot/values.yaml
@@ -48,6 +48,27 @@ grpc:
 #       default:
 #         staging: "tern-staging:9090"
 #         production: "tern-production:9090"
+#
+# Example (gRPC mode, multi-deployment environment):
+#   config:
+#     storage:
+#       dsn: "secretsmanager:schemabot-db#dsn"
+#     databases:
+#       payments:
+#         type: mysql
+#         environments:
+#           production:
+#             deployments:
+#               payments-a: { target: "payments" }
+#               payments-b: { target: "payments" }
+#               payments-c: { target: "payments" }
+#     tern_deployments:
+#       payments-a:
+#         production: "tern-payments-a:9090"
+#       payments-b:
+#         production: "tern-payments-b:9090"
+#       payments-c:
+#         production: "tern-payments-c:9090"
 # config is required — helm install will fail without it.
 config: null
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -111,9 +111,11 @@ In gRPC mode, `target` is an opaque identifier understood by the remote Tern ser
 
 The example above is a single SchemaBot deployment that owns both environments. In environment-isolated deployments, each SchemaBot config should contain only the targets for the environments that instance owns. Use `allowed_environments` to scope each instance.
 
-## Multi-Deployment Environment
+## Multi-Deployment Environment (preview)
 
-A single environment can be fanned out to multiple Tern deployments by replacing the scalar `target` / `deployment` pair with a `deployments` map. Each entry's key is a Tern deployment name (which MUST also exist as a key in `tern_deployments`), and each value carries the per-deployment `target`.
+A single environment will eventually be able to fan out to multiple Tern deployments by replacing the scalar `target` / `deployment` pair with a `deployments` map. Each entry's key is a Tern deployment name (which MUST also exist as a key in `tern_deployments`), and each value carries the per-deployment `target`.
+
+> **Not yet enabled in this release.** The config shape and resolver API are landed, but the plan/apply orchestration path still consumes a single deployment per `(database, environment)`. To prevent silent failures, `Validate()` currently rejects any `deployments` map with more than one entry. A single-entry map is accepted and behaves identically to the scalar `target` / `deployment` shape.
 
 ```yaml
 storage:
@@ -145,7 +147,8 @@ Rules:
 
 - `deployments` is mutually exclusive with the scalar `target` / `deployment` fields and with a local `dsn` / `dsn_from`.
 - The map MUST contain at least one entry, each entry MUST set a non-empty `target`, and each map key MUST resolve through `tern_deployments` with an endpoint configured for this environment.
-- Single-deployment environments continue to use the scalar `target` / `deployment` shape.
+- Until the orchestration path is wired, the map MUST contain exactly one entry; multi-entry maps are rejected at config load.
+- Single-deployment environments should continue to use the scalar `target` / `deployment` shape.
 
 Resolution order from the config layer is deterministic and sorted by deployment key. Server-owned cross-deployment ordering (e.g. rolling deploys across regions) is a forthcoming addition that will live alongside `environment_order`.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -111,6 +111,44 @@ In gRPC mode, `target` is an opaque identifier understood by the remote Tern ser
 
 The example above is a single SchemaBot deployment that owns both environments. In environment-isolated deployments, each SchemaBot config should contain only the targets for the environments that instance owns. Use `allowed_environments` to scope each instance.
 
+## Multi-Deployment Environment
+
+A single environment can be fanned out to multiple Tern deployments by replacing the scalar `target` / `deployment` pair with a `deployments` map. Each entry's key is a Tern deployment name (which MUST also exist as a key in `tern_deployments`), and each value carries the per-deployment `target`.
+
+```yaml
+storage:
+  dsn: "env:SCHEMABOT_DSN"
+
+databases:
+  payments:
+    type: mysql
+    environments:
+      production:
+        deployments:
+          payments-a:
+            target: "payments"
+          payments-b:
+            target: "payments"
+          payments-c:
+            target: "payments"
+
+tern_deployments:
+  payments-a:
+    production: "tern-payments-a:9090"
+  payments-b:
+    production: "tern-payments-b:9090"
+  payments-c:
+    production: "tern-payments-c:9090"
+```
+
+Rules:
+
+- `deployments` is mutually exclusive with the scalar `target` / `deployment` fields and with a local `dsn` / `dsn_from`.
+- The map MUST contain at least one entry, each entry MUST set a non-empty `target`, and each map key MUST resolve through `tern_deployments` with an endpoint configured for this environment.
+- Single-deployment environments continue to use the scalar `target` / `deployment` shape.
+
+Resolution order from the config layer is deterministic and sorted by deployment key. Server-owned cross-deployment ordering (e.g. rolling deploys across regions) is a forthcoming addition that will live alongside `environment_order`.
+
 ## Environment Order
 
 For clients, `schemabot.yaml` environments are strictly an opt-in mechanism. They control which environments a repository opts into; they do not control promotion order. SchemaBot enforces promotion order from server config:

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -617,9 +617,19 @@ func (c *ServerConfig) ResolveDatabaseTargets(database, environment string) ([]R
 		}}, nil
 	}
 
-	if len(envConfig.Deployments) > 0 {
+	// A non-nil deployments map is authoritative — fall through to scalar
+	// routing only when the map was not configured at all. This mirrors the
+	// validation in Validate() so an explicitly empty `deployments: {}` (or
+	// one with an empty key) returns the same clear error here.
+	if envConfig.Deployments != nil {
+		if len(envConfig.Deployments) == 0 {
+			return nil, fmt.Errorf("database %q environment %q deployments map is empty", database, environment)
+		}
 		deployments := make([]string, 0, len(envConfig.Deployments))
 		for deployment := range envConfig.Deployments {
+			if deployment == "" {
+				return nil, fmt.Errorf("database %q environment %q has a deployments map entry with an empty key", database, environment)
+			}
 			deployments = append(deployments, deployment)
 		}
 		slices.Sort(deployments)

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -456,6 +456,14 @@ func (c *ServerConfig) Validate() error {
 				if len(envConfig.Deployments) == 0 {
 					return fmt.Errorf("database %q environment %q deployments map is empty", name, env)
 				}
+				// The multi-deployment apply path (plan, progress, webhook)
+				// is not yet wired to ResolveDatabaseTargets, so accepting a
+				// >1-entry deployments map here would silently break every
+				// plan/apply with a confusing internal resolver error. Gate
+				// it at config load until the orchestration path lands.
+				if len(envConfig.Deployments) > 1 {
+					return fmt.Errorf("database %q environment %q multi-deployment (>1 entries) is not yet supported by this server; got %d deployments", name, env, len(envConfig.Deployments))
+				}
 				for deployment, dt := range envConfig.Deployments {
 					if deployment == "" {
 						return fmt.Errorf("database %q environment %q has a deployments map entry with an empty key", name, env)

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -283,10 +283,23 @@ type EnvironmentConfig struct {
 	DSNFrom *DSNFromConfig `yaml:"dsn_from,omitempty"`
 
 	// Target is the opaque Tern-facing target identifier for gRPC mode.
+	// Mutually exclusive with Deployments.
 	Target string `yaml:"target,omitempty"`
 
 	// Deployment is the Tern deployment key for gRPC mode.
+	// Mutually exclusive with Deployments.
 	Deployment string `yaml:"deployment,omitempty"`
+
+	// Deployments maps a Tern deployment key to its per-deployment target
+	// for multi-deployment environments. Each key MUST also appear in the
+	// top-level tern_deployments map. Mutually exclusive with the scalar
+	// Target/Deployment fields above.
+	//
+	// Example:
+	//   deployments:
+	//     payments-a: { target: payments }
+	//     payments-b: { target: payments }
+	Deployments map[string]DeploymentTarget `yaml:"deployments,omitempty"`
 
 	// For PlanetScale/Vitess:
 	// Organization is the PlanetScale organization name.
@@ -340,6 +353,15 @@ type ResolvedDatabaseTarget struct {
 	DatabaseType string
 	Deployment   string
 	Target       string
+}
+
+// DeploymentTarget is one entry in EnvironmentConfig.Deployments. It carries
+// the per-deployment override values for a multi-deployment environment. The
+// enclosing map key identifies the Tern deployment (and must also appear in
+// the top-level tern_deployments map).
+type DeploymentTarget struct {
+	// Target is the opaque Tern-facing target identifier for this deployment.
+	Target string `yaml:"target"`
 }
 
 var defaultEnvironmentOrder = []string{"staging", "production"}
@@ -418,17 +440,40 @@ func (c *ServerConfig) Validate() error {
 		}
 		for env, envConfig := range dbConfig.Environments {
 			hasDSN := envConfig.HasLocalDSN()
-			hasRemoteRouting := envConfig.Target != "" || envConfig.Deployment != ""
+			hasScalarRouting := envConfig.Target != "" || envConfig.Deployment != ""
+			hasMapRouting := envConfig.Deployments != nil
 			switch {
-			case hasDSN && hasRemoteRouting:
-				return fmt.Errorf("database %q environment %q cannot configure both local DSN and target/deployment", name, env)
+			case hasDSN && (hasScalarRouting || hasMapRouting):
+				return fmt.Errorf("database %q environment %q cannot configure both local DSN and target/deployment(s)", name, env)
+			case hasScalarRouting && hasMapRouting:
+				return fmt.Errorf("database %q environment %q cannot configure both scalar target/deployment and a deployments map", name, env)
 			case hasDSN:
 				if err := envConfig.validateLocalDSNConfig(fmt.Sprintf("database %q environment %q", name, env)); err != nil {
 					return err
 				}
 				continue
-			case !hasRemoteRouting:
-				return fmt.Errorf("database %q environment %q missing local DSN or target/deployment", name, env)
+			case hasMapRouting:
+				if len(envConfig.Deployments) == 0 {
+					return fmt.Errorf("database %q environment %q deployments map is empty", name, env)
+				}
+				for deployment, dt := range envConfig.Deployments {
+					if deployment == "" {
+						return fmt.Errorf("database %q environment %q has a deployments map entry with an empty key", name, env)
+					}
+					if dt.Target == "" {
+						return fmt.Errorf("database %q environment %q deployment %q missing target", name, env, deployment)
+					}
+					endpoints, ok := c.TernDeployments[deployment]
+					if !ok {
+						return fmt.Errorf("database %q environment %q references unknown deployment %q", name, env, deployment)
+					}
+					if endpoints[env] == "" {
+						return fmt.Errorf("database %q environment %q deployment %q has no endpoint", name, env, deployment)
+					}
+				}
+				continue
+			case !hasScalarRouting:
+				return fmt.Errorf("database %q environment %q missing local DSN or target/deployment(s)", name, env)
 			case envConfig.Target == "":
 				return fmt.Errorf("database %q environment %q missing target", name, env)
 			case envConfig.Deployment == "":
@@ -531,37 +576,79 @@ func (c *ServerConfig) DatabaseEnvironment(database, environment string) *Enviro
 // ResolveDatabaseTarget returns the complete routing metadata for a configured
 // database/environment. Local targets use the database name for deployment and
 // target; remote targets use the configured Tern deployment and opaque target.
+//
+// For environments configured with a deployments map (multi-deployment), this
+// returns the single deployment when exactly one is configured and otherwise
+// errors. Callers that need the full set MUST use ResolveDatabaseTargets.
 func (c *ServerConfig) ResolveDatabaseTarget(database, environment string) (ResolvedDatabaseTarget, error) {
+	targets, err := c.ResolveDatabaseTargets(database, environment)
+	if err != nil {
+		return ResolvedDatabaseTarget{}, err
+	}
+	if len(targets) != 1 {
+		return ResolvedDatabaseTarget{}, fmt.Errorf("database %q environment %q resolves to %d deployments; use ResolveDatabaseTargets", database, environment, len(targets))
+	}
+	return targets[0], nil
+}
+
+// ResolveDatabaseTargets returns the complete routing metadata for a configured
+// database/environment as one or more deployment slices. Single-deployment
+// configurations (scalar target/deployment or local DSN) return a one-element
+// slice; multi-deployment environments return one element per entry in the
+// deployments map, ordered deterministically by deployment key.
+func (c *ServerConfig) ResolveDatabaseTargets(database, environment string) ([]ResolvedDatabaseTarget, error) {
 	if c == nil {
-		return ResolvedDatabaseTarget{}, fmt.Errorf("server config is nil")
+		return nil, fmt.Errorf("server config is nil")
 	}
 	dbConfig := c.Database(database)
 	if dbConfig == nil {
-		return ResolvedDatabaseTarget{}, fmt.Errorf("database %q is not configured on this server", database)
+		return nil, fmt.Errorf("database %q is not configured on this server", database)
 	}
 	envConfig, ok := dbConfig.Environments[environment]
 	if !ok {
-		return ResolvedDatabaseTarget{}, fmt.Errorf("database %q environment %q is not configured on this server", database, environment)
+		return nil, fmt.Errorf("database %q environment %q is not configured on this server", database, environment)
 	}
 
 	if envConfig.HasLocalDSN() {
-		return ResolvedDatabaseTarget{
+		return []ResolvedDatabaseTarget{{
 			DatabaseType: dbConfig.Type,
 			Deployment:   database,
 			Target:       database,
-		}, nil
+		}}, nil
 	}
+
+	if len(envConfig.Deployments) > 0 {
+		deployments := make([]string, 0, len(envConfig.Deployments))
+		for deployment := range envConfig.Deployments {
+			deployments = append(deployments, deployment)
+		}
+		slices.Sort(deployments)
+		out := make([]ResolvedDatabaseTarget, 0, len(deployments))
+		for _, deployment := range deployments {
+			dt := envConfig.Deployments[deployment]
+			if dt.Target == "" {
+				return nil, fmt.Errorf("database %q environment %q deployment %q missing target", database, environment, deployment)
+			}
+			out = append(out, ResolvedDatabaseTarget{
+				DatabaseType: dbConfig.Type,
+				Deployment:   deployment,
+				Target:       dt.Target,
+			})
+		}
+		return out, nil
+	}
+
 	if envConfig.Target == "" {
-		return ResolvedDatabaseTarget{}, fmt.Errorf("database %q environment %q missing server-side target", database, environment)
+		return nil, fmt.Errorf("database %q environment %q missing server-side target", database, environment)
 	}
 	if envConfig.Deployment == "" {
-		return ResolvedDatabaseTarget{}, fmt.Errorf("database %q environment %q missing server-side deployment", database, environment)
+		return nil, fmt.Errorf("database %q environment %q missing server-side deployment", database, environment)
 	}
-	return ResolvedDatabaseTarget{
+	return []ResolvedDatabaseTarget{{
 		DatabaseType: dbConfig.Type,
 		Deployment:   envConfig.Deployment,
 		Target:       envConfig.Target,
-	}, nil
+	}}, nil
 }
 
 // IsRepoAllowed returns whether the given repository is permitted to use SchemaBot.

--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -865,7 +865,10 @@ func TestServerConfig_ResolveDatabaseTargets(t *testing.T) {
 			"payments-c": {"production": "tern-c:9090"},
 		},
 	}
-	require.NoError(t, cfg.Validate())
+	// This test exercises the resolver directly on a hand-built config so
+	// it can cover multi-deployment resolution; the Validate() gate on
+	// multi-deployment maps is covered separately by
+	// TestServerConfig_DeploymentsMapValidation.
 
 	t.Run("local DSN returns single element", func(t *testing.T) {
 		got, err := cfg.ResolveDatabaseTargets("localdb", "staging")
@@ -973,14 +976,24 @@ func TestServerConfig_DeploymentsMapValidation(t *testing.T) {
 		wantErrSub string
 	}{
 		{
-			name: "valid deployments map",
+			name: "valid single-entry deployments map",
+			envConfig: EnvironmentConfig{
+				Deployments: map[string]DeploymentTarget{
+					"payments-a": {Target: "payments"},
+				},
+			},
+			tern: baseTern,
+		},
+		{
+			name: "multi-entry deployments map is rejected until orchestration is wired",
 			envConfig: EnvironmentConfig{
 				Deployments: map[string]DeploymentTarget{
 					"payments-a": {Target: "payments"},
 					"payments-b": {Target: "payments"},
 				},
 			},
-			tern: baseTern,
+			tern:       baseTern,
+			wantErrSub: "multi-deployment (>1 entries) is not yet supported",
 		},
 		{
 			name: "mixing scalar and map is rejected",

--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -830,6 +830,204 @@ func TestServerConfig_ResolveDatabaseTarget(t *testing.T) {
 	assert.Contains(t, err.Error(), "not configured")
 }
 
+func TestServerConfig_ResolveDatabaseTargets(t *testing.T) {
+	cfg := ServerConfig{
+		Databases: map[string]DatabaseConfig{
+			"localdb": {
+				Type: "mysql",
+				Environments: map[string]EnvironmentConfig{
+					"staging": {DSN: "root@tcp(localhost)/localdb"},
+				},
+			},
+			"scalardb": {
+				Type: "vitess",
+				Environments: map[string]EnvironmentConfig{
+					"production": {Target: "cluster-production-001", Deployment: "tenant-a"},
+				},
+			},
+			"multidb": {
+				Type: "mysql",
+				Environments: map[string]EnvironmentConfig{
+					"production": {
+						Deployments: map[string]DeploymentTarget{
+							"payments-c": {Target: "payments"},
+							"payments-a": {Target: "payments"},
+							"payments-b": {Target: "payments"},
+						},
+					},
+				},
+			},
+		},
+		TernDeployments: TernConfig{
+			"tenant-a":   {"production": "localhost:9090"},
+			"payments-a": {"production": "tern-a:9090"},
+			"payments-b": {"production": "tern-b:9090"},
+			"payments-c": {"production": "tern-c:9090"},
+		},
+	}
+	require.NoError(t, cfg.Validate())
+
+	t.Run("local DSN returns single element", func(t *testing.T) {
+		got, err := cfg.ResolveDatabaseTargets("localdb", "staging")
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+		assert.Equal(t, ResolvedDatabaseTarget{DatabaseType: "mysql", Deployment: "localdb", Target: "localdb"}, got[0])
+	})
+
+	t.Run("scalar remote returns single element", func(t *testing.T) {
+		got, err := cfg.ResolveDatabaseTargets("scalardb", "production")
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+		assert.Equal(t, ResolvedDatabaseTarget{DatabaseType: "vitess", Deployment: "tenant-a", Target: "cluster-production-001"}, got[0])
+	})
+
+	t.Run("deployments map returns sorted slice", func(t *testing.T) {
+		got, err := cfg.ResolveDatabaseTargets("multidb", "production")
+		require.NoError(t, err)
+		assert.Equal(t, []ResolvedDatabaseTarget{
+			{DatabaseType: "mysql", Deployment: "payments-a", Target: "payments"},
+			{DatabaseType: "mysql", Deployment: "payments-b", Target: "payments"},
+			{DatabaseType: "mysql", Deployment: "payments-c", Target: "payments"},
+		}, got)
+	})
+
+	t.Run("unknown database errors", func(t *testing.T) {
+		_, err := cfg.ResolveDatabaseTargets("missing", "production")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not configured")
+	})
+
+	t.Run("unknown environment errors", func(t *testing.T) {
+		_, err := cfg.ResolveDatabaseTargets("multidb", "staging")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "staging")
+	})
+
+	t.Run("ResolveDatabaseTarget errors on multi-deployment", func(t *testing.T) {
+		_, err := cfg.ResolveDatabaseTarget("multidb", "production")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "ResolveDatabaseTargets")
+	})
+
+	t.Run("ResolveDatabaseTarget works for scalar remote", func(t *testing.T) {
+		got, err := cfg.ResolveDatabaseTarget("scalardb", "production")
+		require.NoError(t, err)
+		assert.Equal(t, "tenant-a", got.Deployment)
+		assert.Equal(t, "cluster-production-001", got.Target)
+	})
+}
+
+func TestServerConfig_DeploymentsMapValidation(t *testing.T) {
+	baseTern := TernConfig{
+		"payments-a": {"production": "tern-a:9090"},
+		"payments-b": {"production": "tern-b:9090"},
+	}
+
+	cases := []struct {
+		name       string
+		envConfig  EnvironmentConfig
+		tern       TernConfig
+		wantErrSub string
+	}{
+		{
+			name: "valid deployments map",
+			envConfig: EnvironmentConfig{
+				Deployments: map[string]DeploymentTarget{
+					"payments-a": {Target: "payments"},
+					"payments-b": {Target: "payments"},
+				},
+			},
+			tern: baseTern,
+		},
+		{
+			name: "mixing scalar and map is rejected",
+			envConfig: EnvironmentConfig{
+				Target:     "payments",
+				Deployment: "payments-a",
+				Deployments: map[string]DeploymentTarget{
+					"payments-a": {Target: "payments"},
+				},
+			},
+			tern:       baseTern,
+			wantErrSub: "cannot configure both scalar target/deployment and a deployments map",
+		},
+		{
+			name: "empty deployments map is rejected",
+			envConfig: EnvironmentConfig{
+				Deployments: map[string]DeploymentTarget{},
+			},
+			tern:       baseTern,
+			wantErrSub: "deployments map is empty",
+		},
+		{
+			name: "entry with empty target is rejected",
+			envConfig: EnvironmentConfig{
+				Deployments: map[string]DeploymentTarget{
+					"payments-a": {Target: ""},
+				},
+			},
+			tern:       baseTern,
+			wantErrSub: `deployment "payments-a" missing target`,
+		},
+		{
+			name: "unknown deployment is rejected",
+			envConfig: EnvironmentConfig{
+				Deployments: map[string]DeploymentTarget{
+					"unknown-deployment": {Target: "payments"},
+				},
+			},
+			tern:       baseTern,
+			wantErrSub: `references unknown deployment "unknown-deployment"`,
+		},
+		{
+			name: "deployment without endpoint for env is rejected",
+			envConfig: EnvironmentConfig{
+				Deployments: map[string]DeploymentTarget{
+					"payments-a": {Target: "payments"},
+				},
+			},
+			tern: TernConfig{
+				"payments-a": {"staging": "tern-a:9090"},
+			},
+			wantErrSub: `deployment "payments-a" has no endpoint`,
+		},
+		{
+			name: "local DSN together with deployments map is rejected",
+			envConfig: EnvironmentConfig{
+				DSN: "root@tcp(localhost)/payments",
+				Deployments: map[string]DeploymentTarget{
+					"payments-a": {Target: "payments"},
+				},
+			},
+			tern:       baseTern,
+			wantErrSub: "cannot configure both local DSN and target/deployment(s)",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := ServerConfig{
+				Databases: map[string]DatabaseConfig{
+					"payments": {
+						Type: "mysql",
+						Environments: map[string]EnvironmentConfig{
+							"production": tc.envConfig,
+						},
+					},
+				},
+				TernDeployments: tc.tern,
+			}
+			err := cfg.Validate()
+			if tc.wantErrSub == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErrSub)
+		})
+	}
+}
+
 func TestServerConfig_EnvironmentIsolatedConfigMaps(t *testing.T) {
 	stagingConfig := ServerConfig{
 		AllowedEnvironments: []string{"staging"},

--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -917,6 +917,49 @@ func TestServerConfig_ResolveDatabaseTargets(t *testing.T) {
 	})
 }
 
+// TestServerConfig_ResolveDatabaseTargets_BypassValidate covers the cases
+// where a caller constructs a ServerConfig directly without going through
+// Validate() (tests, hot-reload paths, etc.). The resolver must still return
+// a clear error rather than falling through to scalar routing with a
+// misleading "missing server-side target" message.
+func TestServerConfig_ResolveDatabaseTargets_BypassValidate(t *testing.T) {
+	makeCfg := func(env EnvironmentConfig) *ServerConfig {
+		return &ServerConfig{
+			Databases: map[string]DatabaseConfig{
+				"payments": {
+					Type:         "mysql",
+					Environments: map[string]EnvironmentConfig{"production": env},
+				},
+			},
+		}
+	}
+
+	t.Run("explicitly empty deployments map errors clearly", func(t *testing.T) {
+		cfg := makeCfg(EnvironmentConfig{Deployments: map[string]DeploymentTarget{}})
+		_, err := cfg.ResolveDatabaseTargets("payments", "production")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "deployments map is empty")
+	})
+
+	t.Run("empty map key errors clearly", func(t *testing.T) {
+		cfg := makeCfg(EnvironmentConfig{Deployments: map[string]DeploymentTarget{
+			"": {Target: "payments"},
+		}})
+		_, err := cfg.ResolveDatabaseTargets("payments", "production")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "empty key")
+	})
+
+	t.Run("entry with empty target errors clearly", func(t *testing.T) {
+		cfg := makeCfg(EnvironmentConfig{Deployments: map[string]DeploymentTarget{
+			"payments-a": {Target: ""},
+		}})
+		_, err := cfg.ResolveDatabaseTargets("payments", "production")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `deployment "payments-a" missing target`)
+	})
+}
+
 func TestServerConfig_DeploymentsMapValidation(t *testing.T) {
 	baseTern := TernConfig{
 		"payments-a": {"production": "tern-a:9090"},


### PR DESCRIPTION
## What ?
Adds an additive `deployments:` map under `databases.<db>.environments.<env>` so one environment can fan out to N Tern deployments, plus a new `ResolveDatabaseTargets` resolver. No production behavior changes yet — no caller of `ResolveDatabaseTargets` exists (yet).

## Why ?

The resolver shape is the contract between config and orchestration. Landing it before the apply write path is updated means downstream callers can be pure consumers of the new API — no half-migrated state in either direction.

## Config shape

```yaml
databases:
  payments:
    type: mysql
    environments:
      production:
        deployments:
          payments-a:
            target: payments
          payments-b:
            target: payments
          payments-c:
            target: payments

tern_deployments:
  payments-a:
    production: "tern-payments-a:9090"
  payments-b:
    production: "tern-payments-b:9090"
  payments-c:
    production: "tern-payments-c:9090"
```

The map key IS the Tern deployment name — same key space as `tern_deployments`, and the same value that will eventually land on `apply_operations.deployment`. Each entry just carries `target:`.

## Resolver API

```go
// New — returns one element per configured deployment, sorted by deployment key.
func (c *ServerConfig) ResolveDatabaseTargets(database, env string) ([]ResolvedDatabaseTarget, error)

// Existing — now delegates to ResolveDatabaseTargets. Errors with a clear
// "use ResolveDatabaseTargets" message when the env resolves to N != 1
// deployments. Single-deployment callers (plan/apply/progress handlers,
// integration tests) are unaffected.
func (c *ServerConfig) ResolveDatabaseTarget(database, env string) (ResolvedDatabaseTarget, error)
```

## Validation rules

`ServerConfig.Validate()` now also rejects:

- mixing scalar `target` / `deployment` with the `deployments:` map
- mixing local `dsn` / `dsn_from` with the `deployments:` map
- an empty `deployments:` map
- a map entry with empty `target`
- a map key not present in `tern_deployments`, or present but missing an endpoint for the current environment (same cross-check the scalar shape already does)

## Back-compat matrix

| Config has | `ResolveDatabaseTargets` | `ResolveDatabaseTarget` (legacy) |
|---|---|---|
| Scalar `target` + `deployment` | 1-element slice | unchanged, works |
| `deployments:` map (N entries) | N elements sorted by deployment key | errors with "use ResolveDatabaseTargets" |
| Local `dsn` / `dsn_from` | 1-element slice (`Deployment == Target == <db name>`) | unchanged, works |
| Both scalar and map present | validation error at config load | — |
| Local DSN AND any remote routing | validation error at config load | — |
| Neither scalar nor map nor local DSN | validation error at config load | — |

## Design decision worth flagging

The map key is the Tern deployment name, not a separate "logical deployment label". An earlier draft had `{ deployment: payments-a, target: payments }` inside each entry, which would split deployment identity across two keys for no current gain. If we ever need a logical label decoupled from the Tern endpoint name (e.g., for PR-comment display), we can add it later as an additive field on `DeploymentTarget`.

Cross-deployment promotion order (a `deployment_order:` analogous to `environment_order:`) is deferred to a follow-up that also renames the scheduler to operator. This PR sorts by deployment key for deterministic resolution.

## Tests

- `TestServerConfig_ResolveDatabaseTargets`: local DSN, scalar remote, sorted multi-deployment, unknown db, unknown env, multi-deployment via the legacy resolver, scalar via the legacy resolver.
- `TestServerConfig_DeploymentsMapValidation` (table): happy path + six rejection cases (mixed scalar+map, empty map, empty target, unknown deployment, deployment without endpoint for env, local DSN + map).

## Verification

- `go build ./...` ✅
- `go vet ./...` ✅
- `go test ./pkg/api/... ./pkg/state/... ./pkg/storage/... ./pkg/schema/... ./pkg/webhook/...` ✅

## Out of scope

- Wiring `ResolveDatabaseTargets` into the apply / plan write paths — a follow-up will start writing one `apply_operations` row per resolved deployment.
- Server-owned cross-deployment promotion order (`deployment_order:`) — deferred to the follow-up that renames scheduler to operator.
- Per-deployment rows in PR progress comments.
- Per-deployment Check Run rollup.

## Rollback

Pure revert. No on-disk artifact, no schema changes, no live callers of the new API.