### PR TITLE
feat(operator): claim failed_retryable apply_operations for recovery parity

### DIFF
--- a/pkg/api/operator.go
+++ b/pkg/api/operator.go
@@ -545,12 +545,15 @@ func (s *Service) startApplyOperationHeartbeat(ctx context.Context, workerID int
 // markOperationFromApplyState transitions the claimed operation row to mirror
 // the parent apply's final state after a successful resume.
 //
-// It returns updated=true only when the operation row was durably written to a
-// terminal state, which is the signal the caller needs before deriving the
-// parent apply's state from its children. A non-terminal parent leaves the
-// operation claimable (updated=false, nil error) so a later poll re-leases and
-// resumes it; a write failure returns the error so the caller skips derivation
-// rather than aggregating a stale child state.
+// It returns updated=true whenever the operation row was durably written to
+// mirror the parent — including resumable final states (stopped,
+// failed_retryable), not only terminal ones. updated=true is the signal the
+// caller needs before deriving the parent apply's state from its children: the
+// child row now reflects the parent, so the derived state is current. A parent
+// that is still mid-flight leaves the operation claimable (updated=false, nil
+// error) so a later poll re-leases and resumes it; a write failure returns the
+// error so the caller skips derivation rather than aggregating a stale child
+// state.
 func (s *Service) markOperationFromApplyState(ctx context.Context, workerID int, op *storage.ApplyOperation, apply *storage.Apply) (updated bool, err error) {
 	opStore := s.storage.ApplyOperations()
 	switch {

--- a/pkg/api/operator.go
+++ b/pkg/api/operator.go
@@ -571,6 +571,16 @@ func (s *Service) markOperationFromApplyState(ctx context.Context, workerID int,
 			return false, fmt.Errorf("update stopped apply_operation %d state (deployment %q): %w", op.ID, op.Deployment, err)
 		}
 		return true, nil
+	case state.IsState(apply.State, state.Apply.FailedRetryable):
+		// failed_retryable is resumable like stopped: mirror the state (leaving
+		// completed_at nil) so FindNextApplyOperation reclaims it under the
+		// parent apply's recovery budget. Leaving the row in its active state
+		// would instead make recovery depend on the stale-heartbeat path, which
+		// has no budget and would re-claim it forever once retries are exhausted.
+		if err := opStore.UpdateState(ctx, op.ID, apply.State); err != nil {
+			return false, fmt.Errorf("update failed_retryable apply_operation %d state (deployment %q): %w", op.ID, op.Deployment, err)
+		}
+		return true, nil
 	case state.IsTerminalApplyState(apply.State):
 		// cancelled / reverted — non-resumable terminal states; stamp completed_at.
 		if err := opStore.MarkTerminal(ctx, op.ID, apply.State); err != nil {

--- a/pkg/api/operator_test.go
+++ b/pkg/api/operator_test.go
@@ -1,10 +1,16 @@
 package api
 
 import (
+	"context"
+	"log/slog"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/block/schemabot/pkg/state"
+	"github.com/block/schemabot/pkg/storage"
 )
 
 func TestOperatorWorkersConfig(t *testing.T) {
@@ -30,4 +36,59 @@ func TestOperatorWorkersConfig(t *testing.T) {
 		config := &ServerConfig{OperatorWorkers: 4, SchedulerWorkers: 2}
 		assert.Error(t, config.resolveDeprecatedOperatorWorkers())
 	})
+}
+
+// recordingApplyOperationStore records the state-mutating call made by
+// markOperationFromApplyState. It embeds the interface so only the methods the
+// test exercises need implementations; any other call panics, which keeps the
+// test honest about the code path it covers.
+type recordingApplyOperationStore struct {
+	storage.ApplyOperationStore
+	updateStateID    int64
+	updateStateValue string
+	updateStateErr   error
+}
+
+func (r *recordingApplyOperationStore) UpdateState(_ context.Context, id int64, newState string) error {
+	r.updateStateID = id
+	r.updateStateValue = newState
+	return r.updateStateErr
+}
+
+type mockStorageWithApplyOperations struct {
+	mockStorage
+	applyOps storage.ApplyOperationStore
+}
+
+func (m *mockStorageWithApplyOperations) ApplyOperations() storage.ApplyOperationStore {
+	return m.applyOps
+}
+
+func newOperatorTestService(opStore storage.ApplyOperationStore) *Service {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	return New(&mockStorageWithApplyOperations{applyOps: opStore}, testServerConfig(), nil, logger)
+}
+
+// TestMarkOperationFromApplyState_MirrorsFailedRetryable verifies that a parent
+// apply in failed_retryable mirrors that state (not a terminal one) onto the
+// operation row via UpdateState, leaving it reclaimable for retry. Returning
+// marked=true lets the caller re-derive the parent state from its children.
+func TestMarkOperationFromApplyState_MirrorsFailedRetryable(t *testing.T) {
+	opStore := &recordingApplyOperationStore{}
+	svc := newOperatorTestService(opStore)
+
+	op := &storage.ApplyOperation{ID: 7, Deployment: "region-a"}
+	apply := &storage.Apply{
+		ID:              3,
+		ApplyIdentifier: "apply-retryable",
+		State:           state.Apply.FailedRetryable,
+		Environment:     "staging",
+	}
+
+	marked, err := svc.markOperationFromApplyState(t.Context(), 1, op, apply)
+	require.NoError(t, err)
+	assert.True(t, marked, "failed_retryable parent must mark the operation so derived apply state is recomputed")
+	assert.Equal(t, int64(7), opStore.updateStateID, "the claimed operation row must be the one updated")
+	assert.Equal(t, state.Apply.FailedRetryable, opStore.updateStateValue,
+		"failed_retryable must be mirrored down, not a terminal state")
 }

--- a/pkg/storage/mysqlstore/apply_operations.go
+++ b/pkg/storage/mysqlstore/apply_operations.go
@@ -439,21 +439,32 @@ func (s *applyOperationStore) FindNextApplyOperation(ctx context.Context) (*stor
 	queryArgs = append(queryArgs,
 		state.ApplyOperation.Stopped,
 		storage.ControlOperationStart, storage.ControlRequestPending)
-	queryArgs = append(queryArgs,
-		state.ApplyOperation.FailedRetryable,
-		maxRecoveryAttempts, retryableRecoveryFreshnessDays)
+	queryArgs = append(queryArgs, state.ApplyOperation.FailedRetryable)
+	queryArgs = append(queryArgs, state.Apply.FailedRetryable, maxRecoveryAttempts, retryableRecoveryFreshnessDays)
+	queryArgs = append(queryArgs, stringArgs(activeStates)...)
 
 	// The stopped-row and failed_retryable clauses mirror ApplyStore.FindNextApply:
-	//   - a stopped operation whose parent apply has a pending start request is
-	//     reclaimable so the operator can resume it;
-	//   - a failed_retryable operation is reclaimable while the parent apply still
-	//     has recovery budget (attempt < max) and the failure is recent.
-	// Both carry no deployment-order gate — these rows already ran, so resuming
-	// them is recovering work they started rather than starting a new deployment.
-	// The recovery budget lives on the parent applies row (each retry claim
-	// increments applies.attempt), so the predicate joins to it; once the budget
-	// is spent the clause stops matching and the operation stays quiet instead of
-	// being re-claimed forever.
+	// neither carries a deployment-order gate, because both rows already ran —
+	// resuming them is recovering work they started, not starting a new deployment.
+	//
+	//   - A stopped operation whose parent apply has a pending start request is
+	//     reclaimable so the operator can resume it.
+	//
+	//   - A failed_retryable operation is reclaimable only while its PARENT apply
+	//     is itself claimable for that operation's recovery. The operator claim
+	//     path drives the parent apply, so the operation row is a shadow of the
+	//     parent: gating on the parent's claimability (not just its retry budget)
+	//     is what keeps a healthy retry from being re-claimed every poll. The two
+	//     sub-conditions mirror the parent clauses in ApplyStore.FindNextApply:
+	//       * parent still failed_retryable, within recovery budget (attempt < max)
+	//         and recent — a fresh bounded retry; and
+	//       * parent already claimed into an active state but its lease has gone
+	//         stale — crash recovery, with no budget gate (the attempt was already
+	//         admitted and counted when the parent was claimed).
+	//     Claiming a failed_retryable parent transitions it to running and refreshes
+	//     applies.updated_at (see persistApplyClaim), so once a worker owns the
+	//     retry neither sub-condition matches and peers back off instead of
+	//     churning on a row another worker is actively driving.
 	//
 	// There is intentionally no "pending + pending start request" clause to
 	// match ApplyStore.FindNextApply's pending-start clause. That apply-level
@@ -498,15 +509,24 @@ func (s *applyOperationStore) FindNextApplyOperation(ctx context.Context) (*stor
 					SELECT 1
 					FROM applies a
 					WHERE a.id = apply_operations.apply_id
-						AND a.attempt < ?
-						AND a.updated_at >= NOW() - INTERVAL ? DAY
+						AND (
+							(
+								a.state = ?
+								AND a.attempt < ?
+								AND a.updated_at >= NOW() - INTERVAL ? DAY
+							)
+							OR (
+								a.state IN (%s)
+								AND a.updated_at < NOW() - INTERVAL %s
+							)
+						)
 				)
 			)
 		)
 		ORDER BY created_at, id
 		LIMIT 1
 		FOR UPDATE SKIP LOCKED
-	`, applyOperationColumns, activeStatePlaceholders, applyOperationHeartbeatStaleness), queryArgs...)
+	`, applyOperationColumns, activeStatePlaceholders, applyOperationHeartbeatStaleness, activeStatePlaceholders, applyOperationHeartbeatStaleness), queryArgs...)
 
 	ad, err := scanApplyOperationInto(row)
 	if errors.Is(err, sql.ErrNoRows) {

--- a/pkg/storage/mysqlstore/apply_operations.go
+++ b/pkg/storage/mysqlstore/apply_operations.go
@@ -439,12 +439,21 @@ func (s *applyOperationStore) FindNextApplyOperation(ctx context.Context) (*stor
 	queryArgs = append(queryArgs,
 		state.ApplyOperation.Stopped,
 		storage.ControlOperationStart, storage.ControlRequestPending)
+	queryArgs = append(queryArgs,
+		state.ApplyOperation.FailedRetryable,
+		maxRecoveryAttempts, retryableRecoveryFreshnessDays)
 
-	// The stopped-row clause mirrors ApplyStore.FindNextApply: a stopped
-	// operation whose parent apply has a pending start request is reclaimable
-	// so the operator can resume it. Like the stale-active clause, it carries
-	// no deployment-order gate — a stopped row already ran, so resuming it is
-	// recovering work it started rather than starting a new deployment.
+	// The stopped-row and failed_retryable clauses mirror ApplyStore.FindNextApply:
+	//   - a stopped operation whose parent apply has a pending start request is
+	//     reclaimable so the operator can resume it;
+	//   - a failed_retryable operation is reclaimable while the parent apply still
+	//     has recovery budget (attempt < max) and the failure is recent.
+	// Both carry no deployment-order gate — these rows already ran, so resuming
+	// them is recovering work they started rather than starting a new deployment.
+	// The recovery budget lives on the parent applies row (each retry claim
+	// increments applies.attempt), so the predicate joins to it; once the budget
+	// is spent the clause stops matching and the operation stays quiet instead of
+	// being re-claimed forever.
 	//
 	// There is intentionally no "pending + pending start request" clause to
 	// match ApplyStore.FindNextApply's pending-start clause. That apply-level
@@ -481,6 +490,16 @@ func (s *applyOperationStore) FindNextApplyOperation(ctx context.Context) (*stor
 					WHERE cr.apply_id = apply_operations.apply_id
 						AND cr.operation = ?
 						AND cr.status = ?
+				)
+			)
+			OR (
+				state = ?
+				AND EXISTS (
+					SELECT 1
+					FROM applies a
+					WHERE a.id = apply_operations.apply_id
+						AND a.attempt < ?
+						AND a.updated_at >= NOW() - INTERVAL ? DAY
 				)
 			)
 		)

