### PR TITLE
test(e2e): add vitess-resolver k8s e2e with LocalScale

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -389,6 +389,17 @@ jobs:
             ~/.cache/go-build
           key: go-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('go.sum') }}
           restore-keys: go-${{ runner.os }}-${{ runner.arch }}-
+      # The runner ships a preinstalled MySQL whose AppArmor profile confines
+      # /usr/sbin/mysqld to its packaged data dirs. LocalScale runs vtcombo's
+      # embedded mysqld (the same binary path) against a vttest data dir, so the
+      # host profile blocks it from reading its own my.cnf and the init aborts.
+      # Unload the profile on the runner so the embedded mysqld runs unconfined.
+      - name: "Disable host mysqld AppArmor profile"
+        run: |
+          if [ -f /etc/apparmor.d/usr.sbin.mysqld ]; then
+            sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld || true
+            sudo ln -sf /etc/apparmor.d/usr.sbin.mysqld /etc/apparmor.d/disable/ || true
+          fi
       - name: "Start minikube"
         uses: medyagh/setup-minikube@d8c0eb871f6f455542491d86a574477bd3894533 # medyagh/setup-minikube@v0.0.18
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -409,6 +409,10 @@ jobs:
       # The script builds the schemabot, etre, and localscale images into
       # minikube's docker daemon, so no separate build step is needed here.
       - name: "Deploy and test"
+        # Keep the namespace on exit so the failure log dump below can read pod
+        # logs; the runner is ephemeral, so there is nothing to clean up after.
+        env:
+          KEEP_NAMESPACE: "1"
         run: e2e/k8s/e2e-vitess-test.sh
       - name: "Pod logs on failure"
         if: failure()

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -368,6 +368,53 @@ jobs:
           echo "=== All pods ==="
           kubectl get pods -n schemabot-e2e-etre -o wide 2>/dev/null || true
 
+  e2e-k8s-vitess:
+    name: "E2E K8s Vitess Tests"
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # actions/checkout@v6
+      - name: "Configure Go"
+        uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # actions/setup-go@v6.1
+        with:
+          go-version-file: go.mod
+          cache: false
+      - name: "Restore Go cache"
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # actions/cache/restore@v4
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: go-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('go.sum') }}
+          restore-keys: go-${{ runner.os }}-${{ runner.arch }}-
+      - name: "Start minikube"
+        uses: medyagh/setup-minikube@d8c0eb871f6f455542491d86a574477bd3894533 # medyagh/setup-minikube@v0.0.18
+        with:
+          driver: docker
+          cpus: 2
+          memory: 6144
+      # The script builds the schemabot, etre, and localscale images into
+      # minikube's docker daemon, so no separate build step is needed here.
+      - name: "Deploy and test"
+        run: e2e/k8s/e2e-vitess-test.sh
+      - name: "Pod logs on failure"
+        if: failure()
+        run: |
+          echo "=== Control Plane ==="
+          kubectl logs -n schemabot-e2e-vitess -l app.kubernetes.io/instance=control-plane-vitess --tail=200 2>/dev/null || true
+          echo "=== Data Plane ==="
+          kubectl logs -n schemabot-e2e-vitess -l app.kubernetes.io/instance=data-plane-vitess --tail=200 2>/dev/null || true
+          echo "=== Etre ==="
+          kubectl logs -n schemabot-e2e-vitess -l app=etre --tail=100 2>/dev/null || true
+          echo "=== LocalScale ==="
+          kubectl logs -n schemabot-e2e-vitess -l app=localscale --tail=200 2>/dev/null || true
+          echo "=== Seed jobs ==="
+          kubectl logs -n schemabot-e2e-vitess -l job-name=etre-seed --tail=50 2>/dev/null || true
+          echo "=== All pods ==="
+          kubectl get pods -n schemabot-e2e-vitess -o wide 2>/dev/null || true
+
   # Rollup jobs that match the old required check names.
   # Remove these after updating branch protection to use the new job names.
   #

--- a/Makefile
+++ b/Makefile
@@ -413,6 +413,9 @@ test-e2e-k8s: ## Run k8s e2e tests on minikube
 test-e2e-k8s-etre: ## Run the etre-resolver k8s e2e on minikube
 	@e2e/k8s/e2e-etre-test.sh
 
