### PR TITLE
fix(github): block applies when a required check has not reported

### DIFF
--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -623,6 +623,9 @@ func (c *ServerConfig) Validate() error {
 	if err := c.validateGitHubAppsConfig(); err != nil {
 		return err
 	}
+	if err := c.validateRequiredChecksNotAggregate(); err != nil {
+		return err
+	}
 	if c.PendingDropsEnabled() {
 		if _, err := c.PendingDropsRetention(); err != nil {
 			return err
@@ -894,6 +897,64 @@ func validateUniqueNames(field string, names []string) error {
 			return fmt.Errorf("%s contains duplicate value %q", field, name)
 		}
 		seen[name] = struct{}{}
+	}
+	return nil
+}
+
+// aggregateCheckNameBases returns the distinct aggregate Check Run base names
+// this deployment publishes: the legacy single-App base or every multi-App
+// base. The default base applies even when check-name is unset, since SchemaBot
+// publishes "SchemaBot" by default.
+func (c *ServerConfig) aggregateCheckNameBases() []string {
+	seen := make(map[string]struct{})
+	var bases []string
+	add := func(base string) {
+		if base == "" {
+			return
+		}
+		if _, ok := seen[base]; ok {
+			return
+		}
+		seen[base] = struct{}{}
+		bases = append(bases, base)
+	}
+	if len(c.Apps) > 0 {
+		for _, app := range c.Apps {
+			add(app.CheckRunNameBase())
+		}
+		return bases
+	}
+	add(c.GitHub.CheckRunNameBase())
+	return bases
+}
+
+// isAggregateCheckName reports whether name is SchemaBot's own aggregate Check
+// Run name for base: the base itself or its environment-scoped form
+// "base (<env>)".
+func isAggregateCheckName(name, base string) bool {
+	if name == base {
+		return true
+	}
+	return strings.HasPrefix(name, base+" (") && strings.HasSuffix(name, ")")
+}
+
+// validateRequiredChecksNotAggregate rejects a required_checks entry that names
+// SchemaBot's own aggregate Check Run. SchemaBot's checks are excluded from the
+// passing-checks gate to avoid self-deadlock, so an aggregate name listed in
+// required_checks would be silently unenforced — the gate would treat it as
+// always satisfied. Failing config load makes the misconfiguration visible
+// instead of producing a gate that never blocks on the named check.
+func (c *ServerConfig) validateRequiredChecksNotAggregate() error {
+	if len(c.RequiredChecks) == 0 {
+		return nil
+	}
+	bases := c.aggregateCheckNameBases()
+	for _, name := range c.RequiredChecks {
+		for _, base := range bases {
+			if isAggregateCheckName(name, base) {
+				return fmt.Errorf("required_checks entry %q names SchemaBot's own aggregate check (base %q); SchemaBot checks are excluded from the passing-checks gate, so this entry would never be enforced", name, base)
+			}
+		}
 	}
 	return nil
 }

--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -386,6 +386,59 @@ func TestServerConfig_Validate(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "required checks reject the default aggregate check base name",
+			cfg: ServerConfig{
+				Databases: map[string]DatabaseConfig{
+					"mydb": {
+						Type:         "mysql",
+						Environments: map[string]EnvironmentConfig{"staging": {DSN: "root@tcp(localhost)/mydb"}},
+					},
+				},
+				RequiredChecks: []string{DefaultGitHubCheckName},
+			},
+			wantErr: true,
+		},
+		{
+			name: "required checks reject the environment-scoped aggregate check name",
+			cfg: ServerConfig{
+				Databases: map[string]DatabaseConfig{
+					"mydb": {
+						Type:         "mysql",
+						Environments: map[string]EnvironmentConfig{"staging": {DSN: "root@tcp(localhost)/mydb"}},
+					},
+				},
+				RequiredChecks: []string{DefaultGitHubCheckName + " (staging)"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "required checks reject a custom aggregate check base name",
+			cfg: ServerConfig{
+				Databases: map[string]DatabaseConfig{
+					"mydb": {
+						Type:         "mysql",
+						Environments: map[string]EnvironmentConfig{"staging": {DSN: "root@tcp(localhost)/mydb"}},
+					},
+				},
+				GitHub:         GitHubConfig{CheckName: "Acme SchemaBot"},
+				RequiredChecks: []string{"Acme SchemaBot (production)"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "required checks allow a name that merely shares the aggregate prefix",
+			cfg: ServerConfig{
+				Databases: map[string]DatabaseConfig{
+					"mydb": {
+						Type:         "mysql",
+						Environments: map[string]EnvironmentConfig{"staging": {DSN: "root@tcp(localhost)/mydb"}},
+					},
+				},
+				RequiredChecks: []string{DefaultGitHubCheckName + " Lint"},
+			},
+			wantErr: false,
+		},
+		{
 			name: "remote database target",
 			cfg: ServerConfig{
 				Databases: map[string]DatabaseConfig{
@@ -520,6 +573,59 @@ func TestServerConfig_Validate(t *testing.T) {
 			}
 		})
 	}
+}
+
+// A required_checks entry that names SchemaBot's own aggregate Check Run would
+// be silently unenforced: SchemaBot checks are excluded from the passing-checks
+// gate, so the gate would treat the named check as always satisfied. Config
+// validation rejects such an entry and the error names the offending entry and
+// the aggregate base so the operator can correct the typo.
+func TestServerConfig_ValidateRejectsAggregateRequiredCheck(t *testing.T) {
+	baseConfig := func(required []string) *ServerConfig {
+		return &ServerConfig{
+			Databases: map[string]DatabaseConfig{
+				"mydb": {
+					Type:         "mysql",
+					Environments: map[string]EnvironmentConfig{"staging": {DSN: "root@tcp(localhost)/mydb"}},
+				},
+			},
+			RequiredChecks: required,
+		}
+	}
+
+	t.Run("default aggregate base", func(t *testing.T) {
+		err := baseConfig([]string{"CI / lint", DefaultGitHubCheckName}).Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "required_checks entry \"SchemaBot\"")
+		assert.Contains(t, err.Error(), "would never be enforced")
+	})
+
+	t.Run("environment-scoped aggregate name", func(t *testing.T) {
+		err := baseConfig([]string{DefaultGitHubCheckName + " (production)"}).Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "required_checks entry \"SchemaBot (production)\"")
+	})
+
+	t.Run("multi-app aggregate base", func(t *testing.T) {
+		cfg := baseConfig([]string{"Acme Bot (staging)"})
+		cfg.Apps = map[string]GitHubAppConfig{
+			"acme": {
+				AppID:         "123",
+				PrivateKey:    "key",
+				WebhookSecret: "secret",
+				CheckName:     "Acme Bot",
+			},
+		}
+		err := cfg.Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "required_checks entry \"Acme Bot (staging)\"")
+		assert.Contains(t, err.Error(), "base \"Acme Bot\"")
+	})
+
+	t.Run("name sharing the aggregate prefix is allowed", func(t *testing.T) {
+		err := baseConfig([]string{DefaultGitHubCheckName + " Lint"}).Validate()
+		assert.NoError(t, err)
+	})
 }
 
 func TestServerConfig_ValidateRejectsLocalRemoteRouteCollision(t *testing.T) {

--- a/pkg/cmd/internal/templates/preview_comment.go
+++ b/pkg/cmd/internal/templates/preview_comment.go
@@ -116,7 +116,7 @@ func previewApplyCommandAllOutput() {
 			fmt.Print(webhooktemplates.RenderApplyBlockedByInProgressChecks("staging", []webhooktemplates.BlockingCheck{
 				{Name: "CI / unit-tests", State: "in_progress"},
 				{Name: "CI / integration-tests", State: "queued"},
-			}))
+			}, nil))
 		}},
 	}
 

