### PR TITLE
feat(inventory): add CredentialResolver seam

### DIFF
--- a/pkg/inventory/credentials.go
+++ b/pkg/inventory/credentials.go
@@ -1,0 +1,68 @@
+package inventory
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/block/schemabot/pkg/secrets"
+)
+
+// Credentials is a resolved database credential. The values never originate
+// from the inventory source (for example Etre); they come from a credential
+// backend such as an environment variable, a mounted file, or a secrets
+// manager.
+type Credentials struct {
+	Username string
+	Password string
+	// Metadata carries engine-specific credential material (for example a
+	// Vitess access token) without widening the struct per engine.
+	Metadata map[string]string
+}
+
+// CredentialResolver resolves credentials for a target, independently of
+// endpoint resolution so the two can be configured and overridden separately.
+//
+// It may use attributes surfaced by endpoint resolution — for example an AWS
+// account id to assume a role, or a cluster name to build a per-cluster secret
+// name — but those attributes are inputs for locating the credential, never the
+// secret values themselves.
+type CredentialResolver interface {
+	ResolveCredentials(ctx context.Context, req Request, attrs map[string]string) (*Credentials, error)
+}
+
+// SecretRefCredentialResolver resolves credentials from a configured username
+// and a password secret reference.
+//
+// The reference is resolved through pkg/secrets (env:, file:, secretsmanager:,
+// or a literal) on every call, so a rotated file-mounted secret — for example
+// one materialized by the External Secrets Operator — is picked up without a
+// restart. The reference may contain a "{target}" placeholder, replaced with
+// the request target, for per-target secret naming. This resolver does not use
+// endpoint attributes; the secrets-manager resolver that does (assume-role,
+// per-cluster names) plugs into the same interface.
+type SecretRefCredentialResolver struct {
+	Username    string
+	PasswordRef string
+}
+
+var _ CredentialResolver = SecretRefCredentialResolver{}
+
+// ResolveCredentials resolves the password reference fresh on every call.
+func (r SecretRefCredentialResolver) ResolveCredentials(_ context.Context, req Request, _ map[string]string) (*Credentials, error) {
+	if r.PasswordRef == "" {
+		return nil, fmt.Errorf("password reference is required for target %q", req.Target)
+	}
+	ref := strings.ReplaceAll(r.PasswordRef, "{target}", req.Target)
+	password, err := secrets.Resolve(ref, "")
+	if err != nil {
+		return nil, fmt.Errorf("resolve password for target %q: %w", req.Target, err)
+	}
+	// secrets.Resolve returns "" without error when an env: var or file: is
+	// unset/empty. Fail closed rather than authenticate with a blank password,
+	// which would otherwise surface as an opaque DB auth error later.
+	if password == "" {
+		return nil, fmt.Errorf("password reference %q resolved to an empty value for target %q", ref, req.Target)
+	}
+	return &Credentials{Username: r.Username, Password: password}, nil
+}

--- a/pkg/inventory/credentials_test.go
+++ b/pkg/inventory/credentials_test.go
@@ -1,0 +1,46 @@
+package inventory
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSecretRefCredentialResolverLiteralPassword(t *testing.T) {
+	r := SecretRefCredentialResolver{Username: "spirit", PasswordRef: "ddl-secret"}
+
+	creds, err := r.ResolveCredentials(t.Context(), Request{Target: "orders-dsid"}, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "spirit", creds.Username)
+	assert.Equal(t, "ddl-secret", creds.Password)
+}
+
+// The password reference may carry a {target} placeholder so a deployment can
+// name per-target secrets without a templating engine.
+func TestSecretRefCredentialResolverTemplatesTarget(t *testing.T) {
+	t.Setenv("ORDERS_DSID_PW", "from-env")
+	r := SecretRefCredentialResolver{Username: "spirit", PasswordRef: "env:{target}_PW"}
+
+	creds, err := r.ResolveCredentials(t.Context(), Request{Target: "ORDERS_DSID"}, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "from-env", creds.Password)
+}
+
+func TestSecretRefCredentialResolverRequiresPasswordRef(t *testing.T) {
+	r := SecretRefCredentialResolver{Username: "spirit"}
+
+	_, err := r.ResolveCredentials(t.Context(), Request{Target: "orders-dsid"}, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "password reference is required")
+}
+
+// An env: reference to an unset variable resolves to "" without error; the
+// resolver must fail closed rather than return a blank password.
+func TestSecretRefCredentialResolverRejectsEmptyResolvedPassword(t *testing.T) {
+	r := SecretRefCredentialResolver{Username: "spirit", PasswordRef: "env:UNSET_DDL_PASSWORD"}
+
+	_, err := r.ResolveCredentials(t.Context(), Request{Target: "orders-dsid"}, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty value")
+}


### PR DESCRIPTION
## Why this matters

Resolving an opaque target to a working database connection has two genuinely separate concerns: **where** to connect (the endpoint) and **how** to authenticate (the credentials). Deployments mix and match these — one keeps the default endpoint resolver but overrides only credentials; another changes both. Folding credentials into the endpoint resolver makes those independent choices impossible.

This PR establishes the credential half as its own seam, so endpoint resolution and credential resolution can be configured, overridden, and evolved independently.

## What it does

Adds to `pkg/inventory`:
- `CredentialResolver` — `ResolveCredentials(ctx, req, attrs) → Credentials`. Credential **values never come from the inventory source**; the `attrs` it receives (surfaced by endpoint resolution — e.g. an account id to assume a role, or a cluster name for a per-cluster secret name) are only used to *locate* the credential.
- `SecretRefCredentialResolver` — a configured username plus a password secret reference, resolved through `pkg/secrets` (`env:` / `file:` / `secretsmanager:` / literal) **on every call**, so a rotated file-mounted secret (e.g. materialized by External Secrets Operator) is picked up without a restart. The reference may carry a `{target}` placeholder for per-target secret naming.

```
ResolveCredentials(req, attrs)
   ├─ static username
   └─ password ref ──(re-resolved each call)──► pkg/secrets ──► env / file / secretsmanager / literal
```

## How it moves us toward the northstar

This is the credentials half of the connection-resolver split. It lets different deployment credential patterns plug in behind one interface — the env/file/ESO path here, and a secrets-manager + assume-role resolver next — without the endpoint resolver knowing or caring. The Etre endpoint resolver (separate PR) consumes this seam.

*Opened by Claude (Opus 4.8, 1M context).*