### PR TITLE
feat(tern): store remote apply id per operation for fan-out applies

### DIFF
--- a/pkg/tern/grpc_client.go
+++ b/pkg/tern/grpc_client.go
@@ -443,7 +443,7 @@ func (c *GRPCClient) Cutover(ctx context.Context, req *ternv1.CutoverRequest) (*
 	return c.client.Cutover(ctx, req)
 }
 
-func (c *GRPCClient) processPendingCutoverControlRequest(ctx context.Context, apply *storage.Apply) error {
+func (c *GRPCClient) processPendingCutoverControlRequest(ctx context.Context, apply *storage.Apply, scope applyTaskScope) error {
 	controlReq, err := pendingCutoverControlRequest(ctx, c.storage, apply)
 	if err != nil {
 		return err
@@ -494,7 +494,8 @@ func (c *GRPCClient) processPendingCutoverControlRequest(ctx context.Context, ap
 			"state", apply.State)
 		return nil
 	}
-	if apply.ExternalID == "" {
+	remoteID := scope.remoteApplyID(apply)
+	if remoteID == "" {
 		message := "remote apply id is not available"
 		if err := failPendingCutoverControlRequests(ctx, c.storage, apply, message); err != nil {
 			return err
@@ -511,7 +512,7 @@ func (c *GRPCClient) processPendingCutoverControlRequest(ctx context.Context, ap
 		return err
 	}
 	resp, err := c.client.Cutover(ctx, &ternv1.CutoverRequest{
-		ApplyId:     apply.ExternalID,
+		ApplyId:     remoteID,
 		Environment: apply.Environment,
 	})
 	if err != nil {
@@ -605,7 +606,8 @@ func (c *GRPCClient) processPendingStopControlRequest(ctx context.Context, apply
 		}
 		return true, nil
 	}
-	if apply.ExternalID == "" {
+	remoteID := scope.remoteApplyID(apply)
+	if remoteID == "" {
 		if err := c.stopUndispatchedApply(ctx, apply, controlRequestCaller(controlReq), scope); err != nil {
 			return true, err
 		}
@@ -616,40 +618,40 @@ func (c *GRPCClient) processPendingStopControlRequest(ctx context.Context, apply
 	}
 
 	resp, err := c.client.Stop(ctx, &ternv1.StopRequest{
-		ApplyId:     apply.ExternalID,
+		ApplyId:     remoteID,
 		Environment: apply.Environment,
 	})
 	if err != nil {
 		if completed, completeErr := c.completeRemoteStopFromTerminalProgress(ctx, apply, controlReq, scope); completeErr == nil && completed {
 			return true, nil
 		} else if completeErr != nil {
-			return true, fmt.Errorf("request remote gRPC stop for apply %s remote %s: %w; terminal progress reconciliation also failed: %w", apply.ApplyIdentifier, apply.ExternalID, err, completeErr)
+			return true, fmt.Errorf("request remote gRPC stop for apply %s remote %s: %w; terminal progress reconciliation also failed: %w", apply.ApplyIdentifier, remoteID, err, completeErr)
 		}
-		return true, fmt.Errorf("request remote gRPC stop for apply %s remote %s: %w", apply.ApplyIdentifier, apply.ExternalID, err)
+		return true, fmt.Errorf("request remote gRPC stop for apply %s remote %s: %w", apply.ApplyIdentifier, remoteID, err)
 	}
 	if resp == nil || !resp.Accepted {
 		errorMessage := "not accepted"
 		if resp != nil && resp.ErrorMessage != "" {
 			errorMessage = resp.ErrorMessage
 		}
-		return true, fmt.Errorf("request remote gRPC stop for apply %s remote %s: %s", apply.ApplyIdentifier, apply.ExternalID, errorMessage)
+		return true, fmt.Errorf("request remote gRPC stop for apply %s remote %s: %s", apply.ApplyIdentifier, remoteID, errorMessage)
 	}
 	c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventStopRequested,
-		fmt.Sprintf("Remote stop accepted for apply %s%s", apply.ExternalID, callerApplyLogSuffix(controlRequestCaller(controlReq))), "", "")
+		fmt.Sprintf("Remote stop accepted for apply %s%s", remoteID, callerApplyLogSuffix(controlRequestCaller(controlReq))), "", "")
 
 	progress, err := c.client.Progress(ctx, &ternv1.ProgressRequest{
-		ApplyId:     apply.ExternalID,
+		ApplyId:     remoteID,
 		Environment: apply.Environment,
 	})
 	if err != nil {
-		return true, fmt.Errorf("sync remote gRPC stop for apply %s remote %s: %w", apply.ApplyIdentifier, apply.ExternalID, err)
+		return true, fmt.Errorf("sync remote gRPC stop for apply %s remote %s: %w", apply.ApplyIdentifier, remoteID, err)
 	}
 	if progress.State == ternv1.State_STATE_NO_ACTIVE_CHANGE {
-		return true, fmt.Errorf("sync remote gRPC stop for apply %s remote %s: no active schema change", apply.ApplyIdentifier, apply.ExternalID)
+		return true, fmt.Errorf("sync remote gRPC stop for apply %s remote %s: no active schema change", apply.ApplyIdentifier, remoteID)
 	}
 	remoteState := ProtoStateToStorage(progress.State)
 	if remoteState == "" {
-		return true, fmt.Errorf("sync remote gRPC stop for apply %s remote %s: unmapped remote state %s", apply.ApplyIdentifier, apply.ExternalID, remoteApplyStateDescription(progress.State))
+		return true, fmt.Errorf("sync remote gRPC stop for apply %s remote %s: unmapped remote state %s", apply.ApplyIdentifier, remoteID, remoteApplyStateDescription(progress.State))
 	}
 	now := time.Now()
 	if apply.StartedAt == nil && !state.IsState(remoteState, state.Apply.Pending) {
@@ -694,7 +696,7 @@ func (c *GRPCClient) processPendingStopControlRequest(ctx context.Context, apply
 
 func (c *GRPCClient) completeRemoteStopFromTerminalProgress(ctx context.Context, apply *storage.Apply, controlReq *storage.ApplyControlRequest, scope applyTaskScope) (bool, error) {
 	progress, err := c.client.Progress(ctx, &ternv1.ProgressRequest{
-		ApplyId:     apply.ExternalID,
+		ApplyId:     scope.remoteApplyID(apply),
 		Environment: apply.Environment,
 	})
 	if err != nil {
@@ -804,24 +806,142 @@ func (c *GRPCClient) Health(ctx context.Context) error {
 	return err
 }
 
-// applyTaskScope selects which task rows the remote drive re-queries. The zero
-// value scopes to the whole apply (all its operations); an operation-scoped
-// value restricts the drive to a single apply_operation (one deployment), so a
-// worker can advance one deployment independently of its siblings.
+// applyTaskScope selects which task rows the remote drive re-queries and where
+// the remote Tern apply id for the drive is read and written. The zero value
+// scopes to the whole apply (all its operations) and uses the parent
+// applies.external_id, matching the single-operation behaviour. An
+// operation-scoped value restricts the drive to a single apply_operation (one
+// deployment) so a worker can advance one deployment independently of its
+// siblings; when the parent owns more than one operation it also routes the
+// remote apply id through that operation's engine_resume_context instead of the
+// shared parent external_id, so one deployment never reuses or overwrites
+// another deployment's remote apply id.
 type applyTaskScope struct {
 	applyOperationID int64
+
+	// operation is the claimed apply_operation row, loaded and validated for
+	// operation-scoped drives. nil for whole-apply drives.
+	operation *storage.ApplyOperation
+
+	// multiOperation is true only when the parent apply owns more than one
+	// operation. Deployment equality is not enough to detect this: the primary
+	// operation of a multi-op apply shares apply.Deployment, so the operation
+	// count is the authoritative signal for routing the remote apply id per op.
+	multiOperation bool
 }
 
 func wholeApplyTaskScope() applyTaskScope {
 	return applyTaskScope{}
 }
 
-func operationApplyTaskScope(applyOperationID int64) applyTaskScope {
-	return applyTaskScope{applyOperationID: applyOperationID}
-}
-
 func (s applyTaskScope) isOperationScoped() bool {
 	return s.applyOperationID > 0
+}
+
+// usesOperationRemoteResume reports whether the remote apply id for this drive
+// lives on the claimed operation's engine_resume_context rather than the parent
+// applies.external_id. Only multi-operation drives do; single-operation and
+// whole-apply drives keep using the parent external_id.
+func (s applyTaskScope) usesOperationRemoteResume() bool {
+	return s.multiOperation && s.operation != nil
+}
+
+// remoteApplyID resolves the remote Tern apply id sent on this drive's
+// Progress/Stop/Start/Cutover calls. Multi-operation drives read the claimed
+// operation's engine_resume_context (which may be empty before dispatch);
+// everything else reads the parent external_id.
+func (s applyTaskScope) remoteApplyID(apply *storage.Apply) string {
+	if s.usesOperationRemoteResume() {
+		return s.operation.EngineResumeContext
+	}
+	return apply.ExternalID
+}
+
+// dispatchState returns the state that governs the dispatch / ambiguity
+// decision. A multi-operation drive keys on the claimed operation's state: the
+// parent apply may already be running because a sibling deployment is active
+// while this operation still needs its first remote dispatch.
+func (s applyTaskScope) dispatchState(apply *storage.Apply) string {
+	if s.usesOperationRemoteResume() {
+		return s.operation.State
+	}
+	return apply.State
+}
+
+// loadOperationApplyTaskScope loads and validates the claimed apply_operation
+// row and determines whether the parent apply is multi-operation. It fails
+// closed on any mismatch so an operation-scoped drive can never act on another
+// apply's row, a sibling deployment, or a row outside the parent's operation
+// set.
+func (c *GRPCClient) loadOperationApplyTaskScope(ctx context.Context, apply *storage.Apply, applyOperationID int64) (applyTaskScope, error) {
+	operation, err := c.storage.ApplyOperations().Get(ctx, applyOperationID)
+	if err != nil {
+		return applyTaskScope{}, fmt.Errorf("load apply_operation %d for apply %s: %w", applyOperationID, apply.ApplyIdentifier, err)
+	}
+	if operation.ApplyID != apply.ID {
+		return applyTaskScope{}, fmt.Errorf("apply_operation %d belongs to apply %d, not %s (%d)", applyOperationID, operation.ApplyID, apply.ApplyIdentifier, apply.ID)
+	}
+	if operation.Deployment == "" {
+		return applyTaskScope{}, fmt.Errorf("apply_operation %d for apply %s has no deployment", applyOperationID, apply.ApplyIdentifier)
+	}
+	if apply.Deployment != "" && apply.Deployment != operation.Deployment {
+		return applyTaskScope{}, fmt.Errorf("apply %s deployment %q does not match apply_operation %d deployment %q", apply.ApplyIdentifier, apply.Deployment, applyOperationID, operation.Deployment)
+	}
+	ops, err := c.storage.ApplyOperations().ListByApply(ctx, apply.ID)
+	if err != nil {
+		return applyTaskScope{}, fmt.Errorf("list operations for apply %s: %w", apply.ApplyIdentifier, err)
+	}
+	found := false
+	for _, op := range ops {
+		if op.ID == applyOperationID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return applyTaskScope{}, fmt.Errorf("apply_operation %d is not part of apply %s operation set", applyOperationID, apply.ApplyIdentifier)
+	}
+	return applyTaskScope{
+		applyOperationID: applyOperationID,
+		operation:        operation,
+		multiOperation:   len(ops) > 1,
+	}, nil
+}
+
+// persistRemoteApplyID stores the remote Tern apply id returned by dispatch.
+// Single-operation drives keep it on the parent applies.external_id (mutated in
+// place so the caller's Applies().Update persists it). Multi-operation drives
+// write it to the claimed operation's engine_resume_context and never touch the
+// parent external_id, refusing to overwrite a different existing id so one
+// deployment can't clobber another deployment's remote apply id.
+func (c *GRPCClient) persistRemoteApplyID(ctx context.Context, apply *storage.Apply, scope applyTaskScope, remoteID string) error {
+	if remoteID == "" {
+		return fmt.Errorf("refusing to persist empty remote apply id for apply %s", apply.ApplyIdentifier)
+	}
+	if !scope.usesOperationRemoteResume() {
+		apply.ExternalID = remoteID
+		return nil
+	}
+	op := scope.operation
+	current, err := c.storage.ApplyOperations().Get(ctx, op.ID)
+	if err != nil {
+		return fmt.Errorf("reload apply_operation %d before storing remote apply id: %w", op.ID, err)
+	}
+	if current.ApplyID != apply.ID {
+		return fmt.Errorf("apply_operation %d belongs to apply %d, not %s (%d)", op.ID, current.ApplyID, apply.ApplyIdentifier, apply.ID)
+	}
+	if current.EngineResumeContext != "" && current.EngineResumeContext != remoteID {
+		return fmt.Errorf("apply_operation %d already has remote apply id %q; refusing to overwrite with %q", op.ID, current.EngineResumeContext, remoteID)
+	}
+	if err := c.storage.ApplyOperations().SaveEngineResumeState(ctx, op.ID, &storage.EngineResumeState{
+		ApplyOperationID: op.ID,
+		MigrationContext: remoteID,
+		Metadata:         "{}",
+	}); err != nil {
+		return fmt.Errorf("store remote apply id for apply_operation %d: %w", op.ID, err)
+	}
+	op.EngineResumeContext = remoteID
+	return nil
 }
 
 // loadApplyTasks loads the task rows the remote drive operates on, scoped either
@@ -874,7 +994,10 @@ func (c *GRPCClient) ResumeApplyOperation(ctx context.Context, apply *storage.Ap
 	if apply == nil {
 		return fmt.Errorf("apply is required")
 	}
-	scope := operationApplyTaskScope(applyOperationID)
+	scope, err := c.loadOperationApplyTaskScope(ctx, apply, applyOperationID)
+	if err != nil {
+		return err
+	}
 	// Fail closed before any dispatch or state mutation: an operation that
 	// resolves to no tasks is an invalid or stale claim. The shared resume path
 	// would otherwise mark the whole parent apply failed (dispatchPendingApply
@@ -906,14 +1029,14 @@ func (c *GRPCClient) resumeApply(ctx context.Context, apply *storage.Apply, scop
 	if handled, err := c.processPendingStopControlRequest(ctx, apply, scope); handled || err != nil {
 		return err
 	}
-	if err := c.processPendingCutoverControlRequest(ctx, apply); err != nil {
+	if err := c.processPendingCutoverControlRequest(ctx, apply, scope); err != nil {
 		return err
 	}
 
-	if shouldDispatchQueuedRemoteApply(apply) {
+	if shouldDispatchQueuedRemoteApply(apply, scope) {
 		return c.dispatchPendingApply(ctx, apply, scope)
 	}
-	if hasAmbiguousRemoteDispatchState(apply) {
+	if hasAmbiguousRemoteDispatchState(apply, scope) {
 		errMsg := fmt.Sprintf("gRPC apply %s is %s without external_id; remote dispatch state is ambiguous", apply.ApplyIdentifier, apply.State)
 		if err := c.markRemoteApplyFailed(ctx, apply, nil, errMsg, false, scope); err != nil {
 			return fmt.Errorf("%s; persist failure state: %w", errMsg, err)
@@ -935,17 +1058,18 @@ func (c *GRPCClient) resumeApply(ctx context.Context, apply *storage.Apply, scop
 		if handled, err := c.processPendingStopControlRequest(ctx, apply, scope); handled || err != nil {
 			return err
 		}
-		if err := c.processPendingStartControlRequest(ctx, apply); err != nil {
+		if err := c.processPendingStartControlRequest(ctx, apply, scope); err != nil {
 			return err
 		}
 	}
 
-	if apply.ExternalID != "" && state.IsState(apply.State, state.Apply.Pending) && !startRequested {
+	remoteID := scope.remoteApplyID(apply)
+	if remoteID != "" && state.IsState(apply.State, state.Apply.Pending) && !startRequested {
 		if handled, err := c.processPendingStopControlRequest(ctx, apply, scope); handled || err != nil {
 			return err
 		}
 		_, err := c.client.Start(ctx, &ternv1.StartRequest{
-			ApplyId:     apply.ExternalID,
+			ApplyId:     remoteID,
 			Environment: apply.Environment,
 		})
 		if err != nil {
@@ -968,7 +1092,7 @@ func (c *GRPCClient) resumeApply(ctx context.Context, apply *storage.Apply, scop
 		oldState := apply.State
 		remoteStartRequested := false
 		resp, err := c.client.Progress(ctx, &ternv1.ProgressRequest{
-			ApplyId:     apply.ExternalID,
+			ApplyId:     remoteID,
 			Environment: apply.Environment,
 		})
 		if err == nil {
@@ -1034,11 +1158,11 @@ func (c *GRPCClient) resumeApply(ctx context.Context, apply *storage.Apply, scop
 				return err
 			}
 			_, err := c.client.Start(ctx, &ternv1.StartRequest{
-				ApplyId:     apply.ExternalID,
+				ApplyId:     remoteID,
 				Environment: apply.Environment,
 			})
 			if err != nil {
-				message := fmt.Sprintf("remote start failed for remote apply %s: %v", apply.ExternalID, err)
+				message := fmt.Sprintf("remote start failed for remote apply %s: %v", remoteID, err)
 				slog.Warn("remote gRPC start failed; storing stopped state for operator retry",
 					"apply_id", apply.ApplyIdentifier,
 					"external_id", apply.ExternalID,
@@ -1147,7 +1271,7 @@ func (c *GRPCClient) waitForPendingStopBeforeStart(ctx context.Context, apply *s
 	}
 }
 
-func (c *GRPCClient) processPendingStartControlRequest(ctx context.Context, apply *storage.Apply) error {
+func (c *GRPCClient) processPendingStartControlRequest(ctx context.Context, apply *storage.Apply, scope applyTaskScope) error {
 	controlReq, err := pendingStartControlRequest(ctx, c.storage, apply)
 	if err != nil {
 		return err
@@ -1171,7 +1295,8 @@ func (c *GRPCClient) processPendingStartControlRequest(ctx context.Context, appl
 	if !state.IsState(apply.State, state.Apply.WaitingForDeploy) {
 		return nil
 	}
-	if apply.ExternalID == "" {
+	remoteID := scope.remoteApplyID(apply)
+	if remoteID == "" {
 		message := fmt.Sprintf("gRPC apply %s is waiting for deploy without external_id; start dispatch state is ambiguous", apply.ApplyIdentifier)
 		if err := failPendingStartControlRequests(ctx, c.storage, apply, message); err != nil {
 			return err
@@ -1179,11 +1304,11 @@ func (c *GRPCClient) processPendingStartControlRequest(ctx context.Context, appl
 		return errors.New(message)
 	}
 	_, err = c.client.Start(ctx, &ternv1.StartRequest{
-		ApplyId:     apply.ExternalID,
+		ApplyId:     remoteID,
 		Environment: apply.Environment,
 	})
 	if err != nil {
-		message := fmt.Sprintf("remote deferred deploy start failed for remote apply %s: %v", apply.ExternalID, err)
+		message := fmt.Sprintf("remote deferred deploy start failed for remote apply %s: %v", remoteID, err)
 		slog.Warn("remote gRPC deferred deploy start failed; storing start request failure",
 			"apply_id", apply.ApplyIdentifier,
 			"external_id", apply.ExternalID,
@@ -1211,20 +1336,20 @@ func (c *GRPCClient) processPendingStartControlRequest(ctx context.Context, appl
 	return nil
 }
 
-func shouldDispatchQueuedRemoteApply(apply *storage.Apply) bool {
+func shouldDispatchQueuedRemoteApply(apply *storage.Apply, scope applyTaskScope) bool {
 	if apply == nil {
 		return false
 	}
-	return apply.ExternalID == "" && state.IsState(apply.State, state.Apply.Pending, state.Apply.FailedRetryable)
+	return scope.remoteApplyID(apply) == "" && state.IsState(scope.dispatchState(apply), state.Apply.Pending, state.Apply.FailedRetryable)
 }
 
-func hasAmbiguousRemoteDispatchState(apply *storage.Apply) bool {
+func hasAmbiguousRemoteDispatchState(apply *storage.Apply, scope applyTaskScope) bool {
 	if apply == nil {
 		return false
 	}
-	return apply.ExternalID == "" &&
-		!state.IsTerminalApplyState(apply.State) &&
-		!shouldDispatchQueuedRemoteApply(apply)
+	return scope.remoteApplyID(apply) == "" &&
+		!state.IsTerminalApplyState(scope.dispatchState(apply)) &&
+		!shouldDispatchQueuedRemoteApply(apply, scope)
 }
 
 func (c *GRPCClient) dispatchPendingApply(ctx context.Context, apply *storage.Apply, scope applyTaskScope) error {
@@ -1317,7 +1442,13 @@ func (c *GRPCClient) dispatchPendingApply(ctx context.Context, apply *storage.Ap
 
 	oldApplyState := apply.State
 	now := time.Now()
-	apply.ExternalID = resp.ApplyId
+	// Persist the remote apply id before the parent state update so a failure
+	// after this point can resume the exact remote operation instead of
+	// dispatching a duplicate. Multi-operation drives store it on the claimed
+	// operation row; single-operation drives mutate apply.ExternalID in place.
+	if err := c.persistRemoteApplyID(ctx, apply, scope, resp.ApplyId); err != nil {
+		return fmt.Errorf("store remote apply id for %s: %w", apply.ApplyIdentifier, err)
+	}
 	apply.State = state.Apply.Running
 	apply.ErrorMessage = ""
 	apply.CompletedAt = nil
@@ -1326,10 +1457,10 @@ func (c *GRPCClient) dispatchPendingApply(ctx context.Context, apply *storage.Ap
 	}
 	apply.UpdatedAt = now
 	if err := c.storage.Applies().Update(ctx, apply); err != nil {
-		return fmt.Errorf("store remote apply id for %s: %w", apply.ApplyIdentifier, err)
+		return fmt.Errorf("update dispatched gRPC apply %s after storing remote apply id %s: %w", apply.ApplyIdentifier, resp.ApplyId, err)
 	}
 	c.logApplyStateTransition(ctx, apply, storage.LogLevelInfo,
-		fmt.Sprintf("Apply dispatched to remote Tern: target=%s deployment=%s remote_apply_id=%s", target, apply.Deployment, apply.ExternalID),
+		fmt.Sprintf("Apply dispatched to remote Tern: target=%s deployment=%s remote_apply_id=%s", target, apply.Deployment, resp.ApplyId),
 		oldApplyState)
 
 	return c.pollForCompletion(ctx, apply, false, scope)
@@ -1885,7 +2016,7 @@ func (c *GRPCClient) pollForCompletion(ctx context.Context, apply *storage.Apply
 			} else if handled {
 				return nil
 			}
-			if err := c.processPendingCutoverControlRequest(ctx, apply); err != nil {
+			if err := c.processPendingCutoverControlRequest(ctx, apply, scope); err != nil {
 				slog.Warn("pending gRPC cutover request processing failed; current apply owner will exit for operator retry",
 					"apply_id", apply.ApplyIdentifier,
 					"external_id", apply.ExternalID,
@@ -1896,17 +2027,18 @@ func (c *GRPCClient) pollForCompletion(ctx context.Context, apply *storage.Apply
 			}
 
 			// Poll progress from remote Tern
+			remoteID := scope.remoteApplyID(apply)
 			resp, err := c.client.Progress(ctx, &ternv1.ProgressRequest{
-				ApplyId:     apply.ExternalID,
+				ApplyId:     remoteID,
 				Environment: apply.Environment,
 			})
 			if err != nil {
 				if status.Code(err) == codes.NotFound {
-					message := fmt.Sprintf("remote apply %s was not found by data plane", apply.ExternalID)
+					message := fmt.Sprintf("remote apply %s was not found by data plane", remoteID)
 					return c.failMissingRemoteApply(ctx, apply, message, err, scope)
 				}
 				if isTerminalRemoteProgressError(err) {
-					message := fmt.Sprintf("remote progress failed for remote apply %s: %v", apply.ExternalID, err)
+					message := fmt.Sprintf("remote progress failed for remote apply %s: %v", remoteID, err)
 					if markErr := c.markRemoteApplyFailed(ctx, apply, nil, message, false, scope); markErr != nil {
 						return fmt.Errorf("mark remote apply %s failed after terminal progress error: %w", apply.ApplyIdentifier, markErr)
 					}

--- a/pkg/tern/grpc_client.go
+++ b/pkg/tern/grpc_client.go
@@ -608,6 +608,18 @@ func (c *GRPCClient) processPendingStopControlRequest(ctx context.Context, apply
 	}
 	remoteID := scope.remoteApplyID(apply)
 	if remoteID == "" {
+		if scope.usesOperationRemoteResume() {
+			// A multi-operation apply has one stop request shared by every
+			// deployment. Stopping this undispatched operation must not
+			// terminalize the parent or complete the apply-level request:
+			// sibling deployments with their own remote apply id still need to
+			// observe the durable stop. Stop only this operation and leave the
+			// request pending for the siblings.
+			if err := c.stopUndispatchedApplyOperation(ctx, apply, controlRequestCaller(controlReq), scope); err != nil {
+				return true, err
+			}
+			return true, nil
+		}
 		if err := c.stopUndispatchedApply(ctx, apply, controlRequestCaller(controlReq), scope); err != nil {
 			return true, err
 		}
@@ -785,6 +797,76 @@ func (c *GRPCClient) stopUndispatchedApply(ctx context.Context, apply *storage.A
 	return nil
 }
 
+// stopUndispatchedApplyOperation stops a single undispatched operation of a
+// multi-operation apply. It terminalizes only this operation's tasks and the
+// operation row, never the parent apply, and never completes the apply-level
+// stop request: that request is shared across deployments and must remain
+// pending so sibling operations with their own remote apply id still observe
+// the stop.
+func (c *GRPCClient) stopUndispatchedApplyOperation(ctx context.Context, apply *storage.Apply, caller string, scope applyTaskScope) error {
+	if !scope.usesOperationRemoteResume() {
+		return fmt.Errorf("undispatched operation stop for apply %s requires multi-operation scope", apply.ApplyIdentifier)
+	}
+	op := scope.operation
+	now := time.Now()
+	taskState := state.Task.Stopped
+	operationState := state.ApplyOperation.Stopped
+	if apply.DatabaseType == storage.DatabaseTypeVitess {
+		taskState = state.Task.Cancelled
+		operationState = state.ApplyOperation.Cancelled
+	}
+	tasks, err := c.loadApplyTasks(ctx, apply, scope)
+	if err != nil {
+		return fmt.Errorf("load tasks for undispatched operation stop %s apply_operation %d: %w", apply.ApplyIdentifier, op.ID, err)
+	}
+	for _, task := range tasks {
+		if state.IsTerminalTaskState(task.State) {
+			slog.Info("leaving terminal gRPC task unchanged during undispatched operation stop",
+				"apply_id", apply.ApplyIdentifier,
+				"apply_operation_id", op.ID,
+				"deployment", op.Deployment,
+				"task_id", task.TaskIdentifier,
+				"table", task.TableName,
+				"task_state", task.State)
+			continue
+		}
+		task.State = taskState
+		if state.IsState(taskState, state.Task.Cancelled) {
+			task.CompletedAt = &now
+		}
+		task.UpdatedAt = now
+		if err := c.storage.Tasks().Update(ctx, task); err != nil {
+			return fmt.Errorf("update task %s for undispatched operation stop %s apply_operation %d: %w", task.TaskIdentifier, apply.ApplyIdentifier, op.ID, err)
+		}
+	}
+	oldState := op.State
+	if state.IsState(operationState, state.ApplyOperation.Cancelled) {
+		if err := c.storage.ApplyOperations().MarkTerminal(ctx, op.ID, operationState); err != nil {
+			return fmt.Errorf("mark undispatched gRPC apply_operation %d cancelled for apply %s: %w", op.ID, apply.ApplyIdentifier, err)
+		}
+		op.CompletedAt = &now
+	} else {
+		if err := c.storage.ApplyOperations().UpdateState(ctx, op.ID, operationState); err != nil {
+			return fmt.Errorf("mark undispatched gRPC apply_operation %d stopped for apply %s: %w", op.ID, apply.ApplyIdentifier, err)
+		}
+		op.CompletedAt = nil
+	}
+	op.State = operationState
+	op.UpdatedAt = now
+	slog.Info("stopped undispatched multi-operation gRPC apply operation; apply-level stop request remains pending for siblings",
+		"apply_id", apply.ApplyIdentifier,
+		"apply_operation_id", op.ID,
+		"deployment", op.Deployment,
+		"database", apply.Database,
+		"environment", apply.Environment,
+		"requested_by", caller,
+		"old_operation_state", oldState,
+		"new_operation_state", operationState)
+	c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventStopRequested,
+		fmt.Sprintf("Remote apply operation %d (deployment %s) stopped before dispatch: %s%s; pending apply stop request remains for sibling operations", op.ID, op.Deployment, operationState, callerApplyLogSuffix(caller)), "", "")
+	return nil
+}
+
 func (c *GRPCClient) Start(ctx context.Context, req *ternv1.StartRequest) (*ternv1.StartResponse, error) {
 	return c.client.Start(ctx, req)
 }
@@ -877,6 +959,9 @@ func (c *GRPCClient) loadOperationApplyTaskScope(ctx context.Context, apply *sto
 	operation, err := c.storage.ApplyOperations().Get(ctx, applyOperationID)
 	if err != nil {
 		return applyTaskScope{}, fmt.Errorf("load apply_operation %d for apply %s: %w", applyOperationID, apply.ApplyIdentifier, err)
+	}
+	if operation == nil {
+		return applyTaskScope{}, fmt.Errorf("apply_operation %d not found for apply %s", applyOperationID, apply.ApplyIdentifier)
 	}
 	if operation.ApplyID != apply.ID {
 		return applyTaskScope{}, fmt.Errorf("apply_operation %d belongs to apply %d, not %s (%d)", applyOperationID, operation.ApplyID, apply.ApplyIdentifier, apply.ID)

--- a/pkg/tern/grpc_client.go
+++ b/pkg/tern/grpc_client.go
@@ -1037,7 +1037,7 @@ func (c *GRPCClient) resumeApply(ctx context.Context, apply *storage.Apply, scop
 		return c.dispatchPendingApply(ctx, apply, scope)
 	}
 	if hasAmbiguousRemoteDispatchState(apply, scope) {
-		errMsg := fmt.Sprintf("gRPC apply %s is %s without external_id; remote dispatch state is ambiguous", apply.ApplyIdentifier, apply.State)
+		errMsg := fmt.Sprintf("gRPC apply %s is %s without a remote apply id; remote dispatch state is ambiguous", apply.ApplyIdentifier, scope.dispatchState(apply))
 		if err := c.markRemoteApplyFailed(ctx, apply, nil, errMsg, false, scope); err != nil {
 			return fmt.Errorf("%s; persist failure state: %w", errMsg, err)
 		}
@@ -1165,7 +1165,7 @@ func (c *GRPCClient) resumeApply(ctx context.Context, apply *storage.Apply, scop
 				message := fmt.Sprintf("remote start failed for remote apply %s: %v", remoteID, err)
 				slog.Warn("remote gRPC start failed; storing stopped state for operator retry",
 					"apply_id", apply.ApplyIdentifier,
-					"external_id", apply.ExternalID,
+					"remote_apply_id", remoteID,
 					"database", apply.Database,
 					"environment", apply.Environment,
 					"error", err)
@@ -1297,7 +1297,7 @@ func (c *GRPCClient) processPendingStartControlRequest(ctx context.Context, appl
 	}
 	remoteID := scope.remoteApplyID(apply)
 	if remoteID == "" {
-		message := fmt.Sprintf("gRPC apply %s is waiting for deploy without external_id; start dispatch state is ambiguous", apply.ApplyIdentifier)
+		message := fmt.Sprintf("gRPC apply %s is waiting for deploy without a remote apply id; start dispatch state is ambiguous", apply.ApplyIdentifier)
 		if err := failPendingStartControlRequests(ctx, c.storage, apply, message); err != nil {
 			return err
 		}
@@ -1311,7 +1311,7 @@ func (c *GRPCClient) processPendingStartControlRequest(ctx context.Context, appl
 		message := fmt.Sprintf("remote deferred deploy start failed for remote apply %s: %v", remoteID, err)
 		slog.Warn("remote gRPC deferred deploy start failed; storing start request failure",
 			"apply_id", apply.ApplyIdentifier,
-			"external_id", apply.ExternalID,
+			"remote_apply_id", remoteID,
 			"database", apply.Database,
 			"environment", apply.Environment,
 			"error", err)
@@ -1340,7 +1340,22 @@ func shouldDispatchQueuedRemoteApply(apply *storage.Apply, scope applyTaskScope)
 	if apply == nil {
 		return false
 	}
-	return scope.remoteApplyID(apply) == "" && state.IsState(scope.dispatchState(apply), state.Apply.Pending, state.Apply.FailedRetryable)
+	if scope.remoteApplyID(apply) != "" {
+		return false
+	}
+	dispatchState := scope.dispatchState(apply)
+	if state.IsState(dispatchState, state.Apply.Pending, state.Apply.FailedRetryable) {
+		return true
+	}
+	// An operation-scoped multi-op drive claims its operation pending→running in
+	// a separate transaction before this drive runs, so a freshly claimed
+	// operation reaches dispatch in running with no operation-scoped remote id
+	// yet. An empty per-operation remote id means nothing was durably dispatched
+	// to remote Tern, so this is the operation's first dispatch — not the
+	// ambiguous "running with no remote id" case the whole-apply path guards
+	// against, where a shared external_id could have been lost after a real
+	// dispatch.
+	return scope.usesOperationRemoteResume() && state.IsState(dispatchState, state.Apply.Running)
 }
 
 func hasAmbiguousRemoteDispatchState(apply *storage.Apply, scope applyTaskScope) bool {

--- a/pkg/tern/grpc_client_test.go
+++ b/pkg/tern/grpc_client_test.go
@@ -705,6 +705,26 @@ func (m *mockApplyOperationStore) ListByApply(_ context.Context, applyID int64) 
 	return ops, nil
 }
 
+func (m *mockApplyOperationStore) UpdateState(_ context.Context, id int64, newState string) error {
+	op, ok := m.ops[id]
+	if !ok {
+		return storage.ErrApplyOperationNotFound
+	}
+	op.State = newState
+	return nil
+}
+
+func (m *mockApplyOperationStore) MarkTerminal(_ context.Context, id int64, newState string) error {
+	op, ok := m.ops[id]
+	if !ok {
+		return storage.ErrApplyOperationNotFound
+	}
+	now := time.Now()
+	op.State = newState
+	op.CompletedAt = &now
+	return nil
+}
+
 func (m *mockApplyOperationStore) SaveEngineResumeState(_ context.Context, operationID int64, resumeState *storage.EngineResumeState) error {
 	if m.saveErr != nil {
 		return m.saveErr
@@ -1003,6 +1023,69 @@ func TestGRPCClient_ResumeApplyOperationStoresRemoteIDOnOperationForMultiOpApply
 	require.NotNil(t, req)
 	require.Len(t, req.DdlChanges, 1)
 	assert.Equal(t, "users", req.DdlChanges[0].TableName)
+}
+
+func TestGRPCClient_ResumeApplyOperationStopsUndispatchedOperationWithoutCompletingApplyStop(t *testing.T) {
+	// A multi-deployment apply has one durable stop request shared by every
+	// deployment. Stopping a claimed-but-undispatched operation (no remote apply
+	// id yet) must terminalize only that operation, leave the parent apply
+	// untouched, and keep the apply-level stop request pending so sibling
+	// deployments that already dispatched still observe the stop.
+	server := &capturingTernServer{}
+	client, cleanup := testCapturingGRPCClient(t, server)
+	defer cleanup()
+
+	apply := &storage.Apply{
+		ID:              7,
+		ApplyIdentifier: "apply-multi-op-stop",
+		PlanID:          99,
+		Database:        "testdb",
+		DatabaseType:    storage.DatabaseTypeMySQL,
+		Environment:     "staging",
+		State:           state.Apply.Running,
+	}
+	operationID := int64(42)
+	siblingID := int64(43)
+	task := &storage.Task{
+		ID:               11,
+		TaskIdentifier:   "task-users",
+		ApplyID:          apply.ID,
+		ApplyOperationID: &operationID,
+		TableName:        "users",
+		State:            state.Task.Running,
+	}
+	operationStore := &mockApplyOperationStore{ops: map[int64]*storage.ApplyOperation{
+		operationID: {ID: operationID, ApplyID: apply.ID, Deployment: "west", State: state.ApplyOperation.Running},
+		siblingID:   {ID: siblingID, ApplyID: apply.ID, Deployment: "east", State: state.ApplyOperation.Running, EngineResumeContext: "remote-east"},
+	}}
+	controlRequests := &testControlRequestStore{requests: []*storage.ApplyControlRequest{{
+		ApplyID:     apply.ID,
+		Operation:   storage.ControlOperationStop,
+		Status:      storage.ControlRequestPending,
+		RequestedBy: "cli:alice",
+	}}}
+	client.storage = &mockStorage{
+		applies:         &mockApplyStore{apply: apply},
+		tasks:           &mockTaskStore{tasks: []*storage.Task{task}},
+		logs:            &mockApplyLogStore{},
+		controlRequests: controlRequests,
+		operations:      operationStore,
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+	err := client.ResumeApplyOperation(ctx, apply, operationID)
+	require.NoError(t, err)
+
+	assert.Empty(t, server.getStopApplyID(), "no remote stop should be sent for an undispatched operation")
+	assert.Equal(t, state.Task.Stopped, task.State, "the operation's task should be stopped")
+	assert.Equal(t, state.ApplyOperation.Stopped, operationStore.ops[operationID].State, "the claimed operation should be stopped")
+	assert.Equal(t, state.Apply.Running, apply.State, "the parent apply must not be terminalized by one undispatched operation")
+	assert.Equal(t, "remote-east", operationStore.ops[siblingID].EngineResumeContext, "the sibling's remote id must be untouched")
+
+	stopReq, err := controlRequests.GetPending(t.Context(), apply.ID, storage.ControlOperationStop)
+	require.NoError(t, err)
+	assert.NotNil(t, stopReq, "the apply-level stop request must remain pending for sibling operations")
 }
 
 func TestGRPCClient_ResumeApplyOperationRejectsMissingOperationID(t *testing.T) {

--- a/pkg/tern/grpc_client_test.go
+++ b/pkg/tern/grpc_client_test.go
@@ -674,6 +674,49 @@ type mockStorage struct {
 	plans           *mockPlanStore
 	logs            *mockApplyLogStore
 	controlRequests *testControlRequestStore
+	operations      *mockApplyOperationStore
+}
+
+// mockApplyOperationStore is an in-memory ApplyOperationStore for the remote
+// drive tests. It backs the operation lookups (Get/ListByApply) and the per-op
+// remote resume id write (SaveEngineResumeState) that the fan-out drive uses.
+type mockApplyOperationStore struct {
+	storage.ApplyOperationStore
+	ops          map[int64]*storage.ApplyOperation
+	saveErr      error
+	savedResumes []*storage.EngineResumeState
+}
+
+func (m *mockApplyOperationStore) Get(_ context.Context, id int64) (*storage.ApplyOperation, error) {
+	op, ok := m.ops[id]
+	if !ok {
+		return nil, storage.ErrApplyOperationNotFound
+	}
+	return op, nil
+}
+
+func (m *mockApplyOperationStore) ListByApply(_ context.Context, applyID int64) ([]*storage.ApplyOperation, error) {
+	var ops []*storage.ApplyOperation
+	for _, op := range m.ops {
+		if op != nil && op.ApplyID == applyID {
+			ops = append(ops, op)
+		}
+	}
+	return ops, nil
+}
+
+func (m *mockApplyOperationStore) SaveEngineResumeState(_ context.Context, operationID int64, resumeState *storage.EngineResumeState) error {
+	if m.saveErr != nil {
+		return m.saveErr
+	}
+	op, ok := m.ops[operationID]
+	if !ok {
+		return storage.ErrApplyOperationNotFound
+	}
+	op.EngineResumeContext = resumeState.MigrationContext
+	op.EngineResumeMetadata = resumeState.Metadata
+	m.savedResumes = append(m.savedResumes, resumeState)
+	return nil
 }
 
 func (m *mockStorage) Applies() storage.ApplyStore {
@@ -705,6 +748,12 @@ func (m *mockStorage) ControlRequests() storage.ControlRequestStore {
 		return m.controlRequests
 	}
 	return &testControlRequestStore{}
+}
+func (m *mockStorage) ApplyOperations() storage.ApplyOperationStore {
+	if m.operations != nil {
+		return m.operations
+	}
+	return &mockApplyOperationStore{}
 }
 
 func testCapturingGRPCClient(t *testing.T, server *capturingTernServer) (*GRPCClient, func()) {
@@ -858,6 +907,9 @@ func TestGRPCClient_ResumeApplyOperationDispatchesScopedTasks(t *testing.T) {
 			ID:             apply.PlanID,
 			PlanIdentifier: "plan-op-scoped",
 		}},
+		operations: &mockApplyOperationStore{ops: map[int64]*storage.ApplyOperation{
+			operationID: {ID: operationID, ApplyID: apply.ID, Deployment: "testdb-deployment", State: state.ApplyOperation.Pending},
+		}},
 	}
 
 	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
@@ -871,6 +923,84 @@ func TestGRPCClient_ResumeApplyOperationDispatchesScopedTasks(t *testing.T) {
 
 	req := server.getApplyRequest()
 	require.NotNil(t, req, "expected operation-scoped apply to be dispatched to remote Tern")
+	require.Len(t, req.DdlChanges, 1)
+	assert.Equal(t, "users", req.DdlChanges[0].TableName)
+}
+
+func TestGRPCClient_ResumeApplyOperationStoresRemoteIDOnOperationForMultiOpApply(t *testing.T) {
+	// On a multi-deployment apply, each deployment gets its own remote Tern apply
+	// id. Dispatching one operation must store its remote id on that operation's
+	// engine_resume_context and must NOT touch the parent applies.external_id,
+	// which has no single authoritative value across deployments.
+	server := &capturingTernServer{
+		remoteApplyID: "remote-op-west-1",
+		progressTables: []*ternv1.TableProgress{{
+			Namespace:       "default",
+			TableName:       "users",
+			Status:          state.Task.Completed,
+			PercentComplete: 100,
+		}},
+	}
+	client, cleanup := testCapturingGRPCClient(t, server)
+	defer cleanup()
+
+	apply := &storage.Apply{
+		ID:              7,
+		ApplyIdentifier: "apply-multi-op",
+		PlanID:          99,
+		Database:        "testdb",
+		DatabaseType:    storage.DatabaseTypeMySQL,
+		Environment:     "staging",
+		State:           state.Apply.Pending,
+	}
+	apply.SetOptions(storage.ApplyOptions{Target: "testdb-target", DeferCutover: true})
+	operationID := int64(42)
+	siblingID := int64(43)
+	task := &storage.Task{
+		ID:               11,
+		TaskIdentifier:   "task-users",
+		ApplyID:          apply.ID,
+		ApplyOperationID: &operationID,
+		TableName:        "users",
+		DDL:              "ALTER TABLE users ADD COLUMN email varchar(255)",
+		DDLAction:        "alter",
+		Namespace:        "default",
+		State:            state.Task.Pending,
+	}
+	taskStore := &mockTaskStore{
+		tasks:           []*storage.Task{task},
+		getByApplyIDErr: errors.New("whole-apply task load must not be used for operation-scoped resume"),
+	}
+	operationStore := &mockApplyOperationStore{ops: map[int64]*storage.ApplyOperation{
+		operationID: {ID: operationID, ApplyID: apply.ID, Deployment: "west", State: state.ApplyOperation.Pending},
+		siblingID:   {ID: siblingID, ApplyID: apply.ID, Deployment: "east", State: state.ApplyOperation.Pending},
+	}}
+	client.storage = &mockStorage{
+		applies: &mockApplyStore{apply: apply},
+		tasks:   taskStore,
+		plans: &mockPlanStore{plan: &storage.Plan{
+			ID:             apply.PlanID,
+			PlanIdentifier: "plan-multi-op",
+		}},
+		operations: operationStore,
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+	err := client.ResumeApplyOperation(ctx, apply, operationID)
+	require.NoError(t, err)
+
+	assert.Empty(t, apply.ExternalID, "multi-op dispatch must not write the parent apply external_id")
+	assert.Equal(t, "remote-op-west-1", operationStore.ops[operationID].EngineResumeContext,
+		"the remote apply id must be stored on the claimed operation")
+	assert.Empty(t, operationStore.ops[siblingID].EngineResumeContext,
+		"the sibling operation's remote id must be untouched")
+	require.Len(t, operationStore.savedResumes, 1)
+	assert.Equal(t, operationID, operationStore.savedResumes[0].ApplyOperationID)
+	assert.Equal(t, "remote-op-west-1", operationStore.savedResumes[0].MigrationContext)
+
+	req := server.getApplyRequest()
+	require.NotNil(t, req)
 	require.Len(t, req.DdlChanges, 1)
 	assert.Equal(t, "users", req.DdlChanges[0].TableName)
 }
@@ -921,6 +1051,9 @@ func TestGRPCClient_ResumeApplyOperationRejectsTasksFromAnotherApply(t *testing.
 			ID:             apply.PlanID,
 			PlanIdentifier: "plan-op-scoped",
 		}},
+		operations: &mockApplyOperationStore{ops: map[int64]*storage.ApplyOperation{
+			operationID: {ID: operationID, ApplyID: apply.ID, Deployment: "testdb-deployment", State: state.ApplyOperation.Pending},
+		}},
 	}
 
 	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
@@ -962,6 +1095,9 @@ func TestGRPCClient_ResumeApplyOperationFailsClosedOnNoTasks(t *testing.T) {
 		plans: &mockPlanStore{plan: &storage.Plan{
 			ID:             apply.PlanID,
 			PlanIdentifier: "plan-op-scoped",
+		}},
+		operations: &mockApplyOperationStore{ops: map[int64]*storage.ApplyOperation{
+			operationID: {ID: operationID, ApplyID: apply.ID, Deployment: "testdb-deployment", State: state.ApplyOperation.Pending},
 		}},
 	}
 
@@ -2101,7 +2237,7 @@ func TestGRPCClient_QueuedRemoteDispatchPredicate(t *testing.T) {
 				State:      tt.state,
 				ExternalID: tt.externalID,
 			}
-			assert.Equal(t, tt.want, shouldDispatchQueuedRemoteApply(apply))
+			assert.Equal(t, tt.want, shouldDispatchQueuedRemoteApply(apply, wholeApplyTaskScope()))
 		})
 	}
 }
@@ -2503,7 +2639,7 @@ func TestGRPCClient_ProcessPendingCutoverWaitsWhenNotReady(t *testing.T) {
 		controlRequests: controlRequests,
 	}
 
-	err := client.processPendingCutoverControlRequest(t.Context(), apply)
+	err := client.processPendingCutoverControlRequest(t.Context(), apply, wholeApplyTaskScope())
 	require.NoError(t, err)
 	assert.Empty(t, server.getCutoverApplyID())
 	pendingCutover, err := controlRequests.GetPending(t.Context(), apply.ID, storage.ControlOperationCutover)
@@ -2547,7 +2683,7 @@ func TestGRPCClient_ProcessPendingCutoverWaitsWhileRecovering(t *testing.T) {
 		controlRequests: controlRequests,
 	}
 
-	err := client.processPendingCutoverControlRequest(t.Context(), apply)
+	err := client.processPendingCutoverControlRequest(t.Context(), apply, wholeApplyTaskScope())
 	require.NoError(t, err)
 	assert.Empty(t, server.getCutoverApplyID())
 	pendingCutover, err := controlRequests.GetPending(t.Context(), apply.ID, storage.ControlOperationCutover)

--- a/pkg/tern/grpc_client_test.go
+++ b/pkg/tern/grpc_client_test.go
@@ -2242,6 +2242,45 @@ func TestGRPCClient_QueuedRemoteDispatchPredicate(t *testing.T) {
 	}
 }
 
+// TestGRPCClient_QueuedRemoteDispatchPredicate_OperationScope pins the dispatch
+// gate for multi-operation drives. The operator claim transitions an operation
+// pending→running in a separate transaction before the drive runs, so a freshly
+// claimed operation reaches dispatch in running with no per-operation remote id
+// yet. That first dispatch must proceed — a running operation with an empty
+// remote id is not the ambiguous crash case the whole-apply path rejects.
+func TestGRPCClient_QueuedRemoteDispatchPredicate_OperationScope(t *testing.T) {
+	tests := []struct {
+		name     string
+		opState  string
+		remoteID string
+		multiOp  bool
+		want     bool
+	}{
+		{name: "multi-op running without remote id dispatches", opState: state.ApplyOperation.Running, multiOp: true, want: true},
+		{name: "multi-op pending without remote id dispatches", opState: state.ApplyOperation.Pending, multiOp: true, want: true},
+		{name: "multi-op running with remote id does not dispatch", opState: state.ApplyOperation.Running, remoteID: "remote-apply-123", multiOp: true, want: false},
+		{name: "multi-op terminal without remote id does not dispatch", opState: state.ApplyOperation.Completed, multiOp: true, want: false},
+		{name: "single-op running without remote id does not dispatch", opState: state.ApplyOperation.Running, multiOp: false, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// The parent apply is running because a sibling deployment is active;
+			// the per-operation remote id (not apply.ExternalID) governs dispatch.
+			apply := &storage.Apply{State: state.Apply.Running}
+			scope := applyTaskScope{
+				applyOperationID: 1,
+				operation: &storage.ApplyOperation{
+					State:               tt.opState,
+					EngineResumeContext: tt.remoteID,
+				},
+				multiOperation: tt.multiOp,
+			}
+			assert.Equal(t, tt.want, shouldDispatchQueuedRemoteApply(apply, scope))
+		})
+	}
+}
+
 func TestGRPCClient_ResumeApply_ThreadsExternalID(t *testing.T) {
 	// Progress returns STOPPED initially so ResumeApply checks remote state,
 	// confirms the apply is stopped, and calls Start. After Start, the mock

--- a/pkg/tern/routing_client.go
+++ b/pkg/tern/routing_client.go
@@ -28,6 +28,7 @@ type ApplyLookup interface {
 // ApplyOperationLookup loads operation-scoped routing metadata for a stored apply.
 type ApplyOperationLookup interface {
 	Get(ctx context.Context, id int64) (*storage.ApplyOperation, error)
+	ListByApply(ctx context.Context, applyID int64) ([]*storage.ApplyOperation, error)
 }
 
 // RoutingClientConfig wires a RoutingClient to routing, storage, and deployment clients.
@@ -396,7 +397,7 @@ func (c *RoutingClient) clientForApply(ctx context.Context, applyIdentifier, req
 		return nil, nil, "", err
 	}
 	c.attachObserver(client, apply.ID)
-	ternApplyID, err := ternApplyIdentifierForClient(apply, client)
+	ternApplyID, err := c.ternApplyIdentifierForClient(ctx, apply, client)
 	if err != nil {
 		return nil, nil, "", err
 	}
@@ -445,7 +446,22 @@ func validateStoredApplyEnvironment(operation string, apply *storage.Apply, requ
 	return fmt.Errorf("apply %q is stored for environment %q, not %q; cannot route %s", apply.ApplyIdentifier, apply.Environment, requestEnvironment, operation)
 }
 
-func ternApplyIdentifierForClient(apply *storage.Apply, client Client) (string, error) {
+// ternApplyIdentifierForClient resolves the remote apply id for an apply-scoped
+// control/progress call (which carries no operation context). A multi-operation
+// remote apply has no single parent remote id — each deployment's id lives on
+// its own operation row — so it fails closed rather than route a stale or empty
+// parent external_id to the wrong deployment. Single-operation and local applies
+// keep using the parent external_id / apply identifier.
+func (c *RoutingClient) ternApplyIdentifierForClient(ctx context.Context, apply *storage.Apply, client Client) (string, error) {
+	if client.IsRemote() {
+		operationCount, err := c.remoteApplyOperationCount(ctx, apply)
+		if err != nil {
+			return "", err
+		}
+		if operationCount > 1 {
+			return "", fmt.Errorf("apply %q spans %d operations; apply-scoped control cannot choose a remote apply id without an operation context", apply.ApplyIdentifier, operationCount)
+		}
+	}
 	if apply.ExternalID != "" {
 		return apply.ExternalID, nil
 	}
@@ -453,6 +469,20 @@ func ternApplyIdentifierForClient(apply *storage.Apply, client Client) (string, 
 		return "", fmt.Errorf("apply %q has not been accepted by remote deployment %q yet", apply.ApplyIdentifier, apply.Deployment)
 	}
 	return apply.ApplyIdentifier, nil
+}
+
+// remoteApplyOperationCount returns how many operations the apply owns, failing
+// closed when the operation lookup is unavailable or errors so an apply-scoped
+// remote control never silently assumes a single-operation apply.
+func (c *RoutingClient) remoteApplyOperationCount(ctx context.Context, apply *storage.Apply) (int, error) {
+	if c.applyOperationLookup == nil {
+		return 0, fmt.Errorf("apply operation lookup is required to route apply %q control", apply.ApplyIdentifier)
+	}
+	ops, err := c.applyOperationLookup.ListByApply(ctx, apply.ID)
+	if err != nil {
+		return 0, fmt.Errorf("list operations for apply %q routing: %w", apply.ApplyIdentifier, err)
+	}
+	return len(ops), nil
 }
 
 func operationScopedApply(apply *storage.Apply, operation *storage.ApplyOperation) *storage.Apply {

--- a/pkg/tern/routing_client_test.go
+++ b/pkg/tern/routing_client_test.go
@@ -38,6 +38,16 @@ func (l routingApplyOperationLookup) Get(_ context.Context, id int64) (*storage.
 	return l[id], nil
 }
 
+func (l routingApplyOperationLookup) ListByApply(_ context.Context, applyID int64) ([]*storage.ApplyOperation, error) {
+	var ops []*storage.ApplyOperation
+	for _, op := range l {
+		if op != nil && op.ApplyID == applyID {
+			ops = append(ops, op)
+		}
+	}
+	return ops, nil
+}
+
 type routingRecordingClient struct {
 	Client
 
@@ -568,6 +578,9 @@ func TestRoutingClientProgressRejectsRemoteApplyWithoutExternalID(t *testing.T) 
 				Environment:     "production",
 			},
 		},
+		ApplyOperationLookup: routingApplyOperationLookup{
+			1: {ID: 1, ApplyID: 42, Deployment: "west"},
+		},
 		ClientForDeployment: testDeploymentClientFunc(clients),
 	})
 
@@ -578,6 +591,43 @@ func TestRoutingClientProgressRejectsRemoteApplyWithoutExternalID(t *testing.T) 
 
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "has not been accepted by remote deployment \"west\" yet")
+	assert.Nil(t, clients["west/production"].progressReq)
+}
+
+func TestRoutingClientProgressFailsClosedForMultiOpRemoteApply(t *testing.T) {
+	// An apply-scoped control/progress call carries no operation context. For a
+	// multi-operation remote apply there is no single authoritative remote apply
+	// id (each deployment's id lives on its own operation row), so routing must
+	// fail closed rather than guess one.
+	clients := map[string]*routingRecordingClient{
+		"west/production": {isRemote: true},
+	}
+	routingClient := newTestRoutingClient(t, RoutingClientConfig{
+		Resolver:   routingResolverFunc(func(context.Context, routing.Request) ([]routing.ExecutionTarget, error) { return nil, nil }),
+		PlanLookup: routingPlanLookup{},
+		ApplyLookup: routingApplyLookup{
+			"apply-123": {
+				ID:              42,
+				ApplyIdentifier: "apply-123",
+				ExternalID:      "remote-apply-456",
+				Deployment:      "west",
+				Environment:     "production",
+			},
+		},
+		ApplyOperationLookup: routingApplyOperationLookup{
+			1: {ID: 1, ApplyID: 42, Deployment: "west"},
+			2: {ID: 2, ApplyID: 42, Deployment: "east"},
+		},
+		ClientForDeployment: testDeploymentClientFunc(clients),
+	})
+
+	_, err := routingClient.Progress(t.Context(), &ternv1.ProgressRequest{
+		ApplyId:     "apply-123",
+		Environment: "production",
+	})
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "spans 2 operations")
 	assert.Nil(t, clients["west/production"].progressReq)
 }
 


### PR DESCRIPTION
## What

Track the remote engine apply id **per operation** for multi-deployment
(fan-out) applies instead of on the parent apply.

- Multi-op applies persist each deployment's remote id on
  `apply_operations.engine_resume_context`; single-op and local applies keep
  using `applies.external_id` (unchanged behavior).
- Every remote control/progress RPC (Apply/Start/Stop/Cutover/Progress)
  resolves its apply id from the operation's scope.
- The remote id is persisted **before** the parent state update so a crash
  mid-dispatch resumes the exact remote operation rather than dispatching a
  duplicate.
- Apply-scoped controls that carry no operation context **fail closed** when
  the apply spans more than one operation.

## Why

A fan-out apply dispatches each deployment to its own remote engine apply, so
there is no single authoritative remote id to hang on the parent
`applies.external_id`. Sharing one parent id is ambiguous: it lets one
deployment's resume/stop/progress call act on another deployment's remote
apply, or route a stale/empty id to the wrong target. Scoping the remote id to
the operation makes each deployment independently resumable and controllable,
and failing closed avoids guessing an id when the context is ambiguous.

## Before / After

```text
                 remote engine apply id
                 ──────────────────────
 BEFORE (parent-scoped)            AFTER (per-operation)
 ╭───────────────────╮            ╭───────────────────╮
 │ applies           │            │ applies           │
 │  external_id ◄──┐ │            │  external_id      │  single-op / local only
 ╰───────────────────╯            ╰───────────────────╯
        ▲ all deployments                 ▲
        │ share ONE id                    │ single-op / local
    AMBIGUOUS for fan-out          ╭──────────────────────────────╮
   (stop/resume/progress can       │ apply_operations             │
    hit the wrong deployment)      │  engine_resume_context ◄──┐  │
                                   ╰──────────────────────────────╯
                                              ▲ one id per deployment
                                              │ independently resumable

 Apply-scoped control, no op context:
   single-op  ─▶ use parent external_id
   multi-op   ─▶ FAIL CLOSED (no single authoritative id)

Safety

Fails closed on: deployment mismatch, operation not in the apply's set, an
operation that resolves to no tasks, overwriting an existing different remote
id, and apply-scoped remote controls on multi-operation applies.
