### PR TITLE
feat(scheduler): operator claim loop on apply_operations behind flag

### DIFF
--- a/integration/scheduler_test.go
+++ b/integration/scheduler_test.go
@@ -213,6 +213,47 @@ func TestScheduler_BasicClaimAndResume(t *testing.T) {
 	)
 }
 
+// TestScheduler_OperatorClaimsOperationToCompletion exercises the operation-level
+// claim loop (operator_claim_operations enabled). An apply created through the
+// normal flow dual-writes exactly one apply_operations row; the operator claims
+// that row, acquires the parent apply lease, drives the schema change to
+// completion, and marks the operation row completed.
+func TestScheduler_OperatorClaimsOperationToCompletion(t *testing.T) {
+	ctx := t.Context()
+	schemaSQL, err := os.ReadFile("testdata/myapp/mysql/schema/users.sql")
+	require.NoError(t, err)
+
+	appDBName, appDSN := createTestDB(t, "operator_claim_")
+	ts := startTestServerOperator(t, appDBName, appDSN)
+
+	planResp := postJSON(t, "http://"+ts.Addr+"/api/plan", map[string]any{
+		"database": appDBName, "environment": "staging", "type": "mysql",
+		"schema_files": map[string]any{"default": map[string]any{"files": map[string]string{"users.sql": string(schemaSQL)}}},
+	})
+	planID, _ := planResp["plan_id"].(string)
+	require.NotEmpty(t, planID)
+
+	applyResp := postJSON(t, "http://"+ts.Addr+"/api/apply", map[string]any{
+		"plan_id": planID, "environment": "staging",
+	})
+	require.True(t, applyResp["accepted"] == true)
+	applyID, _ := applyResp["apply_id"].(string)
+	require.NotEmpty(t, applyID)
+
+	waitForState(t, "http://"+ts.Addr, applyID, "completed", 20*time.Second)
+
+	apply, err := ts.Storage.Applies().GetByApplyIdentifier(ctx, applyID)
+	require.NoError(t, err)
+	require.NotNil(t, apply)
+
+	ops, err := ts.Storage.ApplyOperations().ListByApply(ctx, apply.ID)
+	require.NoError(t, err)
+	require.Len(t, ops, 1, "apply-create dual-write emits exactly one operation row")
+	assert.Equal(t, state.ApplyOperation.Completed, ops[0].State, "operator marks the claimed operation completed")
+	assert.Equal(t, apply.Deployment, ops[0].Deployment)
+	require.NotNil(t, ops[0].CompletedAt, "completed operation stamps completed_at")
+}
+
 func TestScheduler_ClaimOrdering(t *testing.T) {
 	ctx := t.Context()
 

--- a/integration/scheduler_test.go
+++ b/integration/scheduler_test.go
@@ -246,6 +246,18 @@ func TestScheduler_OperatorClaimsOperationToCompletion(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, apply)
 
+	// The operator marks the operation terminal after the parent apply is
+	// persisted completed, so poll for the operation's terminal state rather
+	// than reading it the instant the apply finishes.
+	require.Eventually(t, func() bool {
+		ops, err := ts.Storage.ApplyOperations().ListByApply(ctx, apply.ID)
+		if err != nil || len(ops) != 1 {
+			return false
+		}
+		return state.IsState(ops[0].State, state.ApplyOperation.Completed)
+	}, 10*time.Second, 100*time.Millisecond,
+		"operator should mark the claimed operation completed after the apply finishes")
+
 	ops, err := ts.Storage.ApplyOperations().ListByApply(ctx, apply.ID)
 	require.NoError(t, err)
 	require.Len(t, ops, 1, "apply-create dual-write emits exactly one operation row")

--- a/integration/scheduler_test.go
+++ b/integration/scheduler_test.go
@@ -254,6 +254,56 @@ func TestScheduler_OperatorClaimsOperationToCompletion(t *testing.T) {
 	require.NotNil(t, ops[0].CompletedAt, "completed operation stamps completed_at")
 }
 
+// TestScheduler_OperatorReconcilesOperationWhenParentTerminal covers the safety
+// case where the operator claims an apply_operations row whose parent apply is
+// already terminal — for example the operator flag is enabled after the apply
+// finished, or the parent reached a terminal state via another path. The
+// operator must reconcile the operation to the parent's terminal state rather
+// than re-claiming the same non-terminal row on every poll forever.
+func TestScheduler_OperatorReconcilesOperationWhenParentTerminal(t *testing.T) {
+	ctx := t.Context()
+	appDBName, appDSN := createTestDB(t, "operator_reconcile_")
+	ts := startTestServerOperator(t, appDBName, appDSN)
+
+	now := time.Now()
+	applyID, err := ts.Storage.Applies().Create(ctx, &storage.Apply{
+		ApplyIdentifier: "apply-terminal-parent",
+		Database:        appDBName,
+		DatabaseType:    "mysql",
+		Deployment:      appDBName,
+		Engine:          "spirit",
+		State:           state.Apply.Completed,
+		Options:         []byte("{}"),
+		Environment:     "staging",
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	})
+	require.NoError(t, err)
+
+	opID, err := ts.Storage.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID:    applyID,
+		Deployment: appDBName,
+		Target:     appDBName,
+		State:      state.ApplyOperation.Pending,
+	})
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		op, err := ts.Storage.ApplyOperations().Get(ctx, opID)
+		if err != nil || op == nil {
+			return false
+		}
+		return state.IsState(op.State, state.ApplyOperation.Completed)
+	}, 10*time.Second, 100*time.Millisecond,
+		"operator should reconcile the operation to completed when its parent apply is already completed")
+
+	op, err := ts.Storage.ApplyOperations().Get(ctx, opID)
+	require.NoError(t, err)
+	require.NotNil(t, op)
+	assert.Equal(t, state.ApplyOperation.Completed, op.State)
+	require.NotNil(t, op.CompletedAt, "reconciled completed operation stamps completed_at")
+}
+
 func TestScheduler_ClaimOrdering(t *testing.T) {
 	ctx := t.Context()
 

--- a/integration/workflow_test.go
+++ b/integration/workflow_test.go
@@ -68,6 +68,18 @@ func startTestServer(t *testing.T, appDBName, appDSN string) testServer {
 
 func startTestServerWithSchedulerInterval(t *testing.T, appDBName, appDSN string, schedulerInterval time.Duration) testServer {
 	t.Helper()
+	return startTestServerWithOptions(t, appDBName, appDSN, schedulerInterval, false)
+}
+
+// startTestServerOperator starts a test server whose scheduler claims work at
+// the apply_operations level (operator_claim_operations enabled).
+func startTestServerOperator(t *testing.T, appDBName, appDSN string) testServer {
+	t.Helper()
+	return startTestServerWithOptions(t, appDBName, appDSN, 200*time.Millisecond, true)
+}
+
+func startTestServerWithOptions(t *testing.T, appDBName, appDSN string, schedulerInterval time.Duration, operatorClaimOperations bool) testServer {
+	t.Helper()
 
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
 
@@ -84,6 +96,7 @@ func startTestServerWithSchedulerInterval(t *testing.T, appDBName, appDSN string
 	require.NoError(t, err, "create local client")
 
 	serverConfig := &schemabotapi.ServerConfig{
+		OperatorClaimOperations: operatorClaimOperations,
 		Databases: map[string]schemabotapi.DatabaseConfig{
 			appDBName: {
 				Type: "mysql",

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -79,6 +79,14 @@ type ServerConfig struct {
 	// FOR UPDATE SKIP LOCKED to prevent races. Defaults to 1.
 	SchedulerWorkers int `yaml:"scheduler_workers"`
 
+	// OperatorClaimOperations switches scheduler workers to claim work at the
+	// apply_operations (per-deployment) level via FindNextApplyOperation instead
+	// of the apply level via FindNextApply. While the apply-create dual-write
+	// produces exactly one operation per apply, the two paths are equivalent;
+	// the operation-level path is the foundation for multi-deployment applies.
+	// Defaults to false (apply-level claiming).
+	OperatorClaimOperations bool `yaml:"operator_claim_operations,omitempty"`
+
 	// RequirePassingChecks blocks apply when non-SchemaBot PR checks are failing.
 	// When enabled (default), SchemaBot verifies that all other checks (CI, linters,
 	// security scans) have passed before executing a schema change. Checks with

--- a/pkg/api/scheduler.go
+++ b/pkg/api/scheduler.go
@@ -22,6 +22,14 @@ const (
 	// FindNextApply uses this (via SQL: updated_at < NOW() - INTERVAL 1 MINUTE).
 	HeartbeatTimeout = 1 * time.Minute
 
+	// ApplyOperationHeartbeatInterval bounds how often the operation-row
+	// heartbeat fires while ResumeApply runs. It is kept safely below
+	// HeartbeatTimeout so that a large (or misconfigured) scheduler poll
+	// interval cannot let apply_operations.updated_at go stale and allow a peer
+	// worker to re-claim the operation mid-resume. The effective cadence is
+	// min(schedulerPollInterval, ApplyOperationHeartbeatInterval).
+	ApplyOperationHeartbeatInterval = 10 * time.Second
+
 	// DefaultSchedulerWorkers is the number of concurrent scheduler workers
 	// when not configured via scheduler_workers in the server config.
 	DefaultSchedulerWorkers = 4
@@ -229,22 +237,21 @@ func (s *Service) recoverApplyOperation(ctx context.Context, workerID int, owner
 			"worker", workerID,
 			"lease_owner", owner,
 			"apply_operation_id", op.ID,
-			"apply_id", op.ApplyID,
+			"apply_db_id", op.ApplyID,
 			"deployment", op.Deployment,
 			"error", err)
 		metrics.RecordSchedulerClaimFailure(ctx, "operation_parent_claim_error")
 		return
 	}
 	if apply == nil {
-		// Parent apply is not currently claimable: another worker holds a fresh
-		// lease, or it is terminal. Fail closed — do not drive work. The
-		// operation row's heartbeat goes stale and it is retried on a later poll.
-		s.logger.Warn("operator: parent apply not claimable for operation; operation will be retried",
-			"worker", workerID,
-			"apply_operation_id", op.ID,
-			"apply_id", op.ApplyID,
-			"deployment", op.Deployment)
-		metrics.RecordSchedulerClaimFailure(ctx, "operation_parent_not_claimable")
+		// The parent apply is not currently claimable. Distinguish the two
+		// reasons, because they need opposite handling:
+		//   - terminal parent: the operation row was just leased by
+		//     FindNextApplyOperation, so leaving it non-terminal would re-claim
+		//     it forever. Reconcile it to the parent's terminal state now.
+		//   - transiently unclaimable (a peer holds a fresh lease, or the row is
+		//     locked): fail closed and let a later poll retry once it goes stale.
+		s.reconcileUnclaimableParent(ctx, workerID, op)
 		return
 	}
 
@@ -300,6 +307,55 @@ func (s *Service) recoverApplyOperation(ctx context.Context, workerID int, owner
 	}
 
 	s.markOperationFromApplyState(leasedCtx, workerID, op, finalApply)
+}
+
+// reconcileUnclaimableParent handles a claimed operation whose parent apply
+// ClaimApplyByID refused. If the parent is terminal, the operation row is
+// reconciled to that terminal state so it stops being re-claimed on every poll
+// (the write is unguarded — the operation holds no apply lease — but a terminal
+// apply has no competing driver, so the mirror is safe and idempotent). If the
+// parent is non-terminal (a peer holds a fresh lease, or the row was locked),
+// the operation is left claimable and retried once the parent lease goes stale.
+func (s *Service) reconcileUnclaimableParent(ctx context.Context, workerID int, op *storage.ApplyOperation) {
+	parent, err := s.storage.Applies().Get(ctx, op.ApplyID)
+	if err != nil {
+		s.logger.Error("operator: failed to load unclaimable parent apply; operation will be retried",
+			"worker", workerID,
+			"apply_operation_id", op.ID,
+			"apply_db_id", op.ApplyID,
+			"deployment", op.Deployment,
+			"error", err)
+		metrics.RecordSchedulerClaimFailure(ctx, "operation_parent_not_claimable")
+		return
+	}
+	if parent == nil {
+		s.logger.Error("operator: parent apply not found for claimed operation; operation will be retried",
+			"worker", workerID,
+			"apply_operation_id", op.ID,
+			"apply_db_id", op.ApplyID,
+			"deployment", op.Deployment)
+		metrics.RecordSchedulerClaimFailure(ctx, "operation_parent_not_claimable")
+		return
+	}
+	if state.IsTerminalApplyState(parent.State) {
+		s.logger.Info("operator: parent apply already terminal; reconciling operation to terminal state",
+			"worker", workerID,
+			"apply_operation_id", op.ID,
+			"apply_id", parent.ApplyIdentifier,
+			"deployment", op.Deployment,
+			"environment", parent.Environment,
+			"state", parent.State)
+		s.markOperationFromApplyState(ctx, workerID, op, parent)
+		return
+	}
+	s.logger.Warn("operator: parent apply not claimable for operation; operation will be retried",
+		"worker", workerID,
+		"apply_operation_id", op.ID,
+		"apply_id", parent.ApplyIdentifier,
+		"deployment", op.Deployment,
+		"environment", parent.Environment,
+		"state", parent.State)
+	metrics.RecordSchedulerClaimFailure(ctx, "operation_parent_not_claimable")
 }
 
 // resumeClaimedApply drives a claimed apply through ResumeApply with the apply
@@ -410,15 +466,17 @@ func (s *Service) resumeClaimedApply(ctx context.Context, workerID int, apply *s
 	return true
 }
 
-// startApplyOperationHeartbeat refreshes the claimed operation row's lease on
-// the apply heartbeat cadence while ResumeApply runs. A lost parent apply lease
-// cancels the run so the displaced worker stops; other heartbeat errors are
-// logged and retried on the next tick. Returns a stop func that is safe to call
-// more than once.
+// startApplyOperationHeartbeat refreshes the claimed operation row's lease while
+// ResumeApply runs, at min(schedulerPollInterval, ApplyOperationHeartbeatInterval)
+// so the row cannot go stale and be re-claimed by a peer even when the poll
+// interval is large. A lost parent apply lease cancels the run so the displaced
+// worker stops; other heartbeat errors are logged and retried on the next tick.
+// Returns a stop func that is safe to call more than once.
 func (s *Service) startApplyOperationHeartbeat(ctx context.Context, workerID int, op *storage.ApplyOperation, apply *storage.Apply, cancelRun context.CancelFunc) func() {
 	hbCtx, stop := context.WithCancel(ctx)
+	interval := min(s.schedulerPollInterval, ApplyOperationHeartbeatInterval)
 	s.recoveryWg.Go(func() {
-		ticker := time.NewTicker(s.schedulerPollInterval)
+		ticker := time.NewTicker(interval)
 		defer ticker.Stop()
 		for {
 			select {

--- a/pkg/api/scheduler.go
+++ b/pkg/api/scheduler.go
@@ -529,10 +529,18 @@ func (s *Service) markOperationFromApplyState(ctx context.Context, workerID int,
 				"worker", workerID, "apply_operation_id", op.ID, "apply_id", apply.ApplyIdentifier,
 				"deployment", op.Deployment, "environment", apply.Environment, "error", err)
 		}
-	case state.IsTerminalApplyState(apply.State):
-		// stopped / cancelled / reverted — mirror the terminal state onto the row.
+	case state.IsState(apply.State, state.Apply.Stopped):
+		// stopped is resumable, so mirror the state but leave completed_at nil
+		// (matching the apply-level convention) — stopped work may resume.
 		if err := opStore.UpdateState(ctx, op.ID, apply.State); err != nil {
-			s.logger.Error("operator: failed to update terminal apply_operation state",
+			s.logger.Error("operator: failed to update stopped apply_operation state",
+				"worker", workerID, "apply_operation_id", op.ID, "apply_id", apply.ApplyIdentifier,
+				"deployment", op.Deployment, "environment", apply.Environment, "state", apply.State, "error", err)
+		}
+	case state.IsTerminalApplyState(apply.State):
+		// cancelled / reverted — non-resumable terminal states; stamp completed_at.
+		if err := opStore.MarkTerminal(ctx, op.ID, apply.State); err != nil {
+			s.logger.Error("operator: failed to mark terminal apply_operation state",
 				"worker", workerID, "apply_operation_id", op.ID, "apply_id", apply.ApplyIdentifier,
 				"deployment", op.Deployment, "environment", apply.Environment, "state", apply.State, "error", err)
 		}

--- a/pkg/api/scheduler.go
+++ b/pkg/api/scheduler.go
@@ -168,6 +168,12 @@ func (s *Service) recoverApplies(ctx context.Context, workerID int) {
 	}
 
 	owner := schedulerLeaseOwner(workerID)
+
+	if s.config.OperatorClaimOperations {
+		s.recoverApplyOperation(ctx, workerID, owner)
+		return
+	}
+
 	apply, err := s.storage.Applies().FindNextApply(ctx, owner)
 	if err != nil {
 		s.logger.Error("scheduler: failed to claim apply", "worker", workerID, "lease_owner", owner, "error", err)
@@ -191,7 +197,117 @@ func (s *Service) recoverApplies(ctx context.Context, workerID int) {
 		return
 	}
 	ctx = storage.WithApplyLease(ctx, lease)
+	s.resumeClaimedApply(ctx, workerID, apply)
+}
 
+// recoverApplyOperation claims work at the apply_operations (per-deployment)
+// level: it leases one operation row, acquires the parent apply lease that
+// lease-guarded writes require, drives the apply through the shared resume path
+// while heartbeating the operation row, then marks the operation row terminal
+// from the parent apply's final state. While the apply-create dual-write emits
+// exactly one operation per apply, driving the parent apply is equivalent to
+// driving the single operation; this path is the foundation for the future
+// multi-deployment fan-out.
+func (s *Service) recoverApplyOperation(ctx context.Context, workerID int, owner string) {
+	op, err := s.storage.ApplyOperations().FindNextApplyOperation(ctx)
+	if err != nil {
+		s.logger.Error("operator: failed to claim apply_operation", "worker", workerID, "lease_owner", owner, "error", err)
+		metrics.RecordSchedulerClaimFailure(ctx, "operation_storage_error")
+		return
+	}
+	if op == nil {
+		s.logger.Debug("operator: no apply_operation to claim", "worker", workerID)
+		return
+	}
+
+	// All lease-guarded writes (ResumeApply, MarkCompleted/MarkFailed, the
+	// operation Heartbeat) key off applies.lease_token, so the operation claim
+	// alone is not enough to write safely — acquire the parent apply lease.
+	apply, err := s.storage.Applies().ClaimApplyByID(ctx, op.ApplyID, owner)
+	if err != nil {
+		s.logger.Error("operator: failed to claim parent apply for operation",
+			"worker", workerID,
+			"lease_owner", owner,
+			"apply_operation_id", op.ID,
+			"apply_id", op.ApplyID,
+			"deployment", op.Deployment,
+			"error", err)
+		metrics.RecordSchedulerClaimFailure(ctx, "operation_parent_claim_error")
+		return
+	}
+	if apply == nil {
+		// Parent apply is not currently claimable: another worker holds a fresh
+		// lease, or it is terminal. Fail closed — do not drive work. The
+		// operation row's heartbeat goes stale and it is retried on a later poll.
+		s.logger.Warn("operator: parent apply not claimable for operation; operation will be retried",
+			"worker", workerID,
+			"apply_operation_id", op.ID,
+			"apply_id", op.ApplyID,
+			"deployment", op.Deployment)
+		metrics.RecordSchedulerClaimFailure(ctx, "operation_parent_not_claimable")
+		return
+	}
+
+	lease := apply.Lease()
+	if !lease.Valid() {
+		s.logger.Error("operator: claimed parent apply without a valid lease token; operation will not be driven",
+			"worker", workerID,
+			"lease_owner", owner,
+			"apply_operation_id", op.ID,
+			"apply_id", apply.ApplyIdentifier,
+			"database", apply.Database,
+			"deployment", op.Deployment,
+			"environment", apply.Environment)
+		metrics.RecordSchedulerClaimFailure(ctx, "missing_lease_token")
+		return
+	}
+	leasedCtx := storage.WithApplyLease(ctx, lease)
+
+	// Heartbeat the operation row on the apply heartbeat cadence so a peer
+	// worker does not re-claim it during a long ResumeApply. A lost parent lease
+	// cancels the run so the displaced worker stops writing.
+	runCtx, cancelRun := context.WithCancel(leasedCtx)
+	defer cancelRun()
+	stopHeartbeat := s.startApplyOperationHeartbeat(runCtx, workerID, op, apply, cancelRun)
+	defer stopHeartbeat()
+
+	resumed := s.resumeClaimedApply(runCtx, workerID, apply)
+	stopHeartbeat()
+	if !resumed {
+		return
+	}
+
+	// Reload the parent apply: ResumeApply persists the final state to storage,
+	// and the operation row must mirror the durable outcome, not the in-memory
+	// object the resume path started from.
+	finalApply, err := s.storage.Applies().Get(leasedCtx, apply.ID)
+	if err != nil {
+		s.logger.Error("operator: failed to reload parent apply after resume; operation state not updated",
+			"worker", workerID,
+			"apply_operation_id", op.ID,
+			"apply_id", apply.ApplyIdentifier,
+			"deployment", op.Deployment,
+			"error", err)
+		return
+	}
+	if finalApply == nil {
+		s.logger.Error("operator: parent apply not found after resume; operation state not updated",
+			"worker", workerID,
+			"apply_operation_id", op.ID,
+			"apply_id", apply.ApplyIdentifier,
+			"deployment", op.Deployment)
+		return
+	}
+
+	s.markOperationFromApplyState(leasedCtx, workerID, op, finalApply)
+}
+
+// resumeClaimedApply drives a claimed apply through ResumeApply with the apply
+// lease already attached to ctx. Returns true when the apply resumed without
+// error. Failures are logged and recorded as metrics internally; the bool lets
+// the operation-level claim loop decide whether to mark its operation terminal.
+func (s *Service) resumeClaimedApply(ctx context.Context, workerID int, apply *storage.Apply) bool {
+	lease := apply.Lease()
 	start := s.clock.Now()
 	s.logger.Info("scheduler: claimed apply",
 		"worker", workerID,
@@ -214,7 +330,7 @@ func (s *Service) recoverApplies(ctx context.Context, workerID int) {
 			"environment", apply.Environment,
 			"error", err)
 		metrics.RecordSchedulerResumeFailure(ctx, apply.Database, "", apply.Environment, "missing_deployment")
-		return
+		return false
 	}
 	client, err := s.TernClient(deployment, apply.Environment)
 	if err != nil {
@@ -226,7 +342,7 @@ func (s *Service) recoverApplies(ctx context.Context, workerID int) {
 			"environment", apply.Environment,
 			"error", err)
 		metrics.RecordSchedulerResumeFailure(ctx, apply.Database, deployment, apply.Environment, "no_client")
-		return
+		return false
 	}
 
 	if s.OnApplyRecovered != nil {
@@ -251,7 +367,7 @@ func (s *Service) recoverApplies(ctx context.Context, workerID int) {
 			if retryableClaim {
 				metrics.AdjustActiveApplies(ctx, -1, apply.Database, deployment, apply.Environment)
 			}
-			return
+			return false
 		}
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) || ctx.Err() != nil {
 			s.logger.Debug("scheduler: stopped while running claimed apply",
@@ -264,7 +380,7 @@ func (s *Service) recoverApplies(ctx context.Context, workerID int) {
 			if retryableClaim {
 				metrics.AdjustActiveApplies(ctx, -1, apply.Database, deployment, apply.Environment)
 			}
-			return
+			return false
 		}
 		s.logger.Error("scheduler: failed to resume apply",
 			"worker", workerID,
@@ -277,7 +393,7 @@ func (s *Service) recoverApplies(ctx context.Context, workerID int) {
 		if retryableClaim {
 			metrics.AdjustActiveApplies(ctx, -1, apply.Database, deployment, apply.Environment)
 		}
-		return
+		return false
 	}
 
 	duration := s.clock.Now().Sub(start)
@@ -291,6 +407,82 @@ func (s *Service) recoverApplies(ctx context.Context, workerID int) {
 		"duration", duration)
 	metrics.RecordSchedulerResume(ctx, apply.Database, deployment, apply.Environment, previousState)
 	metrics.RecordSchedulerClaimDuration(ctx, duration, apply.Database, deployment, apply.Environment, previousState)
+	return true
+}
+
+// startApplyOperationHeartbeat refreshes the claimed operation row's lease on
+// the apply heartbeat cadence while ResumeApply runs. A lost parent apply lease
+// cancels the run so the displaced worker stops; other heartbeat errors are
+// logged and retried on the next tick. Returns a stop func that is safe to call
+// more than once.
+func (s *Service) startApplyOperationHeartbeat(ctx context.Context, workerID int, op *storage.ApplyOperation, apply *storage.Apply, cancelRun context.CancelFunc) func() {
+	hbCtx, stop := context.WithCancel(ctx)
+	s.recoveryWg.Go(func() {
+		ticker := time.NewTicker(s.schedulerPollInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-hbCtx.Done():
+				return
+			case <-ticker.C:
+				if err := s.storage.ApplyOperations().Heartbeat(hbCtx, op.ID); err != nil {
+					if errors.Is(err, storage.ErrApplyLeaseLost) {
+						s.logger.Warn("operator: apply_operation heartbeat lost parent apply lease; worker will stop",
+							"worker", workerID,
+							"apply_operation_id", op.ID,
+							"apply_id", apply.ApplyIdentifier,
+							"database", apply.Database,
+							"deployment", op.Deployment,
+							"environment", apply.Environment,
+							"error", err)
+						cancelRun()
+						return
+					}
+					s.logger.Warn("operator: apply_operation heartbeat failed; will retry",
+						"worker", workerID,
+						"apply_operation_id", op.ID,
+						"apply_id", apply.ApplyIdentifier,
+						"database", apply.Database,
+						"deployment", op.Deployment,
+						"environment", apply.Environment,
+						"error", err)
+				}
+			}
+		}
+	})
+	return stop
+}
+
+// markOperationFromApplyState transitions the claimed operation row to mirror
+// the parent apply's final state after a successful resume. Non-terminal parent
+// states leave the operation claimable so a later poll re-leases and resumes it.
+func (s *Service) markOperationFromApplyState(ctx context.Context, workerID int, op *storage.ApplyOperation, apply *storage.Apply) {
+	opStore := s.storage.ApplyOperations()
+	switch {
+	case state.IsState(apply.State, state.Apply.Completed):
+		if err := opStore.MarkCompleted(ctx, op.ID); err != nil {
+			s.logger.Error("operator: failed to mark apply_operation completed",
+				"worker", workerID, "apply_operation_id", op.ID, "apply_id", apply.ApplyIdentifier,
+				"deployment", op.Deployment, "environment", apply.Environment, "error", err)
+		}
+	case state.IsState(apply.State, state.Apply.Failed):
+		if err := opStore.MarkFailed(ctx, op.ID, apply.ErrorMessage); err != nil {
+			s.logger.Error("operator: failed to mark apply_operation failed",
+				"worker", workerID, "apply_operation_id", op.ID, "apply_id", apply.ApplyIdentifier,
+				"deployment", op.Deployment, "environment", apply.Environment, "error", err)
+		}
+	case state.IsTerminalApplyState(apply.State):
+		// stopped / cancelled / reverted — mirror the terminal state onto the row.
+		if err := opStore.UpdateState(ctx, op.ID, apply.State); err != nil {
+			s.logger.Error("operator: failed to update terminal apply_operation state",
+				"worker", workerID, "apply_operation_id", op.ID, "apply_id", apply.ApplyIdentifier,
+				"deployment", op.Deployment, "environment", apply.Environment, "state", apply.State, "error", err)
+		}
+	default:
+		s.logger.Debug("operator: parent apply not terminal after resume; leaving operation claimable",
+			"worker", workerID, "apply_operation_id", op.ID, "apply_id", apply.ApplyIdentifier,
+			"deployment", op.Deployment, "environment", apply.Environment, "state", apply.State)
+	}
 }
 
 func schedulerLeaseOwner(workerID int) string {

--- a/pkg/storage/mysqlstore/applies.go
+++ b/pkg/storage/mysqlstore/applies.go
@@ -1147,24 +1147,70 @@ func (s *applyStore) GetByPR(ctx context.Context, repo string, pr int) ([]*stora
 	return scanApplies(rows)
 }
 
-// Delete removes an apply by ID.
+// Delete removes an apply by ID, along with its per-deployment
+// apply_operations rows, in a single transaction. Deleting the children
+// transactionally prevents orphan operation rows that the operator claim loop
+// would otherwise re-claim forever (their parent lookup returns nil).
 func (s *applyStore) Delete(ctx context.Context, id int64) error {
-	result, err := s.db.ExecContext(ctx, `
-		DELETE FROM applies WHERE id = ?
-	`, id)
+	const opName = "delete apply"
+	writeTx, err := beginApplyWriteTx(ctx, s.db, opName)
 	if err != nil {
 		return err
 	}
+	defer writeTx.close(ctx, opName)
 
-	return checkRowsAffected(result, storage.ErrApplyNotFound)
+	if _, err := writeTx.tx.ExecContext(ctx, `
+		DELETE FROM apply_operations WHERE apply_id = ?
+	`, id); err != nil {
+		return fmt.Errorf("delete apply_operations for apply %d: %w", id, err)
+	}
+
+	result, err := writeTx.tx.ExecContext(ctx, `
+		DELETE FROM applies WHERE id = ?
+	`, id)
+	if err != nil {
+		return fmt.Errorf("delete apply %d: %w", id, err)
+	}
+	if err := checkRowsAffected(result, storage.ErrApplyNotFound); err != nil {
+		return err
+	}
+
+	if err := writeTx.commit(); err != nil {
+		return fmt.Errorf("commit delete apply %d: %w", id, err)
+	}
+	return nil
 }
 
-// DeleteByPR removes all applies for a PR.
+// DeleteByPR removes all applies for a PR, along with their per-deployment
+// apply_operations rows, in a single transaction. Deleting the children
+// transactionally prevents orphan operation rows that the operator claim loop
+// would otherwise re-claim forever (their parent lookup returns nil).
 func (s *applyStore) DeleteByPR(ctx context.Context, repo string, pr int) error {
-	_, err := s.db.ExecContext(ctx, `
+	const opName = "delete applies by PR"
+	writeTx, err := beginApplyWriteTx(ctx, s.db, opName)
+	if err != nil {
+		return err
+	}
+	defer writeTx.close(ctx, opName)
+
+	if _, err := writeTx.tx.ExecContext(ctx, `
+		DELETE ao FROM apply_operations ao
+		JOIN applies a ON a.id = ao.apply_id
+		WHERE a.repository = ? AND a.pull_request = ?
+	`, repo, pr); err != nil {
+		return fmt.Errorf("delete apply_operations for PR %s#%d: %w", repo, pr, err)
+	}
+
+	if _, err := writeTx.tx.ExecContext(ctx, `
 		DELETE FROM applies WHERE repository = ? AND pull_request = ?
-	`, repo, pr)
-	return err
+	`, repo, pr); err != nil {
+		return fmt.Errorf("delete applies for PR %s#%d: %w", repo, pr, err)
+	}
+
+	if err := writeTx.commit(); err != nil {
+		return fmt.Errorf("commit delete applies for PR %s#%d: %w", repo, pr, err)
+	}
+	return nil
 }
 
 // scanApply scans a single apply row, returning nil if not found.

--- a/pkg/storage/mysqlstore/applies.go
+++ b/pkg/storage/mysqlstore/applies.go
@@ -795,20 +795,118 @@ func (s *applyStore) FindNextApply(ctx context.Context, owner string) (*storage.
 		return nil, fmt.Errorf("query next claimable apply: %w", err)
 	}
 
+	claimed, err := persistApplyClaim(ctx, tx, apply, owner)
+	if err != nil {
+		return nil, err
+	}
+	if !claimed {
+		return nil, nil
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("commit claim apply %d: %w", apply.ID, err)
+	}
+
+	return apply, nil
+}
+
+// ClaimApplyByID atomically claims one specific apply by ID using the same
+// claimability rules as FindNextApply, scoped to a single row. The operation-
+// level claim loop calls this after claiming an apply_operations row to acquire
+// the parent apply lease that lease-guarded writes (ResumeApply, MarkCompleted,
+// Heartbeat) require. Returns nil when the apply does not exist, is locked by a
+// peer (SKIP LOCKED), or is not currently claimable.
+func (s *applyStore) ClaimApplyByID(ctx context.Context, applyID int64, owner string) (*storage.Apply, error) {
+	if owner == "" {
+		return nil, fmt.Errorf("operator owner is required to claim apply %d: %w", applyID, storage.ErrApplyLeaseLost)
+	}
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelReadCommitted})
+	if err != nil {
+		return nil, fmt.Errorf("begin claim apply %d transaction: %w", applyID, err)
+	}
+	defer rollbackApplyTx(ctx, tx, "claim apply by id")
+
+	activeStates := claimableApplyStates()
+	activeStatePlaceholders := placeholders(len(activeStates))
+	queryArgs := []any{applyID, state.Apply.Pending}
+	queryArgs = append(queryArgs, stringArgs(activeStates)...)
+	queryArgs = append(queryArgs, state.Apply.FailedRetryable, maxRecoveryAttempts, retryableRecoveryFreshnessDays)
+	queryArgs = append(queryArgs,
+		state.Apply.Pending,
+		storage.ControlOperationStart, storage.ControlRequestPending)
+	queryArgs = append(queryArgs,
+		state.Apply.Stopped,
+		storage.ControlOperationStart, storage.ControlRequestPending)
+
+	row := tx.QueryRowContext(ctx, fmt.Sprintf(`
+		SELECT %s
+		FROM applies a
+		WHERE a.id = ?
+			AND (
+				(a.state = ? AND EXISTS (SELECT 1 FROM tasks t WHERE t.apply_id = a.id))
+				OR (a.state IN (%s) AND a.updated_at < NOW() - INTERVAL 1 MINUTE)
+				OR (a.state = ? AND a.attempt < ? AND a.updated_at >= NOW() - INTERVAL ? DAY)
+				OR (
+					a.state = ?
+					AND EXISTS (
+						SELECT 1
+						FROM apply_control_requests cr
+						WHERE cr.apply_id = a.id AND cr.operation = ? AND cr.status = ?
+					)
+				)
+				OR (
+					a.state = ?
+					AND EXISTS (
+						SELECT 1
+						FROM apply_control_requests cr
+						WHERE cr.apply_id = a.id AND cr.operation = ? AND cr.status = ?
+					)
+				)
+			)
+		LIMIT 1
+		FOR UPDATE SKIP LOCKED
+	`, applyColumns, activeStatePlaceholders), queryArgs...)
+
+	apply, err := scanApplyInto(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil // apply does not exist, is locked, or is not claimable
+	}
+	if err != nil {
+		return nil, fmt.Errorf("query claimable apply %d: %w", applyID, err)
+	}
+
+	claimed, err := persistApplyClaim(ctx, tx, apply, owner)
+	if err != nil {
+		return nil, err
+	}
+	if !claimed {
+		return nil, nil
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("commit claim apply %d: %w", apply.ID, err)
+	}
+
+	return apply, nil
+}
+
+// persistApplyClaim rotates the lease (owner, token, acquired_at) onto apply in
+// memory and persists it inside tx, refreshing the heartbeat in the same write.
+// Pending, stopped-start, and retryable applies move into running as part of the
+// claim so another worker cannot immediately re-claim the same durable request
+// after the transaction releases its row lock; active applies just refresh the
+// heartbeat. Reports false when the guarded UPDATE matched zero rows, meaning
+// another worker moved the row between SELECT and UPDATE.
+func persistApplyClaim(ctx context.Context, tx *sql.Tx, apply *storage.Apply, owner string) (bool, error) {
 	leaseToken := uuid.NewString()
 	leaseAcquiredAt := time.Now()
 	apply.LeaseOwner = owner
 	apply.LeaseToken = leaseToken
 	apply.LeaseAcquiredAt = &leaseAcquiredAt
 
-	// Refresh the heartbeat as part of the claim before releasing the row lock.
-	// Pending, stopped-start, and retryable applies move into an active owner
-	// state while the scheduler acts, so another worker cannot immediately claim
-	// the same durable request after this transaction releases its lock.
 	if apply.State == state.Apply.Pending || apply.State == state.Apply.Stopped || apply.State == state.Apply.FailedRetryable {
-		var result sql.Result
 		nextState := state.Apply.Running
-		result, err = tx.ExecContext(ctx, `
+		result, err := tx.ExecContext(ctx, `
 			UPDATE applies
 			SET state = ?, updated_at = NOW(),
 			    lease_owner = ?, lease_token = ?, lease_acquired_at = NOW(),
@@ -818,36 +916,31 @@ func (s *applyStore) FindNextApply(ctx context.Context, owner string) (*storage.
 			WHERE id = ? AND state = ?
 		`, nextState, owner, leaseToken, apply.State, state.Apply.FailedRetryable, apply.State, state.Apply.FailedRetryable, apply.ID, apply.State)
 		if err != nil {
-			return nil, fmt.Errorf("claim apply %d in state %s: %w", apply.ID, apply.State, err)
+			return false, fmt.Errorf("claim apply %d in state %s: %w", apply.ID, apply.State, err)
 		}
 		rows, err := result.RowsAffected()
 		if err != nil {
-			return nil, fmt.Errorf("read claim rows affected for apply %d: %w", apply.ID, err)
+			return false, fmt.Errorf("read claim rows affected for apply %d: %w", apply.ID, err)
 		}
 		if rows == 0 {
-			return nil, nil
+			return false, nil
 		}
 		if apply.State == state.Apply.FailedRetryable {
 			apply.Attempt++
 			apply.ErrorMessage = ""
 		}
-	} else {
-		_, err = tx.ExecContext(ctx, `
-			UPDATE applies
-			SET updated_at = NOW(),
-			    lease_owner = ?, lease_token = ?, lease_acquired_at = NOW()
-			WHERE id = ?
-		`, owner, leaseToken, apply.ID)
-		if err != nil {
-			return nil, fmt.Errorf("refresh heartbeat for claimed apply %d: %w", apply.ID, err)
-		}
+		return true, nil
 	}
 
-	if err := tx.Commit(); err != nil {
-		return nil, fmt.Errorf("commit claim apply %d: %w", apply.ID, err)
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE applies
+		SET updated_at = NOW(),
+		    lease_owner = ?, lease_token = ?, lease_acquired_at = NOW()
+		WHERE id = ?
+	`, owner, leaseToken, apply.ID); err != nil {
+		return false, fmt.Errorf("refresh heartbeat for claimed apply %d: %w", apply.ID, err)
 	}
-
-	return apply, nil
+	return true, nil
 }
 
 // Heartbeat updates the apply's updated_at timestamp to maintain the lease.

--- a/pkg/storage/mysqlstore/applies_test.go
+++ b/pkg/storage/mysqlstore/applies_test.go
@@ -1703,6 +1703,66 @@ func TestApplyStore_DeleteByPR(t *testing.T) {
 	require.Len(t, applies, 1)
 }
 
+// TestApplyStore_Delete_RemovesApplyOperations verifies that deleting an apply
+// also removes its per-deployment apply_operations rows in the same transaction.
+// Orphan child rows would otherwise be re-claimed forever by the operator claim
+// loop, since their parent lookup returns nil.
+func TestApplyStore_Delete_RemovesApplyOperations(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", "mysql", "staging")
+	apply := createTestApply(t, store, lock, "apply_delete_ops", 610)
+	opID, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-a",
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, store.Applies().Delete(ctx, apply.ID))
+
+	deleted, err := store.Applies().Get(ctx, apply.ID)
+	require.NoError(t, err)
+	require.Nil(t, deleted)
+
+	op, err := store.ApplyOperations().Get(ctx, opID)
+	require.NoError(t, err)
+	require.Nil(t, op, "apply_operations row must be deleted with its parent apply")
+}
+
+// TestApplyStore_DeleteByPR_RemovesApplyOperations verifies that DeleteByPR
+// removes the apply_operations rows of the deleted applies while leaving other
+// PRs' operations intact.
+func TestApplyStore_DeleteByPR_RemovesApplyOperations(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock1 := createTestLockWithPR(t, store, "db1", "mysql", "staging", "org/repo", 110)
+	lock2 := createTestLockWithPR(t, store, "db2", "mysql", "staging", "org/repo", 210)
+	apply1 := createTestApply(t, store, lock1, "apply_pr110", 711)
+	apply2 := createTestApply(t, store, lock2, "apply_pr210", 712)
+
+	op1, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply1.ID, Deployment: "region-a",
+	})
+	require.NoError(t, err)
+	op2, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply2.ID, Deployment: "region-a",
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, store.Applies().DeleteByPR(ctx, "org/repo", 110))
+
+	got1, err := store.ApplyOperations().Get(ctx, op1)
+	require.NoError(t, err)
+	require.Nil(t, got1, "deleted PR's apply_operations row must be removed")
+
+	got2, err := store.ApplyOperations().Get(ctx, op2)
+	require.NoError(t, err)
+	require.NotNil(t, got2, "other PR's apply_operations row must be preserved")
+}
+
 func TestApplyStore_Options(t *testing.T) {
 	clearTables(t)
 	ctx := t.Context()

--- a/pkg/storage/mysqlstore/applies_test.go
+++ b/pkg/storage/mysqlstore/applies_test.go
@@ -928,6 +928,123 @@ func TestApplyStore_FindNextApplyClaimsRetryable(t *testing.T) {
 	assert.Nil(t, claimedAgain)
 }
 
+// ClaimApplyByID claims one specific apply by ID with the same claimability
+// rules as FindNextApply. The operation-level claim loop uses it to acquire the
+// parent apply lease after claiming an apply_operations row, so a pending apply
+// with tasks must be claimable, the claim must rotate a fresh lease, and a
+// repeat claim must be rejected while the lease is fresh.
+func TestApplyStore_ClaimApplyByIDClaimsPendingWithTasks(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", storage.DatabaseTypeMySQL, "staging")
+	apply := createTestApplyWithStateAndEnv(t, store, lock, "apply_claim_by_id_pending", 600, state.Apply.Pending, "staging")
+	addClaimByIDTask(t, store, apply, "task_claim_by_id")
+
+	claimed, err := store.Applies().ClaimApplyByID(ctx, apply.ID, "operator-a")
+	require.NoError(t, err)
+	require.NotNil(t, claimed)
+	assert.Equal(t, apply.ApplyIdentifier, claimed.ApplyIdentifier)
+	assert.Equal(t, state.Apply.Pending, claimed.State, "caller sees the pre-claim state")
+	assert.Equal(t, "operator-a", claimed.LeaseOwner)
+	assert.NotEmpty(t, claimed.LeaseToken)
+	require.NotNil(t, claimed.LeaseAcquiredAt)
+
+	persisted, err := store.Applies().Get(ctx, apply.ID)
+	require.NoError(t, err)
+	require.NotNil(t, persisted)
+	assert.Equal(t, state.Apply.Running, persisted.State)
+	assert.Equal(t, "operator-a", persisted.LeaseOwner)
+
+	again, err := store.Applies().ClaimApplyByID(ctx, apply.ID, "operator-b")
+	require.NoError(t, err)
+	assert.Nil(t, again, "a freshly claimed apply is owned by its current worker")
+}
+
+// ClaimApplyByID must not steal a fresh lease from a healthy apply-level worker,
+// so a running apply with a fresh heartbeat is not claimable; it only becomes
+// claimable once its heartbeat goes stale, matching FindNextApply recovery.
+func TestApplyStore_ClaimApplyByIDSkipsFreshRunningUntilStale(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", storage.DatabaseTypeMySQL, "staging")
+	apply := createTestApplyWithStateAndEnv(t, store, lock, "apply_claim_by_id_running", 601, state.Apply.Running, "staging")
+
+	fresh, err := store.Applies().ClaimApplyByID(ctx, apply.ID, "operator-a")
+	require.NoError(t, err)
+	assert.Nil(t, fresh, "a fresh running apply is owned by its active worker")
+
+	_, err = testDB.ExecContext(ctx, `
+		UPDATE applies
+		SET updated_at = NOW() - INTERVAL 2 MINUTE
+		WHERE id = ?
+	`, apply.ID)
+	require.NoError(t, err)
+
+	claimed, err := store.Applies().ClaimApplyByID(ctx, apply.ID, "operator-a")
+	require.NoError(t, err)
+	require.NotNil(t, claimed)
+	assert.Equal(t, state.Apply.Running, claimed.State)
+	assert.Equal(t, "operator-a", claimed.LeaseOwner)
+	assert.NotEmpty(t, claimed.LeaseToken)
+}
+
+// ClaimApplyByID returns nil for applies that are not claimable (terminal) or
+// do not exist, so the operation loop fails closed instead of driving work.
+func TestApplyStore_ClaimApplyByIDReturnsNilForTerminalAndMissing(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", storage.DatabaseTypeMySQL, "staging")
+	completed := createTestApplyWithStateAndEnv(t, store, lock, "apply_claim_by_id_done", 602, state.Apply.Completed, "staging")
+
+	claimed, err := store.Applies().ClaimApplyByID(ctx, completed.ID, "operator-a")
+	require.NoError(t, err)
+	assert.Nil(t, claimed, "terminal applies are never claimable")
+
+	missing, err := store.Applies().ClaimApplyByID(ctx, 9_999_999, "operator-a")
+	require.NoError(t, err)
+	assert.Nil(t, missing, "a non-existent apply id yields no claim")
+}
+
+// ClaimApplyByID requires an owner so a lease can never be acquired without an
+// identity that lease-guarded writes can fail closed against.
+func TestApplyStore_ClaimApplyByIDRequiresOwner(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	_, err := store.Applies().ClaimApplyByID(ctx, 1, "")
+	require.ErrorIs(t, err, storage.ErrApplyLeaseLost)
+}
+
+func addClaimByIDTask(t *testing.T, store *Storage, apply *storage.Apply, taskID string) {
+	t.Helper()
+	task := &storage.Task{
+		TaskIdentifier: taskID,
+		ApplyID:        apply.ID,
+		PlanID:         apply.PlanID,
+		Database:       apply.Database,
+		DatabaseType:   apply.DatabaseType,
+		Engine:         storage.EngineSpirit,
+		Environment:    apply.Environment,
+		State:          state.Task.Pending,
+		TableName:      "users",
+		DDL:            "ALTER TABLE `users` ADD COLUMN `note` varchar(255)",
+		DDLAction:      "alter",
+		Options:        []byte("{}"),
+		CreatedAt:      time.Now(),
+		UpdatedAt:      time.Now(),
+	}
+	id, err := store.Tasks().Create(t.Context(), task)
+	require.NoError(t, err)
+	task.ID = id
+}
+
 func TestApplyStore_LeaseGuardsOwnedWrites(t *testing.T) {
 	clearTables(t)
 	ctx := t.Context()

--- a/pkg/storage/mysqlstore/apply_operations.go
+++ b/pkg/storage/mysqlstore/apply_operations.go
@@ -308,6 +308,33 @@ func (s *applyOperationStore) MarkFailed(ctx context.Context, id int64, errMsg s
 	return s.checkUpdatedOrExists(ctx, result, id, lease, hasLease, false)
 }
 
+// MarkTerminal sets the given terminal state and stamps completed_at=NOW().
+// Returns storage.ErrApplyOperationNotFound if no row matches the ID.
+//
+// For terminal states that record a reconciliation time (cancelled, reverted).
+// stopped is resumable and must keep completed_at nil — use UpdateState for it.
+//
+// Idempotent: COALESCE preserves completed_at, and re-applying the same state
+// is a no-op, so a re-issue against an already-terminal row returns nil.
+func (s *applyOperationStore) MarkTerminal(ctx context.Context, id int64, newState string) error {
+	lease, hasLease, err := applyOperationLeaseFromContext(ctx)
+	if err != nil {
+		return err
+	}
+	leaseJoin, leasePredicate, leaseArgs := applyOperationLeaseSQL(lease, hasLease)
+	args := append([]any{newState, id}, leaseArgs...)
+	result, err := s.db.ExecContext(ctx, `
+		UPDATE apply_operations ao
+		`+leaseJoin+`
+		SET ao.state = ?, ao.completed_at = COALESCE(ao.completed_at, NOW())
+		WHERE ao.id = ?`+leasePredicate+`
+	`, args...)
+	if err != nil {
+		return fmt.Errorf("mark apply_operation terminal (id=%d, state=%s): %w", id, newState, err)
+	}
+	return s.checkUpdatedOrExists(ctx, result, id, lease, hasLease, false)
+}
+
 // SaveEngineResumeState stores opaque engine state on the operation that owns
 // the execution. It updates only resume-state columns so callers can persist
 // engine progress without changing operation lifecycle state.

--- a/pkg/storage/mysqlstore/apply_operations_test.go
+++ b/pkg/storage/mysqlstore/apply_operations_test.go
@@ -310,6 +310,79 @@ func TestApplyOperationStore_MarkFailed(t *testing.T) {
 	assert.True(t, state.IsApplyOperationTerminal(got.State))
 }
 
+// TestApplyOperationStore_MarkTerminal verifies that non-resumable terminal
+// states (cancelled, reverted) stamp completed_at, while the resumable stopped
+// state mirrors via UpdateState and leaves completed_at nil — matching the
+// apply-level convention since stopped work may still resume.
+func TestApplyOperationStore_MarkTerminal(t *testing.T) {
+	ctx := t.Context()
+	store := New(testDB)
+
+	for _, terminalState := range []string{state.ApplyOperation.Cancelled, state.ApplyOperation.Reverted} {
+		t.Run(terminalState+"_stamps_completed_at", func(t *testing.T) {
+			clearTables(t)
+			lock := createTestLock(t, store, "testdb", "mysql", "staging")
+			apply := createTestApply(t, store, lock, "apply_md_term_"+terminalState, 1)
+			id, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+				ApplyID: apply.ID, Deployment: "region-a",
+			})
+			require.NoError(t, err)
+
+			require.NoError(t, store.ApplyOperations().MarkTerminal(ctx, id, terminalState))
+			got, err := store.ApplyOperations().Get(ctx, id)
+			require.NoError(t, err)
+			assert.Equal(t, terminalState, got.State)
+			require.NotNil(t, got.CompletedAt, "MarkTerminal must stamp completed_at for %s", terminalState)
+			assert.True(t, state.IsApplyOperationTerminal(got.State))
+		})
+	}
+
+	t.Run("stopped_keeps_completed_at_nil", func(t *testing.T) {
+		clearTables(t)
+		lock := createTestLock(t, store, "testdb", "mysql", "staging")
+		apply := createTestApply(t, store, lock, "apply_md_term_stopped", 1)
+		id, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+			ApplyID: apply.ID, Deployment: "region-a",
+		})
+		require.NoError(t, err)
+
+		require.NoError(t, store.ApplyOperations().UpdateState(ctx, id, state.ApplyOperation.Stopped))
+		got, err := store.ApplyOperations().Get(ctx, id)
+		require.NoError(t, err)
+		assert.Equal(t, state.ApplyOperation.Stopped, got.State)
+		assert.Nil(t, got.CompletedAt, "stopped is resumable and must keep completed_at nil")
+		assert.True(t, state.IsApplyOperationTerminal(got.State))
+	})
+
+	t.Run("idempotent_preserves_completed_at", func(t *testing.T) {
+		clearTables(t)
+		lock := createTestLock(t, store, "testdb", "mysql", "staging")
+		apply := createTestApply(t, store, lock, "apply_md_term_idem", 1)
+		id, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+			ApplyID: apply.ID, Deployment: "region-a",
+		})
+		require.NoError(t, err)
+
+		require.NoError(t, store.ApplyOperations().MarkTerminal(ctx, id, state.ApplyOperation.Cancelled))
+		first, err := store.ApplyOperations().Get(ctx, id)
+		require.NoError(t, err)
+		require.NotNil(t, first.CompletedAt)
+
+		require.NoError(t, store.ApplyOperations().MarkTerminal(ctx, id, state.ApplyOperation.Cancelled))
+		second, err := store.ApplyOperations().Get(ctx, id)
+		require.NoError(t, err)
+		require.NotNil(t, second.CompletedAt)
+		assert.Equal(t, first.CompletedAt.UnixNano(), second.CompletedAt.UnixNano(),
+			"COALESCE should preserve original completed_at across repeat MarkTerminal calls")
+	})
+
+	t.Run("missing_row_returns_not_found", func(t *testing.T) {
+		clearTables(t)
+		err := store.ApplyOperations().MarkTerminal(ctx, 999999, state.ApplyOperation.Cancelled)
+		require.ErrorIs(t, err, storage.ErrApplyOperationNotFound)
+	})
+}
+
 func TestApplyOperationStore_UpdateState(t *testing.T) {
 	clearTables(t)
 	ctx := t.Context()

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -378,6 +378,13 @@ type ApplyOperationStore interface {
 	// MarkFailed sets state=failed, error_message, and completed_at on a child row.
 	MarkFailed(ctx context.Context, id int64, errMsg string) error
 
+	// MarkTerminal sets a terminal state and stamps completed_at on a child row.
+	// Use for terminal states that record a reconciliation time (cancelled,
+	// reverted). Do not use for stopped: stopped is resumable, so it keeps
+	// completed_at nil (use UpdateState). Use MarkCompleted / MarkFailed for
+	// completed / failed.
+	MarkTerminal(ctx context.Context, id int64, newState string) error
+
 	// SaveEngineResumeState stores opaque engine resume state on the operation.
 	SaveEngineResumeState(ctx context.Context, operationID int64, resumeState *EngineResumeState) error
 

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -228,6 +228,17 @@ type ApplyStore interface {
 	// Returns the claimed apply, or nil if nothing needs work.
 	FindNextApply(ctx context.Context, owner string) (*Apply, error)
 
+	// ClaimApplyByID atomically claims one specific apply by ID, scoped to the
+	// same claimability rules as FindNextApply (pending with tasks, stale active
+	// state, retryable within budget, or a pending start control request). On a
+	// successful claim it rotates the lease (owner, token, acquired_at) and
+	// refreshes the heartbeat so scheduler-owned writes can fail closed after
+	// ownership changes. Returns the claimed apply, or nil if the apply does not
+	// exist or is not currently claimable (e.g. another worker holds a fresh
+	// lease or the apply is terminal). Used by the operation-level claim loop to
+	// acquire the parent apply lease after claiming an apply_operations row.
+	ClaimApplyByID(ctx context.Context, applyID int64, owner string) (*Apply, error)
+
 	// Heartbeat updates the apply's updated_at timestamp to maintain the lease.
 	// Should be called every 10 seconds while working on an apply.
 	// If not called for > 1 minute, another worker can claim the apply.

--- a/pkg/storage/types.go
+++ b/pkg/storage/types.go
@@ -444,7 +444,10 @@ type ApplyOperation struct {
 	// StartedAt is when the scheduler claimed this child row and execution began.
 	StartedAt *time.Time
 
-	// CompletedAt is when this child row reached a terminal state.
+	// CompletedAt is when this child row reached a non-resumable terminal state
+	// (completed, failed, cancelled, reverted). It stays nil for the resumable
+	// stopped state, matching the apply-level convention, since stopped work may
+	// still resume.
 	CompletedAt *time.Time
 
 	// EngineResumeContext and EngineResumeMetadata are opaque state owned by the


### PR DESCRIPTION
## Summary
Adds a feature-flagged operator claim loop that claims work at the
`apply_operations` (per-deployment) level. Default off; coexists with the
existing apply-level claim path for one release. While apply-create writes one
operation per apply, driving the parent apply is equivalent to driving the
single operation — this is the foundation for multi-deployment fan-out.

## Changes
- `operator_claim_operations` config flag (default off)
- `ClaimApplyByID` storage method: targeted parent-apply lease claim, sharing
  the lease-rotation path with `FindNextApply`
- flag-gated `recoverApplyOperation`: claims an operation row, acquires the
  parent apply lease, drives the shared resume path while heartbeating the
  operation row, then mirrors the apply's final state onto the operation
- fail-closed when the parent apply is not claimable

```
  scheduler worker tick
        │
   operator_claim_operations?
        │
   ┌────┴─────────────┐
  off (default)      on
   │                 │
 FindNextApply   FindNextApplyOperation ── claim op row
 ResumeApply         │
 (unchanged)     ClaimApplyByID(op.ApplyID)  ── acquire parent apply lease
                     │ (nil ⇒ fail closed, retry later)
                 WithApplyLease + op heartbeat goroutine
                     │
                 resumeClaimedApply (shared)
                     │
                 reload apply ⇒ markOperationFromApplyState
```

## Testing / validation
build, vet, lint, unit tests green; integration tests added for
`ClaimApplyByID` and the operator claim-to-completion path.

