### PR TITLE
deps(spirit): bump to v0.15.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.14
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.1
 	github.com/aws/aws-sdk-go-v2/service/sts v1.43.3
-	github.com/block/spirit v0.14.1-0.20260612153639-4865f22b5a5c
+	github.com/block/spirit v0.15.0
 	github.com/bradleyfalzon/ghinstallation/v2 v2.18.0
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10

--- a/go.sum
+++ b/go.sum
@@ -113,8 +113,8 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/block/spirit v0.14.1-0.20260612153639-4865f22b5a5c h1:oPKSD7EGAL9ytktdDavq17I9ztHYyqwIymWpPcsl5C4=
-github.com/block/spirit v0.14.1-0.20260612153639-4865f22b5a5c/go.mod h1:ku7mCCKx7Wk4QrMa/mHnsqQhZkoUD2vdBkpjJEDk4lY=
+github.com/block/spirit v0.15.0 h1:psKO9ztdgkNn1cmOY6rJJa0UuIvfBGaLzK2p4ppOhm8=
+github.com/block/spirit v0.15.0/go.mod h1:ku7mCCKx7Wk4QrMa/mHnsqQhZkoUD2vdBkpjJEDk4lY=
 github.com/block/tidb/pkg/parser v0.0.0-20260506200501-e528fd979fc8 h1:+OfdTacrEyjlqcRUpBFX9uJ6ROBq6cUjwY4DClhnsdU=
 github.com/block/tidb/pkg/parser v0.0.0-20260506200501-e528fd979fc8/go.mod h1:zDLDsfNBU5+L6T4J9/OgWAHc/WZvMUjbpgHqQ/t3yKo=
 github.com/block/vitess v0.0.0-20260601162944-8318a748ceb1 h1:dnHGiR/N1+X2EM1FGzL4548iCzJcIAnhcMbEt026xHQ=


### PR DESCRIPTION
Bumps `github.com/block/spirit` from an untagged June-12 pseudo-version to the tagged **`v0.15.0`** release.

The commits in range are mostly Aurora throttler fixes that affect online-DDL behavior on throttled backends — notably the throttler no longer counts its own polling connection, so it won't throttle a copy on an otherwise-idle instance.

No SchemaBot code changes required. Build, unit (`-race`), and EnsureSchema/Spirit apply integration tests pass on `v0.15.0`.
