### PR TITLE
feat(operator): make rollout halt-on-failure configurable per environment

### DIFF
--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -459,6 +459,16 @@ type EnvironmentConfig struct {
 	// Only meaningful alongside a Deployments map.
 	CutoverPolicy string `yaml:"cutover_policy,omitempty"`
 
+	// HaltOnFailure controls multi-deployment rollout behaviour when a
+	// deployment fails. When true or unset (the default), a failed deployment
+	// halts the rollout — later deployments in deployment_order are not started.
+	// When false, a failed deployment no longer blocks later deployments, so
+	// the rollout attempts every deployment instead of stopping at the first
+	// failure. It governs only rollout continuation; the apply's pass/fail
+	// verdict and the merge gate stay fail-closed on any failed deployment.
+	// Only meaningful alongside a Deployments map.
+	HaltOnFailure *bool `yaml:"halt_on_failure,omitempty"`
+
 	// For PlanetScale/Vitess:
 	// Organization is the PlanetScale organization name.
 	// sadscan:disable kingfisher.planetscale.2
@@ -654,6 +664,9 @@ func (c *ServerConfig) Validate() error {
 				default:
 					return fmt.Errorf("database %q environment %q has invalid cutover_policy %q (want %q or %q)", name, env, envConfig.CutoverPolicy, storage.CutoverPolicyRolling, storage.CutoverPolicyBarrier)
 				}
+			}
+			if envConfig.HaltOnFailure != nil && !hasMapRouting {
+				return fmt.Errorf("database %q environment %q sets halt_on_failure without a deployments map", name, env)
 			}
 			switch {
 			case hasDSN && (hasScalarRouting || hasMapRouting):
@@ -916,6 +929,18 @@ func (c *ServerConfig) CutoverPolicyFor(database, environment string) string {
 		return storage.CutoverPolicyRolling
 	}
 	return env.CutoverPolicy
+}
+
+// HaltOnFailureEnabled reports whether a failed deployment should halt the
+// rollout of later deployments for this database+environment. Defaults to true
+// (halt) when the environment is unconfigured or leaves halt_on_failure unset,
+// preserving stop-at-first-failure as the safe default.
+func (c *ServerConfig) HaltOnFailureEnabled(database, environment string) bool {
+	env := c.DatabaseEnvironment(database, environment)
+	if env == nil || env.HaltOnFailure == nil {
+		return true
+	}
+	return *env.HaltOnFailure
 }
 
 // DatabaseEnvironments returns the environments configured server-side for a

--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -19,6 +19,30 @@ import (
 	"github.com/block/schemabot/pkg/storage"
 )
 
+// TestServerConfig_HaltOnFailureEnabled verifies the rollout-policy resolver:
+// it defaults to halting (true) when unset or unconfigured, and honours an
+// explicit false so a failed deployment no longer halts later ones.
+func TestServerConfig_HaltOnFailureEnabled(t *testing.T) {
+	cfg := &ServerConfig{
+		Databases: map[string]DatabaseConfig{
+			"payments": {
+				Type: "mysql",
+				Environments: map[string]EnvironmentConfig{
+					"halt-unset": {Target: "payments", Deployment: "payments-a"},
+					"halt-true":  {Deployments: map[string]DeploymentTarget{"payments-a": {Target: "payments"}}, HaltOnFailure: new(true)},
+					"halt-false": {Deployments: map[string]DeploymentTarget{"payments-a": {Target: "payments"}}, HaltOnFailure: new(false)},
+				},
+			},
+		},
+	}
+
+	assert.True(t, cfg.HaltOnFailureEnabled("payments", "halt-unset"), "unset defaults to halting")
+	assert.True(t, cfg.HaltOnFailureEnabled("payments", "halt-true"), "explicit true halts")
+	assert.False(t, cfg.HaltOnFailureEnabled("payments", "halt-false"), "explicit false does not halt")
+	assert.True(t, cfg.HaltOnFailureEnabled("payments", "missing-env"), "unconfigured env defaults to halting")
+	assert.True(t, cfg.HaltOnFailureEnabled("missing-db", "halt-false"), "unconfigured database defaults to halting")
+}
+
 func TestLoadServerConfig(t *testing.T) {
 	// Create temp config file
 	dir := t.TempDir()
@@ -1371,6 +1395,26 @@ func TestServerConfig_DeploymentsMapValidation(t *testing.T) {
 					"payments-a": {Target: "payments"},
 				},
 				CutoverPolicy: storage.CutoverPolicyBarrier,
+			},
+			tern: baseTern,
+		},
+		{
+			name: "halt_on_failure without a deployments map is rejected",
+			envConfig: EnvironmentConfig{
+				Target:        "payments",
+				Deployment:    "payments-a",
+				HaltOnFailure: new(false),
+			},
+			tern:       baseTern,
+			wantErrSub: "sets halt_on_failure without a deployments map",
+		},
+		{
+			name: "halt_on_failure with a deployments map is accepted",
+			envConfig: EnvironmentConfig{
+				Deployments: map[string]DeploymentTarget{
+					"payments-a": {Target: "payments"},
+				},
+				HaltOnFailure: new(false),
 			},
 			tern: baseTern,
 		},

