### PR TITLE
feat(inventory): add connection-resolver contract and static backend

### DIFF
--- a/pkg/inventory/static.go
+++ b/pkg/inventory/static.go
@@ -1,0 +1,110 @@
+package inventory
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"strings"
+
+	"github.com/go-sql-driver/mysql"
+
+	"github.com/block/schemabot/pkg/secrets"
+)
+
+// StaticConfig configures a resolver backed by static target entries.
+type StaticConfig struct {
+	Targets map[string]StaticTarget `yaml:"targets"`
+}
+
+// StaticTarget is a static connection entry for one target.
+type StaticTarget struct {
+	DatabaseType string            `yaml:"type"`
+	DSN          string            `yaml:"dsn"`
+	Metadata     map[string]string `yaml:"metadata,omitempty"`
+}
+
+// StaticResolver resolves targets from static configuration.
+type StaticResolver struct {
+	targets map[string]StaticTarget
+}
+
+var _ Resolver = (*StaticResolver)(nil)
+
+// NewStaticResolver creates a static target resolver.
+func NewStaticResolver(config StaticConfig) (*StaticResolver, error) {
+	if len(config.Targets) == 0 {
+		return nil, fmt.Errorf("static target resolver requires at least one target")
+	}
+	targets := make(map[string]StaticTarget, len(config.Targets))
+	for target, entry := range config.Targets {
+		if target == "" {
+			return nil, fmt.Errorf("static target resolver contains an empty target key")
+		}
+		if err := validateStaticTarget(target, entry); err != nil {
+			return nil, err
+		}
+		targets[target] = StaticTarget{
+			DatabaseType: entry.DatabaseType,
+			DSN:          entry.DSN,
+			Metadata:     maps.Clone(entry.Metadata),
+		}
+	}
+	return &StaticResolver{targets: targets}, nil
+}
+
+// ResolveTarget resolves one target from static configuration.
+func (r *StaticResolver) ResolveTarget(_ context.Context, req Request) (*Target, error) {
+	if r == nil {
+		return nil, fmt.Errorf("static target resolver is nil")
+	}
+	if req.Target == "" {
+		return nil, fmt.Errorf("target is required")
+	}
+	entry, ok := r.targets[req.Target]
+	if !ok {
+		return nil, fmt.Errorf("target %q is not configured", req.Target)
+	}
+	if req.DatabaseType != "" && req.DatabaseType != entry.DatabaseType {
+		return nil, fmt.Errorf("target %q is configured for database type %q, not %q", req.Target, entry.DatabaseType, req.DatabaseType)
+	}
+	dsn, err := secrets.Resolve(entry.DSN, "")
+	if err != nil {
+		return nil, fmt.Errorf("resolve DSN for target %q: %w", req.Target, err)
+	}
+	if dsn == "" {
+		return nil, fmt.Errorf("target %q resolved an empty DSN", req.Target)
+	}
+	if err := validateResolvedStaticTargetDSN(req.Target, entry.DatabaseType, dsn); err != nil {
+		return nil, err
+	}
+	return &Target{
+		Target:       req.Target,
+		DatabaseType: entry.DatabaseType,
+		DSN:          dsn,
+		Metadata:     maps.Clone(entry.Metadata),
+	}, nil
+}
+
+func validateStaticTarget(target string, entry StaticTarget) error {
+	if entry.DatabaseType == "" {
+		return fmt.Errorf("target %q missing type", target)
+	}
+	if entry.DSN == "" {
+		return fmt.Errorf("target %q missing dsn", target)
+	}
+	return nil
+}
+
+func validateResolvedStaticTargetDSN(target, databaseType, dsn string) error {
+	if !strings.EqualFold(databaseType, "mysql") {
+		return nil
+	}
+	cfg, err := mysql.ParseDSN(dsn)
+	if err != nil {
+		return fmt.Errorf("parse MySQL DSN for target %q: %w", target, err)
+	}
+	if cfg.DBName != "" {
+		return fmt.Errorf("target %q MySQL DSN must not include a database name; the request supplies the namespace", target)
+	}
+	return nil
+}

