### PR TITLE
fix(operator): halt remaining siblings on stop under continue

### DIFF
--- a/pkg/api/operator.go
+++ b/pkg/api/operator.go
@@ -344,12 +344,34 @@ func (s *Service) recoverApplyOperation(ctx context.Context, workerID int, owner
 		return
 	}
 
-	// Reload the parent apply: ResumeApply persists the final state to storage,
-	// and the operation row must mirror the durable outcome, not the in-memory
-	// object the resume path started from.
+	// Persist the operation row from its OWN drive outcome — the aggregate of
+	// this operation's tasks — rather than mirroring the parent apply down.
+	// Under on_failure "continue" the parent applies.state can be held running
+	// (the policy-aware projection waits for siblings to settle) while this
+	// operation has terminally failed; mirroring the parent down would leave the
+	// failed operation claimable and re-leased on every poll, so its failure
+	// would never be durably recorded. The operation row is authoritative for
+	// its own deployment; the parent state is derived from the operation rows
+	// afterward via updateApplyStateFromOperations.
+	marked, err := s.markOperationFromOwnResult(operationLeaseCtx, workerID, op)
+	if err != nil {
+		s.logger.Error("operator: failed to update apply_operation from its tasks; derived apply state not updated",
+			"worker", workerID, "apply_operation_id", op.ID, "apply_id", apply.ApplyIdentifier,
+			"deployment", op.Deployment, "environment", apply.Environment, "error", err)
+		return
+	}
+	if !marked {
+		return
+	}
+
+	// Reload the parent apply so updateApplyStateFromOperations below re-derives
+	// the parent from its children against the durable apply.State (its
+	// terminal-to-non-terminal guard), not the in-memory object the resume path
+	// started from. The reloaded row is only the target of the re-derivation;
+	// the operation row was already persisted from its own tasks above.
 	finalApply, err := s.storage.Applies().Get(applyLeaseCtx, apply.ID)
 	if err != nil {
-		s.logger.Error("operator: failed to reload parent apply after resume; operation state not updated",
+		s.logger.Error("operator: failed to reload parent apply after resume; derived apply state not updated",
 			"worker", workerID,
 			"apply_operation_id", op.ID,
 			"apply_id", apply.ApplyIdentifier,
@@ -358,22 +380,11 @@ func (s *Service) recoverApplyOperation(ctx context.Context, workerID int, owner
 		return
 	}
 	if finalApply == nil {
-		s.logger.Error("operator: parent apply not found after resume; operation state not updated",
+		s.logger.Error("operator: parent apply not found after resume; derived apply state not updated",
 			"worker", workerID,
 			"apply_operation_id", op.ID,
 			"apply_id", apply.ApplyIdentifier,
 			"deployment", op.Deployment)
-		return
-	}
-
-	marked, err := s.markOperationFromApplyState(operationLeaseCtx, workerID, op, finalApply)
-	if err != nil {
-		s.logger.Error("operator: failed to update apply_operation from parent apply state; derived apply state not updated",
-			"worker", workerID, "apply_operation_id", op.ID, "apply_id", finalApply.ApplyIdentifier,
-			"deployment", op.Deployment, "environment", finalApply.Environment, "state", finalApply.State, "error", err)
-		return
-	}
-	if !marked {
 		return
 	}
 
@@ -663,57 +674,116 @@ func (s *Service) startApplyOperationHeartbeat(ctx context.Context, workerID int
 }
 
 // markOperationFromApplyState transitions the claimed operation row to mirror
-// the parent apply's final state after a successful resume.
-//
-// It returns updated=true whenever the operation row was durably written to
-// mirror the parent — including resumable final states (stopped,
-// failed_retryable), not only terminal ones. updated=true is the signal the
-// caller needs before deriving the parent apply's state from its children: the
-// child row now reflects the parent, so the derived state is current. A parent
-// that is still mid-flight leaves the operation claimable (updated=false, nil
-// error) so a later poll re-leases and resumes it; a write failure returns the
-// error so the caller skips derivation rather than aggregating a stale child
-// state.
+// the parent apply's final state. It is used by the unclaimable-parent
+// reconciliation path, where an already-terminal parent is authoritative for its
+// single operation. The drive path instead uses markOperationFromOwnResult so a
+// failed operation is recorded even while the parent projection holds the apply
+// running under on_failure "continue". Both delegate to persistOperationState,
+// which documents the updated/error contract.
 func (s *Service) markOperationFromApplyState(ctx context.Context, workerID int, op *storage.ApplyOperation, apply *storage.Apply) (updated bool, err error) {
+	return s.persistOperationState(ctx, workerID, op, apply.State, apply.ErrorMessage)
+}
+
+// markOperationFromOwnResult transitions the claimed operation row to reflect
+// the operation's OWN drive result, derived from its tasks via
+// state.DeriveApplyState rather than mirrored from the parent apply.
+//
+// This is the drive-path counterpart to markOperationFromApplyState. Under the
+// on_failure "continue" projection updateApplyStateFromOperations holds the
+// parent apply running while sibling deployments are still in flight, so
+// mirroring this operation from the parent would hit the non-terminal
+// "leave claimable" branch and never persist the operation's own terminal
+// outcome: a failed deployment would be silently re-claimed and the
+// deployment-order gate (which keys off an earlier sibling's failed state under
+// continue) would read a stale value. Deriving from the operation's own tasks
+// records its real result independently of the parent projection, which
+// updateApplyStateFromOperations then aggregates back into the parent apply.
+//
+// The returned updated flag and error carry the same contract as
+// markOperationFromApplyState: updated=true when the row was durably written
+// (including the resumable stopped / failed_retryable states), updated=false
+// with a nil error when the operation's tasks derive a non-terminal state and
+// the row is left claimable for a later poll, and a non-nil error when a read or
+// write fails so the caller skips parent derivation.
+func (s *Service) markOperationFromOwnResult(ctx context.Context, workerID int, op *storage.ApplyOperation) (updated bool, err error) {
+	tasks, err := s.storage.Tasks().GetByApplyOperationID(ctx, op.ID)
+	if err != nil {
+		return false, fmt.Errorf("load tasks for apply_operation %d (deployment %q): %w", op.ID, op.Deployment, err)
+	}
+	taskStates := make([]string, len(tasks))
+	for i, t := range tasks {
+		taskStates[i] = t.State
+	}
+	derived := state.DeriveApplyState(taskStates)
+	return s.persistOperationState(ctx, workerID, op, derived, firstFailedTaskError(tasks))
+}
+
+// firstFailedTaskError returns the ErrorMessage of the first failed task, used
+// to populate the operation row's failure reason when its own tasks derive a
+// failed state. Empty when no failed task carries a message.
+func firstFailedTaskError(tasks []*storage.Task) string {
+	for _, t := range tasks {
+		if state.IsState(t.State, state.Apply.Failed) && t.ErrorMessage != "" {
+			return t.ErrorMessage
+		}
+	}
+	return ""
+}
+
+// persistOperationState writes the claimed operation row to reflect a derived
+// state, mapping each state to the appropriate row-write. The derived state and
+// errorMessage come from either the parent apply (markOperationFromApplyState,
+// the reconcile path) or the operation's own tasks (markOperationFromOwnResult,
+// the drive path); the row-write mapping is identical regardless of source.
+//
+// It returns updated=true whenever the operation row was durably written —
+// including resumable states (stopped, failed_retryable), not only terminal
+// ones. updated=true is the signal the caller needs before deriving the parent
+// apply's state from its children: the child row now reflects its outcome, so
+// the derived state is current. A non-terminal derived state leaves the
+// operation claimable (updated=false, nil error) so a later poll re-leases and
+// resumes it; a write failure returns the error so the caller skips derivation
+// rather than aggregating a stale child state.
+func (s *Service) persistOperationState(ctx context.Context, workerID int, op *storage.ApplyOperation, derived, errorMessage string) (updated bool, err error) {
 	opStore := s.storage.ApplyOperations()
 	switch {
-	case state.IsState(apply.State, state.Apply.Completed):
+	case state.IsState(derived, state.Apply.Completed):
 		if err := opStore.MarkCompleted(ctx, op.ID); err != nil {
 			return false, fmt.Errorf("mark apply_operation %d completed (deployment %q): %w", op.ID, op.Deployment, err)
 		}
 		return true, nil
-	case state.IsState(apply.State, state.Apply.Failed):
-		if err := opStore.MarkFailed(ctx, op.ID, apply.ErrorMessage); err != nil {
+	case state.IsState(derived, state.Apply.Failed):
+		if err := opStore.MarkFailed(ctx, op.ID, errorMessage); err != nil {
 			return false, fmt.Errorf("mark apply_operation %d failed (deployment %q): %w", op.ID, op.Deployment, err)
 		}
 		return true, nil
-	case state.IsState(apply.State, state.Apply.Stopped):
+	case state.IsState(derived, state.Apply.Stopped):
 		// stopped is resumable, so mirror the state but leave completed_at nil
 		// (matching the apply-level convention) — stopped work may resume.
-		if err := opStore.UpdateState(ctx, op.ID, apply.State); err != nil {
+		if err := opStore.UpdateState(ctx, op.ID, derived); err != nil {
 			return false, fmt.Errorf("update stopped apply_operation %d state (deployment %q): %w", op.ID, op.Deployment, err)
 		}
 		return true, nil
-	case state.IsState(apply.State, state.Apply.FailedRetryable):
+	case state.IsState(derived, state.Apply.FailedRetryable):
 		// failed_retryable is resumable like stopped: mirror the state (leaving
 		// completed_at nil) so FindNextApplyOperation reclaims it under the
 		// parent apply's recovery budget. Leaving the row in its active state
 		// would instead make recovery depend on the stale-heartbeat path, which
 		// has no budget and would re-claim it forever once retries are exhausted.
-		if err := opStore.UpdateState(ctx, op.ID, apply.State); err != nil {
+		if err := opStore.UpdateState(ctx, op.ID, derived); err != nil {
 			return false, fmt.Errorf("update failed_retryable apply_operation %d state (deployment %q): %w", op.ID, op.Deployment, err)
 		}
 		return true, nil
-	case state.IsTerminalApplyState(apply.State):
+	case state.IsTerminalApplyState(derived):
 		// cancelled / reverted — non-resumable terminal states; stamp completed_at.
-		if err := opStore.MarkTerminal(ctx, op.ID, apply.State); err != nil {
-			return false, fmt.Errorf("mark terminal apply_operation %d state %q (deployment %q): %w", op.ID, apply.State, op.Deployment, err)
+		if err := opStore.MarkTerminal(ctx, op.ID, derived); err != nil {
+			return false, fmt.Errorf("mark terminal apply_operation %d state %q (deployment %q): %w", op.ID, derived, op.Deployment, err)
 		}
 		return true, nil
 	default:
-		s.logger.Debug("operator: parent apply not terminal after resume; leaving operation claimable",
-			"worker", workerID, "apply_operation_id", op.ID, "apply_id", apply.ApplyIdentifier,
-			"deployment", op.Deployment, "environment", apply.Environment, "state", apply.State)
+		s.logger.Debug("operator: derived operation state not terminal; leaving operation claimable",
+			"worker", workerID, "apply_operation_id", op.ID,
+			"deployment", op.Deployment, "state", derived)
 		return false, nil
 	}
 }

--- a/pkg/api/operator.go
+++ b/pkg/api/operator.go
@@ -179,6 +179,13 @@ func (s *Service) recoverApplies(ctx context.Context, workerID int) {
 	owner := operatorLeaseOwner(workerID)
 
 	if s.config.OperatorClaimOperations {
+		// Service a pending stop with no claimable operation to carry it before
+		// claiming new operation work, so a queued stop wins over starting more
+		// deployments. When nothing needs stop reconciliation this is a cheap
+		// no-op and the worker falls through to the normal operation claim.
+		if s.recoverApplyPendingStop(ctx, workerID, owner) {
+			return
+		}
 		s.recoverApplyOperation(ctx, workerID, owner)
 		return
 	}
@@ -364,6 +371,19 @@ func (s *Service) recoverApplyOperation(ctx context.Context, workerID int, owner
 		return
 	}
 
+	// If a stop is pending, terminalize any still-pending sibling operations to
+	// stopped before deriving the parent. The claim gate keeps those siblings
+	// from ever starting, so under on_failure "continue" a failed sibling would
+	// otherwise hold the projection running with pending siblings that never
+	// settle — stranding the apply. Stopping them lets the derivation below reach
+	// a terminal verdict so the rollout (and the stop request) can resolve.
+	if err := s.stopPendingOperationsForPendingStop(applyLeaseCtx, workerID, apply); err != nil {
+		s.logger.Error("operator: failed to stop pending sibling operations for pending stop request; derived apply state not updated",
+			"worker", workerID, "apply_operation_id", op.ID, "apply_id", apply.ApplyIdentifier,
+			"deployment", op.Deployment, "environment", apply.Environment, "error", err)
+		return
+	}
+
 	// Reload the parent apply so updateApplyStateFromOperations below re-derives
 	// the parent from its children against the durable apply.State (its
 	// terminal-to-non-terminal guard), not the in-memory object the resume path
@@ -394,6 +414,147 @@ func (s *Service) recoverApplyOperation(ctx context.Context, workerID int, owner
 			"deployment", op.Deployment, "environment", finalApply.Environment, "error", err)
 		return
 	}
+
+	// If the derived state above settled the apply terminally and a stop is still
+	// pending, complete it now so the request does not linger after the rollout
+	// has stopped.
+	if err := s.completePendingStopIfApplyResolved(applyLeaseCtx, workerID, finalApply.ID); err != nil {
+		s.logger.Error("operator: failed to complete pending stop request for resolved apply",
+			"worker", workerID, "apply_operation_id", op.ID, "apply_id", finalApply.ApplyIdentifier,
+			"deployment", op.Deployment, "environment", finalApply.Environment, "error", err)
+		return
+	}
+}
+
+// recoverApplyPendingStop drives stop reconciliation for an apply that has a
+// pending stop request but no claimable operation to carry it. Under on_failure
+// "continue" a failed earlier sibling can leave an apply with only terminal and
+// pending operations; the claim gate keeps the pending ones from starting, so
+// the normal operation-claim path never visits the apply and its stop would
+// strand forever. This path claims such an apply directly, stops its pending
+// siblings, re-derives the parent, and completes the stop once the apply is
+// terminal.
+//
+// Returns true when it claimed an apply (so the caller does not also run the
+// normal operation claim this tick), false when there was nothing to reconcile.
+func (s *Service) recoverApplyPendingStop(ctx context.Context, workerID int, owner string) bool {
+	apply, err := s.storage.Applies().FindNextApplyForStopReconciliation(ctx, owner)
+	if err != nil {
+		s.logger.Error("operator: failed to claim apply for stop reconciliation",
+			"worker", workerID, "lease_owner", owner, "error", err)
+		metrics.RecordOperatorClaimFailure(ctx, "stop_reconciliation_claim_error")
+		return true
+	}
+	if apply == nil {
+		s.logger.Debug("operator: no apply needs stop reconciliation", "worker", workerID)
+		return false
+	}
+
+	lease := apply.Lease()
+	if !lease.Valid() {
+		s.logger.Error("operator: claimed apply for stop reconciliation without a valid lease token; skipping",
+			"worker", workerID, "lease_owner", owner,
+			"apply_id", apply.ApplyIdentifier, "database", apply.Database, "environment", apply.Environment)
+		metrics.RecordOperatorClaimFailure(ctx, "stop_reconciliation_missing_lease_token")
+		return true
+	}
+	applyLeaseCtx := storage.WithApplyLease(ctx, lease)
+
+	if err := s.stopPendingOperationsForPendingStop(applyLeaseCtx, workerID, apply); err != nil {
+		s.logger.Error("operator: failed to stop pending sibling operations during stop reconciliation",
+			"worker", workerID, "apply_id", apply.ApplyIdentifier,
+			"database", apply.Database, "environment", apply.Environment, "error", err)
+		return true
+	}
+
+	finalApply, err := s.storage.Applies().Get(applyLeaseCtx, apply.ID)
+	if err != nil {
+		s.logger.Error("operator: failed to reload apply during stop reconciliation; derived apply state not updated",
+			"worker", workerID, "apply_id", apply.ApplyIdentifier,
+			"database", apply.Database, "environment", apply.Environment, "error", err)
+		return true
+	}
+	if finalApply == nil {
+		s.logger.Error("operator: apply not found during stop reconciliation; derived apply state not updated",
+			"worker", workerID, "apply_id", apply.ApplyIdentifier,
+			"database", apply.Database, "environment", apply.Environment)
+		return true
+	}
+
+	if err := s.updateApplyStateFromOperations(applyLeaseCtx, workerID, finalApply); err != nil {
+		s.logger.Error("operator: failed to update derived apply state during stop reconciliation",
+			"worker", workerID, "apply_id", finalApply.ApplyIdentifier,
+			"database", finalApply.Database, "environment", finalApply.Environment, "error", err)
+		return true
+	}
+
+	if err := s.completePendingStopIfApplyResolved(applyLeaseCtx, workerID, finalApply.ID); err != nil {
+		s.logger.Error("operator: failed to complete pending stop request after stop reconciliation",
+			"worker", workerID, "apply_id", finalApply.ApplyIdentifier,
+			"database", finalApply.Database, "environment", finalApply.Environment, "error", err)
+		return true
+	}
+	return true
+}
+
+// stopPendingOperationsForPendingStop terminalizes still-pending sibling
+// operations to stopped when the apply has a pending stop request, so the
+// rollout can settle instead of stranding running with siblings the claim gate
+// keeps from ever starting. No-op when no stop is pending.
+func (s *Service) stopPendingOperationsForPendingStop(ctx context.Context, workerID int, apply *storage.Apply) error {
+	controlReq, err := s.storage.ControlRequests().GetPending(ctx, apply.ID, storage.ControlOperationStop)
+	if err != nil {
+		return fmt.Errorf("load pending stop request for apply %s (%d): %w", apply.ApplyIdentifier, apply.ID, err)
+	}
+	if controlReq == nil {
+		return nil
+	}
+
+	stopped, err := s.storage.ApplyOperations().MarkPendingStoppedByApply(ctx, apply.ID)
+	if err != nil {
+		return fmt.Errorf("stop pending apply_operations for apply %s (%d): %w", apply.ApplyIdentifier, apply.ID, err)
+	}
+	if stopped > 0 {
+		s.logger.Info("operator: stopped pending sibling operations for pending stop request",
+			"worker", workerID, "apply_id", apply.ApplyIdentifier,
+			"database", apply.Database, "environment", apply.Environment,
+			"stopped_operation_count", stopped)
+	}
+	return nil
+}
+
+// completePendingStopIfApplyResolved completes a pending stop control request
+// once the apply has settled to a terminal state, so the request does not stay
+// pending forever after the rollout stops. The apply is reloaded because the
+// derived-state write operates on a copy and does not mutate the caller's row.
+// No-op when the apply is still non-terminal or no stop is pending.
+func (s *Service) completePendingStopIfApplyResolved(ctx context.Context, workerID int, applyID int64) error {
+	apply, err := s.storage.Applies().Get(ctx, applyID)
+	if err != nil {
+		return fmt.Errorf("reload apply %d before completing pending stop: %w", applyID, err)
+	}
+	if apply == nil {
+		return fmt.Errorf("reload apply %d before completing pending stop: %w", applyID, storage.ErrApplyNotFound)
+	}
+	if !state.IsTerminalApplyState(apply.State) {
+		return nil
+	}
+
+	controlReq, err := s.storage.ControlRequests().GetPending(ctx, apply.ID, storage.ControlOperationStop)
+	if err != nil {
+		return fmt.Errorf("load pending stop request for resolved apply %s (%d): %w", apply.ApplyIdentifier, apply.ID, err)
+	}
+	if controlReq == nil {
+		return nil
+	}
+
+	if err := s.storage.ControlRequests().CompletePending(ctx, apply.ID, storage.ControlOperationStop); err != nil {
+		return fmt.Errorf("complete pending stop request for resolved apply %s (%d): %w", apply.ApplyIdentifier, apply.ID, err)
+	}
+	s.logger.Info("operator: completed pending stop request for resolved apply",
+		"worker", workerID, "apply_id", apply.ApplyIdentifier,
+		"database", apply.Database, "environment", apply.Environment, "state", apply.State)
+	return nil
 }
 
 // reconcileUnclaimableParent handles a claimed operation whose parent apply

--- a/pkg/api/operator.go
+++ b/pkg/api/operator.go
@@ -723,7 +723,7 @@ func (s *Service) markOperationFromOwnResult(ctx context.Context, workerID int, 
 // failed state. Empty when no failed task carries a message.
 func firstFailedTaskError(tasks []*storage.Task) string {
 	for _, t := range tasks {
-		if state.IsState(t.State, state.Apply.Failed) && t.ErrorMessage != "" {
+		if state.IsState(t.State, state.Task.Failed) && t.ErrorMessage != "" {
 			return t.ErrorMessage
 		}
 	}

--- a/pkg/api/operator.go
+++ b/pkg/api/operator.go
@@ -730,6 +730,22 @@ func firstFailedTaskError(tasks []*storage.Task) string {
 	return ""
 }
 
+// firstFailedOperationMessage returns a deployment-qualified failure reason from
+// the first failed operation row that carries one. It surfaces the parent
+// apply's ErrorMessage from the aggregate when the rollout settles to failed,
+// rather than leaving whatever message the last-driven (possibly successful)
+// operation wrote. The rollout's failure verdict is the first failure, so the
+// first failed row in deployment order wins. Empty when no failed operation
+// carries a message, so the caller keeps the existing apply message as fallback.
+func firstFailedOperationMessage(ops []*storage.ApplyOperation) string {
+	for _, op := range ops {
+		if state.IsState(op.State, state.ApplyOperation.Failed) && op.ErrorMessage != "" {
+			return fmt.Sprintf("deployment %s failed: %s", op.Deployment, op.ErrorMessage)
+		}
+	}
+	return ""
+}
+
 // persistOperationState writes the claimed operation row to reflect a derived
 // state, mapping each state to the appropriate row-write. The derived state and
 // errorMessage come from either the parent apply (markOperationFromApplyState,
@@ -851,6 +867,17 @@ func (s *Service) updateApplyStateFromOperations(ctx context.Context, workerID i
 		}
 	default:
 		updated.CompletedAt = nil
+	}
+
+	// When the rollout settles to failed, surface the failure reason from the
+	// aggregate (the first failed operation) rather than leaving whatever message
+	// the last-driven operation wrote — under continue the last driver may be a
+	// successful sibling, which would leave the failed verdict with no matching
+	// reason. Keep the existing message as a fallback when no operation carries one.
+	if state.IsState(derived, state.Apply.Failed) {
+		if msg := firstFailedOperationMessage(ops); msg != "" {
+			updated.ErrorMessage = msg
+		}
 	}
 
 	if err := s.storage.Applies().Update(ctx, &updated); err != nil {

--- a/pkg/api/operator.go
+++ b/pkg/api/operator.go
@@ -440,8 +440,11 @@ func (s *Service) recoverApplyOperation(ctx context.Context, workerID int, owner
 // siblings, re-derives the parent, and completes the stop once the apply is
 // terminal.
 //
-// Returns true when it claimed an apply (so the caller does not also run the
-// normal operation claim this tick), false when there was nothing to reconcile.
+// Returns true when this tick is consumed by stop reconciliation — an apply was
+// claimed (whether the reconciliation that followed succeeded or hit an error)
+// or the claim itself errored or returned an invalid lease — so the caller does
+// not also run the normal operation claim this tick. Returns false only when no
+// apply needed reconciliation.
 func (s *Service) recoverApplyPendingStop(ctx context.Context, workerID int, owner string) bool {
 	apply, err := s.storage.Applies().FindNextApplyForStopReconciliation(ctx, owner)
 	if err != nil {

--- a/pkg/api/operator_test.go
+++ b/pkg/api/operator_test.go
@@ -368,3 +368,133 @@ func TestUpdateApplyStateFromOperations_KeepsExistingMessageWhenNoOperationCarri
 	assert.Equal(t, "prior reason", applyStore.updated.ErrorMessage,
 		"with no operation-level message the existing apply reason must be preserved")
 }
+
+// fakeControlRequestStore is a minimal ControlRequestStore for stop
+// reconciliation tests: GetPending returns the configured pending stop request,
+// and CompletePending records the operations it was asked to complete.
+type fakeControlRequestStore struct {
+	storage.ControlRequestStore
+	pendingStop *storage.ApplyControlRequest
+	completed   []storage.ControlOperation
+}
+
+func (s *fakeControlRequestStore) GetPending(_ context.Context, _ int64, op storage.ControlOperation) (*storage.ApplyControlRequest, error) {
+	if op == storage.ControlOperationStop {
+		return s.pendingStop, nil
+	}
+	return nil, nil
+}
+
+func (s *fakeControlRequestStore) CompletePending(_ context.Context, _ int64, op storage.ControlOperation) error {
+	s.completed = append(s.completed, op)
+	return nil
+}
+
+// markPendingStoppedRecordingStore records MarkPendingStoppedByApply so a test
+// can assert the operator stop reconciliation terminalized the pending siblings.
+type markPendingStoppedRecordingStore struct {
+	storage.ApplyOperationStore
+	called     bool
+	stoppedFor int64
+	count      int64
+}
+
+func (s *markPendingStoppedRecordingStore) MarkPendingStoppedByApply(_ context.Context, applyID int64) (int64, error) {
+	s.called = true
+	s.stoppedFor = applyID
+	return s.count, nil
+}
+
+// getApplyStore returns a fixed apply from Get so completePendingStopIfApplyResolved
+// can be driven against a chosen terminal/non-terminal state.
+type getApplyStore struct {
+	storage.ApplyStore
+	apply *storage.Apply
+}
+
+func (s *getApplyStore) Get(_ context.Context, _ int64) (*storage.Apply, error) {
+	return s.apply, nil
+}
+
+type mockStorageWithControlAndOps struct {
+	mockStorage
+	applies  storage.ApplyStore
+	applyOps storage.ApplyOperationStore
+	control  storage.ControlRequestStore
+}
+
+func (m *mockStorageWithControlAndOps) Applies() storage.ApplyStore { return m.applies }
+func (m *mockStorageWithControlAndOps) ApplyOperations() storage.ApplyOperationStore {
+	return m.applyOps
+}
+func (m *mockStorageWithControlAndOps) ControlRequests() storage.ControlRequestStore {
+	return m.control
+}
+
+func newStopReconcileTestService(applies storage.ApplyStore, ops storage.ApplyOperationStore, control storage.ControlRequestStore) *Service {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	return New(&mockStorageWithControlAndOps{applies: applies, applyOps: ops, control: control}, testServerConfig(), nil, logger)
+}
+
+// TestStopPendingOperationsForPendingStop verifies the operator terminalizes
+// pending siblings only when a stop is actually pending for the apply.
+func TestStopPendingOperationsForPendingStop(t *testing.T) {
+	apply := &storage.Apply{ID: 7, ApplyIdentifier: "apply-stop", Environment: "staging"}
+
+	t.Run("stops pending siblings when a stop is pending", func(t *testing.T) {
+		ops := &markPendingStoppedRecordingStore{count: 2}
+		control := &fakeControlRequestStore{pendingStop: &storage.ApplyControlRequest{
+			ApplyID: apply.ID, Operation: storage.ControlOperationStop, Status: storage.ControlRequestPending,
+		}}
+		svc := newStopReconcileTestService(&getApplyStore{}, ops, control)
+
+		require.NoError(t, svc.stopPendingOperationsForPendingStop(t.Context(), 1, apply))
+		assert.True(t, ops.called, "a pending stop must terminalize pending siblings")
+		assert.Equal(t, apply.ID, ops.stoppedFor)
+	})
+
+	t.Run("no-op when no stop is pending", func(t *testing.T) {
+		ops := &markPendingStoppedRecordingStore{}
+		control := &fakeControlRequestStore{pendingStop: nil}
+		svc := newStopReconcileTestService(&getApplyStore{}, ops, control)
+
+		require.NoError(t, svc.stopPendingOperationsForPendingStop(t.Context(), 1, apply))
+		assert.False(t, ops.called, "without a pending stop, no siblings are stopped")
+	})
+}
+
+// TestCompletePendingStopIfApplyResolved verifies the operator completes a
+// pending stop request only once the apply has settled terminally.
+func TestCompletePendingStopIfApplyResolved(t *testing.T) {
+	pendingStop := func() *storage.ApplyControlRequest {
+		return &storage.ApplyControlRequest{ApplyID: 9, Operation: storage.ControlOperationStop, Status: storage.ControlRequestPending}
+	}
+
+	t.Run("completes the stop when the apply is terminal", func(t *testing.T) {
+		applies := &getApplyStore{apply: &storage.Apply{ID: 9, ApplyIdentifier: "apply-done", State: state.Apply.Failed}}
+		control := &fakeControlRequestStore{pendingStop: pendingStop()}
+		svc := newStopReconcileTestService(applies, &markPendingStoppedRecordingStore{}, control)
+
+		require.NoError(t, svc.completePendingStopIfApplyResolved(t.Context(), 1, 9))
+		require.Len(t, control.completed, 1, "a terminal apply with a pending stop completes the request")
+		assert.Equal(t, storage.ControlOperationStop, control.completed[0])
+	})
+
+	t.Run("leaves the stop pending while the apply is non-terminal", func(t *testing.T) {
+		applies := &getApplyStore{apply: &storage.Apply{ID: 9, ApplyIdentifier: "apply-running", State: state.Apply.Running}}
+		control := &fakeControlRequestStore{pendingStop: pendingStop()}
+		svc := newStopReconcileTestService(applies, &markPendingStoppedRecordingStore{}, control)
+
+		require.NoError(t, svc.completePendingStopIfApplyResolved(t.Context(), 1, 9))
+		assert.Empty(t, control.completed, "a non-terminal apply must not complete the stop request")
+	})
+
+	t.Run("no-op when no stop is pending", func(t *testing.T) {
+		applies := &getApplyStore{apply: &storage.Apply{ID: 9, ApplyIdentifier: "apply-done", State: state.Apply.Failed}}
+		control := &fakeControlRequestStore{pendingStop: nil}
+		svc := newStopReconcileTestService(applies, &markPendingStoppedRecordingStore{}, control)
+
+		require.NoError(t, svc.completePendingStopIfApplyResolved(t.Context(), 1, 9))
+		assert.Empty(t, control.completed, "no pending stop means nothing to complete")
+	})
+}

--- a/pkg/api/operator_test.go
+++ b/pkg/api/operator_test.go
@@ -314,3 +314,57 @@ func TestMarkOperationFromOwnResult_LeavesNonTerminalClaimable(t *testing.T) {
 	assert.False(t, marked, "a still-running operation must be left claimable for a later poll")
 	assert.False(t, opStore.called, "no terminal write should occur for a non-terminal operation")
 }
+
+// TestUpdateApplyStateFromOperations_StampsAggregateFailureMessage verifies that
+// when the rollout settles to failed the parent apply's ErrorMessage is surfaced
+// from the first failed operation, not from the last-driven (here, successful)
+// sibling. The failing deployment ran first and the apply carries no prior
+// message; the derived failed verdict must be accompanied by that deployment's
+// reason so an operator sees why the apply failed.
+func TestUpdateApplyStateFromOperations_StampsAggregateFailureMessage(t *testing.T) {
+	ops := []*storage.ApplyOperation{
+		{ID: 1, Deployment: "region-a", State: state.ApplyOperation.Failed, ErrorMessage: "spirit: cutover failed"},
+		{ID: 2, Deployment: "region-b", State: state.ApplyOperation.Completed},
+	}
+	applyStore := &recordingApplyStore{}
+	svc := newOperatorStateTestService(&listingApplyOperationStore{ops: ops}, applyStore)
+
+	apply := &storage.Apply{
+		ID:              3,
+		ApplyIdentifier: "apply-projection",
+		State:           state.Apply.Running,
+		Environment:     "staging",
+	}
+
+	require.NoError(t, svc.updateApplyStateFromOperations(t.Context(), 1, apply))
+	require.NotNil(t, applyStore.updated, "derived failed state differs from running, so the apply must be persisted")
+	assert.Equal(t, state.Apply.Failed, applyStore.updated.State)
+	assert.Equal(t, "deployment region-a failed: spirit: cutover failed", applyStore.updated.ErrorMessage,
+		"the failure reason must come from the failed operation, not the successful last sibling")
+}
+
+// TestUpdateApplyStateFromOperations_KeepsExistingMessageWhenNoOperationCarriesOne
+// verifies that a derived failed verdict preserves the apply's existing message
+// when no failed operation row carries one, rather than blanking the reason.
+func TestUpdateApplyStateFromOperations_KeepsExistingMessageWhenNoOperationCarriesOne(t *testing.T) {
+	ops := []*storage.ApplyOperation{
+		{ID: 1, Deployment: "region-a", State: state.ApplyOperation.Failed},
+		{ID: 2, Deployment: "region-b", State: state.ApplyOperation.Completed},
+	}
+	applyStore := &recordingApplyStore{}
+	svc := newOperatorStateTestService(&listingApplyOperationStore{ops: ops}, applyStore)
+
+	apply := &storage.Apply{
+		ID:              3,
+		ApplyIdentifier: "apply-projection",
+		State:           state.Apply.Running,
+		Environment:     "staging",
+		ErrorMessage:    "prior reason",
+	}
+
+	require.NoError(t, svc.updateApplyStateFromOperations(t.Context(), 1, apply))
+	require.NotNil(t, applyStore.updated)
+	assert.Equal(t, state.Apply.Failed, applyStore.updated.State)
+	assert.Equal(t, "prior reason", applyStore.updated.ErrorMessage,
+		"with no operation-level message the existing apply reason must be preserved")
+}

--- a/pkg/api/operator_test.go
+++ b/pkg/api/operator_test.go
@@ -226,3 +226,91 @@ func TestUpdateApplyStateFromOperations_ContinuePolicy(t *testing.T) {
 		})
 	}
 }
+
+// stubTaskStore returns a fixed task set for GetByApplyOperationID so an
+// operation's own drive result can be derived from its tasks.
+type stubTaskStore struct {
+	storage.TaskStore
+	tasks []*storage.Task
+}
+
+func (s *stubTaskStore) GetByApplyOperationID(context.Context, int64) ([]*storage.Task, error) {
+	return s.tasks, nil
+}
+
+// markFailedRecordingApplyOperationStore records MarkFailed so a test can assert
+// the operation row was persisted failed with its own task's message.
+type markFailedRecordingApplyOperationStore struct {
+	storage.ApplyOperationStore
+	called    bool
+	failedID  int64
+	failedMsg string
+}
+
+func (s *markFailedRecordingApplyOperationStore) MarkFailed(_ context.Context, id int64, errMsg string) error {
+	s.called = true
+	s.failedID = id
+	s.failedMsg = errMsg
+	return nil
+}
+
+type mockStorageWithTasksAndOperations struct {
+	mockStorage
+	tasks    storage.TaskStore
+	applyOps storage.ApplyOperationStore
+}
+
+func (m *mockStorageWithTasksAndOperations) Tasks() storage.TaskStore { return m.tasks }
+
+func (m *mockStorageWithTasksAndOperations) ApplyOperations() storage.ApplyOperationStore {
+	return m.applyOps
+}
+
+// TestMarkOperationFromOwnResult_PersistsFailedIndependentOfParent verifies that
+// the drive path records a failed deployment from the operation's OWN tasks
+// regardless of the parent apply's state. Under the on_failure "continue"
+// projection the parent is held running while sibling deployments are still in
+// flight; deriving the operation from its own failing task still marks the row
+// failed (with that task's message) rather than leaving it claimable to be
+// re-driven, so the deployment-order gate and the parent re-derivation observe
+// the real outcome.
+func TestMarkOperationFromOwnResult_PersistsFailedIndependentOfParent(t *testing.T) {
+	opStore := &markFailedRecordingApplyOperationStore{}
+	taskStore := &stubTaskStore{tasks: []*storage.Task{
+		{State: state.Apply.Completed},
+		{State: state.Apply.Failed, ErrorMessage: "spirit: cutover failed"},
+	}}
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	svc := New(&mockStorageWithTasksAndOperations{tasks: taskStore, applyOps: opStore}, testServerConfig(), nil, logger)
+
+	op := &storage.ApplyOperation{ID: 9, Deployment: "region-b", OnFailure: storage.OnFailureContinue}
+
+	marked, err := svc.markOperationFromOwnResult(t.Context(), 1, op)
+	require.NoError(t, err)
+	assert.True(t, marked, "a failed operation must be durably recorded so it is not re-claimed")
+	assert.True(t, opStore.called, "the operation row must be marked failed from its own tasks")
+	assert.Equal(t, int64(9), opStore.failedID, "the claimed operation row must be the one marked failed")
+	assert.Equal(t, "spirit: cutover failed", opStore.failedMsg,
+		"the failure message must come from the operation's own failing task")
+}
+
+// TestMarkOperationFromOwnResult_LeavesNonTerminalClaimable verifies that an
+// operation whose own tasks are still running is left claimable (marked=false,
+// no terminal write) so a later poll re-leases and resumes it, rather than being
+// prematurely terminalized from a still-in-flight drive.
+func TestMarkOperationFromOwnResult_LeavesNonTerminalClaimable(t *testing.T) {
+	opStore := &markFailedRecordingApplyOperationStore{}
+	taskStore := &stubTaskStore{tasks: []*storage.Task{
+		{State: state.Apply.Running},
+		{State: state.Apply.Completed},
+	}}
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	svc := New(&mockStorageWithTasksAndOperations{tasks: taskStore, applyOps: opStore}, testServerConfig(), nil, logger)
+
+	op := &storage.ApplyOperation{ID: 11, Deployment: "region-c", OnFailure: storage.OnFailureContinue}
+
+	marked, err := svc.markOperationFromOwnResult(t.Context(), 1, op)
+	require.NoError(t, err)
+	assert.False(t, marked, "a still-running operation must be left claimable for a later poll")
+	assert.False(t, opStore.called, "no terminal write should occur for a non-terminal operation")
+}

--- a/pkg/api/operator_test.go
+++ b/pkg/api/operator_test.go
@@ -277,8 +277,8 @@ func (m *mockStorageWithTasksAndOperations) ApplyOperations() storage.ApplyOpera
 func TestMarkOperationFromOwnResult_PersistsFailedIndependentOfParent(t *testing.T) {
 	opStore := &markFailedRecordingApplyOperationStore{}
 	taskStore := &stubTaskStore{tasks: []*storage.Task{
-		{State: state.Apply.Completed},
-		{State: state.Apply.Failed, ErrorMessage: "spirit: cutover failed"},
+		{State: state.Task.Completed},
+		{State: state.Task.Failed, ErrorMessage: "spirit: cutover failed"},
 	}}
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
 	svc := New(&mockStorageWithTasksAndOperations{tasks: taskStore, applyOps: opStore}, testServerConfig(), nil, logger)
@@ -301,8 +301,8 @@ func TestMarkOperationFromOwnResult_PersistsFailedIndependentOfParent(t *testing
 func TestMarkOperationFromOwnResult_LeavesNonTerminalClaimable(t *testing.T) {
 	opStore := &markFailedRecordingApplyOperationStore{}
 	taskStore := &stubTaskStore{tasks: []*storage.Task{
-		{State: state.Apply.Running},
-		{State: state.Apply.Completed},
+		{State: state.Task.Running},
+		{State: state.Task.Completed},
 	}}
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
 	svc := New(&mockStorageWithTasksAndOperations{tasks: taskStore, applyOps: opStore}, testServerConfig(), nil, logger)

--- a/pkg/storage/mysqlstore/applies.go
+++ b/pkg/storage/mysqlstore/applies.go
@@ -961,7 +961,9 @@ func (s *applyStore) ClaimApplyByID(ctx context.Context, applyID int64, owner st
 	return apply, nil
 }
 
-// FindNextApplyForStopReconciliation claims one non-terminal apply that has a
+// FindNextApplyForStopReconciliation claims one apply eligible for stop
+// reconciliation (pending or an active recovery-claimable state; see
+// claimableApplyStates) that has a
 // pending stop control request, at least one pending operation, and no operation
 // currently being driven, so the operator can terminalize the pending siblings
 // and let the apply settle. See the interface doc for why this trigger is needed
@@ -976,10 +978,13 @@ func (s *applyStore) FindNextApplyForStopReconciliation(ctx context.Context, own
 	}
 	defer rollbackApplyTx(ctx, tx, "claim apply for stop reconciliation")
 
-	// Parent eligibility: any non-terminal apply. pending is included so a stop
-	// requested before the first operation is ever claimed is not stranded —
-	// the claim gate refuses the pending ops, so reconciliation must own them;
-	// persistApplyClaim transitions a pending apply to running for the claim.
+	// Parent eligibility: pending plus the active recovery-claimable states
+	// (claimableApplyStates); the resumable failed_retryable and stopped states
+	// are excluded because they have their own resume paths. pending is included
+	// so a stop requested before the first operation is ever claimed is not
+	// stranded — the claim gate refuses the pending ops, so reconciliation must
+	// own them; persistApplyClaim transitions a pending apply to running for the
+	// claim.
 	parentStates := append([]string{state.Apply.Pending}, claimableApplyStates()...)
 	parentStatePlaceholders := placeholders(len(parentStates))
 

--- a/pkg/storage/mysqlstore/applies.go
+++ b/pkg/storage/mysqlstore/applies.go
@@ -929,6 +929,96 @@ func (s *applyStore) ClaimApplyByID(ctx context.Context, applyID int64, owner st
 	return apply, nil
 }
 
+// FindNextApplyForStopReconciliation claims one non-terminal apply that has a
+// pending stop control request, at least one pending operation, and no operation
+// currently being driven, so the operator can terminalize the pending siblings
+// and let the apply settle. See the interface doc for why this trigger is needed
+// under on_failure "continue".
+func (s *applyStore) FindNextApplyForStopReconciliation(ctx context.Context, owner string) (*storage.Apply, error) {
+	if owner == "" {
+		return nil, fmt.Errorf("operator owner is required to claim apply for stop reconciliation: %w", storage.ErrApplyLeaseLost)
+	}
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelReadCommitted})
+	if err != nil {
+		return nil, fmt.Errorf("begin claim apply for stop reconciliation transaction: %w", err)
+	}
+	defer rollbackApplyTx(ctx, tx, "claim apply for stop reconciliation")
+
+	// Parent eligibility: any non-terminal apply. pending is included so a stop
+	// requested before the first operation is ever claimed is not stranded —
+	// the claim gate refuses the pending ops, so reconciliation must own them;
+	// persistApplyClaim transitions a pending apply to running for the claim.
+	parentStates := append([]string{state.Apply.Pending}, claimableApplyStates()...)
+	parentStatePlaceholders := placeholders(len(parentStates))
+
+	// A child operation in any of these states is being driven, or is a crashed
+	// driver awaiting stale recovery. Either way the operation-claim path owns
+	// settling it through the engine (its drive observes the stop), so this path
+	// skips the apply whenever any operation is active — stale or fresh — and
+	// handles only applies with nothing active left to drive. recoverApplyPendingStop
+	// runs before the operation claim, so an active operation falls through to be
+	// recovered there, then a later tick reconciles the remaining pending siblings.
+	activeOpStates := claimableApplyStates()
+	activeOpStatePlaceholders := placeholders(len(activeOpStates))
+
+	queryArgs := stringArgs(parentStates)
+	queryArgs = append(queryArgs, storage.ControlOperationStop, storage.ControlRequestPending)
+	queryArgs = append(queryArgs, state.ApplyOperation.Pending)
+	queryArgs = append(queryArgs, stringArgs(activeOpStates)...)
+
+	row := tx.QueryRowContext(ctx, fmt.Sprintf(`
+		SELECT %s
+		FROM applies a
+		WHERE a.state IN (%s)
+			AND EXISTS (
+				SELECT 1
+				FROM apply_control_requests cr
+				WHERE cr.apply_id = a.id AND cr.operation = ? AND cr.status = ?
+			)
+			AND EXISTS (
+				SELECT 1
+				FROM apply_operations pending
+				WHERE pending.apply_id = a.id AND pending.state = ?
+			)
+			AND NOT EXISTS (
+				SELECT 1
+				FROM apply_operations active
+				WHERE active.apply_id = a.id
+					AND active.state IN (%s)
+			)
+		ORDER BY a.created_at
+		LIMIT 1
+		FOR UPDATE SKIP LOCKED
+	`, applyColumns, parentStatePlaceholders, activeOpStatePlaceholders), queryArgs...)
+
+	apply, err := scanApplyInto(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil // nothing to reconcile
+	}
+	if err != nil {
+		return nil, fmt.Errorf("query next apply for stop reconciliation: %w", err)
+	}
+
+	// persistApplyClaim rotates the lease: an active apply just refreshes its
+	// heartbeat, while a pending apply transitions to running for the claim (no
+	// stopped apply reaches this path — terminal states are excluded above — so
+	// claimAcquiredCommitted, the stopped-only outcome, cannot occur and the
+	// caller always commits an acquired claim).
+	outcome, err := persistApplyClaim(ctx, s.db, tx, apply, owner)
+	if err != nil {
+		return nil, err
+	}
+	if outcome != claimAcquired {
+		return nil, nil
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("commit claim apply %d (%s) for stop reconciliation: %w", apply.ID, apply.ApplyIdentifier, err)
+	}
+
+	return apply, nil
+}
+
 // claimOutcome describes how persistApplyClaim resolved a claim attempt and
 // who owns committing the transaction.
 type claimOutcome int

--- a/pkg/storage/mysqlstore/applies_test.go
+++ b/pkg/storage/mysqlstore/applies_test.go
@@ -2339,3 +2339,153 @@ func TestApplyStore_GetByPlan_DBError(t *testing.T) {
 	_, err = store.Applies().GetByPlan(t.Context(), 123)
 	require.Error(t, err)
 }
+
+// TestApplyStore_FindNextApplyForStopReconciliation_ClaimsStrandedContinueApply
+// verifies the stop-reconciliation trigger: an apply held running under
+// on_failure "continue" (a failed earlier sibling) with a pending stop and a
+// pending sibling that the claim gate keeps from starting is claimed here, so
+// the operator can stop the pending siblings and let the apply settle. Without
+// this path no operation is claimable and the stop would strand forever.
+func TestApplyStore_FindNextApplyForStopReconciliation_ClaimsStrandedContinueApply(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", "mysql", "staging")
+	apply := createTestApplyWithStateAndEnv(t, store, lock, "apply_stop_recon", 1, state.Apply.Running, "staging")
+
+	failedID, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-a", State: state.ApplyOperation.Failed, OnFailure: storage.OnFailureContinue,
+	})
+	require.NoError(t, err)
+	_, err = store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-b", OnFailure: storage.OnFailureContinue,
+	})
+	require.NoError(t, err)
+	// Backdate the failed row so it can't be mistaken for a fresh active op.
+	_, err = testDB.ExecContext(ctx, `
+		UPDATE apply_operations SET updated_at = NOW() - INTERVAL 1 HOUR WHERE id = ?
+	`, failedID)
+	require.NoError(t, err)
+
+	_, _, err = store.ControlRequests().RequestPending(ctx, &storage.ApplyControlRequest{
+		ApplyID:     apply.ID,
+		Operation:   storage.ControlOperationStop,
+		Status:      storage.ControlRequestPending,
+		RequestedBy: "operator",
+	})
+	require.NoError(t, err)
+
+	claimed, err := store.Applies().FindNextApplyForStopReconciliation(ctx, "test-operator")
+	require.NoError(t, err)
+	require.NotNil(t, claimed, "an apply with a pending stop and pending siblings must be claimable for reconciliation")
+	assert.Equal(t, apply.ID, claimed.ID)
+	assert.Equal(t, "test-operator", claimed.LeaseOwner, "claim rotates the lease owner")
+	assert.Equal(t, state.Apply.Running, claimed.State, "reconciliation claim refreshes the lease without changing apply state")
+}
+
+// TestApplyStore_FindNextApplyForStopReconciliation_SkipsApplyWithActiveOp
+// verifies the trigger defers to the operation-claim path whenever any operation
+// is active — whether freshly heartbeating or stale-and-crashed. That path drives
+// the operation through the engine (which observes the stop), so reconciliation
+// must not settle the apply terminally out from under it. Only once nothing is
+// active does this path own the remaining pending siblings.
+func TestApplyStore_FindNextApplyForStopReconciliation_SkipsApplyWithActiveOp(t *testing.T) {
+	cases := []struct {
+		name      string
+		freshness string
+	}{
+		{name: "fresh heartbeat", freshness: "NOW()"},
+		{name: "stale heartbeat", freshness: "NOW() - INTERVAL 1 HOUR"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			clearTables(t)
+			ctx := t.Context()
+			store := New(testDB)
+
+			lock := createTestLock(t, store, "testdb", "mysql", "staging")
+			apply := createTestApplyWithStateAndEnv(t, store, lock, "apply_stop_recon_active", 1, state.Apply.Running, "staging")
+
+			runningID, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+				ApplyID: apply.ID, Deployment: "region-a", State: state.ApplyOperation.Running, OnFailure: storage.OnFailureContinue,
+			})
+			require.NoError(t, err)
+			_, err = store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+				ApplyID: apply.ID, Deployment: "region-b", OnFailure: storage.OnFailureContinue,
+			})
+			require.NoError(t, err)
+			_, err = testDB.ExecContext(ctx, `
+				UPDATE apply_operations SET updated_at = `+tc.freshness+` WHERE id = ?
+			`, runningID)
+			require.NoError(t, err)
+
+			_, _, err = store.ControlRequests().RequestPending(ctx, &storage.ApplyControlRequest{
+				ApplyID:     apply.ID,
+				Operation:   storage.ControlOperationStop,
+				Status:      storage.ControlRequestPending,
+				RequestedBy: "operator",
+			})
+			require.NoError(t, err)
+
+			claimed, err := store.Applies().FindNextApplyForStopReconciliation(ctx, "test-operator")
+			require.NoError(t, err)
+			assert.Nil(t, claimed, "an apply with any active operation is left to the operation-claim path")
+		})
+	}
+}
+
+// TestApplyStore_FindNextApplyForStopReconciliation_ClaimsPendingApplyWithStop
+// verifies a stop requested before the first operation is ever claimed is not
+// stranded: with the claim gate refusing the pending ops, reconciliation claims
+// the still-pending apply (persistApplyClaim transitions it to running) so the
+// operator can stop the pending operations and settle it.
+func TestApplyStore_FindNextApplyForStopReconciliation_ClaimsPendingApplyWithStop(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", "mysql", "staging")
+	apply := createTestApplyWithStateAndEnv(t, store, lock, "apply_stop_recon_pending", 1, state.Apply.Pending, "staging")
+
+	_, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-a", OnFailure: storage.OnFailureContinue,
+	})
+	require.NoError(t, err)
+
+	_, _, err = store.ControlRequests().RequestPending(ctx, &storage.ApplyControlRequest{
+		ApplyID:     apply.ID,
+		Operation:   storage.ControlOperationStop,
+		Status:      storage.ControlRequestPending,
+		RequestedBy: "operator",
+	})
+	require.NoError(t, err)
+
+	claimed, err := store.Applies().FindNextApplyForStopReconciliation(ctx, "test-operator")
+	require.NoError(t, err)
+	require.NotNil(t, claimed, "a pending apply with a pending stop must be claimable so the stop is not stranded")
+	assert.Equal(t, apply.ID, claimed.ID)
+	assert.Equal(t, "test-operator", claimed.LeaseOwner)
+}
+
+// TestApplyStore_FindNextApplyForStopReconciliation_SkipsApplyWithoutPendingStop
+// verifies the trigger is scoped to applies that actually have a pending stop:
+// pending siblings alone (no stop) are normal rollout work, not reconciliation
+// candidates.
+func TestApplyStore_FindNextApplyForStopReconciliation_SkipsApplyWithoutPendingStop(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", "mysql", "staging")
+	apply := createTestApplyWithStateAndEnv(t, store, lock, "apply_stop_recon_nostop", 1, state.Apply.Running, "staging")
+
+	_, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-a", OnFailure: storage.OnFailureContinue,
+	})
+	require.NoError(t, err)
+
+	claimed, err := store.Applies().FindNextApplyForStopReconciliation(ctx, "test-operator")
+	require.NoError(t, err)
+	assert.Nil(t, claimed, "an apply without a pending stop is not a reconciliation candidate")
+}

