### PR TITLE
fix(ux): avoid 0% after row copy starts

### DIFF
--- a/pkg/cmd/internal/templates/progress.go
+++ b/pkg/cmd/internal/templates/progress.go
@@ -493,7 +493,7 @@ func FormatTableProgressWithActivity(t TableProgress, activityBar, activityLabel
 		return b.String()
 	case state.Apply.Recovering:
 		if recoveringIsCopyingRows(t) {
-			pct := ui.ClampPercent(t.PercentComplete)
+			pct := ui.RowCopyDisplayPercent(t.PercentComplete, t.RowsCopied)
 			bar := ui.ProgressBarRowCopy(pct)
 			fmt.Fprintf(&b, indentTable+progressSymbol(t.ChangeType)+"%s: %s Row copy in progress (%d%%)\n", t.TableName, bar, pct)
 			if t.DDL != "" {
@@ -527,7 +527,7 @@ func FormatTableProgressWithActivity(t TableProgress, activityBar, activityLabel
 		b.WriteString(FormatShardProgress(t.Shards))
 		return b.String()
 	case state.Apply.Failed:
-		bar := ui.ProgressBarFailed(t.PercentComplete)
+		bar := ui.ProgressBarFailed(ui.RowCopyDisplayPercent(t.PercentComplete, t.RowsCopied))
 		fmt.Fprintf(&b, indentTable+progressSymbol(t.ChangeType)+"%s: %s ❌ Failed\n", t.TableName, bar)
 		if t.DDL != "" {
 			b.WriteString(formatProgressDDL(t.DDL))
@@ -536,8 +536,9 @@ func FormatTableProgressWithActivity(t TableProgress, activityBar, activityLabel
 		b.WriteString(FormatShardProgress(t.Shards))
 		return b.String()
 	case state.Apply.FailedRetryable:
-		if t.PercentComplete > 0 {
-			bar := ui.ProgressBar(t.PercentComplete, ui.ColorYellow)
+		if t.PercentComplete > 0 || t.RowsCopied > 0 {
+			retryPercent := ui.RowCopyDisplayPercent(t.PercentComplete, t.RowsCopied)
+			bar := ui.ProgressBar(retryPercent, ui.ColorYellow)
 			fmt.Fprintf(&b, indentTable+progressSymbol(t.ChangeType)+"%s: %s Retrying\n", t.TableName, bar)
 		} else {
 			fmt.Fprintf(&b, indentTable+progressSymbol(t.ChangeType)+"%s: Retrying\n", t.TableName)
@@ -558,8 +559,8 @@ func FormatTableProgressWithActivity(t TableProgress, activityBar, activityLabel
 		b.WriteString(FormatShardProgress(t.Shards))
 		return b.String()
 	case state.Apply.Cancelled:
-		if t.PercentComplete > 0 {
-			cancelledPercent := ui.ClampPercent(t.PercentComplete)
+		if t.PercentComplete > 0 || t.RowsCopied > 0 {
+			cancelledPercent := ui.RowCopyDisplayPercent(t.PercentComplete, t.RowsCopied)
 			bar := ui.ProgressBarFailed(cancelledPercent)
 			fmt.Fprintf(&b, indentTable+progressSymbol(t.ChangeType)+"%s: %s ⊘ Cancelled at %d%%\n", t.TableName, bar, cancelledPercent)
 		} else {
@@ -573,13 +574,13 @@ func FormatTableProgressWithActivity(t TableProgress, activityBar, activityLabel
 		return b.String()
 	case state.Apply.Stopped:
 		// Show orange progress bar with current progress when stopped
-		bar := ui.ProgressBarStopped(t.PercentComplete)
+		stoppedPercent := ui.RowCopyDisplayPercent(t.PercentComplete, t.RowsCopied)
+		bar := ui.ProgressBarStopped(stoppedPercent)
 		switch {
 		case t.PercentComplete >= 100:
 			// At 100% = was waiting for cutover when stopped
 			fmt.Fprintf(&b, indentTable+progressSymbol(t.ChangeType)+"%s: %s ⏹️ Stopped (was waiting for cutover)\n", t.TableName, bar)
-		case t.PercentComplete > 0:
-			stoppedPercent := min(t.PercentComplete, 100)
+		case t.PercentComplete > 0 || t.RowsCopied > 0:
 			fmt.Fprintf(&b, indentTable+progressSymbol(t.ChangeType)+"%s: %s ⏹️ Stopped at %d%%\n", t.TableName, bar, stoppedPercent)
 		default:
 			fmt.Fprintf(&b, indentTable+progressSymbol(t.ChangeType)+"%s: ⏹️ Stopped (not started)\n", t.TableName)
@@ -587,7 +588,7 @@ func FormatTableProgressWithActivity(t TableProgress, activityBar, activityLabel
 		if t.DDL != "" {
 			b.WriteString(formatProgressDDL(t.DDL))
 		}
-		if t.RowsTotal > 0 && t.PercentComplete > 0 {
+		if t.RowsTotal > 0 && (t.PercentComplete > 0 || t.RowsCopied > 0) {
 			fmt.Fprintf(&b, indentDetail+"Rows: %s / %s\n", ui.FormatNumber(ui.ClampRows(t.RowsCopied, t.RowsTotal)), ui.FormatNumber(t.RowsTotal))
 		}
 		b.WriteString("\n")
@@ -605,7 +606,7 @@ func FormatTableProgressWithActivity(t TableProgress, activityBar, activityLabel
 			}
 
 			// Parsed successfully - show emoji progress bar with structured data
-			displayPercent := ui.ClampPercent(info.Percent)
+			displayPercent := ui.RowCopyDisplayPercent(info.Percent, info.RowsCopied)
 			bar := ui.ProgressBarRowCopy(displayPercent)
 			fmt.Fprintf(&b, indentTable+progressSymbol(t.ChangeType)+"%s: %s %d%%\n", t.TableName, bar, displayPercent)
 			if t.DDL != "" {
@@ -642,7 +643,7 @@ func FormatTableProgressWithActivity(t TableProgress, activityBar, activityLabel
 		}
 
 		// Row copy in progress — show progress bar with structured fields
-		displayPercent := ui.ClampPercent(t.PercentComplete)
+		displayPercent := ui.RowCopyDisplayPercent(t.PercentComplete, t.RowsCopied)
 		bar := ui.ProgressBarRowCopy(displayPercent)
 		fmt.Fprintf(&b, indentTable+progressSymbol(t.ChangeType)+"%s: %s %d%%\n", t.TableName, bar, displayPercent)
 

--- a/pkg/cmd/internal/templates/progress_shard.go
+++ b/pkg/cmd/internal/templates/progress_shard.go
@@ -125,7 +125,7 @@ func formatShardLine(s ShardProgress) string {
 		if pct == 0 && s.RowsTotal > 0 {
 			pct = int(s.RowsCopied * 100 / s.RowsTotal)
 		}
-		pct = ui.ClampPercent(pct)
+		pct = ui.RowCopyDisplayPercent(pct, s.RowsCopied)
 		detail := fmt.Sprintf("%d%% (%s/%s rows)", pct, ui.FormatNumber(ui.ClampRows(s.RowsCopied, s.RowsTotal)), ui.FormatNumber(s.RowsTotal))
 		if s.ETASeconds > 0 {
 			detail += fmt.Sprintf(" ETA %s", FormatDurationSeconds(s.ETASeconds))

--- a/pkg/cmd/internal/templates/progress_shard_test.go
+++ b/pkg/cmd/internal/templates/progress_shard_test.go
@@ -117,6 +117,19 @@ func TestFormatDurationSeconds(t *testing.T) {
 	}
 }
 
+func TestFormatShardLineDisplaysOnePercentAfterCopyStarts(t *testing.T) {
+	line := formatShardLine(ShardProgress{
+		Shard:           "-80",
+		Status:          state.Task.Running,
+		RowsCopied:      3_000,
+		RowsTotal:       1_604_159,
+		PercentComplete: 0,
+	})
+
+	assert.Contains(t, line, "1% (3,000/1,604,159 rows)")
+	assert.NotContains(t, line, "0%")
+}
+
 func TestIsVSchemaTask(t *testing.T) {
 	assert.True(t, isVSchemaTask(TableProgress{TableName: "VSchema"}))
 	assert.True(t, isVSchemaTask(TableProgress{TableName: "vschema:myapp_sharded"}))

--- a/pkg/cmd/internal/templates/progress_states_test.go
+++ b/pkg/cmd/internal/templates/progress_states_test.go
@@ -242,6 +242,23 @@ func TestFormatTableProgress_CreateDropLabels(t *testing.T) {
 	assert.NotContains(t, output, "Recovering state...")
 }
 
+func TestFormatTableProgress_RowCopyDisplaysOnePercentAfterCopyStarts(t *testing.T) {
+	tp := TableProgress{
+		TableName:       "orders",
+		ChangeType:      "alter",
+		Status:          state.Apply.Running,
+		RowsCopied:      3_000,
+		RowsTotal:       1_604_159,
+		PercentComplete: 0,
+	}
+
+	output := FormatTableProgress(tp)
+
+	assert.Contains(t, output, "orders: "+ui.ProgressBarRowCopy(1)+" 1%")
+	assert.Contains(t, output, "Rows: 3,000 / 1,604,159")
+	assert.NotContains(t, output, " 0%")
+}
+
 func TestFormatTableProgress_FailedRetryableKeepsProgress(t *testing.T) {
 	t.Run("with progress", func(t *testing.T) {
 		tp := TableProgress{

--- a/pkg/ui/format.go
+++ b/pkg/ui/format.go
@@ -64,6 +64,17 @@ func ClampPercent(pct int) int {
 	return pct
 }
 
+// RowCopyDisplayPercent returns the percentage to show for row-copy progress.
+// A non-zero copied row count means copying has begun, so display at least 1%
+// even when integer progress rounds down to 0%.
+func RowCopyDisplayPercent(pct int, rowsCopied int64) int {
+	displayPercent := ClampPercent(pct)
+	if displayPercent == 0 && rowsCopied > 0 {
+		return 1
+	}
+	return displayPercent
+}
+
 // NowFunc returns the current time. Override in previews for deterministic output.
 var NowFunc = time.Now
 

--- a/pkg/ui/format_test.go
+++ b/pkg/ui/format_test.go
@@ -40,6 +40,14 @@ func TestProgressBarActivity(t *testing.T) {
 	assert.Zero(t, strings.Count(bar, ColorEmpty))
 }
 
+func TestRowCopyDisplayPercent(t *testing.T) {
+	assert.Equal(t, 0, RowCopyDisplayPercent(0, 0))
+	assert.Equal(t, 1, RowCopyDisplayPercent(0, 42))
+	assert.Equal(t, 1, RowCopyDisplayPercent(-3, 42))
+	assert.Equal(t, 2, RowCopyDisplayPercent(2, 42))
+	assert.Equal(t, 100, RowCopyDisplayPercent(145, 42))
+}
+
 func TestCleanLintReason(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/pkg/webhook/templates/apply.go
+++ b/pkg/webhook/templates/apply.go
@@ -208,7 +208,7 @@ func writeProgressSummary(sb *strings.Builder, tables []TableProgressData) {
 			if ui.EstimateExceeded(t.RowsCopied, t.RowsTotal) {
 				runningEstimateExceeded = true
 			} else {
-				runningPct = ui.ClampPercent(t.PercentComplete)
+				runningPct = ui.RowCopyDisplayPercent(t.PercentComplete, t.RowsCopied)
 			}
 		case state.Task.Pending:
 			queued++
@@ -352,7 +352,7 @@ func renderTableProgress(sb *strings.Builder, table TableProgressData, globalSta
 
 	case state.Task.Recovering:
 		if recoveringIsCopyingRows(table) {
-			pct := ui.ClampPercent(table.PercentComplete)
+			pct := ui.RowCopyDisplayPercent(table.PercentComplete, table.RowsCopied)
 			bar := ui.ProgressBarRowCopy(pct)
 			fmt.Fprintf(sb, "**`%s`**: %s Row copy in progress (%d%%)\n", table.TableName, bar, pct)
 			writeDDLLine(sb, table.DDL)
@@ -369,12 +369,12 @@ func renderTableProgress(sb *strings.Builder, table TableProgressData, globalSta
 		writeDDLLine(sb, table.DDL)
 
 	case state.Task.Failed:
-		bar := ui.ProgressBarFailed(table.PercentComplete)
+		bar := ui.ProgressBarFailed(ui.RowCopyDisplayPercent(table.PercentComplete, table.RowsCopied))
 		fmt.Fprintf(sb, "**`%s`**: %s \u274c Failed\n", table.TableName, bar)
 		writeDDLLine(sb, table.DDL)
 
 	case state.Task.FailedRetryable:
-		bar := ui.ProgressBarStopped(ui.ClampPercent(table.PercentComplete))
+		bar := ui.ProgressBarStopped(ui.RowCopyDisplayPercent(table.PercentComplete, table.RowsCopied))
 		fmt.Fprintf(sb, "**`%s`**: %s \U0001f504 Interrupted — retrying automatically\n", table.TableName, bar)
 		writeDDLLine(sb, table.DDL)
 		if table.ErrorMessage != "" {
@@ -412,7 +412,7 @@ func renderRunningTable(sb *strings.Builder, table TableProgressData) {
 			return
 		}
 
-		pct := ui.ClampPercent(table.PercentComplete)
+		pct := ui.RowCopyDisplayPercent(table.PercentComplete, table.RowsCopied)
 		bar := ui.ProgressBarRowCopy(pct)
 		fmt.Fprintf(sb, "**`%s`**: %s %d%%\n", table.TableName, bar, pct)
 		writeDDLLine(sb, table.DDL)
@@ -435,7 +435,7 @@ func recoveringCopyPercent(tables []TableProgressData) (int, bool) {
 		if state.NormalizeTaskStatus(table.Status) != state.Task.Recovering || !recoveringIsCopyingRows(table) {
 			continue
 		}
-		percent = min(percent, ui.ClampPercent(table.PercentComplete))
+		percent = min(percent, ui.RowCopyDisplayPercent(table.PercentComplete, table.RowsCopied))
 		found = true
 	}
 	return percent, found
@@ -447,8 +447,8 @@ func renderStoppedTable(sb *strings.Builder, table TableProgressData) {
 	case table.PercentComplete >= 100:
 		bar := ui.ProgressBarStopped(100)
 		fmt.Fprintf(sb, "**`%s`**: %s \u23f9\ufe0f Stopped (was waiting for cutover)\n", table.TableName, bar)
-	case table.PercentComplete > 0:
-		pct := ui.ClampPercent(table.PercentComplete)
+	case table.PercentComplete > 0 || table.RowsCopied > 0:
+		pct := ui.RowCopyDisplayPercent(table.PercentComplete, table.RowsCopied)
 		bar := ui.ProgressBarStopped(pct)
 		fmt.Fprintf(sb, "**`%s`**: %s \u23f9\ufe0f Stopped at %d%%\n", table.TableName, bar, pct)
 	default:
@@ -458,7 +458,7 @@ func renderStoppedTable(sb *strings.Builder, table TableProgressData) {
 	writeDDLLine(sb, table.DDL)
 
 	// Show rows (no ETA) for stopped tables with progress
-	if table.RowsTotal > 0 && table.PercentComplete > 0 {
+	if table.RowsTotal > 0 && (table.PercentComplete > 0 || table.RowsCopied > 0) {
 		fmt.Fprintf(sb, "Rows: %s / %s\n",
 			ui.FormatNumber(ui.ClampRows(table.RowsCopied, table.RowsTotal)),
 			ui.FormatNumber(table.RowsTotal))
@@ -821,14 +821,14 @@ func writeSummaryTableEntry(sb *strings.Builder, t TableProgressData) {
 		fmt.Fprintf(sb, "**`%s`**\n", t.TableName)
 	case state.Task.Failed:
 		label := "Failed"
-		if t.PercentComplete > 0 {
-			label = fmt.Sprintf("Failed at %d%%", ui.ClampPercent(t.PercentComplete))
+		if t.PercentComplete > 0 || t.RowsCopied > 0 {
+			label = fmt.Sprintf("Failed at %d%%", ui.RowCopyDisplayPercent(t.PercentComplete, t.RowsCopied))
 		}
 		fmt.Fprintf(sb, "**`%s`** — %s\n", t.TableName, label)
 	case state.Task.Stopped:
 		label := "Stopped"
-		if t.PercentComplete > 0 {
-			label = fmt.Sprintf("Stopped at %d%%", ui.ClampPercent(t.PercentComplete))
+		if t.PercentComplete > 0 || t.RowsCopied > 0 {
+			label = fmt.Sprintf("Stopped at %d%%", ui.RowCopyDisplayPercent(t.PercentComplete, t.RowsCopied))
 		}
 		fmt.Fprintf(sb, "**`%s`** — %s\n", t.TableName, label)
 	case "reverted":

--- a/pkg/webhook/templates/apply_test.go
+++ b/pkg/webhook/templates/apply_test.go
@@ -68,6 +68,27 @@ func TestRenderApplyStatusComment_Running(t *testing.T) {
 	assert.Contains(t, result, "Queued")
 }
 
+func TestRenderApplyStatusComment_RowCopyDisplaysOnePercentAfterCopyStarts(t *testing.T) {
+	data := ApplyStatusCommentData{
+		Database:    "testapp",
+		Environment: "staging",
+		RequestedBy: "aparajon",
+		State:       state.Apply.Running,
+		Engine:      "Spirit",
+		Tables: []TableProgressData{
+			{TableName: "users", Status: state.Task.Completed},
+			{TableName: "orders", Status: state.Task.Running, RowsCopied: 3_000, RowsTotal: 1_604_159, PercentComplete: 0},
+		},
+	}
+
+	result := RenderApplyStatusComment(data)
+
+	assert.Contains(t, result, "1 running (1%)")
+	assert.Contains(t, result, "**`orders`**: "+ui.ProgressBarRowCopy(1)+" 1%")
+	assert.Contains(t, result, "Rows: 3,000 / 1,604,159")
+	assert.NotContains(t, result, " 0%")
+}
+
 func TestRenderApplyStatusComment_EstimateExceeded(t *testing.T) {
 	data := ApplyStatusCommentData{
 		Database:    "testapp",


### PR DESCRIPTION
## Why
Row-copy progress can copy a non-zero number of rows while integer percentage math still displays 0%, which makes active work look stalled.

## What
- Add a shared row-copy display percent helper that preserves true zero but shows at least 1% after rows copy
- Use the helper in CLI table/shard progress and PR progress comments
- Cover the low-percentage row-copy case in UI, CLI, and GitHub template tests

## Risk Assessment
Low — this only changes progress presentation; stored progress values and schema change execution are unchanged.

Generated with Amp