### PR TITLE
fix(github): show source policy config errors

### DIFF
--- a/pkg/webhook/error_comment.go
+++ b/pkg/webhook/error_comment.go
@@ -41,6 +41,9 @@ func (h *Handler) postCommandError(
 }
 
 func userFacingError(err error) string {
+	if message, ok := userFacingConfigNotAuthorizedError(err); ok {
+		return message
+	}
 	var remoteErr *api.RemoteDeploymentUnavailableError
 	if errors.As(err, &remoteErr) {
 		return userFacingRemoteUnavailableError(remoteErr.Deployment, remoteErr.Target, err.Error())
@@ -49,6 +52,18 @@ func userFacingError(err error) string {
 		return userFacingRemoteUnavailableError("", "", err.Error())
 	}
 	return err.Error()
+}
+
+func userFacingConfigNotAuthorizedError(err error) (string, bool) {
+	var configErr *schemaConfigOutsideAllowedDirsError
+	if !errors.As(err, &configErr) {
+		return "", false
+	}
+	return strings.Join([]string{
+		"SchemaBot found a `schemabot.yaml` configuration, but this SchemaBot instance is not configured to manage its schema directory.",
+		"Schema directory: `" + configErr.SchemaPath + "`.",
+		"Ask a SchemaBot operator to add this directory to `databases." + configErr.Database + ".allowed_dirs` in the server config, or move the schema config and files under an allowed directory.",
+	}, " "), true
 }
 
 func userFacingErrorDetail(errorDetail string) string {

--- a/pkg/webhook/handler_test.go
+++ b/pkg/webhook/handler_test.go
@@ -209,6 +209,31 @@ func TestRenderPRCommentSupportChannelFooter(t *testing.T) {
 	})
 }
 
