### PR TITLE
feat(github): support custom aggregate check names

### DIFF
--- a/docs/check-runs.md
+++ b/docs/check-runs.md
@@ -68,7 +68,9 @@ There are two main ways external systems report status to GitHub:
 A check suite is GitHub's grouping of check runs created by one GitHub App for a
 commit. SchemaBot mostly cares about the individual check run because that is the
 named object shown in branch protection, such as `SchemaBot` or
-`SchemaBot (staging)`.
+`SchemaBot (staging)`. Deployments can configure a custom base name, such as
+`SchemaBot X`, when multiple independent SchemaBot gates appear on the same
+repository.
 
 Why SchemaBot uses check runs:
 
@@ -128,6 +130,11 @@ owned environment. Require each environment check that applies to the repository
 SchemaBot (staging)
 SchemaBot (production)
 ```
+
+If the GitHub App config sets `check-name`, require that configured base name
+instead. For example, `check-name: SchemaBot X` publishes `SchemaBot X` for a
+single aggregate, or `SchemaBot X (staging)` and `SchemaBot X (production)`
+when `allowed_environments` is configured.
 
 Per-database state is stored internally and shown in the aggregate check summary.
 
@@ -810,7 +817,8 @@ environment:
   check storage for the same PR, database type, database, and prior
   environment.
 - If another deployment owns the prior environment, SchemaBot reads the
-  environment aggregate check run from GitHub, such as `SchemaBot (staging)`.
+  environment aggregate check run from GitHub, such as `SchemaBot (staging)` or
+  the deployment's configured check name.
 
 Remote prior-environment checks use the aggregate because the current deployment
 does not have access to the other deployment's per-database storage. That makes
@@ -904,6 +912,10 @@ SchemaBot (staging)
 SchemaBot (production)
 ```
 
+If `github.check-name` is configured, require the matching custom check names.
+All deployments in the same promotion chain should use the same base name so
+later environments can find prior-environment aggregate checks.
+
 GitHub UI setup:
 
 1. Open repository settings.
@@ -912,6 +924,9 @@ GitHub UI setup:
 4. Select the SchemaBot aggregate check names used by the deployment.
 
 GitHub API example for a single aggregate:
+
+Replace `SchemaBot` with the configured check name when `github.check-name` is
+set.
 
 ```bash
 gh api repos/{owner}/{repo}/branches/{branch}/protection \

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -392,6 +392,7 @@ github:
   app-id: "env:STAGING_GITHUB_APP_ID"
   private-key: "file:/run/secrets/staging-github-key.pem"
   webhook-secret: "env:STAGING_WEBHOOK_SECRET"
+  check-name: "SchemaBot X"
 ```
 
 ### Production Instance
@@ -414,6 +415,7 @@ github:
   app-id: "env:PROD_GITHUB_APP_ID"
   private-key: "file:/run/secrets/prod-github-key.pem"
   webhook-secret: "env:PROD_WEBHOOK_SECRET"
