### PR TITLE
feat(operator): park multi-deployment barrier copy phase at the cutover barrier

### DIFF
--- a/pkg/api/operator.go
+++ b/pkg/api/operator.go
@@ -1020,6 +1020,16 @@ func (s *Service) persistOperationState(ctx context.Context, workerID int, op *s
 			return false, fmt.Errorf("update failed_retryable apply_operation %d state (deployment %q): %w", op.ID, op.Deployment, err)
 		}
 		return true, nil
+	case state.IsState(derived, state.Apply.WaitingForCutover):
+		// Under an ordered-cutover policy the copy drive parks a deployment at the
+		// barrier and releases it: persist waiting_for_cutover (completed_at nil,
+		// the work is not done) so the row is durable and the deployment-ordered
+		// cutover claim picks it up later. Without this the row would fall through
+		// to the "leave claimable" default and the copy claim would re-drive it.
+		if err := opStore.UpdateState(ctx, op.ID, derived); err != nil {
+			return false, fmt.Errorf("update waiting_for_cutover apply_operation %d state (deployment %q): %w", op.ID, op.Deployment, err)
+		}
+		return true, nil
 	case state.IsTerminalApplyState(derived):
 		// cancelled / reverted — non-resumable terminal states; stamp completed_at.
 		if err := opStore.MarkTerminal(ctx, op.ID, derived); err != nil {

--- a/pkg/api/operator_test.go
+++ b/pkg/api/operator_test.go
@@ -427,6 +427,47 @@ func TestMarkOperationFromOwnResult_LeavesNonTerminalClaimable(t *testing.T) {
 	assert.False(t, opStore.called, "no terminal write should occur for a non-terminal operation")
 }
 
+// updateStateRecordingApplyOperationStore records UpdateState so a test can
+// assert a parked operation is persisted at waiting_for_cutover (completed_at nil).
+type updateStateRecordingApplyOperationStore struct {
+	storage.ApplyOperationStore
+	called       bool
+	updatedID    int64
+	updatedState string
+}
+
+func (s *updateStateRecordingApplyOperationStore) UpdateState(_ context.Context, id int64, newState string) error {
+	s.called = true
+	s.updatedID = id
+	s.updatedState = newState
+	return nil
+}
+
+// TestMarkOperationFromOwnResult_PersistsWaitingForCutover verifies that an
+// operation whose own tasks have parked at the cutover barrier is durably
+// recorded at waiting_for_cutover via UpdateState (not a terminal write), so the
+// row survives the copy drive's release and the deployment-ordered cutover claim
+// can pick it up later.
+func TestMarkOperationFromOwnResult_PersistsWaitingForCutover(t *testing.T) {
+	opStore := &updateStateRecordingApplyOperationStore{}
+	taskStore := &stubTaskStore{tasks: []*storage.Task{
+		{State: state.Task.WaitingForCutover},
+		{State: state.Task.WaitingForCutover},
+	}}
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	svc := New(&mockStorageWithTasksAndOperations{tasks: taskStore, applyOps: opStore}, testServerConfig(), nil, logger)
+
+	op := &storage.ApplyOperation{ID: 13, Deployment: "region-d", CutoverPolicy: storage.CutoverPolicyBarrier}
+
+	marked, err := svc.markOperationFromOwnResult(t.Context(), 1, op)
+	require.NoError(t, err)
+	assert.True(t, marked, "a parked operation must be durably recorded so the copy claim does not re-drive it")
+	assert.True(t, opStore.called, "the operation row must be updated to waiting_for_cutover from its own tasks")
+	assert.Equal(t, int64(13), opStore.updatedID)
+	assert.True(t, state.IsState(opStore.updatedState, state.Apply.WaitingForCutover),
+		"the parked operation must be persisted at waiting_for_cutover, got %q", opStore.updatedState)
+}
+
 // TestUpdateApplyStateFromOperations_StampsAggregateFailureMessage verifies that
 // when the rollout settles to failed the parent apply's ErrorMessage is surfaced
 // from the first failed operation, not from the last-driven (here, successful)

--- a/pkg/storage/mysqlstore/apply_operations.go
+++ b/pkg/storage/mysqlstore/apply_operations.go
@@ -637,6 +637,14 @@ func (s *applyOperationStore) FindNextApplyOperation(ctx context.Context, owner 
 	queryArgs = append(queryArgs,
 		storage.ControlOperationStop, storage.ControlRequestPending)
 	queryArgs = append(queryArgs, stringArgs(activeStates)...)
+	// Stale-active barrier-park exemption (see the staleness clause below): a
+	// multi-deployment operation parked at the cutover barrier under the barrier
+	// policy is reserved for the deployment-ordered cutover claim, so the copy
+	// claim must not re-lease it as stale-active work. A single-operation apply
+	// has no sibling and is never exempted, so manual --defer-cutover behaviour
+	// is unchanged.
+	queryArgs = append(queryArgs,
+		state.ApplyOperation.WaitingForCutover, storage.CutoverPolicyBarrier)
 	queryArgs = append(queryArgs,
 		state.ApplyOperation.Stopped,
 		storage.ControlOperationStart, storage.ControlRequestPending)
@@ -716,7 +724,20 @@ func (s *applyOperationStore) FindNextApplyOperation(ctx context.Context, owner 
 						AND cr.status = ?
 				)
 			)
-			OR (state IN (%s) AND updated_at < NOW() - INTERVAL %s)
+			OR (
+				state IN (%s)
+				AND updated_at < NOW() - INTERVAL %s
+				AND NOT (
+					state = ?
+					AND cutover_policy = ?
+					AND EXISTS (
+						SELECT 1
+						FROM apply_operations AS sibling
+						WHERE sibling.apply_id = apply_operations.apply_id
+							AND sibling.id <> apply_operations.id
+					)
+				)
+			)
 			OR (
 				state = ?
 				AND EXISTS (

--- a/pkg/storage/mysqlstore/apply_operations_test.go
+++ b/pkg/storage/mysqlstore/apply_operations_test.go
@@ -1597,6 +1597,106 @@ func TestApplyOperationStore_FindNextApplyOperation_BarrierHaltsOnFailedSibling(
 	assert.Nil(t, claimed, "barrier must still halt the rollout on a failed earlier deployment")
 }
 
+// TestApplyOperationStore_FindNextApplyOperation_SkipsStaleMultiOpBarrierParked
+// verifies the copy claim does NOT re-lease a multi-deployment operation parked
+// at the cutover barrier, even once its heartbeat goes stale: that row is
+// reserved for the deployment-ordered cutover claim. Without the exemption the
+// copy claim would re-drive a parked deployment and loop.
+func TestApplyOperationStore_FindNextApplyOperation_SkipsStaleMultiOpBarrierParked(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", "mysql", "staging")
+	apply := createTestApply(t, store, lock, "apply_op_barrier_parked_skip", 1)
+
+	parkedID, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-a",
+		State: state.ApplyOperation.WaitingForCutover, CutoverPolicy: storage.CutoverPolicyBarrier,
+	})
+	require.NoError(t, err)
+	// A completed sibling makes this a multi-operation apply without leaving any
+	// other claimable (pending) row, so the parked row is the only candidate.
+	_, err = store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-b",
+		State: state.ApplyOperation.Completed, CutoverPolicy: storage.CutoverPolicyBarrier,
+	})
+	require.NoError(t, err)
+
+	// Backdate the parked row past the staleness window so only the new
+	// barrier-park exemption — not freshness — keeps it from being re-claimed.
+	_, err = testDB.ExecContext(ctx, `
+		UPDATE apply_operations SET updated_at = NOW() - INTERVAL 2 MINUTE WHERE id = ?
+	`, parkedID)
+	require.NoError(t, err)
+
+	claimed, err := store.ApplyOperations().FindNextApplyOperation(ctx, "test-operator")
+	require.NoError(t, err)
+	assert.Nil(t, claimed, "the copy claim must not re-lease a parked multi-op barrier deployment")
+}
+
+// TestApplyOperationStore_FindNextApplyOperation_ClaimsStaleSingleOpBarrierParked
+// verifies the exemption is scoped to multi-deployment applies: a single-op
+// barrier apply (no sibling) parked at the cutover barrier is still re-claimed
+// when stale, preserving manual --defer-cutover crash-recovery behaviour.
+func TestApplyOperationStore_FindNextApplyOperation_ClaimsStaleSingleOpBarrierParked(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", "mysql", "staging")
+	apply := createTestApply(t, store, lock, "apply_op_barrier_parked_single", 1)
+
+	parkedID, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-a",
+		State: state.ApplyOperation.WaitingForCutover, CutoverPolicy: storage.CutoverPolicyBarrier,
+	})
+	require.NoError(t, err)
+
+	_, err = testDB.ExecContext(ctx, `
+		UPDATE apply_operations SET updated_at = NOW() - INTERVAL 2 MINUTE WHERE id = ?
+	`, parkedID)
+	require.NoError(t, err)
+
+	claimed, err := store.ApplyOperations().FindNextApplyOperation(ctx, "test-operator")
+	require.NoError(t, err)
+	require.NotNil(t, claimed, "a single-op barrier apply has no sibling, so a stale parked row is still recoverable")
+	assert.Equal(t, parkedID, claimed.ID)
+}
+
+// TestApplyOperationStore_FindNextApplyOperation_ClaimsStaleMultiOpRollingParked
+// verifies the exemption is scoped to the barrier policy: a multi-op rolling
+// deployment that is stale at waiting_for_cutover is still re-claimed by the
+// copy claim, because rolling drives copy and cutover inline.
+func TestApplyOperationStore_FindNextApplyOperation_ClaimsStaleMultiOpRollingParked(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", "mysql", "staging")
+	apply := createTestApply(t, store, lock, "apply_op_rolling_parked", 1)
+
+	// Default (rolling) policy: leave CutoverPolicy unset so it resolves to rolling.
+	parkedID, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-a", State: state.ApplyOperation.WaitingForCutover,
+	})
+	require.NoError(t, err)
+	_, err = store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-b", State: state.ApplyOperation.Completed,
+	})
+	require.NoError(t, err)
+
+	_, err = testDB.ExecContext(ctx, `
+		UPDATE apply_operations SET updated_at = NOW() - INTERVAL 2 MINUTE WHERE id = ?
+	`, parkedID)
+	require.NoError(t, err)
+
+	claimed, err := store.ApplyOperations().FindNextApplyOperation(ctx, "test-operator")
+	require.NoError(t, err)
+	require.NotNil(t, claimed, "rolling drives cutover inline, so a stale parked row is still recoverable")
+	assert.Equal(t, parkedID, claimed.ID)
+}
+
 // --- FindNextApplyOperationCutover (OC-1): the cutover-claim predicate ---
 //
 // These tests pin the cutover gate, the counterpart to the copy gate above.

