### PR TITLE
fix(rollback): guard unsafe rollback requests

### DIFF
--- a/integration/cli_test.go
+++ b/integration/cli_test.go
@@ -1241,12 +1241,14 @@ func TestCLI_Rollback_ApplyNotFound(t *testing.T) {
 	endpoint := "http://" + schemabotAddr
 
 	t.Run("rollback_apply_not_found", func(t *testing.T) {
-		_, err := runCLIWithError(t, binPath, "rollback",
+		out, err := runCLIWithError(t, binPath, "rollback",
 			"apply_nonexistent0000",
+			"-e", "staging",
 			"--endpoint", endpoint,
 			"-y",
 		)
 		require.Error(t, err, "expected error for nonexistent apply ID")
+		assert.Contains(t, out, "apply not found: apply_nonexistent0000")
 	})
 }
 
@@ -1312,6 +1314,7 @@ CREATE TABLE items (
 		require.NotEmpty(t, applyID, "apply ID must be set by previous subtest")
 		out := runCLIInDir(t, binPath, schemaDir, "rollback",
 			applyID,
+			"-e", "staging",
 			"--endpoint", endpoint,
 			"-y",
 			"--watch=false",

--- a/pkg/api/control_handlers.go
+++ b/pkg/api/control_handlers.go
@@ -63,11 +63,161 @@ func IsInternalControlError(err error) bool {
 	return controlOperationHTTPStatus(err) >= http.StatusInternalServerError
 }
 
+// ControlOperationHTTPStatus returns the HTTP status associated with a control
+// operation error. Untyped errors are internal failures.
+func ControlOperationHTTPStatus(err error) int {
+	return controlOperationHTTPStatus(err)
+}
+
 func controlHTTPErrorf(status int, format string, args ...any) error {
 	return &controlOperationHTTPError{
 		status: status,
 		err:    fmt.Errorf(format, args...),
 	}
+}
+
+// RollbackSourceRequest identifies the completed apply that a rollback command
+// wants to reverse. GitHub comment flows require repository and pull request
+// scope to keep a PR from rolling back another PR's work.
+type RollbackSourceRequest struct {
+	ApplyIdentifier         string
+	Environment             string
+	Repository              string
+	PullRequest             int
+	RequirePullRequestScope bool
+}
+
+// ValidateRollbackSourceApply rejects rollback requests that cannot be mapped
+// unambiguously to the rollback planner's current source apply. Until rollback
+// planning targets a selected apply directly, only the latest completed source
+// apply with stored original schema is safe to roll back.
+func (s *Service) ValidateRollbackSourceApply(ctx context.Context, req RollbackSourceRequest) (*storage.Apply, *storage.Plan, error) {
+	if req.ApplyIdentifier == "" {
+		return nil, nil, controlHTTPErrorf(http.StatusBadRequest, "apply_id is required")
+	}
+	if req.Environment == "" {
+		return nil, nil, controlHTTPErrorf(http.StatusBadRequest, "environment is required")
+	}
+	if s.storage == nil {
+		return nil, nil, fmt.Errorf("storage is not available")
+	}
+
+	applyStore := s.storage.Applies()
+	if applyStore == nil {
+		return nil, nil, fmt.Errorf("apply store is not available")
+	}
+	planStore := s.storage.Plans()
+	if planStore == nil {
+		return nil, nil, fmt.Errorf("plan store is not available")
+	}
+	taskStore := s.storage.Tasks()
+	if taskStore == nil {
+		return nil, nil, fmt.Errorf("task store is not available")
+	}
+
+	apply, err := applyStore.GetByApplyIdentifier(ctx, req.ApplyIdentifier)
+	if err != nil {
+		return nil, nil, fmt.Errorf("load apply %s for rollback: %w", req.ApplyIdentifier, err)
+	}
+	if apply == nil {
+		return nil, nil, controlHTTPErrorf(http.StatusNotFound, "apply not found: %s", req.ApplyIdentifier)
+	}
+
+	if err := validateRollbackSourceScope(req, apply); err != nil {
+		return apply, nil, err
+	}
+
+	plan, err := planStore.GetByID(ctx, apply.PlanID)
+	if err != nil {
+		return apply, nil, fmt.Errorf("load source plan %d for rollback apply %s: %w", apply.PlanID, apply.ApplyIdentifier, err)
+	}
+	if plan == nil {
+		return apply, nil, fmt.Errorf("source plan %d not found for rollback apply %s", apply.PlanID, apply.ApplyIdentifier)
+	}
+	if len(plan.FlatOriginalSchema()) == 0 {
+		return apply, plan, controlConflictf("apply %s cannot be rolled back safely because its source plan has no stored original schema", apply.ApplyIdentifier)
+	}
+
+	latestTask, err := latestCompletedTaskForRollback(ctx, taskStore, apply.Database, apply.DatabaseType, apply.Environment)
+	if err != nil {
+		return apply, plan, err
+	}
+	if latestTask == nil {
+		return apply, plan, controlConflictf("no completed schema change task found for database %s environment %s", apply.Database, apply.Environment)
+	}
+	if latestTask.ApplyID != apply.ID {
+		return apply, plan, controlConflictf("apply %s is not the schema change that the current rollback planner would select for database %s environment %s", apply.ApplyIdentifier, apply.Database, apply.Environment)
+	}
+	if latestTask.PlanID != apply.PlanID {
+		return apply, plan, fmt.Errorf("latest schema change task for database %s points to plan %d, but apply %s points to plan %d", apply.Database, latestTask.PlanID, apply.ApplyIdentifier, apply.PlanID)
+	}
+
+	return apply, plan, nil
+}
+
+func validateRollbackSourceScope(req RollbackSourceRequest, apply *storage.Apply) error {
+	if !state.IsState(apply.State, state.Apply.Completed) {
+		return controlConflictf("apply %s is %s; rollback requires a completed apply", apply.ApplyIdentifier, apply.State)
+	}
+	if apply.Environment != req.Environment {
+		return controlHTTPErrorf(http.StatusBadRequest,
+			"apply %q belongs to environment %q, not %q", apply.ApplyIdentifier, apply.Environment, req.Environment)
+	}
+	if req.RequirePullRequestScope {
+		if req.Repository == "" {
+			return controlHTTPErrorf(http.StatusBadRequest, "repository is required")
+		}
+		if req.PullRequest <= 0 {
+			return controlHTTPErrorf(http.StatusBadRequest, "pull_request is required")
+		}
+	}
+	if req.Repository != "" {
+		if apply.Repository != req.Repository {
+			return controlHTTPErrorf(http.StatusBadRequest,
+				"apply %q belongs to repository %q, not %q", apply.ApplyIdentifier, apply.Repository, req.Repository)
+		}
+	}
+	if req.PullRequest > 0 {
+		if apply.PullRequest != req.PullRequest {
+			return controlHTTPErrorf(http.StatusBadRequest,
+				"apply %q belongs to PR #%d, not #%d", apply.ApplyIdentifier, apply.PullRequest, req.PullRequest)
+		}
+	}
+	return nil
+}
+
+func latestCompletedTaskForRollback(ctx context.Context, store storage.TaskStore, database, dbType, environment string) (*storage.Task, error) {
+	tasks, err := store.GetByDatabase(ctx, database)
+	if err != nil {
+		return nil, fmt.Errorf("load completed schema change tasks for database %s environment %s: %w", database, environment, err)
+	}
+
+	var latest *storage.Task
+	for _, task := range tasks {
+		if rollbackTaskMatchesPlannerScope(task, dbType, environment) && latest == nil {
+			latest = task
+		} else if rollbackTaskMatchesPlannerScope(task, dbType, environment) && rollbackTaskCompletedAfter(task, latest) {
+			latest = task
+		}
+	}
+	return latest, nil
+}
+
+func rollbackTaskMatchesPlannerScope(task *storage.Task, dbType, environment string) bool {
+	return state.IsState(task.State, state.Task.Completed) && task.DatabaseType == dbType && task.Environment == environment
+}
+
+func rollbackTaskCompletedAfter(candidate, current *storage.Task) bool {
+	if candidate.CompletedAt != nil && current.CompletedAt != nil {
+		return candidate.CompletedAt.After(*current.CompletedAt)
+	}
+	if candidate.CompletedAt != nil {
+		return true
+	}
+	if current.CompletedAt != nil {
+		return false
+	}
+	return candidate.CreatedAt.After(current.CreatedAt)
 }
 
 func controlOperationCaller(caller string) string {
@@ -1502,7 +1652,8 @@ func (s *Service) handleSkipRevert(w http.ResponseWriter, r *http.Request) {
 
 // RollbackPlanRequest is the HTTP request body for POST /api/rollback/plan.
 type RollbackPlanRequest struct {
-	ApplyID string `json:"apply_id"`
+	ApplyID     string `json:"apply_id"`
+	Environment string `json:"environment"`
 }
 
 // handleRollbackPlan handles POST /api/rollback/plan requests.
@@ -1520,15 +1671,17 @@ func (s *Service) handleRollbackPlan(w http.ResponseWriter, r *http.Request) {
 		s.writeError(w, http.StatusBadRequest, "apply_id is required")
 		return
 	}
-
-	// Look up the apply to get database/environment
-	apply, err := s.storage.Applies().GetByApplyIdentifier(r.Context(), req.ApplyID)
-	if err != nil {
-		s.writeError(w, http.StatusInternalServerError, "failed to look up apply: "+err.Error())
+	if req.Environment == "" {
+		s.writeError(w, http.StatusBadRequest, "environment is required")
 		return
 	}
-	if apply == nil {
-		s.writeError(w, http.StatusNotFound, "apply not found: "+req.ApplyID)
+
+	apply, _, err := s.ValidateRollbackSourceApply(r.Context(), RollbackSourceRequest{
+		ApplyIdentifier: req.ApplyID,
+		Environment:     req.Environment,
+	})
+	if err != nil {
+		s.writeControlError(w, "rollback plan", apply, err)
 		return
 	}
 

--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -107,29 +107,72 @@ func (m *mockStorageWithApplyStores) ControlRequests() storage.ControlRequestSto
 
 type staticPlanStore struct {
 	storage.PlanStore
-	plan *storage.Plan
-	err  error
+	plan      *storage.Plan
+	plansByID map[int64]*storage.Plan
+	err       error
 }
 
 func (s *staticPlanStore) Get(context.Context, string) (*storage.Plan, error) {
 	return s.plan, s.err
 }
 
-type staticApplyStore struct {
-	storage.ApplyStore
-	apply *storage.Apply
-	err   error
+func (s *staticPlanStore) GetByID(_ context.Context, id int64) (*storage.Plan, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	if s.plansByID != nil {
+		return s.plansByID[id], nil
+	}
+	return s.plan, nil
 }
 
-func (s *staticApplyStore) GetByApplyIdentifier(context.Context, string) (*storage.Apply, error) {
-	return s.apply, s.err
+type staticApplyStore struct {
+	storage.ApplyStore
+	apply   *storage.Apply
+	applies []*storage.Apply
+	err     error
+}
+
+func (s *staticApplyStore) GetByApplyIdentifier(_ context.Context, applyIdentifier string) (*storage.Apply, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	if len(s.applies) == 0 {
+		return s.apply, nil
+	}
+	for _, apply := range s.applies {
+		if apply.ApplyIdentifier == applyIdentifier {
+			return apply, nil
+		}
+	}
+	return nil, nil
 }
 func (s *staticApplyStore) Get(context.Context, int64) (*storage.Apply, error) {
 	return s.apply, s.err
 }
-func (s *staticApplyStore) GetByDatabase(context.Context, string, string, string) ([]*storage.Apply, error) {
+func (s *staticApplyStore) GetByDatabase(_ context.Context, database, dbType, environment string) ([]*storage.Apply, error) {
 	if s.err != nil {
 		return nil, s.err
+	}
+	if len(s.applies) > 0 {
+		var applies []*storage.Apply
+		for _, apply := range s.applies {
+			if apply.Database != database {
+				continue
+			}
+			if dbType != "" {
+				if apply.DatabaseType != dbType {
+					continue
+				}
+			}
+			if environment != "" {
+				if apply.Environment != environment {
+					continue
+				}
+			}
+			applies = append(applies, apply)
+		}
+		return applies, nil
 	}
 	if s.apply == nil {
 		return nil, nil
@@ -387,6 +430,18 @@ func (s *capturingTaskStore) GetByApplyID(_ context.Context, applyID int64) ([]*
 	return tasks, s.err
 }
 
+func (s *capturingTaskStore) GetByDatabase(_ context.Context, database string) ([]*storage.Task, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var tasks []*storage.Task
+	for _, task := range s.tasks {
+		if task.Database == database {
+			tasks = append(tasks, task)
+		}
+	}
+	return tasks, s.err
+}
+
 type emptyLockStore struct {
 	storage.LockStore
 }
@@ -541,7 +596,7 @@ func (m *mockTernClient) SkipRevert(ctx context.Context, req *ternv1.SkipRevertR
 	}
 	return nil, m.skipRevertErr
 }
-func (m *mockTernClient) RollbackPlan(ctx context.Context, database string) (*ternv1.PlanResponse, error) {
+func (m *mockTernClient) RollbackPlan(ctx context.Context, database, environment string) (*ternv1.PlanResponse, error) {
 	return nil, nil
 }
 func (m *mockTernClient) ResumeApply(ctx context.Context, apply *storage.Apply) error {
@@ -1706,6 +1761,186 @@ func TestProgressResponseFromProtoPreservesVSchemaChangeType(t *testing.T) {
 	assert.Equal(t, "vschema_update", resp.Tables[0].ChangeType)
 }
 
+func TestValidateRollbackSourceApplyAcceptsLatestCompletedApplyWithOriginalSchema(t *testing.T) {
+	now := time.Now().UTC()
+	apply := rollbackGuardrailApply("apply_latest", 1, 10, now)
+	svc := newRollbackGuardrailService(apply, rollbackGuardrailPlan(10, true), []*storage.Task{
+		rollbackGuardrailTask(1, 10, now),
+	})
+
+	gotApply, gotPlan, err := svc.ValidateRollbackSourceApply(t.Context(), RollbackSourceRequest{
+		ApplyIdentifier: "apply_latest",
+		Environment:     "staging",
+		Repository:      "org/repo",
+		PullRequest:     1,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, apply, gotApply)
+	require.NotNil(t, gotPlan)
+	assert.Equal(t, int64(10), gotPlan.ID)
+}
+
+func TestValidateRollbackSourceApplyRequiresEnvironment(t *testing.T) {
+	now := time.Now().UTC()
+	apply := rollbackGuardrailApply("apply_latest", 1, 10, now)
+	svc := newRollbackGuardrailService(apply, rollbackGuardrailPlan(10, true), []*storage.Task{
+		rollbackGuardrailTask(1, 10, now),
+	})
+
+	_, _, err := svc.ValidateRollbackSourceApply(t.Context(), RollbackSourceRequest{
+		ApplyIdentifier: "apply_latest",
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "environment is required")
+}
+
+func TestValidateRollbackSourceApplyRequiresPullRequestScopeWhenRequested(t *testing.T) {
+	now := time.Now().UTC()
+	apply := rollbackGuardrailApply("apply_latest", 1, 10, now)
+	svc := newRollbackGuardrailService(apply, rollbackGuardrailPlan(10, true), []*storage.Task{
+		rollbackGuardrailTask(1, 10, now),
+	})
+
+	_, _, err := svc.ValidateRollbackSourceApply(t.Context(), RollbackSourceRequest{
+		ApplyIdentifier:         "apply_latest",
+		Environment:             "staging",
+		RequirePullRequestScope: true,
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "repository is required")
+}
+
+func TestValidateRollbackSourceApplyRejectsPlanWithoutOriginalSchema(t *testing.T) {
+	now := time.Now().UTC()
+	apply := rollbackGuardrailApply("apply_no_schema", 1, 10, now)
+	svc := newRollbackGuardrailService(apply, rollbackGuardrailPlan(10, false), []*storage.Task{
+		rollbackGuardrailTask(1, 10, now),
+	})
+
+	_, _, err := svc.ValidateRollbackSourceApply(t.Context(), RollbackSourceRequest{
+		ApplyIdentifier: "apply_no_schema",
+		Environment:     "staging",
+		Repository:      "org/repo",
+		PullRequest:     1,
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no stored original schema")
+}
+
+func TestValidateRollbackSourceApplyRejectsPlannerSourceMismatchForOlderApply(t *testing.T) {
+	now := time.Now().UTC()
+	older := rollbackGuardrailApply("apply_older", 1, 10, now.Add(-time.Minute))
+	newer := rollbackGuardrailApply("apply_newer", 2, 20, now)
+	svc := newRollbackGuardrailServiceWithApplies([]*storage.Apply{older, newer}, map[int64]*storage.Plan{
+		10: rollbackGuardrailPlan(10, true),
+		20: rollbackGuardrailPlan(20, true),
+	}, []*storage.Task{
+		rollbackGuardrailTask(1, 10, now.Add(-time.Minute)),
+		rollbackGuardrailTask(2, 20, now),
+	})
+
+	_, _, err := svc.ValidateRollbackSourceApply(t.Context(), RollbackSourceRequest{
+		ApplyIdentifier: "apply_older",
+		Environment:     "staging",
+		Repository:      "org/repo",
+		PullRequest:     1,
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "current rollback planner would select")
+}
+
+func TestValidateRollbackSourceApplyScopesLatestCompletedTaskByEnvironment(t *testing.T) {
+	now := time.Now().UTC()
+	apply := rollbackGuardrailApply("apply_staging", 1, 10, now.Add(-time.Minute))
+	prodTask := rollbackGuardrailTask(2, 20, now)
+	prodTask.Environment = "production"
+	svc := newRollbackGuardrailService(apply, rollbackGuardrailPlan(10, true), []*storage.Task{
+		rollbackGuardrailTask(1, 10, now.Add(-time.Minute)),
+		prodTask,
+	})
+
+	gotApply, gotPlan, err := svc.ValidateRollbackSourceApply(t.Context(), RollbackSourceRequest{
+		ApplyIdentifier: "apply_staging",
+		Environment:     "staging",
+		Repository:      "org/repo",
+		PullRequest:     1,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, apply, gotApply)
+	require.NotNil(t, gotPlan)
+	assert.Equal(t, int64(10), gotPlan.ID)
+}
+
+func newRollbackGuardrailService(apply *storage.Apply, plan *storage.Plan, tasks []*storage.Task) *Service {
+	return newRollbackGuardrailServiceWithApplies([]*storage.Apply{apply}, map[int64]*storage.Plan{plan.ID: plan}, tasks)
+}
+
+func newRollbackGuardrailServiceWithApplies(applies []*storage.Apply, plans map[int64]*storage.Plan, tasks []*storage.Task) *Service {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	return New(&mockStorageWithApplyStores{
+		plans:   &staticPlanStore{plansByID: plans},
+		applies: &staticApplyStore{applies: applies},
+		tasks:   &capturingTaskStore{tasks: tasks},
+	}, testServerConfig(), nil, logger)
+}
+
+func rollbackGuardrailApply(identifier string, id, planID int64, completedAt time.Time) *storage.Apply {
+	return &storage.Apply{
+		ID:              id,
+		ApplyIdentifier: identifier,
+		PlanID:          planID,
+		Database:        "orders",
+		DatabaseType:    storage.DatabaseTypeMySQL,
+		Repository:      "org/repo",
+		PullRequest:     1,
+		Environment:     "staging",
+		State:           state.Apply.Completed,
+		CompletedAt:     &completedAt,
+		CreatedAt:       completedAt,
+		UpdatedAt:       completedAt,
+	}
+}
+
+func rollbackGuardrailPlan(id int64, includeOriginalSchema bool) *storage.Plan {
+	plan := &storage.Plan{
+		ID:           id,
+		Database:     "orders",
+		DatabaseType: storage.DatabaseTypeMySQL,
+		Environment:  "staging",
+		Namespaces: map[string]*storage.NamespacePlanData{
+			"orders": {},
+		},
+	}
+	if includeOriginalSchema {
+		plan.Namespaces["orders"].OriginalSchema = map[string]string{
+			"users": "CREATE TABLE `users` (`id` bigint unsigned NOT NULL AUTO_INCREMENT, PRIMARY KEY (`id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci",
+		}
+	}
+	return plan
+}
+
+func rollbackGuardrailTask(applyID, planID int64, completedAt time.Time) *storage.Task {
+	return &storage.Task{
+		ApplyID:      applyID,
+		PlanID:       planID,
+		Database:     "orders",
+		DatabaseType: storage.DatabaseTypeMySQL,
+		Repository:   "org/repo",
+		PullRequest:  1,
+		Environment:  "staging",
+		State:        state.Task.Completed,
+		CompletedAt:  &completedAt,
+		CreatedAt:    completedAt,
+		UpdatedAt:    completedAt,
+	}
+}
+
 func TestHandleStatusLimitAndEnvironment(t *testing.T) {
 	now := time.Now().UTC()
 	applies := &recentApplyStore{
@@ -2240,7 +2475,7 @@ func TestControlHandlersRejectClientDeployment(t *testing.T) {
 		{
 			name: "rollback plan",
 			path: "/api/rollback/plan",
-			body: `{"apply_id": "apply-123", "deployment": "default"}`,
+			body: `{"apply_id": "apply-123", "environment": "staging", "deployment": "default"}`,
 		},
 	}
 
@@ -2260,6 +2495,20 @@ func TestControlHandlersRejectClientDeployment(t *testing.T) {
 			assert.Contains(t, w.Body.String(), "deployment")
 		})
 	}
+}
+
+func TestRollbackPlanRequiresEnvironment(t *testing.T) {
+	svc := newTestService()
+	mux := http.NewServeMux()
+	svc.ConfigureRoutes(mux)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/rollback/plan", strings.NewReader(`{"apply_id": "apply-123"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
+	assert.Contains(t, w.Body.String(), "environment is required")
 }
 
 func TestControlHandlersRejectClientDatabase(t *testing.T) {
@@ -2296,6 +2545,11 @@ func TestControlHandlersRejectClientDatabase(t *testing.T) {
 		{
 			name: "skip-revert",
 			path: "/api/skip-revert",
+			body: `{"database": "testdb", "environment": "staging", "apply_id": "apply-123"}`,
+		},
+		{
+			name: "rollback plan",
+			path: "/api/rollback/plan",
 			body: `{"database": "testdb", "environment": "staging", "apply_id": "apply-123"}`,
 		},
 	}

--- a/pkg/api/plan_handlers.go
+++ b/pkg/api/plan_handlers.go
@@ -914,7 +914,7 @@ func (s *Service) ExecuteRollbackPlan(ctx context.Context, database, environment
 		return nil, fmt.Errorf("database %q (%s): %w", database, environment, err)
 	}
 
-	resp, err := client.RollbackPlan(ctx, database)
+	resp, err := client.RollbackPlan(ctx, database, environment)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/client/client.go
+++ b/pkg/cmd/client/client.go
@@ -102,9 +102,10 @@ func CallPlanAPIWithFiles(endpoint, database, dbType, environment string, schema
 
 // CallRollbackPlanAPI calls the rollback API to generate a plan that reverts
 // the specified apply. The response includes database/environment metadata.
-func CallRollbackPlanAPI(endpoint, applyID string) (*apitypes.PlanResponse, error) {
+func CallRollbackPlanAPI(endpoint, applyID, environment string) (*apitypes.PlanResponse, error) {
 	body := map[string]any{
-		"apply_id": applyID,
+		"apply_id":    applyID,
+		"environment": environment,
 	}
 	var result apitypes.PlanResponse
 	if err := doPostInto(endpoint, "/api/rollback/plan", body, &result); err != nil {

--- a/pkg/cmd/commands/rollback.go
+++ b/pkg/cmd/commands/rollback.go
@@ -12,6 +12,7 @@ import (
 // RollbackCmd rollbacks a database to its schema state before a specific apply.
 type RollbackCmd struct {
 	ApplyID      string `arg:"" required:"" help:"Apply ID to rollback"`
+	Environment  string `short:"e" required:"" help:"Target environment"`
 	AutoApprove  bool   `short:"y" help:"Skip confirmation prompt" name:"auto-approve"`
 	Watch        bool   `short:"w" help:"Watch progress until completion" default:"true" negatable:""`
 	DeferCutover bool   `help:"Defer cutover until manual trigger" name:"defer-cutover"`
@@ -19,14 +20,14 @@ type RollbackCmd struct {
 
 // Run executes the rollback command.
 func (cmd *RollbackCmd) Run(g *Globals) error {
-	ep, err := resolveEndpoint(g.Endpoint, g.Profile)
+	ep, err := resolveControlFlags(g.Endpoint, g.Profile, cmd.ApplyID, cmd.Environment)
 	if err != nil {
 		return err
 	}
 
 	// Step 1: Generate rollback plan from the specified apply
 	fmt.Println("Generating rollback plan...")
-	planResult, err := client.CallRollbackPlanAPI(ep, cmd.ApplyID)
+	planResult, err := client.CallRollbackPlanAPI(ep, cmd.ApplyID, cmd.Environment)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/main_test.go
+++ b/pkg/cmd/main_test.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"io"
+	"testing"
+
+	"github.com/alecthomas/kong"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRollbackRequiresEnvironmentFlag(t *testing.T) {
+	var cli CLI
+	parser, err := kong.New(&cli,
+		kong.Name("schemabot"),
+		kong.Writers(io.Discard, io.Discard),
+	)
+	require.NoError(t, err)
+
+	_, err = parser.Parse([]string{"rollback", "apply_abc123", "--auto-approve"})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "-e")
+}

--- a/pkg/tern/README.md
+++ b/pkg/tern/README.md
@@ -23,7 +23,7 @@ type Client interface {
     Volume(ctx, *VolumeRequest) (*VolumeResponse, error)
     Revert(ctx, *RevertRequest) (*RevertResponse, error)
     SkipRevert(ctx, *SkipRevertRequest) (*SkipRevertResponse, error)
-    RollbackPlan(ctx, database string) (*PlanResponse, error)
+    RollbackPlan(ctx, database, environment string) (*PlanResponse, error)
     Health(ctx) error
     ResumeApply(ctx, *storage.Apply) error
     ResumeApplyOperation(ctx, *storage.Apply, applyOperationID int64) error

--- a/pkg/tern/client.go
+++ b/pkg/tern/client.go
@@ -66,7 +66,7 @@ type Client interface {
 
 	// RollbackPlan generates a plan to revert to the schema state before the most recent apply.
 	// Uses the OriginalSchema captured at plan time.
-	RollbackPlan(ctx context.Context, database string) (*ternv1.PlanResponse, error)
+	RollbackPlan(ctx context.Context, database, environment string) (*ternv1.PlanResponse, error)
 
 	// Health checks the service health.
 	Health(ctx context.Context) error

--- a/pkg/tern/grpc_client.go
+++ b/pkg/tern/grpc_client.go
@@ -785,7 +785,7 @@ func (c *GRPCClient) SkipRevert(ctx context.Context, req *ternv1.SkipRevertReque
 // RollbackPlan is not supported via gRPC client.
 // Rollback functionality requires access to storage for plan lookup, which is only
 // available in local mode. Use LocalClient for rollback operations.
-func (c *GRPCClient) RollbackPlan(ctx context.Context, database string) (*ternv1.PlanResponse, error) {
+func (c *GRPCClient) RollbackPlan(ctx context.Context, database, environment string) (*ternv1.PlanResponse, error) {
 	return nil, fmt.Errorf("rollback is not supported via gRPC client - use local mode")
 }
 

--- a/pkg/tern/local_control.go
+++ b/pkg/tern/local_control.go
@@ -857,9 +857,13 @@ func (c *LocalClient) SkipRevert(ctx context.Context, req *ternv1.SkipRevertRequ
 }
 
 // RollbackPlan generates a plan to revert to the schema state before the most recent apply.
-func (c *LocalClient) RollbackPlan(ctx context.Context, database string) (*ternv1.PlanResponse, error) {
-	// Find the most recent completed task for this database
-	tasks, err := c.storage.Tasks().GetByDatabase(ctx, c.config.Database)
+func (c *LocalClient) RollbackPlan(ctx context.Context, database, environment string) (*ternv1.PlanResponse, error) {
+	if database != c.config.Database {
+		return nil, fmt.Errorf("rollback plan requested database %s, but client is configured for database %s", database, c.config.Database)
+	}
+
+	// Find the most recent completed task for this database and environment.
+	tasks, err := c.storage.Tasks().GetByDatabase(ctx, database)
 	if err != nil {
 		return nil, fmt.Errorf("get tasks failed: %w", err)
 	}
@@ -868,7 +872,7 @@ func (c *LocalClient) RollbackPlan(ctx context.Context, database string) (*ternv
 	// We prefer CompletedAt comparison when available, but fall back to creation order.
 	var latestCompletedTask *storage.Task
 	for _, t := range tasks {
-		if t.State == state.Task.Completed {
+		if t.Environment == environment && t.DatabaseType == c.config.Type && state.IsState(t.State, state.Task.Completed) {
 			switch {
 			case latestCompletedTask == nil:
 				latestCompletedTask = t
@@ -886,7 +890,7 @@ func (c *LocalClient) RollbackPlan(ctx context.Context, database string) (*ternv
 	}
 
 	if latestCompletedTask == nil {
-		return nil, fmt.Errorf("no completed schema change found to rollback")
+		return nil, fmt.Errorf("no completed schema change found to rollback for database %s environment %s", database, environment)
 	}
 
 	// Get the plan associated with this task
@@ -896,6 +900,9 @@ func (c *LocalClient) RollbackPlan(ctx context.Context, database string) (*ternv
 	}
 	if plan == nil {
 		return nil, fmt.Errorf("plan not found for completed task")
+	}
+	if plan.Environment != environment {
+		return nil, fmt.Errorf("completed task for database %s environment %s points to plan for environment %s", database, environment, plan.Environment)
 	}
 
 	originalSchema := plan.FlatOriginalSchema()
@@ -918,9 +925,9 @@ func (c *LocalClient) RollbackPlan(ctx context.Context, database string) (*ternv
 
 	// Generate a new plan using the original schema as the target
 	return c.Plan(ctx, &ternv1.PlanRequest{
-		Database:    c.config.Database,
+		Database:    database,
 		Type:        c.config.Type,
-		Environment: plan.Environment,
+		Environment: environment,
 		Target:      plan.Target,
 		SchemaFiles: schemaFiles,
 	})

--- a/pkg/tern/routing_client.go
+++ b/pkg/tern/routing_client.go
@@ -283,7 +283,7 @@ func (c *RoutingClient) SkipRevert(ctx context.Context, req *ternv1.SkipRevertRe
 }
 
 // RollbackPlan is not routable without an environment-scoped request.
-func (c *RoutingClient) RollbackPlan(ctx context.Context, database string) (*ternv1.PlanResponse, error) {
+func (c *RoutingClient) RollbackPlan(ctx context.Context, database, environment string) (*ternv1.PlanResponse, error) {
 	return nil, fmt.Errorf("rollback plan for database %q requires an environment-scoped client", database)
 }
 

--- a/pkg/webhook/actor_authorization_test.go
+++ b/pkg/webhook/actor_authorization_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/block/schemabot/pkg/api"
 	ghclient "github.com/block/schemabot/pkg/github"
+	"github.com/block/schemabot/pkg/state"
 	"github.com/block/schemabot/pkg/storage"
 	"github.com/block/schemabot/pkg/webhook/action"
 )
@@ -424,7 +425,7 @@ func TestHandleRollbackCommandBlocksUnauthorizedActor(t *testing.T) {
 	installClient := ghclient.NewInstallationClient(client, testLogger())
 	h := actorAuthStorageTestHandler(cfg, &actorAuthStorage{apply: actorAuthRollbackApply(), locks: locks}, installClient)
 
-	h.handleRollbackCommand("octocat/hello-world", 1, 12345, "mona", CommandResult{Action: action.Rollback, ApplyID: "apply_abcd1234"})
+	h.handleRollbackCommand("octocat/hello-world", 1, 12345, "mona", CommandResult{Action: action.Rollback, ApplyID: "apply_abcd1234", Environment: "staging"})
 
 	body := requireComment(t, comments, "unauthorized rollback comment")
 	assert.Contains(t, body, "SchemaBot Command Not Authorized")
@@ -456,7 +457,7 @@ func TestHandleRollbackCommandAllowsAuthorizedActor(t *testing.T) {
 	installClient := ghclient.NewInstallationClient(client, testLogger())
 	h := actorAuthStorageTestHandler(cfg, &actorAuthStorage{apply: actorAuthRollbackApply(), locks: locks}, installClient)
 
-	h.handleRollbackCommand("octocat/hello-world", 1, 12345, "hubot", CommandResult{Action: action.Rollback, ApplyID: "apply_abcd1234"})
+	h.handleRollbackCommand("octocat/hello-world", 1, 12345, "hubot", CommandResult{Action: action.Rollback, ApplyID: "apply_abcd1234", Environment: "staging"})
 
 	body := requireComment(t, comments, "rollback blocked-by-lock comment")
 	assert.Contains(t, body, "Rollback Blocked")
@@ -610,8 +611,10 @@ func TestHandleUnlockCommandUnconfiguredDatabaseHint(t *testing.T) {
 }
 
 func actorAuthRollbackApply() *storage.Apply {
+	completedAt := time.Now()
 	return &storage.Apply{
 		ID:              42,
+		PlanID:          24,
 		ApplyIdentifier: "apply_abcd1234",
 		Database:        "orders",
 		DatabaseType:    storage.DatabaseTypeMySQL,
@@ -619,6 +622,8 @@ func actorAuthRollbackApply() *storage.Apply {
 		PullRequest:     1,
 		Environment:     "staging",
 		Deployment:      "orders",
+		State:           state.Apply.Completed,
+		CompletedAt:     &completedAt,
 	}
 }
 
@@ -639,6 +644,14 @@ func (s *actorAuthStorage) Locks() storage.LockStore {
 	return s.locks
 }
 
+func (s *actorAuthStorage) Plans() storage.PlanStore {
+	return &actorAuthPlanStore{apply: s.apply}
+}
+
+func (s *actorAuthStorage) Tasks() storage.TaskStore {
+	return &actorAuthTaskStore{apply: s.apply}
+}
+
 type actorAuthApplyStore struct {
 	storage.ApplyStore
 	apply *storage.Apply
@@ -653,6 +666,51 @@ func (s *actorAuthApplyStore) GetByApplyIdentifier(_ context.Context, applyIdent
 
 func (s *actorAuthApplyStore) GetByDatabase(_ context.Context, _, _, _ string) ([]*storage.Apply, error) {
 	return nil, nil
+}
+
+type actorAuthPlanStore struct {
+	storage.PlanStore
+	apply *storage.Apply
+}
+
+func (s *actorAuthPlanStore) GetByID(_ context.Context, id int64) (*storage.Plan, error) {
+	if s.apply == nil || s.apply.PlanID != id {
+		return nil, nil
+	}
+	return &storage.Plan{
+		ID:           s.apply.PlanID,
+		Database:     s.apply.Database,
+		DatabaseType: s.apply.DatabaseType,
+		Environment:  s.apply.Environment,
+		Namespaces: map[string]*storage.NamespacePlanData{
+			s.apply.Database: {
+				OriginalSchema: map[string]string{"users": "CREATE TABLE `users` (`id` bigint unsigned NOT NULL AUTO_INCREMENT, PRIMARY KEY (`id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"},
+			},
+		},
+	}, nil
+}
+
+type actorAuthTaskStore struct {
+	storage.TaskStore
+	apply *storage.Apply
+}
+
+func (s *actorAuthTaskStore) GetByDatabase(_ context.Context, database string) ([]*storage.Task, error) {
+	if s.apply == nil || s.apply.Database != database {
+		return nil, nil
+	}
+	return []*storage.Task{{
+		ApplyID:      s.apply.ID,
+		PlanID:       s.apply.PlanID,
+		Database:     s.apply.Database,
+		DatabaseType: s.apply.DatabaseType,
+		Repository:   s.apply.Repository,
+		PullRequest:  s.apply.PullRequest,
+		Environment:  s.apply.Environment,
+		State:        state.Task.Completed,
+		CompletedAt:  s.apply.CompletedAt,
+		CreatedAt:    s.apply.CreatedAt,
+	}}, nil
 }
 
 // actorAuthLockStore serves locks from a fixed set and records every lock

--- a/pkg/webhook/commands.go
+++ b/pkg/webhook/commands.go
@@ -10,8 +10,8 @@ import (
 
 // CommandSpec declares the parse and dispatch shape of a SchemaBot command.
 //
-// Adding a new command means appending one entry to commandSpecs — the parser
-// regex, flag handling, and missing-env behavior all derive from the spec.
+// Adding a new command means appending one entry to commandSpecs — the parser,
+// unsupported-flag handling, and missing-env behavior all derive from the spec.
 // Adding ad-hoc parsing logic anywhere else for a known command is a sign the
 // spec is missing a field, not that the parser needs another special case.
 type CommandSpec struct {
@@ -69,9 +69,9 @@ var commandSpecs = []CommandSpec{
 	{Name: action.Revert, RequiresEnv: true},
 	{Name: action.SkipRevert, RequiresEnv: true},
 	{Name: action.Cutover, RequiresEnv: true, HasApplyID: true},
-	{Name: action.Rollback, RequiresEnv: true, HasApplyID: true, SupportsDB: true,
+	{Name: action.Rollback, RequiresEnv: true, HasApplyID: true,
 		SupportsDeferCutover: true},
-	{Name: action.RollbackConfirm, RequiresEnv: true, SupportsDB: true},
+	{Name: action.RollbackConfirm, RequiresEnv: true},
 }
 
 // specByName indexes commandSpecs for O(1) lookup by command word.
@@ -82,6 +82,11 @@ var specByName = func() map[string]CommandSpec {
 	}
 	return m
 }()
+
+func commandSupportsDatabaseFlag(actionName string) bool {
+	spec, ok := specByName[actionName]
+	return ok && spec.SupportsDB
+}
 
 // commandNamePattern is the alternation of every registered command name,
 // sorted by length descending so "apply-confirm" wins over "apply" at the same
@@ -258,4 +263,10 @@ func (p *CommandParser) applySpec(spec CommandSpec, body string) CommandResult {
 // command whose spec does not opt into SupportsAutoConfirm.
 func (p *CommandParser) HasAutoConfirmFlag(body string) bool {
 	return p.autoConfirmRegex.MatchString(body)
+}
+
+// HasDatabaseFlag reports whether the body contains a `-d <database>` flag,
+// regardless of which command it accompanies.
+func (p *CommandParser) HasDatabaseFlag(body string) bool {
+	return p.databaseRegex.MatchString(body)
 }

--- a/pkg/webhook/commands_test.go
+++ b/pkg/webhook/commands_test.go
@@ -63,8 +63,8 @@ func TestCommandSpecs_FlagsRespected(t *testing.T) {
 		{name: action.SkipRevert, requiresEnv: true},
 		{name: action.Cutover, requiresEnv: true, hasApplyID: true},
 		{name: action.Rollback, requiresEnv: true, hasApplyID: true,
-			supportsDB: true, supportsDefer: true},
-		{name: action.RollbackConfirm, requiresEnv: true, supportsDB: true},
+			supportsDefer: true},
+		{name: action.RollbackConfirm, requiresEnv: true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -88,6 +88,20 @@ func TestHasAutoConfirmFlag(t *testing.T) {
 	assert.True(t, p.HasAutoConfirmFlag("schemabot apply -e staging --yes"))
 	assert.False(t, p.HasAutoConfirmFlag("schemabot apply -e staging"))
 	assert.False(t, p.HasAutoConfirmFlag(""))
+}
+
+func TestHasDatabaseFlag(t *testing.T) {
+	p := NewCommandParser()
+	assert.True(t, p.HasDatabaseFlag("schemabot rollback apply_abc123 -e staging -d users"))
+	assert.False(t, p.HasDatabaseFlag("schemabot rollback apply_abc123 -e staging"))
+}
+
+func TestCommandSupportsDatabaseFlag(t *testing.T) {
+	assert.True(t, commandSupportsDatabaseFlag(action.Plan))
+	assert.True(t, commandSupportsDatabaseFlag(action.Apply))
+	assert.False(t, commandSupportsDatabaseFlag(action.Rollback))
+	assert.False(t, commandSupportsDatabaseFlag(action.RollbackConfirm))
+	assert.False(t, commandSupportsDatabaseFlag("unknown"))
 }
 
 func TestParseCommand(t *testing.T) {
@@ -370,6 +384,17 @@ func TestParseCommand(t *testing.T) {
 			},
 		},
 		{
+			name: "rollback leaves unsupported database flag out of result",
+			body: "schemabot rollback apply_abc123 -e staging -d users_db",
+			expected: CommandResult{
+				Action:      "rollback",
+				ApplyID:     "apply_abc123",
+				Environment: "staging",
+				Found:       true,
+				IsMention:   true,
+			},
+		},
+		{
 			name: "rollback without apply ID",
 			body: "schemabot rollback -e Staging",
 			expected: CommandResult{
@@ -391,6 +416,16 @@ func TestParseCommand(t *testing.T) {
 		{
 			name: "rollback-confirm",
 			body: "schemabot rollback-confirm -e production",
+			expected: CommandResult{
+				Action:      "rollback-confirm",
+				Environment: "production",
+				Found:       true,
+				IsMention:   true,
+			},
+		},
+		{
+			name: "rollback-confirm leaves unsupported database flag out of result",
+			body: "schemabot rollback-confirm -e production -d users_db",
 			expected: CommandResult{
 				Action:      "rollback-confirm",
 				Environment: "production",

--- a/pkg/webhook/control_e2e_test.go
+++ b/pkg/webhook/control_e2e_test.go
@@ -741,7 +741,7 @@ func (c *stopCommandTernClient) SkipRevert(context.Context, *ternv1.SkipRevertRe
 	return nil, nil
 }
 
-func (c *stopCommandTernClient) RollbackPlan(context.Context, string) (*ternv1.PlanResponse, error) {
+func (c *stopCommandTernClient) RollbackPlan(context.Context, string, string) (*ternv1.PlanResponse, error) {
 	return nil, nil
 }
 

--- a/pkg/webhook/issue_comment.go
+++ b/pkg/webhook/issue_comment.go
@@ -200,6 +200,12 @@ func (h *Handler) handleIssueComment(ctx context.Context, metricApp string, w ht
 		return
 	}
 
+	if !commandSupportsDatabaseFlag(result.Action) && parser.HasDatabaseFlag(payload.Comment.Body) {
+		h.postComment(repo, pr, installationID, templates.RenderUnsupportedDatabaseFlag(result.Action))
+		h.writeJSON(w, http.StatusOK, map[string]string{"message": "unsupported flag"})
+		return
+	}
+
 	h.logger.Info("processing command",
 		"action", result.Action,
 		"environment", result.Environment,

--- a/pkg/webhook/prinfocache_dedup_e2e_test.go
+++ b/pkg/webhook/prinfocache_dedup_e2e_test.go
@@ -150,10 +150,9 @@ func TestRollbackConfirmHandlerDedupesPRFetch(t *testing.T) {
 	// so the handler bails out at the "no lock" branch right after
 	// CreateSchemaRequestFromPR returns — but CreateSchemaRequestFromPR
 	// itself has already exercised multiple FetchPullRequest call sites
-	// (FindConfigByDatabaseName + schema.go) within the same ctx scope.
-	h.handleRollbackConfirmCommand("octocat/hello-world", 1, "staging", dbName, 12345, "testuser", CommandResult{
+	// within the same ctx scope.
+	h.handleRollbackConfirmCommand("octocat/hello-world", 1, "staging", "", 12345, "testuser", CommandResult{
 		Environment: "staging",
-		Database:    dbName,
 	})
 
 	assert.Equal(t, int32(1), prFetchCalls.Load(),

--- a/pkg/webhook/rollback.go
+++ b/pkg/webhook/rollback.go
@@ -3,6 +3,7 @@ package webhook
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"strings"
 
 	"github.com/block/schemabot/pkg/api"
@@ -30,11 +31,22 @@ func (h *Handler) handleRollbackCommand(repo string, pr int, installationID int6
 		return
 	}
 
-	// Look up the apply to get database/environment/type
-	apply, err := h.service.Storage().Applies().GetByApplyIdentifier(ctx, applyID)
+	stor := h.service.Storage()
+	if stor == nil {
+		h.logger.Error("storage not configured for rollback", "repo", repo, "pr", pr, "applyID", applyID)
+		h.postCommandError(repo, pr, installationID, action.Rollback, result.Environment, requestedBy, "Storage is not available")
+		return
+	}
+	applyStore := stor.Applies()
+	if applyStore == nil {
+		h.logger.Error("apply store not configured for rollback", "repo", repo, "pr", pr, "applyID", applyID)
+		h.postCommandError(repo, pr, installationID, action.Rollback, result.Environment, requestedBy, "Apply store is not available")
+		return
+	}
+	apply, err := applyStore.GetByApplyIdentifier(ctx, applyID)
 	if err != nil {
-		h.logger.Error("failed to look up apply", "applyID", applyID, "error", err)
-		h.postCommandError(repo, pr, installationID, action.Rollback, "", requestedBy, "Failed to look up apply: "+err.Error())
+		h.logger.Error("failed to look up rollback apply", "repo", repo, "pr", pr, "applyID", applyID, "error", err)
+		h.postCommandError(repo, pr, installationID, action.Rollback, result.Environment, requestedBy, "Failed to look up apply: "+err.Error())
 		return
 	}
 	if apply == nil {
@@ -47,8 +59,8 @@ func (h *Handler) handleRollbackCommand(repo string, pr int, installationID int6
 	dbType := apply.DatabaseType
 
 	// In multi-instance setups, only the instance that owns this environment
-	// should process the rollback. Without this check, both instances react
-	// to the rollback comment (since rollback has no -e flag to filter on).
+	// should process the rollback. Without this check, every instance receives
+	// the comment delivery and can react to the same rollback request.
 	if h.service != nil && !h.service.Config().IsEnvironmentAllowed(environment) {
 		h.logger.Info("ignoring rollback for non-allowed environment",
 			"repo", repo, "pr", pr, "applyID", applyID, "environment", environment)
@@ -70,8 +82,25 @@ func (h *Handler) handleRollbackCommand(repo string, pr int, installationID int6
 		return
 	}
 
+	if _, _, err := h.service.ValidateRollbackSourceApply(ctx, api.RollbackSourceRequest{
+		ApplyIdentifier:         applyID,
+		Environment:             result.Environment,
+		Repository:              repo,
+		PullRequest:             pr,
+		RequirePullRequestScope: true,
+	}); err != nil {
+		h.handleRollbackSourceError(repo, pr, installationID, requestedBy, apply, applyID, result.Environment, err)
+		return
+	}
+
 	// Check for existing lock
-	existingLock, err := h.service.Storage().Locks().Get(ctx, database, dbType)
+	lockStore := stor.Locks()
+	if lockStore == nil {
+		h.logger.Error("lock store not configured for rollback", "repo", repo, "pr", pr, "applyID", applyID, "database", database, "database_type", dbType)
+		h.postCommandError(repo, pr, installationID, action.Rollback, environment, requestedBy, "Lock store is not available")
+		return
+	}
+	existingLock, err := lockStore.Get(ctx, database, dbType)
 	if err != nil {
 		h.logger.Error("failed to check lock", "error", err)
 		h.postCommandError(repo, pr, installationID, action.Rollback, environment, requestedBy, "Failed to check lock status: "+err.Error())
@@ -87,9 +116,41 @@ func (h *Handler) handleRollbackCommand(repo string, pr int, installationID int6
 		return
 	}
 
+	lockAcquiredByCommand := existingLock == nil
+	if lockAcquiredByCommand {
+		lock := &storage.Lock{
+			DatabaseName: database,
+			DatabaseType: dbType,
+			Owner:        lockOwner,
+			Repository:   repo,
+			PullRequest:  pr,
+		}
+		if err := lockStore.Acquire(ctx, lock); err != nil {
+			h.logger.Error("failed to acquire lock", "error", err)
+			h.postCommandError(repo, pr, installationID, action.Rollback, environment, requestedBy, "Failed to acquire lock: "+err.Error())
+			return
+		}
+	}
+
+	if _, _, err := h.service.ValidateRollbackSourceApply(ctx, api.RollbackSourceRequest{
+		ApplyIdentifier:         applyID,
+		Environment:             result.Environment,
+		Repository:              repo,
+		PullRequest:             pr,
+		RequirePullRequestScope: true,
+	}); err != nil {
+		h.releaseRollbackLockAfterRejectedPlan(ctx, database, dbType, lockOwner, lockAcquiredByCommand)
+		h.logger.Warn("rollback rejected by source apply guardrails after lock acquisition",
+			"repo", repo, "pr", pr, "applyID", applyID,
+			"environment", result.Environment, "database", database, "error", err)
+		h.postRollbackRejected(repo, pr, installationID, apply, applyID, environment, database, err.Error())
+		return
+	}
+
 	// Generate rollback plan (uses the most recent completed apply for this database/environment)
 	planResp, err := h.service.ExecuteRollbackPlan(ctx, database, environment, "")
 	if err != nil {
+		h.releaseRollbackLockAfterRejectedPlan(ctx, database, dbType, lockOwner, lockAcquiredByCommand)
 		errMsg := err.Error()
 		if strings.Contains(errMsg, "no completed") {
 			h.postComment(repo, pr, installationID, templates.RenderRollbackNoCompletedApply(database, environment))
@@ -101,22 +162,9 @@ func (h *Handler) handleRollbackCommand(repo string, pr int, installationID int6
 	}
 
 	if len(planResp.FlatTables()) == 0 {
+		h.releaseRollbackLockAfterRejectedPlan(ctx, database, dbType, lockOwner, lockAcquiredByCommand)
 		h.postComment(repo, pr, installationID,
 			templates.RenderRollbackNothingToDo(database, environment, applyID))
-		return
-	}
-
-	// Acquire lock
-	lock := &storage.Lock{
-		DatabaseName: database,
-		DatabaseType: dbType,
-		Owner:        lockOwner,
-		Repository:   repo,
-		PullRequest:  pr,
-	}
-	if err := h.service.Storage().Locks().Acquire(ctx, lock); err != nil {
-		h.logger.Error("failed to acquire lock", "error", err)
-		h.postCommandError(repo, pr, installationID, action.Rollback, environment, requestedBy, "Failed to acquire lock: "+err.Error())
 		return
 	}
 
@@ -151,6 +199,49 @@ func (h *Handler) handleRollbackCommand(repo string, pr int, installationID int6
 	commentData.Errors = planResp.Errors
 
 	h.postComment(repo, pr, installationID, templates.RenderRollbackPlanComment(commentData))
+}
+
+func (h *Handler) handleRollbackSourceError(repo string, pr int, installationID int64, requestedBy string, apply *storage.Apply, applyID, environment string, err error) {
+	status := api.ControlOperationHTTPStatus(err)
+	if status == http.StatusNotFound {
+		h.postComment(repo, pr, installationID, templates.RenderRollbackApplyNotFound(applyID))
+		return
+	}
+	if status >= http.StatusInternalServerError {
+		h.logger.Error("rollback source validation failed",
+			"repo", repo, "pr", pr, "applyID", applyID,
+			"environment", environment, "error", err)
+		h.postCommandError(repo, pr, installationID, action.Rollback, environment, requestedBy, err.Error())
+		return
+	}
+	h.logger.Warn("rollback rejected by source apply guardrails",
+		"repo", repo, "pr", pr, "applyID", applyID,
+		"environment", environment, "error", err)
+	h.postRollbackRejected(repo, pr, installationID, apply, applyID, environment, "", err.Error())
+}
+
+func (h *Handler) postRollbackRejected(repo string, pr int, installationID int64, apply *storage.Apply, applyID, environment, database, reason string) {
+	data := templates.RollbackRejectedData{
+		ApplyID:     applyID,
+		Database:    database,
+		Environment: environment,
+		Reason:      reason,
+	}
+	if apply != nil {
+		data.Database = apply.Database
+		data.Environment = apply.Environment
+	}
+	h.postComment(repo, pr, installationID, templates.RenderRollbackRejected(data))
+}
+
+func (h *Handler) releaseRollbackLockAfterRejectedPlan(ctx context.Context, database, dbType, lockOwner string, release bool) {
+	if !release {
+		return
+	}
+	if err := h.service.Storage().Locks().Release(ctx, database, dbType, lockOwner); err != nil {
+		h.logger.Error("failed to release rollback lock after rejected plan",
+			"database", database, "database_type", dbType, "owner", lockOwner, "error", err)
+	}
 }
 
 // handleRollbackConfirmCommand handles the "schemabot rollback-confirm -e <env>" PR comment command.

--- a/pkg/webhook/rollback_test.go
+++ b/pkg/webhook/rollback_test.go
@@ -74,6 +74,73 @@ func TestWebhookRollbackConfirmDispatch(t *testing.T) {
 	assert.Contains(t, rr.Body.String(), "rollback-confirm started")
 }
 
+func TestWebhookRollbackRejectsDatabaseFlag(t *testing.T) {
+	h, comments, _ := newTestHandler(t)
+
+	req := buildWebhookRequest(t, webhookPayloadOpts{
+		comment: "schemabot rollback apply_abc123 -e staging -d users_db",
+		isPR:    true,
+	}, nil)
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), "unsupported flag")
+
+	select {
+	case body := <-comments:
+		assert.Contains(t, body, "`-d` flag is not supported")
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for comment")
+	}
+}
+
+func TestWebhookRollbackConfirmRejectsDatabaseFlag(t *testing.T) {
+	h, comments, _ := newTestHandler(t)
+
+	req := buildWebhookRequest(t, webhookPayloadOpts{
+		comment: "schemabot rollback-confirm -e staging -d users_db",
+		isPR:    true,
+	}, nil)
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), "unsupported flag")
+
+	select {
+	case body := <-comments:
+		assert.Contains(t, body, "`-d` flag is not supported")
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for comment")
+	}
+}
+
+func TestWebhookRejectsDatabaseFlagForAnyCommandThatDoesNotSupportIt(t *testing.T) {
+	h, comments, _ := newTestHandler(t)
+
+	req := buildWebhookRequest(t, webhookPayloadOpts{
+		comment: "schemabot stop apply_abc123 -e staging -d users_db",
+		isPR:    true,
+	}, nil)
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), "unsupported flag")
+
+	select {
+	case body := <-comments:
+		assert.Contains(t, body, "`-d` flag is not supported")
+		assert.Contains(t, body, "`stop`")
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for comment")
+	}
+}
+
 func TestWebhookRollbackMissingApplyID(t *testing.T) {
 	h, comments, _ := newTestHandler(t)
 
@@ -119,6 +186,28 @@ func TestWebhookRollbackMissingApplyIDAndEnv(t *testing.T) {
 	}
 }
 
+func TestHandleRollbackCommandStorageUnavailablePostsError(t *testing.T) {
+	client, mux := setupGitHubServer(t)
+	comments := make(chan string, 1)
+	mux.HandleFunc("POST /repos/octocat/hello-world/issues/1/comments", commentRecorder(t, comments))
+
+	installClient := ghclient.NewInstallationClient(client, testLogger())
+	h := &Handler{
+		service:   api.New(nil, &api.ServerConfig{}, nil, testLogger()),
+		ghClients: ghclient.NewSingleClientSet(defaultAppName, &fakeClientFactory{client: installClient}),
+		logger:    testLogger(),
+	}
+
+	h.handleRollbackCommand("octocat/hello-world", 1, 12345, "hubot", CommandResult{
+		Action:      action.Rollback,
+		ApplyID:     "apply_abc123",
+		Environment: "staging",
+	})
+
+	body := requireComment(t, comments, "storage-unavailable rollback comment")
+	assert.Contains(t, body, "Storage is not available")
+}
+
 // rollbackNoopTernClient returns a rollback plan with no schema changes,
 // simulating a database that already matches the original schema when
 // rollback-confirm re-plans for drift detection.
@@ -126,7 +215,7 @@ type rollbackNoopTernClient struct {
 	tern.Client
 }
 
-func (c *rollbackNoopTernClient) RollbackPlan(context.Context, string) (*ternv1.PlanResponse, error) {
+func (c *rollbackNoopTernClient) RollbackPlan(context.Context, string, string) (*ternv1.PlanResponse, error) {
 	return &ternv1.PlanResponse{PlanId: "rollback-plan-noop"}, nil
 }
 

--- a/pkg/webhook/templates/issue_comment.go
+++ b/pkg/webhook/templates/issue_comment.go
@@ -29,6 +29,12 @@ func RenderUnsupportedAutoConfirm(action string) string {
 	return fmt.Sprintf("The `-y` flag is not supported for `%s`.", action)
 }
 
+// RenderUnsupportedDatabaseFlag renders the message posted when `-d` is
+// supplied to a command that does not support database scoping.
+func RenderUnsupportedDatabaseFlag(action string) string {
+	return fmt.Sprintf("The `-d` flag is not supported for `%s`.", action)
+}
+
 // StopCommandAcceptedData contains data for a PR comment stop acknowledgement.
 type StopCommandAcceptedData struct {
 	ApplyID      string

--- a/pkg/webhook/templates/issue_comment_test.go
+++ b/pkg/webhook/templates/issue_comment_test.go
@@ -28,6 +28,16 @@ func TestRenderUnsupportedAutoConfirm(t *testing.T) {
 	assert.Equal(t, "The `-y` flag is not supported for `plan`.", rendered)
 }
 
+func TestRenderUnsupportedDatabaseFlag(t *testing.T) {
+	rendered := RenderUnsupportedDatabaseFlag("rollback")
+	assert.Equal(t, "The `-d` flag is not supported for `rollback`.", rendered)
+}
+
+func TestRenderUnsupportedDatabaseFlagRollbackConfirm(t *testing.T) {
+	rendered := RenderUnsupportedDatabaseFlag("rollback-confirm")
+	assert.Equal(t, "The `-d` flag is not supported for `rollback-confirm`.", rendered)
+}
+
 func TestRenderControlMissingApplyID(t *testing.T) {
 	rendered := RenderControlMissingApplyID("stop")
 	assert.Contains(t, rendered, "Missing Apply ID")

--- a/pkg/webhook/templates/rollback.go
+++ b/pkg/webhook/templates/rollback.go
@@ -95,6 +95,49 @@ func RenderRollbackApplyNotFound(applyID string) string {
 		"No apply found with ID `%s`. Check the ID and try again.", applyID)
 }
 
+// RollbackRejectedData contains the details shown when SchemaBot refuses to
+// generate a rollback plan because the requested apply is not safe to target.
+type RollbackRejectedData struct {
+	ApplyID     string
+	Database    string
+	Environment string
+	Reason      string
+}
+
+// RenderRollbackRejected renders a rollback-specific rejection message. These
+// rejections are deliberate safety gates, not generic command failures.
+func RenderRollbackRejected(data RollbackRejectedData) string {
+	var sb strings.Builder
+	sb.WriteString("## Rollback Not Allowed\n\n")
+	if data.ApplyID != "" {
+		fmt.Fprintf(&sb, "**Apply**: `%s`\n", data.ApplyID)
+	}
+	if data.Database != "" {
+		fmt.Fprintf(&sb, "**Database**: `%s`\n", data.Database)
+	}
+	if data.Environment != "" {
+		fmt.Fprintf(&sb, "**Environment**: `%s`\n", data.Environment)
+	}
+	if data.ApplyID != "" || data.Database != "" || data.Environment != "" {
+		sb.WriteString("\n")
+	}
+
+	sb.WriteString("SchemaBot did not generate a rollback plan because it cannot safely prove this apply is the exact completed schema change that rollback would target.\n\n")
+	if reason := sanitizedRollbackRejectionReason(data.Reason); reason != "" {
+		fmt.Fprintf(&sb, "**Reason**: `%s`\n\n", reason)
+	}
+	sb.WriteString("Rollback is currently allowed only for the latest completed apply for this database and environment, and only when that apply has stored original schema. An operator should reconcile the target schema manually or retry with the latest eligible apply.")
+	return sb.String()
+}
+
+func sanitizedRollbackRejectionReason(reason string) string {
+	fields := strings.Fields(reason)
+	if len(fields) == 0 {
+		return ""
+	}
+	return strings.ReplaceAll(strings.Join(fields, " "), "`", "'")
+}
+
 // RenderRollbackBlockedByLock renders the message posted when a rollback cannot
 // acquire the database lock because another caller holds it. When lockRepo and
 // lockPR are populated, the holder is rendered as a PR link; otherwise the bare

--- a/pkg/webhook/templates/rollback_test.go
+++ b/pkg/webhook/templates/rollback_test.go
@@ -122,6 +122,30 @@ func TestRenderRollbackApplyNotFound(t *testing.T) {
 	assert.Contains(t, rendered, "Check the ID and try again")
 }
 
+func TestRenderRollbackRejected(t *testing.T) {
+	rendered := RenderRollbackRejected(RollbackRejectedData{
+		ApplyID:     "apply-abc123",
+		Database:    "testapp",
+		Environment: "staging",
+		Reason:      "apply apply-abc123 is not the latest completed schema change",
+	})
+	assert.Contains(t, rendered, "## Rollback Not Allowed")
+	assert.Contains(t, rendered, "`apply-abc123`")
+	assert.Contains(t, rendered, "`testapp`")
+	assert.Contains(t, rendered, "`staging`")
+	assert.Contains(t, rendered, "not the latest completed schema change")
+	assert.Contains(t, rendered, "stored original schema")
+}
+
+func TestRenderRollbackRejectedSanitizesReason(t *testing.T) {
+	rendered := RenderRollbackRejected(RollbackRejectedData{
+		ApplyID: "apply-abc123",
+		Reason:  "first line\nsecond `line`",
+	})
+	assert.Contains(t, rendered, "**Reason**: `first line second 'line'`")
+	assert.NotContains(t, rendered, "first line\nsecond")
+}
+
 func TestRenderRollbackBlockedByLock(t *testing.T) {
 	t.Run("PR-owned lock renders as link", func(t *testing.T) {
 		rendered := RenderRollbackBlockedByLock("testapp", "staging", "block/myapp#42", "block/myapp", 42)
@@ -203,6 +227,7 @@ func TestRollbackTemplates_NoStrayWhitespace(t *testing.T) {
 	for name, body := range map[string]string{
 		"MissingApplyID":            RenderRollbackMissingApplyID(),
 		"ApplyNotFound":             RenderRollbackApplyNotFound("a"),
+		"Rejected":                  RenderRollbackRejected(RollbackRejectedData{ApplyID: "a", Database: "d", Environment: "e", Reason: "r"}),
 		"BlockedByLockPR":           RenderRollbackBlockedByLock("d", "e", "o", "r", 1),
 		"BlockedByLockOwner":        RenderRollbackBlockedByLock("d", "e", "o", "", 0),
 		"NothingToDo":               RenderRollbackNothingToDo("d", "e", "a"),

--- a/pkg/webhook/webhook_e2e_test.go
+++ b/pkg/webhook/webhook_e2e_test.go
@@ -2322,10 +2322,13 @@ func TestE2ERollbackPlanViaWebhook(t *testing.T) {
 
 	// Step 2: Plan + apply adding an index (this stores OriginalSchema for rollback)
 	schemaWithIndex := "CREATE TABLE `users` (\n  `id` bigint unsigned NOT NULL AUTO_INCREMENT,\n  `name` varchar(255) NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `idx_name` (`name`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;"
+	prNumber := int32(1)
 	planReq := api.PlanRequest{
 		Database:    dbName,
 		Environment: "staging",
 		Type:        "mysql",
+		Repository:  "octocat/hello-world",
+		PullRequest: &prNumber,
 		SchemaFiles: map[string]*ternv1.SchemaFiles{
 			dbName: {Files: map[string]string{"users.sql": schemaWithIndex}},
 		},
@@ -2525,10 +2528,13 @@ func TestE2ERollbackConfirmExecutesAndPostsComments(t *testing.T) {
 
 	// Step 2: Plan + apply adding an index (creates OriginalSchema for rollback)
 	schemaWithIndex := "CREATE TABLE `users` (\n  `id` bigint unsigned NOT NULL AUTO_INCREMENT,\n  `name` varchar(255) NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `idx_name` (`name`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;"
+	prNumber := int32(1)
 	planResp, err := svc.ExecutePlan(ctx, api.PlanRequest{
 		Database:    dbName,
 		Environment: "staging",
 		Type:        "mysql",
+		Repository:  "octocat/hello-world",
+		PullRequest: &prNumber,
 		SchemaFiles: map[string]*ternv1.SchemaFiles{
 			dbName: {Files: map[string]string{"users.sql": schemaWithIndex}},
 		},
@@ -2631,10 +2637,13 @@ func TestE2ERollbackConfirmUpdatesCheckToActionRequired(t *testing.T) {
 
 	// Step 2: Plan + apply adding an index
 	schemaWithIndex := "CREATE TABLE `users` (\n  `id` bigint unsigned NOT NULL AUTO_INCREMENT,\n  `name` varchar(255) NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `idx_name` (`name`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;"
+	prNumber := int32(1)
 	planResp, err := svc.ExecutePlan(ctx, api.PlanRequest{
 		Database:    dbName,
 		Environment: "staging",
 		Type:        "mysql",
+		Repository:  "octocat/hello-world",
+		PullRequest: &prNumber,
 		SchemaFiles: map[string]*ternv1.SchemaFiles{
 			dbName: {Files: map[string]string{"users.sql": schemaWithIndex}},
 		},


### PR DESCRIPTION
## Summary

- Reject rollback requests unless the requested apply is completed, scoped to the requesting PR/environment, and has stored original schema.
- Require rollback plan requests to target an apply by `apply_id` + `environment`; the database is derived from the stored apply instead of accepted from users.
- Scope rollback planner selection to the latest completed schema change for the same database, database type, and environment.
- Let normal PR command flag handling reject `-d` for rollback and rollback-confirm because those commands do not opt into database scoping.
- Post a rollback-specific rejection comment that explains the safety gate instead of a generic command error.

This keeps self-service rollback fail-closed while the selected-apply rollback planner is split out into follow-up work.

Generated with Amp.
