### PR TITLE
fix(spirit): record terminal state before closing the runner

### DIFF
--- a/pkg/engine/spirit/execution.go
+++ b/pkg/engine/spirit/execution.go
@@ -212,26 +212,30 @@ func (e *Engine) executeSpiritMigration(ctx context.Context, host, username, pas
 		"statement_len", len(combinedStatement),
 	)
 
+	// On every exit path the tracked state must be terminal before the runner
+	// is closed: Close() flips Spirit's status to close while teardown is
+	// still in flight, and a progress poll must observe the recorded outcome,
+	// never infer one from a runner mid-teardown.
 	if err := runner.Run(ctx); err != nil {
 		// Check if this was a cancellation (stop) vs a real failure
 		if ctx.Err() != nil {
 			e.logger.Info("schema change stopped",
 				"reason", ctx.Err(),
 			)
-			utils.CloseAndLog(runner)
 			// Don't change state - Stop() already set it to StateStopped
+			utils.CloseAndLog(runner)
 			return nil
 		}
-		utils.CloseAndLog(runner)
 		e.logger.Error("schema change failed",
 			"error", err,
 		)
 		e.setMigrationFailed(fmt.Errorf("schema change failed: %w", err))
+		utils.CloseAndLog(runner)
 		return err
 	}
 
-	utils.CloseAndLog(runner)
 	e.setMigrationState(engine.StateCompleted)
+	utils.CloseAndLog(runner)
 	e.logger.Info("schema change completed", "database", database, "tables", tables)
 	return nil
 }

--- a/pkg/engine/spirit/spirit.go
+++ b/pkg/engine/spirit/spirit.go
@@ -505,20 +505,18 @@ func (e *Engine) Progress(ctx context.Context, req *engine.ProgressRequest) (*en
 		}
 	}
 
-	// Determine overall state from Spirit's state
-	// Preserve terminal states (stopped, failed) - don't overwrite them
+	// The tracked state is authoritative for terminal outcomes: completed,
+	// failed, and stopped are recorded before the runner is closed, so a
+	// runner observed mid-teardown never implies success on its own.
+	// Spirit's status only refines a non-terminal state, e.g. surfacing the
+	// sentinel wait for a deferred cutover.
 	state := rm.state
 	if state == engine.StateStopped && rm.volumeRestartInProgress {
 		state = engine.StateRunning
 	}
 	if state != engine.StateStopped && state != engine.StateFailed {
-		switch spiritState {
-		case status.WaitingOnSentinelTable:
-			if rm.deferCutover {
-				state = engine.StateWaitingForCutover
-			}
-		case status.Close:
-			state = engine.StateCompleted
+		if spiritState == status.WaitingOnSentinelTable && rm.deferCutover {
+			state = engine.StateWaitingForCutover
 		}
 	}
 

--- a/pkg/engine/spirit/spirit.go
+++ b/pkg/engine/spirit/spirit.go
@@ -505,20 +505,7 @@ func (e *Engine) Progress(ctx context.Context, req *engine.ProgressRequest) (*en
 		}
 	}
 
-	// The tracked state is authoritative for terminal outcomes: completed,
-	// failed, and stopped are recorded before the runner is closed, so a
-	// runner observed mid-teardown never implies success on its own.
-	// Spirit's status only refines a non-terminal state, e.g. surfacing the
-	// sentinel wait for a deferred cutover.
-	state := rm.state
-	if state == engine.StateStopped && rm.volumeRestartInProgress {
-		state = engine.StateRunning
-	}
-	if state != engine.StateStopped && state != engine.StateFailed {
-		if spiritState == status.WaitingOnSentinelTable && rm.deferCutover {
-			state = engine.StateWaitingForCutover
-		}
-	}
+	state := progressState(rm, spiritState)
 
 	// If state was overridden and message is still the default fallback, update message to match
 	defaultMessage := fmt.Sprintf("Schema change %s", rm.state)
@@ -534,6 +521,24 @@ func (e *Engine) Progress(ctx context.Context, req *engine.ProgressRequest) (*en
 		Tables:       tableProgress,
 		ResumeState:  req.ResumeState,
 	}, nil
+}
+
+// progressState resolves the state reported for a progress poll. The tracked
+// state is authoritative for terminal outcomes: they are recorded before the
+// runner is closed, so a runner observed mid-teardown never changes the
+// recorded outcome. Spirit's status only refines a non-terminal state, e.g.
+// surfacing the sentinel wait for a deferred cutover. A stopped tracked state
+// with a volume restart in flight reports running because the schema change
+// is restarting with new settings.
+func progressState(rm *runningMigration, spiritState status.State) engine.State {
+	state := rm.state
+	if state == engine.StateStopped && rm.volumeRestartInProgress {
+		state = engine.StateRunning
+	}
+	if !state.IsTerminal() && spiritState == status.WaitingOnSentinelTable && rm.deferCutover {
+		state = engine.StateWaitingForCutover
+	}
+	return state
 }
 
 // fetchCurrentSchema retrieves table schemas from the database, filtering out

