### PR TITLE
refactor(operator): derive applies.state from all operation rows

### DIFF
--- a/pkg/tern/local_apply_grouped.go
+++ b/pkg/tern/local_apply_grouped.go
@@ -309,6 +309,55 @@ func applyOperationIDForTask(task *storage.Task) (int64, error) {
 	return *task.ApplyOperationID, nil
 }
 
+// deriveAggregateApplyState computes applies.state as the rollout projection
+// over every apply_operation row of the apply.
+//
+// Invariant: applies.state is the rollout projection over all operations of the
+// apply, not only the operation this drive is executing. The current
+// deployment's freshly derived per-operation state is folded in over its own
+// (possibly stale) operation row, then the aggregate is derived from the whole
+// sibling set. Deriving from the current deployment's tasks alone would let one
+// deployment move the apply to a terminal/aggregate state that ignores siblings;
+// folding the current state into the sibling set keeps a still-pending or
+// running sibling holding the apply non-terminal.
+//
+// With one operation per apply the sibling set is the current operation alone,
+// so the projection collapses to the current deployment's derived state and the
+// result is unchanged. If the operation rows cannot be read the projection
+// degrades to that same single-operation value.
+func (c *LocalClient) deriveAggregateApplyState(ctx context.Context, apply *storage.Apply, tasks []*storage.Task) string {
+	currentOpState := state.DeriveApplyState(taskStates(tasks))
+
+	operationID, err := applyOperationIDForTasks(tasks)
+	if err != nil {
+		c.logger.Warn("deriving apply state from current deployment only: could not resolve apply operation for tasks",
+			"apply_id", apply.ApplyIdentifier, "error", err)
+		return currentOpState
+	}
+
+	ops, err := c.storage.ApplyOperations().ListByApply(ctx, apply.ID)
+	if err != nil {
+		c.logger.Warn("deriving apply state from current deployment only: failed to list sibling apply operations",
+			"apply_id", apply.ApplyIdentifier, "error", err)
+		return currentOpState
+	}
+	if len(ops) == 0 {
+		c.logger.Warn("deriving apply state from current deployment only: apply has no operation rows",
+			"apply_id", apply.ApplyIdentifier)
+		return currentOpState
+	}
+
+	childStates := make([]string, len(ops))
+	for i, op := range ops {
+		if op.ID == operationID {
+			childStates[i] = currentOpState
+			continue
+		}
+		childStates[i] = op.State
+	}
+	return state.DeriveApplyState(childStates)
+}
+
 // executeApplySequential runs each DDL as a separate Spirit call (independent mode).
 // Each table copies and cuts over independently.
 
