### PR TITLE
feat(api): run pending drops cleanup from server

### DIFF
--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -10,7 +10,9 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 
+	"github.com/block/schemabot/pkg/pendingdrops"
 	"github.com/block/schemabot/pkg/secrets"
 	"github.com/block/schemabot/pkg/storage"
 	gomysql "github.com/go-sql-driver/mysql"
@@ -130,6 +132,66 @@ type ServerConfig struct {
 	//
 	// Defaults to true (respond to all commands).
 	RespondToUnscoped *bool `yaml:"respond_to_unscoped"`
+
+	// PendingDrops configures the pending drops quarantine for MySQL/Spirit
+	// databases. When enabled (the default), DROP TABLE statements rename the
+	// table into the _pending_drops database instead of dropping it. The
+	// background cleaner can be run by this process or disabled so another
+	// deployment owns permanent cleanup after the retention period.
+	PendingDrops PendingDropsConfig `yaml:"pending_drops,omitempty"`
+}
+
+// PendingDropsConfig configures the pending drops quarantine for MySQL/Spirit
+// databases.
+type PendingDropsConfig struct {
+	// Enabled controls the quarantine.
+	// Defaults to true when not configured (nil = enabled).
+	Enabled *bool `yaml:"enabled"`
+
+	// CleanupEnabled controls whether this server process starts the background
+	// cleaner. Defaults to true when the quarantine is enabled. Set this to false
+	// on frequently redeployed executors when another deployment owns cleanup.
+	CleanupEnabled *bool `yaml:"cleanup_enabled"`
+
+	// Retention is how long quarantined tables are kept before the cleaner
+	// drops them permanently, as a Go duration string (e.g. "168h").
+	// Defaults to 7 days.
+	Retention string `yaml:"retention,omitempty"`
+
+	// DryRun makes the cleaner log the tables it would drop without dropping
+	// them. The quarantine itself is unaffected.
+	DryRun bool `yaml:"dry_run,omitempty"`
+}
+
+// PendingDropsEnabled reports whether the pending drops quarantine is enabled.
+// Defaults to true when not configured.
+func (c *ServerConfig) PendingDropsEnabled() bool {
+	return c.PendingDrops.Enabled == nil || *c.PendingDrops.Enabled
+}
+
+// PendingDropsCleanupEnabled reports whether this process should run the
+// pending drops cleaner. The cleaner never runs when the quarantine is disabled.
+func (c *ServerConfig) PendingDropsCleanupEnabled() bool {
+	if !c.PendingDropsEnabled() {
+		return false
+	}
+	return c.PendingDrops.CleanupEnabled == nil || *c.PendingDrops.CleanupEnabled
+}
+
+// PendingDropsRetention returns the configured retention for quarantined
+// tables, falling back to the default when not configured.
+func (c *ServerConfig) PendingDropsRetention() (time.Duration, error) {
+	if c.PendingDrops.Retention == "" {
+		return pendingdrops.DefaultRetention, nil
+	}
+	d, err := time.ParseDuration(c.PendingDrops.Retention)
+	if err != nil {
+		return 0, fmt.Errorf("parse pending_drops.retention %q: %w", c.PendingDrops.Retention, err)
+	}
+	if d <= 0 {
+		return 0, fmt.Errorf("pending_drops.retention must be positive, got %q", c.PendingDrops.Retention)
+	}
+	return d, nil
 }
 
 // GitHubConfig configures the GitHub App used for webhook-driven schema changes.
@@ -507,6 +569,11 @@ func (c *ServerConfig) Validate() error {
 	}
 	if err := c.validateGitHubAppsConfig(); err != nil {
 		return err
+	}
+	if c.PendingDropsEnabled() {
+		if _, err := c.PendingDropsRetention(); err != nil {
+			return err
+		}
 	}
 
 	// Validate Databases if present. An environment is either local mode

--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -3,15 +3,19 @@ package api
 import (
 	"bytes"
 	"errors"
+	"io"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	gomysql "github.com/go-sql-driver/mysql"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 
+	"github.com/block/schemabot/pkg/pendingdrops"
 	"github.com/block/schemabot/pkg/storage"
 )
 
@@ -2494,4 +2498,115 @@ repos:
 	require.Contains(t, cfg.Apps, "app-b")
 	assert.Equal(t, "app-a", cfg.Repos["org-a/repo-x"].GitHubApp)
 	assert.Equal(t, "app-b", cfg.Repos["org-b/repo-y"].GitHubApp)