--- a/pkg/engine/spirit/spirit_integration_test.go
+++ b/pkg/engine/spirit/spirit_integration_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	spiritmigration "github.com/block/spirit/pkg/migration"
 	"github.com/block/spirit/pkg/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -722,6 +723,72 @@ func TestEngine_Progress_NamespaceFromApplyChanges(t *testing.T) {
 	}
 }
 
+// TestEngine_Progress_ClosedRunnerIsNotCompletion verifies that a progress
+// poll observing a runner in teardown (Spirit status "close") reports the
+// tracked state instead of inferring terminal success. Terminal outcomes are
+// recorded before the runner is closed, so a closing runner alongside a
+// non-terminal tracked state means the apply is still in flight — for
+// example the stopped runner that stays registered while a volume change
+// restarts the schema change.
+func TestEngine_Progress_ClosedRunnerIsNotCompletion(t *testing.T) {
+	password := "testpassword"
+	runner, err := spiritmigration.NewRunner(&spiritmigration.Migration{
+		Host:      "localhost:3306",
+		Username:  "root",
+		Password:  &password,
+		Database:  "testdb",
+		Statement: "ALTER TABLE `progress_close` ADD COLUMN `email` varchar(255) NULL",
+	})
+	require.NoError(t, err, "NewRunner")
+	require.NoError(t, runner.Close(), "close runner")
+
+	t.Run("running state keeps reporting running", func(t *testing.T) {
+		eng := New(Config{})
+		eng.runningMigration = &runningMigration{
+			database: "testdb",
+			tables:   []string{"progress_close"},
+			state:    engine.StateRunning,
+			runners:  []*spiritmigration.Runner{runner},
+		}
+
+		result, err := eng.Progress(t.Context(), &engine.ProgressRequest{})
+		require.NoError(t, err, "Progress()")
+		assert.Equal(t, engine.StateRunning, result.State)
+	})
+
+	t.Run("volume restart reports running", func(t *testing.T) {
+		eng := New(Config{})
+		eng.runningMigration = &runningMigration{
+			database:                "testdb",
+			tables:                  []string{"progress_close"},
+			state:                   engine.StateStopped,
+			volumeRestartInProgress: true,
+			runners:                 []*spiritmigration.Runner{runner},
+		}
+
+		result, err := eng.Progress(t.Context(), &engine.ProgressRequest{})
+		require.NoError(t, err, "Progress()")
+		assert.Equal(t, engine.StateRunning, result.State)
+	})
+
+	t.Run("failed state keeps reporting failed", func(t *testing.T) {
+		eng := New(Config{})
+		eng.runningMigration = &runningMigration{
+			database:     "testdb",
+			tables:       []string{"progress_close"},
+			state:        engine.StateFailed,
+			errorMessage: "schema change failed: ddl error",
+			runners:      []*spiritmigration.Runner{runner},
+		}
+
+		result, err := eng.Progress(t.Context(), &engine.ProgressRequest{})
+		require.NoError(t, err, "Progress()")
+		assert.Equal(t, engine.StateFailed, result.State)
+		assert.Equal(t, "schema change failed: ddl error", result.ErrorMessage)
+		assert.True(t, result.Retryable)
+	})
+}
+
 func TestEngine_FetchCurrentSchema_EmptyDatabase(t *testing.T) {
 	dsn, db := setupTestMySQL(t)
 	cleanupTables(t, db) // Start with clean database
@@ -1008,6 +1075,69 @@ func TestEngine_ExecuteMigration_InvalidSQL(t *testing.T) {
 	eng.mu.Unlock()
 
 	assert.Equal(t, engine.StateFailed, finalState, "expected StateFailed for invalid SQL")
+}
+
+// TestEngine_Progress_FailingApplyNeverReportsCompleted verifies that a
+// schema change which fails against the database is never observable as
+// completed: progress polls taken at any point during the apply — including
+// while the failed runner is torn down — report running and then failed.
+func TestEngine_Progress_FailingApplyNeverReportsCompleted(t *testing.T) {
+	dsn, db := setupTestMySQL(t)
+
+	_, err := db.ExecContext(t.Context(), `CREATE TABLE fail_progress (id INT PRIMARY KEY)`)
+	require.NoError(t, err, "create table")
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	eng := New(Config{Logger: logger})
+
+	host, username, password, database, err := parseDSN(dsn)
+	require.NoError(t, err, "parseDSN")
+
+	ddlStatements := []string{
+		"ALTER TABLE `fail_progress` DROP COLUMN `nonexistent_column`",
+	}
+
+	eng.mu.Lock()
+	eng.runningMigration = &runningMigration{
+		database: database,
+		tables:   []string{"fail_progress"},
+		state:    engine.StateRunning,
+		started:  time.Now(),
+	}
+	eng.mu.Unlock()
+
+	ctx := t.Context()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		eng.executeMigration(ctx, host, username, password, database, ddlStatements, false)
+	}()
+
+	deadline := time.NewTimer(30 * time.Second)
+	defer deadline.Stop()
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+
+	for applyFinished := false; !applyFinished; {
+		select {
+		case <-done:
+			applyFinished = true
+		case <-deadline.C:
+			t.Fatal("timed out waiting for the schema change to fail")
+		case <-ticker.C:
+		}
+		result, err := eng.Progress(t.Context(), &engine.ProgressRequest{})
+		require.NoError(t, err, "Progress()")
+		assert.NotEqual(t, engine.StateCompleted, result.State,
+			"failing schema change reported terminal success")
+	}
+
+	result, err := eng.Progress(t.Context(), &engine.ProgressRequest{})
+	require.NoError(t, err, "Progress()")
+	assert.Equal(t, engine.StateFailed, result.State)
+	assert.Contains(t, result.ErrorMessage, "schema change failed")
+	assert.Contains(t, result.ErrorMessage, "nonexistent_column")
+	assert.True(t, result.Retryable)
 }
 
 // TestEngine_ExecuteMigration_MultipleStatements tests running multiple

