### PR TITLE
fix(operator): persist operation state from its own tasks on drive

### DIFF
--- a/pkg/api/operator.go
+++ b/pkg/api/operator.go
@@ -344,12 +344,34 @@ func (s *Service) recoverApplyOperation(ctx context.Context, workerID int, owner
 		return
 	}
 
-	// Reload the parent apply: ResumeApply persists the final state to storage,
-	// and the operation row must mirror the durable outcome, not the in-memory
-	// object the resume path started from.
+	// Persist the operation row from its OWN drive outcome — the aggregate of
+	// this operation's tasks — rather than mirroring the parent apply down.
+	// Under on_failure "continue" the parent applies.state can be held running
+	// (the policy-aware projection waits for siblings to settle) while this
+	// operation has terminally failed; mirroring the parent down would leave the
+	// failed operation claimable and re-leased on every poll, so its failure
+	// would never be durably recorded. The operation row is authoritative for
+	// its own deployment; the parent state is derived from the operation rows
+	// afterward via updateApplyStateFromOperations.
+	marked, err := s.markOperationFromOwnResult(operationLeaseCtx, workerID, op)
+	if err != nil {
+		s.logger.Error("operator: failed to update apply_operation from its tasks; derived apply state not updated",
+			"worker", workerID, "apply_operation_id", op.ID, "apply_id", apply.ApplyIdentifier,
+			"deployment", op.Deployment, "environment", apply.Environment, "error", err)
+		return
+	}
+	if !marked {
+		return
+	}
+
+	// Reload the parent apply so updateApplyStateFromOperations below re-derives
+	// the parent from its children against the durable apply.State (its
+	// terminal-to-non-terminal guard), not the in-memory object the resume path
+	// started from. The reloaded row is only the target of the re-derivation;
+	// the operation row was already persisted from its own tasks above.
 	finalApply, err := s.storage.Applies().Get(applyLeaseCtx, apply.ID)
 	if err != nil {
-		s.logger.Error("operator: failed to reload parent apply after resume; operation state not updated",
+		s.logger.Error("operator: failed to reload parent apply after resume; derived apply state not updated",
 			"worker", workerID,
 			"apply_operation_id", op.ID,
 			"apply_id", apply.ApplyIdentifier,
@@ -358,22 +380,11 @@ func (s *Service) recoverApplyOperation(ctx context.Context, workerID int, owner
 		return
 	}
 	if finalApply == nil {
-		s.logger.Error("operator: parent apply not found after resume; operation state not updated",
+		s.logger.Error("operator: parent apply not found after resume; derived apply state not updated",
 			"worker", workerID,
 			"apply_operation_id", op.ID,
 			"apply_id", apply.ApplyIdentifier,
 			"deployment", op.Deployment)
-		return
-	}
-
-	marked, err := s.markOperationFromApplyState(operationLeaseCtx, workerID, op, finalApply)
-	if err != nil {
-		s.logger.Error("operator: failed to update apply_operation from parent apply state; derived apply state not updated",
-			"worker", workerID, "apply_operation_id", op.ID, "apply_id", finalApply.ApplyIdentifier,
-			"deployment", op.Deployment, "environment", finalApply.Environment, "state", finalApply.State, "error", err)
-		return
-	}
-	if !marked {
 		return
 	}
 
@@ -663,57 +674,116 @@ func (s *Service) startApplyOperationHeartbeat(ctx context.Context, workerID int
 }
 
 // markOperationFromApplyState transitions the claimed operation row to mirror
-// the parent apply's final state after a successful resume.
-//
-// It returns updated=true whenever the operation row was durably written to
-// mirror the parent — including resumable final states (stopped,
-// failed_retryable), not only terminal ones. updated=true is the signal the
-// caller needs before deriving the parent apply's state from its children: the
-// child row now reflects the parent, so the derived state is current. A parent
-// that is still mid-flight leaves the operation claimable (updated=false, nil
-// error) so a later poll re-leases and resumes it; a write failure returns the
-// error so the caller skips derivation rather than aggregating a stale child
-// state.
+// the parent apply's final state. It is used by the unclaimable-parent
+// reconciliation path, where an already-terminal parent is authoritative for its
+// single operation. The drive path instead uses markOperationFromOwnResult so a
+// failed operation is recorded even while the parent projection holds the apply
+// running under on_failure "continue". Both delegate to persistOperationState,
+// which documents the updated/error contract.
 func (s *Service) markOperationFromApplyState(ctx context.Context, workerID int, op *storage.ApplyOperation, apply *storage.Apply) (updated bool, err error) {
+	return s.persistOperationState(ctx, workerID, op, apply.State, apply.ErrorMessage)
+}
+
+// markOperationFromOwnResult transitions the claimed operation row to reflect
+// the operation's OWN drive result, derived from its tasks via
+// state.DeriveApplyState rather than mirrored from the parent apply.
+//
+// This is the drive-path counterpart to markOperationFromApplyState. Under the
+// on_failure "continue" projection updateApplyStateFromOperations holds the
+// parent apply running while sibling deployments are still in flight, so
+// mirroring this operation from the parent would hit the non-terminal
+// "leave claimable" branch and never persist the operation's own terminal
+// outcome: a failed deployment would be silently re-claimed and the
+// deployment-order gate (which keys off an earlier sibling's failed state under
+// continue) would read a stale value. Deriving from the operation's own tasks
+// records its real result independently of the parent projection, which
+// updateApplyStateFromOperations then aggregates back into the parent apply.
+//
+// The returned updated flag and error carry the same contract as
+// markOperationFromApplyState: updated=true when the row was durably written
+// (including the resumable stopped / failed_retryable states), updated=false
+// with a nil error when the operation's tasks derive a non-terminal state and
+// the row is left claimable for a later poll, and a non-nil error when a read or
+// write fails so the caller skips parent derivation.
+func (s *Service) markOperationFromOwnResult(ctx context.Context, workerID int, op *storage.ApplyOperation) (updated bool, err error) {
+	tasks, err := s.storage.Tasks().GetByApplyOperationID(ctx, op.ID)
+	if err != nil {
+		return false, fmt.Errorf("load tasks for apply_operation %d (deployment %q): %w", op.ID, op.Deployment, err)
+	}
+	taskStates := make([]string, len(tasks))
+	for i, t := range tasks {
+		taskStates[i] = t.State
+	}
+	derived := state.DeriveApplyState(taskStates)
+	return s.persistOperationState(ctx, workerID, op, derived, firstFailedTaskError(tasks))
+}
+
+// firstFailedTaskError returns the ErrorMessage of the first failed task, used
+// to populate the operation row's failure reason when its own tasks derive a
+// failed state. Empty when no failed task carries a message.
+func firstFailedTaskError(tasks []*storage.Task) string {
+	for _, t := range tasks {
+		if state.IsState(t.State, state.Apply.Failed) && t.ErrorMessage != "" {
+			return t.ErrorMessage
+		}
+	}
+	return ""
+}
+
+// persistOperationState writes the claimed operation row to reflect a derived
+// state, mapping each state to the appropriate row-write. The derived state and
+// errorMessage come from either the parent apply (markOperationFromApplyState,
+// the reconcile path) or the operation's own tasks (markOperationFromOwnResult,
+// the drive path); the row-write mapping is identical regardless of source.
+//
+// It returns updated=true whenever the operation row was durably written —
+// including resumable states (stopped, failed_retryable), not only terminal
+// ones. updated=true is the signal the caller needs before deriving the parent
+// apply's state from its children: the child row now reflects its outcome, so
+// the derived state is current. A non-terminal derived state leaves the
+// operation claimable (updated=false, nil error) so a later poll re-leases and
+// resumes it; a write failure returns the error so the caller skips derivation
+// rather than aggregating a stale child state.
+func (s *Service) persistOperationState(ctx context.Context, workerID int, op *storage.ApplyOperation, derived, errorMessage string) (updated bool, err error) {
 	opStore := s.storage.ApplyOperations()
 	switch {
-	case state.IsState(apply.State, state.Apply.Completed):
+	case state.IsState(derived, state.Apply.Completed):
 		if err := opStore.MarkCompleted(ctx, op.ID); err != nil {
 			return false, fmt.Errorf("mark apply_operation %d completed (deployment %q): %w", op.ID, op.Deployment, err)
 		}
 		return true, nil
-	case state.IsState(apply.State, state.Apply.Failed):
-		if err := opStore.MarkFailed(ctx, op.ID, apply.ErrorMessage); err != nil {
+	case state.IsState(derived, state.Apply.Failed):
+		if err := opStore.MarkFailed(ctx, op.ID, errorMessage); err != nil {
 			return false, fmt.Errorf("mark apply_operation %d failed (deployment %q): %w", op.ID, op.Deployment, err)
 		}
 		return true, nil
-	case state.IsState(apply.State, state.Apply.Stopped):
+	case state.IsState(derived, state.Apply.Stopped):
 		// stopped is resumable, so mirror the state but leave completed_at nil
 		// (matching the apply-level convention) — stopped work may resume.
-		if err := opStore.UpdateState(ctx, op.ID, apply.State); err != nil {
+		if err := opStore.UpdateState(ctx, op.ID, derived); err != nil {
 			return false, fmt.Errorf("update stopped apply_operation %d state (deployment %q): %w", op.ID, op.Deployment, err)
 		}
 		return true, nil
-	case state.IsState(apply.State, state.Apply.FailedRetryable):
+	case state.IsState(derived, state.Apply.FailedRetryable):
 		// failed_retryable is resumable like stopped: mirror the state (leaving
 		// completed_at nil) so FindNextApplyOperation reclaims it under the
 		// parent apply's recovery budget. Leaving the row in its active state
 		// would instead make recovery depend on the stale-heartbeat path, which
 		// has no budget and would re-claim it forever once retries are exhausted.
-		if err := opStore.UpdateState(ctx, op.ID, apply.State); err != nil {
+		if err := opStore.UpdateState(ctx, op.ID, derived); err != nil {
 			return false, fmt.Errorf("update failed_retryable apply_operation %d state (deployment %q): %w", op.ID, op.Deployment, err)
 		}
 		return true, nil
-	case state.IsTerminalApplyState(apply.State):
+	case state.IsTerminalApplyState(derived):
 		// cancelled / reverted — non-resumable terminal states; stamp completed_at.
-		if err := opStore.MarkTerminal(ctx, op.ID, apply.State); err != nil {
-			return false, fmt.Errorf("mark terminal apply_operation %d state %q (deployment %q): %w", op.ID, apply.State, op.Deployment, err)
+		if err := opStore.MarkTerminal(ctx, op.ID, derived); err != nil {
+			return false, fmt.Errorf("mark terminal apply_operation %d state %q (deployment %q): %w", op.ID, derived, op.Deployment, err)
 		}
 		return true, nil
 	default:
-		s.logger.Debug("operator: parent apply not terminal after resume; leaving operation claimable",
-			"worker", workerID, "apply_operation_id", op.ID, "apply_id", apply.ApplyIdentifier,
-			"deployment", op.Deployment, "environment", apply.Environment, "state", apply.State)
+		s.logger.Debug("operator: derived operation state not terminal; leaving operation claimable",
+			"worker", workerID, "apply_operation_id", op.ID,
+			"deployment", op.Deployment, "state", derived)
 		return false, nil
 	}
 }

--- a/pkg/api/operator.go
+++ b/pkg/api/operator.go
@@ -723,7 +723,7 @@ func (s *Service) markOperationFromOwnResult(ctx context.Context, workerID int, 
 // failed state. Empty when no failed task carries a message.
 func firstFailedTaskError(tasks []*storage.Task) string {
 	for _, t := range tasks {
-		if state.IsState(t.State, state.Apply.Failed) && t.ErrorMessage != "" {
+		if state.IsState(t.State, state.Task.Failed) && t.ErrorMessage != "" {
 			return t.ErrorMessage
 		}
 	}

--- a/pkg/api/operator.go
+++ b/pkg/api/operator.go
@@ -730,6 +730,22 @@ func firstFailedTaskError(tasks []*storage.Task) string {
 	return ""
 }
 
+// firstFailedOperationMessage returns a deployment-qualified failure reason from
+// the first failed operation row that carries one. It surfaces the parent
+// apply's ErrorMessage from the aggregate when the rollout settles to failed,
+// rather than leaving whatever message the last-driven (possibly successful)
+// operation wrote. The rollout's failure verdict is the first failure, so the
+// first failed row in deployment order wins. Empty when no failed operation
+// carries a message, so the caller keeps the existing apply message as fallback.
+func firstFailedOperationMessage(ops []*storage.ApplyOperation) string {
+	for _, op := range ops {
+		if state.IsState(op.State, state.ApplyOperation.Failed) && op.ErrorMessage != "" {
+			return fmt.Sprintf("deployment %s failed: %s", op.Deployment, op.ErrorMessage)
+		}
+	}
+	return ""
+}
+
 // persistOperationState writes the claimed operation row to reflect a derived
 // state, mapping each state to the appropriate row-write. The derived state and
 // errorMessage come from either the parent apply (markOperationFromApplyState,
@@ -851,6 +867,17 @@ func (s *Service) updateApplyStateFromOperations(ctx context.Context, workerID i
 		}
 	default:
 		updated.CompletedAt = nil
+	}
+
+	// When the rollout settles to failed, surface the failure reason from the
+	// aggregate (the first failed operation) rather than leaving whatever message
+	// the last-driven operation wrote — under continue the last driver may be a
+	// successful sibling, which would leave the failed verdict with no matching
+	// reason. Keep the existing message as a fallback when no operation carries one.
+	if state.IsState(derived, state.Apply.Failed) {
+		if msg := firstFailedOperationMessage(ops); msg != "" {
+			updated.ErrorMessage = msg
+		}
 	}
 
 	if err := s.storage.Applies().Update(ctx, &updated); err != nil {

--- a/pkg/api/operator_test.go
+++ b/pkg/api/operator_test.go
@@ -314,3 +314,57 @@ func TestMarkOperationFromOwnResult_LeavesNonTerminalClaimable(t *testing.T) {
 	assert.False(t, marked, "a still-running operation must be left claimable for a later poll")
 	assert.False(t, opStore.called, "no terminal write should occur for a non-terminal operation")
 }
+
+// TestUpdateApplyStateFromOperations_StampsAggregateFailureMessage verifies that
+// when the rollout settles to failed the parent apply's ErrorMessage is surfaced
+// from the first failed operation, not from the last-driven (here, successful)
+// sibling. The failing deployment ran first and the apply carries no prior
+// message; the derived failed verdict must be accompanied by that deployment's
+// reason so an operator sees why the apply failed.
+func TestUpdateApplyStateFromOperations_StampsAggregateFailureMessage(t *testing.T) {
+	ops := []*storage.ApplyOperation{
+		{ID: 1, Deployment: "region-a", State: state.ApplyOperation.Failed, ErrorMessage: "spirit: cutover failed"},
+		{ID: 2, Deployment: "region-b", State: state.ApplyOperation.Completed},
+	}
+	applyStore := &recordingApplyStore{}
+	svc := newOperatorStateTestService(&listingApplyOperationStore{ops: ops}, applyStore)
+
+	apply := &storage.Apply{
+		ID:              3,
+		ApplyIdentifier: "apply-projection",
+		State:           state.Apply.Running,
+		Environment:     "staging",
+	}
+
+	require.NoError(t, svc.updateApplyStateFromOperations(t.Context(), 1, apply))
+	require.NotNil(t, applyStore.updated, "derived failed state differs from running, so the apply must be persisted")
+	assert.Equal(t, state.Apply.Failed, applyStore.updated.State)
+	assert.Equal(t, "deployment region-a failed: spirit: cutover failed", applyStore.updated.ErrorMessage,
+		"the failure reason must come from the failed operation, not the successful last sibling")
+}
+
+// TestUpdateApplyStateFromOperations_KeepsExistingMessageWhenNoOperationCarriesOne
+// verifies that a derived failed verdict preserves the apply's existing message
+// when no failed operation row carries one, rather than blanking the reason.
+func TestUpdateApplyStateFromOperations_KeepsExistingMessageWhenNoOperationCarriesOne(t *testing.T) {
+	ops := []*storage.ApplyOperation{
+		{ID: 1, Deployment: "region-a", State: state.ApplyOperation.Failed},
+		{ID: 2, Deployment: "region-b", State: state.ApplyOperation.Completed},
+	}
+	applyStore := &recordingApplyStore{}
+	svc := newOperatorStateTestService(&listingApplyOperationStore{ops: ops}, applyStore)
+
+	apply := &storage.Apply{
+		ID:              3,
+		ApplyIdentifier: "apply-projection",
+		State:           state.Apply.Running,
+		Environment:     "staging",
+		ErrorMessage:    "prior reason",
+	}
+
+	require.NoError(t, svc.updateApplyStateFromOperations(t.Context(), 1, apply))
+	require.NotNil(t, applyStore.updated)
+	assert.Equal(t, state.Apply.Failed, applyStore.updated.State)
+	assert.Equal(t, "prior reason", applyStore.updated.ErrorMessage,
+		"with no operation-level message the existing apply reason must be preserved")
+}

--- a/pkg/api/operator_test.go
+++ b/pkg/api/operator_test.go
@@ -226,3 +226,91 @@ func TestUpdateApplyStateFromOperations_ContinuePolicy(t *testing.T) {
 		})
 	}
 }
+
+// stubTaskStore returns a fixed task set for GetByApplyOperationID so an
+// operation's own drive result can be derived from its tasks.
+type stubTaskStore struct {
+	storage.TaskStore
+	tasks []*storage.Task
+}
+
+func (s *stubTaskStore) GetByApplyOperationID(context.Context, int64) ([]*storage.Task, error) {
+	return s.tasks, nil
+}
+
+// markFailedRecordingApplyOperationStore records MarkFailed so a test can assert
+// the operation row was persisted failed with its own task's message.
+type markFailedRecordingApplyOperationStore struct {
+	storage.ApplyOperationStore
+	called    bool
+	failedID  int64
+	failedMsg string
+}
+
+func (s *markFailedRecordingApplyOperationStore) MarkFailed(_ context.Context, id int64, errMsg string) error {
+	s.called = true
+	s.failedID = id
+	s.failedMsg = errMsg
+	return nil
+}
+
+type mockStorageWithTasksAndOperations struct {
+	mockStorage
+	tasks    storage.TaskStore
+	applyOps storage.ApplyOperationStore
+}
+
+func (m *mockStorageWithTasksAndOperations) Tasks() storage.TaskStore { return m.tasks }
+
+func (m *mockStorageWithTasksAndOperations) ApplyOperations() storage.ApplyOperationStore {
+	return m.applyOps
+}
+
+// TestMarkOperationFromOwnResult_PersistsFailedIndependentOfParent verifies that
+// the drive path records a failed deployment from the operation's OWN tasks
+// regardless of the parent apply's state. Under the on_failure "continue"
+// projection the parent is held running while sibling deployments are still in
+// flight; deriving the operation from its own failing task still marks the row
+// failed (with that task's message) rather than leaving it claimable to be
+// re-driven, so the deployment-order gate and the parent re-derivation observe
+// the real outcome.
+func TestMarkOperationFromOwnResult_PersistsFailedIndependentOfParent(t *testing.T) {
+	opStore := &markFailedRecordingApplyOperationStore{}
+	taskStore := &stubTaskStore{tasks: []*storage.Task{
+		{State: state.Apply.Completed},
+		{State: state.Apply.Failed, ErrorMessage: "spirit: cutover failed"},
+	}}
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	svc := New(&mockStorageWithTasksAndOperations{tasks: taskStore, applyOps: opStore}, testServerConfig(), nil, logger)
+
+	op := &storage.ApplyOperation{ID: 9, Deployment: "region-b", OnFailure: storage.OnFailureContinue}
+
+	marked, err := svc.markOperationFromOwnResult(t.Context(), 1, op)
+	require.NoError(t, err)
+	assert.True(t, marked, "a failed operation must be durably recorded so it is not re-claimed")
+	assert.True(t, opStore.called, "the operation row must be marked failed from its own tasks")
+	assert.Equal(t, int64(9), opStore.failedID, "the claimed operation row must be the one marked failed")
+	assert.Equal(t, "spirit: cutover failed", opStore.failedMsg,
+		"the failure message must come from the operation's own failing task")
+}
+
+// TestMarkOperationFromOwnResult_LeavesNonTerminalClaimable verifies that an
+// operation whose own tasks are still running is left claimable (marked=false,
+// no terminal write) so a later poll re-leases and resumes it, rather than being
+// prematurely terminalized from a still-in-flight drive.
+func TestMarkOperationFromOwnResult_LeavesNonTerminalClaimable(t *testing.T) {
+	opStore := &markFailedRecordingApplyOperationStore{}
+	taskStore := &stubTaskStore{tasks: []*storage.Task{
+		{State: state.Apply.Running},
+		{State: state.Apply.Completed},
+	}}
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	svc := New(&mockStorageWithTasksAndOperations{tasks: taskStore, applyOps: opStore}, testServerConfig(), nil, logger)
+
+	op := &storage.ApplyOperation{ID: 11, Deployment: "region-c", OnFailure: storage.OnFailureContinue}
+
+	marked, err := svc.markOperationFromOwnResult(t.Context(), 1, op)
+	require.NoError(t, err)
+	assert.False(t, marked, "a still-running operation must be left claimable for a later poll")
+	assert.False(t, opStore.called, "no terminal write should occur for a non-terminal operation")
+}

--- a/pkg/api/operator_test.go
+++ b/pkg/api/operator_test.go
@@ -277,8 +277,8 @@ func (m *mockStorageWithTasksAndOperations) ApplyOperations() storage.ApplyOpera
 func TestMarkOperationFromOwnResult_PersistsFailedIndependentOfParent(t *testing.T) {
 	opStore := &markFailedRecordingApplyOperationStore{}
 	taskStore := &stubTaskStore{tasks: []*storage.Task{
-		{State: state.Apply.Completed},
-		{State: state.Apply.Failed, ErrorMessage: "spirit: cutover failed"},
+		{State: state.Task.Completed},
+		{State: state.Task.Failed, ErrorMessage: "spirit: cutover failed"},
 	}}
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
 	svc := New(&mockStorageWithTasksAndOperations{tasks: taskStore, applyOps: opStore}, testServerConfig(), nil, logger)
@@ -301,8 +301,8 @@ func TestMarkOperationFromOwnResult_PersistsFailedIndependentOfParent(t *testing
 func TestMarkOperationFromOwnResult_LeavesNonTerminalClaimable(t *testing.T) {
 	opStore := &markFailedRecordingApplyOperationStore{}
 	taskStore := &stubTaskStore{tasks: []*storage.Task{
-		{State: state.Apply.Running},
-		{State: state.Apply.Completed},
+		{State: state.Task.Running},
+		{State: state.Task.Completed},
 	}}
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
 	svc := New(&mockStorageWithTasksAndOperations{tasks: taskStore, applyOps: opStore}, testServerConfig(), nil, logger)


### PR DESCRIPTION
## What and Why ?

When an apply fans out to multiple deployments under `on_failure: continue`, the parent apply is held `running` until every sibling settles. The drive path mirrored the **parent** apply state onto the just-driven operation row, so while the parent was held `running` a terminally failed deployment hit the non-terminal "leave claimable" branch: its failure was never recorded, the row was re-claimed and re-driven on every poll, and the deployment-order gate (which keys off an earlier sibling's `failed` state under `continue`) read a stale value.

This drives each operation off its **own** result. After a successful resume the operation row is persisted from the aggregate of its own tasks; the parent apply state is then re-derived from the operation rows via the policy-aware projection.

The drive path now records each operation's own outcome instead of mirroring the parent apply down, so a failed deployment is durably persisted even while the `on_failure: continue` projection holds the parent running.
```
drive op ─▶ resume ─▶ markOperationFromOwnResult(op)      ◀── derive op state from op's OWN tasks
                      (persistOperationState, under op lease)
        ─▶ reload parent ─▶ updateApplyStateFromOperations(parent)  ◀── policy-aware parent re-derive (#337)
```
Correct for single-op today (the operation result equals the aggregate), and required before the multi-deployment fan-out is wired.

## Changes

- Add `markOperationFromOwnResult`: derive the operation's state from its tasks (`Tasks().GetByApplyOperationID`) and persist the row.
- Extract the state→row-write mapping into a shared `persistOperationState`; `markOperationFromApplyState` now delegates to it.
- Drive path uses the own-result path and persists the operation before reloading the parent.
- The unclaimable-parent reconciliation path keeps mirroring from the already-terminal parent (unchanged).

## Testing / validation

- `go build ./...`, `go vet ./pkg/api`, `gofmt` clean, full `pkg/api` unit suite green.
- New unit tests: a failed operation is recorded `failed` (with its own task's message) independent of the parent state; a still-running operation is left claimable.

## References

Fan-out-gated fix surfaced by the #337 review (operation-state-first persistence).
