### PR TITLE
feat(operator): drive multi-operation applies under the operation lease only

### DIFF
--- a/pkg/api/operator.go
+++ b/pkg/api/operator.go
@@ -268,6 +268,52 @@ func (s *Service) recoverApplyOperation(ctx context.Context, workerID int, owner
 		return
 	}
 
+	// Branch on the operation count. A single-operation apply keeps the legacy
+	// parent-lease drive byte-for-byte. A multi-operation apply drives under the
+	// operation lease only: siblings must not serialize on a shared parent lease,
+	// and the parent applies.state is moved solely by the projection CAS.
+	ops, err := s.storage.ApplyOperations().ListByApply(ctx, op.ApplyID)
+	if err != nil {
+		s.logger.Error("operator: failed to list operations for claimed apply; operation will not be driven",
+			"worker", workerID, "lease_owner", owner, "apply_operation_id", op.ID,
+			"apply_db_id", op.ApplyID, "deployment", op.Deployment, "error", err)
+		metrics.RecordOperatorClaimFailure(ctx, "operation_set_list_error")
+		return
+	}
+	if !operationSetContainsID(ops, op.ID) {
+		s.logger.Error("operator: claimed operation is not part of its apply's operation set; operation will not be driven",
+			"worker", workerID, "lease_owner", owner, "apply_operation_id", op.ID,
+			"apply_db_id", op.ApplyID, "deployment", op.Deployment, "operation_count", len(ops))
+		metrics.RecordOperatorClaimFailure(ctx, "operation_set_missing")
+		return
+	}
+	if len(ops) > 1 {
+		s.recoverMultiApplyOperation(ctx, workerID, op, opLease)
+		return
+	}
+
+	s.recoverSingleApplyOperation(ctx, workerID, owner, op, opLease)
+}
+
+// operationSetContainsID reports whether id is one of the apply's operation
+// rows, used to confirm the claimed operation still belongs to the apply set
+// before driving it.
+func operationSetContainsID(ops []*storage.ApplyOperation, id int64) bool {
+	for _, op := range ops {
+		if op.ID == id {
+			return true
+		}
+	}
+	return false
+}
+
+// recoverSingleApplyOperation drives a single-operation apply on the legacy
+// parent-lease path: it claims the parent apply lease, runs the engine under the
+// dual (apply + operation) lease so the engine writes the parent applies row
+// directly, fires the per-driver terminal observer, and re-derives the parent
+// from the operation rows afterward. This path is byte-for-byte the pre-fan-out
+// behavior.
+func (s *Service) recoverSingleApplyOperation(ctx context.Context, workerID int, owner string, op *storage.ApplyOperation, opLease storage.OperationLease) {
 	// The engine drive still writes the parent applies row (state RUNNING /
 	// COMPLETED / FAILED), and the derived-state reconcile updates
 	// applies.state, so the worker must also hold the parent apply lease — the
@@ -434,6 +480,137 @@ func (s *Service) recoverApplyOperation(ctx context.Context, workerID int, owner
 	// pending, complete it now so the request does not linger after the rollout
 	// has stopped.
 	if err := s.completePendingStopIfApplyResolved(applyLeaseCtx, workerID, finalApply.ID); err != nil {
+		s.logger.Error("operator: failed to complete pending stop request for resolved apply",
+			"worker", workerID, "apply_operation_id", op.ID, "apply_id", finalApply.ApplyIdentifier,
+			"deployment", op.Deployment, "environment", finalApply.Environment, "error", err)
+		return
+	}
+}
+
+// recoverMultiApplyOperation drives one operation of a multi-operation apply
+// under the operation lease only. It never claims the parent apply lease, so
+// sibling operations no longer serialize on a shared parent token. The engine
+// drive is suppressed from writing the parent applies row (the gRPC/local
+// drivers skip parent writes for operation-scoped multi-op drives), and the
+// per-driver terminal observer is disabled; the parent applies.state is moved
+// solely by the operation-authorized projection CAS. The operation row is
+// driven from its own tasks, then the parent is re-derived from the operation
+// rows.
+func (s *Service) recoverMultiApplyOperation(ctx context.Context, workerID int, op *storage.ApplyOperation, opLease storage.OperationLease) {
+	operationLeaseCtx := storage.WithOperationLease(ctx, opLease)
+
+	apply, err := s.storage.Applies().Get(operationLeaseCtx, op.ApplyID)
+	if err != nil {
+		s.logger.Error("operator: failed to load parent apply for operation drive; operation will not be driven",
+			"worker", workerID, "apply_operation_id", op.ID, "apply_db_id", op.ApplyID,
+			"deployment", op.Deployment, "error", err)
+		metrics.RecordOperatorClaimFailure(ctx, "operation_parent_load_error")
+		return
+	}
+	if apply == nil {
+		s.logger.Error("operator: parent apply not found for claimed operation; operation will not be driven",
+			"worker", workerID, "apply_operation_id", op.ID, "apply_db_id", op.ApplyID,
+			"deployment", op.Deployment)
+		metrics.RecordOperatorClaimFailure(ctx, "operation_parent_missing")
+		return
+	}
+
+	// The claimed operation row's deployment is the authoritative routing key; an
+	// empty deployment is a corrupt row with no routing key, so fail closed.
+	if op.Deployment == "" {
+		s.logger.Error("operator: claimed operation is missing deployment metadata; operation will not be driven",
+			"worker", workerID, "apply_operation_id", op.ID, "apply_id", apply.ApplyIdentifier,
+			"database", apply.Database, "environment", apply.Environment)
+		metrics.RecordOperatorClaimFailure(ctx, "missing_operation_deployment")
+		return
+	}
+
+	// Move the parent pending→running via the projection CAS before the drive.
+	// The claim already set this operation running, so the projection reflects an
+	// in-flight rollout; the driver no longer writes the parent running for
+	// multi-op, so without this the parent would linger pending during a long
+	// drive. The op lease authorizes the derived-state CAS.
+	if _, err := s.updateApplyStateFromOperations(operationLeaseCtx, workerID, apply, allowLeaseScopedFailedReopen); err != nil {
+		s.logger.Error("operator: failed to project parent running before operation drive; operation will not be driven",
+			"worker", workerID, "apply_operation_id", op.ID, "apply_id", apply.ApplyIdentifier,
+			"database", apply.Database, "environment", apply.Environment, "error", err)
+		return
+	}
+
+	// Heartbeat the operation row on the apply heartbeat cadence so a peer worker
+	// does not re-claim it during a long drive. The heartbeat writes under the
+	// operation lease, so a lost operation lease cancels the run.
+	runCtx, cancelRun := context.WithCancel(operationLeaseCtx)
+	defer cancelRun()
+	stopHeartbeat := s.startApplyOperationHeartbeat(runCtx, workerID, op, apply, cancelRun)
+	defer stopHeartbeat()
+
+	// Suppress the per-driver terminal observer: the aggregate terminal summary
+	// is published once by the projection CAS winner, not per deployment.
+	resumed, resumeErr := s.resumeClaimedApplyWithOptions(runCtx, workerID, apply, op.ID, op.Deployment,
+		resumeClaimedApplyOptions{suppressRecoveredObserver: true})
+	stopHeartbeat()
+	if !resumed && errors.Is(resumeErr, tern.ErrNoTasksForApplyOperation) {
+		// The drive failed closed: the operation has no tasks, so it can never
+		// make progress. Terminalize it now rather than leaving it to be
+		// re-leased on every poll once its heartbeat goes stale.
+		s.failOperationWithoutTasks(operationLeaseCtx, operationLeaseCtx, workerID, op, apply)
+		return
+	}
+
+	// Persist the operation row from its OWN tasks — even when the drive returned
+	// an error. Unlike the single-op path, a multi-op drive has no
+	// reconcileUnclaimableParent fallback (it never claims the parent), so a
+	// remote rejection that durably failed this operation's tasks must be
+	// promoted to the operation row here or the operation would stay running and
+	// be re-leased forever. markOperationFromOwnResult derives the operation from
+	// its tasks: a still-running task set leaves it claimable (a benign no-op),
+	// while a terminal task set terminalizes it.
+	marked, err := s.markOperationFromOwnResult(operationLeaseCtx, workerID, op)
+	if err != nil {
+		s.logger.Error("operator: failed to update apply_operation from its tasks; derived apply state not updated",
+			"worker", workerID, "apply_operation_id", op.ID, "apply_id", apply.ApplyIdentifier,
+			"deployment", op.Deployment, "environment", apply.Environment, "error", err)
+		return
+	}
+	if !marked {
+		return
+	}
+
+	// If a stop is pending, terminalize any still-pending sibling operations to
+	// stopped before deriving the parent, so the rollout can settle. Authorized
+	// by this operation's own lease (the 6a op-lease branch).
+	if err := s.stopPendingOperationsForPendingStop(operationLeaseCtx, workerID, apply); err != nil {
+		s.logger.Error("operator: failed to stop pending sibling operations for pending stop request; derived apply state not updated",
+			"worker", workerID, "apply_operation_id", op.ID, "apply_id", apply.ApplyIdentifier,
+			"deployment", op.Deployment, "environment", apply.Environment, "error", err)
+		return
+	}
+
+	// Reload the parent so the projection re-derives against the durable
+	// apply.State (its terminal-to-non-terminal guard), then move it via the CAS.
+	finalApply, err := s.storage.Applies().Get(operationLeaseCtx, apply.ID)
+	if err != nil {
+		s.logger.Error("operator: failed to reload parent apply after operation drive; derived apply state not updated",
+			"worker", workerID, "apply_operation_id", op.ID, "apply_id", apply.ApplyIdentifier,
+			"deployment", op.Deployment, "error", err)
+		return
+	}
+	if finalApply == nil {
+		s.logger.Error("operator: parent apply not found after operation drive; derived apply state not updated",
+			"worker", workerID, "apply_operation_id", op.ID, "apply_id", apply.ApplyIdentifier,
+			"deployment", op.Deployment)
+		return
+	}
+
+	if _, err := s.updateApplyStateFromOperations(operationLeaseCtx, workerID, finalApply, allowLeaseScopedFailedReopen); err != nil {
+		s.logger.Error("operator: failed to update derived apply state from apply_operations",
+			"worker", workerID, "apply_operation_id", op.ID, "apply_id", finalApply.ApplyIdentifier,
+			"deployment", op.Deployment, "environment", finalApply.Environment, "error", err)
+		return
+	}
+
+	if err := s.completePendingStopIfApplyResolved(operationLeaseCtx, workerID, finalApply.ID); err != nil {
 		s.logger.Error("operator: failed to complete pending stop request for resolved apply",
 			"worker", workerID, "apply_operation_id", op.ID, "apply_id", finalApply.ApplyIdentifier,
 			"deployment", op.Deployment, "environment", finalApply.Environment, "error", err)
@@ -675,6 +852,19 @@ func (s *Service) failOperationWithoutTasks(opCtx, applyCtx context.Context, wor
 // operation terminal, and the returned error lets it distinguish the fail-closed
 // no-tasks case (tern.ErrNoTasksForApplyOperation) from transient failures.
 func (s *Service) resumeClaimedApply(ctx context.Context, workerID int, apply *storage.Apply, applyOperationID int64, operationDeployment string) (bool, error) {
+	return s.resumeClaimedApplyWithOptions(ctx, workerID, apply, applyOperationID, operationDeployment, resumeClaimedApplyOptions{})
+}
+
+// resumeClaimedApplyOptions tunes a drive for the multi-operation path.
+type resumeClaimedApplyOptions struct {
+	// suppressRecoveredObserver skips the per-driver progress/terminal observer
+	// hook. A multi-operation drive owns only its operation; the aggregate
+	// terminal summary is published once by the projection CAS winner, not per
+	// deployment, so the per-driver observer must not fire.
+	suppressRecoveredObserver bool
+}
+
+func (s *Service) resumeClaimedApplyWithOptions(ctx context.Context, workerID int, apply *storage.Apply, applyOperationID int64, operationDeployment string, opts resumeClaimedApplyOptions) (bool, error) {
 	lease := apply.Lease()
 	start := s.clock.Now()
 
@@ -731,7 +921,7 @@ func (s *Service) resumeClaimedApply(ctx context.Context, workerID int, apply *s
 		return false, err
 	}
 
-	if s.OnApplyRecovered != nil {
+	if s.OnApplyRecovered != nil && !opts.suppressRecoveredObserver {
 		s.OnApplyRecovered(apply)
 	}
 

--- a/pkg/api/operator_test.go
+++ b/pkg/api/operator_test.go
@@ -108,6 +108,44 @@ func TestResumeClaimedApplyRoutesRecoveredObserver(t *testing.T) {
 	assert.Equal(t, observer, deploymentClient.observer)
 }
 
+// A multi-operation drive must not register the per-driver progress/terminal
+// observer: the aggregate terminal summary is published once by the projection
+// CAS winner, not per deployment. resumeClaimedApplyWithOptions suppresses the
+// OnApplyRecovered hook so no observer is set for the drive.
+func TestResumeClaimedApplyWithOptions_SuppressesRecoveredObserverForMultiOp(t *testing.T) {
+	deploymentClient := &mockTernClient{}
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	svc := New(&mockStorageWithApplyStores{
+		plans:   &staticPlanStore{},
+		applies: &staticApplyStore{},
+	}, &ServerConfig{}, map[string]tern.Client{
+		"east/staging": deploymentClient,
+	}, logger)
+	observerSet := false
+	svc.OnApplyRecovered = func(apply *storage.Apply) {
+		observerSet = true
+		svc.SetApplyObserver(apply.Database, apply.Deployment, apply.Environment, apply.ID, noopProgressObserver{})
+	}
+	apply := &storage.Apply{
+		ID:              42,
+		ApplyIdentifier: "apply-42",
+		Database:        "appdb",
+		Deployment:      "east",
+		Environment:     "staging",
+		State:           state.Apply.Pending,
+	}
+
+	resumed, err := svc.resumeClaimedApplyWithOptions(t.Context(), 1, apply, 0, "east",
+		resumeClaimedApplyOptions{suppressRecoveredObserver: true})
+
+	require.NoError(t, err)
+	assert.True(t, resumed)
+	assert.Same(t, apply, deploymentClient.resumeApply)
+	assert.False(t, observerSet, "a multi-op drive must not fire the per-driver observer hook")
+	assert.Zero(t, deploymentClient.observerApplyID, "no observer must be registered for a multi-op drive")
+	assert.Nil(t, deploymentClient.observer)
+}
+
 // TestMarkOperationFromApplyState_MirrorsFailedRetryable verifies that a parent
 // apply in failed_retryable mirrors that state (not a terminal one) onto the
 // operation row via UpdateState, leaving it reclaimable for retry. Returning

--- a/pkg/tern/grpc_client.go
+++ b/pkg/tern/grpc_client.go
@@ -693,7 +693,7 @@ func (c *GRPCClient) processPendingStopControlRequest(ctx context.Context, apply
 	if err := c.syncStoredTasksFromRemoteTasks(ctx, apply, storedTasks, progress.Tables, now); err != nil {
 		return true, err
 	}
-	if err := c.storage.Applies().Update(ctx, apply); err != nil {
+	if _, err := c.persistParentApply(ctx, apply, scope, "sync nonterminal gRPC stop"); err != nil {
 		return true, fmt.Errorf("sync nonterminal remote gRPC stop state for %s: %w", apply.ApplyIdentifier, err)
 	}
 	slog.Info("remote gRPC stop request accepted and remains pending for remote apply owner",
@@ -1175,10 +1175,13 @@ func (c *GRPCClient) resumeApply(ctx context.Context, apply *storage.Apply, scop
 		if apply.StartedAt == nil {
 			apply.StartedAt = &now
 		}
-		if err := c.storage.Applies().Update(ctx, apply); err != nil {
+		persisted, err := c.persistParentApply(ctx, apply, scope, "start queued gRPC apply")
+		if err != nil {
 			return fmt.Errorf("update started gRPC apply %s: %w", apply.ApplyIdentifier, err)
 		}
-		c.logApplyStateTransition(ctx, apply, storage.LogLevelInfo, "Remote apply start requested by operator", state.Apply.Pending)
+		if persisted {
+			c.logApplyStateTransition(ctx, apply, storage.LogLevelInfo, "Remote apply start requested by operator", state.Apply.Pending)
+		}
 	}
 
 	// Check the real state from Tern before deciding what to do. Stored state
@@ -1285,7 +1288,8 @@ func (c *GRPCClient) resumeApply(ctx context.Context, apply *storage.Apply, scop
 			remoteStartRequested = true
 		}
 
-		if err := c.storage.Applies().Update(ctx, apply); err != nil {
+		persisted, err := c.persistParentApply(ctx, apply, scope, "refresh stopped gRPC apply before start")
+		if err != nil {
 			return fmt.Errorf("update apply state: %w", err)
 		}
 		if startRequested {
@@ -1293,10 +1297,12 @@ func (c *GRPCClient) resumeApply(ctx context.Context, apply *storage.Apply, scop
 				return err
 			}
 		}
-		if remoteStartRequested {
-			c.logApplyStateTransition(ctx, apply, storage.LogLevelInfo, "Remote apply start requested by operator", oldState)
-		} else if oldState != apply.State {
-			c.logApplyStateTransition(ctx, apply, storage.LogLevelInfo, fmt.Sprintf("Remote apply state refreshed before operator start: %s -> %s", oldState, apply.State), oldState)
+		if persisted {
+			if remoteStartRequested {
+				c.logApplyStateTransition(ctx, apply, storage.LogLevelInfo, "Remote apply start requested by operator", oldState)
+			} else if oldState != apply.State {
+				c.logApplyStateTransition(ctx, apply, storage.LogLevelInfo, fmt.Sprintf("Remote apply state refreshed before operator start: %s -> %s", oldState, apply.State), oldState)
+			}
 		}
 	}
 
@@ -1421,13 +1427,16 @@ func (c *GRPCClient) processPendingStartControlRequest(ctx context.Context, appl
 	if apply.StartedAt == nil {
 		apply.StartedAt = &now
 	}
-	if err := c.storage.Applies().Update(ctx, apply); err != nil {
+	persisted, err := c.persistParentApply(ctx, apply, scope, "start gRPC deferred deploy")
+	if err != nil {
 		return fmt.Errorf("update started gRPC deferred deploy %s: %w", apply.ApplyIdentifier, err)
 	}
 	if err := completePendingStartControlRequests(ctx, c.storage, apply); err != nil {
 		return err
 	}
-	c.logApplyStateTransition(ctx, apply, storage.LogLevelInfo, fmt.Sprintf("Remote deferred deploy start requested%s", callerApplyLogSuffix(controlRequestCaller(controlReq))), oldState)
+	if persisted {
+		c.logApplyStateTransition(ctx, apply, storage.LogLevelInfo, fmt.Sprintf("Remote deferred deploy start requested%s", callerApplyLogSuffix(controlRequestCaller(controlReq))), oldState)
+	}
 	return nil
 }
 

--- a/pkg/tern/grpc_client.go
+++ b/pkg/tern/grpc_client.go
@@ -928,6 +928,16 @@ func (s applyTaskScope) usesOperationRemoteResume() bool {
 	return s.multiOperation && s.operation != nil
 }
 
+// suppressesDirectParentApplyWrites reports whether this drive must not write
+// the parent applies row (state, heartbeat) or run parent-level side effects
+// (parent stop-request completion, active-apply metrics). Multi-operation drives
+// own only their operation: the parent applies.state is moved solely by the
+// operation-authorized projection CAS in the operator. Single-operation and
+// whole-apply drives keep writing the parent directly.
+func (s applyTaskScope) suppressesDirectParentApplyWrites() bool {
+	return s.usesOperationRemoteResume()
+}
+
 // remoteApplyID resolves the remote Tern apply id sent on this drive's
 // Progress/Stop/Start/Cutover calls. Multi-operation drives read the claimed
 // operation's engine_resume_context (which may be empty before dispatch);
@@ -1556,12 +1566,15 @@ func (c *GRPCClient) dispatchPendingApply(ctx context.Context, apply *storage.Ap
 		apply.StartedAt = &now
 	}
 	apply.UpdatedAt = now
-	if err := c.storage.Applies().Update(ctx, apply); err != nil {
+	persisted, err := c.persistParentApply(ctx, apply, scope, "dispatch gRPC apply")
+	if err != nil {
 		return fmt.Errorf("update dispatched gRPC apply %s after storing remote apply id %s: %w", apply.ApplyIdentifier, resp.ApplyId, err)
 	}
-	c.logApplyStateTransition(ctx, apply, storage.LogLevelInfo,
-		fmt.Sprintf("Apply dispatched to remote Tern: target=%s deployment=%s remote_apply_id=%s", target, apply.Deployment, resp.ApplyId),
-		oldApplyState)
+	if persisted {
+		c.logApplyStateTransition(ctx, apply, storage.LogLevelInfo,
+			fmt.Sprintf("Apply dispatched to remote Tern: target=%s deployment=%s remote_apply_id=%s", target, apply.Deployment, resp.ApplyId),
+			oldApplyState)
+	}
 
 	return c.pollForCompletion(ctx, apply, false, scope)
 }
@@ -1721,6 +1734,38 @@ func logSkippedRemoteApplyTransition(operation string, remoteApply, storedApply 
 	}
 }
 
+// persistParentApply writes the parent applies row unless the drive is a
+// multi-operation operation-only drive, in which case the parent state is owned
+// by the operator's projection CAS and the direct write is skipped. It reports
+// whether the write happened so callers can gate parent-level side effects
+// (state-transition logs, active-apply metrics) on an actual persist.
+func (c *GRPCClient) persistParentApply(ctx context.Context, apply *storage.Apply, scope applyTaskScope, action string) (bool, error) {
+	if scope.suppressesDirectParentApplyWrites() {
+		slog.Debug("skipping direct parent apply write during multi-operation drive; parent state is owned by the rollout projection",
+			"apply_id", apply.ApplyIdentifier,
+			"apply_db_id", apply.ID,
+			"apply_operation_id", scope.applyOperationID,
+			"deployment", scope.operation.Deployment,
+			"environment", apply.Environment,
+			"action", action)
+		return false, nil
+	}
+	if err := c.storage.Applies().Update(ctx, apply); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// heartbeatScopedDrive refreshes the lease keeping a long drive claimed. A
+// multi-operation drive heartbeats its own operation row (it holds no parent
+// apply lease); every other drive heartbeats the parent applies row.
+func (c *GRPCClient) heartbeatScopedDrive(ctx context.Context, apply *storage.Apply, scope applyTaskScope) error {
+	if scope.suppressesDirectParentApplyWrites() {
+		return c.storage.ApplyOperations().Heartbeat(ctx, scope.applyOperationID)
+	}
+	return c.storage.Applies().Heartbeat(ctx, apply.ID)
+}
+
 func (c *GRPCClient) markRemoteApplyFailed(ctx context.Context, remoteApply *storage.Apply, storedTasks []*storage.Task, message string, retryable bool, scope applyTaskScope) error {
 	return c.markRemoteApplyFailedWithOptions(ctx, remoteApply, storedTasks, message, retryable, false, scope)
 }
@@ -1775,6 +1820,21 @@ func (c *GRPCClient) markRemoteApplyFailedWithOptions(ctx context.Context, remot
 		if err := c.storage.Tasks().Update(ctx, storedTask); err != nil {
 			return fmt.Errorf("update task %s after remote gRPC apply failure %s: %w", storedTask.TaskIdentifier, storedApply.ApplyIdentifier, err)
 		}
+	}
+
+	// A multi-operation drive records only its operation's task failures here.
+	// The operator derives the failed operation row from those tasks and moves
+	// the parent applies.state via the projection CAS; the driver must not write
+	// the parent failure or run its parent-level side effects.
+	if scope.suppressesDirectParentApplyWrites() {
+		slog.Debug("recorded operation task failures during multi-operation drive; parent failure is owned by the rollout projection",
+			"apply_id", storedApply.ApplyIdentifier,
+			"apply_db_id", storedApply.ID,
+			"apply_operation_id", scope.applyOperationID,
+			"deployment", scope.operation.Deployment,
+			"environment", storedApply.Environment,
+			"failure_task_state", taskState)
+		return nil
 	}
 
 	oldState := storedApply.State
@@ -1856,7 +1916,7 @@ func (c *GRPCClient) reconcileTerminalRemoteProgress(ctx context.Context, remote
 	if err := c.reconcileStoredTasksForTerminalRemoteApply(ctx, storedApply, remoteApply, storedTasks, now); err != nil {
 		return err
 	}
-	return c.persistTerminalStateFromRemote(ctx, storedApply, remoteApply, now)
+	return c.persistTerminalStateFromRemote(ctx, storedApply, remoteApply, now, scope)
 }
 
 func storedStoppedApplyCanAdoptRemoteTerminalState(storedApply, remoteApply *storage.Apply) bool {
@@ -1865,7 +1925,22 @@ func storedStoppedApplyCanAdoptRemoteTerminalState(storedApply, remoteApply *sto
 		!state.IsState(remoteApply.State, state.Apply.Stopped)
 }
 
-func (c *GRPCClient) persistTerminalStateFromRemote(ctx context.Context, storedApply, remoteApply *storage.Apply, now time.Time) error {
+func (c *GRPCClient) persistTerminalStateFromRemote(ctx context.Context, storedApply, remoteApply *storage.Apply, now time.Time, scope applyTaskScope) error {
+	// A multi-operation drive owns only its operation. The terminal task states
+	// were already synced by the caller; the operation row is derived from those
+	// tasks by the operator, which then moves the parent applies.state via the
+	// projection CAS and completes any parent control requests. The driver must
+	// not write the parent row or run its parent-level side effects here.
+	if scope.suppressesDirectParentApplyWrites() {
+		slog.Debug("skipping parent terminal write during multi-operation drive; operation tasks are resolved and parent state is owned by the rollout projection",
+			"apply_id", storedApply.ApplyIdentifier,
+			"apply_db_id", storedApply.ID,
+			"apply_operation_id", scope.applyOperationID,
+			"deployment", scope.operation.Deployment,
+			"environment", storedApply.Environment,
+			"remote_state", remoteApply.State)
+		return nil
+	}
 	oldState := storedApply.State
 	storedApply.State = remoteApply.State
 	storedApply.ErrorMessage = remoteApply.ErrorMessage
@@ -2142,8 +2217,10 @@ func (c *GRPCClient) pollForCompletion(ctx context.Context, apply *storage.Apply
 		case <-ctx.Done():
 			return ctx.Err()
 		case <-heartbeatTicker.C:
-			// Heartbeat: bump updated_at to maintain lease
-			if err := c.storage.Applies().Heartbeat(ctx, apply.ID); err != nil {
+			// Heartbeat: bump updated_at to maintain the lease. A multi-operation
+			// drive heartbeats its own operation row; every other drive
+			// heartbeats the parent applies row.
+			if err := c.heartbeatScopedDrive(ctx, apply, scope); err != nil {
 				return fmt.Errorf("heartbeat gRPC apply %s: %w", apply.ApplyIdentifier, err)
 			}
 		case <-ticker.C:
@@ -2299,10 +2376,11 @@ func (c *GRPCClient) pollForCompletion(ctx context.Context, apply *storage.Apply
 			if err := c.syncStoredTasksFromRemoteTasks(ctx, apply, storedTasks, resp.Tables, now); err != nil {
 				return err
 			}
-			if err := c.storage.Applies().Update(ctx, apply); err != nil {
+			persisted, err := c.persistParentApply(ctx, apply, scope, "sync nonterminal gRPC progress")
+			if err != nil {
 				return fmt.Errorf("sync apply %s from gRPC progress: %w", apply.ApplyIdentifier, err)
 			}
-			if oldApplyState != apply.State {
+			if persisted && oldApplyState != apply.State {
 				c.logApplyStateTransition(ctx, apply, storage.LogLevelInfo, fmt.Sprintf("Remote apply changed state: %s -> %s", oldApplyState, apply.State), oldApplyState)
 			}
 		}

--- a/pkg/tern/grpc_client_test.go
+++ b/pkg/tern/grpc_client_test.go
@@ -1028,6 +1028,74 @@ func TestGRPCClient_ResumeApplyOperationStoresRemoteIDOnOperationForMultiOpApply
 	assert.Equal(t, "users", req.DdlChanges[0].TableName)
 }
 
+func TestGRPCClient_ResumeApplyOperationStartsQueuedRemoteWithoutWritingParent(t *testing.T) {
+	// A multi-deployment operation that was already dispatched (its remote apply
+	// id lives on the operation) and whose parent apply is still pending must
+	// start its own remote apply by the operation's id and must NOT write the
+	// parent applies row: parent state is owned by the operator's projection CAS.
+	server := &capturingTernServer{
+		progressTables: []*ternv1.TableProgress{{
+			Namespace:       "default",
+			TableName:       "users",
+			Status:          state.Task.Completed,
+			PercentComplete: 100,
+		}},
+	}
+	client, cleanup := testCapturingGRPCClient(t, server)
+	defer cleanup()
+
+	apply := &storage.Apply{
+		ID:              7,
+		ApplyIdentifier: "apply-multi-op-start",
+		PlanID:          99,
+		Database:        "testdb",
+		DatabaseType:    storage.DatabaseTypeMySQL,
+		Environment:     "staging",
+		State:           state.Apply.Pending,
+	}
+	apply.SetOptions(storage.ApplyOptions{Target: "testdb-target"})
+	operationID := int64(42)
+	siblingID := int64(43)
+	task := &storage.Task{
+		ID:               11,
+		TaskIdentifier:   "task-users",
+		ApplyID:          apply.ID,
+		ApplyOperationID: &operationID,
+		TableName:        "users",
+		DDL:              "ALTER TABLE users ADD COLUMN email varchar(255)",
+		DDLAction:        "alter",
+		Namespace:        "default",
+		State:            state.Task.Pending,
+	}
+	taskStore := &mockTaskStore{
+		tasks:           []*storage.Task{task},
+		getByApplyIDErr: errors.New("whole-apply task load must not be used for operation-scoped resume"),
+	}
+	operationStore := &mockApplyOperationStore{ops: map[int64]*storage.ApplyOperation{
+		operationID: {ID: operationID, ApplyID: apply.ID, Deployment: "west", State: state.ApplyOperation.Pending, EngineResumeContext: "remote-op-west-1"},
+		siblingID:   {ID: siblingID, ApplyID: apply.ID, Deployment: "east", State: state.ApplyOperation.Pending},
+	}}
+	applyStore := &mockApplyStore{apply: apply}
+	client.storage = &mockStorage{
+		applies: applyStore,
+		tasks:   taskStore,
+		plans: &mockPlanStore{plan: &storage.Plan{
+			ID:             apply.PlanID,
+			PlanIdentifier: "plan-multi-op-start",
+		}},
+		operations: operationStore,
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+	require.NoError(t, client.ResumeApplyOperation(ctx, apply, operationID))
+
+	assert.Equal(t, "remote-op-west-1", server.getStartApplyID(),
+		"the operation's own remote apply id must be started, not the parent external_id")
+	assert.Empty(t, applyStore.updates,
+		"a multi-op drive must never write the parent applies row directly; parent state is owned by the projection CAS")
+}
+
 func TestGRPCClient_ResumeApplyOperationStopsUndispatchedOperationWithoutCompletingApplyStop(t *testing.T) {
 	// A multi-deployment apply has one durable stop request shared by every
 	// deployment. Stopping a claimed-but-undispatched operation (no remote apply

--- a/pkg/tern/grpc_client_test.go
+++ b/pkg/tern/grpc_client_test.go
@@ -996,8 +996,9 @@ func TestGRPCClient_ResumeApplyOperationStoresRemoteIDOnOperationForMultiOpApply
 		operationID: {ID: operationID, ApplyID: apply.ID, Deployment: "west", State: state.ApplyOperation.Pending},
 		siblingID:   {ID: siblingID, ApplyID: apply.ID, Deployment: "east", State: state.ApplyOperation.Pending},
 	}}
+	applyStore := &mockApplyStore{apply: apply}
 	client.storage = &mockStorage{
-		applies: &mockApplyStore{apply: apply},
+		applies: applyStore,
 		tasks:   taskStore,
 		plans: &mockPlanStore{plan: &storage.Plan{
 			ID:             apply.PlanID,
@@ -1011,6 +1012,7 @@ func TestGRPCClient_ResumeApplyOperationStoresRemoteIDOnOperationForMultiOpApply
 	err := client.ResumeApplyOperation(ctx, apply, operationID)
 	require.NoError(t, err)
 
+	assert.Empty(t, applyStore.updates, "a multi-op drive must never write the parent applies row directly; parent state is owned by the projection CAS")
 	assert.Empty(t, apply.ExternalID, "multi-op dispatch must not write the parent apply external_id")
 	assert.Equal(t, "remote-op-west-1", operationStore.ops[operationID].EngineResumeContext,
 		"the remote apply id must be stored on the claimed operation")
@@ -1087,6 +1089,69 @@ func TestGRPCClient_ResumeApplyOperationStopsUndispatchedOperationWithoutComplet
 	stopReq, err := controlRequests.GetPending(t.Context(), apply.ID, storage.ControlOperationStop)
 	require.NoError(t, err)
 	assert.NotNil(t, stopReq, "the apply-level stop request must remain pending for sibling operations")
+}
+
+func TestGRPCClient_ResumeApplyOperationFailureRecordsTasksOnlyForMultiOpApply(t *testing.T) {
+	// When a multi-deployment operation's remote dispatch is rejected, the drive
+	// records the failure on that operation's own tasks and returns the error,
+	// but must NOT write the parent applies row: the operator derives the failed
+	// operation from its tasks and moves the parent via the projection CAS.
+	server := &capturingTernServer{
+		applyErr: errors.New("remote rejected the apply"),
+	}
+	client, cleanup := testCapturingGRPCClient(t, server)
+	defer cleanup()
+
+	apply := &storage.Apply{
+		ID:              7,
+		ApplyIdentifier: "apply-multi-op-fail",
+		PlanID:          99,
+		Database:        "testdb",
+		DatabaseType:    storage.DatabaseTypeMySQL,
+		Environment:     "staging",
+		State:           state.Apply.Pending,
+	}
+	apply.SetOptions(storage.ApplyOptions{Target: "testdb-target", DeferCutover: true})
+	operationID := int64(42)
+	siblingID := int64(43)
+	task := &storage.Task{
+		ID:               11,
+		TaskIdentifier:   "task-users",
+		ApplyID:          apply.ID,
+		ApplyOperationID: &operationID,
+		TableName:        "users",
+		DDL:              "ALTER TABLE users ADD COLUMN email varchar(255)",
+		DDLAction:        "alter",
+		Namespace:        "default",
+		State:            state.Task.Pending,
+	}
+	taskStore := &mockTaskStore{
+		tasks:           []*storage.Task{task},
+		getByApplyIDErr: errors.New("whole-apply task load must not be used for operation-scoped resume"),
+	}
+	operationStore := &mockApplyOperationStore{ops: map[int64]*storage.ApplyOperation{
+		operationID: {ID: operationID, ApplyID: apply.ID, Deployment: "west", State: state.ApplyOperation.Pending},
+		siblingID:   {ID: siblingID, ApplyID: apply.ID, Deployment: "east", State: state.ApplyOperation.Pending},
+	}}
+	applyStore := &mockApplyStore{apply: apply}
+	client.storage = &mockStorage{
+		applies: applyStore,
+		tasks:   taskStore,
+		plans: &mockPlanStore{plan: &storage.Plan{
+			ID:             apply.PlanID,
+			PlanIdentifier: "plan-multi-op-fail",
+		}},
+		operations: operationStore,
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+	err := client.ResumeApplyOperation(ctx, apply, operationID)
+	require.Error(t, err, "a rejected remote dispatch must return an error so the operator can project the failure")
+
+	assert.True(t, state.IsState(task.State, state.Task.Failed, state.Task.FailedRetryable),
+		"the operation's own task must be recorded as failed; got %q", task.State)
+	assert.Empty(t, applyStore.updates, "a multi-op failure must not write the parent applies row directly")
 }
 
 func TestGRPCClient_ResumeApplyOperationRejectsMissingOperationID(t *testing.T) {


### PR DESCRIPTION
## What and Why ?

Multi-operation fan-out applies now drive each operation independently under its own operation lease, instead of every operation also claiming the shared parent apply lease. Single-operation applies are unchanged (byte-for-byte legacy path). Multi-operation applies are reachable only from seeded tests until the later config flip.

- **Operator**: `recoverApplyOperation` branches on operation count. `len(ops)==1` keeps the legacy parent-lease drive (claim parent, dual lease, engine writes the parent row, per-driver observer fires). `len(ops)>1` drives under the operation lease only — no parent claim — and moves the parent `applies.state` solely via the operation-authorized projection CAS. The multi-op path projects `pending→running` before the drive, suppresses the per-driver observer, and marks the operation from its own tasks even on a drive error (it has no parent-reconcile fallback), then re-derives the parent.
- **gRPC driver**: direct parent `applies` writes, the parent heartbeat, and parent-level terminal/failure side effects are skipped for operation-scoped multi-op drives. Task rows are still written; the parent state is owned by the projection CAS. Centralized behind `persistParentApply` / `heartbeatScopedDrive` rather than scattered guards.
- **Local driver**: already derives the parent from the aggregate projection and CAS-writes it, so no change.

```diagram
multi-op drive (operation lease only)
  claim op ─▶ project parent pending→running (CAS) ─▶ drive (no parent write)
    ├─ task rows persisted by driver
    └─ mark op from own tasks ─▶ re-derive parent (CAS) ─▶ complete stop if resolved
single-op drive ── unchanged: claim parent, dual lease, engine writes parent, observer fires
```
The comprehensive seeded multi-operation drive matrix lands in a dedicated follow-up PR.

