### PR TITLE
feat(engine): quarantine dropped tables as pending drops

### DIFF
--- a/pkg/engine/spirit/execution.go
+++ b/pkg/engine/spirit/execution.go
@@ -83,11 +83,22 @@ func (e *Engine) executeMigration(ctx context.Context, host, username, password,
 		}
 	}
 
-	// Execute DROP TABLE statements last (each individually through Spirit)
+	// Execute DROP TABLE statements last. By default the table is quarantined
+	// in the pending drops database instead of dropped, so its data stays
+	// recoverable until the retention period expires. When pending drops is
+	// disabled, the DROP executes directly through Spirit.
 	for _, stmt := range dropStatements {
-		if err := e.executeSingleStatement(ctx, host, username, password, database, stmt); err != nil {
-			e.logger.Error("DROP TABLE failed", "error", err)
-			e.setMigrationFailed(fmt.Errorf("DROP TABLE failed: %w", err))
+		if e.disablePendingDrops {
+			if err := e.executeSingleStatement(ctx, host, username, password, database, stmt); err != nil {
+				e.logger.Error("DROP TABLE failed", "error", err)
+				e.setMigrationFailed(fmt.Errorf("DROP TABLE failed: %w", err))
+				return
+			}
+			continue
+		}
+		if err := e.quarantineDroppedTables(ctx, host, username, password, database, stmt); err != nil {
+			e.logger.Error("DROP TABLE quarantine failed", "error", err)
+			e.setMigrationFailed(fmt.Errorf("DROP TABLE quarantine failed: %w", err))
 			return
 		}
 	}

--- a/pkg/engine/spirit/pending_drops.go
+++ b/pkg/engine/spirit/pending_drops.go
@@ -1,0 +1,134 @@
+// pendingdrops.go quarantines dropped tables instead of executing DROP TABLE.
+// The table is renamed into the pending drops database with a timestamp prefix
+// so its data stays recoverable until the retention period expires.
+package spirit
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/block/spirit/pkg/statement"
+	"github.com/block/spirit/pkg/utils"
+	"github.com/go-sql-driver/mysql"
+	"github.com/pingcap/tidb/pkg/parser/ast"
+
+	"github.com/block/schemabot/pkg/metrics"
+	"github.com/block/schemabot/pkg/pendingdrops"
+)
+
+// quarantineDroppedTables executes a DROP TABLE statement as a quarantine:
+// every table named in the statement is renamed into the pending drops
+// database instead of being dropped. IF EXISTS semantics are preserved —
+// missing tables are skipped when the statement allows it.
+func (e *Engine) quarantineDroppedTables(ctx context.Context, host, username, password, database, stmt string) error {
+	parsed, err := statement.New(stmt)
+	if err != nil {
+		return fmt.Errorf("parse DROP TABLE statement: %w", err)
+	}
+	if len(parsed) != 1 {
+		return fmt.Errorf("expected exactly 1 parsed DROP TABLE statement, got %d", len(parsed))
+	}
+	dropStmt, ok := (*parsed[0].StmtNode).(*ast.DropTableStmt)
+	if !ok {
+		return fmt.Errorf("statement is not DROP TABLE: %s", stmt)
+	}
+	// DROP VIEW and DROP TEMPORARY TABLE also parse as DropTableStmt. Neither
+	// holds recoverable table data, and neither can be renamed into the pending
+	// drops database with table semantics, so execute them as written.
+	if dropStmt.IsView || dropStmt.TemporaryKeyword != ast.TemporaryNone {
+		e.logger.Info("executing non-table drop directly without pending drops quarantine",
+			"database", database,
+			"statement", stmt,
+			"is_view", dropStmt.IsView,
+			"temporary_keyword", dropStmt.TemporaryKeyword,
+		)
+		if err := e.executeSingleStatement(ctx, host, username, password, database, stmt); err != nil {
+			return fmt.Errorf("execute non-table drop directly: %w", err)
+		}
+		return nil
+	}
+
+	cfg := mysql.NewConfig()
+	cfg.Net = "tcp"
+	cfg.Addr = host
+	cfg.User = username
+	cfg.Passwd = password
+	cfg.DBName = database
+
+	connectionDSN, err := mysqlConnectionDSN(cfg.FormatDSN())
+	if err != nil {
+		return fmt.Errorf("build pending drops connection DSN for database %s: %w", database, err)
+	}
+	db, err := sql.Open("mysql", connectionDSN)
+	if err != nil {
+		return fmt.Errorf("open database %s: %w", database, err)
+	}
+	defer utils.CloseAndLog(db)
+	if err := db.PingContext(ctx); err != nil {
+		return fmt.Errorf("ping database %s: %w", database, err)
+	}
+
+	tables := make([]pendingdrops.TableMove, 0, len(dropStmt.Tables))
+	for _, table := range dropStmt.Tables {
+		tableName := table.Name.String()
+		schemaName := table.Schema.String()
+		if schemaName == "" {
+			schemaName = database
+		}
+
+		if dropStmt.IfExists {
+			exists, err := tableExistsInSchema(ctx, db, schemaName, tableName)
+			if err != nil {
+				return fmt.Errorf("check table `%s`.`%s` exists: %w", schemaName, tableName, err)
+			}
+			if !exists {
+				e.logger.Info("DROP TABLE IF EXISTS target does not exist, skipping quarantine",
+					"database", schemaName,
+					"table", tableName,
+				)
+				continue
+			}
+		}
+		tables = append(tables, pendingdrops.TableMove{SchemaName: schemaName, TableName: tableName})
+	}
+
+	moved, err := pendingdrops.MoveTables(ctx, db, tables, time.Now())
+	if err != nil {
+		return fmt.Errorf("quarantine DROP TABLE targets: %w", err)
+	}
+	for _, table := range moved {
+		e.logger.Info("DROP TABLE intercepted: table quarantined in pending drops and recoverable until the retention period expires",
+			"database", table.SchemaName,
+			"table", table.TableName,
+			"quarantine_database", table.QuarantineSchema,
+			"quarantine_table", table.QuarantineTable,
+		)
+		// Route the quarantine location to the apply log so operators can find
+		// the table for recovery without querying information_schema.
+		e.mu.Lock()
+		onLog := e.onLog
+		e.mu.Unlock()
+		if onLog != nil {
+			onLog(slog.LevelInfo, table.TableName,
+				fmt.Sprintf("table quarantined as `%s`.`%s`; recoverable until the pending drops retention period expires",
+					table.QuarantineSchema, table.QuarantineTable))
+		}
+		metrics.RecordPendingDropMoved(ctx, table.SchemaName)
+	}
+	return nil
+}
+
+// tableExistsInSchema checks if a table exists in the given schema.
+func tableExistsInSchema(ctx context.Context, db *sql.DB, schemaName, tableName string) (bool, error) {
+	var count int
+	err := db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = ? AND table_name = ?",
+		schemaName, tableName).Scan(&count)
+	if err != nil {
+		return false, fmt.Errorf("query information_schema.tables for `%s`.`%s`: %w", schemaName, tableName, err)
+	}
+	return count > 0, nil
+}

