### PR TITLE
fix(tern): route operator apply dispatch

### DIFF
--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -462,6 +462,8 @@ type mockTernClient struct {
 	resumeApply       *storage.Apply
 	resumeOperationID int64
 	resumeCh          chan *storage.Apply
+	observerApplyID   int64
+	observer          tern.ProgressObserver
 	isRemote          bool
 }
 
@@ -577,6 +579,8 @@ func (m *mockTernClient) Endpoint() string                                  { re
 func (m *mockTernClient) IsRemote() bool                                    { return m.isRemote }
 func (m *mockTernClient) SetPendingObserver(observer tern.ProgressObserver) {}
 func (m *mockTernClient) SetObserver(applyID int64, observer tern.ProgressObserver) {
+	m.observerApplyID = applyID
+	m.observer = observer
 }
 func (m *mockTernClient) Close() error { return nil }
 

--- a/pkg/api/operator.go
+++ b/pkg/api/operator.go
@@ -510,9 +510,9 @@ func (s *Service) resumeClaimedApply(ctx context.Context, workerID int, apply *s
 		metrics.RecordOperatorResumeFailure(ctx, apply.Database, "", apply.Environment, "missing_deployment")
 		return false, err
 	}
-	client, err := s.TernClient(deployment, apply.Environment)
+	client, err := s.RoutingTernClient()
 	if err != nil {
-		s.logger.Error("operator: failed to get client",
+		s.logger.Error("operator: failed to get routing client",
 			"worker", workerID,
 			"apply_id", apply.ApplyIdentifier,
 			"database", apply.Database,

--- a/pkg/api/operator_test.go
+++ b/pkg/api/operator_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/block/schemabot/pkg/state"
 	"github.com/block/schemabot/pkg/storage"
+	"github.com/block/schemabot/pkg/tern"
 )
 
 func TestOperatorWorkersConfig(t *testing.T) {
@@ -67,6 +68,43 @@ func (m *mockStorageWithApplyOperations) ApplyOperations() storage.ApplyOperatio
 func newOperatorTestService(opStore storage.ApplyOperationStore) *Service {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
 	return New(&mockStorageWithApplyOperations{applyOps: opStore}, testServerConfig(), nil, logger)
+}
+
+type noopProgressObserver struct{}
+
+func (noopProgressObserver) OnProgress(*storage.Apply, []*storage.Task) {}
+
+func (noopProgressObserver) OnTerminal(*storage.Apply, []*storage.Task) {}
+
+func TestResumeClaimedApplyRoutesRecoveredObserver(t *testing.T) {
+	deploymentClient := &mockTernClient{}
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	svc := New(&mockStorageWithApplyStores{
+		plans:   &staticPlanStore{},
+		applies: &staticApplyStore{},
+	}, &ServerConfig{}, map[string]tern.Client{
+		"east/staging": deploymentClient,
+	}, logger)
+	observer := noopProgressObserver{}
+	svc.OnApplyRecovered = func(apply *storage.Apply) {
+		svc.SetApplyObserver(apply.Database, apply.Deployment, apply.Environment, apply.ID, observer)
+	}
+	apply := &storage.Apply{
+		ID:              42,
+		ApplyIdentifier: "apply-42",
+		Database:        "appdb",
+		Deployment:      "east",
+		Environment:     "staging",
+		State:           state.Apply.Pending,
+	}
+
+	resumed, err := svc.resumeClaimedApply(t.Context(), 1, apply, 0)
+
+	require.NoError(t, err)
+	assert.True(t, resumed)
+	assert.Same(t, apply, deploymentClient.resumeApply)
+	assert.Equal(t, int64(42), deploymentClient.observerApplyID)
+	assert.Equal(t, observer, deploymentClient.observer)
 }
 
 // TestMarkOperationFromApplyState_MirrorsFailedRetryable verifies that a parent

--- a/pkg/api/service.go
+++ b/pkg/api/service.go
@@ -148,9 +148,9 @@ func (s *Service) SetApplyObserver(database, deployment, environment string, app
 			"database", database, "deployment", deployment, "environment", environment, "apply_id", applyID, "error", err)
 		return
 	}
-	client, err := s.TernClient(deployment, environment)
+	client, err := s.RoutingTernClient()
 	if err != nil {
-		s.logger.Error("failed to get tern client for observer",
+		s.logger.Error("failed to get routing tern client for observer",
 			"database", database, "deployment", deployment, "environment", environment, "apply_id", applyID, "error", err)
 		return
 	}

--- a/pkg/api/service.go
+++ b/pkg/api/service.go
@@ -152,9 +152,19 @@ func (s *Service) SetApplyObserver(database, deployment, environment string, app
 	if err != nil {
 		s.logger.Error("failed to get routing tern client for observer",
 			"database", database, "deployment", deployment, "environment", environment, "apply_id", applyID, "error", err)
+	} else {
+		client.SetObserver(applyID, observer)
+	}
+
+	// A known apply can already be running by the time its observer is created,
+	// so also attach directly to the concrete deployment client.
+	deploymentClient, err := s.TernClient(deployment, environment)
+	if err != nil {
+		s.logger.Error("failed to get tern client for observer",
+			"database", database, "deployment", deployment, "environment", environment, "apply_id", applyID, "error", err)
 		return
 	}
-	client.SetObserver(applyID, observer)
+	deploymentClient.SetObserver(applyID, observer)
 }
 
 // SetPendingObserver stores an observer for the next apply request for this


### PR DESCRIPTION
## Why
Operator workers still selected a deployment-scoped Tern client directly when resuming queued applies. Routing that dispatch through the routing wrapper keeps apply execution aligned with the stored execution target as SchemaBot moves toward config-driven deployment routing.

## What
- Route operator apply resume through `RoutingTernClient`
- Register recovered apply observers on the routing wrapper and active deployment client so PR progress updates attach whether the apply is about to resume or already running
- Cover the recovered-observer handoff with an operator unit test

```diagram
╭──────────────╮     ╭────────────────────╮     ╭────────────────────╮
│ Stored apply │────▶│ Operator worker    │────▶│ Routing TernClient │
╰──────────────╯     ╰────────────────────╯     ╰─────────┬──────────╯
                                                            │
                                                            ▼
                                                  ╭────────────────────╮
                                                  │ Deployment client  │
                                                  ╰────────────────────╯
```

## Risk Assessment
Low — this changes the operator dispatch seam for stored applies while preserving the same stored deployment metadata and observer behavior.

Generated with Amp
