### PR TITLE
fix(config): validate revert_window_duration and token references

### DIFF
--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -1356,15 +1356,20 @@ func (c EnvironmentConfig) ResolveDSN() (string, error) {
 }
 
 // validateRevertWindowDuration ensures a configured revert window parses as a
-// Go duration. An empty value means "use the engine default"; only a non-empty
-// unparseable value is rejected so a typo fails closed at config load instead of
-// silently reverting to the default window.
+// positive Go duration. An empty value means "use the engine default". A
+// non-empty value that is unparseable or non-positive is rejected so a typo or
+// a meaningless window fails closed at config load instead of silently reverting
+// to the default window.
 func (c EnvironmentConfig) validateRevertWindowDuration(context string) error {
 	if c.RevertWindowDuration == "" {
 		return nil
 	}
-	if _, err := time.ParseDuration(c.RevertWindowDuration); err != nil {
+	d, err := time.ParseDuration(c.RevertWindowDuration)
+	if err != nil {
 		return fmt.Errorf("%s revert_window_duration %q is not a valid duration: %w", context, c.RevertWindowDuration, err)
+	}
+	if d <= 0 {
+		return fmt.Errorf("%s revert_window_duration %q must be positive (omit it to use the engine default)", context, c.RevertWindowDuration)
 	}
 	return nil
 }

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -650,6 +650,9 @@ func (c *ServerConfig) Validate() error {
 			return fmt.Errorf("database %q has no environments configured", name)
 		}
 		for env, envConfig := range dbConfig.Environments {
+			if err := envConfig.validateRevertWindowDuration(fmt.Sprintf("database %q environment %q", name, env)); err != nil {
+				return err
+			}
 			hasDSN := envConfig.HasLocalDSN()
 			hasScalarRouting := envConfig.Target != "" || envConfig.Deployment != ""
 			hasMapRouting := envConfig.Deployments != nil
@@ -1350,6 +1353,20 @@ func (c EnvironmentConfig) ResolveDSN() (string, error) {
 		return c.DSNFrom.Resolve()
 	}
 	return secrets.Resolve(c.DSN, "")
+}
+
+// validateRevertWindowDuration ensures a configured revert window parses as a
+// Go duration. An empty value means "use the engine default"; only a non-empty
+// unparseable value is rejected so a typo fails closed at config load instead of
+// silently reverting to the default window.
+func (c EnvironmentConfig) validateRevertWindowDuration(context string) error {
+	if c.RevertWindowDuration == "" {
+		return nil
+	}
+	if _, err := time.ParseDuration(c.RevertWindowDuration); err != nil {
+		return fmt.Errorf("%s revert_window_duration %q is not a valid duration: %w", context, c.RevertWindowDuration, err)
+	}
+	return nil
 }
 
 func (c *DSNFromConfig) Validate(context string) error {

--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -570,6 +570,31 @@ func TestServerConfig_ValidateRejectsInvalidRevertWindowDuration(t *testing.T) {
 	assert.Contains(t, err.Error(), "not a valid duration")
 }
 
+// A revert_window_duration that parses but is non-positive ("0", "-5m") is
+// rejected so a meaningless window fails closed at config load instead of
+// silently reverting to the engine default window.
+func TestServerConfig_ValidateRejectsNonPositiveRevertWindowDuration(t *testing.T) {
+	for _, value := range []string{"0", "0s", "-5m"} {
+		t.Run(value, func(t *testing.T) {
+			cfg := ServerConfig{
+				Databases: map[string]DatabaseConfig{
+					"mydb": {
+						Type: "vitess",
+						Environments: map[string]EnvironmentConfig{
+							"staging": {DSN: "root@tcp(localhost)/mydb", RevertWindowDuration: value},
+						},
+					},
+				},
+			}
+
+			err := cfg.Validate()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), `database "mydb" environment "staging" revert_window_duration "`+value+`"`)
+			assert.Contains(t, err.Error(), "must be positive")
+		})
+	}
+}
+
 // A well-formed revert_window_duration parses to the configured window.
 func TestServerConfig_ValidateAcceptsValidRevertWindowDuration(t *testing.T) {
 	cfg := ServerConfig{

--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -549,6 +549,64 @@ func TestServerConfig_ValidateRejectsLocalRemoteRouteCollision(t *testing.T) {
 	assert.Contains(t, err.Error(), `tern_deployments also defines deployment "primary"`)
 }
 
+// A non-empty but unparseable revert_window_duration is a startup config error
+// so a typo (e.g. "30 minutes") fails closed instead of silently reverting to
+// the engine default window.
+func TestServerConfig_ValidateRejectsInvalidRevertWindowDuration(t *testing.T) {
+	cfg := ServerConfig{
+		Databases: map[string]DatabaseConfig{
+			"mydb": {
+				Type: "vitess",
+				Environments: map[string]EnvironmentConfig{
+					"staging": {DSN: "root@tcp(localhost)/mydb", RevertWindowDuration: "30 minutes"},
+				},
+			},
+		},
+	}
+
+	err := cfg.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `database "mydb" environment "staging" revert_window_duration "30 minutes"`)
+	assert.Contains(t, err.Error(), "not a valid duration")
+}
+
+// A well-formed revert_window_duration parses to the configured window.
+func TestServerConfig_ValidateAcceptsValidRevertWindowDuration(t *testing.T) {
+	cfg := ServerConfig{
+		Databases: map[string]DatabaseConfig{
+			"mydb": {
+				Type: "vitess",
+				Environments: map[string]EnvironmentConfig{
+					"staging": {DSN: "root@tcp(localhost)/mydb", RevertWindowDuration: "4h"},
+				},
+			},
+		},
+	}
+
+	require.NoError(t, cfg.Validate())
+
+	parsed, err := time.ParseDuration(cfg.Databases["mydb"].Environments["staging"].RevertWindowDuration)
+	require.NoError(t, err)
+	assert.Equal(t, 4*time.Hour, parsed)
+}
+
+// An empty revert_window_duration is valid and leaves the engine default in
+// place — only a non-empty unparseable value is rejected.
+func TestServerConfig_ValidateAllowsEmptyRevertWindowDuration(t *testing.T) {
+	cfg := ServerConfig{
+		Databases: map[string]DatabaseConfig{
+			"mydb": {
+				Type: "vitess",
+				Environments: map[string]EnvironmentConfig{
+					"staging": {DSN: "root@tcp(localhost)/mydb"},
+				},
+			},
+		},
+	}
+
+	require.NoError(t, cfg.Validate())
+}
+
 func TestServerConfig_ValidateSourcePolicy(t *testing.T) {
 	baseConfig := func(allowedDirs []string) ServerConfig {
 		return ServerConfig{

--- a/pkg/api/service.go
+++ b/pkg/api/service.go
@@ -327,6 +327,20 @@ func (s *Service) RegisterTernClient(deployment, environment string, client tern
 	s.ternClients[key] = client
 }
 
+// malformedTokenError builds an error for a token that did not parse into a
+// name:value pair. The secrets resolver returns literal (unprefixed) values
+// as-is, so when the resolved token equals the configured ref the ref *is* the
+// raw credential and must not be echoed. Only a true reference indirection
+// (ref resolved to a different value, e.g. via env:/file:/secretsmanager:) is
+// safe to print; for a literal we redact it, since the config key alone is
+// enough for triage.
+func malformedTokenError(key, ref, resolved, requirement string) error {
+	if resolved != ref {
+		return fmt.Errorf("token for %s resolved from %q %s", key, ref, requirement)
+	}
+	return fmt.Errorf("token for %s (literal value redacted) %s", key, requirement)
+}
+
 func (s *Service) newLocalTernClient(key, database, dbType string, envConfig EnvironmentConfig) (tern.Client, error) {
 	// Resolve target DSN (handles env:, file: prefixes and structured DSN sources)
 	targetDSN, err := envConfig.ResolveDSN()
@@ -334,7 +348,10 @@ func (s *Service) newLocalTernClient(key, database, dbType string, envConfig Env
 		return nil, fmt.Errorf("resolve DSN for %s: %w", key, err)
 	}
 
-	// Resolve PlanetScale token if configured
+	// Resolve PlanetScale token if configured. Token validation is intentionally
+	// first-use here (at client creation) rather than fail-fast at config load,
+	// unlike revert_window_duration: resolving a token may require a call to a
+	// secrets backend, so it is deferred until the client is actually built.
 	var tokenName, tokenValue string
 	if envConfig.TokenSecretRef != "" {
 		token, err := secrets.Resolve(envConfig.TokenSecretRef, "")
@@ -343,12 +360,12 @@ func (s *Service) newLocalTernClient(key, database, dbType string, envConfig Env
 		}
 		parts := strings.SplitN(token, ":", 2)
 		if len(parts) != 2 {
-			return nil, fmt.Errorf("token for %s resolved from %q must be in name:value format", key, envConfig.TokenSecretRef)
+			return nil, malformedTokenError(key, envConfig.TokenSecretRef, token, "must be in name:value format")
 		}
 		tokenName = strings.TrimSpace(parts[0])
 		tokenValue = strings.TrimSpace(parts[1])
 		if tokenName == "" || tokenValue == "" {
-			return nil, fmt.Errorf("token for %s resolved from %q must be in name:value format with a non-empty name and value", key, envConfig.TokenSecretRef)
+			return nil, malformedTokenError(key, envConfig.TokenSecretRef, token, "must be in name:value format with a non-empty name and value")
 		}
 	}
 
@@ -375,6 +392,13 @@ func (s *Service) newLocalTernClient(key, database, dbType string, envConfig Env
 			return nil, fmt.Errorf("revert_window_duration %q for %s must be positive (omit it to use the engine default)", envConfig.RevertWindowDuration, key)
 		}
 		revertWindow = d
+		// Revert is engine-dependent: only Vitess/PlanetScale honors a revert
+		// window. A window configured on a plain MySQL database is accepted but
+		// ignored, so warn to surface the likely misconfiguration.
+		if dbType == storage.DatabaseTypeMySQL {
+			s.logger.Warn("revert_window_duration is configured but ignored for a MySQL database; revert is engine-dependent",
+				"key", key, "database", database, "revert_window_duration", revertWindow.String())
+		}
 	}
 	metadata := map[string]string{
 		"organization": envConfig.Organization,

--- a/pkg/api/service.go
+++ b/pkg/api/service.go
@@ -342,9 +342,10 @@ func (s *Service) newLocalTernClient(key, database, dbType string, envConfig Env
 			return nil, fmt.Errorf("resolve token for %s: %w", key, err)
 		}
 		parts := strings.SplitN(token, ":", 2)
-		if len(parts) == 2 {
-			tokenName, tokenValue = parts[0], parts[1]
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("token for %s resolved from %q must be in name:value format", key, envConfig.TokenSecretRef)
 		}
+		tokenName, tokenValue = parts[0], parts[1]
 	}
 
 	// Register TLS config for PlanetScale MySQL connections if configured
@@ -356,12 +357,16 @@ func (s *Service) newLocalTernClient(key, database, dbType string, envConfig Env
 		}
 	}
 
-	// LocalClient uses SchemaBot's storage directly
+	// LocalClient uses SchemaBot's storage directly. ServerConfig.Validate
+	// rejects an unparseable revert_window_duration at config load; parse here
+	// fails closed rather than silently falling back to the default window.
 	var revertWindow time.Duration
 	if envConfig.RevertWindowDuration != "" {
-		if d, err := time.ParseDuration(envConfig.RevertWindowDuration); err == nil {
-			revertWindow = d
+		d, err := time.ParseDuration(envConfig.RevertWindowDuration)
+		if err != nil {
+			return nil, fmt.Errorf("parse revert_window_duration %q for %s: %w", envConfig.RevertWindowDuration, key, err)
 		}
+		revertWindow = d
 	}
 	metadata := map[string]string{
 		"organization": envConfig.Organization,

--- a/pkg/api/service.go
+++ b/pkg/api/service.go
@@ -345,7 +345,11 @@ func (s *Service) newLocalTernClient(key, database, dbType string, envConfig Env
 		if len(parts) != 2 {
 			return nil, fmt.Errorf("token for %s resolved from %q must be in name:value format", key, envConfig.TokenSecretRef)
 		}
-		tokenName, tokenValue = parts[0], parts[1]
+		tokenName = strings.TrimSpace(parts[0])
+		tokenValue = strings.TrimSpace(parts[1])
+		if tokenName == "" || tokenValue == "" {
+			return nil, fmt.Errorf("token for %s resolved from %q must be in name:value format with a non-empty name and value", key, envConfig.TokenSecretRef)
+		}
 	}
 
 	// Register TLS config for PlanetScale MySQL connections if configured
@@ -358,13 +362,17 @@ func (s *Service) newLocalTernClient(key, database, dbType string, envConfig Env
 	}
 
 	// LocalClient uses SchemaBot's storage directly. ServerConfig.Validate
-	// rejects an unparseable revert_window_duration at config load; parse here
-	// fails closed rather than silently falling back to the default window.
+	// rejects an unparseable or non-positive revert_window_duration at config
+	// load; parsing here fails closed rather than silently falling back to the
+	// default window.
 	var revertWindow time.Duration
 	if envConfig.RevertWindowDuration != "" {
 		d, err := time.ParseDuration(envConfig.RevertWindowDuration)
 		if err != nil {
 			return nil, fmt.Errorf("parse revert_window_duration %q for %s: %w", envConfig.RevertWindowDuration, key, err)
+		}
+		if d <= 0 {
+			return nil, fmt.Errorf("revert_window_duration %q for %s must be positive (omit it to use the engine default)", envConfig.RevertWindowDuration, key)
 		}
 		revertWindow = d
 	}

--- a/pkg/api/service_test.go
+++ b/pkg/api/service_test.go
@@ -194,3 +194,23 @@ func TestServiceDeploymentForDatabaseEnvironment(t *testing.T) {
 	_, err = service.deploymentForDatabaseEnvironment("missing", "", "staging")
 	require.Error(t, err)
 }
+
+// A PlanetScale token reference that resolves to a value without the name:value
+// separator is rejected when building the local client, rather than silently
+// producing an empty token name and value.
+func TestNewLocalTernClient_RejectsMalformedTokenReference(t *testing.T) {
+	cfg := &ServerConfig{}
+	service := New(nil, cfg, nil, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	envConfig := EnvironmentConfig{
+		DSN:            "root@tcp(localhost:3306)/mydb",
+		Organization:   "acme",
+		TokenSecretRef: "no-separator-token",
+	}
+
+	_, err := service.newLocalTernClient("vitessdb-staging", "vitessdb", "vitess", envConfig)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "vitessdb-staging")
+	assert.Contains(t, err.Error(), `"no-separator-token"`)
+	assert.Contains(t, err.Error(), "name:value format")
+}

--- a/pkg/api/service_test.go
+++ b/pkg/api/service_test.go
@@ -195,47 +195,86 @@ func TestServiceDeploymentForDatabaseEnvironment(t *testing.T) {
 	require.Error(t, err)
 }
 
-// A PlanetScale token reference that resolves to a value without the name:value
-// separator is rejected when building the local client, rather than silently
-// producing an empty token name and value.
-func TestNewLocalTernClient_RejectsMalformedTokenReference(t *testing.T) {
+// A PlanetScale token configured as a literal (the secrets resolver returns
+// unprefixed values as-is) that lacks the name:value separator is rejected when
+// building the local client. The literal is the raw credential, so the error
+// redacts it and identifies the environment by its config key instead.
+func TestNewLocalTernClient_RejectsMalformedLiteralTokenWithoutLeakingValue(t *testing.T) {
 	cfg := &ServerConfig{}
 	service := New(nil, cfg, nil, slog.New(slog.NewTextHandler(io.Discard, nil)))
 
+	const secretLiteral = "pscale_tkn_supersecretvalue"
 	envConfig := EnvironmentConfig{
 		DSN:            "root@tcp(localhost:3306)/mydb",
 		Organization:   "acme",
-		TokenSecretRef: "no-separator-token",
+		TokenSecretRef: secretLiteral,
 	}
 
 	_, err := service.newLocalTernClient("vitessdb-staging", "vitessdb", "vitess", envConfig)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "vitessdb-staging")
-	assert.Contains(t, err.Error(), `"no-separator-token"`)
+	assert.Contains(t, err.Error(), "literal value redacted")
 	assert.Contains(t, err.Error(), "name:value format")
+	assert.NotContains(t, err.Error(), secretLiteral)
 }
 
-// A PlanetScale token reference that resolves to a value with the name:value
-// separator present but an empty name or empty value is rejected, rather than
-// silently producing an empty token name or value.
-func TestNewLocalTernClient_RejectsTokenReferenceWithEmptyParts(t *testing.T) {
+// A literal PlanetScale token with the name:value separator present but an empty
+// name or value is also redacted: the whole literal is the credential, so the
+// error never echoes it. Each case carries a distinctive secret fragment that
+// must be absent from the error.
+func TestNewLocalTernClient_RejectsLiteralTokenWithEmptyPartsWithoutLeakingValue(t *testing.T) {
 	cfg := &ServerConfig{}
 	service := New(nil, cfg, nil, slog.New(slog.NewTextHandler(io.Discard, nil)))
 
-	for _, ref := range []string{":secret", "name:", "  :  "} {
-		t.Run(ref, func(t *testing.T) {
+	cases := []struct {
+		ref      string
+		fragment string // distinctive credential text that must not appear in the error
+	}{
+		{ref: ":supersecretvalue", fragment: "supersecretvalue"},
+		{ref: "supersecretname:", fragment: "supersecretname"},
+		{ref: "  :  ", fragment: "  :  "},
+	}
+	for _, tc := range cases {
+		t.Run(tc.ref, func(t *testing.T) {
 			envConfig := EnvironmentConfig{
 				DSN:            "root@tcp(localhost:3306)/mydb",
 				Organization:   "acme",
-				TokenSecretRef: ref,
+				TokenSecretRef: tc.ref,
 			}
 
 			_, err := service.newLocalTernClient("vitessdb-staging", "vitessdb", "vitess", envConfig)
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), "vitessdb-staging")
+			assert.Contains(t, err.Error(), "literal value redacted")
 			assert.Contains(t, err.Error(), "non-empty name and value")
+			assert.NotContains(t, err.Error(), tc.fragment)
 		})
 	}
+}
+
+// A token configured as a real reference indirection (e.g. env:VAR) that
+// resolves to a malformed value is rejected with the reference echoed: the
+// reference names where the credential lives, not the credential itself, so it
+// is safe to surface for triage while the resolved secret value stays hidden.
+func TestNewLocalTernClient_RejectsMalformedTokenReferenceEchoingTheReference(t *testing.T) {
+	cfg := &ServerConfig{}
+	service := New(nil, cfg, nil, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	const secretValue = "no-separator-secret-value"
+	t.Setenv("SCHEMABOT_TEST_TOKEN", secretValue)
+
+	envConfig := EnvironmentConfig{
+		DSN:            "root@tcp(localhost:3306)/mydb",
+		Organization:   "acme",
+		TokenSecretRef: "env:SCHEMABOT_TEST_TOKEN",
+	}
+
+	_, err := service.newLocalTernClient("vitessdb-staging", "vitessdb", "vitess", envConfig)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "vitessdb-staging")
+	assert.Contains(t, err.Error(), `"env:SCHEMABOT_TEST_TOKEN"`)
+	assert.Contains(t, err.Error(), "name:value format")
+	assert.NotContains(t, err.Error(), secretValue)
 }
 
 // A PlanetScale token reference that resolves to a well-formed name:value pair

--- a/pkg/api/service_test.go
+++ b/pkg/api/service_test.go
@@ -214,3 +214,43 @@ func TestNewLocalTernClient_RejectsMalformedTokenReference(t *testing.T) {
 	assert.Contains(t, err.Error(), `"no-separator-token"`)
 	assert.Contains(t, err.Error(), "name:value format")
 }
+
+// A PlanetScale token reference that resolves to a value with the name:value
+// separator present but an empty name or empty value is rejected, rather than
+// silently producing an empty token name or value.
+func TestNewLocalTernClient_RejectsTokenReferenceWithEmptyParts(t *testing.T) {
+	cfg := &ServerConfig{}
+	service := New(nil, cfg, nil, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	for _, ref := range []string{":secret", "name:", "  :  "} {
+		t.Run(ref, func(t *testing.T) {
+			envConfig := EnvironmentConfig{
+				DSN:            "root@tcp(localhost:3306)/mydb",
+				Organization:   "acme",
+				TokenSecretRef: ref,
+			}
+
+			_, err := service.newLocalTernClient("vitessdb-staging", "vitessdb", "vitess", envConfig)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "vitessdb-staging")
+			assert.Contains(t, err.Error(), "non-empty name and value")
+		})
+	}
+}
+
+// A PlanetScale token reference that resolves to a well-formed name:value pair
+// is accepted when building the local client.
+func TestNewLocalTernClient_AcceptsWellFormedTokenReference(t *testing.T) {
+	cfg := &ServerConfig{}
+	service := New(nil, cfg, nil, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	envConfig := EnvironmentConfig{
+		DSN:            "root@tcp(localhost:3306)/mydb",
+		Organization:   "acme",
+		TokenSecretRef: "name:value",
+	}
+
+	client, err := service.newLocalTernClient("vitessdb-staging", "vitessdb", "vitess", envConfig)
+	require.NoError(t, err)
+	assert.NotNil(t, client)
+}

--- a/pkg/tern/local_apply_grouped.go
+++ b/pkg/tern/local_apply_grouped.go
@@ -619,15 +619,30 @@ func (c *LocalClient) markRevertSkipped(ctx context.Context, apply *storage.Appl
 	}
 }
 
-// revertWindowDuration returns the configured revert window duration,
-// falling back to PlanetScale's default of 30 minutes.
+// revertWindowDuration returns the configured revert window duration, falling
+// back to the engine default when none is set. The server writes a canonical,
+// already-validated duration into metadata, so a malformed value only reaches
+// here when an embedder populates metadata directly. Rather than silently
+// using the default — which would hide a misconfigured revert window — an
+// unparseable or non-positive value is surfaced via a warning before falling
+// back, so the whole class of bad input is observable.
 func (c *LocalClient) revertWindowDuration() time.Duration {
-	if s := c.config.Metadata["revert_window_duration"]; s != "" {
-		if d, err := time.ParseDuration(s); err == nil && d > 0 {
-			return d
-		}
+	s := c.config.Metadata["revert_window_duration"]
+	if s == "" {
+		return defaultRevertWindowDuration
 	}
-	return defaultRevertWindowDuration
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		c.logger.Warn("invalid revert_window_duration metadata; using engine default",
+			"database", c.config.Database, "value", s, "default", defaultRevertWindowDuration, "error", err)
+		return defaultRevertWindowDuration
+	}
+	if d <= 0 {
+		c.logger.Warn("non-positive revert_window_duration metadata; using engine default",
+			"database", c.config.Database, "value", s, "default", defaultRevertWindowDuration)
+		return defaultRevertWindowDuration
+	}
+	return d
 }
 
 // revertWindowDeadline computes when the revert window expires.

--- a/pkg/tern/local_client_test.go
+++ b/pkg/tern/local_client_test.go
@@ -1094,3 +1094,87 @@ func attrValues(t *testing.T, attrs []any) map[string]any {
 	}
 	return values
 }
+
+// capturedLog records a single emitted log record's level, message, and
+// attributes for assertions.
+type capturedLog struct {
+	level slog.Level
+	msg   string
+	attrs map[string]any
+}
+
+// captureHandler is a minimal slog.Handler that records every emitted record so
+// tests can assert on level, message, and attributes.
+type captureHandler struct {
+	records *[]capturedLog
+}
+
+func (h captureHandler) Enabled(context.Context, slog.Level) bool { return true }
+
+func (h captureHandler) Handle(_ context.Context, r slog.Record) error {
+	attrs := make(map[string]any, r.NumAttrs())
+	r.Attrs(func(a slog.Attr) bool {
+		attrs[a.Key] = a.Value.Any()
+		return true
+	})
+	*h.records = append(*h.records, capturedLog{level: r.Level, msg: r.Message, attrs: attrs})
+	return nil
+}
+
+func (h captureHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h captureHandler) WithGroup(string) slog.Handler      { return h }
+
+// A canonical, positive revert_window_duration in metadata is honored, while an
+// empty value falls back to the engine default. A malformed or non-positive
+// value — which the server never writes but an embedder populating metadata
+// directly can — fails observably: it warns with the offending value and the
+// engine default rather than silently defaulting.
+func TestLocalClient_RevertWindowDuration(t *testing.T) {
+	tests := []struct {
+		name      string
+		value     string
+		want      time.Duration
+		wantWarn  bool
+		warnValue string
+	}{
+		{name: "honors a valid positive duration", value: "45m", want: 45 * time.Minute},
+		{name: "empty uses engine default", value: "", want: defaultRevertWindowDuration},
+		{name: "unparseable warns and uses default", value: "not-a-duration", want: defaultRevertWindowDuration, wantWarn: true, warnValue: "not-a-duration"},
+		{name: "zero warns and uses default", value: "0s", want: defaultRevertWindowDuration, wantWarn: true, warnValue: "0s"},
+		{name: "negative warns and uses default", value: "-5m", want: defaultRevertWindowDuration, wantWarn: true, warnValue: "-5m"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var records []capturedLog
+			client := &LocalClient{
+				config: LocalConfig{
+					Database: "orders",
+					Metadata: map[string]string{"revert_window_duration": tc.value},
+				},
+				logger: slog.New(captureHandler{records: &records}),
+			}
+
+			got := client.revertWindowDuration()
+			assert.Equal(t, tc.want, got)
+
+			var warnings []capturedLog
+			for _, r := range records {
+				if r.level == slog.LevelWarn {
+					warnings = append(warnings, r)
+				}
+			}
+
+			if !tc.wantWarn {
+				assert.Empty(t, warnings, "no warning expected")
+				return
+			}
+
+			require.Len(t, warnings, 1, "exactly one warning expected")
+			w := warnings[0]
+			assert.Equal(t, tc.warnValue, w.attrs["value"])
+			assert.Equal(t, "orders", w.attrs["database"])
+			assert.Equal(t, defaultRevertWindowDuration, w.attrs["default"])
+		})
+	}
+}


### PR DESCRIPTION
Two config parse errors were being silently swallowed, leaving operators with a different runtime behavior than they configured.

- `revert_window_duration`: a non-empty value that doesn't parse as a Go duration (e.g. `"30 minutes"`, a trailing space, a typo) was silently dropped, so the engine fell back to the default 30m window. An operator who configured a 4h window unknowingly got 30m. It's now validated in `ServerConfig.Validate()` so a bad value is a startup error, and the local client parse fails closed instead of reverting to the default. An empty value still means "use the default".
- Token reference: a resolved PlanetScale token without the `name:value` separator silently produced an empty token name and value. The malformed reference is now rejected with a clear error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)