### PR TITLE
fix(github): explain empty-diff apply reconciliation

### DIFF
--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -118,10 +118,7 @@ The live database operation was already started and may continue independently o
      ```
      schemabot rollback apply-09f8ba28fb67492e -e staging
      ```
-     Then comment:
-     ```
-     schemabot plan -e staging -d testapp
-     ```
+     After rollback completes, do not run `schemabot plan` on this empty-diff PR unless you first add managed schema files back to the PR. Ask a SchemaBot operator to verify the live schema matches the current desired schema and clear the blocked check state.
 
 The PR check will remain blocked until the live database and PR schema files agree.
 
@@ -157,10 +154,8 @@ Choose one:
      ```
      schemabot rollback apply-09f8ba28fb67492e -e staging
      ```
-   - after rollback completes, comment:
-     ```
-     schemabot plan -e staging -d testapp
-     ```
+   - after rollback completes, do not run `schemabot plan` on this empty-diff PR unless you first add managed schema files back to the PR
+   - ask a SchemaBot operator to verify the live schema matches the current desired schema and clear the blocked check state
 
 The PR check will remain blocked until the live database and PR schema files agree.
 

--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -118,10 +118,9 @@ The live database operation was already started and may continue independently o
      ```
      schemabot rollback apply-09f8ba28fb67492e -e staging
      ```
-     After rollback completes, do not run `schemabot plan` on this empty-diff PR unless you first add managed schema files back to the PR. Ask a SchemaBot operator to verify the live schema matches the current desired schema and clear the blocked check state.
+     After rollback: push a no-op `schemabot.yaml` edit to trigger a fresh plan.
 
