### PR TITLE
fix(github): retain locks and check state when a PR closes with an in-flight apply

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1133,6 +1133,7 @@ var knownStatusCheckOperations = map[string]bool{
 	"aggregate_check_sync":                 true,
 	"stale_check_cleanup":                  true,
 	"stale_check_reconciliation":           true,
+	"pr_close_cleanup":                     true,
 	"schema_config_discovery":              true,
 	"schema_config_source_policy":          true,
 	"schema_config_environment_validation": true,

--- a/pkg/storage/mysqlstore/checks.go
+++ b/pkg/storage/mysqlstore/checks.go
@@ -415,10 +415,20 @@ func (s *checkStore) Delete(ctx context.Context, id int64) error {
 	return checkRowsAffected(result, storage.ErrCheckNotFound)
 }
 
-// DeleteByPR removes all stored check state for a PR.
-func (s *checkStore) DeleteByPR(ctx context.Context, repo string, pr int) error {
-	_, err := s.db.ExecContext(ctx, `DELETE FROM checks WHERE repository = ? AND pull_request = ?`, repo, pr)
-	return err
+// DeleteByPRExcludingApplyOwned removes stored check state for a PR, except
+// rows owned by an in-flight apply. A row with apply_id set and status
+// in_progress must keep blocking until the apply reaches a terminal state,
+// even when PR-close cleanup found no non-terminal apply in the applies table.
+func (s *checkStore) DeleteByPRExcludingApplyOwned(ctx context.Context, repo string, pr int) error {
+	_, err := s.db.ExecContext(ctx, `
+		DELETE FROM checks
+		WHERE repository = ? AND pull_request = ?
+		  AND NOT (apply_id IS NOT NULL AND status = ?)
+	`, repo, pr, checkStatusInProgress)
+	if err != nil {
+		return fmt.Errorf("delete checks for closed PR %s#%d: %w", repo, pr, err)
+	}
+	return nil
 }
 
 // scanCheck scans a single check row, returning nil if not found.

--- a/pkg/storage/mysqlstore/checks_test.go
+++ b/pkg/storage/mysqlstore/checks_test.go
@@ -197,22 +197,29 @@ func TestCheckStore_Delete(t *testing.T) {
 	require.ErrorIs(t, store.Checks().Delete(ctx, 99999), storage.ErrCheckNotFound)
 }
 
-func TestCheckStore_DeleteByPR(t *testing.T) {
+// TestCheckStore_DeleteByPRExcludingApplyOwned verifies PR-close cleanup at the
+// storage layer: all of a PR's stored check state is deleted except rows owned
+// by an in-flight apply (apply_id set and status in_progress), which must keep
+// blocking the PR until the apply reaches a terminal state. Rows for other PRs
+// are untouched.
+func TestCheckStore_DeleteByPRExcludingApplyOwned(t *testing.T) {
 	clearTables(t)
 	ctx := t.Context()
 	store := New(testDB)
 
-	// Create checks for same PR
+	// Checks for the closed PR: two deletable rows, one apply-owned in-flight
+	// row that must survive, and one terminal apply-owned row that is deletable.
 	checksToCreate := []*storage.Check{
 		{Repository: "org/repo", PullRequest: 123, HeadSHA: "abc", Environment: "staging", DatabaseType: "vitess", DatabaseName: "db1", Status: "pending"},
-		{Repository: "org/repo", PullRequest: 123, HeadSHA: "abc", Environment: "production", DatabaseType: "vitess", DatabaseName: "db1", Status: "pending"},
 		{Repository: "org/repo", PullRequest: 123, HeadSHA: "abc", Environment: "staging", DatabaseType: "mysql", DatabaseName: "db2", Status: "pending"},
+		{Repository: "org/repo", PullRequest: 123, HeadSHA: "abc", Environment: "production", DatabaseType: "mysql", DatabaseName: "db3", Status: "in_progress", ApplyID: 77},
+		{Repository: "org/repo", PullRequest: 123, HeadSHA: "abc", Environment: "production", DatabaseType: "mysql", DatabaseName: "db4", Status: "completed", ApplyID: 88, Conclusion: "success"},
 	}
 	for _, c := range checksToCreate {
 		require.NoError(t, store.Checks().Upsert(ctx, c))
 	}
 
-	// Create check for different PR (should not be deleted)
+	// Check for a different PR (must not be deleted)
 	require.NoError(t, store.Checks().Upsert(ctx, &storage.Check{
 		Repository:   "org/repo",
 		PullRequest:  456,
@@ -223,21 +230,24 @@ func TestCheckStore_DeleteByPR(t *testing.T) {
 		Status:       "pending",
 	}))
 
-	// DeleteByPR should succeed
-	require.NoError(t, store.Checks().DeleteByPR(ctx, "org/repo", 123))
+	require.NoError(t, store.Checks().DeleteByPRExcludingApplyOwned(ctx, "org/repo", 123))
 
-	// Verify PR 123 checks are deleted
+	// Only the apply-owned in-flight row survives for PR 123.
 	retrieved, err := store.Checks().GetByPR(ctx, "org/repo", 123)
 	require.NoError(t, err)
-	require.Empty(t, retrieved)
+	require.Len(t, retrieved, 1)
+	assert.Equal(t, "db3", retrieved[0].DatabaseName)
+	assert.Equal(t, "in_progress", retrieved[0].Status)
+	assert.Equal(t, int64(77), retrieved[0].ApplyID)
 
-	// Verify PR 456 check still exists
+	// PR 456's check still exists.
 	retrieved, err = store.Checks().GetByPR(ctx, "org/repo", 456)
 	require.NoError(t, err)
 	require.Len(t, retrieved, 1)
+	assert.Equal(t, "db1", retrieved[0].DatabaseName)
 
-	// DeleteByPR on non-existent PR should not error (no-op)
-	require.NoError(t, store.Checks().DeleteByPR(ctx, "org/repo", 999))
+	// Deleting for a non-existent PR is a no-op, not an error.
+	require.NoError(t, store.Checks().DeleteByPRExcludingApplyOwned(ctx, "org/repo", 999))
 }
 
 func TestCheckStore_GetByPR_DBError(t *testing.T) {

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -129,9 +129,12 @@ type CheckStore interface {
 	// Delete removes stored check state by ID.
 	Delete(ctx context.Context, id int64) error
 
-	// DeleteByPR removes all stored check state for a PR.
-	// Used for cleanup when a PR is closed or merged.
-	DeleteByPR(ctx context.Context, repo string, pr int) error
+	// DeleteByPRExcludingApplyOwned removes stored check state for a PR,
+	// except rows owned by an in-flight apply (apply_id set and status
+	// in_progress). Used for cleanup when a PR is closed or merged:
+	// apply-owned rows must keep blocking until the apply reaches a terminal
+	// state, even across a close and reopen.
+	DeleteByPRExcludingApplyOwned(ctx context.Context, repo string, pr int) error
 }
 
 // SettingsStore manages admin-level SchemaBot settings (global config).

--- a/pkg/webhook/pr_closed_test.go
+++ b/pkg/webhook/pr_closed_test.go
@@ -1,0 +1,210 @@
+package webhook
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/block/schemabot/pkg/api"
+	"github.com/block/schemabot/pkg/state"
+	"github.com/block/schemabot/pkg/storage"
+)
+
+// prClosedTestStorage serves a fixed set of locks and applies and records
+// which cleanup operations handlePRClosed performed, so tests can verify
+// whether locks were released and check state was deleted.
+type prClosedTestStorage struct {
+	emptyStorage
+	locks   *prClosedLockStore
+	applies storage.ApplyStore
+	checks  *prClosedCheckStore
+}
+
+func (s *prClosedTestStorage) Locks() storage.LockStore { return s.locks }
+
+func (s *prClosedTestStorage) Applies() storage.ApplyStore { return s.applies }
+
+func (s *prClosedTestStorage) Checks() storage.CheckStore { return s.checks }
+
+type prClosedLockStore struct {
+	storage.LockStore
+	locks    []*storage.Lock
+	released []string
+}
+
+func (s *prClosedLockStore) GetByPR(_ context.Context, _ string, _ int) ([]*storage.Lock, error) {
+	return s.locks, nil
+}
+
+func (s *prClosedLockStore) Release(_ context.Context, database, _, _ string) error {
+	s.released = append(s.released, database)
+	return nil
+}
+
+type prClosedApplyStore struct {
+	storage.ApplyStore
+	applies []*storage.Apply
+}
+
+func (s *prClosedApplyStore) GetByPR(_ context.Context, _ string, _ int) ([]*storage.Apply, error) {
+	return s.applies, nil
+}
+
+type failingPRApplyLookupStore struct {
+	storage.ApplyStore
+}
+
+func (s *failingPRApplyLookupStore) GetByPR(_ context.Context, _ string, _ int) ([]*storage.Apply, error) {
+	return nil, errors.New("storage read failed")
+}
+
+type prClosedCheckStore struct {
+	storage.CheckStore
+	deleteCalls int
+}
+
+func (s *prClosedCheckStore) DeleteByPRExcludingApplyOwned(_ context.Context, _ string, _ int) error {
+	s.deleteCalls++
+	return nil
+}
+
+func prClosedTestHandler(t *testing.T, st storage.Storage) *Handler {
+	t.Helper()
+	service := api.New(st, &api.ServerConfig{}, nil, testLogger())
+	return &Handler{
+		service: service,
+		logger:  testLogger(),
+	}
+}
+
+func prClosedLock(database string) *storage.Lock {
+	return &storage.Lock{
+		DatabaseName: database,
+		DatabaseType: storage.DatabaseTypeMySQL,
+		Repository:   "octocat/hello-world",
+		PullRequest:  1,
+		Owner:        "octocat/hello-world#1",
+	}
+}
+
+func prClosedApply(database, applyState string) *storage.Apply {
+	return &storage.Apply{
+		ID:              42,
+		ApplyIdentifier: "apply_" + database,
+		Database:        database,
+		DatabaseType:    storage.DatabaseTypeMySQL,
+		Repository:      "octocat/hello-world",
+		PullRequest:     1,
+		Environment:     "staging",
+		State:           applyState,
+	}
+}
+
+// TestPRClosedRetainsLockAndChecksForInFlightApply verifies that closing a PR
+// while one of its applies is still running does not release the apply's
+// database lock and does not delete the PR's stored check state. The lock must
+// keep other PRs from starting a concurrent apply on the same database, and the
+// stored check state must keep blocking a close-and-reopen until the apply
+// reaches a terminal state.
+func TestPRClosedRetainsLockAndChecksForInFlightApply(t *testing.T) {
+	lockStore := &prClosedLockStore{locks: []*storage.Lock{prClosedLock("orders")}}
+	checkStore := &prClosedCheckStore{}
+	st := &prClosedTestStorage{
+		locks:   lockStore,
+		applies: &prClosedApplyStore{applies: []*storage.Apply{prClosedApply("orders", state.Apply.Running)}},
+		checks:  checkStore,
+	}
+
+	h := prClosedTestHandler(t, st)
+	h.handlePRClosed("octocat/hello-world", 1, 12345)
+
+	assert.Empty(t, lockStore.released, "lock for a database with an in-flight apply must not be released on PR close")
+	assert.Equal(t, 0, checkStore.deleteCalls, "stored check state must not be deleted while an apply is in flight")
+}
+
+// TestPRClosedReleasesOnlyLocksWithoutInFlightApply verifies per-database lock
+// cleanup on PR close: a lock on a database whose apply finished is released,
+// while a lock on a database with a running apply is retained. Check state
+// deletion is skipped entirely while any apply is in flight, because stored
+// check state is PR-scoped.
+func TestPRClosedReleasesOnlyLocksWithoutInFlightApply(t *testing.T) {
+	lockStore := &prClosedLockStore{locks: []*storage.Lock{prClosedLock("orders"), prClosedLock("billing")}}
+	checkStore := &prClosedCheckStore{}
+	st := &prClosedTestStorage{
+		locks: lockStore,
+		applies: &prClosedApplyStore{applies: []*storage.Apply{
+			prClosedApply("orders", state.Apply.Running),
+			prClosedApply("billing", state.Apply.Completed),
+		}},
+		checks: checkStore,
+	}
+
+	h := prClosedTestHandler(t, st)
+	h.handlePRClosed("octocat/hello-world", 1, 12345)
+
+	assert.Equal(t, []string{"billing"}, lockStore.released, "only the lock without an in-flight apply is released")
+	assert.Equal(t, 0, checkStore.deleteCalls, "stored check state must not be deleted while any apply is in flight")
+}
+
+// TestPRClosedCleansUpWhenAllAppliesTerminal verifies that once every apply for
+// the PR has reached a terminal state, closing the PR releases all of its locks
+// and deletes its stored check state.
+func TestPRClosedCleansUpWhenAllAppliesTerminal(t *testing.T) {
+	lockStore := &prClosedLockStore{locks: []*storage.Lock{prClosedLock("orders"), prClosedLock("billing")}}
+	checkStore := &prClosedCheckStore{}
+	st := &prClosedTestStorage{
+		locks: lockStore,
+		applies: &prClosedApplyStore{applies: []*storage.Apply{
+			prClosedApply("orders", state.Apply.Completed),
+			prClosedApply("billing", state.Apply.Failed),
+		}},
+		checks: checkStore,
+	}
+
+	h := prClosedTestHandler(t, st)
+	h.handlePRClosed("octocat/hello-world", 1, 12345)
+
+	assert.Equal(t, []string{"orders", "billing"}, lockStore.released, "all locks are released when applies are terminal")
+	assert.Equal(t, 1, checkStore.deleteCalls, "stored check state is deleted when applies are terminal")
+}
+
+// TestPRClosedCleansUpWhenPRHasNoApplies verifies that a PR with no recorded
+// applies (e.g., plan-only PRs) gets full cleanup on close: locks released and
+// stored check state deleted.
+func TestPRClosedCleansUpWhenPRHasNoApplies(t *testing.T) {
+	lockStore := &prClosedLockStore{locks: []*storage.Lock{prClosedLock("orders")}}
+	checkStore := &prClosedCheckStore{}
+	st := &prClosedTestStorage{
+		locks:   lockStore,
+		applies: &prClosedApplyStore{},
+		checks:  checkStore,
+	}
+
+	h := prClosedTestHandler(t, st)
+	h.handlePRClosed("octocat/hello-world", 1, 12345)
+
+	assert.Equal(t, []string{"orders"}, lockStore.released, "locks are released when the PR has no applies")
+	assert.Equal(t, 1, checkStore.deleteCalls, "stored check state is deleted when the PR has no applies")
+}
+
+// TestPRClosedSkipsCleanupWhenApplyLookupFails verifies that PR-close cleanup
+// fails closed: when apply state cannot be read, no lock is released and no
+// stored check state is deleted, because either action could unblock a database
+// with an apply still in flight.
+func TestPRClosedSkipsCleanupWhenApplyLookupFails(t *testing.T) {
+	lockStore := &prClosedLockStore{locks: []*storage.Lock{prClosedLock("orders")}}
+	checkStore := &prClosedCheckStore{}
+	st := &prClosedTestStorage{
+		locks:   lockStore,
+		applies: &failingPRApplyLookupStore{},
+		checks:  checkStore,
+	}
+
+	h := prClosedTestHandler(t, st)
+	h.handlePRClosed("octocat/hello-world", 1, 12345)
+
+	assert.Empty(t, lockStore.released, "no lock is released when apply state is unknown")
+	assert.Equal(t, 0, checkStore.deleteCalls, "no check state is deleted when apply state is unknown")
+}

--- a/pkg/webhook/pull_request.go
+++ b/pkg/webhook/pull_request.go
@@ -266,8 +266,18 @@ func (h *Handler) handlePRClosed(repo string, pr int, _ int64) {
 	// survive the delete at the storage layer even if the applies table missed
 	// the in-flight work above.
 	if err := h.service.Storage().Checks().DeleteByPRExcludingApplyOwned(ctx, repo, pr); err != nil {
+		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
+			Operation:  "pr_close_cleanup",
+			Repository: repo,
+			Status:     "error",
+		})
 		h.logger.Error("failed to delete checks for closed PR", "repo", repo, "pr", pr, "error", err)
 	} else {
+		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
+			Operation:  "pr_close_cleanup",
+			Repository: repo,
+			Status:     "success",
+		})
 		h.logger.Info("deleted checks for closed PR", "repo", repo, "pr", pr)
 	}
 }

