### PR TITLE
feat(observability): rename client-facing scheduler surfaces to operator

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -15,7 +15,7 @@
   - [Apply](#apply)
   - [Apply vs Task](#apply-vs-task)
   - [Progress Flow And Observers](#progress-flow-and-observers)
-  - [Scheduler](#scheduler)
+  - [Operator](#operator)
   - [Execution Modes](#execution-modes)
   - [Integration Modes](#integration-modes)
 - [Engine Layer (Executor)](#engine-layer-executor)
@@ -177,13 +177,13 @@ SchemaBot also stores durable control requests for operations whose accepted
 intent must survive API handler exits or process restarts. `stop`, stopped-state
 `start`, and cutover requests are recorded in
 `apply_control_requests` before the engine side effect is performed. The active
-scheduler-owned apply worker consumes the request, performs or forwards the
+operator-owned apply worker consumes the request, performs or forwards the
 engine control operation, syncs SchemaBot storage to the resulting state, and
 only then marks the control request completed.
 
 ```
 ┌──────────────┐     ┌────────────────────────┐     ┌──────────────┐
-│ CLI / API    │────▶│ apply_control_requests │────▶│ Scheduler    │
+│ CLI / API    │────▶│ apply_control_requests │────▶│ Operator     │
 │ accepts user │     │ pending intent         │     │ apply owner  │
 │ control op   │     └────────────────────────┘     └──────┬───────┘
 └──────────────┘                                           │
@@ -208,15 +208,15 @@ completion until the stop request has been observed and processed. The API
 therefore records the durable stop request first, then immediately attempts a
 safe engine stop as a fast path for local/in-process Tern clients. If the
 immediate stop succeeds, the active engine is interrupted without waiting for the
-scheduler owner's next poll. If it fails or is not accepted, SchemaBot logs the
+operator owner's next poll. If it fails or is not accepted, SchemaBot logs the
 result and leaves the durable request pending so the current owner, or a later
 recovered owner, can retry and reconcile final state. Remote gRPC Tern clients
-skip the API fast path because the scheduler owner must both stop the remote
+skip the API fast path because the operator owner must both stop the remote
 data plane and reconcile SchemaBot's local storage in one owner-controlled flow.
 
 Forward-progress controls must fail closed while a stop is pending. User-driven
 cutover is rejected when a pending stop request exists, whether the request came
-from the CLI/API path or a PR comment, and scheduler-owned pollers check for
+from the CLI/API path or a PR comment, and operator-owned pollers check for
 pending stops before continuing progress work. This avoids the unsafe
 interleaving where `/api/stop` returns accepted while another path moves the
 same apply from `waiting_for_cutover` into cutover or completion before the stop
@@ -224,8 +224,8 @@ can be applied.
 
 Cutover requests follow the same durable-owner model. The API accepts cutover
 when the apply is ready for cutover, records a pending cutover request, and wakes
-the scheduler instead of depending on the API handler to reach the active engine
-process. The scheduler owner then sends the local engine request or remote gRPC
+the operator instead of depending on the API handler to reach the active engine
+process. The operator owner then sends the local engine request or remote gRPC
 `Cutover` request. If the engine accepts, the cutover request is completed; if
 the request fails or is rejected, the request is marked failed with the
 operator-visible reason so a later retry requires a new operator request.
@@ -233,7 +233,7 @@ operator-visible reason so a later retry requires a new operator request.
 Restart recovery has a separate visible phase while SchemaBot reattaches to an
 engine after owner loss. If storage says a MySQL/Spirit apply was
 `waiting_for_cutover` and Spirit's `_spirit_sentinel` table still exists, the
-scheduler marks the apply `recovering` before cutover is safe again. Cutover
+operator marks the apply `recovering` before cutover is safe again. Cutover
 requests are rejected in this phase. Once progress reports concrete engine work,
 SchemaBot returns the apply to the normal state for that work: `running` for row
 copy or `waiting_for_cutover` when Spirit has re-reached the sentinel wait. The
@@ -242,7 +242,7 @@ outcome/status API; sentinel presence is enough to block cutover safely, but it
 does not prove Spirit reused prior row-copy progress.
 
 If the sentinel is already absent when SchemaBot restarts, recovery does not
-enter `recovering`. The scheduler re-plans against the live schema; if
+enter `recovering`. The operator re-plans against the live schema; if
 the desired schema is already present, the apply is marked completed, otherwise
 the remaining work is resumed through the normal checkpoint recovery path.
 
@@ -269,8 +269,8 @@ the remaining work is resumed through the normal checkpoint recovery path.
 
 This preserves single-owner semantics for running applies: a fresh running apply
 with a pending stop request is still owned by its current worker, not claimed by
-a second scheduler worker. If that worker or process exits before acting, the
-stale heartbeat makes the apply claimable through the normal scheduler recovery
+a second operator worker. If that worker or process exits before acting, the
+stale heartbeat makes the apply claimable through the normal operator recovery
 path, and the next worker processes the pending control request before resuming
 or dispatching more work.
 
@@ -385,16 +385,16 @@ Persist applies + tasks
           - terminal summary comment
 ```
 
-State authority is intentionally one-way: engine progress is an input, not the durable source of truth. Raw engine states are first normalized into canonical task states. The poller then reconciles that normalized engine task state with the stored task row: terminal stored tasks stay terminal, scheduler/control-owned states such as `stopped` and `failed_retryable` are not overwritten by stale active engine polls, and ordinary active states can move forward but not backward. Apply state is derived after task rows are coherent, so PR comments, CLI progress, and scheduler checks never need to reason about raw engine states directly.
+State authority is intentionally one-way: engine progress is an input, not the durable source of truth. Raw engine states are first normalized into canonical task states. The poller then reconciles that normalized engine task state with the stored task row: terminal stored tasks stay terminal, operator/control-owned states such as `stopped` and `failed_retryable` are not overwritten by stale active engine polls, and ordinary active states can move forward but not backward. Apply state is derived after task rows are coherent, so PR comments, CLI progress, and operator checks never need to reason about raw engine states directly.
 
 Unknown raw engine states normalize to `running`. This keeps unfamiliar in-flight work visible and blocking without leaking engine-specific strings into SchemaBot state or UI. Once the engine state is understood, update `NormalizeTaskStatus()` and the state-policy tests so the new state has an explicit task-state mapping and ordering policy.
 
 #### Remote gRPC Progress Synchronization
 
-Remote gRPC progress is core Tern scheduler behavior. In gRPC mode, the
+Remote gRPC progress is core Tern operator behavior. In gRPC mode, the
 SchemaBot API queues and tracks applies in control-plane storage, while a remote
 Tern deployment executes the schema change and reports progress for its own
-apply ID. The scheduler worker that claims the stored apply also owns the
+apply ID. The operator worker that claims the stored apply also owns the
 durable progress polling loop for that remote apply.
 
 ```
@@ -404,7 +404,7 @@ CLI / webhook apply request
 SchemaBot API creates stored apply + tasks
         |
         v
-Scheduler worker claims apply
+Operator worker claims apply
         |
         v
 GRPCClient.ResumeApply()
@@ -413,14 +413,14 @@ GRPCClient.ResumeApply()
         |                        and store remote apply_id as external_id
         |
         v
-Same scheduler worker polls Progress(apply_id=external_id, environment)
+Same operator worker polls Progress(apply_id=external_id, environment)
         |
         v
 Stored apply/task rows are updated for status, logs, recovery, and UI
 ```
 
 HTTP progress endpoints and the CLI/TUI may also request progress, but those
-request-time reads are not the durable synchronization path. The scheduler
+request-time reads are not the durable synchronization path. The operator
 worker's polling loop is what keeps SchemaBot storage reconciled with the remote
 data plane.
 
@@ -443,10 +443,10 @@ Transient progress RPC errors do not cause SchemaBot to send a remote `Stop`
 request. A progress outage only proves the control plane cannot observe the
 remote apply; it does not prove the remote apply should be stopped.
 
-Instead, the scheduler worker counts consecutive progress polling errors:
+Instead, the operator worker counts consecutive progress polling errors:
 
 ```
-Scheduler worker polls remote Progress
+Operator worker polls remote Progress
         |
         +-- NotFound / no active change
         |       |
@@ -473,7 +473,7 @@ Scheduler worker polls remote Progress
             reset consecutive error count and sync storage
 ```
 
-`failed_retryable` pauses the current scheduler attempt and keeps the apply
+`failed_retryable` pauses the current operator attempt and keeps the apply
 visible and blocking until recovery retries it. The remote data-plane apply may
 still be running; SchemaBot deliberately avoids issuing a stop command when the
 only problem is repeated inability to read progress.
@@ -498,11 +498,11 @@ Webhook handler: "someone commented schemabot apply"
             |
             v
         store pending apply + tasks
-            +-- Registers Observer on the apply before scheduler dispatch
-            +-- Wakes scheduler
+            +-- Registers Observer on the apply before operator dispatch
+            +-- Wakes operator
                     |
                     v
-                Scheduler worker claims apply
+                Operator worker claims apply
                     |
                     v
                 Client.ResumeApply()
@@ -541,20 +541,20 @@ but no summary comment. That means `OnTerminal` was missed during a process
 restart. The webhook runtime posts the missing summary from the apply record's
 stored GitHub context, and errors never fail server startup.
 
-### Scheduler
+### Operator
 
-The scheduler is part of Tern orchestration. The API service starts it on server startup because the server owns process lifecycle, configuration, and the Tern client pool, but the scheduler's work is to coordinate applies: claim storage records, refresh their heartbeat lease, and call `ResumeApply()` on the right Tern client.
+The operator is part of Tern orchestration. The API service starts it on server startup because the server owns process lifecycle, configuration, and the Tern client pool, but the operator's work is to coordinate applies: claim storage records, refresh their heartbeat lease, and call `ResumeApply()` on the right Tern client.
 
-Each scheduler worker runs immediately on startup, then polls every 10 seconds. The worker claims at most one apply per tick and resumes it through the Tern client for that apply's deployment and environment. Fresh applies also send a best-effort wake signal after their apply and task rows are committed, so a worker can claim them immediately instead of waiting for the next poll tick.
+Each operator worker runs immediately on startup, then polls every 10 seconds. The worker claims at most one apply per tick and resumes it through the Tern client for that apply's deployment and environment. Fresh applies also send a best-effort wake signal after their apply and task rows are committed, so a worker can claim them immediately instead of waiting for the next poll tick.
 
-`scheduler_workers` controls scheduler concurrency. The default is four workers, so an untuned server can still make progress across independent databases and environments concurrently. More workers help larger installations with many independent schema changes because each worker can claim and resume a different target during the same scheduler tick.
+`operator_workers` controls operator concurrency (the deprecated `operator_workers` alias is still accepted for one release). The default is four workers, so an untuned server can still make progress across independent databases and environments concurrently. More workers help larger installations with many independent schema changes because each worker can claim and resume a different target during the same operator tick.
 
-In a multi-pod deployment, every SchemaBot pod runs its own scheduler. Each scheduler has its own configurable worker pool, and every worker coordinates through shared storage before resuming an apply. When a recovered apply came from a PR comment, the worker attaches a reconstructed `ProgressObserver` before calling `ResumeApply()` so the resumed progress poller can keep updating PR comments.
+In a multi-pod deployment, every SchemaBot pod runs its own operator. Each operator has its own configurable worker pool, and every worker coordinates through shared storage before resuming an apply. When a recovered apply came from a PR comment, the worker attaches a reconstructed `ProgressObserver` before calling `ResumeApply()` so the resumed progress poller can keep updating PR comments.
 
 ```
 +--------------------------+      +--------------------------+
 | SchemaBot pod A          |      | SchemaBot pod B          |
-| Scheduler                |      | Scheduler                |
+| Operator                 |      | Operator                 |
 | +----------------------+ |      | +----------------------+ |
 | | worker 0             | |      | | worker 0             | |
 | | claim apply work     | |      | | claim apply work     | |
@@ -586,7 +586,7 @@ In a multi-pod deployment, every SchemaBot pod runs its own scheduler. Each sche
         +-----------------------------------------------+
 ```
 
-The storage arrows represent scheduler coordination. The GitHub arrows represent optional observer notifications; CLI applies simply run without an observer.
+The storage arrows represent operator coordination. The GitHub arrows represent optional observer notifications; CLI applies simply run without an observer.
 
 A **claim** is an atomic storage operation: it selects one apply that needs work,
 refreshes its `updated_at` heartbeat, and rotates an apply lease token in the
@@ -631,11 +631,11 @@ state.
    ╰──────────╯                       ╰──────────────────────────╯
 ```
 
-Claims use `FOR UPDATE SKIP LOCKED` so multiple scheduler workers can run concurrently without taking the same apply.
+Claims use `FOR UPDATE SKIP LOCKED` so multiple operator workers can run concurrently without taking the same apply.
 
 A running apply becomes claimable after its heartbeat has been stale for more than one minute and it is in a state that can be resumed from persisted metadata. Terminal applies are already done, and stopped applies are not auto-resumed; the user must call `schemabot start`.
 
-Freshly queued applies are also claimable once their task rows exist. `ExecuteApply` stores the pending apply and its initial tasks in one transaction, then sends a best-effort wake signal to the scheduler. The wake path is only a latency optimization: it nudges one worker to call the same claim path immediately instead of waiting for the next poll tick. It never bypasses storage claims or creates a second queue. If the scheduler is stopped or a wake is already pending, the signal is skipped and the normal poll loop still finds the apply.
+Freshly queued applies are also claimable once their task rows exist. `ExecuteApply` stores the pending apply and its initial tasks in one transaction, then sends a best-effort wake signal to the operator. The wake path is only a latency optimization: it nudges one worker to call the same claim path immediately instead of waiting for the next poll tick. It never bypasses storage claims or creates a second queue. If the operator is stopped or a wake is already pending, the signal is skipped and the normal poll loop still finds the apply.
 
 ```
 HTTP apply request
@@ -644,7 +644,7 @@ HTTP apply request
 store pending apply + tasks
       |
       v
-best-effort scheduler wake
+best-effort operator wake
       |
       v
 worker calls FindNextApply()
@@ -670,7 +670,7 @@ The named lock is internal storage infrastructure, not user-facing lock state or
 
 If storage cannot acquire the named lock within the bounded wait, the write fails before changing `applies`. If storage cannot confirm lock release, it discards the connection so MySQL releases the session-scoped lock.
 
-The scheduler relies on that invariant. Additional workers increase concurrency across independent targets; they do not make one database/environment run multiple applies at once.
+The operator relies on that invariant. Additional workers increase concurrency across independent targets; they do not make one database/environment run multiple applies at once.
 
 If a worker finds no claimable apply, it waits briefly and retries once during the same tick. This lets another worker that lost a claim race pick up a different target without waiting for the next 10-second poll.
 
@@ -753,7 +753,7 @@ There are two ways to deploy the tern layer:
 
 Used for: local development, self-hosted deployments, single-binary setups.
 
-**gRPC Mode** (`GRPCClient`) — SchemaBot delegates execution to an external Tern service over gRPC. SchemaBot still maintains its own storage for locks, plans, applies, and tasks. HTTP apply requests queue durable control-plane rows first; scheduler workers dispatch the queued apply to the remote Tern service and then poll it until terminal.
+**gRPC Mode** (`GRPCClient`) — SchemaBot delegates execution to an external Tern service over gRPC. SchemaBot still maintains its own storage for locks, plans, applies, and tasks. HTTP apply requests queue durable control-plane rows first; operator workers dispatch the queued apply to the remote Tern service and then poll it until terminal.
 
 ```
 ┌──────────────────────────────┐        ┌──────────────────────────────┐
@@ -766,7 +766,7 @@ Used for: local development, self-hosted deployments, single-binary setups.
 │ (locks, plans, applies)      │        │ (remote apply rows)          │
 │      │                       │        │      │                       │
 │      ▼                       │        │      ▼                       │
-│ Scheduler worker             │        │ Tern Proto Interface         │
+│ Operator worker              │        │ Tern Proto Interface         │
 │      │                       │        │      │                       │
 │      ▼                       │        │      ▼                       │
 │ GRPCClient ──────────────────┼────────▶ Engine ─────────────────────▶│ Target DB
@@ -777,7 +777,7 @@ Used for: distributed deployments where SchemaBot and the database engine run on
 
 **Identity resolution (`apply_identifier` vs `external_id`):**
 
-In gRPC mode, SchemaBot and Tern maintain separate storage with separate IDs. SchemaBot generates an `apply_identifier` for HTTP callers when it queues the apply. The scheduler later calls remote Tern, receives Tern's own apply ID, and stores that remote ID as `external_id`:
+In gRPC mode, SchemaBot and Tern maintain separate storage with separate IDs. SchemaBot generates an `apply_identifier` for HTTP callers when it queues the apply. The operator later calls remote Tern, receives Tern's own apply ID, and stores that remote ID as `external_id`:
 
 An accepted apply must return an apply ID and must be represented in SchemaBot
 storage before webhook progress tracking or Check Run ownership can proceed.
@@ -788,10 +788,10 @@ to the PR check that started the work.
 Apply flow:
   ExecuteApply
     → stores apply_identifier="apply-abc123", external_id=""
-    → wakes scheduler
+    → wakes operator
     → returns apply_id="apply-abc123" to HTTP caller
 
-  Scheduler worker claims apply "apply-abc123"
+  Operator worker claims apply "apply-abc123"
     → GRPCClient.ResumeApply() calls remote Apply()
     → Tern returns ApplyId:"tern-42"
     → SchemaBot stores external_id="tern-42"
@@ -810,10 +810,10 @@ In local mode (`client.IsRemote() == false`), `LocalClient` runs in the same pro
 Apply flow (local):
   ExecuteApply
     → stores apply_identifier="apply-def456", external_id=""
-    → wakes scheduler
+    → wakes operator
     → returns apply_id="apply-def456" to HTTP caller
 
-  Scheduler worker claims apply "apply-def456"
+  Operator worker claims apply "apply-def456"
     → LocalClient.ResumeApply() runs the engine locally
     → external_id remains empty
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,7 +10,7 @@
 - [Multi-Deployment Environment (preview)](#multi-deployment-environment-preview)
 - [Environment Order](#environment-order)
 - [Hybrid Mode](#hybrid-mode)
-- [Scheduler Workers](#scheduler-workers)
+- [Operator Workers](#operator-workers)
 - [Repository Allowlist](#repository-allowlist)
 - [PR Checks Gate](#pr-checks-gate)
 - [Review Gate](#review-gate)
@@ -249,17 +249,19 @@ tern_deployments:
 
 Routing is always server-side. A database environment with `dsn` uses local mode. A database environment with `target` and `deployment` uses gRPC mode through the matching `tern_deployments` endpoint. A database that is not listed in `databases` is not routable.
 
-## Scheduler Workers
+## Operator Workers
 
-SchemaBot runs a background scheduler for apply work that needs server-side coordination. By default, four workers poll for claimable work so a server can make progress across independent databases and environments concurrently.
+SchemaBot runs a background operator for apply work that needs server-side coordination. By default, four workers poll for claimable work so a server can make progress across independent databases and environments concurrently.
 
 ```yaml
-scheduler_workers: 4
+operator_workers: 4
 ```
 
-Increase `scheduler_workers` when one SchemaBot server should make scheduler progress across independent databases or environments concurrently. More workers help high-scale installations with many schema changes because each worker can claim and resume a different target during the same scheduler tick. The scheduler still excludes overlapping work for the same database and environment, so this improves concurrency across independent targets, not parallel execution against one target.
+Increase `operator_workers` when one SchemaBot server should make operator progress across independent databases or environments concurrently. More workers help high-scale installations with many schema changes because each worker can claim and resume a different target during the same operator tick. The operator still excludes overlapping work for the same database and environment, so this improves concurrency across independent targets, not parallel execution against one target.
 
-A scheduler claim means selecting one stale apply and refreshing its heartbeat in the same storage transaction. That heartbeat refresh is the worker's lease while it reloads state and resumes the apply.
+An operator claim means selecting one stale apply and refreshing its heartbeat in the same storage transaction. That heartbeat refresh is the worker's lease while it reloads state and resumes the apply.
+
+> **Deprecated:** the previous `scheduler_workers` key still works as an alias for `operator_workers` and is honored with a deprecation warning. Set only one of the two. The alias will be removed one release after the operator rename has soaked.
 
 ## Repository Allowlist
 

--- a/integration/operator_test.go
+++ b/integration/operator_test.go
@@ -543,7 +543,7 @@ func TestOperator_ExpiresRetryableBudget(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	svc := schemabotapi.New(stor, &schemabotapi.ServerConfig{SchedulerWorkers: 1}, nil, logger)
+	svc := schemabotapi.New(stor, &schemabotapi.ServerConfig{OperatorWorkers: 1}, nil, logger)
 	require.NoError(t, svc.SetOperatorPollInterval(50*time.Millisecond))
 	svc.StartOperator(ctx)
 	defer svc.StopOperator()
@@ -609,7 +609,7 @@ func TestOperator_MultipleWorkersResumeDifferentTargets(t *testing.T) {
 	blockingClient1 := newBlockingResumeClient(client1, blockedResume)
 
 	svc := schemabotapi.New(stor, &schemabotapi.ServerConfig{
-		SchedulerWorkers: 2,
+		OperatorWorkers: 2,
 		Databases: map[string]schemabotapi.DatabaseConfig{
 			db1Name: {
 				Type: "mysql",

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -74,10 +74,20 @@ type ServerConfig struct {
 	// staging before production.
 	EnvironmentOrder []string `yaml:"environment_order"`
 
-	// SchedulerWorkers is the number of concurrent scheduler workers that claim
+	// OperatorWorkers is the number of concurrent operator workers that claim
 	// and resume applies. Each worker independently polls FindNextApply with
-	// FOR UPDATE SKIP LOCKED to prevent races. Defaults to 1.
-	SchedulerWorkers int `yaml:"scheduler_workers"`
+	// FOR UPDATE SKIP LOCKED to prevent races. Defaults to DefaultOperatorWorkers.
+	OperatorWorkers int `yaml:"operator_workers"`
+
+	// SchedulerWorkers is the deprecated alias for OperatorWorkers. It is kept
+	// so existing config files that still set scheduler_workers continue to
+	// load (the YAML decoder runs with KnownFields(true) and would otherwise
+	// reject the unknown key). Validate() copies it into OperatorWorkers when
+	// the new key is unset and logs a deprecation warning. Remove one release
+	// after the operator rename has soaked.
+	//
+	// Deprecated: use operator_workers.
+	SchedulerWorkers int `yaml:"scheduler_workers,omitempty"`
 
 	// OperatorClaimOperations switches scheduler workers to claim work at the
 	// apply_operations (per-deployment) level via FindNextApplyOperation instead
@@ -446,8 +456,29 @@ func LoadServerConfigFromFile(path string) (*ServerConfig, error) {
 	return &config, nil
 }
 
+// resolveDeprecatedOperatorWorkers folds the deprecated scheduler_workers key
+// into operator_workers. When only the deprecated key is set it is honored and
+// a deprecation warning is logged; setting both keys is rejected so the
+// effective value is never ambiguous.
+func (c *ServerConfig) resolveDeprecatedOperatorWorkers() error {
+	if c.SchedulerWorkers == 0 {
+		return nil
+	}
+	if c.OperatorWorkers != 0 {
+		return fmt.Errorf("set only one of operator_workers or scheduler_workers (scheduler_workers is deprecated)")
+	}
+	slog.Warn("scheduler_workers is deprecated; use operator_workers", "scheduler_workers", c.SchedulerWorkers)
+	c.OperatorWorkers = c.SchedulerWorkers
+	c.SchedulerWorkers = 0
+	return nil
+}
+
 // Validate checks the configuration for required fields and consistency.
 func (c *ServerConfig) Validate() error {
+	if err := c.resolveDeprecatedOperatorWorkers(); err != nil {
+		return err
+	}
+
 	// The database registry is required in both local mode and gRPC mode:
 	// local environments provide DSNs, while remote environments provide the
 	// server-owned target/deployment route.

--- a/pkg/api/control_handlers.go
+++ b/pkg/api/control_handlers.go
@@ -603,7 +603,7 @@ func (s *Service) tryImmediateStopAfterQueue(ctx context.Context, client tern.Cl
 			"environment", apply.Environment,
 			"requested_by", caller)
 		s.logControlOperationForApply(ctx, apply, caller, storage.LogEventStopRequested,
-			"Immediate stop skipped for remote Tern client; durable scheduler owner will reconcile stop state")
+			"Immediate stop skipped for remote Tern client; durable operator owner will reconcile stop state")
 		return
 	}
 	resp, err := client.Stop(ctx, &ternv1.StopRequest{
@@ -1320,7 +1320,7 @@ func startNotAllowedForState(apply *storage.Apply) error {
 	case state.IsState(apply.State, state.Apply.RevertWindow):
 		return controlConflictf("schema change is in revert window; use revert or skip-revert instead of start")
 	case state.IsState(apply.State, state.Apply.FailedRetryable):
-		return controlConflictf("schema change is waiting for scheduler retry; start is not allowed")
+		return controlConflictf("schema change is waiting for operator retry; start is not allowed")
 	case state.IsState(apply.State, state.Apply.Failed):
 		return controlConflictf("schema change failed and cannot be started")
 	case state.IsState(apply.State, state.Apply.Completed):

--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -1256,7 +1256,7 @@ func TestExecuteApplyWakesOperatorForQueuedLocalApply(t *testing.T) {
 	applies := &capturingApplyStore{findCh: make(chan struct{}, 1)}
 	mock := &mockTernClient{resumeCh: make(chan *storage.Apply, 1)}
 	svc, _ := newExecuteApplyTestService(mock, applies)
-	svc.config.SchedulerWorkers = 1
+	svc.config.OperatorWorkers = 1
 	require.NoError(t, svc.SetOperatorPollInterval(time.Hour))
 	svc.StartOperator(t.Context())
 	t.Cleanup(svc.StopOperator)
@@ -2501,7 +2501,7 @@ func TestStartHandler(t *testing.T) {
 			{
 				name:        "failed retryable",
 				applyState:  state.Apply.FailedRetryable,
-				wantMessage: "scheduler retry",
+				wantMessage: "operator retry",
 			},
 			{
 				name:        "failed",

--- a/pkg/api/operator.go
+++ b/pkg/api/operator.go
@@ -30,9 +30,9 @@ const (
 	// min(operatorPollInterval, ApplyOperationHeartbeatInterval).
 	ApplyOperationHeartbeatInterval = 10 * time.Second
 
-	// DefaultSchedulerWorkers is the number of concurrent operator workers
-	// when not configured via scheduler_workers in the server config.
-	DefaultSchedulerWorkers = 4
+	// DefaultOperatorWorkers is the number of concurrent operator workers
+	// when not configured via operator_workers in the server config.
+	DefaultOperatorWorkers = 4
 )
 
 // StartOperator starts the background operator worker pool.
@@ -42,7 +42,7 @@ const (
 // includes queued applies, crash recovery for applies with stale heartbeats,
 // and retry recovery for transient engine failures.
 //
-// Launches N concurrent workers (configured via scheduler_workers in config).
+// Launches N concurrent workers (configured via operator_workers in config).
 // Each worker independently claims applies using FOR UPDATE SKIP LOCKED.
 // Call StopOperator to gracefully stop.
 func (s *Service) StartOperator(ctx context.Context) {
@@ -53,9 +53,9 @@ func (s *Service) StartOperator(ctx context.Context) {
 		return
 	}
 
-	workers := s.config.SchedulerWorkers
+	workers := s.config.OperatorWorkers
 	if workers <= 0 {
-		workers = DefaultSchedulerWorkers
+		workers = DefaultOperatorWorkers
 	}
 
 	stop := make(chan struct{})
@@ -160,7 +160,7 @@ func (s *Service) recoverApplies(ctx context.Context, workerID int) {
 	expired, err := s.storage.Applies().ExpireRetryable(ctx)
 	if err != nil {
 		s.logger.Error("operator: failed to expire retryable applies", "worker", workerID, "error", err)
-		metrics.RecordSchedulerClaimFailure(ctx, "expire_retryable_error")
+		metrics.RecordOperatorClaimFailure(ctx, "expire_retryable_error")
 		return
 	}
 	for _, expiration := range expired {
@@ -172,7 +172,7 @@ func (s *Service) recoverApplies(ctx context.Context, workerID int) {
 			"environment", apply.Environment,
 			"attempt", apply.Attempt,
 			"reason", expiration.Reason)
-		metrics.RecordSchedulerResumeFailure(ctx, apply.Database, apply.Deployment, apply.Environment, string(expiration.Reason))
+		metrics.RecordOperatorResumeFailure(ctx, apply.Database, apply.Deployment, apply.Environment, string(expiration.Reason))
 	}
 
 	owner := operatorLeaseOwner(workerID)
@@ -185,7 +185,7 @@ func (s *Service) recoverApplies(ctx context.Context, workerID int) {
 	apply, err := s.storage.Applies().FindNextApply(ctx, owner)
 	if err != nil {
 		s.logger.Error("operator: failed to claim apply", "worker", workerID, "lease_owner", owner, "error", err)
-		metrics.RecordSchedulerClaimFailure(ctx, "storage_error")
+		metrics.RecordOperatorClaimFailure(ctx, "storage_error")
 		return
 	}
 
@@ -201,7 +201,7 @@ func (s *Service) recoverApplies(ctx context.Context, workerID int) {
 			"apply_id", apply.ApplyIdentifier,
 			"database", apply.Database,
 			"environment", apply.Environment)
-		metrics.RecordSchedulerClaimFailure(ctx, "missing_lease_token")
+		metrics.RecordOperatorClaimFailure(ctx, "missing_lease_token")
 		return
 	}
 	ctx = storage.WithApplyLease(ctx, lease)
@@ -220,7 +220,7 @@ func (s *Service) recoverApplyOperation(ctx context.Context, workerID int, owner
 	op, err := s.storage.ApplyOperations().FindNextApplyOperation(ctx)
 	if err != nil {
 		s.logger.Error("operator: failed to claim apply_operation", "worker", workerID, "lease_owner", owner, "error", err)
-		metrics.RecordSchedulerClaimFailure(ctx, "operation_storage_error")
+		metrics.RecordOperatorClaimFailure(ctx, "operation_storage_error")
 		return
 	}
 	if op == nil {
@@ -240,7 +240,7 @@ func (s *Service) recoverApplyOperation(ctx context.Context, workerID int, owner
 			"apply_db_id", op.ApplyID,
 			"deployment", op.Deployment,
 			"error", err)
-		metrics.RecordSchedulerClaimFailure(ctx, "operation_parent_claim_error")
+		metrics.RecordOperatorClaimFailure(ctx, "operation_parent_claim_error")
 		return
 	}
 	if apply == nil {
@@ -265,7 +265,7 @@ func (s *Service) recoverApplyOperation(ctx context.Context, workerID int, owner
 			"database", apply.Database,
 			"deployment", op.Deployment,
 			"environment", apply.Environment)
-		metrics.RecordSchedulerClaimFailure(ctx, "missing_lease_token")
+		metrics.RecordOperatorClaimFailure(ctx, "missing_lease_token")
 		return
 	}
 	leasedCtx := storage.WithApplyLease(ctx, lease)
@@ -325,7 +325,7 @@ func (s *Service) reconcileUnclaimableParent(ctx context.Context, workerID int, 
 			"apply_db_id", op.ApplyID,
 			"deployment", op.Deployment,
 			"error", err)
-		metrics.RecordSchedulerClaimFailure(ctx, "operation_parent_not_claimable")
+		metrics.RecordOperatorClaimFailure(ctx, "operation_parent_not_claimable")
 		return
 	}
 	if parent == nil {
@@ -334,7 +334,7 @@ func (s *Service) reconcileUnclaimableParent(ctx context.Context, workerID int, 
 			"apply_operation_id", op.ID,
 			"apply_db_id", op.ApplyID,
 			"deployment", op.Deployment)
-		metrics.RecordSchedulerClaimFailure(ctx, "operation_parent_not_claimable")
+		metrics.RecordOperatorClaimFailure(ctx, "operation_parent_not_claimable")
 		return
 	}
 	if state.IsTerminalApplyState(parent.State) {
@@ -355,7 +355,7 @@ func (s *Service) reconcileUnclaimableParent(ctx context.Context, workerID int, 
 		"deployment", op.Deployment,
 		"environment", parent.Environment,
 		"state", parent.State)
-	metrics.RecordSchedulerClaimFailure(ctx, "operation_parent_not_claimable")
+	metrics.RecordOperatorClaimFailure(ctx, "operation_parent_not_claimable")
 }
 
 // resumeClaimedApply drives a claimed apply through ResumeApply with the apply
@@ -385,7 +385,7 @@ func (s *Service) resumeClaimedApply(ctx context.Context, workerID int, apply *s
 			"database", apply.Database,
 			"environment", apply.Environment,
 			"error", err)
-		metrics.RecordSchedulerResumeFailure(ctx, apply.Database, "", apply.Environment, "missing_deployment")
+		metrics.RecordOperatorResumeFailure(ctx, apply.Database, "", apply.Environment, "missing_deployment")
 		return false
 	}
 	client, err := s.TernClient(deployment, apply.Environment)
@@ -397,7 +397,7 @@ func (s *Service) resumeClaimedApply(ctx context.Context, workerID int, apply *s
 			"deployment", deployment,
 			"environment", apply.Environment,
 			"error", err)
-		metrics.RecordSchedulerResumeFailure(ctx, apply.Database, deployment, apply.Environment, "no_client")
+		metrics.RecordOperatorResumeFailure(ctx, apply.Database, deployment, apply.Environment, "no_client")
 		return false
 	}
 
@@ -419,7 +419,7 @@ func (s *Service) resumeClaimedApply(ctx context.Context, workerID int, apply *s
 				"deployment", deployment,
 				"environment", apply.Environment,
 				"error", err)
-			metrics.RecordSchedulerResumeFailure(ctx, apply.Database, deployment, apply.Environment, "lease_lost")
+			metrics.RecordOperatorResumeFailure(ctx, apply.Database, deployment, apply.Environment, "lease_lost")
 			if retryableClaim {
 				metrics.AdjustActiveApplies(ctx, -1, apply.Database, deployment, apply.Environment)
 			}
@@ -445,7 +445,7 @@ func (s *Service) resumeClaimedApply(ctx context.Context, workerID int, apply *s
 			"deployment", deployment,
 			"environment", apply.Environment,
 			"error", err)
-		metrics.RecordSchedulerResumeFailure(ctx, apply.Database, deployment, apply.Environment, "resume_error")
+		metrics.RecordOperatorResumeFailure(ctx, apply.Database, deployment, apply.Environment, "resume_error")
 		if retryableClaim {
 			metrics.AdjustActiveApplies(ctx, -1, apply.Database, deployment, apply.Environment)
 		}
@@ -461,8 +461,8 @@ func (s *Service) resumeClaimedApply(ctx context.Context, workerID int, apply *s
 		"environment", apply.Environment,
 		"previous_state", previousState,
 		"duration", duration)
-	metrics.RecordSchedulerResume(ctx, apply.Database, deployment, apply.Environment, previousState)
-	metrics.RecordSchedulerClaimDuration(ctx, duration, apply.Database, deployment, apply.Environment, previousState)
+	metrics.RecordOperatorResume(ctx, apply.Database, deployment, apply.Environment, previousState)
+	metrics.RecordOperatorClaimDuration(ctx, duration, apply.Database, deployment, apply.Environment, previousState)
 	return true
 }
 

--- a/pkg/api/operator_test.go
+++ b/pkg/api/operator_test.go
@@ -4,17 +4,30 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestSchedulerWorkersConfig(t *testing.T) {
+func TestOperatorWorkersConfig(t *testing.T) {
 	t.Run("default workers", func(t *testing.T) {
 		config := &ServerConfig{}
-		assert.Equal(t, 0, config.SchedulerWorkers)
-		assert.Equal(t, 4, DefaultSchedulerWorkers)
+		assert.Equal(t, 0, config.OperatorWorkers)
+		assert.Equal(t, 4, DefaultOperatorWorkers)
 	})
 
 	t.Run("configured workers", func(t *testing.T) {
-		config := &ServerConfig{SchedulerWorkers: 3}
-		assert.Equal(t, 3, config.SchedulerWorkers)
+		config := &ServerConfig{OperatorWorkers: 3}
+		assert.Equal(t, 3, config.OperatorWorkers)
+	})
+
+	t.Run("deprecated scheduler_workers folds into operator_workers", func(t *testing.T) {
+		config := &ServerConfig{SchedulerWorkers: 2}
+		require.NoError(t, config.resolveDeprecatedOperatorWorkers())
+		assert.Equal(t, 2, config.OperatorWorkers)
+		assert.Equal(t, 0, config.SchedulerWorkers)
+	})
+
+	t.Run("setting both keys is rejected", func(t *testing.T) {
+		config := &ServerConfig{OperatorWorkers: 4, SchedulerWorkers: 2}
+		assert.Error(t, config.resolveDeprecatedOperatorWorkers())
 	})
 }

--- a/pkg/api/telemetry_test.go
+++ b/pkg/api/telemetry_test.go
@@ -720,6 +720,7 @@ func TestRecordOperatorMetrics(t *testing.T) {
 	metrics.RecordOperatorClaimFailure(t.Context(), "storage_error")
 	metrics.RecordOperatorClaimFailure(t.Context(), "expire_retryable_error")
 	metrics.RecordOperatorClaimFailure(t.Context(), "missing_lease_token")
+	metrics.RecordOperatorClaimFailure(t.Context(), "operation_parent_not_claimable")
 	metrics.RecordOperatorClaimDuration(t.Context(), 50*time.Millisecond, "testdb", "pie", "staging", "running")
 
 	var rm metricdata.ResourceMetrics
@@ -729,6 +730,7 @@ func TestRecordOperatorMetrics(t *testing.T) {
 	var sawExpireRetryableError bool
 	var sawMissingLeaseToken bool
 	var sawLeaseLost bool
+	var sawOperationParentNotClaimable bool
 	for _, sm := range rm.ScopeMetrics {
 		for _, m := range sm.Metrics {
 			names[m.Name] = true
@@ -747,6 +749,8 @@ func TestRecordOperatorMetrics(t *testing.T) {
 					sawMissingLeaseToken = true
 				case "lease_lost":
 					sawLeaseLost = true
+				case "operation_parent_not_claimable":
+					sawOperationParentNotClaimable = true
 				}
 			}
 		}
@@ -763,6 +767,7 @@ func TestRecordOperatorMetrics(t *testing.T) {
 	assert.True(t, sawExpireRetryableError, "expected expire_retryable_error claim failure reason to be preserved")
 	assert.True(t, sawMissingLeaseToken, "expected missing_lease_token claim failure reason to be preserved")
 	assert.True(t, sawLeaseLost, "expected lease_lost resume failure reason to be recorded")
+	assert.True(t, sawOperationParentNotClaimable, "expected operation_parent_not_claimable claim failure reason to be preserved, not collapsed to unknown")
 }
 
 func TestRecordRemoteDeploymentHealthMetrics(t *testing.T) {

--- a/pkg/api/telemetry_test.go
+++ b/pkg/api/telemetry_test.go
@@ -258,10 +258,10 @@ func TestSchemaBotMetricsIncludeEnvironmentAttribute(t *testing.T) {
 	metrics.RecordRemoteDeploymentHealth(t.Context(), "pie", "staging", true)
 	metrics.RecordRemoteDeploymentHealthCheck(t.Context(), "pie", "staging", "success", "healthy")
 	metrics.RecordLockOperation(t.Context(), "acquire", "mydb", "success")
-	metrics.RecordSchedulerResume(t.Context(), "mydb", "pie", "staging", "running")
-	metrics.RecordSchedulerResumeFailure(t.Context(), "mydb", "pie", "staging", "no_client")
-	metrics.RecordSchedulerClaimFailure(t.Context(), "storage_error")
-	metrics.RecordSchedulerClaimDuration(t.Context(), time.Second, "mydb", "pie", "staging", "running")
+	metrics.RecordOperatorResume(t.Context(), "mydb", "pie", "staging", "running")
+	metrics.RecordOperatorResumeFailure(t.Context(), "mydb", "pie", "staging", "no_client")
+	metrics.RecordOperatorClaimFailure(t.Context(), "storage_error")
+	metrics.RecordOperatorClaimDuration(t.Context(), time.Second, "mydb", "pie", "staging", "running")
 	metrics.RecordSchemaRequestError(t.Context(), "org/repo", "apply", "mydb", "staging", "invalid_config")
 	metrics.RecordGitHubRequest(t.Context(), metrics.GitHubRequestSample{
 		Operation:  metrics.GitHubOperationFetchPullRequest,
@@ -315,6 +315,9 @@ func metricHasDeploymentAttribute(metricName string) bool {
 		"schemabot.control_operations_total",
 		"schemabot.remote_deployment.health",
 		"schemabot.remote_deployment.health_checks_total",
+		"schemabot.operator.resumed_total",
+		"schemabot.operator.resume_failures_total",
+		"schemabot.operator.claim_duration_seconds",
 		"schemabot.scheduler.resumed_total",
 		"schemabot.scheduler.resume_failures_total",
 		"schemabot.scheduler.claim_duration_seconds":
@@ -701,7 +704,7 @@ func TestRecordLockOperationMetric(t *testing.T) {
 	assert.True(t, names["schemabot.lock_operations_total"], "expected schemabot.lock_operations_total")
 }
 
-func TestRecordSchedulerMetrics(t *testing.T) {
+func TestRecordOperatorMetrics(t *testing.T) {
 	reader := sdkmetric.NewManualReader()
 	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
 	prevMP := otel.GetMeterProvider()
@@ -711,13 +714,13 @@ func TestRecordSchedulerMetrics(t *testing.T) {
 		require.NoError(t, mp.Shutdown(t.Context()))
 	})
 
-	metrics.RecordSchedulerResume(t.Context(), "testdb", "pie", "staging", "running")
-	metrics.RecordSchedulerResumeFailure(t.Context(), "testdb", "pie", "staging", "no_client")
-	metrics.RecordSchedulerResumeFailure(t.Context(), "testdb", "pie", "staging", "lease_lost")
-	metrics.RecordSchedulerClaimFailure(t.Context(), "storage_error")
-	metrics.RecordSchedulerClaimFailure(t.Context(), "expire_retryable_error")
-	metrics.RecordSchedulerClaimFailure(t.Context(), "missing_lease_token")
-	metrics.RecordSchedulerClaimDuration(t.Context(), 50*time.Millisecond, "testdb", "pie", "staging", "running")
+	metrics.RecordOperatorResume(t.Context(), "testdb", "pie", "staging", "running")
+	metrics.RecordOperatorResumeFailure(t.Context(), "testdb", "pie", "staging", "no_client")
+	metrics.RecordOperatorResumeFailure(t.Context(), "testdb", "pie", "staging", "lease_lost")
+	metrics.RecordOperatorClaimFailure(t.Context(), "storage_error")
+	metrics.RecordOperatorClaimFailure(t.Context(), "expire_retryable_error")
+	metrics.RecordOperatorClaimFailure(t.Context(), "missing_lease_token")
+	metrics.RecordOperatorClaimDuration(t.Context(), 50*time.Millisecond, "testdb", "pie", "staging", "running")
 
 	var rm metricdata.ResourceMetrics
 	require.NoError(t, reader.Collect(t.Context(), &rm))
@@ -729,7 +732,7 @@ func TestRecordSchedulerMetrics(t *testing.T) {
 	for _, sm := range rm.ScopeMetrics {
 		for _, m := range sm.Metrics {
 			names[m.Name] = true
-			if m.Name != "schemabot.scheduler.claim_failures_total" && m.Name != "schemabot.scheduler.resume_failures_total" {
+			if m.Name != "schemabot.operator.claim_failures_total" && m.Name != "schemabot.operator.resume_failures_total" {
 				continue
 			}
 			sum, ok := m.Data.(metricdata.Sum[int64])
@@ -748,10 +751,15 @@ func TestRecordSchedulerMetrics(t *testing.T) {
 			}
 		}
 	}
-	assert.True(t, names["schemabot.scheduler.resumed_total"], "expected schemabot.scheduler.resumed_total")
-	assert.True(t, names["schemabot.scheduler.resume_failures_total"], "expected schemabot.scheduler.resume_failures_total")
-	assert.True(t, names["schemabot.scheduler.claim_failures_total"], "expected schemabot.scheduler.claim_failures_total")
-	assert.True(t, names["schemabot.scheduler.claim_duration_seconds"], "expected schemabot.scheduler.claim_duration_seconds")
+	assert.True(t, names["schemabot.operator.resumed_total"], "expected schemabot.operator.resumed_total")
+	assert.True(t, names["schemabot.operator.resume_failures_total"], "expected schemabot.operator.resume_failures_total")
+	assert.True(t, names["schemabot.operator.claim_failures_total"], "expected schemabot.operator.claim_failures_total")
+	assert.True(t, names["schemabot.operator.claim_duration_seconds"], "expected schemabot.operator.claim_duration_seconds")
+	// Deprecated scheduler-named aliases are dual-emitted for one release.
+	assert.True(t, names["schemabot.scheduler.resumed_total"], "expected deprecated schemabot.scheduler.resumed_total alias")
+	assert.True(t, names["schemabot.scheduler.resume_failures_total"], "expected deprecated schemabot.scheduler.resume_failures_total alias")
+	assert.True(t, names["schemabot.scheduler.claim_failures_total"], "expected deprecated schemabot.scheduler.claim_failures_total alias")
+	assert.True(t, names["schemabot.scheduler.claim_duration_seconds"], "expected deprecated schemabot.scheduler.claim_duration_seconds alias")
 	assert.True(t, sawExpireRetryableError, "expected expire_retryable_error claim failure reason to be preserved")
 	assert.True(t, sawMissingLeaseToken, "expected missing_lease_token claim failure reason to be preserved")
 	assert.True(t, sawLeaseLost, "expected lease_lost resume failure reason to be recorded")

--- a/pkg/metrics/README.md
+++ b/pkg/metrics/README.md
@@ -86,7 +86,7 @@ available, such as `repository`, `github_app`, and `installation_id`.
 
 **status** (GitHub API): `success`, `error`, `unknown`
 
-**reason** (operator claim failures): `storage_error`, `expire_retryable_error`, `missing_lease_token`, `unknown`
+**reason** (operator claim failures): `storage_error`, `expire_retryable_error`, `missing_lease_token`, `operation_storage_error`, `operation_parent_claim_error`, `operation_parent_not_claimable`, `unknown`
 
 **reason** (operator resume failures): `missing_deployment`, `no_client`, `resume_error`, `lease_lost`, `retry_budget_exhausted`, `recovery_window_expired`
 

--- a/pkg/metrics/README.md
+++ b/pkg/metrics/README.md
@@ -31,10 +31,12 @@ available, such as `repository`, `github_app`, and `installation_id`.
 | `schemabot.github.rate_limit.used` | Gauge | environment, operation, resource, repository, github_app, installation_id | GitHub primary rate limit requests used for the observed API resource |
 | `schemabot.control_operations_total` | Counter | operation, database, environment, status | Control operations (cutover, stop, start, etc.) |
 | `schemabot.lock_operations_total` | Counter | operation, database, environment, status | Lock acquire/release operations |
-| `schemabot.scheduler.resumed_total` | Counter | database, environment, previous_state | Applies resumed by the scheduler |
-| `schemabot.scheduler.resume_failures_total` | Counter | database, environment, reason | Scheduler resume attempts that failed |
-| `schemabot.scheduler.claim_failures_total` | Counter | environment, reason | Scheduler claim attempts that failed |
-| `schemabot.scheduler.claim_duration_seconds` | Histogram | database, environment, previous_state | Scheduler claim and resume duration |
+| `schemabot.operator.resumed_total` | Counter | database, environment, previous_state | Applies resumed by the operator |
+| `schemabot.operator.resume_failures_total` | Counter | database, environment, reason | Operator resume attempts that failed |
+| `schemabot.operator.claim_failures_total` | Counter | environment, reason | Operator claim attempts that failed |
+| `schemabot.operator.claim_duration_seconds` | Histogram | database, environment, previous_state | Operator claim and resume duration |
+
+> **Deprecated aliases:** the `schemabot.scheduler.*` series (`resumed_total`, `resume_failures_total`, `claim_failures_total`, `claim_duration_seconds`) is still emitted alongside the `schemabot.operator.*` series for one release so dashboards and alerts can migrate. The scheduler-named series will be removed afterward.
 
 ### Attribute Values
 
@@ -84,9 +86,9 @@ available, such as `repository`, `github_app`, and `installation_id`.
 
 **status** (GitHub API): `success`, `error`, `unknown`
 
-**reason** (scheduler claim failures): `storage_error`, `expire_retryable_error`, `missing_lease_token`, `unknown`
+**reason** (operator claim failures): `storage_error`, `expire_retryable_error`, `missing_lease_token`, `unknown`
 
-**reason** (scheduler resume failures): `missing_deployment`, `no_client`, `resume_error`, `lease_lost`, `retry_budget_exhausted`, `recovery_window_expired`
+**reason** (operator resume failures): `missing_deployment`, `no_client`, `resume_error`, `lease_lost`, `retry_budget_exhausted`, `recovery_window_expired`
 
 ### Check Ownership Misses
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -547,9 +547,12 @@ func RecordOperatorResumeFailure(ctx context.Context, database, deployment, envi
 }
 
 var knownOperatorClaimFailureReasons = map[string]bool{
-	"expire_retryable_error": true,
-	"missing_lease_token":    true,
-	"storage_error":          true,
+	"expire_retryable_error":         true,
+	"missing_lease_token":            true,
+	"storage_error":                  true,
+	"operation_storage_error":        true,
+	"operation_parent_claim_error":   true,
+	"operation_parent_not_claimable": true,
 }
 
 // RecordOperatorClaimFailure increments the operator claim failure counter.

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -499,96 +499,91 @@ func RecordLockOperation(ctx context.Context, operation, database, status string
 	)
 }
 
-// RecordSchedulerResume increments the scheduler resumed counter when an apply is
+// operatorMetricNames returns the canonical operator metric name alongside its
+// deprecated schemabot.scheduler.* alias. Both are emitted for one release so
+// dashboards and alerts can migrate before the legacy series is removed.
+func operatorMetricNames(suffix string) [2]string {
+	return [2]string{"schemabot.operator." + suffix, "schemabot.scheduler." + suffix}
+}
+
+// addOperatorCounter increments an operator counter and its deprecated
+// scheduler-named alias with the same value and attributes.
+func addOperatorCounter(ctx context.Context, suffix, description, unit string, value int64, attrs ...attribute.KeyValue) {
+	meter := otel.Meter(meterName)
+	for _, name := range operatorMetricNames(suffix) {
+		counter, err := meter.Int64Counter(name,
+			otelmetric.WithDescription(description),
+			otelmetric.WithUnit(unit),
+		)
+		if err != nil {
+			slog.Warn("failed to create operator counter", "metric", name, "error", err)
+			continue
+		}
+		counter.Add(ctx, value, otelmetric.WithAttributes(attrs...))
+	}
+}
+
+// RecordOperatorResume increments the operator resumed counter when an apply is
 // successfully claimed and resumed.
-func RecordSchedulerResume(ctx context.Context, database, deployment, environment, previousState string) {
-	meter := otel.Meter(meterName)
-	counter, err := meter.Int64Counter("schemabot.scheduler.resumed_total",
-		otelmetric.WithDescription("Total number of applies resumed by the scheduler"),
-		otelmetric.WithUnit("{apply}"),
-	)
-	if err != nil {
-		slog.Warn("failed to create scheduler resumed counter", "error", err)
-		return
-	}
-	counter.Add(ctx, 1,
-		otelmetric.WithAttributes(
-			attribute.String("database", database),
-			DeploymentAttribute(deployment),
-			EnvironmentAttribute(environment),
-			attribute.String("previous_state", previousState),
-		),
+func RecordOperatorResume(ctx context.Context, database, deployment, environment, previousState string) {
+	addOperatorCounter(ctx, "resumed_total",
+		"Total number of applies resumed by the operator", "{apply}", 1,
+		attribute.String("database", database),
+		DeploymentAttribute(deployment),
+		EnvironmentAttribute(environment),
+		attribute.String("previous_state", previousState),
 	)
 }
 
-// RecordSchedulerResumeFailure increments the scheduler resume failure counter.
-func RecordSchedulerResumeFailure(ctx context.Context, database, deployment, environment, reason string) {
-	meter := otel.Meter(meterName)
-	counter, err := meter.Int64Counter("schemabot.scheduler.resume_failures_total",
-		otelmetric.WithDescription("Total number of scheduler resume attempts that failed"),
-		otelmetric.WithUnit("{apply}"),
-	)
-	if err != nil {
-		slog.Warn("failed to create scheduler resume failure counter", "error", err)
-		return
-	}
-	counter.Add(ctx, 1,
-		otelmetric.WithAttributes(
-			attribute.String("database", database),
-			DeploymentAttribute(deployment),
-			EnvironmentAttribute(environment),
-			attribute.String("reason", reason),
-		),
+// RecordOperatorResumeFailure increments the operator resume failure counter.
+func RecordOperatorResumeFailure(ctx context.Context, database, deployment, environment, reason string) {
+	addOperatorCounter(ctx, "resume_failures_total",
+		"Total number of operator resume attempts that failed", "{apply}", 1,
+		attribute.String("database", database),
+		DeploymentAttribute(deployment),
+		EnvironmentAttribute(environment),
+		attribute.String("reason", reason),
 	)
 }
 
-var knownSchedulerClaimFailureReasons = map[string]bool{
+var knownOperatorClaimFailureReasons = map[string]bool{
 	"expire_retryable_error": true,
 	"missing_lease_token":    true,
 	"storage_error":          true,
 }
 
-// RecordSchedulerClaimFailure increments the scheduler claim failure counter.
-func RecordSchedulerClaimFailure(ctx context.Context, reason string) {
-	if !knownSchedulerClaimFailureReasons[reason] {
+// RecordOperatorClaimFailure increments the operator claim failure counter.
+func RecordOperatorClaimFailure(ctx context.Context, reason string) {
+	if !knownOperatorClaimFailureReasons[reason] {
 		reason = "unknown"
 	}
-	meter := otel.Meter(meterName)
-	counter, err := meter.Int64Counter("schemabot.scheduler.claim_failures_total",
-		otelmetric.WithDescription("Total number of scheduler claim attempts that failed"),
-		otelmetric.WithUnit("{attempt}"),
-	)
-	if err != nil {
-		slog.Warn("failed to create scheduler claim failure counter", "error", err)
-		return
-	}
-	counter.Add(ctx, 1,
-		otelmetric.WithAttributes(
-			EnvironmentAttribute(""),
-			attribute.String("reason", reason),
-		),
+	addOperatorCounter(ctx, "claim_failures_total",
+		"Total number of operator claim attempts that failed", "{attempt}", 1,
+		EnvironmentAttribute(""),
+		attribute.String("reason", reason),
 	)
 }
 
-// RecordSchedulerClaimDuration records how long it took to claim and resume an apply.
-func RecordSchedulerClaimDuration(ctx context.Context, duration time.Duration, database, deployment, environment, previousState string) {
+// RecordOperatorClaimDuration records how long it took to claim and resume an apply.
+func RecordOperatorClaimDuration(ctx context.Context, duration time.Duration, database, deployment, environment, previousState string) {
 	meter := otel.Meter(meterName)
-	hist, err := meter.Float64Histogram("schemabot.scheduler.claim_duration_seconds",
-		otelmetric.WithDescription("Duration of scheduler claim + resume operations"),
-		otelmetric.WithUnit("s"),
+	attrs := otelmetric.WithAttributes(
+		attribute.String("database", database),
+		DeploymentAttribute(deployment),
+		EnvironmentAttribute(environment),
+		attribute.String("previous_state", previousState),
 	)
-	if err != nil {
-		slog.Warn("failed to create scheduler claim duration histogram", "error", err)
-		return
+	for _, name := range operatorMetricNames("claim_duration_seconds") {
+		hist, err := meter.Float64Histogram(name,
+			otelmetric.WithDescription("Duration of operator claim + resume operations"),
+			otelmetric.WithUnit("s"),
+		)
+		if err != nil {
+			slog.Warn("failed to create operator claim duration histogram", "metric", name, "error", err)
+			continue
+		}
+		hist.Record(ctx, duration.Seconds(), attrs)
 	}
-	hist.Record(ctx, duration.Seconds(),
-		otelmetric.WithAttributes(
-			attribute.String("database", database),
-			DeploymentAttribute(deployment),
-			EnvironmentAttribute(environment),
-			attribute.String("previous_state", previousState),
-		),
-	)
 }
 
 // knownWebhookEvents limits metric cardinality to expected GitHub event types.

--- a/pkg/tern/local_apply_grouped.go
+++ b/pkg/tern/local_apply_grouped.go
@@ -576,7 +576,7 @@ func (c *LocalClient) handleAtomicProgressTick(ctx context.Context, eng engine.E
 		}
 		eventMessage := fmt.Sprintf("Apply completed with state: %s", result.State)
 		if retryableFailure {
-			eventMessage = "Apply paused for scheduler retry after retryable engine failure"
+			eventMessage = "Apply paused for operator retry after retryable engine failure"
 		}
 		c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventStateTransition, storage.LogSourceSchemaBot,
 			eventMessage, ps.lastTaskState, apply.State)

--- a/pkg/tern/local_apply_sequential.go
+++ b/pkg/tern/local_apply_sequential.go
@@ -246,7 +246,7 @@ func (c *LocalClient) startApplyHeartbeat(ctx context.Context, apply *storage.Ap
 							"database", apply.Database,
 							"environment", apply.Environment,
 							"error", err)
-						metrics.RecordSchedulerResumeFailure(hbCtx, apply.Database, apply.Deployment, apply.Environment, "lease_lost")
+						metrics.RecordOperatorResumeFailure(hbCtx, apply.Database, apply.Deployment, apply.Environment, "lease_lost")
 						for _, cancel := range cancelApply {
 							if cancel != nil {
 								cancel()

--- a/pkg/webhook/templates/issue_comment.go
+++ b/pkg/webhook/templates/issue_comment.go
@@ -60,7 +60,7 @@ func RenderControlMissingApplyID(action string) string {
 func RenderStopCommandAccepted(data StopCommandAcceptedData) string {
 	statusLine := "Stop request accepted. SchemaBot will stop this schema change; status remains available from the PR progress comment or CLI."
 	if data.Status == "already_requested" {
-		statusLine = "Stop was already requested. SchemaBot will keep the existing stop request pending until the scheduler owner finishes it."
+		statusLine = "Stop was already requested. SchemaBot will keep the existing stop request pending until the operator owner finishes it."
 	}
 
 	body := "## Stop Request Accepted\n\n" +

--- a/pkg/webhook/webhook_e2e_test.go
+++ b/pkg/webhook/webhook_e2e_test.go
@@ -195,7 +195,7 @@ func setupE2EService(t *testing.T, appDBName string) *api.Service {
 	t.Cleanup(func() { _ = localClient.Close() })
 
 	serverConfig := &api.ServerConfig{
-		SchedulerWorkers: 1,
+		OperatorWorkers: 1,
 		Databases: map[string]api.DatabaseConfig{
 			appDBName: {
 				Type: "mysql",


### PR DESCRIPTION
## What and Why ?
Finishes the scheduler→operator rename for the operator-contract surfaces that
the internal-only rename intentionally left alone: the worker-count config key,
the resume/claim metrics, and user-visible runtime text. These are kept separate
so the client-facing cut-over is reviewable on its own.

## Changes
- **Config:** `scheduler_workers` → `operator_workers`. The old key stays as a deprecated alias (the config decoder runs with `KnownFields(true)`, so an undeclared key would reject existing configs) and is folded into the new field with a deprecation warning; setting both is an error.
- **Metrics:** `schemabot.scheduler.*` → `schemabot.operator.*`, dual-emitting both series for one release so dashboards/alerts can migrate.
- **User-visible text:** PR progress comment, API conflict/control-event messages, and a persisted apply event-log message.
- **Docs:** configuration and metrics references updated with back-compat notes.

## Back-compat
Both the config alias and the metric dual-emit are temporary and slated for
removal one release after this soaks, keeping the cut-over a no-op for operators
and dashboards.

Stacked on the internal-rename PR.
