### PR TITLE
fix(operator): keep shared control requests pending until the multi-op rollout settles

### DIFF
--- a/pkg/api/operator.go
+++ b/pkg/api/operator.go
@@ -554,7 +554,21 @@ func (s *Service) recoverMultiApplyOperation(ctx context.Context, workerID int, 
 		// The drive failed closed: the operation has no tasks, so it can never
 		// make progress. Terminalize it now rather than leaving it to be
 		// re-leased on every poll once its heartbeat goes stale.
-		s.failOperationWithoutTasks(operationLeaseCtx, operationLeaseCtx, workerID, op, apply)
+		//
+		// Reload the parent apply first: the pre-drive projection may already
+		// have moved the durable parent from pending to running, and the
+		// failure projection CAS expects the current durable state. Failing
+		// against the stale pre-drive apply would miss the CAS and strand the
+		// parent apply running.
+		failApply := apply
+		if reloaded, reloadErr := s.storage.Applies().Get(operationLeaseCtx, apply.ID); reloadErr != nil {
+			s.logger.Error("operator: failed to reload parent apply before failing task-less operation; using pre-drive apply state",
+				"worker", workerID, "apply_operation_id", op.ID, "apply_id", apply.ApplyIdentifier,
+				"database", apply.Database, "environment", apply.Environment, "error", reloadErr)
+		} else if reloaded != nil {
+			failApply = reloaded
+		}
+		s.failOperationWithoutTasks(operationLeaseCtx, operationLeaseCtx, workerID, op, failApply)
 		return
 	}
 

--- a/pkg/api/operator_test.go
+++ b/pkg/api/operator_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
@@ -813,4 +814,129 @@ func TestUpdateApplyStateFromOperations_StaleWriteSkipped(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, state.Apply.Pending, applyStore.expectedState, "the write must compare-and-swap on the state read before deriving")
 	assert.Nil(t, applyStore.updated, "a CAS miss must not record a persisted projection")
+}
+
+// casApplyStore models the applies row as a compare-and-swap against a single
+// durable state. Get returns the durable state so a reload observes writes made
+// by an earlier UpdateDerivedState, and UpdateDerivedState only swaps when the
+// caller's expected state matches the durable state — exactly like the SQL CAS.
+type casApplyStore struct {
+	storage.ApplyStore
+	mu       sync.Mutex
+	template storage.Apply
+	state    string
+}
+
+func (s *casApplyStore) Get(context.Context, int64) (*storage.Apply, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	a := s.template
+	a.State = s.state
+	return &a, nil
+}
+
+func (s *casApplyStore) UpdateDerivedState(_ context.Context, _ int64, expectedState, newState, _ string, _, _ *time.Time) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.state != expectedState {
+		return false, nil
+	}
+	s.state = newState
+	return true, nil
+}
+
+func (s *casApplyStore) currentState() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.state
+}
+
+// recoverOperationStore backs the single claimed operation through the recover
+// flow: Get/ListByApply return the live row and MarkFailed transitions it.
+type recoverOperationStore struct {
+	storage.ApplyOperationStore
+	mu sync.Mutex
+	op *storage.ApplyOperation
+}
+
+func (s *recoverOperationStore) Get(context.Context, int64) (*storage.ApplyOperation, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	op := *s.op
+	return &op, nil
+}
+
+func (s *recoverOperationStore) ListByApply(context.Context, int64) ([]*storage.ApplyOperation, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	op := *s.op
+	return []*storage.ApplyOperation{&op}, nil
+}
+
+func (s *recoverOperationStore) MarkFailed(_ context.Context, _ int64, errMsg string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.op.State = state.ApplyOperation.Failed
+	s.op.ErrorMessage = errMsg
+	return nil
+}
+
+func (s *recoverOperationStore) Heartbeat(context.Context, int64) error { return nil }
+
+// recoverTestStorage wires the stores the recover flow touches, including the
+// plan lookup the routing tern client requires to build.
+type recoverTestStorage struct {
+	mockStorage
+	applies storage.ApplyStore
+	ops     storage.ApplyOperationStore
+}
+
+func (s *recoverTestStorage) Applies() storage.ApplyStore                  { return s.applies }
+func (s *recoverTestStorage) ApplyOperations() storage.ApplyOperationStore { return s.ops }
+func (s *recoverTestStorage) Plans() storage.PlanStore                     { return &staticPlanStore{} }
+
+// When a multi-deployment operation has no tasks, the recover flow fails it
+// closed. By the time it fails, the pre-drive projection has already moved the
+// durable parent apply from pending to running, so the failure projection must
+// compare-and-swap against the reloaded running state — not the stale pending
+// apply it started the drive with — or the parent is stranded running.
+func TestRecoverMultiApplyOperation_FailsTaskLessOperationAgainstReloadedParent(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	applyStore := &casApplyStore{
+		template: storage.Apply{
+			ID:              7,
+			ApplyIdentifier: "apply-multi-op-recover",
+			Database:        "testdb",
+			DatabaseType:    storage.DatabaseTypeMySQL,
+			Environment:     "staging",
+		},
+		state: state.Apply.Pending,
+	}
+	opStore := &recoverOperationStore{op: &storage.ApplyOperation{
+		ID:         42,
+		ApplyID:    7,
+		Deployment: "west",
+		State:      state.ApplyOperation.Running,
+	}}
+	deploymentClient := &mockTernClient{resumeErr: tern.ErrNoTasksForApplyOperation}
+
+	svc := New(
+		&recoverTestStorage{applies: applyStore, ops: opStore},
+		testServerConfig(),
+		map[string]tern.Client{"west/staging": deploymentClient},
+		logger,
+	)
+
+	svc.recoverMultiApplyOperation(t.Context(), 1, &storage.ApplyOperation{
+		ID:         42,
+		ApplyID:    7,
+		Deployment: "west",
+		State:      state.ApplyOperation.Running,
+	}, storage.OperationLease{})
+
+	assert.Equal(t, state.Apply.Failed, applyStore.currentState(),
+		"the parent apply must be failed after the task-less operation is terminalized against the reloaded running state")
+	assert.Equal(t, state.ApplyOperation.Failed, opStore.op.State,
+		"the task-less operation row must be marked failed")
 }

