### PR TITLE
feat(inventory): add Etre resolver and MySQL connection assembler

### DIFF
--- a/pkg/etre/resolver.go
+++ b/pkg/etre/resolver.go
@@ -1,0 +1,143 @@
+package etre
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"strings"
+
+	"github.com/block/schemabot/pkg/inventory"
+)
+
+// EtreResolverConfig configures an inventory.Resolver backed by Etre.
+//
+// It is engine-agnostic: the Etre lookup produces an endpoint host and
+// attributes, an injected CredentialResolver produces the credentials, and an
+// injected ConnectionAssembler turns those into the engine-specific connection.
+// Resolving a different engine through Etre means supplying a different
+// assembler, not writing a new resolver.
+type EtreResolverConfig struct {
+	// Client is the Etre query client, bound to the entity type that records
+	// this engine's clusters.
+	Client *Client
+
+	// TargetLabel is the Etre label the request's opaque target matches.
+	TargetLabel string
+
+	// Labels are fixed equality predicates added to every lookup (for example a
+	// region label that disambiguates a target present in multiple regions).
+	Labels map[string]string
+
+	// EnvLabel, when set, adds the request environment as a selector predicate.
+	EnvLabel string
+
+	// HostField is the entity field holding the connection host, passed to the
+	// assembler. It may be empty for engines that connect by attribute rather
+	// than host (the assembler validates what it needs).
+	HostField string
+
+	// AttributeFields are entity fields surfaced to the credential resolver and
+	// the assembler as attributes (for example an account id for assume-role, or
+	// an organization for a Vitess connection).
+	AttributeFields []string
+
+	// Credentials resolves the credentials, independently of the endpoint.
+	Credentials inventory.CredentialResolver
+
+	// Assembler turns the resolved endpoint and credentials into the
+	// engine-specific connection, and determines the resolved target's type.
+	Assembler inventory.ConnectionAssembler
+}
+
+// EtreResolver resolves targets through Etre, delegating the engine-specific
+// connection assembly to a ConnectionAssembler.
+type EtreResolver struct {
+	cfg EtreResolverConfig
+}
+
+var _ inventory.Resolver = (*EtreResolver)(nil)
+
+// NewEtreResolver validates the config and builds a resolver.
+func NewEtreResolver(cfg EtreResolverConfig) (*EtreResolver, error) {
+	switch {
+	case cfg.Client == nil:
+		return nil, fmt.Errorf("etre client is required")
+	case cfg.TargetLabel == "":
+		return nil, fmt.Errorf("target label is required")
+	case cfg.Credentials == nil:
+		return nil, fmt.Errorf("credential resolver is required")
+	case cfg.Assembler == nil:
+		return nil, fmt.Errorf("connection assembler is required")
+	}
+	// Fixed labels must not collide with the target or env predicates, which
+	// would let a misconfigured label silently override them and resolve the
+	// wrong entity.
+	for label := range cfg.Labels {
+		if label == cfg.TargetLabel {
+			return nil, fmt.Errorf("fixed label %q collides with the target label", label)
+		}
+		if cfg.EnvLabel != "" && label == cfg.EnvLabel {
+			return nil, fmt.Errorf("fixed label %q collides with the env label", label)
+		}
+	}
+	return &EtreResolver{cfg: cfg}, nil
+}
+
+// ResolveTarget looks the target up in Etre for its endpoint and attributes,
+// resolves credentials, and delegates engine-specific connection assembly. It
+// fails closed: lookup ambiguity (via the Etre client), credential failure, or
+// an assembler rejecting an incomplete endpoint are all errors.
+func (r *EtreResolver) ResolveTarget(ctx context.Context, req inventory.Request) (*inventory.Target, error) {
+	if req.Target == "" {
+		return nil, fmt.Errorf("target is required")
+	}
+	// Fail closed when the request's type does not match the engine this
+	// resolver serves, rather than returning a connection for a different engine.
+	if dbType := strings.TrimSpace(req.DatabaseType); dbType != "" && !strings.EqualFold(dbType, r.cfg.Assembler.DatabaseType()) {
+		return nil, fmt.Errorf("target %q requested database type %q but this resolver serves %q", req.Target, dbType, r.cfg.Assembler.DatabaseType())
+	}
+
+	selector := map[string]string{r.cfg.TargetLabel: req.Target}
+	maps.Copy(selector, r.cfg.Labels)
+	// When an env label is configured the lookup must be environment-scoped;
+	// resolving without an environment could match a different environment's
+	// entity, so fail closed rather than drop the predicate.
+	if r.cfg.EnvLabel != "" {
+		if req.Environment == "" {
+			return nil, fmt.Errorf("target %q requires an environment because env label %q is configured", req.Target, r.cfg.EnvLabel)
+		}
+		selector[r.cfg.EnvLabel] = req.Environment
+	}
+
+	entity, err := r.cfg.Client.QueryOne(ctx, selector)
+	if err != nil {
+		return nil, fmt.Errorf("resolve target %q: %w", req.Target, err)
+	}
+
+	host := StringField(entity, r.cfg.HostField)
+
+	var attrs map[string]string
+	if len(r.cfg.AttributeFields) > 0 {
+		attrs = make(map[string]string, len(r.cfg.AttributeFields))
+		for _, field := range r.cfg.AttributeFields {
+			attrs[field] = StringField(entity, field)
+		}
+	}
+
+	creds, err := r.cfg.Credentials.ResolveCredentials(ctx, req, attrs)
+	if err != nil {
+		return nil, fmt.Errorf("resolve credentials for target %q: %w", req.Target, err)
+	}
+
+	dsn, metadata, err := r.cfg.Assembler.Assemble(host, attrs, creds)
+	if err != nil {
+		return nil, fmt.Errorf("assemble connection for target %q: %w", req.Target, err)
+	}
+
+	return &inventory.Target{
+		Target:       req.Target,
+		DatabaseType: r.cfg.Assembler.DatabaseType(),
+		DSN:          dsn,
+		Metadata:     metadata,
+	}, nil
+}