--- a/pkg/api/plan_handlers.go
+++ b/pkg/api/plan_handlers.go
@@ -669,11 +669,13 @@ func (s *Service) createStoredApply(
 	// routing. The data shape is what the operator claim-loop PR consumes
 	// once that gate is lifted and plans become deployment-agnostic.
 	cutoverPolicy := s.config.CutoverPolicyFor(plan.Database, req.Environment)
+	haltOnFailure := s.config.HaltOnFailureEnabled(plan.Database, req.Environment)
 	operations := []*storage.ApplyOperation{{
 		Deployment:    apply.Deployment,
 		Target:        plan.Target,
 		State:         state.ApplyOperation.Pending,
 		CutoverPolicy: cutoverPolicy,
+		HaltOnFailure: &haltOnFailure,
 		CreatedAt:     now,
 		UpdatedAt:     now,
 	}}

--- a/pkg/schema/mysql/apply_operations.sql
+++ b/pkg/schema/mysql/apply_operations.sql
@@ -8,6 +8,7 @@ CREATE TABLE `apply_operations` (
   `state` varchar(100) NOT NULL DEFAULT 'pending',
   `error_message` text,
   `cutover_policy` varchar(16) NOT NULL DEFAULT 'rolling',
+  `halt_on_failure` tinyint(1) NOT NULL DEFAULT '1',
   `lease_owner` varchar(255) NOT NULL DEFAULT '',
   `lease_token` varchar(64) NOT NULL DEFAULT '',
   `lease_acquired_at` datetime DEFAULT NULL,

--- a/pkg/storage/mysqlstore/apply_operations.go
+++ b/pkg/storage/mysqlstore/apply_operations.go
@@ -20,7 +20,7 @@ import (
 
 // applyOperationColumns lists all columns for SELECT queries.
 const applyOperationColumns = `id, apply_id, deployment, target, state, error_message,
-	cutover_policy, started_at, completed_at, lease_owner, lease_token, lease_acquired_at,
+	cutover_policy, halt_on_failure, started_at, completed_at, lease_owner, lease_token, lease_acquired_at,
 	engine_resume_context, engine_resume_metadata, created_at, updated_at`
 
 // mysqlErrDupEntry is MySQL's error number for a duplicate-key violation.
@@ -64,13 +64,21 @@ func insertApplyOperation(ctx context.Context, exec sqlExecer, ad *storage.Apply
 		cutoverPolicy = storage.CutoverPolicyRolling
 	}
 
+	// nil policy means the caller did not resolve a halt_on_failure preference,
+	// so fall back to halting — the safe default that matches the column's
+	// NOT NULL DEFAULT 1 and never silently degrades to non-halting behaviour.
+	haltOnFailure := true
+	if ad.HaltOnFailure != nil {
+		haltOnFailure = *ad.HaltOnFailure
+	}
+
 	result, err := exec.ExecContext(ctx, `
 		INSERT INTO apply_operations (
-			apply_id, deployment, target, state, error_message, cutover_policy,
+			apply_id, deployment, target, state, error_message, cutover_policy, halt_on_failure,
 			started_at, completed_at, engine_resume_context, engine_resume_metadata
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`,
-		ad.ApplyID, ad.Deployment, ad.Target, stateVal, nullString(ad.ErrorMessage), cutoverPolicy,
+		ad.ApplyID, ad.Deployment, ad.Target, stateVal, nullString(ad.ErrorMessage), cutoverPolicy, haltOnFailure,
 		ad.StartedAt, ad.CompletedAt, nullString(ad.EngineResumeContext), nullString(ad.EngineResumeMetadata),
 	)
 	if err != nil {
@@ -534,11 +542,20 @@ const applyOperationHeartbeatStaleness = "1 MINUTE"
 // sibling of the same apply (lower created_at, id) has reached completed.
 // This serializes a multi-deployment apply along its deployment_order — the
 // order materialized by the apply-create dual-write into row insertion order
-// — and halts the rollout on the first non-completed sibling (e.g. a failed
-// deployment), since any earlier non-completed row blocks every later one.
-// The gate applies only to starting a pending row; an already-active row
-// re-leasing a stale heartbeat is recovering work it already started, so it
-// is never re-gated.
+// — so deployments roll out in order. The gate applies only to starting a
+// pending row; an already-active row re-leasing a stale heartbeat is
+// recovering work it already started, so it is never re-gated.
+//
+// halt_on_failure (per-apply policy, captured on each row at create): when
+// true (the default), an earlier sibling that is anything other than
+// completed — including terminal-failed — blocks every later sibling, so the
+// rollout halts on the first failure. When false, a terminal-failed earlier
+// sibling is treated as settled and no longer blocks: later deployments are
+// still claimed and attempted. Only terminal `failed` is exempted — pending,
+// running, failed_retryable, and stopped earlier siblings still block under
+// both policies (work is in-flight or recoverable). The policy governs only
+// rollout continuation; the apply's pass/fail verdict and the merge gate stay
+// fail-closed on any failed deployment.
 //
 // Mirrors ApplyStore.FindNextApply: SELECT ... FOR UPDATE SKIP LOCKED to
 // avoid worker races, READ COMMITTED isolation to prevent next-key range
@@ -562,7 +579,7 @@ func (s *applyOperationStore) FindNextApplyOperation(ctx context.Context, owner 
 	activeStates := claimableApplyStates()
 	activeStatePlaceholders := placeholders(len(activeStates))
 
-	queryArgs := []any{state.ApplyOperation.Pending, state.ApplyOperation.Completed}
+	queryArgs := []any{state.ApplyOperation.Pending, state.ApplyOperation.Completed, state.ApplyOperation.Failed}
 	queryArgs = append(queryArgs, stringArgs(activeStates)...)
 	queryArgs = append(queryArgs,
 		state.ApplyOperation.Stopped,
@@ -618,6 +635,7 @@ func (s *applyOperationStore) FindNextApplyOperation(ctx context.Context, owner 
 					WHERE earlier.apply_id = apply_operations.apply_id
 						AND (earlier.created_at, earlier.id) < (apply_operations.created_at, apply_operations.id)
 						AND earlier.state <> ?
+						AND NOT (apply_operations.halt_on_failure = 0 AND earlier.state = ?)
 				)
 			)
 			OR (state IN (%s) AND updated_at < NOW() - INTERVAL %s)
@@ -801,14 +819,18 @@ func scanApplyOperationInto(s scanner) (*storage.ApplyOperation, error) {
 	var errMsg sql.NullString
 	var engineResumeContext, engineResumeMetadata sql.NullString
 	var startedAt, completedAt, leaseAcquiredAt sql.NullTime
+	var haltOnFailure bool
 
 	if err := s.Scan(
 		&ad.ID, &ad.ApplyID, &ad.Deployment, &ad.Target, &ad.State, &errMsg,
-		&ad.CutoverPolicy, &startedAt, &completedAt, &ad.LeaseOwner, &ad.LeaseToken, &leaseAcquiredAt,
+		&ad.CutoverPolicy, &haltOnFailure, &startedAt, &completedAt, &ad.LeaseOwner, &ad.LeaseToken, &leaseAcquiredAt,
 		&engineResumeContext, &engineResumeMetadata, &ad.CreatedAt, &ad.UpdatedAt,
 	); err != nil {
 		return nil, err
 	}
+
+	// The column is NOT NULL, so a stored row always carries an explicit policy.
+	ad.HaltOnFailure = &haltOnFailure
 
 	if errMsg.Valid {
 		ad.ErrorMessage = errMsg.String

--- a/pkg/storage/mysqlstore/apply_operations_test.go
+++ b/pkg/storage/mysqlstore/apply_operations_test.go
@@ -1149,6 +1149,92 @@ func TestApplyOperationStore_FindNextApplyOperation_HaltsOnFailedSibling(t *test
 	assert.Nil(t, claimed, "later siblings must not be claimed once an earlier deployment failed")
 }
 
+// TestApplyOperationStore_FindNextApplyOperation_HaltOnFailureDisabledClaimsPastFailedSibling
+// verifies that when an apply's halt_on_failure policy is disabled, a
+// terminal-failed earlier deployment no longer blocks later siblings: the
+// rollout continues and the next ordered deployment is claimed instead of
+// stalling at the first failure. Only terminal `failed` is exempted — the
+// policy controls rollout continuation, not the apply's verdict.
+func TestApplyOperationStore_FindNextApplyOperation_HaltOnFailureDisabledClaimsPastFailedSibling(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", "mysql", "staging")
+	apply := createTestApply(t, store, lock, "apply_op_no_halt", 1)
+
+	// region-a failed; region-b and region-c are pending behind it. With
+	// halt_on_failure disabled on every row, the failed sibling is treated as
+	// settled and the rollout proceeds to region-b.
+	noHalt := false
+	failedID, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-a", State: state.ApplyOperation.Failed, HaltOnFailure: &noHalt,
+	})
+	require.NoError(t, err)
+	for _, deployment := range []string{"region-b", "region-c"} {
+		_, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+			ApplyID: apply.ID, Deployment: deployment, HaltOnFailure: &noHalt,
+		})
+		require.NoError(t, err)
+	}
+
+	// Backdate the failed row so staleness can't be the reason it's skipped.
+	_, err = testDB.ExecContext(ctx, `
+		UPDATE apply_operations SET updated_at = NOW() - INTERVAL 1 HOUR WHERE id = ?
+	`, failedID)
+	require.NoError(t, err)
+
+	claimed, err := store.ApplyOperations().FindNextApplyOperation(ctx, "test-operator")
+	require.NoError(t, err)
+	require.NotNil(t, claimed, "halt_on_failure disabled must let the rollout proceed past a failed sibling")
+	assert.Equal(t, "region-b", claimed.Deployment, "the next ordered deployment after the failed one is claimed")
+	assert.Equal(t, "test-operator", claimed.LeaseOwner, "claim must record the lease owner")
+
+	// The pending → running transition is persisted on the row, even though the
+	// returned struct reflects the pre-claim state read by the SELECT.
+	stored, err := store.ApplyOperations().Get(ctx, claimed.ID)
+	require.NoError(t, err)
+	assert.Equal(t, state.ApplyOperation.Running, stored.State, "the claimed pending row is transitioned to running")
+}
+
+// TestApplyOperationStore_FindNextApplyOperation_HaltOnFailureDisabledStillBlocksOnRunningSibling
+// verifies that disabling halt_on_failure only exempts terminal `failed` — an
+// earlier sibling that is still in-flight (running) continues to block later
+// deployments, because reordering around work that has not settled would race
+// the rollout.
+func TestApplyOperationStore_FindNextApplyOperation_HaltOnFailureDisabledStillBlocksOnRunningSibling(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", "mysql", "staging")
+	apply := createTestApply(t, store, lock, "apply_op_no_halt_running", 1)
+
+	// region-a is running (fresh, so not stale-claimable); region-b is pending
+	// behind it. Even with halt_on_failure disabled, an in-flight sibling gates
+	// the later pending one — only terminal failure is exempted.
+	noHalt := false
+	runningID, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-a", State: state.ApplyOperation.Running, HaltOnFailure: &noHalt,
+	})
+	require.NoError(t, err)
+	_, err = store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-b", HaltOnFailure: &noHalt,
+	})
+	require.NoError(t, err)
+
+	// Keep region-a fresh so it is not stale-reclaimable; the only thing that
+	// could surface region-b is the (absent) failure exemption.
+	_, err = testDB.ExecContext(ctx, `
+		UPDATE apply_operations SET updated_at = NOW() WHERE id = ?
+	`, runningID)
+	require.NoError(t, err)
+
+	claimed, err := store.ApplyOperations().FindNextApplyOperation(ctx, "test-operator")
+	require.NoError(t, err)
+	assert.Nil(t, claimed, "a running earlier sibling still blocks even with halt_on_failure disabled")
+}
+
 // TestApplyOperationStore_FindNextApplyOperation_PendingStartRequestDoesNotBypassSiblingGate
 // verifies that a parent apply's pending start request does not let a later
 // pending deployment jump the deployment-order gate. Start requests resume

