### PR TITLE
feat(storage): apply_operations claim primitives (FindNextApplyOperation + Heartbeat)

### DIFF
--- a/pkg/schema/mysql/apply_operations.sql
+++ b/pkg/schema/mysql/apply_operations.sql
@@ -11,5 +11,6 @@ CREATE TABLE `apply_operations` (
   `updated_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`),
   UNIQUE KEY `idx_apply_operation` (`apply_id`,`deployment`),
-  KEY `idx_deployment_state` (`deployment`,`state`)
+  KEY `idx_deployment_state` (`deployment`,`state`),
+  KEY `idx_state_created_id` (`state`,`created_at`,`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci

--- a/pkg/storage/mysqlstore/apply_operations.go
+++ b/pkg/storage/mysqlstore/apply_operations.go
@@ -213,6 +213,109 @@ func (s *applyOperationStore) MarkFailed(ctx context.Context, id int64, errMsg s
 	return s.checkUpdatedOrExists(ctx, result, id)
 }
 
+// applyOperationHeartbeatStaleness is the lease window after which a claimed
+// apply_operations row may be re-claimed by another worker. Mirrors the apply
+// heartbeat staleness in applies.go.
+const applyOperationHeartbeatStaleness = "1 MINUTE"
+
+// FindNextApplyOperation atomically claims the next apply_operations row that
+// needs attention and refreshes its heartbeat in the same transaction.
+//
+// Pending rows are transitioned to running and stamped with started_at;
+// already-active rows with a stale heartbeat (updated_at older than the
+// staleness window) are re-leased without changing their state. Terminal
+// rows are never claimed.
+//
+// Mirrors ApplyStore.FindNextApply: SELECT ... FOR UPDATE SKIP LOCKED to
+// avoid worker races, READ COMMITTED isolation to prevent next-key range
+// locks from serializing claims across otherwise independent rows.
+//
+// Pure storage primitive: no caller wires this in yet. The per-deployment
+// claim loop arrives in a subsequent PR in the multi-deployment apply
+// workstream.
+func (s *applyOperationStore) FindNextApplyOperation(ctx context.Context) (*storage.ApplyOperation, error) {
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelReadCommitted})
+	if err != nil {
+		return nil, fmt.Errorf("begin claim apply_operation transaction: %w", err)
+	}
+	defer rollbackApplyTx(ctx, tx, "claim apply_operation")
+
+	activeStates := claimableApplyStates()
+	activeStatePlaceholders := placeholders(len(activeStates))
+
+	queryArgs := []any{state.ApplyOperation.Pending}
+	queryArgs = append(queryArgs, stringArgs(activeStates)...)
+
+	row := tx.QueryRowContext(ctx, fmt.Sprintf(`
+		SELECT %s
+		FROM apply_operations
+		WHERE (
+			state = ?
+			OR (state IN (%s) AND updated_at < NOW() - INTERVAL %s)
+		)
+		ORDER BY created_at, id
+		LIMIT 1
+		FOR UPDATE SKIP LOCKED
+	`, applyOperationColumns, activeStatePlaceholders, applyOperationHeartbeatStaleness), queryArgs...)
+
+	ad, err := scanApplyOperationInto(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil // nothing to claim
+	}
+	if err != nil {
+		return nil, fmt.Errorf("query next claimable apply_operation: %w", err)
+	}
+
+	if ad.State == state.ApplyOperation.Pending {
+		// Pending → running: stamp started_at and update the heartbeat in the
+		// same write. WHERE state = ? guards against a concurrent transition
+		// landing between the SELECT and this UPDATE; RowsAffected == 0 means
+		// another writer already moved the row, so we back off cleanly.
+		result, err := tx.ExecContext(ctx, `
+			UPDATE apply_operations
+			SET state = ?, started_at = COALESCE(started_at, NOW()), updated_at = NOW()
+			WHERE id = ? AND state = ?
+		`, state.ApplyOperation.Running, ad.ID, state.ApplyOperation.Pending)
+		if err != nil {
+			return nil, fmt.Errorf("claim pending apply_operation %d: %w", ad.ID, err)
+		}
+		rows, err := result.RowsAffected()
+		if err != nil {
+			return nil, fmt.Errorf("read claim rows affected for apply_operation %d: %w", ad.ID, err)
+		}
+		if rows == 0 {
+			return nil, nil
+		}
+	} else {
+		// Already-active stale row: just refresh the heartbeat as our lease.
+		_, err = tx.ExecContext(ctx, `
+			UPDATE apply_operations SET updated_at = NOW() WHERE id = ?
+		`, ad.ID)
+		if err != nil {
+			return nil, fmt.Errorf("refresh heartbeat for claimed apply_operation %d: %w", ad.ID, err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("commit claim apply_operation %d: %w", ad.ID, err)
+	}
+
+	return ad, nil
+}
+
+// Heartbeat refreshes updated_at to maintain the claim's lease. Should be
+// called periodically by a worker holding the lease. Silent no-op when the
+// row no longer exists (mirrors ApplyStore.Heartbeat).
+func (s *applyOperationStore) Heartbeat(ctx context.Context, id int64) error {
+	_, err := s.db.ExecContext(ctx, `
+		UPDATE apply_operations SET updated_at = NOW() WHERE id = ?
+	`, id)
+	if err != nil {
+		return fmt.Errorf("heartbeat apply_operation %d: %w", id, err)
+	}
+	return nil
+}
+
 // DeleteByApply removes all child rows for an apply.
 func (s *applyOperationStore) DeleteByApply(ctx context.Context, applyID int64) error {
 	_, err := s.db.ExecContext(ctx, `DELETE FROM apply_operations WHERE apply_id = ?`, applyID)

--- a/pkg/storage/mysqlstore/apply_operations_test.go
+++ b/pkg/storage/mysqlstore/apply_operations_test.go
@@ -4,6 +4,7 @@ package mysqlstore
 
 import (
 	"database/sql"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -492,7 +493,10 @@ func TestApplyOperationStore_FindNextApplyOperation_ClaimsStaleRunning(t *testin
 }
 
 // TestApplyOperationStore_FindNextApplyOperation_SkipsTerminal verifies that
-// terminal rows (completed/failed) are never re-claimed by recovery.
+// every terminal state listed in state.IsApplyOperationTerminal is excluded
+// from the claim. ApplyOperation shares the full Apply state vocabulary, so
+// the contract has to hold for completed, failed, stopped, cancelled, and
+// reverted — not just the two that show up most often.
 func TestApplyOperationStore_FindNextApplyOperation_SkipsTerminal(t *testing.T) {
 	clearTables(t)
 	ctx := t.Context()
@@ -501,27 +505,41 @@ func TestApplyOperationStore_FindNextApplyOperation_SkipsTerminal(t *testing.T) 
 	lock := createTestLock(t, store, "testdb", "mysql", "staging")
 	apply := createTestApply(t, store, lock, "apply_op_skip_terminal", 1)
 
-	completedID, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
-		ApplyID: apply.ID, Deployment: "region-a",
-	})
-	require.NoError(t, err)
-	require.NoError(t, store.ApplyOperations().MarkCompleted(ctx, completedID))
+	terminalStates := []string{
+		state.ApplyOperation.Completed,
+		state.ApplyOperation.Failed,
+		state.ApplyOperation.Stopped,
+		state.ApplyOperation.Cancelled,
+		state.ApplyOperation.Reverted,
+	}
 
-	failedID, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
-		ApplyID: apply.ID, Deployment: "region-b",
-	})
-	require.NoError(t, err)
-	require.NoError(t, store.ApplyOperations().MarkFailed(ctx, failedID, "boom"))
+	var ids []int64
+	for i, terminalState := range terminalStates {
+		require.True(t, state.IsApplyOperationTerminal(terminalState),
+			"terminalStates[%d]=%q is not actually terminal — fix the test fixture", i, terminalState)
+		id, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+			ApplyID:    apply.ID,
+			Deployment: fmt.Sprintf("region-%d", i),
+			State:      terminalState,
+		})
+		require.NoError(t, err)
+		ids = append(ids, id)
+	}
 
-	// Backdate both so staleness can't be the reason they're skipped.
-	_, err = testDB.ExecContext(ctx, `
-		UPDATE apply_operations SET updated_at = NOW() - INTERVAL 1 HOUR WHERE id IN (?, ?)
-	`, completedID, failedID)
+	// Backdate every row so staleness can't be the reason they're skipped;
+	// the only thing keeping them off the claim list must be their state.
+	args := make([]any, len(ids))
+	for i, id := range ids {
+		args[i] = id
+	}
+	_, err := testDB.ExecContext(ctx, fmt.Sprintf(`
+		UPDATE apply_operations SET updated_at = NOW() - INTERVAL 1 HOUR WHERE id IN (%s)
+	`, placeholders(len(ids))), args...)
 	require.NoError(t, err)
 
 	claimed, err := store.ApplyOperations().FindNextApplyOperation(ctx)
 	require.NoError(t, err)
-	assert.Nil(t, claimed, "terminal rows must never be re-claimed")
+	assert.Nil(t, claimed, "terminal rows must never be re-claimed (full vocabulary)")
 }
 
 // TestApplyOperationStore_FindNextApplyOperation_ConcurrentClaims verifies

--- a/pkg/storage/mysqlstore/apply_operations_test.go
+++ b/pkg/storage/mysqlstore/apply_operations_test.go
@@ -4,7 +4,9 @@ package mysqlstore
 
 import (
 	"database/sql"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -391,6 +393,260 @@ func TestApplyOperationStore_MarkFailed_Idempotent(t *testing.T) {
 	require.NotNil(t, second.CompletedAt)
 	assert.Equal(t, first.CompletedAt.UnixNano(), second.CompletedAt.UnixNano(),
 		"COALESCE should preserve original completed_at across repeat MarkFailed calls")
+}
+
+// TestApplyOperationStore_FindNextApplyOperation_ClaimsPending verifies that
+// a freshly inserted pending child row is claimable: returned to the caller,
+// transitioned to running, and stamped with started_at + heartbeat in one
+// transaction. A second immediate claim returns nil because no other row
+// needs work.
+func TestApplyOperationStore_FindNextApplyOperation_ClaimsPending(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", "mysql", "staging")
+	apply := createTestApply(t, store, lock, "apply_op_claim_pending", 1)
+
+	id, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-a", Target: "payments",
+	})
+	require.NoError(t, err)
+
+	claimed, err := store.ApplyOperations().FindNextApplyOperation(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, claimed)
+	assert.Equal(t, id, claimed.ID)
+	assert.Equal(t, "region-a", claimed.Deployment)
+
+	persisted, err := store.ApplyOperations().Get(ctx, id)
+	require.NoError(t, err)
+	require.NotNil(t, persisted)
+	assert.Equal(t, state.ApplyOperation.Running, persisted.State, "pending claim must transition to running")
+	require.NotNil(t, persisted.StartedAt, "pending claim must stamp started_at")
+
+	// No other claimable rows → second call returns nil cleanly.
+	again, err := store.ApplyOperations().FindNextApplyOperation(ctx)
+	require.NoError(t, err)
+	assert.Nil(t, again)
+}
+
+// TestApplyOperationStore_FindNextApplyOperation_SkipsFreshRunning verifies
+// that a running row whose heartbeat is fresh is *not* re-claimed: the active
+// worker still owns it.
+func TestApplyOperationStore_FindNextApplyOperation_SkipsFreshRunning(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", "mysql", "staging")
+	apply := createTestApply(t, store, lock, "apply_op_skip_fresh", 1)
+
+	id, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-a",
+	})
+	require.NoError(t, err)
+	require.NoError(t, store.ApplyOperations().MarkStarted(ctx, id))
+
+	claimed, err := store.ApplyOperations().FindNextApplyOperation(ctx)
+	require.NoError(t, err)
+	assert.Nil(t, claimed, "fresh running rows must not be re-claimed")
+}
+
+// TestApplyOperationStore_FindNextApplyOperation_ClaimsStaleRunning verifies
+// the recovery path: an active row whose heartbeat is older than the staleness
+// window is re-claimed without changing its state, and the heartbeat is
+// refreshed.
+func TestApplyOperationStore_FindNextApplyOperation_ClaimsStaleRunning(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", "mysql", "staging")
+	apply := createTestApply(t, store, lock, "apply_op_claim_stale", 1)
+
+	id, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-a",
+	})
+	require.NoError(t, err)
+	require.NoError(t, store.ApplyOperations().MarkStarted(ctx, id))
+
+	// Backdate the heartbeat past the staleness window.
+	_, err = testDB.ExecContext(ctx, `
+		UPDATE apply_operations SET updated_at = NOW() - INTERVAL 2 MINUTE WHERE id = ?
+	`, id)
+	require.NoError(t, err)
+
+	claimed, err := store.ApplyOperations().FindNextApplyOperation(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, claimed)
+	assert.Equal(t, id, claimed.ID)
+	assert.Equal(t, state.ApplyOperation.Running, claimed.State, "stale running row must keep its state on re-claim")
+
+	persisted, err := store.ApplyOperations().Get(ctx, id)
+	require.NoError(t, err)
+	require.NotNil(t, persisted)
+	assert.Equal(t, state.ApplyOperation.Running, persisted.State)
+	// Heartbeat refreshed inside the claim transaction.
+	assert.WithinDuration(t, time.Now(), persisted.UpdatedAt, 5*time.Second)
+}
+
+// TestApplyOperationStore_FindNextApplyOperation_SkipsTerminal verifies that
+// terminal rows (completed/failed) are never re-claimed by recovery.
+func TestApplyOperationStore_FindNextApplyOperation_SkipsTerminal(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", "mysql", "staging")
+	apply := createTestApply(t, store, lock, "apply_op_skip_terminal", 1)
+
+	completedID, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-a",
+	})
+	require.NoError(t, err)
+	require.NoError(t, store.ApplyOperations().MarkCompleted(ctx, completedID))
+
+	failedID, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-b",
+	})
+	require.NoError(t, err)
+	require.NoError(t, store.ApplyOperations().MarkFailed(ctx, failedID, "boom"))
+
+	// Backdate both so staleness can't be the reason they're skipped.
+	_, err = testDB.ExecContext(ctx, `
+		UPDATE apply_operations SET updated_at = NOW() - INTERVAL 1 HOUR WHERE id IN (?, ?)
+	`, completedID, failedID)
+	require.NoError(t, err)
+
+	claimed, err := store.ApplyOperations().FindNextApplyOperation(ctx)
+	require.NoError(t, err)
+	assert.Nil(t, claimed, "terminal rows must never be re-claimed")
+}
+
+// TestApplyOperationStore_FindNextApplyOperation_ConcurrentClaims verifies
+// the SKIP LOCKED contract on a contended row: N workers race to claim a
+// single pending child row, and exactly one wins. Mirrors the apply-level
+// TestApplyStore_FindNextApplyConcurrentPendingClaims.
+func TestApplyOperationStore_FindNextApplyOperation_ConcurrentClaims(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", "mysql", "staging")
+	apply := createTestApply(t, store, lock, "apply_op_concurrent", 1)
+
+	id, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-a",
+	})
+	require.NoError(t, err)
+
+	const workers = 16
+	stores := make([]*Storage, workers)
+	for i := range workers {
+		db, openErr := sql.Open("mysql", testDSNChangedRows)
+		require.NoError(t, openErr)
+		db.SetMaxOpenConns(1)
+		db.SetMaxIdleConns(1)
+		t.Cleanup(func() {
+			require.NoError(t, db.Close())
+		})
+		stores[i] = New(db)
+	}
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	var claimed []*storage.ApplyOperation
+	var claimErrors []error
+
+	for i := range workers {
+		workerStore := stores[i]
+		wg.Go(func() {
+			<-start
+			got, claimErr := workerStore.ApplyOperations().FindNextApplyOperation(ctx)
+
+			mu.Lock()
+			defer mu.Unlock()
+			if claimErr != nil {
+				claimErrors = append(claimErrors, claimErr)
+				return
+			}
+			if got != nil {
+				claimed = append(claimed, got)
+			}
+		})
+	}
+
+	close(start)
+	wg.Wait()
+
+	require.Empty(t, claimErrors)
+	require.Len(t, claimed, 1, "only one worker should claim a single pending apply_operation")
+	assert.Equal(t, "region-a", claimed[0].Deployment)
+	assert.Equal(t, state.ApplyOperation.Pending, claimed[0].State, "caller sees the pre-claim state")
+
+	persisted, err := store.ApplyOperations().Get(ctx, id)
+	require.NoError(t, err)
+	require.NotNil(t, persisted)
+	assert.Equal(t, state.ApplyOperation.Running, persisted.State)
+}
+
+// TestApplyOperationStore_FindNextApplyOperation_DBError covers the error
+// surface when the underlying connection is gone.
+func TestApplyOperationStore_FindNextApplyOperation_DBError(t *testing.T) {
+	db, err := sql.Open("mysql", testDSN)
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	store := New(db)
+	_, err = store.ApplyOperations().FindNextApplyOperation(t.Context())
+	require.Error(t, err)
+}
+
+// TestApplyOperationStore_Heartbeat verifies that Heartbeat moves updated_at
+// forward for an existing row and is a silent no-op for an unknown id.
+func TestApplyOperationStore_Heartbeat(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", "mysql", "staging")
+	apply := createTestApply(t, store, lock, "apply_op_heartbeat", 1)
+
+	id, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-a",
+	})
+	require.NoError(t, err)
+
+	// Backdate updated_at so the heartbeat refresh is observable.
+	_, err = testDB.ExecContext(ctx, `
+		UPDATE apply_operations SET updated_at = NOW() - INTERVAL 5 MINUTE WHERE id = ?
+	`, id)
+	require.NoError(t, err)
+
+	before, err := store.ApplyOperations().Get(ctx, id)
+	require.NoError(t, err)
+
+	require.NoError(t, store.ApplyOperations().Heartbeat(ctx, id))
+
+	after, err := store.ApplyOperations().Get(ctx, id)
+	require.NoError(t, err)
+	assert.True(t, after.UpdatedAt.After(before.UpdatedAt), "Heartbeat must move updated_at forward")
+	assert.WithinDuration(t, time.Now(), after.UpdatedAt, 5*time.Second)
+
+	// Silent no-op on unknown id (matches ApplyStore.Heartbeat semantics).
+	require.NoError(t, store.ApplyOperations().Heartbeat(ctx, 999999))
+}
+
+func TestApplyOperationStore_Heartbeat_DBError(t *testing.T) {
+	db, err := sql.Open("mysql", testDSN)
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	store := New(db)
+	err = store.ApplyOperations().Heartbeat(t.Context(), 1)
+	require.Error(t, err)
 }
 
 func TestApplyOperationStore_DeleteByApply(t *testing.T) {

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -359,6 +359,26 @@ type ApplyOperationStore interface {
 	// MarkFailed sets state=failed, error_message, and completed_at on a child row.
 	MarkFailed(ctx context.Context, id int64, errMsg string) error
 
+	// FindNextApplyOperation atomically claims the next child row that needs
+	// attention and refreshes its heartbeat in the same transaction.
+	//
+	// Pending rows are transitioned to running and stamped with started_at;
+	// already-active rows whose heartbeat has been stale for more than one
+	// minute are re-leased without changing their state. Terminal rows
+	// (completed/failed/cancelled/stopped/reverted) are never claimed.
+	//
+	// Returns the claimed row, or nil if nothing needs work.
+	//
+	// Pure storage primitive: no scheduler/operator loop calls this yet —
+	// the per-deployment claim loop arrives in a subsequent PR in the
+	// multi-deployment apply workstream.
+	FindNextApplyOperation(ctx context.Context) (*ApplyOperation, error)
+
+	// Heartbeat refreshes the child row's updated_at timestamp to extend the
+	// claim's lease while a worker is acting on it. Mirrors ApplyStore.Heartbeat
+	// semantics: silent no-op when the row no longer exists.
+	Heartbeat(ctx context.Context, id int64) error
+
 	// DeleteByApply removes all child rows for an apply (cleanup on apply delete).
 	DeleteByApply(ctx context.Context, applyID int64) error
 }


### PR DESCRIPTION
## What and Why ?
Adds two additive storage primitives on `ApplyOperationStore` so a later operator claim loop can lease per-deployment child rows directly. No caller wires either method in yet — this is groundwork.

Follows the workstream's working principle: **schema before code, additive before subtractive, dual-write before cut-over.** The schema (`apply_operations` table) and dual-write (apply create) already landed; this PR adds the claim primitive a future operator loop will consume, still with no behaviour change in production.

### What's new

- `FindNextApplyOperation(ctx) (*ApplyOperation, error)` — `SELECT ... FOR UPDATE SKIP LOCKED` claim. Pending rows transition to running and stamp `started_at` + heartbeat in the same transaction; already-active rows whose heartbeat has been stale for more than one minute are re-leased without changing state; terminal rows are never claimed. Returns `nil` when nothing needs work. Mirrors `ApplyStore.FindNextApply`: READ COMMITTED isolation so concurrent claims don't take next-key range locks across otherwise independent rows.
- `Heartbeat(ctx, id) error` — refreshes `updated_at` to extend the claim's lease. Silent no-op when the row no longer exists (matches `ApplyStore.Heartbeat` semantics).

### Why no caller

The per-row operator claim loop is intentionally a separate PR, gated by a feature flag so the new path can soak before any real apply touches it.

### Tests

All integration tests in `pkg/storage/mysqlstore/apply_operations_test.go`:

- claim of a pending row → running + `started_at` + heartbeat
- fresh running row is not re-claimed
- stale running row (heartbeat backdated > 1 minute) is re-claimed without state change; heartbeat refreshed
- terminal rows (completed / failed) with backdated heartbeats are never claimed
- 16-worker SKIP LOCKED contention on a single pending row → exactly one winner
- heartbeat refreshes `updated_at`; no-op on unknown id
- DB-error paths for both methods

\`go build\`, \`go vet\`, \`golangci-lint\`, the integration suite for `pkg/storage/...` and `pkg/state/...`, and the full unit suite all pass.