--- a/pkg/webhook/pull_request.go
+++ b/pkg/webhook/pull_request.go
@@ -9,6 +9,7 @@ import (
 
 	ghclient "github.com/block/schemabot/pkg/github"
 	"github.com/block/schemabot/pkg/metrics"
+	"github.com/block/schemabot/pkg/state"
 	"github.com/block/schemabot/pkg/storage"
 )
 
@@ -224,33 +225,110 @@ func (h *Handler) aggregateMessagesForAllEnvironments(message string) map[string
 	return messages
 }
 
-// handlePRClosed cleans up resources when a PR is closed (merged or unmerged).
-// Releases any locks held by this PR and deletes stored check records.
+// handlePRClosed cleans up resources when a PR is closed (merged or unmerged):
+// it releases locks held by this PR and deletes its stored check state.
+//
+// Cleanup only covers finished work. While any apply for the PR is
+// non-terminal, that apply's database lock is retained so another PR cannot
+// acquire the database mid-apply, and the PR's stored check state is retained
+// so a close-and-reopen cannot convert in-flight apply state into a passing
+// check. If apply state cannot be read, cleanup fails closed and nothing is
+// released or deleted.
 func (h *Handler) handlePRClosed(repo string, pr int, _ int64) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	// Release all locks held by this PR
