### PR TITLE
fix(operator): stop the engine for all active states before recording stop

### DIFF
--- a/pkg/tern/control_requests.go
+++ b/pkg/tern/control_requests.go
@@ -195,6 +195,26 @@ func completePendingStopControlRequests(ctx context.Context, store storage.Stora
 	return nil
 }
 
+// failPendingStopControlRequests marks the pending stop request terminally
+// failed. A failed request is no longer pending, so the operator-owned retry
+// loop stops re-running stop instead of spinning on a permanent rejection.
+func failPendingStopControlRequests(ctx context.Context, store storage.Storage, apply *storage.Apply, errorMessage string) error {
+	if store == nil {
+		return fmt.Errorf("storage is not available")
+	}
+	if err := ensureApplyLeaseForControlRequest(ctx, store, apply, storage.ControlOperationStop); err != nil {
+		return err
+	}
+	controlStore := store.ControlRequests()
+	if controlStore == nil {
+		return fmt.Errorf("control request store is not available")
+	}
+	if err := controlStore.FailPending(ctx, apply.ID, storage.ControlOperationStop, errorMessage); err != nil {
+		return fmt.Errorf("fail pending stop control request for apply %s: %w", apply.ApplyIdentifier, err)
+	}
+	return nil
+}
+
 func ensureApplyLeaseForControlRequest(ctx context.Context, store storage.Storage, apply *storage.Apply, operation storage.ControlOperation) error {
 	lease, ok := storage.ApplyLeaseFromContext(ctx)
 	if !ok {

--- a/pkg/tern/local_client_test.go
+++ b/pkg/tern/local_client_test.go
@@ -510,6 +510,71 @@ func TestLocalClient_ProcessPendingStopControlRequest(t *testing.T) {
 	assert.True(t, hasLogMessageContaining(logs.logs, "Stop requested: 1 tasks stopped, 0 skipped (caller: cli:alice)"))
 }
 
+// A revert-window apply has already cut over, so a durable stop request against
+// it is a permanent rejection. Processing it must resolve the request terminally
+// (failed) with the operator-facing reason instead of bubbling a retryable error
+// that keeps the request pending and spins the operator-owned retry loop forever.
+// The apply stays in the revert window for the operator to revert or skip-revert.
+func TestLocalClient_ProcessPendingStopControlRequestRejectsRevertWindow(t *testing.T) {
+	apply := &storage.Apply{
+		ID:              321,
+		ApplyIdentifier: "apply-revert-window-stop",
+		Database:        "testdb",
+		DatabaseType:    storage.DatabaseTypeVitess,
+		Environment:     "staging",
+		State:           state.Apply.RevertWindow,
+	}
+	task := &storage.Task{
+		ID:             654,
+		ApplyID:        apply.ID,
+		TaskIdentifier: "task-revert-window-stop",
+		Database:       "testdb",
+		DatabaseType:   storage.DatabaseTypeVitess,
+		TableName:      "users",
+		State:          state.Task.RevertWindow,
+	}
+	controlRequests := &testControlRequestStore{requests: []*storage.ApplyControlRequest{{
+		ApplyID:     apply.ID,
+		Operation:   storage.ControlOperationStop,
+		Status:      storage.ControlRequestPending,
+		RequestedBy: "cli:alice",
+	}}}
+	fakeEngine := &fakeControlEngine{}
+	logs := &mockApplyLogStore{}
+	client := &LocalClient{
+		config: LocalConfig{
+			Database: "testdb",
+			Type:     storage.DatabaseTypeVitess,
+		},
+		storage: &exactProgressStorage{
+			applies:         &exactProgressApplyStore{apply: apply},
+			tasks:           &exactProgressTaskStore{tasks: []*storage.Task{task}},
+			logs:            logs,
+			controlRequests: controlRequests,
+		},
+		planetscaleEngine: fakeEngine,
+		logger:            slog.Default(),
+	}
+
+	handled, err := client.processPendingStopControlRequest(t.Context(), apply)
+
+	require.NoError(t, err, "a permanent rejection must not bubble a retryable error")
+	assert.True(t, handled, "the durable request is resolved, so the owner must not retry")
+	assert.Equal(t, 0, fakeEngine.stopCount, "stop must not touch the engine for a revert-window apply")
+	assert.Equal(t, state.Apply.RevertWindow, apply.State, "revert-window apply must not be recorded as cancelled or stopped")
+	assert.Equal(t, state.Task.RevertWindow, task.State, "revert-window task must be preserved")
+
+	pending, err := controlRequests.GetPending(t.Context(), apply.ID, storage.ControlOperationStop)
+	require.NoError(t, err)
+	assert.Nil(t, pending, "the stop request must not be left pending")
+
+	require.Len(t, controlRequests.requests, 1)
+	resolved := controlRequests.requests[0]
+	assert.Equal(t, storage.ControlRequestFailed, resolved.Status, "the stop request must be terminally failed, not retried")
+	assert.Equal(t, "schema change apply-revert-window-stop is in the revert window and has already been applied: use revert to undo it or skip-revert to finalize it", resolved.ErrorMessage)
+	assert.True(t, hasLogMessageContaining(logs.logs, "Pending stop request rejected: schema change apply-revert-window-stop is in the revert window"))
+}
+
 func TestLocalClient_ProcessPendingCutoverControlRequest(t *testing.T) {
 	apply := &storage.Apply{
 		ID:              125,

--- a/pkg/tern/local_control.go
+++ b/pkg/tern/local_control.go
@@ -422,6 +422,15 @@ func (c *LocalClient) processPendingStopControlRequest(ctx context.Context, appl
 // firstRevertWindowTask returns the first targeted task that is in the revert
 // window, or nil if none are. A revert-window task has already cut over, so the
 // stop path must reject rather than treat it as a cancellable in-flight change.
+//
+// When targetApplyID is 0 (an untargeted stop with no apply id), any
+// revert-window task on the database rejects the whole stop, even one belonging
+// to a different apply. This is bounded by the one-active-apply-per-target
+// invariant: storage permits at most one active apply per (database, database
+// type, environment), and LocalClient is scoped to a single such target, so a
+// revert-window task from a second, distinct apply cannot coexist with another
+// active apply on the same target. Cross-apply coexistence is therefore not a
+// case this scope has to disambiguate.
 func firstRevertWindowTask(tasks []*storage.Task, targetApplyID int64) *storage.Task {
 	for _, task := range tasks {
 		if targetApplyID > 0 && task.ApplyID != targetApplyID {
@@ -490,19 +499,34 @@ func (c *LocalClient) applyHasRevertWindowTask(ctx context.Context, apply *stora
 //     behind the abandoned runner.
 //   - WaitingForDeploy: the PlanetScale deferred deploy request exists and stays
 //     startable from the PlanetScale UI until eng.Stop cancels it.
+//   - FailedRetryable: a transient failure (e.g. repeated progress-poll errors)
+//     pauses the apply for operator retry, but the PlanetScale deploy request was
+//     already created and its resume state persisted before the failure, so the
+//     deploy request stays live and startable from the PlanetScale UI. Without
+//     eng.Stop, recording the stop as cancelled would leave that deploy request
+//     runnable from the provider side — the same storage-vs-engine divergence the
+//     other live states avoid. eng.Stop (CancelDeployRequest) is keyed only on the
+//     persisted deploy request id, so cancelling a retryable task is safe; stop is
+//     a terminal operator action that ends the apply rather than retrying it.
 func hasLiveEngineWork(taskState string) bool {
 	return state.IsState(taskState,
 		state.Task.Running,
 		state.Task.WaitingForCutover,
 		state.Task.CuttingOver,
 		state.Task.Recovering,
-		state.Task.WaitingForDeploy)
+		state.Task.WaitingForDeploy,
+		state.Task.FailedRetryable)
 }
 
 // stopEngineForTasks calls eng.Stop() if any targeted task has live engine work.
 // Returns an error if the engine stop fails (e.g., PlanetScale deploy request
 // cancellation failed). For Spirit, stop errors are non-fatal since the runner
 // may have already exited.
+//
+// It stops at the first task with live engine work and returns: an apply drives
+// a single engine operation (one Spirit runner or one PlanetScale deploy
+// request) whose stop terminates the whole operation, so one eng.Stop covers the
+// targeted apply.
 func (c *LocalClient) stopEngineForTasks(ctx context.Context, eng engine.Engine, creds *engine.Credentials, tasks []*storage.Task, targetApplyID int64) error {
 	if eng == nil {
 		c.logger.Error("stopEngineForTasks: engine is nil")

--- a/pkg/tern/local_control.go
+++ b/pkg/tern/local_control.go
@@ -2,6 +2,7 @@ package tern
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -255,9 +256,10 @@ func (c *LocalClient) stop(ctx context.Context, req *ternv1.StopRequest, caller 
 	// change as if nothing happened. Reject so the operator chooses explicitly
 	// between revert (undo the deployed change) and skip-revert (finalize it).
 	if revertTask := firstRevertWindowTask(tasks, targetApplyID); revertTask != nil {
-		c.logger.Warn("stop rejected: task is in the revert window and has already cut over",
-			"task_id", revertTask.TaskIdentifier, "apply_id", revertTask.ApplyID, "state", revertTask.State)
-		return nil, fmt.Errorf("schema change %s is in the revert window and has already been applied: use revert to undo it or skip-revert to finalize it", revertTask.TaskIdentifier)
+		applyIdentifier := c.resolveRevertWindowApplyIdentifier(ctx, req, targetApply, revertTask)
+		c.logger.Warn("stop rejected: schema change is in the revert window and has already cut over",
+			"apply_id", applyIdentifier, "task_id", revertTask.TaskIdentifier, "state", revertTask.State)
+		return nil, errors.New(revertWindowStopRejectionMessage(applyIdentifier))
 	}
 
 	creds := c.credentials()
@@ -372,6 +374,26 @@ func (c *LocalClient) processPendingStopControlRequest(ctx context.Context, appl
 		return true, nil
 	}
 
+	// A revert-window apply has already cut over. Stop is a permanent rejection,
+	// not a retryable error: failing the durable request resolves it terminally
+	// so the operator-owned retry loop stops re-running stop. The operator must
+	// revert (undo) or skip-revert (finalize) instead.
+	if revertWindow, err := c.applyHasRevertWindowTask(ctx, apply); err != nil {
+		return true, err
+	} else if revertWindow {
+		message := revertWindowStopRejectionMessage(apply.ApplyIdentifier)
+		c.logger.Warn("rejecting pending stop request: schema change is in the revert window and has already cut over",
+			"apply_id", apply.ApplyIdentifier,
+			"requested_by", controlRequestCaller(controlReq),
+			"state", apply.State)
+		c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelWarn, storage.LogEventStopRequested, storage.LogSourceSchemaBot,
+			fmt.Sprintf("Pending stop request rejected: %s%s", message, callerApplyLogSuffix(controlRequestCaller(controlReq))), "", "")
+		if err := failPendingStopControlRequests(ctx, c.storage, apply, message); err != nil {
+			return true, err
+		}
+		return true, nil
+	}
+
 	stopCtx := context.WithoutCancel(ctx)
 	resp, err := c.stop(stopCtx, &ternv1.StopRequest{
 		ApplyId:     apply.ApplyIdentifier,
@@ -410,6 +432,50 @@ func firstRevertWindowTask(tasks []*storage.Task, targetApplyID int64) *storage.
 		}
 	}
 	return nil
+}
+
+// revertWindowStopRejectionMessage is the operator-facing reason a stop targeting
+// a revert-window schema change is permanently rejected. The change has already
+// cut over, so the operator must choose revert or skip-revert.
+func revertWindowStopRejectionMessage(applyIdentifier string) string {
+	return fmt.Sprintf("schema change %s is in the revert window and has already been applied: use revert to undo it or skip-revert to finalize it", applyIdentifier)
+}
+
+// resolveRevertWindowApplyIdentifier returns the apply-level identifier an
+// operator supplied or recognizes, not the per-table task identifier. It prefers
+// the requested apply id, then the resolved target apply, then a lookup of the
+// revert task's apply, falling back to the task identifier only if the apply
+// cannot be loaded.
+func (c *LocalClient) resolveRevertWindowApplyIdentifier(ctx context.Context, req *ternv1.StopRequest, targetApply *storage.Apply, revertTask *storage.Task) string {
+	if req.ApplyId != "" {
+		return req.ApplyId
+	}
+	if targetApply != nil && targetApply.ApplyIdentifier != "" {
+		return targetApply.ApplyIdentifier
+	}
+	apply, err := c.storage.Applies().Get(ctx, revertTask.ApplyID)
+	if err != nil {
+		c.logger.Warn("could not load apply to resolve revert-window stop identifier; using task identifier",
+			"apply_db_id", revertTask.ApplyID, "task_id", revertTask.TaskIdentifier, "error", err)
+		return revertTask.TaskIdentifier
+	}
+	if apply == nil {
+		c.logger.Warn("apply not found while resolving revert-window stop identifier; using task identifier",
+			"apply_db_id", revertTask.ApplyID, "task_id", revertTask.TaskIdentifier)
+		return revertTask.TaskIdentifier
+	}
+	return apply.ApplyIdentifier
+}
+
+// applyHasRevertWindowTask reports whether any task for the apply is in the
+// revert window. It reads the stored tasks directly so the durable stop path
+// detects the same cut-over condition the synchronous stop path rejects on.
+func (c *LocalClient) applyHasRevertWindowTask(ctx context.Context, apply *storage.Apply) (bool, error) {
+	tasks, err := c.storage.Tasks().GetByApplyID(ctx, apply.ID)
+	if err != nil {
+		return false, fmt.Errorf("load tasks for apply %s to detect revert window before stop: %w", apply.ApplyIdentifier, err)
+	}
+	return firstRevertWindowTask(tasks, apply.ID) != nil, nil
 }
 
 // hasLiveEngineWork reports whether a task in this state has live engine or

--- a/pkg/tern/local_control.go
+++ b/pkg/tern/local_control.go
@@ -250,6 +250,16 @@ func (c *LocalClient) stop(ctx context.Context, req *ternv1.StopRequest, caller 
 		targetApply = apply
 	}
 
+	// A task in the revert window has already cut over: the new schema is live.
+	// Stop must not finalize it as cancelled — that would record a deployed
+	// change as if nothing happened. Reject so the operator chooses explicitly
+	// between revert (undo the deployed change) and skip-revert (finalize it).
+	if revertTask := firstRevertWindowTask(tasks, targetApplyID); revertTask != nil {
+		c.logger.Warn("stop rejected: task is in the revert window and has already cut over",
+			"task_id", revertTask.TaskIdentifier, "apply_id", revertTask.ApplyID, "state", revertTask.State)
+		return nil, fmt.Errorf("schema change %s is in the revert window and has already been applied: use revert to undo it or skip-revert to finalize it", revertTask.TaskIdentifier)
+	}
+
 	creds := c.credentials()
 	eng := c.getEngine()
 	applyCancel := c.currentApplyCancel()
@@ -387,7 +397,43 @@ func (c *LocalClient) processPendingStopControlRequest(ctx context.Context, appl
 	return true, nil
 }
 
-// stopEngineForTasks calls eng.Stop() if any targeted task is actively running.
+// firstRevertWindowTask returns the first targeted task that is in the revert
+// window, or nil if none are. A revert-window task has already cut over, so the
+// stop path must reject rather than treat it as a cancellable in-flight change.
+func firstRevertWindowTask(tasks []*storage.Task, targetApplyID int64) *storage.Task {
+	for _, task := range tasks {
+		if targetApplyID > 0 && task.ApplyID != targetApplyID {
+			continue
+		}
+		if state.IsState(task.State, state.Task.RevertWindow) {
+			return task
+		}
+	}
+	return nil
+}
+
+// hasLiveEngineWork reports whether a task in this state has live engine or
+// remote work that eng.Stop must terminate before storage records the stop.
+// These are the non-terminal states where a Spirit runner is copying rows or a
+// PlanetScale deploy request is created and can be cancelled:
+//   - Running / CuttingOver: Spirit runner or PlanetScale deploy actively executing.
+//   - WaitingForCutover: Spirit runner alive, holding connections until cutover.
+//   - Recovering: Spirit's runner is restarted with a detached context during
+//     recovery; only eng.Stop kills it, so without this the runner keeps copying
+//     rows while storage reports stopped and a later resume blocks in Drain()
+//     behind the abandoned runner.
+//   - WaitingForDeploy: the PlanetScale deferred deploy request exists and stays
+//     startable from the PlanetScale UI until eng.Stop cancels it.
+func hasLiveEngineWork(taskState string) bool {
+	return state.IsState(taskState,
+		state.Task.Running,
+		state.Task.WaitingForCutover,
+		state.Task.CuttingOver,
+		state.Task.Recovering,
+		state.Task.WaitingForDeploy)
+}
+
+// stopEngineForTasks calls eng.Stop() if any targeted task has live engine work.
 // Returns an error if the engine stop fails (e.g., PlanetScale deploy request
 // cancellation failed). For Spirit, stop errors are non-fatal since the runner
 // may have already exited.
@@ -404,22 +450,23 @@ func (c *LocalClient) stopEngineForTasks(ctx context.Context, eng engine.Engine,
 			c.logger.Info("skipping terminal task in stop", "task_id", task.TaskIdentifier, "state", task.State)
 			continue
 		}
-		if task.State == state.Task.Running ||
-			task.State == state.Task.WaitingForCutover ||
-			task.State == state.Task.CuttingOver {
-			req, err := c.buildControlRequest(ctx, task, creds, eng, engine.ControlStop)
-			if err != nil {
-				return fmt.Errorf("build stop request for task %s: %w", task.TaskIdentifier, err)
-			}
-			if _, err := eng.Stop(ctx, req); err != nil {
-				if c.config.Type == storage.DatabaseTypeVitess {
-					return fmt.Errorf("cancel deploy request for task %s: %w", task.TaskIdentifier, err)
-				}
-				c.logger.Warn("engine stop returned error (runner may have already exited)",
-					"task_id", task.TaskIdentifier, "error", err)
-			}
-			return nil
+		if !hasLiveEngineWork(task.State) {
+			c.logger.Debug("skipping engine stop for task with no live engine work",
+				"task_id", task.TaskIdentifier, "state", task.State)
+			continue
 		}
+		req, err := c.buildControlRequest(ctx, task, creds, eng, engine.ControlStop)
+		if err != nil {
+			return fmt.Errorf("build stop request for task %s: %w", task.TaskIdentifier, err)
+		}
+		if _, err := eng.Stop(ctx, req); err != nil {
+			if c.config.Type == storage.DatabaseTypeVitess {
+				return fmt.Errorf("cancel deploy request for task %s: %w", task.TaskIdentifier, err)
+			}
+			c.logger.Warn("engine stop returned error (runner may have already exited)",
+				"task_id", task.TaskIdentifier, "error", err)
+		}
+		return nil
 	}
 	return nil
 }

--- a/pkg/tern/local_control_test.go
+++ b/pkg/tern/local_control_test.go
@@ -488,6 +488,51 @@ func TestLocalClient_StopWaitingForDeployCancelsDeployRequest(t *testing.T) {
 	assert.Equal(t, state.Apply.Cancelled, apply.State)
 }
 
+// A PlanetScale failed_retryable task paused after a transient failure (e.g.
+// repeated progress-poll errors) still has its created, startable deploy request
+// and persisted resume state. Stop is a terminal operator action, so it must
+// cancel that deploy request via the engine before recording the cancellation —
+// otherwise the deploy stays startable from the PlanetScale UI while SchemaBot
+// reports it cancelled.
+func TestLocalClient_StopFailedRetryableCancelsDeployRequest(t *testing.T) {
+	operationID := int64(99)
+	apply := &storage.Apply{
+		ID:              42,
+		ApplyIdentifier: "apply-vitess-failed-retryable",
+		State:           state.Apply.FailedRetryable,
+	}
+	task := &storage.Task{
+		ID:               7,
+		ApplyID:          apply.ID,
+		ApplyOperationID: &operationID,
+		TaskIdentifier:   "task-vitess-failed-retryable",
+		State:            state.Task.FailedRetryable,
+	}
+	resumeData := planetscale.ResumeData{
+		BranchName:       "branch-123",
+		DeployRequestID:  321,
+		MigrationContext: "ctx-123",
+		DeployRequestURL: "https://example.test/deploys/321",
+		DeferredDeploy:   true,
+	}
+	resumeState := engineResumeStateFromPlanetScaleData(t, operationID, resumeData)
+	eng := &controlCaptureEngine{}
+	stateAtEngineStop := ""
+	eng.onStop = func() { stateAtEngineStop = task.State }
+	client := newVitessControlTestClient(apply, []*storage.Task{task}, resumeState, eng)
+
+	resp, err := client.Stop(t.Context(), &ternv1.StopRequest{ApplyId: apply.ApplyIdentifier})
+
+	require.NoError(t, err)
+	assert.True(t, resp.Accepted)
+	require.NotNil(t, eng.stopReq, "stop must cancel the deploy request for a failed_retryable task")
+	require.NotNil(t, eng.stopReq.ResumeState)
+	assert.Equal(t, resumeData.MigrationContext, eng.stopReq.ResumeState.MigrationContext)
+	assert.Equal(t, state.Task.FailedRetryable, stateAtEngineStop, "deploy request must be cancelled before the task is marked cancelled")
+	assert.Equal(t, state.Task.Cancelled, task.State)
+	assert.Equal(t, state.Apply.Cancelled, apply.State)
+}
+
 // A task in the revert window has already cut over: the new schema is live.
 // Stop must reject rather than record it as cancelled, so an operator chooses
 // explicitly between reverting (undo) and skip-revert (finalize). The engine is

--- a/pkg/tern/local_control_test.go
+++ b/pkg/tern/local_control_test.go
@@ -491,7 +491,8 @@ func TestLocalClient_StopWaitingForDeployCancelsDeployRequest(t *testing.T) {
 // A task in the revert window has already cut over: the new schema is live.
 // Stop must reject rather than record it as cancelled, so an operator chooses
 // explicitly between reverting (undo) and skip-revert (finalize). The engine is
-// not touched and the task state is preserved.
+// not touched and the task state is preserved. The rejection names the
+// apply-level identifier the operator supplied, not the per-table task id.
 func TestLocalClient_StopRejectsRevertWindow(t *testing.T) {
 	operationID := int64(99)
 	apply := &storage.Apply{
@@ -518,9 +519,9 @@ func TestLocalClient_StopRejectsRevertWindow(t *testing.T) {
 	_, err := client.Stop(t.Context(), &ternv1.StopRequest{ApplyId: apply.ApplyIdentifier})
 
 	require.Error(t, err)
-	assert.ErrorContains(t, err, "revert window")
-	assert.ErrorContains(t, err, "revert")
-	assert.ErrorContains(t, err, "skip-revert")
+	assert.ErrorContains(t, err, "schema change apply-vitess-revert-window is in the revert window and has already been applied")
+	assert.ErrorContains(t, err, "use revert to undo it or skip-revert to finalize it")
+	assert.NotContains(t, err.Error(), task.TaskIdentifier, "rejection must name the apply identifier, not the per-table task id")
 	assert.Nil(t, eng.stopReq, "stop must not touch the engine for a revert-window task")
 	assert.Equal(t, state.Task.RevertWindow, task.State, "revert-window task must not be marked cancelled by stop")
 	assert.Equal(t, state.Apply.RevertWindow, apply.State, "revert-window apply must not be marked cancelled by stop")

--- a/pkg/tern/local_control_test.go
+++ b/pkg/tern/local_control_test.go
@@ -129,6 +129,10 @@ type controlCaptureEngine struct {
 	cutoverReq *engine.ControlRequest
 	stopReq    *engine.ControlRequest
 	stopErr    error
+	// onStop runs when Stop is invoked, before it returns. Used to observe
+	// storage state at the moment of the engine stop (e.g. to assert the engine
+	// is stopped before tasks are marked stopped/cancelled).
+	onStop func()
 }
 
 func (e *controlCaptureEngine) Name() string {
@@ -142,6 +146,9 @@ func (e *controlCaptureEngine) Cutover(_ context.Context, req *engine.ControlReq
 
 func (e *controlCaptureEngine) Stop(_ context.Context, req *engine.ControlRequest) (*engine.ControlResult, error) {
 	e.stopReq = req
+	if e.onStop != nil {
+		e.onStop()
+	}
 	if e.stopErr != nil {
 		return nil, e.stopErr
 	}
@@ -400,4 +407,121 @@ func TestLocalClient_StopReturnsVitessEngineStopError(t *testing.T) {
 	require.ErrorIs(t, err, stopErr)
 	require.NotNil(t, eng.stopReq, "stop should call the engine with deploy metadata")
 	assert.Equal(t, state.Task.Running, task.State)
+}
+
+// A recovering Spirit task still has a live runner copying rows under a detached
+// context, so stop must kill it via the engine before storage records the stop.
+// Otherwise storage reports stopped while the runner keeps working and a later
+// resume blocks behind the abandoned runner.
+func TestLocalClient_StopRecoveringMySQLStopsEngineBeforeStorage(t *testing.T) {
+	apply := &storage.Apply{
+		ID:              42,
+		ApplyIdentifier: "apply-mysql-recovering",
+		State:           state.Apply.Recovering,
+		Database:        "testdb",
+		DatabaseType:    storage.DatabaseTypeMySQL,
+		Environment:     "staging",
+	}
+	task := &storage.Task{
+		ID:             7,
+		ApplyID:        apply.ID,
+		TaskIdentifier: "task-mysql-recovering",
+		Database:       "testdb",
+		State:          state.Task.Recovering,
+	}
+	eng := &controlCaptureEngine{}
+	stateAtEngineStop := ""
+	eng.onStop = func() { stateAtEngineStop = task.State }
+	client := newMySQLControlTestClient(apply, []*storage.Task{task}, eng)
+
+	resp, err := client.Stop(t.Context(), &ternv1.StopRequest{ApplyId: apply.ApplyIdentifier})
+
+	require.NoError(t, err)
+	assert.True(t, resp.Accepted)
+	assert.Equal(t, int64(1), resp.StoppedCount)
+	require.NotNil(t, eng.stopReq, "stop should call the engine for a recovering task")
+	assert.Equal(t, state.Task.Recovering, stateAtEngineStop, "engine must be stopped before the task is marked stopped")
+	assert.Equal(t, state.Task.Stopped, task.State)
+	assert.Equal(t, state.Apply.Stopped, apply.State)
+}
+
+// A PlanetScale waiting-for-deploy task has a created, startable deploy request.
+// Stop must cancel that deploy request via the engine before recording the
+// cancellation, otherwise the deploy stays startable from the PlanetScale UI
+// while SchemaBot reports it cancelled.
+func TestLocalClient_StopWaitingForDeployCancelsDeployRequest(t *testing.T) {
+	operationID := int64(99)
+	apply := &storage.Apply{
+		ID:              42,
+		ApplyIdentifier: "apply-vitess-waiting-deploy",
+		State:           state.Apply.WaitingForDeploy,
+	}
+	task := &storage.Task{
+		ID:               7,
+		ApplyID:          apply.ID,
+		ApplyOperationID: &operationID,
+		TaskIdentifier:   "task-vitess-waiting-deploy",
+		State:            state.Task.WaitingForDeploy,
+	}
+	resumeData := planetscale.ResumeData{
+		BranchName:       "branch-123",
+		DeployRequestID:  321,
+		MigrationContext: "ctx-123",
+		DeployRequestURL: "https://example.test/deploys/321",
+		DeferredDeploy:   true,
+	}
+	resumeState := engineResumeStateFromPlanetScaleData(t, operationID, resumeData)
+	eng := &controlCaptureEngine{}
+	stateAtEngineStop := ""
+	eng.onStop = func() { stateAtEngineStop = task.State }
+	client := newVitessControlTestClient(apply, []*storage.Task{task}, resumeState, eng)
+
+	resp, err := client.Stop(t.Context(), &ternv1.StopRequest{ApplyId: apply.ApplyIdentifier})
+
+	require.NoError(t, err)
+	assert.True(t, resp.Accepted)
+	require.NotNil(t, eng.stopReq, "stop must cancel the deploy request for a waiting-for-deploy task")
+	require.NotNil(t, eng.stopReq.ResumeState)
+	assert.Equal(t, resumeData.MigrationContext, eng.stopReq.ResumeState.MigrationContext)
+	assert.Equal(t, state.Task.WaitingForDeploy, stateAtEngineStop, "deploy request must be cancelled before the task is marked cancelled")
+	assert.Equal(t, state.Task.Cancelled, task.State)
+	assert.Equal(t, state.Apply.Cancelled, apply.State)
+}
+
+// A task in the revert window has already cut over: the new schema is live.
+// Stop must reject rather than record it as cancelled, so an operator chooses
+// explicitly between reverting (undo) and skip-revert (finalize). The engine is
+// not touched and the task state is preserved.
+func TestLocalClient_StopRejectsRevertWindow(t *testing.T) {
+	operationID := int64(99)
+	apply := &storage.Apply{
+		ID:              42,
+		ApplyIdentifier: "apply-vitess-revert-window",
+		State:           state.Apply.RevertWindow,
+	}
+	task := &storage.Task{
+		ID:               7,
+		ApplyID:          apply.ID,
+		ApplyOperationID: &operationID,
+		TaskIdentifier:   "task-vitess-revert-window",
+		State:            state.Task.RevertWindow,
+	}
+	resumeState := engineResumeStateFromPlanetScaleData(t, operationID, planetscale.ResumeData{
+		BranchName:       "branch-123",
+		DeployRequestID:  321,
+		MigrationContext: "ctx-123",
+		DeployRequestURL: "https://example.test/deploys/321",
+	})
+	eng := &controlCaptureEngine{}
+	client := newVitessControlTestClient(apply, []*storage.Task{task}, resumeState, eng)
+
+	_, err := client.Stop(t.Context(), &ternv1.StopRequest{ApplyId: apply.ApplyIdentifier})
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "revert window")
+	assert.ErrorContains(t, err, "revert")
+	assert.ErrorContains(t, err, "skip-revert")
+	assert.Nil(t, eng.stopReq, "stop must not touch the engine for a revert-window task")
+	assert.Equal(t, state.Task.RevertWindow, task.State, "revert-window task must not be marked cancelled by stop")
+	assert.Equal(t, state.Apply.RevertWindow, apply.State, "revert-window apply must not be marked cancelled by stop")
 }


### PR DESCRIPTION
Stop only invoked `eng.Stop` for tasks in `running`, `waiting_for_cutover`, or `cutting_over`, but then marked tasks/apply stopped or cancelled and cancelled the apply context regardless. Tasks in other active states were skipped by the engine stop yet still mutated in storage, so SchemaBot's stored state diverged from the live engine and remote state:

- `recovering` — Spirit's runner runs under a detached context during recovery and is only killed by `eng.Stop`. Without it the runner kept copying rows and holding connections while storage reported stopped, and a later resume could block in `Drain()` behind the abandoned runner.
- `waiting_for_deploy` — the PlanetScale deferred deploy request was never cancelled, so it stayed startable from the PlanetScale UI while SchemaBot reported it cancelled.
- `revert_window` — the change had already cut over, yet stop recorded it as cancelled without consulting the engine.

The engine-stop state set now covers `recovering` and `waiting_for_deploy` via a named `hasLiveEngineWork` predicate (using `state.IsState`), so the live runner / deploy request is terminated before storage records the stop.

`revert_window` is handled separately: the change is already live, so stop is not a clean cancel. Stop now rejects it with a definitive message naming the apply identifier and directing the operator to revert (undo) or skip-revert (finalize), rather than recording a deployed change as cancelled. Rejecting is the fail-safe choice — the operator then explicitly reverts or finalizes via the dedicated paths.

The rejection is permanent on both stop entry paths. A synchronous stop returns the rejection to the caller. A durable stop control request (processed by the apply owner) is resolved terminally (`failed`) with the same operator message, so it is never left `pending` and the operator-owned retry loop does not spin re-running stop. The apply stays in `revert_window` for the operator to act on.

```
stop (synchronous)
 ├─ task in revert_window?      → reject (operator picks revert / skip-revert)
 ├─ hasLiveEngineWork(state)?   → eng.Stop (kill Spirit runner / cancel deploy request)
 └─ then: cancel apply ctx, mark tasks + apply stopped/cancelled

processPendingStopControlRequest (durable)
 └─ apply in revert_window?     → fail the stop request terminally (no retry)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
