### PR TITLE
ci: skip workflows on documentation-only changes

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -42,9 +42,9 @@ jobs:
         continue-on-error: true
         uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # dorny/paths-filter@v3.0.3
         with:
-          predicate-quantifier: 'every'
           filters: |
             code:
+              - '**'
               - '!**/*.md'
               - '!docs/**'
       - name: "Resolve code-change flag"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -50,14 +50,18 @@ jobs:
       - name: "Resolve code-change flag"
         id: out
         shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          FILTER_OUTCOME: ${{ steps.filter.outcome }}
+          FILTER_CODE: ${{ steps.filter.outputs.code }}
         run: |
-          if [ "${{ github.event_name }}" != "pull_request" ]; then
+          if [ "$EVENT_NAME" != "pull_request" ]; then
             echo "code=true" >> "$GITHUB_OUTPUT"
-          elif [ "${{ steps.filter.outcome }}" != "success" ]; then
+          elif [ "$FILTER_OUTCOME" != "success" ]; then
             echo "::warning::paths-filter failed; running CI instead of skipping"
             echo "code=true" >> "$GITHUB_OUTPUT"
           else
-            echo "code=${{ steps.filter.outputs.code }}" >> "$GITHUB_OUTPUT"
+            echo "code=$FILTER_CODE" >> "$GITHUB_OUTPUT"
           fi
 
   lint-chart:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,9 +24,46 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  lint-chart:
+  # See test.yaml for the rationale of this docs-only skip pattern.
+  # On PRs that touch only docs/**, the chart lint and Docker build are
+  # skipped. Pushes to main and tags always build (so latest/tagged images
+  # are published regardless of the diff content).
+  changes:
+    name: "Detect changes"
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    permissions:
+      pull-requests: read
+    outputs:
+      code: ${{ steps.out.outputs.code }}
+    steps:
+      - name: "Detect non-docs changes"
+        if: github.event_name == 'pull_request'
+        id: filter
+        continue-on-error: true
+        uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # dorny/paths-filter@v3.0.3
+        with:
+          predicate-quantifier: 'every'
+          filters: |
+            code:
+              - '!**/*.md'
+              - '!docs/**'
+      - name: "Resolve code-change flag"
+        id: out
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "code=true" >> "$GITHUB_OUTPUT"
+          elif [ "${{ steps.filter.outcome }}" != "success" ]; then
+            echo "::warning::paths-filter failed; running CI instead of skipping"
+            echo "code=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "code=${{ steps.filter.outputs.code }}" >> "$GITHUB_OUTPUT"
+          fi
+
+  lint-chart:
+    needs: changes
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && needs.changes.outputs.code == 'true'
     steps:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # actions/checkout@v6
         with:
@@ -62,8 +99,13 @@ jobs:
           echo "Chart version bumped: ${BASE_VERSION} → ${HEAD_VERSION}"
 
   build-and-push:
+    needs: changes
     runs-on: ubuntu-latest
-    if: github.repository == 'block/schemabot'
+    # Skip on PRs that touch only docs/**. Pushes (main and tags) always run
+    # so latest and tagged images are published regardless of diff content.
+    if: >-
+      github.repository == 'block/schemabot' &&
+      (github.event_name != 'pull_request' || needs.changes.outputs.code == 'true')
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -10,8 +10,43 @@ on:
 permissions:
   contents: read
 jobs:
+  # See test.yaml for the rationale of this docs-only skip pattern.
+  changes:
+    name: "Detect changes"
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      code: ${{ steps.out.outputs.code }}
+    steps:
+      - name: "Detect non-docs changes"
+        if: github.event_name == 'pull_request'
+        id: filter
+        continue-on-error: true
+        uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # dorny/paths-filter@v3.0.3
+        with:
+          predicate-quantifier: 'every'
+          filters: |
+            code:
+              - '!**/*.md'
+              - '!docs/**'
+      - name: "Resolve code-change flag"
+        id: out
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "code=true" >> "$GITHUB_OUTPUT"
+          elif [ "${{ steps.filter.outcome }}" != "success" ]; then
+            echo "::warning::paths-filter failed; running CI instead of skipping"
+            echo "code=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "code=${{ steps.filter.outputs.code }}" >> "$GITHUB_OUTPUT"
+          fi
+
   golangci:
     name: lint
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -25,9 +25,9 @@ jobs:
         continue-on-error: true
         uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # dorny/paths-filter@v3.0.3
         with:
