### PR TITLE
fix(vitess): stamp task started_at on terminal progress reconcile

### DIFF
--- a/pkg/tern/local_client.go
+++ b/pkg/tern/local_client.go
@@ -1599,6 +1599,9 @@ func (c *LocalClient) Progress(ctx context.Context, req *ternv1.ProgressRequest)
 				activeTask.State = taskState
 				now := time.Now()
 				activeTask.UpdatedAt = now
+				if activeTask.StartedAt == nil && !state.IsState(taskState, state.Task.Pending) {
+					activeTask.StartedAt = &now
+				}
 				if state.IsTerminalTaskState(taskState) && activeTask.CompletedAt == nil {
 					activeTask.CompletedAt = &now
 				}


### PR DESCRIPTION
## What

When a task reaches a terminal state during a progress poll, also stamp its `started_at` (when it first leaves `pending`), not just `completed_at`.

## Why

Instant DDL produces no `SHOW VITESS_MIGRATIONS` rows, so the engine supplies no per-table timestamps. A task can transition `pending → completed` within a single progress poll, which previously set `completed_at` but left `started_at` nil — surfacing an empty per-table `started_at` in apply progress.

This caused a flaky failure in `TestVitess_Apply_Timestamps` (`table users should have started_at`), seen in [this build](https://github.com/block/schemabot/actions/runs/27727202535/job/82026122370). The bug is pre-existing on `main` and independent of the PR it surfaced on.

## Details
There are two code paths that can observe a task reaching terminal state, and they handle started_at differently:
```
                    task reaches "completed"
                            │
        ┌───────────────────┴───────────────────┐
        ▼                                        ▼
 drive loop:                            Progress() reconcile
 syncAtomicTaskProgress                 branch (local_client.go)
 stamps StartedAt AND CompletedAt       stamped only CompletedAt  ← gap
 (local_apply_grouped.go:1000)
```

## Validation

`TestVitess_Apply_Timestamps` passed 14/14 consecutive local e2e runs after the fix.