+test-e2e-k8s-vitess: ## Run the vitess-resolver k8s e2e on minikube
+	@e2e/k8s/e2e-vitess-test.sh
+
 # Start local dev environment with gRPC backend (separate Tern server)
 up-grpc:
 	docker compose -f deploy/local/docker-compose.grpc.yml up --build

--- a/deploy/local/localscale-entrypoint.sh
+++ b/deploy/local/localscale-entrypoint.sh
@@ -1,8 +1,11 @@
 #!/bin/sh
-# Ensure vtdataroot is writable by the vitess user when a Docker volume
-# is mounted over it (Docker creates named volumes as root).
+# vtcombo's embedded mysqld writes its data dir, my.cnf, and sockets under
+# VTDATAROOT, so that path must be writable by the vitess user the server runs
+# as. When a volume (Docker named volume or Kubernetes emptyDir) is mounted over
+# it, the mount is created root-owned, so chown it before dropping privileges.
+VTDATAROOT="${VTDATAROOT:-/vt/vtdataroot}"
 if [ "$(id -u)" = "0" ]; then
-    chown vitess:vitess /vt/vtdataroot
+    chown vitess:vitess "$VTDATAROOT"
     exec setpriv --reuid=vitess --regid=vitess --init-groups "$@"
 fi
 exec "$@"

--- a/e2e/k8s/control-plane-vitess-values.yaml
+++ b/e2e/k8s/control-plane-vitess-values.yaml
@@ -1,0 +1,39 @@
+# Control plane Helm values for the vitess-resolver k8s e2e.
+#
+# Routes the testapp-vitess database to the vitess data plane over gRPC,
+# carrying the opaque target (a DSID) the data plane resolves through Etre to a
+# PlanetScale organization.
+
+image:
+  repository: schemabot
+  tag: test
+  pullPolicy: Never
+
+config:
+  storage:
+    dsn: "env:MYSQL_DSN"
+  databases:
+    testapp-vitess:
+      type: vitess
+      environments:
+        staging:
+          # Opaque execution target — the DSID the data plane resolves via Etre.
+          target: dsid-testapp-vitess-staging
+          deployment: data-plane-vitess
+  tern_deployments:
+    data-plane-vitess:
+      staging: "data-plane-vitess-schemabot:13370"
+
+env:
+  - name: MYSQL_DSN
+    value: "root:testpassword@tcp(mysql-control-plane:3306)/schemabot?parseTime=true&multiStatements=true"
+  - name: LOG_LEVEL
+    value: "debug"
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 500m
+    memory: 256Mi

--- a/e2e/k8s/data-plane-vitess-values.yaml
+++ b/e2e/k8s/data-plane-vitess-values.yaml
@@ -1,0 +1,54 @@
+# Data plane Helm values for the vitess-resolver k8s e2e.
+#
+# Resolves the opaque target through Etre to a PlanetScale organization, then
+# drives the schema change through the PlanetScale API (LocalScale). The token
+# secret is a PlanetScale token JSON decoded by the secret_ref backend; the
+# organization comes from the resolved entity, not the secret.
+
+image:
+  repository: schemabot
+  tag: test
+  pullPolicy: Never
+
+replicaCount: 2
+
+grpc:
+  enabled: true
+  port: 13370
+
+config:
+  storage:
+    dsn: "env:MYSQL_DSN"
+  target_resolver:
+    etre:
+      addr: "http://etre:8080"
+      database_type: vitess
+      entity_type: planetscale_database
+      target_label: dsid
+      env_label: env
+      vitess:
+        organization_attribute: organization
+        api_url: "http://localscale:8080"
+      credentials:
+        type: secret_ref
+        password_ref: "env:PS_TOKEN"
+
+env:
+  - name: MYSQL_DSN
+    value: "root:testpassword@tcp(mysql-data-plane:3306)/tern?parseTime=true&multiStatements=true"
+  # PlanetScale token secret in JSON form. LocalScale does not validate the
+  # token; the "name=value" form decodes to token_name/token_value.
+  - name: PS_TOKEN
+    value: '{"token":"localscale=localscale"}'
+  - name: TERN_ENVIRONMENT
+    value: "staging"
+  - name: LOG_LEVEL
+    value: "debug"
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 500m
+    memory: 256Mi

