### PR TITLE
fix(github): fail closed when a schema directory exceeds the Contents API cap

### DIFF
--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -976,6 +976,13 @@ func (ic *InstallationClient) FetchFileContent(ctx context.Context, repo, filePa
 	return content, nil
 }
 
+// GitHub caps the Contents API directory listing at this documented maximum and
+// does not paginate or provide a completeness marker for larger directories.
+// Treat reaching the cap as incomplete so schema discovery fails closed instead
+// of silently dropping the lexicographic tail, which would surface as spurious
+// DROP TABLE proposals or missed changes in the declarative differ.
+const maxGitHubDirEntries = 1000
+
 func (ic *InstallationClient) fetchDirectoryContents(ctx context.Context, repo, dirPath, ref string) ([]*gh.RepositoryContent, error) {
 	owner, repoName := splitRepo(repo)
 	opts := &gh.RepositoryContentGetOptions{Ref: ref}
@@ -985,6 +992,9 @@ func (ic *InstallationClient) fetchDirectoryContents(ctx context.Context, repo, 
 	}
 	if fileContent != nil {
 		return nil, fmt.Errorf("expected directory at %s, found file", dirPath)
+	}
+	if len(directoryContent) >= maxGitHubDirEntries {
+		return nil, fmt.Errorf("list schema directory %s in repo %s ref %s reached GitHub Contents API limit: %w", dirPath, repo, ref, ErrDirListingCapped)
 	}
 	return directoryContent, nil
 }

--- a/pkg/github/client_test.go
+++ b/pkg/github/client_test.go
@@ -1,6 +1,7 @@
 package github
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"io"
 	"log/slog"
