### PR TITLE
feat(github): render multi-deployment apply comment from presentation model

### DIFF
--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -3990,6 +3990,11 @@ No schema changes found for database 'new-db'
 ```
 </details>
 
+
+## Apply Gates
+
+### PR Comments
+
 <details>
 <summary><a name="apply-plan-lock--confirm"></a><strong>Apply Plan (Lock + Confirm)</strong></summary>
 
@@ -4455,6 +4460,371 @@ Wait for checks to complete and retry:
 schemabot apply -e staging
 ```
 
+</details>
+
+## Multi-Deployment Apply
+
+### PR Comments
+
+<details>
+<summary><a name="barrier-rollout-in-progress"></a><strong>Barrier Rollout In Progress</strong></summary>
+
+
+## Schema Change In Progress
+
+**Environment**: `production` | **Apply ID**: `apply-a1b2c3d4e5f6` | **Elapsed**: 12m
+
+*Applied by @aparajon at 2026-01-01 00:00:00 UTC*
+
+**Deployments**: 1 ready for cutover, 1 running, 2 waiting
+
+---
+
+To cut over `eu`:
+```
+schemabot cutover apply-a1b2c3d4e5f6
+```
+
+- 🟢 eu — ready for cutover — next in order
+- 🔄 us — running table copy
+- ⏳ au — waiting for us
+- ⏳ ca — waiting for us
+
+<details open>
+<summary>🟢 eu — ready for cutover — next in order</summary>
+
+## Schema Change — Waiting for Cutover
+
+**Database**: `payments_eu` | **Environment**: `production` | **Apply ID**: `apply-a1b2c3d4e5f6` | **Elapsed**: 8m
+
+*Applied by @aparajon at 2026-01-01 00:00:00 UTC*
+
+**0/3** table(s) ready for cutover — waiting on 3
+
+📊 3 waiting for cutover
+
+### Table Progress
+
+**`orders`**: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 Waiting for cutover
+
+```sql
+ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
+```
+
+**`users`**: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 Waiting for cutover
+
+```sql
+ALTER TABLE `users` ADD INDEX `idx_email`(`email`);
+```
+
+**`products`**: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 Waiting for cutover
+
+```sql
+ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
+```
+
+
+---
+
+To proceed with cutover:
+```
+schemabot cutover apply-a1b2c3d4e5f6
+```
+
+</details>
+
+<details open>
+<summary>🔄 us — running table copy</summary>
+
+## Schema Change In Progress
+
+**Database**: `payments_us` | **Environment**: `production` | **Apply ID**: `apply-a1b2c3d4e5f6` | **Elapsed**: 8m
+
+*Applied by @aparajon at 2026-01-01 00:00:00 UTC*
+
+📊 1/3 complete · 1 running (62%) · 1 queued
+
+### Table Progress
+
+**`users`**: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦⬜⬜⬜⬜⬜⬜⬜⬜ 62%
+
+```sql
+ALTER TABLE `users` ADD INDEX `idx_email`(`email`);
+```
+Rows: 914,707 / 1,466,232 · ETA: 3m 15s
+
+**`products`**: ⏳ Queued
+
+```sql
+ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
+```
+
+**`orders`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+
+```sql
+ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
+```
+
+
+---
+
+To stop this schema change:
+```
+schemabot stop apply-a1b2c3d4e5f6
+```
+
+</details>
+
+<details>
+<summary>⏳ au — waiting for us</summary>
+
+_No details available yet._
+
+</details>
+
+<details>
+<summary>⏳ ca — waiting for us</summary>
+
+_No details available yet._
+
+</details>
+
+</details>
+
+<details>
+<summary><a name="halt-on-failure-one-deployment-failed"></a><strong>Halt On Failure (One Deployment Failed)</strong></summary>
+
+
+## ❌ Schema Change Failed
+
+**Environment**: `production` | **Apply ID**: `apply-a1b2c3d4e5f6` | **Elapsed**: 20m
+
+*Applied by @aparajon at 2026-01-01 00:00:00 UTC*
+
+**Deployments**: 1 completed, 2 halted, 1 failed
+
+---
+
+To retry:
+```
+schemabot apply -e production
+```
+
+- ✅ eu — completed
+- ❌ us — failed
+- ⏸ au — halted — us failed
+- ⏸ ca — halted — us failed
+
+<details>
+<summary>✅ eu — completed</summary>
+
+## ✅ Schema Change Applied
+
+**Database**: `payments_eu` | **Environment**: `production` | **Apply ID**: `apply-a1b2c3d4e5f6` | **Elapsed**: 8m
+
+*Applied by @aparajon at 2026-01-01 00:00:00 UTC*
+
+📊 3/3 complete
+
+### Table Progress
+
+**`orders`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+
+```sql
+ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
+```
+
+**`users`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+
+```sql
+ALTER TABLE `users` ADD INDEX `idx_email`(`email`);
+```
+
+**`products`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+
+```sql
+ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
+```
+
+
+</details>
+
+<details open>
+<summary>❌ us — failed</summary>
+
+## ❌ Schema Change Failed
+
+**Database**: `payments_us` | **Environment**: `production` | **Apply ID**: `apply-a1b2c3d4e5f6` | **Elapsed**: 8m
+
+*Applied by @aparajon at 2026-01-01 00:00:00 UTC*
+
+📊 1/3 complete · 1 failed · 1 cancelled
+
+### Table Progress
+
+**`users`**: 🟥🟥🟥🟥🟥🟥⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ ❌ Failed
+
+```sql
+ALTER TABLE `users` ADD INDEX `idx_email`(`email`);
+```
+
+**`orders`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+
+```sql
+ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
+```
+
+**`products`**: ⊘ Cancelled (not started)
+
+```sql
+ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
+```
+
+
+> ⚠️ **Error:** lock wait timeout exceeded; try restarting transaction
+
+---
+
+To retry:
+```
+schemabot apply -e production
+```
+
+</details>
+
+<details open>
+<summary>⏸ au — halted — us failed</summary>
+
+_No details available yet._
+
+</details>
+
+<details open>
+<summary>⏸ ca — halted — us failed</summary>
+
+_No details available yet._
+
+</details>
+
+</details>
+
+<details>
+<summary><a name="all-deployments-completed"></a><strong>All Deployments Completed</strong></summary>
+
+
+## ✅ Schema Change Applied
+
+**Environment**: `production` | **Apply ID**: `apply-a1b2c3d4e5f6` | **Elapsed**: 28m
+
+*Applied by @aparajon at 2026-01-01 00:00:00 UTC*
+
+**Deployments**: 3 completed
+
+- ✅ eu — completed
+- ✅ us — completed
+- ✅ au — completed
+
+<details>
+<summary>✅ eu — completed</summary>
+
+## ✅ Schema Change Applied
+
+**Database**: `payments_eu` | **Environment**: `production` | **Apply ID**: `apply-a1b2c3d4e5f6` | **Elapsed**: 8m
+
+*Applied by @aparajon at 2026-01-01 00:00:00 UTC*
+
+📊 3/3 complete
+
+### Table Progress
+
+**`orders`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+
+```sql
+ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
+```
+
+**`users`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+
+```sql
+ALTER TABLE `users` ADD INDEX `idx_email`(`email`);
+```
+
+**`products`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+
+```sql
+ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
+```
+
+
+</details>
+
+<details>
+<summary>✅ us — completed</summary>
+
+## ✅ Schema Change Applied
+
+**Database**: `payments_us` | **Environment**: `production` | **Apply ID**: `apply-a1b2c3d4e5f6` | **Elapsed**: 8m
+
+*Applied by @aparajon at 2026-01-01 00:00:00 UTC*
+
+📊 3/3 complete
+
+### Table Progress
+
+**`orders`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+
+```sql
+ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
+```
+
+**`users`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+
+```sql
+ALTER TABLE `users` ADD INDEX `idx_email`(`email`);
+```
+
+**`products`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+
+```sql
+ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
+```
+
+
+</details>
+
+<details>
+<summary>✅ au — completed</summary>
+
+## ✅ Schema Change Applied
+
+**Database**: `payments_au` | **Environment**: `production` | **Apply ID**: `apply-a1b2c3d4e5f6` | **Elapsed**: 8m
+
+*Applied by @aparajon at 2026-01-01 00:00:00 UTC*
+
+📊 3/3 complete
+
+### Table Progress
+
+**`orders`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+
+```sql
+ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
+```
+
+**`users`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+
+```sql
+ALTER TABLE `users` ADD INDEX `idx_email`(`email`);
+```
+
+**`products`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+
+```sql
+ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
+```
+
+
+</details>
 </details>
 
 ## Sequential Mode (CLI)

