### PR TITLE
fix(ci): make E2E image builds resilient to registry flakiness

### DIFF
--- a/.github/actions/prepull-base-images/action.yml
+++ b/.github/actions/prepull-base-images/action.yml
@@ -1,0 +1,54 @@
+name: "Pre-pull base images"
+description: >-
+  Pre-pull the Docker Hub base images that E2E image builds depend on, with
+  bounded retry and backoff. Warming the local image cache before
+  `docker compose up --build` / `docker build` means the subsequent build
+  resolves base images locally instead of issuing live Docker Hub pulls
+  mid-build, where unauthenticated rate-limit timeouts and the buildx progress
+  race ("read |0: file already closed") surface.
+
+inputs:
+  images:
+    description: "Space- or newline-separated list of base images to pull."
+    required: false
+    default: |
+      alpine:3.19
+      mysql:8.0
+  attempts:
+    description: "Maximum pull attempts per image."
+    required: false
+    default: "5"
+
+runs:
+  using: "composite"
+  steps:
+    - name: "Pull base images with retry"
+      shell: bash
+      env:
+        IMAGES: ${{ inputs.images }}
+        ATTEMPTS: ${{ inputs.attempts }}
+      run: |
+        set -euo pipefail
+
+        pull_with_retry() {
+          local image="$1"
+          local delay=5
+          for attempt in $(seq 1 "$ATTEMPTS"); do
+            if docker pull "$image"; then
+              echo "Pulled $image (attempt $attempt)"
+              return 0
+            fi
+            if [ "$attempt" -lt "$ATTEMPTS" ]; then
+              echo "::warning::Failed to pull $image (attempt $attempt/$ATTEMPTS); retrying in ${delay}s"
+              sleep "$delay"
+              delay=$((delay * 2))
+            fi
+          done
+          echo "::error::Failed to pull $image after $ATTEMPTS attempts"
+          return 1
+        }
+
+        for image in $IMAGES; do
+          [ -n "$image" ] || continue
+          pull_with_retry "$image"
+        done

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -209,6 +209,8 @@ jobs:
             ~/.cache/go-build
           key: go-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('go.sum') }}
           restore-keys: go-${{ runner.os }}-${{ runner.arch }}-
+      - name: "Pre-pull base images"
+        uses: ./.github/actions/prepull-base-images
       - name: "Test"
         run: make test-e2e-mysql test-e2e-grpc
       - name: "Container logs on failure"
@@ -262,6 +264,8 @@ jobs:
             ~/.cache/go-build
           key: go-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('go.sum') }}
           restore-keys: go-${{ runner.os }}-${{ runner.arch }}-
+      - name: "Pre-pull base images"
+        uses: ./.github/actions/prepull-base-images
       - name: "Test"
         run: |
           echo "Vitess e2e shard ${{ matrix.shard }}: ${{ matrix.run_filter }}"
@@ -302,6 +306,30 @@ jobs:
           CGO_ENABLED=0 GOOS=linux go build -o bin/schemabot-linux ./pkg/cmd
           cp bin/schemabot-linux deploy/local/schemabot-dev
           eval $(minikube docker-env)
+
+          # Warm minikube's image cache before the build and before kubelet
+          # pulls mysql:8.0 for the MySQL pods. Pulling here (with retry) keeps
+          # the unauthenticated Docker Hub rate-limit timeouts off the build and
+          # deploy critical path.
+          pull_with_retry() {
+            local image="$1"
+            local delay=5
+            for attempt in 1 2 3 4 5; do
+              if docker pull "$image"; then
+                return 0
+              fi
+              if [ "$attempt" -lt 5 ]; then
+                echo "::warning::Failed to pull $image (attempt $attempt/5); retrying in ${delay}s"
+                sleep "$delay"
+                delay=$((delay * 2))
+              fi
+            done
+            echo "::error::Failed to pull $image after 5 attempts"
+            return 1
+          }
+          pull_with_retry alpine:3.19
+          pull_with_retry mysql:8.0
+
           docker build -t schemabot:test -f deploy/local/Dockerfile.dev deploy/local/
           rm -f deploy/local/schemabot-dev
       - name: "Deploy and test"


### PR DESCRIPTION
## Summary

E2E jobs (E2E MySQL, E2E Vitess, E2E K8s) build images that pull `alpine:3.19` and `mysql:8.0` from Docker Hub at build/deploy time. These are **unauthenticated** pulls with **no retry**, which produces the recurring intermittent failures:

- `Get "https://registry-1.docker.io/v2/": net/http: request canceled (Client.Timeout exceeded while awaiting headers)` and `failed to resolve source metadata for docker.io/library/alpine:3.19` — Docker Hub rate-limit / timeout on the live pull.
- `failed to execute bake: read |0: file already closed` — the buildx progress race that surfaces when a base-image pull stalls in the middle of `docker compose up --build`.

The base image references themselves are fine; the problem is that the pull happens live, on the build/deploy critical path, with no resilience.

## Fix

Pre-pull the Docker Hub base images with bounded retry and exponential backoff **before** the build/deploy step, so the build resolves them from the local image cache instead of issuing live registry pulls mid-build.

- New reusable composite action `.github/actions/prepull-base-images` (used by the MySQL and Vitess jobs, which build via `docker compose up --build` against the host daemon).
- The K8s job pre-pulls inline inside the existing `minikube docker-env` context so it warms minikube's daemon — both the `docker build` of `Dockerfile.dev` and kubelet's `mysql:8.0` pod pull (`imagePullPolicy: IfNotPresent`) then hit the local cache.

This does not mask test failures or touch any test timeouts: a genuine, persistent registry outage still fails the job loudly after exhausting retries; only transient timeouts are absorbed.

```
checkout ──> pre-pull base images (retry/backoff) ──> build/up --build ──> test
                       │
                       └─ warms local docker cache so the build/deploy
                          step resolves alpine:3.19 / mysql:8.0 locally
                          instead of a live Docker Hub pull
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
