### PR TITLE
fix(observability): recognize queued GitHub webhook labels

### DIFF
--- a/pkg/metrics/github_metrics_test.go
+++ b/pkg/metrics/github_metrics_test.go
@@ -87,9 +87,67 @@ func TestRecordUnregisteredRepositoryWebhook(t *testing.T) {
 	assert.True(t, found)
 }
 
+func TestRecordWebhookEventKnownObservedGitHubLabels(t *testing.T) {
+	seenUnknownWebhookMetricLabels = sync.Map{}
+	t.Cleanup(func() {
+		seenUnknownWebhookMetricLabels = sync.Map{}
+	})
+
+	reader := metric.NewManualReader()
+	mp := metric.NewMeterProvider(metric.WithReader(reader))
+	previousProvider := otel.GetMeterProvider()
+	otel.SetMeterProvider(mp)
+	defer func() {
+		otel.SetMeterProvider(previousProvider)
+		require.NoError(t, mp.Shutdown(t.Context()))
+	}()
+
+	RecordWebhookEvent(t.Context(), "default", "check_suite", "requested", "octocat/hello-world", "ignored")
+	RecordWebhookEvent(t.Context(), "default", "pull_request", "enqueued", "octocat/hello-world", "processed")
+	RecordWebhookEvent(t.Context(), "default", "pull_request", "dequeued", "octocat/hello-world", "processed")
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(t.Context(), &rm))
+
+	got := map[string]int64{}
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != "schemabot.webhook.events_total" {
+				continue
+			}
+			sum, ok := m.Data.(metricdata.Sum[int64])
+			require.True(t, ok)
+			for _, dp := range sum.DataPoints {
+				key := metricAttributeString(t, dp.Attributes, "event_type") + ":" +
+					metricAttributeString(t, dp.Attributes, "action") + ":" +
+					metricAttributeString(t, dp.Attributes, "status")
+				got[key] = dp.Value
+			}
+		}
+	}
+	assert.Equal(t, map[string]int64{
+		"check_suite:requested:ignored":   1,
+		"pull_request:enqueued:processed": 1,
+		"pull_request:dequeued:processed": 1,
+	}, got)
+
+	var unknownLabels int
+	seenUnknownWebhookMetricLabels.Range(func(_, _ any) bool {
+		unknownLabels++
+		return true
+	})
+	assert.Zero(t, unknownLabels)
+}
+
 func assertMetricAttribute(t *testing.T, attrs attribute.Set, key string, want string) {
+	t.Helper()
+	got := metricAttributeString(t, attrs, key)
+	assert.Equal(t, want, got)
+}
+
+func metricAttributeString(t *testing.T, attrs attribute.Set, key string) string {
 	t.Helper()
 	got, ok := attrs.Value(attribute.Key(key))
 	require.True(t, ok)
-	assert.Equal(t, want, got.AsString())
+	return got.AsString()
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -593,6 +593,7 @@ func RecordSchedulerClaimDuration(ctx context.Context, duration time.Duration, d
 
 // knownWebhookEvents limits metric cardinality to expected GitHub event types.
 var knownWebhookEvents = map[string]bool{
+	"check_suite":                 true,
 	"create":                      true,
 	"issues":                      true,
 	"issue_comment":               true,
@@ -615,8 +616,10 @@ var knownWebhookActions = map[string]bool{
 	"created":                true,
 	"deleted":                true,
 	"demilestoned":           true,
+	"dequeued":               true,
 	"dismissed":              true,
 	"edited":                 true,
+	"enqueued":               true,
 	"labeled":                true,
 	"locked":                 true,
 	"milestoned":             true,


### PR DESCRIPTION
## Why
SchemaBot receives GitHub webhook labels that are expected but currently appear as `unknown` in webhook event metrics.

## What
- Add `check_suite` to the known webhook event labels
- Add queue actions `enqueued` and `dequeued` to the known webhook action labels
- Cover the observed labels with a focused metrics test

## Risk Assessment
Low — this only changes metric label normalization for already-received webhook events.

Generated with Amp
