### PR TITLE
feat(storage): authorize the apply-state CAS by operation lease

### DIFF
--- a/pkg/api/operator.go
+++ b/pkg/api/operator.go
@@ -1097,7 +1097,17 @@ func (s *Service) updateApplyStateFromOperations(ctx context.Context, workerID i
 			apply.ApplyIdentifier, apply.ID, derived, apply.State)
 	}
 
-	if state.IsState(apply.State, derived) {
+	// Stamp started_at when the projection first moves the parent out of a
+	// pending state and no start time was recorded yet; UpdateDerivedState only
+	// applies it while started_at is still NULL, so a recorded start is never
+	// rewound. nil means "leave started_at as-is".
+	var startedAt *time.Time
+	if apply.StartedAt == nil && !state.IsState(derived, state.Apply.Pending) {
+		now := s.clock.Now()
+		startedAt = &now
+	}
+
+	if state.IsState(apply.State, derived) && startedAt == nil {
 		s.logger.Debug("operator: derived apply state matches current; no update",
 			"worker", workerID, "apply_id", apply.ApplyIdentifier,
 			"database", apply.Database, "environment", apply.Environment,
@@ -1133,7 +1143,7 @@ func (s *Service) updateApplyStateFromOperations(ctx context.Context, workerID i
 		}
 	}
 
-	swapped, err := s.storage.Applies().UpdateDerivedState(ctx, apply.ID, apply.State, derived, errorMessage, completedAt)
+	swapped, err := s.storage.Applies().UpdateDerivedState(ctx, apply.ID, apply.State, derived, errorMessage, startedAt, completedAt)
 	if err != nil {
 		return fmt.Errorf("update derived apply state for apply %s (%d) to %q: %w", apply.ApplyIdentifier, apply.ID, derived, err)
 	}

--- a/pkg/api/operator_test.go
+++ b/pkg/api/operator_test.go
@@ -154,7 +154,7 @@ type recordingApplyStore struct {
 	swapped       bool
 }
 
-func (s *recordingApplyStore) UpdateDerivedState(_ context.Context, applyID int64, expectedState, newState, errorMessage string, completedAt *time.Time) (bool, error) {
+func (s *recordingApplyStore) UpdateDerivedState(_ context.Context, applyID int64, expectedState, newState, errorMessage string, startedAt, completedAt *time.Time) (bool, error) {
 	s.expectedState = expectedState
 	if !s.swapped {
 		return false, nil
@@ -163,6 +163,7 @@ func (s *recordingApplyStore) UpdateDerivedState(_ context.Context, applyID int6
 		ID:           applyID,
 		State:        newState,
 		ErrorMessage: errorMessage,
+		StartedAt:    startedAt,
 		CompletedAt:  completedAt,
 	}
 	return true, nil

--- a/pkg/storage/mysqlstore/applies.go
+++ b/pkg/storage/mysqlstore/applies.go
@@ -624,6 +624,18 @@ func (s *applyStore) GetByLock(ctx context.Context, lockID int64) ([]*storage.Ap
 
 // Update updates apply state and fields.
 func (s *applyStore) Update(ctx context.Context, apply *storage.Apply) error {
+	// A drive that holds only an operation lease must never write the parent
+	// applies row directly: under fan-out the parent state is owned solely by
+	// the rollout projection (UpdateDerivedState). A single-operation drive
+	// still carries the parent apply lease alongside the operation lease, so it
+	// keeps the direct-write path; only an operation-lease-only context is
+	// refused here.
+	if _, hasOpLease := storage.OperationLeaseFromContext(ctx); hasOpLease {
+		if _, hasApplyLease := storage.ApplyLeaseFromContext(ctx); !hasApplyLease {
+			return fmt.Errorf("operation lease does not authorize a direct update of apply %d; parent state is owned by the rollout projection: %w", apply.ID, storage.ErrApplyLeaseLost)
+		}
+	}
+
 	lease, hasLease, err := applyLeaseFromContext(ctx, apply.ID)
 	if err != nil {
 		return err
@@ -700,30 +712,100 @@ func (s *applyStore) Update(ctx context.Context, apply *storage.Apply) error {
 	return nil
 }
 
+// derivedStateGuard is the lease authorization for a rollout-projection write.
+// predicate is appended to the CAS UPDATE's WHERE clause and predicateArgs holds
+// its bind values; ensureStillOwned re-checks ownership on a zero-rows result so
+// the caller can fail closed on a lost lease (nil for an unguarded write).
+type derivedStateGuard struct {
+	predicate        string
+	predicateArgs    []any
+	ensureStillOwned func(ctx context.Context, db queryRower) error
+}
+
+// derivedStateGuardForContext selects how a UpdateDerivedState write is
+// authorized. An operation lease takes precedence over the parent apply lease,
+// mirroring taskStore.Update: a multi-operation drive advances the parent only
+// through the projection, scoped to an operation that still holds its token and
+// belongs to applyID. The apply-lease path keeps the single-operation behavior.
+func derivedStateGuardForContext(ctx context.Context, applyID int64) (derivedStateGuard, error) {
+	if opLease, ok := storage.OperationLeaseFromContext(ctx); ok {
+		if !opLease.Valid() {
+			return derivedStateGuard{}, fmt.Errorf("invalid operation lease for apply %d: %w", applyID, storage.ErrApplyLeaseLost)
+		}
+		if opLease.ApplyID != applyID {
+			return derivedStateGuard{}, fmt.Errorf("operation lease for apply %d cannot write derived state for apply %d: %w", opLease.ApplyID, applyID, storage.ErrApplyLeaseLost)
+		}
+		return derivedStateGuard{
+			predicate: ` AND EXISTS (
+				SELECT 1 FROM apply_operations ao
+				WHERE ao.id = ? AND ao.apply_id = ? AND ao.lease_token = ?
+			)`,
+			predicateArgs: []any{opLease.OperationID, applyID, opLease.Token},
+			ensureStillOwned: func(ctx context.Context, db queryRower) error {
+				return ensureOperationLeaseOwnsApply(ctx, db, opLease, applyID)
+			},
+		}, nil
+	}
+
+	lease, hasLease, err := applyLeaseFromContext(ctx, applyID)
+	if err != nil {
+		return derivedStateGuard{}, err
+	}
+	if hasLease {
+		return derivedStateGuard{
+			predicate:     " AND lease_token = ?",
+			predicateArgs: []any{lease.Token},
+			ensureStillOwned: func(ctx context.Context, db queryRower) error {
+				return ensureApplyLeaseStillOwned(ctx, db, lease)
+			},
+		}, nil
+	}
+
+	return derivedStateGuard{}, nil
+}
+
+// ensureOperationLeaseOwnsApply returns ErrApplyLeaseLost unless the operation
+// row still holds the lease's token and still belongs to applyID, so a CAS that
+// missed because the operation was reassigned (or rebound to another apply)
+// fails closed instead of being read as a benign miss.
+func ensureOperationLeaseOwnsApply(ctx context.Context, db queryRower, lease storage.OperationLease, applyID int64) error {
+	var match int
+	err := db.QueryRowContext(ctx, `
+		SELECT 1
+		FROM apply_operations
+		WHERE id = ? AND apply_id = ? AND lease_token = ?
+	`, lease.OperationID, applyID, lease.Token).Scan(&match)
+	if errors.Is(err, sql.ErrNoRows) {
+		return fmt.Errorf("operation lease for apply_operation %d (apply %d) is no longer current: %w", lease.OperationID, applyID, storage.ErrApplyLeaseLost)
+	}
+	if err != nil {
+		return fmt.Errorf("verify operation lease for apply_operation %d (apply %d): %w", lease.OperationID, applyID, err)
+	}
+	return nil
+}
+
 // UpdateDerivedState compare-and-swaps the rollout-projected applies.state.
 // It writes only the fields owned by the projection and only when the row still
 // holds expectedState, so a stale projection cannot clobber a newer state a
 // sibling drive already wrote. A lost lease fails closed with an error; a CAS
 // miss (state no longer matches) returns swapped=false so the caller can skip
 // side-effects and reconcile on the next poll.
-func (s *applyStore) UpdateDerivedState(ctx context.Context, applyID int64, expectedState, newState, errorMessage string, completedAt *time.Time) (bool, error) {
-	lease, hasLease, err := applyLeaseFromContext(ctx, applyID)
+func (s *applyStore) UpdateDerivedState(ctx context.Context, applyID int64, expectedState, newState, errorMessage string, startedAt, completedAt *time.Time) (bool, error) {
+	guard, err := derivedStateGuardForContext(ctx, applyID)
 	if err != nil {
 		return false, err
 	}
 
-	args := []any{newState, errorMessage, completedAt, applyID, expectedState}
-	leasePredicate := ""
-	if hasLease {
-		leasePredicate = " AND lease_token = ?"
-		args = append(args, lease.Token)
-	}
+	// started_at is stamped only when it is still NULL so the projection can move
+	// the parent into an active state without ever rewinding a recorded start.
+	args := []any{newState, errorMessage, startedAt, completedAt, applyID, expectedState}
+	args = append(args, guard.predicateArgs...)
 
 	result, err := s.db.ExecContext(ctx, fmt.Sprintf(`
 		UPDATE applies
-		SET state = ?, error_message = ?, completed_at = ?, updated_at = NOW()
+		SET state = ?, error_message = ?, started_at = COALESCE(started_at, ?), completed_at = ?, updated_at = NOW()
 		WHERE id = ? AND state = ?%s
-	`, leasePredicate), args...)
+	`, guard.predicate), args...)
 	if err != nil {
 		return false, fmt.Errorf("compare-and-swap derived apply state for apply %d (%q -> %q): %w", applyID, expectedState, newState, err)
 	}
@@ -738,8 +820,8 @@ func (s *applyStore) UpdateDerivedState(ctx context.Context, applyID int64, expe
 	// Zero rows. A leased caller must distinguish a lost lease (fail closed) from
 	// a benign CAS outcome: the former is an ownership change the caller must
 	// surface, the latter is reconciled on the next poll.
-	if hasLease {
-		if err := ensureApplyLeaseStillOwned(ctx, s.db, lease); err != nil {
+	if guard.ensureStillOwned != nil {
+		if err := guard.ensureStillOwned(ctx, s.db); err != nil {
 			return false, err
 		}
 	}

--- a/pkg/storage/mysqlstore/applies_test.go
+++ b/pkg/storage/mysqlstore/applies_test.go
@@ -1092,6 +1092,19 @@ func TestApplyStore_UpdateDerivedStateOperationLeaseGuard(t *testing.T) {
 	precPersisted, err := store.Applies().Get(ctx, precApply.ID)
 	require.NoError(t, err)
 	assert.Equal(t, state.Apply.Running, precPersisted.State)
+
+	// A current operation lease whose expected state no longer matches the row is
+	// a benign CAS miss: swapped=false with no error, so a stale projection is
+	// reconciled on the next poll rather than mistaken for a lost lease.
+	missApply := runningApply("apply_op_cas_miss", "staging-miss", 904)
+	missOpID := createApplyOperationForLeaseTest(t, store, missApply.ID, "primary")
+	stampOperationLease(t, missOpID, "worker", "op-token")
+	swapped, err = store.Applies().UpdateDerivedState(opLeaseCtx(missApply.ID, missOpID, "op-token"), missApply.ID, state.Apply.Pending, state.Apply.Failed, "stale projection", nil, nil)
+	require.NoError(t, err, "a state mismatch under a current operation lease must not be reported as a lost lease")
+	assert.False(t, swapped, "the expected state no longer matches, so the swap must miss")
+	missPersisted, err := store.Applies().Get(ctx, missApply.ID)
+	require.NoError(t, err)
+	assert.Equal(t, state.Apply.Running, missPersisted.State, "a CAS miss must not write the projection")
 }
 
 // TestApplyStore_UpdateDerivedStateStampsStartedAt verifies that the projection

--- a/pkg/storage/mysqlstore/applies_test.go
+++ b/pkg/storage/mysqlstore/applies_test.go
@@ -920,7 +920,7 @@ func TestApplyStore_UpdateDerivedState(t *testing.T) {
 
 	// Matching expected state swaps and writes the projected fields.
 	completedAt := time.Now()
-	swapped, err := store.Applies().UpdateDerivedState(ctx, apply.ID, state.Apply.Running, state.Apply.Failed, "deployment failed", &completedAt)
+	swapped, err := store.Applies().UpdateDerivedState(ctx, apply.ID, state.Apply.Running, state.Apply.Failed, "deployment failed", nil, &completedAt)
 	require.NoError(t, err)
 	require.True(t, swapped, "expected state matched, so the swap must land")
 
@@ -932,7 +932,7 @@ func TestApplyStore_UpdateDerivedState(t *testing.T) {
 
 	// A stale expected state misses: the row already moved on, so the write is
 	// skipped and the row is left untouched.
-	swapped, err = store.Applies().UpdateDerivedState(ctx, apply.ID, state.Apply.Running, state.Apply.Completed, "", nil)
+	swapped, err = store.Applies().UpdateDerivedState(ctx, apply.ID, state.Apply.Running, state.Apply.Completed, "", nil, nil)
 	require.NoError(t, err)
 	assert.False(t, swapped, "expected state no longer matches, so the swap must miss")
 
@@ -957,12 +957,12 @@ func TestApplyStore_UpdateDerivedStateNoOpUnderChangedRows(t *testing.T) {
 	// Re-deriving the same running state with no other field change is a no-op
 	// that affects zero rows under changed-rows semantics, but the row still
 	// holds the expected state, so the swap is reported as successful.
-	swapped, err := store.Applies().UpdateDerivedState(ctx, apply.ID, state.Apply.Running, state.Apply.Running, "", nil)
+	swapped, err := store.Applies().UpdateDerivedState(ctx, apply.ID, state.Apply.Running, state.Apply.Running, "", nil, nil)
 	require.NoError(t, err)
 	assert.True(t, swapped, "a no-op write to a row already in the expected state is an idempotent swap, not a miss")
 
 	// A stale expected state still misses even under changed-rows semantics.
-	swapped, err = store.Applies().UpdateDerivedState(ctx, apply.ID, state.Apply.Pending, state.Apply.Pending, "", nil)
+	swapped, err = store.Applies().UpdateDerivedState(ctx, apply.ID, state.Apply.Pending, state.Apply.Pending, "", nil, nil)
 	require.NoError(t, err)
 	assert.False(t, swapped, "the row is not in the expected state, so the swap must miss")
 }
@@ -1010,7 +1010,7 @@ func TestApplyStore_UpdateDerivedStateLeaseGuard(t *testing.T) {
 
 	// A stale lease cannot write, even when the expected state matches.
 	staleCtx := storage.WithApplyLease(ctx, storage.ApplyLease{ApplyID: apply.ID, Owner: "worker-old", Token: "stale-token"})
-	_, err = store.Applies().UpdateDerivedState(staleCtx, apply.ID, expectedState, state.Apply.Failed, "stale", nil)
+	_, err = store.Applies().UpdateDerivedState(staleCtx, apply.ID, expectedState, state.Apply.Failed, "stale", nil, nil)
 	require.ErrorIs(t, err, storage.ErrApplyLeaseLost)
 
 	persisted, err := store.Applies().Get(ctx, apply.ID)
@@ -1019,13 +1019,153 @@ func TestApplyStore_UpdateDerivedStateLeaseGuard(t *testing.T) {
 
 	// The current lease holder's matching swap lands.
 	ownedCtx := storage.WithApplyLease(ctx, claimed.Lease())
-	swapped, err := store.Applies().UpdateDerivedState(ownedCtx, apply.ID, expectedState, state.Apply.Failed, "owned failure", nil)
+	swapped, err := store.Applies().UpdateDerivedState(ownedCtx, apply.ID, expectedState, state.Apply.Failed, "owned failure", nil, nil)
 	require.NoError(t, err)
 	assert.True(t, swapped)
 
 	updated, err := store.Applies().Get(ctx, apply.ID)
 	require.NoError(t, err)
 	assert.Equal(t, state.Apply.Failed, updated.State)
+}
+
+// TestApplyStore_UpdateDerivedStateOperationLeaseGuard verifies that the
+// projection can be authorized by an operation lease (so a multi-operation drive
+// can advance the parent only through the aggregate CAS): the swap lands under a
+// current operation token, fails closed on a stale token or a token bound to a
+// different apply, and the operation lease takes precedence over a current apply
+// lease also on the context.
+func TestApplyStore_UpdateDerivedStateOperationLeaseGuard(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	opLeaseCtx := func(applyID, opID int64, token string) context.Context {
+		return storage.WithOperationLease(ctx, storage.OperationLease{
+			ApplyID: applyID, OperationID: opID, Owner: "worker", Token: token,
+		})
+	}
+
+	// Each running apply needs its own target so the active-apply uniqueness
+	// check does not reject the second one.
+	runningApply := func(identifier, env string, planID int64) *storage.Apply {
+		lock := createTestLock(t, store, "testdb", storage.DatabaseTypeMySQL, env)
+		return createTestApplyWithStateAndEnv(t, store, lock, identifier, planID, state.Apply.Running, env)
+	}
+
+	// A current operation lease authorizes the projection swap.
+	apply := runningApply("apply_op_cas_ok", "staging-ok", 900)
+	opID := createApplyOperationForLeaseTest(t, store, apply.ID, "primary")
+	stampOperationLease(t, opID, "worker", "op-token")
+	swapped, err := store.Applies().UpdateDerivedState(opLeaseCtx(apply.ID, opID, "op-token"), apply.ID, state.Apply.Running, state.Apply.Failed, "op failure", nil, nil)
+	require.NoError(t, err)
+	require.True(t, swapped, "a current operation lease must authorize the projection swap")
+	updated, err := store.Applies().Get(ctx, apply.ID)
+	require.NoError(t, err)
+	assert.Equal(t, state.Apply.Failed, updated.State)
+
+	// A stale operation token fails closed even when the expected state matches.
+	staleApply := runningApply("apply_op_cas_stale", "staging-stale", 901)
+	staleOpID := createApplyOperationForLeaseTest(t, store, staleApply.ID, "primary")
+	stampOperationLease(t, staleOpID, "worker", "op-token")
+	_, err = store.Applies().UpdateDerivedState(opLeaseCtx(staleApply.ID, staleOpID, "stale-op-token"), staleApply.ID, state.Apply.Running, state.Apply.Failed, "stale", nil, nil)
+	require.ErrorIs(t, err, storage.ErrApplyLeaseLost)
+	persisted, err := store.Applies().Get(ctx, staleApply.ID)
+	require.NoError(t, err)
+	assert.Equal(t, state.Apply.Running, persisted.State, "a lost operation lease must not write the projection")
+
+	// An operation lease bound to a different apply cannot write the target.
+	_, err = store.Applies().UpdateDerivedState(opLeaseCtx(apply.ID, opID, "op-token"), staleApply.ID, state.Apply.Running, state.Apply.Failed, "cross", nil, nil)
+	require.ErrorIs(t, err, storage.ErrApplyLeaseLost)
+
+	// Operation lease takes precedence: a stale operation token fails closed even
+	// with a current apply lease also on the context.
+	precApply := runningApply("apply_op_cas_prec", "staging-prec", 903)
+	precOpID := createApplyOperationForLeaseTest(t, store, precApply.ID, "primary")
+	stampOperationLease(t, precOpID, "worker", "op-token")
+	_, err = testDB.ExecContext(ctx, `UPDATE applies SET lease_owner=?, lease_token=?, lease_acquired_at=NOW() WHERE id=?`, "current-worker", "apply-token", precApply.ID)
+	require.NoError(t, err)
+	bothCtx := storage.WithApplyLease(opLeaseCtx(precApply.ID, precOpID, "stale-op-token"), storage.ApplyLease{
+		ApplyID: precApply.ID, Owner: "current-worker", Token: "apply-token",
+	})
+	_, err = store.Applies().UpdateDerivedState(bothCtx, precApply.ID, state.Apply.Running, state.Apply.Failed, "prec", nil, nil)
+	require.ErrorIs(t, err, storage.ErrApplyLeaseLost)
+	precPersisted, err := store.Applies().Get(ctx, precApply.ID)
+	require.NoError(t, err)
+	assert.Equal(t, state.Apply.Running, precPersisted.State)
+}
+
+// TestApplyStore_UpdateDerivedStateStampsStartedAt verifies that the projection
+// stamps started_at when it is still NULL (so it can move the parent into an
+// active state) but never rewinds a start time a drive already recorded.
+func TestApplyStore_UpdateDerivedStateStampsStartedAt(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", storage.DatabaseTypeMySQL, "staging")
+	apply := createTestApplyWithStateAndEnv(t, store, lock, "apply_started_stamp", 905, state.Apply.Running, "staging")
+
+	initial, err := store.Applies().Get(ctx, apply.ID)
+	require.NoError(t, err)
+	require.Nil(t, initial.StartedAt, "a freshly created apply has no recorded start time")
+
+	// A same-state projection stamps started_at while it is still NULL.
+	startedAt := time.Now().Truncate(time.Second)
+	swapped, err := store.Applies().UpdateDerivedState(ctx, apply.ID, state.Apply.Running, state.Apply.Running, "", &startedAt, nil)
+	require.NoError(t, err)
+	require.True(t, swapped)
+	stamped, err := store.Applies().Get(ctx, apply.ID)
+	require.NoError(t, err)
+	require.NotNil(t, stamped.StartedAt)
+	assert.WithinDuration(t, startedAt, *stamped.StartedAt, time.Second)
+
+	// A later projection must not rewind the recorded start time.
+	later := startedAt.Add(time.Hour)
+	swapped, err = store.Applies().UpdateDerivedState(ctx, apply.ID, state.Apply.Running, state.Apply.Running, "", &later, nil)
+	require.NoError(t, err)
+	require.True(t, swapped)
+	preserved, err := store.Applies().Get(ctx, apply.ID)
+	require.NoError(t, err)
+	require.NotNil(t, preserved.StartedAt)
+	assert.WithinDuration(t, startedAt, *preserved.StartedAt, time.Second, "started_at must be preserved, not rewound")
+}
+
+// TestApplyStore_UpdateRejectsOperationLeaseOnlyContext verifies that a drive
+// holding only an operation lease cannot write the parent applies row directly:
+// the parent is owned by the projection. A single-operation drive carries the
+// parent apply lease alongside the operation lease, so its direct write still
+// lands.
+func TestApplyStore_UpdateRejectsOperationLeaseOnlyContext(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", storage.DatabaseTypeMySQL, "staging")
+	apply := createTestApplyWithStateAndEnv(t, store, lock, "apply_update_oplease", 906, state.Apply.Running, "staging")
+	opID := createApplyOperationForLeaseTest(t, store, apply.ID, "primary")
+	stampOperationLease(t, opID, "worker", "op-token")
+
+	opOnlyCtx := storage.WithOperationLease(ctx, storage.OperationLease{
+		ApplyID: apply.ID, OperationID: opID, Owner: "worker", Token: "op-token",
+	})
+
+	apply.State = state.Apply.Failed
+	apply.ErrorMessage = "direct write attempt"
+	err := store.Applies().Update(opOnlyCtx, apply)
+	require.ErrorIs(t, err, storage.ErrApplyLeaseLost, "an operation-lease-only context must not directly write the parent apply")
+	unchanged, err := store.Applies().Get(ctx, apply.ID)
+	require.NoError(t, err)
+	assert.Equal(t, state.Apply.Running, unchanged.State, "the parent row must be untouched")
+
+	// A single-operation drive carries both leases, so the direct write lands on
+	// the parent-lease path.
+	_, err = testDB.ExecContext(ctx, `UPDATE applies SET lease_owner=?, lease_token=?, lease_acquired_at=NOW() WHERE id=?`, "current-worker", "apply-token", apply.ID)
+	require.NoError(t, err)
+	dualCtx := storage.WithApplyLease(opOnlyCtx, storage.ApplyLease{ApplyID: apply.ID, Owner: "current-worker", Token: "apply-token"})
+	require.NoError(t, store.Applies().Update(dualCtx, apply))
+	written, err := store.Applies().Get(ctx, apply.ID)
+	require.NoError(t, err)
+	assert.Equal(t, state.Apply.Failed, written.State)
 }
 
 func TestApplyStore_GetInProgress(t *testing.T) {

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -231,17 +231,25 @@ type ApplyStore interface {
 	// UpdateDerivedState compare-and-swaps the rollout-projected applies.state.
 	//
 	// It writes only the fields owned by the rollout projection (state,
-	// error_message, completed_at, updated_at) and only when the row still holds
-	// expectedState, so a stale projection computed from an earlier read cannot
-	// clobber a newer state another sibling drive already wrote. If ctx carries
-	// an apply lease the write additionally requires the current lease token.
+	// error_message, started_at, completed_at, updated_at) and only when the row
+	// still holds expectedState, so a stale projection computed from an earlier
+	// read cannot clobber a newer state another sibling drive already wrote.
+	// started_at is stamped only when it is still NULL, so the projection can
+	// move the parent into an active state without ever rewinding a recorded
+	// start time.
+	//
+	// The write is authorized by whichever lease is on the context: an operation
+	// lease (the operation row must still hold its token and belong to applyID)
+	// takes precedence over the parent apply lease, so a multi-operation drive
+	// can advance the parent only through this projection. If neither lease is
+	// present the write is unguarded.
 	//
 	// swapped=false means the row no longer matched expectedState: the caller's
 	// view is stale, so it must skip apply-level side-effects that assume its
 	// write landed and let the next poll reconcile. A lost lease is returned as
 	// an error (ErrApplyLeaseLost), not swapped=false, so leased callers still
 	// fail closed on ownership changes.
-	UpdateDerivedState(ctx context.Context, applyID int64, expectedState, newState, errorMessage string, completedAt *time.Time) (swapped bool, err error)
+	UpdateDerivedState(ctx context.Context, applyID int64, expectedState, newState, errorMessage string, startedAt, completedAt *time.Time) (swapped bool, err error)
 
 	// GetRecent returns the most recent applies across all databases, ordered by creation time desc.
 	// Used by `schemabot status` (no args) to show recent activity.

--- a/pkg/tern/local_apply_grouped.go
+++ b/pkg/tern/local_apply_grouped.go
@@ -791,7 +791,7 @@ func (c *LocalClient) handleAtomicProgressTick(ctx context.Context, eng engine.E
 			}
 		}
 		ensureApplyFailureMessage(apply, tasks)
-		swapped, err := c.storage.Applies().UpdateDerivedState(ctx, apply.ID, expectedState, apply.State, apply.ErrorMessage, apply.CompletedAt)
+		swapped, err := c.storage.Applies().UpdateDerivedState(ctx, apply.ID, expectedState, apply.State, apply.ErrorMessage, apply.StartedAt, apply.CompletedAt)
 		if err != nil {
 			c.logger.Error("failed to update apply state", "apply_id", apply.ApplyIdentifier, "state", apply.State, "error", err)
 		} else if !swapped {
@@ -840,7 +840,7 @@ func (c *LocalClient) handleAtomicProgressTick(ctx context.Context, eng engine.E
 		return true
 	}
 
-	swapped, err := c.storage.Applies().UpdateDerivedState(ctx, apply.ID, expectedState, apply.State, apply.ErrorMessage, apply.CompletedAt)
+	swapped, err := c.storage.Applies().UpdateDerivedState(ctx, apply.ID, expectedState, apply.State, apply.ErrorMessage, apply.StartedAt, apply.CompletedAt)
 	if err != nil {
 		c.logger.Error("failed to update apply state", "apply_id", apply.ApplyIdentifier, "state", apply.State, "error", err)
 	} else if !swapped {

--- a/pkg/tern/local_client.go
+++ b/pkg/tern/local_client.go
@@ -1077,7 +1077,7 @@ func (c *LocalClient) Progress(ctx context.Context, req *ternv1.ProgressRequest)
 							// Compare-and-swap on the just-read state so a stale
 							// projection cannot clobber a newer state a sibling
 							// drive already wrote.
-							swapped, err := c.storage.Applies().UpdateDerivedState(ctx, apply.ID, apply.State, derived, apply.ErrorMessage, apply.CompletedAt)
+							swapped, err := c.storage.Applies().UpdateDerivedState(ctx, apply.ID, apply.State, derived, apply.ErrorMessage, apply.StartedAt, apply.CompletedAt)
 							if err != nil {
 								c.logger.Warn("failed to update apply after progress task state update", "apply_id", apply.ApplyIdentifier, "state", derived, "error", err)
 							} else if !swapped {
@@ -1136,7 +1136,7 @@ func (c *LocalClient) Progress(ctx context.Context, req *ternv1.ProgressRequest)
 							// Compare-and-swap on the just-read state so a stale
 							// projection cannot clobber a newer state a sibling
 							// drive already wrote.
-							swapped, err := c.storage.Applies().UpdateDerivedState(ctx, apply.ID, expectedState, apply.State, apply.ErrorMessage, apply.CompletedAt)
+							swapped, err := c.storage.Applies().UpdateDerivedState(ctx, apply.ID, expectedState, apply.State, apply.ErrorMessage, apply.StartedAt, apply.CompletedAt)
 							switch {
 							case err != nil:
 								c.logger.Warn("failed to update apply from progress poll", "apply_id", apply.ApplyIdentifier, "state", apply.State, "apply_db_id", apply.ID, "error", err)

--- a/pkg/tern/local_client_test.go
+++ b/pkg/tern/local_client_test.go
@@ -60,7 +60,7 @@ func (s *exactProgressApplyStore) Update(_ context.Context, apply *storage.Apply
 	return nil
 }
 
-func (s *exactProgressApplyStore) UpdateDerivedState(_ context.Context, _ int64, expectedState, newState, errorMessage string, completedAt *time.Time) (bool, error) {
+func (s *exactProgressApplyStore) UpdateDerivedState(_ context.Context, _ int64, expectedState, newState, errorMessage string, startedAt, completedAt *time.Time) (bool, error) {
 	if s.err != nil {
 		return false, s.err
 	}
@@ -69,6 +69,9 @@ func (s *exactProgressApplyStore) UpdateDerivedState(_ context.Context, _ int64,
 	}
 	s.apply.State = newState
 	s.apply.ErrorMessage = errorMessage
+	if s.apply.StartedAt == nil {
+		s.apply.StartedAt = startedAt
+	}
 	s.apply.CompletedAt = completedAt
 	return true, nil
 }
@@ -107,7 +110,7 @@ func (s *snapshotApplyStore) Update(_ context.Context, apply *storage.Apply) err
 	return nil
 }
 
-func (s *snapshotApplyStore) UpdateDerivedState(_ context.Context, _ int64, expectedState, newState, errorMessage string, completedAt *time.Time) (bool, error) {
+func (s *snapshotApplyStore) UpdateDerivedState(_ context.Context, _ int64, expectedState, newState, errorMessage string, startedAt, completedAt *time.Time) (bool, error) {
 	if s.err != nil {
 		return false, s.err
 	}
@@ -116,6 +119,9 @@ func (s *snapshotApplyStore) UpdateDerivedState(_ context.Context, _ int64, expe
 	}
 	s.stored.State = newState
 	s.stored.ErrorMessage = errorMessage
+	if s.stored.StartedAt == nil {
+		s.stored.StartedAt = startedAt
+	}
 	s.stored.CompletedAt = completedAt
 	return true, nil
 }


### PR DESCRIPTION
## What

`PR2` refers to this PR.

The rollout-projection compare-and-swap (`Applies().UpdateDerivedState`) can now be authorized by an **operation lease**, not just the parent apply lease:

- An operation-lease holder may CAS the parent `applies.state`, scoped to an operation that still holds its token **and** belongs to the target apply. A lost operation lease fails closed; a benign CAS miss still returns `swapped=false`.
- The CAS now stamps `started_at` via `COALESCE(started_at, ?)` — it sets a start time only while the column is still NULL, so the projection can move the parent into an active state without ever rewinding a recorded start.
- `Applies().Update` now **fails closed** when the context carries only an operation lease — a direct parent write is refused so the parent row is owned solely by the projection.

## Why

Under multi-deployment fan-out one apply owns N operations, each driven under its own operation lease. The parent `applies.state` must then be owned **solely** by the aggregate projection — never by an individual engine drive. This change establishes that ownership boundary in the storage layer.

It stays dormant for single-operation applies: the projection is always called with the apply-lease context today, and the single-op engine drive runs under a dual (operation + apply) lease, so it keeps the existing direct-write path byte-for-byte. The operation-lease-only path is reachable only once multi-op drives adopt it (a later PR).

## Single-op apply — unchanged (byte-for-byte)
```
                         BEFORE PR2  ═══  AFTER PR2  (identical)

  worker claims apply ──▶ holds DUAL lease  { apply-lease + op-lease }
                                  │
                  ┌───────────────┴────────────────┐
                  ▼                                 ▼
        engine drive writes               aggregate projection
        parent directly                   UpdateDerivedState (CAS)
        Applies().Update                  WHERE id=? AND state=?
        (started_at, state)               authorized by apply-lease ✓
        authorized by apply-lease ✓
                  │                                 │
                  └───────────────┬─────────────────┘
                                  ▼
                       parent applies row
                  (one operation == one apply)

  PR2 effect: Update still has the apply-lease → PASSES. No behavior change.
```
## Multi-op apply — what this PR makes safe
```

                BEFORE PR2 (unsafe / not yet built)        AFTER PR2 (armed for PR6 - multi-op operation-only drive mode)

  op A (op-lease)      op B (op-lease)            op A (op-lease)   op B (op-lease)
       │                    │                          │                 │
       ▼                    ▼                          ▼                 ▼
  Applies().Update     Applies().Update          Applies().Update   Applies().Update
  (direct parent)      (direct parent)                 ✗ FAIL            ✗ FAIL
       │                    │                    ErrApplyLeaseLost  ErrApplyLeaseLost
       └────────┬───────────┘                    (op-lease only,    no direct parent
                ▼                                  no apply-lease)    write possible
        parent applies row                              │                 │
   ╳ last-writer-wins / clobber ╳                       └────────┬────────┘
   two drives race the parent state                              ▼
                                                    aggregate projection ONLY
                                                    UpdateDerivedState (CAS)
                                                    WHERE id=? AND state=?
                                                      + EXISTS(apply_operations
                                                          id, apply_id, token)   ◀ op-lease auth
                                                    started_at = COALESCE(...)
                                                              │
                                                              ▼
                                                       parent applies row
                                                  (single owner = the projection)
```
## The three changes

| Change | Effect |
|---|---|
| op-lease authorizes `UpdateDerivedState` CAS | a multi-op drive can advance the parent **only** through the projection — scoped to an op that still holds its token **and** belongs to the apply |
| `started_at = COALESCE(started_at, ?)` | projection can move the parent `pending → running` without ever rewinding a recorded start time |
| `Applies().Update` fails closed on op-only context | a drive holding **only** an op-lease can't write the parent directly → no clobber, no race |