--- a/pkg/engine/spirit/pending_drops_integration_test.go
+++ b/pkg/engine/spirit/pending_drops_integration_test.go
@@ -1,0 +1,257 @@
+//go:build integration
+
+package spirit
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/block/spirit/pkg/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/block/schemabot/pkg/engine"
+	"github.com/block/schemabot/pkg/pendingdrops"
+)
+
+// cleanupPendingDropsDB removes the quarantine database so each test observes
+// only its own quarantined tables.
+func cleanupPendingDropsDB(t *testing.T, db *sql.DB) {
+	t.Helper()
+	_, err := db.ExecContext(t.Context(), fmt.Sprintf("DROP DATABASE IF EXISTS `%s`", pendingdrops.Database))
+	require.NoError(t, err, "drop pending drops database")
+}
+
+// listQuarantinedTables returns the table names currently in the quarantine database.
+func listQuarantinedTables(t *testing.T, db *sql.DB) []string {
+	t.Helper()
+	rows, err := db.QueryContext(t.Context(),
+		"SELECT table_name FROM information_schema.tables WHERE table_schema = ? ORDER BY table_name",
+		pendingdrops.Database)
+	require.NoError(t, err, "query quarantined tables")
+	defer utils.CloseAndLog(rows)
+
+	var tables []string
+	for rows.Next() {
+		var name string
+		require.NoError(t, rows.Scan(&name), "scan table name")
+		tables = append(tables, name)
+	}
+	require.NoError(t, rows.Err(), "iterate quarantined tables")
+	return tables
+}
+
+// runDDLApply runs DDL statements through the engine and returns the final
+// engine state.
+func runDDLApply(t *testing.T, eng *Engine, dsn string, ddlStatements []string) engine.State {
+	t.Helper()
+
+	host, username, password, database, err := parseDSN(dsn)
+	require.NoError(t, err, "parseDSN")
+
+	eng.mu.Lock()
+	eng.runningMigration = &runningMigration{
+		database: database,
+		state:    engine.StateRunning,
+		started:  time.Now(),
+	}
+	eng.mu.Unlock()
+
+	eng.executeMigration(t.Context(), host, username, password, database, ddlStatements, false)
+
+	eng.mu.Lock()
+	defer eng.mu.Unlock()
+	return eng.runningMigration.state
+}
+
+// A dropped table is quarantined in the pending drops database with its data
+// intact instead of being dropped, so an accidental drop is recoverable until
+// the retention period expires.
+func TestEngine_ExecuteSchemaChange_DropTableQuarantines(t *testing.T) {
+	dsn, db := setupTestMySQL(t)
+	cleanupTables(t, db)
+	cleanupPendingDropsDB(t, db)
+
+	_, err := db.ExecContext(t.Context(), `CREATE TABLE drop_me (
+		id INT PRIMARY KEY AUTO_INCREMENT,
+		name VARCHAR(100) NOT NULL
+	)`)
+	require.NoError(t, err, "create table")
+	for i := range 10 {
+		_, err := db.ExecContext(t.Context(), `INSERT INTO drop_me (name) VALUES (?)`, fmt.Sprintf("row-%d", i))
+		require.NoError(t, err, "insert data")
+	}
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	eng := New(Config{Logger: logger})
+
+	state := runDDLApply(t, eng, dsn, []string{"DROP TABLE `drop_me`"})
+	assert.Equal(t, engine.StateCompleted, state)
+
+	// The table is gone from the target database.
+	var count int
+	err = db.QueryRowContext(t.Context(),
+		"SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = 'testdb' AND table_name = 'drop_me'").Scan(&count)
+	require.NoError(t, err)
+	assert.Equal(t, 0, count, "drop_me should be gone from testdb")
+
+	// The table is quarantined with a parseable timestamp prefix and its data intact.
+	quarantined := listQuarantinedTables(t, db)
+	require.Len(t, quarantined, 1)
+	assert.Contains(t, quarantined[0], "_drop_me")
+	quarantinedAt, ok := pendingdrops.ParseTimestamp(quarantined[0])
+	require.True(t, ok, "quarantine table name %q must carry a parseable timestamp", quarantined[0])
+	assert.WithinDuration(t, time.Now(), quarantinedAt, time.Minute)
+
+	var rowCount int
+	err = db.QueryRowContext(t.Context(),
+		fmt.Sprintf("SELECT COUNT(*) FROM `%s`.`%s`", pendingdrops.Database, quarantined[0])).Scan(&rowCount)
+	require.NoError(t, err)
+	assert.Equal(t, 10, rowCount, "quarantined table keeps its data")
+}
+
+// When pending drops is disabled, DROP TABLE executes directly and no
+// quarantine database is created.
+func TestEngine_ExecuteSchemaChange_DropTableDisabled(t *testing.T) {
+	dsn, db := setupTestMySQL(t)
+	cleanupTables(t, db)
+	cleanupPendingDropsDB(t, db)
+
+	_, err := db.ExecContext(t.Context(), `CREATE TABLE drop_me_direct (
+		id INT PRIMARY KEY AUTO_INCREMENT
+	)`)
+	require.NoError(t, err, "create table")
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	eng := New(Config{Logger: logger, DisablePendingDrops: true})
+
+	state := runDDLApply(t, eng, dsn, []string{"DROP TABLE `drop_me_direct`"})
+	assert.Equal(t, engine.StateCompleted, state)
+
+	var count int
+	err = db.QueryRowContext(t.Context(),
+		"SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = 'testdb' AND table_name = 'drop_me_direct'").Scan(&count)
+	require.NoError(t, err)
+	assert.Equal(t, 0, count, "drop_me_direct should be dropped")
+
+	var dbCount int
+	err = db.QueryRowContext(t.Context(),
+		"SELECT COUNT(*) FROM information_schema.schemata WHERE schema_name = ?",
+		pendingdrops.Database).Scan(&dbCount)
+	require.NoError(t, err)
+	assert.Equal(t, 0, dbCount, "no quarantine database should be created when pending drops is disabled")
+}
+
+// DROP TABLE IF EXISTS on a missing table completes without creating a
+// quarantine entry, matching MySQL's IF EXISTS semantics.
+func TestEngine_ExecuteSchemaChange_DropTableIfExistsMissing(t *testing.T) {
+	dsn, db := setupTestMySQL(t)
+	cleanupTables(t, db)
+	cleanupPendingDropsDB(t, db)
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	eng := New(Config{Logger: logger})
+
+	state := runDDLApply(t, eng, dsn, []string{"DROP TABLE IF EXISTS `never_existed`"})
+	assert.Equal(t, engine.StateCompleted, state)
+
+	quarantined := listQuarantinedTables(t, db)
+	assert.Empty(t, quarantined, "missing table must not create a quarantine entry")
+}
+
+// Multi-table DROP TABLE is quarantined atomically: if any required table is
+// missing, existing tables remain in the target database and no partial
+// quarantine is recorded.
+func TestEngine_ExecuteSchemaChange_DropTableMultiTableFailureIsAtomic(t *testing.T) {
+	dsn, db := setupTestMySQL(t)
+	cleanupTables(t, db)
+	cleanupPendingDropsDB(t, db)
+	t.Cleanup(func() {
+		cleanupCtx := context.WithoutCancel(t.Context())
+		_, err := db.ExecContext(cleanupCtx, "DROP TABLE IF EXISTS `keep_on_failure`")
+		require.NoError(t, err, "drop keep_on_failure")
+		_, err = db.ExecContext(cleanupCtx, fmt.Sprintf("DROP DATABASE IF EXISTS `%s`", pendingdrops.Database))
+		require.NoError(t, err, "drop pending drops database")
+	})
+
+	_, err := db.ExecContext(t.Context(), `CREATE TABLE keep_on_failure (
+		id INT PRIMARY KEY AUTO_INCREMENT
+	)`)
+	require.NoError(t, err, "create table")
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	eng := New(Config{Logger: logger})
+
+	state := runDDLApply(t, eng, dsn, []string{"DROP TABLE `keep_on_failure`, `missing_table`"})
+	assert.Equal(t, engine.StateFailed, state)
+
+	var count int
+	err = db.QueryRowContext(t.Context(),
+		"SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = 'testdb' AND table_name = 'keep_on_failure'").Scan(&count)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count, "existing table should remain when the multi-table quarantine fails")
+
+	quarantined := listQuarantinedTables(t, db)
+	assert.Empty(t, quarantined, "failed multi-table quarantine must not move any table")
+}
+
+// DROP VIEW parses as a TiDB DropTableStmt, but views are not recoverable table
+// data and cannot be renamed into the pending drops database. The view is
+// dropped directly and no quarantine entry is created.
+func TestEngine_ExecuteSchemaChange_DropViewExecutesDirectly(t *testing.T) {
+	dsn, db := setupTestMySQL(t)
+	cleanupTables(t, db)
+	cleanupPendingDropsDB(t, db)
+	t.Cleanup(func() {
+		cleanupCtx := context.WithoutCancel(t.Context())
+		_, err := db.ExecContext(cleanupCtx, "DROP VIEW IF EXISTS `drop_view_target`")
+		require.NoError(t, err, "drop view")
+		_, err = db.ExecContext(cleanupCtx, "DROP TABLE IF EXISTS `drop_view_base`")
+		require.NoError(t, err, "drop base table")
+	})
+
+	_, err := db.ExecContext(t.Context(), `CREATE TABLE drop_view_base (
+		id INT PRIMARY KEY AUTO_INCREMENT
+	)`)
+	require.NoError(t, err, "create base table")
+	_, err = db.ExecContext(t.Context(), "CREATE VIEW `drop_view_target` AS SELECT id FROM `drop_view_base`")
+	require.NoError(t, err, "create view")
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	eng := New(Config{Logger: logger})
+
+	state := runDDLApply(t, eng, dsn, []string{"DROP VIEW `drop_view_target`"})
+	assert.Equal(t, engine.StateCompleted, state)
+
+	var count int
+	err = db.QueryRowContext(t.Context(),
+		"SELECT COUNT(*) FROM information_schema.views WHERE table_schema = 'testdb' AND table_name = 'drop_view_target'").Scan(&count)
+	require.NoError(t, err)
+	assert.Equal(t, 0, count, "view should be dropped")
+
+	quarantined := listQuarantinedTables(t, db)
+	assert.Empty(t, quarantined, "views must not create quarantine entries")
+}
+
+// DROP TEMPORARY TABLE also parses as a TiDB DropTableStmt, but temporary
+// tables are connection-local and cannot be moved with RENAME TABLE. The
+// statement executes directly and no quarantine entry is created.
+func TestEngine_ExecuteSchemaChange_DropTemporaryTableExecutesDirectly(t *testing.T) {
+	dsn, db := setupTestMySQL(t)
+	cleanupTables(t, db)
+	cleanupPendingDropsDB(t, db)
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	eng := New(Config{Logger: logger})
+
+	state := runDDLApply(t, eng, dsn, []string{"DROP TEMPORARY TABLE IF EXISTS `drop_temp_target`"})
+	assert.Equal(t, engine.StateCompleted, state)
+
+	quarantined := listQuarantinedTables(t, db)
+	assert.Empty(t, quarantined, "temporary tables must not create quarantine entries")
+}

