### PR TITLE
fix(storage): pass owner to FindNextApplyOperation in stale-setup recovery test

### DIFF
--- a/pkg/storage/mysqlstore/apply_operations_test.go
+++ b/pkg/storage/mysqlstore/apply_operations_test.go
@@ -1027,7 +1027,7 @@ func TestApplyOperationStore_FindNextApplyOperation_RecoversStaleSetupPhase(t *t
 	`, id)
 	require.NoError(t, err)
 
-	claimed, err := store.ApplyOperations().FindNextApplyOperation(ctx)
+	claimed, err := store.ApplyOperations().FindNextApplyOperation(ctx, "operator-a")
 	require.NoError(t, err)
 	require.NotNil(t, claimed, "a stale running operation must be reclaimable when its parent apply crashed mid-setup")
 	assert.Equal(t, id, claimed.ID)


### PR DESCRIPTION
## What and Why ?

`FindNextApplyOperation` takes `(ctx, owner)`, but the stale-setup recovery integration test still called it with only `ctx`. The signature change and the test landed on `main` from separate PRs — each was green on its own base, but the merged tree fails to compile under the `integration` build tag. This was the last caller left on the old signature; the other call sites already pass an owner.

Because CI lints `PR ∪ main`, this break currently shows up as a red `lint (integration)` job on unrelated open PRs. Landing this fix clears it across all of them.

## Changes

- Pass an owner to `FindNextApplyOperation` in the stale-setup recovery integration test, matching the parent-claim owner used later in the same test.
