### PR TITLE
feat(tern): route serve --grpc through the target resolver

### DIFF
--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -15,6 +15,7 @@ import (
 	"time"
 	"unicode"
 
+	"github.com/block/schemabot/pkg/inventory"
 	"github.com/block/schemabot/pkg/pendingdrops"
 	"github.com/block/schemabot/pkg/routing"
 	"github.com/block/schemabot/pkg/secrets"
@@ -54,6 +55,12 @@ type ServerConfig struct {
 	// Databases contains registered database configurations per environment.
 	// Key format: "database_name" with nested environment configs.
 	Databases map[string]DatabaseConfig `yaml:"databases"`
+
+	// TargetResolver configures how a data-plane server (serve --grpc) resolves
+	// an opaque execution target to a connection. It is distinct from the
+	// control-plane Databases routing table: the data plane receives a target
+	// over gRPC and resolves it here, rather than routing logical database names.
+	TargetResolver TargetResolverConfig `yaml:"target_resolver,omitempty"`
 
 	// Repos holds per-repository configuration.
 	Repos map[string]RepoConfig `yaml:"repos"`
@@ -355,6 +362,25 @@ type DSNFromConfigPaths struct {
 	Host     string `yaml:"host,omitempty"`
 	Port     string `yaml:"port,omitempty"`
 	Database string `yaml:"database,omitempty"`
+}
+
+// TargetResolverConfig configures the data-plane connection resolver. Targets
+// is the static target -> connection inventory: the "no inventory service"
+// fallback and per-target overrides. A dynamic backend (e.g. Etre) discovers
+// targets by key and needs no enumeration here, so it will slot in as a sibling
+// field without changing this shape.
+type TargetResolverConfig struct {
+	Targets map[string]inventory.StaticTarget `yaml:"targets,omitempty"`
+}
+
+// Configured reports whether the data plane has any static target inventory.
+func (c TargetResolverConfig) Configured() bool {
+	return len(c.Targets) > 0
+}
+
+// StaticInventory returns the static inventory config for NewStaticResolver.
+func (c TargetResolverConfig) StaticInventory() inventory.StaticConfig {
+	return inventory.StaticConfig{Targets: c.Targets}
 }
 
 // DatabaseConfig holds configuration for a registered database.

--- a/pkg/cmd/commands/serve.go
+++ b/pkg/cmd/commands/serve.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/signal"
 	"sort"
+	"strings"
 	"syscall"
 	"time"
 
@@ -250,14 +251,9 @@ func (cmd *ServeCmd) Run(g *Globals) error {
 // startGRPCServer starts a gRPC server serving the Tern proto. When the data
 // plane is configured with a target resolver, requests are routed by opaque
 // execution target through a TargetRouter; otherwise it falls back to a single
-// LocalClient bound to the first database in config for TERN_ENVIRONMENT.
+// LocalClient bound to the one database configured for TERN_ENVIRONMENT.
 func startGRPCServer(ctx context.Context, config *api.ServerConfig, st *mysqlstore.Storage, logger *slog.Logger, port string) (*grpc.Server, error) {
-	env := os.Getenv("TERN_ENVIRONMENT")
-	if env == "" {
-		return nil, fmt.Errorf("TERN_ENVIRONMENT is required when GRPC_PORT is set")
-	}
-
-	client, err := buildGRPCTernClient(config, st, logger, env)
+	client, err := buildGRPCTernClient(config, st, logger, os.Getenv("TERN_ENVIRONMENT"))
 	if err != nil {
 		return nil, err
 	}
@@ -284,8 +280,10 @@ func startGRPCServer(ctx context.Context, config *api.ServerConfig, st *mysqlsto
 
 // buildGRPCTernClient builds the tern.Client backing the data-plane gRPC server.
 // When a target resolver is configured, it returns a TargetRouter that resolves
-// each request's opaque target to a connection. Otherwise it falls back to a
-// single LocalClient bound to the first database in config for env.
+// each request's opaque target to a connection per request; the server-level
+// environment is unused in this mode because each request carries its own.
+// Otherwise it falls back to a single LocalClient bound to the one database
+// configured for env.
 func buildGRPCTernClient(config *api.ServerConfig, st *mysqlstore.Storage, logger *slog.Logger, env string) (tern.Client, error) {
 	if config.TargetResolver.Configured() {
 		resolver, err := inventory.NewStaticResolver(config.TargetResolver.StaticInventory())
@@ -301,38 +299,53 @@ func buildGRPCTernClient(config *api.ServerConfig, st *mysqlstore.Storage, logge
 		if err != nil {
 			return nil, fmt.Errorf("build target router: %w", err)
 		}
-		logger.Info("gRPC server routing by target resolver",
-			"targets", len(config.TargetResolver.Targets), "environment", env)
+		logger.Info("gRPC server routing by target resolver", "targets", len(config.TargetResolver.Targets))
 		return router, nil
 	}
 
-	// Single-database fallback: bind to the first database in config that has a
-	// local DSN for env.
-	for dbName, dbConfig := range config.Databases {
-		envConfig, ok := dbConfig.Environments[env]
-		if !ok {
-			continue
-		}
-		if !envConfig.HasLocalDSN() {
-			continue
-		}
-		targetDSN, err := envConfig.ResolveDSN()
-		if err != nil {
-			return nil, fmt.Errorf("resolve DSN for %s/%s: %w", dbName, env, err)
-		}
-		client, err := grpcLocalClientFactory(config)(tern.LocalConfig{
-			Database:  dbName,
-			Type:      dbConfig.Type,
-			TargetDSN: targetDSN,
-		}, st, logger)
-		if err != nil {
-			return nil, fmt.Errorf("create local client for %s: %w", dbName, err)
-		}
-		logger.Info("gRPC server using database", "database", dbName, "environment", env)
-		return client, nil
+	// Single-database fallback selects the one database in config with a local
+	// DSN for env. It requires an environment to select against.
+	if env == "" {
+		return nil, fmt.Errorf("TERN_ENVIRONMENT is required for single-database gRPC mode; set it or configure target_resolver")
 	}
 
-	return nil, fmt.Errorf("no database found for environment %q in config", env)
+	// A single LocalClient serves exactly one database, so selection must be
+	// deterministic and unambiguous. More than one match is a configuration
+	// error rather than a nondeterministic pick over map iteration order.
+	var matches []string
+	for dbName, dbConfig := range config.Databases {
+		envConfig, ok := dbConfig.Environments[env]
+		if !ok || !envConfig.HasLocalDSN() {
+			continue
+		}
+		matches = append(matches, dbName)
+	}
+	sort.Strings(matches)
+	switch len(matches) {
+	case 0:
+		return nil, fmt.Errorf("no database with a local DSN found for environment %q in config", env)
+	case 1:
+		// Exactly one database matches — serve it below.
+	default:
+		return nil, fmt.Errorf("environment %q matches %d databases with local DSNs (%s); single-database gRPC mode serves one database — configure target_resolver to route multiple", env, len(matches), strings.Join(matches, ", "))
+	}
+
+	dbName := matches[0]
+	dbConfig := config.Databases[dbName]
+	targetDSN, err := dbConfig.Environments[env].ResolveDSN()
+	if err != nil {
+		return nil, fmt.Errorf("resolve DSN for %s/%s: %w", dbName, env, err)
+	}
+	client, err := grpcLocalClientFactory(config)(tern.LocalConfig{
+		Database:  dbName,
+		Type:      dbConfig.Type,
+		TargetDSN: targetDSN,
+	}, st, logger)
+	if err != nil {
+		return nil, fmt.Errorf("create local client for %s: %w", dbName, err)
+	}
+	logger.Info("gRPC server using database", "database", dbName, "environment", env)
+	return client, nil
 }
 
 // grpcLocalClientFactory returns a LocalClientFactory that applies server-level

--- a/pkg/cmd/commands/serve.go
+++ b/pkg/cmd/commands/serve.go
@@ -21,8 +21,10 @@ import (
 
 	"github.com/block/schemabot/pkg/api"
 	ghclient "github.com/block/schemabot/pkg/github"
+	"github.com/block/schemabot/pkg/inventory"
 	"github.com/block/schemabot/pkg/metrics"
 	"github.com/block/schemabot/pkg/mysqlconn"
+	"github.com/block/schemabot/pkg/storage"
 	"github.com/block/schemabot/pkg/storage/mysqlstore"
 	"github.com/block/schemabot/pkg/tern"
 	"github.com/block/schemabot/pkg/webhook"
@@ -245,51 +247,23 @@ func (cmd *ServeCmd) Run(g *Globals) error {
 	return server.Shutdown(ctx)
 }
 
-// startGRPCServer starts a gRPC server serving the Tern proto.
-// It creates a LocalClient for the first database in config using TERN_ENVIRONMENT's DSN.
+// startGRPCServer starts a gRPC server serving the Tern proto. When the data
+// plane is configured with a target resolver, requests are routed by opaque
+// execution target through a TargetRouter; otherwise it falls back to a single
+// LocalClient bound to the first database in config for TERN_ENVIRONMENT.
 func startGRPCServer(ctx context.Context, config *api.ServerConfig, st *mysqlstore.Storage, logger *slog.Logger, port string) (*grpc.Server, error) {
 	env := os.Getenv("TERN_ENVIRONMENT")
 	if env == "" {
 		return nil, fmt.Errorf("TERN_ENVIRONMENT is required when GRPC_PORT is set")
 	}
 
-	// Find the first database in config and create a LocalClient for it
-	var localClient tern.Client
-	for dbName, dbConfig := range config.Databases {
-		envConfig, ok := dbConfig.Environments[env]
-		if !ok {
-			continue
-		}
-		if !envConfig.HasLocalDSN() {
-			continue
-		}
-		targetDSN, err := envConfig.ResolveDSN()
-		if err != nil {
-			return nil, fmt.Errorf("resolve DSN for %s/%s: %w", dbName, env, err)
-		}
-		var metadata map[string]string
-		if !config.PendingDropsEnabled() {
-			metadata = map[string]string{"pending_drops": "false"}
-		}
-		localClient, err = tern.NewLocalClient(tern.LocalConfig{
-			Database:  dbName,
-			Type:      dbConfig.Type,
-			TargetDSN: targetDSN,
-			Metadata:  metadata,
-		}, st, logger)
-		if err != nil {
-			return nil, fmt.Errorf("create local client for %s: %w", dbName, err)
-		}
-		logger.Info("gRPC server using database", "database", dbName, "environment", env)
-		break
-	}
-
-	if localClient == nil {
-		return nil, fmt.Errorf("no database found for environment %q in config", env)
+	client, err := buildGRPCTernClient(config, st, logger, env)
+	if err != nil {
+		return nil, err
 	}
 
 	grpcSrv := grpc.NewServer()
-	ternServer := tern.NewServer(localClient)
+	ternServer := tern.NewServer(client)
 	ternServer.Register(grpcSrv)
 
 	var lc net.ListenConfig
@@ -306,6 +280,75 @@ func startGRPCServer(ctx context.Context, config *api.ServerConfig, st *mysqlsto
 	}()
 
 	return grpcSrv, nil
+}
+
+// buildGRPCTernClient builds the tern.Client backing the data-plane gRPC server.
+// When a target resolver is configured, it returns a TargetRouter that resolves
+// each request's opaque target to a connection. Otherwise it falls back to a
+// single LocalClient bound to the first database in config for env.
+func buildGRPCTernClient(config *api.ServerConfig, st *mysqlstore.Storage, logger *slog.Logger, env string) (tern.Client, error) {
+	if config.TargetResolver.Configured() {
+		resolver, err := inventory.NewStaticResolver(config.TargetResolver.StaticInventory())
+		if err != nil {
+			return nil, fmt.Errorf("build static target resolver: %w", err)
+		}
+		router, err := tern.NewTargetRouter(tern.TargetRouterConfig{
+			Resolver:           resolver,
+			Storage:            st,
+			Logger:             logger,
+			LocalClientFactory: grpcLocalClientFactory(config),
+		})
+		if err != nil {
+			return nil, fmt.Errorf("build target router: %w", err)
+		}
+		logger.Info("gRPC server routing by target resolver",
+			"targets", len(config.TargetResolver.Targets), "environment", env)
+		return router, nil
+	}
+
+	// Single-database fallback: bind to the first database in config that has a
+	// local DSN for env.
+	for dbName, dbConfig := range config.Databases {
+		envConfig, ok := dbConfig.Environments[env]
+		if !ok {
+			continue
+		}
+		if !envConfig.HasLocalDSN() {
+			continue
+		}
+		targetDSN, err := envConfig.ResolveDSN()
+		if err != nil {
+			return nil, fmt.Errorf("resolve DSN for %s/%s: %w", dbName, env, err)
+		}
+		client, err := grpcLocalClientFactory(config)(tern.LocalConfig{
+			Database:  dbName,
+			Type:      dbConfig.Type,
+			TargetDSN: targetDSN,
+		}, st, logger)
+		if err != nil {
+			return nil, fmt.Errorf("create local client for %s: %w", dbName, err)
+		}
+		logger.Info("gRPC server using database", "database", dbName, "environment", env)
+		return client, nil
+	}
+
+	return nil, fmt.Errorf("no database found for environment %q in config", env)
+}
+
+// grpcLocalClientFactory returns a LocalClientFactory that applies server-level
+// policy (pending drops) to every LocalClient the data plane builds, so the
+// router and single-database paths share identical execution semantics.
+func grpcLocalClientFactory(config *api.ServerConfig) tern.LocalClientFactory {
+	pendingDropsDisabled := !config.PendingDropsEnabled()
+	return func(cfg tern.LocalConfig, st storage.Storage, logger *slog.Logger) (tern.Client, error) {
+		if pendingDropsDisabled {
+			if cfg.Metadata == nil {
+				cfg.Metadata = map[string]string{}
+			}
+			cfg.Metadata["pending_drops"] = "false"
+		}
+		return tern.NewLocalClient(cfg, st, logger)
+	}
 }
 
 func buildWebhookRuntime(serverConfig *api.ServerConfig, svc *api.Service, logger *slog.Logger) (webhookRuntime, error) {

--- a/pkg/cmd/commands/serve_grpc_test.go
+++ b/pkg/cmd/commands/serve_grpc_test.go
@@ -60,6 +60,68 @@ func TestBuildGRPCTernClientFallsBackToSingleDatabase(t *testing.T) {
 	assert.True(t, ok, "expected a LocalClient when only databases are configured")
 }
 
+// In target-routing mode each request carries its own environment, so the
+// server-level TERN_ENVIRONMENT is not required to start.
+func TestBuildGRPCTernClientRoutesWithoutEnvironment(t *testing.T) {
+	logger := slog.New(slog.DiscardHandler)
+	config := &api.ServerConfig{
+		TargetResolver: api.TargetResolverConfig{
+			Targets: map[string]inventory.StaticTarget{
+				"dsid-orders-prod": {
+					DatabaseType: storage.DatabaseTypeMySQL,
+					DSN:          "root@tcp(localhost:3306)/",
+				},
+			},
+		},
+	}
+
+	client, err := buildGRPCTernClient(config, mysqlstore.New(nil), logger, "")
+	require.NoError(t, err)
+	_, ok := client.(*tern.TargetRouter)
+	assert.True(t, ok, "resolver mode should not require an environment")
+}
+
+// The single-database fallback requires an environment to select against.
+func TestBuildGRPCTernClientErrorsWhenEnvMissingInFallback(t *testing.T) {
+	logger := slog.New(slog.DiscardHandler)
+	config := &api.ServerConfig{
+		Databases: map[string]api.DatabaseConfig{
+			"orders": {
+				Type:         storage.DatabaseTypeMySQL,
+				Environments: map[string]api.EnvironmentConfig{"production": {DSN: "root@tcp(localhost:3306)/orders"}},
+			},
+		},
+	}
+
+	_, err := buildGRPCTernClient(config, mysqlstore.New(nil), logger, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "TERN_ENVIRONMENT")
+}
+
+// A single LocalClient serves exactly one database, so a config where multiple
+// databases have a local DSN for the environment is ambiguous and fails closed
+// rather than binding to a nondeterministic one.
+func TestBuildGRPCTernClientErrorsOnAmbiguousFallback(t *testing.T) {
+	logger := slog.New(slog.DiscardHandler)
+	config := &api.ServerConfig{
+		Databases: map[string]api.DatabaseConfig{
+			"orders": {
+				Type:         storage.DatabaseTypeMySQL,
+				Environments: map[string]api.EnvironmentConfig{"production": {DSN: "root@tcp(localhost:3306)/orders"}},
+			},
+			"payments": {
+				Type:         storage.DatabaseTypeMySQL,
+				Environments: map[string]api.EnvironmentConfig{"production": {DSN: "root@tcp(localhost:3306)/payments"}},
+			},
+		},
+	}
+
+	_, err := buildGRPCTernClient(config, mysqlstore.New(nil), logger, "production")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "orders")
+	assert.Contains(t, err.Error(), "payments")
+}
+
 // With neither a target resolver nor a database for the environment, startup
 // fails closed rather than serving a gRPC endpoint that can resolve nothing.
 func TestBuildGRPCTernClientErrorsWhenNothingConfigured(t *testing.T) {

--- a/pkg/cmd/commands/serve_grpc_test.go
+++ b/pkg/cmd/commands/serve_grpc_test.go
@@ -1,0 +1,71 @@
+package commands
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/block/schemabot/pkg/api"
+	"github.com/block/schemabot/pkg/inventory"
+	"github.com/block/schemabot/pkg/storage"
+	"github.com/block/schemabot/pkg/storage/mysqlstore"
+	"github.com/block/schemabot/pkg/tern"
+)
+
+// The data-plane gRPC server routes by opaque target when a target resolver is
+// configured, so an operator running serve --grpc against a target inventory
+// connects per request rather than binding to one database at startup.
+func TestBuildGRPCTernClientRoutesWhenTargetResolverConfigured(t *testing.T) {
+	logger := slog.New(slog.DiscardHandler)
+	config := &api.ServerConfig{
+		TargetResolver: api.TargetResolverConfig{
+			Targets: map[string]inventory.StaticTarget{
+				"dsid-orders-prod": {
+					DatabaseType: storage.DatabaseTypeMySQL,
+					DSN:          "root@tcp(localhost:3306)/",
+				},
+			},
+		},
+	}
+
+	client, err := buildGRPCTernClient(config, mysqlstore.New(nil), logger, "production")
+	require.NoError(t, err)
+	require.NotNil(t, client)
+	_, ok := client.(*tern.TargetRouter)
+	assert.True(t, ok, "expected a TargetRouter when target_resolver is configured")
+}
+
+// Without a target resolver the data plane falls back to a single LocalClient
+// bound to the first database configured for the environment, preserving the
+// pre-router single-database serving mode.
+func TestBuildGRPCTernClientFallsBackToSingleDatabase(t *testing.T) {
+	logger := slog.New(slog.DiscardHandler)
+	config := &api.ServerConfig{
+		Databases: map[string]api.DatabaseConfig{
+			"orders": {
+				Type: storage.DatabaseTypeMySQL,
+				Environments: map[string]api.EnvironmentConfig{
+					"production": {DSN: "root@tcp(localhost:3306)/orders"},
+				},
+			},
+		},
+	}
+
+	client, err := buildGRPCTernClient(config, mysqlstore.New(nil), logger, "production")
+	require.NoError(t, err)
+	require.NotNil(t, client)
+	_, ok := client.(*tern.LocalClient)
+	assert.True(t, ok, "expected a LocalClient when only databases are configured")
+}
+
+// With neither a target resolver nor a database for the environment, startup
+// fails closed rather than serving a gRPC endpoint that can resolve nothing.
+func TestBuildGRPCTernClientErrorsWhenNothingConfigured(t *testing.T) {
+	logger := slog.New(slog.DiscardHandler)
+
+	_, err := buildGRPCTernClient(&api.ServerConfig{}, mysqlstore.New(nil), logger, "production")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "production")
+}


### PR DESCRIPTION
## Why this matters

Today a data-plane gRPC server (`serve --grpc`) binds to **one** database at startup, taken from a single statically-configured DSN. That means one deployment can serve exactly one database — to cover many databases you need many deployments, each with its own DSN baked in.

The direction we're building toward is the opposite: **one data-plane deployment that serves a whole fleet of databases**, where the control plane decides *where* work goes and the data plane figures out *how to connect* to that target on demand. This PR is the wiring that flips `serve --grpc` from "one database per process" to "resolve the target per request."

## What it does

When a `target_resolver` is configured, `serve --grpc` now routes every request through a `TargetRouter`: it takes the opaque execution target on the request, resolves it to a concrete connection (type + DSN + metadata), and runs the operation against it — caching the per-target client. When no `target_resolver` is configured, it falls back to the existing single-database behavior, so nothing changes for current deployments.

```
serve --grpc
  ├─ target_resolver configured → TargetRouter ──► resolver ──► per-request connection
  │                                                              (opaque target → type/DSN/metadata)
  └─ otherwise                   → single LocalClient (one database for the environment)
```

Config gets a new `target_resolver` section that is deliberately separate from the control-plane `databases` routing table — the data plane receives a target over gRPC and resolves it, rather than routing logical database names:

```yaml
target_resolver:
  targets:
    <opaque-target-key>:
      type: mysql
      dsn: "user@tcp(host:3306)/"   # namespace-free; the schema is injected per operation
      metadata: { ... }
```

The static backend is the "no inventory service" baseline. A dynamic backend (an external inventory service that discovers targets by key) slots in as a sibling of `targets` without changing this shape.

Two safety properties worth calling out:
- **Fail closed on ambiguity.** The single-database fallback now errors if more than one database matches the environment, instead of binding to a nondeterministic one over map-iteration order. A single connection serves exactly one database, so multiple matches are a configuration error.
- **No surprise requirement.** The server-level environment variable is only required in single-database fallback mode; in routing mode each request carries its own environment.

Server-level policy (pending-drops) flows through one shared client factory so the routing and single-database paths execute identically.

## How it moves us toward the northstar

This completes the `serve --grpc` half of the per-target data-plane router. With the connection-resolver contract and the static router already in place, this is the step that lets the vanilla data-plane image actually serve many targets from a single deployment — the foundation for replacing the one-DSN-per-deployment model with a fleet-capable data plane.

*Opened by Claude (Opus 4.8, 1M context).*