### PR TITLE
fix(github): protect apply-owned check state from plan writes on any commit

### DIFF
--- a/docs/check-runs.md
+++ b/docs/check-runs.md
@@ -586,9 +586,10 @@ On new commits:
 - Stale internal records with a started apply or rollback remain blocking
   because the live database may still change.
 - A plan result never overwrites an in-progress apply-owned record, regardless
-  of head SHA. The record is released only when the apply reaches a terminal
-  state or an explicit recovery path proves the target already matches the PR
-  schema.
+  of head SHA. Rollbacks hold the record through the same apply ID ownership,
+  so the record is released only when the owning apply or rollback reaches a
+  terminal state or an explicit recovery path proves the target already matches
+  the PR schema.
 
 ## Edge Cases
 

--- a/docs/check-runs.md
+++ b/docs/check-runs.md
@@ -585,9 +585,10 @@ On new commits:
   started for that row.
 - Stale internal records with a started apply or rollback remain blocking
   because the live database may still change.
-- A plan result for the same head SHA does not overwrite an in-progress apply
-  check. A plan result for a new head SHA clears `apply_id` and becomes the new
-  source of truth for databases still managed by the new PR head.
+- A plan result never overwrites an in-progress apply-owned record, regardless
+  of head SHA. The record is released only when the apply reaches a terminal
+  state or an explicit recovery path proves the target already matches the PR
+  schema.
 
 ## Edge Cases
 
@@ -665,9 +666,9 @@ On the new head:
 - Any stale webhook work for an older SHA is ignored when SchemaBot can verify
   that the PR head has moved on.
 
-If a new plan is for the same head SHA as a running apply, it does not overwrite
-the running `apply_id`. If a new plan is for a newer head SHA, it clears the old
-ownership marker and becomes the source of truth for that PR head.
+A plan never overwrites a running apply's ownership marker, regardless of head
+SHA. The running apply remains the source of truth for that database until it
+reaches a terminal state.
 
 ### New commit pushed while an apply is in progress
 
@@ -681,20 +682,21 @@ The `synchronize` webhook auto-plans the new PR head. Because GitHub branch
 protection evaluates checks on the current head commit, SchemaBot writes
 aggregate checks for the new SHA.
 
-For affected databases, the new plan result becomes the merge-gating source of
-truth for that head. If the new plan still has unapplied changes, the aggregate
-is `action_required`. If the live schema already matches the new desired schema,
-the aggregate can pass.
+For a database whose apply is still running, the new plan result is not stored:
+the apply-owned record keeps the aggregate on the new head `in_progress` and the
+PR stays blocked. A plan against a mid-apply database is not trustworthy — it
+diffs against a schema that is still changing — so it must not become the
+merge-gating source of truth or convert the record into a passing check.
 
-When the old apply watcher eventually finishes, it can complete the check only
-if the stored row still belongs to that `apply_id` and no newer apply exists for
-the same PR, environment, database type, and database name. If a new-head plan
-has replaced the row, the old watcher cannot mark the new PR head success or
-failure based on work started for an older commit.
+When the apply reaches a terminal state, it completes the record it still owns
+(provided no newer apply exists for the same PR, environment, database type, and
+database name). A subsequent plan — auto-plan on the next commit or a manual
+`schemabot plan` — then refreshes the record against the settled live schema and
+becomes the source of truth for the current head.
 
 This is conservative for commits that keep touching the same managed database:
-the new head must be proven by a plan against the current desired schema, not by
-blindly reusing a terminal result from work started on an older commit.
+the new head must be proven by a plan against the settled live schema, not by a
+plan taken while an apply was still mutating it.
 
 #### New head removes the schema changes before apply starts
 
@@ -882,6 +884,8 @@ because another SchemaBot pod can change the same row between those operations.
 SchemaBot uses `apply_id` as a durable ownership marker:
 
 - Apply start sets the internal record to `in_progress` and stores the apply ID.
+- Plan results never overwrite an `in_progress` row that has an `apply_id`,
+  regardless of which head SHA the plan was generated for.
 - Apply completion only updates the row if it is still `in_progress`, still has
   that same `apply_id`, and no newer apply exists for the same
   PR/environment/database.

--- a/pkg/storage/mysqlstore/checks.go
+++ b/pkg/storage/mysqlstore/checks.go
@@ -58,7 +58,7 @@ func (s *checkStore) Upsert(ctx context.Context, check *storage.Check) error {
 }
 
 // UpsertPlanResult stores plan-derived check state without overwriting
