### PR TITLE
fix(tern): leave apply-level stop to operator on operation-only drives

### DIFF
--- a/pkg/tern/grpc_client.go
+++ b/pkg/tern/grpc_client.go
@@ -574,6 +574,7 @@ func logOperationDriveLeavesParentStop(apply *storage.Apply, scope applyTaskScop
 	slog.Info("operation-only drive leaving apply-level stop request for operator projection",
 		"apply_id", apply.ApplyIdentifier,
 		"apply_operation_id", scope.applyOperationID,
+		"remote_apply_id", scope.remoteApplyID(apply),
 		"database", apply.Database,
 		"environment", apply.Environment,
 		"state", apply.State)
@@ -591,7 +592,8 @@ func (c *GRPCClient) processPendingStopControlRequest(ctx context.Context, apply
 		// An operation-only drive must not complete the apply-level stop
 		// request: the operator projection owns it and completes it once the
 		// parent apply derives terminal. If the parent is already terminal in
-		// storage the operator has resolved it, so this drive is done; if not,
+		// storage there is no more remote work for this drive to do, so leave
+		// the stop pending for the operator projection to resolve; otherwise
 		// fall through so this drive can still stop its own operation's remote
 		// work and leave the parent stop pending for the operator.
 		storedApply, err := c.storage.Applies().Get(ctx, apply.ID)

--- a/pkg/tern/grpc_client.go
+++ b/pkg/tern/grpc_client.go
@@ -564,6 +564,21 @@ func (c *GRPCClient) Stop(ctx context.Context, req *ternv1.StopRequest) (*ternv1
 	return c.client.Stop(ctx, req)
 }
 
+// logOperationDriveLeavesParentStop records that a multi-operation
+// operation-only drive observed an apply-level pending stop request and is
+// leaving it pending. Such a drive owns only its operation; the parent stop
+// request is completed by the operator once the projection CAS derives the
+// parent terminal, so completing it from the drive would resolve the
+// apply-level stop early while sibling operations are still live.
+func logOperationDriveLeavesParentStop(apply *storage.Apply, scope applyTaskScope) {
+	slog.Info("operation-only drive leaving apply-level stop request for operator projection",
+		"apply_id", apply.ApplyIdentifier,
+		"apply_operation_id", scope.applyOperationID,
+		"database", apply.Database,
+		"environment", apply.Environment,
+		"state", apply.State)
+}
+
 func (c *GRPCClient) processPendingStopControlRequest(ctx context.Context, apply *storage.Apply, scope applyTaskScope) (bool, error) {
 	controlReq, err := pendingStopControlRequest(ctx, c.storage, apply)
 	if err != nil {
@@ -572,7 +587,26 @@ func (c *GRPCClient) processPendingStopControlRequest(ctx context.Context, apply
 	if controlReq == nil {
 		return false, nil
 	}
-	if completed, err := completePendingStopIfStoredApplyResolved(ctx, c.storage, apply); err != nil {
+	if scope.suppressesDirectParentApplyWrites() {
+		// An operation-only drive must not complete the apply-level stop
+		// request: the operator projection owns it and completes it once the
+		// parent apply derives terminal. If the parent is already terminal in
+		// storage the operator has resolved it, so this drive is done; if not,
+		// fall through so this drive can still stop its own operation's remote
+		// work and leave the parent stop pending for the operator.
+		storedApply, err := c.storage.Applies().Get(ctx, apply.ID)
+		if err != nil {
+			return true, fmt.Errorf("load apply %s before leaving pending stop for operator projection: %w", apply.ApplyIdentifier, err)
+		}
+		if storedApply == nil {
+			return true, fmt.Errorf("load apply %s before leaving pending stop for operator projection: %w", apply.ApplyIdentifier, storage.ErrApplyNotFound)
+		}
+		if state.IsTerminalApplyState(storedApply.State) {
+			*apply = *storedApply
+			logOperationDriveLeavesParentStop(apply, scope)
+			return true, nil
+		}
+	} else if completed, err := completePendingStopIfStoredApplyResolved(ctx, c.storage, apply); err != nil {
 		return true, err
 	} else if completed {
 		slog.Info("completing pending gRPC stop request for resolved apply",
@@ -592,6 +626,10 @@ func (c *GRPCClient) processPendingStopControlRequest(ctx context.Context, apply
 		return true, nil
 	}
 	if state.IsTerminalApplyState(apply.State) {
+		if scope.suppressesDirectParentApplyWrites() {
+			logOperationDriveLeavesParentStop(apply, scope)
+			return true, nil
+		}
 		slog.Info("completing pending gRPC stop request for terminal apply",
 			"apply_id", apply.ApplyIdentifier,
 			"external_id", apply.ExternalID,
@@ -618,6 +656,7 @@ func (c *GRPCClient) processPendingStopControlRequest(ctx context.Context, apply
 			if err := c.stopUndispatchedApplyOperation(ctx, apply, controlRequestCaller(controlReq), scope); err != nil {
 				return true, err
 			}
+			logOperationDriveLeavesParentStop(apply, scope)
 			return true, nil
 		}
 		if err := c.stopUndispatchedApply(ctx, apply, controlRequestCaller(controlReq), scope); err != nil {
@@ -676,16 +715,15 @@ func (c *GRPCClient) processPendingStopControlRequest(ctx context.Context, apply
 		if err := c.reconcileTerminalRemoteProgress(ctx, apply, progress.Tables, now, scope); err != nil {
 			return true, err
 		}
-		// In an operation-scoped multi-op drive the stop request is shared
-		// across sibling operations. One operation reaching terminal must not
-		// complete the apply-level stop request, or stopped siblings would stop
-		// observing it before they settle. Leave it pending for the rollout
-		// projection to complete once the aggregate settles. Restore the
-		// in-memory parent apply fields the driver does not own so this
-		// operation's terminal remote state does not leak onto the shared apply
-		// and let a later stop pass treat the parent as terminal.
-		if scope.usesOperationRemoteResume() {
+		// An operation-only drive owns only its operation: the apply-level stop
+		// request is shared across siblings and completed by the operator
+		// projection once the parent derives terminal. Leave it pending here and
+		// restore the in-memory parent apply fields the driver does not own, so
+		// this operation's terminal remote state does not leak onto the shared
+		// apply and let a later stop pass treat the parent as terminal.
+		if scope.suppressesDirectParentApplyWrites() {
 			apply.State, apply.StartedAt, apply.UpdatedAt = priorState, priorStartedAt, priorUpdatedAt
+			logOperationDriveLeavesParentStop(apply, scope)
 			return true, nil
 		}
 		if err := completePendingStopControlRequests(ctx, c.storage, apply); err != nil {
@@ -759,16 +797,15 @@ func (c *GRPCClient) completeRemoteStopFromTerminalProgress(ctx context.Context,
 	if err := c.reconcileTerminalRemoteProgress(ctx, apply, progress.Tables, now, scope); err != nil {
 		return false, err
 	}
-	// In an operation-scoped multi-op drive the stop request is shared across
-	// sibling operations. One operation reconciling terminal progress must not
-	// complete the apply-level stop request, or stopped siblings would stop
-	// observing it before they settle. Leave it pending for the rollout
-	// projection to complete once the aggregate settles. Restore the in-memory
-	// parent apply fields the driver does not own so this operation's terminal
-	// remote state does not leak onto the shared apply and let a later stop pass
-	// treat the parent as terminal.
-	if scope.usesOperationRemoteResume() {
+	// An operation-only drive owns only its operation: the apply-level stop
+	// request is shared across siblings and completed by the operator projection
+	// once the parent derives terminal. Leave it pending here and restore the
+	// in-memory parent apply fields the driver does not own, so this operation's
+	// terminal remote state does not leak onto the shared apply and let a later
+	// stop pass treat the parent as terminal.
+	if scope.suppressesDirectParentApplyWrites() {
 		apply.State, apply.StartedAt, apply.UpdatedAt = priorState, priorStartedAt, priorUpdatedAt
+		logOperationDriveLeavesParentStop(apply, scope)
 		return true, nil
 	}
 	if err := completePendingStopControlRequests(ctx, c.storage, apply); err != nil {
@@ -1171,7 +1208,7 @@ func (c *GRPCClient) resumeApply(ctx context.Context, apply *storage.Apply, scop
 	}
 	startRequested := startControlReq != nil
 	if startRequested {
-		if err := c.waitForPendingStopBeforeStart(ctx, apply, scope, startControlReq); err != nil {
+		if deferred, err := c.waitForPendingStopBeforeStart(ctx, apply, scope, startControlReq); err != nil || deferred {
 			return err
 		}
 	}
@@ -1278,7 +1315,7 @@ func (c *GRPCClient) resumeApply(ctx context.Context, apply *storage.Apply, scop
 
 		// Only call Start if Tern confirms the apply is actually stopped.
 		if state.IsState(apply.State, state.Apply.Stopped) {
-			if err := c.completePendingStopBeforeRemoteStart(ctx, apply); err != nil {
+			if deferred, err := c.completePendingStopBeforeRemoteStart(ctx, apply, scope); err != nil || deferred {
 				return err
 			}
 			_, err := c.client.Start(ctx, &ternv1.StartRequest{
@@ -1335,16 +1372,33 @@ func (c *GRPCClient) resumeApply(ctx context.Context, apply *storage.Apply, scop
 	return c.pollForCompletion(ctx, apply, startRequested, scope)
 }
 
-func (c *GRPCClient) completePendingStopBeforeRemoteStart(ctx context.Context, apply *storage.Apply) error {
+// completePendingStopBeforeRemoteStart completes an apply-level stop request
+// that raced in just before a remote start. It returns deferred=true when an
+// operation-only drive observes a pending stop: that drive never completes the
+// parent stop (the operator projection owns it), so it must not start remote
+// work and leaves both the stop and start pending for the operator.
+func (c *GRPCClient) completePendingStopBeforeRemoteStart(ctx context.Context, apply *storage.Apply, scope applyTaskScope) (bool, error) {
 	controlReq, err := pendingStopControlRequest(ctx, c.storage, apply)
 	if err != nil {
-		return fmt.Errorf("check pending stop before starting stopped gRPC apply %s: %w", apply.ApplyIdentifier, err)
+		return false, fmt.Errorf("check pending stop before starting stopped gRPC apply %s: %w", apply.ApplyIdentifier, err)
 	}
 	if controlReq == nil {
-		return nil
+		return false, nil
+	}
+	if scope.suppressesDirectParentApplyWrites() {
+		logOperationDriveLeavesParentStop(apply, scope)
+		slog.Info("operation-only drive deferring remote start until apply-level stop resolves",
+			"apply_id", apply.ApplyIdentifier,
+			"apply_operation_id", scope.applyOperationID,
+			"remote_apply_id", scope.remoteApplyID(apply),
+			"database", apply.Database,
+			"environment", apply.Environment,
+			"requested_by", controlRequestCaller(controlReq),
+			"state", apply.State)
+		return true, nil
 	}
 	if err := completePendingStopControlRequests(ctx, c.storage, apply); err != nil {
-		return fmt.Errorf("complete pending stop before starting stopped gRPC apply %s: %w", apply.ApplyIdentifier, err)
+		return false, fmt.Errorf("complete pending stop before starting stopped gRPC apply %s: %w", apply.ApplyIdentifier, err)
 	}
 	slog.Info("completed pending gRPC stop request before starting stopped remote apply",
 		"apply_id", apply.ApplyIdentifier,
@@ -1355,7 +1409,7 @@ func (c *GRPCClient) completePendingStopBeforeRemoteStart(ctx context.Context, a
 		"state", apply.State)
 	c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventStopRequested,
 		fmt.Sprintf("Pending remote stop request completed before start%s", callerApplyLogSuffix(controlRequestCaller(controlReq))), "", "")
-	return nil
+	return false, nil
 }
 
 func hasPendingStartControlRequest(ctx context.Context, store storage.Storage, apply *storage.Apply) (bool, error) {
@@ -1366,15 +1420,49 @@ func hasPendingStartControlRequest(ctx context.Context, store storage.Storage, a
 	return controlReq != nil, nil
 }
 
-func (c *GRPCClient) waitForPendingStopBeforeStart(ctx context.Context, apply *storage.Apply, scope applyTaskScope, startControlReq *storage.ApplyControlRequest) error {
+// waitForPendingStopBeforeStart blocks a pending start until the apply-level
+// stop request resolves. It returns deferred=true when the caller must abandon
+// the start for this drive: an operation-only drive never completes the parent
+// stop (the operator projection owns it), so it stops its own operation's
+// remote work and leaves both the stop and start pending for the operator.
+func (c *GRPCClient) waitForPendingStopBeforeStart(ctx context.Context, apply *storage.Apply, scope applyTaskScope, startControlReq *storage.ApplyControlRequest) (bool, error) {
 	loggedWait := false
 	for {
 		stopReq, err := pendingStopControlRequest(ctx, c.storage, apply)
 		if err != nil {
-			return fmt.Errorf("check pending stop before pending gRPC start for apply %s: %w", apply.ApplyIdentifier, err)
+			return false, fmt.Errorf("check pending stop before pending gRPC start for apply %s: %w", apply.ApplyIdentifier, err)
 		}
 		if stopReq == nil {
-			return nil
+			return false, nil
+		}
+		if scope.suppressesDirectParentApplyWrites() {
+			// Stop this operation's own remote work once, then defer: the
+			// operation-only drive must not spin waiting for a parent stop it
+			// will never complete.
+			handled, err := c.processPendingStopControlRequest(ctx, apply, scope)
+			if err != nil {
+				return false, err
+			}
+			stillPending, err := pendingStopControlRequest(ctx, c.storage, apply)
+			if err != nil {
+				return false, fmt.Errorf("recheck pending stop before deferring pending gRPC start for apply %s: %w", apply.ApplyIdentifier, err)
+			}
+			if stillPending == nil {
+				return false, nil
+			}
+			if !handled {
+				logOperationDriveLeavesParentStop(apply, scope)
+			}
+			slog.Info("operation-only drive deferring pending gRPC start until apply-level stop resolves",
+				"apply_id", apply.ApplyIdentifier,
+				"apply_operation_id", scope.applyOperationID,
+				"remote_apply_id", scope.remoteApplyID(apply),
+				"database", apply.Database,
+				"environment", apply.Environment,
+				"requested_by", controlRequestCaller(startControlReq),
+				"stop_requested_by", controlRequestCaller(stillPending),
+				"state", apply.State)
+			return true, nil
 		}
 		if !loggedWait {
 			slog.Info("pending gRPC start request is waiting for pending stop request to finish",
@@ -1388,11 +1476,11 @@ func (c *GRPCClient) waitForPendingStopBeforeStart(ctx context.Context, apply *s
 			loggedWait = true
 		}
 		if _, err := c.processPendingStopControlRequest(ctx, apply, scope); err != nil {
-			return err
+			return false, err
 		}
 		select {
 		case <-ctx.Done():
-			return ctx.Err()
+			return false, ctx.Err()
 		case <-time.After(grpcProgressPollInterval):
 		}
 	}
@@ -1950,6 +2038,16 @@ func (c *GRPCClient) reconcileTerminalRemoteProgress(ctx context.Context, remote
 			return err
 		}
 		if storedApply != nil && state.IsTerminalApplyState(storedApply.State) {
+			if scope.suppressesDirectParentApplyWrites() {
+				controlReq, err := pendingStopControlRequest(ctx, c.storage, storedApply)
+				if err != nil {
+					return fmt.Errorf("check pending stop after terminal remote progress for apply %s: %w", storedApply.ApplyIdentifier, err)
+				}
+				if controlReq != nil {
+					logOperationDriveLeavesParentStop(storedApply, scope)
+				}
+				return nil
+			}
 			if err := completePendingStopControlRequests(ctx, c.storage, storedApply); err != nil {
 				return err
 			}

--- a/pkg/tern/grpc_client_test.go
+++ b/pkg/tern/grpc_client_test.go
@@ -1299,6 +1299,154 @@ func TestGRPCClient_ResumeApplyOperationStartLeavesApplyStartPending(t *testing.
 	assert.NotNil(t, startReq, "the apply-level start request must remain pending for sibling operations after one operation starts")
 }
 
+func TestGRPCClient_ResumeApplyOperationDispatchedStopLeavesApplyStopPending(t *testing.T) {
+	// A multi-deployment operation that already dispatched (its remote apply id
+	// lives on the operation) stops its own remote work when it sees the shared
+	// stop request, but must NOT complete the apply-level stop request even when
+	// its own remote reaches a terminal state: sibling deployments may still be
+	// live, so the operator's projection owns parent stop completion.
+	server := &capturingTernServer{
+		progressState:    ternv1.State_STATE_STOPPED,
+		progressStateSet: true,
+		progressTables: []*ternv1.TableProgress{{
+			Namespace:       "default",
+			TableName:       "users",
+			Status:          state.Task.Stopped,
+			PercentComplete: 50,
+		}},
+	}
+	client, cleanup := testCapturingGRPCClient(t, server)
+	defer cleanup()
+
+	apply := &storage.Apply{
+		ID:              7,
+		ApplyIdentifier: "apply-multi-op-dispatched-stop",
+		PlanID:          99,
+		Database:        "testdb",
+		DatabaseType:    storage.DatabaseTypeMySQL,
+		Environment:     "staging",
+		State:           state.Apply.Running,
+	}
+	operationID := int64(42)
+	siblingID := int64(43)
+	task := &storage.Task{
+		ID:               11,
+		TaskIdentifier:   "task-users",
+		ApplyID:          apply.ID,
+		ApplyOperationID: &operationID,
+		TableName:        "users",
+		Namespace:        "default",
+		State:            state.Task.Running,
+	}
+	operationStore := &mockApplyOperationStore{ops: map[int64]*storage.ApplyOperation{
+		operationID: {ID: operationID, ApplyID: apply.ID, Deployment: "west", State: state.ApplyOperation.Running, EngineResumeContext: "remote-op-west-1"},
+		siblingID:   {ID: siblingID, ApplyID: apply.ID, Deployment: "east", State: state.ApplyOperation.Running, EngineResumeContext: "remote-op-east-1"},
+	}}
+	controlRequests := &testControlRequestStore{requests: []*storage.ApplyControlRequest{{
+		ApplyID:     apply.ID,
+		Operation:   storage.ControlOperationStop,
+		Status:      storage.ControlRequestPending,
+		RequestedBy: "cli:alice",
+	}}}
+	applyStore := &mockApplyStore{apply: apply}
+	client.storage = &mockStorage{
+		applies:         applyStore,
+		tasks:           &mockTaskStore{tasks: []*storage.Task{task}},
+		logs:            &mockApplyLogStore{},
+		controlRequests: controlRequests,
+		operations:      operationStore,
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+	require.NoError(t, client.ResumeApplyOperation(ctx, apply, operationID))
+
+	assert.Equal(t, "remote-op-west-1", server.getStopApplyID(),
+		"the operation's own remote apply id must be stopped, not the parent external_id")
+	assert.Empty(t, applyStore.updates,
+		"a multi-op drive must never write the parent applies row; parent state is owned by the projection CAS")
+
+	stopReq, err := controlRequests.GetPending(t.Context(), apply.ID, storage.ControlOperationStop)
+	require.NoError(t, err)
+	assert.NotNil(t, stopReq, "the apply-level stop request must remain pending for the operator to complete")
+}
+
+func TestGRPCClient_ResumeApplyOperationDefersStartWhileApplyStopPending(t *testing.T) {
+	// A multi-deployment operation with both a pending start and a pending stop
+	// must not start its remote work or complete the parent stop: it stops its
+	// own remote work and leaves both requests pending for the operator. It must
+	// return promptly rather than spin waiting for a parent stop it never owns.
+	server := &capturingTernServer{
+		progressState:    ternv1.State_STATE_RUNNING,
+		progressStateSet: true,
+	}
+	client, cleanup := testCapturingGRPCClient(t, server)
+	defer cleanup()
+
+	apply := &storage.Apply{
+		ID:              7,
+		ApplyIdentifier: "apply-multi-op-defer-start",
+		PlanID:          99,
+		Database:        "testdb",
+		DatabaseType:    storage.DatabaseTypeMySQL,
+		Environment:     "staging",
+		State:           state.Apply.Running,
+	}
+	operationID := int64(42)
+	siblingID := int64(43)
+	task := &storage.Task{
+		ID:               11,
+		TaskIdentifier:   "task-users",
+		ApplyID:          apply.ID,
+		ApplyOperationID: &operationID,
+		TableName:        "users",
+		Namespace:        "default",
+		State:            state.Task.Running,
+	}
+	operationStore := &mockApplyOperationStore{ops: map[int64]*storage.ApplyOperation{
+		operationID: {ID: operationID, ApplyID: apply.ID, Deployment: "west", State: state.ApplyOperation.Running, EngineResumeContext: "remote-op-west-1"},
+		siblingID:   {ID: siblingID, ApplyID: apply.ID, Deployment: "east", State: state.ApplyOperation.Running, EngineResumeContext: "remote-op-east-1"},
+	}}
+	controlRequests := &testControlRequestStore{requests: []*storage.ApplyControlRequest{
+		{
+			ApplyID:     apply.ID,
+			Operation:   storage.ControlOperationStop,
+			Status:      storage.ControlRequestPending,
+			RequestedBy: "cli:alice",
+		},
+		{
+			ApplyID:     apply.ID,
+			Operation:   storage.ControlOperationStart,
+			Status:      storage.ControlRequestPending,
+			RequestedBy: "cli:bob",
+		},
+	}}
+	applyStore := &mockApplyStore{apply: apply}
+	client.storage = &mockStorage{
+		applies:         applyStore,
+		tasks:           &mockTaskStore{tasks: []*storage.Task{task}},
+		logs:            &mockApplyLogStore{},
+		controlRequests: controlRequests,
+		operations:      operationStore,
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+	require.NoError(t, client.ResumeApplyOperation(ctx, apply, operationID))
+
+	assert.Empty(t, server.getStartApplyID(),
+		"a multi-op drive must not start remote work while the apply-level stop is pending")
+	assert.Empty(t, applyStore.updates,
+		"a multi-op drive must never write the parent applies row; parent state is owned by the projection CAS")
+
+	stopReq, err := controlRequests.GetPending(t.Context(), apply.ID, storage.ControlOperationStop)
+	require.NoError(t, err)
+	assert.NotNil(t, stopReq, "the apply-level stop request must remain pending for the operator to complete")
+	startReq, err := controlRequests.GetPending(t.Context(), apply.ID, storage.ControlOperationStart)
+	require.NoError(t, err)
+	assert.NotNil(t, startReq, "the apply-level start request must remain pending until the stop resolves")
+}
+
 func TestGRPCClient_ResumeApplyOperationFailureRecordsTasksOnlyForMultiOpApply(t *testing.T) {
 	// When a multi-deployment operation's remote dispatch is rejected, the drive
 	// records the failure on that operation's own tasks and returns the error,


### PR DESCRIPTION
## What

In a multi-operation apply, every deployment shares one apply-level stop request. An operation-only drive — one that owns a single `apply_operation` and routes its remote apply id through the operation's resume context — could **complete that shared stop request from its own operation's terminal state**, even while sibling deployments were still live.

This change makes operation-only drives stop only their own operation's remote work and leave the apply-level stop (and any pending start) pending for the operator. The operator's projection CAS completes the stop once the *parent* apply derives terminal.

Guards were added to every parent-stop-completion path on the gRPC drive:

- the resolved-apply and terminal-apply shortcuts
- the dispatched terminal-progress and stop-error reconciliation paths
- the terminal-reconcile fallback
- the start path (`waitForPendingStopBeforeStart`, `completePendingStopBeforeRemoteStart`), which now **defers** instead of starting remote work or spinning on a stop it will never own

## Why

The parent `applies.state` and apply-level stop completion are owned solely by the operator's projection over the operation rows. A drive completing the shared stop from one operation resolves the stop while siblings are still running — last-write-wins on a shared control request. This keeps the drive scoped to its own operation and fail-closed: it never resolves apply-level control state on behalf of its siblings.

## Flow

**Before** — op A reaches terminal first and completes the shared stop while op B is still running, so op B never observes the stop:
```
op A drive (terminal)      shared stop request      op B drive (still running)
│                         │                          │
│ reconcile own op        │                          │
├────────────────────────▶│                          │
│ complete apply-level    │                          │
│ stop                    │                          │
├────────────────────────▶│  COMPLETED ✗             │
│                         │   (B's stop lost)        │
```
**After** — each op stops only its own remote work and leaves the shared stop pending; the operator completes it on the next tick/wake once BOTH ops are terminal:
```
op A drive            op B drive          shared stop        operator projection
│                     │                   │                     │
│ stop+reconcile      │                   │                     │
│ own op (no parent   │                   │                     │
│ write)              │                   │                     │
│ leave pending ──────┼──────────────────▶│ PENDING             │
│                     │ stop+reconcile    │                     │
│                     │ own op (no parent │                     │
│                     │ write)            │                     │
│                     │ leave pending ───▶│ PENDING             │
│                     │                   │                     │
│                     │                   │  ◀── next tick/wake │
│                     │                   │      re-claims &    │
│                     │                   │      re-derives:    │
│                     │                   │      A terminal,    │
│                     │                   │      B terminal ⇒   │
│                     │                   │      parent terminal│
│                     │                   │ COMPLETED ✓ ────────┤
```
The operator loop wakes on either its poll ticker (`OperatorPollInterval`) or a `WakeOperator` signal (fired after an apply is created/updated), then claims each `apply_operation` (`FOR UPDATE SKIP LOCKED`), drives it, and re-derives the parent — completion is not instantaneous and never comes from the drive itself.

**Start path, after** — a pending start defers while a stop is pending:
```
op drive: pending start + pending stop
│ stop own op's remote work
│ leave stop + start pending  ──▶ operator resolves stop, then start
│ return (no remote Start, no spin)
```
## Testing / validation

- `go test ./pkg/tern/...` (unit and `-tags=integration`)
- `golangci-lint run --new-from-rev=origin/main` (default and `integration` build tags)
- New tests: dispatched op stop leaves the apply-level stop pending; pending start+stop defers without starting remote work or writing the parent.

EOF