### PR TITLE
feat(cli): list configured databases

### DIFF
--- a/pkg/cmd/client/client.go
+++ b/pkg/cmd/client/client.go
@@ -52,6 +52,26 @@ func GetEnvironments(endpoint, database string) ([]string, error) {
 	return result.Environments, nil
 }
 
+// ListDatabasesOptions controls database list request fields.
+type ListDatabasesOptions struct {
+	Type string
+}
+
+// ListDatabases fetches the configured databases known to the server.
+func ListDatabases(endpoint string, opts ListDatabasesOptions) (*apitypes.DatabaseListResponse, error) {
+	requestPath := "/api/databases"
+	if opts.Type != "" {
+		values := url.Values{}
+		values.Set("type", opts.Type)
+		requestPath += "?" + values.Encode()
+	}
+	var result apitypes.DatabaseListResponse
+	if err := doGetInto(endpoint, requestPath, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
 // PullSchemaOptions controls optional live schema pull request fields.
 type PullSchemaOptions struct {
 	Namespaces    []string

--- a/pkg/cmd/client/client_test.go
+++ b/pkg/cmd/client/client_test.go
@@ -65,6 +65,38 @@ func TestCallPullSchemaAPIError(t *testing.T) {
 	assert.Contains(t, err.Error(), "database not configured")
 }
 
+func TestListDatabases(t *testing.T) {
+	var gotType string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/databases", r.URL.Path)
+		gotType = r.URL.Query().Get("type")
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(apitypes.DatabaseListResponse{
+			Databases: []*apitypes.DatabaseResponse{
+				{
+					Database: "orders",
+					Type:     "mysql",
+					Environments: []*apitypes.DatabaseEnvironmentResponse{
+						{Environment: "production", Deployments: []string{"pie"}},
+					},
+				},
+			},
+		}))
+	}))
+	t.Cleanup(server.Close)
+
+	result, err := ListDatabases(server.URL, ListDatabasesOptions{Type: "mysql"})
+	require.NoError(t, err)
+
+	assert.Equal(t, "mysql", gotType)
+	require.NotNil(t, result)
+	require.Len(t, result.Databases, 1)
+	assert.Equal(t, "orders", result.Databases[0].Database)
+	assert.Equal(t, "mysql", result.Databases[0].Type)
+	assert.Equal(t, []string{"pie"}, result.Databases[0].Environments[0].Deployments)
+}
+
 func TestGetStatusWithOptions(t *testing.T) {
 	var gotLimit, gotEnvironment, gotFailed string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/cmd/commands/databases.go
+++ b/pkg/cmd/commands/databases.go
@@ -1,0 +1,102 @@
+package commands
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/block/schemabot/pkg/apitypes"
+	"github.com/block/schemabot/pkg/cmd/client"
+	"github.com/block/schemabot/pkg/storage"
+)
+
+// DatabasesCmd lists databases configured on the SchemaBot server.
+type DatabasesCmd struct {
+	Type string `help:"Database type filter (mysql, vitess, or strata)"`
+	JSON bool   `help:"Output as JSON"`
+}
+
+// Run executes the databases command.
+func (cmd *DatabasesCmd) Run(g *Globals) error {
+	ep, err := resolveEndpoint(g.Endpoint, g.Profile)
+	if err != nil {
+		return err
+	}
+	if err := validateDatabaseListType(cmd.Type); err != nil {
+		return err
+	}
+
+	resp, err := client.ListDatabases(ep, client.ListDatabasesOptions{Type: cmd.Type})
+	if err != nil {
+		return fmt.Errorf("list databases: %w", err)
+	}
+	if cmd.JSON {
+		return writeJSON(resp)
+	}
+	return writeDatabaseList(os.Stdout, resp)
+}
+
+func validateDatabaseListType(databaseType string) error {
+	switch databaseType {
+	case "", storage.DatabaseTypeMySQL, storage.DatabaseTypeVitess, storage.DatabaseTypeStrata:
+		return nil
+	default:
+		return fmt.Errorf("--type must be %q, %q, or %q", storage.DatabaseTypeMySQL, storage.DatabaseTypeVitess, storage.DatabaseTypeStrata)
+	}
+}
+
+func writeDatabaseList(w io.Writer, resp *apitypes.DatabaseListResponse) error {
+	if resp == nil || len(resp.Databases) == 0 {
+		_, err := fmt.Fprintln(w, "No databases configured.")
+		return err
+	}
+
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	if _, err := fmt.Fprintln(tw, "DATABASE\tTYPE\tENVIRONMENTS\tDEPLOYMENTS"); err != nil {
+		return err
+	}
+	for _, database := range resp.Databases {
+		if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n",
+			database.Database,
+			database.Type,
+			databaseEnvironments(database.Environments),
+			databaseDeployments(database.Environments),
+		); err != nil {
+			return err
+		}
+	}
+	return tw.Flush()
+}
+
+func databaseEnvironments(environments []*apitypes.DatabaseEnvironmentResponse) string {
+	names := make([]string, 0, len(environments))
+	for _, environment := range environments {
+		if environment == nil || environment.Environment == "" {
+			continue
+		}
+		names = append(names, environment.Environment)
+	}
+	if len(names) == 0 {
+		return "-"
+	}
+	return strings.Join(names, ", ")
+}
+
+func databaseDeployments(environments []*apitypes.DatabaseEnvironmentResponse) string {
+	parts := make([]string, 0, len(environments))
+	for _, environment := range environments {
+		if environment == nil || len(environment.Deployments) == 0 {
+			continue
+		}
+		deployments := append([]string(nil), environment.Deployments...)
+		sort.Strings(deployments)
+		parts = append(parts, fmt.Sprintf("%s: %s", environment.Environment, strings.Join(deployments, ", ")))
+	}
+	if len(parts) == 0 {
+		return "-"
+	}
+	return strings.Join(parts, "; ")
+}

