### PR TITLE
test(operator): lock deployment-order gate against start-request bypass

### DIFF
--- a/pkg/storage/mysqlstore/apply_operations.go
+++ b/pkg/storage/mysqlstore/apply_operations.go
@@ -445,6 +445,19 @@ func (s *applyOperationStore) FindNextApplyOperation(ctx context.Context) (*stor
 	// so the operator can resume it. Like the stale-active clause, it carries
 	// no deployment-order gate — a stopped row already ran, so resuming it is
 	// recovering work it started rather than starting a new deployment.
+	//
+	// There is intentionally no "pending + pending start request" clause to
+	// match ApplyStore.FindNextApply's pending-start clause. That apply-level
+	// clause only matters because apply-level pending claimability is
+	// task-gated (state = pending AND EXISTS tasks); a start request lets a
+	// no-task pending apply be claimed. Operation-level pending claimability is
+	// instead deployment-order-gated (the clause below), so a pending operation
+	// is already claimable the moment it is legal to start — once every earlier
+	// sibling has completed. A parent start request must not relax that gate:
+	// adding an ungated pending-start clause would let a later deployment be
+	// claimed out of order while an earlier sibling is still non-completed, and
+	// a gated one would be redundant with the pending clause below. Start
+	// requests resume eligible work; they do not reorder the rollout.
 	row := tx.QueryRowContext(ctx, fmt.Sprintf(`
 		SELECT %s
 		FROM apply_operations

--- a/pkg/storage/mysqlstore/apply_operations_test.go
+++ b/pkg/storage/mysqlstore/apply_operations_test.go
@@ -916,6 +916,52 @@ func TestApplyOperationStore_FindNextApplyOperation_HaltsOnFailedSibling(t *test
 	assert.Nil(t, claimed, "later siblings must not be claimed once an earlier deployment failed")
 }
 
+// TestApplyOperationStore_FindNextApplyOperation_PendingStartRequestDoesNotBypassSiblingGate
+// verifies that a parent apply's pending start request does not let a later
+// pending deployment jump the deployment-order gate. Start requests resume
+// eligible work (e.g. a stopped operation); they must never reorder a rollout
+// by claiming a pending sibling while an earlier sibling is still non-completed.
+func TestApplyOperationStore_FindNextApplyOperation_PendingStartRequestDoesNotBypassSiblingGate(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", "mysql", "staging")
+	apply := createTestApplyWithStateAndEnv(t, store, lock, "apply_op_pending_start", 1, state.Apply.Running, "staging")
+
+	// region-a is running (fresh, so not stale-claimable); region-b is pending
+	// behind it. The earlier non-completed sibling gates the later pending one.
+	runningID, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-a", State: state.ApplyOperation.Running,
+	})
+	require.NoError(t, err)
+	_, err = store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-b", State: state.ApplyOperation.Pending,
+	})
+	require.NoError(t, err)
+
+	// A pending start request on the parent apply must not unblock region-b.
+	_, _, err = store.ControlRequests().RequestPending(ctx, &storage.ApplyControlRequest{
+		ApplyID:     apply.ID,
+		Operation:   storage.ControlOperationStart,
+		Status:      storage.ControlRequestPending,
+		RequestedBy: "operator",
+	})
+	require.NoError(t, err)
+
+	claimed, err := store.ApplyOperations().FindNextApplyOperation(ctx)
+	require.NoError(t, err)
+	assert.Nil(t, claimed, "a pending start request must not let a later pending sibling bypass the deployment-order gate")
+
+	// Sanity: once the earlier sibling completes, the gate opens normally —
+	// confirming the nil above was the order gate, not an unrelated skip.
+	require.NoError(t, store.ApplyOperations().MarkCompleted(ctx, runningID))
+	next, err := store.ApplyOperations().FindNextApplyOperation(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, next, "region-b must be claimable once region-a completes")
+	assert.Equal(t, "region-b", next.Deployment)
+}
+
 // TestApplyOperationStore_FindNextApplyOperation_IsolatesApplies verifies the
 // sibling gate is scoped per apply: a blocked deployment in one apply does not
 // hold back the first deployment of an unrelated apply.


### PR DESCRIPTION
## What and Why ?

Follow-up to #253 and the `failed_retryable` parity work (#287). The claim disagreement table had one row left: `pending` + pending start-request, where `FindNextApply` (apply-level) has a clause but `FindNextApplyOperation` (operation-level) does not.

Investigation showed this asymmetry is **intentional**, not a gap:

- Apply-level pending is **task-gated** (`pending AND EXISTS tasks`), so the start-request clause exists to let a no-task pending apply be claimed.
- Operation-level pending is **deployment-order-gated** (`pending AND all earlier siblings completed`), so a pending operation is already claimable the moment it is legal to start.

Adding an ungated `pending + start-request` clause to the operation query would let a later deployment jump the rollout order; a gated one would be redundant with the existing pending clause. Start requests resume eligible work — they must not reorder a rollout.

## Changes

- Document the intentional omission of a `pending + start-request` clause in `FindNextApplyOperation`.
- Add a regression test proving a parent apply's pending start request cannot let a later pending sibling bypass an earlier non-completed sibling (the deployment-order gate holds; the row becomes claimable only once the earlier sibling completes)

## Claim parity (final)

| Claimable? | `FindNextApply` | `FindNextApplyOperation` |
|---|---|---|
| `pending` + tasks | ✅ | ✅ (order-gated) |
| stale active | ✅ | ✅ |
| `failed_retryable` | ✅ | ✅ (#287) |
| `stopped` + pending start req | ✅ | ✅ (#253) |
| `pending` + pending start req | ✅ (task-gated) | ✅ via order-gated pending clause — no separate clause needed |

Full analysis: https://github.com/block/schemabot/pull/253#issuecomment-4675020078

## Testing / validation

Integration (MySQL testcontainers): new start-request order-gate guard plus the existing `FindNextApplyOperation` suite (pending, ordering, halt-on-failed-sibling, stopped-with-start) pass unchanged.


## Flow
```

                  FindNextApplyOperation: is a PENDING op claimable?

   ╭───────────────────────────╮
   │ pending apply_operation    │
   │ (one deployment slice)     │
   ╰─────────────┬─────────────╯
                 │
                 ▼
   ╭───────────────────────────────────────────-╮
   │ Are ALL earlier siblings COMPLETED?        │   ← deployment-order gate
   │ (NOT EXISTS earlier sibling state<>done)   │     (the ONLY gate for pending)
   ╰───────┬───────────────────────────┬────────╯
        no │                           │ yes
           ▼                           ▼
   ╭──────────────────╮        ╭──────────────────╮
   │ NOT claimable    │        │ CLAIM (drive it) │
   │ rollout waits    │        ╰──────────────────╯
   ╰──────────────────╯
           ▲
           │  a parent "start request" does NOT add an edge here —
           │  it cannot reorder the rollout
           ╰── ✗ no "pending + start-request" bypass

   Why the apply level differs:
   ╭───────────────────────────────────────────────────────────--─-──╮
   │ FindNextApply (apply-level) pending is TASK-gated:              │
   │   pending AND EXISTS(tasks)            → claim                  │
   │   pending AND pending start-request    → claim (no-task apply)  │  ← needed there
   ╰──────────────────────────────────────────────────────────────---╯
   ╭──────────────────────────────────────────────────────────────---╮
   │ FindNextApplyOperation (op-level) pending is ORDER-gated:       │
   │   pending AND earlier siblings completed → claim                │  ← already enough
   │   (a start-request clause would be redundant, or unsafe if it   │
   │    skipped the order gate)                                      │
   ╰──────────────────────────────────────────────────────────────---╯
```

