### PR TITLE
fix(operator): stop conflict check from failing stopped or retryable tasks

### DIFF
--- a/pkg/state/task.go
+++ b/pkg/state/task.go
@@ -61,6 +61,21 @@ func IsTerminalTaskState(s string) bool {
 	}
 }
 
+// IsInFlightTaskState returns true if the state implies the engine is actively
+// working on the task. These are the only states for which a missing engine
+// migration means the task was abandoned (e.g. a server crash). Resting states
+// such as Stopped and FailedRetryable also have no active engine work, but that
+// absence is expected — Spirit keeps the checkpoint while the operator decides
+// whether to resume or retry — so they are excluded here.
+func IsInFlightTaskState(s string) bool {
+	switch NormalizeState(s) {
+	case Task.Running, Task.WaitingForCutover, Task.CuttingOver, Task.WaitingForDeploy, Task.Recovering:
+		return true
+	default:
+		return false
+	}
+}
+
 // NormalizeTaskStatus maps a raw engine status to a canonical Task state.
 // Called at the parsing boundary (ParseProgressResponse) so rendering code
 // can compare against Task.* constants directly.

--- a/pkg/state/task_test.go
+++ b/pkg/state/task_test.go
@@ -77,3 +77,37 @@ func TestNormalizeTaskStatus_StorageCompleted(t *testing.T) {
 func TestNormalizeTaskStatus_UnknownDefaultsToRunning(t *testing.T) {
 	assert.Equal(t, Task.Running, NormalizeTaskStatus("something_unknown"))
 }
+
+func TestIsInFlightTaskState(t *testing.T) {
+	inFlight := []string{
+		Task.Running,
+		Task.WaitingForCutover,
+		Task.CuttingOver,
+		Task.WaitingForDeploy,
+		Task.Recovering,
+	}
+	for _, s := range inFlight {
+		assert.True(t, IsInFlightTaskState(s), "IsInFlightTaskState(%q)", s)
+	}
+
+	resting := []string{
+		Task.Stopped,
+		Task.FailedRetryable,
+		Task.Pending,
+		Task.Completed,
+		Task.Failed,
+		Task.Reverted,
+		Task.Cancelled,
+		Task.RevertWindow,
+	}
+	for _, s := range resting {
+		assert.False(t, IsInFlightTaskState(s), "IsInFlightTaskState(%q)", s)
+	}
+}
+
+func TestIsInFlightTaskState_NormalizesProtoPrefix(t *testing.T) {
+	assert.True(t, IsInFlightTaskState("STATE_RUNNING"))
+	assert.True(t, IsInFlightTaskState("WAITING_FOR_CUTOVER"))
+	assert.False(t, IsInFlightTaskState("STATE_STOPPED"))
+	assert.False(t, IsInFlightTaskState("FAILED_RETRYABLE"))
+}

--- a/pkg/tern/local_apply.go
+++ b/pkg/tern/local_apply.go
@@ -64,7 +64,9 @@ func (c *LocalClient) findBlockingTask(ctx context.Context, tasks []*storage.Tas
 }
 
 // tryResolveStaleTask checks the engine to see if a non-terminal task is actually done.
-// If the engine reports terminal or "no active schema change", the task is updated in storage.
+// If the engine reports a terminal state, or reports no active work for a task that
+// storage believes is in-flight, the task is updated in storage and no longer blocks.
+// Resting tasks (Stopped, FailedRetryable) are left untouched.
 // Returns true if the task was resolved (no longer blocking).
 func (c *LocalClient) tryResolveStaleTask(ctx context.Context, t *storage.Task, database string) bool {
 	eng := c.getEngine()
@@ -96,9 +98,19 @@ func (c *LocalClient) tryResolveStaleTask(ctx context.Context, t *storage.Task, 
 		return true
 	}
 
-	// Spirit has no active schema change but task isn't terminal — task is stale.
-	// Crashed or failed without updating storage.
+	// The engine has no active work. For in-flight states this means the task was
+	// abandoned (e.g. a server crash) and must be failed so it stops blocking.
+	// Resting states (Stopped, FailedRetryable) also have no active engine work,
+	// but that is expected — Spirit keeps the checkpoint until an operator resumes
+	// or retries. Failing them here would destroy resumable work and void the
+	// operator retry budget, so leave them untouched and let the conflict/lock
+	// logic decide whether the new apply proceeds.
 	if result.Message == "No active schema change" {
+		if !state.IsInFlightTaskState(t.State) {
+			c.logger.Debug("conflict check: leaving resting task untouched (no active engine work expected)",
+				"task_id", t.TaskIdentifier, "storage_state", t.State)
+			return false
+		}
 		c.logger.Info("conflict check: cleaning up stale task (no active schema change in engine)",
 			"task_id", t.TaskIdentifier, "storage_state", t.State, "started_at", t.StartedAt)
 		now := time.Now()

--- a/pkg/tern/local_apply_conflict_test.go
+++ b/pkg/tern/local_apply_conflict_test.go
@@ -1,0 +1,144 @@
+package tern
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/block/schemabot/pkg/engine"
+	"github.com/block/schemabot/pkg/state"
+	"github.com/block/schemabot/pkg/storage"
+)
+
+// newNoActiveChangeClient builds a MySQL client whose engine always reports no
+// running schema change — the exact response Spirit gives whenever it has no
+// active runner, which is true both after a crash and while a task is
+// intentionally paused.
+func newNoActiveChangeClient(database string, tasks []*storage.Task) *LocalClient {
+	return &LocalClient{
+		config: LocalConfig{
+			Database: database,
+			Type:     storage.DatabaseTypeMySQL,
+		},
+		storage: &exactProgressStorage{
+			tasks: &exactProgressTaskStore{tasks: tasks},
+			logs:  &mockApplyLogStore{},
+		},
+		spiritEngine: &fakeControlEngine{
+			progressResult: &engine.ProgressResult{
+				State:   engine.StatePending,
+				Message: "No active schema change",
+			},
+		},
+		logger: slog.Default(),
+	}
+}
+
+// A stopped task keeps its Spirit checkpoint and is resumable via Start. When an
+// unrelated Apply runs on the same database, the engine reports no active work
+// for that database — but the stopped task must stay stopped so its checkpoint
+// and the operator's ability to resume are preserved, and the new apply must be
+// refused rather than running over paused work.
+func TestConflictCheckPreservesStoppedTask(t *testing.T) {
+	stopped := &storage.Task{
+		ID:             1,
+		TaskIdentifier: "task-stopped",
+		Database:       "testdb",
+		DatabaseType:   storage.DatabaseTypeMySQL,
+		TableName:      "users",
+		State:          state.Task.Stopped,
+	}
+	client := newNoActiveChangeClient("testdb", []*storage.Task{stopped})
+
+	resolved := client.tryResolveStaleTask(t.Context(), stopped, "testdb")
+	assert.False(t, resolved, "stopped task must not be resolved as stale")
+	assert.Equal(t, state.Task.Stopped, stopped.State, "stopped task must remain resumable")
+	assert.Empty(t, stopped.ErrorMessage, "no abandoned-task error should be written to a stopped task")
+	assert.Nil(t, stopped.CompletedAt)
+
+	plan := &storage.Plan{Database: "testdb", DatabaseType: storage.DatabaseTypeMySQL}
+	err := client.checkActiveTaskConflict(t.Context(), plan)
+	require.Error(t, err, "a new apply must be refused while a stopped task holds the database")
+	assert.Contains(t, err.Error(), "schema change already in progress")
+	assert.Equal(t, state.Task.Stopped, stopped.State)
+}
+
+// A failed_retryable task is awaiting an operator retry and still owns its Spirit
+// checkpoint. A new Apply on the same database sees no active engine work, but the
+// task must not be converted to a terminal failure — doing so would silently void
+// the operator's retry budget.
+func TestConflictCheckPreservesRetryableTask(t *testing.T) {
+	retryable := &storage.Task{
+		ID:             2,
+		TaskIdentifier: "task-retryable",
+		Database:       "testdb",
+		DatabaseType:   storage.DatabaseTypeMySQL,
+		TableName:      "orders",
+		State:          state.Task.FailedRetryable,
+		ErrorMessage:   "engine connection reset",
+	}
+	client := newNoActiveChangeClient("testdb", []*storage.Task{retryable})
+
+	resolved := client.tryResolveStaleTask(t.Context(), retryable, "testdb")
+	assert.False(t, resolved, "retryable task must not be resolved as stale")
+	assert.Equal(t, state.Task.FailedRetryable, retryable.State, "retryable task must remain retryable")
+	assert.Equal(t, "engine connection reset", retryable.ErrorMessage, "original retry error must be preserved")
+	assert.Nil(t, retryable.CompletedAt)
+
+	plan := &storage.Plan{Database: "testdb", DatabaseType: storage.DatabaseTypeMySQL}
+	err := client.checkActiveTaskConflict(t.Context(), plan)
+	require.Error(t, err, "a new apply must be refused while a retryable task holds the database")
+	assert.Contains(t, err.Error(), "schema change already in progress")
+	assert.Equal(t, state.Task.FailedRetryable, retryable.State)
+}
+
+// A running task whose engine has gone silent (e.g. the server crashed mid-apply)
+// is genuinely abandoned: storage believes work is in flight but the engine has no
+// runner. Such a task is failed so it stops blocking new applies for the database.
+func TestConflictCheckFailsAbandonedInFlightTask(t *testing.T) {
+	for _, inFlightState := range []string{
+		state.Task.Running,
+		state.Task.CuttingOver,
+		state.Task.WaitingForCutover,
+		state.Task.Recovering,
+	} {
+		t.Run(inFlightState, func(t *testing.T) {
+			running := &storage.Task{
+				ID:             3,
+				TaskIdentifier: "task-running",
+				Database:       "testdb",
+				DatabaseType:   storage.DatabaseTypeMySQL,
+				TableName:      "events",
+				State:          inFlightState,
+			}
+			client := newNoActiveChangeClient("testdb", []*storage.Task{running})
+
+			resolved := client.tryResolveStaleTask(t.Context(), running, "testdb")
+			assert.True(t, resolved, "abandoned in-flight task must be resolved")
+			assert.Equal(t, state.Task.Failed, running.State, "abandoned in-flight task must be failed")
+			assert.Contains(t, running.ErrorMessage, "server may have crashed")
+			assert.NotNil(t, running.CompletedAt)
+		})
+	}
+}
+
+// Once an abandoned in-flight task has been failed, it no longer blocks the
+// database, so a new apply is admitted.
+func TestConflictCheckAdmitsApplyAfterFailingAbandonedTask(t *testing.T) {
+	running := &storage.Task{
+		ID:             4,
+		TaskIdentifier: "task-running",
+		Database:       "testdb",
+		DatabaseType:   storage.DatabaseTypeMySQL,
+		TableName:      "events",
+		State:          state.Task.Running,
+	}
+	client := newNoActiveChangeClient("testdb", []*storage.Task{running})
+
+	plan := &storage.Plan{Database: "testdb", DatabaseType: storage.DatabaseTypeMySQL}
+	err := client.checkActiveTaskConflict(t.Context(), plan)
+	require.NoError(t, err, "new apply should proceed once the abandoned task is failed")
+	assert.Equal(t, state.Task.Failed, running.State)
+}


### PR DESCRIPTION
`tryResolveStaleTask` runs on every apply (via the active-task conflict check) for each non-terminal task on the target database, and converted any task whose engine reported `No active schema change` to `failed`. But Spirit reports exactly that whenever it has no running schema change — the normal resting state for a deliberately **stopped** task (checkpoint preserved) and a **failed_retryable** task awaiting operator retry. Because the check sees every task on the database, any new apply silently failed those resting tasks with a misleading "server may have crashed" message, voiding resumes and the operator retry budget.

Now only genuinely in-flight tasks (running, waiting_for_cutover, cutting_over, waiting_for_deploy, recovering) whose engine has gone silent are treated as abandoned. Resting `stopped`/`failed_retryable` tasks are left intact, and the existing conflict logic decides whether the new apply may proceed rather than running over paused work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)