### PR TITLE
feat(api): support pull namespaces

### DIFF
--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -487,6 +487,8 @@ type mockTernClient struct {
 	pullSchemaResp    *ternv1.PullSchemaResponse
 	pullSchemaErr     error
 	pullSchemaReq     *ternv1.PullSchemaRequest
+	pullSchemaReqs    []*ternv1.PullSchemaRequest
+	pullSchemaHook    func(*ternv1.PullSchemaRequest) (*ternv1.PullSchemaResponse, error)
 	applyResp         *ternv1.ApplyResponse
 	applyErr          error
 	applyReq          *ternv1.ApplyRequest
@@ -525,6 +527,10 @@ type mockTernClient struct {
 func (m *mockTernClient) Health(ctx context.Context) error { return m.healthErr }
 func (m *mockTernClient) PullSchema(ctx context.Context, req *ternv1.PullSchemaRequest) (*ternv1.PullSchemaResponse, error) {
 	m.pullSchemaReq = req
+	m.pullSchemaReqs = append(m.pullSchemaReqs, req)
+	if m.pullSchemaHook != nil {
+		return m.pullSchemaHook(req)
+	}
 	if m.pullSchemaResp != nil {
 		return m.pullSchemaResp, m.pullSchemaErr
 	}
@@ -889,8 +895,8 @@ func TestExecutePullSchemaRoutesConfiguredMySQLTarget(t *testing.T) {
 			Database:    "orders",
 			Type:        storage.DatabaseTypeMySQL,
 			Environment: "production",
-			SchemaFiles: map[string]*ternv1.SchemaFiles{
-				"orders": {Files: map[string]string{"users.sql": "CREATE TABLE `users` (`id` bigint NOT NULL);\n"}},
+			Namespaces: map[string]*ternv1.PulledNamespace{
+				"orders": {Tables: map[string]string{"users": "CREATE TABLE `users` (`id` bigint NOT NULL);\n"}},
 			},
 			TableCount: 1,
 		},
@@ -929,9 +935,64 @@ func TestExecutePullSchemaRoutesConfiguredMySQLTarget(t *testing.T) {
 	assert.Equal(t, int32(1), resp.TableCount)
 	require.NotNil(t, mockClient.pullSchemaReq)
 	assert.Equal(t, "orders-production", mockClient.pullSchemaReq.Target)
+	assert.Empty(t, mockClient.pullSchemaReq.Namespace)
 	assert.Equal(t, "production", mockClient.pullSchemaReq.Environment)
 	assert.Equal(t, storage.DatabaseTypeMySQL, mockClient.pullSchemaReq.Type)
-	assert.Equal(t, "CREATE TABLE `users` (`id` bigint NOT NULL);\n", resp.SchemaFiles["orders"].Files["users.sql"])
+	assert.Equal(t, "CREATE TABLE `users` (`id` bigint NOT NULL);\n", resp.Namespaces["orders"].Tables["users"])
+}
+
+func TestExecutePullSchemaPullsRequestedNamespaces(t *testing.T) {
+	mockClient := &mockTernClient{
+		pullSchemaHook: func(req *ternv1.PullSchemaRequest) (*ternv1.PullSchemaResponse, error) {
+			return &ternv1.PullSchemaResponse{
+				Database:    req.Database,
+				Type:        req.Type,
+				Environment: req.Environment,
+				Namespaces: map[string]*ternv1.PulledNamespace{
+					req.Namespace: {Tables: map[string]string{"users": "CREATE TABLE `users` (`id` bigint NOT NULL);\n"}},
+				},
+				TableCount: 1,
+			}, nil
+		},
+	}
+	cfg := &ServerConfig{
+		Databases: map[string]DatabaseConfig{
+			"orders-logical": {
+				Type: storage.DatabaseTypeMySQL,
+				Environments: map[string]EnvironmentConfig{
+					"production": {Target: "orders-production", Deployment: "primary"},
+				},
+			},
+		},
+		TernDeployments: TernConfig{
+			"primary": {"production": "tern.example.com:80"},
+		},
+	}
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	svc := New(&mockStorageWithApplyStores{
+		plans:   &staticPlanStore{},
+		applies: &staticApplyStore{},
+	}, cfg, map[string]tern.Client{
+		"primary/production": mockClient,
+	}, logger)
+
+	resp, err := svc.ExecutePullSchema(t.Context(), apitypes.PullSchemaRequest{
+		Database:    "orders-logical",
+		Environment: "production",
+		Type:        storage.DatabaseTypeMySQL,
+		Namespaces:  []string{"orders_production", "orders_audit_production"},
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, "orders-logical", resp.Database)
+	assert.Equal(t, int32(2), resp.TableCount)
+	assert.Contains(t, resp.Namespaces, "orders_production")
+	assert.Contains(t, resp.Namespaces, "orders_audit_production")
+	require.Len(t, mockClient.pullSchemaReqs, 2)
+	assert.Equal(t, "orders-logical", mockClient.pullSchemaReqs[0].Database)
+	assert.Equal(t, "orders_production", mockClient.pullSchemaReqs[0].Namespace)
+	assert.Equal(t, "orders_audit_production", mockClient.pullSchemaReqs[1].Namespace)
 }
 
 func TestExecutePullSchemaRejectsUnsupportedType(t *testing.T) {

--- a/pkg/api/plan_handlers.go
+++ b/pkg/api/plan_handlers.go
@@ -21,6 +21,7 @@ import (
 	"github.com/block/schemabot/pkg/apitypes"
 	"github.com/block/schemabot/pkg/metrics"
 	ternv1 "github.com/block/schemabot/pkg/proto/ternv1"
+	"github.com/block/schemabot/pkg/schema"
 	"github.com/block/schemabot/pkg/state"
 	"github.com/block/schemabot/pkg/storage"
 )
@@ -180,6 +181,12 @@ func (s *Service) ExecutePullSchema(ctx context.Context, req apitypes.PullSchema
 		span.SetStatus(otelcodes.Error, "unsupported database type")
 		return nil, unsupportedErr
 	}
+	namespaces, err := pullNamespaces(req.Namespaces)
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(otelcodes.Error, "invalid namespaces")
+		return nil, err
+	}
 
 	client, err := s.RoutingTernClient()
 	if err != nil {
@@ -195,47 +202,122 @@ func (s *Service) ExecutePullSchema(ctx context.Context, req apitypes.PullSchema
 		"deployment", resolvedTarget.Deployment,
 		"target", resolvedTarget.Target,
 		"environment", req.Environment,
+		"pull_call_count", len(namespaces),
+		"explicit_namespace_count", len(req.Namespaces),
 		"is_remote", isRemoteTarget,
 	)
 
-	resp, err := client.PullSchema(ctx, &ternv1.PullSchemaRequest{
+	merged := &ternv1.PullSchemaResponse{
 		Database:    req.Database,
-		Type:        req.Type,
+		Type:        resolvedTarget.DatabaseType,
 		Environment: req.Environment,
-	})
-	if err != nil {
-		span.RecordError(err)
-		span.SetStatus(otelcodes.Error, "pull schema failed")
-		s.logger.Error("ExecutePullSchema: routing client PullSchema failed",
-			"database", req.Database,
-			"type", resolvedTarget.DatabaseType,
-			"deployment", resolvedTarget.Deployment,
-			"target", resolvedTarget.Target,
-			"environment", req.Environment,
-			"endpoint", client.Endpoint(),
-			"is_remote", isRemoteTarget,
-			"error", err,
-		)
-		if isRemoteTarget && grpcstatus.Code(err) == grpccodes.Unavailable {
-			return nil, &RemoteDeploymentUnavailableError{
-				Deployment: resolvedTarget.Deployment,
-				Target:     resolvedTarget.Target,
-				Err:        err,
+		Namespaces:  make(map[string]*ternv1.PulledNamespace),
+	}
+	for _, namespace := range namespaces {
+		resp, pullErr := client.PullSchema(ctx, &ternv1.PullSchemaRequest{
+			Database:    req.Database,
+			Type:        resolvedTarget.DatabaseType,
+			Environment: req.Environment,
+			Namespace:   namespace,
+		})
+		if pullErr != nil {
+			span.RecordError(pullErr)
+			span.SetStatus(otelcodes.Error, "pull schema failed")
+			s.logger.Error("ExecutePullSchema: routing client PullSchema failed",
+				"database", req.Database,
+				"type", resolvedTarget.DatabaseType,
+				"deployment", resolvedTarget.Deployment,
+				"target", resolvedTarget.Target,
+				"environment", req.Environment,
+				"namespace", namespace,
+				"endpoint", client.Endpoint(),
+				"is_remote", isRemoteTarget,
+				"error", pullErr,
+			)
+			if isRemoteTarget && grpcstatus.Code(pullErr) == grpccodes.Unavailable {
+				return nil, &RemoteDeploymentUnavailableError{
+					Deployment: resolvedTarget.Deployment,
+					Target:     resolvedTarget.Target,
+					Err:        pullErr,
+				}
 			}
+			return nil, pullErr
 		}
-		return nil, err
+		if err := mergePullSchemaResponse(merged, resp, namespace); err != nil {
+			span.RecordError(err)
+			span.SetStatus(otelcodes.Error, "merge pull schema response")
+			return nil, err
+		}
 	}
 
-	span.SetAttributes(attribute.Int("table_count", int(resp.TableCount)))
+	span.SetAttributes(attribute.Int("table_count", int(merged.TableCount)))
 	s.logger.Info("ExecutePullSchema: pull schema response",
-		"database", resp.Database,
-		"type", resp.Type,
-		"environment", resp.Environment,
-		"table_count", resp.TableCount,
-		"namespace_count", len(resp.SchemaFiles),
+		"database", merged.Database,
+		"type", merged.Type,
+		"environment", merged.Environment,
+		"table_count", merged.TableCount,
+		"namespace_count", len(merged.Namespaces),
 	)
 
-	return pullSchemaResponseFromProto(resp), nil
+	return pullSchemaResponseFromProto(merged), nil
+}
+
+func pullNamespaces(namespaces []string) ([]string, error) {
+	if len(namespaces) == 0 {
+		return []string{""}, nil
+	}
+	result := make([]string, 0, len(namespaces))
+	seenOutput := make(map[string]struct{}, len(namespaces))
+	for _, namespace := range namespaces {
+		if strings.TrimSpace(namespace) != namespace || namespace == "" {
+			return nil, fmt.Errorf("pull namespace %q must be non-empty and contain no leading or trailing whitespace", namespace)
+		}
+		if strings.Contains(namespace, "..") || strings.ContainsAny(namespace, `/\`) {
+			return nil, fmt.Errorf("pull namespace %q must be a single path component", namespace)
+		}
+		if strings.Contains(namespace, "$ENV") {
+			return nil, fmt.Errorf("pull namespace %q must be a concrete live namespace; resolve $ENV before calling pull", namespace)
+		}
+		if schema.IsReservedPullNamespace(namespace) {
+			return nil, fmt.Errorf("pull namespace %q is reserved and cannot be pulled", namespace)
+		}
+		if _, ok := seenOutput[namespace]; ok {
+			return nil, fmt.Errorf("duplicate pull namespace %q", namespace)
+		}
+		seenOutput[namespace] = struct{}{}
+		result = append(result, namespace)
+	}
+	return result, nil
+}
+
+func mergePullSchemaResponse(merged, resp *ternv1.PullSchemaResponse, requestedNamespace string) error {
+	if resp == nil {
+		return fmt.Errorf("pull schema response is empty")
+	}
+	if requestedNamespace != "" {
+		if len(resp.Namespaces) != 1 {
+			return fmt.Errorf("pull namespace %q returned %d namespaces; expected 1", requestedNamespace, len(resp.Namespaces))
+		}
+		for responseNamespace, pulled := range resp.Namespaces {
+			if responseNamespace != requestedNamespace {
+				return fmt.Errorf("pull namespace %q returned namespace %q", requestedNamespace, responseNamespace)
+			}
+			if _, ok := merged.Namespaces[responseNamespace]; ok {
+				return fmt.Errorf("pull schema response contains duplicate namespace %q", responseNamespace)
+			}
+			merged.Namespaces[responseNamespace] = pulled
+		}
+		merged.TableCount += resp.TableCount
+		return nil
+	}
+	for responseNamespace, pulled := range resp.Namespaces {
+		if _, ok := merged.Namespaces[responseNamespace]; ok {
+			return fmt.Errorf("pull schema response contains duplicate namespace %q", responseNamespace)
+		}
+		merged.Namespaces[responseNamespace] = pulled
+	}
+	merged.TableCount += resp.TableCount
+	return nil
 }
 
 func (s *Service) executionTargetUsesRemoteClient(deployment, environment string) bool {

--- a/pkg/api/proto_helpers.go
+++ b/pkg/api/proto_helpers.go
@@ -18,9 +18,25 @@ func pullSchemaResponseFromProto(resp *ternv1.PullSchemaResponse) *apitypes.Pull
 		Database:    resp.Database,
 		Type:        resp.Type,
 		Environment: resp.Environment,
-		SchemaFiles: protoSchemaFilesToAPI(resp.SchemaFiles),
+		Namespaces:  protoPulledNamespacesToAPI(resp.Namespaces),
 		TableCount:  resp.TableCount,
 	}
+}
+
+func protoPulledNamespacesToAPI(namespaces map[string]*ternv1.PulledNamespace) map[string]*apitypes.PulledNamespace {
+	result := make(map[string]*apitypes.PulledNamespace, len(namespaces))
+	for namespace, pulled := range namespaces {
+		if pulled == nil {
+			result[namespace] = &apitypes.PulledNamespace{Tables: map[string]string{}}
+			continue
+		}
+		tables := make(map[string]string, len(pulled.Tables))
+		maps.Copy(tables, pulled.Tables)
+		artifacts := make(map[string]string, len(pulled.Artifacts))
+		maps.Copy(artifacts, pulled.Artifacts)
+		result[namespace] = &apitypes.PulledNamespace{Tables: tables, Artifacts: artifacts}
+	}
+	return result
 }
 
 func protoSchemaFilesToAPI(sf map[string]*ternv1.SchemaFiles) map[string]*apitypes.SchemaFiles {

--- a/pkg/apitypes/apitypes.go
+++ b/pkg/apitypes/apitypes.go
@@ -54,20 +54,29 @@ type SchemaFiles struct {
 	Files map[string]string `json:"files,omitempty"`
 }
 
+// PulledNamespace contains live schema content for a namespace (schema name for
+// MySQL, keyspace for Vitess). It intentionally describes database objects, not
+// repository filenames; clients decide how to materialize tables and artifacts.
+type PulledNamespace struct {
+	Tables    map[string]string `json:"tables,omitempty"`
+	Artifacts map[string]string `json:"artifacts,omitempty"`
+}
+
 // PullSchemaRequest is the HTTP request body for POST /api/pull.
 type PullSchemaRequest struct {
-	Database    string `json:"database"`
-	Environment string `json:"environment"`
-	Type        string `json:"type"`
+	Database    string   `json:"database"`
+	Environment string   `json:"environment"`
+	Type        string   `json:"type"`
+	Namespaces  []string `json:"namespaces,omitempty"`
 }
 
 // PullSchemaResponse is the HTTP response body for POST /api/pull.
 type PullSchemaResponse struct {
-	Database    string                  `json:"database"`
-	Type        string                  `json:"type"`
-	Environment string                  `json:"environment"`
-	SchemaFiles map[string]*SchemaFiles `json:"schema_files"`
-	TableCount  int32                   `json:"table_count"`
+	Database    string                      `json:"database"`
+	Type        string                      `json:"type"`
+	Environment string                      `json:"environment"`
+	Namespaces  map[string]*PulledNamespace `json:"namespaces"`
+	TableCount  int32                       `json:"table_count"`
 }
 
 // PlanRequest is the HTTP request body for POST /api/plan.

--- a/pkg/cmd/client/client.go
+++ b/pkg/cmd/client/client.go
@@ -53,11 +53,12 @@ func GetEnvironments(endpoint, database string) ([]string, error) {
 }
 
 // CallPullSchemaAPI fetches live schema files for a database/environment pair.
-func CallPullSchemaAPI(endpoint, database, dbType, environment string) (*apitypes.PullSchemaResponse, error) {
+func CallPullSchemaAPI(endpoint, database, dbType, environment string, namespaces ...string) (*apitypes.PullSchemaResponse, error) {
 	req := apitypes.PullSchemaRequest{
 		Database:    database,
 		Type:        dbType,
 		Environment: environment,
+		Namespaces:  namespaces,
 	}
 	var result apitypes.PullSchemaResponse
 	if err := doPostInto(endpoint, "/api/pull", req, &result); err != nil {

--- a/pkg/cmd/client/client_test.go
+++ b/pkg/cmd/client/client_test.go
@@ -28,23 +28,23 @@ func TestCallPullSchemaAPI(t *testing.T) {
 			Type:        "mysql",
 			Environment: "production",
 			TableCount:  1,
-			SchemaFiles: map[string]*apitypes.SchemaFiles{
-				"orders": {Files: map[string]string{"users.sql": "CREATE TABLE `users` (`id` bigint NOT NULL);\n"}},
+			Namespaces: map[string]*apitypes.PulledNamespace{
+				"orders": {Tables: map[string]string{"users": "CREATE TABLE `users` (`id` bigint NOT NULL);\n"}},
 			},
 		}))
 	}))
 	t.Cleanup(server.Close)
 
-	result, err := CallPullSchemaAPI(server.URL, "orders", "mysql", "production")
+	result, err := CallPullSchemaAPI(server.URL, "orders", "mysql", "production", "orders_production", "orders_audit_production")
 	require.NoError(t, err)
 
-	assert.Equal(t, apitypes.PullSchemaRequest{Database: "orders", Type: "mysql", Environment: "production"}, gotReq)
+	assert.Equal(t, apitypes.PullSchemaRequest{Database: "orders", Type: "mysql", Environment: "production", Namespaces: []string{"orders_production", "orders_audit_production"}}, gotReq)
 	require.NotNil(t, result)
 	assert.Equal(t, "orders", result.Database)
 	assert.Equal(t, "mysql", result.Type)
 	assert.Equal(t, "production", result.Environment)
 	assert.Equal(t, int32(1), result.TableCount)
-	assert.Equal(t, "CREATE TABLE `users` (`id` bigint NOT NULL);\n", result.SchemaFiles["orders"].Files["users.sql"])
+	assert.Equal(t, "CREATE TABLE `users` (`id` bigint NOT NULL);\n", result.Namespaces["orders"].Tables["users"])
 }
 
 func TestCallPullSchemaAPIError(t *testing.T) {

--- a/pkg/cmd/commands/onboard.go
+++ b/pkg/cmd/commands/onboard.go
@@ -106,7 +106,7 @@ func buildOnboardWritePlan(schemaRoot string, resp *apitypes.PullSchemaResponse)
 	if resp.Type != storage.DatabaseTypeMySQL {
 		return nil, fmt.Errorf("onboard currently supports %s databases; got %s", storage.DatabaseTypeMySQL, resp.Type)
 	}
-	if len(resp.SchemaFiles) == 0 {
+	if len(resp.Namespaces) == 0 {
 		return nil, fmt.Errorf("pull schema returned no tables for database %s environment %s", resp.Database, resp.Environment)
 	}
 	root := filepath.Clean(schemaRoot)
@@ -114,8 +114,8 @@ func buildOnboardWritePlan(schemaRoot string, resp *apitypes.PullSchemaResponse)
 		"schemabot.yaml": fmt.Sprintf("database: %s\ntype: %s\n", resp.Database, resp.Type),
 	}
 
-	namespaces := make([]string, 0, len(resp.SchemaFiles))
-	for namespace := range resp.SchemaFiles {
+	namespaces := make([]string, 0, len(resp.Namespaces))
+	for namespace := range resp.Namespaces {
 		namespaces = append(namespaces, namespace)
 	}
 	sort.Strings(namespaces)
@@ -123,23 +123,26 @@ func buildOnboardWritePlan(schemaRoot string, resp *apitypes.PullSchemaResponse)
 		if err := validateRelativePathPart("namespace", namespace); err != nil {
 			return nil, err
 		}
-		nsFiles := resp.SchemaFiles[namespace]
-		if nsFiles == nil {
-			return nil, fmt.Errorf("schema files for namespace %s are empty", namespace)
+		pulled := resp.Namespaces[namespace]
+		if pulled == nil {
+			return nil, fmt.Errorf("pulled namespace %s is empty", namespace)
 		}
-		if len(nsFiles.Files) == 0 {
-			return nil, fmt.Errorf("schema files for namespace %s contain no tables", namespace)
+		if len(pulled.Tables) == 0 && len(pulled.Artifacts) == 0 {
+			return nil, fmt.Errorf("pulled namespace %s contains no tables or artifacts", namespace)
 		}
-		filenames := make([]string, 0, len(nsFiles.Files))
-		for filename := range nsFiles.Files {
-			filenames = append(filenames, filename)
+		tableNames := make([]string, 0, len(pulled.Tables))
+		for tableName := range pulled.Tables {
+			tableNames = append(tableNames, tableName)
 		}
-		sort.Strings(filenames)
-		for _, filename := range filenames {
-			if err := validateRelativePathPart("schema file", filename); err != nil {
+		sort.Strings(tableNames)
+		for _, tableName := range tableNames {
+			if err := validateRelativePathPart("table", tableName); err != nil {
 				return nil, err
 			}
-			files[filepath.Join(namespace, filename)] = nsFiles.Files[filename]
+			files[filepath.Join(namespace, tableName+".sql")] = pulled.Tables[tableName]
+		}
+		if vschema := pulled.Artifacts["vschema"]; vschema != "" {
+			files[filepath.Join(namespace, "vschema.json")] = vschema
 		}
 	}
 

--- a/pkg/cmd/commands/onboard_test.go
+++ b/pkg/cmd/commands/onboard_test.go
@@ -18,11 +18,11 @@ func TestBuildOnboardWritePlanWritesConfigAndNamespaceFiles(t *testing.T) {
 		Type:        "mysql",
 		Environment: "production",
 		TableCount:  2,
-		SchemaFiles: map[string]*apitypes.SchemaFiles{
+		Namespaces: map[string]*apitypes.PulledNamespace{
 			"orders": {
-				Files: map[string]string{
-					"users.sql":  "CREATE TABLE `users` (`id` bigint NOT NULL);\n",
-					"orders.sql": "CREATE TABLE `orders` (`id` bigint NOT NULL);\n",
+				Tables: map[string]string{
+					"users":  "CREATE TABLE `users` (`id` bigint NOT NULL);\n",
+					"orders": "CREATE TABLE `orders` (`id` bigint NOT NULL);\n",
 				},
 			},
 		},
@@ -51,8 +51,8 @@ func TestOnboardWritePlanRefusesExistingFilesWithoutForce(t *testing.T) {
 		Database:    "orders",
 		Type:        "mysql",
 		Environment: "production",
-		SchemaFiles: map[string]*apitypes.SchemaFiles{
-			"orders": {Files: map[string]string{"users.sql": "CREATE TABLE `users` (`id` bigint NOT NULL);\n"}},
+		Namespaces: map[string]*apitypes.PulledNamespace{
+			"orders": {Tables: map[string]string{"users": "CREATE TABLE `users` (`id` bigint NOT NULL);\n"}},
 		},
 	})
 	require.NoError(t, err)
@@ -70,12 +70,12 @@ func TestBuildOnboardWritePlanRejectsUnsafeResponsePaths(t *testing.T) {
 		Database:    "orders",
 		Type:        "mysql",
 		Environment: "production",
-		SchemaFiles: map[string]*apitypes.SchemaFiles{
-			"orders": {Files: map[string]string{"../users.sql": "CREATE TABLE `users` (`id` bigint NOT NULL);\n"}},
+		Namespaces: map[string]*apitypes.PulledNamespace{
+			"orders": {Tables: map[string]string{"../users": "CREATE TABLE `users` (`id` bigint NOT NULL);\n"}},
 		},
 	})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "schema file")
+	assert.Contains(t, err.Error(), "table")
 }
 
 func TestBuildOnboardWritePlanRejectsInvalidPullResponse(t *testing.T) {
@@ -118,11 +118,11 @@ func TestBuildOnboardWritePlanRejectsInvalidPullResponse(t *testing.T) {
 				Database:    "orders",
 				Type:        "mysql",
 				Environment: "production",
-				SchemaFiles: map[string]*apitypes.SchemaFiles{
-					"orders": {Files: map[string]string{}},
+				Namespaces: map[string]*apitypes.PulledNamespace{
+					"orders": {Tables: map[string]string{}},
 				},
 			},
-			want: "contain no tables",
+			want: "contains no tables or artifacts",
 		},
 	}
 
@@ -180,8 +180,8 @@ func validPullSchemaResponse() *apitypes.PullSchemaResponse {
 		Database:    "orders",
 		Type:        "mysql",
 		Environment: "production",
-		SchemaFiles: map[string]*apitypes.SchemaFiles{
-			"orders": {Files: map[string]string{"users.sql": "CREATE TABLE `users` (`id` bigint NOT NULL);\n"}},
+		Namespaces: map[string]*apitypes.PulledNamespace{
+			"orders": {Tables: map[string]string{"users": "CREATE TABLE `users` (`id` bigint NOT NULL);\n"}},
 		},
 	}
 }

--- a/pkg/cmd/commands/pull.go
+++ b/pkg/cmd/commands/pull.go
@@ -12,9 +12,10 @@ import (
 
 // PullCmd returns live schema from a source environment without writing files.
 type PullCmd struct {
-	Database    string `short:"d" required:"" help:"Database name from SchemaBot server config"`
-	Environment string `short:"e" required:"" help:"Source environment to pull from"`
-	Type        string `help:"Database type" default:"mysql" enum:"mysql"`
+	Database    string   `short:"d" required:"" help:"Database name from SchemaBot server config"`
+	Environment string   `short:"e" required:"" help:"Source environment to pull from"`
+	Type        string   `help:"Database type" default:"mysql" enum:"mysql"`
+	Namespaces  []string `name:"namespace" help:"Concrete live namespace to pull. Repeat for multiple namespaces. Omit to discover all non-reserved namespaces."`
 }
 
 // Run executes the pull command.
@@ -23,7 +24,7 @@ func (cmd *PullCmd) Run(g *Globals) error {
 	if err != nil {
 		return err
 	}
-	resp, err := client.CallPullSchemaAPI(ep, cmd.Database, cmd.Type, cmd.Environment)
+	resp, err := client.CallPullSchemaAPI(ep, cmd.Database, cmd.Type, cmd.Environment, cmd.Namespaces...)
 	if err != nil {
 		if outputSchemaPullRequestError("Pull", cmd.Database, cmd.Environment, err) {
 			return ErrSilent

--- a/pkg/cmd/commands/pull_test.go
+++ b/pkg/cmd/commands/pull_test.go
@@ -20,5 +20,5 @@ func TestWritePullSchemaResponseReturnsSchemaAsJSON(t *testing.T) {
 	assert.Equal(t, "orders", got.Database)
 	assert.Equal(t, "mysql", got.Type)
 	assert.Equal(t, "production", got.Environment)
-	assert.Equal(t, "CREATE TABLE `users` (`id` bigint NOT NULL);\n", got.SchemaFiles["orders"].Files["users.sql"])
+	assert.Equal(t, "CREATE TABLE `users` (`id` bigint NOT NULL);\n", got.Namespaces["orders"].Tables["users"])
 }

--- a/pkg/proto/tern.proto
+++ b/pkg/proto/tern.proto
@@ -255,14 +255,26 @@ message PullSchemaRequest {
   string environment = 3;
   // Opaque identifier for endpoint discovery. Defaults to database if empty.
   string target = 4;
+  // Optional namespace to export. For MySQL this is the schema name from SHOW DATABASES.
+  string namespace = 5;
 }
 
-// PullSchemaResponse contains live schema files grouped by namespace.
+// PulledNamespace contains live schema content for a namespace. It describes
+// database objects rather than repository filenames so clients can choose the
+// file layout they write.
+message PulledNamespace {
+  // Table name → canonical CREATE TABLE statement.
+  map<string, string> tables = 1;
+  // Optional engine-specific namespace content, such as Vitess VSchema JSON.
+  map<string, string> artifacts = 2;
+}
+
+// PullSchemaResponse contains live schema content grouped by namespace.
 message PullSchemaResponse {
   string database = 1;
   string type = 2;
   string environment = 3;
-  map<string, SchemaFiles> schema_files = 4;
+  map<string, PulledNamespace> namespaces = 4;
   int32 table_count = 5;
 }
 

--- a/pkg/proto/ternv1/tern.pb.go
+++ b/pkg/proto/ternv1/tern.pb.go
@@ -279,7 +279,9 @@ type PullSchemaRequest struct {
 	// Environment: "staging" or "production".
 	Environment string `protobuf:"bytes,3,opt,name=environment,proto3" json:"environment,omitempty"`
 	// Opaque identifier for endpoint discovery. Defaults to database if empty.
-	Target        string `protobuf:"bytes,4,opt,name=target,proto3" json:"target,omitempty"`
+	Target string `protobuf:"bytes,4,opt,name=target,proto3" json:"target,omitempty"`
+	// Optional namespace to export. For MySQL this is the schema name from SHOW DATABASES.
+	Namespace     string `protobuf:"bytes,5,opt,name=namespace,proto3" json:"namespace,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -342,21 +344,85 @@ func (x *PullSchemaRequest) GetTarget() string {
 	return ""
 }
 
-// PullSchemaResponse contains live schema files grouped by namespace.
+func (x *PullSchemaRequest) GetNamespace() string {
+	if x != nil {
+		return x.Namespace
+	}
+	return ""
+}
+
+// PulledNamespace contains live schema content for a namespace. It describes
+// database objects rather than repository filenames so clients can choose the
+// file layout they write.
+type PulledNamespace struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Table name → canonical CREATE TABLE statement.
+	Tables map[string]string `protobuf:"bytes,1,rep,name=tables,proto3" json:"tables,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	// Optional engine-specific namespace content, such as Vitess VSchema JSON.
+	Artifacts     map[string]string `protobuf:"bytes,2,rep,name=artifacts,proto3" json:"artifacts,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PulledNamespace) Reset() {
+	*x = PulledNamespace{}
+	mi := &file_tern_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PulledNamespace) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PulledNamespace) ProtoMessage() {}
+
+func (x *PulledNamespace) ProtoReflect() protoreflect.Message {
+	mi := &file_tern_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PulledNamespace.ProtoReflect.Descriptor instead.
+func (*PulledNamespace) Descriptor() ([]byte, []int) {
+	return file_tern_proto_rawDescGZIP(), []int{2}
+}
+
+func (x *PulledNamespace) GetTables() map[string]string {
+	if x != nil {
+		return x.Tables
+	}
+	return nil
+}
+
+func (x *PulledNamespace) GetArtifacts() map[string]string {
+	if x != nil {
+		return x.Artifacts
+	}
+	return nil
+}
+
+// PullSchemaResponse contains live schema content grouped by namespace.
 type PullSchemaResponse struct {
-	state         protoimpl.MessageState  `protogen:"open.v1"`
-	Database      string                  `protobuf:"bytes,1,opt,name=database,proto3" json:"database,omitempty"`
-	Type          string                  `protobuf:"bytes,2,opt,name=type,proto3" json:"type,omitempty"`
-	Environment   string                  `protobuf:"bytes,3,opt,name=environment,proto3" json:"environment,omitempty"`
-	SchemaFiles   map[string]*SchemaFiles `protobuf:"bytes,4,rep,name=schema_files,json=schemaFiles,proto3" json:"schema_files,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	TableCount    int32                   `protobuf:"varint,5,opt,name=table_count,json=tableCount,proto3" json:"table_count,omitempty"`
+	state         protoimpl.MessageState      `protogen:"open.v1"`
+	Database      string                      `protobuf:"bytes,1,opt,name=database,proto3" json:"database,omitempty"`
+	Type          string                      `protobuf:"bytes,2,opt,name=type,proto3" json:"type,omitempty"`
+	Environment   string                      `protobuf:"bytes,3,opt,name=environment,proto3" json:"environment,omitempty"`
+	Namespaces    map[string]*PulledNamespace `protobuf:"bytes,4,rep,name=namespaces,proto3" json:"namespaces,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	TableCount    int32                       `protobuf:"varint,5,opt,name=table_count,json=tableCount,proto3" json:"table_count,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *PullSchemaResponse) Reset() {
 	*x = PullSchemaResponse{}
-	mi := &file_tern_proto_msgTypes[2]
+	mi := &file_tern_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -368,7 +434,7 @@ func (x *PullSchemaResponse) String() string {
 func (*PullSchemaResponse) ProtoMessage() {}
 
 func (x *PullSchemaResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[2]
+	mi := &file_tern_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -381,7 +447,7 @@ func (x *PullSchemaResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PullSchemaResponse.ProtoReflect.Descriptor instead.
 func (*PullSchemaResponse) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{2}
+	return file_tern_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *PullSchemaResponse) GetDatabase() string {
@@ -405,9 +471,9 @@ func (x *PullSchemaResponse) GetEnvironment() string {
 	return ""
 }
 
-func (x *PullSchemaResponse) GetSchemaFiles() map[string]*SchemaFiles {
+func (x *PullSchemaResponse) GetNamespaces() map[string]*PulledNamespace {
 	if x != nil {
-		return x.SchemaFiles
+		return x.Namespaces
 	}
 	return nil
 }
@@ -451,7 +517,7 @@ type PlanRequest struct {
 
 func (x *PlanRequest) Reset() {
 	*x = PlanRequest{}
-	mi := &file_tern_proto_msgTypes[3]
+	mi := &file_tern_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -463,7 +529,7 @@ func (x *PlanRequest) String() string {
 func (*PlanRequest) ProtoMessage() {}
 
 func (x *PlanRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[3]
+	mi := &file_tern_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -476,7 +542,7 @@ func (x *PlanRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PlanRequest.ProtoReflect.Descriptor instead.
 func (*PlanRequest) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{3}
+	return file_tern_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *PlanRequest) GetDatabase() string {
@@ -558,7 +624,7 @@ type TableChange struct {
 
 func (x *TableChange) Reset() {
 	*x = TableChange{}
-	mi := &file_tern_proto_msgTypes[4]
+	mi := &file_tern_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -570,7 +636,7 @@ func (x *TableChange) String() string {
 func (*TableChange) ProtoMessage() {}
 
 func (x *TableChange) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[4]
+	mi := &file_tern_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -583,7 +649,7 @@ func (x *TableChange) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TableChange.ProtoReflect.Descriptor instead.
 func (*TableChange) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{4}
+	return file_tern_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *TableChange) GetTableName() string {
@@ -640,7 +706,7 @@ type SchemaChange struct {
 
 func (x *SchemaChange) Reset() {
 	*x = SchemaChange{}
-	mi := &file_tern_proto_msgTypes[5]
+	mi := &file_tern_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -652,7 +718,7 @@ func (x *SchemaChange) String() string {
 func (*SchemaChange) ProtoMessage() {}
 
 func (x *SchemaChange) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[5]
+	mi := &file_tern_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -665,7 +731,7 @@ func (x *SchemaChange) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SchemaChange.ProtoReflect.Descriptor instead.
 func (*SchemaChange) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{5}
+	return file_tern_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *SchemaChange) GetNamespace() string {
@@ -705,7 +771,7 @@ type LintViolation struct {
 
 func (x *LintViolation) Reset() {
 	*x = LintViolation{}
-	mi := &file_tern_proto_msgTypes[6]
+	mi := &file_tern_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -717,7 +783,7 @@ func (x *LintViolation) String() string {
 func (*LintViolation) ProtoMessage() {}
 
 func (x *LintViolation) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[6]
+	mi := &file_tern_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -730,7 +796,7 @@ func (x *LintViolation) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LintViolation.ProtoReflect.Descriptor instead.
 func (*LintViolation) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{6}
+	return file_tern_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *LintViolation) GetMessage() string {
@@ -789,7 +855,7 @@ type ShardPlan struct {
 
 func (x *ShardPlan) Reset() {
 	*x = ShardPlan{}
-	mi := &file_tern_proto_msgTypes[7]
+	mi := &file_tern_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -801,7 +867,7 @@ func (x *ShardPlan) String() string {
 func (*ShardPlan) ProtoMessage() {}
 
 func (x *ShardPlan) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[7]
+	mi := &file_tern_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -814,7 +880,7 @@ func (x *ShardPlan) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ShardPlan.ProtoReflect.Descriptor instead.
 func (*ShardPlan) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{7}
+	return file_tern_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *ShardPlan) GetShard() string {
@@ -856,7 +922,7 @@ type PlanResponse struct {
 
 func (x *PlanResponse) Reset() {
 	*x = PlanResponse{}
-	mi := &file_tern_proto_msgTypes[8]
+	mi := &file_tern_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -868,7 +934,7 @@ func (x *PlanResponse) String() string {
 func (*PlanResponse) ProtoMessage() {}
 
 func (x *PlanResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[8]
+	mi := &file_tern_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -881,7 +947,7 @@ func (x *PlanResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PlanResponse.ProtoReflect.Descriptor instead.
 func (*PlanResponse) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{8}
+	return file_tern_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *PlanResponse) GetPlanId() string {
@@ -955,7 +1021,7 @@ type ApplyRequest struct {
 
 func (x *ApplyRequest) Reset() {
 	*x = ApplyRequest{}
-	mi := &file_tern_proto_msgTypes[9]
+	mi := &file_tern_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -967,7 +1033,7 @@ func (x *ApplyRequest) String() string {
 func (*ApplyRequest) ProtoMessage() {}
 
 func (x *ApplyRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[9]
+	mi := &file_tern_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -980,7 +1046,7 @@ func (x *ApplyRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ApplyRequest.ProtoReflect.Descriptor instead.
 func (*ApplyRequest) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{9}
+	return file_tern_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *ApplyRequest) GetPlanId() string {
@@ -1066,7 +1132,7 @@ type ApplyResponse struct {
 
 func (x *ApplyResponse) Reset() {
 	*x = ApplyResponse{}
-	mi := &file_tern_proto_msgTypes[10]
+	mi := &file_tern_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1078,7 +1144,7 @@ func (x *ApplyResponse) String() string {
 func (*ApplyResponse) ProtoMessage() {}
 
 func (x *ApplyResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[10]
+	mi := &file_tern_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1091,7 +1157,7 @@ func (x *ApplyResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ApplyResponse.ProtoReflect.Descriptor instead.
 func (*ApplyResponse) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{10}
+	return file_tern_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *ApplyResponse) GetAccepted() bool {
@@ -1128,7 +1194,7 @@ type ProgressRequest struct {
 
 func (x *ProgressRequest) Reset() {
 	*x = ProgressRequest{}
-	mi := &file_tern_proto_msgTypes[11]
+	mi := &file_tern_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1140,7 +1206,7 @@ func (x *ProgressRequest) String() string {
 func (*ProgressRequest) ProtoMessage() {}
 
 func (x *ProgressRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[11]
+	mi := &file_tern_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1153,7 +1219,7 @@ func (x *ProgressRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ProgressRequest.ProtoReflect.Descriptor instead.
 func (*ProgressRequest) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{11}
+	return file_tern_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *ProgressRequest) GetApplyId() string {
@@ -1187,7 +1253,7 @@ type ShardProgress struct {
 
 func (x *ShardProgress) Reset() {
 	*x = ShardProgress{}
-	mi := &file_tern_proto_msgTypes[12]
+	mi := &file_tern_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1199,7 +1265,7 @@ func (x *ShardProgress) String() string {
 func (*ShardProgress) ProtoMessage() {}
 
 func (x *ShardProgress) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[12]
+	mi := &file_tern_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1212,7 +1278,7 @@ func (x *ShardProgress) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ShardProgress.ProtoReflect.Descriptor instead.
 func (*ShardProgress) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{12}
+	return file_tern_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *ShardProgress) GetShard() string {
@@ -1293,7 +1359,7 @@ type TableProgress struct {
 
 func (x *TableProgress) Reset() {
 	*x = TableProgress{}
-	mi := &file_tern_proto_msgTypes[13]
+	mi := &file_tern_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1305,7 +1371,7 @@ func (x *TableProgress) String() string {
 func (*TableProgress) ProtoMessage() {}
 
 func (x *TableProgress) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[13]
+	mi := &file_tern_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1318,7 +1384,7 @@ func (x *TableProgress) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TableProgress.ProtoReflect.Descriptor instead.
 func (*TableProgress) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{13}
+	return file_tern_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *TableProgress) GetTaskId() string {
@@ -1431,7 +1497,7 @@ type ProgressResponse struct {
 
 func (x *ProgressResponse) Reset() {
 	*x = ProgressResponse{}
-	mi := &file_tern_proto_msgTypes[14]
+	mi := &file_tern_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1443,7 +1509,7 @@ func (x *ProgressResponse) String() string {
 func (*ProgressResponse) ProtoMessage() {}
 
 func (x *ProgressResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[14]
+	mi := &file_tern_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1456,7 +1522,7 @@ func (x *ProgressResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ProgressResponse.ProtoReflect.Descriptor instead.
 func (*ProgressResponse) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{14}
+	return file_tern_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *ProgressResponse) GetApplyId() string {
@@ -1542,7 +1608,7 @@ type CutoverRequest struct {
 
 func (x *CutoverRequest) Reset() {
 	*x = CutoverRequest{}
-	mi := &file_tern_proto_msgTypes[15]
+	mi := &file_tern_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1554,7 +1620,7 @@ func (x *CutoverRequest) String() string {
 func (*CutoverRequest) ProtoMessage() {}
 
 func (x *CutoverRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[15]
+	mi := &file_tern_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1567,7 +1633,7 @@ func (x *CutoverRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CutoverRequest.ProtoReflect.Descriptor instead.
 func (*CutoverRequest) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{15}
+	return file_tern_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *CutoverRequest) GetApplyId() string {
@@ -1595,7 +1661,7 @@ type CutoverResponse struct {
 
 func (x *CutoverResponse) Reset() {
 	*x = CutoverResponse{}
-	mi := &file_tern_proto_msgTypes[16]
+	mi := &file_tern_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1607,7 +1673,7 @@ func (x *CutoverResponse) String() string {
 func (*CutoverResponse) ProtoMessage() {}
 
 func (x *CutoverResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[16]
+	mi := &file_tern_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1620,7 +1686,7 @@ func (x *CutoverResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CutoverResponse.ProtoReflect.Descriptor instead.
 func (*CutoverResponse) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{16}
+	return file_tern_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *CutoverResponse) GetAccepted() bool {
@@ -1650,7 +1716,7 @@ type RevertRequest struct {
 
 func (x *RevertRequest) Reset() {
 	*x = RevertRequest{}
-	mi := &file_tern_proto_msgTypes[17]
+	mi := &file_tern_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1662,7 +1728,7 @@ func (x *RevertRequest) String() string {
 func (*RevertRequest) ProtoMessage() {}
 
 func (x *RevertRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[17]
+	mi := &file_tern_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1675,7 +1741,7 @@ func (x *RevertRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RevertRequest.ProtoReflect.Descriptor instead.
 func (*RevertRequest) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{17}
+	return file_tern_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *RevertRequest) GetApplyId() string {
@@ -1703,7 +1769,7 @@ type RevertResponse struct {
 
 func (x *RevertResponse) Reset() {
 	*x = RevertResponse{}
-	mi := &file_tern_proto_msgTypes[18]
+	mi := &file_tern_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1715,7 +1781,7 @@ func (x *RevertResponse) String() string {
 func (*RevertResponse) ProtoMessage() {}
 
 func (x *RevertResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[18]
+	mi := &file_tern_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1728,7 +1794,7 @@ func (x *RevertResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RevertResponse.ProtoReflect.Descriptor instead.
 func (*RevertResponse) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{18}
+	return file_tern_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *RevertResponse) GetAccepted() bool {
@@ -1758,7 +1824,7 @@ type SkipRevertRequest struct {
 
 func (x *SkipRevertRequest) Reset() {
 	*x = SkipRevertRequest{}
-	mi := &file_tern_proto_msgTypes[19]
+	mi := &file_tern_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1770,7 +1836,7 @@ func (x *SkipRevertRequest) String() string {
 func (*SkipRevertRequest) ProtoMessage() {}
 
 func (x *SkipRevertRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[19]
+	mi := &file_tern_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1783,7 +1849,7 @@ func (x *SkipRevertRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SkipRevertRequest.ProtoReflect.Descriptor instead.
 func (*SkipRevertRequest) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{19}
+	return file_tern_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *SkipRevertRequest) GetApplyId() string {
@@ -1811,7 +1877,7 @@ type SkipRevertResponse struct {
 
 func (x *SkipRevertResponse) Reset() {
 	*x = SkipRevertResponse{}
-	mi := &file_tern_proto_msgTypes[20]
+	mi := &file_tern_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1823,7 +1889,7 @@ func (x *SkipRevertResponse) String() string {
 func (*SkipRevertResponse) ProtoMessage() {}
 
 func (x *SkipRevertResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[20]
+	mi := &file_tern_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1836,7 +1902,7 @@ func (x *SkipRevertResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SkipRevertResponse.ProtoReflect.Descriptor instead.
 func (*SkipRevertResponse) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{20}
+	return file_tern_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *SkipRevertResponse) GetAccepted() bool {
@@ -1862,7 +1928,7 @@ type HealthRequest struct {
 
 func (x *HealthRequest) Reset() {
 	*x = HealthRequest{}
-	mi := &file_tern_proto_msgTypes[21]
+	mi := &file_tern_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1874,7 +1940,7 @@ func (x *HealthRequest) String() string {
 func (*HealthRequest) ProtoMessage() {}
 
 func (x *HealthRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[21]
+	mi := &file_tern_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1887,7 +1953,7 @@ func (x *HealthRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HealthRequest.ProtoReflect.Descriptor instead.
 func (*HealthRequest) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{21}
+	return file_tern_proto_rawDescGZIP(), []int{22}
 }
 
 // HealthResponse is the health check response.
@@ -1900,7 +1966,7 @@ type HealthResponse struct {
 
 func (x *HealthResponse) Reset() {
 	*x = HealthResponse{}
-	mi := &file_tern_proto_msgTypes[22]
+	mi := &file_tern_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1912,7 +1978,7 @@ func (x *HealthResponse) String() string {
 func (*HealthResponse) ProtoMessage() {}
 
 func (x *HealthResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[22]
+	mi := &file_tern_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1925,7 +1991,7 @@ func (x *HealthResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HealthResponse.ProtoReflect.Descriptor instead.
 func (*HealthResponse) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{22}
+	return file_tern_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *HealthResponse) GetStatus() string {
@@ -1948,7 +2014,7 @@ type StopRequest struct {
 
 func (x *StopRequest) Reset() {
 	*x = StopRequest{}
-	mi := &file_tern_proto_msgTypes[23]
+	mi := &file_tern_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1960,7 +2026,7 @@ func (x *StopRequest) String() string {
 func (*StopRequest) ProtoMessage() {}
 
 func (x *StopRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[23]
+	mi := &file_tern_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1973,7 +2039,7 @@ func (x *StopRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StopRequest.ProtoReflect.Descriptor instead.
 func (*StopRequest) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{23}
+	return file_tern_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *StopRequest) GetApplyId() string {
@@ -2007,7 +2073,7 @@ type StopResponse struct {
 
 func (x *StopResponse) Reset() {
 	*x = StopResponse{}
-	mi := &file_tern_proto_msgTypes[24]
+	mi := &file_tern_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2019,7 +2085,7 @@ func (x *StopResponse) String() string {
 func (*StopResponse) ProtoMessage() {}
 
 func (x *StopResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[24]
+	mi := &file_tern_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2032,7 +2098,7 @@ func (x *StopResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StopResponse.ProtoReflect.Descriptor instead.
 func (*StopResponse) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{24}
+	return file_tern_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *StopResponse) GetAccepted() bool {
@@ -2083,7 +2149,7 @@ type StartRequest struct {
 
 func (x *StartRequest) Reset() {
 	*x = StartRequest{}
-	mi := &file_tern_proto_msgTypes[25]
+	mi := &file_tern_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2095,7 +2161,7 @@ func (x *StartRequest) String() string {
 func (*StartRequest) ProtoMessage() {}
 
 func (x *StartRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[25]
+	mi := &file_tern_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2108,7 +2174,7 @@ func (x *StartRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StartRequest.ProtoReflect.Descriptor instead.
 func (*StartRequest) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{25}
+	return file_tern_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *StartRequest) GetApplyId() string {
@@ -2140,7 +2206,7 @@ type StartResponse struct {
 
 func (x *StartResponse) Reset() {
 	*x = StartResponse{}
-	mi := &file_tern_proto_msgTypes[26]
+	mi := &file_tern_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2152,7 +2218,7 @@ func (x *StartResponse) String() string {
 func (*StartResponse) ProtoMessage() {}
 
 func (x *StartResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[26]
+	mi := &file_tern_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2165,7 +2231,7 @@ func (x *StartResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StartResponse.ProtoReflect.Descriptor instead.
 func (*StartResponse) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{26}
+	return file_tern_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *StartResponse) GetAccepted() bool {
@@ -2211,7 +2277,7 @@ type VolumeRequest struct {
 
 func (x *VolumeRequest) Reset() {
 	*x = VolumeRequest{}
-	mi := &file_tern_proto_msgTypes[27]
+	mi := &file_tern_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2223,7 +2289,7 @@ func (x *VolumeRequest) String() string {
 func (*VolumeRequest) ProtoMessage() {}
 
 func (x *VolumeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[27]
+	mi := &file_tern_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2236,7 +2302,7 @@ func (x *VolumeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VolumeRequest.ProtoReflect.Descriptor instead.
 func (*VolumeRequest) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{27}
+	return file_tern_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *VolumeRequest) GetApplyId() string {
@@ -2275,7 +2341,7 @@ type VolumeResponse struct {
 
 func (x *VolumeResponse) Reset() {
 	*x = VolumeResponse{}
-	mi := &file_tern_proto_msgTypes[28]
+	mi := &file_tern_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2287,7 +2353,7 @@ func (x *VolumeResponse) String() string {
 func (*VolumeResponse) ProtoMessage() {}
 
 func (x *VolumeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[28]
+	mi := &file_tern_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2300,7 +2366,7 @@ func (x *VolumeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VolumeResponse.ProtoReflect.Descriptor instead.
 func (*VolumeResponse) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{28}
+	return file_tern_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *VolumeResponse) GetAccepted() bool {
@@ -2342,22 +2408,34 @@ const file_tern_proto_rawDesc = "" +
 	"\n" +
 	"FilesEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"}\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x9b\x01\n" +
 	"\x11PullSchemaRequest\x12\x1a\n" +
 	"\bdatabase\x18\x01 \x01(\tR\bdatabase\x12\x12\n" +
 	"\x04type\x18\x02 \x01(\tR\x04type\x12 \n" +
 	"\venvironment\x18\x03 \x01(\tR\venvironment\x12\x16\n" +
-	"\x06target\x18\x04 \x01(\tR\x06target\"\xae\x02\n" +
+	"\x06target\x18\x04 \x01(\tR\x06target\x12\x1c\n" +
+	"\tnamespace\x18\x05 \x01(\tR\tnamespace\"\x8f\x02\n" +
+	"\x0fPulledNamespace\x12<\n" +
+	"\x06tables\x18\x01 \x03(\v2$.tern.v1.PulledNamespace.TablesEntryR\x06tables\x12E\n" +
+	"\tartifacts\x18\x02 \x03(\v2'.tern.v1.PulledNamespace.ArtifactsEntryR\tartifacts\x1a9\n" +
+	"\vTablesEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\x1a<\n" +
+	"\x0eArtifactsEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xad\x02\n" +
 	"\x12PullSchemaResponse\x12\x1a\n" +
 	"\bdatabase\x18\x01 \x01(\tR\bdatabase\x12\x12\n" +
 	"\x04type\x18\x02 \x01(\tR\x04type\x12 \n" +
-	"\venvironment\x18\x03 \x01(\tR\venvironment\x12O\n" +
-	"\fschema_files\x18\x04 \x03(\v2,.tern.v1.PullSchemaResponse.SchemaFilesEntryR\vschemaFiles\x12\x1f\n" +
+	"\venvironment\x18\x03 \x01(\tR\venvironment\x12K\n" +
+	"\n" +
+	"namespaces\x18\x04 \x03(\v2+.tern.v1.PullSchemaResponse.NamespacesEntryR\n" +
+	"namespaces\x12\x1f\n" +
 	"\vtable_count\x18\x05 \x01(\x05R\n" +
-	"tableCount\x1aT\n" +
-	"\x10SchemaFilesEntry\x12\x10\n" +
-	"\x03key\x18\x01 \x01(\tR\x03key\x12*\n" +
-	"\x05value\x18\x02 \x01(\v2\x14.tern.v1.SchemaFilesR\x05value:\x028\x01\"\x9c\x03\n" +
+	"tableCount\x1aW\n" +
+	"\x0fNamespacesEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12.\n" +
+	"\x05value\x18\x02 \x01(\v2\x18.tern.v1.PulledNamespaceR\x05value:\x028\x01\"\x9c\x03\n" +
 	"\vPlanRequest\x12\x1a\n" +
 	"\bdatabase\x18\x01 \x01(\tR\bdatabase\x12\x12\n" +
 	"\x04type\x18\x02 \x01(\tR\x04type\x12H\n" +
@@ -2594,98 +2672,103 @@ func file_tern_proto_rawDescGZIP() []byte {
 }
 
 var file_tern_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
-var file_tern_proto_msgTypes = make([]protoimpl.MessageInfo, 36)
+var file_tern_proto_msgTypes = make([]protoimpl.MessageInfo, 39)
 var file_tern_proto_goTypes = []any{
 	(Engine)(0),                // 0: tern.v1.Engine
 	(State)(0),                 // 1: tern.v1.State
 	(ChangeType)(0),            // 2: tern.v1.ChangeType
 	(*SchemaFiles)(nil),        // 3: tern.v1.SchemaFiles
 	(*PullSchemaRequest)(nil),  // 4: tern.v1.PullSchemaRequest
-	(*PullSchemaResponse)(nil), // 5: tern.v1.PullSchemaResponse
-	(*PlanRequest)(nil),        // 6: tern.v1.PlanRequest
-	(*TableChange)(nil),        // 7: tern.v1.TableChange
-	(*SchemaChange)(nil),       // 8: tern.v1.SchemaChange
-	(*LintViolation)(nil),      // 9: tern.v1.LintViolation
-	(*ShardPlan)(nil),          // 10: tern.v1.ShardPlan
-	(*PlanResponse)(nil),       // 11: tern.v1.PlanResponse
-	(*ApplyRequest)(nil),       // 12: tern.v1.ApplyRequest
-	(*ApplyResponse)(nil),      // 13: tern.v1.ApplyResponse
-	(*ProgressRequest)(nil),    // 14: tern.v1.ProgressRequest
-	(*ShardProgress)(nil),      // 15: tern.v1.ShardProgress
-	(*TableProgress)(nil),      // 16: tern.v1.TableProgress
-	(*ProgressResponse)(nil),   // 17: tern.v1.ProgressResponse
-	(*CutoverRequest)(nil),     // 18: tern.v1.CutoverRequest
-	(*CutoverResponse)(nil),    // 19: tern.v1.CutoverResponse
-	(*RevertRequest)(nil),      // 20: tern.v1.RevertRequest
-	(*RevertResponse)(nil),     // 21: tern.v1.RevertResponse
-	(*SkipRevertRequest)(nil),  // 22: tern.v1.SkipRevertRequest
-	(*SkipRevertResponse)(nil), // 23: tern.v1.SkipRevertResponse
-	(*HealthRequest)(nil),      // 24: tern.v1.HealthRequest
-	(*HealthResponse)(nil),     // 25: tern.v1.HealthResponse
-	(*StopRequest)(nil),        // 26: tern.v1.StopRequest
-	(*StopResponse)(nil),       // 27: tern.v1.StopResponse
-	(*StartRequest)(nil),       // 28: tern.v1.StartRequest
-	(*StartResponse)(nil),      // 29: tern.v1.StartResponse
-	(*VolumeRequest)(nil),      // 30: tern.v1.VolumeRequest
-	(*VolumeResponse)(nil),     // 31: tern.v1.VolumeResponse
-	nil,                        // 32: tern.v1.SchemaFiles.FilesEntry
-	nil,                        // 33: tern.v1.PullSchemaResponse.SchemaFilesEntry
-	nil,                        // 34: tern.v1.PlanRequest.SchemaFilesEntry
-	nil,                        // 35: tern.v1.SchemaChange.MetadataEntry
-	nil,                        // 36: tern.v1.ApplyRequest.OptionsEntry
-	nil,                        // 37: tern.v1.ApplyRequest.SchemaFilesEntry
-	nil,                        // 38: tern.v1.ProgressResponse.MetadataEntry
+	(*PulledNamespace)(nil),    // 5: tern.v1.PulledNamespace
+	(*PullSchemaResponse)(nil), // 6: tern.v1.PullSchemaResponse
+	(*PlanRequest)(nil),        // 7: tern.v1.PlanRequest
+	(*TableChange)(nil),        // 8: tern.v1.TableChange
+	(*SchemaChange)(nil),       // 9: tern.v1.SchemaChange
+	(*LintViolation)(nil),      // 10: tern.v1.LintViolation
+	(*ShardPlan)(nil),          // 11: tern.v1.ShardPlan
+	(*PlanResponse)(nil),       // 12: tern.v1.PlanResponse
+	(*ApplyRequest)(nil),       // 13: tern.v1.ApplyRequest
+	(*ApplyResponse)(nil),      // 14: tern.v1.ApplyResponse
+	(*ProgressRequest)(nil),    // 15: tern.v1.ProgressRequest
+	(*ShardProgress)(nil),      // 16: tern.v1.ShardProgress
+	(*TableProgress)(nil),      // 17: tern.v1.TableProgress
+	(*ProgressResponse)(nil),   // 18: tern.v1.ProgressResponse
+	(*CutoverRequest)(nil),     // 19: tern.v1.CutoverRequest
+	(*CutoverResponse)(nil),    // 20: tern.v1.CutoverResponse
+	(*RevertRequest)(nil),      // 21: tern.v1.RevertRequest
+	(*RevertResponse)(nil),     // 22: tern.v1.RevertResponse
+	(*SkipRevertRequest)(nil),  // 23: tern.v1.SkipRevertRequest
+	(*SkipRevertResponse)(nil), // 24: tern.v1.SkipRevertResponse
+	(*HealthRequest)(nil),      // 25: tern.v1.HealthRequest
+	(*HealthResponse)(nil),     // 26: tern.v1.HealthResponse
+	(*StopRequest)(nil),        // 27: tern.v1.StopRequest
+	(*StopResponse)(nil),       // 28: tern.v1.StopResponse
+	(*StartRequest)(nil),       // 29: tern.v1.StartRequest
+	(*StartResponse)(nil),      // 30: tern.v1.StartResponse
+	(*VolumeRequest)(nil),      // 31: tern.v1.VolumeRequest
+	(*VolumeResponse)(nil),     // 32: tern.v1.VolumeResponse
+	nil,                        // 33: tern.v1.SchemaFiles.FilesEntry
+	nil,                        // 34: tern.v1.PulledNamespace.TablesEntry
+	nil,                        // 35: tern.v1.PulledNamespace.ArtifactsEntry
+	nil,                        // 36: tern.v1.PullSchemaResponse.NamespacesEntry
+	nil,                        // 37: tern.v1.PlanRequest.SchemaFilesEntry
+	nil,                        // 38: tern.v1.SchemaChange.MetadataEntry
+	nil,                        // 39: tern.v1.ApplyRequest.OptionsEntry
+	nil,                        // 40: tern.v1.ApplyRequest.SchemaFilesEntry
+	nil,                        // 41: tern.v1.ProgressResponse.MetadataEntry
 }
 var file_tern_proto_depIdxs = []int32{
-	32, // 0: tern.v1.SchemaFiles.files:type_name -> tern.v1.SchemaFiles.FilesEntry
-	33, // 1: tern.v1.PullSchemaResponse.schema_files:type_name -> tern.v1.PullSchemaResponse.SchemaFilesEntry
-	34, // 2: tern.v1.PlanRequest.schema_files:type_name -> tern.v1.PlanRequest.SchemaFilesEntry
-	2,  // 3: tern.v1.TableChange.change_type:type_name -> tern.v1.ChangeType
-	7,  // 4: tern.v1.SchemaChange.table_changes:type_name -> tern.v1.TableChange
-	35, // 5: tern.v1.SchemaChange.metadata:type_name -> tern.v1.SchemaChange.MetadataEntry
-	0,  // 6: tern.v1.PlanResponse.engine:type_name -> tern.v1.Engine
-	8,  // 7: tern.v1.PlanResponse.changes:type_name -> tern.v1.SchemaChange
-	9,  // 8: tern.v1.PlanResponse.lint_violations:type_name -> tern.v1.LintViolation
-	10, // 9: tern.v1.PlanResponse.shards:type_name -> tern.v1.ShardPlan
-	36, // 10: tern.v1.ApplyRequest.options:type_name -> tern.v1.ApplyRequest.OptionsEntry
-	37, // 11: tern.v1.ApplyRequest.schema_files:type_name -> tern.v1.ApplyRequest.SchemaFilesEntry
-	7,  // 12: tern.v1.ApplyRequest.ddl_changes:type_name -> tern.v1.TableChange
-	15, // 13: tern.v1.TableProgress.shards:type_name -> tern.v1.ShardProgress
-	2,  // 14: tern.v1.TableProgress.change_type:type_name -> tern.v1.ChangeType
-	1,  // 15: tern.v1.ProgressResponse.state:type_name -> tern.v1.State
-	0,  // 16: tern.v1.ProgressResponse.engine:type_name -> tern.v1.Engine
-	16, // 17: tern.v1.ProgressResponse.tables:type_name -> tern.v1.TableProgress
-	38, // 18: tern.v1.ProgressResponse.metadata:type_name -> tern.v1.ProgressResponse.MetadataEntry
-	3,  // 19: tern.v1.PullSchemaResponse.SchemaFilesEntry.value:type_name -> tern.v1.SchemaFiles
-	3,  // 20: tern.v1.PlanRequest.SchemaFilesEntry.value:type_name -> tern.v1.SchemaFiles
-	3,  // 21: tern.v1.ApplyRequest.SchemaFilesEntry.value:type_name -> tern.v1.SchemaFiles
-	4,  // 22: tern.v1.Tern.PullSchema:input_type -> tern.v1.PullSchemaRequest
-	6,  // 23: tern.v1.Tern.Plan:input_type -> tern.v1.PlanRequest
-	12, // 24: tern.v1.Tern.Apply:input_type -> tern.v1.ApplyRequest
-	14, // 25: tern.v1.Tern.Progress:input_type -> tern.v1.ProgressRequest
-	18, // 26: tern.v1.Tern.Cutover:input_type -> tern.v1.CutoverRequest
-	20, // 27: tern.v1.Tern.Revert:input_type -> tern.v1.RevertRequest
-	22, // 28: tern.v1.Tern.SkipRevert:input_type -> tern.v1.SkipRevertRequest
-	24, // 29: tern.v1.Tern.Health:input_type -> tern.v1.HealthRequest
-	26, // 30: tern.v1.Tern.Stop:input_type -> tern.v1.StopRequest
-	28, // 31: tern.v1.Tern.Start:input_type -> tern.v1.StartRequest
-	30, // 32: tern.v1.Tern.Volume:input_type -> tern.v1.VolumeRequest
-	5,  // 33: tern.v1.Tern.PullSchema:output_type -> tern.v1.PullSchemaResponse
-	11, // 34: tern.v1.Tern.Plan:output_type -> tern.v1.PlanResponse
-	13, // 35: tern.v1.Tern.Apply:output_type -> tern.v1.ApplyResponse
-	17, // 36: tern.v1.Tern.Progress:output_type -> tern.v1.ProgressResponse
-	19, // 37: tern.v1.Tern.Cutover:output_type -> tern.v1.CutoverResponse
-	21, // 38: tern.v1.Tern.Revert:output_type -> tern.v1.RevertResponse
-	23, // 39: tern.v1.Tern.SkipRevert:output_type -> tern.v1.SkipRevertResponse
-	25, // 40: tern.v1.Tern.Health:output_type -> tern.v1.HealthResponse
-	27, // 41: tern.v1.Tern.Stop:output_type -> tern.v1.StopResponse
-	29, // 42: tern.v1.Tern.Start:output_type -> tern.v1.StartResponse
-	31, // 43: tern.v1.Tern.Volume:output_type -> tern.v1.VolumeResponse
-	33, // [33:44] is the sub-list for method output_type
-	22, // [22:33] is the sub-list for method input_type
-	22, // [22:22] is the sub-list for extension type_name
-	22, // [22:22] is the sub-list for extension extendee
-	0,  // [0:22] is the sub-list for field type_name
+	33, // 0: tern.v1.SchemaFiles.files:type_name -> tern.v1.SchemaFiles.FilesEntry
+	34, // 1: tern.v1.PulledNamespace.tables:type_name -> tern.v1.PulledNamespace.TablesEntry
+	35, // 2: tern.v1.PulledNamespace.artifacts:type_name -> tern.v1.PulledNamespace.ArtifactsEntry
+	36, // 3: tern.v1.PullSchemaResponse.namespaces:type_name -> tern.v1.PullSchemaResponse.NamespacesEntry
+	37, // 4: tern.v1.PlanRequest.schema_files:type_name -> tern.v1.PlanRequest.SchemaFilesEntry
+	2,  // 5: tern.v1.TableChange.change_type:type_name -> tern.v1.ChangeType
+	8,  // 6: tern.v1.SchemaChange.table_changes:type_name -> tern.v1.TableChange
+	38, // 7: tern.v1.SchemaChange.metadata:type_name -> tern.v1.SchemaChange.MetadataEntry
+	0,  // 8: tern.v1.PlanResponse.engine:type_name -> tern.v1.Engine
+	9,  // 9: tern.v1.PlanResponse.changes:type_name -> tern.v1.SchemaChange
+	10, // 10: tern.v1.PlanResponse.lint_violations:type_name -> tern.v1.LintViolation
+	11, // 11: tern.v1.PlanResponse.shards:type_name -> tern.v1.ShardPlan
+	39, // 12: tern.v1.ApplyRequest.options:type_name -> tern.v1.ApplyRequest.OptionsEntry
+	40, // 13: tern.v1.ApplyRequest.schema_files:type_name -> tern.v1.ApplyRequest.SchemaFilesEntry
+	8,  // 14: tern.v1.ApplyRequest.ddl_changes:type_name -> tern.v1.TableChange
+	16, // 15: tern.v1.TableProgress.shards:type_name -> tern.v1.ShardProgress
+	2,  // 16: tern.v1.TableProgress.change_type:type_name -> tern.v1.ChangeType
+	1,  // 17: tern.v1.ProgressResponse.state:type_name -> tern.v1.State
+	0,  // 18: tern.v1.ProgressResponse.engine:type_name -> tern.v1.Engine
+	17, // 19: tern.v1.ProgressResponse.tables:type_name -> tern.v1.TableProgress
+	41, // 20: tern.v1.ProgressResponse.metadata:type_name -> tern.v1.ProgressResponse.MetadataEntry
+	5,  // 21: tern.v1.PullSchemaResponse.NamespacesEntry.value:type_name -> tern.v1.PulledNamespace
+	3,  // 22: tern.v1.PlanRequest.SchemaFilesEntry.value:type_name -> tern.v1.SchemaFiles
+	3,  // 23: tern.v1.ApplyRequest.SchemaFilesEntry.value:type_name -> tern.v1.SchemaFiles
+	4,  // 24: tern.v1.Tern.PullSchema:input_type -> tern.v1.PullSchemaRequest
+	7,  // 25: tern.v1.Tern.Plan:input_type -> tern.v1.PlanRequest
+	13, // 26: tern.v1.Tern.Apply:input_type -> tern.v1.ApplyRequest
+	15, // 27: tern.v1.Tern.Progress:input_type -> tern.v1.ProgressRequest
+	19, // 28: tern.v1.Tern.Cutover:input_type -> tern.v1.CutoverRequest
+	21, // 29: tern.v1.Tern.Revert:input_type -> tern.v1.RevertRequest
+	23, // 30: tern.v1.Tern.SkipRevert:input_type -> tern.v1.SkipRevertRequest
+	25, // 31: tern.v1.Tern.Health:input_type -> tern.v1.HealthRequest
+	27, // 32: tern.v1.Tern.Stop:input_type -> tern.v1.StopRequest
+	29, // 33: tern.v1.Tern.Start:input_type -> tern.v1.StartRequest
+	31, // 34: tern.v1.Tern.Volume:input_type -> tern.v1.VolumeRequest
+	6,  // 35: tern.v1.Tern.PullSchema:output_type -> tern.v1.PullSchemaResponse
+	12, // 36: tern.v1.Tern.Plan:output_type -> tern.v1.PlanResponse
+	14, // 37: tern.v1.Tern.Apply:output_type -> tern.v1.ApplyResponse
+	18, // 38: tern.v1.Tern.Progress:output_type -> tern.v1.ProgressResponse
+	20, // 39: tern.v1.Tern.Cutover:output_type -> tern.v1.CutoverResponse
+	22, // 40: tern.v1.Tern.Revert:output_type -> tern.v1.RevertResponse
+	24, // 41: tern.v1.Tern.SkipRevert:output_type -> tern.v1.SkipRevertResponse
+	26, // 42: tern.v1.Tern.Health:output_type -> tern.v1.HealthResponse
+	28, // 43: tern.v1.Tern.Stop:output_type -> tern.v1.StopResponse
+	30, // 44: tern.v1.Tern.Start:output_type -> tern.v1.StartResponse
+	32, // 45: tern.v1.Tern.Volume:output_type -> tern.v1.VolumeResponse
+	35, // [35:46] is the sub-list for method output_type
+	24, // [24:35] is the sub-list for method input_type
+	24, // [24:24] is the sub-list for extension type_name
+	24, // [24:24] is the sub-list for extension extendee
+	0,  // [0:24] is the sub-list for field type_name
 }
 
 func init() { file_tern_proto_init() }
@@ -2699,7 +2782,7 @@ func file_tern_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_tern_proto_rawDesc), len(file_tern_proto_rawDesc)),
 			NumEnums:      3,
-			NumMessages:   36,
+			NumMessages:   39,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/pkg/schema/namespace.go
+++ b/pkg/schema/namespace.go
@@ -82,3 +82,14 @@ func GroupFilesByNamespace(files map[string]string, defaultNamespace string, env
 
 	return result, nil
 }
+
+// IsReservedPullNamespace reports whether a live namespace should be excluded
+// from schema pull discovery and rejected for explicit pull requests.
+func IsReservedPullNamespace(namespace string) bool {
+	switch strings.ToLower(namespace) {
+	case "_pending_drops", "dbadmin", "information_schema", "mysql", "performance_schema", "schemabot", "sys":
+		return true
+	default:
+		return strings.HasPrefix(namespace, "_")
+	}
+}

--- a/pkg/schema/namespace_test.go
+++ b/pkg/schema/namespace_test.go
@@ -213,3 +213,23 @@ func TestGroupFilesByNamespace_EnvSubstitution_MultipleNamespaces(t *testing.T) 
 	assert.Contains(t, result, "app_staging")
 	assert.Contains(t, result, "analytics")
 }
+
+func TestIsReservedPullNamespace(t *testing.T) {
+	tests := []struct {
+		name      string
+		namespace string
+		want      bool
+	}{
+		{name: "pending drops", namespace: "_pending_drops", want: true},
+		{name: "system schema", namespace: "information_schema", want: true},
+		{name: "schemabot storage", namespace: "schemabot", want: true},
+		{name: "underscore prefix", namespace: "_scratch", want: true},
+		{name: "application namespace", namespace: "orders_production", want: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, IsReservedPullNamespace(tc.namespace))
+		})
+	}
+}

--- a/pkg/tern/local_client.go
+++ b/pkg/tern/local_client.go
@@ -90,6 +90,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"maps"
 	"sort"
 	"strings"
 	"sync"
@@ -323,11 +324,19 @@ func mysqlDSNWithDatabase(dsn, database string) (string, error) {
 }
 
 func mysqlDSNHasDatabase(dsn string) (bool, error) {
+	database, err := mysqlDSNDatabase(dsn)
+	if err != nil {
+		return false, err
+	}
+	return database != "", nil
+}
+
+func mysqlDSNDatabase(dsn string) (string, error) {
 	cfg, err := mysql.ParseDSN(dsn)
 	if err != nil {
-		return false, fmt.Errorf("parse MySQL DSN: %w", err)
+		return "", fmt.Errorf("parse MySQL DSN: %w", err)
 	}
-	return cfg.DBName != "", nil
+	return cfg.DBName, nil
 }
 
 func (c *LocalClient) deferredCutoverSignalExists(ctx context.Context, apply *storage.Apply) (bool, bool, error) {
@@ -362,58 +371,166 @@ func (c *LocalClient) PullSchema(ctx context.Context, req *ternv1.PullSchemaRequ
 	if req.Type != "" && req.Type != c.config.Type {
 		return nil, fmt.Errorf("pull schema for database %s: request type %q does not match client type %q: %w", c.config.Database, req.Type, c.config.Type, ErrPullSchemaInvalidRequest)
 	}
+	if req.GetNamespace() == "" {
+		return c.pullAllNamespaces(ctx, req)
+	}
+	return c.pullSchemaNamespace(ctx, req, req.GetNamespace())
+}
 
+func (c *LocalClient) pullAllNamespaces(ctx context.Context, req *ternv1.PullSchemaRequest) (*ternv1.PullSchemaResponse, error) {
+	namespaces, err := c.discoverPullNamespaces(ctx)
+	if err != nil {
+		return nil, err
+	}
+	merged := &ternv1.PullSchemaResponse{
+		Database:    c.pullResponseDatabase(req),
+		Type:        c.config.Type,
+		Environment: req.Environment,
+		Namespaces:  make(map[string]*ternv1.PulledNamespace, len(namespaces)),
+	}
+	for _, namespace := range namespaces {
+		resp, err := c.pullSchemaNamespace(ctx, req, namespace)
+		if err != nil {
+			return nil, err
+		}
+		merged.TableCount += resp.TableCount
+		maps.Copy(merged.Namespaces, resp.Namespaces)
+	}
+	return merged, nil
+}
+
+func (c *LocalClient) discoverPullNamespaces(ctx context.Context) ([]string, error) {
+	if database, err := mysqlDSNDatabase(c.config.TargetDSN); err != nil {
+		return nil, fmt.Errorf("inspect MySQL target DSN for namespace discovery: %w", err)
+	} else if database != "" {
+		c.logger.Info("LocalClient.PullSchema: using target DSN database as live namespace", "database", c.config.Database, "namespace", database)
+		return []string{database}, nil
+	}
+
+	attrs := []any{"database", c.config.Database}
+	attrs = append(attrs, dsnLogAttrs(c.config.TargetDSN)...)
+	c.logger.Info("LocalClient.PullSchema: discovering live namespaces", attrs...)
+
+	db, err := mysqlconn.Open(c.config.TargetDSN)
+	if err != nil {
+		return nil, fmt.Errorf("open database target for namespace discovery: %w", err)
+	}
+	defer utils.CloseAndLog(db)
+	if err := db.PingContext(ctx); err != nil {
+		return nil, fmt.Errorf("ping database target for namespace discovery: %w", err)
+	}
+	rows, err := db.QueryContext(ctx, `SELECT schema_name FROM information_schema.schemata ORDER BY schema_name`)
+	if err != nil {
+		return nil, fmt.Errorf("list namespaces for schema pull: %w", err)
+	}
+	defer utils.CloseAndLog(rows)
+
+	var namespaces []string
+	for rows.Next() {
+		var namespace string
+		if err := rows.Scan(&namespace); err != nil {
+			return nil, fmt.Errorf("scan namespace for schema pull: %w", err)
+		}
+		if schema.IsReservedPullNamespace(namespace) {
+			c.logger.Debug("LocalClient.PullSchema: skipping reserved namespace", "database", c.config.Database, "namespace", namespace)
+			continue
+		}
+		namespaces = append(namespaces, namespace)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate namespaces for schema pull: %w", err)
+	}
+	c.logger.Info("LocalClient.PullSchema: discovered live namespaces", "database", c.config.Database, "namespace_count", len(namespaces))
+	return namespaces, nil
+}
+
+func (c *LocalClient) pullSchemaNamespace(ctx context.Context, req *ternv1.PullSchemaRequest, namespace string) (*ternv1.PullSchemaResponse, error) {
 	targetDSN := c.config.TargetDSN
 	if c.config.Type == storage.DatabaseTypeMySQL {
-		creds, err := c.credentialsForMySQLNamespace(c.config.Database)
+		creds, err := c.credentialsForMySQLPullNamespace(namespace)
 		if err != nil {
-			return nil, fmt.Errorf("resolve database %s credentials for schema pull: %w", c.config.Database, err)
+			return nil, fmt.Errorf("resolve database %s namespace %s credentials for schema pull: %w", c.config.Database, namespace, err)
 		}
 		targetDSN = creds.DSN
 	}
 
-	attrs := []any{"database", c.config.Database}
+	attrs := []any{"database", c.config.Database, "namespace", namespace}
 	attrs = append(attrs, dsnLogAttrs(targetDSN)...)
 	c.logger.Info("LocalClient.PullSchema: loading live schema", attrs...)
 
 	db, err := mysqlconn.Open(targetDSN)
 	if err != nil {
-		return nil, fmt.Errorf("open database %s for schema pull: %w", c.config.Database, err)
+		return nil, fmt.Errorf("open database %s namespace %s for schema pull: %w", c.config.Database, namespace, err)
 	}
 	defer utils.CloseAndLog(db)
 
 	if err := db.PingContext(ctx); err != nil {
-		return nil, fmt.Errorf("ping database %s for schema pull: %w", c.config.Database, err)
+		return nil, fmt.Errorf("ping database %s namespace %s for schema pull: %w", c.config.Database, namespace, err)
 	}
 
 	tables, err := spirittable.LoadSchemaFromDB(ctx, db, spirittable.WithoutUnderscoreTables, spirittable.WithoutArchiveTables, spirittable.WithStrippedAutoIncrement)
 	if err != nil {
-		return nil, fmt.Errorf("load live schema for database %s: %w", c.config.Database, err)
+		return nil, fmt.Errorf("load live schema for database %s namespace %s: %w", c.config.Database, namespace, err)
 	}
 	sort.Slice(tables, func(i, j int) bool { return tables[i].Name < tables[j].Name })
 
-	files := make(map[string]string, len(tables))
+	pulledTables := make(map[string]string, len(tables))
 	for _, tbl := range tables {
-		content, err := pulledSchemaFileContent(c.config.Database, tbl)
+		content, err := pulledSchemaFileContent(namespace, tbl)
 		if err != nil {
 			return nil, err
 		}
-		files[tbl.Name+".sql"] = content
+		pulledTables[tbl.Name] = content
 	}
 
 	c.logger.Info("LocalClient.PullSchema: loaded live schema",
 		"database", c.config.Database,
+		"namespace", namespace,
 		"table_count", len(tables),
 	)
 
 	return &ternv1.PullSchemaResponse{
-		Database:    c.config.Database,
+		Database:    c.pullResponseDatabase(req),
 		Type:        c.config.Type,
 		Environment: req.Environment,
-		SchemaFiles: map[string]*ternv1.SchemaFiles{
-			c.config.Database: {Files: files},
+		Namespaces: map[string]*ternv1.PulledNamespace{
+			namespace: {Tables: pulledTables},
 		},
 		TableCount: int32(len(tables)),
+	}, nil
+}
+
+func (c *LocalClient) pullResponseDatabase(req *ternv1.PullSchemaRequest) string {
+	if req.GetDatabase() != "" {
+		return req.GetDatabase()
+	}
+	return c.config.Database
+}
+
+func (c *LocalClient) credentialsForMySQLPullNamespace(namespace string) (*engine.Credentials, error) {
+	if c.config.Type != storage.DatabaseTypeMySQL {
+		return c.credentials(), nil
+	}
+	database, err := mysqlDSNDatabase(c.config.TargetDSN)
+	if err != nil {
+		return nil, fmt.Errorf("inspect MySQL target DSN for namespace injection: %w", err)
+	}
+	if database != "" {
+		if database != namespace {
+			return nil, fmt.Errorf("target DSN database %q does not match requested namespace %q", database, namespace)
+		}
+		return c.credentials(), nil
+	}
+	if namespace == "" {
+		return nil, fmt.Errorf("MySQL namespace is required for a namespace-free target DSN")
+	}
+	dsn, err := mysqlDSNWithDatabase(c.config.TargetDSN, namespace)
+	if err != nil {
+		return nil, err
+	}
+	return &engine.Credentials{
+		DSN:      dsn,
+		Metadata: c.config.Metadata,
 	}, nil
 }
 

--- a/pkg/tern/local_client_integration_test.go
+++ b/pkg/tern/local_client_integration_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/block/spirit/pkg/statement"
 	"github.com/block/spirit/pkg/table"
 	"github.com/block/spirit/pkg/utils"
-	_ "github.com/go-sql-driver/mysql"
+	drivermysql "github.com/go-sql-driver/mysql"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go/modules/mysql"
@@ -510,13 +510,84 @@ func TestLocalClient_PullSchemaLoadsLiveMySQLSchema(t *testing.T) {
 	assert.Equal(t, "testdb", resp.Database)
 	assert.Equal(t, storage.DatabaseTypeMySQL, resp.Type)
 	assert.Equal(t, localClientTestEnvironment, resp.Environment)
-	require.Contains(t, resp.SchemaFiles, "testdb")
-	ddl := resp.SchemaFiles["testdb"].Files["pull_schema_users.sql"]
+	require.Contains(t, resp.Namespaces, "testdb")
+	ddl := resp.Namespaces["testdb"].Tables["pull_schema_users"]
 	assert.Contains(t, ddl, "CREATE TABLE `pull_schema_users`")
 	assert.Contains(t, ddl, "`email` varchar(255) NOT NULL")
 	assert.NotContains(t, ddl, "AUTO_INCREMENT=")
 	assert.True(t, strings.HasSuffix(ddl, "\n"), "pulled schema file should end with a newline")
-	assert.NotContains(t, resp.SchemaFiles["testdb"].Files, "pull_schema_users_archive_2026_06_12.sql")
+	assert.NotContains(t, resp.Namespaces["testdb"].Tables, "pull_schema_users_archive_2026_06_12")
+}
+
+// Pulling all live MySQL namespaces discovers application schemas while
+// excluding system, SchemaBot storage, pending-drop, and underscore-prefixed
+// namespaces from the exported declarative files.
+func TestLocalClient_PullSchemaDiscoversNonReservedNamespaces(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	container, dsn := setupMySQLContainer(t)
+	_ = container // container is managed by TestMain
+	db, err := sql.Open("mysql", dsn)
+	require.NoError(t, err, "open database")
+	defer utils.CloseAndLog(db)
+
+	for _, stmt := range []string{
+		"CREATE DATABASE IF NOT EXISTS `pull_primary`",
+		"CREATE DATABASE IF NOT EXISTS `pull_audit`",
+		"CREATE DATABASE IF NOT EXISTS `_pull_reserved`",
+		"CREATE TABLE IF NOT EXISTS `pull_primary`.`users` (`id` bigint unsigned NOT NULL, PRIMARY KEY (`id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci",
+		"CREATE TABLE IF NOT EXISTS `pull_audit`.`events` (`id` bigint unsigned NOT NULL, PRIMARY KEY (`id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci",
+		"CREATE TABLE IF NOT EXISTS `_pull_reserved`.`old_users` (`id` bigint unsigned NOT NULL, PRIMARY KEY (`id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci",
+	} {
+		_, err = db.ExecContext(t.Context(), stmt)
+		require.NoError(t, err, "prepare namespace discovery schema")
+	}
+	t.Cleanup(func() {
+		cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(t.Context()), 30*time.Second)
+		defer cancel()
+		cleanupDB, cleanupErr := sql.Open("mysql", dsn)
+		require.NoError(t, cleanupErr, "open database for namespace discovery cleanup")
+		defer utils.CloseAndLog(cleanupDB)
+		for _, stmt := range []string{
+			"DROP DATABASE IF EXISTS `pull_primary`",
+			"DROP DATABASE IF EXISTS `pull_audit`",
+			"DROP DATABASE IF EXISTS `_pull_reserved`",
+		} {
+			_, cleanupErr = cleanupDB.ExecContext(cleanupCtx, stmt)
+			assert.NoError(t, cleanupErr, "cleanup namespace discovery schema")
+		}
+	})
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	client, err := NewLocalClient(LocalConfig{
+		Database:  "logicaldb",
+		Type:      storage.DatabaseTypeMySQL,
+		TargetDSN: dsnWithoutDatabase(t, dsn),
+	}, nil, logger)
+	require.NoError(t, err, "create client")
+	defer utils.CloseAndLog(client)
+
+	resp, err := client.PullSchema(t.Context(), &ternv1.PullSchemaRequest{
+		Database:    "logicaldb",
+		Type:        storage.DatabaseTypeMySQL,
+		Environment: localClientTestEnvironment,
+	})
+
+	require.NoError(t, err, "pull all namespaces")
+	assert.Contains(t, resp.Namespaces, "pull_primary")
+	assert.Contains(t, resp.Namespaces, "pull_audit")
+	assert.NotContains(t, resp.Namespaces, "_pull_reserved")
+	assert.NotContains(t, resp.Namespaces, "schemabot")
+}
+
+func dsnWithoutDatabase(t *testing.T, dsn string) string {
+	t.Helper()
+	cfg, err := drivermysql.ParseDSN(dsn)
+	require.NoError(t, err)
+	cfg.DBName = ""
+	return cfg.FormatDSN()
 }
 
 func TestLocalClient_Plan(t *testing.T) {

--- a/pkg/tern/local_client_test.go
+++ b/pkg/tern/local_client_test.go
@@ -1900,6 +1900,32 @@ func TestLocalClient_CredentialsNamespaceResolution(t *testing.T) {
 		assert.Equal(t, "root@tcp(localhost:3306)/orders_schema", creds.DSN)
 	})
 
+	t.Run("pull namespace must match database-bound DSN", func(t *testing.T) {
+		c := &LocalClient{config: LocalConfig{
+			Type:      storage.DatabaseTypeMySQL,
+			TargetDSN: "root@tcp(localhost:3306)/orders_schema",
+		}, logger: slog.Default()}
+
+		creds, err := c.credentialsForMySQLPullNamespace("orders_schema")
+		require.NoError(t, err)
+		assert.Equal(t, "root@tcp(localhost:3306)/orders_schema", creds.DSN)
+
+		_, err = c.credentialsForMySQLPullNamespace("audit_schema")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "does not match requested namespace")
+	})
+
+	t.Run("pull namespace-free DSN injects the namespace as the connection schema", func(t *testing.T) {
+		c := &LocalClient{config: LocalConfig{
+			Type:      storage.DatabaseTypeMySQL,
+			TargetDSN: "root@tcp(localhost:3306)/",
+		}, logger: slog.Default()}
+
+		creds, err := c.credentialsForMySQLPullNamespace("orders_schema")
+		require.NoError(t, err)
+		assert.Equal(t, "root@tcp(localhost:3306)/orders_schema", creds.DSN)
+	})
+
 	t.Run("namespace-free DSN without a namespace is an error", func(t *testing.T) {
 		c := &LocalClient{config: LocalConfig{
 			Type:      storage.DatabaseTypeMySQL,

--- a/pkg/tern/target_router.go
+++ b/pkg/tern/target_router.go
@@ -86,7 +86,11 @@ func (r *TargetRouter) PullSchema(ctx context.Context, req *ternv1.PullSchemaReq
 	if req == nil {
 		return nil, fmt.Errorf("pull schema request is required: %w", ErrPullSchemaInvalidRequest)
 	}
-	client, resolved, err := r.clientForTarget(ctx, targetOrDatabase(req.Target, req.Database), req.Type, req.Environment, req.Database)
+	localDatabase := req.Database
+	if req.GetNamespace() != "" {
+		localDatabase = req.GetNamespace()
+	}
+	client, resolved, err := r.clientForTarget(ctx, targetOrDatabase(req.Target, req.Database), req.Type, req.Environment, localDatabase)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/tern/target_router_test.go
+++ b/pkg/tern/target_router_test.go
@@ -206,6 +206,49 @@ func TestTargetRouterRoutesPlanThroughStaticTarget(t *testing.T) {
 	assert.Len(t, created, 1, "the router should cache LocalClients by resolved target route and namespace")
 }
 
+func TestTargetRouterRoutesPullSchemaNamespaceWithoutChangingLogicalDatabase(t *testing.T) {
+	resolver := newStaticResolver(t)
+	created := make(map[string]*targetRouterRecordingClient)
+	router := newTargetRouterForTest(t, resolver, nil, nil, created)
+
+	_, err := router.PullSchema(t.Context(), &ternv1.PullSchemaRequest{
+		Database:    "orders-logical",
+		Type:        storage.DatabaseTypeMySQL,
+		Environment: "production",
+		Target:      "dsid-orders-prod",
+		Namespace:   "orders_production",
+	})
+
+	require.NoError(t, err)
+	client := created["orders_production"]
+	require.NotNil(t, client)
+	require.NotNil(t, client.pullReq)
+	assert.Equal(t, "orders-logical", client.pullReq.Database)
+	assert.Equal(t, "orders_production", client.pullReq.Namespace)
+	assert.Equal(t, "dsid-orders-prod", client.pullReq.Target)
+}
+
+func TestTargetRouterRoutesAllNamespacePullWithoutInjectingNamespace(t *testing.T) {
+	resolver := newStaticResolver(t)
+	created := make(map[string]*targetRouterRecordingClient)
+	router := newTargetRouterForTest(t, resolver, nil, nil, created)
+
+	_, err := router.PullSchema(t.Context(), &ternv1.PullSchemaRequest{
+		Database:    "orders-logical",
+		Type:        storage.DatabaseTypeMySQL,
+		Environment: "production",
+		Target:      "dsid-orders-prod",
+	})
+
+	require.NoError(t, err)
+	client := created["orders-logical"]
+	require.NotNil(t, client)
+	require.NotNil(t, client.pullReq)
+	assert.Equal(t, "orders-logical", client.pullReq.Database)
+	assert.Empty(t, client.pullReq.Namespace)
+	assert.Equal(t, "dsid-orders-prod", client.pullReq.Target)
+}
+
 func TestTargetRouterRollbackPlanRoutesEnvironment(t *testing.T) {
 	var resolvedReq inventory.Request
 	resolver := targetRouterResolverFunc(func(_ context.Context, req inventory.Request) (*inventory.Target, error) {


### PR DESCRIPTION
## Summary

Add namespace filtering to schema pull while making the pull response object-oriented instead of file-layout-oriented. The request `database` stays the logical SchemaBot route/config key. Physical MySQL schemas are represented by request `namespaces` filters and response `namespaces` keys.

```diagram
Client request
     │
     ▼
SchemaBot API resolves database route
     │
     ▼
No namespaces? discover non-reserved target schemas
Namespaces set? validate/filter requested schemas
     │
     ▼
Data plane connects to each concrete namespace
     │
     ▼
Response groups tables by physical namespace
```

### Default: discover all non-reserved namespaces

```json
{
  "database": "app",
  "environment": "production",
  "type": "mysql"
}
```

`database` is only the logical route key. The returned physical schemas are the `namespaces` map keys, and table names map directly to canonical `CREATE TABLE` statements:

```json
{
  "database": "app",
  "environment": "production",
  "type": "mysql",
  "table_count": 2,
  "namespaces": {
    "app_production": {
      "tables": {
        "users": "CREATE TABLE `users` (...);\n"
      }
    },
    "app_audit_production": {
      "tables": {
        "events": "CREATE TABLE `events` (...);\n"
      }
    }
  }
}
```

Discovery filters reserved/system namespaces such as `_pending_drops`, `dbadmin`, `information_schema`, `mysql`, `performance_schema`, `schemabot`, `sys`, and underscore-prefixed namespaces.

### Filter: pull selected concrete namespaces

```json
{
  "database": "app",
  "environment": "production",
  "type": "mysql",
  "namespaces": ["app_production"]
}
```

Returns only the requested namespace group:

```json
{
  "database": "app",
  "environment": "production",
  "type": "mysql",
  "table_count": 1,
  "namespaces": {
    "app_production": {
      "tables": {
        "users": "CREATE TABLE `users` (...);\n"
      }
    }
  }
}
```

The response shape leaves file layout to clients. Today MySQL fills `tables`; future engines can use generic namespace `artifacts` for declarative non-table artifacts. For example, Vitess can return VSchema JSON without adding a Vitess-specific field to the shared API:

```json
{
  "namespaces": {
    "commerce": {
      "tables": {
        "orders": "CREATE TABLE `orders` (...);\n"
      },
      "artifacts": {
        "vschema": "{ ... }\n"
      }
    }
  }
}
```

Explicit namespaces must be concrete live schema names. They are rejected if they are empty, path-like, `$ENV`-templated, duplicated, or reserved.

The data plane also fails closed if a database-bound target DSN does not match the requested namespace, so exported content cannot be labeled under a namespace different from the schema that was actually loaded.

Generated with Amp.
