### PR TITLE
feat(config): add on_failure enum for rollout continuation

### DIFF
--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -467,15 +467,17 @@ type EnvironmentConfig struct {
 	// Only meaningful alongside a Deployments map.
 	CutoverPolicy string `yaml:"cutover_policy,omitempty"`
 
-	// HaltOnFailure controls multi-deployment rollout behaviour when a
-	// deployment fails. When true or unset (the default), a failed deployment
-	// halts the rollout — later deployments in deployment_order are not started.
-	// When false, a failed deployment no longer blocks later deployments, so
-	// the rollout attempts every deployment instead of stopping at the first
-	// failure. It governs only rollout continuation; the apply's pass/fail
-	// verdict and the merge gate stay fail-closed on any failed deployment.
-	// Only meaningful alongside a Deployments map.
-	HaltOnFailure *bool `yaml:"halt_on_failure,omitempty"`
+	// OnFailure controls multi-deployment rollout continuation when a deployment
+	// terminally fails. "halt" (the default, also used when unset) stops the
+	// rollout — later deployments in deployment_order are not started. "continue"
+	// drops a terminal-failed deployment as a blocker so the rollout attempts
+	// every deployment instead of stopping at the first failure. "pause" is a
+	// known value reserved for a future release-gate behaviour and is rejected
+	// at validation until that machinery lands. It governs only rollout
+	// continuation; the apply's pass/fail verdict and the merge gate stay
+	// fail-closed on any failed deployment. Only meaningful alongside a
+	// Deployments map.
+	OnFailure string `yaml:"on_failure,omitempty"`
 
 	// For PlanetScale/Vitess:
 	// Organization is the PlanetScale organization name.
@@ -666,8 +668,17 @@ func (c *ServerConfig) Validate() error {
 					return fmt.Errorf("database %q environment %q has invalid cutover_policy %q (want %q or %q)", name, env, envConfig.CutoverPolicy, storage.CutoverPolicyRolling, storage.CutoverPolicyBarrier)
 				}
 			}