--- a/e2e/k8s/e2e-test.sh
+++ b/e2e/k8s/e2e-test.sh
@@ -121,7 +121,9 @@ TEST_EXIT_CODE=0
 E2E_SCHEMABOT_URL=http://localhost:8080 \
 E2E_SCHEMABOT_MYSQL_DSN="root:testpassword@tcp(localhost:3307)/schemabot?parseTime=true&multiStatements=true" \
 E2E_TERN_STAGING_MYSQL_DSN="root:testpassword@tcp(localhost:3308)/testapp?parseTime=true&multiStatements=true" \
-go test -count=1 -v -tags=e2e -timeout=10m ./e2e/k8s/... || TEST_EXIT_CODE=$?
+# The etre- and vitess-resolver tests need their own in-cluster stacks and run in
+# dedicated jobs, so skip them here rather than against the base stack.
+go test -count=1 -v -tags=e2e -timeout=10m -skip 'TestK8sEtre|TestK8sVitess' ./e2e/k8s/... || TEST_EXIT_CODE=$?
 
 # --- Teardown ---
 

--- a/e2e/k8s/e2e-test.sh
+++ b/e2e/k8s/e2e-test.sh
@@ -118,12 +118,12 @@ done
 
 echo "Running k8s e2e tests..."
 TEST_EXIT_CODE=0
+# The etre- and vitess-resolver tests need their own in-cluster stacks and run in
+# dedicated jobs, so skip them here rather than against the base stack.
 E2E_SCHEMABOT_URL=http://localhost:8080 \
 E2E_SCHEMABOT_MYSQL_DSN="root:testpassword@tcp(localhost:3307)/schemabot?parseTime=true&multiStatements=true" \
 E2E_TERN_STAGING_MYSQL_DSN="root:testpassword@tcp(localhost:3308)/testapp?parseTime=true&multiStatements=true" \
-# The etre- and vitess-resolver tests need their own in-cluster stacks and run in
-# dedicated jobs, so skip them here rather than against the base stack.
-go test -count=1 -v -tags=e2e -timeout=10m -skip 'TestK8sEtre|TestK8sVitess' ./e2e/k8s/... || TEST_EXIT_CODE=$?
+    go test -count=1 -v -tags=e2e -timeout=10m -skip 'TestK8sEtre|TestK8sVitess' ./e2e/k8s/... || TEST_EXIT_CODE=$?
 
 # --- Teardown ---
 