--- a/pkg/engine/spirit/spirit.go
+++ b/pkg/engine/spirit/spirit.go
@@ -50,11 +50,12 @@ type Engine struct {
 	linter       *lint.Linter
 
 	// Configuration
-	targetChunkTime time.Duration
-	threads         int
-	lockWaitTimeout time.Duration
-	debugLogs       bool
-	cpuHint         int // Inferred CPU count from innodb_buffer_pool_instances (0 = unknown)
+	targetChunkTime     time.Duration
+	threads             int
+	lockWaitTimeout     time.Duration
+	debugLogs           bool
+	disablePendingDrops bool
+	cpuHint             int // Inferred CPU count from innodb_buffer_pool_instances (0 = unknown)
 
 	// Log callback for routing Spirit logs to ApplyLogStore (with table context)
 	onLog func(level slog.Level, table, msg string)
@@ -101,6 +102,12 @@ type Config struct {
 	Threads         int
 	LockWaitTimeout time.Duration
 	DebugLogs       bool // Enable Spirit's verbose debug logs (replication events, etc.)
+
+	// DisablePendingDrops executes DROP TABLE statements directly instead of
+	// quarantining the table in the pending drops database. Quarantine is the
+	// default because it keeps dropped table data recoverable until the
+	// retention period expires.
+	DisablePendingDrops bool
 }
 
 // New creates a new Spirit engine.
@@ -126,12 +133,13 @@ func New(cfg Config) *Engine {
 	}
 
 	eng := &Engine{
-		logger:          logger,
-		linter:          lint.New(),
-		targetChunkTime: targetChunkTime,
-		threads:         threads,
-		lockWaitTimeout: lockWaitTimeout,
-		debugLogs:       cfg.DebugLogs,
+		logger:              logger,
+		linter:              lint.New(),
+		targetChunkTime:     targetChunkTime,
+		threads:             threads,
+		lockWaitTimeout:     lockWaitTimeout,
+		debugLogs:           cfg.DebugLogs,
+		disablePendingDrops: cfg.DisablePendingDrops,
 	}
 
 	// Create Spirit logger with filter that checks debugLogs at runtime

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1101,3 +1101,22 @@ func RecordStatusCheckOperation(ctx context.Context, op StatusCheckOperation) {
 	}
 	counter.Add(ctx, 1, otelmetric.WithAttributes(attrs...))
 }
