### PR TITLE
fix(operator): make PlanetScale setup-phase applies recoverable after crash

### DIFF
--- a/integration/operator_test.go
+++ b/integration/operator_test.go
@@ -638,11 +638,11 @@ func TestOperator_ClaimableStates(t *testing.T) {
 		{name: "failed", applyState: state.Apply.Failed, databaseType: "mysql", engine: "spirit"},
 		{name: "stopped", applyState: state.Apply.Stopped, databaseType: "mysql", engine: "spirit"},
 		{name: "reverted", applyState: state.Apply.Reverted, databaseType: "vitess", engine: "planetscale"},
-		{name: "preparing branch", applyState: state.Apply.PreparingBranch, databaseType: "vitess", engine: "planetscale"},
-		{name: "applying branch changes", applyState: state.Apply.ApplyingBranchChanges, databaseType: "vitess", engine: "planetscale"},
-		{name: "validating branch", applyState: state.Apply.ValidatingBranch, databaseType: "vitess", engine: "planetscale"},
-		{name: "creating deploy request", applyState: state.Apply.CreatingDeployRequest, databaseType: "vitess", engine: "planetscale"},
-		{name: "validating deploy request", applyState: state.Apply.ValidatingDeployRequest, databaseType: "vitess", engine: "planetscale"},
+		{name: "preparing branch", applyState: state.Apply.PreparingBranch, databaseType: "vitess", engine: "planetscale", wantClaim: true},
+		{name: "applying branch changes", applyState: state.Apply.ApplyingBranchChanges, databaseType: "vitess", engine: "planetscale", wantClaim: true},
+		{name: "validating branch", applyState: state.Apply.ValidatingBranch, databaseType: "vitess", engine: "planetscale", wantClaim: true},
+		{name: "creating deploy request", applyState: state.Apply.CreatingDeployRequest, databaseType: "vitess", engine: "planetscale", wantClaim: true},
+		{name: "validating deploy request", applyState: state.Apply.ValidatingDeployRequest, databaseType: "vitess", engine: "planetscale", wantClaim: true},
 	}
 
 	for i, tc := range cases {
@@ -1061,46 +1061,4 @@ func TestOperator_DatabaseExclusionScopedByEnvironment(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, claimed)
 	assert.Equal(t, "apply-env-stale-production", claimed.ApplyIdentifier)
-}
-
-func TestOperator_PlanetScaleSetupStatesNotClaimed(t *testing.T) {
-	ctx := t.Context()
-
-	fixture := newOperatorClaimFixture(t, "ps_states_")
-	appDBName := fixture.appDBName
-	stor := fixture.store
-	schemabotDB := fixture.storageDB
-
-	now := time.Now()
-	for _, ps := range []string{
-		state.Apply.PreparingBranch,
-		state.Apply.ApplyingBranchChanges,
-		state.Apply.ValidatingBranch,
-		state.Apply.CreatingDeployRequest,
-		state.Apply.ValidatingDeployRequest,
-	} {
-		fixture.resetStorage(t)
-		_, err := stor.Applies().Create(ctx, &storage.Apply{
-			ApplyIdentifier: "apply-ps-" + ps,
-			Database:        appDBName,
-			DatabaseType:    "vitess",
-			Deployment:      appDBName,
-			Engine:          "planetscale",
-			State:           ps,
-			Options:         []byte("{}"),
-			Environment:     "staging",
-			CreatedAt:       now,
-			UpdatedAt:       now,
-		})
-		require.NoError(t, err)
-		_, err = schemabotDB.ExecContext(ctx,
-			"UPDATE applies SET updated_at = NOW() - INTERVAL 2 MINUTE WHERE apply_identifier = ?",
-			"apply-ps-"+ps)
-		require.NoError(t, err)
-
-		// The operator should leave PlanetScale setup states unclaimed until resume metadata can be hydrated.
-		claimed, err := stor.Applies().FindNextApply(ctx, "test-owner")
-		require.NoError(t, err)
-		assert.Nil(t, claimed, "stale %s should not be claimed without persisted resume metadata", ps)
-	}
 }

