### PR TITLE
fix(api): cap request body size on all API routes

### DIFF
--- a/pkg/api/control_handlers.go
+++ b/pkg/api/control_handlers.go
@@ -160,7 +160,7 @@ func (s *Service) decodeControlRequest(w http.ResponseWriter, r *http.Request, d
 	decoder := json.NewDecoder(r.Body)
 	decoder.DisallowUnknownFields()
 	if err := decoder.Decode(dest); err != nil {
-		s.writeError(w, http.StatusBadRequest, "invalid request body: "+err.Error())
+		s.writeBodyDecodeError(w, err)
 		return nil, nil, "", false
 	}
 	if *applyID == "" {
@@ -1487,7 +1487,7 @@ func (s *Service) handleRollbackPlan(w http.ResponseWriter, r *http.Request) {
 	decoder := json.NewDecoder(r.Body)
 	decoder.DisallowUnknownFields()
 	if err := decoder.Decode(&req); err != nil {
-		s.writeError(w, http.StatusBadRequest, "invalid request body: "+err.Error())
+		s.writeBodyDecodeError(w, err)
 		return
 	}
 	if req.ApplyID == "" {

--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -1278,6 +1278,56 @@ func TestEnqueueAuthorizedApplyWakesOperatorForQueuedApply(t *testing.T) {
 	}
 }
 
+// planBodyOfSize builds a /api/plan JSON payload of exactly totalSize bytes
+// by padding the schema file content, so tests can probe either side of the
+// API request body limit.
+func planBodyOfSize(t *testing.T, totalSize int) string {
+	const envelope = `{"database":"testdb","environment":"staging","type":"mysql","schema_files":{"testdb":{"files":{"big.sql":"%s"}}}}`
+	overhead := len(envelope) - len("%s")
+	require.Greater(t, totalSize, overhead)
+	return fmt.Sprintf(envelope, strings.Repeat("a", totalSize-overhead))
+}
+
+// A request body over the API limit is rejected with 413 and an error that
+// tells the caller the limit, instead of being buffered into server memory.
+func TestAPIRoutesRejectOversizedRequestBody(t *testing.T) {
+	svc := newTestService()
+	mux := http.NewServeMux()
+	svc.ConfigureRoutes(mux)
+
+	body := planBodyOfSize(t, maxAPIRequestBodyBytes+1)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/plan", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	mux.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusRequestEntityTooLarge, w.Code)
+	var resp apitypes.ErrorResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Contains(t, resp.Error, "request body exceeds the 32 MiB limit")
+	assert.Contains(t, resp.Error, "reduce the payload size")
+}
+
+// A request body just under the API limit passes the size check and reaches
+// normal request handling. The request can still fail validation downstream,
+// but never with the body-size error.
+func TestAPIRoutesAcceptBodyUnderSizeLimit(t *testing.T) {
+	svc := newTestService()
+	mux := http.NewServeMux()
+	svc.ConfigureRoutes(mux)
+
+	body := planBodyOfSize(t, maxAPIRequestBodyBytes-1)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/plan", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	mux.ServeHTTP(w, req)
+
+	assert.NotEqual(t, http.StatusRequestEntityTooLarge, w.Code)
+	assert.NotContains(t, w.Body.String(), "request body exceeds")
+}
+
 func TestPlanHandlerRejectsClientSuppliedSchemaPath(t *testing.T) {
 	svc := newTestService()
 	mux := http.NewServeMux()

--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -1305,7 +1305,7 @@ func TestAPIRoutesRejectOversizedRequestBody(t *testing.T) {
 	assert.Equal(t, http.StatusRequestEntityTooLarge, w.Code)
 	var resp apitypes.ErrorResponse
 	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
-	assert.Contains(t, resp.Error, "request body exceeds the 32 MiB limit")
+	assert.Contains(t, resp.Error, fmt.Sprintf("request body exceeds the %d MiB limit", maxAPIRequestBodyBytes>>20))
 	assert.Contains(t, resp.Error, "reduce the payload size")
 }
 

--- a/pkg/api/health_handlers.go
+++ b/pkg/api/health_handlers.go
@@ -2,6 +2,8 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/block/schemabot/pkg/apitypes"
@@ -57,4 +59,18 @@ func (s *Service) writeError(w http.ResponseWriter, status int, message string) 
 // Clients should match on error_code rather than parsing the error message.
 func (s *Service) writeErrorCode(w http.ResponseWriter, status int, code, message string) {
 	s.writeJSON(w, status, apitypes.ErrorResponse{Error: message, ErrorCode: code})
+}
+
+// writeBodyDecodeError maps a request-body decode failure to the right client
+// error. Bodies that exceed the API request body limit get a 413 that tells
+// the caller the limit so they can shrink the payload; every other decode
+// failure is malformed JSON and gets a 400 with the decoder's error.
+func (s *Service) writeBodyDecodeError(w http.ResponseWriter, err error) {
+	var maxBytesErr *http.MaxBytesError
+	if errors.As(err, &maxBytesErr) {
+		s.writeError(w, http.StatusRequestEntityTooLarge,
+			fmt.Sprintf("request body exceeds the %d MiB limit; reduce the payload size", maxAPIRequestBodyBytes>>20))
+		return
+	}
+	s.writeError(w, http.StatusBadRequest, "invalid request body: "+err.Error())
 }

--- a/pkg/api/health_handlers.go
+++ b/pkg/api/health_handlers.go
@@ -62,14 +62,14 @@ func (s *Service) writeErrorCode(w http.ResponseWriter, status int, code, messag
 }
 
 // writeBodyDecodeError maps a request-body decode failure to the right client
-// error. Bodies that exceed the API request body limit get a 413 that tells
-// the caller the limit so they can shrink the payload; every other decode
-// failure is malformed JSON and gets a 400 with the decoder's error.
+// error. Bodies that exceed the enforced request body limit get a 413 that
+// tells the caller the limit so they can shrink the payload; every other
+// decode failure gets a 400 with the decoder's error.
 func (s *Service) writeBodyDecodeError(w http.ResponseWriter, err error) {
 	var maxBytesErr *http.MaxBytesError
 	if errors.As(err, &maxBytesErr) {
 		s.writeError(w, http.StatusRequestEntityTooLarge,
-			fmt.Sprintf("request body exceeds the %d MiB limit; reduce the payload size", maxAPIRequestBodyBytes>>20))
+			fmt.Sprintf("request body exceeds the %d MiB limit; reduce the payload size", maxBytesErr.Limit>>20))
 		return
 	}
 	s.writeError(w, http.StatusBadRequest, "invalid request body: "+err.Error())

--- a/pkg/api/lock_handlers.go
+++ b/pkg/api/lock_handlers.go
@@ -57,7 +57,7 @@ type LockConflictResponse struct {
 func (s *Service) handleLockAcquire(w http.ResponseWriter, r *http.Request) {
 	var req LockAcquireRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		s.writeError(w, http.StatusBadRequest, "invalid request body")
+		s.writeBodyDecodeError(w, err)
 		return
 	}
 
@@ -118,7 +118,7 @@ func (s *Service) handleLockAcquire(w http.ResponseWriter, r *http.Request) {
 func (s *Service) handleLockRelease(w http.ResponseWriter, r *http.Request) {
 	var req LockReleaseRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		s.writeError(w, http.StatusBadRequest, "invalid request body")
+		s.writeBodyDecodeError(w, err)
 		return
 	}
 

--- a/pkg/api/plan_handlers.go
+++ b/pkg/api/plan_handlers.go
@@ -90,7 +90,7 @@ func (s *Service) handlePullSchema(w http.ResponseWriter, r *http.Request) {
 	decoder := json.NewDecoder(r.Body)
 	decoder.DisallowUnknownFields()
 	if err := decoder.Decode(&req); err != nil {
-		s.writeError(w, http.StatusBadRequest, "invalid request body: "+err.Error())
+		s.writeBodyDecodeError(w, err)
 		return
 	}
 
@@ -253,7 +253,7 @@ func (s *Service) handlePlan(w http.ResponseWriter, r *http.Request) {
 	decoder := json.NewDecoder(r.Body)
 	decoder.DisallowUnknownFields()
 	if err := decoder.Decode(&req); err != nil {
-		s.writeError(w, http.StatusBadRequest, "invalid request body: "+err.Error())
+		s.writeBodyDecodeError(w, err)
 		return
 	}
 
@@ -485,7 +485,7 @@ func (s *Service) handleApply(w http.ResponseWriter, r *http.Request) {
 	decoder := json.NewDecoder(r.Body)
 	decoder.DisallowUnknownFields()
 	if err := decoder.Decode(&req); err != nil {
-		s.writeError(w, http.StatusBadRequest, "invalid request body: "+err.Error())
+		s.writeBodyDecodeError(w, err)
 		return
 	}
 

--- a/pkg/api/service.go
+++ b/pkg/api/service.go
@@ -513,42 +513,65 @@ func (s *Service) HandleRollbackPlan(w http.ResponseWriter, r *http.Request) {
 // Route Registration
 // =============================================================================
 
+// maxAPIRequestBodyBytes caps the request body size for every API route.
+// The largest legitimate payloads are plan and pull requests carrying full
+// schema files — a database with hundreds of tables can reach a few megabytes
+// of DDL — so the cap leaves generous headroom for real schemas while
+// preventing a single oversized request from exhausting server memory.
+const maxAPIRequestBodyBytes = 32 << 20
+
+// limitRequestBody wraps a handler so its request body cannot exceed
+// maxAPIRequestBodyBytes. Reads past the limit fail with *http.MaxBytesError,
+// which writeBodyDecodeError maps to an actionable 413 response.
+func (s *Service) limitRequestBody(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		r.Body = http.MaxBytesReader(w, r.Body, maxAPIRequestBodyBytes)
+		next(w, r)
+	}
+}
+
 // ConfigureRoutes registers all HTTP API routes on the given mux.
+// Every route is wrapped with a request body size limit so oversized
+// requests are rejected instead of being buffered into memory.
 func (s *Service) ConfigureRoutes(mux *http.ServeMux) {
+	handle := func(pattern string, handler http.HandlerFunc) {
+		mux.HandleFunc(pattern, s.limitRequestBody(handler))
+	}
+
 	// Health endpoints
-	mux.HandleFunc("GET /health", s.handleHealth)
-	mux.HandleFunc("GET /tern-health/{deployment}/{environment}", s.handleTernHealth)
+	handle("GET /health", s.handleHealth)
+	handle("GET /tern-health/{deployment}/{environment}", s.handleTernHealth)
 
 	// Config API (for CLI to discover environments)
-	mux.HandleFunc("GET /api/databases/{database}/environments", s.handleDatabaseEnvironments)
+	handle("GET /api/databases/{database}/environments", s.handleDatabaseEnvironments)
 
 	// Orchestration API
-	mux.HandleFunc("POST /api/pull", s.handlePullSchema)
-	mux.HandleFunc("POST /api/plan", s.handlePlan)
-	mux.HandleFunc("POST /api/apply", s.handleApply)
-	mux.HandleFunc("GET /api/progress/apply/{apply_id}", s.handleProgressByApplyID)
-	mux.HandleFunc("GET /api/history/{database}", s.handleDatabaseHistory)
-	mux.HandleFunc("POST /api/cutover", s.handleCutover)
-	mux.HandleFunc("POST /api/stop", s.handleStop)
-	mux.HandleFunc("POST /api/start", s.handleStart)
-	mux.HandleFunc("POST /api/volume", s.handleVolume)
-	mux.HandleFunc("POST /api/revert", s.handleRevert)
-	mux.HandleFunc("POST /api/skip-revert", s.handleSkipRevert)
-	mux.HandleFunc("POST /api/rollback/plan", s.handleRollbackPlan)
-	mux.HandleFunc("GET /api/status", s.handleStatus)
-	mux.HandleFunc("GET /api/logs/{database}", s.handleLogs)
-	mux.HandleFunc("GET /api/logs", s.handleLogsWithoutDatabase)
+	handle("POST /api/pull", s.handlePullSchema)
+	handle("POST /api/plan", s.handlePlan)
+	handle("POST /api/apply", s.handleApply)
+	handle("GET /api/progress/apply/{apply_id}", s.handleProgressByApplyID)
+	handle("GET /api/history/{database}", s.handleDatabaseHistory)
+	handle("POST /api/cutover", s.handleCutover)
+	handle("POST /api/stop", s.handleStop)
+	handle("POST /api/start", s.handleStart)
+	handle("POST /api/volume", s.handleVolume)
+	handle("POST /api/revert", s.handleRevert)
+	handle("POST /api/skip-revert", s.handleSkipRevert)
+	handle("POST /api/rollback/plan", s.handleRollbackPlan)
+	handle("GET /api/status", s.handleStatus)
+	handle("GET /api/logs/{database}", s.handleLogs)
+	handle("GET /api/logs", s.handleLogsWithoutDatabase)
 
 	// Lock API (database-level locking)
-	mux.HandleFunc("POST /api/locks/acquire", s.handleLockAcquire)
-	mux.HandleFunc("DELETE /api/locks", s.handleLockRelease)
-	mux.HandleFunc("GET /api/locks/{database}/{dbtype}", s.handleLockGet)
-	mux.HandleFunc("GET /api/locks", s.handleLockList)
+	handle("POST /api/locks/acquire", s.handleLockAcquire)
+	handle("DELETE /api/locks", s.handleLockRelease)
+	handle("GET /api/locks/{database}/{dbtype}", s.handleLockGet)
+	handle("GET /api/locks", s.handleLockList)
 
 	// Settings API
-	mux.HandleFunc("GET /api/settings", s.handleSettingsList)
-	mux.HandleFunc("GET /api/settings/{key}", s.handleSettingsGet)
-	mux.HandleFunc("POST /api/settings", s.handleSettingsSet)
+	handle("GET /api/settings", s.handleSettingsList)
+	handle("GET /api/settings/{key}", s.handleSettingsGet)
+	handle("POST /api/settings", s.handleSettingsSet)
 
 	// GitHub webhook endpoint — registered externally via RegisterWebhook
 }

--- a/pkg/api/service.go
+++ b/pkg/api/service.go
@@ -513,7 +513,8 @@ func (s *Service) HandleRollbackPlan(w http.ResponseWriter, r *http.Request) {
 // Route Registration
 // =============================================================================
 
-// maxAPIRequestBodyBytes caps the request body size for every API route.
+// maxAPIRequestBodyBytes caps the request body size for every route
+// registered by ConfigureRoutes, including the health endpoints.
 // The largest legitimate payloads are plan and pull requests carrying full
 // schema files — a database with hundreds of tables can reach a few megabytes
 // of DDL — so the cap leaves generous headroom for real schemas while
@@ -530,7 +531,8 @@ func (s *Service) limitRequestBody(next http.HandlerFunc) http.HandlerFunc {
 	}
 }
 
-// ConfigureRoutes registers all HTTP API routes on the given mux.
+// ConfigureRoutes registers all HTTP routes — API and health endpoints —
+// on the given mux.
 // Every route is wrapped with a request body size limit so oversized
 // requests are rejected instead of being buffered into memory.
 func (s *Service) ConfigureRoutes(mux *http.ServeMux) {

--- a/pkg/api/settings_handlers.go
+++ b/pkg/api/settings_handlers.go
@@ -62,7 +62,7 @@ func (s *Service) handleSettingsSet(w http.ResponseWriter, r *http.Request) {
 		Value string `json:"value"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		s.writeError(w, http.StatusBadRequest, "invalid request body")
+		s.writeBodyDecodeError(w, err)
 		return
 	}
 


### PR DESCRIPTION
The webhook handler already caps request bodies, but `/api/*` routes decoded unbounded JSON — a single oversized POST could exhaust server memory and take down in-flight schema operations.

All API routes now enforce a 32 MiB body limit at the routing layer, sized with generous headroom for plan/pull payloads carrying full schema files. Oversized requests get an actionable 413 naming the limit, and all body-decode failures now flow through one shared error-mapping helper.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) (claude-fable-5)