### PR TITLE
feat(github): handle check run rerequests

### DIFF
--- a/docs/check-runs.md
+++ b/docs/check-runs.md
@@ -470,10 +470,12 @@ above.
 
 ## Operator Guidance
 
-When this document says to retry SchemaBot from a PR, it means posting a
-SchemaBot command as a PR comment. The GitHub Check Run "Re-run" button is not
-the recovery path today because SchemaBot does not handle GitHub's
-`check_run.rerequested` webhook event.
+When a SchemaBot aggregate check fails because discovery, planning, or check
+publishing hit a transient error, users can click GitHub's **Re-run** button on
+the failed SchemaBot check to trigger SchemaBot discovery and auto-plan again
+for the current PR head. SchemaBot ignores Check Run re-run events for older
+commits after the PR head has moved, so stale re-runs cannot publish status for
+the current branch protection gate.
 
 Use these PR comment commands for normal retry paths:
 

--- a/pkg/webhook/README.md
+++ b/pkg/webhook/README.md
@@ -190,6 +190,5 @@ Schema request errors are mapped to specific GitHub comment templates:
 
 ## Not Implemented In Webhooks
 
-- Check Run action buttons and GitHub `check_run.rerequested` handling.
 - PR-comment control operations for `stop`, `cutover`, `revert`, and
   `skip-revert`; use the CLI for those operator actions.

--- a/pkg/webhook/check_aggregate.go
+++ b/pkg/webhook/check_aggregate.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/block/schemabot/pkg/api"
 	"github.com/block/schemabot/pkg/storage"
 )
 
@@ -13,11 +14,26 @@ func aggregateCheckNameForEnv(baseName, env string) string {
 	return fmt.Sprintf("%s (%s)", baseName, env)
 }
 
