### PR TITLE
fix(github): block applies when PR checks complete without success

### DIFF
--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -4261,21 +4261,21 @@ Cutover is already in progress. SchemaBot will keep reporting progress from the 
 </details>
 
 <details>
-<summary><a name="checks-gate-failing"></a><strong>Checks Gate: Failing</strong></summary>
+<summary><a name="checks-gate-not-passing"></a><strong>Checks Gate: Not Passing</strong></summary>
 
 
 ## ❌ Apply Blocked
 
 **Environment**: `staging`
 
-Cannot apply while PR checks are failing:
+Cannot apply while PR checks are not passing:
 
 | Check | Status |
 |-------|--------|
 | `CI / unit-tests` | failure |
 | `CI / lint` | timed_out |
 
-Fix the failing checks and retry:
+Get the checks passing — fix failures and re-run cancelled or stale checks — then retry:
 ```
 schemabot apply -e staging
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -325,14 +325,14 @@ If `repos` is not configured or empty, all repositories are allowed.
 
 ## PR Checks Gate
 
-By default, SchemaBot blocks `apply` and `apply-confirm` when non-SchemaBot PR checks are failing. This prevents applying schema changes on a PR with broken CI, linters, or security scans.
+By default, SchemaBot blocks `apply` and `apply-confirm` when non-SchemaBot PR checks are not passing. This prevents applying schema changes on a PR with broken, cancelled, or incomplete CI, linters, or security scans.
 
 ```yaml
 # Block apply when PR checks are failing (default: true)
 require_passing_checks: true
 ```
 
-Apply is blocked in two cases: checks that have **failed** (`failure`, `error`, `timed_out`) and checks that are **still running** (`in_progress`, `queued`, `pending`). Each case shows a distinct message — failing checks prompt the user to fix them, while in-progress checks prompt the user to wait. Checks with conclusion `neutral` or `skipped` are ignored. SchemaBot's own checks (names starting with "SchemaBot") are always excluded.
+Apply is blocked in two cases: completed checks that did not **pass** and checks that are **still running** (`in_progress`, `queued`, `pending`). A completed check passes only with conclusion `success`, `neutral`, or `skipped`; every other conclusion (such as `failure`, `timed_out`, `cancelled`, `action_required`, `stale`, or `startup_failure`) blocks apply, so unrecognized conclusions fail closed. Each case shows a distinct message — failing checks prompt the user to fix them, while in-progress checks prompt the user to wait. SchemaBot's own checks are always excluded.
 
 For repositories with many optional checks, `required_checks` can narrow the gate to specific check names:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -328,11 +328,11 @@ If `repos` is not configured or empty, all repositories are allowed.
 By default, SchemaBot blocks `apply` and `apply-confirm` when non-SchemaBot PR checks are not passing. This prevents applying schema changes on a PR with broken, cancelled, or incomplete CI, linters, or security scans.
 
 ```yaml
