### PR TITLE
feat(github): derive surface-agnostic multi-deployment apply presentation

### DIFF
--- a/pkg/presentation/presentation.go
+++ b/pkg/presentation/presentation.go
@@ -154,11 +154,15 @@ type Apply struct {
 	// Deployments are the per-deployment presentations in resolved deployment
 	// order (the order the caller supplies, which mirrors the rollout order).
 	Deployments []Deployment
+}
 
-	// MultiDeployment is true when the apply owns more than one deployment. The
-	// single-deployment case (false) should render exactly as today's UX with no
-	// deployment hierarchy; the model is still populated for callers that want it.
-	MultiDeployment bool
+// MultiDeployment reports whether the apply owns more than one deployment.
+// Callers use it as the single↔multi render threshold: when false, the apply
+// should render exactly as today's UX with no deployment hierarchy. It is
+// derived from the deployment count rather than stored, so it can never drift
+// from Deployments.
+func (a Apply) MultiDeployment() bool {
+	return len(a.Deployments) > 1
 }
 
 // Derive projects the ordered operations of one apply into its rollup. The input
@@ -177,12 +181,11 @@ func Derive(ops []Operation) Apply {
 
 	aggState := state.DeriveApplyState(rawStates)
 	return Apply{
-		State:           aggState,
-		Label:           aggregateLabel(aggState),
-		Counts:          summaryCounts(deployments),
-		NextAction:      nextAction(aggState, deployments),
-		Deployments:     deployments,
-		MultiDeployment: len(ops) > 1,
+		State:       aggState,
+		Label:       aggregateLabel(aggState),
+		Counts:      summaryCounts(deployments),
+		NextAction:  nextAction(aggState, deployments),
+		Deployments: deployments,
 	}
 }
 