--- a/pkg/cmd/commands/databases_test.go
+++ b/pkg/cmd/commands/databases_test.go
@@ -1,0 +1,106 @@
+package commands
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/block/schemabot/pkg/apitypes"
+)
+
+func TestWriteDatabaseList(t *testing.T) {
+	var out bytes.Buffer
+	err := writeDatabaseList(&out, &apitypes.DatabaseListResponse{
+		Databases: []*apitypes.DatabaseResponse{
+			{
+				Database: "accounts",
+				Type:     "vitess",
+				Environments: []*apitypes.DatabaseEnvironmentResponse{
+					{Environment: "production", Deployments: []string{"sled"}},
+				},
+			},
+			{
+				Database: "orders",
+				Type:     "mysql",
+				Environments: []*apitypes.DatabaseEnvironmentResponse{
+					{Environment: "production", Deployments: []string{"pie"}},
+					{Environment: "staging"},
+				},
+			},
+		},
+	})
+
+	require.NoError(t, err)
+	output := out.String()
+	assert.Contains(t, output, "DATABASE")
+	assert.Contains(t, output, "TYPE")
+	assert.Contains(t, output, "ENVIRONMENTS")
+	assert.Contains(t, output, "DEPLOYMENTS")
+	assert.Contains(t, output, "accounts")
+	assert.Contains(t, output, "vitess")
+	assert.Contains(t, output, "production: sled")
+	assert.Contains(t, output, "orders")
+	assert.Contains(t, output, "mysql")
+	assert.Contains(t, output, "production, staging")
+	assert.Contains(t, output, "production: pie")
+}
+
+func TestDatabasesCommandRunFetchesAndRendersDatabases(t *testing.T) {
+	var gotType string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/databases", r.URL.Path)
+		gotType = r.URL.Query().Get("type")
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(apitypes.DatabaseListResponse{
+			Databases: []*apitypes.DatabaseResponse{
+				{
+					Database: "orders",
+					Type:     "mysql",
+					Environments: []*apitypes.DatabaseEnvironmentResponse{
+						{Environment: "production", Deployments: []string{"pie"}},
+					},
+				},
+			},
+		}))
+	}))
+	t.Cleanup(server.Close)
+
+	cmd := &DatabasesCmd{Type: "mysql"}
+	var runErr error
+	output := captureStdout(func() {
+		runErr = cmd.Run(&Globals{Endpoint: server.URL})
+	})
+
+	require.NoError(t, runErr)
+	assert.Equal(t, "mysql", gotType)
+	assert.Contains(t, output, "DATABASE")
+	assert.Contains(t, output, "orders")
+	assert.Contains(t, output, "mysql")
+	assert.Contains(t, output, "production")
+	assert.Contains(t, output, "production: pie")
+}
+
+func TestWriteDatabaseListEmpty(t *testing.T) {
+	var out bytes.Buffer
+	err := writeDatabaseList(&out, &apitypes.DatabaseListResponse{})
+
+	require.NoError(t, err)
+	assert.Equal(t, "No databases configured.\n", out.String())
+}
+
+func TestValidateDatabaseListType(t *testing.T) {
+	assert.NoError(t, validateDatabaseListType(""))
+	assert.NoError(t, validateDatabaseListType("mysql"))
+	assert.NoError(t, validateDatabaseListType("vitess"))
+	assert.NoError(t, validateDatabaseListType("strata"))
+
+	err := validateDatabaseListType("postgres")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--type must be")
+}

--- a/pkg/cmd/main.go
+++ b/pkg/cmd/main.go
@@ -36,6 +36,7 @@ type CLI struct {
 	Revert     commands.RevertCmd     `cmd:"" help:"Revert a completed schema change during the revert window"`
 	SkipRevert commands.SkipRevertCmd `cmd:"" name:"skip-revert" help:"Skip the revert window, finalizing the schema change"`
 	Rollback   commands.RollbackCmd   `cmd:"" help:"Rollback to the previous schema state"`
+	Databases  commands.DatabasesCmd  `cmd:"" help:"List configured databases"`
 	Unlock     commands.UnlockCmd     `cmd:"" help:"Release a database lock"`
 	Locks      commands.LocksCmd      `cmd:"" help:"List all active database locks"`
 	Logs       commands.LogsCmd       `cmd:"" help:"View apply logs"`


### PR DESCRIPTION
## Why
Operators and API clients now have a server-side database discovery endpoint, but CLI users need a quick way to inspect that inventory without hand-writing HTTP requests.

## What
- Add `schemabot databases` to list configured databases from the server
- Support `--type mysql|vitess|strata` filtering and `--json` output
- Render a compact table with database, type, environments, and deployment topology

## Risk Assessment
Low — this is a read-only CLI command that calls the existing database list API and does not change schema change execution paths.

## References
Example usage:

```bash
schemabot databases
schemabot databases --type mysql
schemabot databases --json
```

Generated with Amp
