### PR TITLE
feat(operator): route deferred starts through operator

### DIFF
--- a/pkg/api/control_handlers.go
+++ b/pkg/api/control_handlers.go
@@ -890,9 +890,9 @@ func (s *Service) handleStart(w http.ResponseWriter, r *http.Request) {
 	s.writeJSON(w, httpStatus, resp)
 }
 
-// ExecuteStart records durable start intent for a stopped apply. The operator
-// owner is responsible for resuming stopped work when immediate dispatch is not
-// possible.
+// ExecuteStart records durable start intent for a stopped apply or deferred
+// deploy. The apply owner is responsible for consuming the request from the
+// per-apply processing loop.
 func (s *Service) ExecuteStart(ctx context.Context, req apitypes.ControlRequest) (*apitypes.StartResponse, error) {
 	client, apply, ternApplyID, err := s.controlTarget(ctx, "start", req.ApplyID, req.Environment)
 	if err != nil {
@@ -902,10 +902,10 @@ func (s *Service) ExecuteStart(ctx context.Context, req apitypes.ControlRequest)
 	return resp, err
 }
 
-// executeStartForApply records durable start intent for an apply or dispatches
-// a deferred deploy. The returned HTTP status is meaningful only when
-// err == nil; every error path returns a zero status, and callers must derive
-// the response status from the error (e.g. via writeControlError).
+// executeStartForApply records durable start intent for an apply. The returned
+// HTTP status is meaningful only when err == nil; every error path returns a
+// zero status, and callers must derive the response status from the error (e.g.
+// via writeControlError).
 func (s *Service) executeStartForApply(ctx context.Context, client tern.Client, apply *storage.Apply, ternApplyID, caller string) (*apitypes.StartResponse, int, error) {
 	if err := validateStartRequestState(apply); err != nil {
 		metrics.RecordControlOperation(ctx, "start", apply.Database, apply.Deployment, apply.Environment, "rejected")
@@ -934,18 +934,8 @@ func (s *Service) executeStartForApply(ctx context.Context, client tern.Client, 
 	queuedForOperator := false
 	switch {
 	case state.IsState(apply.State, state.Apply.WaitingForDeploy):
-		if err := s.rejectControlIfStopPending(ctx, "start dispatch", apply); err != nil {
-			status := "error"
-			if controlOperationHTTPStatus(err) < http.StatusInternalServerError {
-				status = "rejected"
-			}
-			metrics.RecordControlOperation(ctx, "start", apply.Database, apply.Deployment, apply.Environment, status)
-			return nil, 0, err
-		}
-		resp, err = client.Start(ctx, &ternv1.StartRequest{
-			ApplyId:     ternApplyID,
-			Environment: apply.Environment,
-		})
+		resp, responseStatus, err = s.persistStartRequestForOperator(ctx, apply, caller, 1, 0)
+		queuedForOperator = err == nil && resp.Accepted
 	case state.IsState(apply.State, state.Apply.Pending):
 		resp, responseStatus, err = s.startResponseForPendingStartRequest(ctx, apply)
 		queuedForOperator = err == nil && resp.Accepted

--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -2530,13 +2530,8 @@ func TestStopHandler(t *testing.T) {
 }
 
 func TestStartHandler(t *testing.T) {
-	t.Run("passes apply_id to tern client for deferred deploy", func(t *testing.T) {
-		mock := &mockTernClient{
-			startResp: &ternv1.StartResponse{
-				Accepted:     true,
-				StartedCount: 3,
-			},
-		}
+	t.Run("queues deferred deploy start for loop processing", func(t *testing.T) {
+		mock := &mockTernClient{}
 		apply := activeTestApply("apply-xyz789")
 		apply.State = state.Apply.WaitingForDeploy
 		svc := newControlTestService(mock, apply)
@@ -2551,9 +2546,17 @@ func TestStartHandler(t *testing.T) {
 
 		assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
 
-		require.NotNil(t, mock.startReq, "expected start request to be captured")
-		assert.Equal(t, "apply-xyz789", mock.startReq.ApplyId)
-		assert.Equal(t, "staging", mock.startReq.Environment)
+		assert.Nil(t, mock.startReq, "request path should queue start without calling Tern start")
+		controlReq, err := svc.storage.ControlRequests().GetPending(t.Context(), apply.ID, storage.ControlOperationStart)
+		require.NoError(t, err)
+		require.NotNil(t, controlReq)
+		assert.Equal(t, storage.ControlRequestPending, controlReq.Status)
+
+		var resp apitypes.StartResponse
+		err = json.NewDecoder(w.Body).Decode(&resp)
+		require.NoError(t, err, "failed to decode response")
+		assert.True(t, resp.Accepted)
+		assert.Equal(t, int64(1), resp.StartedCount)
 	})
 
 	t.Run("rejects start while stop request is pending", func(t *testing.T) {

--- a/pkg/storage/mysqlstore/applies.go
+++ b/pkg/storage/mysqlstore/applies.go
@@ -755,10 +755,10 @@ func (s *applyStore) GetRecent(ctx context.Context, filter storage.RecentApplies
 // and resumes the apply.
 // Returns the claimed apply, or nil if nothing needs work.
 //
-// Matches queued pending applies with persisted tasks, pending or stopped applies
-// with a pending start control request, stale active applies where heartbeat
-// expired > 1 minute, and recently failed_retryable applies that still have retry
-// budget.
+// Matches queued pending applies with persisted tasks, pending, stopped, or
+// waiting-for-deploy applies with a pending start control request, stale active
+// applies where heartbeat expired > 1 minute, and recently failed_retryable
+// applies that still have retry budget.
 // Apply creation/update enforces one active apply per database/type/environment,
 // so claims only need to lease one row and avoid worker races on that row.
 func (s *applyStore) FindNextApply(ctx context.Context, owner string) (*storage.Apply, error) {
@@ -783,6 +783,9 @@ func (s *applyStore) FindNextApply(ctx context.Context, owner string) (*storage.
 		storage.ControlOperationStart, storage.ControlRequestPending)
 	queryArgs = append(queryArgs,
 		state.Apply.Stopped,
+		storage.ControlOperationStart, storage.ControlRequestPending)
+	queryArgs = append(queryArgs,
+		state.Apply.WaitingForDeploy,
 		storage.ControlOperationStart, storage.ControlRequestPending)
 
 	// Apply creation/update enforces at most one active apply per
@@ -809,6 +812,19 @@ func (s *applyStore) FindNextApply(ctx context.Context, owner string) (*storage.
 						SELECT 1
 						FROM apply_control_requests cr
 						WHERE cr.apply_id = a.id AND cr.operation = ? AND cr.status = ?
+					)
+				)
+				OR (
+					a.state = ?
+					AND EXISTS (
+						SELECT 1
+						FROM apply_control_requests cr
+						WHERE cr.apply_id = a.id AND cr.operation = ? AND cr.status = ?
+						AND (
+							a.lease_acquired_at IS NULL
+							OR a.lease_acquired_at < cr.updated_at
+							OR a.updated_at < NOW() - INTERVAL 1 MINUTE
+						)
 					)
 				)
 			)
@@ -873,6 +889,9 @@ func (s *applyStore) ClaimApplyByID(ctx context.Context, applyID int64, owner st
 	queryArgs = append(queryArgs,
 		state.Apply.Stopped,
 		storage.ControlOperationStart, storage.ControlRequestPending)
+	queryArgs = append(queryArgs,
+		state.Apply.WaitingForDeploy,
+		storage.ControlOperationStart, storage.ControlRequestPending)
 
 	row := tx.QueryRowContext(ctx, fmt.Sprintf(`
 		SELECT %s
@@ -896,6 +915,19 @@ func (s *applyStore) ClaimApplyByID(ctx context.Context, applyID int64, owner st
 						SELECT 1
 						FROM apply_control_requests cr
 						WHERE cr.apply_id = a.id AND cr.operation = ? AND cr.status = ?
+					)
+				)
+				OR (
+					a.state = ?
+					AND EXISTS (
+						SELECT 1
+						FROM apply_control_requests cr
+						WHERE cr.apply_id = a.id AND cr.operation = ? AND cr.status = ?
+						AND (
+							a.lease_acquired_at IS NULL
+							OR a.lease_acquired_at < cr.updated_at
+							OR a.updated_at < NOW() - INTERVAL 1 MINUTE
+						)
 					)
 				)
 			)

--- a/pkg/storage/mysqlstore/applies_test.go
+++ b/pkg/storage/mysqlstore/applies_test.go
@@ -1387,6 +1387,57 @@ func TestApplyStore_FindNextApplyClaimsStoppedStartControlRequest(t *testing.T) 
 	assert.Nil(t, claimedAgain, "claim transition should prevent another worker from taking the same stopped start request")
 }
 
+func TestApplyStore_FindNextApplyClaimsWaitingForDeployStartControlRequest(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", storage.DatabaseTypeVitess, "staging")
+	apply := createTestApplyWithStateAndEnv(t, store, lock, "apply_waiting_deploy_start_request", 505, state.Apply.WaitingForDeploy, "staging")
+	_, err := testDB.ExecContext(ctx, `
+		UPDATE applies
+		SET lease_owner = 'waiting-owner', lease_token = 'waiting-token', lease_acquired_at = NOW() - INTERVAL 2 MINUTE, updated_at = NOW()
+		WHERE id = ?
+	`, apply.ID)
+	require.NoError(t, err)
+	_, alreadyPending, err := store.ControlRequests().RequestPending(ctx, &storage.ApplyControlRequest{
+		ApplyID:     apply.ID,
+		Operation:   storage.ControlOperationStart,
+		Status:      storage.ControlRequestPending,
+		RequestedBy: "operator",
+		Metadata:    []byte(`{}`),
+	})
+	require.NoError(t, err)
+	require.False(t, alreadyPending)
+
+	claimed, err := store.Applies().FindNextApply(ctx, "test-owner")
+	require.NoError(t, err)
+	require.NotNil(t, claimed)
+	assert.Equal(t, apply.ApplyIdentifier, claimed.ApplyIdentifier)
+	assert.Equal(t, state.Apply.WaitingForDeploy, claimed.State)
+
+	persisted, err := store.Applies().Get(ctx, apply.ID)
+	require.NoError(t, err)
+	require.NotNil(t, persisted)
+	assert.Equal(t, state.Apply.WaitingForDeploy, persisted.State)
+	assert.Equal(t, "test-owner", persisted.LeaseOwner)
+	assert.Equal(t, claimed.LeaseToken, persisted.LeaseToken)
+
+	claimedAgain, err := store.Applies().FindNextApply(ctx, "test-owner")
+	require.NoError(t, err)
+	assert.Nil(t, claimedAgain, "fresh processing lease should prevent another worker from taking the same deferred deploy start request")
+
+	_, err = testDB.ExecContext(ctx, `
+		UPDATE applies SET updated_at = NOW() - INTERVAL 2 MINUTE WHERE id = ?
+	`, apply.ID)
+	require.NoError(t, err)
+
+	reclaimed, err := store.Applies().FindNextApply(ctx, "recovery-owner")
+	require.NoError(t, err)
+	require.NotNil(t, reclaimed, "stale deferred deploy start processing owner should be reclaimable")
+	assert.Equal(t, apply.ApplyIdentifier, reclaimed.ApplyIdentifier)
+}
+
 // TestApplyStore_ClaimStoppedStartRefusedWhenTargetActive verifies the
 // one-active-apply-per-target invariant survives a stopped→running claim. A
 // stopped apply is not "active", so a newer apply can become active for the same

--- a/pkg/storage/mysqlstore/apply_operations.go
+++ b/pkg/storage/mysqlstore/apply_operations.go
@@ -621,6 +621,9 @@ func (s *applyOperationStore) FindNextApplyOperation(ctx context.Context, owner 
 	queryArgs = append(queryArgs,
 		state.ApplyOperation.Stopped,
 		storage.ControlOperationStart, storage.ControlRequestPending)
+	queryArgs = append(queryArgs,
+		state.ApplyOperation.WaitingForDeploy,
+		storage.ControlOperationStart, storage.ControlRequestPending)
 	queryArgs = append(queryArgs, state.ApplyOperation.FailedRetryable)
 	queryArgs = append(queryArgs, state.Apply.FailedRetryable, maxRecoveryAttempts, retryableRecoveryFreshnessDays)
 	queryArgs = append(queryArgs, stringArgs(activeStates)...)
@@ -631,6 +634,9 @@ func (s *applyOperationStore) FindNextApplyOperation(ctx context.Context, owner 
 	//
 	//   - A stopped operation whose parent apply has a pending start request is
 	//     reclaimable so the operator can resume it.
+	//
+	//   - A waiting-for-deploy operation whose parent apply has a pending start
+	//     request is reclaimable so the operator can trigger the deferred deploy.
 	//
 	//   - A failed_retryable operation is reclaimable only while its PARENT apply
 	//     is itself claimable for that operation's recovery. The operator claim
@@ -693,6 +699,21 @@ func (s *applyOperationStore) FindNextApplyOperation(ctx context.Context, owner 
 					WHERE cr.apply_id = apply_operations.apply_id
 						AND cr.operation = ?
 						AND cr.status = ?
+				)
+			)
+			OR (
+				state = ?
+				AND EXISTS (
+					SELECT 1
+					FROM apply_control_requests cr
+					WHERE cr.apply_id = apply_operations.apply_id
+						AND cr.operation = ?
+						AND cr.status = ?
+						AND (
+							apply_operations.lease_acquired_at IS NULL
+							OR apply_operations.lease_acquired_at < cr.updated_at
+							OR apply_operations.updated_at < NOW() - INTERVAL 1 MINUTE
+						)
 				)
 			)
 			OR (

--- a/pkg/storage/mysqlstore/apply_operations_test.go
+++ b/pkg/storage/mysqlstore/apply_operations_test.go
@@ -785,6 +785,68 @@ func TestApplyOperationStore_FindNextApplyOperation_ClaimsStoppedWithPendingStar
 	assert.WithinDuration(t, time.Now(), persisted.UpdatedAt, 5*time.Second, "heartbeat must be refreshed on re-claim")
 }
 
+// TestApplyOperationStore_FindNextApplyOperation_ClaimsWaitingForDeployWithPendingStart
+// verifies that a deferred deploy start request returns to the operator loop.
+// The claim keeps the operation in waiting_for_deploy so resume can trigger the
+// deferred deploy with the persisted engine context.
+func TestApplyOperationStore_FindNextApplyOperation_ClaimsWaitingForDeployWithPendingStart(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", storage.DatabaseTypeVitess, "staging")
+	apply := createTestApplyWithStateAndEnv(t, store, lock, "apply_op_waiting_deploy_start", 1, state.Apply.WaitingForDeploy, "staging")
+
+	id, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-a", State: state.ApplyOperation.WaitingForDeploy,
+	})
+	require.NoError(t, err)
+	_, err = testDB.ExecContext(ctx, `
+		UPDATE apply_operations
+		SET lease_owner = 'waiting-owner', lease_token = 'waiting-token', lease_acquired_at = NOW() - INTERVAL 2 MINUTE, updated_at = NOW()
+		WHERE id = ?
+	`, id)
+	require.NoError(t, err)
+
+	_, _, err = store.ControlRequests().RequestPending(ctx, &storage.ApplyControlRequest{
+		ApplyID:     apply.ID,
+		Operation:   storage.ControlOperationStart,
+		Status:      storage.ControlRequestPending,
+		RequestedBy: "operator",
+	})
+	require.NoError(t, err)
+
+	claimed, err := store.ApplyOperations().FindNextApplyOperation(ctx, "test-operator")
+	require.NoError(t, err)
+	require.NotNil(t, claimed, "waiting-for-deploy operation with a pending start request must be reclaimable")
+	assert.Equal(t, id, claimed.ID)
+	assert.Equal(t, state.ApplyOperation.WaitingForDeploy, claimed.State)
+	assert.Equal(t, "test-operator", claimed.LeaseOwner)
+	assert.NotEmpty(t, claimed.LeaseToken)
+
+	persisted, err := store.ApplyOperations().Get(ctx, id)
+	require.NoError(t, err)
+	require.NotNil(t, persisted)
+	assert.Equal(t, state.ApplyOperation.WaitingForDeploy, persisted.State)
+	assert.Equal(t, "test-operator", persisted.LeaseOwner)
+	assert.Equal(t, claimed.LeaseToken, persisted.LeaseToken)
+	assert.WithinDuration(t, time.Now(), persisted.UpdatedAt, 5*time.Second, "heartbeat must be refreshed on re-claim")
+
+	claimedAgain, err := store.ApplyOperations().FindNextApplyOperation(ctx, "test-operator")
+	require.NoError(t, err)
+	assert.Nil(t, claimedAgain, "fresh processing lease should prevent another worker from taking the same deferred deploy start request")
+
+	_, err = testDB.ExecContext(ctx, `
+		UPDATE apply_operations SET updated_at = NOW() - INTERVAL 2 MINUTE WHERE id = ?
+	`, id)
+	require.NoError(t, err)
+
+	reclaimed, err := store.ApplyOperations().FindNextApplyOperation(ctx, "recovery-operator")
+	require.NoError(t, err)
+	require.NotNil(t, reclaimed, "stale deferred deploy operation owner should be reclaimable")
+	assert.Equal(t, id, reclaimed.ID)
+}
+
 // TestApplyOperationStore_FindNextApplyOperation_SkipsStoppedWithCompletedStart
 // verifies the claim predicate filters on a *pending* start request: once the
 // start request is no longer pending, the stopped operation is terminal again

--- a/pkg/tern/grpc_client.go
+++ b/pkg/tern/grpc_client.go
@@ -892,6 +892,14 @@ func (c *GRPCClient) resumeApply(ctx context.Context, apply *storage.Apply, scop
 		return err
 	}
 	startRequested := startControlReq != nil
+	if startRequested && state.IsState(apply.State, state.Apply.WaitingForDeploy) {
+		if handled, err := c.processPendingStopControlRequest(ctx, apply, scope); handled || err != nil {
+			return err
+		}
+		if err := c.processPendingStartControlRequest(ctx, apply); err != nil {
+			return err
+		}
+	}
 
 	if apply.ExternalID != "" && state.IsState(apply.State, state.Apply.Pending) && !startRequested {
 		if handled, err := c.processPendingStopControlRequest(ctx, apply, scope); handled || err != nil {
@@ -912,7 +920,7 @@ func (c *GRPCClient) resumeApply(ctx context.Context, apply *storage.Apply, scop
 		if err := c.storage.Applies().Update(ctx, apply); err != nil {
 			return fmt.Errorf("update started gRPC apply %s: %w", apply.ApplyIdentifier, err)
 		}
-		c.logApplyStateTransition(ctx, apply, storage.LogLevelInfo, "Remote apply start requested by scheduler", state.Apply.Pending)
+		c.logApplyStateTransition(ctx, apply, storage.LogLevelInfo, "Remote apply start requested by operator", state.Apply.Pending)
 	}
 
 	// Check the real state from Tern before deciding what to do. Stored state
@@ -927,7 +935,7 @@ func (c *GRPCClient) resumeApply(ctx context.Context, apply *storage.Apply, scop
 		if err == nil {
 			if resp.State == ternv1.State_STATE_NO_ACTIVE_CHANGE {
 				message := fmt.Sprintf("remote apply %s returned no active schema change for exact apply_id during stopped-state check", apply.ExternalID)
-				slog.Warn("remote gRPC stopped-state check returned no active schema change; scheduler will not request remote start",
+				slog.Warn("remote gRPC stopped-state check returned no active schema change; operator will not request remote start",
 					"apply_id", apply.ApplyIdentifier,
 					"external_id", apply.ExternalID,
 					"database", apply.Database,
@@ -937,8 +945,8 @@ func (c *GRPCClient) resumeApply(ctx context.Context, apply *storage.Apply, scop
 			}
 			remoteState := ProtoStateToStorage(resp.State)
 			if remoteState == "" {
-				message := fmt.Sprintf("Remote stopped-state check returned unmapped state %s; scheduler will not request remote start", remoteApplyStateDescription(resp.State))
-				slog.Warn("remote gRPC stopped-state check returned unmapped state; scheduler will not request remote start",
+				message := fmt.Sprintf("Remote stopped-state check returned unmapped state %s; operator will not request remote start", remoteApplyStateDescription(resp.State))
+				slog.Warn("remote gRPC stopped-state check returned unmapped state; operator will not request remote start",
 					"apply_id", apply.ApplyIdentifier,
 					"external_id", apply.ExternalID,
 					"database", apply.Database,
@@ -970,8 +978,8 @@ func (c *GRPCClient) resumeApply(ctx context.Context, apply *storage.Apply, scop
 				}
 				return fmt.Errorf("check stopped gRPC apply %s before start: %w", apply.ApplyIdentifier, err)
 			}
-			message := fmt.Sprintf("Remote stopped-state check failed before scheduler start: %v", err)
-			slog.Warn("remote gRPC stopped-state check failed; scheduler will not request remote start",
+			message := fmt.Sprintf("Remote stopped-state check failed before operator start: %v", err)
+			slog.Warn("remote gRPC stopped-state check failed; operator will not request remote start",
 				"apply_id", apply.ApplyIdentifier,
 				"external_id", apply.ExternalID,
 				"database", apply.Database,
@@ -1028,13 +1036,77 @@ func (c *GRPCClient) resumeApply(ctx context.Context, apply *storage.Apply, scop
 			}
 		}
 		if remoteStartRequested {
-			c.logApplyStateTransition(ctx, apply, storage.LogLevelInfo, "Remote apply start requested by scheduler", oldState)
+			c.logApplyStateTransition(ctx, apply, storage.LogLevelInfo, "Remote apply start requested by operator", oldState)
 		} else if oldState != apply.State {
-			c.logApplyStateTransition(ctx, apply, storage.LogLevelInfo, fmt.Sprintf("Remote apply state refreshed before scheduler start: %s -> %s", oldState, apply.State), oldState)
+			c.logApplyStateTransition(ctx, apply, storage.LogLevelInfo, fmt.Sprintf("Remote apply state refreshed before operator start: %s -> %s", oldState, apply.State), oldState)
 		}
 	}
 
 	return c.pollForCompletion(ctx, apply, startRequested, scope)
+}
+
+func (c *GRPCClient) processPendingStartControlRequest(ctx context.Context, apply *storage.Apply) error {
+	controlReq, err := pendingStartControlRequest(ctx, c.storage, apply)
+	if err != nil {
+		return err
+	}
+	if controlReq == nil {
+		return nil
+	}
+	if stopReq, err := pendingStopControlRequest(ctx, c.storage, apply); err != nil {
+		return fmt.Errorf("check pending stop before pending gRPC start for apply %s: %w", apply.ApplyIdentifier, err)
+	} else if stopReq != nil {
+		slog.Info("pending gRPC start request is waiting for pending stop request to finish",
+			"apply_id", apply.ApplyIdentifier,
+			"external_id", apply.ExternalID,
+			"database", apply.Database,
+			"environment", apply.Environment,
+			"requested_by", controlRequestCaller(controlReq),
+			"stop_requested_by", controlRequestCaller(stopReq),
+			"state", apply.State)
+		return nil
+	}
+	if !state.IsState(apply.State, state.Apply.WaitingForDeploy) {
+		return nil
+	}
+	if apply.ExternalID == "" {
+		message := fmt.Sprintf("gRPC apply %s is waiting for deploy without external_id; start dispatch state is ambiguous", apply.ApplyIdentifier)
+		if err := failPendingStartControlRequests(ctx, c.storage, apply, message); err != nil {
+			return err
+		}
+		return errors.New(message)
+	}
+	_, err = c.client.Start(ctx, &ternv1.StartRequest{
+		ApplyId:     apply.ExternalID,
+		Environment: apply.Environment,
+	})
+	if err != nil {
+		message := fmt.Sprintf("remote deferred deploy start failed for remote apply %s: %v", apply.ExternalID, err)
+		slog.Warn("remote gRPC deferred deploy start failed; storing start request failure",
+			"apply_id", apply.ApplyIdentifier,
+			"external_id", apply.ExternalID,
+			"database", apply.Database,
+			"environment", apply.Environment,
+			"error", err)
+		if failErr := failPendingStartControlRequests(ctx, c.storage, apply, message); failErr != nil {
+			return failErr
+		}
+		return fmt.Errorf("start gRPC deferred deploy %s: %w", apply.ApplyIdentifier, err)
+	}
+	now := time.Now()
+	oldState := apply.State
+	apply.State = state.Apply.Running
+	if apply.StartedAt == nil {
+		apply.StartedAt = &now
+	}
+	if err := c.storage.Applies().Update(ctx, apply); err != nil {
+		return fmt.Errorf("update started gRPC deferred deploy %s: %w", apply.ApplyIdentifier, err)
+	}
+	if err := completePendingStartControlRequests(ctx, c.storage, apply); err != nil {
+		return err
+	}
+	c.logApplyStateTransition(ctx, apply, storage.LogLevelInfo, fmt.Sprintf("Remote deferred deploy start requested%s", callerApplyLogSuffix(controlRequestCaller(controlReq))), oldState)
+	return nil
 }
 
 func shouldDispatchQueuedRemoteApply(apply *storage.Apply) bool {
@@ -1769,8 +1841,8 @@ func (c *GRPCClient) pollForCompletion(ctx context.Context, apply *storage.Apply
 			oldApplyState := apply.State
 			newState := ProtoStateToStorage(resp.State)
 			if newState == "" {
-				message := fmt.Sprintf("Remote progress returned unmapped apply state %s; scheduler will retry without changing stored state", remoteApplyStateDescription(resp.State))
-				slog.Warn("remote gRPC progress returned unmapped apply state; scheduler will retry without changing stored state",
+				message := fmt.Sprintf("Remote progress returned unmapped apply state %s; operator will retry without changing stored state", remoteApplyStateDescription(resp.State))
+				slog.Warn("remote gRPC progress returned unmapped apply state; operator will retry without changing stored state",
 					"apply_id", apply.ApplyIdentifier,
 					"external_id", apply.ExternalID,
 					"database", apply.Database,
@@ -1785,6 +1857,11 @@ func (c *GRPCClient) pollForCompletion(ctx context.Context, apply *storage.Apply
 				apply.StartedAt = &now
 			}
 			remoteApplyState := newState
+			if allowStoppedAfterStart && state.IsState(remoteApplyState, state.Apply.Stopped) {
+				if terminalTaskState, ok := terminalApplyStateFromRemoteTaskProgress(resp.Tables); ok {
+					remoteApplyState = terminalTaskState
+				}
+			}
 			if allowStoppedAfterStart && state.IsState(remoteApplyState, state.Apply.Stopped) {
 				if stoppedAfterStartDeadline.IsZero() {
 					stoppedAfterStartDeadline = now.Add(grpcStoppedAfterStartGracePeriod)
@@ -1854,4 +1931,23 @@ func (c *GRPCClient) pollForCompletion(ctx context.Context, apply *storage.Apply
 			}
 		}
 	}
+}
+
+func terminalApplyStateFromRemoteTaskProgress(remoteTasks []*ternv1.TableProgress) (string, bool) {
+	if len(remoteTasks) == 0 {
+		return "", false
+	}
+	taskStates := make([]string, 0, len(remoteTasks))
+	for _, remoteTask := range remoteTasks {
+		if remoteTask == nil {
+			return "", false
+		}
+		remoteTaskState := state.NormalizeTaskStatus(remoteTask.Status)
+		if !state.IsTerminalTaskState(remoteTaskState) {
+			return "", false
+		}
+		taskStates = append(taskStates, remoteTaskState)
+	}
+	derivedState := state.DeriveApplyState(taskStates)
+	return derivedState, state.IsTerminalApplyState(derivedState)
 }

--- a/pkg/tern/grpc_client_test.go
+++ b/pkg/tern/grpc_client_test.go
@@ -1286,6 +1286,51 @@ func TestGRPCClient_ProgressPollBoundsStoppedAfterStart(t *testing.T) {
 	assert.True(t, hasLogMessageContaining(logs.logs, "Remote apply reached terminal state: stopped"))
 }
 
+func TestGRPCClient_ProgressPollAdoptsTerminalTablesAfterStart(t *testing.T) {
+	server := &capturingTernServer{
+		progressState:    ternv1.State_STATE_STOPPED,
+		progressStateSet: true,
+		progressTables: []*ternv1.TableProgress{{
+			Namespace:       "default",
+			TableName:       "users",
+			Status:          state.Task.Completed,
+			PercentComplete: 100,
+		}},
+	}
+	client, cleanup := testCapturingGRPCClient(t, server)
+	defer cleanup()
+
+	apply := &storage.Apply{
+		ID:              27,
+		ApplyIdentifier: "apply-stopped-with-completed-table",
+		Database:        "testdb",
+		DatabaseType:    storage.DatabaseTypeVitess,
+		Deployment:      "us-west",
+		Environment:     "staging",
+		ExternalID:      "remote-stopped-with-completed-table",
+		State:           state.Apply.Running,
+	}
+	storedApply := *apply
+	task := &storage.Task{
+		ID:             33,
+		TaskIdentifier: "task-stopped-with-completed-table",
+		ApplyID:        apply.ID,
+		Namespace:      "default",
+		TableName:      "users",
+		State:          state.Task.Running,
+	}
+	client.storage = &mockStorage{
+		applies: &mockApplyStore{apply: &storedApply},
+		tasks:   &mockTaskStore{tasks: []*storage.Task{task}},
+		logs:    &mockApplyLogStore{},
+	}
+
+	err := client.pollForCompletion(t.Context(), apply, true, wholeApplyTaskScope())
+	require.NoError(t, err)
+	assert.Equal(t, state.Apply.Completed, apply.State)
+	assert.Equal(t, state.Task.Completed, task.State)
+}
+
 func TestGRPCClient_ResumeApplyDoesNotRegressRunningApplyToPendingProgress(t *testing.T) {
 	// A freshly dispatched remote apply can report pending before the remote
 	// engine starts copying rows. SchemaBot has already claimed the queued apply
@@ -2149,6 +2194,44 @@ func TestGRPCClient_ResumeApplyStartsQueuedStartAfterClaim(t *testing.T) {
 	assert.Nil(t, controlReq)
 }
 
+func TestGRPCClient_ResumeApplyStartsDeferredDeployFromPendingRequest(t *testing.T) {
+	server := &capturingTernServer{
+		progressState:    ternv1.State_STATE_COMPLETED,
+		progressStateSet: true,
+	}
+	client, cleanup := testCapturingGRPCClient(t, server)
+	defer cleanup()
+
+	apply := &storage.Apply{
+		ID:              1,
+		ApplyIdentifier: "apply-start-deploy",
+		Database:        "testdb",
+		Environment:     "staging",
+		ExternalID:      "remote-start-deploy",
+		State:           state.Apply.WaitingForDeploy,
+	}
+	storedApply := *apply
+	controlRequests := &testControlRequestStore{requests: []*storage.ApplyControlRequest{{
+		ApplyID:   apply.ID,
+		Operation: storage.ControlOperationStart,
+		Status:    storage.ControlRequestPending,
+	}}}
+	client.storage = &mockStorage{
+		applies:         &mockApplyStore{apply: &storedApply},
+		tasks:           &mockTaskStore{},
+		logs:            &mockApplyLogStore{},
+		controlRequests: controlRequests,
+	}
+
+	err := client.ResumeApply(t.Context(), apply)
+	require.NoError(t, err)
+
+	assert.Equal(t, "remote-start-deploy", server.getStartApplyID())
+	controlReq, err := controlRequests.GetPending(t.Context(), apply.ID, storage.ControlOperationStart)
+	require.NoError(t, err)
+	assert.Nil(t, controlReq)
+}
+
 func TestGRPCClient_ResumeApplyStartErrorLeavesApplyStopped(t *testing.T) {
 	// When the operator accepts a stored start request but remote Tern rejects
 	// the Start RPC, keep the apply stopped with a visible reason and leave the
@@ -2694,7 +2777,7 @@ func TestGRPCClient_ResumeApplyDoesNotStartWhenStoppedStateCheckFails(t *testing
 	server.mu.Unlock()
 	assert.False(t, startCalled, "Start should not be called when the remote state check fails")
 	assert.Equal(t, state.Apply.Stopped, apply.State)
-	assert.True(t, hasLogMessageContaining(logs.logs, "Remote stopped-state check failed before scheduler start"))
+	assert.True(t, hasLogMessageContaining(logs.logs, "Remote stopped-state check failed before operator start"))
 }
 
 func TestGRPCClient_ResumeApplyFailsWhenStoppedRemoteHasNoActiveProgress(t *testing.T) {

--- a/pkg/tern/local_client_test.go
+++ b/pkg/tern/local_client_test.go
@@ -91,6 +91,7 @@ func (s *exactProgressTaskStore) Update(context.Context, *storage.Task) error {
 type fakeControlEngine struct {
 	engine.Engine
 	stopCount      int
+	startCount     int
 	cutoverCount   int
 	cutoverResult  *engine.ControlResult
 	cutoverErr     error
@@ -123,6 +124,7 @@ func (e *fakeControlEngine) Stop(context.Context, *engine.ControlRequest) (*engi
 }
 
 func (e *fakeControlEngine) Start(context.Context, *engine.ControlRequest) (*engine.ControlResult, error) {
+	e.startCount++
 	return &engine.ControlResult{Accepted: true}, nil
 }
 
@@ -527,6 +529,112 @@ func TestLocalClient_ProcessPendingStopControlRequest(t *testing.T) {
 	require.NoError(t, err)
 	assert.Nil(t, controlReq)
 	assert.True(t, hasLogMessageContaining(logs.logs, "Stop requested: 1 tasks stopped, 0 skipped (caller: cli:alice)"))
+}
+
+func TestLocalClient_ProcessPendingStartControlRequestWaitsForPendingStop(t *testing.T) {
+	apply := &storage.Apply{
+		ID:              123,
+		ApplyIdentifier: "apply-start-after-stop",
+		Database:        "testdb",
+		DatabaseType:    storage.DatabaseTypeMySQL,
+		Environment:     "staging",
+		State:           state.Apply.WaitingForDeploy,
+	}
+	task := &storage.Task{
+		ID:             456,
+		ApplyID:        apply.ID,
+		TaskIdentifier: "task-start-after-stop",
+		Database:       "testdb",
+		DatabaseType:   storage.DatabaseTypeMySQL,
+		TableName:      "users",
+		State:          state.Task.WaitingForDeploy,
+	}
+	controlRequests := &testControlRequestStore{requests: []*storage.ApplyControlRequest{
+		{
+			ApplyID:     apply.ID,
+			Operation:   storage.ControlOperationStop,
+			Status:      storage.ControlRequestPending,
+			RequestedBy: "cli:stopper",
+		},
+		{
+			ApplyID:     apply.ID,
+			Operation:   storage.ControlOperationStart,
+			Status:      storage.ControlRequestPending,
+			RequestedBy: "cli:starter",
+		},
+	}}
+	fakeEngine := &fakeControlEngine{progressResult: &engine.ProgressResult{State: engine.StateCompleted}}
+	client := &LocalClient{
+		config: LocalConfig{
+			Database: "testdb",
+			Type:     storage.DatabaseTypeMySQL,
+		},
+		storage: &exactProgressStorage{
+			applies:         &exactProgressApplyStore{apply: apply},
+			tasks:           &exactProgressTaskStore{tasks: []*storage.Task{task}},
+			controlRequests: controlRequests,
+		},
+		spiritEngine: fakeEngine,
+		logger:       slog.Default(),
+	}
+
+	handled, err := client.processPendingStartControlRequest(t.Context(), apply)
+	require.NoError(t, err)
+	assert.False(t, handled)
+	assert.Equal(t, 0, fakeEngine.startCount, "pending stop must win before start is processed")
+	startReq, err := controlRequests.GetPending(t.Context(), apply.ID, storage.ControlOperationStart)
+	require.NoError(t, err)
+	assert.NotNil(t, startReq, "start request remains pending until stop is resolved")
+}
+
+func TestLocalClient_ProcessPendingStartControlRequestStartsDeferredDeploy(t *testing.T) {
+	apply := &storage.Apply{
+		ID:              123,
+		ApplyIdentifier: "apply-deferred-start",
+		Database:        "testdb",
+		DatabaseType:    storage.DatabaseTypeMySQL,
+		Environment:     "staging",
+		State:           state.Apply.WaitingForDeploy,
+	}
+	task := &storage.Task{
+		ID:             456,
+		ApplyID:        apply.ID,
+		TaskIdentifier: "task-deferred-start",
+		Database:       "testdb",
+		DatabaseType:   storage.DatabaseTypeMySQL,
+		TableName:      "users",
+		State:          state.Task.WaitingForDeploy,
+	}
+	controlRequests := &testControlRequestStore{requests: []*storage.ApplyControlRequest{{
+		ApplyID:     apply.ID,
+		Operation:   storage.ControlOperationStart,
+		Status:      storage.ControlRequestPending,
+		RequestedBy: "cli:starter",
+	}}}
+	fakeEngine := &fakeControlEngine{progressResult: &engine.ProgressResult{State: engine.StateCompleted}}
+	client := &LocalClient{
+		config: LocalConfig{
+			Database: "testdb",
+			Type:     storage.DatabaseTypeMySQL,
+		},
+		storage: &exactProgressStorage{
+			applies:         &exactProgressApplyStore{apply: apply},
+			tasks:           &exactProgressTaskStore{tasks: []*storage.Task{task}},
+			logs:            &mockApplyLogStore{},
+			controlRequests: controlRequests,
+		},
+		spiritEngine: fakeEngine,
+		logger:       slog.Default(),
+	}
+
+	handled, err := client.processPendingStartControlRequest(t.Context(), apply)
+	require.NoError(t, err)
+	assert.True(t, handled)
+	assert.Equal(t, 1, fakeEngine.startCount)
+	assert.Equal(t, state.Apply.Completed, apply.State)
+	startReq, err := controlRequests.GetPending(t.Context(), apply.ID, storage.ControlOperationStart)
+	require.NoError(t, err)
+	assert.Nil(t, startReq)
 }
 
 // A revert-window apply has already cut over, so a durable stop request against

--- a/pkg/tern/local_control_resume.go
+++ b/pkg/tern/local_control_resume.go
@@ -73,19 +73,6 @@ func (c *LocalClient) Start(ctx context.Context, req *ternv1.StartRequest) (*ter
 	// Deferred deploy: call engine Start to trigger the deploy request.
 	// This is a separate path from the stopped-task resume flow below.
 	if apply.State == state.Apply.WaitingForDeploy {
-		applyTasks, taskErr := c.storage.Tasks().GetByApplyID(ctx, apply.ID)
-		if taskErr != nil || len(applyTasks) == 0 {
-			return nil, fmt.Errorf("no tasks found for apply %s", apply.ApplyIdentifier)
-		}
-		creds := c.credentials()
-		eng := c.getEngine()
-		if eng == nil {
-			return nil, fmt.Errorf("no engine configured for type: %s", c.config.Type)
-		}
-		controlReq, err := c.buildControlRequest(ctx, applyTasks[0], creds, eng, engine.ControlStart)
-		if err != nil {
-			return nil, fmt.Errorf("build deferred deploy request for task %s: %w", applyTasks[0].TaskIdentifier, err)
-		}
 		if controlReq, err := pendingStopControlRequest(ctx, c.storage, apply); err != nil {
 			return nil, fmt.Errorf("check pending stop before deferred deploy start for apply %s: %w", apply.ApplyIdentifier, err)
 		} else if controlReq != nil {
@@ -94,17 +81,11 @@ func (c *LocalClient) Start(ctx context.Context, req *ternv1.StartRequest) (*ter
 				"requested_by", controlRequestCaller(controlReq))
 			return nil, fmt.Errorf("schema change has a pending stop request; start is blocked until stop is processed")
 		}
-		result, err := eng.Start(ctx, controlReq)
+		started, err := c.startDeferredDeploy(ctx, apply, "")
 		if err != nil {
-			return nil, fmt.Errorf("start deferred deploy: %w", err)
+			return nil, err
 		}
-		if !result.Accepted {
-			return nil, fmt.Errorf("deferred deploy not accepted: %s", result.Message)
-		}
-		return &ternv1.StartResponse{
-			Accepted:     true,
-			StartedCount: 1,
-		}, nil
+		return started.response, nil
 	}
 
 	// Second pass: collect stopped tasks ONLY from the target apply
@@ -208,6 +189,116 @@ func (c *LocalClient) Start(ctx context.Context, req *ternv1.StartRequest) (*ter
 		StartedCount: int64(len(resumeTasks)),
 		SkippedCount: completedCount,
 	}, nil
+}
+
+type deferredDeployStart struct {
+	response    *ternv1.StartResponse
+	tasks       []*storage.Task
+	credentials *engine.Credentials
+	resumeState *engine.ResumeState
+}
+
+func (c *LocalClient) startDeferredDeploy(ctx context.Context, apply *storage.Apply, caller string) (*deferredDeployStart, error) {
+	applyTasks, taskErr := c.storage.Tasks().GetByApplyID(ctx, apply.ID)
+	if taskErr != nil {
+		return nil, fmt.Errorf("get tasks for deferred deploy apply %s: %w", apply.ApplyIdentifier, taskErr)
+	}
+	if len(applyTasks) == 0 {
+		return nil, fmt.Errorf("no tasks found for apply %s", apply.ApplyIdentifier)
+	}
+	creds := c.credentials()
+	eng := c.getEngine()
+	if eng == nil {
+		return nil, fmt.Errorf("no engine configured for type: %s", c.config.Type)
+	}
+	controlReq, err := c.buildControlRequest(ctx, applyTasks[0], creds, eng, engine.ControlStart)
+	if err != nil {
+		return nil, fmt.Errorf("build deferred deploy request for task %s: %w", applyTasks[0].TaskIdentifier, err)
+	}
+	result, err := eng.Start(ctx, controlReq)
+	if err != nil {
+		return nil, fmt.Errorf("start deferred deploy: %w", err)
+	}
+	if !result.Accepted {
+		return nil, fmt.Errorf("deferred deploy not accepted: %s", result.Message)
+	}
+	logMessage := "Deferred deploy start requested"
+	if caller != "" {
+		logMessage += callerApplyLogSuffix(caller)
+	}
+	c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventStartRequested, storage.LogSourceSchemaBot,
+		logMessage, state.Apply.WaitingForDeploy, state.Apply.Running)
+	return &deferredDeployStart{
+		response: &ternv1.StartResponse{
+			Accepted:     true,
+			StartedCount: 1,
+		},
+		tasks:       applyTasks,
+		credentials: creds,
+		resumeState: controlReq.ResumeState,
+	}, nil
+}
+
+func (c *LocalClient) processPendingStartControlRequest(ctx context.Context, apply *storage.Apply) (bool, error) {
+	controlReq, err := pendingStartControlRequest(ctx, c.storage, apply)
+	if err != nil {
+		return false, err
+	}
+	if controlReq == nil {
+		return false, nil
+	}
+	if stopReq, err := pendingStopControlRequest(ctx, c.storage, apply); err != nil {
+		return true, fmt.Errorf("check pending stop before pending start for apply %s: %w", apply.ApplyIdentifier, err)
+	} else if stopReq != nil {
+		c.logger.Info("pending start request is waiting for pending stop request to finish",
+			"apply_id", apply.ApplyIdentifier,
+			"database", apply.Database,
+			"environment", apply.Environment,
+			"requested_by", controlRequestCaller(controlReq),
+			"stop_requested_by", controlRequestCaller(stopReq),
+			"state", apply.State)
+		return false, nil
+	}
+	if !state.IsState(apply.State, state.Apply.WaitingForDeploy) {
+		return false, nil
+	}
+	started, err := c.startDeferredDeploy(ctx, apply, controlRequestCaller(controlReq))
+	if err != nil {
+		if failErr := failPendingStartControlRequests(ctx, c.storage, apply, err.Error()); failErr != nil {
+			return true, fmt.Errorf("process pending start for apply %s: %w; fail pending start request: %w", apply.ApplyIdentifier, err, failErr)
+		}
+		return true, fmt.Errorf("process pending start for apply %s: %w", apply.ApplyIdentifier, err)
+	}
+	resp := started.response
+	if resp == nil || !resp.Accepted {
+		errorMessage := "not accepted"
+		if resp != nil && resp.ErrorMessage != "" {
+			errorMessage = resp.ErrorMessage
+		}
+		if err := failPendingStartControlRequests(ctx, c.storage, apply, errorMessage); err != nil {
+			return true, err
+		}
+		return true, fmt.Errorf("process pending start for apply %s: %s", apply.ApplyIdentifier, errorMessage)
+	}
+	now := time.Now()
+	apply.State = state.Apply.Running
+	if apply.StartedAt == nil {
+		apply.StartedAt = &now
+	}
+	if err := c.storage.Applies().Update(ctx, apply); err != nil {
+		return true, fmt.Errorf("update started deferred deploy apply %s: %w", apply.ApplyIdentifier, err)
+	}
+	if err := completePendingStartControlRequests(ctx, c.storage, apply); err != nil {
+		return true, err
+	}
+	c.logger.Info("pending start request accepted and completed",
+		"apply_id", apply.ApplyIdentifier,
+		"database", apply.Database,
+		"environment", apply.Environment,
+		"requested_by", controlRequestCaller(controlReq),
+		"state", apply.State)
+	c.pollForCompletionAtomic(ctx, apply, started.tasks, started.credentials, started.resumeState)
+	return true, ctx.Err()
 }
 
 // resumeApplySequential processes resumed tasks one at a time in sequence.
@@ -656,6 +747,9 @@ func (c *LocalClient) resumeApplyWithTasks(ctx context.Context, apply *storage.A
 	}
 
 	if handled, err := c.processPendingStopControlRequest(ctx, apply); handled || err != nil {
+		return err
+	}
+	if handled, err := c.processPendingStartControlRequest(ctx, apply); handled || err != nil {
 		return err
 	}
 


### PR DESCRIPTION
## Why
Deferred deploy starts should survive process restarts and be owned by the operator loop instead of depending on the HTTP request path or an already-active poller.

## What
- Queue deferred deploy starts as durable start control requests
- Make waiting-for-deploy start requests claimable by the operator with lease-generation gating
- Process queued deferred starts from resume paths for local and remote applies

## Risk Assessment
Medium — this changes control flow for deferred deploy start handling, but it stays within the existing durable control-request and operator-lease model.

Generated with Amp
