### PR TITLE
feat(engine): data-plane embedder enablers (engine registry + type-routing resolver)

### DIFF
--- a/pkg/api/service.go
+++ b/pkg/api/service.go
@@ -109,9 +109,14 @@ type Service struct {
 	config            *ServerConfig
 	ternClients       map[string]tern.Client // keyed by "deployment/environment", lazily created
 	routingTernClient *tern.RoutingClient
-	ternMu            sync.Mutex // protects tern client caches
+	ternMu            sync.Mutex // protects tern client caches and engineFactories
 	logger            *slog.Logger
 	clock             clock.Clock
+
+	// engineFactories holds engine implementations for database types this build
+	// does not provide natively, registered by an embedding service via
+	// RegisterEngine. Local clients the service builds receive them.
+	engineFactories map[string]tern.EngineFactory
 
 	// Operator loop management.
 	operatorMu           sync.Mutex
@@ -216,12 +221,37 @@ func New(st storage.Storage, config *ServerConfig, ternClients map[string]tern.C
 		storage:              st,
 		config:               config,
 		ternClients:          ternClients,
+		engineFactories:      make(map[string]tern.EngineFactory),
 		logger:               logger,
 		clock:                clock.Real{},
 		operatorPollInterval: OperatorPollInterval,
 		remoteHealthInterval: RemoteDeploymentHealthCheckInterval,
 		pendingObservers:     make(map[pendingObserverKey]tern.ProgressObserver),
 	}
+}
+
+// RegisterEngine registers an Engine implementation for a database type this
+// build does not provide natively (the built-in types are unaffected). Call it
+// during setup, before serving: local clients the service builds for that type
+// use the registered factory. It is the extension point for an embedding
+// service to supply an engine without the core depending on its package.
+//
+// It validates its inputs so a misconfiguration fails fast at setup rather than
+// as a confusing downstream error (or a panic on a nil factory).
+func (s *Service) RegisterEngine(databaseType string, factory tern.EngineFactory) error {
+	if databaseType == "" {
+		return fmt.Errorf("register engine: database type must not be empty")
+	}
+	if factory == nil {
+		return fmt.Errorf("register engine for database type %q: factory must not be nil", databaseType)
+	}
+	s.ternMu.Lock()
+	defer s.ternMu.Unlock()
+	if s.engineFactories == nil {
+		s.engineFactories = make(map[string]tern.EngineFactory)
+	}
+	s.engineFactories[databaseType] = factory
+	return nil
 }
 
 // SetClock overrides the time source used by orchestration loops (currently
