### PR TITLE
fix(cli): surface plan API errors in text output

### DIFF
--- a/pkg/cmd/commands/plan.go
+++ b/pkg/cmd/commands/plan.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"sort"
@@ -60,6 +61,9 @@ func (cmd *PlanCmd) Run(g *Globals) error {
 			if cmd.JSON {
 				return client.ExitWithJSON("api_error", err.Error())
 			}
+			if outputPlanRequestError(cfg.Database, "", err) {
+				return ErrSilent
+			}
 			return err
 		}
 		environments = envs
@@ -75,6 +79,9 @@ func (cmd *PlanCmd) Run(g *Globals) error {
 			if cmd.JSON {
 				return client.ExitWithJSON("api_error", err.Error())
 			}
+			if outputPlanRequestError(cfg.Database, env, err) {
+				return ErrSilent
+			}
 			return err
 		}
 		allResults[env] = result
@@ -87,6 +94,28 @@ func (cmd *PlanCmd) Run(g *Globals) error {
 	// Human-readable output for all environments
 	outputMultiEnvPlanResult(allResults, cfg.Database, cfg.SchemaDir)
 	return nil
+}
+
+func outputPlanRequestError(database, environment string, err error) bool {
+	var apiErr *client.APIError
+	var connectionErr *client.ConnectionError
+	if !errors.As(err, &apiErr) && !errors.As(err, &connectionErr) {
+		return false
+	}
+
+	fmt.Printf("%sPlan failed%s\n", templates.ANSIRed, templates.ANSIReset)
+	fmt.Printf("  Database: %s\n", database)
+	if environment != "" {
+		fmt.Printf("  Environment: %s\n", environment)
+	}
+	if apiErr != nil {
+		fmt.Printf("  API status: HTTP %d\n", apiErr.Status)
+		if apiErr.ErrorCode != "" {
+			fmt.Printf("  Error code: %s\n", apiErr.ErrorCode)
+		}
+	}
+	fmt.Printf("  Error: %s\n", err.Error())
+	return true
 }
 
 // outputMultiEnvPlanResult prints plan results for multiple environments.

--- a/pkg/cmd/commands/plan_test.go
+++ b/pkg/cmd/commands/plan_test.go
@@ -2,9 +2,13 @@ package commands
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
@@ -12,8 +16,10 @@ import (
 
 	"github.com/block/spirit/pkg/utils"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/block/schemabot/pkg/apitypes"
+	"github.com/block/schemabot/pkg/cmd/client"
 	"github.com/block/schemabot/pkg/cmd/internal/templates"
 	"github.com/block/schemabot/pkg/state"
 	"github.com/block/schemabot/pkg/ui"
@@ -65,6 +71,84 @@ func planWithTablesAndEngine(engine string, tables ...*apitypes.TableChangeRespo
 			{Namespace: "default", TableChanges: tables},
 		},
 	}
+}
+
+func writeTestSchemaDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "schemabot.yaml"), []byte("database: testdb\ntype: mysql\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "users.sql"), []byte("CREATE TABLE `users` (`id` bigint unsigned NOT NULL AUTO_INCREMENT, PRIMARY KEY (`id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;"), 0o644))
+	return dir
+}
+
+func TestPlanCmd_ServerErrorHumanOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/plan", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_, err := w.Write([]byte(`{"error":"plan failed: read secret file /secrets/db-passwords/test-password: no such file or directory","error_code":"plan_failed"}`))
+		require.NoError(t, err)
+	}))
+	t.Cleanup(server.Close)
+
+	cmd := PlanCmd{SchemaDir: writeTestSchemaDir(t), Environment: "staging"}
+	var runErr error
+	output := captureStdout(func() {
+		runErr = cmd.Run(&Globals{Endpoint: server.URL})
+	})
+
+	require.ErrorIs(t, runErr, ErrSilent)
+	plainOutput := stripAnsi(output)
+	assert.Contains(t, plainOutput, "Plan failed")
+	assert.Contains(t, plainOutput, "Database: testdb")
+	assert.Contains(t, plainOutput, "Environment: staging")
+	assert.Contains(t, plainOutput, "API status: HTTP 500")
+	assert.Contains(t, plainOutput, "Error code: plan_failed")
+	assert.Contains(t, plainOutput, "read secret file /secrets/db-passwords/test-password")
+}
+
+func TestPlanCmd_EnvironmentDiscoveryServerErrorHumanOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/databases/testdb/environments", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, err := w.Write([]byte(`{"error":"database target unavailable","error_code":"target_unavailable"}`))
+		require.NoError(t, err)
+	}))
+	t.Cleanup(server.Close)
+
+	cmd := PlanCmd{SchemaDir: writeTestSchemaDir(t)}
+	var runErr error
+	output := captureStdout(func() {
+		runErr = cmd.Run(&Globals{Endpoint: server.URL})
+	})
+
+	require.ErrorIs(t, runErr, ErrSilent)
+	plainOutput := stripAnsi(output)
+	assert.Contains(t, plainOutput, "Plan failed")
+	assert.Contains(t, plainOutput, "Database: testdb")
+	assert.NotContains(t, plainOutput, "Environment:")
+	assert.Contains(t, plainOutput, "API status: HTTP 503")
+	assert.Contains(t, plainOutput, "Error code: target_unavailable")
+	assert.Contains(t, plainOutput, "database target unavailable")
+}
+
+func TestOutputPlanRequestError_ConnectionErrorHumanOutput(t *testing.T) {
+	err := client.FormatConnectionError("http://127.0.0.1:65535", errors.New("dial tcp 127.0.0.1:65535: connect: connection refused"))
+
+	var rendered bool
+	output := captureStdout(func() {
+		rendered = outputPlanRequestError("testdb", "staging", err)
+	})
+
+	require.True(t, rendered)
+	plainOutput := stripAnsi(output)
+	assert.Contains(t, plainOutput, "Plan failed")
+	assert.Contains(t, plainOutput, "Database: testdb")
+	assert.Contains(t, plainOutput, "Environment: staging")
+	assert.Contains(t, plainOutput, "Error: cannot connect to http://127.0.0.1:65535")
+	assert.NotContains(t, plainOutput, "API status:")
+	assert.NotContains(t, plainOutput, "Error code:")
 }
 
 func TestPlanFingerprint_IdenticalPlans(t *testing.T) {


### PR DESCRIPTION
## Why
Human-readable `plan` output should explain API and connection failures directly instead of relying on top-level stderr handling.

## What
- Render plan request failures with database, environment, HTTP status, error code, and message
- Cover both environment discovery and per-environment plan failures in text mode
- Keep JSON error output unchanged

## Risk Assessment
Low — this only changes CLI error presentation for failed plan requests and leaves successful plan output and API behavior unchanged.

Generated with Amp
