### PR TITLE
feat(storage): drop the legacy halt_on_failure column

### DIFF
--- a/pkg/schema/mysql/apply_operations.sql
+++ b/pkg/schema/mysql/apply_operations.sql
@@ -8,7 +8,6 @@ CREATE TABLE `apply_operations` (
   `state` varchar(100) NOT NULL DEFAULT 'pending',
   `error_message` text,
   `cutover_policy` varchar(16) NOT NULL DEFAULT 'rolling',
-  `halt_on_failure` tinyint(1) NOT NULL DEFAULT '1',
   `on_failure` varchar(16) NOT NULL DEFAULT 'halt',
   `lease_owner` varchar(255) NOT NULL DEFAULT '',
   `lease_token` varchar(64) NOT NULL DEFAULT '',


### PR DESCRIPTION
## What and Why ?

Patch 2 of the two-step `halt_on_failure` → `on_failure` migration: removes the now-unused
`halt_on_failure` column from `apply_operations`. The earlier patch added the `on_failure`
enum and moved all config/storage/claim-predicate code onto it while keeping the old column
additively, so in-flight pods running the previous code were unaffected. Nothing reads the
column anymore, so it can be removed.

`EnsureSchema` reconciles the embedded schema via the Spirit differ on startup, so this
emits the `DROP COLUMN` automatically — no manual schema step.

## Deploy ordering

This must deploy **only after** the `on_failure` code is fully rolled out (https://github.com/block/schemabot/pull/317). A pod still
running the previous code would query `halt_on_failure`; dropping it before then would break
that pod mid-deploy.
