### PR TITLE
feat(inventory): per-type target resolver routing for the data plane

### DIFF
--- a/e2e/k8s/data-plane-etre-values.yaml
+++ b/e2e/k8s/data-plane-etre-values.yaml
@@ -21,21 +21,21 @@ config:
     dsn: "env:MYSQL_DSN"
   target_resolver:
     etre:
-      addr: "http://etre:8080"
-      database_type: mysql
-      entity_type: aurora_cluster
-      target_label: dsid
-      env_label: env
-      labels:
-        aws_region: us-east-1
-      mysql:
-        host_field: writer_endpoint
-        default_port: "3306"
-      credentials:
-        type: awssm
-        region: us-east-1
-        role_arn: "arn:aws:iam::{account}:role/tern-assumed"
-        secret_name: "{target}_ddl_password"
+      - addr: "http://etre:8080"
+        database_type: mysql
+        entity_type: aurora_cluster
+        target_label: dsid
+        env_label: env
+        labels:
+          aws_region: us-east-1
+        mysql:
+          host_field: writer_endpoint
+          default_port: "3306"
+        credentials:
+          type: awssm
+          region: us-east-1
+          role_arn: "arn:aws:iam::{account}:role/tern-assumed"
+          secret_name: "{target}_ddl_password"
 
 env:
   - name: MYSQL_DSN

--- a/e2e/k8s/data-plane-vitess-values.yaml
+++ b/e2e/k8s/data-plane-vitess-values.yaml
@@ -21,17 +21,17 @@ config:
     dsn: "env:MYSQL_DSN"
   target_resolver:
     etre:
