### PR TITLE
feat(storage): compare-and-swap the rollout-projected apply state

### DIFF
--- a/pkg/api/operator.go
+++ b/pkg/api/operator.go
@@ -1105,19 +1105,20 @@ func (s *Service) updateApplyStateFromOperations(ctx context.Context, workerID i
 		return nil
 	}
 
-	updated := *apply
-	updated.State = derived
+	var completedAt *time.Time
 	switch {
 	case state.IsState(derived, state.Apply.Stopped):
 		// stopped is resumable; keep completed_at nil to match the convention.
-		updated.CompletedAt = nil
+		completedAt = nil
 	case state.IsTerminalApplyState(derived):
-		if updated.CompletedAt == nil {
+		if apply.CompletedAt != nil {
+			completedAt = apply.CompletedAt
+		} else {
 			now := s.clock.Now()
-			updated.CompletedAt = &now
+			completedAt = &now
 		}
 	default:
-		updated.CompletedAt = nil
+		completedAt = nil
 	}
 
 	// When the rollout settles to failed, surface the failure reason from the
@@ -1125,14 +1126,25 @@ func (s *Service) updateApplyStateFromOperations(ctx context.Context, workerID i
 	// the last-driven operation wrote — under continue the last driver may be a
 	// successful sibling, which would leave the failed verdict with no matching
 	// reason. Keep the existing message as a fallback when no operation carries one.
+	errorMessage := apply.ErrorMessage
 	if state.IsState(derived, state.Apply.Failed) {
 		if msg := firstFailedOperationMessage(ops); msg != "" {
-			updated.ErrorMessage = msg
+			errorMessage = msg
 		}
 	}
 
-	if err := s.storage.Applies().Update(ctx, &updated); err != nil {
+	swapped, err := s.storage.Applies().UpdateDerivedState(ctx, apply.ID, apply.State, derived, errorMessage, completedAt)
+	if err != nil {
 		return fmt.Errorf("update derived apply state for apply %s (%d) to %q: %w", apply.ApplyIdentifier, apply.ID, derived, err)
+	}
+	if !swapped {
+		// Another drive advanced the apply between our read and write; our
+		// projection is stale. Skip and let the next poll reconcile.
+		s.logger.Info("operator: derived apply state write lost a race; skipping",
+			"worker", workerID, "apply_id", apply.ApplyIdentifier,
+			"database", apply.Database, "environment", apply.Environment,
+			"expected_state", apply.State, "derived_state", derived, "operation_count", len(ops))
+		return nil
 	}
 	s.logger.Info("operator: updated derived apply state from apply_operations",
 		"worker", workerID, "apply_id", apply.ApplyIdentifier,

--- a/pkg/api/operator_test.go
+++ b/pkg/api/operator_test.go
@@ -144,17 +144,28 @@ func (s *listingApplyOperationStore) ListByApply(context.Context, int64) ([]*sto
 	return s.ops, nil
 }
 
-// recordingApplyStore captures the apply persisted by Update so the test can
-// assert the derived state and completed_at stamping.
+// recordingApplyStore captures the projection persisted by UpdateDerivedState so
+// the test can assert the derived state and completed_at stamping. swapped is
+// returned to model whether the compare-and-swap matched the expected state.
 type recordingApplyStore struct {
 	storage.ApplyStore
-	updated *storage.Apply
+	updated       *storage.Apply
+	expectedState string
+	swapped       bool
 }
 
-func (s *recordingApplyStore) Update(_ context.Context, apply *storage.Apply) error {
-	updated := *apply
-	s.updated = &updated
-	return nil
+func (s *recordingApplyStore) UpdateDerivedState(_ context.Context, applyID int64, expectedState, newState, errorMessage string, completedAt *time.Time) (bool, error) {
+	s.expectedState = expectedState
+	if !s.swapped {
+		return false, nil
+	}
+	s.updated = &storage.Apply{
+		ID:           applyID,
+		State:        newState,
+		ErrorMessage: errorMessage,
+		CompletedAt:  completedAt,
+	}
+	return true, nil
 }
 
 func newOperatorStateTestService(opStore storage.ApplyOperationStore, applyStore storage.ApplyStore) *Service {
@@ -206,7 +217,7 @@ func TestUpdateApplyStateFromOperations_ContinuePolicy(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			applyStore := &recordingApplyStore{}
+			applyStore := &recordingApplyStore{swapped: true}
 			svc := newOperatorStateTestService(&listingApplyOperationStore{ops: tc.ops}, applyStore)
 
 			apply := &storage.Apply{
@@ -218,6 +229,7 @@ func TestUpdateApplyStateFromOperations_ContinuePolicy(t *testing.T) {
 
 			require.NoError(t, svc.updateApplyStateFromOperations(t.Context(), 1, apply, allowLeaseScopedFailedReopen))
 			require.NotNil(t, applyStore.updated, "derived state differs from current, so the apply must be persisted")
+			assert.Equal(t, state.Apply.Pending, applyStore.expectedState, "the write must compare-and-swap on the state read before deriving")
 			assert.Equal(t, tc.wantState, applyStore.updated.State)
 			if tc.wantDone {
 				assert.NotNil(t, applyStore.updated.CompletedAt, "terminal derived state stamps completed_at")
@@ -292,7 +304,7 @@ func TestUpdateApplyStateFromOperations_ReopenFailedGuard(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			applyStore := &recordingApplyStore{}
+			applyStore := &recordingApplyStore{swapped: true}
 			svc := newOperatorStateTestService(&listingApplyOperationStore{ops: tc.ops}, applyStore)
 
 			// A terminal parent always carries a stamped completed_at; seed one
@@ -423,7 +435,7 @@ func TestUpdateApplyStateFromOperations_StampsAggregateFailureMessage(t *testing
 		{ID: 1, Deployment: "region-a", State: state.ApplyOperation.Failed, ErrorMessage: "spirit: cutover failed"},
 		{ID: 2, Deployment: "region-b", State: state.ApplyOperation.Completed},
 	}
-	applyStore := &recordingApplyStore{}
+	applyStore := &recordingApplyStore{swapped: true}
 	svc := newOperatorStateTestService(&listingApplyOperationStore{ops: ops}, applyStore)
 
 	apply := &storage.Apply{
@@ -448,7 +460,7 @@ func TestUpdateApplyStateFromOperations_KeepsExistingMessageWhenNoOperationCarri
 		{ID: 1, Deployment: "region-a", State: state.ApplyOperation.Failed},
 		{ID: 2, Deployment: "region-b", State: state.ApplyOperation.Completed},
 	}
-	applyStore := &recordingApplyStore{}
+	applyStore := &recordingApplyStore{swapped: true}
 	svc := newOperatorStateTestService(&listingApplyOperationStore{ops: ops}, applyStore)
 
 	apply := &storage.Apply{
@@ -594,4 +606,28 @@ func TestCompletePendingStopIfApplyResolved(t *testing.T) {
 		require.NoError(t, svc.completePendingStopIfApplyResolved(t.Context(), 1, 9))
 		assert.Empty(t, control.completed, "no pending stop means nothing to complete")
 	})
+}
+
+// TestUpdateApplyStateFromOperations_StaleWriteSkipped verifies that when the
+// compare-and-swap misses — another drive advanced the apply between the
+// operator's read and write — the operator skips quietly rather than erroring or
+// reviving a stale projection.
+func TestUpdateApplyStateFromOperations_StaleWriteSkipped(t *testing.T) {
+	ops := []*storage.ApplyOperation{
+		{ID: 1, State: state.ApplyOperation.Failed},
+		{ID: 2, State: state.ApplyOperation.Pending},
+	}
+	applyStore := &recordingApplyStore{swapped: false}
+	svc := newOperatorStateTestService(&listingApplyOperationStore{ops: ops}, applyStore)
+
+	apply := &storage.Apply{
+		ID:              3,
+		ApplyIdentifier: "apply-projection",
+		State:           state.Apply.Pending,
+		Environment:     "staging",
+	}
+
+	require.NoError(t, svc.updateApplyStateFromOperations(t.Context(), 1, apply, allowLeaseScopedFailedReopen))
+	assert.Equal(t, state.Apply.Pending, applyStore.expectedState, "the write must compare-and-swap on the state read before deriving")
+	assert.Nil(t, applyStore.updated, "a CAS miss must not record a persisted projection")
 }

--- a/pkg/storage/mysqlstore/applies.go
+++ b/pkg/storage/mysqlstore/applies.go
@@ -700,6 +700,72 @@ func (s *applyStore) Update(ctx context.Context, apply *storage.Apply) error {
 	return nil
 }
 
+// UpdateDerivedState compare-and-swaps the rollout-projected applies.state.
+// It writes only the fields owned by the projection and only when the row still
+// holds expectedState, so a stale projection cannot clobber a newer state a
+// sibling drive already wrote. A lost lease fails closed with an error; a CAS
+// miss (state no longer matches) returns swapped=false so the caller can skip
+// side-effects and reconcile on the next poll.
+func (s *applyStore) UpdateDerivedState(ctx context.Context, applyID int64, expectedState, newState, errorMessage string, completedAt *time.Time) (bool, error) {
+	lease, hasLease, err := applyLeaseFromContext(ctx, applyID)
+	if err != nil {
+		return false, err
+	}
+
+	args := []any{newState, errorMessage, completedAt, applyID, expectedState}
+	leasePredicate := ""
+	if hasLease {
+		leasePredicate = " AND lease_token = ?"
+		args = append(args, lease.Token)
+	}
+
+	result, err := s.db.ExecContext(ctx, fmt.Sprintf(`
+		UPDATE applies
+		SET state = ?, error_message = ?, completed_at = ?, updated_at = NOW()
+		WHERE id = ? AND state = ?%s
+	`, leasePredicate), args...)
+	if err != nil {
+		return false, fmt.Errorf("compare-and-swap derived apply state for apply %d (%q -> %q): %w", applyID, expectedState, newState, err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("read derived apply state rows affected for apply %d: %w", applyID, err)
+	}
+	if rows > 0 {
+		return true, nil
+	}
+
+	// Zero rows. A leased caller must distinguish a lost lease (fail closed) from
+	// a benign CAS outcome: the former is an ownership change the caller must
+	// surface, the latter is reconciled on the next poll.
+	if hasLease {
+		if err := ensureApplyLeaseStillOwned(ctx, s.db, lease); err != nil {
+			return false, err
+		}
+	}
+
+	// Under production changed-rows semantics an UPDATE that touches a matching
+	// row but leaves every column unchanged reports zero rows. That only happens
+	// when the projection is a no-op (newState == expectedState and the other
+	// projected fields already hold their target), so a re-read distinguishes
+	// "row still holds expectedState" (idempotent swap) from a genuine CAS miss
+	// where another drive already advanced the state. When newState differs from
+	// expectedState a matching row would have changed, so zero rows is always a
+	// miss and no re-read is needed.
+	if !state.IsState(newState, expectedState) {
+		return false, nil
+	}
+	var currentState string
+	err = s.db.QueryRowContext(ctx, `SELECT state FROM applies WHERE id = ?`, applyID).Scan(&currentState)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("re-read derived apply state for apply %d: %w", applyID, err)
+	}
+	return state.IsState(currentState, expectedState), nil
+}
+
 // GetInProgress returns all applies in non-terminal states.
 // Note: For recovery, use FindNextApply which handles locking and heartbeat staleness.
 func (s *applyStore) GetInProgress(ctx context.Context) ([]*storage.Apply, error) {

--- a/pkg/storage/mysqlstore/applies_test.go
+++ b/pkg/storage/mysqlstore/applies_test.go
@@ -907,6 +907,127 @@ func TestApplyStore_UpdateNonExistent(t *testing.T) {
 	require.NoError(t, store.Applies().Update(ctx, apply))
 }
 
+// TestApplyStore_UpdateDerivedState verifies the rollout-projection compare-and-
+// swap: the write lands only when the row still holds the expected state, so a
+// stale projection cannot clobber a newer state another drive already wrote.
+func TestApplyStore_UpdateDerivedState(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", storage.DatabaseTypeMySQL, "staging")
+	apply := createTestApplyWithStateAndEnv(t, store, lock, "apply_derived_cas", 800, state.Apply.Running, "staging")
+
+	// Matching expected state swaps and writes the projected fields.
+	completedAt := time.Now()
+	swapped, err := store.Applies().UpdateDerivedState(ctx, apply.ID, state.Apply.Running, state.Apply.Failed, "deployment failed", &completedAt)
+	require.NoError(t, err)
+	require.True(t, swapped, "expected state matched, so the swap must land")
+
+	updated, err := store.Applies().Get(ctx, apply.ID)
+	require.NoError(t, err)
+	assert.Equal(t, state.Apply.Failed, updated.State)
+	assert.Equal(t, "deployment failed", updated.ErrorMessage)
+	require.NotNil(t, updated.CompletedAt)
+
+	// A stale expected state misses: the row already moved on, so the write is
+	// skipped and the row is left untouched.
+	swapped, err = store.Applies().UpdateDerivedState(ctx, apply.ID, state.Apply.Running, state.Apply.Completed, "", nil)
+	require.NoError(t, err)
+	assert.False(t, swapped, "expected state no longer matches, so the swap must miss")
+
+	unchanged, err := store.Applies().Get(ctx, apply.ID)
+	require.NoError(t, err)
+	assert.Equal(t, state.Apply.Failed, unchanged.State, "a CAS miss must not overwrite the newer state")
+	assert.Equal(t, "deployment failed", unchanged.ErrorMessage)
+}
+
+// TestApplyStore_UpdateDerivedStateNoOpUnderChangedRows verifies that under
+// production changed-rows semantics a no-op projection write (the steady-state
+// case where the derived state equals the current state) reports a successful
+// swap rather than a false CAS miss, so progress side-effects still fire.
+func TestApplyStore_UpdateDerivedStateNoOpUnderChangedRows(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := newChangedRowsStore(t)
+
+	lock := createTestLock(t, store, "testdb", storage.DatabaseTypeMySQL, "staging")
+	apply := createTestApplyWithStateAndEnv(t, store, lock, "apply_derived_cas_noop", 802, state.Apply.Running, "staging")
+
+	// Re-deriving the same running state with no other field change is a no-op
+	// that affects zero rows under changed-rows semantics, but the row still
+	// holds the expected state, so the swap is reported as successful.
+	swapped, err := store.Applies().UpdateDerivedState(ctx, apply.ID, state.Apply.Running, state.Apply.Running, "", nil)
+	require.NoError(t, err)
+	assert.True(t, swapped, "a no-op write to a row already in the expected state is an idempotent swap, not a miss")
+
+	// A stale expected state still misses even under changed-rows semantics.
+	swapped, err = store.Applies().UpdateDerivedState(ctx, apply.ID, state.Apply.Pending, state.Apply.Pending, "", nil)
+	require.NoError(t, err)
+	assert.False(t, swapped, "the row is not in the expected state, so the swap must miss")
+}
+
+// TestApplyStore_UpdateDerivedStateLeaseGuard verifies that a leased projection
+// write fails closed on a lost lease (an ownership change the caller must
+// surface) while the current lease holder's matching swap succeeds.
+func TestApplyStore_UpdateDerivedStateLeaseGuard(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", storage.DatabaseTypeMySQL, "staging")
+	apply := createTestApplyWithStateAndEnv(t, store, lock, "apply_derived_cas_lease", 801, state.Apply.Pending, "staging")
+
+	task := &storage.Task{
+		TaskIdentifier: "task_derived_cas_lease",
+		ApplyID:        apply.ID,
+		PlanID:         apply.PlanID,
+		Database:       apply.Database,
+		DatabaseType:   apply.DatabaseType,
+		Engine:         storage.EngineSpirit,
+		Environment:    apply.Environment,
+		State:          state.Task.Pending,
+		TableName:      "users",
+		DDL:            "ALTER TABLE `users` ADD COLUMN `cas_note` varchar(255)",
+		DDLAction:      "alter",
+		Options:        []byte("{}"),
+		CreatedAt:      time.Now(),
+		UpdatedAt:      time.Now(),
+	}
+	taskID, err := store.Tasks().Create(ctx, task)
+	require.NoError(t, err)
+	task.ID = taskID
+
+	claimed, err := store.Applies().FindNextApply(ctx, "worker-a")
+	require.NoError(t, err)
+	require.NotNil(t, claimed)
+
+	// The claim may rotate the persisted state, so read the row to learn the
+	// state the compare-and-swap must expect.
+	leased, err := store.Applies().Get(ctx, apply.ID)
+	require.NoError(t, err)
+	expectedState := leased.State
+
+	// A stale lease cannot write, even when the expected state matches.
+	staleCtx := storage.WithApplyLease(ctx, storage.ApplyLease{ApplyID: apply.ID, Owner: "worker-old", Token: "stale-token"})
+	_, err = store.Applies().UpdateDerivedState(staleCtx, apply.ID, expectedState, state.Apply.Failed, "stale", nil)
+	require.ErrorIs(t, err, storage.ErrApplyLeaseLost)
+
+	persisted, err := store.Applies().Get(ctx, apply.ID)
+	require.NoError(t, err)
+	assert.Equal(t, expectedState, persisted.State, "a lost lease must not write the projection")
+
+	// The current lease holder's matching swap lands.
+	ownedCtx := storage.WithApplyLease(ctx, claimed.Lease())
+	swapped, err := store.Applies().UpdateDerivedState(ownedCtx, apply.ID, expectedState, state.Apply.Failed, "owned failure", nil)
+	require.NoError(t, err)
+	assert.True(t, swapped)
+
+	updated, err := store.Applies().Get(ctx, apply.ID)
+	require.NoError(t, err)
+	assert.Equal(t, state.Apply.Failed, updated.State)
+}
+
 func TestApplyStore_GetInProgress(t *testing.T) {
 	clearTables(t)
 	ctx := t.Context()

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -4,6 +4,7 @@ package storage
 
 import (
 	"context"
+	"time"
 )
 
 // Storage provides access to all stores.
@@ -226,6 +227,21 @@ type ApplyStore interface {
 	// would overlap another active apply for the same database, database type,
 	// and environment.
 	Update(ctx context.Context, apply *Apply) error
+
+	// UpdateDerivedState compare-and-swaps the rollout-projected applies.state.
+	//
+	// It writes only the fields owned by the rollout projection (state,
+	// error_message, completed_at, updated_at) and only when the row still holds
+	// expectedState, so a stale projection computed from an earlier read cannot
+	// clobber a newer state another sibling drive already wrote. If ctx carries
+	// an apply lease the write additionally requires the current lease token.
+	//
+	// swapped=false means the row no longer matched expectedState: the caller's
+	// view is stale, so it must skip apply-level side-effects that assume its
+	// write landed and let the next poll reconcile. A lost lease is returned as
+	// an error (ErrApplyLeaseLost), not swapped=false, so leased callers still
+	// fail closed on ownership changes.
+	UpdateDerivedState(ctx context.Context, applyID int64, expectedState, newState, errorMessage string, completedAt *time.Time) (swapped bool, err error)
 
 	// GetRecent returns the most recent applies across all databases, ordered by creation time desc.
 	// Used by `schemabot status` (no args) to show recent activity.

--- a/pkg/tern/local_apply_grouped.go
+++ b/pkg/tern/local_apply_grouped.go
@@ -738,10 +738,17 @@ func (c *LocalClient) handleAtomicProgressTick(ctx context.Context, eng engine.E
 		apply.State = derived
 	}
 	apply.UpdatedAt = now
-	if freshApply, err := c.storage.Applies().Get(ctx, apply.ID); err != nil {
+	freshApply, err := c.storage.Applies().Get(ctx, apply.ID)
+	if err != nil {
 		c.logger.Error("failed to reload apply before progress state update", "apply_id", apply.ApplyIdentifier, "error", err)
 		return true
-	} else if freshApply != nil && state.IsTerminalApplyState(freshApply.State) {
+	}
+	if freshApply == nil {
+		c.logger.Warn("apply row missing before progress state update; yielding",
+			"apply_id", apply.ApplyIdentifier, "apply_db_id", apply.ID)
+		return true
+	}
+	if state.IsTerminalApplyState(freshApply.State) {
 		c.logger.Info("apply already terminal in storage, not overwriting with stale progress state",
 			"apply_id", apply.ApplyIdentifier,
 			"stored_state", freshApply.State,
@@ -754,6 +761,10 @@ func (c *LocalClient) handleAtomicProgressTick(ctx context.Context, eng engine.E
 		}
 		return true
 	}
+	// expectedState is the authoritative current value: the projection write
+	// below compare-and-swaps on it so a stale projection cannot clobber a newer
+	// state a sibling drive already wrote between this reload and the write.
+	expectedState := freshApply.State
 
 	// Gate apply-level terminal side-effects on the rollout-projected apply state
 	// (apply.State, derived above), not the current operation's engine result.
@@ -780,8 +791,15 @@ func (c *LocalClient) handleAtomicProgressTick(ctx context.Context, eng engine.E
 			}
 		}
 		ensureApplyFailureMessage(apply, tasks)
-		if err := c.storage.Applies().Update(ctx, apply); err != nil {
+		swapped, err := c.storage.Applies().UpdateDerivedState(ctx, apply.ID, expectedState, apply.State, apply.ErrorMessage, apply.CompletedAt)
+		if err != nil {
 			c.logger.Error("failed to update apply state", "apply_id", apply.ApplyIdentifier, "state", apply.State, "error", err)
+		} else if !swapped {
+			// Another drive advanced the apply between our reload and write; it
+			// owns the terminal transition and its side-effects. Skip ours.
+			c.logger.Info("apply terminal-state write lost a race; yielding to the owning drive",
+				"apply_id", apply.ApplyIdentifier, "expected_state", expectedState, "derived_state", apply.State)
+			return true
 		}
 		if err := completePendingStopControlRequests(ctx, c.storage, apply); err != nil {
 			c.logger.Warn("failed to complete pending stop request after terminal progress reconciliation; current apply owner will exit for operator retry",
@@ -822,8 +840,16 @@ func (c *LocalClient) handleAtomicProgressTick(ctx context.Context, eng engine.E
 		return true
 	}
 
-	if err := c.storage.Applies().Update(ctx, apply); err != nil {
+	swapped, err := c.storage.Applies().UpdateDerivedState(ctx, apply.ID, expectedState, apply.State, apply.ErrorMessage, apply.CompletedAt)
+	if err != nil {
 		c.logger.Error("failed to update apply state", "apply_id", apply.ApplyIdentifier, "state", apply.State, "error", err)
+	} else if !swapped {
+		// Another drive advanced the apply between our reload and write; our
+		// progress projection is stale. Skip the observer update and let the next
+		// poll reconcile.
+		c.logger.Info("apply progress-state write lost a race; skipping",
+			"apply_id", apply.ApplyIdentifier, "expected_state", expectedState, "derived_state", apply.State)
+		return false
 	}
 
 	// Notify observer of progress update

--- a/pkg/tern/local_client.go
+++ b/pkg/tern/local_client.go
@@ -1074,10 +1074,14 @@ func (c *LocalClient) Progress(ctx context.Context, req *ternv1.ProgressRequest)
 						c.logger.Warn("failed to load apply after progress task state update", "apply_id", activeTask.ApplyID, "error", err)
 					} else if apply != nil && !state.IsTerminalApplyState(apply.State) {
 						if derived, ok := c.deriveAggregateApplyState(ctx, apply, opScopedTasks); ok {
-							apply.State = derived
-							apply.UpdatedAt = now
-							if err := c.storage.Applies().Update(ctx, apply); err != nil {
-								c.logger.Warn("failed to update apply after progress task state update", "apply_id", apply.ApplyIdentifier, "state", apply.State, "error", err)
+							// Compare-and-swap on the just-read state so a stale
+							// projection cannot clobber a newer state a sibling
+							// drive already wrote.
+							swapped, err := c.storage.Applies().UpdateDerivedState(ctx, apply.ID, apply.State, derived, apply.ErrorMessage, apply.CompletedAt)
+							if err != nil {
+								c.logger.Warn("failed to update apply after progress task state update", "apply_id", apply.ApplyIdentifier, "state", derived, "error", err)
+							} else if !swapped {
+								c.logger.Debug("apply progress projection write lost a race; next poll reconciles", "apply_id", apply.ApplyIdentifier, "expected_state", apply.State, "derived_state", derived)
 							}
 						}
 					}
@@ -1107,6 +1111,7 @@ func (c *LocalClient) Progress(ctx context.Context, req *ternv1.ProgressRequest)
 						// one operation per apply the projection equals this
 						// operation's derived state, so this is a no-op until the
 						// multi-deployment fan-out lands.
+						expectedState := apply.State
 						derived, ok := c.deriveAggregateApplyState(ctx, apply, opScopedTasks)
 						quiesce, _, stampCompletedAt := applyQuiesceDecision(derived)
 						if ok && quiesce {
@@ -1128,10 +1133,18 @@ func (c *LocalClient) Progress(ctx context.Context, req *ternv1.ProgressRequest)
 							}
 							ensureApplyFailureMessage(apply, opScopedTasks)
 							apply.UpdatedAt = now
-							if err := c.storage.Applies().Update(ctx, apply); err != nil {
+							// Compare-and-swap on the just-read state so a stale
+							// projection cannot clobber a newer state a sibling
+							// drive already wrote.
+							swapped, err := c.storage.Applies().UpdateDerivedState(ctx, apply.ID, expectedState, apply.State, apply.ErrorMessage, apply.CompletedAt)
+							switch {
+							case err != nil:
 								c.logger.Warn("failed to update apply from progress poll", "apply_id", apply.ApplyIdentifier, "state", apply.State, "apply_db_id", apply.ID, "error", err)
+							case !swapped:
+								c.logger.Debug("apply terminal projection write lost a race; next poll reconciles", "apply_id", apply.ApplyIdentifier, "expected_state", expectedState, "derived_state", derived)
+							default:
+								c.logger.Info("apply state updated from progress polling", "apply_id", apply.ApplyIdentifier, "state", apply.State)
 							}
-							c.logger.Info("apply state updated from progress polling", "apply_id", apply.ApplyIdentifier, "state", apply.State)
 						}
 					}
 				}

--- a/pkg/tern/local_client_test.go
+++ b/pkg/tern/local_client_test.go
@@ -60,6 +60,19 @@ func (s *exactProgressApplyStore) Update(_ context.Context, apply *storage.Apply
 	return nil
 }
 
+func (s *exactProgressApplyStore) UpdateDerivedState(_ context.Context, _ int64, expectedState, newState, errorMessage string, completedAt *time.Time) (bool, error) {
+	if s.err != nil {
+		return false, s.err
+	}
+	if s.apply == nil || !state.IsState(s.apply.State, expectedState) {
+		return false, nil
+	}
+	s.apply.State = newState
+	s.apply.ErrorMessage = errorMessage
+	s.apply.CompletedAt = completedAt
+	return true, nil
+}
+
 // snapshotApplyStore returns a copy of the stored apply on reads and replaces
 // the stored copy on Update, so in-memory mutations to the apply passed into a
 // drive do not leak into the next storage read. This mirrors a real store, where
@@ -92,6 +105,19 @@ func (s *snapshotApplyStore) Update(_ context.Context, apply *storage.Apply) err
 	}
 	s.stored = *apply
 	return nil
+}
+
+func (s *snapshotApplyStore) UpdateDerivedState(_ context.Context, _ int64, expectedState, newState, errorMessage string, completedAt *time.Time) (bool, error) {
+	if s.err != nil {
+		return false, s.err
+	}
+	if !state.IsState(s.stored.State, expectedState) {
+		return false, nil
+	}
+	s.stored.State = newState
+	s.stored.ErrorMessage = errorMessage
+	s.stored.CompletedAt = completedAt
+	return true, nil
 }
 
 type exactProgressTaskStore struct {


### PR DESCRIPTION
## What & why

Stacked on `kiran01bm/rollout-continue-terminal-side-effects` (B3.2). Makes the rollout-projected `applies.state` writes safe under concurrency.

**The bug:** once an apply owns more than one operation, sibling drives and the operator project `applies.state` concurrently. A plain `Update` is last-write-wins — a drive that read an older state clobbers a newer state another drive already wrote, reviving a settled apply or double-running terminal side-effects.
apply (2+ operations),  two drives project applies.state concurrently
drive A read state=running          drive B read state=running, already wrote failed

```
BEFORE                                      AFTER
──────                                      ─────
A's Update(running→running)                A's CAS(expected=running) misses
clobbers B's failed  ✗                        │
│                                             ▼
▼                                          swapped=false → A skips,
parent revived running / side-effects      next poll reconciles  ✓
run twice  ✗                                  │
▼
B's failed stands, side-effects
run once  ✓
```
**The fix:** a narrow `UpdateDerivedState` primitive compare-and-swaps the projection — writing only projection-owned fields (`state`, `error_message`, `completed_at`) and only when the row still holds the expected state. The four projection write sites use it; lifecycle, control, and failure writes keep the full `Update` path. A CAS miss returns `swapped=false` so the caller skips apply-level side-effects and reconciles on the next poll; a lost lease still fails closed.

No-op for single-operation applies (the projection collapses to the current op's derived state); dormant until the multi-deployment fan-out lands.