+  check-name: "SchemaBot X"
 ```
 
 ### Environment-local gRPC targets
@@ -468,9 +470,9 @@ Do not require the staging ConfigMap to contain production targets, or the produ
 
 - **Environment scoping:** When `allowed_environments` is set, the instance only processes commands targeting those environments. Commands for other environments (e.g., `schemabot apply -e production` sent to the staging instance) are accepted without a PR response by this deployment. A deployment that allows the requested environment must process its own webhook delivery.
 
-- **Per-environment aggregate checks:** Each instance creates its own aggregate check run scoped to its environments (e.g., `SchemaBot (staging)`, `SchemaBot (production)`) instead of the default `SchemaBot` aggregate. Configure branch protection to require both aggregates.
+- **Per-environment aggregate checks:** Each instance creates its own aggregate check run scoped to its environments (e.g., `SchemaBot (staging)`, `SchemaBot (production)`) instead of the default `SchemaBot` aggregate. Configure branch protection to require both aggregates. Set `github.check-name` when independent SchemaBot gates need distinct visible names; every instance in the same promotion chain should use the same base name.
 
-- **Cross-instance environment verification:** Environment ordering (e.g., staging must succeed before production) works across instances. The production instance queries the GitHub Checks API for the staging instance's `SchemaBot (staging)` aggregate check to verify the prior environment completed successfully. GitHub check runs are the shared authority for cross-environment state; the production instance does not need staging target configuration to enforce the staging gate.
+- **Cross-instance environment verification:** Environment ordering (e.g., staging must succeed before production) works across instances. The production instance queries the GitHub Checks API for the staging instance's aggregate check to verify the prior environment completed successfully. GitHub check runs are the shared authority for cross-environment state; the production instance does not need staging target configuration to enforce the staging gate.
 
 - **Separate GitHub Apps:** Each instance needs its own GitHub App installation. Both Apps must be installed on the same repositories and configured to receive the same webhook events. GitHub delivers webhooks to all installed Apps independently.
 
@@ -501,10 +503,12 @@ apps:
     app-id: "env:APP_A_ID"
     private-key: "file:/secrets/app-a/private-key"
     webhook-secret: "file:/secrets/app-a/webhook-secret"
+    check-name: "SchemaBot X"
   app-b:
     app-id: "env:APP_B_ID"
     private-key: "file:/secrets/app-b/private-key"
     webhook-secret: "file:/secrets/app-b/webhook-secret"
+    check-name: "SchemaBot Y"
 
 repos:
   org-a/repo-x:
@@ -520,7 +524,7 @@ Rules (enforced once the runtime is wired; today's hard-block fires before these
 - When `apps:` is NOT configured, repositories must not set `github_app:` — it would be silently ignored, so it is rejected at config load to surface misconfiguration early.
 - The legacy single-App `github:` shape continues to work unchanged.
 
-The map key under `apps:` is the App's stable logical name and the value that flows into log lines and metrics. Each entry MUST provide a non-empty `app-id`, `private-key`, and `webhook-secret`; all three accept the same secret-resolution prefixes as the legacy `github:` block (see [Secret Resolution](#secret-resolution)).
+The map key under `apps:` is the App's stable logical name and the value that flows into log lines and metrics. Each entry MUST provide a non-empty `app-id`, `private-key`, and `webhook-secret`; all three accept the same secret-resolution prefixes as the legacy `github:` block (see [Secret Resolution](#secret-resolution)). `check-name` is optional and defaults to `SchemaBot`.
 
 ## Secret Resolution
 

--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -113,6 +113,7 @@ github:
   app-id: "123456"                                 # From step 1
   private-key: "file:/path/to/private-key.pem"     # PEM file
   webhook-secret: "env:GITHUB_WEBHOOK_SECRET"      # From step 1
+  check-name: "SchemaBot X"                      # Optional Check Run base name
 
 databases:
   mydb:

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -17,6 +17,10 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// DefaultGitHubCheckName is the base GitHub Check Run name used when a
+// deployment does not configure a custom name.
+const DefaultGitHubCheckName = "SchemaBot"
+
 // ServerConfig holds the server-side SchemaBot configuration.
 // This is loaded from a YAML file specified by SCHEMABOT_CONFIG_FILE.
 type ServerConfig struct {
@@ -125,6 +129,20 @@ type GitHubConfig struct {
 	// WebhookSecret is the HMAC secret for validating webhook signatures.
 	// Supports secret references: env:VAR, file:/path, secretsmanager:name#key.
 	WebhookSecret string `yaml:"webhook-secret"`
+
+	// CheckName is the base name for aggregate GitHub Check Runs published by
+	// this App. Environment-scoped deployments append the environment in
+	// parentheses, for example "SchemaBot (staging)".
+	CheckName string `yaml:"check-name,omitempty"`
+}
+
+// CheckRunNameBase returns the configured aggregate GitHub Check Run base name.
+func (g GitHubConfig) CheckRunNameBase() string {
+	name := strings.TrimSpace(g.CheckName)
+	if name == "" {
+		return DefaultGitHubCheckName
+	}
+	return name
 }
 
 // Configured returns true if the GitHub App is configured (app ID and private key are set).
@@ -579,7 +597,7 @@ func (c *ServerConfig) validateNoLocalRemoteRouteCollision() error {
 //   - If apps: is NOT set, repos must not declare github_app (it would be a
 //     silently ignored field, which we want to fail closed on).
 func (c *ServerConfig) validateGitHubAppsConfig() error {
-	hasGitHub := c.GitHub.AppID != "" || c.GitHub.PrivateKey != "" || c.GitHub.WebhookSecret != ""
+	hasGitHub := c.GitHub.AppID != "" || c.GitHub.PrivateKey != "" || c.GitHub.WebhookSecret != "" || c.GitHub.CheckName != ""
 	hasApps := c.Apps != nil
 
 	if hasGitHub && hasApps {
@@ -902,6 +920,26 @@ func (c *ServerConfig) IsCheckRequired(name string) bool {
 		return true
 	}
 	return slices.Contains(c.RequiredChecks, name)
+}
+
+// GitHubCheckNameBaseForRepo returns the aggregate GitHub Check Run base name
+// for the App that owns repo.
+func (c *ServerConfig) GitHubCheckNameBaseForRepo(repo string) string {
+	if c == nil {
+		return DefaultGitHubCheckName
+	}
+	if len(c.Apps) > 0 {
+		repoConfig, ok := c.Repos[repo]
+		if !ok {
+			return DefaultGitHubCheckName
+		}
+		appConfig, ok := c.Apps[repoConfig.GitHubApp]
+		if !ok {
+			return DefaultGitHubCheckName
+		}
+		return appConfig.CheckRunNameBase()
+	}
+	return c.GitHub.CheckRunNameBase()
 }
 
 // StorageDSN returns the resolved storage DSN.

--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -2108,6 +2108,42 @@ func TestServerConfig_ResolveGitHubAppForRepo(t *testing.T) {
 	})
 }
 
+func TestServerConfig_GitHubCheckNameBaseForRepo(t *testing.T) {
+	t.Run("legacy single-app defaults", func(t *testing.T) {
+		cfg := &ServerConfig{}
+		assert.Equal(t, DefaultGitHubCheckName, cfg.GitHubCheckNameBaseForRepo("any/repo"))
+	})
+
+	t.Run("legacy single-app trims configured name", func(t *testing.T) {
+		cfg := &ServerConfig{GitHub: GitHubConfig{CheckName: "  SchemaBot X  "}}
+		assert.Equal(t, "SchemaBot X", cfg.GitHubCheckNameBaseForRepo("any/repo"))
+	})
+
+	t.Run("multi-app uses repository app name", func(t *testing.T) {
+		cfg := &ServerConfig{
+			Apps: map[string]GitHubAppConfig{
+				"app-a": {CheckName: "SchemaBot X"},
+				"app-b": {CheckName: "SchemaBot Y"},
+			},
+			Repos: map[string]RepoConfig{
+				"org-a/repo-x": {GitHubApp: "app-a"},
+				"org-b/repo-y": {GitHubApp: "app-b"},
+			},
+		}
+
+		assert.Equal(t, "SchemaBot X", cfg.GitHubCheckNameBaseForRepo("org-a/repo-x"))
+		assert.Equal(t, "SchemaBot Y", cfg.GitHubCheckNameBaseForRepo("org-b/repo-y"))
+	})
+
+	t.Run("multi-app falls back for unknown repository", func(t *testing.T) {
+		cfg := &ServerConfig{
+			Apps:  map[string]GitHubAppConfig{"app-a": {CheckName: "SchemaBot X"}},
+			Repos: map[string]RepoConfig{"org/repo": {GitHubApp: "app-a"}},
+		}
+		assert.Equal(t, DefaultGitHubCheckName, cfg.GitHubCheckNameBaseForRepo("org/unknown"))
+	})
+}
+
 // TestLoadServerConfigFromFile_MultiApp end-to-end-parses the new YAML shape
 // to confirm the apps: map and per-repo github_app: field round-trip through
 // the YAML decoder (including KnownFields(true)), then asserts that
@@ -2122,6 +2158,7 @@ apps:
     app-id: "env:APP_A_ID"
     private-key: "env:APP_A_PK"
     webhook-secret: "env:APP_A_WS"
+    check-name: "SchemaBot X"
   app-b:
     app-id: "env:APP_B_ID"
     private-key: "env:APP_B_PK"
@@ -2154,6 +2191,7 @@ repos:
 	require.Contains(t, parsed.Apps, "app-a")
 	require.Contains(t, parsed.Apps, "app-b")
 	assert.Equal(t, "env:APP_A_ID", parsed.Apps["app-a"].AppID)
+	assert.Equal(t, "SchemaBot X", parsed.Apps["app-a"].CheckName)
 	assert.Equal(t, "app-a", parsed.Repos["org-a/repo-x"].GitHubApp)
 	assert.Equal(t, "app-b", parsed.Repos["org-b/repo-y"].GitHubApp)
 

--- a/pkg/webhook/README.md
+++ b/pkg/webhook/README.md
@@ -143,7 +143,7 @@ ExecutePlan(ctx, PlanRequest)
 
 ## Check Runs
 
-Check Runs are GitHub pre-merge status checks that appear on the PR's "Checks" tab. SchemaBot publishes an aggregate check (`SchemaBot`, or `SchemaBot (<environment>)` when `allowed_environments` is configured) and stores per-database state internally.
+Check Runs are GitHub pre-merge status checks that appear on the PR's "Checks" tab. SchemaBot publishes an aggregate check (`SchemaBot`, or `SchemaBot (<environment>)` when `allowed_environments` is configured) and stores per-database state internally. Deployments can override the visible base name with `github.check-name`.
 
 After a plan, the aggregate reflects the rolled-up internal state:
 

--- a/pkg/webhook/check_aggregate.go
+++ b/pkg/webhook/check_aggregate.go
@@ -8,9 +8,16 @@ import (
 )
 
 // aggregateCheckNameForEnv returns the environment-scoped aggregate check name.
-// e.g., "SchemaBot (staging)" or "SchemaBot (production)".
-func aggregateCheckNameForEnv(env string) string {
-	return fmt.Sprintf("SchemaBot (%s)", env)
+// e.g., "SchemaBot (staging)" or "Custom SchemaBot (production)".
+func aggregateCheckNameForEnv(baseName, env string) string {
+	return fmt.Sprintf("%s (%s)", baseName, env)
+}
+
+func (h *Handler) aggregateCheckNameForRepo(repo string) string {
+	if h == nil || h.service == nil || h.service.Config() == nil {
+		return aggregateCheckName
+	}
+	return h.service.Config().GitHubCheckNameBaseForRepo(repo)
 }
 
 // filterChecksByEnvironment returns only stored check state for the given environment.

--- a/pkg/webhook/check_aggregate_test.go
+++ b/pkg/webhook/check_aggregate_test.go
@@ -6,6 +6,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/block/spirit/pkg/utils"
+
+	"github.com/block/schemabot/pkg/api"
 	"github.com/block/schemabot/pkg/storage"
 )
 
@@ -145,9 +148,23 @@ func TestConclusionEmoji(t *testing.T) {
 }
 
 func TestAggregateCheckNameForEnv(t *testing.T) {
-	assert.Equal(t, "SchemaBot (staging)", aggregateCheckNameForEnv("staging"))
-	assert.Equal(t, "SchemaBot (production)", aggregateCheckNameForEnv("production"))
-	assert.Equal(t, "SchemaBot (sandbox)", aggregateCheckNameForEnv("sandbox"))
+	assert.Equal(t, "SchemaBot (staging)", aggregateCheckNameForEnv(aggregateCheckName, "staging"))
+	assert.Equal(t, "SchemaBot (production)", aggregateCheckNameForEnv(aggregateCheckName, "production"))
+	assert.Equal(t, "SchemaBot X (sandbox)", aggregateCheckNameForEnv("SchemaBot X", "sandbox"))
+}
+
+func TestAggregateCheckNameForRepo(t *testing.T) {
+	t.Run("defaults without service config", func(t *testing.T) {
+		h := &Handler{}
+		assert.Equal(t, aggregateCheckName, h.aggregateCheckNameForRepo("octocat/hello-world"))
+	})
+
+	t.Run("uses single app custom name", func(t *testing.T) {
+		service := api.New(&emptyStorage{}, &api.ServerConfig{GitHub: api.GitHubConfig{CheckName: "SchemaBot X"}}, nil, testLogger())
+		t.Cleanup(func() { utils.CloseAndLog(service) })
+		h := &Handler{service: service}
+		assert.Equal(t, "SchemaBot X", h.aggregateCheckNameForRepo("octocat/hello-world"))
+	})
 }
 
 func TestFilterChecksByEnvironment(t *testing.T) {

--- a/pkg/webhook/check_prior_env.go
+++ b/pkg/webhook/check_prior_env.go
@@ -175,12 +175,12 @@ func storedPriorEnvCheckStatus(check *storage.Check) string {
 // GitHub Checks API for the per-environment aggregate check run created by the
 // other SchemaBot instance that owns that environment.
 //
-// The remote check uses the aggregate "SchemaBot (staging)" which rolls up ALL
-// databases in the prior environment. This is stricter than per-database checking:
-// production apply for any database is blocked until ALL databases in staging are
-// applied. This is the correct behavior for the remote case — we cannot query
-// per-database check state from another instance, and it is safer to require the
-// entire environment to be healthy before promoting.
+// The remote check uses the prior environment's aggregate Check Run, which rolls
+// up ALL databases in the prior environment. This is stricter than per-database
+// checking: production apply for any database is blocked until ALL databases in
+// staging are applied. This is the correct behavior for the remote case — we
+// cannot query per-database check state from another instance, and it is safer to
+// require the entire environment to be healthy before promoting.
 func (h *Handler) checkPriorEnvViaGitHub(
 	ctx context.Context, repo string, pr int,
 	database, environment, priorEnv string,
@@ -204,7 +204,7 @@ func (h *Handler) checkPriorEnvViaGitHub(
 		return true
 	}
 
-	checkName := aggregateCheckNameForEnv(priorEnv)
+	checkName := aggregateCheckNameForEnv(h.aggregateCheckNameForRepo(repo), priorEnv)
 	checkResult, err := h.waitForGitHubPriorEnvCheck(ctx, client, repo, pr, database, environment, priorEnv, prInfo.HeadSHA, checkName)
 	if err != nil {
 		h.logger.Error("failed to query GitHub check for prior environment, blocking apply",

--- a/pkg/webhook/check_prior_env_test.go
+++ b/pkg/webhook/check_prior_env_test.go
@@ -168,7 +168,7 @@ func TestCheckPriorEnvViaGitHub(t *testing.T) {
 
 	// setupCheckRunServer creates a mock GitHub server with PR fetch and optional
 	// comment capture, plus a check-runs endpoint that returns the given check runs.
-	setupCheckRunServer := func(t *testing.T, checkRuns []map[string]any) (*Handler, chan string) {
+	setupCheckRunServer := func(t *testing.T, checkRuns []map[string]any, configs ...*api.ServerConfig) (*Handler, chan string) {
 		t.Helper()
 
 		client, mux := setupGitHubServer(t)
@@ -201,8 +201,15 @@ func TestCheckPriorEnvViaGitHub(t *testing.T) {
 
 		installClient := ghclient.NewInstallationClient(client, testLogger())
 		factory := &fakeClientFactory{client: installClient}
+		config := &api.ServerConfig{}
+		if len(configs) > 0 {
+			config = configs[0]
+		}
+		service := api.New(&emptyStorage{}, config, nil, testLogger())
+		t.Cleanup(func() { utils.CloseAndLog(service) })
 
 		h := &Handler{
+			service:                    service,
 			ghClients:                  ghclient.NewSingleClientSet(defaultAppName, factory),
 			logger:                     testLogger(),
 			priorEnvCheckMaxAttempts:   1,
@@ -216,6 +223,21 @@ func TestCheckPriorEnvViaGitHub(t *testing.T) {
 		h, comments := setupCheckRunServer(t, []map[string]any{
 			{"id": 1, "name": "SchemaBot (staging)", "status": "completed", "conclusion": "success"},
 		})
+
+		blocked := h.checkPriorEnvViaGitHub(t.Context(), repo, pr, "orders", "production", "staging", 12345)
+		assert.False(t, blocked)
+
+		select {
+		case body := <-comments:
+			t.Fatalf("unexpected comment posted: %s", body)
+		default:
+		}
+	})
+
+	t.Run("custom check name success allows proceed", func(t *testing.T) {
+		h, comments := setupCheckRunServer(t, []map[string]any{
+			{"id": 1, "name": "SchemaBot X (staging)", "status": "completed", "conclusion": "success"},
+		}, &api.ServerConfig{GitHub: api.GitHubConfig{CheckName: "SchemaBot X"}})
 
 		blocked := h.checkPriorEnvViaGitHub(t.Context(), repo, pr, "orders", "production", "staging", 12345)
 		assert.False(t, blocked)

--- a/pkg/webhook/check_publisher.go
+++ b/pkg/webhook/check_publisher.go
@@ -65,12 +65,12 @@ func (h *Handler) verifyHeadSHAStillCurrentForPR(ctx context.Context, client *gh
 // up per-database checks for a PR.
 //
 // When allowed_environments is configured, per-environment aggregates are created
-// (e.g., "SchemaBot (staging)") that only roll up checks for that environment. This
-// allows separate SchemaBot instances to each publish their own aggregate without
-// conflicting with each other.
+// (e.g., "SchemaBot (staging)") that only roll up checks for that environment.
+// Deployments can customize the base name when independent SchemaBot gates share
+// a repository.
 //
-// When allowed_environments is NOT configured, a single "SchemaBot" aggregate is
-// created that rolls up all per-database checks.
+// When allowed_environments is NOT configured, a single aggregate is created
+// that rolls up all per-database checks.
 //
 // Aggregate logic (first match wins):
 //   - ANY check "in_progress"     → aggregate status "in_progress"
@@ -119,6 +119,7 @@ func (h *Handler) updateAggregateCheck(ctx context.Context, client *ghclient.Ins
 	}
 
 	config := h.service.Config()
+	checkNameBase := h.aggregateCheckNameForRepo(repo)
 
 	if len(config.AllowedEnvironments) > 0 {
 		// Per-environment aggregates: create one aggregate per allowed environment.
@@ -129,13 +130,13 @@ func (h *Handler) updateAggregateCheck(ctx context.Context, client *ghclient.Ins
 			if len(envChecks) == 0 {
 				continue
 			}
-			checkName := aggregateCheckNameForEnv(env)
+			checkName := aggregateCheckNameForEnv(checkNameBase, env)
 			h.upsertAggregateCheckRun(ctx, client, repo, pr, headSHA, envChecks, checkName, env)
 		}
 	} else {
 		// Single aggregate. Uses aggregateSentinel for the environment field
 		// since there is no per-environment scoping.
-		h.upsertAggregateCheckRun(ctx, client, repo, pr, headSHA, dbChecks, aggregateCheckName, aggregateSentinel)
+		h.upsertAggregateCheckRun(ctx, client, repo, pr, headSHA, dbChecks, checkNameBase, aggregateSentinel)
 	}
 }
 
@@ -278,6 +279,7 @@ func (h *Handler) postPassingAggregates(ctx context.Context, client *ghclient.In
 	}
 
 	config := h.service.Config()
+	checkNameBase := h.aggregateCheckNameForRepo(repo)
 	storedChecks, err := h.service.Storage().Checks().GetByPR(ctx, repo, pr)
 	if err != nil {
 		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
@@ -298,13 +300,13 @@ func (h *Handler) postPassingAggregates(ctx context.Context, client *ghclient.In
 	if len(config.AllowedEnvironments) > 0 {
 		for _, env := range config.AllowedEnvironments {
 			checks = append(checks, envCheck{
-				name:        aggregateCheckNameForEnv(env),
+				name:        aggregateCheckNameForEnv(checkNameBase, env),
 				environment: env,
 			})
 		}
 	} else {
 		checks = append(checks, envCheck{
-			name:        aggregateCheckName,
+			name:        checkNameBase,
 			environment: aggregateSentinel,
 		})
 	}
@@ -453,6 +455,7 @@ func (h *Handler) postFailingAggregatesWithBlock(ctx context.Context, client *gh
 	}
 
 	config := h.service.Config()
+	checkNameBase := h.aggregateCheckNameForRepo(repo)
 
 	type envCheck struct {
 		name        string
@@ -464,14 +467,14 @@ func (h *Handler) postFailingAggregatesWithBlock(ctx context.Context, client *gh
 		for _, env := range config.AllowedEnvironments {
 			if _, hasError := errors[env]; hasError {
 				checks = append(checks, envCheck{
-					name:        aggregateCheckNameForEnv(env),
+					name:        aggregateCheckNameForEnv(checkNameBase, env),
 					environment: env,
 				})
 			}
 		}
 	} else {
 		checks = append(checks, envCheck{
-			name:        aggregateCheckName,
+			name:        checkNameBase,
 			environment: aggregateSentinel,
 		})
 	}

--- a/pkg/webhook/check_runs.go
+++ b/pkg/webhook/check_runs.go
@@ -2,6 +2,8 @@ package webhook
 
 import (
 	"time"
+
+	"github.com/block/schemabot/pkg/api"
 )
 
 // maxCheckRunTextLength is the GitHub API limit for check run output text.
@@ -22,11 +24,11 @@ const (
 	checkConclusionNeutral        = "neutral"
 )
 
-// aggregateCheckName is the GitHub Check Run name to require in branch protection.
+// aggregateCheckName is the default GitHub Check Run base name.
 // Per-database stored check state provides granular internal status per
 // environment and database; the aggregate rolls it into one visible conclusion so
-// branch protection only needs one stable name.
-const aggregateCheckName = "SchemaBot"
+// branch protection only needs one stable name per deployment.
+const aggregateCheckName = api.DefaultGitHubCheckName
 
 const (
 	// defaultPriorEnvCheckMaxAttempts bounds the apply gate wait for prior


### PR DESCRIPTION
## Why
Multiple independent SchemaBot deployments can publish checks on the same repository, so operators need a way to give each visible GitHub gate a distinct name without changing the default behavior.

## What
- Add an optional GitHub App `check-name` config with a `SchemaBot` default
- Use the configured base name for aggregate Check Runs and prior-environment lookups
- Document the branch protection implications for custom check names

## Risk Assessment
Low — this is opt-in configuration, and deployments without `check-name` keep publishing the existing `SchemaBot` checks.

Generated with Amp
