### PR TITLE
feat(api): add EnqueueAuthorizedApply for pre-authorized dispatches

### DIFF
--- a/pkg/api/enqueue_authorized_apply_integration_test.go
+++ b/pkg/api/enqueue_authorized_apply_integration_test.go
@@ -1,0 +1,157 @@
+//go:build integration
+
+package api
+
+import (
+	"database/sql"
+	"errors"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/block/spirit/pkg/utils"
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/modules/mysql"
+
+	"github.com/block/schemabot/pkg/state"
+	"github.com/block/schemabot/pkg/storage"
+	"github.com/block/schemabot/pkg/storage/mysqlstore"
+	"github.com/block/schemabot/pkg/tern"
+	"github.com/block/schemabot/pkg/testutil"
+)
+
+// A data-plane host queues control-plane-authorized dispatches through
+// EnqueueAuthorizedApply against real storage. The queued apply must be durable (apply,
+// task, and operation rows committed in one transaction), claimable by an
+// operator worker, and covered by the one-active-apply-per-target invariant —
+// while the gated ExecuteApply path on the same service keeps failing closed
+// because the deployment has no database config to evaluate source policy
+// against.
+func TestEnqueueAuthorizedApplyQueuesDurableApplyAgainstStorage(t *testing.T) {
+	ctx := t.Context()
+
+	container, err := mysql.Run(ctx,
+		"mysql:8.0",
+		mysql.WithDatabase("schemabot_test"),
+		mysql.WithUsername("root"),
+		mysql.WithPassword("test"),
+	)
+	require.NoError(t, err, "failed to start mysql")
+	t.Cleanup(func() {
+		if err := testcontainers.TerminateContainer(container); err != nil {
+			t.Logf("failed to terminate container: %v", err)
+		}
+	})
+
+	dsn, err := testutil.ContainerConnectionString(ctx, container, "parseTime=true")
+	require.NoError(t, err, "failed to get connection string")
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	require.NoError(t, EnsureSchema(dsn, logger), "failed to ensure schema")
+
+	db, err := sql.Open("mysql", dsn)
+	require.NoError(t, err, "failed to open database")
+	require.NoError(t, db.PingContext(ctx), "failed to ping database")
+	t.Cleanup(func() { utils.CloseAndLog(db) })
+
+	stor := mysqlstore.New(db)
+
+	plan := &storage.Plan{
+		PlanIdentifier: "plan-enqueue-integration",
+		Database:       "testdb",
+		DatabaseType:   storage.DatabaseTypeMySQL,
+		Deployment:     "default",
+		Target:         "testdb-staging-target",
+		Repository:     "octocat/hello-world",
+		PullRequest:    1,
+		SchemaPath:     "schema/testdb",
+		Environment:    "staging",
+		Namespaces: map[string]*storage.NamespacePlanData{
+			"testdb": {
+				Tables: []storage.TableChange{
+					{
+						Namespace: "testdb",
+						Table:     "users",
+						DDL:       "ALTER TABLE users ADD COLUMN email varchar(255)",
+						Operation: "alter",
+					},
+				},
+			},
+		},
+		CreatedAt: time.Now(),
+	}
+	_, err = stor.Plans().Create(ctx, plan)
+	require.NoError(t, err, "failed to store trusted plan")
+
+	cfg := &ServerConfig{
+		TernDeployments: TernConfig{
+			"default": {"staging": "localhost:9090"},
+		},
+	}
+	mockClient := &mockTernClient{isRemote: true}
+	svc := New(stor, cfg, map[string]tern.Client{"default/staging": mockClient}, logger)
+
+	// The gated path fails closed: this deployment has no database config to
+	// evaluate the trusted plan's source against.
+	_, _, err = svc.ExecuteApply(ctx, ApplyRequest{
+		PlanID:      plan.PlanIdentifier,
+		Environment: "staging",
+	})
+	var policyErr *SourcePolicyError
+	require.True(t, errors.As(err, &policyErr), "ExecuteApply must fail closed without database config")
+	assert.Equal(t, SourcePolicyReasonMissingDatabaseConfig, policyErr.Reason)
+
+	resp, applyID, err := svc.EnqueueAuthorizedApply(ctx, ApplyRequest{
+		PlanID:      plan.PlanIdentifier,
+		Environment: "staging",
+		Caller:      "control-plane",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.True(t, resp.Accepted)
+	require.Positive(t, applyID)
+
+	apply, err := stor.Applies().Get(ctx, applyID)
+	require.NoError(t, err)
+	require.NotNil(t, apply)
+	assert.Equal(t, state.Apply.Pending, apply.State)
+	assert.Equal(t, "testdb", apply.Database)
+	assert.Equal(t, "staging", apply.Environment)
+	assert.Equal(t, "default", apply.Deployment)
+	assert.Equal(t, "testdb-staging-target", apply.GetOptions().Target)
+	assert.Equal(t, resp.ApplyID, apply.ApplyIdentifier)
+
+	tasks, err := stor.Tasks().GetByApplyID(ctx, applyID)
+	require.NoError(t, err)
+	require.Len(t, tasks, 1)
+	assert.Equal(t, state.Task.Pending, tasks[0].State)
+	assert.Equal(t, "users", tasks[0].TableName)
+	assert.Contains(t, tasks[0].DDL, "ADD COLUMN")
+	assert.Contains(t, tasks[0].DDL, "email")
+
+	operations, err := stor.ApplyOperations().ListByApply(ctx, applyID)
+	require.NoError(t, err)
+	require.Len(t, operations, 1)
+	assert.Equal(t, "default", operations[0].Deployment)
+	assert.Equal(t, "testdb-staging-target", operations[0].Target)
+
+	// One active apply per target: a second dispatch is rejected while the
+	// first is still pending.
+	_, _, err = svc.EnqueueAuthorizedApply(ctx, ApplyRequest{
+		PlanID:      plan.PlanIdentifier,
+		Environment: "staging",
+	})
+	require.ErrorIs(t, err, storage.ErrActiveApplyExists)
+
+	// The committed apply and task rows make the queued apply claimable by an
+	// operator worker.
+	claimed, err := stor.Applies().FindNextApply(ctx, "worker-test")
+	require.NoError(t, err)
+	require.NotNil(t, claimed, "queued apply must be operator-claimable")
+	assert.Equal(t, applyID, claimed.ID)
+	assert.Equal(t, state.Apply.Pending, claimed.State)
+}

--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -628,13 +628,17 @@ func stoppedTestApply(applyID string) *storage.Apply {
 }
 
 func newExecuteApplyTestService(client tern.Client, applies storage.ApplyStore) (*Service, *capturingTaskStore) {
+	return newQueueApplyTestService(executeApplyTestPlan(), client, applies)
+}
+
+func newQueueApplyTestService(plan *storage.Plan, client tern.Client, applies storage.ApplyStore) (*Service, *capturingTaskStore) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
 	tasks := &capturingTaskStore{}
 	if capturingApplies, ok := applies.(*capturingApplyStore); ok {
 		capturingApplies.taskStore = tasks
 	}
 	return New(&mockStorageWithApplyStores{
-		plans:     &staticPlanStore{plan: executeApplyTestPlan()},
+		plans:     &staticPlanStore{plan: plan},
 		applies:   applies,
 		tasks:     tasks,
 		locks:     &emptyLockStore{},
@@ -972,6 +976,147 @@ func TestExecuteApplySourcePolicyBlocksMissingDatabaseConfig(t *testing.T) {
 	var policyErr *SourcePolicyError
 	require.True(t, errors.As(err, &policyErr), "expected SourcePolicyError")
 	assert.Equal(t, SourcePolicyReasonMissingDatabaseConfig, policyErr.Reason)
+}
+
+// trustedQueueApplyTestPlan returns a stored plan created from the trusted PR
+// discovery path (repository, pull request, and schema path recorded) so
+// queue-path tests can exercise source-policy behavior.
+func trustedQueueApplyTestPlan() *storage.Plan {
+	plan := executeApplyTestPlan()
+	plan.Repository = "octocat/hello-world"
+	plan.PullRequest = 1
+	plan.SchemaPath = "schema/testdb"
+	return plan
+}
+
+// A data-plane deployment executes applies dispatched by a control plane that
+// already evaluated source policy against its own database config. The data
+// plane has no database config of its own, so EnqueueAuthorizedApply queues the trusted
+// plan without re-evaluating source policy, while ExecuteApply on the same
+// service keeps failing closed.
+func TestEnqueueAuthorizedApplyQueuesTrustedPlanWithoutDatabaseConfig(t *testing.T) {
+	applies := &capturingApplyStore{}
+	mockClient := &mockTernClient{isRemote: true}
+	svc, tasks := newQueueApplyTestService(trustedQueueApplyTestPlan(), mockClient, applies)
+
+	_, _, err := svc.ExecuteApply(t.Context(), ApplyRequest{
+		PlanID:      "plan-1",
+		Environment: "staging",
+	})
+	var policyErr *SourcePolicyError
+	require.True(t, errors.As(err, &policyErr), "ExecuteApply must fail closed without database config")
+	assert.Equal(t, SourcePolicyReasonMissingDatabaseConfig, policyErr.Reason)
+
+	resp, applyID, err := svc.EnqueueAuthorizedApply(t.Context(), ApplyRequest{
+		PlanID:      "plan-1",
+		Environment: "staging",
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.True(t, resp.Accepted)
+	assert.Equal(t, int64(123), applyID)
+	assert.Nil(t, mockClient.applyReq, "queued apply must wait for operator dispatch")
+	require.NotNil(t, applies.apply)
+	assert.Equal(t, state.Apply.Pending, applies.apply.State)
+	assert.Equal(t, "testdb", applies.apply.GetOptions().Target)
+	require.Len(t, tasks.tasks, 1)
+	assert.Equal(t, state.Task.Pending, tasks.tasks[0].State)
+	assert.Equal(t, "users", tasks.tasks[0].TableName)
+}
+
+// EnqueueAuthorizedApply skips only source policy. Execution invariants still reject a
+// dispatch whose stored plan was created for a different environment.
+func TestEnqueueAuthorizedApplyRejectsEnvironmentMismatch(t *testing.T) {
+	applies := &capturingApplyStore{}
+	mockClient := &mockTernClient{isRemote: true}
+	svc, tasks := newQueueApplyTestService(trustedQueueApplyTestPlan(), mockClient, applies)
+
+	resp, applyID, err := svc.EnqueueAuthorizedApply(t.Context(), ApplyRequest{
+		PlanID:      "plan-1",
+		Environment: "production",
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `created for environment "staging"`)
+	assert.Nil(t, resp)
+	assert.Zero(t, applyID)
+	assert.Nil(t, applies.apply, "mismatched environment must not store an apply")
+	assert.Empty(t, tasks.tasks)
+}
+
+// EnqueueAuthorizedApply enforces the same stored-plan execution invariants as gated
+// applies: the plan must exist and carry server-side routing metadata.
+func TestEnqueueAuthorizedApplyRejectsInvalidStoredPlan(t *testing.T) {
+	missingDeployment := trustedQueueApplyTestPlan()
+	missingDeployment.Deployment = ""
+	missingTarget := trustedQueueApplyTestPlan()
+	missingTarget.Target = ""
+
+	tests := []struct {
+		name    string
+		plan    *storage.Plan
+		wantErr string
+	}{
+		{name: "plan not found", plan: nil, wantErr: "plan not found"},
+		{name: "missing deployment", plan: missingDeployment, wantErr: `missing server-side routing metadata field "deployment"`},
+		{name: "missing target", plan: missingTarget, wantErr: `missing server-side routing metadata field "target"`},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			applies := &capturingApplyStore{}
+			svc, tasks := newQueueApplyTestService(tc.plan, &mockTernClient{}, applies)
+
+			resp, applyID, err := svc.EnqueueAuthorizedApply(t.Context(), ApplyRequest{
+				PlanID:      "plan-1",
+				Environment: "staging",
+			})
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErr)
+			assert.Nil(t, resp)
+			assert.Zero(t, applyID)
+			assert.Nil(t, applies.apply, "invalid stored plan must not store an apply")
+			assert.Empty(t, tasks.tasks)
+		})
+	}
+}
+
+// A queued trusted dispatch follows the same durable operator path as gated
+// applies: EnqueueAuthorizedApply stores the pending apply, wakes a worker, and the
+// worker claims and resumes it.
+func TestEnqueueAuthorizedApplyWakesOperatorForQueuedApply(t *testing.T) {
+	applies := &capturingApplyStore{findCh: make(chan struct{}, 1)}
+	mock := &mockTernClient{resumeCh: make(chan *storage.Apply, 1)}
+	svc, _ := newQueueApplyTestService(trustedQueueApplyTestPlan(), mock, applies)
+	svc.config.OperatorWorkers = 1
+	require.NoError(t, svc.SetOperatorPollInterval(time.Hour))
+	svc.StartOperator(t.Context())
+	t.Cleanup(svc.StopOperator)
+
+	select {
+	case <-applies.findCh:
+	case <-time.After(2 * time.Second):
+		require.Fail(t, "operator did not perform startup claim")
+	}
+
+	resp, applyID, err := svc.EnqueueAuthorizedApply(t.Context(), ApplyRequest{
+		PlanID:      "plan-1",
+		Environment: "staging",
+	})
+
+	require.NoError(t, err)
+	require.True(t, resp.Accepted)
+	assert.Equal(t, int64(123), applyID)
+
+	select {
+	case resumedApply := <-mock.resumeCh:
+		assert.Equal(t, int64(123), resumedApply.ID)
+		assert.Equal(t, state.Apply.Pending, resumedApply.State)
+		assert.Equal(t, "testdb", resumedApply.Database)
+	case <-time.After(2 * time.Second):
+		require.Fail(t, "operator did not resume queued apply after wake")
+	}
 }
 
 func TestPlanHandlerRejectsClientSuppliedSchemaPath(t *testing.T) {

--- a/pkg/api/plan_handlers.go
+++ b/pkg/api/plan_handlers.go
@@ -377,18 +377,73 @@ func (s *Service) ExecuteApply(ctx context.Context, req ApplyRequest) (*apitypes
 	)
 	defer span.End()
 
+	plan, err := s.loadPlanForApply(ctx, span, req)
+	if err != nil {
+		return nil, 0, err
+	}
+	if err := s.authorizeStoredPlanSource(ctx, span, plan, req); err != nil {
+		return nil, 0, err
+	}
+	return s.queueValidatedApply(ctx, span, plan, req)
+}
+
+// EnqueueAuthorizedApply queues an apply for a stored plan without evaluating
+// source policy. The caller asserts that source authorization for this apply
+// already happened — for example, a control plane that evaluated source policy
+// against its own database config before dispatching to this deployment, or a
+// host process that gates its own callers.
+//
+// This entry point exists because source policy can only be evaluated where
+// the database config lives. A deployment that executes applies dispatched by
+// a separate control plane has no database config, so re-evaluating the
+// policy there can only fail closed.
+//
+// It is intentionally not reachable from SchemaBot's HTTP API. All execution
+// invariants still apply: the plan must exist, match the requested
+// environment, and carry stored routing metadata, and storage still enforces
+// one active apply per target.
+func (s *Service) EnqueueAuthorizedApply(ctx context.Context, req ApplyRequest) (*apitypes.ApplyResponse, int64, error) {
+	ctx, span := otel.Tracer("schemabot").Start(ctx, "EnqueueAuthorizedApply",
+		trace.WithAttributes(
+			attribute.String("plan_id", req.PlanID),
+			attribute.String("environment", req.Environment),
+		),
+	)
+	defer span.End()
+
+	plan, err := s.loadPlanForApply(ctx, span, req)
+	if err != nil {
+		return nil, 0, err
+	}
+	s.logger.Info("queueing apply without source policy evaluation; caller asserted source authorization",
+		"plan_id", req.PlanID,
+		"database", plan.Database,
+		"deployment", plan.Deployment,
+		"environment", req.Environment,
+		"repository", plan.Repository,
+		"pull_request", plan.PullRequest,
+		"schema_path", plan.SchemaPath,
+		"caller", req.Caller)
+	return s.queueValidatedApply(ctx, span, plan, req)
+}
+
+// loadPlanForApply loads the stored plan for an apply request and enforces the
+// execution invariants every queue path requires: the plan exists, was created
+// for the requested environment, and carries the server-side routing metadata
+// (deployment, target) the operator needs to dispatch it.
+func (s *Service) loadPlanForApply(ctx context.Context, span trace.Span, req ApplyRequest) (*storage.Plan, error) {
 	// Load plan first; it is the source of truth for database, type, and routing.
 	plan, err := s.storage.Plans().Get(ctx, req.PlanID)
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(otelcodes.Error, "get plan")
-		return nil, 0, fmt.Errorf("get plan: %w", err)
+		return nil, fmt.Errorf("get plan: %w", err)
 	}
 	if plan == nil {
 		planErr := fmt.Errorf("plan not found: %s", req.PlanID)
 		span.RecordError(planErr)
 		span.SetStatus(otelcodes.Error, "plan not found")
-		return nil, 0, planErr
+		return nil, planErr
 	}
 	span.SetAttributes(attribute.String("database", plan.Database))
 	if plan.Environment != req.Environment {
@@ -396,26 +451,31 @@ func (s *Service) ExecuteApply(ctx context.Context, req ApplyRequest) (*apitypes
 		span.RecordError(applyErr)
 		span.SetStatus(otelcodes.Error, "environment mismatch")
 		metrics.RecordApply(ctx, plan.Repository, plan.Database, plan.Deployment, req.Environment, "error")
-		return nil, 0, applyErr
+		return nil, applyErr
 	}
 	if plan.Deployment == "" {
 		applyErr := fmt.Errorf("plan %s is missing server-side routing metadata field %q; create a new plan and retry apply", req.PlanID, "deployment")
 		span.RecordError(applyErr)
 		span.SetStatus(otelcodes.Error, "missing stored deployment")
 		metrics.RecordApply(ctx, plan.Repository, plan.Database, plan.Deployment, req.Environment, "error")
-		return nil, 0, applyErr
+		return nil, applyErr
 	}
 	if plan.Target == "" {
 		applyErr := fmt.Errorf("plan %s is missing server-side routing metadata field %q; create a new plan and retry apply", req.PlanID, "target")
 		span.RecordError(applyErr)
 		span.SetStatus(otelcodes.Error, "missing stored target")
 		metrics.RecordApply(ctx, plan.Repository, plan.Database, plan.Deployment, req.Environment, "error")
-		return nil, 0, applyErr
+		return nil, applyErr
 	}
-	// Source policy is evaluated for plans created from SchemaBot's trusted
-	// GitHub PR discovery path. Direct operator/API plans do not have a
-	// server-discovered schema path today; those remain governed by endpoint
-	// access until the dedicated auth layer is added.
+	return plan, nil
+}
+
+// authorizeStoredPlanSource evaluates source policy for a stored plan before
+// it is queued. Source policy is evaluated for plans created from SchemaBot's
+// trusted GitHub PR discovery path. Direct operator/API plans do not have a
+// server-discovered schema path today; those remain governed by endpoint
+// access until the dedicated auth layer is added.
+func (s *Service) authorizeStoredPlanSource(ctx context.Context, span trace.Span, plan *storage.Plan, req ApplyRequest) error {
 	if plan.SchemaPath == "" {
 		s.logger.Debug("skipping source policy for apply because stored plan has no trusted schema path",
 			"plan_id", req.PlanID,
@@ -424,32 +484,38 @@ func (s *Service) ExecuteApply(ctx context.Context, req ApplyRequest) (*apitypes
 			"environment", req.Environment,
 			"repository", plan.Repository,
 			"pull_request", plan.PullRequest)
-	} else {
-		if err := s.config.AuthorizePlanSource(PlanSourcePolicyRequest{
-			Database:    plan.Database,
-			Repository:  plan.Repository,
-			PullRequest: plan.PullRequest,
-			SchemaPath:  plan.SchemaPath,
-		}); err != nil {
-			reason := sourcePolicyReason(err)
-			span.RecordError(err)
-			span.SetStatus(otelcodes.Error, "source policy")
-			metrics.RecordApply(ctx, plan.Repository, plan.Database, plan.Deployment, req.Environment, "error")
-			metrics.RecordSourcePolicyBlock(ctx, "apply", plan.Database, req.Environment, reason)
-			s.logger.Warn("apply blocked by source policy",
-				"plan_id", req.PlanID,
-				"database", plan.Database,
-				"deployment", plan.Deployment,
-				"environment", req.Environment,
-				"repository", plan.Repository,
-				"pull_request", plan.PullRequest,
-				"schema_path", plan.SchemaPath,
-				"reason", reason,
-				"error", err)
-			return nil, 0, fmt.Errorf("source policy for plan %s: %w", req.PlanID, err)
-		}
+		return nil
 	}
+	if err := s.config.AuthorizePlanSource(PlanSourcePolicyRequest{
+		Database:    plan.Database,
+		Repository:  plan.Repository,
+		PullRequest: plan.PullRequest,
+		SchemaPath:  plan.SchemaPath,
+	}); err != nil {
+		reason := sourcePolicyReason(err)
+		span.RecordError(err)
+		span.SetStatus(otelcodes.Error, "source policy")
+		metrics.RecordApply(ctx, plan.Repository, plan.Database, plan.Deployment, req.Environment, "error")
+		metrics.RecordSourcePolicyBlock(ctx, "apply", plan.Database, req.Environment, reason)
+		s.logger.Warn("apply blocked by source policy",
+			"plan_id", req.PlanID,
+			"database", plan.Database,
+			"deployment", plan.Deployment,
+			"environment", req.Environment,
+			"repository", plan.Repository,
+			"pull_request", plan.PullRequest,
+			"schema_path", plan.SchemaPath,
+			"reason", reason,
+			"error", err)
+		return fmt.Errorf("source policy for plan %s: %w", req.PlanID, err)
+	}
+	return nil
+}
 
+// queueValidatedApply stores the pending apply and tasks for a validated plan
+// and wakes an operator worker. Callers must have run loadPlanForApply first;
+// gated entry points also run authorizeStoredPlanSource before queueing.
+func (s *Service) queueValidatedApply(ctx context.Context, span trace.Span, plan *storage.Plan, req ApplyRequest) (*apitypes.ApplyResponse, int64, error) {
 	deployment := plan.Deployment
 
 	client, err := s.TernClient(deployment, req.Environment)


### PR DESCRIPTION
## Summary

Deployments that execute applies dispatched by a separate control plane re-ran the source-policy gate through `ExecuteApply` — but source policy can only be evaluated where the database config lives, so a deployment without that config fails every dispatched apply closed with `database ... source policy could not be evaluated because database config is missing`.

This decomposes the queue path so the gate runs exactly once, where the config lives:

```
ExecuteApply           = loadPlanForApply + authorizeStoredPlanSource + queueValidatedApply
EnqueueAuthorizedApply = loadPlanForApply +                             queueValidatedApply
```

- `ExecuteApply` (HTTP API, webhook) is unchanged: it still fails closed when source policy cannot be evaluated.
- `EnqueueAuthorizedApply` is a new Go-level entry point for hosts queueing applies whose source authorization already happened upstream — e.g. a control plane that evaluated source policy against its own database config before dispatching, or an embedding host that gates its own callers. The caller asserts that authorization; the method logs the assertion with the caller identity and keeps every execution invariant: plan existence, environment match, stored routing metadata, and storage's one-active-apply-per-target guarantee. It is not reachable from the HTTP API.

---
*This PR was generated by Amp (claude-fable-5).*