### PR TITLE
feat(github): surface first deployment failure in multi-deployment apply header

### DIFF
--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -4603,7 +4603,7 @@ _No details available yet._
 
 **Deployments**: 1 completed, 2 halted, 1 failed
 
-> ⚠️ **First failure:** `us` — lock wait timeout exceeded; try restarting transaction
+> ⚠️ **First failure:** <code>us</code> — lock wait timeout exceeded; try restarting transaction
 
 ---
 
@@ -4953,7 +4953,7 @@ _Apply ID: `apply-a1b2c3d4e5f6`_
 
 **Deployments**: 1 completed, 2 halted, 1 failed
 
-> ⚠️ **First failure:** `us` — lock wait timeout exceeded; try restarting transaction
+> ⚠️ **First failure:** <code>us</code> — lock wait timeout exceeded; try restarting transaction
 
 ---
 

--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -4603,6 +4603,8 @@ _No details available yet._
 
 **Deployments**: 1 completed, 2 halted, 1 failed
 
+> ⚠️ **First failure:** `us` — lock wait timeout exceeded; try restarting transaction
+
 ---
 
 To retry:
@@ -4950,6 +4952,8 @@ _Apply ID: `apply-a1b2c3d4e5f6`_
 *Applied by @aparajon at 2026-01-01 00:00:00 UTC*
 
 **Deployments**: 1 completed, 2 halted, 1 failed
+
+> ⚠️ **First failure:** `us` — lock wait timeout exceeded; try restarting transaction
 
 ---
 

