### PR TITLE
fix(github): recover stuck checks from no-op plans

### DIFF
--- a/pkg/storage/mysqlstore/checks.go
+++ b/pkg/storage/mysqlstore/checks.go
@@ -107,6 +107,51 @@ func (s *checkStore) UpsertPlanResult(ctx context.Context, check *storage.Check)
 	return err
 }
 
+// RecoverApplyOwnedCheckWithNoOpPlan updates same-head apply-owned stored check
+// state when a successful no-op plan proves the target already matches the PR schema.
+func (s *checkStore) RecoverApplyOwnedCheckWithNoOpPlan(ctx context.Context, check *storage.Check) (bool, error) {
+	if !successfulNoOpPlanResult(check) {
+		return false, nil
+	}
+
+	var checkRunID any
+	if check.CheckRunID != 0 {
+		checkRunID = check.CheckRunID
+	}
+
+	result, err := s.db.ExecContext(ctx, `
+		UPDATE checks
+		SET head_sha = ?,
+		    check_run_id = ?,
+		    apply_id = NULL,
+		    has_changes = ?,
+		    status = ?,
+		    conclusion = ?,
+		    blocking_reason = ?,
+		    error_message = ?
+		WHERE repository = ? AND pull_request = ?
+		  AND environment = ? AND database_type = ? AND database_name = ?
+		  AND status = ? AND head_sha = ? AND apply_id IS NOT NULL
+	`, check.HeadSHA, checkRunID, check.HasChanges, check.Status, check.Conclusion, check.BlockingReason, check.ErrorMessage,
+		check.Repository, check.PullRequest, check.Environment, check.DatabaseType, check.DatabaseName,
+		checkStatusInProgress, check.HeadSHA)
+	if err != nil {
+		return false, err
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	return rows > 0, nil
+}
+
+func successfulNoOpPlanResult(check *storage.Check) bool {
+	return check != nil &&
+		check.Status == "completed" &&
+		check.Conclusion == "success" &&
+		!check.HasChanges
+}
+
 // CompleteForApply updates stored check state to a terminal state only if it
 // still belongs to the apply being completed.
 func (s *checkStore) CompleteForApply(ctx context.Context, check *storage.Check, apply *storage.Apply) (bool, error) {

--- a/pkg/storage/mysqlstore/checks_test.go
+++ b/pkg/storage/mysqlstore/checks_test.go
@@ -353,7 +353,7 @@ func TestCheckStore_UpsertPlanResultPreservesInProgressApply(t *testing.T) {
 		Conclusion:   "",
 	}))
 