-The PR check will remain blocked until the live database and PR schema files agree.
-
+> 💬 Support: [#schema-help](https://chat.example.com/schema-help).
 </details>
 
 <details>
@@ -154,11 +153,9 @@ Choose one:
      ```
      schemabot rollback apply-09f8ba28fb67492e -e staging
      ```
-   - after rollback completes, do not run `schemabot plan` on this empty-diff PR unless you first add managed schema files back to the PR
-   - ask a SchemaBot operator to verify the live schema matches the current desired schema and clear the blocked check state
+   - after rollback: push a no-op `schemabot.yaml` edit to trigger a fresh plan
 
-The PR check will remain blocked until the live database and PR schema files agree.
-
+> 💬 Support: [#schema-help](https://chat.example.com/schema-help).
 </details>
 
 <details>

--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -15,7 +15,7 @@ All templates rendered with sample data.
 
 **Database**: `testapp` | **Schema Name**: `testapp` | **Environment**: `staging`
 
-*Requested by @aparajon at 2026-01-01 00:00:00 UTC · planned from [`abcdef1`](https://github.com/block/schemabot/commit/abcdef1234567890abcdef1234567890abcdef12)*
+*Requested by @jackjackbits at 2026-01-01 00:00:00 UTC · planned from [`abcdef1`](https://github.com/block/schemabot/commit/abcdef1234567890abcdef1234567890abcdef12)*
 
 ```sql
 CREATE TABLE `users` (
@@ -66,9 +66,103 @@ schemabot apply -e staging
 
 **Database**: `testapp` | **Schema Name**: `testapp` | **Environment**: `staging`
 
-*Requested by @aparajon at 2026-01-01 00:00:00 UTC · planned from [`abcdef1`](https://github.com/block/schemabot/commit/abcdef1234567890abcdef1234567890abcdef12)*
+*Requested by @jackjackbits at 2026-01-01 00:00:00 UTC · planned from [`abcdef1`](https://github.com/block/schemabot/commit/abcdef1234567890abcdef1234567890abcdef12)*
 
 ✅ **No schema changes detected**
+
+</details>
+
+<details>
+<summary><a name="no-managed-schema-changes"></a><strong>No Managed Schema Changes</strong></summary>
+
+
+## ✅ No Managed Schema Changes
+
+**Environment**: `staging`
+
+*Requested by @jackjackbits at 2026-03-15 14:30:00 UTC*
+
+This PR does not contain schema changes managed by SchemaBot. SchemaBot did not find any apply-owned state that requires live database reconciliation.
+
+</details>
+
+<details>
+<summary><a name="reconciliation-required-in-progress"></a><strong>Reconciliation Required (In Progress)</strong></summary>
+
+
+## ⚠️ Schema Change Reconciliation Required
+
+**Database**: `testapp` | **Environment**: `staging` | **Apply ID**: `apply-09f8ba28fb67492e`
+
+*Requested by @jackjackbits at 2026-03-15 14:30:00 UTC*
+
+SchemaBot is still applying a schema change from this PR, but the current PR no longer contains that change.
+
+The live database operation was already started and may continue independently of the current PR diff.
+
+### What to do next
+
+1. First, resolve the in-flight apply:
+   - Wait for SchemaBot to post the final apply result, or
+   - If stopping is supported for this database, comment:
+     ```
+     schemabot stop apply-09f8ba28fb67492e -e staging
+     ```
+
+2. Then reconcile the final live schema:
+   - If the live schema change should remain, add the schema change back to the PR, then comment:
+     ```
+     schemabot plan -e staging -d testapp
+     ```
+   - If the live schema change should not remain, roll it back:
+     ```
+     schemabot rollback apply-09f8ba28fb67492e -e staging
+     ```
+     Then comment:
+     ```
+     schemabot plan -e staging -d testapp
+     ```
+
+The PR check will remain blocked until the live database and PR schema files agree.
+
+</details>
+
+<details>
+<summary><a name="reconciliation-required-completed"></a><strong>Reconciliation Required (Completed)</strong></summary>
+
+
+## ⚠️ Schema Change Reconciliation Required
+
+**Database**: `testapp` | **Environment**: `staging` | **Apply ID**: `apply-09f8ba28fb67492e`
+
+*Requested by @jackjackbits at 2026-03-15 14:30:00 UTC*
+
+SchemaBot already applied a schema change from this PR, but the current PR no longer contains that change.
+
+The live database was already updated and may no longer match the current PR schema files.
+
+### What to do next
+
+Choose one:
+
+1. Keep the live schema change:
+   - add the schema change back to the PR
+   - comment:
+     ```
+     schemabot plan -e staging -d testapp
+     ```
+
+2. Undo the live schema change:
+   - comment:
+     ```
+     schemabot rollback apply-09f8ba28fb67492e -e staging
+     ```
+   - after rollback completes, comment:
+     ```
+     schemabot plan -e staging -d testapp
+     ```
+
+The PR check will remain blocked until the live database and PR schema files agree.
 
 </details>
 
@@ -80,7 +174,7 @@ schemabot apply -e staging
 
 **Database**: `commerce` | **Environment**: `staging`
 
-*Requested by @aparajon at 2026-01-01 00:00:00 UTC · planned from [`abcdef1`](https://github.com/block/schemabot/commit/abcdef1234567890abcdef1234567890abcdef12)*
+*Requested by @jackjackbits at 2026-01-01 00:00:00 UTC · planned from [`abcdef1`](https://github.com/block/schemabot/commit/abcdef1234567890abcdef1234567890abcdef12)*
 
 #### Keyspace: `commerce`
 #### VSchema
@@ -168,7 +262,7 @@ schemabot apply -e staging
 
 **Database**: `commerce` | **Environment**: `staging`
 
-*Requested by @aparajon at 2026-01-01 00:00:00 UTC · planned from [`abcdef1`](https://github.com/block/schemabot/commit/abcdef1234567890abcdef1234567890abcdef12)*
+*Requested by @jackjackbits at 2026-01-01 00:00:00 UTC · planned from [`abcdef1`](https://github.com/block/schemabot/commit/abcdef1234567890abcdef1234567890abcdef12)*
 
 🔒 **Lock acquired by** `acme/myapp#42` at 2026-03-14 10:30:00 UTC
 
@@ -265,7 +359,7 @@ schemabot unlock
 
 **Database**: `myapp` | **Environment**: `staging`
 
-*Requested by @aparajon at 2026-01-01 00:00:00 UTC · planned from [`abcdef1`](https://github.com/block/schemabot/commit/abcdef1234567890abcdef1234567890abcdef12)*
+*Requested by @jackjackbits at 2026-01-01 00:00:00 UTC · planned from [`abcdef1`](https://github.com/block/schemabot/commit/abcdef1234567890abcdef1234567890abcdef12)*
 
 #### Schema Name: `app_primary`
 ```sql
@@ -308,7 +402,7 @@ schemabot apply -e staging
 
 **Database**: `testapp`
 
-*Requested by @aparajon at 2026-01-01 00:00:00 UTC · planned from [`abcdef1`](https://github.com/block/schemabot/commit/abcdef1234567890abcdef1234567890abcdef12)*
+*Requested by @jackjackbits at 2026-01-01 00:00:00 UTC · planned from [`abcdef1`](https://github.com/block/schemabot/commit/abcdef1234567890abcdef1234567890abcdef12)*
 
 ### Staging & Production
 
@@ -361,7 +455,7 @@ schemabot apply -e production
 
 **Database**: `testapp`
 
-*Requested by @aparajon at 2026-01-01 00:00:00 UTC · planned from [`abcdef1`](https://github.com/block/schemabot/commit/abcdef1234567890abcdef1234567890abcdef12)*
+*Requested by @jackjackbits at 2026-01-01 00:00:00 UTC · planned from [`abcdef1`](https://github.com/block/schemabot/commit/abcdef1234567890abcdef1234567890abcdef12)*
 
 ### Staging
 
@@ -413,7 +507,7 @@ schemabot apply -e production
 
 **Database**: `testapp`
 
-*Requested by @aparajon at 2026-01-01 00:00:00 UTC · planned from [`abcdef1`](https://github.com/block/schemabot/commit/abcdef1234567890abcdef1234567890abcdef12)*
+*Requested by @jackjackbits at 2026-01-01 00:00:00 UTC · planned from [`abcdef1`](https://github.com/block/schemabot/commit/abcdef1234567890abcdef1234567890abcdef12)*
 
 ### Staging
 
@@ -578,7 +672,7 @@ That command wasn't recognized. Available commands:
 
 **Database**: `testapp` | **Environment**: `staging` | **Apply ID**: `apply-a1b2c3d4e5f6` | **Elapsed**: 8m
 
-*Applied by @aparajon at 2026-01-01 00:00:00 UTC*
+*Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
 
 📊 1/3 complete · 1 failed · 1 cancelled
 
@@ -623,7 +717,7 @@ schemabot apply -e staging
 
 **Environment**: `staging`
 
-*Requested by @aparajon at 2026-01-15 14:30:00 UTC*
+*Requested by @jackjackbits at 2026-01-15 14:30:00 UTC*
 
 No `schemabot.yaml` configuration file was found in this repository.
 
@@ -651,7 +745,7 @@ schemabot plan -e staging -d <database-name>
 
 **Environment**: `staging`
 
-*Requested by @aparajon at 2026-01-15 14:30:00 UTC*
+*Requested by @jackjackbits at 2026-01-15 14:30:00 UTC*
 
 This repository has multiple `schemabot.yaml` configurations.
 
@@ -677,7 +771,7 @@ schemabot plan -e staging -d <database-name>
 
 **Database**: `nonexistent-db` | **Environment**: `staging`
 
-*Requested by @aparajon at 2026-01-15 14:30:00 UTC*
+*Requested by @jackjackbits at 2026-01-15 14:30:00 UTC*
 
 No `schemabot.yaml` configuration with `database: nonexistent-db` was found in this repository.
 
@@ -692,7 +786,7 @@ Check that your `schemabot.yaml` file has the correct `database` field matching 
 
 **Environment**: `staging`
 
-*Requested by @aparajon at 2026-01-15 14:30:00 UTC*
+*Requested by @jackjackbits at 2026-01-15 14:30:00 UTC*
 
 The `schemabot.yaml` file must include `database` and `type` fields:
 
@@ -713,7 +807,7 @@ type: mysql
 
 **Environment**: `staging`
 
-*Requested by @aparajon at 2026-01-15 14:30:00 UTC*
+*Requested by @jackjackbits at 2026-01-15 14:30:00 UTC*
 
 ### Error
 
@@ -1020,7 +1114,7 @@ Production
 
 **Database**: `testapp` | **Environment**: `staging`
 
-*Requested by @aparajon at 2026-01-01 00:00:00 UTC*
+*Requested by @jackjackbits at 2026-01-01 00:00:00 UTC*
 
 Another PR currently holds the lock for this database.
 
@@ -1039,11 +1133,11 @@ Wait for the other PR to complete or ask the lock holder to run `schemabot unloc
 
 **Database**: `testapp` | **Environment**: `staging`
 
-*Requested by @aparajon at 2026-01-01 00:00:00 UTC*
+*Requested by @jackjackbits at 2026-01-01 00:00:00 UTC*
 
 A CLI session currently holds the lock for this database.
 
-**Locked by**: `cli:aparajon@macbook.local`
+**Locked by**: `cli:jackjackbits@macbook.local`
 **Since**: 2026-03-15 14:00:00 UTC
 
 Ask the lock holder to run `schemabot unlock` from their CLI, or force-unlock with:
@@ -1061,7 +1155,7 @@ schemabot unlock -d testapp --force
 
 **Database**: `testapp` | **Environment**: `staging`
 
-*Released by @aparajon at 2026-01-01 00:00:00 UTC*
+*Released by @jackjackbits at 2026-01-01 00:00:00 UTC*
 
 The database is now available for schema changes.
 
@@ -1075,7 +1169,7 @@ The database is now available for schema changes.
 
 **Database**: `testapp` | **Environment**: `staging`
 
-*Requested by @aparajon at 2026-01-01 00:00:00 UTC*
+*Requested by @jackjackbits at 2026-01-01 00:00:00 UTC*
 
 An apply is already running for this PR (apply ID: `apply-a1b2c3d4e5f6`, state: `running`).
 
@@ -1156,7 +1250,7 @@ schemabot apply -e production
 
 **Database**: `testapp` | **Environment**: `staging`
 
-*Requested by @aparajon at 2026-01-01 00:00:00 UTC*
+*Requested by @jackjackbits at 2026-01-01 00:00:00 UTC*
 
 Schema changes require approval from an authorized reviewer before applying.
 
@@ -1178,7 +1272,7 @@ Schema changes require approval from an authorized reviewer before applying.
 
 **Environment**: `staging`
 
-*Requested by @aparajon at  UTC*
+*Requested by @jackjackbits at  UTC*
 
 ### Error
 
@@ -1305,7 +1399,7 @@ Use --force to release a lock owned by someone else.
 🔒 Active Locks (2)
 
   1. testapp (mysql)
-     Owner: cli:aparajon@macbook
+     Owner: cli:jackjackbits@macbook
      Since: 30 minutes ago
      Last activity: 5 minutes ago
 
@@ -1341,7 +1435,7 @@ No active locks.
 
 **Database**: `testapp` | **Schema Name**: `testapp` | **Environment**: `staging`
 
-*Requested by @aparajon at 2026-01-01 00:00:00 UTC · planned from [`abcdef1`](https://github.com/block/schemabot/commit/abcdef1234567890abcdef1234567890abcdef12)*
+*Requested by @jackjackbits at 2026-01-01 00:00:00 UTC · planned from [`abcdef1`](https://github.com/block/schemabot/commit/abcdef1234567890abcdef1234567890abcdef12)*
 
 🔒 **Lock acquired by** `acme/myapp#42` at 2026-03-14 10:30:00 UTC
 
@@ -1395,7 +1489,7 @@ schemabot unlock
 
 **Database**: `testapp` | **Schema Name**: `testapp` | **Environment**: `staging`
 
-*Requested by @aparajon at 2026-01-01 00:00:00 UTC · planned from [`abcdef1`](https://github.com/block/schemabot/commit/abcdef1234567890abcdef1234567890abcdef12)*
+*Requested by @jackjackbits at 2026-01-01 00:00:00 UTC · planned from [`abcdef1`](https://github.com/block/schemabot/commit/abcdef1234567890abcdef1234567890abcdef12)*
 
 🔒 **Lock acquired by** `acme/myapp#42` at 2026-03-14 10:30:00 UTC
 
@@ -1451,7 +1545,7 @@ schemabot unlock
 
 **Database**: `commerce` | **Environment**: `staging`
 
-*Requested by @aparajon at 2026-01-01 00:00:00 UTC · planned from [`abcdef1`](https://github.com/block/schemabot/commit/abcdef1234567890abcdef1234567890abcdef12)*
+*Requested by @jackjackbits at 2026-01-01 00:00:00 UTC · planned from [`abcdef1`](https://github.com/block/schemabot/commit/abcdef1234567890abcdef1234567890abcdef12)*
 
 🔒 **Lock acquired by** `acme/myapp#42` at 2026-03-14 10:30:00 UTC
 
@@ -1548,7 +1642,7 @@ schemabot unlock
 
 **Database**: `testapp` | **Environment**: `staging` | **Apply ID**: `apply-a1b2c3d4e5f6`
 
-*Applied by @aparajon at 2026-01-01 00:00:00 UTC*
+*Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
 
 Schema changes are being applied. Progress updates will be posted as new comments.
 
@@ -1562,7 +1656,7 @@ Schema changes are being applied. Progress updates will be posted as new comment
 
 **Database**: `testapp` | **Environment**: `staging` | **Apply ID**: `apply-a1b2c3d4e5f6` | **Elapsed**: 8m
 
-*Applied by @aparajon at 2026-01-01 00:00:00 UTC*
+*Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
 
 ### Table Progress
 
@@ -1593,7 +1687,7 @@ _Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:0
 
 **Database**: `testapp` | **Environment**: `staging` | **Apply ID**: `apply-a1b2c3d4e5f6` | **Elapsed**: 8m
 
-*Applied by @aparajon at 2026-01-01 00:00:00 UTC*
+*Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
 
 ### Table Progress
 
@@ -1614,7 +1708,7 @@ ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
 
 **Database**: `testapp` | **Environment**: `staging` | **Apply ID**: `apply-a1b2c3d4e5f6` | **Elapsed**: 8m
 
-*Applied by @aparajon at 2026-01-01 00:00:00 UTC*
+*Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
 
 ### Table Progress
 
@@ -1644,7 +1738,7 @@ schemabot apply -e staging
 
 **Database**: `testapp` | **Environment**: `staging` | **Apply ID**: `apply-a1b2c3d4e5f6` | **Elapsed**: 8m
 
-*Applied by @aparajon at 2026-01-01 00:00:00 UTC*
+*Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
 
 ### Table Progress
 
@@ -1673,7 +1767,7 @@ schemabot start apply-a1b2c3d4e5f6
 
 **Database**: `testapp` | **Environment**: `staging` | **Apply ID**: `apply-a1b2c3d4e5f6` | **Elapsed**: 8m
 
-*Applied by @aparajon at 2026-01-01 00:00:00 UTC*
+*Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
 
 📊 3 queued
 
@@ -1717,7 +1811,7 @@ _Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:0
 
 **Database**: `testapp` | **Environment**: `staging` | **Apply ID**: `apply-a1b2c3d4e5f6` | **Elapsed**: 8m
 
-*Applied by @aparajon at 2026-01-01 00:00:00 UTC*
+*Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
 
 📊 1 running (22%) · 2 queued
 
@@ -1762,7 +1856,7 @@ _Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:0
 
 **Database**: `testapp` | **Environment**: `staging` | **Apply ID**: `apply-a1b2c3d4e5f6` | **Elapsed**: 8m
 
-*Applied by @aparajon at 2026-01-01 00:00:00 UTC*
+*Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
 
 📊 1/3 complete · 1 running (62%) · 1 queued
 
@@ -1807,7 +1901,7 @@ _Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:0
 
 **Database**: `testapp` | **Environment**: `staging` | **Apply ID**: `apply-a1b2c3d4e5f6` | **Elapsed**: 8m
 
-*Applied by @aparajon at 2026-01-01 00:00:00 UTC*
+*Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
 
 📊 1/3 complete · 1 running (Active) · 1 queued
 
@@ -1853,7 +1947,7 @@ _Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:0
 
 **Database**: `testapp` | **Environment**: `staging` | **Apply ID**: `apply-a1b2c3d4e5f6` | **Elapsed**: 8m
 
-*Applied by @aparajon at 2026-01-01 00:00:00 UTC*
+*Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
 
 📊 2/3 complete · 1 running (17%)
 
@@ -1898,7 +1992,7 @@ _Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:0
 
 **Database**: `testapp` | **Environment**: `staging` | **Apply ID**: `apply-a1b2c3d4e5f6` | **Elapsed**: 8m
 
-*Applied by @aparajon at 2026-01-01 00:00:00 UTC*
+*Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
 
 📊 3/3 complete
 
@@ -1933,7 +2027,7 @@ ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
 
 **Database**: `testapp` | **Environment**: `staging` | **Apply ID**: `apply-a1b2c3d4e5f6` | **Elapsed**: 8m
 
-*Applied by @aparajon at 2026-01-01 00:00:00 UTC*
+*Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
 
 📊 1 failed · 2 cancelled
 
@@ -1977,7 +2071,7 @@ schemabot apply -e staging
 
 **Database**: `testapp` | **Environment**: `staging` | **Apply ID**: `apply-a1b2c3d4e5f6` | **Elapsed**: 8m
 
-*Applied by @aparajon at 2026-01-01 00:00:00 UTC*
+*Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
 
 📊 1/3 complete · 1 failed · 1 cancelled
 
@@ -2021,7 +2115,7 @@ schemabot apply -e staging
 
 **Database**: `testapp` | **Environment**: `staging` | **Apply ID**: `apply-a1b2c3d4e5f6` | **Elapsed**: 8m
 
-*Applied by @aparajon at 2026-01-01 00:00:00 UTC*
+*Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
 
 📊 1/2 complete · 1 stopped
 
@@ -2058,7 +2152,7 @@ schemabot start apply-a1b2c3d4e5f6
 
 **Database**: `testapp` | **Environment**: `staging` | **Apply ID**: `apply-a1b2c3d4e5f6` | **Elapsed**: 8m
 
-*Applied by @aparajon at 2026-01-01 00:00:00 UTC*
+*Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
 
 **0/3** table(s) ready for cutover — waiting on 3
 
@@ -2104,7 +2198,7 @@ _Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:0
 
 **Database**: `testapp` | **Environment**: `staging` | **Apply ID**: `apply-a1b2c3d4e5f6` | **Elapsed**: 8m
 
-*Applied by @aparajon at 2026-01-01 00:00:00 UTC*
+*Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
 
 **0/3** table(s) ready for cutover — waiting on 3
 
@@ -2237,7 +2331,7 @@ _Apply ID: `apply-a1b2c3d4e5f6`_
 
 **Database**: `testapp` | **Environment**: `staging` | **Apply ID**: `apply-a1b2c3d4e5f6` | **Duration**: 8m
 
-*Applied by @aparajon at 2026-01-01 00:00:00 UTC*
+*Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
 
 > ⚠️ **Error:** table users failed: schema change failed: unsafe warning: Field 'name' doesn't have a default value
 
@@ -2284,7 +2378,7 @@ schemabot apply -e staging
 
 **Database**: `testapp` | **Environment**: `staging` | **Apply ID**: `apply-a1b2c3d4e5f6` | **Duration**: 45m
 
-*Applied by @aparajon at 2026-01-01 00:00:00 UTC*
+*Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
 
 1 of 2 tables completed before stop.
 
@@ -2371,7 +2465,7 @@ _Apply ID: `apply-a1b2c3d4e5f6`_
 
 **Database**: `testapp` | **Environment**: `staging` | **Apply ID**: `apply-a1b2c3d4e5f6` | **Duration**: 3h 30m
 
-*Applied by @aparajon at 2026-01-01 00:00:00 UTC*
+*Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
 
 > ⚠️ **Error:** Error 1062: Duplicate entry '12345' for key 'addresses.idx_user_id'
 
@@ -2435,7 +2529,7 @@ schemabot apply -e staging
 
 **Database**: `testapp` | **Environment**: `staging` | **Apply ID**: `apply-a1b2c3d4e5f6` | **Duration**: 8m
 
-*Applied by @aparajon at 2026-01-01 00:00:00 UTC*
+*Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
 
 > ⚠️ **Error:** table customers.addresses failed: Error 1205: Lock wait timeout exceeded
 
@@ -4019,7 +4113,7 @@ No schema changes found for database 'new-db'
 
 **Database**: `testapp` | **Schema Name**: `testapp` | **Environment**: `staging`
 
-*Requested by @aparajon at 2026-01-01 00:00:00 UTC · planned from [`abcdef1`](https://github.com/block/schemabot/commit/abcdef1234567890abcdef1234567890abcdef12)*
+*Requested by @jackjackbits at 2026-01-01 00:00:00 UTC · planned from [`abcdef1`](https://github.com/block/schemabot/commit/abcdef1234567890abcdef1234567890abcdef12)*
 
 🔒 **Lock acquired by** `acme/myapp#42` at 2026-03-14 10:30:00 UTC
 
@@ -4074,7 +4168,7 @@ schemabot unlock
 
 **Database**: `testapp` | **Schema Name**: `testapp` | **Environment**: `staging`
 
-*Requested by @aparajon at 2026-01-01 00:00:00 UTC · planned from [`abcdef1`](https://github.com/block/schemabot/commit/abcdef1234567890abcdef1234567890abcdef12)*
+*Requested by @jackjackbits at 2026-01-01 00:00:00 UTC · planned from [`abcdef1`](https://github.com/block/schemabot/commit/abcdef1234567890abcdef1234567890abcdef12)*
 
 🔒 **Lock acquired by** `acme/myapp#42` at 2026-03-14 10:30:00 UTC
 
@@ -4131,7 +4225,7 @@ schemabot unlock
 
 **Database**: `testapp` | **Environment**: `staging` | **Apply ID**: `apply-a1b2c3d4e5f6`
 
-*Applied by @aparajon at 2026-01-01 00:00:00 UTC*
+*Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
 
 Schema changes are being applied. Progress updates will be posted as new comments.
 
@@ -4146,7 +4240,7 @@ Schema changes are being applied. Progress updates will be posted as new comment
 
 **Database**: `testapp` | **Environment**: `staging`
 
-*Released by @aparajon at 2026-01-01 00:00:00 UTC*
+*Released by @jackjackbits at 2026-01-01 00:00:00 UTC*
 
 The database is now available for schema changes.
 
@@ -4161,7 +4255,7 @@ The database is now available for schema changes.
 
 **Database**: `testapp` | **Environment**: `staging`
 
-*Requested by @aparajon at 2026-01-01 00:00:00 UTC*
+*Requested by @jackjackbits at 2026-01-01 00:00:00 UTC*
 
 Another PR currently holds the lock for this database.
 
@@ -4181,11 +4275,11 @@ Wait for the other PR to complete or ask the lock holder to run `schemabot unloc
 
 **Database**: `testapp` | **Environment**: `staging`
 
-*Requested by @aparajon at 2026-01-01 00:00:00 UTC*
+*Requested by @jackjackbits at 2026-01-01 00:00:00 UTC*
 
 A CLI session currently holds the lock for this database.
 
-**Locked by**: `cli:aparajon@macbook.local`
+**Locked by**: `cli:jackjackbits@macbook.local`
 **Since**: 2026-03-15 14:00:00 UTC
 
 Ask the lock holder to run `schemabot unlock` from their CLI, or force-unlock with:
@@ -4204,7 +4298,7 @@ schemabot unlock -d testapp --force
 
 **Database**: `testapp` | **Environment**: `staging`
 
-*Requested by @aparajon at 2026-01-01 00:00:00 UTC*
+*Requested by @jackjackbits at 2026-01-01 00:00:00 UTC*
 
 An apply is already running for this PR (apply ID: `apply-a1b2c3d4e5f6`, state: `running`).
 
@@ -4290,7 +4384,7 @@ schemabot apply -e production
 
 **Database**: `testapp` | **Environment**: `staging`
 
-*Requested by @aparajon at 2026-01-01 00:00:00 UTC*
+*Requested by @jackjackbits at 2026-01-01 00:00:00 UTC*
 
 Schema changes require approval from an authorized reviewer before applying.
 
@@ -4313,7 +4407,7 @@ Schema changes require approval from an authorized reviewer before applying.
 
 **Environment**: `staging`
 
-*Requested by @aparajon at  UTC*
+*Requested by @jackjackbits at  UTC*
 
 ### Error
 

--- a/pkg/cmd/commands/preview.go
+++ b/pkg/cmd/commands/preview.go
@@ -71,6 +71,9 @@ func (cmd *PreviewCmd) Run(g *Globals) error {
 		templates.PreviewCLIOutput(previewType)
 	// Comment template types
 	case templates.PreviewCommentPlan, templates.PreviewCommentPlanEmpty,
+		templates.PreviewCommentNoManagedSchema,
+		templates.PreviewCommentReconcileInProgress,
+		templates.PreviewCommentReconcileCompleted,
 		templates.PreviewCommentMultiEnv, templates.PreviewCommentMultiEnvDiff,
 		templates.PreviewCommentMultiEnvLint,
 		templates.PreviewCommentVitessPlan, templates.PreviewCommentVitessApplyPlan,
@@ -229,6 +232,9 @@ Interactive TUI:
 Comment Templates (GitHub PR comments):
   comment_plan                  Plan comment with DDL changes + lint violations
   comment_plan_empty            Plan comment with no changes
+  comment_no_managed_schema     No managed schema changes in current PR
+  comment_reconcile_in_progress Empty diff with an in-progress apply
+  comment_reconcile_completed   Empty diff with a completed apply
   comment_multi_env             Multi-env plan (identical plans, deduplicated)
   comment_multi_env_diff        Multi-env plan (different plans per environment)
   comment_multi_env_lint        Multi-env plan with lint violations

--- a/pkg/cmd/internal/templates/preview.go
+++ b/pkg/cmd/internal/templates/preview.go
@@ -110,6 +110,9 @@ const (
 	// Comment template previews (GitHub PR comments)
 	PreviewCommentPlan                  PreviewType = "comment_plan"                    // Plan comment with DDL changes + lint violations
 	PreviewCommentPlanEmpty             PreviewType = "comment_plan_empty"              // Plan comment with no changes
+	PreviewCommentNoManagedSchema       PreviewType = "comment_no_managed_schema"       // No managed schema changes in current PR
+	PreviewCommentReconcileInProgress   PreviewType = "comment_reconcile_in_progress"   // Empty diff with in-progress apply-owned state
+	PreviewCommentReconcileCompleted    PreviewType = "comment_reconcile_completed"     // Empty diff with completed apply-owned state
 	PreviewCommentMultiEnv              PreviewType = "comment_multi_env"               // Multi-env plan (identical, deduplicated)
 	PreviewCommentMultiEnvDiff          PreviewType = "comment_multi_env_diff"          // Multi-env plan (different per env)
 	PreviewCommentMultiEnvLint          PreviewType = "comment_multi_env_lint"          // Multi-env plan with lint violations

--- a/pkg/cmd/internal/templates/preview_comment.go
+++ b/pkg/cmd/internal/templates/preview_comment.go
@@ -39,6 +39,9 @@ func previewCommentAllOutput() {
 	}{
 		{"PLAN COMMENT", func() { fmt.Print(webhooktemplates.PreviewCommentPlan()) }},
 		{"PLAN COMMENT (NO CHANGES)", func() { fmt.Print(webhooktemplates.PreviewCommentPlanNoChanges()) }},
+		{"NO MANAGED SCHEMA CHANGES", func() { fmt.Print(webhooktemplates.PreviewCommentNoManagedSchemaChanges()) }},
+		{"RECONCILIATION REQUIRED (IN PROGRESS)", func() { fmt.Print(webhooktemplates.PreviewCommentSchemaReconciliationInProgress()) }},
+		{"RECONCILIATION REQUIRED (COMPLETED)", func() { fmt.Print(webhooktemplates.PreviewCommentSchemaReconciliationCompleted()) }},
 		{"SCHEMA CHANGE APPLY (LOCKED)", func() { fmt.Print(webhooktemplates.PreviewCommentApplyPlan()) }},
 		{"SCHEMA CHANGE APPLY (UNSAFE + ALLOWED)", func() { fmt.Print(webhooktemplates.PreviewCommentApplyPlanUnsafe()) }},
 		{"UNSAFE CHANGES BLOCKED", func() { fmt.Print(webhooktemplates.PreviewCommentUnsafeBlocked()) }},
@@ -145,6 +148,9 @@ func previewCommentPlanAllOutput() {
 	}{
 		{"MYSQL PLAN", func() { fmt.Print(webhooktemplates.PreviewCommentPlan()) }},
 		{"MYSQL PLAN (NO CHANGES)", func() { fmt.Print(webhooktemplates.PreviewCommentPlanNoChanges()) }},
+		{"NO MANAGED SCHEMA CHANGES", func() { fmt.Print(webhooktemplates.PreviewCommentNoManagedSchemaChanges()) }},
+		{"RECONCILIATION REQUIRED (IN PROGRESS)", func() { fmt.Print(webhooktemplates.PreviewCommentSchemaReconciliationInProgress()) }},
+		{"RECONCILIATION REQUIRED (COMPLETED)", func() { fmt.Print(webhooktemplates.PreviewCommentSchemaReconciliationCompleted()) }},
 		{"VITESS PLAN", func() { fmt.Print(webhooktemplates.PreviewCommentVitessPlan()) }},
 		{"SCHEMA CHANGE APPLY (LOCKED + OPTIONS)", func() { fmt.Print(webhooktemplates.PreviewCommentVitessApplyPlan()) }},
 		{"MYSQL MULTI-SCHEMA PLAN", func() { fmt.Print(webhooktemplates.PreviewCommentMySQLMultiSchema()) }},

--- a/pkg/cmd/internal/templates/preview_dispatch.go
+++ b/pkg/cmd/internal/templates/preview_dispatch.go
@@ -113,6 +113,12 @@ func PreviewCLIOutput(previewType PreviewType) {
 		fmt.Print(webhooktemplates.PreviewCommentPlan())
 	case PreviewCommentPlanEmpty:
 		fmt.Print(webhooktemplates.PreviewCommentPlanNoChanges())
+	case PreviewCommentNoManagedSchema:
+		fmt.Print(webhooktemplates.PreviewCommentNoManagedSchemaChanges())
+	case PreviewCommentReconcileInProgress:
+		fmt.Print(webhooktemplates.PreviewCommentSchemaReconciliationInProgress())
+	case PreviewCommentReconcileCompleted:
+		fmt.Print(webhooktemplates.PreviewCommentSchemaReconciliationCompleted())
 	case PreviewCommentMultiEnv:
 		fmt.Print(webhooktemplates.PreviewCommentMultiEnvPlan())
 	case PreviewCommentMultiEnvDiff:

--- a/pkg/cmd/internal/templates/preview_lock.go
+++ b/pkg/cmd/internal/templates/preview_lock.go
@@ -9,7 +9,7 @@ func previewLockAcquiredOutput() {
 	WriteLockAcquired(LockData{
 		Database:     "testapp",
 		DatabaseType: "mysql",
-		Owner:        "cli:aparajon@macbook",
+		Owner:        "cli:jackjackbits@macbook",
 		CreatedAt:    previewTime,
 	})
 }
@@ -38,7 +38,7 @@ func previewLocksListOutput() {
 		{
 			Database:     "testapp",
 			DatabaseType: "mysql",
-			Owner:        "cli:aparajon@macbook",
+			Owner:        "cli:jackjackbits@macbook",
 			CreatedAt:    previewTime.Add(-30 * time.Minute),
 			UpdatedAt:    previewTime.Add(-5 * time.Minute),
 		},

--- a/pkg/webhook/apply_handlers.go
+++ b/pkg/webhook/apply_handlers.go
@@ -25,6 +25,14 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 	}
 	defer cancel()
 
+	if handled, err := h.handleNoManagedSchemaChangesForCommand(ctx, client, repo, pr, installationID, action.Apply, environment, databaseName, requestedBy); err != nil {
+		h.logger.Error("failed to check whether apply command needs schema change reconciliation", "repo", repo, "pr", pr, "environment", environment, "database", databaseName, "error", err)
+		h.postCommandError(repo, pr, installationID, action.Apply, environment, requestedBy, err.Error())
+		return
+	} else if handled {
+		return
+	}
+
 	// Discover config and fetch schema files from PR
 	schemaResult, err := h.createManagedSchemaRequestFromPR(ctx, client, repo, pr, environment, databaseName, action.Apply)
 	if err != nil {
@@ -336,6 +344,14 @@ func (h *Handler) handleApplyConfirmCommand(repo string, pr int, environment, da
 		return
 	}
 	defer cancel()
+
+	if handled, err := h.handleNoManagedSchemaChangesForCommand(ctx, client, repo, pr, installationID, action.ApplyConfirm, environment, databaseName, requestedBy); err != nil {
+		h.logger.Error("failed to check whether apply-confirm command needs schema change reconciliation", "repo", repo, "pr", pr, "environment", environment, "database", databaseName, "error", err)
+		h.postCommandError(repo, pr, installationID, action.ApplyConfirm, environment, requestedBy, err.Error())
+		return
+	} else if handled {
+		return
+	}
 
 	// Discover database config from PR's schemabot.yaml
 	schemaResult, err := h.createManagedSchemaRequestFromPR(ctx, client, repo, pr, environment, databaseName, action.ApplyConfirm)

--- a/pkg/webhook/check_runs.go
+++ b/pkg/webhook/check_runs.go
@@ -55,7 +55,7 @@ type checkBlockReason struct {
 // users in per-database check state.
 var schemaRemovedAfterApplyBlock = checkBlockReason{
 	blockingReason: "schema_removed_after_apply_started",
-	message:        "Schema changes were removed from the PR after an apply started; operator action is required before this check can pass.",
+	message:        "The current PR no longer contains a schema change whose apply has already started; reconciliation is required before this check can pass.",
 }
 
 // rollbackCompletedBlock is used after a rollback succeeds. The target

--- a/pkg/webhook/check_runs.go
+++ b/pkg/webhook/check_runs.go
@@ -60,10 +60,10 @@ var schemaRemovedAfterApplyBlock = checkBlockReason{
 
 // rollbackCompletedBlock is used after a rollback succeeds. The target
 // environment no longer has the schema requested by the PR, so the check must
-// stay blocked until the schema change is applied again or the PR is updated.
+// stay blocked until the PR and live schema are reconciled.
 var rollbackCompletedBlock = checkBlockReason{
 	blockingReason: "rollback_completed",
-	message:        "Schema changes were rolled back in this environment; apply again before this check can pass.",
+	message:        "Schema changes were rolled back in this environment; apply the PR schema changes again, or reconcile the PR and live schema before this check can pass.",
 }
 
 // githubConfigDiscoveryUnavailableBlock is used when GitHub is unavailable

--- a/pkg/webhook/handler_test.go
+++ b/pkg/webhook/handler_test.go
@@ -165,6 +165,29 @@ func TestRenderPRCommentSupportChannelFooter(t *testing.T) {
 		assert.Contains(t, body, "> 💬 Support: [#schema-help](https://example.com/schema-help).")
 	})
 
+	t.Run("appends to reconciliation required comments", func(t *testing.T) {
+		cfg := &api.ServerConfig{
+			SupportChannel: api.SupportChannelConfig{
+				Name: "#schema-help",
+				URL:  "https://example.com/schema-help",
+			},
+		}
+		h := &Handler{service: api.New(nil, cfg, nil, testLogger())}
+
+		body := h.renderPRComment(templates.RenderSchemaChangeReconciliationRequired(templates.SchemaChangeReconciliationData{
+			RequestedBy: "alice",
+			Timestamp:   "2026-06-14 12:34:56",
+			Items: []templates.SchemaChangeReconciliationItem{{
+				Database:    "orders",
+				Environment: "staging",
+				ApplyID:     "apply-1234",
+				State:       "completed",
+			}},
+		}))
+
+		assert.Contains(t, body, "> 💬 Support: [#schema-help](https://example.com/schema-help).")
+	})
+
 	t.Run("escapes markdown link text", func(t *testing.T) {
 		cfg := &api.ServerConfig{
 			SupportChannel: api.SupportChannelConfig{

--- a/pkg/webhook/issue_comment.go
+++ b/pkg/webhook/issue_comment.go
@@ -375,6 +375,7 @@ func shouldShowSupportChannel(body string) bool {
 		"not found",
 		"no valid",
 		"multiple",
+		"reconciliation required",
 	} {
 		if strings.Contains(firstLine, marker) {
 			return true

--- a/pkg/webhook/plan.go
+++ b/pkg/webhook/plan.go
@@ -32,6 +32,16 @@ func (h *Handler) handlePlanCommand(w http.ResponseWriter, repo string, pr int, 
 		return
 	}
 
+	if handled, err := h.handleNoManagedSchemaChangesForCommand(ctx, client, repo, pr, installationID, action.Plan, environment, databaseName, requestedBy); err != nil {
+		h.logger.Error("failed to check whether plan command needs schema change reconciliation", "repo", repo, "pr", pr, "environment", environment, "database", databaseName, "error", err)
+		h.postCommandError(repo, pr, installationID, action.Plan, environment, requestedBy, err.Error())
+		h.writeJSON(w, http.StatusOK, map[string]string{"message": "schema reconciliation check failed"})
+		return
+	} else if handled {
+		h.writeJSON(w, http.StatusOK, map[string]string{"message": "no managed schema changes handled"})
+		return
+	}
+
 	// Discover config and fetch schema files from PR
 	schemaResult, err := h.createManagedSchemaRequestFromPR(ctx, client, repo, pr, environment, databaseName, action.Plan)
 	if err != nil {

--- a/pkg/webhook/schema_reconciliation.go
+++ b/pkg/webhook/schema_reconciliation.go
@@ -46,17 +46,10 @@ func (h *Handler) handleNoManagedSchemaChangesForCommand(ctx context.Context, cl
 		return true, nil
 	}
 
-	h.logger.Info("command found no managed schema changes and no apply-owned reconciliation state",
+	h.logger.Debug("command found no apply-owned reconciliation state; continuing with normal config discovery",
 		"repo", repo, "pr", pr, "environment", environment,
 		"database", databaseName, "action", commandName)
-	h.postComment(repo, pr, installationID, templates.RenderNoManagedSchemaChanges(templates.SchemaErrorData{
-		RequestedBy:  requestedBy,
-		Timestamp:    templates.NowFunc().UTC().Format("2006-01-02 15:04:05"),
-		Environment:  environment,
-		DatabaseName: databaseName,
-		CommandName:  commandName,
-	}))
-	return true, nil
+	return false, nil
 }
 
 func prHasCurrentSchemaBotFiles(files []ghclient.PRFile) bool {

--- a/pkg/webhook/schema_reconciliation.go
+++ b/pkg/webhook/schema_reconciliation.go
@@ -1,0 +1,161 @@
+package webhook
+
+import (
+	"context"
+	"fmt"
+	"path"
+	"strings"
+
+	ghclient "github.com/block/schemabot/pkg/github"
+	"github.com/block/schemabot/pkg/state"
+	"github.com/block/schemabot/pkg/storage"
+	"github.com/block/schemabot/pkg/webhook/templates"
+)
+
+type schemaChangeReconciliationRecord struct {
+	check *storage.Check
+	apply *storage.Apply
+}
+
+func (h *Handler) handleNoManagedSchemaChangesForCommand(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, installationID int64, commandName, environment, databaseName, requestedBy string) (bool, error) {
+	files, err := client.FetchPRFiles(ctx, repo, pr)
+	if err != nil {
+		return false, fmt.Errorf("fetch PR files before %s: %w", commandName, err)
+	}
+	if prHasCurrentSchemaBotFiles(files) {
+		h.logger.Debug("command found current SchemaBot-related files in PR; continuing with normal config discovery",
+			"repo", repo, "pr", pr, "environment", environment,
+			"database", databaseName, "action", commandName)
+		return false, nil
+	}
+
+	records, err := h.schemaChangeReconciliationRecords(ctx, repo, pr, environment, databaseName)
+	if err != nil {
+		return true, err
+	}
+	if len(records) > 0 {
+		h.logger.Info("command blocked because current PR no longer contains an apply-owned schema change",
+			"repo", repo, "pr", pr, "environment", environment,
+			"database", databaseName, "action", commandName,
+			"record_count", len(records))
+		h.postComment(repo, pr, installationID, templates.RenderSchemaChangeReconciliationRequired(templates.SchemaChangeReconciliationData{
+			RequestedBy: requestedBy,
+			Timestamp:   templates.NowFunc().UTC().Format("2006-01-02 15:04:05"),
+			Items:       schemaChangeReconciliationItems(records),
+		}))
+		return true, nil
+	}
+
+	h.logger.Info("command found no managed schema changes and no apply-owned reconciliation state",
+		"repo", repo, "pr", pr, "environment", environment,
+		"database", databaseName, "action", commandName)
+	h.postComment(repo, pr, installationID, templates.RenderNoManagedSchemaChanges(templates.SchemaErrorData{
+		RequestedBy:  requestedBy,
+		Timestamp:    templates.NowFunc().UTC().Format("2006-01-02 15:04:05"),
+		Environment:  environment,
+		DatabaseName: databaseName,
+		CommandName:  commandName,
+	}))
+	return true, nil
+}
+
+func prHasCurrentSchemaBotFiles(files []ghclient.PRFile) bool {
+	for _, file := range files {
+		if strings.HasSuffix(file.Filename, ".sql") || strings.HasSuffix(file.Filename, "vschema.json") {
+			return true
+		}
+		if path.Base(file.Filename) == ghclient.ConfigFileName && !strings.EqualFold(file.Status, "removed") {
+			return true
+		}
+	}
+	return false
+}
+
+func (h *Handler) schemaChangeReconciliationRecords(ctx context.Context, repo string, pr int, environment, databaseName string) ([]schemaChangeReconciliationRecord, error) {
+	if h.service == nil || h.service.Storage() == nil {
+		return nil, fmt.Errorf("SchemaBot storage is not configured for schema change reconciliation checks")
+	}
+
+	checks, err := h.service.Storage().Checks().GetByPR(ctx, repo, pr)
+	if err != nil {
+		return nil, fmt.Errorf("load stored check state for schema change reconciliation repo %s pr %d: %w", repo, pr, err)
+	}
+
+	var records []schemaChangeReconciliationRecord
+	for _, check := range checks {
+		if check == nil {
+			h.logger.Warn("skipping nil stored check during schema change reconciliation",
+				"repo", repo, "pr", pr, "environment", environment,
+				"database", databaseName)
+			continue
+		}
+		if isAggregateCheck(check) {
+			h.logger.Debug("skipping aggregate stored check during schema change reconciliation",
+				"repo", repo, "pr", pr, "environment", check.Environment,
+				"check_id", check.ID)
+			continue
+		}
+		if environment != "" && check.Environment != environment {
+			h.logger.Debug("skipping stored check for a different environment during schema change reconciliation",
+				"repo", repo, "pr", pr, "requested_environment", environment,
+				"check_environment", check.Environment, "database", check.DatabaseName,
+				"check_id", check.ID)
+			continue
+		}
+		if databaseName != "" && check.DatabaseName != databaseName {
+			h.logger.Debug("skipping stored check for a different database during schema change reconciliation",
+				"repo", repo, "pr", pr, "requested_database", databaseName,
+				"check_database", check.DatabaseName, "environment", check.Environment,
+				"check_id", check.ID)
+			continue
+		}
+		if !checkHasStartedApply(check) {
+			h.logger.Debug("skipping plan-only stored check during schema change reconciliation",
+				"repo", repo, "pr", pr, "database", check.DatabaseName,
+				"environment", check.Environment, "check_id", check.ID)
+			continue
+		}
+
+		var apply *storage.Apply
+		if check.ApplyID != 0 {
+			apply, err = h.service.Storage().Applies().Get(ctx, check.ApplyID)
+			if err != nil {
+				return nil, fmt.Errorf("load apply %d for schema change reconciliation repo %s pr %d database %s environment %s: %w",
+					check.ApplyID, repo, pr, check.DatabaseName, check.Environment, err)
+			}
+			if apply == nil {
+				h.logger.Warn("stored check references missing apply during schema change reconciliation; check will still block",
+					"repo", repo, "pr", pr, "database", check.DatabaseName,
+					"environment", check.Environment, "check_id", check.ID,
+					"apply_id", check.ApplyID)
+			}
+		} else {
+			h.logger.Warn("stored check has started-apply state without an apply ID during schema change reconciliation; check will still block",
+				"repo", repo, "pr", pr, "database", check.DatabaseName,
+				"environment", check.Environment, "check_id", check.ID,
+				"status", check.Status)
+		}
+
+		records = append(records, schemaChangeReconciliationRecord{check: check, apply: apply})
+	}
+
+	return records, nil
+}
+
+func schemaChangeReconciliationItems(records []schemaChangeReconciliationRecord) []templates.SchemaChangeReconciliationItem {
+	items := make([]templates.SchemaChangeReconciliationItem, 0, len(records))
+	for _, record := range records {
+		item := templates.SchemaChangeReconciliationItem{
+			Database:    record.check.DatabaseName,
+			Environment: record.check.Environment,
+			InProgress:  record.check.Status == checkStatusInProgress,
+		}
+		if record.apply != nil {
+			item.ApplyID = record.apply.ApplyIdentifier
+			item.State = record.apply.State
+			item.InProgress = !state.IsTerminalApplyState(record.apply.State)
+		}
+		items = append(items, item)
+	}
+	return items
+}

--- a/pkg/webhook/schema_reconciliation_test.go
+++ b/pkg/webhook/schema_reconciliation_test.go
@@ -1,0 +1,89 @@
+package webhook
+
+import (
+	"testing"
+
+	ghclient "github.com/block/schemabot/pkg/github"
+	"github.com/block/schemabot/pkg/state"
+	"github.com/block/schemabot/pkg/storage"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPRHasCurrentSchemaBotFiles(t *testing.T) {
+	tests := []struct {
+		name  string
+		files []ghclient.PRFile
+		want  bool
+	}{
+		{
+			name: "empty diff",
+		},
+		{
+			name: "non schema file",
+			files: []ghclient.PRFile{
+				{Filename: "README.md", Status: "modified"},
+			},
+		},
+		{
+			name: "added schema file",
+			files: []ghclient.PRFile{
+				{Filename: "schema/widgets/users.sql", Status: "added"},
+			},
+			want: true,
+		},
+		{
+			name: "removed schema file still needs normal discovery",
+			files: []ghclient.PRFile{
+				{Filename: "schema/widgets/users.sql", Status: "removed"},
+			},
+			want: true,
+		},
+		{
+			name: "removed vschema file still needs normal discovery",
+			files: []ghclient.PRFile{
+				{Filename: "schema/widgets/vschema.json", Status: "removed"},
+			},
+			want: true,
+		},
+		{
+			name: "modified config file needs normal discovery",
+			files: []ghclient.PRFile{
+				{Filename: "schema/schemabot.yaml", Status: "modified"},
+			},
+			want: true,
+		},
+		{
+			name: "removed config alone is not a current managed schema change",
+			files: []ghclient.PRFile{
+				{Filename: "schema/schemabot.yaml", Status: "removed"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, prHasCurrentSchemaBotFiles(tt.files))
+		})
+	}
+}
+
+func TestSchemaChangeReconciliationItemsUseApplyStateOverStaleCheckStatus(t *testing.T) {
+	items := schemaChangeReconciliationItems([]schemaChangeReconciliationRecord{
+		{
+			check: &storage.Check{
+				DatabaseName: "orders",
+				Environment:  "staging",
+				Status:       checkStatusInProgress,
+			},
+			apply: &storage.Apply{
+				ApplyIdentifier: "apply-1234",
+				State:           state.Apply.Completed,
+			},
+		},
+	})
+
+	if assert.Len(t, items, 1) {
+		assert.False(t, items[0].InProgress)
+		assert.Equal(t, state.Apply.Completed, items[0].State)
+	}
+}

--- a/pkg/webhook/templates/preview.go
+++ b/pkg/webhook/templates/preview.go
@@ -15,6 +15,7 @@ const (
 	PreviewErrorMiddleFailed = "lock wait timeout exceeded; try restarting transaction"
 	previewRepository        = "block/schemabot"
 	previewHeadSHA           = "abcdef1234567890abcdef1234567890abcdef12"
+	previewRequestedBy       = "jackjackbits"
 )
 
 // PreviewCommentPlan renders a sample plan comment with DDL changes and lint violations.
@@ -25,7 +26,7 @@ func PreviewCommentPlan() string {
 		Environment: "staging",
 		HeadSHA:     previewHeadSHA,
 		Repository:  previewRepository,
-		RequestedBy: "aparajon",
+		RequestedBy: previewRequestedBy,
 		IsMySQL:     true,
 		Changes: []KeyspaceChangeData{
 			{
@@ -52,9 +53,55 @@ func PreviewCommentPlanNoChanges() string {
 		Environment: "staging",
 		HeadSHA:     previewHeadSHA,
 		Repository:  previewRepository,
-		RequestedBy: "aparajon",
+		RequestedBy: previewRequestedBy,
 		IsMySQL:     true,
 		Changes:     nil,
+	})
+}
+
+// PreviewCommentNoManagedSchemaChanges renders the safe empty-diff comment when
+// SchemaBot has no apply-owned state for the PR.
+func PreviewCommentNoManagedSchemaChanges() string {
+	return RenderNoManagedSchemaChanges(SchemaErrorData{
+		RequestedBy: previewRequestedBy,
+		Timestamp:   "2026-03-15 14:30:00",
+		Environment: "staging",
+		CommandName: action.Plan,
+	})
+}
+
+// PreviewCommentSchemaReconciliationInProgress renders the reconciliation
+// comment for a PR whose current diff no longer contains a running apply.
+func PreviewCommentSchemaReconciliationInProgress() string {
+	return RenderSchemaChangeReconciliationRequired(SchemaChangeReconciliationData{
+		RequestedBy: previewRequestedBy,
+		Timestamp:   "2026-03-15 14:30:00",
+		Items: []SchemaChangeReconciliationItem{
+			{
+				Database:    "testapp",
+				Environment: "staging",
+				ApplyID:     "apply-09f8ba28fb67492e",
+				State:       state.Apply.Running,
+				InProgress:  true,
+			},
+		},
+	})
+}
+
+// PreviewCommentSchemaReconciliationCompleted renders the reconciliation
+// comment for a PR whose current diff no longer contains a completed apply.
+func PreviewCommentSchemaReconciliationCompleted() string {
+	return RenderSchemaChangeReconciliationRequired(SchemaChangeReconciliationData{
+		RequestedBy: previewRequestedBy,
+		Timestamp:   "2026-03-15 14:30:00",
+		Items: []SchemaChangeReconciliationItem{
+			{
+				Database:    "testapp",
+				Environment: "staging",
+				ApplyID:     "apply-09f8ba28fb67492e",
+				State:       state.Apply.Completed,
+			},
+		},
 	})
 }
 
@@ -78,7 +125,7 @@ func PreviewCommentSupportChannel() string {
 // PreviewCommentErrorNoConfig renders the "no config found" error comment.
 func PreviewCommentErrorNoConfig() string {
 	return RenderNoConfig(SchemaErrorData{
-		RequestedBy: "aparajon",
+		RequestedBy: previewRequestedBy,
 		Timestamp:   "2026-01-15 14:30:00",
 		Environment: "staging",
 		CommandName: action.Plan,
@@ -88,7 +135,7 @@ func PreviewCommentErrorNoConfig() string {
 // PreviewCommentErrorMultiple renders the "multiple databases" error comment.
 func PreviewCommentErrorMultiple() string {
 	return RenderMultipleConfigs(SchemaErrorData{
-		RequestedBy:        "aparajon",
+		RequestedBy:        previewRequestedBy,
 		Timestamp:          "2026-01-15 14:30:00",
 		Environment:        "staging",
 		CommandName:        action.Plan,
@@ -99,7 +146,7 @@ func PreviewCommentErrorMultiple() string {
 // PreviewCommentErrorNotFound renders the "database not found" error comment.
 func PreviewCommentErrorNotFound() string {
 	return RenderDatabaseNotFound(SchemaErrorData{
-		RequestedBy:  "aparajon",
+		RequestedBy:  previewRequestedBy,
 		Timestamp:    "2026-01-15 14:30:00",
 		Environment:  "staging",
 		DatabaseName: "nonexistent-db",
@@ -110,7 +157,7 @@ func PreviewCommentErrorNotFound() string {
 // PreviewCommentErrorInvalid renders the "invalid config" error comment.
 func PreviewCommentErrorInvalid() string {
 	return RenderInvalidConfig(SchemaErrorData{
-		RequestedBy: "aparajon",
+		RequestedBy: previewRequestedBy,
 		Timestamp:   "2026-01-15 14:30:00",
 		Environment: "staging",
 		CommandName: action.Plan,
@@ -120,7 +167,7 @@ func PreviewCommentErrorInvalid() string {
 // PreviewCommentErrorGeneric renders a generic plan failure error comment.
 func PreviewCommentErrorGeneric() string {
 	return RenderGenericError(SchemaErrorData{
-		RequestedBy: "aparajon",
+		RequestedBy: previewRequestedBy,
 		Timestamp:   "2026-01-15 14:30:00",
 		Environment: "staging",
 		CommandName: action.Plan,
@@ -147,14 +194,14 @@ func PreviewCommentApplyStarted() string {
 	return RenderApplyStarted(ApplyStatusCommentData{
 		Database:    "testapp",
 		Environment: "staging",
-		RequestedBy: "aparajon",
+		RequestedBy: previewRequestedBy,
 		ApplyID:     "apply-a1b2c3d4e5f6",
 	})
 }
 
 // PreviewCommentUnlockSuccess renders a sample "lock released" confirmation.
 func PreviewCommentUnlockSuccess() string {
-	return RenderUnlockSuccess("testapp", "staging", "aparajon")
+	return RenderUnlockSuccess("testapp", "staging", previewRequestedBy)
 }
 
 // PreviewCommentApplyBlockedByOtherPR renders a sample "blocked by other PR" comment.
@@ -163,7 +210,7 @@ func PreviewCommentApplyBlockedByOtherPR() string {
 		Database:     "testapp",
 		DatabaseType: "mysql",
 		Environment:  "staging",
-		RequestedBy:  "aparajon",
+		RequestedBy:  previewRequestedBy,
 		LockOwner:    "block/myapp#42",
 		LockRepo:     "block/myapp",
 		LockPR:       42,
@@ -177,8 +224,8 @@ func PreviewCommentApplyBlockedByCLI() string {
 		Database:     "testapp",
 		DatabaseType: "mysql",
 		Environment:  "staging",
-		RequestedBy:  "aparajon",
-		LockOwner:    "cli:aparajon@macbook.local",
+		RequestedBy:  previewRequestedBy,
+		LockOwner:    "cli:jackjackbits@macbook.local",
 		LockPR:       0,
 		LockCreated:  sampleTime().Add(-30 * time.Minute),
 	})
@@ -190,7 +237,7 @@ func PreviewCommentApplyInProgress() string {
 		Database:     "testapp",
 		DatabaseType: "mysql",
 		Environment:  "staging",
-		RequestedBy:  "aparajon",
+		RequestedBy:  previewRequestedBy,
 		ApplyID:      "apply-a1b2c3d4e5f6",
 		ApplyState:   "running",
 	})
@@ -206,16 +253,16 @@ func PreviewCommentReviewRequired() string {
 	return RenderReviewRequired(ReviewGateData{
 		Database:    "testapp",
 		Environment: "staging",
-		RequestedBy: "aparajon",
+		RequestedBy: previewRequestedBy,
 		Reviewers:   []string{"acme/schema-reviewers", "jdoe"},
-		PRAuthor:    "aparajon",
+		PRAuthor:    previewRequestedBy,
 	})
 }
 
 // PreviewCommentReviewGateError renders a sample review gate error comment (fail-closed).
 func PreviewCommentReviewGateError() string {
 	return RenderGenericError(SchemaErrorData{
-		RequestedBy: "aparajon",
+		RequestedBy: previewRequestedBy,
 		Environment: "staging",
 		CommandName: action.Apply,
 		ErrorDetail: "Review gate check failed: expand team @acme/schema-reviewers: team membership cannot be read. If approval is granted through a GitHub team, verify the GitHub App can read organization members and team membership.",
@@ -296,7 +343,7 @@ func PreviewCommentUnsafeBlocked() string {
 		Environment: "staging",
 		HeadSHA:     previewHeadSHA,
 		Repository:  previewRepository,
-		RequestedBy: "aparajon",
+		RequestedBy: previewRequestedBy,
 		IsMySQL:     true,
 		Changes: []KeyspaceChangeData{
 			{
@@ -323,7 +370,7 @@ func PreviewCommentApplyPlan() string {
 		Environment:  "staging",
 		HeadSHA:      previewHeadSHA,
 		Repository:   previewRepository,
-		RequestedBy:  "aparajon",
+		RequestedBy:  previewRequestedBy,
 		IsMySQL:      true,
 		Changes:      samplePlanChanges(),
 		IsLocked:     true,
@@ -340,7 +387,7 @@ func PreviewCommentApplyPlanOptions() string {
 		Environment:  "staging",
 		HeadSHA:      previewHeadSHA,
 		Repository:   previewRepository,
-		RequestedBy:  "aparajon",
+		RequestedBy:  previewRequestedBy,
 		IsMySQL:      true,
 		Changes:      samplePlanChanges(),
 		DeferCutover: true,
@@ -359,7 +406,7 @@ func PreviewCommentApplyPlanUnsafe() string {
 		Environment: "staging",
 		HeadSHA:     previewHeadSHA,
 		Repository:  previewRepository,
-		RequestedBy: "aparajon",
+		RequestedBy: previewRequestedBy,
 		IsMySQL:     true,
 		Changes: []KeyspaceChangeData{
 			{
@@ -445,7 +492,7 @@ func PreviewCommentVitessPlan() string {
 		Environment: "staging",
 		HeadSHA:     previewHeadSHA,
 		Repository:  previewRepository,
-		RequestedBy: "aparajon",
+		RequestedBy: previewRequestedBy,
 		IsMySQL:     false,
 		Changes:     sampleVitessPlanChanges(),
 	})
@@ -459,7 +506,7 @@ func PreviewCommentVitessApplyPlan() string {
 		Environment:  "staging",
 		HeadSHA:      previewHeadSHA,
 		Repository:   previewRepository,
-		RequestedBy:  "aparajon",
+		RequestedBy:  previewRequestedBy,
 		IsMySQL:      false,
 		Changes:      sampleVitessPlanChanges(),
 		DeferCutover: true,
@@ -477,7 +524,7 @@ func PreviewCommentMySQLMultiSchema() string {
 		Environment: "staging",
 		HeadSHA:     previewHeadSHA,
 		Repository:  previewRepository,
-		RequestedBy: "aparajon",
+		RequestedBy: previewRequestedBy,
 		IsMySQL:     true,
 		Changes: []KeyspaceChangeData{
 			{
@@ -511,20 +558,20 @@ func PreviewCommentMultiEnvPlan() string {
 		HeadSHA:      previewHeadSHA,
 		Repository:   previewRepository,
 		IsMySQL:      true,
-		RequestedBy:  "aparajon",
+		RequestedBy:  previewRequestedBy,
 		Environments: []string{"staging", "production"},
 		Plans: map[string]*PlanCommentData{
 			"staging": {
 				Database:    "testapp",
 				Environment: "staging",
-				RequestedBy: "aparajon",
+				RequestedBy: previewRequestedBy,
 				IsMySQL:     true,
 				Changes:     changes,
 			},
 			"production": {
 				Database:    "testapp",
 				Environment: "production",
-				RequestedBy: "aparajon",
+				RequestedBy: previewRequestedBy,
 				IsMySQL:     true,
 				Changes:     changes,
 			},
@@ -567,13 +614,13 @@ func PreviewCommentMultiEnvPlanError() string {
 		HeadSHA:      previewHeadSHA,
 		Repository:   previewRepository,
 		IsMySQL:      true,
-		RequestedBy:  "aparajon",
+		RequestedBy:  previewRequestedBy,
 		Environments: []string{"staging", "production"},
 		Plans: map[string]*PlanCommentData{
 			"staging": {
 				Database:    "testapp",
 				Environment: "staging",
-				RequestedBy: "aparajon",
+				RequestedBy: previewRequestedBy,
 				IsMySQL:     true,
 				Changes:     changes,
 			},
@@ -593,20 +640,20 @@ func PreviewCommentMultiEnvPlanDiff() string {
 		HeadSHA:      previewHeadSHA,
 		Repository:   previewRepository,
 		IsMySQL:      true,
-		RequestedBy:  "aparajon",
+		RequestedBy:  previewRequestedBy,
 		Environments: []string{"staging", "production"},
 		Plans: map[string]*PlanCommentData{
 			"staging": {
 				Database:    "testapp",
 				Environment: "staging",
-				RequestedBy: "aparajon",
+				RequestedBy: previewRequestedBy,
 				IsMySQL:     true,
 				Changes:     nil,
 			},
 			"production": {
 				Database:    "testapp",
 				Environment: "production",
-				RequestedBy: "aparajon",
+				RequestedBy: previewRequestedBy,
 				IsMySQL:     true,
 				Changes:     samplePlanChanges(),
 			},
@@ -644,7 +691,7 @@ func sampleApplyData(s string, tables []TableProgressData) ApplyStatusCommentDat
 	return ApplyStatusCommentData{
 		Database:    "testapp",
 		Environment: "staging",
-		RequestedBy: "aparajon",
+		RequestedBy: previewRequestedBy,
 		State:       s,
 		Engine:      "Spirit",
 		ApplyID:     "apply-a1b2c3d4e5f6",
@@ -998,7 +1045,7 @@ func sampleSingleApplyData(s string, table TableProgressData) ApplyStatusComment
 	return ApplyStatusCommentData{
 		Database:    "testapp",
 		Environment: "staging",
-		RequestedBy: "aparajon",
+		RequestedBy: previewRequestedBy,
 		State:       s,
 		Engine:      "Spirit",
 		ApplyID:     "apply-a1b2c3d4e5f6",

--- a/pkg/webhook/templates/preview.go
+++ b/pkg/webhook/templates/preview.go
@@ -18,6 +18,13 @@ const (
 	previewRequestedBy       = "jackjackbits"
 )
 
+func previewSupportChannel() SupportChannelData {
+	return SupportChannelData{
+		Name: "#schema-help",
+		URL:  "https://chat.example.com/schema-help",
+	}
+}
+
 // PreviewCommentPlan renders a sample plan comment with DDL changes and lint violations.
 func PreviewCommentPlan() string {
 	return RenderPlanComment(PlanCommentData{
@@ -74,7 +81,7 @@ func PreviewCommentNoManagedSchemaChanges() string {
 // comment for a PR whose current diff no longer contains managed schema files
 // while a stored apply from that PR is still running.
 func PreviewCommentSchemaReconciliationInProgress() string {
-	return RenderSchemaChangeReconciliationRequired(SchemaChangeReconciliationData{
+	return RenderSupportChannelFooter(RenderSchemaChangeReconciliationRequired(SchemaChangeReconciliationData{
 		RequestedBy: previewRequestedBy,
 		Timestamp:   "2026-03-15 14:30:00",
 		Items: []SchemaChangeReconciliationItem{
@@ -86,14 +93,14 @@ func PreviewCommentSchemaReconciliationInProgress() string {
 				InProgress:  true,
 			},
 		},
-	})
+	}), previewSupportChannel())
 }
 
 // PreviewCommentSchemaReconciliationCompleted renders the reconciliation
 // comment for a PR whose current diff no longer contains managed schema files
 // after a stored apply from that PR has completed.
 func PreviewCommentSchemaReconciliationCompleted() string {
-	return RenderSchemaChangeReconciliationRequired(SchemaChangeReconciliationData{
+	return RenderSupportChannelFooter(RenderSchemaChangeReconciliationRequired(SchemaChangeReconciliationData{
 		RequestedBy: previewRequestedBy,
 		Timestamp:   "2026-03-15 14:30:00",
 		Items: []SchemaChangeReconciliationItem{
@@ -104,7 +111,7 @@ func PreviewCommentSchemaReconciliationCompleted() string {
 				State:       state.Apply.Completed,
 			},
 		},
-	})
+	}), previewSupportChannel())
 }
 
 // PreviewCommentHelp renders the help command reference comment.
@@ -114,14 +121,10 @@ func PreviewCommentHelp() string {
 
 // PreviewCommentSupportChannel renders a sample error comment with a support-channel footer.
 func PreviewCommentSupportChannel() string {
-	support := SupportChannelData{
-		Name: "#schema-help",
-		URL:  "https://chat.example.com/schema-help",
-	}
 	return "### Invalid command\n\n" +
-		RenderSupportChannelFooter(RenderInvalidCommand(), support) +
+		RenderSupportChannelFooter(RenderInvalidCommand(), previewSupportChannel()) +
 		"\n\n### Apply failure\n\n" +
-		RenderSupportChannelFooter(PreviewCommentApplyFailed(), support)
+		RenderSupportChannelFooter(PreviewCommentApplyFailed(), previewSupportChannel())
 }
 
 // PreviewCommentErrorNoConfig renders the "no config found" error comment.

--- a/pkg/webhook/templates/preview.go
+++ b/pkg/webhook/templates/preview.go
@@ -71,7 +71,8 @@ func PreviewCommentNoManagedSchemaChanges() string {
 }
 
 // PreviewCommentSchemaReconciliationInProgress renders the reconciliation
-// comment for a PR whose current diff no longer contains a running apply.
+// comment for a PR whose current diff no longer contains managed schema files
+// while a stored apply from that PR is still running.
 func PreviewCommentSchemaReconciliationInProgress() string {
 	return RenderSchemaChangeReconciliationRequired(SchemaChangeReconciliationData{
 		RequestedBy: previewRequestedBy,
@@ -89,7 +90,8 @@ func PreviewCommentSchemaReconciliationInProgress() string {
 }
 
 // PreviewCommentSchemaReconciliationCompleted renders the reconciliation
-// comment for a PR whose current diff no longer contains a completed apply.
+// comment for a PR whose current diff no longer contains managed schema files
+// after a stored apply from that PR has completed.
 func PreviewCommentSchemaReconciliationCompleted() string {
 	return RenderSchemaChangeReconciliationRequired(SchemaChangeReconciliationData{
 		RequestedBy: previewRequestedBy,

--- a/pkg/webhook/templates/reconciliation.go
+++ b/pkg/webhook/templates/reconciliation.go
@@ -1,0 +1,182 @@
+package templates
+
+import (
+	"fmt"
+	"strings"
+)
+
+// SchemaChangeReconciliationData contains the apply-owned PR state that must be
+// reconciled before SchemaBot can treat an empty PR diff as clean.
+type SchemaChangeReconciliationData struct {
+	RequestedBy string
+	Timestamp   string
+	Items       []SchemaChangeReconciliationItem
+}
+
+// SchemaChangeReconciliationItem describes one database/environment whose live
+// schema may no longer match the current PR contents.
+type SchemaChangeReconciliationItem struct {
+	Database    string
+	Environment string
+	ApplyID     string
+	State       string
+	InProgress  bool
+}
+
+// RenderNoManagedSchemaChanges renders the clear no-op state for a PR that has
+// no managed schema changes and no apply-owned SchemaBot state.
+func RenderNoManagedSchemaChanges(data SchemaErrorData) string {
+	var sb strings.Builder
+	sb.WriteString("## ✅ No Managed Schema Changes\n\n")
+	if data.Environment != "" {
+		fmt.Fprintf(&sb, "**Environment**: `%s`\n\n", data.Environment)
+	}
+	writeRequestedLine(&sb, data.RequestedBy, data.Timestamp)
+	sb.WriteString("\nThis PR does not contain schema changes managed by SchemaBot. SchemaBot did not find any apply-owned state that requires live database reconciliation.\n")
+	return sb.String()
+}
+
+// RenderSchemaChangeReconciliationRequired explains that the current PR no
+// longer contains a schema change whose apply has already started.
+func RenderSchemaChangeReconciliationRequired(data SchemaChangeReconciliationData) string {
+	var sb strings.Builder
+	sb.WriteString("## ⚠️ Schema Change Reconciliation Required\n\n")
+	writeReconciliationMetadata(&sb, data.Items)
+	writeRequestedLine(&sb, data.RequestedBy, data.Timestamp)
+	sb.WriteString("\n")
+
+	if reconciliationHasInProgressApply(data.Items) {
+		writeInProgressReconciliation(&sb, data.Items)
+	} else {
+		writeCompletedReconciliation(&sb, data.Items)
+	}
+
+	sb.WriteString("\nThe PR check will remain blocked until the live database and PR schema files agree.\n")
+	return sb.String()
+}
+
+func writeReconciliationMetadata(sb *strings.Builder, items []SchemaChangeReconciliationItem) {
+	if len(items) == 1 {
+		item := items[0]
+		parts := []string{fmt.Sprintf("**Database**: `%s`", item.Database)}
+		if item.Environment != "" {
+			parts = append(parts, fmt.Sprintf("**Environment**: `%s`", item.Environment))
+		}
+		if item.ApplyID != "" {
+			parts = append(parts, fmt.Sprintf("**Apply ID**: `%s`", item.ApplyID))
+		}
+		fmt.Fprintf(sb, "%s\n\n", strings.Join(parts, " | "))
+		return
+	}
+
+	sb.WriteString("| Database | Environment | Apply ID | State |\n")
+	sb.WriteString("|----------|-------------|----------|-------|\n")
+	for _, item := range items {
+		applyID := item.ApplyID
+		if applyID == "" {
+			applyID = "unknown"
+		}
+		state := item.State
+		if state == "" {
+			state = "unknown"
+		}
+		fmt.Fprintf(sb, "| `%s` | `%s` | `%s` | `%s` |\n", item.Database, item.Environment, applyID, state)
+	}
+	sb.WriteString("\n")
+}
+
+func writeRequestedLine(sb *strings.Builder, requestedBy, timestamp string) {
+	if requestedBy == "" && timestamp == "" {
+		return
+	}
+	if requestedBy == "" {
+		fmt.Fprintf(sb, "*Requested at %s UTC*\n", timestamp)
+		return
+	}
+	if timestamp == "" {
+		fmt.Fprintf(sb, "*Requested by @%s*\n", requestedBy)
+		return
+	}
+	fmt.Fprintf(sb, "*Requested by @%s at %s UTC*\n", requestedBy, timestamp)
+}
+
+func reconciliationHasInProgressApply(items []SchemaChangeReconciliationItem) bool {
+	for _, item := range items {
+		if item.InProgress {
+			return true
+		}
+	}
+	return false
+}
+
+func writeInProgressReconciliation(sb *strings.Builder, items []SchemaChangeReconciliationItem) {
+	sb.WriteString("SchemaBot is still applying a schema change from this PR, but the current PR no longer contains that change.\n\n")
+	sb.WriteString("The live database operation was already started and may continue independently of the current PR diff.\n\n")
+	sb.WriteString("### What to do next\n\n")
+	sb.WriteString("1. First, resolve the in-flight apply:\n")
+	sb.WriteString("   - Wait for SchemaBot to post the final apply result, or\n")
+	sb.WriteString("   - If stopping is supported for this database, comment:\n")
+	fmt.Fprintf(sb, "     ```\n     %s\n     ```\n", stopCommand(items))
+	sb.WriteString("\n2. Then reconcile the final live schema:\n")
+	sb.WriteString("   - If the live schema change should remain, add the schema change back to the PR, then comment:\n")
+	fmt.Fprintf(sb, "     ```\n     %s\n     ```\n", planCommand(items))
+	sb.WriteString("   - If the live schema change should not remain, roll it back:\n")
+	fmt.Fprintf(sb, "     ```\n     %s\n     ```\n", rollbackCommand(items))
+	sb.WriteString("     Then comment:\n")
+	fmt.Fprintf(sb, "     ```\n     %s\n     ```\n", planCommand(items))
+}
+
+func writeCompletedReconciliation(sb *strings.Builder, items []SchemaChangeReconciliationItem) {
+	sb.WriteString("SchemaBot already applied a schema change from this PR, but the current PR no longer contains that change.\n\n")
+	sb.WriteString("The live database was already updated and may no longer match the current PR schema files.\n\n")
+	sb.WriteString("### What to do next\n\n")
+	sb.WriteString("Choose one:\n\n")
+	sb.WriteString("1. Keep the live schema change:\n")
+	sb.WriteString("   - add the schema change back to the PR\n")
+	sb.WriteString("   - comment:\n")
+	fmt.Fprintf(sb, "     ```\n     %s\n     ```\n", planCommand(items))
+	sb.WriteString("\n2. Undo the live schema change:\n")
+	sb.WriteString("   - comment:\n")
+	fmt.Fprintf(sb, "     ```\n     %s\n     ```\n", rollbackCommand(items))
+	sb.WriteString("   - after rollback completes, comment:\n")
+	fmt.Fprintf(sb, "     ```\n     %s\n     ```\n", planCommand(items))
+}
+
+func planCommand(items []SchemaChangeReconciliationItem) string {
+	item, ok := singleCommandItem(items)
+	if !ok {
+		return "schemabot plan -e <environment> -d <database>"
+	}
+	cmd := fmt.Sprintf("schemabot plan -e %s", item.Environment)
+	if item.Database != "" {
+		cmd += fmt.Sprintf(" -d %s", item.Database)
+	}
+	return cmd
+}
+
+func stopCommand(items []SchemaChangeReconciliationItem) string {
+	item, ok := singleCommandItem(items)
+	if !ok || item.ApplyID == "" {
+		return "schemabot stop <apply-id> -e <environment>"
+	}
+	return fmt.Sprintf("schemabot stop %s -e %s", item.ApplyID, item.Environment)
+}
+
+func rollbackCommand(items []SchemaChangeReconciliationItem) string {
+	item, ok := singleCommandItem(items)
+	if !ok || item.ApplyID == "" {
+		return "schemabot rollback <apply-id> -e <environment>"
+	}
+	return fmt.Sprintf("schemabot rollback %s -e %s", item.ApplyID, item.Environment)
+}
+
+func singleCommandItem(items []SchemaChangeReconciliationItem) (SchemaChangeReconciliationItem, bool) {
+	if len(items) != 1 {
+		return SchemaChangeReconciliationItem{}, false
+	}
+	item := items[0]
+	if item.Environment == "" {
+		return SchemaChangeReconciliationItem{}, false
+	}
+	return item, true
+}

--- a/pkg/webhook/templates/reconciliation.go
+++ b/pkg/webhook/templates/reconciliation.go
@@ -51,7 +51,6 @@ func RenderSchemaChangeReconciliationRequired(data SchemaChangeReconciliationDat
 		writeCompletedReconciliation(&sb, data.Items)
 	}
 
-	sb.WriteString("\nThe PR check will remain blocked until the live database and PR schema files agree.\n")
 	return sb.String()
 }
 
@@ -122,7 +121,7 @@ func writeInProgressReconciliation(sb *strings.Builder, items []SchemaChangeReco
 	fmt.Fprintf(sb, "     ```\n     %s\n     ```\n", planCommand(items))
 	sb.WriteString("   - If the live schema change should not remain, roll it back:\n")
 	fmt.Fprintf(sb, "     ```\n     %s\n     ```\n", rollbackCommand(items))
-	sb.WriteString("     After rollback completes, do not run `schemabot plan` on this empty-diff PR unless you first add managed schema files back to the PR. Ask a SchemaBot operator to verify the live schema matches the current desired schema and clear the blocked check state.\n")
+	sb.WriteString("     After rollback: push a no-op `schemabot.yaml` edit to trigger a fresh plan.\n")
 }
 
 func writeCompletedReconciliation(sb *strings.Builder, items []SchemaChangeReconciliationItem) {
@@ -137,8 +136,7 @@ func writeCompletedReconciliation(sb *strings.Builder, items []SchemaChangeRecon
 	sb.WriteString("\n2. Undo the live schema change:\n")
 	sb.WriteString("   - comment:\n")
 	fmt.Fprintf(sb, "     ```\n     %s\n     ```\n", rollbackCommand(items))
-	sb.WriteString("   - after rollback completes, do not run `schemabot plan` on this empty-diff PR unless you first add managed schema files back to the PR\n")
-	sb.WriteString("   - ask a SchemaBot operator to verify the live schema matches the current desired schema and clear the blocked check state\n")
+	sb.WriteString("   - after rollback: push a no-op `schemabot.yaml` edit to trigger a fresh plan\n")
 }
 
 func planCommand(items []SchemaChangeReconciliationItem) string {

--- a/pkg/webhook/templates/reconciliation.go
+++ b/pkg/webhook/templates/reconciliation.go
@@ -122,8 +122,7 @@ func writeInProgressReconciliation(sb *strings.Builder, items []SchemaChangeReco
 	fmt.Fprintf(sb, "     ```\n     %s\n     ```\n", planCommand(items))
 	sb.WriteString("   - If the live schema change should not remain, roll it back:\n")
 	fmt.Fprintf(sb, "     ```\n     %s\n     ```\n", rollbackCommand(items))
-	sb.WriteString("     Then comment:\n")
-	fmt.Fprintf(sb, "     ```\n     %s\n     ```\n", planCommand(items))
+	sb.WriteString("     After rollback completes, do not run `schemabot plan` on this empty-diff PR unless you first add managed schema files back to the PR. Ask a SchemaBot operator to verify the live schema matches the current desired schema and clear the blocked check state.\n")
 }
 
 func writeCompletedReconciliation(sb *strings.Builder, items []SchemaChangeReconciliationItem) {
@@ -138,8 +137,8 @@ func writeCompletedReconciliation(sb *strings.Builder, items []SchemaChangeRecon
 	sb.WriteString("\n2. Undo the live schema change:\n")
 	sb.WriteString("   - comment:\n")
 	fmt.Fprintf(sb, "     ```\n     %s\n     ```\n", rollbackCommand(items))
-	sb.WriteString("   - after rollback completes, comment:\n")
-	fmt.Fprintf(sb, "     ```\n     %s\n     ```\n", planCommand(items))
+	sb.WriteString("   - after rollback completes, do not run `schemabot plan` on this empty-diff PR unless you first add managed schema files back to the PR\n")
+	sb.WriteString("   - ask a SchemaBot operator to verify the live schema matches the current desired schema and clear the blocked check state\n")
 }
 
 func planCommand(items []SchemaChangeReconciliationItem) string {

--- a/pkg/webhook/templates/reconciliation_test.go
+++ b/pkg/webhook/templates/reconciliation_test.go
@@ -27,7 +27,8 @@ func TestRenderSchemaChangeReconciliationRequiredInProgress(t *testing.T) {
 	assert.Contains(t, rendered, "schemabot stop apply-1234 -e staging")
 	assert.Contains(t, rendered, "schemabot rollback apply-1234 -e staging")
 	assert.Contains(t, rendered, "schemabot plan -e staging -d orders")
-	assert.Contains(t, rendered, "do not run `schemabot plan` on this empty-diff PR")
+	assert.Contains(t, rendered, "push a no-op `schemabot.yaml` edit to trigger a fresh plan")
+	assert.NotContains(t, rendered, "ask an operator")
 	assert.NotContains(t, rendered, "Git reverting")
 	assert.NotContains(t, rendered, "Removing the schema change")
 }
@@ -53,8 +54,8 @@ func TestRenderSchemaChangeReconciliationRequiredCompleted(t *testing.T) {
 	assert.Contains(t, rendered, "Undo the live schema change")
 	assert.Contains(t, rendered, "schemabot rollback apply-1234 -e staging")
 	assert.Contains(t, rendered, "schemabot plan -e staging -d orders")
-	assert.Contains(t, rendered, "do not run `schemabot plan` on this empty-diff PR")
-	assert.Contains(t, rendered, "clear the blocked check state")
+	assert.Contains(t, rendered, "push a no-op `schemabot.yaml` edit to trigger a fresh plan")
+	assert.NotContains(t, rendered, "ask an operator")
 	assert.NotContains(t, rendered, "schemabot status")
 	assert.NotContains(t, rendered, "Git reverting")
 }

--- a/pkg/webhook/templates/reconciliation_test.go
+++ b/pkg/webhook/templates/reconciliation_test.go
@@ -1,0 +1,68 @@
+package templates
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRenderSchemaChangeReconciliationRequiredInProgress(t *testing.T) {
+	rendered := RenderSchemaChangeReconciliationRequired(SchemaChangeReconciliationData{
+		RequestedBy: "alice",
+		Timestamp:   "2026-06-14 12:34:56",
+		Items: []SchemaChangeReconciliationItem{
+			{
+				Database:    "orders",
+				Environment: "staging",
+				ApplyID:     "apply-1234",
+				State:       "running",
+				InProgress:  true,
+			},
+		},
+	})
+
+	assert.Contains(t, rendered, "## ⚠️ Schema Change Reconciliation Required")
+	assert.Contains(t, rendered, "SchemaBot is still applying a schema change from this PR")
+	assert.Contains(t, rendered, "The live database operation was already started")
+	assert.Contains(t, rendered, "schemabot stop apply-1234 -e staging")
+	assert.Contains(t, rendered, "schemabot rollback apply-1234 -e staging")
+	assert.Contains(t, rendered, "schemabot plan -e staging -d orders")
+	assert.NotContains(t, rendered, "Git reverting")
+	assert.NotContains(t, rendered, "Removing the schema change")
+}
+
+func TestRenderSchemaChangeReconciliationRequiredCompleted(t *testing.T) {
+	rendered := RenderSchemaChangeReconciliationRequired(SchemaChangeReconciliationData{
+		RequestedBy: "alice",
+		Timestamp:   "2026-06-14 12:34:56",
+		Items: []SchemaChangeReconciliationItem{
+			{
+				Database:    "orders",
+				Environment: "staging",
+				ApplyID:     "apply-1234",
+				State:       "completed",
+			},
+		},
+	})
+
+	assert.Contains(t, rendered, "## ⚠️ Schema Change Reconciliation Required")
+	assert.Contains(t, rendered, "SchemaBot already applied a schema change from this PR")
+	assert.Contains(t, rendered, "The live database was already updated")
+	assert.Contains(t, rendered, "Keep the live schema change")
+	assert.Contains(t, rendered, "Undo the live schema change")
+	assert.Contains(t, rendered, "schemabot rollback apply-1234 -e staging")
+	assert.Contains(t, rendered, "schemabot plan -e staging -d orders")
+	assert.NotContains(t, rendered, "schemabot status")
+	assert.NotContains(t, rendered, "Git reverting")
+}
+
+func TestRenderNoManagedSchemaChanges(t *testing.T) {
+	rendered := RenderNoManagedSchemaChanges(SchemaErrorData{
+		RequestedBy: "alice",
+		Timestamp:   "2026-06-14 12:34:56",
+		Environment: "staging",
+	})
+
+	assert.Contains(t, rendered, "## ✅ No Managed Schema Changes")
+	assert.Contains(t, rendered, "SchemaBot did not find any apply-owned state")
+}

--- a/pkg/webhook/templates/reconciliation_test.go
+++ b/pkg/webhook/templates/reconciliation_test.go
@@ -27,6 +27,7 @@ func TestRenderSchemaChangeReconciliationRequiredInProgress(t *testing.T) {
 	assert.Contains(t, rendered, "schemabot stop apply-1234 -e staging")
 	assert.Contains(t, rendered, "schemabot rollback apply-1234 -e staging")
 	assert.Contains(t, rendered, "schemabot plan -e staging -d orders")
+	assert.Contains(t, rendered, "do not run `schemabot plan` on this empty-diff PR")
 	assert.NotContains(t, rendered, "Git reverting")
 	assert.NotContains(t, rendered, "Removing the schema change")
 }
@@ -52,6 +53,8 @@ func TestRenderSchemaChangeReconciliationRequiredCompleted(t *testing.T) {
 	assert.Contains(t, rendered, "Undo the live schema change")
 	assert.Contains(t, rendered, "schemabot rollback apply-1234 -e staging")
 	assert.Contains(t, rendered, "schemabot plan -e staging -d orders")
+	assert.Contains(t, rendered, "do not run `schemabot plan` on this empty-diff PR")
+	assert.Contains(t, rendered, "clear the blocked check state")
 	assert.NotContains(t, rendered, "schemabot status")
 	assert.NotContains(t, rendered, "Git reverting")
 }

--- a/pkg/webhook/webhook_e2e_test.go
+++ b/pkg/webhook/webhook_e2e_test.go
@@ -82,6 +82,8 @@ import (
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
 
+	"github.com/block/spirit/pkg/utils"
+
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
@@ -348,6 +350,10 @@ func registerCheckStatusRESTHandlersForAnyRef(mux *http.ServeMux, nodes func() [
 // schemaSQL maps filename -> content. Files are placed under schema/{namespace}/.
 // namespace is the MySQL schema name (required).
 func setupFakeGitHubForPlan(t *testing.T, mux *http.ServeMux, schemaSQL map[string]string, schemabotConfig, ns string) *planFlowResult {
+	return setupFakeGitHubForPlanWithPRFiles(t, mux, schemaSQL, schemabotConfig, ns, nil)
+}
+
+func setupFakeGitHubForPlanWithPRFiles(t *testing.T, mux *http.ServeMux, schemaSQL map[string]string, schemabotConfig, ns string, prFiles []*gh.CommitFile) *planFlowResult {
 	t.Helper()
 
 	result := &planFlowResult{
@@ -375,6 +381,10 @@ func setupFakeGitHubForPlan(t *testing.T, mux *http.ServeMux, schemaSQL map[stri
 
 	// PR changed files — report schema files changed (in namespace subdir)
 	mux.HandleFunc("GET /repos/octocat/hello-world/pulls/1/files", func(w http.ResponseWriter, r *http.Request) {
+		if prFiles != nil {
+			_ = json.NewEncoder(w).Encode(prFiles)
+			return
+		}
 		var files []*gh.CommitFile
 		for name := range schemaSQL {
 			files = append(files, &gh.CommitFile{
@@ -2056,7 +2066,8 @@ func TestE2EPlanWithNoCurrentSchemaFilesExplainsInProgressApply(t *testing.T) {
 	assert.Contains(t, body, "schemabot stop apply-empty-diff -e staging")
 	assert.Contains(t, body, "schemabot rollback apply-empty-diff -e staging")
 	assert.Contains(t, body, "schemabot plan -e staging -d webhook_empty_diff_apply")
-	assert.Contains(t, body, "do not run `schemabot plan` on this empty-diff PR")
+	assert.Contains(t, body, "push a no-op `schemabot.yaml` edit to trigger a fresh plan")
+	assert.NotContains(t, body, "ask an operator")
 	assert.NotContains(t, body, "truncated repository tree")
 	assert.NotContains(t, body, "schemabot status")
 }
@@ -2074,10 +2085,80 @@ func TestE2EPlanWithNoCurrentSchemaFilesExplainsCompletedApply(t *testing.T) {
 	assert.Contains(t, body, "Undo the live schema change")
 	assert.Contains(t, body, "schemabot rollback apply-empty-diff -e staging")
 	assert.Contains(t, body, "schemabot plan -e staging -d webhook_empty_diff_apply")
-	assert.Contains(t, body, "do not run `schemabot plan` on this empty-diff PR")
-	assert.Contains(t, body, "clear the blocked check state")
+	assert.Contains(t, body, "push a no-op `schemabot.yaml` edit to trigger a fresh plan")
+	assert.NotContains(t, body, "ask an operator")
 	assert.NotContains(t, body, "truncated repository tree")
 	assert.NotContains(t, body, "Git reverting")
+}
+
+// TestE2EAutoPlanWithOnlySchemaBotConfigChangeClearsRollbackCheck verifies the
+// self-serve reconciliation path for a PR whose live database already matches
+// the current schema files. A no-op schemabot.yaml edit should make config
+// discovery deterministic, auto-plan no changes, and clear the
+// rollback-created blocking check state without operator intervention.
+func TestE2EAutoPlanWithOnlySchemaBotConfigChangeClearsRollbackCheck(t *testing.T) {
+	dbName := "webhook_noop_config_reconcile"
+	svc := setupE2EService(t, dbName)
+	ctx := t.Context()
+
+	schemaSQL := "CREATE TABLE `users` (\n  `id` bigint unsigned NOT NULL AUTO_INCREMENT,\n  `name` varchar(255) NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;"
+	cfg, err := mysql.ParseDSN(e2eTargetDSN)
+	require.NoError(t, err)
+	cfg.DBName = dbName
+	db, err := sql.Open("mysql", cfg.FormatDSN())
+	require.NoError(t, err)
+	defer utils.CloseAndLog(db)
+	require.NoError(t, db.PingContext(ctx))
+	_, err = db.ExecContext(ctx, strings.TrimSuffix(schemaSQL, ";"))
+	require.NoError(t, err)
+
+	require.NoError(t, svc.Storage().Checks().Upsert(ctx, &storage.Check{
+		Repository:     "octocat/hello-world",
+		PullRequest:    1,
+		HeadSHA:        "abc123",
+		Environment:    "staging",
+		DatabaseType:   "mysql",
+		DatabaseName:   dbName,
+		CheckRunID:     100,
+		HasChanges:     true,
+		Status:         checkStatusCompleted,
+		Conclusion:     checkConclusionActionRequired,
+		BlockingReason: rollbackCompletedBlock.blockingReason,
+		ErrorMessage:   rollbackCompletedBlock.message,
+	}))
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	client := gh.NewClient(nil)
+	client.BaseURL, _ = url.Parse(server.URL + "/")
+
+	schemabotConfig := fmt.Sprintf("database: %s\ntype: mysql\n", dbName)
+	setupFakeGitHubForPlanWithPRFiles(t, mux, map[string]string{"users.sql": schemaSQL}, schemabotConfig, dbName, []*gh.CommitFile{
+		{
+			Filename: new("schema/schemabot.yaml"),
+			Status:   new("modified"),
+		},
+	})
+
+	h := newE2EHandler(t, svc, client)
+	req := buildPRWebhookRequest(t, prWebhookPayloadOpts{action: "synchronize"}, nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), "auto-plan started")
+
+	var check *storage.Check
+	require.Eventually(t, func() bool {
+		check, err = svc.Storage().Checks().Get(ctx, "octocat/hello-world", 1, "staging", "mysql", dbName)
+		return err == nil && check != nil && check.Status == checkStatusCompleted && check.Conclusion == checkConclusionSuccess
+	}, webhookIntegrationPollDeadline, 500*time.Millisecond, "no-op config auto-plan should clear rollback-created blocking check")
+	assert.Equal(t, "abc123", check.HeadSHA)
+	assert.False(t, check.HasChanges)
+	assert.Zero(t, check.ApplyID)
+	assert.Empty(t, check.BlockingReason)
+	assert.Empty(t, check.ErrorMessage)
 }
 
 // TestE2EApplyWithNoCurrentSchemaFilesExplainsInProgressApply verifies that

--- a/pkg/webhook/webhook_e2e_test.go
+++ b/pkg/webhook/webhook_e2e_test.go
@@ -2056,6 +2056,7 @@ func TestE2EPlanWithNoCurrentSchemaFilesExplainsInProgressApply(t *testing.T) {
 	assert.Contains(t, body, "schemabot stop apply-empty-diff -e staging")
 	assert.Contains(t, body, "schemabot rollback apply-empty-diff -e staging")
 	assert.Contains(t, body, "schemabot plan -e staging -d webhook_empty_diff_apply")
+	assert.Contains(t, body, "do not run `schemabot plan` on this empty-diff PR")
 	assert.NotContains(t, body, "truncated repository tree")
 	assert.NotContains(t, body, "schemabot status")
 }
@@ -2073,6 +2074,8 @@ func TestE2EPlanWithNoCurrentSchemaFilesExplainsCompletedApply(t *testing.T) {
 	assert.Contains(t, body, "Undo the live schema change")
 	assert.Contains(t, body, "schemabot rollback apply-empty-diff -e staging")
 	assert.Contains(t, body, "schemabot plan -e staging -d webhook_empty_diff_apply")
+	assert.Contains(t, body, "do not run `schemabot plan` on this empty-diff PR")
+	assert.Contains(t, body, "clear the blocked check state")
 	assert.NotContains(t, body, "truncated repository tree")
 	assert.NotContains(t, body, "Git reverting")
 }

--- a/pkg/webhook/webhook_e2e_test.go
+++ b/pkg/webhook/webhook_e2e_test.go
@@ -2043,6 +2043,154 @@ func TestE2EAggregateCheckStaleCleanupBlocksStartedApply(t *testing.T) {
 	}
 }
 
+// TestE2EPlanWithNoCurrentSchemaFilesExplainsInProgressApply verifies that a
+// PR whose current diff no longer contains managed schema files does not fall
+// back to whole-repo config discovery when an apply from that PR is still
+// running. The command should tell the user how to reconcile the in-flight apply.
+func TestE2EPlanWithNoCurrentSchemaFilesExplainsInProgressApply(t *testing.T) {
+	body, treeCalls := runCommandWithNoCurrentSchemaFilesAndApplyOwnedCheck(t, "schemabot plan -e staging", state.Apply.Running, checkStatusInProgress, "")
+
+	assert.Zero(t, treeCalls, "empty-diff plan should not use whole-repo git tree discovery")
+	assert.Contains(t, body, "SchemaBot is still applying a schema change from this PR")
+	assert.Contains(t, body, "The live database operation was already started")
+	assert.Contains(t, body, "schemabot stop apply-empty-diff -e staging")
+	assert.Contains(t, body, "schemabot rollback apply-empty-diff -e staging")
+	assert.Contains(t, body, "schemabot plan -e staging -d webhook_empty_diff_apply")
+	assert.NotContains(t, body, "truncated repository tree")
+	assert.NotContains(t, body, "schemabot status")
+}
+
+// TestE2EPlanWithNoCurrentSchemaFilesExplainsCompletedApply verifies that a PR
+// whose current diff no longer contains managed schema files produces a clear
+// reconciliation-required comment after the apply has reached a terminal state.
+func TestE2EPlanWithNoCurrentSchemaFilesExplainsCompletedApply(t *testing.T) {
+	body, treeCalls := runCommandWithNoCurrentSchemaFilesAndApplyOwnedCheck(t, "schemabot plan -e staging", state.Apply.Completed, checkStatusCompleted, checkConclusionActionRequired)
+
+	assert.Zero(t, treeCalls, "empty-diff plan should not use whole-repo git tree discovery")
+	assert.Contains(t, body, "SchemaBot already applied a schema change from this PR")
+	assert.Contains(t, body, "The live database was already updated")
+	assert.Contains(t, body, "Keep the live schema change")
+	assert.Contains(t, body, "Undo the live schema change")
+	assert.Contains(t, body, "schemabot rollback apply-empty-diff -e staging")
+	assert.Contains(t, body, "schemabot plan -e staging -d webhook_empty_diff_apply")
+	assert.NotContains(t, body, "truncated repository tree")
+	assert.NotContains(t, body, "Git reverting")
+}
+
+// TestE2EApplyWithNoCurrentSchemaFilesExplainsInProgressApply verifies that
+// apply uses the same reconciliation guard as plan instead of falling back to
+// whole-repo config discovery after the current PR diff no longer contains
+// managed schema files.
+func TestE2EApplyWithNoCurrentSchemaFilesExplainsInProgressApply(t *testing.T) {
+	body, treeCalls := runCommandWithNoCurrentSchemaFilesAndApplyOwnedCheck(t, "schemabot apply -e staging", state.Apply.Running, checkStatusInProgress, "")
+
+	assert.Zero(t, treeCalls, "empty-diff apply should not use whole-repo git tree discovery")
+	assert.Contains(t, body, "SchemaBot is still applying a schema change from this PR")
+	assert.Contains(t, body, "schemabot rollback apply-empty-diff -e staging")
+	assert.NotContains(t, body, "truncated repository tree")
+}
+
+func runCommandWithNoCurrentSchemaFilesAndApplyOwnedCheck(t *testing.T, comment, applyState, checkStatus, checkConclusion string) (string, int64) {
+	t.Helper()
+
+	dbName := "webhook_empty_diff_apply"
+	svc := setupE2EService(t, dbName)
+	ctx := t.Context()
+
+	apply := &storage.Apply{
+		ApplyIdentifier: "apply-empty-diff",
+		Database:        dbName,
+		DatabaseType:    "mysql",
+		Environment:     "staging",
+		Repository:      "octocat/hello-world",
+		PullRequest:     1,
+		State:           applyState,
+		Engine:          "spirit",
+	}
+	applyID, err := svc.Storage().Applies().Create(ctx, apply)
+	require.NoError(t, err)
+
+	require.NoError(t, svc.Storage().Checks().Upsert(ctx, &storage.Check{
+		Repository:   "octocat/hello-world",
+		PullRequest:  1,
+		HeadSHA:      "oldsha111",
+		Environment:  "staging",
+		DatabaseType: "mysql",
+		DatabaseName: dbName,
+		CheckRunID:   100,
+		ApplyID:      applyID,
+		HasChanges:   true,
+		Status:       checkStatus,
+		Conclusion:   checkConclusion,
+	}))
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	client := gh.NewClient(nil)
+	client.BaseURL, _ = url.Parse(server.URL + "/")
+
+	mux.HandleFunc("GET /repos/octocat/hello-world/pulls/1", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(gh.PullRequest{
+			Head: &gh.PullRequestBranch{
+				Ref: new("feature-branch"),
+				SHA: new("newsha222"),
+			},
+			Base: &gh.PullRequestBranch{
+				Ref: new("main"),
+				SHA: new("def456"),
+			},
+			User: &gh.User{Login: new("testuser")},
+		})
+	})
+	mux.HandleFunc("GET /repos/octocat/hello-world/pulls/1/files", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode([]*gh.CommitFile{})
+	})
+
+	var treeCalls atomic.Int64
+	mux.HandleFunc("GET /repos/octocat/hello-world/git/trees/", func(w http.ResponseWriter, _ *http.Request) {
+		treeCalls.Add(1)
+		_ = json.NewEncoder(w).Encode(gh.Tree{
+			SHA:       new("newsha222"),
+			Entries:   []*gh.TreeEntry{},
+			Truncated: new(true),
+		})
+	})
+
+	comments := make(chan string, 10)
+	mux.HandleFunc("POST /repos/octocat/hello-world/issues/1/comments", func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Body string `json:"body"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		comments <- body.Body
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": 99})
+	})
+	mux.HandleFunc("POST /repos/octocat/hello-world/issues/comments/42/reactions", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": 1})
+	})
+
+	h := newE2EHandler(t, svc, client)
+	req := buildWebhookRequest(t, webhookPayloadOpts{
+		comment: comment,
+		isPR:    true,
+	}, nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	select {
+	case body := <-comments:
+		return body, treeCalls.Load()
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for reconciliation comment")
+		return "", treeCalls.Load()
+	}
+}
+
 // TestE2EPlanUsesServerSideTarget verifies that the webhook plan handler routes
 // using the database target policy from server config.
 func TestE2EPlanUsesServerSideTarget(t *testing.T) {

--- a/pkg/webhook/webhook_e2e_test.go
+++ b/pkg/webhook/webhook_e2e_test.go
@@ -2090,6 +2090,19 @@ func TestE2EApplyWithNoCurrentSchemaFilesExplainsInProgressApply(t *testing.T) {
 	assert.NotContains(t, body, "truncated repository tree")
 }
 
+// TestE2EApplyConfirmWithNoCurrentSchemaFilesExplainsInProgressApply verifies
+// that apply-confirm also fails closed before discovery when a PR no longer has
+// managed schema files but still owns an in-flight apply.
+func TestE2EApplyConfirmWithNoCurrentSchemaFilesExplainsInProgressApply(t *testing.T) {
+	body, treeCalls := runCommandWithNoCurrentSchemaFilesAndApplyOwnedCheck(t, "schemabot apply-confirm -e staging", state.Apply.Running, checkStatusInProgress, "")
+
+	assert.Zero(t, treeCalls, "empty-diff apply-confirm should not use whole-repo git tree discovery")
+	assert.Contains(t, body, "SchemaBot is still applying a schema change from this PR")
+	assert.Contains(t, body, "schemabot stop apply-empty-diff -e staging")
+	assert.Contains(t, body, "schemabot rollback apply-empty-diff -e staging")
+	assert.NotContains(t, body, "truncated repository tree")
+}
+
 func runCommandWithNoCurrentSchemaFilesAndApplyOwnedCheck(t *testing.T, comment, applyState, checkStatus, checkConclusion string) (string, int64) {
 	t.Helper()
 


### PR DESCRIPTION
## Why
When a PR no longer contains managed schema files after an apply has started, SchemaBot should fail closed with clear reconciliation guidance instead of falling through to broad repository discovery or implying the PR is clean.

## What
- Add empty-diff reconciliation handling for plan/apply/apply-confirm PR commands
- Render distinct guidance for in-progress vs completed apply-owned state
- Add preview scenarios and update the generated template snapshot

## Risk Assessment
Medium — this changes GitHub PR-command behavior for a safety-gate edge case, but only when the current PR has no managed schema files and stored apply-owned state exists.

Generated with Amp
