### PR TITLE
fix(github): fail closed on staging-first gate when target env is unlisted

### DIFF
--- a/pkg/metrics/README.md
+++ b/pkg/metrics/README.md
@@ -22,6 +22,7 @@ available, such as `repository`, `github_app`, and `installation_id`.
 | `schemabot.schema_request.errors_total` | Counter | repository, command, database, environment, reason | Schema request errors by reason |
 | `schemabot.active_applies` | UpDownCounter | database, environment | In-progress applies |
 | `schemabot.check_ownership_misses_total` | Counter | operation, repository, database, database_type, environment | Guarded check updates skipped because ownership changed |
+| `schemabot.promotion.config_error_blocks_total` | Counter | repository, database, environment | Applies blocked because the target environment is absent from the configured promotion order |
 | `schemabot.status_check_operations_total` | Counter | operation, status, repository, database, database_type, environment | Status-check storage and GitHub operations |
 | `schemabot.webhook.events_total` | Counter | environment, event_type, action, repository, status | GitHub webhook events |
 | `schemabot.webhook.unregistered_repository_ignored_total` | Counter | environment, app_name, event_type, action, repository | Webhook events ignored because the repository is not configured |
@@ -131,6 +132,21 @@ Operator response:
 4. If the live schema may now differ from the PR's current declarative schema,
    re-plan the current head and decide whether to apply again, roll back, or
    hold the PR until drift is resolved.
+
+### Promotion Config Error Blocks
+
+`schemabot.promotion.config_error_blocks_total` should always be zero. It
+increments only when a scoped SchemaBot instance (with `allowed_environments`
+configured) is asked to apply to an environment that is absent from the
+configured promotion order. The staging-first gate cannot determine which
+environments must be applied before the target, so it fails closed and blocks
+the apply.
+
+This is an operator misconfiguration, not user commit churn. Group by
+`repository`, `database`, and `environment` to find the affected instance, then
+add the blocked `environment` to that instance's `environment_order` so the gate
+knows where it sits in the promotion sequence. The matching warn log carries the
+`promotion_order` currently in effect.
 
 ### Status Check Operations
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -481,6 +481,32 @@ func RecordUntrustedAggregateNamedCheck(ctx context.Context, repository, environ
 	)
 }
 
