### PR TITLE
fix(storage): make rows-affected checks correct under production changed-rows semantics

### DIFF
--- a/pkg/storage/mysqlstore/locks.go
+++ b/pkg/storage/mysqlstore/locks.go
@@ -191,7 +191,15 @@ func (s *lockStore) List(ctx context.Context) ([]*storage.Lock, error) {
 	return scanLocks(rows)
 }
 
-// Update updates lock metadata (touches updated_at).
+// Update touches updated_at to mark lock liveness.
+//
+// RowsAffected==0 is ambiguous and must not be read as "the lock does not
+// exist". Under MySQL's default changed-rows semantics, a matched row reports
+// zero affected rows when updated_at already equals NOW() — which happens when
+// Update runs twice within the same one-second DATETIME tick. The lock still
+// exists in that case, so the touch has succeeded. To distinguish that from a
+// genuinely missing lock, re-read it and return ErrLockNotFound only when the
+// row is actually gone.
 func (s *lockStore) Update(ctx context.Context, lock *storage.Lock) error {
 	result, err := s.db.ExecContext(ctx, `
 		UPDATE locks
@@ -199,10 +207,26 @@ func (s *lockStore) Update(ctx context.Context, lock *storage.Lock) error {
 		WHERE database_name = ? AND database_type = ?
 	`, lock.DatabaseName, lock.DatabaseType)
 	if err != nil {
-		return err
+		return fmt.Errorf("touch lock for %s/%s: %w", lock.DatabaseName, lock.DatabaseType, err)
+	}
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("read rows affected touching lock for %s/%s: %w",
+			lock.DatabaseName, lock.DatabaseType, err)
+	}
+	if rowsAffected > 0 {
+		return nil
 	}
 
-	return checkRowsAffected(result, storage.ErrLockNotFound)
+	current, getErr := s.Get(ctx, lock.DatabaseName, lock.DatabaseType)
+	if getErr != nil {
+		return fmt.Errorf("read lock after touch affected no rows for %s/%s: %w",
+			lock.DatabaseName, lock.DatabaseType, getErr)
+	}
+	if current == nil {
+		return storage.ErrLockNotFound
+	}
+	return nil
 }
 
 // GetByPR returns all locks associated with a PR.

--- a/pkg/storage/mysqlstore/locks_test.go
+++ b/pkg/storage/mysqlstore/locks_test.go
@@ -498,16 +498,41 @@ func TestLockStore_Update(t *testing.T) {
 		"expected updated_at to change, initial: %v, updated: %v", initial.UpdatedAt, updated.UpdatedAt)
 }
 
