### PR TITLE
fix(spirit): require TLS for RDS connections

### DIFF
--- a/pkg/engine/spirit/control.go
+++ b/pkg/engine/spirit/control.go
@@ -201,7 +201,7 @@ func (e *Engine) Cutover(ctx context.Context, req *engine.ControlRequest) (*engi
 		return nil, fmt.Errorf("database is required for cutover")
 	}
 
-	db, err := sql.Open("mysql", req.Credentials.DSN)
+	db, err := openMySQL(req.Credentials.DSN)
 	if err != nil {
 		return nil, fmt.Errorf("open connection for cutover: %w", err)
 	}
@@ -250,7 +250,7 @@ func (e *Engine) DeferredCutoverSignalExists(ctx context.Context, req *engine.De
 		return false, fmt.Errorf("database is required for deferred cutover signal lookup")
 	}
 
-	db, err := sql.Open("mysql", req.Credentials.DSN)
+	db, err := openMySQL(req.Credentials.DSN)
 	if err != nil {
 		return false, fmt.Errorf("open connection for deferred cutover signal lookup: %w", err)
 	}
@@ -467,7 +467,7 @@ func settingsToVolume(threads int, chunkTime time.Duration) int32 {
 // dynamically calculated from available_logical_processors / 4.
 // Returns 0 if the query fails or the value can't be determined.
 func (e *Engine) queryCPUHint(ctx context.Context, dsn string) int {
-	db, err := sql.Open("mysql", dsn)
+	db, err := openMySQL(dsn)
 	if err != nil {
 		e.logger.Debug("queryCPUHint: failed to open", "error", err)
 		return 0
@@ -509,11 +509,17 @@ func (e *Engine) logCheckpointState(rm *runningMigration, phase string, extra ma
 		return
 	}
 
-	// Build DSN for connection
-	dsn := fmt.Sprintf("%s:%s@tcp(%s)/%s?interpolateParams=true",
-		rm.username, rm.password, rm.host, rm.database)
+	// Build DSN for connection.
+	cfg := mysql.NewConfig()
+	cfg.User = rm.username
+	cfg.Passwd = rm.password
+	cfg.Net = "tcp"
+	cfg.Addr = rm.host
+	cfg.DBName = rm.database
+	cfg.InterpolateParams = true
+	dsn := cfg.FormatDSN()
 
-	db, err := sql.Open("mysql", dsn)
+	db, err := openMySQL(dsn)
 	if err != nil {
 		e.logger.Warn("logCheckpointState: failed to open", "error", err)
 		return

--- a/pkg/engine/spirit/helpers.go
+++ b/pkg/engine/spirit/helpers.go
@@ -3,6 +3,7 @@ package spirit
 import (
 	"database/sql"
 	"fmt"
+	"net"
 	"strings"
 
 	"github.com/block/spirit/pkg/dbconn"
@@ -12,6 +13,8 @@ import (
 	"github.com/block/schemabot/pkg/ddl"
 	"github.com/block/schemabot/pkg/schema"
 )
+
+var lookupCNAME = net.LookupCNAME
 
 // parseDSN extracts connection info from a MySQL DSN using the mysql driver's parser.
 func parseDSN(dsn string) (host, username, password, database string, err error) {
@@ -39,16 +42,40 @@ func mysqlConnectionDSN(dsn string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("parse DSN: %w", err)
 	}
-	if cfg.TLSConfig != "" || !dbconn.IsRDSHost(cfg.Addr) {
+	if cfg.TLSConfig != "" {
+		return dsn, nil
+	}
+	tlsMode, ok := mysqlTLSModeForHost(cfg.Addr)
+	if !ok {
 		return dsn, nil
 	}
 	dbConfig := dbconn.NewDBConfig()
-	dbConfig.TLSMode = "REQUIRED"
+	dbConfig.TLSMode = tlsMode
 	connectionDSN, err := dbconn.EnhanceDSNWithTLS(dsn, dbConfig)
 	if err != nil {
 		return "", fmt.Errorf("enhance RDS DSN with TLS: %w", err)
 	}
 	return connectionDSN, nil
+}
+
+func mysqlTLSModeForHost(addr string) (string, bool) {
+	if dbconn.IsRDSHost(addr) {
+		return "REQUIRED", true
+	}
+
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		host = addr
+	}
+	canonicalHost, err := lookupCNAME(host)
+	if err != nil {
+		return "", false
+	}
+	canonicalHost = strings.TrimSuffix(canonicalHost, ".")
+	if !dbconn.IsRDSHost(canonicalHost) {
+		return "", false
+	}
+	return "VERIFY_CA", true
 }
 
 // namespaceForTable finds which namespace a table belongs to by checking

--- a/pkg/engine/spirit/helpers.go
+++ b/pkg/engine/spirit/helpers.go
@@ -1,12 +1,13 @@
 package spirit
 
 import (
+	"database/sql"
 	"fmt"
 	"strings"
 
-	"github.com/go-sql-driver/mysql"
-
+	"github.com/block/spirit/pkg/dbconn"
 	"github.com/block/spirit/pkg/statement"
+	"github.com/go-sql-driver/mysql"
 
 	"github.com/block/schemabot/pkg/ddl"
 	"github.com/block/schemabot/pkg/schema"
@@ -19,6 +20,35 @@ func parseDSN(dsn string) (host, username, password, database string, err error)
 		return "", "", "", "", fmt.Errorf("parse DSN: %w", err)
 	}
 	return cfg.Addr, cfg.User, cfg.Passwd, cfg.DBName, nil
+}
+
+func openMySQL(dsn string) (*sql.DB, error) {
+	connectionDSN, err := mysqlConnectionDSN(dsn)
+	if err != nil {
+		return nil, err
+	}
+	db, err := sql.Open("mysql", connectionDSN)
+	if err != nil {
+		return nil, fmt.Errorf("open MySQL connection: %w", err)
+	}
+	return db, nil
+}
+
+func mysqlConnectionDSN(dsn string) (string, error) {
+	cfg, err := mysql.ParseDSN(dsn)
+	if err != nil {
+		return "", fmt.Errorf("parse DSN: %w", err)
+	}
+	if cfg.TLSConfig != "" || !dbconn.IsRDSHost(cfg.Addr) {
+		return dsn, nil
+	}
+	dbConfig := dbconn.NewDBConfig()
+	dbConfig.TLSMode = "REQUIRED"
+	connectionDSN, err := dbconn.EnhanceDSNWithTLS(dsn, dbConfig)
+	if err != nil {
+		return "", fmt.Errorf("enhance RDS DSN with TLS: %w", err)
+	}
+	return connectionDSN, nil
 }
 
 // namespaceForTable finds which namespace a table belongs to by checking

--- a/pkg/engine/spirit/helpers.go
+++ b/pkg/engine/spirit/helpers.go
@@ -3,7 +3,6 @@ package spirit
 import (
 	"database/sql"
 	"fmt"
-	"net"
 	"strings"
 
 	"github.com/block/spirit/pkg/dbconn"
@@ -13,8 +12,6 @@ import (
 	"github.com/block/schemabot/pkg/ddl"
 	"github.com/block/schemabot/pkg/schema"
 )
-
-var lookupCNAME = net.LookupCNAME
 
 // parseDSN extracts connection info from a MySQL DSN using the mysql driver's parser.
 func parseDSN(dsn string) (host, username, password, database string, err error) {
@@ -62,20 +59,7 @@ func mysqlTLSModeForHost(addr string) (string, bool) {
 	if dbconn.IsRDSHost(addr) {
 		return "REQUIRED", true
 	}
-
-	host, _, err := net.SplitHostPort(addr)
-	if err != nil {
-		host = addr
-	}
-	canonicalHost, err := lookupCNAME(host)
-	if err != nil {
-		return "", false
-	}
-	canonicalHost = strings.TrimSuffix(canonicalHost, ".")
-	if !dbconn.IsRDSHost(canonicalHost) {
-		return "", false
-	}
-	return "VERIFY_CA", true
+	return "", false
 }
 
 // namespaceForTable finds which namespace a table belongs to by checking

--- a/pkg/engine/spirit/helpers_test.go
+++ b/pkg/engine/spirit/helpers_test.go
@@ -64,6 +64,8 @@ func TestMySQLConnectionDSN(t *testing.T) {
 			cfg, err := mysql.ParseDSN(got)
 			require.NoError(t, err)
 			assert.Equal(t, tt.wantTLS, cfg.TLSConfig)
+			_, err = mysql.NewConnector(cfg)
+			require.NoError(t, err)
 		})
 	}
 }

--- a/pkg/engine/spirit/helpers_test.go
+++ b/pkg/engine/spirit/helpers_test.go
@@ -14,6 +14,8 @@ func TestMySQLConnectionDSN(t *testing.T) {
 	tests := []struct {
 		name       string
 		dsn        string
+		cname      string
+		cnameErr   error
 		wantTLS    string
 		wantSame   bool
 		wantErrSub string
@@ -26,6 +28,24 @@ func TestMySQLConnectionDSN(t *testing.T) {
 		{
 			name:     "non-RDS host is unchanged",
 			dsn:      "root:secret@tcp(localhost:3306)/app?parseTime=true",
+			wantSame: true,
+		},
+		{
+			name:    "CNAME resolving to RDS gets CA verification",
+			dsn:     "spirit:secret@tcp(database.example.com:3306)/app?parseTime=true",
+			cname:   "database.cluster-abc123.us-west-2.rds.amazonaws.com.",
+			wantTLS: "verify_ca",
+		},
+		{
+			name:     "CNAME resolving outside RDS is unchanged",
+			dsn:      "spirit:secret@tcp(database.example.com:3306)/app?parseTime=true",
+			cname:    "database.internal.example.com.",
+			wantSame: true,
+		},
+		{
+			name:     "CNAME lookup failure is unchanged",
+			dsn:      "spirit:secret@tcp(database.example.com:3306)/app?parseTime=true",
+			cnameErr: assert.AnError,
 			wantSame: true,
 		},
 		{
@@ -49,6 +69,12 @@ func TestMySQLConnectionDSN(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			previousLookupCNAME := lookupCNAME
+			lookupCNAME = func(string) (string, error) {
+				return tt.cname, tt.cnameErr
+			}
+			t.Cleanup(func() { lookupCNAME = previousLookupCNAME })
+
 			got, err := mysqlConnectionDSN(tt.dsn)
 			if tt.wantErrSub != "" {
 				require.Error(t, err)

--- a/pkg/engine/spirit/helpers_test.go
+++ b/pkg/engine/spirit/helpers_test.go
@@ -14,8 +14,6 @@ func TestMySQLConnectionDSN(t *testing.T) {
 	tests := []struct {
 		name       string
 		dsn        string
-		cname      string
-		cnameErr   error
 		wantTLS    string
 		wantSame   bool
 		wantErrSub string
@@ -31,21 +29,8 @@ func TestMySQLConnectionDSN(t *testing.T) {
 			wantSame: true,
 		},
 		{
-			name:    "CNAME resolving to RDS gets CA verification",
-			dsn:     "spirit:secret@tcp(database.example.com:3306)/app?parseTime=true",
-			cname:   "database.cluster-abc123.us-west-2.rds.amazonaws.com.",
-			wantTLS: "verify_ca",
-		},
-		{
-			name:     "CNAME resolving outside RDS is unchanged",
+			name:     "database alias is unchanged",
 			dsn:      "spirit:secret@tcp(database.example.com:3306)/app?parseTime=true",
-			cname:    "database.internal.example.com.",
-			wantSame: true,
-		},
-		{
-			name:     "CNAME lookup failure is unchanged",
-			dsn:      "spirit:secret@tcp(database.example.com:3306)/app?parseTime=true",
-			cnameErr: assert.AnError,
 			wantSame: true,
 		},
 		{
@@ -69,12 +54,6 @@ func TestMySQLConnectionDSN(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			previousLookupCNAME := lookupCNAME
-			lookupCNAME = func(string) (string, error) {
-				return tt.cname, tt.cnameErr
-			}
-			t.Cleanup(func() { lookupCNAME = previousLookupCNAME })
-
 			got, err := mysqlConnectionDSN(tt.dsn)
 			if tt.wantErrSub != "" {
 				require.Error(t, err)

--- a/pkg/engine/spirit/helpers_test.go
+++ b/pkg/engine/spirit/helpers_test.go
@@ -3,11 +3,70 @@ package spirit
 import (
 	"testing"
 
+	"github.com/go-sql-driver/mysql"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/block/schemabot/pkg/schema"
 )
+
+func TestMySQLConnectionDSN(t *testing.T) {
+	tests := []struct {
+		name       string
+		dsn        string
+		wantTLS    string
+		wantSame   bool
+		wantErrSub string
+	}{
+		{
+			name:    "RDS host gets TLS",
+			dsn:     "spirit:secret@tcp(database.cluster-abc123.us-west-2.rds.amazonaws.com:3306)/app?parseTime=true",
+			wantTLS: "rds",
+		},
+		{
+			name:     "non-RDS host is unchanged",
+			dsn:      "root:secret@tcp(localhost:3306)/app?parseTime=true",
+			wantSame: true,
+		},
+		{
+			name:     "explicit TLS is preserved",
+			dsn:      "spirit:secret@tcp(database.cluster-abc123.us-west-2.rds.amazonaws.com:3306)/app?tls=skip-verify",
+			wantTLS:  "skip-verify",
+			wantSame: true,
+		},
+		{
+			name:     "explicit disabled TLS is preserved",
+			dsn:      "spirit:secret@tcp(database.cluster-abc123.us-west-2.rds.amazonaws.com:3306)/app?tls=false",
+			wantTLS:  "false",
+			wantSame: true,
+		},
+		{
+			name:       "invalid DSN returns context",
+			dsn:        "not-a-dsn",
+			wantErrSub: "parse DSN",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := mysqlConnectionDSN(tt.dsn)
+			if tt.wantErrSub != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErrSub)
+				return
+			}
+
+			require.NoError(t, err)
+			if tt.wantSame {
+				assert.Equal(t, tt.dsn, got)
+			}
+
+			cfg, err := mysql.ParseDSN(got)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantTLS, cfg.TLSConfig)
+		})
+	}
+}
 
 func TestNamespaceForTable(t *testing.T) {
 	sf := schema.SchemaFiles{

--- a/pkg/engine/spirit/spirit.go
+++ b/pkg/engine/spirit/spirit.go
@@ -14,7 +14,6 @@ package spirit
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -541,7 +540,7 @@ func (e *Engine) Progress(ctx context.Context, req *engine.ProgressRequest) (*en
 // fetchCurrentSchema retrieves table schemas from the database, filtering out
 // internal tables (Spirit shadow/checkpoint tables and other _-prefixed tables).
 func (e *Engine) fetchCurrentSchema(ctx context.Context, dsn, _ string) ([]table.TableSchema, error) {
-	db, err := sql.Open("mysql", dsn)
+	db, err := openMySQL(dsn)
 	if err != nil {
 		return nil, fmt.Errorf("open database: %w", err)
 	}


### PR DESCRIPTION
## Why
Spirit direct MySQL connections should use TLS automatically when connecting to RDS endpoints that require encrypted connections.

## What
- Normalize Spirit MySQL DSNs through one helper before opening direct connections
- Add RDS TLS enhancement when no explicit TLS mode is already configured
- Preserve existing behavior for non-RDS hosts and DSNs with explicit TLS settings

```text
Input DSN
   │
   ▼
Has explicit tls=? ── yes ──▶ unchanged
   │ no
   ▼
Host is RDS? ─────── yes ──▶ tls=rds
   │ no
   ▼
unchanged
```

## Risk Assessment
Low — this is scoped to Spirit direct MySQL connection setup and preserves caller-provided TLS configuration.

Generated with Amp
