### PR TITLE
feat(operator): project apply state with on_failure continue policy

### DIFF
--- a/pkg/api/operator.go
+++ b/pkg/api/operator.go
@@ -723,9 +723,13 @@ func (s *Service) markOperationFromApplyState(ctx context.Context, workerID int,
 //
 // This is the inverse of markOperationFromApplyState: the operator drives each
 // operation row to its state, then the parent apply's state follows from the
-// aggregate via the same state.DeriveApplyState that derives apply state from
-// task states. While an apply has exactly one operation the derived value equals
-// the value ResumeApply already persisted, so this is a no-op until the
+// aggregate via state.DeriveRolloutApplyState, the policy-aware projection over
+// all operation rows. Under on_failure "continue" a terminal-failed sibling no
+// longer terminalizes the apply while other siblings are still in flight; the
+// apply is held running until the rollout settles, then takes the failed verdict.
+// Every other policy (halt, pause, unrecognized) fails closed to the failed
+// verdict. While an apply has exactly one operation the derived value equals the
+// value ResumeApply already persisted, so this is a no-op until the
 // multi-deployment fan-out makes an apply own more than one operation.
 //
 // The caller is responsible for lease scoping: the active operator path passes a
@@ -742,11 +746,14 @@ func (s *Service) updateApplyStateFromOperations(ctx context.Context, workerID i
 		return fmt.Errorf("derive apply state for apply %s (%d): no apply_operations rows", apply.ApplyIdentifier, apply.ID)
 	}
 
-	childStates := make([]string, len(ops))
+	children := make([]state.RolloutChild, len(ops))
 	for i, op := range ops {
-		childStates[i] = op.State
+		children[i] = state.RolloutChild{
+			State:             op.State,
+			ContinueOnFailure: op.OnFailure == storage.OnFailureContinue,
+		}
 	}
-	derived := state.DeriveApplyState(childStates)
+	derived := state.DeriveRolloutApplyState(children)
 
 	if state.IsTerminalApplyState(apply.State) && !state.IsTerminalApplyState(derived) {
 		return fmt.Errorf("derive apply state for terminal apply %s (%d): child operations derive non-terminal state %q from parent state %q",

--- a/pkg/api/operator_test.go
+++ b/pkg/api/operator_test.go
@@ -92,3 +92,99 @@ func TestMarkOperationFromApplyState_MirrorsFailedRetryable(t *testing.T) {
 	assert.Equal(t, state.Apply.FailedRetryable, opStore.updateStateValue,
 		"failed_retryable must be mirrored down, not a terminal state")
 }
+
+// listingApplyOperationStore returns a fixed set of operation rows from
+// ListByApply so the derived-apply-state projection can be exercised against a
+// multi-deployment sibling set.
+type listingApplyOperationStore struct {
+	storage.ApplyOperationStore
+	ops []*storage.ApplyOperation
+}
+
+func (s *listingApplyOperationStore) ListByApply(context.Context, int64) ([]*storage.ApplyOperation, error) {
+	return s.ops, nil
+}
+
+// recordingApplyStore captures the apply persisted by Update so the test can
+// assert the derived state and completed_at stamping.
+type recordingApplyStore struct {
+	storage.ApplyStore
+	updated *storage.Apply
+}
+
+func (s *recordingApplyStore) Update(_ context.Context, apply *storage.Apply) error {
+	updated := *apply
+	s.updated = &updated
+	return nil
+}
+
+func newOperatorStateTestService(opStore storage.ApplyOperationStore, applyStore storage.ApplyStore) *Service {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	return New(&mockStorageWithApplyStoresAndOperations{applyOps: opStore, applies: applyStore}, testServerConfig(), nil, logger)
+}
+
+type mockStorageWithApplyStoresAndOperations struct {
+	mockStorage
+	applyOps storage.ApplyOperationStore
+	applies  storage.ApplyStore
+}
+
+func (m *mockStorageWithApplyStoresAndOperations) ApplyOperations() storage.ApplyOperationStore {
+	return m.applyOps
+}
+func (m *mockStorageWithApplyStoresAndOperations) Applies() storage.ApplyStore { return m.applies }
+
+// TestUpdateApplyStateFromOperations_ContinuePolicy verifies that the operator's
+// apply-state writer projects the rollout policy over the sibling set: under
+// on_failure "continue" a terminally failed deployment holds the apply running
+// while a sibling is still pending, while the default policy fails closed and
+// terminalizes the apply.
+func TestUpdateApplyStateFromOperations_ContinuePolicy(t *testing.T) {
+	cases := []struct {
+		name      string
+		ops       []*storage.ApplyOperation
+		wantState string
+		wantDone  bool
+	}{
+		{
+			name: "continue holds the apply running past a failed deployment",
+			ops: []*storage.ApplyOperation{
+				{ID: 1, State: state.ApplyOperation.Failed, OnFailure: storage.OnFailureContinue},
+				{ID: 2, State: state.ApplyOperation.Pending, OnFailure: storage.OnFailureContinue},
+			},
+			wantState: state.Apply.Running,
+			wantDone:  false,
+		},
+		{
+			name: "default policy terminalizes the apply on a failed deployment",
+			ops: []*storage.ApplyOperation{
+				{ID: 1, State: state.ApplyOperation.Failed},
+				{ID: 2, State: state.ApplyOperation.Pending},
+			},
+			wantState: state.Apply.Failed,
+			wantDone:  true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			applyStore := &recordingApplyStore{}
+			svc := newOperatorStateTestService(&listingApplyOperationStore{ops: tc.ops}, applyStore)
+
+			apply := &storage.Apply{
+				ID:              3,
+				ApplyIdentifier: "apply-projection",
+				State:           state.Apply.Pending,
+				Environment:     "staging",
+			}
+
+			require.NoError(t, svc.updateApplyStateFromOperations(t.Context(), 1, apply))
+			require.NotNil(t, applyStore.updated, "derived state differs from current, so the apply must be persisted")
+			assert.Equal(t, tc.wantState, applyStore.updated.State)
+			if tc.wantDone {
+				assert.NotNil(t, applyStore.updated.CompletedAt, "terminal derived state stamps completed_at")
+			} else {
+				assert.Nil(t, applyStore.updated.CompletedAt, "non-terminal derived state leaves completed_at nil")
+			}
+		})
+	}
+}

--- a/pkg/state/apply.go
+++ b/pkg/state/apply.go
@@ -127,6 +127,73 @@ func DeriveApplyState(taskStates []string) string {
 	return Apply.Pending
 }
 
+// RolloutChild is one apply_operation's contribution to the parent apply's
+// rollout projection: its derived state plus whether the on_failure policy
+// captured on that operation lets the rollout continue past a terminal failure.
+//
+// ContinueOnFailure must be set by the caller using the exact-match semantics of
+// the claim predicate: only the literal on_failure value "continue" is
+// continuable; "halt", "pause", and any unrecognized value are not, so the
+// projection fails closed (a failed sibling keeps the apply failed) on anything
+// but an explicit continue.
+type RolloutChild struct {
+	// State is the child operation's derived apply state.
+	State string
+	// ContinueOnFailure is true only when the operation's on_failure policy is
+	// exactly "continue".
+	ContinueOnFailure bool
+}
+
+// DeriveRolloutApplyState projects the parent apply's state over all of its
+// child operations, accounting for the on_failure rollout-continuation policy.
+//
+// It builds on DeriveApplyState: the base projection is computed the same way,
+// and any non-failed base is returned unchanged. The policy only modulates the
+// failed case. continue governs rollout *continuation*, never the apply's
+// pass/fail verdict — so an apply that suffered a continuable failure still
+// settles to failed once every sibling is terminal; the policy only delays that
+// verdict so the remaining siblings get their turn instead of the first failure
+// terminalizing the whole apply.
+//
+// When the base projection is failed (at least one child terminally failed):
+//
+//   - if any failed child is not continuable (ContinueOnFailure false), the
+//     failure stands and the apply is failed (fail closed, matching halt); else
+//   - if every child is terminal, the rollout is settled and the apply is
+//     failed (the verdict still reflects the failure); else
+//   - the apply is held running so the still-in-flight siblings can run to
+//     completion under continue.
+//
+// An empty child set returns Pending, matching DeriveApplyState.
+func DeriveRolloutApplyState(children []RolloutChild) string {
+	if len(children) == 0 {
+		return Apply.Pending
+	}
+
+	childStates := make([]string, len(children))
+	for i, c := range children {
+		childStates[i] = c.State
+	}
+	base := DeriveApplyState(childStates)
+	if !IsState(base, Apply.Failed) {
+		return base
+	}
+
+	allTerminal := true
+	for _, c := range children {
+		if IsState(c.State, Apply.Failed) && !c.ContinueOnFailure {
+			return Apply.Failed
+		}
+		if !IsTerminalApplyState(c.State) {
+			allTerminal = false
+		}
+	}
+	if allTerminal {
+		return Apply.Failed
+	}
+	return Apply.Running
+}
+
 // normalizeApplyState converts a task state string to its canonical lowercase form.
 func normalizeApplyState(raw string) string {
 	switch strings.ToUpper(raw) {

--- a/pkg/state/apply_test.go
+++ b/pkg/state/apply_test.go
@@ -305,3 +305,108 @@ func TestNormalizeApplyState_NewStates(t *testing.T) {
 	assert.Equal(t, Apply.ValidatingBranch, normalizeApplyState("VALIDATING_BRANCH"))
 	assert.Equal(t, Apply.ValidatingDeployRequest, normalizeApplyState("VALIDATING_DEPLOY_REQUEST"))
 }
+
+// rc builds a RolloutChild from a state and its continuation policy so the
+// truth-table cases below read like the rollout scenario they describe.
+func rc(state string, continueOnFailure bool) RolloutChild {
+	return RolloutChild{State: state, ContinueOnFailure: continueOnFailure}
+}
+
+func TestDeriveRolloutApplyState_Empty(t *testing.T) {
+	assert.Equal(t, Apply.Pending, DeriveRolloutApplyState(nil))
+	assert.Equal(t, Apply.Pending, DeriveRolloutApplyState([]RolloutChild{}))
+}
+
+// TestDeriveRolloutApplyState_NoFailureMatchesBase verifies that when no child
+// has terminally failed, the rollout projection is exactly the base projection
+// regardless of any child's continuation policy.
+func TestDeriveRolloutApplyState_NoFailureMatchesBase(t *testing.T) {
+	cases := []struct {
+		name     string
+		children []RolloutChild
+		want     string
+	}{
+		{
+			name:     "all pending",
+			children: []RolloutChild{rc(Apply.Pending, false), rc(Apply.Pending, true)},
+			want:     Apply.Pending,
+		},
+		{
+			name:     "all completed",
+			children: []RolloutChild{rc(Apply.Completed, true), rc(Apply.Completed, true)},
+			want:     Apply.Completed,
+		},
+		{
+			name:     "running and completed",
+			children: []RolloutChild{rc(Apply.Running, true), rc(Apply.Completed, true)},
+			want:     Apply.Running,
+		},
+		{
+			name:     "stopped sibling holds",
+			children: []RolloutChild{rc(Apply.Stopped, true), rc(Apply.Completed, true)},
+			want:     Apply.Stopped,
+		},
+		{
+			name:     "failed_retryable not yet failed",
+			children: []RolloutChild{rc(Apply.FailedRetryable, true), rc(Apply.Running, true)},
+			want:     Apply.FailedRetryable,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, DeriveRolloutApplyState(tc.children))
+		})
+	}
+}
+
+// TestDeriveRolloutApplyState_FailurePolicy is the truth table for the failed
+// base case: continue holds the apply active until siblings settle, while halt,
+// pause, and unrecognized policies fail closed to the failed verdict.
+func TestDeriveRolloutApplyState_FailurePolicy(t *testing.T) {
+	cases := []struct {
+		name     string
+		children []RolloutChild
+		want     string
+	}{
+		{
+			name:     "continue failure with pending sibling holds running",
+			children: []RolloutChild{rc(Apply.Failed, true), rc(Apply.Pending, true)},
+			want:     Apply.Running,
+		},
+		{
+			name:     "continue failure with running sibling holds running",
+			children: []RolloutChild{rc(Apply.Failed, true), rc(Apply.Running, true)},
+			want:     Apply.Running,
+		},
+		{
+			name:     "continue failure with all siblings terminal settles failed",
+			children: []RolloutChild{rc(Apply.Failed, true), rc(Apply.Completed, true)},
+			want:     Apply.Failed,
+		},
+		{
+			name:     "continue failure with another failed continue sibling settles failed",
+			children: []RolloutChild{rc(Apply.Failed, true), rc(Apply.Failed, true)},
+			want:     Apply.Failed,
+		},
+		{
+			name:     "non-continuable (halt) failure fails closed even with pending sibling",
+			children: []RolloutChild{rc(Apply.Failed, false), rc(Apply.Pending, false)},
+			want:     Apply.Failed,
+		},
+		{
+			name:     "mixed: one continue failure, one halt failure fails closed",
+			children: []RolloutChild{rc(Apply.Failed, true), rc(Apply.Failed, false), rc(Apply.Pending, true)},
+			want:     Apply.Failed,
+		},
+		{
+			name:     "continue failure with completed and pending holds running",
+			children: []RolloutChild{rc(Apply.Failed, true), rc(Apply.Completed, true), rc(Apply.Pending, true)},
+			want:     Apply.Running,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, DeriveRolloutApplyState(tc.children))
+		})
+	}
+}