-// Touching a lock twice within the same one-second DATETIME tick leaves
-// updated_at unchanged on the second write. Under production changed-rows
-// semantics that UPDATE reports zero affected rows, but the lock still exists,
-// so the touch must succeed rather than report the lock as missing.
+// Touching a lock whose updated_at already equals NOW() leaves the row
+// unchanged. Under production changed-rows semantics that UPDATE reports zero
+// affected rows, but the lock still exists, so the touch must succeed rather
+// than report the lock as missing.
+//
+// The session timestamp is frozen on a single pinned connection so both the
+// row's stored updated_at and the touch's NOW() resolve to the same instant,
+// making the UPDATE a guaranteed no-op. Without freezing, a touch that crossed
+// into the next one-second DATETIME tick would change updated_at and report one
+// affected row, masking the changed-rows path this exercises.
 func TestLockStore_UpdateSameSecondSucceeds(t *testing.T) {
 	clearTables(t)
 	ctx := t.Context()
-	store := newChangedRowsStore(t)
 
-	require.NoError(t, store.Locks().Acquire(ctx, &storage.Lock{
+	// Pin to a single connection so the frozen session timestamp persists across
+	// the seed INSERT, the touch UPDATE, and the re-read.
+	db, err := sql.Open("mysql", testDSNChangedRows)
+	require.NoError(t, err)
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
+	t.Cleanup(func() {
+		_, _ = db.ExecContext(t.Context(), "SET TIMESTAMP = DEFAULT")
+		require.NoError(t, db.Close())
+	})
+	require.NoError(t, db.PingContext(ctx))
+
+	// Freeze NOW() so the seeded updated_at and the touch's NOW() are identical.
+	_, err = db.ExecContext(ctx, "SET TIMESTAMP = 1700000000")
+	require.NoError(t, err)
+
+	store := &lockStore{db: db}
+
+	// Acquire seeds the row via the locks table's DEFAULT CURRENT_TIMESTAMP,
+	// which resolves to the frozen NOW().
+	require.NoError(t, store.Acquire(ctx, &storage.Lock{
 		DatabaseName: "testdb",
 		DatabaseType: "vitess",
 		Repository:   "org/repo",
@@ -515,12 +540,13 @@ func TestLockStore_UpdateSameSecondSucceeds(t *testing.T) {
 		Owner:        "testuser",
 	}))
 
-	touch := &storage.Lock{DatabaseName: "testdb", DatabaseType: "vitess"}
-	require.NoError(t, store.Locks().Update(ctx, touch))
-	require.NoError(t, store.Locks().Update(ctx, touch),
-		"a same-second touch is a no-op UPDATE but the lock still exists")
+	// updated_at already equals the frozen NOW(), so the touch's
+	// SET updated_at = NOW() changes nothing: zero affected rows under
+	// changed-rows semantics. The lock still exists, so the touch must succeed.
+	require.NoError(t, store.Update(ctx, &storage.Lock{DatabaseName: "testdb", DatabaseType: "vitess"}),
+		"a no-op touch leaves updated_at unchanged but the lock still exists")
 
-	lock, err := store.Locks().Get(ctx, "testdb", "vitess")
+	lock, err := store.Get(ctx, "testdb", "vitess")
 	require.NoError(t, err)
 	require.NotNil(t, lock)
 	assert.Equal(t, "testuser", lock.Owner)

--- a/pkg/storage/mysqlstore/locks_test.go
+++ b/pkg/storage/mysqlstore/locks_test.go
@@ -519,7 +519,6 @@ func TestLockStore_UpdateSameSecondSucceeds(t *testing.T) {
 	db.SetMaxOpenConns(1)
 	db.SetMaxIdleConns(1)
 	t.Cleanup(func() {
-		_, _ = db.ExecContext(t.Context(), "SET TIMESTAMP = DEFAULT")
 		require.NoError(t, db.Close())
 	})
 	require.NoError(t, db.PingContext(ctx))

--- a/pkg/storage/mysqlstore/locks_test.go
+++ b/pkg/storage/mysqlstore/locks_test.go
@@ -466,7 +466,7 @@ func TestLockStore_List(t *testing.T) {
 func TestLockStore_Update(t *testing.T) {
 	clearTables(t)
 	ctx := t.Context()
-	store := New(testDB)
+	store := newChangedRowsStore(t)
 
 	// Create lock
 	require.NoError(t, store.Locks().Acquire(ctx, &storage.Lock{
@@ -482,7 +482,7 @@ func TestLockStore_Update(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, initial)
 
-	// Wait 1 second to ensure updated_at will change (MySQL datetime has second precision)
+	// Wait 1 second so updated_at advances (MySQL DATETIME has second precision).
 	time.Sleep(1 * time.Second)
 
 	// Update lock (just touches updated_at)
@@ -498,10 +498,38 @@ func TestLockStore_Update(t *testing.T) {
 		"expected updated_at to change, initial: %v, updated: %v", initial.UpdatedAt, updated.UpdatedAt)
 }
 
+// Touching a lock twice within the same one-second DATETIME tick leaves
+// updated_at unchanged on the second write. Under production changed-rows
+// semantics that UPDATE reports zero affected rows, but the lock still exists,
+// so the touch must succeed rather than report the lock as missing.
+func TestLockStore_UpdateSameSecondSucceeds(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := newChangedRowsStore(t)
+
+	require.NoError(t, store.Locks().Acquire(ctx, &storage.Lock{
+		DatabaseName: "testdb",
+		DatabaseType: "vitess",
+		Repository:   "org/repo",
+		PullRequest:  123,
+		Owner:        "testuser",
+	}))
+
+	touch := &storage.Lock{DatabaseName: "testdb", DatabaseType: "vitess"}
+	require.NoError(t, store.Locks().Update(ctx, touch))
+	require.NoError(t, store.Locks().Update(ctx, touch),
+		"a same-second touch is a no-op UPDATE but the lock still exists")
+
+	lock, err := store.Locks().Get(ctx, "testdb", "vitess")
+	require.NoError(t, err)
+	require.NotNil(t, lock)
+	assert.Equal(t, "testuser", lock.Owner)
+}
+
 func TestLockStore_UpdateNonExistent(t *testing.T) {
 	clearTables(t)
 	ctx := t.Context()
-	store := New(testDB)
+	store := newChangedRowsStore(t)
 
 	err := store.Locks().Update(ctx, &storage.Lock{
 		DatabaseName: "nonexistent",

--- a/pkg/storage/mysqlstore/mysql_test.go
+++ b/pkg/storage/mysqlstore/mysql_test.go
@@ -47,10 +47,11 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 
-	// clientFoundRows=true: return number of matched rows, not changed rows
-	// This is needed because UPDATE ... SET updated_at = NOW() may not change
-	// the value if called within the same second, but we still want to know
-	// if the row was found.
+	// testDSN sets clientFoundRows=true so RowsAffected reflects matched rows.
+	// testDSNChangedRows omits it to mirror production, where RowsAffected
+	// reflects changed rows: a matched row whose values are unchanged reports
+	// zero affected rows. Storage paths that infer existence or ownership from
+	// RowsAffected must be correct under the changed-rows connection.
 	testDSN = fmt.Sprintf("root:testpassword@tcp(%s:%d)/schemabot_test?parseTime=true&clientFoundRows=true&multiStatements=true", host, port)
 	testDSNChangedRows = fmt.Sprintf("root:testpassword@tcp(%s:%d)/schemabot_test?parseTime=true&multiStatements=true", host, port)
 


### PR DESCRIPTION
`lockStore.Update` touches `updated_at` and previously treated `RowsAffected == 0` as `ErrLockNotFound`. Production runs on MySQL's default changed-rows semantics (the storage DSN does not set `clientFoundRows`), under which a second touch within the same one-second `DATETIME` tick is a no-op UPDATE: the row matches but reports zero affected rows. The lock was then reported as missing even though it still existed.

This was the last lock/lease path still relying on matched-rows semantics. The fix re-reads the lock when the UPDATE affects no rows and returns `ErrLockNotFound` only when the row is genuinely gone — the same disambiguation `Acquire`/`refreshPendingPlanID`, the apply-lease writes, and the stored-check updates already use.

The default test connection set `clientFoundRows=true`, which masked this in tests. The lock `Update` tests now run on the changed-rows connection that mirrors production, including a case that touches the same lock twice within one second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)