@@ -515,7 +564,7 @@ func (c *LocalClient) handleAtomicProgressTick(ctx context.Context, eng engine.E
 
 	// Update apply state from persisted task state so recovery guards can keep
 	// storage ahead of stale engine progress until Spirit reaches the cutover wait again.
-	apply.State = state.DeriveApplyState(taskStates(tasks))
+	apply.State = c.deriveAggregateApplyState(ctx, apply, tasks)
 	apply.UpdatedAt = now
 	if freshApply, err := c.storage.Applies().Get(ctx, apply.ID); err != nil {
 		c.logger.Error("failed to reload apply before progress state update", "apply_id", apply.ApplyIdentifier, "error", err)

--- a/pkg/tern/local_apply_grouped.go
+++ b/pkg/tern/local_apply_grouped.go
@@ -310,7 +310,9 @@ func applyOperationIDForTask(task *storage.Task) (int64, error) {
 }
 
 // deriveAggregateApplyState computes applies.state as the rollout projection
-// over every apply_operation row of the apply.
+// over every apply_operation row of the apply. The boolean is false when the
+// projection could not be determined safely and the caller must leave the
+// stored apply state unchanged.
 //
 // Invariant: applies.state is the rollout projection over all operations of the
 // apply, not only the operation this drive is executing. The current
@@ -322,36 +324,57 @@ func applyOperationIDForTask(task *storage.Task) (int64, error) {
 // running sibling holding the apply non-terminal.
 //
 // With one operation per apply the sibling set is the current operation alone,
-// so the projection collapses to the current deployment's derived state and the
-// result is unchanged. If the operation rows cannot be read the projection
-// degrades to that same single-operation value.
-func (c *LocalClient) deriveAggregateApplyState(ctx context.Context, apply *storage.Apply, tasks []*storage.Task) string {
+// so the projection collapses to the current deployment's derived state.
+//
+// When the sibling rows cannot be read, the projection falls back to the current
+// deployment's derived state only if that state is non-terminal. A terminal
+// current-deployment state must never become the aggregate on incomplete
+// information: a transient read failure on one deployment would otherwise mark
+// the whole apply terminal while siblings are still in flight. In that case the
+// projection is reported as undetermined (ok=false) and the caller keeps the
+// stored value for the next poll to reconcile.
+//
+// The read-then-write is not atomic, so concurrent sibling drives last-write-
+// wins from possibly stale reads; the aggregate converges on the next poll.
+func (c *LocalClient) deriveAggregateApplyState(ctx context.Context, apply *storage.Apply, tasks []*storage.Task) (string, bool) {
 	currentOpState := state.DeriveApplyState(taskStates(tasks))
+
+	// fallback reports the current deployment's derived state when the sibling
+	// set is unknown, but refuses to terminalize the apply on incomplete
+	// information.
+	fallback := func() (string, bool) {
+		if state.IsTerminalApplyState(currentOpState) {
+			c.logger.Warn("cannot determine aggregate apply state and current deployment is terminal; leaving stored apply state unchanged",
+				"apply_id", apply.ApplyIdentifier, "current_deployment_state", currentOpState)
+			return "", false
+		}
+		return currentOpState, true
+	}
 
 	operationID, err := applyOperationIDForTasks(tasks)
 	if err != nil {
 		c.logger.Warn("deriving apply state from current deployment only: could not resolve apply operation for tasks",
 			"apply_id", apply.ApplyIdentifier, "error", err)
-		return currentOpState
+		return fallback()
 	}
 
 	store := c.storage.ApplyOperations()
 	if store == nil {
 		c.logger.Warn("deriving apply state from current deployment only: apply operation store is not configured",
 			"apply_id", apply.ApplyIdentifier)
-		return currentOpState
+		return fallback()
 	}
 
 	ops, err := store.ListByApply(ctx, apply.ID)
 	if err != nil {
 		c.logger.Warn("deriving apply state from current deployment only: failed to list sibling apply operations",
 			"apply_id", apply.ApplyIdentifier, "error", err)
-		return currentOpState
+		return fallback()
 	}
 	if len(ops) == 0 {
 		c.logger.Warn("deriving apply state from current deployment only: apply has no operation rows",
 			"apply_id", apply.ApplyIdentifier)
-		return currentOpState
+		return fallback()
 	}
 
 	childStates := make([]string, len(ops))
@@ -367,9 +390,9 @@ func (c *LocalClient) deriveAggregateApplyState(ctx context.Context, apply *stor
 	if !foundCurrent {
 		c.logger.Warn("deriving apply state from current deployment only: current operation row missing from sibling set",
 			"apply_id", apply.ApplyIdentifier, "apply_operation_id", operationID)
-		return currentOpState
+		return fallback()
 	}
-	return state.DeriveApplyState(childStates)
+	return state.DeriveApplyState(childStates), true
 }
 
 // executeApplySequential runs each DDL as a separate Spirit call (independent mode).
@@ -578,7 +601,9 @@ func (c *LocalClient) handleAtomicProgressTick(ctx context.Context, eng engine.E
 
 	// Update apply state from persisted task state so recovery guards can keep
 	// storage ahead of stale engine progress until Spirit reaches the cutover wait again.
-	apply.State = c.deriveAggregateApplyState(ctx, apply, tasks)
+	if derived, ok := c.deriveAggregateApplyState(ctx, apply, tasks); ok {
+		apply.State = derived
+	}
 	apply.UpdatedAt = now
 	if freshApply, err := c.storage.Applies().Get(ctx, apply.ID); err != nil {
 		c.logger.Error("failed to reload apply before progress state update", "apply_id", apply.ApplyIdentifier, "error", err)

--- a/pkg/tern/local_apply_grouped.go
+++ b/pkg/tern/local_apply_grouped.go
@@ -326,23 +326,33 @@ func applyOperationIDForTask(task *storage.Task) (int64, error) {
 // With one operation per apply the sibling set is the current operation alone,
 // so the projection collapses to the current deployment's derived state.
 //
-// When the sibling rows cannot be read, the projection falls back to the current
-// deployment's derived state only if that state is non-terminal. A terminal
-// current-deployment state must never become the aggregate on incomplete
-// information: a transient read failure on one deployment would otherwise mark
-// the whole apply terminal while siblings are still in flight. In that case the
-// projection is reported as undetermined (ok=false) and the caller keeps the
-// stored value for the next poll to reconcile.
+// Two outcomes are distinguished when the full sibling set is not available:
+//
+//   - The apply does not use the operation model — its tasks carry no
+//     apply_operation_id, or the operation store is not configured. There are no
+//     siblings, so the per-task derivation is authoritative and may terminalize.
+//     This preserves single-writer/legacy behaviour for applies written before
+//     the apply-create path populated apply_operation_id.
+//
+//   - The apply uses the operation model (its tasks carry an apply_operation_id)
+//     but the sibling rows cannot be read consistently — the list call failed,
+//     returned no rows, or omitted the current operation. Here the sibling
+//     states are genuinely unknown, so a terminal current-deployment derivation
+//     must not become the aggregate: a transient read failure on the
+//     last-finishing deployment would otherwise mark the whole apply terminal
+//     while siblings are still in flight. The projection is reported as
+//     undetermined (ok=false) and the caller keeps the stored value for the next
+//     poll to reconcile. A non-terminal derivation is still a safe fallback.
 //
 // The read-then-write is not atomic, so concurrent sibling drives last-write-
 // wins from possibly stale reads; the aggregate converges on the next poll.
 func (c *LocalClient) deriveAggregateApplyState(ctx context.Context, apply *storage.Apply, tasks []*storage.Task) (string, bool) {
 	currentOpState := state.DeriveApplyState(taskStates(tasks))
 
-	// fallback reports the current deployment's derived state when the sibling
-	// set is unknown, but refuses to terminalize the apply on incomplete
-	// information.
-	fallback := func() (string, bool) {
+	// failClosed reports the current deployment's derived state when the sibling
+	// set is in use but unreadable, refusing to terminalize the apply on
+	// incomplete information.
+	failClosed := func() (string, bool) {
 		if state.IsTerminalApplyState(currentOpState) {
 			c.logger.Warn("cannot determine aggregate apply state and current deployment is terminal; leaving stored apply state unchanged",
 				"apply_id", apply.ApplyIdentifier, "current_deployment_state", currentOpState)
@@ -353,28 +363,32 @@ func (c *LocalClient) deriveAggregateApplyState(ctx context.Context, apply *stor
 
 	operationID, err := applyOperationIDForTasks(tasks)
 	if err != nil {
-		c.logger.Warn("deriving apply state from current deployment only: could not resolve apply operation for tasks",
-			"apply_id", apply.ApplyIdentifier, "error", err)
-		return fallback()
+		// No operation model in use: tasks carry no apply_operation_id, so there
+		// are no siblings and the per-task derivation is authoritative.
+		c.logger.Debug("deriving apply state from tasks: apply has no operation model",
+			"apply_id", apply.ApplyIdentifier, "reason", err)
+		return currentOpState, true
 	}
 
 	store := c.storage.ApplyOperations()
 	if store == nil {
-		c.logger.Warn("deriving apply state from current deployment only: apply operation store is not configured",
+		// Operation store unavailable: no siblings can exist, so the per-task
+		// derivation is authoritative.
+		c.logger.Debug("deriving apply state from tasks: apply operation store is not configured",
 			"apply_id", apply.ApplyIdentifier)
-		return fallback()
+		return currentOpState, true
 	}
 
 	ops, err := store.ListByApply(ctx, apply.ID)
 	if err != nil {
-		c.logger.Warn("deriving apply state from current deployment only: failed to list sibling apply operations",
-			"apply_id", apply.ApplyIdentifier, "error", err)
-		return fallback()
+		c.logger.Warn("cannot determine aggregate apply state: failed to list sibling apply operations",
+			"apply_id", apply.ApplyIdentifier, "apply_operation_id", operationID, "error", err)
+		return failClosed()
 	}
 	if len(ops) == 0 {
-		c.logger.Warn("deriving apply state from current deployment only: apply has no operation rows",
-			"apply_id", apply.ApplyIdentifier)
-		return fallback()
+		c.logger.Warn("cannot determine aggregate apply state: tasks reference an apply operation but no operation rows were found",
+			"apply_id", apply.ApplyIdentifier, "apply_operation_id", operationID)
+		return failClosed()
 	}
 
 	childStates := make([]string, len(ops))
@@ -388,9 +402,9 @@ func (c *LocalClient) deriveAggregateApplyState(ctx context.Context, apply *stor
 		childStates[i] = op.State
 	}
 	if !foundCurrent {
-		c.logger.Warn("deriving apply state from current deployment only: current operation row missing from sibling set",
+		c.logger.Warn("cannot determine aggregate apply state: current operation row missing from sibling set",
 			"apply_id", apply.ApplyIdentifier, "apply_operation_id", operationID)
-		return fallback()
+		return failClosed()
 	}
 	return state.DeriveApplyState(childStates), true
 }

--- a/pkg/tern/local_apply_grouped.go
+++ b/pkg/tern/local_apply_grouped.go
@@ -335,7 +335,14 @@ func (c *LocalClient) deriveAggregateApplyState(ctx context.Context, apply *stor
 		return currentOpState
 	}
 
-	ops, err := c.storage.ApplyOperations().ListByApply(ctx, apply.ID)
+	store := c.storage.ApplyOperations()
+	if store == nil {
+		c.logger.Warn("deriving apply state from current deployment only: apply operation store is not configured",
+			"apply_id", apply.ApplyIdentifier)
+		return currentOpState
+	}
+
+	ops, err := store.ListByApply(ctx, apply.ID)
 	if err != nil {
 		c.logger.Warn("deriving apply state from current deployment only: failed to list sibling apply operations",
 			"apply_id", apply.ApplyIdentifier, "error", err)
@@ -348,12 +355,19 @@ func (c *LocalClient) deriveAggregateApplyState(ctx context.Context, apply *stor
 	}
 
 	childStates := make([]string, len(ops))
+	foundCurrent := false
 	for i, op := range ops {
 		if op.ID == operationID {
 			childStates[i] = currentOpState
+			foundCurrent = true
 			continue
 		}
 		childStates[i] = op.State
+	}
+	if !foundCurrent {
+		c.logger.Warn("deriving apply state from current deployment only: current operation row missing from sibling set",
+			"apply_id", apply.ApplyIdentifier, "apply_operation_id", operationID)
+		return currentOpState
 	}
 	return state.DeriveApplyState(childStates)
 }

--- a/pkg/tern/local_client.go
+++ b/pkg/tern/local_client.go
@@ -839,7 +839,7 @@ func (c *LocalClient) Progress(ctx context.Context, req *ternv1.ProgressRequest)
 					if apply, err := c.storage.Applies().Get(ctx, activeTask.ApplyID); err != nil {
 						c.logger.Warn("failed to load apply after progress task state update", "apply_id", activeTask.ApplyID, "error", err)
 					} else if apply != nil && !state.IsTerminalApplyState(apply.State) {
-						apply.State = state.DeriveApplyState(taskStates(currentApplyTasks))
+						apply.State = c.deriveAggregateApplyState(ctx, apply, currentApplyTasks)
 						apply.UpdatedAt = now
 						if err := c.storage.Applies().Update(ctx, apply); err != nil {
 							c.logger.Warn("failed to update apply after progress task state update", "apply_id", apply.ApplyIdentifier, "state", apply.State, "error", err)

--- a/pkg/tern/local_client.go
+++ b/pkg/tern/local_client.go
@@ -839,10 +839,12 @@ func (c *LocalClient) Progress(ctx context.Context, req *ternv1.ProgressRequest)
 					if apply, err := c.storage.Applies().Get(ctx, activeTask.ApplyID); err != nil {
 						c.logger.Warn("failed to load apply after progress task state update", "apply_id", activeTask.ApplyID, "error", err)
 					} else if apply != nil && !state.IsTerminalApplyState(apply.State) {
-						apply.State = c.deriveAggregateApplyState(ctx, apply, currentApplyTasks)
-						apply.UpdatedAt = now
-						if err := c.storage.Applies().Update(ctx, apply); err != nil {
-							c.logger.Warn("failed to update apply after progress task state update", "apply_id", apply.ApplyIdentifier, "state", apply.State, "error", err)
+						if derived, ok := c.deriveAggregateApplyState(ctx, apply, currentApplyTasks); ok {
+							apply.State = derived
+							apply.UpdatedAt = now
+							if err := c.storage.Applies().Update(ctx, apply); err != nil {
+								c.logger.Warn("failed to update apply after progress task state update", "apply_id", apply.ApplyIdentifier, "state", apply.State, "error", err)
+							}
 						}
 					}
 				}

--- a/pkg/tern/local_client_test.go
+++ b/pkg/tern/local_client_test.go
@@ -1259,14 +1259,53 @@ func TestDeriveAggregateApplyState(t *testing.T) {
 		assert.False(t, state.IsState(got, state.Apply.Completed), "derived state must not clobber the pending sibling to completed")
 	})
 
-	// Degraded paths (sibling rows unknown) must never terminalize the apply on
-	// incomplete information: a transient read failure on the last-finishing
-	// deployment would otherwise mark the whole apply terminal while siblings are
-	// still in flight. The projection is reported undetermined (ok=false) so the
-	// caller keeps the stored value for the next poll to reconcile.
-	degradedStores := map[string]storage.ApplyOperationStore{
-		"operations cannot be read":     &listApplyOperationStore{err: assert.AnError},
-		"operation store not available": nil,
+	// No operation model in use: the tasks carry no apply_operation_id, or the
+	// operation store is not configured. There are no siblings, so the per-task
+	// derivation is authoritative and may terminalize — this preserves
+	// single-writer/legacy behaviour for applies that predate apply_operation_id.
+	taskNoOp := func(taskState string) *storage.Task {
+		return &storage.Task{State: taskState}
+	}
+	noOperationModel := map[string]struct {
+		tasks []*storage.Task
+		store storage.ApplyOperationStore
+	}{
+		"tasks carry no apply_operation_id": {
+			tasks: []*storage.Task{taskNoOp(state.Task.Completed)},
+			store: &listApplyOperationStore{ops: []*storage.ApplyOperation{{ID: currentOpID, State: state.ApplyOperation.Pending}}},
+		},
+		"operation store not configured": {
+			tasks: []*storage.Task{taskWith(state.Task.Completed)},
+			store: nil,
+		},
+	}
+
+	for name, tc := range noOperationModel {
+		t.Run("no operation model ("+name+") terminalizes from tasks", func(t *testing.T) {
+			client := &LocalClient{
+				storage: &exactProgressStorage{applyOperations: tc.store},
+				logger:  slog.Default(),
+			}
+			apply := &storage.Apply{ID: 7, ApplyIdentifier: "apply-no-op-model"}
+
+			want := state.DeriveApplyState(taskStates(tc.tasks))
+			require.True(t, state.IsTerminalApplyState(want), "precondition: per-task derivation is terminal")
+			got, ok := client.deriveAggregateApplyState(t.Context(), apply, tc.tasks)
+			assert.True(t, ok, "no siblings exist, so a terminal per-task derivation is authoritative")
+			assert.Equal(t, want, got)
+		})
+	}
+
+	// Operation model in use (tasks carry an apply_operation_id) but the sibling
+	// rows cannot be read consistently. The sibling states are unknown, so a
+	// terminal current-deployment derivation must not become the aggregate: a
+	// transient read failure on the last-finishing deployment would otherwise
+	// mark the whole apply terminal while siblings are still in flight. The
+	// projection is reported undetermined (ok=false) so the caller keeps the
+	// stored value for the next poll to reconcile.
+	unreadableSiblings := map[string]storage.ApplyOperationStore{
+		"operations cannot be read": &listApplyOperationStore{err: assert.AnError},
+		"no operation rows found":   &listApplyOperationStore{ops: nil},
 		"current operation row missing": &listApplyOperationStore{
 			ops: []*storage.ApplyOperation{
 				{ID: 2, State: state.ApplyOperation.Pending},
@@ -1275,27 +1314,27 @@ func TestDeriveAggregateApplyState(t *testing.T) {
 		},
 	}
 
-	for name, store := range degradedStores {
-		t.Run("degraded ("+name+") refuses to terminalize a terminal current deployment", func(t *testing.T) {
+	for name, store := range unreadableSiblings {
+		t.Run("unreadable siblings ("+name+") refuse to terminalize a terminal current deployment", func(t *testing.T) {
 			tasks := []*storage.Task{taskWith(state.Task.Completed)}
 			client := &LocalClient{
 				storage: &exactProgressStorage{applyOperations: store},
 				logger:  slog.Default(),
 			}
-			apply := &storage.Apply{ID: 7, ApplyIdentifier: "apply-degraded-terminal"}
+			apply := &storage.Apply{ID: 7, ApplyIdentifier: "apply-unreadable-terminal"}
 
 			require.True(t, state.IsTerminalApplyState(state.DeriveApplyState(taskStates(tasks))), "precondition: current deployment derives terminal")
 			_, ok := client.deriveAggregateApplyState(t.Context(), apply, tasks)
 			assert.False(t, ok, "must not overwrite stored apply state from a terminal single-op derivation")
 		})
 
-		t.Run("degraded ("+name+") falls back to a non-terminal current deployment", func(t *testing.T) {
+		t.Run("unreadable siblings ("+name+") fall back to a non-terminal current deployment", func(t *testing.T) {
 			tasks := []*storage.Task{taskWith(state.Task.Running), taskWith(state.Task.Pending)}
 			client := &LocalClient{
 				storage: &exactProgressStorage{applyOperations: store},
 				logger:  slog.Default(),
 			}
-			apply := &storage.Apply{ID: 7, ApplyIdentifier: "apply-degraded-active"}
+			apply := &storage.Apply{ID: 7, ApplyIdentifier: "apply-unreadable-active"}
 
 			want := state.DeriveApplyState(taskStates(tasks))
 			require.False(t, state.IsTerminalApplyState(want), "precondition: current deployment derives non-terminal")

--- a/pkg/tern/local_client_test.go
+++ b/pkg/tern/local_client_test.go
@@ -1186,4 +1186,35 @@ func TestDeriveAggregateApplyState(t *testing.T) {
 		got := client.deriveAggregateApplyState(t.Context(), apply, tasks)
 		assert.Equal(t, state.DeriveApplyState(taskStates(tasks)), got)
 	})
+
+	t.Run("falls back to current deployment derivation when the operation store is not configured", func(t *testing.T) {
+		tasks := []*storage.Task{taskWith(state.Task.Completed)}
+		client := &LocalClient{
+			storage: &exactProgressStorage{applyOperations: nil},
+			logger:  slog.Default(),
+		}
+		apply := &storage.Apply{ID: 7, ApplyIdentifier: "apply-no-store"}
+
+		got := client.deriveAggregateApplyState(t.Context(), apply, tasks)
+		assert.Equal(t, state.DeriveApplyState(taskStates(tasks)), got)
+	})
+
+	t.Run("falls back to current deployment derivation when the current operation row is missing", func(t *testing.T) {
+		tasks := []*storage.Task{taskWith(state.Task.Completed)}
+		client := &LocalClient{
+			storage: &exactProgressStorage{
+				applyOperations: &listApplyOperationStore{
+					ops: []*storage.ApplyOperation{
+						{ID: 2, State: state.ApplyOperation.Pending},
+						{ID: 3, State: state.ApplyOperation.Pending},
+					},
+				},
+			},
+			logger: slog.Default(),
+		}
+		apply := &storage.Apply{ID: 7, ApplyIdentifier: "apply-missing-current-op"}
+
+		got := client.deriveAggregateApplyState(t.Context(), apply, tasks)
+		assert.Equal(t, state.DeriveApplyState(taskStates(tasks)), got)
+	})
 }

--- a/pkg/tern/local_client_test.go
+++ b/pkg/tern/local_client_test.go
@@ -1094,3 +1094,96 @@ func attrValues(t *testing.T, attrs []any) map[string]any {
 	}
 	return values
 }
+
+// listApplyOperationStore is a fake ApplyOperationStore that returns a fixed set
+// of operation rows from ListByApply so the aggregate-state projection can be
+// exercised without a database.
+type listApplyOperationStore struct {
+	storage.ApplyOperationStore
+	ops []*storage.ApplyOperation
+	err error
+}
+
+func (s *listApplyOperationStore) ListByApply(context.Context, int64) ([]*storage.ApplyOperation, error) {
+	return s.ops, s.err
+}
+
+// deriveAggregateApplyState projects applies.state over all of an apply's
+// operation rows. With one operation per apply the projection equals the current
+// deployment's own derived state, so behaviour is unchanged; with a still-active
+// sibling the apply stays non-terminal so one deployment's drive cannot clobber
+// the rollout-level aggregate.
+func TestDeriveAggregateApplyState(t *testing.T) {
+	const currentOpID = int64(1)
+
+	taskWith := func(taskState string) *storage.Task {
+		id := currentOpID
+		return &storage.Task{State: taskState, ApplyOperationID: &id}
+	}
+
+	t.Run("one operation per apply matches current deployment derivation", func(t *testing.T) {
+		taskStateSets := [][]string{
+			{state.Task.Completed},
+			{state.Task.Completed, state.Task.Completed},
+			{state.Task.Running, state.Task.Pending},
+			{state.Task.Failed, state.Task.Completed},
+			{state.Task.WaitingForCutover, state.Task.Completed},
+			{state.Task.Pending},
+		}
+		for _, taskStateSet := range taskStateSets {
+			tasks := make([]*storage.Task, len(taskStateSet))
+			for i, ts := range taskStateSet {
+				tasks[i] = taskWith(ts)
+			}
+			client := &LocalClient{
+				storage: &exactProgressStorage{
+					applyOperations: &listApplyOperationStore{
+						ops: []*storage.ApplyOperation{
+							{ID: currentOpID, State: state.ApplyOperation.Pending},
+						},
+					},
+				},
+				logger: slog.Default(),
+			}
+			apply := &storage.Apply{ID: 7, ApplyIdentifier: "apply-one-op"}
+
+			got := client.deriveAggregateApplyState(t.Context(), apply, tasks)
+			want := state.DeriveApplyState(taskStates(tasks))
+			assert.Equal(t, want, got, "task states %v", taskStateSet)
+		}
+	})
+
+	t.Run("pending sibling keeps the apply non-terminal", func(t *testing.T) {
+		tasks := []*storage.Task{taskWith(state.Task.Completed)}
+		client := &LocalClient{
+			storage: &exactProgressStorage{
+				applyOperations: &listApplyOperationStore{
+					ops: []*storage.ApplyOperation{
+						{ID: currentOpID, State: state.ApplyOperation.Running},
+						{ID: 2, State: state.ApplyOperation.Pending},
+					},
+				},
+			},
+			logger: slog.Default(),
+		}
+		apply := &storage.Apply{ID: 7, ApplyIdentifier: "apply-multi-op"}
+
+		got := client.deriveAggregateApplyState(t.Context(), apply, tasks)
+		assert.False(t, state.IsTerminalApplyState(got), "derived state %q must be non-terminal", got)
+		assert.False(t, state.IsState(got, state.Apply.Completed), "derived state must not clobber the pending sibling to completed")
+	})
+
+	t.Run("falls back to current deployment derivation when operations cannot be read", func(t *testing.T) {
+		tasks := []*storage.Task{taskWith(state.Task.Completed)}
+		client := &LocalClient{
+			storage: &exactProgressStorage{
+				applyOperations: &listApplyOperationStore{err: assert.AnError},
+			},
+			logger: slog.Default(),
+		}
+		apply := &storage.Apply{ID: 7, ApplyIdentifier: "apply-fallback"}
+
+		got := client.deriveAggregateApplyState(t.Context(), apply, tasks)
+		assert.Equal(t, state.DeriveApplyState(taskStates(tasks)), got)
+	})
+}

--- a/pkg/tern/local_client_test.go
+++ b/pkg/tern/local_client_test.go
@@ -1147,8 +1147,9 @@ func TestDeriveAggregateApplyState(t *testing.T) {
 			}
 			apply := &storage.Apply{ID: 7, ApplyIdentifier: "apply-one-op"}
 
-			got := client.deriveAggregateApplyState(t.Context(), apply, tasks)
+			got, ok := client.deriveAggregateApplyState(t.Context(), apply, tasks)
 			want := state.DeriveApplyState(taskStates(tasks))
+			assert.True(t, ok, "task states %v: current op row present, projection must be determined", taskStateSet)
 			assert.Equal(t, want, got, "task states %v", taskStateSet)
 		}
 	})
@@ -1168,53 +1169,55 @@ func TestDeriveAggregateApplyState(t *testing.T) {
 		}
 		apply := &storage.Apply{ID: 7, ApplyIdentifier: "apply-multi-op"}
 
-		got := client.deriveAggregateApplyState(t.Context(), apply, tasks)
+		got, ok := client.deriveAggregateApplyState(t.Context(), apply, tasks)
+		assert.True(t, ok, "current op row present, projection must be determined")
 		assert.False(t, state.IsTerminalApplyState(got), "derived state %q must be non-terminal", got)
 		assert.False(t, state.IsState(got, state.Apply.Completed), "derived state must not clobber the pending sibling to completed")
 	})
 
-	t.Run("falls back to current deployment derivation when operations cannot be read", func(t *testing.T) {
-		tasks := []*storage.Task{taskWith(state.Task.Completed)}
-		client := &LocalClient{
-			storage: &exactProgressStorage{
-				applyOperations: &listApplyOperationStore{err: assert.AnError},
+	// Degraded paths (sibling rows unknown) must never terminalize the apply on
+	// incomplete information: a transient read failure on the last-finishing
+	// deployment would otherwise mark the whole apply terminal while siblings are
+	// still in flight. The projection is reported undetermined (ok=false) so the
+	// caller keeps the stored value for the next poll to reconcile.
+	degradedStores := map[string]storage.ApplyOperationStore{
+		"operations cannot be read":     &listApplyOperationStore{err: assert.AnError},
+		"operation store not available": nil,
+		"current operation row missing": &listApplyOperationStore{
+			ops: []*storage.ApplyOperation{
+				{ID: 2, State: state.ApplyOperation.Pending},
+				{ID: 3, State: state.ApplyOperation.Pending},
 			},
-			logger: slog.Default(),
-		}
-		apply := &storage.Apply{ID: 7, ApplyIdentifier: "apply-fallback"}
+		},
+	}
 
-		got := client.deriveAggregateApplyState(t.Context(), apply, tasks)
-		assert.Equal(t, state.DeriveApplyState(taskStates(tasks)), got)
-	})
+	for name, store := range degradedStores {
+		t.Run("degraded ("+name+") refuses to terminalize a terminal current deployment", func(t *testing.T) {
+			tasks := []*storage.Task{taskWith(state.Task.Completed)}
+			client := &LocalClient{
+				storage: &exactProgressStorage{applyOperations: store},
+				logger:  slog.Default(),
+			}
+			apply := &storage.Apply{ID: 7, ApplyIdentifier: "apply-degraded-terminal"}
 
-	t.Run("falls back to current deployment derivation when the operation store is not configured", func(t *testing.T) {
-		tasks := []*storage.Task{taskWith(state.Task.Completed)}
-		client := &LocalClient{
-			storage: &exactProgressStorage{applyOperations: nil},
-			logger:  slog.Default(),
-		}
-		apply := &storage.Apply{ID: 7, ApplyIdentifier: "apply-no-store"}
+			require.True(t, state.IsTerminalApplyState(state.DeriveApplyState(taskStates(tasks))), "precondition: current deployment derives terminal")
+			_, ok := client.deriveAggregateApplyState(t.Context(), apply, tasks)
+			assert.False(t, ok, "must not overwrite stored apply state from a terminal single-op derivation")
+		})
 
-		got := client.deriveAggregateApplyState(t.Context(), apply, tasks)
-		assert.Equal(t, state.DeriveApplyState(taskStates(tasks)), got)
-	})
+		t.Run("degraded ("+name+") falls back to a non-terminal current deployment", func(t *testing.T) {
+			tasks := []*storage.Task{taskWith(state.Task.Running), taskWith(state.Task.Pending)}
+			client := &LocalClient{
+				storage: &exactProgressStorage{applyOperations: store},
+				logger:  slog.Default(),
+			}
+			apply := &storage.Apply{ID: 7, ApplyIdentifier: "apply-degraded-active"}
 
-	t.Run("falls back to current deployment derivation when the current operation row is missing", func(t *testing.T) {
-		tasks := []*storage.Task{taskWith(state.Task.Completed)}
-		client := &LocalClient{
-			storage: &exactProgressStorage{
-				applyOperations: &listApplyOperationStore{
-					ops: []*storage.ApplyOperation{
-						{ID: 2, State: state.ApplyOperation.Pending},
-						{ID: 3, State: state.ApplyOperation.Pending},
-					},
-				},
-			},
-			logger: slog.Default(),
-		}
-		apply := &storage.Apply{ID: 7, ApplyIdentifier: "apply-missing-current-op"}
-
-		got := client.deriveAggregateApplyState(t.Context(), apply, tasks)
-		assert.Equal(t, state.DeriveApplyState(taskStates(tasks)), got)
-	})
+			want := state.DeriveApplyState(taskStates(tasks))
+			require.False(t, state.IsTerminalApplyState(want), "precondition: current deployment derives non-terminal")
+			got, ok := client.deriveAggregateApplyState(t.Context(), apply, tasks)
+			assert.True(t, ok, "non-terminal single-op derivation is a safe fallback")
+			assert.Equal(t, want, got)
+		})
+	}
 }


### PR DESCRIPTION
## What and Why ?

The per-deployment drive sources the aggregate `applies.state` from only its own task states. With one operation per apply that is correct, but once an apply owns more than one operation, one deployment's drive would overwrite the rollout-level state from just its own tasks — e.g. marking the apply `completed` while a sibling is still `pending`.

This change derives `applies.state` as the rollout projection over **all** of the apply's operation rows, folding in the current deployment's freshly-derived state, via a new `deriveAggregateApplyState` helper used at both drive sites.

before:  apply.State = DeriveApplyState(taskStates(thisOpTasks))
after:   apply.State = DeriveApplyState(state of every operation row, this op folded in)

Behaviour-identical at one operation per apply (the sibling set is the single current op, and `DeriveApplyState` round-trips its own outputs). When the sibling rows cannot be read, the projection falls back to the current op's derived state only if that state is non-terminal; a terminal derivation on incomplete sibling information is refused (the helper reports the projection as undetermined and the caller leaves the stored value for the next poll to reconcile), so a transient read failure on one deployment cannot terminalize the whole apply while siblings are still in flight. Once the multi-deployment fan-out lands, a non-terminal sibling keeps the apply non-terminal, eliminating the clobber that would otherwise re-terminalize the parent mid-rollout.

Dormant until the fan-out is wired (one operation per apply today).

## Roadmap / upcoming PRs

This is the **apply-state / continuation projection** track. Follow-ups, each independently reviewable:

| Ref | Upcoming change | Status | PR |
|---|---|---|---|
| B1 | Derive `applies.state` from all operation rows (no sibling clobber) | This PR | #318 |
| B2 | `continue` projection: hold apply active until all siblings settle — incl. stamping `CompletedAt` from the rollout aggregate, not from a single finished op | Planned | TBD |
| B3 | Eager failure surfacing + `stop` halts remaining siblings under `continue` — incl. surfacing `ErrorMessage` from the aggregate (not the last op) and a conditional/CAS `applies.state` write to drop last-write-wins on concurrent sibling drives | Planned | TBD |
| B4 | `running_degraded` state for active-with-known-failure (fast follow) | Future | TBD |

## Merge note

This branch merges `main`. The diff includes one unrelated line in `pkg/storage/mysqlstore/apply_operations_test.go` — fixing a `FindNextApplyOperation` call that was missing its `owner` argument on `main` and broke the integration build. Pure test-arity fix; no production behavior change.
