### PR TITLE
feat(storage): fail closed on operation-lease-only parent writes

### DIFF
--- a/pkg/storage/mysqlstore/applies.go
+++ b/pkg/storage/mysqlstore/applies.go
@@ -1552,6 +1552,18 @@ func failPendingStartControlRequestTx(ctx context.Context, tx *sql.Tx, applyID i
 // When ctx has an apply lease, a stale token returns ErrApplyLeaseLost so the
 // old operator owner stops before writing state or external side effects.
 func (s *applyStore) Heartbeat(ctx context.Context, applyID int64) error {
+	// A drive that holds only an operation lease must never bump the parent
+	// applies row: under fan-out the parent's liveness is owned by the parent
+	// lease and the rollout projection, not a per-operation drive. A
+	// single-operation drive still carries the parent apply lease alongside the
+	// operation lease, so it keeps the heartbeat; only an operation-lease-only
+	// context is refused here. Mirrors the guard in Update.
+	if _, hasOpLease := storage.OperationLeaseFromContext(ctx); hasOpLease {
+		if _, hasApplyLease := storage.ApplyLeaseFromContext(ctx); !hasApplyLease {
+			return fmt.Errorf("operation lease does not authorize a heartbeat of apply %d; parent liveness is owned by the parent lease: %w", applyID, storage.ErrApplyLeaseLost)
+		}
+	}
+
 	lease, hasLease, err := applyLeaseFromContext(ctx, applyID)
 	if err != nil {
 		return err

--- a/pkg/storage/mysqlstore/applies_test.go
+++ b/pkg/storage/mysqlstore/applies_test.go
@@ -1459,6 +1459,45 @@ func TestApplyStore_UpdateRejectsOperationLeaseOnlyContext(t *testing.T) {
 	assert.Equal(t, state.Apply.Failed, written.State)
 }
 
+// TestApplyStore_HeartbeatRejectsOperationLeaseOnlyContext verifies that a drive
+// holding only an operation lease cannot heartbeat the parent applies row: the
+// parent's liveness is owned by the parent lease and the rollout projection. A
+// single-operation drive carries the parent apply lease alongside the operation
+// lease, so its heartbeat still lands.
+func TestApplyStore_HeartbeatRejectsOperationLeaseOnlyContext(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", storage.DatabaseTypeMySQL, "staging")
+	apply := createTestApplyWithStateAndEnv(t, store, lock, "apply_heartbeat_oplease", 907, state.Apply.Running, "staging")
+	opID := createApplyOperationForLeaseTest(t, store, apply.ID, "primary")
+	stampOperationLease(t, opID, "worker", "op-token")
+
+	_, err := testDB.ExecContext(ctx, `UPDATE applies SET updated_at = NOW() - INTERVAL 5 MINUTE WHERE id = ?`, apply.ID)
+	require.NoError(t, err)
+	before, err := store.Applies().Get(ctx, apply.ID)
+	require.NoError(t, err)
+
+	opOnlyCtx := storage.WithOperationLease(ctx, storage.OperationLease{
+		ApplyID: apply.ID, OperationID: opID, Owner: "worker", Token: "op-token",
+	})
+	require.ErrorIs(t, store.Applies().Heartbeat(opOnlyCtx, apply.ID), storage.ErrApplyLeaseLost,
+		"an operation-lease-only context must not heartbeat the parent apply")
+	unchanged, err := store.Applies().Get(ctx, apply.ID)
+	require.NoError(t, err)
+	assert.Equal(t, before.UpdatedAt, unchanged.UpdatedAt, "the parent row must be untouched")
+
+	// A single-operation drive carries both leases, so the heartbeat lands.
+	_, err = testDB.ExecContext(ctx, `UPDATE applies SET lease_owner=?, lease_token=?, lease_acquired_at=NOW() WHERE id=?`, "current-worker", "apply-token", apply.ID)
+	require.NoError(t, err)
+	dualCtx := storage.WithApplyLease(opOnlyCtx, storage.ApplyLease{ApplyID: apply.ID, Owner: "current-worker", Token: "apply-token"})
+	require.NoError(t, store.Applies().Heartbeat(dualCtx, apply.ID))
+	after, err := store.Applies().Get(ctx, apply.ID)
+	require.NoError(t, err)
+	assert.True(t, after.UpdatedAt.After(before.UpdatedAt), "the heartbeat must move updated_at forward")
+}
+
 func TestApplyStore_GetInProgress(t *testing.T) {
 	clearTables(t)
 	ctx := t.Context()

--- a/pkg/storage/mysqlstore/apply_operations.go
+++ b/pkg/storage/mysqlstore/apply_operations.go
@@ -1060,6 +1060,47 @@ func (s *applyOperationStore) DeleteByApply(ctx context.Context, applyID int64) 
 // Writes are apply-lease guarded when a lease is present in ctx, mirroring
 // DeleteByApply.
 func (s *applyOperationStore) MarkPendingStoppedByApply(ctx context.Context, applyID int64) (int64, error) {
+	// An operation-lease-only drive (fan-out multi-operation mode) holds no
+	// parent apply lease, but it is still an authorized driver of the apply's
+	// rollout and may terminalize the apply's still-pending sibling operations
+	// under a pending stop. Authorize the bulk stop by joining the owning
+	// operation row and requiring it still carries the lease token, so a
+	// displaced driver that lost its lease fails closed instead of stopping
+	// siblings it no longer owns. Operation lease takes precedence over the
+	// parent apply lease, matching operationWriteGuardFromContext.
+	if opLease, ok := storage.OperationLeaseFromContext(ctx); ok {
+		if !opLease.Valid() {
+			return 0, fmt.Errorf("invalid operation lease for stopping pending apply_operations of apply %d: %w", applyID, storage.ErrApplyLeaseLost)
+		}
+		if opLease.ApplyID != applyID {
+			return 0, fmt.Errorf("operation lease for apply %d does not authorize stopping pending operations of apply %d: %w", opLease.ApplyID, applyID, storage.ErrApplyLeaseLost)
+		}
+		result, err := s.db.ExecContext(ctx, `
+			UPDATE apply_operations ao
+			JOIN apply_operations owner_op ON owner_op.apply_id = ao.apply_id
+			SET ao.state = ?, ao.updated_at = NOW()
+			WHERE ao.apply_id = ? AND ao.state = ?
+			  AND owner_op.id = ? AND owner_op.lease_token = ?
+		`, state.ApplyOperation.Stopped, applyID, state.ApplyOperation.Pending, opLease.OperationID, opLease.Token)
+		if err != nil {
+			return 0, fmt.Errorf("stop pending apply_operations for apply %d under operation lease: %w", applyID, err)
+		}
+		rows, err := result.RowsAffected()
+		if err != nil {
+			return 0, fmt.Errorf("read stopped pending apply_operations rows affected for apply %d: %w", applyID, err)
+		}
+		if rows == 0 {
+			// No pending rows changed: either there were none (lease still
+			// valid, a legitimate no-op) or the operation lease token no longer
+			// matches (ownership lost). Distinguish so a displaced driver fails
+			// closed.
+			if err := ensureOperationLeaseStillOwned(ctx, s.db, opLease); err != nil {
+				return 0, err
+			}
+		}
+		return rows, nil
+	}
+
 	lease, hasLease, err := applyLeaseFromContext(ctx, applyID)
 	if err != nil {
 		return 0, err

--- a/pkg/storage/mysqlstore/apply_operations_test.go
+++ b/pkg/storage/mysqlstore/apply_operations_test.go
@@ -2579,3 +2579,58 @@ func TestApplyOperationStore_MarkPendingStoppedByApply(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, int64(0), again, "no pending rows remain to stop")
 }
+
+// Under fan-out multi-operation mode the driving worker holds only an operation
+// lease, not the parent apply lease. MarkPendingStoppedByApply must still let it
+// stop the apply's pending siblings, authorized by the owning operation row's
+// own lease token, and must fail closed when that token is stale or names a
+// different apply so a displaced driver cannot stop siblings it no longer owns.
+func TestApplyOperationStore_MarkPendingStoppedByApply_OperationLease(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", "mysql", "staging")
+	apply := createTestApplyWithStateAndEnv(t, store, lock, "apply_op_mark_stopped_oplease", 1, state.Apply.Running, "staging")
+
+	// The owning operation the driver holds a lease on. It is running (driving),
+	// so MarkPendingStoppedByApply never touches it.
+	ownerID := createApplyOperationForLeaseTest(t, store, apply.ID, "region-owner")
+	require.NoError(t, store.ApplyOperations().UpdateState(ctx, ownerID, state.ApplyOperation.Running))
+	stampOperationLease(t, ownerID, "worker", "op-token")
+
+	pendingID := createApplyOperationForLeaseTest(t, store, apply.ID, "region-pending")
+
+	opCtx := func(applyID, opID int64, token string) context.Context {
+		return storage.WithOperationLease(ctx, storage.OperationLease{
+			ApplyID:     applyID,
+			OperationID: opID,
+			Owner:       "worker",
+			Token:       token,
+		})
+	}
+
+	// A stale operation token while a pending sibling remains fails closed and
+	// leaves the sibling pending.
+	_, err := store.ApplyOperations().MarkPendingStoppedByApply(opCtx(apply.ID, ownerID, "stale-op-token"), apply.ID)
+	require.ErrorIs(t, err, storage.ErrApplyLeaseLost)
+	assertApplyOperationState(t, store, pendingID, state.ApplyOperation.Pending)
+
+	// An operation lease naming a different apply does not authorize the stop.
+	_, err = store.ApplyOperations().MarkPendingStoppedByApply(opCtx(apply.ID+1, ownerID, "op-token"), apply.ID)
+	require.ErrorIs(t, err, storage.ErrApplyLeaseLost)
+	assertApplyOperationState(t, store, pendingID, state.ApplyOperation.Pending)
+
+	// The current operation token stops the pending sibling and leaves the
+	// running owner untouched.
+	stopped, err := store.ApplyOperations().MarkPendingStoppedByApply(opCtx(apply.ID, ownerID, "op-token"), apply.ID)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), stopped)
+	assertApplyOperationState(t, store, pendingID, state.ApplyOperation.Stopped)
+	assertApplyOperationState(t, store, ownerID, state.ApplyOperation.Running)
+
+	// A repeat under the current token is a clean no-op (lease still owned).
+	again, err := store.ApplyOperations().MarkPendingStoppedByApply(opCtx(apply.ID, ownerID, "op-token"), apply.ID)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), again)
+}


### PR DESCRIPTION
## What and Why ?

Storage-layer fail-closed backstops for operation-lease-only drives (multi-operation fan-out mode). These ensure that even if a driver path forgets to gate itself, the storage layer refuses parent writes it is not authorized to make.

- `Applies().Heartbeat` now refuses an operation-lease-only context, mirroring the existing `Update` guard. The parent apply's liveness is owned by the parent lease and the rollout projection, not a per-operation drive. A single-operation drive carries both leases, so its heartbeat still lands.
- `ApplyOperations().MarkPendingStoppedByApply` adds an operation-lease branch so a multi-operation drive (which holds no apply lease) can still stop the apply's pending siblings — authorized by a self-join on the owning operation row's lease token. It fails closed when that token is stale or names a different apply, instead of falling through to an unguarded bulk update.

### Setup: one parent apply, three operations (fan-out)
```
            ╭──────────────────────────────────────────────╮
            │  applies row  A (id=42)                       │
            │    state        = running                     │
            │    lease_owner  = (none, fan-out)             │
            │    lease_token  = (none, fan-out)             │
            │  parent state owned by the rollout projection │
            ╰──────────────────────────────────────────────╯
              ▲                  ▲                  ▲
   apply_id=42│       apply_id=42│       apply_id=42│
   ╭──────────┴───────╮ ╭────────┴─────────╮ ╭──────┴───────────╮
   │ op1 (id=101)     │ │ op2 (id=102)     │ │ op3 (id=103)     │
   │  state = running │ │  state = pending │ │  state = pending │
   │  token = "T1"    │ │  token = "T2"    │ │  token = "T3"    │
   │  ◀ THE DRIVER    │ │                  │ │                  │
   ╰──────────────────╯ ╰──────────────────╯ ╰──────────────────╯
```
The driver worker holds only the op1 operation lease (ApplyID=42, OperationID=101, Token="T1"). It does not hold an apply lease on A.

### Backstop 1 — Applies().Heartbeat(A)
```
context = op-lease-only { op=101, token="T1" }   (no apply lease)
        │
        ▼  Applies().Heartbeat(applyID=42)
   ╭───────────────────────────────────────────────╮
   │ has op lease?  yes                             │
   │ has apply lease? no   ──▶ REFUSE               │
   │ return ErrApplyLeaseLost                       │
   │ (parent A liveness is the projection's job)    │
   ╰───────────────────────────────────────────────╯

context = dual lease { op=101,"T1" } + { apply=42,"A-tok" }  (single-op drive)
        │
        ▼  Applies().Heartbeat(applyID=42)
   ╭───────────────────────────────────────────────╮
   │ has apply lease? yes  ──▶ legacy path lands   │
   │ UPDATE applies SET updated_at=NOW()           │
   │   WHERE id=42 AND lease_token="A-tok"         │
   ╰───────────────────────────────────────────────╯
```
### Backstop 2 — MarkPendingStoppedByApply(A) under a pending stop

The driver wants to terminalize A's still-pending siblings (op2, op3) so the rollout can settle. Authorization comes from op1 still holding its own token — verified by a self-join.
```
context = op-lease-only { op=101, token="T1" }
        │
        ▼  MarkPendingStoppedByApply(applyID=42)
   ╭──────────────────────────────────────────────────────────────╮
   │ guard: opLease.ApplyID == 42 ?            yes                |
   │ UPDATE apply_operations ao                                   │
   │   JOIN apply_operations owner_op                             │
   │        ON owner_op.apply_id = ao.apply_id                    │
   │   SET ao.state = stopped                                     │
   │   WHERE ao.apply_id = 42 AND ao.state = pending              │
   │     AND owner_op.id = 101 AND owner_op.lease_token = "T1"    │
   ╰──────────────────────────────────────────────────────────────╯
        │
        ▼  owner_op (op1) still carries "T1"  ──▶ AUTHORIZED
   ╭──────────────────────────────────────────────────────────────╮
   │ op2 (102): pending ──▶ stopped   ✔                           │
   │ op3 (103): pending ──▶ stopped   ✔                           │
   │ op1 (101): running ──▶ untouched (not pending)               │
   │ returns rows = 2                                             │
   ╰──────────────────────────────────────────────────────────────╯
```
### Fail-closed cases
```
stale / lost token  (op1 row now carries "T1-new", driver still thinks "T1")
   self-join matches 0 owner rows ──▶ 0 pending rows updated
   rows == 0 ──▶ ensureOperationLeaseStillOwned(op=101,"T1")
              ──▶ token no longer current ──▶ ErrApplyLeaseLost
   op2, op3 stay pending. nothing stopped.   ✗ (correctly refused)

wrong apply  (op lease names ApplyID=99, call targets 42)
   guard opLease.ApplyID(99) != 42 ──▶ ErrApplyLeaseLost   ✗ (refused early)

legitimate no-op  (token valid "T1", but no pending siblings left)
   self-join matches op1, but 0 rows are pending ──▶ rows == 0
   ensureOperationLeaseStillOwned ──▶ still owned ──▶ return 0, nil   ✔
```

**NOTE**
The key invariant: a displaced driver that lost op1's lease can never stop op2/op3 — the self-join collapses to zero rows and the ownership re-check converts that into ErrApplyLeaseLost rather than a silent success.