### PR TITLE
feat(operator): claim apply_operations in deployment order

### DIFF
--- a/pkg/storage/mysqlstore/apply_operations.go
+++ b/pkg/storage/mysqlstore/apply_operations.go
@@ -407,6 +407,16 @@ const applyOperationHeartbeatStaleness = "1 MINUTE"
 // staleness window) are re-leased without changing their state. Terminal
 // rows are never claimed.
 //
+// Sibling ordering: a pending row is only claimable once every earlier
+// sibling of the same apply (lower created_at, id) has reached completed.
+// This serializes a multi-deployment apply along its deployment_order — the
+// order materialized by the apply-create dual-write into row insertion order
+// — and halts the rollout on the first non-completed sibling (e.g. a failed
+// deployment), since any earlier non-completed row blocks every later one.
+// The gate applies only to starting a pending row; an already-active row
+// re-leasing a stale heartbeat is recovering work it already started, so it
+// is never re-gated.
+//
 // Mirrors ApplyStore.FindNextApply: SELECT ... FOR UPDATE SKIP LOCKED to
 // avoid worker races, READ COMMITTED isolation to prevent next-key range
 // locks from serializing claims across otherwise independent rows.
@@ -424,14 +434,23 @@ func (s *applyOperationStore) FindNextApplyOperation(ctx context.Context) (*stor
 	activeStates := claimableApplyStates()
 	activeStatePlaceholders := placeholders(len(activeStates))
 
-	queryArgs := []any{state.ApplyOperation.Pending}
+	queryArgs := []any{state.ApplyOperation.Pending, state.ApplyOperation.Completed}
 	queryArgs = append(queryArgs, stringArgs(activeStates)...)
 
 	row := tx.QueryRowContext(ctx, fmt.Sprintf(`
 		SELECT %s
 		FROM apply_operations
 		WHERE (
-			state = ?
+			(
+				state = ?
+				AND NOT EXISTS (
+					SELECT 1
+					FROM apply_operations AS earlier
+					WHERE earlier.apply_id = apply_operations.apply_id
+						AND (earlier.created_at, earlier.id) < (apply_operations.created_at, apply_operations.id)
+						AND earlier.state <> ?
+				)
+			)
 			OR (state IN (%s) AND updated_at < NOW() - INTERVAL %s)
 		)
 		ORDER BY created_at, id

--- a/pkg/storage/mysqlstore/apply_operations_test.go
+++ b/pkg/storage/mysqlstore/apply_operations_test.go
@@ -758,6 +758,127 @@ func TestApplyOperationStore_FindNextApplyOperation_ConcurrentClaims(t *testing.
 	assert.Equal(t, state.ApplyOperation.Running, persisted.State)
 }
 
+// TestApplyOperationStore_FindNextApplyOperation_OrdersSiblings verifies that
+// a multi-deployment apply is claimed one deployment at a time, in insertion
+// (deployment_order) order: a later sibling stays unclaimable until every
+// earlier sibling has completed. This is the sequential rollout an operator
+// expects — region B never starts before region A finishes.
+func TestApplyOperationStore_FindNextApplyOperation_OrdersSiblings(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", "mysql", "staging")
+	apply := createTestApply(t, store, lock, "apply_op_ordered", 1)
+
+	deployments := []string{"region-a", "region-b", "region-c"}
+	ids := make([]int64, len(deployments))
+	for i, deployment := range deployments {
+		id, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+			ApplyID: apply.ID, Deployment: deployment,
+		})
+		require.NoError(t, err)
+		ids[i] = id
+	}
+
+	// Each claim returns the next deployment in order; the rollout only
+	// advances once the prior deployment is marked completed.
+	for i, deployment := range deployments {
+		claimed, err := store.ApplyOperations().FindNextApplyOperation(ctx)
+		require.NoError(t, err)
+		require.NotNil(t, claimed, "deployment %q should be claimable once earlier siblings completed", deployment)
+		assert.Equal(t, ids[i], claimed.ID)
+		assert.Equal(t, deployment, claimed.Deployment)
+
+		// A second claim before completing the current row yields nothing:
+		// the claimed row is running (not completed), so it gates its siblings.
+		blocked, err := store.ApplyOperations().FindNextApplyOperation(ctx)
+		require.NoError(t, err)
+		assert.Nil(t, blocked, "later siblings must wait while %q is still running", deployment)
+
+		require.NoError(t, store.ApplyOperations().MarkCompleted(ctx, claimed.ID))
+	}
+
+	// All deployments completed → nothing left to claim.
+	done, err := store.ApplyOperations().FindNextApplyOperation(ctx)
+	require.NoError(t, err)
+	assert.Nil(t, done)
+}
+
+// TestApplyOperationStore_FindNextApplyOperation_HaltsOnFailedSibling verifies
+// halt-on-first-failure: when an earlier deployment has failed, no later
+// sibling of the same apply is claimed. The rollout stops until an operator
+// intervenes rather than racing ahead past a failed region.
+func TestApplyOperationStore_FindNextApplyOperation_HaltsOnFailedSibling(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", "mysql", "staging")
+	apply := createTestApply(t, store, lock, "apply_op_halt", 1)
+
+	// region-a failed; region-b and region-c are pending behind it.
+	failedID, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-a", State: state.ApplyOperation.Failed,
+	})
+	require.NoError(t, err)
+	for _, deployment := range []string{"region-b", "region-c"} {
+		_, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+			ApplyID: apply.ID, Deployment: deployment,
+		})
+		require.NoError(t, err)
+	}
+
+	// Backdate the failed row so staleness can't be the reason it's skipped —
+	// the only thing holding the rollout is the earlier non-completed sibling.
+	_, err = testDB.ExecContext(ctx, `
+		UPDATE apply_operations SET updated_at = NOW() - INTERVAL 1 HOUR WHERE id = ?
+	`, failedID)
+	require.NoError(t, err)
+
+	claimed, err := store.ApplyOperations().FindNextApplyOperation(ctx)
+	require.NoError(t, err)
+	assert.Nil(t, claimed, "later siblings must not be claimed once an earlier deployment failed")
+}
+
+// TestApplyOperationStore_FindNextApplyOperation_IsolatesApplies verifies the
+// sibling gate is scoped per apply: a blocked deployment in one apply does not
+// hold back the first deployment of an unrelated apply.
+func TestApplyOperationStore_FindNextApplyOperation_IsolatesApplies(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	// Each apply needs its own lock — only one apply may be active per target.
+	lockA := createTestLock(t, store, "testdb_a", "mysql", "staging")
+	lockB := createTestLock(t, store, "testdb_b", "mysql", "staging")
+
+	// Apply A: region-a running fresh, region-b pending behind it (blocked).
+	applyA := createTestApply(t, store, lockA, "apply_op_iso_a", 1)
+	runningID, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: applyA.ID, Deployment: "region-a",
+	})
+	require.NoError(t, err)
+	require.NoError(t, store.ApplyOperations().MarkStarted(ctx, runningID))
+	_, err = store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: applyA.ID, Deployment: "region-b",
+	})
+	require.NoError(t, err)
+
+	// Apply B: its own first deployment is pending and must be claimable
+	// independently of apply A's in-flight rollout.
+	applyB := createTestApply(t, store, lockB, "apply_op_iso_b", 1)
+	bID, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: applyB.ID, Deployment: "region-a",
+	})
+	require.NoError(t, err)
+
+	claimed, err := store.ApplyOperations().FindNextApplyOperation(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, claimed, "an unrelated apply's first deployment must still be claimable")
+	assert.Equal(t, bID, claimed.ID, "the only claimable row is apply B's first deployment")
+}
+
 // TestApplyOperationStore_FindNextApplyOperation_DBError covers the error
 // surface when the underlying connection is gone.
 func TestApplyOperationStore_FindNextApplyOperation_DBError(t *testing.T) {


### PR DESCRIPTION
## What and Why ?

Make the operator claim child `apply_operations` rows of a multi-deployment apply **in deployment order**, advancing one deployment at a time and halting on the first non-completed (e.g. failed) deployment.

A pending row is only claimable once every earlier sibling of the same apply has reached `completed`. Because any earlier non-completed sibling blocks every later one, this single predicate also gives halt-on-first-failure for free. Stale-active re-lease is deliberately left ungated — an already-started row is recovering work, not starting it — so recovery always proceeds.
```
apply A:  region-a ──completed──▶ region-b ──completed──▶ region-c
if region-a fails ─▶ later regions are never claimed
```
This is **additive and dormant**: while the config hard-block keeps every apply at one deployment, the gate is a no-op (no earlier siblings → unchanged behaviour). It is fully exercised by storage tests that seed multiple `apply_operations` rows directly.

## Where this sits in the multi-deployment rollout

This PR is the **ordered-cutover claim predicate** — the core scheduling mechanism. Three related steps complete the workstream:

1. **(prerequisite)** Derive `applies.state` from child `apply_operations` (the branch this is stacked on) — establishes the parent state this rollout drives toward.
2. **(later)** Operation-scoped parallel execution (operation-scoped engine drive, operation-level lease, 4-tuple active lock) — what actually unblocks parallel table copy.
3. **(later)** Flip the `operator_claim_operations` flag default on and lift the `len(deployments) > 1` hard-block — safe only after step 2, else the parent apply lease serializes execution.

## Changes
- `FindNextApplyOperation`: correlated `NOT EXISTS` sibling-completion gate on the pending claim branch only.
- Storage tests: ordered sibling claiming, halt-on-failed-sibling, per-apply isolation.

