### PR TITLE
fix(tern): scope routing pending observers

### DIFF
--- a/pkg/tern/routing_client.go
+++ b/pkg/tern/routing_client.go
@@ -50,9 +50,12 @@ type RoutingClient struct {
 	applyOperationLookup ApplyOperationLookup
 	clientForDeployment  DeploymentClientFunc
 
-	observerMu      sync.Mutex
-	pendingObserver ProgressObserver
-	activeObservers map[int64]ProgressObserver
+	observerMu             sync.Mutex
+	pendingObserversByPlan map[string]ProgressObserver
+	activeObservers        map[int64]ProgressObserver
+
+	delegateApplyMu    sync.Mutex
+	delegateApplyLocks map[string]*sync.Mutex
 }
 
 var _ Client = (*RoutingClient)(nil)
@@ -72,12 +75,14 @@ func NewRoutingClient(config RoutingClientConfig) (*RoutingClient, error) {
 		return nil, fmt.Errorf("deployment client lookup is required")
 	}
 	return &RoutingClient{
-		resolver:             config.Resolver,
-		planLookup:           config.PlanLookup,
-		applyLookup:          config.ApplyLookup,
-		applyOperationLookup: config.ApplyOperationLookup,
-		clientForDeployment:  config.ClientForDeployment,
-		activeObservers:      make(map[int64]ProgressObserver),
+		resolver:               config.Resolver,
+		planLookup:             config.PlanLookup,
+		applyLookup:            config.ApplyLookup,
+		applyOperationLookup:   config.ApplyOperationLookup,
+		clientForDeployment:    config.ClientForDeployment,
+		pendingObserversByPlan: make(map[string]ProgressObserver),
+		activeObservers:        make(map[int64]ProgressObserver),
+		delegateApplyLocks:     make(map[string]*sync.Mutex),
 	}, nil
 }
 
