### PR TITLE
feat(inventory): select the etre credential backend by type

### DIFF
--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -420,12 +420,29 @@ type EtreConfig struct {
 }
 
 // EtreCredentialsConfig configures credentials for an Etre-resolved target.
-// Credentials never come from Etre: the username is configured and the password
-// is a secret reference (env:, file:, secretsmanager:, or a literal), optionally
-// carrying a {target} placeholder for per-target secret naming.
+// Credentials never come from Etre. Type selects the backend; each backend is
+// one pluggable implementation behind the same resolver interface, so the data
+// plane is not coupled to any single secret store.
 type EtreCredentialsConfig struct {
-	Username    string `yaml:"username"`
-	PasswordRef string `yaml:"password_ref"`
+	// Type selects the credential backend: "secret_ref" (default) or "awssm".
+	Type string `yaml:"type,omitempty"`
+
+	// secret_ref backend: a configured username plus a password secret reference
+	// (env:, file:, secretsmanager:, or a literal), optionally carrying a
+	// {target} placeholder for per-target secret naming.
+	Username    string `yaml:"username,omitempty"`
+	PasswordRef string `yaml:"password_ref,omitempty"`
+
+	// awssm backend: assume a per-target IAM role and read a JSON
+	// {username, password} secret from AWS Secrets Manager. RoleARN may carry an
+	// {account} placeholder and SecretName a {target} placeholder; ExternalID is
+	// an optional STS external id; AccountAttribute names the entity attribute
+	// holding the target's AWS account id (defaults to aws_account_id).
+	Region           string `yaml:"region,omitempty"`
+	RoleARN          string `yaml:"role_arn,omitempty"`
+	ExternalID       string `yaml:"external_id,omitempty"`
+	SecretName       string `yaml:"secret_name,omitempty"`
+	AccountAttribute string `yaml:"account_attribute,omitempty"`
 }
 
 // Configured reports whether the data plane should resolve targets through Etre.

--- a/pkg/cmd/commands/serve.go
+++ b/pkg/cmd/commands/serve.go
@@ -10,11 +10,13 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"slices"
 	"sort"
 	"strings"
 	"syscall"
 	"time"
 
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/block/spirit/pkg/utils"
 	_ "github.com/go-sql-driver/mysql"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
