### PR TITLE
docs: clarify required SchemaBot check behavior

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -7,6 +7,7 @@
 - [Declarative Schema](#declarative-schema)
 - [Layers](#layers)
 - [User Layer (CLI / PR Comments / API)](#user-layer-cli-pr-comments-api)
+  - [Status Checks and Branch Protection](#status-checks-and-branch-protection)
   - [Apply Options](#apply-options)
   - [Unsafe Changes](#unsafe-changes)
   - [Control Operations](#control-operations)
@@ -109,9 +110,78 @@ schemabot skip-revert -e staging <apply_id> # Finalize (Vitess)
 
 Users can also run `schemabot plan` manually in a PR comment to re-plan without waiting for auto-plan.
 
-**Check Runs** — SchemaBot publishes aggregate GitHub checks that block merge until managed schema changes are applied. Per-database state is stored internally and rolled up into the aggregate check. Production applies require staging to be clean first when environments are ordered. See [`check-runs.md`](check-runs.md) for the full lifecycle, race-safety model, and branch protection setup.
+**Check Runs** — SchemaBot publishes aggregate GitHub checks that block merge until managed schema changes are applied. See [Status Checks and Branch Protection](#status-checks-and-branch-protection) below.
 
 **API** — HTTP endpoints that both CLI and webhook use internally. The SchemaBot server exposes `/v1/plan`, `/v1/apply`, `/v1/progress`, `/v1/cutover`, etc.
+
+### Status Checks and Branch Protection
+
+GitHub Check Runs are SchemaBot's merge gate: a required SchemaBot check blocks
+merge until every schema change represented by the PR has either been applied
+successfully or resolved by a new plan. Check runs are a tier-0 safety feature —
+without them, the PR workflow is advisory and developers can merge schema
+changes that were never applied.
+
+SchemaBot publishes **aggregate** checks, not one visible check per database.
+Internal per-database check state is stored in SchemaBot's `checks` table — one
+record per (repo, PR, environment, database type, database) — and rolled up into
+one stable check name that branch protection can require:
+
+- `SchemaBot` when one deployment owns all environments
+- `SchemaBot (staging)` / `SchemaBot (production)` when `allowed_environments`
+  scopes a deployment to specific environments
+
+```diagram
+╭───────────────────────────────────╮
+│ Stored check state                │
+│ (one row per database)            │
+│  db_a staging    success          │
+│  db_b staging    in_progress      │──── rollup ───╮
+│  db_b production action_required  │               ▼
+╰───────────────────────────────────╯      ╭───────────────────╮     ╭───────────────────╮
+                                           │ Aggregate Check   │────▶│ Branch protection │
+                                           │ Run on PR head    │     │ blocks/allows     │
+                                           │ commit            │     │ merge             │
+                                           ╰───────────────────╯     ╰───────────────────╯
+```
+
+The rollup is intentionally conservative — first match wins:
+
+| Internal state | Aggregate result | Merge |
+| --- | --- | --- |
+| Any record `in_progress` | `in_progress` | Blocked |
+| Any record `failure` | `failure` | Blocked |
+| Any record `action_required` | `action_required` (plan pending, confirmation needed, rollback completed, reconciliation needed) | Blocked |
+| All records `success` | `success` | Allowed |
+
+**Required checks must exist on every head commit.** GitHub enforces required
+checks by name on each PR head commit and treats a missing check as not passing
+— it cannot distinguish "SchemaBot had no work to do" from "SchemaBot failed to
+report". SchemaBot therefore creates the aggregate check on every PR head, and
+publishes a passing `No managed schema changes` aggregate on PRs that do not
+touch managed schema files so non-schema PRs are not blocked by a missing
+required check.
+
+**Fail closed.** When SchemaBot cannot safely discover config, read or write
+stored check state, verify the current PR head SHA, or reconcile an in-progress
+apply, it leaves branch protection blocked and surfaces an operator-visible
+error. Uncertainty is never converted into a passing check. A check run belongs
+to one commit SHA, so stale work from an older commit can never satisfy branch
+protection for a newer PR head.
+
+**Environment ordering.** PR comment applies follow the server-owned promotion
+order (`environment_order`, default staging before production). Production
+applies are blocked until the prior environment's check state is `success`. When
+another SchemaBot deployment owns the prior environment, the gate reads that
+environment's aggregate check run from GitHub — check runs are the shared
+cross-deployment authority, so environment-scoped deployments never need each
+other's credentials, storage, or targets.
+
+To make the gate enforceable, repository owners must require the aggregate check
+name(s) in branch protection. Without branch protection, SchemaBot's checks are
+informational only. See [`check-runs.md`](check-runs.md) for the full check
+lifecycle, edge cases, race-safety model, blocking reasons, and branch
+protection setup.
 
 ### Apply Options
 

--- a/docs/check-runs.md
+++ b/docs/check-runs.md
@@ -87,6 +87,10 @@ For SchemaBot, the important mechanics are:
 
 - A check run belongs to one commit SHA. Updating a check run from an older SHA
   does not satisfy branch protection for a newer PR head.
+- GitHub required checks are enforced by check name on every PR head commit.
+  GitHub does not know whether SchemaBot had no work to do or failed to report;
+  if a required SchemaBot check run is missing from the current head commit,
+  branch protection blocks the merge.
 - A check run has a `status`, such as `in_progress` or `completed`.
 - A completed check run has a `conclusion`, such as `success`, `failure`, or
   `action_required`.
@@ -117,6 +121,13 @@ failure to represent safety, not a reason to skip.
 SchemaBot publishes aggregate GitHub checks, not one visible check per database.
 The aggregate check rolls up internal per-database state into one stable check
 name that can be required in branch protection.
+
+When the aggregate check is required by branch protection, SchemaBot must create
+a check run with that exact name on every PR head commit. That includes PRs that
+do not touch managed schema files. For those PRs, SchemaBot publishes a passing
+`No managed schema changes` aggregate so GitHub can satisfy the required check
+and allow the PR to merge. Skipping check creation would leave the required
+check missing, which GitHub treats as not passing.
 
 When all environments are owned by one SchemaBot deployment, require this check:
 
@@ -550,6 +561,11 @@ If the PR has no managed schema files, SchemaBot publishes passing aggregate
 checks on the current head SHA. This keeps branch protection from waiting for a
 SchemaBot check that would otherwise never be created.
 
+This check is intentionally published even though SchemaBot has no schema work to
+perform. Branch protection requires a passing check run by name on the current
+head commit; without this explicit success check, a required `SchemaBot` check
+would remain missing and the PR would be blocked from merging.
+
 This also covers SQL files outside an onboarded schema directory: without a
 matching `schemabot.yaml`, SchemaBot has no managed schema config to plan.
 
@@ -946,6 +962,12 @@ branch protection reflects the current database state.
 ## Branch Protection Setup
 
 Require the aggregate SchemaBot check in branch protection.
+
+Branch protection applies required checks to every PR head commit for the
+protected branch, not only to PRs that contain managed schema files. After the
+SchemaBot aggregate is required, SchemaBot will publish a passing no-op aggregate
+on PRs with no managed schema changes so non-schema PRs are not stuck waiting
+for a required check that never appears.
 
 When all environments are owned by one SchemaBot deployment, require:
 


### PR DESCRIPTION
## Why
Branch protection behavior is critical to SchemaBot's safety model, but the architecture overview compressed it into a single sentence, and check-runs.md did not explain why SchemaBot publishes passing aggregate checks on PRs with no managed schema changes.

## What
- Explain in check-runs.md that required checks must exist and pass on every PR head commit, and that no-op aggregate checks prevent non-schema PRs from being blocked by a missing required check
- Add a Status Checks and Branch Protection section to the architecture overview covering the aggregate check model, conservative rollup, fail-closed philosophy, environment ordering, and the branch protection requirement, with a pointer to check-runs.md for the full lifecycle

## Risk Assessment
Low — documentation-only change that does not alter runtime behavior.

Generated with Amp