-      addr: "http://etre:8080"
-      database_type: vitess
-      entity_type: planetscale_database
-      target_label: dsid
-      env_label: env
-      vitess:
-        organization_attribute: organization
-        api_url: "http://localscale:8080"
-      credentials:
-        type: secret_ref
-        password_ref: "env:PS_TOKEN"
+      - addr: "http://etre:8080"
+        database_type: vitess
+        entity_type: planetscale_database
+        target_label: dsid
+        env_label: env
+        vitess:
+          organization_attribute: organization
+          api_url: "http://localscale:8080"
+        credentials:
+          type: secret_ref
+          password_ref: "env:PS_TOKEN"
 
 env:
   - name: MYSQL_DSN

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -375,7 +375,11 @@ type DSNFromConfigPaths struct {
 // time. Each is one pluggable backend behind the same resolver interface.
 type TargetResolverConfig struct {
 	Targets map[string]inventory.StaticTarget `yaml:"targets,omitempty"`
-	Etre    EtreConfig                        `yaml:"etre,omitempty"`
+	// Etre lists one or more Etre-backed resolvers. A single entry resolves every
+	// request directly; multiple entries compose into a per-type router (keyed by
+	// each entry's database_type) so one data plane can serve several engines at
+	// once and the request's database type selects among them.
+	Etre []EtreConfig `yaml:"etre,omitempty"`
 }
 
 // Configured reports whether the data plane has any static target inventory.
@@ -386,7 +390,7 @@ func (c TargetResolverConfig) Configured() bool {
 // Enabled reports whether any target-resolver backend is configured (static
 // inventory or Etre). New backends are added here so callers stay correct.
 func (c TargetResolverConfig) Enabled() bool {
-	return c.Configured() || c.Etre.Configured()
+	return c.Configured() || len(c.Etre) > 0
 }
 
 // StaticInventory returns the static inventory config for NewStaticResolver.
@@ -479,11 +483,6 @@ type EtreCredentialsConfig struct {
 	ExternalID       string `yaml:"external_id,omitempty"`
 	SecretName       string `yaml:"secret_name,omitempty"`
 	AccountAttribute string `yaml:"account_attribute,omitempty"`
-}
-
-// Configured reports whether the data plane should resolve targets through Etre.
-func (c EtreConfig) Configured() bool {
-	return strings.TrimSpace(c.Addr) != ""
 }
 
 // DatabaseConfig holds configuration for a registered database.

--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -273,7 +273,7 @@ func TestServerConfig_Validate(t *testing.T) {
 			name: "etre target_resolver without databases is valid",
 			cfg: ServerConfig{
 				TargetResolver: TargetResolverConfig{
-					Etre: EtreConfig{
+					Etre: []EtreConfig{{
 						Addr:         "http://etre:8080",
 						DatabaseType: storage.DatabaseTypeMySQL,
 						EntityType:   "aurora_cluster",
@@ -283,7 +283,7 @@ func TestServerConfig_Validate(t *testing.T) {
 							Username:    "spirit",
 							PasswordRef: "env:DDL_PASSWORD",
 						},
-					},
+					}},
 				},
 			},
 			wantErr: false,

--- a/pkg/cmd/commands/serve.go
+++ b/pkg/cmd/commands/serve.go
@@ -445,7 +445,12 @@ func buildEtreResolvers(ctx context.Context, etres []api.EtreConfig, logger *slo
 	if err != nil {
 		return nil, fmt.Errorf("build per-type etre resolver routing: %w", err)
 	}
-	logger.Info("gRPC server routing by per-type etre resolvers", "database_types", len(byType))
+	routedTypes := make([]string, 0, len(byType))
+	for databaseType := range byType {
+		routedTypes = append(routedTypes, databaseType)
+	}
+	sort.Strings(routedTypes)
+	logger.Info("gRPC server routing by per-type etre resolvers", "database_types", routedTypes)
 	return router, nil
 }
 

--- a/pkg/cmd/commands/serve.go
+++ b/pkg/cmd/commands/serve.go
@@ -163,7 +163,7 @@ func (cmd *ServeCmd) Run(g *Globals) error {
 	// resolving their target — not just statically-configured deployments. The gRPC
 	// server below reuses the same instance.
 	var dataPlaneClient tern.Client
-	if serverConfig.TargetResolver.Etre.Configured() || serverConfig.TargetResolver.Configured() {
+	if serverConfig.TargetResolver.Enabled() {
 		dataPlaneClient, err = buildGRPCTernClient(ctx, serverConfig, storage, logger, os.Getenv("TERN_ENVIRONMENT"), svc.WakeOperator)
 		if err != nil {
 			return fmt.Errorf("build data-plane target router: %w", err)
@@ -324,7 +324,7 @@ func buildGRPCTernClient(ctx context.Context, config *api.ServerConfig, st *mysq
 	if len(wakeOperator) > 0 {
 		wake = wakeOperator[0]
 	}
-	etreConfigured := config.TargetResolver.Etre.Configured()
+	etreConfigured := len(config.TargetResolver.Etre) > 0
 	staticConfigured := config.TargetResolver.Configured()
 
 	if etreConfigured && staticConfigured {
@@ -394,18 +394,11 @@ func buildGRPCTernClient(ctx context.Context, config *api.ServerConfig, st *mysq
 }
 
 // buildTargetResolver builds the configured inventory.Resolver — the Etre
-// dynamic backend or the static inventory. The caller guarantees exactly one is
-// configured.
+// dynamic backend(s) or the static inventory. The caller guarantees exactly one
+// kind is configured.
 func buildTargetResolver(ctx context.Context, cfg api.TargetResolverConfig, logger *slog.Logger) (inventory.Resolver, error) {
-	if cfg.Etre.Configured() {
-		resolver, err := buildEtreResolver(ctx, cfg.Etre, logger)
-		if err != nil {
-			return nil, fmt.Errorf("build etre resolver: %w", err)
-		}
-		logger.Info("gRPC server routing by etre resolver",
-			"entity_type", cfg.Etre.EntityType, "target_label", cfg.Etre.TargetLabel,
-			"credentials", credentialType(cfg.Etre.Credentials))
-		return resolver, nil
+	if len(cfg.Etre) > 0 {
+		return buildEtreResolvers(ctx, cfg.Etre, logger)
 	}
 
 	resolver, err := inventory.NewStaticResolver(cfg.StaticInventory())
@@ -414,6 +407,54 @@ func buildTargetResolver(ctx context.Context, cfg api.TargetResolverConfig, logg
 	}
 	logger.Info("gRPC server routing by static target resolver", "targets", len(cfg.Targets))
 	return resolver, nil
+}
+
+// buildEtreResolvers builds the Etre-backed resolver(s). A single block resolves
+// every request directly (engine selected by its database_type). Multiple blocks
+// compose into a TypeRoutingResolver keyed by database type so one data plane
+// serves several engines at once and the request's database type selects the
+// engine. It fails closed when multiple blocks omit a database_type or collide on
+// one, so an ambiguous routing config surfaces at startup, not first request.
+func buildEtreResolvers(ctx context.Context, etres []api.EtreConfig, logger *slog.Logger) (inventory.Resolver, error) {
+	if len(etres) == 1 {
+		resolver, err := buildEtreResolver(ctx, etres[0], logger)
+		if err != nil {
+			return nil, fmt.Errorf("build etre resolver: %w", err)
+		}
+		logEtreResolver(logger, etres[0])
+		return resolver, nil
+	}
+
+	byType := make(map[string]inventory.Resolver, len(etres))
+	for _, cfg := range etres {
+		switch {
+		case cfg.DatabaseType == "":
+			return nil, fmt.Errorf("target_resolver.etre: database_type is required for each resolver when more than one is configured")
+		case byType[cfg.DatabaseType] != nil:
+			return nil, fmt.Errorf("target_resolver.etre: more than one resolver configured for database_type %q", cfg.DatabaseType)
+		}
+		resolver, err := buildEtreResolver(ctx, cfg, logger)
+		if err != nil {
+			return nil, fmt.Errorf("build etre resolver for database_type %q: %w", cfg.DatabaseType, err)
+		}
+		logEtreResolver(logger, cfg)
+		byType[cfg.DatabaseType] = resolver
+	}
+
+	router, err := inventory.NewTypeRoutingResolver(byType)
+	if err != nil {
+		return nil, fmt.Errorf("build per-type etre resolver routing: %w", err)
+	}
+	logger.Info("gRPC server routing by per-type etre resolvers", "database_types", len(byType))
+	return router, nil
+}
+
+// logEtreResolver records that an Etre resolver was built, with the identifiers
+// an operator needs to confirm routing at startup.
+func logEtreResolver(logger *slog.Logger, cfg api.EtreConfig) {
+	logger.Info("gRPC server etre resolver configured",
+		"database_type", cfg.DatabaseType, "entity_type", cfg.EntityType,
+		"target_label", cfg.TargetLabel, "credentials", credentialType(cfg.Credentials))
 }
 
 // buildEtreResolver assembles the Etre-backed resolver from config: the Etre

--- a/pkg/cmd/commands/serve_grpc_test.go
+++ b/pkg/cmd/commands/serve_grpc_test.go
@@ -44,14 +44,14 @@ func TestBuildGRPCTernClientRoutesViaEtreResolver(t *testing.T) {
 	logger := slog.New(slog.DiscardHandler)
 	config := &api.ServerConfig{
 		TargetResolver: api.TargetResolverConfig{
-			Etre: api.EtreConfig{
+			Etre: []api.EtreConfig{{
 				Addr:         "https://etre.example",
 				DatabaseType: storage.DatabaseTypeMySQL,
 				EntityType:   "cluster",
 				TargetLabel:  "dsid",
 				MySQL:        api.EtreMySQLConfig{HostField: "writer_endpoint"},
 				Credentials:  api.EtreCredentialsConfig{Username: "spirit", PasswordRef: "env:DDL_PASSWORD"},
-			},
+			}},
 		},
 	}
 
@@ -67,7 +67,7 @@ func TestBuildGRPCTernClientRoutesViaEtreWithAWSSMCredentials(t *testing.T) {
 	logger := slog.New(slog.DiscardHandler)
 	config := &api.ServerConfig{
 		TargetResolver: api.TargetResolverConfig{
-			Etre: api.EtreConfig{
+			Etre: []api.EtreConfig{{
 				Addr:         "https://etre.example",
 				DatabaseType: storage.DatabaseTypeMySQL,
 				EntityType:   "cluster",
@@ -79,7 +79,7 @@ func TestBuildGRPCTernClientRoutesViaEtreWithAWSSMCredentials(t *testing.T) {
 					RoleARN:    "arn:aws:iam::{account}:role/tern-assumed",
 					SecretName: "schemabot/{target}/ddl",
 				},
-			},
+			}},
 		},
 	}
 
@@ -87,6 +87,75 @@ func TestBuildGRPCTernClientRoutesViaEtreWithAWSSMCredentials(t *testing.T) {
 	require.NoError(t, err)
 	_, ok := client.(*tern.TargetRouter)
 	assert.True(t, ok, "expected a TargetRouter with awssm credentials")
+}
+
+// A data plane that serves more than one engine configures one etre block per
+// database type; they compose into a per-type router that selects the engine
+// from each request's database type.
+func TestBuildTargetResolverComposesPerTypeResolvers(t *testing.T) {
+	logger := slog.New(slog.DiscardHandler)
+	cfg := api.TargetResolverConfig{
+		Etre: []api.EtreConfig{
+			{
+				Addr: "https://etre.example", DatabaseType: storage.DatabaseTypeMySQL,
+				EntityType: "cluster", TargetLabel: "dsid",
+				MySQL:       api.EtreMySQLConfig{HostField: "writer_endpoint"},
+				Credentials: api.EtreCredentialsConfig{Username: "spirit", PasswordRef: "env:DDL_PASSWORD"},
+			},
+			{
+				Addr: "https://etre.example", DatabaseType: storage.DatabaseTypeVitess,
+				EntityType: "keyspace", TargetLabel: "dsid",
+				Vitess:      api.EtreVitessConfig{OrganizationAttribute: "organization"},
+				Credentials: api.EtreCredentialsConfig{PasswordRef: "env:PS_TOKEN"},
+			},
+		},
+	}
+
+	resolver, err := buildTargetResolver(t.Context(), cfg, logger)
+	require.NoError(t, err)
+	_, ok := resolver.(*inventory.TypeRoutingResolver)
+	assert.True(t, ok, "expected a TypeRoutingResolver for multiple per-type etre blocks, got %T", resolver)
+}
+
+// With more than one resolver, each must declare a database_type so the router
+// can select among them; an omitted type is a startup configuration error.
+func TestBuildEtreResolversRejectsMissingDatabaseTypeWhenMultiple(t *testing.T) {
+	logger := slog.New(slog.DiscardHandler)
+	etres := []api.EtreConfig{
+		{
+			Addr: "https://etre.example", DatabaseType: storage.DatabaseTypeMySQL,
+			EntityType: "cluster", TargetLabel: "dsid",
+			MySQL:       api.EtreMySQLConfig{HostField: "writer_endpoint"},
+			Credentials: api.EtreCredentialsConfig{Username: "spirit", PasswordRef: "env:DDL_PASSWORD"},
+		},
+		{
+			Addr:       "https://etre.example", // no database_type
+			EntityType: "cluster", TargetLabel: "dsid",
+			MySQL:       api.EtreMySQLConfig{HostField: "writer_endpoint"},
+			Credentials: api.EtreCredentialsConfig{Username: "spirit", PasswordRef: "env:DDL_PASSWORD"},
+		},
+	}
+
+	_, err := buildEtreResolvers(t.Context(), etres, logger)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "database_type is required")
+}
+
+// Two resolvers claiming the same database type is ambiguous and fails closed at
+// startup rather than letting map iteration order decide which one routes.
+func TestBuildEtreResolversRejectsDuplicateDatabaseType(t *testing.T) {
+	logger := slog.New(slog.DiscardHandler)
+	block := api.EtreConfig{
+		Addr: "https://etre.example", DatabaseType: storage.DatabaseTypeMySQL,
+		EntityType: "cluster", TargetLabel: "dsid",
+		MySQL:       api.EtreMySQLConfig{HostField: "writer_endpoint"},
+		Credentials: api.EtreCredentialsConfig{Username: "spirit", PasswordRef: "env:DDL_PASSWORD"},
+	}
+
+	_, err := buildEtreResolvers(t.Context(), []api.EtreConfig{block, block}, logger)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), storage.DatabaseTypeMySQL)
+	assert.Contains(t, err.Error(), "more than one resolver")
 }
 
 // An unknown credentials.type fails closed at startup.
@@ -248,10 +317,10 @@ func TestBuildGRPCTernClientErrorsWhenEtreAndStaticBothConfigured(t *testing.T) 
 			Targets: map[string]inventory.StaticTarget{
 				"dsid-orders-prod": {DatabaseType: storage.DatabaseTypeMySQL, DSN: "root@tcp(localhost:3306)/"},
 			},
-			Etre: api.EtreConfig{
+			Etre: []api.EtreConfig{{
 				Addr: "https://etre.example", EntityType: "cluster", TargetLabel: "dsid",
 				MySQL: api.EtreMySQLConfig{HostField: "writer_endpoint"}, Credentials: api.EtreCredentialsConfig{Username: "spirit", PasswordRef: "env:DDL_PASSWORD"},
-			},
+			}},
 		},
 	}
 


### PR DESCRIPTION
## Why this matters

A data-plane server (`serve --grpc`) backed by a dynamic resolver could configure only a single Etre resolver, bound to one engine. A deployment that serves more than one engine — for example MySQL and Vitess from the same data plane — had no way to route by engine.

## What it does

`target_resolver.etre` is now a **list** of resolver blocks instead of a single block.

- **One block** resolves every request directly — unchanged behavior, no new per-request requirement.
- **Multiple blocks** compose into a `TypeRoutingResolver` keyed by each block's `database_type`; the request's database type selects the engine.

Routing ambiguity fails closed at startup rather than on the first request: with more than one block, each must declare a `database_type`, and two blocks may not claim the same type.

```
target_resolver:
  etre:
    - database_type: mysql
      addr: env:ETRE_ADDR
      mysql: { host_field: writer_endpoint }
      credentials: { ... }
    - database_type: vitess
      addr: env:ETRE_ADDR
      vitess: { organization_attribute: organization }
      credentials: { ... }
```

This is a breaking change to the `target_resolver.etre` config shape (single block → list); single-engine configs become a one-element list.