### PR TITLE
fix(operator): allow failed → running reopen under continue projection

### DIFF
--- a/pkg/api/operator.go
+++ b/pkg/api/operator.go
@@ -413,7 +413,7 @@ func (s *Service) recoverApplyOperation(ctx context.Context, workerID int, owner
 		return
 	}
 
-	if err := s.updateApplyStateFromOperations(applyLeaseCtx, workerID, finalApply); err != nil {
+	if err := s.updateApplyStateFromOperations(applyLeaseCtx, workerID, finalApply, allowLeaseScopedFailedReopen); err != nil {
 		s.logger.Error("operator: failed to update derived apply state from apply_operations",
 			"worker", workerID, "apply_operation_id", op.ID, "apply_id", finalApply.ApplyIdentifier,
 			"deployment", op.Deployment, "environment", finalApply.Environment, "error", err)
@@ -489,7 +489,7 @@ func (s *Service) recoverApplyPendingStop(ctx context.Context, workerID int, own
 		return true
 	}
 
-	if err := s.updateApplyStateFromOperations(applyLeaseCtx, workerID, finalApply); err != nil {
+	if err := s.updateApplyStateFromOperations(applyLeaseCtx, workerID, finalApply, allowLeaseScopedFailedReopen); err != nil {
 		s.logger.Error("operator: failed to update derived apply state during stop reconciliation",
 			"worker", workerID, "apply_id", finalApply.ApplyIdentifier,
 			"database", finalApply.Database, "environment", finalApply.Environment, "error", err)
@@ -611,7 +611,7 @@ func (s *Service) reconcileUnclaimableParent(ctx context.Context, workerID int, 
 		if !marked {
 			return
 		}
-		if err := s.updateApplyStateFromOperations(ctx, workerID, parent); err != nil {
+		if err := s.updateApplyStateFromOperations(ctx, workerID, parent, rejectFailedApplyReopen); err != nil {
 			s.logger.Error("operator: failed to update derived apply state for terminal parent",
 				"worker", workerID, "apply_operation_id", op.ID, "apply_id", parent.ApplyIdentifier,
 				"deployment", op.Deployment, "environment", parent.Environment, "error", err)
@@ -645,7 +645,7 @@ func (s *Service) failOperationWithoutTasks(opCtx, applyCtx context.Context, wor
 			"deployment", op.Deployment, "environment", apply.Environment, "error", err)
 		return
 	}
-	if err := s.updateApplyStateFromOperations(applyCtx, workerID, apply); err != nil {
+	if err := s.updateApplyStateFromOperations(applyCtx, workerID, apply, allowLeaseScopedFailedReopen); err != nil {
 		s.logger.Error("operator: failed to update derived apply state after failing task-less operation",
 			"worker", workerID, "apply_operation_id", op.ID, "apply_id", apply.ApplyIdentifier,
 			"deployment", op.Deployment, "environment", apply.Environment, "error", err)
@@ -1012,6 +1012,30 @@ func (s *Service) persistOperationState(ctx context.Context, workerID int, op *s
 	}
 }
 
+// failedApplyReopenPolicy controls whether updateApplyStateFromOperations may
+// reopen a terminal-failed parent apply back to running when the rollout
+// projection legitimately holds it active under on_failure "continue".
+//
+// The reopen write is only safe when the caller holds the parent apply lease:
+// reviving a failed parent through an unscoped, last-write-wins Applies().Update
+// could clobber a concurrent driver. So the lease-scoped drive paths opt in and
+// the unscoped terminal-parent reconciliation path opts out (it stays fail
+// closed, preserving its original invariant that a terminal parent is never
+// revived without a competing-driver guard).
+type failedApplyReopenPolicy bool
+
+const (
+	// rejectFailedApplyReopen keeps the terminal-to-non-terminal guard fully
+	// closed: a terminal parent (including failed) is never revived. Used by the
+	// unscoped reconcileUnclaimableParent path, which holds no parent lease.
+	rejectFailedApplyReopen failedApplyReopenPolicy = false
+	// allowLeaseScopedFailedReopen permits a failed parent to reopen to running
+	// when the continue projection holds it active. Used only by callers that
+	// pass a lease-scoped context, so the write fails closed after ownership
+	// changes.
+	allowLeaseScopedFailedReopen failedApplyReopenPolicy = true
+)
+
 // updateApplyStateFromOperations re-derives applies.state from the apply's child
 // apply_operations rows and persists it when it differs from the current value.
 //
@@ -1028,10 +1052,14 @@ func (s *Service) persistOperationState(ctx context.Context, workerID int, op *s
 //
 // The caller is responsible for lease scoping: the active operator path passes a
 // lease-scoped context so the write fails closed after ownership changes; the
-// terminal-parent reconciliation path passes an unscoped context, which is safe
-// because a terminal parent has no competing driver and the terminal-to-non-
-// terminal guard below refuses to revive it.
-func (s *Service) updateApplyStateFromOperations(ctx context.Context, workerID int, apply *storage.Apply) error {
+// terminal-parent reconciliation path passes an unscoped context. The reopen
+// parameter encodes the matching authority — a terminal parent may only be
+// reopened (failed → running, for the continue hold-active projection) by a
+// caller that holds the parent lease (allowLeaseScopedFailedReopen). The
+// unscoped reconciliation path passes rejectFailedApplyReopen so it never
+// revives a terminal parent through a last-write-wins update; every other
+// terminal-to-non-terminal transition stays an error regardless.
+func (s *Service) updateApplyStateFromOperations(ctx context.Context, workerID int, apply *storage.Apply, reopen failedApplyReopenPolicy) error {
 	ops, err := s.storage.ApplyOperations().ListByApply(ctx, apply.ID)
 	if err != nil {
 		return fmt.Errorf("list apply_operations for apply %s (%d): %w", apply.ApplyIdentifier, apply.ID, err)
@@ -1040,16 +1068,31 @@ func (s *Service) updateApplyStateFromOperations(ctx context.Context, workerID i
 		return fmt.Errorf("derive apply state for apply %s (%d): no apply_operations rows", apply.ApplyIdentifier, apply.ID)
 	}
 
+	childStates := make([]string, len(ops))
 	children := make([]state.RolloutChild, len(ops))
 	for i, op := range ops {
+		childStates[i] = op.State
 		children[i] = state.RolloutChild{
 			State:             op.State,
 			ContinueOnFailure: op.OnFailure == storage.OnFailureContinue,
 		}
 	}
+	base := state.DeriveApplyState(childStates)
 	derived := state.DeriveRolloutApplyState(children)
 
-	if state.IsTerminalApplyState(apply.State) && !state.IsTerminalApplyState(derived) {
+	// A failed parent is the one terminal state the continue projection can
+	// legitimately reopen: a continuable sibling failure may have terminalized
+	// the parent before the rollout settled, and re-deriving over the operation
+	// rows holds it running until every sibling is terminal. Gate the exception
+	// narrowly — the parent must be failed, the child base must still be failed
+	// (a real continuable failure, not a stale parent over non-failed children),
+	// the derived projection must be running, and the caller must hold the lease.
+	reopensContinuableFailedRollout := bool(reopen) &&
+		state.IsState(apply.State, state.Apply.Failed) &&
+		state.IsState(base, state.Apply.Failed) &&
+		state.IsState(derived, state.Apply.Running)
+
+	if state.IsTerminalApplyState(apply.State) && !state.IsTerminalApplyState(derived) && !reopensContinuableFailedRollout {
 		return fmt.Errorf("derive apply state for terminal apply %s (%d): child operations derive non-terminal state %q from parent state %q",
 			apply.ApplyIdentifier, apply.ID, derived, apply.State)
 	}

--- a/pkg/api/operator_test.go
+++ b/pkg/api/operator_test.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -294,11 +295,15 @@ func TestUpdateApplyStateFromOperations_ReopenFailedGuard(t *testing.T) {
 			applyStore := &recordingApplyStore{}
 			svc := newOperatorStateTestService(&listingApplyOperationStore{ops: tc.ops}, applyStore)
 
+			// A terminal parent always carries a stamped completed_at; seed one
+			// so the reopen-clears-completed_at assertion is meaningful.
+			completedAt := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 			apply := &storage.Apply{
 				ID:              7,
 				ApplyIdentifier: "apply-reopen",
 				State:           tc.parent,
 				Environment:     "staging",
+				CompletedAt:     &completedAt,
 			}
 
 			err := svc.updateApplyStateFromOperations(t.Context(), 1, apply, tc.reopen)

--- a/pkg/api/operator_test.go
+++ b/pkg/api/operator_test.go
@@ -215,7 +215,7 @@ func TestUpdateApplyStateFromOperations_ContinuePolicy(t *testing.T) {
 				Environment:     "staging",
 			}
 
-			require.NoError(t, svc.updateApplyStateFromOperations(t.Context(), 1, apply))
+			require.NoError(t, svc.updateApplyStateFromOperations(t.Context(), 1, apply, allowLeaseScopedFailedReopen))
 			require.NotNil(t, applyStore.updated, "derived state differs from current, so the apply must be persisted")
 			assert.Equal(t, tc.wantState, applyStore.updated.State)
 			if tc.wantDone {
@@ -223,6 +223,98 @@ func TestUpdateApplyStateFromOperations_ContinuePolicy(t *testing.T) {
 			} else {
 				assert.Nil(t, applyStore.updated.CompletedAt, "non-terminal derived state leaves completed_at nil")
 			}
+		})
+	}
+}
+
+// TestUpdateApplyStateFromOperations_ReopenFailedGuard verifies the terminal
+// guard's reopen exception. Under on_failure "continue" a sibling failure can
+// terminalize the parent apply to failed before the rollout settles; once a
+// live sibling still derives the projection running, a lease-holding caller may
+// reopen the parent failed → running so the remaining siblings run to
+// completion. The exception is deliberately narrow: only a failed parent over a
+// genuinely failed child base may reopen, only to running, and only when the
+// caller holds the apply lease. Every other terminal-to-non-terminal transition
+// — including reviving a failed parent from an unscoped reconciliation path, and
+// any genuinely terminal verdict (completed/cancelled/reverted) — stays an error.
+func TestUpdateApplyStateFromOperations_ReopenFailedGuard(t *testing.T) {
+	cases := []struct {
+		name       string
+		parent     string
+		ops        []*storage.ApplyOperation
+		reopen     failedApplyReopenPolicy
+		wantErr    bool
+		wantState  string
+		wantUpdate bool
+	}{
+		{
+			name:   "lease-scoped reopen holds the failed apply running for a live sibling",
+			parent: state.Apply.Failed,
+			ops: []*storage.ApplyOperation{
+				{ID: 1, State: state.ApplyOperation.Failed, OnFailure: storage.OnFailureContinue},
+				{ID: 2, State: state.ApplyOperation.Running, OnFailure: storage.OnFailureContinue},
+			},
+			reopen:     allowLeaseScopedFailedReopen,
+			wantState:  state.Apply.Running,
+			wantUpdate: true,
+		},
+		{
+			name:   "unscoped reconciliation refuses to revive a failed apply",
+			parent: state.Apply.Failed,
+			ops: []*storage.ApplyOperation{
+				{ID: 1, State: state.ApplyOperation.Failed, OnFailure: storage.OnFailureContinue},
+				{ID: 2, State: state.ApplyOperation.Running, OnFailure: storage.OnFailureContinue},
+			},
+			reopen:  rejectFailedApplyReopen,
+			wantErr: true,
+		},
+		{
+			name:   "completed apply is never revived even with the lease",
+			parent: state.Apply.Completed,
+			ops: []*storage.ApplyOperation{
+				{ID: 1, State: state.ApplyOperation.Running, OnFailure: storage.OnFailureContinue},
+				{ID: 2, State: state.ApplyOperation.Completed, OnFailure: storage.OnFailureContinue},
+			},
+			reopen:  allowLeaseScopedFailedReopen,
+			wantErr: true,
+		},
+		{
+			name:   "stale failed apply over a non-failed child base is not reopened",
+			parent: state.Apply.Failed,
+			ops: []*storage.ApplyOperation{
+				{ID: 1, State: state.ApplyOperation.Running, OnFailure: storage.OnFailureContinue},
+				{ID: 2, State: state.ApplyOperation.Completed, OnFailure: storage.OnFailureContinue},
+			},
+			reopen:  allowLeaseScopedFailedReopen,
+			wantErr: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			applyStore := &recordingApplyStore{}
+			svc := newOperatorStateTestService(&listingApplyOperationStore{ops: tc.ops}, applyStore)
+
+			apply := &storage.Apply{
+				ID:              7,
+				ApplyIdentifier: "apply-reopen",
+				State:           tc.parent,
+				Environment:     "staging",
+			}
+
+			err := svc.updateApplyStateFromOperations(t.Context(), 1, apply, tc.reopen)
+			if tc.wantErr {
+				require.Error(t, err)
+				assert.Nil(t, applyStore.updated, "a rejected transition must not persist the apply")
+				return
+			}
+			require.NoError(t, err)
+			if !tc.wantUpdate {
+				assert.Nil(t, applyStore.updated)
+				return
+			}
+			require.NotNil(t, applyStore.updated, "a reopened apply must be persisted")
+			assert.Equal(t, tc.wantState, applyStore.updated.State)
+			assert.Nil(t, applyStore.updated.CompletedAt, "a reopened running apply clears completed_at")
 		})
 	}
 }
@@ -336,7 +428,7 @@ func TestUpdateApplyStateFromOperations_StampsAggregateFailureMessage(t *testing
 		Environment:     "staging",
 	}
 
-	require.NoError(t, svc.updateApplyStateFromOperations(t.Context(), 1, apply))
+	require.NoError(t, svc.updateApplyStateFromOperations(t.Context(), 1, apply, allowLeaseScopedFailedReopen))
 	require.NotNil(t, applyStore.updated, "derived failed state differs from running, so the apply must be persisted")
 	assert.Equal(t, state.Apply.Failed, applyStore.updated.State)
 	assert.Equal(t, "deployment region-a failed: spirit: cutover failed", applyStore.updated.ErrorMessage,
@@ -362,7 +454,7 @@ func TestUpdateApplyStateFromOperations_KeepsExistingMessageWhenNoOperationCarri
 		ErrorMessage:    "prior reason",
 	}
 
-	require.NoError(t, svc.updateApplyStateFromOperations(t.Context(), 1, apply))
+	require.NoError(t, svc.updateApplyStateFromOperations(t.Context(), 1, apply, allowLeaseScopedFailedReopen))
 	require.NotNil(t, applyStore.updated)
 	assert.Equal(t, state.Apply.Failed, applyStore.updated.State)
 	assert.Equal(t, "prior reason", applyStore.updated.ErrorMessage,


### PR DESCRIPTION
## What and Why ?

`updateApplyStateFromOperations` re-derives a parent apply's state from its child
operation rows via the policy-aware rollout projection. Its terminal guard
rejected **every** terminal-to-non-terminal transition — including the one the
`on_failure: continue` projection legitimately produces.

Under `continue`, a deployment failure must not terminalize the whole apply while
sibling deployments are still in flight: the apply is held `running` until every
sibling settles, then takes the `failed` verdict. But once a sibling failure has
written the parent `failed`, re-deriving over the operation rows yields `running`,
and the old guard turned that into an error — the projection could never hold the
apply active.

This relaxes the guard to permit `failed → running`, but only narrowly and only
where it is safe to write:

- the current parent is `failed`,
- the child **base** projection is still `failed` (a real continuable failure, not
  a stale parent over non-failed children),
- the derived projection is `running`, and
- the caller opts in via a reopen policy that only the **lease-scoped** drive paths
  pass.

The unscoped terminal-parent reconciliation path keeps failing closed, so it never
revives a terminal apply through a last-write-wins update. Every other
terminal-to-non-terminal transition (e.g. reviving a `completed` apply) remains an
error.

This is a no-op while an apply owns a single operation, so it stays dormant until
multi-deployment fan-out makes an apply own more than one operation.

## Behaviour

Two deployments under `on_failure: continue`; deployment A fails while B still runs.

> Before — the guard rejects the hold-active transition:
```text
  A = failed    (persisted from op A's own tasks)
  B = running   (op B still in flight)
       |
       v
  re-derive parent state over [A, B]
       |
       v
  projection = running          (continue holds active)
       |
       v
  guard: parent = failed (terminal), derived = running (non-terminal)
       |
       v
  x ERROR - state not written; parent stays "failed"
            -> premature verdict; B's result never aggregated
```
> After — a lease-scoped caller may reopen, then the verdict still stands:
```text
  A = failed    (persisted from op A's own tasks)
  B = running   (op B still in flight)
       |
       v
  re-derive parent state over [A, B]
       |
       v
  projection = running          (continue holds active)
       |
       v
  guard: allow failed -> running
         (lease held, base = failed, derived = running)
       |
       v
  parent = running              (completed_at cleared)
       |
       v
  B finishes -> re-derive -> all siblings terminal
       |
       v
  parent = failed               (verdict stands)

  unscoped reconcile path: failed -> running still refused (fail closed)
```

## References

Deferred B3 item from the policy-aware continuation projection work
(`updateApplyStateFromOperations` / `DeriveRolloutApplyState`).
