### PR TITLE
fix(github): support PR comment start command

### DIFF
--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -532,9 +532,9 @@ schemabot apply -e production
 | `schemabot apply -e <env>` | Plan, lock, and confirm deployment |
 | `schemabot apply-confirm -e <env>` | Execute a locked plan |
 | `schemabot unlock` | Release lock and discard plan |
-| `schemabot stop <apply-id>` | Stop an in-progress deployment |
-| `schemabot start <apply-id>` | Resume a stopped deployment |
-| `schemabot cutover <apply-id>` | Complete a deferred cutover |
+| `schemabot stop <apply-id> -e <env>` | Stop an in-progress deployment |
+| `schemabot start <apply-id> -e <env>` | Resume a stopped deployment |
+| `schemabot cutover <apply-id> -e <env>` | Complete a deferred cutover |
 | `schemabot rollback <apply-id> -e <env>` | Generate a rollback plan |
 | `schemabot rollback-confirm -e <env>` | Execute a rollback |
 
@@ -560,9 +560,9 @@ That command wasn't recognized. Available commands:
 | `schemabot apply -e <env>` | Plan, lock, and confirm deployment |
 | `schemabot apply-confirm -e <env>` | Execute a locked plan |
 | `schemabot unlock` | Release lock and discard plan |
-| `schemabot stop <apply-id>` | Stop an in-progress deployment |
-| `schemabot start <apply-id>` | Resume a stopped deployment |
-| `schemabot cutover <apply-id>` | Complete a deferred cutover |
+| `schemabot stop <apply-id> -e <env>` | Stop an in-progress deployment |
+| `schemabot start <apply-id> -e <env>` | Resume a stopped deployment |
+| `schemabot cutover <apply-id> -e <env>` | Complete a deferred cutover |
 | `schemabot rollback <apply-id> -e <env>` | Generate a rollback plan |
 | `schemabot rollback-confirm -e <env>` | Execute a rollback |
 
@@ -750,9 +750,9 @@ That command wasn't recognized. Available commands:
 | `schemabot apply -e <env>` | Plan, lock, and confirm deployment |
 | `schemabot apply-confirm -e <env>` | Execute a locked plan |
 | `schemabot unlock` | Release lock and discard plan |
-| `schemabot stop <apply-id>` | Stop an in-progress deployment |
-| `schemabot start <apply-id>` | Resume a stopped deployment |
-| `schemabot cutover <apply-id>` | Complete a deferred cutover |
+| `schemabot stop <apply-id> -e <env>` | Stop an in-progress deployment |
+| `schemabot start <apply-id> -e <env>` | Resume a stopped deployment |
+| `schemabot cutover <apply-id> -e <env>` | Complete a deferred cutover |
 | `schemabot rollback <apply-id> -e <env>` | Generate a rollback plan |
 | `schemabot rollback-confirm -e <env>` | Execute a rollback |
 
@@ -2120,6 +2120,38 @@ ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
 ---
 
 Cutover in progress — typically completes within seconds.
+
+</details>
+
+<details>
+<summary><a name="start-command-accepted"></a><strong>Start Command Accepted</strong></summary>
+
+
+## Start Request Accepted
+
+**Apply**: `apply-a1b2c3d4e5f67890`
+**Environment**: `staging`
+**Requested by**: @alice
+
+Start request accepted. SchemaBot will resume this schema change; status remains available from the PR progress comment or CLI.
+
+**Tasks selected for start**: 1 started, 0 skipped.
+
+</details>
+
+<details>
+<summary><a name="start-command-already-pending"></a><strong>Start Command Already Pending</strong></summary>
+
+
+## Start Request Accepted
+
+**Apply**: `apply-a1b2c3d4e5f67890`
+**Environment**: `staging`
+**Requested by**: @alice
+
+Start was already requested. SchemaBot will keep the existing start request pending until the operator owner finishes it.
+
+**Tasks selected for start**: 1 started, 0 skipped.
 
 </details>
 
@@ -4312,6 +4344,40 @@ A configured SchemaBot admin/database operator should inspect SchemaBot authoriz
 `schemabot unlock` cannot run because database `payments` is not configured on this SchemaBot instance.
 
 Verify the database name, or run the command against the SchemaBot instance that manages this database.
+
+
+</details>
+
+<details>
+<summary><a name="start-command-accepted"></a><strong>Start Command Accepted</strong></summary>
+
+
+## Start Request Accepted
+
+**Apply**: `apply-a1b2c3d4e5f67890`
+**Environment**: `staging`
+**Requested by**: @alice
+
+Start request accepted. SchemaBot will resume this schema change; status remains available from the PR progress comment or CLI.
+
+**Tasks selected for start**: 1 started, 0 skipped.
+
+
+</details>
+
+<details>
+<summary><a name="start-command-already-pending"></a><strong>Start Command Already Pending</strong></summary>
+
+
+## Start Request Accepted
+
+**Apply**: `apply-a1b2c3d4e5f67890`
+**Environment**: `staging`
+**Requested by**: @alice
+
+Start was already requested. SchemaBot will keep the existing start request pending until the operator owner finishes it.
+
+**Tasks selected for start**: 1 started, 0 skipped.
 
 
 </details>

--- a/pkg/api/control_handlers.go
+++ b/pkg/api/control_handlers.go
@@ -512,7 +512,7 @@ type stopControlRequestMetadata struct {
 	SkippedCount int64 `json:"skipped_count,omitempty"`
 }
 
-const stopResponseStatusAlreadyRequested = "already_requested"
+const stopResponseStatusAlreadyRequested = apitypes.ControlStatusAlreadyRequested
 
 // handleStop handles POST /api/stop requests.
 // Records durable stop intent for the apply owner to process.
