### PR TITLE
feat(github): retry webhook plan requests after transient remote unavailability

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -267,6 +267,30 @@ func RecordStalePlanRejected(ctx context.Context, environment string) {
 	)
 }
 
+// RecordTransientPlanRetry increments the counter for webhook plan retries
+// after transient remote deployment unavailability. A spike with
+// outcome="exhausted" for one environment means the network path to that
+// remote deployment is down rather than flapping — investigate the
+// connectivity between this server and the deployment.
+func RecordTransientPlanRetry(ctx context.Context, database, environment, outcome string) {
+	meter := otel.Meter(meterName)
+	counter, err := meter.Int64Counter("schemabot.webhook.plan_transient_retry.total",
+		otelmetric.WithDescription("webhook plan retries after transient remote deployment unavailability"),
+		otelmetric.WithUnit("{retry}"),
+	)
+	if err != nil {
+		slog.Warn("failed to create transient plan retry counter", "error", err)
+		return
+	}
+	counter.Add(ctx, 1,
+		otelmetric.WithAttributes(
+			attribute.String("database", database),
+			EnvironmentAttribute(environment),
+			attribute.String("outcome", outcome),
+		),
+	)
+}
+
 var knownSourcePolicyOperations = map[string]bool{
 	"plan":  true,
 	"apply": true,

--- a/pkg/webhook/apply_execute.go
+++ b/pkg/webhook/apply_execute.go
@@ -43,7 +43,7 @@ func (h *Handler) executeApply(
 		SourceTrusted: true,
 	}
 
-	planResp, err := h.service.ExecutePlan(ctx, planReq)
+	planResp, err := h.executePlanWithTransientRetry(ctx, planReq, repo, pr)
 	if err != nil {
 		h.logger.Error("plan execution failed on confirm", "repo", repo, "pr", pr, "error", err)
 		h.postCommandError(repo, pr, installationID, action.Apply, environment, requestedBy, err.Error())

--- a/pkg/webhook/apply_handlers.go
+++ b/pkg/webhook/apply_handlers.go
@@ -144,7 +144,7 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 		SourceTrusted: true,
 	}
 
-	planResp, err := h.service.ExecutePlan(ctx, planReq)
+	planResp, err := h.executePlanWithTransientRetry(ctx, planReq, repo, pr)
 	if err != nil {
 		h.logger.Error("plan execution failed", "repo", repo, "pr", pr, "error", err)
 		h.postCommandError(repo, pr, installationID, action.Apply, environment, requestedBy, err.Error())

--- a/pkg/webhook/handler.go
+++ b/pkg/webhook/handler.go
@@ -73,6 +73,11 @@ type Handler struct {
 	service   *api.Service
 	ghClients github.ClientSet
 
+	// transientPlanRetryDelay overrides the pause before retrying a plan
+	// request that failed with transient remote unavailability. Zero means
+	// the package default.
+	transientPlanRetryDelay time.Duration
+
 	// webhookSecretsByApp maps each configured App's logical name to its
 	// HMAC webhook secret. In legacy single-App mode there is exactly one
 	// entry under defaultAppName. In multi-App mode there is one entry per

--- a/pkg/webhook/plan_retry.go
+++ b/pkg/webhook/plan_retry.go
@@ -1,0 +1,93 @@
+package webhook
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+
+	"github.com/block/schemabot/pkg/api"
+	"github.com/block/schemabot/pkg/apitypes"
+	"github.com/block/schemabot/pkg/metrics"
+)
+
+// defaultTransientPlanRetryDelay is the pause before retrying a plan request
+// that failed with transient remote unavailability. Webhook commands respond
+// asynchronously through PR comments, so a short wait is invisible to the
+// user, and it gives the network path time to recover beyond the gRPC
+// client's own sub-second retry budget.
+const defaultTransientPlanRetryDelay = 3 * time.Second
+
+// isTransientRemotePlanError reports whether a plan failure means the remote
+// deployment was unreachable (a retryable transport condition) rather than a
+// policy, validation, or planning failure.
+func isTransientRemotePlanError(err error) bool {
+	var remoteErr *api.RemoteDeploymentUnavailableError
+	if errors.As(err, &remoteErr) {
+		return true
+	}
+	return grpcstatus.Code(err) == grpccodes.Unavailable
+}
+
+func (h *Handler) planRetryDelay() time.Duration {
+	if h.transientPlanRetryDelay > 0 {
+		return h.transientPlanRetryDelay
+	}
+	return defaultTransientPlanRetryDelay
+}
+
+// executePlanWithTransientRetry runs ExecutePlan and retries once when the
+// failure is transient remote unavailability. Plan requests are safe to
+// re-send: each attempt produces an independent plan record and only the
+// returned plan ID is used. Every other failure class (policy, validation,
+// planning) is returned immediately without a retry.
+//
+// Failing a webhook command on a brief network blip costs the user the whole
+// command ceremony — for apply-confirm that means re-running apply and
+// confirming again. One delayed retry absorbs blips that outlast the gRPC
+// client's retry budget while still surfacing sustained outages within
+// seconds.
+func (h *Handler) executePlanWithTransientRetry(ctx context.Context, planReq api.PlanRequest, repo string, pr int) (*apitypes.PlanResponse, error) {
+	planResp, err := h.service.ExecutePlan(ctx, planReq)
+	if err == nil || !isTransientRemotePlanError(err) {
+		return planResp, err
+	}
+
+	delay := h.planRetryDelay()
+	h.logger.Warn("plan failed with transient remote unavailability; retrying once",
+		"repo", repo,
+		"pr", pr,
+		"database", planReq.Database,
+		"environment", planReq.Environment,
+		"retry_delay", delay,
+		"error", err)
+
+	select {
+	case <-ctx.Done():
+		return nil, fmt.Errorf("plan retry for %s/%s cancelled: %w", planReq.Database, planReq.Environment, ctx.Err())
+	case <-time.After(delay):
+	}
+
+	planResp, retryErr := h.service.ExecutePlan(ctx, planReq)
+	if retryErr != nil {
+		metrics.RecordTransientPlanRetry(ctx, planReq.Database, planReq.Environment, "exhausted")
+		h.logger.Error("plan retry failed; remote deployment is still unavailable",
+			"repo", repo,
+			"pr", pr,
+			"database", planReq.Database,
+			"environment", planReq.Environment,
+			"error", retryErr)
+		return nil, retryErr
+	}
+	metrics.RecordTransientPlanRetry(ctx, planReq.Database, planReq.Environment, "recovered")
+	h.logger.Info("plan retry recovered from transient remote unavailability",
+		"repo", repo,
+		"pr", pr,
+		"database", planReq.Database,
+		"environment", planReq.Environment,
+		"plan_id", planResp.PlanID)
+	return planResp, nil
+}

--- a/pkg/webhook/plan_retry.go
+++ b/pkg/webhook/plan_retry.go
@@ -65,10 +65,12 @@ func (h *Handler) executePlanWithTransientRetry(ctx context.Context, planReq api
 		"retry_delay", delay,
 		"error", err)
 
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
 	select {
 	case <-ctx.Done():
 		return nil, fmt.Errorf("plan retry for %s/%s cancelled: %w", planReq.Database, planReq.Environment, ctx.Err())
-	case <-time.After(delay):
+	case <-timer.C:
 	}
 
 	planResp, retryErr := h.service.ExecutePlan(ctx, planReq)

--- a/pkg/webhook/plan_retry_test.go
+++ b/pkg/webhook/plan_retry_test.go
@@ -1,0 +1,176 @@
+package webhook
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+
+	"github.com/block/schemabot/pkg/api"
+	ternv1 "github.com/block/schemabot/pkg/proto/ternv1"
+	"github.com/block/schemabot/pkg/storage"
+	"github.com/block/schemabot/pkg/tern"
+)
+
+// flakyPlanTernClient fails the first N plan calls with a configurable error
+// and then succeeds, simulating a transient transport failure in front of a
+// healthy remote deployment.
+type flakyPlanTernClient struct {
+	tern.Client
+	mu        sync.Mutex
+	planCalls int
+	failPlans int
+	planErr   error
+}
+
+func (c *flakyPlanTernClient) Plan(context.Context, *ternv1.PlanRequest) (*ternv1.PlanResponse, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.planCalls++
+	if c.planCalls <= c.failPlans {
+		return nil, c.planErr
+	}
+	return &ternv1.PlanResponse{PlanId: "plan-after-retry"}, nil
+}
+
+func (c *flakyPlanTernClient) IsRemote() bool   { return true }
+func (c *flakyPlanTernClient) Endpoint() string { return "remote:9090" }
+
+func (c *flakyPlanTernClient) calls() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.planCalls
+}
+
+type planRetryStorage struct {
+	emptyStorage
+}
+
+func (s *planRetryStorage) Plans() storage.PlanStore { return &noopPlanCreateStore{} }
+
+type noopPlanCreateStore struct {
+	storage.PlanStore
+}
+
+func (s *noopPlanCreateStore) Create(context.Context, *storage.Plan) (int64, error) { return 1, nil }
+func (s *noopPlanCreateStore) Get(context.Context, string) (*storage.Plan, error)   { return nil, nil }
+
+func newPlanRetryTestHandler(client tern.Client, retryDelay time.Duration) *Handler {
+	cfg := &api.ServerConfig{
+		Databases: map[string]api.DatabaseConfig{
+			"orders": {
+				Type: storage.DatabaseTypeMySQL,
+				Environments: map[string]api.EnvironmentConfig{
+					"staging": {Deployment: "remote", Target: "orders-target"},
+				},
+			},
+		},
+		TernDeployments: api.TernConfig{
+			"remote": {"staging": "remote:9090"},
+		},
+	}
+	svc := api.New(&planRetryStorage{}, cfg, map[string]tern.Client{"remote/staging": client}, testLogger())
+	return &Handler{
+		service:                 svc,
+		logger:                  testLogger(),
+		transientPlanRetryDelay: retryDelay,
+	}
+}
+
+func planRetryTestRequest() api.PlanRequest {
+	return api.PlanRequest{
+		Database:    "orders",
+		Environment: "staging",
+		Type:        storage.DatabaseTypeMySQL,
+		SchemaFiles: map[string]*ternv1.SchemaFiles{
+			"orders": {Files: map[string]string{
+				"users.sql": "CREATE TABLE users (id bigint unsigned NOT NULL AUTO_INCREMENT PRIMARY KEY)",
+			}},
+		},
+	}
+}
+
+// A brief remote outage during a webhook command's plan request is absorbed:
+// the handler retries once after the configured delay and the command flow
+// continues with the successful plan instead of posting a failure comment.
+func TestExecutePlanTransientRetryRecovers(t *testing.T) {
+	client := &flakyPlanTernClient{
+		failPlans: 1,
+		planErr:   grpcstatus.Error(grpccodes.Unavailable, "upstream connect error"),
+	}
+	h := newPlanRetryTestHandler(client, time.Millisecond)
+
+	resp, err := h.executePlanWithTransientRetry(t.Context(), planRetryTestRequest(), "octocat/hello-world", 1)
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, "plan-after-retry", resp.PlanID)
+	assert.Equal(t, 2, client.calls(), "handler should retry the failed plan attempt once")
+}
+
+// A sustained remote outage still surfaces within one retry: the handler does
+// not loop, and the caller posts the same operator-visible error it would
+// have without retries.
+func TestExecutePlanTransientRetryExhausted(t *testing.T) {
+	client := &flakyPlanTernClient{
+		failPlans: 10,
+		planErr:   grpcstatus.Error(grpccodes.Unavailable, "upstream connect error"),
+	}
+	h := newPlanRetryTestHandler(client, time.Millisecond)
+
+	resp, err := h.executePlanWithTransientRetry(t.Context(), planRetryTestRequest(), "octocat/hello-world", 1)
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	var remoteErr *api.RemoteDeploymentUnavailableError
+	require.True(t, errors.As(err, &remoteErr), "exhausted retry should surface the remote unavailability error")
+	assert.Equal(t, "remote", remoteErr.Deployment)
+	assert.Equal(t, "orders-target", remoteErr.Target)
+	assert.Equal(t, 2, client.calls(), "handler should stop after one retry")
+}
+
+// Only transient remote unavailability is retried. Deterministic failures
+// (validation, policy, planning errors) surface immediately so the user gets
+// an actionable comment without delay.
+func TestExecutePlanNoRetryForNonTransientErrors(t *testing.T) {
+	client := &flakyPlanTernClient{
+		failPlans: 10,
+		planErr:   grpcstatus.Error(grpccodes.InvalidArgument, "schema name is required"),
+	}
+	h := newPlanRetryTestHandler(client, time.Millisecond)
+
+	resp, err := h.executePlanWithTransientRetry(t.Context(), planRetryTestRequest(), "octocat/hello-world", 1)
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), "schema name is required")
+	assert.Equal(t, 1, client.calls(), "non-transient failures must not be retried")
+}
+
+// A cancelled webhook context aborts the retry wait immediately instead of
+// holding the handler for the full retry delay.
+func TestExecutePlanTransientRetryHonorsContextCancellation(t *testing.T) {
+	client := &flakyPlanTernClient{
+		failPlans: 10,
+		planErr:   grpcstatus.Error(grpccodes.Unavailable, "upstream connect error"),
+	}
+	h := newPlanRetryTestHandler(client, time.Hour)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 50*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	resp, err := h.executePlanWithTransientRetry(ctx, planRetryTestRequest(), "octocat/hello-world", 1)
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.Less(t, time.Since(start), 10*time.Second, "cancellation must abort the retry wait")
+	assert.Equal(t, 1, client.calls(), "cancelled context must not send the retry attempt")
+}


### PR DESCRIPTION
## Summary

When a webhook command's plan request fails because the network path to a remote deployment briefly drops (`UNAVAILABLE` from a proxy or mesh hop), the whole command fails — and for `apply-confirm` that costs the user the entire ceremony: re-acquire the lock, plan again, confirm again.

Webhook commands respond asynchronously through PR comments, so the handler can afford to wait where a CLI caller cannot. The two apply-path plan call sites now retry once after a short delay when — and only when — the failure is transient remote unavailability:

```
ExecutePlan ──✗ transient remote unavailability?
      │ yes                                │ no (policy, validation, planning)
      ▼                                    ▼
wait, retry once                     post error comment immediately
      │
      ├──✓ continue command flow
      ╰──✗ post error comment (same UX as before)
```

This layers with the gRPC client's retry policy (#297): the client absorbs sub-second blips, this absorbs flaps that outlast its budget, and sustained outages still surface within seconds. A new `schemabot.webhook.plan_transient_retry.total` counter records `recovered` vs `exhausted` outcomes so operators can tell a flapping path from a down one.

---
*This PR was generated by Amp (claude-fable-5).*