### PR TITLE
fix(github): read apply gate checks via REST

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -317,7 +317,7 @@ required_checks:
   - "CI / required-tests"
 ```
 
-When any configured check appears in the PR status rollup, only configured checks are evaluated. A configured check that is absent does not block apply. If none of the configured checks appear, SchemaBot falls back to the default behavior and evaluates all non-SchemaBot checks.
+When any configured check appears in the PR check statuses, only configured checks are evaluated. A configured check that is absent does not block apply. If none of the configured checks appear, SchemaBot falls back to the default behavior and evaluates all non-SchemaBot checks.
 
 `required_checks` names must exactly match GitHub check run names or commit status contexts. Matching is case-sensitive, and config validation rejects names with leading or trailing whitespace.
 

--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -60,12 +60,12 @@ Under **Repository permissions**, grant:
 
 | Permission | Access | Used For |
 |-----------|--------|----------|
-| **Checks** | Read & Write | Create check runs on PRs showing plan results |
-| **Commit statuses** | Read | Read PR check statuses for the `require_passing_checks` gate |
-| **Contents** | Read | Read `schemabot.yaml` config and schema files from repos |
+| **Checks** | Read & Write | Create SchemaBot check runs and read GitHub check runs for the `require_passing_checks` gate |
+| **Commit statuses** | Read | Read legacy commit statuses for the `require_passing_checks` gate |
+| **Contents** | Read | Read `schemabot.yaml`, schema files, CODEOWNERS, and commit objects used by GitHub status rollups |
 | **Issues** | Read & Write | Post PR comments and add reactions |
 | **Metadata** | Read | Required (granted automatically) |
-| **Pull requests** | Read & Write | Fetch PR info (head SHA, changed files) |
+| **Pull requests** | Read & Write | Fetch PR info, changed files, and reviews |
 
 Under **Organization permissions**, grant:
 

--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -62,7 +62,7 @@ Under **Repository permissions**, grant:
 |-----------|--------|----------|
 | **Checks** | Read & Write | Create SchemaBot check runs and read GitHub check runs for the `require_passing_checks` gate |
 | **Commit statuses** | Read | Read legacy commit statuses for the `require_passing_checks` gate |
-| **Contents** | Read | Read `schemabot.yaml`, schema files, CODEOWNERS, and commit objects used by GitHub status rollups |
+| **Contents** | Read | Read `schemabot.yaml`, schema files, CODEOWNERS, and commit refs |
 | **Issues** | Read & Write | Post PR comments and add reactions |
 | **Metadata** | Read | Required (granted automatically) |
 | **Pull requests** | Read & Write | Fetch PR info, changed files, and reviews |

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -90,7 +90,7 @@ type ServerConfig struct {
 	RequirePassingChecks *bool `yaml:"require_passing_checks"`
 
 	// RequiredChecks narrows the PR checks gate to named checks when any of
-	// those checks are present in the GitHub status rollup. When empty, all
+	// those checks are present in the PR check statuses. When empty, all
 	// non-SchemaBot checks are evaluated.
 	RequiredChecks []string `yaml:"required_checks"`
 

--- a/pkg/api/telemetry_test.go
+++ b/pkg/api/telemetry_test.go
@@ -621,23 +621,48 @@ func TestRecordWebhookEventMetric(t *testing.T) {
 	metrics.RecordWebhookEvent(t.Context(), "default", "issue_comment", "created", "org/repo", "processed")
 	metrics.RecordWebhookEvent(t.Context(), "default", "pull_request", "opened", "org/repo", "processed")
 	metrics.RecordWebhookEvent(t.Context(), "default", "pull_request", "closed", "org/repo", "processed")
+	metrics.RecordWebhookEvent(t.Context(), "default", "push", "", "org/repo", "ignored")
+	metrics.RecordWebhookEvent(t.Context(), "default", "pull_request_review", "submitted", "org/repo", "ignored")
+	metrics.RecordWebhookEvent(t.Context(), "default", "issues", "edited", "org/repo", "ignored")
 	metrics.RecordWebhookEvent(t.Context(), "default", "ping", "", "", "ignored")
 
 	var rm metricdata.ResourceMetrics
 	require.NoError(t, reader.Collect(t.Context(), &rm))
 
 	var found bool
+	var sawPush, sawPullRequestReview, sawIssues bool
 	for _, sm := range rm.ScopeMetrics {
 		for _, m := range sm.Metrics {
 			if m.Name == "schemabot.webhook.events_total" {
 				found = true
 				sum, ok := m.Data.(metricdata.Sum[int64])
 				require.True(t, ok)
-				assert.Len(t, sum.DataPoints, 4, "expected 4 data points (one per event_type/action/status combo)")
+				assert.Len(t, sum.DataPoints, 7, "expected 7 data points (one per event_type/action/status combo)")
+				for _, dp := range sum.DataPoints {
+					eventType, ok := dp.Attributes.Value("event_type")
+					require.True(t, ok)
+					action, _ := dp.Attributes.Value("action")
+					switch eventType.AsString() {
+					case "push":
+						sawPush = true
+						assert.Empty(t, action.AsString())
+					case "pull_request_review":
+						sawPullRequestReview = true
+						assert.Equal(t, "submitted", action.AsString())
+					case "issues":
+						sawIssues = true
+						assert.Equal(t, "edited", action.AsString())
+					case "unknown":
+						t.Fatalf("expected subscribed webhook events to keep their event_type label: %+v", dp.Attributes)
+					}
+				}
 			}
 		}
 	}
 	assert.True(t, found, "schemabot.webhook.events_total metric not found")
+	assert.True(t, sawPush, "push event should not be normalized to unknown")
+	assert.True(t, sawPullRequestReview, "pull_request_review event should not be normalized to unknown")
+	assert.True(t, sawIssues, "issues event should not be normalized to unknown")
 }
 
 func TestRecordControlOperationMetric(t *testing.T) {

--- a/pkg/github/check_status_singleflight.go
+++ b/pkg/github/check_status_singleflight.go
@@ -7,14 +7,13 @@ import (
 	"golang.org/x/sync/singleflight"
 )
 
-// CheckStatusRow is the identity-independent slice of statusCheckRollup
-// data the singleflight shares across waiters. It deliberately omits
-// IsSchemaBot because that is derived from the calling
-// InstallationClient's appSlug, which is resolved at construction time
-// and may differ across the short-lived InstallationClients that share
-// this coalescer (e.g. when the slug was unavailable at startup and
-// later recovered). The owning InstallationClient projects to
-// PRCheckStatus on every read.
+// CheckStatusRow is the identity-independent check/status data the singleflight
+// shares across waiters. It deliberately omits IsSchemaBot because that is
+// derived from the calling InstallationClient's appSlug, which is resolved at
+// construction time and may differ across the short-lived InstallationClients
+// that share this coalescer (e.g. when the slug was unavailable at startup and
+// later recovered). The owning InstallationClient projects to PRCheckStatus on
+// every read.
 type CheckStatusRow struct {
 	Name       string
 	Status     string
@@ -22,8 +21,8 @@ type CheckStatusRow struct {
 	AppSlug    string // empty for legacy commit statuses (StatusContext nodes have no App)
 }
 
-// CheckStatusSingleflight coalesces concurrent statusCheckRollup fetches
-// for the same (repo, sha) into a single upstream GraphQL request via
+// CheckStatusSingleflight coalesces concurrent check/status fetches
+// for the same logical key into a single upstream GitHub read via
 // singleflight. It does not memoise across calls: once the in-flight
 // fetch completes, the next call issues a fresh request. This preserves
 // the burst-collapsing win (a webhook delivery that fans out to multiple
@@ -56,7 +55,7 @@ func NewCheckStatusSingleflight() *CheckStatusSingleflight {
 // fetch cannot outlive the GitHub round trip it wraps.
 const sharedFetchTimeout = 30 * time.Second
 
-// Do invokes fetch for (repo, sha), collapsing concurrent callers for
+// Do invokes fetch for (repo, key), collapsing concurrent callers for
 // the same key into a single fetch invocation. Each caller observes its
 // own ctx for cancellation/deadline: a caller whose ctx fires while
 // waiting on another caller's in-flight fetch returns promptly with
@@ -71,8 +70,8 @@ const sharedFetchTimeout = 30 * time.Second
 // including the caller that won the singleflight — cannot abort the
 // shared GitHub request and fail unrelated waiters whose own contexts
 // are still valid.
-func (c *CheckStatusSingleflight) Do(ctx context.Context, repo, sha string, fetch func(context.Context) ([]CheckStatusRow, error)) ([]CheckStatusRow, error) {
-	key := repo + "@" + sha
+func (c *CheckStatusSingleflight) Do(ctx context.Context, repo, key string, fetch func(context.Context) ([]CheckStatusRow, error)) ([]CheckStatusRow, error) {
+	key = repo + "@" + key
 
 	ch := c.group.DoChan(key, func() (any, error) {
 		// Decouple the shared fetch from the caller's ctx so a leader's

--- a/pkg/github/check_status_singleflight_test.go
+++ b/pkg/github/check_status_singleflight_test.go
@@ -238,9 +238,8 @@ func TestGetPRCheckStatuses_RecomputesIsSchemaBotPerWaiter(t *testing.T) {
 	postRecovery := &InstallationClient{checkStatusSingleflight: sf}
 	postRecovery.storeAppSlug("schemabot")
 
-	// Intercept the per-client fetch via a stub so the test can
-	// orchestrate when the shared fetch returns without exercising the
-	// real GraphQL transport.
+	// Intercept the per-client fetch via a stub so the test can orchestrate
+	// when the shared fetch returns without exercising the real GitHub API.
 	const repo, sha = "octo/repo", "abc123"
 	sharedRows := []CheckStatusRow{
 		{Name: "schemabot/apply staging", Status: "completed", Conclusion: "success", AppSlug: "schemabot"},
@@ -307,8 +306,8 @@ func TestGetPRCheckStatuses_RecomputesIsSchemaBotPerWaiter(t *testing.T) {
 }
 
 // projectRowsForTest mirrors the projection step inside
-// GetPRCheckStatuses so the per-waiter classification test can verify
-// the IsSchemaBot invariant without spinning up a real GraphQL transport.
+// GetPRCheckStatuses so the per-waiter classification test can verify the
+// IsSchemaBot invariant without spinning up a real GitHub API.
 func projectRowsForTest(ic *InstallationClient, rows []CheckStatusRow) []PRCheckStatus {
 	out := make([]PRCheckStatus, len(rows))
 	for i, r := range rows {

--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -23,7 +23,6 @@ import (
 	"github.com/gofri/go-github-ratelimit/v2/github_ratelimit"
 	"github.com/gofri/go-github-ratelimit/v2/github_ratelimit/github_secondary_ratelimit"
 	gh "github.com/google/go-github/v86/github"
-	"github.com/shurcooL/githubv4"
 )
 
 // GitHubClientFactory creates installation-scoped GitHub clients.
@@ -53,7 +52,7 @@ type Client struct {
 	lastSlugAttempt time.Time
 
 	// installations caches per-installation clients keyed by installationID
-	// so the underlying http.Client, gh.Client, githubv4.Client, and
+	// so the underlying http.Client, gh.Client, and
 	// ghinstallation transport (and its installation-token cache) are
 	// reused across webhook deliveries instead of being reconstructed on
 	// every call.
@@ -64,8 +63,8 @@ type Client struct {
 	// calls for the same (repo, sha) into a single upstream request via
 	// singleflight. Shared across every InstallationClient this factory
 	// produces so concurrent webhook deliveries and command bursts
-	// targeting the same commit collapse to a single GraphQL round
-	// trip even though each delivery may spawn a fresh InstallationClient.
+	// targeting the same commit collapse to one shared GitHub read even
+	// though each delivery may spawn a fresh InstallationClient.
 	// Deliberately not a TTL cache: check status is mutable for a SHA
 	// (reruns, late-arriving checks, branch-protection adding required
 	// checks), so any memoisation window would risk converting a
@@ -97,12 +96,12 @@ const slugFetchRetryCooldown = 5 * time.Second
 // since we can't identify our own checks.
 //
 // The returned Client memoises the *InstallationClient it produces by
-// installationID so the underlying http.Client, gh.Client, githubv4.Client, and
+// installationID so the underlying http.Client, gh.Client, and
 // ghinstallation transport (and its installation-token cache) are reused across
 // webhook deliveries. It also owns a CheckStatusSingleflight that is shared
 // across every InstallationClient it produces, so concurrent webhook
 // deliveries and command bursts targeting the same (repo, sha) collapse to a
-// single upstream GraphQL request.
+// single upstream GitHub read.
 func NewClient(appID int64, privateKey []byte, logger *slog.Logger) *Client {
 	c := &Client{
 		appID:                   appID,
@@ -115,7 +114,7 @@ func NewClient(appID int64, privateKey []byte, logger *slog.Logger) *Client {
 	// from a nil pointer.
 	c.storeAppSlug("")
 
-	// Fetch the app slug so we can identify our own check runs in statusCheckRollup.
+	// Fetch the app slug so we can identify our own check runs.
 	// Non-fatal: if GitHub is down, the server still starts but the check gate won't
 	// exclude own checks (PR applies may be blocked until the slug is fetched).
 	c.fetchAppSlug()
@@ -201,7 +200,6 @@ func (c *Client) ForInstallation(installationID int64) (*InstallationClient, err
 	ghClient.DisableRateLimitCheck = true
 	ic := &InstallationClient{
 		client:                  ghClient,
-		gql:                     githubv4.NewEnterpriseClient(graphQLURLFor(ghClient), httpc),
 		logger:                  c.logger,
 		installationID:          installationID,
 		checkStatusSingleflight: c.checkStatusSingleflight,
@@ -215,8 +213,6 @@ func (c *Client) ForInstallation(installationID int64) (*InstallationClient, err
 
 // NewInstallationClient creates an InstallationClient from a pre-configured go-github client.
 // Used in tests to point at httptest.Server; production uses Client.ForInstallation().
-// The GraphQL endpoint is derived from the go-github client's BaseURL so the same
-// httptest mux serves both REST and GraphQL.
 func NewInstallationClient(client *gh.Client, logger *slog.Logger) *InstallationClient {
 	return NewInstallationClientWithSlug(client, logger, "")
 }
@@ -228,23 +224,12 @@ func NewInstallationClientWithSlug(client *gh.Client, logger *slog.Logger, appSl
 		logger: logger,
 	}
 	ic.storeAppSlug(appSlug)
-	gqlHTTPClient := client.Client()
-	gqlHTTPClient.Transport = newGitHubMetricsTransport(gqlHTTPClient.Transport, 0, ic.loadAppSlug)
-	ic.gql = githubv4.NewEnterpriseClient(graphQLURLFor(client), gqlHTTPClient)
 	return ic
-}
-
-// graphQLURLFor returns the GraphQL endpoint for a given go-github client by
-// appending "graphql" to its REST BaseURL. Works for both api.github.com and
-// httptest servers used in tests.
-func graphQLURLFor(client *gh.Client) string {
-	return strings.TrimRight(client.BaseURL.String(), "/") + "/graphql"
 }
 
 // InstallationClient wraps a go-github client scoped to a specific GitHub App installation.
 type InstallationClient struct {
 	client *gh.Client
-	gql    *githubv4.Client
 	logger *slog.Logger
 
 	installationID int64
@@ -668,43 +653,6 @@ type PRCheckStatus struct {
 	IsSchemaBot bool   // true if this is a SchemaBot check
 }
 
-// statusCheckRollupQuery is the GraphQL query used by GetPRCheckStatuses.
-// statusCheckRollup returns check runs and commit statuses already deduped
-// and filtered to the latest run per check name.
-type statusCheckRollupQuery struct {
-	Repository struct {
-		Object struct {
-			Commit struct {
-				StatusCheckRollup struct {
-					Contexts struct {
-						PageInfo struct {
-							HasNextPage bool
-							EndCursor   githubv4.String
-						}
-						Nodes []struct {
-							Typename string `graphql:"__typename"`
-							CheckRun struct {
-								Name       string
-								Status     string
-								Conclusion string
-								CheckSuite struct {
-									App struct {
-										Slug string
-									}
-								}
-							} `graphql:"... on CheckRun"`
-							StatusContext struct {
-								Context string
-								State   string
-							} `graphql:"... on StatusContext"`
-						}
-					} `graphql:"contexts(first: 100, after: $after)"`
-				}
-			} `graphql:"... on Commit"`
-		} `graphql:"object(oid: $oid)"`
-	} `graphql:"repository(owner: $owner, name: $repo)"`
-}
-
 // isOwnAppSlug returns true if the given slug belongs to this SchemaBot
 // instance. An empty slug never matches — both to handle StatusContext rows
 // (which have no App) and to fail closed when ic.appSlug has not yet been
@@ -720,33 +668,36 @@ func (ic *InstallationClient) isOwnAppSlug(slug string) bool {
 	return strings.EqualFold(slug, own)
 }
 
-// GetPRCheckStatuses fetches all check runs and commit statuses for a ref via
-// the GraphQL Commit.statusCheckRollup, which returns already-deduped, latest-only
-// results in a single round trip. SchemaBot's own check runs are identified via
-// the GitHub App slug (more reliable than name matching).
+// GetPRCheckStatuses fetches check runs and commit statuses for a ref via REST.
+// SchemaBot's own check runs are identified via the GitHub App slug (more
+// reliable than name matching).
 //
 // Concurrent calls for the same (repo, ref) collapse to a single upstream
-// GraphQL request via the Client-shared singleflight (when configured), so
+// GitHub read via the Client-shared singleflight (when configured), so
 // a webhook delivery or command burst that fans out to multiple gate
-// checks for the same commit makes one round trip — even across the
-// short-lived InstallationClients spawned per delivery. The singleflight
-// delivers identity-independent rows; IsSchemaBot is re-derived per call
-// against this client's appSlug snapshot so a shared fetch delivered to N
-// waiters with different appSlug snapshots is classified correctly for
-// each.
-func (ic *InstallationClient) GetPRCheckStatuses(ctx context.Context, repo string, ref string) ([]PRCheckStatus, error) {
+// checks for the same commit shares the upstream work — even across the
+// short-lived InstallationClients spawned per delivery.
+//
+// requiredChecks is optional. When provided, commit statuses are fetched first;
+// if they contain every configured required check, check runs are not fetched.
+// This keeps status-only gates from depending on unrelated check-run access.
+//
+// The singleflight delivers identity-independent rows; IsSchemaBot is re-derived
+// per call against this client's appSlug snapshot so a shared fetch delivered to
+// N waiters with different appSlug snapshots is classified correctly for each.
+func (ic *InstallationClient) GetPRCheckStatuses(ctx context.Context, repo string, ref string, requiredChecks []string) ([]PRCheckStatus, error) {
 	var (
 		rows []CheckStatusRow
 		err  error
 	)
 	if ic.checkStatusSingleflight == nil {
-		rows, err = ic.fetchPRCheckStatuses(ctx, repo, ref)
+		rows, err = ic.fetchPRCheckStatuses(ctx, repo, ref, requiredChecks)
 	} else {
 		// The singleflight supplies its own ctx to the fetch so a
 		// caller cancelling cannot abort the shared GitHub request and
 		// fail unrelated waiters.
-		rows, err = ic.checkStatusSingleflight.Do(ctx, repo, ref, func(fetchCtx context.Context) ([]CheckStatusRow, error) {
-			return ic.fetchPRCheckStatuses(fetchCtx, repo, ref)
+		rows, err = ic.checkStatusSingleflight.Do(ctx, repo, checkStatusSingleflightKey(ref, requiredChecks), func(fetchCtx context.Context) ([]CheckStatusRow, error) {
+			return ic.fetchPRCheckStatuses(fetchCtx, repo, ref, requiredChecks)
 		})
 	}
 	if err != nil {
@@ -767,9 +718,7 @@ func (ic *InstallationClient) GetPRCheckStatuses(ctx context.Context, repo strin
 
 // CheckStatusAccessDiagnostic captures what SchemaBot can prove about the
 // installation token's ability to read the REST resources underlying the PR
-// check-status gate. GitHub's GraphQL statusCheckRollup permission errors do
-// not identify the exact missing permission, so this diagnostic probes the
-// equivalent REST Checks and Commit Statuses endpoints after a rollup failure.
+// check-status gate.
 type CheckStatusAccessDiagnostic struct {
 	ChecksReadable         bool
 	CommitStatusesReadable bool
@@ -779,8 +728,8 @@ type CheckStatusAccessDiagnostic struct {
 }
 
 // DiagnoseCheckStatusAccess probes REST endpoints used to reconstruct a PR's
-// checks/statuses. It is intended for error reporting after GraphQL
-// statusCheckRollup fails, not for the hot success path.
+// checks/statuses. It is intended for error reporting after check-status reads
+// fail, not for the hot success path.
 func (ic *InstallationClient) DiagnoseCheckStatusAccess(ctx context.Context, repo string, ref string) CheckStatusAccessDiagnostic {
 	owner, repoName := splitRepo(repo)
 	d := CheckStatusAccessDiagnostic{}
@@ -812,57 +761,109 @@ func isResourceNotAccessible(err error) bool {
 	return err != nil && strings.Contains(err.Error(), "Resource not accessible")
 }
 
-// fetchPRCheckStatuses performs the actual GraphQL round trip for
-// GetPRCheckStatuses, returning identity-independent rows suitable for
-// caching across InstallationClients with different appSlug snapshots.
-func (ic *InstallationClient) fetchPRCheckStatuses(ctx context.Context, repo string, ref string) ([]CheckStatusRow, error) {
+// fetchPRCheckStatuses performs the actual REST reads for GetPRCheckStatuses,
+// returning identity-independent rows suitable for sharing across
+// InstallationClients with different appSlug snapshots.
+func (ic *InstallationClient) fetchPRCheckStatuses(ctx context.Context, repo string, ref string, requiredChecks []string) ([]CheckStatusRow, error) {
 	owner, repoName := splitRepo(repo)
-	ctx = withGitHubRateLimitContext(ctx, metrics.GitHubOperationGraphQLStatusCheckRollup, repo)
-
-	vars := map[string]any{
-		"owner": githubv4.String(owner),
-		"repo":  githubv4.String(repoName),
-		"oid":   githubv4.GitObjectID(ref),
-		"after": (*githubv4.String)(nil),
-	}
 
 	var out []CheckStatusRow
+	statusRows, err := ic.fetchCommitStatusRows(ctx, owner, repoName, repo, ref)
+	if err != nil {
+		return nil, err
+	}
+	out = append(out, statusRows...)
+
+	if len(requiredChecks) > 0 && checkRowsContainRequiredChecks(statusRows, requiredChecks) {
+		return out, nil
+	}
+
+	checkRows, err := ic.fetchCheckRunRows(ctx, owner, repoName, repo, ref)
+	if err != nil {
+		return nil, err
+	}
+	out = append(out, checkRows...)
+	return out, nil
+}
+
+func (ic *InstallationClient) fetchCommitStatusRows(ctx context.Context, owner, repoName, repo, ref string) ([]CheckStatusRow, error) {
+	ctx = withGitHubRateLimitContext(ctx, metrics.GitHubOperationGetCombinedStatus, repo)
+	opts := &gh.ListOptions{PerPage: 100}
+	var out []CheckStatusRow
 	for {
-		var q statusCheckRollupQuery
-		if err := ic.gql.Query(ctx, &q, vars); err != nil {
-			return nil, fmt.Errorf("graphql statusCheckRollup ref %s: %w", ref, err)
+		combined, resp, err := ic.client.Repositories.GetCombinedStatus(ctx, owner, repoName, ref, opts)
+		if err != nil {
+			return nil, fmt.Errorf("get combined commit status for %s@%s: %w", repo, ref, err)
 		}
-		contexts := q.Repository.Object.Commit.StatusCheckRollup.Contexts
-		for _, n := range contexts.Nodes {
-			switch n.Typename {
-			case "CheckRun":
+		if combined != nil {
+			for _, status := range combined.Statuses {
+				state, conclusion := mapLegacyStatusState(status.GetState())
 				out = append(out, CheckStatusRow{
-					Name:       n.CheckRun.Name,
-					Status:     strings.ToLower(n.CheckRun.Status),
-					Conclusion: strings.ToLower(n.CheckRun.Conclusion),
-					AppSlug:    n.CheckRun.CheckSuite.App.Slug,
-				})
-			case "StatusContext":
-				status, conclusion := mapLegacyStatusState(n.StatusContext.State)
-				out = append(out, CheckStatusRow{
-					Name:       n.StatusContext.Context,
-					Status:     status,
+					Name:       status.GetContext(),
+					Status:     state,
 					Conclusion: conclusion,
-					// AppSlug left empty: commit statuses have no App, so
-					// IsSchemaBot evaluates to false regardless of ic.appSlug.
 				})
 			}
 		}
-		if !contexts.PageInfo.HasNextPage {
+		if resp == nil || resp.NextPage == 0 {
 			break
 		}
-		after := contexts.PageInfo.EndCursor
-		vars["after"] = &after
+		opts.Page = resp.NextPage
 	}
 	return out, nil
 }
 
-// mapLegacyStatusState maps a GraphQL StatusState enum (EXPECTED, ERROR, FAILURE,
+func (ic *InstallationClient) fetchCheckRunRows(ctx context.Context, owner, repoName, repo, ref string) ([]CheckStatusRow, error) {
+	ctx = withGitHubRateLimitContext(ctx, metrics.GitHubOperationListCheckRunsForRef, repo)
+	filter := "latest"
+	opts := &gh.ListCheckRunsOptions{Filter: &filter, ListOptions: gh.ListOptions{PerPage: 100}}
+	var out []CheckStatusRow
+	for {
+		result, resp, err := ic.client.Checks.ListCheckRunsForRef(ctx, owner, repoName, ref, opts)
+		if err != nil {
+			return nil, fmt.Errorf("list check runs for %s@%s: %w", repo, ref, err)
+		}
+		if result != nil {
+			for _, run := range result.CheckRuns {
+				out = append(out, CheckStatusRow{
+					Name:       run.GetName(),
+					Status:     strings.ToLower(run.GetStatus()),
+					Conclusion: strings.ToLower(run.GetConclusion()),
+					AppSlug:    run.GetApp().GetSlug(),
+				})
+			}
+		}
+		if resp == nil || resp.NextPage == 0 {
+			break
+		}
+		opts.Page = resp.NextPage
+	}
+	return out, nil
+}
+
+func checkRowsContainRequiredChecks(rows []CheckStatusRow, requiredChecks []string) bool {
+	seen := make(map[string]bool, len(rows))
+	for _, row := range rows {
+		seen[row.Name] = true
+	}
+	for _, required := range requiredChecks {
+		if !seen[required] {
+			return false
+		}
+	}
+	return true
+}
+
+func checkStatusSingleflightKey(ref string, requiredChecks []string) string {
+	if len(requiredChecks) == 0 {
+		return ref
+	}
+	sortedRequiredChecks := append([]string(nil), requiredChecks...)
+	sort.Strings(sortedRequiredChecks)
+	return ref + "\x00" + strings.Join(sortedRequiredChecks, "\x00")
+}
+
+// mapLegacyStatusState maps a commit status state (EXPECTED, ERROR, FAILURE,
 // PENDING, SUCCESS) to the (status, conclusion) pair used by PRCheckStatus, so
 // downstream filters can treat check runs and legacy statuses uniformly.
 func mapLegacyStatusState(state string) (status, conclusion string) {

--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -289,6 +289,13 @@ func newGitHubRateLimitTransport(base http.RoundTripper) http.RoundTripper {
 	)
 }
 
+// AppSlug returns the GitHub App slug associated with this installation
+// client, when known. It is best-effort: startup can proceed before the slug
+// is fetched, so callers should tolerate an empty string.
+func (ic *InstallationClient) AppSlug() string {
+	return ic.loadAppSlug()
+}
+
 // IsNotFoundError checks if an error is a GitHub API 404 Not Found error.
 func IsNotFoundError(err error) bool {
 	var ghErr *gh.ErrorResponse
@@ -756,6 +763,53 @@ func (ic *InstallationClient) GetPRCheckStatuses(ctx context.Context, repo strin
 		}
 	}
 	return out, nil
+}
+
+// CheckStatusAccessDiagnostic captures what SchemaBot can prove about the
+// installation token's ability to read the REST resources underlying the PR
+// check-status gate. GitHub's GraphQL statusCheckRollup permission errors do
+// not identify the exact missing permission, so this diagnostic probes the
+// equivalent REST Checks and Commit Statuses endpoints after a rollup failure.
+type CheckStatusAccessDiagnostic struct {
+	ChecksReadable         bool
+	CommitStatusesReadable bool
+	ChecksError            string
+	CommitStatusesError    string
+	MissingPermissions     []string
+}
+
+// DiagnoseCheckStatusAccess probes REST endpoints used to reconstruct a PR's
+// checks/statuses. It is intended for error reporting after GraphQL
+// statusCheckRollup fails, not for the hot success path.
+func (ic *InstallationClient) DiagnoseCheckStatusAccess(ctx context.Context, repo string, ref string) CheckStatusAccessDiagnostic {
+	owner, repoName := splitRepo(repo)
+	d := CheckStatusAccessDiagnostic{}
+
+	checksCtx := withGitHubRateLimitContext(ctx, metrics.GitHubOperationListCheckRunsForRef, repo)
+	if _, _, err := ic.client.Checks.ListCheckRunsForRef(checksCtx, owner, repoName, ref, &gh.ListCheckRunsOptions{ListOptions: gh.ListOptions{PerPage: 1}}); err != nil {
+		d.ChecksError = err.Error()
+		if isResourceNotAccessible(err) {
+			d.MissingPermissions = append(d.MissingPermissions, "Checks: Read")
+		}
+	} else {
+		d.ChecksReadable = true
+	}
+
+	statusesCtx := withGitHubRateLimitContext(ctx, metrics.GitHubOperationGetCombinedStatus, repo)
+	if _, _, err := ic.client.Repositories.GetCombinedStatus(statusesCtx, owner, repoName, ref, &gh.ListOptions{PerPage: 1}); err != nil {
+		d.CommitStatusesError = err.Error()
+		if isResourceNotAccessible(err) {
+			d.MissingPermissions = append(d.MissingPermissions, "Commit statuses: Read")
+		}
+	} else {
+		d.CommitStatusesReadable = true
+	}
+
+	return d
+}
+
+func isResourceNotAccessible(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "Resource not accessible")
 }
 
 // fetchPRCheckStatuses performs the actual GraphQL round trip for

--- a/pkg/github/rate_limit_metrics.go
+++ b/pkg/github/rate_limit_metrics.go
@@ -367,6 +367,7 @@ func gitHubRequestCategory(operation string) string {
 		metrics.GitHubOperationFetchFileContent,
 		metrics.GitHubOperationFetchGitTree,
 		metrics.GitHubOperationFetchPullRequest,
+		metrics.GitHubOperationGetCombinedStatus,
 		metrics.GitHubOperationGetTeamMembership,
 		metrics.GitHubOperationGraphQLStatusCheckRollup,
 		metrics.GitHubOperationListCheckRunsForRef,

--- a/pkg/metrics/README.md
+++ b/pkg/metrics/README.md
@@ -69,13 +69,13 @@ available, such as `repository`, `github_app`, and `installation_id`.
 
 **status** (locks): `success`, `conflict`, `not_found`, `not_owned`, `error`
 
-**event_type** (webhooks): `issue_comment`, `pull_request`, `check_run`, `ping`
+**event_type** (webhooks): `create`, `issues`, `issue_comment`, `pull_request`, `pull_request_review`, `pull_request_review_comment`, `check_run`, `ping`, `push`
 
-**action** (webhooks): `created`, `opened`, `synchronize`, `reopened`, `closed`, `requested`, `completed` (omitted for events without actions like `ping`)
+**action** (webhooks): common GitHub actions for the subscribed webhook events, such as `created`, `opened`, `synchronize`, `submitted`, `edited`, `closed`, `requested`, `completed` (omitted for events without actions like `ping` and `push`)
 
 **status** (webhooks): `processed`, `invalid_signature`, `ignored`
 
-**operation** (GitHub API): `add_comment_reaction`, `create_check_run`, `create_issue_comment`, `create_installation_access_token`, `edit_issue_comment`, `fetch_app_slug`, `fetch_blob`, `fetch_file_content`, `fetch_git_tree`, `fetch_pull_request`, `get_team_membership`, `graphql_status_check_rollup`, `list_check_runs_for_ref`, `list_pr_files`, `list_reviews`, `list_team_members`, `request_reviewers`, `unknown`, `update_check_run`
+**operation** (GitHub API): `add_comment_reaction`, `create_check_run`, `create_issue_comment`, `create_installation_access_token`, `edit_issue_comment`, `fetch_app_slug`, `fetch_blob`, `fetch_file_content`, `fetch_git_tree`, `fetch_pull_request`, `get_combined_status`, `get_team_membership`, `graphql_status_check_rollup`, `list_check_runs_for_ref`, `list_pr_files`, `list_reviews`, `list_team_members`, `request_reviewers`, `unknown`, `update_check_run`
 
 **category** (GitHub API): `auth`, `read`, `write`, `unknown`
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -593,22 +593,48 @@ func RecordSchedulerClaimDuration(ctx context.Context, duration time.Duration, d
 
 // knownWebhookEvents limits metric cardinality to expected GitHub event types.
 var knownWebhookEvents = map[string]bool{
-	"issue_comment": true,
-	"pull_request":  true,
-	"check_run":     true,
-	"ping":          true,
+	"create":                      true,
+	"issues":                      true,
+	"issue_comment":               true,
+	"pull_request":                true,
+	"pull_request_review":         true,
+	"pull_request_review_comment": true,
+	"check_run":                   true,
+	"ping":                        true,
+	"push":                        true,
 }
 
 // knownWebhookActions limits metric cardinality to expected GitHub webhook actions.
 var knownWebhookActions = map[string]bool{
-	"created":     true, // issue_comment
-	"opened":      true, // pull_request
-	"synchronize": true, // pull_request
-	"reopened":    true, // pull_request
-	"closed":      true, // pull_request
-	"requested":   true, // check_run
-	"completed":   true, // check_run
-	"":            true, // events without actions (e.g., ping)
+	"assigned":               true,
+	"auto_merge_disabled":    true,
+	"auto_merge_enabled":     true,
+	"closed":                 true,
+	"completed":              true,
+	"converted_to_draft":     true,
+	"created":                true,
+	"deleted":                true,
+	"demilestoned":           true,
+	"dismissed":              true,
+	"edited":                 true,
+	"labeled":                true,
+	"locked":                 true,
+	"milestoned":             true,
+	"opened":                 true,
+	"pinned":                 true,
+	"ready_for_review":       true,
+	"reopened":               true,
+	"requested":              true,
+	"review_request_removed": true,
+	"review_requested":       true,
+	"submitted":              true,
+	"synchronize":            true,
+	"transferred":            true,
+	"unassigned":             true,
+	"unlabeled":              true,
+	"unlocked":               true,
+	"unpinned":               true,
+	"":                       true, // events without actions (e.g., ping, push)
 }
 
 // RecordSchemaRequestError increments the schema request error counter.
@@ -648,6 +674,7 @@ const (
 	GitHubOperationFetchFileContent              = "fetch_file_content"
 	GitHubOperationFetchGitTree                  = "fetch_git_tree"
 	GitHubOperationFetchPullRequest              = "fetch_pull_request"
+	GitHubOperationGetCombinedStatus             = "get_combined_status"
 	GitHubOperationGetTeamMembership             = "get_team_membership"
 	GitHubOperationGraphQLStatusCheckRollup      = "graphql_status_check_rollup"
 	GitHubOperationListCheckRunsForRef           = "list_check_runs_for_ref"
@@ -687,7 +714,10 @@ const (
 	GitHubRateLimitResourceSourceImport              = "source_import"
 )
 
-var seenUnknownGitHubMetricLabels sync.Map
+var (
+	seenUnknownGitHubMetricLabels  sync.Map
+	seenUnknownWebhookMetricLabels sync.Map
+)
 
 // GitHubRequestSample describes a GitHub API response observed by SchemaBot.
 // Category distinguishes reads from content-generating writes so dashboards can
@@ -851,6 +881,7 @@ func isKnownGitHubOperation(operation string) bool {
 		GitHubOperationFetchFileContent,
 		GitHubOperationFetchGitTree,
 		GitHubOperationFetchPullRequest,
+		GitHubOperationGetCombinedStatus,
 		GitHubOperationGetTeamMembership,
 		GitHubOperationGraphQLStatusCheckRollup,
 		GitHubOperationListCheckRunsForRef,
@@ -918,9 +949,11 @@ func isKnownGitHubRateLimitResource(resource string) bool {
 // "default".
 func RecordWebhookEvent(ctx context.Context, appName, eventType, action, repo, status string) {
 	if !knownWebhookEvents[eventType] {
+		logUnknownWebhookMetricLabel("event_type", eventType, appName, repo, status)
 		eventType = "unknown"
 	}
 	if !knownWebhookActions[action] {
+		logUnknownWebhookMetricLabel("action", action, appName, repo, status)
 		action = "unknown"
 	}
 	if appName == "" {
@@ -948,6 +981,19 @@ func RecordWebhookEvent(ctx context.Context, appName, eventType, action, repo, s
 		attrs = append(attrs, attribute.String("repository", repo))
 	}
 	counter.Add(ctx, 1, otelmetric.WithAttributes(attrs...))
+}
+
+func logUnknownWebhookMetricLabel(label, value, appName, repo, status string) {
+	key := label + "\x00" + value + "\x00" + appName + "\x00" + repo + "\x00" + status
+	if _, loaded := seenUnknownWebhookMetricLabels.LoadOrStore(key, struct{}{}); loaded {
+		return
+	}
+	slog.Warn("webhook metric label normalized to unknown",
+		"label", label,
+		"value", value,
+		"app_name", appName,
+		"repo", repo,
+		"status", status)
 }
 
 var knownStatusCheckOperations = map[string]bool{

--- a/pkg/webhook/apply_e2e_test.go
+++ b/pkg/webhook/apply_e2e_test.go
@@ -2007,28 +2007,23 @@ func TestE2EApplyAutoConfirmReGatesAgainstFreshHEADBeforeApply(t *testing.T) {
 	// The schema-freshness check therefore passes; the re-gate is the only
 	// thing that can still block the apply.
 
-	// GraphQL handler: PASS on the early gate call, FAIL on the fresh-HEAD
-	// re-gate call. Without the re-gate, this transition would be invisible
-	// to `apply -y` and the apply would proceed against red CI.
-	var graphqlCalls atomic.Int64
-	passing := rollupGraphQLHandler(nil)
-	failing := rollupGraphQLHandler([]rollupNode{
-		{
+	// Check-status handler: PASS on the early gate read, FAIL on the fresh-HEAD
+	// re-gate read. Without the re-gate, this transition would be invisible to
+	// `apply -y` and the apply would proceed against red CI.
+	var checkStatusReads atomic.Int64
+	provider := func() []checkStatusNode {
+		if checkStatusReads.Add(1) <= 2 {
+			return nil
+		}
+		return []checkStatusNode{{
 			Typename:   "CheckRun",
 			Name:       "ci/lint",
-			Status:     "COMPLETED",
-			Conclusion: "FAILURE",
+			Status:     "completed",
+			Conclusion: "failure",
 			AppSlug:    "ci-bot",
-		},
-	})
-	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if graphqlCalls.Add(1) == 1 {
-			passing(w, r)
-			return
-		}
-		failing(w, r)
-	})
-	result.GraphQLHandler.Store(&handler)
+		}}
+	}
+	result.CheckStatusNodes.Store(&provider)
 
 	h := newE2EHandler(t, svc, client)
 
@@ -2062,11 +2057,11 @@ func TestE2EApplyAutoConfirmReGatesAgainstFreshHEADBeforeApply(t *testing.T) {
 	assert.Contains(t, blocked, "failure", "block comment must show the failing conclusion")
 	assert.Contains(t, blocked, "staging", "retry hint must reference the env")
 
-	// Re-gate must have actually happened — at least two GraphQL calls
-	// (early gate + re-gate). The singleflight does not memoise across
-	// sequential calls so the second call hits the mock.
-	assert.GreaterOrEqual(t, graphqlCalls.Load(), int64(2),
-		"expected at least 2 GraphQL calls (early gate + fresh-HEAD re-gate)")
+	// Re-gate must have actually happened. Each gate reads commit statuses and
+	// check runs, and singleflight does not memoise across sequential calls, so
+	// the fresh-HEAD re-gate hits the mock again.
+	assert.GreaterOrEqual(t, checkStatusReads.Load(), int64(4),
+		"expected early gate + fresh-HEAD re-gate check-status reads")
 
 	// Lock must be released so the user can re-run `apply -y` once checks recover.
 	require.Eventually(t, func() bool {
@@ -2112,40 +2107,35 @@ func TestE2EApplyAutoConfirmFreshHEADBlockPreservesOtherPRLock(t *testing.T) {
 		_ = svc.Storage().Locks().ForceRelease(context.WithoutCancel(t.Context()), dbName, "mysql")
 	})
 
-	// GraphQL handler: PASS on the early gate call; on the re-gate call,
+	// Check-status handler: PASS on the early gate read; on the re-gate read,
 	// FIRST swap the lock owner to a different PR (#999), THEN return FAILURE.
 	// The swap simulates an unrelated `schemabot unlock` + another PR
 	// acquiring the lock in the window between our acquire and our re-gate.
-	var graphqlCalls atomic.Int64
-	passing := rollupGraphQLHandler(nil)
-	failing := rollupGraphQLHandler([]rollupNode{
-		{
-			Typename:   "CheckRun",
-			Name:       "ci/lint",
-			Status:     "COMPLETED",
-			Conclusion: "FAILURE",
-			AppSlug:    "ci-bot",
-		},
-	})
-	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if graphqlCalls.Add(1) == 1 {
-			passing(w, r)
-			return
+	var checkStatusReads atomic.Int64
+	provider := func() []checkStatusNode {
+		if checkStatusReads.Add(1) <= 2 {
+			return nil
 		}
-		// Re-gate call: swap the lock to PR #999 before responding FAILURE.
+		// Re-gate read: swap the lock to PR #999 before responding FAILURE.
 		// ForceRelease then re-Acquire is the closest analogue to "another
 		// caller cleared and reacquired" within a single test process.
-		_ = svc.Storage().Locks().ForceRelease(r.Context(), dbName, "mysql")
-		_ = svc.Storage().Locks().Acquire(r.Context(), &storage.Lock{
+		_ = svc.Storage().Locks().ForceRelease(t.Context(), dbName, "mysql")
+		_ = svc.Storage().Locks().Acquire(t.Context(), &storage.Lock{
 			DatabaseName: dbName,
 			DatabaseType: "mysql",
 			Repository:   "octocat/hello-world",
 			PullRequest:  999,
 			Owner:        otherOwner,
 		})
-		failing(w, r)
-	})
-	result.GraphQLHandler.Store(&handler)
+		return []checkStatusNode{{
+			Typename:   "CheckRun",
+			Name:       "ci/lint",
+			Status:     "completed",
+			Conclusion: "failure",
+			AppSlug:    "ci-bot",
+		}}
+	}
+	result.CheckStatusNodes.Store(&provider)
 
 	h := newE2EHandler(t, svc, client)
 

--- a/pkg/webhook/apply_gating.go
+++ b/pkg/webhook/apply_gating.go
@@ -2,6 +2,7 @@ package webhook
 
 import (
 	"context"
+	"strings"
 
 	"github.com/block/schemabot/pkg/api"
 	ghclient "github.com/block/schemabot/pkg/github"
@@ -48,14 +49,16 @@ func (h *Handler) enforcePassingChecks(ctx context.Context, client *ghclient.Ins
 
 	statuses, err := client.GetPRCheckStatuses(ctx, repo, headSHA, config.RequiredChecks)
 	if err != nil {
-		diagnostic := client.DiagnoseCheckStatusAccess(ctx, repo, headSHA)
 		details := &templates.CheckStatusAccessDetails{
-			GitHubApp:              h.githubAppDisplayNameForRepo(repo, client),
-			MissingPermissions:     diagnostic.MissingPermissions,
-			ChecksReadable:         diagnostic.ChecksReadable,
-			CommitStatusesReadable: diagnostic.CommitStatusesReadable,
-			ChecksError:            diagnostic.ChecksError,
-			CommitStatusesError:    diagnostic.CommitStatusesError,
+			GitHubApp: h.githubAppDisplayNameForRepo(repo, client),
+		}
+		diagnostic := ghclient.CheckStatusAccessDiagnostic{}
+		diagnosticRan := checkStatusReadLooksPermissionDenied(err)
+		if diagnosticRan {
+			diagnostic = client.DiagnoseCheckStatusAccess(ctx, repo, headSHA)
+			details.MissingPermissions = diagnostic.MissingPermissions
+			details.ChecksReadable = diagnostic.ChecksReadable
+			details.CommitStatusesReadable = diagnostic.CommitStatusesReadable
 		}
 		h.logger.Error("failed to fetch PR check statuses, blocking apply",
 			"repo", repo,
@@ -65,6 +68,7 @@ func (h *Handler) enforcePassingChecks(ctx context.Context, client *ghclient.Ins
 			"installation_id", installationID,
 			"github_operation", "read_pr_check_statuses",
 			"github_app", details.GitHubApp,
+			"diagnostic_ran", diagnosticRan,
 			"checks_readable", diagnostic.ChecksReadable,
 			"commit_statuses_readable", diagnostic.CommitStatusesReadable,
 			"missing_permissions", diagnostic.MissingPermissions,
@@ -98,6 +102,10 @@ func (h *Handler) enforcePassingChecks(ctx context.Context, client *ghclient.Ins
 	}
 
 	return false
+}
+
+func checkStatusReadLooksPermissionDenied(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "Resource not accessible")
 }
 
 func (h *Handler) githubAppDisplayNameForRepo(repo string, client *ghclient.InstallationClient) string {

--- a/pkg/webhook/apply_gating.go
+++ b/pkg/webhook/apply_gating.go
@@ -14,7 +14,7 @@ import (
 // are considered failing.
 func filterFailingNonSchemaBotChecks(statuses []ghclient.PRCheckStatus, config *api.ServerConfig) []templates.BlockingCheck {
 	var failing []templates.BlockingCheck
-	filterRequiredChecks := statusRollupContainsRequiredCheck(statuses, config)
+	filterRequiredChecks := statusesContainRequiredCheck(statuses, config)
 	for _, s := range statuses {
 		if s.IsSchemaBot {
 			continue
@@ -46,7 +46,7 @@ func (h *Handler) enforcePassingChecks(ctx context.Context, client *ghclient.Ins
 		return false
 	}
 
-	statuses, err := client.GetPRCheckStatuses(ctx, repo, headSHA)
+	statuses, err := client.GetPRCheckStatuses(ctx, repo, headSHA, config.RequiredChecks)
 	if err != nil {
 		diagnostic := client.DiagnoseCheckStatusAccess(ctx, repo, headSHA)
 		details := &templates.CheckStatusAccessDetails{
@@ -63,7 +63,7 @@ func (h *Handler) enforcePassingChecks(ctx context.Context, client *ghclient.Ins
 			"environment", environment,
 			"head_sha", headSHA,
 			"installation_id", installationID,
-			"github_operation", "graphql_status_check_rollup",
+			"github_operation", "read_pr_check_statuses",
 			"github_app", details.GitHubApp,
 			"checks_readable", diagnostic.ChecksReadable,
 			"commit_statuses_readable", diagnostic.CommitStatusesReadable,
@@ -118,7 +118,7 @@ func (h *Handler) githubAppDisplayNameForRepo(repo string, client *ghclient.Inst
 // excluding SchemaBot's own checks.
 func filterInProgressNonSchemaBotChecks(statuses []ghclient.PRCheckStatus, config *api.ServerConfig) []templates.BlockingCheck {
 	var inProgress []templates.BlockingCheck
-	filterRequiredChecks := statusRollupContainsRequiredCheck(statuses, config)
+	filterRequiredChecks := statusesContainRequiredCheck(statuses, config)
 	for _, s := range statuses {
 		if s.IsSchemaBot {
 			continue
@@ -137,7 +137,7 @@ func filterInProgressNonSchemaBotChecks(statuses []ghclient.PRCheckStatus, confi
 	return inProgress
 }
 
-func statusRollupContainsRequiredCheck(statuses []ghclient.PRCheckStatus, config *api.ServerConfig) bool {
+func statusesContainRequiredCheck(statuses []ghclient.PRCheckStatus, config *api.ServerConfig) bool {
 	if config == nil || len(config.RequiredChecks) == 0 {
 		return false
 	}

--- a/pkg/webhook/apply_gating.go
+++ b/pkg/webhook/apply_gating.go
@@ -48,10 +48,31 @@ func (h *Handler) enforcePassingChecks(ctx context.Context, client *ghclient.Ins
 
 	statuses, err := client.GetPRCheckStatuses(ctx, repo, headSHA)
 	if err != nil {
+		diagnostic := client.DiagnoseCheckStatusAccess(ctx, repo, headSHA)
+		details := &templates.CheckStatusAccessDetails{
+			GitHubApp:              h.githubAppDisplayNameForRepo(repo, client),
+			MissingPermissions:     diagnostic.MissingPermissions,
+			ChecksReadable:         diagnostic.ChecksReadable,
+			CommitStatusesReadable: diagnostic.CommitStatusesReadable,
+			ChecksError:            diagnostic.ChecksError,
+			CommitStatusesError:    diagnostic.CommitStatusesError,
+		}
 		h.logger.Error("failed to fetch PR check statuses, blocking apply",
-			"repo", repo, "pr", pr, "environment", environment, "error", err)
+			"repo", repo,
+			"pr", pr,
+			"environment", environment,
+			"head_sha", headSHA,
+			"installation_id", installationID,
+			"github_operation", "graphql_status_check_rollup",
+			"github_app", details.GitHubApp,
+			"checks_readable", diagnostic.ChecksReadable,
+			"commit_statuses_readable", diagnostic.CommitStatusesReadable,
+			"missing_permissions", diagnostic.MissingPermissions,
+			"checks_error", diagnostic.ChecksError,
+			"commit_statuses_error", diagnostic.CommitStatusesError,
+			"error", err)
 		h.postComment(repo, pr, installationID,
-			templates.RenderApplyBlockedByCheckStatusError(environment, err))
+			templates.RenderApplyBlockedByCheckStatusError(environment, err, details))
 		return true
 	}
 
@@ -77,6 +98,20 @@ func (h *Handler) enforcePassingChecks(ctx context.Context, client *ghclient.Ins
 	}
 
 	return false
+}
+
+func (h *Handler) githubAppDisplayNameForRepo(repo string, client *ghclient.InstallationClient) string {
+	if client != nil {
+		if slug := client.AppSlug(); slug != "" {
+			return slug
+		}
+	}
+	if cfg := h.config(); cfg != nil {
+		if resolved, err := cfg.ResolveGitHubAppForRepo(repo); err == nil && resolved.Name != defaultAppName {
+			return resolved.Name
+		}
+	}
+	return ""
 }
 
 // filterInProgressNonSchemaBotChecks returns checks that are still running,

--- a/pkg/webhook/apply_gating_test.go
+++ b/pkg/webhook/apply_gating_test.go
@@ -235,47 +235,52 @@ func TestFilterInProgressNonSchemaBotChecks_RequiredChecks(t *testing.T) {
 	}
 }
 
-// rollupNode is a single GraphQL statusCheckRollup contexts node, used by tests
-// to build mock GraphQL responses. Set Typename to "CheckRun" or "StatusContext"
-// and populate the matching fields.
-type rollupNode struct {
+// checkStatusNode is a single check run or commit status used by tests to build
+// mock REST responses. Set Typename to "CheckRun" or "StatusContext" and
+// populate the matching fields.
+type checkStatusNode struct {
 	Typename   string
 	Name       string // CheckRun.name
-	Status     string // CheckRun.status (uppercase: COMPLETED, IN_PROGRESS, ...)
-	Conclusion string // CheckRun.conclusion (uppercase: SUCCESS, FAILURE, ...)
+	Status     string // CheckRun.status
+	Conclusion string // CheckRun.conclusion
 	AppSlug    string // CheckRun.checkSuite.app.slug
 	Context    string // StatusContext.context
-	State      string // StatusContext.state (uppercase)
+	State      string // StatusContext.state
 }
 
-// rollupGraphQLHandler returns an http.HandlerFunc that responds to a GraphQL
-// statusCheckRollup query with the supplied contexts.
-func rollupGraphQLHandler(nodes []rollupNode) http.HandlerFunc {
-	return func(w http.ResponseWriter, _ *http.Request) {
-		out := make([]map[string]any, 0, len(nodes))
-		for _, n := range nodes {
-			node := map[string]any{"__typename": n.Typename}
-			switch n.Typename {
-			case "CheckRun":
-				node["name"] = n.Name
-				node["status"] = n.Status
-				node["conclusion"] = n.Conclusion
-				node["checkSuite"] = map[string]any{"app": map[string]any{"slug": n.AppSlug}}
-			case "StatusContext":
-				node["context"] = n.Context
-				node["state"] = n.State
+// registerCheckStatusRESTHandlers registers REST responses for commit statuses
+// and check runs on the standard apply-gating test repository/ref.
+func registerCheckStatusRESTHandlers(mux *http.ServeMux, nodes []checkStatusNode) {
+	registerCheckStatusRESTHandlersForRef(mux, "abc123", func() []checkStatusNode { return nodes })
+}
+
+func registerCheckStatusRESTHandlersForRef(mux *http.ServeMux, ref string, nodes func() []checkStatusNode) {
+	base := "/repos/octocat/hello-world/commits/" + ref
+	mux.HandleFunc("GET "+base+"/status", func(w http.ResponseWriter, _ *http.Request) {
+		statuses := make([]map[string]any, 0)
+		for _, n := range nodes() {
+			if n.Typename != "StatusContext" {
+				continue
 			}
-			out = append(out, node)
+			statuses = append(statuses, map[string]any{"context": n.Context, "state": n.State})
 		}
-		_ = json.NewEncoder(w).Encode(map[string]any{
-			"data": map[string]any{"repository": map[string]any{"object": map[string]any{
-				"statusCheckRollup": map[string]any{"contexts": map[string]any{
-					"pageInfo": map[string]any{"hasNextPage": false, "endCursor": ""},
-					"nodes":    out,
-				}},
-			}}},
-		})
-	}
+		_ = json.NewEncoder(w).Encode(map[string]any{"statuses": statuses, "total_count": len(statuses)})
+	})
+	mux.HandleFunc("GET "+base+"/check-runs", func(w http.ResponseWriter, _ *http.Request) {
+		checkRuns := make([]map[string]any, 0)
+		for _, n := range nodes() {
+			if n.Typename != "CheckRun" {
+				continue
+			}
+			checkRuns = append(checkRuns, map[string]any{
+				"name":       n.Name,
+				"status":     n.Status,
+				"conclusion": n.Conclusion,
+				"app":        map[string]any{"slug": n.AppSlug},
+			})
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"check_runs": checkRuns, "total_count": len(checkRuns)})
+	})
 }
 
 func TestEnforcePassingChecks(t *testing.T) {
@@ -283,15 +288,15 @@ func TestEnforcePassingChecks(t *testing.T) {
 		client, mux := setupGitHubServer(t)
 		comments := make(chan string, 10)
 
-		// Return a GraphQL permission error
-		mux.HandleFunc("POST /graphql", func(w http.ResponseWriter, _ *http.Request) {
+		mux.HandleFunc("GET /repos/octocat/hello-world/commits/abc123/status", func(w http.ResponseWriter, _ *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusOK)
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"errors": []map[string]any{
-					{"message": "Resource not accessible by integration", "type": "FORBIDDEN"},
-				},
-			})
+			w.WriteHeader(http.StatusForbidden)
+			_ = json.NewEncoder(w).Encode(map[string]any{"message": "Resource not accessible by integration"})
+		})
+		mux.HandleFunc("GET /repos/octocat/hello-world/commits/abc123/check-runs", func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusForbidden)
+			_ = json.NewEncoder(w).Encode(map[string]any{"message": "Resource not accessible by integration"})
 		})
 
 		mux.HandleFunc("POST /repos/octocat/hello-world/issues/1/comments", func(w http.ResponseWriter, r *http.Request) {
@@ -321,10 +326,10 @@ func TestEnforcePassingChecks(t *testing.T) {
 		select {
 		case body := <-comments:
 			assert.Contains(t, body, "Apply Blocked")
-			assert.Contains(t, body, "combined check/status rollup")
+			assert.Contains(t, body, "PR check statuses")
 			assert.Contains(t, body, "Checks")
 			assert.Contains(t, body, "Commit statuses")
-			assert.NotContains(t, body, "Resource not accessible", "should not expose raw GraphQL error")
+			assert.NotContains(t, body, "Resource not accessible", "should not expose raw GitHub API error")
 		case <-time.After(2 * time.Second):
 			t.Fatal("timed out waiting for permission error comment")
 		}
@@ -334,7 +339,7 @@ func TestEnforcePassingChecks(t *testing.T) {
 		client, mux := setupGitHubServer(t)
 		comments := make(chan string, 10)
 
-		mux.HandleFunc("POST /graphql", func(w http.ResponseWriter, _ *http.Request) {
+		mux.HandleFunc("GET /repos/octocat/hello-world/commits/abc123/status", func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusInternalServerError)
 		})
 
@@ -375,10 +380,10 @@ func TestEnforcePassingChecks(t *testing.T) {
 		client, mux := setupGitHubServer(t)
 		comments := make(chan string, 10)
 
-		mux.HandleFunc("POST /graphql", rollupGraphQLHandler([]rollupNode{
-			{Typename: "CheckRun", Name: "CI / tests", Status: "COMPLETED", Conclusion: "FAILURE", AppSlug: "github-actions"},
-			{Typename: "CheckRun", Name: "CI / lint", Status: "COMPLETED", Conclusion: "SUCCESS", AppSlug: "github-actions"},
-		}))
+		registerCheckStatusRESTHandlers(mux, []checkStatusNode{
+			{Typename: "CheckRun", Name: "CI / tests", Status: "completed", Conclusion: "failure", AppSlug: "github-actions"},
+			{Typename: "CheckRun", Name: "CI / lint", Status: "completed", Conclusion: "success", AppSlug: "github-actions"},
+		})
 
 		mux.HandleFunc("POST /repos/octocat/hello-world/issues/1/comments", func(w http.ResponseWriter, r *http.Request) {
 			var body struct {
@@ -416,10 +421,10 @@ func TestEnforcePassingChecks(t *testing.T) {
 	t.Run("required checks ignore unlisted failures when configured check is present", func(t *testing.T) {
 		client, mux := setupGitHubServer(t)
 
-		mux.HandleFunc("POST /graphql", rollupGraphQLHandler([]rollupNode{
-			{Typename: "CheckRun", Name: "Required Review", Status: "COMPLETED", Conclusion: "SUCCESS", AppSlug: "review-gate"},
-			{Typename: "CheckRun", Name: "CI / tests", Status: "COMPLETED", Conclusion: "FAILURE", AppSlug: "github-actions"},
-		}))
+		registerCheckStatusRESTHandlers(mux, []checkStatusNode{
+			{Typename: "CheckRun", Name: "Required Review", Status: "completed", Conclusion: "success", AppSlug: "review-gate"},
+			{Typename: "CheckRun", Name: "CI / tests", Status: "completed", Conclusion: "failure", AppSlug: "github-actions"},
+		})
 
 		installClient := ghclient.NewInstallationClient(client, testLogger())
 		factory := &fakeClientFactory{client: installClient}
@@ -436,13 +441,44 @@ func TestEnforcePassingChecks(t *testing.T) {
 		assert.False(t, blocked, "should allow when configured checks pass")
 	})
 
+	t.Run("required status check avoids unrelated check-run read", func(t *testing.T) {
+		client, mux := setupGitHubServer(t)
+		checkRunsCalled := false
+
+		mux.HandleFunc("GET /repos/octocat/hello-world/commits/abc123/status", func(w http.ResponseWriter, _ *http.Request) {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"statuses": []map[string]any{{"context": "Required Review", "state": "success"}},
+			})
+		})
+		mux.HandleFunc("GET /repos/octocat/hello-world/commits/abc123/check-runs", func(w http.ResponseWriter, _ *http.Request) {
+			checkRunsCalled = true
+			w.WriteHeader(http.StatusForbidden)
+			_ = json.NewEncoder(w).Encode(map[string]any{"message": "Resource not accessible by integration"})
+		})
+
+		installClient := ghclient.NewInstallationClient(client, testLogger())
+		factory := &fakeClientFactory{client: installClient}
+
+		service := api.New(nil, &api.ServerConfig{RequiredChecks: []string{"Required Review"}}, nil, testLogger())
+		h := &Handler{
+			service:   service,
+			ghClients: ghclient.NewSingleClientSet(defaultAppName, factory),
+			logger:    testLogger(),
+		}
+
+		ctx := t.Context()
+		blocked := h.enforcePassingChecks(ctx, installClient, "octocat/hello-world", 1, 12345, "abc123", "staging")
+		assert.False(t, blocked, "status-only required gate should pass without reading check runs")
+		assert.False(t, checkRunsCalled, "unrelated check runs should not be fetched once required statuses are found")
+	})
+
 	t.Run("required checks fall back to all checks when none are present", func(t *testing.T) {
 		client, mux := setupGitHubServer(t)
 		comments := make(chan string, 10)
 
-		mux.HandleFunc("POST /graphql", rollupGraphQLHandler([]rollupNode{
-			{Typename: "CheckRun", Name: "CI / tests", Status: "COMPLETED", Conclusion: "FAILURE", AppSlug: "github-actions"},
-		}))
+		registerCheckStatusRESTHandlers(mux, []checkStatusNode{
+			{Typename: "CheckRun", Name: "CI / tests", Status: "completed", Conclusion: "failure", AppSlug: "github-actions"},
+		})
 
 		mux.HandleFunc("POST /repos/octocat/hello-world/issues/1/comments", func(w http.ResponseWriter, r *http.Request) {
 			var body struct {
@@ -480,10 +516,10 @@ func TestEnforcePassingChecks(t *testing.T) {
 	t.Run("all passing allows apply", func(t *testing.T) {
 		client, mux := setupGitHubServer(t)
 
-		mux.HandleFunc("POST /graphql", rollupGraphQLHandler([]rollupNode{
-			{Typename: "CheckRun", Name: "CI / tests", Status: "COMPLETED", Conclusion: "SUCCESS", AppSlug: "github-actions"},
-			{Typename: "CheckRun", Name: "SchemaBot (staging)", Status: "COMPLETED", Conclusion: "ACTION_REQUIRED", AppSlug: "schemabot"},
-		}))
+		registerCheckStatusRESTHandlers(mux, []checkStatusNode{
+			{Typename: "CheckRun", Name: "CI / tests", Status: "completed", Conclusion: "success", AppSlug: "github-actions"},
+			{Typename: "CheckRun", Name: "SchemaBot (staging)", Status: "completed", Conclusion: "action_required", AppSlug: "schemabot"},
+		})
 
 		installClient := ghclient.NewInstallationClientWithSlug(client, testLogger(), "schemabot")
 		factory := &fakeClientFactory{client: installClient}
@@ -504,9 +540,9 @@ func TestEnforcePassingChecks(t *testing.T) {
 		client, mux := setupGitHubServer(t)
 		comments := make(chan string, 10)
 
-		mux.HandleFunc("POST /graphql", rollupGraphQLHandler([]rollupNode{
-			{Typename: "CheckRun", Name: "CI / tests", Status: "IN_PROGRESS", Conclusion: "", AppSlug: "github-actions"},
-		}))
+		registerCheckStatusRESTHandlers(mux, []checkStatusNode{
+			{Typename: "CheckRun", Name: "CI / tests", Status: "in_progress", Conclusion: "", AppSlug: "github-actions"},
+		})
 
 		mux.HandleFunc("POST /repos/octocat/hello-world/issues/1/comments", func(w http.ResponseWriter, r *http.Request) {
 			var body struct {
@@ -543,10 +579,10 @@ func TestEnforcePassingChecks(t *testing.T) {
 	t.Run("variant app slug excluded from gate", func(t *testing.T) {
 		client, mux := setupGitHubServer(t)
 
-		mux.HandleFunc("POST /graphql", rollupGraphQLHandler([]rollupNode{
-			{Typename: "CheckRun", Name: "CI / tests", Status: "COMPLETED", Conclusion: "SUCCESS", AppSlug: "github-actions"},
-			{Typename: "CheckRun", Name: "SchemaBot (staging)", Status: "COMPLETED", Conclusion: "FAILURE", AppSlug: "schemabot-at-acme-staging"},
-		}))
+		registerCheckStatusRESTHandlers(mux, []checkStatusNode{
+			{Typename: "CheckRun", Name: "CI / tests", Status: "completed", Conclusion: "success", AppSlug: "github-actions"},
+			{Typename: "CheckRun", Name: "SchemaBot (staging)", Status: "completed", Conclusion: "failure", AppSlug: "schemabot-at-acme-staging"},
+		})
 
 		installClient := ghclient.NewInstallationClientWithSlug(client, testLogger(), "schemabot-at-acme-staging")
 		factory := &fakeClientFactory{client: installClient}

--- a/pkg/webhook/apply_gating_test.go
+++ b/pkg/webhook/apply_gating_test.go
@@ -321,7 +321,9 @@ func TestEnforcePassingChecks(t *testing.T) {
 		select {
 		case body := <-comments:
 			assert.Contains(t, body, "Apply Blocked")
-			assert.Contains(t, body, "Commit statuses: Read")
+			assert.Contains(t, body, "combined check/status rollup")
+			assert.Contains(t, body, "Checks")
+			assert.Contains(t, body, "Commit statuses")
 			assert.NotContains(t, body, "Resource not accessible", "should not expose raw GraphQL error")
 		case <-time.After(2 * time.Second):
 			t.Fatal("timed out waiting for permission error comment")

--- a/pkg/webhook/apply_gating_test.go
+++ b/pkg/webhook/apply_gating_test.go
@@ -257,30 +257,38 @@ func registerCheckStatusRESTHandlers(mux *http.ServeMux, nodes []checkStatusNode
 func registerCheckStatusRESTHandlersForRef(mux *http.ServeMux, ref string, nodes func() []checkStatusNode) {
 	base := "/repos/octocat/hello-world/commits/" + ref
 	mux.HandleFunc("GET "+base+"/status", func(w http.ResponseWriter, _ *http.Request) {
-		statuses := make([]map[string]any, 0)
-		for _, n := range nodes() {
-			if n.Typename != "StatusContext" {
-				continue
-			}
-			statuses = append(statuses, map[string]any{"context": n.Context, "state": n.State})
-		}
-		_ = json.NewEncoder(w).Encode(map[string]any{"statuses": statuses, "total_count": len(statuses)})
+		writeCommitStatusResponse(w, nodes())
 	})
 	mux.HandleFunc("GET "+base+"/check-runs", func(w http.ResponseWriter, _ *http.Request) {
-		checkRuns := make([]map[string]any, 0)
-		for _, n := range nodes() {
-			if n.Typename != "CheckRun" {
-				continue
-			}
-			checkRuns = append(checkRuns, map[string]any{
-				"name":       n.Name,
-				"status":     n.Status,
-				"conclusion": n.Conclusion,
-				"app":        map[string]any{"slug": n.AppSlug},
-			})
-		}
-		_ = json.NewEncoder(w).Encode(map[string]any{"check_runs": checkRuns, "total_count": len(checkRuns)})
+		writeCheckRunsResponse(w, nodes())
 	})
+}
+
+func writeCommitStatusResponse(w http.ResponseWriter, nodes []checkStatusNode) {
+	statuses := make([]map[string]any, 0)
+	for _, n := range nodes {
+		if n.Typename != "StatusContext" {
+			continue
+		}
+		statuses = append(statuses, map[string]any{"context": n.Context, "state": n.State})
+	}
+	_ = json.NewEncoder(w).Encode(map[string]any{"statuses": statuses, "total_count": len(statuses)})
+}
+
+func writeCheckRunsResponse(w http.ResponseWriter, nodes []checkStatusNode) {
+	checkRuns := make([]map[string]any, 0)
+	for _, n := range nodes {
+		if n.Typename != "CheckRun" {
+			continue
+		}
+		checkRuns = append(checkRuns, map[string]any{
+			"name":       n.Name,
+			"status":     n.Status,
+			"conclusion": n.Conclusion,
+			"app":        map[string]any{"slug": n.AppSlug},
+		})
+	}
+	_ = json.NewEncoder(w).Encode(map[string]any{"check_runs": checkRuns, "total_count": len(checkRuns)})
 }
 
 func TestEnforcePassingChecks(t *testing.T) {

--- a/pkg/webhook/handler.go
+++ b/pkg/webhook/handler.go
@@ -346,6 +346,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	h.logger.Debug("webhook received",
 		"app_name", appName,
+		"delivery_id", r.Header.Get(headerDeliveryID),
 		"event", eventType,
 		"action", action,
 		"repo", repo)
@@ -358,12 +359,26 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		metrics.RecordWebhookEvent(ctx, metricApp, eventType, action, repo, "processed")
 	case "check_run":
 		// Phase 2: h.handleCheckRun(w, body)
+		h.logger.Info("webhook ignored",
+			"reason", "check_run_not_implemented",
+			"app_name", appName,
+			"delivery_id", r.Header.Get(headerDeliveryID),
+			"event", eventType,
+			"action", action,
+			"repo", repo)
 		h.writeJSON(w, http.StatusOK, map[string]string{"message": "check_run events not yet implemented"})
 		metrics.RecordWebhookEvent(ctx, metricApp, eventType, action, repo, "ignored")
 	case "pull_request":
 		h.handlePullRequest(w, body)
 		metrics.RecordWebhookEvent(ctx, metricApp, eventType, action, repo, "processed")
 	default:
+		h.logger.Info("webhook ignored",
+			"reason", "unsupported_event_type",
+			"app_name", appName,
+			"delivery_id", r.Header.Get(headerDeliveryID),
+			"event", eventType,
+			"action", action,
+			"repo", repo)
 		h.writeJSON(w, http.StatusOK, map[string]string{
 			"message": fmt.Sprintf("event type '%s' ignored", eventType),
 		})

--- a/pkg/webhook/issue_comment.go
+++ b/pkg/webhook/issue_comment.go
@@ -90,7 +90,13 @@ func (h *Handler) handleIssueComment(w http.ResponseWriter, body []byte) {
 
 	// Reject commands from repositories not in the configured allowlist
 	if h.service != nil && !h.service.Config().IsRepoAllowed(repo) {
-		h.logger.Warn("webhook from unregistered repository", "repo", repo, "pr", pr)
+		h.logger.Warn("webhook from unregistered repository",
+			"event", "issue_comment",
+			"action", payload.Action,
+			"repo", repo,
+			"pr", pr,
+			"installation_id", installationID,
+			"requested_by", requestedBy)
 		h.postComment(repo, pr, installationID, templates.RenderRepositoryNotRegistered())
 		h.writeJSON(w, http.StatusOK, map[string]string{
 			"message": "repository not registered",

--- a/pkg/webhook/pull_request.go
+++ b/pkg/webhook/pull_request.go
@@ -70,7 +70,12 @@ func (h *Handler) handlePullRequest(w http.ResponseWriter, body []byte) {
 
 	// Reject webhooks from repositories not in the configured allowlist
 	if h.service != nil && !h.service.Config().IsRepoAllowed(repo) {
-		h.logger.Warn("webhook from unregistered repository", "repo", repo)
+		h.logger.Warn("webhook from unregistered repository",
+			"event", "pull_request",
+			"action", payload.Action,
+			"repo", repo,
+			"pr", pr,
+			"installation_id", installationID)
 		h.writeJSON(w, http.StatusOK, map[string]string{
 			"message": "repository not registered",
 		})

--- a/pkg/webhook/templates/apply_commands.go
+++ b/pkg/webhook/templates/apply_commands.go
@@ -390,8 +390,6 @@ type CheckStatusAccessDetails struct {
 	MissingPermissions     []string
 	ChecksReadable         bool
 	CommitStatusesReadable bool
-	ChecksError            string
-	CommitStatusesError    string
 }
 
 func RenderApplyBlockedByCheckStatusError(environment string, err error, details *CheckStatusAccessDetails) string {

--- a/pkg/webhook/templates/apply_commands.go
+++ b/pkg/webhook/templates/apply_commands.go
@@ -385,15 +385,40 @@ func RenderApplyBlockedByFailingChecks(environment string, failing []BlockingChe
 // The function recognises the "Resource not accessible" permission error and
 // surfaces a targeted hint; all other errors are shown verbatim. Both branches
 // include a fenced retry command, matching the failing/in-progress siblings.
-func RenderApplyBlockedByCheckStatusError(environment string, err error) string {
+type CheckStatusAccessDetails struct {
+	GitHubApp              string
+	MissingPermissions     []string
+	ChecksReadable         bool
+	CommitStatusesReadable bool
+	ChecksError            string
+	CommitStatusesError    string
+}
+
+func RenderApplyBlockedByCheckStatusError(environment string, err error, details *CheckStatusAccessDetails) string {
 	var sb strings.Builder
 
 	sb.WriteString("## ❌ Apply Blocked\n\n")
 	fmt.Fprintf(&sb, "**Environment**: `%s`\n\n", environment)
 
 	if err != nil && strings.Contains(err.Error(), "Resource not accessible") {
-		sb.WriteString("The SchemaBot GitHub App does not have permission to read check statuses on this repository. ")
-		sb.WriteString("Grant the app **Commit statuses: Read** permission, then retry:\n")
+		app := "SchemaBot GitHub App"
+		if details != nil && details.GitHubApp != "" {
+			app = fmt.Sprintf("SchemaBot GitHub App `%s`", details.GitHubApp)
+		}
+		fmt.Fprintf(&sb, "The %s cannot read the combined check/status rollup for this repository.\n\n", app)
+
+		switch {
+		case details != nil && len(details.MissingPermissions) > 0:
+			sb.WriteString("The diagnostic REST probes indicate the installation is missing or has not accepted:\n")
+			for _, permission := range details.MissingPermissions {
+				fmt.Fprintf(&sb, "- **%s**\n", permission)
+			}
+			sb.WriteString("\nGrant or accept those permissions, then retry:\n")
+		case details != nil && details.ChecksReadable && details.CommitStatusesReadable:
+			sb.WriteString("Diagnostic REST probes could read both **Checks** and **Commit statuses**, so GitHub rejected the GraphQL `statusCheckRollup` even though the underlying REST permissions appear readable. Verify the app installation has accepted the latest permissions, then retry:\n")
+		default:
+			sb.WriteString("Verify the app installation has access to this repository and has permission to read both **Checks** and **Commit statuses**, then retry:\n")
+		}
 		fmt.Fprintf(&sb, "```\nschemabot apply -e %s\n```\n", environment)
 		return sb.String()
 	}

--- a/pkg/webhook/templates/apply_commands.go
+++ b/pkg/webhook/templates/apply_commands.go
@@ -405,7 +405,7 @@ func RenderApplyBlockedByCheckStatusError(environment string, err error, details
 		if details != nil && details.GitHubApp != "" {
 			app = fmt.Sprintf("SchemaBot GitHub App `%s`", details.GitHubApp)
 		}
-		fmt.Fprintf(&sb, "The %s cannot read the combined check/status rollup for this repository.\n\n", app)
+		fmt.Fprintf(&sb, "The %s cannot read PR check statuses for this repository.\n\n", app)
 
 		switch {
 		case details != nil && len(details.MissingPermissions) > 0:
@@ -415,7 +415,7 @@ func RenderApplyBlockedByCheckStatusError(environment string, err error, details
 			}
 			sb.WriteString("\nGrant or accept those permissions, then retry:\n")
 		case details != nil && details.ChecksReadable && details.CommitStatusesReadable:
-			sb.WriteString("Diagnostic REST probes could read both **Checks** and **Commit statuses**, so GitHub rejected the GraphQL `statusCheckRollup` even though the underlying REST permissions appear readable. Verify the app installation has accepted the latest permissions, then retry:\n")
+			sb.WriteString("Diagnostic REST probes could read both **Checks** and **Commit statuses**, so the check-status read failed even though the underlying permissions appear readable. Retry the command; if it keeps failing, inspect the SchemaBot logs for the exact GitHub API error:\n")
 		default:
 			sb.WriteString("Verify the app installation has access to this repository and has permission to read both **Checks** and **Commit statuses**, then retry:\n")
 		}

--- a/pkg/webhook/templates/apply_test.go
+++ b/pkg/webhook/templates/apply_test.go
@@ -460,14 +460,14 @@ func TestRenderApplyBlockedByFailingChecks_EmptyList(t *testing.T) {
 
 func TestRenderApplyBlockedByCheckStatusError(t *testing.T) {
 	t.Run("generic error is shown verbatim with retry block", func(t *testing.T) {
-		err := errors.New("graphql query failed: 500 Internal Server Error")
+		err := errors.New("get combined commit status: 500 Internal Server Error")
 
 		result := RenderApplyBlockedByCheckStatusError("staging", err, nil)
 
 		assert.Contains(t, result, "## ❌ Apply Blocked")
 		assert.Contains(t, result, "**Environment**: `staging`")
 		assert.Contains(t, result, "Unable to verify PR check statuses")
-		assert.Contains(t, result, "graphql query failed: 500 Internal Server Error")
+		assert.Contains(t, result, "get combined commit status: 500 Internal Server Error")
 		assert.Contains(t, result, "Resolve the issue and retry:\n```\nschemabot apply -e staging\n```",
 			"retry command must be inside a fenced code block immediately after the retry copy")
 	})
@@ -483,7 +483,7 @@ func TestRenderApplyBlockedByCheckStatusError(t *testing.T) {
 		assert.Contains(t, result, "## ❌ Apply Blocked")
 		assert.Contains(t, result, "**Environment**: `production`")
 		assert.Contains(t, result, "SchemaBot GitHub App `schemabot-prod`")
-		assert.Contains(t, result, "cannot read the combined check/status rollup")
+		assert.Contains(t, result, "cannot read PR check statuses")
 		assert.Contains(t, result, "**Checks: Read**")
 		assert.NotContains(t, result, "**Commit statuses: Read**")
 		assert.Contains(t, result, "then retry:\n```\nschemabot apply -e production\n```",
@@ -494,8 +494,8 @@ func TestRenderApplyBlockedByCheckStatusError(t *testing.T) {
 			"permission branch should not also emit the generic-branch retry copy")
 	})
 
-	t.Run("permission error explains graphQL rollup when REST probes pass", func(t *testing.T) {
-		err := errors.New("graphql statusCheckRollup ref abc123: Resource not accessible by integration")
+	t.Run("permission error explains ambiguous check-status failure when REST probes pass", func(t *testing.T) {
+		err := errors.New("read check statuses for abc123: Resource not accessible by integration")
 
 		result := RenderApplyBlockedByCheckStatusError("production", err, &CheckStatusAccessDetails{
 			GitHubApp:              "schemabot-prod",
@@ -505,7 +505,7 @@ func TestRenderApplyBlockedByCheckStatusError(t *testing.T) {
 
 		assert.Contains(t, result, "SchemaBot GitHub App `schemabot-prod`")
 		assert.Contains(t, result, "Diagnostic REST probes could read both **Checks** and **Commit statuses**")
-		assert.Contains(t, result, "GraphQL `statusCheckRollup`")
+		assert.Contains(t, result, "inspect the SchemaBot logs")
 		assert.NotContains(t, result, "Grant or accept those permissions")
 	})
 

--- a/pkg/webhook/templates/apply_test.go
+++ b/pkg/webhook/templates/apply_test.go
@@ -462,7 +462,7 @@ func TestRenderApplyBlockedByCheckStatusError(t *testing.T) {
 	t.Run("generic error is shown verbatim with retry block", func(t *testing.T) {
 		err := errors.New("graphql query failed: 500 Internal Server Error")
 
-		result := RenderApplyBlockedByCheckStatusError("staging", err)
+		result := RenderApplyBlockedByCheckStatusError("staging", err, nil)
 
 		assert.Contains(t, result, "## ❌ Apply Blocked")
 		assert.Contains(t, result, "**Environment**: `staging`")
@@ -475,13 +475,18 @@ func TestRenderApplyBlockedByCheckStatusError(t *testing.T) {
 	t.Run("permission error surfaces a targeted hint with retry block", func(t *testing.T) {
 		err := errors.New("GET https://api.github.com/...: 403 Resource not accessible by integration")
 
-		result := RenderApplyBlockedByCheckStatusError("production", err)
+		result := RenderApplyBlockedByCheckStatusError("production", err, &CheckStatusAccessDetails{
+			GitHubApp:          "schemabot-prod",
+			MissingPermissions: []string{"Checks: Read"},
+		})
 
 		assert.Contains(t, result, "## ❌ Apply Blocked")
 		assert.Contains(t, result, "**Environment**: `production`")
-		assert.Contains(t, result, "does not have permission to read check statuses")
-		assert.Contains(t, result, "**Commit statuses: Read**")
-		assert.Contains(t, result, "permission, then retry:\n```\nschemabot apply -e production\n```",
+		assert.Contains(t, result, "SchemaBot GitHub App `schemabot-prod`")
+		assert.Contains(t, result, "cannot read the combined check/status rollup")
+		assert.Contains(t, result, "**Checks: Read**")
+		assert.NotContains(t, result, "**Commit statuses: Read**")
+		assert.Contains(t, result, "then retry:\n```\nschemabot apply -e production\n```",
 			"retry command must be inside a fenced code block immediately after the retry copy")
 		assert.NotContains(t, result, "Unable to verify PR check statuses",
 			"permission branch should replace the generic verbatim message")
@@ -489,8 +494,23 @@ func TestRenderApplyBlockedByCheckStatusError(t *testing.T) {
 			"permission branch should not also emit the generic-branch retry copy")
 	})
 
+	t.Run("permission error explains graphQL rollup when REST probes pass", func(t *testing.T) {
+		err := errors.New("graphql statusCheckRollup ref abc123: Resource not accessible by integration")
+
+		result := RenderApplyBlockedByCheckStatusError("production", err, &CheckStatusAccessDetails{
+			GitHubApp:              "schemabot-prod",
+			ChecksReadable:         true,
+			CommitStatusesReadable: true,
+		})
+
+		assert.Contains(t, result, "SchemaBot GitHub App `schemabot-prod`")
+		assert.Contains(t, result, "Diagnostic REST probes could read both **Checks** and **Commit statuses**")
+		assert.Contains(t, result, "GraphQL `statusCheckRollup`")
+		assert.NotContains(t, result, "Grant or accept those permissions")
+	})
+
 	t.Run("nil error skips empty fence and uses concise retry copy", func(t *testing.T) {
-		result := RenderApplyBlockedByCheckStatusError("staging", nil)
+		result := RenderApplyBlockedByCheckStatusError("staging", nil, nil)
 
 		assert.Contains(t, result, "## ❌ Apply Blocked")
 		assert.Contains(t, result, "**Environment**: `staging`")

--- a/pkg/webhook/webhook_e2e_test.go
+++ b/pkg/webhook/webhook_e2e_test.go
@@ -265,13 +265,13 @@ type planFlowResult struct {
 	HeadSHAs    []string
 	headSHACall atomic.Int64
 
-	// GraphQLHandler optionally overrides the default passing-checks
-	// GraphQL handler installed by setupFakeGitHubForPlan. Tests that need
-	// to drive different check-gate responses across consecutive calls
-	// (e.g. PASS at the early gate, FAIL at the fresh-HEAD re-gate) install
-	// their own handler here before issuing the webhook request. Nil
-	// preserves the default "no checks → passing" behavior.
-	GraphQLHandler atomic.Pointer[http.HandlerFunc]
+	// CheckStatusNodes optionally overrides the default passing-checks REST
+	// responses installed by setupFakeGitHubForPlan. Tests that need to drive
+	// different check-gate responses across consecutive calls (e.g. PASS at the
+	// early gate, FAIL at the fresh-HEAD re-gate) install their own provider here
+	// before issuing the webhook request. Nil preserves the default
+	// "no checks → passing" behavior.
+	CheckStatusNodes atomic.Pointer[func() []checkStatusNode]
 }
 
 func (p *planFlowResult) nextHeadSHA() string {
@@ -293,20 +293,11 @@ type checkRunCapture struct {
 	Output     *ghclient.CheckRunOutput `json:"output"`
 }
 
-// registerPassingChecks adds a mock GraphQL endpoint for PR check statuses that
-// returns an empty rollup (no checks). This prevents enforcePassingChecks from
-// blocking apply commands in e2e tests.
+// registerPassingChecks adds mock REST endpoints for PR check statuses that
+// return no checks. This prevents enforcePassingChecks from blocking apply
+// commands in e2e tests.
 func registerPassingChecks(mux *http.ServeMux) {
-	mux.HandleFunc("POST /graphql", func(w http.ResponseWriter, _ *http.Request) {
-		_ = json.NewEncoder(w).Encode(map[string]any{
-			"data": map[string]any{"repository": map[string]any{"object": map[string]any{
-				"statusCheckRollup": map[string]any{"contexts": map[string]any{
-					"pageInfo": map[string]any{"hasNextPage": false, "endCursor": ""},
-					"nodes":    []map[string]any{},
-				}},
-			}}},
-		})
-	})
+	registerCheckStatusRESTHandlers(mux, nil)
 }
 
 // setupFakeGitHubForPlan sets up a fake GitHub server for plan flows.
@@ -473,22 +464,14 @@ func setupFakeGitHubForPlan(t *testing.T, mux *http.ServeMux, schemaSQL map[stri
 	})
 
 	// PR check statuses for enforcePassingChecks. Defaults to all passing
-	// (empty rollup) so existing tests are unaffected. Tests that need to
-	// drive different responses across calls install a handler in
-	// result.GraphQLHandler before issuing the webhook request.
-	mux.HandleFunc("POST /graphql", func(w http.ResponseWriter, r *http.Request) {
-		if h := result.GraphQLHandler.Load(); h != nil {
-			(*h)(w, r)
-			return
+	// (empty REST responses) so existing tests are unaffected. Tests that need to
+	// drive different responses across calls install a provider in
+	// result.CheckStatusNodes before issuing the webhook request.
+	registerCheckStatusRESTHandlersForRef(mux, "abc123", func() []checkStatusNode {
+		if provider := result.CheckStatusNodes.Load(); provider != nil {
+			return (*provider)()
 		}
-		_ = json.NewEncoder(w).Encode(map[string]any{
-			"data": map[string]any{"repository": map[string]any{"object": map[string]any{
-				"statusCheckRollup": map[string]any{"contexts": map[string]any{
-					"pageInfo": map[string]any{"hasNextPage": false, "endCursor": ""},
-					"nodes":    []map[string]any{},
-				}},
-			}}},
-		})
+		return nil
 	})
 
 	return result

--- a/pkg/webhook/webhook_e2e_test.go
+++ b/pkg/webhook/webhook_e2e_test.go
@@ -300,6 +300,21 @@ func registerPassingChecks(mux *http.ServeMux) {
 	registerCheckStatusRESTHandlers(mux, nil)
 }
 
+func registerCheckStatusRESTHandlersForAnyRef(mux *http.ServeMux, nodes func() []checkStatusNode) {
+	prefix := "/repos/octocat/hello-world/commits/"
+	mux.HandleFunc("GET "+prefix, func(w http.ResponseWriter, r *http.Request) {
+		path := strings.TrimPrefix(r.URL.Path, prefix)
+		switch {
+		case strings.HasSuffix(path, "/status"):
+			writeCommitStatusResponse(w, nodes())
+		case strings.HasSuffix(path, "/check-runs"):
+			writeCheckRunsResponse(w, nodes())
+		default:
+			http.NotFound(w, r)
+		}
+	})
+}
+
 // setupFakeGitHubForPlan sets up a fake GitHub server for plan flows.
 // schemaSQL maps filename -> content. Files are placed under schema/{namespace}/.
 // namespace is the MySQL schema name (required).
@@ -467,7 +482,7 @@ func setupFakeGitHubForPlan(t *testing.T, mux *http.ServeMux, schemaSQL map[stri
 	// (empty REST responses) so existing tests are unaffected. Tests that need to
 	// drive different responses across calls install a provider in
 	// result.CheckStatusNodes before issuing the webhook request.
-	registerCheckStatusRESTHandlersForRef(mux, "abc123", func() []checkStatusNode {
+	registerCheckStatusRESTHandlersForAnyRef(mux, func() []checkStatusNode {
 		if provider := result.CheckStatusNodes.Load(); provider != nil {
 			return (*provider)()
 		}


### PR DESCRIPTION
## Why
The apply gate should fail closed when PR checks cannot be verified, but it should not depend on GitHub's GraphQL status-check rollup when the same safety decision can be made from REST resources. Reading the underlying REST commit-status and check-run endpoints makes the permission surface explicit and avoids misleading remediation when GitHub rejects the rollup query.

## What
- Replace the apply gate's GraphQL status-check rollup read with REST commit-status and check-run reads
- Keep singleflight coalescing for concurrent reads of the same commit
- For status-only `required_checks`, skip unrelated check-run reads once the required status contexts are found
- Improve blocked-apply comments and logs so missing GitHub App permissions name the affected app and endpoint family
- Update tests and docs for the REST-backed check gate behavior

## Risk Assessment
Low — the apply gate remains fail-closed when GitHub check/status reads fail. The main behavior change is removing the GraphQL rollup dependency and using explicit REST resources instead.

Generated with Amp
