### PR TITLE
fix(github): clean up PR control command error handling

### DIFF
--- a/pkg/api/control_handlers.go
+++ b/pkg/api/control_handlers.go
@@ -54,6 +54,15 @@ func controlOperationHTTPStatus(err error) int {
 	return http.StatusInternalServerError
 }
 
+// IsInternalControlError reports whether a control operation error is an
+// internal failure (storage, Tern, or other unexpected errors) rather than an
+// operator-actionable rejection such as a state conflict. Callers use this to
+// pick error-level logging for failures operators must investigate, versus
+// warning-level logging for rejections the requester can act on.
+func IsInternalControlError(err error) bool {
+	return controlOperationHTTPStatus(err) >= http.StatusInternalServerError
+}
+
 func controlHTTPErrorf(status int, format string, args ...any) error {
 	return &controlOperationHTTPError{
 		status: status,
@@ -342,18 +351,22 @@ func (s *Service) ExecuteCutover(ctx context.Context, req apitypes.ControlReques
 	return resp, err
 }
 
+// executeCutoverForApply records durable cutover intent for an apply. The
+// returned HTTP status is meaningful only when err == nil; every error path
+// returns a zero status, and callers must derive the response status from the
+// error (e.g. via writeControlError).
 func (s *Service) executeCutoverForApply(ctx context.Context, client tern.Client, apply *storage.Apply, ternApplyID, caller string) (*apitypes.ControlResponse, int, error) {
 	controlStore := s.storage.ControlRequests()
 	if controlStore == nil {
 		err := fmt.Errorf("control request store is not available")
 		metrics.RecordControlOperation(ctx, "cutover", apply.Database, apply.Deployment, apply.Environment, "error")
-		return nil, http.StatusOK, err
+		return nil, 0, err
 	}
 	controlReq, err := controlStore.GetPending(ctx, apply.ID, storage.ControlOperationCutover)
 	if err != nil {
 		err := fmt.Errorf("load pending cutover control request for apply %s: %w", apply.ApplyIdentifier, err)
 		metrics.RecordControlOperation(ctx, "cutover", apply.Database, apply.Deployment, apply.Environment, "error")
-		return nil, http.StatusOK, err
+		return nil, 0, err
 	}
 	if controlReq != nil {
 		metrics.RecordControlOperation(ctx, "cutover", apply.Database, apply.Deployment, apply.Environment, "success")
@@ -373,7 +386,7 @@ func (s *Service) executeCutoverForApply(ctx context.Context, client tern.Client
 	if err != nil {
 		err := fmt.Errorf("check cutover readiness for apply %s: %w", apply.ApplyIdentifier, err)
 		metrics.RecordControlOperation(ctx, "cutover", apply.Database, apply.Deployment, apply.Environment, "error")
-		return nil, http.StatusOK, err
+		return nil, 0, err
 	}
 	if readiness == cutoverRequestAlreadyInProgress {
 		metrics.RecordControlOperation(ctx, "cutover", apply.Database, apply.Deployment, apply.Environment, "success")
@@ -398,12 +411,12 @@ func (s *Service) executeCutoverForApply(ctx context.Context, client tern.Client
 			"state", apply.State)
 		err := controlConflictf("schema change is recovering after restart; cutover will be available once recovery completes")
 		metrics.RecordControlOperation(ctx, "cutover", apply.Database, apply.Deployment, apply.Environment, "rejected")
-		return nil, http.StatusOK, err
+		return nil, 0, err
 	}
 	if readiness == cutoverRequestNotReady {
 		err := controlConflictf("schema change is not waiting for cutover (current state: %s)", apply.State)
 		metrics.RecordControlOperation(ctx, "cutover", apply.Database, apply.Deployment, apply.Environment, "rejected")
-		return nil, http.StatusOK, err
+		return nil, 0, err
 	}
 	_, alreadyPending, err := controlStore.RequestPending(ctx, &storage.ApplyControlRequest{
 		ApplyID:     apply.ID,
@@ -414,7 +427,7 @@ func (s *Service) executeCutoverForApply(ctx context.Context, client tern.Client
 	if err != nil {
 		err := fmt.Errorf("record cutover control request for apply %s: %w", apply.ApplyIdentifier, err)
 		metrics.RecordControlOperation(ctx, "cutover", apply.Database, apply.Deployment, apply.Environment, "error")
-		return nil, http.StatusOK, err
+		return nil, 0, err
 	}
 	metrics.RecordControlOperation(ctx, "cutover", apply.Database, apply.Deployment, apply.Environment, "success")
 	message := "Cutover requested by user"
@@ -541,6 +554,10 @@ func (s *Service) ExecuteStop(ctx context.Context, req apitypes.ControlRequest) 
 	return resp, err
 }
 
+// executeStopForApply records durable stop intent for an apply and attempts an
+// immediate local stop. The returned HTTP status is meaningful only when
+// err == nil; every error path returns a zero status, and callers must derive
+// the response status from the error (e.g. via writeControlError).
 func (s *Service) executeStopForApply(ctx context.Context, client tern.Client, apply *storage.Apply, ternApplyID, environment, caller string) (*apitypes.StopResponse, int, error) {
 	resp, responseStatus, err := s.queueStopForApplyOwner(ctx, apply, caller)
 	if err != nil {
@@ -549,7 +566,7 @@ func (s *Service) executeStopForApply(ctx context.Context, client tern.Client, a
 			status = "rejected"
 		}
 		metrics.RecordControlOperation(ctx, "stop", apply.Database, apply.Deployment, apply.Environment, status)
-		return nil, http.StatusOK, err
+		return nil, 0, err
 	}
 	metrics.RecordControlOperation(ctx, "stop", apply.Database, apply.Deployment, apply.Environment, controlStatus(resp.Accepted))
 	if resp.Accepted {
@@ -885,10 +902,14 @@ func (s *Service) ExecuteStart(ctx context.Context, req apitypes.ControlRequest)
 	return resp, err
 }
 
+// executeStartForApply records durable start intent for an apply or dispatches
+// a deferred deploy. The returned HTTP status is meaningful only when
+// err == nil; every error path returns a zero status, and callers must derive
+// the response status from the error (e.g. via writeControlError).
 func (s *Service) executeStartForApply(ctx context.Context, client tern.Client, apply *storage.Apply, ternApplyID, caller string) (*apitypes.StartResponse, int, error) {
 	if err := validateStartRequestState(apply); err != nil {
 		metrics.RecordControlOperation(ctx, "start", apply.Database, apply.Deployment, apply.Environment, "rejected")
-		return nil, http.StatusOK, err
+		return nil, 0, err
 	}
 	if err := s.completeResolvedStopBeforeStart(ctx, client, apply, caller); err != nil {
 		status := "error"
@@ -896,7 +917,7 @@ func (s *Service) executeStartForApply(ctx context.Context, client tern.Client, 
 			status = "rejected"
 		}
 		metrics.RecordControlOperation(ctx, "start", apply.Database, apply.Deployment, apply.Environment, status)
-		return nil, http.StatusOK, err
+		return nil, 0, err
 	}
 	if err := s.rejectControlIfStopPending(ctx, "start", apply); err != nil {
 		status := "error"
@@ -904,7 +925,7 @@ func (s *Service) executeStartForApply(ctx context.Context, client tern.Client, 
 			status = "rejected"
 		}
 		metrics.RecordControlOperation(ctx, "start", apply.Database, apply.Deployment, apply.Environment, status)
-		return nil, http.StatusOK, err
+		return nil, 0, err
 	}
 
 	var resp *ternv1.StartResponse
@@ -919,7 +940,7 @@ func (s *Service) executeStartForApply(ctx context.Context, client tern.Client, 
 				status = "rejected"
 			}
 			metrics.RecordControlOperation(ctx, "start", apply.Database, apply.Deployment, apply.Environment, status)
-			return nil, http.StatusOK, err
+			return nil, 0, err
 		}
 		resp, err = client.Start(ctx, &ternv1.StartRequest{
 			ApplyId:     ternApplyID,
@@ -951,7 +972,7 @@ func (s *Service) executeStartForApply(ctx context.Context, client tern.Client, 
 			status = "rejected"
 		}
 		metrics.RecordControlOperation(ctx, "start", apply.Database, apply.Deployment, apply.Environment, status)
-		return nil, http.StatusOK, err
+		return nil, 0, err
 	}
 
 	metrics.RecordControlOperation(ctx, "start", apply.Database, apply.Deployment, apply.Environment, controlStatus(resp.Accepted))

--- a/pkg/api/control_handlers_test.go
+++ b/pkg/api/control_handlers_test.go
@@ -1,0 +1,38 @@
+package api
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestIsInternalControlError verifies that control operation errors are
+// classified so callers log internal failures at error severity and
+// operator-actionable rejections at warning severity.
+func TestIsInternalControlError(t *testing.T) {
+	t.Run("conflict rejection is not internal", func(t *testing.T) {
+		assert.False(t, IsInternalControlError(controlConflictf("schema change is already terminal (current state: %s)", "completed")))
+	})
+
+	t.Run("client-facing status is not internal", func(t *testing.T) {
+		assert.False(t, IsInternalControlError(controlHTTPErrorf(http.StatusNotFound, "apply not found: %s", "apply-123")))
+		assert.False(t, IsInternalControlError(controlHTTPErrorf(http.StatusBadRequest, "environment is required")))
+	})
+
+	t.Run("wrapped rejection keeps its classification", func(t *testing.T) {
+		wrapped := fmt.Errorf("execute start: %w", controlConflictf("schema change is still running; stop it before starting it again"))
+		assert.False(t, IsInternalControlError(wrapped))
+	})
+
+	t.Run("unclassified error is internal", func(t *testing.T) {
+		assert.True(t, IsInternalControlError(errors.New("control request store is not available")))
+		assert.True(t, IsInternalControlError(fmt.Errorf("record start control request for apply %s: %w", "apply-123", errors.New("storage unavailable"))))
+	})
+
+	t.Run("explicit server status is internal", func(t *testing.T) {
+		assert.True(t, IsInternalControlError(controlHTTPErrorf(http.StatusBadGateway, "tern unavailable")))
+	})
+}

--- a/pkg/webhook/control.go
+++ b/pkg/webhook/control.go
@@ -4,11 +4,33 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/block/schemabot/pkg/api"
 	"github.com/block/schemabot/pkg/apitypes"
 	"github.com/block/schemabot/pkg/storage"
 	"github.com/block/schemabot/pkg/webhook/action"
 	"github.com/block/schemabot/pkg/webhook/templates"
 )
+
+// logControlCommandError logs a failed PR control command at the severity
+// matching the error class: internal failures (storage, control request store,
+// Tern, or other unexpected errors) log at Error so operators investigate
+// them, while operator-actionable rejections such as state conflicts log at
+// Warn.
+func (h *Handler) logControlCommandError(command, repo string, pr int, applyID, environment, requestedBy string, err error) {
+	attrs := []any{
+		"repo", repo,
+		"pr", pr,
+		"apply_id", applyID,
+		"environment", environment,
+		"requested_by", requestedBy,
+		"error", err,
+	}
+	if api.IsInternalControlError(err) {
+		h.logger.Error(command+" PR command failed", attrs...)
+	} else {
+		h.logger.Warn(command+" PR command rejected", attrs...)
+	}
+}
 
 func (h *Handler) loadApplyForPRControl(ctx context.Context, repo string, pr int, installationID int64, requestedBy string, result CommandResult, command string) (*storage.Apply, bool) {
 	if result.ApplyID == "" {
@@ -128,13 +150,7 @@ func (h *Handler) handleStopCommand(repo string, pr int, installationID int64, r
 		Caller:      caller,
 	})
 	if err != nil {
-		h.logger.Warn("stop PR command rejected",
-			"repo", repo,
-			"pr", pr,
-			"apply_id", result.ApplyID,
-			"environment", result.Environment,
-			"requested_by", requestedBy,
-			"error", err)
+		h.logControlCommandError(action.Stop, repo, pr, result.ApplyID, result.Environment, requestedBy, err)
 		h.postCommandError(repo, pr, installationID, action.Stop, result.Environment, requestedBy, err.Error())
 		return
 	}
@@ -208,13 +224,7 @@ func (h *Handler) handleStartCommand(repo string, pr int, installationID int64, 
 		Caller:      caller,
 	})
 	if err != nil {
-		h.logger.Warn("start PR command rejected",
-			"repo", repo,
-			"pr", pr,
-			"apply_id", result.ApplyID,
-			"environment", result.Environment,
-			"requested_by", requestedBy,
-			"error", err)
+		h.logControlCommandError(action.Start, repo, pr, result.ApplyID, result.Environment, requestedBy, err)
 		h.postCommandError(repo, pr, installationID, action.Start, result.Environment, requestedBy, err.Error())
 		return
 	}
@@ -288,13 +298,7 @@ func (h *Handler) handleCutoverCommand(repo string, pr int, installationID int64
 		Caller:      caller,
 	})
 	if err != nil {
-		h.logger.Warn("cutover PR command rejected",
-			"repo", repo,
-			"pr", pr,
-			"apply_id", result.ApplyID,
-			"environment", result.Environment,
-			"requested_by", requestedBy,
-			"error", err)
+		h.logControlCommandError(action.Cutover, repo, pr, result.ApplyID, result.Environment, requestedBy, err)
 		h.postCommandError(repo, pr, installationID, action.Cutover, result.Environment, requestedBy, err.Error())
 		return
 	}


### PR DESCRIPTION
Follow-up to #324, addressing two review nits on the shared PR control command paths.

- **Split webhook control-command log severity by error class.** `stop`/`start`/`cutover` PR command failures previously logged every `Execute*` error at Warn. Internal failures (storage, control request store, Tern errors) now log at Error via a new exported classifier, `api.IsInternalControlError`, while operator-actionable rejections (wrong state, pending stop, already completed) stay at Warn. Triage fields (repo, pr, apply_id, environment, requested_by, error) are unchanged.
- **Make the `execute{Stop,Start,Cutover}ForApply` status contract explicit.** These returned `http.StatusOK` alongside a non-nil error, which callers had to know to ignore. All error paths now return a zero status, and the functions document that the status is meaningful only when `err == nil`, so the success status can never be written for an error. HTTP status/body behavior and PR comment behavior are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)