### PR TITLE
fix(plan): ignore archive tables in Spirit plans

### DIFF
--- a/pkg/engine/spirit/spirit.go
+++ b/pkg/engine/spirit/spirit.go
@@ -552,7 +552,8 @@ func progressState(rm *runningMigration, spiritState status.State) engine.State 
 }
 
 // fetchCurrentSchema retrieves table schemas from the database, filtering out
-// internal tables (Spirit shadow/checkpoint tables and other _-prefixed tables).
+// internal tables (Spirit shadow/checkpoint tables and other _-prefixed tables)
+// and archive tables that are maintained outside declarative schema files.
 func (e *Engine) fetchCurrentSchema(ctx context.Context, dsn, _ string) ([]table.TableSchema, error) {
 	db, err := mysqlconn.Open(dsn)
 	if err != nil {
@@ -564,7 +565,7 @@ func (e *Engine) fetchCurrentSchema(ctx context.Context, dsn, _ string) ([]table
 		return nil, fmt.Errorf("ping database: %w", err)
 	}
 
-	tables, err := table.LoadSchemaFromDB(ctx, db, table.WithoutUnderscoreTables)
+	tables, err := table.LoadSchemaFromDB(ctx, db, table.WithoutUnderscoreTables, table.WithoutArchiveTables, table.WithStrippedAutoIncrement)
 	if err != nil {
 		return nil, fmt.Errorf("load schema: %w", err)
 	}

--- a/pkg/engine/spirit/spirit_integration_test.go
+++ b/pkg/engine/spirit/spirit_integration_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	spiritmigration "github.com/block/spirit/pkg/migration"
+	"github.com/block/spirit/pkg/table"
 	"github.com/block/spirit/pkg/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -104,6 +105,14 @@ func TestMain(m *testing.M) {
 // with a single namespace matching the test database name.
 func testSchemaFiles(files map[string]string) schema.SchemaFiles {
 	return schema.SchemaFiles{"testdb": &schema.Namespace{Files: files}}
+}
+
+func tableSchemaNames(schemas []table.TableSchema) []string {
+	names := make([]string, 0, len(schemas))
+	for _, schema := range schemas {
+		names = append(names, schema.Name)
+	}
+	return names
 }
 
 // setupTestMySQL returns a connection to the shared MySQL container.
@@ -608,12 +617,42 @@ func TestEngine_FetchCurrentSchema(t *testing.T) {
 	require.NoError(t, err, "create t1")
 	_, err = db.ExecContext(t.Context(), `CREATE TABLE t2 (id INT PRIMARY KEY, value INT)`)
 	require.NoError(t, err, "create t2")
+	_, err = db.ExecContext(t.Context(), `CREATE TABLE t1_archive_2026_06 (id INT PRIMARY KEY, name VARCHAR(100))`)
+	require.NoError(t, err, "create archive table")
+	_, err = db.ExecContext(t.Context(), `CREATE TABLE _spirit_t1_ghost (id INT PRIMARY KEY, name VARCHAR(100))`)
+	require.NoError(t, err, "create internal table")
 
 	eng := New(Config{})
 	schemas, err := eng.fetchCurrentSchema(t.Context(), dsn, "testdb")
 	require.NoError(t, err, "fetchCurrentSchema()")
 
 	assert.Len(t, schemas, 2)
+	assert.ElementsMatch(t, []string{"t1", "t2"}, tableSchemaNames(schemas))
+}
+
+// Archive tables are maintained outside declarative schema files, so a plan
+// must not propose dropping live archive tables that are absent from Git.
+func TestEngine_Plan_IgnoresArchiveTables(t *testing.T) {
+	dsn, db := setupTestMySQL(t)
+	cleanupTables(t, db)
+
+	_, err := db.ExecContext(t.Context(), `CREATE TABLE executions (id INT PRIMARY KEY, name VARCHAR(100))`)
+	require.NoError(t, err, "create executions")
+	_, err = db.ExecContext(t.Context(), `CREATE TABLE executions_archive_2026_06 (id INT PRIMARY KEY, name VARCHAR(100))`)
+	require.NoError(t, err, "create archive table")
+
+	eng := New(Config{})
+	result, err := eng.Plan(t.Context(), &engine.PlanRequest{
+		Database: "testdb",
+		SchemaFiles: testSchemaFiles(map[string]string{
+			"executions.sql": `CREATE TABLE executions (id INT PRIMARY KEY, name VARCHAR(100))`,
+		}),
+		Credentials: &engine.Credentials{DSN: dsn},
+	})
+	require.NoError(t, err, "Plan()")
+	require.NotNil(t, result)
+
+	assert.True(t, result.NoChanges, "archive tables must not create DROP TABLE plan entries: %v", result.FlatDDL())
 }
 
 func TestEngine_Apply_NoChanges(t *testing.T) {

--- a/pkg/tern/target_router.go
+++ b/pkg/tern/target_router.go
@@ -283,12 +283,12 @@ func (r *TargetRouter) SkipRevert(ctx context.Context, req *ternv1.SkipRevertReq
 
 // RollbackPlan generates a rollback plan for a target. The database argument is
 // treated as the target key because rollback has no target-aware proto request.
-func (r *TargetRouter) RollbackPlan(ctx context.Context, database string) (*ternv1.PlanResponse, error) {
-	client, _, err := r.clientForTarget(ctx, database, "", "", database)
+func (r *TargetRouter) RollbackPlan(ctx context.Context, database, environment string) (*ternv1.PlanResponse, error) {
+	client, _, err := r.clientForTarget(ctx, database, "", environment, database)
 	if err != nil {
 		return nil, err
 	}
-	return client.RollbackPlan(ctx, database)
+	return client.RollbackPlan(ctx, database, environment)
 }
 
 // Health checks storage connectivity for the data-plane router.

--- a/pkg/tern/target_router_test.go
+++ b/pkg/tern/target_router_test.go
@@ -79,6 +79,8 @@ type targetRouterRecordingClient struct {
 	planReq            *ternv1.PlanRequest
 	applyReq           *ternv1.ApplyRequest
 	progressReq        *ternv1.ProgressRequest
+	rollbackDatabase   string
+	rollbackEnv        string
 	resumeApply        *storage.Apply
 	targetDSN          string
 	pendingObserverSet bool
@@ -130,7 +132,9 @@ func (c *targetRouterRecordingClient) SkipRevert(context.Context, *ternv1.SkipRe
 	return &ternv1.SkipRevertResponse{Accepted: true}, nil
 }
 
-func (c *targetRouterRecordingClient) RollbackPlan(context.Context, string) (*ternv1.PlanResponse, error) {
+func (c *targetRouterRecordingClient) RollbackPlan(_ context.Context, database, environment string) (*ternv1.PlanResponse, error) {
+	c.rollbackDatabase = database
+	c.rollbackEnv = environment
 	return &ternv1.PlanResponse{PlanId: "rollback-plan"}, nil
 }
 

--- a/pkg/tern/target_router_test.go
+++ b/pkg/tern/target_router_test.go
@@ -206,6 +206,30 @@ func TestTargetRouterRoutesPlanThroughStaticTarget(t *testing.T) {
 	assert.Len(t, created, 1, "the router should cache LocalClients by resolved target route and namespace")
 }
 
+func TestTargetRouterRollbackPlanRoutesEnvironment(t *testing.T) {
+	var resolvedReq inventory.Request
+	resolver := targetRouterResolverFunc(func(_ context.Context, req inventory.Request) (*inventory.Target, error) {
+		resolvedReq = req
+		return &inventory.Target{
+			Target:       req.Target,
+			DatabaseType: storage.DatabaseTypeMySQL,
+			DSN:          "root@tcp(localhost:3306)/",
+		}, nil
+	})
+	created := make(map[string]*targetRouterRecordingClient)
+	router := newTargetRouterForTest(t, resolver, nil, nil, created)
+
+	resp, err := router.RollbackPlan(t.Context(), "dsid-orders-prod", "staging")
+
+	require.NoError(t, err)
+	assert.Equal(t, "rollback-plan", resp.PlanId)
+	assert.Equal(t, inventory.Request{Target: "dsid-orders-prod", Environment: "staging"}, resolvedReq)
+	client := created["dsid-orders-prod"]
+	require.NotNil(t, client)
+	assert.Equal(t, "dsid-orders-prod", client.rollbackDatabase)
+	assert.Equal(t, "staging", client.rollbackEnv)
+}
+
 func TestTargetRouterApplyUsesTargetScopedPendingObserver(t *testing.T) {
 	resolver := newStaticResolver(t)
 	created := make(map[string]*targetRouterRecordingClient)


### PR DESCRIPTION
## Why
Plans should not propose drops for archive tables that are maintained outside declarative schema files.

## What
- Filter archive tables when loading the Spirit engine's live schema for planning
- Strip live auto-increment counters consistently with the local tern client path
- Add coverage for live archive tables that are absent from schema files
- Pass rollback plan environment through the target router to match the client contract

## Risk Assessment
Low — this narrows plan input by excluding tables that are intentionally unmanaged, and the change is covered by focused integration coverage.

Generated with Amp