--- a/pkg/cmd/internal/templates/preview_dispatch.go
+++ b/pkg/cmd/internal/templates/preview_dispatch.go
@@ -211,7 +211,7 @@ func PreviewCLIOutput(previewType PreviewType) {
 		fmt.Print(webhooktemplates.RenderApplyBlockedByInProgressChecks("staging", []webhooktemplates.BlockingCheck{
 			{Name: "CI / unit-tests", State: "in_progress"},
 			{Name: "CI / integration-tests", State: "queued"},
-		}))
+		}, nil))
 	case PreviewCommentActorNotAuthorized:
 		fmt.Print(webhooktemplates.PreviewCommentPRCommandNotAuthorized())
 	case PreviewCommentActorAuthUnavailable:

--- a/pkg/webhook/apply_gating.go
+++ b/pkg/webhook/apply_gating.go
@@ -109,7 +109,8 @@ func (h *Handler) enforcePassingChecks(ctx context.Context, client *ghclient.Ins
 	}
 
 	notPassing := filterNonPassingNonSchemaBotChecks(statuses, config)
-	inProgress := filterInProgressNonSchemaBotChecks(statuses, config)
+	missingRequired := missingRequiredChecks(statuses, config)
+	inProgress := append(filterInProgressNonSchemaBotChecks(statuses, config), missingRequired...)
 	h.flagUntrustedAggregateNamedChecks(ctx, statuses, config, repo, pr, headSHA, environment)
 
 	if len(notPassing) > 0 {
@@ -124,7 +125,8 @@ func (h *Handler) enforcePassingChecks(ctx context.Context, client *ghclient.Ins
 	if len(inProgress) > 0 {
 		h.logger.Info("apply blocked by in-progress PR checks",
 			"repo", repo, "pr", pr, "environment", environment,
-			"in_progress_count", len(inProgress))
+			"in_progress_count", len(inProgress),
+			"missing_required_count", len(missingRequired))
 		h.postComment(repo, pr, installationID,
 			templates.RenderApplyBlockedByInProgressChecks(environment, inProgress))
 		return true
@@ -206,6 +208,39 @@ func filterInProgressNonSchemaBotChecks(statuses []ghclient.PRCheckStatus, confi
 		}
 	}
 	return inProgress
+}
+
+// missingRequiredStateNotReported is the State surfaced for a configured
+// required check that GitHub has not yet reported on the PR commit. It mirrors
+// how a legacy commit status in the EXPECTED state maps to in_progress: GitHub
+// knows the check is owed but has not delivered a result, so apply must wait.
+const missingRequiredStateNotReported = "not reported"
+
+// missingRequiredChecks returns the configured required checks that GitHub has
+// not reported on the commit, by name regardless of which app owns the status.
+// An absent required check is treated as a blocking in-progress check so the
+// apply gate fails closed: a required check that has not reported must never
+// let an apply through. Returns nil when no required checks are configured,
+// since the gate then has no named checks to demand.
+func missingRequiredChecks(statuses []ghclient.PRCheckStatus, config *api.ServerConfig) []templates.BlockingCheck {
+	if config == nil || len(config.RequiredChecks) == 0 {
+		return nil
+	}
+	reported := make(map[string]struct{}, len(statuses))
+	for _, s := range statuses {
+		reported[s.Name] = struct{}{}
+	}
+	var missing []templates.BlockingCheck
+	for _, name := range config.RequiredChecks {
+		if _, ok := reported[name]; ok {
+			continue
+		}
+		missing = append(missing, templates.BlockingCheck{
+			Name:  name,
+			State: missingRequiredStateNotReported,
+		})
+	}
+	return missing
 }
 
 func statusesContainRequiredCheck(statuses []ghclient.PRCheckStatus, config *api.ServerConfig) bool {

--- a/pkg/webhook/apply_gating.go
+++ b/pkg/webhook/apply_gating.go
@@ -109,8 +109,8 @@ func (h *Handler) enforcePassingChecks(ctx context.Context, client *ghclient.Ins
 	}
 
 	notPassing := filterNonPassingNonSchemaBotChecks(statuses, config)
-	missingRequired := missingRequiredChecks(statuses, config)
-	inProgress := append(filterInProgressNonSchemaBotChecks(statuses, config), missingRequired...)
+	inProgress := filterInProgressNonSchemaBotChecks(statuses, config)
+	notReported := missingRequiredChecks(statuses, config)
 	h.flagUntrustedAggregateNamedChecks(ctx, statuses, config, repo, pr, headSHA, environment)
 
 	if len(notPassing) > 0 {
@@ -122,17 +122,28 @@ func (h *Handler) enforcePassingChecks(ctx context.Context, client *ghclient.Ins
 		return true
 	}
 
-	if len(inProgress) > 0 {
-		h.logger.Info("apply blocked by in-progress PR checks",
+	if len(inProgress) > 0 || len(notReported) > 0 {
+		h.logger.Info("apply blocked: PR checks have not finished verifying this commit",
 			"repo", repo, "pr", pr, "environment", environment,
 			"in_progress_count", len(inProgress),
-			"missing_required_count", len(missingRequired))
+			"missing_required_count", len(notReported),
+			"missing_required_checks", blockingCheckNames(notReported))
 		h.postComment(repo, pr, installationID,
-			templates.RenderApplyBlockedByInProgressChecks(environment, inProgress))
+			templates.RenderApplyBlockedByInProgressChecks(environment, inProgress, notReported))
 		return true
 	}
 
 	return false
+}
+
+// blockingCheckNames extracts the check names from a slice of blocking checks
+// so triage logs can name the checks rather than only count them.
+func blockingCheckNames(checks []templates.BlockingCheck) []string {
+	names := make([]string, 0, len(checks))
+	for _, c := range checks {
+		names = append(names, c.Name)
+	}
+	return names
 }
 
 func checkStatusReadLooksPermissionDenied(err error) bool {

--- a/pkg/webhook/apply_gating_test.go
+++ b/pkg/webhook/apply_gating_test.go
@@ -834,9 +834,11 @@ func TestEnforcePassingChecks(t *testing.T) {
 
 		select {
 		case body := <-comments:
-			assert.Contains(t, body, "still running")
-			assert.Contains(t, body, "Security scan")
-			assert.Contains(t, body, "not reported")
+			assert.Contains(t, body, "have not reported on this commit")
+			assert.Contains(t, body, "| `Security scan` | not reported |")
+			assert.Contains(t, body, "Verify the name in `required_checks` matches the check exactly and that it runs on this PR")
+			assert.NotContains(t, body, "Cannot apply while PR checks are still running",
+				"a never-reported check must not get the wait-and-retry remediation")
 			assert.NotContains(t, body, "Required Review", "the passing required check should not be listed as blocking")
 		case <-time.After(2 * time.Second):
 			t.Fatal("timed out waiting for missing-required-check comment")
@@ -881,12 +883,102 @@ func TestEnforcePassingChecks(t *testing.T) {
 
 		select {
 		case body := <-comments:
-			assert.Contains(t, body, "still running")
-			assert.Contains(t, body, "Required Review")
-			assert.Contains(t, body, "Security scan")
-			assert.Contains(t, body, "not reported")
+			assert.Contains(t, body, "have not reported on this commit")
+			assert.Contains(t, body, "| `Required Review` | not reported |")
+			assert.Contains(t, body, "| `Security scan` | not reported |")
+			assert.Contains(t, body, "Verify the name in `required_checks` matches the check exactly and that it runs on this PR")
+			assert.NotContains(t, body, "Cannot apply while PR checks are still running",
+				"never-reported required checks must not get the wait-and-retry remediation")
 		case <-time.After(2 * time.Second):
 			t.Fatal("timed out waiting for missing-required-checks comment")
+		}
+	})
+
+	// Triage must be able to identify which required check blocked the apply
+	// from the logs alone, without reproducing the gate. The block log names the
+	// never-reported required checks rather than only counting them.
+	t.Run("block log names the never-reported required checks", func(t *testing.T) {
+		client, mux := setupGitHubServer(t)
+
+		registerCheckStatusRESTHandlers(mux, []checkStatusNode{
+			{Typename: "CheckRun", Name: "Required Review", Status: "completed", Conclusion: "success", AppSlug: "review-gate"},
+		})
+		mux.HandleFunc("POST /repos/octocat/hello-world/issues/1/comments", func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": 99})
+		})
+
+		var logBuf bytes.Buffer
+		logger := slog.New(slog.NewTextHandler(&logBuf, nil))
+		installClient := ghclient.NewInstallationClient(client, logger)
+		factory := &fakeClientFactory{client: installClient}
+
+		service := api.New(nil, &api.ServerConfig{RequiredChecks: []string{"Required Review", "Security scan"}}, nil, logger)
+		h := &Handler{
+			service:   service,
+			ghClients: ghclient.NewSingleClientSet(defaultAppName, factory),
+			logger:    logger,
+		}
+
+		ctx := t.Context()
+		blocked := h.enforcePassingChecks(ctx, installClient, "octocat/hello-world", 1, 12345, "abc123", "staging")
+		assert.True(t, blocked, "should block when a required check has not reported")
+
+		logs := logBuf.String()
+		assert.Contains(t, logs, "apply blocked: PR checks have not finished verifying this commit")
+		assert.Contains(t, logs, "missing_required_count=1")
+		assert.Contains(t, logs, "in_progress_count=0")
+		assert.Contains(t, logs, "missing_required_checks")
+		assert.Contains(t, logs, "Security scan", "the block log must name the never-reported required check")
+		assert.NotContains(t, logs, "Required Review", "the reported required check must not be named as missing")
+	})
+
+	// A still-running non-required check and a never-reported required check can
+	// block the same apply. The single comment surfaces both causes with their
+	// own remediation: wait-and-retry for the running check, verify-the-name for
+	// the never-reported required check.
+	t.Run("in-progress and never-reported checks each get their own remediation", func(t *testing.T) {
+		client, mux := setupGitHubServer(t)
+		comments := make(chan string, 10)
+
+		registerCheckStatusRESTHandlers(mux, []checkStatusNode{
+			{Typename: "CheckRun", Name: "Required Review", Status: "in_progress", Conclusion: "", AppSlug: "review-gate"},
+		})
+
+		mux.HandleFunc("POST /repos/octocat/hello-world/issues/1/comments", func(w http.ResponseWriter, r *http.Request) {
+			var body struct {
+				Body string `json:"body"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			comments <- body.Body
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": 99})
+		})
+
+		installClient := ghclient.NewInstallationClient(client, testLogger())
+		factory := &fakeClientFactory{client: installClient}
+
+		service := api.New(nil, &api.ServerConfig{RequiredChecks: []string{"Required Review", "Security scan"}}, nil, testLogger())
+		h := &Handler{
+			service:   service,
+			ghClients: ghclient.NewSingleClientSet(defaultAppName, factory),
+			logger:    testLogger(),
+		}
+
+		ctx := t.Context()
+		blocked := h.enforcePassingChecks(ctx, installClient, "octocat/hello-world", 1, 12345, "abc123", "staging")
+		assert.True(t, blocked, "should block when a required check is running and another has not reported")
+
+		select {
+		case body := <-comments:
+			assert.Contains(t, body, "Cannot apply while PR checks are still running:")
+			assert.Contains(t, body, "| `Required Review` | in_progress |")
+			assert.Contains(t, body, "Wait for checks to complete and retry:")
+			assert.Contains(t, body, "These required checks have not reported on this commit:")
+			assert.Contains(t, body, "| `Security scan` | not reported |")
+			assert.Contains(t, body, "Verify the name in `required_checks` matches the check exactly and that it runs on this PR")
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out waiting for combined in-progress and not-reported comment")
 		}
 	})
 

--- a/pkg/webhook/apply_gating_test.go
+++ b/pkg/webhook/apply_gating_test.go
@@ -398,6 +398,73 @@ func TestFilterInProgressNonSchemaBotChecks_RequiredChecks(t *testing.T) {
 	}
 }
 
+// A configured required check that GitHub has not reported on the commit must
+// block apply: the gate fails closed and surfaces the missing check by name so
+// the operator knows which check still has to report before apply can proceed.
+func TestMissingRequiredChecks(t *testing.T) {
+	tests := []struct {
+		name       string
+		config     *api.ServerConfig
+		statuses   []ghclient.PRCheckStatus
+		wantNames  []string
+		wantStates []string
+	}{
+		{
+			name:     "no required checks configured demands nothing",
+			config:   &api.ServerConfig{RequiredChecks: nil},
+			statuses: nil,
+		},
+		{
+			name:   "one of two required checks absent blocks on the missing one",
+			config: &api.ServerConfig{RequiredChecks: []string{"check-a", "check-b"}},
+			statuses: []ghclient.PRCheckStatus{
+				{Name: "check-a", Status: "completed", Conclusion: "success"},
+			},
+			wantNames:  []string{"check-b"},
+			wantStates: []string{"not reported"},
+		},
+		{
+			name:   "no required check reported blocks on all of them",
+			config: &api.ServerConfig{RequiredChecks: []string{"check-a", "check-b"}},
+			statuses: []ghclient.PRCheckStatus{
+				{Name: "incidental", Status: "completed", Conclusion: "success"},
+			},
+			wantNames:  []string{"check-a", "check-b"},
+			wantStates: []string{"not reported", "not reported"},
+		},
+		{
+			name:   "all required checks present demand nothing",
+			config: &api.ServerConfig{RequiredChecks: []string{"check-a", "check-b"}},
+			statuses: []ghclient.PRCheckStatus{
+				{Name: "check-a", Status: "completed", Conclusion: "success"},
+				{Name: "check-b", Status: "in_progress", Conclusion: ""},
+			},
+			wantNames: nil,
+		},
+		{
+			name:   "required check reported by SchemaBot is not demanded",
+			config: &api.ServerConfig{RequiredChecks: []string{"SchemaBot (staging)"}},
+			statuses: []ghclient.PRCheckStatus{
+				{Name: "SchemaBot (staging)", Status: "completed", Conclusion: "success", IsSchemaBot: true},
+			},
+			wantNames: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			missing := missingRequiredChecks(tt.statuses, tt.config)
+			require.Len(t, missing, len(tt.wantNames))
+			for i, name := range tt.wantNames {
+				assert.Equal(t, name, missing[i].Name)
+			}
+			for i, state := range tt.wantStates {
+				assert.Equal(t, state, missing[i].State)
+			}
+		})
+	}
+}
+
 // checkStatusNode is a single check run or commit status used by tests to build
 // mock REST responses. Set Typename to "CheckRun" or "StatusContext" and
 // populate the matching fields.
@@ -727,6 +794,127 @@ func TestEnforcePassingChecks(t *testing.T) {
 		case <-time.After(2 * time.Second):
 			t.Fatal("timed out waiting for failing-checks comment")
 		}
+	})
+
+	// With two required checks configured, an apply must wait until every one
+	// has reported. When only the first has reported (and passed), the apply is
+	// blocked because the second required check has not reported yet, and the
+	// comment names the missing check so the operator knows what to wait for.
+	t.Run("absent required check blocks even when present required check passes", func(t *testing.T) {
+		client, mux := setupGitHubServer(t)
+		comments := make(chan string, 10)
+
+		registerCheckStatusRESTHandlers(mux, []checkStatusNode{
+			{Typename: "CheckRun", Name: "Required Review", Status: "completed", Conclusion: "success", AppSlug: "review-gate"},
+		})
+
+		mux.HandleFunc("POST /repos/octocat/hello-world/issues/1/comments", func(w http.ResponseWriter, r *http.Request) {
+			var body struct {
+				Body string `json:"body"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			comments <- body.Body
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": 99})
+		})
+
+		installClient := ghclient.NewInstallationClient(client, testLogger())
+		factory := &fakeClientFactory{client: installClient}
+
+		service := api.New(nil, &api.ServerConfig{RequiredChecks: []string{"Required Review", "Security scan"}}, nil, testLogger())
+		h := &Handler{
+			service:   service,
+			ghClients: ghclient.NewSingleClientSet(defaultAppName, factory),
+			logger:    testLogger(),
+		}
+
+		ctx := t.Context()
+		blocked := h.enforcePassingChecks(ctx, installClient, "octocat/hello-world", 1, 12345, "abc123", "staging")
+		assert.True(t, blocked, "should block when a required check has not reported")
+
+		select {
+		case body := <-comments:
+			assert.Contains(t, body, "still running")
+			assert.Contains(t, body, "Security scan")
+			assert.Contains(t, body, "not reported")
+			assert.NotContains(t, body, "Required Review", "the passing required check should not be listed as blocking")
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out waiting for missing-required-check comment")
+		}
+	})
+
+	// Required checks are configured but none has reported on the commit; only
+	// an unrelated incidental check has passed. The apply must not slip through
+	// on incidental success — every configured required check still has to
+	// report, so the apply is blocked and the comment names each missing check.
+	t.Run("no required check reported blocks despite passing incidental check", func(t *testing.T) {
+		client, mux := setupGitHubServer(t)
+		comments := make(chan string, 10)
+
+		registerCheckStatusRESTHandlers(mux, []checkStatusNode{
+			{Typename: "CheckRun", Name: "CI / lint", Status: "completed", Conclusion: "success", AppSlug: "github-actions"},
+		})
+
+		mux.HandleFunc("POST /repos/octocat/hello-world/issues/1/comments", func(w http.ResponseWriter, r *http.Request) {
+			var body struct {
+				Body string `json:"body"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			comments <- body.Body
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": 99})
+		})
+
+		installClient := ghclient.NewInstallationClient(client, testLogger())
+		factory := &fakeClientFactory{client: installClient}
+
+		service := api.New(nil, &api.ServerConfig{RequiredChecks: []string{"Required Review", "Security scan"}}, nil, testLogger())
+		h := &Handler{
+			service:   service,
+			ghClients: ghclient.NewSingleClientSet(defaultAppName, factory),
+			logger:    testLogger(),
+		}
+
+		ctx := t.Context()
+		blocked := h.enforcePassingChecks(ctx, installClient, "octocat/hello-world", 1, 12345, "abc123", "staging")
+		assert.True(t, blocked, "should block when no required check has reported")
+
+		select {
+		case body := <-comments:
+			assert.Contains(t, body, "still running")
+			assert.Contains(t, body, "Required Review")
+			assert.Contains(t, body, "Security scan")
+			assert.Contains(t, body, "not reported")
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out waiting for missing-required-checks comment")
+		}
+	})
+
+	// When every configured required check has reported and passed, the apply
+	// proceeds even though unrelated incidental checks are not in the required
+	// set.
+	t.Run("all required checks present and passing allows apply", func(t *testing.T) {
+		client, mux := setupGitHubServer(t)
+
+		registerCheckStatusRESTHandlers(mux, []checkStatusNode{
+			{Typename: "CheckRun", Name: "Required Review", Status: "completed", Conclusion: "success", AppSlug: "review-gate"},
+			{Typename: "CheckRun", Name: "Security scan", Status: "completed", Conclusion: "success", AppSlug: "security-app"},
+			{Typename: "CheckRun", Name: "CI / tests", Status: "in_progress", Conclusion: "", AppSlug: "github-actions"},
+		})
+
+		installClient := ghclient.NewInstallationClient(client, testLogger())
+		factory := &fakeClientFactory{client: installClient}
+
+		service := api.New(nil, &api.ServerConfig{RequiredChecks: []string{"Required Review", "Security scan"}}, nil, testLogger())
+		h := &Handler{
+			service:   service,
+			ghClients: ghclient.NewSingleClientSet(defaultAppName, factory),
+			logger:    testLogger(),
+		}
+
+		ctx := t.Context()
+		blocked := h.enforcePassingChecks(ctx, installClient, "octocat/hello-world", 1, 12345, "abc123", "staging")
+		assert.False(t, blocked, "should allow when all required checks reported and passed")
 	})
 
 	t.Run("all passing allows apply", func(t *testing.T) {

--- a/pkg/webhook/templates/apply_commands.go
+++ b/pkg/webhook/templates/apply_commands.go
@@ -441,29 +441,58 @@ func RenderApplyBlockedByCheckStatusError(environment string, err error, details
 }
 
 // RenderApplyBlockedByInProgressChecks renders a comment when apply is blocked
-// because non-SchemaBot PR checks are still running.
-func RenderApplyBlockedByInProgressChecks(environment string, inProgress []BlockingCheck) string {
+// because PR checks have not finished verifying the commit. Two distinct causes
+// are surfaced with distinct remediation:
+//
+//   - inProgress: non-SchemaBot checks GitHub has reported as still running.
+//     These resolve on their own, so the guidance is to wait and retry.
+//   - notReported: configured required checks that GitHub has not reported on
+//     this commit at all. These will not necessarily resolve on their own — a
+//     name that never reports (a typo in required_checks, a check not
+//     configured on the repo, or a path-filtered workflow) means waiting is
+//     futile — so the guidance is to verify the name and that the check runs on
+//     this PR, not to wait indefinitely.
+func RenderApplyBlockedByInProgressChecks(environment string, inProgress, notReported []BlockingCheck) string {
 	var sb strings.Builder
 
 	sb.WriteString("## ⏳ Apply Blocked\n\n")
 	fmt.Fprintf(&sb, "**Environment**: `%s`\n\n", environment)
-	if len(inProgress) == 0 {
+	if len(inProgress) == 0 && len(notReported) == 0 {
 		// Defensive: callers should only invoke this template when at least
-		// one in-progress check has been identified. Render a generic message
-		// rather than an empty Markdown table with column headers but no rows.
-		sb.WriteString("Cannot apply while PR checks are still running.\n\n")
+		// one in-progress or not-reported check has been identified. Render a
+		// generic message rather than empty Markdown tables with column headers
+		// but no rows.
+		sb.WriteString("Cannot apply until PR checks finish verifying this commit.\n\n")
 		sb.WriteString("Wait for checks to complete and retry:\n")
 		fmt.Fprintf(&sb, "```\nschemabot apply -e %s\n```\n", environment)
 		return sb.String()
 	}
-	sb.WriteString("Cannot apply while PR checks are still running:\n\n")
-	sb.WriteString("| Check | Status |\n")
-	sb.WriteString("|-------|--------|\n")
-	for _, c := range inProgress {
-		fmt.Fprintf(&sb, "| `%s` | %s |\n", c.Name, c.State)
+
+	if len(inProgress) > 0 {
+		sb.WriteString("Cannot apply while PR checks are still running:\n\n")
+		sb.WriteString("| Check | Status |\n")
+		sb.WriteString("|-------|--------|\n")
+		for _, c := range inProgress {
+			fmt.Fprintf(&sb, "| `%s` | %s |\n", c.Name, c.State)
+		}
+		sb.WriteString("\nWait for checks to complete and retry:\n")
+		fmt.Fprintf(&sb, "```\nschemabot apply -e %s\n```\n", environment)
 	}
-	sb.WriteString("\nWait for checks to complete and retry:\n")
-	fmt.Fprintf(&sb, "```\nschemabot apply -e %s\n```\n", environment)
+
+	if len(notReported) > 0 {
+		if len(inProgress) > 0 {
+			sb.WriteString("\n")
+		}
+		sb.WriteString("These required checks have not reported on this commit:\n\n")
+		sb.WriteString("| Check | Status |\n")
+		sb.WriteString("|-------|--------|\n")
+		for _, c := range notReported {
+			fmt.Fprintf(&sb, "| `%s` | %s |\n", c.Name, c.State)
+		}
+		sb.WriteString("\nIf a check never reports, waiting will not unblock the apply. ")
+		sb.WriteString("Verify the name in `required_checks` matches the check exactly and that it runs on this PR, then retry:\n")
+		fmt.Fprintf(&sb, "```\nschemabot apply -e %s\n```\n", environment)
+	}
 
 	return sb.String()
 }

--- a/pkg/webhook/templates/apply_test.go
+++ b/pkg/webhook/templates/apply_test.go
@@ -805,7 +805,7 @@ func TestRenderApplyBlockedByInProgressChecks(t *testing.T) {
 		{Name: "CI / integration", State: "queued"},
 	}
 
-	result := RenderApplyBlockedByInProgressChecks("staging", inProgress)
+	result := RenderApplyBlockedByInProgressChecks("staging", inProgress, nil)
 
 	assert.Contains(t, result, "⏳ Apply Blocked")
 	assert.Contains(t, result, "`staging`")
@@ -814,19 +814,66 @@ func TestRenderApplyBlockedByInProgressChecks(t *testing.T) {
 	assert.Contains(t, result, "| `CI / integration` | queued |")
 	assert.Contains(t, result, "Wait for checks to complete")
 	assert.Contains(t, result, "schemabot apply -e staging")
+	assert.NotContains(t, result, "not reported",
+		"in-progress-only render must not surface the never-reported remediation")
+}
+
+// A configured required check that has never reported on the commit gets
+// remediation distinct from the still-running checks: waiting will not unblock
+// it, so the operator is told to verify the name and that the check runs on the
+// PR rather than to wait indefinitely.
+func TestRenderApplyBlockedByInProgressChecks_NotReported(t *testing.T) {
+	notReported := []BlockingCheck{
+		{Name: "Security scan", State: "not reported"},
+	}
+
+	result := RenderApplyBlockedByInProgressChecks("production", nil, notReported)
+
+	assert.Contains(t, result, "⏳ Apply Blocked")
+	assert.Contains(t, result, "`production`")
+	assert.Contains(t, result, "have not reported on this commit")
+	assert.Contains(t, result, "| `Security scan` | not reported |")
+	assert.Contains(t, result, "If a check never reports, waiting will not unblock the apply.")
+	assert.Contains(t, result, "Verify the name in `required_checks` matches the check exactly and that it runs on this PR")
+	assert.Contains(t, result, "schemabot apply -e production")
+	assert.NotContains(t, result, "Cannot apply while PR checks are still running",
+		"not-reported-only render must not surface the wait-and-retry headline")
+}
+
+// When both still-running checks and never-reported required checks block the
+// same apply, each cause keeps its own remediation: the running checks get the
+// wait-and-retry guidance and the missing required checks get the verify-the-name
+// guidance, so the operator does not wait indefinitely on a check that will
+// never report.
+func TestRenderApplyBlockedByInProgressChecks_InProgressAndNotReported(t *testing.T) {
+	inProgress := []BlockingCheck{
+		{Name: "CI / unit-tests", State: "in_progress"},
+	}
+	notReported := []BlockingCheck{
+		{Name: "Security scan", State: "not reported"},
+	}
+
+	result := RenderApplyBlockedByInProgressChecks("staging", inProgress, notReported)
+
+	assert.Contains(t, result, "Cannot apply while PR checks are still running:")
+	assert.Contains(t, result, "| `CI / unit-tests` | in_progress |")
+	assert.Contains(t, result, "Wait for checks to complete and retry:")
+	assert.Contains(t, result, "These required checks have not reported on this commit:")
+	assert.Contains(t, result, "| `Security scan` | not reported |")
+	assert.Contains(t, result, "Verify the name in `required_checks` matches the check exactly and that it runs on this PR")
 }
 
 func TestRenderApplyBlockedByInProgressChecks_EmptyList(t *testing.T) {
-	// Defensive guard: rendering with an empty slice must not emit an empty
+	// Defensive guard: rendering with empty slices must not emit an empty
 	// Markdown table (header row with zero data rows). It should fall back
 	// to a generic message that still preserves the header, environment,
 	// and retry block.
 	for _, inProgress := range [][]BlockingCheck{nil, {}} {
-		result := RenderApplyBlockedByInProgressChecks("staging", inProgress)
+		result := RenderApplyBlockedByInProgressChecks("staging", inProgress, nil)
 
 		assert.Contains(t, result, "## ⏳ Apply Blocked")
 		assert.Contains(t, result, "**Environment**: `staging`")
-		assert.Contains(t, result, "Cannot apply while PR checks are still running.")
+		assert.Contains(t, result, "Cannot apply until PR checks finish verifying this commit.")
 		assert.Contains(t, result, "Wait for checks to complete and retry:\n```\nschemabot apply -e staging\n```",
 			"retry command must be inside a fenced code block immediately after the retry copy")
 		assert.NotContains(t, result, "| Check | Status |",


### PR DESCRIPTION
When `required_checks` is configured, the passing-checks apply gate only evaluated the required checks GitHub had already reported on the PR commit. A configured required check that had not reported yet neither failed nor counted as in-progress, so the apply could proceed before that check ever ran — a fail-open gap in a tier-0 safety gate.

This treats every configured required check that is absent from the fetched statuses as a not-yet-reported in-progress blocker, mirroring how a legacy commit status in the `EXPECTED` state maps to `in_progress`. The gate now fails closed and the apply-blocked comment names the missing required check(s) so the operator knows what still has to report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)