@@ -222,6 +223,68 @@ func TestFindCheckRunByNameErrorsWhenOwnAppSlugUnknown(t *testing.T) {
 	assert.Contains(t, err.Error(), "abc123")
 	assert.Nil(t, result)
 	assert.Equal(t, int64(0), requests.Load())
+}
+
+// A schema directory listed via the GitHub Contents API at the documented
+// 1000-entry cap is treated as truncated: schema discovery fails closed with an
+// error naming the directory rather than proceeding with a possibly-incomplete
+// list, which would otherwise surface as spurious DROP TABLE proposals or missed
+// changes in the declarative differ.
+func TestFetchSchemaFilesOptimizedFailsClosedWhenDirectoryAtCap(t *testing.T) {
+	client, mux := setupRateLimitedTestGitHubServer(t)
+
+	entries := make([]gh.RepositoryContent, 0, maxGitHubDirEntries)
+	for i := range maxGitHubDirEntries {
+		name := "t" + strconv.Itoa(i) + ".sql"
+		entries = append(entries, gh.RepositoryContent{
+			Type: new("file"),
+			Name: new(name),
+			Path: new("schema/" + name),
+		})
+	}
+	mux.HandleFunc("GET /repos/octocat/hello-world/contents/schema", func(w http.ResponseWriter, _ *http.Request) {
+		require.NoError(t, json.NewEncoder(w).Encode(entries))
+	})
+
+	ic := NewInstallationClient(client, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	files, err := ic.FetchSchemaFilesOptimized(t.Context(), "octocat/hello-world", "abc123", "schema", "mysql")
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrDirListingCapped)
+	assert.Contains(t, err.Error(), "schema")
+	assert.Nil(t, files)
+}
+
+// A schema directory below the Contents API cap is listed and its managed
+// schema files are fetched unchanged.
+func TestFetchSchemaFilesOptimizedSmallDirectory(t *testing.T) {
+	client, mux := setupRateLimitedTestGitHubServer(t)
+
+	mux.HandleFunc("GET /repos/octocat/hello-world/contents/schema", func(w http.ResponseWriter, _ *http.Request) {
+		entries := []gh.RepositoryContent{
+			{Type: new("file"), Name: new("users.sql"), Path: new("schema/users.sql")},
+			{Type: new("file"), Name: new("README.md"), Path: new("schema/README.md")},
+		}
+		require.NoError(t, json.NewEncoder(w).Encode(entries))
+	})
+	mux.HandleFunc("GET /repos/octocat/hello-world/contents/schema/users.sql", func(w http.ResponseWriter, _ *http.Request) {
+		require.NoError(t, json.NewEncoder(w).Encode(gh.RepositoryContent{
+			Type:     new("file"),
+			Name:     new("users.sql"),
+			Path:     new("schema/users.sql"),
+			Encoding: new("base64"),
+			Content:  new(base64.StdEncoding.EncodeToString([]byte("CREATE TABLE users (id INT);"))),
+		}))
+	})
+
+	ic := NewInstallationClient(client, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	files, err := ic.FetchSchemaFilesOptimized(t.Context(), "octocat/hello-world", "abc123", "schema", "mysql")
+
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+	assert.Equal(t, "users.sql", files[0].Name)
+	assert.Equal(t, "schema/users.sql", files[0].Path)
+	assert.Equal(t, "CREATE TABLE users (id INT);", files[0].Content)
 }
 
 func setupRateLimitedTestGitHubServer(t *testing.T) (*gh.Client, *http.ServeMux) {

--- a/pkg/github/config.go
+++ b/pkg/github/config.go
@@ -50,6 +50,7 @@ var (
 	ErrMultipleConfigs   = fmt.Errorf("multiple schemabot.yaml configs found - use -d flag to specify database")
 	ErrGitTreeTruncated  = fmt.Errorf("GitHub returned a truncated repository tree; config discovery is incomplete")
 	ErrPRFilesIncomplete = fmt.Errorf("GitHub returned the maximum number of pull request files; config discovery is incomplete")
+	ErrDirListingCapped  = fmt.Errorf("GitHub returned the maximum number of directory entries; schema discovery is incomplete")
 )
 
 // DatabaseNotFoundError indicates the specified database was not found in any config.

--- a/pkg/github/config.go
+++ b/pkg/github/config.go
@@ -45,9 +45,14 @@ const ConfigFileName = "schemabot.yaml"
 
 // Config discovery errors.
 var (
-	ErrNoConfig          = fmt.Errorf("no schemabot.yaml config found")
-	ErrInvalidConfig     = fmt.Errorf("invalid schemabot.yaml config found")
-	ErrMultipleConfigs   = fmt.Errorf("multiple schemabot.yaml configs found - use -d flag to specify database")
+	ErrNoConfig        = fmt.Errorf("no schemabot.yaml config found")
+	ErrInvalidConfig   = fmt.Errorf("invalid schemabot.yaml config found")
+	ErrMultipleConfigs = fmt.Errorf("multiple schemabot.yaml configs found - use -d flag to specify database")
+)
+
+// Incomplete-data errors signal that GitHub returned a capped or truncated
+// listing, so the set of files or directories SchemaBot examined may be partial.
+var (
 	ErrGitTreeTruncated  = fmt.Errorf("GitHub returned a truncated repository tree; config discovery is incomplete")
 	ErrPRFilesIncomplete = fmt.Errorf("GitHub returned the maximum number of pull request files; config discovery is incomplete")
 	ErrDirListingCapped  = fmt.Errorf("GitHub returned the maximum number of directory entries; schema discovery is incomplete")


### PR DESCRIPTION
The GitHub Contents API lists at most 1000 entries per directory with no pagination and no truncation marker. Schema discovery walked these listings assuming they were complete, so a schema or namespace directory with more than 1000 entries silently dropped the lexicographic tail. In the declarative differ, missing desired-schema files produce spurious DROP TABLE proposals or missed changes.

This now fails closed in `fetchDirectoryContents` when a listing reaches the documented cap, returning a sentinel error (`ErrDirListingCapped`) that names the directory and explains the cap. This mirrors the existing fail-closed guards for the Git Trees fallback (`ErrGitTreeTruncated`) and PR file listing (`ErrPRFilesIncomplete`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)