--- a/pkg/tern/local_apply_grouped.go
+++ b/pkg/tern/local_apply_grouped.go
@@ -310,9 +310,15 @@ func applyOperationIDForTask(task *storage.Task) (int64, error) {
 }
 
 // deriveAggregateApplyState computes applies.state as the rollout projection
-// over every apply_operation row of the apply. The boolean is false when the
-// projection could not be determined safely and the caller must leave the
+// over every apply_operation row of the apply, accounting for each operation's
+// on_failure policy via state.DeriveRolloutApplyState. The boolean is false when
+// the projection could not be determined safely and the caller must leave the
 // stored apply state unchanged.
+//
+// Under on_failure "continue" a terminal-failed sibling does not terminalize the
+// apply while other siblings are still in flight: the apply is held running until
+// the rollout settles, then takes the failed verdict. Every other policy fails
+// closed and a failed sibling terminalizes the apply immediately.
 //
 // Invariant: applies.state is the rollout projection over all operations of the
 // apply, not only the operation this drive is executing. The current
@@ -391,22 +397,25 @@ func (c *LocalClient) deriveAggregateApplyState(ctx context.Context, apply *stor
 		return failClosed()
 	}
 
-	childStates := make([]string, len(ops))
+	children := make([]state.RolloutChild, len(ops))
 	foundCurrent := false
 	for i, op := range ops {
-		if op.ID == operationID {
-			childStates[i] = currentOpState
-			foundCurrent = true
-			continue
+		child := state.RolloutChild{
+			State:             op.State,
+			ContinueOnFailure: op.OnFailure == storage.OnFailureContinue,
 		}
-		childStates[i] = op.State
+		if op.ID == operationID {
+			child.State = currentOpState
+			foundCurrent = true
+		}
+		children[i] = child
 	}
 	if !foundCurrent {
 		c.logger.Warn("cannot determine aggregate apply state: current operation row missing from sibling set",
 			"apply_id", apply.ApplyIdentifier, "apply_operation_id", operationID)
 		return failClosed()
 	}
-	return state.DeriveApplyState(childStates), true
+	return state.DeriveRolloutApplyState(children), true
 }
 
 // executeApplySequential runs each DDL as a separate Spirit call (independent mode).

