### PR TITLE
docs(agents): define "driver" as the lease-holding operator worker

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,6 +92,8 @@ The hook uses `--new-from-rev` to only flag issues introduced by the current bra
 
 **Terminology:** NEVER use the word "migration" in code, comments, CLI output, or error messages. ALWAYS use "schema change" instead.
 
+**Driver terminology:** A *driver* is the operator worker that claims an apply via `FOR UPDATE SKIP LOCKED`, holds its lease (`LeaseOwner` / `LeaseToken`), and *drives* it to a terminal state. Use *driver* (noun) and *drive* (verb) — not *worker* — in new code, comments, logs, docs, and tests for the lease-holding goroutine and the work it performs. This is distinct from the **Go MySQL driver** (`github.com/go-sql-driver/mysql`, `database/sql/driver`): always refer to that as the "Go MySQL driver" or "SQL driver" and keep it import-qualified so the two senses never collide.
+
 **OSS-ready code:** Never reference internal company names or proprietary details in code or comments.
 
 ### PR Self-Review Bar


### PR DESCRIPTION
## What

Adds a "Driver terminology" rule to AGENTS.md: a *driver* is the operator worker that claims an apply, holds its lease, and *drives* it to terminal. New code, comments, logs, docs, and tests should use *driver*/*drive* (not *worker*) for that concept, and keep it distinct from the Go MySQL/SQL driver.

## Why

The lease-holding worker and the "drive" verb are already used informally across the apply path; this makes the vocabulary canonical so future changes and agents stay consistent and don't collide with the SQL-driver sense. Docs-only — no code or behavior change.