@@ -22,6 +24,7 @@ import (
 
 	"github.com/block/schemabot/pkg/api"
 	"github.com/block/schemabot/pkg/auth"
+	"github.com/block/schemabot/pkg/awscreds"
 	"github.com/block/schemabot/pkg/etre"
 	ghclient "github.com/block/schemabot/pkg/github"
 	"github.com/block/schemabot/pkg/inventory"
@@ -266,7 +269,7 @@ func (cmd *ServeCmd) Run(g *Globals) error {
 // execution target through a TargetRouter; otherwise it falls back to a single
 // LocalClient bound to the one database configured for TERN_ENVIRONMENT.
 func startGRPCServer(ctx context.Context, config *api.ServerConfig, st *mysqlstore.Storage, logger *slog.Logger, port string) (*grpc.Server, error) {
-	client, err := buildGRPCTernClient(config, st, logger, os.Getenv("TERN_ENVIRONMENT"))
+	client, err := buildGRPCTernClient(ctx, config, st, logger, os.Getenv("TERN_ENVIRONMENT"))
 	if err != nil {
 		return nil, err
 	}
@@ -297,7 +300,7 @@ func startGRPCServer(ctx context.Context, config *api.ServerConfig, st *mysqlsto
 // environment is unused in this mode because each request carries its own.
 // Otherwise it falls back to a single LocalClient bound to the one database
 // configured for env.
-func buildGRPCTernClient(config *api.ServerConfig, st *mysqlstore.Storage, logger *slog.Logger, env string) (tern.Client, error) {
+func buildGRPCTernClient(ctx context.Context, config *api.ServerConfig, st *mysqlstore.Storage, logger *slog.Logger, env string) (tern.Client, error) {
 	etreConfigured := config.TargetResolver.Etre.Configured()
 	staticConfigured := config.TargetResolver.Configured()
 
@@ -306,7 +309,7 @@ func buildGRPCTernClient(config *api.ServerConfig, st *mysqlstore.Storage, logge
 	}
 
 	if etreConfigured || staticConfigured {
-		resolver, err := buildTargetResolver(config.TargetResolver, logger)
+		resolver, err := buildTargetResolver(ctx, config.TargetResolver, logger)
 		if err != nil {
 			return nil, err
 		}
@@ -370,14 +373,15 @@ func buildGRPCTernClient(config *api.ServerConfig, st *mysqlstore.Storage, logge
 // buildTargetResolver builds the configured inventory.Resolver — the Etre
 // dynamic backend or the static inventory. The caller guarantees exactly one is
 // configured.
-func buildTargetResolver(cfg api.TargetResolverConfig, logger *slog.Logger) (inventory.Resolver, error) {
+func buildTargetResolver(ctx context.Context, cfg api.TargetResolverConfig, logger *slog.Logger) (inventory.Resolver, error) {
 	if cfg.Etre.Configured() {
-		resolver, err := buildEtreResolver(cfg.Etre, logger)
+		resolver, err := buildEtreResolver(ctx, cfg.Etre, logger)
 		if err != nil {
 			return nil, fmt.Errorf("build etre resolver: %w", err)
 		}
 		logger.Info("gRPC server routing by etre resolver",
-			"entity_type", cfg.Etre.EntityType, "target_label", cfg.Etre.TargetLabel)
+			"entity_type", cfg.Etre.EntityType, "target_label", cfg.Etre.TargetLabel,
+			"credentials", credentialType(cfg.Etre.Credentials))
 		return resolver, nil
 	}
 
@@ -391,17 +395,15 @@ func buildTargetResolver(cfg api.TargetResolverConfig, logger *slog.Logger) (inv
 
 // buildEtreResolver assembles the Etre-backed MySQL resolver from config: the
 // Etre query client, the namespace-free MySQL connection assembler, and the
-// secret-ref credential resolver. Lazily-validated fields (host, password ref)
+// configured credential resolver. Lazily-validated fields (host, credentials)
 // are checked here so a misconfiguration fails at startup, not first request.
-func buildEtreResolver(cfg api.EtreConfig, logger *slog.Logger) (inventory.Resolver, error) {
+func buildEtreResolver(ctx context.Context, cfg api.EtreConfig, logger *slog.Logger) (inventory.Resolver, error) {
 	if cfg.HostField == "" {
 		return nil, fmt.Errorf("target_resolver.etre.host_field is required")
 	}
-	if cfg.Credentials.Username == "" {
-		return nil, fmt.Errorf("target_resolver.etre.credentials.username is required")
-	}
-	if cfg.Credentials.PasswordRef == "" {
-		return nil, fmt.Errorf("target_resolver.etre.credentials.password_ref is required")
+	creds, err := buildCredentialResolver(ctx, cfg.Credentials)
+	if err != nil {
+		return nil, err
 	}
 	addr, err := secrets.Resolve(cfg.Addr, "")
 	if err != nil {
@@ -422,13 +424,90 @@ func buildEtreResolver(cfg api.EtreConfig, logger *slog.Logger) (inventory.Resol
 		Labels:          cfg.Labels,
 		EnvLabel:        cfg.EnvLabel,
 		HostField:       cfg.HostField,
-		AttributeFields: cfg.AttributeFields,
-		Credentials: inventory.SecretRefCredentialResolver{
-			Username:    cfg.Credentials.Username,
-			PasswordRef: cfg.Credentials.PasswordRef,
-		},
-		Assembler: inventory.MySQLConnectionAssembler{DefaultPort: cfg.DefaultPort},
+		AttributeFields: credentialAttributeFields(cfg),
+		Credentials:     creds,
+		Assembler:       inventory.MySQLConnectionAssembler{DefaultPort: cfg.DefaultPort},
 	})
+}
+
+const (
+	credentialTypeSecretRef = "secret_ref"
+	credentialTypeAWSSM     = "awssm"
+)
+
+// credentialType returns the configured credential backend, defaulting to
+// secret_ref.
+func credentialType(cfg api.EtreCredentialsConfig) string {
+	if cfg.Type == "" {
+		return credentialTypeSecretRef
+	}
+	return cfg.Type
+}
+
+// buildCredentialResolver builds the configured credential backend. Each backend
+// is one inventory.CredentialResolver implementation; the data plane is not
+// coupled to any single secret store.
+func buildCredentialResolver(ctx context.Context, cfg api.EtreCredentialsConfig) (inventory.CredentialResolver, error) {
+	switch credentialType(cfg) {
+	case credentialTypeSecretRef:
+		if cfg.Username == "" {
+			return nil, fmt.Errorf("target_resolver.etre.credentials.username is required")
+		}
+		if cfg.PasswordRef == "" {
+			return nil, fmt.Errorf("target_resolver.etre.credentials.password_ref is required")
+		}
+		return inventory.SecretRefCredentialResolver{Username: cfg.Username, PasswordRef: cfg.PasswordRef}, nil
+
+	case credentialTypeAWSSM:
+		// Validate required fields with config-path context before loading AWS
+		// config, so a misconfiguration fails fast and actionably instead of
+		// after (potentially slow) credential-chain resolution.
+		switch {
+		case cfg.Region == "":
+			return nil, fmt.Errorf("target_resolver.etre.credentials.region is required for the awssm backend")
+		case cfg.RoleARN == "":
+			return nil, fmt.Errorf("target_resolver.etre.credentials.role_arn is required for the awssm backend")
+		case cfg.SecretName == "":
+			return nil, fmt.Errorf("target_resolver.etre.credentials.secret_name is required for the awssm backend")
+		}
+		awsCfg, err := awsconfig.LoadDefaultConfig(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("load AWS config for target_resolver.etre.credentials: %w", err)
+		}
+		resolver, err := awscreds.New(awscreds.Config{
+			AWSConfig:        awsCfg,
+			Region:           cfg.Region,
+			RoleARN:          cfg.RoleARN,
+			ExternalID:       cfg.ExternalID,
+			SecretName:       cfg.SecretName,
+			AccountAttribute: cfg.AccountAttribute,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("build target_resolver.etre.credentials awssm resolver: %w", err)
+		}
+		return resolver, nil
+
+	default:
+		return nil, fmt.Errorf("unknown target_resolver.etre.credentials.type %q (want %q or %q)", cfg.Type, credentialTypeSecretRef, credentialTypeAWSSM)
+	}
+}
+
+// credentialAttributeFields returns the entity attribute fields the resolver
+// must surface, ensuring the assume-role backend's account attribute is included
+// alongside any explicitly configured fields.
+func credentialAttributeFields(cfg api.EtreConfig) []string {
+	fields := cfg.AttributeFields
+	if credentialType(cfg.Credentials) != credentialTypeAWSSM {
+		return fields
+	}
+	accountAttr := cfg.Credentials.AccountAttribute
+	if accountAttr == "" {
+		accountAttr = "aws_account_id"
+	}
+	if slices.Contains(fields, accountAttr) {
+		return fields
+	}
+	return append(append([]string(nil), fields...), accountAttr)
 }
 
 // grpcLocalClientFactory returns a LocalClientFactory that applies server-level

--- a/pkg/cmd/commands/serve_grpc_test.go
+++ b/pkg/cmd/commands/serve_grpc_test.go
@@ -30,7 +30,7 @@ func TestBuildGRPCTernClientRoutesWhenTargetResolverConfigured(t *testing.T) {
 		},
 	}
 
-	client, err := buildGRPCTernClient(config, mysqlstore.New(nil), logger, "production")
+	client, err := buildGRPCTernClient(t.Context(), config, mysqlstore.New(nil), logger, "production")
 	require.NoError(t, err)
 	require.NotNil(t, client)
 	_, ok := client.(*tern.TargetRouter)
@@ -54,10 +54,98 @@ func TestBuildGRPCTernClientRoutesViaEtreResolver(t *testing.T) {
 		},
 	}
 
-	client, err := buildGRPCTernClient(config, mysqlstore.New(nil), logger, "")
+	client, err := buildGRPCTernClient(t.Context(), config, mysqlstore.New(nil), logger, "")
 	require.NoError(t, err)
 	_, ok := client.(*tern.TargetRouter)
 	assert.True(t, ok, "expected a TargetRouter when target_resolver.etre is configured")
+}
+
+// The credential backend is selectable: with credentials.type=awssm the data
+// plane uses the assume-role Secrets Manager resolver instead of a secret ref.
+func TestBuildGRPCTernClientRoutesViaEtreWithAWSSMCredentials(t *testing.T) {
+	logger := slog.New(slog.DiscardHandler)
+	config := &api.ServerConfig{
+		TargetResolver: api.TargetResolverConfig{
+			Etre: api.EtreConfig{
+				Addr:        "https://etre.example",
+				EntityType:  "cluster",
+				TargetLabel: "dsid",
+				HostField:   "writer_endpoint",
+				Credentials: api.EtreCredentialsConfig{
+					Type:       "awssm",
+					Region:     "us-west-2",
+					RoleARN:    "arn:aws:iam::{account}:role/tern-assumed",
+					SecretName: "schemabot/{target}/ddl",
+				},
+			},
+		},
+	}
+
+	client, err := buildGRPCTernClient(t.Context(), config, mysqlstore.New(nil), logger, "")
+	require.NoError(t, err)
+	_, ok := client.(*tern.TargetRouter)
+	assert.True(t, ok, "expected a TargetRouter with awssm credentials")
+}
+
+// An unknown credentials.type fails closed at startup.
+func TestBuildEtreResolverRejectsUnknownCredentialType(t *testing.T) {
+	logger := slog.New(slog.DiscardHandler)
+	cfg := api.EtreConfig{
+		Addr: "https://etre.example", EntityType: "cluster", TargetLabel: "dsid", HostField: "writer_endpoint",
+		Credentials: api.EtreCredentialsConfig{Type: "vault"},
+	}
+
+	_, err := buildEtreResolver(t.Context(), cfg, logger)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "vault")
+}
+
+// The awssm backend validates its required fields with config-path context at
+// startup, before any AWS work, so a misconfiguration fails fast.
+func TestBuildCredentialResolverAWSSMRequiresFields(t *testing.T) {
+	base := api.EtreCredentialsConfig{
+		Type:       "awssm",
+		Region:     "us-east-1",
+		RoleARN:    "arn:aws:iam::{account}:role/tern-assumed",
+		SecretName: "{target}_ddl_password",
+	}
+
+	_, err := buildCredentialResolver(t.Context(), base)
+	require.NoError(t, err)
+
+	cases := map[string]func(*api.EtreCredentialsConfig){
+		"region":      func(c *api.EtreCredentialsConfig) { c.Region = "" },
+		"role_arn":    func(c *api.EtreCredentialsConfig) { c.RoleARN = "" },
+		"secret_name": func(c *api.EtreCredentialsConfig) { c.SecretName = "" },
+	}
+	for field, mutate := range cases {
+		cfg := base
+		mutate(&cfg)
+		_, err := buildCredentialResolver(t.Context(), cfg)
+		require.Error(t, err, field)
+		assert.Contains(t, err.Error(), field)
+	}
+}
+
+// The assume-role backend's account attribute is surfaced to the resolver even
+// when not listed in attribute_fields, so credential resolution can read it.
+func TestCredentialAttributeFieldsIncludesAccountAttribute(t *testing.T) {
+	withDefault := api.EtreConfig{
+		AttributeFields: []string{"region"},
+		Credentials:     api.EtreCredentialsConfig{Type: "awssm"},
+	}
+	assert.Equal(t, []string{"region", "aws_account_id"}, credentialAttributeFields(withDefault))
+
+	custom := api.EtreConfig{
+		Credentials: api.EtreCredentialsConfig{Type: "awssm", AccountAttribute: "account"},
+	}
+	assert.Equal(t, []string{"account"}, credentialAttributeFields(custom))
+
+	secretRef := api.EtreConfig{
+		AttributeFields: []string{"region"},
+		Credentials:     api.EtreCredentialsConfig{Type: "secret_ref"},
+	}
+	assert.Equal(t, []string{"region"}, credentialAttributeFields(secretRef))
 }
 
 // Configuring both the Etre resolver and static targets is ambiguous until
@@ -77,7 +165,7 @@ func TestBuildGRPCTernClientErrorsWhenEtreAndStaticBothConfigured(t *testing.T) 
 		},
 	}
 
-	_, err := buildGRPCTernClient(config, mysqlstore.New(nil), logger, "")
+	_, err := buildGRPCTernClient(t.Context(), config, mysqlstore.New(nil), logger, "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "both etre and static")
 }
@@ -91,24 +179,24 @@ func TestBuildEtreResolverValidatesConfig(t *testing.T) {
 		HostField: "writer_endpoint", Credentials: api.EtreCredentialsConfig{Username: "spirit", PasswordRef: "env:DDL_PASSWORD"},
 	}
 
-	_, err := buildEtreResolver(base, logger)
+	_, err := buildEtreResolver(t.Context(), base, logger)
 	require.NoError(t, err)
 
 	noHost := base
 	noHost.HostField = ""
-	_, err = buildEtreResolver(noHost, logger)
+	_, err = buildEtreResolver(t.Context(), noHost, logger)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "host_field")
 
 	noPassword := base
 	noPassword.Credentials.PasswordRef = ""
-	_, err = buildEtreResolver(noPassword, logger)
+	_, err = buildEtreResolver(t.Context(), noPassword, logger)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "password_ref")
 
 	noUsername := base
 	noUsername.Credentials.Username = ""
-	_, err = buildEtreResolver(noUsername, logger)
+	_, err = buildEtreResolver(t.Context(), noUsername, logger)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "username")
 
@@ -116,7 +204,7 @@ func TestBuildEtreResolverValidatesConfig(t *testing.T) {
 	// with config context rather than a generic downstream error.
 	emptyAddr := base
 	emptyAddr.Addr = "env:UNSET_ETRE_ADDR"
-	_, err = buildEtreResolver(emptyAddr, logger)
+	_, err = buildEtreResolver(t.Context(), emptyAddr, logger)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "addr resolved to an empty value")
 }
@@ -137,7 +225,7 @@ func TestBuildGRPCTernClientFallsBackToSingleDatabase(t *testing.T) {
 		},
 	}
 
-	client, err := buildGRPCTernClient(config, mysqlstore.New(nil), logger, "production")
+	client, err := buildGRPCTernClient(t.Context(), config, mysqlstore.New(nil), logger, "production")
 	require.NoError(t, err)
 	require.NotNil(t, client)
 	_, ok := client.(*tern.LocalClient)
@@ -159,7 +247,7 @@ func TestBuildGRPCTernClientRoutesWithoutEnvironment(t *testing.T) {
 		},
 	}
 
-	client, err := buildGRPCTernClient(config, mysqlstore.New(nil), logger, "")
+	client, err := buildGRPCTernClient(t.Context(), config, mysqlstore.New(nil), logger, "")
 	require.NoError(t, err)
 	_, ok := client.(*tern.TargetRouter)
 	assert.True(t, ok, "resolver mode should not require an environment")
@@ -177,7 +265,7 @@ func TestBuildGRPCTernClientErrorsWhenEnvMissingInFallback(t *testing.T) {
 		},
 	}
 