--- a/pkg/tern/local_client_test.go
+++ b/pkg/tern/local_client_test.go
@@ -1259,6 +1259,52 @@ func TestDeriveAggregateApplyState(t *testing.T) {
 		assert.False(t, state.IsState(got, state.Apply.Completed), "derived state must not clobber the pending sibling to completed")
 	})
 
+	// Under on_failure "continue" a terminally failed deployment does not
+	// terminalize the apply while a sibling is still pending: the apply is held
+	// running so the remaining deployment gets its turn, then settles to failed
+	// once every sibling is terminal.
+	t.Run("continue policy holds the apply active past a failed deployment", func(t *testing.T) {
+		tasks := []*storage.Task{taskWith(state.Task.Failed)}
+		client := &LocalClient{
+			storage: &exactProgressStorage{
+				applyOperations: &listApplyOperationStore{
+					ops: []*storage.ApplyOperation{
+						{ID: currentOpID, State: state.ApplyOperation.Failed, OnFailure: storage.OnFailureContinue},
+						{ID: 2, State: state.ApplyOperation.Pending, OnFailure: storage.OnFailureContinue},
+					},
+				},
+			},
+			logger: slog.Default(),
+		}
+		apply := &storage.Apply{ID: 7, ApplyIdentifier: "apply-continue"}
+
+		got, ok := client.deriveAggregateApplyState(t.Context(), apply, tasks)
+		assert.True(t, ok, "current op row present, projection must be determined")
+		assert.Equal(t, state.Apply.Running, got, "continue policy must hold the apply active until the pending sibling settles")
+	})
+
+	// Default policy (on_failure unset) fails closed: a terminally failed
+	// deployment terminalizes the apply even with a pending sibling.
+	t.Run("default policy terminalizes the apply on a failed deployment", func(t *testing.T) {
+		tasks := []*storage.Task{taskWith(state.Task.Failed)}
+		client := &LocalClient{
+			storage: &exactProgressStorage{
+				applyOperations: &listApplyOperationStore{
+					ops: []*storage.ApplyOperation{
+						{ID: currentOpID, State: state.ApplyOperation.Failed},
+						{ID: 2, State: state.ApplyOperation.Pending},
+					},
+				},
+			},
+			logger: slog.Default(),
+		}
+		apply := &storage.Apply{ID: 7, ApplyIdentifier: "apply-halt"}
+
+		got, ok := client.deriveAggregateApplyState(t.Context(), apply, tasks)
+		assert.True(t, ok, "current op row present, projection must be determined")
+		assert.Equal(t, state.Apply.Failed, got, "default policy must terminalize the apply on a failed deployment")
+	})
+
 	// No operation model in use: the tasks carry no apply_operation_id, or the
 	// operation store is not configured. There are no siblings, so the per-task
 	// derivation is authoritative and may terminalize — this preserves


