### PR TITLE
fix(github): surface lock-release failures on the rollback no-op path

### DIFF
--- a/pkg/webhook/actor_authorization_test.go
+++ b/pkg/webhook/actor_authorization_test.go
@@ -652,12 +652,15 @@ func (s *actorAuthApplyStore) GetByDatabase(_ context.Context, _, _, _ string) (
 
 // actorAuthLockStore serves locks from a fixed set and records every lock
 // mutation so tests can assert which releases and acquisitions happened.
+// Setting releaseErr makes every Release call fail with that error, simulating
+// a storage outage during lock release.
 type actorAuthLockStore struct {
 	storage.LockStore
 	locks         []*storage.Lock
 	acquired      []*storage.Lock
 	released      []string
 	forceReleased []string
+	releaseErr    error
 }
 
 func (s *actorAuthLockStore) Get(_ context.Context, database, dbType string) (*storage.Lock, error) {
@@ -689,6 +692,9 @@ func (s *actorAuthLockStore) Acquire(_ context.Context, lock *storage.Lock) erro
 }
 
 func (s *actorAuthLockStore) Release(_ context.Context, database, _, _ string) error {
+	if s.releaseErr != nil {
+		return s.releaseErr
+	}
 	s.released = append(s.released, database)
 	return nil
 }

--- a/pkg/webhook/rollback.go
+++ b/pkg/webhook/rollback.go
@@ -212,7 +212,15 @@ func (h *Handler) handleRollbackConfirmCommand(repo string, pr int, environment,
 
 	// If no changes remain, release lock and notify
 	if len(planResp.FlatTables()) == 0 {
-		_ = h.service.Storage().Locks().Release(ctx, database, dbType, lockOwner)
+		if err := h.service.Storage().Locks().Release(ctx, database, dbType, lockOwner); err != nil {
+			h.logger.Error("rollback-confirm found nothing to roll back but failed to release the database lock; applies on this database will be blocked until the lock is released manually",
+				"repo", repo, "pr", pr, "database", database,
+				"database_type", dbType, "environment", environment,
+				"lock_owner", lockOwner, "error", err)
+			h.postComment(repo, pr, installationID,
+				templates.RenderRollbackAlreadyRolledBackLockHeld(database, environment, lockOwner))
+			return
+		}
 		h.postComment(repo, pr, installationID,
 			templates.RenderRollbackAlreadyRolledBack(database, environment))
 		return

--- a/pkg/webhook/rollback_test.go
+++ b/pkg/webhook/rollback_test.go
@@ -1,6 +1,10 @@
 package webhook
 
 import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -8,6 +12,13 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/block/schemabot/pkg/api"
+	ghclient "github.com/block/schemabot/pkg/github"
+	ternv1 "github.com/block/schemabot/pkg/proto/ternv1"
+	"github.com/block/schemabot/pkg/storage"
+	"github.com/block/schemabot/pkg/tern"
+	"github.com/block/schemabot/pkg/webhook/action"
 )
 
 func TestWebhookRollbackDispatch(t *testing.T) {
@@ -106,6 +117,104 @@ func TestWebhookRollbackMissingApplyIDAndEnv(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out waiting for comment")
 	}
+}
+
+// rollbackNoopTernClient returns a rollback plan with no schema changes,
+// simulating a database that already matches the original schema when
+// rollback-confirm re-plans for drift detection.
+type rollbackNoopTernClient struct {
+	tern.Client
+}
+
+func (c *rollbackNoopTernClient) RollbackPlan(context.Context, string) (*ternv1.PlanResponse, error) {
+	return &ternv1.PlanResponse{PlanId: "rollback-plan-noop"}, nil
+}
+
+// newRollbackConfirmNoopHandler builds a handler whose rollback-confirm
+// re-plan finds no remaining changes, backed by the supplied lock store and
+// logger, plus a channel that captures posted PR comments.
+func newRollbackConfirmNoopHandler(t *testing.T, locks *actorAuthLockStore, logger *slog.Logger) (*Handler, chan string) {
+	t.Helper()
+	client, mux := setupGitHubServer(t)
+	registerApplyDiscoveryEndpoints(t, mux, "orders")
+	comments := make(chan string, 2)
+	mux.HandleFunc("POST /repos/octocat/hello-world/issues/1/comments", commentRecorder(t, comments))
+
+	cfg := actorAuthTestConfig(true, func(cfg *api.ServerConfig) {
+		cfg.PRCommandAuthorization.AdminUsers = []string{"hubot"}
+	})
+	installClient := ghclient.NewInstallationClient(client, logger)
+	svc := api.New(&actorAuthStorage{locks: locks}, cfg,
+		map[string]tern.Client{"orders/staging": &rollbackNoopTernClient{}}, logger)
+	return &Handler{
+		service:   svc,
+		ghClients: ghclient.NewSingleClientSet(defaultAppName, &fakeClientFactory{client: installClient}),
+		logger:    logger,
+	}, comments
+}
+
+// prOwnedRollbackLock returns a lock held by the PR that issues the
+// rollback-confirm command in these tests.
+func prOwnedRollbackLock() *storage.Lock {
+	return &storage.Lock{
+		DatabaseName: "orders",
+		DatabaseType: storage.DatabaseTypeMySQL,
+		Owner:        "octocat/hello-world#1",
+		Repository:   "octocat/hello-world",
+		PullRequest:  1,
+	}
+}
+
+// TestHandleRollbackConfirmAlreadyRolledBackReleasesLock verifies the
+// rollback-confirm no-op path: when the database already matches the original
+// schema, the PR's database lock is released and the comment tells the
+// operator the lock is gone.
+func TestHandleRollbackConfirmAlreadyRolledBackReleasesLock(t *testing.T) {
+	locks := &actorAuthLockStore{locks: []*storage.Lock{prOwnedRollbackLock()}}
+	h, comments := newRollbackConfirmNoopHandler(t, locks, testLogger())
+
+	h.handleRollbackConfirmCommand("octocat/hello-world", 1, "staging", "", 12345, "hubot", CommandResult{Action: action.RollbackConfirm})
+
+	body := requireComment(t, comments, "already-rolled-back comment")
+	assert.Contains(t, body, "Already Rolled Back")
+	assert.Contains(t, body, "`orders`")
+	assert.Contains(t, body, "Lock released")
+	assert.NotContains(t, body, "failed to release")
+	assert.Equal(t, []string{"orders"}, locks.released)
+}
+
+// TestHandleRollbackConfirmAlreadyRolledBackLockReleaseFails verifies that
+// when the rollback-confirm no-op path cannot release the database lock, the
+// failure is logged with triage identifiers and the comment tells the
+// operator the lock is still held and how to clear it, instead of claiming
+// the lock was released.
+func TestHandleRollbackConfirmAlreadyRolledBackLockReleaseFails(t *testing.T) {
+	locks := &actorAuthLockStore{
+		locks:      []*storage.Lock{prOwnedRollbackLock()},
+		releaseErr: errors.New("storage unavailable"),
+	}
+	var logBuf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logBuf, nil))
+	h, comments := newRollbackConfirmNoopHandler(t, locks, logger)
+
+	h.handleRollbackConfirmCommand("octocat/hello-world", 1, "staging", "", 12345, "hubot", CommandResult{Action: action.RollbackConfirm})
+
+	body := requireComment(t, comments, "already-rolled-back lock-held comment")
+	assert.Contains(t, body, "Already Rolled Back")
+	assert.Contains(t, body, "failed to release the lock held by `octocat/hello-world#1`")
+	assert.Contains(t, body, "Applies on this database will be blocked until the lock is released")
+	assert.Contains(t, body, "schemabot unlock")
+	assert.Contains(t, body, "schemabot unlock -d orders --force")
+	assert.NotContains(t, body, "Lock released")
+	assert.Empty(t, locks.released, "failed release must not be recorded as released")
+
+	logs := logBuf.String()
+	assert.Contains(t, logs, "failed to release the database lock")
+	assert.Contains(t, logs, "octocat/hello-world")
+	assert.Contains(t, logs, "database=orders")
+	assert.Contains(t, logs, "environment=staging")
+	assert.Contains(t, logs, "lock_owner=octocat/hello-world#1")
+	assert.Contains(t, logs, "storage unavailable")
 }
 
 func TestWebhookApplyDispatch(t *testing.T) {

--- a/pkg/webhook/templates/rollback.go
+++ b/pkg/webhook/templates/rollback.go
@@ -144,6 +144,22 @@ func RenderRollbackAlreadyRolledBack(database, environment string) string {
 		database, environment)
 }
 