--- a/pkg/tern/client.go
+++ b/pkg/tern/client.go
@@ -4,6 +4,7 @@ package tern
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	ternv1 "github.com/block/schemabot/pkg/proto/ternv1"
 	"github.com/block/schemabot/pkg/storage"
@@ -16,6 +17,13 @@ import (
 // clients detect this from storage before any dispatch or state mutation, so
 // callers can match it with errors.Is regardless of the transport.
 var ErrNoTasksForApplyOperation = errors.New("no tasks found for apply operation")
+
+// ErrApplyOperationRowMissing is returned by ResumeApplyOperation when tasks
+// scope to the operation but the apply_operation row itself is absent. It is a
+// distinct, more accurate cause than the no-tasks case, but wraps
+// ErrNoTasksForApplyOperation so the same fail-closed handling (errors.Is)
+// terminalizes the stale claim rather than retrying it forever.
+var ErrApplyOperationRowMissing = fmt.Errorf("apply_operation row missing: %w", ErrNoTasksForApplyOperation)
 
 var (
 	// ErrPullSchemaUnsupportedType marks a pull request for a database type that

--- a/pkg/tern/cutover_barrier.go
+++ b/pkg/tern/cutover_barrier.go
@@ -1,0 +1,29 @@
+package tern
+
+import "github.com/block/schemabot/pkg/storage"
+
+// shouldAutoDeferCutover reports whether an operation-scoped copy drive must park
+// at the cutover barrier automatically. It is true only for an operation of a
+// multi-deployment (fan-out) apply running under the barrier cutover policy, so
+// the high-risk cutover swaps can later be driven in deployment order by the
+// cutover-claim path. A single-operation apply has no siblings to order, so it
+// never auto-defers even when its stored cutover_policy is barrier: behaviour is
+// unchanged until multi-deployment fan-out lands.
+func shouldAutoDeferCutover(multiOperation bool, op *storage.ApplyOperation) bool {
+	return multiOperation && op != nil && op.CutoverPolicy == storage.CutoverPolicyBarrier
+}
+
+// effectiveCopyDriveOptions returns the apply options that govern a copy-phase
+// drive. It starts from the apply's stored options and turns on DeferCutover
+// when the operation must park at the barrier (see shouldAutoDeferCutover). The
+// manual per-apply --defer-cutover option stays authoritative — it is OR'd in,
+// never cleared. The returned value is execution-time only and must never be
+// persisted back onto the apply: the automatic decision is per operation, while
+// apply.Options is shared by every deployment of the apply.
+func effectiveCopyDriveOptions(apply *storage.Apply, multiOperation bool, op *storage.ApplyOperation) storage.ApplyOptions {
+	opts := apply.GetOptions()
+	if !opts.DeferCutover && shouldAutoDeferCutover(multiOperation, op) {
+		opts.DeferCutover = true
+	}
+	return opts
+}

--- a/pkg/tern/cutover_barrier.go
+++ b/pkg/tern/cutover_barrier.go
@@ -13,6 +13,17 @@ func shouldAutoDeferCutover(multiOperation bool, op *storage.ApplyOperation) boo
 	return multiOperation && op != nil && op.CutoverPolicy == storage.CutoverPolicyBarrier
 }
 
+// shouldReleaseAtCutoverBarrier reports whether an operation-scoped copy drive
+// should park at the barrier *and release its claim* for the deployment-ordered
+// cutover claim (OC-3). This is the automatic barrier decision only: when the
+// apply was started with manual --defer-cutover, the documented manual contract
+// wins — the operator holds the claim and polls for a manual cutover (subject to
+// the inaction timeout) — so we must not release. effectiveCopyDriveOptions
+// still keeps DeferCutover on either way, so the cutover is deferred regardless.
+func shouldReleaseAtCutoverBarrier(apply *storage.Apply, multiOperation bool, op *storage.ApplyOperation) bool {
+	return !apply.GetOptions().DeferCutover && shouldAutoDeferCutover(multiOperation, op)
+}
+
 // effectiveCopyDriveOptions returns the apply options that govern a copy-phase
 // drive. It starts from the apply's stored options and turns on DeferCutover
 // when the operation must park at the barrier (see shouldAutoDeferCutover). The

--- a/pkg/tern/cutover_barrier_test.go
+++ b/pkg/tern/cutover_barrier_test.go
@@ -36,6 +36,28 @@ func TestShouldAutoDeferCutover(t *testing.T) {
 	}
 }
 
