### PR TITLE
feat(apply): dual-write apply_operations row on apply create

### DIFF
--- a/charts/schemabot/Chart.yaml
+++ b/charts/schemabot/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: schemabot
 description: GitOps for database schemas
 type: application
-version: 0.1.4
+version: 0.1.5
 appVersion: "v0.1.3"
 maintainers:
   - name: aparajon

--- a/charts/schemabot/values.yaml
+++ b/charts/schemabot/values.yaml
@@ -49,7 +49,11 @@ grpc:
 #         staging: "tern-staging:9090"
 #         production: "tern-production:9090"
 #
-# Example (gRPC mode, multi-deployment environment):
+# Example (gRPC mode, multi-deployment environment — PREVIEW):
+# NOTE: multi-entry deployments maps are rejected at config load until the
+# plan/apply orchestration path is wired through ResolveDatabaseTargets.
+# A single-entry deployments map is accepted and behaves identically to the
+# scalar target / deployment shape.
 #   config:
 #     storage:
 #       dsn: "secretsmanager:schemabot-db#dsn"

--- a/charts/schemabot/values.yaml
+++ b/charts/schemabot/values.yaml
@@ -48,6 +48,27 @@ grpc:
 #       default:
 #         staging: "tern-staging:9090"
 #         production: "tern-production:9090"
+#
+# Example (gRPC mode, multi-deployment environment):
+#   config:
+#     storage:
+#       dsn: "secretsmanager:schemabot-db#dsn"
+#     databases:
+#       payments:
+#         type: mysql
+#         environments:
+#           production:
+#             deployments:
+#               payments-a: { target: "payments" }
+#               payments-b: { target: "payments" }
+#               payments-c: { target: "payments" }
+#     tern_deployments:
+#       payments-a:
+#         production: "tern-payments-a:9090"
+#       payments-b:
+#         production: "tern-payments-b:9090"
+#       payments-c:
+#         production: "tern-payments-c:9090"
 # config is required — helm install will fail without it.
 config: null
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -111,9 +111,11 @@ In gRPC mode, `target` is an opaque identifier understood by the remote Tern ser
 
 The example above is a single SchemaBot deployment that owns both environments. In environment-isolated deployments, each SchemaBot config should contain only the targets for the environments that instance owns. Use `allowed_environments` to scope each instance.
 
-## Multi-Deployment Environment
+## Multi-Deployment Environment (preview)
 
