### PR TITLE
feat(inventory): Vitess data plane via the Etre resolver

### DIFF
--- a/e2e/k8s/data-plane-etre-values.yaml
+++ b/e2e/k8s/data-plane-etre-values.yaml
@@ -22,13 +22,15 @@ config:
   target_resolver:
     etre:
       addr: "http://etre:8080"
+      database_type: mysql
       entity_type: aurora_cluster
       target_label: dsid
       env_label: env
       labels:
         aws_region: us-east-1
-      host_field: writer_endpoint
-      default_port: "3306"
+      mysql:
+        host_field: writer_endpoint
+        default_port: "3306"
       credentials:
         type: awssm
         region: us-east-1

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -394,14 +394,19 @@ func (c TargetResolverConfig) StaticInventory() inventory.StaticConfig {
 	return inventory.StaticConfig{Targets: c.Targets}
 }
 
-// EtreConfig configures the data-plane MySQL resolver backed by Etre: the Etre
-// lookup that maps an opaque target to a cluster endpoint, plus the credentials
-// for the assembled connection. It is the common-path dynamic resolver;
-// additional engines and per-target overrides layer on without reshaping it.
+// EtreConfig configures the data-plane resolver backed by Etre: the Etre lookup
+// that maps an opaque target to a cluster endpoint, plus the credentials for the
+// assembled connection. It is the common-path dynamic resolver; the engine is
+// selected by DatabaseType, and engine-specific knobs live in a per-engine block
+// so the shared config carries no engine semantics.
 type EtreConfig struct {
 	// Addr is the Etre server address (supports secret refs, e.g. env:ETRE_ADDR).
 	Addr string `yaml:"addr"`
-	// EntityType is the Etre entity type recording MySQL clusters.
+	// DatabaseType selects the engine the resolver assembles connections for and
+	// is required (no implicit default): "mysql" reads the MySQL block; "vitess"
+	// reads the Vitess block.
+	DatabaseType string `yaml:"database_type"`
+	// EntityType is the Etre entity type recording the target clusters.
 	EntityType string `yaml:"entity_type"`
 	// TargetLabel is the Etre label the request's opaque target matches.
 	TargetLabel string `yaml:"target_label"`
@@ -409,14 +414,34 @@ type EtreConfig struct {
 	EnvLabel string `yaml:"env_label,omitempty"`
 	// Labels are fixed selector predicates added to every lookup (e.g. a region).
 	Labels map[string]string `yaml:"labels,omitempty"`
+	// AttributeFields are entity fields surfaced to the credential resolver.
+	AttributeFields []string `yaml:"attribute_fields,omitempty"`
+	// MySQL holds the MySQL engine knobs, read when DatabaseType is "mysql".
+	MySQL EtreMySQLConfig `yaml:"mysql,omitempty"`
+	// Vitess holds the Vitess engine knobs, read when DatabaseType is "vitess".
+	Vitess EtreVitessConfig `yaml:"vitess,omitempty"`
+	// Credentials configures the credentials for the connection.
+	Credentials EtreCredentialsConfig `yaml:"credentials"`
+}
+
+// EtreMySQLConfig holds the MySQL-specific knobs for an Etre resolver: how to
+// turn a resolved entity into a connection host.
+type EtreMySQLConfig struct {
 	// HostField is the entity field holding the connection host.
 	HostField string `yaml:"host_field"`
 	// DefaultPort is appended to the host when it has no port.
 	DefaultPort string `yaml:"default_port,omitempty"`
-	// AttributeFields are entity fields surfaced to the credential resolver.
-	AttributeFields []string `yaml:"attribute_fields,omitempty"`
-	// Credentials configures the username and password for the connection.
-	Credentials EtreCredentialsConfig `yaml:"credentials"`
+}
+
+// EtreVitessConfig holds the Vitess (PlanetScale) knobs for an Etre resolver:
+// how to find the organization and reach the PlanetScale-compatible API.
+type EtreVitessConfig struct {
+	// OrganizationAttribute is the entity field holding the PlanetScale
+	// organization. Defaults to "organization".
+	OrganizationAttribute string `yaml:"organization_attribute,omitempty"`
+	// APIURL is the PlanetScale-compatible API base URL; a per-target override in
+	// the credential secret takes precedence.
+	APIURL string `yaml:"api_url,omitempty"`
 }
 
 // EtreCredentialsConfig configures credentials for an Etre-resolved target.

--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -274,10 +274,11 @@ func TestServerConfig_Validate(t *testing.T) {
 			cfg: ServerConfig{
 				TargetResolver: TargetResolverConfig{
 					Etre: EtreConfig{
-						Addr:        "http://etre:8080",
-						EntityType:  "aurora_cluster",
-						TargetLabel: "dsid",
-						HostField:   "writer_endpoint",
+						Addr:         "http://etre:8080",
+						DatabaseType: storage.DatabaseTypeMySQL,
+						EntityType:   "aurora_cluster",
+						TargetLabel:  "dsid",
+						MySQL:        EtreMySQLConfig{HostField: "writer_endpoint"},
 						Credentials: EtreCredentialsConfig{
 							Username:    "spirit",
 							PasswordRef: "env:DDL_PASSWORD",

--- a/pkg/awscreds/awscreds.go
+++ b/pkg/awscreds/awscreds.go
@@ -50,6 +50,10 @@ type Config struct {
 	// AccountAttribute is the endpoint attribute holding the target's AWS account
 	// id. Defaults to "aws_account_id".
 	AccountAttribute string
+	// Decode, when set, interprets the fetched secret into Credentials (for
+	// example a PlanetScale token). When nil the secret is parsed as a JSON
+	// {username, password} payload.
+	Decode inventory.SecretDecoder
 }
 
 // Resolver resolves credentials from Secrets Manager via per-account assumed
@@ -58,6 +62,7 @@ type Resolver struct {
 	accountAttr string
 	secretName  string
 	fetch       secretFetcher
+	decode      inventory.SecretDecoder
 }
 
 var _ inventory.CredentialResolver = (*Resolver)(nil)
@@ -89,13 +94,13 @@ func New(cfg Config) (*Resolver, error) {
 		externalID: cfg.ExternalID,
 		clients:    make(map[string]*secretsmanager.Client),
 	}
-	return newResolver(accountAttr, cfg.SecretName, fetch), nil
+	return newResolver(accountAttr, cfg.SecretName, fetch, cfg.Decode), nil
 }
 
 // newResolver constructs a Resolver over a given fetcher, so tests can inject a
 // fake that does not call AWS.
-func newResolver(accountAttr, secretName string, fetch secretFetcher) *Resolver {
-	return &Resolver{accountAttr: accountAttr, secretName: secretName, fetch: fetch}
+func newResolver(accountAttr, secretName string, fetch secretFetcher, decode inventory.SecretDecoder) *Resolver {
+	return &Resolver{accountAttr: accountAttr, secretName: secretName, fetch: fetch, decode: decode}
 }
 
 // ResolveCredentials reads the target's account from attrs, fetches the secret
@@ -112,6 +117,14 @@ func (r *Resolver) ResolveCredentials(ctx context.Context, req inventory.Request
 	raw, err := r.fetch.FetchSecret(ctx, accountID, secretName)
 	if err != nil {
 		return nil, fmt.Errorf("fetch secret %q for target %q in account %s: %w", secretName, req.Target, accountID, err)
+	}
+
+	if r.decode != nil {
+		creds, err := r.decode(raw)
+		if err != nil {
+			return nil, fmt.Errorf("decode secret %q for target %q in account %s: %w", secretName, req.Target, accountID, err)
+		}
+		return creds, nil
 	}
 
 	var parsed struct {

--- a/pkg/awscreds/awscreds_test.go
+++ b/pkg/awscreds/awscreds_test.go
@@ -28,7 +28,7 @@ func (f *fakeFetcher) FetchSecret(_ context.Context, accountID, secretName strin
 
 func TestResolverReadsJSONSecretForTargetAccount(t *testing.T) {
 	fetch := &fakeFetcher{payload: `{"username":"spirit","password":"s3cret"}`}
-	r := newResolver("aws_account_id", "ods-rds-spirit-password", fetch)
+	r := newResolver("aws_account_id", "ods-rds-spirit-password", fetch, nil)
 
 	creds, err := r.ResolveCredentials(t.Context(),
 		inventory.Request{Target: "orders-dsid"},
@@ -44,7 +44,7 @@ func TestResolverReadsJSONSecretForTargetAccount(t *testing.T) {
 // The secret name may carry a {target} placeholder for per-target secrets.
 func TestResolverTemplatesSecretNameByTarget(t *testing.T) {
 	fetch := &fakeFetcher{payload: `{"username":"ddl","password":"pw"}`}
-	r := newResolver("aws_account_id", "schemabot/{target}/ddl", fetch)
+	r := newResolver("aws_account_id", "schemabot/{target}/ddl", fetch, nil)
 
 	_, err := r.ResolveCredentials(t.Context(),
 		inventory.Request{Target: "orders-dsid"},
@@ -54,7 +54,7 @@ func TestResolverTemplatesSecretNameByTarget(t *testing.T) {
 }
 
 func TestResolverFailsWhenAccountAttributeMissing(t *testing.T) {
-	r := newResolver("aws_account_id", "secret", &fakeFetcher{payload: `{"username":"u","password":"p"}`})
+	r := newResolver("aws_account_id", "secret", &fakeFetcher{payload: `{"username":"u","password":"p"}`}, nil)
 
 	_, err := r.ResolveCredentials(t.Context(), inventory.Request{Target: "orders-dsid"}, nil)
 	require.Error(t, err)
@@ -62,7 +62,7 @@ func TestResolverFailsWhenAccountAttributeMissing(t *testing.T) {
 }
 
 func TestResolverPropagatesFetchError(t *testing.T) {
-	r := newResolver("aws_account_id", "secret", &fakeFetcher{err: fmt.Errorf("access denied")})
+	r := newResolver("aws_account_id", "secret", &fakeFetcher{err: fmt.Errorf("access denied")}, nil)
 
 	_, err := r.ResolveCredentials(t.Context(),
 		inventory.Request{Target: "orders-dsid"},
@@ -72,7 +72,7 @@ func TestResolverPropagatesFetchError(t *testing.T) {
 }
 
 func TestResolverFailsOnNonJSONSecret(t *testing.T) {
-	r := newResolver("aws_account_id", "secret", &fakeFetcher{payload: "not-json"})
+	r := newResolver("aws_account_id", "secret", &fakeFetcher{payload: "not-json"}, nil)
 
 	_, err := r.ResolveCredentials(t.Context(),
 		inventory.Request{Target: "orders-dsid"},
@@ -82,13 +82,29 @@ func TestResolverFailsOnNonJSONSecret(t *testing.T) {
 }
 
 func TestResolverFailsOnIncompleteSecret(t *testing.T) {
-	r := newResolver("aws_account_id", "secret", &fakeFetcher{payload: `{"username":"spirit"}`})
+	r := newResolver("aws_account_id", "secret", &fakeFetcher{payload: `{"username":"spirit"}`}, nil)
 
 	_, err := r.ResolveCredentials(t.Context(),
 		inventory.Request{Target: "orders-dsid"},
 		map[string]string{"aws_account_id": "123456789012"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "missing a username or password")
+}
+
+// With a Decode set, the resolver interprets the fetched secret with that
+// decoder instead of the default {username, password} parse — for example a
+// PlanetScale token read through the same assume-role path.
+func TestResolverUsesDecoder(t *testing.T) {
+	fetch := &fakeFetcher{payload: `{"token":"tok-id=tok-secret"}`}
+	r := newResolver("aws_account_id", "secret", fetch, inventory.DecodePlanetScaleSecret)
+
+	creds, err := r.ResolveCredentials(t.Context(),
+		inventory.Request{Target: "orders-dsid"},
+		map[string]string{"aws_account_id": "123456789012"})
+	require.NoError(t, err)
+	assert.Empty(t, creds.Username, "a PlanetScale credential carries no username")
+	assert.Equal(t, "tok-id", creds.Metadata["token_name"])
+	assert.Equal(t, "tok-secret", creds.Metadata["token_value"])
 }
 
 func TestNewValidatesConfig(t *testing.T) {

--- a/pkg/cmd/commands/serve.go
+++ b/pkg/cmd/commands/serve.go
@@ -397,15 +397,16 @@ func buildTargetResolver(ctx context.Context, cfg api.TargetResolverConfig, logg
 	return resolver, nil
 }
 
-// buildEtreResolver assembles the Etre-backed MySQL resolver from config: the
-// Etre query client, the namespace-free MySQL connection assembler, and the
-// configured credential resolver. Lazily-validated fields (host, credentials)
-// are checked here so a misconfiguration fails at startup, not first request.
+// buildEtreResolver assembles the Etre-backed resolver from config: the Etre
+// query client, the engine-specific connection assembler, and the configured
+// credential resolver. Lazily-validated fields (host, credentials) are checked
+// here so a misconfiguration fails at startup, not first request.
 func buildEtreResolver(ctx context.Context, cfg api.EtreConfig, logger *slog.Logger) (inventory.Resolver, error) {
-	if cfg.HostField == "" {
-		return nil, fmt.Errorf("target_resolver.etre.host_field is required")
+	assembler, decode, err := etreAssembler(cfg)
+	if err != nil {
+		return nil, err
 	}
-	creds, err := buildCredentialResolver(ctx, cfg.Credentials)
+	creds, err := buildCredentialResolver(ctx, cfg.Credentials, decode)
 	if err != nil {
 		return nil, err
 	}
@@ -427,11 +428,35 @@ func buildEtreResolver(ctx context.Context, cfg api.EtreConfig, logger *slog.Log
 		TargetLabel:     cfg.TargetLabel,
 		Labels:          cfg.Labels,
 		EnvLabel:        cfg.EnvLabel,
-		HostField:       cfg.HostField,
-		AttributeFields: credentialAttributeFields(cfg),
+		HostField:       cfg.MySQL.HostField,
+		AttributeFields: resolverAttributeFields(cfg),
 		Credentials:     creds,
-		Assembler:       inventory.MySQLConnectionAssembler{DefaultPort: cfg.DefaultPort},
+		Assembler:       assembler,
 	})
+}
+
+// etreAssembler selects the engine-specific connection assembler for the
+// configured database type, plus the secret decoder that backend needs. MySQL
+// builds a namespace-free DSN from the host; Vitess assembles PlanetScale API
+// metadata and decodes a token secret rather than a username/password. A new
+// engine (postgres, strata) is a new case here; an unsupported type fails closed.
+func etreAssembler(cfg api.EtreConfig) (inventory.ConnectionAssembler, inventory.SecretDecoder, error) {
+	switch cfg.DatabaseType {
+	case "":
+		return nil, nil, fmt.Errorf("target_resolver.etre.database_type is required (%q or %q)", storage.DatabaseTypeMySQL, storage.DatabaseTypeVitess)
+	case storage.DatabaseTypeMySQL:
+		if cfg.MySQL.HostField == "" {
+			return nil, nil, fmt.Errorf("target_resolver.etre.mysql.host_field is required for the %q engine", storage.DatabaseTypeMySQL)
+		}
+		return inventory.MySQLConnectionAssembler{DefaultPort: cfg.MySQL.DefaultPort}, nil, nil
+	case storage.DatabaseTypeVitess:
+		return inventory.VitessConnectionAssembler{
+			OrganizationAttribute: cfg.Vitess.OrganizationAttribute,
+			APIURL:                cfg.Vitess.APIURL,
+		}, inventory.DecodePlanetScaleSecret, nil
+	default:
+		return nil, nil, fmt.Errorf("target_resolver.etre.database_type %q is not supported", cfg.DatabaseType)
+	}
 }
 
 const (
@@ -451,16 +476,19 @@ func credentialType(cfg api.EtreCredentialsConfig) string {
 // buildCredentialResolver builds the configured credential backend. Each backend
 // is one inventory.CredentialResolver implementation; the data plane is not
 // coupled to any single secret store.
-func buildCredentialResolver(ctx context.Context, cfg api.EtreCredentialsConfig) (inventory.CredentialResolver, error) {
+func buildCredentialResolver(ctx context.Context, cfg api.EtreCredentialsConfig, decode inventory.SecretDecoder) (inventory.CredentialResolver, error) {
 	switch credentialType(cfg) {
 	case credentialTypeSecretRef:
-		if cfg.Username == "" {
-			return nil, fmt.Errorf("target_resolver.etre.credentials.username is required")
-		}
 		if cfg.PasswordRef == "" {
 			return nil, fmt.Errorf("target_resolver.etre.credentials.password_ref is required")
 		}
-		return inventory.SecretRefCredentialResolver{Username: cfg.Username, PasswordRef: cfg.PasswordRef}, nil
+		// A decoder (for example a Vitess token) produces the full credential from
+		// the secret, so no separate username is configured; require a username
+		// only for the plain username + password form.
+		if decode == nil && cfg.Username == "" {
+			return nil, fmt.Errorf("target_resolver.etre.credentials.username is required")
+		}
+		return inventory.SecretRefCredentialResolver{Username: cfg.Username, PasswordRef: cfg.PasswordRef, Decode: decode}, nil
 
 	case credentialTypeAWSSM:
 		// Validate required fields with config-path context before loading AWS
@@ -485,6 +513,7 @@ func buildCredentialResolver(ctx context.Context, cfg api.EtreCredentialsConfig)
 			ExternalID:       cfg.ExternalID,
 			SecretName:       cfg.SecretName,
 			AccountAttribute: cfg.AccountAttribute,
+			Decode:           decode,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("build target_resolver.etre.credentials awssm resolver: %w", err)
@@ -496,22 +525,37 @@ func buildCredentialResolver(ctx context.Context, cfg api.EtreCredentialsConfig)
 	}
 }
 
-// credentialAttributeFields returns the entity attribute fields the resolver
-// must surface, ensuring the assume-role backend's account attribute is included
+// resolverAttributeFields returns the entity attribute fields the resolver must
+// surface so the assembler and credential backend can locate their inputs: the
+// Vitess organization attribute and the assume-role backend's account attribute,
 // alongside any explicitly configured fields.
-func credentialAttributeFields(cfg api.EtreConfig) []string {
-	fields := cfg.AttributeFields
-	if credentialType(cfg.Credentials) != credentialTypeAWSSM {
+func resolverAttributeFields(cfg api.EtreConfig) []string {
+	fields := append([]string(nil), cfg.AttributeFields...)
+	// Engines that resolve a connection attribute rather than a host surface it
+	// here. A new such engine adds a branch; host-based engines (mysql) add none.
+	if cfg.DatabaseType == storage.DatabaseTypeVitess {
+		orgAttr := cfg.Vitess.OrganizationAttribute
+		if orgAttr == "" {
+			orgAttr = inventory.MetadataOrganization
+		}
+		fields = ensureField(fields, orgAttr)
+	}
+	if credentialType(cfg.Credentials) == credentialTypeAWSSM {
+		accountAttr := cfg.Credentials.AccountAttribute
+		if accountAttr == "" {
+			accountAttr = "aws_account_id"
+		}
+		fields = ensureField(fields, accountAttr)
+	}
+	return fields
+}
+
+// ensureField appends field unless it is already present.
+func ensureField(fields []string, field string) []string {
+	if slices.Contains(fields, field) {
 		return fields
 	}
-	accountAttr := cfg.Credentials.AccountAttribute
-	if accountAttr == "" {
-		accountAttr = "aws_account_id"
-	}
-	if slices.Contains(fields, accountAttr) {
-		return fields
-	}
-	return append(append([]string(nil), fields...), accountAttr)
+	return append(fields, field)
 }
 
 // grpcLocalClientFactory returns a LocalClientFactory that applies server-level

--- a/pkg/cmd/commands/serve_grpc_test.go
+++ b/pkg/cmd/commands/serve_grpc_test.go
@@ -45,11 +45,12 @@ func TestBuildGRPCTernClientRoutesViaEtreResolver(t *testing.T) {
 	config := &api.ServerConfig{
 		TargetResolver: api.TargetResolverConfig{
 			Etre: api.EtreConfig{
-				Addr:        "https://etre.example",
-				EntityType:  "cluster",
-				TargetLabel: "dsid",
-				HostField:   "writer_endpoint",
-				Credentials: api.EtreCredentialsConfig{Username: "spirit", PasswordRef: "env:DDL_PASSWORD"},
+				Addr:         "https://etre.example",
+				DatabaseType: storage.DatabaseTypeMySQL,
+				EntityType:   "cluster",
+				TargetLabel:  "dsid",
+				MySQL:        api.EtreMySQLConfig{HostField: "writer_endpoint"},
+				Credentials:  api.EtreCredentialsConfig{Username: "spirit", PasswordRef: "env:DDL_PASSWORD"},
 			},
 		},
 	}
@@ -67,10 +68,11 @@ func TestBuildGRPCTernClientRoutesViaEtreWithAWSSMCredentials(t *testing.T) {
 	config := &api.ServerConfig{
 		TargetResolver: api.TargetResolverConfig{
 			Etre: api.EtreConfig{
-				Addr:        "https://etre.example",
-				EntityType:  "cluster",
-				TargetLabel: "dsid",
-				HostField:   "writer_endpoint",
+				Addr:         "https://etre.example",
+				DatabaseType: storage.DatabaseTypeMySQL,
+				EntityType:   "cluster",
+				TargetLabel:  "dsid",
+				MySQL:        api.EtreMySQLConfig{HostField: "writer_endpoint"},
 				Credentials: api.EtreCredentialsConfig{
 					Type:       "awssm",
 					Region:     "us-west-2",
@@ -91,7 +93,8 @@ func TestBuildGRPCTernClientRoutesViaEtreWithAWSSMCredentials(t *testing.T) {
 func TestBuildEtreResolverRejectsUnknownCredentialType(t *testing.T) {
 	logger := slog.New(slog.DiscardHandler)
 	cfg := api.EtreConfig{
-		Addr: "https://etre.example", EntityType: "cluster", TargetLabel: "dsid", HostField: "writer_endpoint",
+		Addr: "https://etre.example", DatabaseType: storage.DatabaseTypeMySQL, EntityType: "cluster", TargetLabel: "dsid",
+		MySQL:       api.EtreMySQLConfig{HostField: "writer_endpoint"},
 		Credentials: api.EtreCredentialsConfig{Type: "vault"},
 	}
 
@@ -110,7 +113,7 @@ func TestBuildCredentialResolverAWSSMRequiresFields(t *testing.T) {
 		SecretName: "{target}_ddl_password",
 	}
 
-	_, err := buildCredentialResolver(t.Context(), base)
+	_, err := buildCredentialResolver(t.Context(), base, nil)
 	require.NoError(t, err)
 
 	cases := map[string]func(*api.EtreCredentialsConfig){
@@ -121,7 +124,7 @@ func TestBuildCredentialResolverAWSSMRequiresFields(t *testing.T) {
 	for field, mutate := range cases {
 		cfg := base
 		mutate(&cfg)
-		_, err := buildCredentialResolver(t.Context(), cfg)
+		_, err := buildCredentialResolver(t.Context(), cfg, nil)
 		require.Error(t, err, field)
 		assert.Contains(t, err.Error(), field)
 	}
@@ -134,18 +137,74 @@ func TestCredentialAttributeFieldsIncludesAccountAttribute(t *testing.T) {
 		AttributeFields: []string{"region"},
 		Credentials:     api.EtreCredentialsConfig{Type: "awssm"},
 	}
-	assert.Equal(t, []string{"region", "aws_account_id"}, credentialAttributeFields(withDefault))
+	assert.Equal(t, []string{"region", "aws_account_id"}, resolverAttributeFields(withDefault))
 
 	custom := api.EtreConfig{
 		Credentials: api.EtreCredentialsConfig{Type: "awssm", AccountAttribute: "account"},
 	}
-	assert.Equal(t, []string{"account"}, credentialAttributeFields(custom))
+	assert.Equal(t, []string{"account"}, resolverAttributeFields(custom))
 
 	secretRef := api.EtreConfig{
 		AttributeFields: []string{"region"},
 		Credentials:     api.EtreCredentialsConfig{Type: "secret_ref"},
 	}
-	assert.Equal(t, []string{"region"}, credentialAttributeFields(secretRef))
+	assert.Equal(t, []string{"region"}, resolverAttributeFields(secretRef))
+}
+
+// A Vitess Etre resolver assembles PlanetScale API metadata, so it needs no
+// host_field and no credential username — the token secret carries the
+// credential. Startup wiring accepts this shape.
+func TestBuildEtreResolverVitess(t *testing.T) {
+	logger := slog.New(slog.DiscardHandler)
+	cfg := api.EtreConfig{
+		Addr:         "https://etre.example",
+		DatabaseType: storage.DatabaseTypeVitess,
+		EntityType:   "planetscale_database",
+		TargetLabel:  "dsid",
+		EnvLabel:     "env",
+		Vitess:       api.EtreVitessConfig{APIURL: "https://api.planetscale.test"},
+		Credentials:  api.EtreCredentialsConfig{Type: "secret_ref", PasswordRef: `{"token":"id=value"}`},
+	}
+
+	resolver, err := buildEtreResolver(t.Context(), cfg, logger)
+	require.NoError(t, err)
+	require.NotNil(t, resolver)
+
+	// A Vitess resolver still requires the password ref that carries the token.
+	noToken := cfg
+	noToken.Credentials.PasswordRef = ""
+	_, err = buildEtreResolver(t.Context(), noToken, logger)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "password_ref")
+}
+
+// An unsupported database_type fails closed at startup rather than silently
+// resolving as MySQL, so adding an engine (postgres, strata) is a deliberate
+// change at the assembler-selection site.
+func TestBuildEtreResolverRejectsUnsupportedEngine(t *testing.T) {
+	logger := slog.New(slog.DiscardHandler)
+	cfg := api.EtreConfig{
+		Addr:         "https://etre.example",
+		DatabaseType: "postgres",
+		EntityType:   "pg_cluster",
+		TargetLabel:  "dsid",
+		Credentials:  api.EtreCredentialsConfig{Type: "secret_ref", Username: "ddl", PasswordRef: "env:PW"},
+	}
+
+	_, err := buildEtreResolver(t.Context(), cfg, logger)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "postgres")
+	assert.Contains(t, err.Error(), "not supported")
+}
+
+// The Vitess organization attribute is surfaced to the resolver so the assembler
+// can read it, even when not listed in attribute_fields.
+func TestResolverAttributeFieldsIncludesOrganization(t *testing.T) {
+	defaultOrg := api.EtreConfig{DatabaseType: storage.DatabaseTypeVitess}
+	assert.Equal(t, []string{"organization"}, resolverAttributeFields(defaultOrg))
+
+	customOrg := api.EtreConfig{DatabaseType: storage.DatabaseTypeVitess, Vitess: api.EtreVitessConfig{OrganizationAttribute: "ps_org"}}
+	assert.Equal(t, []string{"ps_org"}, resolverAttributeFields(customOrg))
 }
 
 // Configuring both the Etre resolver and static targets is ambiguous until
@@ -160,7 +219,7 @@ func TestBuildGRPCTernClientErrorsWhenEtreAndStaticBothConfigured(t *testing.T) 
 			},
 			Etre: api.EtreConfig{
 				Addr: "https://etre.example", EntityType: "cluster", TargetLabel: "dsid",
-				HostField: "writer_endpoint", Credentials: api.EtreCredentialsConfig{Username: "spirit", PasswordRef: "env:DDL_PASSWORD"},
+				MySQL: api.EtreMySQLConfig{HostField: "writer_endpoint"}, Credentials: api.EtreCredentialsConfig{Username: "spirit", PasswordRef: "env:DDL_PASSWORD"},
 			},
 		},
 	}
@@ -175,15 +234,15 @@ func TestBuildGRPCTernClientErrorsWhenEtreAndStaticBothConfigured(t *testing.T) 
 func TestBuildEtreResolverValidatesConfig(t *testing.T) {
 	logger := slog.New(slog.DiscardHandler)
 	base := api.EtreConfig{
-		Addr: "https://etre.example", EntityType: "cluster", TargetLabel: "dsid",
-		HostField: "writer_endpoint", Credentials: api.EtreCredentialsConfig{Username: "spirit", PasswordRef: "env:DDL_PASSWORD"},
+		Addr: "https://etre.example", DatabaseType: storage.DatabaseTypeMySQL, EntityType: "cluster", TargetLabel: "dsid",
+		MySQL: api.EtreMySQLConfig{HostField: "writer_endpoint"}, Credentials: api.EtreCredentialsConfig{Username: "spirit", PasswordRef: "env:DDL_PASSWORD"},
 	}
 
 	_, err := buildEtreResolver(t.Context(), base, logger)
 	require.NoError(t, err)
 
 	noHost := base
-	noHost.HostField = ""
+	noHost.MySQL.HostField = ""
 	_, err = buildEtreResolver(t.Context(), noHost, logger)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "host_field")

--- a/pkg/inventory/connection_assembler.go
+++ b/pkg/inventory/connection_assembler.go
@@ -68,3 +68,76 @@ func (a MySQLConnectionAssembler) Assemble(host string, _ map[string]string, cre
 	}
 	return cfg.FormatDSN(), maps.Clone(a.Metadata), nil
 }
+
+// Metadata keys the Vitess (PlanetScale) engine reads from a resolved Target.
+const (
+	// MetadataOrganization is the PlanetScale organization that owns the database.
+	MetadataOrganization = "organization"
+	// MetadataTokenName is the PlanetScale service token id.
+	MetadataTokenName = "token_name"
+	// MetadataTokenValue is the PlanetScale service token secret.
+	MetadataTokenValue = "token_value"
+	// MetadataAPIURL is the PlanetScale-compatible API base URL.
+	MetadataAPIURL = "api_url"
+)
+
+// DefaultPlanetScaleAPIURL is the public PlanetScale API endpoint, used when the
+// assembler is not configured with an override (for example a LocalScale URL in
+// tests).
+const DefaultPlanetScaleAPIURL = "https://api.planetscale.com"
+
+// VitessConnectionAssembler assembles a metadata-only Target for Vitess via
+// PlanetScale. Vitess connects through the PlanetScale API rather than a MySQL
+// DSN, so connection details travel in Metadata: the organization comes from the
+// resolved endpoint's attributes, the service token from credentials, and the
+// API URL from deployment configuration.
+type VitessConnectionAssembler struct {
+	// OrganizationAttribute is the endpoint attribute holding the PlanetScale
+	// organization. Defaults to "organization" when empty.
+	OrganizationAttribute string
+	// APIURL is the PlanetScale-compatible API base URL. Defaults to
+	// DefaultPlanetScaleAPIURL when empty.
+	APIURL string
+	// Metadata is attached to every assembled target for engine-specific
+	// configuration the data plane reads, merged after the resolved fields.
+	Metadata map[string]string
+}
+
+var _ ConnectionAssembler = VitessConnectionAssembler{}
+
+// DatabaseType returns the Vitess engine type.
+func (VitessConnectionAssembler) DatabaseType() string { return "vitess" }
+
+// Assemble builds a metadata-only Vitess Target. The host is unused — Vitess
+// reaches the database through the PlanetScale API keyed by organization, not a
+// host endpoint. The returned DSN is always empty.
+func (a VitessConnectionAssembler) Assemble(_ string, attrs map[string]string, creds *Credentials) (string, map[string]string, error) {
+	if creds == nil {
+		return "", nil, fmt.Errorf("vitess connection requires credentials")
+	}
+	orgAttr := a.OrganizationAttribute
+	if orgAttr == "" {
+		orgAttr = MetadataOrganization
+	}
+	organization := attrs[orgAttr]
+	if organization == "" {
+		return "", nil, fmt.Errorf("vitess connection requires the %q endpoint attribute", orgAttr)
+	}
+	tokenName := creds.Metadata[MetadataTokenName]
+	tokenValue := creds.Metadata[MetadataTokenValue]
+	if tokenName == "" || tokenValue == "" {
+		return "", nil, fmt.Errorf("vitess connection requires %q and %q credentials", MetadataTokenName, MetadataTokenValue)
+	}
+	apiURL := a.APIURL
+	if apiURL == "" {
+		apiURL = DefaultPlanetScaleAPIURL
+	}
+	metadata := map[string]string{
+		MetadataOrganization: organization,
+		MetadataTokenName:    tokenName,
+		MetadataTokenValue:   tokenValue,
+		MetadataAPIURL:       apiURL,
+	}
+	maps.Copy(metadata, a.Metadata)
+	return "", metadata, nil
+}

--- a/pkg/inventory/connection_assembler.go
+++ b/pkg/inventory/connection_assembler.go
@@ -1,9 +1,11 @@
 package inventory
 
 import (
+	"encoding/json"
 	"fmt"
 	"maps"
 	"net"
+	"strings"
 
 	"github.com/go-sql-driver/mysql"
 )
@@ -95,8 +97,9 @@ type VitessConnectionAssembler struct {
 	// OrganizationAttribute is the endpoint attribute holding the PlanetScale
 	// organization. Defaults to "organization" when empty.
 	OrganizationAttribute string
-	// APIURL is the PlanetScale-compatible API base URL. Defaults to
-	// DefaultPlanetScaleAPIURL when empty.
+	// APIURL is the PlanetScale-compatible API base URL. A per-target override in
+	// the credential secret (api_url) takes precedence; this is the deployment
+	// default, itself falling back to DefaultPlanetScaleAPIURL when empty.
 	APIURL string
 	// Metadata is attached to every assembled target for engine-specific
 	// configuration the data plane reads, merged after the resolved fields.
@@ -128,16 +131,56 @@ func (a VitessConnectionAssembler) Assemble(_ string, attrs map[string]string, c
 	if tokenName == "" || tokenValue == "" {
 		return "", nil, fmt.Errorf("vitess connection requires %q and %q credentials", MetadataTokenName, MetadataTokenValue)
 	}
-	apiURL := a.APIURL
+	// A per-target API URL from the secret wins; otherwise the deployment default,
+	// then the public PlanetScale endpoint.
+	apiURL := creds.Metadata[MetadataAPIURL]
+	if apiURL == "" {
+		apiURL = a.APIURL
+	}
 	if apiURL == "" {
 		apiURL = DefaultPlanetScaleAPIURL
 	}
-	metadata := map[string]string{
-		MetadataOrganization: organization,
-		MetadataTokenName:    tokenName,
-		MetadataTokenValue:   tokenValue,
-		MetadataAPIURL:       apiURL,
+	// Configured Metadata supplies extra engine fields (for example main_branch)
+	// but must not override the resolved connection fields, so it is written
+	// first and the authoritative fields last.
+	metadata := maps.Clone(a.Metadata)
+	if metadata == nil {
+		metadata = make(map[string]string, 4)
 	}
-	maps.Copy(metadata, a.Metadata)
+	metadata[MetadataOrganization] = organization
+	metadata[MetadataTokenName] = tokenName
+	metadata[MetadataTokenValue] = tokenValue
+	metadata[MetadataAPIURL] = apiURL
 	return "", metadata, nil
+}
+
+// DecodePlanetScaleSecret decodes a PlanetScale credential secret into engine
+// metadata for a Vitess target. The secret is JSON carrying a service token in
+// "name=value" form and an optional API URL override:
+//
+//	{"token": "<id>=<value>", "api_url": "https://..."}
+//
+// The organization is not part of the secret — it comes from the inventory
+// entity. As a SecretDecoder it plugs into any credential backend that fetches
+// the raw secret (a reference, or an assumed-role Secrets Manager read).
+func DecodePlanetScaleSecret(raw string) (*Credentials, error) {
+	var secret struct {
+		Token  string `json:"token"`
+		APIURL string `json:"api_url"`
+	}
+	if err := json.Unmarshal([]byte(raw), &secret); err != nil {
+		return nil, fmt.Errorf("parse planetscale secret as JSON: %w", err)
+	}
+	tokenName, tokenValue, ok := strings.Cut(secret.Token, "=")
+	if !ok || tokenName == "" || tokenValue == "" {
+		return nil, fmt.Errorf(`planetscale secret "token" must be in "name=value" form`)
+	}
+	metadata := map[string]string{
+		MetadataTokenName:  tokenName,
+		MetadataTokenValue: tokenValue,
+	}
+	if secret.APIURL != "" {
+		metadata[MetadataAPIURL] = secret.APIURL
+	}
+	return &Credentials{Metadata: metadata}, nil
 }

--- a/pkg/inventory/connection_assembler_test.go
+++ b/pkg/inventory/connection_assembler_test.go
@@ -177,3 +177,51 @@ func TestVitessConnectionAssemblerRequiresToken(t *testing.T) {
 func TestVitessConnectionAssemblerDatabaseType(t *testing.T) {
 	assert.Equal(t, "vitess", VitessConnectionAssembler{}.DatabaseType())
 }
+
+// A per-target API URL carried in the credential metadata overrides the
+// assembler's configured default.
+func TestVitessConnectionAssemblerSecretAPIURLOverridesConfig(t *testing.T) {
+	a := VitessConnectionAssembler{APIURL: "https://configured.example"}
+
+	_, meta, err := a.Assemble(
+		"",
+		map[string]string{MetadataOrganization: "acme"},
+		&Credentials{Metadata: map[string]string{
+			MetadataTokenName:  "id",
+			MetadataTokenValue: "secret",
+			MetadataAPIURL:     "https://from-secret.example",
+		}},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "https://from-secret.example", meta[MetadataAPIURL])
+}
+
+// The PlanetScale secret decoder splits the "name=value" token and surfaces the
+// optional API URL, leaving organization to the inventory entity.
+func TestDecodePlanetScaleSecret(t *testing.T) {
+	creds, err := DecodePlanetScaleSecret(`{"token":"tok-id=tok-secret","api_url":"https://localscale.test"}`)
+	require.NoError(t, err)
+	assert.Empty(t, creds.Username)
+	assert.Empty(t, creds.Password)
+	assert.Equal(t, "tok-id", creds.Metadata[MetadataTokenName])
+	assert.Equal(t, "tok-secret", creds.Metadata[MetadataTokenValue])
+	assert.Equal(t, "https://localscale.test", creds.Metadata[MetadataAPIURL])
+	assert.NotContains(t, creds.Metadata, MetadataOrganization, "organization comes from the entity, not the secret")
+}
+
+func TestDecodePlanetScaleSecretOptionalAPIURL(t *testing.T) {
+	creds, err := DecodePlanetScaleSecret(`{"token":"tok-id=tok-secret"}`)
+	require.NoError(t, err)
+	assert.Equal(t, "tok-id", creds.Metadata[MetadataTokenName])
+	assert.NotContains(t, creds.Metadata, MetadataAPIURL, "api_url is optional in the secret")
+}
+
+func TestDecodePlanetScaleSecretRejectsBadInput(t *testing.T) {
+	_, err := DecodePlanetScaleSecret("not-json")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "JSON")
+
+	_, err = DecodePlanetScaleSecret(`{"token":"missing-separator"}`)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "name=value")
+}

--- a/pkg/inventory/connection_assembler_test.go
+++ b/pkg/inventory/connection_assembler_test.go
@@ -81,3 +81,99 @@ func TestMySQLConnectionAssemblerRequiresCredentials(t *testing.T) {
 func TestMySQLConnectionAssemblerDatabaseType(t *testing.T) {
 	assert.Equal(t, "mysql", MySQLConnectionAssembler{}.DatabaseType())
 }
+
+// Vitess connects through the PlanetScale API, so the assembler emits a
+// metadata-only target: organization from the endpoint attributes, the service
+// token from credentials, and the API URL from configuration. No DSN.
+func TestVitessConnectionAssemblerBuildsMetadataTarget(t *testing.T) {
+	a := VitessConnectionAssembler{APIURL: "https://localscale.test"}
+
+	dsn, meta, err := a.Assemble(
+		"",
+		map[string]string{MetadataOrganization: "acme"},
+		&Credentials{Metadata: map[string]string{
+			MetadataTokenName:  "tok-id",
+			MetadataTokenValue: "tok-secret",
+		}},
+	)
+	require.NoError(t, err)
+	assert.Empty(t, dsn, "Vitess targets carry connection details in metadata, not a DSN")
+	assert.Equal(t, map[string]string{
+		MetadataOrganization: "acme",
+		MetadataTokenName:    "tok-id",
+		MetadataTokenValue:   "tok-secret",
+		MetadataAPIURL:       "https://localscale.test",
+	}, meta)
+}
+
+// The host argument is irrelevant for Vitess; resolution keys on organization.
+func TestVitessConnectionAssemblerIgnoresHost(t *testing.T) {
+	a := VitessConnectionAssembler{}
+
+	_, meta, err := a.Assemble(
+		"writer.example:3306",
+		map[string]string{MetadataOrganization: "acme"},
+		&Credentials{Metadata: map[string]string{MetadataTokenName: "id", MetadataTokenValue: "secret"}},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, DefaultPlanetScaleAPIURL, meta[MetadataAPIURL])
+	assert.Equal(t, "acme", meta[MetadataOrganization])
+}
+
+// A custom organization attribute lets the resolver surface the organization
+// under a label other than the default.
+func TestVitessConnectionAssemblerCustomOrganizationAttribute(t *testing.T) {
+	a := VitessConnectionAssembler{OrganizationAttribute: "ps_org"}
+
+	_, meta, err := a.Assemble(
+		"",
+		map[string]string{"ps_org": "acme"},
+		&Credentials{Metadata: map[string]string{MetadataTokenName: "id", MetadataTokenValue: "secret"}},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "acme", meta[MetadataOrganization])
+}
+
+// Configured Metadata is merged after the resolved fields so deployments can
+// attach extra engine configuration.
+func TestVitessConnectionAssemblerMergesConfiguredMetadata(t *testing.T) {
+	a := VitessConnectionAssembler{Metadata: map[string]string{"main_branch": "main"}}
+
+	_, meta, err := a.Assemble(
+		"",
+		map[string]string{MetadataOrganization: "acme"},
+		&Credentials{Metadata: map[string]string{MetadataTokenName: "id", MetadataTokenValue: "secret"}},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "main", meta["main_branch"])
+}
+
+func TestVitessConnectionAssemblerRequiresCredentials(t *testing.T) {
+	_, _, err := VitessConnectionAssembler{}.Assemble("", map[string]string{MetadataOrganization: "acme"}, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "credentials")
+}
+
+func TestVitessConnectionAssemblerRequiresOrganization(t *testing.T) {
+	_, _, err := VitessConnectionAssembler{}.Assemble(
+		"",
+		nil,
+		&Credentials{Metadata: map[string]string{MetadataTokenName: "id", MetadataTokenValue: "secret"}},
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "organization")
+}
+
+func TestVitessConnectionAssemblerRequiresToken(t *testing.T) {
+	_, _, err := VitessConnectionAssembler{}.Assemble(
+		"",
+		map[string]string{MetadataOrganization: "acme"},
+		&Credentials{Metadata: map[string]string{MetadataTokenName: "id"}},
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), MetadataTokenValue)
+}
+
+func TestVitessConnectionAssemblerDatabaseType(t *testing.T) {
+	assert.Equal(t, "vitess", VitessConnectionAssembler{}.DatabaseType())
+}

--- a/pkg/inventory/credentials.go
+++ b/pkg/inventory/credentials.go
@@ -20,6 +20,12 @@ type Credentials struct {
 	Metadata map[string]string
 }
 
+// SecretDecoder interprets a raw secret value into Credentials. It lets a
+// credential resolver fetch a secret one way — a reference, or an assumed-role
+// Secrets Manager read — and interpret it per engine without coupling the fetch
+// to the format: a plain password for MySQL, or a PlanetScale token for Vitess.
+type SecretDecoder func(raw string) (*Credentials, error)
+
 // CredentialResolver resolves credentials for a target, independently of
 // endpoint resolution so the two can be configured and overridden separately.
 //
@@ -44,6 +50,10 @@ type CredentialResolver interface {
 type SecretRefCredentialResolver struct {
 	Username    string
 	PasswordRef string
+	// Decode, when set, interprets the resolved secret value into Credentials
+	// (for example a PlanetScale token). When nil the secret is used directly as
+	// the password alongside the configured username.
+	Decode SecretDecoder
 }
 
 var _ CredentialResolver = SecretRefCredentialResolver{}
@@ -63,6 +73,13 @@ func (r SecretRefCredentialResolver) ResolveCredentials(_ context.Context, req R
 	// which would otherwise surface as an opaque DB auth error later.
 	if password == "" {
 		return nil, fmt.Errorf("password reference %q resolved to an empty value for target %q", ref, req.Target)
+	}
+	if r.Decode != nil {
+		creds, err := r.Decode(password)
+		if err != nil {
+			return nil, fmt.Errorf("decode secret for target %q: %w", req.Target, err)
+		}
+		return creds, nil
 	}
 	return &Credentials{Username: r.Username, Password: password}, nil
 }

--- a/pkg/inventory/credentials_test.go
+++ b/pkg/inventory/credentials_test.go
@@ -44,3 +44,18 @@ func TestSecretRefCredentialResolverRejectsEmptyResolvedPassword(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "empty value")
 }
+
+// With a Decode set, the resolved secret is interpreted by the decoder — here a
+// PlanetScale token — rather than used directly as the password.
+func TestSecretRefCredentialResolverDecodes(t *testing.T) {
+	r := SecretRefCredentialResolver{
+		PasswordRef: `{"token":"tok-id=tok-secret"}`,
+		Decode:      DecodePlanetScaleSecret,
+	}
+
+	creds, err := r.ResolveCredentials(t.Context(), Request{Target: "orders-dsid"}, nil)
+	require.NoError(t, err)
+	assert.Empty(t, creds.Password)
+	assert.Equal(t, "tok-id", creds.Metadata[MetadataTokenName])
+	assert.Equal(t, "tok-secret", creds.Metadata[MetadataTokenValue])
+}

--- a/pkg/tern/target_router.go
+++ b/pkg/tern/target_router.go
@@ -455,13 +455,20 @@ func (r *TargetRouter) clientForTarget(ctx context.Context, target, databaseType
 		return nil, nil, err
 	}
 	// Fail closed on a nil or incomplete resolver result rather than building a
-	// client with an empty type/DSN and surfacing a confusing connection error
-	// later. Don't log the DSN — it carries credentials.
+	// client that surfaces a confusing connection error later. Keep the causes
+	// separate so the log names the missing field, and never log the DSN or
+	// secret values — only field names.
 	if resolved == nil {
 		return nil, nil, fmt.Errorf("resolver returned no target for %q", target)
 	}
-	if resolved.Target == "" || resolved.DatabaseType == "" || resolved.DSN == "" {
-		return nil, nil, fmt.Errorf("resolver returned an incomplete target for %q (target=%q, type=%q, dsn_empty=%t)", target, resolved.Target, resolved.DatabaseType, resolved.DSN == "")
+	if resolved.Target == "" {
+		return nil, nil, fmt.Errorf("resolver returned a target with no identifier for %q", target)
+	}
+	if resolved.DatabaseType == "" {
+		return nil, nil, fmt.Errorf("resolver returned a target with no database type for %q", target)
+	}
+	if err := resolvedTargetConnectable(resolved); err != nil {
+		return nil, nil, fmt.Errorf("resolver returned an incomplete target for %q (type=%q): %w", target, resolved.DatabaseType, err)
 	}
 	key := cacheKeyForResolvedTarget(resolved, environment, namespace)
 	r.mu.Lock()
@@ -541,6 +548,30 @@ func (r *TargetRouter) takePendingObserver(key targetClientKey) ProgressObserver
 
 func cacheKeyForTargetRequest(req inventory.Request) targetClientKey {
 	return targetClientKey{target: req.Target, databaseType: req.DatabaseType, environment: req.Environment}
+}
+
+// resolvedTargetConnectable verifies a resolved target carries enough to open a
+// connection for its engine. Vitess reaches the database through the PlanetScale
+// API using metadata (organization, service token, API URL) and carries no DSN;
+// every other engine connects via a DSN.
+func resolvedTargetConnectable(resolved *inventory.Target) error {
+	if resolved.DatabaseType == storage.DatabaseTypeVitess {
+		for _, key := range []string{
+			inventory.MetadataOrganization,
+			inventory.MetadataTokenName,
+			inventory.MetadataTokenValue,
+			inventory.MetadataAPIURL,
+		} {
+			if resolved.Metadata[key] == "" {
+				return fmt.Errorf("missing %q metadata", key)
+			}
+		}
+		return nil
+	}
+	if resolved.DSN == "" {
+		return fmt.Errorf("missing DSN")
+	}
+	return nil
 }
 
 func cacheKeyForResolvedTarget(target *inventory.Target, environment, namespace string) targetClientKey {

--- a/pkg/tern/target_router_test.go
+++ b/pkg/tern/target_router_test.go
@@ -81,6 +81,7 @@ type targetRouterRecordingClient struct {
 	progressReq        *ternv1.ProgressRequest
 	resumeApply        *storage.Apply
 	targetDSN          string
+	targetMetadata     map[string]string
 	pendingObserverSet bool
 	observerApplyID    int64
 	closed             bool
@@ -395,6 +396,63 @@ func TestTargetRouterFailsClosedOnIncompleteResolvedTarget(t *testing.T) {
 	assert.Empty(t, created, "no client should be created for an incomplete resolved target")
 }
 
+// A Vitess target reaches the database through the PlanetScale API, so it
+// carries connection details in metadata and has no DSN. Routing must accept it
+// and pass the metadata through to the client rather than rejecting the empty
+// DSN as incomplete.
+func TestTargetRouterAcceptsMetadataOnlyVitessTarget(t *testing.T) {
+	resolver := targetRouterResolverFunc(func(context.Context, inventory.Request) (*inventory.Target, error) {
+		return &inventory.Target{
+			Target:       "dsid-orders-vitess",
+			DatabaseType: storage.DatabaseTypeVitess,
+			Metadata: map[string]string{
+				inventory.MetadataOrganization: "acme",
+				inventory.MetadataTokenName:    "tok-id",
+				inventory.MetadataTokenValue:   "tok-secret",
+				inventory.MetadataAPIURL:       "https://localscale.test",
+			},
+		}, nil
+	})
+	created := make(map[string]*targetRouterRecordingClient)
+	router := newTargetRouterForTest(t, resolver, nil, nil, created)
+
+	_, err := router.Plan(t.Context(), &ternv1.PlanRequest{Database: "orders", Target: "dsid-orders-vitess", Type: storage.DatabaseTypeVitess})
+
+	require.NoError(t, err)
+	require.Len(t, created, 1, "the router should build a client for a metadata-only Vitess target")
+	client := created["orders"]
+	require.NotNil(t, client)
+	assert.Empty(t, client.targetDSN, "a Vitess client connects via metadata, not a DSN")
+	assert.Equal(t, "acme", client.targetMetadata[inventory.MetadataOrganization])
+	assert.Equal(t, "tok-secret", client.targetMetadata[inventory.MetadataTokenValue])
+}
+
+// A Vitess target missing its PlanetScale metadata cannot open a connection, so
+// routing must fail closed with the missing field rather than building a client
+// that errors confusingly on first API call.
+func TestTargetRouterFailsClosedOnVitessTargetMissingMetadata(t *testing.T) {
+	resolver := targetRouterResolverFunc(func(context.Context, inventory.Request) (*inventory.Target, error) {
+		return &inventory.Target{
+			Target:       "dsid-orders-vitess",
+			DatabaseType: storage.DatabaseTypeVitess,
+			Metadata: map[string]string{
+				inventory.MetadataOrganization: "acme",
+				inventory.MetadataTokenName:    "tok-id",
+				inventory.MetadataAPIURL:       "https://localscale.test",
+			},
+		}, nil
+	})
+	created := make(map[string]*targetRouterRecordingClient)
+	router := newTargetRouterForTest(t, resolver, nil, nil, created)
+
+	_, err := router.Plan(t.Context(), &ternv1.PlanRequest{Database: "orders", Target: "dsid-orders-vitess", Type: storage.DatabaseTypeVitess})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "incomplete target")
+	assert.Contains(t, err.Error(), inventory.MetadataTokenValue)
+	assert.Empty(t, created, "no client should be created for an incomplete Vitess target")
+}
+
 func TestTargetRouterCloseClosesCachedClients(t *testing.T) {
 	resolver := newStaticResolver(t)
 	created := make(map[string]*targetRouterRecordingClient)
@@ -429,7 +487,7 @@ func newTargetRouterForTest(t *testing.T, resolver inventory.Resolver, applyStor
 		Storage:  targetRouterStorage{applies: applyStore, plans: planStore},
 		Logger:   slog.Default(),
 		LocalClientFactory: func(cfg LocalConfig, _ storage.Storage, _ *slog.Logger) (Client, error) {
-			client := &targetRouterRecordingClient{targetDSN: cfg.TargetDSN}
+			client := &targetRouterRecordingClient{targetDSN: cfg.TargetDSN, targetMetadata: cfg.Metadata}
 			key := cfg.Database
 			if existing := created[key]; existing != nil {
 				key = fmt.Sprintf("%s#%d", cfg.Database, len(created)+1)


### PR DESCRIPTION
## Why this matters

The data plane already resolves MySQL targets from a pluggable inventory backend and credential store, fully server-config-driven. Vitess (via PlanetScale) was the last engine that still required an out-of-tree resolution shim. This adds Vitess to the same resolver, so a deployment can drive **both** engines entirely from server config — no shim.

## What it does

Adds the Vitess engine axis to the Etre-backed resolver:

```
request(target) ─▶ Etre lookup ─┬─ organization (entity attribute)
                                └─ token secret ─▶ decode {"token":"name=value","api_url":...}
                                                        │
                                          VitessConnectionAssembler
                                                        ▼
                            Target{type: vitess, metadata: organization/token/api_url}  (no DSN)
```

- **VitessConnectionAssembler** builds a metadata-only target — Vitess connects through the PlanetScale API, not a DSN. The organization comes from the resolved entity, the service token from the credential secret, and the API URL from the secret (per-target override) or deployment config.
- **TargetRouter** accepts metadata-only targets: the completeness check is now engine-aware (Vitess requires its PlanetScale metadata; every other engine requires a DSN), and the three failure causes are reported separately so a misconfiguration names the missing field.
- **Credential decoding**: a `SecretDecoder` seam on both credential backends (`secret_ref` and `awssm`) lets the same fetch mechanisms — an ESO-style reference or an assumed-role Secrets Manager read — interpret a PlanetScale token secret instead of a username/password.
- **Config**: `database_type` is required (no implicit default; an unknown value fails closed), and engine-specific knobs live in a per-engine block (`mysql:` / `vitess:`) so the shared Etre config carries no engine semantics.

## Config example

```yaml
target_resolver:
  etre:
    addr: env:ETRE_ADDR
    database_type: vitess           # required; "mysql" or "vitess"
    entity_type: planetscale_database
    target_label: dsid              # the request's opaque target matches this label
    env_label: env                  # scope the lookup to the request environment
    vitess:
      organization_attribute: organization  # entity field holding the PlanetScale org (default)
      api_url: https://api.planetscale.com   # default; a per-target secret api_url wins
    credentials:
      type: awssm                   # or "secret_ref"
      region: us-east-1
      role_arn: arn:aws:iam::{account}:role/schemabot-secrets-reader
      secret_name: "{target}_ps_token"       # {target} is the resolved DSID
      account_attribute: aws_account_id
```

The credential secret is a PlanetScale token in JSON (the `organization` is **not** in the secret — it comes from the Etre entity):

```json
{ "token": "<token-id>=<token-value>", "api_url": "https://api.planetscale.com" }
```

For comparison, a MySQL resolver sets `database_type: mysql` and a `mysql:` block (`host_field`, `default_port`) with a `{"username": "...", "password": "..."}` secret.

## How it moves toward the northstar

This completes the engine-agnostic dynamic data plane — endpoint (etre/static) × credentials (reference/assume-role) × engine (mysql/vitess) — all driven from server config. Engine semantics stay in per-engine blocks, so adding Postgres or Strata is a new block plus a new assembler, not a reshaping of the shared config. With both engines resolvable this way, the out-of-tree resolution shim is fully replaceable.

---
*PR drafted by Claude Code (Opus 4.8).*