--- a/pkg/storage/mysqlstore/apply_operations_test.go
+++ b/pkg/storage/mysqlstore/apply_operations_test.go
@@ -854,6 +854,94 @@ func TestApplyOperationStore_FindNextApplyOperation_SkipsFailedRetryableStale(t 
 	assert.Nil(t, claimed, "failed_retryable operation must not be reclaimed once the failure is stale")
 }
 
+// TestApplyOperationStore_FindNextApplyOperation_SkipsFailedRetryableParentActivelyRetrying
+// verifies the failed_retryable claim is gated on the parent apply's state, not
+// just its retry budget. Once a worker claims the parent for retry it
+// transitions the parent to running (an active state) and refreshes its
+// heartbeat, while the child row intentionally stays failed_retryable. A peer
+// must not keep re-claiming that child every poll while the retry is healthy.
+func TestApplyOperationStore_FindNextApplyOperation_SkipsFailedRetryableParentActivelyRetrying(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", "mysql", "staging")
+	apply := createTestApplyWithStateAndEnv(t, store, lock, "apply_op_retryable_active", 1, state.Apply.Running, "staging")
+	// Parent already claimed for retry: running, budget remaining, fresh heartbeat.
+	_, err := testDB.ExecContext(ctx, `
+		UPDATE applies SET state = ?, attempt = ?, updated_at = NOW() WHERE id = ?
+	`, state.Apply.Running, maxRecoveryAttempts-1, apply.ID)
+	require.NoError(t, err)
+
+	_, err = store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-a", State: state.ApplyOperation.FailedRetryable,
+	})
+	require.NoError(t, err)
+
+	claimed, err := store.ApplyOperations().FindNextApplyOperation(ctx)
+	require.NoError(t, err)
+	assert.Nil(t, claimed, "a failed_retryable child must not be re-claimed while its parent is actively (and freshly) retrying")
+}
+
+// TestApplyOperationStore_FindNextApplyOperation_ClaimsFailedRetryableParentActiveStale
+// verifies crash recovery: if the worker driving a retry dies, the parent apply
+// is left active (running) with a stale heartbeat while the child row still says
+// failed_retryable. Another worker must be able to reclaim that child to recover
+// the in-flight retry, mirroring ApplyStore.FindNextApply's stale-active clause.
+func TestApplyOperationStore_FindNextApplyOperation_ClaimsFailedRetryableParentActiveStale(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", "mysql", "staging")
+	apply := createTestApplyWithStateAndEnv(t, store, lock, "apply_op_retryable_crash", 1, state.Apply.Running, "staging")
+	// Parent claimed then crashed: running, budget remaining, heartbeat stale.
+	_, err := testDB.ExecContext(ctx, `
+		UPDATE applies SET state = ?, attempt = ?, updated_at = NOW() - INTERVAL 2 MINUTE WHERE id = ?
+	`, state.Apply.Running, maxRecoveryAttempts-1, apply.ID)
+	require.NoError(t, err)
+
+	id, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-a", State: state.ApplyOperation.FailedRetryable,
+	})
+	require.NoError(t, err)
+
+	claimed, err := store.ApplyOperations().FindNextApplyOperation(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, claimed, "a failed_retryable child must be reclaimable when its parent retry crashed (active + stale)")
+	assert.Equal(t, id, claimed.ID)
+	assert.Equal(t, state.ApplyOperation.FailedRetryable, claimed.State, "re-claim must keep failed_retryable for the resume drive to transition")
+}
+
+// TestApplyOperationStore_FindNextApplyOperation_ClaimsFailedRetryableParentActiveStaleBudgetExhausted
+// verifies the crash-recovery branch is not budget-gated: the retry attempt was
+// already admitted and counted when the parent was claimed, so a crashed retry
+// must still be recoverable even after the attempt count reaches the limit —
+// matching the apply-level stale-active clause, which carries no budget check.
+func TestApplyOperationStore_FindNextApplyOperation_ClaimsFailedRetryableParentActiveStaleBudgetExhausted(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", "mysql", "staging")
+	apply := createTestApplyWithStateAndEnv(t, store, lock, "apply_op_retryable_crash_spent", 1, state.Apply.Running, "staging")
+	// Last retry admitted (attempt at max) then the worker crashed: active + stale.
+	_, err := testDB.ExecContext(ctx, `
+		UPDATE applies SET state = ?, attempt = ?, updated_at = NOW() - INTERVAL 2 MINUTE WHERE id = ?
+	`, state.Apply.Running, maxRecoveryAttempts, apply.ID)
+	require.NoError(t, err)
+
+	id, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-a", State: state.ApplyOperation.FailedRetryable,
+	})
+	require.NoError(t, err)
+
+	claimed, err := store.ApplyOperations().FindNextApplyOperation(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, claimed, "a crashed retry must be recoverable even with the budget spent; the attempt was already counted")
+	assert.Equal(t, id, claimed.ID)
+}
+
 // TestApplyOperationStore_FindNextApplyOperation_ConcurrentClaims verifies
 // the SKIP LOCKED contract on a contended row: N workers race to claim a
 // single pending child row, and exactly one wins. Mirrors the apply-level