+
+// RecordPendingDropMoved increments the counter for tables quarantined into
+// the pending drops database instead of being dropped.
+func RecordPendingDropMoved(ctx context.Context, database string) {
+	meter := otel.Meter(meterName)
+	counter, err := meter.Int64Counter("schemabot.pending_drops.tables_moved_total",
+		otelmetric.WithDescription("Total number of dropped tables quarantined into the pending drops database"),
+		otelmetric.WithUnit("{table}"),
+	)
+	if err != nil {
+		slog.Warn("failed to create pending drops moved counter", "error", err)
+		return
+	}
+	counter.Add(ctx, 1,
+		otelmetric.WithAttributes(
+			attribute.String("database", database),
+		),
+	)
+}

--- a/pkg/pendingdrops/move.go
+++ b/pkg/pendingdrops/move.go
@@ -1,0 +1,94 @@
+package pendingdrops
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// TableMove is one source table to quarantine.
+type TableMove struct {
+	SchemaName string
+	TableName  string
+}
+
+// QuarantinedTable records the quarantine destination for a source table.
+type QuarantinedTable struct {
+	SchemaName       string
+	TableName        string
+	QuarantineSchema string
+	QuarantineTable  string
+}
+
+// MoveTable quarantines a table by renaming it into the _pending_drops
+// database with a timestamp prefix instead of dropping it. It creates the
+// _pending_drops database when missing. Returns the quarantine table name.
+//
+// RENAME TABLE is atomic and metadata-only, so the move is fast regardless of
+// table size and the data is preserved until the cleaner's retention period
+// expires.
+func MoveTable(ctx context.Context, db *sql.DB, schemaName, tableName string, now time.Time) (string, error) {
+	moved, err := MoveTables(ctx, db, []TableMove{{SchemaName: schemaName, TableName: tableName}}, now)
+	if err != nil {
+		return "", err
+	}
+	if len(moved) != 1 {
+		return "", fmt.Errorf("expected 1 quarantined table, got %d", len(moved))
+	}
+	return moved[0].QuarantineTable, nil
+}
+
+// MoveTables quarantines source tables with a single atomic RENAME TABLE
+// statement. Either all source tables move to the pending drops database or
+// none of them do.
+func MoveTables(ctx context.Context, db *sql.DB, tables []TableMove, now time.Time) ([]QuarantinedTable, error) {
+	if len(tables) == 0 {
+		return nil, nil
+	}
+
+	if _, err := db.ExecContext(ctx, fmt.Sprintf("CREATE DATABASE IF NOT EXISTS %s", quoteIdentifier(Database))); err != nil {
+		return nil, fmt.Errorf("create %s database: %w", Database, err)
+	}
+
+	moved := quarantineDestinations(tables, now)
+	renameSQL, err := renameStatement(moved)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := db.ExecContext(ctx, renameSQL); err != nil {
+		return nil, fmt.Errorf("rename tables to pending drops (query = %s): %w", renameSQL, err)
+	}
+	return moved, nil
+}
+
+func quarantineDestinations(tables []TableMove, now time.Time) []QuarantinedTable {
+	moved := make([]QuarantinedTable, 0, len(tables))
+	for _, table := range tables {
+		moved = append(moved, QuarantinedTable{
+			SchemaName:       table.SchemaName,
+			TableName:        table.TableName,
+			QuarantineSchema: Database,
+			QuarantineTable:  TableName(table.SchemaName, table.TableName, now),
+		})
+	}
+	return moved
+}
+
+func renameStatement(moved []QuarantinedTable) (string, error) {
+	if len(moved) == 0 {
+		return "", fmt.Errorf("at least one table is required")
+	}
+	parts := make([]string, 0, len(moved))
+	for _, table := range moved {
+		parts = append(parts, fmt.Sprintf("%s.%s TO %s.%s",
+			quoteIdentifier(table.SchemaName), quoteIdentifier(table.TableName),
+			quoteIdentifier(table.QuarantineSchema), quoteIdentifier(table.QuarantineTable)))
+	}
+	return "RENAME TABLE " + strings.Join(parts, ", "), nil
+}
+
+func quoteIdentifier(name string) string {
+	return "`" + strings.ReplaceAll(name, "`", "``") + "`"
+}

