### PR TITLE
feat(observability): return structured result from apply-state projection

### DIFF
--- a/pkg/api/operator.go
+++ b/pkg/api/operator.go
@@ -420,7 +420,7 @@ func (s *Service) recoverApplyOperation(ctx context.Context, workerID int, owner
 		return
 	}
 
-	if err := s.updateApplyStateFromOperations(applyLeaseCtx, workerID, finalApply, allowLeaseScopedFailedReopen); err != nil {
+	if _, err := s.updateApplyStateFromOperations(applyLeaseCtx, workerID, finalApply, allowLeaseScopedFailedReopen); err != nil {
 		s.logger.Error("operator: failed to update derived apply state from apply_operations",
 			"worker", workerID, "apply_operation_id", op.ID, "apply_id", finalApply.ApplyIdentifier,
 			"deployment", op.Deployment, "environment", finalApply.Environment, "error", err)
@@ -496,7 +496,7 @@ func (s *Service) recoverApplyPendingStop(ctx context.Context, workerID int, own
 		return true
 	}
 
-	if err := s.updateApplyStateFromOperations(applyLeaseCtx, workerID, finalApply, allowLeaseScopedFailedReopen); err != nil {
+	if _, err := s.updateApplyStateFromOperations(applyLeaseCtx, workerID, finalApply, allowLeaseScopedFailedReopen); err != nil {
 		s.logger.Error("operator: failed to update derived apply state during stop reconciliation",
 			"worker", workerID, "apply_id", finalApply.ApplyIdentifier,
 			"database", finalApply.Database, "environment", finalApply.Environment, "error", err)
@@ -618,7 +618,7 @@ func (s *Service) reconcileUnclaimableParent(ctx context.Context, workerID int, 
 		if !marked {
 			return
 		}
-		if err := s.updateApplyStateFromOperations(ctx, workerID, parent, rejectFailedApplyReopen); err != nil {
+		if _, err := s.updateApplyStateFromOperations(ctx, workerID, parent, rejectFailedApplyReopen); err != nil {
 			s.logger.Error("operator: failed to update derived apply state for terminal parent",
 				"worker", workerID, "apply_operation_id", op.ID, "apply_id", parent.ApplyIdentifier,
 				"deployment", op.Deployment, "environment", parent.Environment, "error", err)
@@ -652,7 +652,7 @@ func (s *Service) failOperationWithoutTasks(opCtx, applyCtx context.Context, wor
 			"deployment", op.Deployment, "environment", apply.Environment, "error", err)
 		return
 	}
-	if err := s.updateApplyStateFromOperations(applyCtx, workerID, apply, allowLeaseScopedFailedReopen); err != nil {
+	if _, err := s.updateApplyStateFromOperations(applyCtx, workerID, apply, allowLeaseScopedFailedReopen); err != nil {
 		s.logger.Error("operator: failed to update derived apply state after failing task-less operation",
 			"worker", workerID, "apply_operation_id", op.ID, "apply_id", apply.ApplyIdentifier,
 			"deployment", op.Deployment, "environment", apply.Environment, "error", err)
@@ -1043,6 +1043,27 @@ const (
 	allowLeaseScopedFailedReopen failedApplyReopenPolicy = true
 )
 
+// applyProjectionResult reports what updateApplyStateFromOperations did to the
+// parent apply. It lets callers key apply-level terminal side-effects (the
+// single-publisher terminal summary in the multi-deployment fan-out work) off
+// the projection outcome — "did this drive win the swap that terminalized the
+// parent?" — rather than off the per-operation engine result. It carries no
+// behavior today: every current caller discards it and inspects only the error.
+type applyProjectionResult struct {
+	// Swapped is true when the derived-state compare-and-swap actually advanced
+	// the parent apply row. It is false for a no-op match (derived already
+	// equals the current state with nothing to stamp) and for a lost race (the
+	// CAS found the row already moved).
+	Swapped bool
+	// PreviousState is the parent apply state observed before the projection.
+	PreviousState string
+	// DerivedState is the state derived from the child apply_operations rows.
+	DerivedState string
+	// BecameTerminal is true when this projection won the swap and moved the
+	// parent from a non-terminal previous state to a terminal derived state.
+	BecameTerminal bool
+}
+
 // updateApplyStateFromOperations re-derives applies.state from the apply's child
 // apply_operations rows and persists it when it differs from the current value.
 //
@@ -1066,13 +1087,13 @@ const (
 // unscoped reconciliation path passes rejectFailedApplyReopen so it never
 // revives a terminal parent through a last-write-wins update; every other
 // terminal-to-non-terminal transition stays an error regardless.
-func (s *Service) updateApplyStateFromOperations(ctx context.Context, workerID int, apply *storage.Apply, reopen failedApplyReopenPolicy) error {
+func (s *Service) updateApplyStateFromOperations(ctx context.Context, workerID int, apply *storage.Apply, reopen failedApplyReopenPolicy) (applyProjectionResult, error) {
 	ops, err := s.storage.ApplyOperations().ListByApply(ctx, apply.ID)
 	if err != nil {
-		return fmt.Errorf("list apply_operations for apply %s (%d): %w", apply.ApplyIdentifier, apply.ID, err)
+		return applyProjectionResult{}, fmt.Errorf("list apply_operations for apply %s (%d): %w", apply.ApplyIdentifier, apply.ID, err)
 	}
 	if len(ops) == 0 {
-		return fmt.Errorf("derive apply state for apply %s (%d): no apply_operations rows", apply.ApplyIdentifier, apply.ID)
+		return applyProjectionResult{}, fmt.Errorf("derive apply state for apply %s (%d): no apply_operations rows", apply.ApplyIdentifier, apply.ID)
 	}
 
 	childStates := make([]string, len(ops))
@@ -1100,7 +1121,7 @@ func (s *Service) updateApplyStateFromOperations(ctx context.Context, workerID i
 		state.IsState(derived, state.Apply.Running)
 
 	if state.IsTerminalApplyState(apply.State) && !state.IsTerminalApplyState(derived) && !reopensContinuableFailedRollout {
-		return fmt.Errorf("derive apply state for terminal apply %s (%d): child operations derive non-terminal state %q from parent state %q",
+		return applyProjectionResult{}, fmt.Errorf("derive apply state for terminal apply %s (%d): child operations derive non-terminal state %q from parent state %q",
 			apply.ApplyIdentifier, apply.ID, derived, apply.State)
 	}
 
@@ -1119,7 +1140,7 @@ func (s *Service) updateApplyStateFromOperations(ctx context.Context, workerID i
 			"worker", workerID, "apply_id", apply.ApplyIdentifier,
 			"database", apply.Database, "environment", apply.Environment,
 			"state", derived, "operation_count", len(ops))
-		return nil
+		return applyProjectionResult{PreviousState: apply.State, DerivedState: derived}, nil
 	}
 
 	var completedAt *time.Time
@@ -1152,7 +1173,7 @@ func (s *Service) updateApplyStateFromOperations(ctx context.Context, workerID i
 
 	swapped, err := s.storage.Applies().UpdateDerivedState(ctx, apply.ID, apply.State, derived, errorMessage, startedAt, completedAt)
 	if err != nil {
-		return fmt.Errorf("update derived apply state for apply %s (%d) to %q: %w", apply.ApplyIdentifier, apply.ID, derived, err)
+		return applyProjectionResult{}, fmt.Errorf("update derived apply state for apply %s (%d) to %q: %w", apply.ApplyIdentifier, apply.ID, derived, err)
 	}
 	if !swapped {
 		// Another drive advanced the apply between our read and write; our
@@ -1161,13 +1182,18 @@ func (s *Service) updateApplyStateFromOperations(ctx context.Context, workerID i
 			"worker", workerID, "apply_id", apply.ApplyIdentifier,
 			"database", apply.Database, "environment", apply.Environment,
 			"expected_state", apply.State, "derived_state", derived, "operation_count", len(ops))
-		return nil
+		return applyProjectionResult{PreviousState: apply.State, DerivedState: derived}, nil
 	}
 	s.logger.Info("operator: updated derived apply state from apply_operations",
 		"worker", workerID, "apply_id", apply.ApplyIdentifier,
 		"database", apply.Database, "environment", apply.Environment,
 		"previous_state", apply.State, "derived_state", derived, "operation_count", len(ops))
-	return nil
+	return applyProjectionResult{
+		Swapped:        true,
+		PreviousState:  apply.State,
+		DerivedState:   derived,
+		BecameTerminal: !state.IsTerminalApplyState(apply.State) && state.IsTerminalApplyState(derived),
+	}, nil
 }
 
 func operatorLeaseOwner(workerID int) string {

--- a/pkg/api/operator_test.go
+++ b/pkg/api/operator_test.go
@@ -228,7 +228,8 @@ func TestUpdateApplyStateFromOperations_ContinuePolicy(t *testing.T) {
 				Environment:     "staging",
 			}
 
-			require.NoError(t, svc.updateApplyStateFromOperations(t.Context(), 1, apply, allowLeaseScopedFailedReopen))
+			_, err := svc.updateApplyStateFromOperations(t.Context(), 1, apply, allowLeaseScopedFailedReopen)
+			require.NoError(t, err)
 			require.NotNil(t, applyStore.updated, "derived state differs from current, so the apply must be persisted")
 			assert.Equal(t, state.Apply.Pending, applyStore.expectedState, "the write must compare-and-swap on the state read before deriving")
 			assert.Equal(t, tc.wantState, applyStore.updated.State)
@@ -319,7 +320,7 @@ func TestUpdateApplyStateFromOperations_ReopenFailedGuard(t *testing.T) {
 				CompletedAt:     &completedAt,
 			}
 
-			err := svc.updateApplyStateFromOperations(t.Context(), 1, apply, tc.reopen)
+			_, err := svc.updateApplyStateFromOperations(t.Context(), 1, apply, tc.reopen)
 			if tc.wantErr {
 				require.Error(t, err)
 				assert.Nil(t, applyStore.updated, "a rejected transition must not persist the apply")
@@ -446,7 +447,8 @@ func TestUpdateApplyStateFromOperations_StampsAggregateFailureMessage(t *testing
 		Environment:     "staging",
 	}
 
-	require.NoError(t, svc.updateApplyStateFromOperations(t.Context(), 1, apply, allowLeaseScopedFailedReopen))
+	_, err := svc.updateApplyStateFromOperations(t.Context(), 1, apply, allowLeaseScopedFailedReopen)
+	require.NoError(t, err)
 	require.NotNil(t, applyStore.updated, "derived failed state differs from running, so the apply must be persisted")
 	assert.Equal(t, state.Apply.Failed, applyStore.updated.State)
 	assert.Equal(t, "deployment region-a failed: spirit: cutover failed", applyStore.updated.ErrorMessage,
@@ -473,7 +475,8 @@ func TestUpdateApplyStateFromOperations_FirstFailedDeploymentWins(t *testing.T) 
 		Environment:     "staging",
 	}
 
-	require.NoError(t, svc.updateApplyStateFromOperations(t.Context(), 1, apply, allowLeaseScopedFailedReopen))
+	_, err := svc.updateApplyStateFromOperations(t.Context(), 1, apply, allowLeaseScopedFailedReopen)
+	require.NoError(t, err)
 	require.NotNil(t, applyStore.updated)
 	assert.Equal(t, state.Apply.Failed, applyStore.updated.State)
 	assert.Equal(t, "deployment region-a failed: spirit: region-a cutover failed", applyStore.updated.ErrorMessage,
@@ -499,11 +502,82 @@ func TestUpdateApplyStateFromOperations_KeepsExistingMessageWhenNoOperationCarri
 		ErrorMessage:    "prior reason",
 	}
 
-	require.NoError(t, svc.updateApplyStateFromOperations(t.Context(), 1, apply, allowLeaseScopedFailedReopen))
+	_, err := svc.updateApplyStateFromOperations(t.Context(), 1, apply, allowLeaseScopedFailedReopen)
+	require.NoError(t, err)
 	require.NotNil(t, applyStore.updated)
 	assert.Equal(t, state.Apply.Failed, applyStore.updated.State)
 	assert.Equal(t, "prior reason", applyStore.updated.ErrorMessage,
 		"with no operation-level message the existing apply reason must be preserved")
+}
+
+// TestUpdateApplyStateFromOperations_ReturnsProjectionResult verifies the
+// structured projection result the writer returns: whether the compare-and-swap
+// advanced the apply row, the previous and derived states, and whether the swap
+// terminalized a previously non-terminal apply. Callers in the multi-deployment
+// fan-out work key the single-publisher terminal summary off this result, so the
+// fields must distinguish a winning terminal swap from a non-terminal swap, a
+// no-op match, and a lost race.
+func TestUpdateApplyStateFromOperations_ReturnsProjectionResult(t *testing.T) {
+	startedAt := time.Now().Add(-time.Minute)
+	cases := []struct {
+		name     string
+		ops      []*storage.ApplyOperation
+		apply    *storage.Apply
+		casMatch bool
+		want     applyProjectionResult
+	}{
+		{
+			name: "winning swap to terminal",
+			ops: []*storage.ApplyOperation{
+				{ID: 1, Deployment: "region-a", State: state.ApplyOperation.Failed, ErrorMessage: "boom"},
+				{ID: 2, Deployment: "region-b", State: state.ApplyOperation.Completed},
+			},
+			apply:    &storage.Apply{ID: 3, ApplyIdentifier: "apply-a", State: state.Apply.Running, StartedAt: &startedAt},
+			casMatch: true,
+			want:     applyProjectionResult{Swapped: true, PreviousState: state.Apply.Running, DerivedState: state.Apply.Failed, BecameTerminal: true},
+		},
+		{
+			name: "winning non-terminal swap",
+			ops: []*storage.ApplyOperation{
+				{ID: 1, Deployment: "region-a", State: state.ApplyOperation.Running},
+				{ID: 2, Deployment: "region-b", State: state.ApplyOperation.Pending},
+			},
+			apply:    &storage.Apply{ID: 3, ApplyIdentifier: "apply-b", State: state.Apply.Pending},
+			casMatch: true,
+			want:     applyProjectionResult{Swapped: true, PreviousState: state.Apply.Pending, DerivedState: state.Apply.Running, BecameTerminal: false},
+		},
+		{
+			name: "no-op match",
+			ops: []*storage.ApplyOperation{
+				{ID: 1, Deployment: "region-a", State: state.ApplyOperation.Running},
+				{ID: 2, Deployment: "region-b", State: state.ApplyOperation.Running},
+			},
+			apply:    &storage.Apply{ID: 3, ApplyIdentifier: "apply-c", State: state.Apply.Running, StartedAt: &startedAt},
+			casMatch: true,
+			want:     applyProjectionResult{Swapped: false, PreviousState: state.Apply.Running, DerivedState: state.Apply.Running, BecameTerminal: false},
+		},
+		{
+			name: "lost race",
+			ops: []*storage.ApplyOperation{
+				{ID: 1, Deployment: "region-a", State: state.ApplyOperation.Failed, ErrorMessage: "boom"},
+				{ID: 2, Deployment: "region-b", State: state.ApplyOperation.Completed},
+			},
+			apply:    &storage.Apply{ID: 3, ApplyIdentifier: "apply-d", State: state.Apply.Running, StartedAt: &startedAt},
+			casMatch: false,
+			want:     applyProjectionResult{Swapped: false, PreviousState: state.Apply.Running, DerivedState: state.Apply.Failed, BecameTerminal: false},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			applyStore := &recordingApplyStore{swapped: tc.casMatch}
+			svc := newOperatorStateTestService(&listingApplyOperationStore{ops: tc.ops}, applyStore)
+
+			got, err := svc.updateApplyStateFromOperations(t.Context(), 1, tc.apply, allowLeaseScopedFailedReopen)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
 }
 
 // fakeControlRequestStore is a minimal ControlRequestStore for stop
@@ -655,7 +729,8 @@ func TestUpdateApplyStateFromOperations_StaleWriteSkipped(t *testing.T) {
 		Environment:     "staging",
 	}
 
-	require.NoError(t, svc.updateApplyStateFromOperations(t.Context(), 1, apply, allowLeaseScopedFailedReopen))
+	_, err := svc.updateApplyStateFromOperations(t.Context(), 1, apply, allowLeaseScopedFailedReopen)
+	require.NoError(t, err)
 	assert.Equal(t, state.Apply.Pending, applyStore.expectedState, "the write must compare-and-swap on the state read before deriving")
 	assert.Nil(t, applyStore.updated, "a CAS miss must not record a persisted projection")
 }


### PR DESCRIPTION
## What

`updateApplyStateFromOperations` now returns a structured `applyProjectionResult` alongside its error, instead of just `error`. The result reports what the projection did to the parent apply:

| Field | Meaning |
|---|---|
| `Swapped` | the derived-state compare-and-swap actually advanced the apply row |
| `PreviousState` | parent state observed before the projection |
| `DerivedState` | state derived from the child operation rows |
| `BecameTerminal` | the swap moved a non-terminal parent to a terminal state |

This is **plumbing only** — every current caller discards the result and inspects only the error, so behaviour is unchanged.

## Why

When an apply fans out across multiple deployments, the apply-level terminal side-effects (the single-publisher terminal summary in later fan-out work) must fire exactly once, keyed off *"did this drive win the swap that terminalized the parent?"* — not off the per-operation engine result, which every sibling driver sees. Returning the projection outcome gives those callers the signal they need without re-reading the row or guessing.

## Before / after

BEFORE
```
┌─────────────────────────────────────────────┐
│ updateApplyStateFromOperations(...)  error  │
└───────────────────┬─────────────────────────┘
│
▼
if err != nil { log }
caller cannot tell:
• did the CAS swap or no-op?
• was this the terminalizing write?
```

AFTER
```
┌──────────────────────────────────────────────────────────────┐
│ updateApplyStateFromOperations(...)  (applyProjectionResult, │
│                                       error)                 │
└───────────────────┬──────────────────────────────────────────┘
│
▼
applyProjectionResult{
Swapped:        bool   ──▶ won the CAS (not no-op / lost race)
PreviousState:  string
DerivedState:   string
BecameTerminal: bool   ──▶ non-terminal ➜ terminal swap
}
(callers still discard it today — no behaviour change)
```
## Stack

First of the drive/projection leaf PRs that build on the merged operation-authorized aggregate CAS (#369). PR 4 (route drive by operation deployment) stacks on this; the single-publisher terminal summary consumes `BecameTerminal`.

## Testing / validation

`go build ./...`, `go vet ./pkg/api/...`, `gofmt`, and `golangci-lint` clean. New table-driven test covers all four outcomes: winning terminal swap, winning non-terminal swap, no-op match, and lost race.