--- a/pkg/cmd/commands/preview.go
+++ b/pkg/cmd/commands/preview.go
@@ -83,6 +83,8 @@ func (cmd *PreviewCmd) Run(g *Globals) error {
 		templates.PreviewCommentApplyEstimateExceeded,
 		templates.PreviewCommentApplyFailed, templates.PreviewCommentApplyStopped,
 		templates.PreviewCommentApplyWaitingCutover, templates.PreviewCommentApplyCuttingOver,
+		templates.PreviewCommentMultiDeployInProgress, templates.PreviewCommentMultiDeployFailed,
+		templates.PreviewCommentMultiDeployCompleted, templates.PreviewCommentMultiDeployAll,
 		templates.PreviewCommentSingleProgress, templates.PreviewCommentSingleComplete,
 		templates.PreviewCommentSingleFailed, templates.PreviewCommentSingleStopped,
 		templates.PreviewCommentSummaryCompleted, templates.PreviewCommentSummaryFailed,

--- a/pkg/cmd/internal/templates/preview.go
+++ b/pkg/cmd/internal/templates/preview.go
@@ -131,6 +131,12 @@ const (
 	PreviewCommentApplyWaitingCutover   PreviewType = "comment_apply_waiting_cutover"   // Waiting for cutover
 	PreviewCommentApplyCuttingOver      PreviewType = "comment_apply_cutting_over"      // Cutting over
 
+	// Multi-deployment apply comment previews (one apply fanned out across deployments)
+	PreviewCommentMultiDeployInProgress PreviewType = "comment_multi_deploy_in_progress" // Barrier rollout mid-flight
+	PreviewCommentMultiDeployFailed     PreviewType = "comment_multi_deploy_failed"      // Halt-on-failure: one deployment failed
+	PreviewCommentMultiDeployCompleted  PreviewType = "comment_multi_deploy_completed"   // All deployments completed
+	PreviewCommentMultiDeployAll        PreviewType = "comment_multi_deploy_all"         // Show all multi-deployment apply previews
+
 	// Single-table apply comment previews (most common case)
 	PreviewCommentSingleProgress          PreviewType = "comment_single_progress"            // Single table running
 	PreviewCommentSingleComplete          PreviewType = "comment_single_complete"            // Single table completed

--- a/pkg/cmd/internal/templates/preview_comment.go
+++ b/pkg/cmd/internal/templates/preview_comment.go
@@ -227,6 +227,18 @@ func previewCommentApplyFlowAllOutput() {
 	printSections(sections)
 }
 
+func previewCommentMultiDeployAllOutput() {
+	sections := []struct {
+		name string
+		fn   func()
+	}{
+		{"BARRIER ROLLOUT IN PROGRESS", func() { fmt.Print(webhooktemplates.PreviewCommentMultiDeploymentApplyInProgress()) }},
+		{"HALT ON FAILURE (ONE DEPLOYMENT FAILED)", func() { fmt.Print(webhooktemplates.PreviewCommentMultiDeploymentApplyFailed()) }},
+		{"ALL DEPLOYMENTS COMPLETED", func() { fmt.Print(webhooktemplates.PreviewCommentMultiDeploymentApplyCompleted()) }},
+	}
+	printSections(sections)
+}
+
 func previewCLIPlanAllOutput() {
 	sections := []struct {
 		name string

--- a/pkg/cmd/internal/templates/preview_dispatch.go
+++ b/pkg/cmd/internal/templates/preview_dispatch.go
@@ -153,6 +153,14 @@ func PreviewCLIOutput(previewType PreviewType) {
 		fmt.Print(webhooktemplates.PreviewCommentApplyWaitingForCutover())
 	case PreviewCommentApplyCuttingOver:
 		fmt.Print(webhooktemplates.PreviewCommentApplyCuttingOver())
+	case PreviewCommentMultiDeployInProgress:
+		fmt.Print(webhooktemplates.PreviewCommentMultiDeploymentApplyInProgress())
+	case PreviewCommentMultiDeployFailed:
+		fmt.Print(webhooktemplates.PreviewCommentMultiDeploymentApplyFailed())
+	case PreviewCommentMultiDeployCompleted:
+		fmt.Print(webhooktemplates.PreviewCommentMultiDeploymentApplyCompleted())
+	case PreviewCommentMultiDeployAll:
+		previewCommentMultiDeployAllOutput()
 	case PreviewCommentSingleProgress:
 		fmt.Print(webhooktemplates.PreviewCommentApplySingleProgress())
 	case PreviewCommentSingleComplete:

--- a/pkg/webhook/templates/multi_apply.go
+++ b/pkg/webhook/templates/multi_apply.go
@@ -1,0 +1,169 @@
+package templates
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/block/schemabot/pkg/presentation"
+)
+
+// MultiDeploymentApplyData is the input to the multi-deployment apply comment.
+// It bundles the surface-agnostic rollup (pkg/presentation) with each
+// deployment's existing single-deployment comment data, so the per-deployment
+// detail is rendered by exactly the same code path a single-deployment apply
+// uses today — the multi-deployment comment only adds the aggregate header and
+// the per-deployment hierarchy on top.
+type MultiDeploymentApplyData struct {
+	// Model is the derived rollup: aggregate state/label/counts/next-action and
+	// the per-deployment presentations in resolved deployment order.
+	Model presentation.Apply
+
+	// ApplyID is the parent apply's identifier, shown once in the aggregate header.
+	ApplyID string
+
+	// Environment is the rollout environment, shown in the header and used to
+	// format the next-action command.
+	Environment string
+
+	// RequestedBy is the operator who requested the apply.
+	RequestedBy string
+
+	// StartedAt / CompletedAt are RFC3339 timestamps for the aggregate elapsed time.
+	StartedAt   string
+	CompletedAt string
+
+	// Details maps a deployment name to that deployment's single-deployment
+	// comment data (its tables, error, timing, database). Each deployment's
+	// <details> body is rendered from its entry via RenderApplyStatusComment.
+	Details map[string]ApplyStatusCommentData
+}
+
+// RenderMultiDeploymentApplyComment renders the PR comment for an apply that
+// fans out across more than one deployment. The layout, per the multi-deployment
+// UX: an aggregate header (state title, metadata, per-status counts, and the
+// single next operator action), then a flat per-deployment summary so rollout
+// health and any failure are visible without expanding, then a <details> section
+// per deployment carrying today's per-table UX scoped to that deployment.
+//
+// The single-deployment case is intentionally not handled here: callers render
+// it with RenderApplyStatusComment so that UX stays byte-for-byte unchanged.
+func RenderMultiDeploymentApplyComment(data MultiDeploymentApplyData) string {
+	var sb strings.Builder
+
+	// Aggregate header: reuse the single-deployment title map keyed on the
+	// derived aggregate state so the headline vocabulary is identical.
+	writeApplyHeader(&sb, ApplyStatusCommentData{State: data.Model.State})
+	writeAggregateMetadata(&sb, data)
+	writeDeploymentCounts(&sb, data.Model.Counts)
+	writeAggregateNextAction(&sb, data)
+
+	// Flat per-deployment summary (always visible — survives any later size
+	// trimming of the detail sections).
+	writeDeploymentSummaryList(&sb, data.Model.Deployments)
+
+	// Expandable per-deployment detail, in resolved order.
+	writeDeploymentSections(&sb, data)
+
+	return sb.String()
+}
+
+// writeAggregateMetadata writes the apply-level metadata line. The database is
+// intentionally omitted — it is per-deployment and shown in each deployment's
+// section — so the aggregate carries only the environment, apply ID, elapsed
+// time, and requester.
+func writeAggregateMetadata(sb *strings.Builder, data MultiDeploymentApplyData) {
+	var parts []string
+	if data.Environment != "" {
+		parts = append(parts, fmt.Sprintf("**Environment**: `%s`", data.Environment))
+	}
+	if data.ApplyID != "" {
+		parts = append(parts, fmt.Sprintf("**Apply ID**: `%s`", data.ApplyID))
+	}
+	if elapsed := applyElapsed(ApplyStatusCommentData{StartedAt: data.StartedAt, CompletedAt: data.CompletedAt}); elapsed != "" {
+		parts = append(parts, fmt.Sprintf("**Elapsed**: %s", elapsed))
+	}
+	if len(parts) > 0 {
+		fmt.Fprintf(sb, "%s\n", strings.Join(parts, " | "))
+	}
+	writeAppliedByOrTimestamp(sb, data.RequestedBy)
+}
+
+// writeDeploymentCounts writes the per-status histogram so an operator sees
+// rollout health at a glance without expanding anything.
+func writeDeploymentCounts(sb *strings.Builder, counts []presentation.StateCount) {
+	if len(counts) == 0 {
+		return
+	}
+	parts := make([]string, 0, len(counts))
+	for _, c := range counts {
+		parts = append(parts, fmt.Sprintf("%d %s", c.Count, c.Label))
+	}
+	fmt.Fprintf(sb, "\n**Deployments**: %s\n", strings.Join(parts, ", "))
+}
+
+// writeAggregateNextAction renders the single suggested operator action derived
+// for the rollup, if any. The verb set mirrors the per-deployment commands the
+// CLI exposes; an empty action (NextActionNone) writes nothing.
+func writeAggregateNextAction(sb *strings.Builder, data MultiDeploymentApplyData) {
+	na := data.Model.NextAction
+	switch na.Kind {
+	case presentation.NextActionCutover:
+		writeFooterAction(sb,
+			fmt.Sprintf("To cut over `%s`:", na.Deployment),
+			fmt.Sprintf("schemabot cutover -e %s --deployment %s", data.Environment, na.Deployment))
+	case presentation.NextActionResume:
+		writeFooterAction(sb, "To resume:", fmt.Sprintf("schemabot start -e %s", data.Environment))
+	case presentation.NextActionReviewFailure:
+		if na.Deployment != "" {
+			writeFooterAction(sb,
+				fmt.Sprintf("Review the failure in `%s`, then revert:", na.Deployment),
+				fmt.Sprintf("schemabot revert -e %s --deployment %s", data.Environment, na.Deployment))
+		} else {
+			writeFooterAction(sb, "Review the failed deployment, then revert:",
+				fmt.Sprintf("schemabot revert -e %s", data.Environment))
+		}
+	case presentation.NextActionNone:
+		// No operator action is pending; nothing to render.
+	}
+}
+
+// writeDeploymentSummaryList writes one line per deployment (status glyph, name,
+// derived label) in resolved order. This is the at-a-glance rollout view and the
+// part that must always remain even if detail sections are later trimmed for size.
+func writeDeploymentSummaryList(sb *strings.Builder, deps []presentation.Deployment) {
+	if len(deps) == 0 {
+		return
+	}
+	sb.WriteString("\n")
+	for _, d := range deps {
+		fmt.Fprintf(sb, "- %s — %s\n", deploymentTag(d), d.Label)
+	}
+}
+
+// writeDeploymentSections writes a <details> block per deployment in resolved
+// order. Active and problematic deployments default open; completed and queued
+// ones default collapsed (the model's Open flag). The body reuses the
+// single-deployment renderer so per-table progress, errors, and DDL keep today's
+// fidelity scoped to one deployment.
+func writeDeploymentSections(sb *strings.Builder, data MultiDeploymentApplyData) {
+	for _, d := range data.Model.Deployments {
+		openAttr := ""
+		if d.Open {
+			openAttr = " open"
+		}
+		fmt.Fprintf(sb, "\n<details%s>\n<summary>%s — %s</summary>\n\n", openAttr, deploymentTag(d), d.Label)
+		if detail, ok := data.Details[d.Deployment]; ok {
+			sb.WriteString(RenderApplyStatusComment(detail))
+		}
+		sb.WriteString("\n</details>\n")
+	}
+}
+
+// deploymentTag renders the "<emoji> <deployment>" prefix, omitting the leading
+// space when a state has no glyph.
+func deploymentTag(d presentation.Deployment) string {
+	if d.Emoji == "" {
+		return d.Deployment
+	}
+	return fmt.Sprintf("%s %s", d.Emoji, d.Deployment)
+}

--- a/pkg/webhook/templates/multi_apply.go
+++ b/pkg/webhook/templates/multi_apply.go
@@ -2,6 +2,7 @@ package templates
 
 import (
 	"fmt"
+	"html"
 	"strings"
 
 	"github.com/block/schemabot/pkg/presentation"
@@ -18,11 +19,14 @@ type MultiDeploymentApplyData struct {
 	// the per-deployment presentations in resolved deployment order.
 	Model presentation.Apply
 
-	// ApplyID is the parent apply's identifier, shown once in the aggregate header.
+	// ApplyID is the parent apply's identifier, shown once in the aggregate
+	// header and used to format the next-action commands. Always set: every
+	// apply is created with a server-generated identifier.
 	ApplyID string
 
 	// Environment is the rollout environment, shown in the header and used to
-	// format the next-action command.
+	// format the next-action commands. Always set: a non-empty environment is
+	// enforced when the apply is created.
 	Environment string
 
 	// RequestedBy is the operator who requested the apply.
@@ -72,19 +76,16 @@ func RenderMultiDeploymentApplyComment(data MultiDeploymentApplyData) string {
 // section — so the aggregate carries only the environment, apply ID, elapsed
 // time, and requester.
 func writeAggregateMetadata(sb *strings.Builder, data MultiDeploymentApplyData) {
-	var parts []string
-	if data.Environment != "" {
-		parts = append(parts, fmt.Sprintf("**Environment**: `%s`", data.Environment))
-	}
-	if data.ApplyID != "" {
-		parts = append(parts, fmt.Sprintf("**Apply ID**: `%s`", data.ApplyID))
+	// Environment and ApplyID are always populated from the persisted apply, so
+	// they are rendered unconditionally; only the optional elapsed time is guarded.
+	parts := []string{
+		fmt.Sprintf("**Environment**: `%s`", data.Environment),
+		fmt.Sprintf("**Apply ID**: `%s`", data.ApplyID),
 	}
 	if elapsed := applyElapsed(ApplyStatusCommentData{StartedAt: data.StartedAt, CompletedAt: data.CompletedAt}); elapsed != "" {
 		parts = append(parts, fmt.Sprintf("**Elapsed**: %s", elapsed))
 	}
-	if len(parts) > 0 {
-		fmt.Fprintf(sb, "%s\n", strings.Join(parts, " | "))
-	}
+	fmt.Fprintf(sb, "%s\n", strings.Join(parts, " | "))
 	writeAppliedByOrTimestamp(sb, data.RequestedBy)
 }
 
@@ -102,26 +103,25 @@ func writeDeploymentCounts(sb *strings.Builder, counts []presentation.StateCount
 }
 
 // writeAggregateNextAction renders the single suggested operator action derived
-// for the rollup, if any. The verb set mirrors the per-deployment commands the
-// CLI exposes; an empty action (NextActionNone) writes nothing.
+// for the rollup, if any. An empty action (NextActionNone) writes nothing.
 func writeAggregateNextAction(sb *strings.Builder, data MultiDeploymentApplyData) {
+	// The CLI today addresses an apply by its identifier and has no
+	// --deployment flag, so the suggested commands mirror the executable forms
+	// the single-deployment footer already ships. Deployment-targeted commands
+	// arrive with the per-deployment CLI surface.
 	na := data.Model.NextAction
 	switch na.Kind {
 	case presentation.NextActionCutover:
 		writeFooterAction(sb,
 			fmt.Sprintf("To cut over `%s`:", na.Deployment),
-			fmt.Sprintf("schemabot cutover -e %s --deployment %s", data.Environment, na.Deployment))
+			fmt.Sprintf("schemabot cutover %s", data.ApplyID))
 	case presentation.NextActionResume:
-		writeFooterAction(sb, "To resume:", fmt.Sprintf("schemabot start -e %s", data.Environment))
+		writeFooterAction(sb, "To resume:", fmt.Sprintf("schemabot start %s", data.ApplyID))
 	case presentation.NextActionReviewFailure:
-		if na.Deployment != "" {
-			writeFooterAction(sb,
-				fmt.Sprintf("Review the failure in `%s`, then revert:", na.Deployment),
-				fmt.Sprintf("schemabot revert -e %s --deployment %s", data.Environment, na.Deployment))
-		} else {
-			writeFooterAction(sb, "Review the failed deployment, then revert:",
-				fmt.Sprintf("schemabot revert -e %s", data.Environment))
-		}
+		// revert applies only to a deployment still in its post-cutover revert
+		// window, not to a failure; the recovery path for a failed apply is a
+		// retry, matching the single-deployment failed footer.
+		writeFooterAction(sb, "To retry:", fmt.Sprintf("schemabot apply -e %s", data.Environment))
 	case presentation.NextActionNone:
 		// No operator action is pending; nothing to render.
 	}
@@ -136,7 +136,7 @@ func writeDeploymentSummaryList(sb *strings.Builder, deps []presentation.Deploym
 	}
 	sb.WriteString("\n")
 	for _, d := range deps {
-		fmt.Fprintf(sb, "- %s — %s\n", deploymentTag(d), d.Label)
+		fmt.Fprintf(sb, "- %s — %s\n", deploymentTag(d), html.EscapeString(d.Label))
 	}
 }
 
@@ -151,9 +151,11 @@ func writeDeploymentSections(sb *strings.Builder, data MultiDeploymentApplyData)
 		if d.Open {
 			openAttr = " open"
 		}
-		fmt.Fprintf(sb, "\n<details%s>\n<summary>%s — %s</summary>\n\n", openAttr, deploymentTag(d), d.Label)
+		fmt.Fprintf(sb, "\n<details%s>\n<summary>%s — %s</summary>\n\n", openAttr, deploymentTag(d), html.EscapeString(d.Label))
 		if detail, ok := data.Details[d.Deployment]; ok {
 			sb.WriteString(RenderApplyStatusComment(detail))
+		} else {
+			sb.WriteString("_No details available yet._\n")
 		}
 		sb.WriteString("\n</details>\n")
 	}
@@ -162,8 +164,9 @@ func writeDeploymentSections(sb *strings.Builder, data MultiDeploymentApplyData)
 // deploymentTag renders the "<emoji> <deployment>" prefix, omitting the leading
 // space when a state has no glyph.
 func deploymentTag(d presentation.Deployment) string {
+	name := html.EscapeString(d.Deployment)
 	if d.Emoji == "" {
-		return d.Deployment
+		return name
 	}
-	return fmt.Sprintf("%s %s", d.Emoji, d.Deployment)
+	return fmt.Sprintf("%s %s", d.Emoji, name)
 }

--- a/pkg/webhook/templates/multi_apply_test.go
+++ b/pkg/webhook/templates/multi_apply_test.go
@@ -42,9 +42,11 @@ func TestRenderMultiDeploymentApplyComment_BarrierInProgress(t *testing.T) {
 	assert.Contains(t, out, "**Deployments**: 1 ready for cutover, 1 running, 2 waiting")
 
 	// Single next-action points at the cutover-ready deployment, even though the
-	// aggregate is still running.
+	// aggregate is still running. The command is the executable apply-ID form the
+	// CLI accepts today (no --deployment flag yet).
 	assert.Contains(t, out, "To cut over `eu`:")
-	assert.Contains(t, out, "schemabot cutover -e production --deployment eu")
+	assert.Contains(t, out, "schemabot cutover apply-123")
+	assert.NotContains(t, out, "--deployment")
 
 	// Per-deployment summary lines, in resolved order, with derived labels.
 	assert.Contains(t, out, "- 🟢 eu — ready for cutover — next in order")
@@ -60,8 +62,8 @@ func TestRenderMultiDeploymentApplyComment_BarrierInProgress(t *testing.T) {
 }
 
 // A halt-on-failure rollout with a failed deployment keeps the aggregate failed,
-// names the failure as the next action, and marks the never-started deployments
-// as halted (and open, since halted explains the next action).
+// offers retry as the next action, and marks the never-started deployments as
+// halted (and open, since halted explains the next action).
 func TestRenderMultiDeploymentApplyComment_FailedHalt(t *testing.T) {
 	model := presentation.Derive([]presentation.Operation{
 		rollingOp("eu", so.WaitingForCutover),
@@ -71,13 +73,17 @@ func TestRenderMultiDeploymentApplyComment_FailedHalt(t *testing.T) {
 	})
 	out := RenderMultiDeploymentApplyComment(MultiDeploymentApplyData{
 		Model:       model,
+		ApplyID:     "apply-123",
 		Environment: "production",
 	})
 
 	assert.Contains(t, out, "## ❌ Schema Change Failed")
 	assert.Contains(t, out, "**Deployments**: 1 ready for cutover, 2 halted, 1 failed")
-	assert.Contains(t, out, "Review the failure in `us`, then revert:")
-	assert.Contains(t, out, "schemabot revert -e production --deployment us")
+	// The recovery path for a failed apply is retry, matching the single-deployment
+	// footer. revert is only for a deployment in its post-cutover revert window.
+	assert.Contains(t, out, "To retry:")
+	assert.Contains(t, out, "schemabot apply -e production")
+	assert.NotContains(t, out, "schemabot revert")
 	assert.Contains(t, out, "- ❌ us — failed")
 	assert.Contains(t, out, "- ⏸ au — halted — us failed")
 	assert.Contains(t, out, "<details open>\n<summary>⏸ au — halted — us failed</summary>")
@@ -92,6 +98,7 @@ func TestRenderMultiDeploymentApplyComment_DetailsReuseSingleRenderer(t *testing
 	})
 	out := RenderMultiDeploymentApplyComment(MultiDeploymentApplyData{
 		Model:       model,
+		ApplyID:     "apply-123",
 		Environment: "production",
 		Details: map[string]ApplyStatusCommentData{
 			"us": {
@@ -107,9 +114,11 @@ func TestRenderMultiDeploymentApplyComment_DetailsReuseSingleRenderer(t *testing
 	// The us section carries the single-deployment body: its database and table.
 	assert.Contains(t, out, "**Database**: `payments_us`")
 	assert.Contains(t, out, "orders")
-	// Completed deployment with no detail still renders its summary line + section.
+	// Completed deployment with no detail still renders its summary line + section,
+	// with a placeholder body rather than an empty <details>.
 	assert.Contains(t, out, "- ✅ eu — completed")
 	assert.Contains(t, out, "<details>\n<summary>✅ eu — completed</summary>")
+	assert.Contains(t, out, "_No details available yet._")
 }
 
 // A deployment in an unrecognized engine state still renders a summary line and
@@ -119,7 +128,7 @@ func TestRenderMultiDeploymentApplyComment_UnknownStateNoGlyph(t *testing.T) {
 		rollingOp("eu", so.Running),
 		rollingOp("us", "some_engine_state"),
 	})
-	out := RenderMultiDeploymentApplyComment(MultiDeploymentApplyData{Model: model, Environment: "staging"})
+	out := RenderMultiDeploymentApplyComment(MultiDeploymentApplyData{Model: model, ApplyID: "apply-123", Environment: "staging"})
 	require.Len(t, model.Deployments, 2)
 	assert.Contains(t, out, "- us — some_engine_state")
 	assert.NotContains(t, out, "-  us")
@@ -131,9 +140,24 @@ func TestRenderMultiDeploymentApplyComment_NoNextActionWhenCompleted(t *testing.
 		rollingOp("eu", so.Completed),
 		rollingOp("us", so.Completed),
 	})
-	out := RenderMultiDeploymentApplyComment(MultiDeploymentApplyData{Model: model, Environment: "production"})
+	out := RenderMultiDeploymentApplyComment(MultiDeploymentApplyData{Model: model, ApplyID: "apply-123", Environment: "production"})
 	assert.Contains(t, out, "## ✅ Schema Change Applied")
 	assert.NotContains(t, out, "schemabot cutover")
 	assert.NotContains(t, out, "schemabot revert")
 	assert.NotContains(t, out, "To resume:")
+	assert.NotContains(t, out, "To retry:")
+}
+
+// Deployment names and labels come from configuration/engine state, so they are
+// HTML-escaped before being interpolated into the <summary> tags — a name with
+// markup characters must not break the comment HTML.
+func TestRenderMultiDeploymentApplyComment_EscapesSummaryHTML(t *testing.T) {
+	model := presentation.Derive([]presentation.Operation{
+		rollingOp("eu<b>", so.Running),
+		rollingOp("us&ca", so.Running),
+	})
+	out := RenderMultiDeploymentApplyComment(MultiDeploymentApplyData{Model: model, ApplyID: "apply-123", Environment: "production"})
+	assert.Contains(t, out, "eu&lt;b&gt;")
+	assert.Contains(t, out, "us&amp;ca")
+	assert.NotContains(t, out, "<summary>🔄 eu<b>")
 }

--- a/pkg/webhook/templates/multi_apply_test.go
+++ b/pkg/webhook/templates/multi_apply_test.go
@@ -1,0 +1,139 @@
+package templates
+
+import (
+	"testing"
+
+	"github.com/block/schemabot/pkg/presentation"
+	"github.com/block/schemabot/pkg/state"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var so = state.ApplyOperation
+
+func barrierOp(dep, st string) presentation.Operation {
+	return presentation.Operation{Deployment: dep, State: st, Barrier: true, HaltOnFailure: true}
+}
+
+func rollingOp(dep, st string) presentation.Operation {
+	return presentation.Operation{Deployment: dep, State: st, HaltOnFailure: true}
+}
+
+// A barrier rollout mid-flight (one deployment parked ready for cutover, one
+// copying, two queued behind it) renders an aggregate header with the running
+// title, a per-status count line, a single cutover next-action, an at-a-glance
+// per-deployment summary, and a <details> block per deployment in resolved order.
+func TestRenderMultiDeploymentApplyComment_BarrierInProgress(t *testing.T) {
+	model := presentation.Derive([]presentation.Operation{
+		barrierOp("eu", so.WaitingForCutover),
+		barrierOp("us", so.Running),
+		barrierOp("au", so.Pending),
+		barrierOp("ca", so.Pending),
+	})
+	out := RenderMultiDeploymentApplyComment(MultiDeploymentApplyData{
+		Model:       model,
+		ApplyID:     "apply-123",
+		Environment: "production",
+	})
+
+	assert.Contains(t, out, "## Schema Change In Progress")
+	assert.Contains(t, out, "**Environment**: `production`")
+	assert.Contains(t, out, "**Apply ID**: `apply-123`")
+	assert.Contains(t, out, "**Deployments**: 1 ready for cutover, 1 running, 2 waiting")
+
+	// Single next-action points at the cutover-ready deployment, even though the
+	// aggregate is still running.
+	assert.Contains(t, out, "To cut over `eu`:")
+	assert.Contains(t, out, "schemabot cutover -e production --deployment eu")
+
+	// Per-deployment summary lines, in resolved order, with derived labels.
+	assert.Contains(t, out, "- 🟢 eu — ready for cutover — next in order")
+	assert.Contains(t, out, "- 🔄 us — running table copy")
+	assert.Contains(t, out, "- ⏳ au — waiting for us")
+	assert.Contains(t, out, "- ⏳ ca — waiting for us")
+
+	// Active/ready deployments default open; queued ones default collapsed.
+	assert.Contains(t, out, "<details open>\n<summary>🟢 eu — ready for cutover — next in order</summary>")
+	assert.Contains(t, out, "<details open>\n<summary>🔄 us — running table copy</summary>")
+	assert.Contains(t, out, "<details>\n<summary>⏳ au — waiting for us</summary>")
+	assert.Contains(t, out, "<details>\n<summary>⏳ ca — waiting for us</summary>")
+}
+
+// A halt-on-failure rollout with a failed deployment keeps the aggregate failed,
+// names the failure as the next action, and marks the never-started deployments
+// as halted (and open, since halted explains the next action).
+func TestRenderMultiDeploymentApplyComment_FailedHalt(t *testing.T) {
+	model := presentation.Derive([]presentation.Operation{
+		rollingOp("eu", so.WaitingForCutover),
+		rollingOp("us", so.Failed),
+		rollingOp("au", so.Pending),
+		rollingOp("ca", so.Pending),
+	})
+	out := RenderMultiDeploymentApplyComment(MultiDeploymentApplyData{
+		Model:       model,
+		Environment: "production",
+	})
+
+	assert.Contains(t, out, "## ❌ Schema Change Failed")
+	assert.Contains(t, out, "**Deployments**: 1 ready for cutover, 2 halted, 1 failed")
+	assert.Contains(t, out, "Review the failure in `us`, then revert:")
+	assert.Contains(t, out, "schemabot revert -e production --deployment us")
+	assert.Contains(t, out, "- ❌ us — failed")
+	assert.Contains(t, out, "- ⏸ au — halted — us failed")
+	assert.Contains(t, out, "<details open>\n<summary>⏸ au — halted — us failed</summary>")
+}
+
+// Each deployment's <details> body is rendered by the single-deployment renderer,
+// so per-table progress and the deployment's own database are preserved.
+func TestRenderMultiDeploymentApplyComment_DetailsReuseSingleRenderer(t *testing.T) {
+	model := presentation.Derive([]presentation.Operation{
+		rollingOp("eu", so.Completed),
+		rollingOp("us", so.Running),
+	})
+	out := RenderMultiDeploymentApplyComment(MultiDeploymentApplyData{
+		Model:       model,
+		Environment: "production",
+		Details: map[string]ApplyStatusCommentData{
+			"us": {
+				Database: "payments_us",
+				State:    state.Apply.Running,
+				Tables: []TableProgressData{
+					{TableName: "orders", Status: state.Task.Running, PercentComplete: 42, RowsCopied: 420, RowsTotal: 1000},
+				},
+			},
+		},
+	})
+
+	// The us section carries the single-deployment body: its database and table.
+	assert.Contains(t, out, "**Database**: `payments_us`")
+	assert.Contains(t, out, "orders")
+	// Completed deployment with no detail still renders its summary line + section.
+	assert.Contains(t, out, "- ✅ eu — completed")
+	assert.Contains(t, out, "<details>\n<summary>✅ eu — completed</summary>")
+}
+
+// A deployment in an unrecognized engine state still renders a summary line and
+// section without a leading space where the glyph would be.
+func TestRenderMultiDeploymentApplyComment_UnknownStateNoGlyph(t *testing.T) {
+	model := presentation.Derive([]presentation.Operation{
+		rollingOp("eu", so.Running),
+		rollingOp("us", "some_engine_state"),
+	})
+	out := RenderMultiDeploymentApplyComment(MultiDeploymentApplyData{Model: model, Environment: "staging"})
+	require.Len(t, model.Deployments, 2)
+	assert.Contains(t, out, "- us — some_engine_state")
+	assert.NotContains(t, out, "-  us")
+}
+
+// When the rollup has no pending operator action, no next-action block is written.
+func TestRenderMultiDeploymentApplyComment_NoNextActionWhenCompleted(t *testing.T) {
+	model := presentation.Derive([]presentation.Operation{
+		rollingOp("eu", so.Completed),
+		rollingOp("us", so.Completed),
+	})
+	out := RenderMultiDeploymentApplyComment(MultiDeploymentApplyData{Model: model, Environment: "production"})
+	assert.Contains(t, out, "## ✅ Schema Change Applied")
+	assert.NotContains(t, out, "schemabot cutover")
+	assert.NotContains(t, out, "schemabot revert")
+	assert.NotContains(t, out, "To resume:")
+}

--- a/pkg/webhook/templates/preview.go
+++ b/pkg/webhook/templates/preview.go
@@ -3,6 +3,7 @@ package templates
 import (
 	"time"
 
+	"github.com/block/schemabot/pkg/presentation"
 	"github.com/block/schemabot/pkg/state"
 	"github.com/block/schemabot/pkg/webhook/action"
 )
@@ -776,6 +777,138 @@ func PreviewCommentApplyCuttingOver() string {
 		tables[i].Status = state.Task.CuttingOver
 	}
 	return RenderApplyStatusComment(sampleApplyData(state.Apply.CuttingOver, tables))
+}
+
+// =============================================================================
+// Multi-Deployment Apply Previews (MD-10)
+// =============================================================================
+//
+// These render the aggregate PR comment for an apply that fans out across more
+// than one deployment of a single environment. The per-deployment <details>
+// bodies reuse the single-deployment renderer, so each scenario seeds both the
+// derived rollup (presentation.Derive) and the per-deployment detail data.
+
+// sampleDeploymentDetail builds one deployment's single-deployment comment data
+// for the per-deployment <details> body, with its own database name.
+func sampleDeploymentDetail(database, applyState string, tables []TableProgressData) ApplyStatusCommentData {
+	return ApplyStatusCommentData{
+		Database:    database,
+		Environment: "production",
+		RequestedBy: "aparajon",
+		State:       applyState,
+		Engine:      "Spirit",
+		ApplyID:     "apply-a1b2c3d4e5f6",
+		StartedAt:   sampleTime().Add(-8 * time.Minute).UTC().Format(time.RFC3339),
+		Tables:      tables,
+	}
+}
+
+// PreviewCommentMultiDeploymentApplyInProgress renders a barrier rollout
+// mid-flight: one deployment parked ready for cutover, one copying, two queued.
+func PreviewCommentMultiDeploymentApplyInProgress() string {
+	model := presentation.Derive([]presentation.Operation{
+		{Deployment: "eu", State: state.ApplyOperation.WaitingForCutover, Barrier: true, HaltOnFailure: true},
+		{Deployment: "us", State: state.ApplyOperation.Running, Barrier: true, HaltOnFailure: true},
+		{Deployment: "au", State: state.ApplyOperation.Pending, Barrier: true, HaltOnFailure: true},
+		{Deployment: "ca", State: state.ApplyOperation.Pending, Barrier: true, HaltOnFailure: true},
+	})
+
+	euTables := sampleApplyTables()
+	for i := range euTables {
+		euTables[i].Status = state.Task.WaitingForCutover
+	}
+
+	usTables := sampleApplyTables()
+	usTables[0].Status = state.Task.Completed
+	usTables[1].Status = state.Task.Running
+	usTables[1].RowsCopied = 914707
+	usTables[1].RowsTotal = 1466232
+	usTables[1].PercentComplete = 62
+	usTables[1].ETASeconds = 195
+	usTables[2].Status = state.Task.Pending
+
+	return RenderMultiDeploymentApplyComment(MultiDeploymentApplyData{
+		Model:       model,
+		ApplyID:     "apply-a1b2c3d4e5f6",
+		Environment: "production",
+		RequestedBy: "aparajon",
+		StartedAt:   sampleTime().Add(-12 * time.Minute).UTC().Format(time.RFC3339),
+		Details: map[string]ApplyStatusCommentData{
+			"eu": sampleDeploymentDetail("payments_eu", state.Apply.WaitingForCutover, euTables),
+			"us": sampleDeploymentDetail("payments_us", state.Apply.Running, usTables),
+		},
+	})
+}
+
+// PreviewCommentMultiDeploymentApplyFailed renders a halt-on-failure rollout
+// where one deployment failed: completed deployments stay completed, later
+// deployments are halted, and the aggregate is failed with retry as next action.
+func PreviewCommentMultiDeploymentApplyFailed() string {
+	model := presentation.Derive([]presentation.Operation{
+		{Deployment: "eu", State: state.ApplyOperation.Completed, HaltOnFailure: true},
+		{Deployment: "us", State: state.ApplyOperation.Failed, HaltOnFailure: true, Error: PreviewErrorMiddleFailed},
+		{Deployment: "au", State: state.ApplyOperation.Pending, HaltOnFailure: true},
+		{Deployment: "ca", State: state.ApplyOperation.Pending, HaltOnFailure: true},
+	})
+
+	euTables := sampleApplyTables()
+	for i := range euTables {
+		euTables[i].Status = state.Task.Completed
+	}
+
+	usTables := sampleApplyTables()
+	usTables[0].Status = state.Task.Completed
+	usTables[1].Status = state.Task.Failed
+	usTables[1].RowsCopied = 439870
+	usTables[1].RowsTotal = 1466232
+	usTables[1].PercentComplete = 30
+	usTables[2].Status = state.Task.Cancelled
+	usDetail := sampleDeploymentDetail("payments_us", state.Apply.Failed, usTables)
+	usDetail.ErrorMessage = PreviewErrorMiddleFailed
+
+	return RenderMultiDeploymentApplyComment(MultiDeploymentApplyData{
+		Model:       model,
+		ApplyID:     "apply-a1b2c3d4e5f6",
+		Environment: "production",
+		RequestedBy: "aparajon",
+		StartedAt:   sampleTime().Add(-20 * time.Minute).UTC().Format(time.RFC3339),
+		Details: map[string]ApplyStatusCommentData{
+			"eu": sampleDeploymentDetail("payments_eu", state.Apply.Completed, euTables),
+			"us": usDetail,
+		},
+	})
+}
+
+// PreviewCommentMultiDeploymentApplyCompleted renders a fully completed rollout
+// across all deployments — aggregate applied, no pending operator action.
+func PreviewCommentMultiDeploymentApplyCompleted() string {
+	model := presentation.Derive([]presentation.Operation{
+		{Deployment: "eu", State: state.ApplyOperation.Completed, HaltOnFailure: true},
+		{Deployment: "us", State: state.ApplyOperation.Completed, HaltOnFailure: true},
+		{Deployment: "au", State: state.ApplyOperation.Completed, HaltOnFailure: true},
+	})
+
+	completedTables := func() []TableProgressData {
+		tables := sampleApplyTables()
+		for i := range tables {
+			tables[i].Status = state.Task.Completed
+		}
+		return tables
+	}
+
+	return RenderMultiDeploymentApplyComment(MultiDeploymentApplyData{
+		Model:       model,
+		ApplyID:     "apply-a1b2c3d4e5f6",
+		Environment: "production",
+		RequestedBy: "aparajon",
+		StartedAt:   sampleTime().Add(-30 * time.Minute).UTC().Format(time.RFC3339),
+		CompletedAt: sampleTime().Add(-2 * time.Minute).UTC().Format(time.RFC3339),
+		Details: map[string]ApplyStatusCommentData{
+			"eu": sampleDeploymentDetail("payments_eu", state.Apply.Completed, completedTables()),
+			"us": sampleDeploymentDetail("payments_us", state.Apply.Completed, completedTables()),
+			"au": sampleDeploymentDetail("payments_au", state.Apply.Completed, completedTables()),
+		},
+	})
 }
 
 // =============================================================================

--- a/scripts/update-templates.sh
+++ b/scripts/update-templates.sh
@@ -150,8 +150,17 @@ render_paired_section "Apply Flow"     "comment_apply_flow_all" "cli_apply_all"
     echo ""
     echo "### PR Comments"
     echo ""
-    "$BINARY" preview "comment_apply_all" 2>&1 | wrap_sections >> "$SNAPSHOT"
-}
+    "$BINARY" preview "comment_apply_all" 2>&1 | wrap_sections
+} >> "$SNAPSHOT"
+
+{
+    echo ""
+    echo "## Multi-Deployment Apply"
+    echo ""
+    echo "### PR Comments"
+    echo ""
+    "$BINARY" preview "comment_multi_deploy_all" 2>&1 | wrap_sections
+} >> "$SNAPSHOT"
 
 # === CLI-only sections ===
 render_cli_section "Sequential Mode (CLI)" "sequential_all"


### PR DESCRIPTION
## What and Why ?

Adds the GitHub markdown renderer for multi-deployment apply comments, consuming the surface-agnostic `presentation.Apply` model (from #315). This is the rendering half of MD-10 — it turns the derived presentation into the comment an operator sees on the PR, and seeds the multi-deployment scenarios into the preview pipeline so the UX is reviewable in `TEMPLATES.md`.

## Changes

- New renderer turns `presentation.Apply` into a multi-deployment apply comment:
  - aggregate header + state counts + next-action line
  - per-deployment summary list
  - a `<details>` block per deployment whose body reuses the existing single-deployment renderer, so per-deployment table fidelity is identical to today's single-deployment comment
- Seeds three multi-deployment apply preview scenarios — barrier in-progress, halt-on-failure, and completed rollout — through the preview pipeline so the aggregate + per-deployment UX auto-generates in `TEMPLATES.md`.
- This layer is pure rendering — no storage or dispatch wiring yet (that lands in the follow-up).

## Design-note compliance

Verified the seeded scenarios against the agreed UX contract in [`schemabot/design/schemabot-multi-deployment-ux.md`](https://github.com/squareup/schema-change-notes/blob/main/schemabot/design/schemabot-multi-deployment-ux.md):

| Design-note element | Covered? | Where |
|---|---|---|
| **Aggregate first, details second** | ✅ | All 3 seeds lead with aggregate header + `Deployments: …` counts, then per-deployment `<details>` |
| **Display order = `deployment_order` (eu→us→au→ca)** | ✅ | Rows and details emitted in that order in all 3 |
| **Open/collapsed defaults** (running/waiting/failed open; completed/pending collapsed) | ✅ | Barrier: eu+us `<details open>`, au/ca collapsed; Failure: us `<details open>`, eu/au/ca collapsed; Completed: all collapsed |
| **Failure surfaced at aggregate** (named failed dep + halted-because) | ✅ | Halt-on-failure seed: `❌ us — failed`, `⏸ au — halted — us failed` in the aggregate rows |
| **Single next action** | ✅ | One fenced command per scenario (cutover / retry) |
| **No internal terminology** | ✅ | "deployment", not `apply_operation` |
| **Invariant #9 — no parallel copy implied** | ✅ | Barrier seed has exactly **one** copy running (`us`); `eu` is parked at the cutover barrier — valid barrier semantics, not concurrent copies |
| **Future parallel-copy "multiple ready for cutover" example** | ⛔️ deliberately omitted | The note marks that as a not-yet-built future policy |

**Known divergence (follow-up):** the failure scenario's next-action renders `schemabot apply -e production`, whereas the design note's Failure-UX example prescribes a per-deployment `schemabot retry … --deployment <dep>` (with `revert` reserved for the revert-window only). That's existing renderer behavior, not seed data — tracked as a follow-up.

## Stacking

Part of the MD-10 per-deployment presentation series:
- #315 — derive surface-agnostic presentation model (merged)
- **this PR** — render multi-deployment comment from the model
- next — dispatch the apply comment on deployment count (single vs multi)