@@ -464,11 +494,12 @@ func (s *Service) newLocalTernClient(key, database, dbType string, envConfig Env
 		metadata["pending_drops"] = "false"
 	}
 	client, err := tern.NewLocalClient(tern.LocalConfig{
-		Database:     database,
-		Type:         dbType,
-		TargetDSN:    targetDSN,
-		Metadata:     metadata,
-		WakeOperator: s.wakeOperator,
+		Database:        database,
+		Type:            dbType,
+		TargetDSN:       targetDSN,
+		Metadata:        metadata,
+		WakeOperator:    s.wakeOperator,
+		EngineFactories: s.engineFactories,
 	}, s.storage, s.logger)
 	if err != nil {
 		return nil, fmt.Errorf("create local tern client for %s: %w", key, err)

--- a/pkg/api/service_test.go
+++ b/pkg/api/service_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/block/schemabot/pkg/engine"
 	ternv1 "github.com/block/schemabot/pkg/proto/ternv1"
 	"github.com/block/schemabot/pkg/storage"
 	"github.com/block/schemabot/pkg/tern"
@@ -271,6 +272,46 @@ func TestServiceDeploymentForDatabaseEnvironment(t *testing.T) {
 
 	_, err = service.deploymentForDatabaseEnvironment("missing", "", "staging")
 	require.Error(t, err)
+}
+
+type fakeRegisteredEngine struct{ engine.Engine }
+
+// A database type with no built-in engine fails closed until an embedding
+// service registers one; once registered, the service builds the local client
+// with the supplied engine.
+func TestServiceRegisterEngineSuppliesLocalClientEngine(t *testing.T) {
+	cfg := &ServerConfig{
+		Databases: map[string]DatabaseConfig{
+			"customdb": {
+				Type: "customengine",
+				Environments: map[string]EnvironmentConfig{
+					"staging": {DSN: "root@tcp(localhost:3306)/customdb"},
+				},
+			},
+		},
+	}
+	service := New(nil, cfg, nil, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	_, err := service.TernClient("customdb", "staging")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no engine registered")
+
+	require.NoError(t, service.RegisterEngine("customengine", func(tern.LocalConfig, *slog.Logger) (engine.Engine, error) {
+		return &fakeRegisteredEngine{}, nil
+	}))
+	client, err := service.TernClient("customdb", "staging")
+	require.NoError(t, err)
+	require.NotNil(t, client)
+}
+
+// RegisterEngine validates its inputs so a misconfiguration fails fast at setup.
+func TestServiceRegisterEngineValidates(t *testing.T) {
+	service := New(nil, &ServerConfig{}, nil, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	require.Error(t, service.RegisterEngine("", func(tern.LocalConfig, *slog.Logger) (engine.Engine, error) {
+		return &fakeRegisteredEngine{}, nil
+	}))
+	require.Error(t, service.RegisterEngine("customengine", nil))
 }
 
 // A PlanetScale token configured as a literal (the secrets resolver returns

--- a/pkg/inventory/typerouting.go
+++ b/pkg/inventory/typerouting.go
@@ -1,0 +1,53 @@
+package inventory
+
+import (
+	"context"
+	"fmt"
+)
+
+// TypeRoutingResolver routes a request to the Resolver registered for its
+// database type. Each engine resolver (for example an Etre resolver bound to one
+// entity type and connection assembler) serves a single engine, so a data plane
+// that serves more than one engine composes one per type behind a single
+// Resolver and lets the request's database type select among them.
+type TypeRoutingResolver struct {
+	byType map[string]Resolver
+}
+
+var _ Resolver = (*TypeRoutingResolver)(nil)
+
+// NewTypeRoutingResolver builds a resolver that dispatches by database type. The
+// keys are database types (for example "mysql", "vitess"); each value resolves
+// targets for that type. It fails closed on an empty set, an empty type key, or
+// a nil resolver so a misconfiguration surfaces at construction, not on the
+// first request.
+func NewTypeRoutingResolver(byType map[string]Resolver) (*TypeRoutingResolver, error) {
+	if len(byType) == 0 {
+		return nil, fmt.Errorf("at least one resolver is required")
+	}
+	resolvers := make(map[string]Resolver, len(byType))
+	for databaseType, resolver := range byType {
+		if databaseType == "" {
+			return nil, fmt.Errorf("database type key must not be empty")
+		}
+		if resolver == nil {
+			return nil, fmt.Errorf("resolver for database type %q must not be nil", databaseType)
+		}
+		resolvers[databaseType] = resolver
+	}
+	return &TypeRoutingResolver{byType: resolvers}, nil
+}
+
+// ResolveTarget dispatches to the resolver registered for the request's database
+// type. It fails closed when the request carries no type or no resolver is
+// registered for it, rather than guessing an engine.
+func (r *TypeRoutingResolver) ResolveTarget(ctx context.Context, req Request) (*Target, error) {
+	if req.DatabaseType == "" {
+		return nil, fmt.Errorf("resolve target %q: a database type is required to select an engine resolver", req.Target)
+	}
+	resolver, ok := r.byType[req.DatabaseType]
+	if !ok {
+		return nil, fmt.Errorf("resolve target %q: no resolver registered for database type %q", req.Target, req.DatabaseType)
+	}
+	return resolver.ResolveTarget(ctx, req)
+}

--- a/pkg/inventory/typerouting_test.go
+++ b/pkg/inventory/typerouting_test.go
@@ -1,0 +1,66 @@
+package inventory
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeResolver struct {
+	target *Target
+	gotReq Request
+}
+
+func (f *fakeResolver) ResolveTarget(_ context.Context, req Request) (*Target, error) {
+	f.gotReq = req
+	return f.target, nil
+}
+
+// A data plane serving multiple engines composes one resolver per type and lets
+// the request's database type select among them.
+func TestTypeRoutingResolverDispatchesByType(t *testing.T) {
+	mysql := &fakeResolver{target: &Target{Target: "m", DatabaseType: "mysql"}}
+	vitess := &fakeResolver{target: &Target{Target: "v", DatabaseType: "vitess"}}
+	r, err := NewTypeRoutingResolver(map[string]Resolver{"mysql": mysql, "vitess": vitess})
+	require.NoError(t, err)
+
+	got, err := r.ResolveTarget(t.Context(), Request{Target: "dsid-1", DatabaseType: "vitess"})
+	require.NoError(t, err)
+	assert.Equal(t, "v", got.Target)
+	assert.Equal(t, "dsid-1", vitess.gotReq.Target, "the request is passed through to the engine resolver")
+	assert.Empty(t, mysql.gotReq.Target, "the mysql resolver is not consulted for a vitess request")
+}
+
+func TestTypeRoutingResolverRequiresDatabaseType(t *testing.T) {
+	r, err := NewTypeRoutingResolver(map[string]Resolver{"mysql": &fakeResolver{}})
+	require.NoError(t, err)
+
+	_, err = r.ResolveTarget(t.Context(), Request{Target: "dsid-1"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "database type is required")
+}
+
+func TestTypeRoutingResolverFailsClosedForUnregisteredType(t *testing.T) {
+	r, err := NewTypeRoutingResolver(map[string]Resolver{"mysql": &fakeResolver{}})
+	require.NoError(t, err)
+
+	_, err = r.ResolveTarget(t.Context(), Request{Target: "dsid-1", DatabaseType: "vitess"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no resolver registered for database type")
+}
+
+func TestNewTypeRoutingResolverValidatesConfig(t *testing.T) {
+	_, err := NewTypeRoutingResolver(nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "at least one resolver")
+
+	_, err = NewTypeRoutingResolver(map[string]Resolver{"": &fakeResolver{}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "database type key")
+
+	_, err = NewTypeRoutingResolver(map[string]Resolver{"mysql": nil})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must not be nil")
+}

--- a/pkg/tern/local_client.go
+++ b/pkg/tern/local_client.go
@@ -128,7 +128,8 @@ type LocalConfig struct {
 	// Database is the name of this database.
 	Database string
 
-	// Type is the database type: "mysql" or "vitess".
+	// Type is the database type. "mysql" and "vitess" have built-in engines; any
+	// other value requires a matching EngineFactories entry.
 	Type string
 
 	// TargetDSN is the connection string to the target database for schema changes.
@@ -147,16 +148,29 @@ type LocalConfig struct {
 	// recorded. The callback must not execute control actions itself; it only
 	// nudges the storage-claiming operator to process durable intent promptly.
 	WakeOperator func(applyIdentifier, database, environment string)
+
+	// EngineFactories supplies engine implementations for database types this
+	// build does not implement natively. An embedding service populates it (via
+	// api.Service.RegisterEngine); NewLocalClient uses the matching factory for a
+	// Type that has no built-in engine.
+	EngineFactories map[string]EngineFactory
 }
 
-// LocalClient implements Client by calling the Spirit engine directly.
-// This is used when SchemaBot runs as a single service with embedded engine.
-// It uses SchemaBot's storage for plans and tasks.
+// EngineFactory builds an Engine for a database type this build does not
+// implement natively. It is the extension point that lets an embedding service
+// supply an engine without the core depending on its package.
+type EngineFactory func(cfg LocalConfig, logger *slog.Logger) (engine.Engine, error)
+
+// LocalClient implements Client by calling an embedded engine directly — the
+// built-in Spirit (mysql) or PlanetScale (vitess) engine, or an engine supplied
+// by an embedder for another database type. It uses SchemaBot's storage for
+// plans and tasks.
 type LocalClient struct {
 	config            LocalConfig
 	storage           storage.Storage
 	spiritEngine      engine.Engine
 	planetscaleEngine engine.Engine
+	customEngine      engine.Engine
 	logger            *slog.Logger
 
 	// heartbeatInterval controls how often the apply heartbeat updates updated_at.
@@ -204,6 +218,28 @@ func NewLocalClient(cfg LocalConfig, stor storage.Storage, logger *slog.Logger) 
 		})
 	}
 
+	// For a database type without a built-in engine, build it from a registered
+	// factory. This is the embedder extension point for engines this build does
+	// not include.
+	var customEngine engine.Engine
+	if cfg.Type != storage.DatabaseTypeMySQL && cfg.Type != storage.DatabaseTypeVitess {
+		factory, ok := cfg.EngineFactories[cfg.Type]
+		if !ok {
+			return nil, fmt.Errorf("no engine registered for database type %q", cfg.Type)
+		}
+		if factory == nil {
+			return nil, fmt.Errorf("engine factory registered for database type %q is nil", cfg.Type)
+		}
+		eng, err := factory(cfg, logger)
+		if err != nil {
+			return nil, fmt.Errorf("build engine for database type %q: %w", cfg.Type, err)
+		}
+		if eng == nil {
+			return nil, fmt.Errorf("engine factory for database type %q returned a nil engine", cfg.Type)
+		}
+		customEngine = eng
+	}
+
 	return &LocalClient{
 		config:  cfg,
 		storage: stor,
@@ -214,6 +250,7 @@ func NewLocalClient(cfg LocalConfig, stor storage.Storage, logger *slog.Logger) 
 			DisablePendingDrops: cfg.Metadata["pending_drops"] == "false",
 		}),
 		planetscaleEngine: psEngine,
+		customEngine:      customEngine,
 		logger:            logger,
 		heartbeatInterval: 10 * time.Second,
 	}, nil
@@ -239,6 +276,15 @@ func (c *LocalClient) wakeOperatorForControlRequest(apply *storage.Apply) {
 
 // protoEngine returns the proto engine type based on database configuration.
 func (c *LocalClient) protoEngine() ternv1.Engine {
+	// Derive from the engine actually backing this client, so a registered
+	// engine reports its own type rather than the Spirit default.
+	if eng := c.getEngine(); eng != nil {
+		if e, err := engineNameToProto(eng.Name()); err == nil {
+			return e
+		}
+	}
+	// Fall back to the type default when there is no engine or its name has no
+	// proto representation.
 	if c.config.Type == storage.DatabaseTypeVitess {
 		return ternv1.Engine_ENGINE_PLANETSCALE
 	}
@@ -774,8 +820,8 @@ func pulledSchemaFileContent(database string, tbl spirittable.TableSchema) (stri
 
 // Plan generates a schema change plan from declarative schema files.
 func (c *LocalClient) Plan(ctx context.Context, req *ternv1.PlanRequest) (*ternv1.PlanResponse, error) {
-	if c.config.Type != storage.DatabaseTypeMySQL && c.config.Type != storage.DatabaseTypeVitess {
-		return nil, fmt.Errorf("type must be %q or %q", storage.DatabaseTypeMySQL, storage.DatabaseTypeVitess)
+	if c.getEngine() == nil {
+		return nil, fmt.Errorf("no engine available for database type %q", c.config.Type)
 	}
 
 	// Convert schema files from proto to engine type.
@@ -1224,7 +1270,8 @@ func (c *LocalClient) getEngine() engine.Engine {
 	case storage.DatabaseTypeVitess:
 		return c.planetscaleEngine
 	default:
-		return nil
+		// A registered engine for a non-built-in type (nil if none registered).
+		return c.customEngine
 	}
 }
 

--- a/pkg/tern/local_client_test.go
+++ b/pkg/tern/local_client_test.go
@@ -2325,3 +2325,95 @@ func TestLocalClient_PlanNamespaceUsesConfiguredDatabase(t *testing.T) {
 	assert.Equal(t, "testdb", client.planNamespace("default"))
 	assert.Equal(t, "analytics", client.planNamespace("analytics"))
 }
+
+// A database type without a built-in engine is served by a registered factory,
+// so an embedding service can supply an engine this build does not include.
+func TestNewLocalClientUsesRegisteredEngine(t *testing.T) {
+	fake := &fakeControlEngine{}
+	c, err := NewLocalClient(LocalConfig{
+		Database: "db",
+		Type:     "customengine",
+		EngineFactories: map[string]EngineFactory{
+			"customengine": func(LocalConfig, *slog.Logger) (engine.Engine, error) { return fake, nil },
+		},
+	}, nil, slog.Default())
+	require.NoError(t, err)
+	assert.Same(t, fake, c.getEngine())
+}
+
+// Built-in engine types ignore the registry.
+func TestNewLocalClientBuiltinEngineIgnoresRegistry(t *testing.T) {
+	c, err := NewLocalClient(LocalConfig{Database: "db", Type: storage.DatabaseTypeMySQL}, nil, slog.Default())
+	require.NoError(t, err)
+	assert.NotNil(t, c.getEngine())
+}
+
+// A type with no built-in engine and no registered factory fails closed.
+func TestNewLocalClientErrorsWhenEngineUnregistered(t *testing.T) {
+	_, err := NewLocalClient(LocalConfig{Database: "db", Type: "customengine"}, nil, slog.Default())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no engine registered")
+}
+
+func TestNewLocalClientPropagatesEngineFactoryError(t *testing.T) {
+	_, err := NewLocalClient(LocalConfig{
+		Database: "db",
+		Type:     "customengine",
+		EngineFactories: map[string]EngineFactory{
+			"customengine": func(LocalConfig, *slog.Logger) (engine.Engine, error) {
+				return nil, errors.New("init failed")
+			},
+		},
+	}, nil, slog.Default())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "init failed")
+}
+
+// A factory that returns a nil engine must fail closed rather than yield a
+// client that no-ops or panics on first use.
+func TestNewLocalClientFactoryReturningNilFailsClosed(t *testing.T) {
+	_, err := NewLocalClient(LocalConfig{
+		Database: "db",
+		Type:     "customengine",
+		EngineFactories: map[string]EngineFactory{
+			"customengine": func(LocalConfig, *slog.Logger) (engine.Engine, error) { return nil, nil },
+		},
+	}, nil, slog.Default())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nil engine")
+}
+
+// A registered key mapped to a nil factory must fail closed rather than panic
+// when the factory would be invoked.
+func TestNewLocalClientNilFactoryFailsClosed(t *testing.T) {
+	_, err := NewLocalClient(LocalConfig{
+		Database:        "db",
+		Type:            "customengine",
+		EngineFactories: map[string]EngineFactory{"customengine": nil},
+	}, nil, slog.Default())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "is nil")
+}
+
+type namedEngine struct {
+	engine.Engine
+	name string
+}
+
+func (e namedEngine) Name() string { return e.name }
+
+// The reported proto engine reflects the engine actually backing the client, so
+// a registered engine is not misreported as the Spirit default.
+func TestLocalClientProtoEngineReflectsRegisteredEngine(t *testing.T) {
+	c, err := NewLocalClient(LocalConfig{
+		Database: "db",
+		Type:     "customengine",
+		EngineFactories: map[string]EngineFactory{
+			"customengine": func(LocalConfig, *slog.Logger) (engine.Engine, error) {
+				return namedEngine{name: storage.EngineStrata}, nil
+			},
+		},
+	}, nil, slog.Default())
+	require.NoError(t, err)
+	assert.Equal(t, ternv1.Engine_ENGINE_STRATA, c.protoEngine())
+}


### PR DESCRIPTION
## Why this matters

Running the data plane in an embedding service across more than one engine — including a database type this build does not ship — needs two extension points the core lacked: a way to supply a custom engine, and a way to compose per-engine resolvers behind the single resolver a `TargetRouter` takes. This adds both, behind the existing `engine.Engine` and `inventory.Resolver` interfaces, so no engine-specific package is pulled into core.

## What it does

**Engine registry** — supply an engine for a database type without a built-in implementation:
- `tern.EngineFactory` + `LocalConfig.EngineFactories`: `NewLocalClient` builds the engine for a non-built-in type from a registered factory, failing closed when such a type has no factory, the factory errors, or it returns nil. Built-in `mysql`/`vitess` are unchanged.
- `api.Service.RegisterEngine(databaseType, factory)`: the embedder hook, called during setup; registered factories flow into the local clients the service builds.

**Type-routing resolver** — compose multiple engines behind one resolver:
- An engine resolver serves a single engine (it rejects a request whose type it doesn't serve). `inventory.TypeRoutingResolver` routes a request to the resolver registered for its database type, failing closed when the request carries no type or none is registered.

```
TargetRouter ─▶ TypeRoutingResolver ─┬─ mysql  ─▶ resolver A
                                     └─ vitess ─▶ resolver B
              LocalClientFactory ─▶ NewLocalClient ─▶ built-in or registered engine
```

## How it moves toward the northstar

Completes the embedder extension surface for the engine-agnostic data plane: an embedding service can run any mix of engines — including ones this build does not ship — behind `engine.Engine` and `inventory.Resolver`, with engine-specific code supplied by the embedder rather than the core.

---
*PR drafted by Claude Code (Opus 4.8).*