### PR TITLE
fix(github): enforce actor authorization for rollback and unlock commands

### DIFF
--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -4302,6 +4302,21 @@ A configured SchemaBot admin/database operator should inspect SchemaBot authoriz
 </details>
 
 <details>
+<summary><a name="actor-authorization-database-not-configured"></a><strong>Actor Authorization: Database Not Configured</strong></summary>
+
+
+## SchemaBot Command Not Authorized
+
+**Database**: `payments`
+
+`schemabot unlock` cannot run because database `payments` is not configured on this SchemaBot instance.
+
+Verify the database name, or run the command against the SchemaBot instance that manages this database.
+
+
+</details>
+
+<details>
 <summary><a name="cutover-command-accepted"></a><strong>Cutover Command Accepted</strong></summary>
 
 

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -375,28 +375,29 @@ type DatabaseConfig struct {
 	// and descendants. A literal "*" allows any trusted schema directory.
 	AllowedDirs []string `yaml:"allowed_dirs,omitempty"`
 
-	// OperatorTeams are GitHub teams whose members may run apply/apply-confirm
-	// PR comment commands for this database when PR command authorization is enabled.
+	// OperatorTeams are GitHub teams whose members may run mutating PR comment
+	// commands for this database when PR command authorization is enabled.
 	OperatorTeams []string `yaml:"operator_teams,omitempty"`
 
-	// OperatorUsers are GitHub users who may run apply/apply-confirm PR comment
-	// commands for this database when PR command authorization is enabled.
+	// OperatorUsers are GitHub users who may run mutating PR comment commands
+	// for this database when PR command authorization is enabled.
 	OperatorUsers []string `yaml:"operator_users,omitempty"`
 }
 
-// PRCommandAuthorizationConfig configures actor authorization for SchemaBot
-// apply/apply-confirm GitHub PR comment commands.
+// PRCommandAuthorizationConfig configures actor authorization for mutating
+// SchemaBot GitHub PR comment commands (apply, stop, cutover, rollback,
+// unlock, and their confirmation variants).
 type PRCommandAuthorizationConfig struct {
-	// Enabled turns on fail-closed actor authorization for apply/apply-confirm
-	// PR commands.
+	// Enabled turns on fail-closed actor authorization for mutating PR
+	// commands.
 	Enabled bool `yaml:"enabled,omitempty"`
 
-	// AdminTeams are GitHub teams whose members may run apply/apply-confirm PR
-	// commands for any configured database.
+	// AdminTeams are GitHub teams whose members may run mutating PR commands
+	// for any configured database.
 	AdminTeams []string `yaml:"admin_teams,omitempty"`
 
-	// AdminUsers are GitHub users who may run apply/apply-confirm PR commands
-	// for any configured database.
+	// AdminUsers are GitHub users who may run mutating PR commands for any
+	// configured database.
 	AdminUsers []string `yaml:"admin_users,omitempty"`
 }
 

--- a/pkg/cmd/internal/templates/preview.go
+++ b/pkg/cmd/internal/templates/preview.go
@@ -146,23 +146,24 @@ const (
 	PreviewCommentAll                     PreviewType = "comment_all"                        // Show all comment template previews
 
 	// Apply command comment previews (GitHub PR apply commands)
-	PreviewCommentApplyStartedType     PreviewType = "comment_apply_started"                // Apply started notification
-	PreviewCommentApplyWaiting         PreviewType = "comment_apply_waiting"                // Waiting for cutover notification
-	PreviewCommentUnlock               PreviewType = "comment_unlock"                       // Lock released confirmation
-	PreviewCommentApplyBlocked         PreviewType = "comment_apply_blocked"                // Apply blocked by another PR
-	PreviewCommentApplyBlockedCLI      PreviewType = "comment_apply_blocked_cli"            // Apply blocked by CLI session
-	PreviewCommentApplyActive          PreviewType = "comment_apply_active"                 // Apply already in progress
-	PreviewCommentApplyNoLock          PreviewType = "comment_apply_no_lock"                // No lock found
-	PreviewCommentBlockedByPriorEnv    PreviewType = "comment_blocked_prior_env"            // Blocked by staging (pending)
-	PreviewCommentBlockedByPriorFailed PreviewType = "comment_blocked_prior_env_failed"     // Blocked by staging (failed)
-	PreviewCommentBlockedByPriorInProg PreviewType = "comment_blocked_prior_env_inprogress" // Blocked by staging (in progress)
-	PreviewCommentReviewRequired       PreviewType = "comment_review_required"              // Review gate: approval needed
-	PreviewCommentReviewGateError      PreviewType = "comment_review_gate_error"            // Review gate: fail-closed error
-	PreviewCommentChecksGateNotPassing PreviewType = "comment_checks_gate_not_passing"      // Checks gate: non-passing CI/lint
-	PreviewCommentChecksGateInProgress PreviewType = "comment_checks_gate_in_progress"      // Checks gate: CI still running
-	PreviewCommentActorNotAuthorized   PreviewType = "comment_actor_not_authorized"         // Actor authorization: user is not allowed
-	PreviewCommentActorAuthUnavailable PreviewType = "comment_actor_auth_unavailable"       // Actor authorization: fail-closed error
-	PreviewCommentCutoverAccepted      PreviewType = "comment_cutover_accepted"             // Cutover command accepted
-	PreviewCommentCutoverActive        PreviewType = "comment_cutover_active"               // Cutover command when cutover is already in progress
-	PreviewCommentApplyAllType         PreviewType = "comment_apply_all"                    // Show all apply comment previews
+	PreviewCommentApplyStartedType      PreviewType = "comment_apply_started"                // Apply started notification
+	PreviewCommentApplyWaiting          PreviewType = "comment_apply_waiting"                // Waiting for cutover notification
+	PreviewCommentUnlock                PreviewType = "comment_unlock"                       // Lock released confirmation
+	PreviewCommentApplyBlocked          PreviewType = "comment_apply_blocked"                // Apply blocked by another PR
+	PreviewCommentApplyBlockedCLI       PreviewType = "comment_apply_blocked_cli"            // Apply blocked by CLI session
+	PreviewCommentApplyActive           PreviewType = "comment_apply_active"                 // Apply already in progress
+	PreviewCommentApplyNoLock           PreviewType = "comment_apply_no_lock"                // No lock found
+	PreviewCommentBlockedByPriorEnv     PreviewType = "comment_blocked_prior_env"            // Blocked by staging (pending)
+	PreviewCommentBlockedByPriorFailed  PreviewType = "comment_blocked_prior_env_failed"     // Blocked by staging (failed)
+	PreviewCommentBlockedByPriorInProg  PreviewType = "comment_blocked_prior_env_inprogress" // Blocked by staging (in progress)
+	PreviewCommentReviewRequired        PreviewType = "comment_review_required"              // Review gate: approval needed
+	PreviewCommentReviewGateError       PreviewType = "comment_review_gate_error"            // Review gate: fail-closed error
+	PreviewCommentChecksGateNotPassing  PreviewType = "comment_checks_gate_not_passing"      // Checks gate: non-passing CI/lint
+	PreviewCommentChecksGateInProgress  PreviewType = "comment_checks_gate_in_progress"      // Checks gate: CI still running
+	PreviewCommentActorNotAuthorized    PreviewType = "comment_actor_not_authorized"         // Actor authorization: user is not allowed
+	PreviewCommentActorAuthUnavailable  PreviewType = "comment_actor_auth_unavailable"       // Actor authorization: fail-closed error
+	PreviewCommentDatabaseNotConfigured PreviewType = "comment_database_not_configured"      // Actor authorization: database not configured on this instance
+	PreviewCommentCutoverAccepted       PreviewType = "comment_cutover_accepted"             // Cutover command accepted
+	PreviewCommentCutoverActive         PreviewType = "comment_cutover_active"               // Cutover command when cutover is already in progress
+	PreviewCommentApplyAllType          PreviewType = "comment_apply_all"                    // Show all apply comment previews
 )

