### PR TITLE
feat(api): expose routing tern client

### DIFF
--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -850,7 +850,10 @@ func TestExecutePullSchemaRoutesConfiguredMySQLTarget(t *testing.T) {
 		},
 	}
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
-	svc := New(&mockStorage{}, cfg, map[string]tern.Client{
+	svc := New(&mockStorageWithApplyStores{
+		plans:   &staticPlanStore{},
+		applies: &staticApplyStore{},
+	}, cfg, map[string]tern.Client{
 		"primary/production": mockClient,
 	}, logger)
 

--- a/pkg/api/plan_handlers.go
+++ b/pkg/api/plan_handlers.go
@@ -181,42 +181,42 @@ func (s *Service) ExecutePullSchema(ctx context.Context, req apitypes.PullSchema
 		return nil, unsupportedErr
 	}
 
-	client, err := s.TernClient(resolvedTarget.Deployment, req.Environment)
+	client, err := s.RoutingTernClient()
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(otelcodes.Error, "tern client")
 		return nil, fmt.Errorf("database %q (%s): %w", req.Database, req.Environment, err)
 	}
 
-	s.logger.Info("ExecutePullSchema: calling client.PullSchema",
+	isRemoteTarget := s.executionTargetUsesRemoteClient(resolvedTarget.Deployment, req.Environment)
+	s.logger.Info("ExecutePullSchema: calling routing client PullSchema",
 		"database", req.Database,
 		"type", resolvedTarget.DatabaseType,
 		"deployment", resolvedTarget.Deployment,
 		"target", resolvedTarget.Target,
 		"environment", req.Environment,
-		"is_remote", client.IsRemote(),
+		"is_remote", isRemoteTarget,
 	)
 
 	resp, err := client.PullSchema(ctx, &ternv1.PullSchemaRequest{
 		Database:    req.Database,
-		Type:        resolvedTarget.DatabaseType,
+		Type:        req.Type,
 		Environment: req.Environment,
-		Target:      resolvedTarget.Target,
 	})
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(otelcodes.Error, "pull schema failed")
-		s.logger.Error("ExecutePullSchema: client.PullSchema failed",
+		s.logger.Error("ExecutePullSchema: routing client PullSchema failed",
 			"database", req.Database,
 			"type", resolvedTarget.DatabaseType,
 			"deployment", resolvedTarget.Deployment,
 			"target", resolvedTarget.Target,
 			"environment", req.Environment,
 			"endpoint", client.Endpoint(),
-			"is_remote", client.IsRemote(),
+			"is_remote", isRemoteTarget,
 			"error", err,
 		)
-		if client.IsRemote() && grpcstatus.Code(err) == grpccodes.Unavailable {
+		if isRemoteTarget && grpcstatus.Code(err) == grpccodes.Unavailable {
 			return nil, &RemoteDeploymentUnavailableError{
 				Deployment: resolvedTarget.Deployment,
 				Target:     resolvedTarget.Target,
@@ -236,6 +236,16 @@ func (s *Service) ExecutePullSchema(ctx context.Context, req apitypes.PullSchema
 	)
 
 	return pullSchemaResponseFromProto(resp), nil
+}
+
+func (s *Service) executionTargetUsesRemoteClient(deployment, environment string) bool {
+	if dbConfig := s.config.Database(deployment); dbConfig != nil {
+		if envConfig, ok := dbConfig.Environments[environment]; ok && envConfig.HasLocalDSN() {
+			return false
+		}
+	}
+	_, err := s.config.TernDeployments.Endpoint(deployment, environment)
+	return err == nil
 }
 
 // ApplyRequest is the HTTP request body for POST /api/apply.

--- a/pkg/api/service.go
+++ b/pkg/api/service.go
@@ -105,12 +105,13 @@ type pendingObserverKey struct {
 }
 
 type Service struct {
-	storage     storage.Storage
-	config      *ServerConfig
-	ternClients map[string]tern.Client // keyed by "deployment/environment", lazily created
-	ternMu      sync.Mutex             // protects ternClients
-	logger      *slog.Logger
-	clock       clock.Clock
+	storage           storage.Storage
+	config            *ServerConfig
+	ternClients       map[string]tern.Client // keyed by "deployment/environment", lazily created
+	routingTernClient *tern.RoutingClient
+	ternMu            sync.Mutex // protects tern client caches
+	logger            *slog.Logger
+	clock             clock.Clock
 
 	// Operator loop management.
 	operatorMu           sync.Mutex
@@ -311,6 +312,41 @@ func (s *Service) TernClient(deployment, environment string) (tern.Client, error
 	}
 
 	s.ternClients[key] = client
+	return client, nil
+}
+
+// RoutingTernClient returns a client that routes requests from server
+// configuration and stored execution metadata. It is safe for Plan, Apply, and
+// PullSchema routing; handlers that branch on transport mode must continue to
+// use deployment-scoped clients until transport metadata is request-scoped.
+func (s *Service) RoutingTernClient() (*tern.RoutingClient, error) {
+	if s.config == nil {
+		return nil, fmt.Errorf("server config is required for routing tern client")
+	}
+	if s.storage == nil {
+		return nil, fmt.Errorf("storage is required for routing tern client")
+	}
+
+	s.ternMu.Lock()
+	defer s.ternMu.Unlock()
+	if s.routingTernClient != nil {
+		return s.routingTernClient, nil
+	}
+
+	client, err := tern.NewRoutingClient(tern.RoutingClientConfig{
+		Resolver:             s.config,
+		PlanLookup:           s.storage.Plans(),
+		ApplyLookup:          s.storage.Applies(),
+		ApplyOperationLookup: s.storage.ApplyOperations(),
+		ClientForDeployment: func(_ context.Context, deployment, environment string) (tern.Client, error) {
+			return s.TernClient(deployment, environment)
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create routing tern client: %w", err)
+	}
+	s.routingTernClient = client
+	s.logger.Info("created routing tern client")
 	return client, nil
 }
 
@@ -572,6 +608,11 @@ func (s *Service) Close() error {
 
 	s.ternMu.Lock()
 	var errs []error
+	if s.routingTernClient != nil {
+		if err := s.routingTernClient.Close(); err != nil {
+			errs = append(errs, err)
+		}
+	}
 	for _, client := range s.ternClients {
 		if err := client.Close(); err != nil {
 			errs = append(errs, err)

--- a/pkg/api/service_test.go
+++ b/pkg/api/service_test.go
@@ -7,6 +7,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	ternv1 "github.com/block/schemabot/pkg/proto/ternv1"
+	"github.com/block/schemabot/pkg/storage"
+	"github.com/block/schemabot/pkg/tern"
 )
 
 func TestTernConfig_Endpoint_SingleDeployment(t *testing.T) {
@@ -143,6 +147,80 @@ func TestTernConfig_Endpoint_MultiDeployment(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestService_RoutingTernClientRoutesPlanThroughConfiguredDeployment(t *testing.T) {
+	deploymentClient := &mockTernClient{planResp: &ternv1.PlanResponse{PlanId: "plan-1"}}
+	service := New(&mockStorageWithApplyStores{
+		plans:   &staticPlanStore{},
+		applies: &staticApplyStore{},
+	}, &ServerConfig{
+		Databases: map[string]DatabaseConfig{
+			"appdb": {
+				Type: storage.DatabaseTypeMySQL,
+				Environments: map[string]EnvironmentConfig{
+					"staging": {
+						Deployment: "primary",
+						Target:     "appdb-target",
+					},
+				},
+			},
+		},
+	}, map[string]tern.Client{
+		"primary/staging": deploymentClient,
+	}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	client, err := service.RoutingTernClient()
+	require.NoError(t, err)
+	again, err := service.RoutingTernClient()
+	require.NoError(t, err)
+	assert.Same(t, client, again)
+
+	resp, err := client.Plan(t.Context(), &ternv1.PlanRequest{
+		Database:    "appdb",
+		Environment: "staging",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "plan-1", resp.PlanId)
+	require.NotNil(t, deploymentClient.planReq)
+	assert.Equal(t, storage.DatabaseTypeMySQL, deploymentClient.planReq.Type)
+	assert.Equal(t, "appdb-target", deploymentClient.planReq.Target)
+	assert.Equal(t, "appdb", deploymentClient.planReq.Database)
+	assert.Equal(t, "staging", deploymentClient.planReq.Environment)
+}
+
+func TestService_RoutingTernClientRoutesApplyThroughStoredPlanTarget(t *testing.T) {
+	deploymentClient := &mockTernClient{applyResp: &ternv1.ApplyResponse{Accepted: true, ApplyId: "apply-routed"}}
+	service := New(&mockStorageWithApplyStores{
+		plans: &staticPlanStore{plan: &storage.Plan{
+			PlanIdentifier: "plan-1",
+			Database:       "appdb",
+			DatabaseType:   storage.DatabaseTypeMySQL,
+			Deployment:     "primary",
+			Target:         "appdb-target",
+			Environment:    "staging",
+		}},
+		applies: &staticApplyStore{},
+	}, &ServerConfig{}, map[string]tern.Client{
+		"primary/staging": deploymentClient,
+	}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	client, err := service.RoutingTernClient()
+	require.NoError(t, err)
+	resp, err := client.Apply(t.Context(), &ternv1.ApplyRequest{
+		PlanId:      "plan-1",
+		Environment: "staging",
+	})
+
+	require.NoError(t, err)
+	assert.True(t, resp.Accepted)
+	assert.Equal(t, "apply-routed", resp.ApplyId)
+	require.NotNil(t, deploymentClient.applyReq)
+	assert.Equal(t, "appdb", deploymentClient.applyReq.Database)
+	assert.Equal(t, storage.DatabaseTypeMySQL, deploymentClient.applyReq.Type)
+	assert.Equal(t, "appdb-target", deploymentClient.applyReq.Target)
+	assert.Equal(t, "staging", deploymentClient.applyReq.Environment)
+	assert.Equal(t, "appdb-target", deploymentClient.applyReq.Options["target"])
 }
 
 func TestTernConfig_Endpoint_EmptyEndpoint(t *testing.T) {

--- a/pkg/tern/routing_client.go
+++ b/pkg/tern/routing_client.go
@@ -55,6 +55,8 @@ type RoutingClient struct {
 	activeObservers map[int64]ProgressObserver
 }
 
+var _ Client = (*RoutingClient)(nil)
+
 // NewRoutingClient creates a routing client.
 func NewRoutingClient(config RoutingClientConfig) (*RoutingClient, error) {
 	if config.Resolver == nil {
@@ -77,6 +79,28 @@ func NewRoutingClient(config RoutingClientConfig) (*RoutingClient, error) {
 		clientForDeployment:  config.ClientForDeployment,
 		activeObservers:      make(map[int64]ProgressObserver),
 	}, nil
+}
+
+// PullSchema fetches live schema from the resolved execution target.
+func (c *RoutingClient) PullSchema(ctx context.Context, req *ternv1.PullSchemaRequest) (*ternv1.PullSchemaResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("pull schema request is required: %w", ErrPullSchemaInvalidRequest)
+	}
+	target, err := c.resolveSingleExecutionTarget(ctx, req.Database, req.Environment)
+	if err != nil {
+		return nil, err
+	}
+	if req.Type != "" && req.Type != target.DatabaseType {
+		return nil, fmt.Errorf("pull schema request type %q does not match resolved database type %q: %w", req.Type, target.DatabaseType, ErrPullSchemaInvalidRequest)
+	}
+	client, err := c.clientForDeployment(ctx, target.Deployment, req.Environment)
+	if err != nil {
+		return nil, fmt.Errorf("get client for deployment %q environment %q: %w", target.Deployment, req.Environment, err)
+	}
+	routedReq := proto.Clone(req).(*ternv1.PullSchemaRequest)
+	routedReq.Type = target.DatabaseType
+	routedReq.Target = target.Target
+	return client.PullSchema(ctx, routedReq)
 }
 
 // Plan generates a schema change plan on the resolved execution target.

--- a/pkg/tern/routing_client_test.go
+++ b/pkg/tern/routing_client_test.go
@@ -2,6 +2,7 @@ package tern
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -40,6 +41,7 @@ func (l routingApplyOperationLookup) Get(_ context.Context, id int64) (*storage.
 type routingRecordingClient struct {
 	Client
 
+	pullSchemaReq      *ternv1.PullSchemaRequest
 	planReq            *ternv1.PlanRequest
 	applyReq           *ternv1.ApplyRequest
 	applyErr           error
@@ -49,6 +51,11 @@ type routingRecordingClient struct {
 	pendingObserverSet bool
 	observerApplyID    int64
 	isRemote           bool
+}
+
+func (c *routingRecordingClient) PullSchema(_ context.Context, req *ternv1.PullSchemaRequest) (*ternv1.PullSchemaResponse, error) {
+	c.pullSchemaReq = req
+	return &ternv1.PullSchemaResponse{Database: req.Database}, nil
 }
 
 func (c *routingRecordingClient) Plan(_ context.Context, req *ternv1.PlanRequest) (*ternv1.PlanResponse, error) {
@@ -97,6 +104,80 @@ type routingNoopObserver struct{}
 func (routingNoopObserver) OnProgress(*storage.Apply, []*storage.Task) {}
 
 func (routingNoopObserver) OnTerminal(*storage.Apply, []*storage.Task) {}
+
+func TestRoutingClientPullSchemaResolvesSingleExecutionTarget(t *testing.T) {
+	clients := map[string]*routingRecordingClient{
+		"east/staging": {},
+	}
+	routingClient := newTestRoutingClient(t, RoutingClientConfig{
+		Resolver: routingResolverFunc(func(_ context.Context, req routing.Request) ([]routing.ExecutionTarget, error) {
+			assert.Equal(t, routing.Request{Database: "logical-db", Environment: "staging"}, req)
+			return []routing.ExecutionTarget{{
+				DatabaseType: storage.DatabaseTypeMySQL,
+				Deployment:   "east",
+				Target:       "target-123",
+			}}, nil
+		}),
+		PlanLookup:          routingPlanLookup{},
+		ApplyLookup:         routingApplyLookup{},
+		ClientForDeployment: testDeploymentClientFunc(clients),
+	})
+
+	resp, err := routingClient.PullSchema(t.Context(), &ternv1.PullSchemaRequest{
+		Database:    "logical-db",
+		Environment: "staging",
+		Type:        storage.DatabaseTypeMySQL,
+		Target:      "caller-supplied-target",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "logical-db", resp.Database)
+	require.NotNil(t, clients["east/staging"].pullSchemaReq)
+	assert.Equal(t, "logical-db", clients["east/staging"].pullSchemaReq.Database)
+	assert.Equal(t, "staging", clients["east/staging"].pullSchemaReq.Environment)
+	assert.Equal(t, storage.DatabaseTypeMySQL, clients["east/staging"].pullSchemaReq.Type)
+	assert.Equal(t, "target-123", clients["east/staging"].pullSchemaReq.Target)
+}
+
+func TestRoutingClientPullSchemaRejectsInvalidRequestAsInvalidPullSchemaRequest(t *testing.T) {
+	routingClient := newTestRoutingClient(t, RoutingClientConfig{
+		Resolver:            routingResolverFunc(func(context.Context, routing.Request) ([]routing.ExecutionTarget, error) { return nil, nil }),
+		PlanLookup:          routingPlanLookup{},
+		ApplyLookup:         routingApplyLookup{},
+		ClientForDeployment: testDeploymentClientFunc(nil),
+	})
+
+	_, err := routingClient.PullSchema(t.Context(), nil)
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "pull schema request is required")
+	assert.True(t, errors.Is(err, ErrPullSchemaInvalidRequest))
+}
+
+func TestRoutingClientPullSchemaRejectsTypeMismatchAsInvalidPullSchemaRequest(t *testing.T) {
+	routingClient := newTestRoutingClient(t, RoutingClientConfig{
+		Resolver: routingResolverFunc(func(context.Context, routing.Request) ([]routing.ExecutionTarget, error) {
+			return []routing.ExecutionTarget{{
+				DatabaseType: storage.DatabaseTypeMySQL,
+				Deployment:   "east",
+				Target:       "target-123",
+			}}, nil
+		}),
+		PlanLookup:          routingPlanLookup{},
+		ApplyLookup:         routingApplyLookup{},
+		ClientForDeployment: testDeploymentClientFunc(nil),
+	})
+
+	_, err := routingClient.PullSchema(t.Context(), &ternv1.PullSchemaRequest{
+		Database:    "logical-db",
+		Environment: "staging",
+		Type:        storage.DatabaseTypeVitess,
+	})
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, `request type "vitess" does not match resolved database type "mysql"`)
+	assert.True(t, errors.Is(err, ErrPullSchemaInvalidRequest))
+}
 
 func TestRoutingClientPlanResolvesSingleExecutionTarget(t *testing.T) {
 	clients := map[string]*routingRecordingClient{


### PR DESCRIPTION
## Why
SchemaBot now has a generic routing contract and routing Tern client, but stock server construction still had no first-class way to assemble that client. Exposing this seam lets deployments opt into config-driven request routing without custom client wiring.

## What
- Add `Service.RoutingTernClient()` to build and cache a routing client from server config, storage, and existing deployment clients
- Route live schema pulls through `RoutingClient`, making `/api/pull` use the same target resolution path as the wrapper
- Cover service-level Plan/Apply assembly and live schema pull routing with focused tests

```diagram
Before:
╭──────────────╮     ╭──────────────────╮
│ custom code  │────▶│ deployment Tern  │
╰──────────────╯     ╰──────────────────╯

After:
╭──────────────╮     ╭──────────────────╮     ╭──────────────────╮
│ stock server │────▶│ RoutingTernClient│────▶│ deployment Tern  │
╰──────┬───────╯     ╰──────────────────╯     ╰──────────────────╯
       │
       ▼
╭──────────────╮
│ server config│
│ + storage    │
╰──────────────╯
```

## Risk Assessment
Low — routing client construction is opt-in, and the only handler moved onto it is the read-only live schema pull path. Apply/control handlers remain on deployment-scoped clients until transport-sensitive paths are handled deliberately.

Generated with Amp
