### PR TITLE
fix(github): avoid repo scan for changed schema configs

### DIFF
--- a/pkg/github/config.go
+++ b/pkg/github/config.go
@@ -221,9 +221,14 @@ func (ic *InstallationClient) FindConfigByDatabaseName(ctx context.Context, repo
 		return nil, "", fmt.Errorf("fetch PR info: %w", err)
 	}
 
-	prConfigs, err := ic.findConfigsChangedInPR(ctx, repo, pr, prInfo.HeadSHA)
+	files, err := ic.FetchPRFiles(ctx, repo, pr)
 	if err != nil {
-		return nil, "", fmt.Errorf("find configs changed in PR: %w", err)
+		return nil, "", fmt.Errorf("fetch PR files: %w", err)
+	}
+
+	prConfigs, err := ic.findAllConfigsForPRFiles(ctx, repo, prInfo.HeadSHA, files)
+	if err != nil {
+		return nil, "", fmt.Errorf("find configs for PR: %w", err)
 	}
 	if config, configDir, ok, err := selectConfigByDatabaseName(databaseName, prConfigs); err != nil {
 		return nil, "", err
@@ -365,7 +370,10 @@ func (ic *InstallationClient) FindAllConfigsForPR(ctx context.Context, repo stri
 	if err != nil {
 		return nil, fmt.Errorf("fetch PR files: %w", err)
 	}
+	return ic.findAllConfigsForPRFiles(ctx, repo, prInfo.HeadSHA, files)
+}
 
+func (ic *InstallationClient) findAllConfigsForPRFiles(ctx context.Context, repo, ref string, files []PRFile) ([]DiscoveredConfig, error) {
 	configsByPath := make(map[string]DiscoveredConfig)
 	for _, file := range files {
 		if !isConfigFile(file.Filename) {
@@ -375,7 +383,7 @@ func (ic *InstallationClient) FindAllConfigsForPR(ctx context.Context, repo stri
 			continue
 		}
 		configDir := path.Dir(file.Filename)
-		config, err := ic.FetchConfig(ctx, repo, file.Filename, prInfo.HeadSHA)
+		config, err := ic.FetchConfig(ctx, repo, file.Filename, ref)
 		if err != nil {
 			return nil, fmt.Errorf("fetch changed config %s: %w", file.Filename, err)
 		}
@@ -388,7 +396,7 @@ func (ic *InstallationClient) FindAllConfigsForPR(ctx context.Context, repo stri
 	}
 	schemaFiles := filterSchemaFiles(filenames)
 	for _, schemaFile := range schemaFiles {
-		config, configDir, err := ic.findNearestConfig(ctx, repo, prInfo.HeadSHA, schemaFile)
+		config, configDir, err := ic.findNearestConfig(ctx, repo, ref, schemaFile)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/github/config_test.go
+++ b/pkg/github/config_test.go
@@ -182,6 +182,29 @@ func TestFindConfigByDatabaseNameUsesChangedConfigFileBeforeRepoScan(t *testing.
 	assert.Equal(t, "apps/widgets/schema", schemaDir)
 }
 
+func TestFindConfigByDatabaseNameUsesChangedSchemaFileBeforeRepoScan(t *testing.T) {
+	client, mux := setupConfigTestGitHubServer(t)
+	registerPullRequest(t, mux, "abc123")
+	registerPullRequestFiles(t, mux, []*gh.CommitFile{{
+		Filename: new("apps/widgets/schema/main/widgets.sql"),
+		Status:   new("modified"),
+	}})
+	registerFileContent(t, mux, "/repos/octocat/hello-world/contents/apps/widgets/schema/schemabot.yaml", "database: widgets\ntype: mysql\n")
+	mux.HandleFunc("GET /repos/octocat/hello-world/git/trees/abc123", func(w http.ResponseWriter, _ *http.Request) {
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+			"truncated": true,
+			"tree":      []any{},
+		}))
+	})
+
+	ic := NewInstallationClient(client, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	config, schemaDir, err := ic.FindConfigByDatabaseName(t.Context(), "octocat/hello-world", 1, "widgets")
+
+	require.NoError(t, err)
+	assert.Equal(t, "widgets", config.Database)
+	assert.Equal(t, "apps/widgets/schema", schemaDir)
+}
+
 func TestFindAllConfigsForPRSkipsRemovedConfigFile(t *testing.T) {
 	client, mux := setupConfigTestGitHubServer(t)
 	registerPullRequest(t, mux, "abc123")


### PR DESCRIPTION
## Why
Auto-plan should not require a full repository tree scan after it has already identified the database from changed schema files. Large repositories can make GitHub return truncated recursive trees, which blocks otherwise valid schema-change PRs.

## What
- Reuse changed schema-file config discovery when resolving an explicit database name
- Keep the full repository scan as the fallback for database names not present in the PR
- Add coverage for changed schema files when the recursive tree would be truncated

## Risk Assessment
Low — this only changes config discovery order and preserves the existing fail-closed fallback when the database cannot be resolved from PR changes.

Generated with Amp
