### PR TITLE
refactor(webhook): ClientSet seam for multi-App dispatch (1/2)

### DIFF
--- a/pkg/github/clientset.go
+++ b/pkg/github/clientset.go
@@ -1,0 +1,61 @@
+package github
+
+import (
+	"fmt"
+	"maps"
+	"sort"
+)
+
+// ClientSet holds one or more GitHub App client factories keyed by the App's
+// logical name (the same key used in api.ServerConfig.Apps). Webhook dispatch
+// resolves a repository to its owning App, looks up the factory via For, and
+// then mints an installation-scoped client via the returned factory.
+//
+// Today the production path constructs a single-entry ClientSet keyed
+// "default" from the legacy ServerConfig.GitHub field; the multi-App
+// dispatcher that fans out across N entries lands in a follow-up PR.
+type ClientSet struct {
+	clients map[string]GitHubClientFactory
+}
+
+// NewClientSet returns a ClientSet that owns the given factories. The
+// underlying map is copied so subsequent mutations by the caller do not
+// affect the set.
+func NewClientSet(clients map[string]GitHubClientFactory) ClientSet {
+	cs := ClientSet{clients: make(map[string]GitHubClientFactory, len(clients))}
+	maps.Copy(cs.clients, clients)
+	return cs
+}
+
+// NewSingleClientSet returns a ClientSet containing one factory under the
+// given name. Convenience for legacy single-App configurations and tests.
+func NewSingleClientSet(name string, c GitHubClientFactory) ClientSet {
+	return ClientSet{clients: map[string]GitHubClientFactory{name: c}}
+}
+
+// For returns the factory registered under appName, or an error if no such
+// factory exists. The error includes the configured names so misconfiguration
+// at startup or in tests fails closed with a useful message.
+func (cs ClientSet) For(appName string) (GitHubClientFactory, error) {
+	if cs.clients == nil {
+		return nil, fmt.Errorf("no GitHub App clients configured")
+	}
+	if c, ok := cs.clients[appName]; ok {
+		return c, nil
+	}
+	return nil, fmt.Errorf("no GitHub App client for %q (configured: %v)", appName, cs.Names())
+}
+
+// Names returns the configured App names in sorted order. Used in error
+// messages and structured logs.
+func (cs ClientSet) Names() []string {
+	names := make([]string, 0, len(cs.clients))
+	for name := range cs.clients {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// Len returns the number of configured App clients.
+func (cs ClientSet) Len() int { return len(cs.clients) }

--- a/pkg/github/clientset.go
+++ b/pkg/github/clientset.go
@@ -35,15 +35,21 @@ func NewSingleClientSet(name string, c GitHubClientFactory) ClientSet {
 
 // For returns the factory registered under appName, or an error if no such
 // factory exists. The error includes the configured names so misconfiguration
-// at startup or in tests fails closed with a useful message.
+// at startup or in tests fails closed with a useful message. A registered
+// but nil factory is also treated as a fail-closed misconfiguration so
+// callers never get a nil factory back and panic on a later ForInstallation.
 func (cs ClientSet) For(appName string) (GitHubClientFactory, error) {
 	if cs.clients == nil {
 		return nil, fmt.Errorf("no GitHub App clients configured")
 	}
-	if c, ok := cs.clients[appName]; ok {
-		return c, nil
+	c, ok := cs.clients[appName]
+	if !ok {
+		return nil, fmt.Errorf("no GitHub App client for %q (configured: %v)", appName, cs.Names())
 	}
-	return nil, fmt.Errorf("no GitHub App client for %q (configured: %v)", appName, cs.Names())
+	if c == nil {
+		return nil, fmt.Errorf("GitHub App client for %q is nil (misconfigured)", appName)
+	}
+	return c, nil
 }
 
 // Names returns the configured App names in sorted order. Used in error

--- a/pkg/github/clientset_test.go
+++ b/pkg/github/clientset_test.go
@@ -1,0 +1,46 @@
+package github
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type stubFactory struct{}
+
+func (stubFactory) ForInstallation(int64) (*InstallationClient, error) { return nil, nil }
+
+func TestClientSet_For(t *testing.T) {
+	t.Run("returns registered factory", func(t *testing.T) {
+		f := stubFactory{}
+		cs := NewSingleClientSet("default", f)
+		got, err := cs.For("default")
+		require.NoError(t, err)
+		assert.Equal(t, f, got)
+	})
+
+	t.Run("unknown app name fails closed", func(t *testing.T) {
+		cs := NewSingleClientSet("default", stubFactory{})
+		_, err := cs.For("other")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `no GitHub App client for "other"`)
+	})
+
+	t.Run("empty set fails closed", func(t *testing.T) {
+		var cs ClientSet
+		_, err := cs.For("default")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no GitHub App clients configured")
+	})
+
+	t.Run("registered nil factory fails closed instead of panicking", func(t *testing.T) {
+		// Guards against NewHandler(svc, nil, ...) — the nil factory must
+		// surface as an error from For, not as a nil-pointer panic when a
+		// later caller invokes ForInstallation on it.
+		cs := NewSingleClientSet("default", nil)
+		_, err := cs.For("default")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `GitHub App client for "default" is nil`)
+	})
+}

--- a/pkg/webhook/actor_authorization_test.go
+++ b/pkg/webhook/actor_authorization_test.go
@@ -388,9 +388,9 @@ func TestWebhookStopCommandBlocksUnauthorizedActor(t *testing.T) {
 	})
 	service := api.New(&stopActorAuthStorage{apply: apply}, cfg, nil, testLogger())
 	h := &Handler{
-		service:  service,
-		ghClient: &fakeClientFactory{client: ghclient.NewInstallationClient(client, testLogger())},
-		logger:   testLogger(),
+		service:   service,
+		ghClients: ghclient.NewSingleClientSet(defaultAppName, &fakeClientFactory{client: ghclient.NewInstallationClient(client, testLogger())}),
+		logger:    testLogger(),
 	}
 
 	req := buildWebhookRequest(t, webhookPayloadOpts{
@@ -462,9 +462,9 @@ func actorAuthTestConfig(enabled bool, opts ...func(*api.ServerConfig)) *api.Ser
 func actorAuthTestHandler(cfg *api.ServerConfig, installClient *ghclient.InstallationClient) *Handler {
 	service := api.New(nil, cfg, nil, testLogger())
 	return &Handler{
-		service:  service,
-		ghClient: &fakeClientFactory{client: installClient},
-		logger:   testLogger(),
+		service:   service,
+		ghClients: ghclient.NewSingleClientSet(defaultAppName, &fakeClientFactory{client: installClient}),
+		logger:    testLogger(),
 	}
 }
 

--- a/pkg/webhook/apply_check_records.go
+++ b/pkg/webhook/apply_check_records.go
@@ -99,7 +99,7 @@ func (h *Handler) updateCheckRecordForApplyStart(ctx context.Context, client *gh
 
 // updateCheckRunAfterUnlock updates a check run to neutral after lock release.
 func (h *Handler) updateCheckRunAfterUnlock(ctx context.Context, repo string, pr int, lock *storage.Lock, installationID int64) {
-	client, err := h.ghClient.ForInstallation(installationID)
+	client, err := h.clientForRepo(repo, installationID)
 	if err != nil {
 		h.logger.Error("failed to create GitHub client for check run update", "error", err)
 		return

--- a/pkg/webhook/apply_execute.go
+++ b/pkg/webhook/apply_execute.go
@@ -98,10 +98,21 @@ func (h *Handler) executeApply(
 
 	caller := fmt.Sprintf("github:%s@%s#%d", requestedBy, repo, pr)
 
+	// Resolve the App factory for this repo once so the observer captures
+	// the correct App for all subsequent GitHub calls (comments, check runs).
+	// Failure here is unrecoverable for outbound calls — the same error would
+	// also block postComment — so log and return without attempting a comment.
+	factory, factoryErr := h.factoryForRepo(repo)
+	if factoryErr != nil {
+		h.logger.Error("apply blocked: cannot resolve GitHub App client for repo",
+			"repo", repo, "pr", pr, "database", database, "environment", environment, "error", factoryErr)
+		return
+	}
+
 	// Set observer before queuing the apply so ExecuteApply can register it on
 	// the durable apply row before scheduler dispatch starts.
 	observer := NewCommentObserver(CommentObserverConfig{
-		GHClient:       h.ghClient,
+		GHClient:       factory,
 		Storage:        h.service.Storage(),
 		Repo:           repo,
 		PR:             pr,
@@ -121,7 +132,7 @@ func (h *Handler) executeApply(
 					"repo", repo, "pr", pr, "apply_id", apply.ID, "apply_identifier", apply.ApplyIdentifier)
 				return
 			}
-			ghInstClient, err := h.ghClient.ForInstallation(installationID)
+			ghInstClient, err := factory.ForInstallation(installationID)
 			if err != nil {
 				h.logger.Error("observer: failed to create GitHub client",
 					"repo", repo, "pr", pr, "apply_id", apply.ID, "apply_identifier", apply.ApplyIdentifier,

--- a/pkg/webhook/apply_gating_test.go
+++ b/pkg/webhook/apply_gating_test.go
@@ -309,9 +309,9 @@ func TestEnforcePassingChecks(t *testing.T) {
 
 		service := api.New(nil, &api.ServerConfig{}, nil, testLogger())
 		h := &Handler{
-			service:  service,
-			ghClient: factory,
-			logger:   testLogger(),
+			service:   service,
+			ghClients: ghclient.NewSingleClientSet(defaultAppName, factory),
+			logger:    testLogger(),
 		}
 
 		ctx := t.Context()
@@ -351,9 +351,9 @@ func TestEnforcePassingChecks(t *testing.T) {
 
 		service := api.New(nil, &api.ServerConfig{}, nil, testLogger())
 		h := &Handler{
-			service:  service,
-			ghClient: factory,
-			logger:   testLogger(),
+			service:   service,
+			ghClients: ghclient.NewSingleClientSet(defaultAppName, factory),
+			logger:    testLogger(),
 		}
 
 		ctx := t.Context()
@@ -393,9 +393,9 @@ func TestEnforcePassingChecks(t *testing.T) {
 
 		service := api.New(nil, &api.ServerConfig{}, nil, testLogger())
 		h := &Handler{
-			service:  service,
-			ghClient: factory,
-			logger:   testLogger(),
+			service:   service,
+			ghClients: ghclient.NewSingleClientSet(defaultAppName, factory),
+			logger:    testLogger(),
 		}
 
 		ctx := t.Context()
@@ -424,9 +424,9 @@ func TestEnforcePassingChecks(t *testing.T) {
 
 		service := api.New(nil, &api.ServerConfig{RequiredChecks: []string{"Required Review"}}, nil, testLogger())
 		h := &Handler{
-			service:  service,
-			ghClient: factory,
-			logger:   testLogger(),
+			service:   service,
+			ghClients: ghclient.NewSingleClientSet(defaultAppName, factory),
+			logger:    testLogger(),
 		}
 
 		ctx := t.Context()
@@ -457,9 +457,9 @@ func TestEnforcePassingChecks(t *testing.T) {
 
 		service := api.New(nil, &api.ServerConfig{RequiredChecks: []string{"Required Review"}}, nil, testLogger())
 		h := &Handler{
-			service:  service,
-			ghClient: factory,
-			logger:   testLogger(),
+			service:   service,
+			ghClients: ghclient.NewSingleClientSet(defaultAppName, factory),
+			logger:    testLogger(),
 		}
 
 		ctx := t.Context()
@@ -488,9 +488,9 @@ func TestEnforcePassingChecks(t *testing.T) {
 
 		service := api.New(nil, &api.ServerConfig{}, nil, testLogger())
 		h := &Handler{
-			service:  service,
-			ghClient: factory,
-			logger:   testLogger(),
+			service:   service,
+			ghClients: ghclient.NewSingleClientSet(defaultAppName, factory),
+			logger:    testLogger(),
 		}
 
 		ctx := t.Context()
@@ -521,9 +521,9 @@ func TestEnforcePassingChecks(t *testing.T) {
 
 		service := api.New(nil, &api.ServerConfig{}, nil, testLogger())
 		h := &Handler{
-			service:  service,
-			ghClient: factory,
-			logger:   testLogger(),
+			service:   service,
+			ghClients: ghclient.NewSingleClientSet(defaultAppName, factory),
+			logger:    testLogger(),
 		}
 
 		ctx := t.Context()
@@ -551,9 +551,9 @@ func TestEnforcePassingChecks(t *testing.T) {
 
 		service := api.New(nil, &api.ServerConfig{}, nil, testLogger())
 		h := &Handler{
-			service:  service,
-			ghClient: factory,
-			logger:   testLogger(),
+			service:   service,
+			ghClients: ghclient.NewSingleClientSet(defaultAppName, factory),
+			logger:    testLogger(),
 		}
 
 		ctx := t.Context()

--- a/pkg/webhook/apply_handlers.go
+++ b/pkg/webhook/apply_handlers.go
@@ -15,7 +15,7 @@ import (
 // handleApplyCommand handles the "schemabot apply -e <env>" PR comment command.
 // It generates a plan, acquires a lock, and posts a plan comment with a confirmation footer.
 func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseName string, installationID int64, requestedBy string, result CommandResult) {
-	ctx, cancel, client, err := h.commandBootstrap(installationID)
+	ctx, cancel, client, err := h.commandBootstrap(repo, installationID)
 	if err != nil {
 		h.logger.Error("apply: failed to bootstrap command", "error", err)
 		return
@@ -324,7 +324,7 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 // handleApplyConfirmCommand handles the "schemabot apply-confirm -e <env>" PR comment command.
 // It verifies lock ownership, re-plans for drift detection, executes the apply, and watches progress.
 func (h *Handler) handleApplyConfirmCommand(repo string, pr int, environment, databaseName string, installationID int64, requestedBy string, result CommandResult) {
-	ctx, cancel, client, err := h.commandBootstrap(installationID)
+	ctx, cancel, client, err := h.commandBootstrap(repo, installationID)
 	if err != nil {
 		h.logger.Error("apply-confirm: failed to bootstrap command", "error", err)
 		return

--- a/pkg/webhook/bootstrap.go
+++ b/pkg/webhook/bootstrap.go
@@ -28,12 +28,12 @@ const commandTimeout = 2 * time.Minute
 // returned cancel func is a no-op. The caller is responsible for
 // handler-specific error reporting (HTTP response, PR comment, log line)
 // because that contract varies between handlers.
-func (h *Handler) commandBootstrap(installationID int64) (context.Context, context.CancelFunc, *ghclient.InstallationClient, error) {
+func (h *Handler) commandBootstrap(repo string, installationID int64) (context.Context, context.CancelFunc, *ghclient.InstallationClient, error) {
 	ctx, cancel := h.commandContext(commandTimeout)
-	client, err := h.ghClient.ForInstallation(installationID)
+	client, err := h.clientForRepo(repo, installationID)
 	if err != nil {
 		cancel()
-		return ctx, func() {}, nil, fmt.Errorf("create GitHub client for installation %d: %w", installationID, err)
+		return ctx, func() {}, nil, fmt.Errorf("create GitHub client for repo %q installation %d: %w", repo, installationID, err)
 	}
 	return ctx, cancel, client, nil
 }

--- a/pkg/webhook/check_prior_env.go
+++ b/pkg/webhook/check_prior_env.go
@@ -186,7 +186,7 @@ func (h *Handler) checkPriorEnvViaGitHub(
 	database, environment, priorEnv string,
 	installationID int64,
 ) bool {
-	client, err := h.ghClient.ForInstallation(installationID)
+	client, err := h.clientForRepo(repo, installationID)
 	if err != nil {
 		h.logger.Error("failed to create GitHub client for prior env check, blocking apply",
 			"prior_env", priorEnv, "error", err)

--- a/pkg/webhook/check_prior_env_test.go
+++ b/pkg/webhook/check_prior_env_test.go
@@ -40,7 +40,7 @@ func TestCheckPriorEnvViaLocalFailsClosedOnStorageError(t *testing.T) {
 
 	h := &Handler{
 		service:                    service,
-		ghClient:                   &fakeClientFactory{client: installClient},
+		ghClients:                  ghclient.NewSingleClientSet(defaultAppName, &fakeClientFactory{client: installClient}),
 		logger:                     testLogger(),
 		priorEnvCheckMaxAttempts:   1,
 		priorEnvCheckRetryInterval: time.Nanosecond,
@@ -88,7 +88,7 @@ func TestCheckPriorEnvViaLocalMissingCheckBlocksWithActionableGuidance(t *testin
 
 	h := &Handler{
 		service:                    service,
-		ghClient:                   &fakeClientFactory{client: installClient},
+		ghClients:                  ghclient.NewSingleClientSet(defaultAppName, &fakeClientFactory{client: installClient}),
 		logger:                     testLogger(),
 		priorEnvCheckMaxAttempts:   1,
 		priorEnvCheckRetryInterval: time.Nanosecond,
@@ -142,7 +142,7 @@ func TestCheckPriorEnvViaLocalRetriesBeforeFailClosed(t *testing.T) {
 
 	h := &Handler{
 		service:                    service,
-		ghClient:                   &fakeClientFactory{client: installClient},
+		ghClients:                  ghclient.NewSingleClientSet(defaultAppName, &fakeClientFactory{client: installClient}),
 		logger:                     testLogger(),
 		priorEnvCheckMaxAttempts:   2,
 		priorEnvCheckRetryInterval: time.Nanosecond,
@@ -203,7 +203,7 @@ func TestCheckPriorEnvViaGitHub(t *testing.T) {
 		factory := &fakeClientFactory{client: installClient}
 
 		h := &Handler{
-			ghClient:                   factory,
+			ghClients:                  ghclient.NewSingleClientSet(defaultAppName, factory),
 			logger:                     testLogger(),
 			priorEnvCheckMaxAttempts:   1,
 			priorEnvCheckRetryInterval: time.Nanosecond,
@@ -305,7 +305,7 @@ func TestCheckPriorEnvViaGitHub(t *testing.T) {
 
 		installClient := ghclient.NewInstallationClient(client, testLogger())
 		h := &Handler{
-			ghClient:                   &fakeClientFactory{client: installClient},
+			ghClients:                  ghclient.NewSingleClientSet(defaultAppName, &fakeClientFactory{client: installClient}),
 			logger:                     testLogger(),
 			priorEnvCheckMaxAttempts:   2,
 			priorEnvCheckRetryInterval: time.Nanosecond,
@@ -354,7 +354,7 @@ func TestCheckPriorEnvViaGitHub(t *testing.T) {
 		factory := &fakeClientFactory{client: installClient}
 
 		h := &Handler{
-			ghClient:                   factory,
+			ghClients:                  ghclient.NewSingleClientSet(defaultAppName, factory),
 			logger:                     testLogger(),
 			priorEnvCheckMaxAttempts:   1,
 			priorEnvCheckRetryInterval: time.Nanosecond,

--- a/pkg/webhook/check_records.go
+++ b/pkg/webhook/check_records.go
@@ -444,7 +444,7 @@ func (h *Handler) setCheckActionRequired(repo string, pr int, installationID int
 	})
 
 	// Update the aggregate check to reflect the rollback
-	if aggClient, err := h.ghClient.ForInstallation(installationID); err == nil {
+	if aggClient, err := h.clientForRepo(repo, installationID); err == nil {
 		h.updateAggregateCheck(ctx, aggClient, repo, pr, check.HeadSHA)
 	} else {
 		h.logger.Error("failed to create GitHub client for rollback aggregate update",

--- a/pkg/webhook/check_runs_test.go
+++ b/pkg/webhook/check_runs_test.go
@@ -110,9 +110,9 @@ func TestWebhookEnvironmentFiltering(t *testing.T) {
 		}, nil, testLogger())
 
 		h := &Handler{
-			service:  service,
-			ghClient: factory,
-			logger:   testLogger(),
+			service:   service,
+			ghClients: ghclient.NewSingleClientSet(defaultAppName, factory),
+			logger:    testLogger(),
 		}
 
 		// Plan targeting production should be ignored by this instance because
@@ -149,9 +149,9 @@ func TestWebhookEnvironmentFiltering(t *testing.T) {
 		}, nil, testLogger())
 
 		h := &Handler{
-			service:  service,
-			ghClient: factory,
-			logger:   testLogger(),
+			service:   service,
+			ghClients: ghclient.NewSingleClientSet(defaultAppName, factory),
+			logger:    testLogger(),
 		}
 
 		// Plan for staging should proceed past the environment filter. It will fail
@@ -190,9 +190,9 @@ func TestWebhookEnvironmentFiltering(t *testing.T) {
 		}, nil, testLogger())
 
 		h := &Handler{
-			service:  service,
-			ghClient: factory,
-			logger:   testLogger(),
+			service:   service,
+			ghClients: ghclient.NewSingleClientSet(defaultAppName, factory),
+			logger:    testLogger(),
 		}
 
 		// Plan for production with no allowed_environments config should proceed
@@ -280,9 +280,9 @@ func TestRespondToUnscoped(t *testing.T) {
 		}, nil, testLogger())
 
 		h := &Handler{
-			service:  service,
-			ghClient: factory,
-			logger:   testLogger(),
+			service:   service,
+			ghClients: ghclient.NewSingleClientSet(defaultAppName, factory),
+			logger:    testLogger(),
 		}
 
 		req := buildWebhookRequest(t, webhookPayloadOpts{

--- a/pkg/webhook/control.go
+++ b/pkg/webhook/control.go
@@ -98,9 +98,9 @@ func (h *Handler) handleStopCommand(repo string, pr int, installationID int64, r
 		return
 	}
 	var client *ghclient.InstallationClient
-	if h.service.Config().PRCommandAuthorizationEnabled() && h.ghClient != nil {
+	if h.service.Config().PRCommandAuthorizationEnabled() && h.ghClients.Len() > 0 {
 		var clientErr error
-		client, clientErr = h.ghClient.ForInstallation(installationID)
+		client, clientErr = h.clientForRepo(repo, installationID)
 		if clientErr != nil {
 			h.logger.Warn("stop PR command blocked because actor authorization client could not be created",
 				"repo", repo,
@@ -275,9 +275,9 @@ func (h *Handler) handleCutoverCommand(repo string, pr int, installationID int64
 		return
 	}
 	var client *ghclient.InstallationClient
-	if h.service.Config().PRCommandAuthorizationEnabled() && h.ghClient != nil {
+	if h.service.Config().PRCommandAuthorizationEnabled() && h.ghClients.Len() > 0 {
 		var clientErr error
-		client, clientErr = h.ghClient.ForInstallation(installationID)
+		client, clientErr = h.clientForRepo(repo, installationID)
 		if clientErr != nil {
 			h.logger.Warn("cutover PR command blocked because actor authorization client could not be created",
 				"repo", repo,

--- a/pkg/webhook/control_e2e_test.go
+++ b/pkg/webhook/control_e2e_test.go
@@ -109,9 +109,9 @@ func TestE2EStopCommandRecordsDurableRequest(t *testing.T) {
 	service := apiServiceForStopCommandTest(t, store, database)
 	service.RegisterTernClient(database, "staging", &stopCommandTernClient{remote: true})
 	h := &Handler{
-		service:  service,
-		ghClient: &fakeClientFactory{client: ghclient.NewInstallationClient(client, testLogger())},
-		logger:   testLogger(),
+		service:   service,
+		ghClients: ghclient.NewSingleClientSet(defaultAppName, &fakeClientFactory{client: ghclient.NewInstallationClient(client, testLogger())}),
+		logger:    testLogger(),
 	}
 
 	postStopCommand(t, h, applyIdentifier, "alice")
@@ -206,9 +206,9 @@ func TestE2EStopCommandStopsDeferredCutoverLocalApply(t *testing.T) {
 	})
 	service.RegisterTernClient(database, "staging", localClient)
 	h := &Handler{
-		service:  service,
-		ghClient: &fakeClientFactory{client: ghclient.NewInstallationClient(client, testLogger())},
-		logger:   testLogger(),
+		service:   service,
+		ghClients: ghclient.NewSingleClientSet(defaultAppName, &fakeClientFactory{client: ghclient.NewInstallationClient(client, testLogger())}),
+		logger:    testLogger(),
 	}
 
 	postStopCommand(t, h, applyIdentifier, "alice")
@@ -288,9 +288,9 @@ func TestE2ECutoverCommandRecordsDurableRequest(t *testing.T) {
 	service := apiServiceForStopCommandTest(t, store, database)
 	service.RegisterTernClient(database, "staging", &stopCommandTernClient{remote: true})
 	h := &Handler{
-		service:  service,
-		ghClient: &fakeClientFactory{client: ghclient.NewInstallationClient(client, testLogger())},
-		logger:   testLogger(),
+		service:   service,
+		ghClients: ghclient.NewSingleClientSet(defaultAppName, &fakeClientFactory{client: ghclient.NewInstallationClient(client, testLogger())}),
+		logger:    testLogger(),
 	}
 
 	postCutoverCommand(t, h, applyIdentifier, "alice")
@@ -370,9 +370,9 @@ func TestE2ECutoverCommandRejectsPendingStop(t *testing.T) {
 	ternClient := &stopCommandTernClient{remote: true}
 	service.RegisterTernClient(database, "staging", ternClient)
 	h := &Handler{
-		service:  service,
-		ghClient: &fakeClientFactory{client: ghclient.NewInstallationClient(client, testLogger())},
-		logger:   testLogger(),
+		service:   service,
+		ghClients: ghclient.NewSingleClientSet(defaultAppName, &fakeClientFactory{client: ghclient.NewInstallationClient(client, testLogger())}),
+		logger:    testLogger(),
 	}
 
 	postCutoverCommand(t, h, applyIdentifier, "cutter")

--- a/pkg/webhook/error_comment_test.go
+++ b/pkg/webhook/error_comment_test.go
@@ -36,8 +36,8 @@ func TestPostCommandError_RendersTimestamp(t *testing.T) {
 	})
 
 	h := &Handler{
-		ghClient: &fakeClientFactory{client: ghclient.NewInstallationClient(client, testLogger())},
-		logger:   testLogger(),
+		ghClients: ghclient.NewSingleClientSet(defaultAppName, &fakeClientFactory{client: ghclient.NewInstallationClient(client, testLogger())}),
+		logger:    testLogger(),
 	}
 
 	h.postCommandError(
@@ -75,8 +75,8 @@ func TestPostCommandErrorExplainsRemoteUnavailable(t *testing.T) {
 	})
 
 	h := &Handler{
-		ghClient: &fakeClientFactory{client: ghclient.NewInstallationClient(client, testLogger())},
-		logger:   testLogger(),
+		ghClients: ghclient.NewSingleClientSet(defaultAppName, &fakeClientFactory{client: ghclient.NewInstallationClient(client, testLogger())}),
+		logger:    testLogger(),
 	}
 
 	h.postCommandError(

--- a/pkg/webhook/handler.go
+++ b/pkg/webhook/handler.go
@@ -28,21 +28,39 @@ import (
 	"github.com/block/schemabot/pkg/storage"
 )
 
+// defaultAppName is the synthetic App name used when SchemaBot runs against
+// the legacy single-App ServerConfig.GitHub field. It matches the name
+// returned by ServerConfig.ResolveGitHubAppForRepo for legacy configs, so
+// the per-repo client resolution path works uniformly across single-App and
+// multi-App deployments.
+const defaultAppName = "default"
+
 // Handler processes GitHub webhook events.
 type Handler struct {
 	service                    *api.Service
-	ghClient                   github.GitHubClientFactory
+	ghClients                  github.ClientSet
 	webhookSecret              []byte
 	logger                     *slog.Logger
 	priorEnvCheckMaxAttempts   int
 	priorEnvCheckRetryInterval time.Duration
 }
 
-// NewHandler creates a new webhook handler.
+// NewHandler creates a new webhook handler for the legacy single-App
+// configuration. The provided factory is registered in the internal
+// ClientSet under the "default" App name so per-repo client resolution
+// works uniformly with the multi-App path that lands in a follow-up PR.
 func NewHandler(service *api.Service, ghClient github.GitHubClientFactory, webhookSecret []byte, logger *slog.Logger) *Handler {
+	return NewHandlerWithClientSet(service, github.NewSingleClientSet(defaultAppName, ghClient), webhookSecret, logger)
+}
+
+// NewHandlerWithClientSet creates a new webhook handler from an
+// already-built ClientSet. Production wiring (serve.go) will switch to this
+// constructor when the multi-App config shape is wired in a follow-up PR;
+// tests continue to use NewHandler with a single factory.
+func NewHandlerWithClientSet(service *api.Service, ghClients github.ClientSet, webhookSecret []byte, logger *slog.Logger) *Handler {
 	h := &Handler{
 		service:                    service,
-		ghClient:                   ghClient,
+		ghClients:                  ghClients,
 		webhookSecret:              webhookSecret,
 		logger:                     logger,
 		priorEnvCheckMaxAttempts:   defaultPriorEnvCheckMaxAttempts,
@@ -56,13 +74,22 @@ func NewHandler(service *api.Service, ghClient github.GitHubClientFactory, webho
 			if apply.Repository == "" || apply.PullRequest == 0 || apply.InstallationID == 0 {
 				return
 			}
+			factory, err := h.factoryForRepo(apply.Repository)
+			if err != nil {
+				logger.Error("recovered apply skipped: cannot resolve GitHub App client",
+					"apply_id", apply.ApplyIdentifier,
+					"repo", apply.Repository,
+					"pr", apply.PullRequest,
+					"error", err)
+				return
+			}
 			logger.Info("setting comment observer for recovered apply",
 				"apply_id", apply.ApplyIdentifier,
 				"repo", apply.Repository,
 				"pr", apply.PullRequest)
 			service.SetApplyObserver(apply.Database, apply.Deployment, apply.Environment, apply.ID,
 				NewCommentObserver(CommentObserverConfig{
-					GHClient:       h.ghClient,
+					GHClient:       factory,
 					Storage:        service.Storage(),
 					Repo:           apply.Repository,
 					PR:             apply.PullRequest,
@@ -80,7 +107,7 @@ func NewHandler(service *api.Service, ghClient github.GitHubClientFactory, webho
 								"apply_id", a.ID, "apply_identifier", a.ApplyIdentifier)
 							return
 						}
-						if ghInstClient, err := h.ghClient.ForInstallation(apply.InstallationID); err == nil {
+						if ghInstClient, err := h.clientForRepo(apply.Repository, apply.InstallationID); err == nil {
 							if checkRecord, err := service.Storage().Checks().Get(context.Background(), apply.Repository, apply.PullRequest, a.Environment, a.DatabaseType, a.Database); err == nil && checkRecord != nil {
 								h.updateAggregateCheck(context.Background(), ghInstClient, apply.Repository, apply.PullRequest, checkRecord.HeadSHA)
 							}
@@ -92,6 +119,37 @@ func NewHandler(service *api.Service, ghClient github.GitHubClientFactory, webho
 	}
 
 	return h
+}
+
+// factoryForRepo returns the GitHub App client factory that owns the given
+// repository.
+//
+// In the legacy single-App shape the ClientSet has exactly one entry under
+// defaultAppName and is used uniformly for every repo, matching the prior
+// behavior where there was only one App. Multi-App resolution via
+// ServerConfig.ResolveGitHubAppForRepo lands in the follow-up PR; this method
+// is the single seam that will be extended there.
+func (h *Handler) factoryForRepo(repo string) (github.GitHubClientFactory, error) {
+	if h.ghClients.Len() == 0 {
+		return nil, fmt.Errorf("no GitHub App clients configured")
+	}
+	factory, err := h.ghClients.For(defaultAppName)
+	if err != nil {
+		return nil, fmt.Errorf("lookup GitHub App client for repo %q: %w", repo, err)
+	}
+	return factory, nil
+}
+
+// clientForRepo returns an installation-scoped GitHub client for the App
+// that owns the given repository. Callers that already have a factory in
+// scope should use it directly; this is the convenience for the common
+// "I have a repo + installation_id" path.
+func (h *Handler) clientForRepo(repo string, installationID int64) (*github.InstallationClient, error) {
+	factory, err := h.factoryForRepo(repo)
+	if err != nil {
+		return nil, err
+	}
+	return factory.ForInstallation(installationID)
 }
 
 // ReconcileMissingSummaryComments repairs the apply_comments outbox on startup.

--- a/pkg/webhook/handler_test.go
+++ b/pkg/webhook/handler_test.go
@@ -121,9 +121,9 @@ func newTestHandler(t *testing.T) (*Handler, chan string, chan string) {
 	}, nil, testLogger())
 
 	h := &Handler{
-		service:  service,
-		ghClient: factory,
-		logger:   testLogger(),
+		service:   service,
+		ghClients: ghclient.NewSingleClientSet(defaultAppName, factory),
+		logger:    testLogger(),
 	}
 	return h, comments, reactions
 }
@@ -617,9 +617,9 @@ func TestWebhookRepoAllowlistRejectsUnregisteredRepo(t *testing.T) {
 	}, nil, testLogger())
 
 	h := &Handler{
-		service:  service,
-		ghClient: factory,
-		logger:   testLogger(),
+		service:   service,
+		ghClients: ghclient.NewSingleClientSet(defaultAppName, factory),
+		logger:    testLogger(),
 	}
 
 	req := buildWebhookRequest(t, webhookPayloadOpts{
@@ -663,9 +663,9 @@ func TestWebhookRepoAllowlistAllowsRegisteredRepo(t *testing.T) {
 	}, nil, testLogger())
 
 	h := &Handler{
-		service:  service,
-		ghClient: factory,
-		logger:   testLogger(),
+		service:   service,
+		ghClients: ghclient.NewSingleClientSet(defaultAppName, factory),
+		logger:    testLogger(),
 	}
 
 	req := buildWebhookRequest(t, webhookPayloadOpts{
@@ -699,9 +699,9 @@ func TestWebhookRepoAllowlistEmptyAllowsAll(t *testing.T) {
 	}, nil, testLogger())
 
 	h := &Handler{
-		service:  service,
-		ghClient: factory,
-		logger:   testLogger(),
+		service:   service,
+		ghClients: ghclient.NewSingleClientSet(defaultAppName, factory),
+		logger:    testLogger(),
 	}
 
 	req := buildWebhookRequest(t, webhookPayloadOpts{

--- a/pkg/webhook/issue_comment.go
+++ b/pkg/webhook/issue_comment.go
@@ -167,11 +167,11 @@ func (h *Handler) handleIssueComment(w http.ResponseWriter, body []byte) {
 	// Add acknowledgment reaction now that we know this instance will handle
 	// the command. Placed after all skip/filter checks so only the owning
 	// instance reacts — avoids duplicate reactions in multi-instance setups.
-	if payload.Comment.ID > 0 && h.ghClient != nil {
+	if payload.Comment.ID > 0 && h.ghClients.Len() > 0 {
 		go func() {
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
-			client, err := h.ghClient.ForInstallation(installationID)
+			client, err := h.clientForRepo(repo, installationID)
 			if err != nil {
 				h.logger.Error("failed to create GitHub client for reaction", "error", err)
 				return
@@ -255,7 +255,7 @@ func (h *Handler) postComment(repo string, pr int, installationID int64, body st
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	client, err := h.ghClient.ForInstallation(installationID)
+	client, err := h.clientForRepo(repo, installationID)
 	if err != nil {
 		h.logger.Error("failed to create GitHub client for comment",
 			"repo", repo, "pr", pr, "installation_id", installationID, "error", err)
@@ -274,7 +274,7 @@ func (h *Handler) postAndTrackComment(
 	ctx context.Context, repo string, pr int, installationID int64,
 	applyID int64, commentState string, body string,
 ) int64 {
-	client, err := h.ghClient.ForInstallation(installationID)
+	client, err := h.clientForRepo(repo, installationID)
 	if err != nil {
 		h.logger.Error("failed to create GitHub client for tracked comment", "error", err)
 		return 0

--- a/pkg/webhook/plan.go
+++ b/pkg/webhook/plan.go
@@ -16,7 +16,7 @@ import (
 
 // handlePlanCommand handles the "schemabot plan -e <env>" command.
 func (h *Handler) handlePlanCommand(w http.ResponseWriter, repo string, pr int, environment, databaseName string, installationID int64, requestedBy string) {
-	ctx, cancel, client, err := h.commandBootstrap(installationID)
+	ctx, cancel, client, err := h.commandBootstrap(repo, installationID)
 	if err != nil {
 		h.logger.Error("plan: failed to bootstrap command", "error", err)
 		h.writeError(w, http.StatusInternalServerError, "failed to initialize GitHub client")
@@ -122,7 +122,7 @@ func (h *Handler) handlePlanCommand(w http.ResponseWriter, repo string, pr int, 
 // handleMultiEnvPlan runs plan for all configured environments and posts a single combined comment.
 // When isAutoPlan is true and no environments have changes or errors, the comment is skipped to reduce PR noise.
 func (h *Handler) handleMultiEnvPlan(repo string, pr int, databaseName string, installationID int64, requestedBy string, isAutoPlan bool) {
-	ctx, cancel, client, err := h.commandBootstrap(installationID)
+	ctx, cancel, client, err := h.commandBootstrap(repo, installationID)
 	if err != nil {
 		h.logger.Error("multi-env plan: failed to bootstrap command", "error", err)
 		return

--- a/pkg/webhook/pull_request.go
+++ b/pkg/webhook/pull_request.go
@@ -90,7 +90,7 @@ func (h *Handler) handlePullRequest(w http.ResponseWriter, body []byte) {
 	// Dedupe FetchPullRequest calls within this webhook delivery.
 	ctx = ghclient.WithPRInfoCache(ctx)
 
-	client, err := h.ghClient.ForInstallation(installationID)
+	client, err := h.clientForRepo(repo, installationID)
 	if err != nil {
 		h.logger.Error("failed to create GitHub client", "error", err)
 		h.writeError(w, http.StatusInternalServerError, "failed to initialize GitHub client")
@@ -128,7 +128,7 @@ func (h *Handler) handlePullRequest(w http.ResponseWriter, body []byte) {
 		h.goSafe(repo, pr, installationID, func() {
 			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 			defer cancel()
-			c, err := h.ghClient.ForInstallation(installationID)
+			c, err := h.clientForRepo(repo, installationID)
 			if err != nil {
 				h.logger.Error("failed to create GitHub client for passing aggregate", "error", err)
 				return
@@ -244,7 +244,7 @@ func (h *Handler) cleanupStaleChecks(repo string, pr int, headSHA string, instal
 		return
 	}
 
-	client, clientErr := h.ghClient.ForInstallation(installationID)
+	client, clientErr := h.clientForRepo(repo, installationID)
 	if clientErr != nil {
 		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
 			Operation:  "stale_check_cleanup",

--- a/pkg/webhook/review_gate_test.go
+++ b/pkg/webhook/review_gate_test.go
@@ -127,7 +127,7 @@ func registerReviewsEndpoint(mux *http.ServeMux, reviews []*gh.PullRequestReview
 func TestCheckReviewGate_Disabled(t *testing.T) {
 	h, _ := setupReviewGateHandler(t, nil)
 
-	client, err := h.ghClient.ForInstallation(12345)
+	client, err := h.clientForRepo("octocat/hello-world", 12345)
 	require.NoError(t, err)
 
 	result, err := h.checkReviewGate(t.Context(), client, "octocat/hello-world", 1, "orders", "schema/testdb")
@@ -145,7 +145,7 @@ func TestCheckReviewGate_NoReviewsBlocks(t *testing.T) {
 	registerPREndpoint(mux, "alice")
 	registerReviewsEndpoint(mux, []*gh.PullRequestReview{})
 
-	client, err := h.ghClient.ForInstallation(12345)
+	client, err := h.clientForRepo("octocat/hello-world", 12345)
 	require.NoError(t, err)
 
 	result, err := h.checkReviewGate(t.Context(), client, "octocat/hello-world", 1, "orders", "schema/testdb")
@@ -171,7 +171,7 @@ func TestCheckReviewGate_OperatorUserApproval(t *testing.T) {
 		},
 	})
 
-	client, err := h.ghClient.ForInstallation(12345)
+	client, err := h.clientForRepo("octocat/hello-world", 12345)
 	require.NoError(t, err)
 
 	result, err := h.checkReviewGate(t.Context(), client, "octocat/hello-world", 1, "orders", "schema/testdb")
@@ -194,7 +194,7 @@ func TestCheckReviewGate_AdminUserApproval(t *testing.T) {
 		},
 	})
 
-	client, err := h.ghClient.ForInstallation(12345)
+	client, err := h.clientForRepo("octocat/hello-world", 12345)
 	require.NoError(t, err)
 
 	result, err := h.checkReviewGate(t.Context(), client, "octocat/hello-world", 1, "orders", "schema/testdb")
@@ -213,7 +213,7 @@ func TestCheckReviewGate_NotApproved(t *testing.T) {
 	registerPREndpoint(mux, "alice")
 	registerReviewsEndpoint(mux, []*gh.PullRequestReview{})
 
-	client, err := h.ghClient.ForInstallation(12345)
+	client, err := h.clientForRepo("octocat/hello-world", 12345)
 	require.NoError(t, err)
 
 	result, err := h.checkReviewGate(t.Context(), client, "octocat/hello-world", 1, "orders", "schema/testdb")
@@ -241,7 +241,7 @@ func TestCheckReviewGate_SelfApprovalBlocked(t *testing.T) {
 		},
 	})
 
-	client, err := h.ghClient.ForInstallation(12345)
+	client, err := h.clientForRepo("octocat/hello-world", 12345)
 	require.NoError(t, err)
 
 	result, err := h.checkReviewGate(t.Context(), client, "octocat/hello-world", 1, "orders", "schema/testdb")
@@ -274,7 +274,7 @@ func TestCheckReviewGate_OperatorTeamApproval(t *testing.T) {
 	})
 	mux.HandleFunc("GET /orgs/octocat/teams/db-admins/members", teamMembersHandler(t, http.StatusOK, "bob", "carol"))
 
-	client, err := h.ghClient.ForInstallation(12345)
+	client, err := h.clientForRepo("octocat/hello-world", 12345)
 	require.NoError(t, err)
 
 	result, err := h.checkReviewGate(t.Context(), client, "octocat/hello-world", 1, "orders", "schema/testdb")
@@ -300,7 +300,7 @@ func TestCheckReviewGate_OperatorTeamNotApproved(t *testing.T) {
 	})
 	mux.HandleFunc("GET /orgs/octocat/teams/db-admins/members", teamMembersHandler(t, http.StatusOK, "bob", "carol"))
 
-	client, err := h.ghClient.ForInstallation(12345)
+	client, err := h.clientForRepo("octocat/hello-world", 12345)
 	require.NoError(t, err)
 
 	result, err := h.checkReviewGate(t.Context(), client, "octocat/hello-world", 1, "orders", "schema/testdb")
@@ -326,7 +326,7 @@ func TestCheckReviewGate_CodeownersIgnoredByDefault(t *testing.T) {
 		},
 	})
 
-	client, err := h.ghClient.ForInstallation(12345)
+	client, err := h.clientForRepo("octocat/hello-world", 12345)
 	require.NoError(t, err)
 
 	result, err := h.checkReviewGate(t.Context(), client, "octocat/hello-world", 1, "orders", "schema/testdb")
@@ -352,7 +352,7 @@ func TestCheckReviewGate_CodeownersOptIn(t *testing.T) {
 		},
 	})
 
-	client, err := h.ghClient.ForInstallation(12345)
+	client, err := h.clientForRepo("octocat/hello-world", 12345)
 	require.NoError(t, err)
 
 	result, err := h.checkReviewGate(t.Context(), client, "octocat/hello-world", 1, "orders", "schema/payments")
@@ -376,7 +376,7 @@ func TestCheckReviewGate_NoConfiguredReviewersErrors(t *testing.T) {
 	registerPREndpoint(mux, "alice")
 	registerReviewsEndpoint(mux, nil)
 
-	client, err := h.ghClient.ForInstallation(12345)
+	client, err := h.clientForRepo("octocat/hello-world", 12345)
 	require.NoError(t, err)
 
 	result, err := h.checkReviewGate(t.Context(), client, "octocat/hello-world", 1, "orders", "schema/testdb")

--- a/pkg/webhook/rollback.go
+++ b/pkg/webhook/rollback.go
@@ -141,7 +141,7 @@ func (h *Handler) handleRollbackCommand(repo string, pr int, installationID int6
 // handleRollbackConfirmCommand handles the "schemabot rollback-confirm -e <env>" PR comment command.
 // It verifies the lock, re-generates the rollback plan for drift detection, and executes the apply.
 func (h *Handler) handleRollbackConfirmCommand(repo string, pr int, environment, databaseName string, installationID int64, requestedBy string, result CommandResult) {
-	ctx, cancel, client, err := h.commandBootstrap(installationID)
+	ctx, cancel, client, err := h.commandBootstrap(repo, installationID)
 	if err != nil {
 		h.logger.Error("rollback-confirm: failed to bootstrap command", "error", err)
 		return
@@ -262,12 +262,21 @@ func (h *Handler) handleRollbackConfirmCommand(repo string, pr int, environment,
 	progressBody := formatProgressComment(apply, nil)
 	h.postAndTrackComment(ctx, repo, pr, installationID, applyID, state.Comment.Progress, progressBody)
 
+	// Resolve the App factory for this repo once so the observer captures
+	// the correct App for all subsequent GitHub calls (comments, check runs).
+	factory, factoryErr := h.factoryForRepo(repo)
+	if factoryErr != nil {
+		h.logger.Error("rollback blocked: cannot resolve GitHub App client for repo",
+			"repo", repo, "pr", pr, "database", database, "environment", environment, "error", factoryErr)
+		return
+	}
+
 	// Set observer for rollback progress and check run updates.
 	// On successful rollback, set check to action_required because the PR
 	// changes need to be re-applied.
 	h.service.SetApplyObserver(apply.Database, apply.Deployment, apply.Environment, applyID,
 		NewCommentObserver(CommentObserverConfig{
-			GHClient:       h.ghClient,
+			GHClient:       factory,
 			Storage:        h.service.Storage(),
 			Repo:           repo,
 			PR:             pr,
@@ -296,7 +305,7 @@ func (h *Handler) handleRollbackConfirmCommand(repo string, pr int, environment,
 					return
 				}
 
-				ghInstClient, err := h.ghClient.ForInstallation(installationID)
+				ghInstClient, err := factory.ForInstallation(installationID)
 				if err != nil {
 					h.logger.Error("observer: failed to create GitHub client for rollback aggregate update",
 						"repo", repo, "pr", pr, "database", a.Database,


### PR DESCRIPTION
## What and Why ?
Relates to issue #204. Splits the multi-App runtime work into two reviewable PRs:

- **Step 1/2 (this PR)** — structural refactor only. Webhook handler now owns a `github.ClientSet` instead of a single `GitHubClientFactory`, and every outbound GitHub call is routed through a new per-repo `factoryForRepo` / `clientForRepo` seam. The legacy single-App config still wires exactly one factory under the synthetic `"default"` App name, so runtime behavior is unchanged.
- **Step 2/2 (follow-up)** — actual multi-App behavior: build the `ClientSet` from `serverConfig.Apps`, dispatch inbound webhook deliveries / HMAC verification per App, repo→App resolution via `ServerConfig.ResolveGitHubAppForRepo`, app-mismatch fail-closed checks, and an App label on logs/metrics.

## What changed

- New `pkg/github.ClientSet` — name→factory wrapper with `For(name)` lookup and a `NewSingleClientSet` convenience for the legacy shape.
- `webhook.Handler` field `ghClient` → `ghClients github.ClientSet`. `NewHandler` signature is unchanged for callers and tests; it wraps the factory under the `"default"` App name.
- New `NewHandlerWithClientSet` constructor that step 2 will use from `serve.go`.
- All outbound GitHub call sites in `pkg/webhook` (apply, rollback, plan, control, check runs, issue comments, pull-request handlers, recovery observer, bootstrap) now resolve their client via `clientForRepo(repo, installationID)` instead of touching the factory directly.

**NOTE**

Keeping the structural refactor separate makes the multi-App behavioral change in step 2 a focused diff against a stable seam, instead of mixing client plumbing with dispatch/HMAC/fail-closed logic.