### PR TITLE
fix(webhook): limit webhook request body size

### DIFF
--- a/pkg/webhook/handler.go
+++ b/pkg/webhook/handler.go
@@ -9,6 +9,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -64,6 +65,7 @@ const (
 	headerDeliveryID     = "X-GitHub-Delivery"
 	headerSignature256   = "X-Hub-Signature-256"
 	hookTargetTypeApp    = "integration"
+	maxWebhookBodyBytes  = 10 << 20
 )
 
 // Handler processes GitHub webhook events.
@@ -275,8 +277,22 @@ func (h *Handler) ReconcileMissingSummaryComments(ctx context.Context) {
 // ServeHTTP handles incoming webhook requests.
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Read body for signature validation
+	r.Body = http.MaxBytesReader(w, r.Body, maxWebhookBodyBytes)
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			h.logger.Warn("webhook rejected: request body too large",
+				"delivery_id", r.Header.Get(headerDeliveryID),
+				"event", r.Header.Get("X-GitHub-Event"),
+				"limit_bytes", maxBytesErr.Limit)
+			h.writeError(w, http.StatusRequestEntityTooLarge, "request body too large")
+			return
+		}
+		h.logger.Warn("webhook rejected: failed to read request body",
+			"delivery_id", r.Header.Get(headerDeliveryID),
+			"event", r.Header.Get("X-GitHub-Event"),
+			"error", err)
 		h.writeError(w, http.StatusBadRequest, "failed to read request body")
 		return
 	}

--- a/pkg/webhook/handler_test.go
+++ b/pkg/webhook/handler_test.go
@@ -72,6 +72,24 @@ func TestWebhookRejectsInvalidSignature(t *testing.T) {
 	require.Equal(t, http.StatusUnauthorized, rr.Code)
 }
 
+func TestWebhookRejectsOversizedBody(t *testing.T) {
+	h := &Handler{
+		webhookSecretsByApp: map[string][]byte{defaultAppName: []byte("secret")},
+		logger:              testLogger(),
+	}
+
+	body := strings.NewReader(strings.Repeat("a", maxWebhookBodyBytes+1))
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/webhook", body)
+	req.Header.Set("X-Hub-Signature-256", "sha256=invalid")
+	req.Header.Set("X-GitHub-Event", "issue_comment")
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusRequestEntityTooLarge, rr.Code)
+	assert.Contains(t, rr.Body.String(), "request body too large")
+}
+
 func TestWebhookIgnoresUnknownEvents(t *testing.T) {
 	h := &Handler{logger: testLogger()} // No secret — skip validation
 


### PR DESCRIPTION
## Why
Webhook handlers read request bodies before signature verification, so an oversized delivery can consume unbounded memory before SchemaBot rejects it.

## What
- Cap webhook request bodies at 10 MiB before HMAC validation
- Return `413 Request Entity Too Large` for oversized deliveries with operator-friendly warning logs
- Cover oversized webhook rejection in handler tests

## Risk Assessment
Low — this only affects oversized webhook requests before normal dispatch; valid GitHub webhook deliveries remain on the existing path.

Generated with Amp
