### PR TITLE
fix(github): format apply IDs in completion summaries

### DIFF
--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -2177,7 +2177,7 @@ ALTER TABLE `users` ADD INDEX `idx_email`(`email`);
 ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
 ```
 
-_Apply ID: apply-a1b2c3d4e5f6_
+_Apply ID: `apply-a1b2c3d4e5f6`_
 
 </details>
 
@@ -2311,7 +2311,7 @@ ALTER TABLE `audit_logs` ADD INDEX `idx_created_at`(`created_at`);
 ALTER TABLE `notifications` ADD INDEX `idx_user_status`(`user_id`, `status`);
 ```
 
-_Apply ID: apply-a1b2c3d4e5f6_
+_Apply ID: `apply-a1b2c3d4e5f6`_
 
 </details>
 
@@ -2480,7 +2480,7 @@ ALTER TABLE `addresses` ADD INDEX `idx_zip`(`zip_code`);
 ALTER TABLE `events` ADD INDEX `idx_created_at`(`created_at`);
 ```
 
-_Apply ID: apply-a1b2c3d4e5f6_
+_Apply ID: `apply-a1b2c3d4e5f6`_
 </details>
 
 ### CLI Output

--- a/pkg/webhook/templates/apply.go
+++ b/pkg/webhook/templates/apply.go
@@ -577,7 +577,10 @@ func writeSummaryCompleted(sb *strings.Builder, data ApplyStatusCommentData, tot
 	writeSuccessBlock(sb, msg)
 	writeSummaryTableList(sb, data)
 	if data.ApplyID != "" {
-		fmt.Fprintf(sb, "_Apply ID: %s_\n", data.ApplyID)
+		if !strings.HasSuffix(sb.String(), "\n\n") {
+			sb.WriteString("\n")
+		}
+		fmt.Fprintf(sb, "_Apply ID: `%s`_\n", data.ApplyID)
 	}
 }
 

--- a/pkg/webhook/templates/apply_test.go
+++ b/pkg/webhook/templates/apply_test.go
@@ -2,6 +2,7 @@ package templates
 
 import (
 	"errors"
+	"fmt"
 	"reflect"
 	"strings"
 	"testing"
@@ -590,8 +591,37 @@ func TestPreviewCommentSummaryCompletedLargeSingleNamespaceKeepsApplyIDInsideSec
 	result := PreviewCommentSummaryCompletedLarge()
 
 	assert.Contains(t, result, "All 8 tables applied successfully")
-	assert.Contains(t, result, "_Apply ID: apply-a1b2c3d4e5f6_")
+	assert.Contains(t, result, "_Apply ID: `apply-a1b2c3d4e5f6`_")
 	assert.Equal(t, 0, strings.Count(result, "</details>"))
+}
+
+func TestRenderApplySummaryCommentCompletedCollapsedGroupSeparatesApplyID(t *testing.T) {
+	tableNames := []string{"users", "orders", "products", "invoices", "payments", "shipments"}
+	tables := make([]TableProgressData, 0, len(tableNames))
+	for _, tableName := range tableNames {
+		tables = append(tables, TableProgressData{
+			Namespace: "testapp_primary",
+			TableName: tableName,
+			DDL: fmt.Sprintf(
+				"CREATE TABLE `%s` (`id` bigint unsigned NOT NULL AUTO_INCREMENT, PRIMARY KEY (`id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci",
+				tableName,
+			),
+			Status: state.Task.Completed,
+		})
+	}
+	data := ApplyStatusCommentData{
+		ApplyID:     "apply-a1b2c3d4e5f6",
+		Database:    "testapp",
+		Environment: "staging",
+		State:       state.Apply.Completed,
+		Tables:      tables,
+	}
+
+	result := RenderApplySummaryComment(data)
+
+	assert.Contains(t, result, "<details><summary>✅ <strong>testapp_primary</strong> (6 tables)</summary>")
+	assert.Contains(t, result, "</details>\n\n_Apply ID: `apply-a1b2c3d4e5f6`_")
+	assert.NotContains(t, result, "</details>\n_Apply ID")
 }
 
 func TestRenderApplyBlockedByNonPassingChecks(t *testing.T) {


### PR DESCRIPTION
## Why
Completed schema change summaries should keep rendering Markdown after collapsed table groups so operational identifiers remain readable.

## What
- Preserve Markdown spacing between collapsed table groups and the apply ID footer
- Format completion-summary apply IDs as inline code
- Cover the collapsed-group summary case in template tests

## Risk Assessment
Low — this only changes GitHub comment rendering for completed schema change summaries.

Generated with Amp
