### PR TITLE
fix(spirit): preserve stopped state and run pending drops on resume

### DIFF
--- a/pkg/engine/spirit/control.go
+++ b/pkg/engine/spirit/control.go
@@ -107,7 +107,7 @@ func (e *Engine) Start(ctx context.Context, req *engine.ControlRequest) (*engine
 	password := rm.password
 	database := rm.database
 	tables := rm.tables
-	ddls := rm.ddls
+	originalDDLs := rm.originalDDLs
 	combinedStatement := rm.combinedStatement
 	deferCutover := rm.deferCutover
 	e.mu.Unlock()
@@ -133,10 +133,6 @@ func (e *Engine) Start(ctx context.Context, req *engine.ControlRequest) (*engine
 		"tables", tables,
 	)
 
-	// Update state under the lock before launching goroutine.
-	// Use the stored combined statement directly (not executeMigration) to avoid
-	// re-parsing DDLs through statement.New(), which can normalize formatting and
-	// cause Spirit checkpoint mismatches ("alter statement does not match").
 	e.mu.Lock()
 	rm.state = engine.StateRunning
 	e.mu.Unlock()
@@ -149,11 +145,7 @@ func (e *Engine) Start(ctx context.Context, req *engine.ControlRequest) (*engine
 			e.runningMigration.cancelFunc = cancel
 		}
 		e.mu.Unlock()
-		if combinedStatement != "" {
-			_ = e.executeSpiritMigration(bgCtx, host, username, password, database, combinedStatement, deferCutover)
-		} else {
-			e.executeMigration(bgCtx, host, username, password, database, ddls, deferCutover)
-		}
+		e.resumeMigration(bgCtx, host, username, password, database, originalDDLs, combinedStatement, deferCutover)
 	})
 
 	return &engine.ControlResult{

--- a/pkg/engine/spirit/execution.go
+++ b/pkg/engine/spirit/execution.go
@@ -47,6 +47,16 @@ func (e *Engine) executeMigration(ctx context.Context, host, username, password,
 	// Execute CREATE TABLE statements first (each individually through Spirit)
 	for _, stmt := range createStatements {
 		if err := e.executeSingleStatement(ctx, host, username, password, database, stmt); err != nil {
+			// A cancelled context means the operator stopped the change; engine
+			// state must remain Stopped and later phases must not run. Only a
+			// genuine failure (context still live) transitions to StateFailed.
+			if ctx.Err() != nil {
+				e.logger.Info("schema change stopped during CREATE TABLE",
+					"database", database,
+					"reason", ctx.Err(),
+				)
+				return
+			}
 			e.logger.Error("CREATE TABLE failed", "error", err)
 			e.setMigrationFailed(fmt.Errorf("CREATE TABLE failed: %w", err))
 			return
@@ -90,6 +100,16 @@ func (e *Engine) executeMigration(ctx context.Context, host, username, password,
 	for _, stmt := range dropStatements {
 		if e.disablePendingDrops {
 			if err := e.executeSingleStatement(ctx, host, username, password, database, stmt); err != nil {
+				// A cancelled context means the operator stopped the change; engine
+				// state must remain Stopped and later phases must not run. Only a
+				// genuine failure (context still live) transitions to StateFailed.
+				if ctx.Err() != nil {
+					e.logger.Info("schema change stopped during DROP TABLE",
+						"database", database,
+						"reason", ctx.Err(),
+					)
+					return
+				}
 				e.logger.Error("DROP TABLE failed", "error", err)
 				e.setMigrationFailed(fmt.Errorf("DROP TABLE failed: %w", err))
 				return
@@ -97,10 +117,30 @@ func (e *Engine) executeMigration(ctx context.Context, host, username, password,
 			continue
 		}
 		if err := e.quarantineDroppedTables(ctx, host, username, password, database, stmt); err != nil {
+			// A cancelled context means the operator stopped the change; engine
+			// state must remain Stopped and later phases must not run. Only a
+			// genuine failure (context still live) transitions to StateFailed.
+			if ctx.Err() != nil {
+				e.logger.Info("schema change stopped during DROP TABLE",
+					"database", database,
+					"reason", ctx.Err(),
+				)
+				return
+			}
 			e.logger.Error("DROP TABLE quarantine failed", "error", err)
 			e.setMigrationFailed(fmt.Errorf("DROP TABLE quarantine failed: %w", err))
 			return
 		}
+	}
+
+	// A cancelled context means the operator stopped the change; engine state
+	// must remain Stopped, so do not overwrite it with StateCompleted.
+	if ctx.Err() != nil {
+		e.logger.Info("schema change stopped before completion",
+			"database", database,
+			"reason", ctx.Err(),
+		)
+		return
 	}
 
 	// If we had no ALTER statements (only CREATE/DROP), mark as completed

--- a/pkg/engine/spirit/execution.go
+++ b/pkg/engine/spirit/execution.go
@@ -20,117 +20,30 @@ import (
 // Spirit requires non-ALTER statements to be executed individually (not combined).
 // ALTER statements can be combined for atomic multi-table schema changes.
 func (e *Engine) executeMigration(ctx context.Context, host, username, password, database string, ddlStatements []string, deferCutover bool) {
-	// Categorize DDL statements using AST-based classification
-	// Spirit requires non-ALTER to be individual
-	var createStatements []string
-	var dropStatements []string
-	var alterStatements []string
-
-	for _, stmt := range ddlStatements {
-		stmtType, _, err := ddl.ClassifyStatement(stmt)
-		if err != nil {
-			e.logger.Error("failed to classify statement", "error", err, "statement", stmt)
-			e.setMigrationFailed(err)
-			return
-		}
-		switch stmtType {
-		case statement.StatementCreateTable:
-			createStatements = append(createStatements, stmt)
-		case statement.StatementDropTable:
-			dropStatements = append(dropStatements, stmt)
-		default:
-			// ALTER TABLE, RENAME TABLE, and unknown go here
-			alterStatements = append(alterStatements, stmt)
-		}
+	phases, err := classifyDDLPhases(ddlStatements)
+	if err != nil {
+		e.logger.Error("failed to classify statement", "error", err)
+		e.setMigrationFailed(err)
+		return
 	}
 
-	// Execute CREATE TABLE statements first (each individually through Spirit)
-	for _, stmt := range createStatements {
-		if err := e.executeSingleStatement(ctx, host, username, password, database, stmt); err != nil {
-			// A cancelled context means the operator stopped the change; engine
-			// state must remain Stopped and later phases must not run. Only a
-			// genuine failure (context still live) transitions to StateFailed.
-			if ctx.Err() != nil {
-				e.logger.Info("schema change stopped during CREATE TABLE",
-					"database", database,
-					"reason", ctx.Err(),
-				)
-				return
-			}
-			e.logger.Error("CREATE TABLE failed", "error", err)
-			e.setMigrationFailed(fmt.Errorf("CREATE TABLE failed: %w", err))
+	// Execute CREATE TABLE statements first (each individually through Spirit).
+	if !e.executeCreateStatements(ctx, host, username, password, database, phases.creates) {
+		return
+	}
+
+	// Execute ALTER statements (combined for atomic multi-table execution).
+	if len(phases.alters) > 0 {
+		if !e.executeAlterPhase(ctx, host, username, password, database, phases.alters, deferCutover) {
 			return
 		}
 	}
 
-	// Execute ALTER statements (can be combined for atomic execution)
-	if len(alterStatements) > 0 {
-		combinedStatement := strings.Join(alterStatements, "; ")
-
-		// Parse statements to extract table names for logging
-		var tables []string
-		for _, stmt := range alterStatements {
-			parsed, err := statement.New(stmt)
-			if err != nil {
-				e.logger.Error("failed to parse statement for logging", "error", err, "statement", stmt)
-				e.setMigrationFailed(fmt.Errorf("failed to parse statement: %w", err))
-				return
-			}
-			if len(parsed) > 0 {
-				tables = append(tables, parsed[0].Table)
-			}
-		}
-
-		e.logger.Info("executing ALTER via Spirit",
-			"database", database,
-			"tables", tables,
-			"ddl_count", len(alterStatements),
-			"defer_cutover", deferCutover,
-		)
-
-		if err := e.executeSpiritMigration(ctx, host, username, password, database, combinedStatement, deferCutover); err != nil {
-			return // Error already logged and state set
-		}
-	}
-
-	// Execute DROP TABLE statements last. By default the table is quarantined
-	// in the pending drops database instead of dropped, so its data stays
-	// recoverable until the retention period expires. When pending drops is
-	// disabled, the DROP executes directly through Spirit.
-	for _, stmt := range dropStatements {
-		if e.disablePendingDrops {
-			if err := e.executeSingleStatement(ctx, host, username, password, database, stmt); err != nil {
-				// A cancelled context means the operator stopped the change; engine
-				// state must remain Stopped and later phases must not run. Only a
-				// genuine failure (context still live) transitions to StateFailed.
-				if ctx.Err() != nil {
-					e.logger.Info("schema change stopped during DROP TABLE",
-						"database", database,
-						"reason", ctx.Err(),
-					)
-					return
-				}
-				e.logger.Error("DROP TABLE failed", "error", err)
-				e.setMigrationFailed(fmt.Errorf("DROP TABLE failed: %w", err))
-				return
-			}
-			continue
-		}
-		if err := e.quarantineDroppedTables(ctx, host, username, password, database, stmt); err != nil {
-			// A cancelled context means the operator stopped the change; engine
-			// state must remain Stopped and later phases must not run. Only a
-			// genuine failure (context still live) transitions to StateFailed.
-			if ctx.Err() != nil {
-				e.logger.Info("schema change stopped during DROP TABLE",
-					"database", database,
-					"reason", ctx.Err(),
-				)
-				return
-			}
-			e.logger.Error("DROP TABLE quarantine failed", "error", err)
-			e.setMigrationFailed(fmt.Errorf("DROP TABLE quarantine failed: %w", err))
-			return
-		}
+	// Execute DROP TABLE statements last. By default each table is quarantined
+	// in the pending drops database instead of dropped; when pending drops is
+	// disabled the DROP runs directly through Spirit.
+	if !e.executeDropStatements(ctx, host, username, password, database, phases.drops) {
+		return
 	}
 
 	// A cancelled context means the operator stopped the change; engine state
@@ -143,10 +56,184 @@ func (e *Engine) executeMigration(ctx context.Context, host, username, password,
 		return
 	}
 
-	// If we had no ALTER statements (only CREATE/DROP), mark as completed
-	if len(alterStatements) == 0 {
-		e.setMigrationState(engine.StateCompleted)
+	// Completion is signalled only after every phase has run, so a poller never
+	// observes StateCompleted while a later DROP phase is still pending.
+	e.setMigrationState(engine.StateCompleted)
+}
+
+// resumeMigration continues a stopped schema change to completion.
+//
+// When an ALTER was in flight, its statements are resumed from Spirit's
+// checkpoint using the stored verbatim combined statement (not the original DDL
+// list) so the statement string matches the checkpoint exactly — re-parsing
+// through statement.New() can normalize formatting and trip Spirit's "alter
+// statement does not match" guard. CREATE statements always run before the ALTER
+// phase, so once an ALTER has started they are already applied; only the DROP
+// phase remains and must run after the resumed ALTER completes. When no ALTER was
+// in flight, the whole plan is run from the start.
+func (e *Engine) resumeMigration(ctx context.Context, host, username, password, database string, originalDDLs []string, combinedStatement string, deferCutover bool) {
+	if combinedStatement == "" {
+		e.executeMigration(ctx, host, username, password, database, originalDDLs, deferCutover)
+		return
 	}
+
+	if err := e.executeSpiritMigration(ctx, host, username, password, database, combinedStatement, deferCutover); err != nil {
+		return // Error already logged and state set; on stop the state stays Stopped.
+	}
+
+	// A stop during the resumed ALTER cancels the context; leave the state
+	// Stopped and do not run the pending DROP phase.
+	if ctx.Err() != nil {
+		e.logger.Info("schema change stopped during resumed ALTER",
+			"database", database,
+			"reason", ctx.Err(),
+		)
+		return
+	}
+
+	phases, err := classifyDDLPhases(originalDDLs)
+	if err != nil {
+		e.logger.Error("failed to classify statements on resume", "database", database, "error", err)
+		e.setMigrationFailed(err)
+		return
+	}
+
+	if !e.executeDropStatements(ctx, host, username, password, database, phases.drops) {
+		return
+	}
+
+	if ctx.Err() != nil {
+		e.logger.Info("schema change stopped before completion",
+			"database", database,
+			"reason", ctx.Err(),
+		)
+		return
+	}
+
+	e.setMigrationState(engine.StateCompleted)
+}
+
+// ddlPhases groups a plan's statements into the order Spirit requires:
+// CREATE first, then ALTER (combined), then DROP.
+type ddlPhases struct {
+	creates []string
+	alters  []string
+	drops   []string
+}
+
+// classifyDDLPhases groups DDL statements into CREATE/ALTER/DROP phases using
+// AST-based classification. RENAME and unrecognized statements run in the ALTER
+// phase, matching Spirit's handling.
+func classifyDDLPhases(ddlStatements []string) (ddlPhases, error) {
+	var phases ddlPhases
+	for _, stmt := range ddlStatements {
+		stmtType, _, err := ddl.ClassifyStatement(stmt)
+		if err != nil {
+			return ddlPhases{}, fmt.Errorf("classify statement %q: %w", stmt, err)
+		}
+		switch stmtType {
+		case statement.StatementCreateTable:
+			phases.creates = append(phases.creates, stmt)
+		case statement.StatementDropTable:
+			phases.drops = append(phases.drops, stmt)
+		default:
+			phases.alters = append(phases.alters, stmt)
+		}
+	}
+	return phases, nil
+}
+
+// executeCreateStatements runs each CREATE TABLE through Spirit. It returns false
+// when execution should stop: a cancelled context leaves the state Stopped, a
+// genuine failure transitions to StateFailed. The caller must not run later
+// phases when this returns false.
+func (e *Engine) executeCreateStatements(ctx context.Context, host, username, password, database string, creates []string) bool {
+	for _, stmt := range creates {
+		if err := e.executeSingleStatement(ctx, host, username, password, database, stmt); err != nil {
+			if ctx.Err() != nil {
+				e.logger.Info("schema change stopped during CREATE TABLE",
+					"database", database,
+					"reason", ctx.Err(),
+				)
+				return false
+			}
+			e.logger.Error("CREATE TABLE failed", "database", database, "error", err)
+			e.setMigrationFailed(fmt.Errorf("CREATE TABLE failed: %w", err))
+			return false
+		}
+	}
+	return true
+}
+
+// executeAlterPhase combines the ALTER statements and runs them through Spirit.
+// It returns true when the ALTER ran and the caller may proceed to the DROP
+// phase, and false on a genuine failure (executeSpiritMigration has already set
+// StateFailed). A stop cancels the context but returns true; the caller's later
+// ctx.Err() checks then keep the state Stopped without running further phases.
+func (e *Engine) executeAlterPhase(ctx context.Context, host, username, password, database string, alters []string, deferCutover bool) bool {
+	combinedStatement := strings.Join(alters, "; ")
+
+	var tables []string
+	for _, stmt := range alters {
+		parsed, err := statement.New(stmt)
+		if err != nil {
+			e.logger.Error("failed to parse statement for logging", "database", database, "error", err, "statement", stmt)
+			e.setMigrationFailed(fmt.Errorf("parse ALTER statement %q: %w", stmt, err))
+			return false
+		}
+		if len(parsed) > 0 {
+			tables = append(tables, parsed[0].Table)
+		}
+	}
+
+	e.logger.Info("executing ALTER via Spirit",
+		"database", database,
+		"tables", tables,
+		"ddl_count", len(alters),
+		"defer_cutover", deferCutover,
+	)
+
+	return e.executeSpiritMigration(ctx, host, username, password, database, combinedStatement, deferCutover) == nil
+}
+
+// executeDropStatements runs the DROP TABLE phase. By default each table is
+// quarantined in the pending drops database so its data stays recoverable until
+// the retention period expires; when pending drops is disabled the DROP runs
+// directly through Spirit. Both the initial-apply DROP phase and the resume DROP
+// phase call this helper, so a resumed DROP quarantines exactly like an initial
+// one. It returns false when execution should stop: a cancelled context leaves
+// the state Stopped, a genuine failure transitions to StateFailed.
+func (e *Engine) executeDropStatements(ctx context.Context, host, username, password, database string, drops []string) bool {
+	for _, stmt := range drops {
+		if err := e.executeDropStatement(ctx, host, username, password, database, stmt); err != nil {
+			if ctx.Err() != nil {
+				e.logger.Info("schema change stopped during DROP TABLE",
+					"database", database,
+					"reason", ctx.Err(),
+				)
+				return false
+			}
+			e.logger.Error("DROP TABLE phase failed", "database", database, "error", err)
+			e.setMigrationFailed(fmt.Errorf("DROP TABLE phase failed: %w", err))
+			return false
+		}
+	}
+	return true
+}
+
+// executeDropStatement runs a single DROP TABLE statement, quarantining the
+// table by default and dropping it directly only when pending drops is disabled.
+func (e *Engine) executeDropStatement(ctx context.Context, host, username, password, database, stmt string) error {
+	if e.disablePendingDrops {
+		if err := e.executeSingleStatement(ctx, host, username, password, database, stmt); err != nil {
+			return fmt.Errorf("drop table directly: %w", err)
+		}
+		return nil
+	}
+	if err := e.quarantineDroppedTables(ctx, host, username, password, database, stmt); err != nil {
+		return fmt.Errorf("quarantine dropped table: %w", err)
+	}
+	return nil
 }
 
 // executeSingleStatement runs a single DDL statement through Spirit.
@@ -285,9 +372,8 @@ func (e *Engine) executeSpiritMigration(ctx context.Context, host, username, pas
 		return err
 	}
 
-	e.setMigrationState(engine.StateCompleted)
 	utils.CloseAndLog(runner)
-	e.logger.Info("schema change completed", "database", database, "tables", tables)
+	e.logger.Info("ALTER phase completed", "database", database, "tables", tables)
 	return nil
 }
 

--- a/pkg/engine/spirit/spirit.go
+++ b/pkg/engine/spirit/spirit.go
@@ -71,6 +71,7 @@ type runningMigration struct {
 	tableNamespace          map[string]string // table name → namespace (from ApplyRequest.Changes)
 	tables                  []string
 	ddls                    []string // DDL statement for each table
+	originalDDLs            []string // Full statement list from Apply, in execution order; never overwritten so resume can run the whole plan
 	combinedStatement       string   // Original combined statement passed to Spirit (for checkpoint-safe restart)
 	runners                 []*spiritmigration.Runner
 	progressCallback        func() string // returns Summary from Spirit's Progress API
@@ -391,6 +392,7 @@ func (e *Engine) Apply(ctx context.Context, req *engine.ApplyRequest) (*engine.A
 		database:       database,
 		tableNamespace: tableNamespace,
 		tables:         nil, // Tables will be populated by executeMigration
+		originalDDLs:   req.FlatDDL(),
 		state:          engine.StateRunning,
 		started:        time.Now(),
 		deferCutover:   deferCutover,

--- a/pkg/engine/spirit/spirit_integration_test.go
+++ b/pkg/engine/spirit/spirit_integration_test.go
@@ -1518,6 +1518,184 @@ func TestEngine_Volume_PreservesProgress(t *testing.T) {
 	// Migration cleanup happens automatically when the test ends and the container is stopped
 }
 
+// When an operator stops a schema change, the engine cancels the execution
+// context. A CREATE/DROP-only change must treat that cancellation as a stop:
+// the stored state stays Stopped and the pending CREATE/DROP statements never
+// run, so the change can be resumed rather than wedged in Failed.
+func TestEngine_ExecuteMigration_CancelledContextKeepsStoppedState(t *testing.T) {
+	dsn, db := setupTestMySQL(t)
+	cleanupTables(t, db)
+
+	_, err := db.ExecContext(t.Context(), `CREATE TABLE stop_pending_drop (
+		id INT PRIMARY KEY AUTO_INCREMENT,
+		name VARCHAR(100) NOT NULL
+	)`)
+	require.NoError(t, err, "create table")
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	eng := New(Config{Logger: logger})
+
+	host, username, password, database, err := parseDSN(dsn)
+	require.NoError(t, err, "parseDSN")
+
+	eng.mu.Lock()
+	eng.runningMigration = &runningMigration{
+		database: database,
+		tables:   []string{"stop_pending_drop"},
+		state:    engine.StateStopped,
+		started:  time.Now(),
+	}
+	eng.mu.Unlock()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	ddlStatements := []string{
+		"CREATE TABLE `stop_pending_create` (`id` INT PRIMARY KEY AUTO_INCREMENT) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci",
+		"DROP TABLE `stop_pending_drop`",
+	}
+
+	eng.executeMigration(ctx, host, username, password, database, ddlStatements, false)
+
+	eng.mu.Lock()
+	finalState := eng.runningMigration.state
+	eng.mu.Unlock()
+	assert.Equal(t, engine.StateStopped, finalState, "cancelled context must leave state Stopped, not Failed/Completed")
+
+	assert.False(t, testutil.TableExists(t, db, "testdb", "stop_pending_create"),
+		"CREATE TABLE must not run after the context is cancelled")
+	assert.True(t, testutil.TableExists(t, db, "testdb", "stop_pending_drop"),
+		"DROP TABLE must not run after the context is cancelled")
+}
+
+// Stopping a running ALTER that has a DROP TABLE queued after it must leave the
+// change in Stopped, never Failed/Completed: the post-ALTER DROP phase sees the
+// cancelled context and must not overwrite the operator-set Stopped state. The
+// change must then be resumable from its checkpoint.
+func TestEngine_Stop_DuringAlterWithPendingDrop(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running integration test in short mode")
+	}
+
+	dsn, db := setupTestMySQL(t)
+	cleanupTables(t, db)
+
+	_, err := db.ExecContext(t.Context(), `CREATE TABLE stop_alter_target (
+		id INT PRIMARY KEY AUTO_INCREMENT,
+		name VARCHAR(50) NOT NULL,
+		data VARCHAR(500) NOT NULL
+	)`)
+	require.NoError(t, err, "create alter target table")
+
+	_, err = db.ExecContext(t.Context(), `CREATE TABLE stop_drop_target (
+		id INT PRIMARY KEY AUTO_INCREMENT
+	)`)
+	require.NoError(t, err, "create drop target table")
+
+	// Seed enough rows that the ALTER table copy is observably in-flight when we
+	// stop it, so the stop lands during the ALTER phase before the DROP phase.
+	seedTableRows(t, db, "stop_alter_target")
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	eng := New(Config{
+		Logger:          logger,
+		TargetChunkTime: 100 * time.Millisecond,
+		Threads:         1,
+	})
+
+	ctx := t.Context()
+
+	applyResult, err := eng.Apply(ctx, &engine.ApplyRequest{
+		Database: "testdb",
+		Changes: []engine.SchemaChange{
+			{
+				Namespace: "testdb",
+				TableChanges: []engine.TableChange{
+					{Table: "stop_alter_target", DDL: "ALTER TABLE `stop_alter_target` MODIFY COLUMN `name` varchar(100) NOT NULL"},
+					{Table: "stop_drop_target", DDL: "DROP TABLE `stop_drop_target`"},
+				},
+			},
+		},
+		Credentials: &engine.Credentials{DSN: dsn},
+	})
+	require.NoError(t, err, "Apply()")
+	defer eng.Drain()
+	require.True(t, applyResult.Accepted, "Apply not accepted: %s", applyResult.Message)
+
+	// Wait until the ALTER copy is observably in-flight before stopping, so the
+	// stop lands mid-ALTER (the DROP phase has not yet started).
+	deadline := time.Now().Add(30 * time.Second)
+	copying := false
+	for time.Now().Before(deadline) {
+		progress, perr := eng.Progress(ctx, &engine.ProgressRequest{})
+		require.NoError(t, perr, "Progress()")
+		require.NotEqual(t, engine.StateFailed, progress.State, "apply failed before stop: %s", progress.ErrorMessage)
+		if progress.State == engine.StateCompleted {
+			t.Skip("schema change completed before it could be stopped mid-flight")
+		}
+		if len(progress.Tables) > 0 && progress.Tables[0].RowsCopied > 0 {
+			copying = true
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	require.True(t, copying, "ALTER copy did not become observably in-flight within deadline")
+
+	stopResult, err := eng.Stop(ctx, &engine.ControlRequest{Database: "testdb"})
+	require.NoError(t, err, "Stop()")
+	require.True(t, stopResult.Accepted, "Stop not accepted: %s", stopResult.Message)
+
+	// Stop() waits for the goroutine to exit, so the final state is settled here.
+	progress, err := eng.Progress(ctx, &engine.ProgressRequest{})
+	require.NoError(t, err, "Progress() after stop")
+	assert.Equal(t, engine.StateStopped, progress.State,
+		"stopping mid-ALTER with a pending DROP must report Stopped, not %s", progress.State)
+
+	// The pending DROP must not have run — its table must still exist.
+	assert.True(t, testutil.TableExists(t, db, "testdb", "stop_drop_target"),
+		"pending DROP must not run when the change is stopped mid-ALTER")
+
+	// A stopped change must be resumable; it must not be wedged in a state that
+	// Start() refuses (e.g. failed).
+	startResult, err := eng.Start(ctx, &engine.ControlRequest{
+		Database:    "testdb",
+		Credentials: &engine.Credentials{DSN: dsn},
+	})
+	require.NoError(t, err, "Start() must permit resume of a stopped change")
+	assert.True(t, startResult.Accepted, "resume not accepted: %s", startResult.Message)
+}
+
+// seedTableRows inserts enough rows that a Spirit table copy on the table is
+// observably in-flight across several progress polls. The (name, data) columns
+// match the tables seeded for stop-mid-flight scenarios.
+func seedTableRows(t *testing.T, db *sql.DB, tableName string) {
+	t.Helper()
+
+	seqGen := `(SELECT @row := @row + 1 AS seq FROM
+		(SELECT 0 UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) a,
+		(SELECT 0 UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) b,
+		(SELECT 0 UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) c,
+		(SELECT 0 UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) d,
+		(SELECT 0 UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) e,
+		(SELECT 0 UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) f,
+		(SELECT @row := 0) r) nums`
+
+	const rowCount = 500000
+	query := fmt.Sprintf(
+		"INSERT INTO `%s` (name, data) SELECT CONCAT('name-', seq), REPEAT('x', 400) FROM %s LIMIT %d",
+		tableName, seqGen, rowCount,
+	)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancel()
+	_, err := db.ExecContext(ctx, query)
+	require.NoError(t, err, "seed %d rows into %s", rowCount, tableName)
+
+	var rows int
+	require.NoError(t, db.QueryRowContext(t.Context(), fmt.Sprintf("SELECT COUNT(*) FROM `%s`", tableName)).Scan(&rows), "count seeded rows")
+	require.GreaterOrEqual(t, rows, rowCount, "expected at least %d seeded rows", rowCount)
+}
+
 func containsAddColumn(ddl, column string) bool {
 	// Simple check - in real code would use proper parsing
 	return contains(ddl, "ADD") && contains(ddl, column)

--- a/pkg/engine/spirit/spirit_integration_test.go
+++ b/pkg/engine/spirit/spirit_integration_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/testcontainers/testcontainers-go/wait"
 
 	"github.com/block/schemabot/pkg/engine"
+	"github.com/block/schemabot/pkg/pendingdrops"
 	"github.com/block/schemabot/pkg/schema"
 	"github.com/block/schemabot/pkg/testutil"
 
@@ -1579,11 +1580,11 @@ func TestEngine_Stop_DuringAlterWithPendingDrop(t *testing.T) {
 
 	dsn, db := setupTestMySQL(t)
 	cleanupTables(t, db)
+	cleanupPendingDropsDB(t, db)
 
 	_, err := db.ExecContext(t.Context(), `CREATE TABLE stop_alter_target (
 		id INT PRIMARY KEY AUTO_INCREMENT,
-		name VARCHAR(50) NOT NULL,
-		data VARCHAR(500) NOT NULL
+		name VARCHAR(50) NOT NULL
 	)`)
 	require.NoError(t, err, "create alter target table")
 
@@ -1655,19 +1656,65 @@ func TestEngine_Stop_DuringAlterWithPendingDrop(t *testing.T) {
 	assert.True(t, testutil.TableExists(t, db, "testdb", "stop_drop_target"),
 		"pending DROP must not run when the change is stopped mid-ALTER")
 
-	// A stopped change must be resumable; it must not be wedged in a state that
-	// Start() refuses (e.g. failed).
+	// Resuming a stopped change must finish the entire plan from its checkpoint:
+	// complete the ALTER and then run the queued DROP phase. The default DROP
+	// behavior quarantines the table into the pending drops database rather than
+	// dropping it, so a resume that only finishes the ALTER and skips the DROP
+	// phase would leave the table unquarantined. The test waits for completion and
+	// verifies both effects.
 	startResult, err := eng.Start(ctx, &engine.ControlRequest{
 		Database:    "testdb",
 		Credentials: &engine.Credentials{DSN: dsn},
 	})
 	require.NoError(t, err, "Start() must permit resume of a stopped change")
-	assert.True(t, startResult.Accepted, "resume not accepted: %s", startResult.Message)
+	require.True(t, startResult.Accepted, "resume not accepted: %s", startResult.Message)
+
+	resumeDeadline := time.Now().Add(5 * time.Minute)
+	var finalState engine.State
+	for time.Now().Before(resumeDeadline) {
+		progress, perr := eng.Progress(ctx, &engine.ProgressRequest{})
+		require.NoError(t, perr, "Progress() during resume")
+		finalState = progress.State
+		require.NotEqual(t, engine.StateFailed, finalState, "resume failed: %s", progress.ErrorMessage)
+		if finalState == engine.StateCompleted {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	require.Equal(t, engine.StateCompleted, finalState,
+		"resumed change must run to completion, not stall in %s", finalState)
+
+	// The ALTER's effect must be present: the resumed copy must finish widening
+	// name from varchar(50) to varchar(100).
+	var nameLen int
+	require.NoError(t, db.QueryRowContext(t.Context(), `
+		SELECT CHARACTER_MAXIMUM_LENGTH FROM information_schema.COLUMNS
+		WHERE TABLE_SCHEMA = 'testdb'
+		AND TABLE_NAME = 'stop_alter_target'
+		AND COLUMN_NAME = 'name'
+	`).Scan(&nameLen), "read name column length")
+	assert.Equal(t, 100, nameLen, "resumed ALTER must widen name to varchar(100)")
+
+	// The queued DROP phase must run on resume: its target table is quarantined
+	// into the pending drops database, so it is gone from the source database and
+	// present in the pending drops database with a parseable timestamp prefix.
+	assert.False(t, testutil.TableExists(t, db, "testdb", "stop_drop_target"),
+		"resumed DROP phase must remove stop_drop_target from the source database")
+
+	quarantined := listQuarantinedTables(t, db)
+	require.Len(t, quarantined, 1, "resumed DROP phase must quarantine exactly one table")
+	assert.Contains(t, quarantined[0], "_stop_drop_target",
+		"quarantined table name must carry the dropped table's name")
+	_, ok := pendingdrops.ParseTimestamp(quarantined[0])
+	assert.True(t, ok, "quarantine table name %q must carry a parseable timestamp", quarantined[0])
 }
 
-// seedTableRows inserts enough rows that a Spirit table copy on the table is
-// observably in-flight across several progress polls. The (name, data) columns
-// match the tables seeded for stop-mid-flight scenarios.
+// seedTableRows inserts enough narrow rows that a Spirit table copy on the table
+// stays observably in-flight across several progress polls, so a stop reliably
+// lands mid-copy. Rows are intentionally narrow (no large payload) so both the
+// seed and a subsequent resume-to-completion copy stay well within the suite
+// timeout. The seeded column matches the tables used for stop-mid-flight
+// scenarios.
 func seedTableRows(t *testing.T, db *sql.DB, tableName string) {
 	t.Helper()
 
@@ -1682,7 +1729,7 @@ func seedTableRows(t *testing.T, db *sql.DB, tableName string) {
 
 	const rowCount = 500000
 	query := fmt.Sprintf(
-		"INSERT INTO `%s` (name, data) SELECT CONCAT('name-', seq), REPEAT('x', 400) FROM %s LIMIT %d",
+		"INSERT INTO `%s` (name) SELECT CONCAT('name-', seq) FROM %s LIMIT %d",
 		tableName, seqGen, rowCount,
 	)
 


### PR DESCRIPTION
Stopping a Spirit schema change cancels the execution context and sets the stored state to `Stopped`. `executeMigration` runs CREATE statements, then ALTERs, then DROP statements. The ALTER phase already treated a cancelled context as a stop and returned without touching engine state, but the CREATE and DROP loops did not — `executeSingleStatement` failed with `context canceled` and overwrote `Stopped` with `Failed`. The trailing completion tail could likewise overwrite `Stopped` with `Completed` for CREATE/DROP-only changes. The result: a stopped change reported `Failed`/`Completed`, and resume was refused.

Each phase now treats a cancelled context as a stop and returns without mutating engine state, so `Stopped` is preserved and later phases don't run. Only a genuine failure (context still live) transitions to `Failed`, and completion is only recorded when the context is live — making a stopped change resumable again.

```
CREATE → ALTER → DROP → complete
  │        │       │        │
  └────────┴───────┴────────┴── ctx cancelled? return, leave state Stopped
```

**Resume now honors the full plan.** Hardening the stop test surfaced a related defect: on resume the engine ran only the ALTER and silently skipped the queued DROP, and `Progress()` could report `Completed` off the ALTER runner reaching `Close` while the DROP phase was still pending. Resume now runs the pending DROP after the ALTER finishes from its checkpoint, and completion is reported only after every phase has run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
