### PR TITLE
feat(auth): add Authorizer seam with allow-all NoneAuthorizer

### DIFF
--- a/pkg/api/auth_config_test.go
+++ b/pkg/api/auth_config_test.go
@@ -1,0 +1,26 @@
+package api_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/block/schemabot/pkg/api"
+)
+
+func TestAuthConfigValidate(t *testing.T) {
+	t.Run("empty type is valid", func(t *testing.T) {
+		require.NoError(t, (&api.AuthConfig{}).Validate())
+	})
+
+	t.Run("none type is valid", func(t *testing.T) {
+		require.NoError(t, (&api.AuthConfig{Type: "none"}).Validate())
+	})
+
+	t.Run("unknown type is rejected", func(t *testing.T) {
+		err := (&api.AuthConfig{Type: "ldap"}).Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unknown auth type")
+	})
+}

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -34,6 +34,11 @@ type ServerConfig struct {
 	// If not specified, falls back to MYSQL_DSN environment variable.
 	Storage StorageConfig `yaml:"storage"`
 
+	// Auth configures API authentication. When Type is empty or "none" (the
+	// default), authentication is disabled and all requests are allowed,
+	// unchanged from deployments without this config.
+	Auth AuthConfig `yaml:"auth"`
+
 	// GitHub configures a single GitHub App for webhook-driven schema changes.
 	// Mutually exclusive with Apps. If neither is set, the webhook endpoint
 	// is not registered.
@@ -767,7 +772,31 @@ func (c *ServerConfig) Validate() error {
 		return err
 	}
 
+	if err := c.Auth.Validate(); err != nil {
+		return fmt.Errorf("auth config: %w", err)
+	}
+
 	return nil
+}
+
+// AuthConfig configures authentication for the SchemaBot HTTP API.
+// When Type is empty or "none" (the default), authentication is disabled and
+// all requests are allowed — unchanged from deployments without this config.
+type AuthConfig struct {
+	// Type selects the authenticator: "none" (or "", the default).
+	// Additional types (e.g. "oidc") are introduced in later changes.
+	Type string `yaml:"type"`
+}
+
+// Validate checks the auth configuration. Unknown types are rejected so a
+// typo fails closed at startup rather than silently disabling auth.
+func (a *AuthConfig) Validate() error {
+	switch a.Type {
+	case "", "none":
+		return nil
+	default:
+		return fmt.Errorf("unknown auth type %q (supported: none)", a.Type)
+	}
 }
 
 func validateSupportChannel(c SupportChannelConfig) error {

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -1,0 +1,13 @@
+package auth
+
+import "net/http"
+
+// Authorizer provides HTTP middleware that authenticates and authorizes
+// incoming API requests. Implementations set the authenticated User in the
+// request context for downstream handlers.
+type Authorizer interface {
+	// Middleware returns HTTP middleware that authenticates requests and sets
+	// the authenticated User in the request context on success. On failure it
+	// writes an HTTP error response and does not call next.
+	Middleware(next http.Handler) http.Handler
+}

--- a/pkg/auth/context.go
+++ b/pkg/auth/context.go
@@ -1,0 +1,31 @@
+// Package auth provides authentication and authorization middleware for the
+// SchemaBot API. It currently ships an allow-all authorizer (NoneAuthorizer),
+// which lets every request through with a synthetic anonymous user, used when
+// auth is not configured — local development, self-hosted setups, and today's
+// deployments. OIDC JWT validation is layered on top of this seam.
+package auth
+
+import "context"
+
+type contextKey struct{}
+
+// User represents an authenticated caller extracted from a request.
+type User struct {
+	// Subject is the unique identifier for the user (e.g., "user@example.com").
+	Subject string
+
+	// Groups are the group memberships from the token's groups claim.
+	Groups []string
+}
+
+// WithUser returns a new context with the given user attached.
+func WithUser(ctx context.Context, user *User) context.Context {
+	return context.WithValue(ctx, contextKey{}, user)
+}
+
+// UserFromContext returns the authenticated user from the context, or nil if
+// no user is present.
+func UserFromContext(ctx context.Context) *User {
+	user, _ := ctx.Value(contextKey{}).(*User)
+	return user
+}

--- a/pkg/auth/context_test.go
+++ b/pkg/auth/context_test.go
@@ -1,0 +1,28 @@
+package auth_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/block/schemabot/pkg/auth"
+)
+
+func TestWithUserAndUserFromContext(t *testing.T) {
+	user := &auth.User{
+		Subject: "user@example.com",
+		Groups:  []string{"admins", "developers"},
+	}
+
+	ctx := auth.WithUser(t.Context(), user)
+	got := auth.UserFromContext(ctx)
+	require.NotNil(t, got)
+	assert.Equal(t, "user@example.com", got.Subject)
+	assert.Equal(t, []string{"admins", "developers"}, got.Groups)
+}
+
+func TestUserFromContextReturnsNilWhenNotSet(t *testing.T) {
+	got := auth.UserFromContext(t.Context())
+	assert.Nil(t, got)
+}