+}
+
+func TestPendingDropsConfig(t *testing.T) {
+	boolPtr := func(b bool) *bool { return &b }
+
+	t.Run("enabled by default", func(t *testing.T) {
+		cfg := ServerConfig{}
+		assert.True(t, cfg.PendingDropsEnabled())
+	})
+
+	t.Run("explicit disable", func(t *testing.T) {
+		cfg := ServerConfig{PendingDrops: PendingDropsConfig{Enabled: boolPtr(false)}}
+		assert.False(t, cfg.PendingDropsEnabled())
+		assert.False(t, cfg.PendingDropsCleanupEnabled())
+	})
+
+	t.Run("cleanup enabled by default", func(t *testing.T) {
+		cfg := ServerConfig{}
+		assert.True(t, cfg.PendingDropsCleanupEnabled())
+	})
+
+	t.Run("cleanup can be disabled without disabling quarantine", func(t *testing.T) {
+		cfg := ServerConfig{PendingDrops: PendingDropsConfig{CleanupEnabled: boolPtr(false)}}
+		assert.True(t, cfg.PendingDropsEnabled())
+		assert.False(t, cfg.PendingDropsCleanupEnabled())
+	})
+
+	t.Run("default retention", func(t *testing.T) {
+		cfg := ServerConfig{}
+		retention, err := cfg.PendingDropsRetention()
+		require.NoError(t, err)
+		assert.Equal(t, pendingdrops.DefaultRetention, retention)
+	})
+
+	t.Run("custom retention", func(t *testing.T) {
+		cfg := ServerConfig{PendingDrops: PendingDropsConfig{Retention: "48h"}}
+		retention, err := cfg.PendingDropsRetention()
+		require.NoError(t, err)
+		assert.Equal(t, 48*time.Hour, retention)
+	})
+
+	t.Run("invalid retention rejected", func(t *testing.T) {
+		cfg := ServerConfig{PendingDrops: PendingDropsConfig{Retention: "soon"}}
+		_, err := cfg.PendingDropsRetention()
+		assert.ErrorContains(t, err, "pending_drops.retention")
+	})
+
+	t.Run("non-positive retention rejected", func(t *testing.T) {
+		cfg := ServerConfig{PendingDrops: PendingDropsConfig{Retention: "-1h"}}
+		_, err := cfg.PendingDropsRetention()
+		assert.ErrorContains(t, err, "must be positive")
+	})
+
+	t.Run("validate rejects invalid retention", func(t *testing.T) {
+		cfg := ServerConfig{
+			Databases: map[string]DatabaseConfig{
+				"mydb": {
+					Type: "mysql",
+					Environments: map[string]EnvironmentConfig{
+						"staging": {DSN: "root:pass@tcp(localhost:3306)/mydb"},
+					},
+				},
+			},
+			PendingDrops: PendingDropsConfig{Retention: "not-a-duration"},
+		}
+		err := cfg.Validate()
+		assert.ErrorContains(t, err, "pending_drops.retention")
+	})
+
+	t.Run("validate ignores invalid retention when pending drops disabled", func(t *testing.T) {
+		cfg := ServerConfig{
+			Databases: map[string]DatabaseConfig{
+				"mydb": {
+					Type: "mysql",
+					Environments: map[string]EnvironmentConfig{
+						"staging": {DSN: "root:pass@tcp(localhost:3306)/mydb"},
+					},
+				},
+			},
+			PendingDrops: PendingDropsConfig{Enabled: boolPtr(false), Retention: "not-a-duration"},
+		}
+		assert.NoError(t, cfg.Validate())
+	})
+}
+
+func TestPendingDropsTargetsResolveEachPass(t *testing.T) {
+	dsnPath := filepath.Join(t.TempDir(), "target.dsn")
+	cfg := &ServerConfig{
+		Databases: map[string]DatabaseConfig{
+			"mydb": {
+				Type: storage.DatabaseTypeMySQL,
+				Environments: map[string]EnvironmentConfig{
+					"staging": {DSN: "file:" + dsnPath},
+				},
+			},
+		},
+	}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	svc := New(nil, cfg, nil, logger)
+
+	targets, unresolved := svc.pendingDropsTargets(t.Context())
+	assert.Empty(t, targets)
+	assert.Equal(t, 1, unresolved)
+
+	dsn := "root:testpassword@tcp(127.0.0.1:3306)/testdb?timeout=1s"
+	require.NoError(t, os.WriteFile(dsnPath, []byte(dsn), 0o600))
+
+	targets, unresolved = svc.pendingDropsTargets(t.Context())
+	require.Len(t, targets, 1)
+	assert.Equal(t, 0, unresolved)
+	assert.Equal(t, pendingdrops.Target{Database: "mydb", Environment: "staging", DSN: dsn}, targets[0])
 }