+// RecordPromotionConfigErrorBlock counts applies blocked by the staging-first
+// promotion gate because the target environment is absent from the configured
+// promotion order on a scoped SchemaBot instance. This fires only on operator
+// misconfiguration: the gate cannot identify the target's prior environments,
+// so it fails closed. A non-zero count means an operator must add the
+// environment to environment_order; the matching warn log carries the
+// promotion_order so they can see what is configured.
+func RecordPromotionConfigErrorBlock(ctx context.Context, repository, database, environment string) {
+	meter := otel.Meter(meterName)
+	counter, err := meter.Int64Counter("schemabot.promotion.config_error_blocks_total",
+		otelmetric.WithDescription("Total applies blocked because the target environment is absent from the configured promotion order"),
+		otelmetric.WithUnit("{block}"),
+	)
+	if err != nil {
+		slog.Warn("failed to create promotion config error block counter", "error", err)
+		return
+	}
+	counter.Add(ctx, 1,
+		otelmetric.WithAttributes(
+			attribute.String("repository", repository),
+			attribute.String("database", database),
+			EnvironmentAttribute(environment),
+		),
+	)
+}
+
 // AdjustActiveApplies increments or decrements the active applies gauge.
 // Use delta=1 when an apply is accepted and delta=-1 when it reaches a terminal state.
 func AdjustActiveApplies(ctx context.Context, delta int64, database, deployment, environment string) {

--- a/pkg/webhook/check_prior_env.go
+++ b/pkg/webhook/check_prior_env.go
@@ -49,6 +49,7 @@ func (h *Handler) checkPriorEnvironments(
 			"database", database, "database_type", dbType,
 			"environment", environment,
 			"promotion_order", order)
+		metrics.RecordPromotionConfigErrorBlock(ctx, repo, database, environment)
 		h.postComment(repo, pr, installationID,
 			templates.RenderApplyBlockedByUnlistedEnvironment(environment, order))
 		return true

--- a/pkg/webhook/check_prior_env.go
+++ b/pkg/webhook/check_prior_env.go
@@ -35,6 +35,25 @@ func (h *Handler) checkPriorEnvironments(
 	installationID int64, requestedBy string,
 ) bool {
 	config := h.service.Config()
+
+	// On a scoped instance the server-configured promotion order is the only
+	// authoritative source for which environments precede the target. If the
+	// target is absent from that order we cannot identify its prior
+	// environments, so staging-first ordering cannot be enforced. Fail closed:
+	// block the apply with a config error rather than fall back to a local-only
+	// ordering that omits prior environments owned by other instances.
+	if scopedTargetMissingFromPromotionOrder(config, environment) {
+		order := config.PromotionEnvironmentOrder()
+		h.logger.Warn("target environment is absent from the configured promotion order, blocking apply",
+			"repo", repo, "pr", pr,
+			"database", database, "database_type", dbType,
+			"environment", environment,
+			"promotion_order", order)
+		h.postComment(repo, pr, installationID,
+			templates.RenderApplyBlockedByUnlistedEnvironment(environment, order))
+		return true
+	}
+
 	environments = promotionGateEnvironments(config, environment, environments)
 
 	// Find the index of the current environment
@@ -69,6 +88,18 @@ func (h *Handler) checkPriorEnvironments(
 	}
 
 	return false
+}
+
+// scopedTargetMissingFromPromotionOrder reports whether this instance is scoped
+// to a subset of environments (allowed_environments is configured) while the
+// target environment is absent from the server promotion order. In that state
+// the prior environments cannot be derived from the order, and the staging-first
+// gate cannot be enforced — the caller must fail closed.
+func scopedTargetMissingFromPromotionOrder(config *api.ServerConfig, environment string) bool {
+	if config == nil || len(config.AllowedEnvironments) == 0 {
+		return false
+	}
+	return !slices.Contains(config.PromotionEnvironmentOrder(), environment)
 }
 
 func promotionGateEnvironments(config *api.ServerConfig, environment string, environments []string) []string {

--- a/pkg/webhook/check_prior_env_test.go
+++ b/pkg/webhook/check_prior_env_test.go
@@ -370,6 +370,145 @@ func TestCheckPriorEnvironmentsCrossDeploymentAppTrust(t *testing.T) {
 	})
 }
 
