### PR TITLE
feat(ci): add pre-push hook running unit tests for changed packages

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -82,8 +82,15 @@ while read -r local_ref local_sha remote_ref remote_sha; do
 
     files=$(git diff --name-only --diff-filter=d "$range_base" "$local_sha" -- '*.go' 2>/dev/null || true)
     if [ -n "$files" ]; then
-        changed_go_files="$changed_go_files
+        # Newline-join records so each filename stays on its own line. Append
+        # without a leading newline on the first record so no empty line is
+        # introduced.
+        if [ -z "$changed_go_files" ]; then
+            changed_go_files="$files"
+        else
+            changed_go_files="$changed_go_files
 $files"
+        fi
     fi
 done
 

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,117 @@
+#!/bin/sh
+set -e
+
+# Pre-push: run unit tests (go test -race) for the packages affected by the
+# commits being pushed. This is fast local feedback that mirrors the CI "Unit
+# Tests" job, scoped to changed packages so it stays quick. CI remains the
+# authoritative gate and runs the full suite — this hook does not replace it.
+#
+# Reads the standard pre-push stdin records:
+#   <local ref> <local sha> <remote ref> <remote sha>
+
+# Ensure we're at the worktree root (not the git common dir). Unset GIT_DIR
+# first — git sets it during hooks and it makes subprocess git commands resolve
+# the wrong repo root.
+unset GIT_DIR
+cd "$(git rev-parse --show-toplevel)"
+
+remote_name="$1"
+
+# Ensure GOROOT matches the Go version in go.mod, and that `go` is on PATH.
+# External tools (hermit, asdf) may point GOROOT at a different version, causing
+# "compile: version does not match go tool version" errors.
+GO_VERSION=$(sed -n 's/^go //p' go.mod | head -1)
+if [ -n "$GO_VERSION" ]; then
+    for candidate in \
+        "/opt/homebrew/opt/go/libexec" \
+        "/usr/local/go" \
+        "$HOME/sdk/go${GO_VERSION}" \
+        "$HOME/Library/Caches/hermit/pkg/go-${GO_VERSION}"; do
+        if [ -x "$candidate/bin/go" ]; then
+            CANDIDATE_VERSION=$("$candidate/bin/go" version 2>/dev/null | grep -o "go${GO_VERSION}" || true)
+            if [ -n "$CANDIDATE_VERSION" ]; then
+                export GOROOT="$candidate"
+                export PATH="$GOROOT/bin:$PATH"
+                break
+            fi
+        fi
+    done
+fi
+export PATH="$PATH:$HOME/go/bin:/usr/local/go/bin:/opt/homebrew/bin"
+
+# Resolve a base ref for new-branch pushes (no remote sha yet): prefer the push
+# remote's default branch, then origin/main, then main.
+base_ref=""
+for cand in "refs/remotes/$remote_name/HEAD" "refs/remotes/$remote_name/main" "refs/remotes/origin/main" "main"; do
+    if git rev-parse --verify --quiet "$cand" >/dev/null 2>&1; then
+        base_ref="$cand"
+        break
+    fi
+done
+
+# is_zero_sha returns success when the sha is all zeros (branch create/delete
+# sentinel), independent of SHA-1 vs SHA-256 length.
+is_zero_sha() {
+    case "$1" in
+        *[!0]*) return 1 ;;
+        *) return 0 ;;
+    esac
+}
+
+changed_go_files=""
+while read -r local_ref local_sha remote_ref remote_sha; do
+    # Skip branch deletions — nothing to test.
+    if is_zero_sha "$local_sha"; then
+        continue
+    fi
+
+    if is_zero_sha "$remote_sha"; then
+        # New branch on the remote: test what this branch introduces relative to
+        # the base. Fall back to the single tip commit if no base is available.
+        if [ -n "$base_ref" ]; then
+            range_base=$(git merge-base "$base_ref" "$local_sha" 2>/dev/null || true)
+        else
+            range_base=""
+        fi
+        if [ -z "$range_base" ]; then
+            range_base="${local_sha}~1"
+        fi
+    else
+        range_base="$remote_sha"
+    fi
+
+    files=$(git diff --name-only --diff-filter=d "$range_base" "$local_sha" -- '*.go' 2>/dev/null || true)
+    if [ -n "$files" ]; then
+        changed_go_files="$changed_go_files
+$files"
+    fi
+done
+
+changed_go_files=$(printf '%s\n' "$changed_go_files" | sed '/^$/d' | sort -u)
+if [ -z "$changed_go_files" ]; then
+    echo "pre-push: no Go changes in pushed commits; skipping unit tests."
+    exit 0
+fi
+
+# Map changed files to package directories that still exist and contain Go
+# source. A package whose directory was entirely removed is dropped (nothing to
+# test there).
+pkgs=""
+for dir in $(printf '%s\n' "$changed_go_files" | xargs -n1 dirname | sort -u); do
+    if [ -d "$dir" ] && ls "$dir"/*.go >/dev/null 2>&1; then
+        pkgs="$pkgs ./$dir"
+    fi
+done
+
+# Trim leading whitespace for the empty-check.
+pkgs=$(printf '%s' "$pkgs" | sed 's/^ *//')
+if [ -z "$pkgs" ]; then
+    echo "pre-push: changed Go files map to no testable packages; skipping unit tests."
+    exit 0
+fi
+
+echo "pre-push: running unit tests (race) for changed packages:"
+for p in $pkgs; do echo "  $p"; done
+
+# shellcheck disable=SC2086
+go test -race -count=1 $pkgs

--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,7 @@ lint-fix: ## Run golangci-lint with auto-fix enabled
 
 setup: ## Set up git hooks for development
 	git config core.hooksPath .githooks
-	@echo "Setup complete. Git hooks enabled (.githooks/pre-commit)."
+	@echo "Setup complete. Git hooks enabled (.githooks/pre-commit, .githooks/pre-push)."
 
 clean: ## Clean build artifacts
 	@echo "Cleaning..."


### PR DESCRIPTION
## Summary

Adds a `.githooks/pre-push` hook that runs `go test -race` for the packages
affected by the commits being pushed. It gives fast local feedback that mirrors
the CI unit job, scoped to changed packages so it stays quick. CI remains the
authoritative gate and runs the full suite — this hook does not replace it.

## How it works

The hook diffs the pushed commit range for `*.go` changes, maps them to package
directories that still exist, and tests only those:
```
pushed range --> changed *.go --> existing package dirs --> go test -race (only those)
|
none --> skip
```
Edge cases handled:

- New-branch push: range is the merge-base against the remote's default branch.
- Branch deletion / no-op push: skipped.
- Removed package directory: dropped from the test set.

GOROOT/PATH resolution mirrors the existing pre-commit hook, and `make setup`
already enables the hook via `core.hooksPath`.
