### PR TITLE
feat(github): support environment schema root symlinks

### DIFF
--- a/pkg/github/config_test.go
+++ b/pkg/github/config_test.go
@@ -354,6 +354,148 @@ func TestFetchSchemaFilesOptimizedWalksSchemaDirectoryOnly(t *testing.T) {
 	assert.Equal(t, "apps/widgets/schema/main/widgets.sql", files[2].Path)
 }
 
+func TestCreateSchemaRequestFromPRUsesEnvironmentSymlinkSchemaRoot(t *testing.T) {
+	client, mux := setupConfigTestGitHubServer(t)
+	registerPullRequest(t, mux, "abc123")
+	registerPullRequestFiles(t, mux, []*gh.CommitFile{{
+		Filename: new("services/orders/schema/schemabot.yaml"),
+		Status:   new("modified"),
+	}, {
+		Filename: new("services/orders/schema/base/orders_001/orders.sql"),
+		Status:   new("added"),
+	}})
+	registerFileContent(t, mux, "/repos/octocat/hello-world/contents/services/orders/schema/schemabot.yaml", "database: orders\ntype: mysql\n")
+	registerSymlinkContent(t, mux, "/repos/octocat/hello-world/contents/services/orders/schema/production", "services/orders/schema/production", "base")
+	registerDirectoryContent(t, mux, "/repos/octocat/hello-world/contents/services/orders/schema/base", []*gh.RepositoryContent{
+		{Type: new("dir"), Name: new("orders_001"), Path: new("services/orders/schema/base/orders_001")},
+	})
+	registerDirectoryContent(t, mux, "/repos/octocat/hello-world/contents/services/orders/schema/base/orders_001", []*gh.RepositoryContent{
+		{Type: new("file"), Name: new("orders.sql"), Path: new("services/orders/schema/base/orders_001/orders.sql")},
+	})
+	registerFileContent(t, mux, "/repos/octocat/hello-world/contents/services/orders/schema/base/orders_001/orders.sql", "CREATE TABLE orders (id bigint primary key);\n")
+
+	ic := NewInstallationClient(client, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	result, err := ic.CreateSchemaRequestFromPR(t.Context(), "octocat/hello-world", 1, "production", "", nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, "orders", result.Database)
+	assert.Equal(t, "mysql", result.Type)
+	assert.Equal(t, "services/orders/schema/base", result.SchemaPath)
+	require.Contains(t, result.SchemaFiles, "orders_001")
+	assert.Equal(t, "CREATE TABLE orders (id bigint primary key);\n", result.SchemaFiles["orders_001"].Files["orders.sql"])
+}
+
+func TestCreateSchemaRequestFromPRUsesRepoRootEnvironmentSymlinkSchemaRoot(t *testing.T) {
+	client, mux := setupConfigTestGitHubServer(t)
+	registerPullRequest(t, mux, "abc123")
+	registerPullRequestFiles(t, mux, []*gh.CommitFile{{
+		Filename: new("schemabot.yaml"),
+		Status:   new("modified"),
+	}, {
+		Filename: new("base/orders_001/orders.sql"),
+		Status:   new("added"),
+	}})
+	registerFileContent(t, mux, "/repos/octocat/hello-world/contents/schemabot.yaml", "database: orders\ntype: mysql\n")
+	registerSymlinkContent(t, mux, "/repos/octocat/hello-world/contents/production", "production", "base")
+	registerDirectoryContent(t, mux, "/repos/octocat/hello-world/contents/base", []*gh.RepositoryContent{
+		{Type: new("dir"), Name: new("orders_001"), Path: new("base/orders_001")},
+	})
+	registerDirectoryContent(t, mux, "/repos/octocat/hello-world/contents/base/orders_001", []*gh.RepositoryContent{
+		{Type: new("file"), Name: new("orders.sql"), Path: new("base/orders_001/orders.sql")},
+	})
+	registerFileContent(t, mux, "/repos/octocat/hello-world/contents/base/orders_001/orders.sql", "CREATE TABLE orders (id bigint primary key);\n")
+
+	ic := NewInstallationClient(client, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	result, err := ic.CreateSchemaRequestFromPR(t.Context(), "octocat/hello-world", 1, "production", "", nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, "orders", result.Database)
+	assert.Equal(t, "base", result.SchemaPath)
+	require.Contains(t, result.SchemaFiles, "orders_001")
+	assert.Equal(t, "CREATE TABLE orders (id bigint primary key);\n", result.SchemaFiles["orders_001"].Files["orders.sql"])
+}
+
+func TestResolveSchemaRootForEnvironmentRejectsPathTraversal(t *testing.T) {
+	ic := &InstallationClient{}
+	for _, environment := range []string{"../other", "prod/blue", ".", "..", `prod\blue`} {
+		t.Run(environment, func(t *testing.T) {
+			_, err := ic.resolveSchemaRootForEnvironment(t.Context(), "octocat/hello-world", "abc123", "services/orders/schema", environment)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "must be a single path segment")
+		})
+	}
+}
+
+func TestCreateSchemaRequestFromPRFallsBackWhenEnvironmentSchemaRootMissing(t *testing.T) {
+	client, mux := setupConfigTestGitHubServer(t)
+	registerPullRequest(t, mux, "abc123")
+	registerPullRequestFiles(t, mux, []*gh.CommitFile{{
+		Filename: new("apps/widgets/schema/main/widgets.sql"),
+		Status:   new("modified"),
+	}})
+	registerFileContent(t, mux, "/repos/octocat/hello-world/contents/apps/widgets/schema/schemabot.yaml", "database: widgets\ntype: vitess\n")
+	registerDirectoryContent(t, mux, "/repos/octocat/hello-world/contents/apps/widgets/schema", []*gh.RepositoryContent{
+		{Type: new("dir"), Name: new("main"), Path: new("apps/widgets/schema/main")},
+	})
+	registerDirectoryContent(t, mux, "/repos/octocat/hello-world/contents/apps/widgets/schema/main", []*gh.RepositoryContent{
+		{Type: new("file"), Name: new("widgets.sql"), Path: new("apps/widgets/schema/main/widgets.sql")},
+	})
+	registerFileContent(t, mux, "/repos/octocat/hello-world/contents/apps/widgets/schema/main/widgets.sql", "CREATE TABLE widgets (id bigint primary key);\n")
+
+	ic := NewInstallationClient(client, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	result, err := ic.CreateSchemaRequestFromPR(t.Context(), "octocat/hello-world", 1, "production", "", nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, "apps/widgets/schema", result.SchemaPath)
+	require.Contains(t, result.SchemaFiles, "main")
+	assert.Equal(t, "CREATE TABLE widgets (id bigint primary key);\n", result.SchemaFiles["main"].Files["widgets.sql"])
+}
+
+func TestCreateSchemaRequestFromPRValidatesEnvironmentBeforeResolvingEnvironmentSchemaRoot(t *testing.T) {
+	client, mux := setupConfigTestGitHubServer(t)
+	registerPullRequest(t, mux, "abc123")
+	registerPullRequestFiles(t, mux, []*gh.CommitFile{{
+		Filename: new("services/orders/schema/schemabot.yaml"),
+		Status:   new("modified"),
+	}})
+	registerFileContent(t, mux, "/repos/octocat/hello-world/contents/services/orders/schema/schemabot.yaml", "database: orders\ntype: mysql\n")
+	environmentRootRequests := 0
+	mux.HandleFunc("GET /repos/octocat/hello-world/contents/services/orders/schema/production", func(w http.ResponseWriter, _ *http.Request) {
+		environmentRootRequests++
+		require.NoError(t, json.NewEncoder(w).Encode([]*gh.RepositoryContent{
+			{Type: new("dir"), Name: new("orders_001"), Path: new("services/orders/schema/production/orders_001")},
+		}))
+	})
+
+	validationErr := errors.New("environment rejected")
+	ic := NewInstallationClient(client, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	_, err := ic.CreateSchemaRequestFromPR(t.Context(), "octocat/hello-world", 1, "production", "", func(database, environment string) error {
+		assert.Equal(t, "orders", database)
+		assert.Equal(t, "production", environment)
+		return validationErr
+	})
+
+	require.ErrorIs(t, err, validationErr)
+	assert.Zero(t, environmentRootRequests)
+}
+
+func TestCreateSchemaRequestFromPRRejectsEnvironmentSymlinkOutsideSchemaDirectory(t *testing.T) {
+	client, mux := setupConfigTestGitHubServer(t)
+	registerPullRequest(t, mux, "abc123")
+	registerPullRequestFiles(t, mux, []*gh.CommitFile{{
+		Filename: new("apps/widgets/schema/schemabot.yaml"),
+		Status:   new("modified"),
+	}})
+	registerFileContent(t, mux, "/repos/octocat/hello-world/contents/apps/widgets/schema/schemabot.yaml", "database: widgets\ntype: vitess\n")
+	registerSymlinkContent(t, mux, "/repos/octocat/hello-world/contents/apps/widgets/schema/production", "apps/widgets/schema/production", "../other")
+
+	ic := NewInstallationClient(client, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	_, err := ic.CreateSchemaRequestFromPR(t.Context(), "octocat/hello-world", 1, "production", "", nil)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "points outside schema directory")
+}
+
 // TestFindConfigForPR_AuthFailureDoesNotFallThroughToNoConfig verifies that
 // auth errors propagate instead of being swallowed as ErrNoConfig.
 func TestFindConfigForPR_AuthFailureDoesNotFallThroughToNoConfig(t *testing.T) {
@@ -435,6 +577,18 @@ func registerFileContent(t *testing.T, mux *http.ServeMux, endpointPath, content
 			Type:     new("file"),
 			Encoding: new("base64"),
 			Content:  new(base64.StdEncoding.EncodeToString([]byte(content))),
+		}))
+	})
+}
+
+func registerSymlinkContent(t *testing.T, mux *http.ServeMux, endpointPath, linkPath, target string) {
+	t.Helper()
+
+	mux.HandleFunc("GET "+endpointPath, func(w http.ResponseWriter, _ *http.Request) {
+		require.NoError(t, json.NewEncoder(w).Encode(gh.RepositoryContent{
+			Type:   new("symlink"),
+			Path:   new(linkPath),
+			Target: new(target),
 		}))
 	})
 }