--- a/pkg/storage/mysqlstore/apply_operations_test.go
+++ b/pkg/storage/mysqlstore/apply_operations_test.go
@@ -765,6 +765,95 @@ func TestApplyOperationStore_FindNextApplyOperation_SkipsStoppedWithCompletedSta
 	assert.Nil(t, claimed, "stopped operation must not be reclaimed once its start request is no longer pending")
 }
 
+// TestApplyOperationStore_FindNextApplyOperation_ClaimsFailedRetryableWithinBudget
+// verifies recovery parity with ApplyStore.FindNextApply: a failed_retryable
+// operation is reclaimable while its parent apply still has recovery budget
+// (attempt < max) and the failure is recent. The re-claim keeps the row's
+// failed_retryable state (the resume drive transitions it) and refreshes the
+// heartbeat.
+func TestApplyOperationStore_FindNextApplyOperation_ClaimsFailedRetryableWithinBudget(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", "mysql", "staging")
+	apply := createTestApplyWithStateAndEnv(t, store, lock, "apply_op_retryable_ok", 1, state.Apply.FailedRetryable, "staging")
+	// Budget remaining and a recent failure: the parent is reclaimable.
+	_, err := testDB.ExecContext(ctx, `
+		UPDATE applies SET attempt = ?, updated_at = NOW() WHERE id = ?
+	`, maxRecoveryAttempts-1, apply.ID)
+	require.NoError(t, err)
+
+	id, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-a", State: state.ApplyOperation.FailedRetryable,
+	})
+	require.NoError(t, err)
+
+	claimed, err := store.ApplyOperations().FindNextApplyOperation(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, claimed, "failed_retryable operation within budget must be reclaimable")
+	assert.Equal(t, id, claimed.ID)
+	assert.Equal(t, state.ApplyOperation.FailedRetryable, claimed.State, "re-claim must keep failed_retryable for the resume drive to transition")
+
+	persisted, err := store.ApplyOperations().Get(ctx, id)
+	require.NoError(t, err)
+	require.NotNil(t, persisted)
+	assert.Equal(t, state.ApplyOperation.FailedRetryable, persisted.State)
+	assert.WithinDuration(t, time.Now(), persisted.UpdatedAt, 5*time.Second, "heartbeat must be refreshed on re-claim")
+}
+
+// TestApplyOperationStore_FindNextApplyOperation_SkipsFailedRetryableBudgetExhausted
+// verifies the recovery budget is enforced: once the parent apply's attempt
+// count reaches the limit, the failed_retryable operation is no longer
+// reclaimable and stays quiet rather than being re-claimed forever.
+func TestApplyOperationStore_FindNextApplyOperation_SkipsFailedRetryableBudgetExhausted(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", "mysql", "staging")
+	apply := createTestApplyWithStateAndEnv(t, store, lock, "apply_op_retryable_spent", 1, state.Apply.FailedRetryable, "staging")
+	_, err := testDB.ExecContext(ctx, `
+		UPDATE applies SET attempt = ?, updated_at = NOW() WHERE id = ?
+	`, maxRecoveryAttempts, apply.ID)
+	require.NoError(t, err)
+
+	_, err = store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-a", State: state.ApplyOperation.FailedRetryable,
+	})
+	require.NoError(t, err)
+
+	claimed, err := store.ApplyOperations().FindNextApplyOperation(ctx)
+	require.NoError(t, err)
+	assert.Nil(t, claimed, "failed_retryable operation must not be reclaimed once the recovery budget is spent")
+}
+
+// TestApplyOperationStore_FindNextApplyOperation_SkipsFailedRetryableStale
+// verifies the freshness window is enforced: an old failed_retryable failure is
+// not reclaimed, matching ApplyStore.FindNextApply's recovery-freshness gate.
+func TestApplyOperationStore_FindNextApplyOperation_SkipsFailedRetryableStale(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", "mysql", "staging")
+	apply := createTestApplyWithStateAndEnv(t, store, lock, "apply_op_retryable_stale", 1, state.Apply.FailedRetryable, "staging")
+	// Budget remains, but the failure is older than the freshness window.
+	_, err := testDB.ExecContext(ctx, `
+		UPDATE applies SET attempt = 1, updated_at = NOW() - INTERVAL ? DAY WHERE id = ?
+	`, retryableRecoveryFreshnessDays+1, apply.ID)
+	require.NoError(t, err)
+
+	_, err = store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-a", State: state.ApplyOperation.FailedRetryable,
+	})
+	require.NoError(t, err)
+
+	claimed, err := store.ApplyOperations().FindNextApplyOperation(ctx)
+	require.NoError(t, err)
+	assert.Nil(t, claimed, "failed_retryable operation must not be reclaimed once the failure is stale")
+}
+
 // TestApplyOperationStore_FindNextApplyOperation_ConcurrentClaims verifies
 // the SKIP LOCKED contract on a contended row: N workers race to claim a
 // single pending child row, and exactly one wins. Mirrors the apply-level