+func TestHandleSchemaRequestErrorRendersConfigNotAuthorized(t *testing.T) {
+	client, mux := setupGitHubServer(t)
+	comments := make(chan string, 1)
+	mux.HandleFunc("POST /repos/octocat/hello-world/issues/1/comments", commentRecorder(t, comments))
+
+	installClient := ghclient.NewInstallationClient(client, testLogger())
+	h := &Handler{
+		ghClients: ghclient.NewSingleClientSet(defaultAppName, &fakeClientFactory{client: installClient}),
+		logger:    testLogger(),
+	}
+
+	h.handleSchemaRequestError("octocat/hello-world", 1, 12345, "production", "", "hubot", "apply", &schemaConfigOutsideAllowedDirsError{
+		Database:     "orders",
+		DatabaseType: "mysql",
+		SchemaPath:   "services/orders/schema",
+	})
+
+	body := requireComment(t, comments, "config-not-authorized comment")
+	assert.Contains(t, body, "SchemaBot Configuration Not Authorized")
+	assert.Contains(t, body, "SchemaBot found a `schemabot.yaml` configuration")
+	assert.Contains(t, body, "`services/orders/schema`")
+	assert.Contains(t, body, "`databases.orders.allowed_dirs`")
+	assert.NotContains(t, body, "No `schemabot.yaml` configuration file was found")
+}
+
 func TestCheckRunRerequestIgnoresNonSchemaBotCheck(t *testing.T) {
 	h, _, _ := newTestHandler(t)
 

--- a/pkg/webhook/plan.go
+++ b/pkg/webhook/plan.go
@@ -152,7 +152,7 @@ func (h *Handler) handleMultiEnvPlan(repo string, pr int, databaseName string, i
 			return
 		}
 		if !h.configPathManagedByRepo(ctx, repo, pr, "", config, configDir, action.Plan) {
-			h.handleSchemaRequestError(repo, pr, installationID, "", databaseName, requestedBy, action.Plan, ghclient.ErrNoConfig)
+			h.handleSchemaRequestError(repo, pr, installationID, "", databaseName, requestedBy, action.Plan, newSchemaConfigOutsideAllowedDirsError(config, configDir))
 			return
 		}
 		schemaDatabase = config.Database
@@ -163,7 +163,7 @@ func (h *Handler) handleMultiEnvPlan(repo string, pr int, databaseName string, i
 			return
 		}
 		if !h.configPathManagedByRepo(ctx, repo, pr, "", config, configDir, action.Plan) {
-			h.handleSchemaRequestError(repo, pr, installationID, "", databaseName, requestedBy, action.Plan, ghclient.ErrNoConfig)
+			h.handleSchemaRequestError(repo, pr, installationID, "", databaseName, requestedBy, action.Plan, newSchemaConfigOutsideAllowedDirsError(config, configDir))
 			return
 		}
 		schemaDatabase = config.Database
@@ -372,6 +372,19 @@ func (h *Handler) handleSchemaRequestError(repo string, pr int, installationID i
 		h.logger.Warn("schema request: database not found", logFields...)
 		metrics.RecordSchemaRequestError(ctx, repo, commandName, databaseName, environment, "database_not_found")
 		h.postComment(repo, pr, installationID, templates.RenderDatabaseNotFound(data))
+		return
+	}
+
+	var configNotAuthorizedErr *schemaConfigOutsideAllowedDirsError
+	if errors.As(err, &configNotAuthorizedErr) {
+		data.DatabaseName = configNotAuthorizedErr.Database
+		data.SchemaPath = configNotAuthorizedErr.SchemaPath
+		h.logger.Warn("schema request: config outside allowed_dirs",
+			"repo", repo, "pr", pr, "environment", environment,
+			"database", data.DatabaseName, "database_type", configNotAuthorizedErr.DatabaseType,
+			"schema_path", data.SchemaPath, "action", commandName, "error", err)
+		metrics.RecordSchemaRequestError(ctx, repo, commandName, data.DatabaseName, environment, "config_not_authorized")
+		h.postComment(repo, pr, installationID, templates.RenderConfigNotAuthorized(data))
 		return
 	}
 

--- a/pkg/webhook/plan_test.go
+++ b/pkg/webhook/plan_test.go
@@ -254,6 +254,20 @@ func TestUserFacingErrorPreservesNonGRPCErrors(t *testing.T) {
 	assert.Equal(t, "invalid DDL", got)
 }
 
+func TestUserFacingErrorExplainsConfigOutsideAllowedDirs(t *testing.T) {
+	err := &schemaConfigOutsideAllowedDirsError{
+		Database:     "orders",
+		DatabaseType: "mysql",
+		SchemaPath:   "services/orders/schema",
+	}
+
+	got := userFacingError(err)
+
+	assert.Contains(t, got, "SchemaBot found a `schemabot.yaml` configuration")
+	assert.Contains(t, got, "Schema directory: `services/orders/schema`")
+	assert.Contains(t, got, "`databases.orders.allowed_dirs`")
+}
+
 func TestUserFacingErrorDetailDoesNotWrapFormattedRemoteErrors(t *testing.T) {
 	formatted := "SchemaBot could not reach the remote deployment `pie` for target `orders-staging`. No healthy upstream is available. Raw error: rpc error: code = Unavailable desc = no healthy upstream"
 

--- a/pkg/webhook/schema_source_policy.go
+++ b/pkg/webhook/schema_source_policy.go
@@ -2,10 +2,32 @@ package webhook
 
 import (
 	"context"
+	"fmt"
 
 	ghclient "github.com/block/schemabot/pkg/github"
 	"github.com/block/schemabot/pkg/metrics"
 )
+
+type schemaConfigOutsideAllowedDirsError struct {
+	Database     string
+	DatabaseType string
+	SchemaPath   string
+}
+
+func (e *schemaConfigOutsideAllowedDirsError) Error() string {
+	return fmt.Sprintf("schema config for database %q at %q is outside server allowed_dirs", e.Database, e.SchemaPath)
+}
+
+func newSchemaConfigOutsideAllowedDirsError(config *ghclient.SchemabotConfig, schemaPath string) error {
+	if config == nil {
+		return ghclient.ErrNoConfig
+	}
+	return &schemaConfigOutsideAllowedDirsError{
+		Database:     config.Database,
+		DatabaseType: string(config.GetType()),
+		SchemaPath:   schemaPath,
+	}
+}
 
 func (h *Handler) createManagedSchemaRequestFromPR(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, environment, databaseName, source string) (*ghclient.SchemaRequestResult, error) {
 	schemaResult, err := client.CreateSchemaRequestFromPR(ctx, repo, pr, environment, databaseName)
@@ -13,7 +35,11 @@ func (h *Handler) createManagedSchemaRequestFromPR(ctx context.Context, client *
 		return nil, err
 	}
 	if !h.shouldProcessSchemaConfig(ctx, repo, pr, schemaResult.HeadSHA, schemaResult.Database, schemaResult.Type, schemaResult.SchemaPath, source) {
-		return nil, ghclient.ErrNoConfig
+		return nil, &schemaConfigOutsideAllowedDirsError{
+			Database:     schemaResult.Database,
+			DatabaseType: schemaResult.Type,
+			SchemaPath:   schemaResult.SchemaPath,
+		}
 	}
 	return schemaResult, nil
 }

--- a/pkg/webhook/templates/errors.go
+++ b/pkg/webhook/templates/errors.go
@@ -12,6 +12,7 @@ type SchemaErrorData struct {
 	Timestamp          string
 	Environment        string
 	DatabaseName       string
+	SchemaPath         string
 	CommandName        string // "plan" or "apply"
 	ErrorDetail        string
 	AvailableDatabases string
@@ -82,6 +83,18 @@ database: {{.DatabaseName}}
 type: mysql
 ` + "```" + ``
 
+const configOutsideAllowedDirsTemplate = `## ⚠️ SchemaBot Configuration Not Authorized
+
+**Database**: ` + "`{{.DatabaseName}}`" + ` | **Environment**: ` + "`{{.Environment}}`" + `
+
+*Requested by @{{.RequestedBy}} at {{.Timestamp}} UTC*
+
+SchemaBot found a ` + "`schemabot.yaml`" + ` configuration, but this SchemaBot instance is not configured to manage its schema directory.
+
+**Schema directory**: ` + "`{{.SchemaPath}}`" + `
+
+Ask a SchemaBot operator to add this directory to ` + "`databases.{{.DatabaseName}}.allowed_dirs`" + ` in the server config, or move the schema config and files under an allowed directory.`
+
 const multipleConfigsTemplate = `## ⚠️ Multiple Databases Detected
 
 **Environment**: ` + "`{{.Environment}}`" + `
@@ -118,6 +131,7 @@ var (
 	tmplInvalidConfig        = template.Must(template.New("invalidConfig").Parse(invalidConfigTemplate))
 	tmplNoConfigNoDatabase   = template.Must(template.New("noConfigNoDatabase").Parse(noConfigNoDatabaseTemplate))
 	tmplNoConfigWithDatabase = template.Must(template.New("noConfigWithDatabase").Parse(noConfigWithDatabaseTemplate))
+	tmplConfigNotAuthorized  = template.Must(template.New("configOutsideAllowedDirs").Parse(configOutsideAllowedDirsTemplate))
 	tmplMultipleConfigs      = template.Must(template.New("multipleConfigs").Parse(multipleConfigsTemplate))
 	tmplGenericError         = template.Must(template.New("genericError").Parse(genericErrorTemplate))
 )
@@ -138,6 +152,12 @@ func RenderNoConfig(data SchemaErrorData) string {
 		return renderTemplate(tmplNoConfigNoDatabase, data)
 	}
 	return renderTemplate(tmplNoConfigWithDatabase, data)
+}
+
+// RenderConfigNotAuthorized renders the error shown when schemabot.yaml exists
+// but its schema directory is outside the server-side allowed_dirs boundary.
+func RenderConfigNotAuthorized(data SchemaErrorData) string {
+	return renderTemplate(tmplConfigNotAuthorized, data)
 }
 
 // RenderMultipleConfigs renders the "multiple configs" error comment.


### PR DESCRIPTION
## Why
When server-side source policy ignores a discovered `schemabot.yaml`, the PR comment currently looks like the configuration is missing. That sends operators and authors toward the wrong fix.

## What
- Return a specific error when a discovered config is outside `allowed_dirs`
- Render a dedicated comment that names the schema directory and server config field to update
- Cover the template selection with a focused webhook test

## Risk Assessment
Low — this only changes PR comment rendering for an existing rejected source-policy path and does not relax any safety checks.

Generated with Amp
