### PR TITLE
feat(tern): support Vitess pull schema

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -101,11 +101,13 @@ if [ -z "$changed_go_files" ]; then
 fi
 
 # Map changed files to package directories that still exist and contain Go
-# source. A package whose directory was entirely removed is dropped (nothing to
-# test there).
+# source for the default build. A package whose directory was entirely removed
+# or whose files are all excluded by build tags is dropped (nothing to test in
+# the unit-test hook).
 pkgs=""
 for dir in $(printf '%s\n' "$changed_go_files" | xargs -n1 dirname | sort -u); do
-    if [ -d "$dir" ] && ls "$dir"/*.go >/dev/null 2>&1; then
+    testable_pkg=$(go list -e -f '{{if or (or .GoFiles .TestGoFiles) .XTestGoFiles}}{{.ImportPath}}{{end}}' "./$dir" 2>/dev/null || true)
+    if [ -d "$dir" ] && [ -n "$testable_pkg" ]; then
         pkgs="$pkgs ./$dir"
     fi
 done

--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -1018,6 +1018,62 @@ func TestExecutePullSchemaRoutesConfiguredMySQLTarget(t *testing.T) {
 	assert.Equal(t, "CREATE TABLE `users` (`id` bigint NOT NULL);\n", resp.Namespaces["orders"].Tables["users"])
 }
 
+func TestExecutePullSchemaRoutesConfiguredVitessTarget(t *testing.T) {
+	mockClient := &mockTernClient{
+		pullSchemaResp: &ternv1.PullSchemaResponse{
+			Database:    "commerce",
+			Type:        storage.DatabaseTypeVitess,
+			Environment: "production",
+			Namespaces: map[string]*ternv1.PulledNamespace{
+				"commerce_sharded": {
+					Tables:    map[string]string{"users": "CREATE TABLE `users` (`id` bigint NOT NULL);\n"},
+					Artifacts: map[string]string{"vschema.json": "{\"sharded\":true}"},
+				},
+			},
+			TableCount: 1,
+		},
+	}
+	cfg := &ServerConfig{
+		Databases: map[string]DatabaseConfig{
+			"commerce": {
+				Type: storage.DatabaseTypeVitess,
+				Environments: map[string]EnvironmentConfig{
+					"production": {Target: "commerce-production", Deployment: "primary"},
+				},
+			},
+		},
+		TernDeployments: TernConfig{
+			"primary": {"production": "tern.example.com:80"},
+		},
+	}
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	svc := New(&mockStorageWithApplyStores{
+		plans:   &staticPlanStore{},
+		applies: &staticApplyStore{},
+	}, cfg, map[string]tern.Client{
+		"primary/production": mockClient,
+	}, logger)
+
+	resp, err := svc.ExecutePullSchema(t.Context(), apitypes.PullSchemaRequest{
+		Database:    "commerce",
+		Environment: "production",
+		Type:        storage.DatabaseTypeVitess,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, "commerce", resp.Database)
+	assert.Equal(t, storage.DatabaseTypeVitess, resp.Type)
+	assert.Equal(t, int32(1), resp.TableCount)
+	require.NotNil(t, mockClient.pullSchemaReq)
+	assert.Equal(t, "commerce-production", mockClient.pullSchemaReq.Target)
+	assert.Empty(t, mockClient.pullSchemaReq.Namespace)
+	assert.Equal(t, "production", mockClient.pullSchemaReq.Environment)
+	assert.Equal(t, storage.DatabaseTypeVitess, mockClient.pullSchemaReq.Type)
+	assert.Equal(t, "CREATE TABLE `users` (`id` bigint NOT NULL);\n", resp.Namespaces["commerce_sharded"].Tables["users"])
+	assert.JSONEq(t, "{\"sharded\":true}", resp.Namespaces["commerce_sharded"].Artifacts["vschema.json"])
+}
+
 func TestExecutePullSchemaPullsRequestedNamespaces(t *testing.T) {
 	mockClient := &mockTernClient{
 		pullSchemaHook: func(req *ternv1.PullSchemaRequest) (*ternv1.PullSchemaResponse, error) {
@@ -1079,7 +1135,7 @@ func TestExecutePullSchemaRejectsUnsupportedType(t *testing.T) {
 	cfg := &ServerConfig{
 		Databases: map[string]DatabaseConfig{
 			"orders": {
-				Type: storage.DatabaseTypeVitess,
+				Type: storage.DatabaseTypeStrata,
 				Environments: map[string]EnvironmentConfig{
 					"production": {Target: "orders-production", Deployment: "primary"},
 				},
@@ -1097,12 +1153,12 @@ func TestExecutePullSchemaRejectsUnsupportedType(t *testing.T) {
 	_, err := svc.ExecutePullSchema(t.Context(), apitypes.PullSchemaRequest{
 		Database:    "orders",
 		Environment: "production",
-		Type:        storage.DatabaseTypeVitess,
+		Type:        storage.DatabaseTypeStrata,
 	})
 
 	var unsupportedErr *unsupportedPullSchemaError
 	require.ErrorAs(t, err, &unsupportedErr)
-	assert.Equal(t, storage.DatabaseTypeVitess, unsupportedErr.DatabaseType)
+	assert.Equal(t, storage.DatabaseTypeStrata, unsupportedErr.DatabaseType)
 }
 
 func TestExecutePullSchemaRejectsMultiDeploymentEnvironment(t *testing.T) {

--- a/pkg/api/plan_handlers.go
+++ b/pkg/api/plan_handlers.go
@@ -53,7 +53,7 @@ type unsupportedPullSchemaError struct {
 }
 
 func (e *unsupportedPullSchemaError) Error() string {
-	return fmt.Sprintf("pull schema supports %s databases; got %s", storage.DatabaseTypeMySQL, e.DatabaseType)
+	return fmt.Sprintf("pull schema supports %s and %s databases; got %s", storage.DatabaseTypeMySQL, storage.DatabaseTypeVitess, e.DatabaseType)
 }
 
 type ambiguousPullSchemaTargetError struct {
@@ -180,7 +180,7 @@ func (s *Service) ExecutePullSchema(ctx context.Context, req apitypes.PullSchema
 		span.SetStatus(otelcodes.Error, "type mismatch")
 		return nil, typeErr
 	}
-	if resolvedTarget.DatabaseType != storage.DatabaseTypeMySQL {
+	if resolvedTarget.DatabaseType != storage.DatabaseTypeMySQL && resolvedTarget.DatabaseType != storage.DatabaseTypeVitess {
 		unsupportedErr := &unsupportedPullSchemaError{DatabaseType: resolvedTarget.DatabaseType}
 		span.RecordError(unsupportedErr)
 		span.SetStatus(otelcodes.Error, "unsupported database type")

--- a/pkg/cmd/commands/onboard.go
+++ b/pkg/cmd/commands/onboard.go
@@ -164,8 +164,8 @@ func buildOnboardWritePlan(schemaRoot string, resp *apitypes.PullSchemaResponse)
 	if strings.TrimSpace(resp.Database) == "" {
 		return nil, fmt.Errorf("pull schema response database is empty")
 	}
-	if resp.Type != storage.DatabaseTypeMySQL {
-		return nil, fmt.Errorf("onboard currently supports %s databases; got %s", storage.DatabaseTypeMySQL, resp.Type)
+	if resp.Type != storage.DatabaseTypeMySQL && resp.Type != storage.DatabaseTypeVitess {
+		return nil, fmt.Errorf("onboard currently supports %s and %s databases; got %s", storage.DatabaseTypeMySQL, storage.DatabaseTypeVitess, resp.Type)
 	}
 	if len(resp.Namespaces) == 0 {
 		return nil, fmt.Errorf("pull schema returned no tables for database %s environment %s", resp.Database, resp.Environment)
@@ -202,7 +202,7 @@ func buildOnboardWritePlan(schemaRoot string, resp *apitypes.PullSchemaResponse)
 			}
 			files[filepath.Join(namespace, tableName+".sql")] = pulled.Tables[tableName]
 		}
-		if vschema := pulled.Artifacts["vschema"]; vschema != "" {
+		if vschema := pulled.Artifacts["vschema.json"]; vschema != "" {
 			files[filepath.Join(namespace, "vschema.json")] = vschema
 		}
 	}

--- a/pkg/cmd/commands/onboard_test.go
+++ b/pkg/cmd/commands/onboard_test.go
@@ -44,6 +44,41 @@ func TestBuildOnboardWritePlanWritesConfigAndNamespaceFiles(t *testing.T) {
 	assert.Equal(t, "CREATE TABLE `orders` (`id` bigint NOT NULL);\n", string(orders))
 }
 
+func TestBuildOnboardWritePlanWritesVitessKeyspaceArtifacts(t *testing.T) {
+	root := t.TempDir()
+	plan, err := buildOnboardWritePlan(root, &apitypes.PullSchemaResponse{
+		Database:    "commerce",
+		Type:        "vitess",
+		Environment: "production",
+		TableCount:  1,
+		Namespaces: map[string]*apitypes.PulledNamespace{
+			"commerce_sharded": {
+				Tables: map[string]string{
+					"users": "CREATE TABLE `users` (`id` bigint NOT NULL);\n",
+				},
+				Artifacts: map[string]string{
+					"vschema.json": "{\"sharded\":true}",
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.NoError(t, plan.checkConflicts(false))
+	require.NoError(t, plan.write())
+
+	config, err := os.ReadFile(filepath.Join(root, "schemabot.yaml"))
+	require.NoError(t, err)
+	assert.Equal(t, "database: commerce\ntype: vitess\n", string(config))
+
+	users, err := os.ReadFile(filepath.Join(root, "commerce_sharded", "users.sql"))
+	require.NoError(t, err)
+	assert.Equal(t, "CREATE TABLE `users` (`id` bigint NOT NULL);\n", string(users))
+
+	vschema, err := os.ReadFile(filepath.Join(root, "commerce_sharded", "vschema.json"))
+	require.NoError(t, err)
+	assert.JSONEq(t, "{\"sharded\":true}", string(vschema))
+}
+
 func TestOnboardPullNamespacesUseConcreteLiveNamespaces(t *testing.T) {
 	pullNamespaces, err := onboardPullNamespaces([]string{"orders_production", "orders_audit_production"})
 	require.NoError(t, err)

--- a/pkg/localscale/pull_schema_integration_test.go
+++ b/pkg/localscale/pull_schema_integration_test.go
@@ -1,0 +1,91 @@
+//go:build integration
+
+package localscale_test
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/block/spirit/pkg/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/block/schemabot/pkg/localscale"
+	ternv1 "github.com/block/schemabot/pkg/proto/ternv1"
+	"github.com/block/schemabot/pkg/storage"
+	"github.com/block/schemabot/pkg/tern"
+)
+
+// Pulling a live Vitess schema exports each keyspace as a namespace with table
+// DDL in tables and VSchema JSON in namespace artifacts.
+func TestPullSchemaLoadsLiveVitessSchema(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	ctx := t.Context()
+	const (
+		org      = "test-org"
+		database = "pullvitess"
+	)
+	lsc, err := localscale.RunContainer(ctx, localscale.ContainerConfig{
+		Orgs: map[string]localscale.ContainerOrgConfig{
+			org: {Databases: map[string]localscale.ContainerDatabaseConfig{
+				database: {Keyspaces: []localscale.ContainerKeyspaceConfig{
+					{Name: "commerce", Shards: 1},
+					{Name: "commerce_sharded", Shards: 2},
+				}},
+			}},
+		},
+	})
+	require.NoError(t, err, "start LocalScale")
+	if os.Getenv("DEBUG") != "1" {
+		t.Cleanup(func() {
+			cleanupCtx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+			defer cancel()
+			assert.NoError(t, lsc.Terminate(cleanupCtx), "terminate LocalScale")
+		})
+	}
+
+	require.NoError(t, lsc.SeedVSchema(ctx, org, database, "commerce", []byte("{\"sharded\":false}")))
+	require.NoError(t, lsc.SeedVSchema(ctx, org, database, "commerce_sharded", []byte("{\"sharded\":true,\"vindexes\":{\"hash\":{\"type\":\"hash\"}},\"tables\":{\"users\":{\"column_vindexes\":[{\"column\":\"id\",\"name\":\"hash\"}]}}}")))
+	require.NoError(t, lsc.SeedDDL(ctx, org, database, "commerce",
+		"CREATE TABLE IF NOT EXISTS `settings` (`id` bigint NOT NULL, `name` varchar(255), PRIMARY KEY (`id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"))
+	require.NoError(t, lsc.SeedDDL(ctx, org, database, "commerce_sharded",
+		"CREATE TABLE IF NOT EXISTS `users` (`id` bigint NOT NULL, `email` varchar(255), PRIMARY KEY (`id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"))
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	client, err := tern.NewLocalClient(tern.LocalConfig{
+		Database: database,
+		Type:     storage.DatabaseTypeVitess,
+		Metadata: map[string]string{
+			"organization": org,
+			"token_name":   "test",
+			"token_value":  "test",
+			"api_url":      lsc.URL(),
+		},
+	}, nil, logger)
+	require.NoError(t, err, "create client")
+	defer utils.CloseAndLog(client)
+
+	resp, err := client.PullSchema(ctx, &ternv1.PullSchemaRequest{
+		Database:    database,
+		Type:        storage.DatabaseTypeVitess,
+		Environment: "production",
+	})
+
+	require.NoError(t, err, "pull Vitess schema")
+	require.NotNil(t, resp)
+	assert.Equal(t, database, resp.Database)
+	assert.Equal(t, storage.DatabaseTypeVitess, resp.Type)
+	assert.Equal(t, int32(2), resp.TableCount)
+	require.Contains(t, resp.Namespaces, "commerce")
+	require.Contains(t, resp.Namespaces, "commerce_sharded")
+	assert.Contains(t, resp.Namespaces["commerce"].Tables["settings"], "CREATE TABLE `settings`")
+	assert.Contains(t, resp.Namespaces["commerce_sharded"].Tables["users"], "CREATE TABLE `users`")
+	assert.JSONEq(t, "{}", resp.Namespaces["commerce"].Artifacts["vschema.json"])
+	assert.JSONEq(t, "{\"sharded\":true,\"vindexes\":{\"hash\":{\"type\":\"hash\"}},\"tables\":{\"users\":{\"column_vindexes\":[{\"column\":\"id\",\"name\":\"hash\"}]}}}", resp.Namespaces["commerce_sharded"].Artifacts["vschema.json"])
+}

--- a/pkg/tern/local_client.go
+++ b/pkg/tern/local_client.go
@@ -101,6 +101,7 @@ import (
 	"github.com/block/spirit/pkg/utils"
 	"github.com/go-sql-driver/mysql"
 	"github.com/google/uuid"
+	ps "github.com/planetscale/planetscale-go/planetscale"
 
 	"github.com/block/schemabot/pkg/ddl"
 	"github.com/block/schemabot/pkg/engine"
@@ -171,6 +172,7 @@ type LocalClient struct {
 	spiritEngine      engine.Engine
 	planetscaleEngine engine.Engine
 	customEngine      engine.Engine
+	psClientFunc      func(tokenName, tokenValue string) (psclient.PSClient, error)
 	logger            *slog.Logger
 
 	// heartbeatInterval controls how often the apply heartbeat updates updated_at.
@@ -211,11 +213,13 @@ func NewLocalClient(cfg LocalConfig, stor storage.Storage, logger *slog.Logger) 
 	// that points at the API base URL from metadata (e.g., "http://localscale:8080").
 	// TargetDSN is the vtgate MySQL DSN for SHOW VITESS_MIGRATIONS.
 	var psEngine engine.Engine
+	var psClientFunc func(tokenName, tokenValue string) (psclient.PSClient, error)
 	if cfg.Type == storage.DatabaseTypeVitess {
 		apiURL := cfg.Metadata["api_url"]
-		psEngine = planetscale.NewWithClient(logger, func(tokenName, tokenValue string) (psclient.PSClient, error) {
+		psClientFunc = func(tokenName, tokenValue string) (psclient.PSClient, error) {
 			return psclient.NewPSClientWithBaseURL(tokenName, tokenValue, apiURL)
-		})
+		}
+		psEngine = planetscale.NewWithClient(logger, psClientFunc)
 	}
 
 	// For a database type without a built-in engine, build it from a registered
@@ -251,6 +255,7 @@ func NewLocalClient(cfg LocalConfig, stor storage.Storage, logger *slog.Logger) 
 		}),
 		planetscaleEngine: psEngine,
 		customEngine:      customEngine,
+		psClientFunc:      psClientFunc,
 		logger:            logger,
 		heartbeatInterval: 10 * time.Second,
 	}, nil
@@ -458,8 +463,8 @@ func (c *LocalClient) Health(ctx context.Context) error {
 
 // PullSchema fetches the live schema and returns declarative schema files.
 func (c *LocalClient) PullSchema(ctx context.Context, req *ternv1.PullSchemaRequest) (*ternv1.PullSchemaResponse, error) {
-	if c.config.Type != storage.DatabaseTypeMySQL {
-		return nil, fmt.Errorf("pull schema for database %s type %s: only %s is supported: %w", c.config.Database, c.config.Type, storage.DatabaseTypeMySQL, ErrPullSchemaUnsupportedType)
+	if c.config.Type != storage.DatabaseTypeMySQL && c.config.Type != storage.DatabaseTypeVitess {
+		return nil, fmt.Errorf("pull schema for database %s type %s: only %s and %s are supported: %w", c.config.Database, c.config.Type, storage.DatabaseTypeMySQL, storage.DatabaseTypeVitess, ErrPullSchemaUnsupportedType)
 	}
 	if req.Type != "" && req.Type != c.config.Type {
 		return nil, fmt.Errorf("pull schema for database %s: request type %q does not match client type %q: %w", c.config.Database, req.Type, c.config.Type, ErrPullSchemaInvalidRequest)
@@ -493,6 +498,10 @@ func (c *LocalClient) pullAllNamespaces(ctx context.Context, req *ternv1.PullSch
 }
 
 func (c *LocalClient) discoverPullNamespaces(ctx context.Context) ([]string, error) {
+	if c.config.Type == storage.DatabaseTypeVitess {
+		return c.discoverVitessPullKeyspaces(ctx)
+	}
+
 	if database, err := mysqlDSNDatabase(c.config.TargetDSN); err != nil {
 		return nil, fmt.Errorf("inspect MySQL target DSN for namespace discovery: %w", err)
 	} else if database != "" {
@@ -538,6 +547,10 @@ func (c *LocalClient) discoverPullNamespaces(ctx context.Context) ([]string, err
 }
 
 func (c *LocalClient) pullSchemaNamespace(ctx context.Context, req *ternv1.PullSchemaRequest, namespace string) (*ternv1.PullSchemaResponse, error) {
+	if c.config.Type == storage.DatabaseTypeVitess {
+		return c.pullVitessSchemaNamespace(ctx, req, namespace)
+	}
+
 	targetDSN := c.config.TargetDSN
 	if c.config.Type == storage.DatabaseTypeMySQL {
 		creds, err := c.credentialsForMySQLPullNamespace(namespace)
@@ -569,7 +582,7 @@ func (c *LocalClient) pullSchemaNamespace(ctx context.Context, req *ternv1.PullS
 
 	pulledTables := make(map[string]string, len(tables))
 	for _, tbl := range tables {
-		content, err := pulledSchemaFileContent(namespace, tbl)
+		content, err := pulledSchemaFileContent(namespace, tbl.Name, tbl.Schema)
 		if err != nil {
 			return nil, err
 		}
@@ -599,6 +612,134 @@ func (c *LocalClient) pullSchemaNamespace(ctx context.Context, req *ternv1.PullS
 		},
 		TableCount: int32(len(tables)),
 	}, nil
+}
+
+func (c *LocalClient) discoverVitessPullKeyspaces(ctx context.Context) ([]string, error) {
+	client, org, branch, err := c.planetScalePullClient()
+	if err != nil {
+		return nil, err
+	}
+
+	c.logger.Info("LocalClient.PullSchema: discovering Vitess keyspaces", "database", c.config.Database, "branch", branch)
+	keyspaces, err := client.ListKeyspaces(ctx, &ps.ListKeyspacesRequest{
+		Organization: org,
+		Database:     c.config.Database,
+		Branch:       branch,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list Vitess keyspaces for database %s branch %s: %w", c.config.Database, branch, err)
+	}
+	namespaces := make([]string, 0, len(keyspaces))
+	for _, keyspace := range keyspaces {
+		if keyspace == nil {
+			c.logger.Warn("LocalClient.PullSchema: skipping nil Vitess keyspace", "database", c.config.Database, "branch", branch)
+			continue
+		}
+		if keyspace.Name == "" {
+			return nil, fmt.Errorf("list Vitess keyspaces for database %s branch %s returned a keyspace with no name", c.config.Database, branch)
+		}
+		if schema.IsReservedPullNamespace(keyspace.Name) {
+			c.logger.Debug("LocalClient.PullSchema: skipping reserved Vitess keyspace", "database", c.config.Database, "branch", branch, "namespace", keyspace.Name)
+			continue
+		}
+		namespaces = append(namespaces, keyspace.Name)
+	}
+	sort.Strings(namespaces)
+	c.logger.Info("LocalClient.PullSchema: discovered Vitess keyspaces", "database", c.config.Database, "branch", branch, "namespace_count", len(namespaces))
+	return namespaces, nil
+}
+
+func (c *LocalClient) pullVitessSchemaNamespace(ctx context.Context, req *ternv1.PullSchemaRequest, namespace string) (*ternv1.PullSchemaResponse, error) {
+	client, org, branch, err := c.planetScalePullClient()
+	if err != nil {
+		return nil, err
+	}
+
+	c.logger.Info("LocalClient.PullSchema: loading live Vitess schema", "database", c.config.Database, "branch", branch, "namespace", namespace)
+	schemaResult, err := client.GetBranchSchema(ctx, &ps.BranchSchemaRequest{
+		Organization: org,
+		Database:     c.config.Database,
+		Branch:       branch,
+		Keyspace:     namespace,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("fetch Vitess schema for database %s branch %s keyspace %s: %w", c.config.Database, branch, namespace, err)
+	}
+
+	pulledTables := make(map[string]string, len(schemaResult))
+	for _, tbl := range schemaResult {
+		if tbl == nil {
+			c.logger.Warn("LocalClient.PullSchema: skipping nil Vitess table schema", "database", c.config.Database, "branch", branch, "namespace", namespace)
+			continue
+		}
+		if tbl.Name == "" {
+			return nil, fmt.Errorf("fetch Vitess schema for database %s branch %s keyspace %s returned a table with no name", c.config.Database, branch, namespace)
+		}
+		content, err := pulledSchemaFileContent(c.config.Database, tbl.Name, tbl.Raw)
+		if err != nil {
+			return nil, fmt.Errorf("fetch Vitess schema for database %s branch %s keyspace %s: %w", c.config.Database, branch, namespace, err)
+		}
+		pulledTables[tbl.Name] = content
+	}
+
+	artifacts := map[string]string{}
+	vschema, err := client.GetKeyspaceVSchema(ctx, &ps.GetKeyspaceVSchemaRequest{
+		Organization: org,
+		Database:     c.config.Database,
+		Branch:       branch,
+		Keyspace:     namespace,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("fetch Vitess VSchema for database %s branch %s keyspace %s: %w", c.config.Database, branch, namespace, err)
+	}
+	if vschema != nil && strings.TrimSpace(vschema.Raw) != "" {
+		artifacts[vSchemaArtifactName] = strings.TrimRight(vschema.Raw, "\n") + "\n"
+	}
+
+	c.logger.Info("LocalClient.PullSchema: loaded live Vitess schema",
+		"database", c.config.Database,
+		"branch", branch,
+		"namespace", namespace,
+		"table_count", len(pulledTables),
+		"artifact_count", len(artifacts),
+	)
+
+	return &ternv1.PullSchemaResponse{
+		Database:    c.pullResponseDatabase(req),
+		Type:        c.config.Type,
+		Environment: req.Environment,
+		Namespaces: map[string]*ternv1.PulledNamespace{
+			namespace: {
+				Tables:    pulledTables,
+				Artifacts: artifacts,
+				NamespaceCatalog: &ternv1.NamespaceCatalog{
+					Name:       namespace,
+					Engine:     c.config.Type,
+					TableCount: int32(len(pulledTables)),
+				},
+			},
+		},
+		TableCount: int32(len(pulledTables)),
+	}, nil
+}
+
+func (c *LocalClient) planetScalePullClient() (psclient.PSClient, string, string, error) {
+	if c.psClientFunc == nil {
+		return nil, "", "", fmt.Errorf("PlanetScale client is not configured for database %s: %w", c.config.Database, ErrPullSchemaUnsupportedType)
+	}
+	org := c.config.Metadata["organization"]
+	if org == "" {
+		return nil, "", "", fmt.Errorf("PlanetScale organization metadata is required for database %s", c.config.Database)
+	}
+	branch := c.config.Metadata["main_branch"]
+	if branch == "" {
+		branch = "main"
+	}
+	client, err := c.psClientFunc(c.config.Metadata["token_name"], c.config.Metadata["token_value"])
+	if err != nil {
+		return nil, "", "", fmt.Errorf("create PlanetScale client for database %s: %w", c.config.Database, err)
+	}
+	return client, org, branch, nil
 }
 
 type pulledCatalog struct {
@@ -807,13 +948,13 @@ func (c *LocalClient) credentialsForMySQLPullNamespace(namespace string) (*engin
 	}, nil
 }
 
-func pulledSchemaFileContent(database string, tbl spirittable.TableSchema) (string, error) {
-	if tbl.Name == "" {
+func pulledSchemaFileContent(database string, tableName string, tableDDL string) (string, error) {
+	if tableName == "" {
 		return "", fmt.Errorf("load live schema for database %s: table with empty name", database)
 	}
-	content := strings.TrimRight(tbl.Schema, "\n") + "\n"
+	content := strings.TrimRight(tableDDL, "\n") + "\n"
 	if _, err := statement.ParseCreateTable(content); err != nil {
-		return "", fmt.Errorf("parse pulled schema for database %s table %s: %w", database, tbl.Name, err)
+		return "", fmt.Errorf("parse pulled schema for database %s table %s: %w", database, tableName, err)
 	}
 	return content, nil
 }

--- a/pkg/tern/local_client_test.go
+++ b/pkg/tern/local_client_test.go
@@ -10,32 +10,175 @@ import (
 	"time"
 
 	"github.com/block/spirit/pkg/statement"
-	spirittable "github.com/block/spirit/pkg/table"
+	ps "github.com/planetscale/planetscale-go/planetscale"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/block/schemabot/pkg/engine"
 	ternv1 "github.com/block/schemabot/pkg/proto/ternv1"
+	"github.com/block/schemabot/pkg/psclient"
 	"github.com/block/schemabot/pkg/state"
 	"github.com/block/schemabot/pkg/storage"
 )
 
 func TestPulledSchemaFileContentValidatesDDL(t *testing.T) {
-	content, err := pulledSchemaFileContent("orders", spirittable.TableSchema{
-		Name:   "users",
-		Schema: "CREATE TABLE `users` (`id` bigint NOT NULL) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci",
-	})
+	content, err := pulledSchemaFileContent("orders", "users", "CREATE TABLE `users` (`id` bigint NOT NULL) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci")
 
 	require.NoError(t, err)
 	assert.Equal(t, "CREATE TABLE `users` (`id` bigint NOT NULL) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci\n", content)
 
-	_, err = pulledSchemaFileContent("orders", spirittable.TableSchema{
-		Name:   "broken_users",
-		Schema: "CREATE TABLE",
-	})
+	_, err = pulledSchemaFileContent("orders", "broken_users", "CREATE TABLE")
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "parse pulled schema for database orders table broken_users")
+}
+
+type pullSchemaPSClient struct {
+	psclient.PSClient
+	keyspaces   []*ps.Keyspace
+	schemas     map[string][]*ps.Diff
+	vschemas    map[string]*ps.VSchema
+	listReq     *ps.ListKeyspacesRequest
+	schemaReqs  []*ps.BranchSchemaRequest
+	vschemaReqs []*ps.GetKeyspaceVSchemaRequest
+}
+
+func (c *pullSchemaPSClient) ListKeyspaces(_ context.Context, req *ps.ListKeyspacesRequest) ([]*ps.Keyspace, error) {
+	c.listReq = req
+	return c.keyspaces, nil
+}
+
+func (c *pullSchemaPSClient) GetBranchSchema(_ context.Context, req *ps.BranchSchemaRequest) ([]*ps.Diff, error) {
+	c.schemaReqs = append(c.schemaReqs, req)
+	return c.schemas[req.Keyspace], nil
+}
+
+func (c *pullSchemaPSClient) GetKeyspaceVSchema(_ context.Context, req *ps.GetKeyspaceVSchemaRequest) (*ps.VSchema, error) {
+	c.vschemaReqs = append(c.vschemaReqs, req)
+	return c.vschemas[req.Keyspace], nil
+}
+
+func TestLocalClient_PullSchemaLoadsVitessKeyspaceWithVSchemaArtifact(t *testing.T) {
+	psClient := &pullSchemaPSClient{
+		schemas: map[string][]*ps.Diff{
+			"commerce_sharded": {
+				{Name: "users", Raw: "CREATE TABLE `users` (`id` bigint NOT NULL) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"},
+			},
+		},
+		vschemas: map[string]*ps.VSchema{
+			"commerce_sharded": {Raw: "{\"sharded\":true,\"tables\":{\"users\":{}}}"},
+		},
+	}
+	client := &LocalClient{
+		config: LocalConfig{
+			Database: "commerce",
+			Type:     storage.DatabaseTypeVitess,
+			Metadata: map[string]string{
+				"organization": "test-org",
+				"main_branch":  "production",
+			},
+		},
+		psClientFunc: func(_, _ string) (psclient.PSClient, error) { return psClient, nil },
+		logger:       slog.Default(),
+	}
+
+	resp, err := client.PullSchema(t.Context(), &ternv1.PullSchemaRequest{
+		Database:    "commerce",
+		Type:        storage.DatabaseTypeVitess,
+		Environment: "production",
+		Namespace:   "commerce_sharded",
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, storage.DatabaseTypeVitess, resp.Type)
+	assert.Equal(t, int32(1), resp.TableCount)
+	ns := resp.Namespaces["commerce_sharded"]
+	require.NotNil(t, ns)
+	assert.Equal(t, "CREATE TABLE `users` (`id` bigint NOT NULL) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci\n", ns.Tables["users"])
+	assert.JSONEq(t, "{\"sharded\":true,\"tables\":{\"users\":{}}}", ns.Artifacts[vSchemaArtifactName])
+	assert.Equal(t, "commerce_sharded", ns.NamespaceCatalog.Name)
+	assert.Equal(t, storage.DatabaseTypeVitess, ns.NamespaceCatalog.Engine)
+	assert.Equal(t, int32(1), ns.NamespaceCatalog.TableCount)
+	require.Len(t, psClient.schemaReqs, 1)
+	assert.Equal(t, "test-org", psClient.schemaReqs[0].Organization)
+	assert.Equal(t, "commerce", psClient.schemaReqs[0].Database)
+	assert.Equal(t, "production", psClient.schemaReqs[0].Branch)
+	assert.Equal(t, "commerce_sharded", psClient.schemaReqs[0].Keyspace)
+	require.Len(t, psClient.vschemaReqs, 1)
+	assert.Equal(t, "commerce_sharded", psClient.vschemaReqs[0].Keyspace)
+}
+
+func TestLocalClient_PullSchemaDiscoversVitessKeyspaces(t *testing.T) {
+	psClient := &pullSchemaPSClient{
+		keyspaces: []*ps.Keyspace{{Name: "commerce_sharded"}, {Name: "_vt"}, {Name: "commerce"}},
+		schemas: map[string][]*ps.Diff{
+			"commerce":         {{Name: "settings", Raw: "CREATE TABLE `settings` (`id` bigint NOT NULL) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"}},
+			"commerce_sharded": {{Name: "users", Raw: "CREATE TABLE `users` (`id` bigint NOT NULL) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"}},
+		},
+		vschemas: map[string]*ps.VSchema{
+			"commerce":         {Raw: "{\"sharded\":false}"},
+			"commerce_sharded": {Raw: "{\"sharded\":true}"},
+		},
+	}
+	client := &LocalClient{
+		config: LocalConfig{
+			Database: "commerce",
+			Type:     storage.DatabaseTypeVitess,
+			Metadata: map[string]string{"organization": "test-org"},
+		},
+		psClientFunc: func(_, _ string) (psclient.PSClient, error) { return psClient, nil },
+		logger:       slog.Default(),
+	}
+
+	resp, err := client.PullSchema(t.Context(), &ternv1.PullSchemaRequest{
+		Database:    "commerce",
+		Type:        storage.DatabaseTypeVitess,
+		Environment: "production",
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, int32(2), resp.TableCount)
+	assert.Contains(t, resp.Namespaces, "commerce")
+	assert.Contains(t, resp.Namespaces, "commerce_sharded")
+	assert.NotContains(t, resp.Namespaces, "_vt")
+	require.NotNil(t, psClient.listReq)
+	assert.Equal(t, "test-org", psClient.listReq.Organization)
+	assert.Equal(t, "commerce", psClient.listReq.Database)
+	assert.Equal(t, "main", psClient.listReq.Branch)
+	require.Len(t, psClient.schemaReqs, 2)
+	assert.Equal(t, "commerce", psClient.schemaReqs[0].Keyspace)
+	assert.Equal(t, "commerce_sharded", psClient.schemaReqs[1].Keyspace)
+}
+
+func TestLocalClient_PullSchemaRejectsInvalidVitessDDL(t *testing.T) {
+	psClient := &pullSchemaPSClient{
+		schemas: map[string][]*ps.Diff{
+			"commerce": {{Name: "broken_users", Raw: "CREATE TABLE"}},
+		},
+		vschemas: map[string]*ps.VSchema{"commerce": {Raw: "{}"}},
+	}
+	client := &LocalClient{
+		config: LocalConfig{
+			Database: "commerce",
+			Type:     storage.DatabaseTypeVitess,
+			Metadata: map[string]string{"organization": "test-org"},
+		},
+		psClientFunc: func(_, _ string) (psclient.PSClient, error) { return psClient, nil },
+		logger:       slog.Default(),
+	}
+
+	_, err := client.PullSchema(t.Context(), &ternv1.PullSchemaRequest{
+		Database:    "commerce",
+		Type:        storage.DatabaseTypeVitess,
+		Environment: "production",
+		Namespace:   "commerce",
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "fetch Vitess schema for database commerce branch main keyspace commerce")
+	assert.Contains(t, err.Error(), "parse pulled schema for database commerce table broken_users")
 }
 
 func TestPlanHasOriginalFilesCaptureAcceptsOriginalFiles(t *testing.T) {


### PR DESCRIPTION
## Why
SchemaBot onboarding can already pull MySQL schema state, but Vitess databases need the same control-plane initiated path so keyspace schemas can be made declarative.

## What
- Enable PullSchema execution for Vitess database routes
- Pull Vitess keyspace schemas through the existing PlanetScale/Vitess client path
- Return each keyspace as a namespace with table DDL and `vschema.json` artifacts
- Let `schemabot onboard` materialize Vitess namespaces and VSchema artifacts

## Risk Assessment
Medium — this extends the pull/onboard path for Vitess, but leaves apply behavior unchanged and only runs when callers explicitly request a Vitess pull.

Generated with Amp