+func (h *Handler) serverConfig() (*api.ServerConfig, bool) {
+	if h == nil {
+		return nil, false
+	}
+	if h.service == nil {
+		return nil, false
+	}
+	config := h.service.Config()
+	if config == nil {
+		return nil, false
+	}
+	return config, true
+}
+
 func (h *Handler) aggregateCheckNameForRepo(repo string) string {
-	if h == nil || h.service == nil || h.service.Config() == nil {
+	config, ok := h.serverConfig()
+	if !ok {
 		return aggregateCheckName
 	}
-	return h.service.Config().GitHubCheckNameBaseForRepo(repo)
+	return config.GitHubCheckNameBaseForRepo(repo)
 }
 
 // filterChecksByEnvironment returns only stored check state for the given environment.

--- a/pkg/webhook/check_run.go
+++ b/pkg/webhook/check_run.go
@@ -1,0 +1,146 @@
+package webhook
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+type checkRunPayload struct {
+	Action   string `json:"action"`
+	CheckRun struct {
+		ID           int64  `json:"id"`
+		Name         string `json:"name"`
+		HeadSHA      string `json:"head_sha"`
+		PullRequests []struct {
+			Number int `json:"number"`
+		} `json:"pull_requests"`
+	} `json:"check_run"`
+	Repository struct {
+		FullName string `json:"full_name"`
+	} `json:"repository"`
+	Installation struct {
+		ID int64 `json:"id"`
+	} `json:"installation"`
+}
+
+func (h *Handler) handleCheckRun(w http.ResponseWriter, body []byte) {
+	var payload checkRunPayload
+	if err := json.Unmarshal(body, &payload); err != nil {
+		h.writeError(w, http.StatusBadRequest, "invalid check_run payload")
+		return
+	}
+
+	if payload.Action != "rerequested" {
+		h.logger.Debug("check_run action ignored",
+			"action", payload.Action,
+			"repo", payload.Repository.FullName,
+			"check_run_id", payload.CheckRun.ID,
+			"check_name", payload.CheckRun.Name)
+		h.writeJSON(w, http.StatusOK, map[string]string{"message": "check_run action ignored"})
+		return
+	}
+
+	installationID := payload.Installation.ID
+	if installationID == 0 {
+		h.writeError(w, http.StatusBadRequest, "missing installation ID in webhook payload")
+		return
+	}
+
+	repo := payload.Repository.FullName
+	pr, ok := checkRunPullRequestNumber(payload)
+	if !ok {
+		h.logger.Info("check_run rerequest ignored without pull request",
+			"repo", repo,
+			"check_run_id", payload.CheckRun.ID,
+			"check_name", payload.CheckRun.Name,
+			"head_sha", payload.CheckRun.HeadSHA)
+		h.writeJSON(w, http.StatusOK, map[string]string{"message": "check_run rerequest ignored without pull request"})
+		return
+	}
+
+	if h.service != nil && !h.service.Config().IsRepoAllowed(repo) {
+		h.logger.Warn("webhook from unregistered repository",
+			"event", "check_run",
+			"action", payload.Action,
+			"repo", repo,
+			"pr", pr,
+			"installation_id", installationID,
+			"check_run_id", payload.CheckRun.ID,
+			"check_name", payload.CheckRun.Name)
+		h.writeJSON(w, http.StatusOK, map[string]string{"message": "repository not registered"})
+		return
+	}
+
+	if !h.isSchemaBotAggregateCheckName(repo, payload.CheckRun.Name) {
+		h.logger.Info("check_run rerequest ignored for non-SchemaBot check",
+			"repo", repo,
+			"pr", pr,
+			"check_run_id", payload.CheckRun.ID,
+			"check_name", payload.CheckRun.Name,
+			"head_sha", payload.CheckRun.HeadSHA)
+		h.writeJSON(w, http.StatusOK, map[string]string{"message": "check_run rerequest ignored for non-SchemaBot check"})
+		return
+	}
+
+	if payload.CheckRun.HeadSHA == "" {
+		h.writeError(w, http.StatusBadRequest, "missing check_run head SHA")
+		return
+	}
+
+	ctx, cancel, client, err := h.autoPlanBootstrap(repo, installationID)
+	if err != nil {
+		h.logger.Error("failed to bootstrap check_run rerequest",
+			"repo", repo,
+			"pr", pr,
+			"head_sha", payload.CheckRun.HeadSHA,
+			"installation_id", installationID,
+			"check_run_id", payload.CheckRun.ID,
+			"check_name", payload.CheckRun.Name,
+			"error", err)
+		h.writeError(w, http.StatusInternalServerError, "failed to initialize GitHub client")
+		return
+	}
+	defer cancel()
+
+	if !h.verifyHeadSHAStillCurrentForPR(ctx, client, repo, pr, payload.CheckRun.HeadSHA, "check_run_rerequest") {
+		h.writeJSON(w, http.StatusOK, map[string]string{"message": "check_run rerequest ignored for stale head SHA"})
+		return
+	}
+
+	h.logger.Info("check_run rerequest triggered auto-plan",
+		"repo", repo,
+		"pr", pr,
+		"head_sha", payload.CheckRun.HeadSHA,
+		"installation_id", installationID,
+		"check_run_id", payload.CheckRun.ID,
+		"check_name", payload.CheckRun.Name)
+
+	message := h.runAutoPlanForPR(ctx, client, repo, pr, payload.CheckRun.HeadSHA, installationID, "check_run.rerequested")
+
+	h.writeJSON(w, http.StatusOK, map[string]string{"message": message})
+}
+
+func checkRunPullRequestNumber(payload checkRunPayload) (int, bool) {
+	if len(payload.CheckRun.PullRequests) == 0 {
+		return 0, false
+	}
+	pr := payload.CheckRun.PullRequests[0].Number
+	return pr, pr != 0
+}
+
+func (h *Handler) isSchemaBotAggregateCheckName(repo string, checkName string) bool {
+	baseName := h.aggregateCheckNameForRepo(repo)
+	if checkName == baseName {
+		return true
+	}
+	config, ok := h.serverConfig()
+	if !ok {
+		return false
+	}
+	for _, env := range config.AllowedEnvironments {
+		if checkName == aggregateCheckNameForEnv(baseName, env) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/webhook/handler.go
+++ b/pkg/webhook/handler.go
@@ -358,16 +358,8 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.handleIssueComment(w, body)
 		metrics.RecordWebhookEvent(ctx, metricApp, eventType, action, repo, "processed")
 	case "check_run":
-		// Phase 2: h.handleCheckRun(w, body)
-		h.logger.Info("webhook ignored",
-			"reason", "check_run_not_implemented",
-			"app_name", appName,
-			"delivery_id", r.Header.Get(headerDeliveryID),
-			"event", eventType,
-			"action", action,
-			"repo", repo)
-		h.writeJSON(w, http.StatusOK, map[string]string{"message": "check_run events not yet implemented"})
-		metrics.RecordWebhookEvent(ctx, metricApp, eventType, action, repo, "ignored")
+		h.handleCheckRun(w, body)
+		metrics.RecordWebhookEvent(ctx, metricApp, eventType, action, repo, "processed")
 	case "pull_request":
 		h.handlePullRequest(w, body)
 		metrics.RecordWebhookEvent(ctx, metricApp, eventType, action, repo, "processed")

--- a/pkg/webhook/handler_test.go
+++ b/pkg/webhook/handler_test.go
@@ -103,6 +103,56 @@ func TestWebhookIgnoresUnknownEvents(t *testing.T) {
 	assert.Contains(t, rr.Body.String(), "ignored")
 }
 
+func TestCheckRunRerequestIgnoresNonSchemaBotCheck(t *testing.T) {
+	h, _, _ := newTestHandler(t)
+
+	req := buildCheckRunWebhookRequest(t, checkRunWebhookPayloadOpts{
+		checkName: "CI / tests",
+		headSHA:   "abc123",
+	}, nil)
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), "non-SchemaBot check")
+}
+
+func TestCheckRunRerequestIgnoresStaleHeadSHA(t *testing.T) {
+	client, mux := setupGitHubServer(t)
+
+	mux.HandleFunc("GET /repos/octocat/hello-world/pulls/1", func(w http.ResponseWriter, _ *http.Request) {
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+			"head": map[string]any{"sha": "newsha222", "ref": "feature-branch"},
+			"base": map[string]any{"sha": "def456", "ref": "main"},
+			"user": map[string]any{"login": "testuser"},
+		}))
+	})
+
+	installClient := ghclient.NewInstallationClient(client, testLogger())
+	factory := &fakeClientFactory{client: installClient}
+	service := api.New(&emptyStorage{}, &api.ServerConfig{
+		AllowedEnvironments: []string{"staging"},
+	}, nil, testLogger())
+
+	h := &Handler{
+		service:   service,
+		ghClients: ghclient.NewSingleClientSet(defaultAppName, factory),
+		logger:    testLogger(),
+	}
+
+	req := buildCheckRunWebhookRequest(t, checkRunWebhookPayloadOpts{
+		checkName: "SchemaBot (staging)",
+		headSHA:   "oldsha111",
+	}, nil)
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), "stale head SHA")
+}
+
 // newTestHandler creates a Handler wired to a fake GitHub API server.
 // Returns the handler and a channel that receives posted comment bodies.
 func newTestHandler(t *testing.T) (*Handler, chan string, chan string) {

--- a/pkg/webhook/pull_request.go
+++ b/pkg/webhook/pull_request.go
@@ -3,6 +3,7 @@ package webhook
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"time"
 
@@ -89,25 +90,38 @@ func (h *Handler) handlePullRequest(w http.ResponseWriter, body []byte) {
 		"head_sha", headSHA,
 	)
 
-	// Discover all configs matching changed schema files in this PR
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel, client, err := h.autoPlanBootstrap(repo, installationID)
+	if err != nil {
+		h.logger.Error("failed to bootstrap auto-plan", "repo", repo, "pr", pr, "head_sha", headSHA, "error", err)
+		h.writeError(w, http.StatusInternalServerError, "failed to initialize GitHub client")
+		return
+	}
 	defer cancel()
+
+	message := h.runAutoPlanForPR(ctx, client, repo, pr, headSHA, installationID, "pull_request")
+	h.writeJSON(w, http.StatusOK, map[string]string{"message": message})
+}
+
+func (h *Handler) autoPlanBootstrap(repo string, installationID int64) (context.Context, context.CancelFunc, *ghclient.InstallationClient, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	// Dedupe FetchPullRequest calls within this webhook delivery.
 	ctx = ghclient.WithPRInfoCache(ctx)
 
 	client, err := h.clientForRepo(repo, installationID)
 	if err != nil {
-		h.logger.Error("failed to create GitHub client", "error", err)
-		h.writeError(w, http.StatusInternalServerError, "failed to initialize GitHub client")
-		return
+		cancel()
+		return nil, nil, nil, fmt.Errorf("create GitHub client for repo %s installation %d: %w", repo, installationID, err)
 	}
+	return ctx, cancel, client, nil
+}
 
