### PR TITLE
feat(github): actionable check-trust failures and chain trust model

### DIFF
--- a/docs/check-runs.md
+++ b/docs/check-runs.md
@@ -6,6 +6,7 @@
 
 - [GitHub Check Concepts](#github-check-concepts)
 - [Safety Philosophy](#safety-philosophy)
+- [Cross-Deployment Trust Model](#cross-deployment-trust-model)
 - [Published Checks](#published-checks)
 - [Managed Schema Configs](#managed-schema-configs)
   - [Onboarding a schema directory](#onboarding-a-schema-directory)
@@ -115,6 +116,53 @@ changes, when the apply represented by the stored check state completes
 successfully, or when the current PR head no longer touches that managed
 database. Missing storage, a stale SHA, or ambiguous apply ownership is a
 failure to represent safety, not a reason to skip.
+
+## Cross-Deployment Trust Model
+
+In a split deployment, a later environment's promotion gate consumes a check
+run created by an earlier environment's deployment. Earlier environments are
+assumed to be lower-trust zones: staging typically has looser access controls
+than production, and its GitHub App credentials or runtime could be tampered
+with. The trust model bounds what that tampering can reach:
+
+> Cross-environment signals are evidence for sequencing, never authority for
+> execution. A prior environment's check decides when a later environment may
+> apply — never what DDL executes, who may request it, or whether safety lint
+> is bypassed.
+
+What a fully compromised earlier environment (able to publish arbitrary green
+aggregate checks) can and cannot affect in a later environment:
+
+| Later-environment control | Influenced by the earlier environment? |
+| --- | --- |
+| Promotion ordering (apply only after the prior environment) | Yes — defeated by a forged green check |
+| DDL content | No — the later deployment re-plans from the PR's schema files against its own database |
+| Actor authorization for `apply` / `apply-confirm` | No — evaluated by the later deployment |
+| Review gate (CODEOWNERS approval) | No |
+| Unsafe-change lint and `--allow-unsafe` | No — re-evaluated at the later environment's plan time |
+| Apply confirmation flow and locks | No |
+
+The bound holds because of rules that future changes must preserve:
+
+- **Single consumer.** The prior-environment check feeds exactly one decision:
+  the promotion gate. It must never feed actor policy, plan content, lint
+  decisions, or unsafe-change allowances.
+- **Identity, not names.** Gates trust check runs only from the GitHub App
+  identities in `trusted-check-app-slugs`. Forging the sequencing signal
+  requires compromising a chain App's credentials, not naming a check
+  cleverly. Aggregate-named checks from untrusted apps cannot satisfy the
+  promotion gate, cannot be excluded from the passing-checks gate, and are
+  surfaced with a warning log and metric.
+- **Per-commit evidence.** Checks bind to the PR head SHA, so a forged check
+  on one commit cannot bless another.
+- **Local re-validation is authoritative.** The later environment's plan and
+  lint run fresh against its own database; prior-environment evidence never
+  shortcuts them.
+
+The accepted residual risk: a compromised earlier environment defeats
+staging-first sequencing and nothing else. Hardening beyond that (such as
+signed attestations embedded in check output) is a non-goal — the remaining
+gates already do not trust the earlier environment.
 
 ## Published Checks
 
@@ -893,6 +941,13 @@ the prior environment's deployment uses a different GitHub App, its slug must
 be listed in `trusted-check-app-slugs`; otherwise its aggregate check is
 treated as untrusted and the gate fails closed, blocking the apply.
 
+The blocked comment distinguishes the two failure shapes because their
+remediations differ: when no check exists at all, it directs the user to plan
+and apply the prior environment; when a check exists but only from untrusted
+apps, it names those apps and directs an operator to the
+`trusted-check-app-slugs` config (or to investigate a possible impersonating
+check), since re-running the prior environment cannot change check ownership.
+
 Remote prior-environment checks use the aggregate because the current deployment
 does not have access to the other deployment's per-database storage. That makes
 the remote check stricter than the local check: a production apply can be
@@ -1001,6 +1056,13 @@ GitHub UI setup:
 2. Go to Branches and edit the branch protection rule.
 3. Enable "Require status checks to pass before merging".
 4. Select the SchemaBot aggregate check names used by the deployment.
+5. Pin each required SchemaBot check to the SchemaBot GitHub App that
+   publishes it (GitHub shows the source app next to each check). A required
+   check pinned by name only can be satisfied by any app that creates a
+   same-named passing check run — for example a GitHub Actions job — which
+   would let a PR merge without SchemaBot's verification. SchemaBot's own
+   gates verify App identity; pinning extends that to GitHub's merge gate,
+   which SchemaBot cannot enforce itself.
 
 GitHub API example for a single aggregate:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -8,6 +8,7 @@
   - [Building DSNs from separate secrets](#building-dsns-from-separate-secrets)
 - [gRPC Mode](#grpc-mode)
 - [Multi-Deployment Environment (preview)](#multi-deployment-environment-preview)
+  - [Deployment Order](#deployment-order)
 - [Environment Order](#environment-order)
 - [Hybrid Mode](#hybrid-mode)
 - [Operator Workers](#operator-workers)
@@ -469,6 +470,9 @@ github:
   private-key: "file:/run/secrets/staging-github-key.pem"
   webhook-secret: "env:STAGING_WEBHOOK_SECRET"
   check-name: "SchemaBot X"
+  trusted-check-app-slugs:  # the chain's App slugs — identical in every instance
+    - schemabot-staging
+    - schemabot-production
 ```
 
 ### Production Instance
@@ -492,15 +496,34 @@ github:
   private-key: "file:/run/secrets/prod-github-key.pem"
   webhook-secret: "env:PROD_WEBHOOK_SECRET"
   check-name: "SchemaBot X"
-  trusted-check-app-slugs:
-    - schemabot-staging  # the staging instance's GitHub App slug
+  trusted-check-app-slugs:  # the chain's App slugs — identical in every instance
+    - schemabot-staging
+    - schemabot-production
 ```
 
-The production instance lists the staging instance's GitHub App slug in
-`trusted-check-app-slugs` so the promotion gate can verify the staging
-aggregate check run that the staging App created. Without it, the production
-instance only trusts check runs created by its own App, and the staging gate
-fails closed — production applies stay blocked even when staging is green.
+`trusted-check-app-slugs` declares the promotion chain's GitHub App
+identities. Like `environment_order`, it is chain-level shared configuration:
+every instance carries the same complete list (its own slug included, which is
+harmless). It serves two purposes:
+
+- **Promotion gate**: the production instance verifies the staging aggregate
+  check run, which the staging App created. Without the staging slug, the
+  production instance only trusts its own App's check runs and the staging
+  gate fails closed — production applies stay blocked even when staging is
+  green.
+- **Passing-checks gate**: checks created by trusted chain Apps are classified
+  as SchemaBot checks and excluded from the `require_passing_checks` gate.
+  Without the production slug, the staging instance treats the production
+  App's `SchemaBot X (production)` aggregate — expected to be
+  `action_required` until production applies — as failing external CI and
+  blocks staging applies.
+
+Trust is decided only by the creating GitHub App, never by check name: a
+same-named check from an app outside the list cannot satisfy the promotion
+gate and cannot be hidden from the passing-checks gate. When the passing-checks
+gate sees an aggregate-named check from an untrusted app, it blocks as usual
+and emits a warning log and metric so operators can distinguish a check-name
+spoof from a chain member missing from the list.
 
 ### Environment-local gRPC targets
 
@@ -558,7 +581,7 @@ Do not require the staging ConfigMap to contain production targets, or the produ
 
 - **Cross-instance environment verification:** Environment ordering (e.g., staging must succeed before production) works across instances. The production instance queries the GitHub Checks API for the staging instance's aggregate check to verify the prior environment completed successfully. GitHub check runs are the shared authority for cross-environment state; the production instance does not need staging target configuration to enforce the staging gate.
 
-- **Trusted check App slugs:** The promotion gate only accepts check runs created by trusted SchemaBot GitHub Apps, so a same-named check from an unrelated app (such as a GitHub Actions job) can never satisfy it. When instances use separate GitHub Apps, each instance that verifies a prior environment must list the owning instance's App slug in `github.trusted-check-app-slugs`; otherwise the prior environment's check is treated as untrusted and the gate fails closed, blocking applies. Trusted sibling App checks are also excluded from the `require_passing_checks` gate, the same as the instance's own checks — SchemaBot aggregate checks are governed by the promotion and merge gates, not the CI-health gate.
+- **Trusted check App slugs:** SchemaBot gates trust check runs only by the creating GitHub App, never by check name. Every instance in a promotion chain carries the same `github.trusted-check-app-slugs` list — all of the chain's App slugs, like `environment_order` is shared chain configuration. The promotion gate accepts a prior environment's aggregate check only from a trusted App (fails closed otherwise), and the `require_passing_checks` gate excludes trusted Apps' aggregates from CI-health blocking (a sibling's `action_required` aggregate is expected workflow state, not failing CI). An aggregate-named check from an app outside the list cannot satisfy the promotion gate, cannot be hidden from the CI gate, and is flagged with a warning log and metric for operator triage.
 
 - **Separate GitHub Apps:** Each instance needs its own GitHub App installation. Both Apps must be installed on the same repositories and configured to receive the same webhook events. GitHub delivers webhooks to all installed Apps independently.
 

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -235,13 +235,19 @@ type GitHubConfig struct {
 
 	// TrustedCheckAppSlugs lists the GitHub App slugs of sibling SchemaBot
 	// deployments whose Check Runs this deployment trusts, in addition to its
-	// own App. Environment-scoped deployments that verify a prior
-	// environment's aggregate Check Run must list the App slug of the
-	// deployment that owns that environment here when it is a different
-	// GitHub App; otherwise the promotion gate cannot verify ownership of the
-	// prior environment's check and will block applies. Check Runs from Apps
-	// not in this list (and not this deployment's own App) never satisfy
-	// SchemaBot gates.
+	// own App. This is chain-level shared configuration: every deployment in
+	// a promotion chain should carry the same complete list of the chain's
+	// App slugs (its own included, which is harmless), like environment_order.
+	//
+	// The list feeds two gates. The promotion gate only accepts a prior
+	// environment's aggregate Check Run from a trusted App, so a deployment
+	// that verifies a prior environment owned by a different GitHub App must
+	// trust that App or the gate fails closed and blocks applies. The
+	// require_passing_checks gate classifies trusted Apps' checks as SchemaBot
+	// checks rather than external CI, so a sibling's aggregate sitting at
+	// action_required (expected before its environment applies) does not block
+	// this deployment's applies. Check Runs from Apps not in this list (and
+	// not this deployment's own App) never satisfy SchemaBot gates.
 	TrustedCheckAppSlugs []string `yaml:"trusted-check-app-slugs,omitempty"`
 }
 

--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -649,18 +649,20 @@ type CheckRunResult struct {
 // Only check runs created by a trusted SchemaBot GitHub App are considered:
 // this deployment's own App plus any configured trusted sibling deployment
 // Apps. A same-named check run created by any other app (for example a GitHub
-// Actions job configured with a matching name) is ignored, so it can never
-// satisfy a gate that relies on this lookup. When multiple trusted-app runs
+// Actions job configured with a matching name) can never satisfy a gate that
+// relies on this lookup; the slugs of such apps are returned so callers can
+// tell "no check exists" apart from "a check exists but its App is not
+// trusted" and surface the right remediation. When multiple trusted-app runs
 // share the name, the most recently created one (highest check run ID) is
 // returned.
 //
-// Returns nil if no trusted-app check run matches. Returns an error when the
-// own app slug is unknown and no trusted sibling slugs are configured — check
-// run ownership cannot be verified against anything, and callers must fail
-// closed instead of trusting a same-named run.
-func (ic *InstallationClient) FindCheckRunByName(ctx context.Context, repo, headSHA, checkName string) (*CheckRunResult, error) {
+// Returns a nil run if no trusted-app check run matches. Returns an error
+// when the own app slug is unknown and no trusted sibling slugs are
+// configured — check run ownership cannot be verified against anything, and
+// callers must fail closed instead of trusting a same-named run.
+func (ic *InstallationClient) FindCheckRunByName(ctx context.Context, repo, headSHA, checkName string) (*CheckRunResult, []string, error) {
 	if ic.loadAppSlug() == "" && len(ic.trustedCheckAppSlugs) == 0 {
-		return nil, fmt.Errorf("find check run %q on %s@%s: GitHub App slug is unavailable and no trusted sibling App slugs are configured, check run ownership cannot be verified", checkName, repo, headSHA)
+		return nil, nil, fmt.Errorf("find check run %q on %s@%s: GitHub App slug is unavailable and no trusted sibling App slugs are configured, check run ownership cannot be verified", checkName, repo, headSHA)
 	}
 
 	owner, repoName := splitRepo(repo)
@@ -673,10 +675,12 @@ func (ic *InstallationClient) FindCheckRunByName(ctx context.Context, repo, head
 	}
 
 	var newest *CheckRunResult
+	var untrustedApps []string
+	seenUntrusted := make(map[string]struct{})
 	for {
 		result, resp, err := ic.client.Checks.ListCheckRunsForRef(ctx, owner, repoName, headSHA, opts)
 		if err != nil {
-			return nil, fmt.Errorf("list check runs named %q on %s@%s: %w", checkName, repo, headSHA, err)
+			return nil, nil, fmt.Errorf("list check runs named %q on %s@%s: %w", checkName, repo, headSHA, err)
 		}
 		if result != nil {
 			for _, run := range result.CheckRuns {
@@ -684,6 +688,11 @@ func (ic *InstallationClient) FindCheckRunByName(ctx context.Context, repo, head
 					ic.logger.Warn("ignoring same-named check run created by an untrusted GitHub App",
 						"repo", repo, "head_sha", headSHA, "check_name", checkName,
 						"check_run_id", run.GetID(), "app_slug", run.GetApp().GetSlug())
+					slug := run.GetApp().GetSlug()
+					if _, seen := seenUntrusted[slug]; !seen {
+						seenUntrusted[slug] = struct{}{}
+						untrustedApps = append(untrustedApps, slug)
+					}
 					continue
 				}
 				if newest == nil || run.GetID() > newest.ID {
@@ -702,7 +711,7 @@ func (ic *InstallationClient) FindCheckRunByName(ctx context.Context, repo, head
 		opts.Page = resp.NextPage
 	}
 
-	return newest, nil
+	return newest, untrustedApps, nil
 }
 
 // PRCheckStatus represents the status of a single PR check (check run or commit status).
@@ -710,7 +719,8 @@ type PRCheckStatus struct {
 	Name        string
 	Status      string // "completed", "in_progress", "queued"
 	Conclusion  string // "success", "failure", "neutral", "skipped", etc.
-	IsSchemaBot bool   // true if this is a SchemaBot check
+	AppSlug     string // creating GitHub App slug; empty for commit statuses
+	IsSchemaBot bool   // true if this check was created by a trusted SchemaBot GitHub App
 }
 
 // isOwnAppSlug returns true if the given slug belongs to this SchemaBot
@@ -792,6 +802,7 @@ func (ic *InstallationClient) GetPRCheckStatuses(ctx context.Context, repo strin
 			Name:        r.Name,
 			Status:      r.Status,
 			Conclusion:  r.Conclusion,
+			AppSlug:     r.AppSlug,
 			IsSchemaBot: ic.isTrustedCheckAppSlug(r.AppSlug),
 		}
 	}

--- a/pkg/github/client_test.go
+++ b/pkg/github/client_test.go
@@ -138,7 +138,7 @@ func TestFindCheckRunByNameIgnoresForeignAppCheckRuns(t *testing.T) {
 	})
 
 	ic := NewInstallationClientWithSlug(client, slog.New(slog.NewTextHandler(io.Discard, nil)), "schemabot")
-	result, err := ic.FindCheckRunByName(t.Context(), "octocat/hello-world", "abc123", "SchemaBot (staging)")
+	result, untrustedApps, err := ic.FindCheckRunByName(t.Context(), "octocat/hello-world", "abc123", "SchemaBot (staging)")
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
@@ -146,6 +146,7 @@ func TestFindCheckRunByNameIgnoresForeignAppCheckRuns(t *testing.T) {
 	assert.Equal(t, "SchemaBot (staging)", result.Name)
 	assert.Equal(t, "completed", result.Status)
 	assert.Equal(t, "action_required", result.Conclusion)
+	assert.Equal(t, []string{"github-actions"}, untrustedApps, "the ignored foreign app is reported for triage")
 }
 
 // TestFindCheckRunByNameReturnsNilWhenOnlyForeignAppRunsExist covers a PR
@@ -164,10 +165,11 @@ func TestFindCheckRunByNameReturnsNilWhenOnlyForeignAppRunsExist(t *testing.T) {
 	})
 
 	ic := NewInstallationClientWithSlug(client, slog.New(slog.NewTextHandler(io.Discard, nil)), "schemabot")
-	result, err := ic.FindCheckRunByName(t.Context(), "octocat/hello-world", "abc123", "SchemaBot (staging)")
+	result, untrustedApps, err := ic.FindCheckRunByName(t.Context(), "octocat/hello-world", "abc123", "SchemaBot (staging)")
 
 	require.NoError(t, err)
 	assert.Nil(t, result)
+	assert.Equal(t, []string{"github-actions"}, untrustedApps, "callers can distinguish an untrusted check from a missing one")
 }
 
 // TestFindCheckRunByNameReturnsMostRecentOwnAppRun covers a PR commit with
@@ -188,12 +190,13 @@ func TestFindCheckRunByNameReturnsMostRecentOwnAppRun(t *testing.T) {
 	})
 
 	ic := NewInstallationClientWithSlug(client, slog.New(slog.NewTextHandler(io.Discard, nil)), "schemabot")
-	result, err := ic.FindCheckRunByName(t.Context(), "octocat/hello-world", "abc123", "SchemaBot (staging)")
+	result, untrustedApps, err := ic.FindCheckRunByName(t.Context(), "octocat/hello-world", "abc123", "SchemaBot (staging)")
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	assert.Equal(t, int64(9), result.ID)
 	assert.Equal(t, "success", result.Conclusion)
+	assert.Empty(t, untrustedApps)
 }
 
 // TestFindCheckRunByNameErrorsWhenOwnAppSlugUnknown covers the case where the
@@ -215,13 +218,14 @@ func TestFindCheckRunByNameErrorsWhenOwnAppSlugUnknown(t *testing.T) {
 	})
 
 	ic := NewInstallationClient(client, slog.New(slog.NewTextHandler(io.Discard, nil)))
-	result, err := ic.FindCheckRunByName(t.Context(), "octocat/hello-world", "abc123", "SchemaBot (staging)")
+	result, untrustedApps, err := ic.FindCheckRunByName(t.Context(), "octocat/hello-world", "abc123", "SchemaBot (staging)")
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "check run ownership cannot be verified")
 	assert.Contains(t, err.Error(), "octocat/hello-world")
 	assert.Contains(t, err.Error(), "abc123")
 	assert.Nil(t, result)
+	assert.Empty(t, untrustedApps)
 	assert.Equal(t, int64(0), requests.Load())
 }
 
@@ -305,13 +309,14 @@ func TestFindCheckRunByNameAcceptsTrustedSiblingAppCheckRun(t *testing.T) {
 	})
 
 	ic := NewInstallationClientWithSlug(client, slog.New(slog.NewTextHandler(io.Discard, nil)), "schemabot-production", "schemabot-staging")
-	result, err := ic.FindCheckRunByName(t.Context(), "octocat/hello-world", "abc123", "SchemaBot (staging)")
+	result, untrustedApps, err := ic.FindCheckRunByName(t.Context(), "octocat/hello-world", "abc123", "SchemaBot (staging)")
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	assert.Equal(t, int64(3), result.ID)
 	assert.Equal(t, "completed", result.Status)
 	assert.Equal(t, "success", result.Conclusion)
+	assert.Equal(t, []string{"github-actions"}, untrustedApps)
 }
 
 // TestFindCheckRunByNameProceedsWithTrustedSlugsWhenOwnSlugUnknown covers a
@@ -331,12 +336,13 @@ func TestFindCheckRunByNameProceedsWithTrustedSlugsWhenOwnSlugUnknown(t *testing
 	})
 
 	ic := NewInstallationClientWithSlug(client, slog.New(slog.NewTextHandler(io.Discard, nil)), "", "schemabot-staging")
-	result, err := ic.FindCheckRunByName(t.Context(), "octocat/hello-world", "abc123", "SchemaBot (staging)")
+	result, untrustedApps, err := ic.FindCheckRunByName(t.Context(), "octocat/hello-world", "abc123", "SchemaBot (staging)")
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	assert.Equal(t, int64(4), result.ID)
 	assert.Equal(t, "success", result.Conclusion)
+	assert.Empty(t, untrustedApps)
 }
 
 // TestGetPRCheckStatusesClassifiesTrustedSiblingAppAsSchemaBot verifies that

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -455,9 +455,12 @@ const (
 // sustained spike means either a check-name spoof attempt or a sibling
 // SchemaBot deployment missing from trusted-check-app-slugs; operators should
 // inspect the app_slug attribute and the matching warn logs to tell which.
-// The gate attribute distinguishes where the untrusted check surfaced: the
-// passing-checks gate (it blocks applies as external CI) or the promotion
-// gate (it cannot verify the prior environment).
+// The counter is an identity-mismatch signal, not a blocking signal: it fires
+// whenever such a check is observed by a gate, even when required_checks
+// narrowing keeps that check from gating applies — the warn log states the
+// actual gating impact. The gate attribute distinguishes where the untrusted
+// check surfaced: the passing-checks gate or the promotion gate (where it
+// cannot verify the prior environment).
 func RecordUntrustedAggregateNamedCheck(ctx context.Context, repository, environment, appSlug, gate string) {
 	meter := otel.Meter(meterName)
 	counter, err := meter.Int64Counter("schemabot.untrusted_aggregate_named_checks_total",

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -441,6 +441,43 @@ func RecordCheckOwnershipMiss(ctx context.Context, operation, repository, databa
 	)
 }
 
+// Gates that evaluate check run trust, used as the gate attribute on
+// RecordUntrustedAggregateNamedCheck.
+const (
+	// CheckTrustGatePassingChecks is the require_passing_checks CI-health gate.
+	CheckTrustGatePassingChecks = "passing_checks"
+	// CheckTrustGatePromotion is the prior-environment promotion gate.
+	CheckTrustGatePromotion = "promotion"
+)
+
+// RecordUntrustedAggregateNamedCheck counts PR checks that carry a SchemaBot
+// aggregate Check Run name but were created by an untrusted GitHub App. A
+// sustained spike means either a check-name spoof attempt or a sibling
+// SchemaBot deployment missing from trusted-check-app-slugs; operators should
+// inspect the app_slug attribute and the matching warn logs to tell which.
+// The gate attribute distinguishes where the untrusted check surfaced: the
+// passing-checks gate (it blocks applies as external CI) or the promotion
+// gate (it cannot verify the prior environment).
+func RecordUntrustedAggregateNamedCheck(ctx context.Context, repository, environment, appSlug, gate string) {
+	meter := otel.Meter(meterName)
+	counter, err := meter.Int64Counter("schemabot.untrusted_aggregate_named_checks_total",
+		otelmetric.WithDescription("Total PR checks with a SchemaBot aggregate name from an untrusted GitHub App"),
+		otelmetric.WithUnit("{check}"),
+	)
+	if err != nil {
+		slog.Warn("failed to create untrusted aggregate-named check counter", "error", err)
+		return
+	}
+	counter.Add(ctx, 1,
+		otelmetric.WithAttributes(
+			attribute.String("repository", repository),
+			EnvironmentAttribute(environment),
+			attribute.String("app_slug", appSlug),
+			attribute.String("gate", gate),
+		),
+	)
+}
+
 // AdjustActiveApplies increments or decrements the active applies gauge.
 // Use delta=1 when an apply is accepted and delta=-1 when it reaches a terminal state.
 func AdjustActiveApplies(ctx context.Context, delta int64, database, deployment, environment string) {

--- a/pkg/webhook/apply_gating.go
+++ b/pkg/webhook/apply_gating.go
@@ -6,14 +6,28 @@ import (
 
 	"github.com/block/schemabot/pkg/api"
 	ghclient "github.com/block/schemabot/pkg/github"
+	"github.com/block/schemabot/pkg/metrics"
 	"github.com/block/schemabot/pkg/webhook/templates"
 )
 
+// isAggregateCheckName reports whether a check name matches this deployment's
+// configured aggregate Check Run name: the base name itself or the
+// environment-scoped form "base (<env>)". Aggregate identity is decided by
+// the creating GitHub App, never by name — this predicate exists only to
+// flag aggregate-named checks from untrusted apps for operator triage.
+func isAggregateCheckName(name, aggregateBase string) bool {
+	if name == aggregateBase {
+		return true
+	}
+	return strings.HasPrefix(name, aggregateBase+" (") && strings.HasSuffix(name, ")")
+}
+
 // filterNonPassingNonSchemaBotChecks returns completed checks that block apply,
-// excluding SchemaBot's own checks. A completed check is ignored only when its
-// conclusion is "success", "neutral", or "skipped"; every other conclusion
-// (such as "failure", "timed_out", "cancelled", "action_required", "stale",
-// or "startup_failure") blocks apply, so unrecognized conclusions fail closed.
+// excluding checks created by trusted SchemaBot GitHub Apps. A completed check
+// is ignored only when its conclusion is "success", "neutral", or "skipped";
+// every other conclusion (such as "failure", "timed_out", "cancelled",
+// "action_required", "stale", or "startup_failure") blocks apply, so
+// unrecognized conclusions fail closed.
 func filterNonPassingNonSchemaBotChecks(statuses []ghclient.PRCheckStatus, config *api.ServerConfig) []templates.BlockingCheck {
 	var notPassing []templates.BlockingCheck
 	filterRequiredChecks := statusesContainRequiredCheck(statuses, config)
@@ -96,6 +110,7 @@ func (h *Handler) enforcePassingChecks(ctx context.Context, client *ghclient.Ins
 
 	notPassing := filterNonPassingNonSchemaBotChecks(statuses, config)
 	inProgress := filterInProgressNonSchemaBotChecks(statuses, config)
+	h.flagUntrustedAggregateNamedChecks(ctx, statuses, repo, pr, headSHA, environment)
 
 	if len(notPassing) > 0 {
 		h.logger.Info("apply blocked by non-passing PR checks",
@@ -136,8 +151,31 @@ func (h *Handler) githubAppDisplayNameForRepo(repo string, client *ghclient.Inst
 	return ""
 }
 
+// flagUntrustedAggregateNamedChecks surfaces PR checks that carry this
+// deployment's aggregate Check Run name but were not created by a trusted
+// SchemaBot GitHub App. Such a check is either a spoof attempt or a sibling
+// deployment whose App slug is missing from trusted-check-app-slugs; in both
+// cases it is treated as ordinary external CI (so a non-passing one blocks
+// applies), and operators need the app identity to tell the two apart.
+func (h *Handler) flagUntrustedAggregateNamedChecks(ctx context.Context, statuses []ghclient.PRCheckStatus, repo string, pr int, headSHA, environment string) {
+	aggregateBase := h.aggregateCheckNameForRepo(repo)
+	for _, s := range statuses {
+		if s.IsSchemaBot {
+			continue
+		}
+		if !isAggregateCheckName(s.Name, aggregateBase) {
+			continue
+		}
+		h.logger.Warn("aggregate-named check from untrusted GitHub App is treated as external CI and will block applies unless passing",
+			"repo", repo, "pr", pr, "head_sha", headSHA, "environment", environment,
+			"check_name", s.Name, "app_slug", s.AppSlug,
+			"check_status", s.Status, "check_conclusion", s.Conclusion)
+		metrics.RecordUntrustedAggregateNamedCheck(ctx, repo, environment, s.AppSlug, metrics.CheckTrustGatePassingChecks)
+	}
+}
+
 // filterInProgressNonSchemaBotChecks returns checks that are still running,
-// excluding SchemaBot's own checks.
+// excluding checks created by trusted SchemaBot GitHub Apps.
 func filterInProgressNonSchemaBotChecks(statuses []ghclient.PRCheckStatus, config *api.ServerConfig) []templates.BlockingCheck {
 	var inProgress []templates.BlockingCheck
 	filterRequiredChecks := statusesContainRequiredCheck(statuses, config)

--- a/pkg/webhook/apply_gating.go
+++ b/pkg/webhook/apply_gating.go
@@ -110,7 +110,7 @@ func (h *Handler) enforcePassingChecks(ctx context.Context, client *ghclient.Ins
 
 	notPassing := filterNonPassingNonSchemaBotChecks(statuses, config)
 	inProgress := filterInProgressNonSchemaBotChecks(statuses, config)
-	h.flagUntrustedAggregateNamedChecks(ctx, statuses, repo, pr, headSHA, environment)
+	h.flagUntrustedAggregateNamedChecks(ctx, statuses, config, repo, pr, headSHA, environment)
 
 	if len(notPassing) > 0 {
 		h.logger.Info("apply blocked by non-passing PR checks",
@@ -154,11 +154,15 @@ func (h *Handler) githubAppDisplayNameForRepo(repo string, client *ghclient.Inst
 // flagUntrustedAggregateNamedChecks surfaces PR checks that carry this
 // deployment's aggregate Check Run name but were not created by a trusted
 // SchemaBot GitHub App. Such a check is either a spoof attempt or a sibling
-// deployment whose App slug is missing from trusted-check-app-slugs; in both
-// cases it is treated as ordinary external CI (so a non-passing one blocks
-// applies), and operators need the app identity to tell the two apart.
-func (h *Handler) flagUntrustedAggregateNamedChecks(ctx context.Context, statuses []ghclient.PRCheckStatus, repo string, pr int, headSHA, environment string) {
+// deployment whose App slug is missing from trusted-check-app-slugs; the
+// signal fires in both cases because operators need the app identity to tell
+// the two apart, independent of whether the check currently gates applies.
+// The log states the check's actual gating impact: it is treated as ordinary
+// external CI, but when required_checks narrowing is active a non-required
+// check does not block.
+func (h *Handler) flagUntrustedAggregateNamedChecks(ctx context.Context, statuses []ghclient.PRCheckStatus, config *api.ServerConfig, repo string, pr int, headSHA, environment string) {
 	aggregateBase := h.aggregateCheckNameForRepo(repo)
+	filterRequiredChecks := statusesContainRequiredCheck(statuses, config)
 	for _, s := range statuses {
 		if s.IsSchemaBot {
 			continue
@@ -166,10 +170,17 @@ func (h *Handler) flagUntrustedAggregateNamedChecks(ctx context.Context, statuse
 		if !isAggregateCheckName(s.Name, aggregateBase) {
 			continue
 		}
-		h.logger.Warn("aggregate-named check from untrusted GitHub App is treated as external CI and will block applies unless passing",
-			"repo", repo, "pr", pr, "head_sha", headSHA, "environment", environment,
-			"check_name", s.Name, "app_slug", s.AppSlug,
-			"check_status", s.Status, "check_conclusion", s.Conclusion)
+		if filterRequiredChecks && !config.IsCheckRequired(s.Name) {
+			h.logger.Warn("aggregate-named check from untrusted GitHub App is present; required_checks narrowing keeps it from gating applies, but it may be impersonating SchemaBot",
+				"repo", repo, "pr", pr, "head_sha", headSHA, "environment", environment,
+				"check_name", s.Name, "app_slug", s.AppSlug,
+				"check_status", s.Status, "check_conclusion", s.Conclusion)
+		} else {
+			h.logger.Warn("aggregate-named check from untrusted GitHub App is treated as external CI and will block applies unless passing",
+				"repo", repo, "pr", pr, "head_sha", headSHA, "environment", environment,
+				"check_name", s.Name, "app_slug", s.AppSlug,
+				"check_status", s.Status, "check_conclusion", s.Conclusion)
+		}
 		metrics.RecordUntrustedAggregateNamedCheck(ctx, repo, environment, s.AppSlug, metrics.CheckTrustGatePassingChecks)
 	}
 }

--- a/pkg/webhook/apply_gating_test.go
+++ b/pkg/webhook/apply_gating_test.go
@@ -203,6 +203,91 @@ func TestFilterNonPassingNonSchemaBotChecks_RequiredChecks(t *testing.T) {
 	}
 }
 
+func TestIsAggregateCheckName(t *testing.T) {
+	cases := []struct {
+		name          string
+		checkName     string
+		aggregateBase string
+		want          bool
+	}{
+		{name: "base name matches", checkName: "SchemaBot", aggregateBase: "SchemaBot", want: true},
+		{name: "environment-scoped name matches", checkName: "SchemaBot (staging)", aggregateBase: "SchemaBot", want: true},
+		{name: "custom base environment-scoped name matches", checkName: "SchemaBot X (production)", aggregateBase: "SchemaBot X", want: true},
+		{name: "different base does not match", checkName: "SchemaBot X (staging)", aggregateBase: "SchemaBot", want: false},
+		{name: "prefix without parenthesized suffix does not match", checkName: "SchemaBot Lint", aggregateBase: "SchemaBot", want: false},
+		{name: "unrelated CI check does not match", checkName: "CI / unit-tests", aggregateBase: "SchemaBot", want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, isAggregateCheckName(tc.checkName, tc.aggregateBase))
+		})
+	}
+}
+
+// TestFilterNonPassingNonSchemaBotChecks_SiblingAggregate covers the
+// split-deployment topology where another deployment in the promotion chain
+// publishes its aggregate Check Run under a different GitHub App. When that
+// App's slug is configured as trusted, the aggregate is classified as a
+// SchemaBot check and never blocks applies. When the App is untrusted, the
+// same-named check is treated as ordinary external CI and its non-passing
+// conclusion blocks applies — name alone can never unblock the gate, so a
+// spoofed aggregate name cannot hide a failing check.
+func TestFilterNonPassingNonSchemaBotChecks_SiblingAggregate(t *testing.T) {
+	t.Run("trusted sibling aggregate does not block", func(t *testing.T) {
+		statuses := []ghclient.PRCheckStatus{
+			{Name: "SchemaBot (production)", Status: "completed", Conclusion: "action_required", AppSlug: "schemabot-production", IsSchemaBot: true},
+			{Name: "CI / unit-tests", Status: "completed", Conclusion: "failure"},
+		}
+
+		notPassing := filterNonPassingNonSchemaBotChecks(statuses, nil)
+
+		require.Len(t, notPassing, 1)
+		assert.Equal(t, "CI / unit-tests", notPassing[0].Name)
+		assert.Equal(t, "failure", notPassing[0].State)
+	})
+
+	t.Run("untrusted aggregate-named check blocks", func(t *testing.T) {
+		statuses := []ghclient.PRCheckStatus{
+			{Name: "SchemaBot (production)", Status: "completed", Conclusion: "action_required", AppSlug: "github-actions", IsSchemaBot: false},
+		}
+
+		notPassing := filterNonPassingNonSchemaBotChecks(statuses, nil)
+
+		require.Len(t, notPassing, 1)
+		assert.Equal(t, "SchemaBot (production)", notPassing[0].Name)
+		assert.Equal(t, "action_required", notPassing[0].State)
+	})
+}
+
+// TestFilterInProgressNonSchemaBotChecks_SiblingAggregate verifies the same
+// identity rule for in-flight checks: a trusted sibling deployment's
+// mid-apply aggregate does not block, while an untrusted aggregate-named
+// check that is still running blocks like any other in-progress CI.
+func TestFilterInProgressNonSchemaBotChecks_SiblingAggregate(t *testing.T) {
+	t.Run("trusted sibling aggregate does not block", func(t *testing.T) {
+		statuses := []ghclient.PRCheckStatus{
+			{Name: "SchemaBot (production)", Status: "in_progress", Conclusion: "", AppSlug: "schemabot-production", IsSchemaBot: true},
+			{Name: "CI / tests", Status: "in_progress", Conclusion: ""},
+		}
+
+		inProgress := filterInProgressNonSchemaBotChecks(statuses, nil)
+
+		require.Len(t, inProgress, 1)
+		assert.Equal(t, "CI / tests", inProgress[0].Name)
+	})
+
+	t.Run("untrusted aggregate-named check blocks", func(t *testing.T) {
+		statuses := []ghclient.PRCheckStatus{
+			{Name: "SchemaBot (production)", Status: "in_progress", Conclusion: "", AppSlug: "github-actions", IsSchemaBot: false},
+		}
+
+		inProgress := filterInProgressNonSchemaBotChecks(statuses, nil)
+
+		require.Len(t, inProgress, 1)
+		assert.Equal(t, "SchemaBot (production)", inProgress[0].Name)
+	})
+}
+
 func TestFilterInProgressNonSchemaBotChecks(t *testing.T) {
 	statuses := []ghclient.PRCheckStatus{
 		{Name: "CI / tests", Status: "in_progress", Conclusion: ""},

--- a/pkg/webhook/apply_gating_test.go
+++ b/pkg/webhook/apply_gating_test.go
@@ -1,7 +1,9 @@
 package webhook
 
 import (
+	"bytes"
 	"encoding/json"
+	"log/slog"
 	"net/http"
 	"testing"
 	"time"
@@ -285,6 +287,48 @@ func TestFilterInProgressNonSchemaBotChecks_SiblingAggregate(t *testing.T) {
 
 		require.Len(t, inProgress, 1)
 		assert.Equal(t, "SchemaBot (production)", inProgress[0].Name)
+	})
+}
+
+// TestFlagUntrustedAggregateNamedChecks verifies that the spoof/misconfig
+// signal states the check's actual gating impact: when required_checks
+// narrowing excludes a non-required untrusted aggregate-named check from the
+// gate, the warning says so instead of claiming the check will block applies.
+func TestFlagUntrustedAggregateNamedChecks(t *testing.T) {
+	newHandler := func(buf *bytes.Buffer) *Handler {
+		return &Handler{logger: slog.New(slog.NewTextHandler(buf, nil))}
+	}
+	untrustedAggregate := ghclient.PRCheckStatus{
+		Name: "SchemaBot (production)", Status: "completed", Conclusion: "action_required",
+		AppSlug: "github-actions", IsSchemaBot: false,
+	}
+
+	t.Run("gating check is reported as blocking", func(t *testing.T) {
+		var buf bytes.Buffer
+		h := newHandler(&buf)
+
+		h.flagUntrustedAggregateNamedChecks(t.Context(),
+			[]ghclient.PRCheckStatus{untrustedAggregate},
+			nil, "octocat/hello-world", 1, "abc123", "staging")
+
+		assert.Contains(t, buf.String(), "will block applies unless passing")
+		assert.Contains(t, buf.String(), "app_slug=github-actions")
+	})
+
+	t.Run("check excluded by required_checks narrowing is reported as non-gating", func(t *testing.T) {
+		var buf bytes.Buffer
+		h := newHandler(&buf)
+		config := &api.ServerConfig{RequiredChecks: []string{"Owner Owl"}}
+		statuses := []ghclient.PRCheckStatus{
+			untrustedAggregate,
+			{Name: "Owner Owl", Status: "completed", Conclusion: "success"},
+		}
+
+		h.flagUntrustedAggregateNamedChecks(t.Context(),
+			statuses, config, "octocat/hello-world", 1, "abc123", "staging")
+
+		assert.Contains(t, buf.String(), "required_checks narrowing keeps it from gating applies")
+		assert.NotContains(t, buf.String(), "will block applies unless passing")
 	})
 }
 

--- a/pkg/webhook/check_prior_env.go
+++ b/pkg/webhook/check_prior_env.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/block/schemabot/pkg/api"
 	ghclient "github.com/block/schemabot/pkg/github"
+	"github.com/block/schemabot/pkg/metrics"
 	"github.com/block/schemabot/pkg/storage"
 	"github.com/block/schemabot/pkg/webhook/templates"
 )
@@ -226,7 +227,7 @@ func (h *Handler) checkPriorEnvViaGitHub(
 	}
 
 	checkName := aggregateCheckNameForEnv(h.aggregateCheckNameForRepo(repo), priorEnv)
-	checkResult, err := h.waitForGitHubPriorEnvCheck(ctx, client, repo, pr, database, environment, priorEnv, prInfo.HeadSHA, checkName)
+	checkResult, untrustedApps, err := h.waitForGitHubPriorEnvCheck(ctx, client, repo, pr, database, environment, priorEnv, prInfo.HeadSHA, checkName)
 	if err != nil {
 		h.logger.Error("failed to query GitHub check for prior environment, blocking apply",
 			"repo", repo, "pr", pr,
@@ -236,6 +237,26 @@ func (h *Handler) checkPriorEnvViaGitHub(
 			"check_name", checkName, "error", err)
 		h.postComment(repo, pr, installationID,
 			templates.RenderApplyBlockedByPriorEnvCheckError(priorEnv, "query check runs", err))
+		return true
+	}
+
+	if checkResult == nil && len(untrustedApps) > 0 {
+		// The prior environment's check exists on this commit but none of the
+		// creating apps are trusted — re-running plan/apply on the prior
+		// environment cannot fix this; only trusting the owning deployment's
+		// App (or removing a spoofed check) can.
+		h.logger.Warn("prior environment check exists only from untrusted GitHub Apps, blocking apply",
+			"repo", repo, "pr", pr,
+			"database", database,
+			"environment", environment, "prior_environment", priorEnv,
+			"head_sha", prInfo.HeadSHA,
+			"check_name", checkName,
+			"untrusted_app_slugs", untrustedApps)
+		for _, appSlug := range untrustedApps {
+			metrics.RecordUntrustedAggregateNamedCheck(ctx, repo, environment, appSlug, metrics.CheckTrustGatePromotion)
+		}
+		h.postComment(repo, pr, installationID,
+			templates.RenderApplyBlockedByUntrustedPriorEnvCheck(priorEnv, checkName, untrustedApps))
 		return true
 	}
 
@@ -287,18 +308,20 @@ func (h *Handler) waitForGitHubPriorEnvCheck(
 	ctx context.Context, client *ghclient.InstallationClient,
 	repo string, pr int,
 	database, environment, priorEnv, headSHA, checkName string,
-) (*ghclient.CheckRunResult, error) {
+) (*ghclient.CheckRunResult, []string, error) {
 	// Cross-instance prior environment checks depend on GitHub Check Run
 	// visibility. Retry briefly so ordering jitter does not cause an avoidable
 	// block, then fail closed if the required check is still missing or running.
 	attempts := h.priorEnvCheckMaxAttemptCount()
+	var untrustedApps []string
 	for attempt := 1; attempt <= attempts; attempt++ {
-		checkResult, err := client.FindCheckRunByName(ctx, repo, headSHA, checkName)
+		checkResult, untrusted, err := client.FindCheckRunByName(ctx, repo, headSHA, checkName)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
+		untrustedApps = untrusted
 		if !shouldRetryGitHubPriorEnvCheck(checkResult) || attempt == attempts {
-			return checkResult, nil
+			return checkResult, untrustedApps, nil
 		}
 
 		h.logger.Debug("prior environment GitHub check not ready, retrying",
@@ -310,11 +333,11 @@ func (h *Handler) waitForGitHubPriorEnvCheck(
 			"check_status", githubPriorEnvCheckStatus(checkResult),
 			"attempt", attempt, "max_attempts", attempts)
 		if err := h.waitBeforePriorEnvCheckRetry(ctx); err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 	}
 
-	return nil, nil
+	return nil, untrustedApps, nil
 }
 
 func shouldRetryGitHubPriorEnvCheck(check *ghclient.CheckRunResult) bool {

--- a/pkg/webhook/check_prior_env_test.go
+++ b/pkg/webhook/check_prior_env_test.go
@@ -361,7 +361,9 @@ func TestCheckPriorEnvironmentsCrossDeploymentAppTrust(t *testing.T) {
 		assert.True(t, blocked, "a staging aggregate check from an unconfigured App must not satisfy the promotion gate")
 		select {
 		case body := <-comments:
-			assert.Contains(t, body, "staging")
+			assert.Contains(t, body, "`schemabot-staging`")
+			assert.Contains(t, body, "trusted-check-app-slugs")
+			assert.NotContains(t, body, "could not find a completed `staging` check")
 		case <-time.After(2 * time.Second):
 			t.Fatal("timed out waiting for staging block comment")
 		}
@@ -495,9 +497,10 @@ func TestCheckPriorEnvViaGitHub(t *testing.T) {
 
 	// A repository contributor can create a GitHub Actions job whose name matches
 	// the staging instance's aggregate Check Run. The promotion gate must only
-	// trust Check Runs created by SchemaBot's own GitHub App, so a passing
-	// same-named run from another app blocks the production apply as if the
-	// staging check were missing.
+	// trust Check Runs created by trusted SchemaBot GitHub Apps, so a passing
+	// same-named run from another app blocks the production apply — and the
+	// blocked comment names the untrusted app and points at the trust config
+	// instead of suggesting a staging re-plan that cannot fix it.
 	t.Run("same-named foreign-app success run blocks apply", func(t *testing.T) {
 		h, comments := setupCheckRunServer(t, []map[string]any{
 			{"id": 1, "name": "SchemaBot (staging)", "status": "completed", "conclusion": "success", "app": map[string]any{"slug": "github-actions"}},
@@ -509,9 +512,13 @@ func TestCheckPriorEnvViaGitHub(t *testing.T) {
 		select {
 		case body := <-comments:
 			assert.Contains(t, body, "Apply Blocked")
-			assert.Contains(t, body, "could not find a completed `staging` check")
+			assert.Contains(t, body, "`github-actions`")
+			assert.Contains(t, body, "does not trust")
+			assert.Contains(t, body, "trusted-check-app-slugs")
+			assert.Contains(t, body, "will not resolve this")
+			assert.NotContains(t, body, "could not find a completed `staging` check")
 		default:
-			t.Fatal("expected a comment explaining the missing prior environment check")
+			t.Fatal("expected a comment explaining the untrusted prior environment check")
 		}
 	})
 

--- a/pkg/webhook/templates/apply_commands.go
+++ b/pkg/webhook/templates/apply_commands.go
@@ -498,6 +498,30 @@ func RenderApplyBlockedByMissingPriorEnvCheck(priorEnv string) string {
 	return sb.String()
 }
 
+// RenderApplyBlockedByUntrustedPriorEnvCheck renders a comment when apply is
+// blocked because the prior environment's check exists on the PR head but was
+// created only by GitHub Apps this deployment does not trust. Re-running plan
+// or apply on the prior environment cannot fix this — the remediation is a
+// server config change (trusting the owning deployment's App) or removing a
+// spoofed check, so the comment must not suggest the plan/apply loop.
+func RenderApplyBlockedByUntrustedPriorEnvCheck(priorEnv, checkName string, untrustedApps []string) string {
+	var sb strings.Builder
+
+	sb.WriteString("## ❌ Apply Blocked\n\n")
+	fmt.Fprintf(&sb, "A `%s` check named `%s` exists on this PR, but it was created by a GitHub App this SchemaBot deployment does not trust:\n\n", priorEnv, checkName)
+	for _, app := range untrustedApps {
+		fmt.Fprintf(&sb, "- `%s`\n", app)
+	}
+	sb.WriteString("\n")
+	fmt.Fprintf(&sb, "SchemaBot only verifies `%s` through check runs created by trusted SchemaBot deployment Apps.\n\n", priorEnv)
+	sb.WriteString("### Next steps\n")
+	fmt.Fprintf(&sb, "- If the App above is the SchemaBot deployment that owns `%s`, an operator must add its slug to `github.trusted-check-app-slugs` in this deployment's server config.\n", priorEnv)
+	sb.WriteString("- If you do not recognize the App, do not trust it — the check may be impersonating SchemaBot.\n\n")
+	fmt.Fprintf(&sb, "Re-running `schemabot plan -e %s` will not resolve this.\n", priorEnv)
+
+	return sb.String()
+}
+
 // RenderApplyBlockedByPriorEnvInProgress renders a comment when an apply is blocked
 // because a prior environment's apply is currently running.
 func RenderApplyBlockedByPriorEnvInProgress(database, environment, priorEnv string) string {

--- a/pkg/webhook/templates/apply_test.go
+++ b/pkg/webhook/templates/apply_test.go
@@ -757,6 +757,18 @@ func TestRenderApplyBlockedByMissingPriorEnvCheck(t *testing.T) {
 	assert.NotContains(t, result, "Retry the apply command")
 }
 
+func TestRenderApplyBlockedByUntrustedPriorEnvCheck(t *testing.T) {
+	result := RenderApplyBlockedByUntrustedPriorEnvCheck("staging", "SchemaBot (staging)", []string{"schemabot-staging"})
+
+	assert.Contains(t, result, "## ❌ Apply Blocked")
+	assert.Contains(t, result, "`SchemaBot (staging)`")
+	assert.Contains(t, result, "- `schemabot-staging`")
+	assert.Contains(t, result, "does not trust")
+	assert.Contains(t, result, "trusted-check-app-slugs")
+	assert.Contains(t, result, "Re-running `schemabot plan -e staging` will not resolve this")
+	assert.NotContains(t, result, "could not find a completed")
+}
+
 func TestRenderApplyBlockedByInProgressChecks(t *testing.T) {
 	inProgress := []BlockingCheck{
 		{Name: "CI / unit-tests", State: "in_progress"},


### PR DESCRIPTION
## Summary

SchemaBot gates trust check runs **only by the creating GitHub App, never by check name** — in both directions. The promotion gate accepts a prior environment's aggregate check only from a trusted chain App (fails closed otherwise), and the `require_passing_checks` gate excludes only trusted Apps' aggregates from CI-health blocking. A same-named check from any other app cannot satisfy the promotion gate and cannot be hidden from the CI gate.

`trusted-check-app-slugs` is documented as chain-level shared configuration: every deployment in a promotion chain carries the same complete list of the chain's App slugs (like `environment_order`). That removes the cross-deployment blocking hazard — a sibling's `action_required` aggregate is expected workflow state, not failing CI — without introducing any name-trusted path.

```text
check on PR head               promotion gate      passing-checks gate
-----------------------------  ------------------  -------------------------------
trusted chain App aggregate    can satisfy         excluded (SchemaBot state)
untrusted app, aggregate name  cannot satisfy;     blocks if not passing
                               blocked comment     + warn log + metric
                               names the app
any other external check       cannot satisfy      blocks if not passing
```

**Actionable failure UX.** The promotion gate now distinguishes "no prior-environment check exists" from "a check exists but its App is not trusted", because the remediations differ. The first comment directs the user to plan/apply the prior environment; the second names the untrusted app(s) and directs an operator to `trusted-check-app-slugs` (or to investigate an impersonating check) instead of suggesting a re-plan that cannot change check ownership. `FindCheckRunByName` reports the ignored apps to make this possible.

**Observability.** New counter `schemabot.untrusted_aggregate_named_checks_total` (repository, environment, app_slug, gate) plus warn logs with the creating app slug, in both the passing-checks and promotion gates — so operators can tell a check-name spoof attempt from a chain member missing from the trusted list. `PRCheckStatus` now carries the creating App slug.

**Docs.** `check-runs.md` adds a cross-deployment trust model: prior-environment checks are **sequencing evidence, never execution authority** — a tampered earlier environment can defeat staging-first ordering but cannot influence DDL content, actor authorization, review gating, or lint, all evaluated locally by the later environment. Branch-protection setup now recommends pinning required SchemaBot checks to their publishing App, closing the one name-trust surface SchemaBot cannot enforce itself.

---

*This PR was generated by [Amp](https://ampcode.com) with Fable (claude-fable-5).*
