### PR TITLE
feat(github): support cutover requests from PR comments

### DIFF
--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -2009,6 +2009,34 @@ Cutover in progress — typically completes within seconds.
 </details>
 
 <details>
+<summary><a name="cutover-command-accepted"></a><strong>Cutover Command Accepted</strong></summary>
+
+
+## Cutover Request Accepted
+
+**Apply**: `apply-a1b2c3d4e5f67890`
+**Environment**: `staging`
+**Requested by**: @alice
+
+Cutover request accepted. SchemaBot will complete this schema change; status remains available from the PR progress comment or CLI.
+
+</details>
+
+<details>
+<summary><a name="cutover-command-already-in-progress"></a><strong>Cutover Command Already In Progress</strong></summary>
+
+
+## Cutover Request Accepted
+
+**Apply**: `apply-a1b2c3d4e5f67890`
+**Environment**: `staging`
+**Requested by**: @alice
+
+Cutover is already in progress. SchemaBot will keep reporting progress from the existing apply.
+
+</details>
+
+<details>
 <summary><a name="summary-completed"></a><strong>Summary: Completed</strong></summary>
 
 
@@ -2168,7 +2196,6 @@ ALTER TABLE `audit_logs` ADD INDEX `idx_created_at`(`created_at`);
 ALTER TABLE `notifications` ADD INDEX `idx_user_status`(`user_id`, `status`);
 ```
 
-</details>
 _Apply ID: apply-a1b2c3d4e5f6_
 
 </details>
@@ -2227,7 +2254,6 @@ ALTER TABLE `audit_logs` ADD INDEX `idx_created_at`(`created_at`);
 ALTER TABLE `notifications` ADD INDEX `idx_user_status`(`user_id`, `status`);
 ```
 
-</details>
 
 ---
 
@@ -4156,6 +4182,36 @@ SchemaBot could not verify authorization for `schemabot apply-confirm`. No schem
 If access is granted through a GitHub team, verify the GitHub App can read organization members and team membership.
 
 A configured SchemaBot admin/database operator should inspect SchemaBot authorization logs before retrying.
+
+
+</details>
+
+<details>
+<summary><a name="cutover-command-accepted"></a><strong>Cutover Command Accepted</strong></summary>
+
+
+## Cutover Request Accepted
+
+**Apply**: `apply-a1b2c3d4e5f67890`
+**Environment**: `staging`
+**Requested by**: @alice
+
+Cutover request accepted. SchemaBot will complete this schema change; status remains available from the PR progress comment or CLI.
+
+
+</details>
+
+<details>
+<summary><a name="cutover-command-already-in-progress"></a><strong>Cutover Command Already In Progress</strong></summary>
+
+
+## Cutover Request Accepted
+
+**Apply**: `apply-a1b2c3d4e5f67890`
+**Environment**: `staging`
+**Requested by**: @alice
+
+Cutover is already in progress. SchemaBot will keep reporting progress from the existing apply.
 
 
 </details>

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -191,11 +191,12 @@ skip the API fast path because the scheduler owner must both stop the remote
 data plane and reconcile SchemaBot's local storage in one owner-controlled flow.
 
 Forward-progress controls must fail closed while a stop is pending. User-driven
-cutover is rejected when a pending stop request exists, and scheduler-owned
-pollers check for pending stops before continuing progress work. This avoids the
-unsafe interleaving where `/api/stop` returns accepted while another path moves
-the same apply from `waiting_for_cutover` into cutover or completion before the
-stop can be applied.
+cutover is rejected when a pending stop request exists, whether the request came
+from the CLI/API path or a PR comment, and scheduler-owned pollers check for
+pending stops before continuing progress work. This avoids the unsafe
+interleaving where `/api/stop` returns accepted while another path moves the
+same apply from `waiting_for_cutover` into cutover or completion before the stop
+can be applied.
 
 Cutover requests follow the same durable-owner model. The API accepts cutover
 when the apply is ready for cutover, records a pending cutover request, and wakes

--- a/docs/grpc-control-edge-cases.md
+++ b/docs/grpc-control-edge-cases.md
@@ -230,7 +230,7 @@ follows the remote-readiness scenario above.
 | 17 | Cutover requested while stored apply is already `cutting_over` | Return accepted/idempotent with `status=already_in_progress`, log the caller, and do not queue another durable request | Covered for current cutover path |
 | 18 | MySQL/Spirit cutover RPC lands on a non-owner data-plane replica | After durable readiness checks, any replica can drop the sentinel table; the owner runner observes the DB-side signal | Covered by K8s e2e |
 | 19 | PR comment stop support | Same semantics as CLI stop: durable request first, caller visible, stop priority preserved | Covered |
-| 20 | PR comment cutover support | Same safety gate as CLI cutover, plus durable cutover intent if async ownership requires it | Follow-up |
+| 20 | PR comment cutover support | Same safety gate as CLI/API cutover, including pending-stop rejection, plus durable cutover intent if async ownership requires it | Covered |
 | 21 | Spirit checkpoint resume loses prior copy progress after restart | Surface lost-progress reason through Spirit resume status APIs instead of inferring from sentinel tables | Follow-up after Spirit dependency exposes the API |
 
 ## Review questions for new gRPC control changes

--- a/pkg/api/control_handlers.go
+++ b/pkg/api/control_handlers.go
@@ -327,6 +327,21 @@ func (s *Service) handleCutover(w http.ResponseWriter, r *http.Request) {
 	s.writeJSON(w, httpStatus, resp)
 }
 
