### PR TITLE
fix(operator): derive apply state from tasks when stop finds no active work

### DIFF
--- a/pkg/tern/local_control.go
+++ b/pkg/tern/local_control.go
@@ -483,12 +483,29 @@ func (c *LocalClient) markTasksWithState(ctx context.Context, tasks []*storage.T
 	return stoppedCount, skippedCount, applyID
 }
 
+// firstFailedTaskError returns an apply-level failure reason derived from task
+// rows: the first failed task that recorded an error message, preferring
+// hard-failed tasks over retryable ones. Returns "" when no failed task
+// recorded a reason.
+func firstFailedTaskError(tasks []*storage.Task) string {
+	for _, failedState := range []string{state.Task.Failed, state.Task.FailedRetryable} {
+		for _, task := range tasks {
+			if state.IsState(task.State, failedState) && task.ErrorMessage != "" {
+				return fmt.Sprintf("table %s failed: %s", task.TableName, task.ErrorMessage)
+			}
+		}
+	}
+	return ""
+}
+
 // handleStopAllTasksTerminal handles the edge case where stop is requested but
 // every targeted task is already in a terminal state (completed, failed,
 // cancelled, or reverted). The apply row may still be non-terminal — e.g., a
 // worker exited after finalizing task rows but before the apply row — so the
 // apply's final state is derived from its task states rather than assumed.
