### PR TITLE
feat(api): return pull schema catalog data

### DIFF
--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -977,10 +977,11 @@ func TestExecutePullSchemaPullsRequestedNamespaces(t *testing.T) {
 	}, logger)
 
 	resp, err := svc.ExecutePullSchema(t.Context(), apitypes.PullSchemaRequest{
-		Database:    "orders-logical",
-		Environment: "production",
-		Type:        storage.DatabaseTypeMySQL,
-		Namespaces:  []string{"orders_production", "orders_audit_production"},
+		Database:      "orders-logical",
+		Environment:   "production",
+		Type:          storage.DatabaseTypeMySQL,
+		Namespaces:    []string{"orders_production", "orders_audit_production"},
+		CatalogDetail: "detailed",
 	})
 
 	require.NoError(t, err)
@@ -992,7 +993,9 @@ func TestExecutePullSchemaPullsRequestedNamespaces(t *testing.T) {
 	require.Len(t, mockClient.pullSchemaReqs, 2)
 	assert.Equal(t, "orders-logical", mockClient.pullSchemaReqs[0].Database)
 	assert.Equal(t, "orders_production", mockClient.pullSchemaReqs[0].Namespace)
+	assert.Equal(t, ternv1.PullCatalogDetail_PULL_CATALOG_DETAIL_DETAILED, mockClient.pullSchemaReqs[0].CatalogDetail)
 	assert.Equal(t, "orders_audit_production", mockClient.pullSchemaReqs[1].Namespace)
+	assert.Equal(t, ternv1.PullCatalogDetail_PULL_CATALOG_DETAIL_DETAILED, mockClient.pullSchemaReqs[1].CatalogDetail)
 }
 
 func TestExecutePullSchemaRejectsUnsupportedType(t *testing.T) {

--- a/pkg/api/plan_handlers.go
+++ b/pkg/api/plan_handlers.go
@@ -111,6 +111,10 @@ func (s *Service) handlePullSchema(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
+	if _, err := pullCatalogDetail(req.CatalogDetail); err != nil {
+		s.writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
 
 	resp, err := s.ExecutePullSchema(r.Context(), req)
 	if err != nil {
@@ -187,6 +191,12 @@ func (s *Service) ExecutePullSchema(ctx context.Context, req apitypes.PullSchema
 		span.SetStatus(otelcodes.Error, "invalid namespaces")
 		return nil, err
 	}
+	catalogDetail, err := pullCatalogDetail(req.CatalogDetail)
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(otelcodes.Error, "invalid catalog detail")
+		return nil, err
+	}
 
 	client, err := s.RoutingTernClient()
 	if err != nil {
@@ -215,10 +225,11 @@ func (s *Service) ExecutePullSchema(ctx context.Context, req apitypes.PullSchema
 	}
 	for _, namespace := range namespaces {
 		resp, pullErr := client.PullSchema(ctx, &ternv1.PullSchemaRequest{
-			Database:    req.Database,
-			Type:        resolvedTarget.DatabaseType,
-			Environment: req.Environment,
-			Namespace:   namespace,
+			Database:      req.Database,
+			Type:          resolvedTarget.DatabaseType,
+			Environment:   req.Environment,
+			Namespace:     namespace,
+			CatalogDetail: catalogDetail,
 		})
 		if pullErr != nil {
 			span.RecordError(pullErr)
@@ -288,6 +299,17 @@ func pullNamespaces(namespaces []string) ([]string, error) {
 		result = append(result, namespace)
 	}
 	return result, nil
+}
+
+func pullCatalogDetail(detail string) (ternv1.PullCatalogDetail, error) {
+	switch detail {
+	case "", "basic":
+		return ternv1.PullCatalogDetail_PULL_CATALOG_DETAIL_BASIC, nil
+	case "detailed":
+		return ternv1.PullCatalogDetail_PULL_CATALOG_DETAIL_DETAILED, nil
+	default:
+		return ternv1.PullCatalogDetail_PULL_CATALOG_DETAIL_BASIC, fmt.Errorf("catalog_detail %q must be basic or detailed", detail)
+	}
 }
 
 func mergePullSchemaResponse(merged, resp *ternv1.PullSchemaResponse, requestedNamespace string) error {

--- a/pkg/api/proto_helpers.go
+++ b/pkg/api/proto_helpers.go
@@ -37,7 +37,85 @@ func protoPulledNamespacesToAPI(namespaces map[string]*ternv1.PulledNamespace) m
 		maps.Copy(tables, pulled.Tables)
 		artifacts := make(map[string]string, len(pulled.Artifacts))
 		maps.Copy(artifacts, pulled.Artifacts)
-		result[namespace] = &apitypes.PulledNamespace{Tables: tables, Artifacts: artifacts}
+		result[namespace] = &apitypes.PulledNamespace{
+			Tables:           tables,
+			Artifacts:        artifacts,
+			NamespaceCatalog: protoNamespaceCatalogToAPI(pulled.NamespaceCatalog),
+			TableCatalog:     protoTableCatalogToAPI(pulled.TableCatalog),
+		}
+	}
+	return result
+}
+
+func protoNamespaceCatalogToAPI(catalog *ternv1.NamespaceCatalog) *apitypes.NamespaceCatalog {
+	if catalog == nil {
+		return nil
+	}
+	return &apitypes.NamespaceCatalog{
+		Name:       catalog.Name,
+		Engine:     catalog.Engine,
+		TableCount: catalog.TableCount,
+	}
+}
+
+func protoTableCatalogToAPI(catalog map[string]*ternv1.TableCatalog) map[string]*apitypes.TableCatalog {
+	if len(catalog) == 0 {
+		return nil
+	}
+	result := make(map[string]*apitypes.TableCatalog, len(catalog))
+	for table, protoTable := range catalog {
+		if protoTable == nil {
+			result[table] = &apitypes.TableCatalog{Name: table}
+			continue
+		}
+		result[table] = &apitypes.TableCatalog{
+			Name:    protoTable.Name,
+			Kind:    protoTable.Kind,
+			Comment: protoTable.Comment,
+			Columns: protoColumnCatalogToAPI(protoTable.Columns),
+			Indexes: protoIndexCatalogToAPI(protoTable.Indexes),
+		}
+	}
+	return result
+}
+
+func protoColumnCatalogToAPI(columns []*ternv1.ColumnCatalog) []*apitypes.ColumnCatalog {
+	if len(columns) == 0 {
+		return nil
+	}
+	result := make([]*apitypes.ColumnCatalog, 0, len(columns))
+	for _, column := range columns {
+		if column == nil {
+			continue
+		}
+		result = append(result, &apitypes.ColumnCatalog{
+			Name:         column.Name,
+			Type:         column.Type,
+			Nullable:     column.Nullable,
+			DefaultValue: column.DefaultValue,
+			Comment:      column.Comment,
+		})
+	}
+	return result
+}
+
+func protoIndexCatalogToAPI(indexes []*ternv1.IndexCatalog) []*apitypes.IndexCatalog {
+	if len(indexes) == 0 {
+		return nil
+	}
+	result := make([]*apitypes.IndexCatalog, 0, len(indexes))
+	for _, index := range indexes {
+		if index == nil {
+			continue
+		}
+		parts := make([]string, len(index.Parts))
+		copy(parts, index.Parts)
+		result = append(result, &apitypes.IndexCatalog{
+			Name:    index.Name,
+			Primary: index.Primary,
+			Unique:  index.Unique,
+			Parts:   parts,
+		})
 	}
 	return result
 }

--- a/pkg/apitypes/apitypes.go
+++ b/pkg/apitypes/apitypes.go
@@ -58,16 +58,52 @@ type SchemaFiles struct {
 // MySQL, keyspace for Vitess). It intentionally describes database objects, not
 // repository filenames; clients decide how to materialize tables and artifacts.
 type PulledNamespace struct {
-	Tables    map[string]string `json:"tables,omitempty"`
-	Artifacts map[string]string `json:"artifacts,omitempty"`
+	Tables           map[string]string        `json:"tables,omitempty"`
+	Artifacts        map[string]string        `json:"artifacts,omitempty"`
+	NamespaceCatalog *NamespaceCatalog        `json:"namespace_catalog,omitempty"`
+	TableCatalog     map[string]*TableCatalog `json:"table_catalog,omitempty"`
+}
+
+// NamespaceCatalog contains structured metadata for a pulled namespace.
+type NamespaceCatalog struct {
+	Name       string `json:"name"`
+	Engine     string `json:"engine"`
+	TableCount int32  `json:"table_count"`
+}
+
+// TableCatalog contains structured metadata for a pulled table or view.
+type TableCatalog struct {
+	Name    string           `json:"name"`
+	Kind    string           `json:"kind"`
+	Comment string           `json:"comment,omitempty"`
+	Columns []*ColumnCatalog `json:"columns,omitempty"`
+	Indexes []*IndexCatalog  `json:"indexes,omitempty"`
+}
+
+// ColumnCatalog contains structured metadata for a pulled table column.
+type ColumnCatalog struct {
+	Name         string `json:"name"`
+	Type         string `json:"type"`
+	Nullable     bool   `json:"nullable"`
+	DefaultValue string `json:"default_value,omitempty"`
+	Comment      string `json:"comment,omitempty"`
+}
+
+// IndexCatalog contains structured metadata for a pulled table index.
+type IndexCatalog struct {
+	Name    string   `json:"name"`
+	Primary bool     `json:"primary,omitempty"`
+	Unique  bool     `json:"unique,omitempty"`
+	Parts   []string `json:"parts,omitempty"`
 }
 
 // PullSchemaRequest is the HTTP request body for POST /api/pull.
 type PullSchemaRequest struct {
-	Database    string   `json:"database"`
-	Environment string   `json:"environment"`
-	Type        string   `json:"type"`
-	Namespaces  []string `json:"namespaces,omitempty"`
+	Database      string   `json:"database"`
+	Environment   string   `json:"environment"`
+	Type          string   `json:"type"`
+	Namespaces    []string `json:"namespaces,omitempty"`
+	CatalogDetail string   `json:"catalog_detail,omitempty"`
 }
 
 // PullSchemaResponse is the HTTP response body for POST /api/pull.

--- a/pkg/cmd/client/client.go
+++ b/pkg/cmd/client/client.go
@@ -52,13 +52,25 @@ func GetEnvironments(endpoint, database string) ([]string, error) {
 	return result.Environments, nil
 }
 
+// PullSchemaOptions controls optional live schema pull request fields.
+type PullSchemaOptions struct {
+	Namespaces    []string
+	CatalogDetail string
+}
+
 // CallPullSchemaAPI fetches live schema files for a database/environment pair.
 func CallPullSchemaAPI(endpoint, database, dbType, environment string, namespaces ...string) (*apitypes.PullSchemaResponse, error) {
+	return CallPullSchemaAPIWithOptions(endpoint, database, dbType, environment, PullSchemaOptions{Namespaces: namespaces})
+}
+
+// CallPullSchemaAPIWithOptions fetches live schema with optional namespace and catalog controls.
+func CallPullSchemaAPIWithOptions(endpoint, database, dbType, environment string, opts PullSchemaOptions) (*apitypes.PullSchemaResponse, error) {
 	req := apitypes.PullSchemaRequest{
-		Database:    database,
-		Type:        dbType,
-		Environment: environment,
-		Namespaces:  namespaces,
+		Database:      database,
+		Type:          dbType,
+		Environment:   environment,
+		Namespaces:    opts.Namespaces,
+		CatalogDetail: opts.CatalogDetail,
 	}
 	var result apitypes.PullSchemaResponse
 	if err := doPostInto(endpoint, "/api/pull", req, &result); err != nil {

--- a/pkg/cmd/client/client_test.go
+++ b/pkg/cmd/client/client_test.go
@@ -35,10 +35,13 @@ func TestCallPullSchemaAPI(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	result, err := CallPullSchemaAPI(server.URL, "orders", "mysql", "production", "orders_production", "orders_audit_production")
+	result, err := CallPullSchemaAPIWithOptions(server.URL, "orders", "mysql", "production", PullSchemaOptions{
+		Namespaces:    []string{"orders_production", "orders_audit_production"},
+		CatalogDetail: "detailed",
+	})
 	require.NoError(t, err)
 
-	assert.Equal(t, apitypes.PullSchemaRequest{Database: "orders", Type: "mysql", Environment: "production", Namespaces: []string{"orders_production", "orders_audit_production"}}, gotReq)
+	assert.Equal(t, apitypes.PullSchemaRequest{Database: "orders", Type: "mysql", Environment: "production", Namespaces: []string{"orders_production", "orders_audit_production"}, CatalogDetail: "detailed"}, gotReq)
 	require.NotNil(t, result)
 	assert.Equal(t, "orders", result.Database)
 	assert.Equal(t, "mysql", result.Type)

--- a/pkg/cmd/commands/pull.go
+++ b/pkg/cmd/commands/pull.go
@@ -12,10 +12,11 @@ import (
 
 // PullCmd returns live schema from a source environment without writing files.
 type PullCmd struct {
-	Database    string   `short:"d" required:"" help:"Database name from SchemaBot server config"`
-	Environment string   `short:"e" required:"" help:"Source environment to pull from"`
-	Type        string   `help:"Database type" default:"mysql" enum:"mysql"`
-	Namespaces  []string `name:"namespace" help:"Concrete live namespace to pull. Repeat for multiple namespaces. Omit to discover all non-reserved namespaces."`
+	Database      string   `short:"d" required:"" help:"Database name from SchemaBot server config"`
+	Environment   string   `short:"e" required:"" help:"Source environment to pull from"`
+	Type          string   `help:"Database type" default:"mysql" enum:"mysql"`
+	Namespaces    []string `name:"namespace" help:"Concrete live namespace to pull. Repeat for multiple namespaces. Omit to discover all non-reserved namespaces."`
+	CatalogDetail string   `help:"Structured catalog detail to include" default:"basic" enum:"basic,detailed"`
 }
 
 // Run executes the pull command.
@@ -24,7 +25,10 @@ func (cmd *PullCmd) Run(g *Globals) error {
 	if err != nil {
 		return err
 	}
-	resp, err := client.CallPullSchemaAPI(ep, cmd.Database, cmd.Type, cmd.Environment, cmd.Namespaces...)
+	resp, err := client.CallPullSchemaAPIWithOptions(ep, cmd.Database, cmd.Type, cmd.Environment, client.PullSchemaOptions{
+		Namespaces:    cmd.Namespaces,
+		CatalogDetail: cmd.CatalogDetail,
+	})
 	if err != nil {
 		if outputSchemaPullRequestError("Pull", cmd.Database, cmd.Environment, err) {
 			return ErrSilent

--- a/pkg/proto/tern.proto
+++ b/pkg/proto/tern.proto
@@ -257,6 +257,13 @@ message PullSchemaRequest {
   string target = 4;
   // Optional namespace to export. For MySQL this is the schema name from SHOW DATABASES.
   string namespace = 5;
+  // Controls how much structured catalog data is returned alongside canonical DDL.
+  PullCatalogDetail catalog_detail = 6;
+}
+
+enum PullCatalogDetail {
+  PULL_CATALOG_DETAIL_BASIC = 0;
+  PULL_CATALOG_DETAIL_DETAILED = 1;
 }
 
 // PulledNamespace contains live schema content for a namespace. It describes
@@ -267,6 +274,39 @@ message PulledNamespace {
   map<string, string> tables = 1;
   // Optional engine-specific namespace content, such as Vitess VSchema JSON.
   map<string, string> artifacts = 2;
+  NamespaceCatalog namespace_catalog = 3;
+  map<string, TableCatalog> table_catalog = 4;
+}
+
+message NamespaceCatalog {
+  string name = 1;
+  string engine = 2;
+  int32 table_count = 3;
+}
+
+message TableCatalog {
+  string name = 1;
+  string kind = 2;
+  string comment = 3;
+  repeated ColumnCatalog columns = 4;
+  repeated IndexCatalog indexes = 5;
+}
+
+message ColumnCatalog {
+  string name = 1;
+  string type = 2;
+  bool nullable = 3;
+  string default_value = 4;
+  string comment = 5;
+}
+
+message IndexCatalog {
+  string name = 1;
+  bool primary = 2;
+  bool unique = 3;
+  // Ordered index key parts. Each part may be a column name or an expression,
+  // depending on the database engine.
+  repeated string parts = 4;
 }
 
 // PullSchemaResponse contains live schema content grouped by namespace.

--- a/pkg/proto/ternv1/tern.pb.go
+++ b/pkg/proto/ternv1/tern.pb.go
@@ -223,6 +223,52 @@ func (ChangeType) EnumDescriptor() ([]byte, []int) {
 	return file_tern_proto_rawDescGZIP(), []int{2}
 }
 
+type PullCatalogDetail int32
+
+const (
+	PullCatalogDetail_PULL_CATALOG_DETAIL_BASIC    PullCatalogDetail = 0
+	PullCatalogDetail_PULL_CATALOG_DETAIL_DETAILED PullCatalogDetail = 1
+)
+
+// Enum value maps for PullCatalogDetail.
+var (
+	PullCatalogDetail_name = map[int32]string{
+		0: "PULL_CATALOG_DETAIL_BASIC",
+		1: "PULL_CATALOG_DETAIL_DETAILED",
+	}
+	PullCatalogDetail_value = map[string]int32{
+		"PULL_CATALOG_DETAIL_BASIC":    0,
+		"PULL_CATALOG_DETAIL_DETAILED": 1,
+	}
+)
+
+func (x PullCatalogDetail) Enum() *PullCatalogDetail {
+	p := new(PullCatalogDetail)
+	*p = x
+	return p
+}
+
+func (x PullCatalogDetail) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (PullCatalogDetail) Descriptor() protoreflect.EnumDescriptor {
+	return file_tern_proto_enumTypes[3].Descriptor()
+}
+
+func (PullCatalogDetail) Type() protoreflect.EnumType {
+	return &file_tern_proto_enumTypes[3]
+}
+
+func (x PullCatalogDetail) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use PullCatalogDetail.Descriptor instead.
+func (PullCatalogDetail) EnumDescriptor() ([]byte, []int) {
+	return file_tern_proto_rawDescGZIP(), []int{3}
+}
+
 // SchemaFiles contains the schema files for a namespace (e.g. schema name for MySQL, keyspace for Vitess).
 type SchemaFiles struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -281,7 +327,9 @@ type PullSchemaRequest struct {
 	// Opaque identifier for endpoint discovery. Defaults to database if empty.
 	Target string `protobuf:"bytes,4,opt,name=target,proto3" json:"target,omitempty"`
 	// Optional namespace to export. For MySQL this is the schema name from SHOW DATABASES.
-	Namespace     string `protobuf:"bytes,5,opt,name=namespace,proto3" json:"namespace,omitempty"`
+	Namespace string `protobuf:"bytes,5,opt,name=namespace,proto3" json:"namespace,omitempty"`
+	// Controls how much structured catalog data is returned alongside canonical DDL.
+	CatalogDetail PullCatalogDetail `protobuf:"varint,6,opt,name=catalog_detail,json=catalogDetail,proto3,enum=tern.v1.PullCatalogDetail" json:"catalog_detail,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -351,6 +399,13 @@ func (x *PullSchemaRequest) GetNamespace() string {
 	return ""
 }
 
+func (x *PullSchemaRequest) GetCatalogDetail() PullCatalogDetail {
+	if x != nil {
+		return x.CatalogDetail
+	}
+	return PullCatalogDetail_PULL_CATALOG_DETAIL_BASIC
+}
+
 // PulledNamespace contains live schema content for a namespace. It describes
 // database objects rather than repository filenames so clients can choose the
 // file layout they write.
@@ -359,9 +414,11 @@ type PulledNamespace struct {
 	// Table name → canonical CREATE TABLE statement.
 	Tables map[string]string `protobuf:"bytes,1,rep,name=tables,proto3" json:"tables,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	// Optional engine-specific namespace content, such as Vitess VSchema JSON.
-	Artifacts     map[string]string `protobuf:"bytes,2,rep,name=artifacts,proto3" json:"artifacts,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	Artifacts        map[string]string        `protobuf:"bytes,2,rep,name=artifacts,proto3" json:"artifacts,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	NamespaceCatalog *NamespaceCatalog        `protobuf:"bytes,3,opt,name=namespace_catalog,json=namespaceCatalog,proto3" json:"namespace_catalog,omitempty"`
+	TableCatalog     map[string]*TableCatalog `protobuf:"bytes,4,rep,name=table_catalog,json=tableCatalog,proto3" json:"table_catalog,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
 }
 
 func (x *PulledNamespace) Reset() {
@@ -408,6 +465,302 @@ func (x *PulledNamespace) GetArtifacts() map[string]string {
 	return nil
 }
 
+func (x *PulledNamespace) GetNamespaceCatalog() *NamespaceCatalog {
+	if x != nil {
+		return x.NamespaceCatalog
+	}
+	return nil
+}
+
+func (x *PulledNamespace) GetTableCatalog() map[string]*TableCatalog {
+	if x != nil {
+		return x.TableCatalog
+	}
+	return nil
+}
+
+type NamespaceCatalog struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	Engine        string                 `protobuf:"bytes,2,opt,name=engine,proto3" json:"engine,omitempty"`
+	TableCount    int32                  `protobuf:"varint,3,opt,name=table_count,json=tableCount,proto3" json:"table_count,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *NamespaceCatalog) Reset() {
+	*x = NamespaceCatalog{}
+	mi := &file_tern_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *NamespaceCatalog) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*NamespaceCatalog) ProtoMessage() {}
+
+func (x *NamespaceCatalog) ProtoReflect() protoreflect.Message {
+	mi := &file_tern_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use NamespaceCatalog.ProtoReflect.Descriptor instead.
+func (*NamespaceCatalog) Descriptor() ([]byte, []int) {
+	return file_tern_proto_rawDescGZIP(), []int{3}
+}
+
+func (x *NamespaceCatalog) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *NamespaceCatalog) GetEngine() string {
+	if x != nil {
+		return x.Engine
+	}
+	return ""
+}
+
+func (x *NamespaceCatalog) GetTableCount() int32 {
+	if x != nil {
+		return x.TableCount
+	}
+	return 0
+}
+
+type TableCatalog struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	Kind          string                 `protobuf:"bytes,2,opt,name=kind,proto3" json:"kind,omitempty"`
+	Comment       string                 `protobuf:"bytes,3,opt,name=comment,proto3" json:"comment,omitempty"`
+	Columns       []*ColumnCatalog       `protobuf:"bytes,4,rep,name=columns,proto3" json:"columns,omitempty"`
+	Indexes       []*IndexCatalog        `protobuf:"bytes,5,rep,name=indexes,proto3" json:"indexes,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TableCatalog) Reset() {
+	*x = TableCatalog{}
+	mi := &file_tern_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TableCatalog) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TableCatalog) ProtoMessage() {}
+
+func (x *TableCatalog) ProtoReflect() protoreflect.Message {
+	mi := &file_tern_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TableCatalog.ProtoReflect.Descriptor instead.
+func (*TableCatalog) Descriptor() ([]byte, []int) {
+	return file_tern_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *TableCatalog) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *TableCatalog) GetKind() string {
+	if x != nil {
+		return x.Kind
+	}
+	return ""
+}
+
+func (x *TableCatalog) GetComment() string {
+	if x != nil {
+		return x.Comment
+	}
+	return ""
+}
+
+func (x *TableCatalog) GetColumns() []*ColumnCatalog {
+	if x != nil {
+		return x.Columns
+	}
+	return nil
+}
+
+func (x *TableCatalog) GetIndexes() []*IndexCatalog {
+	if x != nil {
+		return x.Indexes
+	}
+	return nil
+}
+
+type ColumnCatalog struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	Type          string                 `protobuf:"bytes,2,opt,name=type,proto3" json:"type,omitempty"`
+	Nullable      bool                   `protobuf:"varint,3,opt,name=nullable,proto3" json:"nullable,omitempty"`
+	DefaultValue  string                 `protobuf:"bytes,4,opt,name=default_value,json=defaultValue,proto3" json:"default_value,omitempty"`
+	Comment       string                 `protobuf:"bytes,5,opt,name=comment,proto3" json:"comment,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ColumnCatalog) Reset() {
+	*x = ColumnCatalog{}
+	mi := &file_tern_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ColumnCatalog) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ColumnCatalog) ProtoMessage() {}
+
+func (x *ColumnCatalog) ProtoReflect() protoreflect.Message {
+	mi := &file_tern_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ColumnCatalog.ProtoReflect.Descriptor instead.
+func (*ColumnCatalog) Descriptor() ([]byte, []int) {
+	return file_tern_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *ColumnCatalog) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *ColumnCatalog) GetType() string {
+	if x != nil {
+		return x.Type
+	}
+	return ""
+}
+
+func (x *ColumnCatalog) GetNullable() bool {
+	if x != nil {
+		return x.Nullable
+	}
+	return false
+}
+
+func (x *ColumnCatalog) GetDefaultValue() string {
+	if x != nil {
+		return x.DefaultValue
+	}
+	return ""
+}
+
+func (x *ColumnCatalog) GetComment() string {
+	if x != nil {
+		return x.Comment
+	}
+	return ""
+}
+
+type IndexCatalog struct {
+	state   protoimpl.MessageState `protogen:"open.v1"`
+	Name    string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	Primary bool                   `protobuf:"varint,2,opt,name=primary,proto3" json:"primary,omitempty"`
+	Unique  bool                   `protobuf:"varint,3,opt,name=unique,proto3" json:"unique,omitempty"`
+	// Ordered index key parts. Each part may be a column name or an expression,
+	// depending on the database engine.
+	Parts         []string `protobuf:"bytes,4,rep,name=parts,proto3" json:"parts,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *IndexCatalog) Reset() {
+	*x = IndexCatalog{}
+	mi := &file_tern_proto_msgTypes[6]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *IndexCatalog) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*IndexCatalog) ProtoMessage() {}
+
+func (x *IndexCatalog) ProtoReflect() protoreflect.Message {
+	mi := &file_tern_proto_msgTypes[6]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use IndexCatalog.ProtoReflect.Descriptor instead.
+func (*IndexCatalog) Descriptor() ([]byte, []int) {
+	return file_tern_proto_rawDescGZIP(), []int{6}
+}
+
+func (x *IndexCatalog) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *IndexCatalog) GetPrimary() bool {
+	if x != nil {
+		return x.Primary
+	}
+	return false
+}
+
+func (x *IndexCatalog) GetUnique() bool {
+	if x != nil {
+		return x.Unique
+	}
+	return false
+}
+
+func (x *IndexCatalog) GetParts() []string {
+	if x != nil {
+		return x.Parts
+	}
+	return nil
+}
+
 // PullSchemaResponse contains live schema content grouped by namespace.
 type PullSchemaResponse struct {
 	state         protoimpl.MessageState      `protogen:"open.v1"`
@@ -422,7 +775,7 @@ type PullSchemaResponse struct {
 
 func (x *PullSchemaResponse) Reset() {
 	*x = PullSchemaResponse{}
-	mi := &file_tern_proto_msgTypes[3]
+	mi := &file_tern_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -434,7 +787,7 @@ func (x *PullSchemaResponse) String() string {
 func (*PullSchemaResponse) ProtoMessage() {}
 
 func (x *PullSchemaResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[3]
+	mi := &file_tern_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -447,7 +800,7 @@ func (x *PullSchemaResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PullSchemaResponse.ProtoReflect.Descriptor instead.
 func (*PullSchemaResponse) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{3}
+	return file_tern_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *PullSchemaResponse) GetDatabase() string {
@@ -517,7 +870,7 @@ type PlanRequest struct {
 
 func (x *PlanRequest) Reset() {
 	*x = PlanRequest{}
-	mi := &file_tern_proto_msgTypes[4]
+	mi := &file_tern_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -529,7 +882,7 @@ func (x *PlanRequest) String() string {
 func (*PlanRequest) ProtoMessage() {}
 
 func (x *PlanRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[4]
+	mi := &file_tern_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -542,7 +895,7 @@ func (x *PlanRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PlanRequest.ProtoReflect.Descriptor instead.
 func (*PlanRequest) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{4}
+	return file_tern_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *PlanRequest) GetDatabase() string {
@@ -624,7 +977,7 @@ type TableChange struct {
 
 func (x *TableChange) Reset() {
 	*x = TableChange{}
-	mi := &file_tern_proto_msgTypes[5]
+	mi := &file_tern_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -636,7 +989,7 @@ func (x *TableChange) String() string {
 func (*TableChange) ProtoMessage() {}
 
 func (x *TableChange) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[5]
+	mi := &file_tern_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -649,7 +1002,7 @@ func (x *TableChange) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TableChange.ProtoReflect.Descriptor instead.
 func (*TableChange) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{5}
+	return file_tern_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *TableChange) GetTableName() string {
@@ -716,7 +1069,7 @@ type SchemaChange struct {
 
 func (x *SchemaChange) Reset() {
 	*x = SchemaChange{}
-	mi := &file_tern_proto_msgTypes[6]
+	mi := &file_tern_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -728,7 +1081,7 @@ func (x *SchemaChange) String() string {
 func (*SchemaChange) ProtoMessage() {}
 
 func (x *SchemaChange) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[6]
+	mi := &file_tern_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -741,7 +1094,7 @@ func (x *SchemaChange) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SchemaChange.ProtoReflect.Descriptor instead.
 func (*SchemaChange) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{6}
+	return file_tern_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *SchemaChange) GetNamespace() string {
@@ -795,7 +1148,7 @@ type LintViolation struct {
 
 func (x *LintViolation) Reset() {
 	*x = LintViolation{}
-	mi := &file_tern_proto_msgTypes[7]
+	mi := &file_tern_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -807,7 +1160,7 @@ func (x *LintViolation) String() string {
 func (*LintViolation) ProtoMessage() {}
 
 func (x *LintViolation) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[7]
+	mi := &file_tern_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -820,7 +1173,7 @@ func (x *LintViolation) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LintViolation.ProtoReflect.Descriptor instead.
 func (*LintViolation) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{7}
+	return file_tern_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *LintViolation) GetMessage() string {
@@ -879,7 +1232,7 @@ type ShardPlan struct {
 
 func (x *ShardPlan) Reset() {
 	*x = ShardPlan{}
-	mi := &file_tern_proto_msgTypes[8]
+	mi := &file_tern_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -891,7 +1244,7 @@ func (x *ShardPlan) String() string {
 func (*ShardPlan) ProtoMessage() {}
 
 func (x *ShardPlan) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[8]
+	mi := &file_tern_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -904,7 +1257,7 @@ func (x *ShardPlan) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ShardPlan.ProtoReflect.Descriptor instead.
 func (*ShardPlan) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{8}
+	return file_tern_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *ShardPlan) GetShard() string {
@@ -946,7 +1299,7 @@ type PlanResponse struct {
 
 func (x *PlanResponse) Reset() {
 	*x = PlanResponse{}
-	mi := &file_tern_proto_msgTypes[9]
+	mi := &file_tern_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -958,7 +1311,7 @@ func (x *PlanResponse) String() string {
 func (*PlanResponse) ProtoMessage() {}
 
 func (x *PlanResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[9]
+	mi := &file_tern_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -971,7 +1324,7 @@ func (x *PlanResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PlanResponse.ProtoReflect.Descriptor instead.
 func (*PlanResponse) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{9}
+	return file_tern_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *PlanResponse) GetPlanId() string {
@@ -1045,7 +1398,7 @@ type ApplyRequest struct {
 
 func (x *ApplyRequest) Reset() {
 	*x = ApplyRequest{}
-	mi := &file_tern_proto_msgTypes[10]
+	mi := &file_tern_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1057,7 +1410,7 @@ func (x *ApplyRequest) String() string {
 func (*ApplyRequest) ProtoMessage() {}
 
 func (x *ApplyRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[10]
+	mi := &file_tern_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1070,7 +1423,7 @@ func (x *ApplyRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ApplyRequest.ProtoReflect.Descriptor instead.
 func (*ApplyRequest) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{10}
+	return file_tern_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *ApplyRequest) GetPlanId() string {
@@ -1156,7 +1509,7 @@ type ApplyResponse struct {
 
 func (x *ApplyResponse) Reset() {
 	*x = ApplyResponse{}
-	mi := &file_tern_proto_msgTypes[11]
+	mi := &file_tern_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1168,7 +1521,7 @@ func (x *ApplyResponse) String() string {
 func (*ApplyResponse) ProtoMessage() {}
 
 func (x *ApplyResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[11]
+	mi := &file_tern_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1181,7 +1534,7 @@ func (x *ApplyResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ApplyResponse.ProtoReflect.Descriptor instead.
 func (*ApplyResponse) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{11}
+	return file_tern_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *ApplyResponse) GetAccepted() bool {
@@ -1218,7 +1571,7 @@ type ProgressRequest struct {
 
 func (x *ProgressRequest) Reset() {
 	*x = ProgressRequest{}
-	mi := &file_tern_proto_msgTypes[12]
+	mi := &file_tern_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1230,7 +1583,7 @@ func (x *ProgressRequest) String() string {
 func (*ProgressRequest) ProtoMessage() {}
 
 func (x *ProgressRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[12]
+	mi := &file_tern_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1243,7 +1596,7 @@ func (x *ProgressRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ProgressRequest.ProtoReflect.Descriptor instead.
 func (*ProgressRequest) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{12}
+	return file_tern_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *ProgressRequest) GetApplyId() string {
@@ -1277,7 +1630,7 @@ type ShardProgress struct {
 
 func (x *ShardProgress) Reset() {
 	*x = ShardProgress{}
-	mi := &file_tern_proto_msgTypes[13]
+	mi := &file_tern_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1289,7 +1642,7 @@ func (x *ShardProgress) String() string {
 func (*ShardProgress) ProtoMessage() {}
 
 func (x *ShardProgress) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[13]
+	mi := &file_tern_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1302,7 +1655,7 @@ func (x *ShardProgress) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ShardProgress.ProtoReflect.Descriptor instead.
 func (*ShardProgress) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{13}
+	return file_tern_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *ShardProgress) GetShard() string {
@@ -1383,7 +1736,7 @@ type TableProgress struct {
 
 func (x *TableProgress) Reset() {
 	*x = TableProgress{}
-	mi := &file_tern_proto_msgTypes[14]
+	mi := &file_tern_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1395,7 +1748,7 @@ func (x *TableProgress) String() string {
 func (*TableProgress) ProtoMessage() {}
 
 func (x *TableProgress) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[14]
+	mi := &file_tern_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1408,7 +1761,7 @@ func (x *TableProgress) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TableProgress.ProtoReflect.Descriptor instead.
 func (*TableProgress) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{14}
+	return file_tern_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *TableProgress) GetTaskId() string {
@@ -1521,7 +1874,7 @@ type ProgressResponse struct {
 
 func (x *ProgressResponse) Reset() {
 	*x = ProgressResponse{}
-	mi := &file_tern_proto_msgTypes[15]
+	mi := &file_tern_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1533,7 +1886,7 @@ func (x *ProgressResponse) String() string {
 func (*ProgressResponse) ProtoMessage() {}
 
 func (x *ProgressResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[15]
+	mi := &file_tern_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1546,7 +1899,7 @@ func (x *ProgressResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ProgressResponse.ProtoReflect.Descriptor instead.
 func (*ProgressResponse) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{15}
+	return file_tern_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *ProgressResponse) GetApplyId() string {
@@ -1632,7 +1985,7 @@ type CutoverRequest struct {
 
 func (x *CutoverRequest) Reset() {
 	*x = CutoverRequest{}
-	mi := &file_tern_proto_msgTypes[16]
+	mi := &file_tern_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1644,7 +1997,7 @@ func (x *CutoverRequest) String() string {
 func (*CutoverRequest) ProtoMessage() {}
 
 func (x *CutoverRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[16]
+	mi := &file_tern_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1657,7 +2010,7 @@ func (x *CutoverRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CutoverRequest.ProtoReflect.Descriptor instead.
 func (*CutoverRequest) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{16}
+	return file_tern_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *CutoverRequest) GetApplyId() string {
@@ -1685,7 +2038,7 @@ type CutoverResponse struct {
 
 func (x *CutoverResponse) Reset() {
 	*x = CutoverResponse{}
-	mi := &file_tern_proto_msgTypes[17]
+	mi := &file_tern_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1697,7 +2050,7 @@ func (x *CutoverResponse) String() string {
 func (*CutoverResponse) ProtoMessage() {}
 
 func (x *CutoverResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[17]
+	mi := &file_tern_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1710,7 +2063,7 @@ func (x *CutoverResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CutoverResponse.ProtoReflect.Descriptor instead.
 func (*CutoverResponse) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{17}
+	return file_tern_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *CutoverResponse) GetAccepted() bool {
@@ -1740,7 +2093,7 @@ type RevertRequest struct {
 
 func (x *RevertRequest) Reset() {
 	*x = RevertRequest{}
-	mi := &file_tern_proto_msgTypes[18]
+	mi := &file_tern_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1752,7 +2105,7 @@ func (x *RevertRequest) String() string {
 func (*RevertRequest) ProtoMessage() {}
 
 func (x *RevertRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[18]
+	mi := &file_tern_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1765,7 +2118,7 @@ func (x *RevertRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RevertRequest.ProtoReflect.Descriptor instead.
 func (*RevertRequest) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{18}
+	return file_tern_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *RevertRequest) GetApplyId() string {
@@ -1793,7 +2146,7 @@ type RevertResponse struct {
 
 func (x *RevertResponse) Reset() {
 	*x = RevertResponse{}
-	mi := &file_tern_proto_msgTypes[19]
+	mi := &file_tern_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1805,7 +2158,7 @@ func (x *RevertResponse) String() string {
 func (*RevertResponse) ProtoMessage() {}
 
 func (x *RevertResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[19]
+	mi := &file_tern_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1818,7 +2171,7 @@ func (x *RevertResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RevertResponse.ProtoReflect.Descriptor instead.
 func (*RevertResponse) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{19}
+	return file_tern_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *RevertResponse) GetAccepted() bool {
@@ -1848,7 +2201,7 @@ type SkipRevertRequest struct {
 
 func (x *SkipRevertRequest) Reset() {
 	*x = SkipRevertRequest{}
-	mi := &file_tern_proto_msgTypes[20]
+	mi := &file_tern_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1860,7 +2213,7 @@ func (x *SkipRevertRequest) String() string {
 func (*SkipRevertRequest) ProtoMessage() {}
 
 func (x *SkipRevertRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[20]
+	mi := &file_tern_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1873,7 +2226,7 @@ func (x *SkipRevertRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SkipRevertRequest.ProtoReflect.Descriptor instead.
 func (*SkipRevertRequest) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{20}
+	return file_tern_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *SkipRevertRequest) GetApplyId() string {
@@ -1901,7 +2254,7 @@ type SkipRevertResponse struct {
 
 func (x *SkipRevertResponse) Reset() {
 	*x = SkipRevertResponse{}
-	mi := &file_tern_proto_msgTypes[21]
+	mi := &file_tern_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1913,7 +2266,7 @@ func (x *SkipRevertResponse) String() string {
 func (*SkipRevertResponse) ProtoMessage() {}
 
 func (x *SkipRevertResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[21]
+	mi := &file_tern_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1926,7 +2279,7 @@ func (x *SkipRevertResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SkipRevertResponse.ProtoReflect.Descriptor instead.
 func (*SkipRevertResponse) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{21}
+	return file_tern_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *SkipRevertResponse) GetAccepted() bool {
@@ -1952,7 +2305,7 @@ type HealthRequest struct {
 
 func (x *HealthRequest) Reset() {
 	*x = HealthRequest{}
-	mi := &file_tern_proto_msgTypes[22]
+	mi := &file_tern_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1964,7 +2317,7 @@ func (x *HealthRequest) String() string {
 func (*HealthRequest) ProtoMessage() {}
 
 func (x *HealthRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[22]
+	mi := &file_tern_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1977,7 +2330,7 @@ func (x *HealthRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HealthRequest.ProtoReflect.Descriptor instead.
 func (*HealthRequest) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{22}
+	return file_tern_proto_rawDescGZIP(), []int{26}
 }
 
 // HealthResponse is the health check response.
@@ -1990,7 +2343,7 @@ type HealthResponse struct {
 
 func (x *HealthResponse) Reset() {
 	*x = HealthResponse{}
-	mi := &file_tern_proto_msgTypes[23]
+	mi := &file_tern_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2002,7 +2355,7 @@ func (x *HealthResponse) String() string {
 func (*HealthResponse) ProtoMessage() {}
 
 func (x *HealthResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[23]
+	mi := &file_tern_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2015,7 +2368,7 @@ func (x *HealthResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HealthResponse.ProtoReflect.Descriptor instead.
 func (*HealthResponse) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{23}
+	return file_tern_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *HealthResponse) GetStatus() string {
@@ -2038,7 +2391,7 @@ type StopRequest struct {
 
 func (x *StopRequest) Reset() {
 	*x = StopRequest{}
-	mi := &file_tern_proto_msgTypes[24]
+	mi := &file_tern_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2050,7 +2403,7 @@ func (x *StopRequest) String() string {
 func (*StopRequest) ProtoMessage() {}
 
 func (x *StopRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[24]
+	mi := &file_tern_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2063,7 +2416,7 @@ func (x *StopRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StopRequest.ProtoReflect.Descriptor instead.
 func (*StopRequest) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{24}
+	return file_tern_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *StopRequest) GetApplyId() string {
@@ -2097,7 +2450,7 @@ type StopResponse struct {
 
 func (x *StopResponse) Reset() {
 	*x = StopResponse{}
-	mi := &file_tern_proto_msgTypes[25]
+	mi := &file_tern_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2109,7 +2462,7 @@ func (x *StopResponse) String() string {
 func (*StopResponse) ProtoMessage() {}
 
 func (x *StopResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[25]
+	mi := &file_tern_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2122,7 +2475,7 @@ func (x *StopResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StopResponse.ProtoReflect.Descriptor instead.
 func (*StopResponse) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{25}
+	return file_tern_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *StopResponse) GetAccepted() bool {
@@ -2173,7 +2526,7 @@ type StartRequest struct {
 
 func (x *StartRequest) Reset() {
 	*x = StartRequest{}
-	mi := &file_tern_proto_msgTypes[26]
+	mi := &file_tern_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2185,7 +2538,7 @@ func (x *StartRequest) String() string {
 func (*StartRequest) ProtoMessage() {}
 
 func (x *StartRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[26]
+	mi := &file_tern_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2198,7 +2551,7 @@ func (x *StartRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StartRequest.ProtoReflect.Descriptor instead.
 func (*StartRequest) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{26}
+	return file_tern_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *StartRequest) GetApplyId() string {
@@ -2230,7 +2583,7 @@ type StartResponse struct {
 
 func (x *StartResponse) Reset() {
 	*x = StartResponse{}
-	mi := &file_tern_proto_msgTypes[27]
+	mi := &file_tern_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2242,7 +2595,7 @@ func (x *StartResponse) String() string {
 func (*StartResponse) ProtoMessage() {}
 
 func (x *StartResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[27]
+	mi := &file_tern_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2255,7 +2608,7 @@ func (x *StartResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StartResponse.ProtoReflect.Descriptor instead.
 func (*StartResponse) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{27}
+	return file_tern_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *StartResponse) GetAccepted() bool {
@@ -2301,7 +2654,7 @@ type VolumeRequest struct {
 
 func (x *VolumeRequest) Reset() {
 	*x = VolumeRequest{}
-	mi := &file_tern_proto_msgTypes[28]
+	mi := &file_tern_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2313,7 +2666,7 @@ func (x *VolumeRequest) String() string {
 func (*VolumeRequest) ProtoMessage() {}
 
 func (x *VolumeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[28]
+	mi := &file_tern_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2326,7 +2679,7 @@ func (x *VolumeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VolumeRequest.ProtoReflect.Descriptor instead.
 func (*VolumeRequest) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{28}
+	return file_tern_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *VolumeRequest) GetApplyId() string {
@@ -2365,7 +2718,7 @@ type VolumeResponse struct {
 
 func (x *VolumeResponse) Reset() {
 	*x = VolumeResponse{}
-	mi := &file_tern_proto_msgTypes[29]
+	mi := &file_tern_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2377,7 +2730,7 @@ func (x *VolumeResponse) String() string {
 func (*VolumeResponse) ProtoMessage() {}
 
 func (x *VolumeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[29]
+	mi := &file_tern_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2390,7 +2743,7 @@ func (x *VolumeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VolumeResponse.ProtoReflect.Descriptor instead.
 func (*VolumeResponse) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{29}
+	return file_tern_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *VolumeResponse) GetAccepted() bool {
@@ -2432,22 +2785,50 @@ const file_tern_proto_rawDesc = "" +
 	"\n" +
 	"FilesEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x9b\x01\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xde\x01\n" +
 	"\x11PullSchemaRequest\x12\x1a\n" +
 	"\bdatabase\x18\x01 \x01(\tR\bdatabase\x12\x12\n" +
 	"\x04type\x18\x02 \x01(\tR\x04type\x12 \n" +
 	"\venvironment\x18\x03 \x01(\tR\venvironment\x12\x16\n" +
 	"\x06target\x18\x04 \x01(\tR\x06target\x12\x1c\n" +
-	"\tnamespace\x18\x05 \x01(\tR\tnamespace\"\x8f\x02\n" +
+	"\tnamespace\x18\x05 \x01(\tR\tnamespace\x12A\n" +
+	"\x0ecatalog_detail\x18\x06 \x01(\x0e2\x1a.tern.v1.PullCatalogDetailR\rcatalogDetail\"\x80\x04\n" +
 	"\x0fPulledNamespace\x12<\n" +
 	"\x06tables\x18\x01 \x03(\v2$.tern.v1.PulledNamespace.TablesEntryR\x06tables\x12E\n" +
-	"\tartifacts\x18\x02 \x03(\v2'.tern.v1.PulledNamespace.ArtifactsEntryR\tartifacts\x1a9\n" +
+	"\tartifacts\x18\x02 \x03(\v2'.tern.v1.PulledNamespace.ArtifactsEntryR\tartifacts\x12F\n" +
+	"\x11namespace_catalog\x18\x03 \x01(\v2\x19.tern.v1.NamespaceCatalogR\x10namespaceCatalog\x12O\n" +
+	"\rtable_catalog\x18\x04 \x03(\v2*.tern.v1.PulledNamespace.TableCatalogEntryR\ftableCatalog\x1a9\n" +
 	"\vTablesEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\x1a<\n" +
 	"\x0eArtifactsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xad\x02\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\x1aV\n" +
+	"\x11TableCatalogEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12+\n" +
+	"\x05value\x18\x02 \x01(\v2\x15.tern.v1.TableCatalogR\x05value:\x028\x01\"_\n" +
+	"\x10NamespaceCatalog\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12\x16\n" +
+	"\x06engine\x18\x02 \x01(\tR\x06engine\x12\x1f\n" +
+	"\vtable_count\x18\x03 \x01(\x05R\n" +
+	"tableCount\"\xb3\x01\n" +
+	"\fTableCatalog\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12\x12\n" +
+	"\x04kind\x18\x02 \x01(\tR\x04kind\x12\x18\n" +
+	"\acomment\x18\x03 \x01(\tR\acomment\x120\n" +
+	"\acolumns\x18\x04 \x03(\v2\x16.tern.v1.ColumnCatalogR\acolumns\x12/\n" +
+	"\aindexes\x18\x05 \x03(\v2\x15.tern.v1.IndexCatalogR\aindexes\"\x92\x01\n" +
+	"\rColumnCatalog\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12\x12\n" +
+	"\x04type\x18\x02 \x01(\tR\x04type\x12\x1a\n" +
+	"\bnullable\x18\x03 \x01(\bR\bnullable\x12#\n" +
+	"\rdefault_value\x18\x04 \x01(\tR\fdefaultValue\x12\x18\n" +
+	"\acomment\x18\x05 \x01(\tR\acomment\"j\n" +
+	"\fIndexCatalog\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12\x18\n" +
+	"\aprimary\x18\x02 \x01(\bR\aprimary\x12\x16\n" +
+	"\x06unique\x18\x03 \x01(\bR\x06unique\x12\x14\n" +
+	"\x05parts\x18\x04 \x03(\tR\x05parts\"\xad\x02\n" +
 	"\x12PullSchemaResponse\x12\x1a\n" +
 	"\bdatabase\x18\x01 \x01(\tR\bdatabase\x12\x12\n" +
 	"\x04type\x18\x02 \x01(\tR\x04type\x12 \n" +
@@ -2669,7 +3050,10 @@ const file_tern_proto_rawDesc = "" +
 	"\x12CHANGE_TYPE_CREATE\x10\x01\x12\x15\n" +
 	"\x11CHANGE_TYPE_ALTER\x10\x02\x12\x14\n" +
 	"\x10CHANGE_TYPE_DROP\x10\x03\x12\x17\n" +
-	"\x13CHANGE_TYPE_VSCHEMA\x10\x042\x9f\a\n" +
+	"\x13CHANGE_TYPE_VSCHEMA\x10\x04*T\n" +
+	"\x11PullCatalogDetail\x12\x1d\n" +
+	"\x19PULL_CATALOG_DETAIL_BASIC\x10\x00\x12 \n" +
+	"\x1cPULL_CATALOG_DETAIL_DETAILED\x10\x012\x9f\a\n" +
 	"\x04Tern\x12a\n" +
 	"\n" +
 	"PullSchema\x12\x1a.tern.v1.PullSchemaRequest\x1a\x1b.tern.v1.PullSchemaResponse\"\x1a\x82\xd3\xe4\x93\x02\x14:\x01*\"\x0f/v1/pull-schema\x12H\n" +
@@ -2700,106 +3084,118 @@ func file_tern_proto_rawDescGZIP() []byte {
 	return file_tern_proto_rawDescData
 }
 
-var file_tern_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
-var file_tern_proto_msgTypes = make([]protoimpl.MessageInfo, 40)
+var file_tern_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
+var file_tern_proto_msgTypes = make([]protoimpl.MessageInfo, 45)
 var file_tern_proto_goTypes = []any{
 	(Engine)(0),                // 0: tern.v1.Engine
 	(State)(0),                 // 1: tern.v1.State
 	(ChangeType)(0),            // 2: tern.v1.ChangeType
-	(*SchemaFiles)(nil),        // 3: tern.v1.SchemaFiles
-	(*PullSchemaRequest)(nil),  // 4: tern.v1.PullSchemaRequest
-	(*PulledNamespace)(nil),    // 5: tern.v1.PulledNamespace
-	(*PullSchemaResponse)(nil), // 6: tern.v1.PullSchemaResponse
-	(*PlanRequest)(nil),        // 7: tern.v1.PlanRequest
-	(*TableChange)(nil),        // 8: tern.v1.TableChange
-	(*SchemaChange)(nil),       // 9: tern.v1.SchemaChange
-	(*LintViolation)(nil),      // 10: tern.v1.LintViolation
-	(*ShardPlan)(nil),          // 11: tern.v1.ShardPlan
-	(*PlanResponse)(nil),       // 12: tern.v1.PlanResponse
-	(*ApplyRequest)(nil),       // 13: tern.v1.ApplyRequest
-	(*ApplyResponse)(nil),      // 14: tern.v1.ApplyResponse
-	(*ProgressRequest)(nil),    // 15: tern.v1.ProgressRequest
-	(*ShardProgress)(nil),      // 16: tern.v1.ShardProgress
-	(*TableProgress)(nil),      // 17: tern.v1.TableProgress
-	(*ProgressResponse)(nil),   // 18: tern.v1.ProgressResponse
-	(*CutoverRequest)(nil),     // 19: tern.v1.CutoverRequest
-	(*CutoverResponse)(nil),    // 20: tern.v1.CutoverResponse
-	(*RevertRequest)(nil),      // 21: tern.v1.RevertRequest
-	(*RevertResponse)(nil),     // 22: tern.v1.RevertResponse
-	(*SkipRevertRequest)(nil),  // 23: tern.v1.SkipRevertRequest
-	(*SkipRevertResponse)(nil), // 24: tern.v1.SkipRevertResponse
-	(*HealthRequest)(nil),      // 25: tern.v1.HealthRequest
-	(*HealthResponse)(nil),     // 26: tern.v1.HealthResponse
-	(*StopRequest)(nil),        // 27: tern.v1.StopRequest
-	(*StopResponse)(nil),       // 28: tern.v1.StopResponse
-	(*StartRequest)(nil),       // 29: tern.v1.StartRequest
-	(*StartResponse)(nil),      // 30: tern.v1.StartResponse
-	(*VolumeRequest)(nil),      // 31: tern.v1.VolumeRequest
-	(*VolumeResponse)(nil),     // 32: tern.v1.VolumeResponse
-	nil,                        // 33: tern.v1.SchemaFiles.FilesEntry
-	nil,                        // 34: tern.v1.PulledNamespace.TablesEntry
-	nil,                        // 35: tern.v1.PulledNamespace.ArtifactsEntry
-	nil,                        // 36: tern.v1.PullSchemaResponse.NamespacesEntry
-	nil,                        // 37: tern.v1.PlanRequest.SchemaFilesEntry
-	nil,                        // 38: tern.v1.SchemaChange.MetadataEntry
-	nil,                        // 39: tern.v1.SchemaChange.OriginalFilesEntry
-	nil,                        // 40: tern.v1.ApplyRequest.OptionsEntry
-	nil,                        // 41: tern.v1.ApplyRequest.SchemaFilesEntry
-	nil,                        // 42: tern.v1.ProgressResponse.MetadataEntry
+	(PullCatalogDetail)(0),     // 3: tern.v1.PullCatalogDetail
+	(*SchemaFiles)(nil),        // 4: tern.v1.SchemaFiles
+	(*PullSchemaRequest)(nil),  // 5: tern.v1.PullSchemaRequest
+	(*PulledNamespace)(nil),    // 6: tern.v1.PulledNamespace
+	(*NamespaceCatalog)(nil),   // 7: tern.v1.NamespaceCatalog
+	(*TableCatalog)(nil),       // 8: tern.v1.TableCatalog
+	(*ColumnCatalog)(nil),      // 9: tern.v1.ColumnCatalog
+	(*IndexCatalog)(nil),       // 10: tern.v1.IndexCatalog
+	(*PullSchemaResponse)(nil), // 11: tern.v1.PullSchemaResponse
+	(*PlanRequest)(nil),        // 12: tern.v1.PlanRequest
+	(*TableChange)(nil),        // 13: tern.v1.TableChange
+	(*SchemaChange)(nil),       // 14: tern.v1.SchemaChange
+	(*LintViolation)(nil),      // 15: tern.v1.LintViolation
+	(*ShardPlan)(nil),          // 16: tern.v1.ShardPlan
+	(*PlanResponse)(nil),       // 17: tern.v1.PlanResponse
+	(*ApplyRequest)(nil),       // 18: tern.v1.ApplyRequest
+	(*ApplyResponse)(nil),      // 19: tern.v1.ApplyResponse
+	(*ProgressRequest)(nil),    // 20: tern.v1.ProgressRequest
+	(*ShardProgress)(nil),      // 21: tern.v1.ShardProgress
+	(*TableProgress)(nil),      // 22: tern.v1.TableProgress
+	(*ProgressResponse)(nil),   // 23: tern.v1.ProgressResponse
+	(*CutoverRequest)(nil),     // 24: tern.v1.CutoverRequest
+	(*CutoverResponse)(nil),    // 25: tern.v1.CutoverResponse
+	(*RevertRequest)(nil),      // 26: tern.v1.RevertRequest
+	(*RevertResponse)(nil),     // 27: tern.v1.RevertResponse
+	(*SkipRevertRequest)(nil),  // 28: tern.v1.SkipRevertRequest
+	(*SkipRevertResponse)(nil), // 29: tern.v1.SkipRevertResponse
+	(*HealthRequest)(nil),      // 30: tern.v1.HealthRequest
+	(*HealthResponse)(nil),     // 31: tern.v1.HealthResponse
+	(*StopRequest)(nil),        // 32: tern.v1.StopRequest
+	(*StopResponse)(nil),       // 33: tern.v1.StopResponse
+	(*StartRequest)(nil),       // 34: tern.v1.StartRequest
+	(*StartResponse)(nil),      // 35: tern.v1.StartResponse
+	(*VolumeRequest)(nil),      // 36: tern.v1.VolumeRequest
+	(*VolumeResponse)(nil),     // 37: tern.v1.VolumeResponse
+	nil,                        // 38: tern.v1.SchemaFiles.FilesEntry
+	nil,                        // 39: tern.v1.PulledNamespace.TablesEntry
+	nil,                        // 40: tern.v1.PulledNamespace.ArtifactsEntry
+	nil,                        // 41: tern.v1.PulledNamespace.TableCatalogEntry
+	nil,                        // 42: tern.v1.PullSchemaResponse.NamespacesEntry
+	nil,                        // 43: tern.v1.PlanRequest.SchemaFilesEntry
+	nil,                        // 44: tern.v1.SchemaChange.MetadataEntry
+	nil,                        // 45: tern.v1.SchemaChange.OriginalFilesEntry
+	nil,                        // 46: tern.v1.ApplyRequest.OptionsEntry
+	nil,                        // 47: tern.v1.ApplyRequest.SchemaFilesEntry
+	nil,                        // 48: tern.v1.ProgressResponse.MetadataEntry
 }
 var file_tern_proto_depIdxs = []int32{
-	33, // 0: tern.v1.SchemaFiles.files:type_name -> tern.v1.SchemaFiles.FilesEntry
-	34, // 1: tern.v1.PulledNamespace.tables:type_name -> tern.v1.PulledNamespace.TablesEntry
-	35, // 2: tern.v1.PulledNamespace.artifacts:type_name -> tern.v1.PulledNamespace.ArtifactsEntry
-	36, // 3: tern.v1.PullSchemaResponse.namespaces:type_name -> tern.v1.PullSchemaResponse.NamespacesEntry
-	37, // 4: tern.v1.PlanRequest.schema_files:type_name -> tern.v1.PlanRequest.SchemaFilesEntry
-	2,  // 5: tern.v1.TableChange.change_type:type_name -> tern.v1.ChangeType
-	8,  // 6: tern.v1.SchemaChange.table_changes:type_name -> tern.v1.TableChange
-	38, // 7: tern.v1.SchemaChange.metadata:type_name -> tern.v1.SchemaChange.MetadataEntry
-	39, // 8: tern.v1.SchemaChange.original_files:type_name -> tern.v1.SchemaChange.OriginalFilesEntry
-	0,  // 9: tern.v1.PlanResponse.engine:type_name -> tern.v1.Engine
-	9,  // 10: tern.v1.PlanResponse.changes:type_name -> tern.v1.SchemaChange
-	10, // 11: tern.v1.PlanResponse.lint_violations:type_name -> tern.v1.LintViolation
-	11, // 12: tern.v1.PlanResponse.shards:type_name -> tern.v1.ShardPlan
-	40, // 13: tern.v1.ApplyRequest.options:type_name -> tern.v1.ApplyRequest.OptionsEntry
-	41, // 14: tern.v1.ApplyRequest.schema_files:type_name -> tern.v1.ApplyRequest.SchemaFilesEntry
-	8,  // 15: tern.v1.ApplyRequest.ddl_changes:type_name -> tern.v1.TableChange
-	16, // 16: tern.v1.TableProgress.shards:type_name -> tern.v1.ShardProgress
-	2,  // 17: tern.v1.TableProgress.change_type:type_name -> tern.v1.ChangeType
-	1,  // 18: tern.v1.ProgressResponse.state:type_name -> tern.v1.State
-	0,  // 19: tern.v1.ProgressResponse.engine:type_name -> tern.v1.Engine
-	17, // 20: tern.v1.ProgressResponse.tables:type_name -> tern.v1.TableProgress
-	42, // 21: tern.v1.ProgressResponse.metadata:type_name -> tern.v1.ProgressResponse.MetadataEntry
-	5,  // 22: tern.v1.PullSchemaResponse.NamespacesEntry.value:type_name -> tern.v1.PulledNamespace
-	3,  // 23: tern.v1.PlanRequest.SchemaFilesEntry.value:type_name -> tern.v1.SchemaFiles
-	3,  // 24: tern.v1.ApplyRequest.SchemaFilesEntry.value:type_name -> tern.v1.SchemaFiles
-	4,  // 25: tern.v1.Tern.PullSchema:input_type -> tern.v1.PullSchemaRequest
-	7,  // 26: tern.v1.Tern.Plan:input_type -> tern.v1.PlanRequest
-	13, // 27: tern.v1.Tern.Apply:input_type -> tern.v1.ApplyRequest
-	15, // 28: tern.v1.Tern.Progress:input_type -> tern.v1.ProgressRequest
-	19, // 29: tern.v1.Tern.Cutover:input_type -> tern.v1.CutoverRequest
-	21, // 30: tern.v1.Tern.Revert:input_type -> tern.v1.RevertRequest
-	23, // 31: tern.v1.Tern.SkipRevert:input_type -> tern.v1.SkipRevertRequest
-	25, // 32: tern.v1.Tern.Health:input_type -> tern.v1.HealthRequest
-	27, // 33: tern.v1.Tern.Stop:input_type -> tern.v1.StopRequest
-	29, // 34: tern.v1.Tern.Start:input_type -> tern.v1.StartRequest
-	31, // 35: tern.v1.Tern.Volume:input_type -> tern.v1.VolumeRequest
-	6,  // 36: tern.v1.Tern.PullSchema:output_type -> tern.v1.PullSchemaResponse
-	12, // 37: tern.v1.Tern.Plan:output_type -> tern.v1.PlanResponse
-	14, // 38: tern.v1.Tern.Apply:output_type -> tern.v1.ApplyResponse
-	18, // 39: tern.v1.Tern.Progress:output_type -> tern.v1.ProgressResponse
-	20, // 40: tern.v1.Tern.Cutover:output_type -> tern.v1.CutoverResponse
-	22, // 41: tern.v1.Tern.Revert:output_type -> tern.v1.RevertResponse
-	24, // 42: tern.v1.Tern.SkipRevert:output_type -> tern.v1.SkipRevertResponse
-	26, // 43: tern.v1.Tern.Health:output_type -> tern.v1.HealthResponse
-	28, // 44: tern.v1.Tern.Stop:output_type -> tern.v1.StopResponse
-	30, // 45: tern.v1.Tern.Start:output_type -> tern.v1.StartResponse
-	32, // 46: tern.v1.Tern.Volume:output_type -> tern.v1.VolumeResponse
-	36, // [36:47] is the sub-list for method output_type
-	25, // [25:36] is the sub-list for method input_type
-	25, // [25:25] is the sub-list for extension type_name
-	25, // [25:25] is the sub-list for extension extendee
-	0,  // [0:25] is the sub-list for field type_name
+	38, // 0: tern.v1.SchemaFiles.files:type_name -> tern.v1.SchemaFiles.FilesEntry
+	3,  // 1: tern.v1.PullSchemaRequest.catalog_detail:type_name -> tern.v1.PullCatalogDetail
+	39, // 2: tern.v1.PulledNamespace.tables:type_name -> tern.v1.PulledNamespace.TablesEntry
+	40, // 3: tern.v1.PulledNamespace.artifacts:type_name -> tern.v1.PulledNamespace.ArtifactsEntry
+	7,  // 4: tern.v1.PulledNamespace.namespace_catalog:type_name -> tern.v1.NamespaceCatalog
+	41, // 5: tern.v1.PulledNamespace.table_catalog:type_name -> tern.v1.PulledNamespace.TableCatalogEntry
+	9,  // 6: tern.v1.TableCatalog.columns:type_name -> tern.v1.ColumnCatalog
+	10, // 7: tern.v1.TableCatalog.indexes:type_name -> tern.v1.IndexCatalog
+	42, // 8: tern.v1.PullSchemaResponse.namespaces:type_name -> tern.v1.PullSchemaResponse.NamespacesEntry
+	43, // 9: tern.v1.PlanRequest.schema_files:type_name -> tern.v1.PlanRequest.SchemaFilesEntry
+	2,  // 10: tern.v1.TableChange.change_type:type_name -> tern.v1.ChangeType
+	13, // 11: tern.v1.SchemaChange.table_changes:type_name -> tern.v1.TableChange
+	44, // 12: tern.v1.SchemaChange.metadata:type_name -> tern.v1.SchemaChange.MetadataEntry
+	45, // 13: tern.v1.SchemaChange.original_files:type_name -> tern.v1.SchemaChange.OriginalFilesEntry
+	0,  // 14: tern.v1.PlanResponse.engine:type_name -> tern.v1.Engine
+	14, // 15: tern.v1.PlanResponse.changes:type_name -> tern.v1.SchemaChange
+	15, // 16: tern.v1.PlanResponse.lint_violations:type_name -> tern.v1.LintViolation
+	16, // 17: tern.v1.PlanResponse.shards:type_name -> tern.v1.ShardPlan
+	46, // 18: tern.v1.ApplyRequest.options:type_name -> tern.v1.ApplyRequest.OptionsEntry
+	47, // 19: tern.v1.ApplyRequest.schema_files:type_name -> tern.v1.ApplyRequest.SchemaFilesEntry
+	13, // 20: tern.v1.ApplyRequest.ddl_changes:type_name -> tern.v1.TableChange
+	21, // 21: tern.v1.TableProgress.shards:type_name -> tern.v1.ShardProgress
+	2,  // 22: tern.v1.TableProgress.change_type:type_name -> tern.v1.ChangeType
+	1,  // 23: tern.v1.ProgressResponse.state:type_name -> tern.v1.State
+	0,  // 24: tern.v1.ProgressResponse.engine:type_name -> tern.v1.Engine
+	22, // 25: tern.v1.ProgressResponse.tables:type_name -> tern.v1.TableProgress
+	48, // 26: tern.v1.ProgressResponse.metadata:type_name -> tern.v1.ProgressResponse.MetadataEntry
+	8,  // 27: tern.v1.PulledNamespace.TableCatalogEntry.value:type_name -> tern.v1.TableCatalog
+	6,  // 28: tern.v1.PullSchemaResponse.NamespacesEntry.value:type_name -> tern.v1.PulledNamespace
+	4,  // 29: tern.v1.PlanRequest.SchemaFilesEntry.value:type_name -> tern.v1.SchemaFiles
+	4,  // 30: tern.v1.ApplyRequest.SchemaFilesEntry.value:type_name -> tern.v1.SchemaFiles
+	5,  // 31: tern.v1.Tern.PullSchema:input_type -> tern.v1.PullSchemaRequest
+	12, // 32: tern.v1.Tern.Plan:input_type -> tern.v1.PlanRequest
+	18, // 33: tern.v1.Tern.Apply:input_type -> tern.v1.ApplyRequest
+	20, // 34: tern.v1.Tern.Progress:input_type -> tern.v1.ProgressRequest
+	24, // 35: tern.v1.Tern.Cutover:input_type -> tern.v1.CutoverRequest
+	26, // 36: tern.v1.Tern.Revert:input_type -> tern.v1.RevertRequest
+	28, // 37: tern.v1.Tern.SkipRevert:input_type -> tern.v1.SkipRevertRequest
+	30, // 38: tern.v1.Tern.Health:input_type -> tern.v1.HealthRequest
+	32, // 39: tern.v1.Tern.Stop:input_type -> tern.v1.StopRequest
+	34, // 40: tern.v1.Tern.Start:input_type -> tern.v1.StartRequest
+	36, // 41: tern.v1.Tern.Volume:input_type -> tern.v1.VolumeRequest
+	11, // 42: tern.v1.Tern.PullSchema:output_type -> tern.v1.PullSchemaResponse
+	17, // 43: tern.v1.Tern.Plan:output_type -> tern.v1.PlanResponse
+	19, // 44: tern.v1.Tern.Apply:output_type -> tern.v1.ApplyResponse
+	23, // 45: tern.v1.Tern.Progress:output_type -> tern.v1.ProgressResponse
+	25, // 46: tern.v1.Tern.Cutover:output_type -> tern.v1.CutoverResponse
+	27, // 47: tern.v1.Tern.Revert:output_type -> tern.v1.RevertResponse
+	29, // 48: tern.v1.Tern.SkipRevert:output_type -> tern.v1.SkipRevertResponse
+	31, // 49: tern.v1.Tern.Health:output_type -> tern.v1.HealthResponse
+	33, // 50: tern.v1.Tern.Stop:output_type -> tern.v1.StopResponse
+	35, // 51: tern.v1.Tern.Start:output_type -> tern.v1.StartResponse
+	37, // 52: tern.v1.Tern.Volume:output_type -> tern.v1.VolumeResponse
+	42, // [42:53] is the sub-list for method output_type
+	31, // [31:42] is the sub-list for method input_type
+	31, // [31:31] is the sub-list for extension type_name
+	31, // [31:31] is the sub-list for extension extendee
+	0,  // [0:31] is the sub-list for field type_name
 }
 
 func init() { file_tern_proto_init() }
@@ -2812,8 +3208,8 @@ func file_tern_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_tern_proto_rawDesc), len(file_tern_proto_rawDesc)),
-			NumEnums:      3,
-			NumMessages:   40,
+			NumEnums:      4,
+			NumMessages:   45,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/pkg/tern/local_client.go
+++ b/pkg/tern/local_client.go
@@ -87,6 +87,7 @@ package tern
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"log/slog"
 	"maps"
@@ -490,6 +491,10 @@ func (c *LocalClient) pullSchemaNamespace(ctx context.Context, req *ternv1.PullS
 		}
 		pulledTables[tbl.Name] = content
 	}
+	catalog, err := c.pullNamespaceCatalog(ctx, db, namespace, pulledTables, req.GetCatalogDetail())
+	if err != nil {
+		return nil, err
+	}
 
 	c.logger.Info("LocalClient.PullSchema: loaded live schema",
 		"database", c.config.Database,
@@ -502,10 +507,186 @@ func (c *LocalClient) pullSchemaNamespace(ctx context.Context, req *ternv1.PullS
 		Type:        c.config.Type,
 		Environment: req.Environment,
 		Namespaces: map[string]*ternv1.PulledNamespace{
-			namespace: {Tables: pulledTables},
+			namespace: {
+				Tables:           pulledTables,
+				NamespaceCatalog: catalog.namespace,
+				TableCatalog:     catalog.tables,
+			},
 		},
 		TableCount: int32(len(tables)),
 	}, nil
+}
+
+type pulledCatalog struct {
+	namespace *ternv1.NamespaceCatalog
+	tables    map[string]*ternv1.TableCatalog
+}
+
+func (c *LocalClient) pullNamespaceCatalog(ctx context.Context, db *sql.DB, namespace string, pulledTables map[string]string, catalogDetail ternv1.PullCatalogDetail) (*pulledCatalog, error) {
+	catalog := &pulledCatalog{
+		namespace: &ternv1.NamespaceCatalog{
+			Name:       namespace,
+			Engine:     c.config.Type,
+			TableCount: int32(len(pulledTables)),
+		},
+		tables: make(map[string]*ternv1.TableCatalog, len(pulledTables)),
+	}
+	if len(pulledTables) == 0 {
+		return catalog, nil
+	}
+	if err := c.loadTableCatalog(ctx, db, namespace, pulledTables, catalog.tables); err != nil {
+		return nil, err
+	}
+	if catalogDetail != ternv1.PullCatalogDetail_PULL_CATALOG_DETAIL_DETAILED {
+		return catalog, nil
+	}
+	if err := c.loadColumnCatalog(ctx, db, namespace, pulledTables, catalog.tables); err != nil {
+		return nil, err
+	}
+	if err := c.loadIndexCatalog(ctx, db, namespace, pulledTables, catalog.tables); err != nil {
+		return nil, err
+	}
+	return catalog, nil
+}
+
+func (c *LocalClient) loadTableCatalog(ctx context.Context, db *sql.DB, namespace string, pulledTables map[string]string, catalog map[string]*ternv1.TableCatalog) error {
+	rows, err := db.QueryContext(ctx, `
+		SELECT table_name, table_type, table_comment
+		FROM information_schema.tables
+		WHERE table_schema = ?
+		ORDER BY table_name`, namespace)
+	if err != nil {
+		return fmt.Errorf("load table catalog for database %s namespace %s: %w", c.config.Database, namespace, err)
+	}
+	defer utils.CloseAndLog(rows)
+
+	for rows.Next() {
+		var tableName, tableType, tableComment string
+		if err := rows.Scan(&tableName, &tableType, &tableComment); err != nil {
+			return fmt.Errorf("scan table catalog for database %s namespace %s: %w", c.config.Database, namespace, err)
+		}
+		if _, ok := pulledTables[tableName]; ok {
+			catalog[tableName] = &ternv1.TableCatalog{
+				Name:    tableName,
+				Kind:    normalizedTableKind(tableType),
+				Comment: tableComment,
+			}
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterate table catalog for database %s namespace %s: %w", c.config.Database, namespace, err)
+	}
+	return nil
+}
+
+func (c *LocalClient) loadColumnCatalog(ctx context.Context, db *sql.DB, namespace string, pulledTables map[string]string, catalog map[string]*ternv1.TableCatalog) error {
+	rows, err := db.QueryContext(ctx, `
+		SELECT table_name, column_name, column_type, is_nullable, column_default, column_comment
+		FROM information_schema.columns
+		WHERE table_schema = ?
+		ORDER BY table_name, ordinal_position`, namespace)
+	if err != nil {
+		return fmt.Errorf("load column catalog for database %s namespace %s: %w", c.config.Database, namespace, err)
+	}
+	defer utils.CloseAndLog(rows)
+
+	for rows.Next() {
+		var tableName, columnName, columnType, nullable, comment string
+		var defaultValue sql.NullString
+		if err := rows.Scan(&tableName, &columnName, &columnType, &nullable, &defaultValue, &comment); err != nil {
+			return fmt.Errorf("scan column catalog for database %s namespace %s: %w", c.config.Database, namespace, err)
+		}
+		if _, ok := pulledTables[tableName]; ok {
+			tableCatalog := ensurePulledTableCatalog(catalog, tableName)
+			column := &ternv1.ColumnCatalog{
+				Name:     columnName,
+				Type:     columnType,
+				Nullable: nullable == "YES",
+				Comment:  comment,
+			}
+			if defaultValue.Valid {
+				column.DefaultValue = defaultValue.String
+			}
+			tableCatalog.Columns = append(tableCatalog.Columns, column)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterate column catalog for database %s namespace %s: %w", c.config.Database, namespace, err)
+	}
+	return nil
+}
+
+func (c *LocalClient) loadIndexCatalog(ctx context.Context, db *sql.DB, namespace string, pulledTables map[string]string, catalog map[string]*ternv1.TableCatalog) error {
+	rows, err := db.QueryContext(ctx, `
+		SELECT table_name, index_name, non_unique, column_name, expression
+		FROM information_schema.statistics
+		WHERE table_schema = ?
+		ORDER BY table_name, index_name, seq_in_index`, namespace)
+	if err != nil {
+		return fmt.Errorf("load index catalog for database %s namespace %s: %w", c.config.Database, namespace, err)
+	}
+	defer utils.CloseAndLog(rows)
+
+	indexesByTable := make(map[string]map[string]*ternv1.IndexCatalog)
+	for rows.Next() {
+		var tableName, indexName string
+		var columnName, expression sql.NullString
+		var nonUnique int32
+		if err := rows.Scan(&tableName, &indexName, &nonUnique, &columnName, &expression); err != nil {
+			return fmt.Errorf("scan index catalog for database %s namespace %s: %w", c.config.Database, namespace, err)
+		}
+		if _, ok := pulledTables[tableName]; ok {
+			indexedValue := ""
+			switch {
+			case columnName.Valid:
+				indexedValue = columnName.String
+			case expression.Valid:
+				indexedValue = expression.String
+			default:
+				c.logger.Warn("LocalClient.PullSchema: skipping index part without column or expression", "database", c.config.Database, "namespace", namespace, "table", tableName, "index", indexName)
+				continue
+			}
+			tableCatalog := ensurePulledTableCatalog(catalog, tableName)
+			if indexesByTable[tableName] == nil {
+				indexesByTable[tableName] = make(map[string]*ternv1.IndexCatalog)
+			}
+			idx := indexesByTable[tableName][indexName]
+			if idx == nil {
+				idx = &ternv1.IndexCatalog{
+					Name:    indexName,
+					Primary: indexName == "PRIMARY",
+					Unique:  nonUnique == 0,
+				}
+				indexesByTable[tableName][indexName] = idx
+				tableCatalog.Indexes = append(tableCatalog.Indexes, idx)
+			}
+			idx.Parts = append(idx.Parts, indexedValue)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterate index catalog for database %s namespace %s: %w", c.config.Database, namespace, err)
+	}
+	return nil
+}
+
+func ensurePulledTableCatalog(catalog map[string]*ternv1.TableCatalog, tableName string) *ternv1.TableCatalog {
+	tableCatalog := catalog[tableName]
+	if tableCatalog == nil {
+		tableCatalog = &ternv1.TableCatalog{Name: tableName}
+		catalog[tableName] = tableCatalog
+	}
+	return tableCatalog
+}
+
+func normalizedTableKind(tableType string) string {
+	switch tableType {
+	case "BASE TABLE":
+		return "table"
+	case "VIEW":
+		return "view"
+	default:
+		return strings.ToLower(strings.ReplaceAll(tableType, " ", "_"))
+	}
 }
 
 func (c *LocalClient) pullResponseDatabase(req *ternv1.PullSchemaRequest) string {

--- a/pkg/tern/local_client_integration_test.go
+++ b/pkg/tern/local_client_integration_test.go
@@ -486,7 +486,7 @@ func TestLocalClient_PullSchemaLoadsLiveMySQLSchema(t *testing.T) {
 		_, cleanupErr = cleanupDB.ExecContext(cleanupCtx, "DROP TABLE IF EXISTS `pull_schema_users`, `pull_schema_users_archive_2026_06_12`")
 		assert.NoError(t, cleanupErr, "drop pull schema tables")
 	})
-	_, err = db.ExecContext(t.Context(), "CREATE TABLE `pull_schema_users` (`id` bigint unsigned NOT NULL AUTO_INCREMENT, `email` varchar(255) NOT NULL, PRIMARY KEY (`id`), UNIQUE KEY `idx_email` (`email`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci")
+	_, err = db.ExecContext(t.Context(), "CREATE TABLE `pull_schema_users` (`id` bigint unsigned NOT NULL AUTO_INCREMENT, `email` varchar(255) NOT NULL COMMENT 'login email', `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP, PRIMARY KEY (`id`), UNIQUE KEY `idx_email` (`email`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='users table'")
 	require.NoError(t, err, "create pull schema table")
 	_, err = db.ExecContext(t.Context(), "CREATE TABLE `pull_schema_users_archive_2026_06_12` (`id` bigint unsigned NOT NULL, PRIMARY KEY (`id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci")
 	require.NoError(t, err, "create archive table")
@@ -501,8 +501,9 @@ func TestLocalClient_PullSchemaLoadsLiveMySQLSchema(t *testing.T) {
 	defer utils.CloseAndLog(client)
 
 	resp, err := client.PullSchema(t.Context(), &ternv1.PullSchemaRequest{
-		Type:        storage.DatabaseTypeMySQL,
-		Environment: localClientTestEnvironment,
+		Type:          storage.DatabaseTypeMySQL,
+		Environment:   localClientTestEnvironment,
+		CatalogDetail: ternv1.PullCatalogDetail_PULL_CATALOG_DETAIL_DETAILED,
 	})
 
 	require.NoError(t, err, "pull schema")
@@ -511,12 +512,57 @@ func TestLocalClient_PullSchemaLoadsLiveMySQLSchema(t *testing.T) {
 	assert.Equal(t, storage.DatabaseTypeMySQL, resp.Type)
 	assert.Equal(t, localClientTestEnvironment, resp.Environment)
 	require.Contains(t, resp.Namespaces, "testdb")
-	ddl := resp.Namespaces["testdb"].Tables["pull_schema_users"]
+	pulledNamespace := resp.Namespaces["testdb"]
+	ddl := pulledNamespace.Tables["pull_schema_users"]
 	assert.Contains(t, ddl, "CREATE TABLE `pull_schema_users`")
 	assert.Contains(t, ddl, "`email` varchar(255) NOT NULL")
 	assert.NotContains(t, ddl, "AUTO_INCREMENT=")
 	assert.True(t, strings.HasSuffix(ddl, "\n"), "pulled schema file should end with a newline")
-	assert.NotContains(t, resp.Namespaces["testdb"].Tables, "pull_schema_users_archive_2026_06_12")
+	assert.NotContains(t, pulledNamespace.Tables, "pull_schema_users_archive_2026_06_12")
+	require.NotNil(t, pulledNamespace.NamespaceCatalog)
+	assert.Equal(t, "testdb", pulledNamespace.NamespaceCatalog.Name)
+	assert.Equal(t, storage.DatabaseTypeMySQL, pulledNamespace.NamespaceCatalog.Engine)
+	assert.Equal(t, int32(len(pulledNamespace.Tables)), pulledNamespace.NamespaceCatalog.TableCount)
+	require.Contains(t, pulledNamespace.TableCatalog, "pull_schema_users")
+	tableCatalog := pulledNamespace.TableCatalog["pull_schema_users"]
+	assert.Equal(t, "pull_schema_users", tableCatalog.Name)
+	assert.Equal(t, "table", tableCatalog.Kind)
+	assert.Equal(t, "users table", tableCatalog.Comment)
+	require.Len(t, tableCatalog.Columns, 3)
+	assert.Equal(t, "id", tableCatalog.Columns[0].Name)
+	assert.Equal(t, "bigint unsigned", tableCatalog.Columns[0].Type)
+	assert.False(t, tableCatalog.Columns[0].Nullable)
+	assert.Equal(t, "email", tableCatalog.Columns[1].Name)
+	assert.Equal(t, "varchar(255)", tableCatalog.Columns[1].Type)
+	assert.False(t, tableCatalog.Columns[1].Nullable)
+	assert.Equal(t, "login email", tableCatalog.Columns[1].Comment)
+	assert.Equal(t, "created_at", tableCatalog.Columns[2].Name)
+	assert.Equal(t, "timestamp", tableCatalog.Columns[2].Type)
+	assert.True(t, tableCatalog.Columns[2].Nullable)
+	assert.Equal(t, "CURRENT_TIMESTAMP", tableCatalog.Columns[2].DefaultValue)
+	require.Len(t, tableCatalog.Indexes, 2)
+	indexesByName := make(map[string]*ternv1.IndexCatalog, len(tableCatalog.Indexes))
+	for _, index := range tableCatalog.Indexes {
+		indexesByName[index.Name] = index
+	}
+	require.Contains(t, indexesByName, "PRIMARY")
+	assert.True(t, indexesByName["PRIMARY"].Primary)
+	assert.True(t, indexesByName["PRIMARY"].Unique)
+	assert.Equal(t, []string{"id"}, indexesByName["PRIMARY"].Parts)
+	require.Contains(t, indexesByName, "idx_email")
+	assert.False(t, indexesByName["idx_email"].Primary)
+	assert.True(t, indexesByName["idx_email"].Unique)
+	assert.Equal(t, []string{"email"}, indexesByName["idx_email"].Parts)
+
+	basicResp, err := client.PullSchema(t.Context(), &ternv1.PullSchemaRequest{
+		Type:        storage.DatabaseTypeMySQL,
+		Environment: localClientTestEnvironment,
+	})
+	require.NoError(t, err, "pull schema with basic catalog detail")
+	basicCatalog := basicResp.Namespaces["testdb"].TableCatalog["pull_schema_users"]
+	require.NotNil(t, basicCatalog)
+	assert.Empty(t, basicCatalog.Columns)
+	assert.Empty(t, basicCatalog.Indexes)
 }
 
 // Pulling all live MySQL namespaces discovers application schemas while


### PR DESCRIPTION
Adds structured catalog data to the live schema pull response so callers can consume table, column, and index metadata without parsing canonical DDL. The response shape stays engine-agnostic: canonical definitions remain in `namespaces[].tables`, engine extras such as VSchema remain in `artifacts`, and structured metadata lives under `namespace_catalog` and `table_catalog`.

```diagram
╭──────────────╮
│ pull request │
╰──────┬───────╯
       ▼
╭──────────────────────────────╮
│ PullSchemaResponse namespace │
│  tables: canonical DDL       │
│  artifacts: engine extras    │
│  namespace_catalog: summary  │
│  table_catalog: metadata     │
│    indexes[].parts           │
╰──────────────────────────────╯
```

The first implementation populates MySQL catalog data from `information_schema`; future Vitess and Postgres pull implementations can fill the same generic fields without changing callers. Onboarding continues to materialize only tables and artifacts.

### Catalog source coverage

This PR starts with stable metadata that is useful for onboarding and schema-understanding callers:

- `information_schema.TABLES`: table/view kind and table comment.
- `information_schema.COLUMNS`: column type, nullability, default, and `COLUMN_COMMENT`.
- `information_schema.STATISTICS`: index name, uniqueness, primary flag, and ordered index `parts`.

The broader detailed-catalog shape can grow without changing the pull/onboard contract. Follow-up fields should stay explicit rather than overloading the current structures:

- Approximate row-count and size fields from `information_schema.TABLES` should live under a table-statistics object with freshness/estimate caveats. They should remain detailed-only because they are approximate and can be misleading.
- `TABLE_CONSTRAINTS`, `KEY_COLUMN_USAGE`, and `REFERENTIAL_CONSTRAINTS` should become constraint/foreign-key catalog fields rather than being inferred from indexes alone.
- `VIEWS` should become view catalog data once pull has a canonical view representation; it should not be mixed into `tables` unless the declarative view format is supported by plan/apply.

### Basic vs detailed catalog data

`catalog_detail` controls only the structured catalog depth. It does not change the canonical DDL returned in `tables`, and callers do not need to set it for onboarding/export flows.

- **Basic**: default when `catalog_detail` is omitted or set to `"basic"`. Returns canonical DDL, artifacts, `namespace_catalog`, and one `table_catalog` entry per pulled table with stable table-level fields such as `name`, `kind`, and `comment`.
- **Detailed**: opt-in with `"catalog_detail": "detailed"`. Includes everything from basic plus detailed table metadata currently populated for MySQL: `columns` and `indexes`. `indexes[].parts` is intentionally generic: each part may be a column name or an engine-specific expression.

### Payload examples

Default/basic pull:

```json
{
  "database": "app",
  "environment": "production",
  "type": "mysql"
}
```

```json
{
  "database": "app",
  "environment": "production",
  "type": "mysql",
  "table_count": 1,
  "namespaces": {
    "app": {
      "tables": {
        "users": "CREATE TABLE `users` (\n  `id` bigint unsigned NOT NULL AUTO_INCREMENT,\n  `email` varchar(255) NOT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `idx_email` (`email`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci\n"
      },
      "namespace_catalog": {
        "name": "app",
        "engine": "mysql",
        "table_count": 1
      },
      "table_catalog": {
        "users": {
          "name": "users",
          "kind": "table"
        }
      }
    }
  }
}
```

Detailed pull:

```json
{
  "database": "app",
  "environment": "production",
  "type": "mysql",
  "catalog_detail": "detailed",
  "namespaces": ["app"]
}
```

```json
{
  "database": "app",
  "environment": "production",
  "type": "mysql",
  "table_count": 1,
  "namespaces": {
    "app": {
      "tables": {
        "users": "CREATE TABLE `users` (\n  `id` bigint unsigned NOT NULL AUTO_INCREMENT,\n  `email` varchar(255) NOT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `idx_email` (`email`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci\n"
      },
      "namespace_catalog": {
        "name": "app",
        "engine": "mysql",
        "table_count": 1
      },
      "table_catalog": {
        "users": {
          "name": "users",
          "kind": "table",
          "columns": [
            {"name": "id", "type": "bigint unsigned", "nullable": false},
            {"name": "email", "type": "varchar(255)", "nullable": false}
          ],
          "indexes": [
            {"name": "PRIMARY", "primary": true, "unique": true, "parts": ["id"]},
            {"name": "idx_email", "unique": true, "parts": ["email"]}
          ]
        }
      }
    }
  }
}
```

Generated with Amp

