### PR TITLE
feat(config): add optional cutover_policy for multi-deployment environments

### DIFF
--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -450,6 +450,15 @@ type EnvironmentConfig struct {
 	// alphabetical key order. Only meaningful alongside a Deployments map.
 	DeploymentOrder []string `yaml:"deployment_order,omitempty"`
 
+	// CutoverPolicy controls how a multi-deployment rollout sequences the copy
+	// and cutover phases of its deployments. "rolling" (the default, also used
+	// when unset) keeps today's fully serial behaviour: a later deployment does
+	// not start until every earlier sibling in deployment_order has completed.
+	// "barrier" lets later deployments run their copy phase once earlier
+	// siblings reach the cutover barrier, while cutover itself stays ordered.
+	// Only meaningful alongside a Deployments map.
+	CutoverPolicy string `yaml:"cutover_policy,omitempty"`
+
 	// For PlanetScale/Vitess:
 	// Organization is the PlanetScale organization name.
 	// sadscan:disable kingfisher.planetscale.2
@@ -635,6 +644,16 @@ func (c *ServerConfig) Validate() error {
 			hasMapRouting := envConfig.Deployments != nil
 			if len(envConfig.DeploymentOrder) > 0 && !hasMapRouting {
 				return fmt.Errorf("database %q environment %q sets deployment_order without a deployments map", name, env)
+			}
+			if envConfig.CutoverPolicy != "" {
+				if !hasMapRouting {
+					return fmt.Errorf("database %q environment %q sets cutover_policy without a deployments map", name, env)
+				}
+				switch envConfig.CutoverPolicy {
+				case storage.CutoverPolicyRolling, storage.CutoverPolicyBarrier:
+				default:
+					return fmt.Errorf("database %q environment %q has invalid cutover_policy %q (want %q or %q)", name, env, envConfig.CutoverPolicy, storage.CutoverPolicyRolling, storage.CutoverPolicyBarrier)
+				}
 			}
 			switch {
 			case hasDSN && (hasScalarRouting || hasMapRouting):
@@ -885,6 +904,18 @@ func (c *ServerConfig) DatabaseEnvironment(database, environment string) *Enviro
 		return &env
 	}
 	return nil
+}
+
+// CutoverPolicyFor returns the resolved cutover policy for a database+environment.
+// It defaults to CutoverPolicyRolling (today's serial behaviour) when the
+// environment is unconfigured or leaves cutover_policy unset, preserving the
+// conservative rolling rollout as the safe default.
+func (c *ServerConfig) CutoverPolicyFor(database, environment string) string {
+	env := c.DatabaseEnvironment(database, environment)
+	if env == nil || env.CutoverPolicy == "" {
+		return storage.CutoverPolicyRolling
+	}
+	return env.CutoverPolicy
 }
 
 // DatabaseEnvironments returns the environments configured server-side for a

--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -1183,6 +1183,30 @@ func TestValidateDeploymentOrder_EmptyMapKey(t *testing.T) {
 	assert.NotContains(t, err.Error(), `missing deployment ""`)
 }
 
+// TestServerConfig_CutoverPolicyFor verifies the cutover-policy resolver:
+// it defaults to rolling (today's serial rollout) when unset or unconfigured,
+// and honours an explicit barrier policy.
+func TestServerConfig_CutoverPolicyFor(t *testing.T) {
+	cfg := &ServerConfig{
+		Databases: map[string]DatabaseConfig{
+			"payments": {
+				Type: "mysql",
+				Environments: map[string]EnvironmentConfig{
+					"policy-unset":   {Target: "payments", Deployment: "payments-a"},
+					"policy-rolling": {Deployments: map[string]DeploymentTarget{"payments-a": {Target: "payments"}}, CutoverPolicy: storage.CutoverPolicyRolling},
+					"policy-barrier": {Deployments: map[string]DeploymentTarget{"payments-a": {Target: "payments"}}, CutoverPolicy: storage.CutoverPolicyBarrier},
+				},
+			},
+		},
+	}
+
+	assert.Equal(t, storage.CutoverPolicyRolling, cfg.CutoverPolicyFor("payments", "policy-unset"), "unset defaults to rolling")
+	assert.Equal(t, storage.CutoverPolicyRolling, cfg.CutoverPolicyFor("payments", "policy-rolling"), "explicit rolling is rolling")
+	assert.Equal(t, storage.CutoverPolicyBarrier, cfg.CutoverPolicyFor("payments", "policy-barrier"), "explicit barrier is barrier")
+	assert.Equal(t, storage.CutoverPolicyRolling, cfg.CutoverPolicyFor("payments", "missing-env"), "unconfigured env defaults to rolling")
+	assert.Equal(t, storage.CutoverPolicyRolling, cfg.CutoverPolicyFor("missing-db", "policy-barrier"), "unconfigured database defaults to rolling")
+}
+
 func TestServerConfig_DeploymentsMapValidation(t *testing.T) {
 	baseTern := TernConfig{
 		"payments-a": {"production": "tern-a:9090"},
@@ -1308,6 +1332,47 @@ func TestServerConfig_DeploymentsMapValidation(t *testing.T) {
 			},
 			tern:       baseTern,
 			wantErrSub: "sets deployment_order without a deployments map",
+		},
+		{
+			name: "cutover_policy without a deployments map is rejected",
+			envConfig: EnvironmentConfig{
+				Target:        "payments",
+				Deployment:    "payments-a",
+				CutoverPolicy: storage.CutoverPolicyBarrier,
+			},
+			tern:       baseTern,
+			wantErrSub: "sets cutover_policy without a deployments map",
+		},
+		{
+			name: "invalid cutover_policy value is rejected",
+			envConfig: EnvironmentConfig{
+				Deployments: map[string]DeploymentTarget{
+					"payments-a": {Target: "payments"},
+				},
+				CutoverPolicy: "warp-speed",
+			},
+			tern:       baseTern,
+			wantErrSub: `invalid cutover_policy "warp-speed"`,
+		},
+		{
+			name: "cutover_policy rolling with a deployments map is accepted",
+			envConfig: EnvironmentConfig{
+				Deployments: map[string]DeploymentTarget{
+					"payments-a": {Target: "payments"},
+				},
+				CutoverPolicy: storage.CutoverPolicyRolling,
+			},
+			tern: baseTern,
+		},
+		{
+			name: "cutover_policy barrier with a deployments map is accepted",
+			envConfig: EnvironmentConfig{
+				Deployments: map[string]DeploymentTarget{
+					"payments-a": {Target: "payments"},
+				},
+				CutoverPolicy: storage.CutoverPolicyBarrier,
+			},
+			tern: baseTern,
 		},
 	}
 

--- a/pkg/api/plan_handlers.go
+++ b/pkg/api/plan_handlers.go
@@ -668,12 +668,14 @@ func (s *Service) createStoredApply(
 	// always write exactly one operation row that mirrors the apply's own
 	// routing. The data shape is what the operator claim-loop PR consumes
 	// once that gate is lifted and plans become deployment-agnostic.
+	cutoverPolicy := s.config.CutoverPolicyFor(plan.Database, req.Environment)
 	operations := []*storage.ApplyOperation{{
-		Deployment: apply.Deployment,
-		Target:     plan.Target,
-		State:      state.ApplyOperation.Pending,
-		CreatedAt:  now,
-		UpdatedAt:  now,
+		Deployment:    apply.Deployment,
+		Target:        plan.Target,
+		State:         state.ApplyOperation.Pending,
+		CutoverPolicy: cutoverPolicy,
+		CreatedAt:     now,
+		UpdatedAt:     now,
 	}}
 
 	storedApplyID, err := s.storage.Applies().CreateWithTasksAndOperations(ctx, apply, tasks, operations)

--- a/pkg/schema/mysql/apply_operations.sql
+++ b/pkg/schema/mysql/apply_operations.sql
@@ -7,6 +7,7 @@ CREATE TABLE `apply_operations` (
   `engine_resume_metadata` json DEFAULT NULL,
   `state` varchar(100) NOT NULL DEFAULT 'pending',
   `error_message` text,
+  `cutover_policy` varchar(16) NOT NULL DEFAULT 'rolling',
   `lease_owner` varchar(255) NOT NULL DEFAULT '',
   `lease_token` varchar(64) NOT NULL DEFAULT '',
   `lease_acquired_at` datetime DEFAULT NULL,

--- a/pkg/storage/mysqlstore/apply_operations.go
+++ b/pkg/storage/mysqlstore/apply_operations.go
@@ -87,6 +87,7 @@ func insertApplyOperation(ctx context.Context, exec sqlExecer, ad *storage.Apply
 	}
 	ad.ID = id
 	ad.State = stateVal
+	ad.CutoverPolicy = cutoverPolicy
 	return id, nil
 }
 

--- a/pkg/storage/mysqlstore/apply_operations.go
+++ b/pkg/storage/mysqlstore/apply_operations.go
@@ -20,7 +20,7 @@ import (
 
 // applyOperationColumns lists all columns for SELECT queries.
 const applyOperationColumns = `id, apply_id, deployment, target, state, error_message,
-	started_at, completed_at, lease_owner, lease_token, lease_acquired_at,
+	cutover_policy, started_at, completed_at, lease_owner, lease_token, lease_acquired_at,
 	engine_resume_context, engine_resume_metadata, created_at, updated_at`
 
 // mysqlErrDupEntry is MySQL's error number for a duplicate-key violation.
@@ -56,13 +56,21 @@ func insertApplyOperation(ctx context.Context, exec sqlExecer, ad *storage.Apply
 		stateVal = state.ApplyOperation.Pending
 	}
 
+	// An empty policy means the caller did not resolve a cutover_policy, so fall
+	// back to rolling — the serial default that matches the column's NOT NULL
+	// DEFAULT 'rolling'.
+	cutoverPolicy := ad.CutoverPolicy
+	if cutoverPolicy == "" {
+		cutoverPolicy = storage.CutoverPolicyRolling
+	}
+
 	result, err := exec.ExecContext(ctx, `
 		INSERT INTO apply_operations (
-			apply_id, deployment, target, state, error_message,
+			apply_id, deployment, target, state, error_message, cutover_policy,
 			started_at, completed_at, engine_resume_context, engine_resume_metadata
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`,
-		ad.ApplyID, ad.Deployment, ad.Target, stateVal, nullString(ad.ErrorMessage),
+		ad.ApplyID, ad.Deployment, ad.Target, stateVal, nullString(ad.ErrorMessage), cutoverPolicy,
 		ad.StartedAt, ad.CompletedAt, nullString(ad.EngineResumeContext), nullString(ad.EngineResumeMetadata),
 	)
 	if err != nil {
@@ -795,7 +803,7 @@ func scanApplyOperationInto(s scanner) (*storage.ApplyOperation, error) {
 
 	if err := s.Scan(
 		&ad.ID, &ad.ApplyID, &ad.Deployment, &ad.Target, &ad.State, &errMsg,
-		&startedAt, &completedAt, &ad.LeaseOwner, &ad.LeaseToken, &leaseAcquiredAt,
+		&ad.CutoverPolicy, &startedAt, &completedAt, &ad.LeaseOwner, &ad.LeaseToken, &leaseAcquiredAt,
 		&engineResumeContext, &engineResumeMetadata, &ad.CreatedAt, &ad.UpdatedAt,
 	); err != nil {
 		return nil, err

--- a/pkg/storage/mysqlstore/apply_operations_test.go
+++ b/pkg/storage/mysqlstore/apply_operations_test.go
@@ -74,12 +74,14 @@ func TestApplyOperationStore_CutoverPolicyRoundTrip(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	defaultedID, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+	defaultedOp := &storage.ApplyOperation{
 		ApplyID:    apply.ID,
 		Deployment: "region-b",
 		Target:     "payments",
-	})
+	}
+	defaultedID, err := store.ApplyOperations().Insert(ctx, defaultedOp)
 	require.NoError(t, err)
+	assert.Equal(t, storage.CutoverPolicyRolling, defaultedOp.CutoverPolicy, "Insert normalizes an empty policy to rolling on the passed struct")
 
 	barrier, err := store.ApplyOperations().Get(ctx, barrierID)
 	require.NoError(t, err)

--- a/pkg/storage/mysqlstore/apply_operations_test.go
+++ b/pkg/storage/mysqlstore/apply_operations_test.go
@@ -44,6 +44,7 @@ func TestApplyOperationStore_InsertAndGet(t *testing.T) {
 	assert.Equal(t, "region-a", got.Deployment)
 	assert.Equal(t, "payments", got.Target)
 	assert.Equal(t, state.ApplyOperation.Pending, got.State)
+	assert.Equal(t, storage.CutoverPolicyRolling, got.CutoverPolicy, "an unset cutover_policy defaults to rolling")
 	assert.Empty(t, got.ErrorMessage)
 	assert.Nil(t, got.StartedAt)
 	assert.Nil(t, got.CompletedAt)
@@ -51,6 +52,44 @@ func TestApplyOperationStore_InsertAndGet(t *testing.T) {
 	assert.Empty(t, got.EngineResumeMetadata)
 	assert.NotZero(t, got.CreatedAt)
 	assert.NotZero(t, got.UpdatedAt)
+}
+
+// TestApplyOperationStore_CutoverPolicyRoundTrip verifies that an explicit
+// cutover_policy is persisted and read back unchanged, and that an empty policy
+// falls back to rolling on insert — matching the column's NOT NULL default so a
+// caller that omits the policy never silently degrades the rollout.
+func TestApplyOperationStore_CutoverPolicyRoundTrip(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", "mysql", "staging")
+	apply := createTestApply(t, store, lock, "apply_op_cutover_policy", 1)
+
+	barrierID, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID:       apply.ID,
+		Deployment:    "region-a",
+		Target:        "payments",
+		CutoverPolicy: storage.CutoverPolicyBarrier,
+	})
+	require.NoError(t, err)
+
+	defaultedID, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID:    apply.ID,
+		Deployment: "region-b",
+		Target:     "payments",
+	})
+	require.NoError(t, err)
+
+	barrier, err := store.ApplyOperations().Get(ctx, barrierID)
+	require.NoError(t, err)
+	require.NotNil(t, barrier)
+	assert.Equal(t, storage.CutoverPolicyBarrier, barrier.CutoverPolicy, "an explicit barrier policy round-trips unchanged")
+
+	defaulted, err := store.ApplyOperations().Get(ctx, defaultedID)
+	require.NoError(t, err)
+	require.NotNil(t, defaulted)
+	assert.Equal(t, storage.CutoverPolicyRolling, defaulted.CutoverPolicy, "an omitted policy is stored as rolling")
 }
 
 func TestApplyOperationStore_Get_NotFound(t *testing.T) {

--- a/pkg/storage/types.go
+++ b/pkg/storage/types.go
@@ -10,6 +10,21 @@ import (
 	"github.com/block/schemabot/pkg/schema"
 )
 
+// Cutover policies control how a multi-deployment rollout sequences the copy
+// and cutover phases of its deployments. The value is resolved from the
+// environment config at apply-create time and persisted on each apply_operations
+// row so the policy in force when the apply was created travels with it.
+const (
+	// CutoverPolicyRolling is the default: a later deployment does not start
+	// until every earlier sibling in deployment_order has completed, keeping the
+	// rollout fully serial.
+	CutoverPolicyRolling = "rolling"
+
+	// CutoverPolicyBarrier lets later deployments run their copy phase once
+	// earlier siblings reach the cutover barrier, while cutover stays ordered.
+	CutoverPolicyBarrier = "barrier"
+)
+
 // Lock represents a database-level deployment lock.
 // Locks prevent concurrent schema changes to the same database across
 // all environments and PRs. Lock key is database:type (no environment).
@@ -440,6 +455,16 @@ type ApplyOperation struct {
 
 	// ErrorMessage contains error details if state is failed.
 	ErrorMessage string
+
+	// CutoverPolicy is the rollout sequencing policy captured for this
+	// operation's parent apply at apply-create time, drawn from the resolved
+	// environment config. "rolling" (the default) keeps the fully serial
+	// rollout — a later deployment waits for every earlier sibling to complete.
+	// "barrier" allows later deployments to run their copy phase once earlier
+	// siblings reach the cutover barrier. Persisted on each row so the policy in
+	// force when the apply was created travels with the operation. Insert treats
+	// an empty value as "rolling", matching the column's NOT NULL DEFAULT.
+	CutoverPolicy string
 
 	// StartedAt is when the operator claimed this child row and execution began.
 	StartedAt *time.Time


### PR DESCRIPTION
## What and Why ?

Adds an optional `cutover_policy` to multi-deployment environment config. It is
resolved per `(database, environment)` and persisted on each `apply_operations`
row at apply-create, so the policy in force when an apply was created travels
with the operation. This slice is **config-only, additive, and dormant** — the
claim and cutover predicates are unchanged.

- `rolling` (default, also used when unset): today's fully serial rollout — a
  later deployment does not start until every earlier sibling in
  `deployment_order` has completed.
- `barrier`: reserved for the follow-up predicate — later deployments may run
  their copy phase once earlier siblings reach the cutover barrier, while
  cutover stays ordered.

`FindNextApplyOperation` is one global SQL claim with no per-call config, so the
policy is captured on the row rather than read at claim time:

apply-create ──▶ resolve cutover_policy(database, environment)
(rolling default) ──▶ stamp each apply_operations row
(cutover_policy NOT NULL DEFAULT 'rolling')

## Changes

- `EnvironmentConfig.CutoverPolicy` (`yaml: cutover_policy`), valid only
  alongside a `deployments` map; rejected for values outside `{rolling, barrier}`.
- `ServerConfig.CutoverPolicyFor(database, environment)` resolver, defaulting to
  `rolling`.
- `apply_operations.cutover_policy varchar(16) NOT NULL DEFAULT 'rolling'`
  column; dual-written at apply-create; insert defaults empty to `rolling`.
- Shared `storage.CutoverPolicyRolling` / `storage.CutoverPolicyBarrier`
  constants as the single source of truth for the resolver, validation, and the
  insert fallback.

## Stage sequence

| # | Slice | Purpose | Builds on | Behaviour |
|---|---|---|---|---|
| **A** (this PR) | `feat(config): add optional cutover_policy for multi-deployment environments` | Add `cutover_policy` (`rolling`/`barrier`, default `rolling`), validate it, persist resolved value on each `apply_operations` row at apply-create. | leaf off `main` | none — dormant |
| B (follow-up) | `feat(operator): phase-aware cutover_policy claim predicate` | Under `barrier`, later deployments can start copy once earlier siblings reach the cutover barrier; cutover stays ordered on `completed`. `rolling` keeps today's serial behaviour. | A | dormant while flag off + hard-block |

