### PR TITLE
feat(github): dispatch apply status comment by deployment count in observer

### DIFF
--- a/pkg/webhook/apply.go
+++ b/pkg/webhook/apply.go
@@ -63,12 +63,6 @@ func formatProgressComment(apply *storage.Apply, tasks []*storage.Task) string {
 	return templates.RenderApplyStatusComment(buildApplyCommentData(apply, tasks))
 }
 
-// formatCutoverComment renders the cutover confirmation comment.
-// Uses the same template — the cutover state produces the appropriate header and footer.
-func formatCutoverComment(apply *storage.Apply, tasks []*storage.Task) string {
-	return templates.RenderApplyStatusComment(buildApplyCommentData(apply, tasks))
-}
-
 // formatSummaryComment renders the final summary comment for a terminal apply state.
 func formatSummaryComment(apply *storage.Apply, tasks []*storage.Task) string {
 	return templates.RenderApplySummaryComment(buildApplyCommentData(apply, tasks))

--- a/pkg/webhook/apply_test.go
+++ b/pkg/webhook/apply_test.go
@@ -87,7 +87,7 @@ func TestCommentObserverShouldDeferCutoverUsesPersistedApplyOption(t *testing.T)
 	assert.True(t, observer.shouldDeferCutover(apply))
 }
 
