### PR TITLE
fix(spirit): only infer namespace when a single schema namespace exists

### DIFF
--- a/pkg/engine/spirit/helpers.go
+++ b/pkg/engine/spirit/helpers.go
@@ -2,14 +2,15 @@ package spirit
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/block/spirit/pkg/dbconn"
 	"github.com/block/spirit/pkg/statement"
 	"github.com/go-sql-driver/mysql"
 
-	"github.com/block/schemabot/pkg/ddl"
 	"github.com/block/schemabot/pkg/schema"
 )
 
@@ -64,7 +65,14 @@ func mysqlTLSModeForHost(addr string) (string, bool) {
 
 // namespaceForTable finds which namespace a table belongs to by checking
 // which namespace's schema files define it. Uses Spirit's parser for accurate
-// table name extraction. Returns an error if no namespace can be matched.
+// table name extraction across every statement in each file.
+//
+// The namespace is the per-table progress-matching key, so it must be
+// deterministic. When the table's CREATE TABLE cannot be located — for example
+// a DROP TABLE plan, where the table no longer has a defining statement — the
+// namespace can only be inferred when exactly one namespace exists. With two or
+// more namespaces and no match, the table cannot be attributed to a single
+// namespace, so this returns an error rather than an arbitrary map key.
 func namespaceForTable(table string, sf schema.SchemaFiles) (string, error) {
 	for nsName, ns := range sf {
 		for filename, content := range ns.Files {
@@ -73,16 +81,55 @@ func namespaceForTable(table string, sf schema.SchemaFiles) (string, error) {
 			if baseName == table {
 				return nsName, nil
 			}
-			// Parse the file content — only match CREATE TABLE (the defining statement)
-			stmtType, tbl, err := ddl.ClassifyStatement(content)
-			if err == nil && stmtType == statement.StatementCreateTable && tbl == table {
+			// Match the table's CREATE TABLE (the defining statement) in any
+			// statement of the file, not only the first one.
+			defines, err := fileDefinesTable(content, table)
+			if err != nil {
+				return "", fmt.Errorf("classify schema file %q in namespace %q for table %q: %w", filename, nsName, table, err)
+			}
+			if defines {
 				return nsName, nil
 			}
 		}
 	}
-	// Single namespace: return the only one
-	for nsName := range sf {
-		return nsName, nil
+	// When the defining statement is absent, the namespace can only be inferred
+	// when there is exactly one namespace to attribute the table to.
+	if len(sf) == 1 {
+		for nsName := range sf {
+			return nsName, nil
+		}
 	}
-	return "", fmt.Errorf("no namespace found for table %q in schema files", table)
+	return "", fmt.Errorf("no namespace defines table %q among %d schema namespaces %v", table, len(sf), namespaceNames(sf))
+}
+
+// fileDefinesTable reports whether the file content contains a CREATE TABLE
+// statement for the given table. It classifies every statement in the file so
+// that multi-statement files map all of the tables they define. A file with no
+// parseable statements (empty or comment-only) defines no table and is not an
+// error.
+func fileDefinesTable(content, table string) (bool, error) {
+	results, err := statement.Classify(content)
+	if errors.Is(err, statement.ErrNoStatements) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("classify content: %w", err)
+	}
+	for _, c := range results {
+		if c.Type == statement.StatementCreateTable && c.Table == table {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// namespaceNames returns the sorted namespace keys for inclusion in error
+// messages so operators can see which namespaces were searched.
+func namespaceNames(sf schema.SchemaFiles) []string {
+	names := make([]string, 0, len(sf))
+	for nsName := range sf {
+		names = append(names, nsName)
+	}
+	sort.Strings(names)
+	return names
 }

--- a/pkg/engine/spirit/helpers_test.go
+++ b/pkg/engine/spirit/helpers_test.go
@@ -84,9 +84,9 @@ func TestNamespaceForTable(t *testing.T) {
 		},
 		"users": {
 			Files: map[string]string{
-				"users.sql":   "CREATE TABLE `users` (\n  `id` bigint NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci",
-				"orders.sql":  "CREATE TABLE `orders` (\n  `id` bigint NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci",
-				"migrate.sql": "ALTER TABLE `users` ADD COLUMN `email` varchar(255)",
+				"users.sql":  "CREATE TABLE `users` (\n  `id` bigint NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci",
+				"orders.sql": "CREATE TABLE `orders` (\n  `id` bigint NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci",
+				"change.sql": "ALTER TABLE `users` ADD COLUMN `email` varchar(255)",
 			},
 		},
 	}
@@ -123,32 +123,75 @@ func TestNamespaceForTable(t *testing.T) {
 		assert.Equal(t, "ns2", ns, "should match the namespace with CREATE TABLE, not ALTER/DROP/RENAME")
 	})
 
-	t.Run("single namespace fallback", func(t *testing.T) {
-		single := schema.SchemaFiles{
-			"default": {
+	// A single CREATE TABLE match in a multi-namespace setup always resolves to
+	// the same namespace, regardless of Go's randomized map iteration order.
+	t.Run("multi-namespace match is deterministic across map orderings", func(t *testing.T) {
+		for range 50 {
+			ns, err := namespaceForTable("orders", sf)
+			require.NoError(t, err)
+			require.Equal(t, "users", ns)
+		}
+	})
+
+	// A schema file containing several CREATE TABLE statements maps every table
+	// it defines to that file's namespace, not just the first statement.
+	t.Run("multi-statement file maps all defined tables", func(t *testing.T) {
+		multi := schema.SchemaFiles{
+			"catalog": {
 				Files: map[string]string{
-					"other.sql": "CREATE TABLE `other` (`id` bigint NOT NULL) ENGINE=InnoDB",
+					"schema.sql": "CREATE TABLE `products` (\n  `id` bigint NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;\nCREATE TABLE `categories` (\n  `id` bigint NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;",
+				},
+			},
+			"accounts": {
+				Files: map[string]string{
+					"users.sql": "CREATE TABLE `users` (\n  `id` bigint NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci",
 				},
 			},
 		}
-		ns, err := namespaceForTable("nonexistent", single)
+
+		first, err := namespaceForTable("products", multi)
+		require.NoError(t, err)
+		assert.Equal(t, "catalog", first)
+
+		// The second CREATE TABLE in the same file also resolves, proving every
+		// statement in the file is classified.
+		second, err := namespaceForTable("categories", multi)
+		require.NoError(t, err)
+		assert.Equal(t, "catalog", second)
+	})
+
+	// With exactly one namespace, a table whose CREATE is absent (such as a
+	// DROP TABLE plan) is attributed to that sole namespace.
+	t.Run("single namespace fallback returns the only namespace", func(t *testing.T) {
+		single := schema.SchemaFiles{
+			"default": {
+				Files: map[string]string{
+					"other.sql": "CREATE TABLE `other` (\n  `id` bigint NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci",
+				},
+			},
+		}
+		ns, err := namespaceForTable("dropped_table", single)
 		require.NoError(t, err)
 		assert.Equal(t, "default", ns)
 	})
 
-	t.Run("no match falls back to single namespace", func(t *testing.T) {
-		// When no CREATE TABLE matches but there's only one namespace, it's returned as fallback
-		single := schema.SchemaFiles{
-			"only": {Files: map[string]string{"x.sql": "CREATE TABLE `x` (`id` bigint NOT NULL) ENGINE=InnoDB"}},
+	// With two or more namespaces and no defining statement, the namespace is
+	// ambiguous. Returning an arbitrary map key would make per-table progress
+	// matching nondeterministic, so the lookup fails loudly instead.
+	t.Run("multi-namespace with no match returns an error", func(t *testing.T) {
+		for range 50 {
+			ns, err := namespaceForTable("dropped_table", sf)
+			require.Error(t, err)
+			assert.Empty(t, ns)
+			assert.Contains(t, err.Error(), "dropped_table")
+			assert.Contains(t, err.Error(), "billing")
+			assert.Contains(t, err.Error(), "users")
 		}
-		ns, err := namespaceForTable("nonexistent", single)
-		require.NoError(t, err)
-		assert.Equal(t, "only", ns)
 	})
 
-	t.Run("no namespace found with empty schema files", func(t *testing.T) {
-		empty := schema.SchemaFiles{}
-		_, err := namespaceForTable("nonexistent", empty)
-		assert.Error(t, err)
+	t.Run("empty schema files returns an error", func(t *testing.T) {
+		ns, err := namespaceForTable("nonexistent", schema.SchemaFiles{})
+		require.Error(t, err)
+		assert.Empty(t, ns)
 	})
 }


### PR DESCRIPTION
Fixes a correctness bug in the Spirit engine where a table's namespace could be inferred nondeterministically.

`namespaceForTable` maps each table change to a namespace so per-table progress can be matched. When no defining `CREATE TABLE` matched a table, the fallback returned an arbitrary map key. This is reachable for `DROP TABLE` plans (the table no longer has a `CREATE` in any schema file) and for tables that are not the first statement in a multi-statement file. Because Go map iteration order is randomized, the chosen namespace varied per run, and the namespace is the per-table progress-matching key — so progress matching could silently bind to the wrong table.

Changes:
- The single-namespace fallback now applies only when exactly one namespace exists.
- Every statement in each schema file is classified (not just the first), so multi-statement files map all of the tables they define.
- When the namespace is genuinely ambiguous in a multi-namespace setup, the lookup returns an error naming the table and the available namespaces instead of guessing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)