### PR TITLE
feat(auth): add OIDCAuthorizer (verify login tokens)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,9 @@ require (
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
+	github.com/coreos/go-oidc/v3 v3.18.0
 	github.com/docker/go-connections v0.6.0
+	github.com/go-jose/go-jose/v4 v4.1.4
 	github.com/go-mysql-org/go-mysql v1.15.1-0.20260526024741-088eb1fbf0ea
 	github.com/go-sql-driver/mysql v1.10.0
 	github.com/gofri/go-github-ratelimit/v2 v2.0.2

--- a/go.sum
+++ b/go.sum
@@ -167,6 +167,8 @@ github.com/containerd/log v0.1.0 h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I=
 github.com/containerd/log v0.1.0/go.mod h1:VRRf09a7mHDIRezVKTRCrOq78v577GXq3bSa3EhrzVo=
 github.com/containerd/platforms v0.2.1 h1:zvwtM3rz2YHPQsF2CHYM8+KtB5dvhISiXh5ZpSBQv6A=
 github.com/containerd/platforms v0.2.1/go.mod h1:XHCb+2/hzowdiut9rkudds9bE5yJ7npe7dG/wG+uFPw=
+github.com/coreos/go-oidc/v3 v3.18.0 h1:V9orjXynvu5wiC9SemFTWnG4F45v403aIcjWo0d41+A=
+github.com/coreos/go-oidc/v3 v3.18.0/go.mod h1:DYCf24+ncYi+XkIH97GY1+dqoRlbaSI26KVTCI9SrY4=
 github.com/coreos/go-semver v0.3.1 h1:yi21YpKnrx1gt5R+la8n5WgS0kCrsPp33dmEyHReZr4=
 github.com/coreos/go-semver v0.3.1/go.mod h1:irMmmIw/7yzSRPWryHsK7EYSg09caPQL03VsM8rvUec=
 github.com/coreos/go-systemd/v22 v22.7.0 h1:LAEzFkke61DFROc7zNLX/WA2i5J8gYqe0rSj9KI28KA=
@@ -217,6 +219,8 @@ github.com/gammazero/deque v1.2.1 h1:9fnQVFCCZ9/NOc7ccTNqzoKd1tCWOqeI05/lPqFPMGQ
 github.com/gammazero/deque v1.2.1/go.mod h1:5nSFkzVm+afG9+gy0VIowlqVAW4N8zNcMne+CMQVD2g=
 github.com/go-ini/ini v1.67.0 h1:z6ZrTEZqSWOTyH2FlglNbNgARyHG8oLW9gMELqKr06A=
 github.com/go-ini/ini v1.67.0/go.mod h1:ByCAeIL28uOIIG0E3PJtZPDL8WnHpFKFOtgjp+3Ies8=
+github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=
+github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/log v0.1.0/go.mod h1:zbhenjAZHb184qTLMA9ZjW7ThYL0H2mk7Q6pNt4vbaY=

--- a/pkg/api/auth_config_test.go
+++ b/pkg/api/auth_config_test.go
@@ -23,4 +23,32 @@ func TestAuthConfigValidate(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "unknown auth type")
 	})