+// TestCheckPriorEnvironmentsScopedTargetMissingFromOrderFailsClosed covers a
+// scoped SchemaBot instance (allowed_environments is configured) applying to an
+// environment that is not part of the configured promotion order. SchemaBot
+// cannot determine which environments must be applied first, so it cannot
+// enforce staging-first ordering. The apply must fail closed with a
+// configuration error instead of falling back to this instance's local
+// environment list, which would silently skip prior environments owned by other
+// instances.
+func TestCheckPriorEnvironmentsScopedTargetMissingFromOrderFailsClosed(t *testing.T) {
+	const (
+		repo = "octocat/hello-world"
+		pr   = 1
+	)
+
+	client, mux := setupGitHubServer(t)
+	comments := make(chan string, 1)
+	mux.HandleFunc("POST /repos/octocat/hello-world/issues/1/comments", func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Body string `json:"body"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		comments <- body.Body
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": 99})
+	})
+
+	installClient := ghclient.NewInstallationClient(client, testLogger())
+	service := api.New(&emptyStorage{}, &api.ServerConfig{
+		AllowedEnvironments: []string{"production"},
+		EnvironmentOrder:    []string{"staging", "production"},
+		Databases: map[string]api.DatabaseConfig{
+			"orders": {
+				Type: "mysql",
+				Environments: map[string]api.EnvironmentConfig{
+					"canary": {Deployment: "default", Target: "orders"},
+				},
+			},
+		},
+	}, nil, testLogger())
+	t.Cleanup(func() { utils.CloseAndLog(service) })
+
+	h := &Handler{
+		service:                    service,
+		ghClients:                  ghclient.NewSingleClientSet(defaultAppName, &fakeClientFactory{client: installClient}),
+		logger:                     testLogger(),
+		priorEnvCheckMaxAttempts:   1,
+		priorEnvCheckRetryInterval: time.Nanosecond,
+	}
+
+	blocked := h.checkPriorEnvironments(t.Context(), repo, pr,
+		"orders", "mysql", "canary", []string{"canary"}, 12345, "testuser")
+	assert.True(t, blocked, "scoped instance must fail closed when the target environment is not in the promotion order")
+
+	select {
+	case body := <-comments:
+		assert.Contains(t, body, "Apply Blocked")
+		assert.Contains(t, body, "`canary` is not in the configured promotion order")
+		assert.Contains(t, body, "cannot enforce staging-first ordering")
+		assert.Contains(t, body, "environment_order")
+		assert.Contains(t, body, "`staging` → `production`")
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for unlisted-environment config error comment")
+	}
+}
+
+// TestCheckPriorEnvironmentsScopedTargetInOrderAllowsApply covers a scoped
+// SchemaBot instance applying to an environment that is in the configured
+// promotion order, with all prior environments verified successfully. The
+// staging-first config-error gate must not trip: the apply proceeds and no
+// configuration-error comment is posted.
+func TestCheckPriorEnvironmentsScopedTargetInOrderAllowsApply(t *testing.T) {
+	const (
+		repo    = "octocat/hello-world"
+		pr      = 1
+		headSHA = "abc123"
+	)
+
+	client, mux := setupGitHubServer(t)
+	comments := make(chan string, 1)
+
+	mux.HandleFunc("GET /repos/octocat/hello-world/pulls/1", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"head": map[string]any{"sha": headSHA, "ref": "feature"},
+			"base": map[string]any{"sha": "base123", "ref": "main"},
+			"user": map[string]any{"login": "testuser"},
+		})
+	})
+	mux.HandleFunc("GET /repos/octocat/hello-world/commits/abc123/check-runs", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"total_count": 1,
+			"check_runs": []map[string]any{
+				{"id": 1, "name": "SchemaBot (staging)", "status": "completed", "conclusion": "success", "app": map[string]any{"slug": "schemabot"}},
+			},
+		})
+	})
+	mux.HandleFunc("POST /repos/octocat/hello-world/issues/1/comments", func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Body string `json:"body"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		comments <- body.Body
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": 99})
+	})
+
+	installClient := ghclient.NewInstallationClientWithSlug(client, testLogger(), "schemabot")
+	service := api.New(&emptyStorage{}, &api.ServerConfig{
+		AllowedEnvironments: []string{"production"},
+		EnvironmentOrder:    []string{"staging", "production"},
+		Databases: map[string]api.DatabaseConfig{
+			"orders": {
+				Type: "mysql",
+				Environments: map[string]api.EnvironmentConfig{
+					"production": {Deployment: "default", Target: "orders"},
+				},
+			},
+		},
+	}, nil, testLogger())
+	t.Cleanup(func() { utils.CloseAndLog(service) })
+
+	h := &Handler{
+		service:                    service,
+		ghClients:                  ghclient.NewSingleClientSet(defaultAppName, &fakeClientFactory{client: installClient}),
+		logger:                     testLogger(),
+		priorEnvCheckMaxAttempts:   1,
+		priorEnvCheckRetryInterval: time.Nanosecond,
+	}
+
+	blocked := h.checkPriorEnvironments(t.Context(), repo, pr,
+		"orders", "mysql", "production", []string{"production"}, 12345, "testuser")
+	assert.False(t, blocked, "in-order target with a passing prior environment check should be allowed")
+
+	select {
+	case body := <-comments:
+		t.Fatalf("unexpected comment posted: %s", body)
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
 func TestCheckPriorEnvViaGitHub(t *testing.T) {
 	const (
 		repo    = "octocat/hello-world"

--- a/pkg/webhook/check_prior_env_test.go
+++ b/pkg/webhook/check_prior_env_test.go
@@ -8,6 +8,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 
 	"github.com/block/spirit/pkg/utils"
 
@@ -386,6 +390,15 @@ func TestCheckPriorEnvironmentsScopedTargetMissingFromOrderFailsClosed(t *testin
 		pr   = 1
 	)
 
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	prevMP := otel.GetMeterProvider()
+	otel.SetMeterProvider(mp)
+	t.Cleanup(func() {
+		otel.SetMeterProvider(prevMP)
+		require.NoError(t, mp.Shutdown(t.Context()))
+	})
+
 	client, mux := setupGitHubServer(t)
 	comments := make(chan string, 1)
 	mux.HandleFunc("POST /repos/octocat/hello-world/issues/1/comments", func(w http.ResponseWriter, r *http.Request) {
@@ -435,6 +448,44 @@ func TestCheckPriorEnvironmentsScopedTargetMissingFromOrderFailsClosed(t *testin
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out waiting for unlisted-environment config error comment")
 	}
+
+	dp := requirePromotionConfigErrorBlockDataPoint(t, reader)
+	assert.Equal(t, int64(1), dp.Value, "the config-error block must increment the metric exactly once")
+	assertStringAttr(t, dp.Attributes, "repository", repo)
+	assertStringAttr(t, dp.Attributes, "database", "orders")
+	assertStringAttr(t, dp.Attributes, "environment", "canary")
+}
+
+// requirePromotionConfigErrorBlockDataPoint collects metrics from the reader and
+// returns the single data point for the promotion config-error block counter,
+// failing the test if the metric is absent or has more than one data point.
+func requirePromotionConfigErrorBlockDataPoint(t *testing.T, reader *sdkmetric.ManualReader) metricdata.DataPoint[int64] {
+	t.Helper()
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(t.Context(), &rm))
+
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != "schemabot.promotion.config_error_blocks_total" {
+				continue
+			}
+			sum, ok := m.Data.(metricdata.Sum[int64])
+			require.True(t, ok, "promotion config error block metric must be an int64 sum")
+			require.Len(t, sum.DataPoints, 1, "expected exactly one promotion config error block data point")
+			return sum.DataPoints[0]
+		}
+	}
+
+	t.Fatal("schemabot.promotion.config_error_blocks_total metric not found")
+	return metricdata.DataPoint[int64]{}
+}
+
+func assertStringAttr(t *testing.T, set attribute.Set, key, want string) {
+	t.Helper()
+	got, ok := set.Value(attribute.Key(key))
+	assert.True(t, ok, "metric data point must carry the %q attribute", key)
+	assert.Equal(t, want, got.AsString(), "metric attribute %q", key)
 }
 
 // TestCheckPriorEnvironmentsScopedTargetInOrderAllowsApply covers a scoped

--- a/pkg/webhook/check_prior_env_test.go
+++ b/pkg/webhook/check_prior_env_test.go
@@ -372,12 +372,14 @@ func TestCheckPriorEnvironmentsCrossDeploymentAppTrust(t *testing.T) {
 
 // TestCheckPriorEnvironmentsScopedTargetMissingFromOrderFailsClosed covers a
 // scoped SchemaBot instance (allowed_environments is configured) applying to an
-// environment that is not part of the configured promotion order. SchemaBot
-// cannot determine which environments must be applied first, so it cannot
-// enforce staging-first ordering. The apply must fail closed with a
-// configuration error instead of falling back to this instance's local
-// environment list, which would silently skip prior environments owned by other
-// instances.
+// environment that this instance handles but that the operator omitted from the
+// configured promotion order. The command reaches the gate because the target
+// environment is allowed, yet the promotion order cannot place it among its
+// prior environments. SchemaBot cannot determine which environments must be
+// applied first, so it cannot enforce staging-first ordering. The apply must
+// fail closed with a configuration error instead of falling back to this
+// instance's local environment list, which would silently skip prior
+// environments owned by other instances.
 func TestCheckPriorEnvironmentsScopedTargetMissingFromOrderFailsClosed(t *testing.T) {
 	const (
 		repo = "octocat/hello-world"
@@ -398,7 +400,7 @@ func TestCheckPriorEnvironmentsScopedTargetMissingFromOrderFailsClosed(t *testin
 
 	installClient := ghclient.NewInstallationClient(client, testLogger())
 	service := api.New(&emptyStorage{}, &api.ServerConfig{
-		AllowedEnvironments: []string{"production"},
+		AllowedEnvironments: []string{"production", "canary"},
 		EnvironmentOrder:    []string{"staging", "production"},
 		Databases: map[string]api.DatabaseConfig{
 			"orders": {
@@ -421,7 +423,7 @@ func TestCheckPriorEnvironmentsScopedTargetMissingFromOrderFailsClosed(t *testin
 
 	blocked := h.checkPriorEnvironments(t.Context(), repo, pr,
 		"orders", "mysql", "canary", []string{"canary"}, 12345, "testuser")
-	assert.True(t, blocked, "scoped instance must fail closed when the target environment is not in the promotion order")
+	assert.True(t, blocked, "scoped instance must fail closed when an allowed target environment is absent from the promotion order")
 
 	select {
 	case body := <-comments:

--- a/pkg/webhook/templates/apply_commands.go
+++ b/pkg/webhook/templates/apply_commands.go
@@ -536,3 +536,22 @@ func RenderApplyBlockedByPriorEnvInProgress(database, environment, priorEnv stri
 
 	return sb.String()
 }
+
+// RenderApplyBlockedByUnlistedEnvironment renders a comment when an apply is
+// blocked because this scoped SchemaBot instance cannot enforce staging-first
+// promotion ordering: the target environment is not part of the configured
+// promotion order, so SchemaBot cannot determine which environments must be
+// applied before it. This is a configuration error that an operator must fix.
+func RenderApplyBlockedByUnlistedEnvironment(environment string, promotionOrder []string) string {
+	var sb strings.Builder
+
+	sb.WriteString("## ❌ Apply Blocked\n\n")
+	fmt.Fprintf(&sb, "**Environment**: `%s`\n\n", environment)
+	fmt.Fprintf(&sb, "`%s` is not in the configured promotion order, so SchemaBot cannot determine which environments must be applied before it and cannot enforce staging-first ordering.\n\n", environment)
+	if len(promotionOrder) > 0 {
+		fmt.Fprintf(&sb, "Configured promotion order: `%s`\n\n", strings.Join(promotionOrder, "` → `"))
+	}
+	fmt.Fprintf(&sb, "Add `%s` to `environment_order` so SchemaBot knows where it sits in the promotion sequence, then retry the apply.\n", environment)
+
+	return sb.String()
+}


### PR DESCRIPTION
A scoped SchemaBot instance (`allowed_environments` configured) that applied to an environment **not** present in the configured promotion order could not derive the target's prior environments from that order. It fell back to this instance's local environment list, which omits prior environments owned by other instances — so the staging-first promotion gate fell open in exactly the scoped configuration it is meant to protect.

This fails closed instead. When `allowed_environments` is set and the target environment is absent from the promotion order, the apply is blocked with a configuration-error comment explaining that staging-first ordering cannot be enforced until the environment is added to `environment_order`. The in-order path is unchanged.

```
scoped instance, target not in promotion order
  before: fall back to local-only ordering → prior envs skipped → apply allowed
  after:  block apply with config error → operator extends environment_order
```

**Upgrade note:** the promotion order defaults to `[staging, production]` when `environment_order` is unset, so a scoped instance serving any other environment name goes from silently-allowed to blocked on upgrade — operators must add those environment names to `environment_order` or the apply will be blocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
