### PR TITLE
feat(operator): phase-aware cutover_policy claim predicate

### DIFF
--- a/pkg/storage/mysqlstore/apply_operations.go
+++ b/pkg/storage/mysqlstore/apply_operations.go
@@ -538,24 +538,40 @@ const applyOperationHeartbeatStaleness = "1 MINUTE"
 // staleness window) are re-leased without changing their state. Terminal
 // rows are never claimed.
 //
-// Sibling ordering: a pending row is only claimable once every earlier
-// sibling of the same apply (lower created_at, id) has reached completed.
-// This serializes a multi-deployment apply along its deployment_order — the
-// order materialized by the apply-create dual-write into row insertion order
-// — so deployments roll out in order. The gate applies only to starting a
-// pending row; an already-active row re-leasing a stale heartbeat is
-// recovering work it already started, so it is never re-gated.
+// Sibling ordering: a pending row's claimability is gated on its earlier
+// siblings of the same apply (lower created_at, id) along deployment_order —
+// the order materialized by the apply-create dual-write into row insertion
+// order. The gate is cutover_policy-aware (the policy is captured per row at
+// apply-create):
 //
-// halt_on_failure (per-apply policy, captured on each row at create): when
-// true (the default), an earlier sibling that is anything other than
-// completed — including terminal-failed — blocks every later sibling, so the
-// rollout halts on the first failure. When false, a terminal-failed earlier
-// sibling is treated as settled and no longer blocks: later deployments are
-// still claimed and attempted. Only terminal `failed` is exempted — pending,
-// running, failed_retryable, and stopped earlier siblings still block under
-// both policies (work is in-flight or recoverable). The policy governs only
-// rollout continuation; the apply's pass/fail verdict and the merge gate stay
+//   - rolling (the default, and any non-barrier value — which fails closed to
+//     the serial gate): a pending row is claimable only once every earlier
+//     sibling has reached completed. This serializes the rollout and halts it
+//     on the first non-completed sibling (e.g. a failed deployment).
+//   - barrier: an earlier sibling stops blocking once it reaches the cutover
+//     barrier or succeeds (waiting_for_cutover, cutting_over, completed), so a
+//     later deployment may start its copy phase while earlier siblings sit at
+//     the barrier. Earlier siblings that are still in-flight or not yet at the
+//     barrier (pending, running, failed_retryable, stopped) — and terminal
+//     non-success states (failed, cancelled, reverted) — still block, so a
+//     failed earlier deployment still halts the rollout.
+//
+// halt_on_failure (per-apply policy, also captured on each row at create)
+// layers on top of both policies: when true (the default), a terminal-failed
+// earlier sibling blocks every later sibling, so the rollout halts on the
+// first failure. When false, a terminal `failed` earlier sibling is treated as
+// settled and no longer blocks: later deployments are still claimed and
+// attempted. Only terminal `failed` is exempted — pending, running,
+// failed_retryable, and stopped earlier siblings still block under both
+// policies (work is in-flight or recoverable). The policy governs only rollout
+// continuation; the apply's pass/fail verdict and the merge gate stay
 // fail-closed on any failed deployment.
+//
+// The gate applies only to starting a pending row; an already-active row
+// re-leasing a stale heartbeat is recovering work it already started, so it
+// is never re-gated. While the operator flag is off and the single-deployment
+// hard-block stands, an apply has exactly one operation with no earlier
+// siblings, so this gate is dormant regardless of policy.
 //
 // Mirrors ApplyStore.FindNextApply: SELECT ... FOR UPDATE SKIP LOCKED to
 // avoid worker races, READ COMMITTED isolation to prevent next-key range