-	require.NoError(t, store.Checks().UpsertPlanResult(ctx, &storage.Check{
+	err := store.Checks().UpsertPlanResult(ctx, &storage.Check{
 		Repository:   "org/repo",
 		PullRequest:  123,
 		HeadSHA:      "same-sha",
@@ -363,7 +363,8 @@ func TestCheckStore_UpsertPlanResultPreservesInProgressApply(t *testing.T) {
 		HasChanges:   true,
 		Status:       "completed",
 		Conclusion:   "action_required",
-	}))
+	})
+	require.NoError(t, err)
 
 	retrieved, err := store.Checks().Get(ctx, "org/repo", 123, "staging", "mysql", "testdb")
 	require.NoError(t, err)
@@ -372,6 +373,194 @@ func TestCheckStore_UpsertPlanResultPreservesInProgressApply(t *testing.T) {
 	require.Equal(t, "in_progress", retrieved.Status)
 	require.Empty(t, retrieved.Conclusion)
 	require.Equal(t, apply.ID, retrieved.ApplyID)
+}
+
+func TestCheckStore_RecoverApplyOwnedCheckWithNoOpPlanRecoversStoredCheckState(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	apply := createCheckStoreApply(t, store, "apply-noop-success", state.Apply.Running)
+	require.NoError(t, store.Checks().Upsert(ctx, &storage.Check{
+		Repository:     "org/repo",
+		PullRequest:    123,
+		HeadSHA:        "same-sha",
+		Environment:    "staging",
+		DatabaseType:   "mysql",
+		DatabaseName:   "testdb",
+		ApplyID:        apply.ID,
+		HasChanges:     true,
+		Status:         "in_progress",
+		Conclusion:     "",
+		BlockingReason: "schema_change_running",
+		ErrorMessage:   "schema change is still running",
+	}))
+
+	err := store.Checks().UpsertPlanResult(ctx, &storage.Check{
+		Repository:   "org/repo",
+		PullRequest:  123,
+		HeadSHA:      "same-sha",
+		Environment:  "staging",
+		DatabaseType: "mysql",
+		DatabaseName: "testdb",
+		HasChanges:   false,
+		Status:       "completed",
+		Conclusion:   "success",
+	})
+	require.NoError(t, err)
+
+	recovered, err := store.Checks().RecoverApplyOwnedCheckWithNoOpPlan(ctx, &storage.Check{
+		Repository:   "org/repo",
+		PullRequest:  123,
+		HeadSHA:      "same-sha",
+		Environment:  "staging",
+		DatabaseType: "mysql",
+		DatabaseName: "testdb",
+		HasChanges:   false,
+		Status:       "completed",
+		Conclusion:   "success",
+	})
+	require.NoError(t, err)
+	require.True(t, recovered)
+
+	retrieved, err := store.Checks().Get(ctx, "org/repo", 123, "staging", "mysql", "testdb")
+	require.NoError(t, err)
+	require.NotNil(t, retrieved)
+	require.Equal(t, "same-sha", retrieved.HeadSHA)
+	require.Equal(t, "completed", retrieved.Status)
+	require.Equal(t, "success", retrieved.Conclusion)
+	require.False(t, retrieved.HasChanges)
+	require.Equal(t, int64(0), retrieved.ApplyID)
+	require.Empty(t, retrieved.BlockingReason)
+	require.Empty(t, retrieved.ErrorMessage)
+}
+
+func TestCheckStore_UpsertPlanResultPreservesApplyOwnedCheckStateOnNoOpSuccess(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	apply := createCheckStoreApply(t, store, "apply-noop-recovery-disabled", state.Apply.Running)
+	require.NoError(t, store.Checks().Upsert(ctx, &storage.Check{
+		Repository:   "org/repo",
+		PullRequest:  123,
+		HeadSHA:      "same-sha",
+		Environment:  "staging",
+		DatabaseType: "mysql",
+		DatabaseName: "testdb",
+		ApplyID:      apply.ID,
+		HasChanges:   true,
+		Status:       "in_progress",
+		Conclusion:   "",
+	}))
+
+	err := store.Checks().UpsertPlanResult(ctx, &storage.Check{
+		Repository:   "org/repo",
+		PullRequest:  123,
+		HeadSHA:      "same-sha",
+		Environment:  "staging",
+		DatabaseType: "mysql",
+		DatabaseName: "testdb",
+		HasChanges:   false,
+		Status:       "completed",
+		Conclusion:   "success",
+	})
+	require.NoError(t, err)
+
+	retrieved, err := store.Checks().Get(ctx, "org/repo", 123, "staging", "mysql", "testdb")
+	require.NoError(t, err)
+	require.NotNil(t, retrieved)
+	require.Equal(t, "same-sha", retrieved.HeadSHA)
+	require.Equal(t, "in_progress", retrieved.Status)
+	require.Empty(t, retrieved.Conclusion)
+	require.Equal(t, apply.ID, retrieved.ApplyID)
+}
+
+func TestCheckStore_RecoverApplyOwnedCheckWithNoOpPlanRequiresNoOpSuccess(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		applyID    string
+		hasChanges bool
+		status     string
+		conclusion string
+	}{
+		{
+			name:       "plan has changes",
+			applyID:    "apply-plan-has-changes",
+			hasChanges: true,
+			status:     "completed",
+			conclusion: "action_required",
+		},
+		{
+			name:       "plan failed without changes",
+			applyID:    "apply-plan-failed-without-changes",
+			hasChanges: false,
+			status:     "completed",
+			conclusion: "failure",
+		},
+		{
+			name:       "plan failed with changes",
+			applyID:    "apply-plan-failed-with-changes",
+			hasChanges: true,
+			status:     "completed",
+			conclusion: "failure",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			clearTables(t)
+			ctx := t.Context()
+			store := New(testDB)
+
+			apply := createCheckStoreApply(t, store, tc.applyID, state.Apply.Running)
+			require.NoError(t, store.Checks().Upsert(ctx, &storage.Check{
+				Repository:   "org/repo",
+				PullRequest:  123,
+				HeadSHA:      "same-sha",
+				Environment:  "staging",
+				DatabaseType: "mysql",
+				DatabaseName: "testdb",
+				ApplyID:      apply.ID,
+				HasChanges:   true,
+				Status:       "in_progress",
+				Conclusion:   "",
+			}))
+
+			err := store.Checks().UpsertPlanResult(ctx, &storage.Check{
+				Repository:   "org/repo",
+				PullRequest:  123,
+				HeadSHA:      "same-sha",
+				Environment:  "staging",
+				DatabaseType: "mysql",
+				DatabaseName: "testdb",
+				HasChanges:   tc.hasChanges,
+				Status:       tc.status,
+				Conclusion:   tc.conclusion,
+			})
+			require.NoError(t, err)
+
+			recovered, err := store.Checks().RecoverApplyOwnedCheckWithNoOpPlan(ctx, &storage.Check{
+				Repository:   "org/repo",
+				PullRequest:  123,
+				HeadSHA:      "same-sha",
+				Environment:  "staging",
+				DatabaseType: "mysql",
+				DatabaseName: "testdb",
+				HasChanges:   tc.hasChanges,
+				Status:       tc.status,
+				Conclusion:   tc.conclusion,
+			})
+			require.NoError(t, err)
+			require.False(t, recovered)
+
+			retrieved, err := store.Checks().Get(ctx, "org/repo", 123, "staging", "mysql", "testdb")
+			require.NoError(t, err)
+			require.NotNil(t, retrieved)
+			require.Equal(t, "same-sha", retrieved.HeadSHA)
+			require.Equal(t, "in_progress", retrieved.Status)
+			require.Empty(t, retrieved.Conclusion)
+			require.Equal(t, apply.ID, retrieved.ApplyID)
+		})
+	}
 }
 
 func TestCheckStore_UpsertPlanResultReplacesUnownedInProgressCheck(t *testing.T) {
@@ -391,7 +580,7 @@ func TestCheckStore_UpsertPlanResultReplacesUnownedInProgressCheck(t *testing.T)
 		Conclusion:   "",
 	}))
 