--- a/pkg/tern/grpc_client.go
+++ b/pkg/tern/grpc_client.go
@@ -675,6 +675,14 @@ func (c *GRPCClient) processPendingStopControlRequest(ctx context.Context, apply
 		if err := c.reconcileTerminalRemoteProgress(ctx, apply, progress.Tables, now, scope); err != nil {
 			return true, err
 		}
+		// In an operation-scoped multi-op drive the stop request is shared
+		// across sibling operations. One operation reaching terminal must not
+		// complete the apply-level stop request, or stopped siblings would stop
+		// observing it before they settle. Leave it pending for the rollout
+		// projection to complete once the aggregate settles.
+		if scope.usesOperationRemoteResume() {
+			return true, nil
+		}
 		if err := completePendingStopControlRequests(ctx, c.storage, apply); err != nil {
 			return true, err
 		}
@@ -744,6 +752,14 @@ func (c *GRPCClient) completeRemoteStopFromTerminalProgress(ctx context.Context,
 	apply.UpdatedAt = now
 	if err := c.reconcileTerminalRemoteProgress(ctx, apply, progress.Tables, now, scope); err != nil {
 		return false, err
+	}
+	// In an operation-scoped multi-op drive the stop request is shared across
+	// sibling operations. One operation reconciling terminal progress must not
+	// complete the apply-level stop request, or stopped siblings would stop
+	// observing it before they settle. Leave it pending for the rollout
+	// projection to complete once the aggregate settles.
+	if scope.usesOperationRemoteResume() {
+		return true, nil
 	}
 	if err := completePendingStopControlRequests(ctx, c.storage, apply); err != nil {
 		return false, err
@@ -1293,7 +1309,7 @@ func (c *GRPCClient) resumeApply(ctx context.Context, apply *storage.Apply, scop
 			return fmt.Errorf("update apply state: %w", err)
 		}
 		if startRequested {
-			if err := completePendingStartControlRequests(ctx, c.storage, apply); err != nil {
+			if err := c.completeApplyStartRequestForScope(ctx, apply, scope); err != nil {
 				return err
 			}
 		}
@@ -1431,7 +1447,7 @@ func (c *GRPCClient) processPendingStartControlRequest(ctx context.Context, appl
 	if err != nil {
 		return fmt.Errorf("update started gRPC deferred deploy %s: %w", apply.ApplyIdentifier, err)
 	}
-	if err := completePendingStartControlRequests(ctx, c.storage, apply); err != nil {
+	if err := c.completeApplyStartRequestForScope(ctx, apply, scope); err != nil {
 		return err
 	}
 	if persisted {
@@ -1741,6 +1757,25 @@ func logSkippedRemoteApplyTransition(operation string, remoteApply, storedApply 
 	default:
 		slog.Warn("skipping remote gRPC apply state transition", fields...)
 	}
+}
+
+// completeApplyStartRequestForScope completes the apply-level start control
+// request unless this is an operation-scoped multi-op drive. In a multi-op
+// drive the start request is shared across sibling operations; one operation
+// starting must not complete the shared start request, or stopped siblings
+// would become unclaimable before they resume. The rollout projection completes
+// it once the aggregate settles.
+func (c *GRPCClient) completeApplyStartRequestForScope(ctx context.Context, apply *storage.Apply, scope applyTaskScope) error {
+	if scope.usesOperationRemoteResume() {
+		slog.Debug("skipping apply-level start request completion during multi-operation drive; shared start request is owned by the rollout projection",
+			"apply_id", apply.ApplyIdentifier,
+			"apply_db_id", apply.ID,
+			"apply_operation_id", scope.applyOperationID,
+			"deployment", scope.operation.Deployment,
+			"environment", apply.Environment)
+		return nil
+	}
+	return completePendingStartControlRequests(ctx, c.storage, apply)
 }
 
 // persistParentApply writes the parent applies row unless the drive is a

--- a/pkg/tern/grpc_client.go
+++ b/pkg/tern/grpc_client.go
@@ -666,6 +666,7 @@ func (c *GRPCClient) processPendingStopControlRequest(ctx context.Context, apply
 		return true, fmt.Errorf("sync remote gRPC stop for apply %s remote %s: unmapped remote state %s", apply.ApplyIdentifier, remoteID, remoteApplyStateDescription(progress.State))
 	}
 	now := time.Now()
+	priorState, priorStartedAt, priorUpdatedAt := apply.State, apply.StartedAt, apply.UpdatedAt
 	if apply.StartedAt == nil && !state.IsState(remoteState, state.Apply.Pending) {
 		apply.StartedAt = &now
 	}
@@ -679,8 +680,12 @@ func (c *GRPCClient) processPendingStopControlRequest(ctx context.Context, apply
 		// across sibling operations. One operation reaching terminal must not
 		// complete the apply-level stop request, or stopped siblings would stop
 		// observing it before they settle. Leave it pending for the rollout
-		// projection to complete once the aggregate settles.
+		// projection to complete once the aggregate settles. Restore the
+		// in-memory parent apply fields the driver does not own so this
+		// operation's terminal remote state does not leak onto the shared apply
+		// and let a later stop pass treat the parent as terminal.
 		if scope.usesOperationRemoteResume() {
+			apply.State, apply.StartedAt, apply.UpdatedAt = priorState, priorStartedAt, priorUpdatedAt
 			return true, nil
 		}
 		if err := completePendingStopControlRequests(ctx, c.storage, apply); err != nil {
@@ -745,6 +750,7 @@ func (c *GRPCClient) completeRemoteStopFromTerminalProgress(ctx context.Context,
 		return false, fmt.Errorf("sync remote gRPC stop for apply %s remote %s after stop error: unmapped remote state %s", apply.ApplyIdentifier, apply.ExternalID, remoteApplyStateDescription(progress.State))
 	}
 	now := time.Now()
+	priorState, priorStartedAt, priorUpdatedAt := apply.State, apply.StartedAt, apply.UpdatedAt
 	if apply.StartedAt == nil && !state.IsState(remoteState, state.Apply.Pending) {
 		apply.StartedAt = &now
 	}
@@ -757,8 +763,12 @@ func (c *GRPCClient) completeRemoteStopFromTerminalProgress(ctx context.Context,
 	// sibling operations. One operation reconciling terminal progress must not
 	// complete the apply-level stop request, or stopped siblings would stop
 	// observing it before they settle. Leave it pending for the rollout
-	// projection to complete once the aggregate settles.
+	// projection to complete once the aggregate settles. Restore the in-memory
+	// parent apply fields the driver does not own so this operation's terminal
+	// remote state does not leak onto the shared apply and let a later stop pass
+	// treat the parent as terminal.
 	if scope.usesOperationRemoteResume() {
+		apply.State, apply.StartedAt, apply.UpdatedAt = priorState, priorStartedAt, priorUpdatedAt
 		return true, nil
 	}
 	if err := completePendingStopControlRequests(ctx, c.storage, apply); err != nil {

--- a/pkg/tern/grpc_client_test.go
+++ b/pkg/tern/grpc_client_test.go
@@ -1219,6 +1219,8 @@ func TestGRPCClient_ResumeApplyOperationStopReachingTerminalLeavesApplyStopPendi
 
 	assert.Equal(t, "remote-op-west", server.getStopApplyID(),
 		"the operation's own remote apply id must be stopped, not the parent external_id")
+	assert.Equal(t, state.Apply.Running, apply.State,
+		"one operation reaching terminal must not leak its terminal remote state onto the shared parent apply")
 
 	stopReq, err := controlRequests.GetPending(t.Context(), apply.ID, storage.ControlOperationStop)
 	require.NoError(t, err)

--- a/pkg/tern/grpc_client_test.go
+++ b/pkg/tern/grpc_client_test.go
@@ -1159,6 +1159,144 @@ func TestGRPCClient_ResumeApplyOperationStopsUndispatchedOperationWithoutComplet
 	assert.NotNil(t, stopReq, "the apply-level stop request must remain pending for sibling operations")
 }
 
+func TestGRPCClient_ResumeApplyOperationStopReachingTerminalLeavesApplyStopPending(t *testing.T) {
+	// A multi-deployment apply has one durable stop request shared by every
+	// deployment. When a dispatched operation observes its own remote apply
+	// reaching a terminal state, it must NOT complete the apply-level stop
+	// request: sibling deployments still in flight need to keep observing the
+	// stop. The rollout projection completes the shared request once the
+	// aggregate settles.
+	server := &capturingTernServer{
+		progressState:    ternv1.State_STATE_COMPLETED,
+		progressStateSet: true,
+	}
+	client, cleanup := testCapturingGRPCClient(t, server)
+	defer cleanup()
+
+	apply := &storage.Apply{
+		ID:              7,
+		ApplyIdentifier: "apply-multi-op-stop-terminal",
+		PlanID:          99,
+		Database:        "testdb",
+		DatabaseType:    storage.DatabaseTypeMySQL,
+		Environment:     "staging",
+		State:           state.Apply.Running,
+	}
+	operationID := int64(42)
+	siblingID := int64(43)
+	task := &storage.Task{
+		ID:               11,
+		TaskIdentifier:   "task-users",
+		ApplyID:          apply.ID,
+		ApplyOperationID: &operationID,
+		TableName:        "users",
+		State:            state.Task.Running,
+	}
+	operationStore := &mockApplyOperationStore{ops: map[int64]*storage.ApplyOperation{
+		operationID: {ID: operationID, ApplyID: apply.ID, Deployment: "west", State: state.ApplyOperation.Running, EngineResumeContext: "remote-op-west"},
+		siblingID:   {ID: siblingID, ApplyID: apply.ID, Deployment: "east", State: state.ApplyOperation.Running, EngineResumeContext: "remote-east"},
+	}}
+	controlRequests := &testControlRequestStore{requests: []*storage.ApplyControlRequest{{
+		ApplyID:     apply.ID,
+		Operation:   storage.ControlOperationStop,
+		Status:      storage.ControlRequestPending,
+		RequestedBy: "cli:alice",
+	}}}
+	// Keep the stored parent row a distinct copy so mutating the in-memory apply
+	// during the drive does not leak a terminal state into stored reads.
+	storedApply := *apply
+	client.storage = &mockStorage{
+		applies:         &mockApplyStore{apply: &storedApply},
+		tasks:           &mockTaskStore{tasks: []*storage.Task{task}},
+		logs:            &mockApplyLogStore{},
+		controlRequests: controlRequests,
+		operations:      operationStore,
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+	require.NoError(t, client.ResumeApplyOperation(ctx, apply, operationID))
+
+	assert.Equal(t, "remote-op-west", server.getStopApplyID(),
+		"the operation's own remote apply id must be stopped, not the parent external_id")
+
+	stopReq, err := controlRequests.GetPending(t.Context(), apply.ID, storage.ControlOperationStop)
+	require.NoError(t, err)
+	assert.NotNil(t, stopReq, "the apply-level stop request must remain pending for sibling operations after one operation terminalizes")
+}
+
+func TestGRPCClient_ResumeApplyOperationStartLeavesApplyStartPending(t *testing.T) {
+	// A multi-deployment apply has one durable start request shared by every
+	// deployment. When one operation starts its own remote apply, it must NOT
+	// complete the apply-level start request: stopped sibling deployments still
+	// need it pending so they remain claimable and can resume. The rollout
+	// projection completes the shared request once the aggregate settles.
+	server := &capturingTernServer{
+		progressState:    ternv1.State_STATE_STOPPED,
+		progressStateSet: true,
+	}
+	client, cleanup := testCapturingGRPCClient(t, server)
+	defer cleanup()
+
+	apply := &storage.Apply{
+		ID:              7,
+		ApplyIdentifier: "apply-multi-op-start-pending",
+		PlanID:          99,
+		Database:        "testdb",
+		DatabaseType:    storage.DatabaseTypeMySQL,
+		Environment:     "staging",
+		State:           state.Apply.Running,
+	}
+	apply.SetOptions(storage.ApplyOptions{Target: "testdb-target"})
+	operationID := int64(42)
+	siblingID := int64(43)
+	task := &storage.Task{
+		ID:               11,
+		TaskIdentifier:   "task-users",
+		ApplyID:          apply.ID,
+		ApplyOperationID: &operationID,
+		TableName:        "users",
+		State:            state.Task.Stopped,
+	}
+	taskStore := &mockTaskStore{
+		tasks:           []*storage.Task{task},
+		getByApplyIDErr: errors.New("whole-apply task load must not be used for operation-scoped resume"),
+	}
+	operationStore := &mockApplyOperationStore{ops: map[int64]*storage.ApplyOperation{
+		operationID: {ID: operationID, ApplyID: apply.ID, Deployment: "west", State: state.ApplyOperation.Stopped, EngineResumeContext: "remote-op-west"},
+		siblingID:   {ID: siblingID, ApplyID: apply.ID, Deployment: "east", State: state.ApplyOperation.Stopped, EngineResumeContext: "remote-east"},
+	}}
+	controlRequests := &testControlRequestStore{requests: []*storage.ApplyControlRequest{{
+		ApplyID:     apply.ID,
+		Operation:   storage.ControlOperationStart,
+		Status:      storage.ControlRequestPending,
+		RequestedBy: "cli:alice",
+	}}}
+	storedApply := *apply
+	client.storage = &mockStorage{
+		applies:         &mockApplyStore{apply: &storedApply},
+		tasks:           taskStore,
+		logs:            &mockApplyLogStore{},
+		controlRequests: controlRequests,
+		operations:      operationStore,
+		plans: &mockPlanStore{plan: &storage.Plan{
+			ID:             apply.PlanID,
+			PlanIdentifier: "plan-multi-op-start-pending",
+		}},
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+	require.NoError(t, client.ResumeApplyOperation(ctx, apply, operationID))
+
+	assert.Equal(t, "remote-op-west", server.getStartApplyID(),
+		"the operation's own remote apply id must be started, not the parent external_id")
+
+	startReq, err := controlRequests.GetPending(t.Context(), apply.ID, storage.ControlOperationStart)
+	require.NoError(t, err)
+	assert.NotNil(t, startReq, "the apply-level start request must remain pending for sibling operations after one operation starts")
+}
+
 func TestGRPCClient_ResumeApplyOperationFailureRecordsTasksOnlyForMultiOpApply(t *testing.T) {
 	// When a multi-deployment operation's remote dispatch is rejected, the drive
 	// records the failure on that operation's own tasks and returns the error,


### PR DESCRIPTION
## What

Three fixes to the operation-scoped multi-deployment drive:

- **Stop:** one operation reaching terminal no longer completes the apply-level stop request — it stays pending for siblings.
- **Start:** one operation starting no longer completes the apply-level start request — stopped siblings stay claimable.
- **Task-less failure:** reload the parent apply before failing a task-less operation so the failure CAS swaps against the durable state.

## Why

The stop/start control requests and parent apply state are shared across all deployments and owned by the operator's projection, not the driver. Completing them from one operation's progress let siblings stop observing the stop, become unclaimable, or strand the parent `running` after a CAS miss.
```
stop:  before  one op terminal ─▶ completes shared stop ─▶ siblings stop observing
after   leaves pending ─▶ projection completes on aggregate settle
start: before  one op starts ─▶ completes shared start ─▶ stopped siblings unclaimable
after   leaves pending ─▶ siblings stay claimable / resumable
CAS:   before  fail uses stale pending apply ─▶ CAS miss ─▶ parent stranded running
after   reload parent (running) ─▶ CAS swaps running ─▶ failed
```
## Testing

`go build ./...`, `go test ./pkg/tern/ ./pkg/api/`, and `golangci-lint run --new-from-rev origin/main` pass. Three new tests cover each invariant; each was verified to fail when its fix is reverted.
