### PR TITLE
feat(engine): add resume state validation contract

### DIFF
--- a/pkg/engine/README.md
+++ b/pkg/engine/README.md
@@ -81,6 +81,43 @@ type Engine interface {
 
 Engines must support resume: if the server restarts mid-schema-change, the engine must be able to resume from where it left off. The `ResumeState` field on requests carries opaque state (e.g., Spirit's checkpoint table name) that enables this.
 
+Tern owns persistence; engines own resume metadata semantics. Tern should load
+the persisted data and pass the resulting `ResumeState` back to the engine, but
+it should not interpret engine-private `ResumeState.Metadata` JSON.
+
+```
+┌─────────────┐
+│ Engine      │
+│ Apply/      │
+│ Progress    │
+└──────┬──────┘
+       │ returns ResumeState{MigrationContext, Metadata}
+       ▼
+┌─────────────┐
+│ Tern stores │
+│ opaque      │
+│ state       │
+└──────┬──────┘
+       │ loads it for Progress / Control
+       ▼
+┌─────────────┐
+│ Engine      │
+│ validates   │
+│ metadata    │
+└──────┬──────┘
+       │ same ResumeState
+       ▼
+┌─────────────┐
+│ Engine      │
+│ operation   │
+└─────────────┘
+```
+
+Engines with operation-specific metadata requirements can implement
+`ControlResumeValidator`. For example, PlanetScale allows partial metadata while
+a branch is being prepared, but control operations require deploy request
+metadata before they can target a server-side deploy request.
+
 ## Key Types
 
 - **PlanRequest/PlanResult**: Schema files in, DDL + table changes + lint warnings out

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -355,6 +355,27 @@ type ControlRequest struct {
 	Credentials *Credentials // Resolved credentials (from discovery)
 }
 
+// ControlOperation names the control action that will consume a ResumeState.
+// Engines can use this to validate opaque metadata before a caller attempts an
+// operation that would otherwise fail later against the backing service.
+type ControlOperation string
+
+const (
+	ControlStop       ControlOperation = "stop"
+	ControlStart      ControlOperation = "start"
+	ControlCutover    ControlOperation = "cutover"
+	ControlRevert     ControlOperation = "revert"
+	ControlSkipRevert ControlOperation = "skip_revert"
+	ControlVolume     ControlOperation = "volume"
+)
+
+// ControlResumeValidator is an optional interface for engines whose resume
+// metadata has operation-specific readiness requirements. The tern layer owns
+// loading persisted data; engines own the meaning of ResumeState.Metadata.
+type ControlResumeValidator interface {
+	ValidateControlResumeState(operation ControlOperation, state *ResumeState) error
+}
+
 // ControlResult is the response from control operations.
 type ControlResult struct {
 	Accepted    bool

--- a/pkg/engine/planetscale/control.go
+++ b/pkg/engine/planetscale/control.go
@@ -3,11 +3,14 @@ package planetscale
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	ps "github.com/planetscale/planetscale-go/planetscale"
 
 	"github.com/block/schemabot/pkg/engine"
 )
+
+var _ engine.ControlResumeValidator = (*Engine)(nil)
 
 // Stop cancels the deploy request. This is permanent.
 func (e *Engine) Stop(ctx context.Context, req *engine.ControlRequest) (*engine.ControlResult, error) {
@@ -162,12 +165,50 @@ func (e *Engine) controlMeta(req *engine.ControlRequest) (*psMetadata, error) {
 	if req.ResumeState == nil || req.ResumeState.Metadata == "" {
 		return nil, fmt.Errorf("no active schema change")
 	}
+	if err := e.ValidateControlResumeState("", req.ResumeState); err != nil {
+		return nil, err
+	}
 	meta, err := decodePSMetadata(req.ResumeState.Metadata)
 	if err != nil {
 		return nil, fmt.Errorf("decode resume state: %w", err)
 	}
-	if meta.DeployRequestID == 0 {
-		return nil, fmt.Errorf("no active schema change")
-	}
 	return meta, nil
+}
+
+// ValidateControlResumeState checks that the opaque PlanetScale resume state can
+// address the deploy request targeted by a control operation.
+func (e *Engine) ValidateControlResumeState(operation engine.ControlOperation, resumeState *engine.ResumeState) error {
+	return validateControlResumeState(operation, resumeState)
+}
+
+func validateControlResumeState(operation engine.ControlOperation, resumeState *engine.ResumeState) error {
+	if resumeState == nil || resumeState.Metadata == "" {
+		return fmt.Errorf("no active schema change")
+	}
+	meta, err := decodePSMetadata(resumeState.Metadata)
+	if err != nil {
+		return fmt.Errorf("decode resume state: %w", err)
+	}
+	if missing := missingControlMetadata(meta); len(missing) > 0 {
+		prefix := "deploy request metadata is incomplete"
+		if operation != "" {
+			prefix = fmt.Sprintf("%s control resume state is incomplete", operation)
+		}
+		return fmt.Errorf("%s (missing %s)", prefix, strings.Join(missing, ", "))
+	}
+	return nil
+}
+
+func missingControlMetadata(meta *psMetadata) []string {
+	var missing []string
+	if meta.BranchName == "" {
+		missing = append(missing, "branch_name")
+	}
+	if meta.DeployRequestID == 0 {
+		missing = append(missing, "deploy_request_id")
+	}
+	if meta.DeployRequestURL == "" {
+		missing = append(missing, "deploy_request_url")
+	}
+	return missing
 }

--- a/pkg/engine/planetscale/control.go
+++ b/pkg/engine/planetscale/control.go
@@ -14,7 +14,7 @@ var _ engine.ControlResumeValidator = (*Engine)(nil)
 
 // Stop cancels the deploy request. This is permanent.
 func (e *Engine) Stop(ctx context.Context, req *engine.ControlRequest) (*engine.ControlResult, error) {
-	meta, err := e.controlMeta(req)
+	meta, err := controlMeta(engine.ControlStop, req)
 	if err != nil {
 		return nil, fmt.Errorf("decode control metadata: %w", err)
 	}
@@ -42,7 +42,7 @@ func (e *Engine) Stop(ctx context.Context, req *engine.ControlRequest) (*engine.
 
 // Start starts a deferred deploy request. Cancelled deploy requests cannot be restarted.
 func (e *Engine) Start(ctx context.Context, req *engine.ControlRequest) (*engine.ControlResult, error) {
-	meta, err := e.controlMeta(req)
+	meta, err := controlMeta(engine.ControlStart, req)
 	if err != nil {
 		return nil, fmt.Errorf("decode control metadata: %w", err)
 	}
@@ -78,7 +78,7 @@ func (e *Engine) Start(ctx context.Context, req *engine.ControlRequest) (*engine
 
 // Cutover triggers the final schema swap via ApplyDeployRequest.
 func (e *Engine) Cutover(ctx context.Context, req *engine.ControlRequest) (*engine.ControlResult, error) {
-	meta, err := e.controlMeta(req)
+	meta, err := controlMeta(engine.ControlCutover, req)
 	if err != nil {
 		return nil, fmt.Errorf("decode control metadata: %w", err)
 	}
@@ -106,7 +106,7 @@ func (e *Engine) Cutover(ctx context.Context, req *engine.ControlRequest) (*engi
 
 // Revert rolls back a completed schema change during the revert window.
 func (e *Engine) Revert(ctx context.Context, req *engine.ControlRequest) (*engine.ControlResult, error) {
-	meta, err := e.controlMeta(req)
+	meta, err := controlMeta(engine.ControlRevert, req)
 	if err != nil {
 		return nil, fmt.Errorf("decode control metadata: %w", err)
 	}
@@ -134,7 +134,7 @@ func (e *Engine) Revert(ctx context.Context, req *engine.ControlRequest) (*engin
 
 // SkipRevert closes the revert window, making the schema change permanent.
 func (e *Engine) SkipRevert(ctx context.Context, req *engine.ControlRequest) (*engine.ControlResult, error) {
-	meta, err := e.controlMeta(req)
+	meta, err := controlMeta(engine.ControlSkipRevert, req)
 	if err != nil {
 		return nil, fmt.Errorf("decode control metadata: %w", err)
 	}
@@ -161,16 +161,16 @@ func (e *Engine) SkipRevert(ctx context.Context, req *engine.ControlRequest) (*e
 }
 
 // controlMeta extracts and validates psMetadata from a control request.
-func (e *Engine) controlMeta(req *engine.ControlRequest) (*psMetadata, error) {
+func controlMeta(operation engine.ControlOperation, req *engine.ControlRequest) (*psMetadata, error) {
 	if req.ResumeState == nil || req.ResumeState.Metadata == "" {
 		return nil, fmt.Errorf("no active schema change")
-	}
-	if err := e.ValidateControlResumeState("", req.ResumeState); err != nil {
-		return nil, err
 	}
 	meta, err := decodePSMetadata(req.ResumeState.Metadata)
 	if err != nil {
 		return nil, fmt.Errorf("decode resume state: %w", err)
+	}
+	if err := validateControlMetadata(operation, meta); err != nil {
+		return nil, err
 	}
 	return meta, nil
 }
@@ -189,6 +189,10 @@ func validateControlResumeState(operation engine.ControlOperation, resumeState *
 	if err != nil {
 		return fmt.Errorf("decode resume state: %w", err)
 	}
+	return validateControlMetadata(operation, meta)
+}
+
+func validateControlMetadata(operation engine.ControlOperation, meta *psMetadata) error {
 	if missing := missingControlMetadata(meta); len(missing) > 0 {
 		prefix := "deploy request metadata is incomplete"
 		if operation != "" {

--- a/pkg/engine/planetscale/control_test.go
+++ b/pkg/engine/planetscale/control_test.go
@@ -14,9 +14,10 @@ func TestStart_RejectsNonDeferredDeploy(t *testing.T) {
 
 	// Non-deferred metadata — Start should return "not supported"
 	meta, err := encodePSMetadata(&psMetadata{
-		BranchName:      "schemabot-mydb-abc",
-		DeployRequestID: 1,
-		DeferredDeploy:  false,
+		BranchName:       "schemabot-mydb-abc",
+		DeployRequestID:  1,
+		DeployRequestURL: "https://example.test/deploys/1",
+		DeferredDeploy:   false,
 	})
 	require.NoError(t, err)
 
@@ -33,10 +34,11 @@ func TestStart_AcceptsDeferredDeploy(t *testing.T) {
 	e := &Engine{}
 
 	meta, err := encodePSMetadata(&psMetadata{
-		BranchName:      "schemabot-mydb-abc",
-		DeployRequestID: 1,
-		IsInstant:       true,
-		DeferredDeploy:  true,
+		BranchName:       "schemabot-mydb-abc",
+		DeployRequestID:  1,
+		DeployRequestURL: "https://example.test/deploys/1",
+		IsInstant:        true,
+		DeferredDeploy:   true,
 	})
 	require.NoError(t, err)
 

--- a/pkg/engine/planetscale/planetscale.go
+++ b/pkg/engine/planetscale/planetscale.go
@@ -488,24 +488,14 @@ func BuildResumeState(data ResumeData) (*engine.ResumeState, error) {
 // BuildControlResumeState encodes PlanetScale resume metadata for control
 // operations that act on an existing deploy request.
 func BuildControlResumeState(data ResumeData) (*engine.ResumeState, error) {
-	if missing := missingControlResumeData(data); len(missing) > 0 {
-		return nil, fmt.Errorf("deploy request metadata is incomplete (missing %s)", strings.Join(missing, ", "))
+	resumeState, err := BuildResumeState(data)
+	if err != nil {
+		return nil, err
 	}
-	return BuildResumeState(data)
-}
-
-func missingControlResumeData(data ResumeData) []string {
-	var missing []string
-	if data.BranchName == "" {
-		missing = append(missing, "branch_name")
+	if err := validateControlResumeState("", resumeState); err != nil {
+		return nil, err
 	}
-	if data.DeployRequestID == 0 {
-		missing = append(missing, "deploy_request_id")
-	}
-	if data.DeployRequestURL == "" {
-		missing = append(missing, "deploy_request_url")
-	}
-	return missing
+	return resumeState, nil
 }
 
 func encodePSMetadata(m *psMetadata) (string, error) {

--- a/pkg/engine/planetscale/planetscale_test.go
+++ b/pkg/engine/planetscale/planetscale_test.go
@@ -174,6 +174,32 @@ func TestDecodePSMetadata_Invalid(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestBuildControlResumeStateRequiresDeployRequestMetadata(t *testing.T) {
+	_, err := BuildControlResumeState(ResumeData{
+		BranchName:       "schemabot-mydb-12345678",
+		MigrationContext: "ctx-123",
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "deploy request metadata is incomplete")
+	assert.Contains(t, err.Error(), "deploy_request_id")
+	assert.Contains(t, err.Error(), "deploy_request_url")
+}
+
+func TestValidateControlResumeStateIncludesOperation(t *testing.T) {
+	resumeState, err := BuildResumeState(ResumeData{
+		BranchName:       "schemabot-mydb-12345678",
+		MigrationContext: "ctx-123",
+	})
+	require.NoError(t, err)
+
+	err = validateControlResumeState(engine.ControlCutover, resumeState)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cutover control resume state is incomplete")
+	assert.Contains(t, err.Error(), "deploy_request_id")
+}
+
 func TestSplitStatements(t *testing.T) {
 	stmts, err := ddl.SplitStatements("CREATE TABLE `a` (id INT); ALTER TABLE `b` ADD COLUMN x INT;")
 	require.NoError(t, err)

--- a/pkg/tern/local_control.go
+++ b/pkg/tern/local_control.go
@@ -94,7 +94,7 @@ func (c *LocalClient) cutover(ctx context.Context, req *ternv1.CutoverRequest, c
 		return nil, fmt.Errorf("no engine configured for type: %s", c.config.Type)
 	}
 
-	controlReq, err := c.buildControlRequest(ctx, task, creds)
+	controlReq, err := c.buildControlRequest(ctx, task, creds, eng, engine.ControlCutover)
 	if err != nil {
 		return nil, fmt.Errorf("build cutover request for apply %d: %w", task.ApplyID, err)
 	}
@@ -408,7 +408,7 @@ func (c *LocalClient) stopEngineForTasks(ctx context.Context, eng engine.Engine,
 		if task.State == state.Task.Running ||
 			task.State == state.Task.WaitingForCutover ||
 			task.State == state.Task.CuttingOver {
-			req, err := c.buildControlRequest(ctx, task, creds)
+			req, err := c.buildControlRequest(ctx, task, creds, eng, engine.ControlStop)
 			if err != nil {
 				return fmt.Errorf("build stop request for task %s: %w", task.TaskIdentifier, err)
 			}
@@ -570,10 +570,9 @@ func (c *LocalClient) controlSetup(ctx context.Context) (*storage.Task, *engine.
 	return task, c.credentials(), eng, nil
 }
 
-// buildControlRequest creates a ControlRequest with persisted Vitess deploy data.
-// PlanetScale control operations identify the server-side deploy request from
-// ResumeState.Metadata, so missing stored data must fail before calling the engine.
-func (c *LocalClient) buildControlRequest(ctx context.Context, task *storage.Task, creds *engine.Credentials) (*engine.ControlRequest, error) {
+// buildControlRequest creates a ControlRequest with persisted engine resume data.
+// Engines own validation of opaque ResumeState.Metadata before control calls.
+func (c *LocalClient) buildControlRequest(ctx context.Context, task *storage.Task, creds *engine.Credentials, eng engine.Engine, operation engine.ControlOperation) (*engine.ControlRequest, error) {
 	req := &engine.ControlRequest{
 		Database:    c.config.Database,
 		Credentials: creds,
@@ -595,6 +594,11 @@ func (c *LocalClient) buildControlRequest(ctx context.Context, task *storage.Tas
 			return nil, fmt.Errorf("build Vitess control resume state for apply %d: %w", task.ApplyID, err)
 		}
 		req.ResumeState = resumeState
+	}
+	if validator, ok := eng.(engine.ControlResumeValidator); ok {
+		if err := validator.ValidateControlResumeState(operation, req.ResumeState); err != nil {
+			return nil, fmt.Errorf("validate %s resume state for task %s: %w", operation, task.TaskIdentifier, err)
+		}
 	}
 	return req, nil
 }
@@ -623,7 +627,7 @@ func (c *LocalClient) Volume(ctx context.Context, req *ternv1.VolumeRequest) (*t
 	if err != nil {
 		return nil, err
 	}
-	controlReq, err := c.buildControlRequest(ctx, task, creds)
+	controlReq, err := c.buildControlRequest(ctx, task, creds, eng, engine.ControlVolume)
 	if err != nil {
 		return nil, fmt.Errorf("build volume request for task %s: %w", task.TaskIdentifier, err)
 	}
@@ -652,7 +656,7 @@ func (c *LocalClient) Revert(ctx context.Context, req *ternv1.RevertRequest) (*t
 		return nil, err
 	}
 
-	controlReq, err := c.buildControlRequest(ctx, task, creds)
+	controlReq, err := c.buildControlRequest(ctx, task, creds, eng, engine.ControlRevert)
 	if err != nil {
 		return nil, fmt.Errorf("build revert request for task %s: %w", task.TaskIdentifier, err)
 	}
@@ -669,7 +673,7 @@ func (c *LocalClient) SkipRevert(ctx context.Context, req *ternv1.SkipRevertRequ
 		return nil, err
 	}
 
-	controlReq, err := c.buildControlRequest(ctx, task, creds)
+	controlReq, err := c.buildControlRequest(ctx, task, creds, eng, engine.ControlSkipRevert)
 	if err != nil {
 		return nil, fmt.Errorf("build skip-revert request for task %s: %w", task.TaskIdentifier, err)
 	}

--- a/pkg/tern/local_control.go
+++ b/pkg/tern/local_control.go
@@ -589,9 +589,9 @@ func (c *LocalClient) buildControlRequest(ctx context.Context, task *storage.Tas
 		if vad == nil {
 			return nil, fmt.Errorf("load Vitess apply data for apply %d: %w", task.ApplyID, storage.ErrVitessApplyDataNotFound)
 		}
-		resumeState, err := planetscale.BuildControlResumeState(planetscaleResumeData(vad))
+		resumeState, err := planetscale.BuildResumeState(planetscaleResumeData(vad))
 		if err != nil {
-			return nil, fmt.Errorf("build Vitess control resume state for apply %d: %w", task.ApplyID, err)
+			return nil, fmt.Errorf("build Vitess resume state for apply %d: %w", task.ApplyID, err)
 		}
 		req.ResumeState = resumeState
 	}

--- a/pkg/tern/local_control_resume.go
+++ b/pkg/tern/local_control_resume.go
@@ -82,7 +82,7 @@ func (c *LocalClient) Start(ctx context.Context, req *ternv1.StartRequest) (*ter
 		if eng == nil {
 			return nil, fmt.Errorf("no engine configured for type: %s", c.config.Type)
 		}
-		controlReq, err := c.buildControlRequest(ctx, applyTasks[0], creds)
+		controlReq, err := c.buildControlRequest(ctx, applyTasks[0], creds, eng, engine.ControlStart)
 		if err != nil {
 			return nil, fmt.Errorf("build deferred deploy request for task %s: %w", applyTasks[0].TaskIdentifier, err)
 		}

--- a/pkg/tern/local_control_test.go
+++ b/pkg/tern/local_control_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/block/schemabot/pkg/engine"
+	"github.com/block/schemabot/pkg/engine/planetscale"
 	ternv1 "github.com/block/schemabot/pkg/proto/ternv1"
 	"github.com/block/schemabot/pkg/state"
 	"github.com/block/schemabot/pkg/storage"
@@ -160,7 +161,7 @@ func newMySQLControlTestClient(apply *storage.Apply, tasks []*storage.Task, eng 
 	}
 }
 
-func newVitessControlTestClient(apply *storage.Apply, tasks []*storage.Task, vitessData *storage.VitessApplyData, vitessDataErr error, eng *controlCaptureEngine) *LocalClient {
+func newVitessControlTestClient(apply *storage.Apply, tasks []*storage.Task, vitessData *storage.VitessApplyData, vitessDataErr error, eng engine.Engine) *LocalClient {
 	return &LocalClient{
 		config: LocalConfig{
 			Database: "testdb",
@@ -279,14 +280,13 @@ func TestLocalClient_CutoverRequiresCompleteVitessApplyData(t *testing.T) {
 				TaskIdentifier: "task-vitess-control",
 				State:          state.Task.WaitingForCutover,
 			}
-			eng := &controlCaptureEngine{}
+			eng := planetscale.New(slog.Default())
 			client := newVitessControlTestClient(apply, []*storage.Task{task}, tc.vitessData, nil, eng)
 
 			_, err := client.Cutover(t.Context(), &ternv1.CutoverRequest{ApplyId: apply.ApplyIdentifier})
 
-			require.ErrorContains(t, err, "deploy request metadata is incomplete")
+			require.ErrorContains(t, err, "cutover control resume state is incomplete")
 			require.ErrorContains(t, err, tc.missingPart)
-			assert.Nil(t, eng.cutoverReq, "cutover should not call the engine without deploy request metadata")
 		})
 	}
 }


### PR DESCRIPTION
## Why
Tern currently has to know when engine resume metadata is ready for control operations. Making the validation contract explicit keeps persistence in Tern while letting engines own their opaque metadata semantics.

## What
- Add optional engine control resume-state validation
- Validate PlanetScale deploy-request metadata before control calls
- Document the resume-state ownership boundary in the engine package

## Risk Assessment
Low — this is a narrow contract and validation refactor for control-request setup, with existing PlanetScale/Vitess behavior preserved and clearer failures for incomplete metadata.

Generated with Amp