+func TestShouldReleaseAtCutoverBarrier(t *testing.T) {
+	tests := []struct {
+		name           string
+		manualDefer    bool
+		multiOperation bool
+		op             *storage.ApplyOperation
+		want           bool
+	}{
+		{"multi-op barrier auto-releases", false, true, barrierOp(), true},
+		{"manual defer holds the claim", true, true, barrierOp(), false},
+		{"single-op barrier does not release", false, false, barrierOp(), false},
+		{"multi-op rolling does not release", false, true, rollingOp(), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			apply := &storage.Apply{}
+			apply.SetOptions(storage.ApplyOptions{DeferCutover: tt.manualDefer})
+			assert.Equal(t, tt.want, shouldReleaseAtCutoverBarrier(apply, tt.multiOperation, tt.op))
+		})
+	}
+}
+
 func TestEffectiveCopyDriveOptions(t *testing.T) {
 	t.Run("multi-op barrier turns on defer cutover", func(t *testing.T) {
 		apply := &storage.Apply{}

--- a/pkg/tern/cutover_barrier_test.go
+++ b/pkg/tern/cutover_barrier_test.go
@@ -1,0 +1,80 @@
+package tern
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/block/schemabot/pkg/storage"
+)
+
+func barrierOp() *storage.ApplyOperation {
+	return &storage.ApplyOperation{CutoverPolicy: storage.CutoverPolicyBarrier}
+}
+
+func rollingOp() *storage.ApplyOperation {
+	return &storage.ApplyOperation{CutoverPolicy: storage.CutoverPolicyRolling}
+}
+
+func TestShouldAutoDeferCutover(t *testing.T) {
+	tests := []struct {
+		name           string
+		multiOperation bool
+		op             *storage.ApplyOperation
+		want           bool
+	}{
+		{"multi-op barrier parks", true, barrierOp(), true},
+		{"single-op barrier does not park", false, barrierOp(), false},
+		{"multi-op rolling does not park", true, rollingOp(), false},
+		{"multi-op nil op does not park", true, nil, false},
+		{"single-op rolling does not park", false, rollingOp(), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, shouldAutoDeferCutover(tt.multiOperation, tt.op))
+		})
+	}
+}
+
+func TestEffectiveCopyDriveOptions(t *testing.T) {
+	t.Run("multi-op barrier turns on defer cutover", func(t *testing.T) {
+		apply := &storage.Apply{}
+		opts := effectiveCopyDriveOptions(apply, true, barrierOp())
+		assert.True(t, opts.DeferCutover)
+	})
+
+	t.Run("single-op barrier leaves defer cutover off", func(t *testing.T) {
+		apply := &storage.Apply{}
+		opts := effectiveCopyDriveOptions(apply, false, barrierOp())
+		assert.False(t, opts.DeferCutover)
+	})
+
+	t.Run("manual defer cutover is preserved for non-barrier multi-op", func(t *testing.T) {
+		apply := &storage.Apply{}
+		apply.SetOptions(storage.ApplyOptions{DeferCutover: true})
+		opts := effectiveCopyDriveOptions(apply, true, rollingOp())
+		assert.True(t, opts.DeferCutover)
+	})
+
+	t.Run("does not mutate the apply's stored options", func(t *testing.T) {
+		apply := &storage.Apply{}
+		_ = effectiveCopyDriveOptions(apply, true, barrierOp())
+		assert.False(t, apply.GetOptions().DeferCutover)
+	})
+}
+
+// The grouped-apply gating reads DeferCutover from the effective options map, so
+// a MySQL operation that must park at the barrier takes the atomic-cutover path
+// even though the apply's stored options have defer_cutover unset.
+func TestGroupedApplyHonoursEffectiveOptions(t *testing.T) {
+	c := &LocalClient{}
+	apply := &storage.Apply{DatabaseType: storage.DatabaseTypeMySQL}
+
+	stored := apply.GetOptions().Map()
+	assert.False(t, c.usesGroupedApply(apply, stored))
+	assert.Equal(t, "grouped_engine_apply", groupedApplyMode(apply, stored))
+
+	effective := effectiveCopyDriveOptions(apply, true, barrierOp()).Map()
+	assert.True(t, c.usesGroupedApply(apply, effective))
+	assert.Equal(t, "spirit_atomic_cutover", groupedApplyMode(apply, effective))
+}

--- a/pkg/tern/local_apply.go
+++ b/pkg/tern/local_apply.go
@@ -228,8 +228,13 @@ func (c *LocalClient) runWithRecovery(ctx context.Context, apply *storage.Apply,
 	fn()
 }
 