### PR DESCRIPTION
## What and Why?

Makes the parent apply's state projection policy-aware so a single deployment's
terminal failure no longer terminalizes the whole apply under `on_failure: continue`.
The apply is held active until every sibling deployment settles, then takes the
failed verdict. Every other policy (`halt`, `pause`, unrecognized) fails closed and
terminalizes immediately — only the exact value `continue` is continuable, matching
the claim predicate.

`continue` governs rollout *continuation*, never the apply's pass/fail verdict: a
continuable failure still settles to `failed` once the rollout is done.

```
child operations ──▶ DeriveRolloutApplyState
  base = DeriveApplyState(states)
  base != failed                       ─▶ base
  failed + any non-continuable child   ─▶ failed   (fail closed)
  failed + all children terminal       ─▶ failed   (verdict)
  failed + continuable + sibling live  ─▶ running   (hold active)
```

## Changes

- Add `DeriveRolloutApplyState` + `RolloutChild` to `pkg/state`; it builds on
  `DeriveApplyState` and only modulates the failed case.
- Route both apply-state writers through it: the operator's
  `updateApplyStateFromOperations` and the LocalClient's `deriveAggregateApplyState`.
- `ContinueOnFailure` is computed at each call site from the operation's stored
  policy, keeping `pkg/state` free of a storage dependency.

