### PR TITLE
test(e2e): add etre-resolver k8s e2e with ministack

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -320,6 +320,54 @@ jobs:
           echo "=== All pods ==="
           kubectl get pods -n schemabot-e2e -o wide 2>/dev/null || true
 
+  e2e-k8s-etre:
+    name: "E2E K8s Etre Tests"
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # actions/checkout@v6
+      - name: "Configure Go"
+        uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # actions/setup-go@v6.1
+        with:
+          go-version-file: go.mod
+          cache: false
+      - name: "Restore Go cache"
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # actions/cache/restore@v4
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: go-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('go.sum') }}
+          restore-keys: go-${{ runner.os }}-${{ runner.arch }}-
+      - name: "Start minikube"
+        uses: medyagh/setup-minikube@d8c0eb871f6f455542491d86a574477bd3894533 # medyagh/setup-minikube@v0.0.18
+        with:
+          driver: docker
+          cpus: 2
+          memory: 4096
+      # The script builds both the schemabot and etre images into minikube's
+      # docker daemon, so no separate build step is needed here.
+      - name: "Deploy and test"
+        run: e2e/k8s/e2e-etre-test.sh
+      - name: "Pod logs on failure"
+        if: failure()
+        run: |
+          echo "=== Control Plane ==="
+          kubectl logs -n schemabot-e2e-etre -l app.kubernetes.io/instance=control-plane-etre --tail=200 2>/dev/null || true
+          echo "=== Data Plane ==="
+          kubectl logs -n schemabot-e2e-etre -l app.kubernetes.io/instance=data-plane-etre --tail=200 2>/dev/null || true
+          echo "=== Etre ==="
+          kubectl logs -n schemabot-e2e-etre -l app=etre --tail=100 2>/dev/null || true
+          echo "=== ministack ==="
+          kubectl logs -n schemabot-e2e-etre -l app=ministack --tail=100 2>/dev/null || true
+          echo "=== Seed jobs ==="
+          kubectl logs -n schemabot-e2e-etre -l job-name=etre-seed --tail=50 2>/dev/null || true
+          kubectl logs -n schemabot-e2e-etre -l job-name=ministack-seed --tail=50 2>/dev/null || true
+          echo "=== All pods ==="
+          kubectl get pods -n schemabot-e2e-etre -o wide 2>/dev/null || true
+
   # Rollup jobs that match the old required check names.
   # Remove these after updating branch protection to use the new job names.
   #

--- a/Makefile
+++ b/Makefile
@@ -407,6 +407,12 @@ test-e2e-grpc: build ## Run gRPC e2e tests in isolated environment
 test-e2e-k8s: ## Run k8s e2e tests on minikube
 	@e2e/k8s/e2e-test.sh
 
+# Run the etre-resolver k8s e2e on minikube: the data plane resolves a target
+# (DSID) through Etre and assembles credentials via assume-role + Secrets
+# Manager, both emulated by ministack in-cluster.
+test-e2e-k8s-etre: ## Run the etre-resolver k8s e2e on minikube
+	@e2e/k8s/e2e-etre-test.sh
+
 # Start local dev environment with gRPC backend (separate Tern server)
 up-grpc:
 	docker compose -f deploy/local/docker-compose.grpc.yml up --build

--- a/e2e/k8s/control-plane-etre-values.yaml
+++ b/e2e/k8s/control-plane-etre-values.yaml
@@ -1,0 +1,40 @@
+# Control plane Helm values for the etre-resolver k8s e2e.
+#
+# Routes the testapp database to the etre data plane over gRPC, carrying the
+# opaque target (a DSID) the data plane resolves through Etre. Mirrors
+# control-plane-values.yaml but points at the data-plane-etre release and uses
+# a DSID target instead of a static one.
+
+image:
+  repository: schemabot
+  tag: test
+  pullPolicy: Never
+
+config:
+  storage:
+    dsn: "env:MYSQL_DSN"
+  databases:
+    testapp:
+      type: mysql
+      environments:
+        staging:
+          # Opaque execution target — the DSID the data plane resolves via Etre.
+          target: dsid-testapp-staging
+          deployment: data-plane-etre
+  tern_deployments:
+    data-plane-etre:
+      staging: "data-plane-etre-schemabot:13370"
+
+env:
+  - name: MYSQL_DSN
+    value: "root:testpassword@tcp(mysql-control-plane:3306)/schemabot?parseTime=true&multiStatements=true"
+  - name: LOG_LEVEL
+    value: "debug"
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 500m
+    memory: 256Mi

