### PR TITLE
fix(engine): avoid nil deref when polling PlanetScale deploy requests

### DIFF
--- a/pkg/engine/planetscale/apply.go
+++ b/pkg/engine/planetscale/apply.go
@@ -254,16 +254,9 @@ func (e *Engine) Apply(ctx context.Context, req *engine.ApplyRequest) (*engine.A
 		DeployRequestID:  dr.Number,
 		DeployRequestURL: dr.HtmlURL,
 	})
-	for dr.DeploymentState == deployState.Pending {
-		select {
-		case <-ctx.Done():
-			return nil, fmt.Errorf("context cancelled waiting for deploy request: %w", ctx.Err())
-		case <-time.After(500 * time.Millisecond):
-		}
-		dr, err = e.getDeployRequest(ctx, client, org, req.Database, dr.Number)
-		if err != nil {
-			return nil, fmt.Errorf("poll deploy request %d: %w", dr.Number, err)
-		}
+	dr, err = e.waitForDeployRequestPending(ctx, client, org, req.Database, dr)
+	if err != nil {
+		return nil, err
 	}
 	if dr.DeploymentState == deployState.Error {
 		errMsg := formatDeployRequestError(dr)
@@ -796,12 +789,9 @@ func (e *Engine) resumeApply(ctx context.Context, client psclient.PSClient, org 
 	if err != nil {
 		return nil, fmt.Errorf("create deploy request on resume: %w", err)
 	}
-	for dr.DeploymentState == deployState.Pending {
-		time.Sleep(500 * time.Millisecond)
-		dr, err = e.getDeployRequest(ctx, client, org, req.Database, dr.Number)
-		if err != nil {
-			return nil, fmt.Errorf("poll deploy request %d on resume: %w", dr.Number, err)
-		}
+	dr, err = e.waitForDeployRequestPending(ctx, client, org, req.Database, dr)
+	if err != nil {
+		return nil, fmt.Errorf("wait for deploy request on resume: %w", err)
 	}
 	if dr.DeploymentState == deployState.Error {
 		return nil, fmt.Errorf("deploy request #%d failed on resume (state: %s)", dr.Number, dr.DeploymentState)

--- a/pkg/engine/planetscale/apply_test.go
+++ b/pkg/engine/planetscale/apply_test.go
@@ -2,9 +2,11 @@ package planetscale
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"os"
 	"testing"
+	"time"
 
 	ps "github.com/planetscale/planetscale-go/planetscale"
 	"github.com/stretchr/testify/assert"
@@ -74,4 +76,67 @@ func TestApplyKeyspaceChanges_PermanentVSchemaErrorIsPermanent(t *testing.T) {
 	require.Error(t, err)
 	assert.False(t, engine.IsRetryable(err))
 	assert.Equal(t, 1, client.updateCalls)
+}
+
+// pendingPollClient returns the deploy request as pending on every poll until
+// a configured number of polls have occurred, then returns an error. This
+// drives the pending-poll loop through a transient API failure.
+type pendingPollClient struct {
+	psclient.PSClient
+	number       uint64
+	pollErr      error
+	pollsBefore  int
+	getCallCount int
+}
+
+func (c *pendingPollClient) GetDeployRequest(_ context.Context, req *ps.GetDeployRequestRequest) (*ps.DeployRequest, error) {
+	c.getCallCount++
+	if c.getCallCount > c.pollsBefore {
+		return nil, c.pollErr
+	}
+	return &ps.DeployRequest{Number: req.Number, DeploymentState: deployState.Pending}, nil
+}
+
+// When PlanetScale returns a transient error while a deploy request is still
+// computing its schema diff, the apply worker surfaces a wrapped error
+// identifying the deploy request rather than panicking on a nil response.
+func TestWaitForDeployRequestPending_PollErrorIsWrapped(t *testing.T) {
+	e := New(slog.New(slog.NewTextHandler(os.Stdout, nil)))
+	apiErr := &ps.Error{Code: ps.ErrInternal}
+	client := &pendingPollClient{number: 7, pollErr: apiErr, pollsBefore: 1}
+
+	_, err := e.waitForDeployRequestPending(t.Context(), client, "org", "testdb",
+		&ps.DeployRequest{Number: 7, DeploymentState: deployState.Pending})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "poll deploy request 7")
+	assert.ErrorIs(t, err, apiErr)
+	assert.Equal(t, 2, client.getCallCount)
+}
+
+// A deploy request that never leaves the pending state must not block the apply
+// worker forever — cancelling the context stops the poll and returns a wrapped
+// error naming the deploy request.
+func TestWaitForDeployRequestPending_HonorsContextCancellation(t *testing.T) {
+	e := New(slog.New(slog.NewTextHandler(os.Stdout, nil)))
+	client := &pendingPollClient{number: 9, pollErr: errors.New("unreachable"), pollsBefore: 1_000_000}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := e.waitForDeployRequestPending(ctx, client, "org", "testdb",
+			&ps.DeployRequest{Number: 9, DeploymentState: deployState.Pending})
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		require.Error(t, err)
+		assert.ErrorIs(t, err, context.DeadlineExceeded)
+		assert.Contains(t, err.Error(), "deploy request 9")
+	case <-time.After(5 * time.Second):
+		t.Fatal("waitForDeployRequestPending did not return after context cancellation")
+	}
 }

--- a/pkg/engine/planetscale/apply_test.go
+++ b/pkg/engine/planetscale/apply_test.go
@@ -121,8 +121,8 @@ func TestWaitForDeployRequestPending_HonorsContextCancellation(t *testing.T) {
 	e := New(slog.New(slog.NewTextHandler(os.Stdout, nil)))
 	client := &pendingPollClient{number: 9, pollErr: errors.New("unreachable"), pollsBefore: 1_000_000}
 
-	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
-	defer cancel()
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
 
 	done := make(chan error, 1)
 	go func() {
@@ -134,9 +134,26 @@ func TestWaitForDeployRequestPending_HonorsContextCancellation(t *testing.T) {
 	select {
 	case err := <-done:
 		require.Error(t, err)
-		assert.ErrorIs(t, err, context.DeadlineExceeded)
+		assert.ErrorIs(t, err, context.Canceled)
 		assert.Contains(t, err.Error(), "deploy request 9")
-	case <-time.After(5 * time.Second):
+		assert.Equal(t, 0, client.getCallCount)
+	case <-time.After(500 * time.Millisecond):
 		t.Fatal("waitForDeployRequestPending did not return after context cancellation")
 	}
+}
+
+// A nil deploy request indicates an upstream caller never created or fetched it;
+// the poll loop surfaces a wrapped error naming the database rather than
+// dereferencing nil.
+func TestWaitForDeployRequestPending_NilDeployRequestIsRejected(t *testing.T) {
+	e := New(slog.New(slog.NewTextHandler(os.Stdout, nil)))
+	client := &pendingPollClient{number: 11, pollErr: errors.New("unreachable"), pollsBefore: 1_000_000}
+
+	dr, err := e.waitForDeployRequestPending(t.Context(), client, "org", "testdb", nil)
+
+	require.Error(t, err)
+	assert.Nil(t, dr)
+	assert.Contains(t, err.Error(), "deploy request is nil")
+	assert.Contains(t, err.Error(), "testdb")
+	assert.Equal(t, 0, client.getCallCount)
 }

--- a/pkg/engine/planetscale/branch.go
+++ b/pkg/engine/planetscale/branch.go
@@ -518,3 +518,25 @@ func (e *Engine) getDeployRequest(ctx context.Context, client psclient.PSClient,
 		Number:       number,
 	})
 }
+
+// waitForDeployRequestPending polls a deploy request until PlanetScale finishes
+// computing its schema diff and transitions it out of the pending state. The
+// deploy request number is held in a local so a transient poll error never
+// dereferences a nil deploy request, and the poll honors context cancellation so
+// a deploy stuck in pending does not block indefinitely.
+func (e *Engine) waitForDeployRequestPending(ctx context.Context, client psclient.PSClient, org, database string, dr *ps.DeployRequest) (*ps.DeployRequest, error) {
+	number := dr.Number
+	for dr.DeploymentState == deployState.Pending {
+		select {
+		case <-ctx.Done():
+			return nil, fmt.Errorf("context cancelled waiting for deploy request %d: %w", number, ctx.Err())
+		case <-time.After(deployRequestPollInterval):
+		}
+		next, err := e.getDeployRequest(ctx, client, org, database, number)
+		if err != nil {
+			return nil, fmt.Errorf("poll deploy request %d: %w", number, err)
+		}
+		dr = next
+	}
+	return dr, nil
+}

--- a/pkg/engine/planetscale/branch.go
+++ b/pkg/engine/planetscale/branch.go
@@ -525,12 +525,23 @@ func (e *Engine) getDeployRequest(ctx context.Context, client psclient.PSClient,
 // dereferences a nil deploy request, and the poll honors context cancellation so
 // a deploy stuck in pending does not block indefinitely.
 func (e *Engine) waitForDeployRequestPending(ctx context.Context, client psclient.PSClient, org, database string, dr *ps.DeployRequest) (*ps.DeployRequest, error) {
+	// A nil deploy request means an upstream caller never created or fetched it;
+	// poll has nothing to track, so surface the invariant violation rather than
+	// dereferencing it below.
+	if dr == nil {
+		return nil, fmt.Errorf("wait for deploy request in database %s: deploy request is nil", database)
+	}
+
 	number := dr.Number
+
+	ticker := time.NewTicker(deployRequestPollInterval)
+	defer ticker.Stop()
+
 	for dr.DeploymentState == deployState.Pending {
 		select {
 		case <-ctx.Done():
 			return nil, fmt.Errorf("context cancelled waiting for deploy request %d: %w", number, ctx.Err())
-		case <-time.After(deployRequestPollInterval):
+		case <-ticker.C:
 		}
 		next, err := e.getDeployRequest(ctx, client, org, database, number)
 		if err != nil {

--- a/pkg/engine/planetscale/planetscale.go
+++ b/pkg/engine/planetscale/planetscale.go
@@ -423,6 +423,10 @@ const (
 	// backoff (20s, 40s, 60s, 60s) this gives ~3 minutes of total
 	// wait time before failing.
 	maxSnapshotRetries = 5
+
+	// deployRequestPollInterval is how long to wait between polls while a deploy
+	// request is pending PlanetScale's asynchronous schema diff computation.
+	deployRequestPollInterval = 500 * time.Millisecond
 )
 
 // deployState is a shorthand alias for PlanetScale deploy request state constants.


### PR DESCRIPTION
The PlanetScale apply worker polls a newly created deploy request until it leaves the `pending` state. Both the fresh-apply and resume-apply poll loops overwrote the deploy request with the poll result before checking the error, then read the deploy request number off that value to format the error message. Since the poll helper returns a nil deploy request on failure, a single transient API error during polling panicked the apply worker.

- Both poll sites now share a `waitForDeployRequestPending` helper that captures the deploy request number in a local before the loop, so a nil result is never dereferenced when building the error. The helper also rejects a nil deploy request up front with a wrapped error rather than dereferencing it.
- The helper honors context cancellation between polls, so a deploy stuck in `pending` no longer blocks the worker indefinitely (the resume path previously used a bare sleep with no cancellation check). Polling uses a single reusable ticker stopped on return, matching `waitForBranchReady`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)