### PR TITLE
feat(api): add live schema pull primitive

### DIFF
--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -429,6 +429,9 @@ type mockTernClient struct {
 	planResp          *ternv1.PlanResponse
 	planErr           error
 	planReq           *ternv1.PlanRequest
+	pullSchemaResp    *ternv1.PullSchemaResponse
+	pullSchemaErr     error
+	pullSchemaReq     *ternv1.PullSchemaRequest
 	applyResp         *ternv1.ApplyResponse
 	applyErr          error
 	applyReq          *ternv1.ApplyRequest
@@ -463,6 +466,13 @@ type mockTernClient struct {
 }
 
 func (m *mockTernClient) Health(ctx context.Context) error { return m.healthErr }
+func (m *mockTernClient) PullSchema(ctx context.Context, req *ternv1.PullSchemaRequest) (*ternv1.PullSchemaResponse, error) {
+	m.pullSchemaReq = req
+	if m.pullSchemaResp != nil {
+		return m.pullSchemaResp, m.pullSchemaErr
+	}
+	return nil, m.pullSchemaErr
+}
 func (m *mockTernClient) Plan(ctx context.Context, req *ternv1.PlanRequest) (*ternv1.PlanResponse, error) {
 	m.planReq = req
 	if m.planResp != nil {
@@ -812,6 +822,155 @@ func TestExecutePlanUnavailableRemoteErrorIncludesDeployment(t *testing.T) {
 	assert.Equal(t, "pie", remoteErr.Deployment)
 	assert.Equal(t, "orders-staging", remoteErr.Target)
 	assert.Equal(t, codes.Unavailable, status.Code(err))
+}
+
+func TestExecutePullSchemaRoutesConfiguredMySQLTarget(t *testing.T) {
+	mockClient := &mockTernClient{
+		pullSchemaResp: &ternv1.PullSchemaResponse{
+			Database:    "orders",
+			Type:        storage.DatabaseTypeMySQL,
+			Environment: "production",
+			SchemaFiles: map[string]*ternv1.SchemaFiles{
+				"orders": {Files: map[string]string{"users.sql": "CREATE TABLE `users` (`id` bigint NOT NULL);\n"}},
+			},
+			TableCount: 1,
+		},
+	}
+	cfg := &ServerConfig{
+		Databases: map[string]DatabaseConfig{
+			"orders": {
+				Type: storage.DatabaseTypeMySQL,
+				Environments: map[string]EnvironmentConfig{
+					"production": {Target: "orders-production", Deployment: "primary"},
+				},
+			},
+		},
+		TernDeployments: TernConfig{
+			"primary": {"production": "tern.example.com:80"},
+		},
+	}
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	svc := New(&mockStorage{}, cfg, map[string]tern.Client{
+		"primary/production": mockClient,
+	}, logger)
+
+	resp, err := svc.ExecutePullSchema(t.Context(), apitypes.PullSchemaRequest{
+		Database:    "orders",
+		Environment: "production",
+		Type:        storage.DatabaseTypeMySQL,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, "orders", resp.Database)
+	assert.Equal(t, storage.DatabaseTypeMySQL, resp.Type)
+	assert.Equal(t, int32(1), resp.TableCount)
+	require.NotNil(t, mockClient.pullSchemaReq)
+	assert.Equal(t, "orders-production", mockClient.pullSchemaReq.Target)
+	assert.Equal(t, "production", mockClient.pullSchemaReq.Environment)
+	assert.Equal(t, storage.DatabaseTypeMySQL, mockClient.pullSchemaReq.Type)
+	assert.Equal(t, "CREATE TABLE `users` (`id` bigint NOT NULL);\n", resp.SchemaFiles["orders"].Files["users.sql"])
+}
+
+func TestExecutePullSchemaRejectsUnsupportedType(t *testing.T) {
+	cfg := &ServerConfig{
+		Databases: map[string]DatabaseConfig{
+			"orders": {
+				Type: storage.DatabaseTypeVitess,
+				Environments: map[string]EnvironmentConfig{
+					"production": {Target: "orders-production", Deployment: "primary"},
+				},
+			},
+		},
+		TernDeployments: TernConfig{
+			"primary": {"production": "tern.example.com:80"},
+		},
+	}
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	svc := New(&mockStorage{}, cfg, map[string]tern.Client{
+		"primary/production": &mockTernClient{},
+	}, logger)
+
+	_, err := svc.ExecutePullSchema(t.Context(), apitypes.PullSchemaRequest{
+		Database:    "orders",
+		Environment: "production",
+		Type:        storage.DatabaseTypeVitess,
+	})
+
+	var unsupportedErr *unsupportedPullSchemaError
+	require.ErrorAs(t, err, &unsupportedErr)
+	assert.Equal(t, storage.DatabaseTypeVitess, unsupportedErr.DatabaseType)
+}
+
+func TestExecutePullSchemaRejectsMultiDeploymentEnvironment(t *testing.T) {
+	cfg := &ServerConfig{
+		Databases: map[string]DatabaseConfig{
+			"orders": {
+				Type: storage.DatabaseTypeMySQL,
+				Environments: map[string]EnvironmentConfig{
+					"production": {
+						Deployments: map[string]DeploymentTarget{
+							"primary":   {Target: "orders-primary"},
+							"secondary": {Target: "orders-secondary"},
+						},
+					},
+				},
+			},
+		},
+		TernDeployments: TernConfig{
+			"primary":   {"production": "primary.example.com:80"},
+			"secondary": {"production": "secondary.example.com:80"},
+		},
+	}
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	svc := New(&mockStorage{}, cfg, map[string]tern.Client{}, logger)
+
+	_, err := svc.ExecutePullSchema(t.Context(), apitypes.PullSchemaRequest{
+		Database:    "orders",
+		Environment: "production",
+		Type:        storage.DatabaseTypeMySQL,
+	})
+
+	var ambiguousErr *ambiguousPullSchemaTargetError
+	require.ErrorAs(t, err, &ambiguousErr)
+	assert.Equal(t, "orders", ambiguousErr.Database)
+	assert.Equal(t, "production", ambiguousErr.Environment)
+	assert.Equal(t, 2, ambiguousErr.Count)
+}
+
+func TestPullSchemaHandlerRejectsMultiDeploymentEnvironment(t *testing.T) {
+	cfg := &ServerConfig{
+		Databases: map[string]DatabaseConfig{
+			"orders": {
+				Type: storage.DatabaseTypeMySQL,
+				Environments: map[string]EnvironmentConfig{
+					"production": {
+						Deployments: map[string]DeploymentTarget{
+							"primary":   {Target: "orders-primary"},
+							"secondary": {Target: "orders-secondary"},
+						},
+					},
+				},
+			},
+		},
+		TernDeployments: TernConfig{
+			"primary":   {"production": "primary.example.com:80"},
+			"secondary": {"production": "secondary.example.com:80"},
+		},
+	}
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	svc := New(&mockStorage{}, cfg, map[string]tern.Client{}, logger)
+	mux := http.NewServeMux()
+	svc.ConfigureRoutes(mux)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/pull", strings.NewReader(`{"database":"orders","environment":"production","type":"mysql"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	mux.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
+	assert.Contains(t, w.Body.String(), "resolves to 2 deployments")
 }
 
 func TestExecuteApplySourcePolicyAllowsDirectPlan(t *testing.T) {

--- a/pkg/api/plan_handlers.go
+++ b/pkg/api/plan_handlers.go
@@ -46,6 +46,24 @@ type PlanRequest struct {
 	SourceTrusted bool `json:"-"`
 }
 
+type unsupportedPullSchemaError struct {
+	DatabaseType string
+}
+
+func (e *unsupportedPullSchemaError) Error() string {
+	return fmt.Sprintf("pull schema supports %s databases; got %s", storage.DatabaseTypeMySQL, e.DatabaseType)
+}
+
+type ambiguousPullSchemaTargetError struct {
+	Database    string
+	Environment string
+	Count       int
+}
+
+func (e *ambiguousPullSchemaTargetError) Error() string {
+	return fmt.Sprintf("pull schema for database %q environment %q resolves to %d deployments; pull schema currently requires an environment with exactly one deployment", e.Database, e.Environment, e.Count)
+}
+
 // RemoteDeploymentUnavailableError carries routing metadata for remote
 // schema change service availability failures so callers can render actionable
 // operator-facing errors without parsing strings.
@@ -64,6 +82,160 @@ func (e *RemoteDeploymentUnavailableError) Error() string {
 
 func (e *RemoteDeploymentUnavailableError) Unwrap() error {
 	return e.Err
+}
+
+// handlePullSchema handles POST /api/pull requests.
+func (s *Service) handlePullSchema(w http.ResponseWriter, r *http.Request) {
+	var req apitypes.PullSchemaRequest
+	decoder := json.NewDecoder(r.Body)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&req); err != nil {
+		s.writeError(w, http.StatusBadRequest, "invalid request body: "+err.Error())
+		return
+	}
+
+	if req.Database == "" {
+		s.writeError(w, http.StatusBadRequest, "database is required")
+		return
+	}
+	if req.Environment == "" {
+		s.writeError(w, http.StatusBadRequest, "environment is required")
+		return
+	}
+	if req.Type != "" {
+		switch req.Type {
+		case storage.DatabaseTypeMySQL, storage.DatabaseTypeVitess, storage.DatabaseTypeStrata:
+		default:
+			s.writeError(w, http.StatusBadRequest, "type must be "+storage.DatabaseTypeMySQL+", "+storage.DatabaseTypeVitess+", or "+storage.DatabaseTypeStrata)
+			return
+		}
+	}
+
+	resp, err := s.ExecutePullSchema(r.Context(), req)
+	if err != nil {
+		var unsupportedErr *unsupportedPullSchemaError
+		if errors.As(err, &unsupportedErr) {
+			s.logger.Warn("pull schema rejected for unsupported database type", "database", req.Database, "environment", req.Environment, "type", unsupportedErr.DatabaseType)
+			s.writeError(w, http.StatusNotImplemented, err.Error())
+			return
+		}
+		var ambiguousErr *ambiguousPullSchemaTargetError
+		if errors.As(err, &ambiguousErr) {
+			s.logger.Warn("pull schema rejected for multi-deployment environment", "database", ambiguousErr.Database, "environment", ambiguousErr.Environment, "deployment_count", ambiguousErr.Count)
+			s.writeError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		var unavailableErr *RemoteDeploymentUnavailableError
+		if errors.As(err, &unavailableErr) {
+			s.logger.Error("pull schema failed because remote deployment is unavailable",
+				"database", req.Database,
+				"environment", req.Environment,
+				"deployment", unavailableErr.Deployment,
+				"target", unavailableErr.Target,
+				"error", err)
+			s.writeErrorCode(w, http.StatusServiceUnavailable, apitypes.ErrCodeEngineUnavailable, "pull schema failed: "+err.Error())
+			return
+		}
+		s.logger.Error("pull schema failed", "database", req.Database, "environment", req.Environment, "error", err)
+		s.writeError(w, http.StatusInternalServerError, "pull schema failed: "+err.Error())
+		return
+	}
+
+	s.writeJSON(w, http.StatusOK, resp)
+}
+
+// ExecutePullSchema resolves a configured database route and fetches its live schema.
+func (s *Service) ExecutePullSchema(ctx context.Context, req apitypes.PullSchemaRequest) (*apitypes.PullSchemaResponse, error) {
+	ctx, span := otel.Tracer("schemabot").Start(ctx, "ExecutePullSchema",
+		trace.WithAttributes(
+			attribute.String("database", req.Database),
+			attribute.String("environment", req.Environment),
+			attribute.String("type", req.Type),
+		),
+	)
+	defer span.End()
+
+	resolvedTargets, err := s.config.ResolveDatabaseTargets(req.Database, req.Environment)
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(otelcodes.Error, "resolve target")
+		return nil, fmt.Errorf("resolve target for %s/%s: %w", req.Database, req.Environment, err)
+	}
+	if len(resolvedTargets) != 1 {
+		ambiguousErr := &ambiguousPullSchemaTargetError{Database: req.Database, Environment: req.Environment, Count: len(resolvedTargets)}
+		span.RecordError(ambiguousErr)
+		span.SetStatus(otelcodes.Error, "ambiguous target")
+		return nil, ambiguousErr
+	}
+	resolvedTarget := resolvedTargets[0]
+	if req.Type != "" && req.Type != resolvedTarget.DatabaseType {
+		typeErr := fmt.Errorf("database %q type %q does not match server config type %q", req.Database, req.Type, resolvedTarget.DatabaseType)
+		span.RecordError(typeErr)
+		span.SetStatus(otelcodes.Error, "type mismatch")
+		return nil, typeErr
+	}
+	if resolvedTarget.DatabaseType != storage.DatabaseTypeMySQL {
+		unsupportedErr := &unsupportedPullSchemaError{DatabaseType: resolvedTarget.DatabaseType}
+		span.RecordError(unsupportedErr)
+		span.SetStatus(otelcodes.Error, "unsupported database type")
+		return nil, unsupportedErr
+	}
+
+	client, err := s.TernClient(resolvedTarget.Deployment, req.Environment)
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(otelcodes.Error, "tern client")
+		return nil, fmt.Errorf("database %q (%s): %w", req.Database, req.Environment, err)
+	}
+
+	s.logger.Info("ExecutePullSchema: calling client.PullSchema",
+		"database", req.Database,
+		"type", resolvedTarget.DatabaseType,
+		"deployment", resolvedTarget.Deployment,
+		"target", resolvedTarget.Target,
+		"environment", req.Environment,
+		"is_remote", client.IsRemote(),
+	)
+
+	resp, err := client.PullSchema(ctx, &ternv1.PullSchemaRequest{
+		Database:    req.Database,
+		Type:        resolvedTarget.DatabaseType,
+		Environment: req.Environment,
+		Target:      resolvedTarget.Target,
+	})
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(otelcodes.Error, "pull schema failed")
+		s.logger.Error("ExecutePullSchema: client.PullSchema failed",
+			"database", req.Database,
+			"type", resolvedTarget.DatabaseType,
+			"deployment", resolvedTarget.Deployment,
+			"target", resolvedTarget.Target,
+			"environment", req.Environment,
+			"endpoint", client.Endpoint(),
+			"is_remote", client.IsRemote(),
+			"error", err,
+		)
+		if client.IsRemote() && grpcstatus.Code(err) == grpccodes.Unavailable {
+			return nil, &RemoteDeploymentUnavailableError{
+				Deployment: resolvedTarget.Deployment,
+				Target:     resolvedTarget.Target,
+				Err:        err,
+			}
+		}
+		return nil, err
+	}
+
+	span.SetAttributes(attribute.Int("table_count", int(resp.TableCount)))
+	s.logger.Info("ExecutePullSchema: pull schema response",
+		"database", resp.Database,
+		"type", resp.Type,
+		"environment", resp.Environment,
+		"table_count", resp.TableCount,
+		"namespace_count", len(resp.SchemaFiles),
+	)
+
+	return pullSchemaResponseFromProto(resp), nil
 }
 
 // ApplyRequest is the HTTP request body for POST /api/apply.

--- a/pkg/api/proto_helpers.go
+++ b/pkg/api/proto_helpers.go
@@ -13,6 +13,30 @@ import (
 	"github.com/block/schemabot/pkg/storage"
 )
 
+func pullSchemaResponseFromProto(resp *ternv1.PullSchemaResponse) *apitypes.PullSchemaResponse {
+	return &apitypes.PullSchemaResponse{
+		Database:    resp.Database,
+		Type:        resp.Type,
+		Environment: resp.Environment,
+		SchemaFiles: protoSchemaFilesToAPI(resp.SchemaFiles),
+		TableCount:  resp.TableCount,
+	}
+}
+
+func protoSchemaFilesToAPI(sf map[string]*ternv1.SchemaFiles) map[string]*apitypes.SchemaFiles {
+	result := make(map[string]*apitypes.SchemaFiles, len(sf))
+	for namespace, nsFiles := range sf {
+		if nsFiles == nil {
+			result[namespace] = &apitypes.SchemaFiles{Files: map[string]string{}}
+			continue
+		}
+		files := make(map[string]string, len(nsFiles.Files))
+		maps.Copy(files, nsFiles.Files)
+		result[namespace] = &apitypes.SchemaFiles{Files: files}
+	}
+	return result
+}
+
 // planResponseFromProto converts a protobuf PlanResponse to an HTTP PlanResponse.
 func planResponseFromProto(resp *ternv1.PlanResponse) *apitypes.PlanResponse {
 	httpResp := &apitypes.PlanResponse{

--- a/pkg/api/proto_helpers_test.go
+++ b/pkg/api/proto_helpers_test.go
@@ -5,7 +5,19 @@ import (
 
 	ternv1 "github.com/block/schemabot/pkg/proto/ternv1"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestProtoSchemaFilesToAPIIgnoresNilNamespaces(t *testing.T) {
+	result := protoSchemaFilesToAPI(map[string]*ternv1.SchemaFiles{
+		"orders": nil,
+		"users":  {Files: map[string]string{"users.sql": "CREATE TABLE `users` (`id` bigint);\n"}},
+	})
+
+	require.Contains(t, result, "orders")
+	assert.Empty(t, result["orders"].Files)
+	assert.Equal(t, "CREATE TABLE `users` (`id` bigint);\n", result["users"].Files["users.sql"])
+}
 
 func TestChangeTypeRoundTrip(t *testing.T) {
 	// Proto → storage → proto should round-trip correctly

--- a/pkg/api/service.go
+++ b/pkg/api/service.go
@@ -486,6 +486,7 @@ func (s *Service) ConfigureRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/databases/{database}/environments", s.handleDatabaseEnvironments)
 
 	// Orchestration API
+	mux.HandleFunc("POST /api/pull", s.handlePullSchema)
 	mux.HandleFunc("POST /api/plan", s.handlePlan)
 	mux.HandleFunc("POST /api/apply", s.handleApply)
 	mux.HandleFunc("GET /api/progress/apply/{apply_id}", s.handleProgressByApplyID)

--- a/pkg/apitypes/apitypes.go
+++ b/pkg/apitypes/apitypes.go
@@ -54,6 +54,22 @@ type SchemaFiles struct {
 	Files map[string]string `json:"files,omitempty"`
 }
 
+// PullSchemaRequest is the HTTP request body for POST /api/pull.
+type PullSchemaRequest struct {
+	Database    string `json:"database"`
+	Environment string `json:"environment"`
+	Type        string `json:"type"`
+}
+
+// PullSchemaResponse is the HTTP response body for POST /api/pull.
+type PullSchemaResponse struct {
+	Database    string                  `json:"database"`
+	Type        string                  `json:"type"`
+	Environment string                  `json:"environment"`
+	SchemaFiles map[string]*SchemaFiles `json:"schema_files"`
+	TableCount  int32                   `json:"table_count"`
+}
+
 // PlanRequest is the HTTP request body for POST /api/plan.
 type PlanRequest struct {
 	Database    string                  `json:"database"`

--- a/pkg/proto/tern.proto
+++ b/pkg/proto/tern.proto
@@ -26,6 +26,15 @@ option go_package = "github.com/block/schemabot/pkg/proto/ternv1";
 //
 // Only one active schema change per database at a time (enforced by Apply).
 service Tern {
+  // PullSchema fetches the live schema for a database route and returns it as
+  // declarative schema files. It does not modify the database.
+  rpc PullSchema(PullSchemaRequest) returns (PullSchemaResponse) {
+    option (google.api.http) = {
+      post: "/v1/pull-schema"
+      body: "*"
+    };
+  }
+
   // Plan generates a schema change plan by diffing declarative schema files
   // against the live database schema. Returns DDL statements needed to converge.
   //
@@ -234,6 +243,27 @@ enum ChangeType {
 message SchemaFiles {
   // Filename → content mapping (e.g., "users.sql" → CREATE TABLE, "vschema.json" → VSchema JSON).
   map<string, string> files = 1;
+}
+
+// PullSchemaRequest requests a live schema export for a database route.
+message PullSchemaRequest {
+  // Database name from server-side config.
+  string database = 1;
+  // Database type: "vitess" or "mysql".
+  string type = 2;
+  // Environment: "staging" or "production".
+  string environment = 3;
+  // Opaque identifier for endpoint discovery. Defaults to database if empty.
+  string target = 4;
+}
+
+// PullSchemaResponse contains live schema files grouped by namespace.
+message PullSchemaResponse {
+  string database = 1;
+  string type = 2;
+  string environment = 3;
+  map<string, SchemaFiles> schema_files = 4;
+  int32 table_count = 5;
 }
 
 // PlanRequest requests a schema change plan from declarative schema files.

--- a/pkg/proto/ternv1/tern.pb.go
+++ b/pkg/proto/ternv1/tern.pb.go
@@ -269,6 +269,156 @@ func (x *SchemaFiles) GetFiles() map[string]string {
 	return nil
 }
 
+// PullSchemaRequest requests a live schema export for a database route.
+type PullSchemaRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Database name from server-side config.
+	Database string `protobuf:"bytes,1,opt,name=database,proto3" json:"database,omitempty"`
+	// Database type: "vitess" or "mysql".
+	Type string `protobuf:"bytes,2,opt,name=type,proto3" json:"type,omitempty"`
+	// Environment: "staging" or "production".
+	Environment string `protobuf:"bytes,3,opt,name=environment,proto3" json:"environment,omitempty"`
+	// Opaque identifier for endpoint discovery. Defaults to database if empty.
+	Target        string `protobuf:"bytes,4,opt,name=target,proto3" json:"target,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PullSchemaRequest) Reset() {
+	*x = PullSchemaRequest{}
+	mi := &file_tern_proto_msgTypes[1]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PullSchemaRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PullSchemaRequest) ProtoMessage() {}
+
+func (x *PullSchemaRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_tern_proto_msgTypes[1]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PullSchemaRequest.ProtoReflect.Descriptor instead.
+func (*PullSchemaRequest) Descriptor() ([]byte, []int) {
+	return file_tern_proto_rawDescGZIP(), []int{1}
+}
+
+func (x *PullSchemaRequest) GetDatabase() string {
+	if x != nil {
+		return x.Database
+	}
+	return ""
+}
+
+func (x *PullSchemaRequest) GetType() string {
+	if x != nil {
+		return x.Type
+	}
+	return ""
+}
+
+func (x *PullSchemaRequest) GetEnvironment() string {
+	if x != nil {
+		return x.Environment
+	}
+	return ""
+}
+
+func (x *PullSchemaRequest) GetTarget() string {
+	if x != nil {
+		return x.Target
+	}
+	return ""
+}
+
+// PullSchemaResponse contains live schema files grouped by namespace.
+type PullSchemaResponse struct {
+	state         protoimpl.MessageState  `protogen:"open.v1"`
+	Database      string                  `protobuf:"bytes,1,opt,name=database,proto3" json:"database,omitempty"`
+	Type          string                  `protobuf:"bytes,2,opt,name=type,proto3" json:"type,omitempty"`
+	Environment   string                  `protobuf:"bytes,3,opt,name=environment,proto3" json:"environment,omitempty"`
+	SchemaFiles   map[string]*SchemaFiles `protobuf:"bytes,4,rep,name=schema_files,json=schemaFiles,proto3" json:"schema_files,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	TableCount    int32                   `protobuf:"varint,5,opt,name=table_count,json=tableCount,proto3" json:"table_count,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PullSchemaResponse) Reset() {
+	*x = PullSchemaResponse{}
+	mi := &file_tern_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PullSchemaResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PullSchemaResponse) ProtoMessage() {}
+
+func (x *PullSchemaResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_tern_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PullSchemaResponse.ProtoReflect.Descriptor instead.
+func (*PullSchemaResponse) Descriptor() ([]byte, []int) {
+	return file_tern_proto_rawDescGZIP(), []int{2}
+}
+
+func (x *PullSchemaResponse) GetDatabase() string {
+	if x != nil {
+		return x.Database
+	}
+	return ""
+}
+
+func (x *PullSchemaResponse) GetType() string {
+	if x != nil {
+		return x.Type
+	}
+	return ""
+}
+
+func (x *PullSchemaResponse) GetEnvironment() string {
+	if x != nil {
+		return x.Environment
+	}
+	return ""
+}
+
+func (x *PullSchemaResponse) GetSchemaFiles() map[string]*SchemaFiles {
+	if x != nil {
+		return x.SchemaFiles
+	}
+	return nil
+}
+
+func (x *PullSchemaResponse) GetTableCount() int32 {
+	if x != nil {
+		return x.TableCount
+	}
+	return 0
+}
+
 // PlanRequest requests a schema change plan from declarative schema files.
 type PlanRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -301,7 +451,7 @@ type PlanRequest struct {
 
 func (x *PlanRequest) Reset() {
 	*x = PlanRequest{}
-	mi := &file_tern_proto_msgTypes[1]
+	mi := &file_tern_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -313,7 +463,7 @@ func (x *PlanRequest) String() string {
 func (*PlanRequest) ProtoMessage() {}
 
 func (x *PlanRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[1]
+	mi := &file_tern_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -326,7 +476,7 @@ func (x *PlanRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PlanRequest.ProtoReflect.Descriptor instead.
 func (*PlanRequest) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{1}
+	return file_tern_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *PlanRequest) GetDatabase() string {
@@ -408,7 +558,7 @@ type TableChange struct {
 
 func (x *TableChange) Reset() {
 	*x = TableChange{}
-	mi := &file_tern_proto_msgTypes[2]
+	mi := &file_tern_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -420,7 +570,7 @@ func (x *TableChange) String() string {
 func (*TableChange) ProtoMessage() {}
 
 func (x *TableChange) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[2]
+	mi := &file_tern_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -433,7 +583,7 @@ func (x *TableChange) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TableChange.ProtoReflect.Descriptor instead.
 func (*TableChange) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{2}
+	return file_tern_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *TableChange) GetTableName() string {
@@ -490,7 +640,7 @@ type SchemaChange struct {
 
 func (x *SchemaChange) Reset() {
 	*x = SchemaChange{}
-	mi := &file_tern_proto_msgTypes[3]
+	mi := &file_tern_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -502,7 +652,7 @@ func (x *SchemaChange) String() string {
 func (*SchemaChange) ProtoMessage() {}
 
 func (x *SchemaChange) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[3]
+	mi := &file_tern_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -515,7 +665,7 @@ func (x *SchemaChange) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SchemaChange.ProtoReflect.Descriptor instead.
 func (*SchemaChange) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{3}
+	return file_tern_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *SchemaChange) GetNamespace() string {
@@ -555,7 +705,7 @@ type LintViolation struct {
 
 func (x *LintViolation) Reset() {
 	*x = LintViolation{}
-	mi := &file_tern_proto_msgTypes[4]
+	mi := &file_tern_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -567,7 +717,7 @@ func (x *LintViolation) String() string {
 func (*LintViolation) ProtoMessage() {}
 
 func (x *LintViolation) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[4]
+	mi := &file_tern_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -580,7 +730,7 @@ func (x *LintViolation) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LintViolation.ProtoReflect.Descriptor instead.
 func (*LintViolation) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{4}
+	return file_tern_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *LintViolation) GetMessage() string {
@@ -639,7 +789,7 @@ type ShardPlan struct {
 
 func (x *ShardPlan) Reset() {
 	*x = ShardPlan{}
-	mi := &file_tern_proto_msgTypes[5]
+	mi := &file_tern_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -651,7 +801,7 @@ func (x *ShardPlan) String() string {
 func (*ShardPlan) ProtoMessage() {}
 
 func (x *ShardPlan) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[5]
+	mi := &file_tern_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -664,7 +814,7 @@ func (x *ShardPlan) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ShardPlan.ProtoReflect.Descriptor instead.
 func (*ShardPlan) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{5}
+	return file_tern_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *ShardPlan) GetShard() string {
@@ -706,7 +856,7 @@ type PlanResponse struct {
 
 func (x *PlanResponse) Reset() {
 	*x = PlanResponse{}
-	mi := &file_tern_proto_msgTypes[6]
+	mi := &file_tern_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -718,7 +868,7 @@ func (x *PlanResponse) String() string {
 func (*PlanResponse) ProtoMessage() {}
 
 func (x *PlanResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[6]
+	mi := &file_tern_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -731,7 +881,7 @@ func (x *PlanResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PlanResponse.ProtoReflect.Descriptor instead.
 func (*PlanResponse) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{6}
+	return file_tern_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *PlanResponse) GetPlanId() string {
@@ -805,7 +955,7 @@ type ApplyRequest struct {
 
 func (x *ApplyRequest) Reset() {
 	*x = ApplyRequest{}
-	mi := &file_tern_proto_msgTypes[7]
+	mi := &file_tern_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -817,7 +967,7 @@ func (x *ApplyRequest) String() string {
 func (*ApplyRequest) ProtoMessage() {}
 
 func (x *ApplyRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[7]
+	mi := &file_tern_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -830,7 +980,7 @@ func (x *ApplyRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ApplyRequest.ProtoReflect.Descriptor instead.
 func (*ApplyRequest) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{7}
+	return file_tern_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *ApplyRequest) GetPlanId() string {
@@ -916,7 +1066,7 @@ type ApplyResponse struct {
 
 func (x *ApplyResponse) Reset() {
 	*x = ApplyResponse{}
-	mi := &file_tern_proto_msgTypes[8]
+	mi := &file_tern_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -928,7 +1078,7 @@ func (x *ApplyResponse) String() string {
 func (*ApplyResponse) ProtoMessage() {}
 
 func (x *ApplyResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[8]
+	mi := &file_tern_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -941,7 +1091,7 @@ func (x *ApplyResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ApplyResponse.ProtoReflect.Descriptor instead.
 func (*ApplyResponse) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{8}
+	return file_tern_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *ApplyResponse) GetAccepted() bool {
@@ -978,7 +1128,7 @@ type ProgressRequest struct {
 
 func (x *ProgressRequest) Reset() {
 	*x = ProgressRequest{}
-	mi := &file_tern_proto_msgTypes[9]
+	mi := &file_tern_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -990,7 +1140,7 @@ func (x *ProgressRequest) String() string {
 func (*ProgressRequest) ProtoMessage() {}
 
 func (x *ProgressRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[9]
+	mi := &file_tern_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1003,7 +1153,7 @@ func (x *ProgressRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ProgressRequest.ProtoReflect.Descriptor instead.
 func (*ProgressRequest) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{9}
+	return file_tern_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *ProgressRequest) GetApplyId() string {
@@ -1037,7 +1187,7 @@ type ShardProgress struct {
 
 func (x *ShardProgress) Reset() {
 	*x = ShardProgress{}
-	mi := &file_tern_proto_msgTypes[10]
+	mi := &file_tern_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1049,7 +1199,7 @@ func (x *ShardProgress) String() string {
 func (*ShardProgress) ProtoMessage() {}
 
 func (x *ShardProgress) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[10]
+	mi := &file_tern_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1062,7 +1212,7 @@ func (x *ShardProgress) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ShardProgress.ProtoReflect.Descriptor instead.
 func (*ShardProgress) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{10}
+	return file_tern_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *ShardProgress) GetShard() string {
@@ -1143,7 +1293,7 @@ type TableProgress struct {
 
 func (x *TableProgress) Reset() {
 	*x = TableProgress{}
-	mi := &file_tern_proto_msgTypes[11]
+	mi := &file_tern_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1155,7 +1305,7 @@ func (x *TableProgress) String() string {
 func (*TableProgress) ProtoMessage() {}
 
 func (x *TableProgress) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[11]
+	mi := &file_tern_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1168,7 +1318,7 @@ func (x *TableProgress) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TableProgress.ProtoReflect.Descriptor instead.
 func (*TableProgress) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{11}
+	return file_tern_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *TableProgress) GetTaskId() string {
@@ -1281,7 +1431,7 @@ type ProgressResponse struct {
 
 func (x *ProgressResponse) Reset() {
 	*x = ProgressResponse{}
-	mi := &file_tern_proto_msgTypes[12]
+	mi := &file_tern_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1293,7 +1443,7 @@ func (x *ProgressResponse) String() string {
 func (*ProgressResponse) ProtoMessage() {}
 
 func (x *ProgressResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[12]
+	mi := &file_tern_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1306,7 +1456,7 @@ func (x *ProgressResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ProgressResponse.ProtoReflect.Descriptor instead.
 func (*ProgressResponse) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{12}
+	return file_tern_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *ProgressResponse) GetApplyId() string {
@@ -1392,7 +1542,7 @@ type CutoverRequest struct {
 
 func (x *CutoverRequest) Reset() {
 	*x = CutoverRequest{}
-	mi := &file_tern_proto_msgTypes[13]
+	mi := &file_tern_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1404,7 +1554,7 @@ func (x *CutoverRequest) String() string {
 func (*CutoverRequest) ProtoMessage() {}
 
 func (x *CutoverRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[13]
+	mi := &file_tern_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1417,7 +1567,7 @@ func (x *CutoverRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CutoverRequest.ProtoReflect.Descriptor instead.
 func (*CutoverRequest) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{13}
+	return file_tern_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *CutoverRequest) GetApplyId() string {
@@ -1445,7 +1595,7 @@ type CutoverResponse struct {
 
 func (x *CutoverResponse) Reset() {
 	*x = CutoverResponse{}
-	mi := &file_tern_proto_msgTypes[14]
+	mi := &file_tern_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1457,7 +1607,7 @@ func (x *CutoverResponse) String() string {
 func (*CutoverResponse) ProtoMessage() {}
 
 func (x *CutoverResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[14]
+	mi := &file_tern_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1470,7 +1620,7 @@ func (x *CutoverResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CutoverResponse.ProtoReflect.Descriptor instead.
 func (*CutoverResponse) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{14}
+	return file_tern_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *CutoverResponse) GetAccepted() bool {
@@ -1500,7 +1650,7 @@ type RevertRequest struct {
 
 func (x *RevertRequest) Reset() {
 	*x = RevertRequest{}
-	mi := &file_tern_proto_msgTypes[15]
+	mi := &file_tern_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1512,7 +1662,7 @@ func (x *RevertRequest) String() string {
 func (*RevertRequest) ProtoMessage() {}
 
 func (x *RevertRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[15]
+	mi := &file_tern_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1525,7 +1675,7 @@ func (x *RevertRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RevertRequest.ProtoReflect.Descriptor instead.
 func (*RevertRequest) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{15}
+	return file_tern_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *RevertRequest) GetApplyId() string {
@@ -1553,7 +1703,7 @@ type RevertResponse struct {
 
 func (x *RevertResponse) Reset() {
 	*x = RevertResponse{}
-	mi := &file_tern_proto_msgTypes[16]
+	mi := &file_tern_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1565,7 +1715,7 @@ func (x *RevertResponse) String() string {
 func (*RevertResponse) ProtoMessage() {}
 
 func (x *RevertResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[16]
+	mi := &file_tern_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1578,7 +1728,7 @@ func (x *RevertResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RevertResponse.ProtoReflect.Descriptor instead.
 func (*RevertResponse) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{16}
+	return file_tern_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *RevertResponse) GetAccepted() bool {
@@ -1608,7 +1758,7 @@ type SkipRevertRequest struct {
 
 func (x *SkipRevertRequest) Reset() {
 	*x = SkipRevertRequest{}
-	mi := &file_tern_proto_msgTypes[17]
+	mi := &file_tern_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1620,7 +1770,7 @@ func (x *SkipRevertRequest) String() string {
 func (*SkipRevertRequest) ProtoMessage() {}
 
 func (x *SkipRevertRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[17]
+	mi := &file_tern_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1633,7 +1783,7 @@ func (x *SkipRevertRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SkipRevertRequest.ProtoReflect.Descriptor instead.
 func (*SkipRevertRequest) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{17}
+	return file_tern_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *SkipRevertRequest) GetApplyId() string {
@@ -1661,7 +1811,7 @@ type SkipRevertResponse struct {
 
 func (x *SkipRevertResponse) Reset() {
 	*x = SkipRevertResponse{}
-	mi := &file_tern_proto_msgTypes[18]
+	mi := &file_tern_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1673,7 +1823,7 @@ func (x *SkipRevertResponse) String() string {
 func (*SkipRevertResponse) ProtoMessage() {}
 
 func (x *SkipRevertResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[18]
+	mi := &file_tern_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1686,7 +1836,7 @@ func (x *SkipRevertResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SkipRevertResponse.ProtoReflect.Descriptor instead.
 func (*SkipRevertResponse) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{18}
+	return file_tern_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *SkipRevertResponse) GetAccepted() bool {
@@ -1712,7 +1862,7 @@ type HealthRequest struct {
 
 func (x *HealthRequest) Reset() {
 	*x = HealthRequest{}
-	mi := &file_tern_proto_msgTypes[19]
+	mi := &file_tern_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1724,7 +1874,7 @@ func (x *HealthRequest) String() string {
 func (*HealthRequest) ProtoMessage() {}
 
 func (x *HealthRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[19]
+	mi := &file_tern_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1737,7 +1887,7 @@ func (x *HealthRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HealthRequest.ProtoReflect.Descriptor instead.
 func (*HealthRequest) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{19}
+	return file_tern_proto_rawDescGZIP(), []int{21}
 }
 
 // HealthResponse is the health check response.
@@ -1750,7 +1900,7 @@ type HealthResponse struct {
 
 func (x *HealthResponse) Reset() {
 	*x = HealthResponse{}
-	mi := &file_tern_proto_msgTypes[20]
+	mi := &file_tern_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1762,7 +1912,7 @@ func (x *HealthResponse) String() string {
 func (*HealthResponse) ProtoMessage() {}
 
 func (x *HealthResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[20]
+	mi := &file_tern_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1775,7 +1925,7 @@ func (x *HealthResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HealthResponse.ProtoReflect.Descriptor instead.
 func (*HealthResponse) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{20}
+	return file_tern_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *HealthResponse) GetStatus() string {
@@ -1798,7 +1948,7 @@ type StopRequest struct {
 
 func (x *StopRequest) Reset() {
 	*x = StopRequest{}
-	mi := &file_tern_proto_msgTypes[21]
+	mi := &file_tern_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1810,7 +1960,7 @@ func (x *StopRequest) String() string {
 func (*StopRequest) ProtoMessage() {}
 
 func (x *StopRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[21]
+	mi := &file_tern_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1823,7 +1973,7 @@ func (x *StopRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StopRequest.ProtoReflect.Descriptor instead.
 func (*StopRequest) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{21}
+	return file_tern_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *StopRequest) GetApplyId() string {
@@ -1857,7 +2007,7 @@ type StopResponse struct {
 
 func (x *StopResponse) Reset() {
 	*x = StopResponse{}
-	mi := &file_tern_proto_msgTypes[22]
+	mi := &file_tern_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1869,7 +2019,7 @@ func (x *StopResponse) String() string {
 func (*StopResponse) ProtoMessage() {}
 
 func (x *StopResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[22]
+	mi := &file_tern_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1882,7 +2032,7 @@ func (x *StopResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StopResponse.ProtoReflect.Descriptor instead.
 func (*StopResponse) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{22}
+	return file_tern_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *StopResponse) GetAccepted() bool {
@@ -1933,7 +2083,7 @@ type StartRequest struct {
 
 func (x *StartRequest) Reset() {
 	*x = StartRequest{}
-	mi := &file_tern_proto_msgTypes[23]
+	mi := &file_tern_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1945,7 +2095,7 @@ func (x *StartRequest) String() string {
 func (*StartRequest) ProtoMessage() {}
 
 func (x *StartRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[23]
+	mi := &file_tern_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1958,7 +2108,7 @@ func (x *StartRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StartRequest.ProtoReflect.Descriptor instead.
 func (*StartRequest) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{23}
+	return file_tern_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *StartRequest) GetApplyId() string {
@@ -1990,7 +2140,7 @@ type StartResponse struct {
 
 func (x *StartResponse) Reset() {
 	*x = StartResponse{}
-	mi := &file_tern_proto_msgTypes[24]
+	mi := &file_tern_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2002,7 +2152,7 @@ func (x *StartResponse) String() string {
 func (*StartResponse) ProtoMessage() {}
 
 func (x *StartResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[24]
+	mi := &file_tern_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2015,7 +2165,7 @@ func (x *StartResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StartResponse.ProtoReflect.Descriptor instead.
 func (*StartResponse) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{24}
+	return file_tern_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *StartResponse) GetAccepted() bool {
@@ -2061,7 +2211,7 @@ type VolumeRequest struct {
 
 func (x *VolumeRequest) Reset() {
 	*x = VolumeRequest{}
-	mi := &file_tern_proto_msgTypes[25]
+	mi := &file_tern_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2073,7 +2223,7 @@ func (x *VolumeRequest) String() string {
 func (*VolumeRequest) ProtoMessage() {}
 
 func (x *VolumeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[25]
+	mi := &file_tern_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2086,7 +2236,7 @@ func (x *VolumeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VolumeRequest.ProtoReflect.Descriptor instead.
 func (*VolumeRequest) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{25}
+	return file_tern_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *VolumeRequest) GetApplyId() string {
@@ -2125,7 +2275,7 @@ type VolumeResponse struct {
 
 func (x *VolumeResponse) Reset() {
 	*x = VolumeResponse{}
-	mi := &file_tern_proto_msgTypes[26]
+	mi := &file_tern_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2137,7 +2287,7 @@ func (x *VolumeResponse) String() string {
 func (*VolumeResponse) ProtoMessage() {}
 
 func (x *VolumeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[26]
+	mi := &file_tern_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2150,7 +2300,7 @@ func (x *VolumeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VolumeResponse.ProtoReflect.Descriptor instead.
 func (*VolumeResponse) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{26}
+	return file_tern_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *VolumeResponse) GetAccepted() bool {
@@ -2192,7 +2342,22 @@ const file_tern_proto_rawDesc = "" +
 	"\n" +
 	"FilesEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x9c\x03\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"}\n" +
+	"\x11PullSchemaRequest\x12\x1a\n" +
+	"\bdatabase\x18\x01 \x01(\tR\bdatabase\x12\x12\n" +
+	"\x04type\x18\x02 \x01(\tR\x04type\x12 \n" +
+	"\venvironment\x18\x03 \x01(\tR\venvironment\x12\x16\n" +
+	"\x06target\x18\x04 \x01(\tR\x06target\"\xae\x02\n" +
+	"\x12PullSchemaResponse\x12\x1a\n" +
+	"\bdatabase\x18\x01 \x01(\tR\bdatabase\x12\x12\n" +
+	"\x04type\x18\x02 \x01(\tR\x04type\x12 \n" +
+	"\venvironment\x18\x03 \x01(\tR\venvironment\x12O\n" +
+	"\fschema_files\x18\x04 \x03(\v2,.tern.v1.PullSchemaResponse.SchemaFilesEntryR\vschemaFiles\x12\x1f\n" +
+	"\vtable_count\x18\x05 \x01(\x05R\n" +
+	"tableCount\x1aT\n" +
+	"\x10SchemaFilesEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12*\n" +
+	"\x05value\x18\x02 \x01(\v2\x14.tern.v1.SchemaFilesR\x05value:\x028\x01\"\x9c\x03\n" +
 	"\vPlanRequest\x12\x1a\n" +
 	"\bdatabase\x18\x01 \x01(\tR\bdatabase\x12\x12\n" +
 	"\x04type\x18\x02 \x01(\tR\x04type\x12H\n" +
@@ -2397,8 +2562,10 @@ const file_tern_proto_rawDesc = "" +
 	"\x12CHANGE_TYPE_CREATE\x10\x01\x12\x15\n" +
 	"\x11CHANGE_TYPE_ALTER\x10\x02\x12\x14\n" +
 	"\x10CHANGE_TYPE_DROP\x10\x03\x12\x17\n" +
-	"\x13CHANGE_TYPE_VSCHEMA\x10\x042\xbc\x06\n" +
-	"\x04Tern\x12H\n" +
+	"\x13CHANGE_TYPE_VSCHEMA\x10\x042\x9f\a\n" +
+	"\x04Tern\x12a\n" +
+	"\n" +
+	"PullSchema\x12\x1a.tern.v1.PullSchemaRequest\x1a\x1b.tern.v1.PullSchemaResponse\"\x1a\x82\xd3\xe4\x93\x02\x14:\x01*\"\x0f/v1/pull-schema\x12H\n" +
 	"\x04Plan\x12\x14.tern.v1.PlanRequest\x1a\x15.tern.v1.PlanResponse\"\x13\x82\xd3\xe4\x93\x02\r:\x01*\"\b/v1/plan\x12L\n" +
 	"\x05Apply\x12\x15.tern.v1.ApplyRequest\x1a\x16.tern.v1.ApplyResponse\"\x14\x82\xd3\xe4\x93\x02\x0e:\x01*\"\t/v1/apply\x12X\n" +
 	"\bProgress\x12\x18.tern.v1.ProgressRequest\x1a\x19.tern.v1.ProgressResponse\"\x17\x82\xd3\xe4\x93\x02\x11:\x01*\"\f/v1/progress\x12T\n" +
@@ -2427,91 +2594,98 @@ func file_tern_proto_rawDescGZIP() []byte {
 }
 
 var file_tern_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
-var file_tern_proto_msgTypes = make([]protoimpl.MessageInfo, 33)
+var file_tern_proto_msgTypes = make([]protoimpl.MessageInfo, 36)
 var file_tern_proto_goTypes = []any{
 	(Engine)(0),                // 0: tern.v1.Engine
 	(State)(0),                 // 1: tern.v1.State
 	(ChangeType)(0),            // 2: tern.v1.ChangeType
 	(*SchemaFiles)(nil),        // 3: tern.v1.SchemaFiles
-	(*PlanRequest)(nil),        // 4: tern.v1.PlanRequest
-	(*TableChange)(nil),        // 5: tern.v1.TableChange
-	(*SchemaChange)(nil),       // 6: tern.v1.SchemaChange
-	(*LintViolation)(nil),      // 7: tern.v1.LintViolation
-	(*ShardPlan)(nil),          // 8: tern.v1.ShardPlan
-	(*PlanResponse)(nil),       // 9: tern.v1.PlanResponse
-	(*ApplyRequest)(nil),       // 10: tern.v1.ApplyRequest
-	(*ApplyResponse)(nil),      // 11: tern.v1.ApplyResponse
-	(*ProgressRequest)(nil),    // 12: tern.v1.ProgressRequest
-	(*ShardProgress)(nil),      // 13: tern.v1.ShardProgress
-	(*TableProgress)(nil),      // 14: tern.v1.TableProgress
-	(*ProgressResponse)(nil),   // 15: tern.v1.ProgressResponse
-	(*CutoverRequest)(nil),     // 16: tern.v1.CutoverRequest
-	(*CutoverResponse)(nil),    // 17: tern.v1.CutoverResponse
-	(*RevertRequest)(nil),      // 18: tern.v1.RevertRequest
-	(*RevertResponse)(nil),     // 19: tern.v1.RevertResponse
-	(*SkipRevertRequest)(nil),  // 20: tern.v1.SkipRevertRequest
-	(*SkipRevertResponse)(nil), // 21: tern.v1.SkipRevertResponse
-	(*HealthRequest)(nil),      // 22: tern.v1.HealthRequest
-	(*HealthResponse)(nil),     // 23: tern.v1.HealthResponse
-	(*StopRequest)(nil),        // 24: tern.v1.StopRequest
-	(*StopResponse)(nil),       // 25: tern.v1.StopResponse
-	(*StartRequest)(nil),       // 26: tern.v1.StartRequest
-	(*StartResponse)(nil),      // 27: tern.v1.StartResponse
-	(*VolumeRequest)(nil),      // 28: tern.v1.VolumeRequest
-	(*VolumeResponse)(nil),     // 29: tern.v1.VolumeResponse
-	nil,                        // 30: tern.v1.SchemaFiles.FilesEntry
-	nil,                        // 31: tern.v1.PlanRequest.SchemaFilesEntry
-	nil,                        // 32: tern.v1.SchemaChange.MetadataEntry
-	nil,                        // 33: tern.v1.ApplyRequest.OptionsEntry
-	nil,                        // 34: tern.v1.ApplyRequest.SchemaFilesEntry
-	nil,                        // 35: tern.v1.ProgressResponse.MetadataEntry
+	(*PullSchemaRequest)(nil),  // 4: tern.v1.PullSchemaRequest
+	(*PullSchemaResponse)(nil), // 5: tern.v1.PullSchemaResponse
+	(*PlanRequest)(nil),        // 6: tern.v1.PlanRequest
+	(*TableChange)(nil),        // 7: tern.v1.TableChange
+	(*SchemaChange)(nil),       // 8: tern.v1.SchemaChange
+	(*LintViolation)(nil),      // 9: tern.v1.LintViolation
+	(*ShardPlan)(nil),          // 10: tern.v1.ShardPlan
+	(*PlanResponse)(nil),       // 11: tern.v1.PlanResponse
+	(*ApplyRequest)(nil),       // 12: tern.v1.ApplyRequest
+	(*ApplyResponse)(nil),      // 13: tern.v1.ApplyResponse
+	(*ProgressRequest)(nil),    // 14: tern.v1.ProgressRequest
+	(*ShardProgress)(nil),      // 15: tern.v1.ShardProgress
+	(*TableProgress)(nil),      // 16: tern.v1.TableProgress
+	(*ProgressResponse)(nil),   // 17: tern.v1.ProgressResponse
+	(*CutoverRequest)(nil),     // 18: tern.v1.CutoverRequest
+	(*CutoverResponse)(nil),    // 19: tern.v1.CutoverResponse
+	(*RevertRequest)(nil),      // 20: tern.v1.RevertRequest
+	(*RevertResponse)(nil),     // 21: tern.v1.RevertResponse
+	(*SkipRevertRequest)(nil),  // 22: tern.v1.SkipRevertRequest
+	(*SkipRevertResponse)(nil), // 23: tern.v1.SkipRevertResponse
+	(*HealthRequest)(nil),      // 24: tern.v1.HealthRequest
+	(*HealthResponse)(nil),     // 25: tern.v1.HealthResponse
+	(*StopRequest)(nil),        // 26: tern.v1.StopRequest
+	(*StopResponse)(nil),       // 27: tern.v1.StopResponse
+	(*StartRequest)(nil),       // 28: tern.v1.StartRequest
+	(*StartResponse)(nil),      // 29: tern.v1.StartResponse
+	(*VolumeRequest)(nil),      // 30: tern.v1.VolumeRequest
+	(*VolumeResponse)(nil),     // 31: tern.v1.VolumeResponse
+	nil,                        // 32: tern.v1.SchemaFiles.FilesEntry
+	nil,                        // 33: tern.v1.PullSchemaResponse.SchemaFilesEntry
+	nil,                        // 34: tern.v1.PlanRequest.SchemaFilesEntry
+	nil,                        // 35: tern.v1.SchemaChange.MetadataEntry
+	nil,                        // 36: tern.v1.ApplyRequest.OptionsEntry
+	nil,                        // 37: tern.v1.ApplyRequest.SchemaFilesEntry
+	nil,                        // 38: tern.v1.ProgressResponse.MetadataEntry
 }
 var file_tern_proto_depIdxs = []int32{
-	30, // 0: tern.v1.SchemaFiles.files:type_name -> tern.v1.SchemaFiles.FilesEntry
-	31, // 1: tern.v1.PlanRequest.schema_files:type_name -> tern.v1.PlanRequest.SchemaFilesEntry
-	2,  // 2: tern.v1.TableChange.change_type:type_name -> tern.v1.ChangeType
-	5,  // 3: tern.v1.SchemaChange.table_changes:type_name -> tern.v1.TableChange
-	32, // 4: tern.v1.SchemaChange.metadata:type_name -> tern.v1.SchemaChange.MetadataEntry
-	0,  // 5: tern.v1.PlanResponse.engine:type_name -> tern.v1.Engine
-	6,  // 6: tern.v1.PlanResponse.changes:type_name -> tern.v1.SchemaChange
-	7,  // 7: tern.v1.PlanResponse.lint_violations:type_name -> tern.v1.LintViolation
-	8,  // 8: tern.v1.PlanResponse.shards:type_name -> tern.v1.ShardPlan
-	33, // 9: tern.v1.ApplyRequest.options:type_name -> tern.v1.ApplyRequest.OptionsEntry
-	34, // 10: tern.v1.ApplyRequest.schema_files:type_name -> tern.v1.ApplyRequest.SchemaFilesEntry
-	5,  // 11: tern.v1.ApplyRequest.ddl_changes:type_name -> tern.v1.TableChange
-	13, // 12: tern.v1.TableProgress.shards:type_name -> tern.v1.ShardProgress
-	2,  // 13: tern.v1.TableProgress.change_type:type_name -> tern.v1.ChangeType
-	1,  // 14: tern.v1.ProgressResponse.state:type_name -> tern.v1.State
-	0,  // 15: tern.v1.ProgressResponse.engine:type_name -> tern.v1.Engine
-	14, // 16: tern.v1.ProgressResponse.tables:type_name -> tern.v1.TableProgress
-	35, // 17: tern.v1.ProgressResponse.metadata:type_name -> tern.v1.ProgressResponse.MetadataEntry
-	3,  // 18: tern.v1.PlanRequest.SchemaFilesEntry.value:type_name -> tern.v1.SchemaFiles
-	3,  // 19: tern.v1.ApplyRequest.SchemaFilesEntry.value:type_name -> tern.v1.SchemaFiles
-	4,  // 20: tern.v1.Tern.Plan:input_type -> tern.v1.PlanRequest
-	10, // 21: tern.v1.Tern.Apply:input_type -> tern.v1.ApplyRequest
-	12, // 22: tern.v1.Tern.Progress:input_type -> tern.v1.ProgressRequest
-	16, // 23: tern.v1.Tern.Cutover:input_type -> tern.v1.CutoverRequest
-	18, // 24: tern.v1.Tern.Revert:input_type -> tern.v1.RevertRequest
-	20, // 25: tern.v1.Tern.SkipRevert:input_type -> tern.v1.SkipRevertRequest
-	22, // 26: tern.v1.Tern.Health:input_type -> tern.v1.HealthRequest
-	24, // 27: tern.v1.Tern.Stop:input_type -> tern.v1.StopRequest
-	26, // 28: tern.v1.Tern.Start:input_type -> tern.v1.StartRequest
-	28, // 29: tern.v1.Tern.Volume:input_type -> tern.v1.VolumeRequest
-	9,  // 30: tern.v1.Tern.Plan:output_type -> tern.v1.PlanResponse
-	11, // 31: tern.v1.Tern.Apply:output_type -> tern.v1.ApplyResponse
-	15, // 32: tern.v1.Tern.Progress:output_type -> tern.v1.ProgressResponse
-	17, // 33: tern.v1.Tern.Cutover:output_type -> tern.v1.CutoverResponse
-	19, // 34: tern.v1.Tern.Revert:output_type -> tern.v1.RevertResponse
-	21, // 35: tern.v1.Tern.SkipRevert:output_type -> tern.v1.SkipRevertResponse
-	23, // 36: tern.v1.Tern.Health:output_type -> tern.v1.HealthResponse
-	25, // 37: tern.v1.Tern.Stop:output_type -> tern.v1.StopResponse
-	27, // 38: tern.v1.Tern.Start:output_type -> tern.v1.StartResponse
-	29, // 39: tern.v1.Tern.Volume:output_type -> tern.v1.VolumeResponse
-	30, // [30:40] is the sub-list for method output_type
-	20, // [20:30] is the sub-list for method input_type
-	20, // [20:20] is the sub-list for extension type_name
-	20, // [20:20] is the sub-list for extension extendee
-	0,  // [0:20] is the sub-list for field type_name
+	32, // 0: tern.v1.SchemaFiles.files:type_name -> tern.v1.SchemaFiles.FilesEntry
+	33, // 1: tern.v1.PullSchemaResponse.schema_files:type_name -> tern.v1.PullSchemaResponse.SchemaFilesEntry
+	34, // 2: tern.v1.PlanRequest.schema_files:type_name -> tern.v1.PlanRequest.SchemaFilesEntry
+	2,  // 3: tern.v1.TableChange.change_type:type_name -> tern.v1.ChangeType
+	7,  // 4: tern.v1.SchemaChange.table_changes:type_name -> tern.v1.TableChange
+	35, // 5: tern.v1.SchemaChange.metadata:type_name -> tern.v1.SchemaChange.MetadataEntry
+	0,  // 6: tern.v1.PlanResponse.engine:type_name -> tern.v1.Engine
+	8,  // 7: tern.v1.PlanResponse.changes:type_name -> tern.v1.SchemaChange
+	9,  // 8: tern.v1.PlanResponse.lint_violations:type_name -> tern.v1.LintViolation
+	10, // 9: tern.v1.PlanResponse.shards:type_name -> tern.v1.ShardPlan
+	36, // 10: tern.v1.ApplyRequest.options:type_name -> tern.v1.ApplyRequest.OptionsEntry
+	37, // 11: tern.v1.ApplyRequest.schema_files:type_name -> tern.v1.ApplyRequest.SchemaFilesEntry
+	7,  // 12: tern.v1.ApplyRequest.ddl_changes:type_name -> tern.v1.TableChange
+	15, // 13: tern.v1.TableProgress.shards:type_name -> tern.v1.ShardProgress
+	2,  // 14: tern.v1.TableProgress.change_type:type_name -> tern.v1.ChangeType
+	1,  // 15: tern.v1.ProgressResponse.state:type_name -> tern.v1.State
+	0,  // 16: tern.v1.ProgressResponse.engine:type_name -> tern.v1.Engine
+	16, // 17: tern.v1.ProgressResponse.tables:type_name -> tern.v1.TableProgress
+	38, // 18: tern.v1.ProgressResponse.metadata:type_name -> tern.v1.ProgressResponse.MetadataEntry
+	3,  // 19: tern.v1.PullSchemaResponse.SchemaFilesEntry.value:type_name -> tern.v1.SchemaFiles
+	3,  // 20: tern.v1.PlanRequest.SchemaFilesEntry.value:type_name -> tern.v1.SchemaFiles
+	3,  // 21: tern.v1.ApplyRequest.SchemaFilesEntry.value:type_name -> tern.v1.SchemaFiles
+	4,  // 22: tern.v1.Tern.PullSchema:input_type -> tern.v1.PullSchemaRequest
+	6,  // 23: tern.v1.Tern.Plan:input_type -> tern.v1.PlanRequest
+	12, // 24: tern.v1.Tern.Apply:input_type -> tern.v1.ApplyRequest
+	14, // 25: tern.v1.Tern.Progress:input_type -> tern.v1.ProgressRequest
+	18, // 26: tern.v1.Tern.Cutover:input_type -> tern.v1.CutoverRequest
+	20, // 27: tern.v1.Tern.Revert:input_type -> tern.v1.RevertRequest
+	22, // 28: tern.v1.Tern.SkipRevert:input_type -> tern.v1.SkipRevertRequest
+	24, // 29: tern.v1.Tern.Health:input_type -> tern.v1.HealthRequest
+	26, // 30: tern.v1.Tern.Stop:input_type -> tern.v1.StopRequest
+	28, // 31: tern.v1.Tern.Start:input_type -> tern.v1.StartRequest
+	30, // 32: tern.v1.Tern.Volume:input_type -> tern.v1.VolumeRequest
+	5,  // 33: tern.v1.Tern.PullSchema:output_type -> tern.v1.PullSchemaResponse
+	11, // 34: tern.v1.Tern.Plan:output_type -> tern.v1.PlanResponse
+	13, // 35: tern.v1.Tern.Apply:output_type -> tern.v1.ApplyResponse
+	17, // 36: tern.v1.Tern.Progress:output_type -> tern.v1.ProgressResponse
+	19, // 37: tern.v1.Tern.Cutover:output_type -> tern.v1.CutoverResponse
+	21, // 38: tern.v1.Tern.Revert:output_type -> tern.v1.RevertResponse
+	23, // 39: tern.v1.Tern.SkipRevert:output_type -> tern.v1.SkipRevertResponse
+	25, // 40: tern.v1.Tern.Health:output_type -> tern.v1.HealthResponse
+	27, // 41: tern.v1.Tern.Stop:output_type -> tern.v1.StopResponse
+	29, // 42: tern.v1.Tern.Start:output_type -> tern.v1.StartResponse
+	31, // 43: tern.v1.Tern.Volume:output_type -> tern.v1.VolumeResponse
+	33, // [33:44] is the sub-list for method output_type
+	22, // [22:33] is the sub-list for method input_type
+	22, // [22:22] is the sub-list for extension type_name
+	22, // [22:22] is the sub-list for extension extendee
+	0,  // [0:22] is the sub-list for field type_name
 }
 
 func init() { file_tern_proto_init() }
@@ -2525,7 +2699,7 @@ func file_tern_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_tern_proto_rawDesc), len(file_tern_proto_rawDesc)),
 			NumEnums:      3,
-			NumMessages:   33,
+			NumMessages:   36,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/pkg/proto/ternv1/tern.pb.gw.go
+++ b/pkg/proto/ternv1/tern.pb.gw.go
@@ -35,6 +35,33 @@ var (
 	_ = metadata.Join
 )
 
+func request_Tern_PullSchema_0(ctx context.Context, marshaler runtime.Marshaler, client TernClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq PullSchemaRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.PullSchema(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_Tern_PullSchema_0(ctx context.Context, marshaler runtime.Marshaler, server TernServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq PullSchemaRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.PullSchema(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 func request_Tern_Plan_0(ctx context.Context, marshaler runtime.Marshaler, client TernClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
 		protoReq PlanRequest
@@ -305,6 +332,26 @@ func local_request_Tern_Volume_0(ctx context.Context, marshaler runtime.Marshale
 // Note that using this registration option will cause many gRPC library features to stop working. Consider using RegisterTernHandlerFromEndpoint instead.
 // GRPC interceptors will not work for this type of registration. To use interceptors, you must use the "runtime.WithMiddlewares" option in the "runtime.NewServeMux" call.
 func RegisterTernHandlerServer(ctx context.Context, mux *runtime.ServeMux, server TernServer) error {
+	mux.Handle(http.MethodPost, pattern_Tern_PullSchema_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/tern.v1.Tern/PullSchema", runtime.WithHTTPPathPattern("/v1/pull-schema"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_Tern_PullSchema_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_Tern_PullSchema_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodPost, pattern_Tern_Plan_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -545,6 +592,23 @@ func RegisterTernHandler(ctx context.Context, mux *runtime.ServeMux, conn *grpc.
 // doesn't go through the normal gRPC flow (creating a gRPC client etc.) then it will be up to the passed in
 // "TernClient" to call the correct interceptors. This client ignores the HTTP middlewares.
 func RegisterTernHandlerClient(ctx context.Context, mux *runtime.ServeMux, client TernClient) error {
+	mux.Handle(http.MethodPost, pattern_Tern_PullSchema_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/tern.v1.Tern/PullSchema", runtime.WithHTTPPathPattern("/v1/pull-schema"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_Tern_PullSchema_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_Tern_PullSchema_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodPost, pattern_Tern_Plan_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -719,6 +783,7 @@ func RegisterTernHandlerClient(ctx context.Context, mux *runtime.ServeMux, clien
 }
 
 var (
+	pattern_Tern_PullSchema_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "pull-schema"}, ""))
 	pattern_Tern_Plan_0       = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "plan"}, ""))
 	pattern_Tern_Apply_0      = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "apply"}, ""))
 	pattern_Tern_Progress_0   = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "progress"}, ""))
@@ -732,6 +797,7 @@ var (
 )
 
 var (
+	forward_Tern_PullSchema_0 = runtime.ForwardResponseMessage
 	forward_Tern_Plan_0       = runtime.ForwardResponseMessage
 	forward_Tern_Apply_0      = runtime.ForwardResponseMessage
 	forward_Tern_Progress_0   = runtime.ForwardResponseMessage

--- a/pkg/proto/ternv1/tern_grpc.pb.go
+++ b/pkg/proto/ternv1/tern_grpc.pb.go
@@ -19,6 +19,7 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
+	Tern_PullSchema_FullMethodName = "/tern.v1.Tern/PullSchema"
 	Tern_Plan_FullMethodName       = "/tern.v1.Tern/Plan"
 	Tern_Apply_FullMethodName      = "/tern.v1.Tern/Apply"
 	Tern_Progress_FullMethodName   = "/tern.v1.Tern/Progress"
@@ -56,6 +57,9 @@ const (
 //
 // Only one active schema change per database at a time (enforced by Apply).
 type TernClient interface {
+	// PullSchema fetches the live schema for a database route and returns it as
+	// declarative schema files. It does not modify the database.
+	PullSchema(ctx context.Context, in *PullSchemaRequest, opts ...grpc.CallOption) (*PullSchemaResponse, error)
 	// Plan generates a schema change plan by diffing declarative schema files
 	// against the live database schema. Returns DDL statements needed to converge.
 	//
@@ -170,6 +174,16 @@ type ternClient struct {
 
 func NewTernClient(cc grpc.ClientConnInterface) TernClient {
 	return &ternClient{cc}
+}
+
+func (c *ternClient) PullSchema(ctx context.Context, in *PullSchemaRequest, opts ...grpc.CallOption) (*PullSchemaResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(PullSchemaResponse)
+	err := c.cc.Invoke(ctx, Tern_PullSchema_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (c *ternClient) Plan(ctx context.Context, in *PlanRequest, opts ...grpc.CallOption) (*PlanResponse, error) {
@@ -297,6 +311,9 @@ func (c *ternClient) Volume(ctx context.Context, in *VolumeRequest, opts ...grpc
 //
 // Only one active schema change per database at a time (enforced by Apply).
 type TernServer interface {
+	// PullSchema fetches the live schema for a database route and returns it as
+	// declarative schema files. It does not modify the database.
+	PullSchema(context.Context, *PullSchemaRequest) (*PullSchemaResponse, error)
 	// Plan generates a schema change plan by diffing declarative schema files
 	// against the live database schema. Returns DDL statements needed to converge.
 	//
@@ -412,6 +429,9 @@ type TernServer interface {
 // pointer dereference when methods are called.
 type UnimplementedTernServer struct{}
 
+func (UnimplementedTernServer) PullSchema(context.Context, *PullSchemaRequest) (*PullSchemaResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method PullSchema not implemented")
+}
 func (UnimplementedTernServer) Plan(context.Context, *PlanRequest) (*PlanResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method Plan not implemented")
 }
@@ -460,6 +480,24 @@ func RegisterTernServer(s grpc.ServiceRegistrar, srv TernServer) {
 		t.testEmbeddedByValue()
 	}
 	s.RegisterService(&Tern_ServiceDesc, srv)
+}
+
+func _Tern_PullSchema_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(PullSchemaRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(TernServer).PullSchema(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: Tern_PullSchema_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(TernServer).PullSchema(ctx, req.(*PullSchemaRequest))
+	}
+	return interceptor(ctx, in, info, handler)
 }
 
 func _Tern_Plan_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
@@ -649,6 +687,10 @@ var Tern_ServiceDesc = grpc.ServiceDesc{
 	ServiceName: "tern.v1.Tern",
 	HandlerType: (*TernServer)(nil),
 	Methods: []grpc.MethodDesc{
+		{
+			MethodName: "PullSchema",
+			Handler:    _Tern_PullSchema_Handler,
+		},
 		{
 			MethodName: "Plan",
 			Handler:    _Tern_Plan_Handler,

--- a/pkg/tern/client.go
+++ b/pkg/tern/client.go
@@ -17,9 +17,20 @@ import (
 // callers can match it with errors.Is regardless of the transport.
 var ErrNoTasksForApplyOperation = errors.New("no tasks found for apply operation")
 
+var (
+	// ErrPullSchemaUnsupportedType marks a pull request for a database type that
+	// the data plane does not yet support.
+	ErrPullSchemaUnsupportedType = errors.New("pull schema unsupported database type")
+	// ErrPullSchemaInvalidRequest marks a malformed pull request.
+	ErrPullSchemaInvalidRequest = errors.New("pull schema invalid request")
+)
+
 // Client defines the interface for schema change operations.
 // Uses proto-generated types for type safety.
 type Client interface {
+	// PullSchema fetches the live schema and returns it as declarative schema files.
+	PullSchema(ctx context.Context, req *ternv1.PullSchemaRequest) (*ternv1.PullSchemaResponse, error)
+
 	// Plan generates a schema change plan from declarative schema files.
 	// Returns a plan_id that can be used with Apply.
 	Plan(ctx context.Context, req *ternv1.PlanRequest) (*ternv1.PlanResponse, error)

--- a/pkg/tern/grpc_client.go
+++ b/pkg/tern/grpc_client.go
@@ -163,6 +163,7 @@ type Config struct {
 // rides out sub-second blips instead of failing the caller's operation.
 //
 // Only RPCs that are safe to re-send are retried:
+//   - PullSchema: read-only live schema fetch.
 //   - Plan: each attempt produces an independent plan record and only the
 //     returned plan ID is used, so a duplicate attempt is harmless.
 //   - Progress and Health: read-only.
@@ -174,6 +175,7 @@ type Config struct {
 const retryServiceConfig = `{
 	"methodConfig": [{
 		"name": [
+			{"service": "tern.v1.Tern", "method": "PullSchema"},
 			{"service": "tern.v1.Tern", "method": "Plan"},
 			{"service": "tern.v1.Tern", "method": "Progress"},
 			{"service": "tern.v1.Tern", "method": "Health"}
@@ -261,6 +263,10 @@ func (c *GRPCClient) Close() error {
 
 func (c *GRPCClient) Plan(ctx context.Context, req *ternv1.PlanRequest) (*ternv1.PlanResponse, error) {
 	return c.client.Plan(ctx, req)
+}
+
+func (c *GRPCClient) PullSchema(ctx context.Context, req *ternv1.PullSchemaRequest) (*ternv1.PullSchemaResponse, error) {
+	return c.client.PullSchema(ctx, req)
 }
 
 func (c *GRPCClient) Apply(ctx context.Context, req *ternv1.ApplyRequest) (*ternv1.ApplyResponse, error) {

--- a/pkg/tern/local_client.go
+++ b/pkg/tern/local_client.go
@@ -87,13 +87,18 @@ package tern
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"sort"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/block/spirit/pkg/statement"
+	spirittable "github.com/block/spirit/pkg/table"
+	"github.com/block/spirit/pkg/utils"
 	"github.com/go-sql-driver/mysql"
 	"github.com/google/uuid"
 
@@ -270,6 +275,71 @@ func (c *LocalClient) deferredCutoverSignalExists(ctx context.Context, apply *st
 // Health checks the service health.
 func (c *LocalClient) Health(ctx context.Context) error {
 	return c.storage.Ping(ctx)
+}
+
+// PullSchema fetches the live schema and returns declarative schema files.
+func (c *LocalClient) PullSchema(ctx context.Context, req *ternv1.PullSchemaRequest) (*ternv1.PullSchemaResponse, error) {
+	if c.config.Type != storage.DatabaseTypeMySQL {
+		return nil, fmt.Errorf("pull schema for database %s type %s: only %s is supported: %w", c.config.Database, c.config.Type, storage.DatabaseTypeMySQL, ErrPullSchemaUnsupportedType)
+	}
+	if req.Type != "" && req.Type != c.config.Type {
+		return nil, fmt.Errorf("pull schema for database %s: request type %q does not match client type %q: %w", c.config.Database, req.Type, c.config.Type, ErrPullSchemaInvalidRequest)
+	}
+
+	attrs := []any{"database", c.config.Database}
+	attrs = append(attrs, dsnLogAttrs(c.config.TargetDSN)...)
+	c.logger.Info("LocalClient.PullSchema: loading live schema", attrs...)
+
+	db, err := sql.Open("mysql", c.config.TargetDSN)
+	if err != nil {
+		return nil, fmt.Errorf("open database %s for schema pull: %w", c.config.Database, err)
+	}
+	defer utils.CloseAndLog(db)
+
+	if err := db.PingContext(ctx); err != nil {
+		return nil, fmt.Errorf("ping database %s for schema pull: %w", c.config.Database, err)
+	}
+
+	tables, err := spirittable.LoadSchemaFromDB(ctx, db, spirittable.WithoutUnderscoreTables, spirittable.WithoutArchiveTables, spirittable.WithStrippedAutoIncrement)
+	if err != nil {
+		return nil, fmt.Errorf("load live schema for database %s: %w", c.config.Database, err)
+	}
+	sort.Slice(tables, func(i, j int) bool { return tables[i].Name < tables[j].Name })
+
+	files := make(map[string]string, len(tables))
+	for _, tbl := range tables {
+		content, err := pulledSchemaFileContent(c.config.Database, tbl)
+		if err != nil {
+			return nil, err
+		}
+		files[tbl.Name+".sql"] = content
+	}
+
+	c.logger.Info("LocalClient.PullSchema: loaded live schema",
+		"database", c.config.Database,
+		"table_count", len(tables),
+	)
+
+	return &ternv1.PullSchemaResponse{
+		Database:    c.config.Database,
+		Type:        c.config.Type,
+		Environment: req.Environment,
+		SchemaFiles: map[string]*ternv1.SchemaFiles{
+			c.config.Database: {Files: files},
+		},
+		TableCount: int32(len(tables)),
+	}, nil
+}
+
+func pulledSchemaFileContent(database string, tbl spirittable.TableSchema) (string, error) {
+	if tbl.Name == "" {
+		return "", fmt.Errorf("load live schema for database %s: table with empty name", database)
+	}
+	content := strings.TrimRight(tbl.Schema, "\n") + "\n"
+	if _, err := statement.ParseCreateTable(content); err != nil {
+		return "", fmt.Errorf("parse pulled schema for database %s table %s: %w", database, tbl.Name, err)
+	}
+	return content, nil
 }
 
 // Plan generates a schema change plan from declarative schema files.

--- a/pkg/tern/local_client_integration_test.go
+++ b/pkg/tern/local_client_integration_test.go
@@ -441,6 +441,63 @@ func TestLocalClient_Health(t *testing.T) {
 	assert.NoError(t, client.Health(ctx), "Health() returned error")
 }
 
+// Pulling a live MySQL schema returns deterministic declarative files from the
+// data-plane database without preserving volatile AUTO_INCREMENT counters.
+func TestLocalClient_PullSchemaLoadsLiveMySQLSchema(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	container, dsn := setupMySQLContainer(t)
+	_ = container // container is managed by TestMain
+	db, err := sql.Open("mysql", dsn)
+	require.NoError(t, err, "open database")
+	defer utils.CloseAndLog(db)
+
+	_, err = db.ExecContext(t.Context(), "DROP TABLE IF EXISTS `pull_schema_users`, `pull_schema_users_archive_2026_06_12`")
+	require.NoError(t, err, "drop old pull schema tables")
+	t.Cleanup(func() {
+		cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(t.Context()), 30*time.Second)
+		defer cancel()
+		cleanupDB, cleanupErr := sql.Open("mysql", dsn)
+		require.NoError(t, cleanupErr, "open database for pull schema cleanup")
+		defer utils.CloseAndLog(cleanupDB)
+		_, cleanupErr = cleanupDB.ExecContext(cleanupCtx, "DROP TABLE IF EXISTS `pull_schema_users`, `pull_schema_users_archive_2026_06_12`")
+		assert.NoError(t, cleanupErr, "drop pull schema tables")
+	})
+	_, err = db.ExecContext(t.Context(), "CREATE TABLE `pull_schema_users` (`id` bigint unsigned NOT NULL AUTO_INCREMENT, `email` varchar(255) NOT NULL, PRIMARY KEY (`id`), UNIQUE KEY `idx_email` (`email`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci")
+	require.NoError(t, err, "create pull schema table")
+	_, err = db.ExecContext(t.Context(), "CREATE TABLE `pull_schema_users_archive_2026_06_12` (`id` bigint unsigned NOT NULL, PRIMARY KEY (`id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci")
+	require.NoError(t, err, "create archive table")
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	client, err := NewLocalClient(LocalConfig{
+		Database:  "testdb",
+		Type:      storage.DatabaseTypeMySQL,
+		TargetDSN: dsn,
+	}, nil, logger)
+	require.NoError(t, err, "create client")
+	defer utils.CloseAndLog(client)
+
+	resp, err := client.PullSchema(t.Context(), &ternv1.PullSchemaRequest{
+		Type:        storage.DatabaseTypeMySQL,
+		Environment: localClientTestEnvironment,
+	})
+
+	require.NoError(t, err, "pull schema")
+	require.NotNil(t, resp)
+	assert.Equal(t, "testdb", resp.Database)
+	assert.Equal(t, storage.DatabaseTypeMySQL, resp.Type)
+	assert.Equal(t, localClientTestEnvironment, resp.Environment)
+	require.Contains(t, resp.SchemaFiles, "testdb")
+	ddl := resp.SchemaFiles["testdb"].Files["pull_schema_users.sql"]
+	assert.Contains(t, ddl, "CREATE TABLE `pull_schema_users`")
+	assert.Contains(t, ddl, "`email` varchar(255) NOT NULL")
+	assert.NotContains(t, ddl, "AUTO_INCREMENT=")
+	assert.True(t, strings.HasSuffix(ddl, "\n"), "pulled schema file should end with a newline")
+	assert.NotContains(t, resp.SchemaFiles["testdb"].Files, "pull_schema_users_archive_2026_06_12.sql")
+}
+
 func TestLocalClient_Plan(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")

--- a/pkg/tern/local_client_test.go
+++ b/pkg/tern/local_client_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	spirittable "github.com/block/spirit/pkg/table"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -16,6 +17,24 @@ import (
 	"github.com/block/schemabot/pkg/state"
 	"github.com/block/schemabot/pkg/storage"
 )
+
+func TestPulledSchemaFileContentValidatesDDL(t *testing.T) {
+	content, err := pulledSchemaFileContent("orders", spirittable.TableSchema{
+		Name:   "users",
+		Schema: "CREATE TABLE `users` (`id` bigint NOT NULL) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "CREATE TABLE `users` (`id` bigint NOT NULL) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci\n", content)
+
+	_, err = pulledSchemaFileContent("orders", spirittable.TableSchema{
+		Name:   "broken_users",
+		Schema: "CREATE TABLE",
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "parse pulled schema for database orders table broken_users")
+}
 
 type exactProgressApplyStore struct {
 	storage.ApplyStore

--- a/pkg/tern/server.go
+++ b/pkg/tern/server.go
@@ -38,6 +38,27 @@ func (s *Server) Health(ctx context.Context, req *ternv1.HealthRequest) (*ternv1
 	return &ternv1.HealthResponse{Status: "ok"}, nil
 }
 
+func (s *Server) PullSchema(ctx context.Context, req *ternv1.PullSchemaRequest) (*ternv1.PullSchemaResponse, error) {
+	resp, err := s.client.PullSchema(ctx, req)
+	if err != nil {
+		return nil, status.Error(pullSchemaErrorCode(err), err.Error())
+	}
+	return resp, nil
+}
+
+func pullSchemaErrorCode(err error) codes.Code {
+	if err == nil {
+		return codes.OK
+	}
+	if errors.Is(err, ErrPullSchemaUnsupportedType) {
+		return codes.Unimplemented
+	}
+	if errors.Is(err, ErrPullSchemaInvalidRequest) {
+		return codes.InvalidArgument
+	}
+	return codes.Internal
+}
+
 func (s *Server) Plan(ctx context.Context, req *ternv1.PlanRequest) (*ternv1.PlanResponse, error) {
 	resp, err := s.client.Plan(ctx, req)
 	if err != nil {

--- a/pkg/tern/server_test.go
+++ b/pkg/tern/server_test.go
@@ -34,6 +34,15 @@ func (c applyErrorClient) Apply(context.Context, *ternv1.ApplyRequest) (*ternv1.
 	return nil, c.err
 }
 
+type pullSchemaErrorClient struct {
+	Client
+	err error
+}
+
+func (c pullSchemaErrorClient) PullSchema(context.Context, *ternv1.PullSchemaRequest) (*ternv1.PullSchemaResponse, error) {
+	return nil, c.err
+}
+
 type noopControlClient struct {
 	Client
 }
@@ -93,6 +102,40 @@ func TestServerApplyMapsEngineRetryabilityToStatusCode(t *testing.T) {
 			server := NewServer(applyErrorClient{err: tc.err})
 
 			_, err := server.Apply(t.Context(), &ternv1.ApplyRequest{PlanId: "plan-123"})
+			require.Error(t, err)
+			assert.Equal(t, tc.want, status.Code(err))
+		})
+	}
+}
+
+func TestServerPullSchemaMapsKnownErrorsToStatusCode(t *testing.T) {
+	testCases := []struct {
+		name string
+		err  error
+		want codes.Code
+	}{
+		{
+			name: "unsupported type",
+			err:  fmt.Errorf("vitess is not supported yet: %w", ErrPullSchemaUnsupportedType),
+			want: codes.Unimplemented,
+		},
+		{
+			name: "invalid request",
+			err:  fmt.Errorf("request type mismatch: %w", ErrPullSchemaInvalidRequest),
+			want: codes.InvalidArgument,
+		},
+		{
+			name: "unexpected error",
+			err:  errors.New("database unavailable"),
+			want: codes.Internal,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			server := NewServer(pullSchemaErrorClient{err: tc.err})
+
+			_, err := server.PullSchema(t.Context(), &ternv1.PullSchemaRequest{Database: "orders"})
 			require.Error(t, err)
 			assert.Equal(t, tc.want, status.Code(err))
 		})


### PR DESCRIPTION
## Why
Schema onboarding needs a server-side primitive that can fetch live database state from the data plane before future CLI commands write declarative files.

## What
- Add a `PullSchema` Tern RPC and `/api/pull` control-plane endpoint
- Route pull requests through the existing local/gRPC client model
- Return MySQL schemas from live `SHOW CREATE TABLE` data with volatile counters stripped

## References
Payload shapes:

```json
POST /api/pull
{
  "database": "orders",
  "environment": "production",
  "type": "mysql"
}
```

```proto
message PullSchemaRequest {
  string database = 1;
  string type = 2;
  string environment = 3;
  string target = 4;
}

message PullSchemaResponse {
  string database = 1;
  string type = 2;
  string environment = 3;
  map<string, SchemaFiles> schema_files = 4;
  int32 table_count = 5;
}
```

`schema_files` is keyed by namespace, and each namespace contains `files` mapping filenames to declarative schema content.

Generated with Amp