--- a/e2e/k8s/data-plane-etre-values.yaml
+++ b/e2e/k8s/data-plane-etre-values.yaml
@@ -1,0 +1,60 @@
+# Data plane Helm values for the etre-resolver k8s e2e.
+#
+# Resolves the opaque target through Etre and assembles credentials by assuming
+# an IAM role + reading Secrets Manager — both emulated by ministack (pointed at
+# via AWS_ENDPOINT_URL). Distinct from data-plane-values.yaml, which binds a
+# single static database.
+
+image:
+  repository: schemabot
+  tag: test
+  pullPolicy: Never
+
+replicaCount: 2
+
+grpc:
+  enabled: true
+  port: 13370
+
+config:
+  storage:
+    dsn: "env:MYSQL_DSN"
+  target_resolver:
+    etre:
+      addr: "http://etre:8080"
+      entity_type: aurora_cluster
+      target_label: dsid
+      env_label: env
+      labels:
+        aws_region: us-east-1
+      host_field: writer_endpoint
+      default_port: "3306"
+      credentials:
+        type: awssm
+        region: us-east-1
+        role_arn: "arn:aws:iam::{account}:role/tern-assumed"
+        secret_name: "{target}_ddl_password"
+
+env:
+  - name: MYSQL_DSN
+    value: "root:testpassword@tcp(mysql-data-plane:3306)/tern?parseTime=true&multiStatements=true"
+  - name: AWS_ENDPOINT_URL
+    value: "http://ministack:4566"
+  - name: AWS_ACCESS_KEY_ID
+    value: "test"
+  - name: AWS_SECRET_ACCESS_KEY
+    value: "test"
+  - name: AWS_DEFAULT_REGION
+    value: "us-east-1"
+  - name: TERN_ENVIRONMENT
+    value: "staging"
+  - name: LOG_LEVEL
+    value: "debug"
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 500m
+    memory: 256Mi

