### PR TITLE
feat(auth): authenticate CLI requests with a Bearer token

### DIFF
--- a/pkg/cmd/client/config.go
+++ b/pkg/cmd/client/config.go
@@ -151,6 +151,18 @@ func ResolveEndpointWithProfile(endpointFlag, profileFlag string, configEndpoint
 	return "", nil
 }
 
+// ResolveToken returns the Bearer token to authenticate with, checking in order:
+// 1. Explicit --token flag
+// 2. SCHEMABOT_TOKEN environment variable
+// An empty result means no token is configured, which is correct against a
+// server with auth disabled.
+func ResolveToken(tokenFlag string) string {
+	if tokenFlag != "" {
+		return tokenFlag
+	}
+	return os.Getenv("SCHEMABOT_TOKEN")
+}
+
 func trimSlash(s string) string {
 	if len(s) > 0 && s[len(s)-1] == '/' {
 		return s[:len(s)-1]

--- a/pkg/cmd/client/config_token_test.go
+++ b/pkg/cmd/client/config_token_test.go
@@ -1,0 +1,24 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResolveToken(t *testing.T) {
+	t.Run("flag takes precedence over env", func(t *testing.T) {
+		t.Setenv("SCHEMABOT_TOKEN", "from-env")
+		assert.Equal(t, "from-flag", ResolveToken("from-flag"))
+	})
+
+	t.Run("falls back to env when flag is empty", func(t *testing.T) {
+		t.Setenv("SCHEMABOT_TOKEN", "from-env")
+		assert.Equal(t, "from-env", ResolveToken(""))
+	})
+
+	t.Run("empty when neither is set", func(t *testing.T) {
+		t.Setenv("SCHEMABOT_TOKEN", "")
+		assert.Empty(t, ResolveToken(""))
+	})
+}

--- a/pkg/cmd/client/request.go
+++ b/pkg/cmd/client/request.go
@@ -7,7 +7,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -40,11 +42,39 @@ type bearerTransport struct {
 
 func (t *bearerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	if t.token != "" && req.Header.Get("Authorization") == "" {
+		if err := guardInsecureToken(req.URL); err != nil {
+			return nil, err
+		}
 		// RoundTrip must not mutate the caller's request, so clone it.
 		req = req.Clone(req.Context())
 		req.Header.Set("Authorization", "Bearer "+t.token)
 	}
 	return t.base.RoundTrip(req)
+}
+
+// ErrInsecureTokenTransport is returned when a Bearer token would be sent over
+// a plaintext connection to a non-loopback host.
+var ErrInsecureTokenTransport = errors.New("refusing to send auth token over an insecure connection")
+
+// guardInsecureToken refuses to attach a Bearer token to a plaintext connection
+// unless it targets loopback. A token sent over http:// to a remote host is
+// exposed to anyone on the network path, so this fails closed rather than
+// leaking the credential; https and local (loopback) endpoints are allowed.
+func guardInsecureToken(u *url.URL) error {
+	if u.Scheme == "https" || isLoopbackHost(u.Hostname()) {
+		return nil
+	}
+	return fmt.Errorf("%w to %s: use an https:// endpoint (loopback is allowed for local testing)", ErrInsecureTokenTransport, u.Host)
+}
+
+func isLoopbackHost(host string) bool {
+	if host == "localhost" {
+		return true
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return ip.IsLoopback()
+	}
+	return false
 }
 
 // APIError represents an error response from the API.
@@ -256,7 +286,12 @@ func (e *ConnectionError) message() string {
 }
 
 // FormatConnectionError returns a ConnectionError wrapping the underlying cause.
+// A token-transport refusal is surfaced verbatim rather than reframed as a
+// network failure, so the operator sees the actual security reason.
 func FormatConnectionError(endpoint string, err error) error {
+	if errors.Is(err, ErrInsecureTokenTransport) {
+		return err
+	}
 	return &ConnectionError{Endpoint: endpoint, Err: err}
 }
 

--- a/pkg/cmd/client/request.go
+++ b/pkg/cmd/client/request.go
@@ -14,9 +14,38 @@ import (
 	"golang.org/x/net/html"
 )
 
+// authTransport injects a Bearer token on outbound requests when one is
+// configured. It wraps the default transport so every CLI request — including
+// those built outside the doGet/doPost helpers — is authenticated uniformly.
+var authTransport = &bearerTransport{base: http.DefaultTransport}
+
 // httpClient is the shared HTTP client for all CLI requests.
 // Uses a 30s timeout to avoid hanging indefinitely on network stalls.
-var httpClient = &http.Client{Timeout: 30 * time.Second}
+var httpClient = &http.Client{Timeout: 30 * time.Second, Transport: authTransport}
+
+// SetAuthToken configures the Bearer token attached to every CLI request. An
+// empty token leaves requests unauthenticated, which is correct against a
+// server with auth disabled. Surrounding whitespace is trimmed so a token
+// sourced from an environment variable or file does not break the header.
+func SetAuthToken(token string) {
+	authTransport.token = strings.TrimSpace(token)
+}
+
+// bearerTransport sets "Authorization: Bearer <token>" on each request when a
+// token is configured and the header is not already set.
+type bearerTransport struct {
+	base  http.RoundTripper
+	token string
+}
+
+func (t *bearerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if t.token != "" && req.Header.Get("Authorization") == "" {
+		// RoundTrip must not mutate the caller's request, so clone it.
+		req = req.Clone(req.Context())
+		req.Header.Set("Authorization", "Bearer "+t.token)
+	}
+	return t.base.RoundTrip(req)
+}
 
 // APIError represents an error response from the API.
 type APIError struct {

--- a/pkg/cmd/client/request_test.go
+++ b/pkg/cmd/client/request_test.go
@@ -60,3 +60,37 @@ func TestAuthTokenTrimmed(t *testing.T) {
 	require.NoError(t, doPostInto(srv.URL, "/api/plan", map[string]string{}, &out))
 	assert.Equal(t, "Bearer tok-padded", gotAuth)
 }
+
+func TestAuthTokenRefusedOverInsecureRemote(t *testing.T) {
+	setTokenForTest(t, "tok-abc123")
+
+	var out map[string]any
+	err := doGetInto("http://schemabot.example.com", "/api/status", &out)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "insecure connection")
+}
+
+func TestAuthTokenAllowedOverLoopbackHTTP(t *testing.T) {
+	// httptest serves plaintext on 127.0.0.1, which is loopback and therefore
+	// safe to send a token to during local development.
+	var gotAuth string
+	srv := captureAuthServer(t, &gotAuth)
+	setTokenForTest(t, "tok-local")
+
+	var out map[string]any
+	require.NoError(t, doGetInto(srv.URL, "/api/status", &out))
+	assert.Equal(t, "Bearer tok-local", gotAuth)
+}
+
+func TestNoTokenAllowedOverInsecureRemote(t *testing.T) {
+	// Without a token there is nothing to leak, so the insecure-transport guard
+	// must not block ordinary unauthenticated requests.
+	setTokenForTest(t, "")
+
+	var out map[string]any
+	err := doGetInto("http://schemabot.example.com", "/api/status", &out)
+	// The request proceeds past the guard and fails on connection, not on the
+	// token guard.
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "insecure connection")
+}

--- a/pkg/cmd/client/request_test.go
+++ b/pkg/cmd/client/request_test.go
@@ -31,13 +31,28 @@ func setTokenForTest(t *testing.T, token string) {
 	SetAuthToken(token)
 }
 
+// sendThroughTransport drives a request through the shared httpClient (and thus
+// the bearer transport), tying it to the test lifecycle via t.Context(). The
+// optional preset header is set before the transport runs, to verify the
+// transport does not clobber caller-provided headers.
+func sendThroughTransport(t *testing.T, rawURL string, presetAuth string) (*http.Response, error) {
+	t.Helper()
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, rawURL, nil)
+	require.NoError(t, err)
+	if presetAuth != "" {
+		req.Header.Set("Authorization", presetAuth)
+	}
+	return httpClient.Do(req)
+}
+
 func TestAuthTokenAttachedAsBearer(t *testing.T) {
 	var gotAuth string
 	srv := captureAuthServer(t, &gotAuth)
 	setTokenForTest(t, "tok-abc123")
 
-	var out map[string]any
-	require.NoError(t, doGetInto(srv.URL, "/api/status", &out))
+	resp, err := sendThroughTransport(t, srv.URL+"/api/status", "")
+	require.NoError(t, err)
+	_ = resp.Body.Close()
 	assert.Equal(t, "Bearer tok-abc123", gotAuth)
 }
 
@@ -46,8 +61,9 @@ func TestNoAuthTokenSendsNoHeader(t *testing.T) {
 	srv := captureAuthServer(t, &gotAuth)
 	setTokenForTest(t, "")
 
-	var out map[string]any
-	require.NoError(t, doGetInto(srv.URL, "/api/status", &out))
+	resp, err := sendThroughTransport(t, srv.URL+"/api/status", "")
+	require.NoError(t, err)
+	_ = resp.Body.Close()
 	assert.Empty(t, gotAuth)
 }
 
@@ -56,18 +72,21 @@ func TestAuthTokenTrimmed(t *testing.T) {
 	srv := captureAuthServer(t, &gotAuth)
 	setTokenForTest(t, "  tok-padded\n")
 
-	var out map[string]any
-	require.NoError(t, doPostInto(srv.URL, "/api/plan", map[string]string{}, &out))
+	resp, err := sendThroughTransport(t, srv.URL+"/api/status", "")
+	require.NoError(t, err)
+	_ = resp.Body.Close()
 	assert.Equal(t, "Bearer tok-padded", gotAuth)
 }
 
-func TestAuthTokenRefusedOverInsecureRemote(t *testing.T) {
+func TestExistingAuthorizationHeaderPreserved(t *testing.T) {
+	var gotAuth string
+	srv := captureAuthServer(t, &gotAuth)
 	setTokenForTest(t, "tok-abc123")
 
-	var out map[string]any
-	err := doGetInto("http://schemabot.example.com", "/api/status", &out)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "insecure connection")
+	resp, err := sendThroughTransport(t, srv.URL+"/api/status", "Basic dXNlcjpwYXNz")
+	require.NoError(t, err)
+	_ = resp.Body.Close()
+	assert.Equal(t, "Basic dXNlcjpwYXNz", gotAuth)
 }
 
 func TestAuthTokenAllowedOverLoopbackHTTP(t *testing.T) {
@@ -77,20 +96,29 @@ func TestAuthTokenAllowedOverLoopbackHTTP(t *testing.T) {
 	srv := captureAuthServer(t, &gotAuth)
 	setTokenForTest(t, "tok-local")
 
-	var out map[string]any
-	require.NoError(t, doGetInto(srv.URL, "/api/status", &out))
+	resp, err := sendThroughTransport(t, srv.URL+"/api/status", "")
+	require.NoError(t, err)
+	_ = resp.Body.Close()
 	assert.Equal(t, "Bearer tok-local", gotAuth)
+}
+
+func TestAuthTokenRefusedOverInsecureRemote(t *testing.T) {
+	setTokenForTest(t, "tok-abc123")
+
+	var out map[string]any
+	err := doGetIntoCtx(t.Context(), "http://schemabot.example.com", "/api/status", &out)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInsecureTokenTransport)
 }
 
 func TestNoTokenAllowedOverInsecureRemote(t *testing.T) {
 	// Without a token there is nothing to leak, so the insecure-transport guard
-	// must not block ordinary unauthenticated requests.
+	// must not block ordinary unauthenticated requests: the request proceeds
+	// past the guard and fails on connection, not on the token guard.
 	setTokenForTest(t, "")
 
 	var out map[string]any
-	err := doGetInto("http://schemabot.example.com", "/api/status", &out)
-	// The request proceeds past the guard and fails on connection, not on the
-	// token guard.
+	err := doGetIntoCtx(t.Context(), "http://schemabot.example.com", "/api/status", &out)
 	require.Error(t, err)
-	assert.NotContains(t, err.Error(), "insecure connection")
+	assert.NotErrorIs(t, err, ErrInsecureTokenTransport)
 }

--- a/pkg/cmd/client/request_test.go
+++ b/pkg/cmd/client/request_test.go
@@ -1,0 +1,62 @@
+package client
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// captureAuthServer returns a test server that records the Authorization header
+// of the request it receives and replies with an empty JSON object.
+func captureAuthServer(t *testing.T, gotAuth *string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		*gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// setTokenForTest sets the shared auth token and restores it after the test so
+// the package-level transport state does not leak between tests.
+func setTokenForTest(t *testing.T, token string) {
+	t.Helper()
+	prev := authTransport.token
+	t.Cleanup(func() { authTransport.token = prev })
+	SetAuthToken(token)
+}
+
+func TestAuthTokenAttachedAsBearer(t *testing.T) {
+	var gotAuth string
+	srv := captureAuthServer(t, &gotAuth)
+	setTokenForTest(t, "tok-abc123")
+
+	var out map[string]any
+	require.NoError(t, doGetInto(srv.URL, "/api/status", &out))
+	assert.Equal(t, "Bearer tok-abc123", gotAuth)
+}
+
+func TestNoAuthTokenSendsNoHeader(t *testing.T) {
+	var gotAuth string
+	srv := captureAuthServer(t, &gotAuth)
+	setTokenForTest(t, "")
+
+	var out map[string]any
+	require.NoError(t, doGetInto(srv.URL, "/api/status", &out))
+	assert.Empty(t, gotAuth)
+}
+
+func TestAuthTokenTrimmed(t *testing.T) {
+	var gotAuth string
+	srv := captureAuthServer(t, &gotAuth)
+	setTokenForTest(t, "  tok-padded\n")
+
+	var out map[string]any
+	require.NoError(t, doPostInto(srv.URL, "/api/plan", map[string]string{}, &out))
+	assert.Equal(t, "Bearer tok-padded", gotAuth)
+}

--- a/pkg/cmd/commands/common.go
+++ b/pkg/cmd/commands/common.go
@@ -24,6 +24,7 @@ import (
 type Globals struct {
 	Endpoint string `help:"SchemaBot API endpoint (overrides profile)"`
 	Profile  string `help:"Configuration profile"`
+	Token    string `help:"Bearer token for authenticating to an auth-enabled server (or set SCHEMABOT_TOKEN)"`
 
 	// Build info (set by main.go from ldflags)
 	Version string `kong:"-"`

--- a/pkg/cmd/main.go
+++ b/pkg/cmd/main.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/alecthomas/kong"
 
+	"github.com/block/schemabot/pkg/cmd/client"
 	"github.com/block/schemabot/pkg/cmd/commands"
 )
 
@@ -60,6 +61,10 @@ func main() {
 	cli.Version = version
 	cli.Commit = commit
 	cli.Date = date
+
+	// Authenticate every API request with the resolved Bearer token. Empty when
+	// no token is configured, which is correct against a server with auth off.
+	client.SetAuthToken(client.ResolveToken(cli.Token))
 
 	err := ctx.Run(&cli.Globals)
 	if err != nil {


### PR DESCRIPTION
## Why this matters

Once a server enables OIDC auth, the CLI must present a token or every API call gets a 401. CI jobs and scripted/break-glass paths need a non-interactive way to authenticate before the interactive login flow exists.

## What it does

Adds a `--token` flag (and `SCHEMABOT_TOKEN` env fallback, flag taking precedence) and attaches `Authorization: Bearer <token>` to every CLI API request.

- Injected by a single `RoundTripper` on the shared HTTP client, so all requests are authenticated uniformly — no need to thread the token through each call site, and it covers requests built outside the shared helpers.
- Does not overwrite an `Authorization` header that is already set, and trims surrounding whitespace so a token from an env var or file does not break the header.
- An empty token leaves requests unauthenticated, which is correct against a server with auth disabled — so this is a **no-op until an operator opts in**.

## How it moves toward the northstar

This is the CI / non-interactive leg of client auth. The interactive `schemabot login` (auth-code + PKCE) builds on the same token plumbing next, and a full CLI-to-server auth integration test follows once both are in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)