-// A failed task must surface as a failed apply, never as a completed one.
+// A failed task must surface as a failed apply, never as a completed one, and
+// its failure reason is propagated so operators can triage from the apply
+// record. An ErrorMessage already on the apply is authoritative and kept.
 func (c *LocalClient) handleStopAllTasksTerminal(ctx context.Context, applyID int64, skippedCount int64) (*ternv1.StopResponse, error) {
 	apply, err := c.storage.Applies().Get(ctx, applyID)
 	if err != nil {
@@ -507,6 +524,9 @@ func (c *LocalClient) handleStopAllTasksTerminal(ctx context.Context, applyID in
 		oldState := apply.State
 		now := time.Now()
 		apply.State = derivedState
+		if state.IsState(derivedState, state.Apply.Failed) && apply.ErrorMessage == "" {
+			apply.ErrorMessage = firstFailedTaskError(tasks)
+		}
 		if state.IsTerminalApplyState(derivedState) {
 			apply.CompletedAt = &now
 		}

--- a/pkg/tern/local_control.go
+++ b/pkg/tern/local_control.go
@@ -306,8 +306,9 @@ func (c *LocalClient) stop(ctx context.Context, req *ternv1.StopRequest, caller 
 		return nil, fmt.Errorf("no active schema change")
 	}
 
-	// Edge case: stop was requested but all tasks had already completed.
-	// Mark the apply as completed so the TUI sees a clean terminal state.
+	// Edge case: stop was requested but every targeted task is already
+	// terminal. Finalize the apply from its task states so the TUI sees an
+	// accurate terminal state.
 	if stoppedCount == 0 && skippedCount > 0 && applyID > 0 {
 		if targetApply != nil && state.IsTerminalApplyState(targetApply.State) && !state.IsState(targetApply.State, state.Apply.Completed) {
 			c.logger.Info("all tasks are terminal and apply is already terminal; preserving apply state during stop",
@@ -320,7 +321,7 @@ func (c *LocalClient) stop(ctx context.Context, req *ternv1.StopRequest, caller 
 				SkippedCount: skippedCount,
 			}, nil
 		}
-		return c.handleStopAllCompleted(ctx, applyID, skippedCount)
+		return c.handleStopAllTasksTerminal(ctx, applyID, skippedCount)
 	}
 
 	return &ternv1.StopResponse{
@@ -482,25 +483,50 @@ func (c *LocalClient) markTasksWithState(ctx context.Context, tasks []*storage.T
 	return stoppedCount, skippedCount, applyID
 }
 
-// handleStopAllCompleted handles the edge case where stop is requested but all tasks
-// had already completed. Marks the apply as completed so the TUI sees a clean state.
-func (c *LocalClient) handleStopAllCompleted(ctx context.Context, applyID int64, skippedCount int64) (*ternv1.StopResponse, error) {
-	if apply, err := c.storage.Applies().Get(ctx, applyID); err == nil && apply != nil && !state.IsTerminalApplyState(apply.State) {
+// handleStopAllTasksTerminal handles the edge case where stop is requested but
+// every targeted task is already in a terminal state (completed, failed,
+// cancelled, or reverted). The apply row may still be non-terminal — e.g., a
+// worker exited after finalizing task rows but before the apply row — so the
+// apply's final state is derived from its task states rather than assumed.
+// A failed task must surface as a failed apply, never as a completed one.
+func (c *LocalClient) handleStopAllTasksTerminal(ctx context.Context, applyID int64, skippedCount int64) (*ternv1.StopResponse, error) {
+	apply, err := c.storage.Applies().Get(ctx, applyID)
+	if err != nil {
+		return nil, fmt.Errorf("load apply %d after stop found all tasks terminal: %w", applyID, err)
+	}
+	if apply == nil {
+		return nil, fmt.Errorf("load apply %d after stop found all tasks terminal: %w", applyID, storage.ErrApplyNotFound)
+	}
+
+	if !state.IsTerminalApplyState(apply.State) {
+		tasks, err := c.storage.Tasks().GetByApplyID(ctx, applyID)
+		if err != nil {
+			return nil, fmt.Errorf("load tasks for apply %s to derive final state: %w", apply.ApplyIdentifier, err)
+		}
+		derivedState := state.DeriveApplyState(taskStates(tasks))
+		oldState := apply.State
 		now := time.Now()
-		apply.State = state.Apply.Completed
-		apply.CompletedAt = &now
+		apply.State = derivedState
+		if state.IsTerminalApplyState(derivedState) {
+			apply.CompletedAt = &now
+		}
 		apply.UpdatedAt = now
 		if err := c.storage.Applies().Update(ctx, apply); err != nil {
-			c.logger.Error("failed to update apply state", "apply_id", apply.ApplyIdentifier, "state", state.Apply.Completed, "error", err)
+			return nil, fmt.Errorf("update apply %s to derived state %s: %w", apply.ApplyIdentifier, derivedState, err)
 		}
 
+		c.logger.Info("stop found all tasks terminal; apply state derived from tasks",
+			"apply_id", apply.ApplyIdentifier,
+			"old_state", oldState,
+			"new_state", derivedState,
+			"skipped_count", skippedCount)
 		c.logApplyEvent(ctx, applyID, nil, storage.LogLevelInfo, storage.LogEventStateTransition, storage.LogSourceSchemaBot,
-			"All tasks completed before stop took effect", "", state.Apply.Completed)
+			fmt.Sprintf("All tasks terminal before stop took effect; apply state derived from tasks: %s", derivedState), oldState, derivedState)
 	}
 
 	return &ternv1.StopResponse{
 		Accepted:     true,
-		ErrorMessage: "Schema change already completed",
+		ErrorMessage: fmt.Sprintf("Schema change already %s", apply.State),
 		StoppedCount: 0,
 		SkippedCount: skippedCount,
 	}, nil

--- a/pkg/tern/local_control_test.go
+++ b/pkg/tern/local_control_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
 	"testing"
 
@@ -239,6 +240,74 @@ func TestLocalClient_StopMarksMySQLApplyStopped(t *testing.T) {
 	assert.Equal(t, state.Apply.Stopped, apply.State)
 	assert.Nil(t, apply.CompletedAt)
 	require.NotNil(t, eng.stopReq, "stop should call the engine")
+}
+
+// A stop request can race with a worker that finalized all task rows but
+// exited before finalizing the apply row. When every targeted task is already
+// terminal, stop derives the apply's final state from its tasks: an apply
+// whose tasks failed must finish as failed, never as completed, so the
+// failure stays visible to operators instead of being masked as a success.
+func TestLocalClient_StopAllTasksTerminalDerivesApplyState(t *testing.T) {
+	testCases := []struct {
+		name           string
+		taskStates     []string
+		wantApplyState string
+	}{
+		{
+			name:           "all tasks completed",
+			taskStates:     []string{state.Task.Completed, state.Task.Completed},
+			wantApplyState: state.Apply.Completed,
+		},
+		{
+			name:           "all tasks failed",
+			taskStates:     []string{state.Task.Failed, state.Task.Failed},
+			wantApplyState: state.Apply.Failed,
+		},
+		{
+			name:           "failed task among completed tasks",
+			taskStates:     []string{state.Task.Completed, state.Task.Failed},
+			wantApplyState: state.Apply.Failed,
+		},
+		{
+			name:           "all tasks cancelled",
+			taskStates:     []string{state.Task.Cancelled, state.Task.Cancelled},
+			wantApplyState: state.Apply.Cancelled,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			apply := &storage.Apply{
+				ID:              42,
+				ApplyIdentifier: "apply-mysql-stop-terminal",
+				State:           state.Apply.Running,
+				Database:        "testdb",
+				DatabaseType:    storage.DatabaseTypeMySQL,
+				Environment:     "staging",
+			}
+			tasks := make([]*storage.Task, 0, len(tc.taskStates))
+			for i, taskState := range tc.taskStates {
+				tasks = append(tasks, &storage.Task{
+					ID:             int64(i + 1),
+					ApplyID:        apply.ID,
+					TaskIdentifier: fmt.Sprintf("task-mysql-stop-terminal-%d", i+1),
+					Database:       "testdb",
+					State:          taskState,
+				})
+			}
+			client := newMySQLControlTestClient(apply, tasks, &controlCaptureEngine{})
+
+			resp, err := client.Stop(t.Context(), &ternv1.StopRequest{ApplyId: apply.ApplyIdentifier})
+
+			require.NoError(t, err)
+			assert.True(t, resp.Accepted)
+			assert.Equal(t, int64(0), resp.StoppedCount)
+			assert.Equal(t, int64(len(tasks)), resp.SkippedCount)
+			assert.Equal(t, "Schema change already "+tc.wantApplyState, resp.ErrorMessage)
+			assert.Equal(t, tc.wantApplyState, apply.State)
+			require.NotNil(t, apply.CompletedAt)
+		})
+	}
 }
 
 // PlanetScale cutover must include the opaque resume state recorded for the

--- a/pkg/tern/local_control_test.go
+++ b/pkg/tern/local_control_test.go
@@ -247,11 +247,17 @@ func TestLocalClient_StopMarksMySQLApplyStopped(t *testing.T) {
 // terminal, stop derives the apply's final state from its tasks: an apply
 // whose tasks failed must finish as failed, never as completed, so the
 // failure stays visible to operators instead of being masked as a success.
+// When the derived state is failed, the failure reason from the task rows is
+// propagated to the apply record so operators can triage without digging into
+// individual tasks; a reason already on the apply is kept.
 func TestLocalClient_StopAllTasksTerminalDerivesApplyState(t *testing.T) {
 	testCases := []struct {
-		name           string
-		taskStates     []string
-		wantApplyState string
+		name              string
+		taskStates        []string
+		taskErrors        []string
+		applyErrorMessage string
+		wantApplyState    string
+		wantErrorMessage  string
 	}{
 		{
 			name:           "all tasks completed",
@@ -259,14 +265,26 @@ func TestLocalClient_StopAllTasksTerminalDerivesApplyState(t *testing.T) {
 			wantApplyState: state.Apply.Completed,
 		},
 		{
-			name:           "all tasks failed",
-			taskStates:     []string{state.Task.Failed, state.Task.Failed},
-			wantApplyState: state.Apply.Failed,
+			name:             "all tasks failed",
+			taskStates:       []string{state.Task.Failed, state.Task.Failed},
+			taskErrors:       []string{"", "row copy failed: lock wait timeout"},
+			wantApplyState:   state.Apply.Failed,
+			wantErrorMessage: "table t2 failed: row copy failed: lock wait timeout",
 		},
 		{
-			name:           "failed task among completed tasks",
-			taskStates:     []string{state.Task.Completed, state.Task.Failed},
-			wantApplyState: state.Apply.Failed,
+			name:             "failed task among completed tasks",
+			taskStates:       []string{state.Task.Completed, state.Task.Failed},
+			taskErrors:       []string{"", "cutover failed: deadlock detected"},
+			wantApplyState:   state.Apply.Failed,
+			wantErrorMessage: "table t2 failed: cutover failed: deadlock detected",
+		},
+		{
+			name:              "existing apply error message is kept",
+			taskStates:        []string{state.Task.Failed, state.Task.Failed},
+			taskErrors:        []string{"row copy failed: lock wait timeout", ""},
+			applyErrorMessage: "operator recorded failure reason",
+			wantApplyState:    state.Apply.Failed,
+			wantErrorMessage:  "operator recorded failure reason",
 		},
 		{
 			name:           "all tasks cancelled",
@@ -284,16 +302,22 @@ func TestLocalClient_StopAllTasksTerminalDerivesApplyState(t *testing.T) {
 				Database:        "testdb",
 				DatabaseType:    storage.DatabaseTypeMySQL,
 				Environment:     "staging",
+				ErrorMessage:    tc.applyErrorMessage,
 			}
 			tasks := make([]*storage.Task, 0, len(tc.taskStates))
 			for i, taskState := range tc.taskStates {
-				tasks = append(tasks, &storage.Task{
+				task := &storage.Task{
 					ID:             int64(i + 1),
 					ApplyID:        apply.ID,
 					TaskIdentifier: fmt.Sprintf("task-mysql-stop-terminal-%d", i+1),
+					TableName:      fmt.Sprintf("t%d", i+1),
 					Database:       "testdb",
 					State:          taskState,
-				})
+				}
+				if i < len(tc.taskErrors) {
+					task.ErrorMessage = tc.taskErrors[i]
+				}
+				tasks = append(tasks, task)
 			}
 			client := newMySQLControlTestClient(apply, tasks, &controlCaptureEngine{})
 
@@ -305,6 +329,7 @@ func TestLocalClient_StopAllTasksTerminalDerivesApplyState(t *testing.T) {
 			assert.Equal(t, int64(len(tasks)), resp.SkippedCount)
 			assert.Equal(t, "Schema change already "+tc.wantApplyState, resp.ErrorMessage)
 			assert.Equal(t, tc.wantApplyState, apply.State)
+			assert.Equal(t, tc.wantErrorMessage, apply.ErrorMessage)
 			require.NotNil(t, apply.CompletedAt)
 		})
 	}


### PR DESCRIPTION
When a stop request finds no stoppable tasks (every targeted task is already terminal), the apply row was unconditionally marked `completed` — even when the tasks had `failed`, `cancelled`, or `reverted`. If a worker exited after finalizing task rows but before finalizing the apply row, a user-issued stop converted that failure into a permanent success, and since terminal applies are never reclaimed, the failure was masked for good.

- Stop now derives the apply's final state from its task states via `state.DeriveApplyState`, so a failed task surfaces as a failed apply; the all-tasks-completed case still finishes as `completed`.
- When the derived state is `failed` and the apply has no error message, the failure reason from the first failed task is propagated to the apply record so CLI/TUI surfaces show why it failed; a reason already on the apply is kept.
- `CompletedAt` is only set when the derived state is terminal, and storage errors during finalization are returned to the caller instead of being swallowed (missing apply and storage failure are reported as distinct errors).
- The stop response message and apply log event now reflect the actual derived state instead of always claiming the schema change completed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)