### PR TITLE
fix(github): trust configured sibling deployment apps for check run gates

### DIFF
--- a/docs/check-runs.md
+++ b/docs/check-runs.md
@@ -885,6 +885,14 @@ environment:
   environment aggregate check run from GitHub, such as `SchemaBot (staging)` or
   the deployment's configured check name.
 
+The GitHub lookup verifies which App created the check run: only this
+deployment's own GitHub App and the sibling deployment Apps listed in
+`github.trusted-check-app-slugs` are trusted, so a same-named check run from an
+unrelated app (such as a GitHub Actions job) can never satisfy the gate. When
+the prior environment's deployment uses a different GitHub App, its slug must
+be listed in `trusted-check-app-slugs`; otherwise its aggregate check is
+treated as untrusted and the gate fails closed, blocking the apply.
+
 Remote prior-environment checks use the aggregate because the current deployment
 does not have access to the other deployment's per-database storage. That makes
 the remote check stricter than the local check: a production apply can be

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -475,7 +475,15 @@ github:
   private-key: "file:/run/secrets/prod-github-key.pem"
   webhook-secret: "env:PROD_WEBHOOK_SECRET"
   check-name: "SchemaBot X"
+  trusted-check-app-slugs:
+    - schemabot-staging  # the staging instance's GitHub App slug
 ```
+
+The production instance lists the staging instance's GitHub App slug in
+`trusted-check-app-slugs` so the promotion gate can verify the staging
+aggregate check run that the staging App created. Without it, the production
+instance only trusts check runs created by its own App, and the staging gate
+fails closed — production applies stay blocked even when staging is green.
 
 ### Environment-local gRPC targets
 
@@ -532,6 +540,8 @@ Do not require the staging ConfigMap to contain production targets, or the produ
 - **Per-environment aggregate checks:** Each instance creates its own aggregate check run scoped to its environments (e.g., `SchemaBot (staging)`, `SchemaBot (production)`) instead of the default `SchemaBot` aggregate. Configure branch protection to require both aggregates. Set `github.check-name` when independent SchemaBot gates need distinct visible names; every instance in the same promotion chain should use the same base name.
 
 - **Cross-instance environment verification:** Environment ordering (e.g., staging must succeed before production) works across instances. The production instance queries the GitHub Checks API for the staging instance's aggregate check to verify the prior environment completed successfully. GitHub check runs are the shared authority for cross-environment state; the production instance does not need staging target configuration to enforce the staging gate.
+
+- **Trusted check App slugs:** The promotion gate only accepts check runs created by trusted SchemaBot GitHub Apps, so a same-named check from an unrelated app (such as a GitHub Actions job) can never satisfy it. When instances use separate GitHub Apps, each instance that verifies a prior environment must list the owning instance's App slug in `github.trusted-check-app-slugs`; otherwise the prior environment's check is treated as untrusted and the gate fails closed, blocking applies. Trusted sibling App checks are also excluded from the `require_passing_checks` gate, the same as the instance's own checks — SchemaBot aggregate checks are governed by the promotion and merge gates, not the CI-health gate.
 
 - **Separate GitHub Apps:** Each instance needs its own GitHub App installation. Both Apps must be installed on the same repositories and configured to receive the same webhook events. GitHub delivers webhooks to all installed Apps independently.
 

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -214,6 +214,17 @@ type GitHubConfig struct {
 	// this App. Environment-scoped deployments append the environment in
 	// parentheses, for example "SchemaBot (staging)".
 	CheckName string `yaml:"check-name,omitempty"`
+
+	// TrustedCheckAppSlugs lists the GitHub App slugs of sibling SchemaBot
+	// deployments whose Check Runs this deployment trusts, in addition to its
+	// own App. Environment-scoped deployments that verify a prior
+	// environment's aggregate Check Run must list the App slug of the
+	// deployment that owns that environment here when it is a different
+	// GitHub App; otherwise the promotion gate cannot verify ownership of the
+	// prior environment's check and will block applies. Check Runs from Apps
+	// not in this list (and not this deployment's own App) never satisfy
+	// SchemaBot gates.
+	TrustedCheckAppSlugs []string `yaml:"trusted-check-app-slugs,omitempty"`
 }
 
 // CheckRunNameBase returns the configured aggregate GitHub Check Run base name.
@@ -721,11 +732,17 @@ func (c *ServerConfig) validateNoLocalRemoteRouteCollision() error {
 //   - If apps: is NOT set, repos must not declare github_app (it would be a
 //     silently ignored field, which we want to fail closed on).
 func (c *ServerConfig) validateGitHubAppsConfig() error {
-	hasGitHub := c.GitHub.AppID != "" || c.GitHub.PrivateKey != "" || c.GitHub.WebhookSecret != "" || c.GitHub.CheckName != ""
+	hasGitHub := c.GitHub.AppID != "" || c.GitHub.PrivateKey != "" || c.GitHub.WebhookSecret != "" || c.GitHub.CheckName != "" || len(c.GitHub.TrustedCheckAppSlugs) > 0
 	hasApps := c.Apps != nil
 
 	if hasGitHub && hasApps {
 		return fmt.Errorf("github: and apps: are mutually exclusive; configure one or the other")
+	}
+
+	if hasGitHub {
+		if err := validateUniqueNames("github.trusted-check-app-slugs", c.GitHub.TrustedCheckAppSlugs); err != nil {
+			return err
+		}
 	}
 
 	if hasApps {
@@ -744,6 +761,9 @@ func (c *ServerConfig) validateGitHubAppsConfig() error {
 			}
 			if app.WebhookSecret == "" {
 				return fmt.Errorf("app %q missing webhook-secret", name)
+			}
+			if err := validateUniqueNames(fmt.Sprintf("app %q trusted-check-app-slugs", name), app.TrustedCheckAppSlugs); err != nil {
+				return err
 			}
 		}
 		for repo, repoConfig := range c.Repos {

--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -2160,6 +2160,34 @@ func TestServerConfig_AppsValidation(t *testing.T) {
 			repos:  map[string]RepoConfig{"org/repo": {}},
 		},
 		{
+			name: "single-app github: with trusted check app slugs is accepted",
+			github: GitHubConfig{
+				AppID: "42", PrivateKey: "env:PK", WebhookSecret: "env:WS",
+				TrustedCheckAppSlugs: []string{"schemabot-staging"},
+			},
+			repos: map[string]RepoConfig{"org/repo": {}},
+		},
+		{
+			name: "single-app github: with empty trusted check app slug is rejected",
+			github: GitHubConfig{
+				AppID: "42", PrivateKey: "env:PK", WebhookSecret: "env:WS",
+				TrustedCheckAppSlugs: []string{""},
+			},
+			repos:      map[string]RepoConfig{"org/repo": {}},
+			wantErrSub: "github.trusted-check-app-slugs contains an empty value",
+		},
+		{
+			name: "app with duplicate trusted check app slugs is rejected",
+			apps: map[string]GitHubAppConfig{
+				"app-a": {
+					AppID: "12345", PrivateKey: "env:PK", WebhookSecret: "env:WS",
+					TrustedCheckAppSlugs: []string{"schemabot-staging", "schemabot-staging"},
+				},
+			},
+			repos:      map[string]RepoConfig{"org/repo": {GitHubApp: "app-a"}},
+			wantErrSub: `app "app-a" trusted-check-app-slugs contains duplicate value "schemabot-staging"`,
+		},
+		{
 			name: "well-formed multi-app config is accepted",
 			apps: map[string]GitHubAppConfig{
 				"app-a": validApp,

--- a/pkg/cmd/commands/serve.go
+++ b/pkg/cmd/commands/serve.go
@@ -341,9 +341,11 @@ func buildSingleAppWebhookRuntime(serverConfig *api.ServerConfig, svc *api.Servi
 	}
 
 	appID := serverConfig.GitHub.ResolveAppID()
-	ghClient := ghclient.NewClient(appID, []byte(ghPrivateKey), logger)
+	ghClient := ghclient.NewClient(appID, []byte(ghPrivateKey), logger,
+		ghclient.WithTrustedCheckAppSlugs(serverConfig.GitHub.TrustedCheckAppSlugs))
 	handler := webhook.NewHandler(svc, ghClient, []byte(ghWebhookSecret), logger)
-	logger.Info("GitHub webhook endpoint registered", "app_id", appID)
+	logger.Info("GitHub webhook endpoint registered",
+		"app_id", appID, "trusted_check_app_slugs", serverConfig.GitHub.TrustedCheckAppSlugs)
 	return webhookRuntime{
 		handler:                         handler,
 		reconcileMissingSummaryComments: handler.ReconcileMissingSummaryComments,
@@ -398,11 +400,13 @@ func buildMultiAppWebhookRuntime(serverConfig *api.ServerConfig, svc *api.Servic
 			return webhookRuntime{}, fmt.Errorf("app %q webhook secret resolved to empty value", e.name)
 		}
 
-		clients[e.name] = ghclient.NewClient(e.id, []byte(privateKey), logger)
+		clients[e.name] = ghclient.NewClient(e.id, []byte(privateKey), logger,
+			ghclient.WithTrustedCheckAppSlugs(e.cfg.TrustedCheckAppSlugs))
 		secretsByApp[e.name] = []byte(secret)
 		appByID[e.id] = e.name
 
-		logger.Info("registered GitHub App", "app_name", e.name, "app_id", e.id)
+		logger.Info("registered GitHub App",
+			"app_name", e.name, "app_id", e.id, "trusted_check_app_slugs", e.cfg.TrustedCheckAppSlugs)
 	}
 
 	handler := webhook.NewHandlerWithDispatch(

--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -45,6 +45,11 @@ type Client struct {
 	// after NewClient returns (holds the empty string if the fetch failed).
 	appSlug atomic.Pointer[string]
 
+	// trustedCheckAppSlugs lists sibling SchemaBot GitHub App slugs whose
+	// Check Runs this deployment trusts in addition to its own App. Static
+	// configuration set at construction; never mutated afterwards.
+	trustedCheckAppSlugs []string
+
 	// slugFetchMu serialises slug-fetch attempts so concurrent
 	// ForInstallation callers do not thundering-herd retry on startup
 	// failure. lastSlugAttempt is read+written only under this mutex.
@@ -70,6 +75,19 @@ type Client struct {
 	// checks), so any memoisation window would risk converting a
 	// now-failing gate into a passing one.
 	checkStatusSingleflight *CheckStatusSingleflight
+}
+
+// ClientOption configures optional Client behavior at construction.
+type ClientOption func(*Client)
+
+// WithTrustedCheckAppSlugs configures the GitHub App slugs of sibling
+// SchemaBot deployments whose Check Runs this deployment trusts in addition
+// to its own App. Cross-deployment gates (such as the prior-environment
+// promotion gate) accept Check Runs created by these Apps.
+func WithTrustedCheckAppSlugs(slugs []string) ClientOption {
+	return func(c *Client) {
+		c.trustedCheckAppSlugs = slugs
+	}
 }
 
 // loadAppSlug returns the current app slug, or empty if not yet fetched.
@@ -102,13 +120,16 @@ const slugFetchRetryCooldown = 5 * time.Second
 // across every InstallationClient it produces, so concurrent webhook
 // deliveries and command bursts targeting the same (repo, sha) collapse to a
 // single upstream GitHub read.
-func NewClient(appID int64, privateKey []byte, logger *slog.Logger) *Client {
+func NewClient(appID int64, privateKey []byte, logger *slog.Logger, opts ...ClientOption) *Client {
 	c := &Client{
 		appID:                   appID,
 		privateKey:              privateKey,
 		logger:                  logger,
 		installations:           make(map[int64]*InstallationClient),
 		checkStatusSingleflight: NewCheckStatusSingleflight(),
+	}
+	for _, opt := range opts {
+		opt(c)
 	}
 	// Seed the atomic with the empty string so loadAppSlug never returns
 	// from a nil pointer.
@@ -202,6 +223,7 @@ func (c *Client) ForInstallation(installationID int64) (*InstallationClient, err
 		client:                  ghClient,
 		logger:                  c.logger,
 		installationID:          installationID,
+		trustedCheckAppSlugs:    c.trustedCheckAppSlugs,
 		checkStatusSingleflight: c.checkStatusSingleflight,
 	}
 	ic.storeAppSlug(slug)
@@ -217,11 +239,13 @@ func NewInstallationClient(client *gh.Client, logger *slog.Logger) *Installation
 	return NewInstallationClientWithSlug(client, logger, "")
 }
 
-// NewInstallationClientWithSlug creates an InstallationClient with an explicit app slug.
-func NewInstallationClientWithSlug(client *gh.Client, logger *slog.Logger, appSlug string) *InstallationClient {
+// NewInstallationClientWithSlug creates an InstallationClient with an explicit
+// app slug and, optionally, trusted sibling SchemaBot App slugs.
+func NewInstallationClientWithSlug(client *gh.Client, logger *slog.Logger, appSlug string, trustedCheckAppSlugs ...string) *InstallationClient {
 	ic := &InstallationClient{
-		client: client,
-		logger: logger,
+		client:               client,
+		logger:               logger,
+		trustedCheckAppSlugs: trustedCheckAppSlugs,
 	}
 	ic.storeAppSlug(appSlug)
 	return ic
@@ -240,6 +264,11 @@ type InstallationClient struct {
 	// this field after a slug recovery while concurrent isOwnAppSlug reads
 	// run on other goroutines.
 	appSlug atomic.Pointer[string]
+
+	// trustedCheckAppSlugs lists sibling SchemaBot GitHub App slugs whose
+	// Check Runs this deployment trusts in addition to its own App. Static
+	// configuration copied from the parent Client; never mutated.
+	trustedCheckAppSlugs []string
 
 	// checkStatusSingleflight is owned by the parent Client factory and
 	// shared across every InstallationClient it produces so concurrent
@@ -617,18 +646,21 @@ type CheckRunResult struct {
 }
 
 // FindCheckRunByName searches for a check run on a specific commit by name.
-// Only check runs created by this SchemaBot GitHub App are considered: a
-// same-named check run created by another app (for example a GitHub Actions
-// job configured with a matching name) is ignored, so it can never satisfy a
-// gate that relies on this lookup. When multiple own-app runs share the name,
-// the most recently created one (highest check run ID) is returned.
+// Only check runs created by a trusted SchemaBot GitHub App are considered:
+// this deployment's own App plus any configured trusted sibling deployment
+// Apps. A same-named check run created by any other app (for example a GitHub
+// Actions job configured with a matching name) is ignored, so it can never
+// satisfy a gate that relies on this lookup. When multiple trusted-app runs
+// share the name, the most recently created one (highest check run ID) is
+// returned.
 //
-// Returns nil if no own-app check run matches. Returns an error when the own
-// app slug is unknown — check run ownership cannot be verified, and callers
-// must fail closed instead of trusting a same-named run.
+// Returns nil if no trusted-app check run matches. Returns an error when the
+// own app slug is unknown and no trusted sibling slugs are configured — check
+// run ownership cannot be verified against anything, and callers must fail
+// closed instead of trusting a same-named run.
 func (ic *InstallationClient) FindCheckRunByName(ctx context.Context, repo, headSHA, checkName string) (*CheckRunResult, error) {
-	if ic.loadAppSlug() == "" {
-		return nil, fmt.Errorf("find check run %q on %s@%s: GitHub App slug is unavailable, check run ownership cannot be verified", checkName, repo, headSHA)
+	if ic.loadAppSlug() == "" && len(ic.trustedCheckAppSlugs) == 0 {
+		return nil, fmt.Errorf("find check run %q on %s@%s: GitHub App slug is unavailable and no trusted sibling App slugs are configured, check run ownership cannot be verified", checkName, repo, headSHA)
 	}
 
 	owner, repoName := splitRepo(repo)
@@ -648,8 +680,8 @@ func (ic *InstallationClient) FindCheckRunByName(ctx context.Context, repo, head
 		}
 		if result != nil {
 			for _, run := range result.CheckRuns {
-				if !ic.isOwnAppSlug(run.GetApp().GetSlug()) {
-					ic.logger.Warn("ignoring same-named check run created by another GitHub App",
+				if !ic.isTrustedCheckAppSlug(run.GetApp().GetSlug()) {
+					ic.logger.Warn("ignoring same-named check run created by an untrusted GitHub App",
 						"repo", repo, "head_sha", headSHA, "check_name", checkName,
 						"check_run_id", run.GetID(), "app_slug", run.GetApp().GetSlug())
 					continue
@@ -696,9 +728,31 @@ func (ic *InstallationClient) isOwnAppSlug(slug string) bool {
 	return strings.EqualFold(slug, own)
 }
 
+// isTrustedCheckAppSlug returns true if the given slug belongs to a SchemaBot
+// deployment this instance trusts: its own App or a configured trusted sibling
+// deployment App. An empty slug never matches, so StatusContext rows (which
+// have no App) and unverifiable rows fail closed.
+func (ic *InstallationClient) isTrustedCheckAppSlug(slug string) bool {
+	if slug == "" {
+		return false
+	}
+	if ic.isOwnAppSlug(slug) {
+		return true
+	}
+	for _, trusted := range ic.trustedCheckAppSlugs {
+		if strings.EqualFold(slug, trusted) {
+			return true
+		}
+	}
+	return false
+}
+
 // GetPRCheckStatuses fetches check runs and commit statuses for a ref via REST.
-// SchemaBot's own check runs are identified via the GitHub App slug (more
-// reliable than name matching).
+// SchemaBot check runs are identified via the GitHub App slug (more reliable
+// than name matching): this deployment's own App plus any configured trusted
+// sibling deployment Apps. Sibling deployments' aggregate checks are governed
+// by SchemaBot's own promotion and merge gates, so they are classified as
+// SchemaBot checks rather than treated as external CI.
 //
 // Concurrent calls for the same (repo, ref) collapse to a single upstream
 // GitHub read via the Client-shared singleflight (when configured), so
@@ -738,7 +792,7 @@ func (ic *InstallationClient) GetPRCheckStatuses(ctx context.Context, repo strin
 			Name:        r.Name,
 			Status:      r.Status,
 			Conclusion:  r.Conclusion,
-			IsSchemaBot: ic.isOwnAppSlug(r.AppSlug),
+			IsSchemaBot: ic.isTrustedCheckAppSlug(r.AppSlug),
 		}
 	}
 	return out, nil

--- a/pkg/github/client_test.go
+++ b/pkg/github/client_test.go
@@ -287,6 +287,93 @@ func TestFetchSchemaFilesOptimizedSmallDirectory(t *testing.T) {
 	assert.Equal(t, "CREATE TABLE users (id INT);", files[0].Content)
 }
 
+// TestFindCheckRunByNameAcceptsTrustedSiblingAppCheckRun covers the
+// split-deployment topology where the looked-up check run was created by a
+// sibling SchemaBot deployment's GitHub App. The lookup must return the
+// sibling App's run when its slug is configured as trusted, while a
+// same-named run from an unconfigured app is still ignored.
+func TestFindCheckRunByNameAcceptsTrustedSiblingAppCheckRun(t *testing.T) {
+	client, mux := setupRateLimitedTestGitHubServer(t)
+	mux.HandleFunc("GET /repos/octocat/hello-world/commits/abc123/check-runs", func(w http.ResponseWriter, _ *http.Request) {
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+			"total_count": 2,
+			"check_runs": []map[string]any{
+				{"id": 9, "name": "SchemaBot (staging)", "status": "completed", "conclusion": "failure", "app": map[string]any{"slug": "github-actions"}},
+				{"id": 3, "name": "SchemaBot (staging)", "status": "completed", "conclusion": "success", "app": map[string]any{"slug": "schemabot-staging"}},
+			},
+		}))
+	})
+
+	ic := NewInstallationClientWithSlug(client, slog.New(slog.NewTextHandler(io.Discard, nil)), "schemabot-production", "schemabot-staging")
+	result, err := ic.FindCheckRunByName(t.Context(), "octocat/hello-world", "abc123", "SchemaBot (staging)")
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, int64(3), result.ID)
+	assert.Equal(t, "completed", result.Status)
+	assert.Equal(t, "success", result.Conclusion)
+}
+
+// TestFindCheckRunByNameProceedsWithTrustedSlugsWhenOwnSlugUnknown covers a
+// client that failed to fetch its own App slug but has trusted sibling slugs
+// configured. The configured slugs are statically verifiable, so the lookup
+// proceeds and matches the sibling App's run instead of failing closed on the
+// missing own slug.
+func TestFindCheckRunByNameProceedsWithTrustedSlugsWhenOwnSlugUnknown(t *testing.T) {
+	client, mux := setupRateLimitedTestGitHubServer(t)
+	mux.HandleFunc("GET /repos/octocat/hello-world/commits/abc123/check-runs", func(w http.ResponseWriter, _ *http.Request) {
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+			"total_count": 1,
+			"check_runs": []map[string]any{
+				{"id": 4, "name": "SchemaBot (staging)", "status": "completed", "conclusion": "success", "app": map[string]any{"slug": "schemabot-staging"}},
+			},
+		}))
+	})
+
+	ic := NewInstallationClientWithSlug(client, slog.New(slog.NewTextHandler(io.Discard, nil)), "", "schemabot-staging")
+	result, err := ic.FindCheckRunByName(t.Context(), "octocat/hello-world", "abc123", "SchemaBot (staging)")
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, int64(4), result.ID)
+	assert.Equal(t, "success", result.Conclusion)
+}
+
+// TestGetPRCheckStatusesClassifiesTrustedSiblingAppAsSchemaBot verifies that
+// aggregate checks created by a trusted sibling SchemaBot deployment's App are
+// classified as SchemaBot checks. Sibling aggregate checks are governed by
+// SchemaBot's own promotion and merge gates, so the passing-checks gate must
+// not treat them as external CI that can block apply.
+func TestGetPRCheckStatusesClassifiesTrustedSiblingAppAsSchemaBot(t *testing.T) {
+	client, mux := setupRateLimitedTestGitHubServer(t)
+	mux.HandleFunc("GET /repos/octocat/hello-world/commits/abc123/status", func(w http.ResponseWriter, _ *http.Request) {
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{"state": "pending", "statuses": []map[string]any{}}))
+	})
+	mux.HandleFunc("GET /repos/octocat/hello-world/commits/abc123/check-runs", func(w http.ResponseWriter, _ *http.Request) {
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+			"total_count": 3,
+			"check_runs": []map[string]any{
+				{"id": 1, "name": "SchemaBot (production)", "status": "completed", "conclusion": "action_required", "app": map[string]any{"slug": "schemabot-production"}},
+				{"id": 2, "name": "SchemaBot (staging)", "status": "completed", "conclusion": "action_required", "app": map[string]any{"slug": "schemabot-staging"}},
+				{"id": 3, "name": "ci/build", "status": "completed", "conclusion": "success", "app": map[string]any{"slug": "github-actions"}},
+			},
+		}))
+	})
+
+	ic := NewInstallationClientWithSlug(client, slog.New(slog.NewTextHandler(io.Discard, nil)), "schemabot-production", "schemabot-staging")
+	statuses, err := ic.GetPRCheckStatuses(t.Context(), "octocat/hello-world", "abc123", nil)
+
+	require.NoError(t, err)
+	require.Len(t, statuses, 3)
+	byName := make(map[string]PRCheckStatus, len(statuses))
+	for _, s := range statuses {
+		byName[s.Name] = s
+	}
+	assert.True(t, byName["SchemaBot (production)"].IsSchemaBot, "own App check must be classified as SchemaBot")
+	assert.True(t, byName["SchemaBot (staging)"].IsSchemaBot, "trusted sibling App check must be classified as SchemaBot")
+	assert.False(t, byName["ci/build"].IsSchemaBot, "unrelated app check must remain external CI")
+}
+
 func setupRateLimitedTestGitHubServer(t *testing.T) (*gh.Client, *http.ServeMux) {
 	t.Helper()
 

--- a/pkg/webhook/check_prior_env.go
+++ b/pkg/webhook/check_prior_env.go
@@ -197,9 +197,11 @@ func storedPriorEnvCheckStatus(check *storage.Check) string {
 // cannot query per-database check state from another instance, and it is safer to
 // require the entire environment to be healthy before promoting.
 //
-// Only Check Runs created by this GitHub App are trusted: a same-named check
-// run from another app (e.g. a GitHub Actions job) cannot satisfy the gate,
-// and when ownership cannot be verified the gate blocks the apply.
+// Only Check Runs created by a trusted SchemaBot GitHub App are accepted:
+// this deployment's own App or a configured trusted sibling deployment App
+// (github.trusted-check-app-slugs). A same-named check run from any other app
+// (e.g. a GitHub Actions job) cannot satisfy the gate, and when ownership
+// cannot be verified the gate blocks the apply.
 func (h *Handler) checkPriorEnvViaGitHub(
 	ctx context.Context, repo string, pr int,
 	database, environment, priorEnv string,

--- a/pkg/webhook/check_prior_env_test.go
+++ b/pkg/webhook/check_prior_env_test.go
@@ -256,6 +256,118 @@ func TestCheckPriorEnvironmentsWithProductionOnlyServerConfigChecksStaging(t *te
 	}
 }
 
+// TestCheckPriorEnvironmentsCrossDeploymentAppTrust covers the split-deployment
+// topology where each environment is owned by a separate SchemaBot deployment
+// with its own GitHub App: the production deployment verifies staging through
+// the "SchemaBot (staging)" aggregate Check Run, which was created by the
+// staging deployment's App, not its own. The promotion gate must accept that
+// sibling App's check when its slug is configured as trusted — and must keep
+// failing closed when it is not, so an unconfigured deployment never trusts a
+// check it cannot attribute to a SchemaBot App.
+func TestCheckPriorEnvironmentsCrossDeploymentAppTrust(t *testing.T) {
+	const (
+		repo        = "octocat/hello-world"
+		pr          = 1
+		headSHA     = "abc123"
+		ownSlug     = "schemabot-production"
+		siblingSlug = "schemabot-staging"
+	)
+
+	productionScopedConfig := func() *api.ServerConfig {
+		return &api.ServerConfig{
+			AllowedEnvironments: []string{"production"},
+			EnvironmentOrder:    []string{"staging", "production"},
+			Databases: map[string]api.DatabaseConfig{
+				"orders": {
+					Type: "mysql",
+					Environments: map[string]api.EnvironmentConfig{
+						"production": {Deployment: "default", Target: "orders"},
+					},
+				},
+			},
+		}
+	}
+
+	setup := func(t *testing.T, installClient *ghclient.InstallationClient) (*Handler, chan string) {
+		t.Helper()
+		comments := make(chan string, 10)
+
+		service := api.New(&emptyStorage{}, productionScopedConfig(), nil, testLogger())
+		t.Cleanup(func() { utils.CloseAndLog(service) })
+
+		return &Handler{
+			service:                    service,
+			ghClients:                  ghclient.NewSingleClientSet(defaultAppName, &fakeClientFactory{client: installClient}),
+			logger:                     testLogger(),
+			priorEnvCheckMaxAttempts:   1,
+			priorEnvCheckRetryInterval: time.Nanosecond,
+		}, comments
+	}
+
+	registerGitHubEndpoints := func(t *testing.T, mux *http.ServeMux, comments chan string) {
+		t.Helper()
+		mux.HandleFunc("GET /repos/octocat/hello-world/pulls/1", func(w http.ResponseWriter, _ *http.Request) {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"head": map[string]any{"sha": headSHA, "ref": "feature"},
+				"base": map[string]any{"sha": "base123", "ref": "main"},
+				"user": map[string]any{"login": "testuser"},
+			})
+		})
+		mux.HandleFunc("GET /repos/octocat/hello-world/commits/abc123/check-runs", func(w http.ResponseWriter, _ *http.Request) {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"total_count": 1,
+				"check_runs": []map[string]any{
+					{"id": 1, "name": "SchemaBot (staging)", "status": "completed", "conclusion": "success", "app": map[string]any{"slug": siblingSlug}},
+				},
+			})
+		})
+		mux.HandleFunc("POST /repos/octocat/hello-world/issues/1/comments", func(w http.ResponseWriter, r *http.Request) {
+			var body struct {
+				Body string `json:"body"`
+			}
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+			comments <- body.Body
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": 99})
+		})
+	}
+
+	t.Run("trusted sibling app check satisfies the promotion gate", func(t *testing.T) {
+		client, mux := setupGitHubServer(t)
+		installClient := ghclient.NewInstallationClientWithSlug(client, testLogger(), ownSlug, siblingSlug)
+		h, comments := setup(t, installClient)
+		registerGitHubEndpoints(t, mux, comments)
+
+		blocked := h.checkPriorEnvironments(t.Context(), repo, pr,
+			"orders", "mysql", "production", []string{"production"}, 12345, "testuser")
+
+		assert.False(t, blocked, "a passing staging aggregate check from the trusted staging deployment App must allow production apply")
+		select {
+		case body := <-comments:
+			t.Fatalf("unexpected comment posted: %s", body)
+		default:
+		}
+	})
+
+	t.Run("unconfigured sibling app check fails closed", func(t *testing.T) {
+		client, mux := setupGitHubServer(t)
+		installClient := ghclient.NewInstallationClientWithSlug(client, testLogger(), ownSlug)
+		h, comments := setup(t, installClient)
+		registerGitHubEndpoints(t, mux, comments)
+
+		blocked := h.checkPriorEnvironments(t.Context(), repo, pr,
+			"orders", "mysql", "production", []string{"production"}, 12345, "testuser")
+
+		assert.True(t, blocked, "a staging aggregate check from an unconfigured App must not satisfy the promotion gate")
+		select {
+		case body := <-comments:
+			assert.Contains(t, body, "staging")
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out waiting for staging block comment")
+		}
+	})
+}
+
 func TestCheckPriorEnvViaGitHub(t *testing.T) {
 	const (
 		repo    = "octocat/hello-world"


### PR DESCRIPTION
## Summary

The cross-instance promotion gate verifies a prior environment's aggregate Check Run, which is created by the **sibling deployment's** GitHub App — but the lookup only trusted check runs created by this deployment's **own** App. In split deployments where each environment has its own GitHub App, the gate could never attribute the prior environment's check to a trusted App, so applies stayed blocked even when the prior environment was green.

This adds `github.trusted-check-app-slugs` to declare sibling SchemaBot deployment App slugs:

- `FindCheckRunByName` accepts check runs created by the own App or a configured trusted sibling App, still ignores all other apps (a same-named GitHub Actions job can never satisfy a gate), and still fails closed when ownership cannot be verified against anything.
- `GetPRCheckStatuses` classifies trusted sibling aggregate checks as SchemaBot checks, so the `require_passing_checks` gate does not treat one deployment's pending aggregate as failing external CI and deadlock the other deployment's applies.
- The knob is available on both the single-App `github:` block and per-App `apps:` entries, validated for empty/duplicate entries.

```text
production deployment, promotion gate for "SchemaBot (staging)":

check run app slug          before              after
--------------------------  ------------------  ------------------
own App                     trusted             trusted
trusted-check-app-slugs     ignored (blocked)   trusted
any other app               ignored             ignored
unverifiable                fail closed         fail closed
```

A regression test covers the split-deployment topology end-to-end: a production-scoped deployment accepts the staging deployment App's green aggregate check when its slug is trusted, and keeps failing closed when it is not configured.

---

*This PR was generated by [Amp](https://ampcode.com) with Fable (claude-fable-5).*