-// in-progress apply state for the same PR/environment/database/head SHA.
+// in-progress apply-owned state for the same PR/environment/database.
 func (s *checkStore) UpsertPlanResult(ctx context.Context, check *storage.Check) error {
 	var checkRunID any
 	if check.CheckRunID != 0 {
@@ -85,9 +85,12 @@ func (s *checkStore) UpsertPlanResult(ctx context.Context, check *storage.Check)
 		return err
 	}
 
-	// Preserve in-progress apply-owned state for the same PR commit. A plan
-	// result for that same commit is stale relative to the apply that already
-	// started.
+	// Preserve in-progress apply-owned state regardless of the plan's head SHA.
+	// Once an apply has started, the stored row is authoritative until the apply
+	// completes (CompleteForApply, MarkActionRequiredForApply) or an explicit
+	// recovery path releases it. A plan result — even from a newer PR commit that
+	// diffs cleanly against the mid-apply database — must not take ownership or
+	// convert the row into a passing check.
 	_, err = s.db.ExecContext(ctx, `
 		UPDATE checks
 		SET head_sha = ?,
@@ -100,10 +103,10 @@ func (s *checkStore) UpsertPlanResult(ctx context.Context, check *storage.Check)
 		    error_message = ?
 		WHERE repository = ? AND pull_request = ?
 		  AND environment = ? AND database_type = ? AND database_name = ?
-		  AND NOT (status = ? AND head_sha = ? AND apply_id IS NOT NULL)
+		  AND NOT (status = ? AND apply_id IS NOT NULL)
 	`, check.HeadSHA, checkRunID, check.HasChanges, check.Status, check.Conclusion, check.BlockingReason, check.ErrorMessage,
 		check.Repository, check.PullRequest, check.Environment, check.DatabaseType, check.DatabaseName,
-		checkStatusInProgress, check.HeadSHA)
+		checkStatusInProgress)
 	return err
 }
 

--- a/pkg/storage/mysqlstore/checks_test.go
+++ b/pkg/storage/mysqlstore/checks_test.go
@@ -865,7 +865,12 @@ func TestCheckStore_UpsertPlanResultReplacesUnownedInProgressCheck(t *testing.T)
 	require.Equal(t, int64(0), retrieved.ApplyID)
 }
 
