### PR TITLE
feat(ci): run workflows in the merge queue

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -179,7 +179,7 @@ jobs:
           build-args: |
             VERSION=${{ github.ref_name }}
             COMMIT=${{ github.sha }}
-            BUILD_DATE=${{ github.event.head_commit.timestamp || github.event.pull_request.updated_at }}
+            BUILD_DATE=${{ github.event.head_commit.timestamp || github.event.pull_request.updated_at || github.run_started_at }}
 
       # LocalScale image — fake PlanetScale API for testing.
       # Published to ghcr.io/block/schemabot/localscale:<sha|latest>

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,6 +16,10 @@ on:
     tags: ["v*"]
     branches: [main]
   pull_request:
+  # Required status checks must also report on the merge queue, or the queue
+  # waits forever. The build runs to validate; pushes stay gated on push events,
+  # so the queue never publishes. Inert until a repo admin enables the queue.
+  merge_group:
 
 permissions: {}
 
@@ -128,14 +132,14 @@ jobs:
           done
 
       - name: Set up QEMU
-        if: github.event_name != 'pull_request'
+        if: github.event_name == 'push'
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # docker/setup-buildx-action@v3
 
       - name: Login to GitHub Container Registry
-        if: github.event_name != 'pull_request'
+        if: github.event_name == 'push'
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
@@ -166,9 +170,10 @@ jobs:
         with:
           context: .
           file: deploy/Dockerfile
-          # Multi-arch on push/tag, single platform on PR for speed
-          platforms: ${{ github.event_name != 'pull_request' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
-          push: ${{ github.event_name != 'pull_request' }}
+          # Multi-arch only when publishing (push/tag); single platform on PRs
+          # and in the merge queue for speed (those validate the build, no push)
+          platforms: ${{ github.event_name == 'push' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
+          push: ${{ github.event_name == 'push' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
@@ -196,7 +201,7 @@ jobs:
           context: .
           file: deploy/local/Dockerfile.localscale
           platforms: linux/amd64
-          push: ${{ github.event_name != 'pull_request' }}
+          push: ${{ github.event_name == 'push' }}
           tags: ${{ steps.localscale-meta.outputs.tags }}
           labels: ${{ steps.localscale-meta.outputs.labels }}
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -7,6 +7,9 @@ on:
       - master
       - main
   pull_request:
+  # Required status checks must also report on the merge queue, or the queue
+  # waits forever. Inert until a repo admin enables the merge queue.
+  merge_group:
 permissions:
   contents: read
 jobs:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,6 +7,10 @@ on:
       - master
       - main
   pull_request:
+  # Run in the merge queue so the full suite gates merges. Required for the
+  # planned PR-smoke / queue-full e2e split. Inert until a repo admin enables
+  # the merge queue in branch protection.
+  merge_group:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
## What

Add a `merge_group` trigger to the `test`, `lint`, and `docker` workflows so
their checks report on the merge-queue ref. Also re-gate the docker publish
steps (QEMU, registry login, `push:`, multi-arch `platforms:`) to run only on
`push` events, so the queue validates the image build without logging in or
publishing.

## Why

A merge queue requires every required status check to run on the `merge_group`
event, or the queue stalls forever. The `changes` job already resolves
`code=true` for non-PR events, so the full suite runs in the queue with no extra
logic. The publish re-gating fixes a footgun: the old `!= 'pull_request'`
condition is **true** for `merge_group`, which would have made the queue push
images.

Inert until a repo admin enables the merge queue in branch protection and
selects the queue-required checks (keep the PR-only chart-lint out of that set).
No behavior change to today's PR/`main` flows.

## Time savings

This PR is only the enabler — the savings land in the next one (the e2e split).
Jobs run in parallel, so the win is in **CI-minutes (compute/cost)**, not
wall-clock. Figures below are from a representative recent `Tests` run.

Where the minutes go per run:

| Bucket | Jobs | ~CI-min |
|---|---|---|
| Light (stays on PR) | build, unit, integration | ~9 |
| Heavy (moves to queue-only) | 3× E2E-K8s, E2E-MySQL, 3× E2E-Vitess, 3× LocalScale | ~39 |
| **Full run total** | | **~48** |

Cost per PR, by number of pushes before merge (heavy suite runs once at merge
instead of on every push):

| Pushes | Today (N×48) | After (N×12 + 48) | Change |
|---|---|---|---|
| 1 | 48 | 60 | 🔺 +25% |
| 3 | 144 | 84 | 💰 −42% |
| 5 | 240 | 108 | 💰 −55% |
| 10 | 480 | 168 | 💰💰 −65% |

PR feedback wall-clock drops ~5.5 → ~4.5 min (bounded by integration, not k8s).
Single-push PRs are roughly a wash; savings come from iterative PRs, the common
case.