--- a/pkg/presentation/presentation.go
+++ b/pkg/presentation/presentation.go
@@ -1,0 +1,468 @@
+// Package presentation derives the user-facing rollup for a multi-deployment
+// apply from its apply_operations rows. It is surface-agnostic: the PR comment
+// renderer and the Admin CLI both build their output from the same Apply model,
+// so the aggregate header, per-deployment labels, ordering context, and default
+// expand/collapse are computed once and rendered identically everywhere.
+//
+// The derivation adds no persisted state. Labels such as "halted",
+// "ready for cutover — waiting for <deployment>", and "queued — next in order"
+// exist only here; they are projections of (operation state, earlier-sibling
+// states, resolved order, cutover_policy, halt_on_failure). The ordering
+// context is derived from the same gate FindNextApplyOperation evaluates, so the
+// presentation never contradicts what the operator will actually claim next.
+//
+// Vocabulary is deployment-facing only — the model never exposes the internal
+// "apply_operation" term.
+package presentation
+
+import (
+	"fmt"
+
+	"github.com/block/schemabot/pkg/state"
+)
+
+// Operation is the minimal, surface-neutral input the derivation needs for one
+// deployment of an apply. Callers map their own rows (storage.ApplyOperation for
+// the operator/webhook path, an API response for the CLI path) into this shape,
+// resolving the two rollout-policy booleans at the boundary so the derivation
+// stays free of storage and wire types.
+type Operation struct {
+	// Deployment is the deployment name this operation targets.
+	Deployment string
+
+	// State is the canonical operation state (state.ApplyOperation, == state.Apply).
+	State string
+
+	// Barrier is true when the operation's cutover_policy is "barrier" (resolved
+	// by the caller from storage.CutoverPolicyBarrier). Under barrier an earlier
+	// sibling stops blocking a later copy once it reaches the cutover barrier or
+	// succeeds; under rolling only a completed earlier sibling stops blocking.
+	Barrier bool
+
+	// HaltOnFailure is the resolved halt-on-failure policy (the caller derefs the
+	// stored *bool, treating nil as true — the safe default). When false, a
+	// terminal-failed earlier sibling no longer blocks later deployments.
+	HaltOnFailure bool
+
+	// Error is the operation's error detail, set when State is failed.
+	Error string
+}
+
+// PresentationState is the semantic, render-time status of one deployment. It is
+// richer than the raw operation state because the same state means different
+// things depending on a deployment's earlier siblings (a pending operation may
+// be next in order, waiting on an earlier copy, or halted by an earlier
+// failure). Surfaces may switch on this for their own styling; Label/Emoji/Open
+// carry the ready-to-render projection.
+type PresentationState int
+
+const (
+	StateUnknown PresentationState = iota
+	StateCompleted
+	StateRunningCopy
+	StateReadyForCutoverNext
+	StateReadyForCutoverWaiting
+	StateCuttingOver
+	StateQueuedNext
+	StateWaiting
+	StateHalted
+	StateFailed
+	StateRetrying
+	StateStopped
+	StateRevertWindow
+	StateCancelled
+	StateReverted
+)
+
+// Deployment is the derived presentation for one deployment of the apply.
+type Deployment struct {
+	// Deployment is the deployment name.
+	Deployment string
+
+	// State is the raw operation state it was derived from.
+	State string
+
+	// Presentation is the semantic render-time status (see PresentationState).
+	Presentation PresentationState
+
+	// Label is the operator-facing summary, including any referenced deployment
+	// (e.g. "ready for cutover — waiting for payments-eu", "halted — payments-us
+	// failed"). It carries no progress percentage — fine-grained copy progress is
+	// joined from the operation's tasks by the renderer (see the design note's
+	// phase-source section).
+	Label string
+
+	// Emoji is the status glyph for the summary line.
+	Emoji string
+
+	// Open is the default expand/collapse for a details section: active or
+	// problematic deployments default open, completed/queued default collapsed.
+	Open bool
+
+	// Error is the operation's error detail when it failed, for the renderer to
+	// surface in the failed deployment's section.
+	Error string
+}
+
+// NextActionKind is the semantic operator action the aggregate suggests. The
+// derivation deliberately emits a semantic action plus its target deployment
+// rather than a CLI command string, so each surface formats the actual verb and
+// flags (and the verb set stays owned by the CLI, not duplicated here).
+type NextActionKind int
+
+const (
+	// NextActionNone means no operator action is pending.
+	NextActionNone NextActionKind = iota
+	// NextActionCutover means the operator should cut over Deployment.
+	NextActionCutover
+	// NextActionResume means a stopped apply should be resumed.
+	NextActionResume
+	// NextActionReviewFailure means the operator should review the failed
+	// Deployment before remediating.
+	NextActionReviewFailure
+)
+
+// NextAction is the aggregate's suggested next operator action.
+type NextAction struct {
+	Kind NextActionKind
+	// Deployment is the action's target, when the action is deployment-scoped.
+	Deployment string
+}
+
+// StateCount is one entry of the aggregate's per-status histogram.
+type StateCount struct {
+	Label string
+	Count int
+}
+
+// Apply is the surface-agnostic rollup for one logical apply.
+type Apply struct {
+	// State is the aggregate apply state derived from the child operation states
+	// via state.DeriveApplyState — the same projection that backs applies.state.
+	State string
+
+	// Label is the operator-facing aggregate status (e.g. "waiting for cutover").
+	Label string
+
+	// Counts is the per-status histogram in a stable display order, with zero
+	// entries omitted, so the operator sees rollout health without expanding.
+	Counts []StateCount
+
+	// NextAction is the suggested next operator action, if any.
+	NextAction NextAction
+
+	// Deployments are the per-deployment presentations in resolved deployment
+	// order (the order the caller supplies, which mirrors the rollout order).
+	Deployments []Deployment
+
+	// MultiDeployment is true when the apply owns more than one deployment. The
+	// single-deployment case (false) should render exactly as today's UX with no
+	// deployment hierarchy; the model is still populated for callers that want it.
+	MultiDeployment bool
+}
+
+// Derive projects the ordered operations of one apply into its rollup. The input
+// must be in resolved deployment order (as returned by ListByApply); earlier
+// siblings are those before a given index.
+func Derive(ops []Operation) Apply {
+	rawStates := make([]string, len(ops))
+	for i, op := range ops {
+		rawStates[i] = op.State
+	}
+
+	deployments := make([]Deployment, len(ops))
+	for i := range ops {
+		deployments[i] = deriveDeployment(ops, i)
+	}
+
+	aggState := state.DeriveApplyState(rawStates)
+	return Apply{
+		State:           aggState,
+		Label:           aggregateLabel(aggState),
+		Counts:          summaryCounts(deployments),
+		NextAction:      nextAction(aggState, deployments),
+		Deployments:     deployments,
+		MultiDeployment: len(ops) > 1,
+	}
+}
+
+// deriveDeployment projects operation i, using its earlier siblings for the
+// ordering context that disambiguates pending and waiting_for_cutover.
+func deriveDeployment(ops []Operation, i int) Deployment {
+	op := ops[i]
+	d := Deployment{Deployment: op.Deployment, State: op.State, Error: op.Error}
+
+	switch op.State {
+	case state.ApplyOperation.Completed:
+		d.set(StateCompleted, "completed", "✅", false)
+	case state.ApplyOperation.Running:
+		d.set(StateRunningCopy, "running table copy", "🔄", true)
+	case state.ApplyOperation.CuttingOver:
+		d.set(StateCuttingOver, "cutting over", "🔁", true)
+	case state.ApplyOperation.Failed:
+		d.set(StateFailed, "failed", "❌", true)
+	case state.ApplyOperation.FailedRetryable:
+		d.set(StateRetrying, "retrying", "🔁", true)
+	case state.ApplyOperation.Stopped:
+		d.set(StateStopped, "stopped — resume to continue", "⏸", true)
+	case state.ApplyOperation.RevertWindow:
+		d.set(StateRevertWindow, "in revert window", "⏳", true)
+	case state.ApplyOperation.Cancelled:
+		d.set(StateCancelled, "cancelled", "⛔", false)
+	case state.ApplyOperation.Reverted:
+		d.set(StateReverted, "reverted", "↩️", false)
+	case state.ApplyOperation.Pending:
+		derivePending(&d, ops, i)
+	case state.ApplyOperation.WaitingForCutover:
+		deriveWaitingForCutover(&d, ops, i)
+	default:
+		// Unknown / engine-specific transient state: show it verbatim and keep it
+		// open so an operator is never left without a status for a deployment.
+		d.set(StateUnknown, op.State, "", true)
+	}
+	return d
+}
+
+// derivePending splits a pending operation into next-in-order, waiting-on, or
+// halted, mirroring the pending sibling gate in FindNextApplyOperation so the
+// label agrees with what the operator will claim next.
+func derivePending(d *Deployment, ops []Operation, i int) {
+	op := ops[i]
+	if h := haltingBlocker(ops, i); h != nil {
+		d.set(StateHalted, fmt.Sprintf("halted — %s %s", h.Deployment, haltedReason(h.State)), "⏸", true)
+		return
+	}
+	for j := range i {
+		if blocksPending(ops[j].State, op.Barrier, op.HaltOnFailure) {
+			d.set(StateWaiting, fmt.Sprintf("waiting for %s", ops[j].Deployment), "⏳", false)
+			return
+		}
+	}
+	d.set(StateQueuedNext, "queued — next in order", "⏳", false)
+}
+
+// deriveWaitingForCutover splits a copied-and-parked operation into ready-now or
+// ready-but-waiting-on-an-earlier-cutover. Cutover ordering is strict-complete
+// and independent of cutover_policy, which only relaxes copy start.
+func deriveWaitingForCutover(d *Deployment, ops []Operation, i int) {
+	op := ops[i]
+	for j := range i {
+		if blocksCutover(ops[j].State, op.HaltOnFailure) {
+			d.set(StateReadyForCutoverWaiting, fmt.Sprintf("ready for cutover — waiting for %s", ops[j].Deployment), "🟡", true)
+			return
+		}
+	}
+	d.set(StateReadyForCutoverNext, "ready for cutover — next in order", "🟢", true)
+}
+
+// haltingBlocker returns the earliest earlier sibling that halts the rollout for
+// a pending operation: a terminal-failed sibling (only when halt_on_failure is
+// on) or a cancelled/reverted sibling (which halt regardless, matching the
+// predicate's lack of an exemption for them).
+func haltingBlocker(ops []Operation, i int) *Operation {
+	halt := ops[i].HaltOnFailure
+	for j := range i {
+		switch ops[j].State {
+		case state.ApplyOperation.Failed:
+			if halt {
+				return &ops[j]
+			}
+		case state.ApplyOperation.Cancelled, state.ApplyOperation.Reverted:
+			return &ops[j]
+		}
+	}
+	return nil
+}
+
+// blocksPending reports whether an earlier sibling in earlierState blocks a
+// pending operation from being claimed. It mirrors the SQL sibling gate in
+// FindNextApplyOperation exactly: the cutover_policy branch selects the
+// non-blocking set, then the halt_on_failure exemption is applied.
+func blocksPending(earlierState string, barrier, halt bool) bool {
+	var policyBlocks bool
+	if barrier {
+		policyBlocks = !isBarrierNonBlocking(earlierState)
+	} else {
+		policyBlocks = earlierState != state.ApplyOperation.Completed
+	}
+	if !policyBlocks {
+		return false
+	}
+	// halt_on_failure exemption: a terminal-failed earlier sibling stops blocking
+	// when the policy is off.
+	if !halt && earlierState == state.ApplyOperation.Failed {
+		return false
+	}
+	return true
+}
+
+// isBarrierNonBlocking reports whether an earlier sibling state is in the set
+// that, under cutover_policy=barrier, no longer blocks a later copy: it has
+// reached the cutover barrier or succeeded. This must match the IN-list in
+// FindNextApplyOperation's barrier branch (waiting_for_cutover, cutting_over,
+// revert_window, completed).
+func isBarrierNonBlocking(s string) bool {
+	switch s {
+	case state.ApplyOperation.WaitingForCutover,
+		state.ApplyOperation.CuttingOver,
+		state.ApplyOperation.RevertWindow,
+		state.ApplyOperation.Completed:
+		return true
+	default:
+		return false
+	}
+}
+
+// blocksCutover reports whether an earlier sibling in earlierState blocks a
+// later deployment's ordered cutover. Cutover is strictly ordered: an earlier
+// sibling blocks until it is completed, except a terminal-failed sibling under
+// halt_on_failure=false, which the rollout is configured to continue past.
+func blocksCutover(earlierState string, halt bool) bool {
+	if earlierState == state.ApplyOperation.Completed {
+		return false
+	}
+	if earlierState == state.ApplyOperation.Failed && !halt {
+		return false
+	}
+	return true
+}
+
+// haltedReason returns the deployment-facing reason word for a halting blocker.
+func haltedReason(blockerState string) string {
+	switch blockerState {
+	case state.ApplyOperation.Failed:
+		return "failed"
+	case state.ApplyOperation.Cancelled:
+		return "cancelled"
+	case state.ApplyOperation.Reverted:
+		return "reverted"
+	default:
+		return blockerState
+	}
+}
+
+// aggregateLabel glosses the derived aggregate state into an operator-facing
+// status word.
+func aggregateLabel(s string) string {
+	switch s {
+	case state.Apply.Pending:
+		return "queued"
+	case state.Apply.Running:
+		return "running"
+	case state.Apply.WaitingForDeploy:
+		return "waiting for deploy"
+	case state.Apply.WaitingForCutover:
+		return "waiting for cutover"
+	case state.Apply.CuttingOver:
+		return "cutting over"
+	case state.Apply.RevertWindow:
+		return "in revert window"
+	case state.Apply.Completed:
+		return "completed"
+	case state.Apply.Failed:
+		return "failed"
+	case state.Apply.FailedRetryable:
+		return "retrying"
+	case state.Apply.Stopped:
+		return "stopped"
+	case state.Apply.Cancelled:
+		return "cancelled"
+	case state.Apply.Reverted:
+		return "reverted"
+	default:
+		return s
+	}
+}
+
+// nextAction derives the aggregate's suggested operator action from the
+// aggregate state and the per-deployment presentations, in operator-priority
+// order: a failure to review, then a stop to resume, then an available cutover.
+func nextAction(aggState string, deps []Deployment) NextAction {
+	// A failed rollout is fail-closed: review the failure before anything else,
+	// even if an earlier deployment is sitting ready for cutover.
+	if aggState == state.Apply.Failed {
+		if d, ok := firstWithState(deps, state.ApplyOperation.Failed); ok {
+			return NextAction{Kind: NextActionReviewFailure, Deployment: d.Deployment}
+		}
+		return NextAction{Kind: NextActionReviewFailure}
+	}
+	// A deliberately stopped rollout resumes before any cutover is offered.
+	if aggState == state.Apply.Stopped {
+		return NextAction{Kind: NextActionResume}
+	}
+	// A deployment that is next in order for cutover is actionable even while the
+	// aggregate is still running — an earlier deployment can cut over while a
+	// later one is still copying (waiting_for_cutover does not roll the aggregate
+	// up until every deployment has reached it). This covers both the
+	// waiting_for_cutover aggregate and the running-with-one-ready case.
+	if d, ok := firstWithPresentation(deps, StateReadyForCutoverNext); ok {
+		return NextAction{Kind: NextActionCutover, Deployment: d.Deployment}
+	}
+	return NextAction{Kind: NextActionNone}
+}
+
+// summaryCategoryOrder is the stable display order for the aggregate histogram.
+var summaryCategoryOrder = []struct {
+	label  string
+	states []PresentationState
+}{
+	{"completed", []PresentationState{StateCompleted}},
+	{"cutting over", []PresentationState{StateCuttingOver}},
+	{"ready for cutover", []PresentationState{StateReadyForCutoverNext, StateReadyForCutoverWaiting}},
+	{"running", []PresentationState{StateRunningCopy}},
+	{"waiting", []PresentationState{StateWaiting}},
+	{"queued", []PresentationState{StateQueuedNext}},
+	{"halted", []PresentationState{StateHalted}},
+	{"failed", []PresentationState{StateFailed}},
+	{"retrying", []PresentationState{StateRetrying}},
+	{"stopped", []PresentationState{StateStopped}},
+	{"in revert window", []PresentationState{StateRevertWindow}},
+	{"cancelled", []PresentationState{StateCancelled}},
+	{"reverted", []PresentationState{StateReverted}},
+	{"unknown", []PresentationState{StateUnknown}},
+}
+
+// summaryCounts builds the per-status histogram in summaryCategoryOrder, omitting
+// zero entries.
+func summaryCounts(deps []Deployment) []StateCount {
+	tally := make(map[PresentationState]int, len(deps))
+	for _, d := range deps {
+		tally[d.Presentation]++
+	}
+	var counts []StateCount
+	for _, cat := range summaryCategoryOrder {
+		n := 0
+		for _, ps := range cat.states {
+			n += tally[ps]
+		}
+		if n > 0 {
+			counts = append(counts, StateCount{Label: cat.label, Count: n})
+		}
+	}
+	return counts
+}
+
+func firstWithState(deps []Deployment, s string) (Deployment, bool) {
+	for _, d := range deps {
+		if d.State == s {
+			return d, true
+		}
+	}
+	return Deployment{}, false
+}
+
+func firstWithPresentation(deps []Deployment, ps PresentationState) (Deployment, bool) {
+	for _, d := range deps {
+		if d.Presentation == ps {
+			return d, true
+		}
+	}
+	return Deployment{}, false
+}
+
+func (d *Deployment) set(ps PresentationState, label, emoji string, open bool) {
+	d.Presentation = ps
+	d.Label = label
+	d.Emoji = emoji
+	d.Open = open
+}