-	locks, err := h.service.Storage().Locks().GetByPR(ctx, repo, pr)
+	applies, err := h.service.Storage().Applies().GetByPR(ctx, repo, pr)
 	if err != nil {
-		h.logger.Error("failed to look up locks for closed PR", "repo", repo, "pr", pr, "error", err)
-	} else {
-		for _, lock := range locks {
-			if err := h.service.Storage().Locks().Release(ctx, lock.DatabaseName, lock.DatabaseType, lock.Owner); err != nil {
-				h.logger.Error("failed to release lock on PR close",
-					"database", lock.DatabaseName, "error", err)
-			} else {
-				h.logger.Info("released lock on PR close",
-					"repo", repo, "pr", pr, "database", lock.DatabaseName)
-			}
-		}
+		// Fail closed: with apply state unknown, releasing a lock or deleting
+		// check state could unblock a database with an apply still in flight.
+		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
+			Operation:  "pr_close_cleanup",
+			Repository: repo,
+			Status:     "error",
+		})
+		h.logger.Error("PR close cleanup skipped: cannot verify apply state; all locks and check state are retained",
+			"repo", repo, "pr", pr, "error", err)
+		return
 	}
 
-	// Delete all check records for this PR
-	if err := h.service.Storage().Checks().DeleteByPR(ctx, repo, pr); err != nil {
+	inFlight := h.inFlightAppliesForClosedPR(ctx, repo, pr, applies)
+
+	h.releaseLocksForClosedPR(ctx, repo, pr, inFlight)
+
+	if len(inFlight) > 0 {
+		h.logger.Info("check state retained for closed PR until all applies reach a terminal state",
+			"repo", repo, "pr", pr, "in_flight_databases", len(inFlight))
+		return
+	}
+
+	// Delete stored check state for this PR. Rows owned by an in-flight apply
+	// survive the delete at the storage layer even if the applies table missed
+	// the in-flight work above.
+	if err := h.service.Storage().Checks().DeleteByPRExcludingApplyOwned(ctx, repo, pr); err != nil {
 		h.logger.Error("failed to delete checks for closed PR", "repo", repo, "pr", pr, "error", err)
 	} else {
 		h.logger.Info("deleted checks for closed PR", "repo", repo, "pr", pr)
+	}
+}
+
+// closedPRDatabase identifies the database lock an apply holds.
+type closedPRDatabase struct {
+	database     string
+	databaseType string
+}
+
+// inFlightAppliesForClosedPR returns the databases for which the closed PR
+// still has a non-terminal apply recorded. Each in-flight apply is logged and
+// counted because it blocks close cleanup: the database stays locked and the
+// PR's stored check state stays in place until the apply reaches a terminal
+// state.
+func (h *Handler) inFlightAppliesForClosedPR(ctx context.Context, repo string, pr int, applies []*storage.Apply) map[closedPRDatabase]bool {
+	inFlight := make(map[closedPRDatabase]bool)
+	for _, a := range applies {
+		if state.IsTerminalApplyState(a.State) {
+			// Terminal applies never block close cleanup.
+			continue
+		}
+		inFlight[closedPRDatabase{database: a.Database, databaseType: a.DatabaseType}] = true
+		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
+			Operation:    "pr_close_cleanup",
+			Repository:   repo,
+			Database:     a.Database,
+			DatabaseType: a.DatabaseType,
+			Environment:  a.Environment,
+			Status:       "blocked",
+		})
+		h.logger.Warn("retaining lock and check state for closed PR with in-flight apply; close cleanup skipped for this database",
+			"repo", repo, "pr", pr,
+			"database", a.Database, "database_type", a.DatabaseType,
+			"environment", a.Environment,
+			"apply_id", a.ID, "apply_identifier", a.ApplyIdentifier, "apply_state", a.State)
+	}
+	return inFlight
+}
+
+// releaseLocksForClosedPR releases the closed PR's locks, except locks on
+// databases that still have an in-flight apply.
+func (h *Handler) releaseLocksForClosedPR(ctx context.Context, repo string, pr int, inFlight map[closedPRDatabase]bool) {
+	locks, err := h.service.Storage().Locks().GetByPR(ctx, repo, pr)
+	if err != nil {
+		h.logger.Error("failed to look up locks for closed PR; no locks released", "repo", repo, "pr", pr, "error", err)
+		return
+	}
+	for _, lock := range locks {
+		if inFlight[closedPRDatabase{database: lock.DatabaseName, databaseType: lock.DatabaseType}] {
+			h.logger.Info("lock retained on PR close because an apply is in flight",
+				"repo", repo, "pr", pr, "database", lock.DatabaseName, "database_type", lock.DatabaseType)
+			continue
+		}
+		if err := h.service.Storage().Locks().Release(ctx, lock.DatabaseName, lock.DatabaseType, lock.Owner); err != nil {
+			h.logger.Error("failed to release lock on PR close",
+				"repo", repo, "pr", pr, "database", lock.DatabaseName, "database_type", lock.DatabaseType, "error", err)
+		} else {
+			h.logger.Info("released lock on PR close",
+				"repo", repo, "pr", pr, "database", lock.DatabaseName)
+		}
 	}
 }
 

