### PR TITLE
fix(mysql): normalize MySQL connection handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -211,7 +211,8 @@ All SQL statements processed by SchemaBot **must be parseable by the TiDB parser
 
 ### Database Connections
 
-- After `sql.Open()`, always call `db.PingContext(ctx)` to verify the connection works (Go's sql driver lazy-loads connections).
+- Use `mysqlconn.Open()` from `github.com/block/schemabot/pkg/mysqlconn` for SchemaBot-managed MySQL connections. It centralizes DSN normalization, including required TLS settings for RDS targets. Use raw `sql.Open("mysql", ...)` only for local test/dev infrastructure (for example LocalScale) or engine-specific connection paths that intentionally manage their own TLS config (for example PlanetScale/Vitess mTLS).
+- After opening a database with `mysqlconn.Open()` or raw `sql.Open("mysql", ...)`, always call `db.PingContext(ctx)` to verify the connection works (Go's sql driver lazy-loads connections).
 - Always backtick-quote SQL identifiers: `` USE `db` ``, `` SHOW CREATE TABLE `tbl` ``.
 - **Never manipulate DSN strings with `strings.Replace`.** Use `mysql.ParseDSN()` / `cfg.FormatDSN()` from `github.com/go-sql-driver/mysql` to parse, modify fields, and re-serialize. String manipulation is fragile and breaks on DSNs with passwords containing `/` or other special characters.
 

--- a/pkg/api/ensure_schema.go
+++ b/pkg/api/ensure_schema.go
@@ -14,6 +14,7 @@ import (
 	"github.com/block/schemabot/pkg/ddl"
 	"github.com/block/schemabot/pkg/engine"
 	"github.com/block/schemabot/pkg/engine/spirit"
+	"github.com/block/schemabot/pkg/mysqlconn"
 	"github.com/block/schemabot/pkg/schema"
 )
 
@@ -197,7 +198,7 @@ func EnsureSchema(dsn string, logger *slog.Logger) error {
 }
 
 func staleSpiritTableNames(ctx context.Context, dsn string) ([]string, error) {
-	db, err := sql.Open("mysql", dsn)
+	db, err := mysqlconn.Open(dsn)
 	if err != nil {
 		return nil, fmt.Errorf("open database: %w", err)
 	}
@@ -286,7 +287,7 @@ type storageDiagnostic struct {
 // diagnoseStorageTarget connects to the DSN and queries the actual database
 // identity and existing table state. Used for diagnostic logging only.
 func diagnoseStorageTarget(ctx context.Context, dsn string) (*storageDiagnostic, error) {
-	db, err := sql.Open("mysql", dsn)
+	db, err := mysqlconn.Open(dsn)
 	if err != nil {
 		return nil, fmt.Errorf("open database: %w", err)
 	}
@@ -330,7 +331,7 @@ const ensureSchemaLockName = "schemabot_ensure_schema"
 // EnsureSchema across pods. Returns the connection holding the lock — the
 // lock is released when the connection is closed.
 func acquireEnsureSchemaLock(ctx context.Context, dsn string, logger *slog.Logger) (*sql.Conn, error) {
-	db, err := sql.Open("mysql", dsn)
+	db, err := mysqlconn.Open(dsn)
 	if err != nil {
 		return nil, fmt.Errorf("open database: %w", err)
 	}
@@ -378,7 +379,7 @@ func acquireEnsureSchemaLock(ctx context.Context, dsn string, logger *slog.Logge
 // This must NOT be used on target databases where user schema changes may be
 // in progress or resumable.
 func cleanStaleSpiritTables(ctx context.Context, dsn string, logger *slog.Logger) error {
-	db, err := sql.Open("mysql", dsn)
+	db, err := mysqlconn.Open(dsn)
 	if err != nil {
 		return fmt.Errorf("open database: %w", err)
 	}

--- a/pkg/cmd/commands/serve.go
+++ b/pkg/cmd/commands/serve.go
@@ -22,6 +22,7 @@ import (
 	"github.com/block/schemabot/pkg/api"
 	ghclient "github.com/block/schemabot/pkg/github"
 	"github.com/block/schemabot/pkg/metrics"
+	"github.com/block/schemabot/pkg/mysqlconn"
 	"github.com/block/schemabot/pkg/storage/mysqlstore"
 	"github.com/block/schemabot/pkg/tern"
 	"github.com/block/schemabot/pkg/webhook"
@@ -87,7 +88,7 @@ func (cmd *ServeCmd) Run(g *Globals) error {
 			return fmt.Errorf("ensure schema after %d attempts: %w", maxRetries, err)
 		}
 
-		db, err = sql.Open("mysql", dsn)
+		db, err = mysqlconn.Open(dsn)
 		if err != nil {
 			return fmt.Errorf("open database: %w", err)
 		}

--- a/pkg/engine/spirit/control.go
+++ b/pkg/engine/spirit/control.go
@@ -21,6 +21,7 @@ import (
 	"github.com/block/spirit/pkg/utils"
 
 	"github.com/block/schemabot/pkg/engine"
+	"github.com/block/schemabot/pkg/mysqlconn"
 )
 
 // Stop pauses a running schema change.
@@ -193,7 +194,7 @@ func (e *Engine) Cutover(ctx context.Context, req *engine.ControlRequest) (*engi
 		return nil, fmt.Errorf("database is required for cutover")
 	}
 
-	db, err := openMySQL(req.Credentials.DSN)
+	db, err := mysqlconn.Open(req.Credentials.DSN)
 	if err != nil {
 		return nil, fmt.Errorf("open connection for cutover: %w", err)
 	}
@@ -242,7 +243,7 @@ func (e *Engine) DeferredCutoverSignalExists(ctx context.Context, req *engine.De
 		return false, fmt.Errorf("database is required for deferred cutover signal lookup")
 	}
 
-	db, err := openMySQL(req.Credentials.DSN)
+	db, err := mysqlconn.Open(req.Credentials.DSN)
 	if err != nil {
 		return false, fmt.Errorf("open connection for deferred cutover signal lookup: %w", err)
 	}
@@ -459,7 +460,7 @@ func settingsToVolume(threads int, chunkTime time.Duration) int32 {
 // dynamically calculated from available_logical_processors / 4.
 // Returns 0 if the query fails or the value can't be determined.
 func (e *Engine) queryCPUHint(ctx context.Context, dsn string) int {
-	db, err := openMySQL(dsn)
+	db, err := mysqlconn.Open(dsn)
 	if err != nil {
 		e.logger.Debug("queryCPUHint: failed to open", "error", err)
 		return 0
@@ -511,7 +512,7 @@ func (e *Engine) logCheckpointState(rm *runningMigration, phase string, extra ma
 	cfg.InterpolateParams = true
 	dsn := cfg.FormatDSN()
 
-	db, err := openMySQL(dsn)
+	db, err := mysqlconn.Open(dsn)
 	if err != nil {
 		e.logger.Warn("logCheckpointState: failed to open", "error", err)
 		return

--- a/pkg/engine/spirit/helpers.go
+++ b/pkg/engine/spirit/helpers.go
@@ -1,13 +1,11 @@
 package spirit
 
 import (
-	"database/sql"
 	"errors"
 	"fmt"
 	"sort"
 	"strings"
 
-	"github.com/block/spirit/pkg/dbconn"
 	"github.com/block/spirit/pkg/statement"
 	"github.com/go-sql-driver/mysql"
 
@@ -21,46 +19,6 @@ func parseDSN(dsn string) (host, username, password, database string, err error)
 		return "", "", "", "", fmt.Errorf("parse DSN: %w", err)
 	}
 	return cfg.Addr, cfg.User, cfg.Passwd, cfg.DBName, nil
-}
-
-func openMySQL(dsn string) (*sql.DB, error) {
-	connectionDSN, err := mysqlConnectionDSN(dsn)
-	if err != nil {
-		return nil, err
-	}
-	db, err := sql.Open("mysql", connectionDSN)
-	if err != nil {
-		return nil, fmt.Errorf("open MySQL connection: %w", err)
-	}
-	return db, nil
-}
-
-func mysqlConnectionDSN(dsn string) (string, error) {
-	cfg, err := mysql.ParseDSN(dsn)
-	if err != nil {
-		return "", fmt.Errorf("parse DSN: %w", err)
-	}
-	if cfg.TLSConfig != "" {
-		return dsn, nil
-	}
-	tlsMode, ok := mysqlTLSModeForHost(cfg.Addr)
-	if !ok {
-		return dsn, nil
-	}
-	dbConfig := dbconn.NewDBConfig()
-	dbConfig.TLSMode = tlsMode
-	connectionDSN, err := dbconn.EnhanceDSNWithTLS(dsn, dbConfig)
-	if err != nil {
-		return "", fmt.Errorf("enhance RDS DSN with TLS: %w", err)
-	}
-	return connectionDSN, nil
-}
-
-func mysqlTLSModeForHost(addr string) (string, bool) {
-	if dbconn.IsRDSHost(addr) {
-		return "REQUIRED", true
-	}
-	return "", false
 }
 
 // namespaceForTable finds which namespace a table belongs to by checking

--- a/pkg/engine/spirit/helpers_test.go
+++ b/pkg/engine/spirit/helpers_test.go
@@ -3,77 +3,11 @@ package spirit
 import (
 	"testing"
 
-	"github.com/go-sql-driver/mysql"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/block/schemabot/pkg/schema"
 )
-
-func TestMySQLConnectionDSN(t *testing.T) {
-	tests := []struct {
-		name       string
-		dsn        string
-		wantTLS    string
-		wantSame   bool
-		wantErrSub string
-	}{
-		{
-			name:    "RDS host gets TLS",
-			dsn:     "spirit:secret@tcp(database.cluster-abc123.us-west-2.rds.amazonaws.com:3306)/app?parseTime=true",
-			wantTLS: "rds",
-		},
-		{
-			name:     "non-RDS host is unchanged",
-			dsn:      "root:secret@tcp(localhost:3306)/app?parseTime=true",
-			wantSame: true,
-		},
-		{
-			name:     "database alias is unchanged",
-			dsn:      "spirit:secret@tcp(database.example.com:3306)/app?parseTime=true",
-			wantSame: true,
-		},
-		{
-			name:     "explicit TLS is preserved",
-			dsn:      "spirit:secret@tcp(database.cluster-abc123.us-west-2.rds.amazonaws.com:3306)/app?tls=skip-verify",
-			wantTLS:  "skip-verify",
-			wantSame: true,
-		},
-		{
-			name:     "explicit disabled TLS is preserved",
-			dsn:      "spirit:secret@tcp(database.cluster-abc123.us-west-2.rds.amazonaws.com:3306)/app?tls=false",
-			wantTLS:  "false",
-			wantSame: true,
-		},
-		{
-			name:       "invalid DSN returns context",
-			dsn:        "not-a-dsn",
-			wantErrSub: "parse DSN",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := mysqlConnectionDSN(tt.dsn)
-			if tt.wantErrSub != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.wantErrSub)
-				return
-			}
-
-			require.NoError(t, err)
-			if tt.wantSame {
-				assert.Equal(t, tt.dsn, got)
-			}
-
-			cfg, err := mysql.ParseDSN(got)
-			require.NoError(t, err)
-			assert.Equal(t, tt.wantTLS, cfg.TLSConfig)
-			_, err = mysql.NewConnector(cfg)
-			require.NoError(t, err)
-		})
-	}
-}
 
 func TestNamespaceForTable(t *testing.T) {
 	sf := schema.SchemaFiles{

--- a/pkg/engine/spirit/pending_drops.go
+++ b/pkg/engine/spirit/pending_drops.go
@@ -16,6 +16,7 @@ import (
 	"github.com/pingcap/tidb/pkg/parser/ast"
 
 	"github.com/block/schemabot/pkg/metrics"
+	"github.com/block/schemabot/pkg/mysqlconn"
 	"github.com/block/schemabot/pkg/pendingdrops"
 )
 
@@ -58,11 +59,7 @@ func (e *Engine) quarantineDroppedTables(ctx context.Context, host, username, pa
 	cfg.Passwd = password
 	cfg.DBName = database
 
-	connectionDSN, err := mysqlConnectionDSN(cfg.FormatDSN())
-	if err != nil {
-		return fmt.Errorf("build pending drops connection DSN for database %s: %w", database, err)
-	}
-	db, err := sql.Open("mysql", connectionDSN)
+	db, err := mysqlconn.Open(cfg.FormatDSN())
 	if err != nil {
 		return fmt.Errorf("open database %s: %w", database, err)
 	}

--- a/pkg/engine/spirit/spirit.go
+++ b/pkg/engine/spirit/spirit.go
@@ -29,6 +29,7 @@ import (
 	"github.com/block/schemabot/pkg/ddl"
 	"github.com/block/schemabot/pkg/engine"
 	"github.com/block/schemabot/pkg/lint"
+	"github.com/block/schemabot/pkg/mysqlconn"
 )
 
 // DefaultTargetChunkTime is the default time Spirit aims for per chunk.
@@ -553,7 +554,7 @@ func progressState(rm *runningMigration, spiritState status.State) engine.State 
 // fetchCurrentSchema retrieves table schemas from the database, filtering out
 // internal tables (Spirit shadow/checkpoint tables and other _-prefixed tables).
 func (e *Engine) fetchCurrentSchema(ctx context.Context, dsn, _ string) ([]table.TableSchema, error) {
-	db, err := openMySQL(dsn)
+	db, err := mysqlconn.Open(dsn)
 	if err != nil {
 		return nil, fmt.Errorf("open database: %w", err)
 	}

--- a/pkg/mysqlconn/mysqlconn.go
+++ b/pkg/mysqlconn/mysqlconn.go
@@ -1,0 +1,53 @@
+package mysqlconn
+
+import (
+	"database/sql"
+	"fmt"
+
+	"github.com/block/spirit/pkg/dbconn"
+	"github.com/go-sql-driver/mysql"
+)
+
+var openSQL = sql.Open
+
+// Open returns a MySQL connection using the same target-DSN normalization as Spirit.
+func Open(dsn string) (*sql.DB, error) {
+	connectionDSN, err := ConnectionDSN(dsn)
+	if err != nil {
+		return nil, err
+	}
+	db, err := openSQL("mysql", connectionDSN)
+	if err != nil {
+		return nil, fmt.Errorf("open MySQL connection: %w", err)
+	}
+	return db, nil
+}
+
+// ConnectionDSN returns a MySQL DSN with required transport settings applied.
+func ConnectionDSN(dsn string) (string, error) {
+	cfg, err := mysql.ParseDSN(dsn)
+	if err != nil {
+		return "", fmt.Errorf("parse DSN: %w", err)
+	}
+	if cfg.TLSConfig != "" {
+		return dsn, nil
+	}
+	tlsMode, ok := tlsModeForHost(cfg.Addr)
+	if !ok {
+		return dsn, nil
+	}
+	dbConfig := dbconn.NewDBConfig()
+	dbConfig.TLSMode = tlsMode
+	connectionDSN, err := dbconn.EnhanceDSNWithTLS(dsn, dbConfig)
+	if err != nil {
+		return "", fmt.Errorf("enhance RDS DSN with TLS: %w", err)
+	}
+	return connectionDSN, nil
+}
+
+func tlsModeForHost(addr string) (string, bool) {
+	if dbconn.IsRDSHost(addr) {
+		return "REQUIRED", true
+	}
+	return "", false
+}

--- a/pkg/mysqlconn/mysqlconn_test.go
+++ b/pkg/mysqlconn/mysqlconn_test.go
@@ -1,0 +1,98 @@
+package mysqlconn
+
+import (
+	"database/sql"
+	"errors"
+	"testing"
+
+	"github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConnectionDSN(t *testing.T) {
+	tests := []struct {
+		name       string
+		dsn        string
+		wantTLS    string
+		wantSame   bool
+		wantErrSub string
+	}{
+		{
+			name:    "RDS host gets TLS",
+			dsn:     "spirit:secret@tcp(database.cluster-abc123.us-west-2.rds.amazonaws.com:3306)/app?parseTime=true",
+			wantTLS: "rds",
+		},
+		{
+			name:     "non-RDS host is unchanged",
+			dsn:      "root:secret@tcp(localhost:3306)/app?parseTime=true",
+			wantSame: true,
+		},
+		{
+			name:     "database alias is unchanged",
+			dsn:      "spirit:secret@tcp(database.example.com:3306)/app?parseTime=true",
+			wantSame: true,
+		},
+		{
+			name:     "explicit TLS is preserved",
+			dsn:      "spirit:secret@tcp(database.cluster-abc123.us-west-2.rds.amazonaws.com:3306)/app?tls=skip-verify",
+			wantTLS:  "skip-verify",
+			wantSame: true,
+		},
+		{
+			name:     "explicit disabled TLS is preserved",
+			dsn:      "spirit:secret@tcp(database.cluster-abc123.us-west-2.rds.amazonaws.com:3306)/app?tls=false",
+			wantTLS:  "false",
+			wantSame: true,
+		},
+		{
+			name:       "invalid DSN returns context",
+			dsn:        "not-a-dsn",
+			wantErrSub: "parse DSN",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ConnectionDSN(tt.dsn)
+			if tt.wantErrSub != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErrSub)
+				return
+			}
+
+			require.NoError(t, err)
+			if tt.wantSame {
+				assert.Equal(t, tt.dsn, got)
+			}
+
+			cfg, err := mysql.ParseDSN(got)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantTLS, cfg.TLSConfig)
+			_, err = mysql.NewConnector(cfg)
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestOpenNormalizesRDSDSNBeforeOpening(t *testing.T) {
+	originalOpenSQL := openSQL
+	t.Cleanup(func() { openSQL = originalOpenSQL })
+
+	openErr := errors.New("stop before network connection")
+	var gotDriver string
+	var gotDSN string
+	openSQL = func(driverName, dsn string) (*sql.DB, error) {
+		gotDriver = driverName
+		gotDSN = dsn
+		return nil, openErr
+	}
+
+	_, err := Open("spirit:secret@tcp(database.cluster-abc123.us-west-2.rds.amazonaws.com:3306)/app?parseTime=true")
+
+	require.ErrorIs(t, err, openErr)
+	assert.Equal(t, "mysql", gotDriver)
+	cfg, parseErr := mysql.ParseDSN(gotDSN)
+	require.NoError(t, parseErr)
+	assert.Equal(t, "rds", cfg.TLSConfig)
+}

--- a/pkg/pendingdrops/cleaner.go
+++ b/pkg/pendingdrops/cleaner.go
@@ -12,6 +12,7 @@ import (
 	"github.com/block/spirit/pkg/utils"
 
 	"github.com/block/schemabot/pkg/metrics"
+	"github.com/block/schemabot/pkg/mysqlconn"
 )
 
 const (
@@ -85,7 +86,7 @@ func (c *Cleaner) Run(ctx context.Context) error {
 // cleanTarget connects to one target, serializes against other SchemaBot
 // instances with an advisory lock, and drops expired quarantined tables.
 func (c *Cleaner) cleanTarget(ctx context.Context, target Target) error {
-	db, err := sql.Open("mysql", target.DSN)
+	db, err := mysqlconn.Open(target.DSN)
 	if err != nil {
 		metrics.RecordPendingDropsCleanupError(ctx, target.Database, target.Environment, "target_error")
 		return fmt.Errorf("open target %s/%s: %w", target.Database, target.Environment, err)

--- a/pkg/tern/local_client.go
+++ b/pkg/tern/local_client.go
@@ -87,7 +87,6 @@ package tern
 
 import (
 	"context"
-	"database/sql"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -106,6 +105,7 @@ import (
 	"github.com/block/schemabot/pkg/engine"
 	"github.com/block/schemabot/pkg/engine/planetscale"
 	"github.com/block/schemabot/pkg/engine/spirit"
+	"github.com/block/schemabot/pkg/mysqlconn"
 	ternv1 "github.com/block/schemabot/pkg/proto/ternv1"
 	"github.com/block/schemabot/pkg/psclient"
 	"github.com/block/schemabot/pkg/state"
@@ -290,7 +290,7 @@ func (c *LocalClient) PullSchema(ctx context.Context, req *ternv1.PullSchemaRequ
 	attrs = append(attrs, dsnLogAttrs(c.config.TargetDSN)...)
 	c.logger.Info("LocalClient.PullSchema: loading live schema", attrs...)
 
-	db, err := sql.Open("mysql", c.config.TargetDSN)
+	db, err := mysqlconn.Open(c.config.TargetDSN)
 	if err != nil {
 		return nil, fmt.Errorf("open database %s for schema pull: %w", c.config.Database, err)
 	}


### PR DESCRIPTION
## Why
Some SchemaBot-managed MySQL workflows opened raw DSNs directly, which could bypass required connection normalization such as TLS settings for managed MySQL hosts.

## What
- Add a shared MySQL connection helper for SchemaBot-managed MySQL connections
- Route storage bootstrap, Spirit, pull/onboard, and pending-drop MySQL opens through the helper
- Document the helper as the default path for future SchemaBot-managed MySQL connections

## Risk Assessment
Medium — this touches shared MySQL connection setup, but the helper preserves explicit TLS settings and leaves local dev and Vitess-specific connection paths unchanged.

Generated with Amp