### PR TITLE
feat(auth): enforce read/write access tiers (planning is a write)

### DIFF
--- a/pkg/auth/oidc.go
+++ b/pkg/auth/oidc.go
@@ -23,19 +23,29 @@ type OIDCConfig struct {
 
 	// GroupsClaim is the JWT claim containing group memberships (default: "groups").
 	GroupsClaim string
+
+	// AdminGroups are the groups whose members may call write-tier endpoints.
+	// Sourced from pr_command_authorization.admin_teams; matched against the
+	// token's groups claim by exact string or team slug. When empty, no token
+	// can perform write-tier operations (read-only/visibility still works).
+	AdminGroups []string
 }
 
 // OIDCAuthorizer validates OIDC JWTs on incoming API requests using JWKS
-// discovery to verify token signatures. It authenticates the caller and
-// records their subject and group memberships in the request context.
+// discovery to verify token signatures, then enforces a per-endpoint access
+// tier. Read (visibility) endpoints require only a valid token; write endpoints
+// — which include planning, since a plan stages a change against a database —
+// additionally require membership in a configured admin group. The authenticated
+// caller (subject + groups) is recorded in the request context.
 //
-// It does not yet make tier/role decisions: any request carrying a valid token
-// is allowed, and unauthenticated requests are rejected. Tier and RBAC
-// enforcement (read vs write, admin/operator groups) are layered on top of this
-// authenticator in a follow-up.
+// Write access is gated on the configured admin groups — the direct-API/CLI
+// write path is intentionally for a small privileged set. The CLI path does not
+// honor per-database operator groups; those gate the PR-comment workflow, which
+// is where general users (and per-database teams) make changes.
 type OIDCAuthorizer struct {
 	verifier    *oidc.IDTokenVerifier
 	groupsClaim string
+	adminGroups []string
 	logger      *slog.Logger
 }
 
@@ -70,15 +80,17 @@ func NewOIDCAuthorizer(ctx context.Context, cfg OIDCConfig, logger *slog.Logger)
 	return &OIDCAuthorizer{
 		verifier:    provider.Verifier(verifierConfig),
 		groupsClaim: groupsClaim,
+		adminGroups: cfg.AdminGroups,
 		logger:      logger,
 	}, nil
 }
 
-// Middleware validates the Bearer token on API requests and records the
-// authenticated user in the request context. Non-API paths that authenticate
-// themselves (webhooks via HMAC) or are unauthenticated infrastructure
-// endpoints (health, metrics) bypass validation. Any request with a valid token
-// is allowed through; tier/RBAC enforcement is added on top of this seam.
+// Middleware validates the Bearer token on API requests, enforces the
+// endpoint's access tier, and records the authenticated user in the request
+// context. Non-API paths that authenticate themselves (webhooks via HMAC) or
+// are unauthenticated infrastructure endpoints (health, metrics) bypass
+// validation. A valid token clears the read tier; the write tier (which
+// includes planning) additionally requires membership in a configured admin group.
 func (a *OIDCAuthorizer) Middleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if skipAuth(r.URL.Path) {
@@ -86,16 +98,34 @@ func (a *OIDCAuthorizer) Middleware(next http.Handler) http.Handler {
 			return
 		}
 
+		tier := tierForRequest(r.Method, r.URL.Path)
+
 		user, err := a.authenticate(r.Context(), r)
 		if err != nil {
 			a.logger.Warn("authentication failed", "path", r.URL.Path, "error", err)
+			authDecision(r, tier, "deny", "unauthenticated")
 			writeAuthError(w, http.StatusUnauthorized, "invalid or missing authentication token")
 			return
 		}
 
+		if tier == TierWrite && !a.isAdmin(user.Groups) {
+			a.logger.Warn("authorization denied for write operation",
+				"path", r.URL.Path, "subject", user.Subject)
+			authDecision(r, tier, "deny", "not_admin")
+			writeAuthError(w, http.StatusForbidden, "this operation requires membership in an admin group")
+			return
+		}
+
+		authDecision(r, tier, "allow", "")
 		ctx := WithUser(r.Context(), user)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
+}
+
+// isAdmin reports whether any of the caller's groups matches a configured admin
+// group (by exact string or team slug).
+func (a *OIDCAuthorizer) isAdmin(groups []string) bool {
+	return matchesAnyGroup(groups, a.adminGroups)
 }
 
 // authenticate extracts the Bearer token from the Authorization header, verifies

