### PR TITLE
fix(github): verify app identity for promotion gate check runs

### DIFF
--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -617,32 +617,60 @@ type CheckRunResult struct {
 }
 
 // FindCheckRunByName searches for a check run on a specific commit by name.
-// Returns nil if no matching check run is found.
+// Only check runs created by this SchemaBot GitHub App are considered: a
+// same-named check run created by another app (for example a GitHub Actions
+// job configured with a matching name) is ignored, so it can never satisfy a
+// gate that relies on this lookup. When multiple own-app runs share the name,
+// the most recently created one (highest check run ID) is returned.
+//
+// Returns nil if no own-app check run matches. Returns an error when the own
+// app slug is unknown — check run ownership cannot be verified, and callers
+// must fail closed instead of trusting a same-named run.
 func (ic *InstallationClient) FindCheckRunByName(ctx context.Context, repo, headSHA, checkName string) (*CheckRunResult, error) {
+	if ic.loadAppSlug() == "" {
+		return nil, fmt.Errorf("find check run %q on %s@%s: GitHub App slug is unavailable, check run ownership cannot be verified", checkName, repo, headSHA)
+	}
+
 	owner, repoName := splitRepo(repo)
+	ctx = withGitHubRateLimitContext(ctx, metrics.GitHubOperationListCheckRunsForRef, repo)
 	opts := &gh.ListCheckRunsOptions{
 		CheckName: new(checkName),
 		ListOptions: gh.ListOptions{
-			PerPage: 1,
+			PerPage: 100,
 		},
 	}
 
-	result, _, err := ic.client.Checks.ListCheckRunsForRef(ctx, owner, repoName, headSHA, opts)
-	if err != nil {
-		return nil, fmt.Errorf("list check runs for %s: %w", checkName, err)
+	var newest *CheckRunResult
+	for {
+		result, resp, err := ic.client.Checks.ListCheckRunsForRef(ctx, owner, repoName, headSHA, opts)
+		if err != nil {
+			return nil, fmt.Errorf("list check runs named %q on %s@%s: %w", checkName, repo, headSHA, err)
+		}
+		if result != nil {
+			for _, run := range result.CheckRuns {
+				if !ic.isOwnAppSlug(run.GetApp().GetSlug()) {
+					ic.logger.Warn("ignoring same-named check run created by another GitHub App",
+						"repo", repo, "head_sha", headSHA, "check_name", checkName,
+						"check_run_id", run.GetID(), "app_slug", run.GetApp().GetSlug())
+					continue
+				}
+				if newest == nil || run.GetID() > newest.ID {
+					newest = &CheckRunResult{
+						ID:         run.GetID(),
+						Name:       run.GetName(),
+						Status:     run.GetStatus(),
+						Conclusion: run.GetConclusion(),
+					}
+				}
+			}
+		}
+		if resp == nil || resp.NextPage == 0 {
+			break
+		}
+		opts.Page = resp.NextPage
 	}
 
-	if len(result.CheckRuns) == 0 {
-		return nil, nil
-	}
-
-	cr := result.CheckRuns[0]
-	return &CheckRunResult{
-		ID:         cr.GetID(),
-		Name:       cr.GetName(),
-		Status:     cr.GetStatus(),
-		Conclusion: cr.GetConclusion(),
-	}, nil
+	return newest, nil
 }
 
 // PRCheckStatus represents the status of a single PR check (check run or commit status).

--- a/pkg/github/client_test.go
+++ b/pkg/github/client_test.go
@@ -118,6 +118,112 @@ func TestEditIssueCommentDoesNotRetryNonRateLimitWriteError(t *testing.T) {
 	assert.Equal(t, int64(1), attempts.Load())
 }
 
+// TestFindCheckRunByNameIgnoresForeignAppCheckRuns covers a PR commit that
+// carries two completed check runs with the same name: a passing run created
+// by another GitHub App and SchemaBot's own run, which has not passed. The
+// lookup must return SchemaBot's own run so a same-named foreign run can
+// never satisfy a gate that relies on this lookup.
+func TestFindCheckRunByNameIgnoresForeignAppCheckRuns(t *testing.T) {
+	client, mux := setupRateLimitedTestGitHubServer(t)
+	mux.HandleFunc("GET /repos/octocat/hello-world/commits/abc123/check-runs", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "SchemaBot (staging)", r.URL.Query().Get("check_name"))
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+			"total_count": 2,
+			"check_runs": []map[string]any{
+				{"id": 7, "name": "SchemaBot (staging)", "status": "completed", "conclusion": "success", "app": map[string]any{"slug": "github-actions"}},
+				{"id": 3, "name": "SchemaBot (staging)", "status": "completed", "conclusion": "action_required", "app": map[string]any{"slug": "schemabot"}},
+			},
+		}))
+	})
+
+	ic := NewInstallationClientWithSlug(client, slog.New(slog.NewTextHandler(io.Discard, nil)), "schemabot")
+	result, err := ic.FindCheckRunByName(t.Context(), "octocat/hello-world", "abc123", "SchemaBot (staging)")
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, int64(3), result.ID)
+	assert.Equal(t, "SchemaBot (staging)", result.Name)
+	assert.Equal(t, "completed", result.Status)
+	assert.Equal(t, "action_required", result.Conclusion)
+}
+
+// TestFindCheckRunByNameReturnsNilWhenOnlyForeignAppRunsExist covers a PR
+// commit where the only check run with the requested name was created by
+// another GitHub App. The lookup must report the check run as missing so
+// callers treat the gate as unsatisfied.
+func TestFindCheckRunByNameReturnsNilWhenOnlyForeignAppRunsExist(t *testing.T) {
+	client, mux := setupRateLimitedTestGitHubServer(t)
+	mux.HandleFunc("GET /repos/octocat/hello-world/commits/abc123/check-runs", func(w http.ResponseWriter, _ *http.Request) {
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+			"total_count": 1,
+			"check_runs": []map[string]any{
+				{"id": 7, "name": "SchemaBot (staging)", "status": "completed", "conclusion": "success", "app": map[string]any{"slug": "github-actions"}},
+			},
+		}))
+	})
+
+	ic := NewInstallationClientWithSlug(client, slog.New(slog.NewTextHandler(io.Discard, nil)), "schemabot")
+	result, err := ic.FindCheckRunByName(t.Context(), "octocat/hello-world", "abc123", "SchemaBot (staging)")
+
+	require.NoError(t, err)
+	assert.Nil(t, result)
+}
+
+// TestFindCheckRunByNameReturnsMostRecentOwnAppRun covers a PR commit with
+// several own-app check runs sharing the same name. The lookup must return
+// the most recently created run (highest check run ID) regardless of the
+// order GitHub lists them in, so a stale earlier run cannot mask the current
+// gate state.
+func TestFindCheckRunByNameReturnsMostRecentOwnAppRun(t *testing.T) {
+	client, mux := setupRateLimitedTestGitHubServer(t)
+	mux.HandleFunc("GET /repos/octocat/hello-world/commits/abc123/check-runs", func(w http.ResponseWriter, _ *http.Request) {
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+			"total_count": 2,
+			"check_runs": []map[string]any{
+				{"id": 3, "name": "SchemaBot (staging)", "status": "completed", "conclusion": "failure", "app": map[string]any{"slug": "schemabot"}},
+				{"id": 9, "name": "SchemaBot (staging)", "status": "completed", "conclusion": "success", "app": map[string]any{"slug": "schemabot"}},
+			},
+		}))
+	})
+
+	ic := NewInstallationClientWithSlug(client, slog.New(slog.NewTextHandler(io.Discard, nil)), "schemabot")
+	result, err := ic.FindCheckRunByName(t.Context(), "octocat/hello-world", "abc123", "SchemaBot (staging)")
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, int64(9), result.ID)
+	assert.Equal(t, "success", result.Conclusion)
+}
+
+// TestFindCheckRunByNameErrorsWhenOwnAppSlugUnknown covers the case where the
+// client does not know its own GitHub App slug, so check run ownership cannot
+// be verified. The lookup must return an error without querying GitHub —
+// ownership ambiguity must never be converted into a result a gate could
+// trust.
+func TestFindCheckRunByNameErrorsWhenOwnAppSlugUnknown(t *testing.T) {
+	client, mux := setupRateLimitedTestGitHubServer(t)
+	var requests atomic.Int64
+	mux.HandleFunc("GET /repos/octocat/hello-world/commits/abc123/check-runs", func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+			"total_count": 1,
+			"check_runs": []map[string]any{
+				{"id": 7, "name": "SchemaBot (staging)", "status": "completed", "conclusion": "success", "app": map[string]any{"slug": "schemabot"}},
+			},
+		}))
+	})
+
+	ic := NewInstallationClient(client, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	result, err := ic.FindCheckRunByName(t.Context(), "octocat/hello-world", "abc123", "SchemaBot (staging)")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "check run ownership cannot be verified")
+	assert.Contains(t, err.Error(), "octocat/hello-world")
+	assert.Contains(t, err.Error(), "abc123")
+	assert.Nil(t, result)
+	assert.Equal(t, int64(0), requests.Load())
+}
+
 func setupRateLimitedTestGitHubServer(t *testing.T) (*gh.Client, *http.ServeMux) {
 	t.Helper()
 

--- a/pkg/webhook/check_prior_env.go
+++ b/pkg/webhook/check_prior_env.go
@@ -196,6 +196,10 @@ func storedPriorEnvCheckStatus(check *storage.Check) string {
 // staging are applied. This is the correct behavior for the remote case — we
 // cannot query per-database check state from another instance, and it is safer to
 // require the entire environment to be healthy before promoting.
+//
+// Only Check Runs created by this GitHub App are trusted: a same-named check
+// run from another app (e.g. a GitHub Actions job) cannot satisfy the gate,
+// and when ownership cannot be verified the gate blocks the apply.
 func (h *Handler) checkPriorEnvViaGitHub(
 	ctx context.Context, repo string, pr int,
 	database, environment, priorEnv string,
@@ -223,7 +227,11 @@ func (h *Handler) checkPriorEnvViaGitHub(
 	checkResult, err := h.waitForGitHubPriorEnvCheck(ctx, client, repo, pr, database, environment, priorEnv, prInfo.HeadSHA, checkName)
 	if err != nil {
 		h.logger.Error("failed to query GitHub check for prior environment, blocking apply",
-			"prior_env", priorEnv, "check_name", checkName, "error", err)
+			"repo", repo, "pr", pr,
+			"database", database,
+			"environment", environment, "prior_environment", priorEnv,
+			"head_sha", prInfo.HeadSHA,
+			"check_name", checkName, "error", err)
 		h.postComment(repo, pr, installationID,
 			templates.RenderApplyBlockedByPriorEnvCheckError(priorEnv, "query check runs", err))
 		return true

--- a/pkg/webhook/check_prior_env_test.go
+++ b/pkg/webhook/check_prior_env_test.go
@@ -182,7 +182,7 @@ func TestCheckPriorEnvironmentsWithProductionOnlyServerConfigChecksStaging(t *te
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"total_count": 1,
 			"check_runs": []map[string]any{
-				{"id": 1, "name": "SchemaBot (staging)", "status": "completed", "conclusion": "action_required"},
+				{"id": 1, "name": "SchemaBot (staging)", "status": "completed", "conclusion": "action_required", "app": map[string]any{"slug": "schemabot"}},
 			},
 		})
 	})
@@ -196,7 +196,7 @@ func TestCheckPriorEnvironmentsWithProductionOnlyServerConfigChecksStaging(t *te
 		_ = json.NewEncoder(w).Encode(map[string]any{"id": 99})
 	})
 