--- a/pkg/cmd/internal/templates/preview_comment.go
+++ b/pkg/cmd/internal/templates/preview_comment.go
@@ -104,6 +104,7 @@ func previewApplyCommandAllOutput() {
 		{"REVIEW GATE ERROR (FAIL-CLOSED)", func() { fmt.Print(webhooktemplates.PreviewCommentReviewGateError()) }},
 		{"ACTOR AUTHORIZATION: NOT AUTHORIZED", func() { fmt.Print(webhooktemplates.PreviewCommentPRCommandNotAuthorized()) }},
 		{"ACTOR AUTHORIZATION: UNAVAILABLE", func() { fmt.Print(webhooktemplates.PreviewCommentPRCommandAuthorizationUnavailable()) }},
+		{"ACTOR AUTHORIZATION: DATABASE NOT CONFIGURED", func() { fmt.Print(webhooktemplates.PreviewCommentPRCommandDatabaseNotConfigured()) }},
 		{"CUTOVER COMMAND ACCEPTED", func() { fmt.Print(webhooktemplates.PreviewCommentCutoverCommandAccepted()) }},
 		{"CUTOVER COMMAND ALREADY IN PROGRESS", func() { fmt.Print(webhooktemplates.PreviewCommentCutoverCommandAlreadyInProgress()) }},
 		{"CHECKS GATE: NOT PASSING", func() {

--- a/pkg/cmd/internal/templates/preview_dispatch.go
+++ b/pkg/cmd/internal/templates/preview_dispatch.go
@@ -216,6 +216,8 @@ func PreviewCLIOutput(previewType PreviewType) {
 		fmt.Print(webhooktemplates.PreviewCommentPRCommandNotAuthorized())
 	case PreviewCommentActorAuthUnavailable:
 		fmt.Print(webhooktemplates.PreviewCommentPRCommandAuthorizationUnavailable())
+	case PreviewCommentDatabaseNotConfigured:
+		fmt.Print(webhooktemplates.PreviewCommentPRCommandDatabaseNotConfigured())
 	case PreviewCommentCutoverAccepted:
 		fmt.Print(webhooktemplates.PreviewCommentCutoverCommandAccepted())
 	case PreviewCommentCutoverActive:

--- a/pkg/webhook/actor_authorization.go
+++ b/pkg/webhook/actor_authorization.go
@@ -76,6 +76,23 @@ func (h *Handler) enforcePRCommandActorAuthorization(
 		return true
 	}
 	if !result.Allowed {
+		// A missing database config is operationally distinct from an actor who
+		// lacks access: the database simply is not managed by this instance. Post
+		// a hint so operators do not assume an access problem and retry blindly.
+		if result.Reason == api.ActorAuthReasonMissingDatabaseConfig {
+			h.logger.Warn("PR command blocked because the database is not configured on this instance",
+				"repo", repo, "pr", pr, "database", database,
+				"database_type", databaseType, "environment", environment,
+				"command", commandName, "requested_by", requestedBy,
+				"reason", result.Reason)
+			h.postComment(repo, pr, installationID, templates.RenderPRCommandDatabaseNotConfigured(templates.ActorAuthorizationCommentData{
+				RequestedBy: requestedBy,
+				CommandName: commandName,
+				Database:    database,
+				Environment: environment,
+			}))
+			return true
+		}
 		h.logger.Warn("PR command blocked by actor authorization",
 			"repo", repo, "pr", pr, "database", database,
 			"database_type", databaseType, "environment", environment,
@@ -96,7 +113,11 @@ func (h *Handler) enforcePRCommandActorAuthorization(
 			"command", commandName, "requested_by", requestedBy)
 		return false
 	}
-	h.logger.Debug("PR command actor authorization allowed",
+	// Rollback, rollback-confirm, and unlock execute DDL or force-release locks,
+	// so the allow decision is audit-relevant. Log it at Info with the same
+	// identifiers used on the denial paths so operators can reconstruct who was
+	// authorized to mutate which database.
+	h.logger.Info("PR command actor authorization allowed",
 		"repo", repo, "pr", pr, "database", database,
 		"database_type", databaseType, "environment", environment,
 		"command", commandName, "requested_by", requestedBy,

--- a/pkg/webhook/actor_authorization.go
+++ b/pkg/webhook/actor_authorization.go
@@ -11,6 +11,40 @@ import (
 	"github.com/block/schemabot/pkg/webhook/templates"
 )
 
+// actorAuthorizationClient resolves the installation-scoped GitHub client used
+// for actor authorization team membership lookups. The client is only needed
+// when PR command authorization is enabled. A client resolution failure fails
+// closed: the command is blocked and an authorization-unavailable comment is
+// posted so the actor knows no schema change action was taken.
+func (h *Handler) actorAuthorizationClient(
+	repo string,
+	pr int,
+	installationID int64,
+	requestedBy string,
+	database string,
+	environment string,
+	commandName string,
+) (*ghclient.InstallationClient, bool) {
+	if !h.service.Config().PRCommandAuthorizationEnabled() || h.ghClients.Len() == 0 {
+		return nil, false
+	}
+	client, err := h.clientForRepo(repo, installationID)
+	if err != nil {
+		h.logger.Warn("PR command blocked because the actor authorization GitHub client could not be created",
+			"repo", repo, "pr", pr, "database", database,
+			"environment", environment, "command", commandName,
+			"requested_by", requestedBy, "error", err)
+		h.postComment(repo, pr, installationID, templates.RenderPRCommandAuthorizationUnavailable(templates.ActorAuthorizationCommentData{
+			RequestedBy: requestedBy,
+			CommandName: commandName,
+			Database:    database,
+			Environment: environment,
+		}))
+		return nil, true
+	}
+	return client, false
+}
+
 func (h *Handler) enforcePRCommandActorAuthorization(
 	ctx context.Context,
 	client *ghclient.InstallationClient,

--- a/pkg/webhook/actor_authorization_test.go
+++ b/pkg/webhook/actor_authorization_test.go
@@ -266,6 +266,28 @@ func TestEnforcePRCommandActorAuthorizationComments(t *testing.T) {
 	assert.Contains(t, body, "`schemabot apply`")
 }
 
+// A mutating PR command targeting a database that is not configured on this
+// instance fails closed, but the comment distinguishes the missing-database
+// case from a plain access denial so operators do not retry assuming an
+// authorization problem.
+func TestEnforcePRCommandActorAuthorizationUnconfiguredDatabaseComment(t *testing.T) {
+	client, mux := setupGitHubServer(t)
+	comments := make(chan string, 2)
+	mux.HandleFunc("POST /repos/octocat/hello-world/issues/1/comments", commentRecorder(t, comments))
+	installClient := ghclient.NewInstallationClient(client, testLogger())
+	cfg := actorAuthTestConfig(true, func(cfg *api.ServerConfig) {
+		cfg.PRCommandAuthorization.AdminUsers = []string{"hubot"}
+	})
+	h := actorAuthTestHandler(cfg, installClient)
+
+	blocked := h.enforcePRCommandActorAuthorization(t.Context(), installClient, "octocat/hello-world", 1, 12345, "mona", "payments", storage.DatabaseTypeMySQL, "", action.Unlock)
+	assert.True(t, blocked)
+
+	body := requireComment(t, comments, "unconfigured-database authorization comment")
+	assert.Contains(t, body, "database `payments` is not configured on this SchemaBot instance")
+	assert.NotContains(t, body, "is not authorized")
+}
+
 func TestEnforcePRCommandActorAuthorizationTeamLookupErrorComment(t *testing.T) {
 	client, mux := setupGitHubServer(t)
 	comments := make(chan string, 2)
@@ -376,13 +398,21 @@ func TestWebhookStopCommandBlocksUnauthorizedActor(t *testing.T) {
 // flow with actor authorization enabled. Rollback executes DDL against the
 // target database, so an actor who is not a configured admin/operator receives
 // a denial comment before SchemaBot generates a rollback plan or acquires a
-// lock.
+// lock. A conflicting lock is seeded so the test also proves the authorization
+// gate runs before the lock-conflict probe: an unauthorized actor must not be
+// able to learn lock ownership by probing apply IDs.
 func TestHandleRollbackCommandBlocksUnauthorizedActor(t *testing.T) {
 	client, mux := setupGitHubServer(t)
 	comments := make(chan string, 2)
 	mux.HandleFunc("POST /repos/octocat/hello-world/issues/1/comments", commentRecorder(t, comments))
 
-	locks := &actorAuthLockStore{}
+	locks := &actorAuthLockStore{locks: []*storage.Lock{{
+		DatabaseName: "orders",
+		DatabaseType: storage.DatabaseTypeMySQL,
+		Owner:        "octocat/other-repo#9",
+		Repository:   "octocat/other-repo",
+		PullRequest:  9,
+	}}}
 	cfg := actorAuthTestConfig(true, func(cfg *api.ServerConfig) {
 		cfg.PRCommandAuthorization.AdminUsers = []string{"hubot"}
 	})
@@ -395,6 +425,8 @@ func TestHandleRollbackCommandBlocksUnauthorizedActor(t *testing.T) {
 	assert.Contains(t, body, "SchemaBot Command Not Authorized")
 	assert.Contains(t, body, "@mona is not authorized")
 	assert.Contains(t, body, "`schemabot rollback`")
+	assert.NotContains(t, body, "Rollback Blocked", "denied rollback must not leak lock-conflict detail")
+	assert.NotContains(t, body, "octocat/other-repo#9", "denied rollback must not reveal the conflicting lock owner")
 	assert.Empty(t, locks.acquired, "denied rollback must not acquire a lock")
 }
 
@@ -540,6 +572,36 @@ func TestHandleUnlockCommandAllowsAuthorizedActor(t *testing.T) {
 	assert.Contains(t, body, "Lock Released")
 	assert.Contains(t, body, "@hubot")
 	assert.Equal(t, []string{"orders"}, locks.forceReleased)
+}
+
+// TestHandleUnlockCommandUnconfiguredDatabaseHint exercises the PR force-unlock
+// flow against a database that is not configured on this SchemaBot instance.
+// The actor authorization gate fails closed and no lock is released, but the
+// operator-facing comment differentiates the missing-database case from a plain
+// access denial so the operator does not assume an authorization problem.
+func TestHandleUnlockCommandUnconfiguredDatabaseHint(t *testing.T) {
+	client, mux := setupGitHubServer(t)
+	comments := make(chan string, 2)
+	mux.HandleFunc("POST /repos/octocat/hello-world/issues/1/comments", commentRecorder(t, comments))
+
+	locks := &actorAuthLockStore{locks: []*storage.Lock{{
+		DatabaseName: "payments",
+		DatabaseType: storage.DatabaseTypeMySQL,
+		Owner:        "cli:dev@workstation",
+	}}}
+	cfg := actorAuthTestConfig(true, func(cfg *api.ServerConfig) {
+		cfg.PRCommandAuthorization.AdminUsers = []string{"hubot"}
+	})
+	installClient := ghclient.NewInstallationClient(client, testLogger())
+	h := actorAuthStorageTestHandler(cfg, &actorAuthStorage{locks: locks}, installClient)
+
+	h.handleUnlockCommand("octocat/hello-world", 1, 12345, "hubot", CommandResult{Action: action.Unlock, Force: true, Database: "payments"})
+
+	body := requireComment(t, comments, "unconfigured-database unlock comment")
+	assert.Contains(t, body, "database `payments` is not configured on this SchemaBot instance")
+	assert.NotContains(t, body, "is not authorized", "unconfigured database must not render a plain access denial")
+	assert.Empty(t, locks.forceReleased, "unconfigured database unlock must not force-release any lock")
+	assert.Empty(t, locks.released, "unconfigured database unlock must not release any lock")
 }
 
 func actorAuthRollbackApply() *storage.Apply {

--- a/pkg/webhook/actor_authorization_test.go
+++ b/pkg/webhook/actor_authorization_test.go
@@ -250,15 +250,7 @@ func TestAuthorizePRCommandActorMissingServiceFailsClosed(t *testing.T) {
 func TestEnforcePRCommandActorAuthorizationComments(t *testing.T) {
 	client, mux := setupGitHubServer(t)
 	comments := make(chan string, 2)
-	mux.HandleFunc("POST /repos/octocat/hello-world/issues/1/comments", func(w http.ResponseWriter, r *http.Request) {
-		var body struct {
-			Body string `json:"body"`
-		}
-		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
-		comments <- body.Body
-		w.WriteHeader(http.StatusCreated)
-		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{"id": 99}))
-	})
+	mux.HandleFunc("POST /repos/octocat/hello-world/issues/1/comments", commentRecorder(t, comments))
 	installClient := ghclient.NewInstallationClient(client, testLogger())
 	cfg := actorAuthTestConfig(true, func(cfg *api.ServerConfig) {
 		cfg.PRCommandAuthorization.AdminUsers = []string{"hubot"}
@@ -268,29 +260,17 @@ func TestEnforcePRCommandActorAuthorizationComments(t *testing.T) {
 	blocked := h.enforcePRCommandActorAuthorization(t.Context(), installClient, "octocat/hello-world", 1, 12345, "mona", "orders", storage.DatabaseTypeMySQL, "staging", action.Apply)
 	assert.True(t, blocked)
 
-	select {
-	case body := <-comments:
-		assert.Contains(t, body, "SchemaBot Command Not Authorized")
-		assert.Contains(t, body, "@mona is not authorized")
-		assert.Contains(t, body, "`schemabot apply`")
-	case <-time.After(2 * time.Second):
-		require.FailNow(t, "timed out waiting for authorization comment")
-	}
+	body := requireComment(t, comments, "authorization comment")
+	assert.Contains(t, body, "SchemaBot Command Not Authorized")
+	assert.Contains(t, body, "@mona is not authorized")
+	assert.Contains(t, body, "`schemabot apply`")
 }
 
 func TestEnforcePRCommandActorAuthorizationTeamLookupErrorComment(t *testing.T) {
 	client, mux := setupGitHubServer(t)
 	comments := make(chan string, 2)
 	mux.HandleFunc("GET /orgs/octocat/teams/schema-admins/members", teamMembersHandler(t, http.StatusForbidden))
-	mux.HandleFunc("POST /repos/octocat/hello-world/issues/1/comments", func(w http.ResponseWriter, r *http.Request) {
-		var body struct {
-			Body string `json:"body"`
-		}
-		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
-		comments <- body.Body
-		w.WriteHeader(http.StatusCreated)
-		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{"id": 99}))
-	})
+	mux.HandleFunc("POST /repos/octocat/hello-world/issues/1/comments", commentRecorder(t, comments))
 	installClient := ghclient.NewInstallationClient(client, testLogger())
 	cfg := actorAuthTestConfig(true, func(cfg *api.ServerConfig) {
 		cfg.PRCommandAuthorization.AdminTeams = []string{"octocat/schema-admins"}
@@ -300,16 +280,12 @@ func TestEnforcePRCommandActorAuthorizationTeamLookupErrorComment(t *testing.T) 
 	blocked := h.enforcePRCommandActorAuthorization(t.Context(), installClient, "octocat/hello-world", 1, 12345, "mona", "orders", storage.DatabaseTypeMySQL, "staging", action.Apply)
 	assert.True(t, blocked)
 
-	select {
-	case body := <-comments:
-		assert.Contains(t, body, "SchemaBot Authorization Check Failed")
-		assert.Contains(t, body, "could not verify authorization")
-		assert.Contains(t, body, "No schema change was started")
-		assert.Contains(t, body, "GitHub App can read organization members")
-		assert.NotContains(t, body, "is not authorized")
-	case <-time.After(2 * time.Second):
-		require.FailNow(t, "timed out waiting for authorization failure comment")
-	}
+	body := requireComment(t, comments, "authorization failure comment")
+	assert.Contains(t, body, "SchemaBot Authorization Check Failed")
+	assert.Contains(t, body, "could not verify authorization")
+	assert.Contains(t, body, "No schema change was started")
+	assert.Contains(t, body, "GitHub App can read organization members")
+	assert.NotContains(t, body, "is not authorized")
 }
 
 // TestHandleApplyCommandBlocksUnauthorizedActorBeforePlanning exercises the
@@ -321,15 +297,7 @@ func TestHandleApplyCommandBlocksUnauthorizedActorBeforePlanning(t *testing.T) {
 	registerApplyDiscoveryEndpoints(t, mux, "orders")
 
 	comments := make(chan string, 2)
-	mux.HandleFunc("POST /repos/octocat/hello-world/issues/1/comments", func(w http.ResponseWriter, r *http.Request) {
-		var body struct {
-			Body string `json:"body"`
-		}
-		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
-		comments <- body.Body
-		w.WriteHeader(http.StatusCreated)
-		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{"id": 99}))
-	})
+	mux.HandleFunc("POST /repos/octocat/hello-world/issues/1/comments", commentRecorder(t, comments))
 
 	installClient := ghclient.NewInstallationClient(client, testLogger())
 	cfg := actorAuthTestConfig(true, func(cfg *api.ServerConfig) {
@@ -339,13 +307,9 @@ func TestHandleApplyCommandBlocksUnauthorizedActorBeforePlanning(t *testing.T) {
 
 	h.handleApplyCommand("octocat/hello-world", 1, "staging", "", 12345, "mona", CommandResult{Action: action.Apply})
 
-	select {
-	case body := <-comments:
-		assert.Contains(t, body, "SchemaBot Command Not Authorized")
-		assert.Contains(t, body, "@mona is not authorized")
-	case <-time.After(2 * time.Second):
-		require.FailNow(t, "timed out waiting for unauthorized apply comment")
-	}
+	body := requireComment(t, comments, "unauthorized apply comment")
+	assert.Contains(t, body, "SchemaBot Command Not Authorized")
+	assert.Contains(t, body, "@mona is not authorized")
 }
 
 // Stop is a mutating PR comment command, so the full webhook path uses the same
@@ -354,15 +318,7 @@ func TestWebhookStopCommandBlocksUnauthorizedActor(t *testing.T) {
 	client, mux := setupGitHubServer(t)
 	comments := make(chan string, 2)
 	reactions := make(chan string, 2)
-	mux.HandleFunc("POST /repos/octocat/hello-world/issues/1/comments", func(w http.ResponseWriter, r *http.Request) {
-		var body struct {
-			Body string `json:"body"`
-		}
-		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
-		comments <- body.Body
-		w.WriteHeader(http.StatusCreated)
-		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{"id": 99}))
-	})
+	mux.HandleFunc("POST /repos/octocat/hello-world/issues/1/comments", commentRecorder(t, comments))
 	mux.HandleFunc("POST /repos/octocat/hello-world/issues/comments/42/reactions", func(w http.ResponseWriter, r *http.Request) {
 		var body struct {
 			Content string `json:"content"`
@@ -386,7 +342,7 @@ func TestWebhookStopCommandBlocksUnauthorizedActor(t *testing.T) {
 	cfg := actorAuthTestConfig(true, func(cfg *api.ServerConfig) {
 		cfg.PRCommandAuthorization.AdminUsers = []string{"hubot"}
 	})
-	service := api.New(&stopActorAuthStorage{apply: apply}, cfg, nil, testLogger())
+	service := api.New(&actorAuthStorage{apply: apply, locks: &actorAuthLockStore{}}, cfg, nil, testLogger())
 	h := &Handler{
 		service:   service,
 		ghClients: ghclient.NewSingleClientSet(defaultAppName, &fakeClientFactory{client: ghclient.NewInstallationClient(client, testLogger())}),
@@ -410,35 +366,274 @@ func TestWebhookStopCommandBlocksUnauthorizedActor(t *testing.T) {
 		require.FailNow(t, "timed out waiting for stop acknowledgement reaction")
 	}
 
-	select {
-	case body := <-comments:
-		assert.Contains(t, body, "SchemaBot Command Not Authorized")
-		assert.Contains(t, body, "@mona is not authorized")
-		assert.Contains(t, body, "`schemabot stop`")
-	case <-time.After(2 * time.Second):
-		require.FailNow(t, "timed out waiting for unauthorized stop comment")
+	body := requireComment(t, comments, "unauthorized stop comment")
+	assert.Contains(t, body, "SchemaBot Command Not Authorized")
+	assert.Contains(t, body, "@mona is not authorized")
+	assert.Contains(t, body, "`schemabot stop`")
+}
+
+// TestHandleRollbackCommandBlocksUnauthorizedActor exercises the PR rollback
+// flow with actor authorization enabled. Rollback executes DDL against the
+// target database, so an actor who is not a configured admin/operator receives
+// a denial comment before SchemaBot generates a rollback plan or acquires a
+// lock.
+func TestHandleRollbackCommandBlocksUnauthorizedActor(t *testing.T) {
+	client, mux := setupGitHubServer(t)
+	comments := make(chan string, 2)
+	mux.HandleFunc("POST /repos/octocat/hello-world/issues/1/comments", commentRecorder(t, comments))
+
+	locks := &actorAuthLockStore{}
+	cfg := actorAuthTestConfig(true, func(cfg *api.ServerConfig) {
+		cfg.PRCommandAuthorization.AdminUsers = []string{"hubot"}
+	})
+	installClient := ghclient.NewInstallationClient(client, testLogger())
+	h := actorAuthStorageTestHandler(cfg, &actorAuthStorage{apply: actorAuthRollbackApply(), locks: locks}, installClient)
+
+	h.handleRollbackCommand("octocat/hello-world", 1, 12345, "mona", CommandResult{Action: action.Rollback, ApplyID: "apply_abcd1234"})
+
+	body := requireComment(t, comments, "unauthorized rollback comment")
+	assert.Contains(t, body, "SchemaBot Command Not Authorized")
+	assert.Contains(t, body, "@mona is not authorized")
+	assert.Contains(t, body, "`schemabot rollback`")
+	assert.Empty(t, locks.acquired, "denied rollback must not acquire a lock")
+}
+
+// TestHandleRollbackCommandAllowsAuthorizedActor verifies that a configured
+// admin proceeds past the actor authorization gate for rollback: the command
+// reaches the lock check and reports the conflicting lock owner.
+func TestHandleRollbackCommandAllowsAuthorizedActor(t *testing.T) {
+	client, mux := setupGitHubServer(t)
+	comments := make(chan string, 2)
+	mux.HandleFunc("POST /repos/octocat/hello-world/issues/1/comments", commentRecorder(t, comments))
+
+	locks := &actorAuthLockStore{locks: []*storage.Lock{{
+		DatabaseName: "orders",
+		DatabaseType: storage.DatabaseTypeMySQL,
+		Owner:        "octocat/other-repo#9",
+		Repository:   "octocat/other-repo",
+		PullRequest:  9,
+	}}}
+	cfg := actorAuthTestConfig(true, func(cfg *api.ServerConfig) {
+		cfg.PRCommandAuthorization.AdminUsers = []string{"hubot"}
+	})
+	installClient := ghclient.NewInstallationClient(client, testLogger())
+	h := actorAuthStorageTestHandler(cfg, &actorAuthStorage{apply: actorAuthRollbackApply(), locks: locks}, installClient)
+
+	h.handleRollbackCommand("octocat/hello-world", 1, 12345, "hubot", CommandResult{Action: action.Rollback, ApplyID: "apply_abcd1234"})
+
+	body := requireComment(t, comments, "rollback blocked-by-lock comment")
+	assert.Contains(t, body, "Rollback Blocked")
+	assert.Contains(t, body, "octocat/other-repo#9")
+	assert.NotContains(t, body, "is not authorized")
+}
+
+// TestHandleRollbackConfirmCommandBlocksUnauthorizedActor exercises the PR
+// rollback-confirm flow with actor authorization enabled. Rollback-confirm
+// executes DDL with unsafe changes allowed, so an actor who is not a
+// configured admin/operator receives a denial comment before SchemaBot reads
+// lock state or executes the rollback.
+func TestHandleRollbackConfirmCommandBlocksUnauthorizedActor(t *testing.T) {
+	client, mux := setupGitHubServer(t)
+	registerApplyDiscoveryEndpoints(t, mux, "orders")
+	comments := make(chan string, 2)
+	mux.HandleFunc("POST /repos/octocat/hello-world/issues/1/comments", commentRecorder(t, comments))
+
+	locks := &actorAuthLockStore{locks: []*storage.Lock{{
+		DatabaseName: "orders",
+		DatabaseType: storage.DatabaseTypeMySQL,
+		Owner:        "octocat/hello-world#1",
+		Repository:   "octocat/hello-world",
+		PullRequest:  1,
+	}}}
+	cfg := actorAuthTestConfig(true, func(cfg *api.ServerConfig) {
+		cfg.PRCommandAuthorization.AdminUsers = []string{"hubot"}
+	})
+	installClient := ghclient.NewInstallationClient(client, testLogger())
+	h := actorAuthStorageTestHandler(cfg, &actorAuthStorage{locks: locks}, installClient)
+
+	h.handleRollbackConfirmCommand("octocat/hello-world", 1, "staging", "", 12345, "mona", CommandResult{Action: action.RollbackConfirm})
+
+	body := requireComment(t, comments, "unauthorized rollback-confirm comment")
+	assert.Contains(t, body, "SchemaBot Command Not Authorized")
+	assert.Contains(t, body, "@mona is not authorized")
+	assert.Contains(t, body, "`schemabot rollback-confirm`")
+	assert.Empty(t, locks.released, "denied rollback-confirm must not release the lock")
+}
+
+// TestHandleRollbackConfirmCommandAllowsAuthorizedActor verifies that a
+// configured admin proceeds past the actor authorization gate for
+// rollback-confirm: the command reaches the lock-ownership check and reports
+// that no rollback lock is held.
+func TestHandleRollbackConfirmCommandAllowsAuthorizedActor(t *testing.T) {
+	client, mux := setupGitHubServer(t)
+	registerApplyDiscoveryEndpoints(t, mux, "orders")
+	comments := make(chan string, 2)
+	mux.HandleFunc("POST /repos/octocat/hello-world/issues/1/comments", commentRecorder(t, comments))
+
+	cfg := actorAuthTestConfig(true, func(cfg *api.ServerConfig) {
+		cfg.PRCommandAuthorization.AdminUsers = []string{"hubot"}
+	})
+	installClient := ghclient.NewInstallationClient(client, testLogger())
+	h := actorAuthStorageTestHandler(cfg, &actorAuthStorage{locks: &actorAuthLockStore{}}, installClient)
+
+	h.handleRollbackConfirmCommand("octocat/hello-world", 1, "staging", "", 12345, "hubot", CommandResult{Action: action.RollbackConfirm})
+
+	body := requireComment(t, comments, "rollback-confirm no-lock comment")
+	assert.Contains(t, body, "No Lock Found")
+	assert.Contains(t, body, "`orders`")
+	assert.NotContains(t, body, "is not authorized")
+}
+
+// TestHandleUnlockCommandBlocksUnauthorizedActor exercises the PR force-unlock
+// flow with actor authorization enabled. Unlock releases lock state — with
+// --force it can clear locks owned by CLI sessions — so an actor who is not a
+// configured admin/operator receives a denial comment and every lock stays
+// held.
+func TestHandleUnlockCommandBlocksUnauthorizedActor(t *testing.T) {
+	client, mux := setupGitHubServer(t)
+	comments := make(chan string, 2)
+	mux.HandleFunc("POST /repos/octocat/hello-world/issues/1/comments", commentRecorder(t, comments))
+
+	locks := &actorAuthLockStore{locks: []*storage.Lock{{
+		DatabaseName: "orders",
+		DatabaseType: storage.DatabaseTypeMySQL,
+		Owner:        "cli:dev@workstation",
+	}}}
+	cfg := actorAuthTestConfig(true, func(cfg *api.ServerConfig) {
+		cfg.PRCommandAuthorization.AdminUsers = []string{"hubot"}
+	})
+	installClient := ghclient.NewInstallationClient(client, testLogger())
+	h := actorAuthStorageTestHandler(cfg, &actorAuthStorage{locks: locks}, installClient)
+
+	h.handleUnlockCommand("octocat/hello-world", 1, 12345, "mona", CommandResult{Action: action.Unlock, Force: true, Database: "orders"})
+
+	body := requireComment(t, comments, "unauthorized unlock comment")
+	assert.Contains(t, body, "SchemaBot Command Not Authorized")
+	assert.Contains(t, body, "@mona is not authorized")
+	assert.Contains(t, body, "`schemabot unlock`")
+	assert.Empty(t, locks.forceReleased, "denied unlock must not force-release any lock")
+	assert.Empty(t, locks.released, "denied unlock must not release any lock")
+}
+
+// TestHandleUnlockCommandAllowsAuthorizedActor verifies that a configured
+// admin proceeds past the actor authorization gate for force unlock: the
+// CLI-owned lock is force-released and a release comment is posted.
+func TestHandleUnlockCommandAllowsAuthorizedActor(t *testing.T) {
+	client, mux := setupGitHubServer(t)
+	comments := make(chan string, 2)
+	mux.HandleFunc("POST /repos/octocat/hello-world/issues/1/comments", commentRecorder(t, comments))
+
+	locks := &actorAuthLockStore{locks: []*storage.Lock{{
+		DatabaseName: "orders",
+		DatabaseType: storage.DatabaseTypeMySQL,
+		Owner:        "cli:dev@workstation",
+	}}}
+	cfg := actorAuthTestConfig(true, func(cfg *api.ServerConfig) {
+		cfg.PRCommandAuthorization.AdminUsers = []string{"hubot"}
+	})
+	installClient := ghclient.NewInstallationClient(client, testLogger())
+	h := actorAuthStorageTestHandler(cfg, &actorAuthStorage{locks: locks}, installClient)
+
+	h.handleUnlockCommand("octocat/hello-world", 1, 12345, "hubot", CommandResult{Action: action.Unlock, Force: true, Database: "orders"})
+
+	body := requireComment(t, comments, "unlock success comment")
+	assert.Contains(t, body, "Lock Released")
+	assert.Contains(t, body, "@hubot")
+	assert.Equal(t, []string{"orders"}, locks.forceReleased)
+}
+
+func actorAuthRollbackApply() *storage.Apply {
+	return &storage.Apply{
+		ID:              42,
+		ApplyIdentifier: "apply_abcd1234",
+		Database:        "orders",
+		DatabaseType:    storage.DatabaseTypeMySQL,
+		Repository:      "octocat/hello-world",
+		PullRequest:     1,
+		Environment:     "staging",
+		Deployment:      "orders",
 	}
 }
 
-type stopActorAuthStorage struct {
+// actorAuthStorage backs actor authorization handler tests with a stored apply
+// and a lock store that records mutations, so tests can assert that denied
+// commands have no lock side effects.
+type actorAuthStorage struct {
 	emptyStorage
 	apply *storage.Apply
+	locks *actorAuthLockStore
 }
 
-func (s *stopActorAuthStorage) Applies() storage.ApplyStore {
-	return &stopActorAuthApplyStore{apply: s.apply}
+func (s *actorAuthStorage) Applies() storage.ApplyStore {
+	return &actorAuthApplyStore{apply: s.apply}
 }
 
-type stopActorAuthApplyStore struct {
+func (s *actorAuthStorage) Locks() storage.LockStore {
+	return s.locks
+}
+
+type actorAuthApplyStore struct {
 	storage.ApplyStore
 	apply *storage.Apply
 }
 
-func (s *stopActorAuthApplyStore) GetByApplyIdentifier(_ context.Context, applyIdentifier string) (*storage.Apply, error) {
+func (s *actorAuthApplyStore) GetByApplyIdentifier(_ context.Context, applyIdentifier string) (*storage.Apply, error) {
 	if s.apply == nil || s.apply.ApplyIdentifier != applyIdentifier {
 		return nil, nil
 	}
 	return s.apply, nil
+}
+
+func (s *actorAuthApplyStore) GetByDatabase(_ context.Context, _, _, _ string) ([]*storage.Apply, error) {
+	return nil, nil
+}
+
+// actorAuthLockStore serves locks from a fixed set and records every lock
+// mutation so tests can assert which releases and acquisitions happened.
+type actorAuthLockStore struct {
+	storage.LockStore
+	locks         []*storage.Lock
+	acquired      []*storage.Lock
+	released      []string
+	forceReleased []string
+}
+
+func (s *actorAuthLockStore) Get(_ context.Context, database, dbType string) (*storage.Lock, error) {
+	for _, lock := range s.locks {
+		if lock.DatabaseName == database && lock.DatabaseType == dbType {
+			return lock, nil
+		}
+	}
+	return nil, nil
+}
+
+func (s *actorAuthLockStore) GetByPR(_ context.Context, repo string, pr int) ([]*storage.Lock, error) {
+	var matches []*storage.Lock
+	for _, lock := range s.locks {
+		if lock.Repository == repo && lock.PullRequest == pr {
+			matches = append(matches, lock)
+		}
+	}
+	return matches, nil
+}
+
+func (s *actorAuthLockStore) List(_ context.Context) ([]*storage.Lock, error) {
+	return s.locks, nil
+}
+
+func (s *actorAuthLockStore) Acquire(_ context.Context, lock *storage.Lock) error {
+	s.acquired = append(s.acquired, lock)
+	return nil
+}
+
+func (s *actorAuthLockStore) Release(_ context.Context, database, _, _ string) error {
+	s.released = append(s.released, database)
+	return nil
+}
+
+func (s *actorAuthLockStore) ForceRelease(_ context.Context, database, _ string) error {
+	s.forceReleased = append(s.forceReleased, database)
+	return nil
 }
 
 func actorAuthTestConfig(enabled bool, opts ...func(*api.ServerConfig)) *api.ServerConfig {
@@ -460,11 +655,43 @@ func actorAuthTestConfig(enabled bool, opts ...func(*api.ServerConfig)) *api.Ser
 }
 
 func actorAuthTestHandler(cfg *api.ServerConfig, installClient *ghclient.InstallationClient) *Handler {
-	service := api.New(nil, cfg, nil, testLogger())
+	return actorAuthStorageTestHandler(cfg, nil, installClient)
+}
+
+func actorAuthStorageTestHandler(cfg *api.ServerConfig, store storage.Storage, installClient *ghclient.InstallationClient) *Handler {
+	service := api.New(store, cfg, nil, testLogger())
 	return &Handler{
 		service:   service,
 		ghClients: ghclient.NewSingleClientSet(defaultAppName, &fakeClientFactory{client: installClient}),
 		logger:    testLogger(),
+	}
+}
+
+// commentRecorder returns a mux handler that captures posted PR comment bodies
+// on the given channel and responds like the GitHub create-comment API.
+func commentRecorder(t *testing.T, comments chan<- string) http.HandlerFunc {
+	t.Helper()
+	return func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Body string `json:"body"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		comments <- body.Body
+		w.WriteHeader(http.StatusCreated)
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{"id": 99}))
+	}
+}
+
+// requireComment waits for the next captured PR comment and fails the test if
+// none arrives before the deadline.
+func requireComment(t *testing.T, comments <-chan string, failureContext string) string {
+	t.Helper()
+	select {
+	case body := <-comments:
+		return body
+	case <-time.After(2 * time.Second):
+		require.FailNow(t, "timed out waiting for comment", failureContext)
+		return ""
 	}
 }
 

--- a/pkg/webhook/apply_handlers.go
+++ b/pkg/webhook/apply_handlers.go
@@ -497,6 +497,21 @@ func (h *Handler) handleUnlockCommand(repo string, pr int, installationID int64,
 		return
 	}
 
+	// Unlock mutates lock state for every matched database, including
+	// force-releasing CLI-owned locks, so the actor must be an authorized
+	// admin/operator for each affected database before any lock is released.
+	// Locks are not environment-scoped, so authorization is enforced per
+	// database without an environment.
+	client, blocked := h.actorAuthorizationClient(repo, pr, installationID, requestedBy, locks[0].DatabaseName, "", action.Unlock)
+	if blocked {
+		return
+	}
+	for _, lock := range locks {
+		if blocked := h.enforcePRCommandActorAuthorization(ctx, client, repo, pr, installationID, requestedBy, lock.DatabaseName, lock.DatabaseType, "", action.Unlock); blocked {
+			return
+		}
+	}
+
 	// Check for active applies on any locked database. Even force-unlock should
 	// not break a lock while SchemaBot still has a non-terminal apply recorded
 	// for the same database/type. When apply state cannot be read, the unlock

--- a/pkg/webhook/control.go
+++ b/pkg/webhook/control.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/block/schemabot/pkg/apitypes"
-	ghclient "github.com/block/schemabot/pkg/github"
 	"github.com/block/schemabot/pkg/webhook/action"
 	"github.com/block/schemabot/pkg/webhook/templates"
 )
@@ -97,28 +96,9 @@ func (h *Handler) handleStopCommand(repo string, pr int, installationID int64, r
 			fmt.Sprintf("Apply %s belongs to environment %q, not %q", result.ApplyID, apply.Environment, result.Environment))
 		return
 	}
-	var client *ghclient.InstallationClient
-	if h.service.Config().PRCommandAuthorizationEnabled() && h.ghClients.Len() > 0 {
-		var clientErr error
-		client, clientErr = h.clientForRepo(repo, installationID)
-		if clientErr != nil {
-			h.logger.Warn("stop PR command blocked because actor authorization client could not be created",
-				"repo", repo,
-				"pr", pr,
-				"apply_id", result.ApplyID,
-				"database", apply.Database,
-				"database_type", apply.DatabaseType,
-				"environment", result.Environment,
-				"requested_by", requestedBy,
-				"error", clientErr)
-			h.postComment(repo, pr, installationID, templates.RenderPRCommandAuthorizationUnavailable(templates.ActorAuthorizationCommentData{
-				RequestedBy: requestedBy,
-				CommandName: action.Stop,
-				Database:    apply.Database,
-				Environment: result.Environment,
-			}))
-			return
-		}
+	client, blocked := h.actorAuthorizationClient(repo, pr, installationID, requestedBy, apply.Database, result.Environment, action.Stop)
+	if blocked {
+		return
 	}
 	if blocked := h.enforcePRCommandActorAuthorization(ctx, client, repo, pr, installationID, requestedBy, apply.Database, apply.DatabaseType, result.Environment, action.Stop); blocked {
 		return
@@ -274,28 +254,9 @@ func (h *Handler) handleCutoverCommand(repo string, pr int, installationID int64
 			fmt.Sprintf("Apply %s belongs to environment %q, not %q", result.ApplyID, apply.Environment, result.Environment))
 		return
 	}
-	var client *ghclient.InstallationClient
-	if h.service.Config().PRCommandAuthorizationEnabled() && h.ghClients.Len() > 0 {
-		var clientErr error
-		client, clientErr = h.clientForRepo(repo, installationID)
-		if clientErr != nil {
-			h.logger.Warn("cutover PR command blocked because actor authorization client could not be created",
-				"repo", repo,
-				"pr", pr,
-				"apply_id", result.ApplyID,
-				"database", apply.Database,
-				"database_type", apply.DatabaseType,
-				"environment", result.Environment,
-				"requested_by", requestedBy,
-				"error", clientErr)
-			h.postComment(repo, pr, installationID, templates.RenderPRCommandAuthorizationUnavailable(templates.ActorAuthorizationCommentData{
-				RequestedBy: requestedBy,
-				CommandName: action.Cutover,
-				Database:    apply.Database,
-				Environment: result.Environment,
-			}))
-			return
-		}
+	client, blocked := h.actorAuthorizationClient(repo, pr, installationID, requestedBy, apply.Database, result.Environment, action.Cutover)
+	if blocked {
+		return
 	}
 	if blocked := h.enforcePRCommandActorAuthorization(ctx, client, repo, pr, installationID, requestedBy, apply.Database, apply.DatabaseType, result.Environment, action.Cutover); blocked {
 		return

--- a/pkg/webhook/rollback.go
+++ b/pkg/webhook/rollback.go
@@ -55,6 +55,17 @@ func (h *Handler) handleRollbackCommand(repo string, pr int, installationID int6
 		return
 	}
 
+	// Rollback executes DDL against the target database, so the actor must be
+	// an authorized admin/operator before any lock is acquired or a rollback
+	// plan is generated.
+	client, blocked := h.actorAuthorizationClient(repo, pr, installationID, requestedBy, database, environment, action.Rollback)
+	if blocked {
+		return
+	}
+	if blocked := h.enforcePRCommandActorAuthorization(ctx, client, repo, pr, installationID, requestedBy, database, dbType, environment, action.Rollback); blocked {
+		return
+	}
+
 	// Check for existing lock
 	existingLock, err := h.service.Storage().Locks().Get(ctx, database, dbType)
 	if err != nil {
@@ -162,6 +173,13 @@ func (h *Handler) handleRollbackConfirmCommand(repo string, pr int, environment,
 	database := schemaResult.Database
 	dbType := schemaResult.Type
 	lockOwner := fmt.Sprintf("%s#%d", repo, pr)
+
+	// Rollback-confirm executes DDL with unsafe changes allowed, so the actor
+	// must be an authorized admin/operator before any lock state is read,
+	// released, or acted on.
+	if blocked := h.enforcePRCommandActorAuthorization(ctx, client, repo, pr, installationID, requestedBy, database, dbType, environment, action.RollbackConfirm); blocked {
+		return
+	}
 
 	// Check lock ownership
 	existingLock, err := h.service.Storage().Locks().Get(ctx, database, dbType)

--- a/pkg/webhook/rollback.go
+++ b/pkg/webhook/rollback.go
@@ -55,9 +55,13 @@ func (h *Handler) handleRollbackCommand(repo string, pr int, installationID int6
 		return
 	}
 
-	// Rollback executes DDL against the target database, so the actor must be
-	// an authorized admin/operator before any lock is acquired or a rollback
-	// plan is generated.
+	// Rollback executes DDL against the target database, so the actor must be an
+	// authorized admin/operator before SchemaBot reveals any lock or plan detail
+	// for the database. The gate runs as soon as the database is known and only
+	// after the environment-routing check above, so a non-owning instance stays
+	// silent instead of posting a denial for an environment it does not manage.
+	// An unauthorized actor must not learn lock ownership or rollback plan
+	// contents by probing apply IDs.
 	client, blocked := h.actorAuthorizationClient(repo, pr, installationID, requestedBy, database, environment, action.Rollback)
 	if blocked {
 		return

--- a/pkg/webhook/templates/apply_commands.go
+++ b/pkg/webhook/templates/apply_commands.go
@@ -53,6 +53,22 @@ func RenderPRCommandNotAuthorized(data ActorAuthorizationCommentData) string {
 	return sb.String()
 }
 
+// RenderPRCommandDatabaseNotConfigured renders a comment when a mutating PR
+// command targets a database that is not configured on this SchemaBot instance.
+// It is distinct from a plain authorization denial so operators do not waste a
+// round-trip assuming the actor lacks access when the database is simply absent.
+func RenderPRCommandDatabaseNotConfigured(data ActorAuthorizationCommentData) string {
+	var sb strings.Builder
+
+	sb.WriteString("## SchemaBot Command Not Authorized\n\n")
+	writeDBEnvLine(&sb, data.Database, data.Environment)
+	sb.WriteString("\n")
+	fmt.Fprintf(&sb, "`schemabot %s` cannot run because database `%s` is not configured on this SchemaBot instance.\n\n", data.CommandName, data.Database)
+	sb.WriteString("Verify the database name, or run the command against the SchemaBot instance that manages this database.\n")
+
+	return sb.String()
+}
+
 // RenderPRCommandAuthorizationUnavailable renders a comment when SchemaBot
 // cannot verify actor authorization for a mutating PR command.
 func RenderPRCommandAuthorizationUnavailable(data ActorAuthorizationCommentData) string {

--- a/pkg/webhook/templates/apply_commands.go
+++ b/pkg/webhook/templates/apply_commands.go
@@ -36,7 +36,7 @@ type ActorAuthorizationCommentData struct {
 }
 
 // RenderPRCommandNotAuthorized renders a comment when a GitHub PR command
-// actor is not allowed to run SchemaBot apply/apply-confirm for the database.
+// actor is not allowed to run a mutating SchemaBot command for the database.
 func RenderPRCommandNotAuthorized(data ActorAuthorizationCommentData) string {
 	var sb strings.Builder
 
@@ -54,7 +54,7 @@ func RenderPRCommandNotAuthorized(data ActorAuthorizationCommentData) string {
 }
 
 // RenderPRCommandAuthorizationUnavailable renders a comment when SchemaBot
-// cannot verify actor authorization for apply/apply-confirm.
+// cannot verify actor authorization for a mutating PR command.
 func RenderPRCommandAuthorizationUnavailable(data ActorAuthorizationCommentData) string {
 	var sb strings.Builder
 

--- a/pkg/webhook/templates/preview.go
+++ b/pkg/webhook/templates/preview.go
@@ -243,6 +243,16 @@ func PreviewCommentPRCommandAuthorizationUnavailable() string {
 	})
 }
 
+// PreviewCommentPRCommandDatabaseNotConfigured renders a sample comment for a
+// mutating PR command that targets a database not configured on this instance.
+func PreviewCommentPRCommandDatabaseNotConfigured() string {
+	return RenderPRCommandDatabaseNotConfigured(ActorAuthorizationCommentData{
+		RequestedBy: "mona",
+		CommandName: action.Unlock,
+		Database:    "payments",
+	})
+}
+
 // PreviewCommentApplyBlockedByPriorEnv renders a sample "production blocked by staging" comment.
 func PreviewCommentApplyBlockedByPriorEnv() string {
 	return RenderApplyBlockedByPriorEnv("testapp", "production", "staging", "has pending changes", "Apply staging first")


### PR DESCRIPTION
When PR command actor authorization is enabled, the `rollback`, `rollback-confirm`, and `unlock` PR comment commands skipped the allowlist check that gates `apply`, `apply-confirm`, `stop`, and `cutover`. Any GitHub user who could comment on a PR could execute rollback DDL (which forces `allow_unsafe`) or force-release schema change locks, including CLI-owned locks.

- `rollback` and `rollback-confirm` now enforce the fail-closed actor authorization gate before any lock is acquired or released and before any plan or apply executes.
- `unlock` enforces the gate for every matched lock's database before releasing anything; locks are not environment-scoped, so authorization is enforced per database.
- The conditional GitHub-client resolution used by the gate is extracted into a shared helper (`actorAuthorizationClient`) and reused by `stop` and `cutover`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)