### PR TITLE
fix(engine): deploy and rediscover schema change context on PlanetScale resume

### DIFF
--- a/pkg/engine/planetscale/apply.go
+++ b/pkg/engine/planetscale/apply.go
@@ -418,16 +418,7 @@ func (e *Engine) Apply(ctx context.Context, req *engine.ApplyRequest) (*engine.A
 	// Discover migration_context by diffing current SHOW VITESS_MIGRATIONS against
 	// the pre-deploy baseline. Retries because Vitess may not have created migrations
 	// immediately after the deploy request is submitted.
-	var migrationContext string
-	for attempt := range 10 {
-		migrationContext = e.discoverMigrationContext(ctx, client, req.Database, req.Credentials, existingContexts)
-		if migrationContext != "" {
-			break
-		}
-		if attempt < 9 {
-			time.Sleep(500 * time.Millisecond)
-		}
-	}
+	migrationContext := e.discoverMigrationContextWithRetry(ctx, client, req.Database, req.Credentials, existingContexts)
 
 	meta, err := encodePSMetadata(&psMetadata{
 		BranchName:       branchName,
@@ -680,8 +671,8 @@ func (e *Engine) diffBranchForResume(ctx context.Context, client psclient.PSClie
 
 // resumeApply resumes a schema change after restart.
 // Handles two crash scenarios:
-//   - Branch exists, no deploy request: diff branch against desired schema, apply remaining DDL, create deploy request
-//   - Branch exists, deploy request exists: just return current state for Progress polling
+//   - Branch exists, no deploy request: diff branch against desired schema, apply remaining DDL, then create and deploy the deploy request
+//   - Branch exists, deploy request exists: reattach, deploy it when it was created but never started, and rediscover the Vitess migration_context for progress
 func (e *Engine) resumeApply(ctx context.Context, client psclient.PSClient, org string, req *engine.ApplyRequest) (*engine.ApplyResult, error) {
 	meta, err := decodePSMetadata(req.ResumeState.Metadata)
 	if err != nil {
@@ -704,39 +695,9 @@ func (e *Engine) resumeApply(ctx context.Context, client psclient.PSClient, org 
 		"deploy_request", meta.DeployRequestID,
 	)
 
-	// If we have a deploy request ID, check its current state.
+	// If we have a deploy request ID, the worker crashed after creating it.
 	if meta.DeployRequestID != 0 {
-		dr, err := e.getDeployRequest(ctx, client, org, req.Database, meta.DeployRequestID)
-		if err != nil {
-			// Deploy request may have been cleaned up — start fresh.
-			e.logger.Warn("deploy request not found on resume, starting fresh",
-				"deploy_request", meta.DeployRequestID, "error", err)
-			req.ResumeState = nil
-			return e.Apply(ctx, req)
-		}
-
-		// If the deploy request failed, start fresh with a new branch rather
-		// than resuming a broken deploy.
-		if dr.DeploymentState == deployState.Error || dr.DeploymentState == deployState.CompleteError {
-			e.logger.Warn("deploy request in error state on resume, starting fresh",
-				"deploy_request", meta.DeployRequestID, "state", dr.DeploymentState)
-			req.ResumeState = nil
-			return e.Apply(ctx, req)
-		}
-
-		meta.DeployRequestURL = dr.HtmlURL
-		updatedMeta, err := encodePSMetadata(meta)
-		if err != nil {
-			return nil, fmt.Errorf("encode metadata for deploy request #%d: %w", meta.DeployRequestID, err)
-		}
-		return &engine.ApplyResult{
-			Accepted: true,
-			Message:  fmt.Sprintf("Resumed deploy request #%d (state: %s)", dr.Number, dr.DeploymentState),
-			ResumeState: &engine.ResumeState{
-				MigrationContext: req.ResumeState.MigrationContext,
-				Metadata:         updatedMeta,
-			},
-		}, nil
+		return e.resumeExistingDeployRequest(ctx, client, org, req, meta)
 	}
 
 	// No deploy request yet — worker crashed after branch creation but before
@@ -853,6 +814,10 @@ func (e *Engine) resumeApply(ctx context.Context, client psclient.PSClient, org 
 		})
 	}
 
+	// Capture the migration_context baseline before deploying so the new Vitess
+	// context can be identified once Vitess creates migrations for this deploy.
+	existingContexts := e.captureExistingContexts(ctx, client, req.Database, req.Credentials)
+
 	dr, err = client.DeployDeployRequest(ctx, &ps.PerformDeployRequest{
 		Organization: org, Database: req.Database, Number: dr.Number, InstantDDL: useInstant,
 	})
@@ -860,13 +825,132 @@ func (e *Engine) resumeApply(ctx context.Context, client psclient.PSClient, org 
 		return nil, fmt.Errorf("deploy on resume: %w", err)
 	}
 
-	e.logger.Info("resumed and deployed", "number", dr.Number, "branch", meta.BranchName)
+	migrationContext := e.resolveResumeMigrationContext(ctx, client, req, existingContexts)
+
+	e.logger.Info("resumed and deployed", "number", dr.Number, "branch", meta.BranchName, "migration_context", migrationContext)
 	return &engine.ApplyResult{
 		Accepted: true,
 		Message:  fmt.Sprintf("Resumed and deployed request #%d", dr.Number),
 		ResumeState: &engine.ResumeState{
-			MigrationContext: req.ResumeState.MigrationContext,
+			MigrationContext: migrationContext,
 			Metadata:         persistMeta,
 		},
 	}, nil
+}
+
+// resumeExistingDeployRequest resumes an apply whose deploy request was already
+// created before the crash. It reattaches to the recovered deploy request,
+// deploys it when the worker crashed after creation but before the deploy was
+// started, and rediscovers the Vitess migration_context so per-shard progress
+// keeps working for the rest of the apply.
+func (e *Engine) resumeExistingDeployRequest(ctx context.Context, client psclient.PSClient, org string, req *engine.ApplyRequest, meta *psMetadata) (*engine.ApplyResult, error) {
+	dr, err := e.getDeployRequest(ctx, client, org, req.Database, meta.DeployRequestID)
+	if err != nil {
+		// Deploy request may have been cleaned up — start fresh.
+		e.logger.Warn("deploy request not found on resume, starting fresh",
+			"database", req.Database, "deploy_request", meta.DeployRequestID, "error", err)
+		req.ResumeState = nil
+		return e.Apply(ctx, req)
+	}
+
+	// If the deploy request failed, start fresh with a new branch rather
+	// than resuming a broken deploy.
+	if dr.DeploymentState == deployState.Error || dr.DeploymentState == deployState.CompleteError {
+		e.logger.Warn("deploy request in error state on resume, starting fresh",
+			"database", req.Database, "deploy_request", meta.DeployRequestID, "state", dr.DeploymentState)
+		req.ResumeState = nil
+		return e.Apply(ctx, req)
+	}
+
+	meta.DeployRequestURL = dr.HtmlURL
+	updatedMeta, err := encodePSMetadata(meta)
+	if err != nil {
+		return nil, fmt.Errorf("encode metadata for deploy request #%d: %w", meta.DeployRequestID, err)
+	}
+
+	migrationContext := req.ResumeState.MigrationContext
+
+	// A non-deferred deploy request that crashed after creation but before being
+	// deployed sits in "ready" indefinitely: Progress maps "ready" to pending,
+	// the deferred-deploy promotion to waiting_for_deploy does not apply, and the
+	// tern auto-deploy trigger only fires on waiting_for_deploy. Start the deploy
+	// here, mirroring the fresh path, so the schema change actually runs.
+	if deployRequestNeedsResumeDeploy(dr, meta) {
+		e.logger.Info("deploying recovered deploy request that was never started",
+			"database", req.Database, "deploy_request", dr.Number, "branch", meta.BranchName, "instant_ddl", meta.IsInstant)
+
+		// Capture the migration_context baseline before deploying so the new
+		// Vitess context can be identified after Vitess creates migrations.
+		existingContexts := e.captureExistingContexts(ctx, client, req.Database, req.Credentials)
+
+		deployed, deployErr := client.DeployDeployRequest(ctx, &ps.PerformDeployRequest{
+			Organization: org, Database: req.Database, Number: dr.Number, InstantDDL: meta.IsInstant,
+		})
+		if deployErr != nil {
+			return nil, fmt.Errorf("deploy recovered deploy request #%d on resume: %w", dr.Number, deployErr)
+		}
+		dr = deployed
+
+		migrationContext = e.resolveResumeMigrationContext(ctx, client, req, existingContexts)
+
+		e.logger.Info("resumed and deployed recovered deploy request",
+			"database", req.Database, "deploy_request", dr.Number, "branch", meta.BranchName, "migration_context", migrationContext)
+		return &engine.ApplyResult{
+			Accepted: true,
+			Message:  fmt.Sprintf("Resumed and deployed request #%d", dr.Number),
+			ResumeState: &engine.ResumeState{
+				MigrationContext: migrationContext,
+				Metadata:         updatedMeta,
+			},
+		}, nil
+	}
+
+	e.logger.Info("reattached to deploy request on resume",
+		"database", req.Database, "deploy_request", dr.Number, "state", dr.DeploymentState,
+		"deferred_deploy", meta.DeferredDeploy, "has_migration_context", migrationContext != "")
+	return &engine.ApplyResult{
+		Accepted: true,
+		Message:  fmt.Sprintf("Resumed deploy request #%d (state: %s)", dr.Number, dr.DeploymentState),
+		ResumeState: &engine.ResumeState{
+			MigrationContext: migrationContext,
+			Metadata:         updatedMeta,
+		},
+	}, nil
+}
+
+// deployRequestNeedsResumeDeploy reports whether a recovered deploy request must
+// be deployed during resume. This is the case only for a non-deferred deploy
+// request that finished PlanetScale's diff ("ready") but was never started —
+// the worker crashed between creating the deploy request and deploying it. A
+// deferred deploy is left for the operator-triggered deploy, and a request that
+// already has a DeployedAt timestamp is in flight and must not be re-deployed.
+func deployRequestNeedsResumeDeploy(dr *ps.DeployRequest, meta *psMetadata) bool {
+	return dr.DeploymentState == deployState.Ready && !meta.DeferredDeploy && dr.DeployedAt == nil
+}
+
+// resolveResumeMigrationContext rediscovers the Vitess migration_context after a
+// resume deploy. It prefers a freshly discovered context (the one that appeared
+// since the pre-deploy baseline). When discovery turns up nothing — Vitess may
+// not have created migrations within the bounded discovery window — it preserves
+// the stored value rather than clobbering a real context with an empty string.
+// A stored value is only a real Vitess context when it already appears in the
+// baseline; otherwise it is the tern-assigned apply identifier, which never
+// matches SHOW VITESS_MIGRATIONS, so per-shard progress stays empty until a real
+// context is found.
+func (e *Engine) resolveResumeMigrationContext(ctx context.Context, client psclient.PSClient, req *engine.ApplyRequest, existingContexts map[string]bool) string {
+	stored := req.ResumeState.MigrationContext
+
+	discovered := e.discoverMigrationContextWithRetry(ctx, client, req.Database, req.Credentials, existingContexts)
+	if discovered != "" {
+		return discovered
+	}
+
+	if stored != "" && existingContexts[stored] {
+		e.logger.Debug("keeping stored Vitess context on resume", "database", req.Database, "context", stored)
+		return stored
+	}
+
+	e.logger.Warn("Vitess context not discovered on resume; per-shard progress will be empty until it is found",
+		"database", req.Database, "stored_context", stored)
+	return stored
 }

--- a/pkg/engine/planetscale/apply.go
+++ b/pkg/engine/planetscale/apply.go
@@ -3,6 +3,7 @@ package planetscale
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -418,7 +419,7 @@ func (e *Engine) Apply(ctx context.Context, req *engine.ApplyRequest) (*engine.A
 	// Discover migration_context by diffing current SHOW VITESS_MIGRATIONS against
 	// the pre-deploy baseline. Retries because Vitess may not have created migrations
 	// immediately after the deploy request is submitted.
-	migrationContext := e.discoverMigrationContextWithRetry(ctx, client, req.Database, req.Credentials, existingContexts)
+	migrationContext := e.discoverSchemaChangeContextWithRetry(ctx, client, req.Database, req.Credentials, existingContexts)
 
 	meta, err := encodePSMetadata(&psMetadata{
 		BranchName:       branchName,
@@ -825,11 +826,11 @@ func (e *Engine) resumeApply(ctx context.Context, client psclient.PSClient, org 
 		return nil, fmt.Errorf("deploy on resume: %w", err)
 	}
 
-	migrationContext := e.resolveResumeMigrationContext(ctx, client, req, existingContexts)
+	migrationContext := e.resolveResumeSchemaChangeContext(ctx, client, req, existingContexts)
 
 	// Persist the rediscovered context now so a crash before this function
 	// returns does not lose it — the returned ResumeState alone is not durable.
-	e.persistResumeMigrationContext(req, migrationContext, persistMeta)
+	e.persistResumeSchemaChangeContext(req, migrationContext, persistMeta)
 
 	e.logger.Info("resumed and deployed", "number", dr.Number, "branch", meta.BranchName, "migration_context", migrationContext)
 	return &engine.ApplyResult{
@@ -850,11 +851,19 @@ func (e *Engine) resumeApply(ctx context.Context, client psclient.PSClient, org 
 func (e *Engine) resumeExistingDeployRequest(ctx context.Context, client psclient.PSClient, org string, req *engine.ApplyRequest, meta *psMetadata) (*engine.ApplyResult, error) {
 	dr, err := e.getDeployRequest(ctx, client, org, req.Database, meta.DeployRequestID)
 	if err != nil {
-		// Deploy request may have been cleaned up — start fresh.
-		e.logger.Warn("deploy request not found on resume, starting fresh",
-			"database", req.Database, "deploy_request", meta.DeployRequestID, "error", err)
-		req.ResumeState = nil
-		return e.Apply(ctx, req)
+		// Only a genuine not-found means the deploy request was cleaned up and the
+		// apply should start fresh. A transient API error must propagate so resume
+		// retries against the same deploy request — forking a fresh branch and
+		// deploy request here would start a duplicate schema change while the
+		// original is still in flight.
+		var psErr *ps.Error
+		if errors.As(err, &psErr) && psErr.Code == ps.ErrNotFound {
+			e.logger.Warn("deploy request not found on resume, starting fresh",
+				"database", req.Database, "deploy_request", meta.DeployRequestID, "error", err)
+			req.ResumeState = nil
+			return e.Apply(ctx, req)
+		}
+		return nil, fmt.Errorf("get deploy request #%d on resume: %w", meta.DeployRequestID, err)
 	}
 
 	// If the deploy request failed, start fresh with a new branch rather
@@ -879,6 +888,11 @@ func (e *Engine) resumeExistingDeployRequest(ctx context.Context, client psclien
 	// the deferred-deploy promotion to waiting_for_deploy does not apply, and the
 	// tern auto-deploy trigger only fires on waiting_for_deploy. Start the deploy
 	// here, mirroring the fresh path, so the schema change actually runs.
+	//
+	// The gate reads dr just above and then calls DeployDeployRequest, so two
+	// resumes racing here could both decide to deploy. That read→call window is
+	// self-correcting: the provider accepts at most one deploy and rejects the
+	// loser, so a duplicate schema change is never started.
 	if deployRequestNeedsResumeDeploy(dr, meta) {
 		e.logger.Info("deploying recovered deploy request that was never started",
 			"database", req.Database, "deploy_request", dr.Number, "branch", meta.BranchName, "instant_ddl", meta.IsInstant)
@@ -895,11 +909,11 @@ func (e *Engine) resumeExistingDeployRequest(ctx context.Context, client psclien
 		}
 		dr = deployed
 
-		migrationContext = e.resolveResumeMigrationContext(ctx, client, req, existingContexts)
+		migrationContext = e.resolveResumeSchemaChangeContext(ctx, client, req, existingContexts)
 
 		// Persist the rediscovered context now so a crash before this function
 		// returns does not lose it — the returned ResumeState alone is not durable.
-		e.persistResumeMigrationContext(req, migrationContext, updatedMeta)
+		e.persistResumeSchemaChangeContext(req, migrationContext, updatedMeta)
 
 		e.logger.Info("resumed and deployed recovered deploy request",
 			"database", req.Database, "deploy_request", dr.Number, "branch", meta.BranchName, "migration_context", migrationContext)
@@ -922,13 +936,16 @@ func (e *Engine) resumeExistingDeployRequest(ctx context.Context, client psclien
 	if !isRealVitessContext(migrationContext) {
 		e.logger.Info("rediscovering Vitess context on reattach; stored value is not a real context",
 			"database", req.Database, "deploy_request", dr.Number, "stored_context", migrationContext)
-		// The deploy already ran in a prior process, so its Vitess context is
-		// already present in SHOW VITESS_MIGRATIONS. Discover against an empty
-		// baseline so any existing context counts as a match.
-		rediscovered := e.discoverMigrationContextWithRetry(ctx, client, req.Database, req.Credentials, map[string]bool{})
+		// The deploy ran in a prior process, so its context is already in SHOW
+		// VITESS_MIGRATIONS. Discover against an empty baseline, which makes every
+		// context a candidate; selection keeps only non-terminal candidates so a
+		// completed historical context from an unrelated change is never matched.
+		// A genuinely finished change yields no non-terminal candidate, so the
+		// stored identifier is preserved rather than attached to stale progress.
+		rediscovered := e.discoverSchemaChangeContextWithRetry(ctx, client, req.Database, req.Credentials, map[string]bool{})
 		if rediscovered != "" {
 			migrationContext = rediscovered
-			e.persistResumeMigrationContext(req, migrationContext, updatedMeta)
+			e.persistResumeSchemaChangeContext(req, migrationContext, updatedMeta)
 		} else {
 			e.logger.Warn("Vitess context not found on reattach; per-shard progress will be empty until it is found",
 				"database", req.Database, "deploy_request", dr.Number, "stored_context", migrationContext)
@@ -958,7 +975,7 @@ func deployRequestNeedsResumeDeploy(dr *ps.DeployRequest, meta *psMetadata) bool
 	return dr.DeploymentState == deployState.Ready && !meta.DeferredDeploy && dr.DeployedAt == nil
 }
 
-// resolveResumeMigrationContext rediscovers the Vitess migration_context after a
+// resolveResumeSchemaChangeContext rediscovers the Vitess migration_context after a
 // resume deploy. It prefers a freshly discovered context (the one that appeared
 // since the pre-deploy baseline). When discovery turns up nothing — Vitess may
 // not have created migrations within the bounded discovery window — it preserves
@@ -967,10 +984,10 @@ func deployRequestNeedsResumeDeploy(dr *ps.DeployRequest, meta *psMetadata) bool
 // baseline; otherwise it is the tern-assigned apply identifier, which never
 // matches SHOW VITESS_MIGRATIONS, so per-shard progress stays empty until a real
 // context is found.
-func (e *Engine) resolveResumeMigrationContext(ctx context.Context, client psclient.PSClient, req *engine.ApplyRequest, existingContexts map[string]bool) string {
+func (e *Engine) resolveResumeSchemaChangeContext(ctx context.Context, client psclient.PSClient, req *engine.ApplyRequest, existingContexts map[string]bool) string {
 	stored := req.ResumeState.MigrationContext
 
-	discovered := e.discoverMigrationContextWithRetry(ctx, client, req.Database, req.Credentials, existingContexts)
+	discovered := e.discoverSchemaChangeContextWithRetry(ctx, client, req.Database, req.Credentials, existingContexts)
 	if discovered != "" {
 		return discovered
 	}
@@ -988,23 +1005,25 @@ func (e *Engine) resolveResumeMigrationContext(ctx context.Context, client pscli
 // isRealVitessContext reports whether a migration_context value is a real Vitess
 // context (the "<system>:<uuid>" form that appears in SHOW VITESS_MIGRATIONS,
 // e.g. "singularity:17694ee9-...") rather than the tern-assigned apply identifier
-// (e.g. "apply-1a2b3c..."). The apply identifier never matches a Vitess migration
-// row, so per-shard progress stays empty until a real context is resolved. The
-// colon separating system and uuid is the distinguishing marker — tern identifiers
-// never contain one.
+// (e.g. "apply-1a2b3c..."). The apply identifier never matches a SHOW
+// VITESS_MIGRATIONS row, so per-shard progress stays empty until a real context
+// is resolved. The colon separating system and uuid is the distinguishing
+// marker — tern identifiers never contain one.
 func isRealVitessContext(migrationContext string) bool {
 	return strings.Contains(migrationContext, ":")
 }
 
-// persistResumeMigrationContext durably records a freshly resolved Vitess context
+// persistResumeSchemaChangeContext durably records a freshly resolved Vitess context
 // via OnStateChange so a crash after deploy (but before the resume function
 // returns) does not lose it — without persistence the stored ResumeState would
 // still hold the tern apply identifier, leaving the next resume with no per-shard
 // Vitess progress. It only persists a real Vitess context; an empty or
 // apply-identifier value carries no per-shard progress and is left untouched so a
 // previously persisted real context is never clobbered.
-func (e *Engine) persistResumeMigrationContext(req *engine.ApplyRequest, migrationContext, metadata string) {
+func (e *Engine) persistResumeSchemaChangeContext(req *engine.ApplyRequest, migrationContext, metadata string) {
 	if req.OnStateChange == nil {
+		e.logger.Debug("not persisting resume context: no OnStateChange callback",
+			"database", req.Database, "context", migrationContext)
 		return
 	}
 	if !isRealVitessContext(migrationContext) {

--- a/pkg/engine/planetscale/apply.go
+++ b/pkg/engine/planetscale/apply.go
@@ -827,6 +827,10 @@ func (e *Engine) resumeApply(ctx context.Context, client psclient.PSClient, org 
 
 	migrationContext := e.resolveResumeMigrationContext(ctx, client, req, existingContexts)
 
+	// Persist the rediscovered context now so a crash before this function
+	// returns does not lose it — the returned ResumeState alone is not durable.
+	e.persistResumeMigrationContext(req, migrationContext, persistMeta)
+
 	e.logger.Info("resumed and deployed", "number", dr.Number, "branch", meta.BranchName, "migration_context", migrationContext)
 	return &engine.ApplyResult{
 		Accepted: true,
@@ -893,6 +897,10 @@ func (e *Engine) resumeExistingDeployRequest(ctx context.Context, client psclien
 
 		migrationContext = e.resolveResumeMigrationContext(ctx, client, req, existingContexts)
 
+		// Persist the rediscovered context now so a crash before this function
+		// returns does not lose it — the returned ResumeState alone is not durable.
+		e.persistResumeMigrationContext(req, migrationContext, updatedMeta)
+
 		e.logger.Info("resumed and deployed recovered deploy request",
 			"database", req.Database, "deploy_request", dr.Number, "branch", meta.BranchName, "migration_context", migrationContext)
 		return &engine.ApplyResult{
@@ -903,6 +911,28 @@ func (e *Engine) resumeExistingDeployRequest(ctx context.Context, client psclien
 				Metadata:         updatedMeta,
 			},
 		}, nil
+	}
+
+	// Reattach-only path: no deploy was started here. If the stored context is
+	// still the tern apply identifier (not a real Vitess context), an earlier
+	// crash lost the discovered context, so per-shard progress would stay empty
+	// for the rest of the apply. Rediscover it from the current migrations and
+	// persist the result. A stored value that is already a real Vitess context is
+	// kept as-is.
+	if !isRealVitessContext(migrationContext) {
+		e.logger.Info("rediscovering Vitess context on reattach; stored value is not a real context",
+			"database", req.Database, "deploy_request", dr.Number, "stored_context", migrationContext)
+		// The deploy already ran in a prior process, so its Vitess context is
+		// already present in SHOW VITESS_MIGRATIONS. Discover against an empty
+		// baseline so any existing context counts as a match.
+		rediscovered := e.discoverMigrationContextWithRetry(ctx, client, req.Database, req.Credentials, map[string]bool{})
+		if rediscovered != "" {
+			migrationContext = rediscovered
+			e.persistResumeMigrationContext(req, migrationContext, updatedMeta)
+		} else {
+			e.logger.Warn("Vitess context not found on reattach; per-shard progress will be empty until it is found",
+				"database", req.Database, "deploy_request", dr.Number, "stored_context", migrationContext)
+		}
 	}
 
 	e.logger.Info("reattached to deploy request on resume",
@@ -953,4 +983,39 @@ func (e *Engine) resolveResumeMigrationContext(ctx context.Context, client pscli
 	e.logger.Warn("Vitess context not discovered on resume; per-shard progress will be empty until it is found",
 		"database", req.Database, "stored_context", stored)
 	return stored
+}
+
+// isRealVitessContext reports whether a migration_context value is a real Vitess
+// context (the "<system>:<uuid>" form that appears in SHOW VITESS_MIGRATIONS,
+// e.g. "singularity:17694ee9-...") rather than the tern-assigned apply identifier
+// (e.g. "apply-1a2b3c..."). The apply identifier never matches a Vitess migration
+// row, so per-shard progress stays empty until a real context is resolved. The
+// colon separating system and uuid is the distinguishing marker — tern identifiers
+// never contain one.
+func isRealVitessContext(migrationContext string) bool {
+	return strings.Contains(migrationContext, ":")
+}
+
+// persistResumeMigrationContext durably records a freshly resolved Vitess context
+// via OnStateChange so a crash after deploy (but before the resume function
+// returns) does not lose it — without persistence the stored ResumeState would
+// still hold the tern apply identifier, leaving the next resume with no per-shard
+// Vitess progress. It only persists a real Vitess context; an empty or
+// apply-identifier value carries no per-shard progress and is left untouched so a
+// previously persisted real context is never clobbered.
+func (e *Engine) persistResumeMigrationContext(req *engine.ApplyRequest, migrationContext, metadata string) {
+	if req.OnStateChange == nil {
+		return
+	}
+	if !isRealVitessContext(migrationContext) {
+		e.logger.Debug("not persisting resume context: not a real Vitess context yet",
+			"database", req.Database, "context", migrationContext)
+		return
+	}
+	e.logger.Info("persisting rediscovered Vitess context on resume",
+		"database", req.Database, "context", migrationContext)
+	req.OnStateChange(&engine.ResumeState{
+		MigrationContext: migrationContext,
+		Metadata:         metadata,
+	})
 }

--- a/pkg/engine/planetscale/apply_test.go
+++ b/pkg/engine/planetscale/apply_test.go
@@ -219,6 +219,17 @@ func resumeRequest(t *testing.T, meta *psMetadata, migrationContext string) *eng
 	}
 }
 
+// captureStateChanges installs an OnStateChange callback on req that records every
+// persisted ResumeState, so resume tests can assert the engine durably persists a
+// rediscovered Vitess context rather than only returning it in the ApplyResult.
+func captureStateChanges(req *engine.ApplyRequest) *[]*engine.ResumeState {
+	var persisted []*engine.ResumeState
+	req.OnStateChange = func(state *engine.ResumeState) {
+		persisted = append(persisted, state)
+	}
+	return &persisted
+}
+
 // deployRequestNeedsResumeDeploy gates the resume path that starts a deploy the
 // crashed worker never began. It must fire only for a non-deferred deploy
 // request that finished validation ("ready") and was never deployed.
@@ -280,7 +291,7 @@ func TestResumeExistingDeployRequest_DeploysReadyNeverStarted(t *testing.T) {
 	}
 
 	meta := &psMetadata{BranchName: "schemabot-testdb-abc", DeployRequestID: 42, IsInstant: true}
-	req := resumeRequest(t, meta, "singularity-apply-id")
+	req := resumeRequest(t, meta, "apply-1a2b3c4d5e6f7890")
 
 	result, err := e.resumeExistingDeployRequest(t.Context(), client, "org", req, meta)
 
@@ -305,6 +316,7 @@ func TestResumeExistingDeployRequest_InFlightIsNotRedeployed(t *testing.T) {
 
 	meta := &psMetadata{BranchName: "schemabot-testdb-xyz", DeployRequestID: 7}
 	req := resumeRequest(t, meta, "singularity:real-context")
+	persisted := captureStateChanges(req)
 
 	result, err := e.resumeExistingDeployRequest(t.Context(), client, "org", req, meta)
 
@@ -315,6 +327,9 @@ func TestResumeExistingDeployRequest_InFlightIsNotRedeployed(t *testing.T) {
 	require.NotNil(t, result.ResumeState)
 	assert.Equal(t, "singularity:real-context", result.ResumeState.MigrationContext)
 	assert.Contains(t, result.Message, "Resumed deploy request #7")
+	// A stored real Vitess context is authoritative — resume neither rediscovers
+	// nor re-persists it.
+	assert.Empty(t, *persisted)
 }
 
 // A deferred deploy request recovered on resume must wait for the
@@ -326,7 +341,7 @@ func TestResumeExistingDeployRequest_DeferredIsNotDeployed(t *testing.T) {
 	}
 
 	meta := &psMetadata{BranchName: "schemabot-testdb-def", DeployRequestID: 9, DeferredDeploy: true}
-	req := resumeRequest(t, meta, "singularity-apply-id")
+	req := resumeRequest(t, meta, "apply-1a2b3c4d5e6f7890")
 
 	result, err := e.resumeExistingDeployRequest(t.Context(), client, "org", req, meta)
 
@@ -349,7 +364,7 @@ func TestResumeExistingDeployRequest_ErrorStateStartsFresh(t *testing.T) {
 	}
 
 	meta := &psMetadata{BranchName: "schemabot-testdb-err", DeployRequestID: 5}
-	req := resumeRequest(t, meta, "singularity-apply-id")
+	req := resumeRequest(t, meta, "apply-1a2b3c4d5e6f7890")
 
 	_, err := e.resumeExistingDeployRequest(t.Context(), client, "org", req, meta)
 
@@ -368,10 +383,135 @@ func TestResolveResumeMigrationContext_PreservesStoredWithoutDSN(t *testing.T) {
 	req := &engine.ApplyRequest{
 		Database:    "testdb",
 		Credentials: &engine.Credentials{Metadata: map[string]string{"organization": "org", "main_branch": "main"}},
-		ResumeState: &engine.ResumeState{MigrationContext: "singularity-apply-id"},
+		ResumeState: &engine.ResumeState{MigrationContext: "apply-1a2b3c4d5e6f7890"},
 	}
 
 	got := e.resolveResumeMigrationContext(t.Context(), client, req, map[string]bool{})
 
-	assert.Equal(t, "singularity-apply-id", got)
+	assert.Equal(t, "apply-1a2b3c4d5e6f7890", got)
+}
+
+// A real Vitess context carries the "<system>:<uuid>" form that appears in SHOW
+// VITESS_MIGRATIONS, while the tern-assigned apply identifier ("apply-<hex>")
+// does not. Only the former drives per-shard progress, so the two must be
+// distinguishable by the colon separator.
+func TestIsRealVitessContext(t *testing.T) {
+	cases := []struct {
+		name             string
+		migrationContext string
+		want             bool
+	}{
+		{name: "singularity context is real", migrationContext: "singularity:17694ee9-aaaa-bbbb", want: true},
+		{name: "revert context is real", migrationContext: "revert:singularity:17694ee9", want: true},
+		{name: "tern apply identifier is not real", migrationContext: "apply-1a2b3c4d5e6f7890", want: false},
+		{name: "tern task identifier is not real", migrationContext: "task-1a2b3c4d5e6f7890", want: false},
+		{name: "empty is not real", migrationContext: "", want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, isRealVitessContext(tc.migrationContext))
+		})
+	}
+}
+
+// persistResumeMigrationContext must durably record only a real Vitess context.
+// Persisting the tern apply identifier or an empty value would carry no per-shard
+// progress and could clobber a previously persisted real context.
+func TestPersistResumeMigrationContext(t *testing.T) {
+	e := New(slog.New(slog.NewTextHandler(os.Stdout, nil)))
+
+	t.Run("persists real context", func(t *testing.T) {
+		req := resumeRequest(t, &psMetadata{}, "")
+		persisted := captureStateChanges(req)
+
+		e.persistResumeMigrationContext(req, "singularity:real-context", "encoded-meta")
+
+		require.Len(t, *persisted, 1)
+		assert.Equal(t, "singularity:real-context", (*persisted)[0].MigrationContext)
+		assert.Equal(t, "encoded-meta", (*persisted)[0].Metadata)
+	})
+
+	t.Run("skips apply identifier", func(t *testing.T) {
+		req := resumeRequest(t, &psMetadata{}, "")
+		persisted := captureStateChanges(req)
+
+		e.persistResumeMigrationContext(req, "apply-1a2b3c4d5e6f7890", "encoded-meta")
+
+		assert.Empty(t, *persisted)
+	})
+
+	t.Run("skips empty context", func(t *testing.T) {
+		req := resumeRequest(t, &psMetadata{}, "")
+		persisted := captureStateChanges(req)
+
+		e.persistResumeMigrationContext(req, "", "encoded-meta")
+
+		assert.Empty(t, *persisted)
+	})
+
+	t.Run("no-op when callback is nil", func(t *testing.T) {
+		req := resumeRequest(t, &psMetadata{}, "")
+		req.OnStateChange = nil
+
+		assert.NotPanics(t, func() {
+			e.persistResumeMigrationContext(req, "singularity:real-context", "encoded-meta")
+		})
+	})
+}
+
+// When the resume deploy path resolves a real Vitess context, it must persist
+// that context via OnStateChange before returning. Otherwise a crash after the
+// deploy starts but before the apply returns would leave storage holding the
+// tern apply identifier, with no per-shard Vitess progress for the rest of the
+// apply. The stored value here is already a real context, so resolution returns
+// it deterministically without a live vtgate, and the persist must fire.
+func TestResumeExistingDeployRequest_PersistsRealContextOnDeploy(t *testing.T) {
+	e := New(slog.New(slog.NewTextHandler(os.Stdout, nil)))
+	client := &resumeDeployClient{
+		recovered: &ps.DeployRequest{DeploymentState: deployState.Ready, HtmlURL: "https://app/dr/42"},
+	}
+
+	meta := &psMetadata{BranchName: "schemabot-testdb-abc", DeployRequestID: 42}
+	req := resumeRequest(t, meta, "singularity:real-context")
+	persisted := captureStateChanges(req)
+
+	result, err := e.resumeExistingDeployRequest(t.Context(), client, "org", req, meta)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, 1, client.deployCalls)
+	assert.Equal(t, "singularity:real-context", result.ResumeState.MigrationContext)
+
+	require.Len(t, *persisted, 1)
+	assert.Equal(t, "singularity:real-context", (*persisted)[0].MigrationContext)
+	assert.NotEmpty(t, (*persisted)[0].Metadata)
+}
+
+// On the reattach-only path (deploy already in flight from a prior process), a
+// stored value that is still the tern apply identifier means an earlier crash
+// lost the discovered Vitess context. Resume must attempt rediscovery so
+// per-shard progress can recover. Without a vtgate DSN discovery turns up
+// nothing, so the stored identifier is preserved and nothing is persisted —
+// proving the rediscovery branch is gated on the value being a non-real context
+// without clobbering it.
+func TestResumeExistingDeployRequest_ReattachRediscoversWhenApplyIdentifier(t *testing.T) {
+	e := New(slog.New(slog.NewTextHandler(os.Stdout, nil)))
+	client := &resumeDeployClient{
+		recovered: &ps.DeployRequest{DeploymentState: deployState.InProgress, HtmlURL: "https://app/dr/7"},
+	}
+
+	meta := &psMetadata{BranchName: "schemabot-testdb-xyz", DeployRequestID: 7}
+	req := resumeRequest(t, meta, "apply-1a2b3c4d5e6f7890")
+	persisted := captureStateChanges(req)
+
+	result, err := e.resumeExistingDeployRequest(t.Context(), client, "org", req, meta)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, 0, client.deployCalls)
+	require.NotNil(t, result.ResumeState)
+	assert.Equal(t, "apply-1a2b3c4d5e6f7890", result.ResumeState.MigrationContext)
+	// Discovery found no real context (no DSN), so the apply identifier is kept
+	// rather than persisted.
+	assert.Empty(t, *persisted)
 }

--- a/pkg/engine/planetscale/apply_test.go
+++ b/pkg/engine/planetscale/apply_test.go
@@ -170,3 +170,208 @@ func TestWaitForDeployRequestPending_NilDeployRequestIsRejected(t *testing.T) {
 	assert.Contains(t, err.Error(), "testdb")
 	assert.Equal(t, 0, client.getCallCount)
 }
+
+// resumeDeployClient returns a fixed deploy request on Get and records whether a
+// deploy was started. The recovered deploy request lets resume tests drive the
+// reattach path without a live PlanetScale API or vtgate.
+type resumeDeployClient struct {
+	psclient.PSClient
+	recovered    *ps.DeployRequest
+	deployCalls  int
+	lastDeploy   *ps.PerformDeployRequest
+	deployResult *ps.DeployRequest
+}
+
+func (c *resumeDeployClient) GetDeployRequest(_ context.Context, req *ps.GetDeployRequestRequest) (*ps.DeployRequest, error) {
+	dr := *c.recovered
+	dr.Number = req.Number
+	return &dr, nil
+}
+
+func (c *resumeDeployClient) DeployDeployRequest(_ context.Context, req *ps.PerformDeployRequest) (*ps.DeployRequest, error) {
+	c.deployCalls++
+	c.lastDeploy = req
+	if c.deployResult != nil {
+		return c.deployResult, nil
+	}
+	dr := *c.recovered
+	dr.Number = req.Number
+	dr.DeploymentState = deployState.InProgress
+	return &dr, nil
+}
+
+func resumeRequest(t *testing.T, meta *psMetadata, migrationContext string) *engine.ApplyRequest {
+	t.Helper()
+	encoded, err := encodePSMetadata(meta)
+	require.NoError(t, err)
+	return &engine.ApplyRequest{
+		Database: "testdb",
+		Credentials: &engine.Credentials{
+			Metadata: map[string]string{
+				"organization": "org",
+				"main_branch":  "main",
+			},
+		},
+		ResumeState: &engine.ResumeState{
+			MigrationContext: migrationContext,
+			Metadata:         encoded,
+		},
+	}
+}
+
+// deployRequestNeedsResumeDeploy gates the resume path that starts a deploy the
+// crashed worker never began. It must fire only for a non-deferred deploy
+// request that finished validation ("ready") and was never deployed.
+func TestDeployRequestNeedsResumeDeploy(t *testing.T) {
+	deployedAt := time.Now()
+	cases := []struct {
+		name string
+		dr   *ps.DeployRequest
+		meta *psMetadata
+		want bool
+	}{
+		{
+			name: "ready non-deferred not deployed needs deploy",
+			dr:   &ps.DeployRequest{DeploymentState: deployState.Ready},
+			meta: &psMetadata{},
+			want: true,
+		},
+		{
+			name: "ready but deferred is left for operator-triggered deploy",
+			dr:   &ps.DeployRequest{DeploymentState: deployState.Ready},
+			meta: &psMetadata{DeferredDeploy: true},
+			want: false,
+		},
+		{
+			name: "ready but already deployed is in flight",
+			dr:   &ps.DeployRequest{DeploymentState: deployState.Ready, DeployedAt: &deployedAt},
+			meta: &psMetadata{},
+			want: false,
+		},
+		{
+			name: "in progress is already running",
+			dr:   &ps.DeployRequest{DeploymentState: deployState.InProgress},
+			meta: &psMetadata{},
+			want: false,
+		},
+		{
+			name: "pending validation is not ready yet",
+			dr:   &ps.DeployRequest{DeploymentState: deployState.Pending},
+			meta: &psMetadata{},
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, deployRequestNeedsResumeDeploy(tc.dr, tc.meta))
+		})
+	}
+}
+
+// A worker that crashed between creating a non-deferred deploy request and
+// starting it leaves the request stuck in "ready", which Progress reports as
+// pending forever. Resuming must start the deploy so the schema change actually
+// runs, carrying the instant DDL flag from the recovered metadata.
+func TestResumeExistingDeployRequest_DeploysReadyNeverStarted(t *testing.T) {
+	e := New(slog.New(slog.NewTextHandler(os.Stdout, nil)))
+	client := &resumeDeployClient{
+		recovered: &ps.DeployRequest{DeploymentState: deployState.Ready, HtmlURL: "https://app/dr/42"},
+	}
+
+	meta := &psMetadata{BranchName: "schemabot-testdb-abc", DeployRequestID: 42, IsInstant: true}
+	req := resumeRequest(t, meta, "singularity-apply-id")
+
+	result, err := e.resumeExistingDeployRequest(t.Context(), client, "org", req, meta)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.True(t, result.Accepted)
+	assert.Equal(t, 1, client.deployCalls)
+	require.NotNil(t, client.lastDeploy)
+	assert.Equal(t, uint64(42), client.lastDeploy.Number)
+	assert.Equal(t, "testdb", client.lastDeploy.Database)
+	assert.True(t, client.lastDeploy.InstantDDL)
+	assert.Contains(t, result.Message, "Resumed and deployed request #42")
+}
+
+// A deploy request that is already in flight when the worker resumes must not be
+// re-deployed; resume simply reattaches and preserves the stored progress state.
+func TestResumeExistingDeployRequest_InFlightIsNotRedeployed(t *testing.T) {
+	e := New(slog.New(slog.NewTextHandler(os.Stdout, nil)))
+	client := &resumeDeployClient{
+		recovered: &ps.DeployRequest{DeploymentState: deployState.InProgress, HtmlURL: "https://app/dr/7"},
+	}
+
+	meta := &psMetadata{BranchName: "schemabot-testdb-xyz", DeployRequestID: 7}
+	req := resumeRequest(t, meta, "singularity:real-context")
+
+	result, err := e.resumeExistingDeployRequest(t.Context(), client, "org", req, meta)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.True(t, result.Accepted)
+	assert.Equal(t, 0, client.deployCalls)
+	require.NotNil(t, result.ResumeState)
+	assert.Equal(t, "singularity:real-context", result.ResumeState.MigrationContext)
+	assert.Contains(t, result.Message, "Resumed deploy request #7")
+}
+
+// A deferred deploy request recovered on resume must wait for the
+// operator-triggered deploy rather than being started automatically.
+func TestResumeExistingDeployRequest_DeferredIsNotDeployed(t *testing.T) {
+	e := New(slog.New(slog.NewTextHandler(os.Stdout, nil)))
+	client := &resumeDeployClient{
+		recovered: &ps.DeployRequest{DeploymentState: deployState.Ready, HtmlURL: "https://app/dr/9"},
+	}
+
+	meta := &psMetadata{BranchName: "schemabot-testdb-def", DeployRequestID: 9, DeferredDeploy: true}
+	req := resumeRequest(t, meta, "singularity-apply-id")
+
+	result, err := e.resumeExistingDeployRequest(t.Context(), client, "org", req, meta)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, 0, client.deployCalls)
+	assert.Contains(t, result.Message, "Resumed deploy request #9")
+}
+
+// A failed deploy request must not be resumed; the apply restarts fresh on a new
+// branch. With nil credentials the fresh Apply fails fast, proving the recovered
+// request was abandoned rather than reattached.
+func TestResumeExistingDeployRequest_ErrorStateStartsFresh(t *testing.T) {
+	e := NewWithClient(slog.New(slog.NewTextHandler(os.Stdout, nil)),
+		func(_, _ string) (psclient.PSClient, error) {
+			return nil, errors.New("client unavailable")
+		})
+	client := &resumeDeployClient{
+		recovered: &ps.DeployRequest{DeploymentState: deployState.Error},
+	}
+
+	meta := &psMetadata{BranchName: "schemabot-testdb-err", DeployRequestID: 5}
+	req := resumeRequest(t, meta, "singularity-apply-id")
+
+	_, err := e.resumeExistingDeployRequest(t.Context(), client, "org", req, meta)
+
+	require.Error(t, err)
+	assert.Equal(t, 0, client.deployCalls)
+	assert.Nil(t, req.ResumeState)
+}
+
+// When no vtgate DSN is configured, resume cannot rediscover a Vitess context;
+// it must preserve the stored identifier as-is rather than blanking it, so the
+// apply record keeps whatever progress handle it already had.
+func TestResolveResumeMigrationContext_PreservesStoredWithoutDSN(t *testing.T) {
+	e := New(slog.New(slog.NewTextHandler(os.Stdout, nil)))
+	client := &resumeDeployClient{recovered: &ps.DeployRequest{}}
+
+	req := &engine.ApplyRequest{
+		Database:    "testdb",
+		Credentials: &engine.Credentials{Metadata: map[string]string{"organization": "org", "main_branch": "main"}},
+		ResumeState: &engine.ResumeState{MigrationContext: "singularity-apply-id"},
+	}
+
+	got := e.resolveResumeMigrationContext(t.Context(), client, req, map[string]bool{})
+
+	assert.Equal(t, "singularity-apply-id", got)
+}

--- a/pkg/engine/planetscale/apply_test.go
+++ b/pkg/engine/planetscale/apply_test.go
@@ -177,12 +177,18 @@ func TestWaitForDeployRequestPending_NilDeployRequestIsRejected(t *testing.T) {
 type resumeDeployClient struct {
 	psclient.PSClient
 	recovered    *ps.DeployRequest
+	getErr       error
+	getCalls     int
 	deployCalls  int
 	lastDeploy   *ps.PerformDeployRequest
 	deployResult *ps.DeployRequest
 }
 
 func (c *resumeDeployClient) GetDeployRequest(_ context.Context, req *ps.GetDeployRequestRequest) (*ps.DeployRequest, error) {
+	c.getCalls++
+	if c.getErr != nil {
+		return nil, c.getErr
+	}
 	dr := *c.recovered
 	dr.Number = req.Number
 	return &dr, nil
@@ -373,10 +379,67 @@ func TestResumeExistingDeployRequest_ErrorStateStartsFresh(t *testing.T) {
 	assert.Nil(t, req.ResumeState)
 }
 
+// A transient error fetching the recovered deploy request must NOT be treated as
+// "the deploy request was cleaned up." Starting fresh here would create a new
+// branch and a second deploy request while the original is still actively
+// deploying. Resume must propagate the transient error so it retries against the
+// same deploy request instead of forking a duplicate schema change.
+func TestResumeExistingDeployRequest_TransientGetErrorDoesNotFork(t *testing.T) {
+	freshApplyCalled := false
+	e := NewWithClient(slog.New(slog.NewTextHandler(os.Stdout, nil)),
+		func(_, _ string) (psclient.PSClient, error) {
+			freshApplyCalled = true
+			return nil, errors.New("fresh apply must not run")
+		})
+	transientErr := &ps.Error{Code: ps.ErrInternal}
+	client := &resumeDeployClient{getErr: transientErr}
+
+	meta := &psMetadata{BranchName: "schemabot-testdb-xyz", DeployRequestID: 7}
+	req := resumeRequest(t, meta, "singularity:in-flight")
+
+	_, err := e.resumeExistingDeployRequest(t.Context(), client, "org", req, meta)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, transientErr)
+	assert.Contains(t, err.Error(), "get deploy request #7 on resume")
+	// No fresh apply, no second deploy: the original deploy request is untouched.
+	assert.False(t, freshApplyCalled)
+	assert.Equal(t, 0, client.deployCalls)
+	assert.Equal(t, 1, client.getCalls)
+	// ResumeState is preserved so the next resume retries the same deploy request.
+	require.NotNil(t, req.ResumeState)
+	assert.Equal(t, "singularity:in-flight", req.ResumeState.MigrationContext)
+}
+
+// A genuine not-found means the deploy request really was cleaned up, so resume
+// abandons the stale record and starts a fresh apply. The fresh Apply fails fast
+// on the recovered request's incomplete credentials, proving the not-found path
+// takes the start-fresh branch (which clears ResumeState) rather than
+// propagating the not-found as a retryable error.
+func TestResumeExistingDeployRequest_NotFoundStartsFresh(t *testing.T) {
+	e := NewWithClient(slog.New(slog.NewTextHandler(os.Stdout, nil)),
+		func(_, _ string) (psclient.PSClient, error) {
+			return nil, errors.New("client unavailable")
+		})
+	client := &resumeDeployClient{getErr: &ps.Error{Code: ps.ErrNotFound}}
+
+	meta := &psMetadata{BranchName: "schemabot-testdb-gone", DeployRequestID: 13}
+	req := resumeRequest(t, meta, "apply-1a2b3c4d5e6f7890")
+
+	_, err := e.resumeExistingDeployRequest(t.Context(), client, "org", req, meta)
+
+	require.Error(t, err)
+	assert.Equal(t, 0, client.deployCalls)
+	assert.Equal(t, 1, client.getCalls)
+	// The start-fresh branch clears ResumeState before re-running Apply, unlike
+	// the transient-error path which preserves it for retry.
+	assert.Nil(t, req.ResumeState)
+}
+
 // When no vtgate DSN is configured, resume cannot rediscover a Vitess context;
 // it must preserve the stored identifier as-is rather than blanking it, so the
 // apply record keeps whatever progress handle it already had.
-func TestResolveResumeMigrationContext_PreservesStoredWithoutDSN(t *testing.T) {
+func TestResolveResumeSchemaChangeContext_PreservesStoredWithoutDSN(t *testing.T) {
 	e := New(slog.New(slog.NewTextHandler(os.Stdout, nil)))
 	client := &resumeDeployClient{recovered: &ps.DeployRequest{}}
 
@@ -386,7 +449,7 @@ func TestResolveResumeMigrationContext_PreservesStoredWithoutDSN(t *testing.T) {
 		ResumeState: &engine.ResumeState{MigrationContext: "apply-1a2b3c4d5e6f7890"},
 	}
 
-	got := e.resolveResumeMigrationContext(t.Context(), client, req, map[string]bool{})
+	got := e.resolveResumeSchemaChangeContext(t.Context(), client, req, map[string]bool{})
 
 	assert.Equal(t, "apply-1a2b3c4d5e6f7890", got)
 }
@@ -414,17 +477,17 @@ func TestIsRealVitessContext(t *testing.T) {
 	}
 }
 
-// persistResumeMigrationContext must durably record only a real Vitess context.
+// persistResumeSchemaChangeContext must durably record only a real Vitess context.
 // Persisting the tern apply identifier or an empty value would carry no per-shard
 // progress and could clobber a previously persisted real context.
-func TestPersistResumeMigrationContext(t *testing.T) {
+func TestPersistResumeSchemaChangeContext(t *testing.T) {
 	e := New(slog.New(slog.NewTextHandler(os.Stdout, nil)))
 
 	t.Run("persists real context", func(t *testing.T) {
 		req := resumeRequest(t, &psMetadata{}, "")
 		persisted := captureStateChanges(req)
 
-		e.persistResumeMigrationContext(req, "singularity:real-context", "encoded-meta")
+		e.persistResumeSchemaChangeContext(req, "singularity:real-context", "encoded-meta")
 
 		require.Len(t, *persisted, 1)
 		assert.Equal(t, "singularity:real-context", (*persisted)[0].MigrationContext)
@@ -435,7 +498,7 @@ func TestPersistResumeMigrationContext(t *testing.T) {
 		req := resumeRequest(t, &psMetadata{}, "")
 		persisted := captureStateChanges(req)
 
-		e.persistResumeMigrationContext(req, "apply-1a2b3c4d5e6f7890", "encoded-meta")
+		e.persistResumeSchemaChangeContext(req, "apply-1a2b3c4d5e6f7890", "encoded-meta")
 
 		assert.Empty(t, *persisted)
 	})
@@ -444,7 +507,7 @@ func TestPersistResumeMigrationContext(t *testing.T) {
 		req := resumeRequest(t, &psMetadata{}, "")
 		persisted := captureStateChanges(req)
 
-		e.persistResumeMigrationContext(req, "", "encoded-meta")
+		e.persistResumeSchemaChangeContext(req, "", "encoded-meta")
 
 		assert.Empty(t, *persisted)
 	})
@@ -454,7 +517,7 @@ func TestPersistResumeMigrationContext(t *testing.T) {
 		req.OnStateChange = nil
 
 		assert.NotPanics(t, func() {
-			e.persistResumeMigrationContext(req, "singularity:real-context", "encoded-meta")
+			e.persistResumeSchemaChangeContext(req, "singularity:real-context", "encoded-meta")
 		})
 	})
 }

--- a/pkg/engine/planetscale/progress.go
+++ b/pkg/engine/planetscale/progress.go
@@ -177,8 +177,12 @@ func (e *Engine) captureExistingContexts(ctx context.Context, client psclient.PS
 	return existing
 }
 
-// discoverMigrationContext finds the new migration_context that appeared after
-// deploying by comparing current contexts against the pre-deploy baseline.
+// discoverMigrationContext finds the schema change context that this apply's
+// deploy created. It collects current SHOW VITESS_MIGRATIONS rows across all
+// keyspaces and selects the single non-baseline, non-terminal context via
+// selectSchemaChangeContext. Returns "" when no unambiguous candidate exists
+// (zero or multiple), so the caller keeps the stored identifier rather than
+// attaching progress to the wrong context.
 func (e *Engine) discoverMigrationContext(ctx context.Context, client psclient.PSClient, database string, creds *engine.Credentials, existingContexts map[string]bool) string {
 	if creds.DSN == "" {
 		e.logger.Debug("skipping schema change context discovery, no DSN configured")
@@ -198,26 +202,70 @@ func (e *Engine) discoverMigrationContext(ctx context.Context, client psclient.P
 		return ""
 	}
 
+	var rows []vitessMigrationRow
 	for _, ks := range keyspaces {
-		rows, err := e.showVitessMigrationsForKeyspace(ctx, creds.DSN, ks.Name, "")
+		ksRows, err := e.showVitessMigrationsForKeyspace(ctx, creds.DSN, ks.Name, "")
 		if err != nil {
 			e.logger.Debug("failed to query schema changes for keyspace", "keyspace", ks.Name, "error", err)
 			continue
 		}
-		for _, r := range rows {
-			if r.MigrationContext != "" && !existingContexts[r.MigrationContext] {
-				e.logger.Info("discovered schema change context", "context", r.MigrationContext)
-				return r.MigrationContext
-			}
-		}
+		rows = append(rows, ksRows...)
 	}
 
-	e.logger.Warn("schema change context not discovered yet")
-	return ""
+	discovered, candidates := selectSchemaChangeContext(rows, existingContexts)
+	switch {
+	case discovered != "":
+		e.logger.Info("discovered schema change context", "database", database, "context", discovered)
+		return discovered
+	case len(candidates) > 1:
+		// Multiple in-flight contexts not in the baseline — attaching to any one
+		// could render the wrong change's progress. Keep the stored identifier.
+		e.logger.Warn("multiple in-flight schema change contexts; keeping stored identifier to avoid attaching to the wrong change",
+			"database", database, "candidate_count", len(candidates), "candidates", candidates)
+		return ""
+	default:
+		e.logger.Warn("schema change context not discovered yet", "database", database)
+		return ""
+	}
+}
+
+// selectSchemaChangeContext picks the schema change context created by this
+// apply's deploy from a set of SHOW VITESS_MIGRATIONS rows. Candidates are the
+// distinct contexts that are NOT in the pre-deploy baseline AND are still
+// non-terminal — a freshly started change is queued or running, whereas the
+// completed history that SHOW VITESS_MIGRATIONS retains is terminal and must be
+// ignored so an empty-baseline rediscovery never attaches to an old, unrelated
+// change. It returns the single context when exactly one candidate remains and
+// the full candidate list so the caller can distinguish the zero and multiple
+// cases (both ambiguous, both must keep the stored identifier).
+func selectSchemaChangeContext(rows []vitessMigrationRow, existingContexts map[string]bool) (string, []string) {
+	// A context is a candidate if any of its shards is still non-terminal: the
+	// change is in flight even when some shards have already finished.
+	nonTerminal := make(map[string]bool)
+	for _, r := range rows {
+		if r.MigrationContext == "" || existingContexts[r.MigrationContext] {
+			continue
+		}
+		if state.IsTerminalVitessState(r.Status) {
+			continue
+		}
+		nonTerminal[r.MigrationContext] = true
+	}
+
+	candidates := make([]string, 0, len(nonTerminal))
+	for c := range nonTerminal {
+		candidates = append(candidates, c)
+	}
+	sort.Strings(candidates)
+
+	if len(candidates) == 1 {
+		return candidates[0], candidates
+	}
+	return "", candidates
 }
 
 // migrationContextDiscoveryAttempts and migrationContextDiscoveryInterval bound
-// how long discoverMigrationContextWithRetry waits for Vitess to create
+// how long discoverSchemaChangeContextWithRetry waits for Vitess to create
 // migrations after a deploy request is submitted. Vitess does not always create
 // them immediately, so the first poll can legitimately return nothing.
 const (
@@ -225,12 +273,12 @@ const (
 	migrationContextDiscoveryInterval = 500 * time.Millisecond
 )
 
-// discoverMigrationContextWithRetry polls discoverMigrationContext until a new
+// discoverSchemaChangeContextWithRetry polls discoverMigrationContext until a new
 // Vitess context appears or the bounded attempts are exhausted. Vitess may not
 // have created migrations immediately after the deploy request is submitted, so
 // a single poll can miss the context. Returns "" if no new context was found
 // within the window; respects ctx cancellation between attempts.
-func (e *Engine) discoverMigrationContextWithRetry(ctx context.Context, client psclient.PSClient, database string, creds *engine.Credentials, existingContexts map[string]bool) string {
+func (e *Engine) discoverSchemaChangeContextWithRetry(ctx context.Context, client psclient.PSClient, database string, creds *engine.Credentials, existingContexts map[string]bool) string {
 	// Without a vtgate DSN there is nothing to poll; retrying would only burn the
 	// discovery window on a query that can never succeed.
 	if creds.DSN == "" {

--- a/pkg/engine/planetscale/progress.go
+++ b/pkg/engine/planetscale/progress.go
@@ -216,6 +216,45 @@ func (e *Engine) discoverMigrationContext(ctx context.Context, client psclient.P
 	return ""
 }
 
+// migrationContextDiscoveryAttempts and migrationContextDiscoveryInterval bound
+// how long discoverMigrationContextWithRetry waits for Vitess to create
+// migrations after a deploy request is submitted. Vitess does not always create
+// them immediately, so the first poll can legitimately return nothing.
+const (
+	migrationContextDiscoveryAttempts = 10
+	migrationContextDiscoveryInterval = 500 * time.Millisecond
+)
+
+// discoverMigrationContextWithRetry polls discoverMigrationContext until a new
+// Vitess context appears or the bounded attempts are exhausted. Vitess may not
+// have created migrations immediately after the deploy request is submitted, so
+// a single poll can miss the context. Returns "" if no new context was found
+// within the window; respects ctx cancellation between attempts.
+func (e *Engine) discoverMigrationContextWithRetry(ctx context.Context, client psclient.PSClient, database string, creds *engine.Credentials, existingContexts map[string]bool) string {
+	// Without a vtgate DSN there is nothing to poll; retrying would only burn the
+	// discovery window on a query that can never succeed.
+	if creds.DSN == "" {
+		e.logger.Debug("skipping schema change context discovery, no DSN configured", "database", database)
+		return ""
+	}
+
+	for attempt := range migrationContextDiscoveryAttempts {
+		migrationContext := e.discoverMigrationContext(ctx, client, database, creds, existingContexts)
+		if migrationContext != "" {
+			return migrationContext
+		}
+		if attempt < migrationContextDiscoveryAttempts-1 {
+			select {
+			case <-ctx.Done():
+				e.logger.Debug("schema change context discovery cancelled", "database", database, "error", ctx.Err())
+				return ""
+			case <-time.After(migrationContextDiscoveryInterval):
+			}
+		}
+	}
+	return ""
+}
+
 // vitessMigrationRow holds a single row from SHOW VITESS_MIGRATIONS.
 type vitessMigrationRow struct {
 	MigrationUUID    string

--- a/pkg/engine/planetscale/progress_test.go
+++ b/pkg/engine/planetscale/progress_test.go
@@ -212,3 +212,78 @@ func TestShardLess(t *testing.T) {
 	assert.True(t, shardLess("40-80", "80-c0"))
 	assert.False(t, shardLess("80-c0", "40-80"))
 }
+
+// SHOW VITESS_MIGRATIONS retains completed historical rows, so an empty-baseline
+// rediscovery on resume sees both this apply's in-flight change and unrelated
+// finished changes. Selection must attach only to a non-terminal context: a
+// freshly deployed change is queued or running, while old completed history is
+// terminal and must be ignored so progress never renders the wrong change's
+// finished state while the real deploy is mid-flight.
+func TestSelectSchemaChangeContext(t *testing.T) {
+	t.Run("attaches to the in-flight context, ignoring completed history", func(t *testing.T) {
+		rows := []vitessMigrationRow{
+			// Completed history from prior, unrelated schema changes.
+			{MigrationContext: "singularity:old-add-email", Keyspace: "commerce", Shard: "-80", Status: state.Vitess.Complete},
+			{MigrationContext: "singularity:old-add-email", Keyspace: "commerce", Shard: "80-", Status: state.Vitess.Complete},
+			{MigrationContext: "singularity:old-drop-index", Keyspace: "commerce", Shard: "-80", Status: state.Vitess.Cancelled},
+			// This apply's in-flight change.
+			{MigrationContext: "singularity:new-change", Keyspace: "commerce", Shard: "-80", Status: state.Vitess.Running},
+			{MigrationContext: "singularity:new-change", Keyspace: "commerce", Shard: "80-", Status: state.Vitess.Queued},
+		}
+
+		got, candidates := selectSchemaChangeContext(rows, map[string]bool{})
+
+		assert.Equal(t, "singularity:new-change", got)
+		assert.Equal(t, []string{"singularity:new-change"}, candidates)
+	})
+
+	t.Run("only completed history yields no candidate", func(t *testing.T) {
+		rows := []vitessMigrationRow{
+			{MigrationContext: "singularity:old-add-email", Keyspace: "commerce", Shard: "-80", Status: state.Vitess.Complete},
+			{MigrationContext: "singularity:old-add-email", Keyspace: "commerce", Shard: "80-", Status: state.Vitess.Complete},
+			{MigrationContext: "singularity:old-drop-index", Keyspace: "commerce", Shard: "-80", Status: state.Vitess.Failed},
+		}
+
+		got, candidates := selectSchemaChangeContext(rows, map[string]bool{})
+
+		assert.Empty(t, got)
+		assert.Empty(t, candidates)
+	})
+
+	t.Run("a context with one running shard is in flight even if others completed", func(t *testing.T) {
+		rows := []vitessMigrationRow{
+			{MigrationContext: "singularity:new-change", Keyspace: "commerce", Shard: "-80", Status: state.Vitess.Complete},
+			{MigrationContext: "singularity:new-change", Keyspace: "commerce", Shard: "80-", Status: state.Vitess.Running},
+		}
+
+		got, candidates := selectSchemaChangeContext(rows, map[string]bool{})
+
+		assert.Equal(t, "singularity:new-change", got)
+		assert.Equal(t, []string{"singularity:new-change"}, candidates)
+	})
+
+	t.Run("multiple in-flight candidates are ambiguous", func(t *testing.T) {
+		rows := []vitessMigrationRow{
+			{MigrationContext: "singularity:change-a", Keyspace: "commerce", Shard: "-80", Status: state.Vitess.Running},
+			{MigrationContext: "singularity:change-b", Keyspace: "commerce", Shard: "-80", Status: state.Vitess.Queued},
+		}
+
+		got, candidates := selectSchemaChangeContext(rows, map[string]bool{})
+
+		assert.Empty(t, got)
+		assert.Equal(t, []string{"singularity:change-a", "singularity:change-b"}, candidates)
+	})
+
+	t.Run("baseline contexts are never candidates", func(t *testing.T) {
+		rows := []vitessMigrationRow{
+			{MigrationContext: "singularity:pre-existing", Keyspace: "commerce", Shard: "-80", Status: state.Vitess.Running},
+			{MigrationContext: "singularity:new-change", Keyspace: "commerce", Shard: "-80", Status: state.Vitess.Running},
+		}
+		baseline := map[string]bool{"singularity:pre-existing": true}
+
+		got, candidates := selectSchemaChangeContext(rows, baseline)
+
+		assert.Equal(t, "singularity:new-change", got)
+		assert.Equal(t, []string{"singularity:new-change"}, candidates)
+	})
+}

--- a/pkg/state/vitess.go
+++ b/pkg/state/vitess.go
@@ -1,6 +1,8 @@
 package state
 
 import (
+	"strings"
+
 	vitessstatus "vitess.io/vitess/go/vt/schema"
 )
 
@@ -27,4 +29,17 @@ var Vitess = struct {
 	// SchemaBot synthesizes it when a migration is running with ready_to_complete=1
 	// in SHOW VITESS_MIGRATIONS output.
 	ReadyToComplete: "ready_to_complete",
+}
+
+// IsTerminalVitessState reports whether a Vitess OnlineDDL status is terminal —
+// the schema change has reached an end state and will make no further progress.
+// Comparison is case-insensitive so it tolerates whatever casing
+// SHOW VITESS_MIGRATIONS reports.
+func IsTerminalVitessState(s string) bool {
+	switch strings.ToLower(s) {
+	case Vitess.Complete, Vitess.Failed, Vitess.Cancelled:
+		return true
+	default:
+		return false
+	}
 }


### PR DESCRIPTION
Fixes two correctness bugs in the PlanetScale engine's crash-recovery resume path.

**Crash between create and deploy never deployed.** When a worker crashed after creating a deploy request but before starting it, resume reattached to the recovered request and returned current state without ever deploying. For a non-deferred apply the request sits in `ready` forever — Progress maps `ready` to pending, the `waiting_for_deploy` promotion only applies to deferred deploys, and the auto-deploy trigger only fires on `waiting_for_deploy` — so the schema change never ran. Resume now starts the deploy for a recovered request that is `ready`, non-deferred, and not yet deployed, mirroring the fresh apply path. A deferred or already-in-flight request is left alone.

**Resume never discovered the Vitess migration context.** The fresh apply path captures a context baseline before deploying and discovers the new `migration_context` after; the resume path carried the tern apply identifier forward instead. That identifier never matches `SHOW VITESS_MIGRATIONS`, so per-shard progress was empty for the life of a resumed apply. Resume now captures a baseline before the resume deploy and discovers the real context after, preserving an already-real stored context and never clobbering it with an empty result.

```
worker crash after create, before deploy
      |
      v
 resume -> deploy request "ready", non-deferred, DeployedAt == nil
      |                              |
      | (before: returned pending)   v  (now: starts deploy)
      x  never deploys          DeployDeployRequest + rediscover context
```

The shared discovery retry loop is extracted into one helper used by both paths and now honors context cancellation between polls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)