### PR TITLE
fix(engine): accept no-op PlanetScale applies and parse shard progress as float

### DIFF
--- a/pkg/engine/planetscale/apply.go
+++ b/pkg/engine/planetscale/apply.go
@@ -24,6 +24,13 @@ import (
 	"github.com/block/schemabot/pkg/state"
 )
 
+// noChangesApplyResult builds the result for a converged apply where the deploy
+// request reported no schema differences. It must be Accepted so the tern layer
+// completes the apply's tasks instead of treating the no-op as a failure.
+func noChangesApplyResult(message string) *engine.ApplyResult {
+	return &engine.ApplyResult{Accepted: true, Message: message}
+}
+
 // Apply starts executing a schema change plan.
 // Creates a PlanetScale branch, applies DDL via MySQL connection to the branch,
 // then creates and starts a deploy request.
@@ -278,7 +285,7 @@ func (e *Engine) Apply(ctx context.Context, req *engine.ApplyRequest) (*engine.A
 			Message:  fmt.Sprintf("Deploy request #%d: no changes detected", dr.Number),
 			Metadata: map[string]string{"deploy_request_id": fmt.Sprintf("%d", dr.Number)},
 		})
-		return &engine.ApplyResult{Message: "no changes detected"}, nil
+		return noChangesApplyResult("no changes detected"), nil
 	}
 
 	// Determine instant DDL eligibility. Prefer instant when PlanetScale reports
@@ -807,7 +814,7 @@ func (e *Engine) resumeApply(ctx context.Context, client psclient.PSClient, org 
 		return nil, fmt.Errorf("deploy request #%d failed on resume (state: %s)", dr.Number, dr.DeploymentState)
 	}
 	if dr.DeploymentState == deployState.NoChanges {
-		return &engine.ApplyResult{Message: "no changes detected on resume"}, nil
+		return noChangesApplyResult("no changes detected on resume"), nil
 	}
 
 	// Deploy — prefer instant when eligible (no row copy, no revert window needed).

--- a/pkg/engine/planetscale/apply_test.go
+++ b/pkg/engine/planetscale/apply_test.go
@@ -27,6 +27,19 @@ func (c *permanentVSchemaErrorClient) UpdateKeyspaceVSchema(context.Context, *ps
 	return nil, &ps.Error{Code: ps.ErrInvalid}
 }
 