+
+	t.Run("oidc requires issuer", func(t *testing.T) {
+		err := (&api.AuthConfig{Type: "oidc"}).Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "issuer")
+	})
+
+	t.Run("oidc with issuer and audience is valid", func(t *testing.T) {
+		require.NoError(t, (&api.AuthConfig{Type: "oidc", Issuer: "https://issuer.example.com", Audience: "schemabot"}).Validate())
+	})
+
+	t.Run("oidc requires audience", func(t *testing.T) {
+		err := (&api.AuthConfig{Type: "oidc", Issuer: "https://issuer.example.com"}).Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "audience")
+	})
+
+	t.Run("oidc whitespace-only issuer is rejected", func(t *testing.T) {
+		err := (&api.AuthConfig{Type: "oidc", Issuer: "   "}).Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "issuer")
+	})
+
+	t.Run("oidc issuer with surrounding whitespace is rejected", func(t *testing.T) {
+		err := (&api.AuthConfig{Type: "oidc", Issuer: " https://issuer.example.com "}).Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "whitespace")
+	})
 }

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -783,9 +783,20 @@ func (c *ServerConfig) Validate() error {
 // When Type is empty or "none" (the default), authentication is disabled and
 // all requests are allowed — unchanged from deployments without this config.
 type AuthConfig struct {
-	// Type selects the authenticator: "none" (or "", the default).
-	// Additional types (e.g. "oidc") are introduced in later changes.
+	// Type selects the authenticator: "none" (or "", the default) or "oidc".
 	Type string `yaml:"type"`
+
+	// Issuer is the OIDC provider's issuer URL. Required when Type is "oidc".
+	Issuer string `yaml:"issuer"`
+
+	// Audience is the expected token audience (aud) claim. Required when Type is
+	// "oidc" — without it a token minted for another app sharing the issuer
+	// would be accepted.
+	Audience string `yaml:"audience"`
+
+	// GroupsClaim is the JWT claim carrying group memberships. Defaults to
+	// "groups" when empty.
+	GroupsClaim string `yaml:"groups_claim"`
 }
 
 // Validate checks the auth configuration. Unknown types are rejected so a
@@ -794,8 +805,19 @@ func (a *AuthConfig) Validate() error {
 	switch a.Type {
 	case "", "none":
 		return nil
+	case "oidc":
+		if strings.TrimSpace(a.Issuer) == "" {
+			return fmt.Errorf("issuer is required when auth type is oidc")
+		}
+		if a.Issuer != strings.TrimSpace(a.Issuer) {
+			return fmt.Errorf("issuer must not have leading or trailing whitespace")
+		}
+		if strings.TrimSpace(a.Audience) == "" {
+			return fmt.Errorf("audience is required when auth type is oidc")
+		}
+		return nil
 	default:
-		return fmt.Errorf("unknown auth type %q (supported: none)", a.Type)
+		return fmt.Errorf("unknown auth type %q (supported: none, oidc)", a.Type)
 	}
 }
 

--- a/pkg/auth/oidc.go
+++ b/pkg/auth/oidc.go
@@ -1,0 +1,187 @@
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"github.com/coreos/go-oidc/v3/oidc"
+)
+
+// OIDCConfig holds configuration for the OIDC authorizer.
+type OIDCConfig struct {
+	// Issuer is the OIDC provider's issuer URL (e.g., "https://accounts.google.com").
+	Issuer string
+
+	// Audience is the expected audience (aud) claim, required to prevent a token
+	// minted for another app sharing the issuer from being replayed against this
+	// API. go-oidc accepts a token whose aud array contains this value.
+	Audience string
+
+	// GroupsClaim is the JWT claim containing group memberships (default: "groups").
+	GroupsClaim string
+}
+
+// OIDCAuthorizer validates OIDC JWTs on incoming API requests using JWKS
+// discovery to verify token signatures. It authenticates the caller and
+// records their subject and group memberships in the request context.
+//
+// It does not yet make tier/role decisions: any request carrying a valid token
+// is allowed, and unauthenticated requests are rejected. Tier and RBAC
+// enforcement (read vs write, admin/operator groups) are layered on top of this
+// authenticator in a follow-up.
+type OIDCAuthorizer struct {
+	verifier    *oidc.IDTokenVerifier
+	groupsClaim string
+	logger      *slog.Logger
+}
+
+// NewOIDCAuthorizer creates an OIDC authorizer that validates JWTs against the
+// given issuer's JWKS endpoint. The JWKS keys are cached and refreshed
+// automatically by the go-oidc library on key rotation.
+func NewOIDCAuthorizer(ctx context.Context, cfg OIDCConfig, logger *slog.Logger) (*OIDCAuthorizer, error) {
+	if cfg.Issuer == "" {
+		return nil, fmt.Errorf("OIDC issuer is required")
+	}
+	// Audience is required: skipping the aud check would accept a token minted
+	// for any other app sharing the issuer. Tolerating audience-less tokens for
+	// non-spec providers is a deliberate future opt-in, not the default.
+	if cfg.Audience == "" {
+		return nil, fmt.Errorf("OIDC audience is required")
+	}
+
+	groupsClaim := cfg.GroupsClaim
+	if groupsClaim == "" {
+		groupsClaim = "groups"
+	}
+
+	provider, err := oidc.NewProvider(ctx, cfg.Issuer)
+	if err != nil {
+		return nil, fmt.Errorf("discover OIDC provider %s: %w", cfg.Issuer, err)
+	}
+
+	// ClientID with SkipClientIDCheck=false makes go-oidc require the token's
+	// aud to contain cfg.Audience (it handles aud as a string or an array).
+	verifierConfig := &oidc.Config{ClientID: cfg.Audience}
+
+	return &OIDCAuthorizer{
+		verifier:    provider.Verifier(verifierConfig),
+		groupsClaim: groupsClaim,
+		logger:      logger,
+	}, nil
+}
+
+// Middleware validates the Bearer token on API requests and records the
+// authenticated user in the request context. Non-API paths that authenticate
+// themselves (webhooks via HMAC) or are unauthenticated infrastructure
+// endpoints (health, metrics) bypass validation. Any request with a valid token
+// is allowed through; tier/RBAC enforcement is added on top of this seam.
+func (a *OIDCAuthorizer) Middleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if skipAuth(r.URL.Path) {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		user, err := a.authenticate(r.Context(), r)
+		if err != nil {
+			a.logger.Warn("authentication failed", "path", r.URL.Path, "error", err)
+			writeAuthError(w, http.StatusUnauthorized, "invalid or missing authentication token")
+			return
+		}
+
+		ctx := WithUser(r.Context(), user)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+// authenticate extracts the Bearer token from the Authorization header, verifies
+// it against the OIDC provider's JWKS, and returns the authenticated user with
+// their group memberships.
+func (a *OIDCAuthorizer) authenticate(ctx context.Context, r *http.Request) (*User, error) {
+	authHeader := r.Header.Get("Authorization")
+	if authHeader == "" {
+		return nil, fmt.Errorf("missing Authorization header")
+	}
+
+	parts := strings.SplitN(authHeader, " ", 2)
+	if len(parts) != 2 || !strings.EqualFold(parts[0], "Bearer") {
+		return nil, fmt.Errorf("authorization header must use Bearer scheme")
+	}
+	rawToken := parts[1]
+
+	idToken, err := a.verifier.Verify(ctx, rawToken)
+	if err != nil {
+		return nil, fmt.Errorf("verify token: %w", err)
+	}
+
+	groups, err := a.extractGroups(idToken)
+	if err != nil {
+		return nil, fmt.Errorf("extract groups from token: %w", err)
+	}
+
+	return &User{
+		Subject: idToken.Subject,
+		Groups:  groups,
+	}, nil
+}
+
+// extractGroups reads the configured groups claim. Providers emit it as either
+// a JSON array of strings or a single string, so both are accepted. A missing
+// claim means the caller has no group memberships.
+func (a *OIDCAuthorizer) extractGroups(token *oidc.IDToken) ([]string, error) {
+	var claims map[string]json.RawMessage
+	if err := token.Claims(&claims); err != nil {
+		return nil, fmt.Errorf("parse token claims: %w", err)
+	}
+
+	raw, ok := claims[a.groupsClaim]
+	if !ok {
+		return nil, nil
+	}
+
+	var groups []string
+	if err := json.Unmarshal(raw, &groups); err == nil {
+		return groups, nil
+	}
+	var single string
+	if err := json.Unmarshal(raw, &single); err == nil {
+		return []string{single}, nil
+	}
+	return nil, fmt.Errorf("parse %s claim as string or string array", a.groupsClaim)
+}
+
+// skipAuth reports paths that bypass OIDC authentication: webhooks have their
+// own HMAC authentication, and health/metrics are unauthenticated
+// infrastructure endpoints.
+func skipAuth(path string) bool {
+	switch {
+	case path == "/health":
+		return true
+	case path == "/metrics":
+		return true
+	case strings.HasPrefix(path, "/webhook"):
+		return true
+	case strings.HasPrefix(path, "/tern-health/"):
+		return true
+	default:
+		return false
+	}
+}
+
+// writeAuthError writes a JSON error response for an authentication failure.
+func writeAuthError(w http.ResponseWriter, status int, message string) {
+	if status == http.StatusUnauthorized {
+		// RFC 6750: signal a Bearer auth challenge so clients can detect it.
+		w.Header().Set("WWW-Authenticate", "Bearer")
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	resp := map[string]string{"error": message}
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		slog.Error("failed to write auth error response", "error", err)
+	}
+}

--- a/pkg/auth/oidc_test.go
+++ b/pkg/auth/oidc_test.go
@@ -1,0 +1,281 @@
+package auth_test
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/block/schemabot/pkg/auth"
+)
+
+// testOIDCProvider is a minimal OIDC provider that serves discovery and JWKS
+// endpoints and signs JWTs, for exercising token validation in tests.
+type testOIDCProvider struct {
+	server *httptest.Server
+	key    *rsa.PrivateKey
+	keyID  string
+}
+
+func newTestOIDCProvider(t *testing.T) *testOIDCProvider {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	p := &testOIDCProvider{key: key, keyID: "test-key-1"}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/openid-configuration", p.handleDiscovery)
+	mux.HandleFunc("/keys", p.handleJWKS)
+
+	p.server = httptest.NewServer(mux)
+	t.Cleanup(p.server.Close)
+
+	return p
+}
+
+func (p *testOIDCProvider) handleDiscovery(w http.ResponseWriter, _ *http.Request) {
+	discovery := map[string]string{
+		"issuer":                 p.server.URL,
+		"jwks_uri":               p.server.URL + "/keys",
+		"authorization_endpoint": p.server.URL + "/authorize",
+		"token_endpoint":         p.server.URL + "/token",
+	}
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(discovery); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+func (p *testOIDCProvider) handleJWKS(w http.ResponseWriter, _ *http.Request) {
+	jwk := jose.JSONWebKey{
+		Key:       &p.key.PublicKey,
+		KeyID:     p.keyID,
+		Algorithm: string(jose.RS256),
+		Use:       "sig",
+	}
+	jwks := jose.JSONWebKeySet{Keys: []jose.JSONWebKey{jwk}}
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(jwks); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+// issueToken signs a JWT with the groups value under the given claim name.
+// groups is `any` so callers can supply a []string, a single string, or nil.
+func (p *testOIDCProvider) issueToken(t *testing.T, subject, audience, claimName string, groups any, expiry time.Time) string {
+	t.Helper()
+
+	signer, err := jose.NewSigner(jose.SigningKey{
+		Algorithm: jose.RS256,
+		Key:       p.key,
+	}, (&jose.SignerOptions{}).WithType("JWT").WithHeader(jose.HeaderKey("kid"), p.keyID))
+	require.NoError(t, err)
+
+	now := time.Now()
+	claims := map[string]any{
+		"iss":     p.server.URL,
+		"sub":     subject,
+		"aud":     audience,
+		"iat":     now.Unix(),
+		"exp":     expiry.Unix(),
+		claimName: groups,
+	}
+
+	raw, err := jwt.Signed(signer).Claims(claims).Serialize()
+	require.NoError(t, err)
+	return raw
+}
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
+}
+
+func newAuthorizer(t *testing.T, p *testOIDCProvider, cfg auth.OIDCConfig) *auth.OIDCAuthorizer {
+	t.Helper()
+	if cfg.Issuer == "" {
+		cfg.Issuer = p.server.URL
+	}
+	authz, err := auth.NewOIDCAuthorizer(t.Context(), cfg, testLogger())
+	require.NoError(t, err)
+	return authz
+}
+
+// okHandler records whether it ran and the user it saw.
+func okHandler(ran *bool, captured **auth.User) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		*ran = true
+		if captured != nil {
+			*captured = auth.UserFromContext(r.Context())
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+}
+
+func TestOIDCAuthorizerValidTokenAllowed(t *testing.T) {
+	p := newTestOIDCProvider(t)
+	authz := newAuthorizer(t, p, auth.OIDCConfig{Audience: "schemabot"})
+	token := p.issueToken(t, "user@example.com", "schemabot", "groups", []string{"a", "b"}, time.Now().Add(time.Hour))
+
+	var ran bool
+	var captured *auth.User
+	handler := authz.Middleware(okHandler(&ran, &captured))
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/status", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.True(t, ran)
+	require.NotNil(t, captured)
+	assert.Equal(t, "user@example.com", captured.Subject)
+	assert.Equal(t, []string{"a", "b"}, captured.Groups)
+}
+
+// A valid token grants access to write-method API endpoints too: tier/RBAC
+// gating is not part of this authenticator yet.
+func TestOIDCAuthorizerValidTokenAllowedForWriteMethods(t *testing.T) {
+	p := newTestOIDCProvider(t)
+	authz := newAuthorizer(t, p, auth.OIDCConfig{Audience: "schemabot"})
+	token := p.issueToken(t, "user@example.com", "schemabot", "groups", nil, time.Now().Add(time.Hour))
+
+	var ran bool
+	handler := authz.Middleware(okHandler(&ran, nil))
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/apply", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.True(t, ran)
+}
+
+func TestOIDCAuthorizerMissingTokenRejected(t *testing.T) {
+	p := newTestOIDCProvider(t)
+	authz := newAuthorizer(t, p, auth.OIDCConfig{Audience: "schemabot"})
+
+	var ran bool
+	handler := authz.Middleware(okHandler(&ran, nil))
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/status", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	assert.Equal(t, "Bearer", rec.Header().Get("WWW-Authenticate"))
+	assert.False(t, ran)
+	var body map[string]string
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&body))
+	assert.Contains(t, body["error"], "invalid or missing authentication token")
+}
+
+func TestOIDCAuthorizerExpiredTokenRejected(t *testing.T) {
+	p := newTestOIDCProvider(t)
+	authz := newAuthorizer(t, p, auth.OIDCConfig{Audience: "schemabot"})
+	token := p.issueToken(t, "user@example.com", "schemabot", "groups", nil, time.Now().Add(-time.Hour))
+
+	var ran bool
+	handler := authz.Middleware(okHandler(&ran, nil))
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/status", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	assert.False(t, ran)
+}
+
+func TestOIDCAuthorizerWrongAudienceRejected(t *testing.T) {
+	p := newTestOIDCProvider(t)
+	authz := newAuthorizer(t, p, auth.OIDCConfig{Audience: "schemabot"})
+	token := p.issueToken(t, "user@example.com", "someone-else", "groups", nil, time.Now().Add(time.Hour))
+
+	var ran bool
+	handler := authz.Middleware(okHandler(&ran, nil))
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/status", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	assert.False(t, ran)
+}
+
+func TestOIDCAuthorizerCustomGroupsClaim(t *testing.T) {
+	p := newTestOIDCProvider(t)
+	authz := newAuthorizer(t, p, auth.OIDCConfig{Audience: "schemabot", GroupsClaim: "roles"})
+	token := p.issueToken(t, "user@example.com", "schemabot", "roles", []string{"dba"}, time.Now().Add(time.Hour))
+
+	var ran bool
+	var captured *auth.User
+	handler := authz.Middleware(okHandler(&ran, &captured))
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/status", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	require.NotNil(t, captured)
+	assert.Equal(t, []string{"dba"}, captured.Groups)
+}
+
+func TestOIDCAuthorizerGroupsClaimAsSingleString(t *testing.T) {
+	p := newTestOIDCProvider(t)
+	authz := newAuthorizer(t, p, auth.OIDCConfig{Audience: "schemabot"})
+	token := p.issueToken(t, "user@example.com", "schemabot", "groups", "solo", time.Now().Add(time.Hour))
+
+	var ran bool
+	var captured *auth.User
+	handler := authz.Middleware(okHandler(&ran, &captured))
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/status", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	require.NotNil(t, captured)
+	assert.Equal(t, []string{"solo"}, captured.Groups)
+}
+
+func TestNewOIDCAuthorizerRequiresAudience(t *testing.T) {
+	p := newTestOIDCProvider(t)
+	_, err := auth.NewOIDCAuthorizer(t.Context(), auth.OIDCConfig{Issuer: p.server.URL}, testLogger())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "audience")
+}
+
+func TestOIDCAuthorizerBypassesNonAPIPaths(t *testing.T) {
+	p := newTestOIDCProvider(t)
+	authz := newAuthorizer(t, p, auth.OIDCConfig{Audience: "schemabot"})
+
+	for _, path := range []string{"/health", "/metrics", "/webhook", "/tern-health/cake/staging"} {
+		t.Run(path, func(t *testing.T) {
+			var ran bool
+			handler := authz.Middleware(okHandler(&ran, nil))
+			// No Authorization header — must still pass through.
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, path, nil)
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+
+			assert.Equal(t, http.StatusOK, rec.Code)
+			assert.True(t, ran)
+		})
+	}
+}

