### PR TITLE
feat(operator): add running_degraded rollout apply state

### DIFF
--- a/pkg/api/control_handlers.go
+++ b/pkg/api/control_handlers.go
@@ -637,7 +637,7 @@ func (s *Service) cutoverRequestReadiness(ctx context.Context, client tern.Clien
 		}
 		return cutoverRequestNotReady, nil
 	}
-	if !state.IsState(apply.State, state.Apply.Running) {
+	if !state.IsRunningApplyState(apply.State) {
 		return cutoverRequestNotReady, nil
 	}
 	taskStore := s.storage.Tasks()
@@ -1253,7 +1253,7 @@ func (s *Service) queueStoppedApplyForOperator(ctx context.Context, apply *stora
 		}
 		return nil, "", startNotAllowedForState(apply)
 	}
-	if state.IsState(apply.State, state.Apply.Running) {
+	if state.IsRunningApplyState(apply.State) {
 		s.logger.Info("queueing start for stopped tasks while stored apply is still running",
 			"apply_id", apply.ApplyIdentifier,
 			"database", apply.Database,
@@ -1294,7 +1294,7 @@ func (s *Service) queueRemoteStoppedApplyForOperator(ctx context.Context, client
 	if startedCount == 0 {
 		startedCount = 1
 	}
-	if state.IsState(apply.State, state.Apply.Running) {
+	if state.IsRunningApplyState(apply.State) {
 		s.logger.Info("queueing remote start while stored apply is still running",
 			"apply_id", apply.ApplyIdentifier,
 			"external_id", apply.ExternalID,
@@ -1312,7 +1312,7 @@ func (s *Service) queueRemoteStoppedApplyForOperator(ctx context.Context, client
 }
 
 func (s *Service) ensureStoredApplyStoppedForStartClaim(ctx context.Context, apply *storage.Apply) error {
-	if !state.IsState(apply.State, state.Apply.Running) {
+	if !state.IsRunningApplyState(apply.State) {
 		return nil
 	}
 	applyStore := s.storage.Applies()
@@ -1453,7 +1453,7 @@ func startResponseFromControlRequest(controlReq *storage.ApplyControlRequest) (*
 // says running.
 func storedApplyMayHaveStoppedTasksForStart(storedApplyState string) bool {
 	return state.IsState(storedApplyState, state.Apply.Stopped) ||
-		state.IsState(storedApplyState, state.Apply.Running)
+		state.IsRunningApplyState(storedApplyState)
 }
 
 func validateStartRequestState(apply *storage.Apply) error {
@@ -1475,6 +1475,7 @@ func isStartRequestAllowedState(applyState string) bool {
 		state.Apply.WaitingForDeploy,
 		state.Apply.Pending,
 		state.Apply.Running,
+		state.Apply.RunningDegraded,
 		state.Apply.Stopped,
 	)
 }
@@ -1483,7 +1484,7 @@ func startNotAllowedForState(apply *storage.Apply) error {
 	switch {
 	case state.IsState(apply.State, state.Apply.Pending):
 		return controlConflictf("schema change is pending and no start request is queued")
-	case state.IsState(apply.State, state.Apply.Running):
+	case state.IsRunningApplyState(apply.State):
 		// Running applies may reach this helper after the handler checks for
 		// stopped task rows. Without stopped task rows, there is no operator
 		// start work to queue.

--- a/pkg/api/operator.go
+++ b/pkg/api/operator.go
@@ -1129,11 +1129,12 @@ func (s *Service) updateApplyStateFromOperations(ctx context.Context, workerID i
 	// rows holds it running until every sibling is terminal. Gate the exception
 	// narrowly — the parent must be failed, the child base must still be failed
 	// (a real continuable failure, not a stale parent over non-failed children),
-	// the derived projection must be running, and the caller must hold the lease.
+	// the derived projection must be the held-running degraded state, and the
+	// caller must hold the lease.
 	reopensContinuableFailedRollout := bool(reopen) &&
 		state.IsState(apply.State, state.Apply.Failed) &&
 		state.IsState(base, state.Apply.Failed) &&
-		state.IsState(derived, state.Apply.Running)
+		state.IsState(derived, state.Apply.RunningDegraded)
 
 	if state.IsTerminalApplyState(apply.State) && !state.IsTerminalApplyState(derived) && !reopensContinuableFailedRollout {
 		return applyProjectionResult{}, fmt.Errorf("derive apply state for terminal apply %s (%d): child operations derive non-terminal state %q from parent state %q",

--- a/pkg/api/operator_test.go
+++ b/pkg/api/operator_test.go
@@ -198,12 +198,12 @@ func TestUpdateApplyStateFromOperations_ContinuePolicy(t *testing.T) {
 		wantDone  bool
 	}{
 		{
-			name: "continue holds the apply running past a failed deployment",
+			name: "continue holds the apply running_degraded past a failed deployment",
 			ops: []*storage.ApplyOperation{
 				{ID: 1, State: state.ApplyOperation.Failed, OnFailure: storage.OnFailureContinue},
 				{ID: 2, State: state.ApplyOperation.Pending, OnFailure: storage.OnFailureContinue},
 			},
-			wantState: state.Apply.Running,
+			wantState: state.Apply.RunningDegraded,
 			wantDone:  false,
 		},
 		{
@@ -245,11 +245,12 @@ func TestUpdateApplyStateFromOperations_ContinuePolicy(t *testing.T) {
 // TestUpdateApplyStateFromOperations_ReopenFailedGuard verifies the terminal
 // guard's reopen exception. Under on_failure "continue" a sibling failure can
 // terminalize the parent apply to failed before the rollout settles; once a
-// live sibling still derives the projection running, a lease-holding caller may
-// reopen the parent failed → running so the remaining siblings run to
-// completion. The exception is deliberately narrow: only a failed parent over a
-// genuinely failed child base may reopen, only to running, and only when the
-// caller holds the apply lease. Every other terminal-to-non-terminal transition
+// live sibling still derives the projection running_degraded, a lease-holding
+// caller may reopen the parent failed → running_degraded so the remaining
+// siblings run to completion. The exception is deliberately narrow: only a
+// failed parent over a genuinely failed child base may reopen, only to
+// running_degraded, and only when the caller holds the apply lease. Every other
+// terminal-to-non-terminal transition
 // — including reviving a failed parent from an unscoped reconciliation path, and
 // any genuinely terminal verdict (completed/cancelled/reverted) — stays an error.
 func TestUpdateApplyStateFromOperations_ReopenFailedGuard(t *testing.T) {
@@ -263,14 +264,14 @@ func TestUpdateApplyStateFromOperations_ReopenFailedGuard(t *testing.T) {
 		wantUpdate bool
 	}{
 		{
-			name:   "lease-scoped reopen holds the failed apply running for a live sibling",
+			name:   "lease-scoped reopen holds the failed apply running_degraded for a live sibling",
 			parent: state.Apply.Failed,
 			ops: []*storage.ApplyOperation{
 				{ID: 1, State: state.ApplyOperation.Failed, OnFailure: storage.OnFailureContinue},
 				{ID: 2, State: state.ApplyOperation.Running, OnFailure: storage.OnFailureContinue},
 			},
 			reopen:     allowLeaseScopedFailedReopen,
-			wantState:  state.Apply.Running,
+			wantState:  state.Apply.RunningDegraded,
 			wantUpdate: true,
 		},
 		{

--- a/pkg/cmd/commands/apply.go
+++ b/pkg/cmd/commands/apply.go
@@ -72,7 +72,7 @@ func (cmd *ApplyCmd) Run(g *Globals) error {
 			stateMsg = "A schema change is waiting for deploy."
 		case state.IsState(active.State, state.Apply.WaitingForCutover):
 			stateMsg = "A schema change is waiting for cutover."
-		case state.IsState(active.State, state.Apply.Running):
+		case state.IsRunningApplyState(active.State):
 			stateMsg = "A schema change is already running."
 		case state.IsState(active.State, state.Apply.CuttingOver):
 			stateMsg = "A schema change is currently cutting over."

--- a/pkg/cmd/commands/rollback.go
+++ b/pkg/cmd/commands/rollback.go
@@ -46,7 +46,7 @@ func (cmd *RollbackCmd) Run(g *Globals) error {
 			return fmt.Errorf("cannot rollback: a schema change is waiting for deploy")
 		case state.IsState(active.State, state.Apply.WaitingForCutover):
 			return fmt.Errorf("cannot rollback: a schema change is waiting for cutover")
-		case state.IsState(active.State, state.Apply.Running):
+		case state.IsRunningApplyState(active.State):
 			return fmt.Errorf("cannot rollback: a schema change is already running")
 		case state.IsState(active.State, state.Apply.CuttingOver):
 			return fmt.Errorf("cannot rollback: a schema change is currently cutting over")

--- a/pkg/cmd/commands/start.go
+++ b/pkg/cmd/commands/start.go
@@ -36,7 +36,7 @@ func (cmd *StartCmd) Run(g *Globals) error {
 		fmt.Println("Schema change already complete - nothing to start")
 		return nil
 	}
-	if state.IsState(curState, state.Apply.Running, state.Apply.CuttingOver) {
+	if state.IsState(curState, state.Apply.Running, state.Apply.RunningDegraded, state.Apply.CuttingOver) {
 		fmt.Println("Schema change already running")
 		if cmd.Watch {
 			return WatchApplyProgressByApplyID(ep, cmd.ApplyID, true)

--- a/pkg/cmd/commands/stop.go
+++ b/pkg/cmd/commands/stop.go
@@ -43,7 +43,7 @@ func (cmd *StopCmd) Run(g *Globals) error {
 		fmt.Println("Schema change already stopped")
 		return nil
 	}
-	if !state.IsState(curState, state.Apply.Running, state.Apply.CuttingOver, state.Apply.WaitingForDeploy, state.Apply.WaitingForCutover, state.Apply.Pending) {
+	if !state.IsState(curState, state.Apply.Running, state.Apply.RunningDegraded, state.Apply.CuttingOver, state.Apply.WaitingForDeploy, state.Apply.WaitingForCutover, state.Apply.Pending) {
 		return fmt.Errorf("cannot stop schema change in state: %s", curState)
 	}
 

--- a/pkg/cmd/commands/volume.go
+++ b/pkg/cmd/commands/volume.go
@@ -43,7 +43,7 @@ func (cmd *VolumeCmd) Run(g *Globals) error {
 	if state.IsState(curState, state.Apply.Failed) {
 		return fmt.Errorf("schema change failed - cannot adjust volume")
 	}
-	if !state.IsState(curState, state.Apply.Running, state.Apply.CuttingOver, state.Apply.WaitingForCutover, state.Apply.Stopped) {
+	if !state.IsState(curState, state.Apply.Running, state.Apply.RunningDegraded, state.Apply.CuttingOver, state.Apply.WaitingForCutover, state.Apply.Stopped) {
 		return fmt.Errorf("cannot adjust volume in state: %s", curState)
 	}
 

--- a/pkg/cmd/commands/watch_tui.go
+++ b/pkg/cmd/commands/watch_tui.go
@@ -202,13 +202,13 @@ func (m WatchModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, nil
 			}
 			// Stop (Spirit) or cancel (PlanetScale) the schema change
-			if state.IsState(m.state, state.Apply.Running, state.Apply.WaitingForDeploy, state.Apply.WaitingForCutover) && !m.stopTriggered {
+			if state.IsState(m.state, state.Apply.Running, state.Apply.RunningDegraded, state.Apply.WaitingForDeploy, state.Apply.WaitingForCutover) && !m.stopTriggered {
 				m.stopTriggered = true
 				return m, m.triggerStop()
 			}
 		case "v":
 			// Enter volume mode (only when running)
-			if state.IsState(m.state, state.Apply.Running) && !isCuttingOver {
+			if state.IsRunningApplyState(m.state) && !isCuttingOver {
 				m.volumeMode = true
 				return m, nil
 			}

--- a/pkg/state/README.md
+++ b/pkg/state/README.md
@@ -20,6 +20,7 @@ the stored task rows.
 |-------|-------|-------------|
 | Pending | `pending` | Apply created, no tasks started |
 | Running | `running` | At least one task is actively executing |
+| RunningDegraded | `running_degraded` | A multi-deployment rollout is still in flight, but a deployment has already failed under `on_failure: continue`. Projected from the operation rows; the apply still settles to `failed` once every sibling is terminal |
 | ValidatingBranch | `validating_branch` | Branch schema validation in progress after DDL apply (PlanetScale only) |
 | ValidatingDeployRequest | `validating_deploy_request` | PlanetScale is validating the deploy request diff (PlanetScale only) |
 | WaitingForDeploy | `waiting_for_deploy` | Deploy request ready, waiting for user to trigger deploy (PlanetScale only). Without `--defer-deploy`, auto-advances immediately. |
@@ -51,6 +52,9 @@ stateDiagram-v2
     running --> cancelled : permanent (PlanetScale only)
     running --> waiting_for_cutover : atomic mode
     running --> revert_window : PlanetScale only
+    running --> running_degraded : sibling deployment failed (on_failure continue)
+    running_degraded --> failed : all siblings terminal
+    failed --> running_degraded : lease-scoped reopen while a sibling runs
     failed_retryable --> running : scheduler retry
     failed_retryable --> failed : retry budget or recovery window exhausted
 
@@ -67,6 +71,7 @@ stateDiagram-v2
 
 - `waiting_for_deploy`: PlanetScale only. The deploy request is created and ready, but not yet executed. With `--defer-deploy`, the user reviews the deploy request diff on PlanetScale and triggers via `schemabot cutover`. Without `--defer-deploy`, the system auto-advances through this state. For instant DDL, the deploy completes immediately after triggering. `--defer-deploy` and `--defer-cutover` compose: the first pauses before deploy, the second pauses before cutover.
 - `waiting_for_cutover`/`cutting_over`: Only with `--defer-cutover` or atomic mode (Spirit). Note: `--defer-cutover` is a no-op for instant DDL (no cutover exists).
+- `running_degraded`: Projected (not engine-reported) apply state for a multi-deployment rollout that is still in flight after a deployment failed under `on_failure: continue`. It is non-terminal and active — recovery can reclaim a stale degraded parent, and the one-active-apply overlap invariant keeps the whole target set reserved while it holds. It is unreachable for single-operation applies (one failed operation is already terminal, so the apply settles straight to `failed`); it only appears once an apply owns more than one operation. The `continue` policy governs rollout continuation, not the pass/fail verdict, so the apply still settles to `failed` once every sibling reaches a terminal state.
 - `recovering`: Temporary restart recovery. Current MySQL/Spirit deferred-cutover recovery enters this state only after durable storage had already reached `waiting_for_cutover`. That stored cutover-ready state is authoritative: recovery must not move durable storage backward to `running` if Spirit reports row-copy progress after reattaching. Row-copy counters can still be displayed while storage remains `recovering`. Recovery exits to `waiting_for_cutover` only after cutover readiness is proven again, or to `completed` when live-schema reconciliation proves the data plane already reached the desired schema. Control operations that require a later phase are blocked while recovery is active.
 - `revert_window`: Only with `--enable-revert`. Spirit auto-advances through it; PlanetScale holds until expiry or user action. Maps from PlanetScale's `complete_pending_revert` deploy state
 - `stopped`: Spirit only — resumable via `schemabot start`. Spirit checkpoints progress for resume.

--- a/pkg/state/apply.go
+++ b/pkg/state/apply.go
@@ -261,6 +261,18 @@ func IsTerminalApplyState(s string) bool {
 	return ok && info.Terminal
 }
 
+// IsRunningApplyState reports whether an apply is in a running-family state:
+// running, or running_degraded (a continue rollout still in flight after a
+// sibling deployment failed). Control gates that mean "the apply is actively
+// running" — cutover readiness, start reconciliation, stop/volume eligibility —
+// must use this so a degraded rollout is not mistaken for a non-running apply.
+// This is narrower than "active" (non-terminal): pending, waiting_for_cutover,
+// recovering, and other non-terminal states are not running-family.
+// Accepts any format (proto, uppercase, or canonical lowercase).
+func IsRunningApplyState(s string) bool {
+	return IsState(s, Apply.Running, Apply.RunningDegraded)
+}
+
 // IsSetupPhase returns true if the apply state is an engine-lifecycle phase
 // that runs before per-table progress is meaningful (all tables are Queued).
 // Used by the TUI and CLI to hide the table list during setup.

--- a/pkg/state/apply.go
+++ b/pkg/state/apply.go
@@ -15,6 +15,7 @@ import "strings"
 var Apply = struct {
 	Pending           string
 	Running           string
+	RunningDegraded   string
 	WaitingForDeploy  string
 	WaitingForCutover string
 	Recovering        string
@@ -38,6 +39,7 @@ var Apply = struct {
 }{
 	Pending:           "pending",
 	Running:           "running",
+	RunningDegraded:   "running_degraded",
 	WaitingForDeploy:  "waiting_for_deploy",
 	WaitingForCutover: "waiting_for_cutover",
 	Recovering:        "recovering",
@@ -161,8 +163,9 @@ type RolloutChild struct {
 //     failure stands and the apply is failed (fail closed, matching halt); else
 //   - if every child is terminal, the rollout is settled and the apply is
 //     failed (the verdict still reflects the failure); else
-//   - the apply is held running so the still-in-flight siblings can run to
-//     completion under continue.
+//   - the apply is held running_degraded so the still-in-flight siblings can
+//     run to completion under continue while surfacing that a sibling has
+//     already failed.
 //
 // An empty child set returns Pending, matching DeriveApplyState.
 func DeriveRolloutApplyState(children []RolloutChild) string {
@@ -191,7 +194,7 @@ func DeriveRolloutApplyState(children []RolloutChild) string {
 	if allTerminal {
 		return Apply.Failed
 	}
-	return Apply.Running
+	return Apply.RunningDegraded
 }
 
 // normalizeApplyState converts a task state string to its canonical lowercase form.
@@ -201,6 +204,8 @@ func normalizeApplyState(raw string) string {
 		return Apply.Pending
 	case "RUNNING":
 		return Apply.Running
+	case "RUNNING_DEGRADED":
+		return Apply.RunningDegraded
 	case "WAITING_FOR_DEPLOY":
 		return Apply.WaitingForDeploy
 	case "WAITING_FOR_CUTOVER":

--- a/pkg/state/apply_test.go
+++ b/pkg/state/apply_test.go
@@ -184,6 +184,7 @@ func TestIsTerminalApplyState(t *testing.T) {
 	nonTerminalStates := []string{
 		Apply.Pending,
 		Apply.Running,
+		Apply.RunningDegraded,
 		Apply.FailedRetryable,
 		Apply.WaitingForCutover,
 		Apply.CuttingOver,
@@ -210,6 +211,8 @@ func TestNormalizeState(t *testing.T) {
 		{"pending", Apply.Pending},
 		{"RUNNING", Apply.Running},
 		{"running", Apply.Running},
+		{"RUNNING_DEGRADED", Apply.RunningDegraded},
+		{"running_degraded", Apply.RunningDegraded},
 		{"WAITING_FOR_DEPLOY", Apply.WaitingForDeploy},
 		{"waiting_for_deploy", Apply.WaitingForDeploy},
 		{"WAITING_FOR_CUTOVER", Apply.WaitingForCutover},
@@ -369,14 +372,14 @@ func TestDeriveRolloutApplyState_FailurePolicy(t *testing.T) {
 		want     string
 	}{
 		{
-			name:     "continue failure with pending sibling holds running",
+			name:     "continue failure with pending sibling holds running_degraded",
 			children: []RolloutChild{rc(Apply.Failed, true), rc(Apply.Pending, true)},
-			want:     Apply.Running,
+			want:     Apply.RunningDegraded,
 		},
 		{
-			name:     "continue failure with running sibling holds running",
+			name:     "continue failure with running sibling holds running_degraded",
 			children: []RolloutChild{rc(Apply.Failed, true), rc(Apply.Running, true)},
-			want:     Apply.Running,
+			want:     Apply.RunningDegraded,
 		},
 		{
 			name:     "continue failure with all siblings terminal settles failed",
@@ -399,9 +402,9 @@ func TestDeriveRolloutApplyState_FailurePolicy(t *testing.T) {
 			want:     Apply.Failed,
 		},
 		{
-			name:     "continue failure with completed and pending holds running",
+			name:     "continue failure with completed and pending holds running_degraded",
 			children: []RolloutChild{rc(Apply.Failed, true), rc(Apply.Completed, true), rc(Apply.Pending, true)},
-			want:     Apply.Running,
+			want:     Apply.RunningDegraded,
 		},
 	}
 	for _, tc := range cases {

--- a/pkg/state/apply_test.go
+++ b/pkg/state/apply_test.go
@@ -202,6 +202,28 @@ func TestIsTerminalApplyState(t *testing.T) {
 	assert.False(t, IsTerminalApplyState("STATE_RUNNING"))
 }
 
+// TestIsRunningApplyState pins the running-family set that control gates key
+// off: running and running_degraded are running-family; other non-terminal
+// states (pending, waiting_for_cutover, recovering) are not.
+func TestIsRunningApplyState(t *testing.T) {
+	for _, s := range []string{Apply.Running, Apply.RunningDegraded, "RUNNING", "STATE_RUNNING_DEGRADED", "running_degraded"} {
+		assert.Truef(t, IsRunningApplyState(s), "%s should be running-family", s)
+	}
+	for _, s := range []string{
+		Apply.Pending,
+		Apply.WaitingForDeploy,
+		Apply.WaitingForCutover,
+		Apply.Recovering,
+		Apply.CuttingOver,
+		Apply.FailedRetryable,
+		Apply.Completed,
+		Apply.Failed,
+		Apply.Stopped,
+	} {
+		assert.Falsef(t, IsRunningApplyState(s), "%s should NOT be running-family", s)
+	}
+}
+
 func TestNormalizeState(t *testing.T) {
 	testCases := []struct {
 		input    string

--- a/pkg/state/metadata.go
+++ b/pkg/state/metadata.go
@@ -41,6 +41,9 @@ var applyMetadata = map[string]ApplyStateInfo{
 	Apply.Running: {
 		Label: "Running",
 	},
+	Apply.RunningDegraded: {
+		Label: "Running (degraded)",
+	},
 	Apply.WaitingForDeploy: {
 		Label:      "Waiting for deploy",
 		SetupPhase: true,

--- a/pkg/storage/mysqlstore/applies.go
+++ b/pkg/storage/mysqlstore/applies.go
@@ -86,6 +86,7 @@ type txBeginner interface {
 func claimableApplyStates() []string {
 	return []string{
 		state.Apply.Running,
+		state.Apply.RunningDegraded,
 		state.Apply.WaitingForDeploy,
 		state.Apply.WaitingForCutover,
 		state.Apply.Recovering,

--- a/pkg/tern/local_client_test.go
+++ b/pkg/tern/local_client_test.go
@@ -1804,9 +1804,9 @@ func TestDeriveAggregateApplyState(t *testing.T) {
 
 	// Under on_failure "continue" a terminally failed deployment does not
 	// terminalize the apply while a sibling is still pending: the apply is held
-	// running so the remaining deployment gets its turn, then settles to failed
-	// once every sibling is terminal.
-	t.Run("continue policy holds the apply active past a failed deployment", func(t *testing.T) {
+	// running_degraded so the remaining deployment gets its turn, then settles to
+	// failed once every sibling is terminal.
+	t.Run("continue policy holds the apply degraded past a failed deployment", func(t *testing.T) {
 		tasks := []*storage.Task{taskWith(state.Task.Failed)}
 		client := &LocalClient{
 			storage: &exactProgressStorage{
@@ -1823,7 +1823,7 @@ func TestDeriveAggregateApplyState(t *testing.T) {
 
 		got, ok := client.deriveAggregateApplyState(t.Context(), apply, tasks)
 		assert.True(t, ok, "current op row present, projection must be determined")
-		assert.Equal(t, state.Apply.Running, got, "continue policy must hold the apply active until the pending sibling settles")
+		assert.Equal(t, state.Apply.RunningDegraded, got, "continue policy must hold the apply degraded until the pending sibling settles")
 	})
 
 	// Default policy (on_failure unset) fails closed: a terminally failed


### PR DESCRIPTION
## What
Add a first-class `running_degraded` apply state. The rollout projection now
emits it (instead of plain `running`) when a multi-deployment rollout is still
in flight after a sibling deployment has failed under `on_failure: continue`.
It is non-terminal and active, settling to `failed` once every sibling is
terminal.

## Why
Today a rollout holding active past a continuable failure is indistinguishable
from a clean run, so checks/comments/metrics can't surface the degradation.
This makes the state machine carry that signal. Unreachable for single-op
applies (a single failed op is already terminal), so there is no behavior
change until multi-deployment fan-out is live.

## Flow
```
BEFORE                              AFTER
---
op A failed  (continue)            op A failed  (continue)
op B running                       op B running
|                                  |
v                                  v
derive parent state               derive parent state
|                                  |
v                                  v
running                          running_degraded
(looks like a clean run)          (active, failure surfaced)
|                                  |
all siblings terminal             all siblings terminal
v                                  v
failed                             failed

Single-op: one failed op is terminal, so the parent settles straight to
`failed` — the degraded branch is never taken.
```
## Follow-up
PR-4b (stacked): migrate consumers — PR comment/Check Run, CLI/TUI labels,
metrics, and control-handler command gates — to key off `running_degraded`.
