### PR TITLE
feat: fan apply creation out into per-deployment operations

### DIFF
--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -1701,7 +1701,7 @@ func TestCreateStoredApplyFansOutOperationsForResolvedTargets(t *testing.T) {
 		controls:  &memoryControlRequestStore{},
 	}, cfg, map[string]tern.Client{}, logger)
 
-	apply, storedApplyID, err := svc.createStoredApply(t.Context(), executeApplyTestPlan(), ApplyRequest{Environment: "staging"}, DefaultDeployment, nil, "apply-fanout", "")
+	apply, storedApplyID, err := svc.createStoredApply(t.Context(), executeApplyTestPlan(), ApplyRequest{Environment: "staging"}, nil, "apply-fanout", "")
 
 	require.NoError(t, err)
 	assert.Equal(t, int64(123), storedApplyID)

--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -374,6 +374,20 @@ func (s *capturingApplyStore) CreateWithTasksAndOperations(ctx context.Context, 
 	return applyID, nil
 }
 
+func (s *capturingApplyStore) CreateWithGroupedOperations(ctx context.Context, apply *storage.Apply, groups []*storage.ApplyOperationWithTasks) (int64, error) {
+	operations := make([]*storage.ApplyOperation, 0, len(groups))
+	var tasks []*storage.Task
+	for i, group := range groups {
+		group.Operation.ID = int64(i + 1)
+		operations = append(operations, group.Operation)
+		for _, task := range group.Tasks {
+			task.ApplyOperationID = &group.Operation.ID
+			tasks = append(tasks, task)
+		}
+	}
+	return s.CreateWithTasksAndOperations(ctx, apply, tasks, operations)
+}
+
 func (s *capturingApplyStore) Update(_ context.Context, apply *storage.Apply) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -673,6 +687,14 @@ func (m *mockTernClient) Close() error { return nil }
 // should create their own config or add it to the mock ternClients.
 func testServerConfig() *ServerConfig {
 	return &ServerConfig{
+		Databases: map[string]DatabaseConfig{
+			"testdb": {
+				Type: storage.DatabaseTypeMySQL,
+				Environments: map[string]EnvironmentConfig{
+					"staging": {Target: "testdb", Deployment: DefaultDeployment},
+				},
+			},
+		},
 		TernDeployments: TernConfig{
 			"default": TernEndpoints{
 				"staging": "localhost:9090",
@@ -726,7 +748,30 @@ func stoppedTestApply(applyID string) *storage.Apply {
 }
 
 func newExecuteApplyTestService(client tern.Client, applies storage.ApplyStore) (*Service, *capturingTaskStore) {
-	return newQueueApplyTestService(executeApplyTestPlan(), client, applies)
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	tasks := &capturingTaskStore{}
+	if capturingApplies, ok := applies.(*capturingApplyStore); ok {
+		capturingApplies.taskStore = tasks
+	}
+	cfg := testServerConfig()
+	cfg.Databases = map[string]DatabaseConfig{
+		"testdb": {
+			Type: storage.DatabaseTypeMySQL,
+			Environments: map[string]EnvironmentConfig{
+				"staging": {Target: "testdb", Deployment: DefaultDeployment},
+			},
+		},
+	}
+	return New(&mockStorageWithApplyStores{
+		plans:     &staticPlanStore{plan: executeApplyTestPlan()},
+		applies:   applies,
+		tasks:     tasks,
+		locks:     &emptyLockStore{},
+		applyLogs: &noopApplyLogStore{},
+		controls:  &memoryControlRequestStore{},
+	}, cfg, map[string]tern.Client{
+		"default/staging": client,
+	}, logger), tasks
 }
 
 func newQueueApplyTestService(plan *storage.Plan, client tern.Client, applies storage.ApplyStore) (*Service, *capturingTaskStore) {
@@ -735,6 +780,15 @@ func newQueueApplyTestService(plan *storage.Plan, client tern.Client, applies st
 	if capturingApplies, ok := applies.(*capturingApplyStore); ok {
 		capturingApplies.taskStore = tasks
 	}
+	cfg := testServerConfig()
+	cfg.Databases = map[string]DatabaseConfig{
+		"testdb": {
+			Type: storage.DatabaseTypeMySQL,
+			Environments: map[string]EnvironmentConfig{
+				"staging": {Target: "testdb", Deployment: DefaultDeployment},
+			},
+		},
+	}
 	return New(&mockStorageWithApplyStores{
 		plans:     &staticPlanStore{plan: plan},
 		applies:   applies,
@@ -742,7 +796,7 @@ func newQueueApplyTestService(plan *storage.Plan, client tern.Client, applies st
 		locks:     &emptyLockStore{},
 		applyLogs: &noopApplyLogStore{},
 		controls:  &memoryControlRequestStore{},
-	}, testServerConfig(), map[string]tern.Client{
+	}, cfg, map[string]tern.Client{
 		"default/staging": client,
 	}, logger), tasks
 }
@@ -1298,14 +1352,14 @@ func trustedQueueApplyTestPlan() *storage.Plan {
 }
 
 // A data-plane deployment executes applies dispatched by a control plane that
-// already evaluated source policy against its own database config. The data
-// plane has no database config of its own, so EnqueueAuthorizedApply queues the trusted
+// already evaluated source policy. EnqueueAuthorizedApply queues the trusted
 // plan without re-evaluating source policy, while ExecuteApply on the same
-// service keeps failing closed.
+// service keeps failing closed until database routing is configured.
 func TestEnqueueAuthorizedApplyQueuesTrustedPlanWithoutDatabaseConfig(t *testing.T) {
 	applies := &capturingApplyStore{}
 	mockClient := &mockTernClient{isRemote: true}
 	svc, tasks := newQueueApplyTestService(trustedQueueApplyTestPlan(), mockClient, applies)
+	svc.config.Databases = nil
 
 	_, _, err := svc.ExecuteApply(t.Context(), ApplyRequest{
 		PlanID:      "plan-1",
@@ -1314,6 +1368,14 @@ func TestEnqueueAuthorizedApplyQueuesTrustedPlanWithoutDatabaseConfig(t *testing
 	var policyErr *SourcePolicyError
 	require.True(t, errors.As(err, &policyErr), "ExecuteApply must fail closed without database config")
 	assert.Equal(t, SourcePolicyReasonMissingDatabaseConfig, policyErr.Reason)
+	svc.config.Databases = map[string]DatabaseConfig{
+		"testdb": {
+			Type: storage.DatabaseTypeMySQL,
+			Environments: map[string]EnvironmentConfig{
+				"staging": {Target: "testdb", Deployment: DefaultDeployment},
+			},
+		},
+	}
 
 	resp, applyID, err := svc.EnqueueAuthorizedApply(t.Context(), ApplyRequest{
 		PlanID:      "plan-1",
@@ -1597,13 +1659,71 @@ func TestExecuteApplyQueuesRemoteApplyForOperator(t *testing.T) {
 	assert.Nil(t, mock.applyReq, "request path should not call remote Tern before operator claim")
 	require.Len(t, tasks.tasks, 1)
 	assert.Equal(t, state.Task.Pending, tasks.tasks[0].State)
-	// Apply create dual-writes one apply_operations row mirroring the apply's
-	// (deployment, target). Today's hard-block keeps this at one row; the
-	// operator claim-loop PR is what consumes them.
+	// Apply create writes one apply_operations row mirroring the apply's
+	// (deployment, target) and links the queued tasks to it.
 	require.Len(t, applies.operations, 1)
 	assert.Equal(t, DefaultDeployment, applies.operations[0].Deployment)
 	assert.Equal(t, "testdb", applies.operations[0].Target)
 	assert.Equal(t, state.ApplyOperation.Pending, applies.operations[0].State)
+	require.NotNil(t, tasks.tasks[0].ApplyOperationID)
+	assert.Equal(t, applies.operations[0].ID, *tasks.tasks[0].ApplyOperationID)
+}
+
+func TestCreateStoredApplyFansOutOperationsForResolvedTargets(t *testing.T) {
+	// Multi-target apply creation creates an independent operation and task set
+	// for each resolved deployment while preserving the first deployment on the parent apply.
+	applies := &capturingApplyStore{}
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	tasks := &capturingTaskStore{}
+	applies.taskStore = tasks
+	cfg := testServerConfig()
+	cfg.Databases = map[string]DatabaseConfig{}
+	cfg.Databases["testdb"] = DatabaseConfig{
+		Type: storage.DatabaseTypeMySQL,
+		Environments: map[string]EnvironmentConfig{
+			"staging": {
+				Deployments: map[string]DeploymentTarget{
+					"default-a": {Target: "testdb-a"},
+					"default-b": {Target: "testdb-b"},
+				},
+				DeploymentOrder: []string{"default-a", "default-b"},
+				CutoverPolicy:   storage.CutoverPolicyBarrier,
+				OnFailure:       storage.OnFailureContinue,
+			},
+		},
+	}
+	svc := New(&mockStorageWithApplyStores{
+		plans:     &staticPlanStore{plan: executeApplyTestPlan()},
+		applies:   applies,
+		tasks:     tasks,
+		locks:     &emptyLockStore{},
+		applyLogs: &noopApplyLogStore{},
+		controls:  &memoryControlRequestStore{},
+	}, cfg, map[string]tern.Client{}, logger)
+
+	apply, storedApplyID, err := svc.createStoredApply(t.Context(), executeApplyTestPlan(), ApplyRequest{Environment: "staging"}, DefaultDeployment, nil, "apply-fanout", "")
+
+	require.NoError(t, err)
+	assert.Equal(t, int64(123), storedApplyID)
+	require.NotNil(t, apply)
+	assert.Equal(t, "default-a", apply.Deployment)
+	require.Len(t, applies.operations, 2)
+	assert.Equal(t, "default-a", applies.operations[0].Deployment)
+	assert.Equal(t, "testdb-a", applies.operations[0].Target)
+	assert.Equal(t, storage.CutoverPolicyBarrier, applies.operations[0].CutoverPolicy)
+	assert.Equal(t, storage.OnFailureContinue, applies.operations[0].OnFailure)
+	assert.Equal(t, "default-b", applies.operations[1].Deployment)
+	assert.Equal(t, "testdb-b", applies.operations[1].Target)
+	assert.Equal(t, storage.CutoverPolicyBarrier, applies.operations[1].CutoverPolicy)
+	assert.Equal(t, storage.OnFailureContinue, applies.operations[1].OnFailure)
+	require.Len(t, tasks.tasks, 2)
+	assert.NotEqual(t, tasks.tasks[0].TaskIdentifier, tasks.tasks[1].TaskIdentifier)
+	assert.Equal(t, "users", tasks.tasks[0].TableName)
+	assert.Equal(t, "users", tasks.tasks[1].TableName)
+	require.NotNil(t, tasks.tasks[0].ApplyOperationID)
+	require.NotNil(t, tasks.tasks[1].ApplyOperationID)
+	assert.Equal(t, applies.operations[0].ID, *tasks.tasks[0].ApplyOperationID)
+	assert.Equal(t, applies.operations[1].ID, *tasks.tasks[1].ApplyOperationID)
 }
 
 func TestProgressByApplyIDServesQueuedRemoteApplyFromStorage(t *testing.T) {

--- a/pkg/api/plan_handlers.go
+++ b/pkg/api/plan_handlers.go
@@ -874,7 +874,7 @@ func (s *Service) queueValidatedApply(ctx context.Context, span trace.Span, plan
 		client.SetObserver(storedApplyID, observer)
 	}
 
-	applyIdentifier, storedApplyID, err := s.enqueueApply(ctx, plan, req, deployment, options, attachObserver)
+	applyIdentifier, storedApplyID, err := s.enqueueApply(ctx, plan, req, options, attachObserver)
 	if err != nil {
 		recordApplyError("enqueue apply", err)
 		return nil, 0, err
@@ -900,12 +900,11 @@ func (s *Service) enqueueApply(
 	ctx context.Context,
 	plan *storage.Plan,
 	req ApplyRequest,
-	deployment string,
 	options map[string]string,
 	onApplyCreated func(int64),
 ) (string, int64, error) {
 	applyIdentifier := "apply-" + strings.ReplaceAll(uuid.New().String(), "-", "")[:16]
-	apply, storedApplyID, err := s.createStoredApply(ctx, plan, req, deployment, options, applyIdentifier, "")
+	apply, storedApplyID, err := s.createStoredApply(ctx, plan, req, options, applyIdentifier, "")
 	if err != nil {
 		return "", 0, err
 	}
@@ -919,7 +918,6 @@ func (s *Service) createStoredApply(
 	ctx context.Context,
 	plan *storage.Plan,
 	req ApplyRequest,
-	deployment string,
 	options map[string]string,
 	applyIdentifier string,
 	externalID string,
@@ -952,7 +950,7 @@ func (s *Service) createStoredApply(
 		Repository:      plan.Repository,
 		PullRequest:     plan.PullRequest,
 		Environment:     req.Environment,
-		Deployment:      deployment,
+		Deployment:      targets[0].Deployment,
 		Caller:          req.Caller,
 		InstallationID:  req.InstallationID,
 		ExternalID:      externalID,
@@ -962,7 +960,6 @@ func (s *Service) createStoredApply(
 		CreatedAt:       now,
 		UpdatedAt:       now,
 	}
-	apply.Deployment = targets[0].Deployment
 
 	taskChanges := applyTaskChanges(plan)
 	buildTasks := func() []*storage.Task {

--- a/pkg/api/plan_handlers.go
+++ b/pkg/api/plan_handlers.go
@@ -21,6 +21,7 @@ import (
 	"github.com/block/schemabot/pkg/apitypes"
 	"github.com/block/schemabot/pkg/metrics"
 	ternv1 "github.com/block/schemabot/pkg/proto/ternv1"
+	"github.com/block/schemabot/pkg/routing"
 	"github.com/block/schemabot/pkg/schema"
 	"github.com/block/schemabot/pkg/state"
 	"github.com/block/schemabot/pkg/storage"
@@ -924,12 +925,24 @@ func (s *Service) createStoredApply(
 ) (*storage.Apply, int64, error) {
 	now := time.Now()
 	applyOpts := storage.ApplyOptionsFromMap(options)
-	targets, err := s.config.ResolveDatabaseTargets(plan.Database, req.Environment)
-	if err != nil {
-		return nil, 0, fmt.Errorf("resolve targets for %s/%s: %w", plan.Database, req.Environment, err)
-	}
-	if len(targets) == 0 {
-		return nil, 0, fmt.Errorf("resolve targets for %s/%s: no targets", plan.Database, req.Environment)
+
+	// The plan already carries the resolved primary (deployment, target) from
+	// plan time, and is authoritative for single-deployment applies and the
+	// config-light trusted control-plane enqueue path. Multi-deployment fan-out
+	// additionally needs the full ordered target set, which only the server
+	// config knows; use it only when it defines more than one deployment so
+	// single-deployment creation stays unchanged and does not depend on
+	// database config being present.
+	targets := []routing.ExecutionTarget{{
+		DatabaseType: plan.DatabaseType,
+		Deployment:   plan.Deployment,
+		Target:       plan.Target,
+	}}
+	if resolved, err := s.config.ResolveDatabaseTargets(plan.Database, req.Environment); err != nil {
+		s.logger.Debug("createStoredApply: using plan's stored target; config did not resolve database targets",
+			"database", plan.Database, "environment", req.Environment, "error", err)
+	} else if len(resolved) > 1 {
+		targets = resolved
 	}
 
 	var lockID int64

--- a/pkg/api/plan_handlers.go
+++ b/pkg/api/plan_handlers.go
@@ -926,6 +926,13 @@ func (s *Service) createStoredApply(
 ) (*storage.Apply, int64, error) {
 	now := time.Now()
 	applyOpts := storage.ApplyOptionsFromMap(options)
+	targets, err := s.config.ResolveDatabaseTargets(plan.Database, req.Environment)
+	if err != nil {
+		return nil, 0, fmt.Errorf("resolve targets for %s/%s: %w", plan.Database, req.Environment, err)
+	}
+	if len(targets) == 0 {
+		return nil, 0, fmt.Errorf("resolve targets for %s/%s: no targets", plan.Database, req.Environment)
+	}
 
 	var lockID int64
 	lock, err := s.storage.Locks().Get(ctx, plan.Database, plan.DatabaseType)
@@ -955,51 +962,54 @@ func (s *Service) createStoredApply(
 		CreatedAt:       now,
 		UpdatedAt:       now,
 	}
+	apply.Deployment = targets[0].Deployment
 
 	taskChanges := applyTaskChanges(plan)
-	tasks := make([]*storage.Task, 0, len(taskChanges))
-	for _, ddlChange := range taskChanges {
-		task := &storage.Task{
-			TaskIdentifier: "task-" + strings.ReplaceAll(uuid.New().String(), "-", "")[:16],
-			PlanID:         plan.ID,
-			Database:       plan.Database,
-			DatabaseType:   plan.DatabaseType,
-			Engine:         storage.EngineForType(plan.DatabaseType),
-			Repository:     plan.Repository,
-			PullRequest:    plan.PullRequest,
-			Environment:    req.Environment,
-			State:          state.Task.Pending,
-			Options:        storage.MarshalApplyOptions(applyOpts),
-			Namespace:      ddlChange.Namespace,
-			TableName:      ddlChange.Table,
-			DDL:            ddlChange.DDL,
-			DDLAction:      ddlChange.Operation,
-			CreatedAt:      now,
-			UpdatedAt:      now,
+	buildTasks := func() []*storage.Task {
+		tasks := make([]*storage.Task, 0, len(taskChanges))
+		for _, ddlChange := range taskChanges {
+			task := &storage.Task{
+				TaskIdentifier: "task-" + strings.ReplaceAll(uuid.New().String(), "-", "")[:16],
+				PlanID:         plan.ID,
+				Database:       plan.Database,
+				DatabaseType:   plan.DatabaseType,
+				Engine:         storage.EngineForType(plan.DatabaseType),
+				Repository:     plan.Repository,
+				PullRequest:    plan.PullRequest,
+				Environment:    req.Environment,
+				State:          state.Task.Pending,
+				Options:        storage.MarshalApplyOptions(applyOpts),
+				Namespace:      ddlChange.Namespace,
+				TableName:      ddlChange.Table,
+				DDL:            ddlChange.DDL,
+				DDLAction:      ddlChange.Operation,
+				CreatedAt:      now,
+				UpdatedAt:      now,
+			}
+			tasks = append(tasks, task)
 		}
-		tasks = append(tasks, task)
+		return tasks
 	}
 
-	// Dual-write one apply_operations row alongside the applies row in the
-	// same transaction. Today the plan already carries the resolved
-	// (deployment, target) pair from plan-time `ResolveDatabaseTarget`, and
-	// the config layer hard-blocks multi-entry deployments maps, so we
-	// always write exactly one operation row that mirrors the apply's own
-	// routing. The data shape is what the operator claim-loop PR consumes
-	// once that gate is lifted and plans become deployment-agnostic.
 	cutoverPolicy := s.config.CutoverPolicyFor(plan.Database, req.Environment)
 	onFailure := s.config.OnFailure(plan.Database, req.Environment)
-	operations := []*storage.ApplyOperation{{
-		Deployment:    apply.Deployment,
-		Target:        plan.Target,
-		State:         state.ApplyOperation.Pending,
-		CutoverPolicy: cutoverPolicy,
-		OnFailure:     onFailure,
-		CreatedAt:     now,
-		UpdatedAt:     now,
-	}}
+	groups := make([]*storage.ApplyOperationWithTasks, 0, len(targets))
+	for _, target := range targets {
+		groups = append(groups, &storage.ApplyOperationWithTasks{
+			Operation: &storage.ApplyOperation{
+				Deployment:    target.Deployment,
+				Target:        target.Target,
+				State:         state.ApplyOperation.Pending,
+				CutoverPolicy: cutoverPolicy,
+				OnFailure:     onFailure,
+				CreatedAt:     now,
+				UpdatedAt:     now,
+			},
+			Tasks: buildTasks(),
+		})
+	}
 
-	storedApplyID, err := s.storage.Applies().CreateWithTasksAndOperations(ctx, apply, tasks, operations)
+	storedApplyID, err := s.storage.Applies().CreateWithGroupedOperations(ctx, apply, groups)
 	if err != nil {
 		return nil, 0, fmt.Errorf("store apply and tasks: %w", err)
 	}

--- a/pkg/storage/mysqlstore/applies.go
+++ b/pkg/storage/mysqlstore/applies.go
@@ -434,6 +434,8 @@ func (s *applyStore) CreateWithTasks(ctx context.Context, apply *storage.Apply, 
 	return s.CreateWithTasksAndOperations(ctx, apply, tasks, nil)
 }
 
+type applyCreateWriter func(ctx context.Context, tx *sql.Tx, apply *storage.Apply, applyID int64) error
+
 // CreateWithTasksAndOperations is the unified atomic apply-create path: it
 // inserts the applies row, the initial tasks, and (optionally) the
 // per-deployment apply_operations rows in a single transaction. Pending
@@ -441,7 +443,20 @@ func (s *applyStore) CreateWithTasks(ctx context.Context, apply *storage.Apply, 
 // reader observes a partially-populated apply.
 func (s *applyStore) CreateWithTasksAndOperations(ctx context.Context, apply *storage.Apply, tasks []*storage.Task, operations []*storage.ApplyOperation) (int64, error) {
 	const opName = "create apply with tasks"
+	return s.createWithRows(ctx, apply, opName, func(ctx context.Context, tx *sql.Tx, apply *storage.Apply, applyID int64) error {
+		return insertApplyTasksAndOperations(ctx, tx, apply, applyID, tasks, operations)
+	})
+}
 
+// CreateWithGroupedOperations stores an apply with per-operation task groups in one transaction.
+func (s *applyStore) CreateWithGroupedOperations(ctx context.Context, apply *storage.Apply, groups []*storage.ApplyOperationWithTasks) (int64, error) {
+	const opName = "create apply with grouped operations"
+	return s.createWithRows(ctx, apply, opName, func(ctx context.Context, tx *sql.Tx, apply *storage.Apply, applyID int64) error {
+		return insertApplyGroupedOperations(ctx, tx, apply, applyID, groups)
+	})
+}
+
+func (s *applyStore) createWithRows(ctx context.Context, apply *storage.Apply, opName string, writeRows applyCreateWriter) (int64, error) {
 	// Ensure options has valid JSON (empty object if nil)
 	options := apply.Options
 	if len(options) == 0 {
@@ -493,6 +508,18 @@ func (s *applyStore) CreateWithTasksAndOperations(ctx context.Context, apply *st
 		return 0, fmt.Errorf("read inserted apply id for %s: %w", apply.ApplyIdentifier, err)
 	}
 
+	if err := writeRows(ctx, writeTx.tx, apply, id); err != nil {
+		return 0, err
+	}
+
+	if err := writeTx.commit(); err != nil {
+		return 0, fmt.Errorf("commit %s: %w", opName, err)
+	}
+
+	return id, nil
+}
+
+func insertApplyTasksAndOperations(ctx context.Context, tx *sql.Tx, apply *storage.Apply, applyID int64, tasks []*storage.Task, operations []*storage.ApplyOperation) error {
 	// Operations are inserted BEFORE tasks so each task can be persisted
 	// with the apply_operation_id of the operation it belongs to. Today
 	// the config layer hard-blocks multi-entry deployments so there is
@@ -501,9 +528,9 @@ func (s *applyStore) CreateWithTasksAndOperations(ctx context.Context, apply *st
 	// tasks out per-operation, the per-task mapping needs to be encoded
 	// by the caller (see the multi-op guard below).
 	for _, op := range operations {
-		op.ApplyID = id
-		if _, err := insertApplyOperation(ctx, writeTx.tx, op); err != nil {
-			return 0, fmt.Errorf("insert apply_operation (deployment=%s) for apply %s: %w", op.Deployment, apply.ApplyIdentifier, err)
+		op.ApplyID = applyID
+		if _, err := insertApplyOperation(ctx, tx, op); err != nil {
+			return fmt.Errorf("insert apply_operation (deployment=%s) for apply %s: %w", op.Deployment, apply.ApplyIdentifier, err)
 		}
 	}
 
@@ -526,7 +553,7 @@ func (s *applyStore) CreateWithTasksAndOperations(ctx context.Context, apply *st
 		// invalid because there is no row it can reference for this apply.
 		for _, task := range tasks {
 			if task.ApplyOperationID != nil {
-				return 0, fmt.Errorf("create apply %s: task %s has apply_operation_id=%d but apply has no operations", apply.ApplyIdentifier, task.TaskIdentifier, *task.ApplyOperationID)
+				return fmt.Errorf("create apply %s: task %s has apply_operation_id=%d but apply has no operations", apply.ApplyIdentifier, task.TaskIdentifier, *task.ApplyOperationID)
 			}
 		}
 	case len(operations) == 1:
@@ -539,7 +566,7 @@ func (s *applyStore) CreateWithTasksAndOperations(ctx context.Context, apply *st
 				continue
 			}
 			if _, ok := insertedOpIDs[*task.ApplyOperationID]; !ok {
-				return 0, fmt.Errorf("create apply %s: task %s apply_operation_id=%d does not match any inserted operation for this apply", apply.ApplyIdentifier, task.TaskIdentifier, *task.ApplyOperationID)
+				return fmt.Errorf("create apply %s: task %s apply_operation_id=%d does not match any inserted operation for this apply", apply.ApplyIdentifier, task.TaskIdentifier, *task.ApplyOperationID)
 			}
 		}
 	case len(operations) > 1:
@@ -549,28 +576,59 @@ func (s *applyStore) CreateWithTasksAndOperations(ctx context.Context, apply *st
 		// mapping the moment multi-entry deployments are unblocked.
 		for _, task := range tasks {
 			if task.ApplyOperationID == nil {
-				return 0, fmt.Errorf("create apply %s: task %s missing apply_operation_id (apply has %d operations; caller must encode the per-task mapping)", apply.ApplyIdentifier, task.TaskIdentifier, len(operations))
+				return fmt.Errorf("create apply %s: task %s missing apply_operation_id (apply has %d operations; caller must encode the per-task mapping)", apply.ApplyIdentifier, task.TaskIdentifier, len(operations))
 			}
 			if _, ok := insertedOpIDs[*task.ApplyOperationID]; !ok {
-				return 0, fmt.Errorf("create apply %s: task %s apply_operation_id=%d does not match any inserted operation for this apply", apply.ApplyIdentifier, task.TaskIdentifier, *task.ApplyOperationID)
+				return fmt.Errorf("create apply %s: task %s apply_operation_id=%d does not match any inserted operation for this apply", apply.ApplyIdentifier, task.TaskIdentifier, *task.ApplyOperationID)
 			}
 		}
 	}
 
 	for _, task := range tasks {
-		task.ApplyID = id
-		taskID, err := insertTask(ctx, writeTx.tx, task)
+		task.ApplyID = applyID
+		taskID, err := insertTask(ctx, tx, task)
 		if err != nil {
-			return 0, fmt.Errorf("insert task %s for apply %s: %w", task.TaskIdentifier, apply.ApplyIdentifier, err)
+			return fmt.Errorf("insert task %s for apply %s: %w", task.TaskIdentifier, apply.ApplyIdentifier, err)
 		}
 		task.ID = taskID
 	}
+	return nil
+}
 
-	if err := writeTx.commit(); err != nil {
-		return 0, fmt.Errorf("commit %s: %w", opName, err)
+func insertApplyGroupedOperations(ctx context.Context, tx *sql.Tx, apply *storage.Apply, applyID int64, groups []*storage.ApplyOperationWithTasks) error {
+	if len(groups) == 0 {
+		return fmt.Errorf("create apply %s: grouped operations are empty", apply.ApplyIdentifier)
 	}
+	for _, group := range groups {
+		deployment := ""
+		if group != nil && group.Operation != nil {
+			deployment = group.Operation.Deployment
+		}
+		if group == nil {
+			return fmt.Errorf("create apply %s deployment %s: grouped operation is nil", apply.ApplyIdentifier, deployment)
+		}
+		if group.Operation == nil {
+			return fmt.Errorf("create apply %s deployment %s: grouped operation is nil", apply.ApplyIdentifier, deployment)
+		}
+		if len(group.Tasks) == 0 {
+			return fmt.Errorf("create apply %s deployment %s: grouped operation has no tasks", apply.ApplyIdentifier, deployment)
+		}
 
-	return id, nil
+		group.Operation.ApplyID = applyID
+		if _, err := insertApplyOperation(ctx, tx, group.Operation); err != nil {
+			return fmt.Errorf("insert apply_operation (deployment=%s) for apply %s: %w", group.Operation.Deployment, apply.ApplyIdentifier, err)
+		}
+		for _, task := range group.Tasks {
+			task.ApplyID = applyID
+			task.ApplyOperationID = &group.Operation.ID
+			taskID, err := insertTask(ctx, tx, task)
+			if err != nil {
+				return fmt.Errorf("insert task %s for apply %s deployment %s: %w", task.TaskIdentifier, apply.ApplyIdentifier, group.Operation.Deployment, err)
+			}
+			task.ID = taskID
+		}
+	}
+	return nil
 }
 
 // Get returns an apply by ID, or nil if not found.

--- a/pkg/storage/mysqlstore/applies.go
+++ b/pkg/storage/mysqlstore/applies.go
@@ -608,7 +608,7 @@ func insertApplyGroupedOperations(ctx context.Context, tx *sql.Tx, apply *storag
 			return fmt.Errorf("create apply %s deployment %s: grouped operation is nil", apply.ApplyIdentifier, deployment)
 		}
 		if group.Operation == nil {
-			return fmt.Errorf("create apply %s deployment %s: grouped operation is nil", apply.ApplyIdentifier, deployment)
+			return fmt.Errorf("create apply %s deployment %s: grouped operation is missing its operation row", apply.ApplyIdentifier, deployment)
 		}
 		if len(group.Tasks) == 0 {
 			return fmt.Errorf("create apply %s deployment %s: grouped operation has no tasks", apply.ApplyIdentifier, deployment)
@@ -619,6 +619,9 @@ func insertApplyGroupedOperations(ctx context.Context, tx *sql.Tx, apply *storag
 			return fmt.Errorf("insert apply_operation (deployment=%s) for apply %s: %w", group.Operation.Deployment, apply.ApplyIdentifier, err)
 		}
 		for _, task := range group.Tasks {
+			if task == nil {
+				return fmt.Errorf("create apply %s deployment %s: grouped operation has a nil task", apply.ApplyIdentifier, group.Operation.Deployment)
+			}
 			task.ApplyID = applyID
 			task.ApplyOperationID = &group.Operation.ID
 			taskID, err := insertTask(ctx, tx, task)

--- a/pkg/storage/mysqlstore/applies_test.go
+++ b/pkg/storage/mysqlstore/applies_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"database/sql"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -216,6 +217,184 @@ func TestApplyStore_CreateWithTasksAndOperationsCommitsAtomically(t *testing.T) 
 	assert.Equal(t, operations[0].ID, *tasks[0].ApplyOperationID)
 	require.NotNil(t, storedTasks[0].ApplyOperationID, "task.apply_operation_id must be persisted")
 	assert.Equal(t, operations[0].ID, *storedTasks[0].ApplyOperationID)
+}
+
+// Grouped operation creation links each deployment's independent task copies to that deployment's operation.
+func TestApplyStore_CreateWithGroupedOperationsLinksTasksPerOperation(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+	now := time.Now()
+	apply := newGroupedCreateApply(now, "apply_grouped_multi")
+	groups := []*storage.ApplyOperationWithTasks{
+		newGroupedCreateGroup(now, "payments-a", "payments-a-target", "users", "orders"),
+		newGroupedCreateGroup(now, "payments-b", "payments-b-target", "users", "orders"),
+		newGroupedCreateGroup(now, "payments-c", "payments-c-target", "users", "orders"),
+	}
+
+	applyID, err := store.Applies().CreateWithGroupedOperations(ctx, apply, groups)
+	require.NoError(t, err)
+	require.NotZero(t, applyID)
+
+	storedOps, err := store.ApplyOperations().ListByApply(ctx, applyID)
+	require.NoError(t, err)
+	require.Len(t, storedOps, 3)
+	for i, op := range storedOps {
+		assert.Equal(t, applyID, op.ApplyID)
+		assert.Equal(t, groups[i].Operation.Deployment, op.Deployment)
+		assert.Equal(t, groups[i].Operation.Target, op.Target)
+	}
+
+	storedTasks, err := store.Tasks().GetByApplyID(ctx, applyID)
+	require.NoError(t, err)
+	require.Len(t, storedTasks, 6)
+	storedTaskCountsByOp := map[int64]int{}
+	for _, task := range storedTasks {
+		require.NotNil(t, task.ApplyOperationID)
+		assert.NotZero(t, *task.ApplyOperationID)
+		storedTaskCountsByOp[*task.ApplyOperationID]++
+	}
+	for _, group := range groups {
+		require.NotZero(t, group.Operation.ID)
+		assert.Equal(t, applyID, group.Operation.ApplyID)
+		assert.Equal(t, 2, storedTaskCountsByOp[group.Operation.ID])
+		for _, task := range group.Tasks {
+			require.NotNil(t, task.ApplyOperationID)
+			assert.Equal(t, group.Operation.ID, *task.ApplyOperationID)
+			assert.Equal(t, applyID, task.ApplyID)
+		}
+	}
+}
+
+// Single-group creation produces the same operation/task ownership shape as the single-operation create path.
+func TestApplyStore_CreateWithGroupedOperationsSingleGroupMatchesSingleOperationCreate(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+	now := time.Now()
+
+	// The two applies share the same operation (deployment, target) shape but
+	// sit in different environments so the per-environment active-apply target
+	// lock does not reject the second create — both are non-terminal.
+	singleApply := newGroupedCreateApply(now, "apply_grouped_single_flat")
+	singleApply.Environment = "staging"
+	singleTask := newGroupedCreateTask(now, "payments-a", "users")
+	singleOperation := &storage.ApplyOperation{Deployment: "payments-a", Target: "payments-target", State: state.ApplyOperation.Pending, CreatedAt: now, UpdatedAt: now}
+	singleApplyID, err := store.Applies().CreateWithTasksAndOperations(ctx, singleApply, []*storage.Task{singleTask}, []*storage.ApplyOperation{singleOperation})
+	require.NoError(t, err)
+
+	groupedApply := newGroupedCreateApply(now, "apply_grouped_single_group")
+	groupedTask := newGroupedCreateTask(now, "payments-a", "users")
+	// Distinct task identifier (the column is globally unique) while keeping the
+	// table/DDL identical so the shape assertions below still hold.
+	groupedTask.TaskIdentifier = "task_grouped_payments-a_users"
+	groupedOperation := &storage.ApplyOperation{Deployment: "payments-a", Target: "payments-target", State: state.ApplyOperation.Pending, CreatedAt: now, UpdatedAt: now}
+	groupedApplyID, err := store.Applies().CreateWithGroupedOperations(ctx, groupedApply, []*storage.ApplyOperationWithTasks{{Operation: groupedOperation, Tasks: []*storage.Task{groupedTask}}})
+	require.NoError(t, err)
+
+	singleOps, err := store.ApplyOperations().ListByApply(ctx, singleApplyID)
+	require.NoError(t, err)
+	groupedOps, err := store.ApplyOperations().ListByApply(ctx, groupedApplyID)
+	require.NoError(t, err)
+	require.Len(t, singleOps, 1)
+	require.Len(t, groupedOps, 1)
+	assert.Equal(t, singleOps[0].Deployment, groupedOps[0].Deployment)
+	assert.Equal(t, singleOps[0].Target, groupedOps[0].Target)
+	assert.Equal(t, singleOps[0].State, groupedOps[0].State)
+
+	singleTasks, err := store.Tasks().GetByApplyID(ctx, singleApplyID)
+	require.NoError(t, err)
+	groupedTasks, err := store.Tasks().GetByApplyID(ctx, groupedApplyID)
+	require.NoError(t, err)
+	require.Len(t, singleTasks, 1)
+	require.Len(t, groupedTasks, 1)
+	assert.Equal(t, singleTasks[0].TableName, groupedTasks[0].TableName)
+	assert.Equal(t, singleTasks[0].DDL, groupedTasks[0].DDL)
+	require.NotNil(t, singleTasks[0].ApplyOperationID)
+	require.NotNil(t, groupedTasks[0].ApplyOperationID)
+	assert.Equal(t, singleOperation.ID, *singleTasks[0].ApplyOperationID)
+	assert.Equal(t, groupedOperation.ID, *groupedTasks[0].ApplyOperationID)
+}
+
+// Grouped operation creation rejects incomplete group definitions before any rows are committed.
+func TestApplyStore_CreateWithGroupedOperationsRejectsInvalidGroups(t *testing.T) {
+	tests := []struct {
+		name      string
+		groups    []*storage.ApplyOperationWithTasks
+		wantError string
+	}{
+		{name: "empty groups", groups: nil, wantError: "grouped operations are empty"},
+		{name: "nil group", groups: []*storage.ApplyOperationWithTasks{nil}, wantError: "grouped operation is nil"},
+		{name: "nil operation", groups: []*storage.ApplyOperationWithTasks{{Tasks: []*storage.Task{newGroupedCreateTask(time.Now(), "payments-a", "users")}}}, wantError: "grouped operation is nil"},
+		{name: "no tasks", groups: []*storage.ApplyOperationWithTasks{{Operation: &storage.ApplyOperation{Deployment: "payments-a", Target: "payments-target"}}}, wantError: "grouped operation has no tasks"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clearTables(t)
+			ctx := t.Context()
+			store := New(testDB)
+			apply := newGroupedCreateApply(time.Now(), "apply_grouped_invalid_"+strings.ReplaceAll(tt.name, " ", "_"))
+
+			_, err := store.Applies().CreateWithGroupedOperations(ctx, apply, tt.groups)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), apply.ApplyIdentifier)
+			assert.Contains(t, err.Error(), tt.wantError)
+
+			gotApply, getErr := store.Applies().GetByApplyIdentifier(ctx, apply.ApplyIdentifier)
+			require.NoError(t, getErr)
+			assert.Nil(t, gotApply)
+		})
+	}
+}
+
+func newGroupedCreateApply(now time.Time, identifier string) *storage.Apply {
+	return &storage.Apply{
+		ApplyIdentifier: identifier,
+		PlanID:          1,
+		Database:        "payments",
+		DatabaseType:    storage.DatabaseTypeMySQL,
+		Repository:      "org/repo",
+		PullRequest:     123,
+		Environment:     "production",
+		Deployment:      "payments-a",
+		Engine:          storage.EngineSpirit,
+		State:           state.Apply.Pending,
+		Options:         []byte("{}"),
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+}
+
+func newGroupedCreateGroup(now time.Time, deployment, target string, tables ...string) *storage.ApplyOperationWithTasks {
+	tasks := make([]*storage.Task, 0, len(tables))
+	for _, table := range tables {
+		tasks = append(tasks, newGroupedCreateTask(now, deployment, table))
+	}
+	return &storage.ApplyOperationWithTasks{
+		Operation: &storage.ApplyOperation{Deployment: deployment, Target: target, State: state.ApplyOperation.Pending, CreatedAt: now, UpdatedAt: now},
+		Tasks:     tasks,
+	}
+}
+
+func newGroupedCreateTask(now time.Time, deployment, table string) *storage.Task {
+	return &storage.Task{
+		TaskIdentifier: "task_" + deployment + "_" + table,
+		PlanID:         1,
+		Database:       "payments",
+		DatabaseType:   storage.DatabaseTypeMySQL,
+		Engine:         storage.EngineSpirit,
+		Repository:     "org/repo",
+		PullRequest:    123,
+		Environment:    "production",
+		State:          state.Task.Pending,
+		TableName:      table,
+		DDL:            "ALTER TABLE " + table + " ADD COLUMN email VARCHAR(255)",
+		DDLAction:      "alter",
+		Options:        []byte("{}"),
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
 }
 
 // TestApplyStore_CreateWithTasksAndOperationsRollsBackOnTaskFailure pins the

--- a/pkg/storage/mysqlstore/applies_test.go
+++ b/pkg/storage/mysqlstore/applies_test.go
@@ -325,7 +325,7 @@ func TestApplyStore_CreateWithGroupedOperationsRejectsInvalidGroups(t *testing.T
 	}{
 		{name: "empty groups", groups: nil, wantError: "grouped operations are empty"},
 		{name: "nil group", groups: []*storage.ApplyOperationWithTasks{nil}, wantError: "grouped operation is nil"},
-		{name: "nil operation", groups: []*storage.ApplyOperationWithTasks{{Tasks: []*storage.Task{newGroupedCreateTask(time.Now(), "payments-a", "users")}}}, wantError: "grouped operation is nil"},
+		{name: "nil operation", groups: []*storage.ApplyOperationWithTasks{{Tasks: []*storage.Task{newGroupedCreateTask(time.Now(), "payments-a", "users")}}}, wantError: "grouped operation is missing its operation row"},
 		{name: "no tasks", groups: []*storage.ApplyOperationWithTasks{{Operation: &storage.ApplyOperation{Deployment: "payments-a", Target: "payments-target"}}}, wantError: "grouped operation has no tasks"},
 	}
 

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -205,6 +205,12 @@ type ApplyStore interface {
 	// committed, so the operator never observes a partially-populated apply.
 	CreateWithTasksAndOperations(ctx context.Context, apply *Apply, tasks []*Task, operations []*ApplyOperation) (int64, error)
 
+	// CreateWithGroupedOperations stores a new apply and grouped per-deployment
+	// operation/task rows in a single transaction. Each operation row's ApplyID is
+	// set to the new apply ID before insert, and each group's tasks are linked to
+	// that operation after its auto-increment ID is known.
+	CreateWithGroupedOperations(ctx context.Context, apply *Apply, groups []*ApplyOperationWithTasks) (int64, error)
+
 	// Get returns an apply by ID, or nil if not found.
 	Get(ctx context.Context, id int64) (*Apply, error)
 
@@ -321,6 +327,12 @@ type ApplyStore interface {
 
 	// DeleteByPR removes all applies for a PR (cleanup on PR close/merge).
 	DeleteByPR(ctx context.Context, repo string, pr int) error
+}
+
+// ApplyOperationWithTasks groups one apply_operations row with the task rows it owns.
+type ApplyOperationWithTasks struct {
+	Operation *ApplyOperation
+	Tasks     []*Task
 }
 
 // RecentAppliesFilter controls recent apply queries for status views.


### PR DESCRIPTION
## What

`createStoredApply` now resolves **all** ordered deployment targets and creates **one `apply_operations` row per deployment**, each owning its own copy of the planned tasks, via a new grouped-create storage path (`CreateWithGroupedOperations`).

This is **dormant**: the config gate still rejects `len(deployments) > 1`, so single-deployment creation is byte-for-byte unchanged. The fan-out path is reachable only from tests until the gate is lifted.

## Why

The operator claim-loop and single-publisher terminal summary need apply work modelled as N independent per-deployment operations, not one operation mirroring the apply's own routing. This lands the data shape ahead of lifting the multi-deployment gate, so the behavioural switch later is a small, reviewable change rather than a creation rewrite.

## Flow

```
BEFORE — one operation, mirrors the apply routing
─────────────────────────────────────────────────
createStoredApply
│
│  ResolveDatabaseTarget  ──▶  single (deployment, target)
▼
╭─────────────────────────────────────────╮
│ apply (deployment = target)             │
│   └─ operation ─ tasks[…]               │   one op, one task set
╰─────────────────────────────────────────╯
│
▼
CreateWithTasksAndOperations(apply, tasks, [op])
```

```
AFTER — one operation per resolved deployment
─────────────────────────────────────────────────
createStoredApply
│
│  ResolveDatabaseTargets  ──▶  [t0, t1, … tN]   (ordered)
▼
apply.Deployment = t0.Deployment          (primary)
│
▼
╭─────────────────────────────────────────╮
│ apply                                   │
│   ├─ operation(t0) ─ tasks[…copy]       │
│   ├─ operation(t1) ─ tasks[…copy]       │   one op + own task
│   └─ operation(tN) ─ tasks[…copy]       │   set per deployment
╰─────────────────────────────────────────╯
│
▼
CreateWithGroupedOperations(apply, groups)
```

**NOTE:** Gate today: config rejects len(deployments) > 1, so N == 1 in prod
and the AFTER shape collapses to exactly the BEFORE shape.

## Storage path

`CreateWithGroupedOperations` inserts each operation first, learns its auto-increment ID, assigns that ID to the group's tasks, then inserts the tasks — all in one transaction. It fails closed on empty/nil groups and groups with no tasks. The existing `CreateWithTasksAndOperations` behaviour and validation are preserved (shared transaction helper).