--- a/pkg/auth/oidc_test.go
+++ b/pkg/auth/oidc_test.go
@@ -144,23 +144,77 @@ func TestOIDCAuthorizerValidTokenAllowed(t *testing.T) {
 	assert.Equal(t, []string{"a", "b"}, captured.Groups)
 }
 
-// A valid token grants access to write-method API endpoints too: tier/RBAC
-// gating is not part of this authenticator yet.
-func TestOIDCAuthorizerValidTokenAllowedForWriteMethods(t *testing.T) {
+// Read/visibility endpoints (incl. pull) are allowed for any valid token,
+// regardless of group membership.
+func TestOIDCAuthorizerReadAllowedForAnyValidToken(t *testing.T) {
 	p := newTestOIDCProvider(t)
-	authz := newAuthorizer(t, p, auth.OIDCConfig{Audience: "schemabot"})
-	token := p.issueToken(t, "user@example.com", "schemabot", "groups", nil, time.Now().Add(time.Hour))
+	authz := newAuthorizer(t, p, auth.OIDCConfig{Audience: "schemabot", AdminGroups: []string{"octocat/schema-admins"}})
+	token := p.issueToken(t, "user@example.com", "schemabot", "groups", []string{"other-team"}, time.Now().Add(time.Hour))
 
-	var ran bool
-	handler := authz.Middleware(okHandler(&ran, nil))
+	for _, tc := range []struct {
+		name, method, path string
+	}{
+		{"status", http.MethodGet, "/api/status"},
+		{"logs", http.MethodGet, "/api/logs/coffee"},
+		{"pull (read live schema)", http.MethodPost, "/api/pull"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var ran bool
+			handler := authz.Middleware(okHandler(&ran, nil))
+			req := httptest.NewRequestWithContext(t.Context(), tc.method, tc.path, nil)
+			req.Header.Set("Authorization", "Bearer "+token)
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
 
-	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/apply", nil)
-	req.Header.Set("Authorization", "Bearer "+token)
-	rec := httptest.NewRecorder()
-	handler.ServeHTTP(rec, req)
+			assert.Equal(t, http.StatusOK, rec.Code)
+			assert.True(t, ran)
+		})
+	}
+}
 
