### PR TITLE
fix(operator): resume recovered applies with persisted engine state

### DIFF
--- a/pkg/tern/local_apply.go
+++ b/pkg/tern/local_apply.go
@@ -203,7 +203,7 @@ func (c *LocalClient) transitionTaskState(ctx context.Context, task *storage.Tas
 func (c *LocalClient) markTasksRunning(ctx context.Context, tasks []*storage.Task) {
 	now := time.Now()
 	for _, task := range tasks {
-		if task.DDLAction == "vschema_update" {
+		if isVSchemaTask(task) {
 			continue
 		}
 		task.State = state.Task.Running

--- a/pkg/tern/local_apply_grouped.go
+++ b/pkg/tern/local_apply_grouped.go
@@ -816,7 +816,7 @@ func (c *LocalClient) syncAtomicTaskProgress(ctx context.Context, tasks []*stora
 		// VSchema tasks follow deploy-request-level state, not per-migration state.
 		// They have no SHOW VITESS_MIGRATIONS rows. Their state transitions are:
 		// pending → running (during in_progress_vschema) → completed/failed.
-		if task.DDLAction == "vschema_update" {
+		if isVSchemaTask(task) {
 			vsState := c.deriveVSchemaTaskState(task, result, newState, now)
 			if vsState != task.State {
 				msg := fmt.Sprintf("VSchema %s → %s", task.State, vsState)

--- a/pkg/tern/local_apply_grouped.go
+++ b/pkg/tern/local_apply_grouped.go
@@ -261,6 +261,10 @@ func (c *LocalClient) loadEngineResumeState(ctx context.Context, task *storage.T
 	if err != nil {
 		return nil, err
 	}
+	return c.loadEngineResumeStateForOperation(ctx, operationID)
+}
+
+func (c *LocalClient) loadEngineResumeStateForOperation(ctx context.Context, operationID int64) (*engine.ResumeState, error) {
 	store := c.storage.ApplyOperations()
 	if store == nil {
 		return nil, fmt.Errorf("apply operation store is not configured")

--- a/pkg/tern/local_client_integration_test.go
+++ b/pkg/tern/local_client_integration_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/block/spirit/pkg/statement"
 	"github.com/block/spirit/pkg/table"
 	"github.com/block/spirit/pkg/utils"
 	_ "github.com/go-sql-driver/mysql"
@@ -325,7 +326,15 @@ type stagedGroupedResumeEngine struct {
 	applyCount  int
 	drainCount  int
 	applyErr    error
+	applyResult *engine.ApplyResult
 	progress    *engine.ProgressResult
+
+	// applyRequests records a snapshot of each ApplyRequest so tests can
+	// assert on the resume state and changes the resume path sends.
+	applyRequests []*engine.ApplyRequest
+	// progressResumeMetadata records the resume state metadata each Progress
+	// poll carries, in call order.
+	progressResumeMetadata []string
 }
 
 func (e *stagedGroupedResumeEngine) Name() string { return "staged-grouped-resume" }
@@ -342,15 +351,27 @@ func (e *stagedGroupedResumeEngine) Plan(context.Context, *engine.PlanRequest) (
 	return e.planResults[idx], nil
 }
 
-func (e *stagedGroupedResumeEngine) Apply(context.Context, *engine.ApplyRequest) (*engine.ApplyResult, error) {
+func (e *stagedGroupedResumeEngine) Apply(_ context.Context, req *engine.ApplyRequest) (*engine.ApplyResult, error) {
 	e.applyCount++
+	snapshot := *req
+	if req.ResumeState != nil {
+		resumeState := *req.ResumeState
+		snapshot.ResumeState = &resumeState
+	}
+	e.applyRequests = append(e.applyRequests, &snapshot)
 	if e.applyErr != nil {
 		return nil, e.applyErr
+	}
+	if e.applyResult != nil {
+		return e.applyResult, nil
 	}
 	return &engine.ApplyResult{Accepted: true}, nil
 }
 
-func (e *stagedGroupedResumeEngine) Progress(context.Context, *engine.ProgressRequest) (*engine.ProgressResult, error) {
+func (e *stagedGroupedResumeEngine) Progress(_ context.Context, req *engine.ProgressRequest) (*engine.ProgressResult, error) {
+	if req.ResumeState != nil {
+		e.progressResumeMetadata = append(e.progressResumeMetadata, req.ResumeState.Metadata)
+	}
 	if e.progress != nil {
 		return e.progress, nil
 	}
@@ -2008,6 +2029,314 @@ func TestLocalClient_ResumeApplyGroupedStartRequestFailsWhenEngineRejects(t *tes
 	logs, err := stor.ApplyLogs().GetByApply(ctx, applyID)
 	require.NoError(t, err)
 	assert.True(t, hasLogMessageContaining(logs, "Recovery failed: engine apply failed: engine refused grouped resume"))
+}
+
+// This scenario covers restart recovery of a grouped Vitess apply whose opaque
+// engine resume state was persisted before the worker died. Recovery must hand
+// that state back to the engine in exactly one grouped apply — even without
+// defer-cutover — so the engine reattaches to the in-flight deploy request
+// instead of opening a duplicate one. The rebuilt changes must keep the tasks'
+// namespace/table identity for per-table progress matching, and progress
+// polling must carry the engine's returned resume state so the deploy request
+// stays observable and updated state is persisted.
+func TestLocalClient_ResumeApplyVitessGroupedReattachesWithPersistedState(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	_, dsn := setupMySQLContainer(t)
+	setupStorageSchema(t, dsn)
+	cleanupTasks(t, dsn)
+	cleanupTestTables(t, dsn)
+
+	ctx := t.Context()
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	stor := createStorage(t, dsn)
+	defer utils.CloseAndLog(stor)
+
+	client, err := NewLocalClient(LocalConfig{
+		Database:  "testdb",
+		Type:      storage.DatabaseTypeVitess,
+		TargetDSN: dsn,
+	}, stor, logger)
+	require.NoError(t, err)
+	defer utils.CloseAndLog(client)
+
+	usersDDL := "ALTER TABLE `users` ADD COLUMN `email` varchar(255)"
+	ordersDDL := "ALTER TABLE `orders` ADD COLUMN `note` varchar(255)"
+	plan := &storage.Plan{
+		PlanIdentifier: fmt.Sprintf("plan-vitess-resume-%d", time.Now().UnixNano()),
+		Database:       "testdb",
+		DatabaseType:   storage.DatabaseTypeVitess,
+		Deployment:     "testdb",
+		Environment:    localClientTestEnvironment,
+		CreatedAt:      time.Now(),
+		Namespaces: map[string]*storage.NamespacePlanData{
+			"commerce": {Tables: []storage.TableChange{{Namespace: "commerce", Table: "users", DDL: usersDDL, Operation: "alter"}}},
+			"billing":  {Tables: []storage.TableChange{{Namespace: "billing", Table: "orders", DDL: ordersDDL, Operation: "alter"}}},
+		},
+	}
+	planID, err := stor.Plans().Create(ctx, plan)
+	require.NoError(t, err)
+
+	now := time.Now()
+	apply := &storage.Apply{
+		ApplyIdentifier: fmt.Sprintf("apply-vitess-resume-%d", now.UnixNano()),
+		PlanID:          planID,
+		Database:        "testdb",
+		DatabaseType:    storage.DatabaseTypeVitess,
+		Deployment:      "testdb",
+		Engine:          storage.EnginePlanetScale,
+		State:           state.Apply.Running,
+		Environment:     localClientTestEnvironment,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+	tasks := []*storage.Task{
+		{
+			TaskIdentifier: fmt.Sprintf("task-vitess-resume-users-%d", now.UnixNano()),
+			PlanID:         planID,
+			Database:       "testdb",
+			DatabaseType:   storage.DatabaseTypeVitess,
+			Engine:         storage.EnginePlanetScale,
+			State:          state.Task.Running,
+			Namespace:      "commerce",
+			TableName:      "users",
+			DDL:            usersDDL,
+			DDLAction:      "alter",
+			Environment:    localClientTestEnvironment,
+			CreatedAt:      now,
+			UpdatedAt:      now,
+		},
+		{
+			TaskIdentifier: fmt.Sprintf("task-vitess-resume-orders-%d", now.UnixNano()),
+			PlanID:         planID,
+			Database:       "testdb",
+			DatabaseType:   storage.DatabaseTypeVitess,
+			Engine:         storage.EnginePlanetScale,
+			State:          state.Task.Running,
+			Namespace:      "billing",
+			TableName:      "orders",
+			DDL:            ordersDDL,
+			DDLAction:      "alter",
+			Environment:    localClientTestEnvironment,
+			CreatedAt:      now,
+			UpdatedAt:      now,
+		},
+	}
+	operation := &storage.ApplyOperation{
+		Deployment: "testdb",
+		State:      state.ApplyOperation.Running,
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	}
+	applyID, err := stor.Applies().CreateWithTasksAndOperations(ctx, apply, tasks, []*storage.ApplyOperation{operation})
+	require.NoError(t, err)
+	apply.ID = applyID
+
+	persistedMetadata := `{"branch_name":"recovery-branch","deploy_request_id":42,"deploy_request_url":"https://example.test/deploys/42"}`
+	require.NoError(t, stor.ApplyOperations().SaveEngineResumeState(ctx, operation.ID, &storage.EngineResumeState{
+		ApplyOperationID: operation.ID,
+		MigrationContext: apply.ApplyIdentifier,
+		Metadata:         persistedMetadata,
+	}))
+
+	reattachedMetadata := `{"branch_name":"recovery-branch","deploy_request_id":42,"deploy_request_url":"https://example.test/deploys/42-reattached"}`
+	finalMetadata := `{"branch_name":"recovery-branch","deploy_request_id":42,"deploy_request_url":"https://example.test/deploys/42-final"}`
+	resumeEngine := &stagedGroupedResumeEngine{
+		planResults: []*engine.PlanResult{{
+			Changes: []engine.SchemaChange{
+				{Namespace: "commerce", TableChanges: []engine.TableChange{{Table: "users", DDL: usersDDL}}},
+				{Namespace: "billing", TableChanges: []engine.TableChange{{Table: "orders", DDL: ordersDDL}}},
+			},
+		}},
+		applyResult: &engine.ApplyResult{
+			Accepted:    true,
+			ResumeState: &engine.ResumeState{MigrationContext: apply.ApplyIdentifier, Metadata: reattachedMetadata},
+		},
+		progress: &engine.ProgressResult{
+			State:       engine.StateCompleted,
+			ResumeState: &engine.ResumeState{MigrationContext: apply.ApplyIdentifier, Metadata: finalMetadata},
+			Tables: []engine.TableProgress{
+				{Namespace: "commerce", Table: "users", State: state.Task.Completed, Progress: 100},
+				{Namespace: "billing", Table: "orders", State: state.Task.Completed, Progress: 100},
+			},
+		},
+	}
+	client.planetscaleEngine = resumeEngine
+
+	resumeCtx, cancelResume := context.WithTimeout(ctx, 30*time.Second)
+	defer cancelResume()
+	require.NoError(t, client.ResumeApply(resumeCtx, apply))
+
+	require.Len(t, resumeEngine.applyRequests, 1, "grouped recovery must issue exactly one engine apply")
+	applyReq := resumeEngine.applyRequests[0]
+	require.NotNil(t, applyReq.ResumeState)
+	assert.Equal(t, apply.ApplyIdentifier, applyReq.ResumeState.MigrationContext)
+	assert.JSONEq(t, persistedMetadata, applyReq.ResumeState.Metadata)
+
+	require.Len(t, applyReq.Changes, 2)
+	changesByNamespace := make(map[string][]engine.TableChange, len(applyReq.Changes))
+	for _, sc := range applyReq.Changes {
+		changesByNamespace[sc.Namespace] = sc.TableChanges
+	}
+	require.Len(t, changesByNamespace["commerce"], 1)
+	assert.Equal(t, "users", changesByNamespace["commerce"][0].Table)
+	assert.Equal(t, usersDDL, changesByNamespace["commerce"][0].DDL)
+	require.Len(t, changesByNamespace["billing"], 1)
+	assert.Equal(t, "orders", changesByNamespace["billing"][0].Table)
+	assert.Equal(t, ordersDDL, changesByNamespace["billing"][0].DDL)
+
+	require.NotEmpty(t, resumeEngine.progressResumeMetadata)
+	assert.JSONEq(t, reattachedMetadata, resumeEngine.progressResumeMetadata[0])
+
+	storedState, err := stor.ApplyOperations().GetEngineResumeState(ctx, operation.ID)
+	require.NoError(t, err)
+	assert.JSONEq(t, finalMetadata, storedState.Metadata)
+
+	storedApply, err := stor.Applies().Get(ctx, applyID)
+	require.NoError(t, err)
+	require.NotNil(t, storedApply)
+	assert.Equal(t, state.Apply.Completed, storedApply.State)
+
+	for _, task := range tasks {
+		storedTask, err := stor.Tasks().Get(ctx, task.TaskIdentifier)
+		require.NoError(t, err)
+		require.NotNil(t, storedTask)
+		assert.Equal(t, state.Task.Completed, storedTask.State)
+	}
+}
+
+// This scenario covers restart recovery of a grouped deferred-cutover apply
+// with no persisted engine resume state. The engine reattaches through its own
+// durable checkpoints keyed by the schema change context, so recovery issues
+// one grouped engine apply whose resume state carries the apply identifier and
+// whose rebuilt changes keep the tasks' namespace and table so per-table
+// progress matching still works.
+func TestLocalClient_ResumeApplyGroupedRebuildsChangesFromTasks(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	_, dsn := setupMySQLContainer(t)
+	setupStorageSchema(t, dsn)
+	cleanupTasks(t, dsn)
+	cleanupTestTables(t, dsn)
+
+	ctx := t.Context()
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	stor := createStorage(t, dsn)
+	defer utils.CloseAndLog(stor)
+
+	client, err := NewLocalClient(LocalConfig{
+		Database:  "testdb",
+		Type:      storage.DatabaseTypeMySQL,
+		TargetDSN: dsn,
+	}, stor, logger)
+	require.NoError(t, err)
+	defer utils.CloseAndLog(client)
+
+	ddl := "ALTER TABLE `users` ADD COLUMN `resume_note` varchar(255)"
+	plan := &storage.Plan{
+		PlanIdentifier: fmt.Sprintf("plan-grouped-resume-changes-%d", time.Now().UnixNano()),
+		Database:       "testdb",
+		DatabaseType:   storage.DatabaseTypeMySQL,
+		Deployment:     "testdb",
+		Environment:    localClientTestEnvironment,
+		CreatedAt:      time.Now(),
+		Namespaces: map[string]*storage.NamespacePlanData{
+			"testdb": {Tables: []storage.TableChange{{Namespace: "testdb", Table: "users", DDL: ddl, Operation: "alter"}}},
+		},
+	}
+	planID, err := stor.Plans().Create(ctx, plan)
+	require.NoError(t, err)
+
+	now := time.Now()
+	apply := &storage.Apply{
+		ApplyIdentifier: fmt.Sprintf("apply-grouped-resume-changes-%d", now.UnixNano()),
+		PlanID:          planID,
+		Database:        "testdb",
+		DatabaseType:    storage.DatabaseTypeMySQL,
+		Deployment:      "testdb",
+		Engine:          storage.EngineSpirit,
+		State:           state.Apply.Running,
+		Options:         storage.MarshalApplyOptions(storage.ApplyOptions{DeferCutover: true}),
+		Environment:     localClientTestEnvironment,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+	task := &storage.Task{
+		TaskIdentifier: fmt.Sprintf("task-grouped-resume-changes-users-%d", now.UnixNano()),
+		PlanID:         planID,
+		Database:       "testdb",
+		DatabaseType:   storage.DatabaseTypeMySQL,
+		Engine:         storage.EngineSpirit,
+		State:          state.Task.Running,
+		TableName:      "users",
+		Namespace:      "testdb",
+		DDL:            ddl,
+		DDLAction:      "alter",
+		Options:        storage.MarshalApplyOptions(storage.ApplyOptions{DeferCutover: true}),
+		Environment:    localClientTestEnvironment,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+	operation := &storage.ApplyOperation{
+		Deployment: "testdb",
+		State:      state.ApplyOperation.Running,
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	}
+	applyID, err := stor.Applies().CreateWithTasksAndOperations(ctx, apply, []*storage.Task{task}, []*storage.ApplyOperation{operation})
+	require.NoError(t, err)
+	apply.ID = applyID
+
+	resumeEngine := &stagedGroupedResumeEngine{
+		planResults: []*engine.PlanResult{{
+			Changes: []engine.SchemaChange{{
+				Namespace:    "testdb",
+				TableChanges: []engine.TableChange{{Table: "users", DDL: ddl}},
+			}},
+		}},
+		progress: &engine.ProgressResult{
+			State: engine.StateCompleted,
+			Tables: []engine.TableProgress{{
+				Namespace: "testdb",
+				Table:     "users",
+				State:     state.Task.Completed,
+				Progress:  100,
+			}},
+		},
+	}
+	client.spiritEngine = resumeEngine
+
+	resumeCtx, cancelResume := context.WithTimeout(ctx, 30*time.Second)
+	defer cancelResume()
+	require.NoError(t, client.ResumeApply(resumeCtx, apply))
+
+	require.Len(t, resumeEngine.applyRequests, 1, "grouped recovery must issue exactly one engine apply")
+	applyReq := resumeEngine.applyRequests[0]
+	require.NotNil(t, applyReq.ResumeState)
+	assert.Equal(t, apply.ApplyIdentifier, applyReq.ResumeState.MigrationContext)
+	assert.Empty(t, applyReq.ResumeState.Metadata)
+
+	require.Len(t, applyReq.Changes, 1)
+	assert.Equal(t, "testdb", applyReq.Changes[0].Namespace)
+	require.Len(t, applyReq.Changes[0].TableChanges, 1)
+	assert.Equal(t, "users", applyReq.Changes[0].TableChanges[0].Table)
+	assert.Equal(t, ddl, applyReq.Changes[0].TableChanges[0].DDL)
+	assert.Equal(t, statement.StatementAlterTable, applyReq.Changes[0].TableChanges[0].Operation)
+
+	storedApply, err := stor.Applies().Get(ctx, applyID)
+	require.NoError(t, err)
+	require.NotNil(t, storedApply)
+	assert.Equal(t, state.Apply.Completed, storedApply.State)
+
+	storedTask, err := stor.Tasks().Get(ctx, task.TaskIdentifier)
+	require.NoError(t, err)
+	require.NotNil(t, storedTask)
+	assert.Equal(t, state.Task.Completed, storedTask.State)
+	assert.Equal(t, 100, storedTask.ProgressPercent)
 }
 
 func TestLocalClient_Cutover_NoActiveMigration(t *testing.T) {

--- a/pkg/tern/local_client_test.go
+++ b/pkg/tern/local_client_test.go
@@ -585,6 +585,46 @@ func TestGroupedResumeChangesGroupsTasksByNamespace(t *testing.T) {
 	assert.Equal(t, statement.StatementAlterTable, changes[1].TableChanges[0].Operation)
 }
 
+// A VSchema task carries no DDL, so a resumed apply with mixed VSchema and DDL
+// work must keep the VSchema out of TableChanges and instead flag its namespace
+// with the vschema_changed metadata. This is how the engine knows to re-apply
+// vschema.json from the schema files on resume.
+func TestGroupedResumeChangesCarriesVSchemaMetadata(t *testing.T) {
+	tasks := []*storage.Task{
+		{Namespace: "commerce", TableName: "users", DDL: "ALTER TABLE `users` ADD COLUMN `email` varchar(255)", DDLAction: "alter"},
+		{Namespace: "commerce", TableName: "VSchema: commerce", DDLAction: "vschema_update"},
+	}
+
+	changes := groupedResumeChanges(tasks)
+
+	require.Len(t, changes, 1)
+	assert.Equal(t, "commerce", changes[0].Namespace)
+	require.Len(t, changes[0].TableChanges, 1)
+	assert.Equal(t, "users", changes[0].TableChanges[0].Table)
+	assert.Equal(t, tasks[0].DDL, changes[0].TableChanges[0].DDL)
+	assert.Equal(t, statement.StatementAlterTable, changes[0].TableChanges[0].Operation)
+	assert.Equal(t, "true", changes[0].Metadata["vschema_changed"])
+	for _, tc := range changes[0].TableChanges {
+		assert.NotEmpty(t, tc.DDL, "resume changes must not contain an empty-DDL table change")
+	}
+}
+
+// A VSchema-only apply has no DDL tasks. Its resumed change must still carry a
+// namespace flagged with vschema_changed and no table changes, so the engine
+// applies vschema.json without attempting to execute an empty statement.
+func TestGroupedResumeChangesVSchemaOnly(t *testing.T) {
+	tasks := []*storage.Task{
+		{Namespace: "commerce", TableName: "VSchema: commerce", DDLAction: "vschema_update"},
+	}
+
+	changes := groupedResumeChanges(tasks)
+
+	require.Len(t, changes, 1)
+	assert.Equal(t, "commerce", changes[0].Namespace)
+	assert.Empty(t, changes[0].TableChanges)
+	assert.Equal(t, "true", changes[0].Metadata["vschema_changed"])
+}
+
 func TestLocalClient_ProcessPendingStopControlRequest(t *testing.T) {
 	apply := &storage.Apply{
 		ID:              123,

--- a/pkg/tern/local_client_test.go
+++ b/pkg/tern/local_client_test.go
@@ -99,15 +99,24 @@ type fakeControlEngine struct {
 	progressReq    *engine.ProgressRequest
 	progressResult *engine.ProgressResult
 	progressErr    error
+	planResult     *engine.PlanResult
+	applyResult    *engine.ApplyResult
+	applyErr       error
 }
 
 func (e *fakeControlEngine) Name() string { return "fake" }
 
 func (e *fakeControlEngine) Plan(context.Context, *engine.PlanRequest) (*engine.PlanResult, error) {
+	if e.planResult != nil {
+		return e.planResult, nil
+	}
 	return &engine.PlanResult{}, nil
 }
 
 func (e *fakeControlEngine) Apply(context.Context, *engine.ApplyRequest) (*engine.ApplyResult, error) {
+	if e.applyResult != nil || e.applyErr != nil {
+		return e.applyResult, e.applyErr
+	}
 	return &engine.ApplyResult{Accepted: true}, nil
 }
 
@@ -188,12 +197,16 @@ func (s *exactProgressVitessApplyDataStore) GetByApplyID(context.Context, int64)
 
 type exactProgressApplyOperationStore struct {
 	storage.ApplyOperationStore
-	data  *storage.EngineResumeState
-	err   error
-	saved *storage.EngineResumeState
+	data    *storage.EngineResumeState
+	err     error
+	saveErr error
+	saved   *storage.EngineResumeState
 }
 
 func (s *exactProgressApplyOperationStore) SaveEngineResumeState(_ context.Context, operationID int64, resumeState *storage.EngineResumeState) error {
+	if s.saveErr != nil {
+		return s.saveErr
+	}
 	if s.err != nil {
 		return s.err
 	}
@@ -556,6 +569,123 @@ func TestGroupedResumeStateRequiresApplyOperationForVitess(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "apply-unlinked-mysql", resumeState.MigrationContext)
 	assert.Empty(t, resumeState.Metadata)
+}
+
+// reattachResumeFixture builds a Vitess apply that has already reattached to an
+// in-flight deploy request: the engine accepts the grouped resume, so the apply
+// owner must not write terminal failure when post-accept resume-state handling
+// goes wrong. The fake engine's plan keeps the task active through the final
+// schema check so the resume reaches the post-accept persistence path.
+func reattachResumeFixture(applyOperations storage.ApplyOperationStore, applyResult *engine.ApplyResult) (*LocalClient, *storage.Apply, []*storage.Task, *storage.Plan, *exactProgressApplyStore) {
+	operationID := int64(7)
+	apply := &storage.Apply{
+		ID:              42,
+		ApplyIdentifier: "apply-reattach-vitess",
+		Database:        "testdb",
+		DatabaseType:    storage.DatabaseTypeVitess,
+		Engine:          storage.EnginePlanetScale,
+		State:           state.Apply.Recovering,
+	}
+	tasks := []*storage.Task{{
+		ID:               7,
+		ApplyID:          apply.ID,
+		ApplyOperationID: &operationID,
+		TaskIdentifier:   "task-reattach",
+		Database:         "testdb",
+		DatabaseType:     storage.DatabaseTypeVitess,
+		Engine:           storage.EnginePlanetScale,
+		Namespace:        "commerce",
+		TableName:        "users",
+		DDL:              "ALTER TABLE `users` ADD COLUMN `email` varchar(255)",
+		DDLAction:        "alter",
+		State:            state.Task.Recovering,
+	}}
+	plan := &storage.Plan{PlanIdentifier: "plan-reattach"}
+	eng := &fakeControlEngine{
+		planResult: &engine.PlanResult{Changes: []engine.SchemaChange{{
+			Namespace: "commerce",
+			TableChanges: []engine.TableChange{{
+				Table: "users",
+				DDL:   "ALTER TABLE `users` ADD COLUMN `email` varchar(255)",
+			}},
+		}}},
+		applyResult: applyResult,
+	}
+	applyStore := &exactProgressApplyStore{apply: apply}
+	client := &LocalClient{
+		config: LocalConfig{Database: "testdb", Type: storage.DatabaseTypeVitess},
+		storage: &exactProgressStorage{
+			applies:         applyStore,
+			tasks:           &exactProgressTaskStore{tasks: tasks},
+			applyOperations: applyOperations,
+		},
+		planetscaleEngine: eng,
+		logger:            slog.Default(),
+	}
+	return client, apply, tasks, plan, applyStore
+}
+
+// After the engine accepts the grouped resume a deploy request is running on the
+// provider. A failure to persist the returned resume state is storage
+// uncertainty, not a failed schema change: the apply owner exits non-terminally
+// so an operator can retry against the in-flight work instead of abandoning it.
+func TestLaunchAtomicResumeSaveFailureStaysRecoverable(t *testing.T) {
+	store := &exactProgressApplyOperationStore{
+		data: &storage.EngineResumeState{
+			ApplyOperationID: 7,
+			MigrationContext: "ctx-reattach",
+			Metadata:         `{"branch_name":"branch-1","deploy_request_id":5}`,
+		},
+		saveErr: errors.New("storage unavailable"),
+	}
+	applyResult := &engine.ApplyResult{
+		Accepted: true,
+		ResumeState: &engine.ResumeState{
+			MigrationContext: "ctx-reattach",
+			Metadata:         `{"branch_name":"branch-1","deploy_request_id":5}`,
+		},
+	}
+	client, apply, tasks, plan, applyStore := reattachResumeFixture(store, applyResult)
+
+	err := client.launchAtomicResume(t.Context(), apply, tasks, plan, buildApplyOptions(apply), "Recovering from checkpoint", false, false)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errGroupedResumeStateUnavailable)
+	assert.ErrorContains(t, err, "apply-reattach-vitess")
+	assert.False(t, state.IsTerminalApplyState(applyStore.apply.State),
+		"in-flight apply must stay recoverable, not terminal: got %s", applyStore.apply.State)
+	assert.NotEqual(t, state.Apply.Failed, applyStore.apply.State)
+}
+
+// The Vitess poll loop is driven by resume-state metadata, so an accepted resume
+// that returns no metadata leaves the owner unable to track the in-flight deploy
+// request. That ambiguity is non-terminal: the owner exits for operator retry
+// rather than failing an apply whose deploy request is still running.
+func TestLaunchAtomicResumeMissingMetadataStaysRecoverable(t *testing.T) {
+	store := &exactProgressApplyOperationStore{
+		data: &storage.EngineResumeState{
+			ApplyOperationID: 7,
+			MigrationContext: "ctx-reattach",
+			Metadata:         `{"branch_name":"branch-1","deploy_request_id":5}`,
+		},
+	}
+	applyResult := &engine.ApplyResult{
+		Accepted: true,
+		ResumeState: &engine.ResumeState{
+			MigrationContext: "ctx-reattach",
+			Metadata:         "",
+		},
+	}
+	client, apply, tasks, plan, applyStore := reattachResumeFixture(store, applyResult)
+
+	err := client.launchAtomicResume(t.Context(), apply, tasks, plan, buildApplyOptions(apply), "Recovering from checkpoint", false, false)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errGroupedResumeStateUnavailable)
+	assert.ErrorContains(t, err, "apply-reattach-vitess")
+	assert.False(t, state.IsTerminalApplyState(applyStore.apply.State),
+		"in-flight apply must stay recoverable, not terminal: got %s", applyStore.apply.State)
+	assert.NotEqual(t, state.Apply.Failed, applyStore.apply.State)
 }
 
 // Rebuilt resume changes must preserve each task's namespace and table so

--- a/pkg/tern/local_client_test.go
+++ b/pkg/tern/local_client_test.go
@@ -2,12 +2,14 @@ package tern
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"reflect"
 	"slices"
 	"testing"
 	"time"
 
+	"github.com/block/spirit/pkg/statement"
 	spirittable "github.com/block/spirit/pkg/table"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -474,6 +476,113 @@ func TestLocalClient_VitessProgressPassesAndPersistsEngineResumeState(t *testing
 	require.Len(t, progress.Tables, 1)
 	assert.Equal(t, int32(42), progress.Tables[0].PercentComplete)
 	assert.True(t, progress.Tables[0].IsInstant)
+}
+
+func groupedResumeStateClient(databaseType string, applyOperations storage.ApplyOperationStore) *LocalClient {
+	return &LocalClient{
+		config:  LocalConfig{Database: "testdb", Type: databaseType},
+		storage: &exactProgressStorage{applyOperations: applyOperations},
+		logger:  slog.Default(),
+	}
+}
+
+// A grouped resume must hand the engine its persisted state so the engine
+// reattaches to in-flight work instead of starting a duplicate schema change.
+func TestGroupedResumeStateUsesPersistedEngineState(t *testing.T) {
+	operationID := int64(11)
+	apply := &storage.Apply{ID: 4, ApplyIdentifier: "apply-resume-state", Database: "testdb", DatabaseType: storage.DatabaseTypeVitess}
+	tasks := []*storage.Task{{TaskIdentifier: "task-a", ApplyOperationID: &operationID}}
+	persistedMetadata := `{"branch_name":"branch-9","deploy_request_id":9}`
+	store := &exactProgressApplyOperationStore{data: &storage.EngineResumeState{
+		ApplyOperationID: operationID,
+		MigrationContext: "ctx-resume",
+		Metadata:         persistedMetadata,
+	}}
+	client := groupedResumeStateClient(storage.DatabaseTypeVitess, store)
+
+	resumeState, err := client.groupedResumeState(t.Context(), apply, tasks)
+	require.NoError(t, err)
+	assert.Equal(t, "ctx-resume", resumeState.MigrationContext)
+	assert.JSONEq(t, persistedMetadata, resumeState.Metadata)
+}
+
+// Absent persisted state is expected for engines that reattach through durable
+// database-side checkpoints: the resume proceeds from the schema change
+// context alone instead of failing the recovery attempt.
+func TestGroupedResumeStateFallsBackToContextWhenAbsent(t *testing.T) {
+	operationID := int64(11)
+	apply := &storage.Apply{ID: 4, ApplyIdentifier: "apply-resume-absent", Database: "testdb", DatabaseType: storage.DatabaseTypeMySQL}
+	tasks := []*storage.Task{{TaskIdentifier: "task-a", ApplyOperationID: &operationID}}
+	client := groupedResumeStateClient(storage.DatabaseTypeMySQL, &exactProgressApplyOperationStore{})
+
+	resumeState, err := client.groupedResumeState(t.Context(), apply, tasks)
+	require.NoError(t, err)
+	assert.Equal(t, "apply-resume-absent", resumeState.MigrationContext)
+	assert.Empty(t, resumeState.Metadata)
+}
+
+// A storage read failure is distinct from absent state: the resume attempt
+// must fail so a later attempt can retry with intact persisted state, instead
+// of launching engine work that may duplicate an in-flight schema change.
+func TestGroupedResumeStateFailsOnStorageError(t *testing.T) {
+	operationID := int64(11)
+	apply := &storage.Apply{ID: 4, ApplyIdentifier: "apply-resume-storage-error", Database: "testdb", DatabaseType: storage.DatabaseTypeMySQL}
+	tasks := []*storage.Task{{TaskIdentifier: "task-a", ApplyOperationID: &operationID}}
+	storageErr := errors.New("storage unavailable")
+	client := groupedResumeStateClient(storage.DatabaseTypeMySQL, &exactProgressApplyOperationStore{err: storageErr})
+
+	_, err := client.groupedResumeState(t.Context(), apply, tasks)
+	require.ErrorIs(t, err, storageErr)
+	assert.ErrorIs(t, err, errGroupedResumeStateUnavailable)
+	assert.ErrorContains(t, err, "apply-resume-storage-error")
+}
+
+// A Vitess apply whose tasks cannot be resolved to an apply operation cannot
+// prove there is no in-flight deploy request to reattach to, so the resume
+// fails closed. Engines that reattach from the schema change context alone
+// proceed without an apply operation.
+func TestGroupedResumeStateRequiresApplyOperationForVitess(t *testing.T) {
+	tasks := []*storage.Task{{TaskIdentifier: "task-unlinked"}}
+
+	vitessApply := &storage.Apply{ApplyIdentifier: "apply-unlinked-vitess", Database: "testdb", DatabaseType: storage.DatabaseTypeVitess}
+	vitessClient := groupedResumeStateClient(storage.DatabaseTypeVitess, &exactProgressApplyOperationStore{})
+	_, err := vitessClient.groupedResumeState(t.Context(), vitessApply, tasks)
+	require.ErrorIs(t, err, errGroupedResumeStateUnavailable)
+	assert.ErrorContains(t, err, "apply-unlinked-vitess")
+
+	mysqlApply := &storage.Apply{ApplyIdentifier: "apply-unlinked-mysql", Database: "testdb", DatabaseType: storage.DatabaseTypeMySQL}
+	mysqlClient := groupedResumeStateClient(storage.DatabaseTypeMySQL, &exactProgressApplyOperationStore{})
+	resumeState, err := mysqlClient.groupedResumeState(t.Context(), mysqlApply, tasks)
+	require.NoError(t, err)
+	assert.Equal(t, "apply-unlinked-mysql", resumeState.MigrationContext)
+	assert.Empty(t, resumeState.Metadata)
+}
+
+// Rebuilt resume changes must preserve each task's namespace and table so
+// engines key per-table progress on the same identity the stored tasks carry.
+func TestGroupedResumeChangesGroupsTasksByNamespace(t *testing.T) {
+	tasks := []*storage.Task{
+		{Namespace: "commerce", TableName: "users", DDL: "ALTER TABLE `users` ADD COLUMN `email` varchar(255)", DDLAction: "alter"},
+		{Namespace: "commerce", TableName: "orders", DDL: "CREATE TABLE `orders` (`id` bigint unsigned NOT NULL)", DDLAction: "create"},
+		{Namespace: "billing", TableName: "invoices", DDL: "ALTER TABLE `invoices` ADD COLUMN `due_at` datetime", DDLAction: "alter"},
+	}
+
+	changes := groupedResumeChanges(tasks)
+
+	require.Len(t, changes, 2)
+	assert.Equal(t, "commerce", changes[0].Namespace)
+	require.Len(t, changes[0].TableChanges, 2)
+	assert.Equal(t, "users", changes[0].TableChanges[0].Table)
+	assert.Equal(t, tasks[0].DDL, changes[0].TableChanges[0].DDL)
+	assert.Equal(t, statement.StatementAlterTable, changes[0].TableChanges[0].Operation)
+	assert.Equal(t, "orders", changes[0].TableChanges[1].Table)
+	assert.Equal(t, tasks[1].DDL, changes[0].TableChanges[1].DDL)
+	assert.Equal(t, statement.StatementCreateTable, changes[0].TableChanges[1].Operation)
+	assert.Equal(t, "billing", changes[1].Namespace)
+	require.Len(t, changes[1].TableChanges, 1)
+	assert.Equal(t, "invoices", changes[1].TableChanges[0].Table)
+	assert.Equal(t, tasks[2].DDL, changes[1].TableChanges[0].DDL)
+	assert.Equal(t, statement.StatementAlterTable, changes[1].TableChanges[0].Operation)
 }
 
 func TestLocalClient_ProcessPendingStopControlRequest(t *testing.T) {

--- a/pkg/tern/local_control_resume.go
+++ b/pkg/tern/local_control_resume.go
@@ -560,15 +560,22 @@ func (c *LocalClient) launchAtomicResume(ctx context.Context, apply *storage.App
 	if result.ResumeState != nil {
 		resumeState = result.ResumeState
 		if c.config.Type == storage.DatabaseTypeVitess {
+			// The engine has already accepted the resume and a deploy request is
+			// running on the provider. A failure to persist the resume state must
+			// not become terminal apply state — the owner exits and the operator
+			// retries against the in-flight work rather than abandoning it.
 			if saveErr := c.saveEngineResumeState(ctx, tasks, resumeState); saveErr != nil {
-				return fmt.Errorf("save engine resume state after grouped resume of apply %s (database %s): %w", apply.ApplyIdentifier, apply.Database, saveErr)
+				return fmt.Errorf("%w: save engine resume state after grouped resume of apply %s (database %s): %w", errGroupedResumeStateUnavailable, apply.ApplyIdentifier, apply.Database, saveErr)
 			}
 		}
 	}
 	// Progress polling for Vitess applies is driven entirely by resume state
 	// metadata; without it the poll loop can never observe the deploy request.
+	// The engine has already accepted the resume, so an absent metadata invariant
+	// leaves the owner unable to track in-flight work — exit non-terminally so the
+	// operator can retry rather than failing an apply that is still running.
 	if c.config.Type == storage.DatabaseTypeVitess && resumeState.Metadata == "" {
-		return fmt.Errorf("engine accepted grouped resume of Vitess apply %s (database %s) without resume state metadata", apply.ApplyIdentifier, apply.Database)
+		return fmt.Errorf("%w: engine accepted grouped resume of Vitess apply %s (database %s) without resume state metadata", errGroupedResumeStateUnavailable, apply.ApplyIdentifier, apply.Database)
 	}
 
 	now := time.Now()
@@ -620,10 +627,12 @@ func (c *LocalClient) launchAtomicResume(ctx context.Context, apply *storage.App
 	return nil
 }
 
-// errGroupedResumeStateUnavailable marks a resume attempt that could not load
-// (or rule out) persisted engine resume state. The current apply owner must
-// exit without writing terminal state so a later attempt can retry against
-// intact storage — failing the apply here would abandon in-flight engine work.
+// errGroupedResumeStateUnavailable marks a resume attempt whose persisted engine
+// resume state could not be loaded (or ruled out) before the engine apply, or
+// could not be persisted (or confirmed present) after the engine accepted the
+// reattach. The current apply owner must exit without writing terminal state so
+// a later attempt can retry against intact storage — failing the apply here
+// would abandon engine work that is still in flight on the provider.
 var errGroupedResumeStateUnavailable = errors.New("grouped resume state unavailable")
 
 // groupedResumeState returns the ResumeState handed to the engine when a

--- a/pkg/tern/local_control_resume.go
+++ b/pkg/tern/local_control_resume.go
@@ -2,9 +2,11 @@ package tern
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
+	"github.com/block/schemabot/pkg/ddl"
 	"github.com/block/schemabot/pkg/engine"
 	"github.com/block/schemabot/pkg/metrics"
 	ternv1 "github.com/block/schemabot/pkg/proto/ternv1"
@@ -521,35 +523,52 @@ func (c *LocalClient) launchAtomicResume(ctx context.Context, apply *storage.App
 		return nil
 	}
 
-	var ddls []string
-	for _, t := range tasks {
-		ddls = append(ddls, t.DDL)
+	resumeState, err := c.groupedResumeState(ctx, apply, tasks)
+	if err != nil {
+		return err
 	}
 
-	// Build table changes from the DDL list
-	var tableChanges []engine.TableChange
-	for _, ddl := range ddls {
-		tableChanges = append(tableChanges, engine.TableChange{DDL: ddl})
-	}
-
-	// Resume the grouped apply after restart. Use apply identifier as
-	// MigrationContext so Spirit can find existing checkpoint tables from the
-	// original run.
+	// Resume the grouped apply with the engine's persisted state so it
+	// reattaches to in-flight engine work instead of launching a duplicate
+	// schema change. The changes are rebuilt from the stored tasks so the
+	// engine keys per-table progress on the same namespace/table pairs the
+	// tasks carry.
 	result, err := eng.Apply(ctx, &engine.ApplyRequest{
-		Database: apply.Database,
-		Changes: []engine.SchemaChange{{
-			Namespace:    apply.Database,
-			TableChanges: tableChanges,
-		}},
+		Database:    apply.Database,
+		PlanID:      plan.PlanIdentifier,
+		Changes:     groupedResumeChanges(tasks),
+		SchemaFiles: plan.SchemaFiles,
 		Options:     options,
-		ResumeState: &engine.ResumeState{MigrationContext: apply.ApplyIdentifier},
+		ResumeState: resumeState,
 		Credentials: creds,
+		OnStateChange: func(rs *engine.ResumeState) {
+			if rs == nil {
+				c.logger.Debug("OnStateChange: nil resume state", "apply_id", apply.ApplyIdentifier)
+				return
+			}
+			if saveErr := c.saveEngineResumeState(ctx, tasks, rs); saveErr != nil {
+				c.logger.Warn("OnStateChange: failed to persist opaque resume state", "apply_id", apply.ApplyIdentifier, "error", saveErr)
+			}
+		},
 	})
 	if err != nil {
 		return fmt.Errorf("engine apply failed: %w", err)
 	}
 	if !result.Accepted {
 		return fmt.Errorf("engine did not accept apply: %s", result.Message)
+	}
+	if result.ResumeState != nil {
+		resumeState = result.ResumeState
+		if c.config.Type == storage.DatabaseTypeVitess {
+			if saveErr := c.saveEngineResumeState(ctx, tasks, resumeState); saveErr != nil {
+				return fmt.Errorf("save engine resume state after grouped resume of apply %s (database %s): %w", apply.ApplyIdentifier, apply.Database, saveErr)
+			}
+		}
+	}
+	// Progress polling for Vitess applies is driven entirely by resume state
+	// metadata; without it the poll loop can never observe the deploy request.
+	if c.config.Type == storage.DatabaseTypeVitess && resumeState.Metadata == "" {
+		return fmt.Errorf("engine accepted grouped resume of Vitess apply %s (database %s) without resume state metadata", apply.ApplyIdentifier, apply.Database)
 	}
 
 	now := time.Now()
@@ -587,7 +606,7 @@ func (c *LocalClient) launchAtomicResume(ctx context.Context, apply *storage.App
 		defer cancelPoll()
 		stopHeartbeat := c.startApplyHeartbeat(pollCtx, apply, cancelPoll)
 		defer stopHeartbeat()
-		c.pollForCompletionAtomic(pollCtx, apply, tasks, creds, nil)
+		c.pollForCompletionAtomic(pollCtx, apply, tasks, creds, resumeState)
 		return nil
 	}
 
@@ -596,9 +615,81 @@ func (c *LocalClient) launchAtomicResume(ctx context.Context, apply *storage.App
 	go func() {
 		defer cancelResume()
 		defer stopHeartbeat()
-		c.pollForCompletionAtomic(resumeCtx, apply, tasks, creds, nil)
+		c.pollForCompletionAtomic(resumeCtx, apply, tasks, creds, resumeState)
 	}()
 	return nil
+}
+
+// errGroupedResumeStateUnavailable marks a resume attempt that could not load
+// (or rule out) persisted engine resume state. The current apply owner must
+// exit without writing terminal state so a later attempt can retry against
+// intact storage — failing the apply here would abandon in-flight engine work.
+var errGroupedResumeStateUnavailable = errors.New("grouped resume state unavailable")
+
+// groupedResumeState returns the ResumeState handed to the engine when a
+// grouped apply is resumed. Recovery must reattach to the engine's existing
+// work via persisted resume state; launching fresh engine work would duplicate
+// the in-flight schema change. Absent persisted state is expected for engines
+// that reattach through durable database-side checkpoints keyed by the schema
+// change context alone (Spirit); a storage read failure fails the resume
+// attempt so a later attempt can retry with intact state.
+func (c *LocalClient) groupedResumeState(ctx context.Context, apply *storage.Apply, tasks []*storage.Task) (*engine.ResumeState, error) {
+	contextOnly := &engine.ResumeState{MigrationContext: apply.ApplyIdentifier}
+
+	operationID, err := applyOperationIDForTasks(tasks)
+	if err != nil {
+		// Persisted engine resume state is scoped to an apply operation, so a
+		// Vitess apply whose tasks cannot be resolved to one leaves SchemaBot
+		// unable to prove there is no in-flight deploy request to reattach to.
+		if c.config.Type == storage.DatabaseTypeVitess {
+			return nil, fmt.Errorf("%w: resolve apply operation for grouped resume of apply %s (database %s): %w", errGroupedResumeStateUnavailable, apply.ApplyIdentifier, apply.Database, err)
+		}
+		c.logger.Info("tasks have no apply operation to hold persisted engine resume state; engine apply will start from the schema change context",
+			"apply_id", apply.ApplyIdentifier,
+			"database", apply.Database,
+			"database_type", apply.DatabaseType)
+		return contextOnly, nil
+	}
+
+	stored, err := c.loadEngineResumeStateForOperation(ctx, operationID)
+	if errors.Is(err, storage.ErrEngineResumeStateNotFound) {
+		c.logger.Info("no persisted engine resume state for apply operation; engine apply will start from the schema change context",
+			"apply_id", apply.ApplyIdentifier,
+			"apply_operation_id", operationID,
+			"database", apply.Database,
+			"database_type", apply.DatabaseType)
+		return contextOnly, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("%w: load engine resume state for grouped resume of apply %s operation %d (database %s): %w", errGroupedResumeStateUnavailable, apply.ApplyIdentifier, operationID, apply.Database, err)
+	}
+	if stored.MigrationContext == "" {
+		stored.MigrationContext = apply.ApplyIdentifier
+	}
+	return stored, nil
+}
+
+// groupedResumeChanges rebuilds the engine changes for a grouped resume from
+// the stored tasks, grouped per namespace. Tasks carry the authoritative
+// remaining work after re-planning, and engines key per-table progress on
+// namespace and table, so the rebuilt changes must preserve both.
+func groupedResumeChanges(tasks []*storage.Task) []engine.SchemaChange {
+	indexByNamespace := make(map[string]int, len(tasks))
+	var changes []engine.SchemaChange
+	for _, task := range tasks {
+		idx, ok := indexByNamespace[task.Namespace]
+		if !ok {
+			idx = len(changes)
+			indexByNamespace[task.Namespace] = idx
+			changes = append(changes, engine.SchemaChange{Namespace: task.Namespace})
+		}
+		changes[idx].TableChanges = append(changes[idx].TableChanges, engine.TableChange{
+			Table:     task.TableName,
+			DDL:       task.DDL,
+			Operation: ddl.OpToStatementType(task.DDLAction),
+		})
+	}
+	return changes
 }
 
 func (c *LocalClient) notifyTerminalObserver(apply *storage.Apply, tasks []*storage.Task) {
@@ -712,6 +803,14 @@ func (c *LocalClient) resumeApplyWithTasks(ctx context.Context, apply *storage.A
 				defer c.clearApplyCancel(cancelGeneration)
 				defer cancelResume()
 				if err := c.launchAtomicResume(resumeCtx, apply, tasks, plan, options, "Recovering from checkpoint", true, false); err != nil {
+					if errors.Is(err, errGroupedResumeStateUnavailable) {
+						c.logger.Warn("deferred cutover recovery could not load persisted engine resume state; current apply owner will exit for operator retry",
+							"apply_id", apply.ApplyIdentifier,
+							"database", apply.Database,
+							"database_type", apply.DatabaseType,
+							"error", err)
+						return fmt.Errorf("recover deferred cutover apply %s from checkpoint: %w", apply.ApplyIdentifier, err)
+					}
 					return c.handleGroupedResumeFailure(ctx, apply, tasks, fmt.Errorf("recover deferred cutover apply %s from checkpoint: %w", apply.ApplyIdentifier, err), false)
 				}
 				return ctx.Err()
@@ -780,12 +879,20 @@ func (c *LocalClient) resumeApplyWithTasks(ctx context.Context, apply *storage.A
 
 	options := buildApplyOptions(apply)
 
-	if apply.GetOptions().DeferCutover {
+	if c.usesGroupedApply(apply) {
 		resumeCtx, cancelResume := context.WithCancel(ctx)
 		cancelGeneration := c.setApplyCancel(cancelResume)
 		defer c.clearApplyCancel(cancelGeneration)
 		defer cancelResume()
 		if err := c.launchAtomicResume(resumeCtx, apply, activeTasks, plan, options, fmt.Sprintf("Apply resumed from checkpoint (%s)", groupedApplyModeDescription(apply)), true, startRequested); err != nil {
+			if errors.Is(err, errGroupedResumeStateUnavailable) {
+				c.logger.Warn("grouped resume could not load persisted engine resume state; current apply owner will exit for operator retry",
+					"apply_id", apply.ApplyIdentifier,
+					"database", apply.Database,
+					"database_type", apply.DatabaseType,
+					"error", err)
+				return err
+			}
 			return c.handleGroupedResumeFailure(ctx, apply, activeTasks, err, startRequested)
 		}
 	} else {

--- a/pkg/tern/local_control_resume.go
+++ b/pkg/tern/local_control_resume.go
@@ -672,16 +672,30 @@ func (c *LocalClient) groupedResumeState(ctx context.Context, apply *storage.App
 // groupedResumeChanges rebuilds the engine changes for a grouped resume from
 // the stored tasks, grouped per namespace. Tasks carry the authoritative
 // remaining work after re-planning, and engines key per-table progress on
-// namespace and table, so the rebuilt changes must preserve both.
+// namespace and table, so the rebuilt changes must preserve both. VSchema tasks
+// carry no DDL — they are excluded from TableChanges and instead flag their
+// namespace with the vschema_changed metadata so the engine applies vschema.json
+// from the schema files, mirroring how the fresh apply builds changes.
 func groupedResumeChanges(tasks []*storage.Task) []engine.SchemaChange {
 	indexByNamespace := make(map[string]int, len(tasks))
 	var changes []engine.SchemaChange
-	for _, task := range tasks {
-		idx, ok := indexByNamespace[task.Namespace]
+	ensureNamespace := func(namespace string) int {
+		idx, ok := indexByNamespace[namespace]
 		if !ok {
 			idx = len(changes)
-			indexByNamespace[task.Namespace] = idx
-			changes = append(changes, engine.SchemaChange{Namespace: task.Namespace})
+			indexByNamespace[namespace] = idx
+			changes = append(changes, engine.SchemaChange{Namespace: namespace})
+		}
+		return idx
+	}
+	for _, task := range tasks {
+		idx := ensureNamespace(task.Namespace)
+		if isVSchemaTask(task) {
+			if changes[idx].Metadata == nil {
+				changes[idx].Metadata = make(map[string]string)
+			}
+			changes[idx].Metadata["vschema_changed"] = "true"
+			continue
 		}
 		changes[idx].TableChanges = append(changes[idx].TableChanges, engine.TableChange{
 			Table:     task.TableName,
@@ -690,6 +704,13 @@ func groupedResumeChanges(tasks []*storage.Task) []engine.SchemaChange {
 		})
 	}
 	return changes
+}
+
+// isVSchemaTask reports whether a task represents a VSchema update rather than a
+// table DDL change. VSchema tasks have no DDL; their work is applying the
+// namespace's vschema.json.
+func isVSchemaTask(task *storage.Task) bool {
+	return task.DDLAction == "vschema_update"
 }
 
 func (c *LocalClient) notifyTerminalObserver(apply *storage.Apply, tasks []*storage.Task) {


### PR DESCRIPTION
Restart recovery of grouped applies ignored the engine resume state SchemaBot had persisted: the grouped resume path called the engine with a context-only `ResumeState`, polled progress with nil resume state, sent bare DDL strings without namespace/table identity, and `ResumeApply` only used the grouped path for defer-cutover applies. For Vitess this meant a recovered apply opened a new branch and deploy request — duplicating the still-in-flight one — and then polled "no active schema change" forever while its heartbeat kept the lease alive.

- The grouped resume now loads the persisted per-operation engine resume state and hands it to `Apply`, so the engine reattaches to its existing work. Absent state is expected for Spirit (it reattaches via durable checkpoints keyed by the schema change context); a storage read failure aborts the recovery attempt without writing terminal state so a later owner retries against intact storage.
- The engine's returned resume state is persisted and threaded into progress polling, so the recovered apply can observe the deploy request and keep stored state current.
- Resume changes are rebuilt from the stored tasks' namespace/table/DDL, restoring per-table progress matching. VSchema tasks carry no DDL, so they are kept out of the table changes and instead flag their namespace with the `vschema_changed` metadata, matching the fresh apply path so the engine re-applies `vschema.json` on resume instead of executing an empty statement.
- `ResumeApply` dispatches on the same grouped-apply predicate as initial dispatch, so non-defer-cutover Vitess applies recover through one grouped engine apply instead of one fresh apply per task.

```
Before (restart recovery, Vitess):
  ResumeApply ──> eng.Apply(context-only state) ──> new branch + new deploy request (duplicate)
              └─> poll(resume state = nil)      ──> "no active schema change" forever (wedged)

After:
  ResumeApply ──> load persisted resume state ──> eng.Apply(context + metadata)
              │                                    └─> reattaches to existing deploy request
              └─> poll(engine-returned resume state) ──> live progress, updates persisted
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)