### PR TITLE
fix(api): reject null schema_files namespaces instead of panicking

### DIFF
--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -980,6 +980,31 @@ func TestPlanHandlerRejectsClientSuppliedSchemaPath(t *testing.T) {
 	assert.Contains(t, w.Body.String(), "schema_path")
 }
 
+// A null namespace value (JSON `{"default": null}`) is rejected with a clear
+// 400 instead of panicking the request goroutine in schema-files conversion.
+func TestPlanHandlerRejectsNullSchemaFilesNamespace(t *testing.T) {
+	svc := newTestService()
+	mux := http.NewServeMux()
+	svc.ConfigureRoutes(mux)
+
+	body := `{
+		"database": "payments",
+		"environment": "staging",
+		"type": "mysql",
+		"schema_files": {"default": null}
+	}`
+	req := httptest.NewRequestWithContext(t.Context(), "POST", "/api/plan", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	mux.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	var resp apitypes.ErrorResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Contains(t, resp.Error, `schema_files["default"] is null`)
+}
+
 func TestPlanHandlerSourcePolicyAllowsDirectSource(t *testing.T) {
 	cfg := &ServerConfig{
 		Databases: map[string]DatabaseConfig{

--- a/pkg/api/plan_handlers.go
+++ b/pkg/api/plan_handlers.go
@@ -670,19 +670,27 @@ func (s *Service) ExecuteRollbackPlan(ctx context.Context, database, environment
 	return planResponseFromProto(resp), nil
 }
 
-// validateSchemaFiles checks that schema_files has at least one namespace.
-// An empty Files map within a namespace is valid (signals "drop all tables"),
-// so we only reject when schema_files itself is missing.
+// validateSchemaFiles checks that schema_files has at least one namespace and
+// that every namespace carries a non-null value. An empty Files map within a
+// namespace is valid (signals "drop all tables"), so we only reject when
+// schema_files itself is missing or a namespace value is null.
 //
-// Returns a warning message if any namespace has empty files (could indicate
-// a JSON field name bug like "sql_files" instead of "files"). Callers should
-// log this but not reject the request.
+// A null namespace value (e.g. JSON `{"default": null}`) is rejected as a hard
+// error: it cannot be converted to schema files and is almost always a
+// malformed request.
+//
+// Returns a warning message if any namespace has an empty (but non-null) files
+// map (could indicate a JSON field name bug like "sql_files" instead of
+// "files"). Callers should log this but not reject the request.
 func validateSchemaFiles(schemaFiles map[string]*ternv1.SchemaFiles) (warning string, err error) {
 	if len(schemaFiles) == 0 {
 		return "", fmt.Errorf("schema_files is required: must contain at least one namespace (JSON field for files is \"files\", not \"sql_files\")")
 	}
 	for ns, sf := range schemaFiles {
-		if sf == nil || len(sf.GetFiles()) == 0 {
+		if sf == nil {
+			return "", fmt.Errorf("schema_files[%q] is null: each namespace must be an object with a \"files\" map", ns)
+		}
+		if len(sf.GetFiles()) == 0 {
 			warning = fmt.Sprintf("schema_files[%q] has no files — if this is unintentional, check that the JSON field is \"files\" (not \"sql_files\")", ns)
 		}
 	}

--- a/pkg/api/proto_helpers.go
+++ b/pkg/api/proto_helpers.go
@@ -119,8 +119,10 @@ func changeTypeToProto(op string) ternv1.ChangeType {
 func protoToSchemaFiles(sf map[string]*ternv1.SchemaFiles) schema.SchemaFiles {
 	result := make(schema.SchemaFiles, len(sf))
 	for ns, ksFiles := range sf {
-		files := make(map[string]string, len(ksFiles.Files))
-		maps.Copy(files, ksFiles.Files)
+		// A nil namespace value yields an empty Files map; GetFiles is nil-safe.
+		nsFiles := ksFiles.GetFiles()
+		files := make(map[string]string, len(nsFiles))
+		maps.Copy(files, nsFiles)
 		result[ns] = &schema.Namespace{Files: files}
 	}
 	return result

--- a/pkg/api/proto_helpers.go
+++ b/pkg/api/proto_helpers.go
@@ -113,9 +113,9 @@ func changeTypeToProto(op string) ternv1.ChangeType {
 	}
 }
 
-// protoToSchemaFiles converts proto SchemaFiles (per-keyspace with separate sql_files
-// and vschema_file) to the engine's schema.SchemaFiles (per-namespace with a unified
-// Files map).
+// protoToSchemaFiles converts proto SchemaFiles to the engine's schema.SchemaFiles,
+// copying the unified files map for each namespace. A nil namespace value yields an
+// empty Files map (GetFiles is nil-safe).
 func protoToSchemaFiles(sf map[string]*ternv1.SchemaFiles) schema.SchemaFiles {
 	result := make(schema.SchemaFiles, len(sf))
 	for ns, ksFiles := range sf {

--- a/pkg/api/proto_helpers_test.go
+++ b/pkg/api/proto_helpers_test.go
@@ -5,6 +5,7 @@ import (
 
 	ternv1 "github.com/block/schemabot/pkg/proto/ternv1"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestChangeTypeRoundTrip(t *testing.T) {
@@ -49,4 +50,57 @@ func TestPlanResponseFromProto_ChangeType(t *testing.T) {
 	assert.Equal(t, "create", tables[0].ChangeType, "CREATE should be lowercase 'create', not proto enum string")
 	assert.Equal(t, "alter", tables[1].ChangeType, "ALTER should be lowercase 'alter', not proto enum string")
 	assert.Equal(t, "drop", tables[2].ChangeType, "DROP should be lowercase 'drop', not proto enum string")
+}
+
+// A null namespace value in the proto map (e.g. JSON `{"default": null}`)
+// converts to an empty namespace rather than dereferencing a nil pointer.
+func TestProtoToSchemaFiles_NilNamespaceValue(t *testing.T) {
+	result := protoToSchemaFiles(map[string]*ternv1.SchemaFiles{
+		"default": nil,
+		"payments": {Files: map[string]string{
+			"users.sql": "CREATE TABLE users (id bigint primary key)",
+		}},
+	})
+
+	require.Contains(t, result, "default")
+	require.NotNil(t, result["default"])
+	assert.Empty(t, result["default"].Files)
+
+	require.Contains(t, result, "payments")
+	require.NotNil(t, result["payments"])
+	assert.Equal(t, map[string]string{
+		"users.sql": "CREATE TABLE users (id bigint primary key)",
+	}, result["payments"].Files)
+}
+
+// schema_files with a null namespace value is rejected as a hard validation
+// error so the request gets a clear 4xx instead of reaching the converter.
+func TestValidateSchemaFiles_NullNamespaceRejected(t *testing.T) {
+	warning, err := validateSchemaFiles(map[string]*ternv1.SchemaFiles{
+		"default": nil,
+	})
+
+	require.Error(t, err)
+	assert.Empty(t, warning)
+	assert.Contains(t, err.Error(), `schema_files["default"] is null`)
+}
+
+// An empty (but non-null) files map is valid input and only produces a
+// warning, since it legitimately signals "drop all tables" in a namespace.
+func TestValidateSchemaFiles_EmptyFilesWarnsButAllows(t *testing.T) {
+	warning, err := validateSchemaFiles(map[string]*ternv1.SchemaFiles{
+		"default": {Files: map[string]string{}},
+	})
+
+	require.NoError(t, err)
+	assert.Contains(t, warning, `schema_files["default"] has no files`)
+}
+
+// Missing schema_files is rejected with a clear required-field error.
+func TestValidateSchemaFiles_MissingRejected(t *testing.T) {
+	warning, err := validateSchemaFiles(nil)
+
+	require.Error(t, err)
+	assert.Empty(t, warning)
+	assert.Contains(t, err.Error(), "schema_files is required")
 }

--- a/pkg/tern/state_converters.go
+++ b/pkg/tern/state_converters.go
@@ -262,8 +262,10 @@ func isTerminalProtoState(ps ternv1.State) bool {
 func protoToSchemaFiles(sf map[string]*ternv1.SchemaFiles) schema.SchemaFiles {
 	result := make(schema.SchemaFiles, len(sf))
 	for ns, ksFiles := range sf {
-		files := make(map[string]string, len(ksFiles.Files))
-		maps.Copy(files, ksFiles.Files)
+		// A nil namespace value yields an empty Files map; GetFiles is nil-safe.
+		nsFiles := ksFiles.GetFiles()
+		files := make(map[string]string, len(nsFiles))
+		maps.Copy(files, nsFiles)
 		result[ns] = &schema.Namespace{Files: files}
 	}
 	return result

--- a/pkg/tern/state_converters.go
+++ b/pkg/tern/state_converters.go
@@ -256,9 +256,9 @@ func isTerminalProtoState(ps ternv1.State) bool {
 	}
 }
 
-// protoToSchemaFiles converts proto SchemaFiles (per-keyspace with separate sql_files
-// and vschema_file) to the engine's schema.SchemaFiles (per-namespace with a unified
-// Files map).
+// protoToSchemaFiles converts proto SchemaFiles to the engine's schema.SchemaFiles,
+// copying the unified files map for each namespace. A nil namespace value yields an
+// empty Files map (GetFiles is nil-safe).
 func protoToSchemaFiles(sf map[string]*ternv1.SchemaFiles) schema.SchemaFiles {
 	result := make(schema.SchemaFiles, len(sf))
 	for ns, ksFiles := range sf {

--- a/pkg/tern/state_converters_test.go
+++ b/pkg/tern/state_converters_test.go
@@ -1,0 +1,30 @@
+package tern
+
+import (
+	"testing"
+
+	ternv1 "github.com/block/schemabot/pkg/proto/ternv1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A null namespace value in the proto map (e.g. JSON `{"default": null}`)
+// converts to an empty namespace rather than dereferencing a nil pointer.
+func TestProtoToSchemaFiles_NilNamespaceValue(t *testing.T) {
+	result := protoToSchemaFiles(map[string]*ternv1.SchemaFiles{
+		"default": nil,
+		"payments": {Files: map[string]string{
+			"users.sql": "CREATE TABLE users (id bigint primary key)",
+		}},
+	})
+
+	require.Contains(t, result, "default")
+	require.NotNil(t, result["default"])
+	assert.Empty(t, result["default"].Files)
+
+	require.Contains(t, result, "payments")
+	require.NotNil(t, result["payments"])
+	assert.Equal(t, map[string]string{
+		"users.sql": "CREATE TABLE users (id bigint primary key)",
+	}, result["payments"].Files)
+}


### PR DESCRIPTION
A plan request whose `schema_files` map contains a null namespace value (e.g. `{"schema_files": {"default": null}}`) panicked the request goroutine: the proto→schema-files converters dereferenced the nil `*ternv1.SchemaFiles` directly. This is remotely triggerable and returns no proper error.

`validateSchemaFiles` now rejects a null namespace value as a hard validation error, so the request gets a clear 400 before reaching conversion. Both converters also use the nil-safe `GetFiles` getter as defense in depth, so a null value yields an empty namespace rather than a crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)