### PR TITLE
feat(operator): derive applies.state from child apply_operations

### DIFF
--- a/integration/operator_test.go
+++ b/integration/operator_test.go
@@ -264,6 +264,15 @@ func TestOperator_OperatorClaimsOperationToCompletion(t *testing.T) {
 	assert.Equal(t, state.ApplyOperation.Completed, ops[0].State, "operator marks the claimed operation completed")
 	assert.Equal(t, apply.Deployment, ops[0].Deployment)
 	require.NotNil(t, ops[0].CompletedAt, "completed operation stamps completed_at")
+
+	// applies.state is derived from its child operation rows: the parent must
+	// equal DeriveApplyState of the operation states it owns.
+	finalApply, err := ts.Storage.Applies().Get(ctx, apply.ID)
+	require.NoError(t, err)
+	require.NotNil(t, finalApply)
+	derived := state.DeriveApplyState([]string{ops[0].State})
+	assert.Equal(t, state.Apply.Completed, derived)
+	assert.Equal(t, derived, finalApply.State, "parent apply state is derived from its child operations")
 }
 
 // TestOperator_OperatorReconcilesOperationWhenParentTerminal covers the safety
@@ -314,6 +323,15 @@ func TestOperator_OperatorReconcilesOperationWhenParentTerminal(t *testing.T) {
 	require.NotNil(t, op)
 	assert.Equal(t, state.ApplyOperation.Completed, op.State)
 	require.NotNil(t, op.CompletedAt, "reconciled completed operation stamps completed_at")
+
+	// Even on the terminal-parent reconciliation path, the parent stays equal to
+	// DeriveApplyState of its child operations.
+	parent, err := ts.Storage.Applies().Get(ctx, applyID)
+	require.NoError(t, err)
+	require.NotNil(t, parent)
+	derived := state.DeriveApplyState([]string{op.State})
+	assert.Equal(t, state.Apply.Completed, derived)
+	assert.Equal(t, derived, parent.State, "parent apply state is derived from its child operations")
 }
 
 func TestOperator_ClaimOrdering(t *testing.T) {

--- a/pkg/api/operator.go
+++ b/pkg/api/operator.go
@@ -306,7 +306,23 @@ func (s *Service) recoverApplyOperation(ctx context.Context, workerID int, owner
 		return
 	}
 
-	s.markOperationFromApplyState(leasedCtx, workerID, op, finalApply)
+	marked, err := s.markOperationFromApplyState(leasedCtx, workerID, op, finalApply)
+	if err != nil {
+		s.logger.Error("operator: failed to update apply_operation from parent apply state; derived apply state not updated",
+			"worker", workerID, "apply_operation_id", op.ID, "apply_id", finalApply.ApplyIdentifier,
+			"deployment", op.Deployment, "environment", finalApply.Environment, "state", finalApply.State, "error", err)
+		return
+	}
+	if !marked {
+		return
+	}
+
+	if err := s.updateApplyStateFromOperations(leasedCtx, workerID, finalApply); err != nil {
+		s.logger.Error("operator: failed to update derived apply state from apply_operations",
+			"worker", workerID, "apply_operation_id", op.ID, "apply_id", finalApply.ApplyIdentifier,
+			"deployment", op.Deployment, "environment", finalApply.Environment, "error", err)
+		return
+	}
 }
 
 // reconcileUnclaimableParent handles a claimed operation whose parent apply
@@ -345,7 +361,22 @@ func (s *Service) reconcileUnclaimableParent(ctx context.Context, workerID int, 
 			"deployment", op.Deployment,
 			"environment", parent.Environment,
 			"state", parent.State)
