### PR TITLE
feat(observability): render per-deployment breakdown in schemabot progress

### DIFF
--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -5053,6 +5053,127 @@ _No details available yet._
 </details>
 </details>
 
+## Multi-Deployment Apply (CLI)
+
+<details>
+<summary><a name="barrier-rollout-in-progress"></a><strong>Barrier Rollout In Progress</strong></summary>
+
+```
+
+┌───────────────────────────────────────────────────────────────┐
+│  Apply ID:     apply-multi-a1b2c3d4                           │
+│  Environment:  production                                     │
+│  State:        running                                        │
+│  Caller:       octocat                                        │
+│  Started:      Jan 15 14:22:00 UTC                            │
+│  Duration:     8m                                             │
+│  Deployments:  1 ready for cutover · 1 running · 1 waiting    │
+└───────────────────────────────────────────────────────────────┘
+
+  Next: cut over us-east
+
+🟢 us-east — ready for cutover — next in order (orders-us-east)
+
+     ~ orders: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦 Waiting for cutover
+       ALTER TABLE `orders` ADD COLUMN `source` varchar(32);
+
+
+🔄 eu-west — running table copy (orders-eu-west)
+
+     ~ orders: 🟦🟦🟦🟦🟦🟦🟦⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ 35%
+       ALTER TABLE `orders` ADD COLUMN `source` varchar(32);
+       • Rows: 42,000 / 120,000 · ETA: 4m 0s
+
+
+⏳ ap-south — waiting for eu-west (orders-ap-south)
+
+     ~ orders: ⏳ Queued
+       ALTER TABLE `orders` ADD COLUMN `source` varchar(32);
+
+
+
+```
+</details>
+
+<details>
+<summary><a name="halt-on-failure-one-deployment-failed"></a><strong>Halt On Failure (One Deployment Failed)</strong></summary>
+
+```
+
+┌─────────────────────────────────────────────────────┐
+│  Apply ID:     apply-multi-a1b2c3d4                 │
+│  Environment:  production                           │
+│  State:        failed                               │
+│  Caller:       octocat                              │
+│  Started:      Jan 15 14:22:00 UTC                  │
+│  Duration:     8m                                   │
+│  Deployments:  1 completed · 1 halted · 1 failed    │
+└─────────────────────────────────────────────────────┘
+
+  ⚠ First failure: eu-west — duplicate key name 'idx_orders_source'
+
+  Next: review failure in eu-west
+
+✅ us-east — completed (orders-us-east)
+
+     ~ orders: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+       ALTER TABLE `orders` ADD COLUMN `source` varchar(32);
+
+
+❌ eu-west — failed (orders-eu-west)
+  duplicate key name 'idx_orders_source'
+
+     ~ orders: ⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ ❌ Failed
+       ALTER TABLE `orders` ADD INDEX `idx_orders_source`(`source`);
+
+
+⏸ ap-south — halted — eu-west failed (orders-ap-south)
+
+     ~ orders: ⊘ Cancelled (not started)
+       ALTER TABLE `orders` ADD COLUMN `source` varchar(32);
+
+
+
+```
+</details>
+
+<details>
+<summary><a name="all-deployments-completed"></a><strong>All Deployments Completed</strong></summary>
+
+```
+
+┌──────────────────────────────────────┐
+│  Apply ID:     apply-multi-a1b2c3d4  │
+│  Environment:  production            │
+│  State:        completed             │
+│  Caller:       octocat               │
+│  Started:      Jan 15 14:22:00 UTC   │
+│  Duration:     7m                    │
+│  Deployments:  3 completed           │
+└──────────────────────────────────────┘
+
+✅ us-east — completed (orders-us-east)
+
+     ~ orders: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+       ALTER TABLE `orders` ADD COLUMN `source` varchar(32);
+
+
+✅ eu-west — completed (orders-eu-west)
+
+     ~ orders: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+       ALTER TABLE `orders` ADD COLUMN `source` varchar(32);
+
+
+✅ ap-south — completed (orders-ap-south)
+
+     ~ orders: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+       ALTER TABLE `orders` ADD COLUMN `source` varchar(32);
+
+
+```
+</details>
+
+
 ## Sequential Mode (CLI)
 
 <details>