+// RenderRollbackAlreadyRolledBackLockHeld renders the message posted when
+// rollback-confirm finds no changes remain but the database lock could not be
+// released. The lock continues to block applies on the database until an
+// operator releases it.
+func RenderRollbackAlreadyRolledBackLockHeld(database, environment, lockOwner string) string {
+	return fmt.Sprintf("## Already Rolled Back\n\n"+
+		"**Database**: `%s` | **Environment**: `%s`\n\n"+
+		"The database schema already matches the original state, but SchemaBot failed to release the lock held by `%s`. "+
+		"Applies on this database will be blocked until the lock is released.\n\n"+
+		"Release it by commenting:\n"+
+		"```\nschemabot unlock\n```\n"+
+		"If the lock persists, force-release it:\n"+
+		"```\nschemabot unlock -d %s --force\n```",
+		database, environment, lockOwner, database)
+}
+
 // RenderRollbackNotAccepted renders the message posted when the apply service
 // rejects a rollback request (e.g. plan not found, validation error).
 func RenderRollbackNotAccepted(database, environment, errorMessage string) string {

--- a/pkg/webhook/templates/rollback_test.go
+++ b/pkg/webhook/templates/rollback_test.go
@@ -178,6 +178,19 @@ func TestRenderRollbackAlreadyRolledBack(t *testing.T) {
 	assert.Contains(t, rendered, "Lock released")
 }
 
+func TestRenderRollbackAlreadyRolledBackLockHeld(t *testing.T) {
+	rendered := RenderRollbackAlreadyRolledBackLockHeld("testapp", "staging", "block/myapp#42")
+	assert.Contains(t, rendered, "## Already Rolled Back")
+	assert.Contains(t, rendered, "`testapp`")
+	assert.Contains(t, rendered, "`staging`")
+	assert.Contains(t, rendered, "failed to release the lock held by `block/myapp#42`")
+	assert.Contains(t, rendered, "Applies on this database will be blocked until the lock is released")
+	assert.Contains(t, rendered, "schemabot unlock")
+	assert.Contains(t, rendered, "schemabot unlock -d testapp --force")
+	assert.NotContains(t, rendered, "Lock released",
+		"a failed release must not claim the lock was released")
+}
+
 func TestRenderRollbackNotAccepted(t *testing.T) {
 	rendered := RenderRollbackNotAccepted("testapp", "staging", "plan not found")
 	assert.Contains(t, rendered, "## Rollback Not Accepted")
@@ -188,14 +201,15 @@ func TestRenderRollbackNotAccepted(t *testing.T) {
 
 func TestRollbackTemplates_NoStrayWhitespace(t *testing.T) {
 	for name, body := range map[string]string{
-		"MissingApplyID":     RenderRollbackMissingApplyID(),
-		"ApplyNotFound":      RenderRollbackApplyNotFound("a"),
-		"BlockedByLockPR":    RenderRollbackBlockedByLock("d", "e", "o", "r", 1),
-		"BlockedByLockOwner": RenderRollbackBlockedByLock("d", "e", "o", "", 0),
-		"NothingToDo":        RenderRollbackNothingToDo("d", "e", "a"),
-		"LockNotOwned":       RenderRollbackLockNotOwned("d", "e", "o"),
-		"AlreadyRolledBack":  RenderRollbackAlreadyRolledBack("d", "e"),
-		"NotAccepted":        RenderRollbackNotAccepted("d", "e", "x"),
+		"MissingApplyID":            RenderRollbackMissingApplyID(),
+		"ApplyNotFound":             RenderRollbackApplyNotFound("a"),
+		"BlockedByLockPR":           RenderRollbackBlockedByLock("d", "e", "o", "r", 1),
+		"BlockedByLockOwner":        RenderRollbackBlockedByLock("d", "e", "o", "", 0),
+		"NothingToDo":               RenderRollbackNothingToDo("d", "e", "a"),
+		"LockNotOwned":              RenderRollbackLockNotOwned("d", "e", "o"),
+		"AlreadyRolledBack":         RenderRollbackAlreadyRolledBack("d", "e"),
+		"AlreadyRolledBackLockHeld": RenderRollbackAlreadyRolledBackLockHeld("d", "e", "o"),
+		"NotAccepted":               RenderRollbackNotAccepted("d", "e", "x"),
 	} {
 		assert.False(t, strings.HasPrefix(body, " ") || strings.HasPrefix(body, "\n"),
 			"%s body should not start with whitespace", name)


### PR DESCRIPTION
When `rollback-confirm` re-plans and finds the database already matches the original schema, a failure to release the database lock was silently discarded — the lock stayed held with no log and no operator-visible signal while future applies blocked on it.

The release error is now logged at error level with triage identifiers, and the PR comment tells the operator the lock is still held, that applies on the database will be blocked until it is released, and how to clear it with `schemabot unlock` (including the `--force` form). On successful release, behavior is unchanged.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) (claude-fable-5)