### PR TITLE
fix(github): render retryable failures as in-progress with per-table retry detail

### DIFF
--- a/pkg/ui/format.go
+++ b/pkg/ui/format.go
@@ -167,7 +167,7 @@ func TableStatePriority(taskState string) int {
 	switch taskState {
 	case state.Task.Running, state.Task.CuttingOver:
 		return 0 // active — top
-	case state.Task.WaitingForCutover, state.Task.Recovering:
+	case state.Task.WaitingForCutover, state.Task.Recovering, state.Task.FailedRetryable:
 		return 1
 	case state.Task.Pending:
 		return 2

--- a/pkg/webhook/apply.go
+++ b/pkg/webhook/apply.go
@@ -39,6 +39,7 @@ func buildApplyCommentData(apply *storage.Apply, tasks []*storage.Task) template
 			ETASeconds:      int64(t.ETASeconds),
 			IsInstant:       t.IsInstant,
 			ReadyToComplete: t.ReadyToComplete,
+			ErrorMessage:    t.ErrorMessage,
 		})
 	}
 	return data

--- a/pkg/webhook/templates/apply.go
+++ b/pkg/webhook/templates/apply.go
@@ -25,6 +25,10 @@ type TableProgressData struct {
 	ETASeconds      int64
 	IsInstant       bool
 	ReadyToComplete bool
+
+	// ErrorMessage is the task's last error. Rendered for states where the
+	// per-table error explains what the user is seeing (e.g. a retrying task).
+	ErrorMessage string
 }
 
 // ApplyStatusCommentData contains all data needed to render an apply status PR comment.
@@ -81,6 +85,11 @@ func writeApplyHeader(sb *strings.Builder, data ApplyStatusCommentData) {
 		sb.WriteString("## Schema Change Starting\n\n")
 	case state.Apply.Running:
 		sb.WriteString("## Schema Change In Progress\n\n")
+	case state.Apply.FailedRetryable:
+		// Operator recovery retries the apply automatically, so it is still
+		// in progress from the user's perspective. The retry detail is
+		// surfaced per table in the progress section, not in the headline.
+		sb.WriteString("## Schema Change In Progress\n\n")
 	case state.Apply.WaitingForDeploy:
 		sb.WriteString("## Schema Change — Waiting for Deploy\n\n")
 	case state.Apply.WaitingForCutover:
@@ -112,7 +121,7 @@ func writeApplyHeader(sb *strings.Builder, data ApplyStatusCommentData) {
 	case state.Apply.ValidatingDeployRequest:
 		sb.WriteString("## Schema Change — Validating Deploy Request\n\n")
 	default:
-		fmt.Fprintf(sb, "## Schema Change — %s\n\n", capitalizeFirst(data.State))
+		fmt.Fprintf(sb, "## Schema Change — %s\n\n", humanizeState(data.State))
 	}
 }
 
@@ -186,7 +195,7 @@ func writeProgressSummary(sb *strings.Builder, tables []TableProgressData) {
 		return
 	}
 
-	var completed, running, queued, failed, stopped, waiting, recovering, cutting, cancelled int
+	var completed, running, queued, failed, retrying, stopped, waiting, recovering, cutting, cancelled int
 	var runningPct int
 	var runningEstimateExceeded bool
 