@@ -579,7 +595,23 @@ func (s *applyOperationStore) FindNextApplyOperation(ctx context.Context, owner 
 	activeStates := claimableApplyStates()
 	activeStatePlaceholders := placeholders(len(activeStates))
 
-	queryArgs := []any{state.ApplyOperation.Pending, state.ApplyOperation.Completed, state.ApplyOperation.Failed}
+	queryArgs := []any{state.ApplyOperation.Pending}
+	// Sibling-gate args for the pending claim, cutover_policy-aware (see the
+	// gate SQL below). Under barrier, an earlier sibling stops blocking once it
+	// reaches the cutover barrier or succeeds (waiting_for_cutover, cutting_over,
+	// completed); under rolling — and any non-barrier value, which fails closed
+	// to the serial gate — only a completed earlier sibling stops blocking. The
+	// trailing Failed arg drives the halt_on_failure exemption: when the policy
+	// is off, a terminal-failed earlier sibling no longer blocks later ones.
+	queryArgs = append(queryArgs,
+		storage.CutoverPolicyBarrier,
+		state.ApplyOperation.WaitingForCutover,
+		state.ApplyOperation.CuttingOver,
+		state.ApplyOperation.Completed,
+		storage.CutoverPolicyBarrier,
+		state.ApplyOperation.Completed,
+		state.ApplyOperation.Failed,
+	)
 	queryArgs = append(queryArgs, stringArgs(activeStates)...)
 	queryArgs = append(queryArgs,
 		state.ApplyOperation.Stopped,
@@ -634,7 +666,16 @@ func (s *applyOperationStore) FindNextApplyOperation(ctx context.Context, owner 
 					FROM apply_operations AS earlier
 					WHERE earlier.apply_id = apply_operations.apply_id
 						AND (earlier.created_at, earlier.id) < (apply_operations.created_at, apply_operations.id)
-						AND earlier.state <> ?
+						AND (
+							(
+								apply_operations.cutover_policy = ?
+								AND earlier.state NOT IN (?, ?, ?)
+							)
+							OR (
+								apply_operations.cutover_policy <> ?
+								AND earlier.state <> ?
+							)
+						)
 						AND NOT (apply_operations.halt_on_failure = 0 AND earlier.state = ?)
 				)
 			)

--- a/pkg/storage/mysqlstore/apply_operations.go
+++ b/pkg/storage/mysqlstore/apply_operations.go
@@ -549,12 +549,12 @@ const applyOperationHeartbeatStaleness = "1 MINUTE"
 //     sibling has reached completed. This serializes the rollout and halts it
 //     on the first non-completed sibling (e.g. a failed deployment).
 //   - barrier: an earlier sibling stops blocking once it reaches the cutover
-//     barrier or succeeds (waiting_for_cutover, cutting_over, completed), so a
-//     later deployment may start its copy phase while earlier siblings sit at
-//     the barrier. Earlier siblings that are still in-flight or not yet at the
-//     barrier (pending, running, failed_retryable, stopped) — and terminal
-//     non-success states (failed, cancelled, reverted) — still block, so a
-//     failed earlier deployment still halts the rollout.
+//     barrier or succeeds (waiting_for_cutover, cutting_over, revert_window,
+//     completed), so a later deployment may start its copy phase while earlier
+//     siblings sit at the barrier. Earlier siblings that are still in-flight or
+//     not yet at the barrier (pending, running, failed_retryable, stopped) — and
+//     terminal non-success states (failed, cancelled, reverted) — still block,
+//     so a failed earlier deployment still halts the rollout.
 //
 // halt_on_failure (per-apply policy, also captured on each row at create)
 // layers on top of both policies: when true (the default), a terminal-failed
@@ -599,14 +599,16 @@ func (s *applyOperationStore) FindNextApplyOperation(ctx context.Context, owner 
 	// Sibling-gate args for the pending claim, cutover_policy-aware (see the
 	// gate SQL below). Under barrier, an earlier sibling stops blocking once it
 	// reaches the cutover barrier or succeeds (waiting_for_cutover, cutting_over,
-	// completed); under rolling — and any non-barrier value, which fails closed
-	// to the serial gate — only a completed earlier sibling stops blocking. The
-	// trailing Failed arg drives the halt_on_failure exemption: when the policy
-	// is off, a terminal-failed earlier sibling no longer blocks later ones.
+	// revert_window, completed); under rolling — and any non-barrier value, which
+	// fails closed to the serial gate — only a completed earlier sibling stops
+	// blocking. The trailing Failed arg drives the halt_on_failure exemption:
+	// when the policy is off, a terminal-failed earlier sibling no longer blocks
+	// later ones.
 	queryArgs = append(queryArgs,
 		storage.CutoverPolicyBarrier,
 		state.ApplyOperation.WaitingForCutover,
 		state.ApplyOperation.CuttingOver,
+		state.ApplyOperation.RevertWindow,
 		state.ApplyOperation.Completed,
 		storage.CutoverPolicyBarrier,
 		state.ApplyOperation.Completed,
@@ -669,7 +671,7 @@ func (s *applyOperationStore) FindNextApplyOperation(ctx context.Context, owner 
 						AND (
 							(
 								apply_operations.cutover_policy = ?
-								AND earlier.state NOT IN (?, ?, ?)
+								AND earlier.state NOT IN (?, ?, ?, ?)
 							)
 							OR (
 								apply_operations.cutover_policy <> ?

--- a/pkg/storage/mysqlstore/apply_operations_test.go
+++ b/pkg/storage/mysqlstore/apply_operations_test.go
@@ -1269,6 +1269,40 @@ func TestApplyOperationStore_FindNextApplyOperation_BarrierClaimsPastSiblingAtCu
 	assert.Equal(t, "region-b", claimed.Deployment)
 }
 
+// TestApplyOperationStore_FindNextApplyOperation_BarrierClaimsPastSiblingInRevertWindow
+// verifies that revert_window — a PlanetScale post-cutover success state where
+// the schema change has already been applied — is treated as past the cutover
+// barrier under the barrier policy, so an earlier sibling sitting in its revert
+// window does not block a later deployment from starting its copy phase.
+func TestApplyOperationStore_FindNextApplyOperation_BarrierClaimsPastSiblingInRevertWindow(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", "mysql", "staging")
+	apply := createTestApply(t, store, lock, "apply_op_barrier_revert_window", 1)
+
+	// region-a has cut over and is holding its post-cutover revert window;
+	// region-b is pending behind it. Both rows carry the barrier policy.
+	_, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-a",
+		State: state.ApplyOperation.RevertWindow, CutoverPolicy: storage.CutoverPolicyBarrier,
+	})
+	require.NoError(t, err)
+	regionBID, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-b", CutoverPolicy: storage.CutoverPolicyBarrier,
+	})
+	require.NoError(t, err)
+
+	// region-a stays fresh so the stale-reclaim clause can't surface it — the
+	// only row that should be claimable is region-b, via the barrier relaxation.
+	claimed, err := store.ApplyOperations().FindNextApplyOperation(ctx, "test-operator")
+	require.NoError(t, err)
+	require.NotNil(t, claimed, "barrier must let a later deployment copy once an earlier sibling reaches its post-cutover revert window")
+	assert.Equal(t, regionBID, claimed.ID)
+	assert.Equal(t, "region-b", claimed.Deployment)
+}
+
 // TestApplyOperationStore_FindNextApplyOperation_RollingBlocksOnSiblingAtCutoverBarrier
 // verifies that the default rolling policy keeps the fully serial gate: an
 // earlier sibling parked at the cutover barrier (waiting_for_cutover) still

--- a/pkg/storage/mysqlstore/apply_operations_test.go
+++ b/pkg/storage/mysqlstore/apply_operations_test.go
@@ -1235,6 +1235,131 @@ func TestApplyOperationStore_FindNextApplyOperation_HaltOnFailureDisabledStillBl
 	assert.Nil(t, claimed, "a running earlier sibling still blocks even with halt_on_failure disabled")
 }
 