--- a/pkg/webhook/webhook_e2e_test.go
+++ b/pkg/webhook/webhook_e2e_test.go
@@ -184,6 +184,7 @@ func setupE2EService(t *testing.T, appDBName string) *api.Service {
 	// Clean up any stale data from previous test runs (shared storage DB)
 	_, _ = schemabotDB.ExecContext(ctx, "DELETE FROM checks WHERE database_name = ?", appDBName)
 	_, _ = schemabotDB.ExecContext(ctx, "DELETE FROM checks WHERE repository = 'octocat/hello-world' AND pull_request = 1")
+	_, _ = schemabotDB.ExecContext(ctx, "DELETE FROM applies WHERE repository = 'octocat/hello-world' AND pull_request = 1")
 	_, _ = schemabotDB.ExecContext(ctx, "DELETE FROM plans WHERE database_name = ?", appDBName)
 
 	localClient, err := tern.NewLocalClient(tern.LocalConfig{
@@ -2804,7 +2805,12 @@ func TestE2ERollbackIgnoredByNonOwningInstance(t *testing.T) {
 	}
 }
 
-// TestE2EPRCloseCleanup verifies that closing a PR releases locks and deletes checks.
+// TestE2EPRCloseCleanup verifies PR-close cleanup against real storage. While
+// the PR has a running apply, closing it retains the database lock (so no other
+// PR can start a concurrent apply on the same database) and retains stored
+// check state (so a close-and-reopen cannot turn in-flight apply state into a
+// passing check). Once the apply reaches a terminal state, closing the PR
+// releases the lock and deletes the stored check state.
 func TestE2EPRCloseCleanup(t *testing.T) {
 	dbName := "webhook_pr_close"
 	svc := setupE2EService(t, dbName)
@@ -2847,7 +2853,28 @@ func TestE2EPRCloseCleanup(t *testing.T) {
 
 	h := NewHandler(svc, nil, nil, slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError})))
 
-	// Send PR closed webhook
+	// Close the PR while the apply is running. The handler is invoked directly
+	// (not through the async webhook goroutine) so the retention assertions
+	// below observe a finished cleanup pass.
+	h.handlePRClosed("octocat/hello-world", 1, 12345)
+
+	lock, err := svc.Storage().Locks().Get(t.Context(), dbName, "mysql")
+	require.NoError(t, err)
+	require.NotNil(t, lock, "lock must be retained while the apply is running")
+	assert.Equal(t, "octocat/hello-world#1", lock.Owner)
+
+	check, err := svc.Storage().Checks().Get(t.Context(), "octocat/hello-world", 1, "staging", "mysql", dbName)
+	require.NoError(t, err)
+	require.NotNil(t, check, "stored check state must be retained while the apply is running")
+	assert.Equal(t, "action_required", check.Conclusion)
+
+	// Finish the apply, then close the PR again through the webhook path.
+	apply, err := svc.Storage().Applies().Get(t.Context(), applyID)
+	require.NoError(t, err)
+	require.NotNil(t, apply)
+	apply.State = state.Apply.Completed
+	require.NoError(t, svc.Storage().Applies().Update(t.Context(), apply))
+
 	req := buildPRWebhookRequest(t, prWebhookPayloadOpts{action: "closed"}, nil)
 	rr := httptest.NewRecorder()
 	h.ServeHTTP(rr, req)
@@ -2859,18 +2886,13 @@ func TestE2EPRCloseCleanup(t *testing.T) {
 	require.Eventually(t, func() bool {
 		lock, err := svc.Storage().Locks().Get(t.Context(), dbName, "mysql")
 		return err == nil && lock == nil
-	}, 5*time.Second, 100*time.Millisecond, "lock should be released on PR close")
+	}, 5*time.Second, 100*time.Millisecond, "lock should be released on PR close once the apply is terminal")
 
 	// Poll until check is deleted
 	require.Eventually(t, func() bool {
 		check, err := svc.Storage().Checks().Get(t.Context(), "octocat/hello-world", 1, "staging", "mysql", dbName)
 		return err == nil && check == nil
-	}, 5*time.Second, 100*time.Millisecond, "check should be deleted on PR close")
-
-	apply, err := svc.Storage().Applies().Get(t.Context(), applyID)
-	require.NoError(t, err)
-	require.NotNil(t, apply)
-	assert.Equal(t, state.Apply.Running, apply.State)
+	}, 5*time.Second, 100*time.Millisecond, "check should be deleted on PR close once the apply is terminal")
 }
 
 // TestE2EStaleCheckCleanup verifies that checks for databases no longer in the PR