+// A schema that is already converged produces a deploy request with no
+// differences. The apply must be accepted so the orchestrator completes the
+// change's tasks normally rather than reporting a spurious failure.
+func TestNoChangesApplyResultIsAccepted(t *testing.T) {
+	fresh := noChangesApplyResult("no changes detected")
+	assert.True(t, fresh.Accepted)
+	assert.Equal(t, "no changes detected", fresh.Message)
+
+	resume := noChangesApplyResult("no changes detected on resume")
+	assert.True(t, resume.Accepted)
+	assert.Equal(t, "no changes detected on resume", resume.Message)
+}
+
 func TestApply_MainBranchReuseIsPermanent(t *testing.T) {
 	e := NewWithClient(slog.New(slog.NewTextHandler(os.Stdout, nil)), func(_, _ string) (psclient.PSClient, error) {
 		return nil, nil

--- a/pkg/engine/planetscale/progress.go
+++ b/pkg/engine/planetscale/progress.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"math"
 	"sort"
 	"strconv"
 	"strings"
@@ -335,7 +336,7 @@ func (e *Engine) showVitessMigrationsForKeyspace(ctx context.Context, dsn, keysp
 			DDLAction:        colMap["ddl_action"],
 			IsImmediate:      colMap["is_immediate_operation"] == "1",
 		}
-		if v, err := strconv.Atoi(colMap["progress"]); err != nil && colMap["progress"] != "" {
+		if v, err := parseProgressPercent(colMap["progress"]); err != nil {
 			e.logger.Debug("parse vitess_migrations field", "field", "progress", "value", colMap["progress"], "error", err)
 		} else {
 			row.Progress = v
@@ -377,6 +378,24 @@ func validateMigrationContext(s string) error {
 		return fmt.Errorf("invalid context: contains unsafe characters")
 	}
 	return nil
+}
+
+// parseProgressPercent parses the Vitess schema_migrations.progress column,
+// which is a float percentage (e.g. "54.35"), rounds it to the nearest int,
+// and clamps the result to [0, 100].
+func parseProgressPercent(s string) (int, error) {
+	if s == "" {
+		return 0, nil
+	}
+	f, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return 0, fmt.Errorf("parse progress percent %q: %w", s, err)
+	}
+	pct := int(math.Round(f))
+	if pct < 0 {
+		return 0, nil
+	}
+	return min(pct, 100), nil
 }
 
 func parseInt64(s string) (int64, error) {
@@ -477,7 +496,7 @@ func aggregateShardProgress(rows []vitessMigrationRow) ([]engine.TableProgress, 
 				shardState = state.Vitess.ReadyToComplete
 			}
 
-			shardPct := sh.progress
+			shardPct := min(sh.progress, 100)
 			shardCopied := sh.rowsCopied
 			// When a shard is ready for cutover, the copy phase is complete.
 			// Clamp to 100% since Vitess row counts can lag behind slightly.
@@ -504,7 +523,9 @@ func aggregateShardProgress(rows []vitessMigrationRow) ([]engine.TableProgress, 
 		}
 
 		if tblTableRows > 0 {
-			tblProgress = int(tblRowsCopied * 100 / tblTableRows)
+			// rows_copied can momentarily exceed table_rows (concurrent inserts
+			// during copy), so clamp to 100.
+			tblProgress = min(int(tblRowsCopied*100/tblTableRows), 100)
 		} else if tableState == state.Vitess.Complete || tableState == state.Vitess.ReadyToComplete {
 			tblProgress = 100
 		}
@@ -535,7 +556,7 @@ func aggregateShardProgress(rows []vitessMigrationRow) ([]engine.TableProgress, 
 
 	overallProgress := 0
 	if totalTableRows > 0 {
-		overallProgress = int(totalRowsCopied * 100 / totalTableRows)
+		overallProgress = min(int(totalRowsCopied*100/totalTableRows), 100)
 	} else if len(tables) > 0 {
 		allDone := true
 		for _, t := range tables {

--- a/pkg/engine/planetscale/progress_test.go
+++ b/pkg/engine/planetscale/progress_test.go
@@ -142,6 +142,58 @@ func TestAggregateShardProgress(t *testing.T) {
 		assert.Equal(t, 50, tables[0].Shards[1].Progress)
 		assert.Equal(t, int64(5000), tables[0].Shards[1].RowsCopied)
 	})
+
+	t.Run("rows_copied exceeding table_rows clamps to 100%", func(t *testing.T) {
+		// While a shard is still copying, rows_copied can momentarily exceed the
+		// estimated table_rows because of concurrent inserts. Table and overall
+		// progress must never exceed 100%.
+		rows := []vitessMigrationRow{
+			{MigrationUUID: "uuid-1", Keyspace: "commerce", Shard: "-", Table: "orders", Status: "running", Progress: 99, RowsCopied: 12000, TableRows: 10000},
+		}
+
+		tables, overall := aggregateShardProgress(rows)
+		require.Len(t, tables, 1)
+		assert.Equal(t, state.Vitess.Running, tables[0].State)
+		assert.Equal(t, 100, tables[0].Progress)
+		assert.Equal(t, 100, overall)
+	})
+}
+
+func TestParseProgressPercent(t *testing.T) {
+	t.Run("fractional value rounds to nearest int", func(t *testing.T) {
+		pct, err := parseProgressPercent("54.35")
+		require.NoError(t, err)
+		assert.Equal(t, 54, pct)
+	})
+
+	t.Run("rounds half up", func(t *testing.T) {
+		pct, err := parseProgressPercent("54.5")
+		require.NoError(t, err)
+		assert.Equal(t, 55, pct)
+	})
+
+	t.Run("empty value is zero", func(t *testing.T) {
+		pct, err := parseProgressPercent("")
+		require.NoError(t, err)
+		assert.Equal(t, 0, pct)
+	})
+
+	t.Run("clamps above 100", func(t *testing.T) {
+		pct, err := parseProgressPercent("101.7")
+		require.NoError(t, err)
+		assert.Equal(t, 100, pct)
+	})
+
+	t.Run("clamps below 0", func(t *testing.T) {
+		pct, err := parseProgressPercent("-3.2")
+		require.NoError(t, err)
+		assert.Equal(t, 0, pct)
+	})
+
+	t.Run("non-numeric value errors", func(t *testing.T) {
+		_, err := parseProgressPercent("notanumber")
+		require.Error(t, err)
+	})
 }
 
 func TestValidateMigrationContext(t *testing.T) {


### PR DESCRIPTION
Two correctness fixes in the PlanetScale engine.

**Converged applies were treated as failures.** When a schema is already up to date, the deploy request reports no differences. The no-changes returns left `ApplyResult.Accepted` false, so the orchestrator marked the no-op as a failure — even though the same converged case succeeds on the Spirit engine. Both no-changes returns are now accepted so the apply's tasks complete normally.

**Per-shard progress was parsed as an int but the source is a float.** `SHOW VITESS_MIGRATIONS` reports `progress` as a float percentage (e.g. `54.35`). It was parsed with `strconv.Atoi`, which fails on any fractional value, silently reporting 0% for in-flight shards. It is now parsed as a float and rounded. Table, overall, and shard percentages are also clamped to 100, since `rows_copied` can momentarily exceed the estimated `table_rows` during the copy phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)