-			if envConfig.HaltOnFailure != nil && !hasMapRouting {
-				return fmt.Errorf("database %q environment %q sets halt_on_failure without a deployments map", name, env)
+			if envConfig.OnFailure != "" {
+				if !hasMapRouting {
+					return fmt.Errorf("database %q environment %q sets on_failure without a deployments map", name, env)
+				}
+				switch envConfig.OnFailure {
+				case storage.OnFailureHalt, storage.OnFailureContinue:
+				case storage.OnFailurePause:
+					return fmt.Errorf("database %q environment %q sets on_failure %q which is not yet supported; use %q or %q", name, env, storage.OnFailurePause, storage.OnFailureHalt, storage.OnFailureContinue)
+				default:
+					return fmt.Errorf("database %q environment %q has invalid on_failure %q (want %q or %q)", name, env, envConfig.OnFailure, storage.OnFailureHalt, storage.OnFailureContinue)
+				}
 			}
 			switch {
 			case hasDSN && (hasScalarRouting || hasMapRouting):
@@ -932,16 +943,16 @@ func (c *ServerConfig) CutoverPolicyFor(database, environment string) string {
 	return env.CutoverPolicy
 }
 
-// HaltOnFailureEnabled reports whether a failed deployment should halt the
-// rollout of later deployments for this database+environment. Defaults to true
-// (halt) when the environment is unconfigured or leaves halt_on_failure unset,
-// preserving stop-at-first-failure as the safe default.
-func (c *ServerConfig) HaltOnFailureEnabled(database, environment string) bool {
+// OnFailure returns the resolved rollout-continuation policy for a
+// database+environment. It defaults to OnFailureHalt when the environment is
+// unconfigured or leaves on_failure unset, preserving stop-at-first-failure as
+// the safe default.
+func (c *ServerConfig) OnFailure(database, environment string) string {
 	env := c.DatabaseEnvironment(database, environment)
-	if env == nil || env.HaltOnFailure == nil {
-		return true
+	if env == nil || env.OnFailure == "" {
+		return storage.OnFailureHalt
 	}
-	return *env.HaltOnFailure
+	return env.OnFailure
 }
 
 // DatabaseEnvironments returns the environments configured server-side for a

--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -20,28 +20,28 @@ import (
 	"github.com/block/schemabot/pkg/storage"
 )
 
-// TestServerConfig_HaltOnFailureEnabled verifies the rollout-policy resolver:
-// it defaults to halting (true) when unset or unconfigured, and honours an
-// explicit false so a failed deployment no longer halts later ones.
-func TestServerConfig_HaltOnFailureEnabled(t *testing.T) {
+// TestServerConfig_OnFailure verifies the rollout-continuation resolver: it
+// defaults to halt when unset or unconfigured, and honours an explicit
+// continue so a terminal-failed deployment no longer halts later ones.
+func TestServerConfig_OnFailure(t *testing.T) {
 	cfg := &ServerConfig{
 		Databases: map[string]DatabaseConfig{
 			"payments": {
 				Type: "mysql",
 				Environments: map[string]EnvironmentConfig{
-					"halt-unset": {Target: "payments", Deployment: "payments-a"},
-					"halt-true":  {Deployments: map[string]DeploymentTarget{"payments-a": {Target: "payments"}}, HaltOnFailure: new(true)},
-					"halt-false": {Deployments: map[string]DeploymentTarget{"payments-a": {Target: "payments"}}, HaltOnFailure: new(false)},
+					"unset":    {Target: "payments", Deployment: "payments-a"},
+					"halt":     {Deployments: map[string]DeploymentTarget{"payments-a": {Target: "payments"}}, OnFailure: storage.OnFailureHalt},
+					"continue": {Deployments: map[string]DeploymentTarget{"payments-a": {Target: "payments"}}, OnFailure: storage.OnFailureContinue},
 				},
 			},
 		},
 	}
 
-	assert.True(t, cfg.HaltOnFailureEnabled("payments", "halt-unset"), "unset defaults to halting")
-	assert.True(t, cfg.HaltOnFailureEnabled("payments", "halt-true"), "explicit true halts")
-	assert.False(t, cfg.HaltOnFailureEnabled("payments", "halt-false"), "explicit false does not halt")
-	assert.True(t, cfg.HaltOnFailureEnabled("payments", "missing-env"), "unconfigured env defaults to halting")
-	assert.True(t, cfg.HaltOnFailureEnabled("missing-db", "halt-false"), "unconfigured database defaults to halting")
+	assert.Equal(t, storage.OnFailureHalt, cfg.OnFailure("payments", "unset"), "unset defaults to halting")
+	assert.Equal(t, storage.OnFailureHalt, cfg.OnFailure("payments", "halt"), "explicit halt halts")
+	assert.Equal(t, storage.OnFailureContinue, cfg.OnFailure("payments", "continue"), "explicit continue does not halt")
+	assert.Equal(t, storage.OnFailureHalt, cfg.OnFailure("payments", "missing-env"), "unconfigured env defaults to halting")
+	assert.Equal(t, storage.OnFailureHalt, cfg.OnFailure("missing-db", "continue"), "unconfigured database defaults to halting")
 }
 
 func TestLoadServerConfig(t *testing.T) {
@@ -1409,24 +1409,56 @@ func TestServerConfig_DeploymentsMapValidation(t *testing.T) {
 			tern: baseTern,
 		},
 		{
-			name: "halt_on_failure without a deployments map is rejected",
+			name: "on_failure without a deployments map is rejected",
 			envConfig: EnvironmentConfig{
-				Target:        "payments",
-				Deployment:    "payments-a",
-				HaltOnFailure: new(false),
+				Target:     "payments",
+				Deployment: "payments-a",
+				OnFailure:  storage.OnFailureContinue,
 			},
 			tern:       baseTern,
-			wantErrSub: "sets halt_on_failure without a deployments map",
+			wantErrSub: "sets on_failure without a deployments map",
 		},
 		{
-			name: "halt_on_failure with a deployments map is accepted",
+			name: "on_failure halt with a deployments map is accepted",
 			envConfig: EnvironmentConfig{
 				Deployments: map[string]DeploymentTarget{
 					"payments-a": {Target: "payments"},
 				},
-				HaltOnFailure: new(false),
+				OnFailure: storage.OnFailureHalt,
 			},
 			tern: baseTern,
+		},
+		{
+			name: "on_failure continue with a deployments map is accepted",
+			envConfig: EnvironmentConfig{
+				Deployments: map[string]DeploymentTarget{
+					"payments-a": {Target: "payments"},
+				},
+				OnFailure: storage.OnFailureContinue,
+			},
+			tern: baseTern,
+		},
+		{
+			name: "invalid on_failure value is rejected",
+			envConfig: EnvironmentConfig{
+				Deployments: map[string]DeploymentTarget{
+					"payments-a": {Target: "payments"},
+				},
+				OnFailure: "warp-speed",
+			},
+			tern:       baseTern,
+			wantErrSub: `invalid on_failure "warp-speed"`,
+		},
+		{
+			name: "on_failure pause is rejected as not yet supported",
+			envConfig: EnvironmentConfig{
+				Deployments: map[string]DeploymentTarget{
+					"payments-a": {Target: "payments"},
+				},
+				OnFailure: storage.OnFailurePause,
+			},
+			tern:       baseTern,
+			wantErrSub: `sets on_failure "pause" which is not yet supported`,
 		},
 	}
 

--- a/pkg/api/plan_handlers.go
+++ b/pkg/api/plan_handlers.go
@@ -669,13 +669,13 @@ func (s *Service) createStoredApply(
 	// routing. The data shape is what the operator claim-loop PR consumes
 	// once that gate is lifted and plans become deployment-agnostic.
 	cutoverPolicy := s.config.CutoverPolicyFor(plan.Database, req.Environment)
-	haltOnFailure := s.config.HaltOnFailureEnabled(plan.Database, req.Environment)
+	onFailure := s.config.OnFailure(plan.Database, req.Environment)
 	operations := []*storage.ApplyOperation{{
 		Deployment:    apply.Deployment,
 		Target:        plan.Target,
 		State:         state.ApplyOperation.Pending,
 		CutoverPolicy: cutoverPolicy,
-		HaltOnFailure: &haltOnFailure,
+		OnFailure:     onFailure,
 		CreatedAt:     now,
 		UpdatedAt:     now,
 	}}

--- a/pkg/schema/mysql/apply_operations.sql
+++ b/pkg/schema/mysql/apply_operations.sql
@@ -8,6 +8,7 @@ CREATE TABLE `apply_operations` (
   `state` varchar(100) NOT NULL DEFAULT 'pending',
   `error_message` text,
   `cutover_policy` varchar(16) NOT NULL DEFAULT 'rolling',
+  `halt_on_failure` tinyint(1) NOT NULL DEFAULT '1',
   `on_failure` varchar(16) NOT NULL DEFAULT 'halt',
   `lease_owner` varchar(255) NOT NULL DEFAULT '',
   `lease_token` varchar(64) NOT NULL DEFAULT '',

--- a/pkg/schema/mysql/apply_operations.sql
+++ b/pkg/schema/mysql/apply_operations.sql
@@ -8,7 +8,7 @@ CREATE TABLE `apply_operations` (
   `state` varchar(100) NOT NULL DEFAULT 'pending',
   `error_message` text,
   `cutover_policy` varchar(16) NOT NULL DEFAULT 'rolling',
-  `halt_on_failure` tinyint(1) NOT NULL DEFAULT '1',
+  `on_failure` varchar(16) NOT NULL DEFAULT 'halt',
   `lease_owner` varchar(255) NOT NULL DEFAULT '',
   `lease_token` varchar(64) NOT NULL DEFAULT '',
   `lease_acquired_at` datetime DEFAULT NULL,

--- a/pkg/storage/mysqlstore/apply_operations.go
+++ b/pkg/storage/mysqlstore/apply_operations.go
@@ -20,7 +20,7 @@ import (
 
 // applyOperationColumns lists all columns for SELECT queries.
 const applyOperationColumns = `id, apply_id, deployment, target, state, error_message,
-	cutover_policy, halt_on_failure, started_at, completed_at, lease_owner, lease_token, lease_acquired_at,
+	cutover_policy, on_failure, started_at, completed_at, lease_owner, lease_token, lease_acquired_at,
 	engine_resume_context, engine_resume_metadata, created_at, updated_at`
 
 // mysqlErrDupEntry is MySQL's error number for a duplicate-key violation.
@@ -64,21 +64,22 @@ func insertApplyOperation(ctx context.Context, exec sqlExecer, ad *storage.Apply
 		cutoverPolicy = storage.CutoverPolicyRolling
 	}
 
-	// nil policy means the caller did not resolve a halt_on_failure preference,
+	// An empty policy means the caller did not resolve an on_failure preference,
 	// so fall back to halting — the safe default that matches the column's
-	// NOT NULL DEFAULT 1 and never silently degrades to non-halting behaviour.
-	haltOnFailure := true
-	if ad.HaltOnFailure != nil {
-		haltOnFailure = *ad.HaltOnFailure
+	// NOT NULL DEFAULT 'halt' and never silently degrades to non-halting
+	// behaviour.
+	onFailure := ad.OnFailure
+	if onFailure == "" {
+		onFailure = storage.OnFailureHalt
 	}
 
 	result, err := exec.ExecContext(ctx, `
 		INSERT INTO apply_operations (
-			apply_id, deployment, target, state, error_message, cutover_policy, halt_on_failure,
+			apply_id, deployment, target, state, error_message, cutover_policy, on_failure,
 			started_at, completed_at, engine_resume_context, engine_resume_metadata
 		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`,
-		ad.ApplyID, ad.Deployment, ad.Target, stateVal, nullString(ad.ErrorMessage), cutoverPolicy, haltOnFailure,
+		ad.ApplyID, ad.Deployment, ad.Target, stateVal, nullString(ad.ErrorMessage), cutoverPolicy, onFailure,
 		ad.StartedAt, ad.CompletedAt, nullString(ad.EngineResumeContext), nullString(ad.EngineResumeMetadata),
 	)
 	if err != nil {
@@ -96,6 +97,7 @@ func insertApplyOperation(ctx context.Context, exec sqlExecer, ad *storage.Apply
 	ad.ID = id
 	ad.State = stateVal
 	ad.CutoverPolicy = cutoverPolicy
+	ad.OnFailure = onFailure
 	return id, nil
 }
 
@@ -556,11 +558,11 @@ const applyOperationHeartbeatStaleness = "1 MINUTE"
 //     terminal non-success states (failed, cancelled, reverted) — still block,
 //     so a failed earlier deployment still halts the rollout.
 //
-// halt_on_failure (per-apply policy, also captured on each row at create)
-// layers on top of both policies: when true (the default), a terminal-failed
-// earlier sibling blocks every later sibling, so the rollout halts on the
-// first failure. When false, a terminal `failed` earlier sibling is treated as
-// settled and no longer blocks: later deployments are still claimed and
+// on_failure (per-apply policy, also captured on each row at create)
+// layers on top of both policies: "halt" (the default) keeps a terminal-failed
+// earlier sibling blocking every later sibling, so the rollout halts on the
+// first failure. "continue" treats a terminal `failed` earlier sibling as
+// settled so it no longer blocks: later deployments are still claimed and
 // attempted. Only terminal `failed` is exempted — pending, running,
 // failed_retryable, and stopped earlier siblings still block under both
 // policies (work is in-flight or recoverable). The policy governs only rollout
@@ -601,9 +603,9 @@ func (s *applyOperationStore) FindNextApplyOperation(ctx context.Context, owner 
 	// reaches the cutover barrier or succeeds (waiting_for_cutover, cutting_over,
 	// revert_window, completed); under rolling — and any non-barrier value, which
 	// fails closed to the serial gate — only a completed earlier sibling stops
-	// blocking. The trailing Failed arg drives the halt_on_failure exemption:
-	// when the policy is off, a terminal-failed earlier sibling no longer blocks
-	// later ones.
+	// blocking. The trailing on_failure/Failed pair drives the exemption: when
+	// the policy is "continue", a terminal-failed earlier sibling no longer
+	// blocks later ones.
 	queryArgs = append(queryArgs,
 		storage.CutoverPolicyBarrier,
 		state.ApplyOperation.WaitingForCutover,
@@ -612,6 +614,7 @@ func (s *applyOperationStore) FindNextApplyOperation(ctx context.Context, owner 
 		state.ApplyOperation.Completed,
 		storage.CutoverPolicyBarrier,
 		state.ApplyOperation.Completed,
+		storage.OnFailureContinue,
 		state.ApplyOperation.Failed,
 	)
 	queryArgs = append(queryArgs, stringArgs(activeStates)...)
@@ -678,7 +681,7 @@ func (s *applyOperationStore) FindNextApplyOperation(ctx context.Context, owner 
 								AND earlier.state <> ?
 							)
 						)
-						AND NOT (apply_operations.halt_on_failure = 0 AND earlier.state = ?)
+						AND NOT (apply_operations.on_failure = ? AND earlier.state = ?)
 				)
 			)
 			OR (state IN (%s) AND updated_at < NOW() - INTERVAL %s)
@@ -862,18 +865,14 @@ func scanApplyOperationInto(s scanner) (*storage.ApplyOperation, error) {
 	var errMsg sql.NullString
 	var engineResumeContext, engineResumeMetadata sql.NullString
 	var startedAt, completedAt, leaseAcquiredAt sql.NullTime
-	var haltOnFailure bool
 
 	if err := s.Scan(
 		&ad.ID, &ad.ApplyID, &ad.Deployment, &ad.Target, &ad.State, &errMsg,
-		&ad.CutoverPolicy, &haltOnFailure, &startedAt, &completedAt, &ad.LeaseOwner, &ad.LeaseToken, &leaseAcquiredAt,
+		&ad.CutoverPolicy, &ad.OnFailure, &startedAt, &completedAt, &ad.LeaseOwner, &ad.LeaseToken, &leaseAcquiredAt,
 		&engineResumeContext, &engineResumeMetadata, &ad.CreatedAt, &ad.UpdatedAt,
 	); err != nil {
 		return nil, err
 	}
-
-	// The column is NOT NULL, so a stored row always carries an explicit policy.
-	ad.HaltOnFailure = &haltOnFailure
 
 	if errMsg.Valid {
 		ad.ErrorMessage = errMsg.String

--- a/pkg/storage/mysqlstore/apply_operations_test.go
+++ b/pkg/storage/mysqlstore/apply_operations_test.go
@@ -1125,17 +1125,23 @@ func TestApplyOperationStore_FindNextApplyOperation_HaltsOnFailedSibling(t *test
 	lock := createTestLock(t, store, "testdb", "mysql", "staging")
 	apply := createTestApply(t, store, lock, "apply_op_halt", 1)
 
-	// region-a failed; region-b and region-c are pending behind it.
+	// region-a failed; region-b and region-c are pending behind it, all under
+	// the halt policy.
 	failedID, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
-		ApplyID: apply.ID, Deployment: "region-a", State: state.ApplyOperation.Failed,
+		ApplyID: apply.ID, Deployment: "region-a", State: state.ApplyOperation.Failed, OnFailure: storage.OnFailureHalt,
 	})
 	require.NoError(t, err)
 	for _, deployment := range []string{"region-b", "region-c"} {
 		_, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
-			ApplyID: apply.ID, Deployment: deployment,
+			ApplyID: apply.ID, Deployment: deployment, OnFailure: storage.OnFailureHalt,
 		})
 		require.NoError(t, err)
 	}
+
+	// The resolved policy is persisted as the enum string on each row.
+	failedRow, err := store.ApplyOperations().Get(ctx, failedID)
+	require.NoError(t, err)
+	assert.Equal(t, storage.OnFailureHalt, failedRow.OnFailure, "the resolved policy is persisted as the on_failure enum")
 
 	// Backdate the failed row so staleness can't be the reason it's skipped —
 	// the only thing holding the rollout is the earlier non-completed sibling.
@@ -1149,44 +1155,48 @@ func TestApplyOperationStore_FindNextApplyOperation_HaltsOnFailedSibling(t *test
 	assert.Nil(t, claimed, "later siblings must not be claimed once an earlier deployment failed")
 }
 
-// TestApplyOperationStore_FindNextApplyOperation_HaltOnFailureDisabledClaimsPastFailedSibling
-// verifies that when an apply's halt_on_failure policy is disabled, a
+// TestApplyOperationStore_FindNextApplyOperation_OnFailureContinueClaimsPastFailedSibling
+// verifies that when an apply's on_failure policy is "continue", a
 // terminal-failed earlier deployment no longer blocks later siblings: the
 // rollout continues and the next ordered deployment is claimed instead of
 // stalling at the first failure. Only terminal `failed` is exempted — the
 // policy controls rollout continuation, not the apply's verdict.
-func TestApplyOperationStore_FindNextApplyOperation_HaltOnFailureDisabledClaimsPastFailedSibling(t *testing.T) {
+func TestApplyOperationStore_FindNextApplyOperation_OnFailureContinueClaimsPastFailedSibling(t *testing.T) {
 	clearTables(t)
 	ctx := t.Context()
 	store := New(testDB)
 
 	lock := createTestLock(t, store, "testdb", "mysql", "staging")
-	apply := createTestApply(t, store, lock, "apply_op_no_halt", 1)
+	apply := createTestApply(t, store, lock, "apply_op_continue", 1)
 
 	// region-a failed; region-b and region-c are pending behind it. With
-	// halt_on_failure disabled on every row, the failed sibling is treated as
+	// on_failure "continue" on every row, the failed sibling is treated as
 	// settled and the rollout proceeds to region-b.
-	noHalt := false
-	failedID, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
-		ApplyID: apply.ID, Deployment: "region-a", State: state.ApplyOperation.Failed, HaltOnFailure: &noHalt,
+	failed, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-a", State: state.ApplyOperation.Failed, OnFailure: storage.OnFailureContinue,
 	})
 	require.NoError(t, err)
 	for _, deployment := range []string{"region-b", "region-c"} {
 		_, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
-			ApplyID: apply.ID, Deployment: deployment, HaltOnFailure: &noHalt,
+			ApplyID: apply.ID, Deployment: deployment, OnFailure: storage.OnFailureContinue,
 		})
 		require.NoError(t, err)
 	}
 
+	// The resolved policy is persisted as the enum string on each row.
+	failedRow, err := store.ApplyOperations().Get(ctx, failed)
+	require.NoError(t, err)
+	assert.Equal(t, storage.OnFailureContinue, failedRow.OnFailure, "the resolved policy is persisted as the on_failure enum")
+
 	// Backdate the failed row so staleness can't be the reason it's skipped.
 	_, err = testDB.ExecContext(ctx, `
 		UPDATE apply_operations SET updated_at = NOW() - INTERVAL 1 HOUR WHERE id = ?
-	`, failedID)
+	`, failed)
 	require.NoError(t, err)
 
 	claimed, err := store.ApplyOperations().FindNextApplyOperation(ctx, "test-operator")
 	require.NoError(t, err)
-	require.NotNil(t, claimed, "halt_on_failure disabled must let the rollout proceed past a failed sibling")
+	require.NotNil(t, claimed, "on_failure continue must let the rollout proceed past a failed sibling")
 	assert.Equal(t, "region-b", claimed.Deployment, "the next ordered deployment after the failed one is claimed")
 	assert.Equal(t, "test-operator", claimed.LeaseOwner, "claim must record the lease owner")
 
@@ -1197,29 +1207,28 @@ func TestApplyOperationStore_FindNextApplyOperation_HaltOnFailureDisabledClaimsP
 	assert.Equal(t, state.ApplyOperation.Running, stored.State, "the claimed pending row is transitioned to running")
 }
 
-// TestApplyOperationStore_FindNextApplyOperation_HaltOnFailureDisabledStillBlocksOnRunningSibling
-// verifies that disabling halt_on_failure only exempts terminal `failed` — an
+// TestApplyOperationStore_FindNextApplyOperation_OnFailureContinueStillBlocksOnRunningSibling
+// verifies that on_failure "continue" only exempts terminal `failed` — an
 // earlier sibling that is still in-flight (running) continues to block later
 // deployments, because reordering around work that has not settled would race
 // the rollout.
-func TestApplyOperationStore_FindNextApplyOperation_HaltOnFailureDisabledStillBlocksOnRunningSibling(t *testing.T) {
+func TestApplyOperationStore_FindNextApplyOperation_OnFailureContinueStillBlocksOnRunningSibling(t *testing.T) {
 	clearTables(t)
 	ctx := t.Context()
 	store := New(testDB)
 
 	lock := createTestLock(t, store, "testdb", "mysql", "staging")
-	apply := createTestApply(t, store, lock, "apply_op_no_halt_running", 1)
+	apply := createTestApply(t, store, lock, "apply_op_continue_running", 1)
 
 	// region-a is running (fresh, so not stale-claimable); region-b is pending
-	// behind it. Even with halt_on_failure disabled, an in-flight sibling gates
+	// behind it. Even with on_failure "continue", an in-flight sibling gates
 	// the later pending one — only terminal failure is exempted.
-	noHalt := false
 	runningID, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
-		ApplyID: apply.ID, Deployment: "region-a", State: state.ApplyOperation.Running, HaltOnFailure: &noHalt,
+		ApplyID: apply.ID, Deployment: "region-a", State: state.ApplyOperation.Running, OnFailure: storage.OnFailureContinue,
 	})
 	require.NoError(t, err)
 	_, err = store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
-		ApplyID: apply.ID, Deployment: "region-b", HaltOnFailure: &noHalt,
+		ApplyID: apply.ID, Deployment: "region-b", OnFailure: storage.OnFailureContinue,
 	})
 	require.NoError(t, err)
 
@@ -1232,7 +1241,7 @@ func TestApplyOperationStore_FindNextApplyOperation_HaltOnFailureDisabledStillBl
 
 	claimed, err := store.ApplyOperations().FindNextApplyOperation(ctx, "test-operator")
 	require.NoError(t, err)
-	assert.Nil(t, claimed, "a running earlier sibling still blocks even with halt_on_failure disabled")
+	assert.Nil(t, claimed, "a running earlier sibling still blocks even with on_failure continue")
 }
 
 // TestApplyOperationStore_FindNextApplyOperation_BarrierClaimsPastSiblingAtCutoverBarrier

--- a/pkg/storage/mysqlstore/apply_operations_test.go
+++ b/pkg/storage/mysqlstore/apply_operations_test.go
@@ -1244,6 +1244,50 @@ func TestApplyOperationStore_FindNextApplyOperation_OnFailureContinueStillBlocks
 	assert.Nil(t, claimed, "a running earlier sibling still blocks even with on_failure continue")
 }
 
+// TestApplyOperationStore_FindNextApplyOperation_UnrecognizedOnFailureBlocksFailedSibling
+// pins the fail-closed property of the claim predicate: only the exact value
+// "continue" exempts a terminal-failed earlier sibling. Any other stored value
+// — here "pause", which config validation rejects today but a future change or
+// a hand-written row could let reach storage — must keep the failed sibling
+// blocking so the rollout never races ahead on an unrecognized policy.
+func TestApplyOperationStore_FindNextApplyOperation_UnrecognizedOnFailureBlocksFailedSibling(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", "mysql", "staging")
+	apply := createTestApply(t, store, lock, "apply_op_unrecognized", 1)
+
+	// region-a failed; region-b is pending behind it. The failed row carries an
+	// unrecognized on_failure value, so the exemption (which keys on exact
+	// "continue") does not apply and the failed sibling keeps blocking.
+	failedID, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-a", State: state.ApplyOperation.Failed, OnFailure: storage.OnFailurePause,
+	})
+	require.NoError(t, err)
+	_, err = store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-b", OnFailure: storage.OnFailurePause,
+	})
+	require.NoError(t, err)
+
+	// The unrecognized value is persisted verbatim — it is not normalized to a
+	// known enum on the way into storage.
+	failedRow, err := store.ApplyOperations().Get(ctx, failedID)
+	require.NoError(t, err)
+	assert.Equal(t, storage.OnFailurePause, failedRow.OnFailure, "an unrecognized on_failure value is stored as-is")
+
+	// Backdate the failed row so staleness can't be the reason it's skipped —
+	// the only thing holding the rollout is the earlier failed sibling.
+	_, err = testDB.ExecContext(ctx, `
+		UPDATE apply_operations SET updated_at = NOW() - INTERVAL 1 HOUR WHERE id = ?
+	`, failedID)
+	require.NoError(t, err)
+
+	claimed, err := store.ApplyOperations().FindNextApplyOperation(ctx, "test-operator")
+	require.NoError(t, err)
+	assert.Nil(t, claimed, "an unrecognized on_failure value must fail closed and keep the failed sibling blocking")
+}
+
 // TestApplyOperationStore_FindNextApplyOperation_BarrierClaimsPastSiblingAtCutoverBarrier
 // verifies the barrier cutover policy: a later deployment may start its copy
 // phase once an earlier sibling has reached the cutover barrier

--- a/pkg/storage/types.go
+++ b/pkg/storage/types.go
@@ -25,6 +25,28 @@ const (
 	CutoverPolicyBarrier = "barrier"
 )
 
+// On-failure policies control multi-deployment rollout continuation when an
+// earlier deployment terminally fails. Like the cutover policy, the value is
+// resolved from the environment config at apply-create time and persisted on
+// each apply_operations row so the policy in force when the apply was created
+// travels with it.
+const (
+	// OnFailureHalt is the default: a terminal-failed earlier deployment blocks
+	// every later deployment of the same apply, so the rollout stops at the
+	// first failure.
+	OnFailureHalt = "halt"
+
+	// OnFailureContinue treats a terminal-failed earlier deployment as settled
+	// so it no longer blocks later deployments; the rollout attempts every
+	// deployment instead of stopping at the first failure.
+	OnFailureContinue = "continue"
+
+	// OnFailurePause holds the rollout after a failure until a human releases
+	// it. It is a known value but not yet supported; config validation rejects
+	// it until the release machinery lands.
+	OnFailurePause = "pause"
+)
+
 // Lock represents a database-level deployment lock.
 // Locks prevent concurrent schema changes to the same database across
 // all environments and PRs. Lock key is database:type (no environment).
@@ -466,20 +488,18 @@ type ApplyOperation struct {
 	// an empty value as "rolling", matching the column's NOT NULL DEFAULT.
 	CutoverPolicy string
 
-	// HaltOnFailure is the rollout policy captured for this operation's parent
-	// apply at apply-create time, drawn from the resolved environment config.
-	// When true, a failed earlier sibling blocks every later deployment of the
-	// same apply — the rollout stops at the first failure. When false, a
-	// terminal-failed earlier sibling no longer blocks later siblings, so the
-	// rollout attempts every deployment instead of halting. It governs only
-	// rollout continuation, never the apply's pass/fail verdict or the merge
-	// gate, which stay fail-closed on any failed deployment.
-	//
-	// A pointer so an unset value is distinguishable from an explicit false:
-	// Insert treats nil as halt-on-failure (the safe default, matching the
-	// column's NOT NULL DEFAULT 1), so a caller that omits the policy never
-	// silently degrades to the less-safe non-halting behaviour.
-	HaltOnFailure *bool
+	// OnFailure is the rollout-continuation policy captured for this operation's
+	// parent apply at apply-create time, drawn from the resolved environment
+	// config. "halt" (the default) blocks every later deployment of the same
+	// apply once an earlier sibling terminally fails — the rollout stops at the
+	// first failure. "continue" treats a terminal-failed earlier sibling as
+	// settled so it no longer blocks later siblings, and the rollout attempts
+	// every deployment instead of halting. It governs only rollout
+	// continuation, never the apply's pass/fail verdict or the merge gate,
+	// which stay fail-closed on any failed deployment. Insert treats an empty
+	// value as "halt", matching the column's NOT NULL DEFAULT, so a caller that
+	// omits the policy never silently degrades to the less-safe behaviour.
+	OnFailure string
 
 	// StartedAt is when the operator claimed this child row and execution began.
 	StartedAt *time.Time


### PR DESCRIPTION
## What and Why?

Introduces an `on_failure` enum (`halt | continue | pause`, default `halt`) as the per-environment rollout-continuation policy, replacing the `halt_on_failure` boolean knob. Behaviour matches the boolean for the two existing values; `pause` is parsed but validation-rejected until its release machinery lands.

on_failure: halt      ->  failed sibling blocks the rest of the rollout (default)
on_failure: continue  ->  terminal-failed sibling is exempted; rollout continues
on_failure: pause     ->  rejected in validation (follow-up)

- Config: `EnvironmentConfig.OnFailure` + `ServerConfig.OnFailure(database, environment)` resolver, defaulting to `halt`.
- Validation: requires a `deployments` map; rejects unknown values and `pause`.
- Storage: adds per-row column `on_failure varchar(16) NOT NULL DEFAULT 'halt'` (mirrors `cutover_policy`); picked up by `EnsureSchema`.
- Claim predicate: `FindNextApplyOperation` exempts a terminal-`failed` earlier sibling only when `on_failure = 'continue'`; every other value — including unrecognized ones — fails closed and keeps blocking.

Dormant until the multi-deployment fan-out is wired (one operation per apply today), so the field, column, and predicate are no-ops at runtime regardless of value.

### Schema rollout safety (two-step)

`apply_operations.halt_on_failure` already ships in the live schema, and `EnsureSchema` reconciles a renamed column by drop+add, not rename. Dropping it in the same change that adds `on_failure` would break still-running old pods mid-deploy, since they still query `halt_on_failure`. So this PR is the **additive** step — it adds `on_failure` and keeps `halt_on_failure`; a follow-up removes the old column once every pod runs the `on_failure` code.

Patch 1 (this PR):   add on_failure, keep halt_on_failure  -> old pods unaffected
Patch 2 (follow-up): drop halt_on_failure                  -> no code references it

The new `on_failure` column is additive (default `halt`), so no existing data is touched.

## Roadmap / upcoming PRs

This PR (the `on_failure` enum surface) is **merged**. The runtime continuation behaviour it gates lands in the B-track continuation-projection follow-ups; cross-referenced below so the enum surface and its consumers stay correlated.

| Upcoming change | Status | PR |
|---|---|---|
| `on_failure` enum surface (config/storage/predicate), additive column | ✅ Merged | #317 |
| Aggregate `applies.state` over all `apply_operations` rows ("Option B") | ✅ Merged | #318 |
| Policy-aware `continue` projection — hold apply active until siblings settle (**B2**) | Next | TBD |
| Eager failure surfacing + `stop` halts remaining siblings under `continue` (**B3**) | Planned | TBD |
| Drop `halt_on_failure` column (patch 2 above) | Planned | TBD |
| `on_failure: pause` as a release gate | Planned (depends on B2 + pause/release machinery) | TBD |
| Compile `on_failure` into dependency-graph edges (remove runtime knob) | Future (blocked on north-star Phases 4–5) | TBD |