-          predicate-quantifier: 'every'
           filters: |
             code:
+              - '**'
               - '!**/*.md'
               - '!docs/**'
       - name: "Resolve code-change flag"

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -33,14 +33,18 @@ jobs:
       - name: "Resolve code-change flag"
         id: out
         shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          FILTER_OUTCOME: ${{ steps.filter.outcome }}
+          FILTER_CODE: ${{ steps.filter.outputs.code }}
         run: |
-          if [ "${{ github.event_name }}" != "pull_request" ]; then
+          if [ "$EVENT_NAME" != "pull_request" ]; then
             echo "code=true" >> "$GITHUB_OUTPUT"
-          elif [ "${{ steps.filter.outcome }}" != "success" ]; then
+          elif [ "$FILTER_OUTCOME" != "success" ]; then
             echo "::warning::paths-filter failed; running CI instead of skipping"
             echo "code=true" >> "$GITHUB_OUTPUT"
           else
-            echo "code=${{ steps.filter.outputs.code }}" >> "$GITHUB_OUTPUT"
+            echo "code=$FILTER_CODE" >> "$GITHUB_OUTPUT"
           fi
 
   golangci:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -36,14 +36,18 @@ jobs:
       - name: "Resolve code-change flag"
         id: out
         shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          FILTER_OUTCOME: ${{ steps.filter.outcome }}
+          FILTER_CODE: ${{ steps.filter.outputs.code }}
         run: |
-          if [ "${{ github.event_name }}" != "pull_request" ]; then
+          if [ "$EVENT_NAME" != "pull_request" ]; then
             echo "code=true" >> "$GITHUB_OUTPUT"
-          elif [ "${{ steps.filter.outcome }}" != "success" ]; then
+          elif [ "$FILTER_OUTCOME" != "success" ]; then
             echo "::warning::paths-filter failed; running CI instead of skipping"
             echo "code=true" >> "$GITHUB_OUTPUT"
           else
-            echo "code=${{ steps.filter.outputs.code }}" >> "$GITHUB_OUTPUT"
+            echo "code=$FILTER_CODE" >> "$GITHUB_OUTPUT"
           fi
 
   build:
@@ -329,22 +333,27 @@ jobs:
     if: always()
     steps:
       - shell: bash
+        env:
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          CHANGES_CODE: ${{ needs.changes.outputs.code }}
+          E2E_MYSQL_RESULT: ${{ needs.e2e-mysql.result }}
+          E2E_VITESS_RESULT: ${{ needs.e2e-vitess.result }}
         run: |
           set -euo pipefail
-          if [ "${{ needs.changes.result }}" != "success" ]; then
+          if [ "$CHANGES_RESULT" != "success" ]; then
             echo "::error::changes job failed"
             exit 1
           fi
-          if [ "${{ needs.changes.outputs.code }}" != "true" ]; then
+          if [ "$CHANGES_CODE" != "true" ]; then
             echo "Docs-only PR; E2E intentionally skipped."
             exit 0
           fi
-          if [ "${{ needs.e2e-mysql.result }}" != "success" ]; then
-            echo "::error::e2e-mysql result=${{ needs.e2e-mysql.result }}"
+          if [ "$E2E_MYSQL_RESULT" != "success" ]; then
+            echo "::error::e2e-mysql result=$E2E_MYSQL_RESULT"
             exit 1
           fi
-          if [ "${{ needs.e2e-vitess.result }}" != "success" ]; then
-            echo "::error::e2e-vitess result=${{ needs.e2e-vitess.result }}"
+          if [ "$E2E_VITESS_RESULT" != "success" ]; then
+            echo "::error::e2e-vitess result=$E2E_VITESS_RESULT"
             exit 1
           fi
 
@@ -355,17 +364,21 @@ jobs:
     if: always()
     steps:
       - shell: bash