-	assert.Equal(t, http.StatusOK, rec.Code)
-	assert.True(t, ran)
+// Write-tier endpoints — which include plan, since planning stages a change —
+// require an admin group; a valid non-admin token is 403.
+func TestOIDCAuthorizerWriteDeniedWithoutAdminGroup(t *testing.T) {
+	p := newTestOIDCProvider(t)
+	authz := newAuthorizer(t, p, auth.OIDCConfig{Audience: "schemabot", AdminGroups: []string{"octocat/schema-admins"}})
+	token := p.issueToken(t, "bob@example.com", "schemabot", "groups", []string{"engineers"}, time.Now().Add(time.Hour))
+
+	for _, path := range []string{"/api/plan", "/api/apply"} {
+		t.Run(path, func(t *testing.T) {
+			var ran bool
+			handler := authz.Middleware(okHandler(&ran, nil))
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, path, nil)
+			req.Header.Set("Authorization", "Bearer "+token)
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+
+			assert.Equal(t, http.StatusForbidden, rec.Code)
+			assert.False(t, ran)
+		})
+	}
+}
+
+// An admin-group member clears the write tier (plan and apply). The token
+// carries the bare slug "schema-admins"; the config lists "octocat/schema-admins"
+// — slug match.
+func TestOIDCAuthorizerWriteAllowedForAdminGroup(t *testing.T) {
+	p := newTestOIDCProvider(t)
+	authz := newAuthorizer(t, p, auth.OIDCConfig{Audience: "schemabot", AdminGroups: []string{"octocat/schema-admins"}})
+	token := p.issueToken(t, "alice@example.com", "schemabot", "groups", []string{"schema-admins"}, time.Now().Add(time.Hour))
+
+	for _, path := range []string{"/api/plan", "/api/apply"} {
+		t.Run(path, func(t *testing.T) {
+			var ran bool
+			handler := authz.Middleware(okHandler(&ran, nil))
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, path, nil)
+			req.Header.Set("Authorization", "Bearer "+token)
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+
+			assert.Equal(t, http.StatusOK, rec.Code)
+			assert.True(t, ran)
+		})
+	}
 }
 
 func TestOIDCAuthorizerMissingTokenRejected(t *testing.T) {

--- a/pkg/auth/tiers.go
+++ b/pkg/auth/tiers.go
@@ -1,0 +1,104 @@
+package auth
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/block/schemabot/pkg/metrics"
+)
+
+// Tier is the access level an API endpoint requires.
+type Tier int
+
+const (
+	// TierRead is read-only / visibility access: status, progress, logs, locks
+	// list, history, and reading live schema (pull). Any valid token may use it.
+	TierRead Tier = iota
+	// TierWrite covers everything that stages or makes a change: plan, apply,
+	// cutover, control operations, locks, and settings. It requires membership
+	// in a configured admin group — the CLI/direct-API write path is for a small
+	// privileged set; general users go through the PR-comment workflow instead.
+	// Planning is included deliberately — running a plan stages a change against
+	// a specific database and reads its live schema, so it belongs to the change
+	// workflow, not open read access. Viewing existing plan results and reading a
+	// schema (pull) stay in TierRead.
+	TierWrite
+)
+
+func (t Tier) String() string {
+	switch t {
+	case TierRead:
+		return "read"
+	case TierWrite:
+		return "write"
+	default:
+		return "unknown"
+	}
+}
+
+// readPaths are non-GET endpoints that are nonetheless read-only — they expose
+// information without staging a change. `pull` exports a database's live schema
+// for visibility; it is not a step toward modifying anything.
+var readPaths = map[string]bool{
+	"/api/pull": true,
+}
+
+// tierForRequest classifies an API request into the access tier it requires.
+// GET/HEAD requests and the explicit read-only endpoints are read; everything
+// else is write, so a newly added mutating-looking endpoint fails closed
+// (requires authorization) until it is classified here.
+func tierForRequest(method, path string) Tier {
+	if readPaths[path] {
+		return TierRead
+	}
+	switch method {
+	case http.MethodGet, http.MethodHead:
+		return TierRead
+	default:
+		return TierWrite
+	}
+}
+
+// teamSlug returns the last path segment of a group/team name. Some identity
+// providers emit a bare group name (e.g. "schema-admins") while configuration
+// names the org-qualified team (e.g. "org/schema-admins"); comparing slugs lets
+// those line up. See groupMatches for how the bridge is bounded.
+func teamSlug(s string) string {
+	if i := strings.LastIndex(s, "/"); i >= 0 {
+		return s[i+1:]
+	}
+	return s
+}
+
+// groupMatches compares one caller group against one configured group. They
+// match on an exact string, or by slug only when at least one side is a bare
+// slug (no "/"). The bare-slug condition is important: it bridges a provider
+// that emits "schema-admins" to a configured "org/schema-admins", without
+// letting "org-a/admins" match "org-b/admins" across organization boundaries.
+func groupMatches(callerGroup, configured string) bool {
+	if callerGroup == configured {
+		return true
+	}
+	if !strings.Contains(callerGroup, "/") || !strings.Contains(configured, "/") {
+		return teamSlug(callerGroup) == teamSlug(configured)
+	}
+	return false
+}
+
+// matchesAnyGroup reports whether any of the caller's groups matches any of the
+// configured groups (see groupMatches).
+func matchesAnyGroup(callerGroups, configured []string) bool {
+	for _, cg := range callerGroups {
+		for _, want := range configured {
+			if groupMatches(cg, want) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// authDecision records an API auth decision metric for the request.
+func authDecision(r *http.Request, tier Tier, decision, reason string) {
+	metrics.RecordAuthDecision(r.Context(), tier.String(), decision, reason)
+}

--- a/pkg/auth/tiers_test.go
+++ b/pkg/auth/tiers_test.go
@@ -1,0 +1,46 @@
+package auth
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTierForRequest(t *testing.T) {
+	cases := []struct {
+		method, path string
+		want         Tier
+	}{
+		{http.MethodGet, "/api/status", TierRead},
+		{http.MethodGet, "/api/logs/coffee", TierRead},
+		{http.MethodGet, "/api/locks", TierRead},
+		{http.MethodGet, "/api/settings", TierRead},
+		{http.MethodPost, "/api/pull", TierRead},  // reading live schema is visibility, not a change
+		{http.MethodPost, "/api/plan", TierWrite}, // planning stages a change
+		{http.MethodPost, "/api/rollback/plan", TierWrite},
+		{http.MethodPost, "/api/apply", TierWrite},
+		{http.MethodPost, "/api/cutover", TierWrite},
+		{http.MethodPost, "/api/settings", TierWrite},
+		{http.MethodDelete, "/api/locks", TierWrite},
+	}
+	for _, c := range cases {
+		assert.Equalf(t, c.want, tierForRequest(c.method, c.path), "%s %s", c.method, c.path)
+	}
+}
+
+func TestMatchesAnyGroup(t *testing.T) {
+	admin := []string{"octocat/schema-admins"}
+
+	assert.True(t, matchesAnyGroup([]string{"schema-admins"}, admin), "bare slug should match org/slug")
+	assert.True(t, matchesAnyGroup([]string{"octocat/schema-admins"}, admin), "exact match")
+	assert.True(t, matchesAnyGroup([]string{"x", "schema-admins"}, admin), "any caller group matches")
+	assert.False(t, matchesAnyGroup([]string{"other-team"}, admin))
+	assert.False(t, matchesAnyGroup(nil, admin))
+	assert.False(t, matchesAnyGroup([]string{"schema-admins"}, nil), "no admin groups configured")
+
+	// Slug matching must not cross organization boundaries: two org-qualified
+	// names with the same slug only match on an exact string.
+	assert.False(t, matchesAnyGroup([]string{"other-org/schema-admins"}, admin),
+		"same slug under a different org must not match")
+}

--- a/pkg/cmd/commands/serve.go
+++ b/pkg/cmd/commands/serve.go
@@ -211,7 +211,7 @@ func (cmd *ServeCmd) Run(g *Globals) error {
 	// allow-all NoneAuthorizer that lets every request through (attaching an
 	// anonymous user); with "oidc" it validates Bearer JWTs and bypasses
 	// non-API paths (/webhook, /metrics, health) itself.
-	authz, err := buildAuthorizer(ctx, serverConfig.Auth, logger)
+	authz, err := buildAuthorizer(ctx, serverConfig.Auth, serverConfig.PRCommandAuthorization.AdminTeams, logger)
 	if err != nil {
 		return fmt.Errorf("setup auth: %w", err)
 	}
@@ -661,20 +661,24 @@ func getEnv(key, defaultValue string) string {
 // in context); "oidc" validates Bearer JWTs against the issuer's JWKS. Unknown
 // types are rejected so a misconfigured auth type fails closed at startup
 // rather than silently disabling auth.
-func buildAuthorizer(ctx context.Context, cfg api.AuthConfig, logger *slog.Logger) (auth.Authorizer, error) {
+func buildAuthorizer(ctx context.Context, cfg api.AuthConfig, adminGroups []string, logger *slog.Logger) (auth.Authorizer, error) {
 	switch cfg.Type {
 	case "", "none":
 		logger.Info("API authentication disabled — all requests allowed")
 		return auth.NoneAuthorizer{}, nil
 	case "oidc":
-		logger.Info("initializing OIDC authentication", "issuer", cfg.Issuer)
+		logger.Info("initializing OIDC authentication", "issuer", cfg.Issuer, "admin_groups", len(adminGroups))
 		authz, err := auth.NewOIDCAuthorizer(ctx, auth.OIDCConfig{
 			Issuer:      cfg.Issuer,
 			Audience:    cfg.Audience,
 			GroupsClaim: cfg.GroupsClaim,
+			AdminGroups: adminGroups,
 		}, logger)
 		if err != nil {
 			return nil, err
+		}
+		if len(adminGroups) == 0 {
+			logger.Warn("OIDC authentication enabled with no admin groups configured: all write operations will be denied (read and plan still work). Set pr_command_authorization.admin_teams to allow writes.")
 		}
 		logger.Info("OIDC authentication enabled", "issuer", cfg.Issuer)
 		return authz, nil

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -406,6 +406,28 @@ func RecordPRCommandActorAuthorization(ctx context.Context, command, database, e
 	)
 }
 
+// RecordAuthDecision increments the counter for API auth decisions on the
+// direct (OIDC) request path. Labels are inherently low-cardinality: tier is
+// read/plan/write, decision is allow/deny, reason is a fixed set.
+func RecordAuthDecision(ctx context.Context, tier, decision, reason string) {
+	meter := otel.Meter(meterName)
+	counter, err := meter.Int64Counter("schemabot.auth_decisions.total",
+		otelmetric.WithDescription("Total API auth decisions on the OIDC request path"),
+		otelmetric.WithUnit("{decision}"),
+	)
+	if err != nil {
+		slog.Warn("failed to create auth decisions counter", "error", err)
+		return
+	}
+	counter.Add(ctx, 1,
+		otelmetric.WithAttributes(
+			attribute.String("tier", tier),
+			attribute.String("decision", decision),
+			attribute.String("reason", reason),
+		),
+	)
+}
+
 // knownCheckOwnershipOperations limits metric cardinality to expected check
 // ownership miss paths.
 var knownCheckOwnershipOperations = map[string]bool{


### PR DESCRIPTION
## Why this matters
#357 taught the API to check *who* you are. This PR adds *what you're allowed to do*.

The rule is simple: **anyone with a valid login can look; only admins can change anything.**

One subtlety worth stating up front: **running a `plan` counts as changing, not looking** — it stages a diff against a real database and reads its live schema. So `plan` is admin-gated alongside `apply`. If you just want to see what's there, `pull` and the read endpoints already cover you, no plan needed.

## What it does
- Classifies each API request as **read** or **write**.
  - **read** (any valid token): status, progress, logs, history, locks list, and `pull` (read a live schema).
  - **write** (requires an admin group): **plan**, rollback-plan, apply, cutover, stop/start/volume/revert, locks acquire/release, settings.
- The OIDC authorizer enforces it: read passes for any valid token; write requires the caller's groups to include a configured admin group. Non-admin valid token → `403`; no/invalid token → `401`.
- Admin groups come from the existing `pr_command_authorization.admin_teams`, matched against the token's groups claim by exact string or **team slug** (so a token group `schema-admins` matches a configured `org/schema-admins`).
- Unclassified routes default to **write** (fail closed).
- Adds a `schemabot.auth_decisions.total` metric (tier / decision / reason), and a startup warning if `oidc` is enabled with no admin groups (writes would be impossible).

## Scope
- **The direct/CLI write tier is for a small privileged set, by design.** It gates on the configured `admin_teams`. The CLI is privileged break-glass; general users (and per-database teams) make changes through the PR-comment workflow, not the direct API. The CLI path intentionally does **not** consult per-database operator groups — those gate the PR-comment path — so no per-target authorization is needed here.
- **Off by default.** With `auth.type: none` (the default, allow-all), nothing changes. Tiers are only enforced under `auth.type: oidc`.

## Tests
Read (incl. pull) allowed for any valid token; write (plan + apply) denied (403) for a valid non-admin and allowed for an admin-group member (incl. the bare-slug ↔ `org/slug` match); plus a unit test pinning the classification (pull→read, plan→write) and group matching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)