### PR TITLE
deps(spirit): bump to block/spirit#977 throttler fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.14
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.1
 	github.com/aws/aws-sdk-go-v2/service/sts v1.43.3
-	github.com/block/spirit v0.15.0
+	github.com/block/spirit v0.15.1-0.20260617235652-98a38a253173
 	github.com/bradleyfalzon/ghinstallation/v2 v2.18.0
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10

--- a/go.sum
+++ b/go.sum
@@ -113,8 +113,8 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/block/spirit v0.15.0 h1:psKO9ztdgkNn1cmOY6rJJa0UuIvfBGaLzK2p4ppOhm8=
-github.com/block/spirit v0.15.0/go.mod h1:ku7mCCKx7Wk4QrMa/mHnsqQhZkoUD2vdBkpjJEDk4lY=
+github.com/block/spirit v0.15.1-0.20260617235652-98a38a253173 h1:+wbB4brtVUflISkTJsAnkzY+Xw8lTrIvTS3yvanpfN0=
+github.com/block/spirit v0.15.1-0.20260617235652-98a38a253173/go.mod h1:ku7mCCKx7Wk4QrMa/mHnsqQhZkoUD2vdBkpjJEDk4lY=
 github.com/block/tidb/pkg/parser v0.0.0-20260506200501-e528fd979fc8 h1:+OfdTacrEyjlqcRUpBFX9uJ6ROBq6cUjwY4DClhnsdU=
 github.com/block/tidb/pkg/parser v0.0.0-20260506200501-e528fd979fc8/go.mod h1:zDLDsfNBU5+L6T4J9/OgWAHc/WZvMUjbpgHqQ/t3yKo=
 github.com/block/vitess v0.0.0-20260601162944-8318a748ceb1 h1:dnHGiR/N1+X2EM1FGzL4548iCzJcIAnhcMbEt026xHQ=


### PR DESCRIPTION
Bumps `github.com/block/spirit` to the [block/spirit#977](https://github.com/block/spirit/pull/977) merge commit (`98a38a2`, `v0.15.1-0.20260617235652-98a38a253173`) — a forward bump from the `v0.15.0` already on `main`.

#977 fixes two undersizing problems that stall online DDL on small / non-autoscaling Aurora instances:

1. **Throttler self-trip.** The `Threads_running` hard-stop throttled at `Threads_running > vCPUs`. On a 2-vCPU instance that threshold is tripped by Spirit's *own* monitoring footprint (the throttler poll + commit-latency poll + periodic GTID-changeset flush) even with zero production load, so the copy crawls through `BlockWait` timeouts. Now trips at `> vCPUs + selfMonitoringHeadroom(2)`.
2. **Control-plane pool starvation.** The main pool was sized `Threads + WriteThreads + 1`; under a saturated copy the checkpoint/flush/stats queries serialize behind the single spare. Now sized `len(changes) + 2`.

No SchemaBot code changes required. Build is clean on the new pin.

> Affects SchemaBot's own `EnsureSchema` online DDL. The data plane resolves Spirit via its own module graph, so getting the fix there is a separate dependency bump.