No behavioural change for single-operation applies (one failed op is already
terminal), so this is dormant until the multi-deployment fan-out wires more than
one operation per apply.

## Roadmap / upcoming PRs

This PR is the **B2** projection slice. The continuation track is sequenced so each PR
is a small, reviewable step; the `on_failure` enum surface (#317) is the policy input it
consumes.

| Upcoming change | Status | PR |
|---|---|---|
| **B1** — derive `applies.state` as the aggregate over all `apply_operations` rows ("Option B") | ✅ Merged | #318 |
| **B2** — policy-aware `continue` projection (hold apply active until siblings settle) | This PR | #337 |
| **B3** — eager failure surfacing + atomic write (see follow-ups below) | Next | TBD |
| **B4** — `running_degraded` active-with-known-failure state | Future | TBD |

### Deferred to B3 (fan-out-gated)

This PR makes the *projection* policy-aware; the *operation-state persistence* and the
*apply-level terminal side-effects* still treat one operation's engine result as
authoritative for the whole apply. Both are correct for single-op (so this PR is a safe
no-op today) and only need fixing once more than one operation per apply exists.

| Issue | Where | Fan-out behaviour under `continue` | Fix |
|---|---|---|---|
| Operation failure not persisted | operator `markOperationFromApplyState` | parent held `running` → mirror takes the "leave claimable" branch → failed op never stored `failed`; sibling gate reads wrong | persist the operation's own drive result first, then re-derive the parent from operation rows |
| Terminal side-effects off per-op result | LocalClient progress finalize | engine result terminal while projection is `running` → stamps `completed_at`, metrics, observers, stops polling early | gate apply-level terminal side-effects on the projected apply state, not the per-operation engine result |
| Terminal guard rejects `failed → running` | `updateApplyStateFromOperations` | guard errors on the legitimate hold-active transition | relax to allow `failed → running` when the projection holds active |

