### PR TITLE
fix(github): support force-unlocking CLI locks from PRs

### DIFF
--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -977,7 +977,7 @@ A CLI session currently holds the lock for this database.
 
 Ask the lock holder to run `schemabot unlock` from their CLI, or force-unlock with:
 ```
-schemabot unlock -d testapp -e staging --force
+schemabot unlock -d testapp --force
 ```
 
 </details>
@@ -4022,7 +4022,7 @@ A CLI session currently holds the lock for this database.
 
 Ask the lock holder to run `schemabot unlock` from their CLI, or force-unlock with:
 ```
-schemabot unlock -d testapp -e staging --force
+schemabot unlock -d testapp --force
 ```
 
 
@@ -4768,21 +4768,21 @@ The following changes will permanently delete data:
 === Exit Context: MySQL Detach ===
 
   Apply ID:  apply-8487c4ad
-  Resume:    schemabot progress --apply-id apply-8487c4ad -e staging
+  Resume:    schemabot progress apply-8487c4ad -e staging
 
 
 === Exit Context: Vitess Detach ===
 
   Apply ID:  apply-9849818a9cec4ba7
   Deploy Request:  https://app.planetscale.com/square-production/inventory2/deploy-requests/109
-  Resume:    schemabot progress --apply-id apply-9849818a9cec4ba7 -e production
+  Resume:    schemabot progress apply-9849818a9cec4ba7 -e production
 
 
 === Exit Context: MySQL Connection Lost ===
 Error: unexpected error: connection refused
 
   Apply ID:  apply-8487c4ad
-  Resume:    schemabot progress --apply-id apply-8487c4ad -e staging
+  Resume:    schemabot progress apply-8487c4ad -e staging
 
 
 === Exit Context: Vitess Connection Lost ===
@@ -4790,6 +4790,6 @@ Error: unexpected error: connection refused
 
   Apply ID:  apply-9849818a9cec4ba7
   Deploy Request:  https://app.planetscale.com/square-production/inventory2/deploy-requests/109
-  Resume:    schemabot progress --apply-id apply-9849818a9cec4ba7 -e production
+  Resume:    schemabot progress apply-9849818a9cec4ba7 -e production
 
 

