### PR TITLE
feat(github): dispatch apply comment on deployment count

### DIFF
--- a/pkg/webhook/apply.go
+++ b/pkg/webhook/apply.go
@@ -23,12 +23,25 @@ func buildApplyCommentData(apply *storage.Apply, tasks []*storage.Task) template
 	if apply.CompletedAt != nil {
 		data.CompletedAt = apply.CompletedAt.Format(time.RFC3339)
 	}
+	data.Tables = tableProgressFromTasks(apply.Database, tasks)
+	return data
+}
+
+// tableProgressFromTasks maps storage tasks to per-table template rows. The
+// databaseFallback is used as a task's namespace when the task has none, so the
+// single-deployment and per-deployment builders render table identities the same
+// way.
+func tableProgressFromTasks(databaseFallback string, tasks []*storage.Task) []templates.TableProgressData {
+	if len(tasks) == 0 {
+		return nil
+	}
+	out := make([]templates.TableProgressData, 0, len(tasks))
 	for _, t := range tasks {
 		ns := t.Namespace
 		if ns == "" {
-			ns = apply.Database
+			ns = databaseFallback
 		}
-		data.Tables = append(data.Tables, templates.TableProgressData{
+		out = append(out, templates.TableProgressData{
 			Namespace:       ns,
 			TableName:       t.TableName,
 			DDL:             t.DDL,
@@ -42,7 +55,7 @@ func buildApplyCommentData(apply *storage.Apply, tasks []*storage.Task) template
 			ErrorMessage:    t.ErrorMessage,
 		})
 	}
-	return data
+	return out
 }
 
 // formatProgressComment renders the progress comment using the template system.

--- a/pkg/webhook/multi_apply.go
+++ b/pkg/webhook/multi_apply.go
@@ -1,0 +1,116 @@
+package webhook
+
+import (
+	"time"
+
+	"github.com/block/schemabot/pkg/presentation"
+	"github.com/block/schemabot/pkg/storage"
+	"github.com/block/schemabot/pkg/webhook/templates"
+)
+
+// formatApplyStatusComment renders the progress/status PR comment for an apply,
+// choosing the layout from how many deployments the apply owns. The threshold is
+// the apply's own operation-row count: zero or one operation renders today's
+// single-deployment UX byte-for-byte (legacy applies that predate
+// apply_operations fall here too), and two or more renders the aggregated
+// multi-deployment comment derived from pkg/presentation.
+//
+// ops must be in resolved deployment order (as returned by
+// ApplyOperations().ListByApply); tasks are the apply's tasks across all
+// deployments, regrouped per operation for the multi-deployment layout.
+func formatApplyStatusComment(apply *storage.Apply, ops []*storage.ApplyOperation, tasks []*storage.Task) string {
+	if len(ops) <= 1 {
+		return templates.RenderApplyStatusComment(buildApplyCommentData(apply, tasks))
+	}
+	return templates.RenderMultiDeploymentApplyComment(buildMultiApplyData(apply, ops, tasks))
+}
+
+// buildMultiApplyData assembles the multi-deployment comment input: the derived
+// rollup plus each deployment's own single-deployment comment data, so each
+// deployment's section reuses the existing per-table renderer.
+func buildMultiApplyData(apply *storage.Apply, ops []*storage.ApplyOperation, tasks []*storage.Task) templates.MultiDeploymentApplyData {
+	tasksByOp := groupTasksByOperation(tasks)
+
+	model := deriveApplyPresentation(ops)
+	details := make(map[string]templates.ApplyStatusCommentData, len(ops))
+	for _, op := range ops {
+		details[op.Deployment] = buildDeploymentDetail(apply, op, tasksByOp[op.ID])
+	}
+
+	data := templates.MultiDeploymentApplyData{
+		Model:       model,
+		ApplyID:     apply.ApplyIdentifier,
+		Environment: apply.Environment,
+		Details:     details,
+	}
+	if apply.StartedAt != nil {
+		data.StartedAt = apply.StartedAt.Format(time.RFC3339)
+	}
+	if apply.CompletedAt != nil {
+		data.CompletedAt = apply.CompletedAt.Format(time.RFC3339)
+	}
+	return data
+}
+
+// deriveApplyPresentation maps the apply's operation rows to the surface-neutral
+// presentation inputs and derives the rollup. Rows are already in resolved order.
+func deriveApplyPresentation(ops []*storage.ApplyOperation) presentation.Apply {
+	inputs := make([]presentation.Operation, 0, len(ops))
+	for _, op := range ops {
+		inputs = append(inputs, applyOperationToPresentation(op))
+	}
+	return presentation.Derive(inputs)
+}
+
+// applyOperationToPresentation maps one storage operation row to the neutral
+// presentation input, resolving the two rollout-policy values at the boundary:
+// cutover_policy "barrier" becomes the Barrier flag, and a nil halt_on_failure
+// resolves to true (the safe default the claim predicate also assumes).
+func applyOperationToPresentation(op *storage.ApplyOperation) presentation.Operation {
+	return presentation.Operation{
+		Deployment:    op.Deployment,
+		State:         op.State,
+		Barrier:       op.CutoverPolicy == storage.CutoverPolicyBarrier,
+		HaltOnFailure: op.HaltOnFailure == nil || *op.HaltOnFailure,
+		Error:         op.ErrorMessage,
+	}
+}
+
+// buildDeploymentDetail builds the single-deployment comment data for one
+// deployment's <details> body: its operation state and error, the parent apply's
+// identity and timing, and the deployment's own tasks. The deployment's database
+// target is shown via the section's deployment name; the per-table rows fall back
+// to the apply database for namespace, matching the single-deployment renderer.
+func buildDeploymentDetail(apply *storage.Apply, op *storage.ApplyOperation, tasks []*storage.Task) templates.ApplyStatusCommentData {
+	data := templates.ApplyStatusCommentData{
+		ApplyID:      apply.ApplyIdentifier,
+		Database:     apply.Database,
+		Environment:  apply.Environment,
+		State:        op.State,
+		Engine:       apply.Engine,
+		ErrorMessage: op.ErrorMessage,
+		Tables:       tableProgressFromTasks(apply.Database, tasks),
+	}
+	if apply.StartedAt != nil {
+		data.StartedAt = apply.StartedAt.Format(time.RFC3339)
+	}
+	if apply.CompletedAt != nil {
+		data.CompletedAt = apply.CompletedAt.Format(time.RFC3339)
+	}
+	return data
+}
+
+// groupTasksByOperation buckets tasks by their owning apply_operation. Tasks with
+// no apply_operation_id (legacy rows predating the per-deployment back-fill) are
+// not attributable to a deployment and are omitted from the per-deployment
+// sections; in a genuine multi-deployment apply every task carries the id.
+func groupTasksByOperation(tasks []*storage.Task) map[int64][]*storage.Task {
+	byOp := make(map[int64][]*storage.Task)
+	for _, t := range tasks {
+		if t.ApplyOperationID == nil {
+			continue
+		}
+		byOp[*t.ApplyOperationID] = append(byOp[*t.ApplyOperationID], t)
+	}
+	return byOp
+}

--- a/pkg/webhook/multi_apply.go
+++ b/pkg/webhook/multi_apply.go
@@ -64,14 +64,15 @@ func deriveApplyPresentation(ops []*storage.ApplyOperation) presentation.Apply {
 
 // applyOperationToPresentation maps one storage operation row to the neutral
 // presentation input, resolving the two rollout-policy values at the boundary:
-// cutover_policy "barrier" becomes the Barrier flag, and a nil halt_on_failure
-// resolves to true (the safe default the claim predicate also assumes).
+// cutover_policy "barrier" becomes the Barrier flag, and on_failure becomes the
+// HaltOnFailure flag — true unless on_failure is "continue", so any other value
+// fails closed to halting, the safe default the claim predicate also assumes.
 func applyOperationToPresentation(op *storage.ApplyOperation) presentation.Operation {
 	return presentation.Operation{
 		Deployment:    op.Deployment,
 		State:         op.State,
 		Barrier:       op.CutoverPolicy == storage.CutoverPolicyBarrier,
-		HaltOnFailure: op.HaltOnFailure == nil || *op.HaltOnFailure,
+		HaltOnFailure: op.OnFailure != storage.OnFailureContinue,
 		Error:         op.ErrorMessage,
 	}
 }

--- a/pkg/webhook/multi_apply_test.go
+++ b/pkg/webhook/multi_apply_test.go
@@ -1,0 +1,111 @@
+package webhook
+
+import (
+	"testing"
+
+	"github.com/block/schemabot/pkg/state"
+	"github.com/block/schemabot/pkg/storage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func runningApply() *storage.Apply {
+	return &storage.Apply{
+		ApplyIdentifier: "apply-1",
+		Database:        "payments",
+		Environment:     "production",
+		State:           state.Apply.Running,
+		Engine:          "spirit",
+	}
+}
+
+// An apply with no operation rows (legacy, predating apply_operations) renders
+// the single-deployment comment unchanged — no aggregate header.
+func TestFormatApplyStatusComment_NoOperationsRendersSingle(t *testing.T) {
+	out := formatApplyStatusComment(runningApply(), nil, nil)
+	assert.Contains(t, out, "## Schema Change In Progress")
+	assert.NotContains(t, out, "**Deployments**:")
+}
+
+// A single-deployment apply (one operation) also renders the single-deployment
+// comment — the multi-deployment hierarchy only appears with more than one.
+func TestFormatApplyStatusComment_OneOperationRendersSingle(t *testing.T) {
+	ops := []*storage.ApplyOperation{
+		{ID: 1, Deployment: "eu", State: state.ApplyOperation.Running},
+	}
+	out := formatApplyStatusComment(runningApply(), ops, nil)
+	assert.NotContains(t, out, "**Deployments**:")
+	assert.NotContains(t, out, "- 🔄 eu")
+}
+
+// An apply that fans out across two deployments renders the aggregate header,
+// the per-status count line, and a per-deployment summary in resolved order.
+func TestFormatApplyStatusComment_MultipleOperationsRendersMulti(t *testing.T) {
+	ops := []*storage.ApplyOperation{
+		{ID: 1, Deployment: "eu", State: state.ApplyOperation.Completed, CutoverPolicy: storage.CutoverPolicyBarrier},
+		{ID: 2, Deployment: "us", State: state.ApplyOperation.Running, CutoverPolicy: storage.CutoverPolicyBarrier},
+	}
+	out := formatApplyStatusComment(runningApply(), ops, nil)
+	assert.Contains(t, out, "## Schema Change In Progress")
+	assert.Contains(t, out, "**Deployments**: 1 completed, 1 running")
+	assert.Contains(t, out, "- ✅ eu — completed")
+	assert.Contains(t, out, "- 🔄 us — running table copy")
+}
+
+// Each deployment's tasks are routed into that deployment's section only, by
+// apply_operation_id — a task for `us` must not appear under `eu`.
+func TestBuildMultiApplyData_RoutesTasksByOperation(t *testing.T) {
+	ops := []*storage.ApplyOperation{
+		{ID: 1, Deployment: "eu", State: state.ApplyOperation.Running},
+		{ID: 2, Deployment: "us", State: state.ApplyOperation.Running},
+	}
+	tasks := []*storage.Task{
+		{ApplyOperationID: new(int64(2)), TableName: "orders", State: state.Task.Running},
+		{ApplyOperationID: new(int64(1)), TableName: "customers", State: state.Task.Running},
+	}
+	data := buildMultiApplyData(runningApply(), ops, tasks)
+
+	require.Len(t, data.Details["eu"].Tables, 1)
+	assert.Equal(t, "customers", data.Details["eu"].Tables[0].TableName)
+	require.Len(t, data.Details["us"].Tables, 1)
+	assert.Equal(t, "orders", data.Details["us"].Tables[0].TableName)
+}
+
+// The per-deployment section reflects the operation's own state and error, not
+// the parent apply's aggregate state.
+func TestBuildDeploymentDetail_UsesOperationStateAndError(t *testing.T) {
+	op := &storage.ApplyOperation{ID: 1, Deployment: "us", State: state.ApplyOperation.Failed, ErrorMessage: "lock wait timeout"}
+	detail := buildDeploymentDetail(runningApply(), op, nil)
+	assert.Equal(t, state.Apply.Failed, detail.State)
+	assert.Equal(t, "lock wait timeout", detail.ErrorMessage)
+	assert.Equal(t, "payments", detail.Database)
+}
+
+// The storage→presentation boundary resolves the rollout policies: barrier flips
+// the Barrier flag, and a nil halt_on_failure resolves to true (the safe default).
+func TestApplyOperationToPresentation_ResolvesPolicies(t *testing.T) {
+	barrier := applyOperationToPresentation(&storage.ApplyOperation{
+		Deployment: "eu", State: state.ApplyOperation.Running, CutoverPolicy: storage.CutoverPolicyBarrier,
+	})
+	assert.True(t, barrier.Barrier)
+	assert.True(t, barrier.HaltOnFailure, "nil halt_on_failure resolves to true")
+
+	rolling := applyOperationToPresentation(&storage.ApplyOperation{
+		Deployment: "us", State: state.ApplyOperation.Running,
+		CutoverPolicy: storage.CutoverPolicyRolling, HaltOnFailure: new(false),
+	})
+	assert.False(t, rolling.Barrier)
+	assert.False(t, rolling.HaltOnFailure)
+}
+
+// Tasks without an apply_operation_id (legacy rows) are not attributable to a
+// deployment and are dropped from the per-operation grouping.
+func TestGroupTasksByOperation_SkipsUnlinkedTasks(t *testing.T) {
+	grouped := groupTasksByOperation([]*storage.Task{
+		{ApplyOperationID: new(int64(1)), TableName: "a"},
+		{ApplyOperationID: nil, TableName: "orphan"},
+		{ApplyOperationID: new(int64(1)), TableName: "b"},
+	})
+	require.Len(t, grouped[1], 2)
+	assert.Len(t, grouped, 1)
+}

--- a/pkg/webhook/multi_apply_test.go
+++ b/pkg/webhook/multi_apply_test.go
@@ -82,17 +82,18 @@ func TestBuildDeploymentDetail_UsesOperationStateAndError(t *testing.T) {
 }
 
 // The storage→presentation boundary resolves the rollout policies: barrier flips
-// the Barrier flag, and a nil halt_on_failure resolves to true (the safe default).
+// the Barrier flag, and on_failure becomes HaltOnFailure — true unless on_failure
+// is "continue", so an unset value resolves to halting (the safe default).
 func TestApplyOperationToPresentation_ResolvesPolicies(t *testing.T) {
 	barrier := applyOperationToPresentation(&storage.ApplyOperation{
 		Deployment: "eu", State: state.ApplyOperation.Running, CutoverPolicy: storage.CutoverPolicyBarrier,
 	})
 	assert.True(t, barrier.Barrier)
-	assert.True(t, barrier.HaltOnFailure, "nil halt_on_failure resolves to true")
+	assert.True(t, barrier.HaltOnFailure, "unset on_failure resolves to halting")
 
 	rolling := applyOperationToPresentation(&storage.ApplyOperation{
 		Deployment: "us", State: state.ApplyOperation.Running,
-		CutoverPolicy: storage.CutoverPolicyRolling, HaltOnFailure: new(false),
+		CutoverPolicy: storage.CutoverPolicyRolling, OnFailure: storage.OnFailureContinue,
 	})
 	assert.False(t, rolling.Barrier)
 	assert.False(t, rolling.HaltOnFailure)

--- a/pkg/webhook/templates/multi_apply.go
+++ b/pkg/webhook/templates/multi_apply.go
@@ -1,0 +1,169 @@
+package templates
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/block/schemabot/pkg/presentation"
+)
+
+// MultiDeploymentApplyData is the input to the multi-deployment apply comment.
+// It bundles the surface-agnostic rollup (pkg/presentation) with each
+// deployment's existing single-deployment comment data, so the per-deployment
+// detail is rendered by exactly the same code path a single-deployment apply
+// uses today — the multi-deployment comment only adds the aggregate header and
+// the per-deployment hierarchy on top.
+type MultiDeploymentApplyData struct {
+	// Model is the derived rollup: aggregate state/label/counts/next-action and
+	// the per-deployment presentations in resolved deployment order.
+	Model presentation.Apply
+
+	// ApplyID is the parent apply's identifier, shown once in the aggregate header.
+	ApplyID string
+
+	// Environment is the rollout environment, shown in the header and used to
+	// format the next-action command.
+	Environment string
+
+	// RequestedBy is the operator who requested the apply.
+	RequestedBy string
+
+	// StartedAt / CompletedAt are RFC3339 timestamps for the aggregate elapsed time.
+	StartedAt   string
+	CompletedAt string
+
+	// Details maps a deployment name to that deployment's single-deployment
+	// comment data (its tables, error, timing, database). Each deployment's
+	// <details> body is rendered from its entry via RenderApplyStatusComment.
+	Details map[string]ApplyStatusCommentData
+}
+
+// RenderMultiDeploymentApplyComment renders the PR comment for an apply that
+// fans out across more than one deployment. The layout, per the multi-deployment
+// UX: an aggregate header (state title, metadata, per-status counts, and the
+// single next operator action), then a flat per-deployment summary so rollout
+// health and any failure are visible without expanding, then a <details> section
+// per deployment carrying today's per-table UX scoped to that deployment.
+//
+// The single-deployment case is intentionally not handled here: callers render
+// it with RenderApplyStatusComment so that UX stays byte-for-byte unchanged.
+func RenderMultiDeploymentApplyComment(data MultiDeploymentApplyData) string {
+	var sb strings.Builder
+
+	// Aggregate header: reuse the single-deployment title map keyed on the
+	// derived aggregate state so the headline vocabulary is identical.
+	writeApplyHeader(&sb, ApplyStatusCommentData{State: data.Model.State})
+	writeAggregateMetadata(&sb, data)
+	writeDeploymentCounts(&sb, data.Model.Counts)
+	writeAggregateNextAction(&sb, data)
+
+	// Flat per-deployment summary (always visible — survives any later size
+	// trimming of the detail sections).
+	writeDeploymentSummaryList(&sb, data.Model.Deployments)
+
+	// Expandable per-deployment detail, in resolved order.
+	writeDeploymentSections(&sb, data)
+
+	return sb.String()
+}
+
+// writeAggregateMetadata writes the apply-level metadata line. The database is
+// intentionally omitted — it is per-deployment and shown in each deployment's
+// section — so the aggregate carries only the environment, apply ID, elapsed
+// time, and requester.
+func writeAggregateMetadata(sb *strings.Builder, data MultiDeploymentApplyData) {
+	var parts []string
+	if data.Environment != "" {
+		parts = append(parts, fmt.Sprintf("**Environment**: `%s`", data.Environment))
+	}
+	if data.ApplyID != "" {
+		parts = append(parts, fmt.Sprintf("**Apply ID**: `%s`", data.ApplyID))
+	}
+	if elapsed := applyElapsed(ApplyStatusCommentData{StartedAt: data.StartedAt, CompletedAt: data.CompletedAt}); elapsed != "" {
+		parts = append(parts, fmt.Sprintf("**Elapsed**: %s", elapsed))
+	}
+	if len(parts) > 0 {
+		fmt.Fprintf(sb, "%s\n", strings.Join(parts, " | "))
+	}
+	writeAppliedByOrTimestamp(sb, data.RequestedBy)
+}
+
+// writeDeploymentCounts writes the per-status histogram so an operator sees
+// rollout health at a glance without expanding anything.
+func writeDeploymentCounts(sb *strings.Builder, counts []presentation.StateCount) {
+	if len(counts) == 0 {
+		return
+	}
+	parts := make([]string, 0, len(counts))
+	for _, c := range counts {
+		parts = append(parts, fmt.Sprintf("%d %s", c.Count, c.Label))
+	}
+	fmt.Fprintf(sb, "\n**Deployments**: %s\n", strings.Join(parts, ", "))
+}
+
+// writeAggregateNextAction renders the single suggested operator action derived
+// for the rollup, if any. The verb set mirrors the per-deployment commands the
+// CLI exposes; an empty action (NextActionNone) writes nothing.
+func writeAggregateNextAction(sb *strings.Builder, data MultiDeploymentApplyData) {
+	na := data.Model.NextAction
+	switch na.Kind {
+	case presentation.NextActionCutover:
+		writeFooterAction(sb,
+			fmt.Sprintf("To cut over `%s`:", na.Deployment),
+			fmt.Sprintf("schemabot cutover -e %s --deployment %s", data.Environment, na.Deployment))
+	case presentation.NextActionResume:
+		writeFooterAction(sb, "To resume:", fmt.Sprintf("schemabot start -e %s", data.Environment))
+	case presentation.NextActionReviewFailure:
+		if na.Deployment != "" {
+			writeFooterAction(sb,
+				fmt.Sprintf("Review the failure in `%s`, then revert:", na.Deployment),
+				fmt.Sprintf("schemabot revert -e %s --deployment %s", data.Environment, na.Deployment))
+		} else {
+			writeFooterAction(sb, "Review the failed deployment, then revert:",
+				fmt.Sprintf("schemabot revert -e %s", data.Environment))
+		}
+	case presentation.NextActionNone:
+		// No operator action is pending; nothing to render.
+	}
+}
+
+// writeDeploymentSummaryList writes one line per deployment (status glyph, name,
+// derived label) in resolved order. This is the at-a-glance rollout view and the
+// part that must always remain even if detail sections are later trimmed for size.
+func writeDeploymentSummaryList(sb *strings.Builder, deps []presentation.Deployment) {
+	if len(deps) == 0 {
+		return
+	}
+	sb.WriteString("\n")
+	for _, d := range deps {
+		fmt.Fprintf(sb, "- %s — %s\n", deploymentTag(d), d.Label)
+	}
+}
+
+// writeDeploymentSections writes a <details> block per deployment in resolved
+// order. Active and problematic deployments default open; completed and queued
+// ones default collapsed (the model's Open flag). The body reuses the
+// single-deployment renderer so per-table progress, errors, and DDL keep today's
+// fidelity scoped to one deployment.
+func writeDeploymentSections(sb *strings.Builder, data MultiDeploymentApplyData) {
+	for _, d := range data.Model.Deployments {
+		openAttr := ""
+		if d.Open {
+			openAttr = " open"
+		}
+		fmt.Fprintf(sb, "\n<details%s>\n<summary>%s — %s</summary>\n\n", openAttr, deploymentTag(d), d.Label)
+		if detail, ok := data.Details[d.Deployment]; ok {
+			sb.WriteString(RenderApplyStatusComment(detail))
+		}
+		sb.WriteString("\n</details>\n")
+	}
+}
+
+// deploymentTag renders the "<emoji> <deployment>" prefix, omitting the leading
+// space when a state has no glyph.
+func deploymentTag(d presentation.Deployment) string {
+	if d.Emoji == "" {
+		return d.Deployment
+	}
+	return fmt.Sprintf("%s %s", d.Emoji, d.Deployment)
+}

--- a/pkg/webhook/templates/multi_apply.go
+++ b/pkg/webhook/templates/multi_apply.go
@@ -2,6 +2,7 @@ package templates
 
 import (
 	"fmt"
+	"html"
 	"strings"
 
 	"github.com/block/schemabot/pkg/presentation"
@@ -18,11 +19,14 @@ type MultiDeploymentApplyData struct {
 	// the per-deployment presentations in resolved deployment order.
 	Model presentation.Apply
 
-	// ApplyID is the parent apply's identifier, shown once in the aggregate header.
+	// ApplyID is the parent apply's identifier, shown once in the aggregate
+	// header and used to format the next-action commands. Always set: every
+	// apply is created with a server-generated identifier.
 	ApplyID string
 
 	// Environment is the rollout environment, shown in the header and used to
-	// format the next-action command.
+	// format the next-action commands. Always set: a non-empty environment is
+	// enforced when the apply is created.
 	Environment string
 
 	// RequestedBy is the operator who requested the apply.
@@ -72,19 +76,16 @@ func RenderMultiDeploymentApplyComment(data MultiDeploymentApplyData) string {
 // section — so the aggregate carries only the environment, apply ID, elapsed
 // time, and requester.
 func writeAggregateMetadata(sb *strings.Builder, data MultiDeploymentApplyData) {
-	var parts []string
-	if data.Environment != "" {
-		parts = append(parts, fmt.Sprintf("**Environment**: `%s`", data.Environment))
-	}
-	if data.ApplyID != "" {
-		parts = append(parts, fmt.Sprintf("**Apply ID**: `%s`", data.ApplyID))
+	// Environment and ApplyID are always populated from the persisted apply, so
+	// they are rendered unconditionally; only the optional elapsed time is guarded.
+	parts := []string{
+		fmt.Sprintf("**Environment**: `%s`", data.Environment),
+		fmt.Sprintf("**Apply ID**: `%s`", data.ApplyID),
 	}
 	if elapsed := applyElapsed(ApplyStatusCommentData{StartedAt: data.StartedAt, CompletedAt: data.CompletedAt}); elapsed != "" {
 		parts = append(parts, fmt.Sprintf("**Elapsed**: %s", elapsed))
 	}
-	if len(parts) > 0 {
-		fmt.Fprintf(sb, "%s\n", strings.Join(parts, " | "))
-	}
+	fmt.Fprintf(sb, "%s\n", strings.Join(parts, " | "))
 	writeAppliedByOrTimestamp(sb, data.RequestedBy)
 }
 
@@ -102,26 +103,25 @@ func writeDeploymentCounts(sb *strings.Builder, counts []presentation.StateCount
 }
 
 // writeAggregateNextAction renders the single suggested operator action derived
-// for the rollup, if any. The verb set mirrors the per-deployment commands the
-// CLI exposes; an empty action (NextActionNone) writes nothing.
+// for the rollup, if any. An empty action (NextActionNone) writes nothing.
 func writeAggregateNextAction(sb *strings.Builder, data MultiDeploymentApplyData) {
+	// The CLI today addresses an apply by its identifier and has no
+	// --deployment flag, so the suggested commands mirror the executable forms
+	// the single-deployment footer already ships. Deployment-targeted commands
+	// arrive with the per-deployment CLI surface.
 	na := data.Model.NextAction
 	switch na.Kind {
 	case presentation.NextActionCutover:
 		writeFooterAction(sb,
 			fmt.Sprintf("To cut over `%s`:", na.Deployment),
-			fmt.Sprintf("schemabot cutover -e %s --deployment %s", data.Environment, na.Deployment))
+			fmt.Sprintf("schemabot cutover %s", data.ApplyID))
 	case presentation.NextActionResume:
-		writeFooterAction(sb, "To resume:", fmt.Sprintf("schemabot start -e %s", data.Environment))
+		writeFooterAction(sb, "To resume:", fmt.Sprintf("schemabot start %s", data.ApplyID))
 	case presentation.NextActionReviewFailure:
-		if na.Deployment != "" {
-			writeFooterAction(sb,
-				fmt.Sprintf("Review the failure in `%s`, then revert:", na.Deployment),
-				fmt.Sprintf("schemabot revert -e %s --deployment %s", data.Environment, na.Deployment))
-		} else {
-			writeFooterAction(sb, "Review the failed deployment, then revert:",
-				fmt.Sprintf("schemabot revert -e %s", data.Environment))
-		}
+		// revert applies only to a deployment still in its post-cutover revert
+		// window, not to a failure; the recovery path for a failed apply is a
+		// retry, matching the single-deployment failed footer.
+		writeFooterAction(sb, "To retry:", fmt.Sprintf("schemabot apply -e %s", data.Environment))
 	case presentation.NextActionNone:
 		// No operator action is pending; nothing to render.
 	}
@@ -136,7 +136,7 @@ func writeDeploymentSummaryList(sb *strings.Builder, deps []presentation.Deploym
 	}
 	sb.WriteString("\n")
 	for _, d := range deps {
-		fmt.Fprintf(sb, "- %s — %s\n", deploymentTag(d), d.Label)
+		fmt.Fprintf(sb, "- %s — %s\n", deploymentTag(d), html.EscapeString(d.Label))
 	}
 }
 
@@ -151,9 +151,11 @@ func writeDeploymentSections(sb *strings.Builder, data MultiDeploymentApplyData)
 		if d.Open {
 			openAttr = " open"
 		}
-		fmt.Fprintf(sb, "\n<details%s>\n<summary>%s — %s</summary>\n\n", openAttr, deploymentTag(d), d.Label)
+		fmt.Fprintf(sb, "\n<details%s>\n<summary>%s — %s</summary>\n\n", openAttr, deploymentTag(d), html.EscapeString(d.Label))
 		if detail, ok := data.Details[d.Deployment]; ok {
 			sb.WriteString(RenderApplyStatusComment(detail))
+		} else {
+			sb.WriteString("_No details available yet._\n")
 		}
 		sb.WriteString("\n</details>\n")
 	}
@@ -162,8 +164,9 @@ func writeDeploymentSections(sb *strings.Builder, data MultiDeploymentApplyData)
 // deploymentTag renders the "<emoji> <deployment>" prefix, omitting the leading
 // space when a state has no glyph.
 func deploymentTag(d presentation.Deployment) string {
+	name := html.EscapeString(d.Deployment)
 	if d.Emoji == "" {
-		return d.Deployment
+		return name
 	}
-	return fmt.Sprintf("%s %s", d.Emoji, d.Deployment)
+	return fmt.Sprintf("%s %s", d.Emoji, name)
 }

--- a/pkg/webhook/templates/multi_apply_test.go
+++ b/pkg/webhook/templates/multi_apply_test.go
@@ -42,9 +42,11 @@ func TestRenderMultiDeploymentApplyComment_BarrierInProgress(t *testing.T) {
 	assert.Contains(t, out, "**Deployments**: 1 ready for cutover, 1 running, 2 waiting")
 
 	// Single next-action points at the cutover-ready deployment, even though the
-	// aggregate is still running.
+	// aggregate is still running. The command is the executable apply-ID form the
+	// CLI accepts today (no --deployment flag yet).
 	assert.Contains(t, out, "To cut over `eu`:")
-	assert.Contains(t, out, "schemabot cutover -e production --deployment eu")
+	assert.Contains(t, out, "schemabot cutover apply-123")
+	assert.NotContains(t, out, "--deployment")
 
 	// Per-deployment summary lines, in resolved order, with derived labels.
 	assert.Contains(t, out, "- 🟢 eu — ready for cutover — next in order")
@@ -60,8 +62,8 @@ func TestRenderMultiDeploymentApplyComment_BarrierInProgress(t *testing.T) {
 }
 
 // A halt-on-failure rollout with a failed deployment keeps the aggregate failed,
-// names the failure as the next action, and marks the never-started deployments
-// as halted (and open, since halted explains the next action).
+// offers retry as the next action, and marks the never-started deployments as
+// halted (and open, since halted explains the next action).
 func TestRenderMultiDeploymentApplyComment_FailedHalt(t *testing.T) {
 	model := presentation.Derive([]presentation.Operation{
 		rollingOp("eu", so.WaitingForCutover),
@@ -71,13 +73,17 @@ func TestRenderMultiDeploymentApplyComment_FailedHalt(t *testing.T) {
 	})
 	out := RenderMultiDeploymentApplyComment(MultiDeploymentApplyData{
 		Model:       model,
+		ApplyID:     "apply-123",
 		Environment: "production",
 	})
 
 	assert.Contains(t, out, "## ❌ Schema Change Failed")
 	assert.Contains(t, out, "**Deployments**: 1 ready for cutover, 2 halted, 1 failed")
-	assert.Contains(t, out, "Review the failure in `us`, then revert:")
-	assert.Contains(t, out, "schemabot revert -e production --deployment us")
+	// The recovery path for a failed apply is retry, matching the single-deployment
+	// footer. revert is only for a deployment in its post-cutover revert window.
+	assert.Contains(t, out, "To retry:")
+	assert.Contains(t, out, "schemabot apply -e production")
+	assert.NotContains(t, out, "schemabot revert")
 	assert.Contains(t, out, "- ❌ us — failed")
 	assert.Contains(t, out, "- ⏸ au — halted — us failed")
 	assert.Contains(t, out, "<details open>\n<summary>⏸ au — halted — us failed</summary>")
@@ -92,6 +98,7 @@ func TestRenderMultiDeploymentApplyComment_DetailsReuseSingleRenderer(t *testing
 	})
 	out := RenderMultiDeploymentApplyComment(MultiDeploymentApplyData{
 		Model:       model,
+		ApplyID:     "apply-123",
 		Environment: "production",
 		Details: map[string]ApplyStatusCommentData{
 			"us": {
@@ -107,9 +114,11 @@ func TestRenderMultiDeploymentApplyComment_DetailsReuseSingleRenderer(t *testing
 	// The us section carries the single-deployment body: its database and table.
 	assert.Contains(t, out, "**Database**: `payments_us`")
 	assert.Contains(t, out, "orders")
-	// Completed deployment with no detail still renders its summary line + section.
+	// Completed deployment with no detail still renders its summary line + section,
+	// with a placeholder body rather than an empty <details>.
 	assert.Contains(t, out, "- ✅ eu — completed")
 	assert.Contains(t, out, "<details>\n<summary>✅ eu — completed</summary>")
+	assert.Contains(t, out, "_No details available yet._")
 }
 
 // A deployment in an unrecognized engine state still renders a summary line and
@@ -119,7 +128,7 @@ func TestRenderMultiDeploymentApplyComment_UnknownStateNoGlyph(t *testing.T) {
 		rollingOp("eu", so.Running),
 		rollingOp("us", "some_engine_state"),
 	})
-	out := RenderMultiDeploymentApplyComment(MultiDeploymentApplyData{Model: model, Environment: "staging"})
+	out := RenderMultiDeploymentApplyComment(MultiDeploymentApplyData{Model: model, ApplyID: "apply-123", Environment: "staging"})
 	require.Len(t, model.Deployments, 2)
 	assert.Contains(t, out, "- us — some_engine_state")
 	assert.NotContains(t, out, "-  us")
@@ -131,9 +140,24 @@ func TestRenderMultiDeploymentApplyComment_NoNextActionWhenCompleted(t *testing.
 		rollingOp("eu", so.Completed),
 		rollingOp("us", so.Completed),
 	})
-	out := RenderMultiDeploymentApplyComment(MultiDeploymentApplyData{Model: model, Environment: "production"})
+	out := RenderMultiDeploymentApplyComment(MultiDeploymentApplyData{Model: model, ApplyID: "apply-123", Environment: "production"})
 	assert.Contains(t, out, "## ✅ Schema Change Applied")
 	assert.NotContains(t, out, "schemabot cutover")
 	assert.NotContains(t, out, "schemabot revert")
 	assert.NotContains(t, out, "To resume:")
+	assert.NotContains(t, out, "To retry:")
+}
+
+// Deployment names and labels come from configuration/engine state, so they are
+// HTML-escaped before being interpolated into the <summary> tags — a name with
+// markup characters must not break the comment HTML.
+func TestRenderMultiDeploymentApplyComment_EscapesSummaryHTML(t *testing.T) {
+	model := presentation.Derive([]presentation.Operation{
+		rollingOp("eu<b>", so.Running),
+		rollingOp("us&ca", so.Running),
+	})
+	out := RenderMultiDeploymentApplyComment(MultiDeploymentApplyData{Model: model, ApplyID: "apply-123", Environment: "production"})
+	assert.Contains(t, out, "eu&lt;b&gt;")
+	assert.Contains(t, out, "us&amp;ca")
+	assert.NotContains(t, out, "<summary>🔄 eu<b>")
 }

--- a/pkg/webhook/templates/multi_apply_test.go
+++ b/pkg/webhook/templates/multi_apply_test.go
@@ -1,0 +1,139 @@
+package templates
+
+import (
+	"testing"
+
+	"github.com/block/schemabot/pkg/presentation"
+	"github.com/block/schemabot/pkg/state"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var so = state.ApplyOperation
+
+func barrierOp(dep, st string) presentation.Operation {
+	return presentation.Operation{Deployment: dep, State: st, Barrier: true, HaltOnFailure: true}
+}
+
+func rollingOp(dep, st string) presentation.Operation {
+	return presentation.Operation{Deployment: dep, State: st, HaltOnFailure: true}
+}
+
+// A barrier rollout mid-flight (one deployment parked ready for cutover, one
+// copying, two queued behind it) renders an aggregate header with the running
+// title, a per-status count line, a single cutover next-action, an at-a-glance
+// per-deployment summary, and a <details> block per deployment in resolved order.
+func TestRenderMultiDeploymentApplyComment_BarrierInProgress(t *testing.T) {
+	model := presentation.Derive([]presentation.Operation{
+		barrierOp("eu", so.WaitingForCutover),
+		barrierOp("us", so.Running),
+		barrierOp("au", so.Pending),
+		barrierOp("ca", so.Pending),
+	})
+	out := RenderMultiDeploymentApplyComment(MultiDeploymentApplyData{
+		Model:       model,
+		ApplyID:     "apply-123",
+		Environment: "production",
+	})
+
+	assert.Contains(t, out, "## Schema Change In Progress")
+	assert.Contains(t, out, "**Environment**: `production`")
+	assert.Contains(t, out, "**Apply ID**: `apply-123`")
+	assert.Contains(t, out, "**Deployments**: 1 ready for cutover, 1 running, 2 waiting")
+
+	// Single next-action points at the cutover-ready deployment, even though the
+	// aggregate is still running.
+	assert.Contains(t, out, "To cut over `eu`:")
+	assert.Contains(t, out, "schemabot cutover -e production --deployment eu")
+
+	// Per-deployment summary lines, in resolved order, with derived labels.
+	assert.Contains(t, out, "- 🟢 eu — ready for cutover — next in order")
+	assert.Contains(t, out, "- 🔄 us — running table copy")
+	assert.Contains(t, out, "- ⏳ au — waiting for us")
+	assert.Contains(t, out, "- ⏳ ca — waiting for us")
+
+	// Active/ready deployments default open; queued ones default collapsed.
+	assert.Contains(t, out, "<details open>\n<summary>🟢 eu — ready for cutover — next in order</summary>")
+	assert.Contains(t, out, "<details open>\n<summary>🔄 us — running table copy</summary>")
+	assert.Contains(t, out, "<details>\n<summary>⏳ au — waiting for us</summary>")
+	assert.Contains(t, out, "<details>\n<summary>⏳ ca — waiting for us</summary>")
+}
+
+// A halt-on-failure rollout with a failed deployment keeps the aggregate failed,
+// names the failure as the next action, and marks the never-started deployments
+// as halted (and open, since halted explains the next action).
+func TestRenderMultiDeploymentApplyComment_FailedHalt(t *testing.T) {
+	model := presentation.Derive([]presentation.Operation{
+		rollingOp("eu", so.WaitingForCutover),
+		rollingOp("us", so.Failed),
+		rollingOp("au", so.Pending),
+		rollingOp("ca", so.Pending),
+	})
+	out := RenderMultiDeploymentApplyComment(MultiDeploymentApplyData{
+		Model:       model,
+		Environment: "production",
+	})
+
+	assert.Contains(t, out, "## ❌ Schema Change Failed")
+	assert.Contains(t, out, "**Deployments**: 1 ready for cutover, 2 halted, 1 failed")
+	assert.Contains(t, out, "Review the failure in `us`, then revert:")
+	assert.Contains(t, out, "schemabot revert -e production --deployment us")
+	assert.Contains(t, out, "- ❌ us — failed")
+	assert.Contains(t, out, "- ⏸ au — halted — us failed")
+	assert.Contains(t, out, "<details open>\n<summary>⏸ au — halted — us failed</summary>")
+}
+
+// Each deployment's <details> body is rendered by the single-deployment renderer,
+// so per-table progress and the deployment's own database are preserved.
+func TestRenderMultiDeploymentApplyComment_DetailsReuseSingleRenderer(t *testing.T) {
+	model := presentation.Derive([]presentation.Operation{
+		rollingOp("eu", so.Completed),
+		rollingOp("us", so.Running),
+	})
+	out := RenderMultiDeploymentApplyComment(MultiDeploymentApplyData{
+		Model:       model,
+		Environment: "production",
+		Details: map[string]ApplyStatusCommentData{
+			"us": {
+				Database: "payments_us",
+				State:    state.Apply.Running,
+				Tables: []TableProgressData{
+					{TableName: "orders", Status: state.Task.Running, PercentComplete: 42, RowsCopied: 420, RowsTotal: 1000},
+				},
+			},
+		},
+	})
+
+	// The us section carries the single-deployment body: its database and table.
+	assert.Contains(t, out, "**Database**: `payments_us`")
+	assert.Contains(t, out, "orders")
+	// Completed deployment with no detail still renders its summary line + section.
+	assert.Contains(t, out, "- ✅ eu — completed")
+	assert.Contains(t, out, "<details>\n<summary>✅ eu — completed</summary>")
+}
+
+// A deployment in an unrecognized engine state still renders a summary line and
+// section without a leading space where the glyph would be.
+func TestRenderMultiDeploymentApplyComment_UnknownStateNoGlyph(t *testing.T) {
+	model := presentation.Derive([]presentation.Operation{
+		rollingOp("eu", so.Running),
+		rollingOp("us", "some_engine_state"),
+	})
+	out := RenderMultiDeploymentApplyComment(MultiDeploymentApplyData{Model: model, Environment: "staging"})
+	require.Len(t, model.Deployments, 2)
+	assert.Contains(t, out, "- us — some_engine_state")
+	assert.NotContains(t, out, "-  us")
+}
+
+// When the rollup has no pending operator action, no next-action block is written.
+func TestRenderMultiDeploymentApplyComment_NoNextActionWhenCompleted(t *testing.T) {
+	model := presentation.Derive([]presentation.Operation{
+		rollingOp("eu", so.Completed),
+		rollingOp("us", so.Completed),
+	})
+	out := RenderMultiDeploymentApplyComment(MultiDeploymentApplyData{Model: model, Environment: "production"})
+	assert.Contains(t, out, "## ✅ Schema Change Applied")
+	assert.NotContains(t, out, "schemabot cutover")
+	assert.NotContains(t, out, "schemabot revert")
+	assert.NotContains(t, out, "To resume:")
+}


### PR DESCRIPTION
## What and Why ?

Wires the apply-comment path end to end: storage → presentation → render. Chooses the single- or multi-deployment renderer based on how many apply operations the apply owns, so single-deployment PRs are byte-for-byte unchanged and multi-deployment PRs get the new aggregated comment.

## Changes

- `pkg/webhook/apply.go`: extract shared `tableProgressFromTasks(...)` helper used by the existing single-deployment comment builder.
- New `pkg/webhook/multi_apply.go`: dispatcher that
  - with `<= 1` operation, uses the existing single-deployment renderer unchanged;
  - with `>= 2` operations, maps `[]storage.ApplyOperation` to `presentation.Operation`, groups tasks by `ApplyOperationID`, derives the presentation model, and renders the multi-deployment comment.

## Stacking

Final piece of the MD-10 per-deployment presentation series, on top of #315 (model) and the renderer PR.
