### PR TITLE
feat(api): list configured databases

### DIFF
--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -1654,6 +1654,125 @@ func TestDatabaseEnvironmentsUsesServerPromotionOrder(t *testing.T) {
 	assert.Equal(t, []string{"production", "staging", "sandbox"}, resp.Environments)
 }
 
+func TestDatabaseListSanitizesConfigAndReportsTopology(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	svc := New(&mockStorage{}, &ServerConfig{
+		Databases: map[string]DatabaseConfig{
+			"accounts": {
+				Type: storage.DatabaseTypeVitess,
+				Environments: map[string]EnvironmentConfig{
+					"production": {
+						Target:     "accounts-prod-target",
+						Deployment: "sled",
+					},
+				},
+			},
+			"orders": {
+				Type: storage.DatabaseTypeMySQL,
+				Environments: map[string]EnvironmentConfig{
+					"staging": {
+						DSN: "orders_user:orders_password@tcp(localhost:3306)/orders_staging",
+					},
+					"production": {
+						Target:     "orders-prod-target",
+						Deployment: "pie",
+					},
+				},
+				AllowedRepos: []string{"octocat/orders"},
+				AllowedDirs:  []string{"schema/orders"},
+			},
+		},
+		TernDeployments: TernConfig{
+			"pie":  {"production": "pie.example:9090"},
+			"sled": {"production": "sled.example:9090"},
+		},
+		AllowedEnvironments: []string{"staging"},
+		EnvironmentOrder:    []string{"production", "staging"},
+	}, nil, logger)
+	mux := http.NewServeMux()
+	svc.ConfigureRoutes(mux)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/databases", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	body := w.Body.String()
+	assert.NotContains(t, body, "orders_password")
+	assert.NotContains(t, body, "orders-prod-target")
+	assert.NotContains(t, body, "pie.example")
+	assert.NotContains(t, body, "execution_mode")
+	assert.NotContains(t, body, "execution_target_count")
+	assert.NotContains(t, body, "server_handles_environment")
+
+	var resp apitypes.DatabaseListResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Len(t, resp.Databases, 2)
+
+	accounts := resp.Databases[0]
+	assert.Equal(t, "accounts", accounts.Database)
+	assert.Equal(t, storage.DatabaseTypeVitess, accounts.Type)
+	require.Len(t, accounts.Environments, 1)
+	assert.Equal(t, "production", accounts.Environments[0].Environment)
+	assert.Equal(t, []string{"sled"}, accounts.Environments[0].Deployments)
+
+	orders := resp.Databases[1]
+	assert.Equal(t, "orders", orders.Database)
+	assert.Equal(t, storage.DatabaseTypeMySQL, orders.Type)
+	require.Len(t, orders.Environments, 2)
+	assert.Equal(t, "production", orders.Environments[0].Environment)
+	assert.Equal(t, []string{"pie"}, orders.Environments[0].Deployments)
+	assert.Equal(t, "staging", orders.Environments[1].Environment)
+	assert.Empty(t, orders.Environments[1].Deployments)
+
+	req = httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/databases?type=mysql", nil)
+	w = httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Len(t, resp.Databases, 1)
+	assert.Equal(t, "orders", resp.Databases[0].Database)
+	assert.Equal(t, storage.DatabaseTypeMySQL, resp.Databases[0].Type)
+
+	req = httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/databases?type=vitess", nil)
+	w = httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Len(t, resp.Databases, 1)
+	assert.Equal(t, "accounts", resp.Databases[0].Database)
+	assert.Equal(t, storage.DatabaseTypeVitess, resp.Databases[0].Type)
+
+	req = httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/databases?type=strata", nil)
+	w = httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Empty(t, resp.Databases)
+
+	req = httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/databases?type=postgres", nil)
+	w = httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	require.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
+	assert.Contains(t, w.Body.String(), "type must be")
+}
+
+func TestDatabaseListRejectsInvalidDeploymentTopology(t *testing.T) {
+	_, err := databaseListResponse(&ServerConfig{
+		Databases: map[string]DatabaseConfig{
+			"orders": {
+				Type: storage.DatabaseTypeMySQL,
+				Environments: map[string]EnvironmentConfig{
+					"production": {Deployments: map[string]DeploymentTarget{}},
+				},
+			},
+		},
+	}, "")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `database "orders" environment "production" deployments map is empty`)
+}
+
 func TestProgressByApplyIDResolvesExternalIDForRemoteApply(t *testing.T) {
 	mock := &mockTernClient{
 		isRemote: true,

--- a/pkg/api/progress_handlers.go
+++ b/pkg/api/progress_handlers.go
@@ -461,6 +461,106 @@ func (s *Service) handleDatabaseEnvironments(w http.ResponseWriter, r *http.Requ
 	})
 }
 