--- a/pkg/pendingdrops/pending_drops.go
+++ b/pkg/pendingdrops/pending_drops.go
@@ -1,0 +1,73 @@
+// Package pendingdrops implements the pending drops quarantine for dropped
+// MySQL tables.
+//
+// Instead of executing DROP TABLE, the Spirit engine renames the table into a
+// _pending_drops database with a timestamp prefix. The table keeps its data and
+// can be recovered with a manual RENAME TABLE until the cleaner removes it
+// after the retention period.
+package pendingdrops
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+)
+
+const (
+	// Database is the MySQL database (schema) that holds quarantined tables.
+	Database = "_pending_drops"
+
+	// DefaultRetention is how long quarantined tables are kept before the
+	// cleaner drops them permanently.
+	DefaultRetention = 7 * 24 * time.Hour
+
+	// tableNameLengthLimit is MySQL's maximum table name length.
+	tableNameLengthLimit = 64
+
+	// timestampLen is the length of the timestamp prefix in quarantined table
+	// names: "YYYYMMDDHHmmSSmmm_" = 18 characters.
+	timestampLen = 18
+
+	// timestampBaseFormat is the Go time format for the date+time portion of
+	// the prefix (14 digits: YYYYMMDDHHmmSS). The trailing 3 digits are
+	// milliseconds, parsed separately since Go's time.Parse cannot parse
+	// concatenated millisecond digits without a separator.
+	timestampBaseFormat = "20060102150405"
+)
+
+// TableName returns the quarantine table name for a dropped table, capped at
+// MySQL's 64-character limit. The timestamp prefix is UTC and records when the
+// table was quarantined so the cleaner can compute its age from the name alone.
+// ParseTimestamp reads the prefix back as UTC, so both sides agree on the
+// instant regardless of the server's local time zone.
+func TableName(_ string, tableName string, now time.Time) string {
+	now = now.UTC()
+	prefix := fmt.Sprintf("%s%03d_", now.Format(timestampBaseFormat), now.Nanosecond()/int(time.Millisecond))
+	maxTableLen := tableNameLengthLimit - len(prefix)
+	if len(tableName) > maxTableLen {
+		tableName = tableName[:maxTableLen]
+	}
+	return prefix + tableName
+}
+
+// ParseTimestamp extracts the quarantine time from a table name produced by
+// TableName. It returns false for names that do not carry a valid timestamp
+// prefix; the cleaner must never drop those tables because their age is
+// unknown.
+func ParseTimestamp(name string) (time.Time, bool) {
+	if len(name) < timestampLen {
+		return time.Time{}, false
+	}
+	if name[timestampLen-1] != '_' {
+		return time.Time{}, false
+	}
+	t, err := time.Parse(timestampBaseFormat, name[:14])
+	if err != nil {
+		return time.Time{}, false
+	}
+	ms, err := strconv.Atoi(name[14 : timestampLen-1])
+	if err != nil || ms < 0 || ms > 999 {
+		return time.Time{}, false
+	}
+	return t.Add(time.Duration(ms) * time.Millisecond), true
+}