@@ -855,7 +855,7 @@ type startControlRequestMetadata struct {
 
 const (
 	startResponseStatusQueued           = "queued"
-	startResponseStatusAlreadyRequested = "already_requested"
+	startResponseStatusAlreadyRequested = apitypes.ControlStatusAlreadyRequested
 )
 
 // handleStart handles POST /api/start requests.
@@ -865,29 +865,46 @@ func (s *Service) handleStart(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
+	resp, httpStatus, err := s.executeStartForApply(r.Context(), client, apply, applyID, req.Caller)
+	if err != nil {
+		s.writeControlError(w, "start", apply, err)
+		return
+	}
+	s.writeJSON(w, httpStatus, resp)
+}
 
+// ExecuteStart records durable start intent for a stopped apply. The operator
+// owner is responsible for resuming stopped work when immediate dispatch is not
+// possible.
+func (s *Service) ExecuteStart(ctx context.Context, req apitypes.ControlRequest) (*apitypes.StartResponse, error) {
+	client, apply, ternApplyID, err := s.controlTarget(ctx, "start", req.ApplyID, req.Environment)
+	if err != nil {
+		return nil, err
+	}
+	resp, _, err := s.executeStartForApply(ctx, client, apply, ternApplyID, req.Caller)
+	return resp, err
+}
+
+func (s *Service) executeStartForApply(ctx context.Context, client tern.Client, apply *storage.Apply, ternApplyID, caller string) (*apitypes.StartResponse, int, error) {
 	if err := validateStartRequestState(apply); err != nil {
-		metrics.RecordControlOperation(r.Context(), "start", apply.Database, apply.Deployment, apply.Environment, "rejected")
-		s.writeControlError(w, "start", apply, err)
-		return
+		metrics.RecordControlOperation(ctx, "start", apply.Database, apply.Deployment, apply.Environment, "rejected")
+		return nil, http.StatusOK, err
 	}
-	if err := s.completeResolvedStopBeforeStart(r.Context(), client, apply, req.Caller); err != nil {
+	if err := s.completeResolvedStopBeforeStart(ctx, client, apply, caller); err != nil {
 		status := "error"
 		if controlOperationHTTPStatus(err) < http.StatusInternalServerError {
 			status = "rejected"
 		}
-		metrics.RecordControlOperation(r.Context(), "start", apply.Database, apply.Deployment, apply.Environment, status)
-		s.writeControlError(w, "start", apply, err)
-		return
+		metrics.RecordControlOperation(ctx, "start", apply.Database, apply.Deployment, apply.Environment, status)
+		return nil, http.StatusOK, err
 	}
-	if err := s.rejectControlIfStopPending(r.Context(), "start", apply); err != nil {
+	if err := s.rejectControlIfStopPending(ctx, "start", apply); err != nil {
 		status := "error"
 		if controlOperationHTTPStatus(err) < http.StatusInternalServerError {
 			status = "rejected"
 		}
-		metrics.RecordControlOperation(r.Context(), "start", apply.Database, apply.Deployment, apply.Environment, status)
-		s.writeControlError(w, "start", apply, err)
-		return
+		metrics.RecordControlOperation(ctx, "start", apply.Database, apply.Deployment, apply.Environment, status)
+		return nil, http.StatusOK, err
 	}
 
 	var resp *ternv1.StartResponse
@@ -896,21 +913,20 @@ func (s *Service) handleStart(w http.ResponseWriter, r *http.Request) {
 	queuedForOperator := false
 	switch {
 	case state.IsState(apply.State, state.Apply.WaitingForDeploy):
-		if err := s.rejectControlIfStopPending(r.Context(), "start dispatch", apply); err != nil {
+		if err := s.rejectControlIfStopPending(ctx, "start dispatch", apply); err != nil {
 			status := "error"
 			if controlOperationHTTPStatus(err) < http.StatusInternalServerError {
 				status = "rejected"
 			}
-			metrics.RecordControlOperation(r.Context(), "start", apply.Database, apply.Deployment, apply.Environment, status)
-			s.writeControlError(w, "start", apply, err)
-			return
+			metrics.RecordControlOperation(ctx, "start", apply.Database, apply.Deployment, apply.Environment, status)
+			return nil, http.StatusOK, err
 		}
-		resp, err = client.Start(r.Context(), &ternv1.StartRequest{
-			ApplyId:     applyID,
+		resp, err = client.Start(ctx, &ternv1.StartRequest{
+			ApplyId:     ternApplyID,
 			Environment: apply.Environment,
 		})
 	case state.IsState(apply.State, state.Apply.Pending):
-		resp, responseStatus, err = s.startResponseForPendingStartRequest(r.Context(), apply)
+		resp, responseStatus, err = s.startResponseForPendingStartRequest(ctx, apply)
 		queuedForOperator = err == nil && resp.Accepted
 	case storedApplyMayHaveStoppedTasksForStart(apply.State):
 		// A queued or operator-claimed start can leave the durable request
@@ -918,12 +934,12 @@ func (s *Service) handleStart(w http.ResponseWriter, r *http.Request) {
 		// either state as idempotent duplicates instead of revalidating remote
 		// state or recording another request.
 		var foundPendingStart bool
-		resp, responseStatus, foundPendingStart, err = s.pendingStartResponseIfPresent(r.Context(), apply)
+		resp, responseStatus, foundPendingStart, err = s.pendingStartResponseIfPresent(ctx, apply)
 		queuedForOperator = err == nil && foundPendingStart && resp.Accepted
 		if err == nil && !foundPendingStart && client.IsRemote() && apply.ExternalID != "" {
-			resp, responseStatus, err = s.queueRemoteStoppedApplyForOperator(r.Context(), client, apply, req.Caller)
+			resp, responseStatus, err = s.queueRemoteStoppedApplyForOperator(ctx, client, apply, caller)
 		} else if err == nil && !foundPendingStart {
-			resp, responseStatus, err = s.queueStoppedApplyForOperator(r.Context(), apply, req.Caller)
+			resp, responseStatus, err = s.queueStoppedApplyForOperator(ctx, apply, caller)
 		}
 		queuedForOperator = queuedForOperator || (err == nil && resp.Accepted)
 	default:
@@ -934,14 +950,13 @@ func (s *Service) handleStart(w http.ResponseWriter, r *http.Request) {
 		if controlOperationHTTPStatus(err) < http.StatusInternalServerError {
 			status = "rejected"
 		}
-		metrics.RecordControlOperation(r.Context(), "start", apply.Database, apply.Deployment, apply.Environment, status)
-		s.writeControlError(w, "start", apply, err)
-		return
+		metrics.RecordControlOperation(ctx, "start", apply.Database, apply.Deployment, apply.Environment, status)
+		return nil, http.StatusOK, err
 	}
 
-	metrics.RecordControlOperation(r.Context(), "start", apply.Database, apply.Deployment, apply.Environment, controlStatus(resp.Accepted))
+	metrics.RecordControlOperation(ctx, "start", apply.Database, apply.Deployment, apply.Environment, controlStatus(resp.Accepted))
 	if resp.Accepted {
-		s.logControlOperation(r, apply.ApplyIdentifier, req.Caller, storage.LogEventStartRequested, "Start requested by user")
+		s.logControlOperationForApply(ctx, apply, caller, storage.LogEventStartRequested, "Start requested by user")
 		if queuedForOperator {
 			s.wakeOperator(apply.ApplyIdentifier, apply.Database, apply.Environment)
 		}
@@ -959,7 +974,7 @@ func (s *Service) handleStart(w http.ResponseWriter, r *http.Request) {
 	if responseStatus == startResponseStatusAlreadyRequested {
 		httpStatus = http.StatusAccepted
 	}
-	s.writeJSON(w, httpStatus, httpResp)
+	return httpResp, httpStatus, nil
 }
 
 func (s *Service) completeResolvedStopBeforeStart(ctx context.Context, client tern.Client, apply *storage.Apply, caller string) error {

--- a/pkg/apitypes/apitypes.go
+++ b/pkg/apitypes/apitypes.go
@@ -253,7 +253,10 @@ type ControlResponse struct {
 	Status       string `json:"status,omitempty"`
 }
 
-const ControlStatusAlreadyInProgress = "already_in_progress"
+const (
+	ControlStatusAlreadyInProgress = "already_in_progress"
+	ControlStatusAlreadyRequested  = "already_requested"
+)
 
 // StopResponse is the HTTP response for POST /api/stop.
 type StopResponse struct {

--- a/pkg/cmd/commands/preview.go
+++ b/pkg/cmd/commands/preview.go
@@ -98,6 +98,8 @@ func (cmd *PreviewCmd) Run(g *Globals) error {
 		templates.PreviewCommentApplyNoLock, templates.PreviewCommentApplyAllType,
 		templates.PreviewCommentChecksGateNotPassing, templates.PreviewCommentChecksGateInProgress,
 		templates.PreviewCommentActorNotAuthorized, templates.PreviewCommentActorAuthUnavailable,
+		templates.PreviewCommentDatabaseNotConfigured,
+		templates.PreviewCommentStartAccepted, templates.PreviewCommentStartPending,
 		templates.PreviewCommentCutoverAccepted, templates.PreviewCommentCutoverActive:
 		templates.PreviewCLIOutput(previewType)
 	// Paired aggregate types (PR + CLI subsections)
@@ -263,6 +265,9 @@ Apply Command Comments (GitHub PR apply commands):
   comment_apply_no_lock         No lock found (need apply first)
   comment_actor_not_authorized  Actor authorization denied
   comment_actor_auth_unavailable Actor authorization fail-closed error
+  comment_database_not_configured Actor authorization database missing from this instance
+  comment_start_accepted        Start request accepted
+  comment_start_pending         Start already pending
   comment_cutover_accepted      Cutover request accepted
   comment_cutover_active        Cutover already in progress
   comment_apply_all             Show all apply command previews

--- a/pkg/cmd/internal/templates/preview.go
+++ b/pkg/cmd/internal/templates/preview.go
@@ -163,6 +163,8 @@ const (
 	PreviewCommentActorNotAuthorized    PreviewType = "comment_actor_not_authorized"         // Actor authorization: user is not allowed
 	PreviewCommentActorAuthUnavailable  PreviewType = "comment_actor_auth_unavailable"       // Actor authorization: fail-closed error
 	PreviewCommentDatabaseNotConfigured PreviewType = "comment_database_not_configured"      // Actor authorization: database not configured on this instance
+	PreviewCommentStartAccepted         PreviewType = "comment_start_accepted"               // Start command accepted
+	PreviewCommentStartPending          PreviewType = "comment_start_pending"                // Start command when start is already pending
 	PreviewCommentCutoverAccepted       PreviewType = "comment_cutover_accepted"             // Cutover command accepted
 	PreviewCommentCutoverActive         PreviewType = "comment_cutover_active"               // Cutover command when cutover is already in progress
 	PreviewCommentApplyAllType          PreviewType = "comment_apply_all"                    // Show all apply comment previews

--- a/pkg/cmd/internal/templates/preview_comment.go
+++ b/pkg/cmd/internal/templates/preview_comment.go
@@ -105,6 +105,8 @@ func previewApplyCommandAllOutput() {
 		{"ACTOR AUTHORIZATION: NOT AUTHORIZED", func() { fmt.Print(webhooktemplates.PreviewCommentPRCommandNotAuthorized()) }},
 		{"ACTOR AUTHORIZATION: UNAVAILABLE", func() { fmt.Print(webhooktemplates.PreviewCommentPRCommandAuthorizationUnavailable()) }},
 		{"ACTOR AUTHORIZATION: DATABASE NOT CONFIGURED", func() { fmt.Print(webhooktemplates.PreviewCommentPRCommandDatabaseNotConfigured()) }},
+		{"START COMMAND ACCEPTED", func() { fmt.Print(webhooktemplates.PreviewCommentStartCommandAccepted()) }},
+		{"START COMMAND ALREADY PENDING", func() { fmt.Print(webhooktemplates.PreviewCommentStartCommandAlreadyRequested()) }},
 		{"CUTOVER COMMAND ACCEPTED", func() { fmt.Print(webhooktemplates.PreviewCommentCutoverCommandAccepted()) }},
 		{"CUTOVER COMMAND ALREADY IN PROGRESS", func() { fmt.Print(webhooktemplates.PreviewCommentCutoverCommandAlreadyInProgress()) }},
 		{"CHECKS GATE: NOT PASSING", func() {
@@ -209,6 +211,8 @@ func previewCommentApplyFlowAllOutput() {
 		// Cutover states
 		{"WAITING FOR CUTOVER", func() { fmt.Print(webhooktemplates.PreviewCommentApplyWaitingForCutover()) }},
 		{"CUTTING OVER", func() { fmt.Print(webhooktemplates.PreviewCommentApplyCuttingOver()) }},
+		{"START COMMAND ACCEPTED", func() { fmt.Print(webhooktemplates.PreviewCommentStartCommandAccepted()) }},
+		{"START COMMAND ALREADY PENDING", func() { fmt.Print(webhooktemplates.PreviewCommentStartCommandAlreadyRequested()) }},
 		{"CUTOVER COMMAND ACCEPTED", func() { fmt.Print(webhooktemplates.PreviewCommentCutoverCommandAccepted()) }},
 		{"CUTOVER COMMAND ALREADY IN PROGRESS", func() { fmt.Print(webhooktemplates.PreviewCommentCutoverCommandAlreadyInProgress()) }},
 		// Summaries

--- a/pkg/cmd/internal/templates/preview_dispatch.go
+++ b/pkg/cmd/internal/templates/preview_dispatch.go
@@ -218,6 +218,10 @@ func PreviewCLIOutput(previewType PreviewType) {
 		fmt.Print(webhooktemplates.PreviewCommentPRCommandAuthorizationUnavailable())
 	case PreviewCommentDatabaseNotConfigured:
 		fmt.Print(webhooktemplates.PreviewCommentPRCommandDatabaseNotConfigured())
+	case PreviewCommentStartAccepted:
+		fmt.Print(webhooktemplates.PreviewCommentStartCommandAccepted())
+	case PreviewCommentStartPending:
+		fmt.Print(webhooktemplates.PreviewCommentStartCommandAlreadyRequested())
 	case PreviewCommentCutoverAccepted:
 		fmt.Print(webhooktemplates.PreviewCommentCutoverCommandAccepted())
 	case PreviewCommentCutoverActive:

--- a/pkg/webhook/action/action.go
+++ b/pkg/webhook/action/action.go
@@ -8,6 +8,7 @@ const (
 	ApplyConfirm    = "apply-confirm"
 	Unlock          = "unlock"
 	Stop            = "stop"
+	Start           = "start"
 	Cutover         = "cutover"
 	Revert          = "revert"
 	SkipRevert      = "skip-revert"

--- a/pkg/webhook/actor_authorization_test.go
+++ b/pkg/webhook/actor_authorization_test.go
@@ -334,9 +334,10 @@ func TestHandleApplyCommandBlocksUnauthorizedActorBeforePlanning(t *testing.T) {
 	assert.Contains(t, body, "@mona is not authorized")
 }
 
-// Stop is a mutating PR comment command, so the full webhook path uses the same
-// configured admin/operator authorization as apply before recording durable stop intent.
-func TestWebhookStopCommandBlocksUnauthorizedActor(t *testing.T) {
+// Apply-scoped control commands are mutating PR comments, so the full webhook
+// path uses the same configured admin/operator authorization as apply before
+// recording durable operator intent.
+func TestWebhookApplyScopedControlCommandBlocksUnauthorizedActor(t *testing.T) {
 	client, mux := setupGitHubServer(t)
 	comments := make(chan string, 2)
 	reactions := make(chan string, 2)
@@ -371,27 +372,31 @@ func TestWebhookStopCommandBlocksUnauthorizedActor(t *testing.T) {
 		logger:    testLogger(),
 	}
 
-	req := buildWebhookRequest(t, webhookPayloadOpts{
-		comment:   "schemabot stop " + apply.ApplyIdentifier + " -e staging",
-		userLogin: "mona",
-		isPR:      true,
-	}, nil)
-	rr := httptest.NewRecorder()
-	h.ServeHTTP(rr, req)
-	require.Equal(t, http.StatusOK, rr.Code)
-	assert.Contains(t, rr.Body.String(), "stop started")
+	for _, command := range []string{action.Stop, action.Start} {
+		t.Run(command, func(t *testing.T) {
+			req := buildWebhookRequest(t, webhookPayloadOpts{
+				comment:   "schemabot " + command + " " + apply.ApplyIdentifier + " -e staging",
+				userLogin: "mona",
+				isPR:      true,
+			}, nil)
+			rr := httptest.NewRecorder()
+			h.ServeHTTP(rr, req)
+			require.Equal(t, http.StatusOK, rr.Code)
+			assert.Contains(t, rr.Body.String(), command+" started")
 
-	select {
-	case reaction := <-reactions:
-		assert.Equal(t, "eyes", reaction)
-	case <-time.After(2 * time.Second):
-		require.FailNow(t, "timed out waiting for stop acknowledgement reaction")
+			select {
+			case reaction := <-reactions:
+				assert.Equal(t, "eyes", reaction)
+			case <-time.After(2 * time.Second):
+				require.FailNow(t, "timed out waiting for "+command+" acknowledgement reaction")
+			}
+
+			body := requireComment(t, comments, "unauthorized "+command+" comment")
+			assert.Contains(t, body, "SchemaBot Command Not Authorized")
+			assert.Contains(t, body, "@mona is not authorized")
+			assert.Contains(t, body, "`schemabot "+command+"`")
+		})
 	}
-
-	body := requireComment(t, comments, "unauthorized stop comment")
-	assert.Contains(t, body, "SchemaBot Command Not Authorized")
-	assert.Contains(t, body, "@mona is not authorized")
-	assert.Contains(t, body, "`schemabot stop`")
 }
 
 // TestHandleRollbackCommandBlocksUnauthorizedActor exercises the PR rollback

--- a/pkg/webhook/commands.go
+++ b/pkg/webhook/commands.go
@@ -65,6 +65,7 @@ var commandSpecs = []CommandSpec{
 	{Name: action.Unlock, SupportsDB: true, SupportsForce: true},
 	{Name: action.FixLint, SupportsDB: true},
 	{Name: action.Stop, RequiresEnv: true, HasApplyID: true},
+	{Name: action.Start, RequiresEnv: true, HasApplyID: true},
 	{Name: action.Revert, RequiresEnv: true},
 	{Name: action.SkipRevert, RequiresEnv: true},
 	{Name: action.Cutover, RequiresEnv: true, HasApplyID: true},

--- a/pkg/webhook/commands_test.go
+++ b/pkg/webhook/commands_test.go
@@ -19,6 +19,7 @@ func TestCommandSpecs_CoverEveryDispatcherAction(t *testing.T) {
 		action.Unlock,
 		action.FixLint,
 		action.Stop,
+		action.Start,
 		action.Revert,
 		action.SkipRevert,
 		action.Cutover,
@@ -57,6 +58,7 @@ func TestCommandSpecs_FlagsRespected(t *testing.T) {
 		{name: action.Unlock, supportsDB: true, supportsForce: true},
 		{name: action.FixLint, supportsDB: true},
 		{name: action.Stop, requiresEnv: true, hasApplyID: true},
+		{name: action.Start, requiresEnv: true, hasApplyID: true},
 		{name: action.Revert, requiresEnv: true},
 		{name: action.SkipRevert, requiresEnv: true},
 		{name: action.Cutover, requiresEnv: true, hasApplyID: true},
@@ -298,6 +300,17 @@ func TestParseCommand(t *testing.T) {
 			body: "schemabot stop apply_abc123 -e production",
 			expected: CommandResult{
 				Action:      "stop",
+				ApplyID:     "apply_abc123",
+				Environment: "production",
+				Found:       true,
+				IsMention:   true,
+			},
+		},
+		{
+			name: "start",
+			body: "schemabot start apply_abc123 -e production",
+			expected: CommandResult{
+				Action:      "start",
 				ApplyID:     "apply_abc123",
 				Environment: "production",
 				Found:       true,

--- a/pkg/webhook/control.go
+++ b/pkg/webhook/control.go
@@ -1,79 +1,82 @@
 package webhook
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/block/schemabot/pkg/apitypes"
+	"github.com/block/schemabot/pkg/storage"
 	"github.com/block/schemabot/pkg/webhook/action"
 	"github.com/block/schemabot/pkg/webhook/templates"
 )
 
-// handleStopCommand handles the "schemabot stop <apply-id> -e <env>" PR
-// comment command by recording durable stop intent for the operator owner.
-func (h *Handler) handleStopCommand(repo string, pr int, installationID int64, requestedBy string, result CommandResult) {
-	ctx, cancel := h.commandContext(commandTimeout)
-	defer cancel()
-
+func (h *Handler) loadApplyForPRControl(ctx context.Context, repo string, pr int, installationID int64, requestedBy string, result CommandResult, command string) (*storage.Apply, bool) {
 	if result.ApplyID == "" {
-		h.postComment(repo, pr, installationID, templates.RenderControlMissingApplyID(action.Stop))
-		return
+		h.postComment(repo, pr, installationID, templates.RenderControlMissingApplyID(command))
+		return nil, false
 	}
 	if h.service == nil {
-		h.logger.Error("service not configured for stop PR command",
+		h.logger.Error("service not configured for PR control command",
+			"command", command,
 			"repo", repo,
 			"pr", pr,
 			"apply_id", result.ApplyID,
 			"environment", result.Environment,
 			"requested_by", requestedBy)
-		h.postCommandError(repo, pr, installationID, action.Stop, result.Environment, requestedBy, "SchemaBot service is not configured for stop commands")
-		return
+		h.postCommandError(repo, pr, installationID, command, result.Environment, requestedBy, "SchemaBot service is not configured for "+command+" commands")
+		return nil, false
 	}
 	store := h.service.Storage()
 	if store == nil {
-		h.logger.Error("storage not configured for stop PR command",
+		h.logger.Error("storage not configured for PR control command",
+			"command", command,
 			"repo", repo,
 			"pr", pr,
 			"apply_id", result.ApplyID,
 			"environment", result.Environment,
 			"requested_by", requestedBy)
-		h.postCommandError(repo, pr, installationID, action.Stop, result.Environment, requestedBy, "SchemaBot storage is not configured for stop commands")
-		return
+		h.postCommandError(repo, pr, installationID, command, result.Environment, requestedBy, "SchemaBot storage is not configured for "+command+" commands")
+		return nil, false
 	}
 	applyStore := store.Applies()
 	if applyStore == nil {
-		h.logger.Error("apply store not configured for stop PR command",
+		h.logger.Error("apply store not configured for PR control command",
+			"command", command,
 			"repo", repo,
 			"pr", pr,
 			"apply_id", result.ApplyID,
 			"environment", result.Environment,
 			"requested_by", requestedBy)
-		h.postCommandError(repo, pr, installationID, action.Stop, result.Environment, requestedBy, "SchemaBot apply storage is not configured for stop commands")
-		return
+		h.postCommandError(repo, pr, installationID, command, result.Environment, requestedBy, "SchemaBot apply storage is not configured for "+command+" commands")
+		return nil, false
 	}
 	apply, err := applyStore.GetByApplyIdentifier(ctx, result.ApplyID)
 	if err != nil {
-		h.logger.Error("failed to load apply for stop PR command",
+		h.logger.Error("failed to load apply for PR control command",
+			"command", command,
 			"repo", repo,
 			"pr", pr,
 			"apply_id", result.ApplyID,
 			"environment", result.Environment,
 			"requested_by", requestedBy,
 			"error", err)
-		h.postCommandError(repo, pr, installationID, action.Stop, result.Environment, requestedBy, "Failed to look up apply: "+err.Error())
-		return
+		h.postCommandError(repo, pr, installationID, command, result.Environment, requestedBy, "Failed to look up apply: "+err.Error())
+		return nil, false
 	}
 	if apply == nil {
-		h.logger.Warn("stop PR command rejected because apply was not found",
+		h.logger.Warn("PR control command rejected because apply was not found",
+			"command", command,
 			"repo", repo,
 			"pr", pr,
 			"apply_id", result.ApplyID,
 			"environment", result.Environment,
 			"requested_by", requestedBy)
-		h.postCommandError(repo, pr, installationID, action.Stop, result.Environment, requestedBy, "Apply not found: "+result.ApplyID)
-		return
+		h.postCommandError(repo, pr, installationID, command, result.Environment, requestedBy, "Apply not found: "+result.ApplyID)
+		return nil, false
 	}
 	if apply.Repository != repo || apply.PullRequest != pr {
-		h.logger.Warn("stop PR command rejected because apply belongs to another PR",
+		h.logger.Warn("PR control command rejected because apply belongs to another PR",
+			"command", command,
 			"repo", repo,
 			"pr", pr,
 			"apply_id", result.ApplyID,
@@ -81,19 +84,33 @@ func (h *Handler) handleStopCommand(repo string, pr int, installationID int64, r
 			"apply_pr", apply.PullRequest,
 			"environment", result.Environment,
 			"requested_by", requestedBy)
-		h.postCommandError(repo, pr, installationID, action.Stop, result.Environment, requestedBy, "Apply "+result.ApplyID+" is not associated with this PR")
-		return
+		h.postCommandError(repo, pr, installationID, command, result.Environment, requestedBy, "Apply "+result.ApplyID+" is not associated with this PR")
+		return nil, false
 	}
 	if apply.Environment != result.Environment {
-		h.logger.Warn("stop PR command rejected because environment does not match apply",
+		h.logger.Warn("PR control command rejected because environment does not match apply",
+			"command", command,
 			"repo", repo,
 			"pr", pr,
 			"apply_id", result.ApplyID,
 			"apply_environment", apply.Environment,
 			"requested_environment", result.Environment,
 			"requested_by", requestedBy)
-		h.postCommandError(repo, pr, installationID, action.Stop, result.Environment, requestedBy,
+		h.postCommandError(repo, pr, installationID, command, result.Environment, requestedBy,
 			fmt.Sprintf("Apply %s belongs to environment %q, not %q", result.ApplyID, apply.Environment, result.Environment))
+		return nil, false
+	}
+	return apply, true
+}
+
+// handleStopCommand handles the "schemabot stop <apply-id> -e <env>" PR
+// comment command by recording durable stop intent for the operator owner.
+func (h *Handler) handleStopCommand(repo string, pr int, installationID int64, requestedBy string, result CommandResult) {
+	ctx, cancel := h.commandContext(commandTimeout)
+	defer cancel()
+
+	apply, ok := h.loadApplyForPRControl(ctx, repo, pr, installationID, requestedBy, result, action.Stop)
+	if !ok {
 		return
 	}
 	client, blocked := h.actorAuthorizationClient(repo, pr, installationID, requestedBy, apply.Database, result.Environment, action.Stop)
@@ -166,92 +183,94 @@ func (h *Handler) handleStopCommand(repo string, pr int, installationID int64, r
 	}))
 }
 
-// handleCutoverCommand handles the "schemabot cutover <apply-id> -e <env>" PR
-// comment command by recording durable cutover intent for the operator owner.
-func (h *Handler) handleCutoverCommand(repo string, pr int, installationID int64, requestedBy string, result CommandResult) {
+// handleStartCommand handles the "schemabot start <apply-id> -e <env>" PR
+// comment command by recording durable start intent for the operator owner.
+func (h *Handler) handleStartCommand(repo string, pr int, installationID int64, requestedBy string, result CommandResult) {
 	ctx, cancel := h.commandContext(commandTimeout)
 	defer cancel()
 
-	if result.ApplyID == "" {
-		h.postComment(repo, pr, installationID, templates.RenderControlMissingApplyID(action.Cutover))
+	apply, ok := h.loadApplyForPRControl(ctx, repo, pr, installationID, requestedBy, result, action.Start)
+	if !ok {
 		return
 	}
-	if h.service == nil {
-		h.logger.Error("service not configured for cutover PR command",
-			"repo", repo,
-			"pr", pr,
-			"apply_id", result.ApplyID,
-			"environment", result.Environment,
-			"requested_by", requestedBy)
-		h.postCommandError(repo, pr, installationID, action.Cutover, result.Environment, requestedBy, "SchemaBot service is not configured for cutover commands")
+	client, blocked := h.actorAuthorizationClient(repo, pr, installationID, requestedBy, apply.Database, result.Environment, action.Start)
+	if blocked {
 		return
 	}
-	store := h.service.Storage()
-	if store == nil {
-		h.logger.Error("storage not configured for cutover PR command",
-			"repo", repo,
-			"pr", pr,
-			"apply_id", result.ApplyID,
-			"environment", result.Environment,
-			"requested_by", requestedBy)
-		h.postCommandError(repo, pr, installationID, action.Cutover, result.Environment, requestedBy, "SchemaBot storage is not configured for cutover commands")
+	if blocked := h.enforcePRCommandActorAuthorization(ctx, client, repo, pr, installationID, requestedBy, apply.Database, apply.DatabaseType, result.Environment, action.Start); blocked {
 		return
 	}
-	applyStore := store.Applies()
-	if applyStore == nil {
-		h.logger.Error("apply store not configured for cutover PR command",
-			"repo", repo,
-			"pr", pr,
-			"apply_id", result.ApplyID,
-			"environment", result.Environment,
-			"requested_by", requestedBy)
-		h.postCommandError(repo, pr, installationID, action.Cutover, result.Environment, requestedBy, "SchemaBot apply storage is not configured for cutover commands")
-		return
-	}
-	apply, err := applyStore.GetByApplyIdentifier(ctx, result.ApplyID)
+
+	caller := fmt.Sprintf("github:%s@%s#%d", requestedBy, repo, pr)
+	resp, err := h.service.ExecuteStart(ctx, apitypes.ControlRequest{
+		ApplyID:     result.ApplyID,
+		Environment: result.Environment,
+		Caller:      caller,
+	})
 	if err != nil {
-		h.logger.Error("failed to load apply for cutover PR command",
+		h.logger.Warn("start PR command rejected",
 			"repo", repo,
 			"pr", pr,
 			"apply_id", result.ApplyID,
 			"environment", result.Environment,
 			"requested_by", requestedBy,
 			"error", err)
-		h.postCommandError(repo, pr, installationID, action.Cutover, result.Environment, requestedBy, "Failed to look up apply: "+err.Error())
+		h.postCommandError(repo, pr, installationID, action.Start, result.Environment, requestedBy, err.Error())
 		return
 	}
-	if apply == nil {
-		h.logger.Warn("cutover PR command rejected because apply was not found",
+	if resp == nil {
+		h.logger.Error("start PR command returned no response",
 			"repo", repo,
 			"pr", pr,
 			"apply_id", result.ApplyID,
 			"environment", result.Environment,
 			"requested_by", requestedBy)
-		h.postCommandError(repo, pr, installationID, action.Cutover, result.Environment, requestedBy, "Apply not found: "+result.ApplyID)
+		h.postCommandError(repo, pr, installationID, action.Start, result.Environment, requestedBy, "SchemaBot accepted the start command but returned no response")
 		return
 	}
-	if apply.Repository != repo || apply.PullRequest != pr {
-		h.logger.Warn("cutover PR command rejected because apply belongs to another PR",
+	if !resp.Accepted {
+		detail := resp.ErrorMessage
+		if detail == "" {
+			detail = "Start was not accepted"
+		}
+		h.logger.Warn("start PR command was not accepted",
 			"repo", repo,
 			"pr", pr,
 			"apply_id", result.ApplyID,
-			"apply_repo", apply.Repository,
-			"apply_pr", apply.PullRequest,
 			"environment", result.Environment,
-			"requested_by", requestedBy)
-		h.postCommandError(repo, pr, installationID, action.Cutover, result.Environment, requestedBy, "Apply "+result.ApplyID+" is not associated with this PR")
+			"requested_by", requestedBy,
+			"error_message", resp.ErrorMessage)
+		h.postCommandError(repo, pr, installationID, action.Start, result.Environment, requestedBy, detail)
 		return
 	}
-	if apply.Environment != result.Environment {
-		h.logger.Warn("cutover PR command rejected because environment does not match apply",
-			"repo", repo,
-			"pr", pr,
-			"apply_id", result.ApplyID,
-			"apply_environment", apply.Environment,
-			"requested_environment", result.Environment,
-			"requested_by", requestedBy)
-		h.postCommandError(repo, pr, installationID, action.Cutover, result.Environment, requestedBy,
-			fmt.Sprintf("Apply %s belongs to environment %q, not %q", result.ApplyID, apply.Environment, result.Environment))
+
+	h.logger.Info("start PR command accepted",
+		"repo", repo,
+		"pr", pr,
+		"apply_id", result.ApplyID,
+		"environment", result.Environment,
+		"requested_by", requestedBy,
+		"status", resp.Status,
+		"started_count", resp.StartedCount,
+		"skipped_count", resp.SkippedCount)
+	h.postComment(repo, pr, installationID, templates.RenderStartCommandAccepted(templates.StartCommandAcceptedData{
+		ApplyID:      result.ApplyID,
+		Environment:  result.Environment,
+		RequestedBy:  requestedBy,
+		Status:       resp.Status,
+		StartedCount: resp.StartedCount,
+		SkippedCount: resp.SkippedCount,
+	}))
+}
+
+// handleCutoverCommand handles the "schemabot cutover <apply-id> -e <env>" PR
+// comment command by recording durable cutover intent for the operator owner.
+func (h *Handler) handleCutoverCommand(repo string, pr int, installationID int64, requestedBy string, result CommandResult) {
+	ctx, cancel := h.commandContext(commandTimeout)
+	defer cancel()
+
+	apply, ok := h.loadApplyForPRControl(ctx, repo, pr, installationID, requestedBy, result, action.Cutover)
+	if !ok {
 		return
 	}
 	client, blocked := h.actorAuthorizationClient(repo, pr, installationID, requestedBy, apply.Database, result.Environment, action.Cutover)

--- a/pkg/webhook/control_e2e_test.go
+++ b/pkg/webhook/control_e2e_test.go
@@ -231,6 +231,161 @@ func TestE2EStopCommandStopsDeferredCutoverLocalApply(t *testing.T) {
 	assertReactionEventually(t, reactions)
 }
 
+// TestE2EStartCommandRecordsDurableRequest verifies that a PR comment start
+// command records durable operator intent for a stopped apply without directly
+// claiming execution from the webhook process.
+func TestE2EStartCommandRecordsDurableRequest(t *testing.T) {
+	ctx := t.Context()
+	schemabotDB, err := sql.Open("mysql", e2eSchemabotDSN)
+	require.NoError(t, err)
+	require.NoError(t, schemabotDB.PingContext(ctx))
+
+	store := mysqlstore.New(schemabotDB)
+	applyIdentifier := "apply_bcdf2345"
+	database := "start_pr_comments_db"
+	cleanupStopCommandTestRows(t, schemabotDB, applyIdentifier, database)
+	t.Cleanup(func() {
+		cleanupStopCommandTestRows(t, schemabotDB, applyIdentifier, database)
+		utils.CloseAndLog(schemabotDB)
+	})
+
+	applyID := createStopCommandApply(t, store, applyIdentifier, database)
+	storedApply, err := store.Applies().GetByApplyIdentifier(ctx, applyIdentifier)
+	require.NoError(t, err)
+	require.NotNil(t, storedApply)
+	storedApply.State = state.Apply.Stopped
+	storedApply.UpdatedAt = time.Now().UTC()
+	require.NoError(t, store.Applies().Update(ctx, storedApply))
+	storedTasks, err := store.Tasks().GetByApplyID(ctx, applyID)
+	require.NoError(t, err)
+	require.Len(t, storedTasks, 1)
+	storedTasks[0].State = state.Task.Stopped
+	storedTasks[0].UpdatedAt = time.Now().UTC()
+	require.NoError(t, store.Tasks().Update(ctx, storedTasks[0]))
+
+	client, mux := setupGitHubServer(t)
+	comments := make(chan string, 10)
+	reactions := make(chan string, 10)
+	mux.HandleFunc("POST /repos/octocat/hello-world/issues/1/comments", func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Body string `json:"body"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		comments <- body.Body
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": 99})
+	})
+	mux.HandleFunc("POST /repos/octocat/hello-world/issues/comments/42/reactions", func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Content string `json:"content"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		reactions <- body.Content
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": 1})
+	})
+
+	service := apiServiceForStopCommandTest(t, store, database)
+	service.RegisterTernClient(database, "staging", &stopCommandTernClient{})
+	h := &Handler{
+		service:   service,
+		ghClients: ghclient.NewSingleClientSet(defaultAppName, &fakeClientFactory{client: ghclient.NewInstallationClient(client, testLogger())}),
+		logger:    testLogger(),
+	}
+
+	postStartCommand(t, h, applyIdentifier, "alice")
+	firstComment := readComment(t, comments)
+	assert.Contains(t, firstComment, "Start Request Accepted")
+	assert.Contains(t, firstComment, "`"+applyIdentifier+"`")
+	assert.Contains(t, firstComment, "@alice")
+
+	controlReq, err := store.ControlRequests().GetPending(ctx, applyID, storage.ControlOperationStart)
+	require.NoError(t, err)
+	require.NotNil(t, controlReq)
+	assert.Equal(t, "github:alice@octocat/hello-world#1", controlReq.RequestedBy)
+	assert.Equal(t, storage.ControlRequestPending, controlReq.Status)
+
+	postStartCommand(t, h, applyIdentifier, "bob")
+	secondComment := readComment(t, comments)
+	assert.Contains(t, secondComment, "Start was already requested")
+	assert.Contains(t, secondComment, "@bob")
+
+	logs, err := store.ApplyLogs().List(ctx, storage.ApplyLogFilter{ApplyID: applyID, Limit: 20})
+	require.NoError(t, err)
+	assert.True(t, applyLogContains(logs, "Start requested by user (caller: github:alice@octocat/hello-world#1)"))
+	assert.True(t, applyLogContains(logs, "Start requested by user (caller: github:bob@octocat/hello-world#1)"))
+
+	assertReactionEventually(t, reactions)
+	assertReactionEventually(t, reactions)
+}
+
+// TestE2EStartCommandRejectsCompletedApply verifies that a PR comment start
+// command surfaces an actionable error when the apply is already terminal and
+// does not record a durable start request.
+func TestE2EStartCommandRejectsCompletedApply(t *testing.T) {
+	ctx := t.Context()
+	schemabotDB, err := sql.Open("mysql", e2eSchemabotDSN)
+	require.NoError(t, err)
+	require.NoError(t, schemabotDB.PingContext(ctx))
+
+	store := mysqlstore.New(schemabotDB)
+	applyIdentifier := "apply_cfab3456"
+	database := "start_pr_comments_completed_db"
+	cleanupStopCommandTestRows(t, schemabotDB, applyIdentifier, database)
+	t.Cleanup(func() {
+		cleanupStopCommandTestRows(t, schemabotDB, applyIdentifier, database)
+		utils.CloseAndLog(schemabotDB)
+	})
+
+	applyID := createStopCommandApply(t, store, applyIdentifier, database)
+	storedApply, err := store.Applies().GetByApplyIdentifier(ctx, applyIdentifier)
+	require.NoError(t, err)
+	require.NotNil(t, storedApply)
+	storedApply.State = state.Apply.Completed
+	storedApply.UpdatedAt = time.Now().UTC()
+	require.NoError(t, store.Applies().Update(ctx, storedApply))
+
+	client, mux := setupGitHubServer(t)
+	comments := make(chan string, 10)
+	reactions := make(chan string, 10)
+	mux.HandleFunc("POST /repos/octocat/hello-world/issues/1/comments", func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Body string `json:"body"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		comments <- body.Body
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": 99})
+	})
+	mux.HandleFunc("POST /repos/octocat/hello-world/issues/comments/42/reactions", func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Content string `json:"content"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		reactions <- body.Content
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": 1})
+	})
+
+	service := apiServiceForStopCommandTest(t, store, database)
+	service.RegisterTernClient(database, "staging", &stopCommandTernClient{})
+	h := &Handler{
+		service:   service,
+		ghClients: ghclient.NewSingleClientSet(defaultAppName, &fakeClientFactory{client: ghclient.NewInstallationClient(client, testLogger())}),
+		logger:    testLogger(),
+	}
+
+	postStartCommand(t, h, applyIdentifier, "alice")
+	comment := readComment(t, comments)
+	assert.Contains(t, comment, "Start Failed")
+	assert.Contains(t, comment, "already completed and cannot be started")
+
+	pendingStart, err := store.ControlRequests().GetPending(ctx, applyID, storage.ControlOperationStart)
+	require.NoError(t, err)
+	assert.Nil(t, pendingStart)
+	assertReactionEventually(t, reactions)
+}
+
 // TestE2ECutoverCommandRecordsDurableRequest verifies that a PR comment
 // cutover command records durable operator intent for the exact apply and
 // environment, then leaves the operator owner to perform the data-plane action.
@@ -478,6 +633,19 @@ func postStopCommand(t *testing.T, h *Handler, applyIdentifier, user string) {
 	h.ServeHTTP(rr, req)
 	require.Equal(t, http.StatusOK, rr.Code)
 	assert.Contains(t, rr.Body.String(), "stop started")
+}
+
+func postStartCommand(t *testing.T, h *Handler, applyIdentifier, user string) {
+	t.Helper()
+	req := buildWebhookRequest(t, webhookPayloadOpts{
+		comment:   "schemabot start " + applyIdentifier + " -e staging",
+		userLogin: user,
+		isPR:      true,
+	}, nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), "start started")
 }
 
 func postCutoverCommand(t *testing.T, h *Handler, applyIdentifier, user string) {

--- a/pkg/webhook/handler_test.go
+++ b/pkg/webhook/handler_test.go
@@ -409,6 +409,7 @@ func TestWebhookControlCommandMissingApplyID(t *testing.T) {
 		action  string
 	}{
 		{name: "stop", comment: "schemabot stop -e staging", action: "stop"},
+		{name: "start", comment: "schemabot start -e staging", action: "start"},
 		{name: "cutover", comment: "schemabot cutover -e staging", action: "cutover"},
 	}
 
@@ -557,7 +558,7 @@ func TestWebhookEyesReaction(t *testing.T) {
 func TestWebhookPhase2CommandNotYetAvailable(t *testing.T) {
 	h, comments, _ := newTestHandler(t)
 
-	// Test remaining Phase 2 commands (apply, apply-confirm, unlock, stop, and cutover are now implemented)
+	// Test remaining Phase 2 commands (apply, apply-confirm, unlock, stop, start, and cutover are now implemented)
 	cmds := []struct {
 		comment string
 		action  string

--- a/pkg/webhook/issue_comment.go
+++ b/pkg/webhook/issue_comment.go
@@ -241,6 +241,11 @@ func (h *Handler) handleIssueComment(ctx context.Context, metricApp string, w ht
 			h.handleStopCommand(repo, pr, installationID, requestedBy, result)
 		})
 		h.writeJSON(w, http.StatusOK, map[string]string{"message": "stop started"})
+	case action.Start:
+		h.goSafe(repo, pr, installationID, func() {
+			h.handleStartCommand(repo, pr, installationID, requestedBy, result)
+		})
+		h.writeJSON(w, http.StatusOK, map[string]string{"message": "start started"})
 	case action.Cutover:
 		h.goSafe(repo, pr, installationID, func() {
 			h.handleCutoverCommand(repo, pr, installationID, requestedBy, result)

--- a/pkg/webhook/templates/help.go
+++ b/pkg/webhook/templates/help.go
@@ -9,9 +9,9 @@ func commandReference() string {
 | ` + "`schemabot apply -e <env>`" + ` | Plan, lock, and confirm deployment |
 | ` + "`schemabot apply-confirm -e <env>`" + ` | Execute a locked plan |
 | ` + "`schemabot unlock`" + ` | Release lock and discard plan |
-| ` + "`schemabot stop <apply-id>`" + ` | Stop an in-progress deployment |
-| ` + "`schemabot start <apply-id>`" + ` | Resume a stopped deployment |
-| ` + "`schemabot cutover <apply-id>`" + ` | Complete a deferred cutover |
+| ` + "`schemabot stop <apply-id> -e <env>`" + ` | Stop an in-progress deployment |
+| ` + "`schemabot start <apply-id> -e <env>`" + ` | Resume a stopped deployment |
+| ` + "`schemabot cutover <apply-id> -e <env>`" + ` | Complete a deferred cutover |
 | ` + "`schemabot rollback <apply-id> -e <env>`" + ` | Generate a rollback plan |
 | ` + "`schemabot rollback-confirm -e <env>`" + ` | Execute a rollback |
 

--- a/pkg/webhook/templates/issue_comment.go
+++ b/pkg/webhook/templates/issue_comment.go
@@ -39,6 +39,16 @@ type StopCommandAcceptedData struct {
 	SkippedCount int64
 }
 
+// StartCommandAcceptedData contains data for a PR comment start acknowledgement.
+type StartCommandAcceptedData struct {
+	ApplyID      string
+	Environment  string
+	RequestedBy  string
+	Status       string
+	StartedCount int64
+	SkippedCount int64
+}
+
 // CutoverCommandAcceptedData contains data for a PR comment cutover acknowledgement.
 type CutoverCommandAcceptedData struct {
 	ApplyID     string
@@ -59,7 +69,7 @@ func RenderControlMissingApplyID(action string) string {
 // comment stop command records durable stop intent.
 func RenderStopCommandAccepted(data StopCommandAcceptedData) string {
 	statusLine := "Stop request accepted. SchemaBot will stop this schema change; status remains available from the PR progress comment or CLI."
-	if data.Status == "already_requested" {
+	if data.Status == apitypes.ControlStatusAlreadyRequested {
 		statusLine = "Stop was already requested. SchemaBot will keep the existing stop request pending until the operator owner finishes it."
 	}
 
@@ -74,6 +84,52 @@ func RenderStopCommandAccepted(data StopCommandAcceptedData) string {
 		body += fmt.Sprintf("\n**Tasks selected for stop**: %d stopped, %d skipped.\n", data.StoppedCount, data.SkippedCount)
 	}
 	return body
+}
+
+// RenderStartCommandAccepted renders the acknowledgement posted when a PR
+// comment start command records durable start intent.
+func RenderStartCommandAccepted(data StartCommandAcceptedData) string {
+	statusLine := "Start request accepted. SchemaBot will resume this schema change; status remains available from the PR progress comment or CLI."
+	if data.Status == apitypes.ControlStatusAlreadyRequested {
+		statusLine = "Start was already requested. SchemaBot will keep the existing start request pending until the operator owner finishes it."
+	}
+
+	body := "## Start Request Accepted\n\n" +
+		fmt.Sprintf("**Apply**: `%s`\n", data.ApplyID) +
+		fmt.Sprintf("**Environment**: `%s`\n", data.Environment)
+	if data.RequestedBy != "" {
+		body += fmt.Sprintf("**Requested by**: @%s\n", data.RequestedBy)
+	}
+	body += "\n" + statusLine + "\n"
+	if data.StartedCount > 0 || data.SkippedCount > 0 {
+		body += fmt.Sprintf("\n**Tasks selected for start**: %d started, %d skipped.\n", data.StartedCount, data.SkippedCount)
+	}
+	return body
+}
+
+// PreviewCommentStartCommandAccepted renders a sample start command
+// acknowledgement comment.
+func PreviewCommentStartCommandAccepted() string {
+	return RenderStartCommandAccepted(StartCommandAcceptedData{
+		ApplyID:      "apply-a1b2c3d4e5f67890",
+		Environment:  "staging",
+		RequestedBy:  "alice",
+		StartedCount: 1,
+		SkippedCount: 0,
+	})
+}
+
+// PreviewCommentStartCommandAlreadyRequested renders a sample start
+// acknowledgement when start is already pending.
+func PreviewCommentStartCommandAlreadyRequested() string {
+	return RenderStartCommandAccepted(StartCommandAcceptedData{
+		ApplyID:      "apply-a1b2c3d4e5f67890",
+		Environment:  "staging",
+		RequestedBy:  "alice",
+		Status:       apitypes.ControlStatusAlreadyRequested,
+		StartedCount: 1,
+		SkippedCount: 0,
+	})
 }
 
 // RenderCutoverCommandAccepted renders the acknowledgement posted when a PR

--- a/pkg/webhook/templates/issue_comment_test.go
+++ b/pkg/webhook/templates/issue_comment_test.go
@@ -54,9 +54,33 @@ func TestRenderStopCommandAcceptedAlreadyRequested(t *testing.T) {
 	rendered := RenderStopCommandAccepted(StopCommandAcceptedData{
 		ApplyID:     "apply_abc123",
 		Environment: "staging",
-		Status:      "already_requested",
+		Status:      apitypes.ControlStatusAlreadyRequested,
 	})
 	assert.Contains(t, rendered, "Stop was already requested")
+}
+
+func TestRenderStartCommandAccepted(t *testing.T) {
+	rendered := RenderStartCommandAccepted(StartCommandAcceptedData{
+		ApplyID:      "apply_abc123",
+		Environment:  "staging",
+		RequestedBy:  "alice",
+		StartedCount: 1,
+		SkippedCount: 2,
+	})
+	assert.Contains(t, rendered, "Start Request Accepted")
+	assert.Contains(t, rendered, "`apply_abc123`")
+	assert.Contains(t, rendered, "`staging`")
+	assert.Contains(t, rendered, "@alice")
+	assert.Contains(t, rendered, "1 started, 2 skipped")
+}
+
+func TestRenderStartCommandAcceptedAlreadyRequested(t *testing.T) {
+	rendered := RenderStartCommandAccepted(StartCommandAcceptedData{
+		ApplyID:     "apply_abc123",
+		Environment: "staging",
+		Status:      apitypes.ControlStatusAlreadyRequested,
+	})
+	assert.Contains(t, rendered, "Start was already requested")
 }
 
 func TestRenderCutoverCommandAccepted(t *testing.T) {


### PR DESCRIPTION
Adds PR-comment support for `schemabot start <apply-id> -e <env>` by routing it through the same durable start control path used by the CLI/API.

Shares apply-scoped PR control validation across `stop`, `start`, and `cutover` so control commands consistently fail closed when the apply belongs to another PR/environment or actor authorization fails.

*This PR was generated by Amp.*