### PR TITLE
fix(cli): compact apply completion output

### DIFF
--- a/pkg/cmd/commands/apply.go
+++ b/pkg/cmd/commands/apply.go
@@ -336,7 +336,7 @@ func WatchApplyProgressAfterCutover(endpoint, applyID string) error {
 				bar := ui.ProgressBarComplete()
 				fmt.Printf("%*s: %s ✓ Complete\n", maxTableNameLen, tbl.TableName, bar)
 			}
-			fmt.Printf("\n\n%s\n", templates.FormatApplyComplete())
+			fmt.Printf("\n\n%s\n", templates.FormatApplyCompleteWithSummary(countProgressResponseChanges(tables).summary(), applyID))
 			return nil
 		}
 

--- a/pkg/cmd/commands/common.go
+++ b/pkg/cmd/commands/common.go
@@ -325,3 +325,63 @@ func printWatchInstructions(applyID, database, environment string) {
 		fmt.Printf("To watch and manage: schemabot status -d %s -e %s\n", database, environment)
 	}
 }
+
+type applyChangeCounts struct {
+	created        int
+	altered        int
+	dropped        int
+	vschemaUpdates int
+}
+
+func countTableProgressChanges(tables []tableProgress) applyChangeCounts {
+	var counts applyChangeCounts
+	for _, table := range tables {
+		counts.add(table.ChangeType)
+	}
+	return counts
+}
+
+func countProgressResponseChanges(tables []*apitypes.TableProgressResponse) applyChangeCounts {
+	var counts applyChangeCounts
+	for _, table := range tables {
+		counts.add(table.ChangeType)
+	}
+	return counts
+}
+
+func (c *applyChangeCounts) add(changeType string) {
+	switch strings.ToUpper(changeType) {
+	case "CREATE", "CHANGE_TYPE_CREATE":
+		c.created++
+	case "ALTER", "CHANGE_TYPE_ALTER":
+		c.altered++
+	case "DROP", "CHANGE_TYPE_DROP":
+		c.dropped++
+	case "VSCHEMA", "VSCHEMA_UPDATE", "CHANGE_TYPE_VSCHEMA":
+		c.vschemaUpdates++
+	}
+}
+
+func (c applyChangeCounts) summary() string {
+	var parts []string
+	if c.created > 0 {
+		parts = append(parts, fmt.Sprintf("%d created", c.created))
+	}
+	if c.altered > 0 {
+		parts = append(parts, fmt.Sprintf("%d altered", c.altered))
+	}
+	if c.dropped > 0 {
+		parts = append(parts, fmt.Sprintf("%d dropped", c.dropped))
+	}
+	if c.vschemaUpdates > 0 {
+		word := "updates"
+		if c.vschemaUpdates == 1 {
+			word = "update"
+		}
+		parts = append(parts, fmt.Sprintf("%d VSchema %s", c.vschemaUpdates, word))
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return fmt.Sprintf("Changes: %s.", strings.Join(parts, ", "))
+}

--- a/pkg/cmd/commands/common_test.go
+++ b/pkg/cmd/commands/common_test.go
@@ -49,3 +49,27 @@ func TestLoadCLIConfig_RejectsDeployment(t *testing.T) {
 	assert.Nil(t, cfg)
 	assert.Contains(t, err.Error(), "field deployment not found")
 }
+
+func TestApplyChangeCountsSummary(t *testing.T) {
+	tables := []tableProgress{
+		{ChangeType: "CREATE"},
+		{ChangeType: "CHANGE_TYPE_CREATE"},
+		{ChangeType: "ALTER"},
+		{ChangeType: "DROP"},
+		{ChangeType: "DROP"},
+		{ChangeType: "VSCHEMA_UPDATE"},
+		{ChangeType: "CHANGE_TYPE_VSCHEMA"},
+	}
+
+	assert.Equal(t, "Changes: 2 created, 1 altered, 2 dropped, 2 VSchema updates.", countTableProgressChanges(tables).summary())
+}
+
+func TestApplyChangeCountsSummaryVSchemaOnly(t *testing.T) {
+	tables := []tableProgress{{ChangeType: "vschema_update"}}
+
+	assert.Equal(t, "Changes: 1 VSchema update.", countTableProgressChanges(tables).summary())
+}
+
+func TestApplyChangeCountsSummaryEmpty(t *testing.T) {
+	assert.Empty(t, countTableProgressChanges(nil).summary())
+}

--- a/pkg/cmd/commands/watch_tui.go
+++ b/pkg/cmd/commands/watch_tui.go
@@ -411,8 +411,11 @@ func runWatchModel(model WatchModel) (err error) {
 
 	m := finalModel.(WatchModel)
 
-	// Always print apply context on exit so operators can resume monitoring.
-	printExitContext(m.applyID, m.deployRequestURL, m.database, m.environment)
+	// Completed applies render their apply ID in the success line. Other exits
+	// need explicit context so operators can resume monitoring or investigate.
+	if !state.IsState(m.state, state.Apply.Completed) {
+		printExitContext(m.applyID, m.deployRequestURL, m.database, m.environment)
+	}
 
 	// The TUI view already displays errors inline, so return ErrSilent
 	// to exit with code 1 without printing the error again.

--- a/pkg/cmd/commands/watch_tui_test.go
+++ b/pkg/cmd/commands/watch_tui_test.go
@@ -83,6 +83,26 @@ func TestWatchModel_FirstPollRetryableError_ShowsLoadingWithError(t *testing.T) 
 	assert.Nil(t, retCmd, "retryable error should return nil cmd (tick loop handles retry)")
 }
 
+func TestWatchModel_CompletedViewShowsCompactSummary(t *testing.T) {
+	m := NewWatchModel("http://localhost:8080", "testdb", "staging", false)
+	m.applyID = "apply-abc123"
+	m.state = state.Apply.Completed
+	m.initialized = true
+	m.tables = []tableProgress{
+		{Name: "users", ChangeType: "CREATE"},
+		{Name: "orders", ChangeType: "CREATE"},
+		{Name: "products", ChangeType: "CREATE"},
+		{Name: "audit_events", ChangeType: "CREATE"},
+		{Name: "legacy_orders", ChangeType: "DROP"},
+		{Name: "VSchema: commerce", ChangeType: "vschema_update"},
+	}
+
+	view := m.View()
+	assert.Contains(t, view, "✓ Apply complete!")
+	assert.Contains(t, view, "Changes: 4 created, 1 dropped, 1 VSchema update. Apply ID: apply-abc123")
+	assert.NotContains(t, view, "Resume:")
+}
+
 func TestWatchModel_FirstPollPermanentError_QuitsWithError(t *testing.T) {
 	// First poll fails with a permanent error (not found).
 	// TUI should show the error and quit.

--- a/pkg/cmd/commands/watch_tui_view.go
+++ b/pkg/cmd/commands/watch_tui_view.go
@@ -131,7 +131,7 @@ func (m WatchModel) progressView() string {
 	switch {
 	case state.IsState(m.state, state.Apply.Completed):
 		b.WriteString("\n\n")
-		b.WriteString(templates.FormatApplyComplete())
+		b.WriteString(templates.FormatApplyCompleteWithSummary(countTableProgressChanges(m.tables).summary(), m.applyID))
 		b.WriteString("\n")
 	case state.IsState(m.state, state.Apply.Failed):
 		b.WriteString("\n\n")

--- a/pkg/cmd/internal/templates/progress_render.go
+++ b/pkg/cmd/internal/templates/progress_render.go
@@ -165,6 +165,17 @@ func FormatApplyComplete() string {
 	return fmt.Sprintf("%s%s✓ Apply complete!%s", ANSIBold, ANSIGreen, ANSIReset)
 }
 
+func FormatApplyCompleteWithSummary(summary, applyID string) string {
+	msg := FormatApplyComplete()
+	if summary != "" {
+		msg = fmt.Sprintf("%s %s", msg, summary)
+	}
+	if applyID == "" {
+		return msg
+	}
+	return fmt.Sprintf("%s Apply ID: %s", msg, applyID)
+}
+
 // FormatApplyFailed returns the styled "Apply failed" message with recovery guidance.
 func FormatApplyFailed() string {
 	return fmt.Sprintf("%s%s✗ Apply failed%s\n\nFix the issue above, then run a new apply.\nThe new apply will only process tables that haven't completed.", ANSIBold, ANSIRed, ANSIReset)


### PR DESCRIPTION
## Why
Completed applies printed both a success message and follow-up resume context, which made the final CLI output noisier than necessary after the schema change had already finished.

## What
- Render successful applies as a single compact completion line with change counts and the apply ID
- Include Vitess VSchema updates in the final change summary, including VSchema-only applies
- Keep resume/watch context for non-completed exits where operators still need a recovery command
- Add focused coverage for the completion summary and change-count formatting

Sample outputs:
```
✓ Apply complete! Changes: 4 created, 1 altered, 1 dropped. Apply ID: apply-abc123
✓ Apply complete! Changes: 1 VSchema update. Apply ID: apply-abc123
```

## Risk Assessment
Low — this only changes successful CLI rendering and preserves the existing recovery context for incomplete, failed, stopped, or detached flows.

Generated with Amp
