### PR TITLE
fix(github): detect config-only onboarding

### DIFF
--- a/docs/check-runs.md
+++ b/docs/check-runs.md
@@ -8,6 +8,7 @@
 - [Safety Philosophy](#safety-philosophy)
 - [Published Checks](#published-checks)
 - [Managed Schema Configs](#managed-schema-configs)
+  - [Onboarding a schema directory](#onboarding-a-schema-directory)
 - [Internal Records](#internal-records)
 - [Lifecycle](#lifecycle)
   - [Pull Request Events](#pull-request-events)
@@ -147,6 +148,61 @@ that PR. In that case, SchemaBot publishes passing aggregate checks so branch
 protection is not left waiting for a check it cannot produce.
 
 See [namespaces](./namespaces.md) for the schema directory and namespace layout.
+
+### Onboarding a schema directory
+
+To onboard an existing declarative schema directory, add a `schemabot.yaml` file
+next to the SQL files or namespace subdirectories it owns:
+
+```yaml
+database: widgets
+type: mysql
+```
+
+For Vitess-backed databases, use `type: vitess`:
+
+```yaml
+database: commerce
+type: vitess
+```
+
+A PR that only adds or edits `schemabot.yaml` is still managed work. SchemaBot
+loads the changed config directly, plans the current schema files for each
+configured environment, and publishes the normal aggregate check for the
+discovered database.
+
+On the happy path, where the live database already matches the declarative
+schema files, the aggregate check completes successfully with a clear no-op
+summary:
+
+```text
+SchemaBot (staging) — Schema up to date
+```
+
+```markdown
+| Database | Environment | Status |
+|----------|-------------|--------|
+| `widgets` | staging | Up to date |
+```
+
+If onboarding discovers unapplied schema changes, SchemaBot does not treat the
+onboarding as clean. It publishes the same pending apply state used for any
+schema change, so branch protection remains blocked until the target environment
+is applied or otherwise reconciled:
+
+```text
+SchemaBot (staging) — 1 apply pending
+```
+
+```markdown
+| Database | Environment | Status |
+|----------|-------------|--------|
+| `widgets` | staging | Pending |
+```
+
+If the PR does not add or edit `schemabot.yaml` and does not touch managed SQL
+or `vschema.json` files, SchemaBot publishes `No managed schema changes` instead
+because the PR does not affect a managed schema directory.
 
 ## Internal Records
 

--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -12,6 +12,7 @@ import (
 	"net"
 	"net/http"
 	"path"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -871,6 +872,19 @@ func (ic *InstallationClient) FetchFileContent(ctx context.Context, repo, filePa
 	return content, nil
 }
 
+func (ic *InstallationClient) fetchDirectoryContents(ctx context.Context, repo, dirPath, ref string) ([]*gh.RepositoryContent, error) {
+	owner, repoName := splitRepo(repo)
+	opts := &gh.RepositoryContentGetOptions{Ref: ref}
+	fileContent, directoryContent, _, err := ic.client.Repositories.GetContents(ctx, owner, repoName, dirPath, opts)
+	if err != nil {
+		return nil, fmt.Errorf("fetch directory content at %s: %w", dirPath, classifyGitHubAPIError(err))
+	}
+	if fileContent != nil {
+		return nil, fmt.Errorf("expected directory at %s, found file", dirPath)
+	}
+	return directoryContent, nil
+}
+
 // GitHubFile represents a file fetched from GitHub API.
 type GitHubFile struct {
 	Name    string
@@ -884,7 +898,7 @@ type fileResult struct {
 	err  error
 }
 
-// FetchSchemaFilesOptimized fetches schema files using Tree API + parallel blob fetching.
+// FetchSchemaFilesOptimized fetches schema files by walking the configured schema directory.
 // Accepts both flat files (single namespace) and namespace subdirectories (multiple namespaces).
 //
 // Supported layouts (see docs/namespaces.md):
@@ -903,34 +917,23 @@ type fileResult struct {
 //	  schema/commerce/orders.sql
 //	  schema/customers/users.sql
 func (ic *InstallationClient) FetchSchemaFilesOptimized(ctx context.Context, repo string, headSHA, schemaPath, dbType string) ([]GitHubFile, error) {
-	entries, _, err := ic.FetchGitTree(ctx, repo, headSHA)
+	entries, err := ic.schemaDirectoryEntries(ctx, repo, headSHA, schemaPath)
 	if err != nil {
-		return nil, fmt.Errorf("fetch git tree: %w", err)
+		if IsNotFoundError(err) {
+			return ic.fetchSchemaFilesFromTree(ctx, repo, headSHA, schemaPath)
+		}
+		return nil, err
 	}
 
-	// Filter tree entries to find schema files under schemaPath
-	var filesToFetch []TreeEntry
-	schemaPathPrefix := schemaPath + "/"
-
+	var filesToFetch []*gh.RepositoryContent
 	for _, entry := range entries {
-		if entry.Type != "blob" {
+		if entry.GetType() != "file" {
 			continue
 		}
-		if !strings.HasPrefix(entry.Path, schemaPathPrefix) {
+		if !isManagedSchemaFile(entry.GetPath()) {
 			continue
 		}
-		if !strings.HasSuffix(entry.Path, ".sql") && !strings.HasSuffix(entry.Path, "vschema.json") {
-			continue
-		}
-
-		relativePath := strings.TrimPrefix(entry.Path, schemaPathPrefix)
-		hasNamespaceDir := strings.Contains(relativePath, "/")
-
-		// Accept both flat files (single namespace) and namespace subdirs (multiple namespaces).
-		// Only allow one level of nesting (schema/namespace/table.sql, not schema/a/b/table.sql).
-		if !hasNamespaceDir || strings.Count(relativePath, "/") == 1 {
-			filesToFetch = append(filesToFetch, entry)
-		}
+		filesToFetch = append(filesToFetch, entry)
 	}
 
 	if len(filesToFetch) == 0 {
@@ -942,6 +945,82 @@ func (ic *InstallationClient) FetchSchemaFilesOptimized(ctx context.Context, rep
 	var wg sync.WaitGroup
 	semaphore := make(chan struct{}, 10)
 
+	for _, entry := range filesToFetch {
+		wg.Go(func() {
+			semaphore <- struct{}{}
+			defer func() { <-semaphore }()
+
+			content, err := ic.FetchFileContent(ctx, repo, entry.GetPath(), headSHA)
+			if err != nil {
+				results <- fileResult{err: fmt.Errorf("fetch %s: %w", entry.GetPath(), err)}
+				return
+			}
+			results <- fileResult{
+				file: GitHubFile{
+					Name:    path.Base(entry.GetPath()),
+					Content: content,
+					Path:    entry.GetPath(),
+				},
+			}
+		})
+	}
+
+	go func() {
+		wg.Wait()
+		close(results)
+	}()
+
+	var files []GitHubFile
+	var fetchErr error
+	for result := range results {
+		if result.err != nil {
+			fetchErr = result.err
+			continue
+		}
+		files = append(files, result.file)
+	}
+	if fetchErr != nil {
+		return nil, fetchErr
+	}
+
+	sort.Slice(files, func(i, j int) bool {
+		return files[i].Path < files[j].Path
+	})
+	return files, nil
+}
+
+func (ic *InstallationClient) fetchSchemaFilesFromTree(ctx context.Context, repo string, headSHA, schemaPath string) ([]GitHubFile, error) {
+	entries, truncated, err := ic.FetchGitTree(ctx, repo, headSHA)
+	if err != nil {
+		return nil, fmt.Errorf("fetch git tree: %w", err)
+	}
+	if truncated {
+		return nil, fmt.Errorf("fetch schema files from %s in repo %s ref %s: %w", schemaPath, repo, headSHA, ErrGitTreeTruncated)
+	}
+
+	var filesToFetch []TreeEntry
+	schemaPathPrefix := schemaPath + "/"
+	for _, entry := range entries {
+		if entry.Type != "blob" {
+			continue
+		}
+		if !strings.HasPrefix(entry.Path, schemaPathPrefix) {
+			continue
+		}
+		if !isManagedSchemaFile(entry.Path) {
+			continue
+		}
+
+		relativePath := strings.TrimPrefix(entry.Path, schemaPathPrefix)
+		hasNamespaceDir := strings.Contains(relativePath, "/")
+		if !hasNamespaceDir || strings.Count(relativePath, "/") == 1 {
+			filesToFetch = append(filesToFetch, entry)
+		}
+	}
+
+	results := make(chan fileResult, len(filesToFetch))
+	var wg sync.WaitGroup
+	semaphore := make(chan struct{}, 10)
 	for _, entry := range filesToFetch {
 		wg.Go(func() {
 			semaphore <- struct{}{}
@@ -980,5 +1059,38 @@ func (ic *InstallationClient) FetchSchemaFilesOptimized(ctx context.Context, rep
 		return nil, fetchErr
 	}
 
+	sort.Slice(files, func(i, j int) bool {
+		return files[i].Path < files[j].Path
+	})
 	return files, nil
+}
+
+func (ic *InstallationClient) schemaDirectoryEntries(ctx context.Context, repo, ref, schemaPath string) ([]*gh.RepositoryContent, error) {
+	rootEntries, err := ic.fetchDirectoryContents(ctx, repo, schemaPath, ref)
+	if err != nil {
+		return nil, err
+	}
+
+	entries := make([]*gh.RepositoryContent, 0, len(rootEntries))
+	entries = append(entries, rootEntries...)
+	for _, entry := range rootEntries {
+		if entry.GetType() != "dir" {
+			continue
+		}
+
+		subEntries, err := ic.fetchDirectoryContents(ctx, repo, entry.GetPath(), ref)
+		if err != nil {
+			return nil, fmt.Errorf("fetch schema namespace directory %s: %w", entry.GetPath(), err)
+		}
+		entries = append(entries, subEntries...)
+	}
+
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].GetPath() < entries[j].GetPath()
+	})
+	return entries, nil
+}
+
+func isManagedSchemaFile(filePath string) bool {
+	return strings.HasSuffix(filePath, ".sql") || path.Base(filePath) == "vschema.json"
 }

--- a/pkg/github/config.go
+++ b/pkg/github/config.go
@@ -371,6 +371,9 @@ func (ic *InstallationClient) FindAllConfigsForPR(ctx context.Context, repo stri
 		if !isConfigFile(file.Filename) {
 			continue
 		}
+		if isRemovedPRFile(file.Status) {
+			continue
+		}
 		configDir := path.Dir(file.Filename)
 		config, err := ic.FetchConfig(ctx, repo, file.Filename, prInfo.HeadSHA)
 		if err != nil {
@@ -439,6 +442,10 @@ func isConfigFile(filename string) bool {
 	return path.Base(filename) == ConfigFileName
 }
 
+func isRemovedPRFile(status string) bool {
+	return strings.EqualFold(status, "removed")
+}
+
 func filterSchemaFiles(files []string) []string {
 	var result []string
 	for _, file := range files {
@@ -503,6 +510,9 @@ func (ic *InstallationClient) findConfigsChangedInPR(ctx context.Context, repo s
 	configsByPath := make(map[string]DiscoveredConfig)
 	for _, file := range files {
 		if !isConfigFile(file.Filename) {
+			continue
+		}
+		if isRemovedPRFile(file.Status) {
 			continue
 		}
 		configDir := path.Dir(file.Filename)

--- a/pkg/github/config.go
+++ b/pkg/github/config.go
@@ -98,9 +98,10 @@ const ConfigFileName = "schemabot.yaml"
 
 // Config discovery errors.
 var (
-	ErrNoConfig        = fmt.Errorf("no schemabot.yaml config found")
-	ErrInvalidConfig   = fmt.Errorf("invalid schemabot.yaml config found")
-	ErrMultipleConfigs = fmt.Errorf("multiple schemabot.yaml configs found - use -d flag to specify database")
+	ErrNoConfig         = fmt.Errorf("no schemabot.yaml config found")
+	ErrInvalidConfig    = fmt.Errorf("invalid schemabot.yaml config found")
+	ErrMultipleConfigs  = fmt.Errorf("multiple schemabot.yaml configs found - use -d flag to specify database")
+	ErrGitTreeTruncated = fmt.Errorf("GitHub returned a truncated repository tree; config discovery is incomplete")
 )
 
 // DatabaseNotFoundError indicates the specified database was not found in any config.
@@ -165,9 +166,12 @@ type FindAllConfigsResult struct {
 
 // FindAllConfigs uses the Tree API to discover all schemabot.yaml config files in the repository.
 func (ic *InstallationClient) FindAllConfigs(ctx context.Context, repo, ref string) (*FindAllConfigsResult, error) {
-	entries, _, err := ic.FetchGitTree(ctx, repo, ref)
+	entries, truncated, err := ic.FetchGitTree(ctx, repo, ref)
 	if err != nil {
 		return nil, fmt.Errorf("fetch git tree: %w", err)
+	}
+	if truncated {
+		return nil, fmt.Errorf("discover schemabot configs in repo %s ref %s: %w", repo, ref, ErrGitTreeTruncated)
 	}
 
 	var configPaths []string
@@ -217,6 +221,16 @@ func (ic *InstallationClient) FindConfigByDatabaseName(ctx context.Context, repo
 		return nil, "", fmt.Errorf("fetch PR info: %w", err)
 	}
 
+	prConfigs, err := ic.findConfigsChangedInPR(ctx, repo, pr, prInfo.HeadSHA)
+	if err != nil {
+		return nil, "", fmt.Errorf("find configs changed in PR: %w", err)
+	}
+	if config, configDir, ok, err := selectConfigByDatabaseName(databaseName, prConfigs); err != nil {
+		return nil, "", err
+	} else if ok {
+		return config, configDir, nil
+	}
+
 	result, err := ic.FindAllConfigs(ctx, repo, prInfo.HeadSHA)
 	if err != nil {
 		return nil, "", fmt.Errorf("find configs: %w", err)
@@ -234,14 +248,11 @@ func (ic *InstallationClient) FindConfigByDatabaseName(ctx context.Context, repo
 		return nil, "", ErrNoConfig
 	}
 
-	var matches []DiscoveredConfig
-	for _, dc := range result.ValidConfigs {
-		if strings.EqualFold(dc.Config.Database, databaseName) {
-			matches = append(matches, dc)
-		}
+	config, configDir, ok, err := selectConfigByDatabaseName(databaseName, result.ValidConfigs)
+	if err != nil {
+		return nil, "", err
 	}
-
-	if len(matches) == 0 {
+	if !ok {
 		var available []string
 		for _, dc := range result.ValidConfigs {
 			available = append(available, dc.Config.Database)
@@ -249,25 +260,30 @@ func (ic *InstallationClient) FindConfigByDatabaseName(ctx context.Context, repo
 		return nil, "", &DatabaseNotFoundError{DatabaseName: databaseName, AvailableDatabases: available}
 	}
 
-	if len(matches) > 1 {
-		var paths []string
-		for _, m := range matches {
-			paths = append(paths, m.SchemaDir)
-		}
-		return nil, "", fmt.Errorf("ambiguous: database '%s' matches multiple configs at: %s",
-			databaseName, strings.Join(paths, ", "))
-	}
-
-	match := matches[0]
-	ic.logger.Debug("found config for database", "database", databaseName, "path", match.SchemaDir)
-	return match.Config, match.SchemaDir, nil
+	ic.logger.Debug("found config for database", "database", databaseName, "path", configDir)
+	return config, configDir, nil
 }
 
-// FindConfigForPR finds the schemabot.yaml config by searching directories of changed schema files.
+// FindConfigForPR finds the schemabot.yaml config by searching changed config files and directories of changed schema files.
 func (ic *InstallationClient) FindConfigForPR(ctx context.Context, repo string, pr int) (*SchemabotConfig, string, error) {
 	prInfo, err := ic.FetchPullRequest(ctx, repo, pr)
 	if err != nil {
 		return nil, "", fmt.Errorf("fetch PR info: %w", err)
+	}
+
+	configs, err := ic.findConfigsChangedInPR(ctx, repo, pr, prInfo.HeadSHA)
+	if err != nil {
+		return nil, "", err
+	}
+	if len(configs) == 1 {
+		return configs[0].Config, configs[0].SchemaDir, nil
+	}
+	if len(configs) > 1 {
+		var databases []string
+		for _, dc := range configs {
+			databases = append(databases, fmt.Sprintf("`%s` (%s)", dc.Config.Database, dc.SchemaDir))
+		}
+		return nil, "", fmt.Errorf("%w: %s", ErrMultipleConfigs, strings.Join(databases, ", "))
 	}
 
 	files, err := ic.FetchPRFiles(ctx, repo, pr)
@@ -350,16 +366,24 @@ func (ic *InstallationClient) FindAllConfigsForPR(ctx context.Context, repo stri
 		return nil, fmt.Errorf("fetch PR files: %w", err)
 	}
 
+	configsByPath := make(map[string]DiscoveredConfig)
+	for _, file := range files {
+		if !isConfigFile(file.Filename) {
+			continue
+		}
+		configDir := path.Dir(file.Filename)
+		config, err := ic.FetchConfig(ctx, repo, file.Filename, prInfo.HeadSHA)
+		if err != nil {
+			return nil, fmt.Errorf("fetch changed config %s: %w", file.Filename, err)
+		}
+		configsByPath[configDir] = newDiscoveredConfig(config, configDir)
+	}
+
 	var filenames []string
 	for _, f := range files {
 		filenames = append(filenames, f.Filename)
 	}
 	schemaFiles := filterSchemaFiles(filenames)
-	if len(schemaFiles) == 0 {
-		return nil, nil
-	}
-
-	configsByPath := make(map[string]DiscoveredConfig)
 	for _, schemaFile := range schemaFiles {
 		config, configDir, err := ic.findNearestConfig(ctx, repo, prInfo.HeadSHA, schemaFile)
 		if err != nil {
@@ -409,6 +433,10 @@ func (ic *InstallationClient) FindConfigInRepo(ctx context.Context, repo string,
 
 func isSchemaFile(filename string) bool {
 	return strings.HasSuffix(filename, ".sql") || strings.HasSuffix(filename, "vschema.json")
+}
+
+func isConfigFile(filename string) bool {
+	return path.Base(filename) == ConfigFileName
 }
 
 func filterSchemaFiles(files []string) []string {
@@ -464,6 +492,51 @@ func newDiscoveredConfig(config *SchemabotConfig, dir string) DiscoveredConfig {
 		SchemaDir:    dir,
 		Environments: config.GetEnvironments(),
 	}
+}
+
+func (ic *InstallationClient) findConfigsChangedInPR(ctx context.Context, repo string, pr int, ref string) ([]DiscoveredConfig, error) {
+	files, err := ic.FetchPRFiles(ctx, repo, pr)
+	if err != nil {
+		return nil, fmt.Errorf("fetch PR files: %w", err)
+	}
+
+	configsByPath := make(map[string]DiscoveredConfig)
+	for _, file := range files {
+		if !isConfigFile(file.Filename) {
+			continue
+		}
+		configDir := path.Dir(file.Filename)
+		config, err := ic.FetchConfig(ctx, repo, file.Filename, ref)
+		if err != nil {
+			return nil, fmt.Errorf("fetch changed config %s: %w", file.Filename, err)
+		}
+		configsByPath[configDir] = newDiscoveredConfig(config, configDir)
+	}
+
+	return sortedConfigs(configsByPath), nil
+}
+
+func selectConfigByDatabaseName(databaseName string, configs []DiscoveredConfig) (*SchemabotConfig, string, bool, error) {
+	var matches []DiscoveredConfig
+	for _, dc := range configs {
+		if strings.EqualFold(dc.Config.Database, databaseName) {
+			matches = append(matches, dc)
+		}
+	}
+	if len(matches) == 0 {
+		return nil, "", false, nil
+	}
+	if len(matches) > 1 {
+		var paths []string
+		for _, m := range matches {
+			paths = append(paths, m.SchemaDir)
+		}
+		return nil, "", false, fmt.Errorf("ambiguous: database '%s' matches multiple configs at: %s",
+			databaseName, strings.Join(paths, ", "))
+	}
+
+	match := matches[0]
+	return match.Config, match.SchemaDir, true, nil
 }
 
 func sortedConfigs(configsByPath map[string]DiscoveredConfig) []DiscoveredConfig {

--- a/pkg/github/config_test.go
+++ b/pkg/github/config_test.go
@@ -1,6 +1,7 @@
 package github
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"io"
@@ -129,6 +130,103 @@ func TestFindAllConfigsForPRDoesNotClassifyMissingConfigAsGitHubUnavailable(t *t
 	assert.Empty(t, configs)
 }
 
+func TestFindAllConfigsForPRDiscoversChangedConfigFile(t *testing.T) {
+	client, mux := setupConfigTestGitHubServer(t)
+	registerPullRequest(t, mux, "abc123")
+	registerPullRequestFiles(t, mux, []*gh.CommitFile{{
+		Filename: new("apps/widgets/schema/schemabot.yaml"),
+		Status:   new("added"),
+	}})
+	registerFileContent(t, mux, "/repos/octocat/hello-world/contents/apps/widgets/schema/schemabot.yaml", "database: widgets\ntype: mysql\n")
+
+	ic := NewInstallationClient(client, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	configs, err := ic.FindAllConfigsForPR(t.Context(), "octocat/hello-world", 1)
+
+	require.NoError(t, err)
+	require.Len(t, configs, 1)
+	assert.Equal(t, "widgets", configs[0].Config.Database)
+	assert.Equal(t, "apps/widgets/schema", configs[0].SchemaDir)
+}
+
+func TestFindConfigForPRDiscoversChangedConfigFile(t *testing.T) {
+	client, mux := setupConfigTestGitHubServer(t)
+	registerPullRequest(t, mux, "abc123")
+	registerPullRequestFiles(t, mux, []*gh.CommitFile{{
+		Filename: new("apps/widgets/schema/schemabot.yaml"),
+		Status:   new("added"),
+	}})
+	registerFileContent(t, mux, "/repos/octocat/hello-world/contents/apps/widgets/schema/schemabot.yaml", "database: widgets\ntype: mysql\n")
+
+	ic := NewInstallationClient(client, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	config, schemaDir, err := ic.FindConfigForPR(t.Context(), "octocat/hello-world", 1)
+
+	require.NoError(t, err)
+	assert.Equal(t, "widgets", config.Database)
+	assert.Equal(t, "apps/widgets/schema", schemaDir)
+}
+
+func TestFindConfigByDatabaseNameUsesChangedConfigFileBeforeRepoScan(t *testing.T) {
+	client, mux := setupConfigTestGitHubServer(t)
+	registerPullRequest(t, mux, "abc123")
+	registerPullRequestFiles(t, mux, []*gh.CommitFile{{
+		Filename: new("apps/widgets/schema/schemabot.yaml"),
+		Status:   new("added"),
+	}})
+	registerFileContent(t, mux, "/repos/octocat/hello-world/contents/apps/widgets/schema/schemabot.yaml", "database: widgets\ntype: mysql\n")
+
+	ic := NewInstallationClient(client, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	config, schemaDir, err := ic.FindConfigByDatabaseName(t.Context(), "octocat/hello-world", 1, "widgets")
+
+	require.NoError(t, err)
+	assert.Equal(t, "widgets", config.Database)
+	assert.Equal(t, "apps/widgets/schema", schemaDir)
+}
+
+func TestFindAllConfigsFailsClosedOnTruncatedGitTree(t *testing.T) {
+	client, mux := setupConfigTestGitHubServer(t)
+	mux.HandleFunc("GET /repos/octocat/hello-world/git/trees/abc123", func(w http.ResponseWriter, _ *http.Request) {
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+			"truncated": true,
+			"tree":      []any{},
+		}))
+	})
+
+	ic := NewInstallationClient(client, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	_, err := ic.FindAllConfigs(t.Context(), "octocat/hello-world", "abc123")
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrGitTreeTruncated)
+}
+
+func TestFetchSchemaFilesOptimizedWalksSchemaDirectoryOnly(t *testing.T) {
+	client, mux := setupConfigTestGitHubServer(t)
+	registerDirectoryContent(t, mux, "/repos/octocat/hello-world/contents/apps/widgets/schema", []*gh.RepositoryContent{
+		{Type: new("file"), Name: new("schemabot.yaml"), Path: new("apps/widgets/schema/schemabot.yaml")},
+		{Type: new("dir"), Name: new("main"), Path: new("apps/widgets/schema/main")},
+		{Type: new("dir"), Name: new("archive"), Path: new("apps/widgets/schema/archive")},
+	})
+	registerDirectoryContent(t, mux, "/repos/octocat/hello-world/contents/apps/widgets/schema/main", []*gh.RepositoryContent{
+		{Type: new("file"), Name: new("widgets.sql"), Path: new("apps/widgets/schema/main/widgets.sql")},
+		{Type: new("file"), Name: new("vschema.json"), Path: new("apps/widgets/schema/main/vschema.json")},
+		{Type: new("dir"), Name: new("nested"), Path: new("apps/widgets/schema/main/nested")},
+	})
+	registerDirectoryContent(t, mux, "/repos/octocat/hello-world/contents/apps/widgets/schema/archive", []*gh.RepositoryContent{
+		{Type: new("file"), Name: new("old.sql"), Path: new("apps/widgets/schema/archive/old.sql")},
+	})
+	registerFileContent(t, mux, "/repos/octocat/hello-world/contents/apps/widgets/schema/main/widgets.sql", "CREATE TABLE widgets (id bigint primary key);\n")
+	registerFileContent(t, mux, "/repos/octocat/hello-world/contents/apps/widgets/schema/main/vschema.json", "{}\n")
+	registerFileContent(t, mux, "/repos/octocat/hello-world/contents/apps/widgets/schema/archive/old.sql", "CREATE TABLE old_widgets (id bigint primary key);\n")
+
+	ic := NewInstallationClient(client, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	files, err := ic.FetchSchemaFilesOptimized(t.Context(), "octocat/hello-world", "abc123", "apps/widgets/schema", "vitess")
+
+	require.NoError(t, err)
+	require.Len(t, files, 3)
+	assert.Equal(t, "apps/widgets/schema/archive/old.sql", files[0].Path)
+	assert.Equal(t, "apps/widgets/schema/main/vschema.json", files[1].Path)
+	assert.Equal(t, "apps/widgets/schema/main/widgets.sql", files[2].Path)
+}
+
 // TestFindConfigForPR_AuthFailureDoesNotFallThroughToNoConfig verifies that
 // auth errors propagate instead of being swallowed as ErrNoConfig.
 func TestFindConfigForPR_AuthFailureDoesNotFallThroughToNoConfig(t *testing.T) {
@@ -172,4 +270,42 @@ func setupConfigTestGitHubServer(t *testing.T) (*gh.Client, *http.ServeMux) {
 	client.BaseURL = baseURL
 
 	return client, mux
+}
+
+func registerPullRequest(t *testing.T, mux *http.ServeMux, headSHA string) {
+	t.Helper()
+
+	mux.HandleFunc("GET /repos/octocat/hello-world/pulls/1", func(w http.ResponseWriter, _ *http.Request) {
+		require.NoError(t, json.NewEncoder(w).Encode(gh.PullRequest{
+			Head: &gh.PullRequestBranch{SHA: new(headSHA)},
+		}))
+	})
+}
+
+func registerPullRequestFiles(t *testing.T, mux *http.ServeMux, files []*gh.CommitFile) {
+	t.Helper()
+
+	mux.HandleFunc("GET /repos/octocat/hello-world/pulls/1/files", func(w http.ResponseWriter, _ *http.Request) {
+		require.NoError(t, json.NewEncoder(w).Encode(files))
+	})
+}
+
+func registerFileContent(t *testing.T, mux *http.ServeMux, endpointPath, content string) {
+	t.Helper()
+
+	mux.HandleFunc("GET "+endpointPath, func(w http.ResponseWriter, _ *http.Request) {
+		require.NoError(t, json.NewEncoder(w).Encode(gh.RepositoryContent{
+			Type:     new("file"),
+			Encoding: new("base64"),
+			Content:  new(base64.StdEncoding.EncodeToString([]byte(content))),
+		}))
+	})
+}
+
+func registerDirectoryContent(t *testing.T, mux *http.ServeMux, endpointPath string, contents []*gh.RepositoryContent) {
+	t.Helper()
+
+	mux.HandleFunc("GET "+endpointPath, func(w http.ResponseWriter, _ *http.Request) {
+		require.NoError(t, json.NewEncoder(w).Encode(contents))
+	})
 }

--- a/pkg/github/config_test.go
+++ b/pkg/github/config_test.go
@@ -182,6 +182,35 @@ func TestFindConfigByDatabaseNameUsesChangedConfigFileBeforeRepoScan(t *testing.
 	assert.Equal(t, "apps/widgets/schema", schemaDir)
 }
 
+func TestFindAllConfigsForPRSkipsRemovedConfigFile(t *testing.T) {
+	client, mux := setupConfigTestGitHubServer(t)
+	registerPullRequest(t, mux, "abc123")
+	registerPullRequestFiles(t, mux, []*gh.CommitFile{{
+		Filename: new("apps/widgets/schema/schemabot.yaml"),
+		Status:   new("removed"),
+	}})
+
+	ic := NewInstallationClient(client, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	configs, err := ic.FindAllConfigsForPR(t.Context(), "octocat/hello-world", 1)
+
+	require.NoError(t, err)
+	assert.Empty(t, configs)
+}
+
+func TestFindConfigForPRSkipsRemovedConfigFile(t *testing.T) {
+	client, mux := setupConfigTestGitHubServer(t)
+	registerPullRequest(t, mux, "abc123")
+	registerPullRequestFiles(t, mux, []*gh.CommitFile{{
+		Filename: new("apps/widgets/schema/schemabot.yaml"),
+		Status:   new("removed"),
+	}})
+
+	ic := NewInstallationClient(client, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	_, _, err := ic.FindConfigForPR(t.Context(), "octocat/hello-world", 1)
+
+	require.ErrorIs(t, err, ErrNoConfig)
+}
+
 func TestFindAllConfigsFailsClosedOnTruncatedGitTree(t *testing.T) {
 	client, mux := setupConfigTestGitHubServer(t)
 	mux.HandleFunc("GET /repos/octocat/hello-world/git/trees/abc123", func(w http.ResponseWriter, _ *http.Request) {

--- a/pkg/webhook/check_aggregate.go
+++ b/pkg/webhook/check_aggregate.go
@@ -98,7 +98,11 @@ func computeAggregate(checks []*storage.Check) (conclusion, status string) {
 func aggregateSummary(checks []*storage.Check, conclusion string) (title, summary string) {
 	switch conclusion {
 	case checkConclusionSuccess:
-		title = "All applies complete"
+		if allChecksAreUpToDate(checks) {
+			title = "Schema up to date"
+		} else {
+			title = "All applies complete"
+		}
 		summary = buildAggregateTable(checks)
 	case checkConclusionFailure:
 		title = "Apply failed"
@@ -132,7 +136,7 @@ func buildAggregateTable(checks []*storage.Check) string {
 	sb.WriteString("|----------|-------------|--------|\n")
 
 	for i, c := range checks {
-		row := fmt.Sprintf("| `%s` | %s | %s |\n", c.DatabaseName, c.Environment, conclusionEmoji(c.Status, c.Conclusion))
+		row := fmt.Sprintf("| `%s` | %s | %s |\n", c.DatabaseName, c.Environment, checkStatusLabel(c))
 		if sb.Len()+len(row) > maxCheckRunTextLength-1000 {
 			fmt.Fprintf(&sb, "\n... and %d more check(s)\n", len(checks)-i)
 			break
@@ -141,6 +145,25 @@ func buildAggregateTable(checks []*storage.Check) string {
 	}
 
 	return sb.String()
+}
+
+func allChecksAreUpToDate(checks []*storage.Check) bool {
+	if len(checks) == 0 {
+		return false
+	}
+	for _, c := range checks {
+		if c.Status != checkStatusCompleted || c.Conclusion != checkConclusionSuccess || c.HasChanges {
+			return false
+		}
+	}
+	return true
+}
+
+func checkStatusLabel(c *storage.Check) string {
+	if c.Status == checkStatusCompleted && c.Conclusion == checkConclusionSuccess && !c.HasChanges {
+		return "Up to date"
+	}
+	return conclusionEmoji(c.Status, c.Conclusion)
 }
 
 // conclusionEmoji returns a short status label for a check.

--- a/pkg/webhook/check_aggregate_test.go
+++ b/pkg/webhook/check_aggregate_test.go
@@ -112,7 +112,7 @@ func TestIsAggregateCheck(t *testing.T) {
 
 func TestAggregateSummary(t *testing.T) {
 	checks := []*storage.Check{
-		{DatabaseName: "orders", Environment: "staging", Status: checkStatusCompleted, Conclusion: checkConclusionSuccess},
+		{DatabaseName: "orders", Environment: "staging", Status: checkStatusCompleted, Conclusion: checkConclusionSuccess, HasChanges: true},
 		{DatabaseName: "orders", Environment: "production", Status: checkStatusCompleted, Conclusion: checkConclusionActionRequired},
 	}
 
@@ -128,12 +128,25 @@ func TestAggregateSummary(t *testing.T) {
 
 func TestAggregateSummary_AllSuccess(t *testing.T) {
 	checks := []*storage.Check{
-		{DatabaseName: "orders", Environment: "staging", Status: checkStatusCompleted, Conclusion: checkConclusionSuccess},
-		{DatabaseName: "orders", Environment: "production", Status: checkStatusCompleted, Conclusion: checkConclusionSuccess},
+		{DatabaseName: "orders", Environment: "staging", Status: checkStatusCompleted, Conclusion: checkConclusionSuccess, HasChanges: true},
+		{DatabaseName: "orders", Environment: "production", Status: checkStatusCompleted, Conclusion: checkConclusionSuccess, HasChanges: true},
 	}
 
 	title, _ := aggregateSummary(checks, checkConclusionSuccess)
 	assert.Equal(t, "All applies complete", title)
+}
+
+func TestAggregateSummary_AllUpToDate(t *testing.T) {
+	checks := []*storage.Check{
+		{DatabaseName: "orders", Environment: "staging", Status: checkStatusCompleted, Conclusion: checkConclusionSuccess},
+		{DatabaseName: "users", Environment: "staging", Status: checkStatusCompleted, Conclusion: checkConclusionSuccess},
+	}
+
+	title, summary := aggregateSummary(checks, checkConclusionSuccess)
+
+	assert.Equal(t, "Schema up to date", title)
+	assert.Contains(t, summary, "Up to date")
+	assert.NotContains(t, summary, "Applied")
 }
 
 func TestConclusionEmoji(t *testing.T) {


### PR DESCRIPTION
Config-only onboarding PRs now participate in normal SchemaBot discovery instead of being treated as unrelated changes. When a PR adds or edits `schemabot.yaml`, SchemaBot loads that config directly, runs the normal plan path for the discovered database, and reports a database-specific check result.

The happy-path onboarding UX is now explicit: if the live database already matches the declarative schema files, the aggregate check reports `Schema up to date` and each database row shows `Up to date`. If onboarding discovers unapplied schema changes, SchemaBot publishes the normal pending apply state so branch protection stays blocked until the target environment is applied or otherwise reconciled.

This also makes GitHub tree truncation fail closed instead of converting an incomplete repository listing into a passing/no-config result. Schema file loading now prefers a schema-directory-scoped walk, and the check-run docs describe the onboarding states operators should expect.

Generated with Amp