+// TestApplyOperationStore_FindNextApplyOperation_BarrierClaimsPastSiblingAtCutoverBarrier
+// verifies the barrier cutover policy: a later deployment may start its copy
+// phase once an earlier sibling has reached the cutover barrier
+// (waiting_for_cutover), rather than waiting for it to fully complete. This is
+// the parallel-copy relaxation the barrier policy enables.
+func TestApplyOperationStore_FindNextApplyOperation_BarrierClaimsPastSiblingAtCutoverBarrier(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", "mysql", "staging")
+	apply := createTestApply(t, store, lock, "apply_op_barrier_claims", 1)
+
+	// region-a has finished copying and is parked at the cutover barrier;
+	// region-b is pending behind it. Both rows carry the barrier policy.
+	_, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-a",
+		State: state.ApplyOperation.WaitingForCutover, CutoverPolicy: storage.CutoverPolicyBarrier,
+	})
+	require.NoError(t, err)
+	regionBID, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-b", CutoverPolicy: storage.CutoverPolicyBarrier,
+	})
+	require.NoError(t, err)
+
+	// region-a stays fresh so the stale-reclaim clause can't surface it — the
+	// only row that should be claimable is region-b, via the barrier relaxation.
+	claimed, err := store.ApplyOperations().FindNextApplyOperation(ctx, "test-operator")
+	require.NoError(t, err)
+	require.NotNil(t, claimed, "barrier must let a later deployment copy once an earlier sibling reaches the cutover barrier")
+	assert.Equal(t, regionBID, claimed.ID)
+	assert.Equal(t, "region-b", claimed.Deployment)
+}
+
+// TestApplyOperationStore_FindNextApplyOperation_RollingBlocksOnSiblingAtCutoverBarrier
+// verifies that the default rolling policy keeps the fully serial gate: an
+// earlier sibling parked at the cutover barrier (waiting_for_cutover) still
+// blocks a later pending deployment, which is only released once the earlier
+// sibling completes.
+func TestApplyOperationStore_FindNextApplyOperation_RollingBlocksOnSiblingAtCutoverBarrier(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", "mysql", "staging")
+	apply := createTestApply(t, store, lock, "apply_op_rolling_blocks", 1)
+
+	// Default (rolling) policy: leave CutoverPolicy unset so it resolves to rolling.
+	_, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-a", State: state.ApplyOperation.WaitingForCutover,
+	})
+	require.NoError(t, err)
+	_, err = store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-b",
+	})
+	require.NoError(t, err)
+
+	claimed, err := store.ApplyOperations().FindNextApplyOperation(ctx, "test-operator")
+	require.NoError(t, err)
+	assert.Nil(t, claimed, "rolling must keep a later deployment blocked until the earlier sibling completes")
+}
+
+// TestApplyOperationStore_FindNextApplyOperation_BarrierStillBlocksOnRunningSibling
+// verifies that barrier only relaxes the gate for siblings that have reached
+// the cutover barrier — an earlier sibling still copying (running) continues to
+// block later deployments, because nothing past the barrier has settled yet.
+func TestApplyOperationStore_FindNextApplyOperation_BarrierStillBlocksOnRunningSibling(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", "mysql", "staging")
+	apply := createTestApply(t, store, lock, "apply_op_barrier_running", 1)
+
+	// region-a is still copying (running, fresh so not stale-reclaimable);
+	// region-b is pending behind it. Both carry the barrier policy.
+	_, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-a",
+		State: state.ApplyOperation.Running, CutoverPolicy: storage.CutoverPolicyBarrier,
+	})
+	require.NoError(t, err)
+	_, err = store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-b", CutoverPolicy: storage.CutoverPolicyBarrier,
+	})
+	require.NoError(t, err)
+
+	claimed, err := store.ApplyOperations().FindNextApplyOperation(ctx, "test-operator")
+	require.NoError(t, err)
+	assert.Nil(t, claimed, "barrier must still block a later deployment while an earlier sibling is still copying")
+}
+
+// TestApplyOperationStore_FindNextApplyOperation_BarrierHaltsOnFailedSibling
+// verifies that barrier does not weaken halt-on-first-failure: a terminal-failed
+// earlier sibling still blocks later deployments under barrier, so a failed
+// region halts the rollout rather than letting later regions race ahead.
+func TestApplyOperationStore_FindNextApplyOperation_BarrierHaltsOnFailedSibling(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", "mysql", "staging")
+	apply := createTestApply(t, store, lock, "apply_op_barrier_failed", 1)
+
+	failedID, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-a",
+		State: state.ApplyOperation.Failed, CutoverPolicy: storage.CutoverPolicyBarrier,
+	})
+	require.NoError(t, err)
+	_, err = store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-b", CutoverPolicy: storage.CutoverPolicyBarrier,
+	})
+	require.NoError(t, err)
+
+	// Backdate the failed row so staleness can't be mistaken for the reason it
+	// is skipped; a failed earlier sibling must block regardless.
+	_, err = testDB.ExecContext(ctx, `
+		UPDATE apply_operations SET updated_at = NOW() - INTERVAL 1 HOUR WHERE id = ?
+	`, failedID)
+	require.NoError(t, err)
+
+	claimed, err := store.ApplyOperations().FindNextApplyOperation(ctx, "test-operator")
+	require.NoError(t, err)
+	assert.Nil(t, claimed, "barrier must still halt the rollout on a failed earlier deployment")
+}
+
 // TestApplyOperationStore_FindNextApplyOperation_PendingStartRequestDoesNotBypassSiblingGate
 // verifies that a parent apply's pending start request does not let a later
 // pending deployment jump the deployment-order gate. Start requests resume


