### PR TITLE
fix(ux): show progress comment freshness

### DIFF
--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -1581,6 +1581,8 @@ To stop this schema change:
 schemabot stop apply-a1b2c3d4e5f6
 ```
 
+_Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:00 UTC</relative-time> (2026-01-01 00:00:00 UTC)_
+
 </details>
 
 <details>
@@ -1703,6 +1705,8 @@ To stop this schema change:
 schemabot stop apply-a1b2c3d4e5f6
 ```
 
+_Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:00 UTC</relative-time> (2026-01-01 00:00:00 UTC)_
+
 </details>
 
 <details>
@@ -1746,6 +1750,8 @@ To stop this schema change:
 schemabot stop apply-a1b2c3d4e5f6
 ```
 
+_Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:00 UTC</relative-time> (2026-01-01 00:00:00 UTC)_
+
 </details>
 
 <details>
@@ -1788,6 +1794,8 @@ To stop this schema change:
 ```
 schemabot stop apply-a1b2c3d4e5f6
 ```
+
+_Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:00 UTC</relative-time> (2026-01-01 00:00:00 UTC)_
 
 </details>
 
@@ -1833,6 +1841,8 @@ To stop this schema change:
 schemabot stop apply-a1b2c3d4e5f6
 ```
 
+_Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:00 UTC</relative-time> (2026-01-01 00:00:00 UTC)_
+
 </details>
 
 <details>
@@ -1875,6 +1885,8 @@ To stop this schema change:
 ```
 schemabot stop apply-a1b2c3d4e5f6
 ```
+
+_Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:00 UTC</relative-time> (2026-01-01 00:00:00 UTC)_
 
 </details>
 
