### PR TITLE
fix(observability): log apply identifier in cutover events

### DIFF
--- a/pkg/tern/grpc_client.go
+++ b/pkg/tern/grpc_client.go
@@ -518,11 +518,11 @@ func (c *GRPCClient) processPendingCutoverControlRequest(ctx context.Context, ap
 	if err != nil {
 		errorMessage := fmt.Sprintf("remote cutover failed: %v", err)
 		if failErr := failPendingCutoverControlRequests(ctx, c.storage, apply, errorMessage); failErr != nil {
-			return fmt.Errorf("request remote gRPC cutover for apply %s remote %s: %w; fail pending cutover request: %w", apply.ApplyIdentifier, apply.ExternalID, err, failErr)
+			return fmt.Errorf("request remote gRPC cutover for apply %s remote %s: %w; fail pending cutover request: %w", apply.ApplyIdentifier, remoteID, err, failErr)
 		}
 		c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelError, storage.LogEventError,
-			fmt.Sprintf("Remote cutover failed for apply %s (remote %s)%s: %v", apply.ApplyIdentifier, apply.ExternalID, callerApplyLogSuffix(controlRequestCaller(controlReq)), err), "", "")
-		return fmt.Errorf("request remote gRPC cutover for apply %s remote %s: %w", apply.ApplyIdentifier, apply.ExternalID, err)
+			fmt.Sprintf("Remote cutover failed for apply %s (remote %s)%s: %v", apply.ApplyIdentifier, remoteID, callerApplyLogSuffix(controlRequestCaller(controlReq)), err), "", "")
+		return fmt.Errorf("request remote gRPC cutover for apply %s remote %s: %w", apply.ApplyIdentifier, remoteID, err)
 	}
 	if resp == nil {
 		errorMessage := "not accepted"
@@ -530,8 +530,8 @@ func (c *GRPCClient) processPendingCutoverControlRequest(ctx context.Context, ap
 			return err
 		}
 		c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelError, storage.LogEventError,
-			fmt.Sprintf("Remote cutover returned no response for apply %s (remote %s)%s", apply.ApplyIdentifier, apply.ExternalID, callerApplyLogSuffix(controlRequestCaller(controlReq))), "", "")
-		return fmt.Errorf("request remote gRPC cutover for apply %s remote %s: %s", apply.ApplyIdentifier, apply.ExternalID, errorMessage)
+			fmt.Sprintf("Remote cutover returned no response for apply %s (remote %s)%s", apply.ApplyIdentifier, remoteID, callerApplyLogSuffix(controlRequestCaller(controlReq))), "", "")
+		return fmt.Errorf("request remote gRPC cutover for apply %s remote %s: %s", apply.ApplyIdentifier, remoteID, errorMessage)
 	}
 	if !resp.Accepted {
 		errorMessage := "not accepted"
@@ -542,11 +542,11 @@ func (c *GRPCClient) processPendingCutoverControlRequest(ctx context.Context, ap
 			return err
 		}
 		c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelError, storage.LogEventError,
-			fmt.Sprintf("Remote cutover was not accepted for apply %s (remote %s)%s: %s", apply.ApplyIdentifier, apply.ExternalID, callerApplyLogSuffix(controlRequestCaller(controlReq)), errorMessage), "", "")
-		return fmt.Errorf("request remote gRPC cutover for apply %s remote %s: %s", apply.ApplyIdentifier, apply.ExternalID, errorMessage)
+			fmt.Sprintf("Remote cutover was not accepted for apply %s (remote %s)%s: %s", apply.ApplyIdentifier, remoteID, callerApplyLogSuffix(controlRequestCaller(controlReq)), errorMessage), "", "")
+		return fmt.Errorf("request remote gRPC cutover for apply %s remote %s: %s", apply.ApplyIdentifier, remoteID, errorMessage)
 	}
 	c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventCutoverTriggered,
-		fmt.Sprintf("Remote cutover accepted for apply %s (remote %s)%s", apply.ApplyIdentifier, apply.ExternalID, callerApplyLogSuffix(controlRequestCaller(controlReq))), "", "")
+		fmt.Sprintf("Remote cutover accepted for apply %s (remote %s)%s", apply.ApplyIdentifier, remoteID, callerApplyLogSuffix(controlRequestCaller(controlReq))), "", "")
 	if err := completePendingCutoverControlRequests(ctx, c.storage, apply); err != nil {
 		return err
 	}

--- a/pkg/tern/grpc_client.go
+++ b/pkg/tern/grpc_client.go
@@ -521,7 +521,7 @@ func (c *GRPCClient) processPendingCutoverControlRequest(ctx context.Context, ap
 			return fmt.Errorf("request remote gRPC cutover for apply %s remote %s: %w; fail pending cutover request: %w", apply.ApplyIdentifier, apply.ExternalID, err, failErr)
 		}
 		c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelError, storage.LogEventError,
