### PR TITLE
refactor(github): remove repo-owned environment selection from schemabot.yaml

### DIFF
--- a/docs/check-runs.md
+++ b/docs/check-runs.md
@@ -462,7 +462,7 @@ Run output remains human-readable and may change.
 | `rollback_completed` | Per-database row | A rollback succeeded, so the target environment no longer contains the PR's desired schema. |
 | `github_schema_config_discovery_unavailable` | Aggregate row | SchemaBot knew the PR head SHA, but GitHub was unavailable while SchemaBot inspected changed files or repository contents. |
 | `schema_config_discovery_failed` | Aggregate row | SchemaBot could reach GitHub, but could not determine the managed schema configuration or schema files. |
-| `no_allowed_configured_environments` | Aggregate row | Schema files changed, but none of the environments declared by `schemabot.yaml` are allowed for this deployment. |
+| `no_allowed_configured_environments` | Aggregate row | Schema files changed, but none of the database's server-configured environments are allowed for this deployment. |
 
 Generic plan and apply errors can still publish `completed` / `failure` without
 a stable `blocking_reason` when the error is not one of the explicit classes
@@ -499,7 +499,7 @@ Common fail-closed scenarios:
 | Aggregate update skipped for a stale SHA | A background worker tried to publish status for a commit that is no longer the PR head. | Confirm the latest commit has a SchemaBot aggregate check. If it does not, comment `schemabot plan -e <environment>` or `schemabot plan`. |
 | GitHub unavailable during config discovery | SchemaBot cannot safely read PR metadata or repository contents. | Wait for GitHub API recovery, then comment `schemabot plan -e <environment>` or `schemabot plan`. CLI operations can still manage live schema changes while GitHub is down, but they do not make branch protection pass. |
 | Config discovery failed for a non-GitHub reason | SchemaBot could read GitHub, but could not determine the managed schema config or schema files. | Fix `schemabot.yaml`, the schema file layout, or the invalid SQL/config state. Push the fix, or comment `schemabot plan -e <environment>` after fixing the PR. Use logs with `blocking_reason=schema_config_discovery_failed` for the underlying read or parse failure. |
-| Schema changes found but no configured environments are allowed | The repo's `schemabot.yaml` asks for environments this deployment is not allowed to process. Publishing success would hide a deployment/config mismatch. | Align `schemabot.yaml` and this deployment's `allowed_environments`, then push the config fix or comment `schemabot plan -e <environment>`. |
+| Schema changes found but no configured environments are allowed | The database is configured only for environments this deployment is not allowed to process. Publishing success would hide a deployment/config mismatch. | Align the server database environment config with this deployment's `allowed_environments`, then push the config fix or comment `schemabot plan -e <environment>`. |
 | Accepted apply cannot be tracked | The engine accepted work, but SchemaBot could not store or reload the apply ID needed for progress and check ownership. | Treat this as a storage or apply-tracking incident. Inspect engine state and the `applies` table before retrying; do not rely on branch protection until a new plan reflects the live schema. |
 | Accepted apply could not update required check state | The apply may be running, but SchemaBot could not mark the stored check row `in_progress` with the accepted `apply_id`. | Inspect the accepted apply, storage health, and aggregate check. Retry only after confirming the live schema state and stored check state agree. |
 | Prior-environment check state could not be read | SchemaBot cannot prove that an earlier environment is clean. | Treat this as a SchemaBot storage health issue. Restore storage access, then repeat the blocked command, for example `schemabot apply -e production`. Do not bypass the promotion gate unless this is an explicit breakglass decision. |
@@ -768,8 +768,8 @@ continues to block until a new plan shows no changes or the changes are applied.
 ### Schema changes but no configured environments are allowed
 
 When `allowed_environments` is configured, a SchemaBot deployment may discover
-that the PR touches a managed database but none of the environments declared by
-that database's `schemabot.yaml` are allowed for this deployment. That is treated
+that the PR touches a managed database but none of that database's
+server-configured environments are allowed for this deployment. That is treated
 as a configuration mismatch, not a no-op. SchemaBot publishes a failing aggregate
 for the environments this deployment is responsible for, stores
 `blocking_reason=no_allowed_configured_environments`, and does not post a plan
@@ -832,8 +832,8 @@ watcher from overwriting a newer plan or newer apply result.
 
 ## Environment Ordering
 
-Environment ordering is enforced for PR comment commands. The set of enabled
-environments comes from `schemabot.yaml`, but the order comes from server config:
+Environment ordering is enforced for PR comment commands. The set of configured
+environments and their promotion order both come from server config:
 
 ```yaml
 environment_order:
@@ -844,21 +844,8 @@ environment_order:
 If `environment_order` is omitted, SchemaBot defaults to staging before
 production.
 
-For clients, `schemabot.yaml` environments are strictly an opt-in mechanism:
-
-```yaml
-environments:
-  - production
-  - staging
-```
-
-The order in that file is ignored for apply gating. In the example above, the
-repository has opted into both environments. SchemaBot still treats staging as
-the prior environment for production because the server-owned order says staging
-comes first.
-
 Before applying to an environment, SchemaBot checks all prior environments for
-the same database that are also enabled in `schemabot.yaml`:
+the same database that are configured server-side:
 
 | Prior environment state | Apply allowed? | Reason |
 | --- | --- | --- |
@@ -892,8 +879,7 @@ target identifiers in its server config. Its apply flow is:
 schemabot apply -e production
         |
         v
-Read enabled environments from schemabot.yaml
-and promotion order from server config
+Read configured environments and promotion order from server config
         |
         v
 For each prior environment:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -180,7 +180,7 @@ Resolution order from the config layer is deterministic and sorted by deployment
 
 ## Environment Order
 
-For clients, `schemabot.yaml` environments are strictly an opt-in mechanism. They control which environments a repository opts into; they do not control promotion order. SchemaBot enforces promotion order from server config:
+Environment availability and promotion order are server-owned. Repository `schemabot.yaml` files identify the database and type; they do not list or opt into environments. SchemaBot resolves the environments for a database from server config:
 
 ```yaml
 environment_order:
@@ -188,21 +188,7 @@ environment_order:
   - production
 ```
 
-If omitted, SchemaBot defaults to `staging` before `production`. The order of values in `schemabot.yaml` is ignored for apply gating, so these two repo configs are equivalent:
-
-```yaml
-environments:
-  - staging
-  - production
-```
-
-```yaml
-environments:
-  - production
-  - staging
-```
-
-Both enable staging and production. When applying production, SchemaBot checks staging first because the server-owned `environment_order` says staging precedes production.
+If omitted, SchemaBot defaults to `staging` before `production`. Before applying production, SchemaBot checks staging first when both environments are configured for the database because the server-owned `environment_order` says staging precedes production.
 
 ## Hybrid Mode
 
@@ -488,11 +474,12 @@ Do not require the staging ConfigMap to contain production targets, or the produ
 When a PR is opened or updated, each instance auto-plans only the environments it owns. The staging instance plans staging, the production instance plans production. Each posts its own plan comment and creates its own per-environment aggregate check.
 
 If a PR changes managed schema files but a deployment's `allowed_environments`
-does not overlap any environment declared by the matching `schemabot.yaml`, that
+does not overlap any environment configured server-side for the database, that
 deployment publishes a failing aggregate check instead of treating the PR as
-safe. This usually means the repo config and server config disagree. Align the
-`schemabot.yaml` environments with the deployment's `allowed_environments`, then
-run `schemabot plan -e <environment>` or push a new commit to refresh checks.
+safe. This usually means the database environment config and deployment scoping
+disagree. Align the server environment config with the deployment's
+`allowed_environments`, then run `schemabot plan -e <environment>` or push a new
+commit to refresh checks.
 
 ## Multi-App Routing
 

--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -165,16 +165,14 @@ my-repo/
 ```yaml
 database: mydb
 type: mysql
