### PR TITLE
feat(storage): add Tasks().GetByApplyOperationID

### DIFF
--- a/pkg/storage/mysqlstore/tasks.go
+++ b/pkg/storage/mysqlstore/tasks.go
@@ -164,9 +164,9 @@ func (s *taskStore) GetByApplyID(ctx context.Context, applyID int64) ([]*storage
 func (s *taskStore) GetByApplyOperationID(ctx context.Context, applyOperationID int64) ([]*storage.Task, error) {
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT `+taskColumns+`
-		FROM `+"`tasks`"+` FORCE INDEX (`+"`idx_apply_operation_id`"+`)
-		WHERE `+"`apply_operation_id`"+` = ?
-		ORDER BY `+"`created_at`"+` DESC
+		FROM tasks FORCE INDEX (idx_apply_operation_id)
+		WHERE apply_operation_id = ?
+		ORDER BY created_at DESC, id DESC
 	`, applyOperationID)
 	if err != nil {
 		return nil, fmt.Errorf("query tasks for apply_operation %d: %w", applyOperationID, err)

--- a/pkg/storage/mysqlstore/tasks.go
+++ b/pkg/storage/mysqlstore/tasks.go
@@ -156,6 +156,26 @@ func (s *taskStore) GetByApplyID(ctx context.Context, applyID int64) ([]*storage
 	return scanTasks(rows)
 }
 
+// GetByApplyOperationID returns the tasks for a single apply_operation (one
+// deployment of a multi-deployment apply). While the config layer hard-blocks
+// more than one deployment per environment this returns the same rows as
+// GetByApplyID for the apply's single operation; it lets a worker drive and
+// reconcile one deployment independently once an apply fans out across several.
+func (s *taskStore) GetByApplyOperationID(ctx context.Context, applyOperationID int64) ([]*storage.Task, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT `+taskColumns+`
+		FROM `+"`tasks`"+` FORCE INDEX (`+"`idx_apply_operation_id`"+`)
+		WHERE `+"`apply_operation_id`"+` = ?
+		ORDER BY `+"`created_at`"+` DESC
+	`, applyOperationID)
+	if err != nil {
+		return nil, fmt.Errorf("query tasks for apply_operation %d: %w", applyOperationID, err)
+	}
+	defer utils.CloseAndLog(rows)
+
+	return scanTasks(rows)
+}
+
 // GetByDatabase returns all tasks for a database.
 // Results are ordered by created_at DESC, then by id DESC as a tiebreaker
 // (since created_at only has second precision).

