### PR TITLE
feat(storage): thread apply_operation_id through task writes

### DIFF
--- a/pkg/storage/mysqlstore/applies.go
+++ b/pkg/storage/mysqlstore/applies.go
@@ -431,15 +431,39 @@ func (s *applyStore) CreateWithTasksAndOperations(ctx context.Context, apply *st
 		}
 	}
 
+	// tasks.apply_operation_id is indexed but not a foreign key, so the
+	// store must validate the link itself: any non-nil ApplyOperationID
+	// MUST point at one of the apply_operations rows just inserted above.
+	// Without this check a caller could persist an arbitrary or zero id
+	// and silently break per-operation task scoping once the operator
+	// claim loop comes online.
+	insertedOpIDs := make(map[int64]struct{}, len(operations))
+	for _, op := range operations {
+		insertedOpIDs[op.ID] = struct{}{}
+	}
+
 	switch {
 	case len(tasks) == 0:
 		// no tasks; nothing to link.
+	case len(operations) == 0:
+		// No operations supplied; any pre-populated ApplyOperationID is
+		// invalid because there is no row it can reference for this apply.
+		for _, task := range tasks {
+			if task.ApplyOperationID != nil {
+				return 0, fmt.Errorf("create apply %s: task %s has apply_operation_id=%d but apply has no operations", apply.ApplyIdentifier, task.TaskIdentifier, *task.ApplyOperationID)
+			}
+		}
 	case len(operations) == 1:
 		// Single-operation apply: link every task to the lone operation
-		// unless the caller already supplied an explicit value.
+		// unless the caller already supplied an explicit value. An explicit
+		// value still has to match the inserted operation.
 		for _, task := range tasks {
 			if task.ApplyOperationID == nil {
 				task.ApplyOperationID = &operations[0].ID
+				continue
+			}
+			if _, ok := insertedOpIDs[*task.ApplyOperationID]; !ok {
+				return 0, fmt.Errorf("create apply %s: task %s apply_operation_id=%d does not match any inserted operation for this apply", apply.ApplyIdentifier, task.TaskIdentifier, *task.ApplyOperationID)
 			}
 		}
 	case len(operations) > 1:
@@ -450,6 +474,9 @@ func (s *applyStore) CreateWithTasksAndOperations(ctx context.Context, apply *st
 		for _, task := range tasks {
 			if task.ApplyOperationID == nil {
 				return 0, fmt.Errorf("create apply %s: task %s missing apply_operation_id (apply has %d operations; caller must encode the per-task mapping)", apply.ApplyIdentifier, task.TaskIdentifier, len(operations))
+			}
+			if _, ok := insertedOpIDs[*task.ApplyOperationID]; !ok {
+				return 0, fmt.Errorf("create apply %s: task %s apply_operation_id=%d does not match any inserted operation for this apply", apply.ApplyIdentifier, task.TaskIdentifier, *task.ApplyOperationID)
 			}
 		}
 	}

--- a/pkg/storage/mysqlstore/applies.go
+++ b/pkg/storage/mysqlstore/applies.go
@@ -417,6 +417,43 @@ func (s *applyStore) CreateWithTasksAndOperations(ctx context.Context, apply *st
 		return 0, fmt.Errorf("read inserted apply id for %s: %w", apply.ApplyIdentifier, err)
 	}
 
+	// Operations are inserted BEFORE tasks so each task can be persisted
+	// with the apply_operation_id of the operation it belongs to. Today
+	// the config layer hard-blocks multi-entry deployments so there is
+	// always exactly one operation per apply, and all tasks are linked
+	// to it. When the multi-entry block is lifted and apply-create fans
+	// tasks out per-operation, the per-task mapping needs to be encoded
+	// by the caller (see the multi-op guard below).
+	for _, op := range operations {
+		op.ApplyID = id
+		if _, err := insertApplyOperation(ctx, writeTx.tx, op); err != nil {
+			return 0, fmt.Errorf("insert apply_operation (deployment=%s) for apply %s: %w", op.Deployment, apply.ApplyIdentifier, err)
+		}
+	}
+
+	switch {
+	case len(tasks) == 0:
+		// no tasks; nothing to link.
+	case len(operations) == 1:
+		// Single-operation apply: link every task to the lone operation
+		// unless the caller already supplied an explicit value.
+		for _, task := range tasks {
+			if task.ApplyOperationID == nil {
+				task.ApplyOperationID = &operations[0].ID
+			}
+		}
+	case len(operations) > 1:
+		// Multi-operation apply: caller MUST decide which operation each
+		// task belongs to and pre-populate task.ApplyOperationID. Silently
+		// assigning every task to operations[0] would lock in a wrong
+		// mapping the moment multi-entry deployments are unblocked.
+		for _, task := range tasks {
+			if task.ApplyOperationID == nil {
+				return 0, fmt.Errorf("create apply %s: task %s missing apply_operation_id (apply has %d operations; caller must encode the per-task mapping)", apply.ApplyIdentifier, task.TaskIdentifier, len(operations))
+			}
+		}
+	}
+
 	for _, task := range tasks {
 		task.ApplyID = id
 		taskID, err := insertTask(ctx, writeTx.tx, task)
@@ -424,13 +461,6 @@ func (s *applyStore) CreateWithTasksAndOperations(ctx context.Context, apply *st
 			return 0, fmt.Errorf("insert task %s for apply %s: %w", task.TaskIdentifier, apply.ApplyIdentifier, err)
 		}
 		task.ID = taskID
-	}
-
-	for _, op := range operations {
-		op.ApplyID = id
-		if _, err := insertApplyOperation(ctx, writeTx.tx, op); err != nil {
-			return 0, fmt.Errorf("insert apply_operation (deployment=%s) for apply %s: %w", op.Deployment, apply.ApplyIdentifier, err)
-		}
 	}
 
 	if err := writeTx.commit(); err != nil {

--- a/pkg/storage/mysqlstore/applies_test.go
+++ b/pkg/storage/mysqlstore/applies_test.go
@@ -205,9 +205,113 @@ func TestApplyStore_CreateWithTasksAndOperationsCommitsAtomically(t *testing.T) 
 	assert.Equal(t, "payments-a", storedOps[0].Deployment)
 	assert.Equal(t, "payments", storedOps[0].Target)
 	assert.Equal(t, state.ApplyOperation.Pending, storedOps[0].State)
-	// CreateWithTasksAndOperations also back-fills the operation's ApplyID
+	// CreateWithTasksAndOperations back-fills the operation's ApplyID
 	// onto the caller-supplied struct (same contract as CreateWithTasks).
 	assert.Equal(t, applyID, operations[0].ApplyID)
+	// It also back-fills the operation's ID onto every task so the row in
+	// MySQL carries the apply_operation_id link the operator claim loop
+	// will consume. The link must be present both in-memory (on the
+	// caller-supplied struct) and on the persisted row.
+	require.NotNil(t, tasks[0].ApplyOperationID, "task.ApplyOperationID must be back-filled in-memory")
+	assert.Equal(t, operations[0].ID, *tasks[0].ApplyOperationID)
+	require.NotNil(t, storedTasks[0].ApplyOperationID, "task.apply_operation_id must be persisted")
+	assert.Equal(t, operations[0].ID, *storedTasks[0].ApplyOperationID)
+}
+
+// TestApplyStore_CreateWithTasksAndOperationsRollsBackOnTaskFailure pins the
+// post-reorder invariant: operations are inserted before tasks, so a task
+// insert failure must roll back the already-inserted apply_operations rows
+// (and the apply row) — no orphan operations left behind.
+func TestApplyStore_CreateWithTasksAndOperationsRollsBackOnTaskFailure(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "payments", storage.DatabaseTypeMySQL, "production")
+	now := time.Now()
+	apply := &storage.Apply{
+		ApplyIdentifier: "apply_rollback_on_task_failure",
+		LockID:          lock.ID,
+		PlanID:          1,
+		Database:        "payments",
+		DatabaseType:    storage.DatabaseTypeMySQL,
+		Repository:      "org/repo",
+		PullRequest:     123,
+		Environment:     "production",
+		Deployment:      "payments-a",
+		Engine:          storage.EngineSpirit,
+		State:           state.Apply.Pending,
+		Options:         []byte("{}"),
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+	// Two tasks sharing the same task_identifier violates the UNIQUE KEY
+	// idx_task_identifier on the second insert.
+	tasks := []*storage.Task{
+		{TaskIdentifier: "task_dup", PlanID: 1, Database: "payments", DatabaseType: storage.DatabaseTypeMySQL, Engine: storage.EngineSpirit, Environment: "production", State: state.Task.Pending, TableName: "users", DDL: "ALTER TABLE users ADD COLUMN a INT", DDLAction: "alter", Options: []byte("{}"), CreatedAt: now, UpdatedAt: now},
+		{TaskIdentifier: "task_dup", PlanID: 1, Database: "payments", DatabaseType: storage.DatabaseTypeMySQL, Engine: storage.EngineSpirit, Environment: "production", State: state.Task.Pending, TableName: "orders", DDL: "ALTER TABLE orders ADD COLUMN b INT", DDLAction: "alter", Options: []byte("{}"), CreatedAt: now, UpdatedAt: now},
+	}
+	operations := []*storage.ApplyOperation{
+		{Deployment: "payments-a", Target: "payments", State: state.ApplyOperation.Pending, CreatedAt: now, UpdatedAt: now},
+	}
+
+	_, err := store.Applies().CreateWithTasksAndOperations(ctx, apply, tasks, operations)
+	require.Error(t, err)
+
+	gotApply, err := store.Applies().GetByApplyIdentifier(ctx, apply.ApplyIdentifier)
+	require.NoError(t, err)
+	assert.Nil(t, gotApply, "apply row must not exist after rollback")
+
+	// The op insert succeeded before the task insert failed; the rollback
+	// must drop it too — no orphan apply_operations rows for this deployment.
+	var opCount int
+	require.NoError(t, testDB.QueryRowContext(ctx, `SELECT COUNT(*) FROM apply_operations WHERE deployment = ?`, "payments-a").Scan(&opCount))
+	assert.Zero(t, opCount, "apply_operations row must be rolled back along with tasks and apply")
+}
+
+// TestApplyStore_CreateWithTasksAndOperationsRejectsMultiOpWithoutTaskMapping
+// pins the multi-op guard: when an apply has >1 operations, the caller MUST
+// pre-populate task.ApplyOperationID; the store will not silently link every
+// task to operations[0]. This guard prevents a wrong default from getting
+// locked in once the config-layer multi-entry-deployments block is lifted.
+func TestApplyStore_CreateWithTasksAndOperationsRejectsMultiOpWithoutTaskMapping(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "payments", storage.DatabaseTypeMySQL, "production")
+	now := time.Now()
+	apply := &storage.Apply{
+		ApplyIdentifier: "apply_multi_op_no_mapping",
+		LockID:          lock.ID,
+		PlanID:          1,
+		Database:        "payments",
+		DatabaseType:    storage.DatabaseTypeMySQL,
+		Repository:      "org/repo",
+		PullRequest:     123,
+		Environment:     "production",
+		Deployment:      "payments-a",
+		Engine:          storage.EngineSpirit,
+		State:           state.Apply.Pending,
+		Options:         []byte("{}"),
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+	tasks := []*storage.Task{
+		{TaskIdentifier: "task_unmapped", PlanID: 1, Database: "payments", DatabaseType: storage.DatabaseTypeMySQL, Engine: storage.EngineSpirit, Environment: "production", State: state.Task.Pending, TableName: "users", DDL: "ALTER TABLE users ADD COLUMN a INT", DDLAction: "alter", Options: []byte("{}"), CreatedAt: now, UpdatedAt: now},
+	}
+	operations := []*storage.ApplyOperation{
+		{Deployment: "payments-a", Target: "payments", State: state.ApplyOperation.Pending, CreatedAt: now, UpdatedAt: now},
+		{Deployment: "payments-b", Target: "payments", State: state.ApplyOperation.Pending, CreatedAt: now, UpdatedAt: now},
+	}
+
+	_, err := store.Applies().CreateWithTasksAndOperations(ctx, apply, tasks, operations)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "missing apply_operation_id")
+
+	gotApply, err := store.Applies().GetByApplyIdentifier(ctx, apply.ApplyIdentifier)
+	require.NoError(t, err)
+	assert.Nil(t, gotApply, "apply row must not exist after rejected multi-op create")
 }
 
 func TestApplyStore_CreateWithTasksAndOperationsRollsBackOnOperationFailure(t *testing.T) {

--- a/pkg/storage/mysqlstore/applies_test.go
+++ b/pkg/storage/mysqlstore/applies_test.go
@@ -314,6 +314,100 @@ func TestApplyStore_CreateWithTasksAndOperationsRejectsMultiOpWithoutTaskMapping
 	assert.Nil(t, gotApply, "apply row must not exist after rejected multi-op create")
 }
 
