### PR TITLE
feat(storage): scope the active-apply check by deployment

### DIFF
--- a/pkg/storage/mysqlstore/applies.go
+++ b/pkg/storage/mysqlstore/applies.go
@@ -252,28 +252,40 @@ func closeApplyTargetLockConn(ctx context.Context, conn *sql.Conn, lockName, ope
 	}
 }
 
-func checkNoActiveApplyForTarget(ctx context.Context, tx *sql.Tx, database, dbType, environment string, excludeApplyID int64) error {
-	statePredicate, stateArgs := nonTerminalApplyStatePredicate("state")
+// checkNoActiveApplyForTarget enforces the "one active apply per target"
+// invariant, scoped to the 4-tuple (database, type, environment, deployment).
+// Deployment is part of the identity because each deployment is a distinct
+// physical target (its own Tern endpoint): two applies for the same
+// environment but different deployments touch different databases and may run
+// concurrently, while a second apply for the same deployment is rejected.
+//
+// While the config layer hard-blocks more than one deployment per environment
+// there is a 1-to-1 mapping between (database, type, environment) and the
+// 4-tuple, so this scoping is a no-op today; it only diverges once that
+// hard-block lifts and an environment fans out across deployments.
+func checkNoActiveApplyForTarget(ctx context.Context, tx *sql.Tx, database, dbType, environment, deployment string, excludeApplyID int64) error {
+	statePredicate, stateArgs := nonTerminalApplyStatePredicate("`state`")
 	query := fmt.Sprintf(`
-		SELECT count(*) FROM applies FORCE INDEX (idx_database_env)
-		WHERE database_name = ?
-		AND database_type = ?
-		AND environment = ?
+		SELECT count(*) FROM `+"`applies`"+` FORCE INDEX (`+"`idx_database_env_deployment`"+`)
+		WHERE `+"`database_name`"+` = ?
+		AND `+"`database_type`"+` = ?
+		AND `+"`environment`"+` = ?
+		AND `+"`deployment`"+` = ?
 		AND %s
 	`, statePredicate)
-	args := append([]any{database, dbType, environment}, stateArgs...)
+	args := append([]any{database, dbType, environment, deployment}, stateArgs...)
 	if excludeApplyID > 0 {
-		query += " AND id != ?"
+		query += " AND `id` != ?"
 		args = append(args, excludeApplyID)
 	}
 
 	var activeCount int64
 	err := tx.QueryRowContext(ctx, query, args...).Scan(&activeCount)
 	if err != nil {
-		return fmt.Errorf("check active applies for %s/%s/%s: %w", database, dbType, environment, err)
+		return fmt.Errorf("check active applies for %s/%s/%s/%s: %w", database, dbType, environment, deployment, err)
 	}
 	if activeCount > 0 {
-		return fmt.Errorf("active apply exists for %s/%s/%s: %w", database, dbType, environment, storage.ErrActiveApplyExists)
+		return fmt.Errorf("active apply exists for %s/%s/%s/%s: %w", database, dbType, environment, deployment, storage.ErrActiveApplyExists)
 	}
 	return nil
 }
@@ -319,24 +331,30 @@ func ensureApplyLeaseStillOwned(ctx context.Context, db queryRower, lease storag
 	return nil
 }
 
-func applyTargetForUpdate(ctx context.Context, db queryRower, apply *storage.Apply) (string, string, string, error) {
-	if hasApplyTarget(apply.Database, apply.DatabaseType, apply.Environment) {
-		return apply.Database, apply.DatabaseType, apply.Environment, nil
+// applyTargetForUpdate resolves the (database, type, environment, deployment)
+// target an update should lock and check against. The stored row is
+// authoritative, so it is reloaded whenever the in-memory apply is missing the
+// 3-tuple target or carries an empty deployment (the Go zero value is
+// indistinguishable from "not populated", and deployment is part of the active
+// target identity).
+func applyTargetForUpdate(ctx context.Context, db queryRower, apply *storage.Apply) (string, string, string, string, error) {
+	if hasApplyTarget(apply.Database, apply.DatabaseType, apply.Environment) && apply.Deployment != "" {
+		return apply.Database, apply.DatabaseType, apply.Environment, apply.Deployment, nil
 	}
 
-	var database, dbType, environment string
+	var database, dbType, environment, deployment string
 	err := db.QueryRowContext(ctx, `
-		SELECT database_name, database_type, environment
-		FROM applies
-		WHERE id = ?
-	`, apply.ID).Scan(&database, &dbType, &environment)
+		SELECT `+"`database_name`, `database_type`, `environment`, `deployment`"+`
+		FROM `+"`applies`"+`
+		WHERE `+"`id`"+` = ?
+	`, apply.ID).Scan(&database, &dbType, &environment, &deployment)
 	if errors.Is(err, sql.ErrNoRows) {
-		return "", "", "", nil
+		return "", "", "", "", nil
 	}
 	if err != nil {
-		return "", "", "", fmt.Errorf("load apply target for update %d: %w", apply.ID, err)
+		return "", "", "", "", fmt.Errorf("load apply target for update %d: %w", apply.ID, err)
 	}
-	return database, dbType, environment, nil
+	return database, dbType, environment, deployment, nil
 }
 
 // Create stores a new apply and returns its ID.
@@ -364,7 +382,7 @@ func (s *applyStore) Create(ctx context.Context, apply *storage.Apply) (int64, e
 	defer writeTx.close(ctx, "create apply")
 
 	if lockTarget {
-		if err := checkNoActiveApplyForTarget(ctx, writeTx.tx, apply.Database, apply.DatabaseType, apply.Environment, 0); err != nil {
+		if err := checkNoActiveApplyForTarget(ctx, writeTx.tx, apply.Database, apply.DatabaseType, apply.Environment, apply.Deployment, 0); err != nil {
 			return 0, err
 		}
 	}
@@ -435,7 +453,7 @@ func (s *applyStore) CreateWithTasksAndOperations(ctx context.Context, apply *st
 	defer writeTx.close(ctx, opName)
 
 	if lockTarget {
-		if err := checkNoActiveApplyForTarget(ctx, writeTx.tx, apply.Database, apply.DatabaseType, apply.Environment, 0); err != nil {
+		if err := checkNoActiveApplyForTarget(ctx, writeTx.tx, apply.Database, apply.DatabaseType, apply.Environment, apply.Deployment, 0); err != nil {
 			return 0, err
 		}
 	}
@@ -599,9 +617,9 @@ func (s *applyStore) Update(ctx context.Context, apply *storage.Apply) error {
 		return err
 	}
 	lockTarget := isActiveApplyState(apply.State)
-	database, dbType, environment := apply.Database, apply.DatabaseType, apply.Environment
-	if lockTarget && !hasApplyTarget(database, dbType, environment) {
-		database, dbType, environment, err = applyTargetForUpdate(ctx, s.db, apply)
+	database, dbType, environment, deployment := apply.Database, apply.DatabaseType, apply.Environment, apply.Deployment
+	if lockTarget && (!hasApplyTarget(database, dbType, environment) || deployment == "") {
+		database, dbType, environment, deployment, err = applyTargetForUpdate(ctx, s.db, apply)
 		if err != nil {
 			return err
 		}
@@ -623,7 +641,7 @@ func (s *applyStore) Update(ctx context.Context, apply *storage.Apply) error {
 	defer writeTx.close(ctx, "update apply")
 
 	if shouldLockTarget {
-		if err := checkNoActiveApplyForTarget(ctx, writeTx.tx, database, dbType, environment, apply.ID); err != nil {
+		if err := checkNoActiveApplyForTarget(ctx, writeTx.tx, database, dbType, environment, deployment, apply.ID); err != nil {
 			return err
 		}
 	}

--- a/pkg/storage/mysqlstore/applies.go
+++ b/pkg/storage/mysqlstore/applies.go
@@ -264,30 +264,31 @@ func closeApplyTargetLockConn(ctx context.Context, conn *sql.Conn, lockName, ope
 // 4-tuple, so this scoping is a no-op today; it only diverges once that
 // hard-block lifts and an environment fans out across deployments.
 func checkNoActiveApplyForTarget(ctx context.Context, tx *sql.Tx, database, dbType, environment, deployment string, excludeApplyID int64) error {
-	statePredicate, stateArgs := nonTerminalApplyStatePredicate("`state`")
+	statePredicate, stateArgs := nonTerminalApplyStatePredicate("state")
 	query := fmt.Sprintf(`
-		SELECT count(*) FROM `+"`applies`"+` FORCE INDEX (`+"`idx_database_env_deployment`"+`)
-		WHERE `+"`database_name`"+` = ?
-		AND `+"`database_type`"+` = ?
-		AND `+"`environment`"+` = ?
-		AND `+"`deployment`"+` = ?
+		SELECT 1 FROM applies FORCE INDEX (idx_database_env_deployment)
+		WHERE database_name = ?
+		AND database_type = ?
+		AND environment = ?
+		AND deployment = ?
 		AND %s
 	`, statePredicate)
 	args := append([]any{database, dbType, environment, deployment}, stateArgs...)
 	if excludeApplyID > 0 {
-		query += " AND `id` != ?"
+		query += " AND id != ?"
 		args = append(args, excludeApplyID)
 	}
+	query += " LIMIT 1"
 
-	var activeCount int64
-	err := tx.QueryRowContext(ctx, query, args...).Scan(&activeCount)
+	var exists int
+	err := tx.QueryRowContext(ctx, query, args...).Scan(&exists)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil
+	}
 	if err != nil {
 		return fmt.Errorf("check active applies for %s/%s/%s/%s: %w", database, dbType, environment, deployment, err)
 	}
-	if activeCount > 0 {
-		return fmt.Errorf("active apply exists for %s/%s/%s/%s: %w", database, dbType, environment, deployment, storage.ErrActiveApplyExists)
-	}
-	return nil
+	return fmt.Errorf("active apply exists for %s/%s/%s/%s: %w", database, dbType, environment, deployment, storage.ErrActiveApplyExists)
 }
 
 func applyLeaseFromContext(ctx context.Context, applyID int64) (storage.ApplyLease, bool, error) {
@@ -344,9 +345,9 @@ func applyTargetForUpdate(ctx context.Context, db queryRower, apply *storage.App
 
 	var database, dbType, environment, deployment string
 	err := db.QueryRowContext(ctx, `
-		SELECT `+"`database_name`, `database_type`, `environment`, `deployment`"+`
-		FROM `+"`applies`"+`
-		WHERE `+"`id`"+` = ?
+		SELECT database_name, database_type, environment, deployment
+		FROM applies
+		WHERE id = ?
 	`, apply.ID).Scan(&database, &dbType, &environment, &deployment)
 	if errors.Is(err, sql.ErrNoRows) {
 		return "", "", "", "", nil

--- a/pkg/storage/mysqlstore/applies_test.go
+++ b/pkg/storage/mysqlstore/applies_test.go
@@ -515,6 +515,47 @@ func TestApplyStore_CreateBlocksActiveApplyForSameTarget(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// TestApplyStore_CreateScopesActiveApplyByDeployment verifies the active-apply
+// invariant is keyed on the full (database, type, environment, deployment)
+// target. Two deployments under the same environment are distinct physical
+// targets, so both may be active at once; a second active apply for the same
+// deployment is still rejected.
+func TestApplyStore_CreateScopesActiveApplyByDeployment(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", "mysql", "staging")
+
+	newApply := func(identifier, deployment string, planID int64) *storage.Apply {
+		return &storage.Apply{
+			ApplyIdentifier: identifier,
+			LockID:          lock.ID,
+			PlanID:          planID,
+			Database:        "testdb",
+			DatabaseType:    "mysql",
+			Repository:      "org/repo",
+			PullRequest:     123,
+			Environment:     "staging",
+			Deployment:      deployment,
+			Engine:          "spirit",
+			State:           state.Apply.Running,
+		}
+	}
+
+	// First deployment becomes active.
+	_, err := store.Applies().Create(ctx, newApply("apply_region_a", "region-a", 1))
+	require.NoError(t, err)
+
+	// A different deployment under the same environment is allowed concurrently.
+	_, err = store.Applies().Create(ctx, newApply("apply_region_b", "region-b", 2))
+	require.NoError(t, err, "different deployments are distinct targets and may be active together")
+
+	// A second active apply for an already-active deployment is rejected.
+	_, err = store.Applies().Create(ctx, newApply("apply_region_a_again", "region-a", 3))
+	require.ErrorIs(t, err, storage.ErrActiveApplyExists, "same 4-tuple target must still be exclusive")
+}
+
 func TestApplyStore_CreateWaitsForApplyTargetLock(t *testing.T) {
 	clearTables(t)
 	ctx := t.Context()


### PR DESCRIPTION
## What and Why ?

Make the "one active apply per target" invariant deployment-aware: the authoritative active-apply check now keys on the full `(database, type, environment, deployment)` identity instead of `(database, type, environment)`.

Each deployment is a distinct physical target (its own Tern endpoint), so two applies for the same environment but different deployments touch different databases and may run concurrently. A second active apply for the *same* deployment is still rejected.
```
same env, different deployments → both may be active
same (db,type,env,deployment)  → ErrActiveApplyExists
```
This is **additive and dormant**: while the config layer hard-blocks more than one deployment per environment there is a 1-to-1 mapping between the 3-tuple and the 4-tuple, so behaviour is unchanged today. It only diverges once that hard-block lifts and an environment fans out across deployments.

The env-scoped advisory lock is intentionally left unchanged — it only serializes the brief check+insert critical section (not apply execution), so it never blocks different deployments from coexisting, and keeping the lock name stable avoids a rolling-deploy window where old and new pods would hash to different lock names.

## Changes
- `checkNoActiveApplyForTarget`: add `deployment` to the predicate; use `idx_database_env_deployment`.
- `applyTargetForUpdate`: return and reload `deployment` (reload when the in-memory value is empty).
- Thread `deployment` through the Create / op / Update call sites.
- Test: `TestApplyStore_CreateScopesActiveApplyByDeployment`.

## Where this sits

This is **stage 3b** of making the active-target identity deployment-aware — the third of three changes needed for true multi-deployment parallel execution:

1. **Operation-scoped engine drive** — a worker drives a single operation's tasks (keyed by `apply_operation_id`) instead of resuming the whole parent apply. *(follow-up, not yet open)*
2. **Operation-level lease** — guarded writes key off the per-operation claim rather than the parent `applies.lease_token`, so sibling deployments can run concurrently. *(follow-up, not yet open)*
3. **Deployment-aware active-target identity** `(database, type, environment, deployment)` — so two deployments under one environment count as distinct targets:
   - **3a — schema**: the `deployment` column plus the `idx_apply_target_v2` and `idx_database_env_deployment` composite indexes — landed in #194.
   - **3b — this PR**: scope the authoritative active-apply check by `deployment`.

Flipping the operator-claim flag default on and lifting the `len(deployments) > 1` config hard-block come later still, and must not land before items 1–3 — otherwise the parent apply lease would serialize execution and there would be no real parallelism.