-	installClient := ghclient.NewInstallationClient(client, testLogger())
+	installClient := ghclient.NewInstallationClientWithSlug(client, testLogger(), "schemabot")
 	service := api.New(&emptyStorage{}, &api.ServerConfig{
 		AllowedEnvironments: []string{"production"},
 		EnvironmentOrder:    []string{"staging", "production"},
@@ -296,7 +296,7 @@ func TestCheckPriorEnvViaGitHub(t *testing.T) {
 			})
 		})
 
-		installClient := ghclient.NewInstallationClient(client, testLogger())
+		installClient := ghclient.NewInstallationClientWithSlug(client, testLogger(), "schemabot")
 		factory := &fakeClientFactory{client: installClient}
 		config := &api.ServerConfig{}
 		if len(configs) > 0 {
@@ -318,7 +318,7 @@ func TestCheckPriorEnvViaGitHub(t *testing.T) {
 
 	t.Run("staging check success allows proceed", func(t *testing.T) {
 		h, comments := setupCheckRunServer(t, []map[string]any{
-			{"id": 1, "name": "SchemaBot (staging)", "status": "completed", "conclusion": "success"},
+			{"id": 1, "name": "SchemaBot (staging)", "status": "completed", "conclusion": "success", "app": map[string]any{"slug": "schemabot"}},
 		})
 
 		blocked := h.checkPriorEnvViaGitHub(t.Context(), repo, pr, "orders", "production", "staging", 12345)
@@ -333,7 +333,7 @@ func TestCheckPriorEnvViaGitHub(t *testing.T) {
 
 	t.Run("custom check name success allows proceed", func(t *testing.T) {
 		h, comments := setupCheckRunServer(t, []map[string]any{
-			{"id": 1, "name": "SchemaBot X (staging)", "status": "completed", "conclusion": "success"},
+			{"id": 1, "name": "SchemaBot X (staging)", "status": "completed", "conclusion": "success", "app": map[string]any{"slug": "schemabot"}},
 		}, &api.ServerConfig{GitHub: api.GitHubConfig{CheckName: "SchemaBot X"}})
 
 		blocked := h.checkPriorEnvViaGitHub(t.Context(), repo, pr, "orders", "production", "staging", 12345)
@@ -348,7 +348,7 @@ func TestCheckPriorEnvViaGitHub(t *testing.T) {
 
 	t.Run("staging check pending blocks apply", func(t *testing.T) {
 		h, _ := setupCheckRunServer(t, []map[string]any{
-			{"id": 1, "name": "SchemaBot (staging)", "status": "completed", "conclusion": "action_required"},
+			{"id": 1, "name": "SchemaBot (staging)", "status": "completed", "conclusion": "action_required", "app": map[string]any{"slug": "schemabot"}},
 		})
 
 		blocked := h.checkPriorEnvViaGitHub(t.Context(), repo, pr, "orders", "production", "staging", 12345)
@@ -374,11 +374,87 @@ func TestCheckPriorEnvViaGitHub(t *testing.T) {
 
 	t.Run("staging check in progress blocks apply", func(t *testing.T) {
 		h, _ := setupCheckRunServer(t, []map[string]any{
-			{"id": 1, "name": "SchemaBot (staging)", "status": "in_progress", "conclusion": ""},
+			{"id": 1, "name": "SchemaBot (staging)", "status": "in_progress", "conclusion": "", "app": map[string]any{"slug": "schemabot"}},
 		})
 
 		blocked := h.checkPriorEnvViaGitHub(t.Context(), repo, pr, "orders", "production", "staging", 12345)
 		assert.True(t, blocked)
+	})
+
+	// A repository contributor can create a GitHub Actions job whose name matches
+	// the staging instance's aggregate Check Run. The promotion gate must only
+	// trust Check Runs created by SchemaBot's own GitHub App, so a passing
+	// same-named run from another app blocks the production apply as if the
+	// staging check were missing.
+	t.Run("same-named foreign-app success run blocks apply", func(t *testing.T) {
+		h, comments := setupCheckRunServer(t, []map[string]any{
+			{"id": 1, "name": "SchemaBot (staging)", "status": "completed", "conclusion": "success", "app": map[string]any{"slug": "github-actions"}},
+		})
+
+		blocked := h.checkPriorEnvViaGitHub(t.Context(), repo, pr, "orders", "production", "staging", 12345)
+		assert.True(t, blocked, "a foreign-app check run must not satisfy the promotion gate")
+
+		select {
+		case body := <-comments:
+			assert.Contains(t, body, "Apply Blocked")
+			assert.Contains(t, body, "could not find a completed `staging` check")
+		default:
+			t.Fatal("expected a comment explaining the missing prior environment check")
+		}
+	})
+
+	// When SchemaBot does not know its own GitHub App slug it cannot verify
+	// which app created the staging Check Run, so the promotion gate blocks the
+	// production apply even though a same-named passing run exists.
+	t.Run("unknown own app slug blocks apply", func(t *testing.T) {
+		client, mux := setupGitHubServer(t)
+		comments := make(chan string, 10)
+
+		mux.HandleFunc("GET /repos/octocat/hello-world/pulls/1", func(w http.ResponseWriter, _ *http.Request) {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"head": map[string]any{"sha": headSHA, "ref": "feature"},
+				"base": map[string]any{"sha": "base123", "ref": "main"},
+				"user": map[string]any{"login": "testuser"},
+			})
+		})
+
+		mux.HandleFunc("POST /repos/octocat/hello-world/issues/1/comments", func(w http.ResponseWriter, r *http.Request) {
+			var body struct {
+				Body string `json:"body"`
+			}
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+			comments <- body.Body
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": 99})
+		})
+
+		mux.HandleFunc("GET /repos/octocat/hello-world/commits/abc123/check-runs", func(w http.ResponseWriter, _ *http.Request) {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"total_count": 1,
+				"check_runs": []map[string]any{
+					{"id": 1, "name": "SchemaBot (staging)", "status": "completed", "conclusion": "success", "app": map[string]any{"slug": "schemabot"}},
+				},
+			})
+		})
+
+		installClient := ghclient.NewInstallationClient(client, testLogger())
+		h := &Handler{
+			ghClients:                  ghclient.NewSingleClientSet(defaultAppName, &fakeClientFactory{client: installClient}),
+			logger:                     testLogger(),
+			priorEnvCheckMaxAttempts:   1,
+			priorEnvCheckRetryInterval: time.Nanosecond,
+		}
+
+		blocked := h.checkPriorEnvViaGitHub(t.Context(), repo, pr, "orders", "production", "staging", 12345)
+		assert.True(t, blocked, "unverifiable check run ownership must block the promotion gate")
+
+		select {
+		case body := <-comments:
+			assert.Contains(t, body, "Apply Blocked")
+			assert.Contains(t, body, "staging")
+		default:
+			t.Fatal("expected a comment explaining the verification failure")
+		}
 	})
 
 	// This covers the cross-instance race where the production SchemaBot instance
@@ -413,7 +489,7 @@ func TestCheckPriorEnvViaGitHub(t *testing.T) {
 			checkRuns := []map[string]any{}
 			if checkCalls > 1 {
 				checkRuns = []map[string]any{
-					{"id": 1, "name": "SchemaBot (staging)", "status": "completed", "conclusion": "success"},
+					{"id": 1, "name": "SchemaBot (staging)", "status": "completed", "conclusion": "success", "app": map[string]any{"slug": "schemabot"}},
 				}
 			}
 			_ = json.NewEncoder(w).Encode(map[string]any{
@@ -422,7 +498,7 @@ func TestCheckPriorEnvViaGitHub(t *testing.T) {
 			})
 		})
 
-		installClient := ghclient.NewInstallationClient(client, testLogger())
+		installClient := ghclient.NewInstallationClientWithSlug(client, testLogger(), "schemabot")
 		h := &Handler{
 			ghClients:                  ghclient.NewSingleClientSet(defaultAppName, &fakeClientFactory{client: installClient}),
 			logger:                     testLogger(),
@@ -469,7 +545,7 @@ func TestCheckPriorEnvViaGitHub(t *testing.T) {
 			w.WriteHeader(http.StatusInternalServerError)
 		})
 
-		installClient := ghclient.NewInstallationClient(client, testLogger())
+		installClient := ghclient.NewInstallationClientWithSlug(client, testLogger(), "schemabot")
 		factory := &fakeClientFactory{client: installClient}
 
 		h := &Handler{


### PR DESCRIPTION
The cross-instance staging-first promotion gate looks up the prior environment's aggregate Check Run by name on the PR head commit. The lookup did not verify which GitHub App created the run, so a same-named check run from another app (for example a GitHub Actions job configured with a matching name) could satisfy the gate and allow a production apply without the prior environment ever being applied.

- `FindCheckRunByName` now only returns Check Runs created by SchemaBot's own GitHub App, selecting the most recently created run when several own-app runs share the name; same-named foreign-app runs are ignored and logged.
- When the own app slug is unknown, the lookup returns an error instead of an arbitrary run, so ownership ambiguity fails closed and blocks the promotion gate.
- The gate's failure log now includes repo, PR, head SHA, environment, and check name for triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)