-	require.NoError(t, store.Checks().UpsertPlanResult(ctx, &storage.Check{
+	err := store.Checks().UpsertPlanResult(ctx, &storage.Check{
 		Repository:   "org/repo",
 		PullRequest:  123,
 		HeadSHA:      "same-sha",
@@ -401,7 +590,8 @@ func TestCheckStore_UpsertPlanResultReplacesUnownedInProgressCheck(t *testing.T)
 		HasChanges:   true,
 		Status:       "completed",
 		Conclusion:   "action_required",
-	}))
+	})
+	require.NoError(t, err)
 
 	retrieved, err := store.Checks().Get(ctx, "org/repo", 123, "staging", "mysql", "testdb")
 	require.NoError(t, err)
@@ -431,7 +621,7 @@ func TestCheckStore_UpsertPlanResultReplacesInProgressApplyOnNewHead(t *testing.
 		Conclusion:   "",
 	}))
 
-	require.NoError(t, store.Checks().UpsertPlanResult(ctx, &storage.Check{
+	err := store.Checks().UpsertPlanResult(ctx, &storage.Check{
 		Repository:   "org/repo",
 		PullRequest:  123,
 		HeadSHA:      "newsha",
@@ -441,7 +631,8 @@ func TestCheckStore_UpsertPlanResultReplacesInProgressApplyOnNewHead(t *testing.
 		HasChanges:   true,
 		Status:       "completed",
 		Conclusion:   "action_required",
-	}))
+	})
+	require.NoError(t, err)
 
 	retrieved, err := store.Checks().Get(ctx, "org/repo", 123, "staging", "mysql", "testdb")
 	require.NoError(t, err)
@@ -471,7 +662,7 @@ func TestCheckStore_UpsertPlanResultClearsApplyIDWhenNotInProgress(t *testing.T)
 		Conclusion:   "success",
 	}))
 
