### PR TITLE
fix(cli): limit defer deploy to vitess applies

### DIFF
--- a/pkg/cmd/commands/apply.go
+++ b/pkg/cmd/commands/apply.go
@@ -104,6 +104,9 @@ func (cmd *ApplyCmd) Run(g *Globals) error {
 	if cmd.SkipRevert && planResult.Engine != "" && !state.IsPlanetScaleEngine(planResult.Engine) {
 		return fmt.Errorf("--skip-revert is only supported for Vitess/PlanetScale databases")
 	}
+	if cmd.DeferDeploy && planResult.Engine != "" && !state.IsPlanetScaleEngine(planResult.Engine) {
+		return fmt.Errorf("--defer-deploy is only supported for Vitess/PlanetScale databases")
+	}
 	if cmd.Branch != "" && planResult.Engine != "" && !state.IsPlanetScaleEngine(planResult.Engine) {
 		return fmt.Errorf("--branch is only supported for Vitess/PlanetScale databases")
 	}

--- a/pkg/cmd/commands/apply_test.go
+++ b/pkg/cmd/commands/apply_test.go
@@ -4,6 +4,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/block/schemabot/pkg/apitypes"
+	"github.com/block/schemabot/pkg/storage"
 )
 
 func TestBranchFlagValidation(t *testing.T) {
@@ -37,4 +41,65 @@ func TestBranchFlagValidation(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestBuildApplyOptionsDefersDeployOnlyForPlanetScale(t *testing.T) {
+	tests := []struct {
+		name         string
+		engine       string
+		deferDeploy  bool
+		watch        bool
+		format       OutputFormat
+		wantDeferred bool
+	}{
+		{
+			name:         "interactive PlanetScale apply defers deploy for review",
+			engine:       storage.EnginePlanetScale,
+			watch:        true,
+			format:       OutputFormatInteractive,
+			wantDeferred: true,
+		},
+		{
+			name:         "explicit PlanetScale defer deploy is preserved",
+			engine:       storage.EnginePlanetScale,
+			deferDeploy:  true,
+			format:       OutputFormatLog,
+			wantDeferred: true,
+		},
+		{
+			name:   "interactive MySQL apply does not show PlanetScale deploy controls",
+			engine: storage.EngineSpirit,
+			watch:  true,
+			format: OutputFormatInteractive,
+		},
+		{
+			name:        "explicit MySQL defer deploy is not sent",
+			engine:      storage.EngineSpirit,
+			deferDeploy: true,
+			format:      OutputFormatLog,
+		},
+		{
+			name:   "unknown engine does not auto defer deploy",
+			engine: "",
+			watch:  true,
+			format: OutputFormatInteractive,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			options := buildApplyOptions(&apitypes.PlanResponse{Engine: tt.engine}, false, tt.deferDeploy, false, "", tt.watch, tt.format)
+			_, gotDeferred := options["defer_deploy"]
+			assert.Equal(t, tt.wantDeferred, gotDeferred)
+		})
+	}
+}
+
+func TestBuildApplyOptionsPreservesOtherOptions(t *testing.T) {
+	options := buildApplyOptions(&apitypes.PlanResponse{Engine: storage.EnginePlanetScale}, true, true, true, "feature-branch", false, OutputFormatLog)
+
+	require.Equal(t, "true", options["defer_cutover"])
+	require.Equal(t, "true", options["defer_deploy"])
+	require.Equal(t, "true", options["skip_revert"])
+	require.Equal(t, "feature-branch", options["branch"])
 }

--- a/pkg/cmd/commands/common.go
+++ b/pkg/cmd/commands/common.go
@@ -18,6 +18,7 @@ import (
 	"github.com/block/schemabot/pkg/apitypes"
 	"github.com/block/schemabot/pkg/cmd/client"
 	ghclient "github.com/block/schemabot/pkg/github"
+	"github.com/block/schemabot/pkg/state"
 )
 
 // Globals holds flags shared by all commands.
@@ -259,21 +260,7 @@ func applyAndWatch(ep string, planResult *apitypes.PlanResponse, database, envir
 		return "", fmt.Errorf("no plan_id in response")
 	}
 
-	options := make(map[string]string)
-	if deferCutover {
-		options["defer_cutover"] = "true"
-	}
-	// TUI mode: defer deploy so the user can review the deploy request diff
-	// on PlanetScale before triggering. Non-interactive modes auto-deploy.
-	if deferDeploy || (watch && format == OutputFormatInteractive) {
-		options["defer_deploy"] = "true"
-	}
-	if skipRevert {
-		options["skip_revert"] = "true"
-	}
-	if branch != "" {
-		options["branch"] = branch
-	}
+	options := buildApplyOptions(planResult, deferCutover, deferDeploy, skipRevert, branch, watch, format)
 
 	applyResult, err := client.CallApplyAPI(ep, planResult.PlanID, environment, caller, options)
 	if err != nil {
@@ -315,6 +302,26 @@ func applyAndWatch(ep string, planResult *apitypes.PlanResponse, database, envir
 	}
 
 	return applyID, nil
+}
+
+func buildApplyOptions(planResult *apitypes.PlanResponse, deferCutover, deferDeploy, skipRevert bool, branch string, watch bool, format OutputFormat) map[string]string {
+	options := make(map[string]string)
+	isPlanetScale := planResult != nil && state.IsPlanetScaleEngine(planResult.Engine)
+	if deferCutover {
+		options["defer_cutover"] = "true"
+	}
+	// TUI mode: defer deploy so the user can review the deploy request diff
+	// on PlanetScale before triggering. Non-interactive modes auto-deploy.
+	if isPlanetScale && (deferDeploy || (watch && format == OutputFormatInteractive)) {
+		options["defer_deploy"] = "true"
+	}
+	if skipRevert {
+		options["skip_revert"] = "true"
+	}
+	if branch != "" {
+		options["branch"] = branch
+	}
+	return options
 }
 
 // printWatchInstructions prints the "To watch and manage" hint.


### PR DESCRIPTION
## Why
Interactive apply was surfacing deploy-request controls for engines that do not have a deploy request phase, which made MySQL applies look like they had a Vitess-only option enabled.

## What
- Only set `defer_deploy` automatically for Vitess applies
- Reject explicit `--defer-deploy` when the planned engine is not Vitess
- Add focused coverage for apply option generation

## Risk Assessment
Low — this narrows a CLI option to the engine that supports it and preserves existing Vitess behavior.

Generated with Amp