-			fmt.Sprintf("Remote cutover failed for apply %s%s: %v", apply.ExternalID, callerApplyLogSuffix(controlRequestCaller(controlReq)), err), "", "")
+			fmt.Sprintf("Remote cutover failed for apply %s (remote %s)%s: %v", apply.ApplyIdentifier, apply.ExternalID, callerApplyLogSuffix(controlRequestCaller(controlReq)), err), "", "")
 		return fmt.Errorf("request remote gRPC cutover for apply %s remote %s: %w", apply.ApplyIdentifier, apply.ExternalID, err)
 	}
 	if resp == nil {
@@ -530,7 +530,7 @@ func (c *GRPCClient) processPendingCutoverControlRequest(ctx context.Context, ap
 			return err
 		}
 		c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelError, storage.LogEventError,
-			fmt.Sprintf("Remote cutover returned no response for apply %s%s", apply.ExternalID, callerApplyLogSuffix(controlRequestCaller(controlReq))), "", "")
+			fmt.Sprintf("Remote cutover returned no response for apply %s (remote %s)%s", apply.ApplyIdentifier, apply.ExternalID, callerApplyLogSuffix(controlRequestCaller(controlReq))), "", "")
 		return fmt.Errorf("request remote gRPC cutover for apply %s remote %s: %s", apply.ApplyIdentifier, apply.ExternalID, errorMessage)
 	}
 	if !resp.Accepted {
@@ -542,11 +542,11 @@ func (c *GRPCClient) processPendingCutoverControlRequest(ctx context.Context, ap
 			return err
 		}
 		c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelError, storage.LogEventError,
-			fmt.Sprintf("Remote cutover was not accepted for apply %s%s: %s", apply.ExternalID, callerApplyLogSuffix(controlRequestCaller(controlReq)), errorMessage), "", "")
+			fmt.Sprintf("Remote cutover was not accepted for apply %s (remote %s)%s: %s", apply.ApplyIdentifier, apply.ExternalID, callerApplyLogSuffix(controlRequestCaller(controlReq)), errorMessage), "", "")
 		return fmt.Errorf("request remote gRPC cutover for apply %s remote %s: %s", apply.ApplyIdentifier, apply.ExternalID, errorMessage)
 	}
 	c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventCutoverTriggered,
-		fmt.Sprintf("Remote cutover accepted for apply %s%s", apply.ExternalID, callerApplyLogSuffix(controlRequestCaller(controlReq))), "", "")
+		fmt.Sprintf("Remote cutover accepted for apply %s (remote %s)%s", apply.ApplyIdentifier, apply.ExternalID, callerApplyLogSuffix(controlRequestCaller(controlReq))), "", "")
 	if err := completePendingCutoverControlRequests(ctx, c.storage, apply); err != nil {
 		return err
 	}

--- a/pkg/tern/grpc_client_test.go
+++ b/pkg/tern/grpc_client_test.go
@@ -2856,7 +2856,7 @@ func TestGRPCClient_ResumeApplyProcessesQueuedCutover(t *testing.T) {
 	controlReq, err := controlRequests.GetPending(t.Context(), apply.ID, storage.ControlOperationCutover)
 	require.NoError(t, err)
 	assert.Nil(t, controlReq)
-	assert.True(t, hasLogMessageContaining(logs.logs, "Remote cutover accepted for apply remote-cutover-claimed (caller: cli:alice)"))
+	assert.True(t, hasLogMessageContaining(logs.logs, "Remote cutover accepted for apply apply-cutover-claimed (remote remote-cutover-claimed) (caller: cli:alice)"))
 }
 
 func TestGRPCClient_ProcessPendingCutoverWaitsWhenNotReady(t *testing.T) {
@@ -2999,7 +2999,7 @@ func TestGRPCClient_ResumeApplyCutoverErrorFailsPendingRequest(t *testing.T) {
 	require.Len(t, controlRequests.requests, 1)
 	assert.Equal(t, storage.ControlRequestFailed, controlRequests.requests[0].Status)
 	assert.Contains(t, controlRequests.requests[0].ErrorMessage, "remote cutover failed")
-	assert.True(t, hasLogMessageContaining(logs.logs, "Remote cutover failed for apply remote-cutover-error (caller: cli:alice)"))
+	assert.True(t, hasLogMessageContaining(logs.logs, "Remote cutover failed for apply apply-cutover-error (remote remote-cutover-error) (caller: cli:alice)"))
 }
 
 func TestGRPCClient_ResumeApplyCompletesQueuedStartWhenRemoteAlreadyActive(t *testing.T) {


### PR DESCRIPTION
## What and Why ?
Four cutover `logApplyEvent` messages in `pkg/tern/grpc_client.go` say
`for apply %s` but substitute `apply.ExternalID` (the remote Tern apply id)
instead of `apply.ApplyIdentifier`. During cutover triage an operator
grepping the apply identifier never matches these events, and the value
shown under "apply" is actually the remote id — the exact triage hazard the
repo's logging guidance warns against. The sibling `fmt.Errorf` returns in
the same branches already use the apply identifier; this aligns the logs.

## Changes
- `Remote cutover failed/returned no response/was not accepted/accepted for
  apply <id>` now log `for apply <ApplyIdentifier> (remote <ExternalID>)`.
- Update the two affected assertions in `grpc_client_test.go`.

## References
Surfaced while triaging the Copilot review on #401:
https://github.com/block/schemabot/pull/401#pullrequestreview-4519712336
(the flagged cutover identifier issue lives in already-merged code, split
out here to keep the fan-out operator-drive PR focused).
