### PR TITLE
fix(tern): route Spirit stop through apply owner

### DIFF
--- a/e2e/k8s/k8s_test.go
+++ b/e2e/k8s/k8s_test.go
@@ -634,6 +634,22 @@ func waitForDataPlaneProgress(t *testing.T, client ternv1.TernClient, applyID st
 		})
 }
 
+func waitForDataPlaneHealthRPC(t *testing.T, client ternv1.TernClient) {
+	t.Helper()
+
+	var lastErr error
+	testutil.Poll(t, testutil.PollDeadline, testutil.PollInterval,
+		func() bool {
+			ctx, cancel := context.WithTimeout(t.Context(), testutil.ProgressTimeout)
+			_, lastErr = client.Health(ctx, &ternv1.HealthRequest{})
+			cancel()
+			return lastErr == nil
+		},
+		func() string {
+			return fmt.Sprintf("timeout waiting for data-plane gRPC health: last_err=%v", lastErr)
+		})
+}
+
 func waitForControlPlaneStartControlRequestCompleted(t *testing.T, applyID string) {
 	t.Helper()
 	waitForControlPlaneControlRequestCompleted(t, applyID, storage.ControlOperationStart)
@@ -697,6 +713,60 @@ func TestK8s_ProgressStableAcrossDataPlaneReplicas(t *testing.T) {
 
 	testutil.WaitForState(t, fixture.Endpoint, fixture.ApplyID, state.Apply.Completed, 3*time.Minute)
 	waitForIndex(t, fixture.TargetDSN, fixture.TableName, "idx_account_created", testutil.PollDeadline)
+}
+
+// TestK8s_DataPlaneStopWithoutLocalRunnerQueuesOwnerStop verifies the
+// multi-replica data-plane safety invariant for stop. A pod that can see shared
+// storage but does not own a live Spirit runner records durable stop intent for
+// the apply owner instead of recording stopped state itself.
+func TestK8s_DataPlaneStopWithoutLocalRunnerQueuesOwnerStop(t *testing.T) {
+	cleanupState(t)
+	pods := podNamesForInstance(t, "data-plane")
+	require.NotEmpty(t, pods, "expected data-plane pods")
+	tableName := testutil.UniqueTableName("table_dp_stop_no_runner")
+
+	dataPlaneApplyID := createStoredK8sApplyWithTask(t, storageDSNs(t)[0], &storage.Apply{
+		ApplyIdentifier: testutil.UniqueTableName("apply-dp-stop-no-runner"),
+		Database:        "testapp",
+		DatabaseType:    storage.DatabaseTypeMySQL,
+		Deployment:      "testapp",
+		Environment:     "staging",
+		Caller:          "e2e",
+		Engine:          storage.EngineSpirit,
+		State:           state.Apply.Running,
+	}, &storage.Task{
+		TaskIdentifier: testutil.UniqueTableName("task-dp-stop-no-runner"),
+		Database:       "testapp",
+		DatabaseType:   storage.DatabaseTypeMySQL,
+		Namespace:      "testapp",
+		TableName:      tableName,
+		DDL:            fmt.Sprintf("ALTER TABLE `%s` ADD INDEX `idx_account_created` (`account_id`, `created_at`)", tableName),
+		DDLAction:      "alter",
+		Engine:         storage.EngineSpirit,
+		Environment:    "staging",
+		State:          state.Task.Running,
+	})
+
+	conn, err := grpc.NewClient(startDataPlanePodGRPCPortForward(t, pods[0]), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	defer utils.CloseAndLog(conn)
+
+	dataPlaneClient := ternv1.NewTernClient(conn)
+	waitForDataPlaneHealthRPC(t, dataPlaneClient)
+	ctx, cancel := context.WithTimeout(t.Context(), testutil.ProgressTimeout)
+	defer cancel()
+	resp, err := dataPlaneClient.Stop(ctx, &ternv1.StopRequest{
+		ApplyId:     dataPlaneApplyID,
+		Environment: "staging",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.True(t, resp.Accepted)
+	waitForDataPlaneStopControlRequestPending(t, storageDSNs(t)[0], dataPlaneApplyID)
+
+	applyState, taskState := storedK8sApplyAndTaskStates(t, storageDSNs(t)[0], dataPlaneApplyID)
+	assert.Equal(t, state.Apply.Running, applyState, "non-owner stop must leave the data-plane apply active for the owner")
+	assert.Equal(t, state.Task.Running, taskState, "non-owner stop must leave the data-plane task active for the owner")
 }
 
 type dataPlanePodEndpoint struct {
@@ -774,6 +844,47 @@ func formatPodProgressResponses(responses map[string]*ternv1.ProgressResponse) s
 
 func hasRowCopyProgress(rowsTotal, rowsCopied int64, percentComplete int32) bool {
 	return rowsTotal > 0 && (rowsCopied > 0 || percentComplete > 0)
+}
+
+func storedK8sApplyAndTaskStates(t *testing.T, dsn, applyID string) (string, string) {
+	t.Helper()
+	db, err := sql.Open("mysql", dsn)
+	require.NoError(t, err)
+	defer utils.CloseAndLog(db)
+	require.NoError(t, db.PingContext(t.Context()))
+
+	var applyState, taskState string
+	require.NoError(t, db.QueryRowContext(t.Context(), `
+		SELECT a.state, t.state
+		FROM applies a
+		JOIN tasks t ON t.apply_id = a.id
+		WHERE a.apply_identifier = ?
+	`, applyID).Scan(&applyState, &taskState))
+	return applyState, taskState
+}
+
+func waitForDataPlaneStopControlRequestPending(t *testing.T, dsn, applyID string) {
+	t.Helper()
+	db, err := sql.Open("mysql", dsn)
+	require.NoError(t, err)
+	defer utils.CloseAndLog(db)
+	require.NoError(t, db.PingContext(t.Context()))
+
+	var status string
+	var lastErr error
+	testutil.Poll(t, testutil.PollDeadline, testutil.PollInterval,
+		func() bool {
+			lastErr = db.QueryRowContext(t.Context(), `
+				SELECT cr.status
+				FROM apply_control_requests cr
+				JOIN applies a ON a.id = cr.apply_id
+				WHERE a.apply_identifier = ? AND cr.operation = ?
+			`, applyID, storage.ControlOperationStop).Scan(&status)
+			return lastErr == nil && status == string(storage.ControlRequestPending)
+		},
+		func() string {
+			return fmt.Sprintf("stop control request was not pending for %s: status=%q last_err=%v", applyID, status, lastErr)
+		})
 }
 
 // TestK8s_Operator_DataPlanePodRestartRecoversIndexAdd verifies operator

--- a/pkg/api/control_handlers.go
+++ b/pkg/api/control_handlers.go
@@ -762,7 +762,7 @@ func (s *Service) tryImmediateStopAfterQueue(ctx context.Context, client tern.Cl
 		return
 	}
 	if client.IsRemote() {
-		s.logger.Info("immediate stop skipped for remote Tern client; durable stop request remains pending for operator-owned reconciliation",
+		s.logger.Info("propagating stop request to remote Tern durable queue",
 			"apply_id", apply.ApplyIdentifier,
 			"tern_apply_id", ternApplyID,
 			"database", apply.Database,
@@ -770,8 +770,7 @@ func (s *Service) tryImmediateStopAfterQueue(ctx context.Context, client tern.Cl
 			"environment", apply.Environment,
 			"requested_by", caller)
 		s.logControlOperationForApply(ctx, apply, caller, storage.LogEventStopRequested,
-			"Immediate stop skipped for remote Tern client; durable operator owner will reconcile stop state")
-		return
+			"Stop request propagation to remote Tern durable queue started")
 	}
 	resp, err := client.Stop(ctx, &ternv1.StopRequest{
 		ApplyId:     ternApplyID,

--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -2736,7 +2736,7 @@ func TestStopHandler(t *testing.T) {
 		assert.Equal(t, int64(1), resp.StoppedCount)
 	})
 
-	t.Run("remote stop queues durable request without immediate remote stop", func(t *testing.T) {
+	t.Run("remote stop queues durable request and propagates to remote durable queue", func(t *testing.T) {
 		mock := &mockTernClient{isRemote: true, stopResp: &ternv1.StopResponse{Accepted: true}}
 		apply := activeTestApply("apply-remote-stop")
 		apply.ExternalID = "remote-apply-stop"
@@ -2757,7 +2757,9 @@ func TestStopHandler(t *testing.T) {
 		mux.ServeHTTP(w, req)
 
 		assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
-		assert.Nil(t, mock.stopReq, "remote stop must be reconciled by the operator owner")
+		require.NotNil(t, mock.stopReq, "remote stop propagation should queue data-plane durable intent")
+		assert.Equal(t, "remote-apply-stop", mock.stopReq.ApplyId)
+		assert.Equal(t, "staging", mock.stopReq.Environment)
 		controlReq, err := svc.storage.ControlRequests().GetPending(t.Context(), apply.ID, storage.ControlOperationStop)
 		require.NoError(t, err)
 		require.NotNil(t, controlReq)

--- a/pkg/api/operator.go
+++ b/pkg/api/operator.go
@@ -132,6 +132,13 @@ func (s *Service) wakeOperator(applyIdentifier, database, environment string) {
 	}
 }
 
+// WakeOperator nudges the operator worker pool to claim queued durable work.
+// Storage locking still decides ownership; this does not execute apply control
+// actions directly.
+func (s *Service) WakeOperator(applyIdentifier, database, environment string) {
+	s.wakeOperator(applyIdentifier, database, environment)
+}
+
 // operatorWorker is a single worker that claims at most one apply on startup
 // and on each operator poll tick. Wake signals share the same claim path as
 // polling; storage locking decides whether a worker actually owns work.

--- a/pkg/api/service.go
+++ b/pkg/api/service.go
@@ -464,10 +464,11 @@ func (s *Service) newLocalTernClient(key, database, dbType string, envConfig Env
 		metadata["pending_drops"] = "false"
 	}
 	client, err := tern.NewLocalClient(tern.LocalConfig{
-		Database:  database,
-		Type:      dbType,
-		TargetDSN: targetDSN,
-		Metadata:  metadata,
+		Database:     database,
+		Type:         dbType,
+		TargetDSN:    targetDSN,
+		Metadata:     metadata,
+		WakeOperator: s.wakeOperator,
 	}, s.storage, s.logger)
 	if err != nil {
 		return nil, fmt.Errorf("create local tern client for %s: %w", key, err)

--- a/pkg/cmd/commands/serve.go
+++ b/pkg/cmd/commands/serve.go
@@ -169,7 +169,7 @@ func (cmd *ServeCmd) Run(g *Globals) error {
 	var grpcServer *grpc.Server
 	grpcPort := os.Getenv("GRPC_PORT")
 	if grpcPort != "" {
-		grpcServer, err = startGRPCServer(ctx, serverConfig, storage, logger, grpcPort)
+		grpcServer, err = startGRPCServer(ctx, serverConfig, storage, logger, grpcPort, svc.WakeOperator)
 		if err != nil {
 			return fmt.Errorf("start grpc server: %w", err)
 		}
@@ -268,8 +268,8 @@ func (cmd *ServeCmd) Run(g *Globals) error {
 // plane is configured with a target resolver, requests are routed by opaque
 // execution target through a TargetRouter; otherwise it falls back to a single
 // LocalClient bound to the one database configured for TERN_ENVIRONMENT.
-func startGRPCServer(ctx context.Context, config *api.ServerConfig, st *mysqlstore.Storage, logger *slog.Logger, port string) (*grpc.Server, error) {
-	client, err := buildGRPCTernClient(ctx, config, st, logger, os.Getenv("TERN_ENVIRONMENT"))
+func startGRPCServer(ctx context.Context, config *api.ServerConfig, st *mysqlstore.Storage, logger *slog.Logger, port string, wakeOperator func(applyIdentifier, database, environment string)) (*grpc.Server, error) {
+	client, err := buildGRPCTernClient(ctx, config, st, logger, os.Getenv("TERN_ENVIRONMENT"), wakeOperator)
 	if err != nil {
 		return nil, err
 	}
@@ -300,7 +300,11 @@ func startGRPCServer(ctx context.Context, config *api.ServerConfig, st *mysqlsto
 // environment is unused in this mode because each request carries its own.
 // Otherwise it falls back to a single LocalClient bound to the one database
 // configured for env.
-func buildGRPCTernClient(ctx context.Context, config *api.ServerConfig, st *mysqlstore.Storage, logger *slog.Logger, env string) (tern.Client, error) {
+func buildGRPCTernClient(ctx context.Context, config *api.ServerConfig, st *mysqlstore.Storage, logger *slog.Logger, env string, wakeOperator ...func(applyIdentifier, database, environment string)) (tern.Client, error) {
+	var wake func(applyIdentifier, database, environment string)
+	if len(wakeOperator) > 0 {
+		wake = wakeOperator[0]
+	}
 	etreConfigured := config.TargetResolver.Etre.Configured()
 	staticConfigured := config.TargetResolver.Configured()
 
@@ -317,7 +321,7 @@ func buildGRPCTernClient(ctx context.Context, config *api.ServerConfig, st *mysq
 			Resolver:           resolver,
 			Storage:            st,
 			Logger:             logger,
-			LocalClientFactory: grpcLocalClientFactory(config),
+			LocalClientFactory: grpcLocalClientFactory(config, wake),
 		})
 		if err != nil {
 			return nil, fmt.Errorf("build target router: %w", err)
@@ -358,7 +362,7 @@ func buildGRPCTernClient(ctx context.Context, config *api.ServerConfig, st *mysq
 	if err != nil {
 		return nil, fmt.Errorf("resolve DSN for %s/%s: %w", dbName, env, err)
 	}
-	client, err := grpcLocalClientFactory(config)(tern.LocalConfig{
+	client, err := grpcLocalClientFactory(config, wake)(tern.LocalConfig{
 		Database:  dbName,
 		Type:      dbConfig.Type,
 		TargetDSN: targetDSN,
@@ -513,7 +517,7 @@ func credentialAttributeFields(cfg api.EtreConfig) []string {
 // grpcLocalClientFactory returns a LocalClientFactory that applies server-level
 // policy (pending drops) to every LocalClient the data plane builds, so the
 // router and single-database paths share identical execution semantics.
-func grpcLocalClientFactory(config *api.ServerConfig) tern.LocalClientFactory {
+func grpcLocalClientFactory(config *api.ServerConfig, wakeOperator func(applyIdentifier, database, environment string)) tern.LocalClientFactory {
 	pendingDropsDisabled := !config.PendingDropsEnabled()
 	return func(cfg tern.LocalConfig, st storage.Storage, logger *slog.Logger) (tern.Client, error) {
 		if pendingDropsDisabled {
@@ -521,6 +525,9 @@ func grpcLocalClientFactory(config *api.ServerConfig) tern.LocalClientFactory {
 				cfg.Metadata = map[string]string{}
 			}
 			cfg.Metadata["pending_drops"] = "false"
+		}
+		if cfg.WakeOperator == nil {
+			cfg.WakeOperator = wakeOperator
 		}
 		return tern.NewLocalClient(cfg, st, logger)
 	}

--- a/pkg/tern/grpc_client.go
+++ b/pkg/tern/grpc_client.go
@@ -583,6 +583,11 @@ func (c *GRPCClient) processPendingStopControlRequest(ctx context.Context, apply
 			"state", apply.State)
 		c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventStopRequested, storage.LogSourceSchemaBot,
 			fmt.Sprintf("Pending remote stop request completed for resolved apply%s", callerApplyLogSuffix(controlRequestCaller(controlReq))), "", "")
+		if hasPendingStart, startErr := hasPendingStartControlRequest(ctx, c.storage, apply); startErr != nil {
+			return true, startErr
+		} else if hasPendingStart {
+			return false, nil
+		}
 		return true, nil
 	}
 	if state.IsTerminalApplyState(apply.State) {
@@ -659,6 +664,11 @@ func (c *GRPCClient) processPendingStopControlRequest(ctx context.Context, apply
 		if err := completePendingStopControlRequests(ctx, c.storage, apply); err != nil {
 			return true, err
 		}
+		if hasPendingStart, startErr := hasPendingStartControlRequest(ctx, c.storage, apply); startErr != nil {
+			return true, startErr
+		} else if hasPendingStart {
+			return false, nil
+		}
 		return true, nil
 	}
 
@@ -672,7 +682,14 @@ func (c *GRPCClient) processPendingStopControlRequest(ctx context.Context, apply
 	if err := c.storage.Applies().Update(ctx, apply); err != nil {
 		return true, fmt.Errorf("sync nonterminal remote gRPC stop state for %s: %w", apply.ApplyIdentifier, err)
 	}
-	return true, fmt.Errorf("remote gRPC stop for apply %s accepted but remote state is still %s", apply.ApplyIdentifier, remoteState)
+	slog.Info("remote gRPC stop request accepted and remains pending for remote apply owner",
+		"apply_id", apply.ApplyIdentifier,
+		"external_id", apply.ExternalID,
+		"database", apply.Database,
+		"environment", apply.Environment,
+		"requested_by", controlRequestCaller(controlReq),
+		"remote_state", remoteState)
+	return false, nil
 }
 
 func (c *GRPCClient) completeRemoteStopFromTerminalProgress(ctx context.Context, apply *storage.Apply, controlReq *storage.ApplyControlRequest, scope applyTaskScope) (bool, error) {
@@ -916,6 +933,11 @@ func (c *GRPCClient) resumeApply(ctx context.Context, apply *storage.Apply, scop
 		return err
 	}
 	startRequested := startControlReq != nil
+	if startRequested {
+		if err := c.waitForPendingStopBeforeStart(ctx, apply, scope, startControlReq); err != nil {
+			return err
+		}
+	}
 	if startRequested && state.IsState(apply.State, state.Apply.WaitingForDeploy) {
 		if handled, err := c.processPendingStopControlRequest(ctx, apply, scope); handled || err != nil {
 			return err
@@ -1015,7 +1037,7 @@ func (c *GRPCClient) resumeApply(ctx context.Context, apply *storage.Apply, scop
 
 		// Only call Start if Tern confirms the apply is actually stopped.
 		if state.IsState(apply.State, state.Apply.Stopped) {
-			if handled, err := c.processPendingStopControlRequest(ctx, apply, scope); handled || err != nil {
+			if err := c.completePendingStopBeforeRemoteStart(ctx, apply); err != nil {
 				return err
 			}
 			_, err := c.client.Start(ctx, &ternv1.StartRequest{
@@ -1067,6 +1089,69 @@ func (c *GRPCClient) resumeApply(ctx context.Context, apply *storage.Apply, scop
 	}
 
 	return c.pollForCompletion(ctx, apply, startRequested, scope)
+}
+
+func (c *GRPCClient) completePendingStopBeforeRemoteStart(ctx context.Context, apply *storage.Apply) error {
+	controlReq, err := pendingStopControlRequest(ctx, c.storage, apply)
+	if err != nil {
+		return fmt.Errorf("check pending stop before starting stopped gRPC apply %s: %w", apply.ApplyIdentifier, err)
+	}
+	if controlReq == nil {
+		return nil
+	}
+	if err := completePendingStopControlRequests(ctx, c.storage, apply); err != nil {
+		return fmt.Errorf("complete pending stop before starting stopped gRPC apply %s: %w", apply.ApplyIdentifier, err)
+	}
+	slog.Info("completed pending gRPC stop request before starting stopped remote apply",
+		"apply_id", apply.ApplyIdentifier,
+		"external_id", apply.ExternalID,
+		"database", apply.Database,
+		"environment", apply.Environment,
+		"requested_by", controlRequestCaller(controlReq),
+		"state", apply.State)
+	c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventStopRequested, storage.LogSourceSchemaBot,
+		fmt.Sprintf("Pending remote stop request completed before start%s", callerApplyLogSuffix(controlRequestCaller(controlReq))), "", "")
+	return nil
+}
+
+func hasPendingStartControlRequest(ctx context.Context, store storage.Storage, apply *storage.Apply) (bool, error) {
+	controlReq, err := pendingStartControlRequest(ctx, store, apply)
+	if err != nil {
+		return false, err
+	}
+	return controlReq != nil, nil
+}
+
+func (c *GRPCClient) waitForPendingStopBeforeStart(ctx context.Context, apply *storage.Apply, scope applyTaskScope, startControlReq *storage.ApplyControlRequest) error {
+	loggedWait := false
+	for {
+		stopReq, err := pendingStopControlRequest(ctx, c.storage, apply)
+		if err != nil {
+			return fmt.Errorf("check pending stop before pending gRPC start for apply %s: %w", apply.ApplyIdentifier, err)
+		}
+		if stopReq == nil {
+			return nil
+		}
+		if !loggedWait {
+			slog.Info("pending gRPC start request is waiting for pending stop request to finish",
+				"apply_id", apply.ApplyIdentifier,
+				"external_id", apply.ExternalID,
+				"database", apply.Database,
+				"environment", apply.Environment,
+				"requested_by", controlRequestCaller(startControlReq),
+				"stop_requested_by", controlRequestCaller(stopReq),
+				"state", apply.State)
+			loggedWait = true
+		}
+		if _, err := c.processPendingStopControlRequest(ctx, apply, scope); err != nil {
+			return err
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(grpcProgressPollInterval):
+		}
+	}
 }
 
 func (c *GRPCClient) processPendingStartControlRequest(ctx context.Context, apply *storage.Apply) error {

--- a/pkg/tern/grpc_client_test.go
+++ b/pkg/tern/grpc_client_test.go
@@ -2194,6 +2194,59 @@ func TestGRPCClient_ResumeApplyStartsQueuedStartAfterClaim(t *testing.T) {
 	assert.Nil(t, controlReq)
 }
 
+func TestGRPCClient_ResumeApplyCompletesQueuedStopBeforeQueuedStart(t *testing.T) {
+	// Start can arrive immediately after stop progress is visible. The operator
+	// should consume the resolved stop request and continue with the queued start
+	// in the same claim instead of requiring another scheduler pass.
+	server := &capturingTernServer{
+		progressState:    ternv1.State_STATE_STOPPED,
+		progressStateSet: true,
+	}
+	client, cleanup := testCapturingGRPCClient(t, server)
+	defer cleanup()
+
+	apply := &storage.Apply{
+		ID:              1,
+		ApplyIdentifier: "apply-start-after-stop",
+		Database:        "testdb",
+		Environment:     "staging",
+		ExternalID:      "remote-start-after-stop",
+		State:           state.Apply.Running,
+	}
+	storedApply := *apply
+	controlRequests := &testControlRequestStore{requests: []*storage.ApplyControlRequest{
+		{
+			ApplyID:     apply.ID,
+			Operation:   storage.ControlOperationStop,
+			Status:      storage.ControlRequestPending,
+			RequestedBy: "stop-caller",
+		},
+		{
+			ApplyID:     apply.ID,
+			Operation:   storage.ControlOperationStart,
+			Status:      storage.ControlRequestPending,
+			RequestedBy: "start-caller",
+		},
+	}}
+	client.storage = &mockStorage{
+		applies:         &mockApplyStore{apply: &storedApply},
+		tasks:           &mockTaskStore{},
+		logs:            &mockApplyLogStore{},
+		controlRequests: controlRequests,
+	}
+
+	err := client.ResumeApply(t.Context(), apply)
+	require.NoError(t, err)
+
+	assert.Equal(t, "remote-start-after-stop", server.getStartApplyID())
+	stopReq, err := controlRequests.GetPending(t.Context(), apply.ID, storage.ControlOperationStop)
+	require.NoError(t, err)
+	assert.Nil(t, stopReq)
+	startReq, err := controlRequests.GetPending(t.Context(), apply.ID, storage.ControlOperationStart)
+	require.NoError(t, err)
+	assert.Nil(t, startReq)
+}
+
 func TestGRPCClient_ResumeApplyStartsDeferredDeployFromPendingRequest(t *testing.T) {
 	server := &capturingTernServer{
 		progressState:    ternv1.State_STATE_COMPLETED,

--- a/pkg/tern/local_client.go
+++ b/pkg/tern/local_client.go
@@ -141,6 +141,11 @@ type LocalConfig struct {
 	// Keys used by Spirit: pending_drops ("false" disables the pending drops
 	// quarantine so DROP TABLE executes directly).
 	Metadata map[string]string
+
+	// WakeOperator notifies the owner loop after an external control request is
+	// recorded. The callback must not execute control actions itself; it only
+	// nudges the storage-claiming operator to process durable intent promptly.
+	WakeOperator func(applyIdentifier, database, environment string)
 }
 
 // LocalClient implements Client by calling the Spirit engine directly.
@@ -219,6 +224,17 @@ func (c *LocalClient) IsRemote() bool { return false }
 
 // Endpoint returns the database name for this local client.
 func (c *LocalClient) Endpoint() string { return c.config.Database }
+
+func (c *LocalClient) wakeOperatorForControlRequest(apply *storage.Apply) {
+	if c.config.WakeOperator == nil {
+		c.logger.Debug("operator wake skipped because no wake callback is configured",
+			"apply_id", apply.ApplyIdentifier,
+			"database", apply.Database,
+			"environment", apply.Environment)
+		return
+	}
+	c.config.WakeOperator(apply.ApplyIdentifier, apply.Database, apply.Environment)
+}
 
 // protoEngine returns the proto engine type based on database configuration.
 func (c *LocalClient) protoEngine() ternv1.Engine {

--- a/pkg/tern/local_client_test.go
+++ b/pkg/tern/local_client_test.go
@@ -1003,6 +1003,66 @@ func TestLocalClient_ProcessPendingStartControlRequestStartsDeferredDeploy(t *te
 	assert.Nil(t, startReq)
 }
 
+func TestLocalClient_StartQueuesOwnerRequest(t *testing.T) {
+	apply := &storage.Apply{
+		ID:              123,
+		ApplyIdentifier: "apply-stopped-start",
+		Database:        "testdb",
+		DatabaseType:    storage.DatabaseTypeMySQL,
+		Environment:     "staging",
+		State:           state.Apply.Stopped,
+		UpdatedAt:       time.Now(),
+	}
+	task := &storage.Task{
+		ID:             456,
+		ApplyID:        apply.ID,
+		TaskIdentifier: "task-stopped-start",
+		Database:       "testdb",
+		Namespace:      "testdb",
+		DatabaseType:   storage.DatabaseTypeMySQL,
+		TableName:      "users",
+		State:          state.Task.Stopped,
+		UpdatedAt:      time.Now(),
+	}
+	controlRequests := &testControlRequestStore{}
+	var wakeApplyID, wakeDatabase, wakeEnvironment string
+	client := &LocalClient{
+		config: LocalConfig{
+			Database: "testdb",
+			Type:     storage.DatabaseTypeMySQL,
+			WakeOperator: func(applyIdentifier, database, environment string) {
+				wakeApplyID = applyIdentifier
+				wakeDatabase = database
+				wakeEnvironment = environment
+			},
+		},
+		storage: &exactProgressStorage{
+			applies:         &exactProgressApplyStore{apply: apply},
+			tasks:           &exactProgressTaskStore{tasks: []*storage.Task{task}},
+			logs:            &mockApplyLogStore{},
+			controlRequests: controlRequests,
+		},
+		spiritEngine: &fakeControlEngine{},
+		logger:       slog.Default(),
+	}
+
+	resp, err := client.Start(t.Context(), &ternv1.StartRequest{ApplyId: apply.ApplyIdentifier})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.True(t, resp.Accepted)
+	assert.Equal(t, int64(1), resp.StartedCount)
+	assert.Equal(t, state.Apply.Stopped, apply.State)
+	assert.Equal(t, state.Task.Stopped, task.State)
+
+	startReq, err := controlRequests.GetPending(t.Context(), apply.ID, storage.ControlOperationStart)
+	require.NoError(t, err)
+	require.NotNil(t, startReq)
+	assert.Equal(t, "tern-grpc", startReq.RequestedBy)
+	assert.Equal(t, apply.ApplyIdentifier, wakeApplyID)
+	assert.Equal(t, apply.Database, wakeDatabase)
+	assert.Equal(t, apply.Environment, wakeEnvironment)
+}
+
 // A revert-window apply has already cut over, so a durable stop request against
 // it is a permanent rejection. Processing it must resolve the request terminally
 // (failed) with the operator-facing reason instead of bubbling a retryable error
@@ -1349,7 +1409,7 @@ func TestLocalClient_StopPreservesTerminalCancelledApply(t *testing.T) {
 		logger:            slog.Default(),
 	}
 
-	resp, err := client.stop(t.Context(), &ternv1.StopRequest{
+	resp, err := client.stopOwnedApply(t.Context(), &ternv1.StopRequest{
 		ApplyId:     apply.ApplyIdentifier,
 		Environment: apply.Environment,
 	}, "cli:second")

--- a/pkg/tern/local_control.go
+++ b/pkg/tern/local_control.go
@@ -232,10 +232,95 @@ func (c *LocalClient) processPendingCutoverControlRequest(ctx context.Context, a
 
 // Stop pauses an in-progress schema change.
 func (c *LocalClient) Stop(ctx context.Context, req *ternv1.StopRequest) (*ternv1.StopResponse, error) {
-	return c.stop(ctx, req, "")
+	return c.requestStop(ctx, req, "")
 }
 
-func (c *LocalClient) stop(ctx context.Context, req *ternv1.StopRequest, caller string) (*ternv1.StopResponse, error) {
+func (c *LocalClient) requestStop(ctx context.Context, req *ternv1.StopRequest, caller string) (*ternv1.StopResponse, error) {
+	c.logger.Info("Stop requested", "database", c.config.Database, "type", c.config.Type, "apply_id", req.ApplyId)
+	apply, err := c.resolveStopApply(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	if apply == nil {
+		return nil, fmt.Errorf("no active schema change")
+	}
+
+	if revertWindow, err := c.applyHasRevertWindowTask(ctx, apply); err != nil {
+		return nil, err
+	} else if revertWindow {
+		c.logger.Warn("stop rejected: schema change is in the revert window and has already cut over",
+			"apply_id", apply.ApplyIdentifier,
+			"state", apply.State)
+		return nil, errors.New(revertWindowStopRejectionMessage(apply.ApplyIdentifier))
+	}
+
+	controlStore := c.storage.ControlRequests()
+	if controlStore == nil {
+		return nil, fmt.Errorf("control request store is not available")
+	}
+	requestedBy := caller
+	if requestedBy == "" {
+		requestedBy = "tern-grpc"
+	}
+	_, alreadyPending, err := controlStore.RequestPending(ctx, &storage.ApplyControlRequest{
+		ApplyID:     apply.ID,
+		Operation:   storage.ControlOperationStop,
+		Status:      storage.ControlRequestPending,
+		RequestedBy: requestedBy,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("record stop control request for apply %s: %w", apply.ApplyIdentifier, err)
+	}
+	if alreadyPending {
+		c.logger.Info("stop request already pending for apply owner",
+			"apply_id", apply.ApplyIdentifier,
+			"database", apply.Database,
+			"environment", apply.Environment,
+			"requested_by", requestedBy)
+	} else {
+		c.logger.Info("stop request queued for apply owner",
+			"apply_id", apply.ApplyIdentifier,
+			"database", apply.Database,
+			"environment", apply.Environment,
+			"requested_by", requestedBy)
+		c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventStopRequested, storage.LogSourceSchemaBot,
+			fmt.Sprintf("Stop request queued for apply owner%s", callerApplyLogSuffix(requestedBy)), "", "")
+	}
+	c.wakeOperatorForControlRequest(apply)
+	return &ternv1.StopResponse{Accepted: true}, nil
+}
+
+func (c *LocalClient) resolveStopApply(ctx context.Context, req *ternv1.StopRequest) (*storage.Apply, error) {
+	if req.ApplyId != "" {
+		apply, err := c.storage.Applies().GetByApplyIdentifier(ctx, req.ApplyId)
+		if err != nil {
+			return nil, fmt.Errorf("load apply %s before stop: %w", req.ApplyId, err)
+		}
+		if apply == nil {
+			return nil, fmt.Errorf("load apply %s before stop: %w", req.ApplyId, storage.ErrApplyNotFound)
+		}
+		return apply, nil
+	}
+
+	task, err := c.getActiveTaskForDatabase(ctx, c.config.Database)
+	if err != nil {
+		return nil, err
+	}
+	if task == nil {
+		c.logger.Info("stop request found no active task", "database", c.config.Database, "type", c.config.Type)
+		return nil, nil
+	}
+	apply, err := c.storage.Applies().Get(ctx, task.ApplyID)
+	if err != nil {
+		return nil, fmt.Errorf("load apply %d before stop: %w", task.ApplyID, err)
+	}
+	if apply == nil {
+		return nil, fmt.Errorf("load apply %d before stop: %w", task.ApplyID, storage.ErrApplyNotFound)
+	}
+	return apply, nil
+}
+
+func (c *LocalClient) stopOwnedApply(ctx context.Context, req *ternv1.StopRequest, caller string) (*ternv1.StopResponse, error) {
 	c.logger.Info("Stop requested", "database", c.config.Database, "type", c.config.Type, "apply_id", req.ApplyId)
 	tasks, err := c.storage.Tasks().GetByDatabase(ctx, c.config.Database)
 	if err != nil {
@@ -399,7 +484,7 @@ func (c *LocalClient) processPendingStopControlRequest(ctx context.Context, appl
 	}
 
 	stopCtx := context.WithoutCancel(ctx)
-	resp, err := c.stop(stopCtx, &ternv1.StopRequest{
+	resp, err := c.stopOwnedApply(stopCtx, &ternv1.StopRequest{
 		ApplyId:     apply.ApplyIdentifier,
 		Environment: apply.Environment,
 	}, controlRequestCaller(controlReq))
@@ -523,9 +608,8 @@ func hasLiveEngineWork(taskState string) bool {
 }
 
 // stopEngineForTasks calls eng.Stop() if any targeted task has live engine work.
-// Returns an error if the engine stop fails (e.g., PlanetScale deploy request
-// cancellation failed). For Spirit, stop errors are non-fatal since the runner
-// may have already exited.
+// Returns an error if the engine stop fails. Storage must not record stopped
+// state until the apply owner has stopped the live engine work.
 //
 // It stops at the first task with live engine work and returns: an apply drives
 // a single engine operation (one Spirit runner or one PlanetScale deploy
@@ -561,8 +645,7 @@ func (c *LocalClient) stopEngineForTasks(ctx context.Context, eng engine.Engine,
 			if c.config.Type == storage.DatabaseTypeVitess {
 				return nil, fmt.Errorf("cancel deploy request for task %s: %w", task.TaskIdentifier, err)
 			}
-			c.logger.Warn("engine stop returned error (runner may have already exited)",
-				"task_id", task.TaskIdentifier, "error", err)
+			return nil, fmt.Errorf("stop local engine for task %s: %w", task.TaskIdentifier, err)
 		}
 		return creds, nil
 	}

--- a/pkg/tern/local_control_resume.go
+++ b/pkg/tern/local_control_resume.go
@@ -2,6 +2,7 @@ package tern
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
@@ -15,14 +16,62 @@ import (
 )
 
 // Start resumes a stopped schema change.
-// On resume, we re-plan against the current DB state to find which DDLs are still
-// needed. Tables that completed before the stop are detected as no-ops by the
-// diff and their tasks are marked completed. Only the remaining DDLs are sent to
-// the engine, which auto-detects Spirit checkpoints for partially-copied tables.
 func (c *LocalClient) Start(ctx context.Context, req *ternv1.StartRequest) (*ternv1.StartResponse, error) {
+	apply, startedCount, skippedCount, err := c.resolveStartRequest(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	controlStore := c.storage.ControlRequests()
+	if controlStore == nil {
+		return nil, fmt.Errorf("control request store is not available")
+	}
+	metadata, err := json.Marshal(localStartControlRequestMetadata{
+		StartedCount: startedCount,
+		SkippedCount: skippedCount,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal start control request metadata for apply %s: %w", apply.ApplyIdentifier, err)
+	}
+	_, alreadyPending, err := controlStore.RequestPending(ctx, &storage.ApplyControlRequest{
+		ApplyID:     apply.ID,
+		Operation:   storage.ControlOperationStart,
+		Status:      storage.ControlRequestPending,
+		RequestedBy: "tern-grpc",
+		Metadata:    metadata,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("record start control request for apply %s: %w", apply.ApplyIdentifier, err)
+	}
+	if alreadyPending {
+		c.logger.Info("start request already pending for apply owner",
+			"apply_id", apply.ApplyIdentifier,
+			"database", apply.Database,
+			"environment", apply.Environment)
+	} else {
+		c.logger.Info("start request queued for apply owner",
+			"apply_id", apply.ApplyIdentifier,
+			"database", apply.Database,
+			"environment", apply.Environment)
+		c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventStartRequested, storage.LogSourceSchemaBot,
+			"Start request queued for apply owner", "", "")
+	}
+	c.wakeOperatorForControlRequest(apply)
+	return &ternv1.StartResponse{
+		Accepted:     true,
+		StartedCount: startedCount,
+		SkippedCount: skippedCount,
+	}, nil
+}
+
+type localStartControlRequestMetadata struct {
+	StartedCount int64 `json:"started_count,omitempty"`
+	SkippedCount int64 `json:"skipped_count,omitempty"`
+}
+
+func (c *LocalClient) resolveStartRequest(ctx context.Context, req *ternv1.StartRequest) (*storage.Apply, int64, int64, error) {
 	tasks, err := c.storage.Tasks().GetByDatabase(ctx, c.config.Database)
 	if err != nil {
-		return nil, fmt.Errorf("get tasks failed: %w", err)
+		return nil, 0, 0, fmt.Errorf("get tasks failed: %w", err)
 	}
 
 	// Find the target apply: either from the request's apply_id or the most recent stopped apply.
@@ -41,7 +90,7 @@ func (c *LocalClient) Start(ctx context.Context, req *ternv1.StartRequest) (*ter
 		// Use the explicitly requested apply
 		a, err := c.storage.Applies().GetByApplyIdentifier(ctx, req.ApplyId)
 		if err != nil || a == nil {
-			return nil, fmt.Errorf("apply %s not found", req.ApplyId)
+			return nil, 0, 0, fmt.Errorf("apply %s not found", req.ApplyId)
 		}
 		apply = a
 		c.logger.Info("Start: found apply", "apply_internal_id", apply.ID, "apply_identifier", apply.ApplyIdentifier, "state", apply.State)
@@ -64,34 +113,22 @@ func (c *LocalClient) Start(ctx context.Context, req *ternv1.StartRequest) (*ter
 	}
 
 	if apply == nil {
-		return nil, fmt.Errorf("no stopped schema change to resume")
+		return nil, 0, 0, fmt.Errorf("no stopped schema change to resume")
 	}
 
 	// Deferred deploy that isn't ready yet — reject with a clear message.
 	if apply.GetOptions().DeferDeploy && apply.State != state.Apply.WaitingForDeploy {
-		return nil, fmt.Errorf("schema change is not ready for deploy (current state: %s)", apply.State)
+		return nil, 0, 0, fmt.Errorf("schema change is not ready for deploy (current state: %s)", apply.State)
+	}
+	if state.IsState(apply.State, state.Apply.WaitingForDeploy) {
+		return apply, 1, 0, nil
+	}
+	if !state.IsState(apply.State, state.Apply.Stopped, state.Apply.Running) {
+		return nil, 0, 0, fmt.Errorf("schema change is not stopped (current state: %s)", apply.State)
 	}
 
-	// Deferred deploy: call engine Start to trigger the deploy request.
-	// This is a separate path from the stopped-task resume flow below.
-	if apply.State == state.Apply.WaitingForDeploy {
-		if controlReq, err := pendingStopControlRequest(ctx, c.storage, apply); err != nil {
-			return nil, fmt.Errorf("check pending stop before deferred deploy start for apply %s: %w", apply.ApplyIdentifier, err)
-		} else if controlReq != nil {
-			c.logger.Info("deferred deploy start blocked because stop request is pending",
-				"apply_id", apply.ApplyIdentifier,
-				"requested_by", controlRequestCaller(controlReq))
-			return nil, fmt.Errorf("schema change has a pending stop request; start is blocked until stop is processed")
-		}
-		started, err := c.startDeferredDeploy(ctx, apply, "")
-		if err != nil {
-			return nil, err
-		}
-		return started.response, nil
-	}
-
-	// Second pass: collect stopped tasks ONLY from the target apply
-	var stoppedTasks []*storage.Task
+	var startedCount int64
+	var skippedCount int64
 	for _, task := range tasks {
 		c.logger.Info("Start: checking task",
 			"task_id", task.TaskIdentifier,
@@ -110,87 +147,18 @@ func (c *LocalClient) Start(ctx context.Context, req *ternv1.StartRequest) (*ter
 			c.logger.Info("skipping old stopped task", "task_id", task.TaskIdentifier, "updated_at", task.UpdatedAt)
 			continue
 		}
-		stoppedTasks = append(stoppedTasks, task)
-	}
-
-	if len(stoppedTasks) == 0 {
-		return nil, fmt.Errorf("no stopped schema change to resume (found %d tasks for database, apply has ID %d)", len(tasks), apply.ID)
-	}
-
-	// Re-plan: diff current DB state against the plan's desired schema to find
-	// which DDLs are still needed. Tables that already completed will not appear
-	// in the re-plan result.
-	plan, err := c.storage.Plans().GetByID(ctx, apply.PlanID)
-	if err != nil || plan == nil {
-		return nil, fmt.Errorf("plan not found for apply %s", apply.ApplyIdentifier)
-	}
-
-	rp, err := c.replanAndFilterTasks(ctx, apply, stoppedTasks, plan)
-	if err != nil {
-		return nil, err
-	}
-
-	resumeTasks := rp.ActiveTasks
-	completedCount := rp.CompletedCount
-	now := time.Now()
-
-	if len(resumeTasks) == 0 {
-		// All tasks were already done — mark apply completed
-		apply.State = state.Apply.Completed
-		apply.CompletedAt = &now
-		apply.UpdatedAt = now
-		if err := c.storage.Applies().Update(ctx, apply); err != nil {
-			c.logger.Error("failed to update apply state", "apply_id", apply.ApplyIdentifier, "state", state.Apply.Completed, "error", err)
+		switch {
+		case state.IsState(task.State, state.Task.Stopped):
+			startedCount++
+		case state.IsTerminalTaskState(task.State):
+			skippedCount++
 		}
-		c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventStateTransition, storage.LogSourceSchemaBot,
-			"All tasks already completed on resume (re-plan shows no changes)", apply.State, state.Apply.Completed)
-
-		return &ternv1.StartResponse{
-			Accepted:     true,
-			StartedCount: 0,
-			SkippedCount: completedCount,
-		}, nil
 	}
 
-	options := buildApplyOptions(apply)
-	oldApplyState := apply.State
-
-	if apply.GetOptions().DeferCutover {
-		logMsg := fmt.Sprintf("Resume requested: %d tasks resumed, %d already completed", len(resumeTasks), completedCount)
-		if err := c.launchAtomicResume(ctx, apply, resumeTasks, plan, options, logMsg, false, false); err != nil {
-			return nil, err
-		}
-	} else {
-		// Sequential mode: process each task one at a time in a background goroutine.
-		// Mark tasks as PENDING synchronously so the progress API shows a non-stopped
-		// state immediately — the watcher exits on STOPPED and would miss the resume.
-		for _, task := range resumeTasks {
-			c.transitionTaskState(ctx, task, 0, state.Task.Pending, "")
-		}
-
-		apply.State = state.Apply.Running
-		apply.UpdatedAt = now
-		if err := c.storage.Applies().Update(ctx, apply); err != nil {
-			c.logger.Error("failed to update apply state", "apply_id", apply.ApplyIdentifier, "state", state.Apply.Running, "error", err)
-		}
-
-		c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventStartRequested, storage.LogSourceSchemaBot,
-			fmt.Sprintf("Resume requested (sequential): %d tasks to resume, %d already completed", len(resumeTasks), completedCount), oldApplyState, state.Apply.Running)
-
-		resumeCtx, cancelResume := context.WithCancel(context.WithoutCancel(ctx))
-		cancelGeneration := c.setApplyCancel(cancelResume)
-		go func() {
-			defer c.clearApplyCancel(cancelGeneration)
-			defer cancelResume()
-			c.resumeApplySequential(resumeCtx, apply, resumeTasks, plan, options)
-		}()
+	if startedCount == 0 {
+		return nil, 0, 0, fmt.Errorf("no stopped schema change to resume (found %d tasks for database, apply has ID %d)", len(tasks), apply.ID)
 	}
-
-	return &ternv1.StartResponse{
-		Accepted:     true,
-		StartedCount: int64(len(resumeTasks)),
-		SkippedCount: completedCount,
-	}, nil
+	return apply, startedCount, skippedCount, nil
 }
 
 type deferredDeployStart struct {

--- a/pkg/tern/local_control_test.go
+++ b/pkg/tern/local_control_test.go
@@ -170,9 +170,10 @@ func newMySQLControlTestClient(apply *storage.Apply, tasks []*storage.Task, eng 
 			TargetDSN: "root@tcp(localhost:3306)/",
 		},
 		storage: &controlTestStorage{
-			applies:   &controlTestApplyStore{apply: apply},
-			tasks:     &controlTestTaskStore{tasks: tasks},
-			applyLogs: &controlTestApplyLogStore{},
+			applies:         &controlTestApplyStore{apply: apply},
+			tasks:           &controlTestTaskStore{tasks: tasks},
+			applyLogs:       &controlTestApplyLogStore{},
+			controlRequests: &testControlRequestStore{},
 		},
 		spiritEngine: eng,
 		logger:       slog.Default(),
@@ -242,7 +243,7 @@ func TestLocalClient_StopMarksMySQLApplyStopped(t *testing.T) {
 	eng := &controlCaptureEngine{}
 	client := newMySQLControlTestClient(apply, []*storage.Task{task}, eng)
 
-	resp, err := client.Stop(t.Context(), &ternv1.StopRequest{ApplyId: apply.ApplyIdentifier})
+	resp, err := client.stopOwnedApply(t.Context(), &ternv1.StopRequest{ApplyId: apply.ApplyIdentifier}, "")
 
 	require.NoError(t, err)
 	assert.True(t, resp.Accepted)
@@ -251,6 +252,84 @@ func TestLocalClient_StopMarksMySQLApplyStopped(t *testing.T) {
 	assert.Equal(t, state.Apply.Stopped, apply.State)
 	assert.Nil(t, apply.CompletedAt)
 	require.NotNil(t, eng.stopReq, "stop should call the engine")
+}
+
+// External Stop records durable intent in shared storage. The apply owner
+// observes the pending request and performs the local engine stop, so any
+// replica can accept the request without mutating stopped state itself.
+func TestLocalClient_StopQueuesStopRequestForApplyOwner(t *testing.T) {
+	apply := &storage.Apply{
+		ID:              42,
+		ApplyIdentifier: "apply-mysql-stop-queued",
+		State:           state.Apply.Running,
+		Database:        "testdb",
+		DatabaseType:    storage.DatabaseTypeMySQL,
+		Environment:     "staging",
+	}
+	task := &storage.Task{
+		ID:             7,
+		ApplyID:        apply.ID,
+		TaskIdentifier: "task-mysql-stop-queued",
+		Database:       "testdb",
+		Namespace:      "testdb",
+		State:          state.Task.Running,
+	}
+	eng := &controlCaptureEngine{}
+	client := newMySQLControlTestClient(apply, []*storage.Task{task}, eng)
+	var wakeApplyID, wakeDatabase, wakeEnvironment string
+	client.config.WakeOperator = func(applyIdentifier, database, environment string) {
+		wakeApplyID = applyIdentifier
+		wakeDatabase = database
+		wakeEnvironment = environment
+	}
+
+	resp, err := client.Stop(t.Context(), &ternv1.StopRequest{ApplyId: apply.ApplyIdentifier})
+
+	require.NoError(t, err)
+	assert.True(t, resp.Accepted)
+	assert.Nil(t, eng.stopReq, "external stop should not call the local engine directly")
+	assert.Equal(t, state.Task.Running, task.State)
+	assert.Equal(t, state.Apply.Running, apply.State)
+	controlReq, err := client.storage.ControlRequests().GetPending(t.Context(), apply.ID, storage.ControlOperationStop)
+	require.NoError(t, err)
+	require.NotNil(t, controlReq)
+	assert.Equal(t, "tern-grpc", controlReq.RequestedBy)
+	assert.Equal(t, apply.ApplyIdentifier, wakeApplyID)
+	assert.Equal(t, apply.Database, wakeDatabase)
+	assert.Equal(t, apply.Environment, wakeEnvironment)
+}
+
+// Apply-owner stop is only authoritative after the local Spirit runner stops.
+// If the engine cannot stop, storage must remain active so user-facing status
+// does not diverge from a runner that is still copying rows.
+func TestLocalClient_StopOwnedApplyReturnsMySQLEngineStopError(t *testing.T) {
+	apply := &storage.Apply{
+		ID:              42,
+		ApplyIdentifier: "apply-mysql-stop-non-owner",
+		State:           state.Apply.Running,
+		Database:        "testdb",
+		DatabaseType:    storage.DatabaseTypeMySQL,
+		Environment:     "staging",
+	}
+	task := &storage.Task{
+		ID:             7,
+		ApplyID:        apply.ID,
+		TaskIdentifier: "task-mysql-stop-non-owner",
+		Database:       "testdb",
+		Namespace:      "testdb",
+		State:          state.Task.Running,
+	}
+	stopErr := errors.New("no active schema change to stop")
+	eng := &controlCaptureEngine{stopErr: stopErr}
+	client := newMySQLControlTestClient(apply, []*storage.Task{task}, eng)
+
+	_, err := client.stopOwnedApply(t.Context(), &ternv1.StopRequest{ApplyId: apply.ApplyIdentifier}, "")
+
+	require.ErrorIs(t, err, stopErr)
+	require.NotNil(t, eng.stopReq, "stop should call the local engine before mutating storage")
+	assert.Equal(t, state.Task.Running, task.State)
+	assert.Equal(t, state.Apply.Running, apply.State)
+	assert.Nil(t, apply.CompletedAt)
 }
 
 // Sequential MySQL applies can contain tasks from multiple namespaces, but only
@@ -285,7 +364,7 @@ func TestLocalClient_StopSnapshotsProgressWithStoppedTaskNamespace(t *testing.T)
 	eng := &controlCaptureEngine{}
 	client := newMySQLControlTestClient(apply, []*storage.Task{pendingTask, liveTask}, eng)
 
-	resp, err := client.Stop(t.Context(), &ternv1.StopRequest{ApplyId: apply.ApplyIdentifier})
+	resp, err := client.stopOwnedApply(t.Context(), &ternv1.StopRequest{ApplyId: apply.ApplyIdentifier}, "")
 
 	require.NoError(t, err)
 	assert.True(t, resp.Accepted)
@@ -377,7 +456,7 @@ func TestLocalClient_StopAllTasksTerminalDerivesApplyState(t *testing.T) {
 			}
 			client := newMySQLControlTestClient(apply, tasks, &controlCaptureEngine{})
 
-			resp, err := client.Stop(t.Context(), &ternv1.StopRequest{ApplyId: apply.ApplyIdentifier})
+			resp, err := client.stopOwnedApply(t.Context(), &ternv1.StopRequest{ApplyId: apply.ApplyIdentifier}, "")
 
 			require.NoError(t, err)
 			assert.True(t, resp.Accepted)
@@ -545,7 +624,7 @@ func TestLocalClient_StopReturnsVitessEngineStopError(t *testing.T) {
 	eng := &controlCaptureEngine{stopErr: stopErr}
 	client := newVitessControlTestClient(apply, []*storage.Task{task}, resumeState, eng)
 
-	_, err := client.Stop(t.Context(), &ternv1.StopRequest{ApplyId: apply.ApplyIdentifier})
+	_, err := client.stopOwnedApply(t.Context(), &ternv1.StopRequest{ApplyId: apply.ApplyIdentifier}, "")
 
 	require.ErrorIs(t, err, stopErr)
 	require.NotNil(t, eng.stopReq, "stop should call the engine with deploy metadata")
@@ -578,7 +657,7 @@ func TestLocalClient_StopRecoveringMySQLStopsEngineBeforeStorage(t *testing.T) {
 	eng.onStop = func() { stateAtEngineStop = task.State }
 	client := newMySQLControlTestClient(apply, []*storage.Task{task}, eng)
 
-	resp, err := client.Stop(t.Context(), &ternv1.StopRequest{ApplyId: apply.ApplyIdentifier})
+	resp, err := client.stopOwnedApply(t.Context(), &ternv1.StopRequest{ApplyId: apply.ApplyIdentifier}, "")
 
 	require.NoError(t, err)
 	assert.True(t, resp.Accepted)
@@ -620,7 +699,7 @@ func TestLocalClient_StopWaitingForDeployCancelsDeployRequest(t *testing.T) {
 	eng.onStop = func() { stateAtEngineStop = task.State }
 	client := newVitessControlTestClient(apply, []*storage.Task{task}, resumeState, eng)
 
-	resp, err := client.Stop(t.Context(), &ternv1.StopRequest{ApplyId: apply.ApplyIdentifier})
+	resp, err := client.stopOwnedApply(t.Context(), &ternv1.StopRequest{ApplyId: apply.ApplyIdentifier}, "")
 
 	require.NoError(t, err)
 	assert.True(t, resp.Accepted)
@@ -665,7 +744,7 @@ func TestLocalClient_StopFailedRetryableCancelsDeployRequest(t *testing.T) {
 	eng.onStop = func() { stateAtEngineStop = task.State }
 	client := newVitessControlTestClient(apply, []*storage.Task{task}, resumeState, eng)
 
-	resp, err := client.Stop(t.Context(), &ternv1.StopRequest{ApplyId: apply.ApplyIdentifier})
+	resp, err := client.stopOwnedApply(t.Context(), &ternv1.StopRequest{ApplyId: apply.ApplyIdentifier}, "")
 
 	require.NoError(t, err)
 	assert.True(t, resp.Accepted)

--- a/pkg/webhook/control_e2e_test.go
+++ b/pkg/webhook/control_e2e_test.go
@@ -140,10 +140,10 @@ func TestE2EStopCommandRecordsDurableRequest(t *testing.T) {
 	assertReactionEventually(t, reactions)
 }
 
-// TestE2EStopCommandStopsDeferredCutoverLocalApply verifies that a PR comment
-// stop command stops an active local schema change that is waiting for deferred
-// cutover instead of issuing cutover.
-func TestE2EStopCommandStopsDeferredCutoverLocalApply(t *testing.T) {
+// TestE2EStopCommandQueuesDeferredCutoverLocalApplyWithoutRunner verifies that
+// a PR comment stop command records durable stop intent when storage has an
+// active local schema change but this process does not own the Spirit runner.
+func TestE2EStopCommandQueuesDeferredCutoverLocalApplyWithoutRunner(t *testing.T) {
 	ctx := t.Context()
 	schemabotDB, err := sql.Open("mysql", e2eSchemabotDSN)
 	require.NoError(t, err)
@@ -219,15 +219,16 @@ func TestE2EStopCommandStopsDeferredCutoverLocalApply(t *testing.T) {
 	storedApply, err = store.Applies().GetByApplyIdentifier(ctx, applyIdentifier)
 	require.NoError(t, err)
 	require.NotNil(t, storedApply)
-	assert.Equal(t, state.Apply.Stopped, storedApply.State)
+	assert.Equal(t, state.Apply.WaitingForCutover, storedApply.State)
 	assert.True(t, storedApply.GetOptions().DeferCutover)
 	storedTasks, err = store.Tasks().GetByApplyID(ctx, applyID)
 	require.NoError(t, err)
 	require.Len(t, storedTasks, 1)
-	assert.Equal(t, state.Task.Stopped, storedTasks[0].State)
+	assert.Equal(t, state.Task.WaitingForCutover, storedTasks[0].State)
 	pendingStop, err := store.ControlRequests().GetPending(ctx, applyID, storage.ControlOperationStop)
 	require.NoError(t, err)
-	assert.Nil(t, pendingStop)
+	require.NotNil(t, pendingStop)
+	assert.Equal(t, storage.ControlRequestPending, pendingStop.Status)
 	assertReactionEventually(t, reactions)
 }
 


### PR DESCRIPTION
## Why
In a multi-replica data plane, control RPCs can land on a pod that can see shared storage but does not own the in-memory Spirit runner. Start and stop intent need to be durable in the storage the owner/operator watches, and only the owner should execute Spirit control actions or move stored state forward.

## What
- Queue external Stop RPCs as durable stop control requests instead of stopping the local engine from whichever pod receives the RPC
- Queue external Start RPCs as durable start control requests instead of resuming from whichever pod receives the RPC
- Propagate control-plane remote start/stop requests into the remote Tern durable queue, so the data-plane apply owner observes them promptly
- Keep the apply-owner/operator path responsible for calling Spirit start/stop and recording task/apply state
- Preserve queued start intent when it races with stop completion, so the owner completes the durable stop and resumes the remote apply in the same claim
- Cover the behavior with LocalClient, API/webhook control, gRPC stop/start, and Kubernetes multi-replica regressions

```diagram
╭───────────────╮ start/stop command ╭──────────────────────╮
│ Control plane │───────────────────▶│ control-plane store  │
╰──────┬────────╯                    ╰──────────────────────╯
       │ propagates durable intent via RPC
       ▼
╭────────────────────╮ queues intent ╭──────────────────────╮
│ Any data-plane pod │──────────────▶│ data-plane storage   │
╰────────────────────╯               ╰────────┬─────────────╯
                                               │ owner observes
                                               ▼
                                     ╭──────────────────────╮
                                     │ Apply-owner operator │
                                     ╰────────┬─────────────╯
                                              │ executes Spirit control + updates state
                                              ▼
                                     ╭──────────────────────╮
                                     │ Spirit runner/state  │
                                     ╰──────────────────────╯
```

## Risk Assessment
Medium — this changes start/stop handling for active MySQL applies so external control requests become durable owner work instead of pod-local state transitions.

Generated with Amp