@@ -211,6 +220,8 @@ func writeProgressSummary(sb *strings.Builder, tables []TableProgressData) {
 			cutting++
 		case state.Task.Failed:
 			failed++
+		case state.Task.FailedRetryable:
+			retrying++
 		case state.Task.Stopped:
 			stopped++
 		case state.Task.Cancelled:
@@ -267,6 +278,13 @@ func writeProgressSummary(sb *strings.Builder, tables []TableProgressData) {
 			parts = append(parts, fmt.Sprintf("%d failed", failed))
 		} else {
 			parts = append(parts, "failed")
+		}
+	}
+	if retrying > 0 {
+		if multi {
+			parts = append(parts, fmt.Sprintf("%d retrying", retrying))
+		} else {
+			parts = append(parts, "retrying")
 		}
 	}
 	if stopped > 0 {
@@ -354,6 +372,14 @@ func renderTableProgress(sb *strings.Builder, table TableProgressData, globalSta
 		bar := ui.ProgressBarFailed(table.PercentComplete)
 		fmt.Fprintf(sb, "**`%s`**: %s \u274c Failed\n", table.TableName, bar)
 		writeDDLLine(sb, table.DDL)
+
+	case state.Task.FailedRetryable:
+		bar := ui.ProgressBarStopped(ui.ClampPercent(table.PercentComplete))
+		fmt.Fprintf(sb, "**`%s`**: %s \U0001f504 Interrupted — retrying automatically\n", table.TableName, bar)
+		writeDDLLine(sb, table.DDL)
+		if table.ErrorMessage != "" {
+			fmt.Fprintf(sb, "Last error: %s\n", table.ErrorMessage)
+		}
 
 	case state.Task.Cancelled:
 		fmt.Fprintf(sb, "**`%s`**: \u2298 Cancelled (not started)\n", table.TableName)
@@ -484,6 +510,8 @@ func writeApplyFooter(sb *strings.Builder, data ApplyStatusCommentData) {
 		sb.WriteString("Cutover in progress — typically completes within seconds.\n")
 	case state.Apply.Running:
 		writeFooterAction(sb, "To stop this schema change:", fmt.Sprintf("schemabot stop %s", data.ApplyID))
+	case state.Apply.FailedRetryable:
+		writeFooterAction(sb, "A transient error interrupted this schema change; SchemaBot retries automatically. To stop instead:", fmt.Sprintf("schemabot stop %s", data.ApplyID))
 	case state.Apply.Stopped:
 		writeFooterAction(sb, "To resume:", fmt.Sprintf("schemabot start %s", data.ApplyID))
 	case state.Apply.Failed:
@@ -517,7 +545,7 @@ func RenderApplySummaryComment(data ApplyStatusCommentData) string {
 	case state.Apply.Stopped:
 		writeSummaryStopped(&sb, data, completedCount, totalTables)
 	default:
-		fmt.Fprintf(&sb, "## Schema Change \u2014 %s\n\n", capitalizeFirst(data.State))
+		fmt.Fprintf(&sb, "## Schema Change \u2014 %s\n\n", humanizeState(data.State))
 		writeSummaryMetadata(&sb, data)
 	}
 

--- a/pkg/webhook/templates/apply.go
+++ b/pkg/webhook/templates/apply.go
@@ -511,7 +511,7 @@ func writeApplyFooter(sb *strings.Builder, data ApplyStatusCommentData) {
 	case state.Apply.Running:
 		writeFooterAction(sb, "To stop this schema change:", fmt.Sprintf("schemabot stop %s", data.ApplyID))
 	case state.Apply.FailedRetryable:
-		writeFooterAction(sb, "A transient error interrupted this schema change; SchemaBot retries automatically. To stop instead:", fmt.Sprintf("schemabot stop %s", data.ApplyID))
+		writeFooterAction(sb, "An error interrupted this schema change. SchemaBot retries automatically and marks it failed if retries are exhausted. To stop retrying:", fmt.Sprintf("schemabot stop %s", data.ApplyID))
 	case state.Apply.Stopped:
 		writeFooterAction(sb, "To resume:", fmt.Sprintf("schemabot start %s", data.ApplyID))
 	case state.Apply.Failed:

--- a/pkg/webhook/templates/apply.go
+++ b/pkg/webhook/templates/apply.go
@@ -378,7 +378,7 @@ func renderTableProgress(sb *strings.Builder, table TableProgressData, globalSta
 		fmt.Fprintf(sb, "**`%s`**: %s \U0001f504 Interrupted — retrying automatically\n", table.TableName, bar)
 		writeDDLLine(sb, table.DDL)
 		if table.ErrorMessage != "" {
-			fmt.Fprintf(sb, "Last error: %s\n", table.ErrorMessage)
+			writeTableErrorLine(sb, table.ErrorMessage)
 		}
 
 	case state.Task.Cancelled:

--- a/pkg/webhook/templates/apply_test.go
+++ b/pkg/webhook/templates/apply_test.go
@@ -2,6 +2,7 @@ package templates
 
 import (
 	"errors"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -178,6 +179,83 @@ func TestRenderApplyStatusComment_Failed(t *testing.T) {
 	assert.Contains(t, result, "1 cancelled")
 	assert.Contains(t, result, "To retry:")
 	assert.Contains(t, result, "schemabot apply -e staging")
+}
+
+// A retryable failure is operator-recovery state, not a user-facing outcome:
+// the comment keeps the in-progress headline, surfaces the retry and its last
+// error on the affected table, and tells the user SchemaBot retries
+// automatically.
+func TestRenderApplyStatusComment_FailedRetryable(t *testing.T) {
+	data := ApplyStatusCommentData{
+		Database:    "testapp",
+		Environment: "staging",
+		RequestedBy: "aparajon",
+		State:       state.Apply.FailedRetryable,
+		Engine:      "Spirit",
+		ApplyID:     "apply-abc123",
+		Tables: []TableProgressData{
+			{TableName: "orders", DDL: "ALTER TABLE `orders` ADD INDEX `idx_user_id` (`user_id`)", Status: state.Task.Completed},
+			{
+				TableName:       "users",
+				DDL:             "ALTER TABLE `users` ADD COLUMN `email` varchar(255)",
+				Status:          state.Task.FailedRetryable,
+				PercentComplete: 35,
+				ErrorMessage:    "remote deployment unavailable",
+			},
+		},
+	}
+
+	result := RenderApplyStatusComment(data)
+
+	assert.Contains(t, result, "## Schema Change In Progress")
+	assert.NotContains(t, result, "Failed_retryable")
+	assert.NotContains(t, result, "failed_retryable")
+	// The retry detail lives on the affected table, not in the headline.
+	assert.Contains(t, result, "🔄 Interrupted — retrying automatically")
+	assert.Contains(t, result, "Last error: remote deployment unavailable")
+	assert.Contains(t, result, "🟧") // orange bar for the interrupted table
+	// Progress summary counts the retrying table.
+	assert.Contains(t, result, "1/2 complete")
+	assert.Contains(t, result, "1 retrying")
+	// Footer explains automatic retry and offers stop, not a manual re-apply.
+	assert.Contains(t, result, "SchemaBot retries automatically")
+	assert.Contains(t, result, "schemabot stop apply-abc123")
+	assert.NotContains(t, result, "schemabot apply -e staging")
+}
+
+// Every apply state must render a human-readable headline. Raw snake_case
+// state constants are internal vocabulary and must never appear in a PR
+// comment title, including for states added after this test.
+func TestApplyHeaderNeverLeaksRawStateConstants(t *testing.T) {
+	applyStates := reflect.ValueOf(state.Apply)
+	for _, field := range applyStates.Fields() {
+		stateValue := field.String()
+		t.Run(stateValue, func(t *testing.T) {
+			var sb strings.Builder
+			writeApplyHeader(&sb, ApplyStatusCommentData{State: stateValue})
+			header := sb.String()
+			require.NotEmpty(t, header)
+			assert.NotContains(t, header, "_", "header for state %q leaks a raw state constant", stateValue)
+		})
+	}
+}
+
+// Storage task states arrive uppercase; the renderer must normalize them so a
+// retrying task never falls through to the running renderer.
+func TestRenderApplyStatusComment_FailedRetryableUppercaseStatus(t *testing.T) {
+	data := ApplyStatusCommentData{
+		Database:    "testapp",
+		Environment: "staging",
+		State:       state.Apply.FailedRetryable,
+		Tables: []TableProgressData{
+			{TableName: "users", DDL: "ALTER TABLE `users` ADD COLUMN `email` varchar(255)", Status: "FAILED_RETRYABLE"},
+		},
+	}
+
+	result := RenderApplyStatusComment(data)
+
+	assert.Contains(t, result, "🔄 Interrupted — retrying automatically")
+	assert.NotContains(t, result, "Running...")
 }
 
 func TestRenderApplyStatusComment_Stopped(t *testing.T) {

--- a/pkg/webhook/templates/apply_test.go
+++ b/pkg/webhook/templates/apply_test.go
@@ -212,7 +212,7 @@ func TestRenderApplyStatusComment_FailedRetryable(t *testing.T) {
 	assert.NotContains(t, result, "failed_retryable")
 	// The retry detail lives on the affected table, not in the headline.
 	assert.Contains(t, result, "🔄 Interrupted — retrying automatically")
-	assert.Contains(t, result, "Last error: remote deployment unavailable")
+	assert.Contains(t, result, "> ⚠️ Last error: remote deployment unavailable")
 	assert.Contains(t, result, "🟧") // orange bar for the interrupted table
 	// Progress summary counts the retrying table.
 	assert.Contains(t, result, "1/2 complete")
@@ -256,6 +256,29 @@ func TestRenderApplyStatusComment_FailedRetryableUppercaseStatus(t *testing.T) {
 
 	assert.Contains(t, result, "🔄 Interrupted — retrying automatically")
 	assert.NotContains(t, result, "Running...")
+}
+
+// Engine errors can span multiple lines; every line must stay inside the
+// blockquote so the error cannot break the structure of the rest of the
+// comment.
+func TestRenderApplyStatusComment_FailedRetryableMultilineError(t *testing.T) {
+	data := ApplyStatusCommentData{
+		Database:    "testapp",
+		Environment: "staging",
+		State:       state.Apply.FailedRetryable,
+		Tables: []TableProgressData{
+			{
+				TableName:    "users",
+				DDL:          "ALTER TABLE `users` ADD COLUMN `email` varchar(255)",
+				Status:       state.Task.FailedRetryable,
+				ErrorMessage: "rpc error: code = Unavailable\ndesc = upstream connect error",
+			},
+		},
+	}
+
+	result := RenderApplyStatusComment(data)
+
+	assert.Contains(t, result, "> ⚠️ Last error: rpc error: code = Unavailable\n> desc = upstream connect error")
 }
 
 func TestRenderApplyStatusComment_Stopped(t *testing.T) {

--- a/pkg/webhook/templates/apply_test.go
+++ b/pkg/webhook/templates/apply_test.go
@@ -217,9 +217,11 @@ func TestRenderApplyStatusComment_FailedRetryable(t *testing.T) {
 	// Progress summary counts the retrying table.
 	assert.Contains(t, result, "1/2 complete")
 	assert.Contains(t, result, "1 retrying")
-	// Footer explains automatic retry and offers stop, not a manual re-apply.
-	assert.Contains(t, result, "SchemaBot retries automatically")
+	// Footer explains automatic retry — including the failure outcome when
+	// retries are exhausted — and offers stop, not a manual re-apply.
+	assert.Contains(t, result, "SchemaBot retries automatically and marks it failed if retries are exhausted")
 	assert.Contains(t, result, "schemabot stop apply-abc123")
+	assert.NotContains(t, result, "transient")
 	assert.NotContains(t, result, "schemabot apply -e staging")
 }
 

--- a/pkg/webhook/templates/common.go
+++ b/pkg/webhook/templates/common.go
@@ -14,6 +14,14 @@ func capitalizeFirst(s string) string {
 	return strings.ToUpper(s[:1]) + s[1:]
 }
 
+// humanizeState renders a canonical snake_case state constant as a
+// human-readable label (e.g. "waiting_for_cutover" → "Waiting for cutover").
+// Used by default branches so a state without an explicit template never
+// leaks a raw constant into a PR comment.
+func humanizeState(s string) string {
+	return capitalizeFirst(strings.ReplaceAll(s, "_", " "))
+}
+
 // TimestampFunc is the function used to generate timestamps in templates.
 // Override in previews/tests to produce deterministic output.
 var TimestampFunc = func() string {

--- a/pkg/webhook/templates/common.go
+++ b/pkg/webhook/templates/common.go
@@ -41,6 +41,14 @@ func writeErrorBlock(sb *strings.Builder, msg string) {
 	fmt.Fprintf(sb, "\n> ⚠️ **Error:** %s\n", msg)
 }
 
+// writeTableErrorLine writes a task's last error as a blockquote below its
+// progress line. Newlines are quoted so multi-line engine errors stay inside
+// the quote instead of escaping into the surrounding comment structure.
+func writeTableErrorLine(sb *strings.Builder, msg string) {
+	quoted := strings.ReplaceAll(msg, "\n", "\n> ")
+	fmt.Fprintf(sb, "> ⚠️ Last error: %s\n", quoted)
+}
+
 // writeSuccessBlock writes a success message as a blockquote.
 func writeSuccessBlock(sb *strings.Builder, msg string) {
 	fmt.Fprintf(sb, "\n> %s\n", msg)


### PR DESCRIPTION
## Summary

A retryable failure is operator-recovery state — SchemaBot retries the apply automatically — but the progress comment treated it as an unmapped state and fell through template defaults: a raw `Failed_retryable` headline, the affected table rendered as `Running...`, the stored task error suppressed, and no guidance about what happens next.

The comment now reflects the user's perspective — the schema change is still in progress — and surfaces the retry where it belongs, on the affected table:

```
## Schema Change In Progress

### Table Progress
bikes: 🟧🟧🟧⬜⬜… 🔄 Interrupted — retrying automatically
  ALTER TABLE ...
  > ⚠️ Last error: <stored task error>
---
An error interrupted this schema change. SchemaBot retries automatically
and marks it failed if retries are exhausted. To stop retrying:
schemabot stop <apply-id>
```

- Apply headline stays **In Progress**; the retry and its last error render per table (new `TableProgressData.ErrorMessage`, populated from the stored task and blockquoted so multi-line engine errors cannot break the comment structure)
- The footer states the real contract — automatic retries, permanent failure if they are exhausted — without claiming the error is transient, since a retryable classification does not prove that
- Multi-table progress summaries count retrying tables; they sort with the other attention-worthy states
- Default header/summary branches humanize unmapped states, and a test walks every apply state so a missing template case can never leak a raw snake_case constant into a PR comment headline

---
*This PR was generated by Amp (claude-fable-5).*