### PR DESCRIPTION
## What and Why ?

Makes the pending sibling gate in `FindNextApplyOperation` aware of the
`cutover_policy` stamped on each `apply_operations` row (added in #312). This is
the predicate half of `cutover_policy`; it is **additive and dormant** — while
the operator claim flag is off and the single-deployment hard-block stands, an
apply has exactly one operation with no earlier siblings, so the gate is a no-op
regardless of policy.

The blocking condition for whether an earlier sibling holds back a later
deployment's `pending` claim is now policy-dependent:

rolling (default, and any non-barrier value — fails closed to serial):
earlier sibling blocks unless it is  completed

barrier:
earlier sibling blocks unless it is in
{ waiting_for_cutover, cutting_over, completed }

Under `barrier`, a later deployment can begin its copy phase once earlier
siblings reach the cutover barrier, instead of waiting for them to fully
complete. `rolling` keeps today's fully serial rollout.

Earlier siblings that are still in-flight (`pending`, `running`,
`failed_retryable`, `stopped`) or terminal-but-unsuccessful (`failed`,
`cancelled`, `reverted`) keep blocking under both policies, so halt-on-first-
failure is preserved — a failed deployment still halts the rollout. Keeping
`failed` in the blocking set also lets the separate `halt_on_failure` predicate
compose cleanly on `earlier.state = 'failed'`.

## Stage sequence

| # | Slice | Purpose | Status |
|---|---|---|---|
| A | `feat(config): add optional cutover_policy for multi-deployment environments` | Add `cutover_policy` (`rolling`/`barrier`, default `rolling`), validate it, persist the resolved value on each `apply_operations` row at apply-create. | merged (#312) |
| **B** (this PR) | `feat(operator): phase-aware cutover_policy claim predicate` | Make the pending sibling gate `cutover_policy`-aware: `barrier` lets a later deployment start copy once earlier siblings reach the cutover barrier; `rolling` stays serial. | this PR |

## Note

True ordered cutover (later deployments parking at `waiting_for_cutover` and a
separate cutover-claim that gates the cutover phase on order) is a later slice —
the operator drive currently runs cutover inline. This PR only relaxes the
copy-start gate, as a correct dormant foundation.

## Planet-scale specific note
```
PlanetScale deployment lifecycle:
  running → waiting_for_cutover → cutting_over → revert_window → completed
                  └──────────── past the barrier ────────────┘
                       (all should be non-blocking under barrier)
```
This pr also adds `revert_window` to the non-blocking set so anything at-or-past the barrier consistently stops blocking. **Note** this never weakens safety: terminal non-success states (failed, cancelled, reverted) and pre-barrier states (pending, running, stopped, failed_retryable) still block, so a failed earlier deployment still halts the rollout. 