--- a/e2e/k8s/e2e-etre-test.sh
+++ b/e2e/k8s/e2e-etre-test.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# Runs the etre-resolver k8s e2e on minikube.
+#
+# Like e2e-test.sh, but the data plane resolves an opaque target (a DSID)
+# through Etre and assembles credentials by assuming an IAM role + reading
+# Secrets Manager — both emulated by ministack, deployed in-cluster. Proves the
+# dynamic resolution path end to end against a real Etre server and the AWS
+# credential flow rather than mocks.
+#
+# Prerequisites: minikube, helm, docker, kubectl, go.
+#
+# Usage:
+#   e2e/k8s/e2e-etre-test.sh
+
+set -euo pipefail
+
+NAMESPACE="schemabot-e2e-etre"
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+
+for cmd in minikube helm docker kubectl go; do
+    if ! command -v "$cmd" > /dev/null 2>&1; then
+        echo "Error: $cmd is not installed"
+        exit 1
+    fi
+done
+
+if ! minikube status > /dev/null 2>&1; then
+    echo "Starting minikube..."
+    minikube start --driver=docker --cpus=4 --memory=4096
+fi
+
+# --- Build images into minikube's docker daemon ---
+
+echo "Building schemabot + etre images for minikube..."
+CGO_ENABLED=0 GOOS=linux go build -o "$REPO_ROOT/bin/schemabot-linux" ./pkg/cmd
+cp "$REPO_ROOT/bin/schemabot-linux" "$REPO_ROOT/deploy/local/schemabot-dev"
+eval "$(minikube docker-env)"
+docker build -t schemabot:test -f "$REPO_ROOT/deploy/local/Dockerfile.dev" "$REPO_ROOT/deploy/local/"
+rm -f "$REPO_ROOT/deploy/local/schemabot-dev"
+docker build -t etre:test "$REPO_ROOT/e2e/k8s/etre/"
+
+PIDS=()
+cleanup() {
+    echo "Cleaning up port-forwards..."
+    for pid in ${PIDS[@]+"${PIDS[@]}"}; do
+        kill "$pid" 2>/dev/null || true
+    done
+}
+trap cleanup EXIT
+
+# Namespace teardown is left to the caller (KEEP_NAMESPACE=1 to inspect after a
+# failure); a re-run reconciles the existing namespace via apply + upgrade.
+teardown_namespace() {
+    if [ "${KEEP_NAMESPACE:-0}" != "1" ]; then
+        kubectl delete namespace "$NAMESPACE" --ignore-not-found
+    fi
+}
+
+wait_for_ready_pods() {
+    local selector="$1"
+    local timeout_seconds="${2:-180}"
+    local deadline=$((SECONDS + timeout_seconds))
+    until kubectl get pod -n "$NAMESPACE" -l "$selector" -o name 2>/dev/null | grep -q .; do
+        if ((SECONDS >= deadline)); then
+            echo "Timeout waiting for pods matching selector: $selector"
+            kubectl get pods -n "$NAMESPACE" -o wide || true
+            exit 1
+        fi
+        sleep 1
+    done
+    local remaining=$((deadline - SECONDS))
+    ((remaining < 1)) && remaining=1
+    kubectl wait --for=condition=ready pod -l "$selector" -n "$NAMESPACE" --timeout="${remaining}s"
+}
+
+# --- Deploy ---
+
+echo "Creating namespace..."
+kubectl create namespace "$NAMESPACE" 2>/dev/null || true
+
+echo "Deploying MySQL + Etre + MongoDB + ministack..."
+kubectl apply -n "$NAMESPACE" -f "$REPO_ROOT/e2e/k8s/mysql.yaml"
+# Build the entity fixtures ConfigMap from the JSON documents so the seed Job
+# loads exactly what is checked in under e2e/k8s/etre/fixtures.
+kubectl create configmap etre-fixtures \
+    --from-file="$REPO_ROOT/e2e/k8s/etre/fixtures" \
+    -n "$NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
+# Jobs are immutable, so a KEEP_NAMESPACE rerun would not re-run the completed
+# seed Jobs. Delete them first so kubectl apply recreates them and reruns seed
+# deterministically.
+kubectl delete job etre-mongo-init etre-seed ministack-seed -n "$NAMESPACE" --ignore-not-found
+kubectl apply -n "$NAMESPACE" -f "$REPO_ROOT/e2e/k8s/etre-stack.yaml"
+wait_for_ready_pods "app=mysql-control-plane"
+wait_for_ready_pods "app=mysql-data-plane"
+wait_for_ready_pods "app=etre"
+wait_for_ready_pods "app=ministack"
+
+echo "Waiting for seed jobs..."
+kubectl wait --for=condition=complete job/etre-mongo-init -n "$NAMESPACE" --timeout=180s
+kubectl wait --for=condition=complete job/etre-seed -n "$NAMESPACE" --timeout=180s
+kubectl wait --for=condition=complete job/ministack-seed -n "$NAMESPACE" --timeout=180s
+
+echo "Installing etre data plane..."
+helm upgrade --install data-plane-etre "$REPO_ROOT/charts/schemabot" \
+    -n "$NAMESPACE" -f "$REPO_ROOT/e2e/k8s/data-plane-etre-values.yaml"
+wait_for_ready_pods "app.kubernetes.io/instance=data-plane-etre"
+
+echo "Installing control plane..."
+helm upgrade --install control-plane-etre "$REPO_ROOT/charts/schemabot" \
+    -n "$NAMESPACE" -f "$REPO_ROOT/e2e/k8s/control-plane-etre-values.yaml"
+wait_for_ready_pods "app.kubernetes.io/instance=control-plane-etre"
+
+# --- Port-forwards ---
+
+echo "Starting port-forwards..."
+kubectl port-forward -n "$NAMESPACE" svc/control-plane-etre-schemabot 8080:8080 &
+PIDS+=($!)
+kubectl port-forward -n "$NAMESPACE" svc/mysql-control-plane 3307:3306 &
+PIDS+=($!)
+kubectl port-forward -n "$NAMESPACE" svc/mysql-data-plane 3308:3306 &
+PIDS+=($!)
+
+echo "Waiting for control plane..."
+for i in $(seq 1 30); do
+    if curl -sf http://localhost:8080/health > /dev/null 2>&1; then
+        echo "Control plane is healthy"
+        break
+    fi
+    [ "$i" -eq 30 ] && { echo "Timeout waiting for port-forward"; exit 1; }
+    sleep 1
+done
+
+# --- Test ---
+
+echo "Running etre-resolver k8s e2e..."
+TEST_EXIT_CODE=0
+E2E_SCHEMABOT_URL=http://localhost:8080 \
+E2E_SCHEMABOT_MYSQL_DSN="root:testpassword@tcp(localhost:3307)/schemabot?parseTime=true&multiStatements=true" \
+E2E_TERN_STAGING_MYSQL_DSN="root:testpassword@tcp(localhost:3308)/testapp?parseTime=true&multiStatements=true" \
+go test -count=1 -v -tags=e2e -timeout=10m -run TestK8sEtre ./e2e/k8s/... || TEST_EXIT_CODE=$?
+
+teardown_namespace
+exit "$TEST_EXIT_CODE"