+// ExecuteCutover records durable cutover intent for an apply. The scheduler
+// owner is responsible for completing cutover against the data plane.
+func (s *Service) ExecuteCutover(ctx context.Context, req apitypes.ControlRequest) (*apitypes.ControlResponse, error) {
+	client, apply, ternApplyID, err := s.controlTarget(ctx, "cutover", req.ApplyID, req.Environment)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.rejectControlIfStopPending(ctx, "cutover", apply); err != nil {
+		metrics.RecordControlOperation(ctx, "cutover", apply.Database, apply.Deployment, apply.Environment, "rejected")
+		return nil, err
+	}
+	resp, _, err := s.executeCutoverForApply(ctx, client, apply, ternApplyID, req.Caller)
+	return resp, err
+}
+
 func (s *Service) executeCutoverForApply(ctx context.Context, client tern.Client, apply *storage.Apply, ternApplyID, caller string) (*apitypes.ControlResponse, int, error) {
 	controlStore := s.storage.ControlRequests()
 	if controlStore == nil {

--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -2723,6 +2723,37 @@ func TestCutoverHandler(t *testing.T) {
 		assert.True(t, hasApplyLogMessageContaining(logs.logs, "Pending stop request blocked cutover (caller: cli:stopper)"))
 	})
 
+	t.Run("ExecuteCutover rejects while stop request is pending", func(t *testing.T) {
+		mock := &mockTernClient{
+			cutoverResp: &ternv1.CutoverResponse{Accepted: true},
+		}
+		apply := activeTestApply("apply-execute-cutover-stop-pending")
+		logs := &capturingApplyLogStore{}
+		controlRequests := &memoryControlRequestStore{requests: []*storage.ApplyControlRequest{{
+			ApplyID:     apply.ID,
+			Operation:   storage.ControlOperationStop,
+			Status:      storage.ControlRequestPending,
+			RequestedBy: "cli:stopper",
+		}}}
+		svc := newControlTestService(mock, apply)
+		require.IsType(t, &mockStorageWithApplyStores{}, svc.storage)
+		store := svc.storage.(*mockStorageWithApplyStores)
+		store.controls = controlRequests
+		store.applyLogs = logs
+
+		resp, err := svc.ExecuteCutover(t.Context(), apitypes.ControlRequest{
+			ApplyID:     "apply-execute-cutover-stop-pending",
+			Environment: "staging",
+			Caller:      "github:cutter@octocat/hello-world#1",
+		})
+
+		require.Error(t, err)
+		assert.Nil(t, resp)
+		assert.Nil(t, mock.cutoverReq)
+		assert.Contains(t, err.Error(), "pending stop request")
+		assert.True(t, hasApplyLogMessageContaining(logs.logs, "Pending stop request blocked cutover (caller: cli:stopper)"))
+	})
+
 	t.Run("requires apply_id", func(t *testing.T) {
 		mock := &mockTernClient{}
 		svc := newControlTestService(mock, activeTestApply("apply-active-cutover"))

--- a/pkg/cmd/commands/preview.go
+++ b/pkg/cmd/commands/preview.go
@@ -92,7 +92,8 @@ func (cmd *PreviewCmd) Run(g *Globals) error {
 		templates.PreviewCommentApplyActive,
 		templates.PreviewCommentApplyNoLock, templates.PreviewCommentApplyAllType,
 		templates.PreviewCommentChecksGateFailing, templates.PreviewCommentChecksGateInProgress,
-		templates.PreviewCommentActorNotAuthorized, templates.PreviewCommentActorAuthUnavailable:
+		templates.PreviewCommentActorNotAuthorized, templates.PreviewCommentActorAuthUnavailable,
+		templates.PreviewCommentCutoverAccepted, templates.PreviewCommentCutoverActive:
 		templates.PreviewCLIOutput(previewType)
 	// Paired aggregate types (PR + CLI subsections)
 	case templates.PreviewCommentPlanAll, templates.PreviewCommentLockingAll,
@@ -251,6 +252,8 @@ Apply Command Comments (GitHub PR apply commands):
   comment_apply_no_lock         No lock found (need apply first)
   comment_actor_not_authorized  Actor authorization denied
   comment_actor_auth_unavailable Actor authorization fail-closed error
+  comment_cutover_accepted      Cutover request accepted
+  comment_cutover_active        Cutover already in progress
   comment_apply_all             Show all apply command previews
 
 Aggregate Types (grouped PR + CLI pairs):

--- a/pkg/cmd/internal/templates/preview.go
+++ b/pkg/cmd/internal/templates/preview.go
@@ -160,5 +160,7 @@ const (
 	PreviewCommentChecksGateInProgress PreviewType = "comment_checks_gate_in_progress"      // Checks gate: CI still running
 	PreviewCommentActorNotAuthorized   PreviewType = "comment_actor_not_authorized"         // Actor authorization: user is not allowed
 	PreviewCommentActorAuthUnavailable PreviewType = "comment_actor_auth_unavailable"       // Actor authorization: fail-closed error
+	PreviewCommentCutoverAccepted      PreviewType = "comment_cutover_accepted"             // Cutover command accepted
+	PreviewCommentCutoverActive        PreviewType = "comment_cutover_active"               // Cutover command when cutover is already in progress
 	PreviewCommentApplyAllType         PreviewType = "comment_apply_all"                    // Show all apply comment previews
 )

--- a/pkg/cmd/internal/templates/preview_comment.go
+++ b/pkg/cmd/internal/templates/preview_comment.go
@@ -60,6 +60,8 @@ func previewCommentAllOutput() {
 		{"APPLY STOPPED", func() { fmt.Print(webhooktemplates.PreviewCommentApplyStopped()) }},
 		{"APPLY WAITING FOR CUTOVER", func() { fmt.Print(webhooktemplates.PreviewCommentApplyWaitingForCutover()) }},
 		{"APPLY CUTTING OVER", func() { fmt.Print(webhooktemplates.PreviewCommentApplyCuttingOver()) }},
+		{"CUTOVER COMMAND ACCEPTED", func() { fmt.Print(webhooktemplates.PreviewCommentCutoverCommandAccepted()) }},
+		{"CUTOVER COMMAND ALREADY IN PROGRESS", func() { fmt.Print(webhooktemplates.PreviewCommentCutoverCommandAlreadyInProgress()) }},
 		{"SUMMARY: COMPLETED", func() { fmt.Print(webhooktemplates.PreviewCommentSummaryCompleted()) }},
 		{"SUMMARY: FAILED", func() { fmt.Print(webhooktemplates.PreviewCommentSummaryFailed()) }},
 		{"SUMMARY: STOPPED", func() { fmt.Print(webhooktemplates.PreviewCommentSummaryStopped()) }},
@@ -100,6 +102,8 @@ func previewApplyCommandAllOutput() {
 		{"REVIEW GATE ERROR (FAIL-CLOSED)", func() { fmt.Print(webhooktemplates.PreviewCommentReviewGateError()) }},
 		{"ACTOR AUTHORIZATION: NOT AUTHORIZED", func() { fmt.Print(webhooktemplates.PreviewCommentPRCommandNotAuthorized()) }},
 		{"ACTOR AUTHORIZATION: UNAVAILABLE", func() { fmt.Print(webhooktemplates.PreviewCommentPRCommandAuthorizationUnavailable()) }},
+		{"CUTOVER COMMAND ACCEPTED", func() { fmt.Print(webhooktemplates.PreviewCommentCutoverCommandAccepted()) }},
+		{"CUTOVER COMMAND ALREADY IN PROGRESS", func() { fmt.Print(webhooktemplates.PreviewCommentCutoverCommandAlreadyInProgress()) }},
 		{"CHECKS GATE: FAILING", func() {
 			fmt.Print(webhooktemplates.RenderApplyBlockedByFailingChecks("staging", []webhooktemplates.BlockingCheck{
 				{Name: "CI / unit-tests", State: "failure"},
@@ -200,6 +204,8 @@ func previewCommentApplyFlowAllOutput() {
 		// Cutover states
 		{"WAITING FOR CUTOVER", func() { fmt.Print(webhooktemplates.PreviewCommentApplyWaitingForCutover()) }},
 		{"CUTTING OVER", func() { fmt.Print(webhooktemplates.PreviewCommentApplyCuttingOver()) }},
+		{"CUTOVER COMMAND ACCEPTED", func() { fmt.Print(webhooktemplates.PreviewCommentCutoverCommandAccepted()) }},
+		{"CUTOVER COMMAND ALREADY IN PROGRESS", func() { fmt.Print(webhooktemplates.PreviewCommentCutoverCommandAlreadyInProgress()) }},
 		// Summaries
 		{"SUMMARY: COMPLETED", func() { fmt.Print(webhooktemplates.PreviewCommentSummaryCompleted()) }},
 		{"SUMMARY: FAILED", func() { fmt.Print(webhooktemplates.PreviewCommentSummaryFailed()) }},

--- a/pkg/cmd/internal/templates/preview_dispatch.go
+++ b/pkg/cmd/internal/templates/preview_dispatch.go
@@ -212,6 +212,10 @@ func PreviewCLIOutput(previewType PreviewType) {
 		fmt.Print(webhooktemplates.PreviewCommentPRCommandNotAuthorized())
 	case PreviewCommentActorAuthUnavailable:
 		fmt.Print(webhooktemplates.PreviewCommentPRCommandAuthorizationUnavailable())
+	case PreviewCommentCutoverAccepted:
+		fmt.Print(webhooktemplates.PreviewCommentCutoverCommandAccepted())
+	case PreviewCommentCutoverActive:
+		fmt.Print(webhooktemplates.PreviewCommentCutoverCommandAlreadyInProgress())
 	case PreviewCommentApplyAllType:
 		previewApplyCommandAllOutput()
 	// Paired aggregate previews (PR + CLI subsections)

--- a/pkg/webhook/commands.go
+++ b/pkg/webhook/commands.go
@@ -64,7 +64,7 @@ var commandSpecs = []CommandSpec{
 	{Name: action.Stop, RequiresEnv: true, HasApplyID: true},
 	{Name: action.Revert, RequiresEnv: true},
 	{Name: action.SkipRevert, RequiresEnv: true},
-	{Name: action.Cutover, RequiresEnv: true},
+	{Name: action.Cutover, RequiresEnv: true, HasApplyID: true},
 	{Name: action.Rollback, RequiresEnv: true, HasApplyID: true, SupportsDB: true,
 		SupportsDeferCutover: true},
 	{Name: action.RollbackConfirm, RequiresEnv: true, SupportsDB: true},

--- a/pkg/webhook/commands_test.go
+++ b/pkg/webhook/commands_test.go
@@ -58,7 +58,7 @@ func TestCommandSpecs_FlagsRespected(t *testing.T) {
 		{name: action.Stop, requiresEnv: true, hasApplyID: true},
 		{name: action.Revert, requiresEnv: true},
 		{name: action.SkipRevert, requiresEnv: true},
-		{name: action.Cutover, requiresEnv: true},
+		{name: action.Cutover, requiresEnv: true, hasApplyID: true},
 		{name: action.Rollback, requiresEnv: true, hasApplyID: true,
 			supportsDB: true, supportsDefer: true},
 		{name: action.RollbackConfirm, requiresEnv: true, supportsDB: true},
@@ -293,9 +293,10 @@ func TestParseCommand(t *testing.T) {
 		},
 		{
 			name: "cutover",
-			body: "schemabot cutover -e staging",
+			body: "schemabot cutover apply_abc123 -e staging",
 			expected: CommandResult{
 				Action:      "cutover",
+				ApplyID:     "apply_abc123",
 				Environment: "staging",
 				Found:       true,
 				IsMention:   true,

--- a/pkg/webhook/control.go
+++ b/pkg/webhook/control.go
@@ -185,3 +185,176 @@ func (h *Handler) handleStopCommand(repo string, pr int, installationID int64, r
 		SkippedCount: resp.SkippedCount,
 	}))
 }
+
+// handleCutoverCommand handles the "schemabot cutover <apply-id> -e <env>" PR
+// comment command by recording durable cutover intent for the scheduler owner.
+func (h *Handler) handleCutoverCommand(repo string, pr int, installationID int64, requestedBy string, result CommandResult) {
+	ctx, cancel := h.commandContext(commandTimeout)
+	defer cancel()
+
+	if result.ApplyID == "" {
+		h.postComment(repo, pr, installationID, templates.RenderControlMissingApplyID(action.Cutover))
+		return
+	}
+	if h.service == nil {
+		h.logger.Error("service not configured for cutover PR command",
+			"repo", repo,
+			"pr", pr,
+			"apply_id", result.ApplyID,
+			"environment", result.Environment,
+			"requested_by", requestedBy)
+		h.postCommandError(repo, pr, installationID, action.Cutover, result.Environment, requestedBy, "SchemaBot service is not configured for cutover commands")
+		return
+	}
+	store := h.service.Storage()
+	if store == nil {
+		h.logger.Error("storage not configured for cutover PR command",
+			"repo", repo,
+			"pr", pr,
+			"apply_id", result.ApplyID,
+			"environment", result.Environment,
+			"requested_by", requestedBy)
+		h.postCommandError(repo, pr, installationID, action.Cutover, result.Environment, requestedBy, "SchemaBot storage is not configured for cutover commands")
+		return
+	}
+	applyStore := store.Applies()
+	if applyStore == nil {
+		h.logger.Error("apply store not configured for cutover PR command",
+			"repo", repo,
+			"pr", pr,
+			"apply_id", result.ApplyID,
+			"environment", result.Environment,
+			"requested_by", requestedBy)
+		h.postCommandError(repo, pr, installationID, action.Cutover, result.Environment, requestedBy, "SchemaBot apply storage is not configured for cutover commands")
+		return
+	}
+	apply, err := applyStore.GetByApplyIdentifier(ctx, result.ApplyID)
+	if err != nil {
+		h.logger.Error("failed to load apply for cutover PR command",
+			"repo", repo,
+			"pr", pr,
+			"apply_id", result.ApplyID,
+			"environment", result.Environment,
+			"requested_by", requestedBy,
+			"error", err)
+		h.postCommandError(repo, pr, installationID, action.Cutover, result.Environment, requestedBy, "Failed to look up apply: "+err.Error())
+		return
+	}
+	if apply == nil {
+		h.logger.Warn("cutover PR command rejected because apply was not found",
+			"repo", repo,
+			"pr", pr,
+			"apply_id", result.ApplyID,
+			"environment", result.Environment,
+			"requested_by", requestedBy)
+		h.postCommandError(repo, pr, installationID, action.Cutover, result.Environment, requestedBy, "Apply not found: "+result.ApplyID)
+		return
+	}
+	if apply.Repository != repo || apply.PullRequest != pr {
+		h.logger.Warn("cutover PR command rejected because apply belongs to another PR",
+			"repo", repo,
+			"pr", pr,
+			"apply_id", result.ApplyID,
+			"apply_repo", apply.Repository,
+			"apply_pr", apply.PullRequest,
+			"environment", result.Environment,
+			"requested_by", requestedBy)
+		h.postCommandError(repo, pr, installationID, action.Cutover, result.Environment, requestedBy, "Apply "+result.ApplyID+" is not associated with this PR")
+		return
+	}
+	if apply.Environment != result.Environment {
+		h.logger.Warn("cutover PR command rejected because environment does not match apply",
+			"repo", repo,
+			"pr", pr,
+			"apply_id", result.ApplyID,
+			"apply_environment", apply.Environment,
+			"requested_environment", result.Environment,
+			"requested_by", requestedBy)
+		h.postCommandError(repo, pr, installationID, action.Cutover, result.Environment, requestedBy,
+			fmt.Sprintf("Apply %s belongs to environment %q, not %q", result.ApplyID, apply.Environment, result.Environment))
+		return
+	}
+	var client *ghclient.InstallationClient
+	if h.service.Config().PRCommandAuthorizationEnabled() && h.ghClient != nil {
+		var clientErr error
+		client, clientErr = h.ghClient.ForInstallation(installationID)
+		if clientErr != nil {
+			h.logger.Warn("cutover PR command blocked because actor authorization client could not be created",
+				"repo", repo,
+				"pr", pr,
+				"apply_id", result.ApplyID,
+				"database", apply.Database,
+				"database_type", apply.DatabaseType,
+				"environment", result.Environment,
+				"requested_by", requestedBy,
+				"error", clientErr)
+			h.postComment(repo, pr, installationID, templates.RenderPRCommandAuthorizationUnavailable(templates.ActorAuthorizationCommentData{
+				RequestedBy: requestedBy,
+				CommandName: action.Cutover,
+				Database:    apply.Database,
+				Environment: result.Environment,
+			}))
+			return
+		}
+	}
+	if blocked := h.enforcePRCommandActorAuthorization(ctx, client, repo, pr, installationID, requestedBy, apply.Database, apply.DatabaseType, result.Environment, action.Cutover); blocked {
+		return
+	}
+
+	caller := fmt.Sprintf("github:%s@%s#%d", requestedBy, repo, pr)
+	resp, err := h.service.ExecuteCutover(ctx, apitypes.ControlRequest{
+		ApplyID:     result.ApplyID,
+		Environment: result.Environment,
+		Caller:      caller,
+	})
+	if err != nil {
+		h.logger.Warn("cutover PR command rejected",
+			"repo", repo,
+			"pr", pr,
+			"apply_id", result.ApplyID,
+			"environment", result.Environment,
+			"requested_by", requestedBy,
+			"error", err)
+		h.postCommandError(repo, pr, installationID, action.Cutover, result.Environment, requestedBy, err.Error())
+		return
+	}
+	if resp == nil {
+		h.logger.Error("cutover PR command returned no response",
+			"repo", repo,
+			"pr", pr,
+			"apply_id", result.ApplyID,
+			"environment", result.Environment,
+			"requested_by", requestedBy)
+		h.postCommandError(repo, pr, installationID, action.Cutover, result.Environment, requestedBy, "SchemaBot accepted the cutover command but returned no response")
+		return
+	}
+	if !resp.Accepted {
+		detail := resp.ErrorMessage
+		if detail == "" {
+			detail = "Cutover was not accepted"
+		}
+		h.logger.Warn("cutover PR command was not accepted",
+			"repo", repo,
+			"pr", pr,
+			"apply_id", result.ApplyID,
+			"environment", result.Environment,
+			"requested_by", requestedBy,
+			"error_message", resp.ErrorMessage)
+		h.postCommandError(repo, pr, installationID, action.Cutover, result.Environment, requestedBy, detail)
+		return
+	}
+
+	h.logger.Info("cutover PR command accepted",
+		"repo", repo,
+		"pr", pr,
+		"apply_id", result.ApplyID,
+		"environment", result.Environment,
+		"requested_by", requestedBy,
+		"status", resp.Status)
+	h.postComment(repo, pr, installationID, templates.RenderCutoverCommandAccepted(templates.CutoverCommandAcceptedData{
+		ApplyID:     result.ApplyID,
+		Environment: result.Environment,
+		RequestedBy: requestedBy,
+		Status:      resp.Status,
+	}))
+}

--- a/pkg/webhook/control_e2e_test.go
+++ b/pkg/webhook/control_e2e_test.go
@@ -231,6 +231,168 @@ func TestE2EStopCommandStopsDeferredCutoverLocalApply(t *testing.T) {
 	assertReactionEventually(t, reactions)
 }
 
+// TestE2ECutoverCommandRecordsDurableRequest verifies that a PR comment
+// cutover command records durable operator intent for the exact apply and
+// environment, then leaves the scheduler owner to perform the data-plane action.
+func TestE2ECutoverCommandRecordsDurableRequest(t *testing.T) {
+	ctx := t.Context()
+	schemabotDB, err := sql.Open("mysql", e2eSchemabotDSN)
+	require.NoError(t, err)
+	require.NoError(t, schemabotDB.PingContext(ctx))
+
+	store := mysqlstore.New(schemabotDB)
+	applyIdentifier := "apply_cdef3456"
+	database := "cutover_pr_comments_db"
+	cleanupStopCommandTestRows(t, schemabotDB, applyIdentifier, database)
+	t.Cleanup(func() {
+		cleanupStopCommandTestRows(t, schemabotDB, applyIdentifier, database)
+		utils.CloseAndLog(schemabotDB)
+	})
+
+	applyID := createStopCommandApply(t, store, applyIdentifier, database)
+	storedApply, err := store.Applies().GetByApplyIdentifier(ctx, applyIdentifier)
+	require.NoError(t, err)
+	require.NotNil(t, storedApply)
+	storedApply.State = state.Apply.WaitingForCutover
+	storedApply.SetOptions(storage.ApplyOptions{DeferCutover: true})
+	require.NoError(t, store.Applies().Update(ctx, storedApply))
+	storedTasks, err := store.Tasks().GetByApplyID(ctx, applyID)
+	require.NoError(t, err)
+	require.Len(t, storedTasks, 1)
+	storedTasks[0].State = state.Task.WaitingForCutover
+	storedTasks[0].UpdatedAt = time.Now().UTC()
+	require.NoError(t, store.Tasks().Update(ctx, storedTasks[0]))
+
+	client, mux := setupGitHubServer(t)
+	comments := make(chan string, 10)
+	reactions := make(chan string, 10)
+	mux.HandleFunc("POST /repos/octocat/hello-world/issues/1/comments", func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Body string `json:"body"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		comments <- body.Body
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": 99})
+	})
+	mux.HandleFunc("POST /repos/octocat/hello-world/issues/comments/42/reactions", func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Content string `json:"content"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		reactions <- body.Content
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": 1})
+	})
+
+	service := apiServiceForStopCommandTest(t, store, database)
+	service.RegisterTernClient(database, "staging", &stopCommandTernClient{remote: true})
+	h := &Handler{
+		service:  service,
+		ghClient: &fakeClientFactory{client: ghclient.NewInstallationClient(client, testLogger())},
+		logger:   testLogger(),
+	}
+
+	postCutoverCommand(t, h, applyIdentifier, "alice")
+	comment := readComment(t, comments)
+	assert.Contains(t, comment, "Cutover Request Accepted")
+	assert.Contains(t, comment, "`"+applyIdentifier+"`")
+	assert.Contains(t, comment, "@alice")
+
+	controlReq, err := store.ControlRequests().GetPending(ctx, applyID, storage.ControlOperationCutover)
+	require.NoError(t, err)
+	require.NotNil(t, controlReq)
+	assert.Equal(t, "github:alice@octocat/hello-world#1", controlReq.RequestedBy)
+	assert.Equal(t, storage.ControlRequestPending, controlReq.Status)
+
+	logs, err := store.ApplyLogs().List(ctx, storage.ApplyLogFilter{ApplyID: applyID, Limit: 20})
+	require.NoError(t, err)
+	assert.True(t, applyLogContains(logs, "Cutover requested by user (caller: github:alice@octocat/hello-world#1)"))
+	assertReactionEventually(t, reactions)
+}
+
+// TestE2ECutoverCommandRejectsPendingStop verifies that a PR comment cutover
+// command honors an outstanding stop request for the same apply, preserving the
+// operator's stop intent and surfacing the rejection back to the PR.
+func TestE2ECutoverCommandRejectsPendingStop(t *testing.T) {
+	ctx := t.Context()
+	schemabotDB, err := sql.Open("mysql", e2eSchemabotDSN)
+	require.NoError(t, err)
+	require.NoError(t, schemabotDB.PingContext(ctx))
+
+	store := mysqlstore.New(schemabotDB)
+	applyIdentifier := "apply_defa4567"
+	database := "cutover_pr_comments_stop_pending_db"
+	cleanupStopCommandTestRows(t, schemabotDB, applyIdentifier, database)
+	t.Cleanup(func() {
+		cleanupStopCommandTestRows(t, schemabotDB, applyIdentifier, database)
+		utils.CloseAndLog(schemabotDB)
+	})
+
+	applyID := createStopCommandApply(t, store, applyIdentifier, database)
+	storedApply, err := store.Applies().GetByApplyIdentifier(ctx, applyIdentifier)
+	require.NoError(t, err)
+	require.NotNil(t, storedApply)
+	storedApply.State = state.Apply.WaitingForCutover
+	storedApply.SetOptions(storage.ApplyOptions{DeferCutover: true})
+	require.NoError(t, store.Applies().Update(ctx, storedApply))
+	_, alreadyPending, err := store.ControlRequests().RequestPending(ctx, &storage.ApplyControlRequest{
+		ApplyID:     applyID,
+		Operation:   storage.ControlOperationStop,
+		RequestedBy: "github:stopper@octocat/hello-world#1",
+	})
+	require.NoError(t, err)
+	require.False(t, alreadyPending)
+
+	client, mux := setupGitHubServer(t)
+	comments := make(chan string, 10)
+	reactions := make(chan string, 10)
+	mux.HandleFunc("POST /repos/octocat/hello-world/issues/1/comments", func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Body string `json:"body"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		comments <- body.Body
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": 99})
+	})
+	mux.HandleFunc("POST /repos/octocat/hello-world/issues/comments/42/reactions", func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Content string `json:"content"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		reactions <- body.Content
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": 1})
+	})
+
+	service := apiServiceForStopCommandTest(t, store, database)
+	ternClient := &stopCommandTernClient{remote: true}
+	service.RegisterTernClient(database, "staging", ternClient)
+	h := &Handler{
+		service:  service,
+		ghClient: &fakeClientFactory{client: ghclient.NewInstallationClient(client, testLogger())},
+		logger:   testLogger(),
+	}
+
+	postCutoverCommand(t, h, applyIdentifier, "cutter")
+	comment := readComment(t, comments)
+	assert.Contains(t, comment, "pending stop request")
+	assert.Contains(t, comment, "cutover")
+
+	pendingStop, err := store.ControlRequests().GetPending(ctx, applyID, storage.ControlOperationStop)
+	require.NoError(t, err)
+	require.NotNil(t, pendingStop)
+	assert.Equal(t, "github:stopper@octocat/hello-world#1", pendingStop.RequestedBy)
+	pendingCutover, err := store.ControlRequests().GetPending(ctx, applyID, storage.ControlOperationCutover)
+	require.NoError(t, err)
+	assert.Nil(t, pendingCutover)
+	logs, err := store.ApplyLogs().List(ctx, storage.ApplyLogFilter{ApplyID: applyID, Limit: 20})
+	require.NoError(t, err)
+	assert.True(t, applyLogContains(logs, "Pending stop request blocked cutover (caller: github:stopper@octocat/hello-world#1)"))
+	assertReactionEventually(t, reactions)
+}
+
 func apiServiceForStopCommandTest(t *testing.T, store storage.Storage, database string) *api.Service {
 	t.Helper()
 	return api.New(store, &api.ServerConfig{
@@ -318,13 +480,26 @@ func postStopCommand(t *testing.T, h *Handler, applyIdentifier, user string) {
 	assert.Contains(t, rr.Body.String(), "stop started")
 }
 
+func postCutoverCommand(t *testing.T, h *Handler, applyIdentifier, user string) {
+	t.Helper()
+	req := buildWebhookRequest(t, webhookPayloadOpts{
+		comment:   "schemabot cutover " + applyIdentifier + " -e staging",
+		userLogin: user,
+		isPR:      true,
+	}, nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), "cutover started")
+}
+
 func readComment(t *testing.T, comments chan string) string {
 	t.Helper()
 	select {
 	case body := <-comments:
 		return body
 	case <-time.After(webhookIntegrationCheckRunDeadline):
-		t.Fatal("timed out waiting for stop command comment")
+		t.Fatal("timed out waiting for control command comment")
 		return ""
 	}
 }

--- a/pkg/webhook/handler_test.go
+++ b/pkg/webhook/handler_test.go
@@ -226,26 +226,39 @@ func TestWebhookYesFlagRejectedOnNonApply(t *testing.T) {
 	}
 }
 
-func TestWebhookStopMissingApplyID(t *testing.T) {
-	h, comments, _ := newTestHandler(t)
+func TestWebhookControlCommandMissingApplyID(t *testing.T) {
+	tests := []struct {
+		name    string
+		comment string
+		action  string
+	}{
+		{name: "stop", comment: "schemabot stop -e staging", action: "stop"},
+		{name: "cutover", comment: "schemabot cutover -e staging", action: "cutover"},
+	}
 
-	req := buildWebhookRequest(t, webhookPayloadOpts{
-		comment: "schemabot stop -e staging",
-		isPR:    true,
-	}, nil)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h, comments, _ := newTestHandler(t)
 
-	rr := httptest.NewRecorder()
-	h.ServeHTTP(rr, req)
+			req := buildWebhookRequest(t, webhookPayloadOpts{
+				comment: tt.comment,
+				isPR:    true,
+			}, nil)
 
-	require.Equal(t, http.StatusOK, rr.Code)
-	assert.Contains(t, rr.Body.String(), "stop started")
+			rr := httptest.NewRecorder()
+			h.ServeHTTP(rr, req)
 
-	select {
-	case body := <-comments:
-		assert.Contains(t, body, "Missing Apply ID")
-		assert.Contains(t, body, "schemabot stop <apply-id> -e <environment>")
-	case <-time.After(2 * time.Second):
-		t.Fatal("timed out waiting for missing apply ID comment")
+			require.Equal(t, http.StatusOK, rr.Code)
+			assert.Contains(t, rr.Body.String(), tt.action+" started")
+
+			select {
+			case body := <-comments:
+				assert.Contains(t, body, "Missing Apply ID")
+				assert.Contains(t, body, "schemabot "+tt.action+" <apply-id> -e <environment>")
+			case <-time.After(2 * time.Second):
+				t.Fatal("timed out waiting for missing apply ID comment")
+			}
+		})
 	}
 }
 
@@ -368,14 +381,13 @@ func TestWebhookEyesReaction(t *testing.T) {
 func TestWebhookPhase2CommandNotYetAvailable(t *testing.T) {
 	h, comments, _ := newTestHandler(t)
 
-	// Test remaining Phase 2 commands (apply, apply-confirm, unlock, and stop are now implemented)
+	// Test remaining Phase 2 commands (apply, apply-confirm, unlock, stop, and cutover are now implemented)
 	cmds := []struct {
 		comment string
 		action  string
 	}{
 		{"schemabot revert -e staging", "revert"},
 		{"schemabot skip-revert -e staging", "skip-revert"},
-		{"schemabot cutover -e staging", "cutover"},
 	}
 
 	for _, cmd := range cmds {

--- a/pkg/webhook/issue_comment.go
+++ b/pkg/webhook/issue_comment.go
@@ -232,8 +232,13 @@ func (h *Handler) handleIssueComment(w http.ResponseWriter, body []byte) {
 			h.handleStopCommand(repo, pr, installationID, requestedBy, result)
 		})
 		h.writeJSON(w, http.StatusOK, map[string]string{"message": "stop started"})
+	case action.Cutover:
+		h.goSafe(repo, pr, installationID, func() {
+			h.handleCutoverCommand(repo, pr, installationID, requestedBy, result)
+		})
+		h.writeJSON(w, http.StatusOK, map[string]string{"message": "cutover started"})
 	// Phase 2 commands — acknowledge but not yet implemented
-	case action.Revert, action.SkipRevert, action.Cutover:
+	case action.Revert, action.SkipRevert:
 		h.postComment(repo, pr, installationID,
 			templates.RenderCommandNotYetAvailable(result.Action, result.Environment))
 		h.writeJSON(w, http.StatusOK, map[string]string{

--- a/pkg/webhook/templates/apply.go
+++ b/pkg/webhook/templates/apply.go
@@ -665,6 +665,7 @@ func writeSummaryTableList(sb *strings.Builder, data ApplyStatusCommentData) {
 	singleGroup := len(groups) == 1
 	for _, g := range groups {
 		skipHeader := singleGroup && (g.namespace == "" || g.namespace == "default" || g.namespace == data.Database)
+		groupCollapsed := collapsed && !skipHeader
 
 		if !skipHeader {
 			header := g.namespace
@@ -674,7 +675,7 @@ func writeSummaryTableList(sb *strings.Builder, data ApplyStatusCommentData) {
 
 			groupEmoji := groupStateEmoji(g.tables)
 
-			if collapsed {
+			if groupCollapsed {
 				sb.WriteString("\n<details><summary>")
 				fmt.Fprintf(sb, "%s <strong>%s</strong> (%d tables)</summary>\n\n", groupEmoji, header, len(g.tables))
 			} else {
@@ -688,7 +689,7 @@ func writeSummaryTableList(sb *strings.Builder, data ApplyStatusCommentData) {
 			writeSummaryTableEntry(sb, t)
 		}
 
-		if collapsed {
+		if groupCollapsed {
 			sb.WriteString("</details>\n")
 		}
 	}

--- a/pkg/webhook/templates/apply_test.go
+++ b/pkg/webhook/templates/apply_test.go
@@ -388,6 +388,14 @@ func TestPreviewCommentSummaryStopped(t *testing.T) {
 	assert.Contains(t, result, "**`orders`**")
 }
 
+func TestPreviewCommentSummaryCompletedLargeSingleNamespaceKeepsApplyIDInsideSection(t *testing.T) {
+	result := PreviewCommentSummaryCompletedLarge()
+
+	assert.Contains(t, result, "All 8 tables applied successfully")
+	assert.Contains(t, result, "_Apply ID: apply-a1b2c3d4e5f6_")
+	assert.Equal(t, 0, strings.Count(result, "</details>"))
+}
+
 func TestRenderApplyBlockedByFailingChecks(t *testing.T) {
 	failing := []BlockingCheck{
 		{Name: "CI / unit-tests", State: "failure"},

--- a/pkg/webhook/templates/issue_comment.go
+++ b/pkg/webhook/templates/issue_comment.go
@@ -1,6 +1,10 @@
 package templates
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/block/schemabot/pkg/apitypes"
+)
 
 // RenderRepositoryNotRegistered renders the message posted when a SchemaBot
 // command arrives from a repository that is not in the configured allowlist.
@@ -42,6 +46,14 @@ type StopCommandAcceptedData struct {
 	SkippedCount int64
 }
 
+// CutoverCommandAcceptedData contains data for a PR comment cutover acknowledgement.
+type CutoverCommandAcceptedData struct {
+	ApplyID     string
+	Environment string
+	RequestedBy string
+	Status      string
+}
+
 // RenderControlMissingApplyID renders the message posted when an apply-scoped
 // control command is invoked without the required apply ID.
 func RenderControlMissingApplyID(action string) string {
@@ -69,6 +81,44 @@ func RenderStopCommandAccepted(data StopCommandAcceptedData) string {
 		body += fmt.Sprintf("\n**Tasks selected for stop**: %d stopped, %d skipped.\n", data.StoppedCount, data.SkippedCount)
 	}
 	return body
+}
+
+// RenderCutoverCommandAccepted renders the acknowledgement posted when a PR
+// comment cutover command records durable cutover intent.
+func RenderCutoverCommandAccepted(data CutoverCommandAcceptedData) string {
+	statusLine := "Cutover request accepted. SchemaBot will complete this schema change; status remains available from the PR progress comment or CLI."
+	if data.Status == apitypes.ControlStatusAlreadyInProgress {
+		statusLine = "Cutover is already in progress. SchemaBot will keep reporting progress from the existing apply."
+	}
+
+	body := "## Cutover Request Accepted\n\n" +
+		fmt.Sprintf("**Apply**: `%s`\n", data.ApplyID) +
+		fmt.Sprintf("**Environment**: `%s`\n", data.Environment)
+	if data.RequestedBy != "" {
+		body += fmt.Sprintf("**Requested by**: @%s\n", data.RequestedBy)
+	}
+	return body + "\n" + statusLine + "\n"
+}
+
+// PreviewCommentCutoverCommandAccepted renders a sample cutover command
+// acknowledgement comment.
+func PreviewCommentCutoverCommandAccepted() string {
+	return RenderCutoverCommandAccepted(CutoverCommandAcceptedData{
+		ApplyID:     "apply-a1b2c3d4e5f67890",
+		Environment: "staging",
+		RequestedBy: "alice",
+	})
+}
+
+// PreviewCommentCutoverCommandAlreadyInProgress renders a sample cutover
+// acknowledgement when cutover is already in progress.
+func PreviewCommentCutoverCommandAlreadyInProgress() string {
+	return RenderCutoverCommandAccepted(CutoverCommandAcceptedData{
+		ApplyID:     "apply-a1b2c3d4e5f67890",
+		Environment: "staging",
+		RequestedBy: "alice",
+		Status:      apitypes.ControlStatusAlreadyInProgress,
+	})
 }
 
 // RenderCommandNotYetAvailable renders the acknowledgement posted when a

--- a/pkg/webhook/templates/issue_comment_test.go
+++ b/pkg/webhook/templates/issue_comment_test.go
@@ -3,6 +3,7 @@ package templates
 import (
 	"testing"
 
+	"github.com/block/schemabot/pkg/apitypes"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -63,6 +64,28 @@ func TestRenderStopCommandAcceptedAlreadyRequested(t *testing.T) {
 		Status:      "already_requested",
 	})
 	assert.Contains(t, rendered, "Stop was already requested")
+}
+
+func TestRenderCutoverCommandAccepted(t *testing.T) {
+	rendered := RenderCutoverCommandAccepted(CutoverCommandAcceptedData{
+		ApplyID:     "apply_abc123",
+		Environment: "staging",
+		RequestedBy: "alice",
+	})
+	assert.Contains(t, rendered, "Cutover Request Accepted")
+	assert.Contains(t, rendered, "`apply_abc123`")
+	assert.Contains(t, rendered, "`staging`")
+	assert.Contains(t, rendered, "@alice")
+	assert.Contains(t, rendered, "Cutover request accepted")
+}
+
+func TestRenderCutoverCommandAcceptedAlreadyInProgress(t *testing.T) {
+	rendered := RenderCutoverCommandAccepted(CutoverCommandAcceptedData{
+		ApplyID:     "apply_abc123",
+		Environment: "staging",
+		Status:      apitypes.ControlStatusAlreadyInProgress,
+	})
+	assert.Contains(t, rendered, "Cutover is already in progress")
 }
 
 func TestRenderCommandNotYetAvailable(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds PR-comment cutover support through the durable control request path. Operators can now run `schemabot cutover <apply-id> -e <environment>` from a PR, and SchemaBot validates the apply belongs to that PR/environment before queuing recoverable cutover intent for the scheduler owner.

```diagram
╭────────────╮    ╭──────────────╮    ╭────────────────────╮
│ PR comment │───▶│ webhook      │───▶│ durable cutover    │
│ cutover    │    │ validation   │    │ control request    │
╰────────────╯    ╰──────────────╯    ╰─────────┬──────────╯
                                                ▼
                                      ╭────────────────────╮
                                      │ scheduler/data     │
                                      │ plane performs it  │
                                      ╰────────────────────╯
```

This mirrors the stop-command safety model: the webhook handles GitHub UX and authorization, while the scheduler/data-plane path remains responsible for the actual control side effect.

Generated with Amp.