### PR TITLE
fix(api): allow a target_resolver data plane without databases

### DIFF
--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -383,6 +383,12 @@ func (c TargetResolverConfig) Configured() bool {
 	return len(c.Targets) > 0
 }
 
+// Enabled reports whether any target-resolver backend is configured (static
+// inventory or Etre). New backends are added here so callers stay correct.
+func (c TargetResolverConfig) Enabled() bool {
+	return c.Configured() || c.Etre.Configured()
+}
+
 // StaticInventory returns the static inventory config for NewStaticResolver.
 func (c TargetResolverConfig) StaticInventory() inventory.StaticConfig {
 	return inventory.StaticConfig{Targets: c.Targets}
@@ -671,11 +677,12 @@ func (c *ServerConfig) Validate() error {
 		return err
 	}
 
-	// The database registry is required in both local mode and gRPC mode:
-	// local environments provide DSNs, while remote environments provide the
-	// server-owned target/deployment route.
-	if len(c.Databases) == 0 {
-		return fmt.Errorf("databases is required")
+	// The database registry is required for the control plane and for a
+	// single-database data plane. A data plane configured with a target_resolver
+	// resolves opaque targets dynamically and has no database registry, so it is
+	// exempt.
+	if len(c.Databases) == 0 && !c.TargetResolver.Enabled() {
+		return fmt.Errorf("databases or target_resolver is required")
 	}
 
 	if err := validateUniqueNames("environment_order", c.EnvironmentOrder); err != nil {

--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 
+	"github.com/block/schemabot/pkg/inventory"
 	"github.com/block/schemabot/pkg/pendingdrops"
 	"github.com/block/schemabot/pkg/routing"
 	"github.com/block/schemabot/pkg/storage"
@@ -265,6 +266,39 @@ func TestServerConfig_Validate(t *testing.T) {
 				TernDeployments: TernConfig{},
 			},
 			wantErr: true,
+		},
+		{
+			// A data plane configured with a target_resolver resolves targets
+			// dynamically and needs no database registry.
+			name: "etre target_resolver without databases is valid",
+			cfg: ServerConfig{
+				TargetResolver: TargetResolverConfig{
+					Etre: EtreConfig{
+						Addr:        "http://etre:8080",
+						EntityType:  "aurora_cluster",
+						TargetLabel: "dsid",
+						HostField:   "writer_endpoint",
+						Credentials: EtreCredentialsConfig{
+							Username:    "spirit",
+							PasswordRef: "env:DDL_PASSWORD",
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			// The static-inventory backend is also exempt from the databases
+			// requirement.
+			name: "static target_resolver without databases is valid",
+			cfg: ServerConfig{
+				TargetResolver: TargetResolverConfig{
+					Targets: map[string]inventory.StaticTarget{
+						"dsid-orders-prod": {DatabaseType: "mysql", DSN: "root@tcp(localhost:3306)/"},
+					},
+				},
+			},
+			wantErr: false,
 		},
 		{
 			name: "deployment with no environments",


### PR DESCRIPTION
## Why this matters

A data plane configured with a `target_resolver` resolves opaque targets dynamically and has **no `databases` registry** — but config validation required one, so `serve --grpc` in resolver mode failed to load its config at startup (`invalid config: databases is required`). The resolver wiring was unit-tested at the `buildGRPCTernClient` layer, which bypasses `ServerConfig.Validate()`, so this only surfaced running the full server (caught by the k8s etre e2e).

## What it does

`databases` is now required **only when no `target_resolver` is configured** (static targets or etre). The control plane and single-database data plane still require it; a resolver-mode data plane is exempt. Adds a validation test for the exemption.

*Opened by Claude (Opus 4.8, 1M context).*