--- a/pkg/github/schema.go
+++ b/pkg/github/schema.go
@@ -9,6 +9,7 @@ import (
 
 	ternv1 "github.com/block/schemabot/pkg/proto/ternv1"
 	"github.com/block/schemabot/pkg/schema"
+	gh "github.com/google/go-github/v86/github"
 )
 
 // SchemaRequestResult contains everything needed to execute a plan from a PR.
@@ -23,8 +24,13 @@ type SchemaRequestResult struct {
 	HeadSHA      string // Commit SHA used to fetch schema files
 }
 
+// EnvironmentValidator verifies that a discovered database can be used with
+// the requested environment before the environment is used to resolve schema
+// files in the repository.
+type EnvironmentValidator func(database, environment string) error
+
 // CreateSchemaRequestFromPR discovers config, fetches schema files, and builds a plan request.
-func (ic *InstallationClient) CreateSchemaRequestFromPR(ctx context.Context, repo string, pr int, environment, databaseName string) (*SchemaRequestResult, error) {
+func (ic *InstallationClient) CreateSchemaRequestFromPR(ctx context.Context, repo string, pr int, environment, databaseName string, validateEnvironment EnvironmentValidator) (*SchemaRequestResult, error) {
 	var config *SchemabotConfig
 	var configDir string
 	var err error
@@ -40,23 +46,35 @@ func (ic *InstallationClient) CreateSchemaRequestFromPR(ctx context.Context, rep
 	if err != nil {
 		return nil, err
 	}
+	if validateEnvironment != nil {
+		if err := validateEnvironment(config.Database, environment); err != nil {
+			return nil, err
+		}
+	}
 
 	// Get PR info for head SHA
 	prInfo, err := ic.FetchPullRequest(ctx, repo, pr)
 	if err != nil {
 		return nil, fmt.Errorf("fetch PR info: %w", err)
 	}
+	schemaRoot, err := ic.resolveSchemaRootForEnvironment(ctx, repo, prInfo.HeadSHA, configDir, environment)
+	if err != nil {
+		return nil, err
+	}
 
 	// Fetch schema files using optimized Tree API + parallel fetching
-	files, err := ic.FetchSchemaFilesOptimized(ctx, repo, prInfo.HeadSHA, configDir, string(config.GetType()))
+	files, err := ic.FetchSchemaFilesOptimized(ctx, repo, prInfo.HeadSHA, schemaRoot, string(config.GetType()))
 	if err != nil {
-		return nil, fmt.Errorf("fetch schema files from %s: %w", configDir, err)
+		return nil, fmt.Errorf("fetch schema files from %s: %w", schemaRoot, err)
 	}
 
 	// Group files by keyspace/namespace
-	schemaFiles, err := groupFilesByNamespace(files, configDir, environment)
+	schemaFiles, err := groupFilesByNamespace(files, schemaRoot, environment)
 	if err != nil {
 		return nil, err
+	}
+	if len(schemaFiles) == 0 {
+		return nil, fmt.Errorf("no schema files found under %s for environment %q", schemaRoot, environment)
 	}
 
 	return &SchemaRequestResult{
@@ -65,9 +83,104 @@ func (ic *InstallationClient) CreateSchemaRequestFromPR(ctx context.Context, rep
 		SchemaFiles: schemaFiles,
 		Repository:  repo,
 		PullRequest: pr,
-		SchemaPath:  configDir,
+		SchemaPath:  schemaRoot,
 		HeadSHA:     prInfo.HeadSHA,
 	}, nil
+}
+
+func (ic *InstallationClient) resolveSchemaRootForEnvironment(ctx context.Context, repo, ref, configDir, environment string) (string, error) {
+	if environment == "" {
+		return configDir, nil
+	}
+	if err := validateEnvironmentPathSegment(environment); err != nil {
+		return "", err
+	}
+
+	candidate := path.Join(configDir, environment)
+	content, directoryContent, err := ic.fetchRepositoryContents(ctx, repo, candidate, ref)
+	if err != nil {
+		if IsNotFoundError(err) {
+			return configDir, nil
+		}
+		return "", fmt.Errorf("resolve schema root for environment %s at %s: %w", environment, candidate, err)
+	}
+	if directoryContent != nil {
+		return candidate, nil
+	}
+	if content == nil || content.GetType() != "symlink" {
+		return "", fmt.Errorf("environment schema root %s in repo %s ref %s is not a directory or symlink", candidate, repo, ref)
+	}
+
+	resolved, err := resolveSchemaRootSymlinkTarget(configDir, candidate, content.GetTarget())
+	if err != nil {
+		return "", err
+	}
+	resolvedContent, resolvedDirectoryContent, err := ic.fetchRepositoryContents(ctx, repo, resolved, ref)
+	if err != nil {
+		return "", fmt.Errorf("resolve environment schema root symlink %s target %s: %w", candidate, resolved, err)
+	}
+	if resolvedContent != nil || resolvedDirectoryContent == nil {
+		return "", fmt.Errorf("environment schema root symlink %s points to non-directory path %s", candidate, resolved)
+	}
+	return resolved, nil
+}
+
+func validateEnvironmentPathSegment(environment string) error {
+	if environment == "." || environment == ".." || strings.ContainsAny(environment, `/\`) {
+		return fmt.Errorf("environment %q must be a single path segment", environment)
+	}
+	return nil
+}
+
+func (ic *InstallationClient) fetchRepositoryContents(ctx context.Context, repo, filePath, ref string) (*gh.RepositoryContent, []*gh.RepositoryContent, error) {
+	owner, repoName := splitRepo(repo)
+	opts := &gh.RepositoryContentGetOptions{Ref: ref}
+	readResult, err := retryGitHubUnavailableRead(ctx, ic.logger, "fetch repository content", []any{"repo", repo, "path", filePath, "ref", ref}, func(ctx context.Context) (struct {
+		fileContent      *gh.RepositoryContent
+		directoryContent []*gh.RepositoryContent
+	}, error) {
+		fileContent, directoryContent, _, err := ic.client.Repositories.GetContents(ctx, owner, repoName, filePath, opts)
+		if err != nil {
+			return struct {
+				fileContent      *gh.RepositoryContent
+				directoryContent []*gh.RepositoryContent
+			}{}, fmt.Errorf("fetch repository content at %s: %w", filePath, classifyGitHubAPIError(err))
+		}
+		return struct {
+			fileContent      *gh.RepositoryContent
+			directoryContent []*gh.RepositoryContent
+		}{fileContent: fileContent, directoryContent: directoryContent}, nil
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	return readResult.fileContent, readResult.directoryContent, nil
+}
+
+func resolveSchemaRootSymlinkTarget(configDir, symlinkPath, target string) (string, error) {
+	target = strings.TrimSpace(target)
+	if target == "" {
+		return "", fmt.Errorf("environment schema root symlink %s has empty target", symlinkPath)
+	}
+	if strings.HasPrefix(target, "/") {
+		return "", fmt.Errorf("environment schema root symlink %s points to absolute path %s", symlinkPath, target)
+	}
+
+	resolved := path.Clean(path.Join(path.Dir(symlinkPath), target))
+	cleanConfigDir := path.Clean(configDir)
+	if !schemaPathWithinDirectory(cleanConfigDir, resolved) {
+		return "", fmt.Errorf("environment schema root symlink %s points outside schema directory: %s", symlinkPath, target)
+	}
+	return resolved, nil
+}
+
+func schemaPathWithinDirectory(directory, candidate string) bool {
+	directory = path.Clean(directory)
+	candidate = path.Clean(candidate)
+	if directory == "." {
+		return candidate == "." || candidate != ".." && !strings.HasPrefix(candidate, "../") && !strings.HasPrefix(candidate, "/")
+	}
+	return candidate == directory || strings.HasPrefix(candidate, directory+"/")
 }
 
 // groupFilesByNamespace groups fetched files into the proto SchemaFiles format.

--- a/pkg/webhook/check_aggregate_test.go
+++ b/pkg/webhook/check_aggregate_test.go
@@ -84,6 +84,31 @@ func TestComputeAggregate(t *testing.T) {
 	}
 }
 
+func TestValidateRequestedDatabaseEnvironmentUsesServerConfig(t *testing.T) {
+	service := api.New(&emptyStorage{}, &api.ServerConfig{
+		Databases: map[string]api.DatabaseConfig{
+			"orders": {
+				Environments: map[string]api.EnvironmentConfig{
+					"production": {Deployment: "default", Target: "orders"},
+				},
+			},
+		},
+	}, nil, testLogger())
+	t.Cleanup(func() { utils.CloseAndLog(service) })
+	h := &Handler{service: service}
+
+	assert.NoError(t, h.validateRequestedDatabaseEnvironment("orders", "production"))
+	assert.NoError(t, h.validateRequestedDatabaseEnvironment("orders", ""))
+
+	err := h.validateRequestedDatabaseEnvironment("orders", "staging")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `database "orders" environment "staging" is not configured on this server`)
+
+	err = h.validateRequestedDatabaseEnvironment("payments", "production")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `database "payments" is not configured on this server`)
+}
+
 func TestIsAggregateCheck(t *testing.T) {
 	t.Run("global aggregate", func(t *testing.T) {
 		aggregate := &storage.Check{

--- a/pkg/webhook/schema_source_policy.go
+++ b/pkg/webhook/schema_source_policy.go
@@ -3,6 +3,7 @@ package webhook
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	ghclient "github.com/block/schemabot/pkg/github"
 	"github.com/block/schemabot/pkg/metrics"
@@ -30,7 +31,7 @@ func newSchemaConfigOutsideAllowedDirsError(config *ghclient.SchemabotConfig, sc
 }
 
 func (h *Handler) createManagedSchemaRequestFromPR(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, environment, databaseName, source string) (*ghclient.SchemaRequestResult, error) {
-	schemaResult, err := client.CreateSchemaRequestFromPR(ctx, repo, pr, environment, databaseName)
+	schemaResult, err := client.CreateSchemaRequestFromPR(ctx, repo, pr, environment, databaseName, h.validateRequestedDatabaseEnvironment)
 	if err != nil {
 		return nil, err
 	}
@@ -42,6 +43,20 @@ func (h *Handler) createManagedSchemaRequestFromPR(ctx context.Context, client *
 		}
 	}
 	return schemaResult, nil
+}
+
+func (h *Handler) validateRequestedDatabaseEnvironment(database, environment string) error {
+	if environment == "" {
+		return nil
+	}
+	environments, err := h.configuredDatabaseEnvironments(database)
+	if err != nil {
+		return fmt.Errorf("resolve configured environments for database %q: %w", database, err)
+	}
+	if slices.Contains(environments, environment) {
+		return nil
+	}
+	return fmt.Errorf("database %q environment %q is not configured on this server", database, environment)
 }
 
 func (h *Handler) configPathManagedByRepo(ctx context.Context, repo string, pr int, headSHA string, config *ghclient.SchemabotConfig, schemaPath, source string) bool {


### PR DESCRIPTION
## Why
Some repositories use an environment path as the schema root selector, with that path pointing at a shared schema directory until environments diverge. SchemaBot should resolve that layout before planning instead of sending an empty schema file set downstream.

## What
- Resolve `<schema directory>/<environment>` before fetching schema files
- Support environment roots that are either directories or repo-local symlinks
- Fail early when the resolved schema root has no schema files

## Risk Assessment
Low — repositories without an environment root keep the existing schema directory behavior, and invalid symlink targets fail closed before planning.

Generated with Amp