### PR TITLE
fix(github): preserve staging-first gate for scoped deployments

### DIFF
--- a/docs/check-runs.md
+++ b/docs/check-runs.md
@@ -844,8 +844,12 @@ environment_order:
 If `environment_order` is omitted, SchemaBot defaults to staging before
 production.
 
-Before applying to an environment, SchemaBot checks all prior environments for
-the same database that are configured server-side:
+Before applying to an environment from a PR comment, SchemaBot checks prior
+environments from the server-owned promotion order. In a single deployment, the
+promotion gate uses the database environments configured on that server. In a
+deployment scoped with `allowed_environments`, the promotion gate uses
+`environment_order` so an environment-local deployment can still verify earlier
+environments owned by another SchemaBot deployment.
 
 | Prior environment state | Apply allowed? | Reason |
 | --- | --- | --- |
@@ -873,13 +877,14 @@ same database's staging row.
 
 In split deployments, GitHub check runs are the central authority for
 cross-environment gating. A production SchemaBot instance does not need staging
-target identifiers in its server config. Its apply flow is:
+target identifiers in its server config; it only needs the shared
+`environment_order` that says staging precedes production. Its apply flow is:
 
 ```text
 schemabot apply -e production
         |
         v
-Read configured environments and promotion order from server config
+Read promotion order from server config
         |
         v
 For each prior environment:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -188,7 +188,37 @@ environment_order:
   - production
 ```
 
-If omitted, SchemaBot defaults to `staging` before `production`. Before applying production, SchemaBot checks staging first when both environments are configured for the database because the server-owned `environment_order` says staging precedes production.
+If omitted, SchemaBot defaults to `staging` before `production`. Before applying production from a PR comment, SchemaBot checks staging first because the server-owned `environment_order` says staging precedes production.
+
+There are two related but separate concepts:
+
+- **Routing environments** — the `databases.<name>.environments` entries this SchemaBot process can plan/apply directly. These entries must include the local DSN or remote `target`/`deployment` needed to execute work for that environment.
+- **Promotion order** — the ordered environment chain used by PR comment applies. In a single deployment, this is normally the same set as the database's routing environments. In a deployment scoped with `allowed_environments`, promotion gating uses `environment_order` so a production-only deployment can still verify earlier environments that are owned by another SchemaBot deployment.
+
+For example, this production-scoped deployment only has production routing metadata, but production applies still require the staging aggregate check to be successful because `staging` precedes `production` in `environment_order`:
+
+```yaml
+allowed_environments:
+  - production
+
+environment_order:
+  - staging
+  - production
+
+databases:
+  payments:
+    type: mysql
+    environments:
+      production:
+        target: "payments-production"
+        deployment: primary
+
+tern_deployments:
+  primary:
+    production: "tern-production:9090"
+```
+
+The production deployment does not need a staging target. It verifies staging by reading the staging deployment's GitHub aggregate check, then resolves only the production target from its own config.
 
 ## Hybrid Mode
 

--- a/pkg/webhook/check_prior_env.go
+++ b/pkg/webhook/check_prior_env.go
@@ -3,8 +3,10 @@ package webhook
 import (
 	"context"
 	"fmt"
+	"slices"
 	"time"
 
+	"github.com/block/schemabot/pkg/api"
 	ghclient "github.com/block/schemabot/pkg/github"
 	"github.com/block/schemabot/pkg/storage"
 	"github.com/block/schemabot/pkg/webhook/templates"
@@ -32,7 +34,7 @@ func (h *Handler) checkPriorEnvironments(
 	installationID int64, requestedBy string,
 ) bool {
 	config := h.service.Config()
-	environments = config.OrderedEnvironments(environments)
+	environments = promotionGateEnvironments(config, environment, environments)
 
 	// Find the index of the current environment
 	currentIdx := -1
@@ -66,6 +68,19 @@ func (h *Handler) checkPriorEnvironments(
 	}
 
 	return false
+}
+
+func promotionGateEnvironments(config *api.ServerConfig, environment string, environments []string) []string {
+	if config == nil {
+		return environments
+	}
+	if len(config.AllowedEnvironments) > 0 {
+		order := config.PromotionEnvironmentOrder()
+		if slices.Contains(order, environment) {
+			return order
+		}
+	}
+	return config.OrderedEnvironments(environments)
 }
 
 // checkPriorEnvViaLocal checks the prior environment status using the local database.

--- a/pkg/webhook/check_prior_env_test.go
+++ b/pkg/webhook/check_prior_env_test.go
@@ -159,6 +159,103 @@ func TestCheckPriorEnvViaLocalRetriesBeforeFailClosed(t *testing.T) {
 	}
 }
 