--- a/pkg/storage/mysqlstore/apply_operations.go
+++ b/pkg/storage/mysqlstore/apply_operations.go
@@ -569,6 +569,12 @@ const applyOperationHeartbeatStaleness = "1 MINUTE"
 // continuation; the apply's pass/fail verdict and the merge gate stay
 // fail-closed on any failed deployment.
 //
+// A pending stop control request layers a hard halt on top: while a stop is
+// pending for the apply, no pending sibling is claimable for start, regardless
+// of cutover_policy or on_failure. This is what makes `stop` halt remaining
+// siblings under "continue" — without it a continue-exempted pending sibling
+// would still be started after the user asked to stop.
+//
 // The gate applies only to starting a pending row; an already-active row
 // re-leasing a stale heartbeat is recovering work it already started, so it
 // is never re-gated. While the operator flag is off and the single-deployment
@@ -617,6 +623,15 @@ func (s *applyOperationStore) FindNextApplyOperation(ctx context.Context, owner 
 		storage.OnFailureContinue,
 		state.ApplyOperation.Failed,
 	)
+	// Pending stop gate: a pending operation is not claimable for start while
+	// its apply has a pending stop control request. This is what makes `stop`
+	// halt remaining siblings under on_failure "continue" — without it, a
+	// continue-exempted pending sibling would still be claimed and started even
+	// though the user asked to stop the rollout. The gate covers only pending
+	// (not-yet-started) rows; an already-active row re-leasing a stale heartbeat
+	// is recovering work it started and is handled by the staleness clause below.
+	queryArgs = append(queryArgs,
+		storage.ControlOperationStop, storage.ControlRequestPending)
 	queryArgs = append(queryArgs, stringArgs(activeStates)...)
 	queryArgs = append(queryArgs,
 		state.ApplyOperation.Stopped,
@@ -683,6 +698,13 @@ func (s *applyOperationStore) FindNextApplyOperation(ctx context.Context, owner 
 						)
 						AND NOT (apply_operations.on_failure = ? AND earlier.state = ?)
 				)