+func (h *Handler) runAutoPlanForPR(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, headSHA string, installationID int64, source string) string {
+	// Discover all configs matching changed schema files in this PR
 	configs, err := client.FindAllConfigsForPR(ctx, repo, pr)
 	if err != nil {
-		h.logger.Error("failed to discover configs for PR", "repo", repo, "pr", pr, "error", err)
+		h.logger.Error("failed to discover configs for PR", "repo", repo, "pr", pr, "head_sha", headSHA, "source", source, "error", err)
 		h.postConfigDiscoveryFailure(ctx, client, repo, pr, headSHA, err)
-		h.writeJSON(w, http.StatusOK, map[string]string{"message": "config discovery failed"})
-		return
+		return "config discovery failed"
 	}
 
 	// Collect database names from discovered configs
@@ -123,7 +137,7 @@ func (h *Handler) handlePullRequest(w http.ResponseWriter, body []byte) {
 	})
 
 	if len(configs) == 0 {
-		h.logger.Info("no schema files in PR, skipping auto-plan", "repo", repo, "pr", pr)
+		h.logger.Info("no schema files in PR, skipping auto-plan", "repo", repo, "pr", pr, "head_sha", headSHA, "source", source)
 		// Post passing aggregates on the current HEAD SHA so branch protection
 		// isn't blocked on PRs that don't touch schema files. Always post —
 		// on synchronize events the HEAD SHA changes, so the aggregate must be
@@ -142,8 +156,7 @@ func (h *Handler) handlePullRequest(w http.ResponseWriter, body []byte) {
 				"No managed schema changes",
 				"This PR does not contain schema changes managed by SchemaBot.")
 		})
