### PR TITLE
feat(config): add optional deployment_order for multi-deployment environments

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -152,6 +152,10 @@ databases:
     type: mysql
     environments:
       production:
+        deployment_order:
+          - payments-c
+          - payments-a
+          - payments-b
         deployments:
           payments-a:
             target: "payments"
@@ -176,7 +180,9 @@ Rules:
 - Until the orchestration path is wired, the map MUST contain exactly one entry; multi-entry maps are rejected at config load.
 - Single-deployment environments should continue to use the scalar `target` / `deployment` shape.
 
-Resolution order from the config layer is deterministic and sorted by deployment key. Server-owned cross-deployment ordering (e.g. rolling deploys across regions) is a forthcoming addition that will live alongside `environment_order`.
+### Deployment Order
+
+`deployment_order` defines the rollout order across the `deployments` map for an environment, analogous to the server-wide `environment_order`. When set, it MUST list every key in `deployments` exactly once (no empty, duplicate, or unknown entries) and MUST accompany a `deployments` map. `ResolveDatabaseTargets` then returns deployments in this order. When omitted, deployments resolve in alphabetical key order, which stays the deterministic default.
 
 ## Environment Order
 

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -800,6 +800,11 @@ func orderedDeploymentKeys(deployments map[string]DeploymentTarget, order []stri
 // validateDeploymentOrder checks that deployment_order lists every key in the
 // deployments map exactly once, with no empty, duplicate, or unknown entries.
 func validateDeploymentOrder(deployments map[string]DeploymentTarget, order []string, context string) error {
+	for deployment := range deployments {
+		if deployment == "" {
+			return fmt.Errorf("%s has a deployments map entry with an empty key", context)
+		}
+	}
 	seen := make(map[string]bool, len(order))
 	for _, deployment := range order {
 		if deployment == "" {

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -351,6 +351,13 @@ type EnvironmentConfig struct {
 	//     payments-b: { target: payments }
 	Deployments map[string]DeploymentTarget `yaml:"deployments,omitempty"`
 
+	// DeploymentOrder defines the rollout order of the deployments map for this
+	// environment, analogous to the server-wide EnvironmentOrder. When set it
+	// must list every key in Deployments exactly once; ResolveDatabaseTargets
+	// then returns deployments in this order. When empty, deployments resolve in
+	// alphabetical key order. Only meaningful alongside a Deployments map.
+	DeploymentOrder []string `yaml:"deployment_order,omitempty"`
+
 	// For PlanetScale/Vitess:
 	// Organization is the PlanetScale organization name.
 	// sadscan:disable kingfisher.planetscale.2
@@ -526,6 +533,9 @@ func (c *ServerConfig) Validate() error {
 			hasDSN := envConfig.HasLocalDSN()
 			hasScalarRouting := envConfig.Target != "" || envConfig.Deployment != ""
 			hasMapRouting := envConfig.Deployments != nil
+			if len(envConfig.DeploymentOrder) > 0 && !hasMapRouting {
+				return fmt.Errorf("database %q environment %q sets deployment_order without a deployments map", name, env)
+			}
 			switch {
 			case hasDSN && (hasScalarRouting || hasMapRouting):
 				return fmt.Errorf("database %q environment %q cannot configure both local DSN and target/deployment(s)", name, env)
@@ -539,6 +549,11 @@ func (c *ServerConfig) Validate() error {
 			case hasMapRouting:
 				if len(envConfig.Deployments) == 0 {
 					return fmt.Errorf("database %q environment %q deployments map is empty", name, env)
+				}
+				if len(envConfig.DeploymentOrder) > 0 {
+					if err := validateDeploymentOrder(envConfig.Deployments, envConfig.DeploymentOrder, fmt.Sprintf("database %q environment %q", name, env)); err != nil {
+						return err
+					}
 				}
 				// The multi-deployment apply path (plan, progress, webhook)
 				// is not yet wired to ResolveDatabaseTargets, so accepting a
@@ -758,6 +773,54 @@ func (c *ServerConfig) ResolveDatabaseTarget(database, environment string) (Reso
 	return targets[0], nil
 }
 
+// orderedDeploymentKeys returns the keys of a deployments map in rollout order:
+// the explicit deployment_order when set, otherwise alphabetical for
+// deterministic resolution. When an order is given it is validated to be a
+// permutation of the map keys.
+func orderedDeploymentKeys(deployments map[string]DeploymentTarget, order []string, context string) ([]string, error) {
+	for deployment := range deployments {
+		if deployment == "" {
+			return nil, fmt.Errorf("%s has a deployments map entry with an empty key", context)
+		}
+	}
+	if len(order) == 0 {
+		keys := make([]string, 0, len(deployments))
+		for deployment := range deployments {
+			keys = append(keys, deployment)
+		}
+		slices.Sort(keys)
+		return keys, nil
+	}
+	if err := validateDeploymentOrder(deployments, order, context); err != nil {
+		return nil, err
+	}
+	return slices.Clone(order), nil
+}
+
+// validateDeploymentOrder checks that deployment_order lists every key in the
+// deployments map exactly once, with no empty, duplicate, or unknown entries.
+func validateDeploymentOrder(deployments map[string]DeploymentTarget, order []string, context string) error {
+	seen := make(map[string]bool, len(order))
+	for _, deployment := range order {
+		if deployment == "" {
+			return fmt.Errorf("%s deployment_order has an empty entry", context)
+		}
+		if seen[deployment] {
+			return fmt.Errorf("%s deployment_order has duplicate entry %q", context, deployment)
+		}
+		if _, ok := deployments[deployment]; !ok {
+			return fmt.Errorf("%s deployment_order references unknown deployment %q", context, deployment)
+		}
+		seen[deployment] = true
+	}
+	for deployment := range deployments {
+		if !seen[deployment] {
+			return fmt.Errorf("%s deployment_order is missing deployment %q", context, deployment)
+		}
+	}
+	return nil
+}
+
 // ResolveDatabaseTargets returns the complete routing metadata for a configured
 // database/environment as one or more deployment slices. Single-deployment
 // configurations (scalar target/deployment or local DSN) return a one-element
@@ -792,14 +855,10 @@ func (c *ServerConfig) ResolveDatabaseTargets(database, environment string) ([]R
 		if len(envConfig.Deployments) == 0 {
 			return nil, fmt.Errorf("database %q environment %q deployments map is empty", database, environment)
 		}
-		deployments := make([]string, 0, len(envConfig.Deployments))
-		for deployment := range envConfig.Deployments {
-			if deployment == "" {
-				return nil, fmt.Errorf("database %q environment %q has a deployments map entry with an empty key", database, environment)
-			}
-			deployments = append(deployments, deployment)
+		deployments, err := orderedDeploymentKeys(envConfig.Deployments, envConfig.DeploymentOrder, fmt.Sprintf("database %q environment %q", database, environment))
+		if err != nil {
+			return nil, err
 		}
-		slices.Sort(deployments)
 		out := make([]ResolvedDatabaseTarget, 0, len(deployments))
 		for _, deployment := range deployments {
 			dt := envConfig.Deployments[deployment]

--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -1083,6 +1083,83 @@ func TestServerConfig_ResolveDatabaseTargets_BypassValidate(t *testing.T) {
 	})
 }
 
+// TestServerConfig_ResolveDatabaseTargets_DeploymentOrder exercises the
+// resolver directly on hand-built multi-deployment configs (bypassing the
+// Validate() >1-entry gate) so it can cover deployment_order ordering and the
+// permutation checks the resolver enforces.
+func TestServerConfig_ResolveDatabaseTargets_DeploymentOrder(t *testing.T) {
+	makeCfg := func(env EnvironmentConfig) *ServerConfig {
+		return &ServerConfig{
+			Databases: map[string]DatabaseConfig{
+				"payments": {
+					Type:         "mysql",
+					Environments: map[string]EnvironmentConfig{"production": env},
+				},
+			},
+		}
+	}
+	deployments := map[string]DeploymentTarget{
+		"payments-a": {Target: "payments"},
+		"payments-b": {Target: "payments"},
+		"payments-c": {Target: "payments"},
+	}
+	resolvedOrder := func(t *testing.T, targets []ResolvedDatabaseTarget) []string {
+		t.Helper()
+		order := make([]string, 0, len(targets))
+		for _, rt := range targets {
+			order = append(order, rt.Deployment)
+		}
+		return order
+	}
+
+	t.Run("explicit deployment_order controls rollout order", func(t *testing.T) {
+		cfg := makeCfg(EnvironmentConfig{
+			Deployments:     deployments,
+			DeploymentOrder: []string{"payments-c", "payments-a", "payments-b"},
+		})
+		got, err := cfg.ResolveDatabaseTargets("payments", "production")
+		require.NoError(t, err)
+		assert.Equal(t, []string{"payments-c", "payments-a", "payments-b"}, resolvedOrder(t, got))
+	})
+
+	t.Run("empty deployment_order falls back to alphabetical", func(t *testing.T) {
+		cfg := makeCfg(EnvironmentConfig{Deployments: deployments})
+		got, err := cfg.ResolveDatabaseTargets("payments", "production")
+		require.NoError(t, err)
+		assert.Equal(t, []string{"payments-a", "payments-b", "payments-c"}, resolvedOrder(t, got))
+	})
+
+	t.Run("deployment_order missing a deployment errors", func(t *testing.T) {
+		cfg := makeCfg(EnvironmentConfig{
+			Deployments:     deployments,
+			DeploymentOrder: []string{"payments-a", "payments-b"},
+		})
+		_, err := cfg.ResolveDatabaseTargets("payments", "production")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `deployment_order is missing deployment "payments-c"`)
+	})
+
+	t.Run("deployment_order with duplicate entry errors", func(t *testing.T) {
+		cfg := makeCfg(EnvironmentConfig{
+			Deployments:     deployments,
+			DeploymentOrder: []string{"payments-a", "payments-a", "payments-b", "payments-c"},
+		})
+		_, err := cfg.ResolveDatabaseTargets("payments", "production")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `deployment_order has duplicate entry "payments-a"`)
+	})
+
+	t.Run("deployment_order with unknown deployment errors", func(t *testing.T) {
+		cfg := makeCfg(EnvironmentConfig{
+			Deployments:     deployments,
+			DeploymentOrder: []string{"payments-a", "payments-b", "payments-c", "payments-z"},
+		})
+		_, err := cfg.ResolveDatabaseTargets("payments", "production")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `deployment_order references unknown deployment "payments-z"`)
+	})
+}
+
 func TestServerConfig_DeploymentsMapValidation(t *testing.T) {
 	baseTern := TernConfig{
 		"payments-a": {"production": "tern-a:9090"},
@@ -1177,6 +1254,37 @@ func TestServerConfig_DeploymentsMapValidation(t *testing.T) {
 			},
 			tern:       baseTern,
 			wantErrSub: "cannot configure both local DSN and target/deployment(s)",
+		},
+		{
+			name: "single-entry deployments map with matching deployment_order",
+			envConfig: EnvironmentConfig{
+				Deployments: map[string]DeploymentTarget{
+					"payments-a": {Target: "payments"},
+				},
+				DeploymentOrder: []string{"payments-a"},
+			},
+			tern: baseTern,
+		},
+		{
+			name: "deployment_order referencing unknown deployment is rejected",
+			envConfig: EnvironmentConfig{
+				Deployments: map[string]DeploymentTarget{
+					"payments-a": {Target: "payments"},
+				},
+				DeploymentOrder: []string{"payments-z"},
+			},
+			tern:       baseTern,
+			wantErrSub: `deployment_order references unknown deployment "payments-z"`,
+		},
+		{
+			name: "deployment_order without a deployments map is rejected",
+			envConfig: EnvironmentConfig{
+				Target:          "payments",
+				Deployment:      "payments-a",
+				DeploymentOrder: []string{"payments-a"},
+			},
+			tern:       baseTern,
+			wantErrSub: "sets deployment_order without a deployments map",
 		},
 	}
 

--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -1160,6 +1160,25 @@ func TestServerConfig_ResolveDatabaseTargets_DeploymentOrder(t *testing.T) {
 	})
 }
 
+// validateDeploymentOrder must report an empty deployments map key with the
+// same clear error used elsewhere, rather than the confusing
+// "missing deployment \"\"" that fell out of the permutation check. This guards
+// the Validate() path, which calls validateDeploymentOrder before its own
+// empty-key check.
+func TestValidateDeploymentOrder_EmptyMapKey(t *testing.T) {
+	err := validateDeploymentOrder(
+		map[string]DeploymentTarget{
+			"":           {Target: "payments"},
+			"payments-a": {Target: "payments"},
+		},
+		[]string{"payments-a"},
+		"database \"payments\" environment \"production\"",
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "has a deployments map entry with an empty key")
+	assert.NotContains(t, err.Error(), `missing deployment ""`)
+}
+
 func TestServerConfig_DeploymentsMapValidation(t *testing.T) {
 	baseTern := TernConfig{
 		"payments-a": {"production": "tern-a:9090"},


### PR DESCRIPTION
## What and Why ?
Adds an optional per-environment `deployment_order` that pins the rollout order
across an environment's `deployments` map, analogous to the server-wide
`environment_order`. When unset, deployments resolve in alphabetical key order
(unchanged default).

## Changes
- New `deployment_order` field on the environment config.
- `ResolveDatabaseTargets` returns deployments in `deployment_order` when set; otherwise alphabetical.
- Config validation rejects a `deployment_order` that isn't a permutation of the deployments map keys (empty/duplicate/unknown/missing entries), or one set without a `deployments` map.
- Docs for the new field.

## Behavior
Additive only — the existing multi-entry `deployments` hard-block still stands,
so no config that loads today changes behavior. This is plumbing the eventual
multi-deployment cut-over builds on.

Stacked on the client-facing rename PR.