-	_, err := buildGRPCTernClient(config, mysqlstore.New(nil), logger, "")
+	_, err := buildGRPCTernClient(t.Context(), config, mysqlstore.New(nil), logger, "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "TERN_ENVIRONMENT")
 }
@@ -200,7 +288,7 @@ func TestBuildGRPCTernClientErrorsOnAmbiguousFallback(t *testing.T) {
 		},
 	}
 
-	_, err := buildGRPCTernClient(config, mysqlstore.New(nil), logger, "production")
+	_, err := buildGRPCTernClient(t.Context(), config, mysqlstore.New(nil), logger, "production")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "orders")
 	assert.Contains(t, err.Error(), "payments")
@@ -211,7 +299,7 @@ func TestBuildGRPCTernClientErrorsOnAmbiguousFallback(t *testing.T) {
 func TestBuildGRPCTernClientErrorsWhenNothingConfigured(t *testing.T) {
 	logger := slog.New(slog.DiscardHandler)
 
-	_, err := buildGRPCTernClient(&api.ServerConfig{}, mysqlstore.New(nil), logger, "production")
+	_, err := buildGRPCTernClient(t.Context(), &api.ServerConfig{}, mysqlstore.New(nil), logger, "production")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "production")
 }


### PR DESCRIPTION
## Why this matters