--- a/pkg/webhook/apply_e2e_test.go
+++ b/pkg/webhook/apply_e2e_test.go
@@ -5,6 +5,7 @@ package webhook
 import (
 	"context"
 	"database/sql"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -361,6 +362,98 @@ func TestE2EUnlock(t *testing.T) {
 	case <-time.After(10 * time.Second):
 		t.Fatal("timed out waiting for check run")
 	}
+}
+
+func TestE2EUnlockForceInfersDatabaseForCLILock(t *testing.T) {
+	dbName := "webhook_unlock_cli"
+	svc := setupE2EService(t, dbName)
+
+	// Seed the production symptom: a local CLI session owns the database lock, so
+	// the normal PR-scoped unlock lookup cannot find it by repository/PR.
+	err := svc.Storage().Locks().Acquire(t.Context(), &storage.Lock{
+		DatabaseName: dbName,
+		DatabaseType: "mysql",
+		Owner:        "cli:testuser@example.local",
+	})
+	require.NoError(t, err)
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	client := gh.NewClient(nil)
+	client.BaseURL, _ = url.Parse(server.URL + "/")
+
+	mux.HandleFunc("GET /repos/octocat/hello-world/pulls/1", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(gh.PullRequest{
+			Head: &gh.PullRequestBranch{
+				Ref: new("feature-branch"),
+				SHA: new("abc123"),
+			},
+			Base: &gh.PullRequestBranch{
+				Ref: new("main"),
+				SHA: new("def456"),
+			},
+			User: &gh.User{Login: new("testuser")},
+		})
+	})
+	mux.HandleFunc("GET /repos/octocat/hello-world/pulls/1/files", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode([]map[string]string{{
+			"filename": "schemabot.yaml",
+			"status":   "modified",
+		}})
+	})
+	mux.HandleFunc("GET /repos/octocat/hello-world/contents/schemabot.yaml", func(w http.ResponseWriter, _ *http.Request) {
+		content := fmt.Sprintf("database: %s\ntype: mysql\nenvironments:\n  - staging\n", dbName)
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"type":     "file",
+			"encoding": "base64",
+			"content":  base64.StdEncoding.EncodeToString([]byte(content)),
+		})
+	})
+
+	comments := make(chan string, 10)
+	mux.HandleFunc("POST /repos/octocat/hello-world/issues/1/comments", func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Body string `json:"body"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		comments <- body.Body
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": 99})
+	})
+	mux.HandleFunc("POST /repos/octocat/hello-world/issues/comments/42/reactions", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": 1})
+	})
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	installClient := ghclient.NewInstallationClient(client, logger)
+	factory := &fakeClientFactory{client: installClient}
+	h := NewHandler(svc, factory, nil, logger)
+
+	req := buildWebhookRequest(t, webhookPayloadOpts{
+		comment: "schemabot unlock --force",
+		isPR:    true,
+	}, nil)
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), "unlock started")
+
+	select {
+	case body := <-comments:
+		assert.Contains(t, body, "Lock Released")
+		assert.Contains(t, body, dbName)
+	case <-time.After(30 * time.Second):
+		t.Fatal("timed out waiting for unlock comment")
+	}
+
+	lock, err := svc.Storage().Locks().Get(t.Context(), dbName, "mysql")
+	require.NoError(t, err)
+	assert.Nil(t, lock, "expected CLI-owned lock to be force released")
 }
 
 // TestE2EUnlockDoesNotPassAggregateWithPendingChanges verifies that releasing

--- a/pkg/webhook/apply_handlers.go
+++ b/pkg/webhook/apply_handlers.go
@@ -1,11 +1,13 @@
 package webhook
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"time"
 
 	"github.com/block/schemabot/pkg/api"
+	ghclient "github.com/block/schemabot/pkg/github"
 	"github.com/block/schemabot/pkg/state"
 	"github.com/block/schemabot/pkg/storage"
 	"github.com/block/schemabot/pkg/webhook/action"
@@ -457,15 +459,27 @@ func (h *Handler) handleApplyConfirmCommand(repo string, pr int, environment, da
 }
 
 // handleUnlockCommand handles the "schemabot unlock" PR comment command.
-// It finds all locks held by this PR and releases them.
-func (h *Handler) handleUnlockCommand(repo string, pr int, installationID int64, requestedBy string) {
+// By default it finds all locks held by this PR and releases them. With
+// `--force`, it can also release a CLI-owned lock for the database inferred
+// from this PR's SchemaBot config; `-d <database>` disambiguates multi-database
+// PRs. This lets a PR author clear a stale local-session lock from the PR
+// workflow that it is blocking.
+func (h *Handler) handleUnlockCommand(repo string, pr int, installationID int64, requestedBy string, result CommandResult) {
 	ctx, cancel := h.commandContext(30 * time.Second)
 	defer cancel()
+	if result.Force && result.Database == "" {
+		database, err := h.inferUnlockDatabase(ctx, repo, pr, installationID)
+		if err != nil {
+			h.logger.Error("failed to infer database for force unlock", "repo", repo, "pr", pr, "error", err)
+			h.postCommandError(repo, pr, installationID, action.Unlock, "", requestedBy, "Failed to infer database for force unlock: "+err.Error())
+			return
+		}
+		result.Database = database
+	}
 
-	// Find locks held by this PR
-	locks, err := h.service.Storage().Locks().GetByPR(ctx, repo, pr)
+	locks, err := h.locksForUnlock(ctx, repo, pr, result)
 	if err != nil {
-		h.logger.Error("failed to look up locks", "repo", repo, "pr", pr, "error", err)
+		h.logger.Error("failed to look up unlock targets", "repo", repo, "pr", pr, "database", result.Database, "force", result.Force, "error", err)
 		h.postCommandError(repo, pr, installationID, action.Unlock, "", requestedBy, "Failed to look up locks: "+err.Error())
 		return
 	}
@@ -476,11 +490,13 @@ func (h *Handler) handleUnlockCommand(repo string, pr int, installationID int64,
 		return
 	}
 
-	// Check for active applies on any locked database
+	// Check for active applies on any locked database. Even force-unlock should
+	// not break a lock while SchemaBot still has a non-terminal apply recorded
+	// for the same database/type.
 	for _, lock := range locks {
-		applies, err := h.service.Storage().Applies().GetByPR(ctx, repo, pr)
+		applies, err := h.service.Storage().Applies().GetByDatabase(ctx, lock.DatabaseName, lock.DatabaseType, "")
 		if err != nil {
-			h.logger.Error("failed to check active applies", "error", err)
+			h.logger.Error("failed to check active applies", "database", lock.DatabaseName, "database_type", lock.DatabaseType, "error", err)
 			continue
 		}
 		for _, a := range applies {
@@ -494,7 +510,13 @@ func (h *Handler) handleUnlockCommand(repo string, pr int, installationID int64,
 
 	// Release all locks
 	for _, lock := range locks {
-		if err := h.service.Storage().Locks().ForceRelease(ctx, lock.DatabaseName, lock.DatabaseType); err != nil {
+		var err error
+		if result.Force {
+			err = h.service.Storage().Locks().ForceRelease(ctx, lock.DatabaseName, lock.DatabaseType)
+		} else {
+			err = h.service.Storage().Locks().Release(ctx, lock.DatabaseName, lock.DatabaseType, lock.Owner)
+		}
+		if err != nil {
 			h.logger.Error("failed to release lock", "database", lock.DatabaseName, "error", err)
 			continue
 		}
@@ -502,7 +524,73 @@ func (h *Handler) handleUnlockCommand(repo string, pr int, installationID int64,
 		h.postComment(repo, pr, installationID, templates.RenderUnlockSuccess(
 			lock.DatabaseName, "", requestedBy))
 
-		// Update check run to neutral
-		h.updateCheckRunAfterUnlock(ctx, repo, pr, lock, installationID)
+		// Update check run to neutral for PR-owned locks. CLI-owned locks have no
+		// associated PR check record to update.
+		if lock.Repository != "" && lock.PullRequest != 0 {
+			h.updateCheckRunAfterUnlock(ctx, repo, pr, lock, installationID)
+		}
 	}
+}
+
+func (h *Handler) locksForUnlock(ctx context.Context, repo string, pr int, result CommandResult) ([]*storage.Lock, error) {
+	if result.Force {
+		if result.Database == "" {
+			return nil, fmt.Errorf("--force requires a database target")
+		}
+
+		locks, err := h.service.Storage().Locks().List(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		var matches []*storage.Lock
+		for _, lock := range locks {
+			if lock.DatabaseName != result.Database {
+				continue
+			}
+			if lock.PullRequest != 0 && (lock.Repository != repo || lock.PullRequest != pr) {
+				return nil, fmt.Errorf("lock for %s is held by %s#%d", result.Database, lock.Repository, lock.PullRequest)
+			}
+			matches = append(matches, lock)
+		}
+		return matches, nil
+	}
+
+	locks, err := h.service.Storage().Locks().GetByPR(ctx, repo, pr)
+	if err != nil {
+		return nil, err
+	}
+	if result.Database == "" {
+		return locks, nil
+	}
+
+	filtered := locks[:0]
+	for _, lock := range locks {
+		if lock.DatabaseName == result.Database {
+			filtered = append(filtered, lock)
+		}
+	}
+	return filtered, nil
+}
+
+func (h *Handler) inferUnlockDatabase(ctx context.Context, repo string, pr int, installationID int64) (string, error) {
+	client, err := h.clientForRepo(repo, installationID)
+	if err != nil {
+		return "", err
+	}
+
+	config, _, err := client.FindConfigForPR(ctx, repo, pr)
+	if errors.Is(err, ghclient.ErrNoConfig) {
+		config, _, _, err = client.FindConfigInRepo(ctx, repo, pr)
+	}
+	if err != nil {
+		if errors.Is(err, ghclient.ErrMultipleConfigs) {
+			return "", fmt.Errorf("multiple SchemaBot configs match this PR; retry with `schemabot unlock -d <database> --force`: %w", err)
+		}
+		return "", err
+	}
+	if config == nil || config.Database == "" {
+		return "", fmt.Errorf("no database found in SchemaBot config")
+	}
+	return config.Database, nil
 }

--- a/pkg/webhook/commands.go
+++ b/pkg/webhook/commands.go
@@ -45,6 +45,9 @@ type CommandSpec struct {
 
 	// SupportsAllowUnsafe means `--allow-unsafe` is recognized.
 	SupportsAllowUnsafe bool
+
+	// SupportsForce means `--force` is recognized.
+	SupportsForce bool
 }
 
 // commandSpecs is the registry of all SchemaBot commands. Order does not
@@ -59,7 +62,7 @@ var commandSpecs = []CommandSpec{
 		SupportsAllowUnsafe: true, SupportsAutoConfirm: true},
 	{Name: action.ApplyConfirm, RequiresEnv: true, SupportsDB: true,
 		SupportsSkipRevert: true, SupportsDeferCutover: true, SupportsAllowUnsafe: true},
-	{Name: action.Unlock},
+	{Name: action.Unlock, SupportsDB: true, SupportsForce: true},
 	{Name: action.FixLint, SupportsDB: true},
 	{Name: action.Stop, RequiresEnv: true, HasApplyID: true},
 	{Name: action.Revert, RequiresEnv: true},
@@ -102,6 +105,7 @@ type CommandParser struct {
 	skipRevertRegex   *regexp.Regexp
 	deferCutoverRegex *regexp.Regexp
 	allowUnsafeRegex  *regexp.Regexp
+	forceRegex        *regexp.Regexp
 	autoConfirmRegex  *regexp.Regexp
 }
 
@@ -117,6 +121,7 @@ func NewCommandParser() *CommandParser {
 		skipRevertRegex:   regexp.MustCompile(`(?i)--skip-revert\b`),
 		deferCutoverRegex: regexp.MustCompile(`(?i)--defer-cutover\b`),
 		allowUnsafeRegex:  regexp.MustCompile(`(?i)--allow-unsafe\b`),
+		forceRegex:        regexp.MustCompile(`(?i)--force\b`),
 		autoConfirmRegex:  regexp.MustCompile(`(?i)(?:--yes\b|-y\b)`),
 	}
 }
@@ -130,6 +135,7 @@ type CommandResult struct {
 	SkipRevert   bool
 	DeferCutover bool
 	AllowUnsafe  bool
+	Force        bool
 	AutoConfirm  bool
 	Found        bool
 	IsHelp       bool
@@ -221,6 +227,9 @@ func (p *CommandParser) applySpec(spec CommandSpec, body string) CommandResult {
 	}
 	if spec.SupportsAllowUnsafe {
 		result.AllowUnsafe = p.allowUnsafeRegex.MatchString(body)
+	}
+	if spec.SupportsForce {
+		result.Force = p.forceRegex.MatchString(body)
 	}
 	if spec.SupportsAutoConfirm {
 		result.AutoConfirm = p.autoConfirmRegex.MatchString(body)

--- a/pkg/webhook/commands_test.go
+++ b/pkg/webhook/commands_test.go
@@ -45,6 +45,7 @@ func TestCommandSpecs_FlagsRespected(t *testing.T) {
 		supportsSkipRevert  bool
 		supportsDefer       bool
 		supportsAllowUnsafe bool
+		supportsForce       bool
 	}{
 		{name: action.Help},
 		{name: action.Plan, requiresEnv: true, supportsDB: true},
@@ -53,7 +54,7 @@ func TestCommandSpecs_FlagsRespected(t *testing.T) {
 			supportsDefer: true, supportsAllowUnsafe: true},
 		{name: action.ApplyConfirm, requiresEnv: true, supportsDB: true,
 			supportsSkipRevert: true, supportsDefer: true, supportsAllowUnsafe: true},
-		{name: action.Unlock},
+		{name: action.Unlock, supportsDB: true, supportsForce: true},
 		{name: action.FixLint, supportsDB: true},
 		{name: action.Stop, requiresEnv: true, hasApplyID: true},
 		{name: action.Revert, requiresEnv: true},
@@ -74,6 +75,7 @@ func TestCommandSpecs_FlagsRespected(t *testing.T) {
 			assert.Equal(t, tc.supportsSkipRevert, spec.SupportsSkipRevert, "SupportsSkipRevert")
 			assert.Equal(t, tc.supportsDefer, spec.SupportsDeferCutover, "SupportsDeferCutover")
 			assert.Equal(t, tc.supportsAllowUnsafe, spec.SupportsAllowUnsafe, "SupportsAllowUnsafe")
+			assert.Equal(t, tc.supportsForce, spec.SupportsForce, "SupportsForce")
 		})
 	}
 }
@@ -161,6 +163,17 @@ func TestParseCommand(t *testing.T) {
 			body: "schemabot unlock",
 			expected: CommandResult{
 				Action:    "unlock",
+				Found:     true,
+				IsMention: true,
+			},
+		},
+		{
+			name: "unlock with database and force",
+			body: "schemabot unlock -d example-db --force",
+			expected: CommandResult{
+				Action:    "unlock",
+				Database:  "example-db",
+				Force:     true,
 				Found:     true,
 				IsMention: true,
 			},

--- a/pkg/webhook/issue_comment.go
+++ b/pkg/webhook/issue_comment.go
@@ -214,7 +214,7 @@ func (h *Handler) handleIssueComment(w http.ResponseWriter, body []byte) {
 		h.writeJSON(w, http.StatusOK, map[string]string{"message": "apply-confirm started"})
 	case action.Unlock:
 		h.goSafe(repo, pr, installationID, func() {
-			h.handleUnlockCommand(repo, pr, installationID, requestedBy)
+			h.handleUnlockCommand(repo, pr, installationID, requestedBy, result)
 		})
 		h.writeJSON(w, http.StatusOK, map[string]string{"message": "unlock started"})
 	case action.Rollback:

--- a/pkg/webhook/prinfocache_dedup_e2e_test.go
+++ b/pkg/webhook/prinfocache_dedup_e2e_test.go
@@ -19,6 +19,7 @@ import (
 
 	ghclient "github.com/block/schemabot/pkg/github"
 	"github.com/block/schemabot/pkg/storage"
+	"github.com/block/schemabot/pkg/webhook/action"
 )
 
 // prFetchCountingTransport counts GET /repos/octocat/hello-world/pulls/1
@@ -96,7 +97,7 @@ func TestUnlockHandlerDedupesPRFetchAcrossLocks(t *testing.T) {
 	// Call the handler entry point synchronously so every fan-out into
 	// updateCheckRunAfterUnlock resolves within the same WithPRInfoCache
 	// scope before the test asserts.
-	h.handleUnlockCommand("octocat/hello-world", 1, 12345, "testuser")
+	h.handleUnlockCommand("octocat/hello-world", 1, 12345, "testuser", CommandResult{Action: action.Unlock})
 
 	for _, db := range []string{dbA, dbB} {
 		l, err := svc.Storage().Locks().Get(t.Context(), db, "mysql")

--- a/pkg/webhook/templates/apply_commands.go
+++ b/pkg/webhook/templates/apply_commands.go
@@ -191,7 +191,7 @@ func RenderApplyBlockedByOtherPR(data ApplyLockConflictData) string {
 
 	if isCLI {
 		sb.WriteString("Ask the lock holder to run `schemabot unlock` from their CLI, or force-unlock with:\n")
-		fmt.Fprintf(&sb, "```\nschemabot unlock -d %s -e %s --force\n```\n", data.Database, data.Environment)
+		fmt.Fprintf(&sb, "```\nschemabot unlock -d %s --force\n```\n", data.Database)
 	} else {
 		sb.WriteString("Wait for the other PR to complete or ask the lock holder to run `schemabot unlock`.\n")
 	}

--- a/pkg/webhook/templates/apply_test.go
+++ b/pkg/webhook/templates/apply_test.go
@@ -4,12 +4,25 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/block/schemabot/pkg/apitypes"
 	"github.com/block/schemabot/pkg/state"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestRenderApplyBlockedByCLILockUsesValidUnlockCommand(t *testing.T) {
+	rendered := RenderApplyBlockedByOtherPR(ApplyLockConflictData{
+		Database:    "example-db",
+		Environment: "staging",
+		LockOwner:   "cli:testuser@example.local",
+		LockCreated: time.Date(2026, 6, 4, 12, 0, 0, 0, time.UTC),
+	})
+
+	assert.Contains(t, rendered, "schemabot unlock -d example-db --force")
+	assert.NotContains(t, rendered, "schemabot unlock -d example-db -e staging --force")
+}
 
 func TestRenderApplyStatusComment_Running(t *testing.T) {
 	data := ApplyStatusCommentData{


### PR DESCRIPTION
## Why
A PR comment unlock should be able to recover from a stale CLI-owned database lock that is blocking the PR workflow.

## What
- Parse `--force` and `-d` for PR comment unlock commands
- Infer the target database for `schemabot unlock --force` when the PR has one matching SchemaBot config
- Preserve safe behavior for ambiguous or other-PR-owned locks
- Fix the lock conflict hint so it shows valid unlock CLI syntax

## Risk Assessment
Low — scoped to PR comment unlock handling and lock-conflict messaging. Normal PR-owned unlock behavior is preserved, and force unlock still targets a specific inferred or explicit database.

## Validation
- `go test ./pkg/webhook -run 'Test(CommandSpecs|ParseCommand)'`
- `go test ./pkg/webhook/templates -run 'TestRenderApplyBlockedByCLILockUsesValidUnlockCommand'`
- `go test -tags=integration ./pkg/webhook -run 'TestE2EUnlockForceInfersDatabaseForCLILock' -count=1`
- `git diff --check`

Generated with Amp