--- a/pkg/api/pending_drops_cleaner.go
+++ b/pkg/api/pending_drops_cleaner.go
@@ -1,0 +1,170 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/block/schemabot/pkg/metrics"
+	"github.com/block/schemabot/pkg/pendingdrops"
+	"github.com/block/schemabot/pkg/storage"
+)
+
+// PendingDropsCleanupInterval is how often the pending drops cleaner runs a
+// cleanup pass. Quarantined tables are retained for days, so a coarse interval
+// is sufficient; the per-target advisory lock keeps concurrent instances from
+// duplicating work.
+const PendingDropsCleanupInterval = 6 * time.Hour
+
+// StartPendingDropsCleaner starts the background loop that permanently drops
+// expired quarantined tables from local-mode MySQL databases. It does not
+// start when cleanup is disabled for this process or when no local MySQL
+// targets are configured (gRPC-mode targets are cleaned by the deployment that
+// executes the schema changes).
+func (s *Service) StartPendingDropsCleaner(ctx context.Context) {
+	if !s.config.PendingDropsCleanupEnabled() {
+		s.logger.Info("pending drops cleaner not started because cleanup is disabled for this process")
+		return
+	}
+
+	retention, err := s.config.PendingDropsRetention()
+	if err != nil {
+		// Validate() rejects invalid retention before the server starts, so
+		// this guards direct embedders that skip config validation.
+		s.logger.Error("pending drops cleaner not started because retention is invalid; quarantined tables will accumulate until the config is fixed", "error", err)
+		return
+	}
+
+	if !s.hasPendingDropsLocalTargets() {
+		s.logger.Info("pending drops cleaner not started because no local MySQL database targets are configured")
+		return
+	}
+
+	s.pendingDropsMu.Lock()
+	if s.pendingDropsCancel != nil {
+		s.pendingDropsMu.Unlock()
+		s.logger.Info("pending drops cleaner already running")
+		return
+	}
+	cleanerCtx, cancel := context.WithCancel(ctx)
+	s.pendingDropsCancel = cancel
+	s.pendingDropsMu.Unlock()
+
+	s.pendingDropsWg.Go(func() {
+		s.pendingDropsCleanerLoop(cleanerCtx, retention, s.config.PendingDrops.DryRun)
+	})
+	s.logger.Info("pending drops cleaner started",
+		"retention", retention,
+		"dry_run", s.config.PendingDrops.DryRun,
+		"interval", PendingDropsCleanupInterval,
+	)
+}
+
+// StopPendingDropsCleaner stops the background pending drops cleaner.
+// Safe to call multiple times.
+func (s *Service) StopPendingDropsCleaner() {
+	s.pendingDropsMu.Lock()
+	cancel := s.pendingDropsCancel
+	if cancel == nil {
+		s.pendingDropsMu.Unlock()
+		return
+	}
+	s.pendingDropsCancel = nil
+	s.pendingDropsMu.Unlock()
+
+	cancel()
+	s.pendingDropsWg.Wait()
+	s.logger.Info("pending drops cleaner stopped")
+}
+
+func (s *Service) pendingDropsCleanerLoop(ctx context.Context, retention time.Duration, dryRun bool) {
+	ticker := time.NewTicker(PendingDropsCleanupInterval)
+	defer ticker.Stop()
+
+	if err := s.runPendingDropsCleanupPass(ctx, retention, dryRun); err != nil {
+		s.logger.Error("pending drops cleanup pass was incomplete; failed targets retry on the next pass", "error", err)
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			s.logger.Debug("pending drops cleaner stopping", "error", ctx.Err())
+			return
+		case <-ticker.C:
+			if err := s.runPendingDropsCleanupPass(ctx, retention, dryRun); err != nil {
+				s.logger.Error("pending drops cleanup pass was incomplete; failed targets retry on the next pass", "error", err)
+			}
+		}
+	}
+}
+
+func (s *Service) runPendingDropsCleanupPass(ctx context.Context, retention time.Duration, dryRun bool) error {
+	targets, unresolved := s.pendingDropsTargets(ctx)
+	if len(targets) == 0 {
+		if unresolved > 0 {
+			return fmt.Errorf("resolve pending drops cleanup targets: %d local MySQL target(s) could not resolve DSN", unresolved)
+		}
+		s.logger.Warn("pending drops cleanup pass found no resolved local MySQL targets; targets with unresolved DSNs will retry on the next pass")
+		return nil
+	}
+	cleaner := pendingdrops.NewCleaner(targets, retention, dryRun, s.logger)
+	if err := cleaner.Run(ctx); err != nil {
+		if unresolved > 0 {
+			return fmt.Errorf("clean resolved pending drops targets; %d local MySQL target(s) could not resolve DSN: %w", unresolved, err)
+		}
+		return err
+	}
+	if unresolved > 0 {
+		return fmt.Errorf("resolve pending drops cleanup targets: %d local MySQL target(s) could not resolve DSN", unresolved)
+	}
+	return nil
+}
+
+func (s *Service) hasPendingDropsLocalTargets() bool {
+	for _, dbConfig := range s.config.Databases {
+		if dbConfig.Type != storage.DatabaseTypeMySQL {
+			continue
+		}
+		for _, envConfig := range dbConfig.Environments {
+			if envConfig.HasLocalDSN() {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// pendingDropsTargets resolves the local-mode MySQL databases the cleaner
+// inspects. Databases without a local DSN are executed by a remote deployment,
+// which owns quarantine cleanup for its own targets.
+func (s *Service) pendingDropsTargets(ctx context.Context) ([]pendingdrops.Target, int) {
+	var targets []pendingdrops.Target
+	var unresolved int
+	for dbName, dbConfig := range s.config.Databases {
+		if dbConfig.Type != storage.DatabaseTypeMySQL {
+			continue
+		}
+		for envName, envConfig := range dbConfig.Environments {
+			if !envConfig.HasLocalDSN() {
+				continue
+			}
+			dsn, err := envConfig.ResolveDSN()
+			if err != nil {
+				unresolved++
+				s.logger.Error("pending drops cleaner skipping target because its DSN could not be resolved; quarantined tables on this target will not be cleaned",
+					"database", dbName,
+					"environment", envName,
+					"error", err,
+				)
+				metrics.RecordPendingDropsCleanupError(ctx, dbName, envName, "dsn_resolution_error")
+				continue
+			}
+			targets = append(targets, pendingdrops.Target{
+				Database:    dbName,
+				Environment: envName,
+				DSN:         dsn,
+			})
+		}
+	}
+	return targets, unresolved
+}

--- a/pkg/api/pending_drops_cleaner_integration_test.go
+++ b/pkg/api/pending_drops_cleaner_integration_test.go
@@ -1,0 +1,84 @@
+//go:build integration
+
+package api
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/block/spirit/pkg/utils"
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/modules/mysql"
+
+	"github.com/block/schemabot/pkg/pendingdrops"
+	"github.com/block/schemabot/pkg/storage"
+	"github.com/block/schemabot/pkg/testutil"
+)
+
+// The service-level pending drops cleaner starts a scheduled background loop
+// and runs an immediate cleanup pass, so expired quarantined tables are dropped
+// without waiting for the next interval.
+func TestStartPendingDropsCleanerDropsExpiredTable(t *testing.T) {
+	ctx := t.Context()
+
+	container, err := mysql.Run(ctx,
+		"mysql:8.0",
+		mysql.WithDatabase("schemabot_test"),
+		mysql.WithUsername("root"),
+		mysql.WithPassword("test"),
+	)
+	require.NoError(t, err, "start mysql")
+	t.Cleanup(func() {
+		if err := testcontainers.TerminateContainer(container); err != nil {
+			t.Logf("terminate mysql container: %v", err)
+		}
+	})
+
+	dsn, err := testutil.ContainerConnectionString(ctx, container, "parseTime=true")
+	require.NoError(t, err, "container connection string")
+
+	db, err := sql.Open("mysql", dsn)
+	require.NoError(t, err, "open mysql")
+	defer utils.CloseAndLog(db)
+	require.NoError(t, db.PingContext(ctx), "ping mysql")
+
+	expired := pendingdrops.TableName("schemabot_test", "scheduled_drop", time.Now().Add(-48*time.Hour))
+	_, err = db.ExecContext(ctx, fmt.Sprintf("CREATE DATABASE IF NOT EXISTS `%s`", pendingdrops.Database))
+	require.NoError(t, err, "create pending drops database")
+	_, err = db.ExecContext(ctx, fmt.Sprintf("CREATE TABLE `%s`.`%s` (id INT PRIMARY KEY)", pendingdrops.Database, expired))
+	require.NoError(t, err, "create expired quarantined table")
+
+	svc := New(nil, &ServerConfig{
+		Databases: map[string]DatabaseConfig{
+			"schemabot_test": {
+				Type: storage.DatabaseTypeMySQL,
+				Environments: map[string]EnvironmentConfig{
+					"staging": {DSN: dsn},
+				},
+			},
+		},
+		PendingDrops: PendingDropsConfig{Retention: "24h"},
+	}, nil, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	cleanerCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	svc.StartPendingDropsCleaner(cleanerCtx)
+	t.Cleanup(svc.StopPendingDropsCleaner)
+
+	require.Eventually(t, func() bool {
+		var count int
+		err := db.QueryRowContext(t.Context(),
+			"SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = ? AND table_name = ?",
+			pendingdrops.Database, expired,
+		).Scan(&count)
+		require.NoError(t, err, "query expired quarantined table")
+		return count == 0
+	}, 10*time.Second, 100*time.Millisecond, "scheduled cleaner should drop expired quarantined table")
+}

--- a/pkg/api/service.go
+++ b/pkg/api/service.go
@@ -124,6 +124,11 @@ type Service struct {
 	remoteHealthWg       sync.WaitGroup
 	remoteHealthInterval time.Duration
 
+	// Pending drops cleaner loop management.
+	pendingDropsMu     sync.Mutex
+	pendingDropsCancel context.CancelFunc
+	pendingDropsWg     sync.WaitGroup
+
 	// OnApplyRecovered is called after the operator claims an apply and before
 	// ResumeApply starts the engine/poller. Set by the webhook handler to attach
 	// an observer for PR comments.
@@ -371,6 +376,9 @@ func (s *Service) newLocalTernClient(key, database, dbType string, envConfig Env
 	}
 	if envConfig.APIURL != "" {
 		metadata["api_url"] = envConfig.APIURL
+	}
+	if !s.config.PendingDropsEnabled() {
+		metadata["pending_drops"] = "false"
 	}
 	client, err := tern.NewLocalClient(tern.LocalConfig{
 		Database:  database,

--- a/pkg/cmd/commands/serve.go
+++ b/pkg/cmd/commands/serve.go
@@ -185,6 +185,11 @@ func (cmd *ServeCmd) Run(g *Globals) error {
 	svc.StartRemoteDeploymentHealthMonitor(ctx)
 	defer svc.StopRemoteDeploymentHealthMonitor()
 
+	// Permanently drop expired quarantined tables from local-mode MySQL
+	// databases once their pending drops retention period has passed.
+	svc.StartPendingDropsCleaner(ctx)
+	defer svc.StopPendingDropsCleaner()
+
 	// Configure routes
 	mux := http.NewServeMux()
 	svc.ConfigureRoutes(mux)
@@ -261,10 +266,15 @@ func startGRPCServer(ctx context.Context, config *api.ServerConfig, st *mysqlsto
 		if err != nil {
 			return nil, fmt.Errorf("resolve DSN for %s/%s: %w", dbName, env, err)
 		}
+		var metadata map[string]string
+		if !config.PendingDropsEnabled() {
+			metadata = map[string]string{"pending_drops": "false"}
+		}
 		localClient, err = tern.NewLocalClient(tern.LocalConfig{
 			Database:  dbName,
 			Type:      dbConfig.Type,
 			TargetDSN: targetDSN,
+			Metadata:  metadata,
 		}, st, logger)
 		if err != nil {
 			return nil, fmt.Errorf("create local client for %s: %w", dbName, err)

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1120,3 +1120,88 @@ func RecordPendingDropMoved(ctx context.Context, database string) {
 		),
 	)
 }
+
+// RecordPendingDropsCleanupDropped increments the counter for expired
+// quarantined tables permanently dropped by the pending drops cleaner.
+func RecordPendingDropsCleanupDropped(ctx context.Context, database, environment string) {
+	meter := otel.Meter(meterName)
+	counter, err := meter.Int64Counter("schemabot.pending_drops.cleanup_dropped_total",
+		otelmetric.WithDescription("Total number of expired quarantined tables dropped by the pending drops cleaner"),
+		otelmetric.WithUnit("{table}"),
+	)
+	if err != nil {
+		slog.Warn("failed to create pending drops cleanup dropped counter", "error", err)
+		return
+	}
+	counter.Add(ctx, 1,
+		otelmetric.WithAttributes(
+			attribute.String("database", database),
+			EnvironmentAttribute(environment),
+		),
+	)
+}
+
+// RecordPendingDropsCleanupSkipped increments the counter for quarantined
+// tables the cleaner skipped because their names carry no valid timestamp
+// prefix. A sustained nonzero rate means tables are accumulating that an
+// operator must inspect and remove manually.
+func RecordPendingDropsCleanupSkipped(ctx context.Context, database, environment string) {
+	meter := otel.Meter(meterName)
+	counter, err := meter.Int64Counter("schemabot.pending_drops.cleanup_skipped_total",
+		otelmetric.WithDescription("Total number of quarantined tables skipped by the cleaner due to unparseable names"),
+		otelmetric.WithUnit("{table}"),
+	)
+	if err != nil {
+		slog.Warn("failed to create pending drops cleanup skipped counter", "error", err)
+		return
+	}
+	counter.Add(ctx, 1,
+		otelmetric.WithAttributes(
+			attribute.String("database", database),
+			EnvironmentAttribute(environment),
+		),
+	)
+}
+
+// RecordPendingDropsCleanupLockSkipped increments the counter for cleanup
+// passes skipped because another SchemaBot instance owns the per-target
+// advisory lock.
+func RecordPendingDropsCleanupLockSkipped(ctx context.Context, database, environment string) {
+	meter := otel.Meter(meterName)
+	counter, err := meter.Int64Counter("schemabot.pending_drops.cleanup_lock_skipped_total",
+		otelmetric.WithDescription("Total number of pending drops cleanup target passes skipped because another instance held the cleanup lock"),
+		otelmetric.WithUnit("{pass}"),
+	)
+	if err != nil {
+		slog.Warn("failed to create pending drops cleanup lock skipped counter", "error", err)
+		return
+	}
+	counter.Add(ctx, 1,
+		otelmetric.WithAttributes(
+			attribute.String("database", database),
+			EnvironmentAttribute(environment),
+		),
+	)
+}
+
+// RecordPendingDropsCleanupError increments the counter for pending drops
+// cleanup failures. Failed targets and tables are retried on the next cleanup
+// pass.
+func RecordPendingDropsCleanupError(ctx context.Context, database, environment, reason string) {
+	meter := otel.Meter(meterName)
+	counter, err := meter.Int64Counter("schemabot.pending_drops.cleanup_errors_total",
+		otelmetric.WithDescription("Total number of pending drops cleanup failures"),
+		otelmetric.WithUnit("{error}"),
+	)
+	if err != nil {
+		slog.Warn("failed to create pending drops cleanup errors counter", "error", err)
+		return
+	}
+	counter.Add(ctx, 1,
+		otelmetric.WithAttributes(
+			attribute.String("database", database),
+			EnvironmentAttribute(environment),
+			attribute.String("reason", reason),
+		),
+	)
+}

--- a/pkg/pendingdrops/cleaner.go
+++ b/pkg/pendingdrops/cleaner.go
@@ -1,0 +1,265 @@
+package pendingdrops
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/block/spirit/pkg/utils"
+
+	"github.com/block/schemabot/pkg/metrics"
+)
+
+const (
+	lockNamePrefix = "schemabot_pending_drops_"
+	lockHashLen    = 16
+)
+
+// Target is one database the cleaner inspects. The DSN must be resolved
+// (no secret references) and reachable from this process.
+type Target struct {
+	// Database is the SchemaBot database name, used for logs and metrics.
+	Database string
+
+	// Environment is the SchemaBot environment name, used for logs and metrics.
+	Environment string
+
+	// DSN is the resolved MySQL connection string for the target.
+	DSN string
+}
+
+// Cleaner permanently drops quarantined tables from _pending_drops once they
+// are older than the retention period. Tables whose names do not carry a
+// valid timestamp prefix are never dropped because their age is unknown.
+type Cleaner struct {
+	targets   []Target
+	retention time.Duration
+	dryRun    bool
+	logger    *slog.Logger
+
+	// nowFunc is overridable for testing.
+	nowFunc func() time.Time
+}
+
+// NewCleaner creates a Cleaner for the given targets. When dryRun is true,
+// the cleaner logs the tables it would drop without dropping them.
+func NewCleaner(targets []Target, retention time.Duration, dryRun bool, logger *slog.Logger) *Cleaner {
+	if retention <= 0 {
+		retention = DefaultRetention
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Cleaner{
+		targets:   targets,
+		retention: retention,
+		dryRun:    dryRun,
+		logger:    logger,
+		nowFunc:   time.Now,
+	}
+}
+
+// Run performs one cleanup pass over every target. Targets are independent:
+// a failure on one target is logged and counted, and the pass continues with
+// the remaining targets. The last error is returned so callers can surface
+// that the pass was incomplete.
+func (c *Cleaner) Run(ctx context.Context) error {
+	var lastErr error
+	for _, target := range c.targets {
+		if err := c.cleanTarget(ctx, target); err != nil {
+			c.logger.Error("pending drops cleanup failed for target; continuing with remaining targets",
+				"database", target.Database,
+				"environment", target.Environment,
+				"error", err,
+			)
+			lastErr = err
+		}
+	}
+	return lastErr
+}
+
+// cleanTarget connects to one target, serializes against other SchemaBot
+// instances with an advisory lock, and drops expired quarantined tables.
+func (c *Cleaner) cleanTarget(ctx context.Context, target Target) error {
+	db, err := sql.Open("mysql", target.DSN)
+	if err != nil {
+		metrics.RecordPendingDropsCleanupError(ctx, target.Database, target.Environment, "target_error")
+		return fmt.Errorf("open target %s/%s: %w", target.Database, target.Environment, err)
+	}
+	defer utils.CloseAndLog(db)
+
+	if err := db.PingContext(ctx); err != nil {
+		metrics.RecordPendingDropsCleanupError(ctx, target.Database, target.Environment, "target_error")
+		return fmt.Errorf("ping target %s/%s: %w", target.Database, target.Environment, err)
+	}
+
+	// GET_LOCK is session-scoped, so hold one connection for the whole pass.
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		metrics.RecordPendingDropsCleanupError(ctx, target.Database, target.Environment, "target_error")
+		return fmt.Errorf("acquire connection for %s/%s: %w", target.Database, target.Environment, err)
+	}
+	defer utils.CloseAndLog(conn)
+
+	lockName := targetLockName(target)
+	var locked int
+	if err := conn.QueryRowContext(ctx, "SELECT GET_LOCK(?, 0)", lockName).Scan(&locked); err != nil {
+		metrics.RecordPendingDropsCleanupError(ctx, target.Database, target.Environment, "target_error")
+		return fmt.Errorf("acquire advisory lock on %s/%s: %w", target.Database, target.Environment, err)
+	}
+	if locked != 1 {
+		c.logger.Info("pending drops cleanup skipped: another instance holds the cleanup lock",
+			"database", target.Database,
+			"environment", target.Environment,
+			"lock_name", lockName,
+		)
+		metrics.RecordPendingDropsCleanupLockSkipped(ctx, target.Database, target.Environment)
+		return nil
+	}
+	defer func() {
+		if _, err := conn.ExecContext(context.WithoutCancel(ctx), "SELECT RELEASE_LOCK(?)", lockName); err != nil {
+			c.logger.Warn("failed to release pending drops cleanup lock; the lock releases when the session closes",
+				"database", target.Database,
+				"environment", target.Environment,
+				"lock_name", lockName,
+				"error", err,
+			)
+		}
+	}()
+
+	exists, err := pendingDropsDatabaseExists(ctx, conn)
+	if err != nil {
+		metrics.RecordPendingDropsCleanupError(ctx, target.Database, target.Environment, "target_error")
+		return fmt.Errorf("check %s database on %s/%s: %w", Database, target.Database, target.Environment, err)
+	}
+	if !exists {
+		c.logger.Debug("pending drops cleanup: no quarantine database on target, nothing to clean",
+			"database", target.Database,
+			"environment", target.Environment,
+		)
+		return nil
+	}
+
+	tables, err := listPendingDropTables(ctx, conn)
+	if err != nil {
+		metrics.RecordPendingDropsCleanupError(ctx, target.Database, target.Environment, "target_error")
+		return fmt.Errorf("list %s tables on %s/%s: %w", Database, target.Database, target.Environment, err)
+	}
+
+	now := c.nowFunc()
+	cutoff := now.Add(-c.retention)
+	var dropped, wouldDrop, kept, skipped int
+	var dropErr error
+
+	for _, tableName := range tables {
+		quarantinedAt, ok := ParseTimestamp(tableName)
+		if !ok {
+			c.logger.Warn("pending drops cleanup: table name has no valid timestamp prefix, table will never be auto-dropped",
+				"database", target.Database,
+				"environment", target.Environment,
+				"table", tableName,
+			)
+			metrics.RecordPendingDropsCleanupSkipped(ctx, target.Database, target.Environment)
+			skipped++
+			continue
+		}
+		if !quarantinedAt.Before(cutoff) {
+			kept++
+			continue
+		}
+
+		age := now.Sub(quarantinedAt).Round(time.Hour)
+		if c.dryRun {
+			c.logger.Info("pending drops cleanup dry run: table would be dropped",
+				"database", target.Database,
+				"environment", target.Environment,
+				"table", tableName,
+				"age", age,
+			)
+			wouldDrop++
+			continue
+		}
+
+		dropSQL := fmt.Sprintf("DROP TABLE IF EXISTS %s.%s", quoteIdentifier(Database), quoteIdentifier(tableName))
+		if _, err := conn.ExecContext(ctx, dropSQL); err != nil {
+			c.logger.Error("pending drops cleanup: drop failed, table remains quarantined until the next pass",
+				"database", target.Database,
+				"environment", target.Environment,
+				"table", tableName,
+				"error", err,
+			)
+			metrics.RecordPendingDropsCleanupError(ctx, target.Database, target.Environment, "drop_error")
+			dropErr = err
+			continue
+		}
+		c.logger.Info("pending drops cleanup: dropped expired quarantined table",
+			"database", target.Database,
+			"environment", target.Environment,
+			"table", tableName,
+			"age", age,
+		)
+		metrics.RecordPendingDropsCleanupDropped(ctx, target.Database, target.Environment)
+		dropped++
+	}
+
+	attrs := []any{
+		"database", target.Database,
+		"environment", target.Environment,
+		"dry_run", c.dryRun,
+		"kept", kept,
+		"skipped_unparseable", skipped,
+	}
+	if c.dryRun {
+		attrs = append(attrs, "would_drop", wouldDrop)
+	} else {
+		attrs = append(attrs, "dropped", dropped)
+	}
+	c.logger.Info("pending drops cleanup pass complete", attrs...)
+	if dropErr != nil {
+		return fmt.Errorf("drop expired pending drops tables on %s/%s: %w", target.Database, target.Environment, dropErr)
+	}
+	return nil
+}
+
+func targetLockName(target Target) string {
+	sum := sha256.Sum256([]byte(target.Database + "\x00" + target.Environment))
+	return lockNamePrefix + hex.EncodeToString(sum[:])[:lockHashLen]
+}
+
+func pendingDropsDatabaseExists(ctx context.Context, conn *sql.Conn) (bool, error) {
+	var count int
+	err := conn.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM information_schema.schemata WHERE schema_name = ?",
+		Database).Scan(&count)
+	if err != nil {
+		return false, fmt.Errorf("query information_schema.schemata: %w", err)
+	}
+	return count > 0, nil
+}
+
+func listPendingDropTables(ctx context.Context, conn *sql.Conn) ([]string, error) {
+	rows, err := conn.QueryContext(ctx,
+		"SELECT table_name FROM information_schema.tables WHERE table_schema = ?",
+		Database)
+	if err != nil {
+		return nil, fmt.Errorf("query information_schema.tables: %w", err)
+	}
+	defer utils.CloseAndLog(rows)
+
+	var tables []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, fmt.Errorf("scan table name: %w", err)
+		}
+		tables = append(tables, name)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate table names: %w", err)
+	}
+	return tables, nil
+}

--- a/pkg/pendingdrops/cleaner_integration_test.go
+++ b/pkg/pendingdrops/cleaner_integration_test.go
@@ -1,0 +1,263 @@
+//go:build integration
+
+package pendingdrops
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/block/spirit/pkg/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+
+	"github.com/block/schemabot/pkg/testutil"
+
+	_ "github.com/go-sql-driver/mysql"
+)
+
+var sharedDSN string
+
+func TestMain(m *testing.M) {
+	ctx := context.Background()
+
+	req := testcontainers.ContainerRequest{
+		Image:        "mysql:8.0",
+		ExposedPorts: []string{"3306/tcp"},
+		Env: map[string]string{
+			"MYSQL_ROOT_PASSWORD": "testpassword",
+			"MYSQL_DATABASE":      "testdb",
+		},
+		WaitingFor: wait.ForAll(
+			wait.ForLog("ready for connections").WithOccurrence(2).WithStartupTimeout(30*time.Second),
+			wait.ForListeningPort("3306/tcp"),
+		),
+	}
+
+	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: req,
+		Started:          true,
+	})
+	if err != nil {
+		log.Fatalf("start mysql container: %v", err)
+	}
+
+	host, err := testutil.ContainerHost(ctx, container)
+	if err != nil {
+		log.Fatalf("get container host: %v", err)
+	}
+	port, err := testutil.ContainerPort(ctx, container, "3306")
+	if err != nil {
+		log.Fatalf("get container port: %v", err)
+	}
+	sharedDSN = fmt.Sprintf("root:testpassword@tcp(%s:%d)/testdb?parseTime=true", host, port)
+
+	var db *sql.DB
+	for range 30 {
+		db, err = sql.Open("mysql", sharedDSN)
+		if err != nil {
+			time.Sleep(500 * time.Millisecond)
+			continue
+		}
+		if err = db.PingContext(ctx); err == nil {
+			if err := db.Close(); err != nil {
+				log.Fatalf("close mysql readiness connection: %v", err)
+			}
+			break
+		}
+		if closeErr := db.Close(); closeErr != nil {
+			log.Printf("close mysql readiness connection: %v", closeErr)
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	if err != nil {
+		log.Fatalf("connect to mysql: %v", err)
+	}
+
+	code := m.Run()
+
+	if err := container.Terminate(ctx); err != nil {
+		log.Printf("terminate mysql container: %v", err)
+	}
+	os.Exit(code)
+}
+
+func setupCleanerTest(t *testing.T) *sql.DB {
+	t.Helper()
+
+	db, err := sql.Open("mysql", sharedDSN)
+	require.NoError(t, err, "connect to mysql")
+	t.Cleanup(func() { utils.CloseAndLog(db) })
+	require.NoError(t, db.PingContext(t.Context()), "ping mysql")
+
+	_, err = db.ExecContext(t.Context(), fmt.Sprintf("DROP DATABASE IF EXISTS `%s`", Database))
+	require.NoError(t, err, "reset quarantine database")
+	return db
+}
+
+// createQuarantinedTable creates a table in the quarantine database named as
+// if it was quarantined at the given time.
+func createQuarantinedTable(t *testing.T, db *sql.DB, table string, quarantinedAt time.Time) string {
+	t.Helper()
+	_, err := db.ExecContext(t.Context(), fmt.Sprintf("CREATE DATABASE IF NOT EXISTS `%s`", Database))
+	require.NoError(t, err, "create quarantine database")
+
+	name := TableName("testdb", table, quarantinedAt)
+	_, err = db.ExecContext(t.Context(), fmt.Sprintf("CREATE TABLE `%s`.`%s` (id INT)", Database, name))
+	require.NoError(t, err, "create quarantined table")
+	return name
+}
+
+// createUnparseableQuarantineTable creates a table in the quarantine database
+// whose name carries no timestamp prefix.
+func createUnparseableQuarantineTable(t *testing.T, db *sql.DB, name string) {
+	t.Helper()
+	_, err := db.ExecContext(t.Context(), fmt.Sprintf("CREATE DATABASE IF NOT EXISTS `%s`", Database))
+	require.NoError(t, err, "create quarantine database")
+	_, err = db.ExecContext(t.Context(), fmt.Sprintf("CREATE TABLE `%s`.`%s` (id INT)", Database, name))
+	require.NoError(t, err, "create unparseable quarantined table")
+}
+
+func quarantinedTables(t *testing.T, db *sql.DB) []string {
+	t.Helper()
+	rows, err := db.QueryContext(t.Context(),
+		"SELECT table_name FROM information_schema.tables WHERE table_schema = ? ORDER BY table_name",
+		Database)
+	require.NoError(t, err, "query quarantined tables")
+	defer utils.CloseAndLog(rows)
+
+	var tables []string
+	for rows.Next() {
+		var name string
+		require.NoError(t, rows.Scan(&name), "scan table name")
+		tables = append(tables, name)
+	}
+	require.NoError(t, rows.Err(), "iterate quarantined tables")
+	return tables
+}
+
+func testCleaner(t *testing.T, retention time.Duration, dryRun bool) *Cleaner {
+	t.Helper()
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	targets := []Target{{Database: "testdb", Environment: "staging", DSN: sharedDSN}}
+	return NewCleaner(targets, retention, dryRun, logger)
+}
+
+// The cleaner drops quarantined tables older than the retention period and
+// keeps fresh ones, so an accidental drop stays recoverable for the full
+// retention window while expired tables are reclaimed.
+func TestCleaner_DropsExpiredKeepsFresh(t *testing.T) {
+	db := setupCleanerTest(t)
+
+	now := time.Now()
+	expired := createQuarantinedTable(t, db, "old_table", now.Add(-8*24*time.Hour))
+	fresh := createQuarantinedTable(t, db, "new_table", now.Add(-1*24*time.Hour))
+
+	cleaner := testCleaner(t, DefaultRetention, false)
+	require.NoError(t, cleaner.Run(t.Context()))
+
+	remaining := quarantinedTables(t, db)
+	assert.NotContains(t, remaining, expired, "expired table should be dropped")
+	assert.Contains(t, remaining, fresh, "fresh table should be kept")
+}
+
+// Tables whose names carry no valid timestamp prefix are never dropped: their
+// age is unknown, so deleting them could destroy data that was quarantined
+// recently or placed there manually.
+func TestCleaner_NeverDropsUnparseableNames(t *testing.T) {
+	db := setupCleanerTest(t)
+
+	createUnparseableQuarantineTable(t, db, "manually_parked_table")
+
+	cleaner := testCleaner(t, DefaultRetention, false)
+	require.NoError(t, cleaner.Run(t.Context()))
+
+	remaining := quarantinedTables(t, db)
+	assert.Contains(t, remaining, "manually_parked_table")
+}
+
+// Dry-run mode reports expired tables without dropping them so operators can
+// preview a retention change safely.
+func TestCleaner_DryRunDropsNothing(t *testing.T) {
+	db := setupCleanerTest(t)
+
+	expired := createQuarantinedTable(t, db, "old_table", time.Now().Add(-30*24*time.Hour))
+
+	cleaner := testCleaner(t, DefaultRetention, true)
+	require.NoError(t, cleaner.Run(t.Context()))
+
+	remaining := quarantinedTables(t, db)
+	assert.Contains(t, remaining, expired, "dry run must not drop tables")
+}
+
+// A target without a quarantine database is a no-op, so the cleaner is safe to
+// run against databases that never had a schema change drop a table.
+func TestCleaner_NoQuarantineDatabase(t *testing.T) {
+	db := setupCleanerTest(t)
+
+	cleaner := testCleaner(t, DefaultRetention, false)
+	require.NoError(t, cleaner.Run(t.Context()))
+
+	var dbCount int
+	err := db.QueryRowContext(t.Context(),
+		"SELECT COUNT(*) FROM information_schema.schemata WHERE schema_name = ?", Database).Scan(&dbCount)
+	require.NoError(t, err)
+	assert.Equal(t, 0, dbCount, "cleaner must not create the quarantine database")
+}
+
+// A custom retention shorter than the default is honored.
+func TestCleaner_CustomRetention(t *testing.T) {
+	db := setupCleanerTest(t)
+
+	now := time.Now()
+	expired := createQuarantinedTable(t, db, "two_days_old", now.Add(-2*24*time.Hour))
+	fresh := createQuarantinedTable(t, db, "hours_old", now.Add(-2*time.Hour))
+
+	cleaner := testCleaner(t, 24*time.Hour, false)
+	require.NoError(t, cleaner.Run(t.Context()))
+
+	remaining := quarantinedTables(t, db)
+	assert.NotContains(t, remaining, expired)
+	assert.Contains(t, remaining, fresh)
+}
+
+// A table-level cleanup failure is surfaced to the caller while the table
+// remains quarantined for the next cleanup pass.
+func TestCleaner_DropFailureReturnsError(t *testing.T) {
+	db := setupCleanerTest(t)
+
+	expired := createQuarantinedTable(t, db, "parent_table", time.Now().Add(-8*24*time.Hour))
+	_, err := db.ExecContext(t.Context(), fmt.Sprintf("ALTER TABLE `%s`.`%s` ADD PRIMARY KEY (id)", Database, expired))
+	require.NoError(t, err, "add parent primary key")
+	_, err = db.ExecContext(t.Context(), fmt.Sprintf("CREATE TABLE `%s`.`child_table` (id INT PRIMARY KEY, parent_id INT, CONSTRAINT fk_pending_parent FOREIGN KEY (parent_id) REFERENCES `%s`.`%s` (id))", Database, Database, expired))
+	require.NoError(t, err, "create referencing child table")
+	t.Cleanup(func() {
+		_, cleanupErr := db.ExecContext(context.WithoutCancel(t.Context()), fmt.Sprintf("DROP TABLE IF EXISTS `%s`.`child_table`", Database))
+		require.NoError(t, cleanupErr, "drop child table")
+	})
+
+	cleaner := testCleaner(t, DefaultRetention, false)
+	require.Error(t, cleaner.Run(t.Context()))
+
+	remaining := quarantinedTables(t, db)
+	assert.Contains(t, remaining, expired, "failed drop should remain quarantined")
+}
+
+// An unreachable target fails the pass with an error but does not panic; the
+// failed target is retried on the next pass.
+func TestCleaner_UnreachableTargetReturnsError(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	targets := []Target{{Database: "downdb", Environment: "staging", DSN: "root:wrong@tcp(127.0.0.1:1)/missing?timeout=2s"}}
+	cleaner := NewCleaner(targets, DefaultRetention, false, logger)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+	require.Error(t, cleaner.Run(ctx))
+}

--- a/pkg/pendingdrops/pending_drops_test.go
+++ b/pkg/pendingdrops/pending_drops_test.go
@@ -65,3 +65,16 @@ func TestParseTimestampRejectsInvalidNames(t *testing.T) {
 	_, ok := ParseTimestamp("20260610143022123_")
 	assert.True(t, ok)
 }
+
+func TestTargetLockNameIncludesTargetIdentity(t *testing.T) {
+	base := targetLockName(Target{Database: "orders", Environment: "staging"})
+	same := targetLockName(Target{Database: "orders", Environment: "staging"})
+	differentDatabase := targetLockName(Target{Database: "customers", Environment: "staging"})
+	differentEnvironment := targetLockName(Target{Database: "orders", Environment: "production"})
+
+	assert.Equal(t, same, base)
+	assert.NotEqual(t, differentDatabase, base)
+	assert.NotEqual(t, differentEnvironment, base)
+	assert.LessOrEqual(t, len(base), 64)
+	assert.True(t, strings.HasPrefix(base, lockNamePrefix))
+}


### PR DESCRIPTION
## Why
Pending-drop quarantine keeps data recoverable, but expired quarantined tables still need a coordinated permanent cleanup path that can be owned by a stable server deployment.

## What
- Add a pending-drops cleaner that drops expired quarantine tables and skips unknown-age names
- Start the cleaner from the server for local-mode MySQL targets with per-target advisory locks
- Add `pending_drops` server config for quarantine enablement, cleanup ownership, retention, and dry-run
- Cover the scheduled service cleanup path with an integration test

## Risk Assessment
Medium — adds a background cleanup loop that permanently drops expired quarantined tables. It defaults to the existing retention window, is serialized per target, retries failures, and can be disabled per process with `cleanup_enabled: false`.

## References
Stack: #285 → #286

Generated with Amp