+// handleDatabaseList returns the sanitized databases registered on this
+// server. It intentionally exposes topology metadata only; connection
+// strings, opaque execution targets, and endpoint addresses stay server-side.
+func (s *Service) handleDatabaseList(w http.ResponseWriter, r *http.Request) {
+	databaseType, err := parseDatabaseListTypeFilter(r)
+	if err != nil {
+		s.writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	resp, err := databaseListResponse(s.config, databaseType)
+	if err != nil {
+		s.logger.Error("database list failed", "error", err)
+		s.writeError(w, http.StatusInternalServerError, "failed to list databases: "+err.Error())
+		return
+	}
+	s.writeJSON(w, http.StatusOK, resp)
+}
+
+func parseDatabaseListTypeFilter(r *http.Request) (string, error) {
+	databaseType := r.URL.Query().Get("type")
+	switch databaseType {
+	case "", storage.DatabaseTypeMySQL, storage.DatabaseTypeVitess, storage.DatabaseTypeStrata:
+		return databaseType, nil
+	default:
+		return "", fmt.Errorf("type must be %q, %q, or %q", storage.DatabaseTypeMySQL, storage.DatabaseTypeVitess, storage.DatabaseTypeStrata)
+	}
+}
+
+func databaseListResponse(config *ServerConfig, databaseType string) (*apitypes.DatabaseListResponse, error) {
+	if config == nil {
+		return nil, fmt.Errorf("server config is nil")
+	}
+	databaseNames := make([]string, 0, len(config.Databases))
+	for database, dbConfig := range config.Databases {
+		if databaseType != "" && dbConfig.Type != databaseType {
+			continue
+		}
+		databaseNames = append(databaseNames, database)
+	}
+	sort.Strings(databaseNames)
+
+	resp := &apitypes.DatabaseListResponse{Databases: make([]*apitypes.DatabaseResponse, 0, len(databaseNames))}
+	for _, database := range databaseNames {
+		dbConfig := config.Databases[database]
+		environments, err := config.DatabaseEnvironments(database)
+		if err != nil {
+			return nil, fmt.Errorf("list database environments for database %q: %w", database, err)
+		}
+		databaseResp := &apitypes.DatabaseResponse{
+			Database:     database,
+			Type:         dbConfig.Type,
+			Environments: make([]*apitypes.DatabaseEnvironmentResponse, 0, len(environments)),
+		}
+		for _, environment := range environments {
+			envRoute, err := databaseEnvironmentResponse(database, dbConfig, environment)
+			if err != nil {
+				return nil, err
+			}
+			databaseResp.Environments = append(databaseResp.Environments, envRoute)
+		}
+		resp.Databases = append(resp.Databases, databaseResp)
+	}
+	return resp, nil
+}
+
+func databaseEnvironmentResponse(database string, dbConfig DatabaseConfig, environment string) (*apitypes.DatabaseEnvironmentResponse, error) {
+	envConfig, ok := dbConfig.Environments[environment]
+	if !ok {
+		return nil, fmt.Errorf("database %q environment %q is not configured on this server", database, environment)
+	}
+	deployments, err := sanitizedDatabaseDeployments(database, environment, envConfig)
+	if err != nil {
+		return nil, err
+	}
+	return &apitypes.DatabaseEnvironmentResponse{
+		Environment: environment,
+		Deployments: deployments,
+	}, nil
+}
+
+func sanitizedDatabaseDeployments(database, environment string, envConfig EnvironmentConfig) ([]string, error) {
+	if envConfig.HasLocalDSN() {
+		return nil, nil
+	}
+	if envConfig.Deployments != nil {
+		if len(envConfig.Deployments) == 0 {
+			return nil, fmt.Errorf("database %q environment %q deployments map is empty", database, environment)
+		}
+		deployments, err := orderedDeploymentKeys(envConfig.Deployments, envConfig.DeploymentOrder, fmt.Sprintf("database %q environment %q", database, environment))
+		if err != nil {
+			return nil, err
+		}
+		return deployments, nil
+	}
+	if envConfig.Deployment == "" {
+		return nil, fmt.Errorf("database %q environment %q missing server-side deployment", database, environment)
+	}
+	return []string{envConfig.Deployment}, nil
+}
+
 // handleStatus handles GET /api/status requests.
 // Returns recent schema changes.
 func (s *Service) handleStatus(w http.ResponseWriter, r *http.Request) {

--- a/pkg/api/service.go
+++ b/pkg/api/service.go
@@ -592,6 +592,7 @@ func (s *Service) ConfigureRoutes(mux *http.ServeMux) {
 	handle("GET /tern-health/{deployment}/{environment}", s.handleTernHealth)
 
 	// Config API (for CLI to discover environments)
+	handle("GET /api/databases", s.handleDatabaseList)
 	handle("GET /api/databases/{database}/environments", s.handleDatabaseEnvironments)
 
 	// Orchestration API

--- a/pkg/apitypes/apitypes.go
+++ b/pkg/apitypes/apitypes.go
@@ -115,6 +115,26 @@ type PullSchemaResponse struct {
 	TableCount  int32                       `json:"table_count"`
 }
 
+// DatabaseListResponse is the HTTP response body for GET /api/databases.
+type DatabaseListResponse struct {
+	Databases []*DatabaseResponse `json:"databases"`
+}
+
+// DatabaseResponse describes one server-side database without
+// exposing connection strings, opaque execution targets, or endpoint addresses.
+type DatabaseResponse struct {
+	Database     string                         `json:"database"`
+	Type         string                         `json:"type"`
+	Environments []*DatabaseEnvironmentResponse `json:"environments"`
+}
+
+// DatabaseEnvironmentResponse describes one configured database environment
+// without exposing connection strings, opaque execution targets, or endpoints.
+type DatabaseEnvironmentResponse struct {
+	Environment string   `json:"environment"`
+	Deployments []string `json:"deployments,omitempty"`
+}
+
 // PlanRequest is the HTTP request body for POST /api/plan.
 type PlanRequest struct {
 	Database    string                  `json:"database"`


### PR DESCRIPTION
## Why
Operators and API clients need a safe way to discover which databases a SchemaBot server knows about before they call schema pull, status, or future inventory workflows.

## What
- Add `GET /api/databases` for sanitized server-side database discovery
- Support `?type=mysql`, `?type=vitess`, and `?type=strata` filters
- Return database, environment, and deployment topology without exposing DSNs, opaque targets, endpoints, or authorization internals

## Example payloads

All configured databases:

```json
{
  "databases": [
    {
      "database": "orders",
      "type": "mysql",
      "environments": [
        {
          "environment": "production",
          "deployments": ["pie"]
        },
        {
          "environment": "staging"
        }
      ]
    },
    {
      "database": "accounts",
      "type": "vitess",
      "environments": [
        {
          "environment": "production",
          "deployments": ["sled"]
        }
      ]
    }
  ]
}
```

Filtered `GET /api/databases?type=mysql`:

```json
{
  "databases": [
    {
      "database": "orders",
      "type": "mysql",
      "environments": [
        {
          "environment": "production",
          "deployments": ["pie"]
        },
        {
          "environment": "staging"
        }
      ]
    }
  ]
}
```

Filtered `GET /api/databases?type=vitess`:

```json
{
  "databases": [
    {
      "database": "accounts",
      "type": "vitess",
      "environments": [
        {
          "environment": "production",
          "deployments": ["sled"]
        }
      ]
    }
  ]
}
```

## Risk Assessment
Low — this adds a read-only discovery endpoint backed by existing server config and intentionally returns sanitized topology metadata only.

Generated with Amp