--- a/pkg/presentation/presentation_test.go
+++ b/pkg/presentation/presentation_test.go
@@ -27,14 +27,14 @@ func TestDerive_Empty(t *testing.T) {
 	got := Derive(nil)
 	assert.Equal(t, state.Apply.Pending, got.State)
 	assert.Empty(t, got.Deployments)
-	assert.False(t, got.MultiDeployment)
+	assert.False(t, got.MultiDeployment())
 }
 
 // TestDerive_SingleDeployment: one operation is never flagged multi-deployment,
 // and the aggregate equals the single operation's state.
 func TestDerive_SingleDeployment(t *testing.T) {
 	got := Derive([]Operation{rolling("eu", so.Running)})
-	assert.False(t, got.MultiDeployment)
+	assert.False(t, got.MultiDeployment())
 	assert.Equal(t, state.Apply.Running, got.State)
 	require.Len(t, got.Deployments, 1)
 	assert.Equal(t, StateRunningCopy, got.Deployments[0].Presentation)
@@ -215,7 +215,7 @@ func TestDerive_AggregateBarrierWorkedExample(t *testing.T) {
 		barrier("ca", so.Pending),
 	})
 
-	assert.True(t, got.MultiDeployment)
+	assert.True(t, got.MultiDeployment())
 	assert.Equal(t, state.Apply.Running, got.State)
 	assert.Equal(t, "running", got.Label)
 

