### PR TITLE
fix(storage): order ListByApply by (created_at, id) to match the claim gate

### DIFF
--- a/pkg/api/operator_test.go
+++ b/pkg/api/operator_test.go
@@ -452,6 +452,33 @@ func TestUpdateApplyStateFromOperations_StampsAggregateFailureMessage(t *testing
 		"the failure reason must come from the failed operation, not the successful last sibling")
 }
 
+// TestUpdateApplyStateFromOperations_FirstFailedDeploymentWins verifies that
+// when more than one deployment fails the surfaced reason comes from the first
+// failed operation in deployment order — the order ListByApply returns rows in,
+// matching the order the claim gate drives them. The rollout's failure verdict
+// is the first failure, so a later failed sibling's message must not override it.
+func TestUpdateApplyStateFromOperations_FirstFailedDeploymentWins(t *testing.T) {
+	ops := []*storage.ApplyOperation{
+		{ID: 1, Deployment: "region-a", State: state.ApplyOperation.Failed, ErrorMessage: "spirit: region-a cutover failed"},
+		{ID: 2, Deployment: "region-b", State: state.ApplyOperation.Failed, ErrorMessage: "spirit: region-b cutover failed"},
+	}
+	applyStore := &recordingApplyStore{swapped: true}
+	svc := newOperatorStateTestService(&listingApplyOperationStore{ops: ops}, applyStore)
+
+	apply := &storage.Apply{
+		ID:              3,
+		ApplyIdentifier: "apply-projection",
+		State:           state.Apply.Running,
+		Environment:     "staging",
+	}
+
+	require.NoError(t, svc.updateApplyStateFromOperations(t.Context(), 1, apply, allowLeaseScopedFailedReopen))
+	require.NotNil(t, applyStore.updated)
+	assert.Equal(t, state.Apply.Failed, applyStore.updated.State)
+	assert.Equal(t, "deployment region-a failed: spirit: region-a cutover failed", applyStore.updated.ErrorMessage,
+		"the reason must come from the first failed deployment in order, not a later failed sibling")
+}
+
 // TestUpdateApplyStateFromOperations_KeepsExistingMessageWhenNoOperationCarriesOne
 // verifies that a derived failed verdict preserves the apply's existing message
 // when no failed operation row carries one, rather than blanking the reason.

--- a/pkg/schema/mysql/apply_operations.sql
+++ b/pkg/schema/mysql/apply_operations.sql
@@ -19,5 +19,6 @@ CREATE TABLE `apply_operations` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `idx_apply_operation` (`apply_id`,`deployment`),
   KEY `idx_deployment_state` (`deployment`,`state`),
-  KEY `idx_state_created_id` (`state`,`created_at`,`id`)
+  KEY `idx_state_created_id` (`state`,`created_at`,`id`),
+  KEY `idx_apply_created_id` (`apply_id`,`created_at`,`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci

--- a/pkg/storage/mysqlstore/apply_operations.go
+++ b/pkg/storage/mysqlstore/apply_operations.go
@@ -121,13 +121,17 @@ func (s *applyOperationStore) GetByApplyAndDeployment(ctx context.Context, apply
 	return scanApplyOperation(row)
 }
 
-// ListByApply returns all child rows for an apply, ordered by id ascending.
+// ListByApply returns all child rows for an apply, ordered by (created_at, id)
+// ascending — the same deployment order the claim gate enforces. Keeping the
+// projection and "first failed deployment" derivation on this order means the
+// aggregate apply state and its surfaced failure reason agree with the order the
+// rollout actually drives deployments in.
 func (s *applyOperationStore) ListByApply(ctx context.Context, applyID int64) ([]*storage.ApplyOperation, error) {
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT `+applyOperationColumns+`
 		FROM apply_operations
 		WHERE apply_id = ?
-		ORDER BY id
+		ORDER BY created_at, id
 	`, applyID)
 	if err != nil {
 		return nil, fmt.Errorf("query apply_operations for apply %d: %w", applyID, err)

--- a/pkg/storage/mysqlstore/apply_operations_test.go
+++ b/pkg/storage/mysqlstore/apply_operations_test.go
@@ -259,12 +259,55 @@ func TestApplyOperationStore_ListByApply(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, got, 3)
 
-	// ListByApply is ordered by id (insertion order).
+	// ListByApply is ordered by (created_at, id); rows inserted in the same
+	// second tie-break on id, preserving insertion (deployment) order.
 	deps := make([]string, len(got))
 	for i, ad := range got {
 		deps[i] = ad.Deployment
 	}
 	assert.Equal(t, []string{"region-a", "region-b", "region-c"}, deps)
+}
+
+// TestApplyOperationStore_ListByApply_OrderedByCreatedAt proves ListByApply
+// honours created_at before id, matching the deployment order the claim gate
+// enforces. A row inserted later but stamped with an earlier created_at must
+// sort ahead of its lower-id siblings, so the aggregate projection and the
+// first-failed-deployment message agree with the order the rollout runs in.
+func TestApplyOperationStore_ListByApply_OrderedByCreatedAt(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", "mysql", "staging")
+	apply := createTestApply(t, store, lock, "apply_md_list_order", 1)
+
+	ids := make(map[string]int64, 3)
+	for _, dep := range []string{"region-a", "region-b", "region-c"} {
+		id, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+			ApplyID: apply.ID, Deployment: dep, Target: "payments",
+		})
+		require.NoError(t, err)
+		ids[dep] = id
+	}
+
+	// Backdate the last-inserted (highest-id) row so its created_at precedes its
+	// siblings. Ordering by id alone would keep it last; ordering by created_at
+	// must move it to the front.
+	_, err := testDB.ExecContext(ctx,
+		"UPDATE apply_operations SET created_at = '2000-01-01 00:00:00' WHERE id = ?",
+		ids["region-c"])
+	require.NoError(t, err)
+
+	got, err := store.ApplyOperations().ListByApply(ctx, apply.ID)
+	require.NoError(t, err)
+	require.Len(t, got, 3)
+
+	deps := make([]string, len(got))
+	for i, ad := range got {
+		deps[i] = ad.Deployment
+	}
+	assert.Equal(t, []string{"region-c", "region-a", "region-b"}, deps,
+		"created_at must take precedence over id in ListByApply ordering")
 }
 
 func TestApplyOperationStore_ListByApply_Isolation(t *testing.T) {


### PR DESCRIPTION
## What

`ListByApply` now orders rows by `(created_at, id)` instead of `id` alone — the same order the claim gate (`FindNextApplyOperation`) enforces.

## Why

The aggregate apply-state projection and the surfaced first-failed-deployment reason both consume `ListByApply`. Ordering it like the claim gate makes the parent's derived state and its failure message agree with the order the rollout actually drives deployments in, instead of drifting when `created_at` and `id` disagree.

No-op for single-operation applies (one row → order is trivially identical). Foundation for multi-deployment fan-out.