-	require.NoError(t, store.Checks().UpsertPlanResult(ctx, &storage.Check{
+	err := store.Checks().UpsertPlanResult(ctx, &storage.Check{
 		Repository:   "org/repo",
 		PullRequest:  123,
 		HeadSHA:      "newsha",
@@ -481,7 +672,8 @@ func TestCheckStore_UpsertPlanResultClearsApplyIDWhenNotInProgress(t *testing.T)
 		HasChanges:   true,
 		Status:       "completed",
 		Conclusion:   "action_required",
-	}))
+	})
+	require.NoError(t, err)
 
 	retrieved, err := store.Checks().Get(ctx, "org/repo", 123, "staging", "mysql", "testdb")
 	require.NoError(t, err)

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -89,6 +89,10 @@ type CheckStore interface {
 	// but preserves in-progress apply state for the same PR/environment/database/head SHA.
 	UpsertPlanResult(ctx context.Context, check *Check) error
 
+	// RecoverApplyOwnedCheckWithNoOpPlan updates same-head apply-owned stored check state
+	// from in_progress to a successful no-op plan result. Returns true when recovery occurred.
+	RecoverApplyOwnedCheckWithNoOpPlan(ctx context.Context, check *Check) (bool, error)
+
 	// CompleteForApply updates stored check state to a terminal state only if
 	// it still belongs to the given apply and no newer apply exists for the
 	// same PR/environment/database. Returns false when another worker changed

--- a/pkg/webhook/check_records.go
+++ b/pkg/webhook/check_records.go
@@ -17,6 +17,45 @@ import (
 // No per-database GitHub Check Run is created — only the aggregate is visible on the PR.
 // Returns the commit SHA used for the plan. Failures are non-fatal.
 func (h *Handler) storePlanCheckRecord(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, schema *ghclient.SchemaRequestResult, planResp *apitypes.PlanResponse, environment string) (string, error) {
+	headSHA, _, err := h.upsertPlanCheckRecord(ctx, client, repo, pr, schema, planResp, environment)
+	return headSHA, err
+}
+
+// storeManualPlanCheckRecord stores per-database check state after a manual
+// plan and then reconciles same-head apply-owned stored check state when the manual
+// plan proves the target already matches the PR schema.
+func (h *Handler) storeManualPlanCheckRecord(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, schema *ghclient.SchemaRequestResult, planResp *apitypes.PlanResponse, environment string) (string, bool, error) {
+	headSHA, check, err := h.upsertPlanCheckRecord(ctx, client, repo, pr, schema, planResp, environment)
+	if err != nil {
+		return headSHA, false, err
+	}
+
+	recoveredApplyOwnedCheckState, err := h.service.Storage().Checks().RecoverApplyOwnedCheckWithNoOpPlan(ctx, check)
+	if err != nil {
+		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
+			Operation:    "plan_check_recorded",
+			Repository:   repo,
+			Database:     schema.Database,
+			DatabaseType: schema.Type,
+			Environment:  environment,
+			Status:       "error",
+		})
+		return headSHA, false, fmt.Errorf("recover apply-owned check state with no-op plan repo %s pr %d environment %s database_type %s database %s head_sha %s: %w",
+			repo, pr, environment, schema.Type, schema.Database, headSHA, err)
+	}
+	if recoveredApplyOwnedCheckState {
+		h.logger.Info("no-op plan recovered apply-owned check state",
+			"repo", repo,
+			"pr", pr,
+			"head_sha", headSHA,
+			"environment", environment,
+			"database_type", schema.Type,
+			"database", schema.Database)
+	}
+	return headSHA, recoveredApplyOwnedCheckState, nil
+}
+
+func (h *Handler) upsertPlanCheckRecord(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, schema *ghclient.SchemaRequestResult, planResp *apitypes.PlanResponse, environment string) (string, *storage.Check, error) {
 	headSHA := schema.HeadSHA
 	if headSHA == "" {
 		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
@@ -27,7 +66,7 @@ func (h *Handler) storePlanCheckRecord(ctx context.Context, client *ghclient.Ins
 			Environment:  environment,
 			Status:       "error",
 		})
-		return "", fmt.Errorf("schema request missing head SHA for stored check state repo %s pr %d environment %s database_type %s database %s",
+		return "", nil, fmt.Errorf("schema request missing head SHA for stored check state repo %s pr %d environment %s database_type %s database %s",
 			repo, pr, environment, schema.Type, schema.Database)
 	}
 
@@ -41,7 +80,7 @@ func (h *Handler) storePlanCheckRecord(ctx context.Context, client *ghclient.Ins
 			Environment:  environment,
 			Status:       "error",
 		})