--- a/pkg/api/progress_handlers.go
+++ b/pkg/api/progress_handlers.go
@@ -185,11 +185,13 @@ func progressResponseFromProto(resp *ternv1.ProgressResponse) *apitypes.Progress
 
 func progressOperationResponseFromStorage(op *storage.ApplyOperation) *apitypes.ProgressOperationResponse {
 	resp := &apitypes.ProgressOperationResponse{
-		Deployment:   op.Deployment,
-		Target:       op.Target,
-		State:        op.State,
-		ErrorCode:    deriveErrorCode(op.State, op.ErrorMessage),
-		ErrorMessage: op.ErrorMessage,
+		Deployment:    op.Deployment,
+		Target:        op.Target,
+		State:         op.State,
+		CutoverPolicy: op.CutoverPolicy,
+		OnFailure:     op.OnFailure,
+		ErrorCode:     deriveErrorCode(op.State, op.ErrorMessage),
+		ErrorMessage:  op.ErrorMessage,
 	}
 	if op.StartedAt != nil {
 		resp.StartedAt = op.StartedAt.Format(time.RFC3339)

--- a/pkg/apitypes/apitypes.go
+++ b/pkg/apitypes/apitypes.go
@@ -310,9 +310,13 @@ type ProgressResponse struct {
 
 // ProgressOperationResponse represents progress for one deployment operation.
 type ProgressOperationResponse struct {
-	Deployment   string `json:"deployment"`
-	Target       string `json:"target,omitempty"`
-	State        string `json:"state"`
+	Deployment string `json:"deployment"`
+	Target     string `json:"target,omitempty"`
+	State      string `json:"state"`
+	// CutoverPolicy is the rollout boundary policy for this deployment operation.
+	CutoverPolicy string `json:"cutover_policy,omitempty"`
+	// OnFailure is the rollout failure policy for this deployment operation.
+	OnFailure    string `json:"on_failure,omitempty"`
 	ErrorCode    string `json:"error_code,omitempty"`
 	ErrorMessage string `json:"error_message,omitempty"`
 	StartedAt    string `json:"started_at,omitempty"`

--- a/pkg/cmd/commands/preview.go
+++ b/pkg/cmd/commands/preview.go
@@ -85,6 +85,8 @@ func (cmd *PreviewCmd) Run(g *Globals) error {
 		templates.PreviewCommentApplyWaitingCutover, templates.PreviewCommentApplyCuttingOver,
 		templates.PreviewCommentMultiDeployInProgress, templates.PreviewCommentMultiDeployFailed,
 		templates.PreviewCommentMultiDeployCompleted, templates.PreviewCommentMultiDeployAll,
+		templates.PreviewCLIMultiDeployInProgress, templates.PreviewCLIMultiDeployFailed,
+		templates.PreviewCLIMultiDeployCompleted, templates.PreviewCLIMultiDeployAll,
 		templates.PreviewCommentSingleProgress, templates.PreviewCommentSingleComplete,
 		templates.PreviewCommentSingleFailed, templates.PreviewCommentSingleStopped,
 		templates.PreviewCommentSummaryCompleted, templates.PreviewCommentSummaryFailed,
@@ -244,6 +246,10 @@ Comment Templates (GitHub PR comments):
   comment_apply_stopped         Multi-table: stopped (partial progress)
   comment_apply_waiting_cutover Waiting for cutover
   comment_apply_cutting_over    Cutting over
+  cli_multi_deploy_in_progress  CLI multi-deployment apply in progress
+  cli_multi_deploy_failed       CLI multi-deployment apply with one failed deployment
+  cli_multi_deploy_completed    CLI multi-deployment apply completed
+  cli_multi_deploy_all          Show all CLI multi-deployment apply previews
   comment_summary_completed       Summary: apply completed
   comment_summary_failed          Summary: apply failed (with error)
   comment_summary_stopped         Summary: apply stopped

--- a/pkg/cmd/internal/templates/preview.go
+++ b/pkg/cmd/internal/templates/preview.go
@@ -136,6 +136,10 @@ const (
 	PreviewCommentMultiDeployFailed     PreviewType = "comment_multi_deploy_failed"      // Halt-on-failure: one deployment failed
 	PreviewCommentMultiDeployCompleted  PreviewType = "comment_multi_deploy_completed"   // All deployments completed
 	PreviewCommentMultiDeployAll        PreviewType = "comment_multi_deploy_all"         // Show all multi-deployment apply previews
+	PreviewCLIMultiDeployInProgress     PreviewType = "cli_multi_deploy_in_progress"     // Barrier rollout mid-flight
+	PreviewCLIMultiDeployFailed         PreviewType = "cli_multi_deploy_failed"          // Halt-on-failure: one deployment failed
+	PreviewCLIMultiDeployCompleted      PreviewType = "cli_multi_deploy_completed"       // All deployments completed
+	PreviewCLIMultiDeployAll            PreviewType = "cli_multi_deploy_all"             // Show all CLI multi-deployment apply previews
 
 	// Single-table apply comment previews (most common case)
 	PreviewCommentSingleProgress          PreviewType = "comment_single_progress"            // Single table running

--- a/pkg/cmd/internal/templates/preview_dispatch.go
+++ b/pkg/cmd/internal/templates/preview_dispatch.go
@@ -161,6 +161,14 @@ func PreviewCLIOutput(previewType PreviewType) {
 		fmt.Print(webhooktemplates.PreviewCommentMultiDeploymentApplyCompleted())
 	case PreviewCommentMultiDeployAll:
 		previewCommentMultiDeployAllOutput()
+	case PreviewCLIMultiDeployInProgress:
+		previewCLIMultiDeploymentApplyInProgress()
+	case PreviewCLIMultiDeployFailed:
+		previewCLIMultiDeploymentApplyFailed()
+	case PreviewCLIMultiDeployCompleted:
+		previewCLIMultiDeploymentApplyCompleted()
+	case PreviewCLIMultiDeployAll:
+		previewCLIMultiDeployAllOutput()
 	case PreviewCommentSingleProgress:
 		fmt.Print(webhooktemplates.PreviewCommentApplySingleProgress())
 	case PreviewCommentSingleComplete:

--- a/pkg/cmd/internal/templates/preview_progress_multi.go
+++ b/pkg/cmd/internal/templates/preview_progress_multi.go
@@ -1,0 +1,77 @@
+package templates
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/block/schemabot/pkg/state"
+	"github.com/block/schemabot/pkg/storage"
+)
+
+func previewCLIMultiDeploymentApplyInProgress() {
+	WriteProgress(multiDeploymentProgressData([]ProgressOperation{
+		{Deployment: "us-east", Target: "orders-us-east", State: state.ApplyOperation.WaitingForCutover, CutoverPolicy: storage.CutoverPolicyBarrier, OnFailure: storage.OnFailureHalt},
+		{Deployment: "eu-west", Target: "orders-eu-west", State: state.ApplyOperation.Running, CutoverPolicy: storage.CutoverPolicyBarrier, OnFailure: storage.OnFailureHalt},
+		{Deployment: "ap-south", Target: "orders-ap-south", State: state.ApplyOperation.Pending, CutoverPolicy: storage.CutoverPolicyBarrier, OnFailure: storage.OnFailureHalt},
+	}, []TableProgress{
+		{Deployment: "us-east", TableName: "orders", ChangeType: "alter", DDL: "ALTER TABLE `orders` ADD COLUMN `source` varchar(32) DEFAULT NULL", Status: state.Task.WaitingForCutover, RowsCopied: 80000, RowsTotal: 80000, PercentComplete: 100},
+		{Deployment: "eu-west", TableName: "orders", ChangeType: "alter", DDL: "ALTER TABLE `orders` ADD COLUMN `source` varchar(32) DEFAULT NULL", Status: state.Task.Running, RowsCopied: 42000, RowsTotal: 120000, PercentComplete: 35, ETASeconds: 240},
+		{Deployment: "ap-south", TableName: "orders", ChangeType: "alter", DDL: "ALTER TABLE `orders` ADD COLUMN `source` varchar(32) DEFAULT NULL", Status: state.Task.Pending},
+	}))
+}
+
+func previewCLIMultiDeploymentApplyFailed() {
+	WriteProgress(multiDeploymentProgressData([]ProgressOperation{
+		{Deployment: "us-east", Target: "orders-us-east", State: state.ApplyOperation.Completed, CutoverPolicy: storage.CutoverPolicyRolling, OnFailure: storage.OnFailureHalt},
+		{Deployment: "eu-west", Target: "orders-eu-west", State: state.ApplyOperation.Failed, CutoverPolicy: storage.CutoverPolicyRolling, OnFailure: storage.OnFailureHalt, ErrorMessage: "duplicate key name 'idx_orders_source'"},
+		{Deployment: "ap-south", Target: "orders-ap-south", State: state.ApplyOperation.Pending, CutoverPolicy: storage.CutoverPolicyRolling, OnFailure: storage.OnFailureHalt},
+	}, []TableProgress{
+		{Deployment: "us-east", TableName: "orders", ChangeType: "alter", DDL: "ALTER TABLE `orders` ADD COLUMN `source` varchar(32) DEFAULT NULL", Status: state.Task.Completed, RowsCopied: 80000, RowsTotal: 80000, PercentComplete: 100},
+		{Deployment: "eu-west", TableName: "orders", ChangeType: "alter", DDL: "ALTER TABLE `orders` ADD INDEX `idx_orders_source` (`source`)", Status: state.Task.Failed, RowsCopied: 0, RowsTotal: 120000, PercentComplete: 0},
+		{Deployment: "ap-south", TableName: "orders", ChangeType: "alter", DDL: "ALTER TABLE `orders` ADD COLUMN `source` varchar(32) DEFAULT NULL", Status: TaskCancelled},
+	}))
+}
+
+func previewCLIMultiDeploymentApplyCompleted() {
+	data := multiDeploymentProgressData([]ProgressOperation{
+		{Deployment: "us-east", Target: "orders-us-east", State: state.ApplyOperation.Completed, CutoverPolicy: storage.CutoverPolicyRolling, OnFailure: storage.OnFailureHalt},
+		{Deployment: "eu-west", Target: "orders-eu-west", State: state.ApplyOperation.Completed, CutoverPolicy: storage.CutoverPolicyRolling, OnFailure: storage.OnFailureHalt},
+		{Deployment: "ap-south", Target: "orders-ap-south", State: state.ApplyOperation.Completed, CutoverPolicy: storage.CutoverPolicyRolling, OnFailure: storage.OnFailureHalt},
+	}, []TableProgress{
+		{Deployment: "us-east", TableName: "orders", ChangeType: "alter", DDL: "ALTER TABLE `orders` ADD COLUMN `source` varchar(32) DEFAULT NULL", Status: state.Task.Completed, RowsCopied: 80000, RowsTotal: 80000, PercentComplete: 100},
+		{Deployment: "eu-west", TableName: "orders", ChangeType: "alter", DDL: "ALTER TABLE `orders` ADD COLUMN `source` varchar(32) DEFAULT NULL", Status: state.Task.Completed, RowsCopied: 120000, RowsTotal: 120000, PercentComplete: 100},
+		{Deployment: "ap-south", TableName: "orders", ChangeType: "alter", DDL: "ALTER TABLE `orders` ADD COLUMN `source` varchar(32) DEFAULT NULL", Status: state.Task.Completed, RowsCopied: 60000, RowsTotal: 60000, PercentComplete: 100},
+	})
+	data.CompletedAt = previewTime.Add(-1 * time.Minute).Format(time.RFC3339)
+	WriteProgress(data)
+}
+
+func previewCLIMultiDeployAllOutput() {
+	sections := []struct {
+		name string
+		fn   func()
+	}{
+		{"BARRIER ROLLOUT IN PROGRESS", previewCLIMultiDeploymentApplyInProgress},
+		{"HALT ON FAILURE (ONE DEPLOYMENT FAILED)", previewCLIMultiDeploymentApplyFailed},
+		{"ALL DEPLOYMENTS COMPLETED", previewCLIMultiDeploymentApplyCompleted},
+	}
+	for i, section := range sections {
+		if i > 0 {
+			fmt.Println()
+		}
+		fmt.Printf("--- %s ---\n\n", section.name)
+		section.fn()
+	}
+}
+
+func multiDeploymentProgressData(ops []ProgressOperation, tables []TableProgress) ProgressData {
+	return ProgressData{
+		ApplyID:     "apply-multi-a1b2c3d4",
+		Environment: "production",
+		Caller:      "octocat",
+		State:       state.Apply.Running,
+		StartedAt:   previewTime.Add(-8 * time.Minute).Format(time.RFC3339),
+		Operations:  ops,
+		Tables:      tables,
+	}
+}

--- a/pkg/cmd/internal/templates/progress.go
+++ b/pkg/cmd/internal/templates/progress.go
@@ -60,6 +60,10 @@ func WriteProgress(data ProgressData) {
 		fmt.Println("No active schema change")
 		return
 	}
+	if len(data.Operations) > 1 {
+		writeMultiDeploymentProgress(data)
+		return
+	}
 
 	// Build key/value pairs for the detail box
 	displayState := state.Label(data.State)

--- a/pkg/cmd/internal/templates/progress_multi.go
+++ b/pkg/cmd/internal/templates/progress_multi.go
@@ -1,0 +1,174 @@
+package templates
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/block/schemabot/pkg/presentation"
+	"github.com/block/schemabot/pkg/state"
+	"github.com/block/schemabot/pkg/storage"
+	"github.com/block/schemabot/pkg/ui"
+)
+
+func writeMultiDeploymentProgress(data ProgressData) {
+	model := presentation.Derive(progressOperationsForPresentation(data.Operations))
+
+	writeMultiDeploymentHeader(data, model)
+	writeMultiDeploymentFirstFailure(model.FirstFailure)
+	writeMultiDeploymentNextAction(model.NextAction)
+	fmt.Println()
+
+	for _, deployment := range model.Deployments {
+		writeDeploymentProgressSection(deployment, data)
+	}
+}
+
+func progressOperationsForPresentation(ops []ProgressOperation) []presentation.Operation {
+	presentationOps := make([]presentation.Operation, 0, len(ops))
+	for _, op := range ops {
+		presentationOps = append(presentationOps, presentation.Operation{
+			Deployment:    op.Deployment,
+			State:         op.State,
+			Barrier:       op.CutoverPolicy == storage.CutoverPolicyBarrier,
+			HaltOnFailure: op.OnFailure != storage.OnFailureContinue,
+			Error:         op.ErrorMessage,
+		})
+	}
+	return presentationOps
+}
+
+func writeMultiDeploymentHeader(data ProgressData, model presentation.Apply) {
+	rows := []BoxRow{}
+	if data.ApplyID != "" {
+		rows = append(rows, BoxRow{"Apply ID", data.ApplyID})
+	}
+	if data.Environment != "" {
+		rows = append(rows, BoxRow{"Environment", data.Environment})
+	}
+	rows = append(rows, BoxRow{"State", model.Label})
+	if data.Caller != "" {
+		rows = append(rows, BoxRow{"Caller", data.Caller})
+	}
+	if data.PullRequestURL != "" {
+		rows = append(rows, BoxRow{"PR", data.PullRequestURL})
+	}
+	if data.StartedAt != "" {
+		if started, err := time.Parse(time.RFC3339, data.StartedAt); err == nil {
+			rows = append(rows, BoxRow{"Started", started.Format("Jan 2 15:04:05 MST")})
+		}
+	}
+	if dur := formatApplyDuration(data.StartedAt, data.CompletedAt); dur != "-" {
+		rows = append(rows, BoxRow{"Duration", dur})
+	}
+	if counts := formatDeploymentCounts(model.Counts); counts != "" {
+		rows = append(rows, BoxRow{"Deployments", counts})
+	}
+	WriteBox(rows, "State", stateColorFunc(model.State))
+}
+
+func formatDeploymentCounts(counts []presentation.StateCount) string {
+	parts := make([]string, 0, len(counts))
+	for _, count := range counts {
+		parts = append(parts, fmt.Sprintf("%d %s", count.Count, count.Label))
+	}
+	return strings.Join(parts, " · ")
+}
+
+func writeMultiDeploymentFirstFailure(failure *presentation.Deployment) {
+	if failure == nil {
+		return
+	}
+	if failure.Error == "" {
+		fmt.Printf("\n  %s⚠ First failure: %s%s\n", ANSIRed, failure.Deployment, ANSIReset)
+		return
+	}
+	fmt.Printf("\n  %s⚠ First failure: %s — %s%s\n", ANSIRed, failure.Deployment, failure.Error, ANSIReset)
+}
+
+func writeMultiDeploymentNextAction(next presentation.NextAction) {
+	switch next.Kind {
+	case presentation.NextActionCutover:
+		fmt.Printf("\n  Next: cut over %s\n", next.Deployment)
+	case presentation.NextActionResume:
+		fmt.Println("\n  Next: resume apply")
+	case presentation.NextActionReviewFailure:
+		if next.Deployment == "" {
+			fmt.Println("\n  Next: review failure")
+			return
+		}
+		fmt.Printf("\n  Next: review failure in %s\n", next.Deployment)
+	case presentation.NextActionNone:
+	}
+}
+
+func writeDeploymentProgressSection(deployment presentation.Deployment, data ProgressData) {
+	fmt.Printf("%s %s — %s", deployment.Emoji, deployment.Deployment, deployment.Label)
+	if target := targetForDeployment(data.Operations, deployment.Deployment); target != "" {
+		fmt.Printf(" (%s)", target)
+	}
+	fmt.Println()
+
+	if deployment.Error != "" {
+		fmt.Printf("  %s%s%s\n", ANSIRed, deployment.Error, ANSIReset)
+	}
+
+	tables := activeTablesForDeployment(data.Tables, deployment.Deployment)
+	if len(tables) > 0 && !state.IsSetupPhase(data.State) {
+		sortActiveTables(tables)
+		if hasTableNamespaces(tables) {
+			fmt.Print(FormatNamespacedTables(tables))
+		} else {
+			fmt.Println()
+			for _, table := range tables {
+				fmt.Print(FormatTableProgress(table))
+			}
+		}
+	}
+	fmt.Println()
+}
+
+func targetForDeployment(ops []ProgressOperation, deployment string) string {
+	for _, op := range ops {
+		if op.Deployment == deployment {
+			return op.Target
+		}
+	}
+	return ""
+}
+
+func activeTablesForDeployment(tables []TableProgress, deployment string) []TableProgress {
+	activeTables := make([]TableProgress, 0, len(tables))
+	for _, table := range tables {
+		if table.Deployment == deployment && table.TableName != "" {
+			activeTables = append(activeTables, table)
+		}
+	}
+	return activeTables
+}
+
+func sortActiveTables(tables []TableProgress) {
+	sort.SliceStable(tables, func(i, j int) bool {
+		pi := ui.TableStatePriority(state.NormalizeTaskStatus(tables[i].Status))
+		pj := ui.TableStatePriority(state.NormalizeTaskStatus(tables[j].Status))
+		if pi != pj {
+			return pi < pj
+		}
+		si := len(tables[i].Shards) > 0
+		sj := len(tables[j].Shards) > 0
+		if si != sj {
+			return si
+		}
+		return false
+	})
+}
+
+func hasTableNamespaces(tables []TableProgress) bool {
+	for _, table := range tables {
+		if table.Namespace != "" {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/cmd/internal/templates/progress_multi_test.go
+++ b/pkg/cmd/internal/templates/progress_multi_test.go
@@ -1,0 +1,83 @@
+package templates
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/block/schemabot/pkg/state"
+	"github.com/block/schemabot/pkg/storage"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWriteProgressMultiDeploymentRendersAggregateAndSections(t *testing.T) {
+	output := captureStdout(t, func() {
+		WriteProgress(ProgressData{
+			ApplyID:     "apply-test",
+			Environment: "staging",
+			Caller:      "octocat",
+			State:       state.Apply.Running,
+			StartedAt:   "2026-06-16T10:00:00Z",
+			Operations: []ProgressOperation{
+				{Deployment: "region-a", Target: "orders-a", State: state.ApplyOperation.Completed, CutoverPolicy: storage.CutoverPolicyRolling, OnFailure: storage.OnFailureHalt},
+				{Deployment: "region-b", Target: "orders-b", State: state.ApplyOperation.Failed, CutoverPolicy: storage.CutoverPolicyRolling, OnFailure: storage.OnFailureHalt, ErrorMessage: "duplicate column name 'region'"},
+				{Deployment: "region-c", Target: "orders-c", State: state.ApplyOperation.Pending, CutoverPolicy: storage.CutoverPolicyRolling, OnFailure: storage.OnFailureHalt},
+			},
+			Tables: []TableProgress{
+				{Deployment: "region-a", TableName: "users_a", ChangeType: "alter", DDL: "ALTER TABLE `users_a` ADD COLUMN `region` varchar(20)", Status: state.Task.Completed},
+				{Deployment: "region-b", TableName: "users_b", ChangeType: "alter", DDL: "ALTER TABLE `users_b` ADD COLUMN `region` varchar(20)", Status: state.Task.Failed},
+				{Deployment: "region-c", TableName: "users_c", ChangeType: "alter", DDL: "ALTER TABLE `users_c` ADD COLUMN `region` varchar(20)", Status: state.Task.Running},
+			},
+		})
+	})
+
+	assert.Contains(t, output, "Apply ID:")
+	assert.Contains(t, output, "apply-test")
+	assert.Contains(t, output, "State:")
+	assert.Contains(t, output, "failed")
+	assert.Contains(t, output, "Caller:")
+	assert.Contains(t, output, "octocat")
+	assert.Contains(t, output, "Deployments:")
+	assert.Contains(t, output, "1 completed · 1 halted · 1 failed")
+	assert.Contains(t, output, "First failure: region-b — duplicate column name 'region'")
+	assert.Contains(t, output, "Next: review failure in region-b")
+	assertLess(t, output, "✅ region-a — completed", "❌ region-b — failed")
+	assertLess(t, output, "❌ region-b — failed", "⏸ region-c — halted — region-b failed")
+	assert.Contains(t, output, "users_a")
+	assert.Contains(t, output, "users_b")
+	assert.Contains(t, output, "users_c")
+}
+
+func TestWriteProgressSingleDeploymentDoesNotRenderMultiDeploymentAggregate(t *testing.T) {
+	data := ProgressData{
+		ApplyID:     "apply-single",
+		Database:    "orders",
+		Environment: "staging",
+		State:       state.Apply.Running,
+		Operations: []ProgressOperation{
+			{Deployment: "region-a", Target: "orders-a", State: state.ApplyOperation.Running, CutoverPolicy: storage.CutoverPolicyBarrier, OnFailure: storage.OnFailureHalt},
+		},
+		Tables: []TableProgress{
+			{Deployment: "region-a", TableName: "users", ChangeType: "alter", DDL: "ALTER TABLE `users` ADD COLUMN `region` varchar(20)", Status: state.Task.Running},
+		},
+	}
+
+	withOperation := captureStdout(t, func() { WriteProgress(data) })
+	data.Operations = nil
+	withoutOperation := captureStdout(t, func() { WriteProgress(data) })
+
+	assert.Equal(t, withoutOperation, withOperation)
+	assert.Contains(t, withOperation, "Database:")
+	assert.Contains(t, withOperation, "orders")
+	assert.Contains(t, withOperation, "users")
+	assert.NotContains(t, withOperation, "Deployments:")
+	assert.NotContains(t, withOperation, "region-a —")
+}
+
+func assertLess(t *testing.T, output, left, right string) {
+	t.Helper()
+	leftIndex := strings.Index(output, left)
+	rightIndex := strings.Index(output, right)
+	assert.NotEqual(t, -1, leftIndex, "expected output to contain %q", left)
+	assert.NotEqual(t, -1, rightIndex, "expected output to contain %q", right)
+	assert.Less(t, leftIndex, rightIndex, "expected %q before %q", left, right)
+}

--- a/pkg/cmd/internal/templates/progress_parse.go
+++ b/pkg/cmd/internal/templates/progress_parse.go
@@ -34,13 +34,15 @@ type ProgressData struct {
 
 // ProgressOperation represents progress for one deployment operation.
 type ProgressOperation struct {
-	Deployment   string
-	Target       string
-	State        string
-	ErrorMessage string
-	ErrorCode    string
-	StartedAt    string
-	CompletedAt  string
+	Deployment    string
+	Target        string
+	State         string
+	CutoverPolicy string
+	OnFailure     string
+	ErrorMessage  string
+	ErrorCode     string
+	StartedAt     string
+	CompletedAt   string
 }
 
 // TableProgress represents progress for a single table schema change.
@@ -146,13 +148,15 @@ func ParseProgressResponse(result *apitypes.ProgressResponse) ProgressData {
 
 	for _, op := range result.Operations {
 		data.Operations = append(data.Operations, ProgressOperation{
-			Deployment:   op.Deployment,
-			Target:       op.Target,
-			State:        state.NormalizeState(op.State),
-			ErrorMessage: op.ErrorMessage,
-			ErrorCode:    op.ErrorCode,
-			StartedAt:    op.StartedAt,
-			CompletedAt:  op.CompletedAt,
+			Deployment:    op.Deployment,
+			Target:        op.Target,
+			State:         state.NormalizeState(op.State),
+			CutoverPolicy: op.CutoverPolicy,
+			OnFailure:     op.OnFailure,
+			ErrorMessage:  op.ErrorMessage,
+			ErrorCode:     op.ErrorCode,
+			StartedAt:     op.StartedAt,
+			CompletedAt:   op.CompletedAt,
 		})
 	}
 

--- a/pkg/cmd/internal/templates/progress_parse_test.go
+++ b/pkg/cmd/internal/templates/progress_parse_test.go
@@ -15,13 +15,15 @@ func TestParseProgressResponseIncludesOperationsAndTableDeployments(t *testing.T
 		State: state.Apply.Running,
 		Operations: []*apitypes.ProgressOperationResponse{
 			{
-				Deployment:   "deploy-a",
-				Target:       "target-a",
-				State:        "STATE_RUNNING",
-				ErrorCode:    "engine_error_retryable",
-				ErrorMessage: "retryable failure",
-				StartedAt:    "2026-06-16T10:00:00Z",
-				CompletedAt:  "2026-06-16T10:05:00Z",
+				Deployment:    "deploy-a",
+				Target:        "target-a",
+				State:         "STATE_RUNNING",
+				CutoverPolicy: "barrier",
+				OnFailure:     "continue",
+				ErrorCode:     "engine_error_retryable",
+				ErrorMessage:  "retryable failure",
+				StartedAt:     "2026-06-16T10:00:00Z",
+				CompletedAt:   "2026-06-16T10:05:00Z",
 			},
 		},
 		Tables: []*apitypes.TableProgressResponse{
@@ -42,6 +44,8 @@ func TestParseProgressResponseIncludesOperationsAndTableDeployments(t *testing.T
 	assert.Equal(t, "deploy-a", data.Operations[0].Deployment)
 	assert.Equal(t, "target-a", data.Operations[0].Target)
 	assert.Equal(t, state.Apply.Running, data.Operations[0].State)
+	assert.Equal(t, "barrier", data.Operations[0].CutoverPolicy)
+	assert.Equal(t, "continue", data.Operations[0].OnFailure)
 	assert.Equal(t, "engine_error_retryable", data.Operations[0].ErrorCode)
 	assert.Equal(t, "retryable failure", data.Operations[0].ErrorMessage)
 	assert.Equal(t, "2026-06-16T10:00:00Z", data.Operations[0].StartedAt)

--- a/scripts/update-templates.sh
+++ b/scripts/update-templates.sh
@@ -163,6 +163,7 @@ render_paired_section "Apply Flow"     "comment_apply_flow_all" "cli_apply_all"
 } >> "$SNAPSHOT"
 
 # === CLI-only sections ===
+render_cli_section "Multi-Deployment Apply (CLI)" "cli_multi_deploy_all"
 render_cli_section "Sequential Mode (CLI)" "sequential_all"
 render_cli_section "Defer Cutover (CLI)"   "defer_all"
 render_cli_section "Lint & Unsafe (CLI)"   "lint_all"


### PR DESCRIPTION
## What

Adds a static CLI multi-deployment view to `schemabot progress` (and `status <apply_id>`, which shares the renderer). When an apply fans out across more than one deployment, the output now shows an aggregate header (state, per-status counts, first failure, next action) followed by a per-deployment section carrying today's per-table progress. Single-deployment output is byte-for-byte unchanged.

Carries `cutover_policy` / `on_failure` through the progress API so the CLI can resolve the rollout-ordering labels (waiting / queued-next / halted).

Deployments:  1 ready for cutover · 1 running · 1 waiting

🟢 us-east  — ready for cutover — next in order
🔄 eu-west  — running table copy   35%
⏳ ap-south — waiting for eu-west

## Why

The aggregate state alone hides which deployment is running, blocked, or failed during a fan-out rollout. This gives operators per-deployment visibility from the CLI, reusing `pkg/presentation` (the same rollup the PR comment uses) and the existing single-deployment table formatters, so the multi layout stays consistent with the rest of the UX and adds no new rollup logic.

## Stack — 3b per-deployment `progress` breakdown

| Item | Description | PR |
|---|---|---|
| 3b-A | Per-deployment progress plumbing (API + CLI parser; no visible output change) | [#365](https://github.com/block/schemabot/pull/365) |
| **3b-B** | **Static CLI multi-deployment renderer + tests — _this PR_** | **[#367](https://github.com/block/schemabot/pull/367)** |
| 3b-TUI | Multi-deployment view in the default `progress --watch` Bubble Tea TUI | [#368](https://github.com/block/schemabot/pull/368) |

## Notes

- Stacked on #365; base retargets to `main` once that merges.
- The multi layout triggers only when an apply has >1 deployment (`len(Operations) > 1`).

## Testing / validation

`gofmt` clean · `go build ./...` · `go vet` · `go test ./pkg/cmd/... ./pkg/presentation/...` — all pass. Includes a single-deployment byte-for-byte invariant test; `./bin/schemabot preview cli_multi_deploy_in_progress` renders correctly.