--- a/pkg/presentation/presentation_test.go
+++ b/pkg/presentation/presentation_test.go
@@ -1,0 +1,299 @@
+package presentation
+
+import (
+	"testing"
+
+	"github.com/block/schemabot/pkg/state"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// so is the shared operation/apply state vocabulary (state.ApplyOperation == state.Apply).
+var so = state.ApplyOperation
+
+// rolling builds a rolling, halt-on-failure operation (the conservative defaults).
+func rolling(dep, st string) Operation {
+	return Operation{Deployment: dep, State: st, Barrier: false, HaltOnFailure: true}
+}
+
+// barrier builds a barrier, halt-on-failure operation.
+func barrier(dep, st string) Operation {
+	return Operation{Deployment: dep, State: st, Barrier: true, HaltOnFailure: true}
+}
+
+// TestDerive_Empty: an apply with no operations rolls up to pending with no
+// deployments and is not treated as multi-deployment.
+func TestDerive_Empty(t *testing.T) {
+	got := Derive(nil)
+	assert.Equal(t, state.Apply.Pending, got.State)
+	assert.Empty(t, got.Deployments)
+	assert.False(t, got.MultiDeployment)
+}
+
+// TestDerive_SingleDeployment: one operation is never flagged multi-deployment,
+// and the aggregate equals the single operation's state.
+func TestDerive_SingleDeployment(t *testing.T) {
+	got := Derive([]Operation{rolling("eu", so.Running)})
+	assert.False(t, got.MultiDeployment)
+	assert.Equal(t, state.Apply.Running, got.State)
+	require.Len(t, got.Deployments, 1)
+	assert.Equal(t, StateRunningCopy, got.Deployments[0].Presentation)
+}
+
+// TestDeriveDeployment_StateLabels: each operation state with no blocking
+// siblings maps to its expected presentation state, label, emoji, and default
+// expand/collapse.
+func TestDeriveDeployment_StateLabels(t *testing.T) {
+	cases := []struct {
+		state string
+		want  PresentationState
+		label string
+		emoji string
+		open  bool
+	}{
+		{so.Completed, StateCompleted, "completed", "✅", false},
+		{so.Running, StateRunningCopy, "running table copy", "🔄", true},
+		{so.CuttingOver, StateCuttingOver, "cutting over", "🔁", true},
+		{so.Failed, StateFailed, "failed", "❌", true},
+		{so.FailedRetryable, StateRetrying, "retrying", "🔁", true},
+		{so.Stopped, StateStopped, "stopped — resume to continue", "⏸", true},
+		{so.RevertWindow, StateRevertWindow, "in revert window", "⏳", true},
+		{so.Cancelled, StateCancelled, "cancelled", "⛔", false},
+		{so.Reverted, StateReverted, "reverted", "↩️", false},
+		{"some_engine_state", StateUnknown, "some_engine_state", "", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.state, func(t *testing.T) {
+			// Single op so there are no earlier siblings to add ordering context.
+			d := Derive([]Operation{rolling("eu", tc.state)}).Deployments[0]
+			assert.Equal(t, tc.want, d.Presentation)
+			assert.Equal(t, tc.label, d.Label)
+			assert.Equal(t, tc.emoji, d.Emoji)
+			assert.Equal(t, tc.open, d.Open)
+		})
+	}
+}
+
+// TestDerivePending_Ordering: a pending operation's label depends on its earlier
+// siblings and the rollout policy, mirroring the claim predicate's sibling gate.
+func TestDerivePending_Ordering(t *testing.T) {
+	cases := []struct {
+		name  string
+		ops   []Operation
+		want  PresentationState
+		label string
+	}{
+		{
+			name:  "rolling: earlier completed -> next in order",
+			ops:   []Operation{rolling("eu", so.Completed), rolling("us", so.Pending)},
+			want:  StateQueuedNext,
+			label: "queued — next in order",
+		},
+		{
+			name:  "rolling: earlier running -> waiting for it",
+			ops:   []Operation{rolling("eu", so.Running), rolling("us", so.Pending)},
+			want:  StateWaiting,
+			label: "waiting for eu",
+		},
+		{
+			name:  "rolling: earlier at barrier still blocks (serial)",
+			ops:   []Operation{rolling("eu", so.WaitingForCutover), rolling("us", so.Pending)},
+			want:  StateWaiting,
+			label: "waiting for eu",
+		},
+		{
+			name:  "barrier: earlier at barrier no longer blocks copy start",
+			ops:   []Operation{barrier("eu", so.WaitingForCutover), barrier("us", so.Pending)},
+			want:  StateQueuedNext,
+			label: "queued — next in order",
+		},
+		{
+			name:  "barrier: earlier in revert_window no longer blocks copy start",
+			ops:   []Operation{barrier("eu", so.RevertWindow), barrier("us", so.Pending)},
+			want:  StateQueuedNext,
+			label: "queued — next in order",
+		},
+		{
+			name:  "barrier: earlier still copying blocks",
+			ops:   []Operation{barrier("eu", so.Running), barrier("us", so.Pending)},
+			want:  StateWaiting,
+			label: "waiting for eu",
+		},
+		{
+			name:  "halt: earlier failed halts the rollout",
+			ops:   []Operation{rolling("eu", so.Failed), rolling("us", so.Pending)},
+			want:  StateHalted,
+			label: "halted — eu failed",
+		},
+		{
+			name: "no-halt: earlier failed no longer blocks",
+			ops: []Operation{
+				{Deployment: "eu", State: so.Failed, HaltOnFailure: false},
+				{Deployment: "us", State: so.Pending, HaltOnFailure: false},
+			},
+			want:  StateQueuedNext,
+			label: "queued — next in order",
+		},
+		{
+			name:  "cancelled earlier halts regardless of halt flag",
+			ops:   []Operation{{Deployment: "eu", State: so.Cancelled, HaltOnFailure: false}, {Deployment: "us", State: so.Pending, HaltOnFailure: false}},
+			want:  StateHalted,
+			label: "halted — eu cancelled",
+		},
+		{
+			name:  "halt naming picks the failed sibling over an in-flight one",
+			ops:   []Operation{rolling("eu", so.Failed), rolling("us", so.Running), rolling("au", so.Pending)},
+			want:  StateHalted,
+			label: "halted — eu failed",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			deps := Derive(tc.ops).Deployments
+			last := deps[len(deps)-1]
+			assert.Equal(t, tc.want, last.Presentation)
+			assert.Equal(t, tc.label, last.Label)
+		})
+	}
+}
+
+// TestDeriveWaitingForCutover_Ordering: cutover stays strictly ordered (an
+// earlier sibling blocks until completed) regardless of cutover_policy, since
+// the policy only relaxes copy start.
+func TestDeriveWaitingForCutover_Ordering(t *testing.T) {
+	cases := []struct {
+		name  string
+		ops   []Operation
+		want  PresentationState
+		label string
+	}{
+		{
+			name:  "earlier completed -> ready, next in order",
+			ops:   []Operation{rolling("eu", so.Completed), rolling("us", so.WaitingForCutover)},
+			want:  StateReadyForCutoverNext,
+			label: "ready for cutover — next in order",
+		},
+		{
+			name:  "earlier still copying -> ready, waiting for it",
+			ops:   []Operation{rolling("eu", so.Running), rolling("us", so.WaitingForCutover)},
+			want:  StateReadyForCutoverWaiting,
+			label: "ready for cutover — waiting for eu",
+		},
+		{
+			name:  "barrier: earlier also at barrier still blocks cutover (cutover stays ordered)",
+			ops:   []Operation{barrier("eu", so.WaitingForCutover), barrier("us", so.WaitingForCutover)},
+			want:  StateReadyForCutoverWaiting,
+			label: "ready for cutover — waiting for eu",
+		},
+		{
+			name: "no-halt: earlier failed does not block cutover (rollout continues past it)",
+			ops: []Operation{
+				{Deployment: "eu", State: so.Failed, HaltOnFailure: false},
+				{Deployment: "us", State: so.WaitingForCutover, HaltOnFailure: false},
+			},
+			want:  StateReadyForCutoverNext,
+			label: "ready for cutover — next in order",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			last := Derive(tc.ops).Deployments[1]
+			assert.Equal(t, tc.want, last.Presentation)
+			assert.Equal(t, tc.label, last.Label)
+		})
+	}
+}
+
+// TestDerive_AggregateBarrierWorkedExample: the design note's barrier worked
+// example — eu at the barrier, us copying, au and ca waiting — rolls up to a
+// running aggregate with a cutover next-action on eu and a per-status histogram.
+func TestDerive_AggregateBarrierWorkedExample(t *testing.T) {
+	got := Derive([]Operation{
+		barrier("eu", so.WaitingForCutover),
+		barrier("us", so.Running),
+		barrier("au", so.Pending),
+		barrier("ca", so.Pending),
+	})
+
+	assert.True(t, got.MultiDeployment)
+	assert.Equal(t, state.Apply.Running, got.State)
+	assert.Equal(t, "running", got.Label)
+
+	// eu ready (next), us running, au waiting on us, ca waiting on au.
+	assert.Equal(t, StateReadyForCutoverNext, got.Deployments[0].Presentation)
+	assert.Equal(t, StateRunningCopy, got.Deployments[1].Presentation)
+	assert.Equal(t, StateWaiting, got.Deployments[2].Presentation)
+	assert.Equal(t, "waiting for us", got.Deployments[2].Label)
+	// ca names the earliest blocking sibling (us, still copying), not its
+	// immediate predecessor au: under barrier eu is non-blocking and au is itself
+	// pending, so the deployment whose progress unblocks the line is us — the same
+	// one the claim predicate is gated on.
+	assert.Equal(t, StateWaiting, got.Deployments[3].Presentation)
+	assert.Equal(t, "waiting for us", got.Deployments[3].Label)
+
+	assert.Equal(t, NextAction{Kind: NextActionCutover, Deployment: "eu"}, got.NextAction)
+	assert.Equal(t, []StateCount{
+		{Label: "ready for cutover", Count: 1},
+		{Label: "running", Count: 1},
+		{Label: "waiting", Count: 2},
+	}, got.Counts)
+}
+
+// TestDerive_AggregateFailedHaltExample: with halt_on_failure on, a failed
+// deployment halts the rest; the aggregate stays failed (fail-closed) and points
+// the operator at the failed deployment.
+func TestDerive_AggregateFailedHaltExample(t *testing.T) {
+	got := Derive([]Operation{
+		rolling("eu", so.WaitingForCutover),
+		rolling("us", so.Failed),
+		rolling("au", so.Pending),
+		rolling("ca", so.Pending),
+	})
+
+	assert.Equal(t, state.Apply.Failed, got.State)
+	assert.Equal(t, "failed", got.Label)
+	assert.Equal(t, NextAction{Kind: NextActionReviewFailure, Deployment: "us"}, got.NextAction)
+	assert.Equal(t, StateHalted, got.Deployments[2].Presentation)
+	assert.Equal(t, "halted — us failed", got.Deployments[2].Label)
+	assert.Equal(t, StateHalted, got.Deployments[3].Presentation)
+}
+
+// TestDerive_CompletedWithOneFailedDeployment: under halt_on_failure=false the
+// rollout continues, so other deployments complete, but the aggregate stays
+// failed (the G3 render-half decision).
+func TestDerive_CompletedWithOneFailedDeployment(t *testing.T) {
+	got := Derive([]Operation{
+		{Deployment: "eu", State: so.Completed, HaltOnFailure: false},
+		{Deployment: "us", State: so.Completed, HaltOnFailure: false},
+		{Deployment: "au", State: so.Failed, HaltOnFailure: false},
+		{Deployment: "ca", State: so.Completed, HaltOnFailure: false},
+	})
+
+	assert.Equal(t, state.Apply.Failed, got.State)
+	assert.Equal(t, StateFailed, got.Deployments[2].Presentation)
+	assert.Equal(t, []StateCount{
+		{Label: "completed", Count: 3},
+		{Label: "failed", Count: 1},
+	}, got.Counts)
+}
+
+// TestDerive_StoppedAggregateNextAction: a stopped deployment makes the aggregate
+// stopped and suggests resuming.
+func TestDerive_StoppedAggregateNextAction(t *testing.T) {
+	got := Derive([]Operation{
+		rolling("eu", so.Completed),
+		rolling("us", so.Stopped),
+	})
+	assert.Equal(t, state.Apply.Stopped, got.State)
+	assert.Equal(t, NextAction{Kind: NextActionResume}, got.NextAction)
+}
+
+// TestDerive_FailedDeploymentCarriesError: the failed deployment surfaces its
+// error detail for the renderer.
+func TestDerive_FailedDeploymentCarriesError(t *testing.T) {
+	got := Derive([]Operation{
+		{Deployment: "eu", State: so.Failed, HaltOnFailure: true, Error: "lock wait timeout"},
+	})
+	require.Len(t, got.Deployments, 1)
+	assert.Equal(t, "lock wait timeout", got.Deployments[0].Error)
+}


