### PR TITLE
fix(github): run all webhook-spawned goroutines with panic recovery

### DIFF
--- a/pkg/webhook/handler_test.go
+++ b/pkg/webhook/handler_test.go
@@ -913,3 +913,27 @@ func TestWebhookRepoAllowlistPullRequestRejectsUnregistered(t *testing.T) {
 
 // PR close bypass of the allowlist is tested in the integration suite
 // (TestE2EPRCloseCleanup) which has real storage via testcontainers.
+
+// A panic inside a webhook-spawned goroutine must not crash the server:
+// goSafe recovers it, logs the stack, and posts an error comment on the PR
+// so the user gets feedback instead of silence. This is the recovery wrapper
+// every async command dispatch (apply, plan, rollback, reactions) runs under.
+func TestGoSafeRecoversPanicAndPostsErrorComment(t *testing.T) {
+	client, mux := setupGitHubServer(t)
+	comments := make(chan string, 1)
+	mux.HandleFunc("POST /repos/octocat/hello-world/issues/1/comments", commentRecorder(t, comments))
+	installClient := ghclient.NewInstallationClient(client, testLogger())
+
+	h := &Handler{
+		ghClients: ghclient.NewSingleClientSet(defaultAppName, &fakeClientFactory{client: installClient}),
+		logger:    testLogger(),
+	}
+
+	h.goSafe("octocat/hello-world", 1, 12345, func() {
+		panic("boom")
+	})
+
+	body := requireComment(t, comments, "panic recovery comment")
+	assert.Contains(t, body, "Internal error: goroutine panic")
+	assert.Contains(t, body, "boom")
+}

--- a/pkg/webhook/issue_comment.go
+++ b/pkg/webhook/issue_comment.go
@@ -125,7 +125,9 @@ func (h *Handler) handleIssueComment(ctx context.Context, metricApp string, w ht
 		if result.Action == action.Plan {
 			// Plan without -e: run for all configured environments
 			h.logger.Info("plan without -e flag", "repo", repo, "pr", pr)
-			go h.handleMultiEnvPlan(repo, pr, result.Database, installationID, requestedBy, false)
+			h.goSafe(repo, pr, installationID, func() {
+				h.handleMultiEnvPlan(repo, pr, result.Database, installationID, requestedBy, false)
+			})
 			h.writeJSON(w, http.StatusOK, map[string]string{"message": "multi-env plan started"})
 			return
 		}
@@ -177,7 +179,7 @@ func (h *Handler) handleIssueComment(ctx context.Context, metricApp string, w ht
 	// the command. Placed after all skip/filter checks so only the owning
 	// instance reacts — avoids duplicate reactions in multi-instance setups.
 	if payload.Comment.ID > 0 && h.ghClients.Len() > 0 {
-		go func() {
+		h.goSafe(repo, pr, installationID, func() {
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
 			client, err := h.clientForRepo(repo, installationID)
@@ -188,7 +190,7 @@ func (h *Handler) handleIssueComment(ctx context.Context, metricApp string, w ht
 			if err := client.AddReactionToComment(ctx, repo, payload.Comment.ID, "eyes"); err != nil {
 				h.logger.Error("failed to add acknowledgment reaction", "error", err)
 			}
-		}()
+		})
 	}
 
 	// Reject -y/--yes on commands that don't support it


### PR DESCRIPTION
Webhook command dispatch runs each handler in a background goroutine. Most paths already went through `goSafe`, which recovers panics, logs the stack, and posts an error comment on the PR — but the multi-environment plan dispatch and the comment-reaction goroutine were spawned bare, so a panic there would crash the whole server and take down any in-flight applies.

This routes both through the shared recovery wrapper and adds a test proving a panicking webhook goroutine leaves the server running and posts an error comment instead of failing silently.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) (claude-fable-5)