--- a/pkg/pendingdrops/pending_drops_test.go
+++ b/pkg/pendingdrops/pending_drops_test.go
@@ -1,0 +1,67 @@
+package pendingdrops
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTableName(t *testing.T) {
+	now := time.Date(2026, 6, 10, 14, 30, 22, 123*int(time.Millisecond), time.UTC)
+
+	name := TableName("testdb", "users", now)
+	assert.Equal(t, "20260610143022123_users", name)
+
+	parsed, ok := ParseTimestamp(name)
+	require.True(t, ok)
+	assert.Equal(t, now, parsed)
+}
+
+func TestTableNameUsesUTC(t *testing.T) {
+	loc := time.FixedZone("UTC+5", 5*3600)
+	local := time.Date(2026, 6, 10, 19, 30, 22, 0, loc) // 14:30:22 UTC
+
+	name := TableName("testdb", "users", local)
+	assert.Equal(t, "20260610143022000_users", name)
+
+	parsed, ok := ParseTimestamp(name)
+	require.True(t, ok)
+	assert.True(t, parsed.Equal(local), "parsed instant %v should equal original %v", parsed, local)
+}
+
+func TestTableNameCapsAtMySQLLimit(t *testing.T) {
+	now := time.Date(2026, 6, 10, 14, 30, 22, 0, time.UTC)
+	longTable := strings.Repeat("a", 80)
+
+	name := TableName("testdb", longTable, now)
+	assert.Len(t, name, 64)
+	assert.True(t, strings.HasPrefix(name, "20260610143022000_"))
+
+	parsed, ok := ParseTimestamp(name)
+	require.True(t, ok)
+	assert.Equal(t, now, parsed)
+}
+
+func TestParseTimestampRejectsInvalidNames(t *testing.T) {
+	invalid := []string{
+		"",
+		"users",
+		"20260610143022123users",     // missing underscore separator
+		"2026061014302212x_users",    // non-numeric milliseconds
+		"20261310143022123_users",    // month 13
+		"abcdefghijklmn123_users",    // non-numeric date
+		"_users_old_20260610_143022", // Spirit old-table naming, not quarantine naming
+		"20260610143022123_",         // valid prefix, empty table name is still parseable
+	}
+	for _, name := range invalid[:len(invalid)-1] {
+		_, ok := ParseTimestamp(name)
+		assert.False(t, ok, "expected %q to be rejected", name)
+	}
+
+	// A bare prefix is parseable: age is known even if the original name was truncated away.
+	_, ok := ParseTimestamp("20260610143022123_")
+	assert.True(t, ok)
+}

