### PR TITLE
fix(ux): simplify apply comment title

### DIFF
--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -161,10 +161,10 @@ schemabot apply -e staging
 </details>
 
 <details>
-<summary><a name="vitess-apply-plan-locked--options"></a><strong>Vitess Apply Plan (Locked + Options)</strong></summary>
+<summary><a name="schema-change-apply-locked--options"></a><strong>Schema Change Apply (Locked + Options)</strong></summary>
 
 
-## Vitess Schema Change Plan (Apply)
+## Schema Change Apply
 
 **Database**: `commerce` | **Environment**: `staging`
 
@@ -1334,10 +1334,10 @@ No active locks.
 ### PR Comments
 
 <details>
-<summary><a name="mysql-apply-plan-lock--confirm"></a><strong>MySQL Apply Plan (Lock + Confirm)</strong></summary>
+<summary><a name="schema-change-apply-lock--confirm"></a><strong>Schema Change Apply (Lock + Confirm)</strong></summary>
 
 
-## MySQL Schema Change Plan (Apply)
+## Schema Change Apply
 
 **Database**: `testapp` | **Schema Name**: `testapp` | **Environment**: `staging`
 
@@ -1388,10 +1388,10 @@ schemabot unlock
 </details>
 
 <details>
-<summary><a name="mysql-apply-plan-with-options"></a><strong>MySQL Apply Plan (With Options)</strong></summary>
+<summary><a name="schema-change-apply-with-options"></a><strong>Schema Change Apply (With Options)</strong></summary>
 
 
-## MySQL Schema Change Plan (Apply)
+## Schema Change Apply
 
 **Database**: `testapp` | **Schema Name**: `testapp` | **Environment**: `staging`
 
@@ -1444,10 +1444,10 @@ schemabot unlock
 </details>
 
 <details>
-<summary><a name="vitess-apply-plan-locked--options"></a><strong>Vitess Apply Plan (Locked + Options)</strong></summary>
+<summary><a name="schema-change-apply-vitess--options"></a><strong>Schema Change Apply (Vitess + Options)</strong></summary>
 
 
-## Vitess Schema Change Plan (Apply)
+## Schema Change Apply
 
 **Database**: `commerce` | **Environment**: `staging`
 
@@ -3996,10 +3996,10 @@ No schema changes found for database 'new-db'
 ### PR Comments
 
 <details>
-<summary><a name="apply-plan-lock--confirm"></a><strong>Apply Plan (Lock + Confirm)</strong></summary>
+<summary><a name="apply-gate-schema-change-apply-lock--confirm"></a><strong>Apply Gate: Schema Change Apply (Lock + Confirm)</strong></summary>
 
 
-## MySQL Schema Change Plan (Apply)
+## Schema Change Apply
 
 **Database**: `testapp` | **Schema Name**: `testapp` | **Environment**: `staging`
 
@@ -4051,10 +4051,10 @@ schemabot unlock
 </details>
 
 <details>
-<summary><a name="apply-plan-with-options"></a><strong>Apply Plan (With Options)</strong></summary>
+<summary><a name="apply-gate-schema-change-apply-with-options"></a><strong>Apply Gate: Schema Change Apply (With Options)</strong></summary>
 
 
-## MySQL Schema Change Plan (Apply)
+## Schema Change Apply
 
 **Database**: `testapp` | **Schema Name**: `testapp` | **Environment**: `staging`
 