+        env:
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          CHANGES_CODE: ${{ needs.changes.outputs.code }}
+          LOCALSCALE_RESULT: ${{ needs.localscale.result }}
         run: |
           set -euo pipefail
-          if [ "${{ needs.changes.result }}" != "success" ]; then
+          if [ "$CHANGES_RESULT" != "success" ]; then
             echo "::error::changes job failed"
             exit 1
           fi
-          if [ "${{ needs.changes.outputs.code }}" != "true" ]; then
+          if [ "$CHANGES_CODE" != "true" ]; then
             echo "Docs-only PR; LocalScale intentionally skipped."
             exit 0
           fi
-          if [ "${{ needs.localscale.result }}" != "success" ]; then
-            echo "::error::localscale result=${{ needs.localscale.result }}"
+          if [ "$LOCALSCALE_RESULT" != "success" ]; then
+            echo "::error::localscale result=$LOCALSCALE_RESULT"
             exit 1
           fi

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,8 +11,45 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 jobs:
+  # Detect whether the change touches anything other than *.md / docs/**.
+  # PRs that touch only docs skip the heavy jobs below; pushes (main/tags)
+  # always run. Fails open: if detection fails, treat as code change.
+  changes:
+    name: "Detect changes"
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      code: ${{ steps.out.outputs.code }}
+    steps:
+      - name: "Detect non-docs changes"
+        if: github.event_name == 'pull_request'
+        id: filter
+        continue-on-error: true
+        uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # dorny/paths-filter@v3.0.3
+        with:
+          predicate-quantifier: 'every'
+          filters: |
+            code:
+              - '!**/*.md'
+              - '!docs/**'
+      - name: "Resolve code-change flag"
+        id: out
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "code=true" >> "$GITHUB_OUTPUT"
+          elif [ "${{ steps.filter.outcome }}" != "success" ]; then
+            echo "::warning::paths-filter failed; running CI instead of skipping"
+            echo "code=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "code=${{ steps.filter.outputs.code }}" >> "$GITHUB_OUTPUT"
+          fi
+
   build:
     name: "Build"
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -47,6 +84,8 @@ jobs:
 
   unit:
     name: "Unit Tests"
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -69,6 +108,8 @@ jobs:
 
   integration:
     name: "Integration Tests"
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -111,7 +152,8 @@ jobs:
 
   localscale:
     name: "LocalScale Tests (${{ matrix.shard }})"
-    needs: [build, localscale-matrix]
+    needs: [changes, build, localscale-matrix]
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     strategy:
@@ -144,6 +186,8 @@ jobs:
 
   e2e-mysql:
     name: "E2E MySQL Tests"
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -191,7 +235,8 @@ jobs:
 
   e2e-vitess:
     name: "E2E Vitess Tests (${{ matrix.shard }})"
-    needs: e2e-vitess-matrix
+    needs: [changes, e2e-vitess-matrix]
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     strategy:
@@ -223,6 +268,8 @@ jobs:
           docker compose -f deploy/e2e/docker-compose.yml logs --tail=300 schemabot localscale 2>/dev/null || true
   e2e-k8s:
     name: "E2E K8s Tests"
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -271,24 +318,54 @@ jobs:
 
   # Rollup jobs that match the old required check names.
   # Remove these after updating branch protection to use the new job names.
+  #
+  # On docs-only PRs the upstream jobs are intentionally skipped via the
+  # `changes` job; the rollups treat that as success. On any other PR a
+  # skipped or failed upstream is treated as failure.
   e2e-rollup:
     name: "E2E Tests"
-    needs: [e2e-mysql, e2e-vitess]
+    needs: [changes, e2e-mysql, e2e-vitess]
     runs-on: ubuntu-latest
     if: always()
     steps:
-      - run: |
-          if [ "${{ needs.e2e-mysql.result }}" != "success" ] || [ "${{ needs.e2e-vitess.result }}" != "success" ]; then
+      - shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${{ needs.changes.result }}" != "success" ]; then
+            echo "::error::changes job failed"
+            exit 1
+          fi
+          if [ "${{ needs.changes.outputs.code }}" != "true" ]; then
+            echo "Docs-only PR; E2E intentionally skipped."
+            exit 0
+          fi
+          if [ "${{ needs.e2e-mysql.result }}" != "success" ]; then
+            echo "::error::e2e-mysql result=${{ needs.e2e-mysql.result }}"
+            exit 1
+          fi
+          if [ "${{ needs.e2e-vitess.result }}" != "success" ]; then
+            echo "::error::e2e-vitess result=${{ needs.e2e-vitess.result }}"
             exit 1
           fi
 
   localscale-rollup:
     name: "LocalScale Tests"