-func TestFormatCutoverComment(t *testing.T) {
+func TestFormatProgressCommentCutoverState(t *testing.T) {
 	apply := &storage.Apply{
 		ApplyIdentifier: "apply-abc123",
 		Database:        "testdb",
@@ -100,7 +100,7 @@ func TestFormatCutoverComment(t *testing.T) {
 		{TableName: "orders", State: state.Task.WaitingForCutover, ReadyToComplete: true},
 	}
 
-	body := formatCutoverComment(apply, tasks)
+	body := formatProgressComment(apply, tasks)
 
 	assert.Contains(t, body, "Cutover")
 	assert.Contains(t, body, "testdb")

--- a/pkg/webhook/comment_observer.go
+++ b/pkg/webhook/comment_observer.go
@@ -160,7 +160,7 @@ func (o *CommentObserver) OnProgress(apply *storage.Apply, tasks []*storage.Task
 	// Post cutover comment when entering cutting_over with defer_cutover,
 	// but only if one hasn't been posted already.
 	if currentState == state.Apply.CuttingOver && o.shouldDeferCutover(apply) && !o.hasCutoverComment {
-		body := formatCutoverComment(apply, tasks)
+		body := o.formatStatusComment(apply, tasks)
 		o.postAndTrackComment(apply, state.Comment.Cutover, body)
 		o.hasCutoverComment = true
 		o.lastState = currentState
@@ -205,7 +205,7 @@ func (o *CommentObserver) OnProgress(apply *storage.Apply, tasks []*storage.Task
 	o.lastProgressPost = now
 
 	// Edit the progress comment
-	body := formatProgressComment(apply, tasks)
+	body := o.formatStatusComment(apply, tasks)
 	o.editTrackedComment(apply, state.Comment.Progress, body)
 }
 
@@ -240,7 +240,7 @@ func (o *CommentObserver) OnTerminal(apply *storage.Apply, tasks []*storage.Task
 		o.markSummaryPosted(apply, activeCommentState)
 	} else {
 		// Edit the progress comment to its final state (completed bars / error).
-		finalBody := formatProgressComment(apply, tasks)
+		finalBody := o.formatStatusComment(apply, tasks)
 		o.editTrackedComment(apply, activeCommentState, finalBody)
 
 		// Post a separate summary comment. A new comment is more reliable than
@@ -257,6 +257,26 @@ func (o *CommentObserver) OnTerminal(apply *storage.Apply, tasks []*storage.Task
 	if o.OnTerminalHook != nil {
 		o.OnTerminalHook(apply)
 	}
+}
+
+// formatStatusComment renders the apply's progress/cutover status comment,
+// choosing the single- or multi-deployment layout by the apply's operation-row
+// count via formatApplyStatusComment. It loads the operation rows (in resolved
+// deployment order) so a multi-deployment apply renders the aggregated comment;
+// a single operation (every apply today, until the fan-out lands) renders the
+// single-deployment layout byte-for-byte. A load failure falls back to the
+// single-deployment layout so a transient storage error never blocks a comment
+// update.
+func (o *CommentObserver) formatStatusComment(apply *storage.Apply, tasks []*storage.Task) string {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	ops, err := o.stor.ApplyOperations().ListByApply(ctx, apply.ID)
+	if err != nil {
+		o.logger.Error("observer: failed to load apply operations for comment dispatch; rendering single-deployment layout",
+			"apply_id", apply.ApplyIdentifier, "error", err)
+		return formatProgressComment(apply, tasks)
+	}
+	return formatApplyStatusComment(apply, ops, tasks)
 }
 
 func (o *CommentObserver) shouldDeferCutover(apply *storage.Apply) bool {

--- a/pkg/webhook/comment_observer.go
+++ b/pkg/webhook/comment_observer.go
@@ -261,8 +261,8 @@ func (o *CommentObserver) OnTerminal(apply *storage.Apply, tasks []*storage.Task
 
 // formatStatusComment renders the apply's progress/cutover status comment,
 // choosing the single- or multi-deployment layout by the apply's operation-row
-// count via formatApplyStatusComment. It loads the operation rows (in resolved
-// deployment order) so a multi-deployment apply renders the aggregated comment;
+// count via formatApplyStatusComment. It loads the operation rows (as returned
+// by ListByApply) so a multi-deployment apply renders the aggregated comment;
 // a single operation (every apply today, until the fan-out lands) renders the
 // single-deployment layout byte-for-byte. A load failure falls back to the
 // single-deployment layout so a transient storage error never blocks a comment
@@ -270,10 +270,10 @@ func (o *CommentObserver) OnTerminal(apply *storage.Apply, tasks []*storage.Task
 func (o *CommentObserver) formatStatusComment(apply *storage.Apply, tasks []*storage.Task) string {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
-	ops, err := o.stor.ApplyOperations().ListByApply(ctx, apply.ID)
+	ops, err := o.stor.ApplyOperations().ListByApply(ctx, o.applyID)
 	if err != nil {
 		o.logger.Error("observer: failed to load apply operations for comment dispatch; rendering single-deployment layout",
-			"apply_id", apply.ApplyIdentifier, "error", err)
+			"apply_id", o.applyID, "error", err)
 		return formatProgressComment(apply, tasks)
 	}
 	return formatApplyStatusComment(apply, ops, tasks)

--- a/pkg/webhook/comment_observer_test.go
+++ b/pkg/webhook/comment_observer_test.go
@@ -1,11 +1,16 @@
 package webhook
 
 import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/block/schemabot/pkg/state"
 	"github.com/block/schemabot/pkg/storage"
 )
 
@@ -96,4 +101,73 @@ func TestCommentObserverErrorLogsWithoutApplyRecord(t *testing.T) {
 	assert.NotContains(t, fields, "apply_id")
 	assert.NotContains(t, fields, "apply_db_id")
 	assert.NotContains(t, fields, "database")
+}
+
+// stubApplyOperationStore returns a fixed operation set (or error) from
+// ListByApply so the observer's comment-dispatch routing can be exercised
+// without a database.
+type stubApplyOperationStore struct {
+	storage.ApplyOperationStore
+	ops []*storage.ApplyOperation
+	err error
+}
+
+func (s *stubApplyOperationStore) ListByApply(context.Context, int64) ([]*storage.ApplyOperation, error) {
+	return s.ops, s.err
+}
+
+// stubStorage exposes only the ApplyOperations accessor the comment dispatch
+// needs; every other store would panic, keeping the test honest about the path
+// it covers.
+type stubStorage struct {
+	storage.Storage
+	ops storage.ApplyOperationStore
+}
+
+func (s *stubStorage) ApplyOperations() storage.ApplyOperationStore { return s.ops }
+
+func newDispatchTestObserver(opStore storage.ApplyOperationStore) *CommentObserver {
+	return &CommentObserver{
+		stor:   &stubStorage{ops: opStore},
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+}
+
+// A multi-deployment apply renders the aggregated comment: the observer loads
+// the operation rows and routes through the multi-deployment layout.
+func TestFormatStatusCommentRoutesMultiDeployment(t *testing.T) {
+	o := newDispatchTestObserver(&stubApplyOperationStore{ops: []*storage.ApplyOperation{
+		{ID: 1, Deployment: "eu", State: state.ApplyOperation.Completed},
+		{ID: 2, Deployment: "us", State: state.ApplyOperation.Running},
+	}})
+
+	body := o.formatStatusComment(runningApply(), nil)
+
+	assert.Contains(t, body, "**Deployments**: 1 completed, 1 running")
+	assert.Contains(t, body, "- ✅ eu — completed")
+	assert.Contains(t, body, "- 🔄 us — running table copy")
+}
+
+// A single-operation apply (every apply today, until fan-out lands) renders the
+// single-deployment comment unchanged — no aggregate header.
+func TestFormatStatusCommentRoutesSingleDeployment(t *testing.T) {
+	o := newDispatchTestObserver(&stubApplyOperationStore{ops: []*storage.ApplyOperation{
+		{ID: 1, Deployment: "eu", State: state.ApplyOperation.Running},
+	}})
+
+	body := o.formatStatusComment(runningApply(), nil)
+
+	assert.Contains(t, body, "## Schema Change In Progress")
+	assert.NotContains(t, body, "**Deployments**:")
+}
+
+// A transient operation-load failure falls back to the single-deployment layout
+// so a storage error never blocks the comment update.
+func TestFormatStatusCommentFallsBackOnLoadError(t *testing.T) {
+	o := newDispatchTestObserver(&stubApplyOperationStore{err: errors.New("db unavailable")})
+
+	body := o.formatStatusComment(runningApply(), nil)
+
+	assert.Contains(t, body, "## Schema Change In Progress")
+	assert.NotContains(t, body, "**Deployments**:")
 }


### PR DESCRIPTION
## What
Route the comment observer's status comments through the multi-deployment dispatcher (`formatApplyStatusComment`) at all three status call sites: the **progress** edit, the **cutover** comment, and the **terminal progress-edit-to-final**. Each loads the apply's operation rows and picks the single- vs multi-deployment layout by operation count, falling back to the single-deployment layout if the operation load fails. The terminal **summary** comment stays single-deployment for now.

## Why
The dispatcher (MD-10c) landed dormant — nothing in the production path called it; the observer still rendered the single-deployment comment directly. This wires it to its real call sites. It's a no-op for single-operation applies (every apply today), and the multi-deployment layout activates automatically once the fan-out makes an apply own more than one operation — so the UX is ready ahead of fan-out without changing today's output.

## Next
- **MD-10e** — add a multi-deployment **summary** comment renderer and route `formatSummaryComment` through it (the one status surface still single-deployment after this PR).
- **Fan-out wiring** — make an apply own more than one operation; this is what actually activates the multi-deployment rendering wired here (and the rest of the dormant multi-deployment path).