@@ -147,7 +152,10 @@ func (c *RoutingClient) Apply(ctx context.Context, req *ternv1.ApplyRequest) (*t
 	if err != nil {
 		return nil, fmt.Errorf("get client for plan %q deployment %q environment %q: %w", req.PlanId, plan.Deployment, plan.Environment, err)
 	}
-	if observer := c.takePendingObserver(); observer != nil {
+	delegateApplyLock := c.delegateApplyLock(plan.Deployment, plan.Environment)
+	delegateApplyLock.Lock()
+	defer delegateApplyLock.Unlock()
+	if observer := c.takePendingObserverForPlan(req.PlanId); observer != nil {
 		client.SetPendingObserver(observer)
 		defer func() {
 			if err != nil {
@@ -320,11 +328,24 @@ func (c *RoutingClient) Endpoint() string { return "routing" }
 // clients until transport metadata becomes request-scoped.
 func (c *RoutingClient) IsRemote() bool { return false }
 
-// SetPendingObserver sets an observer that will be consumed by the next Apply call.
-func (c *RoutingClient) SetPendingObserver(observer ProgressObserver) {
+// SetPendingObserver is unsupported for routed applies because routing needs a
+// plan identifier to attach observers safely. Use SetPendingObserverForPlan.
+func (c *RoutingClient) SetPendingObserver(observer ProgressObserver) {}
+
+// SetPendingObserverForPlan sets an observer that will be consumed only by an
+// Apply call for the matching plan identifier.
+func (c *RoutingClient) SetPendingObserverForPlan(planIdentifier string, observer ProgressObserver) error {
+	if planIdentifier == "" {
+		return fmt.Errorf("plan identifier is required for plan-scoped pending observer")
+	}
 	c.observerMu.Lock()
 	defer c.observerMu.Unlock()
-	c.pendingObserver = observer
+	if observer == nil {
+		delete(c.pendingObserversByPlan, planIdentifier)
+		return nil
+	}
+	c.pendingObserversByPlan[planIdentifier] = observer
+	return nil
 }
 
 // SetObserver registers a progress observer for an active apply.
@@ -450,12 +471,26 @@ func operationScopedApply(apply *storage.Apply, operation *storage.ApplyOperatio
 	return &scopedApply
 }
 
-func (c *RoutingClient) takePendingObserver() ProgressObserver {
+func (c *RoutingClient) takePendingObserverForPlan(planIdentifier string) ProgressObserver {
 	c.observerMu.Lock()
 	defer c.observerMu.Unlock()
-	observer := c.pendingObserver
-	c.pendingObserver = nil
-	return observer
+	if observer, ok := c.pendingObserversByPlan[planIdentifier]; ok {
+		delete(c.pendingObserversByPlan, planIdentifier)
+		return observer
+	}
+	return nil
+}
+
+func (c *RoutingClient) delegateApplyLock(deployment, environment string) *sync.Mutex {
+	key := deployment + "/" + environment
+	c.delegateApplyMu.Lock()
+	defer c.delegateApplyMu.Unlock()
+	lock := c.delegateApplyLocks[key]
+	if lock == nil {
+		lock = &sync.Mutex{}
+		c.delegateApplyLocks[key] = lock
+	}
+	return lock
 }
 
 func (c *RoutingClient) attachObserver(client Client, applyID int64) {

--- a/pkg/tern/routing_client_test.go
+++ b/pkg/tern/routing_client_test.go
@@ -49,6 +49,7 @@ type routingRecordingClient struct {
 	resumeApply        *storage.Apply
 	resumeOperationID  int64
 	pendingObserverSet bool
+	pendingObserver    ProgressObserver
 	observerApplyID    int64
 	isRemote           bool
 }
@@ -89,6 +90,7 @@ func (c *routingRecordingClient) ResumeApplyOperation(_ context.Context, apply *
 
 func (c *routingRecordingClient) SetPendingObserver(observer ProgressObserver) {
 	c.pendingObserverSet = observer != nil
+	c.pendingObserver = observer
 }
 
 func (c *routingRecordingClient) IsRemote() bool {
@@ -104,6 +106,11 @@ type routingNoopObserver struct{}
 func (routingNoopObserver) OnProgress(*storage.Apply, []*storage.Task) {}
 
 func (routingNoopObserver) OnTerminal(*storage.Apply, []*storage.Task) {}
+
+type namedRoutingObserver struct {
+	routingNoopObserver
+	name string
+}
 
 func TestRoutingClientPullSchemaResolvesSingleExecutionTarget(t *testing.T) {
 	clients := map[string]*routingRecordingClient{
@@ -257,7 +264,7 @@ func TestRoutingClientApplyRoutesByStoredPlan(t *testing.T) {
 		ApplyLookup:         routingApplyLookup{},
 		ClientForDeployment: testDeploymentClientFunc(clients),
 	})
-	routingClient.SetPendingObserver(routingNoopObserver{})
+	require.NoError(t, routingClient.SetPendingObserverForPlan("plan-123", routingNoopObserver{}))
 
 	resp, err := routingClient.Apply(t.Context(), &ternv1.ApplyRequest{
 		PlanId:      "plan-123",
@@ -279,6 +286,142 @@ func TestRoutingClientApplyRoutesByStoredPlan(t *testing.T) {
 	assert.Equal(t, "production", clients["west/production"].applyReq.Environment)
 	assert.Equal(t, "stored-target", clients["west/production"].applyReq.Target)
 	assert.Equal(t, "stored-target", clients["west/production"].applyReq.Options["target"])
+}
+
+func TestRoutingClientApplyConsumesPlanScopedPendingObserver(t *testing.T) {
+	clients := map[string]*routingRecordingClient{
+		"west/production": {},
+	}
+	routingClient := newTestRoutingClient(t, RoutingClientConfig{
+		Resolver: routingResolverFunc(func(context.Context, routing.Request) ([]routing.ExecutionTarget, error) {
+			return nil, fmt.Errorf("apply must route from stored plan")
+		}),
+		PlanLookup: routingPlanLookup{
+			"plan-123": {
+				PlanIdentifier: "plan-123",
+				Database:       "stored-db",
+				DatabaseType:   storage.DatabaseTypeMySQL,
+				Deployment:     "west",
+				Target:         "stored-target",
+				Environment:    "production",
+			},
+			"plan-456": {
+				PlanIdentifier: "plan-456",
+				Database:       "stored-db",
+				DatabaseType:   storage.DatabaseTypeMySQL,
+				Deployment:     "west",
+				Target:         "stored-target",
+				Environment:    "production",
+			},
+		},
+		ApplyLookup:         routingApplyLookup{},
+		ClientForDeployment: testDeploymentClientFunc(clients),
+	})
+	planObserver := namedRoutingObserver{name: "plan-456"}
+	require.NoError(t, routingClient.SetPendingObserverForPlan("plan-456", planObserver))
+
+	_, err := routingClient.Apply(t.Context(), &ternv1.ApplyRequest{
+		PlanId:      "plan-123",
+		Environment: "production",
+	})
+	require.NoError(t, err)
+	assert.False(t, clients["west/production"].pendingObserverSet)
+
+	_, err = routingClient.Apply(t.Context(), &ternv1.ApplyRequest{
+		PlanId:      "plan-456",
+		Environment: "production",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, clients["west/production"].pendingObserver)
+	assert.Equal(t, ProgressObserver(planObserver), clients["west/production"].pendingObserver)
+
+	clients["west/production"].pendingObserverSet = false
+	clients["west/production"].pendingObserver = nil
+	_, err = routingClient.Apply(t.Context(), &ternv1.ApplyRequest{
+		PlanId:      "plan-456",
+		Environment: "production",
+	})
+	require.NoError(t, err)
+	assert.False(t, clients["west/production"].pendingObserverSet)
+}
+
+func TestRoutingClientSetPendingObserverForPlanValidatesPlanIdentifier(t *testing.T) {
+	routingClient := newTestRoutingClient(t, RoutingClientConfig{
+		Resolver:            routingResolverFunc(func(context.Context, routing.Request) ([]routing.ExecutionTarget, error) { return nil, nil }),
+		PlanLookup:          routingPlanLookup{},
+		ApplyLookup:         routingApplyLookup{},
+		ClientForDeployment: testDeploymentClientFunc(nil),
+	})
+
+	err := routingClient.SetPendingObserverForPlan("", routingNoopObserver{})
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "plan identifier is required")
+}
+
+func TestRoutingClientSetPendingObserverDoesNotAttachUnscopedObserver(t *testing.T) {
+	clients := map[string]*routingRecordingClient{
+		"west/production": {},
+	}
+	routingClient := newTestRoutingClient(t, RoutingClientConfig{
+		Resolver: routingResolverFunc(func(context.Context, routing.Request) ([]routing.ExecutionTarget, error) {
+			return nil, fmt.Errorf("apply must route from stored plan")
+		}),
+		PlanLookup: routingPlanLookup{
+			"plan-123": {
+				PlanIdentifier: "plan-123",
+				Database:       "stored-db",
+				DatabaseType:   storage.DatabaseTypeMySQL,
+				Deployment:     "west",
+				Target:         "stored-target",
+				Environment:    "production",
+			},
+		},
+		ApplyLookup:         routingApplyLookup{},
+		ClientForDeployment: testDeploymentClientFunc(clients),
+	})
+	routingClient.SetPendingObserver(routingNoopObserver{})
+
+	_, err := routingClient.Apply(t.Context(), &ternv1.ApplyRequest{
+		PlanId:      "plan-123",
+		Environment: "production",
+	})
+
+	require.NoError(t, err)
+	assert.False(t, clients["west/production"].pendingObserverSet)
+}
+
+func TestRoutingClientSetPendingObserverForPlanClearsObserver(t *testing.T) {
+	clients := map[string]*routingRecordingClient{
+		"west/production": {},
+	}
+	routingClient := newTestRoutingClient(t, RoutingClientConfig{
+		Resolver: routingResolverFunc(func(context.Context, routing.Request) ([]routing.ExecutionTarget, error) {
+			return nil, fmt.Errorf("apply must route from stored plan")
+		}),
+		PlanLookup: routingPlanLookup{
+			"plan-123": {
+				PlanIdentifier: "plan-123",
+				Database:       "stored-db",
+				DatabaseType:   storage.DatabaseTypeMySQL,
+				Deployment:     "west",
+				Target:         "stored-target",
+				Environment:    "production",
+			},
+		},
+		ApplyLookup:         routingApplyLookup{},
+		ClientForDeployment: testDeploymentClientFunc(clients),
+	})
+	require.NoError(t, routingClient.SetPendingObserverForPlan("plan-123", routingNoopObserver{}))
+	require.NoError(t, routingClient.SetPendingObserverForPlan("plan-123", nil))
+
+	_, err := routingClient.Apply(t.Context(), &ternv1.ApplyRequest{
+		PlanId:      "plan-123",
+		Environment: "production",
+	})
+
+	require.NoError(t, err)
+	assert.False(t, clients["west/production"].pendingObserverSet)
 }
 
 func TestRoutingClientApplyRejectsEnvironmentMismatch(t *testing.T) {
@@ -334,7 +477,7 @@ func TestRoutingClientApplyClearsPendingObserverOnError(t *testing.T) {
 		ApplyLookup:         routingApplyLookup{},
 		ClientForDeployment: testDeploymentClientFunc(clients),
 	})
-	routingClient.SetPendingObserver(routingNoopObserver{})
+	require.NoError(t, routingClient.SetPendingObserverForPlan("plan-123", routingNoopObserver{}))
 
 	_, err := routingClient.Apply(t.Context(), &ternv1.ApplyRequest{
 		PlanId:      "plan-123",


### PR DESCRIPTION
## Why
The routing Tern client is intended to become the stock server path for config-driven target routing. Before Apply handlers move onto that shared client, observer attachment has to be deterministic: the legacy “next Apply wins” slot can attach the wrong progress observer when multiple requests share one routing client.

## What
- Add plan-scoped pending observer registration to `RoutingClient`
- Make routed Apply ignore unscoped pending observers and consume only the matching plan observer
- Serialize delegate Apply calls per deployment/environment while preserving concurrency across different deployments

```diagram
Before: shared routing client + legacy pending observer
╭───────────────╮     ╭────────────────────╮
│ observer A    │────▶│ next routed Apply   │
╰───────────────╯     ╰─────────┬──────────╯
╭───────────────╮               │
│ observer B    │───────────────╯
╰───────────────╯
      │
      ▼
observer ownership depends on request timing

After: observer is bound to the plan being applied
╭────────────────────╮     ╭────────────────────╮
│ observer for plan A│────▶│ Apply(plan A)       │
╰────────────────────╯     ╰────────────────────╯
╭────────────────────╮     ╭────────────────────╮
│ observer for plan B│────▶│ Apply(plan B)       │
╰────────────────────╯     ╰────────────────────╯
```

## Risk Assessment
Low — this only changes the new routing client path before Apply handlers use it. Existing deployment-scoped clients and API Apply behavior are unchanged, and this removes an unsafe compatibility fallback rather than expanding behavior.

Generated with Amp