-    needs: localscale
+    needs: [changes, localscale]
     runs-on: ubuntu-latest
     if: always()
     steps:
-      - run: |
+      - shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${{ needs.changes.result }}" != "success" ]; then
+            echo "::error::changes job failed"
+            exit 1
+          fi
+          if [ "${{ needs.changes.outputs.code }}" != "true" ]; then
+            echo "Docs-only PR; LocalScale intentionally skipped."
+            exit 0
+          fi
           if [ "${{ needs.localscale.result }}" != "success" ]; then
+            echo "::error::localscale result=${{ needs.localscale.result }}"
             exit 1
           fi

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,9 +28,9 @@ jobs:
         continue-on-error: true
         uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # dorny/paths-filter@v3.0.3
         with:
-          predicate-quantifier: 'every'
           filters: |
             code:
+              - '**'
               - '!**/*.md'
               - '!docs/**'
       - name: "Resolve code-change flag"


### PR DESCRIPTION
## What and Why ?
Adds a per-workflow `changes` job using `dorny/paths-filter@v3.0.3` to
detect whether a PR touches anything outside `*.md` / `docs/**`. Heavy
jobs (build, lint, unit, integration, e2e, Docker image) gate on the
result so docs-only PRs skip them.

### Behavior matrix

| Event             | Diff content            | `code`              | Heavy jobs                            |
| ----------------- | ----------------------- | ------------------- | ------------------------------------- |
| Pull request      | only `*.md` / `docs/**` | `false`             | skipped (rollups still pass)          |
| Pull request      | any code change         | `true`              | run                                   |
| Push (main / tag) | any                     | `true`              | run (image publishing unaffected)     |
| Filter errors     | any                     | `true` (fail-open)  | run                                   |

#### How `Resolve code-change flag` decides

~~~
            ┌──────────────────────┐
            │  Resolve             │
            │  code-change flag    │
            └──────────┬───────────┘
                       │
       ┌───────────────┼───────────────┐
       ▼               ▼               ▼
 ┌───────────┐   ┌───────────┐   ┌──────────────┐
 │ non-PR    │   │ filter    │   │ filter       │
 │ event     │   │ errored   │   │ succeeded    │
 │ (push/tag)│   │ /skipped  │   │ (PR event)   │
 └─────┬─────┘   └─────┬─────┘   └──────┬───────┘
       │               │                │
       ▼               ▼                ▼
   code=true       code=true     code=<filter result>
~~~

**Why each branch exists**

1. **Non-PR events** — the filter step has `if: github.event_name == 'pull_request'`, so on push/tag it does not run and its output is empty. Forcing `code=true` here means main and tag pushes always build, so releases keep publishing images.
2. **Fail-open** — if the filter action errors (API flake, missing token, etc.), `steps.filter.outcome != 'success'`. Forcing `code=true` here means the worst case is running CI unnecessarily, not silently skipping CI on a real code PR.
3. **Normal PR path** — propagate what the filter computed: `true` if any non-doc file changed, `false` if every file matches `**/*.md` or `docs/**`.

`steps.filter.outcome` (not `conclusion`) is the raw result before `continue-on-error: true` masks failures, which is what lets this step detect and handle filter failures itself.

## Notes

- Matrix-generator jobs (`localscale-matrix`, `e2e-vitess-matrix`) are intentionally not gated, so dependent jobs always have a valid `fromJson(...)` input.
- `e2e-rollup` and `localscale-rollup` accept upstream `skipped` only when `changes.outputs.code != 'true'`; any other skipped/failed upstream still fails the rollup.
- `docker.yml build-and-push` skips only on PRs; pushes to `main` and tags always build and publish.

Inspired by the equivalent change in block/spirit#833.