@@ -2080,6 +2092,8 @@ To proceed with cutover:
 schemabot cutover apply-a1b2c3d4e5f6
 ```
 
+_Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:00 UTC</relative-time> (2026-01-01 00:00:00 UTC)_
+
 </details>
 
 <details>
@@ -2120,6 +2134,8 @@ ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
 ---
 
 Cutover in progress — typically completes within seconds.
+
+_Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:00 UTC</relative-time> (2026-01-01 00:00:00 UTC)_
 
 </details>
 
@@ -4588,6 +4604,8 @@ _No details available yet._
 _No details available yet._
 
 </details>
+
+_Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:00 UTC</relative-time> (2026-01-01 00:00:00 UTC)_
 
 </details>
 

--- a/pkg/webhook/templates/apply.go
+++ b/pkg/webhook/templates/apply.go
@@ -49,13 +49,17 @@ type ApplyStatusCommentData struct {
 // When Tables is populated, per-table progress bars are shown.
 // When Tables is empty, a simple status message is rendered.
 func RenderApplyStatusComment(data ApplyStatusCommentData) string {
+	return renderApplyStatusComment(data, true, currentTimestamp())
+}
+
+func renderApplyStatusComment(data ApplyStatusCommentData, includeLastUpdated bool, renderedAt string) string {
 	var sb strings.Builder
 
 	// Header varies by state
 	writeApplyHeader(&sb, data)
 
 	// Metadata line
-	writeApplyMetadata(&sb, data)
+	writeApplyMetadata(&sb, data, renderedAt)
 
 	// Cutover readiness summary
 	if data.State == state.Apply.WaitingForCutover || data.State == state.Apply.CuttingOver {
@@ -74,6 +78,9 @@ func RenderApplyStatusComment(data ApplyStatusCommentData) string {
 
 	// Footer with next actions
 	writeApplyFooter(&sb, data)
+	if includeLastUpdated && !state.IsTerminalApplyState(data.State) {
+		writeLastUpdatedFooter(&sb, renderedAt)
+	}
 
 	return sb.String()
 }
@@ -126,7 +133,7 @@ func writeApplyHeader(sb *strings.Builder, data ApplyStatusCommentData) {
 }
 
 // writeApplyMetadata writes the database, environment, apply ID, elapsed time, and requester info.
-func writeApplyMetadata(sb *strings.Builder, data ApplyStatusCommentData) {
+func writeApplyMetadata(sb *strings.Builder, data ApplyStatusCommentData, renderedAt string) {
 	var parts []string
 	parts = append(parts, fmt.Sprintf("**Database**: `%s`", data.Database))
 	if data.Environment != "" {
@@ -139,7 +146,7 @@ func writeApplyMetadata(sb *strings.Builder, data ApplyStatusCommentData) {
 		parts = append(parts, fmt.Sprintf("**Elapsed**: %s", elapsed))
 	}
 	fmt.Fprintf(sb, "%s\n", strings.Join(parts, " | "))
-	writeAppliedByOrTimestamp(sb, data.RequestedBy)
+	writeAppliedByOrTimestampAt(sb, data.RequestedBy, renderedAt)
 }
 
 // writeCutoverSummary writes a readiness summary for cutover states,

--- a/pkg/webhook/templates/apply_commands.go
+++ b/pkg/webhook/templates/apply_commands.go
@@ -139,7 +139,7 @@ func RenderApplyStarted(data ApplyStatusCommentData) string {
 	var sb strings.Builder
 
 	sb.WriteString("## Schema Change In Progress\n\n")
-	writeApplyMetadata(&sb, data)
+	writeApplyMetadata(&sb, data, currentTimestamp())
 	sb.WriteString("\nSchema changes are being applied. Progress updates will be posted as new comments.\n")
 
 	return sb.String()

--- a/pkg/webhook/templates/apply_test.go
+++ b/pkg/webhook/templates/apply_test.go
@@ -15,6 +15,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func withTemplateTimestamp(t *testing.T, timestamp string) {
+	t.Helper()
+	original := TimestampFunc
+	TimestampFunc = func() string { return timestamp }
+	t.Cleanup(func() { TimestampFunc = original })
+}
+
 func TestRenderApplyBlockedByCLILockUsesValidUnlockCommand(t *testing.T) {
 	rendered := RenderApplyBlockedByOtherPR(ApplyLockConflictData{
 		Database:    "example-db",
@@ -28,6 +35,7 @@ func TestRenderApplyBlockedByCLILockUsesValidUnlockCommand(t *testing.T) {
 }
 
 func TestRenderApplyStatusComment_Running(t *testing.T) {
+	withTemplateTimestamp(t, "2026-06-16 19:42:00 UTC")
 	data := ApplyStatusCommentData{
 		Database:    "testapp",
 		Environment: "staging",
@@ -47,6 +55,8 @@ func TestRenderApplyStatusComment_Running(t *testing.T) {
 	assert.Contains(t, result, "@aparajon")
 	assert.Contains(t, result, "`testapp`")
 	assert.Contains(t, result, "`staging`")
+	assert.Contains(t, result, "_Last updated: <relative-time datetime=\"2026-06-16T19:42:00Z\">2026-06-16 19:42:00 UTC</relative-time> (2026-06-16 19:42:00 UTC)_")
+	assert.NotContains(t, result, "**Last updated**")
 	// Progress summary
 	assert.Contains(t, result, "📊 1/3 complete")
 	assert.Contains(t, result, "1 running (45%)")
@@ -93,6 +103,29 @@ func TestRenderApplyStatusComment_EstimateExceeded(t *testing.T) {
 	assert.NotContains(t, result, "100,000 / 100,000")
 }
 
+func TestRenderApplyStatusComment_UsesOneRenderTimestamp(t *testing.T) {
+	original := TimestampFunc
+	timestamps := []string{"2026-06-16 19:42:00 UTC", "2026-06-16 19:42:01 UTC"}
+	TimestampFunc = func() string {
+		ts := timestamps[0]
+		timestamps = timestamps[1:]
+		return ts
+	}
+	t.Cleanup(func() { TimestampFunc = original })
+
+	result := RenderApplyStatusComment(ApplyStatusCommentData{
+		Database:    "testapp",
+		Environment: "staging",
+		RequestedBy: "aparajon",
+		State:       state.Apply.Running,
+		ApplyID:     "apply-abc123",
+	})
+
+	assert.Contains(t, result, "*Applied by @aparajon at 2026-06-16 19:42:00 UTC*")
+	assert.Contains(t, result, "<relative-time datetime=\"2026-06-16T19:42:00Z\">2026-06-16 19:42:00 UTC</relative-time>")
+	assert.NotContains(t, result, "2026-06-16 19:42:01 UTC")
+}
+
 func TestRenderApplyStatusComment_Completed(t *testing.T) {
 	data := ApplyStatusCommentData{
 		Database:    "testapp",
@@ -114,6 +147,7 @@ func TestRenderApplyStatusComment_Completed(t *testing.T) {
 	assert.Contains(t, result, "📊 2/2 complete")
 	// Each table has "✓ Complete" = 2 total
 	assert.Equal(t, 2, strings.Count(result, "Complete"))
+	assert.NotContains(t, result, "Last updated")
 }
 
 func TestRenderApplyStatusComment_SQLFencesAreTopLevel(t *testing.T) {

--- a/pkg/webhook/templates/common.go
+++ b/pkg/webhook/templates/common.go
@@ -2,6 +2,7 @@ package templates
 
 import (
 	"fmt"
+	"html"
 	"strings"
 	"time"
 )
@@ -88,18 +89,44 @@ func writeAppliedByOrTimestamp(sb *strings.Builder, appliedBy string) {
 	writeAttributionLine(sb, "Applied", appliedBy)
 }
 
+func writeAppliedByOrTimestampAt(sb *strings.Builder, appliedBy, timestamp string) {
+	writeAttributionLineAt(sb, "Applied", appliedBy, timestamp, "")
+}
+
 // writeAttributionLine writes a "*Verb by @user at timestamp*" line.
 func writeAttributionLine(sb *strings.Builder, verb, user string) {
 	writeAttributionLineWithSuffix(sb, verb, user, "")
 }
 
 func writeAttributionLineWithSuffix(sb *strings.Builder, verb, user, suffix string) {
-	ts := currentTimestamp()
+	writeAttributionLineAt(sb, verb, user, currentTimestamp(), suffix)
+}
+
+func writeAttributionLineAt(sb *strings.Builder, verb, user, timestamp, suffix string) {
 	if user != "" {
-		fmt.Fprintf(sb, "\n*%s by @%s at %s%s*\n", verb, user, ts, suffix)
+		fmt.Fprintf(sb, "\n*%s by @%s at %s%s*\n", verb, user, timestamp, suffix)
 	} else {
-		fmt.Fprintf(sb, "\n*Started at %s%s*\n", ts, suffix)
+		fmt.Fprintf(sb, "\n*Started at %s%s*\n", timestamp, suffix)
 	}
+}
+
+func writeLastUpdatedFooter(sb *strings.Builder, timestamp string) {
+	if !strings.HasSuffix(sb.String(), "\n") {
+		sb.WriteString("\n")
+	}
+	escapedTimestamp := html.EscapeString(timestamp)
+	fmt.Fprintf(sb, "\n_Last updated: <relative-time datetime=\"%s\">%s</relative-time> (%s)_\n",
+		escapeRelativeTimeDatetime(timestamp),
+		escapedTimestamp,
+		escapedTimestamp)
+}
+
+func escapeRelativeTimeDatetime(timestamp string) string {
+	parsed, err := time.Parse("2006-01-02 15:04:05 UTC", timestamp)
+	if err != nil {
+		return html.EscapeString(timestamp)
+	}
+	return parsed.UTC().Format(time.RFC3339)
 }
 
 // truncateDDL strips backtick-quoting from a DDL statement and truncates to maxLen characters.

--- a/pkg/webhook/templates/multi_apply.go
+++ b/pkg/webhook/templates/multi_apply.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/block/schemabot/pkg/presentation"
+	"github.com/block/schemabot/pkg/state"
 )
 
 // MultiDeploymentApplyData is the input to the multi-deployment apply comment.
@@ -53,11 +54,12 @@ type MultiDeploymentApplyData struct {
 // it with RenderApplyStatusComment so that UX stays byte-for-byte unchanged.
 func RenderMultiDeploymentApplyComment(data MultiDeploymentApplyData) string {
 	var sb strings.Builder
+	renderedAt := currentTimestamp()
 
 	// Aggregate header: reuse the single-deployment title map keyed on the
 	// derived aggregate state so the headline vocabulary is identical.
 	writeApplyHeader(&sb, ApplyStatusCommentData{State: data.Model.State})
-	writeAggregateMetadata(&sb, data)
+	writeAggregateMetadata(&sb, data, renderedAt)
 	writeDeploymentCounts(&sb, data.Model.Counts)
 	writeAggregateFirstFailure(&sb, data.Model.FirstFailure)
 	writeAggregateNextAction(&sb, data)
@@ -67,7 +69,10 @@ func RenderMultiDeploymentApplyComment(data MultiDeploymentApplyData) string {
 	writeDeploymentSummaryList(&sb, data.Model.Deployments)
 
 	// Expandable per-deployment detail, in resolved order.
-	writeDeploymentSections(&sb, data)
+	writeDeploymentSections(&sb, data, renderedAt)
+	if !state.IsTerminalApplyState(data.Model.State) {
+		writeLastUpdatedFooter(&sb, renderedAt)
+	}
 
 	return sb.String()
 }
@@ -85,7 +90,7 @@ func RenderMultiDeploymentApplySummaryComment(data MultiDeploymentApplyData) str
 	var sb strings.Builder
 
 	writeApplyHeader(&sb, ApplyStatusCommentData{State: data.Model.State})
-	writeAggregateMetadata(&sb, data)
+	writeAggregateMetadata(&sb, data, currentTimestamp())
 	writeDeploymentCounts(&sb, data.Model.Counts)
 	writeAggregateFirstFailure(&sb, data.Model.FirstFailure)
 	writeAggregateNextAction(&sb, data)
@@ -102,7 +107,7 @@ func RenderMultiDeploymentApplySummaryComment(data MultiDeploymentApplyData) str
 // intentionally omitted — it is per-deployment and shown in each deployment's
 // section — so the aggregate carries only the environment, apply ID, elapsed
 // time, and requester.
-func writeAggregateMetadata(sb *strings.Builder, data MultiDeploymentApplyData) {
+func writeAggregateMetadata(sb *strings.Builder, data MultiDeploymentApplyData, renderedAt string) {
 	// Environment and ApplyID are always populated from the persisted apply, so
 	// they are rendered unconditionally; only the optional elapsed time is guarded.
 	parts := []string{
@@ -113,7 +118,7 @@ func writeAggregateMetadata(sb *strings.Builder, data MultiDeploymentApplyData) 
 		parts = append(parts, fmt.Sprintf("**Elapsed**: %s", elapsed))
 	}
 	fmt.Fprintf(sb, "%s\n", strings.Join(parts, " | "))
-	writeAppliedByOrTimestamp(sb, data.RequestedBy)
+	writeAppliedByOrTimestampAt(sb, data.RequestedBy, renderedAt)
 }
 
 // writeDeploymentCounts writes the per-status histogram so an operator sees
@@ -192,8 +197,10 @@ func writeDeploymentSummaryList(sb *strings.Builder, deps []presentation.Deploym
 
 // writeDeploymentSections writes the in-progress status detail per deployment,
 // reusing the single-deployment status renderer for each <details> body.
-func writeDeploymentSections(sb *strings.Builder, data MultiDeploymentApplyData) {
-	writeDeploymentDetailSections(sb, data, RenderApplyStatusComment)
+func writeDeploymentSections(sb *strings.Builder, data MultiDeploymentApplyData, renderedAt string) {
+	writeDeploymentDetailSections(sb, data, func(detail ApplyStatusCommentData) string {
+		return renderApplyStatusComment(detail, false, renderedAt)
+	})
 }
 
 // writeDeploymentSummarySections writes the terminal summary detail per

--- a/pkg/webhook/templates/multi_apply_test.go
+++ b/pkg/webhook/templates/multi_apply_test.go
@@ -24,6 +24,7 @@ func rollingOp(dep, st string) presentation.Operation {
 // title, a per-status count line, a single cutover next-action, an at-a-glance
 // per-deployment summary, and a <details> block per deployment in resolved order.
 func TestRenderMultiDeploymentApplyComment_BarrierInProgress(t *testing.T) {
+	withTemplateTimestamp(t, "2026-06-16 19:43:00 UTC")
 	model := presentation.Derive([]presentation.Operation{
 		barrierOp("eu", so.WaitingForCutover),
 		barrierOp("us", so.Running),
@@ -39,6 +40,8 @@ func TestRenderMultiDeploymentApplyComment_BarrierInProgress(t *testing.T) {
 	assert.Contains(t, out, "## Schema Change In Progress")
 	assert.Contains(t, out, "**Environment**: `production`")
 	assert.Contains(t, out, "**Apply ID**: `apply-123`")
+	assert.Contains(t, out, "_Last updated: <relative-time datetime=\"2026-06-16T19:43:00Z\">2026-06-16 19:43:00 UTC</relative-time> (2026-06-16 19:43:00 UTC)_")
+	assert.NotContains(t, out, "**Last updated**")
 	assert.Contains(t, out, "**Deployments**: 1 ready for cutover, 1 running, 2 waiting")
 
 	// Single next-action points at the cutover-ready deployment, even though the
@@ -90,6 +93,39 @@ func TestRenderMultiDeploymentApplyComment_FailedHalt(t *testing.T) {
 	// With no error detail on the failed operation, the first-failure line names
 	// the deployment without a reason.
 	assert.Contains(t, out, "> ⚠️ **First failure:** <code>us</code>\n")
+}
+
+func TestRenderMultiDeploymentApplyComment_UsesOneRenderTimestamp(t *testing.T) {
+	original := TimestampFunc
+	timestamps := []string{"2026-06-16 19:43:00 UTC", "2026-06-16 19:43:01 UTC"}
+	TimestampFunc = func() string {
+		ts := timestamps[0]
+		timestamps = timestamps[1:]
+		return ts
+	}
+	t.Cleanup(func() { TimestampFunc = original })
+
+	model := presentation.Derive([]presentation.Operation{
+		rollingOp("us", so.Running),
+	})
+	out := RenderMultiDeploymentApplyComment(MultiDeploymentApplyData{
+		Model:       model,
+		ApplyID:     "apply-123",
+		Environment: "production",
+		RequestedBy: "aparajon",
+		Details: map[string]ApplyStatusCommentData{
+			"us": {
+				Database:    "payments_us",
+				Environment: "production",
+				State:       state.Apply.Running,
+				RequestedBy: "aparajon",
+			},
+		},
+	})
+
+	assert.Contains(t, out, "*Applied by @aparajon at 2026-06-16 19:43:00 UTC*")
+	assert.Contains(t, out, "<relative-time datetime=\"2026-06-16T19:43:00Z\">2026-06-16 19:43:00 UTC</relative-time>")
+	assert.NotContains(t, out, "2026-06-16 19:43:01 UTC")
 }
 
 // firstFailingOp builds a rolling, continue-policy operation carrying an error,
@@ -304,6 +340,7 @@ func TestRenderMultiDeploymentApplyComment_NoNextActionWhenCompleted(t *testing.
 	assert.NotContains(t, out, "schemabot revert")
 	assert.NotContains(t, out, "To resume:")
 	assert.NotContains(t, out, "To retry:")
+	assert.NotContains(t, out, "Last updated")
 }
 
 // Deployment names and labels come from configuration/engine state, so they are


### PR DESCRIPTION
## Why
PR progress comments can appear stale during slow row-copy work when the visible progress bar does not change. Showing when the comment was last refreshed helps operators distinguish slow progress from a stuck update loop.

## What
- Add a `Last updated` timestamp to single-deployment progress comment metadata
- Add the same freshness timestamp to multi-deployment aggregate progress comments
- Regenerate `TEMPLATES.md` from the preview script

## Risk Assessment
Low — this only changes GitHub comment presentation; schema change execution and stored state are unchanged.

Generated with Amp