--- a/e2e/k8s/e2e-vitess-test.sh
+++ b/e2e/k8s/e2e-vitess-test.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# Runs the vitess-resolver k8s e2e on minikube.
+#
+# The data plane resolves an opaque target (a DSID) through Etre to a PlanetScale
+# organization, then drives the schema change through the PlanetScale API served
+# by LocalScale (real Vitess/vtcombo in-process). Proves the dynamic resolution
+# path end to end for Vitess against real services rather than mocks.
+#
+# Prerequisites: minikube, helm, docker, kubectl, go.
+#
+# Usage:
+#   e2e/k8s/e2e-vitess-test.sh
+
+set -euo pipefail
+
+NAMESPACE="schemabot-e2e-vitess"
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+
+for cmd in minikube helm docker kubectl go; do
+    if ! command -v "$cmd" > /dev/null 2>&1; then
+        echo "Error: $cmd is not installed"
+        exit 1
+    fi
+done
+
+if ! minikube status > /dev/null 2>&1; then
+    echo "Starting minikube..."
+    minikube start --driver=docker --cpus=4 --memory=4096
+fi
+
+# --- Build images into minikube's docker daemon ---
+
+echo "Building schemabot + etre + localscale images for minikube..."
+CGO_ENABLED=0 GOOS=linux go build -o "$REPO_ROOT/bin/schemabot-linux" ./pkg/cmd
+CGO_ENABLED=0 GOOS=linux go build -o "$REPO_ROOT/bin/localscale-linux" ./cmd/localscale
+cp "$REPO_ROOT/bin/schemabot-linux" "$REPO_ROOT/deploy/local/schemabot-dev"
+eval "$(minikube docker-env)"
+docker build -t schemabot:test -f "$REPO_ROOT/deploy/local/Dockerfile.dev" "$REPO_ROOT/deploy/local/"
+rm -f "$REPO_ROOT/deploy/local/schemabot-dev"
+docker build -t etre:test "$REPO_ROOT/e2e/k8s/etre/"
+# LocalScale's Dockerfile COPYs bin/localscale-linux relative to the repo root.
+docker build -t localscale:test -f "$REPO_ROOT/deploy/local/Dockerfile.localscale" "$REPO_ROOT"
+
+PIDS=()
+cleanup() {
+    echo "Cleaning up port-forwards..."
+    for pid in ${PIDS[@]+"${PIDS[@]}"}; do
+        kill "$pid" 2>/dev/null || true
+    done
+}
+trap cleanup EXIT
+
+# Namespace teardown is left to the caller (KEEP_NAMESPACE=1 to inspect after a
+# failure); a re-run reconciles the existing namespace via apply + upgrade.
+teardown_namespace() {
+    if [ "${KEEP_NAMESPACE:-0}" != "1" ]; then
+        kubectl delete namespace "$NAMESPACE" --ignore-not-found
+    fi
+}
+
+wait_for_ready_pods() {
+    local selector="$1"
+    local timeout_seconds="${2:-180}"
+    local deadline=$((SECONDS + timeout_seconds))
+    until kubectl get pod -n "$NAMESPACE" -l "$selector" -o name 2>/dev/null | grep -q .; do
+        if ((SECONDS >= deadline)); then
+            echo "Timeout waiting for pods matching selector: $selector"
+            kubectl get pods -n "$NAMESPACE" -o wide || true
+            exit 1
+        fi
+        sleep 1
+    done
+    local remaining=$((deadline - SECONDS))
+    ((remaining < 1)) && remaining=1
+    kubectl wait --for=condition=ready pod -l "$selector" -n "$NAMESPACE" --timeout="${remaining}s"
+}
+
+# --- Deploy ---
+
+echo "Creating namespace..."
+kubectl create namespace "$NAMESPACE" 2>/dev/null || true
+
+echo "Deploying MySQL + Etre + MongoDB + LocalScale..."
+kubectl apply -n "$NAMESPACE" -f "$REPO_ROOT/e2e/k8s/mysql.yaml"
+# Build the entity fixtures ConfigMap from the JSON documents so the seed Job
+# loads exactly what is checked in under e2e/k8s/vitess/fixtures.
+kubectl create configmap etre-fixtures \
+    --from-file="$REPO_ROOT/e2e/k8s/vitess/fixtures" \
+    -n "$NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
+# Jobs are immutable, so a KEEP_NAMESPACE rerun would not re-run the completed
+# seed Jobs. Delete them first so kubectl apply recreates them and reruns seed
+# deterministically.
+kubectl delete job etre-mongo-init etre-seed -n "$NAMESPACE" --ignore-not-found
+kubectl apply -n "$NAMESPACE" -f "$REPO_ROOT/e2e/k8s/vitess-stack.yaml"
+wait_for_ready_pods "app=mysql-control-plane"
+wait_for_ready_pods "app=mysql-data-plane"
+wait_for_ready_pods "app=etre"
+# vtcombo takes about a minute to start, so allow a little more than the others.
+wait_for_ready_pods "app=localscale" 240
+
+echo "Waiting for seed jobs..."
+kubectl wait --for=condition=complete job/etre-mongo-init -n "$NAMESPACE" --timeout=180s
+kubectl wait --for=condition=complete job/etre-seed -n "$NAMESPACE" --timeout=180s
+
+echo "Installing vitess data plane..."
+helm upgrade --install data-plane-vitess "$REPO_ROOT/charts/schemabot" \
+    -n "$NAMESPACE" -f "$REPO_ROOT/e2e/k8s/data-plane-vitess-values.yaml"
+wait_for_ready_pods "app.kubernetes.io/instance=data-plane-vitess"
+
+echo "Installing control plane..."
+helm upgrade --install control-plane-vitess "$REPO_ROOT/charts/schemabot" \
+    -n "$NAMESPACE" -f "$REPO_ROOT/e2e/k8s/control-plane-vitess-values.yaml"
+wait_for_ready_pods "app.kubernetes.io/instance=control-plane-vitess"
+
+# --- Port-forwards ---
+
+echo "Starting port-forwards..."
+kubectl port-forward -n "$NAMESPACE" svc/control-plane-vitess-schemabot 8080:8080 &
+PIDS+=($!)
+kubectl port-forward -n "$NAMESPACE" svc/mysql-control-plane 3307:3306 &
+PIDS+=($!)
+
+echo "Waiting for control plane..."
+for i in $(seq 1 30); do
+    if curl -sf http://localhost:8080/health > /dev/null 2>&1; then
+        echo "Control plane is healthy"
+        break
+    fi
+    [ "$i" -eq 30 ] && { echo "Timeout waiting for port-forward"; exit 1; }
+    sleep 1
+done
+
+# --- Test ---
+
+echo "Running vitess-resolver k8s e2e..."
+TEST_EXIT_CODE=0
+E2E_SCHEMABOT_URL=http://localhost:8080 \
+E2E_SCHEMABOT_MYSQL_DSN="root:testpassword@tcp(localhost:3307)/schemabot?parseTime=true&multiStatements=true" \
+go test -count=1 -v -tags=e2e -timeout=10m -run TestK8sVitess ./e2e/k8s/... || TEST_EXIT_CODE=$?
+
+teardown_namespace
+exit "$TEST_EXIT_CODE"