-func groupedApplyMode(apply *storage.Apply) string {
-	opts := apply.GetOptions()
+// groupedApplyMode classifies the grouped-apply strategy for a drive. It reads
+// DeferCutover from the effective options map (which may carry an automatic
+// barrier-park decision, see effectiveCopyDriveOptions) rather than from
+// apply.GetOptions(), so an operation-scoped copy drive that must park at the
+// cutover barrier takes the atomic-cutover path.
+func groupedApplyMode(apply *storage.Apply, options map[string]string) string {
+	opts := storage.ApplyOptionsFromMap(options)
 	switch {
 	case apply.DatabaseType == storage.DatabaseTypeMySQL && opts.DeferCutover:
 		return "spirit_atomic_cutover"
@@ -240,8 +245,8 @@ func groupedApplyMode(apply *storage.Apply) string {
 	}
 }
 
-func groupedApplyModeDescription(apply *storage.Apply) string {
-	switch groupedApplyMode(apply) {
+func groupedApplyModeDescription(apply *storage.Apply, options map[string]string) string {
+	switch groupedApplyMode(apply, options) {
 	case "spirit_atomic_cutover":
 		return "Spirit atomic cutover"
 	case "vitess_deploy_request":
@@ -251,11 +256,11 @@ func groupedApplyModeDescription(apply *storage.Apply) string {
 	}
 }
 
-func (c *LocalClient) usesGroupedApply(apply *storage.Apply) bool {
+func (c *LocalClient) usesGroupedApply(apply *storage.Apply, options map[string]string) bool {
 	if apply.DatabaseType == storage.DatabaseTypeVitess {
 		return true
 	}
-	return apply.DatabaseType == storage.DatabaseTypeMySQL && apply.GetOptions().DeferCutover
+	return apply.DatabaseType == storage.DatabaseTypeMySQL && storage.ApplyOptionsFromMap(options).DeferCutover
 }
 
 func (c *LocalClient) setApplyCancel(cancel context.CancelFunc) uint64 {
@@ -292,18 +297,18 @@ func (c *LocalClient) cancelApplyHandle(handle applyCancelHandle) {
 	c.cancelMu.Unlock()
 }
 
-func (c *LocalClient) startApplyExecution(ctx context.Context, cancelGeneration uint64, cancel context.CancelFunc, apply *storage.Apply, tasks []*storage.Task, plan *storage.Plan, options map[string]string) {
+func (c *LocalClient) startApplyExecution(ctx context.Context, cancelGeneration uint64, cancel context.CancelFunc, apply *storage.Apply, tasks []*storage.Task, plan *storage.Plan, options map[string]string, releaseAtCutoverBarrier bool) {
 	go func() {
 		defer c.clearApplyCancel(cancelGeneration)
 		defer cancel()
-		c.runApplyExecution(ctx, apply, tasks, plan, options)
+		c.runApplyExecution(ctx, apply, tasks, plan, options, releaseAtCutoverBarrier)
 	}()
 }
 
-func (c *LocalClient) runApplyExecution(ctx context.Context, apply *storage.Apply, tasks []*storage.Task, plan *storage.Plan, options map[string]string) {
-	if c.usesGroupedApply(apply) {
+func (c *LocalClient) runApplyExecution(ctx context.Context, apply *storage.Apply, tasks []*storage.Task, plan *storage.Plan, options map[string]string, releaseAtCutoverBarrier bool) {
+	if c.usesGroupedApply(apply, options) {
 		c.runWithRecovery(ctx, apply, tasks, func() {
-			c.executeGroupedApply(ctx, apply, tasks, plan, options)
+			c.executeGroupedApply(ctx, apply, tasks, plan, options, releaseAtCutoverBarrier)
 		})
 		return
 	}

--- a/pkg/tern/local_apply_grouped.go
+++ b/pkg/tern/local_apply_grouped.go
@@ -15,12 +15,12 @@ import (
 
 // executeGroupedApply runs all DDLs in one engine operation. For Spirit with
 // defer_cutover, this is atomic cutover; for Vitess, this is one deploy request.
-func (c *LocalClient) executeGroupedApply(ctx context.Context, apply *storage.Apply, tasks []*storage.Task, plan *storage.Plan, options map[string]string) {
+func (c *LocalClient) executeGroupedApply(ctx context.Context, apply *storage.Apply, tasks []*storage.Task, plan *storage.Plan, options map[string]string, releaseAtCutoverBarrier bool) {
 	ctx, cancelApply := context.WithCancel(ctx)
 	defer cancelApply()
 	defer c.startApplyHeartbeat(ctx, apply, cancelApply)()
-	mode := groupedApplyMode(apply)
-	modeDescription := groupedApplyModeDescription(apply)
+	mode := groupedApplyMode(apply, options)
+	modeDescription := groupedApplyModeDescription(apply, options)
 
 	// Extract all DDLs and table names from tasks
 	ddl := make([]string, len(tasks))
@@ -233,7 +233,7 @@ func (c *LocalClient) executeGroupedApply(ctx context.Context, apply *storage.Ap
 		fmt.Sprintf("All %d tables started copying in parallel", len(tasks)), state.Apply.Pending, apply.State)
 
 	// Poll for completion - all tasks share the same state
-	c.pollForCompletionAtomic(ctx, apply, tasks, creds, resumeState)
+	c.pollForCompletionAtomic(ctx, apply, tasks, creds, resumeState, options, releaseAtCutoverBarrier)
 }
 
 func (c *LocalClient) saveEngineResumeState(ctx context.Context, tasks []*storage.Task, resumeState *engine.ResumeState) error {
@@ -508,7 +508,7 @@ func (c *LocalClient) deriveAggregateApplyState(ctx context.Context, apply *stor
 // Each table copies and cuts over independently.
 
 // pollForCompletionAtomic polls the engine for progress in atomic mode (all tasks share state).
-func (c *LocalClient) pollForCompletionAtomic(ctx context.Context, apply *storage.Apply, tasks []*storage.Task, creds *engine.Credentials, resumeState *engine.ResumeState) {
+func (c *LocalClient) pollForCompletionAtomic(ctx context.Context, apply *storage.Apply, tasks []*storage.Task, creds *engine.Credentials, resumeState *engine.ResumeState, options map[string]string, releaseAtCutoverBarrier bool) {
 	eng := c.getEngine()
 	ticker := time.NewTicker(500 * time.Millisecond)
 	defer ticker.Stop()
@@ -520,7 +520,7 @@ func (c *LocalClient) pollForCompletionAtomic(ctx context.Context, apply *storag
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			if done := c.handleAtomicProgressTick(ctx, eng, apply, tasks, creds, resumeState, ps); done {
+			if done := c.handleAtomicProgressTick(ctx, eng, apply, tasks, creds, resumeState, ps, options, releaseAtCutoverBarrier); done {
 				return
 			}
 		}
@@ -554,7 +554,7 @@ func applyQuiesceDecision(projectedApplyState string) (quiesce, retryablePause, 
 // tasks settled while a sibling holds the apply running. The apply-level
 // wind-down runs only when the aggregate quiesces, not when a single operation
 // finishes ahead of its siblings.
-func (c *LocalClient) handleAtomicProgressTick(ctx context.Context, eng engine.Engine, apply *storage.Apply, tasks []*storage.Task, creds *engine.Credentials, resumeState *engine.ResumeState, ps *atomicPollState) bool {
+func (c *LocalClient) handleAtomicProgressTick(ctx context.Context, eng engine.Engine, apply *storage.Apply, tasks []*storage.Task, creds *engine.Credentials, resumeState *engine.ResumeState, ps *atomicPollState, options map[string]string, releaseAtCutoverBarrier bool) bool {
 	if handled, err := c.processPendingStopControlRequest(ctx, apply); err != nil {
 		c.logger.Warn("pending stop request processing failed; current apply owner will exit for operator retry",
 			"apply_id", apply.ApplyIdentifier, "error", err)
@@ -643,7 +643,7 @@ func (c *LocalClient) handleAtomicProgressTick(ctx context.Context, eng engine.E
 		return true
 	}
 
-	opts := apply.GetOptions()
+	opts := storage.ApplyOptionsFromMap(options)
 	controlReq := &engine.ControlRequest{
 		Database:    apply.Database,
 		Credentials: creds,
@@ -682,8 +682,11 @@ func (c *LocalClient) handleAtomicProgressTick(ctx context.Context, eng engine.E
 		}
 	}
 
-	// Timeout: cancel the apply if waiting for manual cutover too long.
-	if result.State == engine.StateWaitingForCutover && opts.DeferCutover &&
+	// Timeout: cancel the apply if waiting for manual cutover too long. An
+	// operation parking at the barrier under an ordered-cutover policy is exempt:
+	// it releases the copy drive below for the deployment-ordered cutover claim
+	// to pick up later, so it must not be cancelled for "inaction".
+	if result.State == engine.StateWaitingForCutover && opts.DeferCutover && !releaseAtCutoverBarrier &&
 		!ps.stateEnteredAt.IsZero() && time.Since(ps.stateEnteredAt) > waitingForManualActionTimeout {
 		c.logger.Info("waiting-for-cutover timed out, cancelling apply",
 			"apply_id", apply.ApplyIdentifier, "timeout", waitingForManualActionTimeout)
@@ -810,13 +813,13 @@ func (c *LocalClient) handleAtomicProgressTick(ctx context.Context, eng engine.E
 		switch {
 		case retryableFailure:
 			c.logger.Warn("apply paused for operator retry",
-				"mode", groupedApplyMode(apply), "apply_id", apply.ApplyIdentifier, "error", apply.ErrorMessage, "task_count", len(tasks))
+				"mode", groupedApplyMode(apply, options), "apply_id", apply.ApplyIdentifier, "error", apply.ErrorMessage, "task_count", len(tasks))
 		case state.IsState(apply.State, state.Apply.Failed):
 			c.logger.Error("apply failed",
-				"mode", groupedApplyMode(apply), "apply_id", apply.ApplyIdentifier, "error", apply.ErrorMessage, "task_count", len(tasks))
+				"mode", groupedApplyMode(apply, options), "apply_id", apply.ApplyIdentifier, "error", apply.ErrorMessage, "task_count", len(tasks))
 		default:
 			c.logger.Info("apply completed",
-				"mode", groupedApplyMode(apply), "apply_id", apply.ApplyIdentifier, "state", apply.State, "task_count", len(tasks))
+				"mode", groupedApplyMode(apply, options), "apply_id", apply.ApplyIdentifier, "state", apply.State, "task_count", len(tasks))
 		}
 		eventMessage := fmt.Sprintf("Apply completed with state: %s", apply.State)
 		if retryableFailure {
@@ -868,9 +871,22 @@ func (c *LocalClient) handleAtomicProgressTick(ctx context.Context, eng engine.E
 	// state, so the apply-level gate already fired when it finished and this is
 	// never reached — single-operation behaviour is unchanged.
 	opState := state.DeriveApplyState(taskStates(tasks))
+	// Park-and-release at the cutover barrier. Under an ordered-cutover policy a
+	// multi-deployment operation runs its copy phase and then stops at
+	// waiting_for_cutover instead of holding the claim for a manual cutover: the
+	// drive exits so the operator persists the operation row at
+	// waiting_for_cutover (completed_at nil) and frees it for the
+	// deployment-ordered cutover claim. releaseAtCutoverBarrier is set only for
+	// multi-operation barrier operations, so single-operation drives (including
+	// manual --defer-cutover) keep waiting for a manual cutover unchanged.
+	if releaseAtCutoverBarrier && state.IsState(opState, state.Apply.WaitingForCutover) {
+		c.logger.Info("operation parked at cutover barrier; exiting copy drive",
+			"mode", groupedApplyMode(apply, options), "apply_id", apply.ApplyIdentifier, "operation_state", opState, "apply_state", apply.State)
+		return true
+	}
 	if state.IsTerminalApplyState(opState) || state.IsState(opState, state.Apply.FailedRetryable) {
 		c.logger.Info("operation settled while apply continues; exiting operation drive",
-			"mode", groupedApplyMode(apply), "apply_id", apply.ApplyIdentifier, "operation_state", opState, "apply_state", apply.State)
+			"mode", groupedApplyMode(apply, options), "apply_id", apply.ApplyIdentifier, "operation_state", opState, "apply_state", apply.State)
 		return true
 	}
 	return false

--- a/pkg/tern/local_client.go
+++ b/pkg/tern/local_client.go
@@ -1395,7 +1395,10 @@ func (c *LocalClient) Apply(ctx context.Context, req *ternv1.ApplyRequest) (*ter
 	// Start apply in background with cancellable context (Stop() cancels this)
 	applyCtx, cancelApply := context.WithCancel(context.WithoutCancel(ctx))
 	cancelGeneration := c.setApplyCancel(cancelApply)
-	c.startApplyExecution(applyCtx, cancelGeneration, cancelApply, apply, tasks, plan, options)
+	// A fresh dispatch (including a remote gRPC drive) has no operation context,
+	// so it never auto-parks at the cutover barrier; ordered-cutover parking is
+	// driven by the operator's operation-scoped resume path.
+	c.startApplyExecution(applyCtx, cancelGeneration, cancelApply, apply, tasks, plan, options, false)
 
 	return &ternv1.ApplyResponse{
 		Accepted: true,

--- a/pkg/tern/local_client_integration_test.go
+++ b/pkg/tern/local_client_integration_test.go
@@ -3303,7 +3303,7 @@ func TestLocalClient_AtomicRetryableFailureQueuesOperatorRetry(t *testing.T) {
 	// The engine reports a failed result with Retryable=true. The local Tern
 	// worker should stop this attempt, keep the apply non-terminal, and leave
 	// already-completed task work untouched for the operator retry.
-	client.pollForCompletionAtomic(ctx, apply, tasks, &engine.Credentials{DSN: dsn}, nil)
+	client.pollForCompletionAtomic(ctx, apply, tasks, &engine.Credentials{DSN: dsn}, nil, apply.GetOptions().Map(), false)
 
 	failedApply, err := stor.Applies().Get(ctx, applyID)
 	require.NoError(t, err)

--- a/pkg/tern/local_client_test.go
+++ b/pkg/tern/local_client_test.go
@@ -883,7 +883,7 @@ func TestLaunchAtomicResumeSaveFailureStaysRecoverable(t *testing.T) {
 	}
 	client, apply, tasks, plan, applyStore := reattachResumeFixture(store, applyResult)
 
-	err := client.launchAtomicResume(t.Context(), apply, tasks, plan, buildApplyOptions(apply), "Recovering from checkpoint", false, false)
+	err := client.launchAtomicResume(t.Context(), apply, tasks, plan, apply.GetOptions().Map(), "Recovering from checkpoint", false, false, false)
 
 	require.Error(t, err)
 	assert.ErrorIs(t, err, errGroupedResumeStateUnavailable)
@@ -914,7 +914,7 @@ func TestLaunchAtomicResumeMissingMetadataStaysRecoverable(t *testing.T) {
 	}
 	client, apply, tasks, plan, applyStore := reattachResumeFixture(store, applyResult)
 
-	err := client.launchAtomicResume(t.Context(), apply, tasks, plan, buildApplyOptions(apply), "Recovering from checkpoint", false, false)
+	err := client.launchAtomicResume(t.Context(), apply, tasks, plan, apply.GetOptions().Map(), "Recovering from checkpoint", false, false, false)
 
 	require.Error(t, err)
 	assert.ErrorIs(t, err, errGroupedResumeStateUnavailable)
@@ -1092,7 +1092,7 @@ func TestLocalClient_ProcessPendingStartControlRequestWaitsForPendingStop(t *tes
 		logger:       slog.Default(),
 	}
 
-	handled, err := client.processPendingStartControlRequest(t.Context(), apply)
+	handled, err := client.processPendingStartControlRequest(t.Context(), apply, apply.GetOptions().Map(), false)
 	require.NoError(t, err)
 	assert.False(t, handled)
 	assert.Equal(t, 0, fakeEngine.startCount, "pending stop must win before start is processed")
@@ -1142,7 +1142,7 @@ func TestLocalClient_ProcessPendingStartControlRequestStartsDeferredDeploy(t *te
 		logger:       slog.Default(),
 	}
 
-	handled, err := client.processPendingStartControlRequest(t.Context(), apply)
+	handled, err := client.processPendingStartControlRequest(t.Context(), apply, apply.GetOptions().Map(), false)
 	require.NoError(t, err)
 	assert.True(t, handled)
 	assert.Equal(t, 1, fakeEngine.startCount)
@@ -2227,7 +2227,7 @@ func TestHandleAtomicProgressTickOperationGate(t *testing.T) {
 		}
 		client := &LocalClient{storage: stor, logger: slog.Default()}
 		ps := &atomicPollState{lastProgressLog: time.Now()}
-		done := client.handleAtomicProgressTick(t.Context(), completedEngine(), apply, tasks, &engine.Credentials{}, nil, ps)
+		done := client.handleAtomicProgressTick(t.Context(), completedEngine(), apply, tasks, &engine.Credentials{}, nil, ps, apply.GetOptions().Map(), false)
 		return done, apply
 	}
 
@@ -2252,6 +2252,66 @@ func TestHandleAtomicProgressTickOperationGate(t *testing.T) {
 		assert.True(t, done, "polling must stop when the apply quiesces")
 		assert.Equal(t, state.Apply.Completed, apply.State, "a single-operation apply terminalizes when its operation completes")
 		assert.NotNil(t, apply.CompletedAt, "a completed apply stamps completed_at")
+	})
+}
+
+// Under an ordered-cutover policy a multi-deployment operation runs its copy
+// phase and then parks at the barrier: the copy drive must exit (release the
+// claim) so the operator can persist the operation row at waiting_for_cutover
+// and the deployment-ordered cutover claim can drive the swap later. A drive
+// that is not releasing at the barrier (single-op / manual --defer-cutover)
+// keeps polling and holds the claim for a manual cutover.
+func TestHandleAtomicProgressTickReleasesAtCutoverBarrier(t *testing.T) {
+	newApply := func() *storage.Apply {
+		return &storage.Apply{
+			ID:              9,
+			ApplyIdentifier: "apply-barrier-park",
+			Database:        "testdb",
+			State:           state.Apply.Running,
+			Options:         storage.MarshalApplyOptions(storage.ApplyOptions{DeferCutover: true}),
+		}
+	}
+	waitingForCutoverEngine := func() *fakeControlEngine {
+		return &fakeControlEngine{progressResult: &engine.ProgressResult{
+			State:  engine.StateWaitingForCutover,
+			Tables: []engine.TableProgress{{Namespace: "testdb", Table: "users", State: state.Task.WaitingForCutover, Progress: 100}},
+		}}
+	}
+	runTick := func(t *testing.T, releaseAtCutoverBarrier bool) (bool, *storage.Apply) {
+		t.Helper()
+		apply := newApply()
+		opID := int64(1)
+		tasks := []*storage.Task{{
+			TaskIdentifier:   "task-users",
+			ApplyID:          apply.ID,
+			ApplyOperationID: &opID,
+			State:            state.Task.Running,
+			TableName:        "users",
+			Namespace:        "testdb",
+		}}
+		stor := &exactProgressStorage{
+			applies:         &snapshotApplyStore{stored: *apply},
+			tasks:           &exactProgressTaskStore{tasks: tasks},
+			controlRequests: &testControlRequestStore{},
+			applyOperations: &listApplyOperationStore{ops: []*storage.ApplyOperation{{ID: opID, State: state.ApplyOperation.Running}}},
+		}
+		client := &LocalClient{storage: stor, logger: slog.Default()}
+		ps := &atomicPollState{lastProgressLog: time.Now()}
+		done := client.handleAtomicProgressTick(t.Context(), waitingForCutoverEngine(), apply, tasks, &engine.Credentials{}, nil, ps, apply.GetOptions().Map(), releaseAtCutoverBarrier)
+		return done, apply
+	}
+
+	t.Run("barrier auto-park exits the drive without terminalizing", func(t *testing.T) {
+		done, apply := runTick(t, true)
+		assert.True(t, done, "the copy drive must exit so the operation can be persisted parked")
+		assert.False(t, state.IsTerminalApplyState(apply.State), "a parked operation must not terminalize the apply, got %q", apply.State)
+		assert.Nil(t, apply.CompletedAt, "a parked operation must not stamp completed_at")
+	})
+
+	t.Run("manual defer keeps polling for a manual cutover", func(t *testing.T) {
+		done, apply := runTick(t, false)
+		assert.False(t, done, "a manual --defer-cutover drive must keep polling for a manual cutover")
+		assert.Nil(t, apply.CompletedAt, "waiting for cutover must not stamp completed_at")
 	})
 }
 

--- a/pkg/tern/local_control_resume.go
+++ b/pkg/tern/local_control_resume.go
@@ -212,7 +212,7 @@ func (c *LocalClient) startDeferredDeploy(ctx context.Context, apply *storage.Ap
 	}, nil
 }
 
-func (c *LocalClient) processPendingStartControlRequest(ctx context.Context, apply *storage.Apply) (bool, error) {
+func (c *LocalClient) processPendingStartControlRequest(ctx context.Context, apply *storage.Apply, options map[string]string, releaseAtCutoverBarrier bool) (bool, error) {
 	controlReq, err := pendingStartControlRequest(ctx, c.storage, apply)
 	if err != nil {
 		return false, err
@@ -270,7 +270,7 @@ func (c *LocalClient) processPendingStartControlRequest(ctx context.Context, app
 		"environment", apply.Environment,
 		"requested_by", controlRequestCaller(controlReq),
 		"state", apply.State)
-	c.pollForCompletionAtomic(ctx, apply, started.tasks, started.credentials, started.resumeState)
+	c.pollForCompletionAtomic(ctx, apply, started.tasks, started.credentials, started.resumeState, options, releaseAtCutoverBarrier)
 	return true, ctx.Err()
 }
 
@@ -432,11 +432,6 @@ func (c *LocalClient) replanAndFilterTasks(ctx context.Context, apply *storage.A
 	return &replanResult{ActiveTasks: activeTasks, CompletedCount: completedCount}, nil
 }
 
-// buildApplyOptions converts apply options to the string map used by the engine.
-func buildApplyOptions(apply *storage.Apply) map[string]string {
-	return apply.GetOptions().Map()
-}
-
 // prepareRetryableTasksForResume queues only the task work that previously
 // stopped on a retryable engine failure. Completed tasks remain completed, and
 // pending tasks remain queued behind the retried work.
@@ -516,7 +511,7 @@ func (c *LocalClient) markApplyRecovering(ctx context.Context, apply *storage.Ap
 // retry-waiting state; user start calls poll in the background and returns
 // after the engine accepts the resume.
 func (c *LocalClient) launchAtomicResume(ctx context.Context, apply *storage.Apply,
-	tasks []*storage.Task, plan *storage.Plan, options map[string]string, logMessage string, block bool, startRequested bool) error {
+	tasks []*storage.Task, plan *storage.Plan, options map[string]string, logMessage string, block bool, startRequested bool, releaseAtCutoverBarrier bool) error {
 
 	allTasks := tasks
 	eng := c.getEngine()
@@ -656,7 +651,7 @@ func (c *LocalClient) launchAtomicResume(ctx context.Context, apply *storage.App
 		defer cancelPoll()
 		stopHeartbeat := c.startApplyHeartbeat(pollCtx, apply, cancelPoll)
 		defer stopHeartbeat()
-		c.pollForCompletionAtomic(pollCtx, apply, tasks, creds, resumeState)
+		c.pollForCompletionAtomic(pollCtx, apply, tasks, creds, resumeState, options, releaseAtCutoverBarrier)
 		return nil
 	}
 
@@ -665,7 +660,7 @@ func (c *LocalClient) launchAtomicResume(ctx context.Context, apply *storage.App
 	go func() {
 		defer cancelResume()
 		defer stopHeartbeat()
-		c.pollForCompletionAtomic(resumeCtx, apply, tasks, creds, resumeState)
+		c.pollForCompletionAtomic(resumeCtx, apply, tasks, creds, resumeState, options, releaseAtCutoverBarrier)
 	}()
 	return nil
 }
@@ -780,7 +775,9 @@ func (c *LocalClient) ResumeApply(ctx context.Context, apply *storage.Apply) err
 	if err != nil {
 		return fmt.Errorf("get tasks for apply %s: %w", apply.ApplyIdentifier, err)
 	}
-	return c.resumeApplyWithTasks(ctx, apply, tasks)
+	// Whole-apply scope has no single operation to order, so the stored apply
+	// options govern the drive directly (no automatic barrier park).
+	return c.resumeApplyWithTasks(ctx, apply, tasks, apply.GetOptions().Map(), false)
 }
 
 // ResumeApplyOperation starts or resumes a single apply_operation (one
@@ -800,13 +797,31 @@ func (c *LocalClient) ResumeApplyOperation(ctx context.Context, apply *storage.A
 	if len(tasks) == 0 {
 		return fmt.Errorf("apply_operation %d (apply %s): %w", applyOperationID, apply.ApplyIdentifier, ErrNoTasksForApplyOperation)
 	}
-	return c.resumeApplyWithTasks(ctx, apply, tasks)
+	op, err := c.storage.ApplyOperations().Get(ctx, applyOperationID)
+	if err != nil {
+		return fmt.Errorf("get apply_operation %d (apply %s): %w", applyOperationID, apply.ApplyIdentifier, err)
+	}
+	if op == nil {
+		return fmt.Errorf("apply_operation %d (apply %s): %w", applyOperationID, apply.ApplyIdentifier, ErrNoTasksForApplyOperation)
+	}
+	siblings, err := c.storage.ApplyOperations().ListByApply(ctx, apply.ID)
+	if err != nil {
+		return fmt.Errorf("list apply_operations for apply %s: %w", apply.ApplyIdentifier, err)
+	}
+	multiOperation := len(siblings) > 1
+	// A multi-deployment barrier operation auto-defers its cutover and parks
+	// (releases) the copy drive at the barrier; the deployment-ordered cutover
+	// claim drives the swap later. Single-operation or rolling drives are
+	// unchanged.
+	releaseAtCutoverBarrier := shouldAutoDeferCutover(multiOperation, op)
+	options := effectiveCopyDriveOptions(apply, multiOperation, op).Map()
+	return c.resumeApplyWithTasks(ctx, apply, tasks, options, releaseAtCutoverBarrier)
 }
 
 // resumeApplyWithTasks drives an apply (or one of its operations) from the set
 // of tasks the caller has loaded. Callers choose whether tasks are scoped to the
 // whole apply or to a single operation.
-func (c *LocalClient) resumeApplyWithTasks(ctx context.Context, apply *storage.Apply, tasks []*storage.Task) error {
+func (c *LocalClient) resumeApplyWithTasks(ctx context.Context, apply *storage.Apply, tasks []*storage.Task, options map[string]string, releaseAtCutoverBarrier bool) error {
 	if len(tasks) == 0 {
 		c.logger.Warn("no tasks found for apply, marking as failed",
 			"apply_id", apply.ApplyIdentifier)
@@ -822,7 +837,7 @@ func (c *LocalClient) resumeApplyWithTasks(ctx context.Context, apply *storage.A
 	if handled, err := c.processPendingStopControlRequest(ctx, apply); handled || err != nil {
 		return err
 	}
-	if handled, err := c.processPendingStartControlRequest(ctx, apply); handled || err != nil {
+	if handled, err := c.processPendingStartControlRequest(ctx, apply, options, releaseAtCutoverBarrier); handled || err != nil {
 		return err
 	}
 
@@ -842,7 +857,7 @@ func (c *LocalClient) resumeApplyWithTasks(ctx context.Context, apply *storage.A
 	}
 
 	if state.IsState(apply.State, state.Apply.Pending) && apply.StartedAt == nil {
-		c.dispatchQueuedApply(ctx, apply, tasks, plan)
+		c.dispatchQueuedApply(ctx, apply, tasks, plan, options, releaseAtCutoverBarrier)
 		return ctx.Err()
 	}
 
@@ -873,12 +888,11 @@ func (c *LocalClient) resumeApplyWithTasks(ctx context.Context, apply *storage.A
 				if err := c.markApplyRecovering(ctx, apply, tasks); err != nil {
 					return err
 				}
-				options := buildApplyOptions(apply)
 				resumeCtx, cancelResume := context.WithCancel(ctx)
 				cancelGeneration := c.setApplyCancel(cancelResume)
 				defer c.clearApplyCancel(cancelGeneration)
 				defer cancelResume()
-				if err := c.launchAtomicResume(resumeCtx, apply, tasks, plan, options, "Recovering from checkpoint", true, false); err != nil {
+				if err := c.launchAtomicResume(resumeCtx, apply, tasks, plan, options, "Recovering from checkpoint", true, false, releaseAtCutoverBarrier); err != nil {
 					if errors.Is(err, errGroupedResumeStateUnavailable) {
 						c.logger.Warn("deferred cutover recovery could not load persisted engine resume state; current apply owner will exit for operator retry",
 							"apply_id", apply.ApplyIdentifier,
@@ -953,14 +967,12 @@ func (c *LocalClient) resumeApplyWithTasks(ctx context.Context, apply *storage.A
 	c.prepareRetryableTasksForResume(ctx, apply, activeTasks)
 	c.prepareStoppedTasksForResume(ctx, apply, activeTasks, startRequested)
 
-	options := buildApplyOptions(apply)
-
-	if c.usesGroupedApply(apply) {
+	if c.usesGroupedApply(apply, options) {
 		resumeCtx, cancelResume := context.WithCancel(ctx)
 		cancelGeneration := c.setApplyCancel(cancelResume)
 		defer c.clearApplyCancel(cancelGeneration)
 		defer cancelResume()
-		if err := c.launchAtomicResume(resumeCtx, apply, activeTasks, plan, options, fmt.Sprintf("Apply resumed from checkpoint (%s)", groupedApplyModeDescription(apply)), true, startRequested); err != nil {
+		if err := c.launchAtomicResume(resumeCtx, apply, activeTasks, plan, options, fmt.Sprintf("Apply resumed from checkpoint (%s)", groupedApplyModeDescription(apply, options)), true, startRequested, releaseAtCutoverBarrier); err != nil {
 			if errors.Is(err, errGroupedResumeStateUnavailable) {
 				c.logger.Warn("grouped resume could not load persisted engine resume state; current apply owner will exit for operator retry",
 					"apply_id", apply.ApplyIdentifier,
@@ -1027,8 +1039,7 @@ func (c *LocalClient) handleGroupedResumeFailure(ctx context.Context, apply *sto
 	return err
 }
 
-func (c *LocalClient) dispatchQueuedApply(ctx context.Context, apply *storage.Apply, tasks []*storage.Task, plan *storage.Plan) {
-	options := buildApplyOptions(apply)
+func (c *LocalClient) dispatchQueuedApply(ctx context.Context, apply *storage.Apply, tasks []*storage.Task, plan *storage.Plan, options map[string]string, releaseAtCutoverBarrier bool) {
 	applyCtx, cancelApply := context.WithCancel(ctx)
 	cancelGeneration := c.setApplyCancel(cancelApply)
 	defer c.clearApplyCancel(cancelGeneration)
@@ -1041,5 +1052,5 @@ func (c *LocalClient) dispatchQueuedApply(ctx context.Context, apply *storage.Ap
 		"task_count", len(tasks),
 	)
 
-	c.runApplyExecution(applyCtx, apply, tasks, plan, options)
+	c.runApplyExecution(applyCtx, apply, tasks, plan, options, releaseAtCutoverBarrier)
 }

--- a/pkg/tern/local_control_resume.go
+++ b/pkg/tern/local_control_resume.go
@@ -802,7 +802,7 @@ func (c *LocalClient) ResumeApplyOperation(ctx context.Context, apply *storage.A
 		return fmt.Errorf("get apply_operation %d (apply %s): %w", applyOperationID, apply.ApplyIdentifier, err)
 	}
 	if op == nil {
-		return fmt.Errorf("apply_operation %d (apply %s): %w", applyOperationID, apply.ApplyIdentifier, ErrNoTasksForApplyOperation)
+		return fmt.Errorf("apply_operation %d (apply %s): %w", applyOperationID, apply.ApplyIdentifier, ErrApplyOperationRowMissing)
 	}
 	siblings, err := c.storage.ApplyOperations().ListByApply(ctx, apply.ID)
 	if err != nil {
@@ -813,7 +813,7 @@ func (c *LocalClient) ResumeApplyOperation(ctx context.Context, apply *storage.A
 	// (releases) the copy drive at the barrier; the deployment-ordered cutover
 	// claim drives the swap later. Single-operation or rolling drives are
 	// unchanged.
-	releaseAtCutoverBarrier := shouldAutoDeferCutover(multiOperation, op)
+	releaseAtCutoverBarrier := shouldReleaseAtCutoverBarrier(apply, multiOperation, op)
 	options := effectiveCopyDriveOptions(apply, multiOperation, op).Map()
 	return c.resumeApplyWithTasks(ctx, apply, tasks, options, releaseAtCutoverBarrier)
 }


### PR DESCRIPTION
## What & why

OC-2 of the ordered-cutover workstream. Under the `barrier` cutover policy, an operation of a multi-deployment apply now **runs its copy phase and parks at `waiting_for_cutover`** instead of inline-driving to `completed`, so the high-risk atomic swaps can later be driven in deployment order by the cutover claim (OC-3).

Today the operator drives each claimed operation inline (copy + cutover in one claim). OC-1 added the dormant cutover-claim predicate; OC-2 makes the copy drive actually stop at the barrier and hand off.

## Behaviour

```text
gate only                         OC-2 (park + release)
 copy → waiting_for_cutover         copy → waiting_for_cutover
   → block for manual cutover         → release the claim
   → timeout → cancel  ✗              → op row persisted waiting_for_cutover
                                       → OC-3 cutover claim drives it later ✓
```
1. Auto-defer gate — effectiveCopyDriveOptions turns on defer-cutover only for multiOperation && cutover_policy == barrier; the manual --defer-cutover option stays authoritative. Threaded as an execution-only value, never persisted onto the apply.
2. Park & release — the atomic drive exits at waiting_for_cutover (no auto-cutover, no manual-cutover timeout/cancel) so the operator can persist the row and free the claim.
3. Persist parked — persistOperationState records waiting_for_cutover (completed_at nil, resumable).
4. Copy-claim exemption — FindNextApplyOperation no longer re-leases a stale multi-op barrier row parked at the barrier; it is reserved for the cutover claim.

Safety / scope

- Gated on multiOperation && barrier, so single-op, rolling, and manual --defer-cutover are byte-for-byte unchanged (covered by tests).
- Dormant in production: an apply owns one operation today, so the barrier branch is never taken until multi-deployment fan-out lands.
- Local operator drive only. The gRPC remote drive runs a fresh apply with no operation context, so it does not yet park/release at the barrier — this is a deliberate follow-up (needs a transport signal carrying the per-operation barrier decision to the remote drive).
- Sequencing: OC-3 (the cutover claim + ordered cutover drive) must land before the fan-out enablement config flip (tracker PR 11), otherwise parked operations would have no claimer.

Testing / validation

- Unit: defer-cutover truth table; grouped-apply gating honours effective options; park-and-release vs manual-defer keeps polling; op-row persisted at waiting_for_cutover.
- Integration: copy claim skips a stale multi-op barrier parked row, but still re-claims a single-op barrier parked row and a multi-op rolling parked row.
- Full pkg/tern, pkg/api, pkg/storage/mysqlstore unit + integration suites and golangci-lint --new-from-rev origin/main pass.

References

- OC-1 cutover-claim predicate: #398
