### PR TITLE
fix(github): guard stale-plan check update against in-flight applies

### DIFF
--- a/pkg/storage/mysqlstore/checks.go
+++ b/pkg/storage/mysqlstore/checks.go
@@ -152,6 +152,44 @@ func successfulNoOpPlanResult(check *storage.Check) bool {
 		!check.HasChanges
 }
 
+// MarkStalePlanSuccessful marks plan-only stored check state successful when its
+// database is no longer in the PR. The update is guarded so a started apply that
+// claimed the row after stale cleanup read it keeps blocking: a row that is
+// in_progress or owns an apply ID is left untouched, because a passing check must
+// never be derived from cleanup alone while an apply may have reached the live
+// database. Returns true when the row was marked successful.
+func (s *checkStore) MarkStalePlanSuccessful(ctx context.Context, check *storage.Check) (bool, error) {
+	var checkRunID any
+	if check.CheckRunID != 0 {
+		checkRunID = check.CheckRunID
+	}
+
+	result, err := s.db.ExecContext(ctx, `
+		UPDATE checks
+		SET head_sha = ?,
+		    check_run_id = ?,
+		    apply_id = NULL,
+		    has_changes = ?,
+		    status = ?,
+		    conclusion = ?,
+		    blocking_reason = ?,
+		    error_message = ?
+		WHERE repository = ? AND pull_request = ?
+		  AND environment = ? AND database_type = ? AND database_name = ?
+		  AND status != ? AND apply_id IS NULL
+	`, check.HeadSHA, checkRunID, check.HasChanges, check.Status, check.Conclusion, check.BlockingReason, check.ErrorMessage,
+		check.Repository, check.PullRequest, check.Environment, check.DatabaseType, check.DatabaseName,
+		checkStatusInProgress)
+	if err != nil {
+		return false, err
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	return rows > 0, nil
+}
+
 // CompleteForApply updates stored check state to a terminal state only if it
 // still belongs to the apply being completed.
 func (s *checkStore) CompleteForApply(ctx context.Context, check *storage.Check, apply *storage.Apply) (bool, error) {

--- a/pkg/storage/mysqlstore/checks.go
+++ b/pkg/storage/mysqlstore/checks.go
@@ -157,7 +157,9 @@ func successfulNoOpPlanResult(check *storage.Check) bool {
 // claimed the row after stale cleanup read it keeps blocking: a row that is
 // in_progress or owns an apply ID is left untouched, because a passing check must
 // never be derived from cleanup alone while an apply may have reached the live
-// database. Returns true when the row was marked successful.
+// database. Returns true when the row is in the plan-only successful state after
+// this call (whether this call wrote it or it already was), and false only when a
+// started apply still owns it.
 func (s *checkStore) MarkStalePlanSuccessful(ctx context.Context, check *storage.Check) (bool, error) {
 	var checkRunID any
 	if check.CheckRunID != 0 {
@@ -181,13 +183,43 @@ func (s *checkStore) MarkStalePlanSuccessful(ctx context.Context, check *storage
 		check.Repository, check.PullRequest, check.Environment, check.DatabaseType, check.DatabaseName,
 		checkStatusInProgress)
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("mark stale plan check successful for %s#%d %s/%s/%s: %w",
+			check.Repository, check.PullRequest, check.Environment, check.DatabaseType, check.DatabaseName, err)
 	}
 	rows, err := result.RowsAffected()
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("rows affected marking stale plan check successful for %s#%d %s/%s/%s: %w",
+			check.Repository, check.PullRequest, check.Environment, check.DatabaseType, check.DatabaseName, err)
 	}
-	return rows > 0, nil
+	if rows > 0 {
+		return true, nil
+	}
+
+	// Under changed-rows semantics, RowsAffected is 0 both when the guard
+	// excluded the row (an apply claimed it) and when the row already held the
+	// exact plan-only success values this call would have written. Re-read the
+	// row to tell these apart so an already-successful row is treated as success
+	// rather than left blocking.
+	current, err := s.Get(ctx, check.Repository, check.PullRequest, check.Environment, check.DatabaseType, check.DatabaseName)
+	if err != nil {
+		return false, fmt.Errorf("re-read stale plan check after no-op update for %s#%d %s/%s/%s: %w",
+			check.Repository, check.PullRequest, check.Environment, check.DatabaseType, check.DatabaseName, err)
+	}
+	if current == nil {
+		return false, fmt.Errorf("stale plan check vanished after no-op update for %s#%d %s/%s/%s",
+			check.Repository, check.PullRequest, check.Environment, check.DatabaseType, check.DatabaseName)
+	}
+	return isPlanOnlySuccessful(current), nil
+}
+
+// isPlanOnlySuccessful reports whether stored check state is already in the
+// plan-only successful state stale cleanup converges to: a completed, successful
+// check with no started apply and no pending schema change.
+func isPlanOnlySuccessful(check *storage.Check) bool {
+	return check.Status == "completed" &&
+		check.Conclusion == "success" &&
+		check.ApplyID == 0 &&
+		!check.HasChanges
 }
 
 // CompleteForApply updates stored check state to a terminal state only if it

--- a/pkg/storage/mysqlstore/checks_test.go
+++ b/pkg/storage/mysqlstore/checks_test.go
@@ -564,6 +564,147 @@ func TestCheckStore_RecoverApplyOwnedCheckWithNoOpPlanRequiresNoOpSuccess(t *tes
 	}
 }
 
+// When a database drops out of a PR and its stored check state is a plan-only
+// result with no started apply, stale cleanup marks it successful so the PR is
+// no longer blocked by a database it no longer touches.
+func TestCheckStore_MarkStalePlanSuccessfulMarksPlanOnlyCheck(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	require.NoError(t, store.Checks().Upsert(ctx, &storage.Check{
+		Repository:     "org/repo",
+		PullRequest:    123,
+		HeadSHA:        "oldsha",
+		Environment:    "staging",
+		DatabaseType:   "mysql",
+		DatabaseName:   "testdb",
+		HasChanges:     true,
+		Status:         "completed",
+		Conclusion:     "action_required",
+		BlockingReason: "schema_change_pending",
+		ErrorMessage:   "schema change pending apply",
+	}))
+
+	marked, err := store.Checks().MarkStalePlanSuccessful(ctx, &storage.Check{
+		Repository:   "org/repo",
+		PullRequest:  123,
+		HeadSHA:      "newsha",
+		Environment:  "staging",
+		DatabaseType: "mysql",
+		DatabaseName: "testdb",
+		HasChanges:   false,
+		Status:       "completed",
+		Conclusion:   "success",
+	})
+	require.NoError(t, err)
+	require.True(t, marked)
+
+	retrieved, err := store.Checks().Get(ctx, "org/repo", 123, "staging", "mysql", "testdb")
+	require.NoError(t, err)
+	require.NotNil(t, retrieved)
+	require.Equal(t, "newsha", retrieved.HeadSHA)
+	require.Equal(t, "completed", retrieved.Status)
+	require.Equal(t, "success", retrieved.Conclusion)
+	require.False(t, retrieved.HasChanges)
+	require.Equal(t, int64(0), retrieved.ApplyID)
+	require.Empty(t, retrieved.BlockingReason)
+	require.Empty(t, retrieved.ErrorMessage)
+}
+
+// A database can drop out of a PR at the same moment an apply for it begins. If
+// the apply claims the stored check state after stale cleanup read it, the row
+// is in_progress and apply-owned. Stale cleanup must not convert that into a
+// passing check: the apply may already have reached the live database, so the
+// row stays blocking until an operator reconciles the target.
+func TestCheckStore_MarkStalePlanSuccessfulLeavesInProgressApplyBlocking(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	apply := createCheckStoreApply(t, store, "apply-claimed-after-cleanup-read", state.Apply.Running)
+	require.NoError(t, store.Checks().Upsert(ctx, &storage.Check{
+		Repository:   "org/repo",
+		PullRequest:  123,
+		HeadSHA:      "oldsha",
+		Environment:  "staging",
+		DatabaseType: "mysql",
+		DatabaseName: "testdb",
+		CheckRunID:   100,
+		ApplyID:      apply.ID,
+		HasChanges:   true,
+		Status:       "in_progress",
+		Conclusion:   "",
+	}))
+
+	marked, err := store.Checks().MarkStalePlanSuccessful(ctx, &storage.Check{
+		Repository:   "org/repo",
+		PullRequest:  123,
+		HeadSHA:      "newsha",
+		Environment:  "staging",
+		DatabaseType: "mysql",
+		DatabaseName: "testdb",
+		HasChanges:   false,
+		Status:       "completed",
+		Conclusion:   "success",
+	})
+	require.NoError(t, err)
+	require.False(t, marked, "in-flight apply-owned check must not be marked successful by stale cleanup")
+
+	retrieved, err := store.Checks().Get(ctx, "org/repo", 123, "staging", "mysql", "testdb")
+	require.NoError(t, err)
+	require.NotNil(t, retrieved)
+	require.Equal(t, "oldsha", retrieved.HeadSHA)
+	require.Equal(t, "in_progress", retrieved.Status)
+	require.Empty(t, retrieved.Conclusion)
+	require.True(t, retrieved.HasChanges)
+	require.Equal(t, apply.ID, retrieved.ApplyID)
+}
+
+// A terminal apply-owned row (apply ID still set after the apply finished) keeps
+// blocking under stale cleanup. The apply already touched the live database, so a
+// later commit dropping the database must not derive a passing check by cleanup
+// alone.
+func TestCheckStore_MarkStalePlanSuccessfulLeavesTerminalApplyOwnedBlocking(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	apply := createCheckStoreApply(t, store, "apply-terminal-owned", state.Apply.Completed)
+	require.NoError(t, store.Checks().Upsert(ctx, &storage.Check{
+		Repository:   "org/repo",
+		PullRequest:  123,
+		HeadSHA:      "oldsha",
+		Environment:  "staging",
+		DatabaseType: "mysql",
+		DatabaseName: "testdb",
+		ApplyID:      apply.ID,
+		HasChanges:   true,
+		Status:       "completed",
+		Conclusion:   "success",
+	}))
+
+	marked, err := store.Checks().MarkStalePlanSuccessful(ctx, &storage.Check{
+		Repository:   "org/repo",
+		PullRequest:  123,
+		HeadSHA:      "newsha",
+		Environment:  "staging",
+		DatabaseType: "mysql",
+		DatabaseName: "testdb",
+		HasChanges:   false,
+		Status:       "completed",
+		Conclusion:   "success",
+	})
+	require.NoError(t, err)
+	require.False(t, marked, "terminal apply-owned check must not be cleaned to success by stale cleanup")
+
+	retrieved, err := store.Checks().Get(ctx, "org/repo", 123, "staging", "mysql", "testdb")
+	require.NoError(t, err)
+	require.NotNil(t, retrieved)
+	require.Equal(t, "oldsha", retrieved.HeadSHA)
+	require.Equal(t, apply.ID, retrieved.ApplyID)
+}
+
 func TestCheckStore_UpsertPlanResultReplacesUnownedInProgressCheck(t *testing.T) {
 	clearTables(t)
 	ctx := t.Context()

--- a/pkg/storage/mysqlstore/checks_test.go
+++ b/pkg/storage/mysqlstore/checks_test.go
@@ -705,6 +705,127 @@ func TestCheckStore_MarkStalePlanSuccessfulLeavesTerminalApplyOwnedBlocking(t *t
 	require.Equal(t, apply.ID, retrieved.ApplyID)
 }
 
+// Stale cleanup runs more than once for the same dropped database: the webhook
+// can re-deliver, or a later commit re-triggers cleanup for a database that is
+// already cleaned. Re-marking a row that already holds the plan-only successful
+// values is idempotent and must report success, not falsely report the row as
+// blocked by an in-flight apply. Under MySQL's production changed-rows
+// semantics the no-op update affects zero rows, so this is the case that proves
+// the re-read distinguishes "already successful" from "apply-owned". The test
+// runs on a changed-rows connection (no clientFoundRows) to exercise that path.
+func TestCheckStore_MarkStalePlanSuccessfulIsIdempotentUnderChangedRows(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := newChangedRowsStore(t)
+
+	require.NoError(t, store.Checks().Upsert(ctx, &storage.Check{
+		Repository:     "org/repo",
+		PullRequest:    123,
+		HeadSHA:        "oldsha",
+		Environment:    "staging",
+		DatabaseType:   "mysql",
+		DatabaseName:   "testdb",
+		HasChanges:     true,
+		Status:         "completed",
+		Conclusion:     "action_required",
+		BlockingReason: "schema_change_pending",
+		ErrorMessage:   "schema change pending apply",
+	}))
+
+	successCheck := &storage.Check{
+		Repository:   "org/repo",
+		PullRequest:  123,
+		HeadSHA:      "newsha",
+		Environment:  "staging",
+		DatabaseType: "mysql",
+		DatabaseName: "testdb",
+		HasChanges:   false,
+		Status:       "completed",
+		Conclusion:   "success",
+	}
+
+	marked, err := store.Checks().MarkStalePlanSuccessful(ctx, successCheck)
+	require.NoError(t, err)
+	require.True(t, marked, "first stale cleanup must mark the plan-only check successful")
+
+	// Re-marking the already-successful row is a no-op write under changed-rows
+	// semantics, but the row is genuinely successful and must still report so.
+	marked, err = store.Checks().MarkStalePlanSuccessful(ctx, successCheck)
+	require.NoError(t, err)
+	require.True(t, marked, "re-marking an already-successful plan check must report success, not blocking")
+
+	retrieved, err := store.Checks().Get(ctx, "org/repo", 123, "staging", "mysql", "testdb")
+	require.NoError(t, err)
+	require.NotNil(t, retrieved)
+	require.Equal(t, "newsha", retrieved.HeadSHA)
+	require.Equal(t, "completed", retrieved.Status)
+	require.Equal(t, "success", retrieved.Conclusion)
+	require.False(t, retrieved.HasChanges)
+	require.Equal(t, int64(0), retrieved.ApplyID)
+	require.Empty(t, retrieved.BlockingReason)
+	require.Empty(t, retrieved.ErrorMessage)
+}
+
+// Under changed-rows semantics, a row claimed by a started apply between the
+// cleanup read and the write must still be reported as blocking. The guard
+// excludes it (zero rows affected) and the re-read finds an in_progress,
+// apply-owned row, so cleanup must not derive a passing check from it.
+func TestCheckStore_MarkStalePlanSuccessfulLeavesInProgressApplyBlockingUnderChangedRows(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := newChangedRowsStore(t)
+
+	apply := createCheckStoreApply(t, store, "apply-claimed-under-changed-rows", state.Apply.Running)
+	require.NoError(t, store.Checks().Upsert(ctx, &storage.Check{
+		Repository:   "org/repo",
+		PullRequest:  123,
+		HeadSHA:      "oldsha",
+		Environment:  "staging",
+		DatabaseType: "mysql",
+		DatabaseName: "testdb",
+		CheckRunID:   100,
+		ApplyID:      apply.ID,
+		HasChanges:   true,
+		Status:       "in_progress",
+		Conclusion:   "",
+	}))
+
+	marked, err := store.Checks().MarkStalePlanSuccessful(ctx, &storage.Check{
+		Repository:   "org/repo",
+		PullRequest:  123,
+		HeadSHA:      "newsha",
+		Environment:  "staging",
+		DatabaseType: "mysql",
+		DatabaseName: "testdb",
+		HasChanges:   false,
+		Status:       "completed",
+		Conclusion:   "success",
+	})
+	require.NoError(t, err)
+	require.False(t, marked, "in-flight apply-owned check must not be marked successful by stale cleanup")
+
+	retrieved, err := store.Checks().Get(ctx, "org/repo", 123, "staging", "mysql", "testdb")
+	require.NoError(t, err)
+	require.NotNil(t, retrieved)
+	require.Equal(t, "oldsha", retrieved.HeadSHA)
+	require.Equal(t, "in_progress", retrieved.Status)
+	require.True(t, retrieved.HasChanges)
+	require.Equal(t, apply.ID, retrieved.ApplyID)
+}
+
+// newChangedRowsStore opens a Storage on a connection without clientFoundRows so
+// UPDATE ... RowsAffected reflects changed rows, matching production semantics.
+func newChangedRowsStore(t *testing.T) *Storage {
+	t.Helper()
+	db, err := sql.Open("mysql", testDSNChangedRows)
+	require.NoError(t, err)
+	require.NoError(t, db.PingContext(t.Context()))
+	t.Cleanup(func() {
+		require.NoError(t, db.Close())
+	})
+	return New(db)
+}
+
 func TestCheckStore_UpsertPlanResultReplacesUnownedInProgressCheck(t *testing.T) {
 	clearTables(t)
 	ctx := t.Context()

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -93,6 +93,13 @@ type CheckStore interface {
 	// from in_progress to a successful no-op plan result. Returns true when recovery occurred.
 	RecoverApplyOwnedCheckWithNoOpPlan(ctx context.Context, check *Check) (bool, error)
 
+	// MarkStalePlanSuccessful marks plan-only stored check state successful when
+	// the database it covers is no longer in the PR. It fails closed: the update
+	// is skipped when the row is in_progress or owns an apply ID, so a started
+	// apply that began after stale cleanup read the row keeps blocking the PR.
+	// Returns true when the row was marked successful.
+	MarkStalePlanSuccessful(ctx context.Context, check *Check) (bool, error)
+
 	// CompleteForApply updates stored check state to a terminal state only if
 	// it still belongs to the given apply and no newer apply exists for the
 	// same PR/environment/database. Returns false when another worker changed

--- a/pkg/webhook/pull_request.go
+++ b/pkg/webhook/pull_request.go
@@ -399,13 +399,19 @@ func (h *Handler) blockStaleStartedApplyCheckState(ctx context.Context, repo str
 }
 
 func (h *Handler) markStalePlanOnlyCheckStateSuccessful(ctx context.Context, repo string, pr int, headSHA string, check *storage.Check) bool {
+	priorApplyID := check.ApplyID
 	check.HeadSHA = headSHA
 	check.Conclusion = checkConclusionSuccess
 	check.HasChanges = false
 	check.Status = checkStatusCompleted
+	check.ApplyID = 0
 	check.BlockingReason = ""
 	check.ErrorMessage = ""
-	if err := h.service.Storage().Checks().Upsert(ctx, check); err != nil {
+
+	// The success write is guarded against in-flight apply-owned rows: an apply
+	// that started after this cleanup read the row must keep blocking the PR.
+	marked, err := h.service.Storage().Checks().MarkStalePlanSuccessful(ctx, check)
+	if err != nil {
 		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
 			Operation:    "stale_check_cleanup",
 			Repository:   repo,
@@ -418,9 +424,30 @@ func (h *Handler) markStalePlanOnlyCheckStateSuccessful(ctx context.Context, rep
 			"repo", repo, "pr", pr, "head_sha", headSHA,
 			"database", check.DatabaseName, "database_type", check.DatabaseType,
 			"environment", check.Environment, "check_id", check.ID,
-			"error", err)
+			"apply_id", priorApplyID, "error", err)
 		return false
 	}
+
+	if !marked {
+		// A concurrent apply claimed the row between the cleanup read and this
+		// write. Leave it in_progress and apply-owned so it keeps blocking until
+		// an operator reconciles the target environment.
+		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
+			Operation:    "stale_check_cleanup",
+			Repository:   repo,
+			Database:     check.DatabaseName,
+			DatabaseType: check.DatabaseType,
+			Environment:  check.Environment,
+			Status:       "blocked",
+		})
+		h.logger.Warn("stale plan check left blocking because an apply started concurrently; the check gate will block PR applies until an operator reconciles the target",
+			"repo", repo, "pr", pr, "head_sha", headSHA,
+			"database", check.DatabaseName, "database_type", check.DatabaseType,
+			"environment", check.Environment, "check_id", check.ID,
+			"apply_id", priorApplyID)
+		return true
+	}
+
 	metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
 		Operation:    "stale_check_cleanup",
 		Repository:   repo,

--- a/pkg/webhook/pull_request.go
+++ b/pkg/webhook/pull_request.go
@@ -424,7 +424,7 @@ func (h *Handler) markStalePlanOnlyCheckStateSuccessful(ctx context.Context, rep
 			"repo", repo, "pr", pr, "head_sha", headSHA,
 			"database", check.DatabaseName, "database_type", check.DatabaseType,
 			"environment", check.Environment, "check_id", check.ID,
-			"apply_id", priorApplyID, "error", err)
+			"prior_apply_id", priorApplyID, "error", err)
 		return false
 	}
 
@@ -444,7 +444,7 @@ func (h *Handler) markStalePlanOnlyCheckStateSuccessful(ctx context.Context, rep
 			"repo", repo, "pr", pr, "head_sha", headSHA,
 			"database", check.DatabaseName, "database_type", check.DatabaseType,
 			"environment", check.Environment, "check_id", check.ID,
-			"apply_id", priorApplyID)
+			"prior_apply_id", priorApplyID)
 		return true
 	}
 


### PR DESCRIPTION
Stale-plan check cleanup marked a check `success` with a blind upsert. Between reading the PR's checks and that write, a concurrent apply could claim the same check row (`in_progress` with an apply ID). The unconditional write then overwrote that started, apply-owned blocking check into a passing one — letting a PR merge while an apply may already have reached the live database.

The stale-plan success write now goes through a conditional store update that fails closed: a row is marked successful only when it is neither `in_progress` nor apply-owned. When a concurrent apply has claimed the row, it is left blocking until an operator reconciles the target environment, and the outcome is logged and counted.

```
cleanupStaleChecks: GetByPR (row is plan-only, no apply)
        │
        │   concurrent apply-confirm:
        │   updateCheckRecordForApplyStart → row = in_progress + apply_id
        ▼
mark stale success → guarded UPDATE ... WHERE status != in_progress AND apply_id IS NULL
        │
        ├─ row still plan-only → marked success
        └─ row now apply-owned → 0 rows; left blocking
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)