### PR TITLE
feat(inventory): flexible AWS Secrets Manager credential backend

### DIFF
--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -458,11 +458,15 @@ type EtreCredentialsConfig struct {
 	Username    string `yaml:"username,omitempty"`
 	PasswordRef string `yaml:"password_ref,omitempty"`
 
-	// awssm backend: assume a per-target IAM role and read a JSON
-	// {username, password} secret from AWS Secrets Manager. RoleARN may carry an
-	// {account} placeholder and SecretName a {target} placeholder; ExternalID is
-	// an optional STS external id; AccountAttribute names the entity attribute
-	// holding the target's AWS account id (defaults to aws_account_id).
+	// awssm backend: read a secret from AWS Secrets Manager and parse it as a JSON
+	// {username, password} payload (or, for engines like Vitess, a token decoded
+	// by the assembler). SecretName may carry {target} and {attribute} placeholders
+	// to locate per-target or per-cluster secrets. RoleARN is optional: when set,
+	// the backend assumes a per-target role (carrying an {account} placeholder) so
+	// one data plane can read secrets across accounts, and AccountAttribute names
+	// the entity attribute holding the target's AWS account id (defaults to
+	// aws_account_id); when empty, secrets are read from the caller's own account.
+	// ExternalID is an optional STS external id used only with RoleARN.
 	Region           string `yaml:"region,omitempty"`
 	RoleARN          string `yaml:"role_arn,omitempty"`
 	ExternalID       string `yaml:"external_id,omitempty"`

--- a/pkg/awscreds/awscreds.go
+++ b/pkg/awscreds/awscreds.go
@@ -1,18 +1,20 @@
-// Package awscreds resolves database credentials from AWS Secrets Manager,
-// assuming a per-target IAM role first so a single data plane can read secrets
-// across many AWS accounts.
+// Package awscreds resolves database credentials from AWS Secrets Manager.
 //
-// It implements inventory.CredentialResolver: the target's AWS account comes
-// from an endpoint attribute (surfaced by endpoint resolution), the resolver
-// assumes a role in that account, reads the secret, and parses it as a JSON
-// {username, password} payload. Credential values come from Secrets Manager,
-// never from the inventory source.
+// It implements inventory.CredentialResolver. The secret name is templated over
+// the resolved target and its entity attributes, so one configuration can locate
+// per-target or per-cluster secrets. By default it reads from the caller's own
+// AWS account; when a role ARN is configured it assumes a per-target role first,
+// so a single data plane can read secrets across many AWS accounts. The fetched
+// secret is parsed as a JSON {username, password} payload, or interpreted by a
+// configured decoder (for example a PlanetScale token). Credential values come
+// from Secrets Manager, never from the inventory source.
 package awscreds
 
 import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"strings"
 	"sync"
 
@@ -28,27 +30,35 @@ import (
 // account id when one is not configured.
 const defaultAccountAttribute = "aws_account_id"
 
+// secretNamePlaceholderRe matches "{name}" placeholders in a secret name
+// template. "{target}" is the request target; any other name is an entity
+// attribute resolved for the target.
+var secretNamePlaceholderRe = regexp.MustCompile(`\{([a-zA-Z0-9_]+)\}`)
+
 // Config configures a Resolver.
 type Config struct {
 	// AWSConfig is the base AWS config used to assume roles and build Secrets
 	// Manager clients.
 	AWSConfig aws.Config
-	// Region is the region for assumed-role sessions and Secrets Manager.
+	// Region is the region for Secrets Manager (and assumed-role sessions, when a
+	// role is configured).
 	Region string
-	// RoleARN is the IAM role assumed in the target account. It may contain an
-	// "{account}" placeholder, replaced with the target's AWS account id. Using a
-	// full ARN (rather than a bare role name) keeps the partition and role path
-	// explicit, so non-commercial partitions (aws-us-gov, aws-cn) work — e.g.
-	// "arn:aws:iam::{account}:role/tern-assumed".
+	// RoleARN is the IAM role assumed in the target account. When empty, secrets
+	// are read from the caller's own account without assuming a role. When set, it
+	// may contain an "{account}" placeholder, replaced with the target's AWS
+	// account id. Using a full ARN (rather than a bare role name) keeps the
+	// partition and role path explicit, so non-commercial partitions (aws-us-gov,
+	// aws-cn) work — e.g. "arn:aws:iam::{account}:role/tern-assumed".
 	RoleARN string
 	// ExternalID is an optional STS AssumeRole external id, required by some
-	// cross-account trust policies.
+	// cross-account trust policies. It is only used when RoleARN is set.
 	ExternalID string
-	// SecretName is the Secrets Manager secret id. It may contain a "{target}"
-	// placeholder, replaced with the request target for per-target secrets.
+	// SecretName is the Secrets Manager secret id. It may contain placeholders:
+	// "{target}" (the request target) and "{attribute}" (any resolved entity
+	// attribute), replaced to locate per-target or per-cluster secrets.
 	SecretName string
 	// AccountAttribute is the endpoint attribute holding the target's AWS account
-	// id. Defaults to "aws_account_id".
+	// id. Defaults to "aws_account_id". Only required when RoleARN is set.
 	AccountAttribute string
 	// Decode, when set, interprets the fetched secret into Credentials (for
 	// example a PlanetScale token). When nil the secret is parsed as a JSON
@@ -56,30 +66,30 @@ type Config struct {
 	Decode inventory.SecretDecoder
 }
 
-// Resolver resolves credentials from Secrets Manager via per-account assumed
-// roles.
+// Resolver resolves credentials from Secrets Manager, optionally via per-account
+// assumed roles.
 type Resolver struct {
-	accountAttr string
-	secretName  string
-	fetch       secretFetcher
-	decode      inventory.SecretDecoder
+	accountAttr    string
+	secretName     string
+	fetch          secretFetcher
+	decode         inventory.SecretDecoder
+	requireAccount bool
 }
 
 var _ inventory.CredentialResolver = (*Resolver)(nil)
 
-// secretFetcher reads a raw secret value for a target AWS account.
+// secretFetcher reads a raw secret value, optionally scoped to a target AWS
+// account (ignored by backends that read from the caller's own account).
 type secretFetcher interface {
 	FetchSecret(ctx context.Context, accountID, secretName string) (string, error)
 }
 
-// New builds a Resolver backed by per-account assumed-role Secrets Manager
-// clients.
+// New builds a Resolver. With a role ARN it assumes a per-account role to read
+// secrets across accounts; without one it reads from the caller's own account.
 func New(cfg Config) (*Resolver, error) {
 	switch {
 	case cfg.Region == "":
 		return nil, fmt.Errorf("region is required")
-	case cfg.RoleARN == "":
-		return nil, fmt.Errorf("role ARN is required")
 	case cfg.SecretName == "":
 		return nil, fmt.Errorf("secret name is required")
 	}
@@ -87,6 +97,17 @@ func New(cfg Config) (*Resolver, error) {
 	if accountAttr == "" {
 		accountAttr = defaultAccountAttribute
 	}
+
+	// No role: read from the caller's own account with a single client. A role
+	// switches on per-account assume-role so one data plane can read secrets
+	// across many accounts; the target account then comes from an attribute.
+	if cfg.RoleARN == "" {
+		regionalCfg := cfg.AWSConfig
+		regionalCfg.Region = cfg.Region
+		fetch := &ownAccountFetcher{client: secretsmanager.NewFromConfig(regionalCfg)}
+		return newResolver(accountAttr, cfg.SecretName, fetch, cfg.Decode, false), nil
+	}
+
 	fetch := &assumeRoleFetcher{
 		awsCfg:     cfg.AWSConfig,
 		region:     cfg.Region,
@@ -94,35 +115,52 @@ func New(cfg Config) (*Resolver, error) {
 		externalID: cfg.ExternalID,
 		clients:    make(map[string]*secretsmanager.Client),
 	}
-	return newResolver(accountAttr, cfg.SecretName, fetch, cfg.Decode), nil
+	return newResolver(accountAttr, cfg.SecretName, fetch, cfg.Decode, true), nil
 }
 
 // newResolver constructs a Resolver over a given fetcher, so tests can inject a
 // fake that does not call AWS.
-func newResolver(accountAttr, secretName string, fetch secretFetcher, decode inventory.SecretDecoder) *Resolver {
-	return &Resolver{accountAttr: accountAttr, secretName: secretName, fetch: fetch, decode: decode}
+func newResolver(accountAttr, secretName string, fetch secretFetcher, decode inventory.SecretDecoder, requireAccount bool) *Resolver {
+	return &Resolver{accountAttr: accountAttr, secretName: secretName, fetch: fetch, decode: decode, requireAccount: requireAccount}
 }
 
-// ResolveCredentials reads the target's account from attrs, fetches the secret
-// from that account, and parses it as a JSON {username, password} payload. It
-// fails closed: a missing account attribute, a fetch failure, an unparseable
-// secret, or a missing username/password are all errors.
+// SecretNameAttributes returns the entity attribute names referenced by a secret
+// name template — every "{placeholder}" except "{target}" — so callers can
+// ensure the resolver surfaces them.
+func SecretNameAttributes(template string) []string {
+	var attrs []string
+	for _, m := range secretNamePlaceholderRe.FindAllStringSubmatch(template, -1) {
+		if m[1] != "target" {
+			attrs = append(attrs, m[1])
+		}
+	}
+	return attrs
+}
+
+// ResolveCredentials fetches the secret for the target and parses it as a JSON
+// {username, password} payload (or via the configured decoder). It fails closed:
+// a missing required account attribute, an unresolved secret-name placeholder, a
+// fetch failure, an unparseable secret, or a missing username/password are all
+// errors.
 func (r *Resolver) ResolveCredentials(ctx context.Context, req inventory.Request, attrs map[string]string) (*inventory.Credentials, error) {
 	accountID := attrs[r.accountAttr]
-	if accountID == "" {
+	if r.requireAccount && accountID == "" {
 		return nil, fmt.Errorf("target %q has no %q attribute for assume-role credential resolution", req.Target, r.accountAttr)
 	}
 
-	secretName := strings.ReplaceAll(r.secretName, "{target}", req.Target)
+	secretName, err := r.renderSecretName(req, attrs)
+	if err != nil {
+		return nil, err
+	}
 	raw, err := r.fetch.FetchSecret(ctx, accountID, secretName)
 	if err != nil {
-		return nil, fmt.Errorf("fetch secret %q for target %q in account %s: %w", secretName, req.Target, accountID, err)
+		return nil, fmt.Errorf("fetch secret %q for target %q: %w", secretName, req.Target, err)
 	}
 
 	if r.decode != nil {
 		creds, err := r.decode(raw)
 		if err != nil {
-			return nil, fmt.Errorf("decode secret %q for target %q in account %s: %w", secretName, req.Target, accountID, err)
+			return nil, fmt.Errorf("decode secret %q for target %q: %w", secretName, req.Target, err)
 		}
 		return creds, nil
 	}
@@ -140,6 +178,53 @@ func (r *Resolver) ResolveCredentials(ctx context.Context, req inventory.Request
 	return &inventory.Credentials{Username: parsed.Username, Password: parsed.Password}, nil
 }
 
+// renderSecretName replaces "{target}" with the request target and every other
+// "{attribute}" placeholder with the resolved attribute value, failing closed if
+// any referenced attribute was not resolved.
+func (r *Resolver) renderSecretName(req inventory.Request, attrs map[string]string) (string, error) {
+	var missing []string
+	rendered := secretNamePlaceholderRe.ReplaceAllStringFunc(r.secretName, func(match string) string {
+		key := match[1 : len(match)-1]
+		if key == "target" {
+			return req.Target
+		}
+		if v := attrs[key]; v != "" {
+			return v
+		}
+		missing = append(missing, key)
+		return match
+	})
+	if len(missing) > 0 {
+		return "", fmt.Errorf("secret name template %q for target %q references unresolved attribute(s): %s", r.secretName, req.Target, strings.Join(missing, ", "))
+	}
+	return rendered, nil
+}
+
+// getSecretString reads a string secret value, rejecting binary secrets.
+func getSecretString(ctx context.Context, client *secretsmanager.Client, secretName string) (string, error) {
+	resp, err := client.GetSecretValue(ctx, &secretsmanager.GetSecretValueInput{
+		SecretId: aws.String(secretName),
+	})
+	if err != nil {
+		return "", fmt.Errorf("get secret value: %w", err)
+	}
+	if resp.SecretString == nil {
+		return "", fmt.Errorf("secret %q has no string value (binary secrets are not supported)", secretName)
+	}
+	return *resp.SecretString, nil
+}
+
+// ownAccountFetcher reads secrets from the caller's own account using a single
+// Secrets Manager client — no STS AssumeRole. The account id is ignored.
+type ownAccountFetcher struct {
+	client *secretsmanager.Client
+}
+
+// FetchSecret returns the raw secret string from the caller's own account.
+func (f *ownAccountFetcher) FetchSecret(ctx context.Context, _ string, secretName string) (string, error) {
+	return getSecretString(ctx, f.client, secretName)
+}
+
 // assumeRoleFetcher reads secrets via Secrets Manager using per-account
 // assumed-role credentials, caching one client per account to avoid repeated
 // STS AssumeRole calls.
@@ -155,17 +240,7 @@ type assumeRoleFetcher struct {
 
 // FetchSecret returns the raw secret string from the target account.
 func (f *assumeRoleFetcher) FetchSecret(ctx context.Context, accountID, secretName string) (string, error) {
-	client := f.clientForAccount(accountID)
-	resp, err := client.GetSecretValue(ctx, &secretsmanager.GetSecretValueInput{
-		SecretId: aws.String(secretName),
-	})
-	if err != nil {
-		return "", fmt.Errorf("get secret value: %w", err)
-	}
-	if resp.SecretString == nil {
-		return "", fmt.Errorf("secret %q has no string value (binary secrets are not supported)", secretName)
-	}
-	return *resp.SecretString, nil
+	return getSecretString(ctx, f.clientForAccount(accountID), secretName)
 }
 
 func (f *assumeRoleFetcher) clientForAccount(accountID string) *secretsmanager.Client {

--- a/pkg/awscreds/awscreds.go
+++ b/pkg/awscreds/awscreds.go
@@ -152,15 +152,16 @@ func (r *Resolver) ResolveCredentials(ctx context.Context, req inventory.Request
 	if err != nil {
 		return nil, err
 	}
+	where := targetContext(req.Target, accountID)
 	raw, err := r.fetch.FetchSecret(ctx, accountID, secretName)
 	if err != nil {
-		return nil, fmt.Errorf("fetch secret %q for target %q: %w", secretName, req.Target, err)
+		return nil, fmt.Errorf("fetch secret %q for %s: %w", secretName, where, err)
 	}
 
 	if r.decode != nil {
 		creds, err := r.decode(raw)
 		if err != nil {
-			return nil, fmt.Errorf("decode secret %q for target %q: %w", secretName, req.Target, err)
+			return nil, fmt.Errorf("decode secret %q for %s: %w", secretName, where, err)
 		}
 		return creds, nil
 	}
@@ -170,12 +171,22 @@ func (r *Resolver) ResolveCredentials(ctx context.Context, req inventory.Request
 		Password string `json:"password"`
 	}
 	if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
-		return nil, fmt.Errorf("parse secret %q for target %q as JSON {username, password}: %w", secretName, req.Target, err)
+		return nil, fmt.Errorf("parse secret %q for %s as JSON {username, password}: %w", secretName, where, err)
 	}
 	if parsed.Username == "" || parsed.Password == "" {
-		return nil, fmt.Errorf("secret %q for target %q is missing a username or password", secretName, req.Target)
+		return nil, fmt.Errorf("secret %q for %s is missing a username or password", secretName, where)
 	}
 	return &inventory.Credentials{Username: parsed.Username, Password: parsed.Password}, nil
+}
+
+// targetContext describes the target for error messages, including its AWS
+// account id when assume-role mode resolved one (own-account mode has none), so
+// cross-account failures stay diagnosable.
+func targetContext(target, accountID string) string {
+	if accountID != "" {
+		return fmt.Sprintf("target %q in account %s", target, accountID)
+	}
+	return fmt.Sprintf("target %q", target)
 }
 
 // renderSecretName replaces "{target}" with the request target and every other

--- a/pkg/awscreds/awscreds_test.go
+++ b/pkg/awscreds/awscreds_test.go
@@ -151,6 +151,22 @@ func TestSecretNameAttributes(t *testing.T) {
 	assert.Empty(t, SecretNameAttributes("static-secret"))
 }
 
+// Assume-role failures carry the target AWS account id so cross-account
+// problems stay diagnosable; own-account mode has no account to report.
+func TestResolverFetchErrorIncludesAccountInAssumeRoleMode(t *testing.T) {
+	assumeRole := newResolver("aws_account_id", "secret", &fakeFetcher{err: fmt.Errorf("access denied")}, nil, true)
+	_, err := assumeRole.ResolveCredentials(t.Context(),
+		inventory.Request{Target: "orders-dsid"},
+		map[string]string{"aws_account_id": "123456789012"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "123456789012")
+
+	ownAccount := newResolver("aws_account_id", "secret", &fakeFetcher{err: fmt.Errorf("access denied")}, nil, false)
+	_, err = ownAccount.ResolveCredentials(t.Context(), inventory.Request{Target: "orders-dsid"}, nil)
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "in account")
+}
+
 func TestNewValidatesConfig(t *testing.T) {
 	base := Config{Region: "us-west-2", RoleARN: "arn:aws:iam::{account}:role/tern-assumed", SecretName: "secret"}
 

--- a/pkg/awscreds/awscreds_test.go
+++ b/pkg/awscreds/awscreds_test.go
@@ -28,7 +28,7 @@ func (f *fakeFetcher) FetchSecret(_ context.Context, accountID, secretName strin
 
 func TestResolverReadsJSONSecretForTargetAccount(t *testing.T) {
 	fetch := &fakeFetcher{payload: `{"username":"spirit","password":"s3cret"}`}
-	r := newResolver("aws_account_id", "ods-rds-spirit-password", fetch, nil)
+	r := newResolver("aws_account_id", "ods-rds-spirit-password", fetch, nil, true)
 
 	creds, err := r.ResolveCredentials(t.Context(),
 		inventory.Request{Target: "orders-dsid"},
@@ -44,7 +44,7 @@ func TestResolverReadsJSONSecretForTargetAccount(t *testing.T) {
 // The secret name may carry a {target} placeholder for per-target secrets.
 func TestResolverTemplatesSecretNameByTarget(t *testing.T) {
 	fetch := &fakeFetcher{payload: `{"username":"ddl","password":"pw"}`}
-	r := newResolver("aws_account_id", "schemabot/{target}/ddl", fetch, nil)
+	r := newResolver("aws_account_id", "schemabot/{target}/ddl", fetch, nil, true)
 
 	_, err := r.ResolveCredentials(t.Context(),
 		inventory.Request{Target: "orders-dsid"},
@@ -54,7 +54,7 @@ func TestResolverTemplatesSecretNameByTarget(t *testing.T) {
 }
 
 func TestResolverFailsWhenAccountAttributeMissing(t *testing.T) {
-	r := newResolver("aws_account_id", "secret", &fakeFetcher{payload: `{"username":"u","password":"p"}`}, nil)
+	r := newResolver("aws_account_id", "secret", &fakeFetcher{payload: `{"username":"u","password":"p"}`}, nil, true)
 
 	_, err := r.ResolveCredentials(t.Context(), inventory.Request{Target: "orders-dsid"}, nil)
 	require.Error(t, err)
@@ -62,7 +62,7 @@ func TestResolverFailsWhenAccountAttributeMissing(t *testing.T) {
 }
 
 func TestResolverPropagatesFetchError(t *testing.T) {
-	r := newResolver("aws_account_id", "secret", &fakeFetcher{err: fmt.Errorf("access denied")}, nil)
+	r := newResolver("aws_account_id", "secret", &fakeFetcher{err: fmt.Errorf("access denied")}, nil, true)
 
 	_, err := r.ResolveCredentials(t.Context(),
 		inventory.Request{Target: "orders-dsid"},
@@ -72,7 +72,7 @@ func TestResolverPropagatesFetchError(t *testing.T) {
 }
 
 func TestResolverFailsOnNonJSONSecret(t *testing.T) {
-	r := newResolver("aws_account_id", "secret", &fakeFetcher{payload: "not-json"}, nil)
+	r := newResolver("aws_account_id", "secret", &fakeFetcher{payload: "not-json"}, nil, true)
 
 	_, err := r.ResolveCredentials(t.Context(),
 		inventory.Request{Target: "orders-dsid"},
@@ -82,7 +82,7 @@ func TestResolverFailsOnNonJSONSecret(t *testing.T) {
 }
 
 func TestResolverFailsOnIncompleteSecret(t *testing.T) {
-	r := newResolver("aws_account_id", "secret", &fakeFetcher{payload: `{"username":"spirit"}`}, nil)
+	r := newResolver("aws_account_id", "secret", &fakeFetcher{payload: `{"username":"spirit"}`}, nil, true)
 
 	_, err := r.ResolveCredentials(t.Context(),
 		inventory.Request{Target: "orders-dsid"},
@@ -96,7 +96,7 @@ func TestResolverFailsOnIncompleteSecret(t *testing.T) {
 // PlanetScale token read through the same assume-role path.
 func TestResolverUsesDecoder(t *testing.T) {
 	fetch := &fakeFetcher{payload: `{"token":"tok-id=tok-secret"}`}
-	r := newResolver("aws_account_id", "secret", fetch, inventory.DecodePlanetScaleSecret)
+	r := newResolver("aws_account_id", "secret", fetch, inventory.DecodePlanetScaleSecret, true)
 
 	creds, err := r.ResolveCredentials(t.Context(),
 		inventory.Request{Target: "orders-dsid"},
@@ -105,6 +105,50 @@ func TestResolverUsesDecoder(t *testing.T) {
 	assert.Empty(t, creds.Username, "a PlanetScale credential carries no username")
 	assert.Equal(t, "tok-id", creds.Metadata["token_name"])
 	assert.Equal(t, "tok-secret", creds.Metadata["token_value"])
+}
+
+// The secret name may template over resolved entity attributes for per-cluster
+// secret naming, not just the target.
+func TestResolverTemplatesSecretNameByAttribute(t *testing.T) {
+	fetch := &fakeFetcher{payload: `{"username":"ddl","password":"pw"}`}
+	r := newResolver("aws_account_id", "{cluster}_schemabot_password", fetch, nil, true)
+
+	_, err := r.ResolveCredentials(t.Context(),
+		inventory.Request{Target: "orders-dsid"},
+		map[string]string{"aws_account_id": "123456789012", "cluster": "orders-mysql"})
+	require.NoError(t, err)
+	assert.Equal(t, "orders-mysql_schemabot_password", fetch.gotSecret)
+}
+
+// A secret-name placeholder that the resolver did not surface fails closed
+// rather than fetching a wrong (partially templated) secret name.
+func TestResolverFailsOnUnresolvedSecretNameAttribute(t *testing.T) {
+	r := newResolver("aws_account_id", "{cluster}_password", &fakeFetcher{payload: `{"username":"u","password":"p"}`}, nil, true)
+
+	_, err := r.ResolveCredentials(t.Context(),
+		inventory.Request{Target: "orders-dsid"},
+		map[string]string{"aws_account_id": "123456789012"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cluster")
+}
+
+// Own-account mode (no role) reads from the caller's account, so it neither
+// requires nor uses the account attribute.
+func TestResolverOwnAccountModeSkipsAccountRequirement(t *testing.T) {
+	fetch := &fakeFetcher{payload: `{"username":"ddl","password":"pw"}`}
+	r := newResolver("aws_account_id", "schemabot_password", fetch, nil, false)
+
+	creds, err := r.ResolveCredentials(t.Context(), inventory.Request{Target: "orders-dsid"}, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "schemabot_password", fetch.gotSecret)
+	assert.Empty(t, fetch.gotAccount, "own-account mode does not scope to an account")
+	assert.Equal(t, "ddl", creds.Username)
+}
+
+func TestSecretNameAttributes(t *testing.T) {
+	assert.Equal(t, []string{"cluster"}, SecretNameAttributes("{cluster}_{target}_password"))
+	assert.Empty(t, SecretNameAttributes("schemabot/{target}/ddl"))
+	assert.Empty(t, SecretNameAttributes("static-secret"))
 }
 
 func TestNewValidatesConfig(t *testing.T) {
@@ -119,11 +163,12 @@ func TestNewValidatesConfig(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "region")
 
+	// RoleARN is optional: without it, secrets are read from the caller's own
+	// account, so New succeeds.
 	noRole := base
 	noRole.RoleARN = ""
 	_, err = New(noRole)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "role")
+	require.NoError(t, err)
 
 	noSecret := base
 	noSecret.SecretName = ""

--- a/pkg/cmd/commands/serve.go
+++ b/pkg/cmd/commands/serve.go
@@ -493,12 +493,11 @@ func buildCredentialResolver(ctx context.Context, cfg api.EtreCredentialsConfig,
 	case credentialTypeAWSSM:
 		// Validate required fields with config-path context before loading AWS
 		// config, so a misconfiguration fails fast and actionably instead of
-		// after (potentially slow) credential-chain resolution.
+		// after (potentially slow) credential-chain resolution. role_arn is
+		// optional: without it the backend reads from the caller's own account.
 		switch {
 		case cfg.Region == "":
 			return nil, fmt.Errorf("target_resolver.etre.credentials.region is required for the awssm backend")
-		case cfg.RoleARN == "":
-			return nil, fmt.Errorf("target_resolver.etre.credentials.role_arn is required for the awssm backend")
 		case cfg.SecretName == "":
 			return nil, fmt.Errorf("target_resolver.etre.credentials.secret_name is required for the awssm backend")
 		}
@@ -541,11 +540,20 @@ func resolverAttributeFields(cfg api.EtreConfig) []string {
 		fields = ensureField(fields, orgAttr)
 	}
 	if credentialType(cfg.Credentials) == credentialTypeAWSSM {
-		accountAttr := cfg.Credentials.AccountAttribute
-		if accountAttr == "" {
-			accountAttr = "aws_account_id"
+		// Assume-role mode (role_arn set) resolves the target account from an
+		// attribute; own-account mode does not need it.
+		if cfg.Credentials.RoleARN != "" {
+			accountAttr := cfg.Credentials.AccountAttribute
+			if accountAttr == "" {
+				accountAttr = "aws_account_id"
+			}
+			fields = ensureField(fields, accountAttr)
 		}
-		fields = ensureField(fields, accountAttr)
+		// The secret name may template over resolved attributes; surface those so
+		// the resolver fetches them for the credential backend.
+		for _, attr := range awscreds.SecretNameAttributes(cfg.Credentials.SecretName) {
+			fields = ensureField(fields, attr)
+		}
 	}
 	return fields
 }

--- a/pkg/cmd/commands/serve_grpc_test.go
+++ b/pkg/cmd/commands/serve_grpc_test.go
@@ -116,9 +116,15 @@ func TestBuildCredentialResolverAWSSMRequiresFields(t *testing.T) {
 	_, err := buildCredentialResolver(t.Context(), base, nil)
 	require.NoError(t, err)
 
+	// role_arn is optional: without it the backend reads from the caller's own
+	// account, so the resolver still builds.
+	ownAccount := base
+	ownAccount.RoleARN = ""
+	_, err = buildCredentialResolver(t.Context(), ownAccount, nil)
+	require.NoError(t, err)
+
 	cases := map[string]func(*api.EtreCredentialsConfig){
 		"region":      func(c *api.EtreCredentialsConfig) { c.Region = "" },
-		"role_arn":    func(c *api.EtreCredentialsConfig) { c.RoleARN = "" },
 		"secret_name": func(c *api.EtreCredentialsConfig) { c.SecretName = "" },
 	}
 	for field, mutate := range cases {
@@ -132,17 +138,34 @@ func TestBuildCredentialResolverAWSSMRequiresFields(t *testing.T) {
 
 // The assume-role backend's account attribute is surfaced to the resolver even
 // when not listed in attribute_fields, so credential resolution can read it.
-func TestCredentialAttributeFieldsIncludesAccountAttribute(t *testing.T) {
-	withDefault := api.EtreConfig{
+func TestCredentialAttributeFields(t *testing.T) {
+	// Assume-role mode (role_arn set) resolves the target account from an
+	// attribute, defaulting to aws_account_id.
+	assumeRole := api.EtreConfig{
 		AttributeFields: []string{"region"},
-		Credentials:     api.EtreCredentialsConfig{Type: "awssm"},
+		Credentials:     api.EtreCredentialsConfig{Type: "awssm", RoleARN: "arn:aws:iam::{account}:role/ddl", SecretName: "secret"},
 	}
-	assert.Equal(t, []string{"region", "aws_account_id"}, resolverAttributeFields(withDefault))
+	assert.Equal(t, []string{"region", "aws_account_id"}, resolverAttributeFields(assumeRole))
 
+	// A custom account attribute is surfaced instead of the default.
 	custom := api.EtreConfig{
-		Credentials: api.EtreCredentialsConfig{Type: "awssm", AccountAttribute: "account"},
+		Credentials: api.EtreCredentialsConfig{Type: "awssm", RoleARN: "arn:aws:iam::{account}:role/ddl", AccountAttribute: "account", SecretName: "secret"},
 	}
 	assert.Equal(t, []string{"account"}, resolverAttributeFields(custom))
+
+	// Own-account mode (no role_arn) needs no account attribute.
+	ownAccount := api.EtreConfig{
+		AttributeFields: []string{"region"},
+		Credentials:     api.EtreCredentialsConfig{Type: "awssm", SecretName: "secret"},
+	}
+	assert.Equal(t, []string{"region"}, resolverAttributeFields(ownAccount))
+
+	// A secret_name templated over entity attributes surfaces those attributes so
+	// the resolver fetches them for the credential backend.
+	templated := api.EtreConfig{
+		Credentials: api.EtreCredentialsConfig{Type: "awssm", SecretName: "{cluster}_schemabot_password"},
+	}
+	assert.Equal(t, []string{"cluster"}, resolverAttributeFields(templated))
 
 	secretRef := api.EtreConfig{
 		AttributeFields: []string{"region"},


### PR DESCRIPTION
## Why this matters

The Secrets Manager credential backend assumed every secret is fetched via a cross-account **assume-role** and named by the **request target**. Many deployments instead keep credentials in the data plane's *own* account and name secrets per **cluster**. Today that forces an embedder to write a bespoke `inventory.CredentialResolver` — code that should not need to exist when the only difference is naming and account scope.

## What it does

Generalizes the `awssm` backend so both shapes are config-driven:

- **`role_arn` is optional.** When unset, secrets are read from the caller's own AWS account with a single client; the account attribute is neither required nor surfaced. When set, per-target assume-role is unchanged.
- **`secret_name` templates over `{target}` and any `{attribute}`** resolved for the target (e.g. `{cluster}_schemabot_password`), so per-cluster naming works without custom code.
- Attributes referenced by the template are **surfaced to the resolver automatically** and **fail closed** if unresolved (no silently mis-templated secret id).

Existing `{target}` + assume-role configs are unaffected.

## How it moves toward the northstar

An embedder can now drive credential resolution entirely from server config (`target_resolver.etre.credentials`) rather than shipping a custom resolver — keeping the data plane fully configuration-driven.

---
*Authored by Claude Code (Opus 4.8).*