### PR TITLE
fix(github): retry transient PR discovery reads

### DIFF
--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -303,6 +303,40 @@ func newGitHubRateLimitTransport(base http.RoundTripper) http.RoundTripper {
 	)
 }
 
+const githubUnavailableReadRetryMaxAttempts = 3
+
+var githubUnavailableReadRetryDelay = 200 * time.Millisecond
+
+func retryGitHubUnavailableRead[T any](ctx context.Context, logger *slog.Logger, operation string, logAttrs []any, read func(context.Context) (T, error)) (T, error) {
+	var zero T
+	for attempt := 1; attempt <= githubUnavailableReadRetryMaxAttempts; attempt++ {
+		result, err := read(ctx)
+		if err == nil {
+			if attempt > 1 && logger != nil {
+				logger.Info("GitHub read succeeded after retry",
+					append(logAttrs, "operation", operation, "attempt", attempt)...)
+			}
+			return result, nil
+		}
+		if !IsUnavailableError(err) || attempt == githubUnavailableReadRetryMaxAttempts || ctx.Err() != nil {
+			return zero, err
+		}
+		delay := githubUnavailableReadRetryDelay * time.Duration(attempt)
+		if logger != nil {
+			logger.Warn("retrying unavailable GitHub read",
+				append(logAttrs, "operation", operation, "attempt", attempt, "max_attempts", githubUnavailableReadRetryMaxAttempts, "delay", delay, "error", err)...)
+		}
+		timer := time.NewTimer(delay)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return zero, fmt.Errorf("wait to retry GitHub read %s: %w", operation, ctx.Err())
+		case <-timer.C:
+		}
+	}
+	return zero, fmt.Errorf("retry GitHub read %s: exhausted attempts", operation)
+}
+
 // AppSlug returns the GitHub App slug associated with this installation
 // client, when known. It is best-effort: startup can proceed before the slug
 // is fetched, so callers should tolerate an empty string.
