### PR TITLE
feat(cli): support onboard namespace templates

### DIFF
--- a/pkg/cmd/commands/onboard.go
+++ b/pkg/cmd/commands/onboard.go
@@ -16,13 +16,15 @@ import (
 
 // OnboardCmd pulls live schema into a new declarative schema directory.
 type OnboardCmd struct {
-	Database    string `short:"d" required:"" help:"Database name from SchemaBot server config"`
-	Environment string `short:"e" required:"" help:"Source environment to pull from"`
-	SchemaDir   string `short:"s" required:"" help:"Schema root to write schemabot.yaml and namespace directories" name:"schema_dir"`
-	Type        string `help:"Database type" default:"mysql" enum:"mysql"`
-	DryRun      bool   `help:"Preview files without writing them" name:"dry-run"`
-	Force       bool   `help:"Overwrite existing generated files"`
-	SkipVerify  bool   `help:"Skip plan verification after writing files" name:"skip-verify"`
+	Database          string   `short:"d" required:"" help:"Database name from SchemaBot server config"`
+	Environment       string   `short:"e" required:"" help:"Source environment to pull from"`
+	SchemaDir         string   `short:"s" required:"" help:"Schema root to write schemabot.yaml and namespace directories" name:"schema_dir"`
+	Type              string   `help:"Database type" default:"mysql" enum:"mysql"`
+	Namespaces        []string `name:"namespace" help:"Concrete live namespace to onboard. Repeat for multiple namespaces. Omit to discover all non-reserved namespaces."`
+	TemplateEnvSuffix bool     `help:"Write namespaces ending in _<environment> as _$ENV directories" name:"template-env-suffix"`
+	DryRun            bool     `help:"Preview files without writing them" name:"dry-run"`
+	Force             bool     `help:"Overwrite existing generated files"`
+	SkipVerify        bool     `help:"Skip plan verification after writing files" name:"skip-verify"`
 }
 
 // Run executes the onboard command.
@@ -32,12 +34,19 @@ func (cmd *OnboardCmd) Run(g *Globals) error {
 		return err
 	}
 
-	resp, err := client.CallPullSchemaAPI(ep, cmd.Database, cmd.Type, cmd.Environment)
+	pullNamespaces, err := onboardPullNamespaces(cmd.Namespaces)
+	if err != nil {
+		return err
+	}
+	resp, err := client.CallPullSchemaAPI(ep, cmd.Database, cmd.Type, cmd.Environment, pullNamespaces...)
 	if err != nil {
 		if outputSchemaPullRequestError("Onboard", cmd.Database, cmd.Environment, err) {
 			return ErrSilent
 		}
 		return fmt.Errorf("pull schema for database %s environment %s: %w", cmd.Database, cmd.Environment, err)
+	}
+	if err := rewriteOnboardNamespaces(resp, cmd.Environment, cmd.TemplateEnvSuffix); err != nil {
+		return err
 	}
 	plan, err := buildOnboardWritePlan(cmd.SchemaDir, resp)
 	if err != nil {
@@ -91,6 +100,58 @@ func (cmd *OnboardCmd) Run(g *Globals) error {
 type onboardWritePlan struct {
 	root  string
 	files map[string]string
+}
+
+func onboardPullNamespaces(namespaces []string) ([]string, error) {
+	if len(namespaces) == 0 {
+		return nil, nil
+	}
+	pullNamespaces := make([]string, 0, len(namespaces))
+	seen := make(map[string]struct{}, len(namespaces))
+	for _, outputNamespace := range namespaces {
+		if strings.TrimSpace(outputNamespace) != outputNamespace || outputNamespace == "" {
+			return nil, fmt.Errorf("namespace %q must be non-empty and contain no leading or trailing whitespace", outputNamespace)
+		}
+		if err := validateRelativePathPart("namespace", outputNamespace); err != nil {
+			return nil, err
+		}
+		if strings.Contains(outputNamespace, "$ENV") {
+			return nil, fmt.Errorf("namespace %q must be a concrete live namespace; use --template-env-suffix to write _$ENV directories when a live namespace ends with _<environment>", outputNamespace)
+		}
+		if _, ok := seen[outputNamespace]; ok {
+			return nil, fmt.Errorf("duplicate namespace %q", outputNamespace)
+		}
+		seen[outputNamespace] = struct{}{}
+		pullNamespaces = append(pullNamespaces, outputNamespace)
+	}
+	return pullNamespaces, nil
+}
+
+func rewriteOnboardNamespaces(resp *apitypes.PullSchemaResponse, environment string, templateEnvSuffix bool) error {
+	if resp == nil || len(resp.Namespaces) == 0 {
+		return nil
+	}
+	rewritten := make(map[string]*apitypes.PulledNamespace, len(resp.Namespaces))
+	for pullNamespace, pulled := range resp.Namespaces {
+		outputNamespace := onboardOutputNamespace(pullNamespace, environment, templateEnvSuffix)
+		if _, ok := rewritten[outputNamespace]; ok {
+			return fmt.Errorf("multiple pulled namespaces resolve to output namespace %q", outputNamespace)
+		}
+		rewritten[outputNamespace] = pulled
+	}
+	resp.Namespaces = rewritten
+	return nil
+}
+
+func onboardOutputNamespace(namespace, environment string, templateEnvSuffix bool) string {
+	if !templateEnvSuffix {
+		return namespace
+	}
+	environmentSuffix := "_" + environment
+	if environment != "" && strings.HasSuffix(namespace, environmentSuffix) {
+		return strings.TrimSuffix(namespace, environmentSuffix) + "_$ENV"
+	}
+	return namespace
 }
 
 func buildOnboardWritePlan(schemaRoot string, resp *apitypes.PullSchemaResponse) (*onboardWritePlan, error) {

--- a/pkg/cmd/commands/onboard_test.go
+++ b/pkg/cmd/commands/onboard_test.go
@@ -44,6 +44,47 @@ func TestBuildOnboardWritePlanWritesConfigAndNamespaceFiles(t *testing.T) {
 	assert.Equal(t, "CREATE TABLE `orders` (`id` bigint NOT NULL);\n", string(orders))
 }
 
+func TestOnboardPullNamespacesUseConcreteLiveNamespaces(t *testing.T) {
+	pullNamespaces, err := onboardPullNamespaces([]string{"orders_production", "orders_audit_production"})
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"orders_production", "orders_audit_production"}, pullNamespaces)
+
+	_, err = onboardPullNamespaces([]string{"orders_$ENV"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must be a concrete live namespace")
+}
+
+func TestRewriteOnboardNamespacesInfersEnvironmentTemplate(t *testing.T) {
+	resp := &apitypes.PullSchemaResponse{
+		Database:    "orders-logical",
+		Type:        "mysql",
+		Environment: "production",
+		Namespaces: map[string]*apitypes.PulledNamespace{
+			"orders_production":       {Tables: map[string]string{"users": "CREATE TABLE `users` (`id` bigint NOT NULL);\n"}},
+			"orders_audit_production": {Tables: map[string]string{"events": "CREATE TABLE `events` (`id` bigint NOT NULL);\n"}},
+		},
+	}
+	require.NoError(t, rewriteOnboardNamespaces(resp, "production", true))
+	assert.Contains(t, resp.Namespaces, "orders_$ENV")
+	assert.Contains(t, resp.Namespaces, "orders_audit_$ENV")
+	assert.NotContains(t, resp.Namespaces, "orders_production")
+}
+
+func TestRewriteOnboardNamespacesKeepsConcreteNamesByDefault(t *testing.T) {
+	resp := &apitypes.PullSchemaResponse{
+		Database:    "orders-logical",
+		Type:        "mysql",
+		Environment: "production",
+		Namespaces: map[string]*apitypes.PulledNamespace{
+			"orders_production": {Tables: map[string]string{"users": "CREATE TABLE `users` (`id` bigint NOT NULL);\n"}},
+		},
+	}
+	require.NoError(t, rewriteOnboardNamespaces(resp, "production", false))
+	assert.Contains(t, resp.Namespaces, "orders_production")
+	assert.NotContains(t, resp.Namespaces, "orders_$ENV")
+}
+
 func TestOnboardWritePlanRefusesExistingFilesWithoutForce(t *testing.T) {
 	root := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(root, "schemabot.yaml"), []byte("database: old\ntype: mysql\n"), 0o644))


### PR DESCRIPTION
## Summary

Update `schemabot onboard` so namespace selection uses concrete live namespaces while keeping `$ENV` directory templates as an explicit output option. `--namespace` now filters the pull to one or more live namespaces, and onboard writes those names directly by default. When the new `--template-env-suffix` flag is set, namespaces ending in `_<environment>` are materialized as `_$ENV` directories.

```diagram
onboard --namespace app_production -e production --template-env-suffix
        │
        ▼
server pulls app_production tables
        │
        ▼
CLI writes app_$ENV/*.sql + schemabot.yaml
```

When `--namespace` is omitted, onboard uses the pull default: discover all non-reserved namespaces from the resolved target. `--template-env-suffix` applies the same output-directory rewriting to every pulled namespace.

Generated with Amp.