-# Block apply when PR checks are failing (default: true)
+# Block apply when PR checks are not passing (default: true)
 require_passing_checks: true
 ```
 
-Apply is blocked in two cases: completed checks that did not **pass** and checks that are **still running** (`in_progress`, `queued`, `pending`). A completed check passes only with conclusion `success`, `neutral`, or `skipped`; every other conclusion (such as `failure`, `timed_out`, `cancelled`, `action_required`, `stale`, or `startup_failure`) blocks apply, so unrecognized conclusions fail closed. Each case shows a distinct message — failing checks prompt the user to fix them, while in-progress checks prompt the user to wait. SchemaBot's own checks are always excluded.
+Apply is blocked in two cases: completed checks that did not **pass** and checks that are **still running** (`in_progress`, `queued`, `pending`). A completed check passes only with conclusion `success`, `neutral`, or `skipped`; every other conclusion (such as `failure`, `timed_out`, `cancelled`, `action_required`, `stale`, or `startup_failure`) blocks apply, so unrecognized conclusions fail closed. Each case shows a distinct message — completed checks that are not passing prompt the user to get them passing (fix failures and re-run cancelled or stale checks), while in-progress checks prompt the user to wait. SchemaBot's own checks are always excluded.
 
 For repositories with many optional checks, `required_checks` can narrow the gate to specific check names:
 
@@ -347,7 +347,7 @@ When any configured check appears in the PR check statuses, only configured chec
 
 `required_checks` names must exactly match GitHub check run names or commit status contexts. Matching is case-sensitive, and config validation rejects names with leading or trailing whitespace.
 
-When checks are failing, SchemaBot posts a comment listing the failing checks and instructs the user to fix them before retrying.
+When checks are not passing, SchemaBot posts a comment listing the non-passing checks and instructs the user to get them passing — fixing failures and re-running cancelled or stale checks — before retrying.
 
 If the GitHub API is unreachable when checking statuses, the apply is blocked (fail-closed). SchemaBot posts a comment explaining the error and suggests retrying.
 

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -1060,7 +1060,7 @@ func (c *ServerConfig) ShouldRespondToUnscoped() bool {
 }
 
 // ShouldRequirePassingChecks returns whether apply should be blocked when
-// non-SchemaBot PR checks are failing. Defaults to true when not configured.
+// non-SchemaBot PR checks are not passing. Defaults to true when not configured.
 func (c *ServerConfig) ShouldRequirePassingChecks() bool {
 	if c == nil || c.RequirePassingChecks == nil {
 		return true

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -97,11 +97,12 @@ type ServerConfig struct {
 	// Defaults to false (apply-level claiming).
 	OperatorClaimOperations bool `yaml:"operator_claim_operations,omitempty"`
 
-	// RequirePassingChecks blocks apply when non-SchemaBot PR checks are failing.
-	// When enabled (default), SchemaBot verifies that all other checks (CI, linters,
-	// security scans) have passed before executing a schema change. Checks with
-	// conclusion "neutral" or "skipped" are ignored. SchemaBot's own checks are
-	// excluded from the evaluation.
+	// RequirePassingChecks blocks apply when non-SchemaBot PR checks are not
+	// passing. When enabled (default), SchemaBot verifies that all other checks
+	// (CI, linters, security scans) have passed before executing a schema
+	// change. Completed checks are ignored only when their conclusion is
+	// "success", "neutral", or "skipped"; every other conclusion blocks apply.
+	// SchemaBot's own checks are excluded from the evaluation.
 	//
 	// Defaults to true when not configured (nil = enabled).
 	RequirePassingChecks *bool `yaml:"require_passing_checks"`

--- a/pkg/cmd/commands/preview.go
+++ b/pkg/cmd/commands/preview.go
@@ -96,7 +96,7 @@ func (cmd *PreviewCmd) Run(g *Globals) error {
 		templates.PreviewCommentApplyBlocked, templates.PreviewCommentApplyBlockedCLI,
 		templates.PreviewCommentApplyActive,
 		templates.PreviewCommentApplyNoLock, templates.PreviewCommentApplyAllType,
-		templates.PreviewCommentChecksGateFailing, templates.PreviewCommentChecksGateInProgress,
+		templates.PreviewCommentChecksGateNotPassing, templates.PreviewCommentChecksGateInProgress,
 		templates.PreviewCommentActorNotAuthorized, templates.PreviewCommentActorAuthUnavailable,
 		templates.PreviewCommentCutoverAccepted, templates.PreviewCommentCutoverActive:
 		templates.PreviewCLIOutput(previewType)

--- a/pkg/cmd/internal/templates/preview.go
+++ b/pkg/cmd/internal/templates/preview.go
@@ -157,7 +157,7 @@ const (
 	PreviewCommentBlockedByPriorInProg PreviewType = "comment_blocked_prior_env_inprogress" // Blocked by staging (in progress)
 	PreviewCommentReviewRequired       PreviewType = "comment_review_required"              // Review gate: approval needed
 	PreviewCommentReviewGateError      PreviewType = "comment_review_gate_error"            // Review gate: fail-closed error
-	PreviewCommentChecksGateFailing    PreviewType = "comment_checks_gate_failing"          // Checks gate: failing CI/lint
+	PreviewCommentChecksGateNotPassing PreviewType = "comment_checks_gate_not_passing"      // Checks gate: non-passing CI/lint
 	PreviewCommentChecksGateInProgress PreviewType = "comment_checks_gate_in_progress"      // Checks gate: CI still running
 	PreviewCommentActorNotAuthorized   PreviewType = "comment_actor_not_authorized"         // Actor authorization: user is not allowed
 	PreviewCommentActorAuthUnavailable PreviewType = "comment_actor_auth_unavailable"       // Actor authorization: fail-closed error

--- a/pkg/cmd/internal/templates/preview_comment.go
+++ b/pkg/cmd/internal/templates/preview_comment.go
@@ -105,8 +105,8 @@ func previewApplyCommandAllOutput() {
 		{"ACTOR AUTHORIZATION: UNAVAILABLE", func() { fmt.Print(webhooktemplates.PreviewCommentPRCommandAuthorizationUnavailable()) }},
 		{"CUTOVER COMMAND ACCEPTED", func() { fmt.Print(webhooktemplates.PreviewCommentCutoverCommandAccepted()) }},
 		{"CUTOVER COMMAND ALREADY IN PROGRESS", func() { fmt.Print(webhooktemplates.PreviewCommentCutoverCommandAlreadyInProgress()) }},
-		{"CHECKS GATE: FAILING", func() {
-			fmt.Print(webhooktemplates.RenderApplyBlockedByFailingChecks("staging", []webhooktemplates.BlockingCheck{
+		{"CHECKS GATE: NOT PASSING", func() {
+			fmt.Print(webhooktemplates.RenderApplyBlockedByNonPassingChecks("staging", []webhooktemplates.BlockingCheck{
 				{Name: "CI / unit-tests", State: "failure"},
 				{Name: "CI / lint", State: "timed_out"},
 			}))

--- a/pkg/cmd/internal/templates/preview_dispatch.go
+++ b/pkg/cmd/internal/templates/preview_dispatch.go
@@ -200,8 +200,8 @@ func PreviewCLIOutput(previewType PreviewType) {
 		fmt.Print(webhooktemplates.PreviewCommentReviewRequired())
 	case PreviewCommentReviewGateError:
 		fmt.Print(webhooktemplates.PreviewCommentReviewGateError())
-	case PreviewCommentChecksGateFailing:
-		fmt.Print(webhooktemplates.RenderApplyBlockedByFailingChecks("staging", []webhooktemplates.BlockingCheck{
+	case PreviewCommentChecksGateNotPassing:
+		fmt.Print(webhooktemplates.RenderApplyBlockedByNonPassingChecks("staging", []webhooktemplates.BlockingCheck{
 			{Name: "CI / unit-tests", State: "failure"},
 			{Name: "CI / lint", State: "timed_out"},
 		}))

--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -172,7 +172,7 @@ func (c *Client) ForInstallation(installationID int64) (*InstallationClient, err
 			c.fetchAppSlug()
 		}
 		if c.loadAppSlug() == "" {
-			c.logger.Error("app slug unavailable — check gate will block PR applies if own checks are failing")
+			c.logger.Error("app slug unavailable — check gate will block PR applies if own checks are not passing")
 		}
 	}
 

--- a/pkg/webhook/apply_gating.go
+++ b/pkg/webhook/apply_gating.go
@@ -9,10 +9,11 @@ import (
 	"github.com/block/schemabot/pkg/webhook/templates"
 )
 
-// filterFailingNonSchemaBotChecks returns checks that are failing, excluding
-// SchemaBot's own checks and checks with conclusion "neutral", "skipped", or "success".
-// Only checks with completed status and conclusion "failure", "error", or "timed_out"
-// are considered failing.
+// filterFailingNonSchemaBotChecks returns completed checks that block apply,
+// excluding SchemaBot's own checks. A completed check is ignored only when its
+// conclusion is "success", "neutral", or "skipped"; every other conclusion
+// (such as "failure", "timed_out", "cancelled", "action_required", "stale",
+// or "startup_failure") blocks apply, so unrecognized conclusions fail closed.
 func filterFailingNonSchemaBotChecks(statuses []ghclient.PRCheckStatus, config *api.ServerConfig) []templates.BlockingCheck {
 	var failing []templates.BlockingCheck
 	filterRequiredChecks := statusesContainRequiredCheck(statuses, config)
@@ -26,15 +27,27 @@ func filterFailingNonSchemaBotChecks(statuses []ghclient.PRCheckStatus, config *
 		if s.Status != "completed" {
 			continue
 		}
-		switch s.Conclusion {
-		case "failure", "error", "timed_out":
-			failing = append(failing, templates.BlockingCheck{
-				Name:  s.Name,
-				State: s.Conclusion,
-			})
+		if isPassingCheckConclusion(s.Conclusion) {
+			continue
 		}
+		failing = append(failing, templates.BlockingCheck{
+			Name:  s.Name,
+			State: s.Conclusion,
+		})
 	}
 	return failing
+}
+
+// isPassingCheckConclusion reports whether a completed check's conclusion
+// allows apply to proceed. Only "success", "neutral", and "skipped" pass;
+// every other conclusion blocks apply.
+func isPassingCheckConclusion(conclusion string) bool {
+	switch conclusion {
+	case "success", "neutral", "skipped":
+		return true
+	default:
+		return false
+	}
 }
 
 // enforcePassingChecks verifies that all non-SchemaBot PR checks are passing.

--- a/pkg/webhook/apply_gating.go
+++ b/pkg/webhook/apply_gating.go
@@ -9,13 +9,13 @@ import (
 	"github.com/block/schemabot/pkg/webhook/templates"
 )
 
-// filterFailingNonSchemaBotChecks returns completed checks that block apply,
+// filterNonPassingNonSchemaBotChecks returns completed checks that block apply,
 // excluding SchemaBot's own checks. A completed check is ignored only when its
 // conclusion is "success", "neutral", or "skipped"; every other conclusion
 // (such as "failure", "timed_out", "cancelled", "action_required", "stale",
 // or "startup_failure") blocks apply, so unrecognized conclusions fail closed.
-func filterFailingNonSchemaBotChecks(statuses []ghclient.PRCheckStatus, config *api.ServerConfig) []templates.BlockingCheck {
-	var failing []templates.BlockingCheck
+func filterNonPassingNonSchemaBotChecks(statuses []ghclient.PRCheckStatus, config *api.ServerConfig) []templates.BlockingCheck {
+	var notPassing []templates.BlockingCheck
 	filterRequiredChecks := statusesContainRequiredCheck(statuses, config)
 	for _, s := range statuses {
 		if s.IsSchemaBot {
@@ -30,12 +30,12 @@ func filterFailingNonSchemaBotChecks(statuses []ghclient.PRCheckStatus, config *
 		if isPassingCheckConclusion(s.Conclusion) {
 			continue
 		}
-		failing = append(failing, templates.BlockingCheck{
+		notPassing = append(notPassing, templates.BlockingCheck{
 			Name:  s.Name,
 			State: s.Conclusion,
 		})
 	}
-	return failing
+	return notPassing
 }
 
 // isPassingCheckConclusion reports whether a completed check's conclusion
@@ -52,7 +52,8 @@ func isPassingCheckConclusion(conclusion string) bool {
 
 // enforcePassingChecks verifies that all non-SchemaBot PR checks are passing.
 // Returns true if apply was blocked (caller should return), false if it may proceed.
-// Blocks on both failing checks and in-progress checks with distinct messages.
+// Blocks on both non-passing completed checks and in-progress checks with
+// distinct messages.
 func (h *Handler) enforcePassingChecks(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, installationID int64, headSHA, environment string) bool {
 	config := h.service.Config()
 	if !config.ShouldRequirePassingChecks() {
@@ -93,15 +94,15 @@ func (h *Handler) enforcePassingChecks(ctx context.Context, client *ghclient.Ins
 		return true
 	}
 
-	failing := filterFailingNonSchemaBotChecks(statuses, config)
+	notPassing := filterNonPassingNonSchemaBotChecks(statuses, config)
 	inProgress := filterInProgressNonSchemaBotChecks(statuses, config)
 
-	if len(failing) > 0 {
-		h.logger.Info("apply blocked by failing PR checks",
+	if len(notPassing) > 0 {
+		h.logger.Info("apply blocked by non-passing PR checks",
 			"repo", repo, "pr", pr, "environment", environment,
-			"failing_count", len(failing))
+			"not_passing_count", len(notPassing))
 		h.postComment(repo, pr, installationID,
-			templates.RenderApplyBlockedByFailingChecks(environment, failing))
+			templates.RenderApplyBlockedByNonPassingChecks(environment, notPassing))
 		return true
 	}
 

--- a/pkg/webhook/apply_gating_test.go
+++ b/pkg/webhook/apply_gating_test.go
@@ -15,10 +15,11 @@ import (
 
 func TestFilterFailingNonSchemaBotChecks(t *testing.T) {
 	tests := []struct {
-		name      string
-		statuses  []ghclient.PRCheckStatus
-		wantLen   int
-		wantNames []string
+		name       string
+		statuses   []ghclient.PRCheckStatus
+		wantLen    int
+		wantNames  []string
+		wantStates []string
 	}{
 		{
 			name:     "empty statuses returns nil",
@@ -48,8 +49,38 @@ func TestFilterFailingNonSchemaBotChecks(t *testing.T) {
 				{Name: "security-scan", Status: "completed", Conclusion: "error"},
 				{Name: "CI / integration", Status: "completed", Conclusion: "timed_out"},
 			},
-			wantLen:   2,
-			wantNames: []string{"security-scan", "CI / integration"},
+			wantLen:    2,
+			wantNames:  []string{"security-scan", "CI / integration"},
+			wantStates: []string{"error", "timed_out"},
+		},
+		{
+			// A check whose run was cancelled, never started, went stale, or
+			// stopped awaiting action has not verified the PR. Each of these
+			// conclusions blocks apply, while SchemaBot's own checks remain
+			// excluded.
+			name: "checks completed without success block apply",
+			statuses: []ghclient.PRCheckStatus{
+				{Name: "CI / unit-tests", Status: "completed", Conclusion: "cancelled"},
+				{Name: "CI / lint", Status: "completed", Conclusion: "action_required"},
+				{Name: "CI / integration", Status: "completed", Conclusion: "stale"},
+				{Name: "CI / build", Status: "completed", Conclusion: "startup_failure"},
+				{Name: "SchemaBot (staging)", Status: "completed", Conclusion: "cancelled", IsSchemaBot: true},
+				{Name: "CI / docs", Status: "completed", Conclusion: "success"},
+			},
+			wantLen:    4,
+			wantNames:  []string{"CI / unit-tests", "CI / lint", "CI / integration", "CI / build"},
+			wantStates: []string{"cancelled", "action_required", "stale", "startup_failure"},
+		},
+		{
+			// Conclusions SchemaBot does not recognize block apply, so the
+			// gate fails closed if GitHub introduces a new conclusion.
+			name: "unknown conclusion blocks apply",
+			statuses: []ghclient.PRCheckStatus{
+				{Name: "CI / new-check", Status: "completed", Conclusion: "some_future_conclusion"},
+			},
+			wantLen:    1,
+			wantNames:  []string{"CI / new-check"},
+			wantStates: []string{"some_future_conclusion"},
 		},
 		{
 			name: "SchemaBot checks are excluded",
@@ -100,6 +131,9 @@ func TestFilterFailingNonSchemaBotChecks(t *testing.T) {
 			require.Len(t, failing, tt.wantLen)
 			for i, name := range tt.wantNames {
 				assert.Equal(t, name, failing[i].Name)
+			}
+			for i, state := range tt.wantStates {
+				assert.Equal(t, state, failing[i].State)
 			}
 		})
 	}
@@ -423,6 +457,51 @@ func TestEnforcePassingChecks(t *testing.T) {
 			assert.Contains(t, body, "failure")
 		case <-time.After(2 * time.Second):
 			t.Fatal("timed out waiting for failing-checks comment")
+		}
+	})
+
+	// A push or concurrency-group rule can cancel a CI run after the apply
+	// command was issued. The cancelled run never verified the PR, so the
+	// apply is blocked and the comment names the cancelled check.
+	t.Run("cancelled checks block apply", func(t *testing.T) {
+		client, mux := setupGitHubServer(t)
+		comments := make(chan string, 10)
+
+		registerCheckStatusRESTHandlers(mux, []checkStatusNode{
+			{Typename: "CheckRun", Name: "CI / tests", Status: "completed", Conclusion: "cancelled", AppSlug: "github-actions"},
+			{Typename: "CheckRun", Name: "CI / lint", Status: "completed", Conclusion: "success", AppSlug: "github-actions"},
+		})
+
+		mux.HandleFunc("POST /repos/octocat/hello-world/issues/1/comments", func(w http.ResponseWriter, r *http.Request) {
+			var body struct {
+				Body string `json:"body"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			comments <- body.Body
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": 99})
+		})
+
+		installClient := ghclient.NewInstallationClient(client, testLogger())
+		factory := &fakeClientFactory{client: installClient}
+
+		service := api.New(nil, &api.ServerConfig{}, nil, testLogger())
+		h := &Handler{
+			service:   service,
+			ghClients: ghclient.NewSingleClientSet(defaultAppName, factory),
+			logger:    testLogger(),
+		}
+
+		ctx := t.Context()
+		blocked := h.enforcePassingChecks(ctx, installClient, "octocat/hello-world", 1, 12345, "abc123", "staging")
+		assert.True(t, blocked, "should block when a check was cancelled")
+
+		select {
+		case body := <-comments:
+			assert.Contains(t, body, "CI / tests")
+			assert.Contains(t, body, "cancelled")
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out waiting for cancelled-checks comment")
 		}
 	})
 

