### PR TITLE
feat(operator): drive the claimed operation, not the whole apply

### DIFF
--- a/integration/operator_test.go
+++ b/integration/operator_test.go
@@ -334,6 +334,233 @@ func TestOperator_OperatorReconcilesOperationWhenParentTerminal(t *testing.T) {
 	assert.Equal(t, derived, parent.State, "parent apply state is derived from its child operations")
 }
 
+// TestOperator_OperationDeploymentMismatchFailsClosed covers the safety guard
+// on the operation-claim path. The claimed apply_operations row's deployment is
+// the authoritative routing key for the drive, but the shared resume path
+// selects the Tern client from the parent apply's stored deployment. While one
+// operation maps to one apply these are always identical; if they ever diverge
+// (data corruption, or a future multi-deployment fan-out), driving via the
+// parent deployment would run the wrong deployment. The operator must fail
+// closed: it claims the operation but never drives it to a terminal state.
+func TestOperator_OperationDeploymentMismatchFailsClosed(t *testing.T) {
+	ctx := t.Context()
+	schemaSQL, err := os.ReadFile("testdata/myapp/mysql/schema/users.sql")
+	require.NoError(t, err)
+
+	appDBName, appDSN := createTestDB(t, "op_deploy_mismatch_")
+	ts := startTestServerOperator(t, appDBName, appDSN)
+
+	// Apply the schema normally so the target reaches the desired state, then
+	// drop the table so a replan yields DDL a resumed operation could run.
+	planResp := postJSON(t, "http://"+ts.Addr+"/api/plan", map[string]any{
+		"database": appDBName, "environment": "staging", "type": "mysql",
+		"schema_files": map[string]any{"default": map[string]any{"files": map[string]string{"users.sql": string(schemaSQL)}}},
+	})
+	planID, _ := planResp["plan_id"].(string)
+	require.NotEmpty(t, planID)
+	applyResp := postJSON(t, "http://"+ts.Addr+"/api/apply", map[string]any{
+		"plan_id": planID, "environment": "staging",
+	})
+	require.True(t, applyResp["accepted"] == true)
+	applyID, _ := applyResp["apply_id"].(string)
+	require.NotEmpty(t, applyID)
+	waitForState(t, "http://"+ts.Addr, applyID, "completed", 20*time.Second)
+	ts.Service.StopOperator()
+
+	targetConn, err := sql.Open("mysql", appDSN)
+	require.NoError(t, err)
+	require.NoError(t, targetConn.PingContext(ctx))
+	defer utils.CloseAndLog(targetConn)
+	_, err = targetConn.ExecContext(ctx, "DROP TABLE IF EXISTS users")
+	require.NoError(t, err)
+
+	plan2Resp := postJSON(t, "http://"+ts.Addr+"/api/plan", map[string]any{
+		"database": appDBName, "environment": "staging", "type": "mysql",
+		"schema_files": map[string]any{"default": map[string]any{"files": map[string]string{"users.sql": string(schemaSQL)}}},
+	})
+	planID2, _ := plan2Resp["plan_id"].(string)
+	plan2, err := ts.Storage.Plans().Get(ctx, planID2)
+	require.NoError(t, err)
+
+	// Seed a resumable apply whose stored deployment is the real, routable
+	// target, but a child operation whose deployment deliberately diverges. The
+	// operation's tasks are present and runnable, so the only thing stopping the
+	// drive is the deployment-mismatch guard.
+	now := time.Now()
+	apply := &storage.Apply{
+		ApplyIdentifier: fmt.Sprintf("apply-deploy-mismatch-%d", now.UnixNano()%100000),
+		PlanID:          plan2.ID,
+		Database:        appDBName,
+		DatabaseType:    "mysql",
+		Deployment:      appDBName,
+		Engine:          "spirit",
+		State:           state.Apply.Running,
+		Options:         []byte("{}"),
+		Environment:     "staging",
+		StartedAt:       &now,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+	applyDBID, err := ts.Storage.Applies().Create(ctx, apply)
+	require.NoError(t, err)
+
+	opID, err := ts.Storage.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID:    applyDBID,
+		Deployment: appDBName + "-divergent",
+		Target:     appDBName,
+		State:      state.ApplyOperation.Running,
+		StartedAt:  &now,
+	})
+	require.NoError(t, err)
+
+	for _, tc := range plan2.FlatDDLChanges() {
+		_, err := ts.Storage.Tasks().Create(ctx, &storage.Task{
+			TaskIdentifier:   fmt.Sprintf("task-mismatch-%d", time.Now().UnixNano()),
+			ApplyID:          applyDBID,
+			ApplyOperationID: &opID,
+			PlanID:           plan2.ID,
+			Database:         appDBName,
+			DatabaseType:     "mysql",
+			Engine:           "spirit",
+			State:            state.Task.Running,
+			TableName:        tc.Table,
+			DDL:              tc.DDL,
+			DDLAction:        tc.Operation,
+			Options:          []byte("{}"),
+			Environment:      "staging",
+			CreatedAt:        now,
+			UpdatedAt:        now,
+		})
+		require.NoError(t, err)
+	}
+
+	// Age both rows so the operation-claim loop leases the operation on its
+	// first poll.
+	schemabotDB, err := sql.Open("mysql", schemabotDSN)
+	require.NoError(t, err)
+	require.NoError(t, schemabotDB.PingContext(ctx))
+	defer utils.CloseAndLog(schemabotDB)
+	_, err = schemabotDB.ExecContext(ctx, "UPDATE applies SET updated_at = NOW() - INTERVAL 10 MINUTE WHERE id = ?", applyDBID)
+	require.NoError(t, err)
+	_, err = schemabotDB.ExecContext(ctx, "UPDATE apply_operations SET updated_at = NOW() - INTERVAL 10 MINUTE WHERE id = ?", opID)
+	require.NoError(t, err)
+
+	staleOp, err := ts.Storage.ApplyOperations().Get(ctx, opID)
+	require.NoError(t, err)
+	require.NotNil(t, staleOp)
+	seededUpdatedAt := staleOp.UpdatedAt
+
+	ts.Service.StartOperator(t.Context())
+	defer ts.Service.StopOperator()
+
+	// The operator must actually claim the operation — claiming refreshes its
+	// heartbeat — so we know the deployment-mismatch guard was reached.
+	require.Eventually(t, func() bool {
+		op, err := ts.Storage.ApplyOperations().Get(ctx, opID)
+		require.NoError(t, err)
+		return op != nil && op.UpdatedAt.After(seededUpdatedAt)
+	}, 10*time.Second, 200*time.Millisecond,
+		"operator should claim the stale operation, reaching the deployment-mismatch guard")
+
+	// Having reached the guard, it must never drive the operation to a terminal
+	// state, because its deployment diverges from the parent apply's.
+	require.Never(t, func() bool {
+		op, err := ts.Storage.ApplyOperations().Get(ctx, opID)
+		require.NoError(t, err)
+		return op != nil && state.IsTerminalApplyState(op.State)
+	}, 3*time.Second, 200*time.Millisecond,
+		"operator must fail closed and never drive an operation whose deployment diverges from its parent apply")
+
+	op, err := ts.Storage.ApplyOperations().Get(ctx, opID)
+	require.NoError(t, err)
+	require.NotNil(t, op)
+	assert.Nil(t, op.CompletedAt, "failed-closed operation must not stamp completed_at")
+
+	parent, err := ts.Storage.Applies().Get(ctx, applyDBID)
+	require.NoError(t, err)
+	require.NotNil(t, parent)
+	assert.NotEqual(t, state.Apply.Completed, parent.State,
+		"parent apply must not be driven to completion through a mismatched operation")
+}
+
+// TestOperator_OperationWithoutTasksFailsClosed covers the fail-closed
+// terminalization on the operation-claim path. When a claimed operation resolves
+// to no tasks, the drive cannot make progress: the operator must mark that
+// operation failed (so it is not re-leased forever once its heartbeat goes
+// stale) and re-derive the parent apply's state from its operations, rather than
+// leaving the operation running indefinitely.
+func TestOperator_OperationWithoutTasksFailsClosed(t *testing.T) {
+	ctx := t.Context()
+	appDBName, appDSN := createTestDB(t, "op_no_tasks_")
+	ts := startTestServerOperator(t, appDBName, appDSN)
+	ts.Service.StopOperator()
+
+	// Seed a resumable apply and a child operation whose deployment matches the
+	// parent (so the drive is attempted) but with no tasks scoped to it.
+	now := time.Now()
+	apply := &storage.Apply{
+		ApplyIdentifier: fmt.Sprintf("apply-no-tasks-%d", now.UnixNano()%100000),
+		Database:        appDBName,
+		DatabaseType:    "mysql",
+		Deployment:      appDBName,
+		Engine:          "spirit",
+		State:           state.Apply.Running,
+		Options:         []byte("{}"),
+		Environment:     "staging",
+		StartedAt:       &now,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+	applyDBID, err := ts.Storage.Applies().Create(ctx, apply)
+	require.NoError(t, err)
+
+	opID, err := ts.Storage.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID:    applyDBID,
+		Deployment: appDBName,
+		Target:     appDBName,
+		State:      state.ApplyOperation.Running,
+		StartedAt:  &now,
+	})
+	require.NoError(t, err)
+
+	// Age both rows so the operation-claim loop leases the operation and its
+	// parent apply on the first poll.
+	schemabotDB, err := sql.Open("mysql", schemabotDSN)
+	require.NoError(t, err)
+	require.NoError(t, schemabotDB.PingContext(ctx))
+	defer utils.CloseAndLog(schemabotDB)
+	_, err = schemabotDB.ExecContext(ctx, "UPDATE applies SET updated_at = NOW() - INTERVAL 10 MINUTE WHERE id = ?", applyDBID)
+	require.NoError(t, err)
+	_, err = schemabotDB.ExecContext(ctx, "UPDATE apply_operations SET updated_at = NOW() - INTERVAL 10 MINUTE WHERE id = ?", opID)
+	require.NoError(t, err)
+
+	ts.Service.StartOperator(t.Context())
+	defer ts.Service.StopOperator()
+
+	// The operator must terminalize the task-less operation as failed rather
+	// than re-leasing it forever.
+	require.Eventually(t, func() bool {
+		op, err := ts.Storage.ApplyOperations().Get(ctx, opID)
+		require.NoError(t, err)
+		return op != nil && state.IsState(op.State, state.ApplyOperation.Failed)
+	}, 10*time.Second, 200*time.Millisecond,
+		"operator should fail closed and mark a task-less operation failed")
+
+	op, err := ts.Storage.ApplyOperations().Get(ctx, opID)
+	require.NoError(t, err)
+	require.NotNil(t, op)
+	assert.Equal(t, state.ApplyOperation.Failed, op.State)
+	require.NotNil(t, op.CompletedAt, "a failed operation stamps completed_at")
+
+	// The parent apply state is derived from its child operations, so a single
+	// failed operation drives the parent to failed.
+	parent, err := ts.Storage.Applies().Get(ctx, applyDBID)
+	require.NoError(t, err)
+	require.NotNil(t, parent)
+	assert.Equal(t, state.Apply.Failed, parent.State,
+		"parent apply is derived from its operations and must reflect the failed child")
+}
+
 func TestOperator_ClaimOrdering(t *testing.T) {
 	ctx := t.Context()
 

--- a/pkg/api/operator.go
+++ b/pkg/api/operator.go
@@ -205,17 +205,19 @@ func (s *Service) recoverApplies(ctx context.Context, workerID int) {
 		return
 	}
 	ctx = storage.WithApplyLease(ctx, lease)
-	s.resumeClaimedApply(ctx, workerID, apply)
+	// Legacy FindNextApply path drives the whole apply (applyOperationID == 0).
+	s.resumeClaimedApply(ctx, workerID, apply, 0)
 }
 
 // recoverApplyOperation claims work at the apply_operations (per-deployment)
 // level: it leases one operation row, acquires the parent apply lease that
