### PR TITLE
feat(tern): LocalClient operation-scoped resume

### DIFF
--- a/pkg/tern/local_client_integration_test.go
+++ b/pkg/tern/local_client_integration_test.go
@@ -875,7 +875,7 @@ func TestLocalClient_ResumeApplyOperationDrivesOperationTasks(t *testing.T) {
 		ApplyID:    applyID,
 		Deployment: "testdb",
 		Target:     "testdb",
-		State:      state.Apply.Pending,
+		State:      state.ApplyOperation.Pending,
 	})
 	require.NoError(t, err)
 

--- a/pkg/tern/local_client_integration_test.go
+++ b/pkg/tern/local_client_integration_test.go
@@ -807,6 +807,122 @@ func TestLocalClient_GroupedApplyKeepsClaimLeaseRunning(t *testing.T) {
 	assert.Equal(t, state.Apply.Completed, completed.State)
 }
 
+// An operator worker resumes a single apply_operation — one deployment of an
+// apply — rather than the whole apply. ResumeApplyOperation loads only that
+// operation's tasks (via the operation-scoped read primitive) and drives them
+// to completion through the same engine path as ResumeApply.
+func TestLocalClient_ResumeApplyOperationDrivesOperationTasks(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	_, dsn := setupMySQLContainer(t)
+	setupStorageSchema(t, dsn)
+	cleanupTasks(t, dsn)
+	cleanupTestTables(t, dsn)
+
+	ctx := t.Context()
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	stor := createStorage(t, dsn)
+	defer utils.CloseAndLog(stor)
+
+	client, err := NewLocalClient(LocalConfig{
+		Database:  "testdb",
+		Type:      storage.DatabaseTypeMySQL,
+		TargetDSN: dsn,
+	}, stor, logger)
+	require.NoError(t, err)
+	defer utils.CloseAndLog(client)
+
+	plan := &storage.Plan{
+		PlanIdentifier: fmt.Sprintf("plan-op-%d", time.Now().UnixNano()),
+		Database:       "testdb",
+		DatabaseType:   storage.DatabaseTypeMySQL,
+		Deployment:     "testdb",
+		Environment:    localClientTestEnvironment,
+		CreatedAt:      time.Now(),
+		Namespaces: map[string]*storage.NamespacePlanData{
+			"testdb": {
+				Tables: []storage.TableChange{
+					{Namespace: "testdb", Table: "users", DDL: "ALTER TABLE `users` ADD COLUMN op_note VARCHAR(255)", Operation: "alter"},
+				},
+			},
+		},
+	}
+	planID, err := stor.Plans().Create(ctx, plan)
+	require.NoError(t, err)
+	plan.ID = planID
+
+	now := time.Now()
+	apply := &storage.Apply{
+		ApplyIdentifier: fmt.Sprintf("apply-op-%d", time.Now().UnixNano()),
+		PlanID:          planID,
+		Database:        "testdb",
+		DatabaseType:    storage.DatabaseTypeMySQL,
+		Deployment:      "testdb",
+		Engine:          storage.EngineSpirit,
+		State:           state.Apply.Pending,
+		Options:         storage.MarshalApplyOptions(storage.ApplyOptions{DeferCutover: true}),
+		Environment:     localClientTestEnvironment,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+	applyID, err := stor.Applies().Create(ctx, apply)
+	require.NoError(t, err)
+	apply.ID = applyID
+
+	operationID, err := stor.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID:    applyID,
+		Deployment: "testdb",
+		Target:     "testdb",
+		State:      state.Apply.Pending,
+	})
+	require.NoError(t, err)
+
+	task := &storage.Task{
+		TaskIdentifier:   fmt.Sprintf("task-op-users-%d", time.Now().UnixNano()),
+		ApplyID:          applyID,
+		ApplyOperationID: &operationID,
+		PlanID:           planID,
+		Database:         "testdb",
+		DatabaseType:     storage.DatabaseTypeMySQL,
+		Engine:           storage.EngineSpirit,
+		State:            state.Task.Pending,
+		TableName:        "users",
+		Namespace:        "testdb",
+		DDL:              "ALTER TABLE `users` ADD COLUMN op_note VARCHAR(255)",
+		DDLAction:        "alter",
+		Options:          storage.MarshalApplyOptions(storage.ApplyOptions{DeferCutover: true}),
+		Environment:      localClientTestEnvironment,
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}
+	taskID, err := stor.Tasks().Create(ctx, task)
+	require.NoError(t, err)
+	task.ID = taskID
+
+	claimed, err := stor.Applies().FindNextApply(ctx, "test-owner")
+	require.NoError(t, err)
+	require.NotNil(t, claimed)
+	require.Equal(t, state.Apply.Pending, claimed.State)
+
+	client.spiritEngine = &leaseInspectingEngine{store: stor, applyID: applyID}
+
+	require.NoError(t, client.ResumeApplyOperation(ctx, claimed, operationID))
+
+	completed, err := stor.Applies().Get(ctx, applyID)
+	require.NoError(t, err)
+	require.NotNil(t, completed)
+	assert.Equal(t, state.Apply.Completed, completed.State)
+
+	tasks, err := stor.Tasks().GetByApplyOperationID(ctx, operationID)
+	require.NoError(t, err)
+	require.Len(t, tasks, 1)
+	assert.Equal(t, state.Task.Completed, tasks[0].State)
+	require.NotNil(t, tasks[0].ApplyOperationID)
+	assert.Equal(t, operationID, *tasks[0].ApplyOperationID)
+}
+
 // This scenario covers an operator-owned grouped start where the target schema
 // advances between the recovery re-plan and the final pre-dispatch schema check.
 // The operator should complete durable state without reissuing engine apply work.