--- a/pkg/presentation/presentation.go
+++ b/pkg/presentation/presentation.go
@@ -151,6 +151,16 @@ type Apply struct {
 	// NextAction is the suggested next operator action, if any.
 	NextAction NextAction
 
+	// FirstFailure is the first deployment, in resolved order, whose operation
+	// is terminally failed, or nil when no deployment has failed. It is the
+	// rendering counterpart of the persisted aggregate ErrorMessage (which is
+	// also stamped from the first failed operation): surfaces lift the failed
+	// deployment and its error to the aggregate header so an operator sees what
+	// failed without expanding a per-deployment section. Under on_failure
+	// continue this is populated while the aggregate is still running, so the
+	// failure surfaces eagerly rather than only on the terminal comment.
+	FirstFailure *Deployment
+
 	// Deployments are the per-deployment presentations in resolved deployment
 	// order (the order the caller supplies, which mirrors the rollout order).
 	Deployments []Deployment
@@ -181,12 +191,27 @@ func Derive(ops []Operation) Apply {
 
 	aggState := state.DeriveApplyState(rawStates)
 	return Apply{
-		State:       aggState,
-		Label:       aggregateLabel(aggState),
-		Counts:      summaryCounts(deployments),
-		NextAction:  nextAction(aggState, deployments),
-		Deployments: deployments,
+		State:        aggState,
+		Label:        aggregateLabel(aggState),
+		Counts:       summaryCounts(deployments),
+		NextAction:   nextAction(aggState, deployments),
+		FirstFailure: firstFailure(deployments),
+		Deployments:  deployments,
 	}
+}
+
+// firstFailure returns the first deployment, in resolved order, whose raw
+// operation state is terminally failed, or nil when none failed. failed_retryable
+// is excluded: a retrying deployment is still in progress and surfaces no
+// operator-facing failure. The result aliases the slice element so the renderer
+// reads the same derived label and error.
+func firstFailure(deps []Deployment) *Deployment {
+	for i := range deps {
+		if deps[i].State == state.ApplyOperation.Failed {
+			return &deps[i]
+		}
+	}
+	return nil
 }
 
 // deriveDeployment projects operation i, using its earlier siblings for the

--- a/pkg/presentation/presentation.go
+++ b/pkg/presentation/presentation.go
@@ -203,12 +203,14 @@ func Derive(ops []Operation) Apply {
 // firstFailure returns the first deployment, in resolved order, whose raw
 // operation state is terminally failed, or nil when none failed. failed_retryable
 // is excluded: a retrying deployment is still in progress and surfaces no
-// operator-facing failure. The result aliases the slice element so the renderer
-// reads the same derived label and error.
+// operator-facing failure. The result is a copy, not an alias into Deployments,
+// so a caller that later re-slices or sorts Deployments cannot turn it into a
+// stale pointer.
 func firstFailure(deps []Deployment) *Deployment {
 	for i := range deps {
 		if deps[i].State == state.ApplyOperation.Failed {
-			return &deps[i]
+			failed := deps[i]
+			return &failed
 		}
 	}
 	return nil

--- a/pkg/presentation/presentation_test.go
+++ b/pkg/presentation/presentation_test.go
@@ -297,3 +297,54 @@ func TestDerive_FailedDeploymentCarriesError(t *testing.T) {
 	require.Len(t, got.Deployments, 1)
 	assert.Equal(t, "lock wait timeout", got.Deployments[0].Error)
 }
+
+// TestDerive_FirstFailureNoneWhenHealthy: a rollout with no failed deployment
+// exposes no first failure.
+func TestDerive_FirstFailureNoneWhenHealthy(t *testing.T) {
+	got := Derive([]Operation{
+		rolling("eu", so.Completed),
+		rolling("us", so.Running),
+	})
+	assert.Nil(t, got.FirstFailure)
+}
+
+// TestDerive_FirstFailurePicksEarliestInOrder: with more than one failed
+// deployment, the first failure is the earliest in resolved order and carries
+// its error, mirroring the first-failed-operation the persisted aggregate
+// ErrorMessage is stamped from.
+func TestDerive_FirstFailurePicksEarliestInOrder(t *testing.T) {
+	got := Derive([]Operation{
+		{Deployment: "eu", State: so.Completed, HaltOnFailure: false},
+		{Deployment: "us", State: so.Failed, HaltOnFailure: false, Error: "first boom"},
+		{Deployment: "au", State: so.Failed, HaltOnFailure: false, Error: "second boom"},
+	})
+	require.NotNil(t, got.FirstFailure)
+	assert.Equal(t, "us", got.FirstFailure.Deployment)
+	assert.Equal(t, "first boom", got.FirstFailure.Error)
+}
+
+// TestDerive_FirstFailureWhileSiblingStillRunning: under on_failure continue an
+// earlier deployment can be failed while a later one is still copying. The
+// aggregate is fail-closed to failed, but the in-progress comment still has a
+// running deployment, so surfacing the first failure here lifts the reason onto
+// the status comment rather than waiting for the terminal summary.
+func TestDerive_FirstFailureWhileSiblingStillRunning(t *testing.T) {
+	got := Derive([]Operation{
+		{Deployment: "eu", State: so.Failed, HaltOnFailure: false, Error: "boom"},
+		{Deployment: "us", State: so.Running, HaltOnFailure: false},
+	})
+	assert.Equal(t, state.Apply.Failed, got.State)
+	assert.Equal(t, StateRunningCopy, got.Deployments[1].Presentation)
+	require.NotNil(t, got.FirstFailure)
+	assert.Equal(t, "eu", got.FirstFailure.Deployment)
+}
+
+// TestDerive_FirstFailureExcludesRetrying: a failed_retryable deployment is
+// still in progress, so it is not surfaced as a first failure.
+func TestDerive_FirstFailureExcludesRetrying(t *testing.T) {
+	got := Derive([]Operation{
+		rolling("eu", so.Completed),
+		rolling("us", so.FailedRetryable),
+	})
+	assert.Nil(t, got.FirstFailure)
+}

--- a/pkg/webhook/templates/multi_apply.go
+++ b/pkg/webhook/templates/multi_apply.go
@@ -135,16 +135,21 @@ func writeDeploymentCounts(sb *strings.Builder, counts []presentation.StateCount
 // reason is the first failed operation's error — the same operation the
 // persisted aggregate ErrorMessage is stamped from — and falls back to naming
 // the deployment when that operation carried no error detail.
+//
+// The deployment name is wrapped in a <code> element rather than Markdown
+// backticks: a name may contain HTML-significant characters (and backticks
+// themselves), and HTML-escaped text inside a code span would render its
+// entities literally.
 func writeAggregateFirstFailure(sb *strings.Builder, failure *presentation.Deployment) {
 	if failure == nil {
 		return
 	}
 	name := html.EscapeString(failure.Deployment)
 	if failure.Error == "" {
-		fmt.Fprintf(sb, "\n> ⚠️ **First failure:** `%s`\n", name)
+		fmt.Fprintf(sb, "\n> ⚠️ **First failure:** <code>%s</code>\n", name)
 		return
 	}
-	fmt.Fprintf(sb, "\n> ⚠️ **First failure:** `%s` — %s\n", name, html.EscapeString(failure.Error))
+	fmt.Fprintf(sb, "\n> ⚠️ **First failure:** <code>%s</code> — %s\n", name, html.EscapeString(failure.Error))
 }
 
 // writeAggregateNextAction renders the single suggested operator action derived

--- a/pkg/webhook/templates/multi_apply.go
+++ b/pkg/webhook/templates/multi_apply.go
@@ -59,6 +59,7 @@ func RenderMultiDeploymentApplyComment(data MultiDeploymentApplyData) string {
 	writeApplyHeader(&sb, ApplyStatusCommentData{State: data.Model.State})
 	writeAggregateMetadata(&sb, data)
 	writeDeploymentCounts(&sb, data.Model.Counts)
+	writeAggregateFirstFailure(&sb, data.Model.FirstFailure)
 	writeAggregateNextAction(&sb, data)
 
 	// Flat per-deployment summary (always visible — survives any later size
@@ -86,6 +87,7 @@ func RenderMultiDeploymentApplySummaryComment(data MultiDeploymentApplyData) str
 	writeApplyHeader(&sb, ApplyStatusCommentData{State: data.Model.State})
 	writeAggregateMetadata(&sb, data)
 	writeDeploymentCounts(&sb, data.Model.Counts)
+	writeAggregateFirstFailure(&sb, data.Model.FirstFailure)
 	writeAggregateNextAction(&sb, data)
 
 	writeDeploymentSummaryList(&sb, data.Model.Deployments)
@@ -125,6 +127,24 @@ func writeDeploymentCounts(sb *strings.Builder, counts []presentation.StateCount
 		parts = append(parts, fmt.Sprintf("%d %s", c.Count, c.Label))
 	}
 	fmt.Fprintf(sb, "\n**Deployments**: %s\n", strings.Join(parts, ", "))
+}
+
+// writeAggregateFirstFailure lifts the first failed deployment's error to the
+// aggregate header so an operator sees what failed without expanding that
+// deployment's section. It renders nothing when no deployment has failed. The
+// reason is the first failed operation's error — the same operation the
+// persisted aggregate ErrorMessage is stamped from — and falls back to naming
+// the deployment when that operation carried no error detail.
+func writeAggregateFirstFailure(sb *strings.Builder, failure *presentation.Deployment) {
+	if failure == nil {
+		return
+	}
+	name := html.EscapeString(failure.Deployment)
+	if failure.Error == "" {
+		fmt.Fprintf(sb, "\n> ⚠️ **First failure:** `%s`\n", name)
+		return
+	}
+	fmt.Fprintf(sb, "\n> ⚠️ **First failure:** `%s` — %s\n", name, html.EscapeString(failure.Error))
 }
 
 // writeAggregateNextAction renders the single suggested operator action derived

--- a/pkg/webhook/templates/multi_apply_test.go
+++ b/pkg/webhook/templates/multi_apply_test.go
@@ -89,7 +89,7 @@ func TestRenderMultiDeploymentApplyComment_FailedHalt(t *testing.T) {
 	assert.Contains(t, out, "<details open>\n<summary>⏸ au — halted — us failed</summary>")
 	// With no error detail on the failed operation, the first-failure line names
 	// the deployment without a reason.
-	assert.Contains(t, out, "> ⚠️ **First failure:** `us`\n")
+	assert.Contains(t, out, "> ⚠️ **First failure:** <code>us</code>\n")
 }
 
 // firstFailingOp builds a rolling, continue-policy operation carrying an error,
@@ -116,9 +116,9 @@ func TestRenderMultiDeploymentApplyComment_FirstFailureSurfacesError(t *testing.
 
 	// A later deployment is still running even though the aggregate is fail-closed.
 	assert.Contains(t, out, "- 🔄 au — running table copy")
-	assert.Contains(t, out, "> ⚠️ **First failure:** `us` — Error 1061: Duplicate key name idx\n")
+	assert.Contains(t, out, "> ⚠️ **First failure:** <code>us</code> — Error 1061: Duplicate key name idx\n")
 	// Only the earliest failure is lifted to the header.
-	assert.NotContains(t, out, "First failure:** `eu`")
+	assert.NotContains(t, out, "First failure:** <code>eu</code>")
 }
 
 // A healthy rollout (no failed deployment) renders no first-failure line.
@@ -150,7 +150,23 @@ func TestRenderMultiDeploymentApplySummaryComment_FirstFailureSurfacesError(t *t
 		Environment: "production",
 	})
 
-	assert.Contains(t, out, "> ⚠️ **First failure:** `us` — boom &lt;script&gt;\n")
+	assert.Contains(t, out, "> ⚠️ **First failure:** <code>us</code> — boom &lt;script&gt;\n")
+}
+
+// A deployment name with HTML-significant characters is escaped inside the
+// <code> element, so it renders correctly rather than leaking entities the way
+// an escaped Markdown code span would.
+func TestRenderMultiDeploymentApplyComment_FirstFailureEscapesName(t *testing.T) {
+	model := presentation.Derive([]presentation.Operation{
+		{Deployment: "us&ca", State: so.Failed, HaltOnFailure: true, Error: "boom"},
+	})
+	out := RenderMultiDeploymentApplyComment(MultiDeploymentApplyData{
+		Model:       model,
+		ApplyID:     "apply-123",
+		Environment: "production",
+	})
+
+	assert.Contains(t, out, "> ⚠️ **First failure:** <code>us&amp;ca</code> — boom\n")
 }
 
 // Each deployment's <details> body is rendered by the single-deployment renderer,

--- a/pkg/webhook/templates/multi_apply_test.go
+++ b/pkg/webhook/templates/multi_apply_test.go
@@ -87,6 +87,70 @@ func TestRenderMultiDeploymentApplyComment_FailedHalt(t *testing.T) {
 	assert.Contains(t, out, "- ❌ us — failed")
 	assert.Contains(t, out, "- ⏸ au — halted — us failed")
 	assert.Contains(t, out, "<details open>\n<summary>⏸ au — halted — us failed</summary>")
+	// With no error detail on the failed operation, the first-failure line names
+	// the deployment without a reason.
+	assert.Contains(t, out, "> ⚠️ **First failure:** `us`\n")
+}
+
+// firstFailingOp builds a rolling, continue-policy operation carrying an error,
+// so a fan-out can fail one deployment and keep going.
+func firstFailingOp(dep, st, errMsg string) presentation.Operation {
+	return presentation.Operation{Deployment: dep, State: st, HaltOnFailure: false, Error: errMsg}
+}
+
+// A failed deployment's reason is lifted to the aggregate header so an operator
+// sees what failed without expanding that deployment's section. Under on_failure
+// continue a later deployment is still copying, so the reason surfaces on the
+// in-progress status comment, and only the first failure in resolved order shows.
+func TestRenderMultiDeploymentApplyComment_FirstFailureSurfacesError(t *testing.T) {
+	model := presentation.Derive([]presentation.Operation{
+		firstFailingOp("us", so.Failed, "Error 1061: Duplicate key name idx"),
+		firstFailingOp("eu", so.Failed, "second failure"),
+		{Deployment: "au", State: so.Running, HaltOnFailure: false},
+	})
+	out := RenderMultiDeploymentApplyComment(MultiDeploymentApplyData{
+		Model:       model,
+		ApplyID:     "apply-123",
+		Environment: "production",
+	})
+
+	// A later deployment is still running even though the aggregate is fail-closed.
+	assert.Contains(t, out, "- 🔄 au — running table copy")
+	assert.Contains(t, out, "> ⚠️ **First failure:** `us` — Error 1061: Duplicate key name idx\n")
+	// Only the earliest failure is lifted to the header.
+	assert.NotContains(t, out, "First failure:** `eu`")
+}
+
+// A healthy rollout (no failed deployment) renders no first-failure line.
+func TestRenderMultiDeploymentApplyComment_NoFirstFailureWhenHealthy(t *testing.T) {
+	model := presentation.Derive([]presentation.Operation{
+		rollingOp("eu", so.Completed),
+		rollingOp("us", so.Running),
+	})
+	out := RenderMultiDeploymentApplyComment(MultiDeploymentApplyData{
+		Model:       model,
+		ApplyID:     "apply-123",
+		Environment: "production",
+	})
+
+	assert.NotContains(t, out, "First failure:")
+}
+
+// The terminal summary comment surfaces the same first-failure line, and escapes
+// HTML in the error so a failure message can never inject markup.
+func TestRenderMultiDeploymentApplySummaryComment_FirstFailureSurfacesError(t *testing.T) {
+	model := presentation.Derive([]presentation.Operation{
+		rollingOp("eu", so.Completed),
+		{Deployment: "us", State: so.Failed, HaltOnFailure: true, Error: "boom <script>"},
+		rollingOp("au", so.Pending),
+	})
+	out := RenderMultiDeploymentApplySummaryComment(MultiDeploymentApplyData{
+		Model:       model,
+		ApplyID:     "apply-123",
+		Environment: "production",
+	})
+
+	assert.Contains(t, out, "> ⚠️ **First failure:** `us` — boom &lt;script&gt;\n")
 }
 
 // Each deployment's <details> body is rendered by the single-deployment renderer,


### PR DESCRIPTION
## What and Why ?

A multi-deployment apply comment showed *which* deployment failed but not *why* — the error was only inside that deployment's collapsed `<details>` section. This lifts the first failed deployment and its error onto the aggregate header of both the status and terminal-summary comments, so an operator sees the reason at a glance.

The first failure is derived once on the `pkg/presentation` rollup (the same "first failed operation" the persisted aggregate error is stamped from) and rendered by both comment paths. Single- and zero-operation applies are unaffected.

## Behaviour
```
BEFORE                                AFTER
❌ Schema Change Failed            ## ❌ Schema Change Failed
Deployments: 1 completed,            Deployments: 1 completed,
2 halted, 1 failed                   2 halted, 1 failed

--- To retry: ...W                   > ⚠️ First failure: us —          ◀ NEW
- ✅ eu — completed                      lock wait timeout exceeded
- ❌ us — failed      ◀ no reason     --- To retry: ...
- ⏸ au — halted — us failed          - ✅ eu / ❌ us / ⏸ au / ⏸ ca
- ⏸ ca — halted — us failed
(reason only inside <details>)        (reason visible under the counts)
```

- `Apply.FirstFailure` = first deployment in resolved order with state `failed` (excludes `failed_retryable`); `nil` when none failed.
- Error is HTML-escaped; falls back to naming the deployment when the operation carried no error detail.
