### PR TITLE
feat(api): validate MySQL namespaces before remote dispatch

### DIFF
--- a/integration/grpc_integration_test.go
+++ b/integration/grpc_integration_test.go
@@ -259,7 +259,7 @@ func TestGRPC_ExternalID_StoredOnApply(t *testing.T) {
 		"environment": "staging",
 		"type":        "mysql",
 		"schema_files": map[string]any{
-			"default": map[string]any{
+			appDBName: map[string]any{
 				"files": map[string]string{
 					"items.sql": schemaSQL,
 				},
@@ -406,7 +406,7 @@ func TestGRPC_TaskStateUpdatedOnCompletion(t *testing.T) {
 		"environment": "staging",
 		"type":        "mysql",
 		"schema_files": map[string]any{
-			"default": map[string]any{
+			appDBName: map[string]any{
 				"files": map[string]string{
 					"task_state_test.sql": schemaSQL,
 				},
@@ -474,7 +474,7 @@ func TestGRPC_ServerSideTargetPlan(t *testing.T) {
 		"environment": "staging",
 		"type":        "mysql",
 		"schema_files": map[string]any{
-			"default": map[string]any{
+			"testapp": map[string]any{
 				"files": map[string]string{
 					"target_test.sql": schemaSQL,
 				},
@@ -590,7 +590,7 @@ func TestGRPC_ServerSideDeploymentStoredOnApply(t *testing.T) {
 		"environment": "staging",
 		"type":        "mysql",
 		"schema_files": map[string]any{
-			"default": map[string]any{
+			appDBName: map[string]any{
 				"files": map[string]string{"widgets.sql": schemaSQL},
 			},
 		},

--- a/integration/hybrid_mode_test.go
+++ b/integration/hybrid_mode_test.go
@@ -193,7 +193,7 @@ func TestHybridMode_LocalAndNamedRemoteTargets(t *testing.T) {
 		"environment": "staging",
 		"type":        "mysql",
 		"schema_files": map[string]any{
-			"default": map[string]any{
+			grpcDBName: map[string]any{
 				"files": map[string]string{
 					"grpc_items.sql": grpcSchemaSQL,
 				},

--- a/integration/resolve_apply_id_test.go
+++ b/integration/resolve_apply_id_test.go
@@ -98,7 +98,7 @@ func TestRemoteApplyID_ControlOperations(t *testing.T) {
 		"environment": "staging",
 		"type":        "mysql",
 		"schema_files": map[string]any{
-			"default": map[string]any{
+			appDBName: map[string]any{
 				"files": map[string]string{
 					tableName + ".sql": schemaSQL,
 				},

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -481,6 +481,13 @@ type ResolvedDatabaseTarget struct {
 	DatabaseType string
 	Deployment   string
 	Target       string
+
+	// RequiresSingleConcreteNamespace is a bridge constraint for execution paths
+	// that cannot yet fan one plan out across multiple namespace scopes. The
+	// future resolver/composer model should replace this with resolved namespace
+	// scopes; until then, remote MySQL dispatch requires exactly one real
+	// namespace so the executing deployment can target the right schema.
+	RequiresSingleConcreteNamespace bool
 }
 
 // DeploymentTarget is one entry in EnvironmentConfig.Deployments. It carries
@@ -939,9 +946,10 @@ func (c *ServerConfig) ResolveDatabaseTargets(database, environment string) ([]R
 				return nil, fmt.Errorf("database %q environment %q deployment %q missing target", database, environment, deployment)
 			}
 			out = append(out, ResolvedDatabaseTarget{
-				DatabaseType: dbConfig.Type,
-				Deployment:   deployment,
-				Target:       dt.Target,
+				DatabaseType:                    dbConfig.Type,
+				Deployment:                      deployment,
+				Target:                          dt.Target,
+				RequiresSingleConcreteNamespace: dbConfig.Type == storage.DatabaseTypeMySQL,
 			})
 		}
 		return out, nil
@@ -954,9 +962,10 @@ func (c *ServerConfig) ResolveDatabaseTargets(database, environment string) ([]R
 		return nil, fmt.Errorf("database %q environment %q missing server-side deployment", database, environment)
 	}
 	return []ResolvedDatabaseTarget{{
-		DatabaseType: dbConfig.Type,
-		Deployment:   envConfig.Deployment,
-		Target:       envConfig.Target,
+		DatabaseType:                    dbConfig.Type,
+		Deployment:                      envConfig.Deployment,
+		Target:                          envConfig.Target,
+		RequiresSingleConcreteNamespace: dbConfig.Type == storage.DatabaseTypeMySQL,
 	}}, nil
 }
 

--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -1012,9 +1012,9 @@ func TestServerConfig_ResolveDatabaseTargets(t *testing.T) {
 		got, err := cfg.ResolveDatabaseTargets("multidb", "production")
 		require.NoError(t, err)
 		assert.Equal(t, []ResolvedDatabaseTarget{
-			{DatabaseType: "mysql", Deployment: "payments-a", Target: "payments"},
-			{DatabaseType: "mysql", Deployment: "payments-b", Target: "payments"},
-			{DatabaseType: "mysql", Deployment: "payments-c", Target: "payments"},
+			{DatabaseType: "mysql", Deployment: "payments-a", Target: "payments", RequiresSingleConcreteNamespace: true},
+			{DatabaseType: "mysql", Deployment: "payments-b", Target: "payments", RequiresSingleConcreteNamespace: true},
+			{DatabaseType: "mysql", Deployment: "payments-c", Target: "payments", RequiresSingleConcreteNamespace: true},
 		}, got)
 	})
 

--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -669,6 +669,138 @@ func newTestService() *Service {
 	return New(&mockStorage{}, testServerConfig(), nil, logger)
 }
 
+// For MySQL, the namespace key is the schema name a connection will target.
+// Ambiguous layouts (multiple namespaces, or "default" meaning the schema
+// name is unknown) are rejected at plan time with an actionable error, before
+// the request is dispatched to any executing deployment. Vitess plans keep
+// multiple namespaces — keyspaces are inherently plural.
+func TestExecutePlanValidatesMySQLNamespaces(t *testing.T) {
+	newNamespaceService := func(dbType string) (*Service, *mockTernClient) {
+		t.Helper()
+		mockClient := &mockTernClient{
+			planResp: &ternv1.PlanResponse{PlanId: "plan-namespaces"},
+		}
+		cfg := &ServerConfig{
+			Databases: map[string]DatabaseConfig{
+				"payments": {
+					Type: dbType,
+					Environments: map[string]EnvironmentConfig{
+						"staging": {Target: "payments-staging-target", Deployment: DefaultDeployment},
+					},
+				},
+			},
+			TernDeployments: TernConfig{
+				DefaultDeployment: {"staging": "localhost:9090"},
+			},
+		}
+		logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+		svc := New(&mockStorageWithPlanLookup{plans: &capturingPlanStore{}}, cfg, map[string]tern.Client{
+			DefaultDeployment + "/staging": mockClient,
+		}, logger)
+		return svc, mockClient
+	}
+
+	planFiles := func(namespaces ...string) map[string]*ternv1.SchemaFiles {
+		files := make(map[string]*ternv1.SchemaFiles, len(namespaces))
+		for _, ns := range namespaces {
+			files[ns] = &ternv1.SchemaFiles{Files: map[string]string{"users.sql": "CREATE TABLE users (id bigint primary key)"}}
+		}
+		return files
+	}
+
+	t.Run("multiple MySQL namespaces are rejected before dispatch", func(t *testing.T) {
+		svc, mockClient := newNamespaceService(storage.DatabaseTypeMySQL)
+
+		resp, err := svc.ExecutePlan(t.Context(), PlanRequest{
+			Database:    "payments",
+			Environment: "staging",
+			Type:        storage.DatabaseTypeMySQL,
+			SchemaFiles: planFiles("payments", "payments_audit"),
+		})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "multiple MySQL namespaces")
+		assert.Nil(t, resp)
+		assert.Nil(t, mockClient.planReq, "invalid namespaces must not be dispatched")
+	})
+
+	t.Run("default namespace is rejected before dispatch", func(t *testing.T) {
+		svc, mockClient := newNamespaceService(storage.DatabaseTypeMySQL)
+
+		resp, err := svc.ExecutePlan(t.Context(), PlanRequest{
+			Database:    "payments",
+			Environment: "staging",
+			Type:        storage.DatabaseTypeMySQL,
+			SchemaFiles: planFiles("default"),
+		})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `"default" is not a valid MySQL schema name`)
+		assert.Nil(t, resp)
+		assert.Nil(t, mockClient.planReq, "invalid namespaces must not be dispatched")
+	})
+
+	t.Run("single MySQL namespace dispatches", func(t *testing.T) {
+		svc, mockClient := newNamespaceService(storage.DatabaseTypeMySQL)
+
+		resp, err := svc.ExecutePlan(t.Context(), PlanRequest{
+			Database:    "payments",
+			Environment: "staging",
+			Type:        storage.DatabaseTypeMySQL,
+			SchemaFiles: planFiles("payments_staging"),
+		})
+
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		assert.Equal(t, "plan-namespaces", resp.PlanID)
+		require.NotNil(t, mockClient.planReq)
+	})
+
+	t.Run("multiple Vitess keyspaces dispatch", func(t *testing.T) {
+		svc, mockClient := newNamespaceService(storage.DatabaseTypeVitess)
+
+		resp, err := svc.ExecutePlan(t.Context(), PlanRequest{
+			Database:    "payments",
+			Environment: "staging",
+			Type:        storage.DatabaseTypeVitess,
+			SchemaFiles: planFiles("commerce", "customers"),
+		})
+
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.NotNil(t, mockClient.planReq, "multi-keyspace Vitess plans must dispatch")
+	})
+
+	t.Run("multiple MySQL namespaces dispatch for local-DSN targets", func(t *testing.T) {
+		mockClient := &mockTernClient{planResp: &ternv1.PlanResponse{PlanId: "plan-namespaces"}}
+		cfg := &ServerConfig{
+			Databases: map[string]DatabaseConfig{
+				"payments": {
+					Type: storage.DatabaseTypeMySQL,
+					Environments: map[string]EnvironmentConfig{
+						"staging": {DSN: "root:test@tcp(localhost:3306)/payments?parseTime=true"},
+					},
+				},
+			},
+		}
+		logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+		svc := New(&mockStorageWithPlanLookup{plans: &capturingPlanStore{}}, cfg, map[string]tern.Client{
+			"payments/staging": mockClient,
+		}, logger)
+
+		resp, err := svc.ExecutePlan(t.Context(), PlanRequest{
+			Database:    "payments",
+			Environment: "staging",
+			Type:        storage.DatabaseTypeMySQL,
+			SchemaFiles: planFiles("payments", "payments_audit"),
+		})
+
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.NotNil(t, mockClient.planReq, "local-DSN targets treat namespaces as labels and must dispatch")
+	})
+}
+
 func TestExecutePlanSourcePolicy(t *testing.T) {
 	newPolicyService := func() (*Service, *mockTernClient, *capturingPlanStore) {
 		t.Helper()

--- a/pkg/api/plan_handlers.go
+++ b/pkg/api/plan_handlers.go
@@ -21,6 +21,7 @@ import (
 	"github.com/block/schemabot/pkg/apitypes"
 	"github.com/block/schemabot/pkg/metrics"
 	ternv1 "github.com/block/schemabot/pkg/proto/ternv1"
+	"github.com/block/schemabot/pkg/schema"
 	"github.com/block/schemabot/pkg/state"
 	"github.com/block/schemabot/pkg/storage"
 )
@@ -202,6 +203,28 @@ func (s *Service) ExecutePlan(ctx context.Context, req PlanRequest) (*apitypes.P
 				"reason", reason,
 				"error", err)
 			return nil, fmt.Errorf("source policy: %w", err)
+		}
+	}
+
+	// Some execution paths cannot yet fan one plan out across multiple namespace
+	// scopes. Validate before dispatch so a bad layout fails here with an
+	// actionable error instead of a remote routing error. Local-DSN MySQL targets
+	// skip this because sequential applies can handle multiple namespace labels;
+	// atomic/defer-cutover mode still enforces its own single-namespace guard.
+	if resolvedTarget.RequiresSingleConcreteNamespace && resolvedTarget.DatabaseType == storage.DatabaseTypeMySQL {
+		if _, err := schema.MySQLSchemaName(req.SchemaFiles); err != nil {
+			span.RecordError(err)
+			span.SetStatus(otelcodes.Error, "invalid namespaces")
+			metrics.RecordPlan(ctx, req.Repository, req.Database, deployment, req.Environment, "error")
+			metrics.RecordPlanDuration(ctx, time.Since(planStart), req.Repository, req.Database, deployment, req.Environment, "error")
+			s.logger.Warn("plan rejected: target requires one concrete namespace",
+				"database", req.Database,
+				"environment", req.Environment,
+				"repository", req.Repository,
+				"deployment", deployment,
+				"namespace_count", len(req.SchemaFiles),
+				"error", err)
+			return nil, fmt.Errorf("validate schema namespaces for database %q: %w", req.Database, err)
 		}
 	}
 

--- a/pkg/schema/namespace.go
+++ b/pkg/schema/namespace.go
@@ -6,6 +6,39 @@ import (
 	"strings"
 )
 
+// MySQLSchemaName returns the MySQL schema name for a schema-files map.
+//
+// For MySQL, the namespace key is the actual schema name (the value from
+// SHOW DATABASES), which may differ from the database routing identifier —
+// for example namespace "payments_staging" for database "payments" after
+// $ENV substitution. The schema name decides which schema a connection
+// targets, so it must be unambiguous:
+//
+//   - "default" is rejected: it means schema files were at the directory
+//     root instead of inside a schema-named subdirectory, so the schema name
+//     is unknown.
+//   - Multiple namespaces in one plan are rejected: executing them requires
+//     a separate connection per schema, which is not yet supported for MySQL.
+//
+// Returns "" for an empty map. The map value type is generic because the
+// same namespace contract travels in several shapes (wire schema files,
+// stored schema files) and only the keys carry the schema name.
+func MySQLSchemaName[V any](schemaFiles map[string]V) (string, error) {
+	if len(schemaFiles) > 1 {
+		return "", fmt.Errorf("multiple MySQL namespaces in a single plan are not yet supported (got %d)", len(schemaFiles))
+	}
+	for namespace := range schemaFiles {
+		if namespace == "default" {
+			return "", fmt.Errorf(
+				`namespace "default" is not a valid MySQL schema name — ` +
+					`schema files must be in a subdirectory named after the MySQL schema ` +
+					`(the value from SHOW DATABASES), e.g. schema/testapp/users.sql where "testapp" is the schema name`)
+		}
+		return namespace, nil
+	}
+	return "", nil
+}
+
 // GroupFilesByNamespace groups schema files by namespace using their relative paths.
 // Two layouts are supported:
 //

--- a/pkg/schema/namespace_test.go
+++ b/pkg/schema/namespace_test.go
@@ -213,3 +213,43 @@ func TestGroupFilesByNamespace_EnvSubstitution_MultipleNamespaces(t *testing.T) 
 	assert.Contains(t, result, "app_staging")
 	assert.Contains(t, result, "analytics")
 }
+
+func TestMySQLSchemaName(t *testing.T) {
+	tests := []struct {
+		name       string
+		namespaces []string
+		wantSchema string
+		wantErr    string
+	}{
+		{name: "single namespace is the schema name", namespaces: []string{"bikeshare_staging"}, wantSchema: "bikeshare_staging"},
+		{name: "empty map has no schema name", namespaces: nil, wantSchema: ""},
+		{name: "multiple namespaces are rejected", namespaces: []string{"payments", "payments_audit"}, wantErr: "multiple MySQL namespaces"},
+		{name: "default namespace is rejected", namespaces: []string{"default"}, wantErr: `"default" is not a valid MySQL schema name`},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			files := make(map[string]*Namespace, len(tc.namespaces))
+			for _, ns := range tc.namespaces {
+				files[ns] = &Namespace{}
+			}
+
+			schemaName, err := MySQLSchemaName(files)
+
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantSchema, schemaName)
+		})
+	}
+}
+
+// The namespace contract travels in several map shapes; only the keys carry
+// the schema name, so any value type resolves identically.
+func TestMySQLSchemaNameIsValueTypeAgnostic(t *testing.T) {
+	schemaName, err := MySQLSchemaName(map[string]string{"testapp": "ignored"})
+	require.NoError(t, err)
+	assert.Equal(t, "testapp", schemaName)
+}


### PR DESCRIPTION
## Why
Current execution paths do not all have the same namespace contract. Local DSN MySQL can keep treating namespace keys as plan labels because the DSN owns the connection schema, and Vitess already uses keyspace-style namespaces. The bridge gap is remote MySQL execution: until target resolution/composition can fan out across resolved namespace scopes, that path needs exactly one concrete namespace before dispatch.

## What
- Add a shared MySQL namespace helper for extracting one concrete namespace when a caller requires that shape
- Add `RequiresSingleConcreteNamespace` to resolved targets as a temporary capability, not a remote/local policy
- Validate MySQL plan requests only when the resolved execution path requires one concrete namespace
- Keep local DSN MySQL behavior and Vitess multi-keyspace behavior unchanged
- Update remote-dispatch integration fixtures to use concrete schema namespaces

## Future direction
This PR is intentionally a small bridge toward the northstar resolver/composer/operator model. The longer-term contract should resolve namespace scopes explicitly, then let the composer and execution operator decide whether an apply can span one or many scopes for that engine and execution mode. When that exists, this bridge boolean should disappear rather than grow into engine-specific schema/keyspace fields.

## Risk Assessment
Low to medium — this adds an early validation gate only for remote MySQL paths that currently need a single concrete namespace, while preserving existing local DSN and Vitess behavior.

Generated with Amp