--- a/pkg/webhook/webhook_e2e_test.go
+++ b/pkg/webhook/webhook_e2e_test.go
@@ -184,6 +184,10 @@ func setupE2EService(t *testing.T, appDBName string) *api.Service {
 	// Clean up any stale data from previous test runs (shared storage DB)
 	_, _ = schemabotDB.ExecContext(ctx, "DELETE FROM checks WHERE database_name = ?", appDBName)
 	_, _ = schemabotDB.ExecContext(ctx, "DELETE FROM checks WHERE repository = 'octocat/hello-world' AND pull_request = 1")
+	// Delete child apply_operations rows before their parent applies rows so the
+	// operator claim loop cannot re-claim orphan operations whose parent lookup
+	// returns nil.
+	_, _ = schemabotDB.ExecContext(ctx, "DELETE ao FROM apply_operations ao JOIN applies a ON a.id = ao.apply_id WHERE a.repository = 'octocat/hello-world' AND a.pull_request = 1")
 	_, _ = schemabotDB.ExecContext(ctx, "DELETE FROM applies WHERE repository = 'octocat/hello-world' AND pull_request = 1")
 	_, _ = schemabotDB.ExecContext(ctx, "DELETE FROM plans WHERE database_name = ?", appDBName)
 


### PR DESCRIPTION
Closing a PR previously released all of its conflict locks and deleted all of its stored check state unconditionally, so a close could let another PR start a concurrent apply on a database mid-apply, and a close-and-reopen could erase blocking state for an apply that already reached the target database.

PR-close cleanup now fails closed: while any apply for the PR is non-terminal, that apply's database lock is retained and the PR's stored check state is kept; if apply state cannot be read, nothing is released or deleted. The check store's PR-delete additionally excludes apply-owned in-progress rows at the SQL layer, so in-flight apply state survives close cleanup even if the applies lookup misses it. Once all applies are terminal, cleanup proceeds exactly as before. Both branches log with full triage identifiers and record a `pr_close_cleanup` metric.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) (claude-fable-5)