### PR TITLE
fix(github): fail closed on incomplete PR files

### DIFF
--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -466,6 +466,12 @@ type PRFile struct {
 	Status   string // added, removed, modified, renamed
 }
 
+// GitHub caps pull request file listings at this documented maximum and does
+// not provide a separate completeness marker for larger PRs. Treat reaching
+// the cap as incomplete so schema discovery fails closed instead of assuming
+// there are no managed schema changes later in the list.
+const maxGitHubPRFiles = 3000
+
 // FetchPRFiles gets the list of files changed in a PR.
 func (ic *InstallationClient) FetchPRFiles(ctx context.Context, repo string, pr int) ([]PRFile, error) {
 	owner, repoName := splitRepo(repo)
@@ -482,6 +488,9 @@ func (ic *InstallationClient) FetchPRFiles(ctx context.Context, repo string, pr 
 				Filename: f.GetFilename(),
 				Status:   f.GetStatus(),
 			})
+		}
+		if len(allFiles) >= maxGitHubPRFiles {
+			return nil, fmt.Errorf("list PR files for %s#%d reached GitHub API limit: %w", repo, pr, ErrPRFilesIncomplete)
 		}
 		if resp.NextPage == 0 {
 			break

--- a/pkg/github/config.go
+++ b/pkg/github/config.go
@@ -98,10 +98,11 @@ const ConfigFileName = "schemabot.yaml"
 
 // Config discovery errors.
 var (
-	ErrNoConfig         = fmt.Errorf("no schemabot.yaml config found")
-	ErrInvalidConfig    = fmt.Errorf("invalid schemabot.yaml config found")
-	ErrMultipleConfigs  = fmt.Errorf("multiple schemabot.yaml configs found - use -d flag to specify database")
-	ErrGitTreeTruncated = fmt.Errorf("GitHub returned a truncated repository tree; config discovery is incomplete")
+	ErrNoConfig          = fmt.Errorf("no schemabot.yaml config found")
+	ErrInvalidConfig     = fmt.Errorf("invalid schemabot.yaml config found")
+	ErrMultipleConfigs   = fmt.Errorf("multiple schemabot.yaml configs found - use -d flag to specify database")
+	ErrGitTreeTruncated  = fmt.Errorf("GitHub returned a truncated repository tree; config discovery is incomplete")
+	ErrPRFilesIncomplete = fmt.Errorf("GitHub returned the maximum number of pull request files; config discovery is incomplete")
 )
 
 // DatabaseNotFoundError indicates the specified database was not found in any config.

--- a/pkg/github/config_test.go
+++ b/pkg/github/config_test.go
@@ -227,6 +227,26 @@ func TestFindAllConfigsFailsClosedOnTruncatedGitTree(t *testing.T) {
 	assert.ErrorIs(t, err, ErrGitTreeTruncated)
 }
 
+func TestFindAllConfigsForPRFailsClosedOnIncompletePRFileList(t *testing.T) {
+	client, mux := setupConfigTestGitHubServer(t)
+	registerPullRequest(t, mux, "abc123")
+
+	files := make([]*gh.CommitFile, maxGitHubPRFiles)
+	filename := "docs/readme.md"
+	status := "modified"
+	for i := range files {
+		files[i] = &gh.CommitFile{Filename: &filename, Status: &status}
+	}
+	registerPullRequestFiles(t, mux, files)
+
+	ic := NewInstallationClient(client, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	_, err := ic.FindAllConfigsForPR(t.Context(), "octocat/hello-world", 1)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrPRFilesIncomplete)
+	assert.False(t, errors.Is(err, ErrNoConfig))
+}
+
 func TestFetchSchemaFilesOptimizedWalksSchemaDirectoryOnly(t *testing.T) {
 	client, mux := setupConfigTestGitHubServer(t)
 	registerDirectoryContent(t, mux, "/repos/octocat/hello-world/contents/apps/widgets/schema", []*gh.RepositoryContent{


### PR DESCRIPTION
## Why
GitHub only returns a bounded PR file list. If SchemaBot treats a capped list as complete, it can miss managed schema files and publish a passing “no schema changes” aggregate.

## What
- Detect when PR changed-file enumeration reaches GitHub’s documented file cap
- Return a typed discovery error so webhook config discovery fails closed instead of falling through to no config
- Add coverage that capped PR file lists do not become `ErrNoConfig`

## Risk Assessment
Low — this only changes the over-cap PR discovery path from potentially passing to explicitly blocking until the PR can be inspected safely.

## References
- [GitHub REST docs for List pull request files](https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#list-pull-requests-files): “Responses include a maximum of 3000 files.”

Generated with Amp