--- a/pkg/storage/mysqlstore/tasks.go
+++ b/pkg/storage/mysqlstore/tasks.go
@@ -164,7 +164,7 @@ func (s *taskStore) GetByApplyID(ctx context.Context, applyID int64) ([]*storage
 func (s *taskStore) GetByApplyOperationID(ctx context.Context, applyOperationID int64) ([]*storage.Task, error) {
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT `+taskColumns+`
-		FROM tasks FORCE INDEX (idx_apply_operation_id)
+		FROM tasks
 		WHERE apply_operation_id = ?
 		ORDER BY created_at DESC, id DESC
 	`, applyOperationID)

--- a/pkg/storage/mysqlstore/tasks.go
+++ b/pkg/storage/mysqlstore/tasks.go
@@ -173,7 +173,16 @@ func (s *taskStore) GetByApplyOperationID(ctx context.Context, applyOperationID 
 	}
 	defer utils.CloseAndLog(rows)
 
-	return scanTasks(rows)
+	tasks, err := scanTasks(rows)
+	if err != nil {
+		return nil, err
+	}
+	if tasks == nil {
+		// Return a non-nil empty slice so callers can never confuse "operation
+		// has no tasks" with nil and fall back to the parent apply's tasks.
+		return []*storage.Task{}, nil
+	}
+	return tasks, nil
 }
 
 // GetByDatabase returns all tasks for a database.

--- a/pkg/storage/mysqlstore/tasks_test.go
+++ b/pkg/storage/mysqlstore/tasks_test.go
@@ -33,6 +33,10 @@ func TestTaskStore_GetByApplyOperationID(t *testing.T) {
 		ApplyID: apply.ID, Deployment: "region-b", Target: "payments",
 	})
 	require.NoError(t, err)
+	opEmpty, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-c", Target: "payments",
+	})
+	require.NoError(t, err)
 
 	createTask := func(identifier, table string, operationID int64) {
 		now := time.Now()
@@ -80,9 +84,10 @@ func TestTaskStore_GetByApplyOperationID(t *testing.T) {
 	require.NotNil(t, tasksB[0].ApplyOperationID)
 	assert.Equal(t, opB, *tasksB[0].ApplyOperationID)
 
-	// An operation with no tasks returns an empty slice — no fallback to the
-	// parent apply's tasks.
-	tasksNone, err := store.Tasks().GetByApplyOperationID(ctx, opB+1000)
+	// A real operation row that owns zero tasks returns a non-nil empty slice —
+	// never nil and never a fallback to the parent apply's tasks.
+	tasksEmpty, err := store.Tasks().GetByApplyOperationID(ctx, opEmpty)
 	require.NoError(t, err)
-	assert.Empty(t, tasksNone)
+	require.NotNil(t, tasksEmpty)
+	assert.Empty(t, tasksEmpty)
 }

--- a/pkg/storage/mysqlstore/tasks_test.go
+++ b/pkg/storage/mysqlstore/tasks_test.go
@@ -60,11 +60,13 @@ func TestTaskStore_GetByApplyOperationID(t *testing.T) {
 	createTask("task_b_users", "users", opB)
 
 	// region-a's operation returns only its two tasks, never region-b's.
+	// created_at is second-precision, so both tasks usually share a timestamp;
+	// the id DESC tiebreaker makes the order deterministic (newest id first).
 	tasksA, err := store.Tasks().GetByApplyOperationID(ctx, opA)
 	require.NoError(t, err)
 	require.Len(t, tasksA, 2)
-	identifiersA := []string{tasksA[0].TaskIdentifier, tasksA[1].TaskIdentifier}
-	assert.ElementsMatch(t, []string{"task_a_users", "task_a_orders"}, identifiersA)
+	assert.Equal(t, "task_a_orders", tasksA[0].TaskIdentifier)
+	assert.Equal(t, "task_a_users", tasksA[1].TaskIdentifier)
 	for _, task := range tasksA {
 		require.NotNil(t, task.ApplyOperationID)
 		assert.Equal(t, opA, *task.ApplyOperationID)

--- a/pkg/storage/mysqlstore/tasks_test.go
+++ b/pkg/storage/mysqlstore/tasks_test.go
@@ -1,0 +1,86 @@
+//go:build integration
+
+package mysqlstore
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/block/schemabot/pkg/state"
+	"github.com/block/schemabot/pkg/storage"
+)
+
+// TestTaskStore_GetByApplyOperationID verifies that tasks can be loaded for a
+// single apply_operation (one deployment) independently of its sibling
+// deployments under the same apply. This is the read primitive an operator
+// worker uses to drive only the deployment it has claimed.
+func TestTaskStore_GetByApplyOperationID(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", "mysql", "staging")
+	apply := createTestApply(t, store, lock, "apply_tasks_by_op", 1)
+
+	opA, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-a", Target: "payments",
+	})
+	require.NoError(t, err)
+	opB, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-b", Target: "payments",
+	})
+	require.NoError(t, err)
+
+	createTask := func(identifier, table string, operationID int64) {
+		now := time.Now()
+		_, err := store.Tasks().Create(ctx, &storage.Task{
+			TaskIdentifier:   identifier,
+			ApplyID:          apply.ID,
+			ApplyOperationID: &operationID,
+			PlanID:           apply.PlanID,
+			Database:         apply.Database,
+			DatabaseType:     apply.DatabaseType,
+			Engine:           storage.EngineSpirit,
+			Environment:      apply.Environment,
+			State:            state.Task.Pending,
+			TableName:        table,
+			DDL:              "ALTER TABLE " + table + " ADD COLUMN email VARCHAR(255)",
+			DDLAction:        "ALTER",
+			CreatedAt:        now,
+			UpdatedAt:        now,
+		})
+		require.NoError(t, err)
+	}
+
+	createTask("task_a_users", "users", opA)
+	createTask("task_a_orders", "orders", opA)
+	createTask("task_b_users", "users", opB)
+
+	// region-a's operation returns only its two tasks, never region-b's.
+	tasksA, err := store.Tasks().GetByApplyOperationID(ctx, opA)
+	require.NoError(t, err)
+	require.Len(t, tasksA, 2)
+	identifiersA := []string{tasksA[0].TaskIdentifier, tasksA[1].TaskIdentifier}
+	assert.ElementsMatch(t, []string{"task_a_users", "task_a_orders"}, identifiersA)
+	for _, task := range tasksA {
+		require.NotNil(t, task.ApplyOperationID)
+		assert.Equal(t, opA, *task.ApplyOperationID)
+	}
+
+	// region-b's operation returns only its single task.
+	tasksB, err := store.Tasks().GetByApplyOperationID(ctx, opB)
+	require.NoError(t, err)
+	require.Len(t, tasksB, 1)
+	assert.Equal(t, "task_b_users", tasksB[0].TaskIdentifier)
+	require.NotNil(t, tasksB[0].ApplyOperationID)
+	assert.Equal(t, opB, *tasksB[0].ApplyOperationID)
+
+	// An operation with no tasks returns an empty slice — no fallback to the
+	// parent apply's tasks.
+	tasksNone, err := store.Tasks().GetByApplyOperationID(ctx, opB+1000)
+	require.NoError(t, err)
+	assert.Empty(t, tasksNone)
+}

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -308,6 +308,11 @@ type TaskStore interface {
 	// Used for aggregating task states to derive Apply state.
 	GetByApplyID(ctx context.Context, applyID int64) ([]*Task, error)
 
+	// GetByApplyOperationID returns the tasks for a single apply_operation
+	// (one deployment of a multi-deployment apply). Used to drive and
+	// reconcile one operation independently of its sibling deployments.
+	GetByApplyOperationID(ctx context.Context, applyOperationID int64) ([]*Task, error)
+
 	// GetByDatabase returns all tasks for a database.
 	GetByDatabase(ctx context.Context, database string) ([]*Task, error)
 


### PR DESCRIPTION
## What and Why ?

Add a storage read primitive, `Tasks().GetByApplyOperationID(ctx, operationID)`, that returns the tasks belonging to a single `apply_operation` — one deployment of a multi-deployment apply — using the `idx_apply_operation_id` index.

Today the operator drives an apply by loading **all** of its tasks (`GetByApplyID`). To eventually drive one deployment independently of its siblings, a worker needs to load just that operation's tasks. This PR adds that primitive with **no callers** — the smallest, dormant first step.

It is behaviour-identical today: while the config layer hard-blocks more than one deployment per environment, an apply's single operation owns all of its tasks, so this returns the same rows as `GetByApplyID`. It only diverges once an apply fans out across deployments.

The method deliberately does **not** fall back to the parent apply's tasks on an empty result — an empty slice is the correct fail-closed signal for future operation-scoped callers.

## Changes
- `TaskStore.GetByApplyOperationID` interface method + `mysqlstore` implementation.
- Test: `TestTaskStore_GetByApplyOperationID` (per-operation isolation; empty operation returns empty, no fallback).

## Where this sits — operation-scoped engine drive

The operator should drive only the deployment a worker has claimed, loading tasks by `apply_operation_id` instead of resuming the whole apply. Because the resume path is shared by the local and remote clients and re-queries tasks in many places, that lands as a sequence of dormant PRs — only the final switch changes behaviour:

| # | PR | Purpose | Builds on |
|---|---|---|---|
| 1 | **this PR** — `Tasks().GetByApplyOperationID` | Read primitive for one operation's tasks; no callers; no fallback on empty. | — |
| 2 | LocalClient operation-scoped resume | `LocalClient.ResumeApplyOperation` loads tasks via the primitive; legacy `ResumeApply` untouched. | 1 |
| 3 | GRPCClient operation-scoped resume | `GRPCClient.ResumeApplyOperation`; thread the scope through the remote drive's re-query sites. | 1, mirrors 2 |
| 4 | Promote to the `Client` interface | Add `ResumeApplyOperation` once both clients implement it. | 2 + 3 |
| 5 | Switch the operation claim loop | Operator drives the claimed operation, fail-closed on zero tasks; legacy apply path unchanged. | 4 |

Every step is dormant under the single-deployment hard-block — an operation-scoped load returns the same rows as the apply-scoped load until an apply fans out across deployments.