--- a/e2e/k8s/vitess-stack.yaml
+++ b/e2e/k8s/vitess-stack.yaml
@@ -164,13 +164,18 @@ spec:
           imagePullPolicy: Never
           env:
             - { name: CONFIG_FILE, value: "/config/localscale.json" }
+            # Point VTDATAROOT at a dedicated emptyDir rather than the image's
+            # own /vt/vtdataroot. Under the cluster's overlay filesystem the
+            # image layer's directory is not reliably writable by the dropped
+            # vitess user, which makes vtcombo's mysqld fail to initialize its
+            # data dir. The emptyDir gives a clean writable path; the entrypoint
+            # chowns it to vitess before dropping privileges. /vt/config (the
+            # mycnf templates and init SQL) stays on the image, unmasked.
+            - { name: VTDATAROOT, value: "/vtdataroot" }
           ports: [{ containerPort: 8080 }]
-          # /vt/vtdataroot is left as the image's own writable path: vtcombo's
-          # mysqld needs the scaffolding the vttestserver image places there, and
-          # an emptyDir would mask it. The e2e pod is ephemeral, so no persistent
-          # volume is needed.
           volumeMounts:
             - { name: config, mountPath: /config, readOnly: true }
+            - { name: vtdataroot, mountPath: /vtdataroot }
           # vtcombo brings up MySQL and the per-shard sidecars before /health
           # returns 200 — about a minute — so allow a startup window past that.
           readinessProbe:
@@ -188,6 +193,8 @@ spec:
       volumes:
         - name: config
           configMap: { name: localscale-config }
+        - name: vtdataroot
+          emptyDir: {}
 ---
 apiVersion: v1
 kind: Service

--- a/e2e/k8s/vitess-stack.yaml
+++ b/e2e/k8s/vitess-stack.yaml
@@ -138,6 +138,9 @@ data:
         }
       },
       "listen_addr": ":8080",
+      "proxy_advertise_host": "localscale",
+      "proxy_port_start": 19100,
+      "proxy_port_end": 19104,
       "revert_window_duration": "2s",
       "default_throttle_ratio": 0.85,
       "branch_creation_delay": "50ms",
@@ -172,7 +175,17 @@ spec:
             # chowns it to vitess before dropping privileges. /vt/config (the
             # mycnf templates and init SQL) stays on the image, unmasked.
             - { name: VTDATAROOT, value: "/vtdataroot" }
-          ports: [{ containerPort: 8080 }]
+          # 8080 is the PlanetScale API; 19100-19104 are the per-branch vtgate
+          # MySQL proxies the engine dials to apply DDL to a branch. The proxy
+          # port range is pinned in the config above so the Service can route
+          # exactly these ports (k8s Services cannot express a port range).
+          ports:
+            - { containerPort: 8080 }
+            - { containerPort: 19100 }
+            - { containerPort: 19101 }
+            - { containerPort: 19102 }
+            - { containerPort: 19103 }
+            - { containerPort: 19104 }
           volumeMounts:
             - { name: config, mountPath: /config, readOnly: true }
             - { name: vtdataroot, mountPath: /vtdataroot }
@@ -202,7 +215,15 @@ metadata:
   name: localscale
 spec:
   selector: { app: localscale }
