### PR TITLE
fix(tern): finalize applies on the rollout-projected state, not per-op engine result

### DIFF
--- a/pkg/state/README.md
+++ b/pkg/state/README.md
@@ -452,8 +452,13 @@ Engine (Spirit/Vitess)
   → engineStateToStorage()  → Storage (DB)
   → storageStateToProto()   → Proto (gRPC wire)
   → ProtoStateToStorage()   → back to canonical for CLI
-  → taskStateToApplyState() → Apply state for DB
 ```
+
+Apply state is derived from task and operation rows rather than from a single
+task: `DeriveApplyState()` (in `pkg/state`) aggregates a task set into one apply
+state, and `deriveAggregateApplyState()` (in `pkg/tern`) projects that across an
+apply's `apply_operations` siblings for the rollout-level value persisted to the
+DB.
 
 Engines report their own native states (Spirit camelCase, Vitess lowercase). The engine adapter
 (`pkg/engine/spirit`, `pkg/engine/planetscale`) translates these into `engine.State` values. From

--- a/pkg/tern/apply_states_test.go
+++ b/pkg/tern/apply_states_test.go
@@ -395,36 +395,39 @@ func TestDeriveVSchemaTaskState(t *testing.T) {
 // applyQuiesceDecision gates the apply-level terminal/pause side-effects on the
 // rollout-projected apply state. A drive must quiesce the whole apply only when
 // the projection is terminal or a retry-pause — never when a continue policy
-// holds the apply running while siblings are still in flight. Stamping
-// completed_at follows quiesce && !retryablePause (and stopped is terminal but
-// resumable, so completed_at stays nil even though it quiesces).
+// holds the apply running while siblings are still in flight. completed_at is
+// stamped only for truly-finished states: failed_retryable (a retry pause) and
+// stopped (terminal but resumable) keep completed_at nil even though they
+// quiesce.
 func TestApplyQuiesceDecision(t *testing.T) {
 	cases := []struct {
 		name           string
 		projected      string
 		wantQuiesce    bool
 		wantRetryPause bool
+		wantStamp      bool
 	}{
-		{"completed", state.Apply.Completed, true, false},
-		{"failed", state.Apply.Failed, true, false},
-		{"cancelled", state.Apply.Cancelled, true, false},
-		{"reverted", state.Apply.Reverted, true, false},
-		{"stopped", state.Apply.Stopped, true, false},
-		{"failed_retryable", state.Apply.FailedRetryable, true, true},
-		{"running", state.Apply.Running, false, false},
-		{"pending", state.Apply.Pending, false, false},
-		{"waiting_for_cutover", state.Apply.WaitingForCutover, false, false},
-		{"waiting_for_deploy", state.Apply.WaitingForDeploy, false, false},
-		{"cutting_over", state.Apply.CuttingOver, false, false},
-		{"recovering", state.Apply.Recovering, false, false},
-		{"revert_window", state.Apply.RevertWindow, false, false},
-		{"empty/undetermined", "", false, false},
+		{"completed", state.Apply.Completed, true, false, true},
+		{"failed", state.Apply.Failed, true, false, true},
+		{"cancelled", state.Apply.Cancelled, true, false, true},
+		{"reverted", state.Apply.Reverted, true, false, true},
+		{"stopped", state.Apply.Stopped, true, false, false},
+		{"failed_retryable", state.Apply.FailedRetryable, true, true, false},
+		{"running", state.Apply.Running, false, false, false},
+		{"pending", state.Apply.Pending, false, false, false},
+		{"waiting_for_cutover", state.Apply.WaitingForCutover, false, false, false},
+		{"waiting_for_deploy", state.Apply.WaitingForDeploy, false, false, false},
+		{"cutting_over", state.Apply.CuttingOver, false, false, false},
+		{"recovering", state.Apply.Recovering, false, false, false},
+		{"revert_window", state.Apply.RevertWindow, false, false, false},
+		{"empty/undetermined", "", false, false, false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			quiesce, retryPause := applyQuiesceDecision(tc.projected)
+			quiesce, retryPause, stamp := applyQuiesceDecision(tc.projected)
 			assert.Equal(t, tc.wantQuiesce, quiesce, "quiesce for projected state %q", tc.projected)
 			assert.Equal(t, tc.wantRetryPause, retryPause, "retryablePause for projected state %q", tc.projected)
+			assert.Equal(t, tc.wantStamp, stamp, "stampCompletedAt for projected state %q", tc.projected)
 		})
 	}
 }

--- a/pkg/tern/apply_states_test.go
+++ b/pkg/tern/apply_states_test.go
@@ -391,3 +391,40 @@ func TestDeriveVSchemaTaskState(t *testing.T) {
 		assert.Equal(t, state.Task.Completed, got)
 	})
 }
+
+// applyQuiesceDecision gates the apply-level terminal/pause side-effects on the
+// rollout-projected apply state. A drive must quiesce the whole apply only when
+// the projection is terminal or a retry-pause — never when a continue policy
+// holds the apply running while siblings are still in flight. Stamping
+// completed_at follows quiesce && !retryablePause (and stopped is terminal but
+// resumable, so completed_at stays nil even though it quiesces).
+func TestApplyQuiesceDecision(t *testing.T) {
+	cases := []struct {
+		name           string
+		projected      string
+		wantQuiesce    bool
+		wantRetryPause bool
+	}{
+		{"completed", state.Apply.Completed, true, false},
+		{"failed", state.Apply.Failed, true, false},
+		{"cancelled", state.Apply.Cancelled, true, false},
+		{"reverted", state.Apply.Reverted, true, false},
+		{"stopped", state.Apply.Stopped, true, false},
+		{"failed_retryable", state.Apply.FailedRetryable, true, true},
+		{"running", state.Apply.Running, false, false},
+		{"pending", state.Apply.Pending, false, false},
+		{"waiting_for_cutover", state.Apply.WaitingForCutover, false, false},
+		{"waiting_for_deploy", state.Apply.WaitingForDeploy, false, false},
+		{"cutting_over", state.Apply.CuttingOver, false, false},
+		{"recovering", state.Apply.Recovering, false, false},
+		{"revert_window", state.Apply.RevertWindow, false, false},
+		{"empty/undetermined", "", false, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			quiesce, retryPause := applyQuiesceDecision(tc.projected)
+			assert.Equal(t, tc.wantQuiesce, quiesce, "quiesce for projected state %q", tc.projected)
+			assert.Equal(t, tc.wantRetryPause, retryPause, "retryablePause for projected state %q", tc.projected)
+		})
+	}
+}

--- a/pkg/tern/local_apply_grouped.go
+++ b/pkg/tern/local_apply_grouped.go
@@ -441,6 +441,21 @@ func (c *LocalClient) pollForCompletionAtomic(ctx context.Context, apply *storag
 	}
 }
 
+// applyQuiesceDecision reports whether a drive should run the apply-level
+// terminal/pause side-effects — stamping completed_at, dropping the active-
+// applies metric, completing pending stop requests, notifying observers, and
+// stopping polling — based on the rollout-projected apply state rather than one
+// operation's engine result. Under on_failure=continue a failed operation holds
+// the apply running while siblings are still in flight, so its terminal engine
+// result must not quiesce the whole apply. retryablePause is reported separately
+// because failed_retryable pauses for operator retry (completed_at stays nil,
+// observers receive progress not terminal) rather than terminalizing the apply.
+func applyQuiesceDecision(projectedApplyState string) (quiesce, retryablePause bool) {
+	retryablePause = state.IsState(projectedApplyState, state.Apply.FailedRetryable)
+	quiesce = state.IsTerminalApplyState(projectedApplyState) || retryablePause
+	return quiesce, retryablePause
+}
+
 // handleAtomicProgressTick processes a single progress poll tick in atomic mode.
 // Returns true when polling should stop because the apply reached a terminal state
 // or this owner attempt must exit for operator retry.
@@ -645,8 +660,16 @@ func (c *LocalClient) handleAtomicProgressTick(ctx context.Context, eng engine.E
 		return true
 	}
 
-	if result.State.IsTerminal() {
-		retryableFailure := state.IsState(newState, state.Task.FailedRetryable)
+	// Gate apply-level terminal side-effects on the rollout-projected apply state
+	// (apply.State, derived above), not the current operation's engine result.
+	// Under on_failure=continue a failed operation holds the apply running while
+	// siblings are still in flight, so one operation's terminal engine result
+	// must not stamp completed_at, drop the active-applies metric, tear down
+	// observers, or stop polling for the whole apply. With one operation per
+	// apply the projection equals this operation's derived state, so this is a
+	// no-op until the multi-deployment fan-out lands.
+	quiesce, retryableFailure := applyQuiesceDecision(apply.State)
+	if quiesce {
 		if retryableFailure {
 			apply.CompletedAt = nil
 		} else {
@@ -678,14 +701,14 @@ func (c *LocalClient) handleAtomicProgressTick(ctx context.Context, eng engine.E
 		case retryableFailure:
 			c.logger.Warn("apply paused for operator retry",
 				"mode", groupedApplyMode(apply), "apply_id", apply.ApplyIdentifier, "error", apply.ErrorMessage, "task_count", len(tasks))
-		case result.State == engine.StateFailed:
+		case state.IsState(apply.State, state.Apply.Failed):
 			c.logger.Error("apply failed",
 				"mode", groupedApplyMode(apply), "apply_id", apply.ApplyIdentifier, "error", apply.ErrorMessage, "task_count", len(tasks))
 		default:
 			c.logger.Info("apply completed",
-				"mode", groupedApplyMode(apply), "apply_id", apply.ApplyIdentifier, "state", result.State, "task_count", len(tasks))
+				"mode", groupedApplyMode(apply), "apply_id", apply.ApplyIdentifier, "state", apply.State, "task_count", len(tasks))
 		}
-		eventMessage := fmt.Sprintf("Apply completed with state: %s", result.State)
+		eventMessage := fmt.Sprintf("Apply completed with state: %s", apply.State)
 		if retryableFailure {
 			eventMessage = "Apply paused for operator retry after retryable engine failure"
 		}

--- a/pkg/tern/local_apply_grouped.go
+++ b/pkg/tern/local_apply_grouped.go
@@ -317,6 +317,69 @@ func applyOperationIDForTask(task *storage.Task) (int64, error) {
 	return *task.ApplyOperationID, nil
 }
 
+// tasksForOperation returns the subset of tasks belonging to the given
+// apply_operation. It is nil-safe: a nil task or one without an
+// apply_operation_id is skipped. Callers use it to scope an apply-wide task set
+// (which spans multiple operations once an apply fans out) down to a single
+// operation before deriving that operation's state.
+func tasksForOperation(tasks []*storage.Task, operationID int64) []*storage.Task {
+	var scoped []*storage.Task
+	for _, task := range tasks {
+		if task == nil || task.ApplyOperationID == nil {
+			continue
+		}
+		if *task.ApplyOperationID == operationID {
+			scoped = append(scoped, task)
+		}
+	}
+	return scoped
+}
+
+// classifyOperationTasks reports how a task set maps to the apply-operation
+// model so deriveAggregateApplyState can distinguish three cases that must be
+// handled differently:
+//
+//   - No operation model (usesModel=false, err=nil): every task carries no
+//     apply_operation_id, or the set is empty. There are no siblings, so the
+//     per-task derivation is authoritative and may terminalize. This preserves
+//     single-writer/legacy behaviour for applies written before the apply-create
+//     path populated apply_operation_id.
+//   - Single operation (usesModel=true, err=nil): every task carries the same
+//     apply_operation_id. The sibling-row projection applies.
+//   - Ambiguous (err!=nil): the tasks span multiple operation ids, mix
+//     operation-model and legacy rows, or include a nil task. The set cannot be
+//     attributed to one operation, so a terminal aggregate derived from it would
+//     be unsafe; the caller must fail closed.
+//
+// It is intentionally stricter than applyOperationIDForTasks's "no operation"
+// fallback: a mixed set is an error here, not a legacy no-op-model case.
+func classifyOperationTasks(tasks []*storage.Task) (operationID int64, usesModel bool, err error) {
+	var sawNil, sawID bool
+	for _, task := range tasks {
+		if task == nil {
+			return 0, false, fmt.Errorf("apply operation task is nil")
+		}
+		if task.ApplyOperationID == nil || *task.ApplyOperationID == 0 {
+			sawNil = true
+			continue
+		}
+		id := *task.ApplyOperationID
+		if sawID && operationID != id {
+			return 0, false, fmt.Errorf("tasks span multiple apply operations: %d and %d", operationID, id)
+		}
+		operationID = id
+		sawID = true
+	}
+	switch {
+	case sawID && sawNil:
+		return 0, false, fmt.Errorf("tasks mix operation-model and legacy rows")
+	case sawID:
+		return operationID, true, nil
+	default:
+		return 0, false, nil
+	}
+}
+
 // deriveAggregateApplyState computes applies.state as the rollout projection
 // over every apply_operation row of the apply, accounting for each operation's
 // on_failure policy via state.DeriveRolloutApplyState. The boolean is false when
@@ -340,13 +403,19 @@ func applyOperationIDForTask(task *storage.Task) (int64, error) {
 // With one operation per apply the sibling set is the current operation alone,
 // so the projection collapses to the current deployment's derived state.
 //
-// Two outcomes are distinguished when the full sibling set is not available:
+// Three outcomes are distinguished when the full sibling set is not available:
 //
 //   - The apply does not use the operation model — its tasks carry no
 //     apply_operation_id, or the operation store is not configured. There are no
 //     siblings, so the per-task derivation is authoritative and may terminalize.
 //     This preserves single-writer/legacy behaviour for applies written before
 //     the apply-create path populated apply_operation_id.
+//
+//   - The task set is not scoped to one operation — it spans multiple
+//     apply_operation_ids or mixes operation-model and legacy rows. The set
+//     cannot be attributed to a single operation, so its derived state is not a
+//     meaningful per-operation state and must not terminalize the apply. The
+//     projection fails closed (ok=false) so the caller keeps the stored value.
 //
 //   - The apply uses the operation model (its tasks carry an apply_operation_id)
 //     but the sibling rows cannot be read consistently — the list call failed,
@@ -375,12 +444,21 @@ func (c *LocalClient) deriveAggregateApplyState(ctx context.Context, apply *stor
 		return currentOpState, true
 	}
 
-	operationID, err := applyOperationIDForTasks(tasks)
+	operationID, usesModel, err := classifyOperationTasks(tasks)
 	if err != nil {
+		// The task set cannot be attributed to a single apply operation: it spans
+		// multiple operation ids or mixes operation-model and legacy rows. The
+		// sibling states are unknowable from such a mix, so fail closed rather
+		// than task-deriving a possibly terminal aggregate from an ambiguous set.
+		c.logger.Warn("cannot determine aggregate apply state: task set is not scoped to one apply operation",
+			"apply_id", apply.ApplyIdentifier, "error", err)
+		return failClosed()
+	}
+	if !usesModel {
 		// No operation model in use: tasks carry no apply_operation_id, so there
 		// are no siblings and the per-task derivation is authoritative.
 		c.logger.Debug("deriving apply state from tasks: apply has no operation model",
-			"apply_id", apply.ApplyIdentifier, "reason", err)
+			"apply_id", apply.ApplyIdentifier)
 		return currentOpState, true
 	}
 

--- a/pkg/tern/local_apply_grouped.go
+++ b/pkg/tern/local_apply_grouped.go
@@ -548,8 +548,12 @@ func applyQuiesceDecision(projectedApplyState string) (quiesce, retryablePause, 
 }
 
 // handleAtomicProgressTick processes a single progress poll tick in atomic mode.
-// Returns true when polling should stop because the apply reached a terminal state
-// or this owner attempt must exit for operator retry.
+// Returns true when this operation's drive should stop polling: the aggregate
+// apply quiesced (terminal or paused for retry), this owner attempt must exit
+// for operator retry, or — under on_failure=continue — this operation's own
+// tasks settled while a sibling holds the apply running. The apply-level
+// wind-down runs only when the aggregate quiesces, not when a single operation
+// finishes ahead of its siblings.
 func (c *LocalClient) handleAtomicProgressTick(ctx context.Context, eng engine.Engine, apply *storage.Apply, tasks []*storage.Task, creds *engine.Credentials, resumeState *engine.ResumeState, ps *atomicPollState) bool {
 	if handled, err := c.processPendingStopControlRequest(ctx, apply); err != nil {
 		c.logger.Warn("pending stop request processing failed; current apply owner will exit for operator retry",
@@ -825,6 +829,23 @@ func (c *LocalClient) handleAtomicProgressTick(ctx context.Context, eng engine.E
 	// Notify observer of progress update
 	if obs := c.getObserver(apply.ID); obs != nil {
 		obs.OnProgress(apply, tasks)
+	}
+
+	// Exit this operation's drive once its own tasks have settled, even though
+	// the aggregate apply has not quiesced. The apply-level gate above keys off
+	// the rollout projection: under on_failure=continue a still-in-flight sibling
+	// holds the apply running, so it was skipped. This operation's work is done,
+	// so stop polling and let the operator persist its apply_operation row and
+	// re-derive the parent; the apply-level wind-down (completed_at, metric drop,
+	// observer teardown, stop-request completion) stays with the last sibling to
+	// settle. With one operation per apply the projection equals this operation's
+	// state, so the apply-level gate already fired when it finished and this is
+	// never reached — single-operation behaviour is unchanged.
+	opState := state.DeriveApplyState(taskStates(tasks))
+	if state.IsTerminalApplyState(opState) || state.IsState(opState, state.Apply.FailedRetryable) {
+		c.logger.Info("operation settled while apply continues; exiting operation drive",
+			"mode", groupedApplyMode(apply), "apply_id", apply.ApplyIdentifier, "operation_state", opState, "apply_state", apply.State)
+		return true
 	}
 	return false
 }

--- a/pkg/tern/local_apply_grouped.go
+++ b/pkg/tern/local_apply_grouped.go
@@ -450,10 +450,15 @@ func (c *LocalClient) pollForCompletionAtomic(ctx context.Context, apply *storag
 // result must not quiesce the whole apply. retryablePause is reported separately
 // because failed_retryable pauses for operator retry (completed_at stays nil,
 // observers receive progress not terminal) rather than terminalizing the apply.
-func applyQuiesceDecision(projectedApplyState string) (quiesce, retryablePause bool) {
+func applyQuiesceDecision(projectedApplyState string) (quiesce, retryablePause, stampCompletedAt bool) {
 	retryablePause = state.IsState(projectedApplyState, state.Apply.FailedRetryable)
 	quiesce = state.IsTerminalApplyState(projectedApplyState) || retryablePause
-	return quiesce, retryablePause
+	// completed_at is stamped only when the apply is truly finished. Resumable
+	// states keep it nil so an operator can resume: failed_retryable is a retry
+	// pause, and stopped is terminal but explicitly resumable.
+	resumable := retryablePause || state.IsState(projectedApplyState, state.Apply.Stopped)
+	stampCompletedAt = quiesce && !resumable
+	return quiesce, retryablePause, stampCompletedAt
 }
 
 // handleAtomicProgressTick processes a single progress poll tick in atomic mode.
@@ -668,26 +673,23 @@ func (c *LocalClient) handleAtomicProgressTick(ctx context.Context, eng engine.E
 	// observers, or stop polling for the whole apply. With one operation per
 	// apply the projection equals this operation's derived state, so this is a
 	// no-op until the multi-deployment fan-out lands.
-	quiesce, retryableFailure := applyQuiesceDecision(apply.State)
+	quiesce, retryableFailure, stampCompletedAt := applyQuiesceDecision(apply.State)
 	if quiesce {
-		if retryableFailure {
-			apply.CompletedAt = nil
-		} else {
+		if stampCompletedAt {
 			apply.CompletedAt = &now
+		} else {
+			apply.CompletedAt = nil
 		}
-		// Propagate error message from failed tasks to the apply record
+		// Prefer this operation's engine failure message. Under on_failure=continue
+		// the rollout projection can resolve the apply to a failure because of a
+		// sibling operation while this engine result is non-failed, so fall back to
+		// the failed task rows to avoid persisting a failed apply with no message.
 		if result.State == engine.StateFailed {
 			if msg := progressFailureMessage(result); msg != "" {
 				apply.ErrorMessage = msg
-			} else {
-				for _, task := range tasks {
-					if (task.State == state.Task.Failed || task.State == state.Task.FailedRetryable) && task.ErrorMessage != "" {
-						apply.ErrorMessage = fmt.Sprintf("table %s failed: %s", task.TableName, task.ErrorMessage)
-						break
-					}
-				}
 			}
 		}
+		ensureApplyFailureMessage(apply, tasks)
 		if err := c.storage.Applies().Update(ctx, apply); err != nil {
 			c.logger.Error("failed to update apply state", "apply_id", apply.ApplyIdentifier, "state", apply.State, "error", err)
 		}

--- a/pkg/tern/local_client.go
+++ b/pkg/tern/local_client.go
@@ -977,6 +977,18 @@ func (c *LocalClient) Progress(ctx context.Context, req *ternv1.ProgressRequest)
 	// Get ALL tasks for this apply (completed + running + pending)
 	currentApplyTasks := filterTasksByApply(tasks, activeTask.ApplyID)
 
+	// Scope to the active task's apply operation before deriving the aggregate
+	// apply state. currentApplyTasks is scoped by apply, so once an apply fans
+	// out to multiple operations it is a mixed set; deriving the aggregate from
+	// that mix would bypass the sibling operation rows and the on_failure policy.
+	// currentApplyTasks is still used below for the response table list and the
+	// all-terminal gate. With one operation per apply the two slices are equal,
+	// so this is a no-op until the multi-deployment fan-out lands.
+	opScopedTasks := currentApplyTasks
+	if activeTask.ApplyOperationID != nil {
+		opScopedTasks = tasksForOperation(currentApplyTasks, *activeTask.ApplyOperationID)
+	}
+
 	creds := c.credentials()
 	eng := c.getEngine()
 
@@ -1061,7 +1073,7 @@ func (c *LocalClient) Progress(ctx context.Context, req *ternv1.ProgressRequest)
 					if apply, err := c.storage.Applies().Get(ctx, activeTask.ApplyID); err != nil {
 						c.logger.Warn("failed to load apply after progress task state update", "apply_id", activeTask.ApplyID, "error", err)
 					} else if apply != nil && !state.IsTerminalApplyState(apply.State) {
-						if derived, ok := c.deriveAggregateApplyState(ctx, apply, currentApplyTasks); ok {
+						if derived, ok := c.deriveAggregateApplyState(ctx, apply, opScopedTasks); ok {
 							apply.State = derived
 							apply.UpdatedAt = now
 							if err := c.storage.Applies().Update(ctx, apply); err != nil {
@@ -1095,7 +1107,7 @@ func (c *LocalClient) Progress(ctx context.Context, req *ternv1.ProgressRequest)
 						// one operation per apply the projection equals this
 						// operation's derived state, so this is a no-op until the
 						// multi-deployment fan-out lands.
-						derived, ok := c.deriveAggregateApplyState(ctx, apply, currentApplyTasks)
+						derived, ok := c.deriveAggregateApplyState(ctx, apply, opScopedTasks)
 						quiesce, _, stampCompletedAt := applyQuiesceDecision(derived)
 						if ok && quiesce {
 							now := time.Now()
@@ -1114,7 +1126,7 @@ func (c *LocalClient) Progress(ctx context.Context, req *ternv1.ProgressRequest)
 									apply.ErrorMessage = msg
 								}
 							}
-							ensureApplyFailureMessage(apply, currentApplyTasks)
+							ensureApplyFailureMessage(apply, opScopedTasks)
 							apply.UpdatedAt = now
 							if err := c.storage.Applies().Update(ctx, apply); err != nil {
 								c.logger.Warn("failed to update apply from progress poll", "apply_id", apply.ApplyIdentifier, "state", apply.State, "apply_db_id", apply.ID, "error", err)

--- a/pkg/tern/local_client.go
+++ b/pkg/tern/local_client.go
@@ -948,21 +948,32 @@ func (c *LocalClient) Progress(ctx context.Context, req *ternv1.ProgressRequest)
 				if retryableFailure || allTerminal {
 					apply, _ := c.storage.Applies().GetByApplyIdentifier(ctx, req.ApplyId)
 					if apply != nil && !state.IsTerminalApplyState(apply.State) {
-						now := time.Now()
-						apply.State = taskStateToApplyState(taskState)
-						if retryableFailure {
-							apply.CompletedAt = nil
-						} else {
-							apply.CompletedAt = &now
+						// Terminalize the parent apply on the rollout projection
+						// over all sibling operations, not this operation's tasks
+						// alone: under on_failure=continue a failed operation must
+						// hold the apply running while siblings are in flight. With
+						// one operation per apply the projection equals this
+						// operation's derived state, so this is a no-op until the
+						// multi-deployment fan-out lands.
+						derived, ok := c.deriveAggregateApplyState(ctx, apply, currentApplyTasks)
+						quiesce, projectedRetryablePause := applyQuiesceDecision(derived)
+						if ok && quiesce {
+							now := time.Now()
+							apply.State = derived
+							if projectedRetryablePause {
+								apply.CompletedAt = nil
+							} else {
+								apply.CompletedAt = &now
+							}
+							if result.State == engine.StateFailed {
+								apply.ErrorMessage = progressFailureMessage(result)
+							}
+							apply.UpdatedAt = now
+							if err := c.storage.Applies().Update(ctx, apply); err != nil {
+								c.logger.Warn("failed to update apply from progress poll", "apply_id", apply.ApplyIdentifier, "state", apply.State, "apply_db_id", apply.ID, "error", err)
+							}
+							c.logger.Info("apply state updated from progress polling", "apply_id", apply.ApplyIdentifier, "state", apply.State)
 						}
-						if result.State == engine.StateFailed {
-							apply.ErrorMessage = progressFailureMessage(result)
-						}
-						apply.UpdatedAt = now
-						if err := c.storage.Applies().Update(ctx, apply); err != nil {
-							c.logger.Warn("failed to update apply from progress poll", "apply_id", apply.ApplyIdentifier, "state", apply.State, "apply_db_id", apply.ID, "error", err)
-						}
-						c.logger.Info("apply state updated from progress polling", "apply_id", apply.ApplyIdentifier, "state", apply.State)
 					}
 				}
 			}

--- a/pkg/tern/local_client.go
+++ b/pkg/tern/local_client.go
@@ -956,18 +956,25 @@ func (c *LocalClient) Progress(ctx context.Context, req *ternv1.ProgressRequest)
 						// operation's derived state, so this is a no-op until the
 						// multi-deployment fan-out lands.
 						derived, ok := c.deriveAggregateApplyState(ctx, apply, currentApplyTasks)
-						quiesce, projectedRetryablePause := applyQuiesceDecision(derived)
+						quiesce, _, stampCompletedAt := applyQuiesceDecision(derived)
 						if ok && quiesce {
 							now := time.Now()
 							apply.State = derived
-							if projectedRetryablePause {
-								apply.CompletedAt = nil
-							} else {
+							if stampCompletedAt {
 								apply.CompletedAt = &now
+							} else {
+								apply.CompletedAt = nil
 							}
+							// Prefer this operation's engine failure message; fall back
+							// to the failed task rows when the rollout projection resolves
+							// the apply to a failure due to a sibling operation that this
+							// engine result doesn't reflect.
 							if result.State == engine.StateFailed {
-								apply.ErrorMessage = progressFailureMessage(result)
+								if msg := progressFailureMessage(result); msg != "" {
+									apply.ErrorMessage = msg
+								}
 							}
+							ensureApplyFailureMessage(apply, currentApplyTasks)
 							apply.UpdatedAt = now
 							if err := c.storage.Applies().Update(ctx, apply); err != nil {
 								c.logger.Warn("failed to update apply from progress poll", "apply_id", apply.ApplyIdentifier, "state", apply.State, "apply_db_id", apply.ID, "error", err)

--- a/pkg/tern/local_client_test.go
+++ b/pkg/tern/local_client_test.go
@@ -60,6 +60,40 @@ func (s *exactProgressApplyStore) Update(_ context.Context, apply *storage.Apply
 	return nil
 }
 
+// snapshotApplyStore returns a copy of the stored apply on reads and replaces
+// the stored copy on Update, so in-memory mutations to the apply passed into a
+// drive do not leak into the next storage read. This mirrors a real store, where
+// a reload reflects the last persisted write rather than uncommitted state.
+type snapshotApplyStore struct {
+	storage.ApplyStore
+	stored storage.Apply
+	err    error
+}
+
+func (s *snapshotApplyStore) Get(context.Context, int64) (*storage.Apply, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	cp := s.stored
+	return &cp, nil
+}
+
+func (s *snapshotApplyStore) GetByApplyIdentifier(context.Context, string) (*storage.Apply, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	cp := s.stored
+	return &cp, nil
+}
+
+func (s *snapshotApplyStore) Update(_ context.Context, apply *storage.Apply) error {
+	if s.err != nil {
+		return s.err
+	}
+	s.stored = *apply
+	return nil
+}
+
 type exactProgressTaskStore struct {
 	storage.TaskStore
 	tasks []*storage.Task
@@ -1887,6 +1921,78 @@ func TestTasksForOperation(t *testing.T) {
 	require.Len(t, got, 2)
 	assert.Equal(t, "a", got[0].TaskIdentifier)
 	assert.Equal(t, "c", got[1].TaskIdentifier)
+}
+
+// handleAtomicProgressTick must separate "this operation is done" from "the
+// apply should quiesce". Under on_failure=continue an operation whose own tasks
+// have settled exits its drive while a still-pending sibling holds the apply
+// running, so the apply-level wind-down (completed_at, observer teardown, metric
+// drop) is deferred to the last sibling. With one operation per apply the
+// aggregate equals the operation's own state, so finishing the operation
+// quiesces the apply exactly as before.
+func TestHandleAtomicProgressTickOperationGate(t *testing.T) {
+	const currentOpID = int64(1)
+
+	newApply := func() *storage.Apply {
+		return &storage.Apply{
+			ID:              7,
+			ApplyIdentifier: "apply-op-gate",
+			Database:        "testdb",
+			State:           state.Apply.Running,
+			Options:         storage.MarshalApplyOptions(storage.ApplyOptions{DeferCutover: true}),
+		}
+	}
+	completedEngine := func() *fakeControlEngine {
+		return &fakeControlEngine{progressResult: &engine.ProgressResult{
+			State:  engine.StateCompleted,
+			Tables: []engine.TableProgress{{Namespace: "testdb", Table: "users", State: state.Task.Completed, Progress: 100}},
+		}}
+	}
+	runTick := func(t *testing.T, apply *storage.Apply, ops []*storage.ApplyOperation) (bool, *storage.Apply) {
+		t.Helper()
+		opID := currentOpID
+		tasks := []*storage.Task{{
+			TaskIdentifier:   "task-users",
+			ApplyID:          apply.ID,
+			ApplyOperationID: &opID,
+			State:            state.Task.Running,
+			TableName:        "users",
+			Namespace:        "testdb",
+		}}
+		stor := &exactProgressStorage{
+			applies:         &snapshotApplyStore{stored: *apply},
+			tasks:           &exactProgressTaskStore{tasks: tasks},
+			controlRequests: &testControlRequestStore{},
+			applyOperations: &listApplyOperationStore{ops: ops},
+		}
+		client := &LocalClient{storage: stor, logger: slog.Default()}
+		ps := &atomicPollState{lastProgressLog: time.Now()}
+		done := client.handleAtomicProgressTick(t.Context(), completedEngine(), apply, tasks, &engine.Credentials{}, nil, ps)
+		return done, apply
+	}
+
+	// A completed operation with a still-pending continue sibling exits its drive
+	// but must not terminalize the apply or stamp completed_at.
+	t.Run("operation completes while sibling holds the apply running", func(t *testing.T) {
+		done, apply := runTick(t, newApply(), []*storage.ApplyOperation{
+			{ID: currentOpID, State: state.ApplyOperation.Running, OnFailure: storage.OnFailureContinue},
+			{ID: 2, State: state.ApplyOperation.Pending, OnFailure: storage.OnFailureContinue},
+		})
+		assert.True(t, done, "operation drive must exit once its own tasks are terminal")
+		assert.False(t, state.IsTerminalApplyState(apply.State), "the apply must stay non-terminal while the sibling is in flight, got %q", apply.State)
+		assert.Nil(t, apply.CompletedAt, "the apply-level wind-down must not stamp completed_at for a finished operation")
+	})
+
+	// With one operation per apply the aggregate equals the operation's state, so
+	// the apply-level gate fires and terminalizes the apply as before.
+	t.Run("single operation terminalizes the apply", func(t *testing.T) {
+		done, apply := runTick(t, newApply(), []*storage.ApplyOperation{
+			{ID: currentOpID, State: state.ApplyOperation.Running},
+		})
+		assert.True(t, done, "polling must stop when the apply quiesces")
+		assert.Equal(t, state.Apply.Completed, apply.State, "a single-operation apply terminalizes when its operation completes")
+		assert.NotNil(t, apply.CompletedAt, "a completed apply stamps completed_at")
+	})
 }
 
 // capturedLog records a single emitted log record's level, message, and

--- a/pkg/tern/local_client_test.go
+++ b/pkg/tern/local_client_test.go
@@ -1781,6 +1781,112 @@ func TestDeriveAggregateApplyState(t *testing.T) {
 			assert.Equal(t, want, got)
 		})
 	}
+
+	// A task set that spans more than one apply operation, or mixes
+	// operation-model and legacy rows, cannot be attributed to a single
+	// operation. Its per-task derivation is not a meaningful per-operation state,
+	// so a terminal derivation must not become the aggregate — the projection
+	// fails closed (ok=false) and the caller keeps the stored apply state. This
+	// guards the Progress path before its caller scopes the set to one operation.
+	opID1, opID2 := int64(1), int64(2)
+	ambiguousTaskSets := map[string][]*storage.Task{
+		"tasks span multiple operations": {
+			{State: state.Task.Completed, ApplyOperationID: &opID1},
+			{State: state.Task.Completed, ApplyOperationID: &opID2},
+		},
+		"tasks mix operation-model and legacy rows": {
+			{State: state.Task.Completed, ApplyOperationID: &opID1},
+			{State: state.Task.Completed},
+		},
+	}
+	for name, tasks := range ambiguousTaskSets {
+		t.Run("ambiguous task set ("+name+") fails closed when terminal", func(t *testing.T) {
+			client := &LocalClient{
+				storage: &exactProgressStorage{
+					applyOperations: &listApplyOperationStore{
+						ops: []*storage.ApplyOperation{
+							{ID: currentOpID, State: state.ApplyOperation.Running},
+							{ID: 2, State: state.ApplyOperation.Pending},
+						},
+					},
+				},
+				logger: slog.Default(),
+			}
+			apply := &storage.Apply{ID: 7, ApplyIdentifier: "apply-ambiguous"}
+
+			require.True(t, state.IsTerminalApplyState(state.DeriveApplyState(taskStates(tasks))), "precondition: mixed set derives terminal")
+			_, ok := client.deriveAggregateApplyState(t.Context(), apply, tasks)
+			assert.False(t, ok, "an ambiguous multi-operation task set must not terminalize the apply")
+		})
+	}
+}
+
+// classifyOperationTasks distinguishes legacy applies (no apply_operation_id)
+// from operation-model applies, and rejects ambiguous sets that span multiple
+// operations or mix legacy and operation-model rows.
+func TestClassifyOperationTasks(t *testing.T) {
+	opID1, opID2, opID5 := int64(1), int64(2), int64(5)
+
+	t.Run("empty set is legacy no-op-model", func(t *testing.T) {
+		id, usesModel, err := classifyOperationTasks(nil)
+		require.NoError(t, err)
+		assert.False(t, usesModel)
+		assert.Zero(t, id)
+	})
+
+	t.Run("all legacy rows is no-op-model", func(t *testing.T) {
+		tasks := []*storage.Task{{State: state.Task.Completed}, {State: state.Task.Pending}}
+		id, usesModel, err := classifyOperationTasks(tasks)
+		require.NoError(t, err)
+		assert.False(t, usesModel)
+		assert.Zero(t, id)
+	})
+
+	t.Run("single shared operation uses the model", func(t *testing.T) {
+		tasks := []*storage.Task{
+			{State: state.Task.Completed, ApplyOperationID: &opID5},
+			{State: state.Task.Running, ApplyOperationID: &opID5},
+		}
+		id, usesModel, err := classifyOperationTasks(tasks)
+		require.NoError(t, err)
+		assert.True(t, usesModel)
+		assert.Equal(t, int64(5), id)
+	})
+
+	t.Run("multiple operations is ambiguous", func(t *testing.T) {
+		tasks := []*storage.Task{
+			{State: state.Task.Completed, ApplyOperationID: &opID1},
+			{State: state.Task.Completed, ApplyOperationID: &opID2},
+		}
+		_, _, err := classifyOperationTasks(tasks)
+		assert.Error(t, err)
+	})
+
+	t.Run("mixed legacy and operation rows is ambiguous", func(t *testing.T) {
+		tasks := []*storage.Task{
+			{State: state.Task.Completed, ApplyOperationID: &opID1},
+			{State: state.Task.Completed},
+		}
+		_, _, err := classifyOperationTasks(tasks)
+		assert.Error(t, err)
+	})
+}
+
+// tasksForOperation filters an apply-wide (possibly multi-operation) task set
+// down to a single operation, skipping nil tasks and tasks with no operation id.
+func TestTasksForOperation(t *testing.T) {
+	opID1, opID2 := int64(1), int64(2)
+	tasks := []*storage.Task{
+		{TaskIdentifier: "a", ApplyOperationID: &opID1},
+		{TaskIdentifier: "b", ApplyOperationID: &opID2},
+		{TaskIdentifier: "c", ApplyOperationID: &opID1},
+		{TaskIdentifier: "d"},
+		nil,
+	}
+	got := tasksForOperation(tasks, 1)
+	require.Len(t, got, 2)
+	assert.Equal(t, "a", got[0].TaskIdentifier)
+	assert.Equal(t, "c", got[1].TaskIdentifier)
 }
 
 // capturedLog records a single emitted log record's level, message, and

--- a/pkg/tern/local_control.go
+++ b/pkg/tern/local_control.go
@@ -635,6 +635,25 @@ func firstFailedTaskError(tasks []*storage.Task) string {
 	return ""
 }
 
+// ensureApplyFailureMessage derives the apply's failure reason from the failed
+// task rows when the apply has resolved to a failure state but still carries no
+// message. Under on_failure=continue the rollout projection can resolve the
+// apply to failed/failed_retryable because of a sibling operation while the
+// finishing operation's own engine result is non-failed, so the per-operation
+// engine message is not always available. An ErrorMessage already on the apply
+// is authoritative and left untouched.
+func ensureApplyFailureMessage(apply *storage.Apply, tasks []*storage.Task) {
+	if apply.ErrorMessage != "" {
+		return
+	}
+	if !state.IsState(apply.State, state.Apply.Failed) && !state.IsState(apply.State, state.Apply.FailedRetryable) {
+		return
+	}
+	if msg := firstFailedTaskError(tasks); msg != "" {
+		apply.ErrorMessage = msg
+	}
+}
+
 // handleStopAllTasksTerminal handles the edge case where stop is requested but
 // every targeted task is already in a terminal state (completed, failed,
 // cancelled, or reverted). The apply row may still be non-terminal — e.g., a

--- a/pkg/tern/state_converters.go
+++ b/pkg/tern/state_converters.go
@@ -16,41 +16,6 @@ import (
 	"github.com/block/schemabot/pkg/storage"
 )
 
-// taskStateToApplyState maps a task state string to an Apply state string.
-func taskStateToApplyState(ts string) string {
-	ts = state.NormalizeTaskStatus(ts)
-	switch ts {
-	case state.Task.Pending:
-		return state.Apply.Pending
-	case state.Task.Running:
-		return state.Apply.Running
-	case state.Task.WaitingForDeploy:
-		return state.Apply.WaitingForDeploy
-	case state.Task.WaitingForCutover:
-		return state.Apply.WaitingForCutover
-	case state.Task.Recovering:
-		return state.Apply.Recovering
-	case state.Task.CuttingOver:
-		return state.Apply.CuttingOver
-	case state.Task.RevertWindow:
-		return state.Apply.RevertWindow
-	case state.Task.Completed:
-		return state.Apply.Completed
-	case state.Task.Failed:
-		return state.Apply.Failed
-	case state.Task.FailedRetryable:
-		return state.Apply.FailedRetryable
-	case state.Task.Stopped:
-		return state.Apply.Stopped
-	case state.Task.Reverted:
-		return state.Apply.Reverted
-	case state.Task.Cancelled:
-		return state.Apply.Cancelled
-	default:
-		return state.Apply.Pending
-	}
-}
-
 func taskStates(tasks []*storage.Task) []string {
 	states := make([]string, 0, len(tasks))
 	for _, task := range tasks {


### PR DESCRIPTION
## What

Apply-level terminal side-effects — stamping `completed_at`, dropping the
active-applies metric, completing pending stop requests, tearing down observers,
and stopping polling — now gate on the **rollout-projected** apply state
(`deriveAggregateApplyState` over all operation rows) rather than the current
operation's engine result. Extracted into a small `applyQuiesceDecision` helper
used by both the grouped driver and the progress writer.

## Why

Under `on_failure=continue`, one operation can reach a terminal engine result
(e.g. failed) while the rollout projection legitimately holds the apply running
because siblings are still in flight. Keying finalization off the per-operation
result would prematurely stamp `completed_at` on a running apply, double-drop the
active-applies metric, tear down observers, and stop polling before siblings
finish. Gating on the projection fixes that and keeps a `completed` last
operation from terminalizing a `failed`-projected parent.

This is a no-op for single-operation applies: the projection collapses to the
current operation's derived state, so today's behavior is unchanged. It only
takes effect once an apply owns more than one operation.

## Stacking / sequencing

Branches off `main` (its tern files are disjoint from the operation-state-first
persistence work in #343), but it pairs with that change and should land after
it. The next slice — making the projected apply-state writes compare-and-swap so
concurrent sibling drives stop last-write-wins clobbering — stacks on this branch.