--- a/pkg/cmd/commands/serve.go
+++ b/pkg/cmd/commands/serve.go
@@ -201,10 +201,9 @@ func (cmd *ServeCmd) Run(g *Globals) error {
 
 	// Authentication middleware. With the default (none) auth this is an
 	// allow-all NoneAuthorizer that lets every request through (attaching an
-	// anonymous user); it gates nothing until an auth type is configured. The
-	// authorizer is responsible for bypassing non-API paths (/webhook, /metrics,
-	// health) once real enforcement is added.
-	authz, err := buildAuthorizer(serverConfig.Auth, logger)
+	// anonymous user); with "oidc" it validates Bearer JWTs and bypasses
+	// non-API paths (/webhook, /metrics, health) itself.
+	authz, err := buildAuthorizer(ctx, serverConfig.Auth, logger)
 	if err != nil {
 		return fmt.Errorf("setup auth: %w", err)
 	}
@@ -443,16 +442,28 @@ func getEnv(key, defaultValue string) string {
 	return defaultValue
 }
 
-// buildAuthorizer selects the API authorizer from config. Today only the
-// allow-all NoneAuthorizer is supported (every request allowed, with an
-// anonymous user in context); other types are rejected so a misconfigured auth
-// type fails closed at startup rather than silently disabling auth. OIDC
-// support is layered on top of this seam.
-func buildAuthorizer(cfg api.AuthConfig, logger *slog.Logger) (auth.Authorizer, error) {
+// buildAuthorizer selects the API authorizer from config. The default
+// allow-all NoneAuthorizer lets every request through (with an anonymous user
+// in context); "oidc" validates Bearer JWTs against the issuer's JWKS. Unknown
+// types are rejected so a misconfigured auth type fails closed at startup
+// rather than silently disabling auth.
+func buildAuthorizer(ctx context.Context, cfg api.AuthConfig, logger *slog.Logger) (auth.Authorizer, error) {
 	switch cfg.Type {
 	case "", "none":
 		logger.Info("API authentication disabled — all requests allowed")
 		return auth.NoneAuthorizer{}, nil
+	case "oidc":
+		logger.Info("initializing OIDC authentication", "issuer", cfg.Issuer)
+		authz, err := auth.NewOIDCAuthorizer(ctx, auth.OIDCConfig{
+			Issuer:      cfg.Issuer,
+			Audience:    cfg.Audience,
+			GroupsClaim: cfg.GroupsClaim,
+		}, logger)
+		if err != nil {
+			return nil, err
+		}
+		logger.Info("OIDC authentication enabled", "issuer", cfg.Issuer)
+		return authz, nil
 	default:
 		return nil, fmt.Errorf("auth type %q is not yet supported", cfg.Type)
 	}


### PR DESCRIPTION
## Why this matters
SchemaBot's HTTP API has no authentication today — anyone who can reach the server can call it. This adds an optional, standards-based login so the API can tell **who** is calling. That's the groundwork for letting people use the CLI safely without giving everyone full access.

## What it does
- Adds an `oidc` auth option. When an operator turns it on (`auth.type: oidc` with an issuer and audience), the server checks the `Authorization: Bearer <token>` on each API request — confirming it's a genuine, current login (see below) — and remembers who the caller is.
- A valid token is allowed through; a missing, expired, or wrong-audience token gets a `401`.
- Infrastructure and webhook endpoints (`/health`, `/metrics`, `/webhook`, `/tern-health/`) are exempt — they authenticate themselves or aren't user-facing.
- **Off by default.** With no `auth` config (or `auth.type: none`), nothing changes — every request is allowed, exactly as today.

## What "validating the token" means
The login token is a JWT — a small, signed "ID card." Validating it means proving it's genuine and untampered before trusting it. On each request the server:
- checks the **signature** using the identity provider's published **public keys** (its *JWKS* — fetched once and cached),
- confirms the **issuer** (who minted it) and **audience** (who it's for) are the ones we expect, and
- confirms it **hasn't expired**.

Only then does it read who the caller is (their subject + groups). Because the signature is checked with the provider's *public* keys, the server verifies every token **on its own** — no call back to the identity provider per request, so no runtime dependency on the login system. ("JWT validation against JWKS" in the engineering shorthand.)

## What it intentionally leaves for later
This PR only answers "is this a valid user?" — **not** "are they allowed to do this?" Any valid token can currently call anything. Limiting who can run writes (apply, cutover, …) versus read-only commands is the next step. Keeping it opt-in and read-permissive means this change can't accidentally block anyone.

## How it fits the bigger picture
Auth is being built in small, safe steps: first a pluggable seam (#355), **then this — validating the login**, then per-action permissions, then a `login` command for the CLI. The end goal is read-only API/CLI access available broadly, with writes limited to admins.

## Notes for reviewers
- Requiring an `audience` is deliberate: it stops a token minted for a different app (same provider) from being accepted here.
- Uses the standard, widely-used Go libraries for this — `coreos/go-oidc` and `go-jose` — the same stack tools like ArgoCD use. No custom crypto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)