--- a/pkg/cmd/internal/templates/preview_comment.go
+++ b/pkg/cmd/internal/templates/preview_comment.go
@@ -39,8 +39,8 @@ func previewCommentAllOutput() {
 	}{
 		{"PLAN COMMENT", func() { fmt.Print(webhooktemplates.PreviewCommentPlan()) }},
 		{"PLAN COMMENT (NO CHANGES)", func() { fmt.Print(webhooktemplates.PreviewCommentPlanNoChanges()) }},
-		{"APPLY PLAN (LOCKED)", func() { fmt.Print(webhooktemplates.PreviewCommentApplyPlan()) }},
-		{"APPLY PLAN (UNSAFE + ALLOWED)", func() { fmt.Print(webhooktemplates.PreviewCommentApplyPlanUnsafe()) }},
+		{"SCHEMA CHANGE APPLY (LOCKED)", func() { fmt.Print(webhooktemplates.PreviewCommentApplyPlan()) }},
+		{"SCHEMA CHANGE APPLY (UNSAFE + ALLOWED)", func() { fmt.Print(webhooktemplates.PreviewCommentApplyPlanUnsafe()) }},
 		{"UNSAFE CHANGES BLOCKED", func() { fmt.Print(webhooktemplates.PreviewCommentUnsafeBlocked()) }},
 		{"MULTI-ENV PLAN (IDENTICAL)", func() { fmt.Print(webhooktemplates.PreviewCommentMultiEnvPlan()) }},
 		{"MULTI-ENV PLAN (DIFFERENT)", func() { fmt.Print(webhooktemplates.PreviewCommentMultiEnvPlanDiff()) }},
@@ -89,8 +89,8 @@ func previewApplyCommandAllOutput() {
 		name string
 		fn   func()
 	}{
-		{"APPLY PLAN (LOCK + CONFIRM)", func() { fmt.Print(webhooktemplates.PreviewCommentApplyPlan()) }},
-		{"APPLY PLAN (WITH OPTIONS)", func() { fmt.Print(webhooktemplates.PreviewCommentApplyPlanOptions()) }},
+		{"APPLY GATE: SCHEMA CHANGE APPLY (LOCK + CONFIRM)", func() { fmt.Print(webhooktemplates.PreviewCommentApplyPlan()) }},
+		{"APPLY GATE: SCHEMA CHANGE APPLY (WITH OPTIONS)", func() { fmt.Print(webhooktemplates.PreviewCommentApplyPlanOptions()) }},
 		{"APPLY STARTED", func() { fmt.Print(webhooktemplates.PreviewCommentApplyStarted()) }},
 		{"UNLOCK SUCCESS", func() { fmt.Print(webhooktemplates.PreviewCommentUnlockSuccess()) }},
 		{"APPLY BLOCKED BY OTHER PR", func() { fmt.Print(webhooktemplates.PreviewCommentApplyBlockedByOtherPR()) }},
@@ -146,7 +146,7 @@ func previewCommentPlanAllOutput() {
 		{"MYSQL PLAN", func() { fmt.Print(webhooktemplates.PreviewCommentPlan()) }},
 		{"MYSQL PLAN (NO CHANGES)", func() { fmt.Print(webhooktemplates.PreviewCommentPlanNoChanges()) }},
 		{"VITESS PLAN", func() { fmt.Print(webhooktemplates.PreviewCommentVitessPlan()) }},
-		{"VITESS APPLY PLAN (LOCKED + OPTIONS)", func() { fmt.Print(webhooktemplates.PreviewCommentVitessApplyPlan()) }},
+		{"SCHEMA CHANGE APPLY (LOCKED + OPTIONS)", func() { fmt.Print(webhooktemplates.PreviewCommentVitessApplyPlan()) }},
 		{"MYSQL MULTI-SCHEMA PLAN", func() { fmt.Print(webhooktemplates.PreviewCommentMySQLMultiSchema()) }},
 		{"MULTI-ENV PLAN (IDENTICAL)", func() { fmt.Print(webhooktemplates.PreviewCommentMultiEnvPlan()) }},
 		{"MULTI-ENV PLAN (DIFFERENT)", func() { fmt.Print(webhooktemplates.PreviewCommentMultiEnvPlanDiff()) }},
@@ -189,9 +189,9 @@ func previewCommentApplyFlowAllOutput() {
 		name string
 		fn   func()
 	}{
-		{"MYSQL APPLY PLAN (LOCK + CONFIRM)", func() { fmt.Print(webhooktemplates.PreviewCommentApplyPlan()) }},
-		{"MYSQL APPLY PLAN (WITH OPTIONS)", func() { fmt.Print(webhooktemplates.PreviewCommentApplyPlanOptions()) }},
-		{"VITESS APPLY PLAN (LOCKED + OPTIONS)", func() { fmt.Print(webhooktemplates.PreviewCommentVitessApplyPlan()) }},
+		{"SCHEMA CHANGE APPLY (LOCK + CONFIRM)", func() { fmt.Print(webhooktemplates.PreviewCommentApplyPlan()) }},
+		{"SCHEMA CHANGE APPLY (WITH OPTIONS)", func() { fmt.Print(webhooktemplates.PreviewCommentApplyPlanOptions()) }},
+		{"SCHEMA CHANGE APPLY (VITESS + OPTIONS)", func() { fmt.Print(webhooktemplates.PreviewCommentVitessApplyPlan()) }},
 		{"APPLY STARTED", func() { fmt.Print(webhooktemplates.PreviewCommentApplyStarted()) }},
 		// Single-table (most common case)
 		{"SINGLE TABLE: RUNNING", func() { fmt.Print(webhooktemplates.PreviewCommentApplySingleProgress()) }},

--- a/pkg/webhook/apply_e2e_test.go
+++ b/pkg/webhook/apply_e2e_test.go
@@ -66,7 +66,7 @@ func TestE2EApplyWithChanges(t *testing.T) {
 	// The apply handler runs as a goroutine — wait for the apply plan confirmation comment
 	select {
 	case body := <-result.comments:
-		assert.Contains(t, body, "Schema Change Plan (Apply)")
+		assert.Contains(t, body, "## Schema Change Apply")
 		assert.Contains(t, body, "CREATE TABLE")
 		assert.Contains(t, body, dbName)
 		assert.Contains(t, body, "Lock acquired by")
@@ -1103,7 +1103,7 @@ func TestE2EApplyStaleLockReacquire(t *testing.T) {
 	// Should succeed: release stale lock, re-plan, acquire new lock, post confirmation
 	select {
 	case body := <-result.comments:
-		assert.Contains(t, body, "Schema Change Plan (Apply)")
+		assert.Contains(t, body, "## Schema Change Apply")
 		assert.Contains(t, body, "Lock acquired by")
 		assert.Contains(t, body, "schemabot apply-confirm -e staging")
 	case <-time.After(30 * time.Second):
@@ -1303,7 +1303,7 @@ func TestE2EApplyAutoConfirmExecutes(t *testing.T) {
 	// First comment: plan with "Applying automatically"
 	select {
 	case body := <-result.comments:
-		assert.Contains(t, body, "Schema Change Plan (Apply)")
+		assert.Contains(t, body, "## Schema Change Apply")
 		assert.Contains(t, body, "Applying automatically")
 		assert.Contains(t, body, "-y")
 	case <-time.After(30 * time.Second):
@@ -2352,7 +2352,7 @@ func TestE2EApplyStoresServerSideTarget(t *testing.T) {
 	// Wait for the apply plan confirmation comment.
 	select {
 	case body := <-result.comments:
-		assert.Contains(t, body, "Schema Change Plan (Apply)")
+		assert.Contains(t, body, "## Schema Change Apply")
 		assert.Contains(t, body, "CREATE TABLE")
 		assert.Contains(t, body, dbName)
 	case <-time.After(30 * time.Second):

--- a/pkg/webhook/review_gate_e2e_test.go
+++ b/pkg/webhook/review_gate_e2e_test.go
@@ -305,7 +305,7 @@ func TestE2EApplyProceedsWithApproval(t *testing.T) {
 	// Should get a plan comment (not blocked), confirming the gate passed
 	select {
 	case body := <-result.comments:
-		assert.Contains(t, body, "Schema Change Plan (Apply)")
+		assert.Contains(t, body, "## Schema Change Apply")
 		assert.Contains(t, body, "CREATE TABLE")
 		assert.NotContains(t, body, "Review Required")
 	case <-time.After(10 * time.Second):
@@ -467,7 +467,7 @@ func TestE2EApplyNoCodeownersFile_Approved(t *testing.T) {
 
 	select {
 	case body := <-result.comments:
-		assert.Contains(t, body, "Schema Change Plan (Apply)")
+		assert.Contains(t, body, "## Schema Change Apply")
 		assert.NotContains(t, body, "Review Required")
 	case <-time.After(10 * time.Second):
 		t.Fatal("timeout waiting for plan comment")
@@ -533,7 +533,7 @@ func TestE2EApplyTeamSlugApproval(t *testing.T) {
 	// Team member approved — should proceed to plan
 	select {
 	case body := <-result.comments:
-		assert.Contains(t, body, "Schema Change Plan (Apply)")
+		assert.Contains(t, body, "## Schema Change Apply")
 		assert.NotContains(t, body, "Review Required")
 	case <-time.After(10 * time.Second):
 		t.Fatal("timeout waiting for plan comment")
@@ -655,7 +655,7 @@ func TestE2EApplyCodeownersOptIn(t *testing.T) {
 
 	select {
 	case body := <-result.comments:
-		assert.Contains(t, body, "Schema Change Plan (Apply)")
+		assert.Contains(t, body, "## Schema Change Apply")
 		assert.NotContains(t, body, "Review Required")
 	case <-time.After(10 * time.Second):
 		t.Fatal("timeout waiting for plan comment")
@@ -705,7 +705,7 @@ func TestE2EApplyReviewGateDisabled(t *testing.T) {
 	// Should proceed to plan (gate is off, so no review check)
 	select {
 	case body := <-result.comments:
-		assert.Contains(t, body, "Schema Change Plan (Apply)")
+		assert.Contains(t, body, "## Schema Change Apply")
 		assert.NotContains(t, body, "Review Required")
 	case <-time.After(10 * time.Second):
 		t.Fatal("timeout waiting for plan comment")

--- a/pkg/webhook/templates/plan.go
+++ b/pkg/webhook/templates/plan.go
@@ -78,7 +78,7 @@ func RenderPlanComment(data PlanCommentData) string {
 		dbTypeLabel = "MySQL"
 	}
 	if data.IsLocked {
-		fmt.Fprintf(&sb, "## %s Schema Change Plan (Apply)\n\n", dbTypeLabel)
+		sb.WriteString("## Schema Change Apply\n\n")
 	} else {
 		fmt.Fprintf(&sb, "## %s Schema Change Plan\n\n", dbTypeLabel)
 	}


### PR DESCRIPTION
Simplifies the locked apply confirmation comment title so it reads as the apply flow the user is confirming, rather than as a plan comment variant. Plain plan comments keep their existing `Schema Change Plan` title, while locked apply comments now render as `Schema Change Apply`. Template preview section labels and generated snapshots were updated to match.

Generated with Amp.