+// TestApplyStore_CreateWithTasksAndOperationsRejectsTaskApplyOperationIDMismatch
+// pins the ID-membership check: every non-nil task.ApplyOperationID must
+// point at one of the apply_operations rows just inserted for this apply.
+// tasks.apply_operation_id is not a foreign key (only an index), so without
+// this check a caller could persist an arbitrary or zero id and silently
+// break per-operation task scoping once the operator claim loop comes
+// online.
+func TestApplyStore_CreateWithTasksAndOperationsRejectsTaskApplyOperationIDMismatch(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "payments", storage.DatabaseTypeMySQL, "production")
+	now := time.Now()
+	apply := &storage.Apply{
+		ApplyIdentifier: "apply_op_id_mismatch",
+		LockID:          lock.ID,
+		PlanID:          1,
+		Database:        "payments",
+		DatabaseType:    storage.DatabaseTypeMySQL,
+		Repository:      "org/repo",
+		PullRequest:     123,
+		Environment:     "production",
+		Deployment:      "payments-a",
+		Engine:          storage.EngineSpirit,
+		State:           state.Apply.Pending,
+		Options:         []byte("{}"),
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+	// Caller supplies an arbitrary id (9_999_999) that cannot possibly
+	// match an apply_operations row created in the same transaction.
+	bogusOpID := int64(9_999_999)
+	tasks := []*storage.Task{
+		{TaskIdentifier: "task_bogus_op_id", ApplyOperationID: &bogusOpID, PlanID: 1, Database: "payments", DatabaseType: storage.DatabaseTypeMySQL, Engine: storage.EngineSpirit, Environment: "production", State: state.Task.Pending, TableName: "users", DDL: "ALTER TABLE users ADD COLUMN a INT", DDLAction: "alter", Options: []byte("{}"), CreatedAt: now, UpdatedAt: now},
+	}
+	operations := []*storage.ApplyOperation{
+		{Deployment: "payments-a", Target: "payments", State: state.ApplyOperation.Pending, CreatedAt: now, UpdatedAt: now},
+	}
+
+	_, err := store.Applies().CreateWithTasksAndOperations(ctx, apply, tasks, operations)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "does not match any inserted operation")
+
+	gotApply, err := store.Applies().GetByApplyIdentifier(ctx, apply.ApplyIdentifier)
+	require.NoError(t, err)
+	assert.Nil(t, gotApply, "apply row must not exist after rejected mismatched-op-id create")
+
+	var opCount int
+	require.NoError(t, testDB.QueryRowContext(ctx, `SELECT COUNT(*) FROM apply_operations WHERE deployment = ?`, "payments-a").Scan(&opCount))
+	assert.Zero(t, opCount, "apply_operations row must be rolled back along with the rejected apply")
+}
+
+// TestApplyStore_CreateWithTasksAndOperationsRejectsTasksWithApplyOperationIDWhenNoOperations
+// pins the no-operations case explicitly: when an apply is created with
+// tasks but no apply_operations, every task.ApplyOperationID must be nil.
+// A non-nil value here cannot reference any row this apply owns.
+func TestApplyStore_CreateWithTasksAndOperationsRejectsTasksWithApplyOperationIDWhenNoOperations(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "payments", storage.DatabaseTypeMySQL, "production")
+	now := time.Now()
+	apply := &storage.Apply{
+		ApplyIdentifier: "apply_tasks_no_ops",
+		LockID:          lock.ID,
+		PlanID:          1,
+		Database:        "payments",
+		DatabaseType:    storage.DatabaseTypeMySQL,
+		Repository:      "org/repo",
+		PullRequest:     123,
+		Environment:     "production",
+		Deployment:      "payments-a",
+		Engine:          storage.EngineSpirit,
+		State:           state.Apply.Pending,
+		Options:         []byte("{}"),
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+	bogusOpID := int64(42)
+	tasks := []*storage.Task{
+		{TaskIdentifier: "task_no_ops", ApplyOperationID: &bogusOpID, PlanID: 1, Database: "payments", DatabaseType: storage.DatabaseTypeMySQL, Engine: storage.EngineSpirit, Environment: "production", State: state.Task.Pending, TableName: "users", DDL: "ALTER TABLE users ADD COLUMN a INT", DDLAction: "alter", Options: []byte("{}"), CreatedAt: now, UpdatedAt: now},
+	}
+
+	_, err := store.Applies().CreateWithTasksAndOperations(ctx, apply, tasks, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "apply has no operations")
+
+	gotApply, err := store.Applies().GetByApplyIdentifier(ctx, apply.ApplyIdentifier)
+	require.NoError(t, err)
+	assert.Nil(t, gotApply, "apply row must not exist after rejected no-ops create")
+}
+
 func TestApplyStore_CreateWithTasksAndOperationsRollsBackOnOperationFailure(t *testing.T) {
 	clearTables(t)
 	ctx := t.Context()

--- a/pkg/storage/mysqlstore/tasks.go
+++ b/pkg/storage/mysqlstore/tasks.go
@@ -15,7 +15,7 @@ import (
 )
 
 // taskColumns lists all columns for SELECT queries.
-const taskColumns = `id, task_identifier, apply_id, plan_id, database_name, database_type,
+const taskColumns = `id, task_identifier, apply_id, apply_operation_id, plan_id, database_name, database_type,
 	namespace, table_name, ddl, ddl_action,
 	engine, repository, pull_request, environment, state, error_message, options, attempt,
 	rows_copied, rows_total, progress_percent, eta_seconds,
@@ -54,15 +54,15 @@ func insertTask(ctx context.Context, execer taskInserter, task *storage.Task) (i
 
 	result, err := execer.ExecContext(ctx, `
 		INSERT INTO tasks (
-			task_identifier, apply_id, plan_id, database_name, database_type,
+			task_identifier, apply_id, apply_operation_id, plan_id, database_name, database_type,
 			namespace, table_name, ddl, ddl_action,
 			engine, repository, pull_request, environment, state, error_message, options, attempt,
 			rows_copied, rows_total, progress_percent, eta_seconds,
 			is_instant, ready_to_complete, engine_migration_id,
 			started_at, completed_at, created_at, updated_at
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`,
-		task.TaskIdentifier, task.ApplyID, task.PlanID, task.Database, task.DatabaseType,
+		task.TaskIdentifier, task.ApplyID, nullInt64Ptr(task.ApplyOperationID), task.PlanID, task.Database, task.DatabaseType,
 		task.Namespace, nullString(task.TableName), nullString(task.DDL), nullString(task.DDLAction),
 		task.Engine, task.Repository, task.PullRequest, task.Environment,
 		task.State, nullString(task.ErrorMessage), string(options), task.Attempt,
@@ -242,13 +242,14 @@ func scanTaskInto(s scanner) (*storage.Task, error) {
 	var task storage.Task
 	var tableName, ddl, ddlAction, errorMsg, engineMigrationID sql.NullString
 	var options []byte
-	var etaSeconds sql.NullInt64
+	var applyOperationID, etaSeconds sql.NullInt64
 	var startedAt, completedAt sql.NullTime
 
 	err := s.Scan(
 		&task.ID,
 		&task.TaskIdentifier,
 		&task.ApplyID,
+		&applyOperationID,
 		&task.PlanID,
 		&task.Database,
 		&task.DatabaseType,
@@ -288,6 +289,10 @@ func scanTaskInto(s scanner) (*storage.Task, error) {
 	task.ETASeconds = int(etaSeconds.Int64)
 	task.EngineMigrationID = engineMigrationID.String
 	task.State = state.NormalizeTaskStatus(task.State)
+	if applyOperationID.Valid {
+		v := applyOperationID.Int64
+		task.ApplyOperationID = &v
+	}
 	if startedAt.Valid {
 		task.StartedAt = &startedAt.Time
 	}

--- a/pkg/storage/types.go
+++ b/pkg/storage/types.go
@@ -584,6 +584,14 @@ type Task struct {
 	// ApplyID points to applies.id.
 	ApplyID int64
 
+	// ApplyOperationID points to apply_operations.id when the task is
+	// owned by a specific per-deployment operation row. Nullable for
+	// backwards compatibility with rows written before the apply-create
+	// path started populating this column; once the operator claim loop
+	// owns task creation in the multi-deployment world, every new task
+	// carries a value.
+	ApplyOperationID *int64
+
 	// PlanID points to plans.id.
 	PlanID int64
 


### PR DESCRIPTION
## What

Apply-create now persists every `tasks` row with the `apply_operation_id` of the `apply_operations` row it belongs to. Write-side companion to [#220](https://github.com/block/schemabot/pull/220) (claim primitives) so the future operator claim loop can scope tasks per-operation instead of falling back to `apply_id` joins.

## Why

The `tasks.apply_operation_id` column was added (nullable) in [#205](https://github.com/block/schemabot/pull/205) but nothing has been populating it. Joining tasks to operations via `apply_id` works today only because the config layer hard-blocks multi-entry `deployments:` maps — one apply, one operation, ambiguity-free. The moment that block is lifted, an apply will span N operations and a tasks→operation lookup via `apply_id` becomes wrong-by-design. This PR is the pure-additive plumbing that makes the upcoming claim loop's task-scoping correct from day one.

## How

- `storage.Task` gains a nullable `ApplyOperationID *int64`. Old NULL rows keep working — `apply_operations` is consumed only by the still-gated operator claim path.
- `CreateWithTasksAndOperations` reorders the atomic insert sequence so `apply_operations` rows insert **before** `tasks`. Each task is back-filled with the operation's id before its own insert.
- **Multi-op guard**: when an apply has more than one operation, the store refuses to silently link every task to `operations[0]`. The caller must encode the per-task mapping explicitly — error returned otherwise. Prevents a wrong default from getting locked in once the multi-entry block is lifted.
- `taskColumns` + `scanTaskInto` round-trip the new column.

## Tests

- Extended `TestApplyStore_CreateWithTasksAndOperationsCommitsAtomically` to assert the back-fill on both the in-memory struct and the persisted row.
- New `TestApplyStore_CreateWithTasksAndOperationsRollsBackOnTaskFailure` pins the post-reorder rollback invariant — a task insert failure rolls back the already-inserted `apply_operations` row.
- New `TestApplyStore_CreateWithTasksAndOperationsRejectsMultiOpWithoutTaskMapping` pins the multi-op guard.
- Existing `TestApplyStore_CreateWithTasksAndOperationsRollsBackOnOperationFailure` still passes (passes nil tasks, so reorder is a no-op for it).

Validation: `go build`, `go vet`, `go test ./...`, `go test -tags=integration ./pkg/storage/...`, `golangci-lint run ./pkg/storage/...` — all green.