-  ports: [{ port: 8080 }]
+  # Route the PlanetScale API (8080) and the pinned per-branch vtgate MySQL
+  # proxy ports (19100-19104) the engine dials to apply DDL to a branch.
+  ports:
+    - { name: api, port: 8080 }
+    - { name: proxy-0, port: 19100 }
+    - { name: proxy-1, port: 19101 }
+    - { name: proxy-2, port: 19102 }
+    - { name: proxy-3, port: 19103 }
+    - { name: proxy-4, port: 19104 }
 ---
 # Load the entity fixtures into Etre. The fixtures live in
 # e2e/k8s/vitess/fixtures/<entity_type>.json and are mounted via the

--- a/e2e/k8s/vitess-stack.yaml
+++ b/e2e/k8s/vitess-stack.yaml
@@ -1,0 +1,242 @@
+# Etre + MongoDB + LocalScale for the k8s vitess-resolver e2e.
+#
+# The data plane resolves an opaque target (DSID) through Etre to a PlanetScale
+# organization, then drives the schema change through the PlanetScale API —
+# emulated by LocalScale, which runs real Vitess (vtcombo) in-process. The seed
+# Job registers a planetscale_database entity in Etre so a plan/apply for the
+# routed Vitess database resolves and applies end to end.
+---
+# MongoDB (single-node replica set — Etre's CDC needs the oplog).
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: etre-mongo
+  labels: { app: etre-mongo }
+spec:
+  replicas: 1
+  selector:
+    matchLabels: { app: etre-mongo }
+  template:
+    metadata:
+      labels: { app: etre-mongo }
+    spec:
+      containers:
+        - name: mongo
+          image: mongo:6.0
+          command: ["mongod", "--replSet", "rs0", "--bind_ip_all"]
+          ports: [{ containerPort: 27017 }]
+          readinessProbe:
+            exec:
+              command: ["mongosh", "--quiet", "--eval", "db.adminCommand('ping')"]
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 5
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: etre-mongo
+spec:
+  selector: { app: etre-mongo }
+  ports: [{ port: 27017 }]
+---
+# One-shot replica-set initiation (idempotent).
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: etre-mongo-init
+spec:
+  backoffLimit: 30
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: init
+          image: mongo:6.0
+          command:
+            - sh
+            - -c
+            - |
+              until mongosh --host etre-mongo:27017 --quiet --eval "db.adminCommand('ping')"; do
+                echo "waiting for mongo..."; sleep 2;
+              done
+              mongosh --host etre-mongo:27017 --quiet --eval '
+                try { rs.status() }
+                catch (e) { rs.initiate({_id: "rs0", members: [{_id: 0, host: "etre-mongo:27017"}]}) }'
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: etre-config
+data:
+  config.yaml: |
+    server:
+      addr: ":8080"
+    datasource:
+      url: "mongodb://etre-mongo:27017/?replicaSet=rs0&directConnection=true"
+    cdc:
+      datasource:
+        url: "mongodb://etre-mongo:27017/?replicaSet=rs0&directConnection=true"
+    entity:
+      types:
+        - planetscale_database
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: etre
+  labels: { app: etre }
+spec:
+  replicas: 1
+  selector:
+    matchLabels: { app: etre }
+  template:
+    metadata:
+      labels: { app: etre }
+    spec:
+      containers:
+        - name: etre
+          image: etre:test
+          imagePullPolicy: Never
+          ports: [{ containerPort: 8080 }]
+          volumeMounts:
+            - name: config
+              mountPath: /etc/etre
+          readinessProbe:
+            tcpSocket: { port: 8080 }
+            initialDelaySeconds: 5
+            periodSeconds: 5
+      volumes:
+        - name: config
+          configMap: { name: etre-config }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: etre
+spec:
+  selector: { app: etre }
+  ports: [{ port: 8080 }]
+---
+# LocalScale: fake PlanetScale API with managed Vitess (vtcombo) in-process.
+# Built from source (deploy/local/Dockerfile.localscale) so the e2e always
+# exercises the current LocalScale, not a published image that could drift.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: localscale-config
+data:
+  localscale.json: |
+    {
+      "organizations": {
+        "localscale-staging": {
+          "databases": {
+            "testapp-vitess": {
+              "keyspaces": [{"name": "testapp", "shards": 1}]
+            }
+          }
+        }
+      },
+      "listen_addr": ":8080",
+      "revert_window_duration": "2s",
+      "default_throttle_ratio": 0.85,
+      "branch_creation_delay": "50ms",
+      "deploy_request_delay": "50ms",
+      "processor_tick_interval": "100ms"
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: localscale
+  labels: { app: localscale }
+spec:
+  replicas: 1
+  selector:
+    matchLabels: { app: localscale }
+  template:
+    metadata:
+      labels: { app: localscale }
+    spec:
+      containers:
+        - name: localscale
+          image: localscale:test
+          imagePullPolicy: Never
+          env:
+            - { name: CONFIG_FILE, value: "/config/localscale.json" }
+          ports: [{ containerPort: 8080 }]
+          # /vt/vtdataroot is left as the image's own writable path: vtcombo's
+          # mysqld needs the scaffolding the vttestserver image places there, and
+          # an emptyDir would mask it. The e2e pod is ephemeral, so no persistent
+          # volume is needed.
+          volumeMounts:
+            - { name: config, mountPath: /config, readOnly: true }
+          # vtcombo brings up MySQL and the per-shard sidecars before /health
+          # returns 200 — about a minute — so allow a startup window past that.
+          readinessProbe:
+            httpGet: { path: /health, port: 8080 }
+            initialDelaySeconds: 15
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 24
+          resources:
+            requests:
+              cpu: 500m
+              memory: 1Gi
+            limits:
+              memory: 2Gi
+      volumes:
+        - name: config
+          configMap: { name: localscale-config }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: localscale
+spec:
+  selector: { app: localscale }
+  ports: [{ port: 8080 }]
+---
+# Load the entity fixtures into Etre. The fixtures live in
+# e2e/k8s/vitess/fixtures/<entity_type>.json and are mounted via the
+# etre-fixtures ConfigMap, which the runner script builds from that directory.
+# Each file is POSTed to the collection named after the file. Seeding is skipped
+# when a type already has entities so a KEEP_NAMESPACE rerun does not create
+# duplicate rows, which would make resolution fail closed on an ambiguous match.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: etre-seed
+spec:
+  backoffLimit: 30
+  template:
+    spec:
+      restartPolicy: OnFailure
+      volumes:
+        - name: fixtures
+          configMap:
+            name: etre-fixtures
+      containers:
+        - name: seed
+          image: curlimages/curl:8.10.1
+          volumeMounts:
+            - { name: fixtures, mountPath: /fixtures }
+          command:
+            - sh
+            - -c
+            - |
+              until curl -sf "http://etre:8080/api/v1/entities/planetscale_database?query=_id!=0" >/dev/null; do
+                echo "waiting for etre..."; sleep 2;
+              done
+              for f in /fixtures/*.json; do
+                entity_type=$(basename "$f" .json)
+                if curl -sf "http://etre:8080/api/v1/entities/$entity_type?query=_id!=0" | grep -q '"_id"'; then
+                  echo "$entity_type already seeded, skipping"
+                  continue
+                fi
+                echo "seeding $entity_type from $f"
+                curl -sf -X POST "http://etre:8080/api/v1/entities/$entity_type" \
+                  -H "Content-Type: application/json" \
+                  -d @"$f"
+              done
+              echo "etre seeded"

--- a/e2e/k8s/vitess/fixtures/planetscale_database.json
+++ b/e2e/k8s/vitess/fixtures/planetscale_database.json
@@ -1,0 +1,9 @@
+[
+  {
+    "name": "testapp-vitess",
+    "app": "testapp",
+    "dsid": "dsid-testapp-vitess-staging",
+    "env": "staging",
+    "organization": "localscale-staging"
+  }
+]

--- a/e2e/k8s/vitess_resolver_test.go
+++ b/e2e/k8s/vitess_resolver_test.go
@@ -1,0 +1,63 @@
+//go:build e2e
+
+package k8s
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/block/schemabot/e2e/testutil"
+	"github.com/block/schemabot/pkg/apitypes"
+	"github.com/block/schemabot/pkg/cmd/client"
+	"github.com/block/schemabot/pkg/state"
+)
+
+// TestK8sVitess_PlanApply_CreateTable exercises the dynamic data-plane
+// resolution path for Vitess end to end. The control plane routes the
+// testapp-vitess database to the vitess data plane carrying an opaque target (a
+// DSID). The data plane resolves that DSID through a real Etre server to a
+// PlanetScale organization, then drives the schema change through the
+// PlanetScale API — served by LocalScale running real Vitess (vtcombo)
+// in-process — and the apply runs to completion. It is the Vitess counterpart
+// to the etre MySQL resolve-then-apply coverage, against real services.
+func TestK8sVitess_PlanApply_CreateTable(t *testing.T) {
+	ep := testutil.Endpoint(t)
+	tableName := testutil.UniqueTableName("k8s_vitess_create")
+
+	// Vitess schema files are keyed by keyspace (the namespace), so the new table
+	// lands in the testapp keyspace LocalScale is configured with. The keyspace
+	// starts empty, so a single CREATE TABLE plans cleanly (no base schema, no
+	// DROPs).
+	schemaFiles := map[string]string{
+		tableName + ".sql": fmt.Sprintf(
+			`CREATE TABLE %s (
+    id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(255) NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;`, tableName),
+	}
+
+	planResp, err := client.CallPlanAPIWithFiles(ep, "testapp-vitess", "vitess", "staging",
+		map[string]*apitypes.SchemaFiles{"testapp": {Files: schemaFiles}}, "", 0)
+	require.NoError(t, err)
+	require.NotEmpty(t, planResp.PlanID)
+
+	// Assert the plan actually contains the CREATE, so a no-op plan from broken
+	// resolution or keyspace wiring fails here rather than silently "succeeding".
+	var ddl strings.Builder
+	for _, change := range planResp.Changes {
+		for _, tc := range change.TableChanges {
+			ddl.WriteString(tc.DDL + "\n")
+		}
+	}
+	require.Contains(t, ddl.String(), "CREATE TABLE", "plan produced no CREATE")
+	require.Contains(t, ddl.String(), tableName, "plan does not target %s", tableName)
+
+	applyResp, err := client.CallApplyAPI(ep, planResp.PlanID, "staging", "", nil)
+	require.NoError(t, err)
+	require.True(t, applyResp.Accepted, "apply not accepted: %s", applyResp.ErrorMessage)
+
+	testutil.WaitForState(t, ep, applyResp.ApplyID, state.Apply.Completed, testutil.PollDeadline)
+}


### PR DESCRIPTION
## Why this matters

The Vitess data plane — resolve a PlanetScale target through Etre, then drive the schema change through the PlanetScale API — is unit-tested and validated against real entity shapes, but nothing exercises it end to end. This adds the highest-fidelity coverage, the Vitess counterpart to the etre MySQL e2e, so the resolve-then-apply path is proven against real services (a real Etre server + real Vitess via LocalScale) rather than mocks.

## What it does

Runs the whole vitess resolution stack in-cluster on minikube:

```
control plane (testapp-vitess) ─▶ target dsid ─▶ data-plane-vitess
                                                      │ resolve dsid via Etre
                                                      ▼
                                        organization + token ─▶ PlanetScale API (LocalScale)
                                                      │
                                            CREATE TABLE in keyspace ─▶ apply ─▶ Completed
```

- a real **Etre** server (built from source) backed by MongoDB, seeded with a `planetscale_database` entity
- **LocalScale** (built from source) — a PlanetScale-compatible API backed by real Vitess (vtcombo) in-process
- the SchemaBot control + data planes via Helm, the data plane configured with `database_type: vitess`

`TestK8sVitess_PlanApply_CreateTable` routes a Vitess database to the data plane carrying an opaque target; the data plane resolves it through Etre to a PlanetScale organization, decodes the token credential, drives a CREATE TABLE through the PlanetScale API, and the apply runs to completion against the (empty) `testapp` keyspace.

Ships the in-cluster stack, the entity fixture, data/control-plane Helm values, the runner script, a `test-e2e-k8s-vitess` make target, and a dedicated CI job. LocalScale is built from source so the e2e tracks the current code rather than a published image that could drift.

## How it moves toward the northstar

This completes validation parity for the engine-agnostic data plane — MySQL and Vitess are now both covered end to end by a real-services k8s e2e. With both engines resolved from server config and proven in CI, the out-of-tree resolution shim is fully replaceable for both.

---
*PR drafted by Claude Code (Opus 4.8).*