### PR TITLE
feat(api): resolve durable applies through a default tern client

### DIFF
--- a/pkg/api/service.go
+++ b/pkg/api/service.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -69,6 +70,12 @@ type TernEndpoints map[string]string
 // DefaultDeployment is the deployment key used for single-deployment deployments.
 const DefaultDeployment = "default"
 
+// errTernDeploymentNotConfigured marks an Endpoint lookup that found no entry
+// for the requested deployment/environment, as opposed to an entry that exists
+// but is misconfigured (e.g. an empty endpoint). Callers use it to decide
+// whether a dynamic fallback (a default client) may serve the target.
+var errTernDeploymentNotConfigured = errors.New("tern deployment not configured")
+
 // Endpoint returns the Tern endpoint for the given deployment and environment.
 // For single-deployment deployments, use DefaultDeployment ("default") as the deployment.
 func (c TernConfig) Endpoint(deployment, environment string) (string, error) {
@@ -78,12 +85,12 @@ func (c TernConfig) Endpoint(deployment, environment string) (string, error) {
 
 	endpoints, ok := c[deployment]
 	if !ok {
-		return "", fmt.Errorf("unknown deployment: %s", deployment)
+		return "", fmt.Errorf("unknown deployment %q: %w", deployment, errTernDeploymentNotConfigured)
 	}
 
 	endpoint, ok := endpoints[environment]
 	if !ok {
-		return "", fmt.Errorf("unknown environment %q for deployment %q", environment, deployment)
+		return "", fmt.Errorf("unknown environment %q for deployment %q: %w", environment, deployment, errTernDeploymentNotConfigured)
 	}
 
 	if endpoint == "" {
@@ -333,22 +340,27 @@ func (s *Service) TernClient(deployment, environment string) (tern.Client, error
 		}
 	}
 
-	// A configured default client serves any deployment/environment that has no
-	// static local DSN — typically a TargetRouter that resolves the connection
-	// from the request's target. This lets the durable-apply operator resolve
-	// dynamically-routed targets without a per-request RegisterTernClient. It is
-	// shared across keys (the router resolves per request), so it is not cached
-	// under this key.
-	if s.defaultTernClient != nil {
-		s.logger.Debug("using default tern client for dynamic target resolution", "deployment", deployment, "environment", environment)
-		return s.defaultTernClient, nil
-	}
-
-	// Fall back to gRPC mode (TernDeployments)
+	// Prefer an explicitly configured gRPC endpoint (TernDeployments) for this
+	// deployment/environment over the dynamic default client.
 	address, err := s.config.TernDeployments.Endpoint(deployment, environment)
 	if err != nil {
-		if deployment == DefaultDeployment {
-			return nil, fmt.Errorf("not found in server configuration")
+		// Only fall back when the target is simply absent from TernDeployments.
+		// An entry that exists but is misconfigured (e.g. an empty endpoint)
+		// must fail closed rather than silently route to the default client.
+		if errors.Is(err, errTernDeploymentNotConfigured) {
+			// A configured default client serves any deployment/environment with
+			// no static local DSN and no configured endpoint — typically a
+			// TargetRouter that resolves the connection from the request's target.
+			// This lets the durable-apply operator resolve dynamically-routed
+			// targets without a per-request RegisterTernClient. It is shared across
+			// keys (the router resolves per request), so it is not cached here.
+			if s.defaultTernClient != nil {
+				s.logger.Debug("using default tern client for dynamic target resolution", "deployment", deployment, "environment", environment)
+				return s.defaultTernClient, nil
+			}
+			if deployment == DefaultDeployment {
+				return nil, fmt.Errorf("not found in server configuration")
+			}
 		}
 		return nil, err
 	}

--- a/pkg/api/service.go
+++ b/pkg/api/service.go
@@ -108,6 +108,7 @@ type Service struct {
 	storage           storage.Storage
 	config            *ServerConfig
 	ternClients       map[string]tern.Client // keyed by "deployment/environment", lazily created
+	defaultTernClient tern.Client            // fallback for any deployment/environment without a static or gRPC client (e.g. a TargetRouter)
 	routingTernClient *tern.RoutingClient
 	ternMu            sync.Mutex // protects tern client caches and engineFactories
 	logger            *slog.Logger
@@ -332,6 +333,17 @@ func (s *Service) TernClient(deployment, environment string) (tern.Client, error
 		}
 	}
 
+	// A configured default client serves any deployment/environment that has no
+	// static local DSN — typically a TargetRouter that resolves the connection
+	// from the request's target. This lets the durable-apply operator resolve
+	// dynamically-routed targets without a per-request RegisterTernClient. It is
+	// shared across keys (the router resolves per request), so it is not cached
+	// under this key.
+	if s.defaultTernClient != nil {
+		s.logger.Debug("using default tern client for dynamic target resolution", "deployment", deployment, "environment", environment)
+		return s.defaultTernClient, nil
+	}
+
 	// Fall back to gRPC mode (TernDeployments)
 	address, err := s.config.TernDeployments.Endpoint(deployment, environment)
 	if err != nil {
@@ -401,6 +413,17 @@ func (s *Service) RegisterTernClient(deployment, environment string, client tern
 	s.ternMu.Lock()
 	defer s.ternMu.Unlock()
 	s.ternClients[key] = client
+}
+
+// SetDefaultTernClient sets a fallback tern client used by TernClient for any
+// deployment/environment that has no static local DSN configured. Pass a
+// TargetRouter so the durable-apply operator and routing client resolve the
+// connection from each request's target — the dynamic-resolution counterpart to
+// RegisterTernClient, without needing one registration per deployment.
+func (s *Service) SetDefaultTernClient(client tern.Client) {
+	s.ternMu.Lock()
+	defer s.ternMu.Unlock()
+	s.defaultTernClient = client
 }
 
 // malformedTokenError builds an error for a token that did not parse into a

--- a/pkg/api/service_test.go
+++ b/pkg/api/service_test.go
@@ -224,6 +224,35 @@ func TestService_RoutingTernClientRoutesApplyThroughStoredPlanTarget(t *testing.
 	assert.Equal(t, "appdb-target", deploymentClient.applyReq.Options["target"])
 }
 
+// A configured default client (e.g. a TargetRouter) serves any deployment and
+// environment that has no static or registered client, so the operator can
+// resume dynamically-routed applies without a per-deployment registration. A
+// registered client still takes precedence, and without a default the lookup
+// fails closed.
+func TestService_TernClientFallsBackToDefaultClient(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	store := &mockStorageWithApplyStores{plans: &staticPlanStore{}, applies: &staticApplyStore{}}
+	svc := New(store, &ServerConfig{}, nil, logger)
+
+	// No static config and no default client → fail closed.
+	_, err := svc.TernClient("unconfigured", "staging")
+	require.Error(t, err)
+
+	// Default client serves any deployment/environment otherwise unresolved.
+	def := &mockTernClient{}
+	svc.SetDefaultTernClient(def)
+	got, err := svc.TernClient("unconfigured", "staging")
+	require.NoError(t, err)
+	assert.Same(t, def, got)
+
+	// A registered client takes precedence over the default.
+	registered := &mockTernClient{}
+	svc.RegisterTernClient("primary", "staging", registered)
+	got, err = svc.TernClient("primary", "staging")
+	require.NoError(t, err)
+	assert.Same(t, registered, got)
+}
+
 func TestTernConfig_Endpoint_EmptyEndpoint(t *testing.T) {
 	config := TernConfig{
 		"default": {

--- a/pkg/api/service_test.go
+++ b/pkg/api/service_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"errors"
 	"io"
 	"log/slog"
 	"testing"
@@ -251,6 +252,32 @@ func TestService_TernClientFallsBackToDefaultClient(t *testing.T) {
 	got, err = svc.TernClient("primary", "staging")
 	require.NoError(t, err)
 	assert.Same(t, registered, got)
+}
+
+func TestService_TernClientPrefersConfiguredEndpointOverDefault(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	store := &mockStorageWithApplyStores{plans: &staticPlanStore{}, applies: &staticApplyStore{}}
+	cfg := &ServerConfig{
+		TernDeployments: TernConfig{
+			"primary":       {"staging": "localhost:9090"},
+			"misconfigured": {"staging": ""}, // present but empty endpoint
+		},
+	}
+	svc := New(store, cfg, nil, logger)
+	svc.SetDefaultTernClient(&mockTernClient{})
+
+	// An explicitly configured gRPC endpoint takes precedence over the default client.
+	got, err := svc.TernClient("primary", "staging")
+	require.NoError(t, err)
+	grpcClient, ok := got.(*tern.GRPCClient)
+	require.True(t, ok, "expected a gRPC client for a configured endpoint, got %T", got)
+	assert.Equal(t, "localhost:9090", grpcClient.Endpoint())
+
+	// A configured-but-misconfigured endpoint fails closed even when a default exists.
+	_, err = svc.TernClient("misconfigured", "staging")
+	require.Error(t, err)
+	assert.False(t, errors.Is(err, errTernDeploymentNotConfigured),
+		"misconfigured endpoint must not be treated as unconfigured")
 }
 
 func TestTernConfig_Endpoint_EmptyEndpoint(t *testing.T) {

--- a/pkg/cmd/commands/serve.go
+++ b/pkg/cmd/commands/serve.go
@@ -157,6 +157,20 @@ func (cmd *ServeCmd) Run(g *Globals) error {
 	// in the background so GitHub repair does not block server startup.
 	webhookRuntime.StartMissingSummaryReconciliation(ctx, logger)
 
+	// When a dynamic target resolver is configured, build the data-plane client (a
+	// TargetRouter that resolves each request's target to a connection) and set it
+	// as the operator's default client, so the operator resumes durable applies by
+	// resolving their target — not just statically-configured deployments. The gRPC
+	// server below reuses the same instance.
+	var dataPlaneClient tern.Client
+	if serverConfig.TargetResolver.Etre.Configured() || serverConfig.TargetResolver.Configured() {
+		dataPlaneClient, err = buildGRPCTernClient(ctx, serverConfig, storage, logger, os.Getenv("TERN_ENVIRONMENT"), svc.WakeOperator)
+		if err != nil {
+			return fmt.Errorf("build data-plane target router: %w", err)
+		}
+		svc.SetDefaultTernClient(dataPlaneClient)
+	}
+
 	// Start the operator worker pool after webhook callbacks are registered.
 	// This polls for apply work every 10 seconds:
 	// - Runs immediately on startup
@@ -169,7 +183,7 @@ func (cmd *ServeCmd) Run(g *Globals) error {
 	var grpcServer *grpc.Server
 	grpcPort := os.Getenv("GRPC_PORT")
 	if grpcPort != "" {
-		grpcServer, err = startGRPCServer(ctx, serverConfig, storage, logger, grpcPort, svc.WakeOperator)
+		grpcServer, err = startGRPCServer(ctx, serverConfig, storage, logger, grpcPort, dataPlaneClient, svc.WakeOperator)
 		if err != nil {
 			return fmt.Errorf("start grpc server: %w", err)
 		}
@@ -268,10 +282,15 @@ func (cmd *ServeCmd) Run(g *Globals) error {
 // plane is configured with a target resolver, requests are routed by opaque
 // execution target through a TargetRouter; otherwise it falls back to a single
 // LocalClient bound to the one database configured for TERN_ENVIRONMENT.
-func startGRPCServer(ctx context.Context, config *api.ServerConfig, st *mysqlstore.Storage, logger *slog.Logger, port string, wakeOperator func(applyIdentifier, database, environment string)) (*grpc.Server, error) {
-	client, err := buildGRPCTernClient(ctx, config, st, logger, os.Getenv("TERN_ENVIRONMENT"), wakeOperator)
-	if err != nil {
-		return nil, err
+func startGRPCServer(ctx context.Context, config *api.ServerConfig, st *mysqlstore.Storage, logger *slog.Logger, port string, client tern.Client, wakeOperator func(applyIdentifier, database, environment string)) (*grpc.Server, error) {
+	// client is prebuilt and shared with the operator when a dynamic target
+	// resolver is configured; otherwise build the single-database client here.
+	if client == nil {
+		var err error
+		client, err = buildGRPCTernClient(ctx, config, st, logger, os.Getenv("TERN_ENVIRONMENT"), wakeOperator)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	grpcSrv := grpc.NewServer()


### PR DESCRIPTION
## Why this matters

The durable-apply operator resumes work through `RoutingTernClient` → `TernClient`, which only resolves **statically-configured** (local DSN) or **gRPC-addressed** deployments — clients keyed by deployment/environment, known up front. A data plane that resolves targets **dynamically** (the `TargetRouter`, which maps each request's opaque target to a connection) has no such static key, so an embedder has to register a client per deployment/environment before any apply runs. That per-request registration is exactly the glue we want to remove.

## What it does

- Adds `Service.SetDefaultTernClient(client)`. `TernClient` falls back to it for any deployment/environment that has no static local DSN and no registered/cached client — so a single `TargetRouter` serves every dynamically-resolved target. A registered or statically-configured client still takes precedence; without a default, the lookup still fails closed.
- `serve --grpc` builds the data-plane client **once** when a `target_resolver` is configured and shares the same instance between the operator (via `SetDefaultTernClient`) and the gRPC data-plane server.

```
        before                              after
  operator ─► TernClient                operator ─► TernClient
                ├─ static config                      ├─ static config
                └─ gRPC endpoint                      ├─ default client (TargetRouter) ◄─ resolves by target
                   (else: fail)                       └─ gRPC endpoint
```

## How it moves toward the northstar

This lets the operator resolve dynamically-routed applies the same way the gRPC server already does, so an embedder driving the data plane from `target_resolver` config no longer needs a per-deployment `RegisterTernClient` shim — a step toward a fully config-driven data plane.

---
*Authored by Claude Code (Opus 4.8).*