### PR TITLE
fix(observability): stop logging target DSN prefix

### DIFF
--- a/pkg/tern/local_client.go
+++ b/pkg/tern/local_client.go
@@ -94,6 +94,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/go-sql-driver/mysql"
 	"github.com/google/uuid"
 
 	"github.com/block/schemabot/pkg/ddl"
@@ -280,11 +281,10 @@ func (c *LocalClient) Plan(ctx context.Context, req *ternv1.PlanRequest) (*ternv
 
 	creds := c.credentials()
 
-	c.logger.Info("LocalClient.Plan: calling engine",
-		"database", c.config.Database,
-		"target_dsn_prefix", c.config.TargetDSN[:min(len(c.config.TargetDSN), 40)],
-		"schema_file_count", len(schemaFiles),
-	)
+	planLogAttrs := []any{"database", c.config.Database}
+	planLogAttrs = append(planLogAttrs, dsnLogAttrs(c.config.TargetDSN)...)
+	planLogAttrs = append(planLogAttrs, "schema_file_count", len(schemaFiles))
+	c.logger.Info("LocalClient.Plan: calling engine", planLogAttrs...)
 
 	result, err := eng.Plan(ctx, &engine.PlanRequest{
 		Database:     c.config.Database,
@@ -1197,4 +1197,21 @@ func ensureMetadata(m map[string]string) map[string]string {
 		return make(map[string]string)
 	}
 	return m
+}
+
+// dsnLogAttrs returns slog key/value attributes describing a target DSN using
+// only non-sensitive fields (network address and database name). The DSN
+// password and raw DSN string are never included, so these attributes are safe
+// to emit in logs. If the DSN cannot be parsed, the attributes record that
+// parsing failed without echoing any part of the DSN, since a parse error
+// message can contain fragments of the credential-bearing string.
+func dsnLogAttrs(dsn string) []any {
+	cfg, err := mysql.ParseDSN(dsn)
+	if err != nil {
+		return []any{"target_dsn_parsed", false}
+	}
+	return []any{
+		"target_addr", cfg.Addr,
+		"target_db", cfg.DBName,
+	}
 }

--- a/pkg/tern/local_client_test.go
+++ b/pkg/tern/local_client_test.go
@@ -1038,3 +1038,59 @@ func TestRecoveringProtoConversion(t *testing.T) {
 	assert.Equal(t, ternv1.State_STATE_RECOVERING, storageStateToProto("recovering_cutover"))
 	assert.Equal(t, state.Apply.Recovering, ProtoStateToStorage(ternv1.State_STATE_RECOVERING))
 }
+
+// dsnLogAttrs describes a target DSN for logging using only the network address
+// and database name. The DSN password — even one containing reserved characters
+// like '/', '@', and ':' — must never appear in the emitted attributes, and the
+// host and database must be reported so operators can trace the target.
+func TestDSNLogAttrs(t *testing.T) {
+	const password = "p:a/ss@w:rd/with@special"
+	dsn := "appuser:" + password + "@tcp(db.example.internal:3306)/orders?parseTime=true"
+
+	attrs := dsnLogAttrs(dsn)
+
+	for _, a := range attrs {
+		if s, ok := a.(string); ok {
+			assert.NotContains(t, s, password, "log attribute must not contain the DSN password")
+		}
+	}
+
+	values := attrValues(t, attrs)
+	assert.Equal(t, "db.example.internal:3306", values["target_addr"])
+	assert.Equal(t, "orders", values["target_db"])
+	assert.NotContains(t, values, "target_dsn_prefix", "raw DSN prefix must not be logged")
+}
+
+// dsnLogAttrs records that parsing failed without echoing any part of an
+// unparseable DSN, so a malformed credential-bearing string never reaches logs.
+func TestDSNLogAttrsUnparseable(t *testing.T) {
+	const password = "secretpw"
+	// Missing the slash before the database name makes ParseDSN fail.
+	dsn := "appuser:" + password + "@tcp(db.example.internal:3306)"
+
+	attrs := dsnLogAttrs(dsn)
+
+	for _, a := range attrs {
+		if s, ok := a.(string); ok {
+			assert.NotContains(t, s, password, "failed-parse log attribute must not contain the DSN password")
+		}
+	}
+
+	values := attrValues(t, attrs)
+	assert.Equal(t, false, values["target_dsn_parsed"])
+	assert.NotContains(t, values, "target_addr")
+}
+
+// attrValues converts a flat slog key/value attribute slice into a map keyed by
+// attribute name for assertions.
+func attrValues(t *testing.T, attrs []any) map[string]any {
+	t.Helper()
+	require.Equal(t, 0, len(attrs)%2, "attributes must form key/value pairs")
+	values := make(map[string]any, len(attrs)/2)
+	for i := 0; i+1 < len(attrs); i += 2 {
+		key, ok := attrs[i].(string)
+		require.True(t, ok, "attribute key must be a string")
+		values[key] = attrs[i+1]
+	}
+	return values
+}


### PR DESCRIPTION
The `LocalClient.Plan` log emitted the first 40 characters of the target DSN. For a MySQL DSN (`user:password@tcp(host)/db`) those leading characters typically include the password, so credentials were written to logs.

This derives the log fields from the DSN via `mysql.ParseDSN` and emits only non-sensitive fields — the network address and database name. The raw DSN prefix is gone. If the DSN cannot be parsed, the log records that parsing failed without echoing any part of the DSN, since a parse error message can contain fragments of the credential-bearing string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)