### PR TITLE
fix(github): keep approval when a later review only comments

### DIFF
--- a/pkg/github/reviews.go
+++ b/pkg/github/reviews.go
@@ -57,11 +57,13 @@ func (ic *InstallationClient) ListReviews(ctx context.Context, repo string, pr i
 	return allReviews, nil
 }
 
-// GetApprovedReviewers returns usernames whose latest review is APPROVED.
-// Reviews are processed in chronological order; only the most recent review
-// per user counts.
+// GetApprovedReviewers returns usernames whose latest decisive review is
+// APPROVED. A user is approved iff their most recent APPROVED, CHANGES_REQUESTED,
+// or DISMISSED review is APPROVED. COMMENTED reviews are non-binding feedback in
+// GitHub's model and never alter a user's approval state, so they are ignored
+// when determining the latest decisive review. On equal timestamps the later
+// entry wins, matching GitHub's chronological ordering.
 func GetApprovedReviewers(reviews []*ReviewInfo) []string {
-	// Track each user's latest review by timestamp
 	type latestReview struct {
 		State       string
 		SubmittedAt time.Time
@@ -71,8 +73,11 @@ func GetApprovedReviewers(reviews []*ReviewInfo) []string {
 		if r.User == "" {
 			continue
 		}
+		if strings.EqualFold(r.State, ReviewCommented) {
+			continue
+		}
 		key := strings.ToLower(r.User)
-		if cur, ok := latest[key]; !ok || r.SubmittedAt.After(cur.SubmittedAt) {
+		if cur, ok := latest[key]; !ok || !r.SubmittedAt.Before(cur.SubmittedAt) {
 			latest[key] = latestReview{State: r.State, SubmittedAt: r.SubmittedAt}
 		}
 	}

--- a/pkg/github/reviews_test.go
+++ b/pkg/github/reviews_test.go
@@ -81,6 +81,7 @@ func TestParseCodeowners(t *testing.T) {
 }
 
 func TestGetApprovedReviewers(t *testing.T) {
+	sameSecond := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
 	tests := []struct {
 		name     string
 		reviews  []*ReviewInfo
@@ -103,6 +104,35 @@ func TestGetApprovedReviewers(t *testing.T) {
 			reviews: []*ReviewInfo{
 				{User: "alice", State: ReviewApproved, SubmittedAt: time.Now().Add(-time.Hour)},
 				{User: "alice", State: ReviewChangesRequested, SubmittedAt: time.Now()},
+			},
+			expected: nil,
+		},
+		{
+			// A reviewer who approves and then replies on a thread (which GitHub
+			// records as a COMMENTED review) keeps their approval, since COMMENTED
+			// reviews are non-binding feedback.
+			name: "approval then commented - still approved",
+			reviews: []*ReviewInfo{
+				{User: "alice", State: ReviewApproved, SubmittedAt: time.Now().Add(-time.Hour)},
+				{User: "alice", State: ReviewCommented, SubmittedAt: time.Now()},
+			},
+			expected: []string{"alice"},
+		},
+		{
+			// COMMENTED is non-binding feedback and never grants approval on its own.
+			name: "commented only - not approved",
+			reviews: []*ReviewInfo{
+				{User: "alice", State: ReviewCommented, SubmittedAt: time.Now()},
+			},
+			expected: nil,
+		},
+		{
+			// GitHub timestamps have second granularity, so a CHANGES_REQUESTED
+			// that follows an APPROVED in the same second must still win.
+			name: "approval then changes requested same timestamp - not approved",
+			reviews: []*ReviewInfo{
+				{User: "alice", State: ReviewApproved, SubmittedAt: sameSecond},
+				{User: "alice", State: ReviewChangesRequested, SubmittedAt: sameSecond},
 			},
 			expected: nil,
 		},


### PR DESCRIPTION
A reviewer who approves a PR and then replies on a thread submits a COMMENTED review. In GitHub's model a COMMENTED review is non-binding feedback and does not invalidate an earlier approval — only a later CHANGES_REQUESTED or an explicit dismissal does. `GetApprovedReviewers` previously kept each user's single latest review by timestamp, so a trailing comment silently dropped the approval and the review gate blocked the apply with a misleading "review required".

This change ignores COMMENTED reviews when computing each user's latest decisive review state, and breaks timestamp ties in favor of the later entry so a same-second CHANGES_REQUESTED following an APPROVED still wins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)