--- a/pkg/storage/mysqlstore/applies.go
+++ b/pkg/storage/mysqlstore/applies.go
@@ -72,10 +72,16 @@ type txBeginner interface {
 // claimableApplyStates returns active apply states where operator recovery can
 // safely resume work after the heartbeat becomes stale. Pending has a separate
 // queue path and does not need to be stale before a worker claims it. Terminal
-// states are already done, failed_retryable has its own retry path, stopped
-// requires an explicit user start, and PlanetScale setup states are excluded
-// until recovery can reload the persisted branch/deploy metadata needed to
-// resume them without restarting setup.
+// states are already done, failed_retryable has its own retry path, and stopped
+// requires an explicit user start.
+//
+// The PlanetScale setup-phase states (preparing_branch through
+// validating_deploy_request) are included: a stale heartbeat in any of them
+// unambiguously means the worker driving engine setup died, and the persisted
+// branch/deploy metadata lets recovery resume the apply from stored state. A
+// healthy worker mid-setup keeps its heartbeat fresh, so it is never claimed out
+// from under itself. Leaving these states out would strand a crashed setup-phase
+// apply non-terminal and unclaimable, so no operator could ever recover it.
 func claimableApplyStates() []string {
 	return []string{
 		state.Apply.Running,
@@ -85,6 +91,11 @@ func claimableApplyStates() []string {
 		"recovering_cutover",
 		state.Apply.CuttingOver,
 		state.Apply.RevertWindow,
+		state.Apply.PreparingBranch,
+		state.Apply.ApplyingBranchChanges,
+		state.Apply.ValidatingBranch,
+		state.Apply.CreatingDeployRequest,
+		state.Apply.ValidatingDeployRequest,
 	}
 }
 

--- a/pkg/storage/mysqlstore/applies_test.go
+++ b/pkg/storage/mysqlstore/applies_test.go
@@ -1052,6 +1052,83 @@ func TestApplyStore_ClaimApplyByIDReturnsNilForTerminalAndMissing(t *testing.T) 
 	assert.Nil(t, missing, "a non-existent apply id yields no claim")
 }
 
+// A PlanetScale apply transitions through engine setup-phase states
+// (preparing_branch through validating_deploy_request) before per-table work
+// begins. If the worker driving setup crashes, the apply is left in one of
+// those states; a fresh worker must reclaim it once the heartbeat goes stale so
+// setup resumes from persisted branch/deploy metadata. While the original
+// worker is still alive its heartbeat stays fresh, so the apply is not claimed
+// out from under it.
+func TestApplyStore_FindNextApplyClaimsStaleSetupPhase(t *testing.T) {
+	for _, setupState := range []string{
+		state.Apply.PreparingBranch,
+		state.Apply.ApplyingBranchChanges,
+		state.Apply.ValidatingBranch,
+		state.Apply.CreatingDeployRequest,
+		state.Apply.ValidatingDeployRequest,
+	} {
+		t.Run(setupState, func(t *testing.T) {
+			clearTables(t)
+			ctx := t.Context()
+			store := New(testDB)
+
+			lock := createTestLock(t, store, "testdb", storage.DatabaseTypeMySQL, "staging")
+			apply := createTestApplyWithStateAndEnv(t, store, lock, "apply_setup_"+setupState, 700, setupState, "staging")
+
+			fresh, err := store.Applies().FindNextApply(ctx, "operator-a")
+			require.NoError(t, err)
+			assert.Nil(t, fresh, "a setup-phase apply with a fresh heartbeat is owned by its active worker")
+
+			_, err = testDB.ExecContext(ctx, `
+				UPDATE applies
+				SET updated_at = NOW() - INTERVAL 2 MINUTE
+				WHERE id = ?
+			`, apply.ID)
+			require.NoError(t, err)
+
+			claimed, err := store.Applies().FindNextApply(ctx, "operator-a")
+			require.NoError(t, err)
+			require.NotNil(t, claimed, "a stale setup-phase apply must be reclaimable for recovery")
+			assert.Equal(t, apply.ApplyIdentifier, claimed.ApplyIdentifier)
+			assert.Equal(t, setupState, claimed.State, "the caller sees the setup-phase state to resume from")
+			assert.Equal(t, "operator-a", claimed.LeaseOwner)
+			assert.NotEmpty(t, claimed.LeaseToken)
+		})
+	}
+}
+
+// ClaimApplyByID is how the operation-level claim loop acquires the parent apply
+// lease after leasing a stale operation row. When a PlanetScale worker crashes
+// mid-setup the operation row stays running (stale) while the parent apply sits
+// in a setup-phase state, so ClaimApplyByID must reclaim that stale parent for
+// recovery while still refusing one whose heartbeat is fresh.
+func TestApplyStore_ClaimApplyByIDClaimsStaleSetupPhase(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", storage.DatabaseTypeMySQL, "staging")
+	apply := createTestApplyWithStateAndEnv(t, store, lock, "apply_claim_setup", 701, state.Apply.ApplyingBranchChanges, "staging")
+
+	fresh, err := store.Applies().ClaimApplyByID(ctx, apply.ID, "operator-a")
+	require.NoError(t, err)
+	assert.Nil(t, fresh, "a fresh setup-phase apply is owned by its active worker")
+
+	_, err = testDB.ExecContext(ctx, `
+		UPDATE applies
+		SET updated_at = NOW() - INTERVAL 2 MINUTE
+		WHERE id = ?
+	`, apply.ID)
+	require.NoError(t, err)
+
+	claimed, err := store.Applies().ClaimApplyByID(ctx, apply.ID, "operator-a")
+	require.NoError(t, err)
+	require.NotNil(t, claimed, "a stale setup-phase parent apply must be reclaimable")
+	assert.Equal(t, state.Apply.ApplyingBranchChanges, claimed.State)
+	assert.Equal(t, "operator-a", claimed.LeaseOwner)
+	assert.NotEmpty(t, claimed.LeaseToken)
+}
+
 // ClaimApplyByID requires an owner so a lease can never be acquired without an
 // identity that lease-guarded writes can fail closed against.
 func TestApplyStore_ClaimApplyByIDRequiresOwner(t *testing.T) {

--- a/pkg/storage/mysqlstore/applies_test.go
+++ b/pkg/storage/mysqlstore/applies_test.go
@@ -1072,8 +1072,9 @@ func TestApplyStore_FindNextApplyClaimsStaleSetupPhase(t *testing.T) {
 			ctx := t.Context()
 			store := New(testDB)
 
-			lock := createTestLock(t, store, "testdb", storage.DatabaseTypeMySQL, "staging")
+			lock := createTestLock(t, store, "testdb", storage.DatabaseTypeVitess, "staging")
 			apply := createTestApplyWithStateAndEnv(t, store, lock, "apply_setup_"+setupState, 700, setupState, "staging")
+			require.Equal(t, storage.EnginePlanetScale, apply.Engine, "setup-phase states only occur for the PlanetScale engine")
 
 			fresh, err := store.Applies().FindNextApply(ctx, "operator-a")
 			require.NoError(t, err)
@@ -1091,6 +1092,7 @@ func TestApplyStore_FindNextApplyClaimsStaleSetupPhase(t *testing.T) {
 			require.NotNil(t, claimed, "a stale setup-phase apply must be reclaimable for recovery")
 			assert.Equal(t, apply.ApplyIdentifier, claimed.ApplyIdentifier)
 			assert.Equal(t, setupState, claimed.State, "the caller sees the setup-phase state to resume from")
+			assert.Equal(t, storage.EnginePlanetScale, claimed.Engine, "the reclaimed apply keeps its PlanetScale engine")
 			assert.Equal(t, "operator-a", claimed.LeaseOwner)
 			assert.NotEmpty(t, claimed.LeaseToken)
 		})
@@ -1107,8 +1109,9 @@ func TestApplyStore_ClaimApplyByIDClaimsStaleSetupPhase(t *testing.T) {
 	ctx := t.Context()
 	store := New(testDB)
 
-	lock := createTestLock(t, store, "testdb", storage.DatabaseTypeMySQL, "staging")
+	lock := createTestLock(t, store, "testdb", storage.DatabaseTypeVitess, "staging")
 	apply := createTestApplyWithStateAndEnv(t, store, lock, "apply_claim_setup", 701, state.Apply.ApplyingBranchChanges, "staging")
+	require.Equal(t, storage.EnginePlanetScale, apply.Engine, "setup-phase states only occur for the PlanetScale engine")
 
 	fresh, err := store.Applies().ClaimApplyByID(ctx, apply.ID, "operator-a")
 	require.NoError(t, err)
@@ -1125,6 +1128,7 @@ func TestApplyStore_ClaimApplyByIDClaimsStaleSetupPhase(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, claimed, "a stale setup-phase parent apply must be reclaimable")
 	assert.Equal(t, state.Apply.ApplyingBranchChanges, claimed.State)
+	assert.Equal(t, storage.EnginePlanetScale, claimed.Engine, "the reclaimed parent apply keeps its PlanetScale engine")
 	assert.Equal(t, "operator-a", claimed.LeaseOwner)
 	assert.NotEmpty(t, claimed.LeaseToken)
 }
@@ -2211,7 +2215,7 @@ func createTestApplyWithStateAndEnv(t *testing.T, store *Storage, lock *storage.
 		Repository:      lock.Repository,
 		PullRequest:     lock.PullRequest,
 		Environment:     env,
-		Engine:          "spirit",
+		Engine:          storage.EngineForType(lock.DatabaseType),
 		State:           applyState,
 	}
 

--- a/pkg/storage/mysqlstore/apply_operations_test.go
+++ b/pkg/storage/mysqlstore/apply_operations_test.go
@@ -955,8 +955,9 @@ func TestApplyOperationStore_FindNextApplyOperation_RecoversStaleSetupPhase(t *t
 	ctx := t.Context()
 	store := New(testDB)
 
-	lock := createTestLock(t, store, "testdb", "mysql", "staging")
+	lock := createTestLock(t, store, "testdb", storage.DatabaseTypeVitess, "staging")
 	apply := createTestApplyWithStateAndEnv(t, store, lock, "apply_op_setup_crash", 1, state.Apply.ApplyingBranchChanges, "staging")
+	require.Equal(t, storage.EnginePlanetScale, apply.Engine, "setup-phase states only occur for the PlanetScale engine")
 	_, err := testDB.ExecContext(ctx, `
 		UPDATE applies SET state = ?, updated_at = NOW() - INTERVAL 2 MINUTE WHERE id = ?
 	`, state.Apply.ApplyingBranchChanges, apply.ID)
@@ -981,6 +982,7 @@ func TestApplyOperationStore_FindNextApplyOperation_RecoversStaleSetupPhase(t *t
 	require.NoError(t, err)
 	require.NotNil(t, parent, "the stale setup-phase parent apply must be claimable so the operation can be driven")
 	assert.Equal(t, state.Apply.ApplyingBranchChanges, parent.State)
+	assert.Equal(t, storage.EnginePlanetScale, parent.Engine, "the reclaimed parent apply keeps its PlanetScale engine")
 	assert.Equal(t, "operator-a", parent.LeaseOwner)
 	assert.NotEmpty(t, parent.LeaseToken)
 }

--- a/pkg/storage/mysqlstore/apply_operations_test.go
+++ b/pkg/storage/mysqlstore/apply_operations_test.go
@@ -942,6 +942,49 @@ func TestApplyOperationStore_FindNextApplyOperation_ClaimsFailedRetryableParentA
 	assert.Equal(t, id, claimed.ID)
 }
 
+// TestApplyOperationStore_FindNextApplyOperation_RecoversStaleSetupPhase
+// verifies crash recovery during PlanetScale engine setup under the
+// operation-claim model. While a worker drives setup the operation row is
+// running and the parent apply moves through setup-phase states
+// (applying_branch_changes here). If that worker dies, both rows are left active
+// with a stale heartbeat. A peer must be able to lease the stale operation and
+// then acquire the parent apply lease via ClaimApplyByID — both halves of the
+// recovery path — so setup resumes instead of stranding the apply forever.
+func TestApplyOperationStore_FindNextApplyOperation_RecoversStaleSetupPhase(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", "mysql", "staging")
+	apply := createTestApplyWithStateAndEnv(t, store, lock, "apply_op_setup_crash", 1, state.Apply.ApplyingBranchChanges, "staging")
+	_, err := testDB.ExecContext(ctx, `
+		UPDATE applies SET state = ?, updated_at = NOW() - INTERVAL 2 MINUTE WHERE id = ?
+	`, state.Apply.ApplyingBranchChanges, apply.ID)
+	require.NoError(t, err)
+
+	id, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-a", State: state.ApplyOperation.Running,
+	})
+	require.NoError(t, err)
+	_, err = testDB.ExecContext(ctx, `
+		UPDATE apply_operations SET updated_at = NOW() - INTERVAL 2 MINUTE WHERE id = ?
+	`, id)
+	require.NoError(t, err)
+
+	claimed, err := store.ApplyOperations().FindNextApplyOperation(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, claimed, "a stale running operation must be reclaimable when its parent apply crashed mid-setup")
+	assert.Equal(t, id, claimed.ID)
+	assert.Equal(t, state.ApplyOperation.Running, claimed.State, "re-claim keeps the running state for the resume drive")
+
+	parent, err := store.Applies().ClaimApplyByID(ctx, apply.ID, "operator-a")
+	require.NoError(t, err)
+	require.NotNil(t, parent, "the stale setup-phase parent apply must be claimable so the operation can be driven")
+	assert.Equal(t, state.Apply.ApplyingBranchChanges, parent.State)
+	assert.Equal(t, "operator-a", parent.LeaseOwner)
+	assert.NotEmpty(t, parent.LeaseToken)
+}
+
 // TestApplyOperationStore_FindNextApplyOperation_ConcurrentClaims verifies
 // the SKIP LOCKED contract on a contended row: N workers race to claim a
 // single pending child row, and exactly one wins. Mirrors the apply-level


