### PR TITLE
fix(operator): write apply_operations row when creating applies via the Tern client

### DIFF
--- a/pkg/tern/local_client.go
+++ b/pkg/tern/local_client.go
@@ -611,6 +611,11 @@ func (c *LocalClient) Apply(ctx context.Context, req *ternv1.ApplyRequest) (*ter
 	// claimable, resumable operation. CreateWithTasksAndOperations links each
 	// task to the single operation via ApplyOperationID, which the engine
 	// resume-state path requires and the operator claim loop selects on.
+	//
+	// CutoverPolicy and HaltOnFailure are intentionally left unset: the Tern
+	// client has no environment config to resolve them from (unlike the API
+	// apply path), so the store applies its safe defaults (rolling cutover,
+	// halt on failure).
 	operations := []*storage.ApplyOperation{{
 		Deployment: apply.Deployment,
 		Target:     plan.Target,

--- a/pkg/tern/local_client.go
+++ b/pkg/tern/local_client.go
@@ -538,7 +538,21 @@ func (c *LocalClient) Apply(ctx context.Context, req *ternv1.ApplyRequest) (*ter
 	}
 	optionsJSON := storage.MarshalApplyOptions(applyOpts)
 
-	// Create Apply record first (1 Apply -> N Tasks)
+	// Create VSchema tasks for namespaces with VSchema changes so the
+	// progress API and TUI can track VSchema application alongside DDL.
+	// For VSchema-only deploys (0 DDL changes), this gives the progress API
+	// something to track.
+	for ns, nsData := range plan.Namespaces {
+		if len(nsData.VSchema) > 0 {
+			ddlChanges = append(ddlChanges, storage.TableChange{
+				Table:     "VSchema: " + ns,
+				Namespace: ns,
+				Operation: "vschema_update",
+			})
+		}
+	}
+
+	// Build the Apply record (1 Apply -> N Tasks).
 	applyIdentifier := "apply-" + strings.ReplaceAll(uuid.New().String(), "-", "")[:16]
 	apply := &storage.Apply{
 		ApplyIdentifier: applyIdentifier,
@@ -556,19 +570,7 @@ func (c *LocalClient) Apply(ctx context.Context, req *ternv1.ApplyRequest) (*ter
 		CreatedAt:       now,
 		UpdatedAt:       now,
 	}
-	applyID, err := c.storage.Applies().Create(ctx, apply)
-	if err != nil {
-		return nil, fmt.Errorf("create apply: %w", err)
-	}
-	apply.ID = applyID
 
-	// Log apply started
-	c.logApplyEvent(ctx, applyID, nil, storage.LogLevelInfo, storage.LogEventInfo, storage.LogSourceSchemaBot,
-		fmt.Sprintf("Apply started: %s", applyIdentifier), "", state.Apply.Pending)
-
-	// Create one Task per DDLChange in the plan.
-	// For VSchema-only deploys (0 DDL changes), create a synthetic task per
-	// keyspace with VSchema changes so the progress API has something to track.
 	c.logger.Info("Apply: creating tasks",
 		"plan_id", plan.PlanIdentifier,
 		"ddl_change_count", len(ddlChanges),
@@ -581,24 +583,11 @@ func (c *LocalClient) Apply(ctx context.Context, req *ternv1.ApplyRequest) (*ter
 		)
 	}
 
-	// Create VSchema tasks for namespaces with VSchema changes so the
-	// progress API and TUI can track VSchema application alongside DDL.
-	for ns, nsData := range plan.Namespaces {
-		if len(nsData.VSchema) > 0 {
-			ddlChanges = append(ddlChanges, storage.TableChange{
-				Table:     "VSchema: " + ns,
-				Namespace: ns,
-				Operation: "vschema_update",
-			})
-		}
-	}
-
 	tasks := make([]*storage.Task, len(ddlChanges))
 	for i, ddlChange := range ddlChanges {
 		taskIdentifier := "task-" + strings.ReplaceAll(uuid.New().String(), "-", "")[:16]
 		tasks[i] = &storage.Task{
 			TaskIdentifier: taskIdentifier,
-			ApplyID:        applyID,
 			PlanID:         plan.ID,
 			Database:       plan.Database,
 			DatabaseType:   plan.DatabaseType,
@@ -615,12 +604,30 @@ func (c *LocalClient) Apply(ctx context.Context, req *ternv1.ApplyRequest) (*ter
 			CreatedAt:      now,
 			UpdatedAt:      now,
 		}
-		taskID, err := c.storage.Tasks().Create(ctx, tasks[i])
-		if err != nil {
-			return nil, fmt.Errorf("create task for table %s: %w", ddlChange.Table, err)
-		}
-		tasks[i].ID = taskID
 	}
+
+	// Dual-write one apply_operations row alongside the applies row in the
+	// same transaction so every apply created via the Tern client carries a
+	// claimable, resumable operation. CreateWithTasksAndOperations links each
+	// task to the single operation via ApplyOperationID, which the engine
+	// resume-state path requires and the operator claim loop selects on.
+	operations := []*storage.ApplyOperation{{
+		Deployment: apply.Deployment,
+		Target:     plan.Target,
+		State:      state.ApplyOperation.Pending,
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	}}
+
+	applyID, err := c.storage.Applies().CreateWithTasksAndOperations(ctx, apply, tasks, operations)
+	if err != nil {
+		return nil, fmt.Errorf("create apply %s with tasks and operations: %w", applyIdentifier, err)
+	}
+	apply.ID = applyID
+
+	// Log apply started
+	c.logApplyEvent(ctx, applyID, nil, storage.LogLevelInfo, storage.LogEventInfo, storage.LogSourceSchemaBot,
+		fmt.Sprintf("Apply started: %s", applyIdentifier), "", state.Apply.Pending)
 
 	// Direct client calls can still register a pending observer before starting
 	// the engine. API-created applies use the service-level observer registry

--- a/pkg/tern/local_client_integration_test.go
+++ b/pkg/tern/local_client_integration_test.go
@@ -626,6 +626,94 @@ func TestLocalClient_Apply(t *testing.T) {
 	assert.Equal(t, 1, columnCount, "expected email column to exist, got count %d", columnCount)
 }
 
+// An apply created via the Tern client must carry exactly one apply_operations
+// row, and every task must link to it via ApplyOperationID. The operator claim
+// loop selects work exclusively from apply_operations, and the engine
+// resume-state path requires a non-nil ApplyOperationID, so an apply without
+// this child row would never start, recover, or persist resume state.
+func TestLocalClient_Apply_WritesApplyOperationRow(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	_, dsn := setupMySQLContainer(t)
+	setupStorageSchema(t, dsn)
+	cleanupTestTables(t, dsn)
+
+	ctx := t.Context()
+
+	db, err := sql.Open("mysql", dsn)
+	require.NoError(t, err, "failed to open database")
+	defer utils.CloseAndLog(db)
+
+	_, err = db.ExecContext(ctx, "CREATE TABLE users (id INT PRIMARY KEY)")
+	require.NoError(t, err, "failed to create table")
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	stor := createStorage(t, dsn)
+	defer utils.CloseAndLog(stor)
+
+	client, err := NewLocalClient(LocalConfig{
+		Database:  "testdb",
+		Type:      storage.DatabaseTypeMySQL,
+		TargetDSN: dsn,
+	}, stor, logger)
+	require.NoError(t, err, "failed to create client")
+	defer utils.CloseAndLog(client)
+
+	schemaFiles := buildSchemaWithAllTables(t, dsn, map[string]string{
+		"users": "CREATE TABLE users (id INT PRIMARY KEY, email VARCHAR(255))",
+	})
+
+	planResp, err := client.Plan(ctx, &ternv1.PlanRequest{
+		Type:     "mysql",
+		Database: "testdb",
+		SchemaFiles: map[string]*ternv1.SchemaFiles{
+			"default": {Files: schemaFiles},
+		},
+	})
+	require.NoError(t, err, "Plan() returned error")
+	require.NotEmpty(t, planResp.PlanId, "expected plan_id but got empty string")
+
+	applyResp, err := client.Apply(ctx, &ternv1.ApplyRequest{
+		PlanId:      planResp.PlanId,
+		Environment: localClientTestEnvironment,
+	})
+	require.NoError(t, err, "Apply() returned error")
+	require.True(t, applyResp.Accepted, "expected apply to be accepted, got error: %s", applyResp.ErrorMessage)
+
+	apply, err := stor.Applies().GetByApplyIdentifier(ctx, applyResp.ApplyId)
+	require.NoError(t, err, "lookup apply by identifier")
+	require.NotNil(t, apply, "apply should exist in storage")
+
+	operations, err := stor.ApplyOperations().ListByApply(ctx, apply.ID)
+	require.NoError(t, err, "list apply operations")
+	require.Len(t, operations, 1, "exactly one apply_operations row must be written per apply")
+
+	op := operations[0]
+	assert.Equal(t, apply.ID, op.ApplyID, "operation must reference the apply")
+	assert.Equal(t, "testdb", op.Deployment, "operation deployment must mirror the apply deployment")
+	assert.Equal(t, "testdb", op.Target, "operation target must mirror the resolved plan target")
+	assert.Equal(t, state.ApplyOperation.Pending, op.State, "operation must start pending")
+
+	tasks, err := stor.Tasks().GetByApplyID(ctx, apply.ID)
+	require.NoError(t, err, "list tasks for apply")
+	require.NotEmpty(t, tasks, "apply must have at least one task")
+	for _, task := range tasks {
+		require.NotNil(t, task.ApplyOperationID, "task %s must link to the apply_operations row", task.TaskIdentifier)
+		assert.Equal(t, op.ID, *task.ApplyOperationID, "task %s must reference the apply's operation row", task.TaskIdentifier)
+	}
+
+	// The apply still runs to completion against the real Spirit engine with the
+	// operation row present (the sequential path is unaffected by the linkage).
+	waitForApplyComplete(t, client, ctx, applyResp.ApplyId)
+
+	var columnCount int
+	err = db.QueryRowContext(ctx, "SELECT COUNT(*) FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = 'testdb' AND TABLE_NAME = 'users' AND COLUMN_NAME = 'email'").Scan(&columnCount)
+	require.NoError(t, err, "query columns")
+	assert.Equal(t, 1, columnCount, "expected email column to exist, got count %d", columnCount)
+}
+
 // TestLocalClient_Progress verifies that progress is scoped to a concrete apply
 // and returns the stored task details for that apply.
 func TestLocalClient_Progress(t *testing.T) {


### PR DESCRIPTION
`LocalClient.Apply` (the path used when SchemaBot serves as a remote Tern engine over gRPC) created the `applies` row and its tasks separately and never wrote an `apply_operations` child row, so every task carried a nil `ApplyOperationID`. The HTTP/API apply path already dual-writes that row via `CreateWithTasksAndOperations`; the Tern-client path did not. Two consequences:

- With operator operation-claiming enabled, the claim loop selects work exclusively from `apply_operations`. Applies created without a child row would never be started, crash-recovered, or retried — silently.
- Grouped applies require a non-nil `ApplyOperationID` to persist engine resume state. The apply was failed *after* the deploy request had already been created, orphaning the remote deploy request.

`Apply` now uses `CreateWithTasksAndOperations` to write the applies row, its tasks, and exactly one `apply_operations` row in a single transaction, mirroring the API path. The store links each task to the operation via `ApplyOperationID`. The sequential (Spirit) path is unaffected by the linkage and continues to run unchanged.

Legacy applies created before this dual-write existed still lack an operation row; backfilling them is a possible follow-up and is intentionally out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)