### PR TITLE
feat(inventory): add generic Etre entity-query client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/planetscale/planetscale-go v0.155.0
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
 	github.com/prometheus/client_golang v1.23.2
+	github.com/square/etre v0.15.0
 	github.com/stretchr/testify v1.11.1
 	github.com/testcontainers/testcontainers-go v0.40.0
 	github.com/testcontainers/testcontainers-go/modules/localstack v0.40.0
@@ -133,12 +134,14 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v4 v4.5.2 // indirect
 	github.com/golang/glog v1.2.5 // indirect
+	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/golang/snappy v1.0.0 // indirect
 	github.com/google/go-github/v84 v84.0.0 // indirect
 	github.com/google/go-querystring v1.2.0 // indirect
 	github.com/google/safehtml v0.1.0 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
+	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
 	github.com/hashicorp/consul/api v1.34.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -252,6 +252,8 @@ github.com/golang-jwt/jwt/v4 v4.5.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/glog v1.2.5 h1:DrW6hGnjIhtvhOIiAKT6Psh/Kd/ldepEa81DKeiRJ5I=
 github.com/golang/glog v1.2.5/go.mod h1:6AhwSGph0fcJtXVM/PEHPqZlFeoLxhs7/t5UDAwmO+w=
+github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 h1:f+oWsMOmNPc8JmEHVZIycC7hBoQxHH9pNKQORJNozsQ=
+github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8/go.mod h1:wcDNUvekVysuuOpQKo3191zZyTpiI6se1N1ULghS0sw=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/mock v1.6.0/go.mod h1:p6yTPP+5HYm5mzsMV8JkE6ZKdX+/wYM6Hr+LicevLPs=
 github.com/golang/mock v1.7.0-rc.1 h1:YojYx61/OLFsiv6Rw1Z96LpldJIy31o+UHmwAUMJ6/U=
@@ -299,6 +301,8 @@ github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaU
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/grpc-ecosystem/go-grpc-middleware v1.4.0 h1:UH//fgunKIs4JdUbpDl1VZCDaL56wXCB/5+wF6uHfaI=
 github.com/grpc-ecosystem/go-grpc-middleware v1.4.0/go.mod h1:g5qyo/la0ALbONm6Vbp88Yd8NsDy6rZz+RcrMPxvld8=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 h1:Ovs26xHkKqVztRpIrF/92BcuyuQ/YW4NSIpoGtfXNho=
@@ -583,6 +587,8 @@ github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
 github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.21.0 h1:x5S+0EU27Lbphp4UKm1C+1oQO+rKx36vfCoaVebLFSU=
 github.com/spf13/viper v1.21.0/go.mod h1:P0lhsswPGWD/1lZJ9ny3fYnVqxiegrlNrEmgLjbTCAY=
+github.com/square/etre v0.15.0 h1:6J4vOAqZG25zotCljKEHXFvpoVNrNw5jkNa2h2M0OYg=
+github.com/square/etre v0.15.0/go.mod h1:8QMy3gckDPYvyZ9/h30O2EVYj4rVpNCo0qYuvcn226Q=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=

