### PR TITLE
fix(github): respect repository schema path allowlists

### DIFF
--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -776,6 +776,124 @@ func TestServerConfig_AuthorizePlanSource(t *testing.T) {
 	}
 }
 
+func TestServerConfig_RepoSchemaDirAllowlist(t *testing.T) {
+	cfg := &ServerConfig{
+		Databases: map[string]DatabaseConfig{
+			"payments": {
+				Type: storage.DatabaseTypeMySQL,
+				Environments: map[string]EnvironmentConfig{
+					"staging": {DSN: "root@tcp(localhost)/payments"},
+				},
+				AllowedRepos: []string{"octocat/hello-world"},
+				AllowedDirs:  []string{"schema/payments"},
+			},
+			"ledger": {
+				Type: storage.DatabaseTypeMySQL,
+				Environments: map[string]EnvironmentConfig{
+					"staging": {DSN: "root@tcp(localhost)/ledger"},
+				},
+				AllowedRepos: []string{"octocat/hello-world"},
+				AllowedDirs:  []string{"services/ledger/schema"},
+			},
+			"docs": {
+				Type: storage.DatabaseTypeMySQL,
+				Environments: map[string]EnvironmentConfig{
+					"staging": {DSN: "root@tcp(localhost)/docs"},
+				},
+				AllowedRepos: []string{"octocat/docs"},
+				AllowedDirs:  []string{"schema/docs"},
+			},
+			"open": {
+				Type: storage.DatabaseTypeMySQL,
+				Environments: map[string]EnvironmentConfig{
+					"staging": {DSN: "root@tcp(localhost)/open"},
+				},
+				AllowedDirs: []string{"shared/open"},
+			},
+			"unscoped": {
+				Type: storage.DatabaseTypeMySQL,
+				Environments: map[string]EnvironmentConfig{
+					"staging": {DSN: "root@tcp(localhost)/unscoped"},
+				},
+				AllowedRepos: []string{"octocat/no-dirs"},
+			},
+		},
+	}
+
+	tests := []struct {
+		name          string
+		repo          string
+		schemaPath    string
+		wantAllowlist bool
+		wantAllowed   bool
+	}{
+		{
+			name:          "repo with allowed dirs allows configured path",
+			repo:          "octocat/hello-world",
+			schemaPath:    "schema/payments",
+			wantAllowlist: true,
+			wantAllowed:   true,
+		},
+		{
+			name:          "repo with allowed dirs allows descendant path",
+			repo:          "octocat/hello-world",
+			schemaPath:    "services/ledger/schema/tables",
+			wantAllowlist: true,
+			wantAllowed:   true,
+		},
+		{
+			name:          "repo with allowed dirs rejects sibling path",
+			repo:          "octocat/hello-world",
+			schemaPath:    "schema/payments_archive",
+			wantAllowlist: true,
+			wantAllowed:   false,
+		},
+		{
+			name:          "repo with allowed dirs rejects local fixture path",
+			repo:          "octocat/hello-world",
+			schemaPath:    "schema/local/testapp",
+			wantAllowlist: true,
+			wantAllowed:   false,
+		},
+		{
+			name:          "repo with allowed dirs rejects path owned by another repo",
+			repo:          "octocat/hello-world",
+			schemaPath:    "schema/docs",
+			wantAllowlist: true,
+			wantAllowed:   false,
+		},
+		{
+			name:          "database without allowed repos applies to any repo",
+			repo:          "octocat/another-repo",
+			schemaPath:    "shared/open",
+			wantAllowlist: true,
+			wantAllowed:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.wantAllowlist, cfg.RepoHasSchemaDirAllowlist(tt.repo))
+			assert.Equal(t, tt.wantAllowed, cfg.SchemaPathAllowedForRepo(tt.repo, tt.schemaPath))
+		})
+	}
+
+	noDirCfg := &ServerConfig{
+		Databases: map[string]DatabaseConfig{
+			"unscoped": {
+				Type: storage.DatabaseTypeMySQL,
+				Environments: map[string]EnvironmentConfig{
+					"staging": {DSN: "root@tcp(localhost)/unscoped"},
+				},
+				AllowedRepos: []string{"octocat/no-dirs"},
+			},
+		},
+	}
+
+	assert.False(t, noDirCfg.RepoHasSchemaDirAllowlist("octocat/no-dirs"))
+	assert.False(t, noDirCfg.SchemaPathAllowedForRepo("octocat/no-dirs", "anything/testapp"))
+}
+
 func TestServerConfig_ResolveDatabaseTarget(t *testing.T) {
 	cfg := ServerConfig{
 		Databases: map[string]DatabaseConfig{

--- a/pkg/api/source_policy.go
+++ b/pkg/api/source_policy.go
@@ -115,6 +115,45 @@ func (c *ServerConfig) AuthorizePlanSource(req PlanSourcePolicyRequest) error {
 	return nil
 }
 
+// RepoHasSchemaDirAllowlist reports whether this repository has any configured
+// database with allowed_dirs. When true, those directories are the repo-level
+// ownership boundary for SchemaBot config discovery.
+func (c *ServerConfig) RepoHasSchemaDirAllowlist(repo string) bool {
+	if c == nil {
+		return false
+	}
+	for _, dbConfig := range c.Databases {
+		if len(dbConfig.AllowedDirs) == 0 {
+			continue
+		}
+		if databaseAllowsRepo(dbConfig, repo) {
+			return true
+		}
+	}
+	return false
+}
+
+// SchemaPathAllowedForRepo reports whether schemaPath is under any allowed_dirs
+// for databases this repository may manage. Call RepoHasSchemaDirAllowlist first
+// when callers need to distinguish "no repo allowlist" from "not allowed".
+func (c *ServerConfig) SchemaPathAllowedForRepo(repo, schemaPath string) bool {
+	if c == nil {
+		return false
+	}
+	for _, dbConfig := range c.Databases {
+		if len(dbConfig.AllowedDirs) == 0 {
+			continue
+		}
+		if !databaseAllowsRepo(dbConfig, repo) {
+			continue
+		}
+		if schemaPathAllowed(dbConfig.AllowedDirs, schemaPath) {
+			return true
+		}
+	}
+	return false
+}
+
 func (d DatabaseConfig) hasSourcePolicy() bool {
 	return len(d.AllowedRepos) > 0 || len(d.AllowedDirs) > 0
 }
@@ -168,6 +207,10 @@ func repoAllowed(allowedRepos []string, repo string) bool {
 		}
 	}
 	return false
+}
+
+func databaseAllowsRepo(dbConfig DatabaseConfig, repo string) bool {
+	return len(dbConfig.AllowedRepos) == 0 || repoAllowed(dbConfig.AllowedRepos, repo)
 }
 
 func schemaPathAllowed(allowedDirs []string, schemaPath string) bool {

--- a/pkg/metrics/README.md
+++ b/pkg/metrics/README.md
@@ -58,7 +58,7 @@ available, such as `repository`, `github_app`, and `installation_id`.
 
 **operation** (check ownership): `apply_finished`, `rollback_finished`
 
-**operation** (status checks): `plan_check_recorded`, `apply_started`, `apply_finished`, `rollback_finished`, `aggregate_check_sync`, `stale_check_cleanup`, `stale_check_reconciliation`, `schema_config_discovery`, `schema_config_environment_validation`
+**operation** (status checks): `plan_check_recorded`, `apply_started`, `apply_finished`, `rollback_finished`, `aggregate_check_sync`, `stale_check_cleanup`, `stale_check_reconciliation`, `schema_config_discovery`, `schema_config_source_policy`, `schema_config_environment_validation`
 
 **status** (status checks): `success`, `error`, `skipped`, `stale`, `noop`, `blocked` (operation outcome, not GitHub Check Run conclusion)
 
@@ -145,6 +145,7 @@ Operation values:
 | `stale_check_cleanup` | SchemaBot handled stored check state for a database that is no longer touched by the latest commit on the PR branch. Plan-only state can be cleared; apply-owned state stays blocked. |
 | `stale_check_reconciliation` | SchemaBot repaired stale `in_progress` stored check state by comparing it with authoritative apply state after a worker restart, crash, or race. |
 | `schema_config_discovery` | SchemaBot discovered managed schema configs for the PR before deciding what to plan or which aggregate checks to publish. |
+| `schema_config_source_policy` | SchemaBot evaluated whether a discovered `schemabot.yaml` path is inside this repository's server-owned `allowed_dirs` boundary. `status="skipped"` means the config is outside the managed paths and was ignored; `status="error"` means the config is in a managed path but cannot be routed safely. |
 | `schema_config_environment_validation` | SchemaBot found schema changes but none of the database's server-configured environments are allowed for this deployment, so it failed the aggregate check closed. |
 
 A spike in `status="blocked"` for `operation="aggregate_check_sync"` or

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1046,6 +1046,7 @@ var knownStatusCheckOperations = map[string]bool{
 	"stale_check_cleanup":                  true,
 	"stale_check_reconciliation":           true,
 	"schema_config_discovery":              true,
+	"schema_config_source_policy":          true,
 	"schema_config_environment_validation": true,
 }
 

--- a/pkg/webhook/apply_handlers.go
+++ b/pkg/webhook/apply_handlers.go
@@ -25,7 +25,7 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 	defer cancel()
 
 	// Discover config and fetch schema files from PR
-	schemaResult, err := client.CreateSchemaRequestFromPR(ctx, repo, pr, environment, databaseName)
+	schemaResult, err := h.createManagedSchemaRequestFromPR(ctx, client, repo, pr, environment, databaseName, action.Apply)
 	if err != nil {
 		h.handleSchemaRequestError(repo, pr, installationID, environment, databaseName, requestedBy, action.Apply, err)
 		return
@@ -337,7 +337,7 @@ func (h *Handler) handleApplyConfirmCommand(repo string, pr int, environment, da
 	defer cancel()
 
 	// Discover database config from PR's schemabot.yaml
-	schemaResult, err := client.CreateSchemaRequestFromPR(ctx, repo, pr, environment, databaseName)
+	schemaResult, err := h.createManagedSchemaRequestFromPR(ctx, client, repo, pr, environment, databaseName, action.ApplyConfirm)
 	if err != nil {
 		h.handleSchemaRequestError(repo, pr, installationID, environment, databaseName, requestedBy, action.ApplyConfirm, err)
 		return
@@ -586,15 +586,18 @@ func (h *Handler) inferUnlockDatabase(ctx context.Context, repo string, pr int, 
 		return "", err
 	}
 
-	config, _, err := client.FindConfigForPR(ctx, repo, pr)
+	config, configDir, err := client.FindConfigForPR(ctx, repo, pr)
 	if errors.Is(err, ghclient.ErrNoConfig) {
-		config, _, _, err = client.FindConfigInRepo(ctx, repo, pr)
+		config, configDir, _, err = client.FindConfigInRepo(ctx, repo, pr)
 	}
 	if err != nil {
 		if errors.Is(err, ghclient.ErrMultipleConfigs) {
 			return "", fmt.Errorf("multiple SchemaBot configs match this PR; retry with `schemabot unlock -d <database> --force`: %w", err)
 		}
 		return "", err
+	}
+	if !h.configPathManagedByRepo(ctx, repo, pr, "", config, configDir, action.Unlock) {
+		return "", ghclient.ErrNoConfig
 	}
 	if config == nil || config.Database == "" {
 		return "", fmt.Errorf("no database found in SchemaBot config")

--- a/pkg/webhook/plan.go
+++ b/pkg/webhook/plan.go
@@ -33,7 +33,7 @@ func (h *Handler) handlePlanCommand(w http.ResponseWriter, repo string, pr int, 
 	}
 
 	// Discover config and fetch schema files from PR
-	schemaResult, err := client.CreateSchemaRequestFromPR(ctx, repo, pr, environment, databaseName)
+	schemaResult, err := h.createManagedSchemaRequestFromPR(ctx, client, repo, pr, environment, databaseName, action.Plan)
 	if err != nil {
 		h.handleSchemaRequestError(repo, pr, installationID, environment, databaseName, requestedBy, action.Plan, err)
 		h.writeJSON(w, http.StatusOK, map[string]string{"message": "schema request error handled"})
@@ -146,16 +146,24 @@ func (h *Handler) handleMultiEnvPlan(repo string, pr int, databaseName string, i
 	// Find config to get the database identity. Environments are server-owned.
 	var schemaDatabase string
 	if databaseName != "" {
-		config, _, findErr := client.FindConfigByDatabaseName(ctx, repo, pr, databaseName)
+		config, configDir, findErr := client.FindConfigByDatabaseName(ctx, repo, pr, databaseName)
 		if findErr != nil {
 			h.handleSchemaRequestError(repo, pr, installationID, "", databaseName, requestedBy, action.Plan, findErr)
 			return
 		}
+		if !h.configPathManagedByRepo(ctx, repo, pr, "", config, configDir, action.Plan) {
+			h.handleSchemaRequestError(repo, pr, installationID, "", databaseName, requestedBy, action.Plan, ghclient.ErrNoConfig)
+			return
+		}
 		schemaDatabase = config.Database
 	} else {
-		config, _, findErr := client.FindConfigForPR(ctx, repo, pr)
+		config, configDir, findErr := client.FindConfigForPR(ctx, repo, pr)
 		if findErr != nil {
 			h.handleSchemaRequestError(repo, pr, installationID, "", databaseName, requestedBy, action.Plan, findErr)
+			return
+		}
+		if !h.configPathManagedByRepo(ctx, repo, pr, "", config, configDir, action.Plan) {
+			h.handleSchemaRequestError(repo, pr, installationID, "", databaseName, requestedBy, action.Plan, ghclient.ErrNoConfig)
 			return
 		}
 		schemaDatabase = config.Database
@@ -213,7 +221,7 @@ func (h *Handler) handleMultiEnvPlan(repo string, pr int, databaseName string, i
 	}
 
 	for _, env := range environments {
-		schemaResult, err := client.CreateSchemaRequestFromPR(ctx, repo, pr, env, databaseName)
+		schemaResult, err := h.createManagedSchemaRequestFromPR(ctx, client, repo, pr, env, databaseName, action.Plan)
 		if err != nil {
 			h.logger.Error("schema request failed", "repo", repo, "pr", pr, "env", env, "error", err)
 			multiEnvData.Errors[env] = userFacingError(err)

--- a/pkg/webhook/pull_request.go
+++ b/pkg/webhook/pull_request.go
@@ -186,7 +186,7 @@ func (h *Handler) filterManagedDiscoveredConfigs(ctx context.Context, repo strin
 			})
 			continue
 		}
-		if h.schemaPathManagedByRepo(ctx, repo, pr, headSHA, cfg.Config.Database, string(cfg.Config.GetType()), cfg.SchemaDir, source) {
+		if h.shouldProcessSchemaConfig(ctx, repo, pr, headSHA, cfg.Config.Database, string(cfg.Config.GetType()), cfg.SchemaDir, source) {
 			managed = append(managed, cfg)
 		}
 	}

--- a/pkg/webhook/pull_request.go
+++ b/pkg/webhook/pull_request.go
@@ -124,6 +124,7 @@ func (h *Handler) runAutoPlanForPR(ctx context.Context, client *ghclient.Install
 		h.postConfigDiscoveryFailure(ctx, client, repo, pr, headSHA, err)
 		return "config discovery failed"
 	}
+	configs = h.filterManagedDiscoveredConfigs(ctx, repo, pr, headSHA, source, configs)
 
 	// Collect database names from discovered configs
 	affectedDatabases := make(map[string]bool)
@@ -169,6 +170,27 @@ func (h *Handler) runAutoPlanForPR(ctx context.Context, client *ghclient.Install
 	}
 
 	return "auto-plan started"
+}
+
+func (h *Handler) filterManagedDiscoveredConfigs(ctx context.Context, repo string, pr int, headSHA, source string, configs []ghclient.DiscoveredConfig) []ghclient.DiscoveredConfig {
+	managed := configs[:0]
+	for _, cfg := range configs {
+		if cfg.Config == nil {
+			h.logger.Warn("discovered schema config is missing parsed config and will be ignored",
+				"repo", repo, "pr", pr, "head_sha", headSHA,
+				"schema_path", cfg.SchemaDir, "source", source)
+			metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
+				Operation:  "schema_config_discovery",
+				Repository: repo,
+				Status:     "skipped",
+			})
+			continue
+		}
+		if h.schemaPathManagedByRepo(ctx, repo, pr, headSHA, cfg.Config.Database, string(cfg.Config.GetType()), cfg.SchemaDir, source) {
+			managed = append(managed, cfg)
+		}
+	}
+	return managed
 }
 
 func (h *Handler) postConfigDiscoveryFailure(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, headSHA string, discoveryErr error) {

--- a/pkg/webhook/rollback.go
+++ b/pkg/webhook/rollback.go
@@ -149,7 +149,7 @@ func (h *Handler) handleRollbackConfirmCommand(repo string, pr int, environment,
 	defer cancel()
 
 	// Discover database config from PR's schemabot.yaml
-	schemaResult, err := client.CreateSchemaRequestFromPR(ctx, repo, pr, environment, databaseName)
+	schemaResult, err := h.createManagedSchemaRequestFromPR(ctx, client, repo, pr, environment, databaseName, action.RollbackConfirm)
 	if err != nil {
 		h.handleSchemaRequestError(repo, pr, installationID, environment, databaseName, requestedBy, action.RollbackConfirm, err)
 		return

--- a/pkg/webhook/schema_source_policy.go
+++ b/pkg/webhook/schema_source_policy.go
@@ -1,0 +1,85 @@
+package webhook
+
+import (
+	"context"
+
+	ghclient "github.com/block/schemabot/pkg/github"
+	"github.com/block/schemabot/pkg/metrics"
+)
+
+func (h *Handler) createManagedSchemaRequestFromPR(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, environment, databaseName, source string) (*ghclient.SchemaRequestResult, error) {
+	schemaResult, err := client.CreateSchemaRequestFromPR(ctx, repo, pr, environment, databaseName)
+	if err != nil {
+		return nil, err
+	}
+	if !h.schemaPathManagedByRepo(ctx, repo, pr, schemaResult.HeadSHA, schemaResult.Database, schemaResult.Type, schemaResult.SchemaPath, source) {
+		return nil, ghclient.ErrNoConfig
+	}
+	return schemaResult, nil
+}
+
+func (h *Handler) configPathManagedByRepo(ctx context.Context, repo string, pr int, headSHA string, config *ghclient.SchemabotConfig, schemaPath, source string) bool {
+	if config == nil {
+		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
+			Operation:  "schema_config_discovery",
+			Repository: repo,
+			Status:     "skipped",
+		})
+		h.logger.Warn("schema config is missing parsed config and will be ignored",
+			"repo", repo, "pr", pr, "head_sha", headSHA,
+			"schema_path", schemaPath, "source", source)
+		return false
+	}
+	return h.schemaPathManagedByRepo(ctx, repo, pr, headSHA, config.Database, string(config.GetType()), schemaPath, source)
+}
+
+func (h *Handler) schemaPathManagedByRepo(ctx context.Context, repo string, pr int, headSHA, database, databaseType, schemaPath, source string) bool {
+	config, ok := h.serverConfig()
+	if !ok {
+		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
+			Operation:    "schema_config_source_policy",
+			Repository:   repo,
+			Database:     database,
+			DatabaseType: databaseType,
+			Status:       "error",
+		})
+		h.logger.Warn("schema config source policy cannot be evaluated because server config is unavailable",
+			"repo", repo, "pr", pr, "head_sha", headSHA,
+			"database", database, "database_type", databaseType,
+			"schema_path", schemaPath, "source", source)
+		return true
+	}
+
+	if !config.RepoHasSchemaDirAllowlist(repo) {
+		return true
+	}
+
+	if !config.SchemaPathAllowedForRepo(repo, schemaPath) {
+		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
+			Operation:  "schema_config_source_policy",
+			Repository: repo,
+			Status:     "skipped",
+		})
+		h.logger.Info("schema config is outside repo allowed_dirs and will be ignored",
+			"repo", repo, "pr", pr, "head_sha", headSHA,
+			"database", database, "database_type", databaseType,
+			"schema_path", schemaPath, "source", source)
+		return false
+	}
+
+	if config.Database(database) == nil {
+		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
+			Operation:    "schema_config_source_policy",
+			Repository:   repo,
+			Database:     database,
+			DatabaseType: databaseType,
+			Status:       "error",
+		})
+		h.logger.Warn("schema config is inside repo allowed_dirs but database is not configured",
+			"repo", repo, "pr", pr, "head_sha", headSHA,
+			"database", database, "database_type", databaseType,
+			"schema_path", schemaPath, "source", source)
+	}
+
+	return true
+}

--- a/pkg/webhook/schema_source_policy.go
+++ b/pkg/webhook/schema_source_policy.go
@@ -12,7 +12,7 @@ func (h *Handler) createManagedSchemaRequestFromPR(ctx context.Context, client *
 	if err != nil {
 		return nil, err
 	}
-	if !h.schemaPathManagedByRepo(ctx, repo, pr, schemaResult.HeadSHA, schemaResult.Database, schemaResult.Type, schemaResult.SchemaPath, source) {
+	if !h.shouldProcessSchemaConfig(ctx, repo, pr, schemaResult.HeadSHA, schemaResult.Database, schemaResult.Type, schemaResult.SchemaPath, source) {
 		return nil, ghclient.ErrNoConfig
 	}
 	return schemaResult, nil
@@ -30,10 +30,10 @@ func (h *Handler) configPathManagedByRepo(ctx context.Context, repo string, pr i
 			"schema_path", schemaPath, "source", source)
 		return false
 	}
-	return h.schemaPathManagedByRepo(ctx, repo, pr, headSHA, config.Database, string(config.GetType()), schemaPath, source)
+	return h.shouldProcessSchemaConfig(ctx, repo, pr, headSHA, config.Database, string(config.GetType()), schemaPath, source)
 }
 
-func (h *Handler) schemaPathManagedByRepo(ctx context.Context, repo string, pr int, headSHA, database, databaseType, schemaPath, source string) bool {
+func (h *Handler) shouldProcessSchemaConfig(ctx context.Context, repo string, pr int, headSHA, database, databaseType, schemaPath, source string) bool {
 	config, ok := h.serverConfig()
 	if !ok {
 		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{


### PR DESCRIPTION
## Summary

When a repository has server-configured `allowed_dirs`, treat those directories as the ownership boundary for SchemaBot config discovery. Configs discovered outside the managed paths are ignored instead of failing on an unrelated database name, while configs inside managed paths still fail closed when they cannot be routed safely.

This also adds operator-facing logs and status-check operation metrics for source-policy decisions during schema config discovery.

Generated with Amp.