-		s.markOperationFromApplyState(ctx, workerID, op, parent)
+		marked, err := s.markOperationFromApplyState(ctx, workerID, op, parent)
+		if err != nil {
+			s.logger.Error("operator: failed to reconcile apply_operation from terminal parent; derived apply state not updated",
+				"worker", workerID, "apply_operation_id", op.ID, "apply_id", parent.ApplyIdentifier,
+				"deployment", op.Deployment, "environment", parent.Environment, "state", parent.State, "error", err)
+			return
+		}
+		if !marked {
+			return
+		}
+		if err := s.updateApplyStateFromOperations(ctx, workerID, parent); err != nil {
+			s.logger.Error("operator: failed to update derived apply state for terminal parent",
+				"worker", workerID, "apply_operation_id", op.ID, "apply_id", parent.ApplyIdentifier,
+				"deployment", op.Deployment, "environment", parent.Environment, "error", err)
+			return
+		}
 		return
 	}
 	s.logger.Warn("operator: parent apply not claimable for operation; operation will be retried",
@@ -512,43 +543,114 @@ func (s *Service) startApplyOperationHeartbeat(ctx context.Context, workerID int
 }
 
 // markOperationFromApplyState transitions the claimed operation row to mirror
-// the parent apply's final state after a successful resume. Non-terminal parent
-// states leave the operation claimable so a later poll re-leases and resumes it.
-func (s *Service) markOperationFromApplyState(ctx context.Context, workerID int, op *storage.ApplyOperation, apply *storage.Apply) {
+// the parent apply's final state after a successful resume.
+//
+// It returns updated=true only when the operation row was durably written to a
+// terminal state, which is the signal the caller needs before deriving the
+// parent apply's state from its children. A non-terminal parent leaves the
+// operation claimable (updated=false, nil error) so a later poll re-leases and
+// resumes it; a write failure returns the error so the caller skips derivation
+// rather than aggregating a stale child state.
+func (s *Service) markOperationFromApplyState(ctx context.Context, workerID int, op *storage.ApplyOperation, apply *storage.Apply) (updated bool, err error) {
 	opStore := s.storage.ApplyOperations()
 	switch {
 	case state.IsState(apply.State, state.Apply.Completed):
 		if err := opStore.MarkCompleted(ctx, op.ID); err != nil {
-			s.logger.Error("operator: failed to mark apply_operation completed",
-				"worker", workerID, "apply_operation_id", op.ID, "apply_id", apply.ApplyIdentifier,
-				"deployment", op.Deployment, "environment", apply.Environment, "error", err)
+			return false, fmt.Errorf("mark apply_operation %d completed (deployment %q): %w", op.ID, op.Deployment, err)
 		}
+		return true, nil
 	case state.IsState(apply.State, state.Apply.Failed):
 		if err := opStore.MarkFailed(ctx, op.ID, apply.ErrorMessage); err != nil {
-			s.logger.Error("operator: failed to mark apply_operation failed",
-				"worker", workerID, "apply_operation_id", op.ID, "apply_id", apply.ApplyIdentifier,
-				"deployment", op.Deployment, "environment", apply.Environment, "error", err)
+			return false, fmt.Errorf("mark apply_operation %d failed (deployment %q): %w", op.ID, op.Deployment, err)
 		}
+		return true, nil
 	case state.IsState(apply.State, state.Apply.Stopped):
 		// stopped is resumable, so mirror the state but leave completed_at nil
 		// (matching the apply-level convention) — stopped work may resume.
 		if err := opStore.UpdateState(ctx, op.ID, apply.State); err != nil {
-			s.logger.Error("operator: failed to update stopped apply_operation state",
-				"worker", workerID, "apply_operation_id", op.ID, "apply_id", apply.ApplyIdentifier,
-				"deployment", op.Deployment, "environment", apply.Environment, "state", apply.State, "error", err)
+			return false, fmt.Errorf("update stopped apply_operation %d state (deployment %q): %w", op.ID, op.Deployment, err)
 		}
+		return true, nil
 	case state.IsTerminalApplyState(apply.State):
 		// cancelled / reverted — non-resumable terminal states; stamp completed_at.
 		if err := opStore.MarkTerminal(ctx, op.ID, apply.State); err != nil {
-			s.logger.Error("operator: failed to mark terminal apply_operation state",
-				"worker", workerID, "apply_operation_id", op.ID, "apply_id", apply.ApplyIdentifier,
-				"deployment", op.Deployment, "environment", apply.Environment, "state", apply.State, "error", err)
+			return false, fmt.Errorf("mark terminal apply_operation %d state %q (deployment %q): %w", op.ID, apply.State, op.Deployment, err)
 		}
+		return true, nil
 	default:
 		s.logger.Debug("operator: parent apply not terminal after resume; leaving operation claimable",
 			"worker", workerID, "apply_operation_id", op.ID, "apply_id", apply.ApplyIdentifier,
 			"deployment", op.Deployment, "environment", apply.Environment, "state", apply.State)
+		return false, nil
 	}
+}
+
+// updateApplyStateFromOperations re-derives applies.state from the apply's child
+// apply_operations rows and persists it when it differs from the current value.
+//
+// This is the inverse of markOperationFromApplyState: the operator drives each
+// operation row to its state, then the parent apply's state follows from the
+// aggregate via the same state.DeriveApplyState that derives apply state from
+// task states. While an apply has exactly one operation the derived value equals
+// the value ResumeApply already persisted, so this is a no-op until the
+// multi-deployment fan-out makes an apply own more than one operation.
+//
+// The caller is responsible for lease scoping: the active operator path passes a
+// lease-scoped context so the write fails closed after ownership changes; the
+// terminal-parent reconciliation path passes an unscoped context, which is safe
+// because a terminal parent has no competing driver and the terminal-to-non-
+// terminal guard below refuses to revive it.
+func (s *Service) updateApplyStateFromOperations(ctx context.Context, workerID int, apply *storage.Apply) error {
+	ops, err := s.storage.ApplyOperations().ListByApply(ctx, apply.ID)
+	if err != nil {
+		return fmt.Errorf("list apply_operations for apply %s (%d): %w", apply.ApplyIdentifier, apply.ID, err)
+	}
+	if len(ops) == 0 {
+		return fmt.Errorf("derive apply state for apply %s (%d): no apply_operations rows", apply.ApplyIdentifier, apply.ID)
+	}
+
+	childStates := make([]string, len(ops))
+	for i, op := range ops {
+		childStates[i] = op.State
+	}
+	derived := state.DeriveApplyState(childStates)
+
+	if state.IsTerminalApplyState(apply.State) && !state.IsTerminalApplyState(derived) {
+		return fmt.Errorf("derive apply state for terminal apply %s (%d): child operations derive non-terminal state %q from parent state %q",
+			apply.ApplyIdentifier, apply.ID, derived, apply.State)
+	}
+
+	if state.IsState(apply.State, derived) {
+		s.logger.Debug("operator: derived apply state matches current; no update",
+			"worker", workerID, "apply_id", apply.ApplyIdentifier,
+			"database", apply.Database, "environment", apply.Environment,
+			"state", derived, "operation_count", len(ops))
+		return nil
+	}
+
+	updated := *apply
+	updated.State = derived
+	switch {
+	case state.IsState(derived, state.Apply.Stopped):
+		// stopped is resumable; keep completed_at nil to match the convention.
+		updated.CompletedAt = nil
+	case state.IsTerminalApplyState(derived):
+		if updated.CompletedAt == nil {
+			now := s.clock.Now()
+			updated.CompletedAt = &now
+		}
+	default:
+		updated.CompletedAt = nil
+	}
+
+	if err := s.storage.Applies().Update(ctx, &updated); err != nil {
+		return fmt.Errorf("update derived apply state for apply %s (%d) to %q: %w", apply.ApplyIdentifier, apply.ID, derived, err)
+	}
+	s.logger.Info("operator: updated derived apply state from apply_operations",
+		"worker", workerID, "apply_id", apply.ApplyIdentifier,
+		"database", apply.Database, "environment", apply.Environment,
+		"previous_state", apply.State, "derived_state", derived, "operation_count", len(ops))
+	return nil
 }
 
 func operatorLeaseOwner(workerID int) string {

--- a/pkg/storage/mysqlstore/apply_operations.go
+++ b/pkg/storage/mysqlstore/apply_operations.go
@@ -407,6 +407,16 @@ const applyOperationHeartbeatStaleness = "1 MINUTE"
 // staleness window) are re-leased without changing their state. Terminal
 // rows are never claimed.
 //
+// Sibling ordering: a pending row is only claimable once every earlier
+// sibling of the same apply (lower created_at, id) has reached completed.
+// This serializes a multi-deployment apply along its deployment_order — the
+// order materialized by the apply-create dual-write into row insertion order
+// — and halts the rollout on the first non-completed sibling (e.g. a failed
+// deployment), since any earlier non-completed row blocks every later one.
+// The gate applies only to starting a pending row; an already-active row
+// re-leasing a stale heartbeat is recovering work it already started, so it
+// is never re-gated.
+//
 // Mirrors ApplyStore.FindNextApply: SELECT ... FOR UPDATE SKIP LOCKED to
 // avoid worker races, READ COMMITTED isolation to prevent next-key range
 // locks from serializing claims across otherwise independent rows.
@@ -424,14 +434,23 @@ func (s *applyOperationStore) FindNextApplyOperation(ctx context.Context) (*stor
 	activeStates := claimableApplyStates()
 	activeStatePlaceholders := placeholders(len(activeStates))
 
-	queryArgs := []any{state.ApplyOperation.Pending}
+	queryArgs := []any{state.ApplyOperation.Pending, state.ApplyOperation.Completed}
 	queryArgs = append(queryArgs, stringArgs(activeStates)...)
 
 	row := tx.QueryRowContext(ctx, fmt.Sprintf(`
 		SELECT %s
 		FROM apply_operations
 		WHERE (
-			state = ?
+			(
+				state = ?
+				AND NOT EXISTS (
+					SELECT 1
+					FROM apply_operations AS earlier
+					WHERE earlier.apply_id = apply_operations.apply_id
+						AND (earlier.created_at, earlier.id) < (apply_operations.created_at, apply_operations.id)
+						AND earlier.state <> ?
+				)
+			)
 			OR (state IN (%s) AND updated_at < NOW() - INTERVAL %s)
 		)
 		ORDER BY created_at, id

--- a/pkg/storage/mysqlstore/apply_operations.go
+++ b/pkg/storage/mysqlstore/apply_operations.go
@@ -436,7 +436,15 @@ func (s *applyOperationStore) FindNextApplyOperation(ctx context.Context) (*stor
 
 	queryArgs := []any{state.ApplyOperation.Pending, state.ApplyOperation.Completed}
 	queryArgs = append(queryArgs, stringArgs(activeStates)...)
+	queryArgs = append(queryArgs,
+		state.ApplyOperation.Stopped,
+		storage.ControlOperationStart, storage.ControlRequestPending)
 
+	// The stopped-row clause mirrors ApplyStore.FindNextApply: a stopped
+	// operation whose parent apply has a pending start request is reclaimable
+	// so the operator can resume it. Like the stale-active clause, it carries
+	// no deployment-order gate — a stopped row already ran, so resuming it is
+	// recovering work it started rather than starting a new deployment.
 	row := tx.QueryRowContext(ctx, fmt.Sprintf(`
 		SELECT %s
 		FROM apply_operations
@@ -452,6 +460,16 @@ func (s *applyOperationStore) FindNextApplyOperation(ctx context.Context) (*stor
 				)
 			)
 			OR (state IN (%s) AND updated_at < NOW() - INTERVAL %s)
+			OR (
+				state = ?
+				AND EXISTS (
+					SELECT 1
+					FROM apply_control_requests cr
+					WHERE cr.apply_id = apply_operations.apply_id
+						AND cr.operation = ?
+						AND cr.status = ?
+				)
+			)
 		)
 		ORDER BY created_at, id
 		LIMIT 1
@@ -487,7 +505,10 @@ func (s *applyOperationStore) FindNextApplyOperation(ctx context.Context) (*stor
 			return nil, nil
 		}
 	} else {
-		// Already-active stale row: just refresh the heartbeat as our lease.
+		// Re-leasing a row that already started: a stale active heartbeat, or a
+		// stopped operation whose parent apply has a pending start request. Both
+		// keep their current state and are driven by the caller, so just refresh
+		// the heartbeat as our lease.
 		_, err = tx.ExecContext(ctx, `
 			UPDATE apply_operations SET updated_at = NOW() WHERE id = ?
 		`, ad.ID)

--- a/pkg/storage/mysqlstore/apply_operations_test.go
+++ b/pkg/storage/mysqlstore/apply_operations_test.go
@@ -758,6 +758,127 @@ func TestApplyOperationStore_FindNextApplyOperation_ConcurrentClaims(t *testing.
 	assert.Equal(t, state.ApplyOperation.Running, persisted.State)
 }
 
+// TestApplyOperationStore_FindNextApplyOperation_OrdersSiblings verifies that
+// a multi-deployment apply is claimed one deployment at a time, in insertion
+// (deployment_order) order: a later sibling stays unclaimable until every
+// earlier sibling has completed. This is the sequential rollout an operator
+// expects — region B never starts before region A finishes.
+func TestApplyOperationStore_FindNextApplyOperation_OrdersSiblings(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", "mysql", "staging")
+	apply := createTestApply(t, store, lock, "apply_op_ordered", 1)
+
+	deployments := []string{"region-a", "region-b", "region-c"}
+	ids := make([]int64, len(deployments))
+	for i, deployment := range deployments {
+		id, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+			ApplyID: apply.ID, Deployment: deployment,
+		})
+		require.NoError(t, err)
+		ids[i] = id
+	}
+
+	// Each claim returns the next deployment in order; the rollout only
+	// advances once the prior deployment is marked completed.
+	for i, deployment := range deployments {
+		claimed, err := store.ApplyOperations().FindNextApplyOperation(ctx)
+		require.NoError(t, err)
+		require.NotNil(t, claimed, "deployment %q should be claimable once earlier siblings completed", deployment)
+		assert.Equal(t, ids[i], claimed.ID)
+		assert.Equal(t, deployment, claimed.Deployment)
+
+		// A second claim before completing the current row yields nothing:
+		// the claimed row is running (not completed), so it gates its siblings.
+		blocked, err := store.ApplyOperations().FindNextApplyOperation(ctx)
+		require.NoError(t, err)
+		assert.Nil(t, blocked, "later siblings must wait while %q is still running", deployment)
+
+		require.NoError(t, store.ApplyOperations().MarkCompleted(ctx, claimed.ID))
+	}
+
+	// All deployments completed → nothing left to claim.
+	done, err := store.ApplyOperations().FindNextApplyOperation(ctx)
+	require.NoError(t, err)
+	assert.Nil(t, done)
+}
+
+// TestApplyOperationStore_FindNextApplyOperation_HaltsOnFailedSibling verifies
+// halt-on-first-failure: when an earlier deployment has failed, no later
+// sibling of the same apply is claimed. The rollout stops until an operator
+// intervenes rather than racing ahead past a failed region.
+func TestApplyOperationStore_FindNextApplyOperation_HaltsOnFailedSibling(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", "mysql", "staging")
+	apply := createTestApply(t, store, lock, "apply_op_halt", 1)
+
+	// region-a failed; region-b and region-c are pending behind it.
+	failedID, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-a", State: state.ApplyOperation.Failed,
+	})
+	require.NoError(t, err)
+	for _, deployment := range []string{"region-b", "region-c"} {
+		_, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+			ApplyID: apply.ID, Deployment: deployment,
+		})
+		require.NoError(t, err)
+	}
+
+	// Backdate the failed row so staleness can't be the reason it's skipped —
+	// the only thing holding the rollout is the earlier non-completed sibling.
+	_, err = testDB.ExecContext(ctx, `
+		UPDATE apply_operations SET updated_at = NOW() - INTERVAL 1 HOUR WHERE id = ?
+	`, failedID)
+	require.NoError(t, err)
+
+	claimed, err := store.ApplyOperations().FindNextApplyOperation(ctx)
+	require.NoError(t, err)
+	assert.Nil(t, claimed, "later siblings must not be claimed once an earlier deployment failed")
+}
+
+// TestApplyOperationStore_FindNextApplyOperation_IsolatesApplies verifies the
+// sibling gate is scoped per apply: a blocked deployment in one apply does not
+// hold back the first deployment of an unrelated apply.
+func TestApplyOperationStore_FindNextApplyOperation_IsolatesApplies(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	// Each apply needs its own lock — only one apply may be active per target.
+	lockA := createTestLock(t, store, "testdb_a", "mysql", "staging")
+	lockB := createTestLock(t, store, "testdb_b", "mysql", "staging")
+
+	// Apply A: region-a running fresh, region-b pending behind it (blocked).
+	applyA := createTestApply(t, store, lockA, "apply_op_iso_a", 1)
+	runningID, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: applyA.ID, Deployment: "region-a",
+	})
+	require.NoError(t, err)
+	require.NoError(t, store.ApplyOperations().MarkStarted(ctx, runningID))
+	_, err = store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: applyA.ID, Deployment: "region-b",
+	})
+	require.NoError(t, err)
+
+	// Apply B: its own first deployment is pending and must be claimable
+	// independently of apply A's in-flight rollout.
+	applyB := createTestApply(t, store, lockB, "apply_op_iso_b", 1)
+	bID, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: applyB.ID, Deployment: "region-a",
+	})
+	require.NoError(t, err)
+
+	claimed, err := store.ApplyOperations().FindNextApplyOperation(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, claimed, "an unrelated apply's first deployment must still be claimable")
+	assert.Equal(t, bID, claimed.ID, "the only claimable row is apply B's first deployment")
+}
+
 // TestApplyOperationStore_FindNextApplyOperation_DBError covers the error
 // surface when the underlying connection is gone.
 func TestApplyOperationStore_FindNextApplyOperation_DBError(t *testing.T) {

--- a/pkg/storage/mysqlstore/apply_operations_test.go
+++ b/pkg/storage/mysqlstore/apply_operations_test.go
@@ -690,6 +690,81 @@ func TestApplyOperationStore_FindNextApplyOperation_SkipsTerminal(t *testing.T) 
 	assert.Nil(t, claimed, "terminal rows must never be re-claimed (full vocabulary)")
 }
 