--- a/pkg/etre/etre.go
+++ b/pkg/etre/etre.go
@@ -1,0 +1,127 @@
+// Package etre is a thin client over the Etre entity registry, a generic
+// entity database.
+//
+// It adds two things over the raw Etre client: construction from config, and
+// fail-closed "exactly one match" lookup semantics for resolving a single
+// entity from a selector. It is deliberately generic — no entity type, label,
+// or field name is baked in. Mapping a data-plane target to a selector, and a
+// resolved entity to a connection, is the caller's concern.
+package etre
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"sort"
+	"strings"
+
+	"github.com/square/etre"
+)
+
+// Config configures a Client. A Client is bound to a single entity type, which
+// mirrors the underlying Etre entity client.
+type Config struct {
+	// Addr is the Etre server address (e.g. https://etre.example:8443).
+	Addr string
+	// EntityType is the Etre entity type this client queries.
+	EntityType string
+	// HTTPClient is used for Etre requests. The deployment owns any required
+	// routing/TLS. When nil, http.DefaultClient is used.
+	HTTPClient *http.Client
+	// Retry is the per-request retry count on network or API error.
+	Retry uint
+	// Logger receives debug logs for lookups. Defaults to slog.Default().
+	Logger *slog.Logger
+}
+
+// Client looks up entities in an Etre entity registry.
+type Client struct {
+	entities   etre.EntityClient
+	entityType string
+	logger     *slog.Logger
+}
+
+// New builds a Client backed by a real Etre entity client.
+func New(cfg Config) (*Client, error) {
+	if strings.TrimSpace(cfg.Addr) == "" {
+		return nil, fmt.Errorf("etre address is required")
+	}
+	if strings.TrimSpace(cfg.EntityType) == "" {
+		return nil, fmt.Errorf("etre entity type is required")
+	}
+	entities := etre.NewEntityClientWithConfig(etre.EntityClientConfig{
+		EntityType: cfg.EntityType,
+		Addr:       cfg.Addr,
+		HTTPClient: cfg.HTTPClient,
+		Retry:      cfg.Retry,
+	})
+	return newClient(entities, cfg.EntityType, cfg.Logger), nil
+}
+
+// newClient constructs a Client over a given entity client. It exists so tests
+// can inject a fake etre.EntityClient.
+func newClient(entities etre.EntityClient, entityType string, logger *slog.Logger) *Client {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Client{
+		entities:   entities,
+		entityType: entityType,
+		logger:     logger,
+	}
+}
+
+// QueryOne returns the single entity matching selector.
+//
+// It fails closed: an empty selector, zero matches, or more than one match are
+// all errors rather than a best-effort pick. Callers resolving a connection
+// target must get exactly one entity or a clear error — never an arbitrary one.
+//
+// Selector predicates are equality matches joined into an Etre query; keys are
+// sorted so the query string is deterministic.
+func (c *Client) QueryOne(ctx context.Context, selector map[string]string) (etre.Entity, error) {
+	if len(selector) == 0 {
+		return nil, fmt.Errorf("selector is required to query etre %q entities", c.entityType)
+	}
+
+	query := buildQuery(selector)
+	c.logger.Debug("etre: querying for one entity", "entity_type", c.entityType, "query", query)
+
+	entities, err := c.entities.Query(ctx, query, etre.QueryFilter{})
+	if err != nil {
+		return nil, fmt.Errorf("etre query %q for %q: %w", c.entityType, query, err)
+	}
+	switch len(entities) {
+	case 0:
+		return nil, fmt.Errorf("no etre %q entity matched %q", c.entityType, query)
+	case 1:
+		c.logger.Debug("etre: resolved one entity", "entity_type", c.entityType, "query", query)
+		return entities[0], nil
+	default:
+		return nil, fmt.Errorf("etre %q query %q matched %d entities (expected exactly one); narrow the selector to disambiguate", c.entityType, query, len(entities))
+	}
+}
+
+// buildQuery turns equality predicates into a deterministic Etre query string
+// of the form "k1=v1,k2=v2", sorted by key.
+func buildQuery(selector map[string]string) string {
+	keys := make([]string, 0, len(selector))
+	for k := range selector {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, k := range keys {
+		parts = append(parts, k+"="+selector[k])
+	}
+	return strings.Join(parts, ",")
+}
+
+// StringField reads a string-valued entity field, returning "" when the field
+// is absent or not a string. It is a convenience for callers mapping entities
+// to their own connection records.
+func StringField(e etre.Entity, key string) string {
+	v, _ := e[key].(string)
+	return v
+}

--- a/pkg/etre/etre.go
+++ b/pkg/etre/etre.go
@@ -10,6 +10,7 @@ package etre
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -18,6 +19,13 @@ import (
 
 	"github.com/square/etre"
 )
+
+// ErrNotFound is wrapped by QueryOne when no entity matches the selector. A
+// resolver that looks a target up across more than one entity type (for
+// example one type for each database engine) can use errors.Is to fall back to
+// the next type on not-found, while still treating query errors and ambiguous
+// (more than one) matches as hard failures.
+var ErrNotFound = errors.New("no matching etre entity")
 
 // Config configures a Client. A Client is bound to a single entity type, which
 // mirrors the underlying Etre entity client.
@@ -94,7 +102,7 @@ func (c *Client) QueryOne(ctx context.Context, selector map[string]string) (etre
 	}
 	switch len(entities) {
 	case 0:
-		return nil, fmt.Errorf("no etre %q entity matched %q", c.entityType, query)
+		return nil, fmt.Errorf("no etre %q entity matched %q: %w", c.entityType, query, ErrNotFound)
 	case 1:
 		c.logger.Debug("etre: resolved one entity", "entity_type", c.entityType, "query", query)
 		return entities[0], nil

--- a/pkg/etre/etre.go
+++ b/pkg/etre/etre.go
@@ -96,18 +96,18 @@ func (c *Client) QueryOne(ctx context.Context, selector map[string]string) (etre
 	query := buildQuery(selector)
 	c.logger.Debug("etre: querying for one entity", "entity_type", c.entityType, "query", query)
 
-	entities, err := c.entities.Query(ctx, query, etre.QueryFilter{})
+	matches, err := c.entities.Query(ctx, query, etre.QueryFilter{})
 	if err != nil {
-		return nil, fmt.Errorf("etre query %q for %q: %w", c.entityType, query, err)
+		return nil, fmt.Errorf("query etre %q entities matching %q: %w", c.entityType, query, err)
 	}
-	switch len(entities) {
+	switch len(matches) {
 	case 0:
 		return nil, fmt.Errorf("no etre %q entity matched %q: %w", c.entityType, query, ErrNotFound)
 	case 1:
 		c.logger.Debug("etre: resolved one entity", "entity_type", c.entityType, "query", query)
-		return entities[0], nil
+		return matches[0], nil
 	default:
-		return nil, fmt.Errorf("etre %q query %q matched %d entities (expected exactly one); narrow the selector to disambiguate", c.entityType, query, len(entities))
+		return nil, fmt.Errorf("%d etre %q entities matched %q (expected exactly one); narrow the selector to disambiguate", len(matches), c.entityType, query)
 	}
 }
 

--- a/pkg/etre/etre_test.go
+++ b/pkg/etre/etre_test.go
@@ -1,0 +1,97 @@
+package etre
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/square/etre"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockClient builds an etre.MockEntityClient (shipped by the library) that
+// records the query it received and returns the configured result.
+func mockClient(gotQuery *string, entities []etre.Entity, queryErr error) etre.EntityClient {
+	return etre.MockEntityClient{
+		QueryFunc: func(_ context.Context, query string, _ etre.QueryFilter) ([]etre.Entity, error) {
+			if gotQuery != nil {
+				*gotQuery = query
+			}
+			return entities, queryErr
+		},
+	}
+}
+
+func TestQueryOneReturnsSingleMatch(t *testing.T) {
+	entity := etre.Entity{"name": "orders", "region": "r1", "host": "orders.example:3306"}
+	c := newClient(mockClient(nil, []etre.Entity{entity}, nil), "cluster", nil)
+
+	got, err := c.QueryOne(t.Context(), map[string]string{"name": "orders", "region": "r1"})
+	require.NoError(t, err)
+	assert.Equal(t, "orders.example:3306", StringField(got, "host"))
+}
+
+// The selector is rendered into a deterministic, key-sorted Etre query.
+func TestQueryOneBuildsSortedDeterministicQuery(t *testing.T) {
+	var gotQuery string
+	c := newClient(mockClient(&gotQuery, []etre.Entity{{"name": "orders"}}, nil), "cluster", nil)
+
+	_, err := c.QueryOne(t.Context(), map[string]string{"region": "r1", "name": "orders", "env": "production"})
+	require.NoError(t, err)
+	assert.Equal(t, "env=production,name=orders,region=r1", gotQuery)
+}
+
+func TestQueryOneRequiresSelector(t *testing.T) {
+	c := newClient(mockClient(nil, nil, nil), "cluster", nil)
+
+	_, err := c.QueryOne(t.Context(), nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "selector is required")
+}
+
+func TestQueryOneFailsClosedWhenNotFound(t *testing.T) {
+	c := newClient(mockClient(nil, nil, nil), "cluster", nil)
+
+	_, err := c.QueryOne(t.Context(), map[string]string{"name": "missing"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no etre")
+}
+
+// More than one match must fail closed rather than connect to an arbitrary one.
+func TestQueryOneFailsClosedOnMultipleMatches(t *testing.T) {
+	c := newClient(mockClient(nil, []etre.Entity{{"name": "orders"}, {"name": "orders"}}, nil), "cluster", nil)
+
+	_, err := c.QueryOne(t.Context(), map[string]string{"name": "orders"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "matched 2 entities")
+}
+
+func TestQueryOnePropagatesQueryError(t *testing.T) {
+	c := newClient(mockClient(nil, nil, fmt.Errorf("etre unreachable")), "cluster", nil)
+
+	_, err := c.QueryOne(t.Context(), map[string]string{"name": "orders"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "etre unreachable")
+}
+
+func TestStringFieldHandlesMissingAndNonString(t *testing.T) {
+	e := etre.Entity{"host": "db.example:3306", "port": 3306}
+	assert.Equal(t, "db.example:3306", StringField(e, "host"))
+	assert.Equal(t, "", StringField(e, "missing"))
+	assert.Equal(t, "", StringField(e, "port"))
+}
+
+func TestNewValidatesConfig(t *testing.T) {
+	_, err := New(Config{EntityType: "cluster"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "address is required")
+
+	_, err = New(Config{Addr: "https://etre.example"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "entity type is required")
+
+	c, err := New(Config{Addr: "https://etre.example", EntityType: "cluster"})
+	require.NoError(t, err)
+	require.NotNil(t, c)
+}

--- a/pkg/etre/etre_test.go
+++ b/pkg/etre/etre_test.go
@@ -58,6 +58,25 @@ func TestQueryOneFailsClosedWhenNotFound(t *testing.T) {
 	assert.Contains(t, err.Error(), "no etre")
 }
 
+// Not-found is a distinguishable sentinel so a resolver spanning multiple entity
+// types can fall back on not-found while still aborting on ambiguous matches or
+// query errors.
+func TestQueryOneNotFoundIsErrNotFound(t *testing.T) {
+	notFound := newClient(mockClient(nil, nil, nil), "cluster", nil)
+	_, err := notFound.QueryOne(t.Context(), map[string]string{"name": "missing"})
+	assert.ErrorIs(t, err, ErrNotFound)
+
+	ambiguous := newClient(mockClient(nil, []etre.Entity{{"name": "x"}, {"name": "x"}}, nil), "cluster", nil)
+	_, err = ambiguous.QueryOne(t.Context(), map[string]string{"name": "x"})
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, ErrNotFound)
+
+	queryErr := newClient(mockClient(nil, nil, fmt.Errorf("etre unreachable")), "cluster", nil)
+	_, err = queryErr.QueryOne(t.Context(), map[string]string{"name": "x"})
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, ErrNotFound)
+}
+
 // More than one match must fail closed rather than connect to an arbitrary one.
 func TestQueryOneFailsClosedOnMultipleMatches(t *testing.T) {
 	c := newClient(mockClient(nil, []etre.Entity{{"name": "orders"}, {"name": "orders"}}, nil), "cluster", nil)

--- a/pkg/etre/etre_test.go
+++ b/pkg/etre/etre_test.go
@@ -83,7 +83,8 @@ func TestQueryOneFailsClosedOnMultipleMatches(t *testing.T) {
 
 	_, err := c.QueryOne(t.Context(), map[string]string{"name": "orders"})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "matched 2 entities")
+	assert.Contains(t, err.Error(), "2 etre")
+	assert.Contains(t, err.Error(), "expected exactly one")
 }
 
 func TestQueryOnePropagatesQueryError(t *testing.T) {


### PR DESCRIPTION
## Why this matters

The data plane needs to discover *where a target lives* at request time. Today that discovery is done by an external resolution layer that the data plane depends on; the direction we're moving toward is a data plane that resolves targets itself, directly against an inventory source, with no intermediary shim.

This PR adds one building block of that direct path: a small client over Etre, an entity registry that can record where targets live.

**About Etre:** [Etre](https://github.com/square/etre) is an open-source entity registry — a generic API for storing and querying "entities" (records with arbitrary key/value labels) backed by MongoDB, with label-selector queries (e.g. `name=orders,env=production`) and change-data-capture feeds. It's used as a source of truth for infrastructure inventory: you register entities describing resources and look them up by selector. This client only uses the read/query path.

**Etre is one pluggable backend, not the only way to do dynamic inventory.** Dynamic resolution sits behind the generic `inventory.Resolver` interface — the static backend and this Etre client are both just implementations. A deployment that doesn't run Etre can implement its own resolver (a service discovery system, a custom HTTP service, etc.) without touching core. Etre support is optional and self-contained in its own package precisely so it never becomes a required dependency.

## What it does

Adds `pkg/etre`, a thin client over the Etre entity registry. Etre is a generic entity database, so the client is deliberately generic:

- A client is bound to a configured **entity type**.
- `QueryOne(selector)` resolves a **single** entity from an equality selector, rendering it into a deterministic, key-sorted Etre query.
- It **fails closed**: an empty selector, zero matches, or more than one match are all errors — a caller resolving a connection target gets exactly one entity or a clear error, never an arbitrary one.

```
selector{a:1, b:2}  ──►  "a=1,b=2"  ──►  Etre query  ──►  exactly one entity
                                                          (0 or 2+ → error)
```

No entity type, label, or field name is baked in. Mapping a data-plane target to a selector, and a resolved entity to a connection, is the consuming resolver's concern — kept out of this layer on purpose.

Unit tests drive lookups through the registry library's own mock client, covering deterministic query construction and each fail-closed case.

## How it moves us toward the northstar

This is the discovery half of one dynamic connection resolver. The next leaf is an Etre-backed `inventory.Resolver` that composes this lookup with credential loading to turn an opaque target into a ready-to-use connection — one implementation behind the same interface the static backend already uses, letting the data plane resolve targets on its own and removing the external resolution dependency for deployments that choose Etre.

*Opened by Claude (Opus 4.8, 1M context).*