### PR DESCRIPTION
## Summary

Adds a `pkg/presentation` primitive that derives the user-facing rollup for a multi-deployment apply from its `apply_operations` rows. It is surface-agnostic — both the PR comment renderer and the Admin CLI can build their output from the same ordered model, so the aggregate header, per-deployment labels, ordering context, and default expand/collapse are computed once and stay consistent everywhere.

The derivation adds no persisted state. Labels such as `halted`, `ready for cutover — waiting for <deployment>`, and `queued — next in order` are projections of `(operation state, earlier-sibling states, resolved order, cutover_policy, halt_on_failure)`. The ordering and blocking context is derived from the same gate the claim predicate evaluates, so the presentation never contradicts what the operator will actually claim next.

```diagram
 apply_operations rows ─┬─► DeriveApplyState ──────► aggregate state · label · counts · next-action
 (resolved order)       │
                        └─► per-row + sibling gate ─► per-deployment label · emoji · open/collapsed
   cutover_policy, halt_on_failure ──────────────────┘   (mirrors the claim predicate)
```

This slice is dormant: no callers yet. A single-deployment apply will continue to render exactly as today.

Key behaviors:
- Single-deployment applies are never flagged multi-deployment — UX is unchanged.
- A pending deployment resolves to `queued — next in order`, `waiting for <earlier>`, or `halted — <earlier> failed`, mirroring the rolling/barrier sibling gate and the `halt_on_failure` exemption.
- Cutover stays strictly ordered (policy only relaxes copy start); a deployment ready for cutover surfaces a cutover next-action even while the aggregate is still running.
- The aggregate is fail-closed via the existing state derivation: any failed deployment keeps the rollup failed.