+				AND NOT EXISTS (
+					SELECT 1
+					FROM apply_control_requests cr
+					WHERE cr.apply_id = apply_operations.apply_id
+						AND cr.operation = ?
+						AND cr.status = ?
+				)
 			)
 			OR (state IN (%s) AND updated_at < NOW() - INTERVAL %s)
 			OR (
@@ -738,13 +760,22 @@ func (s *applyOperationStore) FindNextApplyOperation(ctx context.Context, owner 
 		// Pending → running: stamp started_at, rotate the lease, and update the
 		// heartbeat in the same write. WHERE state = ? guards against a concurrent
 		// transition landing between the SELECT and this UPDATE; RowsAffected == 0
-		// means another writer already moved the row, so we back off cleanly.
+		// means another writer already moved the row, so we back off cleanly. The
+		// NOT EXISTS stop guard mirrors the SELECT's pending-stop gate so a stop
+		// request committed between the SELECT and this UPDATE still wins — the
+		// pending sibling is not started once a stop is pending.
 		result, err := tx.ExecContext(ctx, `
 			UPDATE apply_operations
 			SET state = ?, started_at = COALESCE(started_at, NOW()), updated_at = NOW(),
 			    lease_owner = ?, lease_token = ?, lease_acquired_at = NOW()
 			WHERE id = ? AND state = ?
-		`, state.ApplyOperation.Running, owner, leaseToken, ad.ID, state.ApplyOperation.Pending)
+				AND NOT EXISTS (
+					SELECT 1
+					FROM apply_control_requests cr
+					WHERE cr.apply_id = ? AND cr.operation = ? AND cr.status = ?
+				)
+		`, state.ApplyOperation.Running, owner, leaseToken, ad.ID, state.ApplyOperation.Pending,
+			ad.ApplyID, storage.ControlOperationStop, storage.ControlRequestPending)
 		if err != nil {
 			return nil, fmt.Errorf("claim pending apply_operation %d: %w", ad.ID, err)
 		}
@@ -835,6 +866,63 @@ func (s *applyOperationStore) DeleteByApply(ctx context.Context, applyID int64) 
 		}
 	}
 	return nil
+}
+
+// MarkPendingStoppedByApply transitions every still-pending operation of an
+// apply to stopped, returning the number of rows changed. It is the operator's
+// stop-reconciliation primitive: once a stop is pending the claim gate keeps
+// pending siblings from ever starting, so they must be terminalized here or the
+// apply would strand non-terminal under on_failure "continue" — a failed sibling
+// holds the projection running while the pending siblings never settle.
+//
+// Only pending rows are touched, never running or terminal: an in-flight
+// operation is left for its own driver (which observes the stop through the
+// engine) and an already-terminal operation keeps its recorded result. stopped
+// is resumable, so completed_at is left nil to match the apply-level convention.
+// Writes are apply-lease guarded when a lease is present in ctx, mirroring
+// DeleteByApply.
+func (s *applyOperationStore) MarkPendingStoppedByApply(ctx context.Context, applyID int64) (int64, error) {
+	lease, hasLease, err := applyLeaseFromContext(ctx, applyID)
+	if err != nil {
+		return 0, err
+	}
+	if !hasLease {
+		result, err := s.db.ExecContext(ctx, `
+			UPDATE apply_operations
+			SET state = ?, updated_at = NOW()
+			WHERE apply_id = ? AND state = ?
+		`, state.ApplyOperation.Stopped, applyID, state.ApplyOperation.Pending)
+		if err != nil {
+			return 0, fmt.Errorf("stop pending apply_operations for apply %d: %w", applyID, err)
+		}
+		rows, err := result.RowsAffected()
+		if err != nil {
+			return 0, fmt.Errorf("read stopped pending apply_operations rows affected for apply %d: %w", applyID, err)
+		}
+		return rows, nil
+	}
+	result, err := s.db.ExecContext(ctx, `
+		UPDATE apply_operations ao
+		JOIN applies a ON a.id = ao.apply_id
+		SET ao.state = ?, ao.updated_at = NOW()
+		WHERE ao.apply_id = ? AND ao.state = ? AND a.lease_token = ?
+	`, state.ApplyOperation.Stopped, applyID, state.ApplyOperation.Pending, lease.Token)
+	if err != nil {
+		return 0, fmt.Errorf("stop pending apply_operations for apply %d: %w", applyID, err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("read stopped pending apply_operations rows affected for apply %d: %w", applyID, err)
+	}
+	if rows == 0 {
+		// No pending rows changed: either there were none (lease still valid, a
+		// legitimate no-op) or the lease token no longer matches (ownership lost).
+		// Distinguish the two so a displaced worker fails closed.
+		if err := ensureApplyLeaseStillOwned(ctx, s.db, lease); err != nil {
+			return 0, err
+		}
+	}
+	return rows, nil
 }
 
 // scanApplyOperation scans a single apply_operations row, returning nil if not found.

--- a/pkg/storage/mysqlstore/apply_operations_test.go
+++ b/pkg/storage/mysqlstore/apply_operations_test.go
@@ -2001,3 +2001,134 @@ func TestApplyOperationStore_DeleteByApply_DBError(t *testing.T) {
 	err = store.ApplyOperations().DeleteByApply(t.Context(), 1)
 	require.Error(t, err)
 }
+
+// TestApplyOperationStore_FindNextApplyOperation_PendingStopGateHaltsSibling
+// verifies that a pending stop control request halts remaining siblings under
+// on_failure "continue": a pending sibling that would otherwise be claimable
+// (the earlier failed sibling is continue-exempted) is not started while the
+// stop is pending, so `stop` actually stops the rollout instead of letting the
+// next deployment kick off.
+func TestApplyOperationStore_FindNextApplyOperation_PendingStopGateHaltsSibling(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", "mysql", "staging")
+	apply := createTestApplyWithStateAndEnv(t, store, lock, "apply_op_stop_gate", 1, state.Apply.Running, "staging")
+
+	// region-a failed (continue), region-b pending behind it. Without a stop
+	// this is exactly the OnFailureContinueClaimsPastFailedSibling case, where
+	// region-b would be claimed.
+	failed, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-a", State: state.ApplyOperation.Failed, OnFailure: storage.OnFailureContinue,
+	})
+	require.NoError(t, err)
+	_, err = store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-b", OnFailure: storage.OnFailureContinue,
+	})
+	require.NoError(t, err)
+	// Backdate the failed row so staleness can't be the reason region-b is held.
+	_, err = testDB.ExecContext(ctx, `
+		UPDATE apply_operations SET updated_at = NOW() - INTERVAL 1 HOUR WHERE id = ?
+	`, failed)
+	require.NoError(t, err)
+
+	// A pending stop request now exists for the apply.
+	_, _, err = store.ControlRequests().RequestPending(ctx, &storage.ApplyControlRequest{
+		ApplyID:     apply.ID,
+		Operation:   storage.ControlOperationStop,
+		Status:      storage.ControlRequestPending,
+		RequestedBy: "operator",
+	})
+	require.NoError(t, err)
+
+	claimed, err := store.ApplyOperations().FindNextApplyOperation(ctx, "test-operator")
+	require.NoError(t, err)
+	assert.Nil(t, claimed, "a pending stop must halt the next sibling even under on_failure continue")
+}
+
+// TestApplyOperationStore_FindNextApplyOperation_PendingStopDoesNotBlockStaleRecovery
+// verifies the stop gate covers only pending (not-yet-started) rows: a row that
+// already started and went stale is recovering work it began, so it is still
+// re-leasable even while a stop is pending. The in-flight drive observes the
+// stop through the engine.
+func TestApplyOperationStore_FindNextApplyOperation_PendingStopDoesNotBlockStaleRecovery(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", "mysql", "staging")
+	apply := createTestApplyWithStateAndEnv(t, store, lock, "apply_op_stop_stale", 1, state.Apply.Running, "staging")
+
+	runningID, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-a", State: state.ApplyOperation.Running, OnFailure: storage.OnFailureContinue,
+	})
+	require.NoError(t, err)
+	// Make the running row stale so it is re-leasable for crash recovery.
+	_, err = testDB.ExecContext(ctx, `
+		UPDATE apply_operations SET updated_at = NOW() - INTERVAL 1 HOUR WHERE id = ?
+	`, runningID)
+	require.NoError(t, err)
+
+	_, _, err = store.ControlRequests().RequestPending(ctx, &storage.ApplyControlRequest{
+		ApplyID:     apply.ID,
+		Operation:   storage.ControlOperationStop,
+		Status:      storage.ControlRequestPending,
+		RequestedBy: "operator",
+	})
+	require.NoError(t, err)
+
+	claimed, err := store.ApplyOperations().FindNextApplyOperation(ctx, "test-operator")
+	require.NoError(t, err)
+	require.NotNil(t, claimed, "a stale active row is recovering started work and is not gated by a pending stop")
+	assert.Equal(t, runningID, claimed.ID)
+	assert.Equal(t, state.ApplyOperation.Running, claimed.State, "re-lease keeps the running state for the resume drive")
+}
+
+// TestApplyOperationStore_MarkPendingStoppedByApply verifies the operator stop
+// reconciliation primitive: it terminalizes only the still-pending operations of
+// an apply to stopped, leaving running and already-terminal rows untouched, and
+// keeps completed_at nil because stopped is resumable.
+func TestApplyOperationStore_MarkPendingStoppedByApply(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", "mysql", "staging")
+	apply := createTestApplyWithStateAndEnv(t, store, lock, "apply_op_mark_stopped", 1, state.Apply.Running, "staging")
+
+	failedID, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-a", State: state.ApplyOperation.Failed, OnFailure: storage.OnFailureContinue,
+	})
+	require.NoError(t, err)
+	runningID, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-b", State: state.ApplyOperation.Running, OnFailure: storage.OnFailureContinue,
+	})
+	require.NoError(t, err)
+	pendingID, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-c", OnFailure: storage.OnFailureContinue,
+	})
+	require.NoError(t, err)
+
+	stopped, err := store.ApplyOperations().MarkPendingStoppedByApply(ctx, apply.ID)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), stopped, "only the single pending row is stopped")
+
+	pending, err := store.ApplyOperations().Get(ctx, pendingID)
+	require.NoError(t, err)
+	assert.Equal(t, state.ApplyOperation.Stopped, pending.State, "pending row is terminalized to stopped")
+	assert.Nil(t, pending.CompletedAt, "stopped is resumable, so completed_at stays nil")
+
+	failed, err := store.ApplyOperations().Get(ctx, failedID)
+	require.NoError(t, err)
+	assert.Equal(t, state.ApplyOperation.Failed, failed.State, "an already-terminal row keeps its recorded result")
+
+	running, err := store.ApplyOperations().Get(ctx, runningID)
+	require.NoError(t, err)
+	assert.Equal(t, state.ApplyOperation.Running, running.State, "an in-flight row is left for its own driver")
+
+	// A second call is a no-op once nothing is pending.
+	again, err := store.ApplyOperations().MarkPendingStoppedByApply(ctx, apply.ID)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), again, "no pending rows remain to stop")
+}

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -253,8 +253,11 @@ type ApplyStore interface {
 	// acquire the parent apply lease after claiming an apply_operations row.
 	ClaimApplyByID(ctx context.Context, applyID int64, owner string) (*Apply, error)
 
-	// FindNextApplyForStopReconciliation atomically claims one non-terminal apply
-	// (including pending) that has a pending stop control request, at least one
+	// FindNextApplyForStopReconciliation atomically claims one apply eligible for
+	// stop reconciliation — pending or one of the active recovery-claimable states
+	// (the claimableApplyStates set); the resumable non-terminal states
+	// failed_retryable and stopped are excluded because they have their own resume
+	// paths — that has a pending stop control request, at least one
 	// pending operation, and no active operation (none being driven and none
 	// awaiting stale recovery), rotating the lease onto it like FindNextApply. It
 	// is the trigger for stop reconciliation when no operation is claimable to

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -253,6 +253,20 @@ type ApplyStore interface {
 	// acquire the parent apply lease after claiming an apply_operations row.
 	ClaimApplyByID(ctx context.Context, applyID int64, owner string) (*Apply, error)
 
+	// FindNextApplyForStopReconciliation atomically claims one non-terminal apply
+	// (including pending) that has a pending stop control request, at least one
+	// pending operation, and no active operation (none being driven and none
+	// awaiting stale recovery), rotating the lease onto it like FindNextApply. It
+	// is the trigger for stop reconciliation when no operation is claimable to
+	// carry it: under on_failure "continue" a failed earlier sibling can leave the
+	// apply with only terminal and pending operations, and the claim gate keeps
+	// the pending ones from starting, so without this path the apply would strand
+	// non-terminal with its stop request pending forever. Skipping applies with
+	// any active operation leaves in-flight (and crash-recovered) drives to settle
+	// the stop themselves. Returns nil when no such apply exists or it is locked
+	// by a peer.
+	FindNextApplyForStopReconciliation(ctx context.Context, owner string) (*Apply, error)
+
 	// Heartbeat updates the apply's updated_at timestamp to maintain the lease.
 	// Should be called every 10 seconds while working on an apply.
 	// If not called for > 1 minute, another worker can claim the apply.
@@ -431,6 +445,16 @@ type ApplyOperationStore interface {
 
 	// DeleteByApply removes all child rows for an apply (cleanup on apply delete).
 	DeleteByApply(ctx context.Context, applyID int64) error
+
+	// MarkPendingStoppedByApply transitions every still-pending operation of an
+	// apply to stopped, returning the number of rows changed. Used by operator
+	// stop reconciliation: once a stop is pending the claim gate keeps pending
+	// siblings from starting, so they are terminalized here to let the apply
+	// settle instead of stranding non-terminal under on_failure "continue". Only
+	// pending rows are touched; running/terminal rows are left untouched. stopped
+	// is resumable, so completed_at is left nil. Apply-lease guarded when a lease
+	// is present in ctx.
+	MarkPendingStoppedByApply(ctx context.Context, applyID int64) (int64, error)
 }
 
 // VitessApplyDataStore manages Vitess-specific apply data (deploy request tracking).


### PR DESCRIPTION
## What & why

Stacked on #345 (→ #343). Makes a user `stop` actually halt a rollout running under `on_failure: continue`.

**The bug:** under `continue`, a failed earlier deployment no longer blocks later siblings — but `stop` failed to stop them. The operation claim predicate had no stop check, so a continue-exempted pending sibling was still started after the user asked to stop.
```
apply (on_failure: continue),  user issues STOP
op1 = failed     op2 = pending     op3 = pending

BEFORE                                      AFTER
──────                                      ─────
STOP ignored by claim gate                STOP gates the pending claim
│                                             │
▼                                             ▼
op2 claimed & STARTED  ✗                   op2 / op3 → stopped  (never started)
op3 claimed & STARTED  ✗                      │
│                                             ▼
└─ or strands: parent held                parent derives terminal (failed)
running forever, stop never                   │
completes  ✗                                  ▼
stop request completed  ✓
```
**The fix:**
1. **Claim gate** — a pending operation is un-claimable while its apply has a pending stop (added to the `FindNextApplyOperation` SELECT and the pending→running UPDATE). Stale-active recovery is untouched, so an in-flight drive still resumes and observes the stop.
2. **Stop reconciliation** — terminalize the still-pending siblings to `stopped` so the aggregate settles terminal, then complete the stop. Driven inline in `recoverApplyOperation` when an op is being driven, and via a dedicated `recoverApplyPendingStop` claim path when nothing is active (which would otherwise strand a failed-continue apply).

Only `pending` rows are touched (never running/terminal), `completed_at` stays nil (stopped is resumable), writes are apply-lease guarded. Dormant until multi-deployment fan-out lands (one operation per apply today).