--- a/pkg/webhook/apply_gating_test.go
+++ b/pkg/webhook/apply_gating_test.go
@@ -13,7 +13,7 @@ import (
 	ghclient "github.com/block/schemabot/pkg/github"
 )
 
-func TestFilterFailingNonSchemaBotChecks(t *testing.T) {
+func TestFilterNonPassingNonSchemaBotChecks(t *testing.T) {
 	tests := []struct {
 		name       string
 		statuses   []ghclient.PRCheckStatus
@@ -27,7 +27,7 @@ func TestFilterFailingNonSchemaBotChecks(t *testing.T) {
 			wantLen:  0,
 		},
 		{
-			name: "all passing checks returns no failures",
+			name: "all passing checks block nothing",
 			statuses: []ghclient.PRCheckStatus{
 				{Name: "CI / unit-tests", Status: "completed", Conclusion: "success"},
 				{Name: "CI / lint", Status: "completed", Conclusion: "success"},
@@ -103,7 +103,7 @@ func TestFilterFailingNonSchemaBotChecks(t *testing.T) {
 			wantNames: []string{"CI / lint"},
 		},
 		{
-			name: "in-progress checks are not considered failing",
+			name: "in-progress checks are excluded from the completed-check filter",
 			statuses: []ghclient.PRCheckStatus{
 				{Name: "CI / unit-tests", Status: "in_progress", Conclusion: ""},
 				{Name: "CI / lint", Status: "queued", Conclusion: ""},
@@ -127,19 +127,19 @@ func TestFilterFailingNonSchemaBotChecks(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			failing := filterFailingNonSchemaBotChecks(tt.statuses, nil)
-			require.Len(t, failing, tt.wantLen)
+			notPassing := filterNonPassingNonSchemaBotChecks(tt.statuses, nil)
+			require.Len(t, notPassing, tt.wantLen)
 			for i, name := range tt.wantNames {
-				assert.Equal(t, name, failing[i].Name)
+				assert.Equal(t, name, notPassing[i].Name)
 			}
 			for i, state := range tt.wantStates {
-				assert.Equal(t, state, failing[i].State)
+				assert.Equal(t, state, notPassing[i].State)
 			}
 		})
 	}
 }
 
-func TestFilterFailingNonSchemaBotChecks_RequiredChecks(t *testing.T) {
+func TestFilterNonPassingNonSchemaBotChecks_RequiredChecks(t *testing.T) {
 	tests := []struct {
 		name      string
 		config    *api.ServerConfig
@@ -194,10 +194,10 @@ func TestFilterFailingNonSchemaBotChecks_RequiredChecks(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			failing := filterFailingNonSchemaBotChecks(tt.statuses, tt.config)
-			require.Len(t, failing, len(tt.wantNames))
+			notPassing := filterNonPassingNonSchemaBotChecks(tt.statuses, tt.config)
+			require.Len(t, notPassing, len(tt.wantNames))
 			for i, name := range tt.wantNames {
-				assert.Equal(t, name, failing[i].Name)
+				assert.Equal(t, name, notPassing[i].Name)
 			}
 		})
 	}

--- a/pkg/webhook/apply_handlers.go
+++ b/pkg/webhook/apply_handlers.go
@@ -53,7 +53,7 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 		return
 	}
 
-	// Tier 2: PR checks gate — block if non-SchemaBot checks are failing
+	// Tier 2: PR checks gate — block if non-SchemaBot checks are not passing
 	prInfo, err := client.FetchPullRequest(ctx, repo, pr)
 	if err != nil {
 		h.logger.Error("failed to fetch PR for checks gate", "error", err)

--- a/pkg/webhook/templates/apply_commands.go
+++ b/pkg/webhook/templates/apply_commands.go
@@ -353,29 +353,29 @@ type BlockingCheck struct {
 	State string
 }
 
-// RenderApplyBlockedByFailingChecks renders a comment when apply is blocked
-// because non-SchemaBot PR checks are failing.
-func RenderApplyBlockedByFailingChecks(environment string, failing []BlockingCheck) string {
+// RenderApplyBlockedByNonPassingChecks renders a comment when apply is blocked
+// because non-SchemaBot PR checks completed without passing.
+func RenderApplyBlockedByNonPassingChecks(environment string, notPassing []BlockingCheck) string {
 	var sb strings.Builder
 
 	sb.WriteString("## ❌ Apply Blocked\n\n")
 	fmt.Fprintf(&sb, "**Environment**: `%s`\n\n", environment)
-	if len(failing) == 0 {
+	if len(notPassing) == 0 {
 		// Defensive: callers should only invoke this template when at least
-		// one failing check has been identified. Render a generic message
+		// one non-passing check has been identified. Render a generic message
 		// rather than an empty Markdown table with column headers but no rows.
-		sb.WriteString("Cannot apply while PR checks are failing.\n\n")
-		sb.WriteString("Fix the failing checks and retry:\n")
+		sb.WriteString("Cannot apply while PR checks are not passing.\n\n")
+		sb.WriteString("Get the checks passing — fix failures and re-run cancelled or stale checks — then retry:\n")
 		fmt.Fprintf(&sb, "```\nschemabot apply -e %s\n```\n", environment)
 		return sb.String()
 	}
-	sb.WriteString("Cannot apply while PR checks are failing:\n\n")
+	sb.WriteString("Cannot apply while PR checks are not passing:\n\n")
 	sb.WriteString("| Check | Status |\n")
 	sb.WriteString("|-------|--------|\n")
-	for _, f := range failing {
+	for _, f := range notPassing {
 		fmt.Fprintf(&sb, "| `%s` | %s |\n", f.Name, f.State)
 	}
-	sb.WriteString("\nFix the failing checks and retry:\n")
+	sb.WriteString("\nGet the checks passing — fix failures and re-run cancelled or stale checks — then retry:\n")
 	fmt.Fprintf(&sb, "```\nschemabot apply -e %s\n```\n", environment)
 
 	return sb.String()
@@ -385,7 +385,7 @@ func RenderApplyBlockedByFailingChecks(environment string, failing []BlockingChe
 // because the GitHub API returned an error while fetching PR check statuses.
 // The function recognises the "Resource not accessible" permission error and
 // surfaces a targeted hint; all other errors are shown verbatim. Both branches
-// include a fenced retry command, matching the failing/in-progress siblings.
+// include a fenced retry command, matching the non-passing/in-progress siblings.
 type CheckStatusAccessDetails struct {
 	GitHubApp              string
 	MissingPermissions     []string

--- a/pkg/webhook/templates/apply_commands.go
+++ b/pkg/webhook/templates/apply_commands.go
@@ -344,9 +344,10 @@ func RenderApplyBlockedByPriorEnv(database, environment, priorEnv, status, actio
 }
 
 // BlockingCheck represents a PR check that is blocking apply, either because
-// it failed or because it is still running. State holds the GitHub-reported
-// conclusion (e.g. "failure", "error", "timed_out") for failed checks, or the
-// status (e.g. "in_progress", "queued", "pending") for in-progress checks.
+// it completed without passing or because it is still running. State holds the
+// GitHub-reported conclusion (e.g. "failure", "timed_out", "cancelled") for
+// completed checks, or the status (e.g. "in_progress", "queued", "pending")
+// for in-progress checks.
 type BlockingCheck struct {
 	Name  string
 	State string

--- a/pkg/webhook/templates/apply_test.go
+++ b/pkg/webhook/templates/apply_test.go
@@ -491,47 +491,47 @@ func TestPreviewCommentSummaryCompletedLargeSingleNamespaceKeepsApplyIDInsideSec
 	assert.Equal(t, 0, strings.Count(result, "</details>"))
 }
 
-func TestRenderApplyBlockedByFailingChecks(t *testing.T) {
-	failing := []BlockingCheck{
+func TestRenderApplyBlockedByNonPassingChecks(t *testing.T) {
+	notPassing := []BlockingCheck{
 		{Name: "CI / unit-tests", State: "failure"},
 		{Name: "CI / lint", State: "timed_out"},
 	}
 
-	result := RenderApplyBlockedByFailingChecks("staging", failing)
+	result := RenderApplyBlockedByNonPassingChecks("staging", notPassing)
 
 	assert.Contains(t, result, "## ❌ Apply Blocked")
 	assert.Contains(t, result, "`staging`")
-	assert.Contains(t, result, "Cannot apply while PR checks are failing")
+	assert.Contains(t, result, "Cannot apply while PR checks are not passing")
 	assert.Contains(t, result, "| Check | Status |")
 	assert.Contains(t, result, "| `CI / unit-tests` | failure |")
 	assert.Contains(t, result, "| `CI / lint` | timed_out |")
 	assert.Contains(t, result, "schemabot apply -e staging")
 }
 
-func TestRenderApplyBlockedByFailingChecks_SingleCheck(t *testing.T) {
-	failing := []BlockingCheck{
+func TestRenderApplyBlockedByNonPassingChecks_SingleCheck(t *testing.T) {
+	notPassing := []BlockingCheck{
 		{Name: "security-scan", State: "error"},
 	}
 
-	result := RenderApplyBlockedByFailingChecks("production", failing)
+	result := RenderApplyBlockedByNonPassingChecks("production", notPassing)
 
 	assert.Contains(t, result, "`production`")
 	assert.Contains(t, result, "| `security-scan` | error |")
 	assert.Contains(t, result, "schemabot apply -e production")
 }
 
-func TestRenderApplyBlockedByFailingChecks_EmptyList(t *testing.T) {
+func TestRenderApplyBlockedByNonPassingChecks_EmptyList(t *testing.T) {
 	// Defensive guard: rendering with an empty slice must not emit an empty
 	// Markdown table (header row with zero data rows). It should fall back
 	// to a generic message that still preserves the header, environment,
 	// and retry block.
-	for _, failing := range [][]BlockingCheck{nil, {}} {
-		result := RenderApplyBlockedByFailingChecks("staging", failing)
+	for _, notPassing := range [][]BlockingCheck{nil, {}} {
+		result := RenderApplyBlockedByNonPassingChecks("staging", notPassing)
 
 		assert.Contains(t, result, "## ❌ Apply Blocked")
 		assert.Contains(t, result, "**Environment**: `staging`")
-		assert.Contains(t, result, "Cannot apply while PR checks are failing.")
-		assert.Contains(t, result, "Fix the failing checks and retry:\n```\nschemabot apply -e staging\n```",
+		assert.Contains(t, result, "Cannot apply while PR checks are not passing.")
+		assert.Contains(t, result, "Get the checks passing — fix failures and re-run cancelled or stale checks — then retry:\n```\nschemabot apply -e staging\n```",
 			"retry command must be inside a fenced code block immediately after the retry copy")
 		assert.NotContains(t, result, "| Check | Status |",
 			"empty-list branch must not emit a table header with no data rows")


### PR DESCRIPTION
The passing-checks apply gate treated only `failure`, `error`, and `timed_out` as blocking conclusions. Checks that completed as `cancelled` (e.g. a push or concurrency-group rule cancelling a CI run), `action_required`, `stale`, or `startup_failure` (broken workflow file) slipped through both the failing-check and in-progress filters, so the PR counted as "all checks passing" and the apply proceeded.

- The gate now fails closed: a completed non-SchemaBot check blocks apply unless its conclusion is `success`, `neutral`, or `skipped` — covering the known unsuccessful conclusions and any conclusion GitHub introduces in the future.
- The in-progress filter and `required_checks` narrowing are unchanged.
- Config and docs updated to state the conclusion invariant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)