### PR TITLE
feat(observability): route operator drive by operation deployment

### DIFF
--- a/integration/operator_test.go
+++ b/integration/operator_test.go
@@ -350,15 +350,15 @@ func TestOperator_OperatorReconcilesOperationWhenParentTerminal(t *testing.T) {
 	assert.Equal(t, derived, parent.State, "parent apply state is derived from its child operations")
 }
 
-// TestOperator_OperationDeploymentMismatchFailsClosed covers the safety guard
-// on the operation-claim path. The claimed apply_operations row's deployment is
-// the authoritative routing key for the drive, but the shared resume path
-// selects the Tern client from the parent apply's stored deployment. While one
-// operation maps to one apply these are always identical; if they ever diverge
-// (data corruption, or a future multi-deployment fan-out), driving via the
-// parent deployment would run the wrong deployment. The operator must fail
-// closed: it claims the operation but never drives it to a terminal state.
-func TestOperator_OperationDeploymentMismatchFailsClosed(t *testing.T) {
+// TestOperator_OperationDeploymentDrivesByOperationDeployment proves the
+// operation-claim path routes the drive by the claimed apply_operations row's
+// own deployment, not the parent apply's stored deployment. The parent apply's
+// deployment is only the primary deployment for legacy queries; the operation
+// deployment is the routing key. Here the parent's stored deployment is a
+// non-routable placeholder while the operation's deployment is the real,
+// configured target, so the operator must still drive the operation to
+// completion via its own deployment.
+func TestOperator_OperationDeploymentDrivesByOperationDeployment(t *testing.T) {
 	ctx := t.Context()
 	schemaSQL, err := os.ReadFile("testdata/myapp/mysql/schema/users.sql")
 	require.NoError(t, err)
@@ -398,14 +398,125 @@ func TestOperator_OperationDeploymentMismatchFailsClosed(t *testing.T) {
 	plan2, err := ts.Storage.Plans().Get(ctx, planID2)
 	require.NoError(t, err)
 
-	// Seed a resumable apply whose stored deployment is the real, routable
-	// target, but a child operation whose deployment deliberately diverges. The
-	// operation's tasks are present and runnable, so the only thing stopping the
-	// drive is the deployment-mismatch guard.
+	// Seed a resumable apply whose stored (primary) deployment is a non-routable
+	// placeholder, but whose child operation carries the real, configured
+	// deployment. The operation's tasks are present and runnable, so the drive
+	// must route by the operation's deployment and reach completion.
 	now := time.Now()
 	apply := &storage.Apply{
-		ApplyIdentifier: fmt.Sprintf("apply-deploy-mismatch-%d", now.UnixNano()%100000),
+		ApplyIdentifier: fmt.Sprintf("apply-op-route-%d", now.UnixNano()%100000),
 		PlanID:          plan2.ID,
+		Database:        appDBName,
+		DatabaseType:    "mysql",
+		Deployment:      appDBName + "-primary",
+		Engine:          "spirit",
+		State:           state.Apply.Running,
+		Options:         []byte("{}"),
+		Environment:     "staging",
+		StartedAt:       &now,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+	applyDBID, err := ts.Storage.Applies().Create(ctx, apply)
+	require.NoError(t, err)
+
+	opID, err := ts.Storage.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID:    applyDBID,
+		Deployment: appDBName,
+		Target:     appDBName,
+		State:      state.ApplyOperation.Running,
+		StartedAt:  &now,
+	})
+	require.NoError(t, err)
+
+	for _, tc := range plan2.FlatDDLChanges() {
+		_, err := ts.Storage.Tasks().Create(ctx, &storage.Task{
+			TaskIdentifier:   fmt.Sprintf("task-op-route-%d", time.Now().UnixNano()),
+			ApplyID:          applyDBID,
+			ApplyOperationID: &opID,
+			PlanID:           plan2.ID,
+			Database:         appDBName,
+			DatabaseType:     "mysql",
+			Engine:           "spirit",
+			State:            state.Task.Running,
+			TableName:        tc.Table,
+			DDL:              tc.DDL,
+			DDLAction:        tc.Operation,
+			Options:          []byte("{}"),
+			Environment:      "staging",
+			CreatedAt:        now,
+			UpdatedAt:        now,
+		})
+		require.NoError(t, err)
+	}
+
+	// Age both rows so the operation-claim loop leases the operation on its
+	// first poll.
+	schemabotDB, err := sql.Open("mysql", schemabotDSN)
+	require.NoError(t, err)
+	require.NoError(t, schemabotDB.PingContext(ctx))
+	defer utils.CloseAndLog(schemabotDB)
+	_, err = schemabotDB.ExecContext(ctx, "UPDATE applies SET updated_at = NOW() - INTERVAL 10 MINUTE WHERE id = ?", applyDBID)
+	require.NoError(t, err)
+	_, err = schemabotDB.ExecContext(ctx, "UPDATE apply_operations SET updated_at = NOW() - INTERVAL 10 MINUTE WHERE id = ?", opID)
+	require.NoError(t, err)
+
+	ts.Service.StartOperator(t.Context())
+	defer ts.Service.StopOperator()
+
+	// The drive routes by the operation's deployment, so the operation reaches
+	// completed even though it diverges from the parent apply's stored
+	// deployment.
+	require.Eventually(t, func() bool {
+		op, err := ts.Storage.ApplyOperations().Get(ctx, opID)
+		require.NoError(t, err)
+		return op != nil && state.IsState(op.State, state.ApplyOperation.Completed)
+	}, 20*time.Second, 200*time.Millisecond,
+		"operator should drive the operation to completion via its own deployment")
+
+	op, err := ts.Storage.ApplyOperations().Get(ctx, opID)
+	require.NoError(t, err)
+	require.NotNil(t, op)
+	require.NotNil(t, op.CompletedAt, "completed operation stamps completed_at")
+
+	// The parent apply is derived from its operation rows, so it settles
+	// completed regardless of its non-routable primary deployment.
+	parent, err := ts.Storage.Applies().Get(ctx, applyDBID)
+	require.NoError(t, err)
+	require.NotNil(t, parent)
+	assert.Equal(t, state.Apply.Completed, parent.State,
+		"parent apply state is derived from its child operation, which completed")
+}
+
+// TestOperator_OperationMissingDeploymentFailsClosed covers the safety guard on
+// the operation-claim path: an apply_operations row with no deployment has no
+// routing key, so the operator must claim it but never drive it to a terminal
+// state — driving via any default deployment could run the wrong target.
+func TestOperator_OperationMissingDeploymentFailsClosed(t *testing.T) {
+	ctx := t.Context()
+	schemaSQL, err := os.ReadFile("testdata/myapp/mysql/schema/users.sql")
+	require.NoError(t, err)
+
+	appDBName, appDSN := createTestDB(t, "op_missing_deploy_")
+	ts := startTestServerOperator(t, appDBName, appDSN)
+
+	planResp := postJSON(t, "http://"+ts.Addr+"/api/plan", map[string]any{
+		"database": appDBName, "environment": "staging", "type": "mysql",
+		"schema_files": map[string]any{"default": map[string]any{"files": map[string]string{"users.sql": string(schemaSQL)}}},
+	})
+	planID, _ := planResp["plan_id"].(string)
+	require.NotEmpty(t, planID)
+	plan, err := ts.Storage.Plans().Get(ctx, planID)
+	require.NoError(t, err)
+	ts.Service.StopOperator()
+
+	// Seed a resumable apply and a child operation whose deployment is empty.
+	// The operation's tasks are present and runnable, so the only thing stopping
+	// the drive is the missing-deployment guard.
+	now := time.Now()
+	apply := &storage.Apply{
+		ApplyIdentifier: fmt.Sprintf("apply-no-deploy-%d", now.UnixNano()%100000),
+		PlanID:          plan.ID,
 		Database:        appDBName,
 		DatabaseType:    "mysql",
 		Deployment:      appDBName,
@@ -422,19 +533,19 @@ func TestOperator_OperationDeploymentMismatchFailsClosed(t *testing.T) {
 
 	opID, err := ts.Storage.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
 		ApplyID:    applyDBID,
-		Deployment: appDBName + "-divergent",
+		Deployment: "",
 		Target:     appDBName,
 		State:      state.ApplyOperation.Running,
 		StartedAt:  &now,
 	})
 	require.NoError(t, err)
 
-	for _, tc := range plan2.FlatDDLChanges() {
+	for _, tc := range plan.FlatDDLChanges() {
 		_, err := ts.Storage.Tasks().Create(ctx, &storage.Task{
-			TaskIdentifier:   fmt.Sprintf("task-mismatch-%d", time.Now().UnixNano()),
+			TaskIdentifier:   fmt.Sprintf("task-no-deploy-%d", time.Now().UnixNano()),
 			ApplyID:          applyDBID,
 			ApplyOperationID: &opID,
-			PlanID:           plan2.ID,
+			PlanID:           plan.ID,
 			Database:         appDBName,
 			DatabaseType:     "mysql",
 			Engine:           "spirit",
@@ -470,16 +581,16 @@ func TestOperator_OperationDeploymentMismatchFailsClosed(t *testing.T) {
 	defer ts.Service.StopOperator()
 
 	// The operator must actually claim the operation — claiming refreshes its
-	// heartbeat — so we know the deployment-mismatch guard was reached.
+	// heartbeat — so we know the missing-deployment guard was reached.
 	require.Eventually(t, func() bool {
 		op, err := ts.Storage.ApplyOperations().Get(ctx, opID)
 		require.NoError(t, err)
 		return op != nil && op.UpdatedAt.After(seededUpdatedAt)
 	}, 10*time.Second, 200*time.Millisecond,
-		"operator should claim the stale operation, reaching the deployment-mismatch guard")
+		"operator should claim the stale operation, reaching the missing-deployment guard")
 
 	// Having reached the guard, it must never drive the operation to a terminal
-	// state, because its deployment diverges from the parent apply's.
+	// state, because it has no deployment to route by.
 	neverTerminalDeadline := time.NewTimer(3 * time.Second)
 	defer neverTerminalDeadline.Stop()
 	neverTerminalPoll := time.NewTicker(200 * time.Millisecond)
@@ -494,7 +605,7 @@ func TestOperator_OperationDeploymentMismatchFailsClosed(t *testing.T) {
 			op, err := ts.Storage.ApplyOperations().Get(ctx, opID)
 			require.NoError(t, err)
 			if op != nil && state.IsTerminalApplyState(op.State) {
-				require.Failf(t, "operation reached terminal state", "operator must fail closed and never drive an operation whose deployment diverges from its parent apply; got state %q", op.State)
+				require.Failf(t, "operation reached terminal state", "operator must fail closed and never drive an operation with no deployment; got state %q", op.State)
 			}
 		}
 	}
@@ -508,7 +619,7 @@ func TestOperator_OperationDeploymentMismatchFailsClosed(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, parent)
 	assert.NotEqual(t, state.Apply.Completed, parent.State,
-		"parent apply must not be driven to completion through a mismatched operation")
+		"parent apply must not be driven to completion through an operation with no deployment")
 }
 
 // TestOperator_OperationWithoutTasksFailsClosed covers the fail-closed

--- a/pkg/api/operator.go
+++ b/pkg/api/operator.go
@@ -338,6 +338,7 @@ func (s *Service) recoverApplyOperation(ctx context.Context, workerID int, owner
 			"apply_operation_id", op.ID,
 			"apply_id", apply.ApplyIdentifier,
 			"database", apply.Database,
+			"deployment", op.Deployment,
 			"apply_deployment", apply.Deployment,
 			"environment", apply.Environment)
 		metrics.RecordOperatorClaimFailure(ctx, "missing_operation_deployment")

--- a/pkg/api/operator.go
+++ b/pkg/api/operator.go
@@ -228,7 +228,7 @@ func (s *Service) recoverApplies(ctx context.Context, workerID int) {
 	// Legacy FindNextApply path drives the whole apply (applyOperationID == 0).
 	// Failures are handled inside resumeClaimedApply; the whole-apply path has no
 	// operation row to terminalize, so the return values are not needed here.
-	_, _ = s.resumeClaimedApply(ctx, workerID, apply, 0)
+	_, _ = s.resumeClaimedApply(ctx, workerID, apply, 0, "")
 }
 
 // recoverApplyOperation claims work at the apply_operations (per-deployment)
@@ -324,21 +324,23 @@ func (s *Service) recoverApplyOperation(ctx context.Context, workerID int, owner
 	dualLeaseCtx := storage.WithOperationLease(applyLeaseCtx, opLease)
 
 	// The claimed operation row's deployment is the authoritative routing key
-	// for the drive, but resumeClaimedApply selects the Tern client from the
-	// parent apply's stored deployment. These are identical while one operation
-	// maps to one apply; if they ever diverge the worker would drive the wrong
-	// deployment, so fail closed rather than route to the parent's deployment.
-	if op.Deployment != apply.Deployment {
-		s.logger.Error("operator: claimed operation deployment does not match parent apply deployment; operation will not be driven",
+	// for the drive: RoutingClient.ResumeApplyOperation reloads the operation
+	// row, routes by its deployment, and fails closed when no client is
+	// configured for that deployment/environment. The parent apply's stored
+	// deployment is only the primary deployment and is not the routing source,
+	// so an operation deployment that differs from the parent is expected for
+	// multi-deployment applies. An empty operation deployment is a corrupt row
+	// with no routing key, so fail closed rather than fall back to a default.
+	if op.Deployment == "" {
+		s.logger.Error("operator: claimed operation is missing deployment metadata; operation will not be driven",
 			"worker", workerID,
 			"lease_owner", owner,
 			"apply_operation_id", op.ID,
 			"apply_id", apply.ApplyIdentifier,
 			"database", apply.Database,
-			"operation_deployment", op.Deployment,
 			"apply_deployment", apply.Deployment,
 			"environment", apply.Environment)
-		metrics.RecordOperatorClaimFailure(ctx, "deployment_mismatch")
+		metrics.RecordOperatorClaimFailure(ctx, "missing_operation_deployment")
 		return
 	}
 
@@ -351,7 +353,7 @@ func (s *Service) recoverApplyOperation(ctx context.Context, workerID int, owner
 	stopHeartbeat := s.startApplyOperationHeartbeat(runCtx, workerID, op, apply, cancelRun)
 	defer stopHeartbeat()
 
-	resumed, resumeErr := s.resumeClaimedApply(runCtx, workerID, apply, op.ID)
+	resumed, resumeErr := s.resumeClaimedApply(runCtx, workerID, apply, op.ID, op.Deployment)
 	stopHeartbeat()
 	if !resumed {
 		if errors.Is(resumeErr, tern.ErrNoTasksForApplyOperation) {
@@ -671,15 +673,38 @@ func (s *Service) failOperationWithoutTasks(opCtx, applyCtx context.Context, wor
 // the bool lets the operation-level claim loop decide whether to mark its
 // operation terminal, and the returned error lets it distinguish the fail-closed
 // no-tasks case (tern.ErrNoTasksForApplyOperation) from transient failures.
-func (s *Service) resumeClaimedApply(ctx context.Context, workerID int, apply *storage.Apply, applyOperationID int64) (bool, error) {
+func (s *Service) resumeClaimedApply(ctx context.Context, workerID int, apply *storage.Apply, applyOperationID int64, operationDeployment string) (bool, error) {
 	lease := apply.Lease()
 	start := s.clock.Now()
+
+	// operationDeployment is observability attribution only — RoutingClient
+	// reloads the operation row and routes by its own deployment. The
+	// operation-claim path passes the claimed op's deployment so logs/metrics
+	// name the deployment actually being driven; the legacy whole-apply path
+	// passes "" and falls back to the apply's stored deployment. For single-op
+	// applies the two are equal, so the attribution is unchanged.
+	deployment := operationDeployment
+	if deployment == "" {
+		stored, err := storedDeploymentForApply(apply)
+		if err != nil {
+			s.logger.Error("operator: claimed apply is missing stored deployment metadata",
+				"worker", workerID,
+				"apply_id", apply.ApplyIdentifier,
+				"database", apply.Database,
+				"environment", apply.Environment,
+				"error", err)
+			metrics.RecordOperatorResumeFailure(ctx, apply.Database, "", apply.Environment, "missing_deployment")
+			return false, err
+		}
+		deployment = stored
+	}
+
 	s.logger.Info("operator: claimed apply",
 		"worker", workerID,
 		"lease_owner", lease.Owner,
 		"apply_id", apply.ApplyIdentifier,
 		"database", apply.Database,
-		"deployment", apply.Deployment,
+		"deployment", deployment,
 		"environment", apply.Environment,
 		"state", apply.State,
 		"last_heartbeat", apply.UpdatedAt)
@@ -692,17 +717,6 @@ func (s *Service) resumeClaimedApply(ctx context.Context, workerID int, apply *s
 
 	previousState := apply.State
 
-	deployment, err := storedDeploymentForApply(apply)
-	if err != nil {
-		s.logger.Error("operator: claimed apply is missing stored deployment metadata",
-			"worker", workerID,
-			"apply_id", apply.ApplyIdentifier,
-			"database", apply.Database,
-			"environment", apply.Environment,
-			"error", err)
-		metrics.RecordOperatorResumeFailure(ctx, apply.Database, "", apply.Environment, "missing_deployment")
-		return false, err
-	}
 	client, err := s.RoutingTernClient()
 	if err != nil {
 		s.logger.Error("operator: failed to get routing client",

--- a/pkg/api/operator_test.go
+++ b/pkg/api/operator_test.go
@@ -99,7 +99,7 @@ func TestResumeClaimedApplyRoutesRecoveredObserver(t *testing.T) {
 		State:           state.Apply.Pending,
 	}
 
-	resumed, err := svc.resumeClaimedApply(t.Context(), 1, apply, 0)
+	resumed, err := svc.resumeClaimedApply(t.Context(), 1, apply, 0, "")
 
 	require.NoError(t, err)
 	assert.True(t, resumed)

--- a/pkg/metrics/README.md
+++ b/pkg/metrics/README.md
@@ -92,7 +92,7 @@ available, such as `repository`, `github_app`, and `installation_id`.
 
 **status** (GitHub API): `success`, `error`, `unknown`
 
-**reason** (operator claim failures): `storage_error`, `expire_retryable_error`, `missing_lease_token`, `operation_storage_error`, `operation_parent_claim_error`, `operation_parent_not_claimable`, `missing_operation_deployment`, `unknown`
+**reason** (operator claim failures): `storage_error`, `expire_retryable_error`, `missing_lease_token`, `operation_storage_error`, `missing_operation_lease_token`, `operation_parent_claim_error`, `operation_parent_not_claimable`, `missing_operation_deployment`, `stop_reconciliation_claim_error`, `stop_reconciliation_missing_lease_token`, `unknown`
 
 **reason** (operator resume failures): `missing_deployment`, `no_client`, `resume_error`, `lease_lost`, `retry_budget_exhausted`, `recovery_window_expired`
 

--- a/pkg/metrics/README.md
+++ b/pkg/metrics/README.md
@@ -92,7 +92,7 @@ available, such as `repository`, `github_app`, and `installation_id`.
 
 **status** (GitHub API): `success`, `error`, `unknown`
 
-**reason** (operator claim failures): `storage_error`, `expire_retryable_error`, `missing_lease_token`, `operation_storage_error`, `operation_parent_claim_error`, `operation_parent_not_claimable`, `unknown`
+**reason** (operator claim failures): `storage_error`, `expire_retryable_error`, `missing_lease_token`, `operation_storage_error`, `operation_parent_claim_error`, `operation_parent_not_claimable`, `missing_operation_deployment`, `unknown`
 
 **reason** (operator resume failures): `missing_deployment`, `no_client`, `resume_error`, `lease_lost`, `retry_budget_exhausted`, `recovery_window_expired`
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -659,13 +659,16 @@ func RecordOperatorResumeFailure(ctx context.Context, database, deployment, envi
 }
 
 var knownOperatorClaimFailureReasons = map[string]bool{
-	"expire_retryable_error":         true,
-	"missing_lease_token":            true,
-	"storage_error":                  true,
-	"operation_storage_error":        true,
-	"operation_parent_claim_error":   true,
-	"operation_parent_not_claimable": true,
-	"missing_operation_deployment":   true,
+	"expire_retryable_error":                  true,
+	"missing_lease_token":                     true,
+	"storage_error":                           true,
+	"operation_storage_error":                 true,
+	"missing_operation_lease_token":           true,
+	"operation_parent_claim_error":            true,
+	"operation_parent_not_claimable":          true,
+	"missing_operation_deployment":            true,
+	"stop_reconciliation_claim_error":         true,
+	"stop_reconciliation_missing_lease_token": true,
 }
 
 // RecordOperatorClaimFailure increments the operator claim failure counter.

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -665,6 +665,7 @@ var knownOperatorClaimFailureReasons = map[string]bool{
 	"operation_storage_error":        true,
 	"operation_parent_claim_error":   true,
 	"operation_parent_not_claimable": true,
+	"missing_operation_deployment":   true,
 }
 
 // RecordOperatorClaimFailure increments the operator claim failure counter.


### PR DESCRIPTION
## What

The operator no longer rejects an `apply_operation` whose deployment differs from the parent apply's stored deployment. The operation row's deployment is now the authoritative routing key; the parent apply's deployment is just the **primary** deployment. Only an operation with an **empty** deployment (a corrupt row with no routing key) fails closed. Logs and metrics on the op-claim path are attributed to the operation's deployment.

## Why

`RoutingClient.ResumeApplyOperation` already reloads the operation row, routes by `operation.Deployment`, and fails closed on unconfigured deployments — so the old `op.Deployment != apply.Deployment` gate was obsolete and blocked multi-deployment fan-out for no safety benefit. Single-op applies are byte-for-byte unchanged (op deployment == apply deployment); multi-op stays dormant behind the config gate until the final flip.

## Flow
```
BEFORE                                AFTER
---
claim op -> claim parent              claim op -> claim parent
|                                     |
v                                     v
op.Deployment != apply.Deployment?    op.Deployment == "" ?
|                                     |
yes -+-> fail closed  (X)            yes -+-> fail closed  (X) corrupt row
|                                     |
no  -+                                no  -+
|                                     |
v                                     v
drive                                 drive, routed by op.Deployment
(logs use apply.Deployment)           (logs/metrics use op.Deployment)
```

Single-op: `op.Deployment == apply.Deployment`, so the AFTER path collapses to the BEFORE path.