--- a/pkg/inventory/static.go
+++ b/pkg/inventory/static.go
@@ -25,7 +25,7 @@ type StaticTarget struct {
 
 // StaticResolver resolves targets from static configuration.
 type StaticResolver struct {
-	targets map[string]StaticTarget
+	targets map[string]Target
 }
 
 var _ Resolver = (*StaticResolver)(nil)
@@ -35,19 +35,16 @@ func NewStaticResolver(config StaticConfig) (*StaticResolver, error) {
 	if len(config.Targets) == 0 {
 		return nil, fmt.Errorf("static target resolver requires at least one target")
 	}
-	targets := make(map[string]StaticTarget, len(config.Targets))
+	targets := make(map[string]Target, len(config.Targets))
 	for target, entry := range config.Targets {
 		if target == "" {
 			return nil, fmt.Errorf("static target resolver contains an empty target key")
 		}
-		if err := validateStaticTarget(target, entry); err != nil {
+		resolved, err := resolveStaticTarget(target, entry)
+		if err != nil {
 			return nil, err
 		}
-		targets[target] = StaticTarget{
-			DatabaseType: entry.DatabaseType,
-			DSN:          entry.DSN,
-			Metadata:     maps.Clone(entry.Metadata),
-		}
+		targets[target] = *resolved
 	}
 	return &StaticResolver{targets: targets}, nil
 }
@@ -64,39 +61,55 @@ func (r *StaticResolver) ResolveTarget(_ context.Context, req Request) (*Target,
 	if !ok {
 		return nil, fmt.Errorf("target %q is not configured", req.Target)
 	}
-	if req.DatabaseType != "" && req.DatabaseType != entry.DatabaseType {
-		return nil, fmt.Errorf("target %q is configured for database type %q, not %q", req.Target, entry.DatabaseType, req.DatabaseType)
+	if strings.TrimSpace(req.DatabaseType) != "" {
+		requestedType := canonicalDatabaseType(req.DatabaseType)
+		if requestedType != entry.DatabaseType {
+			return nil, fmt.Errorf("target %q is configured for database type %q, not %q", req.Target, entry.DatabaseType, requestedType)
+		}
+	}
+	return &Target{
+		Target:       entry.Target,
+		DatabaseType: entry.DatabaseType,
+		DSN:          entry.DSN,
+		Metadata:     maps.Clone(entry.Metadata),
+	}, nil
+}
+
+func resolveStaticTarget(target string, entry StaticTarget) (*Target, error) {
+	if entry.DatabaseType == "" {
+		return nil, fmt.Errorf("target %q missing type", target)
+	}
+	databaseType := canonicalDatabaseType(entry.DatabaseType)
+	if databaseType == "" {
+		return nil, fmt.Errorf("target %q missing type", target)
+	}
+	if entry.DSN == "" {
+		return nil, fmt.Errorf("target %q missing dsn", target)
 	}
 	dsn, err := secrets.Resolve(entry.DSN, "")
 	if err != nil {
-		return nil, fmt.Errorf("resolve DSN for target %q: %w", req.Target, err)
+		return nil, fmt.Errorf("resolve DSN for target %q: %w", target, err)
 	}
 	if dsn == "" {
-		return nil, fmt.Errorf("target %q resolved an empty DSN", req.Target)
+		return nil, fmt.Errorf("target %q resolved an empty DSN", target)
 	}
-	if err := validateResolvedStaticTargetDSN(req.Target, entry.DatabaseType, dsn); err != nil {
+	if err := validateResolvedStaticTargetDSN(target, databaseType, dsn); err != nil {
 		return nil, err
 	}
 	return &Target{
-		Target:       req.Target,
-		DatabaseType: entry.DatabaseType,
+		Target:       target,
+		DatabaseType: databaseType,
 		DSN:          dsn,
 		Metadata:     maps.Clone(entry.Metadata),
 	}, nil
 }
 
-func validateStaticTarget(target string, entry StaticTarget) error {
-	if entry.DatabaseType == "" {
-		return fmt.Errorf("target %q missing type", target)
-	}
-	if entry.DSN == "" {
-		return fmt.Errorf("target %q missing dsn", target)
-	}
-	return nil
+func canonicalDatabaseType(databaseType string) string {
+	return strings.ToLower(strings.TrimSpace(databaseType))
 }
 
 func validateResolvedStaticTargetDSN(target, databaseType, dsn string) error {
-	if !strings.EqualFold(databaseType, "mysql") {
+	if databaseType != "mysql" {
 		return nil
 	}
 	cfg, err := mysql.ParseDSN(dsn)

--- a/pkg/inventory/static_test.go
+++ b/pkg/inventory/static_test.go
@@ -1,0 +1,141 @@
+package inventory
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStaticResolverResolveTarget(t *testing.T) {
+	t.Setenv("TARGET_DSN", "user:pass@tcp(db.example:3306)/")
+	resolver, err := NewStaticResolver(StaticConfig{Targets: map[string]StaticTarget{
+		"dsid-orders-prod": {
+			DatabaseType: "mysql",
+			DSN:          "env:TARGET_DSN",
+			Metadata:     map[string]string{"pending_drops": "false"},
+		},
+	}})
+	require.NoError(t, err)
+
+	got, err := resolver.ResolveTarget(t.Context(), Request{
+		Target:       "dsid-orders-prod",
+		DatabaseType: "mysql",
+		Environment:  "production",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "dsid-orders-prod", got.Target)
+	assert.Equal(t, "mysql", got.DatabaseType)
+	assert.Equal(t, "user:pass@tcp(db.example:3306)/", got.DSN)
+	assert.Equal(t, map[string]string{"pending_drops": "false"}, got.Metadata)
+}
+
+func TestStaticResolverResolveTargetClonesMetadata(t *testing.T) {
+	resolver, err := NewStaticResolver(StaticConfig{Targets: map[string]StaticTarget{
+		"target-1": {
+			DatabaseType: "mysql",
+			DSN:          "root@tcp(localhost:3306)/",
+			Metadata:     map[string]string{"source": "static"},
+		},
+	}})
+	require.NoError(t, err)
+
+	first, err := resolver.ResolveTarget(t.Context(), Request{Target: "target-1"})
+	require.NoError(t, err)
+	first.Metadata["source"] = "mutated"
+
+	second, err := resolver.ResolveTarget(t.Context(), Request{Target: "target-1"})
+	require.NoError(t, err)
+	assert.Equal(t, "static", second.Metadata["source"])
+}
+
+func TestStaticResolverResolveTargetFromFile(t *testing.T) {
+	file, err := os.CreateTemp(t.TempDir(), "dsn-*")
+	require.NoError(t, err)
+	_, err = file.WriteString("root@tcp(localhost:3306)/\n")
+	require.NoError(t, err)
+	require.NoError(t, file.Close())
+
+	resolver, err := NewStaticResolver(StaticConfig{Targets: map[string]StaticTarget{
+		"target-1": {
+			DatabaseType: "mysql",
+			DSN:          "file:" + file.Name(),
+		},
+	}})
+	require.NoError(t, err)
+
+	got, err := resolver.ResolveTarget(t.Context(), Request{Target: "target-1"})
+
+	require.NoError(t, err)
+	assert.Equal(t, "root@tcp(localhost:3306)/", got.DSN)
+}
+
+func TestStaticResolverResolveTargetValidatesRequest(t *testing.T) {
+	resolver, err := NewStaticResolver(StaticConfig{Targets: map[string]StaticTarget{
+		"target-1": {
+			DatabaseType: "mysql",
+			DSN:          "root@tcp(localhost:3306)/",
+		},
+	}})
+	require.NoError(t, err)
+
+	_, err = resolver.ResolveTarget(t.Context(), Request{})
+	assert.ErrorContains(t, err, "target is required")
+
+	_, err = resolver.ResolveTarget(t.Context(), Request{Target: "missing"})
+	assert.ErrorContains(t, err, "target \"missing\" is not configured")
+
+	_, err = resolver.ResolveTarget(t.Context(), Request{Target: "target-1", DatabaseType: "vitess"})
+	assert.ErrorContains(t, err, "target \"target-1\" is configured for database type \"mysql\", not \"vitess\"")
+}
+
+func TestStaticResolverResolveTargetRejectsMySQLDSNWithDatabase(t *testing.T) {
+	resolver, err := NewStaticResolver(StaticConfig{Targets: map[string]StaticTarget{
+		"target-1": {
+			DatabaseType: "mysql",
+			DSN:          "root@tcp(localhost:3306)/appdb",
+		},
+	}})
+	require.NoError(t, err)
+
+	_, err = resolver.ResolveTarget(t.Context(), Request{Target: "target-1"})
+	assert.ErrorContains(t, err, "MySQL DSN must not include a database name")
+}
+
+func TestNewStaticResolverValidatesConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  StaticConfig
+		wantErr string
+	}{
+		{
+			name:    "empty targets",
+			config:  StaticConfig{},
+			wantErr: "static target resolver requires at least one target",
+		},
+		{
+			name:    "empty target key",
+			config:  StaticConfig{Targets: map[string]StaticTarget{"": {DatabaseType: "mysql", DSN: "dsn"}}},
+			wantErr: "static target resolver contains an empty target key",
+		},
+		{
+			name:    "missing type",
+			config:  StaticConfig{Targets: map[string]StaticTarget{"target-1": {DSN: "dsn"}}},
+			wantErr: "target \"target-1\" missing type",
+		},
+		{
+			name:    "missing dsn",
+			config:  StaticConfig{Targets: map[string]StaticTarget{"target-1": {DatabaseType: "mysql"}}},
+			wantErr: "target \"target-1\" missing dsn",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewStaticResolver(tt.config)
+			assert.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}

--- a/pkg/inventory/static_test.go
+++ b/pkg/inventory/static_test.go
@@ -12,7 +12,7 @@ func TestStaticResolverResolveTarget(t *testing.T) {
 	t.Setenv("TARGET_DSN", "user:pass@tcp(db.example:3306)/")
 	resolver, err := NewStaticResolver(StaticConfig{Targets: map[string]StaticTarget{
 		"dsid-orders-prod": {
-			DatabaseType: "mysql",
+			DatabaseType: "MySQL",
 			DSN:          "env:TARGET_DSN",
 			Metadata:     map[string]string{"pending_drops": "false"},
 		},
@@ -21,7 +21,7 @@ func TestStaticResolverResolveTarget(t *testing.T) {
 
 	got, err := resolver.ResolveTarget(t.Context(), Request{
 		Target:       "dsid-orders-prod",
-		DatabaseType: "mysql",
+		DatabaseType: "MYSQL",
 		Environment:  "production",
 	})
 
@@ -30,6 +30,23 @@ func TestStaticResolverResolveTarget(t *testing.T) {
 	assert.Equal(t, "mysql", got.DatabaseType)
 	assert.Equal(t, "user:pass@tcp(db.example:3306)/", got.DSN)
 	assert.Equal(t, map[string]string{"pending_drops": "false"}, got.Metadata)
+}
+
+func TestStaticResolverResolvesDSNAtConstruction(t *testing.T) {
+	t.Setenv("TARGET_DSN", "user:pass@tcp(db.example:3306)/")
+	resolver, err := NewStaticResolver(StaticConfig{Targets: map[string]StaticTarget{
+		"target-1": {
+			DatabaseType: "mysql",
+			DSN:          "env:TARGET_DSN",
+		},
+	}})
+	require.NoError(t, err)
+	t.Setenv("TARGET_DSN", "other:pass@tcp(db.example:3306)/")
+
+	got, err := resolver.ResolveTarget(t.Context(), Request{Target: "target-1"})
+
+	require.NoError(t, err)
+	assert.Equal(t, "user:pass@tcp(db.example:3306)/", got.DSN)
 }
 
 func TestStaticResolverResolveTargetClonesMetadata(t *testing.T) {
@@ -92,15 +109,13 @@ func TestStaticResolverResolveTargetValidatesRequest(t *testing.T) {
 }
 
 func TestStaticResolverResolveTargetRejectsMySQLDSNWithDatabase(t *testing.T) {
-	resolver, err := NewStaticResolver(StaticConfig{Targets: map[string]StaticTarget{
+	_, err := NewStaticResolver(StaticConfig{Targets: map[string]StaticTarget{
 		"target-1": {
 			DatabaseType: "mysql",
 			DSN:          "root@tcp(localhost:3306)/appdb",
 		},
 	}})
-	require.NoError(t, err)
 
-	_, err = resolver.ResolveTarget(t.Context(), Request{Target: "target-1"})
 	assert.ErrorContains(t, err, "MySQL DSN must not include a database name")
 }
 

--- a/pkg/inventory/target.go
+++ b/pkg/inventory/target.go
@@ -1,0 +1,27 @@
+// Package inventory resolves opaque data-plane targets into inventory records.
+package inventory
+
+import "context"
+
+// Request identifies the opaque execution target a data plane must look up.
+// For inventory-backed deployments, Target is typically a DSID. Static
+// deployments can use any stable target key. The requested database namespace
+// stays on the Tern request and is not part of inventory resolution.
+type Request struct {
+	Target       string
+	DatabaseType string
+	Environment  string
+}
+
+// Target is the resolved inventory record for a target.
+type Target struct {
+	Target       string
+	DatabaseType string
+	DSN          string
+	Metadata     map[string]string
+}
+
+// Resolver resolves opaque execution targets to inventory records.
+type Resolver interface {
+	ResolveTarget(ctx context.Context, req Request) (*Target, error)
+}


### PR DESCRIPTION
## Why
The data plane needs a reusable way to answer "how do I connect to this target?" (target → DSN + engine metadata) that deployments can start with as static config and later back with a dynamic inventory source.

## What
- Add `pkg/inventory`: the connection-resolver contract (`Request`/`Target`) plus a static, config-driven backend.
- Kept deliberately distinct from `pkg/routing.Resolver`, which answers "where does work go?". Inventory carries no routing decisions and no execution-namespace concerns — MySQL schema names come from schema files at execution time, not from the target.

## Risk
Low — additive, new package, not wired into any default path. This is a leaf of the larger data-plane routing work in #339.

🤖 Generated with [Claude Code](https://claude.com/claude-code)