### PR TITLE
feat(routing): introduce execution target resolver

### DIFF
--- a/integration/operator_test.go
+++ b/integration/operator_test.go
@@ -464,12 +464,24 @@ func TestOperator_OperationDeploymentMismatchFailsClosed(t *testing.T) {
 
 	// Having reached the guard, it must never drive the operation to a terminal
 	// state, because its deployment diverges from the parent apply's.
-	require.Never(t, func() bool {
-		op, err := ts.Storage.ApplyOperations().Get(ctx, opID)
-		require.NoError(t, err)
-		return op != nil && state.IsTerminalApplyState(op.State)
-	}, 3*time.Second, 200*time.Millisecond,
-		"operator must fail closed and never drive an operation whose deployment diverges from its parent apply")
+	neverTerminalDeadline := time.NewTimer(3 * time.Second)
+	defer neverTerminalDeadline.Stop()
+	neverTerminalPoll := time.NewTicker(200 * time.Millisecond)
+	defer neverTerminalPoll.Stop()
+
+	observingOperation := true
+	for observingOperation {
+		select {
+		case <-neverTerminalDeadline.C:
+			observingOperation = false
+		case <-neverTerminalPoll.C:
+			op, err := ts.Storage.ApplyOperations().Get(ctx, opID)
+			require.NoError(t, err)
+			if op != nil && state.IsTerminalApplyState(op.State) {
+				require.Failf(t, "operation reached terminal state", "operator must fail closed and never drive an operation whose deployment diverges from its parent apply; got state %q", op.State)
+			}
+		}
+	}
 
 	op, err := ts.Storage.ApplyOperations().Get(ctx, opID)
 	require.NoError(t, err)

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -15,6 +16,7 @@ import (
 	"github.com/block/schemabot/pkg/pendingdrops"
 	"github.com/block/schemabot/pkg/secrets"
 	"github.com/block/schemabot/pkg/storage"
+	"github.com/block/schemabot/pkg/targetresolver"
 	gomysql "github.com/go-sql-driver/mysql"
 	"gopkg.in/yaml.v3"
 )
@@ -487,13 +489,6 @@ type RepoConfig struct {
 	GitHubApp string `yaml:"github_app,omitempty"`
 }
 
-// ResolvedDatabaseTarget is the server-owned routing decision for plan/apply.
-type ResolvedDatabaseTarget struct {
-	DatabaseType string
-	Deployment   string
-	Target       string
-}
-
 // DeploymentTarget is one entry in EnvironmentConfig.Deployments. It carries
 // the per-deployment override values for a multi-deployment environment. The
 // enclosing map key identifies the Tern deployment (and must also appear in
@@ -850,13 +845,13 @@ func (c *ServerConfig) DatabaseEnvironments(database string) ([]string, error) {
 // For environments configured with a deployments map (multi-deployment), this
 // returns the single deployment when exactly one is configured and otherwise
 // errors. Callers that need the full set MUST use ResolveDatabaseTargets.
-func (c *ServerConfig) ResolveDatabaseTarget(database, environment string) (ResolvedDatabaseTarget, error) {
+func (c *ServerConfig) ResolveDatabaseTarget(database, environment string) (targetresolver.Target, error) {
 	targets, err := c.ResolveDatabaseTargets(database, environment)
 	if err != nil {
-		return ResolvedDatabaseTarget{}, err
+		return targetresolver.Target{}, err
 	}
 	if len(targets) != 1 {
-		return ResolvedDatabaseTarget{}, fmt.Errorf("database %q environment %q resolves to %d deployments; use ResolveDatabaseTargets", database, environment, len(targets))
+		return targetresolver.Target{}, fmt.Errorf("database %q environment %q resolves to %d deployments; use ResolveDatabaseTargets", database, environment, len(targets))
 	}
 	return targets[0], nil
 }
@@ -914,12 +909,18 @@ func validateDeploymentOrder(deployments map[string]DeploymentTarget, order []st
 	return nil
 }
 
+// ResolveTargets implements targetresolver.Resolver using this server's static
+// configuration.
+func (c *ServerConfig) ResolveTargets(_ context.Context, req targetresolver.Request) ([]targetresolver.Target, error) {
+	return c.ResolveDatabaseTargets(req.Database, req.Environment)
+}
+
 // ResolveDatabaseTargets returns the complete routing metadata for a configured
 // database/environment as one or more deployment slices. Single-deployment
 // configurations (scalar target/deployment or local DSN) return a one-element
 // slice; multi-deployment environments return one element per entry in the
 // deployments map, ordered deterministically by deployment key.
-func (c *ServerConfig) ResolveDatabaseTargets(database, environment string) ([]ResolvedDatabaseTarget, error) {
+func (c *ServerConfig) ResolveDatabaseTargets(database, environment string) ([]targetresolver.Target, error) {
 	if c == nil {
 		return nil, fmt.Errorf("server config is nil")
 	}
@@ -933,7 +934,7 @@ func (c *ServerConfig) ResolveDatabaseTargets(database, environment string) ([]R
 	}
 
 	if envConfig.HasLocalDSN() {
-		return []ResolvedDatabaseTarget{{
+		return []targetresolver.Target{{
 			DatabaseType: dbConfig.Type,
 			Deployment:   database,
 			Target:       database,
@@ -952,13 +953,13 @@ func (c *ServerConfig) ResolveDatabaseTargets(database, environment string) ([]R
 		if err != nil {
 			return nil, err
 		}
-		out := make([]ResolvedDatabaseTarget, 0, len(deployments))
+		out := make([]targetresolver.Target, 0, len(deployments))
 		for _, deployment := range deployments {
 			dt := envConfig.Deployments[deployment]
 			if dt.Target == "" {
 				return nil, fmt.Errorf("database %q environment %q deployment %q missing target", database, environment, deployment)
 			}
-			out = append(out, ResolvedDatabaseTarget{
+			out = append(out, targetresolver.Target{
 				DatabaseType: dbConfig.Type,
 				Deployment:   deployment,
 				Target:       dt.Target,
@@ -973,7 +974,7 @@ func (c *ServerConfig) ResolveDatabaseTargets(database, environment string) ([]R
 	if envConfig.Deployment == "" {
 		return nil, fmt.Errorf("database %q environment %q missing server-side deployment", database, environment)
 	}
-	return []ResolvedDatabaseTarget{{
+	return []targetresolver.Target{{
 		DatabaseType: dbConfig.Type,
 		Deployment:   envConfig.Deployment,
 		Target:       envConfig.Target,

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -14,9 +14,9 @@ import (
 	"time"
 
 	"github.com/block/schemabot/pkg/pendingdrops"
+	"github.com/block/schemabot/pkg/routing"
 	"github.com/block/schemabot/pkg/secrets"
 	"github.com/block/schemabot/pkg/storage"
-	"github.com/block/schemabot/pkg/targetresolver"
 	gomysql "github.com/go-sql-driver/mysql"
 	"gopkg.in/yaml.v3"
 )
@@ -845,13 +845,13 @@ func (c *ServerConfig) DatabaseEnvironments(database string) ([]string, error) {
 // For environments configured with a deployments map (multi-deployment), this
 // returns the single deployment when exactly one is configured and otherwise
 // errors. Callers that need the full set MUST use ResolveDatabaseTargets.
-func (c *ServerConfig) ResolveDatabaseTarget(database, environment string) (targetresolver.Target, error) {
+func (c *ServerConfig) ResolveDatabaseTarget(database, environment string) (routing.ExecutionTarget, error) {
 	targets, err := c.ResolveDatabaseTargets(database, environment)
 	if err != nil {
-		return targetresolver.Target{}, err
+		return routing.ExecutionTarget{}, err
 	}
 	if len(targets) != 1 {
-		return targetresolver.Target{}, fmt.Errorf("database %q environment %q resolves to %d deployments; use ResolveDatabaseTargets", database, environment, len(targets))
+		return routing.ExecutionTarget{}, fmt.Errorf("database %q environment %q resolves to %d deployments; use ResolveDatabaseTargets", database, environment, len(targets))
 	}
 	return targets[0], nil
 }
@@ -909,9 +909,9 @@ func validateDeploymentOrder(deployments map[string]DeploymentTarget, order []st
 	return nil
 }
 
-// ResolveTargets implements targetresolver.Resolver using this server's static
+// ResolveTargets implements routing.Resolver using this server's static
 // configuration.
-func (c *ServerConfig) ResolveTargets(_ context.Context, req targetresolver.Request) ([]targetresolver.Target, error) {
+func (c *ServerConfig) ResolveTargets(_ context.Context, req routing.Request) ([]routing.ExecutionTarget, error) {
 	return c.ResolveDatabaseTargets(req.Database, req.Environment)
 }
 
@@ -920,7 +920,7 @@ func (c *ServerConfig) ResolveTargets(_ context.Context, req targetresolver.Requ
 // configurations (scalar target/deployment or local DSN) return a one-element
 // slice; multi-deployment environments return one element per entry in the
 // deployments map, ordered deterministically by deployment key.
-func (c *ServerConfig) ResolveDatabaseTargets(database, environment string) ([]targetresolver.Target, error) {
+func (c *ServerConfig) ResolveDatabaseTargets(database, environment string) ([]routing.ExecutionTarget, error) {
 	if c == nil {
 		return nil, fmt.Errorf("server config is nil")
 	}
@@ -934,7 +934,7 @@ func (c *ServerConfig) ResolveDatabaseTargets(database, environment string) ([]t
 	}
 
 	if envConfig.HasLocalDSN() {
-		return []targetresolver.Target{{
+		return []routing.ExecutionTarget{{
 			DatabaseType: dbConfig.Type,
 			Deployment:   database,
 			Target:       database,
@@ -953,13 +953,13 @@ func (c *ServerConfig) ResolveDatabaseTargets(database, environment string) ([]t
 		if err != nil {
 			return nil, err
 		}
-		out := make([]targetresolver.Target, 0, len(deployments))
+		out := make([]routing.ExecutionTarget, 0, len(deployments))
 		for _, deployment := range deployments {
 			dt := envConfig.Deployments[deployment]
 			if dt.Target == "" {
 				return nil, fmt.Errorf("database %q environment %q deployment %q missing target", database, environment, deployment)
 			}
-			out = append(out, targetresolver.Target{
+			out = append(out, routing.ExecutionTarget{
 				DatabaseType: dbConfig.Type,
 				Deployment:   deployment,
 				Target:       dt.Target,
@@ -974,7 +974,7 @@ func (c *ServerConfig) ResolveDatabaseTargets(database, environment string) ([]t
 	if envConfig.Deployment == "" {
 		return nil, fmt.Errorf("database %q environment %q missing server-side deployment", database, environment)
 	}
-	return []targetresolver.Target{{
+	return []routing.ExecutionTarget{{
 		DatabaseType: dbConfig.Type,
 		Deployment:   envConfig.Deployment,
 		Target:       envConfig.Target,

--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -16,8 +16,8 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/block/schemabot/pkg/pendingdrops"
+	"github.com/block/schemabot/pkg/routing"
 	"github.com/block/schemabot/pkg/storage"
-	"github.com/block/schemabot/pkg/targetresolver"
 )
 
 func TestLoadServerConfig(t *testing.T) {
@@ -999,29 +999,29 @@ func TestServerConfig_ResolveDatabaseTargets(t *testing.T) {
 		got, err := cfg.ResolveDatabaseTargets("localdb", "staging")
 		require.NoError(t, err)
 		require.Len(t, got, 1)
-		assert.Equal(t, targetresolver.Target{DatabaseType: "mysql", Deployment: "localdb", Target: "localdb"}, got[0])
+		assert.Equal(t, routing.ExecutionTarget{DatabaseType: "mysql", Deployment: "localdb", Target: "localdb"}, got[0])
 	})
 
 	t.Run("scalar remote returns single element", func(t *testing.T) {
 		got, err := cfg.ResolveDatabaseTargets("scalardb", "production")
 		require.NoError(t, err)
 		require.Len(t, got, 1)
-		assert.Equal(t, targetresolver.Target{DatabaseType: "vitess", Deployment: "tenant-a", Target: "cluster-production-001"}, got[0])
+		assert.Equal(t, routing.ExecutionTarget{DatabaseType: "vitess", Deployment: "tenant-a", Target: "cluster-production-001"}, got[0])
 	})
 
 	t.Run("deployments map returns sorted slice", func(t *testing.T) {
 		got, err := cfg.ResolveDatabaseTargets("multidb", "production")
 		require.NoError(t, err)
-		assert.Equal(t, []targetresolver.Target{
+		assert.Equal(t, []routing.ExecutionTarget{
 			{DatabaseType: "mysql", Deployment: "payments-a", Target: "payments"},
 			{DatabaseType: "mysql", Deployment: "payments-b", Target: "payments"},
 			{DatabaseType: "mysql", Deployment: "payments-c", Target: "payments"},
 		}, got)
 	})
 
-	t.Run("implements targetresolver interface", func(t *testing.T) {
-		var resolver targetresolver.Resolver = &cfg
-		got, err := resolver.ResolveTargets(t.Context(), targetresolver.Request{Database: "scalardb", Environment: "production"})
+	t.Run("implements routing interface", func(t *testing.T) {
+		var resolver routing.Resolver = &cfg
+		got, err := resolver.ResolveTargets(t.Context(), routing.Request{Database: "scalardb", Environment: "production"})
 		require.NoError(t, err)
 		require.Len(t, got, 1)
 		assert.Equal(t, "tenant-a", got[0].Deployment)
@@ -1117,7 +1117,7 @@ func TestServerConfig_ResolveDatabaseTargets_DeploymentOrder(t *testing.T) {
 		"payments-b": {Target: "payments"},
 		"payments-c": {Target: "payments"},
 	}
-	resolvedOrder := func(t *testing.T, targets []targetresolver.Target) []string {
+	resolvedOrder := func(t *testing.T, targets []routing.ExecutionTarget) []string {
 		t.Helper()
 		order := make([]string, 0, len(targets))
 		for _, rt := range targets {

--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/block/schemabot/pkg/pendingdrops"
 	"github.com/block/schemabot/pkg/storage"
+	"github.com/block/schemabot/pkg/targetresolver"
 )
 
 func TestLoadServerConfig(t *testing.T) {
@@ -998,24 +999,33 @@ func TestServerConfig_ResolveDatabaseTargets(t *testing.T) {
 		got, err := cfg.ResolveDatabaseTargets("localdb", "staging")
 		require.NoError(t, err)
 		require.Len(t, got, 1)
-		assert.Equal(t, ResolvedDatabaseTarget{DatabaseType: "mysql", Deployment: "localdb", Target: "localdb"}, got[0])
+		assert.Equal(t, targetresolver.Target{DatabaseType: "mysql", Deployment: "localdb", Target: "localdb"}, got[0])
 	})
 
 	t.Run("scalar remote returns single element", func(t *testing.T) {
 		got, err := cfg.ResolveDatabaseTargets("scalardb", "production")
 		require.NoError(t, err)
 		require.Len(t, got, 1)
-		assert.Equal(t, ResolvedDatabaseTarget{DatabaseType: "vitess", Deployment: "tenant-a", Target: "cluster-production-001"}, got[0])
+		assert.Equal(t, targetresolver.Target{DatabaseType: "vitess", Deployment: "tenant-a", Target: "cluster-production-001"}, got[0])
 	})
 
 	t.Run("deployments map returns sorted slice", func(t *testing.T) {
 		got, err := cfg.ResolveDatabaseTargets("multidb", "production")
 		require.NoError(t, err)
-		assert.Equal(t, []ResolvedDatabaseTarget{
+		assert.Equal(t, []targetresolver.Target{
 			{DatabaseType: "mysql", Deployment: "payments-a", Target: "payments"},
 			{DatabaseType: "mysql", Deployment: "payments-b", Target: "payments"},
 			{DatabaseType: "mysql", Deployment: "payments-c", Target: "payments"},
 		}, got)
+	})
+
+	t.Run("implements targetresolver interface", func(t *testing.T) {
+		var resolver targetresolver.Resolver = &cfg
+		got, err := resolver.ResolveTargets(t.Context(), targetresolver.Request{Database: "scalardb", Environment: "production"})
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+		assert.Equal(t, "tenant-a", got[0].Deployment)
+		assert.Equal(t, "cluster-production-001", got[0].Target)
 	})
 
 	t.Run("unknown database errors", func(t *testing.T) {
@@ -1107,7 +1117,7 @@ func TestServerConfig_ResolveDatabaseTargets_DeploymentOrder(t *testing.T) {
 		"payments-b": {Target: "payments"},
 		"payments-c": {Target: "payments"},
 	}
-	resolvedOrder := func(t *testing.T, targets []ResolvedDatabaseTarget) []string {
+	resolvedOrder := func(t *testing.T, targets []targetresolver.Target) []string {
 		t.Helper()
 		order := make([]string, 0, len(targets))
 		for _, rt := range targets {

--- a/pkg/routing/resolver.go
+++ b/pkg/routing/resolver.go
@@ -1,6 +1,6 @@
-// Package targetresolver defines the boundary for turning logical SchemaBot
+// Package routing defines the boundary for turning logical SchemaBot
 // targets into execution targets.
-package targetresolver
+package routing
 
 import "context"
 
@@ -13,10 +13,10 @@ type Request struct {
 	Environment string
 }
 
-// Target is one execution target returned by a Resolver. A single logical
-// request can resolve to multiple targets when an environment fans out across
-// deployments.
-type Target struct {
+// ExecutionTarget is one execution target returned by a Resolver. A single
+// logical request can resolve to multiple targets when an environment fans out
+// across deployments.
+type ExecutionTarget struct {
 	DatabaseType string
 	Deployment   string
 	Target       string
@@ -24,5 +24,5 @@ type Target struct {
 
 // Resolver resolves logical SchemaBot targets to concrete execution targets.
 type Resolver interface {
-	ResolveTargets(ctx context.Context, req Request) ([]Target, error)
+	ResolveTargets(ctx context.Context, req Request) ([]ExecutionTarget, error)
 }

--- a/pkg/routing/resolver.go
+++ b/pkg/routing/resolver.go
@@ -13,9 +13,10 @@ type Request struct {
 	Environment string
 }
 
-// ExecutionTarget is one execution target returned by a Resolver. A single
-// logical request can resolve to multiple targets when an environment fans out
-// across deployments.
+// ExecutionTarget is one physical/data-plane target returned by a Resolver. A
+// single logical request can resolve to multiple targets when an environment
+// fans out across deployments. It is not an operation identity: one execution
+// target can have multiple concurrent operations.
 type ExecutionTarget struct {
 	DatabaseType string
 	Deployment   string

--- a/pkg/targetresolver/resolver.go
+++ b/pkg/targetresolver/resolver.go
@@ -1,0 +1,28 @@
+// Package targetresolver defines the boundary for turning logical SchemaBot
+// targets into execution targets.
+package targetresolver
+
+import "context"
+
+// Request identifies the logical database/environment a caller wants to target.
+// Schema files are intentionally not part of this request: resolving where work
+// runs is separate from deciding how namespace-scoped schema changes compose
+// into operations.
+type Request struct {
+	Database    string
+	Environment string
+}
+
+// Target is one execution target returned by a Resolver. A single logical
+// request can resolve to multiple targets when an environment fans out across
+// deployments.
+type Target struct {
+	DatabaseType string
+	Deployment   string
+	Target       string
+}
+
+// Resolver resolves logical SchemaBot targets to concrete execution targets.
+type Resolver interface {
+	ResolveTargets(ctx context.Context, req Request) ([]Target, error)
+}


### PR DESCRIPTION
## Summary

Adds a small routing package that defines the boundary for turning a logical database/environment request into one or more execution targets. The existing static server configuration now implements that resolver interface while preserving current routing behavior.

This keeps target routing separate from schema-file namespace semantics and leaves room for future resolver implementations without changing plan/apply APIs.

Generated with Amp