--- a/pkg/storage/types.go
+++ b/pkg/storage/types.go
@@ -466,6 +466,21 @@ type ApplyOperation struct {
 	// an empty value as "rolling", matching the column's NOT NULL DEFAULT.
 	CutoverPolicy string
 
+	// HaltOnFailure is the rollout policy captured for this operation's parent
+	// apply at apply-create time, drawn from the resolved environment config.
+	// When true, a failed earlier sibling blocks every later deployment of the
+	// same apply — the rollout stops at the first failure. When false, a
+	// terminal-failed earlier sibling no longer blocks later siblings, so the
+	// rollout attempts every deployment instead of halting. It governs only
+	// rollout continuation, never the apply's pass/fail verdict or the merge
+	// gate, which stay fail-closed on any failed deployment.
+	//
+	// A pointer so an unset value is distinguishable from an explicit false:
+	// Insert treats nil as halt-on-failure (the safe default, matching the
+	// column's NOT NULL DEFAULT 1), so a caller that omits the policy never
+	// silently degrades to the less-safe non-halting behaviour.
+	HaltOnFailure *bool
+
 	// StartedAt is when the operator claimed this child row and execution began.
 	StartedAt *time.Time
 


### PR DESCRIPTION
## What and Why ?

Adds a `halt_on_failure` rollout policy (per database + environment) that
controls whether a failed deployment halts the rest of a multi-deployment
apply. It defaults to `true` (halt), preserving today's stop-at-first-failure
behaviour. When disabled, a terminal-`failed` earlier deployment no longer
blocks later ones, so the rollout attempts every deployment instead of
stopping at the first failure.

The policy governs **rollout continuation only**. The apply's pass/fail
verdict (`DeriveApplyState`) and the merge/check gate stay fail-closed on any
failed deployment — `halt_on_failure=false` means "attempt later deployments
even after one fails", never "treat a failed rollout as passing".

`FindNextApplyOperation` is a single global claim query with no per-call
config, so the policy is captured on each `apply_operations` row at
apply-create time (dual-written from the resolved environment config) and read
back by the claim predicate.

### Claim gate: can the next deployment start, given its earlier sibling?

| earlier sibling state | `halt_on_failure=true` (default) | `halt_on_failure=false` |
|---|---|---|
| `completed` | ✅ later sibling claimable | ✅ later sibling claimable |
| `failed` (terminal) | ⛔ blocks later siblings | ✅ later sibling claimable |
| `pending` / `running` / `failed_retryable` / `stopped` | ⛔ blocks later siblings | ⛔ blocks later siblings |

Decision for the earlier sibling of the deployment we want to start:

    completed ──────────────────────────────────▶ later sibling claimable

    failed (terminal) ──┬─ halt_on_failure=true ──▶ blocks later siblings
                        └─ halt_on_failure=false ─▶ later sibling claimable   ◀ the only difference

    pending / running / ────────────────────────▶ blocks later siblings
    failed_retryable / stopped                       (both policies — work is
                                                      in-flight or recoverable)

Only terminal `failed` is exempted when the policy is off — in-flight or
recoverable earlier siblings still block under both policies.

## Changes

- `EnvironmentConfig.HaltOnFailure *bool` + `ServerConfig.HaltOnFailureEnabled()`
  resolver (defaults to halt); validated only alongside a `deployments` map.
- New `halt_on_failure` column on `apply_operations`, dual-written at apply create.
- `storage.ApplyOperation.HaltOnFailure *bool` (nil ⇒ Insert defaults to halt,
  matching the column's `NOT NULL DEFAULT 1`).
- Claim predicate exempts a terminal-`failed` earlier sibling when the policy
  is disabled.

## Notes

Stacked on #294: this edits `FindNextApplyOperation`, the same function the
operation-lease stack modifies, so stacking avoids a guaranteed rebase
conflict while that stack is in review. Rebases onto `main` naturally once it
lands.