-A single environment can be fanned out to multiple Tern deployments by replacing the scalar `target` / `deployment` pair with a `deployments` map. Each entry's key is a Tern deployment name (which MUST also exist as a key in `tern_deployments`), and each value carries the per-deployment `target`.
+A single environment will eventually be able to fan out to multiple Tern deployments by replacing the scalar `target` / `deployment` pair with a `deployments` map. Each entry's key is a Tern deployment name (which MUST also exist as a key in `tern_deployments`), and each value carries the per-deployment `target`.
+
+> **Not yet enabled in this release.** The config shape and resolver API are landed, but the plan/apply orchestration path still consumes a single deployment per `(database, environment)`. To prevent silent failures, `Validate()` currently rejects any `deployments` map with more than one entry. A single-entry map is accepted and behaves identically to the scalar `target` / `deployment` shape.
 
 ```yaml
 storage:
@@ -145,7 +147,8 @@ Rules:
 
 - `deployments` is mutually exclusive with the scalar `target` / `deployment` fields and with a local `dsn` / `dsn_from`.
 - The map MUST contain at least one entry, each entry MUST set a non-empty `target`, and each map key MUST resolve through `tern_deployments` with an endpoint configured for this environment.
-- Single-deployment environments continue to use the scalar `target` / `deployment` shape.
+- Until the orchestration path is wired, the map MUST contain exactly one entry; multi-entry maps are rejected at config load.
+- Single-deployment environments should continue to use the scalar `target` / `deployment` shape.
 
 Resolution order from the config layer is deterministic and sorted by deployment key. Server-owned cross-deployment ordering (e.g. rolling deploys across regions) is a forthcoming addition that will live alongside `environment_order`.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -111,6 +111,44 @@ In gRPC mode, `target` is an opaque identifier understood by the remote Tern ser
 
 The example above is a single SchemaBot deployment that owns both environments. In environment-isolated deployments, each SchemaBot config should contain only the targets for the environments that instance owns. Use `allowed_environments` to scope each instance.
 
+## Multi-Deployment Environment
+
+A single environment can be fanned out to multiple Tern deployments by replacing the scalar `target` / `deployment` pair with a `deployments` map. Each entry's key is a Tern deployment name (which MUST also exist as a key in `tern_deployments`), and each value carries the per-deployment `target`.
+
+```yaml
+storage:
+  dsn: "env:SCHEMABOT_DSN"
+
+databases:
+  payments:
+    type: mysql
+    environments:
+      production:
+        deployments:
+          payments-a:
+            target: "payments"
+          payments-b:
+            target: "payments"
+          payments-c:
+            target: "payments"
+
+tern_deployments:
+  payments-a:
+    production: "tern-payments-a:9090"
+  payments-b:
+    production: "tern-payments-b:9090"
+  payments-c:
+    production: "tern-payments-c:9090"
+```
+
+Rules:
+
+- `deployments` is mutually exclusive with the scalar `target` / `deployment` fields and with a local `dsn` / `dsn_from`.
+- The map MUST contain at least one entry, each entry MUST set a non-empty `target`, and each map key MUST resolve through `tern_deployments` with an endpoint configured for this environment.
+- Single-deployment environments continue to use the scalar `target` / `deployment` shape.
+
+Resolution order from the config layer is deterministic and sorted by deployment key. Server-owned cross-deployment ordering (e.g. rolling deploys across regions) is a forthcoming addition that will live alongside `environment_order`.
+
 ## Environment Order
 
 For clients, `schemabot.yaml` environments are strictly an opt-in mechanism. They control which environments a repository opts into; they do not control promotion order. SchemaBot enforces promotion order from server config:

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -617,9 +617,19 @@ func (c *ServerConfig) ResolveDatabaseTargets(database, environment string) ([]R
 		}}, nil
 	}
 
-	if len(envConfig.Deployments) > 0 {
+	// A non-nil deployments map is authoritative — fall through to scalar
+	// routing only when the map was not configured at all. This mirrors the
+	// validation in Validate() so an explicitly empty `deployments: {}` (or
+	// one with an empty key) returns the same clear error here.
+	if envConfig.Deployments != nil {
+		if len(envConfig.Deployments) == 0 {
+			return nil, fmt.Errorf("database %q environment %q deployments map is empty", database, environment)
+		}
 		deployments := make([]string, 0, len(envConfig.Deployments))
 		for deployment := range envConfig.Deployments {
+			if deployment == "" {
+				return nil, fmt.Errorf("database %q environment %q has a deployments map entry with an empty key", database, environment)
+			}
 			deployments = append(deployments, deployment)
 		}
 		slices.Sort(deployments)

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -456,6 +456,14 @@ func (c *ServerConfig) Validate() error {
 				if len(envConfig.Deployments) == 0 {
 					return fmt.Errorf("database %q environment %q deployments map is empty", name, env)
 				}
+				// The multi-deployment apply path (plan, progress, webhook)
+				// is not yet wired to ResolveDatabaseTargets, so accepting a
+				// >1-entry deployments map here would silently break every
+				// plan/apply with a confusing internal resolver error. Gate
+				// it at config load until the orchestration path lands.
+				if len(envConfig.Deployments) > 1 {
+					return fmt.Errorf("database %q environment %q multi-deployment (>1 entries) is not yet supported by this server; got %d deployments", name, env, len(envConfig.Deployments))
+				}
 				for deployment, dt := range envConfig.Deployments {
 					if deployment == "" {
 						return fmt.Errorf("database %q environment %q has a deployments map entry with an empty key", name, env)

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -283,10 +283,23 @@ type EnvironmentConfig struct {
 	DSNFrom *DSNFromConfig `yaml:"dsn_from,omitempty"`
 
 	// Target is the opaque Tern-facing target identifier for gRPC mode.
+	// Mutually exclusive with Deployments.
 	Target string `yaml:"target,omitempty"`
 
 	// Deployment is the Tern deployment key for gRPC mode.
+	// Mutually exclusive with Deployments.
 	Deployment string `yaml:"deployment,omitempty"`
+
+	// Deployments maps a Tern deployment key to its per-deployment target
+	// for multi-deployment environments. Each key MUST also appear in the
+	// top-level tern_deployments map. Mutually exclusive with the scalar
+	// Target/Deployment fields above.
+	//
+	// Example:
+	//   deployments:
+	//     payments-a: { target: payments }
+	//     payments-b: { target: payments }
+	Deployments map[string]DeploymentTarget `yaml:"deployments,omitempty"`
 
 	// For PlanetScale/Vitess:
 	// Organization is the PlanetScale organization name.
@@ -340,6 +353,15 @@ type ResolvedDatabaseTarget struct {
 	DatabaseType string
 	Deployment   string
 	Target       string
+}
+
+// DeploymentTarget is one entry in EnvironmentConfig.Deployments. It carries
+// the per-deployment override values for a multi-deployment environment. The
+// enclosing map key identifies the Tern deployment (and must also appear in
+// the top-level tern_deployments map).
+type DeploymentTarget struct {
+	// Target is the opaque Tern-facing target identifier for this deployment.
+	Target string `yaml:"target"`
 }
 
 var defaultEnvironmentOrder = []string{"staging", "production"}
@@ -418,17 +440,40 @@ func (c *ServerConfig) Validate() error {
 		}
 		for env, envConfig := range dbConfig.Environments {
 			hasDSN := envConfig.HasLocalDSN()
-			hasRemoteRouting := envConfig.Target != "" || envConfig.Deployment != ""
+			hasScalarRouting := envConfig.Target != "" || envConfig.Deployment != ""
+			hasMapRouting := envConfig.Deployments != nil
 			switch {
-			case hasDSN && hasRemoteRouting:
-				return fmt.Errorf("database %q environment %q cannot configure both local DSN and target/deployment", name, env)
+			case hasDSN && (hasScalarRouting || hasMapRouting):
+				return fmt.Errorf("database %q environment %q cannot configure both local DSN and target/deployment(s)", name, env)
+			case hasScalarRouting && hasMapRouting:
+				return fmt.Errorf("database %q environment %q cannot configure both scalar target/deployment and a deployments map", name, env)
 			case hasDSN:
 				if err := envConfig.validateLocalDSNConfig(fmt.Sprintf("database %q environment %q", name, env)); err != nil {
 					return err
 				}
 				continue
-			case !hasRemoteRouting:
-				return fmt.Errorf("database %q environment %q missing local DSN or target/deployment", name, env)
+			case hasMapRouting:
+				if len(envConfig.Deployments) == 0 {
+					return fmt.Errorf("database %q environment %q deployments map is empty", name, env)
+				}
+				for deployment, dt := range envConfig.Deployments {
+					if deployment == "" {
+						return fmt.Errorf("database %q environment %q has a deployments map entry with an empty key", name, env)
+					}
+					if dt.Target == "" {
+						return fmt.Errorf("database %q environment %q deployment %q missing target", name, env, deployment)
+					}
+					endpoints, ok := c.TernDeployments[deployment]
+					if !ok {
+						return fmt.Errorf("database %q environment %q references unknown deployment %q", name, env, deployment)
+					}
+					if endpoints[env] == "" {
+						return fmt.Errorf("database %q environment %q deployment %q has no endpoint", name, env, deployment)
+					}
+				}
+				continue
+			case !hasScalarRouting:
+				return fmt.Errorf("database %q environment %q missing local DSN or target/deployment(s)", name, env)
 			case envConfig.Target == "":
 				return fmt.Errorf("database %q environment %q missing target", name, env)
 			case envConfig.Deployment == "":
@@ -531,37 +576,79 @@ func (c *ServerConfig) DatabaseEnvironment(database, environment string) *Enviro
 // ResolveDatabaseTarget returns the complete routing metadata for a configured
 // database/environment. Local targets use the database name for deployment and
 // target; remote targets use the configured Tern deployment and opaque target.
+//
+// For environments configured with a deployments map (multi-deployment), this
+// returns the single deployment when exactly one is configured and otherwise
+// errors. Callers that need the full set MUST use ResolveDatabaseTargets.
 func (c *ServerConfig) ResolveDatabaseTarget(database, environment string) (ResolvedDatabaseTarget, error) {
+	targets, err := c.ResolveDatabaseTargets(database, environment)
+	if err != nil {
+		return ResolvedDatabaseTarget{}, err
+	}
+	if len(targets) != 1 {
+		return ResolvedDatabaseTarget{}, fmt.Errorf("database %q environment %q resolves to %d deployments; use ResolveDatabaseTargets", database, environment, len(targets))
+	}
+	return targets[0], nil
+}
+
+// ResolveDatabaseTargets returns the complete routing metadata for a configured
+// database/environment as one or more deployment slices. Single-deployment
+// configurations (scalar target/deployment or local DSN) return a one-element
+// slice; multi-deployment environments return one element per entry in the
+// deployments map, ordered deterministically by deployment key.
+func (c *ServerConfig) ResolveDatabaseTargets(database, environment string) ([]ResolvedDatabaseTarget, error) {
 	if c == nil {
-		return ResolvedDatabaseTarget{}, fmt.Errorf("server config is nil")
+		return nil, fmt.Errorf("server config is nil")
 	}
 	dbConfig := c.Database(database)
 	if dbConfig == nil {
-		return ResolvedDatabaseTarget{}, fmt.Errorf("database %q is not configured on this server", database)
+		return nil, fmt.Errorf("database %q is not configured on this server", database)
 	}
 	envConfig, ok := dbConfig.Environments[environment]
 	if !ok {
-		return ResolvedDatabaseTarget{}, fmt.Errorf("database %q environment %q is not configured on this server", database, environment)
+		return nil, fmt.Errorf("database %q environment %q is not configured on this server", database, environment)
 	}
 
 	if envConfig.HasLocalDSN() {
-		return ResolvedDatabaseTarget{
+		return []ResolvedDatabaseTarget{{
 			DatabaseType: dbConfig.Type,
 			Deployment:   database,
 			Target:       database,
-		}, nil
+		}}, nil
 	}
+
+	if len(envConfig.Deployments) > 0 {
+		deployments := make([]string, 0, len(envConfig.Deployments))
+		for deployment := range envConfig.Deployments {
+			deployments = append(deployments, deployment)
+		}
+		slices.Sort(deployments)
+		out := make([]ResolvedDatabaseTarget, 0, len(deployments))
+		for _, deployment := range deployments {
+			dt := envConfig.Deployments[deployment]
+			if dt.Target == "" {
+				return nil, fmt.Errorf("database %q environment %q deployment %q missing target", database, environment, deployment)
+			}
+			out = append(out, ResolvedDatabaseTarget{
+				DatabaseType: dbConfig.Type,
+				Deployment:   deployment,
+				Target:       dt.Target,
+			})
+		}
+		return out, nil
+	}
+
 	if envConfig.Target == "" {
-		return ResolvedDatabaseTarget{}, fmt.Errorf("database %q environment %q missing server-side target", database, environment)
+		return nil, fmt.Errorf("database %q environment %q missing server-side target", database, environment)
 	}
 	if envConfig.Deployment == "" {
-		return ResolvedDatabaseTarget{}, fmt.Errorf("database %q environment %q missing server-side deployment", database, environment)
+		return nil, fmt.Errorf("database %q environment %q missing server-side deployment", database, environment)
 	}
-	return ResolvedDatabaseTarget{
+	return []ResolvedDatabaseTarget{{
 		DatabaseType: dbConfig.Type,
 		Deployment:   envConfig.Deployment,
 		Target:       envConfig.Target,
-	}, nil
+	}}, nil
 }
 
 // IsRepoAllowed returns whether the given repository is permitted to use SchemaBot.

--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -865,7 +865,10 @@ func TestServerConfig_ResolveDatabaseTargets(t *testing.T) {
 			"payments-c": {"production": "tern-c:9090"},
 		},
 	}
-	require.NoError(t, cfg.Validate())
+	// This test exercises the resolver directly on a hand-built config so
+	// it can cover multi-deployment resolution; the Validate() gate on
+	// multi-deployment maps is covered separately by
+	// TestServerConfig_DeploymentsMapValidation.
 
 	t.Run("local DSN returns single element", func(t *testing.T) {
 		got, err := cfg.ResolveDatabaseTargets("localdb", "staging")
@@ -973,14 +976,24 @@ func TestServerConfig_DeploymentsMapValidation(t *testing.T) {
 		wantErrSub string
 	}{
 		{
-			name: "valid deployments map",
+			name: "valid single-entry deployments map",
+			envConfig: EnvironmentConfig{
+				Deployments: map[string]DeploymentTarget{
+					"payments-a": {Target: "payments"},
+				},
+			},
+			tern: baseTern,
+		},
+		{
+			name: "multi-entry deployments map is rejected until orchestration is wired",
 			envConfig: EnvironmentConfig{
 				Deployments: map[string]DeploymentTarget{
 					"payments-a": {Target: "payments"},
 					"payments-b": {Target: "payments"},
 				},
 			},
-			tern: baseTern,
+			tern:       baseTern,
+			wantErrSub: "multi-deployment (>1 entries) is not yet supported",
 		},
 		{
 			name: "mixing scalar and map is rejected",

--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -830,6 +830,204 @@ func TestServerConfig_ResolveDatabaseTarget(t *testing.T) {
 	assert.Contains(t, err.Error(), "not configured")
 }
 
+func TestServerConfig_ResolveDatabaseTargets(t *testing.T) {
+	cfg := ServerConfig{
+		Databases: map[string]DatabaseConfig{
+			"localdb": {
+				Type: "mysql",
+				Environments: map[string]EnvironmentConfig{
+					"staging": {DSN: "root@tcp(localhost)/localdb"},
+				},
+			},
+			"scalardb": {
+				Type: "vitess",
+				Environments: map[string]EnvironmentConfig{
+					"production": {Target: "cluster-production-001", Deployment: "tenant-a"},
+				},
+			},
+			"multidb": {
+				Type: "mysql",
+				Environments: map[string]EnvironmentConfig{
+					"production": {
+						Deployments: map[string]DeploymentTarget{
+							"payments-c": {Target: "payments"},
+							"payments-a": {Target: "payments"},
+							"payments-b": {Target: "payments"},
+						},
+					},
+				},
+			},
+		},
+		TernDeployments: TernConfig{
+			"tenant-a":   {"production": "localhost:9090"},
+			"payments-a": {"production": "tern-a:9090"},
+			"payments-b": {"production": "tern-b:9090"},
+			"payments-c": {"production": "tern-c:9090"},
+		},
+	}
+	require.NoError(t, cfg.Validate())
+
+	t.Run("local DSN returns single element", func(t *testing.T) {
+		got, err := cfg.ResolveDatabaseTargets("localdb", "staging")
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+		assert.Equal(t, ResolvedDatabaseTarget{DatabaseType: "mysql", Deployment: "localdb", Target: "localdb"}, got[0])
+	})
+
+	t.Run("scalar remote returns single element", func(t *testing.T) {
+		got, err := cfg.ResolveDatabaseTargets("scalardb", "production")
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+		assert.Equal(t, ResolvedDatabaseTarget{DatabaseType: "vitess", Deployment: "tenant-a", Target: "cluster-production-001"}, got[0])
+	})
+
+	t.Run("deployments map returns sorted slice", func(t *testing.T) {
+		got, err := cfg.ResolveDatabaseTargets("multidb", "production")
+		require.NoError(t, err)
+		assert.Equal(t, []ResolvedDatabaseTarget{
+			{DatabaseType: "mysql", Deployment: "payments-a", Target: "payments"},
+			{DatabaseType: "mysql", Deployment: "payments-b", Target: "payments"},
+			{DatabaseType: "mysql", Deployment: "payments-c", Target: "payments"},
+		}, got)
+	})
+
+	t.Run("unknown database errors", func(t *testing.T) {
+		_, err := cfg.ResolveDatabaseTargets("missing", "production")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not configured")
+	})
+
+	t.Run("unknown environment errors", func(t *testing.T) {
+		_, err := cfg.ResolveDatabaseTargets("multidb", "staging")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "staging")
+	})
+
+	t.Run("ResolveDatabaseTarget errors on multi-deployment", func(t *testing.T) {
+		_, err := cfg.ResolveDatabaseTarget("multidb", "production")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "ResolveDatabaseTargets")
+	})
+
+	t.Run("ResolveDatabaseTarget works for scalar remote", func(t *testing.T) {
+		got, err := cfg.ResolveDatabaseTarget("scalardb", "production")
+		require.NoError(t, err)
+		assert.Equal(t, "tenant-a", got.Deployment)
+		assert.Equal(t, "cluster-production-001", got.Target)
+	})
+}
+
+func TestServerConfig_DeploymentsMapValidation(t *testing.T) {
+	baseTern := TernConfig{
+		"payments-a": {"production": "tern-a:9090"},
+		"payments-b": {"production": "tern-b:9090"},
+	}
+
+	cases := []struct {
+		name       string
+		envConfig  EnvironmentConfig
+		tern       TernConfig
+		wantErrSub string
+	}{
+		{
+			name: "valid deployments map",
+			envConfig: EnvironmentConfig{
+				Deployments: map[string]DeploymentTarget{
+					"payments-a": {Target: "payments"},
+					"payments-b": {Target: "payments"},
+				},
+			},
+			tern: baseTern,
+		},
+		{
+			name: "mixing scalar and map is rejected",
+			envConfig: EnvironmentConfig{
+				Target:     "payments",
+				Deployment: "payments-a",
+				Deployments: map[string]DeploymentTarget{
+					"payments-a": {Target: "payments"},
+				},
+			},
+			tern:       baseTern,
+			wantErrSub: "cannot configure both scalar target/deployment and a deployments map",
+		},
+		{
+			name: "empty deployments map is rejected",
+			envConfig: EnvironmentConfig{
+				Deployments: map[string]DeploymentTarget{},
+			},
+			tern:       baseTern,
+			wantErrSub: "deployments map is empty",
+		},
+		{
+			name: "entry with empty target is rejected",
+			envConfig: EnvironmentConfig{
+				Deployments: map[string]DeploymentTarget{
+					"payments-a": {Target: ""},
+				},
+			},
+			tern:       baseTern,
+			wantErrSub: `deployment "payments-a" missing target`,
+		},
+		{
+			name: "unknown deployment is rejected",
+			envConfig: EnvironmentConfig{
+				Deployments: map[string]DeploymentTarget{
+					"unknown-deployment": {Target: "payments"},
+				},
+			},
+			tern:       baseTern,
+			wantErrSub: `references unknown deployment "unknown-deployment"`,
+		},
+		{
+			name: "deployment without endpoint for env is rejected",
+			envConfig: EnvironmentConfig{
+				Deployments: map[string]DeploymentTarget{
+					"payments-a": {Target: "payments"},
+				},
+			},
+			tern: TernConfig{
+				"payments-a": {"staging": "tern-a:9090"},
+			},
+			wantErrSub: `deployment "payments-a" has no endpoint`,
+		},
+		{
+			name: "local DSN together with deployments map is rejected",
+			envConfig: EnvironmentConfig{
+				DSN: "root@tcp(localhost)/payments",
+				Deployments: map[string]DeploymentTarget{
+					"payments-a": {Target: "payments"},
+				},
+			},
+			tern:       baseTern,
+			wantErrSub: "cannot configure both local DSN and target/deployment(s)",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := ServerConfig{
+				Databases: map[string]DatabaseConfig{
+					"payments": {
+						Type: "mysql",
+						Environments: map[string]EnvironmentConfig{
+							"production": tc.envConfig,
+						},
+					},
+				},
+				TernDeployments: tc.tern,
+			}
+			err := cfg.Validate()
+			if tc.wantErrSub == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErrSub)
+		})
+	}
+}
+
 func TestServerConfig_EnvironmentIsolatedConfigMaps(t *testing.T) {
 	stagingConfig := ServerConfig{
 		AllowedEnvironments: []string{"staging"},

--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -917,6 +917,49 @@ func TestServerConfig_ResolveDatabaseTargets(t *testing.T) {
 	})
 }
 
+// TestServerConfig_ResolveDatabaseTargets_BypassValidate covers the cases
+// where a caller constructs a ServerConfig directly without going through
+// Validate() (tests, hot-reload paths, etc.). The resolver must still return
+// a clear error rather than falling through to scalar routing with a
+// misleading "missing server-side target" message.
+func TestServerConfig_ResolveDatabaseTargets_BypassValidate(t *testing.T) {
+	makeCfg := func(env EnvironmentConfig) *ServerConfig {
+		return &ServerConfig{
+			Databases: map[string]DatabaseConfig{
+				"payments": {
+					Type:         "mysql",
+					Environments: map[string]EnvironmentConfig{"production": env},
+				},
+			},
+		}
+	}
+
+	t.Run("explicitly empty deployments map errors clearly", func(t *testing.T) {
+		cfg := makeCfg(EnvironmentConfig{Deployments: map[string]DeploymentTarget{}})
+		_, err := cfg.ResolveDatabaseTargets("payments", "production")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "deployments map is empty")
+	})
+
+	t.Run("empty map key errors clearly", func(t *testing.T) {
+		cfg := makeCfg(EnvironmentConfig{Deployments: map[string]DeploymentTarget{
+			"": {Target: "payments"},
+		}})
+		_, err := cfg.ResolveDatabaseTargets("payments", "production")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "empty key")
+	})
+
+	t.Run("entry with empty target errors clearly", func(t *testing.T) {
+		cfg := makeCfg(EnvironmentConfig{Deployments: map[string]DeploymentTarget{
+			"payments-a": {Target: ""},
+		}})
+		_, err := cfg.ResolveDatabaseTargets("payments", "production")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `deployment "payments-a" missing target`)
+	})
+}
+
 func TestServerConfig_DeploymentsMapValidation(t *testing.T) {
 	baseTern := TernConfig{
 		"payments-a": {"production": "tern-a:9090"},

--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -247,12 +247,13 @@ func cloneControlRequest(req *storage.ApplyControlRequest) *storage.ApplyControl
 
 type capturingApplyStore struct {
 	storage.ApplyStore
-	mu        sync.Mutex
-	apply     *storage.Apply
-	taskStore *capturingTaskStore
-	claimed   bool
-	findCh    chan struct{}
-	err       error
+	mu         sync.Mutex
+	apply      *storage.Apply
+	operations []*storage.ApplyOperation
+	taskStore  *capturingTaskStore
+	claimed    bool
+	findCh     chan struct{}
+	err        error
 }
 
 func (s *capturingApplyStore) Create(_ context.Context, apply *storage.Apply) (int64, error) {
@@ -266,6 +267,10 @@ func (s *capturingApplyStore) Create(_ context.Context, apply *storage.Apply) (i
 }
 
 func (s *capturingApplyStore) CreateWithTasks(ctx context.Context, apply *storage.Apply, tasks []*storage.Task) (int64, error) {
+	return s.CreateWithTasksAndOperations(ctx, apply, tasks, nil)
+}
+
+func (s *capturingApplyStore) CreateWithTasksAndOperations(ctx context.Context, apply *storage.Apply, tasks []*storage.Task, operations []*storage.ApplyOperation) (int64, error) {
 	s.mu.Lock()
 	if s.err != nil {
 		err := s.err
@@ -296,6 +301,7 @@ func (s *capturingApplyStore) CreateWithTasks(ctx context.Context, apply *storag
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.apply = apply
+	s.operations = append(s.operations, operations...)
 	return applyID, nil
 }
 
@@ -1040,6 +1046,13 @@ func TestExecuteApplyQueuesRemoteApplyForScheduler(t *testing.T) {
 	assert.Nil(t, mock.applyReq, "request path should not call remote Tern before scheduler claim")
 	require.Len(t, tasks.tasks, 1)
 	assert.Equal(t, state.Task.Pending, tasks.tasks[0].State)
+	// Apply create dual-writes one apply_operations row mirroring the apply's
+	// (deployment, target). Today's hard-block keeps this at one row; the
+	// operator claim-loop PR is what consumes them.
+	require.Len(t, applies.operations, 1)
+	assert.Equal(t, DefaultDeployment, applies.operations[0].Deployment)
+	assert.Equal(t, "testdb", applies.operations[0].Target)
+	assert.Equal(t, state.ApplyOperation.Pending, applies.operations[0].State)
 }
 
 func TestProgressByApplyIDServesQueuedRemoteApplyFromStorage(t *testing.T) {

--- a/pkg/api/plan_handlers.go
+++ b/pkg/api/plan_handlers.go
@@ -593,7 +593,22 @@ func (s *Service) createStoredApply(
 		tasks = append(tasks, task)
 	}
 
-	storedApplyID, err := s.storage.Applies().CreateWithTasks(ctx, apply, tasks)
+	// Dual-write one apply_operations row alongside the applies row in the
+	// same transaction. Today the plan already carries the resolved
+	// (deployment, target) pair from plan-time `ResolveDatabaseTarget`, and
+	// the config layer hard-blocks multi-entry deployments maps, so we
+	// always write exactly one operation row that mirrors the apply's own
+	// routing. The data shape is what the operator claim-loop PR consumes
+	// once that gate is lifted and plans become deployment-agnostic.
+	operations := []*storage.ApplyOperation{{
+		Deployment: apply.Deployment,
+		Target:     plan.Target,
+		State:      state.ApplyOperation.Pending,
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	}}
+
+	storedApplyID, err := s.storage.Applies().CreateWithTasksAndOperations(ctx, apply, tasks, operations)
 	if err != nil {
 		return nil, 0, fmt.Errorf("store apply and tasks: %w", err)
 	}

--- a/pkg/storage/mysqlstore/applies.go
+++ b/pkg/storage/mysqlstore/applies.go
@@ -355,6 +355,17 @@ func (s *applyStore) Create(ctx context.Context, apply *storage.Apply) (int64, e
 
 // CreateWithTasks stores an apply and its initial tasks in one transaction.
 func (s *applyStore) CreateWithTasks(ctx context.Context, apply *storage.Apply, tasks []*storage.Task) (int64, error) {
+	return s.CreateWithTasksAndOperations(ctx, apply, tasks, nil)
+}
+
+// CreateWithTasksAndOperations is the unified atomic apply-create path: it
+// inserts the applies row, the initial tasks, and (optionally) the
+// per-deployment apply_operations rows in a single transaction. Pending
+// applies become operator-claimable only after every row commits, so no
+// reader observes a partially-populated apply.
+func (s *applyStore) CreateWithTasksAndOperations(ctx context.Context, apply *storage.Apply, tasks []*storage.Task, operations []*storage.ApplyOperation) (int64, error) {
+	const opName = "create apply with tasks"
+
 	// Ensure options has valid JSON (empty object if nil)
 	options := apply.Options
 	if len(options) == 0 {
@@ -365,17 +376,17 @@ func (s *applyStore) CreateWithTasks(ctx context.Context, apply *storage.Apply, 
 	var writeTx *applyWriteTx
 	var err error
 	if lockTarget {
-		writeTx, err = beginApplyTargetWriteTx(ctx, s.db, "create apply with tasks", apply.Database, apply.DatabaseType, apply.Environment)
+		writeTx, err = beginApplyTargetWriteTx(ctx, s.db, opName, apply.Database, apply.DatabaseType, apply.Environment)
 		if err != nil {
 			return 0, err
 		}
 	} else {
-		writeTx, err = beginApplyWriteTx(ctx, s.db, "create apply with tasks")
+		writeTx, err = beginApplyWriteTx(ctx, s.db, opName)
 		if err != nil {
 			return 0, err
 		}
 	}
-	defer writeTx.close(ctx, "create apply with tasks")
+	defer writeTx.close(ctx, opName)
 
 	if lockTarget {
 		if err := checkNoActiveApplyForTarget(ctx, writeTx.tx, apply.Database, apply.DatabaseType, apply.Environment, 0); err != nil {
@@ -415,8 +426,15 @@ func (s *applyStore) CreateWithTasks(ctx context.Context, apply *storage.Apply, 
 		task.ID = taskID
 	}
 
+	for _, op := range operations {
+		op.ApplyID = id
+		if _, err := insertApplyOperation(ctx, writeTx.tx, op); err != nil {
+			return 0, fmt.Errorf("insert apply_operation (deployment=%s) for apply %s: %w", op.Deployment, apply.ApplyIdentifier, err)
+		}
+	}
+
 	if err := writeTx.commit(); err != nil {
-		return 0, fmt.Errorf("commit create apply with tasks: %w", err)
+		return 0, fmt.Errorf("commit %s: %w", opName, err)
 	}
 
 	return id, nil

--- a/pkg/storage/mysqlstore/applies_test.go
+++ b/pkg/storage/mysqlstore/applies_test.go
@@ -139,6 +139,116 @@ func TestApplyStore_CreateWithTasksCommitsQueueAtomically(t *testing.T) {
 	assert.Equal(t, apply.ApplyIdentifier, claimed.ApplyIdentifier)
 }
 
+func TestApplyStore_CreateWithTasksAndOperationsCommitsAtomically(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "payments", storage.DatabaseTypeMySQL, "production")
+	now := time.Now()
+	apply := &storage.Apply{
+		ApplyIdentifier: "apply_create_with_ops",
+		LockID:          lock.ID,
+		PlanID:          1,
+		Database:        "payments",
+		DatabaseType:    storage.DatabaseTypeMySQL,
+		Repository:      "org/repo",
+		PullRequest:     123,
+		Environment:     "production",
+		Deployment:      "payments-a",
+		Engine:          storage.EngineSpirit,
+		State:           state.Apply.Pending,
+		Options:         []byte("{}"),
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+	tasks := []*storage.Task{
+		{
+			TaskIdentifier: "task_create_with_ops_users",
+			PlanID:         1,
+			Database:       "payments",
+			DatabaseType:   storage.DatabaseTypeMySQL,
+			Engine:         storage.EngineSpirit,
+			Environment:    "production",
+			State:          state.Task.Pending,
+			TableName:      "users",
+			DDL:            "ALTER TABLE users ADD COLUMN email VARCHAR(255)",
+			DDLAction:      "alter",
+			Options:        []byte("{}"),
+			CreatedAt:      now,
+			UpdatedAt:      now,
+		},
+	}
+	operations := []*storage.ApplyOperation{
+		{
+			Deployment: "payments-a",
+			Target:     "payments",
+			State:      state.ApplyOperation.Pending,
+			CreatedAt:  now,
+			UpdatedAt:  now,
+		},
+	}
+
+	applyID, err := store.Applies().CreateWithTasksAndOperations(ctx, apply, tasks, operations)
+	require.NoError(t, err)
+	require.NotZero(t, applyID)
+
+	storedTasks, err := store.Tasks().GetByApplyID(ctx, applyID)
+	require.NoError(t, err)
+	require.Len(t, storedTasks, 1)
+	assert.Equal(t, applyID, tasks[0].ApplyID)
+
+	storedOps, err := store.ApplyOperations().ListByApply(ctx, applyID)
+	require.NoError(t, err)
+	require.Len(t, storedOps, 1)
+	assert.Equal(t, applyID, storedOps[0].ApplyID)
+	assert.Equal(t, "payments-a", storedOps[0].Deployment)
+	assert.Equal(t, "payments", storedOps[0].Target)
+	assert.Equal(t, state.ApplyOperation.Pending, storedOps[0].State)
+	// CreateWithTasksAndOperations also back-fills the operation's ApplyID
+	// onto the caller-supplied struct (same contract as CreateWithTasks).
+	assert.Equal(t, applyID, operations[0].ApplyID)
+}
+
+func TestApplyStore_CreateWithTasksAndOperationsRollsBackOnOperationFailure(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "payments", storage.DatabaseTypeMySQL, "production")
+	now := time.Now()
+	apply := &storage.Apply{
+		ApplyIdentifier: "apply_rollback_on_op_failure",
+		LockID:          lock.ID,
+		PlanID:          1,
+		Database:        "payments",
+		DatabaseType:    storage.DatabaseTypeMySQL,
+		Repository:      "org/repo",
+		PullRequest:     123,
+		Environment:     "production",
+		Deployment:      "payments-a",
+		Engine:          storage.EngineSpirit,
+		State:           state.Apply.Pending,
+		Options:         []byte("{}"),
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+	// Two operations sharing the same deployment violates the
+	// UNIQUE KEY (apply_id, deployment) constraint on the second insert and
+	// must roll back the whole transaction — no orphan apply or tasks rows.
+	operations := []*storage.ApplyOperation{
+		{Deployment: "payments-a", Target: "payments", State: state.ApplyOperation.Pending, CreatedAt: now, UpdatedAt: now},
+		{Deployment: "payments-a", Target: "payments", State: state.ApplyOperation.Pending, CreatedAt: now, UpdatedAt: now},
+	}
+
+	_, err := store.Applies().CreateWithTasksAndOperations(ctx, apply, nil, operations)
+	require.Error(t, err)
+
+	got, err := store.Applies().GetByApplyIdentifier(ctx, apply.ApplyIdentifier)
+	require.NoError(t, err)
+	assert.Nil(t, got, "apply row must not exist after rollback")
+}
+
 func TestApplyStore_CreateBlocksActiveApplyForSameTarget(t *testing.T) {
 	clearTables(t)
 	ctx := t.Context()

--- a/pkg/storage/mysqlstore/apply_operations.go
+++ b/pkg/storage/mysqlstore/apply_operations.go
@@ -38,12 +38,27 @@ type applyOperationStore struct {
 // Translates a unique-key conflict on (apply_id, deployment) into
 // storage.ErrApplyOperationExists so callers can branch cleanly.
 func (s *applyOperationStore) Insert(ctx context.Context, ad *storage.ApplyOperation) (int64, error) {
+	return insertApplyOperation(ctx, s.db, ad)
+}
+
+// sqlExecer is the subset of *sql.DB / *sql.Tx used by insertApplyOperation.
+// Defined locally so the helper can run against either the pool or an
+// in-flight transaction (for atomic apply-create dual-writes).
+type sqlExecer interface {
+	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
+}
+
+// insertApplyOperation inserts one apply_operations row using the supplied
+// executer (pool or transaction). On success the row's ID and State fields
+// are set. A duplicate-key violation on (apply_id, deployment) is translated
+// to storage.ErrApplyOperationExists for callers to branch on.
+func insertApplyOperation(ctx context.Context, exec sqlExecer, ad *storage.ApplyOperation) (int64, error) {
 	stateVal := ad.State
 	if stateVal == "" {
 		stateVal = state.ApplyOperation.Pending
 	}
 
-	result, err := s.db.ExecContext(ctx, `
+	result, err := exec.ExecContext(ctx, `
 		INSERT INTO apply_operations (
 			apply_id, deployment, target, state, error_message,
 			started_at, completed_at

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -179,6 +179,13 @@ type ApplyStore interface {
 	// task rows are committed.
 	CreateWithTasks(ctx context.Context, apply *Apply, tasks []*Task) (int64, error)
 
+	// CreateWithTasksAndOperations stores a new apply, its initial tasks, and
+	// its per-deployment apply_operations rows in a single transaction. Each
+	// operation row's ApplyID is set to the new apply ID before insert.
+	// Pending applies become scheduler-claimable only after every row is
+	// committed, so the operator never observes a partially-populated apply.
+	CreateWithTasksAndOperations(ctx context.Context, apply *Apply, tasks []*Task, operations []*ApplyOperation) (int64, error)
+
 	// Get returns an apply by ID, or nil if not found.
 	Get(ctx context.Context, id int64) (*Apply, error)
 

--- a/pkg/webhook/webhook_e2e_test.go
+++ b/pkg/webhook/webhook_e2e_test.go
@@ -2217,6 +2217,63 @@ func applyEmbeddedSchema(db *sql.DB, schemaFS embed.FS) error {
 	return nil
 }
 
+// TestE2EApplyCreateDualWritesApplyOperationRow verifies the service-level
+// apply create path writes exactly one apply_operations row in the same
+// transaction as the applies row, mirroring the apply's (deployment, target)
+// routing. The operator claim loop is not yet wired to these rows, so the
+// row stays in pending — that's the contract until a subsequent PR lifts
+// the deployments-map gate and introduces the per-row claim loop.
+func TestE2EApplyCreateDualWritesApplyOperationRow(t *testing.T) {
+	dbName := "webhook_apply_dual_write"
+	svc := setupE2EService(t, dbName)
+	ctx := t.Context()
+
+	// Seed the target so the plan produces a real DDL change.
+	appDSN := strings.Replace(e2eTargetDSN, "/target_test", "/"+dbName, 1) + "&multiStatements=true"
+	db, err := sql.Open("mysql", appDSN)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, "CREATE TABLE `users` (\n  `id` bigint unsigned NOT NULL AUTO_INCREMENT,\n  `name` varchar(255) NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci")
+	require.NoError(t, err)
+	_ = db.Close()
+
+	schemaWithIndex := "CREATE TABLE `users` (\n  `id` bigint unsigned NOT NULL AUTO_INCREMENT,\n  `name` varchar(255) NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `idx_name` (`name`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;"
+	planResp, err := svc.ExecutePlan(ctx, api.PlanRequest{
+		Database:    dbName,
+		Environment: "staging",
+		Type:        "mysql",
+		SchemaFiles: map[string]*ternv1.SchemaFiles{
+			dbName: {Files: map[string]string{"users.sql": schemaWithIndex}},
+		},
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, planResp.Changes, "expected DDL changes")
+
+	applyResp, applyID, err := svc.ExecuteApply(ctx, api.ApplyRequest{
+		PlanID:      planResp.PlanID,
+		Environment: "staging",
+		Options:     map[string]string{"allow_unsafe": "true"},
+	})
+	require.NoError(t, err)
+	require.True(t, applyResp.Accepted)
+	require.Greater(t, applyID, int64(0))
+
+	apply, err := svc.Storage().Applies().Get(ctx, applyID)
+	require.NoError(t, err)
+	require.NotNil(t, apply)
+	plan, err := svc.Storage().Plans().Get(ctx, planResp.PlanID)
+	require.NoError(t, err)
+	require.NotNil(t, plan)
+
+	ops, err := svc.Storage().ApplyOperations().ListByApply(ctx, applyID)
+	require.NoError(t, err)
+	require.Len(t, ops, 1, "apply create must dual-write exactly one apply_operations row")
+	op := ops[0]
+	assert.Equal(t, applyID, op.ApplyID)
+	assert.Equal(t, apply.Deployment, op.Deployment, "operation deployment must match apply deployment")
+	assert.Equal(t, plan.Target, op.Target, "operation target must mirror the plan-time target")
+	assert.Equal(t, state.ApplyOperation.Pending, op.State, "operation row stays pending — no consumer is wired yet")
+}
+
 // TestE2ERollbackPlanViaWebhook tests the full rollback flow:
 // 1. Plan + apply a schema change via the service (simulating a prior apply)
 // 2. Run "schemabot rollback <apply-id> -e staging" via webhook


### PR DESCRIPTION
> Stacked on #213 — review and land that one first. Re-target to `main` once #213 merges.

Apply create now writes one `apply_operations` row alongside the `applies` row and its initial tasks, all in a single transaction. Puts the per-deployment data shape in place ahead of the operator claim-loop change that consumes it. No behavior change at apply time today — the claim loop still drives off `applies` rows.

## Table of contents

- [Storage API](#storage-api)
- [Service wiring](#service-wiring)
- [Why not call ResolveDatabaseTargets at apply time](#why-not-call-resolvedatabasetargets-at-apply-time)
- [Tests](#tests)
- [Verification](#verification)
- [Out of scope](#out-of-scope)
- [Rollback](#rollback)

## Storage API

```go
// New — atomic apply + tasks + operations in one transaction.
ApplyStore.CreateWithTasksAndOperations(ctx, apply, tasks, operations) (int64, error)
```

`CreateWithTasks` now delegates to it with `nil` operations, so the lock + transaction code lives in one place. `insertApplyOperation(ctx, exec, op)` is extracted so the in-tx caller and the existing public `ApplyOperationStore.Insert` share the same insert + dup-key translation.

## Service wiring

`createStoredApply` builds one `ApplyOperation` mirroring the apply's `(Deployment, Target)` and passes it through `CreateWithTasksAndOperations`. The config layer still hard-blocks `deployments:` maps with >1 entries, so this slice is always length 1 today.

## Why not call ResolveDatabaseTargets at apply time

The plan already carries the resolved `(deployment, target)` pair from plan-time `ResolveDatabaseTarget`. Re-resolving at apply time would silently change routing if server config drifted between plan and apply. The next PR (which makes plans deployment-agnostic for multi-deployment configs) is the right place to wire `ResolveDatabaseTargets` at apply time.

## Tests

- `TestExecuteApplyQueuesRemoteApplyForScheduler` now also asserts the dual-written operation (deployment / target / state=pending).
- New integration tests in `pkg/storage/mysqlstore/applies_test.go`:
  - `CreateWithTasksAndOperationsCommitsAtomically` — apply + task + operation all visible after commit; `ApplyID` back-filled on the caller-supplied operation struct.
  - `CreateWithTasksAndOperationsRollsBackOnOperationFailure` — a duplicate `(apply_id, deployment)` on the second operation insert rolls back the whole transaction, leaving no orphan apply.

## Verification

- `go build ./...` ✅
- `go vet ./...` ✅
- `go vet -tags integration ./pkg/storage/mysqlstore/...` ✅
- `go test ./pkg/api/... ./pkg/state/... ./pkg/storage/... ./pkg/schema/... ./pkg/webhook/... ./pkg/tern/...` ✅

## Out of scope

- Operator claim loop reading `apply_operations` rows.
- Lifting the config-layer hard-block on multi-entry `deployments:` maps.
- Per-deployment progress comments / Check Run rollup.

## Rollback

Pure revert. New `apply_operations` rows written during soak are harmless — no reader yet — and can be left in place or deleted with a one-shot query.