### PR TITLE
feat(tern): add ResumeApplyOperation to the Client interface

### DIFF
--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -425,40 +425,41 @@ func hasApplyLogMessageContaining(logs []*storage.ApplyLog, want string) bool {
 
 // mockTernClient implements tern.Client for testing.
 type mockTernClient struct {
-	healthErr      error
-	planResp       *ternv1.PlanResponse
-	planErr        error
-	planReq        *ternv1.PlanRequest
-	applyResp      *ternv1.ApplyResponse
-	applyErr       error
-	applyReq       *ternv1.ApplyRequest
-	progressResp   *ternv1.ProgressResponse
-	progressErr    error
-	progressReq    *ternv1.ProgressRequest
-	volumeResp     *ternv1.VolumeResponse
-	volumeErr      error
-	volumeReq      *ternv1.VolumeRequest // captured request
-	stopResp       *ternv1.StopResponse
-	stopErr        error
-	stopReq        *ternv1.StopRequest // captured request
-	stopHook       func()
-	startResp      *ternv1.StartResponse
-	startErr       error
-	startReq       *ternv1.StartRequest // captured request
-	cutoverResp    *ternv1.CutoverResponse
-	cutoverErr     error
-	cutoverReq     *ternv1.CutoverRequest // captured request
-	revertResp     *ternv1.RevertResponse
-	revertErr      error
-	revertReq      *ternv1.RevertRequest // captured request
-	skipRevertResp *ternv1.SkipRevertResponse
-	skipRevertErr  error
-	skipRevertReq  *ternv1.SkipRevertRequest // captured request
-	resumeMu       sync.Mutex
-	resumeErr      error
-	resumeApply    *storage.Apply
-	resumeCh       chan *storage.Apply
-	isRemote       bool
+	healthErr         error
+	planResp          *ternv1.PlanResponse
+	planErr           error
+	planReq           *ternv1.PlanRequest
+	applyResp         *ternv1.ApplyResponse
+	applyErr          error
+	applyReq          *ternv1.ApplyRequest
+	progressResp      *ternv1.ProgressResponse
+	progressErr       error
+	progressReq       *ternv1.ProgressRequest
+	volumeResp        *ternv1.VolumeResponse
+	volumeErr         error
+	volumeReq         *ternv1.VolumeRequest // captured request
+	stopResp          *ternv1.StopResponse
+	stopErr           error
+	stopReq           *ternv1.StopRequest // captured request
+	stopHook          func()
+	startResp         *ternv1.StartResponse
+	startErr          error
+	startReq          *ternv1.StartRequest // captured request
+	cutoverResp       *ternv1.CutoverResponse
+	cutoverErr        error
+	cutoverReq        *ternv1.CutoverRequest // captured request
+	revertResp        *ternv1.RevertResponse
+	revertErr         error
+	revertReq         *ternv1.RevertRequest // captured request
+	skipRevertResp    *ternv1.SkipRevertResponse
+	skipRevertErr     error
+	skipRevertReq     *ternv1.SkipRevertRequest // captured request
+	resumeMu          sync.Mutex
+	resumeErr         error
+	resumeApply       *storage.Apply
+	resumeOperationID int64
+	resumeCh          chan *storage.Apply
+	isRemote          bool
 }
 
 func (m *mockTernClient) Health(ctx context.Context) error { return m.healthErr }
@@ -534,6 +535,22 @@ func (m *mockTernClient) RollbackPlan(ctx context.Context, database string) (*te
 func (m *mockTernClient) ResumeApply(ctx context.Context, apply *storage.Apply) error {
 	m.resumeMu.Lock()
 	m.resumeApply = apply
+	resumeCh := m.resumeCh
+	resumeErr := m.resumeErr
+	m.resumeMu.Unlock()
+
+	if resumeCh != nil {
+		select {
+		case resumeCh <- apply:
+		default:
+		}
+	}
+	return resumeErr
+}
+func (m *mockTernClient) ResumeApplyOperation(ctx context.Context, apply *storage.Apply, applyOperationID int64) error {
+	m.resumeMu.Lock()
+	m.resumeApply = apply
+	m.resumeOperationID = applyOperationID
 	resumeCh := m.resumeCh
 	resumeErr := m.resumeErr
 	m.resumeMu.Unlock()

--- a/pkg/tern/README.md
+++ b/pkg/tern/README.md
@@ -26,6 +26,7 @@ type Client interface {
     RollbackPlan(ctx, database string) (*PlanResponse, error)
     Health(ctx) error
     ResumeApply(ctx, *storage.Apply) error
+    ResumeApplyOperation(ctx, *storage.Apply, applyOperationID int64) error
     Close() error
 }
 ```

--- a/pkg/tern/client.go
+++ b/pkg/tern/client.go
@@ -56,6 +56,14 @@ type Client interface {
 	// use checkpoint/resume capabilities of the underlying engine.
 	ResumeApply(ctx context.Context, apply *storage.Apply) error
 
+	// ResumeApplyOperation starts or resumes a single apply_operation (one
+	// deployment of a multi-deployment apply), driving only that operation's
+	// tasks. The drive logic is identical to ResumeApply; the operation scope
+	// only narrows which tasks are loaded/re-queried so a worker can advance one
+	// deployment independently of its siblings. Fails closed when no tasks match
+	// the operation rather than touching the rest of the apply.
+	ResumeApplyOperation(ctx context.Context, apply *storage.Apply, applyOperationID int64) error
+
 	// Endpoint returns the address this client connects to.
 	// For GRPCClient, this is the dial address (e.g., "tern-staging:9090").
 	// For LocalClient, this is the database name.


### PR DESCRIPTION
## What and Why ?

Both `LocalClient` (#257) and `GRPCClient` (#258) now implement operation-scoped resume, so this promotes `ResumeApplyOperation` onto the `Client` interface for callers to depend on. It is a pure interface addition with no caller yet, so there is no behaviour change. Switching the operator to drive a single claimed operation (instead of the whole apply) lands as the next step.

## Changes

- Add `ResumeApplyOperation(ctx, *storage.Apply, applyOperationID int64) error` to the `tern.Client` interface, with a doc comment noting it drives only one deployment's tasks and fails closed when none match.
- Implement the method on the test `mockTernClient` so it still satisfies the interface (captures the operation id alongside the apply). The embedded-interface mock used by the operator tests needs no change.
- Keep the abbreviated interface mirror in `pkg/tern/README.md` in sync.

The existing compile-time `var _ Client` assertions for both clients confirm they satisfy the expanded interface.
