### PR TITLE
feat(inventory): length operator for awssm credential templates

### DIFF
--- a/pkg/awscreds/awscreds.go
+++ b/pkg/awscreds/awscreds.go
@@ -19,8 +19,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
+	"unicode/utf8"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
@@ -34,10 +36,13 @@ import (
 // account id when one is not configured.
 const defaultAccountAttribute = "aws_account_id"
 
-// templatePlaceholderRe matches "{name}" placeholders in a template. "{target}"
-// is the request target; any other name is an entity attribute resolved for the
-// target.
-var templatePlaceholderRe = regexp.MustCompile(`\{([a-zA-Z0-9_]+)\}`)
+// templatePlaceholderRe matches "{name}" placeholders in a template, with an
+// optional ":N" length operator (e.g. "{app:24}"). "{target}" is the request
+// target; any other name is an entity attribute resolved for the target. When a
+// length operator is present, the resolved value is truncated to at most N
+// characters — used to fit database identifier limits (e.g. MySQL's 32-character
+// username cap, Postgres's 63) when an attribute can exceed them.
+var templatePlaceholderRe = regexp.MustCompile(`\{([a-zA-Z0-9_]+)(?::(\d+))?\}`)
 
 // Config configures a Resolver.
 type Config struct {
@@ -59,7 +64,9 @@ type Config struct {
 	ExternalID string
 	// SecretName is the Secrets Manager secret id. It may contain placeholders:
 	// "{target}" (the request target) and "{attribute}" (any resolved entity
-	// attribute), replaced to locate per-target or per-cluster secrets.
+	// attribute), replaced to locate per-target or per-cluster secrets. A
+	// placeholder may carry a ":N" length operator (e.g. "{cluster:20}") that
+	// truncates the value to at most N characters.
 	SecretName string
 	// AccountAttribute is the endpoint attribute holding the target's AWS account
 	// id. Defaults to "aws_account_id". Only required when RoleARN is set.
@@ -68,7 +75,10 @@ type Config struct {
 	// placeholders) that renders the database username, and the fetched secret is
 	// treated as the plain-text password rather than a JSON payload. Use this for
 	// conventions that derive the username from entity attributes (e.g.
-	// "{app}_ddl") and store only the password. Mutually exclusive with Decode.
+	// "{app}_ddl") and store only the password. A placeholder may carry a ":N"
+	// length operator (e.g. "{app:24}_ddl") so the rendered username fits the
+	// database's identifier limit when an attribute can exceed it. Mutually
+	// exclusive with Decode.
 	Username string
 	// Decode, when set, interprets the fetched secret into Credentials (for
 	// example a PlanetScale token). When nil (and no Username template is set) the
@@ -235,25 +245,55 @@ func targetContext(target, accountID string) string {
 }
 
 // renderTemplate replaces "{target}" with the request target and every other
-// "{attribute}" placeholder with the resolved attribute value, failing closed if
-// any referenced attribute was not resolved. what labels the template in errors.
+// "{attribute}" placeholder with the resolved attribute value, applying an
+// optional ":N" length operator that truncates the value to at most N
+// characters. It fails closed if any referenced attribute was not resolved or a
+// length operator is invalid (zero, or too large to parse). what labels the
+// template in errors.
 func renderTemplate(what, tmpl, target string, attrs map[string]string) (string, error) {
-	var missing []string
+	var missing, invalid []string
 	rendered := templatePlaceholderRe.ReplaceAllStringFunc(tmpl, func(match string) string {
-		key := match[1 : len(match)-1]
-		if key == "target" {
-			return target
+		groups := templatePlaceholderRe.FindStringSubmatch(match)
+		key, lengthOp := groups[1], groups[2]
+
+		var value string
+		switch {
+		case key == "target":
+			value = target
+		case attrs[key] != "":
+			value = attrs[key]
+		default:
+			missing = append(missing, key)
+			return match
 		}
-		if v := attrs[key]; v != "" {
-			return v
+
+		if lengthOp == "" {
+			return value
 		}
-		missing = append(missing, key)
-		return match
+		maxLen, err := strconv.Atoi(lengthOp)
+		if err != nil || maxLen < 1 {
+			invalid = append(invalid, match)
+			return match
+		}
+		return truncateToRunes(value, maxLen)
 	})
+	if len(invalid) > 0 {
+		return "", fmt.Errorf("%s template %q for target %q has invalid length operator(s): %s", what, tmpl, target, strings.Join(invalid, ", "))
+	}
 	if len(missing) > 0 {
 		return "", fmt.Errorf("%s template %q for target %q references unresolved attribute(s): %s", what, tmpl, target, strings.Join(missing, ", "))
 	}
 	return rendered, nil
+}
+
+// truncateToRunes returns at most maxLen runes of s. Database identifier limits
+// count characters, so truncating by rune (not byte) keeps multi-byte values
+// from being cut mid-character.
+func truncateToRunes(s string, maxLen int) string {
+	if utf8.RuneCountInString(s) <= maxLen {
+		return s
+	}
+	return string([]rune(s)[:maxLen])
 }
 
 // getSecretString reads a string secret value, rejecting binary secrets.

--- a/pkg/awscreds/awscreds.go
+++ b/pkg/awscreds/awscreds.go
@@ -41,8 +41,11 @@ const defaultAccountAttribute = "aws_account_id"
 // target; any other name is an entity attribute resolved for the target. When a
 // length operator is present, the resolved value is truncated to at most N
 // characters — used to fit database identifier limits (e.g. MySQL's 32-character
-// username cap, Postgres's 63) when an attribute can exceed them.
-var templatePlaceholderRe = regexp.MustCompile(`\{([a-zA-Z0-9_]+)(?::(\d+))?\}`)
+// username cap, Postgres's 63) when an attribute can exceed them. The operator is
+// captured loosely (any text after the colon) so a malformed one like "{app:x}"
+// is still recognized as a placeholder and rejected at render, rather than
+// rendering literally.
+var templatePlaceholderRe = regexp.MustCompile(`\{([a-zA-Z0-9_]+)(:[^}]*)?\}`)
 
 // Config configures a Resolver.
 type Config struct {
@@ -270,7 +273,9 @@ func renderTemplate(what, tmpl, target string, attrs map[string]string) (string,
 		if lengthOp == "" {
 			return value
 		}
-		maxLen, err := strconv.Atoi(lengthOp)
+		// lengthOp includes the leading colon (e.g. ":24"); the spec after it must
+		// be a positive integer. Anything else (":", ":x", ":0") is a config error.
+		maxLen, err := strconv.Atoi(lengthOp[1:])
 		if err != nil || maxLen < 1 {
 			invalid = append(invalid, match)
 			return match

--- a/pkg/awscreds/awscreds_test.go
+++ b/pkg/awscreds/awscreds_test.go
@@ -195,13 +195,18 @@ func TestResolverSecretNameLengthOperatorTruncates(t *testing.T) {
 // A zero or unparseable length operator is a configuration error, not a silent
 // passthrough that would produce a wrong identifier.
 func TestResolverFailsOnInvalidLengthOperator(t *testing.T) {
-	r := newResolver("aws_account_id", "secret", "{app:0}_ddl", &fakeFetcher{payload: "pw"}, nil, false)
+	// Zero, non-numeric, negative, and empty operators are all configuration
+	// errors. A malformed operator must still be recognized as a placeholder and
+	// rejected, never rendered literally into the username.
+	for _, tmpl := range []string{"{app:0}_ddl", "{app:nope}_ddl", "{app:-1}_ddl", "{app:}_ddl"} {
+		r := newResolver("aws_account_id", "secret", tmpl, &fakeFetcher{payload: "pw"}, nil, false)
 
-	_, err := r.ResolveCredentials(t.Context(),
-		inventory.Request{Target: "orders-dsid"},
-		map[string]string{"app": "orders"})
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "invalid length operator")
+		_, err := r.ResolveCredentials(t.Context(),
+			inventory.Request{Target: "orders-dsid"},
+			map[string]string{"app": "orders"})
+		require.Error(t, err, tmpl)
+		assert.Contains(t, err.Error(), "invalid length operator", tmpl)
+	}
 }
 
 // Truncation counts characters, not bytes, so a multi-byte value is never cut

--- a/pkg/awscreds/awscreds_test.go
+++ b/pkg/awscreds/awscreds_test.go
@@ -150,6 +150,66 @@ func TestTemplateAttributes(t *testing.T) {
 	assert.Equal(t, []string{"app"}, TemplateAttributes("{app}_ddl"))
 	assert.Empty(t, TemplateAttributes("schemabot/{target}/ddl"))
 	assert.Empty(t, TemplateAttributes("static-secret"))
+	// A length operator does not change which attribute the placeholder references.
+	assert.Equal(t, []string{"app"}, TemplateAttributes("{app:24}_ddl"))
+}
+
+// A ":N" length operator truncates the resolved value so a derived username fits
+// the database's identifier limit even when the source attribute is longer (e.g.
+// an app name longer than MySQL's 32-character cap).
+func TestResolverUsernameLengthOperatorTruncates(t *testing.T) {
+	fetch := &fakeFetcher{payload: "pw"}
+	r := newResolver("aws_account_id", "secret", "{app:24}_ddl", fetch, nil, false)
+
+	creds, err := r.ResolveCredentials(t.Context(),
+		inventory.Request{Target: "orders-dsid"},
+		map[string]string{"app": "abcdefghijklmnopqrstuvwxyz0123"}) // 30 chars
+	require.NoError(t, err)
+	assert.Equal(t, "abcdefghijklmnopqrstuvwx_ddl", creds.Username) // 24 + "_ddl"
+}
+
+// A value already within the limit is left intact by the length operator.
+func TestResolverLengthOperatorLeavesShortValueIntact(t *testing.T) {
+	fetch := &fakeFetcher{payload: "pw"}
+	r := newResolver("aws_account_id", "secret", "{app:24}_ddl", fetch, nil, false)
+
+	creds, err := r.ResolveCredentials(t.Context(),
+		inventory.Request{Target: "orders-dsid"},
+		map[string]string{"app": "orders"})
+	require.NoError(t, err)
+	assert.Equal(t, "orders_ddl", creds.Username)
+}
+
+// The length operator also applies to secret-name templates.
+func TestResolverSecretNameLengthOperatorTruncates(t *testing.T) {
+	fetch := &fakeFetcher{payload: `{"username":"u","password":"p"}`}
+	r := newResolver("aws_account_id", "schemabot/{cluster:8}/ddl", "", fetch, nil, true)
+
+	_, err := r.ResolveCredentials(t.Context(),
+		inventory.Request{Target: "orders-dsid"},
+		map[string]string{"aws_account_id": "123456789012", "cluster": "production-cluster"})
+	require.NoError(t, err)
+	assert.Equal(t, "schemabot/producti/ddl", fetch.gotSecret)
+}
+
+// A zero or unparseable length operator is a configuration error, not a silent
+// passthrough that would produce a wrong identifier.
+func TestResolverFailsOnInvalidLengthOperator(t *testing.T) {
+	r := newResolver("aws_account_id", "secret", "{app:0}_ddl", &fakeFetcher{payload: "pw"}, nil, false)
+
+	_, err := r.ResolveCredentials(t.Context(),
+		inventory.Request{Target: "orders-dsid"},
+		map[string]string{"app": "orders"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid length operator")
+}
+
+// Truncation counts characters, not bytes, so a multi-byte value is never cut
+// mid-character.
+func TestTruncateToRunesCountsCharacters(t *testing.T) {
+	assert.Equal(t, "héllo", truncateToRunes("héllo-world", 5))
+	assert.Equal(t, "abc", truncateToRunes("abc", 5))
+	assert.Equal(t, "", truncateToRunes("abc", 0))
 }
 
 // Some conventions derive the username from an entity attribute and store only


### PR DESCRIPTION
## Why this matters

The awssm credential resolver derives a database username and locates a secret from templates over the request target and resolved entity attributes (e.g. `{app}_ddl`). When a templated value is longer than the database allows for an identifier, the rendered username is silently wrong and the apply fails to authenticate. MySQL caps usernames at 32 characters and Postgres at 63, so a derived username must be bounded to fit.

## What it does

Adds an optional `:N` length operator to any placeholder — `{app:24}_ddl` resolves the `app` attribute and truncates it to at most 24 characters before substitution. It applies to both secret-name and username templates.

- Truncates by **rune**, not byte, so a multi-byte value is never cut mid-character.
- A zero or unparseable length is a **configuration error** (`invalid length operator`), not a silent passthrough that would produce a wrong identifier.
- The config surface is unchanged: the operator is template syntax, opaque to config parsing, and attribute discovery still resolves the underlying attribute name (so `{app:24}` still surfaces `app`).

```
template      attribute (length)                       rendered
{app:24}_ddl  "abcdefghijklmnopqrstuvwxyz0123" (30)  -> "abcdefghijklmnopqrstuvwx_ddl"  (truncated to 24 + suffix)
{app:24}_ddl  "orders" (6)                           -> "orders_ddl"                    (within limit, unchanged)
{app:0}_ddl                                          -> error: invalid length operator
```