### PR TITLE
fix(operator): stamp apply ErrorMessage from the aggregate failure

### DIFF
--- a/pkg/api/operator.go
+++ b/pkg/api/operator.go
@@ -730,6 +730,22 @@ func firstFailedTaskError(tasks []*storage.Task) string {
 	return ""
 }
 
+// firstFailedOperationMessage returns a deployment-qualified failure reason from
+// the first failed operation row that carries one. It surfaces the parent
+// apply's ErrorMessage from the aggregate when the rollout settles to failed,
+// rather than leaving whatever message the last-driven (possibly successful)
+// operation wrote. The rollout's failure verdict is the first failure, so the
+// first failed row in deployment order wins. Empty when no failed operation
+// carries a message, so the caller keeps the existing apply message as fallback.
+func firstFailedOperationMessage(ops []*storage.ApplyOperation) string {
+	for _, op := range ops {
+		if state.IsState(op.State, state.ApplyOperation.Failed) && op.ErrorMessage != "" {
+			return fmt.Sprintf("deployment %s failed: %s", op.Deployment, op.ErrorMessage)
+		}
+	}
+	return ""
+}
+
 // persistOperationState writes the claimed operation row to reflect a derived
 // state, mapping each state to the appropriate row-write. The derived state and
 // errorMessage come from either the parent apply (markOperationFromApplyState,
@@ -851,6 +867,17 @@ func (s *Service) updateApplyStateFromOperations(ctx context.Context, workerID i
 		}
 	default:
 		updated.CompletedAt = nil
+	}
+
+	// When the rollout settles to failed, surface the failure reason from the
+	// aggregate (the first failed operation) rather than leaving whatever message
+	// the last-driven operation wrote — under continue the last driver may be a
+	// successful sibling, which would leave the failed verdict with no matching
+	// reason. Keep the existing message as a fallback when no operation carries one.
+	if state.IsState(derived, state.Apply.Failed) {
+		if msg := firstFailedOperationMessage(ops); msg != "" {
+			updated.ErrorMessage = msg
+		}
 	}
 
 	if err := s.storage.Applies().Update(ctx, &updated); err != nil {

--- a/pkg/api/operator_test.go
+++ b/pkg/api/operator_test.go
@@ -314,3 +314,57 @@ func TestMarkOperationFromOwnResult_LeavesNonTerminalClaimable(t *testing.T) {
 	assert.False(t, marked, "a still-running operation must be left claimable for a later poll")
 	assert.False(t, opStore.called, "no terminal write should occur for a non-terminal operation")
 }
+
+// TestUpdateApplyStateFromOperations_StampsAggregateFailureMessage verifies that
+// when the rollout settles to failed the parent apply's ErrorMessage is surfaced
+// from the first failed operation, not from the last-driven (here, successful)
+// sibling. The failing deployment ran first and the apply carries no prior
+// message; the derived failed verdict must be accompanied by that deployment's
+// reason so an operator sees why the apply failed.
+func TestUpdateApplyStateFromOperations_StampsAggregateFailureMessage(t *testing.T) {
+	ops := []*storage.ApplyOperation{
+		{ID: 1, Deployment: "region-a", State: state.ApplyOperation.Failed, ErrorMessage: "spirit: cutover failed"},
+		{ID: 2, Deployment: "region-b", State: state.ApplyOperation.Completed},
+	}
+	applyStore := &recordingApplyStore{}
+	svc := newOperatorStateTestService(&listingApplyOperationStore{ops: ops}, applyStore)
+
+	apply := &storage.Apply{
+		ID:              3,
+		ApplyIdentifier: "apply-projection",
+		State:           state.Apply.Running,
+		Environment:     "staging",
+	}
+
+	require.NoError(t, svc.updateApplyStateFromOperations(t.Context(), 1, apply))
+	require.NotNil(t, applyStore.updated, "derived failed state differs from running, so the apply must be persisted")
+	assert.Equal(t, state.Apply.Failed, applyStore.updated.State)
+	assert.Equal(t, "deployment region-a failed: spirit: cutover failed", applyStore.updated.ErrorMessage,
+		"the failure reason must come from the failed operation, not the successful last sibling")
+}
+
+// TestUpdateApplyStateFromOperations_KeepsExistingMessageWhenNoOperationCarriesOne
+// verifies that a derived failed verdict preserves the apply's existing message
+// when no failed operation row carries one, rather than blanking the reason.
+func TestUpdateApplyStateFromOperations_KeepsExistingMessageWhenNoOperationCarriesOne(t *testing.T) {
+	ops := []*storage.ApplyOperation{
+		{ID: 1, Deployment: "region-a", State: state.ApplyOperation.Failed},
+		{ID: 2, Deployment: "region-b", State: state.ApplyOperation.Completed},
+	}
+	applyStore := &recordingApplyStore{}
+	svc := newOperatorStateTestService(&listingApplyOperationStore{ops: ops}, applyStore)
+
+	apply := &storage.Apply{
+		ID:              3,
+		ApplyIdentifier: "apply-projection",
+		State:           state.Apply.Running,
+		Environment:     "staging",
+		ErrorMessage:    "prior reason",
+	}
+
+	require.NoError(t, svc.updateApplyStateFromOperations(t.Context(), 1, apply))
+	require.NotNil(t, applyStore.updated)
+	assert.Equal(t, state.Apply.Failed, applyStore.updated.State)
+	assert.Equal(t, "prior reason", applyStore.updated.ErrorMessage,
+		"with no operation-level message the existing apply reason must be preserved")
+}


### PR DESCRIPTION
## What

When the operator re-derives a parent apply's state from its `apply_operations` rows and the rollout settles to `failed`, the apply's `ErrorMessage` is now surfaced from the **aggregate** — the first failed operation — instead of whatever message the last-driven operation left behind.

## Why

**The bug:** `updateApplyStateFromOperations` re-derives `applies.state` from the operation rows but copies the apply struct verbatim and never touches `ErrorMessage`. So the failure reason is whatever the last operation to write the apply happened to leave. Under `on_failure: continue` the rollout keeps driving siblings past a failed deployment, so the *last* driver is frequently a **successful** sibling — leaving the apply with a `failed` verdict and an empty or misleading reason. An operator triaging the failure sees the verdict but not why.

**The fix:** when the derived state is `failed`, stamp `ErrorMessage` from the first failed operation row (deployment order), formatted as `deployment <name> failed: <reason>`. The rollout's verdict is the first failure, so the first failed row wins. If no failed operation carries a message, the existing apply message is kept as a fallback rather than blanked.

Operation rows already carry their own correct failure message (each operation is persisted from its own tasks), so the aggregate has the right data to surface.

ops: [region-a failed "cutover failed", region-b completed] ─▶ derived = failed
└▶ apply.ErrorMessage = "deployment region-a failed: cutover failed"
(not region-b's empty / last-op message)

## Notes

Stacked on #343 (operation-state-first persistence) — review/merge that first. Scoped to the operator's aggregate writer; the tern per-op stamping and single-writer refactor are separate follow-ups.
