### PR TITLE
feat(cli): add `onboard` and `pull` commands

### DIFF
--- a/pkg/cmd/client/client.go
+++ b/pkg/cmd/client/client.go
@@ -52,6 +52,20 @@ func GetEnvironments(endpoint, database string) ([]string, error) {
 	return result.Environments, nil
 }
 
+// CallPullSchemaAPI fetches live schema files for a database/environment pair.
+func CallPullSchemaAPI(endpoint, database, dbType, environment string) (*apitypes.PullSchemaResponse, error) {
+	req := apitypes.PullSchemaRequest{
+		Database:    database,
+		Type:        dbType,
+		Environment: environment,
+	}
+	var result apitypes.PullSchemaResponse
+	if err := doPostInto(endpoint, "/api/pull", req, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
 // CallPlanAPI calls the plan API by reading .sql files from schemaDir.
 // Files are grouped by namespace: subdirectories become namespace keys,
 // flat files use the directory name as the namespace.

--- a/pkg/cmd/client/client_test.go
+++ b/pkg/cmd/client/client_test.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -9,7 +10,57 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/block/schemabot/pkg/apitypes"
 )
+
+func TestCallPullSchemaAPI(t *testing.T) {
+	var gotReq apitypes.PullSchemaRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/pull", r.URL.Path)
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&gotReq))
+
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(apitypes.PullSchemaResponse{
+			Database:    "orders",
+			Type:        "mysql",
+			Environment: "production",
+			TableCount:  1,
+			SchemaFiles: map[string]*apitypes.SchemaFiles{
+				"orders": {Files: map[string]string{"users.sql": "CREATE TABLE `users` (`id` bigint NOT NULL);\n"}},
+			},
+		}))
+	}))
+	t.Cleanup(server.Close)
+
+	result, err := CallPullSchemaAPI(server.URL, "orders", "mysql", "production")
+	require.NoError(t, err)
+
+	assert.Equal(t, apitypes.PullSchemaRequest{Database: "orders", Type: "mysql", Environment: "production"}, gotReq)
+	require.NotNil(t, result)
+	assert.Equal(t, "orders", result.Database)
+	assert.Equal(t, "mysql", result.Type)
+	assert.Equal(t, "production", result.Environment)
+	assert.Equal(t, int32(1), result.TableCount)
+	assert.Equal(t, "CREATE TABLE `users` (`id` bigint NOT NULL);\n", result.SchemaFiles["orders"].Files["users.sql"])
+}
+
+func TestCallPullSchemaAPIError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, err := w.Write([]byte(`{"error":"database not configured"}`))
+		require.NoError(t, err)
+	}))
+	t.Cleanup(server.Close)
+
+	result, err := CallPullSchemaAPI(server.URL, "orders", "mysql", "production")
+	require.Error(t, err)
+
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "database not configured")
+}
 
 func TestGetStatusWithOptions(t *testing.T) {
 	var gotLimit, gotEnvironment, gotFailed string

--- a/pkg/cmd/commands/onboard.go
+++ b/pkg/cmd/commands/onboard.go
@@ -77,10 +77,14 @@ func (cmd *OnboardCmd) Run(g *Globals) error {
 	if !cmd.SkipVerify {
 		fmt.Println()
 		fmt.Println("Verifying pulled schema against the source environment...")
-		if err := verifyOnboardPlan(ep, resp, cmd.SchemaDir); err != nil {
+		verifyResult, err := verifyOnboardPlan(ep, resp, cmd.SchemaDir)
+		if err != nil {
 			return err
 		}
 		fmt.Println("Verified: pulled schema produces no schema changes in the source environment.")
+		if lintErrorCount := len(verifyResult.LintErrors()); lintErrorCount > 0 {
+			fmt.Printf("Warning: pulled schema has %d lint errors; normal PR checks will report them.\n", lintErrorCount)
+		}
 	}
 	fmt.Println()
 	fmt.Println("Next: open a normal PR. SchemaBot plan comments and checks will reconcile other configured environments.")
@@ -223,15 +227,18 @@ func formatOnboardWriteError(operation, path string, written []string, err error
 	return fmt.Errorf("%s %s after writing files:\n  %s\nerror: %w", operation, path, strings.Join(written, "\n  "), err)
 }
 
-func verifyOnboardPlan(endpoint string, resp *apitypes.PullSchemaResponse, schemaDir string) error {
+func verifyOnboardPlan(endpoint string, resp *apitypes.PullSchemaResponse, schemaDir string) (*apitypes.PlanResponse, error) {
 	planResult, err := client.CallPlanAPI(endpoint, resp.Database, resp.Type, resp.Environment, schemaDir, "", 0)
 	if err != nil {
 		if outputPlanRequestError(resp.Database, resp.Environment, err) {
-			return ErrSilent
+			return nil, ErrSilent
 		}
-		return fmt.Errorf("verify pulled schema for database %s environment %s: %w", resp.Database, resp.Environment, err)
+		return nil, fmt.Errorf("verify pulled schema for database %s environment %s: %w", resp.Database, resp.Environment, err)
 	}
-	return validateOnboardPlanResult(planResult)
+	if err := validateOnboardPlanResult(planResult); err != nil {
+		return nil, err
+	}
+	return planResult, nil
 }
 
 func validateOnboardPlanResult(result *apitypes.PlanResponse) error {
@@ -240,9 +247,6 @@ func validateOnboardPlanResult(result *apitypes.PlanResponse) error {
 	}
 	if len(result.Errors) > 0 {
 		return fmt.Errorf("verify pulled schema: plan returned errors:\n  %s", strings.Join(result.Errors, "\n  "))
-	}
-	if result.HasErrors() {
-		return fmt.Errorf("verify pulled schema: plan returned lint errors")
 	}
 	if hasResultChanges(result) {
 		return fmt.Errorf("verify pulled schema: pulled files still produce schema changes in %s", result.Environment)

--- a/pkg/cmd/commands/onboard.go
+++ b/pkg/cmd/commands/onboard.go
@@ -1,8 +1,10 @@
 package commands
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -25,6 +27,13 @@ type OnboardCmd struct {
 	SkipVerify  bool   `help:"Skip plan verification after writing files" name:"skip-verify"`
 }
 
+// PullCmd returns live schema from a source environment without writing files.
+type PullCmd struct {
+	Database    string `short:"d" required:"" help:"Database name from SchemaBot server config"`
+	Environment string `short:"e" required:"" help:"Source environment to pull from"`
+	Type        string `help:"Database type" default:"mysql" enum:"mysql"`
+}
+
 // Run executes the onboard command.
 func (cmd *OnboardCmd) Run(g *Globals) error {
 	ep, err := resolveEndpoint(g.Endpoint, g.Profile)
@@ -34,7 +43,7 @@ func (cmd *OnboardCmd) Run(g *Globals) error {
 
 	resp, err := client.CallPullSchemaAPI(ep, cmd.Database, cmd.Type, cmd.Environment)
 	if err != nil {
-		if outputOnboardRequestError(cmd.Database, cmd.Environment, err) {
+		if outputSchemaPullRequestError("Onboard", cmd.Database, cmd.Environment, err) {
 			return ErrSilent
 		}
 		return fmt.Errorf("pull schema for database %s environment %s: %w", cmd.Database, cmd.Environment, err)
@@ -86,6 +95,31 @@ func (cmd *OnboardCmd) Run(g *Globals) error {
 	fmt.Printf("Onboarding complete for %s from %s.\n", resp.Database, resp.Environment)
 	fmt.Println("Next: open a normal PR with these files. SchemaBot will reconcile other configured environments.")
 	return nil
+}
+
+// Run executes the pull command.
+func (cmd *PullCmd) Run(g *Globals) error {
+	ep, err := resolveEndpoint(g.Endpoint, g.Profile)
+	if err != nil {
+		return err
+	}
+	resp, err := client.CallPullSchemaAPI(ep, cmd.Database, cmd.Type, cmd.Environment)
+	if err != nil {
+		if outputSchemaPullRequestError("Pull", cmd.Database, cmd.Environment, err) {
+			return ErrSilent
+		}
+		return fmt.Errorf("pull schema for database %s environment %s: %w", cmd.Database, cmd.Environment, err)
+	}
+	if err := writePullSchemaResponse(os.Stdout, resp); err != nil {
+		return fmt.Errorf("write pull schema response: %w", err)
+	}
+	return nil
+}
+
+func writePullSchemaResponse(w io.Writer, resp *apitypes.PullSchemaResponse) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(resp)
 }
 
 type onboardWritePlan struct {
@@ -248,14 +282,14 @@ func validateOnboardPlanResult(result *apitypes.PlanResponse) error {
 	return nil
 }
 
-func outputOnboardRequestError(database, environment string, err error) bool {
+func outputSchemaPullRequestError(operation, database, environment string, err error) bool {
 	var apiErr *client.APIError
 	var connectionErr *client.ConnectionError
 	if !errors.As(err, &apiErr) && !errors.As(err, &connectionErr) {
 		return false
 	}
 
-	fmt.Printf("%sOnboard failed%s\n", templates.ANSIRed, templates.ANSIReset)
+	fmt.Printf("%s%s failed%s\n", templates.ANSIRed, operation, templates.ANSIReset)
 	fmt.Printf("  Database: %s\n", database)
 	fmt.Printf("  Environment: %s\n", environment)
 	if apiErr != nil {

--- a/pkg/cmd/commands/onboard.go
+++ b/pkg/cmd/commands/onboard.go
@@ -84,7 +84,7 @@ func (cmd *OnboardCmd) Run(g *Globals) error {
 	}
 	fmt.Println()
 	fmt.Printf("Onboarding complete for %s from %s.\n", resp.Database, resp.Environment)
-	fmt.Println("Next: open a normal PR. SchemaBot plan comments and checks will reconcile other configured environments.")
+	fmt.Println("Next: open a normal PR with these files. SchemaBot will reconcile other configured environments.")
 	return nil
 }
 

--- a/pkg/cmd/commands/onboard.go
+++ b/pkg/cmd/commands/onboard.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/block/schemabot/pkg/apitypes"
 	"github.com/block/schemabot/pkg/cmd/client"
+	"github.com/block/schemabot/pkg/cmd/internal/templates"
 	"github.com/block/schemabot/pkg/storage"
 )
 
@@ -20,6 +22,7 @@ type OnboardCmd struct {
 	Type        string `help:"Database type" default:"mysql" enum:"mysql"`
 	DryRun      bool   `help:"Preview files without writing them" name:"dry-run"`
 	Force       bool   `help:"Overwrite existing generated files"`
+	SkipVerify  bool   `help:"Skip plan verification after writing files" name:"skip-verify"`
 }
 
 // Run executes the onboard command.
@@ -28,12 +31,12 @@ func (cmd *OnboardCmd) Run(g *Globals) error {
 	if err != nil {
 		return err
 	}
-	if cmd.Type != storage.DatabaseTypeMySQL {
-		return fmt.Errorf("onboard currently supports %s databases; got %s", storage.DatabaseTypeMySQL, cmd.Type)
-	}
 
 	resp, err := client.CallPullSchemaAPI(ep, cmd.Database, cmd.Type, cmd.Environment)
 	if err != nil {
+		if outputOnboardRequestError(cmd.Database, cmd.Environment, err) {
+			return ErrSilent
+		}
 		return fmt.Errorf("pull schema for database %s environment %s: %w", cmd.Database, cmd.Environment, err)
 	}
 	plan, err := buildOnboardWritePlan(cmd.SchemaDir, resp)
@@ -50,7 +53,12 @@ func (cmd *OnboardCmd) Run(g *Globals) error {
 	if cmd.DryRun {
 		fmt.Println("Dry run: would write files:")
 		for _, path := range plan.paths() {
-			if fileExists(path) {
+			exists, statErr := fileStatusForDryRun(path)
+			if statErr != nil {
+				fmt.Printf("  %s (exists or inaccessible: %v)\n", path, statErr)
+				continue
+			}
+			if exists {
 				fmt.Printf("  %s (exists)\n", path)
 				continue
 			}
@@ -66,6 +74,14 @@ func (cmd *OnboardCmd) Run(g *Globals) error {
 	for _, path := range plan.paths() {
 		fmt.Printf("  %s\n", path)
 	}
+	if !cmd.SkipVerify {
+		fmt.Println()
+		fmt.Println("Verifying pulled schema against the source environment...")
+		if err := verifyOnboardPlan(ep, resp, cmd.SchemaDir); err != nil {
+			return err
+		}
+		fmt.Println("Verified: pulled schema produces no schema changes in the source environment.")
+	}
 	fmt.Println()
 	fmt.Println("Next: open a normal PR. SchemaBot plan comments and checks will reconcile other configured environments.")
 	return nil
@@ -77,11 +93,20 @@ type onboardWritePlan struct {
 }
 
 func buildOnboardWritePlan(schemaRoot string, resp *apitypes.PullSchemaResponse) (*onboardWritePlan, error) {
+	if strings.TrimSpace(schemaRoot) == "" {
+		return nil, fmt.Errorf("schema root is required")
+	}
 	if resp == nil {
 		return nil, fmt.Errorf("pull schema response is empty")
 	}
+	if strings.TrimSpace(resp.Database) == "" {
+		return nil, fmt.Errorf("pull schema response database is empty")
+	}
 	if resp.Type != storage.DatabaseTypeMySQL {
 		return nil, fmt.Errorf("onboard currently supports %s databases; got %s", storage.DatabaseTypeMySQL, resp.Type)
+	}
+	if len(resp.SchemaFiles) == 0 {
+		return nil, fmt.Errorf("pull schema returned no tables for database %s environment %s", resp.Database, resp.Environment)
 	}
 	root := filepath.Clean(schemaRoot)
 	files := map[string]string{
@@ -100,6 +125,9 @@ func buildOnboardWritePlan(schemaRoot string, resp *apitypes.PullSchemaResponse)
 		nsFiles := resp.SchemaFiles[namespace]
 		if nsFiles == nil {
 			return nil, fmt.Errorf("schema files for namespace %s are empty", namespace)
+		}
+		if len(nsFiles.Files) == 0 {
+			return nil, fmt.Errorf("schema files for namespace %s contain no tables", namespace)
 		}
 		filenames := make([]string, 0, len(nsFiles.Files))
 		for filename := range nsFiles.Files {
@@ -128,9 +156,17 @@ func validateRelativePathPart(kind, value string) error {
 }
 
 func (p *onboardWritePlan) paths() []string {
+	paths := make([]string, 0, len(p.relativePaths()))
+	for _, relativePath := range p.relativePaths() {
+		paths = append(paths, filepath.Join(p.root, relativePath))
+	}
+	return paths
+}
+
+func (p *onboardWritePlan) relativePaths() []string {
 	paths := make([]string, 0, len(p.files))
 	for relativePath := range p.files {
-		paths = append(paths, filepath.Join(p.root, relativePath))
+		paths = append(paths, relativePath)
 	}
 	sort.Strings(paths)
 	return paths
@@ -154,20 +190,82 @@ func (p *onboardWritePlan) checkConflicts(force bool) error {
 	return nil
 }
 
-func fileExists(path string) bool {
+func fileStatusForDryRun(path string) (exists bool, statErr error) {
 	_, err := os.Stat(path)
-	return err == nil
+	if err == nil {
+		return true, nil
+	}
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return true, err
 }
 
 func (p *onboardWritePlan) write() error {
-	for relativePath, content := range p.files {
+	written := make([]string, 0, len(p.files))
+	for _, relativePath := range p.relativePaths() {
 		path := filepath.Join(p.root, relativePath)
 		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-			return fmt.Errorf("create directory for %s: %w", path, err)
+			return formatOnboardWriteError("create directory for", path, written, err)
 		}
-		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
-			return fmt.Errorf("write %s: %w", path, err)
+		if err := os.WriteFile(path, []byte(p.files[relativePath]), 0o644); err != nil {
+			return formatOnboardWriteError("write", path, written, err)
 		}
+		written = append(written, path)
 	}
 	return nil
+}
+
+func formatOnboardWriteError(operation, path string, written []string, err error) error {
+	if len(written) == 0 {
+		return fmt.Errorf("%s %s: %w", operation, path, err)
+	}
+	return fmt.Errorf("%s %s after writing files:\n  %s\nerror: %w", operation, path, strings.Join(written, "\n  "), err)
+}
+
+func verifyOnboardPlan(endpoint string, resp *apitypes.PullSchemaResponse, schemaDir string) error {
+	planResult, err := client.CallPlanAPI(endpoint, resp.Database, resp.Type, resp.Environment, schemaDir, "", 0)
+	if err != nil {
+		if outputPlanRequestError(resp.Database, resp.Environment, err) {
+			return ErrSilent
+		}
+		return fmt.Errorf("verify pulled schema for database %s environment %s: %w", resp.Database, resp.Environment, err)
+	}
+	return validateOnboardPlanResult(planResult)
+}
+
+func validateOnboardPlanResult(result *apitypes.PlanResponse) error {
+	if result == nil {
+		return fmt.Errorf("verify pulled schema: plan response is empty")
+	}
+	if len(result.Errors) > 0 {
+		return fmt.Errorf("verify pulled schema: plan returned errors:\n  %s", strings.Join(result.Errors, "\n  "))
+	}
+	if result.HasErrors() {
+		return fmt.Errorf("verify pulled schema: plan returned lint errors")
+	}
+	if hasResultChanges(result) {
+		return fmt.Errorf("verify pulled schema: pulled files still produce schema changes in %s", result.Environment)
+	}
+	return nil
+}
+
+func outputOnboardRequestError(database, environment string, err error) bool {
+	var apiErr *client.APIError
+	var connectionErr *client.ConnectionError
+	if !errors.As(err, &apiErr) && !errors.As(err, &connectionErr) {
+		return false
+	}
+
+	fmt.Printf("%sOnboard failed%s\n", templates.ANSIRed, templates.ANSIReset)
+	fmt.Printf("  Database: %s\n", database)
+	fmt.Printf("  Environment: %s\n", environment)
+	if apiErr != nil {
+		fmt.Printf("  API status: HTTP %d\n", apiErr.Status)
+		if apiErr.ErrorCode != "" {
+			fmt.Printf("  Error code: %s\n", apiErr.ErrorCode)
+		}
+	}
+	fmt.Printf("  Error: %s\n", err.Error())
+	return true
 }

--- a/pkg/cmd/commands/onboard.go
+++ b/pkg/cmd/commands/onboard.go
@@ -77,14 +77,10 @@ func (cmd *OnboardCmd) Run(g *Globals) error {
 	if !cmd.SkipVerify {
 		fmt.Println()
 		fmt.Println("Verifying pulled schema against the source environment...")
-		verifyResult, err := verifyOnboardPlan(ep, resp, cmd.SchemaDir)
-		if err != nil {
+		if err := verifyOnboardPlan(ep, resp, cmd.SchemaDir); err != nil {
 			return err
 		}
 		fmt.Println("Verified: pulled schema produces no schema changes in the source environment.")
-		if lintErrorCount := len(verifyResult.LintErrors()); lintErrorCount > 0 {
-			fmt.Printf("Warning: pulled schema has %d lint errors; normal PR checks will report them.\n", lintErrorCount)
-		}
 	}
 	fmt.Println()
 	fmt.Println("Next: open a normal PR. SchemaBot plan comments and checks will reconcile other configured environments.")
@@ -227,18 +223,15 @@ func formatOnboardWriteError(operation, path string, written []string, err error
 	return fmt.Errorf("%s %s after writing files:\n  %s\nerror: %w", operation, path, strings.Join(written, "\n  "), err)
 }
 
-func verifyOnboardPlan(endpoint string, resp *apitypes.PullSchemaResponse, schemaDir string) (*apitypes.PlanResponse, error) {
+func verifyOnboardPlan(endpoint string, resp *apitypes.PullSchemaResponse, schemaDir string) error {
 	planResult, err := client.CallPlanAPI(endpoint, resp.Database, resp.Type, resp.Environment, schemaDir, "", 0)
 	if err != nil {
 		if outputPlanRequestError(resp.Database, resp.Environment, err) {
-			return nil, ErrSilent
+			return ErrSilent
 		}
-		return nil, fmt.Errorf("verify pulled schema for database %s environment %s: %w", resp.Database, resp.Environment, err)
+		return fmt.Errorf("verify pulled schema for database %s environment %s: %w", resp.Database, resp.Environment, err)
 	}
-	if err := validateOnboardPlanResult(planResult); err != nil {
-		return nil, err
-	}
-	return planResult, nil
+	return validateOnboardPlanResult(planResult)
 }
 
 func validateOnboardPlanResult(result *apitypes.PlanResponse) error {

--- a/pkg/cmd/commands/onboard.go
+++ b/pkg/cmd/commands/onboard.go
@@ -83,6 +83,7 @@ func (cmd *OnboardCmd) Run(g *Globals) error {
 		fmt.Println("Verified: pulled schema produces no schema changes in the source environment.")
 	}
 	fmt.Println()
+	fmt.Printf("Onboarding complete for %s from %s.\n", resp.Database, resp.Environment)
 	fmt.Println("Next: open a normal PR. SchemaBot plan comments and checks will reconcile other configured environments.")
 	return nil
 }

--- a/pkg/cmd/commands/onboard.go
+++ b/pkg/cmd/commands/onboard.go
@@ -1,10 +1,8 @@
 package commands
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -25,13 +23,6 @@ type OnboardCmd struct {
 	DryRun      bool   `help:"Preview files without writing them" name:"dry-run"`
 	Force       bool   `help:"Overwrite existing generated files"`
 	SkipVerify  bool   `help:"Skip plan verification after writing files" name:"skip-verify"`
-}
-
-// PullCmd returns live schema from a source environment without writing files.
-type PullCmd struct {
-	Database    string `short:"d" required:"" help:"Database name from SchemaBot server config"`
-	Environment string `short:"e" required:"" help:"Source environment to pull from"`
-	Type        string `help:"Database type" default:"mysql" enum:"mysql"`
 }
 
 // Run executes the onboard command.
@@ -95,31 +86,6 @@ func (cmd *OnboardCmd) Run(g *Globals) error {
 	fmt.Printf("Onboarding complete for %s from %s.\n", resp.Database, resp.Environment)
 	fmt.Println("Next: open a normal PR with these files. SchemaBot will reconcile other configured environments.")
 	return nil
-}
-
-// Run executes the pull command.
-func (cmd *PullCmd) Run(g *Globals) error {
-	ep, err := resolveEndpoint(g.Endpoint, g.Profile)
-	if err != nil {
-		return err
-	}
-	resp, err := client.CallPullSchemaAPI(ep, cmd.Database, cmd.Type, cmd.Environment)
-	if err != nil {
-		if outputSchemaPullRequestError("Pull", cmd.Database, cmd.Environment, err) {
-			return ErrSilent
-		}
-		return fmt.Errorf("pull schema for database %s environment %s: %w", cmd.Database, cmd.Environment, err)
-	}
-	if err := writePullSchemaResponse(os.Stdout, resp); err != nil {
-		return fmt.Errorf("write pull schema response: %w", err)
-	}
-	return nil
-}
-
-func writePullSchemaResponse(w io.Writer, resp *apitypes.PullSchemaResponse) error {
-	enc := json.NewEncoder(w)
-	enc.SetIndent("", "  ")
-	return enc.Encode(resp)
 }
 
 type onboardWritePlan struct {

--- a/pkg/cmd/commands/onboard.go
+++ b/pkg/cmd/commands/onboard.go
@@ -1,0 +1,173 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/block/schemabot/pkg/apitypes"
+	"github.com/block/schemabot/pkg/cmd/client"
+	"github.com/block/schemabot/pkg/storage"
+)
+
+// OnboardCmd pulls live schema into a new declarative schema directory.
+type OnboardCmd struct {
+	Database    string `short:"d" required:"" help:"Database name from SchemaBot server config"`
+	Environment string `short:"e" required:"" help:"Source environment to pull from"`
+	SchemaDir   string `short:"s" required:"" help:"Schema root to write schemabot.yaml and namespace directories" name:"schema_dir"`
+	Type        string `help:"Database type" default:"mysql" enum:"mysql"`
+	DryRun      bool   `help:"Preview files without writing them" name:"dry-run"`
+	Force       bool   `help:"Overwrite existing generated files"`
+}
+
+// Run executes the onboard command.
+func (cmd *OnboardCmd) Run(g *Globals) error {
+	ep, err := resolveEndpoint(g.Endpoint, g.Profile)
+	if err != nil {
+		return err
+	}
+	if cmd.Type != storage.DatabaseTypeMySQL {
+		return fmt.Errorf("onboard currently supports %s databases; got %s", storage.DatabaseTypeMySQL, cmd.Type)
+	}
+
+	resp, err := client.CallPullSchemaAPI(ep, cmd.Database, cmd.Type, cmd.Environment)
+	if err != nil {
+		return fmt.Errorf("pull schema for database %s environment %s: %w", cmd.Database, cmd.Environment, err)
+	}
+	plan, err := buildOnboardWritePlan(cmd.SchemaDir, resp)
+	if err != nil {
+		return err
+	}
+	if !cmd.DryRun {
+		if err := plan.checkConflicts(cmd.Force); err != nil {
+			return err
+		}
+	}
+
+	fmt.Printf("Pulled %d tables from %s/%s.\n", resp.TableCount, resp.Database, resp.Environment)
+	if cmd.DryRun {
+		fmt.Println("Dry run: would write files:")
+		for _, path := range plan.paths() {
+			if fileExists(path) {
+				fmt.Printf("  %s (exists)\n", path)
+				continue
+			}
+			fmt.Printf("  %s\n", path)
+		}
+		return nil
+	}
+
+	if err := plan.write(); err != nil {
+		return err
+	}
+	fmt.Println("Wrote declarative schema files:")
+	for _, path := range plan.paths() {
+		fmt.Printf("  %s\n", path)
+	}
+	fmt.Println()
+	fmt.Println("Next: open a normal PR. SchemaBot plan comments and checks will reconcile other configured environments.")
+	return nil
+}
+
+type onboardWritePlan struct {
+	root  string
+	files map[string]string
+}
+
+func buildOnboardWritePlan(schemaRoot string, resp *apitypes.PullSchemaResponse) (*onboardWritePlan, error) {
+	if resp == nil {
+		return nil, fmt.Errorf("pull schema response is empty")
+	}
+	if resp.Type != storage.DatabaseTypeMySQL {
+		return nil, fmt.Errorf("onboard currently supports %s databases; got %s", storage.DatabaseTypeMySQL, resp.Type)
+	}
+	root := filepath.Clean(schemaRoot)
+	files := map[string]string{
+		"schemabot.yaml": fmt.Sprintf("database: %s\ntype: %s\n", resp.Database, resp.Type),
+	}
+
+	namespaces := make([]string, 0, len(resp.SchemaFiles))
+	for namespace := range resp.SchemaFiles {
+		namespaces = append(namespaces, namespace)
+	}
+	sort.Strings(namespaces)
+	for _, namespace := range namespaces {
+		if err := validateRelativePathPart("namespace", namespace); err != nil {
+			return nil, err
+		}
+		nsFiles := resp.SchemaFiles[namespace]
+		if nsFiles == nil {
+			return nil, fmt.Errorf("schema files for namespace %s are empty", namespace)
+		}
+		filenames := make([]string, 0, len(nsFiles.Files))
+		for filename := range nsFiles.Files {
+			filenames = append(filenames, filename)
+		}
+		sort.Strings(filenames)
+		for _, filename := range filenames {
+			if err := validateRelativePathPart("schema file", filename); err != nil {
+				return nil, err
+			}
+			files[filepath.Join(namespace, filename)] = nsFiles.Files[filename]
+		}
+	}
+
+	return &onboardWritePlan{root: root, files: files}, nil
+}
+
+func validateRelativePathPart(kind, value string) error {
+	if value == "" {
+		return fmt.Errorf("%s is empty", kind)
+	}
+	if filepath.IsAbs(value) || strings.Contains(value, "..") || strings.ContainsAny(value, `/\`) {
+		return fmt.Errorf("%s %q must be a single relative path component", kind, value)
+	}
+	return nil
+}
+
+func (p *onboardWritePlan) paths() []string {
+	paths := make([]string, 0, len(p.files))
+	for relativePath := range p.files {
+		paths = append(paths, filepath.Join(p.root, relativePath))
+	}
+	sort.Strings(paths)
+	return paths
+}
+
+func (p *onboardWritePlan) checkConflicts(force bool) error {
+	if force {
+		return nil
+	}
+	var existing []string
+	for _, path := range p.paths() {
+		if _, err := os.Stat(path); err == nil {
+			existing = append(existing, path)
+		} else if !os.IsNotExist(err) {
+			return fmt.Errorf("check output file %s: %w", path, err)
+		}
+	}
+	if len(existing) > 0 {
+		return fmt.Errorf("refusing to overwrite existing files (use --force to overwrite):\n  %s", strings.Join(existing, "\n  "))
+	}
+	return nil
+}
+
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+func (p *onboardWritePlan) write() error {
+	for relativePath, content := range p.files {
+		path := filepath.Join(p.root, relativePath)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			return fmt.Errorf("create directory for %s: %w", path, err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			return fmt.Errorf("write %s: %w", path, err)
+		}
+	}
+	return nil
+}

--- a/pkg/cmd/commands/onboard_test.go
+++ b/pkg/cmd/commands/onboard_test.go
@@ -1,6 +1,8 @@
 package commands
 
 import (
+	"bytes"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -42,6 +44,18 @@ func TestBuildOnboardWritePlanWritesConfigAndNamespaceFiles(t *testing.T) {
 	orders, err := os.ReadFile(filepath.Join(root, "orders", "orders.sql"))
 	require.NoError(t, err)
 	assert.Equal(t, "CREATE TABLE `orders` (`id` bigint NOT NULL);\n", string(orders))
+}
+
+func TestWritePullSchemaResponseReturnsSchemaAsJSON(t *testing.T) {
+	var out bytes.Buffer
+	require.NoError(t, writePullSchemaResponse(&out, validPullSchemaResponse()))
+
+	var got apitypes.PullSchemaResponse
+	require.NoError(t, json.Unmarshal(out.Bytes(), &got))
+	assert.Equal(t, "orders", got.Database)
+	assert.Equal(t, "mysql", got.Type)
+	assert.Equal(t, "production", got.Environment)
+	assert.Equal(t, "CREATE TABLE `users` (`id` bigint NOT NULL);\n", got.SchemaFiles["orders"].Files["users.sql"])
 }
 
 func TestOnboardWritePlanRefusesExistingFilesWithoutForce(t *testing.T) {

--- a/pkg/cmd/commands/onboard_test.go
+++ b/pkg/cmd/commands/onboard_test.go
@@ -77,3 +77,107 @@ func TestBuildOnboardWritePlanRejectsUnsafeResponsePaths(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "schema file")
 }
+
+func TestBuildOnboardWritePlanRejectsInvalidPullResponse(t *testing.T) {
+	tests := []struct {
+		name       string
+		schemaRoot string
+		resp       *apitypes.PullSchemaResponse
+		want       string
+	}{
+		{
+			name:       "empty schema root",
+			schemaRoot: "",
+			resp:       validPullSchemaResponse(),
+			want:       "schema root is required",
+		},
+		{
+			name:       "empty database",
+			schemaRoot: t.TempDir(),
+			resp: func() *apitypes.PullSchemaResponse {
+				resp := validPullSchemaResponse()
+				resp.Database = ""
+				return resp
+			}(),
+			want: "database is empty",
+		},
+		{
+			name:       "empty pull",
+			schemaRoot: t.TempDir(),
+			resp: &apitypes.PullSchemaResponse{
+				Database:    "orders",
+				Type:        "mysql",
+				Environment: "production",
+			},
+			want: "returned no tables",
+		},
+		{
+			name:       "empty namespace",
+			schemaRoot: t.TempDir(),
+			resp: &apitypes.PullSchemaResponse{
+				Database:    "orders",
+				Type:        "mysql",
+				Environment: "production",
+				SchemaFiles: map[string]*apitypes.SchemaFiles{
+					"orders": {Files: map[string]string{}},
+				},
+			},
+			want: "contain no tables",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			plan, err := buildOnboardWritePlan(tt.schemaRoot, tt.resp)
+			require.Error(t, err)
+			assert.Nil(t, plan)
+			assert.Contains(t, err.Error(), tt.want)
+		})
+	}
+}
+
+func TestFileStatusForDryRunTreatsStatErrorsAsExisting(t *testing.T) {
+	root := t.TempDir()
+	existing := filepath.Join(root, "schemabot.yaml")
+	require.NoError(t, os.WriteFile(existing, []byte("database: orders\ntype: mysql\n"), 0o644))
+
+	exists, err := fileStatusForDryRun(existing)
+	require.NoError(t, err)
+	assert.True(t, exists)
+
+	exists, err = fileStatusForDryRun(filepath.Join(root, "missing.sql"))
+	require.NoError(t, err)
+	assert.False(t, exists)
+
+	exists, err = fileStatusForDryRun(filepath.Join(existing, "child.sql"))
+	require.Error(t, err)
+	assert.True(t, exists)
+}
+
+func TestValidateOnboardPlanResult(t *testing.T) {
+	assert.NoError(t, validateOnboardPlanResult(&apitypes.PlanResponse{Environment: "production"}))
+
+	err := validateOnboardPlanResult(&apitypes.PlanResponse{
+		Environment: "production",
+		Changes: []*apitypes.SchemaChangeResponse{
+			{TableChanges: []*apitypes.TableChangeResponse{{TableName: "users", ChangeType: "ALTER"}}},
+		},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "still produce schema changes")
+
+	err = validateOnboardPlanResult(&apitypes.PlanResponse{Errors: []string{"syntax error"}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "plan returned errors")
+}
+
+func validPullSchemaResponse() *apitypes.PullSchemaResponse {
+	return &apitypes.PullSchemaResponse{
+		Database:    "orders",
+		Type:        "mysql",
+		Environment: "production",
+		SchemaFiles: map[string]*apitypes.SchemaFiles{
+			"orders": {Files: map[string]string{"users.sql": "CREATE TABLE `users` (`id` bigint NOT NULL);\n"}},
+		},
+	}
+}

--- a/pkg/cmd/commands/onboard_test.go
+++ b/pkg/cmd/commands/onboard_test.go
@@ -156,6 +156,10 @@ func TestFileStatusForDryRunTreatsStatErrorsAsExisting(t *testing.T) {
 
 func TestValidateOnboardPlanResult(t *testing.T) {
 	assert.NoError(t, validateOnboardPlanResult(&apitypes.PlanResponse{Environment: "production"}))
+	assert.NoError(t, validateOnboardPlanResult(&apitypes.PlanResponse{
+		Environment: "production",
+		LintResults: []*apitypes.LintViolationResponse{{Severity: "error", Message: "existing lint violation"}},
+	}))
 
 	err := validateOnboardPlanResult(&apitypes.PlanResponse{
 		Environment: "production",

--- a/pkg/cmd/commands/onboard_test.go
+++ b/pkg/cmd/commands/onboard_test.go
@@ -1,0 +1,79 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/block/schemabot/pkg/apitypes"
+)
+
+func TestBuildOnboardWritePlanWritesConfigAndNamespaceFiles(t *testing.T) {
+	root := t.TempDir()
+	plan, err := buildOnboardWritePlan(root, &apitypes.PullSchemaResponse{
+		Database:    "orders",
+		Type:        "mysql",
+		Environment: "production",
+		TableCount:  2,
+		SchemaFiles: map[string]*apitypes.SchemaFiles{
+			"orders": {
+				Files: map[string]string{
+					"users.sql":  "CREATE TABLE `users` (`id` bigint NOT NULL);\n",
+					"orders.sql": "CREATE TABLE `orders` (`id` bigint NOT NULL);\n",
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.NoError(t, plan.checkConflicts(false))
+	require.NoError(t, plan.write())
+
+	config, err := os.ReadFile(filepath.Join(root, "schemabot.yaml"))
+	require.NoError(t, err)
+	assert.Equal(t, "database: orders\ntype: mysql\n", string(config))
+
+	users, err := os.ReadFile(filepath.Join(root, "orders", "users.sql"))
+	require.NoError(t, err)
+	assert.Equal(t, "CREATE TABLE `users` (`id` bigint NOT NULL);\n", string(users))
+
+	orders, err := os.ReadFile(filepath.Join(root, "orders", "orders.sql"))
+	require.NoError(t, err)
+	assert.Equal(t, "CREATE TABLE `orders` (`id` bigint NOT NULL);\n", string(orders))
+}
+
+func TestOnboardWritePlanRefusesExistingFilesWithoutForce(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "schemabot.yaml"), []byte("database: old\ntype: mysql\n"), 0o644))
+	plan, err := buildOnboardWritePlan(root, &apitypes.PullSchemaResponse{
+		Database:    "orders",
+		Type:        "mysql",
+		Environment: "production",
+		SchemaFiles: map[string]*apitypes.SchemaFiles{
+			"orders": {Files: map[string]string{"users.sql": "CREATE TABLE `users` (`id` bigint NOT NULL);\n"}},
+		},
+	})
+	require.NoError(t, err)
+
+	err = plan.checkConflicts(false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "refusing to overwrite existing files")
+	assert.Contains(t, err.Error(), filepath.Join(root, "schemabot.yaml"))
+
+	require.NoError(t, plan.checkConflicts(true))
+}
+
+func TestBuildOnboardWritePlanRejectsUnsafeResponsePaths(t *testing.T) {
+	_, err := buildOnboardWritePlan(t.TempDir(), &apitypes.PullSchemaResponse{
+		Database:    "orders",
+		Type:        "mysql",
+		Environment: "production",
+		SchemaFiles: map[string]*apitypes.SchemaFiles{
+			"orders": {Files: map[string]string{"../users.sql": "CREATE TABLE `users` (`id` bigint NOT NULL);\n"}},
+		},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "schema file")
+}

--- a/pkg/cmd/commands/onboard_test.go
+++ b/pkg/cmd/commands/onboard_test.go
@@ -1,8 +1,6 @@
 package commands
 
 import (
-	"bytes"
-	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -44,18 +42,6 @@ func TestBuildOnboardWritePlanWritesConfigAndNamespaceFiles(t *testing.T) {
 	orders, err := os.ReadFile(filepath.Join(root, "orders", "orders.sql"))
 	require.NoError(t, err)
 	assert.Equal(t, "CREATE TABLE `orders` (`id` bigint NOT NULL);\n", string(orders))
-}
-
-func TestWritePullSchemaResponseReturnsSchemaAsJSON(t *testing.T) {
-	var out bytes.Buffer
-	require.NoError(t, writePullSchemaResponse(&out, validPullSchemaResponse()))
-
-	var got apitypes.PullSchemaResponse
-	require.NoError(t, json.Unmarshal(out.Bytes(), &got))
-	assert.Equal(t, "orders", got.Database)
-	assert.Equal(t, "mysql", got.Type)
-	assert.Equal(t, "production", got.Environment)
-	assert.Equal(t, "CREATE TABLE `users` (`id` bigint NOT NULL);\n", got.SchemaFiles["orders"].Files["users.sql"])
 }
 
 func TestOnboardWritePlanRefusesExistingFilesWithoutForce(t *testing.T) {

--- a/pkg/cmd/commands/pull.go
+++ b/pkg/cmd/commands/pull.go
@@ -1,0 +1,43 @@
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/block/schemabot/pkg/apitypes"
+	"github.com/block/schemabot/pkg/cmd/client"
+)
+
+// PullCmd returns live schema from a source environment without writing files.
+type PullCmd struct {
+	Database    string `short:"d" required:"" help:"Database name from SchemaBot server config"`
+	Environment string `short:"e" required:"" help:"Source environment to pull from"`
+	Type        string `help:"Database type" default:"mysql" enum:"mysql"`
+}
+
+// Run executes the pull command.
+func (cmd *PullCmd) Run(g *Globals) error {
+	ep, err := resolveEndpoint(g.Endpoint, g.Profile)
+	if err != nil {
+		return err
+	}
+	resp, err := client.CallPullSchemaAPI(ep, cmd.Database, cmd.Type, cmd.Environment)
+	if err != nil {
+		if outputSchemaPullRequestError("Pull", cmd.Database, cmd.Environment, err) {
+			return ErrSilent
+		}
+		return fmt.Errorf("pull schema for database %s environment %s: %w", cmd.Database, cmd.Environment, err)
+	}
+	if err := writePullSchemaResponse(os.Stdout, resp); err != nil {
+		return fmt.Errorf("write pull schema response: %w", err)
+	}
+	return nil
+}
+
+func writePullSchemaResponse(w io.Writer, resp *apitypes.PullSchemaResponse) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(resp)
+}

--- a/pkg/cmd/commands/pull_test.go
+++ b/pkg/cmd/commands/pull_test.go
@@ -1,0 +1,24 @@
+package commands
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/block/schemabot/pkg/apitypes"
+)
+
+func TestWritePullSchemaResponseReturnsSchemaAsJSON(t *testing.T) {
+	var out bytes.Buffer
+	require.NoError(t, writePullSchemaResponse(&out, validPullSchemaResponse()))
+
+	var got apitypes.PullSchemaResponse
+	require.NoError(t, json.Unmarshal(out.Bytes(), &got))
+	assert.Equal(t, "orders", got.Database)
+	assert.Equal(t, "mysql", got.Type)
+	assert.Equal(t, "production", got.Environment)
+	assert.Equal(t, "CREATE TABLE `users` (`id` bigint NOT NULL);\n", got.SchemaFiles["orders"].Files["users.sql"])
+}

--- a/pkg/cmd/main.go
+++ b/pkg/cmd/main.go
@@ -25,7 +25,8 @@ type CLI struct {
 	VersionFlag kong.VersionFlag `name:"version" help:"Show version information"`
 
 	Plan       commands.PlanCmd       `cmd:"" help:"Create a schema change plan"`
-	Onboard    commands.OnboardCmd    `cmd:"" aliases:"pull" help:"Pull live schema into a declarative schema directory"`
+	Onboard    commands.OnboardCmd    `cmd:"" help:"Pull live schema into a new declarative schema directory"`
+	Pull       commands.PullCmd       `cmd:"" help:"Return live schema from a source environment"`
 	Apply      commands.ApplyCmd      `cmd:"" help:"Apply schema changes"`
 	Progress   commands.ProgressCmd   `cmd:"" help:"Get schema change progress"`
 	Cutover    commands.CutoverCmd    `cmd:"" help:"Trigger cutover for a deferred schema change"`

--- a/pkg/cmd/main.go
+++ b/pkg/cmd/main.go
@@ -25,6 +25,7 @@ type CLI struct {
 	VersionFlag kong.VersionFlag `name:"version" help:"Show version information"`
 
 	Plan       commands.PlanCmd       `cmd:"" help:"Create a schema change plan"`
+	Onboard    commands.OnboardCmd    `cmd:"" aliases:"pull" help:"Pull live schema into a declarative schema directory"`
 	Apply      commands.ApplyCmd      `cmd:"" help:"Apply schema changes"`
 	Progress   commands.ProgressCmd   `cmd:"" help:"Get schema change progress"`
 	Cutover    commands.CutoverCmd    `cmd:"" help:"Trigger cutover for a deferred schema change"`


### PR DESCRIPTION
## Why
Make it easier to onboard an existing live MySQL database into SchemaBot's declarative schema layout without manually copying table definitions.

## What
- Add `schemabot onboard` to create `schemabot.yaml` plus namespace-scoped SQL files from live schema
- Add read-only `schemabot pull` to return the server-side pull payload without writing files
- Verify onboarded files produce no schema changes against the source environment by default
- Add dry-run previews, response validation, and overwrite protection with explicit `--force`

```text
schemabot onboard -d mydb -e production -s schema/mydb
        │
        ▼
SchemaBot API /api/pull ──▶ source environment live schema
        │
        ▼
schema/mydb/
├── schemabot.yaml
└── mydb/
    ├── users.sql
    └── orders.sql
        │
        ▼
plan verification against production: no schema changes
        │
        ▼
open a normal PR; SchemaBot reconciles other configured environments

schemabot pull -d mydb -e production
        │
        ▼
prints the /api/pull schema payload to stdout; no files are written
```

## Risk Assessment
Low — these are new opt-in CLI commands. `onboard` only writes local files, refuses to overwrite existing output unless explicitly forced, and validates the generated schema with a follow-up plan check; `pull` is read-only.

Generated with Amp