-environments:
-  - staging
-  - production
 ```
 
 | Field | Required | Description |
 |-------|----------|-------------|
 | `database` | Yes | Must match a database name in your SchemaBot server config |
 | `type` | Yes | `"mysql"` or `"vitess"` |
-| `environments` | No | Defaults to `["staging"]`. Valid values: `"staging"`, `"production"`. This is an opt-in list; server config controls promotion order. |
+
+Environment availability and promotion order are configured on the SchemaBot server.
 
 ### Schema File Layout
 

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -70,9 +70,8 @@ type ServerConfig struct {
 	// When empty or nil, all environments are allowed.
 	AllowedEnvironments []string `yaml:"allowed_environments"`
 
-	// EnvironmentOrder defines the server-owned promotion order. Client-side
-	// schemabot.yaml environments only opt into environments; their YAML order is
-	// not authoritative for apply gating. Defaults to staging before production.
+	// EnvironmentOrder defines the server-owned promotion order. Defaults to
+	// staging before production.
 	EnvironmentOrder []string `yaml:"environment_order"`
 
 	// SchedulerWorkers is the number of concurrent scheduler workers that claim
@@ -683,6 +682,23 @@ func (c *ServerConfig) DatabaseEnvironment(database, environment string) *Enviro
 		return &env
 	}
 	return nil
+}
+
+// DatabaseEnvironments returns the environments configured server-side for a
+// database, ordered by the server-owned promotion order.
+func (c *ServerConfig) DatabaseEnvironments(database string) ([]string, error) {
+	if c == nil {
+		return nil, fmt.Errorf("server config is nil")
+	}
+	db := c.Database(database)
+	if db == nil {
+		return nil, fmt.Errorf("database %q is not configured on this server", database)
+	}
+	environments := make([]string, 0, len(db.Environments))
+	for environment := range db.Environments {
+		environments = append(environments, environment)
+	}
+	return c.OrderedEnvironments(environments), nil
 }
 
 // ResolveDatabaseTarget returns the complete routing metadata for a configured

--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -1103,6 +1103,38 @@ func TestProgressByApplyIDServesQueuedRemoteApplyFromStorage(t *testing.T) {
 	assert.Equal(t, "users", resp.Tables[0].TableName)
 }
 
+func TestDatabaseEnvironmentsUsesServerPromotionOrder(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	svc := New(&mockStorage{}, &ServerConfig{
+		Databases: map[string]DatabaseConfig{
+			"testdb": {
+				Type: storage.DatabaseTypeMySQL,
+				Environments: map[string]EnvironmentConfig{
+					"sandbox":    {},
+					"staging":    {},
+					"production": {},
+				},
+			},
+		},
+		EnvironmentOrder: []string{"production", "staging"},
+	}, nil, logger)
+	mux := http.NewServeMux()
+	svc.ConfigureRoutes(mux)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/databases/testdb/environments", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	var resp struct {
+		Database     string   `json:"database"`
+		Environments []string `json:"environments"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "testdb", resp.Database)
+	assert.Equal(t, []string{"production", "staging", "sandbox"}, resp.Environments)
+}
+
 func TestProgressByApplyIDResolvesExternalIDForRemoteApply(t *testing.T) {
 	mock := &mockTernClient{
 		isRemote: true,

--- a/pkg/api/progress_handlers.go
+++ b/pkg/api/progress_handlers.go
@@ -406,13 +406,25 @@ func (s *Service) handleDatabaseEnvironments(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	var environments []string
-
-	// Databases is the server-side registry for both local DSN and remote Tern targets.
-	if dbConfig := s.config.Database(database); dbConfig != nil {
-		for env := range dbConfig.Environments {
-			environments = append(environments, env)
+	environments, err := s.config.DatabaseEnvironments(database)
+	if err != nil {
+		available := make([]string, 0, len(s.config.Databases))
+		for name := range s.config.Databases {
+			available = append(available, name)
 		}
+		sort.Strings(available)
+		s.logger.Warn("database environments not found",
+			"database", database,
+			"available_databases", available,
+			"error", err)
+		if len(available) > 0 {
+			s.writeError(w, http.StatusNotFound,
+				fmt.Sprintf("no environments found for database %q - configure this database in the SchemaBot server config (available: %v)", database, available))
+		} else {
+			s.writeError(w, http.StatusNotFound,
+				fmt.Sprintf("no environments found for database %q - no databases configured on this server", database))
+		}
+		return
 	}
 
 	if len(environments) == 0 {
@@ -433,8 +445,6 @@ func (s *Service) handleDatabaseEnvironments(w http.ResponseWriter, r *http.Requ
 		}
 		return
 	}
-
-	sort.Strings(environments)
 
 	s.writeJSON(w, http.StatusOK, map[string]any{
 		"database":     database,

--- a/pkg/cmd/commands/common.go
+++ b/pkg/cmd/commands/common.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/block/schemabot/pkg/apitypes"
 	"github.com/block/schemabot/pkg/cmd/client"
-	ghclient "github.com/block/schemabot/pkg/github"
 	"github.com/block/schemabot/pkg/state"
 )
 
@@ -63,10 +62,9 @@ var ErrSilent = errors.New("silent error")
 
 // CLIConfig represents the schemabot.yaml configuration file for CLI commands.
 type CLIConfig struct {
-	Database     string                   `yaml:"database"`
-	Type         string                   `yaml:"type"`
-	Environments ghclient.EnvironmentList `yaml:"environments,omitempty"`
-	SchemaDir    string                   `yaml:"-"` // Set by LoadCLIConfig, not from YAML
+	Database  string `yaml:"database"`
+	Type      string `yaml:"type"`
+	SchemaDir string `yaml:"-"` // Set by LoadCLIConfig, not from YAML
 }
 
 // LoadCLIConfig loads configuration from schemabot.yaml in the given directory.

--- a/pkg/cmd/commands/common_test.go
+++ b/pkg/cmd/commands/common_test.go
@@ -11,20 +11,18 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/block/schemabot/pkg/e2eutil"
-	ghclient "github.com/block/schemabot/pkg/github"
 )
 
-func TestLoadCLIConfig_WithEnvironments(t *testing.T) {
-	dir := e2eutil.WriteSchemaDir(t, "testapp", "mysql", map[string]string{
-		"users.sql": "CREATE TABLE users (id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY);",
-	}, e2eutil.WithEnvironmentNames("staging", "production"))
+func TestLoadCLIConfig_RejectsEnvironments(t *testing.T) {
+	dir := t.TempDir()
+	content := "database: mydb\ntype: mysql\nenvironments:\n  - staging\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "schemabot.yaml"), []byte(content), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "users.sql"), []byte("CREATE TABLE users (id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY);"), 0644))
 
 	cfg, err := LoadCLIConfig(dir)
-	require.NoError(t, err)
-
-	assert.Equal(t, "testapp", cfg.Database)
-	assert.Equal(t, "mysql", cfg.Type)
-	assert.Equal(t, ghclient.EnvironmentList{{Name: "production"}, {Name: "staging"}}, cfg.Environments)
+	require.Error(t, err)
+	assert.Nil(t, cfg)
+	assert.Contains(t, err.Error(), "field environments not found")
 }
 
 func TestLoadCLIConfig_WithoutEnvironments(t *testing.T) {
@@ -36,6 +34,7 @@ func TestLoadCLIConfig_WithoutEnvironments(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, "testapp", cfg.Database)
+	assert.Equal(t, "mysql", cfg.Type)
 }
 
 func TestLoadCLIConfig_RejectsDeployment(t *testing.T) {

--- a/pkg/e2eutil/e2eutil.go
+++ b/pkg/e2eutil/e2eutil.go
@@ -14,7 +14,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
-	"sort"
 	"strings"
 	"sync"
 	"testing"
@@ -118,19 +117,10 @@ func RunCLIWithError(binPath, dir string, args ...string) (string, error) {
 	return stdout.String() + stderr.String(), err
 }
 
-type schemaDirConfig struct {
-	environments []string
-}
+type schemaDirConfig struct{}
 
 // SchemaDirOption configures optional fields for WriteSchemaDir.
 type SchemaDirOption func(*schemaDirConfig)
-
-// WithEnvironmentNames adds environment names to the generated schemabot.yaml.
-func WithEnvironmentNames(envs ...string) SchemaDirOption {
-	return func(c *schemaDirConfig) {
-		c.environments = append([]string(nil), envs...)
-	}
-}
 
 // WriteSchemaDir creates a temporary directory with a schemabot.yaml config and
 // the provided SQL files. Returns the directory path.
@@ -145,14 +135,6 @@ func WriteSchemaDir(t *testing.T, database, dbType string, sqlFiles map[string]s
 	dir := t.TempDir()
 	var b strings.Builder
 	fmt.Fprintf(&b, "database: %s\ntype: %s\n", database, dbType)
-	if len(cfg.environments) > 0 {
-		envNames := append([]string(nil), cfg.environments...)
-		sort.Strings(envNames)
-		b.WriteString("environments:\n")
-		for _, env := range envNames {
-			fmt.Fprintf(&b, "  - %s\n", env)
-		}
-	}
 	if err := os.WriteFile(filepath.Join(dir, "schemabot.yaml"), []byte(b.String()), 0644); err != nil {
 		t.Fatalf("write schemabot.yaml: %v", err)
 	}

--- a/pkg/e2eutil/e2eutil_test.go
+++ b/pkg/e2eutil/e2eutil_test.go
@@ -22,19 +22,3 @@ func TestWriteSchemaDir_NoOptions(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "CREATE TABLE t1 (id INT);", string(sql))
 }
-
-func TestWriteSchemaDir_WithEnvironmentNames(t *testing.T) {
-	dir := WriteSchemaDir(t, "testdb", "mysql", map[string]string{
-		"001.sql": "CREATE TABLE t1 (id INT);",
-	}, WithEnvironmentNames("staging", "production"))
-
-	config, err := os.ReadFile(filepath.Join(dir, "schemabot.yaml"))
-	require.NoError(t, err)
-
-	configStr := string(config)
-	assert.Contains(t, configStr, "database: testdb")
-	assert.Contains(t, configStr, "type: mysql")
-	assert.Contains(t, configStr, "environments:")
-	assert.Contains(t, configStr, "  - staging")
-	assert.Contains(t, configStr, "  - production")
-}

--- a/pkg/github/config.go
+++ b/pkg/github/config.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"path"
-	"slices"
 	"sort"
 	"strings"
 
@@ -21,46 +20,12 @@ const (
 	DatabaseTypeStrata DatabaseType = "strata"
 )
 
-// EnvironmentEntry represents an environment a repository has opted into.
-type EnvironmentEntry struct {
-	Name string
-}
-
-// EnvironmentList supports a list of environment names in YAML:
-//
-//	environments:
-//	  - staging
-//	  - production
-type EnvironmentList []EnvironmentEntry
-
-// UnmarshalYAML handles list-of-strings form.
-func (e *EnvironmentList) UnmarshalYAML(value *yaml.Node) error {
-	*e = nil // Reset to avoid accumulating entries on re-unmarshal
-	switch value.Kind {
-	case yaml.SequenceNode:
-		// List form: ["staging", "production"]
-		var names []string
-		if err := value.Decode(&names); err != nil {
-			return err
-		}
-		for _, name := range names {
-			*e = append(*e, EnvironmentEntry{Name: name})
-		}
-		return nil
-	case yaml.MappingNode:
-		return fmt.Errorf("environments must be a list of names; configure database targets in the SchemaBot server config")
-	default:
-		return fmt.Errorf("environments must be a list, got %v", value.Kind)
-	}
-}
-
 // SchemabotConfig represents the schemabot.yaml configuration file.
 // The presence of this file in a directory indicates that directory contains schema files.
 type SchemabotConfig struct {
-	Database     string          `yaml:"database" json:"database"`
-	Name         string          `yaml:"name" json:"name"`
-	Type         DatabaseType    `yaml:"type,omitempty" json:"type,omitempty"`
-	Environments EnvironmentList `yaml:"environments,omitempty" json:"environments,omitempty"`
+	Database string       `yaml:"database" json:"database"`
+	Name     string       `yaml:"name" json:"name"`
+	Type     DatabaseType `yaml:"type,omitempty" json:"type,omitempty"`
 }
 
 // GetType returns the database type. Type is always set — FetchConfig rejects empty values.
@@ -68,30 +33,11 @@ func (c *SchemabotConfig) GetType() DatabaseType {
 	return c.Type
 }
 
-// GetEnvironments returns the enabled environment names, defaulting to ["staging"].
-// The returned order is not authoritative; SchemaBot servers own promotion order.
-func (c *SchemabotConfig) GetEnvironments() []string {
-	if len(c.Environments) == 0 {
-		return []string{"staging"}
-	}
-	names := make([]string, len(c.Environments))
-	for i, e := range c.Environments {
-		names[i] = e.Name
-	}
-	return names
-}
-
-// HasEnvironment returns true if the specified environment is configured.
-func (c *SchemabotConfig) HasEnvironment(env string) bool {
-	return slices.Contains(c.GetEnvironments(), env)
-}
-
 // DiscoveredConfig represents a schemabot.yaml config found via Tree API search.
 type DiscoveredConfig struct {
-	Config       *SchemabotConfig
-	Path         string   // Full path to schemabot.yaml file
-	SchemaDir    string   // Directory containing schemabot.yaml
-	Environments []string // Enabled environments from config.GetEnvironments()
+	Config    *SchemabotConfig
+	Path      string // Full path to schemabot.yaml file
+	SchemaDir string // Directory containing schemabot.yaml
 }
 
 // ConfigFileName is the name of the schemabot config file.
@@ -152,13 +98,6 @@ func (ic *InstallationClient) FetchConfig(ctx context.Context, repo, configPath,
 		return nil, fmt.Errorf("invalid schemabot.yaml at %s: type must be 'vitess', 'mysql', or 'strata', got '%s'", configPath, config.Type)
 	}
 
-	validEnvs := map[string]bool{"staging": true, "production": true}
-	for _, env := range config.Environments {
-		if !validEnvs[env.Name] {
-			return nil, fmt.Errorf("invalid schemabot.yaml at %s: environment must be 'staging' or 'production', got '%s'", configPath, env.Name)
-		}
-	}
-
 	return &config, nil
 }
 
@@ -203,10 +142,9 @@ func (ic *InstallationClient) FindAllConfigs(ctx context.Context, repo, ref stri
 
 		schemaDir := path.Dir(configPath)
 		result.ValidConfigs = append(result.ValidConfigs, DiscoveredConfig{
-			Config:       config,
-			Path:         configPath,
-			SchemaDir:    schemaDir,
-			Environments: config.GetEnvironments(),
+			Config:    config,
+			Path:      configPath,
+			SchemaDir: schemaDir,
 		})
 	}
 
@@ -506,10 +444,9 @@ func newDiscoveredConfig(config *SchemabotConfig, dir string) DiscoveredConfig {
 		configPath = ConfigFileName
 	}
 	return DiscoveredConfig{
-		Config:       config,
-		Path:         configPath,
-		SchemaDir:    dir,
-		Environments: config.GetEnvironments(),
+		Config:    config,
+		Path:      configPath,
+		SchemaDir: dir,
 	}
 }
 

--- a/pkg/github/config_test.go
+++ b/pkg/github/config_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 
 	gh "github.com/google/go-github/v86/github"
@@ -17,7 +18,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-func TestEnvironmentList_SimpleForm(t *testing.T) {
+func TestSchemabotConfigRejectsEnvironments(t *testing.T) {
 	yamlData := `
 database: testdb
 type: mysql
@@ -26,58 +27,11 @@ environments:
   - production
 `
 	var config SchemabotConfig
-	require.NoError(t, yaml.Unmarshal([]byte(yamlData), &config))
-	assert.Equal(t, []string{"staging", "production"}, config.GetEnvironments())
-}
-
-func TestEnvironmentList_MapFormRejected(t *testing.T) {
-	yamlData := `
-database: testdb
-type: mysql
-environments:
-  staging:
-    target: cluster-staging-001
-  production:
-    target: cluster-production-001
-`
-	var config SchemabotConfig
-	err := yaml.Unmarshal([]byte(yamlData), &config)
+	decoder := yaml.NewDecoder(strings.NewReader(yamlData))
+	decoder.KnownFields(true)
+	err := decoder.Decode(&config)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "configure database targets in the SchemaBot server config")
-}
-
-func TestGetEnvironments_Default(t *testing.T) {
-	config := SchemabotConfig{Database: "mydb"}
-	assert.Equal(t, []string{"staging"}, config.GetEnvironments())
-}
-
-func TestHasEnvironment_SimpleForm(t *testing.T) {
-	config := SchemabotConfig{
-		Database: "mydb",
-		Environments: EnvironmentList{
-			{Name: "staging"},
-			{Name: "production"},
-		},
-	}
-	assert.True(t, config.HasEnvironment("staging"))
-	assert.True(t, config.HasEnvironment("production"))
-	assert.False(t, config.HasEnvironment("unknown"))
-}
-
-func TestHasEnvironment_MapForm(t *testing.T) {
-	yamlData := `
-database: testdb
-type: mysql
-environments:
-  staging:
-    target: cluster-001
-  production:
-    target: cluster-002
-`
-	var config SchemabotConfig
-	err := yaml.Unmarshal([]byte(yamlData), &config)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "configure database targets in the SchemaBot server config")
+	assert.Contains(t, err.Error(), "field environments not found")
 }
 
 func TestFindAllConfigsForPRClassifiesGitHubUnavailable(t *testing.T) {

--- a/pkg/github/schema.go
+++ b/pkg/github/schema.go
@@ -14,7 +14,7 @@ import (
 // SchemaRequestResult contains everything needed to execute a plan from a PR.
 type SchemaRequestResult struct {
 	Database     string
-	Environments []string // Enabled environments from schemabot.yaml; server config owns promotion order.
+	Environments []string // Server-owned environments for this database, populated by webhook handlers.
 	Type         string   // "mysql" or "vitess"
 	SchemaFiles  map[string]*ternv1.SchemaFiles
 	Repository   string
@@ -41,10 +41,6 @@ func (ic *InstallationClient) CreateSchemaRequestFromPR(ctx context.Context, rep
 		return nil, err
 	}
 
-	if environment != "" && !config.HasEnvironment(environment) {
-		return nil, fmt.Errorf("environment %q is not configured for this database (configured: %v)", environment, config.GetEnvironments())
-	}
-
 	// Get PR info for head SHA
 	prInfo, err := ic.FetchPullRequest(ctx, repo, pr)
 	if err != nil {
@@ -64,14 +60,13 @@ func (ic *InstallationClient) CreateSchemaRequestFromPR(ctx context.Context, rep
 	}
 
 	return &SchemaRequestResult{
-		Database:     config.Database,
-		Environments: config.GetEnvironments(),
-		Type:         string(config.GetType()),
-		SchemaFiles:  schemaFiles,
-		Repository:   repo,
-		PullRequest:  pr,
-		SchemaPath:   configDir,
-		HeadSHA:      prInfo.HeadSHA,
+		Database:    config.Database,
+		Type:        string(config.GetType()),
+		SchemaFiles: schemaFiles,
+		Repository:  repo,
+		PullRequest: pr,
+		SchemaPath:  configDir,
+		HeadSHA:     prInfo.HeadSHA,
 	}, nil
 }
 

--- a/pkg/metrics/README.md
+++ b/pkg/metrics/README.md
@@ -145,7 +145,7 @@ Operation values:
 | `stale_check_cleanup` | SchemaBot handled stored check state for a database that is no longer touched by the latest commit on the PR branch. Plan-only state can be cleared; apply-owned state stays blocked. |
 | `stale_check_reconciliation` | SchemaBot repaired stale `in_progress` stored check state by comparing it with authoritative apply state after a worker restart, crash, or race. |
 | `schema_config_discovery` | SchemaBot discovered managed schema configs for the PR before deciding what to plan or which aggregate checks to publish. |
-| `schema_config_environment_validation` | SchemaBot found schema changes but none of the environments declared by `schemabot.yaml` are allowed for this deployment, so it failed the aggregate check closed. |
+| `schema_config_environment_validation` | SchemaBot found schema changes but none of the database's server-configured environments are allowed for this deployment, so it failed the aggregate check closed. |
 
 A spike in `status="blocked"` for `operation="aggregate_check_sync"` or
 `operation="stale_check_cleanup"` means SchemaBot is fail-closing instead of

--- a/pkg/webhook/README.md
+++ b/pkg/webhook/README.md
@@ -99,10 +99,10 @@ The `schemabot.yaml` config file marks a directory as containing schema files:
 ```yaml
 database: payments_db
 type: mysql
-environments:
-  - staging
-  - production
 ```
+
+Environment availability and order are resolved from server config for the
+configured database.
 
 Three discovery strategies, tried in order:
 

--- a/pkg/webhook/actor_authorization_test.go
+++ b/pkg/webhook/actor_authorization_test.go
@@ -489,7 +489,7 @@ func teamMembersHandler(t *testing.T, statusCode int, members ...string) http.Ha
 func registerApplyDiscoveryEndpoints(t *testing.T, mux *http.ServeMux, database string) {
 	t.Helper()
 
-	schemabotConfig := fmt.Sprintf("database: %s\ntype: mysql\nenvironments:\n  - staging\n", database)
+	schemabotConfig := fmt.Sprintf("database: %s\ntype: mysql\n", database)
 	schemaSQL := "CREATE TABLE `users` (`id` bigint unsigned NOT NULL AUTO_INCREMENT, PRIMARY KEY (`id`))"
 
 	mux.HandleFunc("GET /repos/octocat/hello-world/pulls/1", func(w http.ResponseWriter, _ *http.Request) {

--- a/pkg/webhook/apply_e2e_test.go
+++ b/pkg/webhook/apply_e2e_test.go
@@ -404,7 +404,7 @@ func TestE2EUnlockForceInfersDatabaseForCLILock(t *testing.T) {
 		}})
 	})
 	mux.HandleFunc("GET /repos/octocat/hello-world/contents/schemabot.yaml", func(w http.ResponseWriter, _ *http.Request) {
-		content := fmt.Sprintf("database: %s\ntype: mysql\nenvironments:\n  - staging\n", dbName)
+		content := fmt.Sprintf("database: %s\ntype: mysql\n", dbName)
 		_ = json.NewEncoder(w).Encode(map[string]string{
 			"type":     "file",
 			"encoding": "base64",
@@ -1133,9 +1133,9 @@ func TestE2EApplyProductionBlockedByStagingFirst(t *testing.T) {
 	client := gh.NewClient(nil)
 	client.BaseURL, _ = url.Parse(server.URL + "/")
 
-	// Client config can enable environments, but cannot control promotion order.
-	// Production listed before staging must still be gated by staging.
-	schemabotConfig := fmt.Sprintf("database: %s\ntype: mysql\nenvironments:\n  - production\n  - staging\n", dbName)
+	// Server config owns both environment availability and promotion order.
+	// Production must be gated by staging.
+	schemabotConfig := fmt.Sprintf("database: %s\ntype: mysql\n", dbName)
 	schemaFiles := map[string]string{
 		"users.sql": "CREATE TABLE `users` (\n  `id` bigint unsigned NOT NULL AUTO_INCREMENT,\n  `name` varchar(255) NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;",
 	}
@@ -1166,8 +1166,8 @@ func TestE2EApplyProductionBlockedByStagingFirst(t *testing.T) {
 }
 
 // TestE2EApplyUsesCustomServerEnvironmentOrder verifies that environment_order
-// in server config controls promotion order. The repo lists staging before
-// production, but this server config makes production the prior environment.
+// in server config controls promotion order. This server config makes
+// production the prior environment.
 func TestE2EApplyUsesCustomServerEnvironmentOrder(t *testing.T) {
 	dbName := "webhook_custom_env_order"
 	svc := setupE2EService(t, dbName)
@@ -1182,7 +1182,7 @@ func TestE2EApplyUsesCustomServerEnvironmentOrder(t *testing.T) {
 	client := gh.NewClient(nil)
 	client.BaseURL, _ = url.Parse(server.URL + "/")
 
-	schemabotConfig := fmt.Sprintf("database: %s\ntype: mysql\nenvironments:\n  - staging\n  - production\n", dbName)
+	schemabotConfig := fmt.Sprintf("database: %s\ntype: mysql\n", dbName)
 	schemaFiles := map[string]string{
 		"users.sql": "CREATE TABLE `users` (\n  `id` bigint unsigned NOT NULL AUTO_INCREMENT,\n  `name` varchar(255) NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;",
 	}
@@ -1226,7 +1226,7 @@ func TestE2EApplyProductionAllowedWhenStagingSuccess(t *testing.T) {
 	client := gh.NewClient(nil)
 	client.BaseURL, _ = url.Parse(server.URL + "/")
 
-	schemabotConfig := fmt.Sprintf("database: %s\ntype: mysql\nenvironments:\n  - staging\n  - production\n", dbName)
+	schemabotConfig := fmt.Sprintf("database: %s\ntype: mysql\n", dbName)
 	schemaFiles := map[string]string{
 		"users.sql": "CREATE TABLE `users` (\n  `id` bigint unsigned NOT NULL AUTO_INCREMENT,\n  `name` varchar(255) NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;",
 	}
@@ -2268,7 +2268,7 @@ func TestE2EApplyStoresServerSideTarget(t *testing.T) {
 	client := gh.NewClient(nil)
 	client.BaseURL, _ = url.Parse(server.URL + "/")
 
-	schemabotConfig := fmt.Sprintf("database: %s\ntype: mysql\nenvironments:\n  - staging\n", dbName)
+	schemabotConfig := fmt.Sprintf("database: %s\ntype: mysql\n", dbName)
 	schemaFiles := map[string]string{
 		"users.sql": "CREATE TABLE `users` (\n  `id` bigint unsigned NOT NULL AUTO_INCREMENT,\n  `name` varchar(255) NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;",
 	}

--- a/pkg/webhook/apply_e2e_test.go
+++ b/pkg/webhook/apply_e2e_test.go
@@ -1122,6 +1122,7 @@ func TestE2EApplyStaleLockReacquire(t *testing.T) {
 func TestE2EApplyProductionBlockedByStagingFirst(t *testing.T) {
 	dbName := "webhook_staging_first"
 	svc := setupE2EService(t, dbName)
+	configureE2EServiceEnvironments(t, svc, dbName, "production")
 
 	// Seed a staging check that is NOT success (action_required — unapplied changes)
 	seedCheck(t, svc, dbName, "staging", "action_required")
@@ -1171,6 +1172,7 @@ func TestE2EApplyProductionBlockedByStagingFirst(t *testing.T) {
 func TestE2EApplyUsesCustomServerEnvironmentOrder(t *testing.T) {
 	dbName := "webhook_custom_env_order"
 	svc := setupE2EService(t, dbName)
+	configureE2EServiceEnvironments(t, svc, dbName, "production")
 	svc.Config().EnvironmentOrder = []string{"production", "staging"}
 
 	seedCheck(t, svc, dbName, "production", "action_required")
@@ -1215,6 +1217,7 @@ func TestE2EApplyUsesCustomServerEnvironmentOrder(t *testing.T) {
 func TestE2EApplyProductionAllowedWhenStagingSuccess(t *testing.T) {
 	dbName := "webhook_staging_ok"
 	svc := setupE2EService(t, dbName)
+	configureE2EServiceEnvironments(t, svc, dbName, "production")
 
 	// Seed a staging check that IS success
 	seedCheck(t, svc, dbName, "staging", "success")

--- a/pkg/webhook/apply_handlers.go
+++ b/pkg/webhook/apply_handlers.go
@@ -30,6 +30,10 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 		h.handleSchemaRequestError(repo, pr, installationID, environment, databaseName, requestedBy, action.Apply, err)
 		return
 	}
+	if err := h.attachServerEnvironments(schemaResult, environment); err != nil {
+		h.handleSchemaRequestError(repo, pr, installationID, environment, databaseName, requestedBy, action.Apply, err)
+		return
+	}
 
 	if blocked := h.enforcePRCommandActorAuthorization(ctx, client, repo, pr, installationID, requestedBy, schemaResult.Database, schemaResult.Type, environment, action.Apply); blocked {
 		return
@@ -64,8 +68,7 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 	dbType := schemaResult.Type
 	lockOwner := fmt.Sprintf("%s#%d", repo, pr)
 
-	// Environment ordering enforcement: prior environments must be clean before applying.
-	// The repo config only opts into environments; server config owns their order.
+	// Environment ordering enforcement: prior server-configured environments must be clean before applying.
 	if blocked := h.checkPriorEnvironments(ctx, repo, pr, database, dbType, environment, schemaResult.Environments, installationID, requestedBy); blocked {
 		h.logger.Info("apply blocked by environment ordering", "repo", repo, "pr", pr, "database", database, "environment", environment)
 		return
@@ -336,6 +339,10 @@ func (h *Handler) handleApplyConfirmCommand(repo string, pr int, environment, da
 	// Discover database config from PR's schemabot.yaml
 	schemaResult, err := client.CreateSchemaRequestFromPR(ctx, repo, pr, environment, databaseName)
 	if err != nil {
+		h.handleSchemaRequestError(repo, pr, installationID, environment, databaseName, requestedBy, action.ApplyConfirm, err)
+		return
+	}
+	if err := h.attachServerEnvironments(schemaResult, environment); err != nil {
 		h.handleSchemaRequestError(repo, pr, installationID, environment, databaseName, requestedBy, action.ApplyConfirm, err)
 		return
 	}

--- a/pkg/webhook/check_aggregate.go
+++ b/pkg/webhook/check_aggregate.go
@@ -2,9 +2,11 @@ package webhook
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/block/schemabot/pkg/api"
+	ghclient "github.com/block/schemabot/pkg/github"
 	"github.com/block/schemabot/pkg/storage"
 )
 
@@ -34,6 +36,50 @@ func (h *Handler) aggregateCheckNameForRepo(repo string) string {
 		return aggregateCheckName
 	}
 	return config.GitHubCheckNameBaseForRepo(repo)
+}
+
+func (h *Handler) configuredDatabaseEnvironments(database string) ([]string, error) {
+	config, ok := h.serverConfig()
+	if !ok {
+		return nil, fmt.Errorf("server config is unavailable")
+	}
+	return config.DatabaseEnvironments(database)
+}
+
+func (h *Handler) allowedDatabaseEnvironments(database string) ([]string, error) {
+	config, ok := h.serverConfig()
+	if !ok {
+		return nil, fmt.Errorf("server config is unavailable")
+	}
+	environments, err := config.DatabaseEnvironments(database)
+	if err != nil {
+		return nil, fmt.Errorf("resolve configured environments for database %q: %w", database, err)
+	}
+	if len(config.AllowedEnvironments) == 0 {
+		return environments, nil
+	}
+	allowed := make([]string, 0, len(environments))
+	for _, environment := range environments {
+		if config.IsEnvironmentAllowed(environment) {
+			allowed = append(allowed, environment)
+		}
+	}
+	return allowed, nil
+}
+
+func (h *Handler) attachServerEnvironments(schemaResult *ghclient.SchemaRequestResult, environment string) error {
+	if schemaResult == nil {
+		return fmt.Errorf("schema request result is nil")
+	}
+	environments, err := h.configuredDatabaseEnvironments(schemaResult.Database)
+	if err != nil {
+		return fmt.Errorf("resolve configured environments for database %q: %w", schemaResult.Database, err)
+	}
+	if environment != "" && !slices.Contains(environments, environment) {
+		return fmt.Errorf("database %q environment %q is not configured on this server", schemaResult.Database, environment)
+	}
+	schemaResult.Environments = environments
+	return nil
 }
 
 // filterChecksByEnvironment returns only stored check state for the given environment.

--- a/pkg/webhook/check_prior_env.go
+++ b/pkg/webhook/check_prior_env.go
@@ -20,7 +20,7 @@ import (
 //   - applying to staging: sandbox must be success
 //   - applying to production: both sandbox and staging must be success
 //
-// schemabot.yaml only opts into environments; its YAML order is ignored.
+// Server config owns the configured environments and their promotion order.
 // When allowed_environments is configured, this instance only owns a subset of
 // environments. For prior environments owned by this instance, local storage is
 // checked. For prior environments owned by another instance, the GitHub Checks

--- a/pkg/webhook/check_runs.go
+++ b/pkg/webhook/check_runs.go
@@ -85,10 +85,10 @@ var configDiscoveryFailedBlock = checkBlockReason{
 }
 
 // noAllowedConfiguredEnvironmentsBlock is used when schema files changed but
-// the environments declared by schemabot.yaml do not overlap this service's
-// allowed_environments. SchemaBot cannot safely plan the schema change in that
-// configuration, so the aggregate check must fail closed.
+// the server-configured environments for the database do not overlap this
+// service's allowed_environments. SchemaBot cannot safely plan the schema
+// change in that configuration, so the aggregate check must fail closed.
 var noAllowedConfiguredEnvironmentsBlock = checkBlockReason{
 	blockingReason: "no_allowed_configured_environments",
-	message:        "SchemaBot found schema changes, but no environment declared by schemabot.yaml is allowed for this SchemaBot deployment. Align schemabot.yaml with allowed_environments, then retry the check.",
+	message:        "SchemaBot found schema changes, but no configured environment for this database is allowed for this SchemaBot deployment. Align server environment configuration with allowed_environments, then retry the check.",
 }

--- a/pkg/webhook/plan.go
+++ b/pkg/webhook/plan.go
@@ -39,6 +39,11 @@ func (h *Handler) handlePlanCommand(w http.ResponseWriter, repo string, pr int, 
 		h.writeJSON(w, http.StatusOK, map[string]string{"message": "schema request error handled"})
 		return
 	}
+	if err := h.attachServerEnvironments(schemaResult, environment); err != nil {
+		h.handleSchemaRequestError(repo, pr, installationID, environment, databaseName, requestedBy, action.Plan, err)
+		h.writeJSON(w, http.StatusOK, map[string]string{"message": "schema request error handled"})
+		return
+	}
 
 	// Reject if the PR HEAD advanced after discovery loaded schema files.
 	// Rendering a plan comment against stale files would mislead the user
@@ -138,44 +143,35 @@ func (h *Handler) handleMultiEnvPlan(repo string, pr int, databaseName string, i
 		return
 	}
 
-	// Find config to get environments
-	var environments []string
+	// Find config to get the database identity. Environments are server-owned.
+	var schemaDatabase string
 	if databaseName != "" {
 		config, _, findErr := client.FindConfigByDatabaseName(ctx, repo, pr, databaseName)
 		if findErr != nil {
 			h.handleSchemaRequestError(repo, pr, installationID, "", databaseName, requestedBy, action.Plan, findErr)
 			return
 		}
-		environments = config.GetEnvironments()
+		schemaDatabase = config.Database
 	} else {
 		config, _, findErr := client.FindConfigForPR(ctx, repo, pr)
 		if findErr != nil {
 			h.handleSchemaRequestError(repo, pr, installationID, "", databaseName, requestedBy, action.Plan, findErr)
 			return
 		}
-		environments = config.GetEnvironments()
+		schemaDatabase = config.Database
 	}
-	configuredEnvironments := append([]string(nil), environments...)
-	var allowedEnvironments []string
-
-	// Filter environments to those this service is allowed to handle.
-	if h.service != nil {
-		config := h.service.Config()
-		environments = config.OrderedEnvironments(environments)
-		allowedEnvironments = append([]string(nil), config.AllowedEnvironments...)
-		if len(config.AllowedEnvironments) > 0 {
-			var allowed []string
-			for _, env := range environments {
-				if config.IsEnvironmentAllowed(env) {
-					allowed = append(allowed, env)
-				} else {
-					h.logger.Debug("skipping environment not allowed for this service",
-						"repo", repo, "pr", pr, "env", env)
-				}
-			}
-			environments = allowed
-		}
+	configuredEnvironments, envErr := h.configuredDatabaseEnvironments(schemaDatabase)
+	if envErr != nil {
+		h.handleSchemaRequestError(repo, pr, installationID, "", databaseName, requestedBy, action.Plan, envErr)
+		return
 	}
+	environments, envErr := h.allowedDatabaseEnvironments(schemaDatabase)
+	if envErr != nil {
+		h.handleSchemaRequestError(repo, pr, installationID, "", databaseName, requestedBy, action.Plan, envErr)
+		return
+	}
+	configuredEnvironments = append([]string(nil), configuredEnvironments...)
+	allowedEnvironments := append([]string(nil), h.service.Config().AllowedEnvironments...)
 
 	if len(environments) == 0 {
 		prInfo, err := client.FetchPullRequest(ctx, repo, pr)
@@ -214,6 +210,11 @@ func (h *Handler) handleMultiEnvPlan(repo string, pr int, databaseName string, i
 		schemaResult, err := client.CreateSchemaRequestFromPR(ctx, repo, pr, env, databaseName)
 		if err != nil {
 			h.logger.Error("schema request failed", "repo", repo, "pr", pr, "env", env, "error", err)
+			multiEnvData.Errors[env] = userFacingError(err)
+			continue
+		}
+		if err := h.attachServerEnvironments(schemaResult, env); err != nil {
+			h.logger.Error("schema environment validation failed", "repo", repo, "pr", pr, "env", env, "error", err)
 			multiEnvData.Errors[env] = userFacingError(err)
 			continue
 		}

--- a/pkg/webhook/plan.go
+++ b/pkg/webhook/plan.go
@@ -162,11 +162,17 @@ func (h *Handler) handleMultiEnvPlan(repo string, pr int, databaseName string, i
 	}
 	configuredEnvironments, envErr := h.configuredDatabaseEnvironments(schemaDatabase)
 	if envErr != nil {
+		if isAutoPlan {
+			h.postFailingAggregateForMultiEnvSetupError(ctx, client, repo, pr, schemaDatabase, envErr)
+		}
 		h.handleSchemaRequestError(repo, pr, installationID, "", databaseName, requestedBy, action.Plan, envErr)
 		return
 	}
 	environments, envErr := h.allowedDatabaseEnvironments(schemaDatabase)
 	if envErr != nil {
+		if isAutoPlan {
+			h.postFailingAggregateForMultiEnvSetupError(ctx, client, repo, pr, schemaDatabase, envErr)
+		}
 		h.handleSchemaRequestError(repo, pr, installationID, "", databaseName, requestedBy, action.Plan, envErr)
 		return
 	}
@@ -321,6 +327,19 @@ func (h *Handler) handleMultiEnvPlan(repo string, pr int, databaseName string, i
 
 	// Post a single combined comment
 	h.postComment(repo, pr, installationID, templates.RenderMultiEnvPlanComment(multiEnvData))
+}
+
+func (h *Handler) postFailingAggregateForMultiEnvSetupError(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, database string, err error) {
+	prInfo, fetchErr := client.FetchPullRequest(ctx, repo, pr)
+	if fetchErr != nil {
+		h.logger.Error("failed to fetch PR for multi-env setup failure aggregate", "repo", repo, "pr", pr, "database", database, "error", fetchErr)
+		return
+	}
+	userError := userFacingError(err)
+	h.logger.Warn("multi-env plan setup failed; posting failing aggregate",
+		"repo", repo, "pr", pr, "head_sha", prInfo.HeadSHA, "database", database, "error", err)
+	h.postFailingAggregates(ctx, client, repo, pr, prInfo.HeadSHA,
+		h.aggregateMessagesForAllEnvironments(userError))
 }
 
 // handleSchemaRequestError maps schema request errors to GitHub comments.

--- a/pkg/webhook/rollback.go
+++ b/pkg/webhook/rollback.go
@@ -154,6 +154,10 @@ func (h *Handler) handleRollbackConfirmCommand(repo string, pr int, environment,
 		h.handleSchemaRequestError(repo, pr, installationID, environment, databaseName, requestedBy, action.RollbackConfirm, err)
 		return
 	}
+	if err := h.attachServerEnvironments(schemaResult, environment); err != nil {
+		h.handleSchemaRequestError(repo, pr, installationID, environment, databaseName, requestedBy, action.RollbackConfirm, err)
+		return
+	}
 
 	database := schemaResult.Database
 	dbType := schemaResult.Type

--- a/pkg/webhook/webhook_e2e_test.go
+++ b/pkg/webhook/webhook_e2e_test.go
@@ -218,6 +218,29 @@ func setupE2EService(t *testing.T, appDBName string) *api.Service {
 	return svc
 }
 
+func configureE2EServiceEnvironments(t *testing.T, svc *api.Service, dbName string, environments ...string) {
+	t.Helper()
+	config := svc.Config()
+	if config.Databases == nil {
+		config.Databases = make(map[string]api.DatabaseConfig)
+	}
+	dbConfig := config.Databases[dbName]
+	if dbConfig.Type == "" {
+		dbConfig.Type = "mysql"
+	}
+	if dbConfig.Environments == nil {
+		dbConfig.Environments = make(map[string]api.EnvironmentConfig)
+	}
+	stagingConfig := dbConfig.Environments["staging"]
+	for _, environment := range environments {
+		if _, ok := dbConfig.Environments[environment]; ok {
+			continue
+		}
+		dbConfig.Environments[environment] = stagingConfig
+	}
+	config.Databases[dbName] = dbConfig
+}
+
 // seedCheck creates a check record in storage with common defaults.
 // Use conclusion "action_required" for pending changes, "success" for applied.
 func seedCheck(t *testing.T, svc *api.Service, dbName, env, conclusion string) {
@@ -3400,6 +3423,7 @@ func setupE2EServiceWithAllowedEnvs(t *testing.T, allowedEnvs []string) *api.Ser
 func TestE2EAutoPlanFailsWhenConfiguredEnvironmentsAreNotAllowed(t *testing.T) {
 	dbName := "webhook_no_owned_envs"
 	svc := setupE2EServiceWithAllowedEnvs(t, []string{"sandbox"})
+	configureE2EServiceEnvironments(t, svc, dbName, "staging", "production")
 
 	mux := http.NewServeMux()
 	server := httptest.NewServer(mux)

--- a/pkg/webhook/webhook_e2e_test.go
+++ b/pkg/webhook/webhook_e2e_test.go
@@ -805,7 +805,7 @@ func TestE2EMultiEnvPlan(t *testing.T) {
 	client := gh.NewClient(nil)
 	client.BaseURL, _ = url.Parse(server.URL + "/")
 
-	schemabotConfig := fmt.Sprintf("database: %s\ntype: mysql\nenvironments:\n  - staging\n  - production\n", dbName)
+	schemabotConfig := fmt.Sprintf("database: %s\ntype: mysql\n", dbName)
 	schemaFiles := map[string]string{
 		"users.sql": "CREATE TABLE `users` (\n  `id` bigint unsigned NOT NULL AUTO_INCREMENT,\n  `name` varchar(255) NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;",
 	}
@@ -882,7 +882,7 @@ func TestE2EMultiEnvPlanDifferentChanges(t *testing.T) {
 	client := gh.NewClient(nil)
 	client.BaseURL, _ = url.Parse(server.URL + "/")
 
-	schemabotConfig := fmt.Sprintf("database: %s\ntype: mysql\nenvironments:\n  - staging\n  - production\n", dbName)
+	schemabotConfig := fmt.Sprintf("database: %s\ntype: mysql\n", dbName)
 	schemaFiles := map[string]string{
 		"users.sql": "CREATE TABLE `users` (\n  `id` bigint unsigned NOT NULL AUTO_INCREMENT,\n  `name` varchar(255) NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;",
 	}
@@ -1527,7 +1527,7 @@ func TestE2EAggregateCheck(t *testing.T) {
 	client := gh.NewClient(nil)
 	client.BaseURL, _ = url.Parse(server.URL + "/")
 
-	schemabotConfig := fmt.Sprintf("database: %s\ntype: mysql\nenvironments:\n  - staging\n  - production\n", dbName)
+	schemabotConfig := fmt.Sprintf("database: %s\ntype: mysql\n", dbName)
 	schemaFiles := map[string]string{
 		"users.sql": "CREATE TABLE `users` (\n  `id` bigint unsigned NOT NULL AUTO_INCREMENT,\n  `name` varchar(255) NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;",
 	}
@@ -3393,11 +3393,11 @@ func setupE2EServiceWithAllowedEnvs(t *testing.T, allowedEnvs []string) *api.Ser
 	return svc
 }
 
-// TestE2EAutoPlanFailsWhenRepoEnvironmentsAreNotAllowed verifies that
-// SchemaBot fails closed when schema files changed, but the repo's
-// schemabot.yaml only names environments this service is not allowed to
-// process. This is a configuration mismatch, not "no work".
-func TestE2EAutoPlanFailsWhenRepoEnvironmentsAreNotAllowed(t *testing.T) {
+// TestE2EAutoPlanFailsWhenConfiguredEnvironmentsAreNotAllowed verifies that
+// SchemaBot fails closed when schema files changed, but the server-configured
+// database environments do not overlap this service's allowed environments.
+// This is a configuration mismatch, not "no work".
+func TestE2EAutoPlanFailsWhenConfiguredEnvironmentsAreNotAllowed(t *testing.T) {
 	dbName := "webhook_no_owned_envs"
 	svc := setupE2EServiceWithAllowedEnvs(t, []string{"sandbox"})
 
@@ -3408,10 +3408,10 @@ func TestE2EAutoPlanFailsWhenRepoEnvironmentsAreNotAllowed(t *testing.T) {
 	client := gh.NewClient(nil)
 	client.BaseURL, _ = url.Parse(server.URL + "/")
 
-	// The repo config asks for staging and production, but this test service is
-	// configured to process only sandbox. SchemaBot cannot safely plan this
-	// schema change because none of the repo-configured environments are allowed.
-	schemabotConfig := fmt.Sprintf("database: %s\ntype: mysql\nenvironments:\n  - staging\n  - production\n", dbName)
+	// The database is configured for staging and production, but this test service
+	// processes only sandbox. SchemaBot cannot safely plan this schema change
+	// because none of the configured environments are allowed.
+	schemabotConfig := fmt.Sprintf("database: %s\ntype: mysql\n", dbName)
 	schemaFiles := map[string]string{
 		"users.sql": "CREATE TABLE `users` (\n  `id` bigint unsigned NOT NULL AUTO_INCREMENT,\n  `name` varchar(255) NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;",
 	}
@@ -3433,7 +3433,7 @@ func TestE2EAutoPlanFailsWhenRepoEnvironmentsAreNotAllowed(t *testing.T) {
 
 	// The webhook still accepts the PR event asynchronously, but auto-plan posts
 	// a failing aggregate because this service cannot process any environment
-	// named by schemabot.yaml.
+	// configured for the database.
 	select {
 	case cr := <-result.checkRuns:
 		assert.Equal(t, "SchemaBot (sandbox)", cr.Name)
@@ -3457,7 +3457,7 @@ func TestE2EAutoPlanFailsWhenRepoEnvironmentsAreNotAllowed(t *testing.T) {
 	// There should be no plan comment because no environment reached planning.
 	select {
 	case body := <-result.comments:
-		t.Fatalf("expected no plan comment when no repo-configured environments are allowed, got: %s", body)
+		t.Fatalf("expected no plan comment when no configured environments are allowed, got: %s", body)
 	case <-time.After(500 * time.Millisecond):
 	}
 }


### PR DESCRIPTION
## Why
Environment availability and promotion order should be owned by SchemaBot server configuration instead of repository config. This keeps target routing and deployment scoping centralized with the server that processes schema changes.

## What
- Remove `environments` from supported `schemabot.yaml` and CLI config parsing
- Resolve database environments from server config before planning/applying PR commands
- Update docs and tests to describe server-owned environment availability and ordering

## Risk Assessment
Medium — this is an intentional breaking config change for repositories that still set `environments` in `schemabot.yaml`; strict config parsing will reject that field until it is removed.

Generated with Amp