### PR DESCRIPTION
A PlanetScale apply moves through engine setup-phase states — `preparing_branch`, `applying_branch_changes`, `validating_branch`, `creating_deploy_request`, `validating_deploy_request` — before per-table work begins. These states matched no clause of the operator claim queries: not `pending`, not in the claimable set, not terminal. So a worker crash mid-setup left the apply non-terminal **and** permanently unclaimable, with no operator able to recover it.

This adds the setup-phase states to `claimableApplyStates`, so a stale-heartbeat apply stuck in setup is reclaimed for recovery just like the other in-flight states. A healthy worker keeps its heartbeat fresh, so an in-progress setup is never claimed out from under it; terminal states stay excluded. Both the apply-level (`FindNextApply`, `ClaimApplyByID`) and operation-level (`FindNextApplyOperation`) claim paths share this set and now treat setup-phase applies consistently.

```
worker crash during setup
  apply.state = applying_branch_changes (non-terminal)
  heartbeat goes stale
    before: matches no claim clause -> wedged forever
    after:  matches stale-active clause -> operator reclaims and resumes
```

**Merge order:** This should land **after #265** (resume with persisted engine state). On `main` today, a claimed setup-phase Vitess apply resumes through the path that re-runs engine setup without persisted state, which can duplicate branch/deploy-request work. Merging this before #265 converts "wedged after crash" into "recovered wrongly," which is worse. The deleted negative test is correct only once #265 is in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
