### PR TITLE
fix(github): ignore unregistered repositories without PR comments

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -290,10 +290,12 @@ tern_deployments:
     staging: "tern2-staging:9090"
 ```
 
-When a webhook arrives from an unlisted repository:
-- If the user invoked a SchemaBot command (e.g., `schemabot plan`), a PR comment explains the repo is not registered.
-- Auto-plan events (PR open/sync) are ignored without a PR comment because the
-  repository is outside this SchemaBot instance's ownership.
+When a SchemaBot command or auto-plan event reaches the allowlist check from an
+unlisted repository:
+- SchemaBot logs a warning and ignores the event without posting a PR comment
+  because the repository is outside this SchemaBot instance's ownership.
+- SchemaBot increments `schemabot.webhook.unregistered_repository_ignored_total`
+  so operators can detect unexpected webhook delivery or missing configuration.
 
 If `repos` is not configured or empty, all repositories are allowed.
 

--- a/pkg/metrics/README.md
+++ b/pkg/metrics/README.md
@@ -24,6 +24,7 @@ available, such as `repository`, `github_app`, and `installation_id`.
 | `schemabot.check_ownership_misses_total` | Counter | operation, repository, database, database_type, environment | Guarded check updates skipped because ownership changed |
 | `schemabot.status_check_operations_total` | Counter | operation, status, repository, database, database_type, environment | Status-check storage and GitHub operations |
 | `schemabot.webhook.events_total` | Counter | environment, event_type, action, repository, status | GitHub webhook events |
+| `schemabot.webhook.unregistered_repository_ignored_total` | Counter | environment, app_name, event_type, action, repository | Webhook events ignored because the repository is not configured |
 | `schemabot.github.requests_total` | Counter | environment, operation, category, resource, status, repository, github_app, installation_id | GitHub API responses observed by SchemaBot |
 | `schemabot.github.rate_limit.limit` | Gauge | environment, operation, resource, repository, github_app, installation_id | GitHub primary rate limit for the observed API resource |
 | `schemabot.github.rate_limit.remaining` | Gauge | environment, operation, resource, repository, github_app, installation_id | GitHub primary rate limit requests remaining for the observed API resource |

--- a/pkg/metrics/github_metrics_test.go
+++ b/pkg/metrics/github_metrics_test.go
@@ -4,7 +4,13 @@ import (
 	"sync"
 	"testing"
 
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNormalizeGitHubOperation(t *testing.T) {
@@ -43,4 +49,47 @@ func TestUnknownGitHubMetricLabelsAreTrackedOncePerDistinctValue(t *testing.T) {
 		return true
 	})
 	assert.Equal(t, 2, seen)
+}
+
+func TestRecordUnregisteredRepositoryWebhook(t *testing.T) {
+	reader := metric.NewManualReader()
+	mp := metric.NewMeterProvider(metric.WithReader(reader))
+	previousProvider := otel.GetMeterProvider()
+	otel.SetMeterProvider(mp)
+	defer func() {
+		otel.SetMeterProvider(previousProvider)
+		require.NoError(t, mp.Shutdown(t.Context()))
+	}()
+
+	RecordUnregisteredRepositoryWebhook(t.Context(), "default", "issue_comment", "created", "octocat/hello-world")
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(t.Context(), &rm))
+
+	var found bool
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != "schemabot.webhook.unregistered_repository_ignored_total" {
+				continue
+			}
+			found = true
+			sum, ok := m.Data.(metricdata.Sum[int64])
+			require.True(t, ok)
+			require.Len(t, sum.DataPoints, 1)
+			assert.Equal(t, int64(1), sum.DataPoints[0].Value)
+			assertMetricAttribute(t, sum.DataPoints[0].Attributes, "environment", "unknown")
+			assertMetricAttribute(t, sum.DataPoints[0].Attributes, "app_name", "default")
+			assertMetricAttribute(t, sum.DataPoints[0].Attributes, "event_type", "issue_comment")
+			assertMetricAttribute(t, sum.DataPoints[0].Attributes, "action", "created")
+			assertMetricAttribute(t, sum.DataPoints[0].Attributes, "repository", "octocat/hello-world")
+		}
+	}
+	assert.True(t, found)
+}
+
+func assertMetricAttribute(t *testing.T, attrs attribute.Set, key string, want string) {
+	t.Helper()
+	got, ok := attrs.Value(attribute.Key(key))
+	require.True(t, ok)
+	assert.Equal(t, want, got.AsString())
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -996,6 +996,44 @@ func logUnknownWebhookMetricLabel(label, value, appName, repo, status string) {
 		"status", status)
 }
 
+// RecordUnregisteredRepositoryWebhook increments the counter for webhook events
+// ignored because the repository is outside this SchemaBot instance's configured
+// ownership. A spike means GitHub is delivering events for repositories that this
+// deployment will not process.
+func RecordUnregisteredRepositoryWebhook(ctx context.Context, appName, eventType, action, repo string) {
+	if !knownWebhookEvents[eventType] {
+		logUnknownWebhookMetricLabel("event_type", eventType, appName, repo, "ignored")
+		eventType = "unknown"
+	}
+	if !knownWebhookActions[action] {
+		logUnknownWebhookMetricLabel("action", action, appName, repo, "ignored")
+		action = "unknown"
+	}
+	if appName == "" {
+		appName = "default"
+	}
+
+	meter := otel.Meter(meterName)
+	counter, err := meter.Int64Counter("schemabot.webhook.unregistered_repository_ignored_total",
+		otelmetric.WithDescription("Total number of GitHub webhook events ignored because the repository is not configured"),
+		otelmetric.WithUnit("{event}"),
+	)
+	if err != nil {
+		slog.Warn("failed to create unregistered repository webhook counter", "error", err)
+		return
+	}
+	attrs := []attribute.KeyValue{
+		EnvironmentAttribute(""),
+		attribute.String("app_name", appName),
+		attribute.String("event_type", eventType),
+		attribute.String("repository", repo),
+	}
+	if action != "" {
+		attrs = append(attrs, attribute.String("action", action))
+	}
+	counter.Add(ctx, 1, otelmetric.WithAttributes(attrs...))
+}
+
 var knownStatusCheckOperations = map[string]bool{
 	"plan_check_recorded":                  true,
 	"apply_started":                        true,

--- a/pkg/webhook/handler.go
+++ b/pkg/webhook/handler.go
@@ -355,7 +355,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	switch eventType {
 	case "issue_comment":
-		h.handleIssueComment(w, body)
+		h.handleIssueComment(ctx, metricApp, w, body)
 		metrics.RecordWebhookEvent(ctx, metricApp, eventType, action, repo, "processed")
 	case "check_run":
 		// Phase 2: h.handleCheckRun(w, body)
@@ -369,7 +369,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.writeJSON(w, http.StatusOK, map[string]string{"message": "check_run events not yet implemented"})
 		metrics.RecordWebhookEvent(ctx, metricApp, eventType, action, repo, "ignored")
 	case "pull_request":
-		h.handlePullRequest(w, body)
+		h.handlePullRequest(ctx, metricApp, w, body)
 		metrics.RecordWebhookEvent(ctx, metricApp, eventType, action, repo, "processed")
 	default:
 		h.logger.Info("webhook ignored",

--- a/pkg/webhook/handler_test.go
+++ b/pkg/webhook/handler_test.go
@@ -655,10 +655,8 @@ func TestWebhookRepoAllowlistRejectsUnregisteredRepo(t *testing.T) {
 
 	select {
 	case body := <-comments:
-		assert.Contains(t, body, "Repository not registered")
-		assert.Contains(t, body, "`repos`")
-	case <-time.After(2 * time.Second):
-		t.Fatal("timed out waiting for rejection comment")
+		t.Fatalf("unexpected rejection comment: %s", body)
+	case <-time.After(100 * time.Millisecond):
 	}
 }
 

--- a/pkg/webhook/issue_comment.go
+++ b/pkg/webhook/issue_comment.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/block/schemabot/pkg/metrics"
 	"github.com/block/schemabot/pkg/storage"
 	"github.com/block/schemabot/pkg/webhook/action"
 	"github.com/block/schemabot/pkg/webhook/templates"
@@ -38,7 +39,7 @@ type webhookPayload struct {
 }
 
 // handleIssueComment processes GitHub issue comment webhooks.
-func (h *Handler) handleIssueComment(w http.ResponseWriter, body []byte) {
+func (h *Handler) handleIssueComment(ctx context.Context, metricApp string, w http.ResponseWriter, body []byte) {
 	var payload webhookPayload
 	if err := json.Unmarshal(body, &payload); err != nil {
 		h.writeError(w, http.StatusBadRequest, "invalid webhook payload")
@@ -97,7 +98,7 @@ func (h *Handler) handleIssueComment(w http.ResponseWriter, body []byte) {
 			"pr", pr,
 			"installation_id", installationID,
 			"requested_by", requestedBy)
-		h.postComment(repo, pr, installationID, templates.RenderRepositoryNotRegistered())
+		metrics.RecordUnregisteredRepositoryWebhook(ctx, metricApp, "issue_comment", payload.Action, repo)
 		h.writeJSON(w, http.StatusOK, map[string]string{
 			"message": "repository not registered",
 		})

--- a/pkg/webhook/pull_request.go
+++ b/pkg/webhook/pull_request.go
@@ -34,7 +34,7 @@ type pullRequestPayload struct {
 
 // handlePullRequest processes GitHub pull_request webhook events.
 // On PR open/synchronize/reopen, it auto-plans all databases with schema changes.
-func (h *Handler) handlePullRequest(w http.ResponseWriter, body []byte) {
+func (h *Handler) handlePullRequest(ctx context.Context, metricApp string, w http.ResponseWriter, body []byte) {
 	var payload pullRequestPayload
 	if err := json.Unmarshal(body, &payload); err != nil {
 		h.writeError(w, http.StatusBadRequest, "invalid pull_request payload")
@@ -76,6 +76,7 @@ func (h *Handler) handlePullRequest(w http.ResponseWriter, body []byte) {
 			"repo", repo,
 			"pr", pr,
 			"installation_id", installationID)
+		metrics.RecordUnregisteredRepositoryWebhook(ctx, metricApp, "pull_request", payload.Action, repo)
 		h.writeJSON(w, http.StatusOK, map[string]string{
 			"message": "repository not registered",
 		})

--- a/pkg/webhook/templates/issue_comment.go
+++ b/pkg/webhook/templates/issue_comment.go
@@ -6,13 +6,6 @@ import (
 	"github.com/block/schemabot/pkg/apitypes"
 )
 
-// RenderRepositoryNotRegistered renders the message posted when a SchemaBot
-// command arrives from a repository that is not in the configured allowlist.
-func RenderRepositoryNotRegistered() string {
-	return "**Repository not registered.** This repository is not in SchemaBot's configuration. " +
-		"To onboard, add it to the `repos` section of SchemaBot's config and redeploy."
-}
-
 // RenderRollbackMissingArguments renders the message posted when `schemabot rollback`
 // is invoked without an apply ID and without an `-e` flag.
 func RenderRollbackMissingArguments() string {

--- a/pkg/webhook/templates/issue_comment_test.go
+++ b/pkg/webhook/templates/issue_comment_test.go
@@ -7,13 +7,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestRenderRepositoryNotRegistered(t *testing.T) {
-	rendered := RenderRepositoryNotRegistered()
-	assert.Contains(t, rendered, "**Repository not registered.**")
-	assert.Contains(t, rendered, "`repos`")
-	assert.Contains(t, rendered, "redeploy")
-}
-
 func TestRenderRollbackMissingArguments(t *testing.T) {
 	rendered := RenderRollbackMissingArguments()
 	assert.Contains(t, rendered, "## Missing Arguments")


### PR DESCRIPTION
SchemaBot now treats unregistered-repository webhook deliveries as operator signals instead of PR feedback. The allowlist behavior stays fail-closed: events are ignored, a warning is logged, and operators get a dedicated counter for unexpected delivery or missing config.

- Stop posting a PR comment when an unregistered repository invokes SchemaBot
- Emit `schemabot.webhook.unregistered_repository_ignored_total` for ignored unregistered-repo webhooks
- Document the warning-and-metric behavior for repo allowlist misses

Generated with Amp