### PR DESCRIPTION
## What and Why ?

Follow-up to #253. The operation-claim path (`FindNextApplyOperation`) diverged from the apply-claim path (`FindNextApply`) on which rows are reclaimable. This closes the `failed_retryable` gap so a child operation recovers with the same budget/freshness rules as its parent apply.

## Changes

- `FindNextApplyOperation` reclaims a `failed_retryable` operation while the parent apply still has recovery budget (`attempt < max`) and the failure is recent — no deployment-order gate, mirroring the apply-level clause.
- `markOperationFromApplyState` mirrors `failed_retryable` down to the child row (leaving `completed_at` nil) so recovery runs under the parent's bounded retry budget rather than the unbounded stale-heartbeat path.

## Claim parity after this change

| Claimable? | `FindNextApply` | `FindNextApplyOperation` |
|---|---|---|
| `pending` + tasks | ✅ | ✅ |
| stale active | ✅ | ✅ |
| `failed_retryable` | ✅ | ✅ (this PR) |
| `stopped` + pending start req | ✅ | ✅ (#253) |
| `pending` + pending start req | ✅ | ⏳ follow-up |

## Follow-up

The `pending` + pending start-request row is still a clause-shape divergence and is intentionally out of scope here. Unlike `failed_retryable`, it is likely already functionally covered: the operation-level pending clause is broader than the apply-level one (no tasks requirement), so a pending operation with deployment order satisfied is already claimable regardless of a start request. A follow-up will confirm whether an explicit clause is needed for true parity or only for symmetry.

Full analysis: https://github.com/block/schemabot/pull/253#issuecomment-4675020078

## Testing / validation

Unit + integration (MySQL testcontainers): mirror behavior, plus `failed_retryable` claim within budget, budget-exhausted, and stale-failure cases; existing `FindNextApplyOperation` suite passes unchanged.