-		return "", fmt.Errorf("fetch PR for stored check state: %w", err)
+		return "", nil, fmt.Errorf("fetch PR for stored check state: %w", err)
 	}
 	if prInfo.HeadSHA != headSHA {
 		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
@@ -52,7 +91,7 @@ func (h *Handler) storePlanCheckRecord(ctx context.Context, client *ghclient.Ins
 			Environment:  environment,
 			Status:       "stale",
 		})
-		return headSHA, fmt.Errorf("skip stale plan check record for repo %s pr %d environment %s database_type %s database %s: plan head SHA %s no longer matches current head SHA for PR %s",
+		return headSHA, nil, fmt.Errorf("skip stale plan check record for repo %s pr %d environment %s database_type %s database %s: plan head SHA %s no longer matches current head SHA for PR %s",
 			repo, pr, environment, schema.Type, schema.Database, headSHA, prInfo.HeadSHA)
 	}
 
@@ -89,7 +128,7 @@ func (h *Handler) storePlanCheckRecord(ctx context.Context, client *ghclient.Ins
 			Environment:  environment,
 			Status:       "error",
 		})
-		return headSHA, fmt.Errorf("store check state: %w", err)
+		return headSHA, nil, fmt.Errorf("store check state: %w", err)
 	}
 
 	metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
@@ -100,7 +139,7 @@ func (h *Handler) storePlanCheckRecord(ctx context.Context, client *ghclient.Ins
 		Environment:  environment,
 		Status:       "success",
 	})
