### PR TITLE
fix(tern): reconcile lagging tasks when the remote apply is terminal

### DIFF
--- a/pkg/tern/grpc_client.go
+++ b/pkg/tern/grpc_client.go
@@ -1821,6 +1821,10 @@ func terminalTaskStateForApply(applyState string) (string, bool) {
 		return state.Task.Stopped, true
 	case state.IsState(applyState, state.Apply.Failed):
 		return state.Task.Failed, true
+	case state.IsState(applyState, state.Apply.Cancelled):
+		return state.Task.Cancelled, true
+	case state.IsState(applyState, state.Apply.Reverted):
+		return state.Task.Reverted, true
 	default:
 		return "", false
 	}

--- a/pkg/tern/grpc_client.go
+++ b/pkg/tern/grpc_client.go
@@ -1622,7 +1622,7 @@ func (c *GRPCClient) reconcileTerminalRemoteProgress(ctx context.Context, remote
 	if err := c.syncStoredTasksFromRemoteTasks(ctx, storedApply, storedTasks, remoteTasks, now); err != nil {
 		return err
 	}
-	if err := ensureStoredTasksResolvedForTerminalRemoteApply(remoteApply, storedTasks); err != nil {
+	if err := c.reconcileStoredTasksForTerminalRemoteApply(ctx, storedApply, remoteApply, storedTasks, now); err != nil {
 		return err
 	}
 	return c.persistTerminalStateFromRemote(ctx, storedApply, remoteApply, now)
@@ -1770,22 +1770,60 @@ func remoteTaskOmittedRowTotals(storedTask *storage.Task, remoteTask *ternv1.Tab
 	return storedTask.RowsTotal > 0 && remoteTask.RowsTotal <= 0
 }
 
-func ensureStoredTasksResolvedForTerminalRemoteApply(remoteApply *storage.Apply, storedTasks []*storage.Task) error {
+// reconcileStoredTasksForTerminalRemoteApply force-resolves any stored task the
+// remote progress left unresolved once the remote apply itself is terminal. A
+// terminal remote apply is authoritative: the remote will send no further task
+// progress, so a lagging task is driven to the apply's terminal state and
+// persisted rather than blocking finalization (which would otherwise re-poll the
+// already-terminal remote forever). A storage failure is still returned so the
+// operator retries that genuinely-transient case.
+func (c *GRPCClient) reconcileStoredTasksForTerminalRemoteApply(ctx context.Context, storedApply, remoteApply *storage.Apply, storedTasks []*storage.Task, now time.Time) error {
+	terminalTaskState, ok := terminalTaskStateForApply(remoteApply.State)
+	if !ok {
+		return fmt.Errorf("reconcile stored tasks for %s: remote apply state %q is not terminal", storedApply.ApplyIdentifier, remoteApply.State)
+	}
 	for _, storedTask := range storedTasks {
 		if storedTaskResolvedForTerminalRemoteApply(remoteApply.State, storedTask.State) {
 			continue
 		}
-		slog.Warn("terminal remote gRPC apply still has unresolved stored task after syncing remote task progress",
-			"apply_id", remoteApply.ApplyIdentifier,
-			"external_id", remoteApply.ExternalID,
+		oldTaskState := storedTask.State
+		storedTask.State = terminalTaskState
+		if state.IsState(terminalTaskState, state.Task.Completed) {
+			storedTask.ProgressPercent = 100
+		}
+		if state.IsTerminalTaskState(terminalTaskState) && storedTask.CompletedAt == nil {
+			storedTask.CompletedAt = &now
+		}
+		storedTask.UpdatedAt = now
+		if err := c.storage.Tasks().Update(ctx, storedTask); err != nil {
+			return fmt.Errorf("reconcile lagging task %s to %s for terminal remote gRPC apply %s: %w", storedTask.TaskIdentifier, terminalTaskState, storedApply.ApplyIdentifier, err)
+		}
+		slog.Warn("reconciled lagging stored task to terminal remote gRPC apply state",
+			"apply_id", storedApply.ApplyIdentifier,
+			"external_id", storedApply.ExternalID,
 			"remote_apply_state", remoteApply.State,
 			"task_id", storedTask.TaskIdentifier,
 			"table", storedTask.TableName,
-			"stored_task_state", storedTask.State)
-		return fmt.Errorf("terminal remote gRPC apply %s is %s but stored task %s is still %s after syncing remote task progress",
-			remoteApply.ApplyIdentifier, remoteApply.State, storedTask.TaskIdentifier, storedTask.State)
+			"old_task_state", oldTaskState,
+			"new_task_state", terminalTaskState)
+		c.logTaskStateTransition(ctx, storedApply.ID, storedTask, fmt.Sprintf("Task %s reconciled to %s for terminal remote apply state %s", storedTask.TableName, terminalTaskState, remoteApply.State), oldTaskState)
 	}
 	return nil
+}
+
+// terminalTaskStateForApply maps a terminal apply state to the task state a
+// lagging stored task must adopt when its terminal apply is authoritative.
+func terminalTaskStateForApply(applyState string) (string, bool) {
+	switch {
+	case state.IsState(applyState, state.Apply.Completed):
+		return state.Task.Completed, true
+	case state.IsState(applyState, state.Apply.Stopped):
+		return state.Task.Stopped, true
+	case state.IsState(applyState, state.Apply.Failed):
+		return state.Task.Failed, true
+	default:
+		return "", false
+	}
 }
 
 func storedTaskResolvedForTerminalRemoteApply(remoteApplyState, storedTaskState string) bool {

--- a/pkg/tern/grpc_client_test.go
+++ b/pkg/tern/grpc_client_test.go
@@ -1791,31 +1791,31 @@ func TestGRPCClient_PollKeepsApplyActiveWhenReconcilingLaggingTaskStorageFails(t
 }
 
 // When a stop drives the remote apply to a terminal state but the remote no
-// longer reports the per-task progress (the remote cohort is already terminal
-// and gone), the terminal remote apply is authoritative: the lagging stored task
-// must be reconciled to the matching terminal state so the stop finalizes. The
-// control plane must not loop forever waiting for task progress the terminal
-// remote will never send again.
+// longer reports the per-task progress (the remote apply is already terminal and
+// drops the task from its payload), the terminal remote apply is authoritative:
+// the lagging stored task must be reconciled to the matching terminal state so
+// the stop finalizes. The control plane must not loop forever waiting for task
+// progress the terminal remote will never send again.
 func TestGRPCClient_PollReconcilesLaggingTaskWhenRemoteApplyStoppedAndTaskProgressOmitted(t *testing.T) {
 	client, cleanup := testCapturingGRPCClient(t, &capturingTernServer{
 		progressState:    ternv1.State_STATE_STOPPED,
 		progressStateSet: true,
-		// No progressTables: the terminal remote cohort no longer reports the task.
+		// No progressTables: the terminal remote apply no longer reports the task.
 	})
 	defer cleanup()
 
 	apply := &storage.Apply{
 		ID:              31,
-		ApplyIdentifier: "apply-stop-terminal-cohort",
+		ApplyIdentifier: "apply-stop-terminal-remote",
 		Database:        "testdb",
 		Environment:     "staging",
-		ExternalID:      "remote-stop-terminal-cohort",
+		ExternalID:      "remote-stop-terminal-apply",
 		State:           state.Apply.Running,
 	}
 	storedApply := *apply
 	task := &storage.Task{
 		ID:             41,
-		TaskIdentifier: "task-stop-terminal-cohort",
+		TaskIdentifier: "task-stop-terminal-remote",
 		ApplyID:        apply.ID,
 		TableName:      "users",
 		State:          state.Task.Running,
@@ -1835,6 +1835,48 @@ func TestGRPCClient_PollReconcilesLaggingTaskWhenRemoteApplyStoppedAndTaskProgre
 	assert.Equal(t, state.Apply.Stopped, applyStore.apply.State)
 	assert.Equal(t, state.Task.Stopped, task.State,
 		"lagging stored task should be reconciled to the apply's stopped state, got %q", task.State)
+}
+
+// terminalTaskStateForApply must map every terminal apply state a remote can
+// report — including the less-common cancelled and reverted outcomes — to the
+// task state a lagging stored task adopts. A terminal apply state with no
+// mapping would make terminal reconciliation error and re-poll the already
+// terminal remote forever.
+func TestTerminalTaskStateForApply(t *testing.T) {
+	tests := []struct {
+		name       string
+		applyState string
+		wantTask   string
+		wantOK     bool
+	}{
+		{name: "completed", applyState: state.Apply.Completed, wantTask: state.Task.Completed, wantOK: true},
+		{name: "stopped", applyState: state.Apply.Stopped, wantTask: state.Task.Stopped, wantOK: true},
+		{name: "failed", applyState: state.Apply.Failed, wantTask: state.Task.Failed, wantOK: true},
+		{name: "cancelled", applyState: state.Apply.Cancelled, wantTask: state.Task.Cancelled, wantOK: true},
+		{name: "reverted", applyState: state.Apply.Reverted, wantTask: state.Task.Reverted, wantOK: true},
+		{name: "running is not terminal", applyState: state.Apply.Running, wantOK: false},
+		{name: "failed-retryable is not terminal", applyState: state.Apply.FailedRetryable, wantOK: false},
+		{name: "pending is not terminal", applyState: state.Apply.Pending, wantOK: false},
+		{name: "waiting-for-cutover is not terminal", applyState: state.Apply.WaitingForCutover, wantOK: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := terminalTaskStateForApply(tt.applyState)
+			assert.Equal(t, tt.wantOK, ok)
+			assert.Equal(t, tt.wantTask, got)
+		})
+	}
+
+	// Every terminal apply state in the registry must have a task mapping so the
+	// reconcile path can never error on a terminal remote apply.
+	for _, applyState := range []string{
+		state.Apply.Completed, state.Apply.Failed, state.Apply.Stopped,
+		state.Apply.Cancelled, state.Apply.Reverted,
+	} {
+		require.True(t, state.IsTerminalApplyState(applyState), "%q should be a terminal apply state", applyState)
+		_, ok := terminalTaskStateForApply(applyState)
+		assert.True(t, ok, "terminal apply state %q must map to a task state", applyState)
+	}
 }
 
 func hasLogMessageContaining(logs []*storage.ApplyLog, want string) bool {

--- a/pkg/tern/grpc_client_test.go
+++ b/pkg/tern/grpc_client_test.go
@@ -623,6 +623,7 @@ type mockTaskStore struct {
 	tasks               []*storage.Task
 	getByApplyIDErr     error
 	getByOperationIDErr error
+	updateErr           error
 	lastOperationID     int64
 }
 
@@ -640,7 +641,7 @@ func (m *mockTaskStore) GetByApplyOperationID(_ context.Context, applyOperationI
 	}
 	return m.tasks, nil
 }
-func (m *mockTaskStore) Update(context.Context, *storage.Task) error { return nil }
+func (m *mockTaskStore) Update(context.Context, *storage.Task) error { return m.updateErr }
 
 type mockApplyLogStore struct {
 	storage.ApplyLogStore
@@ -1703,9 +1704,11 @@ func TestGRPCClient_PollSetsTerminalTaskMetadataFromRemoteTaskProgress(t *testin
 	require.NotNil(t, task.CompletedAt)
 }
 
-func TestGRPCClient_PollReturnsErrorWhenTerminalRemoteApplyLeavesStoredTaskActive(t *testing.T) {
-	// A terminal remote apply with no terminal remote task state is inconsistent.
-	// The control plane should retry instead of inventing a stored task result.
+func TestGRPCClient_PollReconcilesLaggingTaskWhenRemoteApplyCompletedAndTaskProgressOmitted(t *testing.T) {
+	// A terminal remote apply is authoritative: the remote will send no more task
+	// progress, so a stored task the remote no longer reports is reconciled to the
+	// apply's terminal state and the apply finalizes — rather than looping forever
+	// waiting for progress that will never arrive.
 	client, cleanup := testCapturingGRPCClient(t, &capturingTernServer{
 		progressState:    ternv1.State_STATE_COMPLETED,
 		progressStateSet: true,
@@ -1738,10 +1741,100 @@ func TestGRPCClient_PollReturnsErrorWhenTerminalRemoteApplyLeavesStoredTaskActiv
 	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
 	defer cancel()
 	err := client.pollForCompletion(ctx, apply, false, wholeApplyTaskScope())
+	require.NoError(t, err)
+
+	assert.Equal(t, state.Apply.Completed, applyStore.apply.State)
+	assert.Equal(t, state.Task.Completed, task.State)
+	assert.Equal(t, 100, task.ProgressPercent)
+	require.NotNil(t, task.CompletedAt)
+}
+
+// A storage failure while reconciling a lagging task is genuinely transient, so
+// the apply is kept active for operator retry rather than finalized.
+func TestGRPCClient_PollKeepsApplyActiveWhenReconcilingLaggingTaskStorageFails(t *testing.T) {
+	client, cleanup := testCapturingGRPCClient(t, &capturingTernServer{
+		progressState:    ternv1.State_STATE_COMPLETED,
+		progressStateSet: true,
+	})
+	defer cleanup()
+
+	apply := &storage.Apply{
+		ID:              19,
+		ApplyIdentifier: "apply-terminal-task-update-fails",
+		Database:        "testdb",
+		Environment:     "staging",
+		ExternalID:      "remote-terminal-task-update-fails",
+		State:           state.Apply.Running,
+	}
+	storedApply := *apply
+	task := &storage.Task{
+		ID:             23,
+		TaskIdentifier: "task-terminal-update-fails",
+		ApplyID:        apply.ID,
+		TableName:      "users",
+		State:          state.Task.Running,
+	}
+	applyStore := &mockApplyStore{apply: &storedApply}
+	client.storage = &mockStorage{
+		applies: applyStore,
+		tasks:   &mockTaskStore{tasks: []*storage.Task{task}, updateErr: errors.New("storage unavailable")},
+		logs:    &mockApplyLogStore{},
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+	err := client.pollForCompletion(ctx, apply, false, wholeApplyTaskScope())
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "stored task task-terminal-missing-state is still running")
+	assert.Contains(t, err.Error(), "storage unavailable")
 	assert.Equal(t, state.Apply.Running, applyStore.apply.State)
 	assert.Nil(t, applyStore.apply.CompletedAt)
+}
+
+// When a stop drives the remote apply to a terminal state but the remote no
+// longer reports the per-task progress (the remote cohort is already terminal
+// and gone), the terminal remote apply is authoritative: the lagging stored task
+// must be reconciled to the matching terminal state so the stop finalizes. The
+// control plane must not loop forever waiting for task progress the terminal
+// remote will never send again.
+func TestGRPCClient_PollReconcilesLaggingTaskWhenRemoteApplyStoppedAndTaskProgressOmitted(t *testing.T) {
+	client, cleanup := testCapturingGRPCClient(t, &capturingTernServer{
+		progressState:    ternv1.State_STATE_STOPPED,
+		progressStateSet: true,
+		// No progressTables: the terminal remote cohort no longer reports the task.
+	})
+	defer cleanup()
+
+	apply := &storage.Apply{
+		ID:              31,
+		ApplyIdentifier: "apply-stop-terminal-cohort",
+		Database:        "testdb",
+		Environment:     "staging",
+		ExternalID:      "remote-stop-terminal-cohort",
+		State:           state.Apply.Running,
+	}
+	storedApply := *apply
+	task := &storage.Task{
+		ID:             41,
+		TaskIdentifier: "task-stop-terminal-cohort",
+		ApplyID:        apply.ID,
+		TableName:      "users",
+		State:          state.Task.Running,
+	}
+	applyStore := &mockApplyStore{apply: &storedApply}
+	client.storage = &mockStorage{
+		applies: applyStore,
+		tasks:   &mockTaskStore{tasks: []*storage.Task{task}},
+		logs:    &mockApplyLogStore{},
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+	err := client.pollForCompletion(ctx, apply, false, wholeApplyTaskScope())
+	require.NoError(t, err)
+
+	assert.Equal(t, state.Apply.Stopped, applyStore.apply.State)
+	assert.Equal(t, state.Task.Stopped, task.State,
+		"lagging stored task should be reconciled to the apply's stopped state, got %q", task.State)
 }
 
 func hasLogMessageContaining(logs []*storage.ApplyLog, want string) bool {


### PR DESCRIPTION
## Why this matters

A remote gRPC data plane is authoritative for its own apply lifecycle. When the control plane drives that apply to a terminal state — stopped, completed, or failed — but a stored task is still non-terminal, finalization hard-errored. Because the remote apply is already terminal it will send no further progress for that task, so the operator re-claimed the apply and re-polled the same terminal remote forever instead of converging. A stop that races the apply finishing is the common trigger: the remote drops the task from its progress payload exactly as the apply settles.

## What it does

Treats a terminal remote apply as the source of truth for its tasks: a lagging stored task is reconciled to the apply's terminal task state (`completed` → completed at 100%, `stopped` → stopped, `failed` → failed), persisted, and logged. The only error path retained is a storage write failure while reconciling — that is genuinely transient, so the operator still retries it and the apply stays active until the write lands.

```
remote apply terminal + stored task still active
  before:  return error ──> operator re-claims & re-polls forever
  after:   task -> apply's terminal state, persist, log ──> apply finalizes
           (storage write fails -> return error, retry; apply stays active)
```

Fail-closed where it matters (storage uncertainty), converge where the remote is authoritative.