--- a/e2e/k8s/etre-stack.yaml
+++ b/e2e/k8s/etre-stack.yaml
@@ -1,0 +1,233 @@
+# Etre + MongoDB + ministack for the k8s etre-resolver e2e.
+#
+# The data plane resolves an opaque target (DSID) through Etre to a MySQL
+# endpoint, then assembles credentials by assuming an IAM role and reading a
+# Secrets Manager secret — both emulated by ministack. The seed Jobs register a
+# generic cluster entity in Etre and the matching secret in ministack so a
+# plan/apply for the routed database resolves and connects end to end.
+
+---
+# MongoDB (single-node replica set — Etre's CDC needs the oplog).
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: etre-mongo
+  labels: { app: etre-mongo }
+spec:
+  replicas: 1
+  selector:
+    matchLabels: { app: etre-mongo }
+  template:
+    metadata:
+      labels: { app: etre-mongo }
+    spec:
+      containers:
+        - name: mongo
+          image: mongo:6.0
+          command: ["mongod", "--replSet", "rs0", "--bind_ip_all"]
+          ports: [{ containerPort: 27017 }]
+          readinessProbe:
+            exec:
+              command: ["mongosh", "--quiet", "--eval", "db.adminCommand('ping')"]
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 5
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: etre-mongo
+spec:
+  selector: { app: etre-mongo }
+  ports: [{ port: 27017 }]
+---
+# One-shot replica-set initiation (idempotent).
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: etre-mongo-init
+spec:
+  backoffLimit: 30
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: init
+          image: mongo:6.0
+          command:
+            - sh
+            - -c
+            - |
+              until mongosh --host etre-mongo:27017 --quiet --eval "db.adminCommand('ping')"; do
+                echo "waiting for mongo..."; sleep 2;
+              done
+              mongosh --host etre-mongo:27017 --quiet --eval '
+                try { rs.status() }
+                catch (e) { rs.initiate({_id: "rs0", members: [{_id: 0, host: "etre-mongo:27017"}]}) }'
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: etre-config
+data:
+  config.yaml: |
+    server:
+      addr: ":8080"
+    datasource:
+      url: "mongodb://etre-mongo:27017/?replicaSet=rs0&directConnection=true"
+    cdc:
+      datasource:
+        url: "mongodb://etre-mongo:27017/?replicaSet=rs0&directConnection=true"
+    entity:
+      types:
+        - aurora_cluster
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: etre
+  labels: { app: etre }
+spec:
+  replicas: 1
+  selector:
+    matchLabels: { app: etre }
+  template:
+    metadata:
+      labels: { app: etre }
+    spec:
+      containers:
+        - name: etre
+          image: etre:test
+          imagePullPolicy: Never
+          ports: [{ containerPort: 8080 }]
+          volumeMounts:
+            - name: config
+              mountPath: /etc/etre
+          readinessProbe:
+            tcpSocket: { port: 8080 }
+            initialDelaySeconds: 5
+            periodSeconds: 5
+      volumes:
+        - name: config
+          configMap: { name: etre-config }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: etre
+spec:
+  selector: { app: etre }
+  ports: [{ port: 8080 }]
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ministack
+  labels: { app: ministack }
+spec:
+  replicas: 1
+  selector:
+    matchLabels: { app: ministack }
+  template:
+    metadata:
+      labels: { app: ministack }
+    spec:
+      containers:
+        - name: ministack
+          image: ministackorg/ministack:1.3.64
+          ports: [{ containerPort: 4566 }]
+          readinessProbe:
+            tcpSocket: { port: 4566 }
+            initialDelaySeconds: 5
+            periodSeconds: 5
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ministack
+spec:
+  selector: { app: ministack }
+  ports: [{ port: 4566 }]
+---
+# Load the entity fixtures into Etre. The fixtures live in
+# e2e/k8s/etre/fixtures/<entity_type>.json and are mounted via the etre-fixtures
+# ConfigMap, which the runner script builds from that directory. Each file is
+# POSTed to the collection named after the file. Seeding is skipped when a type
+# already has entities so a KEEP_NAMESPACE rerun does not create duplicate rows,
+# which would make resolution fail closed on an ambiguous match.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: etre-seed
+spec:
+  backoffLimit: 30
+  template:
+    spec:
+      restartPolicy: OnFailure
+      volumes:
+        - name: fixtures
+          configMap:
+            name: etre-fixtures
+      containers:
+        - name: seed
+          image: curlimages/curl:8.10.1
+          volumeMounts:
+            - { name: fixtures, mountPath: /fixtures }
+          command:
+            - sh
+            - -c
+            - |
+              until curl -sf "http://etre:8080/api/v1/entities/aurora_cluster?query=_id!=0" >/dev/null; do
+                echo "waiting for etre..."; sleep 2;
+              done
+              for f in /fixtures/*.json; do
+                entity_type=$(basename "$f" .json)
+                if curl -sf "http://etre:8080/api/v1/entities/$entity_type?query=_id!=0" | grep -q '"_id"'; then
+                  echo "$entity_type already seeded, skipping"
+                  continue
+                fi
+                echo "seeding $entity_type from $f"
+                curl -sf -X POST "http://etre:8080/api/v1/entities/$entity_type" \
+                  -H "Content-Type: application/json" \
+                  -d @"$f"
+              done
+              echo "etre seeded"
+---
+# Create the DDL credential secret in ministack as a JSON {username,password}
+# payload (the awssm credential resolver parses this shape).
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ministack-seed
+spec:
+  backoffLimit: 30
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: seed
+          image: amazon/aws-cli:2.17.0
+          env:
+            - { name: AWS_ACCESS_KEY_ID, value: "test" }
+            - { name: AWS_SECRET_ACCESS_KEY, value: "test" }
+            - { name: AWS_DEFAULT_REGION, value: "us-east-1" }
+          command:
+            - sh
+            - -c
+            - |
+              until aws --endpoint-url http://ministack:4566 sts get-caller-identity >/dev/null 2>&1; do
+                echo "waiting for ministack..."; sleep 2;
+              done
+              # Create only when absent so reruns are idempotent, but let a real
+              # create failure propagate instead of masking an unhealthy ministack.
+              if ! aws --endpoint-url http://ministack:4566 iam get-role --role-name tern-assumed >/dev/null 2>&1; then
+                aws --endpoint-url http://ministack:4566 iam create-role \
+                  --role-name tern-assumed \
+                  --assume-role-policy-document '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"*"},"Action":"sts:AssumeRole"}]}'
+              fi
+              if ! aws --endpoint-url http://ministack:4566 secretsmanager describe-secret --secret-id "dsid-testapp-staging_ddl_password" >/dev/null 2>&1; then
+                aws --endpoint-url http://ministack:4566 secretsmanager create-secret \
+                  --name "dsid-testapp-staging_ddl_password" \
+                  --secret-string '{"username":"root","password":"testpassword"}'
+              fi
+              echo "ministack seeded"

--- a/e2e/k8s/etre/Dockerfile
+++ b/e2e/k8s/etre/Dockerfile
@@ -1,0 +1,18 @@
+# Etre entity-registry server for the k8s e2e suite.
+#
+# Etre publishes no image, so the server is built from source at the same module
+# and version as the client dependency in go.mod (github.com/square/etre). The
+# server config is mounted from a ConfigMap at runtime rather than baked in, so
+# the same image works for any datasource.
+FROM golang:1.26.3-alpine AS builder
+WORKDIR /app
+RUN apk add --no-cache git
+RUN git clone --depth 1 --branch v0.15.0 https://github.com/square/etre.git .
+RUN go build -o etre ./bin/etre
+
+FROM alpine:3.19
+RUN apk add --no-cache ca-certificates
+WORKDIR /app
+COPY --from=builder /app/etre .
+EXPOSE 8080
+CMD ["./etre", "-config", "/etc/etre/config.yaml"]

--- a/e2e/k8s/etre/fixtures/aurora_cluster.json
+++ b/e2e/k8s/etre/fixtures/aurora_cluster.json
@@ -1,0 +1,29 @@
+[
+  {
+    "name": "testapp-cluster",
+    "app": "testapp",
+    "dsid": "dsid-testapp-staging",
+    "env": "staging",
+    "aws_region": "us-east-1",
+    "aws_account_id": "000000000000",
+    "writer_endpoint": "mysql-data-plane"
+  },
+  {
+    "name": "orders-cluster",
+    "app": "orders",
+    "dsid": "dsid-orders-staging",
+    "env": "staging",
+    "aws_region": "us-east-1",
+    "aws_account_id": "000000000000",
+    "writer_endpoint": "orders-staging.cluster-cr8s4mn2plq7.us-east-1.rds.amazonaws.com"
+  },
+  {
+    "name": "payments-cluster",
+    "app": "payments",
+    "dsid": "dsid-payments-staging",
+    "env": "staging",
+    "aws_region": "us-east-1",
+    "aws_account_id": "000000000000",
+    "writer_endpoint": "payments-staging.cluster-zk31d9c7vh20.us-east-1.rds.amazonaws.com"
+  }
+]

--- a/e2e/k8s/etre_resolver_test.go
+++ b/e2e/k8s/etre_resolver_test.go
@@ -1,0 +1,52 @@
+//go:build e2e
+
+package k8s
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/block/schemabot/e2e/testutil"
+	"github.com/block/schemabot/pkg/apitypes"
+	"github.com/block/schemabot/pkg/cmd/client"
+	"github.com/block/schemabot/pkg/state"
+)
+
+// TestK8sEtre_PlanApply_AddColumn exercises the dynamic data-plane resolution
+// path end to end. The control plane routes the testapp database to the etre
+// data plane carrying an opaque target (a DSID). The data plane resolves that
+// DSID through Etre to a MySQL endpoint, assumes an IAM role and reads the DDL
+// credential from Secrets Manager — both emulated by ministack — then applies
+// the schema change against the resolved database. It is the highest-fidelity
+// coverage of the resolve-then-apply path, exercising the real Etre server and
+// the AWS credential flow rather than mocks.
+func TestK8sEtre_PlanApply_AddColumn(t *testing.T) {
+	ep, dsn := testutil.Endpoint(t), testutil.TernStagingDSN(t)
+	tableName := testutil.UniqueTableName("k8s_etre_addcol")
+
+	testutil.CreateTestTableWithCleanup(t, dsn, tableName, fmt.Sprintf(
+		`CREATE TABLE %s (id INT NOT NULL AUTO_INCREMENT PRIMARY KEY, name VARCHAR(255) NOT NULL)`, tableName),
+		storageDSNs(t)...)
+
+	schemaFiles := map[string]string{
+		tableName + ".sql": fmt.Sprintf(
+			`CREATE TABLE %s (id INT NOT NULL AUTO_INCREMENT PRIMARY KEY, name VARCHAR(255) NOT NULL, email VARCHAR(255) DEFAULT NULL);`, tableName),
+	}
+
+	planResp, err := client.CallPlanAPIWithFiles(ep, "testapp", "mysql", "staging",
+		map[string]*apitypes.SchemaFiles{"testapp": {Files: schemaFiles}}, "", 0)
+	require.NoError(t, err)
+	require.NotEmpty(t, planResp.PlanID)
+
+	applyResp, err := client.CallApplyAPI(ep, planResp.PlanID, "staging", "", nil)
+	require.NoError(t, err)
+	require.True(t, applyResp.Accepted, "apply not accepted: %s", applyResp.ErrorMessage)
+
+	testutil.WaitForState(t, ep, applyResp.ApplyID, state.Apply.Completed, testutil.PollDeadline)
+
+	assert.True(t, testutil.ColumnExists(t, dsn, tableName, "email"),
+		"expected column 'email' on %s after an etre-resolved apply", tableName)
+}


### PR DESCRIPTION
## Why this matters

The data plane can now resolve an opaque target through a pluggable inventory backend and fetch credentials by assuming an IAM role + reading Secrets Manager. Until now that path was only covered by unit tests with mocked clients — and mocks hid two real bugs (a nil HTTP client panic and a config-validation gap, both already fixed) that only appear against real services. This adds the highest-fidelity test of the resolve-then-apply path so those regressions are caught before an operator hits them.

## What it does

Runs the whole dynamic-resolution stack in-cluster on minikube:

```
control plane ──route(opaque target)──▶ data plane ──┬─ resolve target ─▶ Etre ─▶ MySQL host
                                                     ├─ assume role ────▶ ministack (STS)
                                                     └─ get secret ─────▶ ministack (SM)
                                                                │
                                                                ▼
                                                          apply DDL ─▶ MySQL
```

- a real Etre entity-registry server (built from source) backed by MongoDB
- ministack emulating STS AssumeRole + Secrets Manager
- the SchemaBot control and data planes via Helm

`TestK8sEtre_PlanApply_AddColumn` routes a database to the data plane carrying an opaque target; the data plane resolves it through Etre to a MySQL endpoint, assumes an IAM role, reads the DDL credential from Secrets Manager, and applies an AddColumn against the resolved database. Ships the etre image, the in-cluster stack manifest, data/control-plane Helm values, a runner script, and a `test-e2e-k8s-etre` make target.

## How it moves toward the northstar

The northstar is an OSS data plane that resolves execution targets through pluggable inventory and credential backends, retiring the out-of-tree shim. This is the high-fidelity safety net for that path — and because it covers resolve + assume-role + apply against real services, the equivalent out-of-tree MySQL e2e tests can be retired, shifting that coverage into OSS for faster feedback.

---
*PR drafted by Claude Code (Opus 4.8).*