### PR TITLE
chore(lint): enable unparam and clear production violations

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -12,6 +12,7 @@ linters:
     - noctx           # requests without context
     - bodyclose       # unclosed HTTP response bodies
     - usetesting      # enforce t.Context() over context.Background() in tests
+    - unparam         # unused/constant function parameters and results
   settings:
     errcheck:
       exclude-functions:
@@ -19,6 +20,13 @@ linters:
     usetesting:
       context-background: true
       context-todo: true
+  exclusions:
+    rules:
+      # Test helpers intentionally keep uniform signatures and fixed arguments
+      # for readability, so unused/constant params there are not worth churn.
+      - path: _test\.go
+        linters:
+          - unparam
 formatters:
   enable:
     - gofmt

--- a/pkg/api/control_handlers.go
+++ b/pkg/api/control_handlers.go
@@ -1027,11 +1027,11 @@ const (
 // handleStart handles POST /api/start requests.
 func (s *Service) handleStart(w http.ResponseWriter, r *http.Request) {
 	var req StartRequest
-	client, apply, applyID, ok := s.decodeControlRequest(w, r, &req, &req.ApplyID, &req.Environment)
+	client, apply, _, ok := s.decodeControlRequest(w, r, &req, &req.ApplyID, &req.Environment)
 	if !ok {
 		return
 	}
-	resp, httpStatus, err := s.executeStartForApply(r.Context(), client, apply, applyID, req.Caller)
+	resp, httpStatus, err := s.executeStartForApply(r.Context(), client, apply, req.Caller)
 	if err != nil {
 		s.writeControlError(w, "start", apply, err)
 		return
@@ -1043,11 +1043,11 @@ func (s *Service) handleStart(w http.ResponseWriter, r *http.Request) {
 // deploy. The apply owner is responsible for consuming the request from the
 // per-apply processing loop.
 func (s *Service) ExecuteStart(ctx context.Context, req apitypes.ControlRequest) (*apitypes.StartResponse, error) {
-	client, apply, ternApplyID, err := s.controlTarget(ctx, "start", req.ApplyID, req.Environment)
+	client, apply, _, err := s.controlTarget(ctx, "start", req.ApplyID, req.Environment)
 	if err != nil {
 		return nil, err
 	}
-	resp, _, err := s.executeStartForApply(ctx, client, apply, ternApplyID, req.Caller)
+	resp, _, err := s.executeStartForApply(ctx, client, apply, req.Caller)
 	return resp, err
 }
 
@@ -1055,7 +1055,7 @@ func (s *Service) ExecuteStart(ctx context.Context, req apitypes.ControlRequest)
 // HTTP status is meaningful only when err == nil; every error path returns a
 // zero status, and callers must derive the response status from the error (e.g.
 // via writeControlError).
-func (s *Service) executeStartForApply(ctx context.Context, client tern.Client, apply *storage.Apply, ternApplyID, caller string) (*apitypes.StartResponse, int, error) {
+func (s *Service) executeStartForApply(ctx context.Context, client tern.Client, apply *storage.Apply, caller string) (*apitypes.StartResponse, int, error) {
 	if err := validateStartRequestState(apply); err != nil {
 		metrics.RecordControlOperation(ctx, "start", apply.Database, apply.Deployment, apply.Environment, "rejected")
 		return nil, 0, err

--- a/pkg/cmd/commands/apply.go
+++ b/pkg/cmd/commands/apply.go
@@ -234,7 +234,7 @@ func (cmd *ApplyCmd) Run(g *Globals) error {
 
 	fmt.Println("\nApplying changes...")
 
-	if _, err := applyAndWatch(ep, planResult, cfg.Database, cmd.Environment, owner, "apply", cmd.DeferCutover, cmd.DeferDeploy, cmd.SkipRevert, cmd.Branch, cmd.Watch, cmd.Output, cmd.LogHeartbeat); err != nil {
+	if err := applyAndWatch(ep, planResult, cfg.Database, cmd.Environment, owner, "apply", cmd.DeferCutover, cmd.DeferDeploy, cmd.SkipRevert, cmd.Branch, cmd.Watch, cmd.Output, cmd.LogHeartbeat); err != nil {
 		return err
 	}
 

--- a/pkg/cmd/commands/common.go
+++ b/pkg/cmd/commands/common.go
@@ -249,24 +249,23 @@ func resolveControlFlags(endpoint, profile, applyID, environment string) (string
 }
 
 // applyAndWatch extracts a plan ID, calls the apply API, prints status, and
-// optionally watches progress. Returns the apply ID (for yield logic, etc.).
-// Used by both RunApply and RunRollback.
+// optionally watches progress. Used by both RunApply and RunRollback.
 func applyAndWatch(ep string, planResult *apitypes.PlanResponse, database, environment, caller, operation string,
-	deferCutover, deferDeploy, skipRevert bool, branch string, watch bool, format OutputFormat, logHeartbeat time.Duration) (string, error) {
+	deferCutover, deferDeploy, skipRevert bool, branch string, watch bool, format OutputFormat, logHeartbeat time.Duration) error {
 
 	if planResult.PlanID == "" {
-		return "", fmt.Errorf("no plan_id in response")
+		return fmt.Errorf("no plan_id in response")
 	}
 
 	options := buildApplyOptions(planResult, deferCutover, deferDeploy, skipRevert, branch, watch, format)
 
 	applyResult, err := client.CallApplyAPI(ep, planResult.PlanID, environment, caller, options)
 	if err != nil {
-		return "", err
+		return err
 	}
 
 	if err := checkAccepted(applyResponseWrapper{applyResult}, operation); err != nil {
-		return "", err
+		return err
 	}
 
 	applyID := applyResult.ApplyID
@@ -279,7 +278,7 @@ func applyAndWatch(ep string, planResult *apitypes.PlanResponse, database, envir
 		}
 		enc := json.NewEncoder(os.Stdout)
 		_ = enc.Encode(result)
-		return applyID, nil
+		return nil
 	}
 
 	label := strings.ToUpper(operation[:1]) + operation[1:]
@@ -291,15 +290,15 @@ func applyAndWatch(ep string, planResult *apitypes.PlanResponse, database, envir
 
 	if !watch {
 		printWatchInstructions(applyID, database, environment)
-		return applyID, nil
+		return nil
 	}
 
 	fmt.Println("Watching progress...")
 	if err := WatchApplyProgressWithFormat(ep, applyID, environment, true, format, logHeartbeat); err != nil {
-		return applyID, err
+		return err
 	}
 
-	return applyID, nil
+	return nil
 }
 
 func buildApplyOptions(planResult *apitypes.PlanResponse, deferCutover, deferDeploy, skipRevert bool, branch string, watch bool, format OutputFormat) map[string]string {

--- a/pkg/cmd/commands/preview_exit.go
+++ b/pkg/cmd/commands/preview_exit.go
@@ -42,21 +42,20 @@ func previewExitAll() {
 }
 
 func previewExitDetachMySQL() {
-	fmt.Print(formatExitContext("apply-8487c4ad", "", "mydb", "staging"))
+	fmt.Print(formatExitContext("apply-8487c4ad", "", "staging"))
 }
 
 func previewExitDetachVitess() {
 	fmt.Print(formatExitContext(
 		"apply-9849818a9cec4ba7",
 		"https://app.planetscale.com/square-production/inventory2/deploy-requests/109",
-		"inventory2",
 		"production",
 	))
 }
 
 func previewExitErrorMySQL() {
 	fmt.Println("Error: unexpected error: connection refused")
-	fmt.Print(formatExitContext("apply-8487c4ad", "", "mydb", "staging"))
+	fmt.Print(formatExitContext("apply-8487c4ad", "", "staging"))
 }
 
 func previewExitErrorVitess() {
@@ -64,7 +63,6 @@ func previewExitErrorVitess() {
 	fmt.Print(formatExitContext(
 		"apply-9849818a9cec4ba7",
 		"https://app.planetscale.com/square-production/inventory2/deploy-requests/109",
-		"inventory2",
 		"production",
 	))
 }

--- a/pkg/cmd/commands/preview_tui.go
+++ b/pkg/cmd/commands/preview_tui.go
@@ -83,7 +83,8 @@ func previewTUI(name string, live bool) error {
 		return fmt.Errorf("unknown TUI preview type: %s (available: %s)", name, strings.Join(tuiPreviewNames(), ", "))
 	}
 	if !live {
-		return previewTUIStatic(scenario)
+		previewTUIStatic(scenario)
+		return nil
 	}
 
 	var poll atomic.Int64
@@ -113,7 +114,7 @@ func previewTUI(name string, live bool) error {
 	return watchApplyProgressByApplyIDWithEnvironment(server.URL, scenario.ApplyID, "staging", true)
 }
 
-func previewTUIStatic(scenario tuiPreviewScenario) error {
+func previewTUIStatic(scenario tuiPreviewScenario) {
 	progress := scenario.Progress(1)
 	msg := parseProgressResult(&progress)
 
@@ -131,7 +132,6 @@ func previewTUIStatic(scenario tuiPreviewScenario) error {
 	model.initialized = true
 
 	fmt.Print(model.View())
-	return nil
 }
 
 func tuiPreviewNames() []string {

--- a/pkg/cmd/commands/rollback.go
+++ b/pkg/cmd/commands/rollback.go
@@ -140,6 +140,6 @@ func (cmd *RollbackCmd) Run(g *Globals) error {
 
 	fmt.Println("\nApplying rollback...")
 
-	_, err = applyAndWatch(ep, planResult, database, environment, owner, "rollback", cmd.DeferCutover, false, false, "", cmd.Watch, OutputFormatInteractive, 0)
+	err = applyAndWatch(ep, planResult, database, environment, owner, "rollback", cmd.DeferCutover, false, false, "", cmd.Watch, OutputFormatInteractive, 0)
 	return err
 }

--- a/pkg/cmd/commands/watch_tui.go
+++ b/pkg/cmd/commands/watch_tui.go
@@ -405,7 +405,7 @@ func runWatchModel(model WatchModel) (err error) {
 	// Print apply context even on panic so operators never lose the apply ID.
 	defer func() {
 		if r := recover(); r != nil {
-			printExitContext(model.applyID, "", model.database, model.environment)
+			printExitContext(model.applyID, "", model.environment)
 			err = fmt.Errorf("unexpected error: %v", r)
 		}
 	}()
@@ -414,7 +414,7 @@ func runWatchModel(model WatchModel) (err error) {
 	p := tea.NewProgram(model)
 	finalModel, err := p.Run()
 	if err != nil {
-		printExitContext(model.applyID, "", model.database, model.environment)
+		printExitContext(model.applyID, "", model.environment)
 		return err
 	}
 
@@ -423,7 +423,7 @@ func runWatchModel(model WatchModel) (err error) {
 	// Completed applies render their apply ID in the success line. Other exits
 	// need explicit context so operators can resume monitoring or investigate.
 	if !state.IsState(m.state, state.Apply.Completed) {
-		printExitContext(m.applyID, m.deployRequestURL, m.database, m.environment)
+		printExitContext(m.applyID, m.deployRequestURL, m.environment)
 	}
 
 	// The TUI view already displays errors inline, so return ErrSilent
@@ -440,8 +440,8 @@ func runWatchModel(model WatchModel) (err error) {
 
 // printExitContext prints apply context on any TUI exit so operators
 // can resume monitoring or find the apply in PlanetScale.
-func printExitContext(applyID, deployRequestURL, database, environment string) {
-	msg := formatExitContext(applyID, deployRequestURL, database, environment)
+func printExitContext(applyID, deployRequestURL, environment string) {
+	msg := formatExitContext(applyID, deployRequestURL, environment)
 	if msg != "" {
 		fmt.Print(msg)
 	}
@@ -449,7 +449,7 @@ func printExitContext(applyID, deployRequestURL, database, environment string) {
 
 // formatExitContext builds the exit context message with apply ID, deploy
 // request URL, and resume command. Returns empty string if no apply ID.
-func formatExitContext(applyID, deployRequestURL, database, environment string) string {
+func formatExitContext(applyID, deployRequestURL, environment string) string {
 	if applyID == "" {
 		return ""
 	}

--- a/pkg/cmd/commands/watch_tui_test.go
+++ b/pkg/cmd/commands/watch_tui_test.go
@@ -616,30 +616,30 @@ func TestWatchModel_EnterTriggersSkipRevert(t *testing.T) {
 
 func TestFormatExitContext(t *testing.T) {
 	t.Run("includes apply ID and resume command", func(t *testing.T) {
-		result := formatExitContext("apply-abc123", "", "mydb", "production")
+		result := formatExitContext("apply-abc123", "", "production")
 		assert.Contains(t, result, "apply-abc123")
 		assert.Contains(t, result, "schemabot progress apply-abc123 -e production")
 	})
 
 	t.Run("includes deploy request URL when present", func(t *testing.T) {
-		result := formatExitContext("apply-abc123", "https://app.planetscale.com/org/db/deploy-requests/42", "mydb", "production")
+		result := formatExitContext("apply-abc123", "https://app.planetscale.com/org/db/deploy-requests/42", "production")
 		assert.Contains(t, result, "apply-abc123")
 		assert.Contains(t, result, "https://app.planetscale.com/org/db/deploy-requests/42")
 		assert.Contains(t, result, "schemabot progress apply-abc123 -e production")
 	})
 
 	t.Run("omits deploy URL when empty", func(t *testing.T) {
-		result := formatExitContext("apply-abc123", "", "mydb", "staging")
+		result := formatExitContext("apply-abc123", "", "staging")
 		assert.NotContains(t, result, "Deploy Request:")
 	})
 
 	t.Run("empty apply ID returns empty string", func(t *testing.T) {
-		result := formatExitContext("", "https://example.com", "mydb", "staging")
+		result := formatExitContext("", "https://example.com", "staging")
 		assert.Empty(t, result)
 	})
 
 	t.Run("omits environment flag when empty", func(t *testing.T) {
-		result := formatExitContext("apply-abc123", "", "mydb", "")
+		result := formatExitContext("apply-abc123", "", "")
 		assert.Contains(t, result, "schemabot progress apply-abc123")
 		assert.NotContains(t, result, "-e ")
 	})

--- a/pkg/engine/planetscale/apply.go
+++ b/pkg/engine/planetscale/apply.go
@@ -190,7 +190,7 @@ func (e *Engine) Apply(ctx context.Context, req *engine.ApplyRequest) (*engine.A
 	// Uses MySQL to fetch the branch schema (real-time, no API staleness).
 	if existingBranch != "" {
 		keyspaces := sortedKeyspaces(req.SchemaFiles)
-		if err := e.verifyBranchMatchesMain(ctx, client, org, req.Database, branchName, main, keyspaces, req.SchemaFiles, password); err != nil {
+		if err := e.verifyBranchMatchesMain(ctx, client, org, req.Database, branchName, main, keyspaces, password); err != nil {
 			return nil, fmt.Errorf("branch %s has stale changes from a previous apply — delete the branch and retry without --branch: %w", branchName, err)
 		}
 	}

--- a/pkg/engine/planetscale/branch.go
+++ b/pkg/engine/planetscale/branch.go
@@ -280,7 +280,7 @@ func (e *Engine) diffKeyspace(ctx context.Context, client psclient.PSClient, org
 // against main for the given keyspaces. Returns an error if any DDL changes
 // exist, indicating the branch has stale DDL from a previous failed apply
 // that RefreshSchema did not clean up.
-func (e *Engine) verifyBranchMatchesMain(ctx context.Context, client psclient.PSClient, org, database, branchName, mainBranch string, keyspaces []string, schemaFiles schema.SchemaFiles, password *ps.DatabaseBranchPassword) error {
+func (e *Engine) verifyBranchMatchesMain(ctx context.Context, client psclient.PSClient, org, database, branchName, mainBranch string, keyspaces []string, password *ps.DatabaseBranchPassword) error {
 	// Fetch main schema via API (stable, not recently modified) and branch
 	// schema via MySQL (real-time, avoids API staleness after RefreshSchema).
 	mainSchema, err := e.fetchDatabaseSchema(ctx, client, org, database, mainBranch, keyspaces)

--- a/pkg/engine/spirit/execution.go
+++ b/pkg/engine/spirit/execution.go
@@ -58,7 +58,7 @@ func (e *Engine) executeMigration(ctx context.Context, host, username, password,
 
 	// Completion is signalled only after every phase has run, so a poller never
 	// observes StateCompleted while a later DROP phase is still pending.
-	e.setMigrationState(engine.StateCompleted)
+	e.setMigrationCompleted()
 }
 
 // resumeMigration continues a stopped schema change to completion.
@@ -110,7 +110,7 @@ func (e *Engine) resumeMigration(ctx context.Context, host, username, password, 
 		return
 	}
 
-	e.setMigrationState(engine.StateCompleted)
+	e.setMigrationCompleted()
 }
 
 // ddlPhases groups a plan's statements into the order Spirit requires:
@@ -381,11 +381,11 @@ func (e *Engine) executeSpiritMigration(ctx context.Context, host, username, pas
 	return nil
 }
 
-func (e *Engine) setMigrationState(state engine.State) {
+func (e *Engine) setMigrationCompleted() {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	if e.runningMigration != nil {
-		e.runningMigration.state = state
+		e.runningMigration.state = engine.StateCompleted
 	}
 }
 

--- a/pkg/engine/spirit/spirit_integration_test.go
+++ b/pkg/engine/spirit/spirit_integration_test.go
@@ -524,13 +524,13 @@ func TestSetMigrationState(t *testing.T) {
 	eng := New(Config{})
 
 	// No running schema change - should not panic
-	eng.setMigrationState(engine.StateCompleted)
+	eng.setMigrationCompleted()
 
 	// With running schema change
 	eng.runningMigration = &runningMigration{
 		state: engine.StateRunning,
 	}
-	eng.setMigrationState(engine.StateCompleted)
+	eng.setMigrationCompleted()
 
 	assert.Equal(t, engine.StateCompleted, eng.runningMigration.state)
 }

--- a/pkg/engine/spirit/spirit_integration_test.go
+++ b/pkg/engine/spirit/spirit_integration_test.go
@@ -520,7 +520,7 @@ func TestNew_CustomConfig(t *testing.T) {
 	assert.Equal(t, 8, eng.threads)
 }
 
-func TestSetMigrationState(t *testing.T) {
+func TestSetMigrationCompleted(t *testing.T) {
 	eng := New(Config{})
 
 	// No running schema change - should not panic

--- a/pkg/tern/grpc_client.go
+++ b/pkg/tern/grpc_client.go
@@ -321,7 +321,7 @@ func (c *GRPCClient) clearObserver(applyID int64) {
 // logApplyEvent appends a control-plane apply log entry for gRPC applies. The
 // remote Tern service writes its own local logs, but operators read SchemaBot's
 // control-plane apply history from SchemaBot storage.
-func (c *GRPCClient) logApplyEvent(ctx context.Context, applyID int64, taskID *int64, level, eventType, source, message string, oldState, newState string) {
+func (c *GRPCClient) logApplyEvent(ctx context.Context, applyID int64, taskID *int64, level, eventType, message string, oldState, newState string) {
 	logStore := c.storage.ApplyLogs()
 	if logStore == nil {
 		slog.Error("missing apply log store for gRPC apply event",
@@ -335,7 +335,7 @@ func (c *GRPCClient) logApplyEvent(ctx context.Context, applyID int64, taskID *i
 		TaskID:    taskID,
 		Level:     level,
 		EventType: eventType,
-		Source:    source,
+		Source:    storage.LogSourceSchemaBot,
 		Message:   message,
 		OldState:  oldState,
 		NewState:  newState,
@@ -351,18 +351,18 @@ func (c *GRPCClient) logApplyEvent(ctx context.Context, applyID int64, taskID *i
 }
 
 func (c *GRPCClient) logApplyStateTransition(ctx context.Context, apply *storage.Apply, level, message, oldState string) {
-	c.logApplyEvent(ctx, apply.ID, nil, level, storage.LogEventStateTransition, storage.LogSourceSchemaBot,
+	c.logApplyEvent(ctx, apply.ID, nil, level, storage.LogEventStateTransition,
 		message, oldState, apply.State)
 }
 
 func (c *GRPCClient) logTaskStateTransition(ctx context.Context, applyID int64, task *storage.Task, message, oldState string) {
 	taskID := task.ID
-	c.logApplyEvent(ctx, applyID, &taskID, storage.LogLevelInfo, storage.LogEventStateTransition, storage.LogSourceSchemaBot,
+	c.logApplyEvent(ctx, applyID, &taskID, storage.LogLevelInfo, storage.LogEventStateTransition,
 		message, oldState, task.State)
 }
 
 func (c *GRPCClient) logApplyWarning(ctx context.Context, apply *storage.Apply, message string) {
-	c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelWarn, storage.LogEventError, storage.LogSourceSchemaBot,
+	c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelWarn, storage.LogEventError,
 		message, apply.State, apply.State)
 }
 
@@ -459,7 +459,7 @@ func (c *GRPCClient) processPendingCutoverControlRequest(ctx context.Context, ap
 			"environment", apply.Environment,
 			"requested_by", controlRequestCaller(controlReq),
 			"state", apply.State)
-		c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventCutoverTriggered, storage.LogSourceSchemaBot,
+		c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventCutoverTriggered,
 			fmt.Sprintf("Pending remote cutover request completed for resolved apply%s", callerApplyLogSuffix(controlRequestCaller(controlReq))), "", "")
 		return completePendingCutoverControlRequests(ctx, c.storage, apply)
 	}
@@ -519,7 +519,7 @@ func (c *GRPCClient) processPendingCutoverControlRequest(ctx context.Context, ap
 		if failErr := failPendingCutoverControlRequests(ctx, c.storage, apply, errorMessage); failErr != nil {
 			return fmt.Errorf("request remote gRPC cutover for apply %s remote %s: %w; fail pending cutover request: %w", apply.ApplyIdentifier, apply.ExternalID, err, failErr)
 		}
-		c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelError, storage.LogEventError, storage.LogSourceSchemaBot,
+		c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelError, storage.LogEventError,
 			fmt.Sprintf("Remote cutover failed for apply %s%s: %v", apply.ExternalID, callerApplyLogSuffix(controlRequestCaller(controlReq)), err), "", "")
 		return fmt.Errorf("request remote gRPC cutover for apply %s remote %s: %w", apply.ApplyIdentifier, apply.ExternalID, err)
 	}
@@ -528,7 +528,7 @@ func (c *GRPCClient) processPendingCutoverControlRequest(ctx context.Context, ap
 		if err := failPendingCutoverControlRequests(ctx, c.storage, apply, errorMessage); err != nil {
 			return err
 		}
-		c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelError, storage.LogEventError, storage.LogSourceSchemaBot,
+		c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelError, storage.LogEventError,
 			fmt.Sprintf("Remote cutover returned no response for apply %s%s", apply.ExternalID, callerApplyLogSuffix(controlRequestCaller(controlReq))), "", "")
 		return fmt.Errorf("request remote gRPC cutover for apply %s remote %s: %s", apply.ApplyIdentifier, apply.ExternalID, errorMessage)
 	}
@@ -540,11 +540,11 @@ func (c *GRPCClient) processPendingCutoverControlRequest(ctx context.Context, ap
 		if err := failPendingCutoverControlRequests(ctx, c.storage, apply, errorMessage); err != nil {
 			return err
 		}
-		c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelError, storage.LogEventError, storage.LogSourceSchemaBot,
+		c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelError, storage.LogEventError,
 			fmt.Sprintf("Remote cutover was not accepted for apply %s%s: %s", apply.ExternalID, callerApplyLogSuffix(controlRequestCaller(controlReq)), errorMessage), "", "")
 		return fmt.Errorf("request remote gRPC cutover for apply %s remote %s: %s", apply.ApplyIdentifier, apply.ExternalID, errorMessage)
 	}
-	c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventCutoverTriggered, storage.LogSourceSchemaBot,
+	c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventCutoverTriggered,
 		fmt.Sprintf("Remote cutover accepted for apply %s%s", apply.ExternalID, callerApplyLogSuffix(controlRequestCaller(controlReq))), "", "")
 	if err := completePendingCutoverControlRequests(ctx, c.storage, apply); err != nil {
 		return err
@@ -581,7 +581,7 @@ func (c *GRPCClient) processPendingStopControlRequest(ctx context.Context, apply
 			"environment", apply.Environment,
 			"requested_by", controlRequestCaller(controlReq),
 			"state", apply.State)
-		c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventStopRequested, storage.LogSourceSchemaBot,
+		c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventStopRequested,
 			fmt.Sprintf("Pending remote stop request completed for resolved apply%s", callerApplyLogSuffix(controlRequestCaller(controlReq))), "", "")
 		if hasPendingStart, startErr := hasPendingStartControlRequest(ctx, c.storage, apply); startErr != nil {
 			return true, startErr
@@ -598,7 +598,7 @@ func (c *GRPCClient) processPendingStopControlRequest(ctx context.Context, apply
 			"environment", apply.Environment,
 			"requested_by", controlRequestCaller(controlReq),
 			"state", apply.State)
-		c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventStopRequested, storage.LogSourceSchemaBot,
+		c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventStopRequested,
 			fmt.Sprintf("Pending remote stop request completed for terminal apply%s", callerApplyLogSuffix(controlRequestCaller(controlReq))), "", "")
 		if err := completePendingStopControlRequests(ctx, c.storage, apply); err != nil {
 			return true, err
@@ -634,7 +634,7 @@ func (c *GRPCClient) processPendingStopControlRequest(ctx context.Context, apply
 		}
 		return true, fmt.Errorf("request remote gRPC stop for apply %s remote %s: %s", apply.ApplyIdentifier, apply.ExternalID, errorMessage)
 	}
-	c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventStopRequested, storage.LogSourceSchemaBot,
+	c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventStopRequested,
 		fmt.Sprintf("Remote stop accepted for apply %s%s", apply.ExternalID, callerApplyLogSuffix(controlRequestCaller(controlReq))), "", "")
 
 	progress, err := c.client.Progress(ctx, &ternv1.ProgressRequest{
@@ -734,7 +734,7 @@ func (c *GRPCClient) completeRemoteStopFromTerminalProgress(ctx context.Context,
 	if err := completePendingStopControlRequests(ctx, c.storage, apply); err != nil {
 		return false, err
 	}
-	c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventStopRequested, storage.LogSourceSchemaBot,
+	c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventStopRequested,
 		fmt.Sprintf("Remote stop request completed from terminal progress after stop error%s", callerApplyLogSuffix(controlRequestCaller(controlReq))), "", "")
 	return true, nil
 }
@@ -1102,7 +1102,7 @@ func (c *GRPCClient) completePendingStopBeforeRemoteStart(ctx context.Context, a
 		"environment", apply.Environment,
 		"requested_by", controlRequestCaller(controlReq),
 		"state", apply.State)
-	c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventStopRequested, storage.LogSourceSchemaBot,
+	c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventStopRequested,
 		fmt.Sprintf("Pending remote stop request completed before start%s", callerApplyLogSuffix(controlRequestCaller(controlReq))), "", "")
 	return nil
 }

--- a/pkg/tern/local_apply_sequential.go
+++ b/pkg/tern/local_apply_sequential.go
@@ -65,7 +65,7 @@ func (c *LocalClient) executeApplySequential(ctx context.Context, apply *storage
 			"elapsed_ms", time.Since(seqStart).Milliseconds(),
 		)
 
-		action = c.runEngineTask(ctx, apply, task, plan, options, creds)
+		action = c.runEngineTask(ctx, apply, task, options, creds)
 
 		// Notify observer after each task completes
 		if obs := c.getObserver(apply.ID); obs != nil {
@@ -138,7 +138,7 @@ func (c *LocalClient) checkTaskReady(ctx context.Context, task *storage.Task) ta
 
 // runEngineTask calls the engine for a single DDL, marks the task running, and polls to completion.
 // Returns the outcome: taskContinue (completed), taskFailed, or taskStopped.
-func (c *LocalClient) runEngineTask(ctx context.Context, apply *storage.Apply, task *storage.Task, plan *storage.Plan, options map[string]string, creds *engine.Credentials) taskAction {
+func (c *LocalClient) runEngineTask(ctx context.Context, apply *storage.Apply, task *storage.Task, options map[string]string, creds *engine.Credentials) taskAction {
 	if handled, err := c.processPendingStopControlRequest(ctx, apply); err != nil {
 		c.logger.Warn("pending stop request processing failed before sequential engine apply; current apply owner will exit for operator retry",
 			"apply_id", apply.ApplyIdentifier, "task_id", task.TaskIdentifier, "error", err)

--- a/pkg/tern/local_control_resume.go
+++ b/pkg/tern/local_control_resume.go
@@ -337,7 +337,7 @@ func (c *LocalClient) resumeApplySequential(ctx context.Context, apply *storage.
 			continue
 		}
 
-		action = c.runEngineTask(ctx, apply, task, plan, options, creds)
+		action = c.runEngineTask(ctx, apply, task, options, creds)
 
 		taskID := task.ID
 		c.logApplyEvent(ctx, apply.ID, &taskID, storage.LogLevelInfo, storage.LogEventStateTransition, storage.LogSourceSchemaBot,

--- a/pkg/webhook/actor_authorization_test.go
+++ b/pkg/webhook/actor_authorization_test.go
@@ -489,7 +489,7 @@ func TestHandleRollbackConfirmCommandBlocksUnauthorizedActor(t *testing.T) {
 	installClient := ghclient.NewInstallationClient(client, testLogger())
 	h := actorAuthStorageTestHandler(cfg, &actorAuthStorage{locks: locks, plan: rollbackAuthPlan()}, installClient)
 
-	h.handleRollbackConfirmCommand("octocat/hello-world", 1, "staging", "", 12345, "mona", CommandResult{Action: action.RollbackConfirm})
+	h.handleRollbackConfirmCommand("octocat/hello-world", 1, "staging", 12345, "mona", CommandResult{Action: action.RollbackConfirm})
 
 	body := requireComment(t, comments, "unauthorized rollback-confirm comment")
 	assert.Contains(t, body, "SchemaBot Command Not Authorized")
@@ -513,7 +513,7 @@ func TestHandleRollbackConfirmCommandAllowsAuthorizedActor(t *testing.T) {
 	installClient := ghclient.NewInstallationClient(client, testLogger())
 	h := actorAuthStorageTestHandler(cfg, &actorAuthStorage{locks: &actorAuthLockStore{}}, installClient)
 
-	h.handleRollbackConfirmCommand("octocat/hello-world", 1, "staging", "", 12345, "hubot", CommandResult{Action: action.RollbackConfirm})
+	h.handleRollbackConfirmCommand("octocat/hello-world", 1, "staging", 12345, "hubot", CommandResult{Action: action.RollbackConfirm})
 
 	body := requireComment(t, comments, "rollback-confirm no-lock comment")
 	assert.Contains(t, body, "No Lock Found")

--- a/pkg/webhook/apply_comment_e2e_test.go
+++ b/pkg/webhook/apply_comment_e2e_test.go
@@ -206,13 +206,14 @@ func TestE2EApplyCommentLifecycle(t *testing.T) {
 	h := NewHandler(svc, factory, nil, logger)
 
 	// Step 1: Post initial progress comment
-	progressCommentID := h.postAndTrackComment(ctx, "org/repo", 42, 12345, applyID, state.Comment.Progress, "Initial progress")
+	h.postAndTrackComment(ctx, "org/repo", 42, 12345, applyID, state.Comment.Progress, "Initial progress")
 
 	// Verify create was captured
+	var progressCommentID int64
 	select {
 	case created := <-capture.creates:
 		assert.Equal(t, "Initial progress", created.Body)
-		assert.Equal(t, progressCommentID, created.ID)
+		progressCommentID = created.ID
 	case <-time.After(5 * time.Second):
 		t.Fatal("timed out waiting for progress comment create")
 	}
@@ -255,12 +256,13 @@ func TestE2EApplyCommentLifecycle(t *testing.T) {
 	assert.Equal(t, progressCommentID, active.GitHubCommentID)
 
 	// Step 4: Post cutover comment (simulating defer_cutover)
-	cutoverCommentID := h.postAndTrackComment(ctx, "org/repo", 42, 12345, applyID, state.Comment.Cutover, "Cutover ready")
+	h.postAndTrackComment(ctx, "org/repo", 42, 12345, applyID, state.Comment.Cutover, "Cutover ready")
 
+	var cutoverCommentID int64
 	select {
 	case created := <-capture.creates:
 		assert.Equal(t, "Cutover ready", created.Body)
-		assert.Equal(t, cutoverCommentID, created.ID)
+		cutoverCommentID = created.ID
 	case <-time.After(5 * time.Second):
 		t.Fatal("timed out waiting for cutover comment create")
 	}
@@ -284,12 +286,13 @@ func TestE2EApplyCommentLifecycle(t *testing.T) {
 	}
 
 	// Step 7: Post summary comment (terminal state)
-	summaryCommentID := h.postAndTrackComment(ctx, "org/repo", 42, 12345, applyID, state.Comment.Summary, "Schema change completed")
+	h.postAndTrackComment(ctx, "org/repo", 42, 12345, applyID, state.Comment.Summary, "Schema change completed")
 
+	var summaryCommentID int64
 	select {
 	case created := <-capture.creates:
 		assert.Equal(t, "Schema change completed", created.Body)
-		assert.Equal(t, summaryCommentID, created.ID)
+		summaryCommentID = created.ID
 	case <-time.After(5 * time.Second):
 		t.Fatal("timed out waiting for summary comment create")
 	}
@@ -494,11 +497,13 @@ func TestE2EApplyCommentUpsertOnResume(t *testing.T) {
 	h := NewHandler(svc, factory, nil, logger)
 
 	// Resume: post new progress comment (upsert should replace old ID)
-	newProgressID := h.postAndTrackComment(ctx, "org/repo-resume", 43, 12345, applyID, state.Comment.Progress, "Resumed progress")
+	h.postAndTrackComment(ctx, "org/repo-resume", 43, 12345, applyID, state.Comment.Progress, "Resumed progress")
 
+	var newProgressID int64
 	select {
 	case created := <-capture.creates:
 		assert.Equal(t, "Resumed progress", created.Body)
+		newProgressID = created.ID
 	case <-time.After(5 * time.Second):
 		t.Fatal("timed out waiting for resumed progress comment")
 	}
@@ -511,11 +516,13 @@ func TestE2EApplyCommentUpsertOnResume(t *testing.T) {
 	assert.NotEqual(t, int64(111), comment.GitHubCommentID, "old comment ID should be replaced")
 
 	// Post new summary (upsert replaces old ID)
-	newSummaryID := h.postAndTrackComment(ctx, "org/repo-resume", 43, 12345, applyID, state.Comment.Summary, "Resumed summary")
+	h.postAndTrackComment(ctx, "org/repo-resume", 43, 12345, applyID, state.Comment.Summary, "Resumed summary")
 
+	var newSummaryID int64
 	select {
 	case created := <-capture.creates:
 		assert.Equal(t, "Resumed summary", created.Body)
+		newSummaryID = created.ID
 	case <-time.After(5 * time.Second):
 		t.Fatal("timed out waiting for resumed summary comment")
 	}

--- a/pkg/webhook/apply_e2e_test.go
+++ b/pkg/webhook/apply_e2e_test.go
@@ -2267,7 +2267,7 @@ func TestE2EApplyThreeEnvEnforcement(t *testing.T) {
 	seedCheck(t, svc, dbName, "sandbox", "action_required")
 
 	blocked := h.checkPriorEnvironments(t.Context(), "octocat/hello-world", 1,
-		dbName, "mysql", "production", envs, 1, "testuser")
+		dbName, "mysql", "production", envs, 1)
 	assert.True(t, blocked, "production should be blocked when sandbox is action_required")
 
 	select {
@@ -2282,7 +2282,7 @@ func TestE2EApplyThreeEnvEnforcement(t *testing.T) {
 	seedCheck(t, svc, dbName, "staging", "action_required")
 
 	blocked = h.checkPriorEnvironments(t.Context(), "octocat/hello-world", 1,
-		dbName, "mysql", "production", envs, 1, "testuser")
+		dbName, "mysql", "production", envs, 1)
 	assert.True(t, blocked, "production should be blocked when staging is action_required")
 
 	select {
@@ -2296,19 +2296,19 @@ func TestE2EApplyThreeEnvEnforcement(t *testing.T) {
 	seedCheck(t, svc, dbName, "staging", "success")
 
 	blocked = h.checkPriorEnvironments(t.Context(), "octocat/hello-world", 1,
-		dbName, "mysql", "production", envs, 1, "testuser")
+		dbName, "mysql", "production", envs, 1)
 	assert.False(t, blocked, "production should not be blocked when all prior envs are success")
 
 	// Case 4: staging only requires sandbox (not production)
 	seedCheck(t, svc, dbName, "sandbox", "action_required")
 
 	blocked = h.checkPriorEnvironments(t.Context(), "octocat/hello-world", 1,
-		dbName, "mysql", "staging", envs, 1, "testuser")
+		dbName, "mysql", "staging", envs, 1)
 	assert.True(t, blocked, "staging should be blocked when sandbox is action_required")
 
 	// Case 5: sandbox (first env) is never blocked
 	blocked = h.checkPriorEnvironments(t.Context(), "octocat/hello-world", 1,
-		dbName, "mysql", "sandbox", envs, 1, "testuser")
+		dbName, "mysql", "sandbox", envs, 1)
 	assert.False(t, blocked, "sandbox (first env) should never be blocked")
 }
 

--- a/pkg/webhook/apply_handlers.go
+++ b/pkg/webhook/apply_handlers.go
@@ -70,7 +70,7 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 	lockOwner := fmt.Sprintf("%s#%d", repo, pr)
 
 	// Environment ordering enforcement: prior server-configured environments must be clean before applying.
-	if blocked := h.checkPriorEnvironments(ctx, repo, pr, database, dbType, environment, schemaResult.Environments, installationID, requestedBy); blocked {
+	if blocked := h.checkPriorEnvironments(ctx, repo, pr, database, dbType, environment, schemaResult.Environments, installationID); blocked {
 		h.logger.Info("apply blocked by environment ordering", "repo", repo, "pr", pr, "database", database, "environment", environment)
 		return
 	}

--- a/pkg/webhook/check_prior_env.go
+++ b/pkg/webhook/check_prior_env.go
@@ -32,7 +32,7 @@ func (h *Handler) checkPriorEnvironments(
 	ctx context.Context, repo string, pr int,
 	database, dbType, environment string,
 	environments []string,
-	installationID int64, requestedBy string,
+	installationID int64,
 ) bool {
 	config := h.service.Config()
 

--- a/pkg/webhook/check_prior_env_test.go
+++ b/pkg/webhook/check_prior_env_test.go
@@ -224,7 +224,7 @@ func TestCheckPriorEnvironmentsWithProductionOnlyServerConfigChecksStaging(t *te
 	}
 
 	blocked := h.checkPriorEnvironments(t.Context(), repo, pr,
-		"orders", "mysql", "production", []string{"staging", "production"}, 12345, "testuser")
+		"orders", "mysql", "production", []string{"staging", "production"}, 12345)
 	assert.True(t, blocked, "production blocks when the environment list includes staging before production")
 
 	select {
@@ -244,7 +244,7 @@ func TestCheckPriorEnvironmentsWithProductionOnlyServerConfigChecksStaging(t *te
 	assert.Equal(t, []string{"production"}, schemaResult.Environments)
 
 	blocked = h.checkPriorEnvironments(t.Context(), repo, pr,
-		"orders", "mysql", "production", schemaResult.Environments, 12345, "testuser")
+		"orders", "mysql", "production", schemaResult.Environments, 12345)
 	assert.True(t, blocked, "production blocks on staging even when this server only has a production target for the database")
 
 	select {
@@ -343,7 +343,7 @@ func TestCheckPriorEnvironmentsCrossDeploymentAppTrust(t *testing.T) {
 		registerGitHubEndpoints(t, mux, comments)
 
 		blocked := h.checkPriorEnvironments(t.Context(), repo, pr,
-			"orders", "mysql", "production", []string{"production"}, 12345, "testuser")
+			"orders", "mysql", "production", []string{"production"}, 12345)
 
 		assert.False(t, blocked, "a passing staging aggregate check from the trusted staging deployment App must allow production apply")
 		select {
@@ -360,7 +360,7 @@ func TestCheckPriorEnvironmentsCrossDeploymentAppTrust(t *testing.T) {
 		registerGitHubEndpoints(t, mux, comments)
 
 		blocked := h.checkPriorEnvironments(t.Context(), repo, pr,
-			"orders", "mysql", "production", []string{"production"}, 12345, "testuser")
+			"orders", "mysql", "production", []string{"production"}, 12345)
 
 		assert.True(t, blocked, "a staging aggregate check from an unconfigured App must not satisfy the promotion gate")
 		select {
@@ -435,7 +435,7 @@ func TestCheckPriorEnvironmentsScopedTargetMissingFromOrderFailsClosed(t *testin
 	}
 
 	blocked := h.checkPriorEnvironments(t.Context(), repo, pr,
-		"orders", "mysql", "canary", []string{"canary"}, 12345, "testuser")
+		"orders", "mysql", "canary", []string{"canary"}, 12345)
 	assert.True(t, blocked, "scoped instance must fail closed when an allowed target environment is absent from the promotion order")
 
 	select {
@@ -552,7 +552,7 @@ func TestCheckPriorEnvironmentsScopedTargetInOrderAllowsApply(t *testing.T) {
 	}
 
 	blocked := h.checkPriorEnvironments(t.Context(), repo, pr,
-		"orders", "mysql", "production", []string{"production"}, 12345, "testuser")
+		"orders", "mysql", "production", []string{"production"}, 12345)
 	assert.False(t, blocked, "in-order target with a passing prior environment check should be allowed")
 
 	select {

--- a/pkg/webhook/check_publisher.go
+++ b/pkg/webhook/check_publisher.go
@@ -269,7 +269,11 @@ func (h *Handler) upsertAggregateCheckRun(
 // manages. Without this, branch protection would block indefinitely waiting for a
 // check that would never come. It does not publish success over existing
 // per-database state that still needs operator attention.
-func (h *Handler) postPassingAggregates(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, headSHA, title, summary string) {
+func (h *Handler) postPassingAggregates(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, headSHA string) {
+	const (
+		title   = "No managed schema changes"
+		summary = "This PR does not contain schema changes managed by SchemaBot."
+	)
 	if !h.shouldPublishChecks(ctx, repo, "aggregate_check_sync") {
 		return
 	}

--- a/pkg/webhook/issue_comment.go
+++ b/pkg/webhook/issue_comment.go
@@ -258,7 +258,7 @@ func (h *Handler) handleIssueComment(ctx context.Context, metricApp string, w ht
 		h.writeJSON(w, http.StatusOK, map[string]string{"message": "rollback started"})
 	case action.RollbackConfirm:
 		h.goSafe(repo, pr, installationID, func() {
-			h.handleRollbackConfirmCommand(repo, pr, result.Environment, result.Database, installationID, requestedBy, result)
+			h.handleRollbackConfirmCommand(repo, pr, result.Environment, installationID, requestedBy, result)
 		})
 		h.writeJSON(w, http.StatusOK, map[string]string{"message": "rollback-confirm started"})
 	case action.Stop:
@@ -308,22 +308,21 @@ func (h *Handler) postComment(repo string, pr int, installationID int64, body st
 }
 
 // postAndTrackComment creates a PR comment and stores its ID in apply_comments.
-// Returns the GitHub comment ID, or 0 if the comment failed to post.
 func (h *Handler) postAndTrackComment(
 	ctx context.Context, repo string, pr int, installationID int64,
 	applyID int64, commentState string, body string,
-) int64 {
+) {
 	client, err := h.clientForRepo(repo, installationID)
 	if err != nil {
 		h.logger.Error("failed to create GitHub client for tracked comment", "error", err)
-		return 0
+		return
 	}
 
 	commentID, err := client.CreateIssueComment(ctx, repo, pr, h.renderPRComment(body))
 	if err != nil {
 		h.logger.Error("failed to post tracked comment",
 			"repo", repo, "pr", pr, "commentState", commentState, "error", err)
-		return 0
+		return
 	}
 
 	comment := &storage.ApplyComment{
@@ -335,8 +334,6 @@ func (h *Handler) postAndTrackComment(
 		h.logger.Error("failed to store comment ID",
 			"applyID", applyID, "commentState", commentState, "commentID", commentID, "error", err)
 	}
-
-	return commentID
 }
 
 func (h *Handler) renderPRComment(body string) string {

--- a/pkg/webhook/prinfocache_dedup_e2e_test.go
+++ b/pkg/webhook/prinfocache_dedup_e2e_test.go
@@ -153,7 +153,7 @@ func TestRollbackConfirmHandlerDoesNotFetchPRForNoLock(t *testing.T) {
 	// Call the handler entry point synchronously. No lock is acquired, so the
 	// handler must bail out without fetching the PR or discovering current schema
 	// files.
-	h.handleRollbackConfirmCommand("octocat/hello-world", 1, "staging", "", 12345, "testuser", CommandResult{
+	h.handleRollbackConfirmCommand("octocat/hello-world", 1, "staging", 12345, "testuser", CommandResult{
 		Environment: "staging",
 	})
 

--- a/pkg/webhook/pull_request.go
+++ b/pkg/webhook/pull_request.go
@@ -155,9 +155,7 @@ func (h *Handler) runAutoPlanForPR(ctx context.Context, client *ghclient.Install
 				h.logger.Error("failed to create GitHub client for passing aggregate", "error", err)
 				return
 			}
-			h.postPassingAggregates(ctx, c, repo, pr, headSHA,
-				"No managed schema changes",
-				"This PR does not contain schema changes managed by SchemaBot.")
+			h.postPassingAggregates(ctx, c, repo, pr, headSHA)
 		})
 		return "no schema files in PR"
 	}

--- a/pkg/webhook/rollback.go
+++ b/pkg/webhook/rollback.go
@@ -276,7 +276,7 @@ func (h *Handler) releaseRollbackLockAfterRejectedPlan(ctx context.Context, data
 // handleRollbackConfirmCommand handles the "schemabot rollback-confirm -e <env>" PR comment command.
 // It verifies the lock, loads the rollback plan pinned by the preceding rollback
 // command, and executes the apply.
-func (h *Handler) handleRollbackConfirmCommand(repo string, pr int, environment, databaseName string, installationID int64, requestedBy string, result CommandResult) {
+func (h *Handler) handleRollbackConfirmCommand(repo string, pr int, environment string, installationID int64, requestedBy string, result CommandResult) {
 	ctx, cancel, client, err := h.commandBootstrap(repo, installationID)
 	if err != nil {
 		h.logger.Error("rollback-confirm: failed to bootstrap command", "error", err)

--- a/pkg/webhook/rollback_test.go
+++ b/pkg/webhook/rollback_test.go
@@ -319,7 +319,7 @@ func TestHandleRollbackConfirmAlreadyRolledBackReleasesLock(t *testing.T) {
 	locks := &actorAuthLockStore{locks: []*storage.Lock{prOwnedRollbackLock()}}
 	h, comments := newRollbackConfirmNoopHandler(t, locks, testLogger())
 
-	h.handleRollbackConfirmCommand("octocat/hello-world", 1, "staging", "", 12345, "hubot", CommandResult{Action: action.RollbackConfirm})
+	h.handleRollbackConfirmCommand("octocat/hello-world", 1, "staging", 12345, "hubot", CommandResult{Action: action.RollbackConfirm})
 
 	body := requireComment(t, comments, "already-rolled-back comment")
 	assert.Contains(t, body, "Already Rolled Back")
@@ -343,7 +343,7 @@ func TestHandleRollbackConfirmAlreadyRolledBackLockReleaseFails(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(&logBuf, nil))
 	h, comments := newRollbackConfirmNoopHandler(t, locks, logger)
 
-	h.handleRollbackConfirmCommand("octocat/hello-world", 1, "staging", "", 12345, "hubot", CommandResult{Action: action.RollbackConfirm})
+	h.handleRollbackConfirmCommand("octocat/hello-world", 1, "staging", 12345, "hubot", CommandResult{Action: action.RollbackConfirm})
 
 	body := requireComment(t, comments, "already-rolled-back lock-held comment")
 	assert.Contains(t, body, "Already Rolled Back")

--- a/pkg/webhook/templates/apply.go
+++ b/pkg/webhook/templates/apply.go
@@ -323,7 +323,7 @@ func writeTableProgressSection(sb *strings.Builder, data ApplyStatusCommentData)
 	})
 
 	for _, table := range sorted {
-		renderTableProgress(sb, table, data.State)
+		renderTableProgress(sb, table)
 	}
 }
 
@@ -334,7 +334,7 @@ func tableStatePriority(tableStatus string) int {
 
 // renderTableProgress renders a single table's progress as markdown.
 // Mirrors the CLI's writeTableProgressWithState logic but outputs markdown instead of ANSI.
-func renderTableProgress(sb *strings.Builder, table TableProgressData, globalState string) {
+func renderTableProgress(sb *strings.Builder, table TableProgressData) {
 	// Normalize to canonical Task state for consistent matching.
 	status := state.NormalizeTaskStatus(table.Status)
 

--- a/pkg/webhook/templates/apply_commands.go
+++ b/pkg/webhook/templates/apply_commands.go
@@ -106,14 +106,14 @@ func RenderUnsafeChangesBlocked(data PlanCommentData) string {
 	sb.WriteString("\n")
 
 	// Count and show changes
-	totalStatements, keyspacesWithDDL, keyspacesWithVSchema := countChanges(data.Changes)
+	totalStatements, keyspacesWithVSchema := countChanges(data.Changes)
 	totalChanges := totalStatements + keyspacesWithVSchema
 
 	if totalChanges > 0 {
 		writeKeyspaceChanges(&sb, data)
 	}
 
-	writePlanSummary(&sb, data, totalStatements, keyspacesWithDDL, keyspacesWithVSchema)
+	writePlanSummary(&sb, data, totalStatements, keyspacesWithVSchema)
 
 	// Unsafe changes blocked section
 	sb.WriteString("---\n\n")

--- a/pkg/webhook/templates/apply_test.go
+++ b/pkg/webhook/templates/apply_test.go
@@ -938,17 +938,6 @@ func TestRenderApplyBlockedByInProgressChecks_EmptyList(t *testing.T) {
 	}
 }
 
-func TestTruncateDDL(t *testing.T) {
-	assert.Equal(t, "ALTER TABLE orders ADD INDEX idx_user_id (user_id)", truncateDDL("ALTER TABLE `orders` ADD INDEX `idx_user_id` (`user_id`)", 80))
-	assert.Equal(t, "short", truncateDDL("short", 80))
-	assert.Equal(t, "", truncateDDL("", 80))
-
-	long := "ALTER TABLE `very_long_table_name` ADD INDEX `idx_very_long_column_name_that_goes_on_forever` (`very_long_column_name_that_goes_on_forever`)"
-	result := truncateDDL(long, 80)
-	assert.Len(t, result, 80)
-	assert.True(t, strings.HasSuffix(result, "..."))
-}
-
 func TestRenderApplyStatusComment_WaitingForCutover_ReadyNotReady(t *testing.T) {
 	data := ApplyStatusCommentData{
 		ApplyID:     "apply-abc123",

--- a/pkg/webhook/templates/common.go
+++ b/pkg/webhook/templates/common.go
@@ -129,16 +129,6 @@ func escapeRelativeTimeDatetime(timestamp string) string {
 	return parsed.UTC().Format(time.RFC3339)
 }
 
-// truncateDDL strips backtick-quoting from a DDL statement and truncates to maxLen characters.
-// Used in summary comments where DDL should be inline and scannable, not verbose.
-func truncateDDL(ddl string, maxLen int) string {
-	cleaned := strings.ReplaceAll(ddl, "`", "")
-	if len(cleaned) > maxLen {
-		return cleaned[:maxLen-3] + "..."
-	}
-	return cleaned
-}
-
 // writeDBEnvLine writes the **Database** | **Environment** metadata line.
 func writeDBEnvLine(sb *strings.Builder, database, environment string) {
 	if environment != "" {

--- a/pkg/webhook/templates/plan.go
+++ b/pkg/webhook/templates/plan.go
@@ -97,7 +97,7 @@ func RenderPlanComment(data PlanCommentData) string {
 	sb.WriteString("\n")
 
 	// Count changes
-	totalStatements, keyspacesWithDDL, keyspacesWithVSchema := countChanges(data.Changes)
+	totalStatements, keyspacesWithVSchema := countChanges(data.Changes)
 	totalChanges := totalStatements + keyspacesWithVSchema
 
 	// No changes — short-circuit with a single clean message
@@ -125,7 +125,7 @@ func RenderPlanComment(data PlanCommentData) string {
 	}
 
 	// Summary and options (after DDL, matching CLI layout)
-	writePlanSummary(&sb, data, totalStatements, keyspacesWithDDL, keyspacesWithVSchema)
+	writePlanSummary(&sb, data, totalStatements, keyspacesWithVSchema)
 	writeOptions(&sb, data)
 
 	// Footer
@@ -228,11 +228,10 @@ func writeOptions(sb *strings.Builder, data PlanCommentData) {
 	}
 }
 
-func countChanges(changes []KeyspaceChangeData) (totalStatements, keyspacesWithDDL, keyspacesWithVSchema int) {
+func countChanges(changes []KeyspaceChangeData) (totalStatements, keyspacesWithVSchema int) {
 	for _, ks := range changes {
 		if len(ks.Statements) > 0 {
 			totalStatements += len(ks.Statements)
-			keyspacesWithDDL++
 		}
 		if ks.VSchemaChanged {
 			keyspacesWithVSchema++
@@ -241,7 +240,7 @@ func countChanges(changes []KeyspaceChangeData) (totalStatements, keyspacesWithD
 	return
 }
 
-func writePlanSummary(sb *strings.Builder, data PlanCommentData, totalStatements, keyspacesWithDDL, keyspacesWithVSchema int) {
+func writePlanSummary(sb *strings.Builder, data PlanCommentData, totalStatements, keyspacesWithVSchema int) {
 	totalChanges := totalStatements + keyspacesWithVSchema
 	if totalChanges == 0 {
 		writeNoChangesDetected(sb, data)
@@ -451,7 +450,7 @@ func RenderMultiEnvPlanComment(data MultiEnvPlanCommentData) string {
 	if !hasErrors && envsWithChanges >= 2 && allPlansIdentical(data) {
 		// Identical plans: render once with combined header
 		fmt.Fprintf(&sb, "### %s\n\n", capitalizeEnvNames(data.Environments))
-		writeEnvironmentPlanSection(&sb, data.Plans[data.Environments[0]], data.IsMySQL)
+		writeEnvironmentPlanSection(&sb, data.Plans[data.Environments[0]])
 	} else {
 		// Separate sections per environment
 		for _, env := range data.Environments {
@@ -469,7 +468,7 @@ func RenderMultiEnvPlanComment(data MultiEnvPlanCommentData) string {
 				continue
 			}
 
-			writeEnvironmentPlanSection(&sb, plan, data.IsMySQL)
+			writeEnvironmentPlanSection(&sb, plan)
 		}
 	}
 
@@ -481,8 +480,8 @@ func RenderMultiEnvPlanComment(data MultiEnvPlanCommentData) string {
 }
 
 // writeEnvironmentPlanSection writes the plan body for a single environment within a multi-env comment.
-func writeEnvironmentPlanSection(sb *strings.Builder, plan *PlanCommentData, isMySQL bool) {
-	totalStatements, keyspacesWithDDL, keyspacesWithVSchema := countChanges(plan.Changes)
+func writeEnvironmentPlanSection(sb *strings.Builder, plan *PlanCommentData) {
+	totalStatements, keyspacesWithVSchema := countChanges(plan.Changes)
 	totalChanges := totalStatements + keyspacesWithVSchema
 
 	if totalChanges == 0 {
@@ -509,7 +508,7 @@ func writeEnvironmentPlanSection(sb *strings.Builder, plan *PlanCommentData, isM
 	}
 
 	// Summary (after DDL, matching CLI layout)
-	writePlanSummary(sb, *plan, totalStatements, keyspacesWithDDL, keyspacesWithVSchema)
+	writePlanSummary(sb, *plan, totalStatements, keyspacesWithVSchema)
 }
 
 // writeMultiEnvFooter writes the footer with apply commands and error guidance.

--- a/pkg/webhook/templates/rollback.go
+++ b/pkg/webhook/templates/rollback.go
@@ -22,7 +22,7 @@ func RenderRollbackPlanComment(data PlanCommentData) string {
 	sb.WriteString("\n")
 
 	// Count changes
-	totalStatements, keyspacesWithDDL, keyspacesWithVSchema := countChanges(data.Changes)
+	totalStatements, keyspacesWithVSchema := countChanges(data.Changes)
 	totalChanges := totalStatements + keyspacesWithVSchema
 
 	// Summary
@@ -48,7 +48,7 @@ func RenderRollbackPlanComment(data PlanCommentData) string {
 	}
 
 	// Summary (after DDL, matching CLI layout)
-	writePlanSummary(&sb, data, totalStatements, keyspacesWithDDL, keyspacesWithVSchema)
+	writePlanSummary(&sb, data, totalStatements, keyspacesWithVSchema)
 
 	// Footer
 	sb.WriteString("---\n\n")

--- a/pkg/webhook/webhook_e2e_test.go
+++ b/pkg/webhook/webhook_e2e_test.go
@@ -2001,9 +2001,7 @@ func TestE2EAggregateCheckStaleCleanupBlocksStartedApply(t *testing.T) {
 	}
 
 	installClient := ghclient.NewInstallationClient(client, h.logger)
-	h.postPassingAggregates(ctx, installClient, "octocat/hello-world", 1, "newsha222",
-		"No managed schema changes",
-		"This PR does not contain schema changes managed by SchemaBot.")
+	h.postPassingAggregates(ctx, installClient, "octocat/hello-world", 1, "newsha222")
 	select {
 	case cr := <-checkRuns:
 		require.NotEqual(t, checkConclusionSuccess, cr.Conclusion, "passing aggregate must not be published while a started apply blocks the PR")
@@ -3977,9 +3975,7 @@ func TestE2EDisabledRepoChecksSkipAggregatePublishing(t *testing.T) {
 	installClient := ghclient.NewInstallationClient(client, h.logger)
 
 	h.updateAggregateCheck(ctx, installClient, "octocat/hello-world", 1, "abc123")
-	h.postPassingAggregates(ctx, installClient, "octocat/hello-world", 1, "abc123",
-		"No managed schema changes",
-		"This PR does not contain schema changes managed by SchemaBot.")
+	h.postPassingAggregates(ctx, installClient, "octocat/hello-world", 1, "abc123")
 	h.postFailingAggregates(ctx, installClient, "octocat/hello-world", 1, "abc123", map[string]string{
 		"staging": "Plan failed",
 	})
@@ -4025,9 +4021,7 @@ func TestE2EPassingAggregateRequiresGitHubHeadVerification(t *testing.T) {
 
 	h := newE2EHandler(t, svc, client)
 	installClient := ghclient.NewInstallationClient(client, h.logger)
-	h.postPassingAggregates(ctx, installClient, "octocat/hello-world", 1, "abc123",
-		"No managed schema changes",
-		"This PR does not contain schema changes managed by SchemaBot.")
+	h.postPassingAggregates(ctx, installClient, "octocat/hello-world", 1, "abc123")
 
 	// Without head verification, SchemaBot must not publish or store a passing
 	// aggregate check that could incorrectly unblock branch protection.


### PR DESCRIPTION
## What

Enable the `unparam` linter (excluding `_test.go`) and fix the resulting backlog of production violations:

- Remove unused parameters and the now-dead call-site arguments.
- Drop function results that no caller consumes.
- Inline parameters that only ever receive one constant value.
- Delete `truncateDDL`, which had no production caller.

## Why

`unparam` flags dead/constant parameters and unused results — the same class of issue raised in Copilot review on #390 (https://github.com/block/schemabot/pull/390#discussion_r3424740463). Enforcing it in CI catches these automatically instead of relying on review. Test helpers are excluded because their uniform signatures intentionally carry fixed arguments, so churning them adds noise without value.

All three lint matrices (default, integration, e2e) report 0 issues; build and unit tests pass.

## Details
- **Unused params removed** (+ call sites updated): `executeStartForApply` (`ternApplyID`), `verifyBranchMatchesMain` (`schemaFiles`), `runEngineTask` (`plan`), `checkPriorEnvironments` (`requestedBy`), `handleRollbackConfirmCommand` (`databaseName`), `renderTableProgress` (`globalState`), `writePlanSummary` (`keyspacesWithDDL`), `writeEnvironmentPlanSection` (`isMySQL`), `formatExitContext`/`printExitContext` (`database`)
- **Unused results removed:** `applyAndWatch` (string), `previewTUIStatic` (error), `postAndTrackComment` (int64 — tests now capture the ID from the GH-create channel), `countChanges` (`keyspacesWithDDL`)
- **Constant params inlined:** `setMigrationState` → `setMigrationCompleted` (always `StateCompleted`), `logApplyEvent` (gRPC, `source` always `schemabot`), `postPassingAggregates` (`title`/`summary` constants)
- **Dead code deleted:** `truncateDDL` + its test (only test-referenced)

