### PR TITLE
fix(tern): fail closed without mutating the apply when an operation has no tasks

### DIFF
--- a/pkg/tern/grpc_client.go
+++ b/pkg/tern/grpc_client.go
@@ -794,7 +794,27 @@ func (c *GRPCClient) ResumeApplyOperation(ctx context.Context, apply *storage.Ap
 	if applyOperationID <= 0 {
 		return fmt.Errorf("apply operation id is required")
 	}
-	return c.resumeApply(ctx, apply, operationApplyTaskScope(applyOperationID))
+	if c.storage == nil {
+		return fmt.Errorf("storage not configured for GRPCClient")
+	}
+	if apply == nil {
+		return fmt.Errorf("apply is required")
+	}
+	scope := operationApplyTaskScope(applyOperationID)
+	// Fail closed before any dispatch or state mutation: an operation that
+	// resolves to no tasks is an invalid or stale claim. The shared resume path
+	// would otherwise mark the whole parent apply failed (dispatchPendingApply
+	// and the remote-failure sites set applies.state regardless of scope), which
+	// is wrong when only this operation's lookup came back empty. Mirrors
+	// LocalClient.ResumeApplyOperation.
+	tasks, err := c.loadApplyTasks(ctx, apply, scope)
+	if err != nil {
+		return err
+	}
+	if len(tasks) == 0 {
+		return fmt.Errorf("no tasks found for apply_operation %d (apply %s)", applyOperationID, apply.ApplyIdentifier)
+	}
+	return c.resumeApply(ctx, apply, scope)
 }
 
 // resumeApply runs work claimed by the operator. Fresh queued applies have no

--- a/pkg/tern/grpc_client_test.go
+++ b/pkg/tern/grpc_client_test.go
@@ -825,6 +825,50 @@ func TestGRPCClient_ResumeApplyOperationRejectsTasksFromAnotherApply(t *testing.
 	assert.Nil(t, server.getApplyRequest(), "foreign tasks must not be dispatched to remote Tern")
 }
 
+func TestGRPCClient_ResumeApplyOperationFailsClosedOnNoTasks(t *testing.T) {
+	// An operation that resolves to no tasks is an invalid or stale claim. The
+	// remote drive must fail closed without dispatching or mutating the parent
+	// apply — marking the whole apply failed would be wrong when only this one
+	// operation's lookup came back empty. Mirrors LocalClient.
+	server := &capturingTernServer{remoteApplyID: "remote-should-not-dispatch"}
+	client, cleanup := testCapturingGRPCClient(t, server)
+	defer cleanup()
+
+	apply := &storage.Apply{
+		ID:              7,
+		ApplyIdentifier: "apply-op-scoped",
+		PlanID:          99,
+		Database:        "testdb",
+		DatabaseType:    storage.DatabaseTypeMySQL,
+		Environment:     "staging",
+		State:           state.Apply.Pending,
+	}
+	apply.SetOptions(storage.ApplyOptions{Target: "testdb-target", DeferCutover: true})
+	operationID := int64(42)
+
+	applyStore := &mockApplyStore{apply: apply}
+	taskStore := &mockTaskStore{tasks: nil}
+	client.storage = &mockStorage{
+		applies: applyStore,
+		tasks:   taskStore,
+		plans: &mockPlanStore{plan: &storage.Plan{
+			ID:             apply.PlanID,
+			PlanIdentifier: "plan-op-scoped",
+		}},
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+	err := client.ResumeApplyOperation(ctx, apply, operationID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no tasks found for apply_operation 42")
+
+	assert.Equal(t, operationID, taskStore.lastOperationID, "drive must look up tasks scoped to the operation")
+	assert.Nil(t, server.getApplyRequest(), "an operation with no tasks must not be dispatched to remote Tern")
+	assert.Empty(t, applyStore.updates, "the parent apply must not be mutated when one operation lookup is empty")
+	assert.Equal(t, state.Apply.Pending, apply.State, "the parent apply state must be left untouched")
+}
+
 func TestGRPCClient_ResumeApplyLogsRemoteLifecycle(t *testing.T) {
 	// gRPC mode keeps the stored apply history in the control plane. When the
 	// operator dispatches work to a remote Tern service, operators should still


### PR DESCRIPTION
## What and Why ?

`GRPCClient.ResumeApplyOperation` now fails closed **before any dispatch or state mutation** when the operation's scoped task lookup returns zero rows, matching `LocalClient.ResumeApplyOperation`. Previously the remote path forwarded an empty operation-scoped result into the shared resume path, whose `dispatchPendingApply` (and remote-failure sites) set `applies.state` regardless of scope — so a single empty operation lookup could mark the **whole parent apply** failed. That contradicts the `Client.ResumeApplyOperation` contract ("fails closed when no tasks match the operation rather than touching the rest of the apply").

A zero-task operation is an invalid or stale claim, never normal flow; failing closed keeps it from corrupting sibling deployments' state.

Related comment - https://github.com/block/schemabot/pull/289#discussion_r3392556114

```
ResumeApplyOperation(apply, opID)
├─ opID<=0 / storage nil / apply nil → error
├─ loadApplyTasks(opID)              → cross-apply trust-boundary guard
├─ len(tasks)==0 → error, NO mutation, NO dispatch   ← parity with LocalClient
└─ resumeApply(scope)               → normal drive
```
## Changes

- Add an upfront fail-closed guard in `GRPCClient.ResumeApplyOperation`: load the operation-scoped tasks first and return an error on zero rows before reaching the dispatch/poll/failure paths.
- Add `TestGRPCClient_ResumeApplyOperationFailsClosedOnNoTasks`: asserts an error is returned, the lookup is operation-scoped, no remote dispatch occurs, and the parent apply is not mutated.

The whole-apply path (`ResumeApply`) is unchanged — a queued apply with no tasks is still correctly marked failed.