--- a/pkg/tern/local_control_resume.go
+++ b/pkg/tern/local_control_resume.go
@@ -629,6 +629,13 @@ func (c *LocalClient) ResumeApplyOperation(ctx context.Context, apply *storage.A
 	if err != nil {
 		return fmt.Errorf("get tasks for apply_operation %d (apply %s): %w", applyOperationID, apply.ApplyIdentifier, err)
 	}
+	// An empty result is the fail-closed signal for an invalid or mismatched
+	// applyOperationID. Unlike ResumeApply, we must not forward this to
+	// resumeApplyWithTasks: that path marks the whole parent apply as failed,
+	// which is incorrect when only one operation lookup came back empty.
+	if len(tasks) == 0 {
+		return fmt.Errorf("no tasks found for apply_operation %d (apply %s)", applyOperationID, apply.ApplyIdentifier)
+	}
 	return c.resumeApplyWithTasks(ctx, apply, tasks)
 }
 

--- a/pkg/tern/local_control_resume.go
+++ b/pkg/tern/local_control_resume.go
@@ -612,12 +612,30 @@ func (c *LocalClient) notifyTerminalObserver(apply *storage.Apply, tasks []*stor
 // Pending applies are dispatched for the first time; stale applies use the
 // engine's resume metadata to continue after a missed heartbeat.
 func (c *LocalClient) ResumeApply(ctx context.Context, apply *storage.Apply) error {
-	// Get tasks for this apply
 	tasks, err := c.storage.Tasks().GetByApplyID(ctx, apply.ID)
 	if err != nil {
 		return fmt.Errorf("get tasks for apply %s: %w", apply.ApplyIdentifier, err)
 	}
+	return c.resumeApplyWithTasks(ctx, apply, tasks)
+}
 
+// ResumeApplyOperation starts or resumes a single apply_operation (one
+// deployment of a multi-deployment apply), driving only that operation's tasks.
+// The drive logic is identical to ResumeApply; the only difference is that tasks
+// are loaded scoped to the operation rather than the whole apply, so a worker
+// can advance one deployment independently of its siblings.
+func (c *LocalClient) ResumeApplyOperation(ctx context.Context, apply *storage.Apply, applyOperationID int64) error {
+	tasks, err := c.storage.Tasks().GetByApplyOperationID(ctx, applyOperationID)
+	if err != nil {
+		return fmt.Errorf("get tasks for apply_operation %d (apply %s): %w", applyOperationID, apply.ApplyIdentifier, err)
+	}
+	return c.resumeApplyWithTasks(ctx, apply, tasks)
+}
+
+// resumeApplyWithTasks drives an apply (or one of its operations) from the set
+// of tasks the caller has loaded. Callers choose whether tasks are scoped to the
+// whole apply or to a single operation.
+func (c *LocalClient) resumeApplyWithTasks(ctx context.Context, apply *storage.Apply, tasks []*storage.Task) error {
 	if len(tasks) == 0 {
 		c.logger.Warn("no tasks found for apply, marking as failed",
 			"apply_id", apply.ApplyIdentifier)


### PR DESCRIPTION
## What and Why ?

Adds `LocalClient.ResumeApplyOperation`, which drives a single
`apply_operation` (one deployment of an apply) rather than the whole apply.
This is item (1) — operation-scoped engine drive — of the required future
work for multi-deployment parallelism, sliced as PR 2 of 5.

The in-process resume body is extracted into a shared `resumeApplyWithTasks`;
the only difference between the two entry points is how tasks are loaded:

```
ResumeApply ─────────┐  loads GetByApplyID
├──▶ resumeApplyWithTasks(apply, tasks) ──▶ drive
ResumeApplyOperation ┘  loads GetByApplyOperationID
```

`ResumeApply` is behaviour-identical. `ResumeApplyOperation` has no callers
yet — it is promoted onto the `Client` interface and wired into the operator
in later PRs. Dormant under the single-deployment hard-block, since an apply
owns exactly one operation today (operation-scoped load returns the same rows
as the apply-scoped load).

## Changes

- Split `ResumeApply` into a shared `resumeApplyWithTasks` drive helper.
- Add `ResumeApplyOperation(ctx, apply, applyOperationID)` using the
  operation-scoped read primitive.
- Add an integration test that drives one operation to completion and asserts
  the operation's task is completed.

> Stacked on #256 (the `GetByApplyOperationID` primitive). Retarget to `main`
> once #256 lands.