@@ -480,9 +514,15 @@ func (ic *InstallationClient) FetchPullRequestNoCache(ctx context.Context, repo 
 
 func (ic *InstallationClient) fetchPullRequest(ctx context.Context, repo string, pr int) (*PullRequestInfo, error) {
 	owner, repoName := splitRepo(repo)
-	ghPR, _, err := ic.client.PullRequests.Get(ctx, owner, repoName, pr)
+	ghPR, err := retryGitHubUnavailableRead(ctx, ic.logger, "fetch pull request", []any{"repo", repo, "pr", pr}, func(ctx context.Context) (*gh.PullRequest, error) {
+		ghPR, _, err := ic.client.PullRequests.Get(ctx, owner, repoName, pr)
+		if err != nil {
+			return nil, fmt.Errorf("fetch pull request %s#%d: %w", repo, pr, classifyGitHubAPIError(err))
+		}
+		return ghPR, nil
+	})
 	if err != nil {
-		return nil, fmt.Errorf("fetch pull request %s#%d: %w", repo, pr, classifyGitHubAPIError(err))
+		return nil, err
 	}
 	return &PullRequestInfo{
 		HeadRef: ghPR.GetHead().GetRef(),
@@ -512,11 +552,26 @@ func (ic *InstallationClient) FetchPRFiles(ctx context.Context, repo string, pr 
 	var allFiles []PRFile
 
 	for {
-		ghFiles, resp, err := ic.client.PullRequests.ListFiles(ctx, owner, repoName, pr, opts)
+		readResult, err := retryGitHubUnavailableRead(ctx, ic.logger, "list PR files", []any{"repo", repo, "pr", pr, "page", opts.Page}, func(ctx context.Context) (struct {
+			files []*gh.CommitFile
+			resp  *gh.Response
+		}, error) {
+			ghFiles, resp, err := ic.client.PullRequests.ListFiles(ctx, owner, repoName, pr, opts)
+			if err != nil {
+				return struct {
+					files []*gh.CommitFile
+					resp  *gh.Response
+				}{}, fmt.Errorf("list PR files: %w", classifyGitHubAPIError(err))
+			}
+			return struct {
+				files []*gh.CommitFile
+				resp  *gh.Response
+			}{files: ghFiles, resp: resp}, nil
+		})
 		if err != nil {
-			return nil, fmt.Errorf("list PR files: %w", classifyGitHubAPIError(err))
+			return nil, err
 		}
-		for _, f := range ghFiles {
+		for _, f := range readResult.files {
 			allFiles = append(allFiles, PRFile{
 				Filename: f.GetFilename(),
 				Status:   f.GetStatus(),
@@ -525,10 +580,10 @@ func (ic *InstallationClient) FetchPRFiles(ctx context.Context, repo string, pr 
 		if len(allFiles) >= maxGitHubPRFiles {
 			return nil, fmt.Errorf("list PR files for %s#%d reached GitHub API limit: %w", repo, pr, ErrPRFilesIncomplete)
 		}
-		if resp.NextPage == 0 {
+		if readResult.resp.NextPage == 0 {
 			break
 		}
-		opts.Page = resp.NextPage
+		opts.Page = readResult.resp.NextPage
 	}
 
 	return allFiles, nil
@@ -986,9 +1041,15 @@ type TreeEntry struct {
 // FetchGitTree fetches the entire directory tree in one API call using recursive mode.
 func (ic *InstallationClient) FetchGitTree(ctx context.Context, repo, treeSHA string) ([]TreeEntry, bool, error) {
 	owner, repoName := splitRepo(repo)
-	ghTree, _, err := ic.client.Git.GetTree(ctx, owner, repoName, treeSHA, true)
+	ghTree, err := retryGitHubUnavailableRead(ctx, ic.logger, "fetch git tree", []any{"repo", repo, "tree_sha", treeSHA}, func(ctx context.Context) (*gh.Tree, error) {
+		ghTree, _, err := ic.client.Git.GetTree(ctx, owner, repoName, treeSHA, true)
+		if err != nil {
+			return nil, fmt.Errorf("fetch git tree: %w", classifyGitHubAPIError(err))
+		}
+		return ghTree, nil
+	})
 	if err != nil {
-		return nil, false, fmt.Errorf("fetch git tree: %w", classifyGitHubAPIError(err))
+		return nil, false, err
 	}
 
 	entries := make([]TreeEntry, len(ghTree.Entries))
@@ -1007,9 +1068,15 @@ func (ic *InstallationClient) FetchGitTree(ctx context.Context, repo, treeSHA st
 // FetchBlobContent fetches file content using the Git Blob API.
 func (ic *InstallationClient) FetchBlobContent(ctx context.Context, repo, blobSHA string) (string, error) {
 	owner, repoName := splitRepo(repo)
-	blob, _, err := ic.client.Git.GetBlob(ctx, owner, repoName, blobSHA)
+	blob, err := retryGitHubUnavailableRead(ctx, ic.logger, "fetch blob", []any{"repo", repo, "blob_sha", blobSHA}, func(ctx context.Context) (*gh.Blob, error) {
+		blob, _, err := ic.client.Git.GetBlob(ctx, owner, repoName, blobSHA)
+		if err != nil {
+			return nil, fmt.Errorf("fetch blob: %w", classifyGitHubAPIError(err))
+		}
+		return blob, nil
+	})
 	if err != nil {
-		return "", fmt.Errorf("fetch blob: %w", classifyGitHubAPIError(err))
+		return "", err
 	}
 
 	content := blob.GetContent()
@@ -1027,9 +1094,15 @@ func (ic *InstallationClient) FetchBlobContent(ctx context.Context, repo, blobSH
 func (ic *InstallationClient) FetchFileContent(ctx context.Context, repo, filePath, ref string) (string, error) {
 	owner, repoName := splitRepo(repo)
 	opts := &gh.RepositoryContentGetOptions{Ref: ref}
-	fileContent, _, _, err := ic.client.Repositories.GetContents(ctx, owner, repoName, filePath, opts)
+	fileContent, err := retryGitHubUnavailableRead(ctx, ic.logger, "fetch file content", []any{"repo", repo, "path", filePath, "ref", ref}, func(ctx context.Context) (*gh.RepositoryContent, error) {
+		fileContent, _, _, err := ic.client.Repositories.GetContents(ctx, owner, repoName, filePath, opts)
+		if err != nil {
+			return nil, fmt.Errorf("fetch file content: %w", classifyGitHubAPIError(err))
+		}
+		return fileContent, nil
+	})
 	if err != nil {
-		return "", fmt.Errorf("fetch file content: %w", classifyGitHubAPIError(err))
+		return "", err
 	}
 	if fileContent == nil {
 		return "", fmt.Errorf("file not found: %s", filePath)
@@ -1051,17 +1124,32 @@ const maxGitHubDirEntries = 1000
 func (ic *InstallationClient) fetchDirectoryContents(ctx context.Context, repo, dirPath, ref string) ([]*gh.RepositoryContent, error) {
 	owner, repoName := splitRepo(repo)
 	opts := &gh.RepositoryContentGetOptions{Ref: ref}
-	fileContent, directoryContent, _, err := ic.client.Repositories.GetContents(ctx, owner, repoName, dirPath, opts)
+	readResult, err := retryGitHubUnavailableRead(ctx, ic.logger, "fetch directory content", []any{"repo", repo, "path", dirPath, "ref", ref}, func(ctx context.Context) (struct {
+		fileContent      *gh.RepositoryContent
+		directoryContent []*gh.RepositoryContent
+	}, error) {
+		fileContent, directoryContent, _, err := ic.client.Repositories.GetContents(ctx, owner, repoName, dirPath, opts)
+		if err != nil {
+			return struct {
+				fileContent      *gh.RepositoryContent
+				directoryContent []*gh.RepositoryContent
+			}{}, fmt.Errorf("fetch directory content at %s: %w", dirPath, classifyGitHubAPIError(err))
+		}
+		return struct {
+			fileContent      *gh.RepositoryContent
+			directoryContent []*gh.RepositoryContent
+		}{fileContent: fileContent, directoryContent: directoryContent}, nil
+	})
 	if err != nil {
-		return nil, fmt.Errorf("fetch directory content at %s: %w", dirPath, classifyGitHubAPIError(err))
+		return nil, err
 	}
-	if fileContent != nil {
+	if readResult.fileContent != nil {
 		return nil, fmt.Errorf("expected directory at %s, found file", dirPath)
 	}
-	if len(directoryContent) >= maxGitHubDirEntries {
+	if len(readResult.directoryContent) >= maxGitHubDirEntries {
 		return nil, fmt.Errorf("list schema directory %s in repo %s ref %s reached GitHub Contents API limit: %w", dirPath, repo, ref, ErrDirListingCapped)
 	}
-	return directoryContent, nil
+	return readResult.directoryContent, nil
 }
 
 // GitHubFile represents a file fetched from GitHub API.

--- a/pkg/github/client_test.go
+++ b/pkg/github/client_test.go
@@ -239,11 +239,10 @@ func TestFetchSchemaFilesOptimizedFailsClosedWhenDirectoryAtCap(t *testing.T) {
 
 	entries := make([]gh.RepositoryContent, 0, maxGitHubDirEntries)
 	for i := range maxGitHubDirEntries {
-		name := "t" + strconv.Itoa(i) + ".sql"
 		entries = append(entries, gh.RepositoryContent{
 			Type: new("file"),
-			Name: new(name),
-			Path: new("schema/" + name),
+			Name: new("t" + strconv.Itoa(i) + ".sql"),
+			Path: new("schema/t" + strconv.Itoa(i) + ".sql"),
 		})
 	}
 	mux.HandleFunc("GET /repos/octocat/hello-world/contents/schema", func(w http.ResponseWriter, _ *http.Request) {

--- a/pkg/github/config_test.go
+++ b/pkg/github/config_test.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 
 	gh "github.com/google/go-github/v86/github"
 	"github.com/stretchr/testify/assert"
@@ -35,8 +36,12 @@ environments:
 }
 
 func TestFindAllConfigsForPRClassifiesGitHubUnavailable(t *testing.T) {
+	setGitHubUnavailableReadRetryDelay(t, time.Millisecond)
+
 	client, mux := setupConfigTestGitHubServer(t)
+	requests := 0
 	mux.HandleFunc("GET /repos/octocat/hello-world/pulls/1", func(w http.ResponseWriter, _ *http.Request) {
+		requests++
 		http.Error(w, "service unavailable", http.StatusServiceUnavailable)
 	})
 
@@ -44,11 +49,106 @@ func TestFindAllConfigsForPRClassifiesGitHubUnavailable(t *testing.T) {
 	_, err := ic.FindAllConfigsForPR(t.Context(), "octocat/hello-world", 1)
 	require.Error(t, err)
 	require.ErrorIs(t, err, ErrGitHubUnavailable)
+	assert.Equal(t, githubUnavailableReadRetryMaxAttempts, requests)
+}
+
+func TestFindAllConfigsForPRRetriesUnavailablePullRequestRead(t *testing.T) {
+	setGitHubUnavailableReadRetryDelay(t, time.Millisecond)
+
+	client, mux := setupConfigTestGitHubServer(t)
+	requests := 0
+	mux.HandleFunc("GET /repos/octocat/hello-world/pulls/1", func(w http.ResponseWriter, _ *http.Request) {
+		requests++
+		if requests == 1 {
+			http.Error(w, "service unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		require.NoError(t, json.NewEncoder(w).Encode(gh.PullRequest{
+			Head: &gh.PullRequestBranch{SHA: new("abc123")},
+		}))
+	})
+	registerPullRequestFiles(t, mux, []*gh.CommitFile{{
+		Filename: new("apps/widgets/schema/schemabot.yaml"),
+		Status:   new("added"),
+	}})
+	registerFileContent(t, mux, "/repos/octocat/hello-world/contents/apps/widgets/schema/schemabot.yaml", "database: widgets\ntype: mysql\n")
+
+	ic := NewInstallationClient(client, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	configs, err := ic.FindAllConfigsForPR(t.Context(), "octocat/hello-world", 1)
+
+	require.NoError(t, err)
+	require.Len(t, configs, 1)
+	assert.Equal(t, "widgets", configs[0].Config.Database)
+	assert.Equal(t, 2, requests)
+}
+
+func TestFindAllConfigsForPRRetriesUnavailablePRFilesRead(t *testing.T) {
+	setGitHubUnavailableReadRetryDelay(t, time.Millisecond)
+
+	client, mux := setupConfigTestGitHubServer(t)
+	registerPullRequest(t, mux, "abc123")
+	requests := 0
+	mux.HandleFunc("GET /repos/octocat/hello-world/pulls/1/files", func(w http.ResponseWriter, _ *http.Request) {
+		requests++
+		if requests == 1 {
+			http.Error(w, "bad gateway", http.StatusBadGateway)
+			return
+		}
+		require.NoError(t, json.NewEncoder(w).Encode([]*gh.CommitFile{{
+			Filename: new("apps/widgets/schema/schemabot.yaml"),
+			Status:   new("added"),
+		}}))
+	})
+	registerFileContent(t, mux, "/repos/octocat/hello-world/contents/apps/widgets/schema/schemabot.yaml", "database: widgets\ntype: mysql\n")
+
+	ic := NewInstallationClient(client, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	configs, err := ic.FindAllConfigsForPR(t.Context(), "octocat/hello-world", 1)
+
+	require.NoError(t, err)
+	require.Len(t, configs, 1)
+	assert.Equal(t, "widgets", configs[0].Config.Database)
+	assert.Equal(t, 2, requests)
+}
+
+func TestFindAllConfigsForPRRetriesUnavailableConfigContentRead(t *testing.T) {
+	setGitHubUnavailableReadRetryDelay(t, time.Millisecond)
+
+	client, mux := setupConfigTestGitHubServer(t)
+	registerPullRequest(t, mux, "abc123")
+	registerPullRequestFiles(t, mux, []*gh.CommitFile{{
+		Filename: new("apps/widgets/schema/schemabot.yaml"),
+		Status:   new("added"),
+	}})
+	requests := 0
+	mux.HandleFunc("GET /repos/octocat/hello-world/contents/apps/widgets/schema/schemabot.yaml", func(w http.ResponseWriter, _ *http.Request) {
+		requests++
+		if requests == 1 {
+			http.Error(w, "service unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		require.NoError(t, json.NewEncoder(w).Encode(gh.RepositoryContent{
+			Type:     new("file"),
+			Encoding: new("base64"),
+			Content:  new(base64.StdEncoding.EncodeToString([]byte("database: widgets\ntype: mysql\n"))),
+		}))
+	})
+
+	ic := NewInstallationClient(client, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	configs, err := ic.FindAllConfigsForPR(t.Context(), "octocat/hello-world", 1)
+
+	require.NoError(t, err)
+	require.Len(t, configs, 1)
+	assert.Equal(t, "widgets", configs[0].Config.Database)
+	assert.Equal(t, 2, requests)
 }
 
 func TestFindAllConfigsForPRDoesNotClassifyRateLimitAsGitHubUnavailable(t *testing.T) {
+	setGitHubUnavailableReadRetryDelay(t, time.Millisecond)
+
 	client, mux := setupConfigTestGitHubServer(t)
+	requests := 0
 	mux.HandleFunc("GET /repos/octocat/hello-world/pulls/1", func(w http.ResponseWriter, _ *http.Request) {
+		requests++
 		w.Header().Set("X-RateLimit-Remaining", "0")
 		w.WriteHeader(http.StatusForbidden)
 		_, err := w.Write([]byte(`{"message":"API rate limit exceeded"}`))
@@ -59,6 +159,7 @@ func TestFindAllConfigsForPRDoesNotClassifyRateLimitAsGitHubUnavailable(t *testi
 	_, err := ic.FindAllConfigsForPR(t.Context(), "octocat/hello-world", 1)
 	require.Error(t, err)
 	assert.False(t, errors.Is(err, ErrGitHubUnavailable))
+	assert.Equal(t, 1, requests)
 }
 
 func TestFindAllConfigsForPRDoesNotClassifyMissingConfigAsGitHubUnavailable(t *testing.T) {
@@ -296,6 +397,16 @@ func setupConfigTestGitHubServer(t *testing.T) (*gh.Client, *http.ServeMux) {
 	client.BaseURL = baseURL
 
 	return client, mux
+}
+
+func setGitHubUnavailableReadRetryDelay(t *testing.T, delay time.Duration) {
+	t.Helper()
+
+	originalDelay := githubUnavailableReadRetryDelay
+	githubUnavailableReadRetryDelay = delay
+	t.Cleanup(func() {
+		githubUnavailableReadRetryDelay = originalDelay
+	})
 }
 
 func registerPullRequest(t *testing.T, mux *http.ServeMux, headSHA string) {

--- a/pkg/github/pr_info_cache_test.go
+++ b/pkg/github/pr_info_cache_test.go
@@ -105,7 +105,7 @@ func TestFetchPullRequest_ErrorsAreNotCached(t *testing.T) {
 	mux.HandleFunc("/repos/octo/repo/pulls/42", func(w http.ResponseWriter, r *http.Request) {
 		n := calls.Add(1)
 		if n < 3 {
-			http.Error(w, "boom", http.StatusInternalServerError)
+			http.Error(w, "bad credentials", http.StatusUnauthorized)
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
## Why
Transient GitHub API availability failures can make PR schema discovery fail closed even when a retry would succeed. Retrying only idempotent reads makes the GitHub PR UX more resilient without weakening safety gates.

## What
- Retry transient unavailable errors for PR and repository content reads used by schema discovery
- Keep auth, rate limit, missing resource, and other non-transient failures fail-closed
- Cover PR metadata, PR files, and config content retries with focused tests

## Risk Assessment
Low — this only retries read-only GitHub calls that already failed as temporarily unavailable, while preserving existing fail-closed behavior for non-retryable errors.

Generated with Amp