--- a/pkg/auth/none.go
+++ b/pkg/auth/none.go
@@ -1,0 +1,16 @@
+package auth
+
+import "net/http"
+
+// NoneAuthorizer is an allow-all authorizer: it lets every request through and
+// sets a synthetic anonymous user in the request context. Used when auth is not
+// configured (local development, self-hosted, today's deployments).
+type NoneAuthorizer struct{}
+
+// Middleware passes all requests through with an anonymous user in context.
+func (NoneAuthorizer) Middleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := WithUser(r.Context(), &User{Subject: "anonymous"})
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}

--- a/pkg/auth/none_test.go
+++ b/pkg/auth/none_test.go
@@ -1,0 +1,49 @@
+package auth_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/block/schemabot/pkg/auth"
+)
+
+func TestNoneAuthorizerSetsAnonymousUser(t *testing.T) {
+	var captured *auth.User
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured = auth.UserFromContext(r.Context())
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := auth.NoneAuthorizer{}.Middleware(inner)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/status", nil)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	require.NotNil(t, captured)
+	assert.Equal(t, "anonymous", captured.Subject)
+}
+
+func TestNoneAuthorizerPassesAllMethods(t *testing.T) {
+	methods := []string{http.MethodGet, http.MethodPost, http.MethodDelete}
+	for _, method := range methods {
+		t.Run(method, func(t *testing.T) {
+			inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			})
+
+			handler := auth.NoneAuthorizer{}.Middleware(inner)
+			req := httptest.NewRequestWithContext(t.Context(), method, "/api/plan", nil)
+			rec := httptest.NewRecorder()
+
+			handler.ServeHTTP(rec, req)
+			assert.Equal(t, http.StatusOK, rec.Code)
+		})
+	}
+}

--- a/pkg/cmd/commands/serve.go
+++ b/pkg/cmd/commands/serve.go
@@ -20,6 +20,7 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/block/schemabot/pkg/api"
+	"github.com/block/schemabot/pkg/auth"
 	ghclient "github.com/block/schemabot/pkg/github"
 	"github.com/block/schemabot/pkg/metrics"
 	"github.com/block/schemabot/pkg/mysqlconn"
@@ -198,12 +199,23 @@ func (cmd *ServeCmd) Run(g *Globals) error {
 
 	mux.Handle("POST /webhook", webhookRuntime.handler)
 
-	// Wrap mux with OTel HTTP instrumentation for automatic request
-	// duration, request body size, and response body size metrics.
+	// Authentication middleware. With the default (none) auth this is an
+	// allow-all NoneAuthorizer that lets every request through (attaching an
+	// anonymous user); it gates nothing until an auth type is configured. The
+	// authorizer is responsible for bypassing non-API paths (/webhook, /metrics,
+	// health) once real enforcement is added.
+	authz, err := buildAuthorizer(serverConfig.Auth, logger)
+	if err != nil {
+		return fmt.Errorf("setup auth: %w", err)
+	}
+	authedHandler := authz.Middleware(mux)
+
+	// Wrap with OTel HTTP instrumentation for automatic request duration,
+	// request body size, and response body size metrics.
 	metricHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		labeler, _ := otelhttp.LabelerFromContext(r.Context())
 		labeler.Add(metrics.EnvironmentAttribute(""))
-		mux.ServeHTTP(w, r)
+		authedHandler.ServeHTTP(w, r)
 	})
 	handler := otelhttp.NewHandler(metricHandler, "schemabot")
 
@@ -429,6 +441,21 @@ func getEnv(key, defaultValue string) string {
 		return value
 	}
 	return defaultValue
+}
+
+// buildAuthorizer selects the API authorizer from config. Today only the
+// allow-all NoneAuthorizer is supported (every request allowed, with an
+// anonymous user in context); other types are rejected so a misconfigured auth
+// type fails closed at startup rather than silently disabling auth. OIDC
+// support is layered on top of this seam.
+func buildAuthorizer(cfg api.AuthConfig, logger *slog.Logger) (auth.Authorizer, error) {
+	switch cfg.Type {
+	case "", "none":
+		logger.Info("API authentication disabled — all requests allowed")
+		return auth.NoneAuthorizer{}, nil
+	default:
+		return nil, fmt.Errorf("auth type %q is not yet supported", cfg.Type)
+	}
 }
 
 func logLevel() slog.Level {


### PR DESCRIPTION
Replaces the stale #70 with a fresh, rebased, minimal first step toward client auth. This is **P1** of the client-auth plan — the seam only.

## What
- `pkg/auth`: an `Authorizer` interface (HTTP middleware that sets an authenticated `User` in the request context) and a `NoneAuthorizer` that allows all requests with a synthetic anonymous user.
- `api.AuthConfig` (`auth.type`) wired into `ServerConfig.Validate`; the server builds an authorizer and wraps the API mux with it.

## Lands dark
The default and only supported type is `none`, so **behavior is unchanged for every current deployment**. Unknown auth types are rejected at startup so a misconfiguration fails closed rather than silently disabling auth.

## What's deliberately not here
OIDC JWT validation, tier/RBAC enforcement, the Dex profile, and the CLI Bearer/login flow are follow-ups that build on this seam. Ported only the relevant, current pieces of #70 — its flat `admin_group` model is intentionally dropped (the RBAC follow-up reuses the `pr_command_authorization` vocabulary).

Supersedes #70.

🤖 Generated with [Claude Code](https://claude.com/claude-code)