--- a/pkg/etre/resolver_test.go
+++ b/pkg/etre/resolver_test.go
@@ -1,0 +1,239 @@
+package etre
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-sql-driver/mysql"
+	"github.com/square/etre"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/block/schemabot/pkg/inventory"
+)
+
+func newEtreResolverForTest(t *testing.T, gotQuery *string, entities []etre.Entity, cfg EtreResolverConfig) *EtreResolver {
+	t.Helper()
+	cfg.Client = newClient(mockClient(gotQuery, entities, nil), "cluster", nil)
+	if cfg.Credentials == nil {
+		cfg.Credentials = inventory.SecretRefCredentialResolver{Username: "ddl", PasswordRef: "pw"}
+	}
+	if cfg.Assembler == nil {
+		cfg.Assembler = inventory.MySQLConnectionAssembler{DefaultPort: "3306"}
+	}
+	r, err := NewEtreResolver(cfg)
+	require.NoError(t, err)
+	return r
+}
+
+// capturingCredResolver records what the resolver passes to credential
+// resolution so tests can assert the surfaced attributes.
+type capturingCredResolver struct {
+	gotTarget string
+	gotAttrs  map[string]string
+	creds     *inventory.Credentials
+}
+
+func (c *capturingCredResolver) ResolveCredentials(_ context.Context, req inventory.Request, attrs map[string]string) (*inventory.Credentials, error) {
+	c.gotTarget = req.Target
+	c.gotAttrs = attrs
+	return c.creds, nil
+}
+
+// fakeAssembler records what the resolver hands the assembler and returns a
+// fixed connection, so the resolver's delegation can be asserted in isolation.
+type fakeAssembler struct {
+	gotHost  string
+	gotAttrs map[string]string
+	gotCreds *inventory.Credentials
+}
+
+func (f *fakeAssembler) DatabaseType() string { return "fake" }
+
+func (f *fakeAssembler) Assemble(host string, attrs map[string]string, creds *inventory.Credentials) (string, map[string]string, error) {
+	f.gotHost = host
+	f.gotAttrs = attrs
+	f.gotCreds = creds
+	return "assembled-dsn", map[string]string{"k": "v"}, nil
+}
+
+// End to end with the real MySQL assembler: the resolver builds the Etre
+// selector, looks up the cluster for its endpoint, and produces a namespace-free
+// MySQL DSN from the host and the (separately resolved) credentials.
+func TestEtreResolverResolvesMySQLTarget(t *testing.T) {
+	var gotQuery string
+	entity := etre.Entity{"writer_endpoint": "orders.example"}
+	r := newEtreResolverForTest(t, &gotQuery, []etre.Entity{entity}, EtreResolverConfig{
+		TargetLabel: "dsid",
+		Labels:      map[string]string{"aws_region": "r1"},
+		EnvLabel:    "env",
+		HostField:   "writer_endpoint",
+		Credentials: inventory.SecretRefCredentialResolver{Username: "ddl", PasswordRef: "ddl-secret"},
+		Assembler:   inventory.MySQLConnectionAssembler{DefaultPort: "3306", Metadata: map[string]string{"pending_drops": "false"}},
+	})
+
+	target, err := r.ResolveTarget(t.Context(), inventory.Request{Target: "orders-dsid", DatabaseType: "mysql", Environment: "production"})
+	require.NoError(t, err)
+
+	assert.Equal(t, "aws_region=r1,dsid=orders-dsid,env=production", gotQuery)
+	assert.Equal(t, "orders-dsid", target.Target)
+	assert.Equal(t, "mysql", target.DatabaseType)
+	assert.Equal(t, map[string]string{"pending_drops": "false"}, target.Metadata)
+
+	cfg, err := mysql.ParseDSN(target.DSN)
+	require.NoError(t, err)
+	assert.Equal(t, "ddl", cfg.User)
+	assert.Equal(t, "ddl-secret", cfg.Passwd)
+	assert.Equal(t, "orders.example:3306", cfg.Addr)
+	assert.Equal(t, "", cfg.DBName, "MySQL DSN must be namespace-free; the request supplies the schema")
+}
+
+// The resolver surfaces the endpoint host and configured attributes to both the
+// credential resolver and the assembler, and returns the assembler's output.
+func TestEtreResolverDelegatesToAssembler(t *testing.T) {
+	entity := etre.Entity{"writer_endpoint": "orders.example:3306", "aws_account_id": "123456789012", "name": "orders-001"}
+	asm := &fakeAssembler{}
+	creds := &capturingCredResolver{creds: &inventory.Credentials{Username: "spirit", Password: "pw"}}
+	r := newEtreResolverForTest(t, nil, []etre.Entity{entity}, EtreResolverConfig{
+		TargetLabel:     "dsid",
+		HostField:       "writer_endpoint",
+		AttributeFields: []string{"aws_account_id", "name"},
+		Credentials:     creds,
+		Assembler:       asm,
+	})
+
+	target, err := r.ResolveTarget(t.Context(), inventory.Request{Target: "orders-dsid"})
+	require.NoError(t, err)
+
+	wantAttrs := map[string]string{"aws_account_id": "123456789012", "name": "orders-001"}
+	assert.Equal(t, "orders-dsid", creds.gotTarget)
+	assert.Equal(t, wantAttrs, creds.gotAttrs)
+	assert.Equal(t, "orders.example:3306", asm.gotHost)
+	assert.Equal(t, wantAttrs, asm.gotAttrs)
+	assert.Equal(t, "spirit", asm.gotCreds.Username)
+
+	assert.Equal(t, "fake", target.DatabaseType)
+	assert.Equal(t, "assembled-dsn", target.DSN)
+	assert.Equal(t, map[string]string{"k": "v"}, target.Metadata)
+}
+
+func TestEtreResolverOmitsEnvLabelWhenUnset(t *testing.T) {
+	var gotQuery string
+	entity := etre.Entity{"writer_endpoint": "orders.example:3306"}
+	r := newEtreResolverForTest(t, &gotQuery, []etre.Entity{entity}, EtreResolverConfig{
+		TargetLabel: "dsid",
+		HostField:   "writer_endpoint",
+	})
+
+	_, err := r.ResolveTarget(t.Context(), inventory.Request{Target: "orders-dsid", Environment: "production"})
+	require.NoError(t, err)
+	assert.Equal(t, "dsid=orders-dsid", gotQuery)
+}
+
+// A not-found lookup fails closed and surfaces the sentinel so a multi-type
+// resolver could fall back.
+func TestEtreResolverFailsClosedOnNotFound(t *testing.T) {
+	r := newEtreResolverForTest(t, nil, nil, EtreResolverConfig{
+		TargetLabel: "dsid",
+		HostField:   "writer_endpoint",
+	})
+
+	_, err := r.ResolveTarget(t.Context(), inventory.Request{Target: "missing"})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrNotFound)
+}
+
+// A request whose type does not match the engine the resolver serves fails
+// closed rather than returning a connection for the wrong engine.
+func TestEtreResolverRejectsDatabaseTypeMismatch(t *testing.T) {
+	entity := etre.Entity{"writer_endpoint": "orders.example:3306"}
+	r := newEtreResolverForTest(t, nil, []etre.Entity{entity}, EtreResolverConfig{
+		TargetLabel: "dsid",
+		HostField:   "writer_endpoint",
+	})
+
+	_, err := r.ResolveTarget(t.Context(), inventory.Request{Target: "orders-dsid", DatabaseType: "vitess"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "vitess")
+	assert.Contains(t, err.Error(), "mysql")
+}
+
+// With an env label configured, a request without an environment fails closed
+// rather than running an environment-unscoped lookup.
+func TestEtreResolverRequiresEnvironmentWhenEnvLabelSet(t *testing.T) {
+	entity := etre.Entity{"writer_endpoint": "orders.example:3306"}
+	r := newEtreResolverForTest(t, nil, []etre.Entity{entity}, EtreResolverConfig{
+		TargetLabel: "dsid",
+		EnvLabel:    "env",
+		HostField:   "writer_endpoint",
+	})
+
+	_, err := r.ResolveTarget(t.Context(), inventory.Request{Target: "orders-dsid"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "environment")
+}
+
+// A fixed label that collides with the target or env label is a configuration
+// error, since it could silently override the predicate that selects the entity.
+func TestNewEtreResolverRejectsCollidingLabels(t *testing.T) {
+	client := newClient(mockClient(nil, nil, nil), "cluster", nil)
+	base := EtreResolverConfig{
+		Client:      client,
+		TargetLabel: "dsid",
+		EnvLabel:    "env",
+		HostField:   "writer_endpoint",
+		Credentials: inventory.SecretRefCredentialResolver{Username: "ddl", PasswordRef: "pw"},
+		Assembler:   inventory.MySQLConnectionAssembler{},
+	}
+
+	targetCollision := base
+	targetCollision.Labels = map[string]string{"dsid": "x"}
+	_, err := NewEtreResolver(targetCollision)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "target label")
+
+	envCollision := base
+	envCollision.Labels = map[string]string{"env": "production"}
+	_, err = NewEtreResolver(envCollision)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "env label")
+}
+
+func TestEtreResolverRequiresTarget(t *testing.T) {
+	r := newEtreResolverForTest(t, nil, nil, EtreResolverConfig{
+		TargetLabel: "dsid",
+		HostField:   "writer_endpoint",
+	})
+
+	_, err := r.ResolveTarget(t.Context(), inventory.Request{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "target is required")
+}
+
+func TestNewEtreResolverValidatesConfig(t *testing.T) {
+	client := newClient(mockClient(nil, nil, nil), "cluster", nil)
+	base := EtreResolverConfig{
+		Client:      client,
+		TargetLabel: "dsid",
+		HostField:   "writer_endpoint",
+		Credentials: inventory.SecretRefCredentialResolver{Username: "ddl", PasswordRef: "pw"},
+		Assembler:   inventory.MySQLConnectionAssembler{},
+	}
+
+	_, err := NewEtreResolver(base)
+	require.NoError(t, err)
+
+	cases := map[string]func(*EtreResolverConfig){
+		"etre client is required":          func(c *EtreResolverConfig) { c.Client = nil },
+		"target label is required":         func(c *EtreResolverConfig) { c.TargetLabel = "" },
+		"credential resolver is required":  func(c *EtreResolverConfig) { c.Credentials = nil },
+		"connection assembler is required": func(c *EtreResolverConfig) { c.Assembler = nil },
+	}
+	for wantErr, mutate := range cases {
+		cfg := base
+		mutate(&cfg)
+		_, err := NewEtreResolver(cfg)
+		require.Error(t, err, wantErr)
+		assert.Contains(t, err.Error(), wantErr)
+	}
+}

--- a/pkg/inventory/connection_assembler.go
+++ b/pkg/inventory/connection_assembler.go
@@ -1,0 +1,70 @@
+package inventory
+
+import (
+	"fmt"
+	"maps"
+	"net"
+
+	"github.com/go-sql-driver/mysql"
+)
+
+// ConnectionAssembler turns a resolved endpoint and credentials into the
+// connection fields of a Target for a specific database engine.
+//
+// It is the engine axis of resolution: written once per engine and reused
+// across every inventory source, so endpoint resolution (which source) and
+// credential resolution (which secret backend) stay engine-agnostic. Adding an
+// engine means adding an assembler, not a new per-source resolver.
+type ConnectionAssembler interface {
+	// DatabaseType is the engine this assembler targets.
+	DatabaseType() string
+	// Assemble builds the connection fields of a Target — a DSN and/or
+	// engine-specific Metadata — from a resolved endpoint host, the endpoint's
+	// attributes, and credentials.
+	Assemble(host string, attrs map[string]string, creds *Credentials) (dsn string, metadata map[string]string, err error)
+}
+
+// MySQLConnectionAssembler assembles a namespace-free MySQL DSN. The schema is
+// injected per operation by the data plane, so the DSN carries no database name.
+type MySQLConnectionAssembler struct {
+	// DefaultPort is appended to the host when it has no port.
+	DefaultPort string
+	// Params are extra MySQL DSN parameters (for example TLS settings).
+	Params map[string]string
+	// Metadata is attached to every assembled target for engine-specific
+	// configuration the data plane reads.
+	Metadata map[string]string
+}
+
+var _ ConnectionAssembler = MySQLConnectionAssembler{}
+
+// DatabaseType returns the MySQL engine type.
+func (MySQLConnectionAssembler) DatabaseType() string { return "mysql" }
+
+// Assemble builds a namespace-free MySQL DSN from the host and credentials. The
+// endpoint attributes are unused for MySQL.
+func (a MySQLConnectionAssembler) Assemble(host string, _ map[string]string, creds *Credentials) (string, map[string]string, error) {
+	if host == "" {
+		return "", nil, fmt.Errorf("mysql connection requires a host")
+	}
+	if creds == nil {
+		return "", nil, fmt.Errorf("mysql connection requires credentials")
+	}
+	// Append the default port only when the host has none. net.SplitHostPort
+	// errors when no port is present, including for bare IPv6 addresses; in that
+	// case net.JoinHostPort adds the required brackets.
+	if a.DefaultPort != "" {
+		if _, _, err := net.SplitHostPort(host); err != nil {
+			host = net.JoinHostPort(host, a.DefaultPort)
+		}
+	}
+	cfg := mysql.NewConfig()
+	cfg.User = creds.Username
+	cfg.Passwd = creds.Password
+	cfg.Net = "tcp"
+	cfg.Addr = host
+	if len(a.Params) > 0 {
+		cfg.Params = maps.Clone(a.Params)
+	}
+	return cfg.FormatDSN(), maps.Clone(a.Metadata), nil
+}

--- a/pkg/inventory/connection_assembler_test.go
+++ b/pkg/inventory/connection_assembler_test.go
@@ -1,0 +1,83 @@
+package inventory
+
+import (
+	"testing"
+
+	"github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMySQLConnectionAssemblerBuildsNamespaceFreeDSN(t *testing.T) {
+	a := MySQLConnectionAssembler{DefaultPort: "3306", Metadata: map[string]string{"pending_drops": "false"}}
+
+	dsn, meta, err := a.Assemble("orders.example", nil, &Credentials{Username: "ddl", Password: "secret"})
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{"pending_drops": "false"}, meta)
+
+	cfg, err := mysql.ParseDSN(dsn)
+	require.NoError(t, err)
+	assert.Equal(t, "ddl", cfg.User)
+	assert.Equal(t, "secret", cfg.Passwd)
+	assert.Equal(t, "tcp", cfg.Net)
+	assert.Equal(t, "orders.example:3306", cfg.Addr)
+	assert.Equal(t, "", cfg.DBName, "MySQL DSN must be namespace-free; the request supplies the schema")
+}
+
+func TestMySQLConnectionAssemblerKeepsExistingPort(t *testing.T) {
+	a := MySQLConnectionAssembler{DefaultPort: "3306"}
+
+	dsn, _, err := a.Assemble("orders.example:3307", nil, &Credentials{Username: "ddl", Password: "secret"})
+	require.NoError(t, err)
+	cfg, err := mysql.ParseDSN(dsn)
+	require.NoError(t, err)
+	assert.Equal(t, "orders.example:3307", cfg.Addr)
+}
+
+func TestMySQLConnectionAssemblerPassesParams(t *testing.T) {
+	a := MySQLConnectionAssembler{Params: map[string]string{"foo": "bar"}}
+
+	dsn, _, err := a.Assemble("orders.example:3306", nil, &Credentials{Username: "ddl", Password: "secret"})
+	require.NoError(t, err)
+	cfg, err := mysql.ParseDSN(dsn)
+	require.NoError(t, err)
+	assert.Equal(t, "bar", cfg.Params["foo"])
+}
+
+// A bare IPv6 host has colons but no port; the default port must be appended
+// with brackets so the resulting MySQL address is valid.
+func TestMySQLConnectionAssemblerBracketsIPv6WithDefaultPort(t *testing.T) {
+	a := MySQLConnectionAssembler{DefaultPort: "3306"}
+
+	dsn, _, err := a.Assemble("2001:db8::1", nil, &Credentials{Username: "ddl", Password: "secret"})
+	require.NoError(t, err)
+	cfg, err := mysql.ParseDSN(dsn)
+	require.NoError(t, err)
+	assert.Equal(t, "[2001:db8::1]:3306", cfg.Addr)
+}
+
+func TestMySQLConnectionAssemblerKeepsBracketedIPv6Port(t *testing.T) {
+	a := MySQLConnectionAssembler{DefaultPort: "3306"}
+
+	dsn, _, err := a.Assemble("[2001:db8::1]:3307", nil, &Credentials{Username: "ddl", Password: "secret"})
+	require.NoError(t, err)
+	cfg, err := mysql.ParseDSN(dsn)
+	require.NoError(t, err)
+	assert.Equal(t, "[2001:db8::1]:3307", cfg.Addr)
+}
+
+func TestMySQLConnectionAssemblerRequiresHost(t *testing.T) {
+	_, _, err := MySQLConnectionAssembler{}.Assemble("", nil, &Credentials{Username: "ddl", Password: "secret"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "host")
+}
+
+func TestMySQLConnectionAssemblerRequiresCredentials(t *testing.T) {
+	_, _, err := MySQLConnectionAssembler{}.Assemble("orders.example:3306", nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "credentials")
+}
+
+func TestMySQLConnectionAssemblerDatabaseType(t *testing.T) {
+	assert.Equal(t, "mysql", MySQLConnectionAssembler{}.DatabaseType())
+}


### PR DESCRIPTION
## Why this matters

To resolve targets on its own — instead of depending on an external resolution shim — the data plane needs to look up *where a target lives* directly against the inventory source. This PR adds the Etre-backed resolver, factored so it scales to more database engines without a combinatorial explosion of resolvers.

The key decision: **engine-specific connection logic does not live in the resolver.** Resolution has three orthogonal axes that compose rather than multiply — endpoint (which inventory source), credentials (which secret backend), and engine (how to build the connection). Folding the engine into the resolver would mean a new DSN-building resolver per `source × engine`; keeping it separate means one assembler per engine, reused across sources.

## What it does

- **`EtreResolver`** (`pkg/etre`) is engine-agnostic. It builds an equality selector from the request, looks up **exactly one** entity via the generic Etre client (fail-closed on 0/2+ inherited), surfaces the endpoint host + configured attributes, and delegates the rest.
- **`ConnectionAssembler`** (`pkg/inventory`) is the **engine axis**: `Assemble(host, attrs, creds) → (dsn, metadata)`, plus `DatabaseType()`. Written once per engine, reused across every inventory source.
- **`MySQLConnectionAssembler`** builds a **namespace-free** MySQL DSN (the request supplies the schema per operation).
- Credentials come from the injected `CredentialResolver` (merged separately) — never from Etre.

```
Request ─► EtreResolver ─► Etre QueryOne ─► entity{host, attrs}
                              │
        CredentialResolver(req, attrs) ─► creds
                              │
        ConnectionAssembler.Assemble(host, attrs, creds) ─► (dsn, metadata)
                              ▼
                        inventory.Target{type = assembler.DatabaseType()}
```

Fails closed on lookup ambiguity, credential failure, or an assembler rejecting an incomplete endpoint.

## How it moves us toward the northstar

This is the Etre dynamic backend, factored along the axis that matters for scale. Adding **Vitess** is a `VitessConnectionAssembler` (builds org/token metadata instead of a DSN); adding **Postgres** is a `PostgresConnectionAssembler` (Postgres DSN + `sslmode`) — each reuses the same `EtreResolver` and credential seam. No new per-source resolver, no duplicated connection-string construction. The engine-agnostic spine is what lets resolution grow to the full engine set behind one `inventory.Resolver` interface.

*Opened by Claude (Opus 4.8, 1M context).*