--- a/pkg/engine/spirit/spirit_integration_test.go
+++ b/pkg/engine/spirit/spirit_integration_test.go
@@ -731,12 +731,14 @@ func TestEngine_Progress_NamespaceFromApplyChanges(t *testing.T) {
 // example the stopped runner that stays registered while a volume change
 // restarts the schema change.
 func TestEngine_Progress_ClosedRunnerIsNotCompletion(t *testing.T) {
-	password := "testpassword"
+	host, username, password, database, err := parseDSN(sharedDSN)
+	require.NoError(t, err, "parseDSN")
+
 	runner, err := spiritmigration.NewRunner(&spiritmigration.Migration{
-		Host:      "localhost:3306",
-		Username:  "root",
+		Host:      host,
+		Username:  username,
 		Password:  &password,
-		Database:  "testdb",
+		Database:  database,
 		Statement: "ALTER TABLE `progress_close` ADD COLUMN `email` varchar(255) NULL",
 	})
 	require.NoError(t, err, "NewRunner")
@@ -745,7 +747,7 @@ func TestEngine_Progress_ClosedRunnerIsNotCompletion(t *testing.T) {
 	t.Run("running state keeps reporting running", func(t *testing.T) {
 		eng := New(Config{})
 		eng.runningMigration = &runningMigration{
-			database: "testdb",
+			database: database,
 			tables:   []string{"progress_close"},
 			state:    engine.StateRunning,
 			runners:  []*spiritmigration.Runner{runner},
@@ -759,7 +761,7 @@ func TestEngine_Progress_ClosedRunnerIsNotCompletion(t *testing.T) {
 	t.Run("volume restart reports running", func(t *testing.T) {
 		eng := New(Config{})
 		eng.runningMigration = &runningMigration{
-			database:                "testdb",
+			database:                database,
 			tables:                  []string{"progress_close"},
 			state:                   engine.StateStopped,
 			volumeRestartInProgress: true,
@@ -774,7 +776,7 @@ func TestEngine_Progress_ClosedRunnerIsNotCompletion(t *testing.T) {
 	t.Run("failed state keeps reporting failed", func(t *testing.T) {
 		eng := New(Config{})
 		eng.runningMigration = &runningMigration{
-			database:     "testdb",
+			database:     database,
 			tables:       []string{"progress_close"},
 			state:        engine.StateFailed,
 			errorMessage: "schema change failed: ddl error",
@@ -786,6 +788,21 @@ func TestEngine_Progress_ClosedRunnerIsNotCompletion(t *testing.T) {
 		assert.Equal(t, engine.StateFailed, result.State)
 		assert.Equal(t, "schema change failed: ddl error", result.ErrorMessage)
 		assert.True(t, result.Retryable)
+	})
+
+	t.Run("completed state keeps reporting completed", func(t *testing.T) {
+		eng := New(Config{})
+		eng.runningMigration = &runningMigration{
+			database:     database,
+			tables:       []string{"progress_close"},
+			state:        engine.StateCompleted,
+			deferCutover: true,
+			runners:      []*spiritmigration.Runner{runner},
+		}
+
+		result, err := eng.Progress(t.Context(), &engine.ProgressRequest{})
+		require.NoError(t, err, "Progress()")
+		assert.Equal(t, engine.StateCompleted, result.State)
 	})
 }
 

--- a/pkg/engine/spirit/spirit_test.go
+++ b/pkg/engine/spirit/spirit_test.go
@@ -1,0 +1,109 @@
+package spirit
+
+import (
+	"testing"
+
+	"github.com/block/spirit/pkg/status"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/block/schemabot/pkg/engine"
+)
+
+// TestProgressState verifies that a progress poll reports the tracked state
+// for every terminal outcome regardless of what a lingering runner's Spirit
+// status says, and that Spirit's status only refines non-terminal states
+// (sentinel wait for a deferred cutover, volume restarts).
+func TestProgressState(t *testing.T) {
+	tests := []struct {
+		name        string
+		rm          *runningMigration
+		spiritState status.State
+		want        engine.State
+	}{
+		{
+			name: "completed is never downgraded by sentinel wait",
+			rm: &runningMigration{
+				state:        engine.StateCompleted,
+				deferCutover: true,
+			},
+			spiritState: status.WaitingOnSentinelTable,
+			want:        engine.StateCompleted,
+		},
+		{
+			name: "completed is not re-derived from a closing runner",
+			rm: &runningMigration{
+				state: engine.StateCompleted,
+			},
+			spiritState: status.Close,
+			want:        engine.StateCompleted,
+		},
+		{
+			name: "failed is never downgraded by sentinel wait",
+			rm: &runningMigration{
+				state:        engine.StateFailed,
+				deferCutover: true,
+			},
+			spiritState: status.WaitingOnSentinelTable,
+			want:        engine.StateFailed,
+		},
+		{
+			name: "stopped stays stopped while the runner tears down",
+			rm: &runningMigration{
+				state:        engine.StateStopped,
+				deferCutover: true,
+			},
+			spiritState: status.WaitingOnSentinelTable,
+			want:        engine.StateStopped,
+		},
+		{
+			name: "closing runner does not imply completion",
+			rm: &runningMigration{
+				state: engine.StateRunning,
+			},
+			spiritState: status.Close,
+			want:        engine.StateRunning,
+		},
+		{
+			name: "sentinel wait surfaces deferred cutover",
+			rm: &runningMigration{
+				state:        engine.StateRunning,
+				deferCutover: true,
+			},
+			spiritState: status.WaitingOnSentinelTable,
+			want:        engine.StateWaitingForCutover,
+		},
+		{
+			name: "sentinel wait without deferred cutover stays running",
+			rm: &runningMigration{
+				state: engine.StateRunning,
+			},
+			spiritState: status.WaitingOnSentinelTable,
+			want:        engine.StateRunning,
+		},
+		{
+			name: "volume restart reports stopped state as running",
+			rm: &runningMigration{
+				state:                   engine.StateStopped,
+				volumeRestartInProgress: true,
+			},
+			spiritState: status.Close,
+			want:        engine.StateRunning,
+		},
+		{
+			name: "volume restart still surfaces deferred cutover",
+			rm: &runningMigration{
+				state:                   engine.StateStopped,
+				volumeRestartInProgress: true,
+				deferCutover:            true,
+			},
+			spiritState: status.WaitingOnSentinelTable,
+			want:        engine.StateWaitingForCutover,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, progressState(tt.rm, tt.spiritState))
+		})
+	}
+}


### PR DESCRIPTION
Spirit's `Runner.Close()` sets its internal status to `close` as its first action, while teardown (dropping internal tables, closing pools) is still in flight. A progress poll landing in that window saw a runner that looked finished while the tracked engine state was still running, and reported a failed schema change as completed — a terminal success state the orchestration layer persists.

- `executeSpiritMigration` now records the terminal engine state (failed or completed) before closing the runner, so the tracked state is always terminal by the time `Close()` can be observed. The stop path was already correct: `Stop()` records stopped before cancelling.
- `Progress` no longer maps Spirit's `close` status to terminal success on its own — the tracked state is authoritative for terminal outcomes. This also fixes a false "completed" window during volume restarts, where the stopped runner stays registered (and reported as running) until the restarted apply replaces it.

```
before: Run() fails -> Close() [status=close, teardown...] -> state=failed
                              ^ poll here reported completed
after:  Run() fails -> state=failed -> Close() [status=close, teardown...]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)