### PR TITLE
feat(inventory): route serve --grpc through the Etre resolver

### DIFF
--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -371,11 +371,11 @@ type DSNFromConfigPaths struct {
 
 // TargetResolverConfig configures the data-plane connection resolver. Targets
 // is the static target -> connection inventory: the "no inventory service"
-// fallback and per-target overrides. A dynamic backend (e.g. Etre) discovers
-// targets by key and needs no enumeration here, so it will slot in as a sibling
-// field without changing this shape.
+// fallback. Etre is the dynamic backend that discovers targets by key at request
+// time. Each is one pluggable backend behind the same resolver interface.
 type TargetResolverConfig struct {
 	Targets map[string]inventory.StaticTarget `yaml:"targets,omitempty"`
+	Etre    EtreConfig                        `yaml:"etre,omitempty"`
 }
 
 // Configured reports whether the data plane has any static target inventory.
@@ -386,6 +386,45 @@ func (c TargetResolverConfig) Configured() bool {
 // StaticInventory returns the static inventory config for NewStaticResolver.
 func (c TargetResolverConfig) StaticInventory() inventory.StaticConfig {
 	return inventory.StaticConfig{Targets: c.Targets}
+}
+
+// EtreConfig configures the data-plane MySQL resolver backed by Etre: the Etre
+// lookup that maps an opaque target to a cluster endpoint, plus the credentials
+// for the assembled connection. It is the common-path dynamic resolver;
+// additional engines and per-target overrides layer on without reshaping it.
+type EtreConfig struct {
+	// Addr is the Etre server address (supports secret refs, e.g. env:ETRE_ADDR).
+	Addr string `yaml:"addr"`
+	// EntityType is the Etre entity type recording MySQL clusters.
+	EntityType string `yaml:"entity_type"`
+	// TargetLabel is the Etre label the request's opaque target matches.
+	TargetLabel string `yaml:"target_label"`
+	// EnvLabel, when set, scopes the lookup to the request environment.
+	EnvLabel string `yaml:"env_label,omitempty"`
+	// Labels are fixed selector predicates added to every lookup (e.g. a region).
+	Labels map[string]string `yaml:"labels,omitempty"`
+	// HostField is the entity field holding the connection host.
+	HostField string `yaml:"host_field"`
+	// DefaultPort is appended to the host when it has no port.
+	DefaultPort string `yaml:"default_port,omitempty"`
+	// AttributeFields are entity fields surfaced to the credential resolver.
+	AttributeFields []string `yaml:"attribute_fields,omitempty"`
+	// Credentials configures the username and password for the connection.
+	Credentials EtreCredentialsConfig `yaml:"credentials"`
+}
+
+// EtreCredentialsConfig configures credentials for an Etre-resolved target.
+// Credentials never come from Etre: the username is configured and the password
+// is a secret reference (env:, file:, secretsmanager:, or a literal), optionally
+// carrying a {target} placeholder for per-target secret naming.
+type EtreCredentialsConfig struct {
+	Username    string `yaml:"username"`
+	PasswordRef string `yaml:"password_ref"`
+}
+
+// Configured reports whether the data plane should resolve targets through Etre.
+func (c EtreConfig) Configured() bool {
+	return strings.TrimSpace(c.Addr) != ""
 }
 
 // DatabaseConfig holds configuration for a registered database.

--- a/pkg/cmd/commands/serve.go
+++ b/pkg/cmd/commands/serve.go
@@ -22,10 +22,12 @@ import (
 
 	"github.com/block/schemabot/pkg/api"
 	"github.com/block/schemabot/pkg/auth"
+	"github.com/block/schemabot/pkg/etre"
 	ghclient "github.com/block/schemabot/pkg/github"
 	"github.com/block/schemabot/pkg/inventory"
 	"github.com/block/schemabot/pkg/metrics"
 	"github.com/block/schemabot/pkg/mysqlconn"
+	"github.com/block/schemabot/pkg/secrets"
 	"github.com/block/schemabot/pkg/storage"
 	"github.com/block/schemabot/pkg/storage/mysqlstore"
 	"github.com/block/schemabot/pkg/tern"
@@ -296,10 +298,17 @@ func startGRPCServer(ctx context.Context, config *api.ServerConfig, st *mysqlsto
 // Otherwise it falls back to a single LocalClient bound to the one database
 // configured for env.
 func buildGRPCTernClient(config *api.ServerConfig, st *mysqlstore.Storage, logger *slog.Logger, env string) (tern.Client, error) {
-	if config.TargetResolver.Configured() {
-		resolver, err := inventory.NewStaticResolver(config.TargetResolver.StaticInventory())
+	etreConfigured := config.TargetResolver.Etre.Configured()
+	staticConfigured := config.TargetResolver.Configured()
+
+	if etreConfigured && staticConfigured {
+		return nil, fmt.Errorf("target_resolver configures both etre and static targets; per-target overrides are not yet supported — use one")
+	}
+
+	if etreConfigured || staticConfigured {
+		resolver, err := buildTargetResolver(config.TargetResolver, logger)
 		if err != nil {
-			return nil, fmt.Errorf("build static target resolver: %w", err)
+			return nil, err
 		}
 		router, err := tern.NewTargetRouter(tern.TargetRouterConfig{
 			Resolver:           resolver,
@@ -310,7 +319,6 @@ func buildGRPCTernClient(config *api.ServerConfig, st *mysqlstore.Storage, logge
 		if err != nil {
 			return nil, fmt.Errorf("build target router: %w", err)
 		}
-		logger.Info("gRPC server routing by target resolver", "targets", len(config.TargetResolver.Targets))
 		return router, nil
 	}
 
@@ -357,6 +365,70 @@ func buildGRPCTernClient(config *api.ServerConfig, st *mysqlstore.Storage, logge
 	}
 	logger.Info("gRPC server using database", "database", dbName, "environment", env)
 	return client, nil
+}
+
+// buildTargetResolver builds the configured inventory.Resolver — the Etre
+// dynamic backend or the static inventory. The caller guarantees exactly one is
+// configured.
+func buildTargetResolver(cfg api.TargetResolverConfig, logger *slog.Logger) (inventory.Resolver, error) {
+	if cfg.Etre.Configured() {
+		resolver, err := buildEtreResolver(cfg.Etre, logger)
+		if err != nil {
+			return nil, fmt.Errorf("build etre resolver: %w", err)
+		}
+		logger.Info("gRPC server routing by etre resolver",
+			"entity_type", cfg.Etre.EntityType, "target_label", cfg.Etre.TargetLabel)
+		return resolver, nil
+	}
+
+	resolver, err := inventory.NewStaticResolver(cfg.StaticInventory())
+	if err != nil {
+		return nil, fmt.Errorf("build static target resolver: %w", err)
+	}
+	logger.Info("gRPC server routing by static target resolver", "targets", len(cfg.Targets))
+	return resolver, nil
+}
+
+// buildEtreResolver assembles the Etre-backed MySQL resolver from config: the
+// Etre query client, the namespace-free MySQL connection assembler, and the
+// secret-ref credential resolver. Lazily-validated fields (host, password ref)
+// are checked here so a misconfiguration fails at startup, not first request.
+func buildEtreResolver(cfg api.EtreConfig, logger *slog.Logger) (inventory.Resolver, error) {
+	if cfg.HostField == "" {
+		return nil, fmt.Errorf("target_resolver.etre.host_field is required")
+	}
+	if cfg.Credentials.Username == "" {
+		return nil, fmt.Errorf("target_resolver.etre.credentials.username is required")
+	}
+	if cfg.Credentials.PasswordRef == "" {
+		return nil, fmt.Errorf("target_resolver.etre.credentials.password_ref is required")
+	}
+	addr, err := secrets.Resolve(cfg.Addr, "")
+	if err != nil {
+		return nil, fmt.Errorf("resolve target_resolver.etre.addr: %w", err)
+	}
+	// A secret ref (env:/file:/secretsmanager:) can resolve to "" without error;
+	// surface that as a clear config error rather than a generic downstream one.
+	if addr == "" {
+		return nil, fmt.Errorf("target_resolver.etre.addr resolved to an empty value")
+	}
+	client, err := etre.New(etre.Config{Addr: addr, EntityType: cfg.EntityType, Logger: logger})
+	if err != nil {
+		return nil, fmt.Errorf("build etre client: %w", err)
+	}
+	return etre.NewEtreResolver(etre.EtreResolverConfig{
+		Client:          client,
+		TargetLabel:     cfg.TargetLabel,
+		Labels:          cfg.Labels,
+		EnvLabel:        cfg.EnvLabel,
+		HostField:       cfg.HostField,
+		AttributeFields: cfg.AttributeFields,
+		Credentials: inventory.SecretRefCredentialResolver{
+			Username:    cfg.Credentials.Username,
+			PasswordRef: cfg.Credentials.PasswordRef,
+		},
+		Assembler: inventory.MySQLConnectionAssembler{DefaultPort: cfg.DefaultPort},
+	})
 }
 
 // grpcLocalClientFactory returns a LocalClientFactory that applies server-level

--- a/pkg/cmd/commands/serve_grpc_test.go
+++ b/pkg/cmd/commands/serve_grpc_test.go
@@ -37,6 +37,90 @@ func TestBuildGRPCTernClientRoutesWhenTargetResolverConfigured(t *testing.T) {
 	assert.True(t, ok, "expected a TargetRouter when target_resolver is configured")
 }
 
+// When a target_resolver.etre block is configured, the data plane routes
+// through the Etre-backed resolver, resolving each target against Etre per
+// request rather than binding to one database.
+func TestBuildGRPCTernClientRoutesViaEtreResolver(t *testing.T) {
+	logger := slog.New(slog.DiscardHandler)
+	config := &api.ServerConfig{
+		TargetResolver: api.TargetResolverConfig{
+			Etre: api.EtreConfig{
+				Addr:        "https://etre.example",
+				EntityType:  "cluster",
+				TargetLabel: "dsid",
+				HostField:   "writer_endpoint",
+				Credentials: api.EtreCredentialsConfig{Username: "spirit", PasswordRef: "env:DDL_PASSWORD"},
+			},
+		},
+	}
+
+	client, err := buildGRPCTernClient(config, mysqlstore.New(nil), logger, "")
+	require.NoError(t, err)
+	_, ok := client.(*tern.TargetRouter)
+	assert.True(t, ok, "expected a TargetRouter when target_resolver.etre is configured")
+}
+
+// Configuring both the Etre resolver and static targets is ambiguous until
+// per-target overrides exist, so startup fails closed rather than silently
+// picking one.
+func TestBuildGRPCTernClientErrorsWhenEtreAndStaticBothConfigured(t *testing.T) {
+	logger := slog.New(slog.DiscardHandler)
+	config := &api.ServerConfig{
+		TargetResolver: api.TargetResolverConfig{
+			Targets: map[string]inventory.StaticTarget{
+				"dsid-orders-prod": {DatabaseType: storage.DatabaseTypeMySQL, DSN: "root@tcp(localhost:3306)/"},
+			},
+			Etre: api.EtreConfig{
+				Addr: "https://etre.example", EntityType: "cluster", TargetLabel: "dsid",
+				HostField: "writer_endpoint", Credentials: api.EtreCredentialsConfig{Username: "spirit", PasswordRef: "env:DDL_PASSWORD"},
+			},
+		},
+	}
+
+	_, err := buildGRPCTernClient(config, mysqlstore.New(nil), logger, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "both etre and static")
+}
+
+// The Etre resolver's lazily-validated fields are checked at startup so a
+// misconfiguration fails fast instead of on the first request.
+func TestBuildEtreResolverValidatesConfig(t *testing.T) {
+	logger := slog.New(slog.DiscardHandler)
+	base := api.EtreConfig{
+		Addr: "https://etre.example", EntityType: "cluster", TargetLabel: "dsid",
+		HostField: "writer_endpoint", Credentials: api.EtreCredentialsConfig{Username: "spirit", PasswordRef: "env:DDL_PASSWORD"},
+	}
+
+	_, err := buildEtreResolver(base, logger)
+	require.NoError(t, err)
+
+	noHost := base
+	noHost.HostField = ""
+	_, err = buildEtreResolver(noHost, logger)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "host_field")
+
+	noPassword := base
+	noPassword.Credentials.PasswordRef = ""
+	_, err = buildEtreResolver(noPassword, logger)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "password_ref")
+
+	noUsername := base
+	noUsername.Credentials.Username = ""
+	_, err = buildEtreResolver(noUsername, logger)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "username")
+
+	// A secret ref that resolves to empty (e.g. an unset env var) fails closed
+	// with config context rather than a generic downstream error.
+	emptyAddr := base
+	emptyAddr.Addr = "env:UNSET_ETRE_ADDR"
+	_, err = buildEtreResolver(emptyAddr, logger)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "addr resolved to an empty value")
+}
+
 // Without a target resolver the data plane falls back to a single LocalClient
 // bound to the first database configured for the environment, preserving the
 // pre-router single-database serving mode.


### PR DESCRIPTION
## Why this matters

The Etre resolution chain now exists in the codebase — the query client, the engine-agnostic resolver, the MySQL connection assembler, and the credential seam — but a running data plane can't reach it. `serve --grpc` only knows how to build the *static* resolver. This PR wires up the dynamic path, so an operator can actually run the data plane against Etre and have it resolve targets per request.

## What it does

- Adds a `target_resolver.etre` config block: the Etre lookup (`addr`, `entity_type`, `target_label`, optional `env_label` and fixed `labels`, `host_field`, `default_port`, `attribute_fields`) plus `credentials` (`username` + a `password_ref`).
- `serve --grpc` builds the Etre-backed resolver from that config — Etre query client → resolver → MySQL connection assembler → secret-ref credentials — and serves requests through the per-target router. The static-inventory path is unchanged; both now flow through one `buildTargetResolver`.

Concrete config:

```yaml
target_resolver:
  etre:
    addr: env:ETRE_ADDR            # secret ref or literal
    entity_type: aurora_cluster    # Etre entity type recording MySQL clusters
    target_label: dsid             # entity label the request's opaque target matches
    env_label: env                 # optional: scope the lookup to the request environment
    labels:                        # optional fixed selector predicates
      aws_region: us-west-2
    host_field: writer_endpoint    # entity field holding the connection host
    default_port: "3306"
    credentials:
      username: spirit
      password_ref: secretsmanager:schemabot/mysql/{target}/ddl-password
```

A request for target `dsid-orders-prod` (environment `production`) then resolves by querying Etre for `aws_region=us-west-2,dsid=dsid-orders-prod,env=production`, reading `writer_endpoint` off the matched cluster, and assembling a namespace-free MySQL DSN whose password comes from `secretsmanager:schemabot/mysql/dsid-orders-prod/ddl-password`.

```
target_resolver.etre ─► EtreResolver ─► per-request: Etre lookup → MySQL DSN (creds from secret ref)
target_resolver.targets ─► StaticResolver
neither ─► single LocalClient (one database for the environment)
```

Two fail-closed properties:
- **Etre and static targets are mutually exclusive** for now (per-target overrides are a later addition), so configuring both errors at startup rather than silently picking one.
- The resolver's **lazily-validated fields** (`host_field`, `password_ref`) are checked at startup, so a misconfiguration fails fast instead of on the first request.

Credentials come from the secret reference (`env:` / `file:` / `secretsmanager:` / literal, with an optional `{target}` placeholder) — never from Etre. This is usable today for a single shared secret via an env/file reference; a secrets-manager + assume-role credential resolver is a follow-up that plugs into the same seam.

## How it moves us toward the northstar

This makes the dynamic inventory backend a real, runnable capability: the data plane resolves opaque targets against Etre on its own, with no external resolution shim. It's the common-path subset of the full `target_resolver` design — additional engines (a Vitess assembler) and per-target overrides layer on without reshaping this config.

*Opened by Claude (Opus 4.8, 1M context).*