### PR TITLE
fix(vitess): recover late migration context

### DIFF
--- a/pkg/engine/planetscale/apply.go
+++ b/pkg/engine/planetscale/apply.go
@@ -422,7 +422,7 @@ func (e *Engine) Apply(ctx context.Context, req *engine.ApplyRequest) (*engine.A
 	// immediately after the deploy request is submitted.
 	var migrationContext string
 	for attempt := range 10 {
-		migrationContext = e.discoverMigrationContext(ctx, client, req.Database, req.Credentials, existingContexts)
+		migrationContext = e.discoverMigrationContext(ctx, client, req.Database, req.Credentials, existingContexts, dr.CreatedAt)
 		if migrationContext != "" {
 			break
 		}

--- a/pkg/engine/planetscale/apply.go
+++ b/pkg/engine/planetscale/apply.go
@@ -250,9 +250,10 @@ func (e *Engine) Apply(ctx context.Context, req *engine.ApplyRequest) (*engine.A
 		NewState: state.Apply.ValidatingDeployRequest,
 	})
 	persistState(&psMetadata{
-		BranchName:       branchName,
-		DeployRequestID:  dr.Number,
-		DeployRequestURL: dr.HtmlURL,
+		BranchName:            branchName,
+		DeployRequestID:       dr.Number,
+		DeployRequestURL:      dr.HtmlURL,
+		ExistingMigrationCtxs: existingContexts,
 	})
 	for dr.DeploymentState == deployState.Pending {
 		select {
@@ -349,11 +350,12 @@ func (e *Engine) Apply(ctx context.Context, req *engine.ApplyRequest) (*engine.A
 			"instant_eligible", useInstant,
 		)
 		meta, encErr := encodePSMetadata(&psMetadata{
-			BranchName:       branchName,
-			DeployRequestID:  dr.Number,
-			DeployRequestURL: dr.HtmlURL,
-			IsInstant:        useInstant,
-			DeferredDeploy:   true,
+			BranchName:            branchName,
+			DeployRequestID:       dr.Number,
+			DeployRequestURL:      dr.HtmlURL,
+			ExistingMigrationCtxs: existingContexts,
+			IsInstant:             useInstant,
+			DeferredDeploy:        true,
 		})
 		if encErr != nil {
 			return nil, fmt.Errorf("encode metadata for deferred deploy request #%d: %w", dr.Number, encErr)
@@ -430,10 +432,11 @@ func (e *Engine) Apply(ctx context.Context, req *engine.ApplyRequest) (*engine.A
 	}
 
 	meta, err := encodePSMetadata(&psMetadata{
-		BranchName:       branchName,
-		DeployRequestID:  dr.Number,
-		DeployRequestURL: dr.HtmlURL,
-		IsInstant:        useInstant,
+		BranchName:            branchName,
+		DeployRequestID:       dr.Number,
+		DeployRequestURL:      dr.HtmlURL,
+		ExistingMigrationCtxs: existingContexts,
+		IsInstant:             useInstant,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("encode metadata for deploy request #%d: %w", dr.Number, err)

--- a/pkg/engine/planetscale/planetscale.go
+++ b/pkg/engine/planetscale/planetscale.go
@@ -444,24 +444,35 @@ func formatDeployRequestError(dr *ps.DeployRequest) string {
 
 // psMetadata holds PlanetScale-specific state stored as JSON in ResumeState.Metadata.
 type psMetadata struct {
-	BranchName       string     `json:"branch_name"`
-	DeployRequestID  uint64     `json:"deploy_request_id"`
-	DeployRequestURL string     `json:"deploy_request_url,omitempty"`
-	DeployedAt       *time.Time `json:"deployed_at,omitempty"`
-	IsInstant        bool       `json:"is_instant,omitempty"`
-	DeferredDeploy   bool       `json:"deferred_deploy,omitempty"`
+	BranchName            string                                `json:"branch_name"`
+	DeployRequestID       uint64                                `json:"deploy_request_id"`
+	DeployRequestURL      string                                `json:"deploy_request_url,omitempty"`
+	ExistingMigrationCtxs map[string]MigrationContextTimestamps `json:"existing_migration_contexts,omitempty"`
+	DeployedAt            *time.Time                            `json:"deployed_at,omitempty"`
+	IsInstant             bool                                  `json:"is_instant,omitempty"`
+	DeferredDeploy        bool                                  `json:"deferred_deploy,omitempty"`
+}
+
+// MigrationContextTimestamps records Vitess timestamp fields seen on an existing
+// SHOW VITESS_MIGRATIONS context before a deploy starts. The keys of the parent
+// map are used for context membership; these values are diagnostic for operators.
+type MigrationContextTimestamps struct {
+	RequestedTimestamp string `json:"requested_timestamp,omitempty"`
+	StartedTimestamp   string `json:"started_timestamp,omitempty"`
+	CompletedTimestamp string `json:"completed_timestamp,omitempty"`
 }
 
 // ResumeData is PlanetScale deploy metadata persisted by the tern layer and
 // encoded into engine.ResumeState.Metadata for engine control and progress calls.
 type ResumeData struct {
-	BranchName       string
-	DeployRequestID  uint64
-	DeployRequestURL string
-	MigrationContext string
-	DeployedAt       *time.Time
-	IsInstant        bool
-	DeferredDeploy   bool
+	BranchName            string
+	DeployRequestID       uint64
+	DeployRequestURL      string
+	MigrationContext      string
+	ExistingMigrationCtxs map[string]MigrationContextTimestamps
+	DeployedAt            *time.Time
+	IsInstant             bool
+	DeferredDeploy        bool
 }
 
 // BuildResumeState encodes PlanetScale resume metadata into the opaque
@@ -469,12 +480,13 @@ type ResumeData struct {
 // can persist branch information before the deploy request exists.
 func BuildResumeState(data ResumeData) (*engine.ResumeState, error) {
 	metadata, err := encodePSMetadata(&psMetadata{
-		BranchName:       data.BranchName,
-		DeployRequestID:  data.DeployRequestID,
-		DeployRequestURL: data.DeployRequestURL,
-		DeployedAt:       data.DeployedAt,
-		IsInstant:        data.IsInstant,
-		DeferredDeploy:   data.DeferredDeploy,
+		BranchName:            data.BranchName,
+		DeployRequestID:       data.DeployRequestID,
+		DeployRequestURL:      data.DeployRequestURL,
+		ExistingMigrationCtxs: data.ExistingMigrationCtxs,
+		DeployedAt:            data.DeployedAt,
+		IsInstant:             data.IsInstant,
+		DeferredDeploy:        data.DeferredDeploy,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/engine/planetscale/planetscale_test.go
+++ b/pkg/engine/planetscale/planetscale_test.go
@@ -130,6 +130,13 @@ func TestPSMetadataEncodeDecode(t *testing.T) {
 		BranchName:       "schemabot-mydb-12345678",
 		DeployRequestID:  42,
 		DeployRequestURL: "https://app.planetscale.com/org/db/deploy-requests/42",
+		ExistingMigrationCtxs: map[string]MigrationContextTimestamps{
+			"ctx-1": {
+				RequestedTimestamp: "2026-06-04T20:00:00Z",
+				StartedTimestamp:   "2026-06-04T20:01:00Z",
+				CompletedTimestamp: "2026-06-04T20:02:00Z",
+			},
+		},
 	}
 
 	encoded, err := encodePSMetadata(original)
@@ -142,6 +149,7 @@ func TestPSMetadataEncodeDecode(t *testing.T) {
 	assert.Equal(t, original.BranchName, decoded.BranchName)
 	assert.Equal(t, original.DeployRequestID, decoded.DeployRequestID)
 	assert.Equal(t, original.DeployRequestURL, decoded.DeployRequestURL)
+	assert.Equal(t, original.ExistingMigrationCtxs, decoded.ExistingMigrationCtxs)
 }
 
 func TestPSMetadataEncodeDecode_DeferredDeploy(t *testing.T) {

--- a/pkg/engine/planetscale/progress.go
+++ b/pkg/engine/planetscale/progress.go
@@ -81,7 +81,7 @@ func (e *Engine) Progress(ctx context.Context, req *engine.ProgressRequest) (*en
 		}
 	}
 	if req.ResumeState.MigrationContext == "" && len(meta.ExistingMigrationCtxs) > 0 {
-		migrationContext := e.discoverMigrationContext(ctx, client, req.Database, req.Credentials, meta.ExistingMigrationCtxs)
+		migrationContext := e.discoverMigrationContext(ctx, client, req.Database, req.Credentials, meta.ExistingMigrationCtxs, dr.CreatedAt)
 		if migrationContext != "" {
 			req.ResumeState = &engine.ResumeState{
 				MigrationContext: migrationContext,
@@ -202,13 +202,13 @@ func formatMigrationTimestamp(ts *time.Time) string {
 
 // discoverMigrationContext finds the new migration_context that appeared after
 // deploying by comparing current contexts against the pre-deploy baseline.
-func (e *Engine) discoverMigrationContext(ctx context.Context, client psclient.PSClient, database string, creds *engine.Credentials, existingContexts map[string]MigrationContextTimestamps) string {
+func (e *Engine) discoverMigrationContext(ctx context.Context, client psclient.PSClient, database string, creds *engine.Credentials, existingContexts map[string]MigrationContextTimestamps, deployCreatedAt time.Time) string {
 	if creds.DSN == "" {
 		e.logger.Debug("skipping schema change context discovery, no DSN configured")
 		return ""
 	}
 
-	e.logger.Info("discovering schema change context", "database", database, "baseline_count", len(existingContexts))
+	e.logger.Info("discovering schema change context", "database", database, "baseline_count", len(existingContexts), "deploy_created_at", deployCreatedAt)
 
 	branch := mainBranch(creds)
 	keyspaces, err := client.ListKeyspaces(ctx, &ps.ListKeyspacesRequest{
@@ -221,23 +221,93 @@ func (e *Engine) discoverMigrationContext(ctx context.Context, client psclient.P
 		return ""
 	}
 
+	var rows []vitessMigrationRow
 	for _, ks := range keyspaces {
-		rows, err := e.showVitessMigrationsForKeyspace(ctx, creds.DSN, ks.Name, "")
+		keyspaceRows, err := e.showVitessMigrationsForKeyspace(ctx, creds.DSN, ks.Name, "")
 		if err != nil {
 			e.logger.Debug("failed to query schema changes for keyspace", "keyspace", ks.Name, "error", err)
 			continue
 		}
-		for _, r := range rows {
-			_, exists := existingContexts[r.MigrationContext]
-			if r.MigrationContext != "" && !exists {
-				e.logger.Info("discovered schema change context", "context", r.MigrationContext)
-				return r.MigrationContext
-			}
-		}
+		rows = append(rows, keyspaceRows...)
+	}
+
+	migrationContext := selectMigrationContext(rows, existingContexts, deployCreatedAt)
+	if migrationContext != "" {
+		e.logger.Info("discovered schema change context", "context", migrationContext)
+		return migrationContext
 	}
 
 	e.logger.Warn("schema change context not discovered yet")
 	return ""
+}
+
+func selectMigrationContext(rows []vitessMigrationRow, existingContexts map[string]MigrationContextTimestamps, deployCreatedAt time.Time) string {
+	type candidate struct {
+		context     string
+		requestedAt *time.Time
+	}
+
+	candidatesByContext := make(map[string]candidate)
+	for _, row := range rows {
+		if row.MigrationContext == "" {
+			continue
+		}
+		if _, exists := existingContexts[row.MigrationContext]; exists {
+			continue
+		}
+		existingCandidate, seen := candidatesByContext[row.MigrationContext]
+		if !seen || earlierTime(row.RequestedAt, existingCandidate.requestedAt) {
+			candidatesByContext[row.MigrationContext] = candidate{
+				context:     row.MigrationContext,
+				requestedAt: row.RequestedAt,
+			}
+		}
+	}
+
+	candidates := make([]candidate, 0, len(candidatesByContext))
+	for _, candidate := range candidatesByContext {
+		candidates = append(candidates, candidate)
+	}
+	if len(candidates) == 0 {
+		return ""
+	}
+	if len(candidates) == 1 && candidates[0].requestedAt == nil {
+		return candidates[0].context
+	}
+
+	requestedAfterDeploy := candidates[:0]
+	for _, candidate := range candidates {
+		if candidate.requestedAt == nil {
+			continue
+		}
+		if candidate.requestedAt.Before(deployCreatedAt) {
+			continue
+		}
+		requestedAfterDeploy = append(requestedAfterDeploy, candidate)
+	}
+	if len(requestedAfterDeploy) == 0 {
+		return ""
+	}
+
+	sort.Slice(requestedAfterDeploy, func(i, j int) bool {
+		left := requestedAfterDeploy[i]
+		right := requestedAfterDeploy[j]
+		if !left.requestedAt.Equal(*right.requestedAt) {
+			return left.requestedAt.Before(*right.requestedAt)
+		}
+		return left.context < right.context
+	})
+	return requestedAfterDeploy[0].context
+}
+
+func earlierTime(left, right *time.Time) bool {
+	if left == nil {
+		return false
+	}
+	if right == nil {
+		return true
+	}
+	return left.Before(*right)
 }
 
 // vitessMigrationRow holds a single row from SHOW VITESS_MIGRATIONS.

--- a/pkg/engine/planetscale/progress.go
+++ b/pkg/engine/planetscale/progress.go
@@ -80,6 +80,15 @@ func (e *Engine) Progress(ctx context.Context, req *engine.ProgressRequest) (*en
 			}
 		}
 	}
+	if req.ResumeState.MigrationContext == "" && len(meta.ExistingMigrationCtxs) > 0 {
+		migrationContext := e.discoverMigrationContext(ctx, client, req.Database, req.Credentials, meta.ExistingMigrationCtxs)
+		if migrationContext != "" {
+			req.ResumeState = &engine.ResumeState{
+				MigrationContext: migrationContext,
+				Metadata:         req.ResumeState.Metadata,
+			}
+		}
+	}
 
 	e.logger.Debug("progress poll",
 		"database", req.Database,
@@ -142,8 +151,8 @@ func (e *Engine) Progress(ctx context.Context, req *engine.ProgressRequest) (*en
 // captureExistingContexts returns the set of migration_context values currently
 // in SHOW VITESS_MIGRATIONS. Used as a baseline before deploying so that new
 // contexts can be identified after deploy.
-func (e *Engine) captureExistingContexts(ctx context.Context, client psclient.PSClient, database string, creds *engine.Credentials) map[string]bool {
-	existing := make(map[string]bool)
+func (e *Engine) captureExistingContexts(ctx context.Context, client psclient.PSClient, database string, creds *engine.Credentials) map[string]MigrationContextTimestamps {
+	existing := make(map[string]MigrationContextTimestamps)
 	if creds.DSN == "" {
 		return existing
 	}
@@ -167,7 +176,7 @@ func (e *Engine) captureExistingContexts(ctx context.Context, client psclient.PS
 		}
 		for _, r := range rows {
 			if r.MigrationContext != "" {
-				existing[r.MigrationContext] = true
+				existing[r.MigrationContext] = migrationRowTimestamps(r)
 			}
 		}
 	}
@@ -176,9 +185,24 @@ func (e *Engine) captureExistingContexts(ctx context.Context, client psclient.PS
 	return existing
 }
 
+func migrationRowTimestamps(row vitessMigrationRow) MigrationContextTimestamps {
+	return MigrationContextTimestamps{
+		RequestedTimestamp: formatMigrationTimestamp(row.RequestedAt),
+		StartedTimestamp:   formatMigrationTimestamp(row.StartedAt),
+		CompletedTimestamp: formatMigrationTimestamp(row.CompletedAt),
+	}
+}
+
+func formatMigrationTimestamp(ts *time.Time) string {
+	if ts == nil {
+		return ""
+	}
+	return ts.UTC().Format(time.RFC3339)
+}
+
 // discoverMigrationContext finds the new migration_context that appeared after
 // deploying by comparing current contexts against the pre-deploy baseline.
-func (e *Engine) discoverMigrationContext(ctx context.Context, client psclient.PSClient, database string, creds *engine.Credentials, existingContexts map[string]bool) string {
+func (e *Engine) discoverMigrationContext(ctx context.Context, client psclient.PSClient, database string, creds *engine.Credentials, existingContexts map[string]MigrationContextTimestamps) string {
 	if creds.DSN == "" {
 		e.logger.Debug("skipping schema change context discovery, no DSN configured")
 		return ""
@@ -204,7 +228,8 @@ func (e *Engine) discoverMigrationContext(ctx context.Context, client psclient.P
 			continue
 		}
 		for _, r := range rows {
-			if r.MigrationContext != "" && !existingContexts[r.MigrationContext] {
+			_, exists := existingContexts[r.MigrationContext]
+			if r.MigrationContext != "" && !exists {
 				e.logger.Info("discovered schema change context", "context", r.MigrationContext)
 				return r.MigrationContext
 			}
@@ -231,6 +256,7 @@ type vitessMigrationRow struct {
 	TableRows        int64
 	IsImmediate      bool
 	CutoverAttempts  int
+	RequestedAt      *time.Time
 	StartedAt        *time.Time
 	CompletedAt      *time.Time
 }
@@ -358,7 +384,9 @@ func (e *Engine) showVitessMigrationsForKeyspace(ctx context.Context, dsn, keysp
 		if v, err := parseInt64(colMap["cutover_attempts"]); err == nil {
 			row.CutoverAttempts = int(v)
 		}
-
+		if ts, parseErr := time.Parse("2006-01-02 15:04:05", colMap["requested_timestamp"]); parseErr == nil {
+			row.RequestedAt = &ts
+		}
 		if ts, parseErr := time.Parse("2006-01-02 15:04:05", colMap["started_timestamp"]); parseErr == nil {
 			row.StartedAt = &ts
 		}

--- a/pkg/engine/planetscale/progress_test.go
+++ b/pkg/engine/planetscale/progress_test.go
@@ -26,6 +26,52 @@ func TestMigrationRowTimestamps(t *testing.T) {
 	assert.Empty(t, migrationRowTimestamps(vitessMigrationRow{}))
 }
 
+func TestSelectMigrationContextUsesDeployTimestamp(t *testing.T) {
+	deployCreatedAt := time.Date(2026, 6, 4, 19, 0, 0, 0, time.UTC)
+	beforeDeploy := deployCreatedAt.Add(-time.Second)
+	firstAfterDeploy := deployCreatedAt.Add(time.Second)
+	laterAfterDeploy := deployCreatedAt.Add(2 * time.Second)
+
+	got := selectMigrationContext([]vitessMigrationRow{
+		{MigrationContext: "baseline", RequestedAt: &beforeDeploy},
+		{MigrationContext: "manual-before-deploy", RequestedAt: &beforeDeploy},
+		{MigrationContext: "schemabot-context", RequestedAt: &firstAfterDeploy},
+		{MigrationContext: "manual-after-deploy", RequestedAt: &laterAfterDeploy},
+	}, map[string]MigrationContextTimestamps{
+		"baseline": {RequestedTimestamp: beforeDeploy.Format(time.RFC3339)},
+	}, deployCreatedAt)
+
+	assert.Equal(t, "schemabot-context", got)
+}
+
+func TestSelectMigrationContextDeduplicatesShardsByEarliestRequestedAt(t *testing.T) {
+	deployCreatedAt := time.Date(2026, 6, 4, 19, 0, 0, 0, time.UTC)
+	firstShard := deployCreatedAt.Add(2 * time.Second)
+	secondShard := deployCreatedAt.Add(3 * time.Second)
+	otherContext := deployCreatedAt.Add(4 * time.Second)
+
+	got := selectMigrationContext([]vitessMigrationRow{
+		{MigrationContext: "schemabot-context", Shard: "80-", RequestedAt: &secondShard},
+		{MigrationContext: "other-context", RequestedAt: &otherContext},
+		{MigrationContext: "schemabot-context", Shard: "-80", RequestedAt: &firstShard},
+	}, nil, deployCreatedAt)
+
+	assert.Equal(t, "schemabot-context", got)
+}
+
+func TestSelectMigrationContextDoesNotGuessAmongMultipleUntimedContexts(t *testing.T) {
+	deployCreatedAt := time.Date(2026, 6, 4, 19, 0, 0, 0, time.UTC)
+
+	assert.Equal(t, "only-new-context", selectMigrationContext([]vitessMigrationRow{
+		{MigrationContext: "only-new-context"},
+	}, nil, deployCreatedAt))
+
+	assert.Empty(t, selectMigrationContext([]vitessMigrationRow{
+		{MigrationContext: "first-new-context"},
+		{MigrationContext: "second-new-context"},
+	}, nil, deployCreatedAt))
+}
+
 func TestAggregateShardProgress(t *testing.T) {
 	t.Run("two shards one table", func(t *testing.T) {
 		rows := []vitessMigrationRow{

--- a/pkg/engine/planetscale/progress_test.go
+++ b/pkg/engine/planetscale/progress_test.go
@@ -2,12 +2,29 @@ package planetscale
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/block/schemabot/pkg/state"
 )
+
+func TestMigrationRowTimestamps(t *testing.T) {
+	requestedAt := time.Date(2026, 6, 4, 19, 0, 0, 0, time.UTC)
+	startedAt := time.Date(2026, 6, 4, 19, 1, 0, 0, time.UTC)
+	completedAt := time.Date(2026, 6, 4, 19, 2, 0, 0, time.UTC)
+
+	timestamps := migrationRowTimestamps(vitessMigrationRow{
+		RequestedAt: &requestedAt,
+		StartedAt:   &startedAt,
+		CompletedAt: &completedAt,
+	})
+	assert.Equal(t, requestedAt.Format(time.RFC3339), timestamps.RequestedTimestamp)
+	assert.Equal(t, startedAt.Format(time.RFC3339), timestamps.StartedTimestamp)
+	assert.Equal(t, completedAt.Format(time.RFC3339), timestamps.CompletedTimestamp)
+	assert.Empty(t, migrationRowTimestamps(vitessMigrationRow{}))
+}
 
 func TestAggregateShardProgress(t *testing.T) {
 	t.Run("two shards one table", func(t *testing.T) {

--- a/pkg/schema/mysql/vitess_apply_data.sql
+++ b/pkg/schema/mysql/vitess_apply_data.sql
@@ -4,6 +4,7 @@ CREATE TABLE `vitess_apply_data` (
   `branch_name` varchar(255) NOT NULL,
   `deploy_request_id` bigint unsigned DEFAULT NULL,
   `migration_context` varchar(255) DEFAULT NULL,
+  `existing_migration_contexts` json DEFAULT NULL,
   `deploy_request_url` varchar(512) DEFAULT NULL,
   `is_instant` tinyint(1) NOT NULL DEFAULT '0',
   `deferred_deploy` tinyint(1) NOT NULL DEFAULT '0',

--- a/pkg/storage/mysqlstore/vitess_apply_data.go
+++ b/pkg/storage/mysqlstore/vitess_apply_data.go
@@ -3,6 +3,7 @@ package mysqlstore
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -14,18 +15,24 @@ type vitessApplyDataStore struct {
 }
 
 func (s *vitessApplyDataStore) Save(ctx context.Context, data *storage.VitessApplyData) error {
-	_, err := s.db.ExecContext(ctx, `
-		INSERT INTO vitess_apply_data (apply_id, branch_name, deploy_request_id, migration_context, deploy_request_url, is_instant, deferred_deploy, revert_skipped_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+	existingContexts, err := json.Marshal(data.ExistingMigrationCtxs)
+	if err != nil {
+		return fmt.Errorf("marshal existing migration contexts for apply %d: %w", data.ApplyID, err)
+	}
+
+	_, err = s.db.ExecContext(ctx, `
+		INSERT INTO vitess_apply_data (apply_id, branch_name, deploy_request_id, migration_context, existing_migration_contexts, deploy_request_url, is_instant, deferred_deploy, revert_skipped_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON DUPLICATE KEY UPDATE
 			branch_name = VALUES(branch_name),
 			deploy_request_id = VALUES(deploy_request_id),
 			migration_context = VALUES(migration_context),
+			existing_migration_contexts = VALUES(existing_migration_contexts),
 			deploy_request_url = VALUES(deploy_request_url),
 			is_instant = VALUES(is_instant),
 			deferred_deploy = VALUES(deferred_deploy),
 			revert_skipped_at = VALUES(revert_skipped_at)`,
-		data.ApplyID, data.BranchName, data.DeployRequestID, data.MigrationContext, data.DeployRequestURL, data.IsInstant, data.DeferredDeploy, data.RevertSkippedAt,
+		data.ApplyID, data.BranchName, data.DeployRequestID, data.MigrationContext, string(existingContexts), data.DeployRequestURL, data.IsInstant, data.DeferredDeploy, data.RevertSkippedAt,
 	)
 	if err != nil {
 		return fmt.Errorf("save vitess apply data for apply %d: %w", data.ApplyID, err)
@@ -35,15 +42,21 @@ func (s *vitessApplyDataStore) Save(ctx context.Context, data *storage.VitessApp
 
 func (s *vitessApplyDataStore) GetByApplyID(ctx context.Context, applyID int64) (*storage.VitessApplyData, error) {
 	var data storage.VitessApplyData
+	var existingContexts sql.NullString
 	err := s.db.QueryRowContext(ctx, `
-		SELECT apply_id, branch_name, deploy_request_id, migration_context, deploy_request_url, is_instant, deferred_deploy, revert_skipped_at
+		SELECT apply_id, branch_name, deploy_request_id, migration_context, existing_migration_contexts, deploy_request_url, is_instant, deferred_deploy, revert_skipped_at
 		FROM vitess_apply_data WHERE apply_id = ?`, applyID,
-	).Scan(&data.ApplyID, &data.BranchName, &data.DeployRequestID, &data.MigrationContext, &data.DeployRequestURL, &data.IsInstant, &data.DeferredDeploy, &data.RevertSkippedAt)
+	).Scan(&data.ApplyID, &data.BranchName, &data.DeployRequestID, &data.MigrationContext, &existingContexts, &data.DeployRequestURL, &data.IsInstant, &data.DeferredDeploy, &data.RevertSkippedAt)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, storage.ErrVitessApplyDataNotFound
 		}
 		return nil, fmt.Errorf("get vitess apply data for apply %d: %w", applyID, err)
+	}
+	if existingContexts.Valid && existingContexts.String != "" {
+		if err := json.Unmarshal([]byte(existingContexts.String), &data.ExistingMigrationCtxs); err != nil {
+			return nil, fmt.Errorf("unmarshal existing migration contexts for apply %d: %w", applyID, err)
+		}
 	}
 	return &data, nil
 }

--- a/pkg/storage/types.go
+++ b/pkg/storage/types.go
@@ -769,17 +769,26 @@ type ApplyLogFilter struct {
 // VitessApplyData holds Vitess-specific data for deploy request tracking.
 // Stored in vitess_apply_data table, one row per apply when database_type = 'vitess'.
 type VitessApplyData struct {
-	ApplyID          int64
-	BranchName       string
-	DeployRequestID  uint64
-	MigrationContext string
-	DeployRequestURL string
-	IsInstant        bool // True when PlanetScale reported the deploy as instant-eligible
-	DeferredDeploy   bool // True when deploy was deferred (--defer-deploy flag)
+	ApplyID               int64
+	BranchName            string
+	DeployRequestID       uint64
+	MigrationContext      string
+	ExistingMigrationCtxs map[string]VitessMigrationContextTimestamps
+	DeployRequestURL      string
+	IsInstant             bool // True when PlanetScale reported the deploy as instant-eligible
+	DeferredDeploy        bool // True when deploy was deferred (--defer-deploy flag)
 
 	// RevertSkippedAt records when skip-revert was dispatched. Non-nil means
 	// finalization is in progress — the deploy request is transitioning across
 	// shards from complete_pending_revert to complete. On large keyspaces
 	// this can take longer as shards are processed in batches.
 	RevertSkippedAt *time.Time
+}
+
+// VitessMigrationContextTimestamps records Vitess timestamp fields for a
+// pre-existing migration context captured before a PlanetScale deploy starts.
+type VitessMigrationContextTimestamps struct {
+	RequestedTimestamp string `json:"requested_timestamp,omitempty"`
+	StartedTimestamp   string `json:"started_timestamp,omitempty"`
+	CompletedTimestamp string `json:"completed_timestamp,omitempty"`
 }

--- a/pkg/tern/local_apply_grouped.go
+++ b/pkg/tern/local_apply_grouped.go
@@ -289,6 +289,9 @@ func (c *LocalClient) handleAtomicProgressTick(ctx context.Context, eng engine.E
 	// updated metadata like deploy request URL or migration context).
 	if result.ResumeState != nil && resumeState != nil {
 		*resumeState = *result.ResumeState
+		if c.config.Type == storage.DatabaseTypeVitess {
+			c.persistRecoveredVitessMigrationContext(ctx, apply.ID, result.ResumeState)
+		}
 	}
 
 	now := time.Now()
@@ -504,6 +507,43 @@ func (c *LocalClient) handleAtomicProgressTick(ctx context.Context, eng engine.E
 		obs.OnProgress(apply, tasks)
 	}
 	return false
+}
+
+func (c *LocalClient) persistRecoveredVitessMigrationContext(ctx context.Context, applyID int64, resumeState *engine.ResumeState) {
+	if c.config.Type != storage.DatabaseTypeVitess || resumeState == nil || resumeState.MigrationContext == "" {
+		return
+	}
+	store := c.storage.VitessApplyData()
+	if store == nil {
+		return
+	}
+	vad, err := store.GetByApplyID(ctx, applyID)
+	if err != nil {
+		c.logger.Warn("failed to load VitessApplyData for recovered migration context", "apply_id", applyID, "migration_context", resumeState.MigrationContext, "error", err)
+		return
+	}
+	if vad == nil {
+		c.logger.Warn("VitessApplyData missing for recovered migration context", "apply_id", applyID, "migration_context", resumeState.MigrationContext)
+		return
+	}
+	if vad.MigrationContext == resumeState.MigrationContext {
+		return
+	}
+
+	vad.MigrationContext = resumeState.MigrationContext
+	if meta, decodeErr := decodePSMetadataForStorage(resumeState.Metadata); decodeErr != nil {
+		c.logger.Warn("failed to decode Vitess progress metadata while persisting recovered migration context", "apply_id", applyID, "error", decodeErr)
+	} else if meta != nil {
+		vad.BranchName = meta.BranchName
+		vad.DeployRequestID = meta.DeployRequestID
+		vad.ExistingMigrationCtxs = meta.ExistingMigrationCtxs
+		vad.DeployRequestURL = meta.DeployRequestURL
+		vad.IsInstant = meta.IsInstant
+		vad.DeferredDeploy = meta.DeferredDeploy
+	}
+	if saveErr := store.Save(ctx, vad); saveErr != nil {
+		c.logger.Warn("failed to persist recovered Vitess migration context", "apply_id", applyID, "migration_context", resumeState.MigrationContext, "error", saveErr)
+	}
 }
 
 // markRevertSkipped sets RevertSkippedAt on the VitessApplyData record so

--- a/pkg/tern/local_apply_grouped.go
+++ b/pkg/tern/local_apply_grouped.go
@@ -121,13 +121,14 @@ func (c *LocalClient) executeGroupedApply(ctx context.Context, apply *storage.Ap
 				return
 			}
 			if saveErr := c.storage.VitessApplyData().Save(ctx, &storage.VitessApplyData{
-				ApplyID:          apply.ID,
-				BranchName:       meta.BranchName,
-				DeployRequestID:  meta.DeployRequestID,
-				MigrationContext: rs.MigrationContext,
-				DeployRequestURL: meta.DeployRequestURL,
-				IsInstant:        meta.IsInstant,
-				DeferredDeploy:   meta.DeferredDeploy,
+				ApplyID:               apply.ID,
+				BranchName:            meta.BranchName,
+				DeployRequestID:       meta.DeployRequestID,
+				MigrationContext:      rs.MigrationContext,
+				ExistingMigrationCtxs: meta.ExistingMigrationCtxs,
+				DeployRequestURL:      meta.DeployRequestURL,
+				IsInstant:             meta.IsInstant,
+				DeferredDeploy:        meta.DeferredDeploy,
 			}); saveErr != nil {
 				c.logger.Warn("OnStateChange: failed to persist resume state", "apply_id", apply.ApplyIdentifier, "error", saveErr)
 			}
@@ -177,13 +178,14 @@ func (c *LocalClient) executeGroupedApply(ctx context.Context, apply *storage.Ap
 				"raw_metadata", resumeState.Metadata[:min(len(resumeState.Metadata), 200)],
 			)
 			if saveErr := c.storage.VitessApplyData().Save(ctx, &storage.VitessApplyData{
-				ApplyID:          apply.ID,
-				BranchName:       meta.BranchName,
-				DeployRequestID:  meta.DeployRequestID,
-				MigrationContext: resumeState.MigrationContext,
-				DeployRequestURL: meta.DeployRequestURL,
-				IsInstant:        meta.IsInstant,
-				DeferredDeploy:   meta.DeferredDeploy,
+				ApplyID:               apply.ID,
+				BranchName:            meta.BranchName,
+				DeployRequestID:       meta.DeployRequestID,
+				MigrationContext:      resumeState.MigrationContext,
+				ExistingMigrationCtxs: meta.ExistingMigrationCtxs,
+				DeployRequestURL:      meta.DeployRequestURL,
+				IsInstant:             meta.IsInstant,
+				DeferredDeploy:        meta.DeferredDeploy,
 			}); saveErr != nil {
 				c.logger.Warn("failed to save vitess apply data", "apply_id", apply.ApplyIdentifier, "error", saveErr)
 			}

--- a/pkg/tern/local_client.go
+++ b/pkg/tern/local_client.go
@@ -770,11 +770,8 @@ func (c *LocalClient) Progress(ctx context.Context, req *ternv1.ProgressRequest)
 		result, err := eng.Progress(ctx, progressReq)
 		if err == nil {
 			engineResult = result
-			if c.config.Type == storage.DatabaseTypeVitess && vitessApplyData != nil && result.ResumeState != nil && result.ResumeState.MigrationContext != "" && vitessApplyData.MigrationContext != result.ResumeState.MigrationContext {
-				vitessApplyData.MigrationContext = result.ResumeState.MigrationContext
-				if saveErr := c.storage.VitessApplyData().Save(ctx, vitessApplyData); saveErr != nil {
-					c.logger.Warn("failed to persist recovered Vitess migration context", "apply_id", activeTask.ApplyID, "migration_context", result.ResumeState.MigrationContext, "error", saveErr)
-				}
+			if c.config.Type == storage.DatabaseTypeVitess && vitessApplyData != nil && result.ResumeState != nil {
+				c.persistRecoveredVitessMigrationContext(ctx, activeTask.ApplyID, result.ResumeState)
 			}
 			c.logger.Info("Progress: engine returned", "engine_state", result.State, "message", result.Message, "task_id", activeTask.TaskIdentifier, "storage_state", activeTask.State)
 			engineTaskState := taskStateFromProgressResult(result)

--- a/pkg/tern/local_client.go
+++ b/pkg/tern/local_client.go
@@ -734,6 +734,7 @@ func (c *LocalClient) Progress(ctx context.Context, req *ternv1.ProgressRequest)
 	// can poll the deploy request and query SHOW VITESS_MIGRATIONS.
 	var engineResult *engine.ProgressResult
 	var vitessApplyIsInstant bool
+	var vitessApplyData *storage.VitessApplyData
 	// Query engine for live progress. For Vitess, also query during pending state
 	// to surface PlanetScale states (preparing branch, deploy request, etc.).
 	queryDuringPending := c.config.Type == storage.DatabaseTypeVitess
@@ -756,6 +757,7 @@ func (c *LocalClient) Progress(ctx context.Context, req *ternv1.ProgressRequest)
 			case vad == nil:
 				c.logger.Warn("VitessApplyData not found for progress — apply may still be initializing", "apply_id", activeTask.ApplyID)
 			default:
+				vitessApplyData = vad
 				vitessApplyIsInstant = vad.IsInstant
 				resumeState, resumeErr := planetscale.BuildResumeState(planetscaleResumeData(vad))
 				if resumeErr != nil {
@@ -768,6 +770,12 @@ func (c *LocalClient) Progress(ctx context.Context, req *ternv1.ProgressRequest)
 		result, err := eng.Progress(ctx, progressReq)
 		if err == nil {
 			engineResult = result
+			if c.config.Type == storage.DatabaseTypeVitess && vitessApplyData != nil && result.ResumeState != nil && result.ResumeState.MigrationContext != "" && vitessApplyData.MigrationContext != result.ResumeState.MigrationContext {
+				vitessApplyData.MigrationContext = result.ResumeState.MigrationContext
+				if saveErr := c.storage.VitessApplyData().Save(ctx, vitessApplyData); saveErr != nil {
+					c.logger.Warn("failed to persist recovered Vitess migration context", "apply_id", activeTask.ApplyID, "migration_context", result.ResumeState.MigrationContext, "error", saveErr)
+				}
+			}
 			c.logger.Info("Progress: engine returned", "engine_state", result.State, "message", result.Message, "task_id", activeTask.TaskIdentifier, "storage_state", activeTask.State)
 			engineTaskState := taskStateFromProgressResult(result)
 			taskState := taskStateWithNoBackwardProgress(activeTask.State, engineTaskState)

--- a/pkg/tern/local_client_test.go
+++ b/pkg/tern/local_client_test.go
@@ -71,10 +71,12 @@ func (s *exactProgressTaskStore) Update(context.Context, *storage.Task) error {
 
 type fakeControlEngine struct {
 	engine.Engine
-	stopCount     int
-	cutoverCount  int
-	cutoverResult *engine.ControlResult
-	cutoverErr    error
+	stopCount      int
+	cutoverCount   int
+	progressResult *engine.ProgressResult
+	progressErr    error
+	cutoverResult  *engine.ControlResult
+	cutoverErr     error
 }
 
 func (e *fakeControlEngine) Name() string { return "fake" }
@@ -88,6 +90,9 @@ func (e *fakeControlEngine) Apply(context.Context, *engine.ApplyRequest) (*engin
 }
 
 func (e *fakeControlEngine) Progress(context.Context, *engine.ProgressRequest) (*engine.ProgressResult, error) {
+	if e.progressResult != nil || e.progressErr != nil {
+		return e.progressResult, e.progressErr
+	}
 	return &engine.ProgressResult{State: engine.StateRunning}, nil
 }
 
@@ -126,6 +131,7 @@ type exactProgressStorage struct {
 	tasks           storage.TaskStore
 	logs            storage.ApplyLogStore
 	controlRequests storage.ControlRequestStore
+	vitessApplyData storage.VitessApplyDataStore
 }
 
 func (s *exactProgressStorage) Applies() storage.ApplyStore { return s.applies }
@@ -138,6 +144,30 @@ func (s *exactProgressStorage) ApplyLogs() storage.ApplyLogStore {
 }
 func (s *exactProgressStorage) ControlRequests() storage.ControlRequestStore {
 	return s.controlRequests
+}
+func (s *exactProgressStorage) VitessApplyData() storage.VitessApplyDataStore {
+	return s.vitessApplyData
+}
+
+type exactProgressVitessApplyDataStore struct {
+	storage.VitessApplyDataStore
+	data     *storage.VitessApplyData
+	saveData *storage.VitessApplyData
+	err      error
+}
+
+func (s *exactProgressVitessApplyDataStore) GetByApplyID(context.Context, int64) (*storage.VitessApplyData, error) {
+	return s.data, s.err
+}
+
+func (s *exactProgressVitessApplyDataStore) Save(_ context.Context, data *storage.VitessApplyData) error {
+	if s.err != nil {
+		return s.err
+	}
+	clone := *data
+	s.saveData = &clone
+	s.data = data
+	return nil
 }
 
 func TestApplyCancelHandleDoesNotCancelNewerOwner(t *testing.T) {
@@ -289,6 +319,67 @@ func TestLocalClient_ProgressByApplyIDReturnsNotFoundForMissingApplyData(t *test
 			require.ErrorIs(t, err, tc.wantError)
 		})
 	}
+}
+
+func TestLocalClient_ProgressPersistsRecoveredVitessMigrationContext(t *testing.T) {
+	apply := &storage.Apply{
+		ID:              42,
+		ApplyIdentifier: "apply-vitess-recovered-context",
+		Database:        "testdb",
+		DatabaseType:    storage.DatabaseTypeVitess,
+		Environment:     "staging",
+		State:           state.Apply.Running,
+		Engine:          storage.EnginePlanetScale,
+	}
+	task := &storage.Task{
+		ID:             43,
+		ApplyID:        apply.ID,
+		TaskIdentifier: "task-vitess-recovered-context",
+		Database:       "testdb",
+		DatabaseType:   storage.DatabaseTypeVitess,
+		Namespace:      "testdb",
+		TableName:      "users",
+		State:          state.Task.Running,
+	}
+	vitessData := &storage.VitessApplyData{
+		ApplyID:         apply.ID,
+		BranchName:      "schemabot-apply",
+		DeployRequestID: 123,
+		ExistingMigrationCtxs: map[string]storage.VitessMigrationContextTimestamps{
+			"preexisting": {RequestedTimestamp: "2026-01-01 00:00:00"},
+		},
+	}
+	vitessStore := &exactProgressVitessApplyDataStore{data: vitessData}
+	client := &LocalClient{
+		config: LocalConfig{
+			Database: "testdb",
+			Type:     storage.DatabaseTypeVitess,
+		},
+		storage: &exactProgressStorage{
+			applies:         &exactProgressApplyStore{apply: apply},
+			tasks:           &exactProgressTaskStore{tasks: []*storage.Task{task}},
+			vitessApplyData: vitessStore,
+		},
+		planetscaleEngine: &fakeControlEngine{progressResult: &engine.ProgressResult{
+			State: engine.StateRunning,
+			ResumeState: &engine.ResumeState{
+				MigrationContext: "recovered-context",
+			},
+		}},
+		logger: slog.Default(),
+	}
+
+	_, err := client.Progress(t.Context(), &ternv1.ProgressRequest{
+		ApplyId:     apply.ApplyIdentifier,
+		Environment: apply.Environment,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, vitessStore.saveData)
+	assert.Equal(t, "recovered-context", vitessStore.saveData.MigrationContext)
+	assert.Equal(t, apply.ID, vitessStore.saveData.ApplyID)
+	assert.Equal(t, "schemabot-apply", vitessStore.saveData.BranchName)
+	assert.Equal(t, uint64(123), vitessStore.saveData.DeployRequestID)
+	assert.Contains(t, vitessStore.saveData.ExistingMigrationCtxs, "preexisting")
 }
 
 func TestLocalClient_ProcessPendingStopControlRequest(t *testing.T) {

--- a/pkg/tern/local_client_test.go
+++ b/pkg/tern/local_client_test.go
@@ -382,6 +382,101 @@ func TestLocalClient_ProgressPersistsRecoveredVitessMigrationContext(t *testing.
 	assert.Contains(t, vitessStore.saveData.ExistingMigrationCtxs, "preexisting")
 }
 
+func TestLocalClient_PersistRecoveredVitessMigrationContextUpdatesStoredApplyData(t *testing.T) {
+	vitessData := &storage.VitessApplyData{
+		ApplyID:         42,
+		BranchName:      "old-branch",
+		DeployRequestID: 123,
+		ExistingMigrationCtxs: map[string]storage.VitessMigrationContextTimestamps{
+			"preexisting": {RequestedTimestamp: "2026-01-01T00:00:00Z"},
+		},
+	}
+	vitessStore := &exactProgressVitessApplyDataStore{data: vitessData}
+	client := &LocalClient{
+		config: LocalConfig{
+			Database: "testdb",
+			Type:     storage.DatabaseTypeVitess,
+		},
+		storage: &exactProgressStorage{vitessApplyData: vitessStore},
+		logger:  slog.Default(),
+	}
+
+	client.persistRecoveredVitessMigrationContext(t.Context(), 42, &engine.ResumeState{
+		MigrationContext: "recovered-context",
+		Metadata: `{
+			"branch_name":"new-branch",
+			"deploy_request_id":456,
+			"deploy_request_url":"https://example.test/deploys/456",
+			"existing_migration_contexts":{"preexisting":{"requested_timestamp":"2026-01-01T00:00:00Z"}},
+			"is_instant":true,
+			"deferred_deploy":true
+		}`,
+	})
+
+	require.NotNil(t, vitessStore.saveData)
+	assert.Equal(t, "recovered-context", vitessStore.saveData.MigrationContext)
+	assert.Equal(t, "new-branch", vitessStore.saveData.BranchName)
+	assert.Equal(t, uint64(456), vitessStore.saveData.DeployRequestID)
+	assert.Equal(t, "https://example.test/deploys/456", vitessStore.saveData.DeployRequestURL)
+	assert.True(t, vitessStore.saveData.IsInstant)
+	assert.True(t, vitessStore.saveData.DeferredDeploy)
+	assert.Contains(t, vitessStore.saveData.ExistingMigrationCtxs, "preexisting")
+}
+
+func TestLocalClient_AtomicProgressTickPersistsRecoveredVitessMigrationContext(t *testing.T) {
+	apply := &storage.Apply{
+		ID:              42,
+		ApplyIdentifier: "apply-vitess-worker-context",
+		Database:        "testdb",
+		DatabaseType:    storage.DatabaseTypeVitess,
+		Environment:     "staging",
+		State:           state.Apply.Running,
+		Engine:          storage.EnginePlanetScale,
+	}
+	task := &storage.Task{
+		ID:             43,
+		ApplyID:        apply.ID,
+		TaskIdentifier: "task-vitess-worker-context",
+		Database:       "testdb",
+		DatabaseType:   storage.DatabaseTypeVitess,
+		Namespace:      "testdb",
+		TableName:      "users",
+		State:          state.Task.Running,
+	}
+	vitessStore := &exactProgressVitessApplyDataStore{data: &storage.VitessApplyData{
+		ApplyID:         apply.ID,
+		BranchName:      "schemabot-apply",
+		DeployRequestID: 123,
+	}}
+	client := &LocalClient{
+		config: LocalConfig{
+			Database: "testdb",
+			Type:     storage.DatabaseTypeVitess,
+		},
+		storage: &exactProgressStorage{
+			applies:         &exactProgressApplyStore{apply: apply},
+			tasks:           &exactProgressTaskStore{tasks: []*storage.Task{task}},
+			controlRequests: &testControlRequestStore{},
+			vitessApplyData: vitessStore,
+		},
+		logger: slog.Default(),
+	}
+	resumeState := &engine.ResumeState{}
+
+	stopped := client.handleAtomicProgressTick(t.Context(), &fakeControlEngine{progressResult: &engine.ProgressResult{
+		State: engine.StateRunning,
+		ResumeState: &engine.ResumeState{
+			MigrationContext: "recovered-context",
+		},
+	}}, apply, []*storage.Task{task}, &engine.Credentials{}, resumeState, &atomicPollState{lastTaskState: state.Task.Running})
+
+	assert.False(t, stopped)
+	assert.Equal(t, "recovered-context", resumeState.MigrationContext)
+	require.NotNil(t, vitessStore.saveData)
+	assert.Equal(t, "recovered-context", vitessStore.saveData.MigrationContext)
+	assert.Equal(t, apply.ID, vitessStore.saveData.ApplyID)
+}
+
 func TestLocalClient_ProcessPendingStopControlRequest(t *testing.T) {
 	apply := &storage.Apply{
 		ID:              123,

--- a/pkg/tern/local_control.go
+++ b/pkg/tern/local_control.go
@@ -578,13 +578,29 @@ func planetscaleResumeData(vad *storage.VitessApplyData) planetscale.ResumeData 
 		return planetscale.ResumeData{}
 	}
 	return planetscale.ResumeData{
-		BranchName:       vad.BranchName,
-		DeployRequestID:  vad.DeployRequestID,
-		DeployRequestURL: vad.DeployRequestURL,
-		MigrationContext: vad.MigrationContext,
-		IsInstant:        vad.IsInstant,
-		DeferredDeploy:   vad.DeferredDeploy,
+		BranchName:            vad.BranchName,
+		DeployRequestID:       vad.DeployRequestID,
+		DeployRequestURL:      vad.DeployRequestURL,
+		MigrationContext:      vad.MigrationContext,
+		ExistingMigrationCtxs: planetscaleMigrationContextTimestamps(vad.ExistingMigrationCtxs),
+		IsInstant:             vad.IsInstant,
+		DeferredDeploy:        vad.DeferredDeploy,
 	}
+}
+
+func planetscaleMigrationContextTimestamps(contexts map[string]storage.VitessMigrationContextTimestamps) map[string]planetscale.MigrationContextTimestamps {
+	if len(contexts) == 0 {
+		return nil
+	}
+	result := make(map[string]planetscale.MigrationContextTimestamps, len(contexts))
+	for context, timestamps := range contexts {
+		result[context] = planetscale.MigrationContextTimestamps{
+			RequestedTimestamp: timestamps.RequestedTimestamp,
+			StartedTimestamp:   timestamps.StartedTimestamp,
+			CompletedTimestamp: timestamps.CompletedTimestamp,
+		}
+	}
+	return result
 }
 
 // Volume modifies the schema change speed/concurrency in-flight.

--- a/pkg/tern/state_converters.go
+++ b/pkg/tern/state_converters.go
@@ -256,12 +256,13 @@ func protoToSchemaFiles(sf map[string]*ternv1.SchemaFiles) schema.SchemaFiles {
 // psMetadataForStorage is a subset of the PlanetScale engine's metadata
 // used for storing deploy request tracking data.
 type psMetadataForStorage struct {
-	BranchName       string     `json:"branch_name"`
-	DeployRequestID  uint64     `json:"deploy_request_id"`
-	DeployRequestURL string     `json:"deploy_request_url,omitempty"`
-	DeployedAt       *time.Time `json:"deployed_at,omitempty"`
-	IsInstant        bool       `json:"is_instant,omitempty"`
-	DeferredDeploy   bool       `json:"deferred_deploy,omitempty"`
+	BranchName            string                                              `json:"branch_name"`
+	DeployRequestID       uint64                                              `json:"deploy_request_id"`
+	DeployRequestURL      string                                              `json:"deploy_request_url,omitempty"`
+	ExistingMigrationCtxs map[string]storage.VitessMigrationContextTimestamps `json:"existing_migration_contexts,omitempty"`
+	DeployedAt            *time.Time                                          `json:"deployed_at,omitempty"`
+	IsInstant             bool                                                `json:"is_instant,omitempty"`
+	DeferredDeploy        bool                                                `json:"deferred_deploy,omitempty"`
 }
 
 func decodePSMetadataForStorage(s string) (*psMetadataForStorage, error) {


### PR DESCRIPTION
> **Status — superseded, do not merge as-is (will be reworked).** The recovery
> logic here is still wanted, but the storage approach is changing. This PR
> persists the migration-context baseline on the `vitess_apply_data` table; that
> table is being removed in favor of carrying PlanetScale engine resume state on
> the operation row (`engine_resume_metadata`). This PR will be reworked to store
> the baseline/recovered contexts in `engine_resume_metadata` instead of a new
> `vitess_apply_data` column, so the fix lands alongside that consolidation rather
> than deepening a table that is going away. The recovery algorithm (baseline
> diff, earliest-timestamp selection, persist from both the worker and API paths)
> is preserved.

---

## Why
SchemaBot can sometimes create/start a PlanetScale deploy request before Vitess exposes the deploy's `migration_context` in `SHOW VITESS_MIGRATIONS`.

When that happens, SchemaBot still knows the deploy request ID, but it cannot show the richer Vitess progress view: per-table/per-shard progress, row counts, ETA, and related migration details. Without a recovery path, progress can stay limited to coarse deploy-request status even after the Vitess rows appear.

## What
- Save the set of Vitess migration contexts that existed before the deploy starts.
- Persist that baseline on `vitess_apply_data` so it survives normal progress polling and restarts.
- If progress polling later sees deploy metadata but no `migration_context`, query `SHOW VITESS_MIGRATIONS` again and recover a context from current rows.
- Select recovered contexts deterministically: ignore baseline contexts, prefer the earliest `requested_timestamp` at or after the deploy request creation time, and avoid guessing when multiple untimed new contexts exist.
- Persist a recovered context from both the active apply worker loop and read/API progress path so recovery survives worker restarts and scheduler owner handoff.
- Store Vitess row timestamps with each baseline context for operator debugging.

## Risk Assessment
Low. This only improves PlanetScale progress enrichment when resume state is missing `migration_context`; deploy-request state remains the source of truth for apply state.

The storage change is additive: a nullable JSON column on `vitess_apply_data`.

Generated with Amp