## Why a separate `presentation` package

There are already two presentation layers, but neither is the right home for the multi-deployment *model*:

- `pkg/ui` — low-level formatting primitives (number formatting, progress bars, color emojis). No domain logic.
- `pkg/webhook/templates` — the GitHub-markdown renderer (`RenderApplyStatusComment`). It produces PR-comment markdown and lives under `pkg/webhook` (GitHub-specific).
- The CLI renders its own text output under `pkg/cmd/commands`.

What was missing is the layer *between* storage and those renderers: the semantic derivation (aggregate rollup, per-deployment labels, ordering context, halted/next-action, open/collapse) that must be identical across the PR comment and the CLI, and must stay in lockstep with the claim predicate. It produces no markdown.

```diagram
 storage rows ─► pkg/presentation ─┬─► pkg/webhook/templates  (GitHub markdown)
 (derive model, no markdown)       └─► pkg/cmd/commands       (CLI text)
                                       both use pkg/ui for low-level formatting
```

It deliberately does not live in `pkg/webhook/templates` because the CLI must not import `pkg/webhook` just to render status; nor in `pkg/ui` (formatting primitives, not domain derivation); nor in `pkg/state` (intentionally a minimal, pure state vocabulary). A small dedicated package is the correct seam: `templates` and the CLI become thin renderers over one shared, predicate-faithful model.

## Roadmap

This is the first of a small series that turns the multi-deployment apply into a first-class PR/CLI experience. Each lands independently behind the existing single-deployment behavior:

```diagram
 [this PR] derivation primitive   surface-agnostic rollup model (no callers)
    |
    +-- PR comment renderer       render the aggregate header + per-deployment
    |                             details behind the single<->multi threshold
    |                             (one deployment => today's UX verbatim)
    |
    +-- CLI presentation          status output renders from the same model,
    |                             same resolved order as the PR comment
    |
    +-- per-deployment controls   manual cutover + per-deployment action verbs
                                  (the next-action lines this model names)
```

- **This PR** — the neutral model. No behavior change.
- **PR comment renderer** — consume the model in `pkg/webhook` to show an aggregate summary plus per-deployment `<details>`, gated on the apply's own operation-row count so single-deployment applies are untouched.
- **CLI presentation** — render the same model in the Admin CLI status path, in resolved deployment order, so both surfaces agree.
- **Per-deployment controls** — manual cutover and the per-deployment action verbs the next-action lines reference.