-// lease-guarded writes require, drives the apply through the shared resume path
-// while heartbeating the operation row, then marks the operation row terminal
-// from the parent apply's final state. While the apply-create dual-write emits
-// exactly one operation per apply, driving the parent apply is equivalent to
-// driving the single operation; this path is the foundation for the future
-// multi-deployment fan-out.
+// lease-guarded writes require, drives only that operation's tasks through the
+// shared resume path while heartbeating the operation row, then marks the
+// operation row terminal from the parent apply's final state. Scoping the drive
+// to the claimed operation is what lets sibling deployments run concurrently
+// once the multi-deployment fan-out lands; while the apply-create dual-write
+// emits exactly one operation per apply, the operation-scoped drive resolves to
+// the same tasks as the whole apply.
 func (s *Service) recoverApplyOperation(ctx context.Context, workerID int, owner string) {
 	op, err := s.storage.ApplyOperations().FindNextApplyOperation(ctx)
 	if err != nil {
@@ -278,7 +280,7 @@ func (s *Service) recoverApplyOperation(ctx context.Context, workerID int, owner
 	stopHeartbeat := s.startApplyOperationHeartbeat(runCtx, workerID, op, apply, cancelRun)
 	defer stopHeartbeat()
 
-	resumed := s.resumeClaimedApply(runCtx, workerID, apply)
+	resumed := s.resumeClaimedApply(runCtx, workerID, apply, op.ID)
 	stopHeartbeat()
 	if !resumed {
 		return
@@ -389,11 +391,15 @@ func (s *Service) reconcileUnclaimableParent(ctx context.Context, workerID int, 
 	metrics.RecordOperatorClaimFailure(ctx, "operation_parent_not_claimable")
 }
 
-// resumeClaimedApply drives a claimed apply through ResumeApply with the apply
-// lease already attached to ctx. Returns true when the apply resumed without
-// error. Failures are logged and recorded as metrics internally; the bool lets
-// the operation-level claim loop decide whether to mark its operation terminal.
-func (s *Service) resumeClaimedApply(ctx context.Context, workerID int, apply *storage.Apply) bool {
+// resumeClaimedApply drives claimed work through the engine with the apply lease
+// already attached to ctx. When applyOperationID is set (the operation-claim
+// path) it drives only that deployment's tasks via ResumeApplyOperation, so
+// sibling deployments are unaffected; when it is 0 (the legacy whole-apply path)
+// it drives every task of the apply via ResumeApply. Returns true when the work
+// resumed without error. Failures are logged and recorded as metrics internally;
+// the bool lets the operation-level claim loop decide whether to mark its
+// operation terminal.
+func (s *Service) resumeClaimedApply(ctx context.Context, workerID int, apply *storage.Apply, applyOperationID int64) bool {
 	lease := apply.Lease()
 	start := s.clock.Now()
 	s.logger.Info("operator: claimed apply",
@@ -440,7 +446,16 @@ func (s *Service) resumeClaimedApply(ctx context.Context, workerID int, apply *s
 	if retryableClaim {
 		metrics.AdjustActiveApplies(ctx, 1, apply.Database, deployment, apply.Environment)
 	}
-	if err := client.ResumeApply(ctx, apply); err != nil {
+	// The operation-claim path scopes the drive to the single deployment it
+	// leased so sibling deployments are unaffected; ResumeApplyOperation fails
+	// closed when no tasks scope to the operation. The legacy whole-apply path
+	// (applyOperationID == 0) drives every task of the apply.
+	if applyOperationID > 0 {
+		err = client.ResumeApplyOperation(ctx, apply, applyOperationID)
+	} else {
+		err = client.ResumeApply(ctx, apply)
+	}
+	if err != nil {
 		if errors.Is(err, storage.ErrApplyLeaseLost) {
 			s.logger.Warn("operator: apply lease was lost; worker will stop writing this apply",
 				"worker", workerID,

--- a/pkg/api/operator.go
+++ b/pkg/api/operator.go
@@ -10,6 +10,7 @@ import (
 	"github.com/block/schemabot/pkg/metrics"
 	"github.com/block/schemabot/pkg/state"
 	"github.com/block/schemabot/pkg/storage"
+	"github.com/block/schemabot/pkg/tern"
 )
 
 // Operator constants.
@@ -206,7 +207,9 @@ func (s *Service) recoverApplies(ctx context.Context, workerID int) {
 	}
 	ctx = storage.WithApplyLease(ctx, lease)
 	// Legacy FindNextApply path drives the whole apply (applyOperationID == 0).
-	s.resumeClaimedApply(ctx, workerID, apply, 0)
+	// Failures are handled inside resumeClaimedApply; the whole-apply path has no
+	// operation row to terminalize, so the return values are not needed here.
+	_, _ = s.resumeClaimedApply(ctx, workerID, apply, 0)
 }
 
 // recoverApplyOperation claims work at the apply_operations (per-deployment)
@@ -272,6 +275,25 @@ func (s *Service) recoverApplyOperation(ctx context.Context, workerID int, owner
 	}
 	leasedCtx := storage.WithApplyLease(ctx, lease)
 
+	// The claimed operation row's deployment is the authoritative routing key
+	// for the drive, but resumeClaimedApply selects the Tern client from the
+	// parent apply's stored deployment. These are identical while one operation
+	// maps to one apply; if they ever diverge the worker would drive the wrong
+	// deployment, so fail closed rather than route to the parent's deployment.
+	if op.Deployment != apply.Deployment {
+		s.logger.Error("operator: claimed operation deployment does not match parent apply deployment; operation will not be driven",
+			"worker", workerID,
+			"lease_owner", owner,
+			"apply_operation_id", op.ID,
+			"apply_id", apply.ApplyIdentifier,
+			"database", apply.Database,
+			"operation_deployment", op.Deployment,
+			"apply_deployment", apply.Deployment,
+			"environment", apply.Environment)
+		metrics.RecordOperatorClaimFailure(ctx, "deployment_mismatch")
+		return
+	}
+
 	// Heartbeat the operation row on the apply heartbeat cadence so a peer
 	// worker does not re-claim it during a long ResumeApply. A lost parent lease
 	// cancels the run so the displaced worker stops writing.
@@ -280,9 +302,15 @@ func (s *Service) recoverApplyOperation(ctx context.Context, workerID int, owner
 	stopHeartbeat := s.startApplyOperationHeartbeat(runCtx, workerID, op, apply, cancelRun)
 	defer stopHeartbeat()
 
-	resumed := s.resumeClaimedApply(runCtx, workerID, apply, op.ID)
+	resumed, resumeErr := s.resumeClaimedApply(runCtx, workerID, apply, op.ID)
 	stopHeartbeat()
 	if !resumed {
+		if errors.Is(resumeErr, tern.ErrNoTasksForApplyOperation) {
+			// The drive failed closed: the operation has no tasks, so it can
+			// never make progress. Terminalize it now rather than leaving it to
+			// be re-leased on every poll once its heartbeat goes stale.
+			s.failOperationWithoutTasks(leasedCtx, workerID, op, apply)
+		}
 		return
 	}
 
@@ -391,6 +419,29 @@ func (s *Service) reconcileUnclaimableParent(ctx context.Context, workerID int, 
 	metrics.RecordOperatorClaimFailure(ctx, "operation_parent_not_claimable")
 }
 
+// failOperationWithoutTasks terminalizes an operation whose drive failed closed
+// because no tasks scope to it. Such a claim is invalid or stale: the operation
+// can never make progress, so leaving the row non-terminal would re-lease it on
+// every poll once its heartbeat goes stale. Mark it failed and re-derive the
+// parent apply state from its operations so the parent reflects the terminal
+// child. The caller passes a lease-scoped context so the writes fail closed if
+// ownership has since changed.
+func (s *Service) failOperationWithoutTasks(ctx context.Context, workerID int, op *storage.ApplyOperation, apply *storage.Apply) {
+	const reason = "operation has no tasks; invalid or stale claim"
+	if err := s.storage.ApplyOperations().MarkFailed(ctx, op.ID, reason); err != nil {
+		s.logger.Error("operator: failed to mark task-less apply_operation failed; operation will be retried",
+			"worker", workerID, "apply_operation_id", op.ID, "apply_id", apply.ApplyIdentifier,
+			"deployment", op.Deployment, "environment", apply.Environment, "error", err)
+		return
+	}
+	if err := s.updateApplyStateFromOperations(ctx, workerID, apply); err != nil {
+		s.logger.Error("operator: failed to update derived apply state after failing task-less operation",
+			"worker", workerID, "apply_operation_id", op.ID, "apply_id", apply.ApplyIdentifier,
+			"deployment", op.Deployment, "environment", apply.Environment, "error", err)
+		return
+	}
+}
+
 // resumeClaimedApply drives claimed work through the engine with the apply lease
 // already attached to ctx. When applyOperationID is set (the operation-claim
 // path) it drives only that deployment's tasks via ResumeApplyOperation, so
@@ -398,8 +449,9 @@ func (s *Service) reconcileUnclaimableParent(ctx context.Context, workerID int, 
 // it drives every task of the apply via ResumeApply. Returns true when the work
 // resumed without error. Failures are logged and recorded as metrics internally;
 // the bool lets the operation-level claim loop decide whether to mark its
-// operation terminal.
-func (s *Service) resumeClaimedApply(ctx context.Context, workerID int, apply *storage.Apply, applyOperationID int64) bool {
+// operation terminal, and the returned error lets it distinguish the fail-closed
+// no-tasks case (tern.ErrNoTasksForApplyOperation) from transient failures.
+func (s *Service) resumeClaimedApply(ctx context.Context, workerID int, apply *storage.Apply, applyOperationID int64) (bool, error) {
 	lease := apply.Lease()
 	start := s.clock.Now()
 	s.logger.Info("operator: claimed apply",
@@ -423,7 +475,7 @@ func (s *Service) resumeClaimedApply(ctx context.Context, workerID int, apply *s
 			"environment", apply.Environment,
 			"error", err)
 		metrics.RecordOperatorResumeFailure(ctx, apply.Database, "", apply.Environment, "missing_deployment")
-		return false
+		return false, err
 	}
 	client, err := s.TernClient(deployment, apply.Environment)
 	if err != nil {
@@ -435,7 +487,7 @@ func (s *Service) resumeClaimedApply(ctx context.Context, workerID int, apply *s
 			"environment", apply.Environment,
 			"error", err)
 		metrics.RecordOperatorResumeFailure(ctx, apply.Database, deployment, apply.Environment, "no_client")
-		return false
+		return false, err
 	}
 
 	if s.OnApplyRecovered != nil {
@@ -469,7 +521,26 @@ func (s *Service) resumeClaimedApply(ctx context.Context, workerID int, apply *s
 			if retryableClaim {
 				metrics.AdjustActiveApplies(ctx, -1, apply.Database, deployment, apply.Environment)
 			}
-			return false
+			return false, err
+		}
+		if errors.Is(err, tern.ErrNoTasksForApplyOperation) {
+			// Fail-closed: no tasks scope to the operation, so it is an invalid
+			// or stale claim that can never make progress. The drive mutated
+			// nothing; the caller terminalizes the operation row so it is not
+			// re-leased on every poll once its heartbeat goes stale.
+			s.logger.Error("operator: claimed operation has no tasks; failing it closed",
+				"worker", workerID,
+				"apply_id", apply.ApplyIdentifier,
+				"database", apply.Database,
+				"deployment", deployment,
+				"environment", apply.Environment,
+				"apply_operation_id", applyOperationID,
+				"error", err)
+			metrics.RecordOperatorResumeFailure(ctx, apply.Database, deployment, apply.Environment, "operation_no_tasks")
+			if retryableClaim {
+				metrics.AdjustActiveApplies(ctx, -1, apply.Database, deployment, apply.Environment)
+			}
+			return false, err
 		}
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) || ctx.Err() != nil {
 			s.logger.Debug("operator: stopped while running claimed apply",
@@ -482,7 +553,7 @@ func (s *Service) resumeClaimedApply(ctx context.Context, workerID int, apply *s
 			if retryableClaim {
 				metrics.AdjustActiveApplies(ctx, -1, apply.Database, deployment, apply.Environment)
 			}
-			return false
+			return false, err
 		}
 		s.logger.Error("operator: failed to resume apply",
 			"worker", workerID,
@@ -495,7 +566,7 @@ func (s *Service) resumeClaimedApply(ctx context.Context, workerID int, apply *s
 		if retryableClaim {
 			metrics.AdjustActiveApplies(ctx, -1, apply.Database, deployment, apply.Environment)
 		}
-		return false
+		return false, err
 	}
 
 	duration := s.clock.Now().Sub(start)
@@ -509,7 +580,7 @@ func (s *Service) resumeClaimedApply(ctx context.Context, workerID int, apply *s
 		"duration", duration)
 	metrics.RecordOperatorResume(ctx, apply.Database, deployment, apply.Environment, previousState)
 	metrics.RecordOperatorClaimDuration(ctx, duration, apply.Database, deployment, apply.Environment, previousState)
-	return true
+	return true, nil
 }
 
 // startApplyOperationHeartbeat refreshes the claimed operation row's lease while

--- a/pkg/tern/client.go
+++ b/pkg/tern/client.go
@@ -3,10 +3,19 @@ package tern
 
 import (
 	"context"
+	"errors"
 
 	ternv1 "github.com/block/schemabot/pkg/proto/ternv1"
 	"github.com/block/schemabot/pkg/storage"
 )
+
+// ErrNoTasksForApplyOperation is returned by ResumeApplyOperation when no tasks
+// scope to the requested operation. It is the fail-closed signal for an invalid
+// or stale operation claim: the operation cannot make progress, so the operator
+// terminalizes it rather than retrying it forever. Both the local and remote
+// clients detect this from storage before any dispatch or state mutation, so
+// callers can match it with errors.Is regardless of the transport.
+var ErrNoTasksForApplyOperation = errors.New("no tasks found for apply operation")
 
 // Client defines the interface for schema change operations.
 // Uses proto-generated types for type safety.

--- a/pkg/tern/grpc_client.go
+++ b/pkg/tern/grpc_client.go
@@ -812,7 +812,7 @@ func (c *GRPCClient) ResumeApplyOperation(ctx context.Context, apply *storage.Ap
 		return err
 	}
 	if len(tasks) == 0 {
-		return fmt.Errorf("no tasks found for apply_operation %d (apply %s)", applyOperationID, apply.ApplyIdentifier)
+		return fmt.Errorf("apply_operation %d (apply %s): %w", applyOperationID, apply.ApplyIdentifier, ErrNoTasksForApplyOperation)
 	}
 	return c.resumeApply(ctx, apply, scope)
 }

--- a/pkg/tern/grpc_client_test.go
+++ b/pkg/tern/grpc_client_test.go
@@ -861,7 +861,8 @@ func TestGRPCClient_ResumeApplyOperationFailsClosedOnNoTasks(t *testing.T) {
 	defer cancel()
 	err := client.ResumeApplyOperation(ctx, apply, operationID)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "no tasks found for apply_operation 42")
+	require.ErrorIs(t, err, ErrNoTasksForApplyOperation, "the empty-operation fail-closed signal must be matchable with errors.Is")
+	assert.Contains(t, err.Error(), "apply_operation 42")
 
 	assert.Equal(t, operationID, taskStore.lastOperationID, "drive must look up tasks scoped to the operation")
 	assert.Nil(t, server.getApplyRequest(), "an operation with no tasks must not be dispatched to remote Tern")

--- a/pkg/tern/local_client_integration_test.go
+++ b/pkg/tern/local_client_integration_test.go
@@ -923,6 +923,71 @@ func TestLocalClient_ResumeApplyOperationDrivesOperationTasks(t *testing.T) {
 	assert.Equal(t, operationID, *tasks[0].ApplyOperationID)
 }
 
+// An operation that resolves to no tasks is an invalid or stale claim. The local
+// drive must fail closed with ErrNoTasksForApplyOperation — matchable with
+// errors.Is — without mutating the parent apply, so the operator can terminalize
+// just that operation rather than marking the whole apply failed.
+func TestLocalClient_ResumeApplyOperationFailsClosedOnNoTasks(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	_, dsn := setupMySQLContainer(t)
+	setupStorageSchema(t, dsn)
+	cleanupTasks(t, dsn)
+	cleanupTestTables(t, dsn)
+
+	ctx := t.Context()
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	stor := createStorage(t, dsn)
+	defer utils.CloseAndLog(stor)
+
+	client, err := NewLocalClient(LocalConfig{
+		Database:  "testdb",
+		Type:      storage.DatabaseTypeMySQL,
+		TargetDSN: dsn,
+	}, stor, logger)
+	require.NoError(t, err)
+	defer utils.CloseAndLog(client)
+
+	now := time.Now()
+	apply := &storage.Apply{
+		ApplyIdentifier: fmt.Sprintf("apply-op-notasks-%d", time.Now().UnixNano()),
+		Database:        "testdb",
+		DatabaseType:    storage.DatabaseTypeMySQL,
+		Deployment:      "testdb",
+		Engine:          storage.EngineSpirit,
+		State:           state.Apply.Running,
+		Options:         storage.MarshalApplyOptions(storage.ApplyOptions{}),
+		Environment:     localClientTestEnvironment,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+	applyID, err := stor.Applies().Create(ctx, apply)
+	require.NoError(t, err)
+	apply.ID = applyID
+
+	// Insert an operation but deliberately no tasks scoped to it.
+	operationID, err := stor.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID:    applyID,
+		Deployment: "testdb",
+		Target:     "testdb",
+		State:      state.ApplyOperation.Running,
+	})
+	require.NoError(t, err)
+
+	err = client.ResumeApplyOperation(ctx, apply, operationID)
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrNoTasksForApplyOperation, "the empty-operation fail-closed signal must be matchable with errors.Is")
+
+	// The parent apply must be untouched: the empty lookup is scoped to the one
+	// operation, not the whole apply.
+	after, err := stor.Applies().Get(ctx, applyID)
+	require.NoError(t, err)
+	require.NotNil(t, after)
+	assert.Equal(t, state.Apply.Running, after.State, "a task-less operation must not mutate the parent apply state")
+}
+
 // This scenario covers an operator-owned grouped start where the target schema
 // advances between the recovery re-plan and the final pre-dispatch schema check.
 // The operator should complete durable state without reissuing engine apply work.

--- a/pkg/tern/local_control_resume.go
+++ b/pkg/tern/local_control_resume.go
@@ -634,7 +634,7 @@ func (c *LocalClient) ResumeApplyOperation(ctx context.Context, apply *storage.A
 	// resumeApplyWithTasks: that path marks the whole parent apply as failed,
 	// which is incorrect when only one operation lookup came back empty.
 	if len(tasks) == 0 {
-		return fmt.Errorf("no tasks found for apply_operation %d (apply %s)", applyOperationID, apply.ApplyIdentifier)
+		return fmt.Errorf("apply_operation %d (apply %s): %w", applyOperationID, apply.ApplyIdentifier, ErrNoTasksForApplyOperation)
 	}
 	return c.resumeApplyWithTasks(ctx, apply, tasks)
 }


### PR DESCRIPTION
## What and Why ?
Final step of operation-scoped engine drive. The operator's
operation-claim path now drives **only the tasks of the `apply_operations` row
it leased** via `ResumeApplyOperation`, instead of resuming the whole parent
apply. This is what lets sibling deployments under one environment run
concurrently once the multi-deployment fan-out lands.

Dormant today: with the `len(deployments) > 1` hard-block and one operation per
apply, the operation-scoped drive resolves to exactly the same tasks as the
whole apply, so behaviour is unchanged until the hard-block lifts.

## Changes
- `resumeClaimedApply` gains an `applyOperationID int64` parameter:
  - operation-claim path (`recoverApplyOperation`) passes `op.ID` →
    `client.ResumeApplyOperation(ctx, apply, op.ID)`, which fails closed when no
    tasks scope to the operation (see #290).
  - legacy `FindNextApply` path passes `0` → `client.ResumeApply(ctx, apply)`,
    behaviour-identical to before.

## Builds on
This is step 5 of the 5-PR sequence that scopes the engine drive by
`apply_operation_id`; all predecessors are merged:
- #256 — `Tasks().GetByApplyOperationID` (read primitive)
- #257 — `LocalClient.ResumeApplyOperation`
- #258 — `GRPCClient.ResumeApplyOperation`
- #289 — `ResumeApplyOperation` on the `Client` interface
- #290 — gRPC fails closed without mutating the apply when an operation has no tasks

## Testing / validation
- `go build ./...`
- `go vet ./pkg/api/`
- `go test ./pkg/api/ -count=1`
- `golangci-lint run --build-tags=integration --new-from-rev=origin/main ./pkg/api/...` → 0 issues
- `go test -tags=integration -run 'TestOperator_' ./integration/ -count=1`

## References
- Completes operation-scoped engine drive
- Sequenced ahead of flip `operator_claim_operations` default on; lift the
  `len(deployments) > 1` hard-block), which is what makes this drive load-bearing