The data plane can now resolve targets via Etre, but its credentials were locked to a single backend (a username + secret reference). Real deployments need a choice — a shared secret via env/file for one, per-target assume-role Secrets Manager for another — without the data plane being coupled to any one secret store.

## What it does

Adds a `credentials.type` selector to `target_resolver.etre.credentials`, dispatched at startup to one `inventory.CredentialResolver` implementation:

- **`secret_ref`** (default) — a configured username plus a password secret reference (`env:` / `file:` / `secretsmanager:` / literal, with `{target}` templating).
- **`awssm`** — assume a per-target IAM role and read a JSON `{username, password}` secret from AWS Secrets Manager (the resolver from #372).

```yaml
target_resolver:
  etre:
    addr: env:ETRE_ADDR
    entity_type: aurora_cluster
    target_label: dsid
    host_field: writer_endpoint
    credentials:
      type: awssm                # or "secret_ref" (default)
      region: us-west-2
      role_arn: arn:aws:iam::{account}:role/tern-assumed
      secret_name: schemabot/mysql/{target}/ddl
      # account_attribute: aws_account_id   # default
```

The assume-role backend's account attribute is surfaced to the resolver automatically (the Etre lookup includes it). An unknown `type`, or missing required fields for the chosen backend, fails closed at startup.

## How it moves us toward the northstar

Credentials become a pluggable axis, just like the inventory backend. AWS is one selectable option behind the generic `CredentialResolver` seam — not the mechanism — so a deployment that doesn't use AWS keeps `secret_ref`, and a future backend (e.g. Vault) slots in as another `type` without touching the resolver or the data plane.

*Opened by Claude (Opus 4.8, 1M context).*