-func TestCheckStore_UpsertPlanResultReplacesInProgressApplyOnNewHead(t *testing.T) {
+// An apply starts on one commit and a newer commit reverts the schema change
+// in-file. The auto-plan for the newer commit diffs against the mid-apply
+// database and reports a successful no-op, but it must not overwrite or take
+// ownership of the in-progress apply-owned row: the stored state keeps blocking
+// the PR until the apply itself completes and writes its real result.
+func TestCheckStore_UpsertPlanResultPreservesInProgressApplyOnNewHead(t *testing.T) {
 	clearTables(t)
 	ctx := t.Context()
 	store := New(testDB)
@@ -891,6 +896,65 @@ func TestCheckStore_UpsertPlanResultReplacesInProgressApplyOnNewHead(t *testing.
 		Environment:  "staging",
 		DatabaseType: "mysql",
 		DatabaseName: "testdb",
+		HasChanges:   false,
+		Status:       "completed",
+		Conclusion:   "success",
+	})
+	require.NoError(t, err)
+
+	retrieved, err := store.Checks().Get(ctx, "org/repo", 123, "staging", "mysql", "testdb")
+	require.NoError(t, err)
+	require.NotNil(t, retrieved)
+	assert.Equal(t, "oldsha", retrieved.HeadSHA)
+	assert.Equal(t, "in_progress", retrieved.Status)
+	assert.Empty(t, retrieved.Conclusion)
+	assert.True(t, retrieved.HasChanges)
+	assert.Equal(t, apply.ID, retrieved.ApplyID)
+
+	// The apply still owns the row, so its completion lands the real result.
+	completion := *retrieved
+	completion.Status = "completed"
+	completion.Conclusion = "success"
+	completion.HasChanges = false
+	updated, err := store.Checks().CompleteForApply(ctx, &completion, apply)
+	require.NoError(t, err)
+	require.True(t, updated)
+
+	retrieved, err = store.Checks().Get(ctx, "org/repo", 123, "staging", "mysql", "testdb")
+	require.NoError(t, err)
+	require.NotNil(t, retrieved)
+	assert.Equal(t, "completed", retrieved.Status)
+	assert.Equal(t, "success", retrieved.Conclusion)
+	assert.Equal(t, apply.ID, retrieved.ApplyID)
+}
+
+// A plan result for a newer commit replaces an in-progress row that no apply
+// owns: without a started apply there is nothing authoritative to protect, so
+// the plan write proceeds normally.
+func TestCheckStore_UpsertPlanResultReplacesUnownedInProgressCheckOnNewHead(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	require.NoError(t, store.Checks().Upsert(ctx, &storage.Check{
+		Repository:   "org/repo",
+		PullRequest:  123,
+		HeadSHA:      "oldsha",
+		Environment:  "staging",
+		DatabaseType: "mysql",
+		DatabaseName: "testdb",
+		HasChanges:   true,
+		Status:       "in_progress",
+		Conclusion:   "",
+	}))
+
+	err := store.Checks().UpsertPlanResult(ctx, &storage.Check{
+		Repository:   "org/repo",
+		PullRequest:  123,
+		HeadSHA:      "newsha",
+		Environment:  "staging",
+		DatabaseType: "mysql",
+		DatabaseName: "testdb",
 		HasChanges:   true,
 		Status:       "completed",
 		Conclusion:   "action_required",
@@ -900,10 +964,10 @@ func TestCheckStore_UpsertPlanResultReplacesInProgressApplyOnNewHead(t *testing.
 	retrieved, err := store.Checks().Get(ctx, "org/repo", 123, "staging", "mysql", "testdb")
 	require.NoError(t, err)
 	require.NotNil(t, retrieved)
-	require.Equal(t, "newsha", retrieved.HeadSHA)
-	require.Equal(t, "completed", retrieved.Status)
-	require.Equal(t, "action_required", retrieved.Conclusion)
-	require.Equal(t, int64(0), retrieved.ApplyID)
+	assert.Equal(t, "newsha", retrieved.HeadSHA)
+	assert.Equal(t, "completed", retrieved.Status)
+	assert.Equal(t, "action_required", retrieved.Conclusion)
+	assert.Equal(t, int64(0), retrieved.ApplyID)
 }
 
 func TestCheckStore_UpsertPlanResultClearsApplyIDWhenNotInProgress(t *testing.T) {

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -85,8 +85,10 @@ type CheckStore interface {
 	// Upsert creates or updates stored check state.
 	Upsert(ctx context.Context, check *Check) error
 
-	// UpsertPlanResult creates or updates stored check state from a plan result,
-	// but preserves in-progress apply state for the same PR/environment/database/head SHA.
+	// UpsertPlanResult creates or updates stored check state from a plan result.
+	// It fails closed: an in-progress apply-owned row for the same
+	// PR/environment/database is preserved regardless of head SHA, and is
+	// released only by apply completion or an explicit recovery path.
 	UpsertPlanResult(ctx context.Context, check *Check) error
 
 	// RecoverApplyOwnedCheckWithNoOpPlan updates same-head apply-owned stored check state

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -87,8 +87,10 @@ type CheckStore interface {
 
 	// UpsertPlanResult creates or updates stored check state from a plan result.
 	// It fails closed: an in-progress apply-owned row for the same
-	// PR/environment/database is preserved regardless of head SHA, and is
-	// released only by apply completion or an explicit recovery path.
+	// PR/environment/database is preserved regardless of head SHA. Ownership is
+	// released only by apply completion (CompleteForApply), rollback completion
+	// (MarkActionRequiredForApply), or the explicit same-head no-op recovery
+	// path (RecoverApplyOwnedCheckWithNoOpPlan).
 	UpsertPlanResult(ctx context.Context, check *Check) error
 
 	// RecoverApplyOwnedCheckWithNoOpPlan updates same-head apply-owned stored check state

--- a/pkg/webhook/webhook_e2e_test.go
+++ b/pkg/webhook/webhook_e2e_test.go
@@ -1767,11 +1767,13 @@ func TestE2EAggregateCheckStaleCleanup(t *testing.T) {
 	assert.False(t, prematurePassingAggregate.Load(), "passing aggregate was published before stale per-database records were cleaned")
 }
 
-// TestE2ENewHeadPlanReplacesInProgressApplyOwnership verifies the case where
-// an older commit has a running apply, then a newer commit still contains schema
-// changes and produces a fresh plan result. The old apply must not own or update
-// the new commit's check state.
-func TestE2ENewHeadPlanReplacesInProgressApplyOwnership(t *testing.T) {
+// TestE2ENewHeadPlanPreservesInProgressApplyOwnership verifies the case where
+// an older commit has a running apply, then a newer commit is pushed and
+// auto-planned. The running apply remains authoritative for the stored check
+// state: the new commit's plan result must not take ownership or overwrite it,
+// the aggregate on the new commit stays in_progress (blocking merge), and the
+// apply's own completion still lands its real result.
+func TestE2ENewHeadPlanPreservesInProgressApplyOwnership(t *testing.T) {
 	dbName := "webhook_new_head_replans"
 	svc := setupE2EService(t, dbName)
 	ctx := t.Context()
@@ -1823,7 +1825,8 @@ func TestE2ENewHeadPlanReplacesInProgressApplyOwnership(t *testing.T) {
 	}))
 
 	// Fake GitHub now serves the newer PR commit and schema files. Auto-plan
-	// should replace the old apply-owned check state with a new plan result.
+	// produces a plan result for the new commit, but the running apply keeps
+	// ownership of the stored check state.
 	mux := http.NewServeMux()
 	server := httptest.NewServer(mux)
 	t.Cleanup(server.Close)
@@ -1846,41 +1849,41 @@ func TestE2ENewHeadPlanReplacesInProgressApplyOwnership(t *testing.T) {
 	h.ServeHTTP(rr, req)
 	require.Equal(t, http.StatusOK, rr.Code)
 
-	// The new commit has a plan result but no started apply yet, so ApplyID is
-	// cleared while the check remains action_required.
-	require.Eventually(t, func() bool {
-		check, err := svc.Storage().Checks().Get(ctx, "octocat/hello-world", 1, "staging", "mysql", dbName)
-		return err == nil && check != nil &&
-			check.HeadSHA == "abc123" &&
-			check.Status == checkStatusCompleted &&
-			check.Conclusion == checkConclusionActionRequired &&
-			check.ApplyID == 0
-	}, webhookIntegrationPollDeadline, 200*time.Millisecond, "new-head plan should replace old apply ownership")
-
+	// The aggregate is re-created on the new commit and stays in_progress
+	// because the apply-owned per-database row still blocks it.
 	select {
 	case cr := <-result.checkRuns:
 		assert.Equal(t, aggregateCheckName, cr.Name)
 		assert.Equal(t, "abc123", cr.HeadSHA)
-		assert.Equal(t, checkStatusCompleted, cr.Status)
-		assert.Equal(t, checkConclusionActionRequired, cr.Conclusion)
+		assert.Equal(t, checkStatusInProgress, cr.Status)
+		assert.Empty(t, cr.Conclusion)
 	case <-time.After(webhookIntegrationCheckRunDeadline):
 		t.Fatal("timed out waiting for new-head aggregate check run")
 	}
 
-	// The old apply finishing later is an ownership miss. It must not overwrite
-	// the newer commit's action_required plan result.
-	apply.State = state.Apply.Completed
-	updated, err := h.updateCheckRecordForApplyResult(ctx, "octocat/hello-world", 1, apply)
-	require.NoError(t, err)
-	assert.False(t, updated, "old apply completion should not overwrite the new-head plan result")
-
+	// The running apply keeps ownership: the new commit's plan result must not
+	// overwrite the in-progress check state or clear the apply ID.
 	check, err := svc.Storage().Checks().Get(ctx, "octocat/hello-world", 1, "staging", "mysql", dbName)
 	require.NoError(t, err)
 	require.NotNil(t, check)
-	assert.Equal(t, "abc123", check.HeadSHA)
+	assert.Equal(t, "oldsha111", check.HeadSHA)
+	assert.Equal(t, checkStatusInProgress, check.Status)
+	assert.Empty(t, check.Conclusion)
+	assert.Equal(t, applyID, check.ApplyID)
+
+	// The apply still owns the check state, so its completion lands the real
+	// terminal result instead of missing ownership.
+	apply.State = state.Apply.Completed
+	updated, err := h.updateCheckRecordForApplyResult(ctx, "octocat/hello-world", 1, apply)
+	require.NoError(t, err)
+	assert.True(t, updated, "apply completion should update the check state it owns")
+
+	check, err = svc.Storage().Checks().Get(ctx, "octocat/hello-world", 1, "staging", "mysql", dbName)
+	require.NoError(t, err)
+	require.NotNil(t, check)
 	assert.Equal(t, checkStatusCompleted, check.Status)
-	assert.Equal(t, checkConclusionActionRequired, check.Conclusion)
-	assert.Equal(t, int64(0), check.ApplyID)
+	assert.Equal(t, checkConclusionSuccess, check.Conclusion)
+	assert.Equal(t, applyID, check.ApplyID)
 }
 
 func TestE2EAggregateCheckStaleCleanupBlocksStartedApply(t *testing.T) {


### PR DESCRIPTION
A plan-result write could overwrite an in-progress apply-owned check row when the plan was generated for a different head SHA — e.g. a commit that reverts the schema change in-file auto-plans against the mid-apply database, sees "no changes", and converts the blocking row into a passing check while also orphaning the apply's own completion write.

Plan results now never overwrite or take ownership of an in-progress apply-owned row regardless of head SHA; the aggregate on the new commit stays `in_progress` until the apply completes. Apply-owned rows are released only by apply completion, rollback completion, or the explicit same-head no-op recovery path. Check-run docs updated to match.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) (claude-fable-5)