+// TestApplyOperationStore_FindNextApplyOperation_ClaimsStoppedWithPendingStart
+// verifies stop/start parity with ApplyStore.FindNextApply: a stopped operation
+// whose parent apply has a pending start request is reclaimable so the operator
+// can resume it. Without this, a stopped operation would strand the apply's
+// start request under the operation-claim path. The re-claim keeps the row's
+// stopped state (the resume drive transitions it) and refreshes the heartbeat.
+func TestApplyOperationStore_FindNextApplyOperation_ClaimsStoppedWithPendingStart(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", "mysql", "staging")
+	apply := createTestApplyWithStateAndEnv(t, store, lock, "apply_op_stopped_start", 1, state.Apply.Stopped, "staging")
+
+	id, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-a", State: state.ApplyOperation.Stopped,
+	})
+	require.NoError(t, err)
+
+	_, _, err = store.ControlRequests().RequestPending(ctx, &storage.ApplyControlRequest{
+		ApplyID:     apply.ID,
+		Operation:   storage.ControlOperationStart,
+		Status:      storage.ControlRequestPending,
+		RequestedBy: "operator",
+	})
+	require.NoError(t, err)
+
+	claimed, err := store.ApplyOperations().FindNextApplyOperation(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, claimed, "stopped operation with a pending start request must be reclaimable")
+	assert.Equal(t, id, claimed.ID)
+	assert.Equal(t, state.ApplyOperation.Stopped, claimed.State, "re-claim must keep the stopped state for the resume drive to transition")
+
+	persisted, err := store.ApplyOperations().Get(ctx, id)
+	require.NoError(t, err)
+	require.NotNil(t, persisted)
+	assert.Equal(t, state.ApplyOperation.Stopped, persisted.State)
+	assert.WithinDuration(t, time.Now(), persisted.UpdatedAt, 5*time.Second, "heartbeat must be refreshed on re-claim")
+}
+
+// TestApplyOperationStore_FindNextApplyOperation_SkipsStoppedWithCompletedStart
+// verifies the claim predicate filters on a *pending* start request: once the
+// start request is no longer pending, the stopped operation is terminal again
+// and must not be re-claimed.
+func TestApplyOperationStore_FindNextApplyOperation_SkipsStoppedWithCompletedStart(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", "mysql", "staging")
+	apply := createTestApplyWithStateAndEnv(t, store, lock, "apply_op_stopped_done", 1, state.Apply.Stopped, "staging")
+
+	_, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-a", State: state.ApplyOperation.Stopped,
+	})
+	require.NoError(t, err)
+
+	_, _, err = store.ControlRequests().RequestPending(ctx, &storage.ApplyControlRequest{
+		ApplyID:     apply.ID,
+		Operation:   storage.ControlOperationStart,
+		Status:      storage.ControlRequestPending,
+		RequestedBy: "operator",
+	})
+	require.NoError(t, err)
+	// Move the start request out of pending; the stopped row is terminal again.
+	_, err = testDB.ExecContext(ctx, `
+		UPDATE apply_control_requests SET status = ? WHERE apply_id = ? AND operation = ?
+	`, storage.ControlRequestCompleted, apply.ID, storage.ControlOperationStart)
+	require.NoError(t, err)
+
+	claimed, err := store.ApplyOperations().FindNextApplyOperation(ctx)
+	require.NoError(t, err)
+	assert.Nil(t, claimed, "stopped operation must not be reclaimed once its start request is no longer pending")
+}
+
 // TestApplyOperationStore_FindNextApplyOperation_ConcurrentClaims verifies
 // the SKIP LOCKED contract on a contended row: N workers race to claim a
 // single pending child row, and exactly one wins. Mirrors the apply-level


### PR DESCRIPTION
## What and Why ?

Invert the apply-state source of truth in the flag-gated operator path. After the operator drives an `apply_operations` row to its state, `applies.state` is now **derived** from the apply's child operation rows via the same `state.DeriveApplyState` already used to derive apply state from task states — rather than only being mirrored down onto the operation row.

```
ResumeApply writes durable applies.state
│
▼
operator reloads parent apply
│
▼
markOperationFromApplyState → child operation row reaches its state
│  (reports updated=true only on a durable terminal write)
▼
updateApplyStateFromOperations → re-derive applies.state from ALL
child operations, persist only if it differs
```
Gated behind `operator_claim_operations` (default off); the legacy `FindNextApply` path and `ResumeApply` are untouched. While an apply owns exactly one operation the derived value equals what `ResumeApply` already wrote, so this is a no-op in value — it establishes the aggregation seam the multi-deployment fan-out needs.

Fail-closed: skips derivation when the child write failed (never aggregates a stale child state), refuses to revive a terminal apply from inconsistent children, and errors on an apply with zero operation rows. `markOperationFromApplyState` now returns `(updated bool, err error)` so callers sequence the derivation correctly.