--- a/pkg/tern/local_client.go
+++ b/pkg/tern/local_client.go
@@ -123,6 +123,8 @@ type LocalConfig struct {
 	// engine via Credentials.Metadata and reads specific keys as needed.
 	// Keys used by PlanetScale: organization, token_name, token_value,
 	// tls_name, revert_window_duration, main_branch.
+	// Keys used by Spirit: pending_drops ("false" disables the pending drops
+	// quarantine so DROP TABLE executes directly).
 	Metadata map[string]string
 }
 
@@ -182,9 +184,14 @@ func NewLocalClient(cfg LocalConfig, stor storage.Storage, logger *slog.Logger) 
 	}
 
 	return &LocalClient{
-		config:            cfg,
-		storage:           stor,
-		spiritEngine:      spirit.New(spirit.Config{Logger: logger}),
+		config:  cfg,
+		storage: stor,
+		spiritEngine: spirit.New(spirit.Config{
+			Logger: logger,
+			// Pending drops quarantine is on by default; deployments opt out
+			// via the pending_drops metadata key.
+			DisablePendingDrops: cfg.Metadata["pending_drops"] == "false",
+		}),
 		planetscaleEngine: psEngine,
 		logger:            logger,
 		heartbeatInterval: 10 * time.Second,


### PR DESCRIPTION
## Why
`DROP TABLE` destroys data instantly and irreversibly. Quarantining dropped MySQL tables gives operators a recovery window after an accidental schema file removal passes review.

## What
- Intercept Spirit `DROP TABLE` execution and atomically rename targets into `_pending_drops`
- Preserve `IF EXISTS` semantics and make multi-table drops all-or-nothing
- Execute `DROP VIEW` and `DROP TEMPORARY TABLE` directly, since TiDB parses them as drop-table AST nodes but they are not recoverable table data
- Name quarantine tables with a UTC timestamp so cleanup can reason about age from the table name
- Record the quarantine location in apply logs and emit a moved-table counter

## Risk Assessment
Medium — changes Spirit/MySQL `DROP TABLE` execution semantics, but the new behavior is safer because table data is retained instead of destroyed. Deployments can opt out via the metadata/config plumbing added in the follow-up cleanup PR.

## References
Stack: #283 → #285 → #286

Generated with Amp