+func TestCheckPriorEnvironmentsWithProductionOnlyServerConfigChecksStaging(t *testing.T) {
+	const (
+		repo    = "octocat/hello-world"
+		pr      = 1
+		headSHA = "abc123"
+	)
+
+	client, mux := setupGitHubServer(t)
+	comments := make(chan string, 10)
+	checkRunRequests := make(chan struct{}, 10)
+
+	mux.HandleFunc("GET /repos/octocat/hello-world/pulls/1", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"head": map[string]any{"sha": headSHA, "ref": "feature"},
+			"base": map[string]any{"sha": "base123", "ref": "main"},
+			"user": map[string]any{"login": "testuser"},
+		})
+	})
+	mux.HandleFunc("GET /repos/octocat/hello-world/commits/abc123/check-runs", func(w http.ResponseWriter, r *http.Request) {
+		checkRunRequests <- struct{}{}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"total_count": 1,
+			"check_runs": []map[string]any{
+				{"id": 1, "name": "SchemaBot (staging)", "status": "completed", "conclusion": "action_required"},
+			},
+		})
+	})
+	mux.HandleFunc("POST /repos/octocat/hello-world/issues/1/comments", func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Body string `json:"body"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		comments <- body.Body
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": 99})
+	})
+
+	installClient := ghclient.NewInstallationClient(client, testLogger())
+	service := api.New(&emptyStorage{}, &api.ServerConfig{
+		AllowedEnvironments: []string{"production"},
+		EnvironmentOrder:    []string{"staging", "production"},
+		Databases: map[string]api.DatabaseConfig{
+			"orders": {
+				Type: "mysql",
+				Environments: map[string]api.EnvironmentConfig{
+					"production": {Deployment: "default", Target: "orders"},
+				},
+			},
+		},
+	}, nil, testLogger())
+	t.Cleanup(func() { utils.CloseAndLog(service) })
+
+	h := &Handler{
+		service:                    service,
+		ghClients:                  ghclient.NewSingleClientSet(defaultAppName, &fakeClientFactory{client: installClient}),
+		logger:                     testLogger(),
+		priorEnvCheckMaxAttempts:   1,
+		priorEnvCheckRetryInterval: time.Nanosecond,
+	}
+
+	blocked := h.checkPriorEnvironments(t.Context(), repo, pr,
+		"orders", "mysql", "production", []string{"staging", "production"}, 12345, "testuser")
+	assert.True(t, blocked, "production blocks when the environment list includes staging before production")
+
+	select {
+	case <-checkRunRequests:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected staging GitHub check lookup")
+	}
+	select {
+	case body := <-comments:
+		assert.Contains(t, body, "staging")
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for staging block comment")
+	}
+
+	schemaResult := &ghclient.SchemaRequestResult{Database: "orders", Type: "mysql"}
+	require.NoError(t, h.attachServerEnvironments(schemaResult, "production"))
+	assert.Equal(t, []string{"production"}, schemaResult.Environments)
+
+	blocked = h.checkPriorEnvironments(t.Context(), repo, pr,
+		"orders", "mysql", "production", schemaResult.Environments, 12345, "testuser")
+	assert.True(t, blocked, "production blocks on staging even when this server only has a production target for the database")
+
+	select {
+	case <-checkRunRequests:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected staging GitHub check lookup")
+	}
+	select {
+	case body := <-comments:
+		assert.Contains(t, body, "staging")
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for staging block comment")
+	}
+}
+
 func TestCheckPriorEnvViaGitHub(t *testing.T) {
 	const (
 		repo    = "octocat/hello-world"


### PR DESCRIPTION
## Summary

Preserve staging-before-production enforcement when a scoped SchemaBot deployment only has local routing config for its own environment. Prior-environment gating now uses the server promotion order for scoped deployments, so a production-only deployment still checks the staging aggregate check through GitHub before allowing production applies.

Adds a focused test covering the production-only server config shape and updates configuration/check-run docs to distinguish routing environments from promotion order.

Generated with Amp