-		h.writeJSON(w, http.StatusOK, map[string]string{"message": "no schema files in PR"})
-		return
+		return "no schema files in PR"
 	}
 
 	// Launch auto-plan for each discovered config
@@ -154,7 +167,7 @@ func (h *Handler) handlePullRequest(w http.ResponseWriter, body []byte) {
 		})
 	}
 
-	h.writeJSON(w, http.StatusOK, map[string]string{"message": "auto-plan started"})
+	return "auto-plan started"
 }
 
 func (h *Handler) postConfigDiscoveryFailure(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, headSHA string, discoveryErr error) {

--- a/pkg/webhook/testhelpers_test.go
+++ b/pkg/webhook/testhelpers_test.go
@@ -48,6 +48,13 @@ type prWebhookPayloadOpts struct {
 	headRef string
 }
 
+type checkRunWebhookPayloadOpts struct {
+	action    string
+	checkName string
+	headSHA   string
+	pr        int
+}
+
 // buildPRWebhookRequest constructs a valid pull_request webhook POST request with HMAC signature.
 func buildPRWebhookRequest(t *testing.T, opts prWebhookPayloadOpts, secret []byte) *http.Request {
 	t.Helper()
@@ -87,6 +94,57 @@ func buildPRWebhookRequest(t *testing.T, opts prWebhookPayloadOpts, secret []byt
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/webhook", strings.NewReader(string(body)))
 	req.Header.Set("X-GitHub-Event", "pull_request")
+
+	if len(secret) > 0 {
+		mac := hmac.New(sha256.New, secret)
+		mac.Write(body)
+		sig := "sha256=" + hex.EncodeToString(mac.Sum(nil))
+		req.Header.Set("X-Hub-Signature-256", sig)
+	}
+
+	return req
+}
+
+// buildCheckRunWebhookRequest constructs a valid check_run webhook POST request with HMAC signature.
+func buildCheckRunWebhookRequest(t *testing.T, opts checkRunWebhookPayloadOpts, secret []byte) *http.Request {
+	t.Helper()
+
+	if opts.action == "" {
+		opts.action = "rerequested"
+	}
+	if opts.checkName == "" {
+		opts.checkName = "SchemaBot"
+	}
+	if opts.headSHA == "" {
+		opts.headSHA = "abc123"
+	}
+	if opts.pr == 0 {
+		opts.pr = 1
+	}
+
+	payload := map[string]any{
+		"action": opts.action,
+		"check_run": map[string]any{
+			"id":       123,
+			"name":     opts.checkName,
+			"head_sha": opts.headSHA,
+			"pull_requests": []map[string]any{{
+				"number": opts.pr,
+			}},
+		},
+		"repository": map[string]any{
+			"full_name": "octocat/hello-world",
+		},
+		"installation": map[string]any{
+			"id": 12345,
+		},
+	}
+
+	body, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/webhook", strings.NewReader(string(body)))
+	req.Header.Set("X-GitHub-Event", "check_run")
 
 	if len(secret) > 0 {
 		mac := hmac.New(sha256.New, secret)

--- a/pkg/webhook/webhook_e2e_test.go
+++ b/pkg/webhook/webhook_e2e_test.go
@@ -3544,6 +3544,128 @@ func TestE2EPassingAggregateOnNonSchemaPR(t *testing.T) {
 	assert.True(t, seen["SchemaBot (production)"], "expected SchemaBot (production) check")
 }
 
+// TestE2ECheckRunRerequestReplansCurrentPR verifies that rerunning a SchemaBot
+// Check Run from GitHub reuses auto-plan discovery and republishes aggregate
+// check state for the current PR head.
+func TestE2ECheckRunRerequestReplansCurrentPR(t *testing.T) {
+	svc := setupE2EServiceWithAllowedEnvs(t, []string{"staging"})
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	client := gh.NewClient(nil)
+	client.BaseURL, _ = url.Parse(server.URL + "/")
+
+	mux.HandleFunc("GET /repos/octocat/hello-world/pulls/1", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(gh.PullRequest{
+			Head: &gh.PullRequestBranch{Ref: new("feature-branch"), SHA: new("abc123")},
+			Base: &gh.PullRequestBranch{Ref: new("main"), SHA: new("def456")},
+			User: &gh.User{Login: new("testuser")},
+		})
+	})
+	mux.HandleFunc("GET /repos/octocat/hello-world/pulls/1/files", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode([]*gh.CommitFile{
+			{Filename: new("README.md"), Status: new("modified")},
+		})
+	})
+	mux.HandleFunc("GET /repos/octocat/hello-world/git/trees/abc123", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(gh.Tree{
+			SHA:       new("abc123"),
+			Entries:   []*gh.TreeEntry{},
+			Truncated: new(false),
+		})
+	})
+
+	checkRuns := make(chan checkRunCapture, 10)
+	mux.HandleFunc("POST /repos/octocat/hello-world/check-runs", func(w http.ResponseWriter, r *http.Request) {
+		var body checkRunCapture
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		checkRuns <- body
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": 1})
+	})
+
+	h := newE2EHandler(t, svc, client)
+	req := buildCheckRunWebhookRequest(t, checkRunWebhookPayloadOpts{
+		checkName: "SchemaBot (staging)",
+		headSHA:   "abc123",
+	}, nil)
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), "no schema files in PR")
+
+	select {
+	case cr := <-checkRuns:
+		assert.Equal(t, "SchemaBot (staging)", cr.Name)
+		assert.Equal(t, "abc123", cr.HeadSHA)
+		assert.Equal(t, checkStatusCompleted, cr.Status)
+		assert.Equal(t, checkConclusionSuccess, cr.Conclusion)
+	case <-time.After(webhookIntegrationCheckRunDeadline):
+		t.Fatal("timed out waiting for rerun aggregate check")
+	}
+}
+
+// TestE2ECheckRunRerequestIgnoresStaleHeadSHA verifies that rerunning an old
+// Check Run cannot publish check state for a commit that is no longer the PR
+// head.
+func TestE2ECheckRunRerequestIgnoresStaleHeadSHA(t *testing.T) {
+	svc := setupE2EServiceWithAllowedEnvs(t, []string{"staging"})
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	client := gh.NewClient(nil)
+	client.BaseURL, _ = url.Parse(server.URL + "/")
+
+	var fileListCalls atomic.Int64
+	mux.HandleFunc("GET /repos/octocat/hello-world/pulls/1", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(gh.PullRequest{
+			Head: &gh.PullRequestBranch{Ref: new("feature-branch"), SHA: new("newsha222")},
+			Base: &gh.PullRequestBranch{Ref: new("main"), SHA: new("def456")},
+			User: &gh.User{Login: new("testuser")},
+		})
+	})
+	mux.HandleFunc("GET /repos/octocat/hello-world/pulls/1/files", func(w http.ResponseWriter, _ *http.Request) {
+		fileListCalls.Add(1)
+		_ = json.NewEncoder(w).Encode([]*gh.CommitFile{
+			{Filename: new("README.md"), Status: new("modified")},
+		})
+	})
+
+	checkRuns := make(chan checkRunCapture, 1)
+	mux.HandleFunc("POST /repos/octocat/hello-world/check-runs", func(w http.ResponseWriter, r *http.Request) {
+		var body checkRunCapture
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		checkRuns <- body
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": 1})
+	})
+
+	h := newE2EHandler(t, svc, client)
+	req := buildCheckRunWebhookRequest(t, checkRunWebhookPayloadOpts{
+		checkName: "SchemaBot (staging)",
+		headSHA:   "oldsha111",
+	}, nil)
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), "stale head SHA")
+	assert.Equal(t, int64(0), fileListCalls.Load(), "stale check reruns should stop before config discovery")
+
+	select {
+	case cr := <-checkRuns:
+		t.Fatalf("stale check rerun should not publish a check run, got: %+v", cr)
+	case <-time.After(250 * time.Millisecond):
+	}
+}
+
 // TestE2EPassingAggregateSynchronizeUpdatesNewSHA verifies that when a non-schema PR
 // receives a synchronize event (force push / new commit), the passing aggregate check
 // is recreated on the new HEAD SHA — not left stale on the old commit.


### PR DESCRIPTION
## Why
When a SchemaBot Check Run fails because of a transient GitHub/config discovery issue, users should be able to recover from the GitHub UI. This lets them click **Re-run** on the failed SchemaBot check to re-drive SchemaBot discovery/auto-plan without pushing another commit or posting a PR comment.

## What
- Handle `check_run.rerequested` events for SchemaBot aggregate Check Runs
- Reuse the pull-request auto-plan path so reruns repeat config discovery, stale-check cleanup, and aggregate publishing consistently
- Ignore stale Check Run reruns before discovery if the PR head moved
- Document the GitHub **Re-run** recovery path in the Check Runs docs

Generated with Amp
