### PR TITLE
feat(inventory): awssm username templates and plain-password secrets

### DIFF
--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -455,7 +455,9 @@ type EtreCredentialsConfig struct {
 	// Username is the database user. For secret_ref it is a literal username. For
 	// awssm it is optional: when set, it is a template (over {target} and
 	// {attribute} placeholders, e.g. "{app}_ddl") and the fetched secret is treated
-	// as the plain-text password instead of a JSON payload.
+	// as the plain-text password instead of a JSON payload. For awssm it is mutually
+	// exclusive with token-decoding engines (e.g. vitess), which interpret the
+	// secret themselves.
 	// PasswordRef (secret_ref) is a password secret reference (env:, file:,
 	// secretsmanager:, or a literal), optionally carrying a {target} placeholder.
 	Username    string `yaml:"username,omitempty"`

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -452,21 +452,26 @@ type EtreCredentialsConfig struct {
 	// Type selects the credential backend: "secret_ref" (default) or "awssm".
 	Type string `yaml:"type,omitempty"`
 
-	// secret_ref backend: a configured username plus a password secret reference
-	// (env:, file:, secretsmanager:, or a literal), optionally carrying a
-	// {target} placeholder for per-target secret naming.
+	// Username is the database user. For secret_ref it is a literal username. For
+	// awssm it is optional: when set, it is a template (over {target} and
+	// {attribute} placeholders, e.g. "{app}_ddl") and the fetched secret is treated
+	// as the plain-text password instead of a JSON payload.
+	// PasswordRef (secret_ref) is a password secret reference (env:, file:,
+	// secretsmanager:, or a literal), optionally carrying a {target} placeholder.
 	Username    string `yaml:"username,omitempty"`
 	PasswordRef string `yaml:"password_ref,omitempty"`
 
-	// awssm backend: read a secret from AWS Secrets Manager and parse it as a JSON
-	// {username, password} payload (or, for engines like Vitess, a token decoded
-	// by the assembler). SecretName may carry {target} and {attribute} placeholders
-	// to locate per-target or per-cluster secrets. RoleARN is optional: when set,
-	// the backend assumes a per-target role (carrying an {account} placeholder) so
-	// one data plane can read secrets across accounts, and AccountAttribute names
-	// the entity attribute holding the target's AWS account id (defaults to
-	// aws_account_id); when empty, secrets are read from the caller's own account.
-	// ExternalID is an optional STS external id used only with RoleARN.
+	// awssm backend: read a secret from AWS Secrets Manager. By default it is parsed
+	// as a JSON {username, password} payload (or, for engines like Vitess, a token
+	// decoded by the assembler); set Username to instead derive the user from entity
+	// attributes and treat the secret as a plain-text password. SecretName may carry
+	// {target} and {attribute} placeholders to locate per-target or per-cluster
+	// secrets. RoleARN is optional: when set, the backend assumes a per-target role
+	// (carrying an {account} placeholder) so one data plane can read secrets across
+	// accounts, and AccountAttribute names the entity attribute holding the target's
+	// AWS account id (defaults to aws_account_id); when empty, secrets are read from
+	// the caller's own account. ExternalID is an optional STS external id used only
+	// with RoleARN.
 	Region           string `yaml:"region,omitempty"`
 	RoleARN          string `yaml:"role_arn,omitempty"`
 	ExternalID       string `yaml:"external_id,omitempty"`

--- a/pkg/awscreds/awscreds.go
+++ b/pkg/awscreds/awscreds.go
@@ -196,15 +196,19 @@ func (r *Resolver) ResolveCredentials(ctx context.Context, req inventory.Request
 		return creds, nil
 	}
 
-	// Username template mode: the secret is the plain-text password.
+	// Username template mode: the secret is the plain-text password. Trim
+	// surrounding whitespace, which a stored password rarely intends but a secret
+	// pasted or uploaded from a file commonly carries (a trailing newline), so the
+	// failure mode is a clear config error here rather than an opaque auth failure.
 	if r.usernameTmpl != "" {
 		if username == "" {
 			return nil, fmt.Errorf("username template %q for %s resolved to an empty username", r.usernameTmpl, where)
 		}
-		if raw == "" {
+		password := strings.TrimSpace(raw)
+		if password == "" {
 			return nil, fmt.Errorf("secret %q for %s is empty (expected a password)", secretName, where)
 		}
-		return &inventory.Credentials{Username: username, Password: raw}, nil
+		return &inventory.Credentials{Username: username, Password: password}, nil
 	}
 
 	var parsed struct {

--- a/pkg/awscreds/awscreds.go
+++ b/pkg/awscreds/awscreds.go
@@ -4,10 +4,14 @@
 // the resolved target and its entity attributes, so one configuration can locate
 // per-target or per-cluster secrets. By default it reads from the caller's own
 // AWS account; when a role ARN is configured it assumes a per-target role first,
-// so a single data plane can read secrets across many AWS accounts. The fetched
-// secret is parsed as a JSON {username, password} payload, or interpreted by a
-// configured decoder (for example a PlanetScale token). Credential values come
-// from Secrets Manager, never from the inventory source.
+// so a single data plane can read secrets across many AWS accounts.
+//
+// The fetched secret is interpreted in one of three ways: by a configured decoder
+// (for example a PlanetScale token); as a JSON {username, password} payload (the
+// default); or, when a username template is configured, as a plain-text password
+// with the username rendered from the template — for conventions that derive the
+// username from entity attributes and store only the password. Credential values
+// come from Secrets Manager, never from the inventory source.
 package awscreds
 
 import (
@@ -30,10 +34,10 @@ import (
 // account id when one is not configured.
 const defaultAccountAttribute = "aws_account_id"
 
-// secretNamePlaceholderRe matches "{name}" placeholders in a secret name
-// template. "{target}" is the request target; any other name is an entity
-// attribute resolved for the target.
-var secretNamePlaceholderRe = regexp.MustCompile(`\{([a-zA-Z0-9_]+)\}`)
+// templatePlaceholderRe matches "{name}" placeholders in a template. "{target}"
+// is the request target; any other name is an entity attribute resolved for the
+// target.
+var templatePlaceholderRe = regexp.MustCompile(`\{([a-zA-Z0-9_]+)\}`)
 
 // Config configures a Resolver.
 type Config struct {
@@ -60,9 +64,15 @@ type Config struct {
 	// AccountAttribute is the endpoint attribute holding the target's AWS account
 	// id. Defaults to "aws_account_id". Only required when RoleARN is set.
 	AccountAttribute string
+	// Username, when set, is a template (over "{target}" and "{attribute}"
+	// placeholders) that renders the database username, and the fetched secret is
+	// treated as the plain-text password rather than a JSON payload. Use this for
+	// conventions that derive the username from entity attributes (e.g.
+	// "{app}_ddl") and store only the password. Mutually exclusive with Decode.
+	Username string
 	// Decode, when set, interprets the fetched secret into Credentials (for
-	// example a PlanetScale token). When nil the secret is parsed as a JSON
-	// {username, password} payload.
+	// example a PlanetScale token). When nil (and no Username template is set) the
+	// secret is parsed as a JSON {username, password} payload.
 	Decode inventory.SecretDecoder
 }
 
@@ -71,6 +81,7 @@ type Config struct {
 type Resolver struct {
 	accountAttr    string
 	secretName     string
+	usernameTmpl   string
 	fetch          secretFetcher
 	decode         inventory.SecretDecoder
 	requireAccount bool
@@ -92,6 +103,8 @@ func New(cfg Config) (*Resolver, error) {
 		return nil, fmt.Errorf("region is required")
 	case cfg.SecretName == "":
 		return nil, fmt.Errorf("secret name is required")
+	case cfg.Username != "" && cfg.Decode != nil:
+		return nil, fmt.Errorf("username template and decode are mutually exclusive")
 	}
 	accountAttr := cfg.AccountAttribute
 	if accountAttr == "" {
@@ -105,7 +118,7 @@ func New(cfg Config) (*Resolver, error) {
 		regionalCfg := cfg.AWSConfig
 		regionalCfg.Region = cfg.Region
 		fetch := &ownAccountFetcher{client: secretsmanager.NewFromConfig(regionalCfg)}
-		return newResolver(accountAttr, cfg.SecretName, fetch, cfg.Decode, false), nil
+		return newResolver(accountAttr, cfg.SecretName, cfg.Username, fetch, cfg.Decode, false), nil
 	}
 
 	fetch := &assumeRoleFetcher{
@@ -115,21 +128,28 @@ func New(cfg Config) (*Resolver, error) {
 		externalID: cfg.ExternalID,
 		clients:    make(map[string]*secretsmanager.Client),
 	}
-	return newResolver(accountAttr, cfg.SecretName, fetch, cfg.Decode, true), nil
+	return newResolver(accountAttr, cfg.SecretName, cfg.Username, fetch, cfg.Decode, true), nil
 }
 
 // newResolver constructs a Resolver over a given fetcher, so tests can inject a
 // fake that does not call AWS.
-func newResolver(accountAttr, secretName string, fetch secretFetcher, decode inventory.SecretDecoder, requireAccount bool) *Resolver {
-	return &Resolver{accountAttr: accountAttr, secretName: secretName, fetch: fetch, decode: decode, requireAccount: requireAccount}
+func newResolver(accountAttr, secretName, usernameTmpl string, fetch secretFetcher, decode inventory.SecretDecoder, requireAccount bool) *Resolver {
+	return &Resolver{
+		accountAttr:    accountAttr,
+		secretName:     secretName,
+		usernameTmpl:   usernameTmpl,
+		fetch:          fetch,
+		decode:         decode,
+		requireAccount: requireAccount,
+	}
 }
 
-// SecretNameAttributes returns the entity attribute names referenced by a secret
-// name template — every "{placeholder}" except "{target}" — so callers can
-// ensure the resolver surfaces them.
-func SecretNameAttributes(template string) []string {
+// TemplateAttributes returns the entity attribute names referenced by a template
+// — every "{placeholder}" except "{target}" — so callers can ensure the resolver
+// surfaces them.
+func TemplateAttributes(template string) []string {
 	var attrs []string
-	for _, m := range secretNamePlaceholderRe.FindAllStringSubmatch(template, -1) {
+	for _, m := range templatePlaceholderRe.FindAllStringSubmatch(template, -1) {
 		if m[1] != "target" {
 			attrs = append(attrs, m[1])
 		}
@@ -137,21 +157,31 @@ func SecretNameAttributes(template string) []string {
 	return attrs
 }
 
-// ResolveCredentials fetches the secret for the target and parses it as a JSON
-// {username, password} payload (or via the configured decoder). It fails closed:
-// a missing required account attribute, an unresolved secret-name placeholder, a
-// fetch failure, an unparseable secret, or a missing username/password are all
-// errors.
+// ResolveCredentials fetches the secret for the target and interprets it via the
+// configured decoder, a username template (plain-text password), or a JSON
+// {username, password} payload. It fails closed: a missing required account
+// attribute, an unresolved template placeholder, a fetch failure, an unparseable
+// secret, or a missing username/password are all errors.
 func (r *Resolver) ResolveCredentials(ctx context.Context, req inventory.Request, attrs map[string]string) (*inventory.Credentials, error) {
 	accountID := attrs[r.accountAttr]
 	if r.requireAccount && accountID == "" {
 		return nil, fmt.Errorf("target %q has no %q attribute for assume-role credential resolution", req.Target, r.accountAttr)
 	}
 
-	secretName, err := r.renderSecretName(req, attrs)
+	secretName, err := renderTemplate("secret name", r.secretName, req.Target, attrs)
 	if err != nil {
 		return nil, err
 	}
+	// Render the username template up front so a misconfiguration fails before the
+	// fetch rather than after it.
+	var username string
+	if r.usernameTmpl != "" {
+		username, err = renderTemplate("username", r.usernameTmpl, req.Target, attrs)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	where := targetContext(req.Target, accountID)
 	raw, err := r.fetch.FetchSecret(ctx, accountID, secretName)
 	if err != nil {
@@ -164,6 +194,17 @@ func (r *Resolver) ResolveCredentials(ctx context.Context, req inventory.Request
 			return nil, fmt.Errorf("decode secret %q for %s: %w", secretName, where, err)
 		}
 		return creds, nil
+	}
+
+	// Username template mode: the secret is the plain-text password.
+	if r.usernameTmpl != "" {
+		if username == "" {
+			return nil, fmt.Errorf("username template %q for %s resolved to an empty username", r.usernameTmpl, where)
+		}
+		if raw == "" {
+			return nil, fmt.Errorf("secret %q for %s is empty (expected a password)", secretName, where)
+		}
+		return &inventory.Credentials{Username: username, Password: raw}, nil
 	}
 
 	var parsed struct {
@@ -189,15 +230,15 @@ func targetContext(target, accountID string) string {
 	return fmt.Sprintf("target %q", target)
 }
 
-// renderSecretName replaces "{target}" with the request target and every other
+// renderTemplate replaces "{target}" with the request target and every other
 // "{attribute}" placeholder with the resolved attribute value, failing closed if
-// any referenced attribute was not resolved.
-func (r *Resolver) renderSecretName(req inventory.Request, attrs map[string]string) (string, error) {
+// any referenced attribute was not resolved. what labels the template in errors.
+func renderTemplate(what, tmpl, target string, attrs map[string]string) (string, error) {
 	var missing []string
-	rendered := secretNamePlaceholderRe.ReplaceAllStringFunc(r.secretName, func(match string) string {
+	rendered := templatePlaceholderRe.ReplaceAllStringFunc(tmpl, func(match string) string {
 		key := match[1 : len(match)-1]
 		if key == "target" {
-			return req.Target
+			return target
 		}
 		if v := attrs[key]; v != "" {
 			return v
@@ -206,7 +247,7 @@ func (r *Resolver) renderSecretName(req inventory.Request, attrs map[string]stri
 		return match
 	})
 	if len(missing) > 0 {
-		return "", fmt.Errorf("secret name template %q for target %q references unresolved attribute(s): %s", r.secretName, req.Target, strings.Join(missing, ", "))
+		return "", fmt.Errorf("%s template %q for target %q references unresolved attribute(s): %s", what, tmpl, target, strings.Join(missing, ", "))
 	}
 	return rendered, nil
 }

--- a/pkg/awscreds/awscreds_test.go
+++ b/pkg/awscreds/awscreds_test.go
@@ -28,7 +28,7 @@ func (f *fakeFetcher) FetchSecret(_ context.Context, accountID, secretName strin
 
 func TestResolverReadsJSONSecretForTargetAccount(t *testing.T) {
 	fetch := &fakeFetcher{payload: `{"username":"spirit","password":"s3cret"}`}
-	r := newResolver("aws_account_id", "ods-rds-spirit-password", fetch, nil, true)
+	r := newResolver("aws_account_id", "ods-rds-spirit-password", "", fetch, nil, true)
 
 	creds, err := r.ResolveCredentials(t.Context(),
 		inventory.Request{Target: "orders-dsid"},
@@ -44,7 +44,7 @@ func TestResolverReadsJSONSecretForTargetAccount(t *testing.T) {
 // The secret name may carry a {target} placeholder for per-target secrets.
 func TestResolverTemplatesSecretNameByTarget(t *testing.T) {
 	fetch := &fakeFetcher{payload: `{"username":"ddl","password":"pw"}`}
-	r := newResolver("aws_account_id", "schemabot/{target}/ddl", fetch, nil, true)
+	r := newResolver("aws_account_id", "schemabot/{target}/ddl", "", fetch, nil, true)
 
 	_, err := r.ResolveCredentials(t.Context(),
 		inventory.Request{Target: "orders-dsid"},
@@ -54,7 +54,7 @@ func TestResolverTemplatesSecretNameByTarget(t *testing.T) {
 }
 
 func TestResolverFailsWhenAccountAttributeMissing(t *testing.T) {
-	r := newResolver("aws_account_id", "secret", &fakeFetcher{payload: `{"username":"u","password":"p"}`}, nil, true)
+	r := newResolver("aws_account_id", "secret", "", &fakeFetcher{payload: `{"username":"u","password":"p"}`}, nil, true)
 
 	_, err := r.ResolveCredentials(t.Context(), inventory.Request{Target: "orders-dsid"}, nil)
 	require.Error(t, err)
@@ -62,7 +62,7 @@ func TestResolverFailsWhenAccountAttributeMissing(t *testing.T) {
 }
 
 func TestResolverPropagatesFetchError(t *testing.T) {
-	r := newResolver("aws_account_id", "secret", &fakeFetcher{err: fmt.Errorf("access denied")}, nil, true)
+	r := newResolver("aws_account_id", "secret", "", &fakeFetcher{err: fmt.Errorf("access denied")}, nil, true)
 
 	_, err := r.ResolveCredentials(t.Context(),
 		inventory.Request{Target: "orders-dsid"},
@@ -72,7 +72,7 @@ func TestResolverPropagatesFetchError(t *testing.T) {
 }
 
 func TestResolverFailsOnNonJSONSecret(t *testing.T) {
-	r := newResolver("aws_account_id", "secret", &fakeFetcher{payload: "not-json"}, nil, true)
+	r := newResolver("aws_account_id", "secret", "", &fakeFetcher{payload: "not-json"}, nil, true)
 
 	_, err := r.ResolveCredentials(t.Context(),
 		inventory.Request{Target: "orders-dsid"},
@@ -82,7 +82,7 @@ func TestResolverFailsOnNonJSONSecret(t *testing.T) {
 }
 
 func TestResolverFailsOnIncompleteSecret(t *testing.T) {
-	r := newResolver("aws_account_id", "secret", &fakeFetcher{payload: `{"username":"spirit"}`}, nil, true)
+	r := newResolver("aws_account_id", "secret", "", &fakeFetcher{payload: `{"username":"spirit"}`}, nil, true)
 
 	_, err := r.ResolveCredentials(t.Context(),
 		inventory.Request{Target: "orders-dsid"},
@@ -96,7 +96,7 @@ func TestResolverFailsOnIncompleteSecret(t *testing.T) {
 // PlanetScale token read through the same assume-role path.
 func TestResolverUsesDecoder(t *testing.T) {
 	fetch := &fakeFetcher{payload: `{"token":"tok-id=tok-secret"}`}
-	r := newResolver("aws_account_id", "secret", fetch, inventory.DecodePlanetScaleSecret, true)
+	r := newResolver("aws_account_id", "secret", "", fetch, inventory.DecodePlanetScaleSecret, true)
 
 	creds, err := r.ResolveCredentials(t.Context(),
 		inventory.Request{Target: "orders-dsid"},
@@ -111,7 +111,7 @@ func TestResolverUsesDecoder(t *testing.T) {
 // secret naming, not just the target.
 func TestResolverTemplatesSecretNameByAttribute(t *testing.T) {
 	fetch := &fakeFetcher{payload: `{"username":"ddl","password":"pw"}`}
-	r := newResolver("aws_account_id", "{cluster}_schemabot_password", fetch, nil, true)
+	r := newResolver("aws_account_id", "{cluster}_schemabot_password", "", fetch, nil, true)
 
 	_, err := r.ResolveCredentials(t.Context(),
 		inventory.Request{Target: "orders-dsid"},
@@ -123,7 +123,7 @@ func TestResolverTemplatesSecretNameByAttribute(t *testing.T) {
 // A secret-name placeholder that the resolver did not surface fails closed
 // rather than fetching a wrong (partially templated) secret name.
 func TestResolverFailsOnUnresolvedSecretNameAttribute(t *testing.T) {
-	r := newResolver("aws_account_id", "{cluster}_password", &fakeFetcher{payload: `{"username":"u","password":"p"}`}, nil, true)
+	r := newResolver("aws_account_id", "{cluster}_password", "", &fakeFetcher{payload: `{"username":"u","password":"p"}`}, nil, true)
 
 	_, err := r.ResolveCredentials(t.Context(),
 		inventory.Request{Target: "orders-dsid"},
@@ -136,7 +136,7 @@ func TestResolverFailsOnUnresolvedSecretNameAttribute(t *testing.T) {
 // requires nor uses the account attribute.
 func TestResolverOwnAccountModeSkipsAccountRequirement(t *testing.T) {
 	fetch := &fakeFetcher{payload: `{"username":"ddl","password":"pw"}`}
-	r := newResolver("aws_account_id", "schemabot_password", fetch, nil, false)
+	r := newResolver("aws_account_id", "schemabot_password", "", fetch, nil, false)
 
 	creds, err := r.ResolveCredentials(t.Context(), inventory.Request{Target: "orders-dsid"}, nil)
 	require.NoError(t, err)
@@ -145,23 +145,67 @@ func TestResolverOwnAccountModeSkipsAccountRequirement(t *testing.T) {
 	assert.Equal(t, "ddl", creds.Username)
 }
 
-func TestSecretNameAttributes(t *testing.T) {
-	assert.Equal(t, []string{"cluster"}, SecretNameAttributes("{cluster}_{target}_password"))
-	assert.Empty(t, SecretNameAttributes("schemabot/{target}/ddl"))
-	assert.Empty(t, SecretNameAttributes("static-secret"))
+func TestTemplateAttributes(t *testing.T) {
+	assert.Equal(t, []string{"cluster"}, TemplateAttributes("{cluster}_{target}_password"))
+	assert.Equal(t, []string{"app"}, TemplateAttributes("{app}_ddl"))
+	assert.Empty(t, TemplateAttributes("schemabot/{target}/ddl"))
+	assert.Empty(t, TemplateAttributes("static-secret"))
+}
+
+// CAKE-style credentials derive the username from an entity attribute and store
+// only the password as a plain-text secret.
+func TestResolverUsernameTemplateWithPlainPassword(t *testing.T) {
+	fetch := &fakeFetcher{payload: "s3cret-pw"}
+	r := newResolver("aws_account_id", "{name}_ddl_password", "{app}_ddl", fetch, nil, false)
+
+	creds, err := r.ResolveCredentials(t.Context(),
+		inventory.Request{Target: "orders-dsid"},
+		map[string]string{"app": "orders", "name": "orders-mysql"})
+	require.NoError(t, err)
+	assert.Equal(t, "orders-mysql_ddl_password", fetch.gotSecret)
+	assert.Equal(t, "orders_ddl", creds.Username)
+	assert.Equal(t, "s3cret-pw", creds.Password)
+}
+
+// A username template referencing an attribute the resolver did not surface
+// fails closed rather than producing a partial username.
+func TestResolverFailsOnUnresolvedUsernameAttribute(t *testing.T) {
+	r := newResolver("aws_account_id", "secret", "{app}_ddl", &fakeFetcher{payload: "pw"}, nil, false)
+
+	_, err := r.ResolveCredentials(t.Context(), inventory.Request{Target: "orders-dsid"}, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "app")
+}
+
+// In username-template mode an empty secret is a missing password, not a valid
+// credential.
+func TestResolverUsernameTemplateRejectsEmptyPassword(t *testing.T) {
+	r := newResolver("aws_account_id", "secret", "{app}_ddl", &fakeFetcher{payload: ""}, nil, false)
+
+	_, err := r.ResolveCredentials(t.Context(),
+		inventory.Request{Target: "orders-dsid"},
+		map[string]string{"app": "orders"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "password")
+}
+
+func TestNewRejectsUsernameWithDecode(t *testing.T) {
+	_, err := New(Config{Region: "us-west-2", SecretName: "secret", Username: "{app}_ddl", Decode: inventory.DecodePlanetScaleSecret})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mutually exclusive")
 }
 
 // Assume-role failures carry the target AWS account id so cross-account
 // problems stay diagnosable; own-account mode has no account to report.
 func TestResolverFetchErrorIncludesAccountInAssumeRoleMode(t *testing.T) {
-	assumeRole := newResolver("aws_account_id", "secret", &fakeFetcher{err: fmt.Errorf("access denied")}, nil, true)
+	assumeRole := newResolver("aws_account_id", "secret", "", &fakeFetcher{err: fmt.Errorf("access denied")}, nil, true)
 	_, err := assumeRole.ResolveCredentials(t.Context(),
 		inventory.Request{Target: "orders-dsid"},
 		map[string]string{"aws_account_id": "123456789012"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "123456789012")
 
-	ownAccount := newResolver("aws_account_id", "secret", &fakeFetcher{err: fmt.Errorf("access denied")}, nil, false)
+	ownAccount := newResolver("aws_account_id", "secret", "", &fakeFetcher{err: fmt.Errorf("access denied")}, nil, false)
 	_, err = ownAccount.ResolveCredentials(t.Context(), inventory.Request{Target: "orders-dsid"}, nil)
 	require.Error(t, err)
 	assert.NotContains(t, err.Error(), "in account")

--- a/pkg/awscreds/awscreds_test.go
+++ b/pkg/awscreds/awscreds_test.go
@@ -152,10 +152,11 @@ func TestTemplateAttributes(t *testing.T) {
 	assert.Empty(t, TemplateAttributes("static-secret"))
 }
 
-// CAKE-style credentials derive the username from an entity attribute and store
-// only the password as a plain-text secret.
+// Some conventions derive the username from an entity attribute and store only
+// the password as a plain-text secret rather than a JSON payload.
 func TestResolverUsernameTemplateWithPlainPassword(t *testing.T) {
-	fetch := &fakeFetcher{payload: "s3cret-pw"}
+	// A trailing newline (common in file-uploaded secrets) is trimmed.
+	fetch := &fakeFetcher{payload: "s3cret-pw\n"}
 	r := newResolver("aws_account_id", "{name}_ddl_password", "{app}_ddl", fetch, nil, false)
 
 	creds, err := r.ResolveCredentials(t.Context(),

--- a/pkg/cmd/commands/serve.go
+++ b/pkg/cmd/commands/serve.go
@@ -512,6 +512,7 @@ func buildCredentialResolver(ctx context.Context, cfg api.EtreCredentialsConfig,
 			ExternalID:       cfg.ExternalID,
 			SecretName:       cfg.SecretName,
 			AccountAttribute: cfg.AccountAttribute,
+			Username:         cfg.Username,
 			Decode:           decode,
 		})
 		if err != nil {
@@ -549,9 +550,12 @@ func resolverAttributeFields(cfg api.EtreConfig) []string {
 			}
 			fields = ensureField(fields, accountAttr)
 		}
-		// The secret name may template over resolved attributes; surface those so
-		// the resolver fetches them for the credential backend.
-		for _, attr := range awscreds.SecretNameAttributes(cfg.Credentials.SecretName) {
+		// The secret name and username may template over resolved attributes;
+		// surface those so the resolver fetches them for the credential backend.
+		for _, attr := range awscreds.TemplateAttributes(cfg.Credentials.SecretName) {
+			fields = ensureField(fields, attr)
+		}
+		for _, attr := range awscreds.TemplateAttributes(cfg.Credentials.Username) {
 			fields = ensureField(fields, attr)
 		}
 	}

--- a/pkg/cmd/commands/serve.go
+++ b/pkg/cmd/commands/serve.go
@@ -500,6 +500,8 @@ func buildCredentialResolver(ctx context.Context, cfg api.EtreCredentialsConfig,
 			return nil, fmt.Errorf("target_resolver.etre.credentials.region is required for the awssm backend")
 		case cfg.SecretName == "":
 			return nil, fmt.Errorf("target_resolver.etre.credentials.secret_name is required for the awssm backend")
+		case cfg.Username != "" && decode != nil:
+			return nil, fmt.Errorf("target_resolver.etre.credentials.username (plain-password secrets) cannot be combined with a token-decoding engine such as vitess")
 		}
 		awsCfg, err := awsconfig.LoadDefaultConfig(ctx)
 		if err != nil {

--- a/pkg/cmd/commands/serve_grpc_test.go
+++ b/pkg/cmd/commands/serve_grpc_test.go
@@ -134,6 +134,14 @@ func TestBuildCredentialResolverAWSSMRequiresFields(t *testing.T) {
 		require.Error(t, err, field)
 		assert.Contains(t, err.Error(), field)
 	}
+
+	// A username template (plain-password mode) combined with a token-decoding
+	// engine fails fast with a config-path error, before any AWS config loading.
+	withUsername := base
+	withUsername.Username = "{app}_ddl"
+	_, err = buildCredentialResolver(t.Context(), withUsername, inventory.DecodePlanetScaleSecret)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "username")
 }
 
 // The assume-role backend's account attribute is surfaced to the resolver even


### PR DESCRIPTION
## Why this matters

The `awssm` credential backend assumes every secret is a JSON `{username, password}` payload. Some conventions instead **derive the username from entity attributes** (e.g. `{app}_ddl`) and store **only the password** as a plain-text secret. Without backend support, an embedder with that convention would need a bespoke `inventory.CredentialResolver` — exactly the kind of glue the config-driven data plane is meant to avoid.

## What it does

- **Username template.** When `username` is set on the `awssm` backend, it is a template over `{target}` and `{attribute}` placeholders that renders the database user, and the fetched secret is treated as the **plain-text password** (not JSON). Mutually exclusive with a decoder.
- **Attribute surfacing.** The username template's attributes are surfaced to the resolver alongside the secret-name template's, so both are fetched from the inventory source; both **fail closed** on an unresolved placeholder.

Existing JSON `{username, password}` and decoder (token) modes are unchanged. The placeholder helper is generalized (`SecretNameAttributes` → `TemplateAttributes`) since it now applies to both templates.

## How it moves toward the northstar

Together with the own-account / attribute-templated secret-name support already on `main`, an embedder can drive **both** plain-password and JSON credential conventions entirely from `target_resolver.etre.credentials` config — no custom resolver code.

---
*Authored by Claude Code (Opus 4.8).*