-	return headSHA, nil
+	return headSHA, check, nil
 }
 
 type applyCheckKey struct {

--- a/pkg/webhook/plan.go
+++ b/pkg/webhook/plan.go
@@ -101,14 +101,16 @@ func (h *Handler) handlePlanCommand(w http.ResponseWriter, repo string, pr int, 
 
 	metrics.RecordPlan(ctx, repo, schemaResult.Database, deployment, environment, "success")
 
-	// Post plan comment
-	h.postComment(repo, pr, installationID, templates.RenderPlanComment(commentData))
-
 	// Store per-database check record and update aggregate
-	headSHA, checkErr := h.storePlanCheckRecord(ctx, client, repo, pr, schemaResult, planResp, environment)
+	headSHA, recoveredApplyOwnedCheckState, checkErr := h.storeManualPlanCheckRecord(ctx, client, repo, pr, schemaResult, planResp, environment)
 	if checkErr != nil {
 		h.logger.Error("failed to store plan check record", "repo", repo, "pr", pr, "database", schemaResult.Database, "deployment", deployment, "environment", environment, "error", checkErr)
 	}
+	commentData.RecoveredApplyOwnedCheckState = recoveredApplyOwnedCheckState
+
+	// Post plan comment
+	h.postComment(repo, pr, installationID, templates.RenderPlanComment(commentData))
+
 	if headSHA != "" {
 		h.updateAggregateCheck(ctx, client, repo, pr, headSHA)
 	}
@@ -263,17 +265,25 @@ func (h *Handler) handleMultiEnvPlan(repo string, pr int, databaseName string, i
 			continue
 		}
 
-		commentData := buildPlanCommentData(schemaResult, planResp, env, requestedBy)
-		multiEnvData.Plans[env] = &commentData
-
 		// Store per-database check record per environment
-		sha, checkErr := h.storePlanCheckRecord(ctx, client, repo, pr, schemaResult, planResp, env)
+		var recoveredApplyOwnedCheckState bool
+		var sha string
+		var checkErr error
+		if isAutoPlan {
+			sha, checkErr = h.storePlanCheckRecord(ctx, client, repo, pr, schemaResult, planResp, env)
+		} else {
+			sha, recoveredApplyOwnedCheckState, checkErr = h.storeManualPlanCheckRecord(ctx, client, repo, pr, schemaResult, planResp, env)
+		}
 		if checkErr != nil {
 			h.logger.Error("failed to store plan check record", "repo", repo, "pr", pr, "env", env, "error", checkErr)
 		}
 		if sha != "" {
 			headSHA = sha
 		}
+
+		commentData := buildPlanCommentData(schemaResult, planResp, env, requestedBy)
+		commentData.RecoveredApplyOwnedCheckState = recoveredApplyOwnedCheckState
+		multiEnvData.Plans[env] = &commentData
 	}
 
 	// Update aggregate check once after all environments are planned.

--- a/pkg/webhook/plan_test.go
+++ b/pkg/webhook/plan_test.go
@@ -192,6 +192,22 @@ func TestRenderPlanComment_ShowsPRHeadSHA(t *testing.T) {
 	assert.NotContains(t, rendered, "**PR head SHA**")
 }
 
+func TestRenderPlanComment_ShowsRecoveredApplyOwnedCheckState(t *testing.T) {
+	data := templates.PlanCommentData{
+		Database:                      "testdb",
+		Environment:                   "staging",
+		IsMySQL:                       true,
+		RecoveredApplyOwnedCheckState: true,
+	}
+
+	rendered := templates.RenderPlanComment(data)
+
+	assert.Contains(t, rendered, "✅ **No schema changes detected**")
+	assert.Contains(t, rendered, "SchemaBot found stored PR check state")
+	assert.Contains(t, rendered, "still marked as an apply in progress")
+	assert.Contains(t, rendered, "SchemaBot updated the PR check to passing")
+}
+
 func TestRenderMultiEnvPlanComment_ShowsPRHeadSHA(t *testing.T) {
 	data := templates.MultiEnvPlanCommentData{
 		Database:     "testdb",

--- a/pkg/webhook/templates/plan.go
+++ b/pkg/webhook/templates/plan.go
@@ -55,6 +55,8 @@ type PlanCommentData struct {
 	// Auto-confirm state
 	AutoConfirm                bool   // -y flag was used, will auto-execute
 	AutoConfirmDowngradeReason string // Non-empty: -y was downgraded to manual, this is the reason
+
+	RecoveredApplyOwnedCheckState bool
 }
 
 // KeyspaceChangeData contains changes for a single keyspace/schema.
@@ -99,7 +101,7 @@ func RenderPlanComment(data PlanCommentData) string {
 
 	// No changes — short-circuit with a single clean message
 	if totalChanges == 0 {
-		sb.WriteString("✅ **No schema changes detected**\n")
+		writeNoChangesDetected(&sb, data)
 		return sb.String()
 	}
 
@@ -241,7 +243,8 @@ func countChanges(changes []KeyspaceChangeData) (totalStatements, keyspacesWithD
 func writePlanSummary(sb *strings.Builder, data PlanCommentData, totalStatements, keyspacesWithDDL, keyspacesWithVSchema int) {
 	totalChanges := totalStatements + keyspacesWithVSchema
 	if totalChanges == 0 {
-		sb.WriteString("✅ **No schema changes detected**\n\n")
+		writeNoChangesDetected(sb, data)
+		sb.WriteString("\n")
 		return
 	}
 
@@ -267,6 +270,13 @@ func writePlanSummary(sb *strings.Builder, data PlanCommentData, totalStatements
 	} else {
 		// Fallback for unrecognized statement types
 		fmt.Fprintf(sb, "📋 **Plan**: %d DDL %s\n\n", totalStatements, pluralize("statement", totalStatements))
+	}
+}
+
+func writeNoChangesDetected(sb *strings.Builder, data PlanCommentData) {
+	sb.WriteString("✅ **No schema changes detected**\n")
+	if data.RecoveredApplyOwnedCheckState {
+		sb.WriteString("\nℹ️ SchemaBot found stored PR check state for this database/environment that was still marked as an apply in progress. Because this fresh plan shows the target schema already matches this PR, SchemaBot updated the PR check to passing.\n")
 	}
 }
 


### PR DESCRIPTION
## Why
Manual plans should be able to recover a stuck check when a fresh plan proves the target schema already matches the PR.

## What
- Allow manual successful no-op plans to recover same-head in-progress apply check state
- Keep apply-owned in-progress checks preserved for auto-plan, apply-plan, changed plans, and failed plans
- Add a plan comment note when SchemaBot reconciles the check to passing

## Risk Assessment
Medium — this touches status-check safety logic, but the recovery path is limited to fresh successful no-op manual plans and preserves fail-closed behavior otherwise.

Generated with Amp
