### PR TITLE
fix(inventory): default the etre client's HTTP client

### DIFF
--- a/pkg/etre/etre.go
+++ b/pkg/etre/etre.go
@@ -58,10 +58,16 @@ func New(cfg Config) (*Client, error) {
 	if strings.TrimSpace(cfg.EntityType) == "" {
 		return nil, fmt.Errorf("etre entity type is required")
 	}
+	// The Etre client does not default a nil HTTP client and would panic on the
+	// first request, so default it here.
+	httpClient := cfg.HTTPClient
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
 	entities := etre.NewEntityClientWithConfig(etre.EntityClientConfig{
 		EntityType: cfg.EntityType,
 		Addr:       cfg.Addr,
-		HTTPClient: cfg.HTTPClient,
+		HTTPClient: httpClient,
 		Retry:      cfg.Retry,
 	})
 	return newClient(entities, cfg.EntityType, cfg.Logger), nil

--- a/pkg/etre/etre_test.go
+++ b/pkg/etre/etre_test.go
@@ -3,12 +3,32 @@ package etre
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/square/etre"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// New must produce a usable client when no HTTPClient is configured: the
+// underlying Etre client does not default a nil HTTP client and would panic on
+// the first request. This drives the real client over HTTP, not the mock.
+func TestNewQueriesOverRealHTTPClient(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[{"name":"orders","host":"orders.example:3306"}]`))
+	}))
+	defer srv.Close()
+
+	c, err := New(Config{Addr: srv.URL, EntityType: "cluster"})
+	require.NoError(t, err)
+
+	got, err := c.QueryOne(t.Context(), map[string]string{"name": "orders"})
+	require.NoError(t, err)
+	assert.Equal(t, "orders.example:3306", StringField(got, "host"))
+}
 
 // mockClient builds an etre.MockEntityClient (shipped by the library) that
 // records the query it received and returns the configured result.


### PR DESCRIPTION
## Why this matters

`etre.New` passed the configured HTTP client straight to the underlying Etre client, which does **not** default a nil one — so a resolver built without an explicit HTTP client hit a nil-pointer dereference (`SIGSEGV`) on the *first* query. The unit tests used the library's mock entity client, which bypasses the real HTTP path entirely, so the panic only appeared against a real Etre server (caught by the k8s etre e2e).

## What it does

Default the HTTP client to `http.DefaultClient` when none is configured. Adds an `httptest`-backed test that drives a real client through `New` (the mock-based tests couldn't have caught this).

*Opened by Claude (Opus 4.8, 1M context).*