### PR TITLE
refactor: rename operator worker terminology to driver

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -252,7 +252,7 @@ SchemaBot also stores durable control requests for operations whose accepted
 intent must survive API handler exits or process restarts. `stop`, stopped-state
 `start`, and cutover requests are recorded in
 `apply_control_requests` before the engine side effect is performed. The active
-operator-owned apply worker consumes the request, performs or forwards the
+operator-owned apply driver consumes the request, performs or forwards the
 engine control operation, syncs SchemaBot storage to the resulting state, and
 only then marks the control request completed.
 
@@ -343,10 +343,10 @@ the remaining work is resumed through the normal checkpoint recovery path.
 ```
 
 This preserves single-owner semantics for running applies: a fresh running apply
-with a pending stop request is still owned by its current worker, not claimed by
-a second operator worker. If that worker or process exits before acting, the
+with a pending stop request is still owned by its current driver, not claimed by
+a second operator driver. If that driver or process exits before acting, the
 stale heartbeat makes the apply claimable through the normal operator recovery
-path, and the next worker processes the pending control request before resuming
+path, and the next driver processes the pending control request before resuming
 or dispatching more work.
 
 The gRPC Tern path has additional remote-vs-stored reconciliation cases because
@@ -469,7 +469,7 @@ Unknown raw engine states normalize to `running`. This keeps unfamiliar in-fligh
 Remote gRPC progress is core Tern operator behavior. In gRPC mode, the
 SchemaBot API queues and tracks applies in control-plane storage, while a remote
 Tern deployment executes the schema change and reports progress for its own
-apply ID. The operator worker that claims the stored apply also owns the
+apply ID. The operator driver that claims the stored apply also owns the
 durable progress polling loop for that remote apply.
 
 ```
@@ -479,7 +479,7 @@ CLI / webhook apply request
 SchemaBot API creates stored apply + tasks
         |
         v
-Operator worker claims apply
+Operator driver claims apply
         |
         v
 GRPCClient.ResumeApply()
@@ -488,7 +488,7 @@ GRPCClient.ResumeApply()
         |                        and store remote apply_id as external_id
         |
         v
-Same operator worker polls Progress(apply_id=external_id, environment)
+Same operator driver polls Progress(apply_id=external_id, environment)
         |
         v
 Stored apply/task rows are updated for status, logs, recovery, and UI
@@ -496,7 +496,7 @@ Stored apply/task rows are updated for status, logs, recovery, and UI
 
 HTTP progress endpoints and the CLI/TUI may also request progress, but those
 request-time reads are not the durable synchronization path. The operator
-worker's polling loop is what keeps SchemaBot storage reconciled with the remote
+driver's polling loop is what keeps SchemaBot storage reconciled with the remote
 data plane.
 
 Remote progress requests are scoped by apply ID and environment only:
@@ -518,10 +518,10 @@ Transient progress RPC errors do not cause SchemaBot to send a remote `Stop`
 request. A progress outage only proves the control plane cannot observe the
 remote apply; it does not prove the remote apply should be stopped.
 
-Instead, the operator worker counts consecutive progress polling errors:
+Instead, the operator driver counts consecutive progress polling errors:
 
 ```
-Operator worker polls remote Progress
+Operator driver polls remote Progress
         |
         +-- NotFound / no active change
         |       |
@@ -577,7 +577,7 @@ Webhook handler: "someone commented schemabot apply"
             +-- Wakes operator
                     |
                     v
-                Operator worker claims apply
+                Operator driver claims apply
                     |
                     v
                 Client.ResumeApply()
@@ -620,24 +620,24 @@ stored GitHub context, and errors never fail server startup.
 
 The operator is part of Tern orchestration. The API service starts it on server startup because the server owns process lifecycle, configuration, and the Tern client pool, but the operator's work is to coordinate applies: claim storage records, refresh their heartbeat lease, and call `ResumeApply()` on the right Tern client.
 
-Each operator worker runs immediately on startup, then polls every 10 seconds. The worker claims at most one apply per tick and resumes it through the Tern client for that apply's deployment and environment. Fresh applies also send a best-effort wake signal after their apply and task rows are committed, so a worker can claim them immediately instead of waiting for the next poll tick.
+Each operator driver runs immediately on startup, then polls every 10 seconds. The driver claims at most one apply per tick and resumes it through the Tern client for that apply's deployment and environment. Fresh applies also send a best-effort wake signal after their apply and task rows are committed, so a driver can claim them immediately instead of waiting for the next poll tick.
 
-`operator_workers` controls operator concurrency (the deprecated `operator_workers` alias is still accepted for one release). The default is four workers, so an untuned server can still make progress across independent databases and environments concurrently. More workers help larger installations with many independent schema changes because each worker can claim and resume a different target during the same operator tick.
+`operator_workers` controls operator concurrency (the deprecated `operator_workers` alias is still accepted for one release). The default is four drivers, so an untuned server can still make progress across independent databases and environments concurrently. More drivers help larger installations with many independent schema changes because each driver can claim and resume a different target during the same operator tick.
 
-In a multi-pod deployment, every SchemaBot pod runs its own operator. Each operator has its own configurable worker pool, and every worker coordinates through shared storage before resuming an apply. When a recovered apply came from a PR comment, the worker attaches a reconstructed `ProgressObserver` before calling `ResumeApply()` so the resumed progress poller can keep updating PR comments.
+In a multi-pod deployment, every SchemaBot pod runs its own operator. Each operator has its own configurable driver pool, and every driver coordinates through shared storage before resuming an apply. When a recovered apply came from a PR comment, the driver attaches a reconstructed `ProgressObserver` before calling `ResumeApply()` so the resumed progress poller can keep updating PR comments.
 
 ```
 +--------------------------+      +--------------------------+
 | SchemaBot pod A          |      | SchemaBot pod B          |
 | Operator                 |      | Operator                 |
 | +----------------------+ |      | +----------------------+ |
-| | worker 0             | |      | | worker 0             | |
+| | driver 0             | |      | | driver 0             | |
 | | claim apply work     | |      | | claim apply work     | |
 | | attach Observer      | |      | | attach Observer      | |
 | | ResumeApply          | |      | | ResumeApply          | |
 | +----------------------+ |      | +----------------------+ |
 | +----------------------+ |      | +----------------------+ |
-| | worker 1             | |      | | worker 1             | |
+| | driver 1             | |      | | driver 1             | |
 | | claim apply work     | |      | | claim apply work     | |
 | | attach Observer      | |      | | attach Observer      | |
 | | ResumeApply          | |      | | ResumeApply          | |
@@ -665,52 +665,52 @@ The storage arrows represent operator coordination. The GitHub arrows represent 
 
 A **claim** is an atomic storage operation: it selects one apply that needs work,
 refreshes its `updated_at` heartbeat, and rotates an apply lease token in the
-same transaction. The heartbeat timestamp decides when another worker may try to
-recover the apply; the lease token decides which worker may write. Lease-owned
+same transaction. The heartbeat timestamp decides when another driver may try to
+recover the apply; the lease token decides which driver may write. Lease-owned
 apply updates, task updates, heartbeats, apply logs, and recovered PR-comment
-observer side effects must match the current token. If another worker claims the
-apply and rotates the token, the old worker's writes fail with an ownership error
-and the old worker exits instead of posting stale comments or overwriting newer
+observer side effects must match the current token. If another driver claims the
+apply and rotates the token, the old driver's writes fail with an ownership error
+and the old driver exits instead of posting stale comments or overwriting newer
 state.
 
 ```diagram
-1. worker A claims the apply
+1. driver A claims the apply
 
    ╭──────────╮        claim         ╭──────────────────────────╮
-   │ worker A │─────────────────────▶│ applies row              │
+   │ driver A │─────────────────────▶│ applies row              │
    │ token A  │                      │ updated_at = fresh       │
    ╰──────────╯                      │ lease_token = token A    │
                                      ╰──────────────────────────╯
 
-2. worker A stops heartbeating long enough for recovery
+2. driver A stops heartbeating long enough for recovery
 
    ╭──────────╮                      ╭──────────────────────────╮
-   │ worker A │                      │ applies row              │
+   │ driver A │                      │ applies row              │
    │ token A  │                      │ updated_at = stale       │
    ╰──────────╯                      │ lease_token = token A    │
                                      ╰──────────────────────────╯
 
-3. worker B claims the stale apply and rotates the token
+3. driver B claims the stale apply and rotates the token
 
    ╭──────────╮        claim         ╭──────────────────────────╮
-   │ worker B │─────────────────────▶│ applies row              │
+   │ driver B │─────────────────────▶│ applies row              │
    │ token B  │                      │ updated_at = fresh       │
    ╰──────────╯                      │ lease_token = token B    │
                                      ╰──────────────────────────╯
 
-4. worker A wakes up and tries to write with token A
+4. driver A wakes up and tries to write with token A
 
    ╭──────────╮   write WHERE token=A ╭──────────────────────────╮
-   │ worker A │──────────────────────▶│ applies row              │
+   │ driver A │──────────────────────▶│ applies row              │
    │ token A  │       rejected        │ lease_token = token B    │
    ╰──────────╯                       ╰──────────────────────────╯
 ```
 
-Claims use `FOR UPDATE SKIP LOCKED` so multiple operator workers can run concurrently without taking the same apply.
+Claims use `FOR UPDATE SKIP LOCKED` so multiple operator drivers can run concurrently without taking the same apply.
 
 A running apply becomes claimable after its heartbeat has been stale for more than one minute and it is in a state that can be resumed from persisted metadata. Terminal applies are already done, and stopped applies are not auto-resumed; the user must call `schemabot start`.
 
-Freshly queued applies are also claimable once their task rows exist. `ExecuteApply` stores the pending apply and its initial tasks in one transaction, then sends a best-effort wake signal to the operator. The wake path is only a latency optimization: it nudges one worker to call the same claim path immediately instead of waiting for the next poll tick. It never bypasses storage claims or creates a second queue. If the operator is stopped or a wake is already pending, the signal is skipped and the normal poll loop still finds the apply.
+Freshly queued applies are also claimable once their task rows exist. `ExecuteApply` stores the pending apply and its initial tasks in one transaction, then sends a best-effort wake signal to the operator. The wake path is only a latency optimization: it nudges one driver to call the same claim path immediately instead of waiting for the next poll tick. It never bypasses storage claims or creates a second queue. If the operator is stopped or a wake is already pending, the signal is skipped and the normal poll loop still finds the apply.
 
 ```
 HTTP apply request
@@ -722,7 +722,7 @@ store pending apply + tasks
 best-effort operator wake
       |
       v
-worker calls FindNextApply()
+driver calls FindNextApply()
       |
       v
 claim row + refresh heartbeat
@@ -745,9 +745,9 @@ The named lock is internal storage infrastructure, not user-facing lock state or
 
 If storage cannot acquire the named lock within the bounded wait, the write fails before changing `applies`. If storage cannot confirm lock release, it discards the connection so MySQL releases the session-scoped lock.
 
-The operator relies on that invariant. Additional workers increase concurrency across independent targets; they do not make one database/environment run multiple applies at once.
+The operator relies on that invariant. Additional drivers increase concurrency across independent targets; they do not make one database/environment run multiple applies at once.
 
-If a worker finds no claimable apply, it waits briefly and retries once during the same tick. This lets another worker that lost a claim race pick up a different target without waiting for the next 10-second poll.
+If a driver finds no claimable apply, it waits briefly and retries once during the same tick. This lets another driver that lost a claim race pick up a different target without waiting for the next 10-second poll.
 
 ### Execution Modes
 
@@ -828,7 +828,7 @@ There are two ways to deploy the tern layer:
 
 Used for: local development, self-hosted deployments, single-binary setups.
 
-**gRPC Mode** (`GRPCClient`) — SchemaBot delegates execution to an external Tern service over gRPC. SchemaBot still maintains its own storage for locks, plans, applies, and tasks. HTTP apply requests queue durable control-plane rows first; operator workers dispatch the queued apply to the remote Tern service and then poll it until terminal.
+**gRPC Mode** (`GRPCClient`) — SchemaBot delegates execution to an external Tern service over gRPC. SchemaBot still maintains its own storage for locks, plans, applies, and tasks. HTTP apply requests queue durable control-plane rows first; operator drivers dispatch the queued apply to the remote Tern service and then poll it until terminal.
 
 ```
 ┌──────────────────────────────┐        ┌──────────────────────────────┐
@@ -841,7 +841,7 @@ Used for: local development, self-hosted deployments, single-binary setups.
 │ (locks, plans, applies)      │        │ (remote apply rows)          │
 │      │                       │        │      │                       │
 │      ▼                       │        │      ▼                       │
-│ Operator worker              │        │ Tern Proto Interface         │
+│ Operator driver              │        │ Tern Proto Interface         │
 │      │                       │        │      │                       │
 │      ▼                       │        │      ▼                       │
 │ GRPCClient ──────────────────┼────────▶ Engine ─────────────────────▶│ Target DB
@@ -866,11 +866,11 @@ Apply flow:
     → wakes operator
     → returns apply_id="apply-abc123" to HTTP caller
 
-  Operator worker claims apply "apply-abc123"
+  Operator driver claims apply "apply-abc123"
     → GRPCClient.ResumeApply() calls remote Apply()
     → Tern returns ApplyId:"tern-42"
     → SchemaBot stores external_id="tern-42"
-    → worker polls remote progress until terminal
+    → driver polls remote progress until terminal
 
 Subsequent RPCs (Progress, Stop, Start, Cutover, Volume):
   HTTP caller sends apply_id="apply-abc123"
@@ -888,7 +888,7 @@ Apply flow (local):
     → wakes operator
     → returns apply_id="apply-def456" to HTTP caller
 
-  Operator worker claims apply "apply-def456"
+  Operator driver claims apply "apply-def456"
     → LocalClient.ResumeApply() runs the engine locally
     → external_id remains empty
 

--- a/docs/check-runs.md
+++ b/docs/check-runs.md
@@ -544,25 +544,25 @@ schemabot plan                    # Re-plan all configured environments
 schemabot apply -e <environment>  # Re-run apply gating and create a new apply plan
 ```
 
-A stored check ownership miss means a worker tried to update a stored check row,
-but the row no longer represents the apply that worker is completing. This is
+A stored check ownership miss means a driver tried to update a stored check row,
+but the row no longer represents the apply that driver is completing. This is
 usually healthy race protection: a newer plan, apply, rollback, or stale-check
 reconciliation pass has become the source of truth for that PR/environment/
-database, so the older worker must not overwrite it.
+database, so the older driver must not overwrite it.
 
 Common fail-closed scenarios:
 
 | Scenario | Why SchemaBot blocks | Operator action |
 | --- | --- | --- |
 | PR branch moved while SchemaBot was processing | The work was based on an older commit SHA. Publishing that result on the current PR could be misleading. | Usually wait for the `synchronize` webhook to auto-plan the latest commit. If the required check stays missing or stale, comment `schemabot plan -e <environment>` on the PR, or `schemabot plan` for all configured environments. |
-| Aggregate update skipped for a stale SHA | A background worker tried to publish status for a commit that is no longer the PR head. | Confirm the latest commit has a SchemaBot aggregate check. If it does not, comment `schemabot plan -e <environment>` or `schemabot plan`. |
+| Aggregate update skipped for a stale SHA | A background driver tried to publish status for a commit that is no longer the PR head. | Confirm the latest commit has a SchemaBot aggregate check. If it does not, comment `schemabot plan -e <environment>` or `schemabot plan`. |
 | GitHub unavailable during config discovery | SchemaBot cannot safely read PR metadata or repository contents. | Wait for GitHub API recovery, then comment `schemabot plan -e <environment>` or `schemabot plan`. CLI operations can still manage live schema changes while GitHub is down, but they do not make branch protection pass. |
 | Config discovery failed for a non-GitHub reason | SchemaBot could read GitHub, but could not determine the managed schema config or schema files. | Fix `schemabot.yaml`, the schema file layout, or the invalid SQL/config state. Push the fix, or comment `schemabot plan -e <environment>` after fixing the PR. Use logs with `blocking_reason=schema_config_discovery_failed` for the underlying read or parse failure. |
 | Schema changes found but no configured environments are allowed | The database is configured only for environments this deployment is not allowed to process. Publishing success would hide a deployment/config mismatch. | Align the server database environment config with this deployment's `allowed_environments`, then push the config fix or comment `schemabot plan -e <environment>`. |
 | Accepted apply cannot be tracked | The engine accepted work, but SchemaBot could not store or reload the apply ID needed for progress and check ownership. | Treat this as a storage or apply-tracking incident. Inspect engine state and the `applies` table before retrying; do not rely on branch protection until a new plan reflects the live schema. |
 | Accepted apply could not update required check state | The apply may be running, but SchemaBot could not mark the stored check row `in_progress` with the accepted `apply_id`. | Inspect the accepted apply, storage health, and aggregate check. Retry only after confirming the live schema state and stored check state agree. |
 | Prior-environment check state could not be read | SchemaBot cannot prove that an earlier environment is clean. | Treat this as a SchemaBot storage health issue. Restore storage access, then repeat the blocked command, for example `schemabot apply -e production`. Do not bypass the promotion gate unless this is an explicit breakglass decision. |
-| Stored check ownership miss | A newer plan or apply owns the stored check state for the same PR, environment, and database. Letting the older worker write would overwrite newer safety state. | Inspect the newest apply for that repo/PR/environment/database with the CLI, for example `schemabot status -d <database> -e <environment>` or `schemabot progress <apply-id>`. Let the newest apply finish, or reconcile it with operator commands before retrying PR comments. |
+| Stored check ownership miss | A newer plan or apply owns the stored check state for the same PR, environment, and database. Letting the older driver write would overwrite newer safety state. | Inspect the newest apply for that repo/PR/environment/database with the CLI, for example `schemabot status -d <database> -e <environment>` or `schemabot progress <apply-id>`. Let the newest apply finish, or reconcile it with operator commands before retrying PR comments. |
 | Schema changes were removed while an apply may still be running | The live database may still change even though the current PR no longer represents that change. | Inspect the in-flight apply in Tern or with the CLI. If the change reached the live database, either put the schema change back in the PR and comment `schemabot plan -e <environment>` before applying again, or roll back/reconcile the live schema first. |
 | Stale in-progress row after a pod crash | Stored check state says an apply is running, but the watcher may have died before publishing the terminal result. | Comment `schemabot plan -e <environment>` or `schemabot apply -e <environment>` to trigger stale-check reconciliation. If reconciliation fails, inspect SchemaBot storage and the latest apply for that database. |
 

--- a/docs/grpc-control-edge-cases.md
+++ b/docs/grpc-control-edge-cases.md
@@ -28,7 +28,7 @@ comment workflows.
 
 The gRPC path has two state sources:
 
-- **Remote Tern state** — what the remote data-plane worker reports through
+- **Remote Tern state** — what the remote data-plane driver reports through
   `Progress`, and what it accepts through `Stop`, `Start`, or `Cutover` RPCs.
 - **Stored SchemaBot state** — apply state, durable control requests, apply logs,
   and user-facing progress shown by CLI watch, PR comments, and check runs.
@@ -65,7 +65,7 @@ request against remote Tern, and records the result back in SchemaBot storage.
 ```text
 ╭─────────────╮   ╭─────────────╮   ╭─────────────╮   ╭─────────────╮   ╭─────────────╮
 │ Operator /  │   │ SchemaBot   │   │ SchemaBot   │   │ Scheduler   │   │ Remote Tern │
-│ automation  │──▶│ API         │──▶│ storage     │──▶│ worker      │──▶│ data plane  │
+│ automation  │──▶│ API         │──▶│ storage     │──▶│ driver      │──▶│ data plane  │
 ╰─────────────╯   ╰─────────────╯   ╰─────────────╯   ╰─────────────╯   ╰─────────────╯
      request        validate +       durable intent     claim +          Stop / Start /
                     accept           caller metadata    execute          Cutover RPC
@@ -81,7 +81,7 @@ state; they do not infer state directly from remote Tern.
 ```text
 ╭─────────────╮   ╭─────────────╮   ╭─────────────╮   ╭────────────────╮
 │ Scheduler   │   │ Remote Tern │   │ SchemaBot   │   │ User-visible   │
-│ worker      │──▶│ data plane  │──▶│ storage     │──▶│ observers      │
+│ driver      │──▶│ data plane  │──▶│ storage     │──▶│ observers      │
 ╰─────────────╯   ╰─────────────╯   ╰─────────────╯   ╰────────────────╯
      poll           progress         reconciled        CLI watch,
                     sample           state, errors,    PR comments,

--- a/docs/spirit_progress.md
+++ b/docs/spirit_progress.md
@@ -301,7 +301,7 @@ The `⠋` is a Braille spinner (animated in the TUI, static here).
    `IsComplete`.
 
 4. **Crash recovery loses up to 500ms of progress.** The pollers write to storage every 500ms.
-   On crash, the last persisted snapshot may be up to 500ms stale. Scheduler workers find
+   On crash, the last persisted snapshot may be up to 500ms stale. Scheduler drivers find
    applies with stale heartbeats and call `Tern.ResumeApply()`, which re-plans against the
    actual DB state to determine what still needs to be done.
 

--- a/integration/operator_test.go
+++ b/integration/operator_test.go
@@ -26,9 +26,9 @@ import (
 	"github.com/block/schemabot/pkg/tern"
 )
 
-// These tests exercise operator behavior at two levels: the full worker loop
+// These tests exercise operator behavior at two levels: the full driver loop
 // in the resume tests, and the atomic claim query through FindNextApply.
-// Operator workers use FindNextApply before calling ResumeApply, so direct
+// Operator drivers use FindNextApply before calling ResumeApply, so direct
 // calls keep claim policy tests focused without waiting for ticks.
 
 type operatorClaimFixture struct {
@@ -82,7 +82,7 @@ func (c *blockingResumeClient) waitForResume(t *testing.T, timeout time.Duration
 
 // newOperatorClaimFixture creates a real target database plus a clean SchemaBot
 // metadata store. The claim-policy tests write apply rows directly into storage
-// so they can test operator decisions without depending on worker timing.
+// so they can test operator decisions without depending on driver timing.
 func newOperatorClaimFixture(t *testing.T, appDBPrefix string) *operatorClaimFixture {
 	t.Helper()
 
@@ -148,7 +148,7 @@ func TestOperator_BasicClaimAndResume(t *testing.T) {
 	require.NoError(t, err)
 
 	// Seed storage with a stale running apply and running tasks, matching the
-	// state left behind when a worker stops heartbeating before completing.
+	// state left behind when a driver stops heartbeating before completing.
 	now := time.Now()
 	staleApply := &storage.Apply{
 		ApplyIdentifier: fmt.Sprintf("apply-stale-%d", now.UnixNano()%100000),
@@ -868,7 +868,7 @@ func TestOperator_ClaimRefreshesHeartbeat(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, beforeClaim)
 
-	// Claiming is also the operator's lease renewal; it keeps another worker from immediately reclaiming the same apply.
+	// Claiming is also the operator's lease renewal; it keeps another driver from immediately reclaiming the same apply.
 	claimed, err := stor.Applies().FindNextApply(ctx, "test-owner")
 	require.NoError(t, err)
 	require.NotNil(t, claimed)
@@ -988,8 +988,8 @@ func TestOperator_MultipleWorkersResumeDifferentTargets(t *testing.T) {
 	}
 
 	// The first client blocks after the operator claims its apply. That keeps
-	// one worker occupied across the next poll, so completion of the second
-	// apply proves another worker can claim independent work.
+	// one driver occupied across the next poll, so completion of the second
+	// apply proves another driver can claim independent work.
 	blockingClient1 := newBlockingResumeClient(client1, blockedResume)
 
 	svc := schemabotapi.New(stor, &schemabotapi.ServerConfig{
@@ -1024,9 +1024,9 @@ func TestOperator_MultipleWorkersResumeDifferentTargets(t *testing.T) {
 
 	blockingClient1.waitForResume(t, 5*time.Second)
 
-	// A worker can miss work on the startup claim and pick it up on the next
+	// A driver can miss work on the startup claim and pick it up on the next
 	// poll. The important behavior is that the second apply completes while the
-	// first worker is still blocked.
+	// first driver is still blocked.
 	waitForOperatorAppliesCompleted(t, stor, []int64{apply2ID}, operatorPollInterval+5*time.Second)
 
 	blockedApply, err := stor.Applies().Get(ctx, apply1ID)
@@ -1080,7 +1080,7 @@ func seedStaleOperatorApply(
 
 	now := time.Now()
 	applyID, err := stor.Applies().Create(t.Context(), &storage.Apply{
-		ApplyIdentifier: fmt.Sprintf("apply-multi-worker-%s", dbName),
+		ApplyIdentifier: fmt.Sprintf("apply-multi-driver-%s", dbName),
 		PlanID:          plan.ID,
 		Database:        dbName,
 		DatabaseType:    storage.DatabaseTypeMySQL,
@@ -1095,7 +1095,7 @@ func seedStaleOperatorApply(
 
 	for _, tc := range plan.FlatDDLChanges() {
 		_, err := stor.Tasks().Create(t.Context(), &storage.Task{
-			TaskIdentifier: fmt.Sprintf("task-multi-worker-%s-%s", dbName, tc.Table),
+			TaskIdentifier: fmt.Sprintf("task-multi-driver-%s-%s", dbName, tc.Table),
 			ApplyID:        applyID,
 			PlanID:         plan.ID,
 			Database:       dbName,

--- a/integration/workflow_test.go
+++ b/integration/workflow_test.go
@@ -1398,7 +1398,7 @@ CREATE TABLE ccc_cancelled (
 
 	// Step 3: Poll progress until the retryable failure is durable in storage.
 	// The request that observes the engine failure can briefly return failed
-	// before the background worker persists failed_retryable.
+	// before the background driver persists failed_retryable.
 	var lastState string
 	var errorMessage string
 	var finalTables []any

--- a/pkg/api/README.md
+++ b/pkg/api/README.md
@@ -1,6 +1,6 @@
 # api
 
-Package `api` provides the SchemaBot HTTP API service. It routes requests to Tern clients, manages a lazy client pool, and runs the background scheduler for apply coordination.
+Package `api` provides the SchemaBot HTTP API service. It routes requests to Tern clients, manages a lazy client pool, and runs the background operator for apply coordination.
 
 ## Service
 
@@ -78,9 +78,9 @@ request bodies that try to send database or deployment fields.
 | GET | `/health` | Storage connectivity check |
 | GET | `/tern-health/{deployment}/{environment}` | Tern client health |
 
-## Scheduler
+## Operator
 
-On startup, the service launches a background scheduler (`StartOperator`) that claims apply work from storage. A claim means selecting one apply that needs work and refreshing its heartbeat in the same transaction so the driver has a lease while it starts or resumes the apply.
+On startup, the service launches a background operator (`StartOperator`) that claims apply work from storage. A claim means selecting one apply that needs work and refreshing its heartbeat in the same transaction so the driver has a lease while it starts or resumes the apply.
 
 1. Runs immediately, then polls every 10 seconds per configured driver
 2. Finds fresh queued applies or applies with stale heartbeats (no update for 1+ minute)
@@ -107,7 +107,7 @@ See the top-level [README](../../README.md) for configuration examples.
 |------|---------|
 | `service.go` | `Service` type, Tern client pool, route registration, graceful shutdown |
 | `config.go` | `ServerConfig` loading and validation |
-| `scheduler.go` | Scheduler worker pool and background apply coordination |
+| `operator.go` | Operator driver pool and background apply coordination |
 | `plan_handlers.go` | Plan and Apply HTTP handlers |
 | `control_handlers.go` | Cutover, Stop, Start, Volume, Revert handlers |
 | `progress_handlers.go` | Progress, Status, History handlers |

--- a/pkg/api/README.md
+++ b/pkg/api/README.md
@@ -80,9 +80,9 @@ request bodies that try to send database or deployment fields.
 
 ## Scheduler
 
-On startup, the service launches a background scheduler (`StartScheduler`) that claims apply work from storage. A claim means selecting one apply that needs work and refreshing its heartbeat in the same transaction so the worker has a lease while it starts or resumes the apply.
+On startup, the service launches a background scheduler (`StartScheduler`) that claims apply work from storage. A claim means selecting one apply that needs work and refreshing its heartbeat in the same transaction so the driver has a lease while it starts or resumes the apply.
 
-1. Runs immediately, then polls every 10 seconds per configured worker
+1. Runs immediately, then polls every 10 seconds per configured driver
 2. Finds fresh queued applies or applies with stale heartbeats (no update for 1+ minute)
 3. Claims one apply atomically by selecting it and refreshing its heartbeat in the same transaction
 4. Gets the appropriate Tern client for the database/environment

--- a/pkg/api/README.md
+++ b/pkg/api/README.md
@@ -80,7 +80,7 @@ request bodies that try to send database or deployment fields.
 
 ## Scheduler
 
-On startup, the service launches a background scheduler (`StartScheduler`) that claims apply work from storage. A claim means selecting one apply that needs work and refreshing its heartbeat in the same transaction so the driver has a lease while it starts or resumes the apply.
+On startup, the service launches a background scheduler (`StartOperator`) that claims apply work from storage. A claim means selecting one apply that needs work and refreshing its heartbeat in the same transaction so the driver has a lease while it starts or resumes the apply.
 
 1. Runs immediately, then polls every 10 seconds per configured driver
 2. Finds fresh queued applies or applies with stale heartbeats (no update for 1+ minute)

--- a/pkg/api/control_handlers.go
+++ b/pkg/api/control_handlers.go
@@ -1226,7 +1226,7 @@ func (s *Service) completeResolvedStopBeforeStart(ctx context.Context, client te
 }
 
 // queueStoppedApplyForOperator makes a user start request claimable by a
-// operator worker. Resuming stopped table work can outlive the HTTP request,
+// operator driver. Resuming stopped table work can outlive the HTTP request,
 // so the handler records intent, normalizes a lagging stored apply row to
 // stopped, and wakes the operator.
 func (s *Service) queueStoppedApplyForOperator(ctx context.Context, apply *storage.Apply, caller string) (*ternv1.StartResponse, string, error) {

--- a/pkg/api/enqueue_authorized_apply_integration_test.go
+++ b/pkg/api/enqueue_authorized_apply_integration_test.go
@@ -27,7 +27,7 @@ import (
 // A data-plane host queues control-plane-authorized dispatches through
 // EnqueueAuthorizedApply against real storage. The queued apply must be durable (apply,
 // task, and operation rows committed in one transaction), claimable by an
-// operator worker, and covered by the one-active-apply-per-target invariant —
+// operator driver, and covered by the one-active-apply-per-target invariant —
 // while the gated ExecuteApply path on the same service keeps failing closed
 // because the deployment has no database config to evaluate source policy
 // against.
@@ -148,8 +148,8 @@ func TestEnqueueAuthorizedApplyQueuesDurableApplyAgainstStorage(t *testing.T) {
 	require.ErrorIs(t, err, storage.ErrActiveApplyExists)
 
 	// The committed apply and task rows make the queued apply claimable by an
-	// operator worker.
-	claimed, err := stor.Applies().FindNextApply(ctx, "worker-test")
+	// operator driver.
+	claimed, err := stor.Applies().FindNextApply(ctx, "driver-test")
 	require.NoError(t, err)
 	require.NotNil(t, claimed, "queued apply must be operator-claimable")
 	assert.Equal(t, applyID, claimed.ID)

--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -1526,8 +1526,8 @@ func TestEnqueueAuthorizedApplyRejectsInvalidStoredPlan(t *testing.T) {
 }
 
 // A queued trusted dispatch follows the same durable operator path as gated
-// applies: EnqueueAuthorizedApply stores the pending apply, wakes a worker, and the
-// worker claims and resumes it.
+// applies: EnqueueAuthorizedApply stores the pending apply, wakes a driver, and the
+// driver claims and resumes it.
 func TestEnqueueAuthorizedApplyWakesOperatorForQueuedApply(t *testing.T) {
 	applies := &capturingApplyStore{findCh: make(chan struct{}, 1)}
 	mock := &mockTernClient{resumeCh: make(chan *storage.Apply, 1)}

--- a/pkg/api/operator.go
+++ b/pkg/api/operator.go
@@ -19,7 +19,7 @@ const (
 	OperatorPollInterval = 10 * time.Second
 
 	// HeartbeatTimeout is how long since last heartbeat before
-	// an apply is considered to have a crashed worker and needs recovery.
+	// an apply is considered to have a crashed driver and needs recovery.
 	// FindNextApply uses this (via SQL: updated_at < NOW() - INTERVAL 1 MINUTE).
 	HeartbeatTimeout = 1 * time.Minute
 
@@ -27,11 +27,11 @@ const (
 	// heartbeat fires while ResumeApply runs. It is kept safely below
 	// HeartbeatTimeout so that a large (or misconfigured) operator poll
 	// interval cannot let apply_operations.updated_at go stale and allow a peer
-	// worker to re-claim the operation mid-resume. The effective cadence is
+	// driver to re-claim the operation mid-resume. The effective cadence is
 	// min(operatorPollInterval, ApplyOperationHeartbeatInterval).
 	ApplyOperationHeartbeatInterval = 10 * time.Second
 
-	// DefaultOperatorWorkers is the number of concurrent operator workers
+	// DefaultOperatorWorkers is the number of concurrent operator drivers
 	// when not configured via operator_workers in the server config.
 	DefaultOperatorWorkers = 4
 
@@ -41,15 +41,15 @@ const (
 	ApplyClaimLogTimeout = 5 * time.Second
 )
 
-// StartOperator starts the background operator worker pool.
+// StartOperator starts the background operator driver pool.
 //
-// Operator workers claim apply work from storage so one server can make
+// Operator drivers claim apply work from storage so one server can make
 // progress across independent databases and environments concurrently. This
 // includes queued applies, crash recovery for applies with stale heartbeats,
 // and retry recovery for transient engine failures.
 //
-// Launches N concurrent workers (configured via operator_workers in config).
-// Each worker independently claims applies using FOR UPDATE SKIP LOCKED.
+// Launches N concurrent drivers (configured via operator_workers in config).
+// Each driver independently claims applies using FOR UPDATE SKIP LOCKED.
 // Call StopOperator to gracefully stop.
 func (s *Service) StartOperator(ctx context.Context) {
 	s.operatorMu.Lock()
@@ -59,30 +59,30 @@ func (s *Service) StartOperator(ctx context.Context) {
 		return
 	}
 
-	workers := s.config.OperatorWorkers
-	if workers <= 0 {
-		workers = DefaultOperatorWorkers
+	driverCount := s.config.OperatorWorkers
+	if driverCount <= 0 {
+		driverCount = DefaultOperatorWorkers
 	}
 
 	stop := make(chan struct{})
-	wake := make(chan struct{}, workers)
-	workerCtx, cancel := context.WithCancel(ctx)
+	wake := make(chan struct{}, driverCount)
+	driverCtx, cancel := context.WithCancel(ctx)
 	s.stopRecovery = stop
 	s.cancelRecovery = cancel
 	s.operatorWake = wake
 	s.operatorMu.Unlock()
 
-	for i := range workers {
-		workerID := i
+	for i := range driverCount {
+		driverID := i
 		s.recoveryWg.Go(func() {
-			s.operatorWorker(workerCtx, workerID, stop, wake)
+			s.operatorDriver(driverCtx, driverID, stop, wake)
 		})
 	}
 
-	s.logger.Info("operator started", "workers", workers, "interval", s.operatorPollInterval)
+	s.logger.Info("operator started", "drivers", driverCount, "interval", s.operatorPollInterval)
 }
 
-// StopOperator stops the background operator and waits for all workers to finish.
+// StopOperator stops the background operator and waits for all drivers to finish.
 // Safe to call multiple times.
 func (s *Service) StopOperator() {
 	s.operatorMu.Lock()
@@ -132,54 +132,54 @@ func (s *Service) wakeOperator(applyIdentifier, database, environment string) {
 	}
 }
 
-// WakeOperator nudges the operator worker pool to claim queued durable work.
+// WakeOperator nudges the operator driver pool to claim queued durable work.
 // Storage locking still decides ownership; this does not execute apply control
 // actions directly.
 func (s *Service) WakeOperator(applyIdentifier, database, environment string) {
 	s.wakeOperator(applyIdentifier, database, environment)
 }
 
-// operatorWorker is a single worker that claims at most one apply on startup
+// operatorDriver is a single driver that claims at most one apply on startup
 // and on each operator poll tick. Wake signals share the same claim path as
-// polling; storage locking decides whether a worker actually owns work.
-func (s *Service) operatorWorker(ctx context.Context, workerID int, stop <-chan struct{}, wake <-chan struct{}) {
+// polling; storage locking decides whether a driver actually owns work.
+func (s *Service) operatorDriver(ctx context.Context, driverID int, stop <-chan struct{}, wake <-chan struct{}) {
 	ticker := time.NewTicker(s.operatorPollInterval)
 	defer ticker.Stop()
 
-	s.logger.Debug("operator worker started", "worker", workerID)
+	s.logger.Debug("operator driver started", "driver", driverID)
 
-	s.recoverApplies(ctx, workerID)
+	s.recoverApplies(ctx, driverID)
 
 	for {
 		select {
 		case <-stop:
-			s.logger.Debug("operator worker stopping", "worker", workerID)
+			s.logger.Debug("operator driver stopping", "driver", driverID)
 			return
 		case <-ctx.Done():
-			s.logger.Debug("operator worker context cancelled", "worker", workerID)
+			s.logger.Debug("operator driver context cancelled", "driver", driverID)
 			return
 		case <-wake:
-			s.logger.Debug("operator worker woke for queued apply", "worker", workerID)
-			s.recoverApplies(ctx, workerID)
+			s.logger.Debug("operator driver woke for queued apply", "driver", driverID)
+			s.recoverApplies(ctx, driverID)
 		case <-ticker.C:
-			s.recoverApplies(ctx, workerID)
+			s.recoverApplies(ctx, driverID)
 		}
 	}
 }
 
 // recoverApplies claims and resumes applies that need attention.
 // Each call claims one apply (if available) to keep the scheduling loop responsive.
-func (s *Service) recoverApplies(ctx context.Context, workerID int) {
+func (s *Service) recoverApplies(ctx context.Context, driverID int) {
 	expired, err := s.storage.Applies().ExpireRetryable(ctx)
 	if err != nil {
-		s.logger.Error("operator: failed to expire retryable applies", "worker", workerID, "error", err)
+		s.logger.Error("operator: failed to expire retryable applies", "driver", driverID, "error", err)
 		metrics.RecordOperatorClaimFailure(ctx, "expire_retryable_error")
 		return
 	}
 	for _, expiration := range expired {
 		apply := expiration.Apply
 		s.logger.Error("operator: retryable apply expired",
-			"worker", workerID,
+			"driver", driverID,
 			"apply_id", apply.ApplyIdentifier,
 			"database", apply.Database,
 			"environment", apply.Environment,
@@ -188,35 +188,35 @@ func (s *Service) recoverApplies(ctx context.Context, workerID int) {
 		metrics.RecordOperatorResumeFailure(ctx, apply.Database, apply.Deployment, apply.Environment, string(expiration.Reason))
 	}
 
-	owner := operatorLeaseOwner(workerID)
+	owner := driverLeaseOwner(driverID)
 
 	if s.config.OperatorClaimOperations {
 		// Service a pending stop with no claimable operation to carry it before
 		// claiming new operation work, so a queued stop wins over starting more
 		// deployments. When nothing needs stop reconciliation this is a cheap
-		// no-op and the worker falls through to the normal operation claim.
-		if s.recoverApplyPendingStop(ctx, workerID, owner) {
+		// no-op and the driver falls through to the normal operation claim.
+		if s.recoverApplyPendingStop(ctx, driverID, owner) {
 			return
 		}
-		s.recoverApplyOperation(ctx, workerID, owner)
+		s.recoverApplyOperation(ctx, driverID, owner)
 		return
 	}
 
 	apply, err := s.storage.Applies().FindNextApply(ctx, owner)
 	if err != nil {
-		s.logger.Error("operator: failed to claim apply", "worker", workerID, "lease_owner", owner, "error", err)
+		s.logger.Error("operator: failed to claim apply", "driver", driverID, "lease_owner", owner, "error", err)
 		metrics.RecordOperatorClaimFailure(ctx, "storage_error")
 		return
 	}
 
 	if apply == nil {
-		s.logger.Debug("operator: no apply to claim", "worker", workerID)
+		s.logger.Debug("operator: no apply to claim", "driver", driverID)
 		return
 	}
 	lease := apply.Lease()
 	if !lease.Valid() {
 		s.logger.Error("operator: claimed apply without a valid lease token; operator will not resume it",
-			"worker", workerID,
+			"driver", driverID,
 			"lease_owner", owner,
 			"apply_id", apply.ApplyIdentifier,
 			"database", apply.Database,
@@ -228,7 +228,7 @@ func (s *Service) recoverApplies(ctx context.Context, workerID int) {
 	// Legacy FindNextApply path drives the whole apply (applyOperationID == 0).
 	// Failures are handled inside resumeClaimedApply; the whole-apply path has no
 	// operation row to terminalize, so the return values are not needed here.
-	_, _ = s.resumeClaimedApply(ctx, workerID, apply, 0, "")
+	_, _ = s.resumeClaimedApply(ctx, driverID, apply, 0, "")
 }
 
 // recoverApplyOperation claims work at the apply_operations (per-deployment)
@@ -240,15 +240,15 @@ func (s *Service) recoverApplies(ctx context.Context, workerID int) {
 // once the multi-deployment fan-out lands; while the apply-create dual-write
 // emits exactly one operation per apply, the operation-scoped drive resolves to
 // the same tasks as the whole apply.
-func (s *Service) recoverApplyOperation(ctx context.Context, workerID int, owner string) {
+func (s *Service) recoverApplyOperation(ctx context.Context, driverID int, owner string) {
 	op, err := s.storage.ApplyOperations().FindNextApplyOperation(ctx, owner)
 	if err != nil {
-		s.logger.Error("operator: failed to claim apply_operation", "worker", workerID, "lease_owner", owner, "error", err)
+		s.logger.Error("operator: failed to claim apply_operation", "driver", driverID, "lease_owner", owner, "error", err)
 		metrics.RecordOperatorClaimFailure(ctx, "operation_storage_error")
 		return
 	}
 	if op == nil {
-		s.logger.Debug("operator: no apply_operation to claim", "worker", workerID)
+		s.logger.Debug("operator: no apply_operation to claim", "driver", driverID)
 		return
 	}
 
@@ -259,7 +259,7 @@ func (s *Service) recoverApplyOperation(ctx context.Context, workerID int, owner
 	opLease := op.Lease()
 	if !opLease.Valid() {
 		s.logger.Error("operator: claimed apply_operation without a valid operation lease token; operation will not be driven",
-			"worker", workerID,
+			"driver", driverID,
 			"lease_owner", owner,
 			"apply_operation_id", op.ID,
 			"apply_db_id", op.ApplyID,
@@ -275,24 +275,24 @@ func (s *Service) recoverApplyOperation(ctx context.Context, workerID int, owner
 	ops, err := s.storage.ApplyOperations().ListByApply(ctx, op.ApplyID)
 	if err != nil {
 		s.logger.Error("operator: failed to list operations for claimed apply; operation will not be driven",
-			"worker", workerID, "lease_owner", owner, "apply_operation_id", op.ID,
+			"driver", driverID, "lease_owner", owner, "apply_operation_id", op.ID,
 			"apply_db_id", op.ApplyID, "deployment", op.Deployment, "error", err)
 		metrics.RecordOperatorClaimFailure(ctx, "operation_set_list_error")
 		return
 	}
 	if !operationSetContainsID(ops, op.ID) {
 		s.logger.Error("operator: claimed operation is not part of its apply's operation set; operation will not be driven",
-			"worker", workerID, "lease_owner", owner, "apply_operation_id", op.ID,
+			"driver", driverID, "lease_owner", owner, "apply_operation_id", op.ID,
 			"apply_db_id", op.ApplyID, "deployment", op.Deployment, "operation_count", len(ops))
 		metrics.RecordOperatorClaimFailure(ctx, "operation_set_missing")
 		return
 	}
 	if len(ops) > 1 {
-		s.recoverMultiApplyOperation(ctx, workerID, op, opLease)
+		s.recoverMultiApplyOperation(ctx, driverID, op, opLease)
 		return
 	}
 
-	s.recoverSingleApplyOperation(ctx, workerID, owner, op, opLease)
+	s.recoverSingleApplyOperation(ctx, driverID, owner, op, opLease)
 }
 
 // operationSetContainsID reports whether id is one of the apply's operation
@@ -313,15 +313,15 @@ func operationSetContainsID(ops []*storage.ApplyOperation, id int64) bool {
 // directly, fires the per-driver terminal observer, and re-derives the parent
 // from the operation rows afterward. This path is byte-for-byte the pre-fan-out
 // behavior.
-func (s *Service) recoverSingleApplyOperation(ctx context.Context, workerID int, owner string, op *storage.ApplyOperation, opLease storage.OperationLease) {
+func (s *Service) recoverSingleApplyOperation(ctx context.Context, driverID int, owner string, op *storage.ApplyOperation, opLease storage.OperationLease) {
 	// The engine drive still writes the parent applies row (state RUNNING /
 	// COMPLETED / FAILED), and the derived-state reconcile updates
-	// applies.state, so the worker must also hold the parent apply lease — the
+	// applies.state, so the driver must also hold the parent apply lease — the
 	// operation lease alone does not authorize parent-apply writes.
 	apply, err := s.storage.Applies().ClaimApplyByID(ctx, op.ApplyID, owner)
 	if err != nil {
 		s.logger.Error("operator: failed to claim parent apply for operation",
-			"worker", workerID,
+			"driver", driverID,
 			"lease_owner", owner,
 			"apply_operation_id", op.ID,
 			"apply_db_id", op.ApplyID,
@@ -338,14 +338,14 @@ func (s *Service) recoverSingleApplyOperation(ctx context.Context, workerID int,
 		//     it forever. Reconcile it to the parent's terminal state now.
 		//   - transiently unclaimable (a peer holds a fresh lease, or the row is
 		//     locked): fail closed and let a later poll retry once it goes stale.
-		s.reconcileUnclaimableParent(ctx, workerID, op)
+		s.reconcileUnclaimableParent(ctx, driverID, op)
 		return
 	}
 
 	applyLease := apply.Lease()
 	if !applyLease.Valid() {
 		s.logger.Error("operator: claimed parent apply without a valid lease token; operation will not be driven",
-			"worker", workerID,
+			"driver", driverID,
 			"lease_owner", owner,
 			"apply_operation_id", op.ID,
 			"apply_id", apply.ApplyIdentifier,
@@ -379,7 +379,7 @@ func (s *Service) recoverSingleApplyOperation(ctx context.Context, workerID int,
 	// with no routing key, so fail closed rather than fall back to a default.
 	if op.Deployment == "" {
 		s.logger.Error("operator: claimed operation is missing deployment metadata; operation will not be driven",
-			"worker", workerID,
+			"driver", driverID,
 			"lease_owner", owner,
 			"apply_operation_id", op.ID,
 			"apply_id", apply.ApplyIdentifier,
@@ -392,22 +392,22 @@ func (s *Service) recoverSingleApplyOperation(ctx context.Context, workerID int,
 	}
 
 	// Heartbeat the operation row on the apply heartbeat cadence so a peer
-	// worker does not re-claim it during a long drive. The heartbeat writes
+	// driver does not re-claim it during a long drive. The heartbeat writes
 	// under the operation lease, so a lost operation lease cancels the run and
-	// the displaced worker stops writing.
+	// the displaced driver stops writing.
 	runCtx, cancelRun := context.WithCancel(dualLeaseCtx)
 	defer cancelRun()
-	stopHeartbeat := s.startApplyOperationHeartbeat(runCtx, workerID, op, apply, cancelRun)
+	stopHeartbeat := s.startApplyOperationHeartbeat(runCtx, driverID, op, apply, cancelRun)
 	defer stopHeartbeat()
 
-	resumed, resumeErr := s.resumeClaimedApply(runCtx, workerID, apply, op.ID, op.Deployment)
+	resumed, resumeErr := s.resumeClaimedApply(runCtx, driverID, apply, op.ID, op.Deployment)
 	stopHeartbeat()
 	if !resumed {
 		if errors.Is(resumeErr, tern.ErrNoTasksForApplyOperation) {
 			// The drive failed closed: the operation has no tasks, so it can
 			// never make progress. Terminalize it now rather than leaving it to
 			// be re-leased on every poll once its heartbeat goes stale.
-			s.failOperationWithoutTasks(operationLeaseCtx, applyLeaseCtx, workerID, op, apply)
+			s.failOperationWithoutTasks(operationLeaseCtx, applyLeaseCtx, driverID, op, apply)
 		}
 		return
 	}
@@ -421,10 +421,10 @@ func (s *Service) recoverSingleApplyOperation(ctx context.Context, workerID int,
 	// would never be durably recorded. The operation row is authoritative for
 	// its own deployment; the parent state is derived from the operation rows
 	// afterward via updateApplyStateFromOperations.
-	marked, err := s.markOperationFromOwnResult(operationLeaseCtx, workerID, op)
+	marked, err := s.markOperationFromOwnResult(operationLeaseCtx, driverID, op)
 	if err != nil {
 		s.logger.Error("operator: failed to update apply_operation from its tasks; derived apply state not updated",
-			"worker", workerID, "apply_operation_id", op.ID, "apply_id", apply.ApplyIdentifier,
+			"driver", driverID, "apply_operation_id", op.ID, "apply_id", apply.ApplyIdentifier,
 			"deployment", op.Deployment, "environment", apply.Environment, "error", err)
 		return
 	}
@@ -438,9 +438,9 @@ func (s *Service) recoverSingleApplyOperation(ctx context.Context, workerID int,
 	// otherwise hold the projection running with pending siblings that never
 	// settle — stranding the apply. Stopping them lets the derivation below reach
 	// a terminal verdict so the rollout (and the stop request) can resolve.
-	if err := s.stopPendingOperationsForPendingStop(applyLeaseCtx, workerID, apply); err != nil {
+	if err := s.stopPendingOperationsForPendingStop(applyLeaseCtx, driverID, apply); err != nil {
 		s.logger.Error("operator: failed to stop pending sibling operations for pending stop request; derived apply state not updated",
-			"worker", workerID, "apply_operation_id", op.ID, "apply_id", apply.ApplyIdentifier,
+			"driver", driverID, "apply_operation_id", op.ID, "apply_id", apply.ApplyIdentifier,
 			"deployment", op.Deployment, "environment", apply.Environment, "error", err)
 		return
 	}
@@ -453,7 +453,7 @@ func (s *Service) recoverSingleApplyOperation(ctx context.Context, workerID int,
 	finalApply, err := s.storage.Applies().Get(applyLeaseCtx, apply.ID)
 	if err != nil {
 		s.logger.Error("operator: failed to reload parent apply after resume; derived apply state not updated",
-			"worker", workerID,
+			"driver", driverID,
 			"apply_operation_id", op.ID,
 			"apply_id", apply.ApplyIdentifier,
 			"deployment", op.Deployment,
@@ -462,16 +462,16 @@ func (s *Service) recoverSingleApplyOperation(ctx context.Context, workerID int,
 	}
 	if finalApply == nil {
 		s.logger.Error("operator: parent apply not found after resume; derived apply state not updated",
-			"worker", workerID,
+			"driver", driverID,
 			"apply_operation_id", op.ID,
 			"apply_id", apply.ApplyIdentifier,
 			"deployment", op.Deployment)
 		return
 	}
 
-	if _, err := s.updateApplyStateFromOperations(applyLeaseCtx, workerID, finalApply, allowLeaseScopedFailedReopen); err != nil {
+	if _, err := s.updateApplyStateFromOperations(applyLeaseCtx, driverID, finalApply, allowLeaseScopedFailedReopen); err != nil {
 		s.logger.Error("operator: failed to update derived apply state from apply_operations",
-			"worker", workerID, "apply_operation_id", op.ID, "apply_id", finalApply.ApplyIdentifier,
+			"driver", driverID, "apply_operation_id", op.ID, "apply_id", finalApply.ApplyIdentifier,
 			"deployment", op.Deployment, "environment", finalApply.Environment, "error", err)
 		return
 	}
@@ -479,9 +479,9 @@ func (s *Service) recoverSingleApplyOperation(ctx context.Context, workerID int,
 	// If the derived state above settled the apply terminally and a stop is still
 	// pending, complete it now so the request does not linger after the rollout
 	// has stopped.
-	if err := s.completePendingStopIfApplyResolved(applyLeaseCtx, workerID, finalApply.ID); err != nil {
+	if err := s.completePendingStopIfApplyResolved(applyLeaseCtx, driverID, finalApply.ID); err != nil {
 		s.logger.Error("operator: failed to complete pending stop request for resolved apply",
-			"worker", workerID, "apply_operation_id", op.ID, "apply_id", finalApply.ApplyIdentifier,
+			"driver", driverID, "apply_operation_id", op.ID, "apply_id", finalApply.ApplyIdentifier,
 			"deployment", op.Deployment, "environment", finalApply.Environment, "error", err)
 		return
 	}
@@ -496,20 +496,20 @@ func (s *Service) recoverSingleApplyOperation(ctx context.Context, workerID int,
 // solely by the operation-authorized projection CAS. The operation row is
 // driven from its own tasks, then the parent is re-derived from the operation
 // rows.
-func (s *Service) recoverMultiApplyOperation(ctx context.Context, workerID int, op *storage.ApplyOperation, opLease storage.OperationLease) {
+func (s *Service) recoverMultiApplyOperation(ctx context.Context, driverID int, op *storage.ApplyOperation, opLease storage.OperationLease) {
 	operationLeaseCtx := storage.WithOperationLease(ctx, opLease)
 
 	apply, err := s.storage.Applies().Get(operationLeaseCtx, op.ApplyID)
 	if err != nil {
 		s.logger.Error("operator: failed to load parent apply for operation drive; operation will not be driven",
-			"worker", workerID, "apply_operation_id", op.ID, "apply_db_id", op.ApplyID,
+			"driver", driverID, "apply_operation_id", op.ID, "apply_db_id", op.ApplyID,
 			"deployment", op.Deployment, "error", err)
 		metrics.RecordOperatorClaimFailure(ctx, "operation_parent_load_error")
 		return
 	}
 	if apply == nil {
 		s.logger.Error("operator: parent apply not found for claimed operation; operation will not be driven",
-			"worker", workerID, "apply_operation_id", op.ID, "apply_db_id", op.ApplyID,
+			"driver", driverID, "apply_operation_id", op.ID, "apply_db_id", op.ApplyID,
 			"deployment", op.Deployment)
 		metrics.RecordOperatorClaimFailure(ctx, "operation_parent_missing")
 		return
@@ -519,7 +519,7 @@ func (s *Service) recoverMultiApplyOperation(ctx context.Context, workerID int, 
 	// empty deployment is a corrupt row with no routing key, so fail closed.
 	if op.Deployment == "" {
 		s.logger.Error("operator: claimed operation is missing deployment metadata; operation will not be driven",
-			"worker", workerID, "apply_operation_id", op.ID, "apply_id", apply.ApplyIdentifier,
+			"driver", driverID, "apply_operation_id", op.ID, "apply_id", apply.ApplyIdentifier,
 			"database", apply.Database, "environment", apply.Environment)
 		metrics.RecordOperatorClaimFailure(ctx, "missing_operation_deployment")
 		return
@@ -530,24 +530,24 @@ func (s *Service) recoverMultiApplyOperation(ctx context.Context, workerID int, 
 	// in-flight rollout; the driver no longer writes the parent running for
 	// multi-op, so without this the parent would linger pending during a long
 	// drive. The op lease authorizes the derived-state CAS.
-	if _, err := s.updateApplyStateFromOperations(operationLeaseCtx, workerID, apply, allowLeaseScopedFailedReopen); err != nil {
+	if _, err := s.updateApplyStateFromOperations(operationLeaseCtx, driverID, apply, allowLeaseScopedFailedReopen); err != nil {
 		s.logger.Error("operator: failed to project parent running before operation drive; operation will not be driven",
-			"worker", workerID, "apply_operation_id", op.ID, "apply_id", apply.ApplyIdentifier,
+			"driver", driverID, "apply_operation_id", op.ID, "apply_id", apply.ApplyIdentifier,
 			"database", apply.Database, "environment", apply.Environment, "error", err)
 		return
 	}
 
-	// Heartbeat the operation row on the apply heartbeat cadence so a peer worker
+	// Heartbeat the operation row on the apply heartbeat cadence so a peer driver
 	// does not re-claim it during a long drive. The heartbeat writes under the
 	// operation lease, so a lost operation lease cancels the run.
 	runCtx, cancelRun := context.WithCancel(operationLeaseCtx)
 	defer cancelRun()
-	stopHeartbeat := s.startApplyOperationHeartbeat(runCtx, workerID, op, apply, cancelRun)
+	stopHeartbeat := s.startApplyOperationHeartbeat(runCtx, driverID, op, apply, cancelRun)
 	defer stopHeartbeat()
 
 	// Suppress the per-driver terminal observer: the aggregate terminal summary
 	// is published once by the projection CAS winner, not per deployment.
-	resumed, resumeErr := s.resumeClaimedApplyWithOptions(runCtx, workerID, apply, op.ID, op.Deployment,
+	resumed, resumeErr := s.resumeClaimedApplyWithOptions(runCtx, driverID, apply, op.ID, op.Deployment,
 		resumeClaimedApplyOptions{suppressRecoveredObserver: true})
 	stopHeartbeat()
 	if !resumed && errors.Is(resumeErr, tern.ErrNoTasksForApplyOperation) {
@@ -563,12 +563,12 @@ func (s *Service) recoverMultiApplyOperation(ctx context.Context, workerID int, 
 		failApply := apply
 		if reloaded, reloadErr := s.storage.Applies().Get(operationLeaseCtx, apply.ID); reloadErr != nil {
 			s.logger.Error("operator: failed to reload parent apply before failing task-less operation; using pre-drive apply state",
-				"worker", workerID, "apply_operation_id", op.ID, "apply_id", apply.ApplyIdentifier,
+				"driver", driverID, "apply_operation_id", op.ID, "apply_id", apply.ApplyIdentifier,
 				"database", apply.Database, "environment", apply.Environment, "error", reloadErr)
 		} else if reloaded != nil {
 			failApply = reloaded
 		}
-		s.failOperationWithoutTasks(operationLeaseCtx, operationLeaseCtx, workerID, op, failApply)
+		s.failOperationWithoutTasks(operationLeaseCtx, operationLeaseCtx, driverID, op, failApply)
 		return
 	}
 
@@ -580,10 +580,10 @@ func (s *Service) recoverMultiApplyOperation(ctx context.Context, workerID int, 
 	// be re-leased forever. markOperationFromOwnResult derives the operation from
 	// its tasks: a still-running task set leaves it claimable (a benign no-op),
 	// while a terminal task set terminalizes it.
-	marked, err := s.markOperationFromOwnResult(operationLeaseCtx, workerID, op)
+	marked, err := s.markOperationFromOwnResult(operationLeaseCtx, driverID, op)
 	if err != nil {
 		s.logger.Error("operator: failed to update apply_operation from its tasks; derived apply state not updated",
-			"worker", workerID, "apply_operation_id", op.ID, "apply_id", apply.ApplyIdentifier,
+			"driver", driverID, "apply_operation_id", op.ID, "apply_id", apply.ApplyIdentifier,
 			"deployment", op.Deployment, "environment", apply.Environment, "error", err)
 		return
 	}
@@ -594,9 +594,9 @@ func (s *Service) recoverMultiApplyOperation(ctx context.Context, workerID int, 
 	// If a stop is pending, terminalize any still-pending sibling operations to
 	// stopped before deriving the parent, so the rollout can settle. Authorized
 	// by this operation's own lease (the 6a op-lease branch).
-	if err := s.stopPendingOperationsForPendingStop(operationLeaseCtx, workerID, apply); err != nil {
+	if err := s.stopPendingOperationsForPendingStop(operationLeaseCtx, driverID, apply); err != nil {
 		s.logger.Error("operator: failed to stop pending sibling operations for pending stop request; derived apply state not updated",
-			"worker", workerID, "apply_operation_id", op.ID, "apply_id", apply.ApplyIdentifier,
+			"driver", driverID, "apply_operation_id", op.ID, "apply_id", apply.ApplyIdentifier,
 			"deployment", op.Deployment, "environment", apply.Environment, "error", err)
 		return
 	}
@@ -606,21 +606,21 @@ func (s *Service) recoverMultiApplyOperation(ctx context.Context, workerID int, 
 	finalApply, err := s.storage.Applies().Get(operationLeaseCtx, apply.ID)
 	if err != nil {
 		s.logger.Error("operator: failed to reload parent apply after operation drive; derived apply state not updated",
-			"worker", workerID, "apply_operation_id", op.ID, "apply_id", apply.ApplyIdentifier,
+			"driver", driverID, "apply_operation_id", op.ID, "apply_id", apply.ApplyIdentifier,
 			"deployment", op.Deployment, "error", err)
 		return
 	}
 	if finalApply == nil {
 		s.logger.Error("operator: parent apply not found after operation drive; derived apply state not updated",
-			"worker", workerID, "apply_operation_id", op.ID, "apply_id", apply.ApplyIdentifier,
+			"driver", driverID, "apply_operation_id", op.ID, "apply_id", apply.ApplyIdentifier,
 			"deployment", op.Deployment)
 		return
 	}
 
-	result, err := s.updateApplyStateFromOperations(operationLeaseCtx, workerID, finalApply, allowLeaseScopedFailedReopen)
+	result, err := s.updateApplyStateFromOperations(operationLeaseCtx, driverID, finalApply, allowLeaseScopedFailedReopen)
 	if err != nil {
 		s.logger.Error("operator: failed to update derived apply state from apply_operations",
-			"worker", workerID, "apply_operation_id", op.ID, "apply_id", finalApply.ApplyIdentifier,
+			"driver", driverID, "apply_operation_id", op.ID, "apply_id", finalApply.ApplyIdentifier,
 			"deployment", op.Deployment, "environment", finalApply.Environment, "error", err)
 		return
 	}
@@ -629,11 +629,11 @@ func (s *Service) recoverMultiApplyOperation(ctx context.Context, workerID int, 
 	// swap that terminalized the parent. Do this before stop-request cleanup: the
 	// summary depends only on the apply being terminal, and a later cleanup error
 	// must not suppress it.
-	s.publishTerminalSummaryIfWon(operationLeaseCtx, workerID, finalApply, result)
+	s.publishTerminalSummaryIfWon(operationLeaseCtx, driverID, finalApply, result)
 
-	if err := s.completePendingStopIfApplyResolved(operationLeaseCtx, workerID, finalApply.ID); err != nil {
+	if err := s.completePendingStopIfApplyResolved(operationLeaseCtx, driverID, finalApply.ID); err != nil {
 		s.logger.Error("operator: failed to complete pending stop request for resolved apply",
-			"worker", workerID, "apply_operation_id", op.ID, "apply_id", finalApply.ApplyIdentifier,
+			"driver", driverID, "apply_operation_id", op.ID, "apply_id", finalApply.ApplyIdentifier,
 			"deployment", op.Deployment, "environment", finalApply.Environment, "error", err)
 		return
 	}
@@ -653,32 +653,32 @@ func (s *Service) recoverMultiApplyOperation(ctx context.Context, workerID int, 
 // or the claim itself errored or returned an invalid lease — so the caller does
 // not also run the normal operation claim this tick. Returns false only when no
 // apply needed reconciliation.
-func (s *Service) recoverApplyPendingStop(ctx context.Context, workerID int, owner string) bool {
+func (s *Service) recoverApplyPendingStop(ctx context.Context, driverID int, owner string) bool {
 	apply, err := s.storage.Applies().FindNextApplyForStopReconciliation(ctx, owner)
 	if err != nil {
 		s.logger.Error("operator: failed to claim apply for stop reconciliation",
-			"worker", workerID, "lease_owner", owner, "error", err)
+			"driver", driverID, "lease_owner", owner, "error", err)
 		metrics.RecordOperatorClaimFailure(ctx, "stop_reconciliation_claim_error")
 		return true
 	}
 	if apply == nil {
-		s.logger.Debug("operator: no apply needs stop reconciliation", "worker", workerID)
+		s.logger.Debug("operator: no apply needs stop reconciliation", "driver", driverID)
 		return false
 	}
 
 	lease := apply.Lease()
 	if !lease.Valid() {
 		s.logger.Error("operator: claimed apply for stop reconciliation without a valid lease token; skipping",
-			"worker", workerID, "lease_owner", owner,
+			"driver", driverID, "lease_owner", owner,
 			"apply_id", apply.ApplyIdentifier, "database", apply.Database, "environment", apply.Environment)
 		metrics.RecordOperatorClaimFailure(ctx, "stop_reconciliation_missing_lease_token")
 		return true
 	}
 	applyLeaseCtx := storage.WithApplyLease(ctx, lease)
 
-	if err := s.stopPendingOperationsForPendingStop(applyLeaseCtx, workerID, apply); err != nil {
+	if err := s.stopPendingOperationsForPendingStop(applyLeaseCtx, driverID, apply); err != nil {
 		s.logger.Error("operator: failed to stop pending sibling operations during stop reconciliation",
-			"worker", workerID, "apply_id", apply.ApplyIdentifier,
+			"driver", driverID, "apply_id", apply.ApplyIdentifier,
 			"database", apply.Database, "environment", apply.Environment, "error", err)
 		return true
 	}
@@ -686,21 +686,21 @@ func (s *Service) recoverApplyPendingStop(ctx context.Context, workerID int, own
 	finalApply, err := s.storage.Applies().Get(applyLeaseCtx, apply.ID)
 	if err != nil {
 		s.logger.Error("operator: failed to reload apply during stop reconciliation; derived apply state not updated",
-			"worker", workerID, "apply_id", apply.ApplyIdentifier,
+			"driver", driverID, "apply_id", apply.ApplyIdentifier,
 			"database", apply.Database, "environment", apply.Environment, "error", err)
 		return true
 	}
 	if finalApply == nil {
 		s.logger.Error("operator: apply not found during stop reconciliation; derived apply state not updated",
-			"worker", workerID, "apply_id", apply.ApplyIdentifier,
+			"driver", driverID, "apply_id", apply.ApplyIdentifier,
 			"database", apply.Database, "environment", apply.Environment)
 		return true
 	}
 
-	result, err := s.updateApplyStateFromOperations(applyLeaseCtx, workerID, finalApply, allowLeaseScopedFailedReopen)
+	result, err := s.updateApplyStateFromOperations(applyLeaseCtx, driverID, finalApply, allowLeaseScopedFailedReopen)
 	if err != nil {
 		s.logger.Error("operator: failed to update derived apply state during stop reconciliation",
-			"worker", workerID, "apply_id", finalApply.ApplyIdentifier,
+			"driver", driverID, "apply_id", finalApply.ApplyIdentifier,
 			"database", finalApply.Database, "environment", finalApply.Environment, "error", err)
 		return true
 	}
@@ -708,11 +708,11 @@ func (s *Service) recoverApplyPendingStop(ctx context.Context, workerID int, own
 	// A multi-operation apply that settles terminal here (stop reconciliation has
 	// no operation drive to publish on its behalf) still owes its single terminal
 	// summary; publish it if this projection won the terminal swap.
-	s.publishTerminalSummaryIfWon(applyLeaseCtx, workerID, finalApply, result)
+	s.publishTerminalSummaryIfWon(applyLeaseCtx, driverID, finalApply, result)
 
-	if err := s.completePendingStopIfApplyResolved(applyLeaseCtx, workerID, finalApply.ID); err != nil {
+	if err := s.completePendingStopIfApplyResolved(applyLeaseCtx, driverID, finalApply.ID); err != nil {
 		s.logger.Error("operator: failed to complete pending stop request after stop reconciliation",
-			"worker", workerID, "apply_id", finalApply.ApplyIdentifier,
+			"driver", driverID, "apply_id", finalApply.ApplyIdentifier,
 			"database", finalApply.Database, "environment", finalApply.Environment, "error", err)
 		return true
 	}
@@ -723,7 +723,7 @@ func (s *Service) recoverApplyPendingStop(ctx context.Context, workerID int, own
 // operations to stopped when the apply has a pending stop request, so the
 // rollout can settle instead of stranding running with siblings the claim gate
 // keeps from ever starting. No-op when no stop is pending.
-func (s *Service) stopPendingOperationsForPendingStop(ctx context.Context, workerID int, apply *storage.Apply) error {
+func (s *Service) stopPendingOperationsForPendingStop(ctx context.Context, driverID int, apply *storage.Apply) error {
 	controlReq, err := s.storage.ControlRequests().GetPending(ctx, apply.ID, storage.ControlOperationStop)
 	if err != nil {
 		return fmt.Errorf("load pending stop request for apply %s (%d): %w", apply.ApplyIdentifier, apply.ID, err)
@@ -738,7 +738,7 @@ func (s *Service) stopPendingOperationsForPendingStop(ctx context.Context, worke
 	}
 	if stopped > 0 {
 		s.logger.Info("operator: stopped pending sibling operations for pending stop request",
-			"worker", workerID, "apply_id", apply.ApplyIdentifier,
+			"driver", driverID, "apply_id", apply.ApplyIdentifier,
 			"database", apply.Database, "environment", apply.Environment,
 			"stopped_operation_count", stopped)
 	}
@@ -750,7 +750,7 @@ func (s *Service) stopPendingOperationsForPendingStop(ctx context.Context, worke
 // pending forever after the rollout stops. The apply is reloaded because the
 // derived-state write operates on a copy and does not mutate the caller's row.
 // No-op when the apply is still non-terminal or no stop is pending.
-func (s *Service) completePendingStopIfApplyResolved(ctx context.Context, workerID int, applyID int64) error {
+func (s *Service) completePendingStopIfApplyResolved(ctx context.Context, driverID int, applyID int64) error {
 	apply, err := s.storage.Applies().Get(ctx, applyID)
 	if err != nil {
 		return fmt.Errorf("reload apply %d before completing pending stop: %w", applyID, err)
@@ -774,7 +774,7 @@ func (s *Service) completePendingStopIfApplyResolved(ctx context.Context, worker
 		return fmt.Errorf("complete pending stop request for resolved apply %s (%d): %w", apply.ApplyIdentifier, apply.ID, err)
 	}
 	s.logger.Info("operator: completed pending stop request for resolved apply",
-		"worker", workerID, "apply_id", apply.ApplyIdentifier,
+		"driver", driverID, "apply_id", apply.ApplyIdentifier,
 		"database", apply.Database, "environment", apply.Environment, "state", apply.State)
 	return nil
 }
@@ -786,11 +786,11 @@ func (s *Service) completePendingStopIfApplyResolved(ctx context.Context, worker
 // apply has no competing driver, so the mirror is safe and idempotent). If the
 // parent is non-terminal (a peer holds a fresh lease, or the row was locked),
 // the operation is left claimable and retried once the parent lease goes stale.
-func (s *Service) reconcileUnclaimableParent(ctx context.Context, workerID int, op *storage.ApplyOperation) {
+func (s *Service) reconcileUnclaimableParent(ctx context.Context, driverID int, op *storage.ApplyOperation) {
 	parent, err := s.storage.Applies().Get(ctx, op.ApplyID)
 	if err != nil {
 		s.logger.Error("operator: failed to load unclaimable parent apply; operation will be retried",
-			"worker", workerID,
+			"driver", driverID,
 			"apply_operation_id", op.ID,
 			"apply_db_id", op.ApplyID,
 			"deployment", op.Deployment,
@@ -800,7 +800,7 @@ func (s *Service) reconcileUnclaimableParent(ctx context.Context, workerID int, 
 	}
 	if parent == nil {
 		s.logger.Error("operator: parent apply not found for claimed operation; operation will be retried",
-			"worker", workerID,
+			"driver", driverID,
 			"apply_operation_id", op.ID,
 			"apply_db_id", op.ApplyID,
 			"deployment", op.Deployment)
@@ -809,32 +809,32 @@ func (s *Service) reconcileUnclaimableParent(ctx context.Context, workerID int, 
 	}
 	if state.IsTerminalApplyState(parent.State) {
 		s.logger.Info("operator: parent apply already terminal; reconciling operation to terminal state",
-			"worker", workerID,
+			"driver", driverID,
 			"apply_operation_id", op.ID,
 			"apply_id", parent.ApplyIdentifier,
 			"deployment", op.Deployment,
 			"environment", parent.Environment,
 			"state", parent.State)
-		marked, err := s.markOperationFromApplyState(ctx, workerID, op, parent)
+		marked, err := s.markOperationFromApplyState(ctx, driverID, op, parent)
 		if err != nil {
 			s.logger.Error("operator: failed to reconcile apply_operation from terminal parent; derived apply state not updated",
-				"worker", workerID, "apply_operation_id", op.ID, "apply_id", parent.ApplyIdentifier,
+				"driver", driverID, "apply_operation_id", op.ID, "apply_id", parent.ApplyIdentifier,
 				"deployment", op.Deployment, "environment", parent.Environment, "state", parent.State, "error", err)
 			return
 		}
 		if !marked {
 			return
 		}
-		if _, err := s.updateApplyStateFromOperations(ctx, workerID, parent, rejectFailedApplyReopen); err != nil {
+		if _, err := s.updateApplyStateFromOperations(ctx, driverID, parent, rejectFailedApplyReopen); err != nil {
 			s.logger.Error("operator: failed to update derived apply state for terminal parent",
-				"worker", workerID, "apply_operation_id", op.ID, "apply_id", parent.ApplyIdentifier,
+				"driver", driverID, "apply_operation_id", op.ID, "apply_id", parent.ApplyIdentifier,
 				"deployment", op.Deployment, "environment", parent.Environment, "error", err)
 			return
 		}
 		return
 	}
 	s.logger.Warn("operator: parent apply not claimable for operation; operation will be retried",
-		"worker", workerID,
+		"driver", driverID,
 		"apply_operation_id", op.ID,
 		"apply_id", parent.ApplyIdentifier,
 		"deployment", op.Deployment,
@@ -851,18 +851,18 @@ func (s *Service) reconcileUnclaimableParent(ctx context.Context, workerID int, 
 // under the parent apply lease (applyCtx). The two writes target different rows
 // with different guards, so they take separate lease-scoped contexts and fail
 // closed if ownership has since changed.
-func (s *Service) failOperationWithoutTasks(opCtx, applyCtx context.Context, workerID int, op *storage.ApplyOperation, apply *storage.Apply) {
+func (s *Service) failOperationWithoutTasks(opCtx, applyCtx context.Context, driverID int, op *storage.ApplyOperation, apply *storage.Apply) {
 	const reason = "operation has no tasks; invalid or stale claim"
 	if err := s.storage.ApplyOperations().MarkFailed(opCtx, op.ID, reason); err != nil {
 		s.logger.Error("operator: failed to mark task-less apply_operation failed; operation will be retried",
-			"worker", workerID, "apply_operation_id", op.ID, "apply_id", apply.ApplyIdentifier,
+			"driver", driverID, "apply_operation_id", op.ID, "apply_id", apply.ApplyIdentifier,
 			"deployment", op.Deployment, "environment", apply.Environment, "error", err)
 		return
 	}
-	result, err := s.updateApplyStateFromOperations(applyCtx, workerID, apply, allowLeaseScopedFailedReopen)
+	result, err := s.updateApplyStateFromOperations(applyCtx, driverID, apply, allowLeaseScopedFailedReopen)
 	if err != nil {
 		s.logger.Error("operator: failed to update derived apply state after failing task-less operation",
-			"worker", workerID, "apply_operation_id", op.ID, "apply_id", apply.ApplyIdentifier,
+			"driver", driverID, "apply_operation_id", op.ID, "apply_id", apply.ApplyIdentifier,
 			"deployment", op.Deployment, "environment", apply.Environment, "error", err)
 		return
 	}
@@ -870,7 +870,7 @@ func (s *Service) failOperationWithoutTasks(opCtx, applyCtx context.Context, wor
 	// A task-less operation failure that terminalizes a multi-operation apply
 	// publishes the summary here; the gate on OperationCount keeps the single-op
 	// caller (which still publishes via its per-driver observer) unchanged.
-	s.publishTerminalSummaryIfWon(applyCtx, workerID, apply, result)
+	s.publishTerminalSummaryIfWon(applyCtx, driverID, apply, result)
 }
 
 // resumeClaimedApply drives claimed work through the engine. When
@@ -884,8 +884,8 @@ func (s *Service) failOperationWithoutTasks(opCtx, applyCtx context.Context, wor
 // the bool lets the operation-level claim loop decide whether to mark its
 // operation terminal, and the returned error lets it distinguish the fail-closed
 // no-tasks case (tern.ErrNoTasksForApplyOperation) from transient failures.
-func (s *Service) resumeClaimedApply(ctx context.Context, workerID int, apply *storage.Apply, applyOperationID int64, operationDeployment string) (bool, error) {
-	return s.resumeClaimedApplyWithOptions(ctx, workerID, apply, applyOperationID, operationDeployment, resumeClaimedApplyOptions{})
+func (s *Service) resumeClaimedApply(ctx context.Context, driverID int, apply *storage.Apply, applyOperationID int64, operationDeployment string) (bool, error) {
+	return s.resumeClaimedApplyWithOptions(ctx, driverID, apply, applyOperationID, operationDeployment, resumeClaimedApplyOptions{})
 }
 
 // resumeClaimedApplyOptions tunes a drive for the multi-operation path.
@@ -897,7 +897,7 @@ type resumeClaimedApplyOptions struct {
 	suppressRecoveredObserver bool
 }
 
-func (s *Service) resumeClaimedApplyWithOptions(ctx context.Context, workerID int, apply *storage.Apply, applyOperationID int64, operationDeployment string, opts resumeClaimedApplyOptions) (bool, error) {
+func (s *Service) resumeClaimedApplyWithOptions(ctx context.Context, driverID int, apply *storage.Apply, applyOperationID int64, operationDeployment string, opts resumeClaimedApplyOptions) (bool, error) {
 	lease := apply.Lease()
 	start := s.clock.Now()
 
@@ -912,7 +912,7 @@ func (s *Service) resumeClaimedApplyWithOptions(ctx context.Context, workerID in
 		stored, err := storedDeploymentForApply(apply)
 		if err != nil {
 			s.logger.Error("operator: claimed apply is missing stored deployment metadata",
-				"worker", workerID,
+				"driver", driverID,
 				"apply_id", apply.ApplyIdentifier,
 				"database", apply.Database,
 				"environment", apply.Environment,
@@ -924,7 +924,7 @@ func (s *Service) resumeClaimedApplyWithOptions(ctx context.Context, workerID in
 	}
 
 	s.logger.Info("operator: claimed apply",
-		"worker", workerID,
+		"driver", driverID,
 		"lease_owner", lease.Owner,
 		"apply_id", apply.ApplyIdentifier,
 		"database", apply.Database,
@@ -934,17 +934,17 @@ func (s *Service) resumeClaimedApplyWithOptions(ctx context.Context, workerID in
 		"last_heartbeat", apply.UpdatedAt)
 
 	// Record the claim in the apply's durable log so the timeline explains
-	// why new state transitions appear after a failure or a worker crash —
+	// why new state transitions appear after a failure or a driver crash —
 	// without this entry, an operator reading apply_logs sees a gap between
 	// the last failure and the resumed work.
-	s.logApplyResumeClaim(ctx, workerID, apply)
+	s.logApplyResumeClaim(ctx, driverID, apply)
 
 	previousState := apply.State
 
 	client, err := s.RoutingTernClient()
 	if err != nil {
 		s.logger.Error("operator: failed to get routing client",
-			"worker", workerID,
+			"driver", driverID,
 			"apply_id", apply.ApplyIdentifier,
 			"database", apply.Database,
 			"deployment", deployment,
@@ -973,8 +973,8 @@ func (s *Service) resumeClaimedApplyWithOptions(ctx context.Context, workerID in
 	}
 	if err != nil {
 		if errors.Is(err, storage.ErrApplyLeaseLost) {
-			s.logger.Warn("operator: apply lease was lost; worker will stop writing this apply",
-				"worker", workerID,
+			s.logger.Warn("operator: apply lease was lost; driver will stop writing this apply",
+				"driver", driverID,
 				"lease_owner", lease.Owner,
 				"apply_id", apply.ApplyIdentifier,
 				"database", apply.Database,
@@ -993,7 +993,7 @@ func (s *Service) resumeClaimedApplyWithOptions(ctx context.Context, workerID in
 			// nothing; the caller terminalizes the operation row so it is not
 			// re-leased on every poll once its heartbeat goes stale.
 			s.logger.Error("operator: claimed operation has no tasks; failing it closed",
-				"worker", workerID,
+				"driver", driverID,
 				"apply_id", apply.ApplyIdentifier,
 				"database", apply.Database,
 				"deployment", deployment,
@@ -1008,7 +1008,7 @@ func (s *Service) resumeClaimedApplyWithOptions(ctx context.Context, workerID in
 		}
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) || ctx.Err() != nil {
 			s.logger.Debug("operator: stopped while running claimed apply",
-				"worker", workerID,
+				"driver", driverID,
 				"apply_id", apply.ApplyIdentifier,
 				"database", apply.Database,
 				"deployment", deployment,
@@ -1020,7 +1020,7 @@ func (s *Service) resumeClaimedApplyWithOptions(ctx context.Context, workerID in
 			return false, err
 		}
 		s.logger.Error("operator: failed to resume apply",
-			"worker", workerID,
+			"driver", driverID,
 			"apply_id", apply.ApplyIdentifier,
 			"database", apply.Database,
 			"deployment", deployment,
@@ -1035,7 +1035,7 @@ func (s *Service) resumeClaimedApplyWithOptions(ctx context.Context, workerID in
 
 	duration := s.clock.Now().Sub(start)
 	s.logger.Info("operator: resumed apply",
-		"worker", workerID,
+		"driver", driverID,
 		"apply_id", apply.ApplyIdentifier,
 		"database", apply.Database,
 		"deployment", deployment,
@@ -1048,14 +1048,14 @@ func (s *Service) resumeClaimedApplyWithOptions(ctx context.Context, workerID in
 }
 
 // logApplyResumeClaim appends a durable apply log entry recording that an
-// operator worker claimed the apply to resume it. Best-effort: a failed
+// operator driver claimed the apply to resume it. Best-effort: a failed
 // append must not block the resume, so the error is logged and the claim
 // proceeds.
-func (s *Service) logApplyResumeClaim(ctx context.Context, workerID int, apply *storage.Apply) {
+func (s *Service) logApplyResumeClaim(ctx context.Context, driverID int, apply *storage.Apply) {
 	logStore := s.storage.ApplyLogs()
 	if logStore == nil {
 		s.logger.Warn("operator: no apply log store configured; apply claim will not appear in apply logs",
-			"worker", workerID,
+			"driver", driverID,
 			"apply_id", apply.ApplyIdentifier)
 		return
 	}
@@ -1066,13 +1066,13 @@ func (s *Service) logApplyResumeClaim(ctx context.Context, workerID int, apply *
 		Level:     storage.LogLevelInfo,
 		EventType: storage.LogEventInfo,
 		Source:    storage.LogSourceSchemaBot,
-		Message:   fmt.Sprintf("Operator claimed apply to resume it (worker %d, state %s)", workerID, apply.State),
+		Message:   fmt.Sprintf("Operator claimed apply to resume it (driver %d, state %s)", driverID, apply.State),
 		OldState:  apply.State,
 		NewState:  apply.State,
 		CreatedAt: s.clock.Now(),
 	}); err != nil {
 		s.logger.Warn("operator: failed to log apply claim; apply claim will not appear in apply logs",
-			"worker", workerID,
+			"driver", driverID,
 			"apply_id", apply.ApplyIdentifier,
 			"database", apply.Database,
 			"environment", apply.Environment,
@@ -1084,10 +1084,10 @@ func (s *Service) logApplyResumeClaim(ctx context.Context, workerID int, apply *
 // ResumeApply runs, at min(operatorPollInterval, ApplyOperationHeartbeatInterval)
 // so the row cannot go stale and be re-claimed by a peer even when the poll
 // interval is large. The heartbeat writes under the operation lease, so a lost
-// operation lease cancels the run and the displaced worker stops; other
+// operation lease cancels the run and the displaced driver stops; other
 // heartbeat errors are logged and retried on the next tick.
 // Returns a stop func that is safe to call more than once.
-func (s *Service) startApplyOperationHeartbeat(ctx context.Context, workerID int, op *storage.ApplyOperation, apply *storage.Apply, cancelRun context.CancelFunc) func() {
+func (s *Service) startApplyOperationHeartbeat(ctx context.Context, driverID int, op *storage.ApplyOperation, apply *storage.Apply, cancelRun context.CancelFunc) func() {
 	hbCtx, stop := context.WithCancel(ctx)
 	interval := min(s.operatorPollInterval, ApplyOperationHeartbeatInterval)
 	s.recoveryWg.Go(func() {
@@ -1100,8 +1100,8 @@ func (s *Service) startApplyOperationHeartbeat(ctx context.Context, workerID int
 			case <-ticker.C:
 				if err := s.storage.ApplyOperations().Heartbeat(hbCtx, op.ID); err != nil {
 					if errors.Is(err, storage.ErrApplyLeaseLost) {
-						s.logger.Warn("operator: apply_operation heartbeat lost operation lease; worker will stop",
-							"worker", workerID,
+						s.logger.Warn("operator: apply_operation heartbeat lost operation lease; driver will stop",
+							"driver", driverID,
 							"apply_operation_id", op.ID,
 							"apply_id", apply.ApplyIdentifier,
 							"database", apply.Database,
@@ -1112,7 +1112,7 @@ func (s *Service) startApplyOperationHeartbeat(ctx context.Context, workerID int
 						return
 					}
 					s.logger.Warn("operator: apply_operation heartbeat failed; will retry",
-						"worker", workerID,
+						"driver", driverID,
 						"apply_operation_id", op.ID,
 						"apply_id", apply.ApplyIdentifier,
 						"database", apply.Database,
@@ -1133,8 +1133,8 @@ func (s *Service) startApplyOperationHeartbeat(ctx context.Context, workerID int
 // failed operation is recorded even while the parent projection holds the apply
 // running under on_failure "continue". Both delegate to persistOperationState,
 // which documents the updated/error contract.
-func (s *Service) markOperationFromApplyState(ctx context.Context, workerID int, op *storage.ApplyOperation, apply *storage.Apply) (updated bool, err error) {
-	return s.persistOperationState(ctx, workerID, op, apply.State, apply.ErrorMessage)
+func (s *Service) markOperationFromApplyState(ctx context.Context, driverID int, op *storage.ApplyOperation, apply *storage.Apply) (updated bool, err error) {
+	return s.persistOperationState(ctx, driverID, op, apply.State, apply.ErrorMessage)
 }
 
 // markOperationFromOwnResult transitions the claimed operation row to reflect
@@ -1158,7 +1158,7 @@ func (s *Service) markOperationFromApplyState(ctx context.Context, workerID int,
 // with a nil error when the operation's tasks derive a non-terminal state and
 // the row is left claimable for a later poll, and a non-nil error when a read or
 // write fails so the caller skips parent derivation.
-func (s *Service) markOperationFromOwnResult(ctx context.Context, workerID int, op *storage.ApplyOperation) (updated bool, err error) {
+func (s *Service) markOperationFromOwnResult(ctx context.Context, driverID int, op *storage.ApplyOperation) (updated bool, err error) {
 	tasks, err := s.storage.Tasks().GetByApplyOperationID(ctx, op.ID)
 	if err != nil {
 		return false, fmt.Errorf("load tasks for apply_operation %d (deployment %q): %w", op.ID, op.Deployment, err)
@@ -1168,7 +1168,7 @@ func (s *Service) markOperationFromOwnResult(ctx context.Context, workerID int, 
 		taskStates[i] = t.State
 	}
 	derived := state.DeriveApplyState(taskStates)
-	return s.persistOperationState(ctx, workerID, op, derived, firstFailedTaskError(tasks))
+	return s.persistOperationState(ctx, driverID, op, derived, firstFailedTaskError(tasks))
 }
 
 // firstFailedTaskError returns the ErrorMessage of the first failed task, used
@@ -1213,7 +1213,7 @@ func firstFailedOperationMessage(ops []*storage.ApplyOperation) string {
 // operation claimable (updated=false, nil error) so a later poll re-leases and
 // resumes it; a write failure returns the error so the caller skips derivation
 // rather than aggregating a stale child state.
-func (s *Service) persistOperationState(ctx context.Context, workerID int, op *storage.ApplyOperation, derived, errorMessage string) (updated bool, err error) {
+func (s *Service) persistOperationState(ctx context.Context, driverID int, op *storage.ApplyOperation, derived, errorMessage string) (updated bool, err error) {
 	opStore := s.storage.ApplyOperations()
 	switch {
 	case state.IsState(derived, state.Apply.Completed):
@@ -1261,7 +1261,7 @@ func (s *Service) persistOperationState(ctx context.Context, workerID int, op *s
 		return true, nil
 	default:
 		s.logger.Debug("operator: derived operation state not terminal; leaving operation claimable",
-			"worker", workerID, "apply_operation_id", op.ID,
+			"driver", driverID, "apply_operation_id", op.ID,
 			"deployment", op.Deployment, "state", derived)
 		return false, nil
 	}
@@ -1341,7 +1341,7 @@ type applyProjectionResult struct {
 // unscoped reconciliation path passes rejectFailedApplyReopen so it never
 // revives a terminal parent through a last-write-wins update; every other
 // terminal-to-non-terminal transition stays an error regardless.
-func (s *Service) updateApplyStateFromOperations(ctx context.Context, workerID int, apply *storage.Apply, reopen failedApplyReopenPolicy) (applyProjectionResult, error) {
+func (s *Service) updateApplyStateFromOperations(ctx context.Context, driverID int, apply *storage.Apply, reopen failedApplyReopenPolicy) (applyProjectionResult, error) {
 	ops, err := s.storage.ApplyOperations().ListByApply(ctx, apply.ID)
 	if err != nil {
 		return applyProjectionResult{}, fmt.Errorf("list apply_operations for apply %s (%d): %w", apply.ApplyIdentifier, apply.ID, err)
@@ -1392,7 +1392,7 @@ func (s *Service) updateApplyStateFromOperations(ctx context.Context, workerID i
 
 	if state.IsState(apply.State, derived) && startedAt == nil {
 		s.logger.Debug("operator: derived apply state matches current; no update",
-			"worker", workerID, "apply_id", apply.ApplyIdentifier,
+			"driver", driverID, "apply_id", apply.ApplyIdentifier,
 			"database", apply.Database, "environment", apply.Environment,
 			"state", derived, "operation_count", len(ops))
 		return applyProjectionResult{PreviousState: apply.State, DerivedState: derived, OperationCount: len(ops)}, nil
@@ -1434,13 +1434,13 @@ func (s *Service) updateApplyStateFromOperations(ctx context.Context, workerID i
 		// Another drive advanced the apply between our read and write; our
 		// projection is stale. Skip and let the next poll reconcile.
 		s.logger.Info("operator: derived apply state write lost a race; skipping",
-			"worker", workerID, "apply_id", apply.ApplyIdentifier,
+			"driver", driverID, "apply_id", apply.ApplyIdentifier,
 			"database", apply.Database, "environment", apply.Environment,
 			"expected_state", apply.State, "derived_state", derived, "operation_count", len(ops))
 		return applyProjectionResult{PreviousState: apply.State, DerivedState: derived, OperationCount: len(ops)}, nil
 	}
 	s.logger.Info("operator: updated derived apply state from apply_operations",
-		"worker", workerID, "apply_id", apply.ApplyIdentifier,
+		"driver", driverID, "apply_id", apply.ApplyIdentifier,
 		"database", apply.Database, "environment", apply.Environment,
 		"previous_state", apply.State, "derived_state", derived, "operation_count", len(ops))
 	return applyProjectionResult{
@@ -1460,13 +1460,13 @@ func (s *Service) updateApplyStateFromOperations(ctx context.Context, workerID i
 // durably terminal once result.BecameTerminal is true, publishing is best
 // effort: every failure is logged with triage identifiers and counted, never
 // reverted, and left for summary reconciliation to repair.
-func (s *Service) publishTerminalSummaryIfWon(ctx context.Context, workerID int, apply *storage.Apply, result applyProjectionResult) {
+func (s *Service) publishTerminalSummaryIfWon(ctx context.Context, driverID int, apply *storage.Apply, result applyProjectionResult) {
 	if !result.BecameTerminal || result.OperationCount <= 1 {
 		return
 	}
 	if s.OnApplyTerminalSummary == nil {
 		s.logger.Debug("operator: aggregate terminal summary publisher not configured; skipping",
-			"worker", workerID, "apply_id", apply.ApplyIdentifier,
+			"driver", driverID, "apply_id", apply.ApplyIdentifier,
 			"database", apply.Database, "environment", apply.Environment,
 			"derived_state", result.DerivedState, "operation_count", result.OperationCount)
 		return
@@ -1478,7 +1478,7 @@ func (s *Service) publishTerminalSummaryIfWon(ctx context.Context, workerID int,
 	terminalApply, err := s.storage.Applies().Get(ctx, apply.ID)
 	if err != nil {
 		s.logger.Error("operator: failed to reload terminal apply for aggregate summary; summary not published",
-			"worker", workerID, "apply_id", apply.ApplyIdentifier,
+			"driver", driverID, "apply_id", apply.ApplyIdentifier,
 			"database", apply.Database, "environment", apply.Environment,
 			"derived_state", result.DerivedState, "operation_count", result.OperationCount, "error", err)
 		metrics.RecordOperatorTerminalSummaryFailure(ctx, "reload_apply_error")
@@ -1486,7 +1486,7 @@ func (s *Service) publishTerminalSummaryIfWon(ctx context.Context, workerID int,
 	}
 	if terminalApply == nil {
 		s.logger.Error("operator: terminal apply not found while publishing aggregate summary; summary not published",
-			"worker", workerID, "apply_id", apply.ApplyIdentifier,
+			"driver", driverID, "apply_id", apply.ApplyIdentifier,
 			"database", apply.Database, "environment", apply.Environment,
 			"derived_state", result.DerivedState, "operation_count", result.OperationCount)
 		metrics.RecordOperatorTerminalSummaryFailure(ctx, "apply_missing")
@@ -1494,7 +1494,7 @@ func (s *Service) publishTerminalSummaryIfWon(ctx context.Context, workerID int,
 	}
 	if !state.IsTerminalApplyState(terminalApply.State) {
 		s.logger.Error("operator: reloaded apply is no longer terminal while publishing aggregate summary; summary not published",
-			"worker", workerID, "apply_id", terminalApply.ApplyIdentifier,
+			"driver", driverID, "apply_id", terminalApply.ApplyIdentifier,
 			"database", terminalApply.Database, "environment", terminalApply.Environment,
 			"reloaded_state", terminalApply.State, "derived_state", result.DerivedState,
 			"operation_count", result.OperationCount)
@@ -1507,7 +1507,7 @@ func (s *Service) publishTerminalSummaryIfWon(ctx context.Context, workerID int,
 	tasks, err := s.storage.Tasks().GetByApplyID(ctx, terminalApply.ID)
 	if err != nil {
 		s.logger.Error("operator: failed to reload tasks for aggregate terminal summary; summary not published",
-			"worker", workerID, "apply_id", terminalApply.ApplyIdentifier,
+			"driver", driverID, "apply_id", terminalApply.ApplyIdentifier,
 			"database", terminalApply.Database, "environment", terminalApply.Environment,
 			"derived_state", result.DerivedState, "operation_count", result.OperationCount, "error", err)
 		metrics.RecordOperatorTerminalSummaryFailure(ctx, "reload_tasks_error")
@@ -1516,22 +1516,22 @@ func (s *Service) publishTerminalSummaryIfWon(ctx context.Context, workerID int,
 
 	if err := s.OnApplyTerminalSummary(ctx, terminalApply, tasks); err != nil {
 		s.logger.Error("operator: aggregate terminal summary publish failed; parent state stays terminal, summary left for reconciliation",
-			"worker", workerID, "apply_id", terminalApply.ApplyIdentifier,
+			"driver", driverID, "apply_id", terminalApply.ApplyIdentifier,
 			"database", terminalApply.Database, "environment", terminalApply.Environment,
 			"derived_state", result.DerivedState, "operation_count", result.OperationCount, "error", err)
 		metrics.RecordOperatorTerminalSummaryFailure(ctx, "callback_error")
 		return
 	}
 	s.logger.Info("operator: published aggregate terminal summary for multi-operation apply",
-		"worker", workerID, "apply_id", terminalApply.ApplyIdentifier,
+		"driver", driverID, "apply_id", terminalApply.ApplyIdentifier,
 		"database", terminalApply.Database, "environment", terminalApply.Environment,
 		"derived_state", result.DerivedState, "operation_count", result.OperationCount)
 }
 
-func operatorLeaseOwner(workerID int) string {
+func driverLeaseOwner(driverID int) string {
 	hostname, err := os.Hostname()
 	if err != nil || hostname == "" {
 		hostname = "unknown-host"
 	}
-	return fmt.Sprintf("%s/%d/worker-%d", hostname, os.Getpid(), workerID)
+	return fmt.Sprintf("%s/%d/driver-%d", hostname, os.Getpid(), driverID)
 }

--- a/pkg/api/plan_handlers.go
+++ b/pkg/api/plan_handlers.go
@@ -676,7 +676,7 @@ func applyMetricStatusForError(err error) string {
 }
 
 // ExecuteApply queues an apply request in storage and returns once the work is
-// durable. Operator workers own dispatching queued work through the Tern
+// durable. Operator drivers own dispatching queued work through the Tern
 // client so request cancellation cannot orphan in-memory execution.
 //
 // Flow:
@@ -684,7 +684,7 @@ func applyMetricStatusForError(err error) string {
 //  2. Resolve the Tern client to validate the deployment/environment.
 //  3. Create a pending Apply record and pending Task records from the plan.
 //  4. Attach any pending observer to the stored apply before dispatch can start.
-//  5. Wake an operator worker so fresh applies usually start immediately.
+//  5. Wake an operator driver so fresh applies usually start immediately.
 //  6. Return the SchemaBot apply_identifier to the HTTP caller.
 //
 // Returns the API response, the stored apply ID (0 if not stored), and any error.
@@ -833,7 +833,7 @@ func (s *Service) authorizeStoredPlanSource(ctx context.Context, span trace.Span
 }
 
 // queueValidatedApply stores the pending apply and tasks for a validated plan
-// and wakes an operator worker. Callers must have run loadPlanForApply first;
+// and wakes an operator driver. Callers must have run loadPlanForApply first;
 // gated entry points also run authorizeStoredPlanSource before queueing.
 func (s *Service) queueValidatedApply(ctx context.Context, span trace.Span, plan *storage.Plan, req ApplyRequest) (*apitypes.ApplyResponse, int64, error) {
 	deployment := plan.Deployment

--- a/pkg/api/progress_handlers.go
+++ b/pkg/api/progress_handlers.go
@@ -67,7 +67,7 @@ func shouldServeProgressFromStorage(applyState string) bool {
 }
 
 // A remote apply may be accepted into control-plane storage before an operator
-// worker dispatches it and stores the data-plane ID. During that handoff window,
+// driver dispatches it and stores the data-plane ID. During that handoff window,
 // progress must use local storage instead of asking the data plane about a
 // control-plane apply identifier it cannot know.
 func shouldServeRemoteProgressFromStorage(apply *storage.Apply, client tern.Client) bool {
@@ -81,7 +81,7 @@ func shouldServeRemoteProgressFromStorage(apply *storage.Apply, client tern.Clie
 }
 
 // queuedRemoteProgressApply returns the user-visible apply state while a gRPC
-// apply is claimed by an operator worker but has not been accepted by the
+// apply is claimed by an operator driver but has not been accepted by the
 // remote data plane yet. The storage row is already running for recovery
 // purposes, but operators should still see pending until external_id exists.
 func queuedRemoteProgressApply(apply *storage.Apply) *storage.Apply {

--- a/pkg/api/service.go
+++ b/pkg/api/service.go
@@ -280,7 +280,7 @@ func (s *Service) RegisterEngine(databaseType string, factory tern.EngineFactory
 
 // SetClock overrides the time source used by orchestration loops (currently
 // the operator claim-duration measurement). Must be called before
-// StartOperator — once operator workers are running they read s.clock
+// StartOperator — once operator drivers are running they read s.clock
 // concurrently, so swapping the field is rejected to avoid a data race.
 // Production callers should leave the default clock.Real{} in place; tests
 // use clock.NewFake to make timing observable. A nil or typed-nil c is
@@ -295,10 +295,10 @@ func (s *Service) SetClock(c clock.Clock) error {
 	return nil
 }
 
-// SetOperatorPollInterval sets the operator worker poll interval.
+// SetOperatorPollInterval sets the operator driver poll interval.
 // Most deployments should use the default interval; this is a low-level
 // embedding hook for callers that need to tune the operator loop directly.
-// Call before StartOperator so workers create their tickers with the intended
+// Call before StartOperator so drivers create their tickers with the intended
 // interval.
 func (s *Service) SetOperatorPollInterval(interval time.Duration) error {
 	if interval <= 0 {
@@ -721,7 +721,7 @@ func (s *Service) Storage() storage.Storage {
 
 // Close closes the service and releases resources.
 func (s *Service) Close() error {
-	// Stop background workers first.
+	// Stop background drivers first.
 	s.StopOperator()
 	s.StopRemoteDeploymentHealthMonitor()
 

--- a/pkg/cmd/commands/serve.go
+++ b/pkg/cmd/commands/serve.go
@@ -171,7 +171,7 @@ func (cmd *ServeCmd) Run(g *Globals) error {
 		svc.SetDefaultTernClient(dataPlaneClient)
 	}
 
-	// Start the operator worker pool after webhook callbacks are registered.
+	// Start the operator driver pool after webhook callbacks are registered.
 	// This polls for apply work every 10 seconds:
 	// - Runs immediately on startup
 	// - Dispatches queued local applies

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -248,7 +248,7 @@ type ApplyRequest struct {
 
 	// OnStateChange is called by the engine to persist ResumeState at key milestones
 	// during Apply (e.g., after branch creation, after deploy request creation).
-	// This enables crash recovery: if the worker dies mid-Apply, the tern layer can
+	// This enables crash recovery: if the driver dies mid-Apply, the tern layer can
 	// resume from the last persisted state instead of starting over.
 	// Nil means no persistence (state is only returned at the end of Apply).
 	OnStateChange func(state *ResumeState)
@@ -414,11 +414,11 @@ type ControlResult struct {
 // The same volume number has different effects per engine:
 //   - Spirit: controls thread count (1-16+) and chunk timing. Higher volume =
 //     more parallel copy threads = faster but more load. State is in-process
-//     and lost on worker crash (restarts with defaults).
+//     and lost on driver crash (restarts with defaults).
 //   - PlanetScale/Vitess: controls a server-side rejection throttle ratio
 //     (0.0-0.95). Online DDL runs on a single thread per shard; the throttle
 //     ratio determines what fraction of write requests are rejected to limit
-//     replication lag impact. State is server-side and survives worker crashes.
+//     replication lag impact. State is server-side and survives driver crashes.
 //
 // The scale provides a consistent user interface across engines, but the
 // underlying mechanisms are fundamentally different (concurrency control

--- a/pkg/engine/planetscale/apply.go
+++ b/pkg/engine/planetscale/apply.go
@@ -73,7 +73,7 @@ func (e *Engine) Apply(ctx context.Context, req *engine.ApplyRequest) (*engine.A
 	}
 	// persistState persists apply metadata to storage via OnStateChange for crash recovery.
 	// On first apply, migCtx is empty until the tern layer assigns one via ResumeState.
-	// persistState is a no-op in this window — if the worker crashes before Apply returns,
+	// persistState is a no-op in this window — if the driver crashes before Apply returns,
 	// there's no ResumeState to recover from. The tern layer handles this by retrying
 	// the full Apply on the next heartbeat recovery cycle.
 	persistState := func(meta *psMetadata) {
@@ -696,12 +696,12 @@ func (e *Engine) resumeApply(ctx context.Context, client psclient.PSClient, org 
 		"deploy_request", meta.DeployRequestID,
 	)
 
-	// If we have a deploy request ID, the worker crashed after creating it.
+	// If we have a deploy request ID, the driver crashed after creating it.
 	if meta.DeployRequestID != 0 {
 		return e.resumeExistingDeployRequest(ctx, client, org, req, meta)
 	}
 
-	// No deploy request yet — worker crashed after branch creation but before
+	// No deploy request yet — driver crashed after branch creation but before
 	// the deploy request was created. Diff the branch against desired schema
 	// to find DDL that wasn't applied before the crash, then apply only the
 	// missing changes.
@@ -845,7 +845,7 @@ func (e *Engine) resumeApply(ctx context.Context, client psclient.PSClient, org 
 
 // resumeExistingDeployRequest resumes an apply whose deploy request was already
 // created before the crash. It reattaches to the recovered deploy request,
-// deploys it when the worker crashed after creation but before the deploy was
+// deploys it when the driver crashed after creation but before the deploy was
 // started, and rediscovers the Vitess migration_context so per-shard progress
 // keeps working for the rest of the apply.
 func (e *Engine) resumeExistingDeployRequest(ctx context.Context, client psclient.PSClient, org string, req *engine.ApplyRequest, meta *psMetadata) (*engine.ApplyResult, error) {
@@ -968,7 +968,7 @@ func (e *Engine) resumeExistingDeployRequest(ctx context.Context, client psclien
 // deployRequestNeedsResumeDeploy reports whether a recovered deploy request must
 // be deployed during resume. This is the case only for a non-deferred deploy
 // request that finished PlanetScale's diff ("ready") but was never started —
-// the worker crashed between creating the deploy request and deploying it. A
+// the driver crashed between creating the deploy request and deploying it. A
 // deferred deploy is left for the operator-triggered deploy, and a request that
 // already has a DeployedAt timestamp is in flight and must not be re-deployed.
 func deployRequestNeedsResumeDeploy(dr *ps.DeployRequest, meta *psMetadata) bool {

--- a/pkg/engine/planetscale/apply_test.go
+++ b/pkg/engine/planetscale/apply_test.go
@@ -111,7 +111,7 @@ func (c *pendingPollClient) GetDeployRequest(_ context.Context, req *ps.GetDeplo
 }
 
 // When PlanetScale returns a transient error while a deploy request is still
-// computing its schema diff, the apply worker surfaces a wrapped error
+// computing its schema diff, the apply driver surfaces a wrapped error
 // identifying the deploy request rather than panicking on a nil response.
 func TestWaitForDeployRequestPending_PollErrorIsWrapped(t *testing.T) {
 	e := New(slog.New(slog.NewTextHandler(os.Stdout, nil)))
@@ -128,7 +128,7 @@ func TestWaitForDeployRequestPending_PollErrorIsWrapped(t *testing.T) {
 }
 
 // A deploy request that never leaves the pending state must not block the apply
-// worker forever — cancelling the context stops the poll and returns a wrapped
+// driver forever — cancelling the context stops the poll and returns a wrapped
 // error naming the deploy request.
 func TestWaitForDeployRequestPending_HonorsContextCancellation(t *testing.T) {
 	e := New(slog.New(slog.NewTextHandler(os.Stdout, nil)))
@@ -237,7 +237,7 @@ func captureStateChanges(req *engine.ApplyRequest) *[]*engine.ResumeState {
 }
 
 // deployRequestNeedsResumeDeploy gates the resume path that starts a deploy the
-// crashed worker never began. It must fire only for a non-deferred deploy
+// crashed driver never began. It must fire only for a non-deferred deploy
 // request that finished validation ("ready") and was never deployed.
 func TestDeployRequestNeedsResumeDeploy(t *testing.T) {
 	deployedAt := time.Now()
@@ -286,7 +286,7 @@ func TestDeployRequestNeedsResumeDeploy(t *testing.T) {
 	}
 }
 
-// A worker that crashed between creating a non-deferred deploy request and
+// A driver that crashed between creating a non-deferred deploy request and
 // starting it leaves the request stuck in "ready", which Progress reports as
 // pending forever. Resuming must start the deploy so the schema change actually
 // runs, carrying the instant DDL flag from the recovered metadata.
@@ -312,7 +312,7 @@ func TestResumeExistingDeployRequest_DeploysReadyNeverStarted(t *testing.T) {
 	assert.Contains(t, result.Message, "Resumed and deployed request #42")
 }
 
-// A deploy request that is already in flight when the worker resumes must not be
+// A deploy request that is already in flight when the driver resumes must not be
 // re-deployed; resume simply reattaches and preserves the stored progress state.
 func TestResumeExistingDeployRequest_InFlightIsNotRedeployed(t *testing.T) {
 	e := New(slog.New(slog.NewTextHandler(os.Stdout, nil)))

--- a/pkg/metrics/README.md
+++ b/pkg/metrics/README.md
@@ -99,10 +99,10 @@ available, such as `repository`, `github_app`, and `installation_id`.
 ### Check Ownership Misses
 
 `schemabot.check_ownership_misses_total` should normally be near zero. A spike
-means an apply or rollback worker reached a terminal path after the stored check
+means an apply or rollback driver reached a terminal path after the stored check
 state had already moved to a different owner, usually because a new commit,
-newer apply, rollback, pod restart, or recovery path raced with the older worker.
-The guarded update prevented the stale worker from overwriting current merge-gate
+newer apply, rollback, pod restart, or recovery path raced with the older driver.
+The guarded update prevented the stale driver from overwriting current merge-gate
 state, so the metric is a near-miss signal rather than proof that check state was
 corrupted.
 
@@ -110,13 +110,13 @@ Operation values:
 
 | Operation | Meaning |
 |---|---|
-| `apply_finished` | A worker tried to record a terminal apply result, but the stored check state no longer belonged to that apply. |
-| `rollback_finished` | A rollback worker tried to mark the check `action_required`, but the stored check state no longer belonged to that rollback apply. |
+| `apply_finished` | A driver tried to record a terminal apply result, but the stored check state no longer belonged to that apply. |
+| `rollback_finished` | A rollback driver tried to mark the check `action_required`, but the stored check state no longer belonged to that rollback apply. |
 
 A spike is still dangerous because the live database can keep changing after the
 PR's desired schema has moved on. For example, an apply can start for commit A,
 an agent can push commit B that removes the schema change, and commit A's apply
-can still reach the database. The guard prevents the old apply worker from
+can still reach the database. The guard prevents the old apply driver from
 marking the current check successful, but it does not undo live-schema drift.
 
 Operator response:
@@ -127,7 +127,7 @@ Operator response:
    apply was running, then compare the latest commit on the PR branch, stored
    check state, and active apply state before allowing merge.
 3. For a global spike, check recent deploys, pod restarts, recovery activity, and
-   webhook redeliveries. A broad spike can indicate duplicate workers or a
+   webhook redeliveries. A broad spike can indicate duplicate drivers or a
    service-level race, not just user commit churn.
 4. If the live schema may now differ from the PR's current declarative schema,
    re-plan the current head and decide whether to apply again, roll back, or
@@ -166,7 +166,7 @@ Operation values:
 | `rollback_finished` | SchemaBot marked stored check state `action_required` after a rollback succeeded because the PR's desired schema is no longer present in that environment. |
 | `aggregate_check_sync` | SchemaBot tried to make the visible aggregate GitHub Check Run match stored per-database check state. The status label says whether it created/updated, skipped, blocked, or failed. |
 | `stale_check_cleanup` | SchemaBot handled stored check state for a database that is no longer touched by the latest commit on the PR branch. Plan-only state can be cleared; apply-owned state stays blocked. |
-| `stale_check_reconciliation` | SchemaBot repaired stale `in_progress` stored check state by comparing it with authoritative apply state after a worker restart, crash, or race. |
+| `stale_check_reconciliation` | SchemaBot repaired stale `in_progress` stored check state by comparing it with authoritative apply state after a driver restart, crash, or race. |
 | `schema_config_discovery` | SchemaBot discovered managed schema configs for the PR before deciding what to plan or which aggregate checks to publish. |
 | `schema_config_source_policy` | SchemaBot evaluated whether a discovered `schemabot.yaml` path is inside this repository's server-owned `allowed_dirs` boundary. `status="skipped"` means the config is outside the managed paths and was ignored; `status="error"` means the config is in a managed path but cannot be routed safely. |
 | `schema_config_environment_validation` | SchemaBot found schema changes but none of the database's server-configured environments are allowed for this deployment, so it failed the aggregate check closed. |

--- a/pkg/state/README.md
+++ b/pkg/state/README.md
@@ -80,7 +80,7 @@ stateDiagram-v2
 - `recovering`: Temporary restart recovery. Current MySQL/Spirit deferred-cutover recovery enters this state only after durable storage had already reached `waiting_for_cutover`. That stored cutover-ready state is authoritative: recovery must not move durable storage backward to `running` if Spirit reports row-copy progress after reattaching. Row-copy counters can still be displayed while storage remains `recovering`. Recovery exits to `waiting_for_cutover` only after cutover readiness is proven again, or to `completed` when live-schema reconciliation proves the data plane already reached the desired schema. Control operations that require a later phase are blocked while recovery is active.
 - `revert_window`: Only with `--enable-revert`. Spirit auto-advances through it; PlanetScale holds until expiry or user action. Maps from PlanetScale's `complete_pending_revert` deploy state
 - `stopped`: Spirit only — resumable via `schemabot start`. Spirit checkpoints progress for resume.
-- `failed_retryable`: transient engine failure. Scheduler workers retry while the retry budget remains, then move the apply to `failed`.
+- `failed_retryable`: transient engine failure. Scheduler drivers retry while the retry budget remains, then move the apply to `failed`.
 - `cancelled`: PlanetScale only — permanent. Cancels the deploy request; the underlying Vitess migrations are cancelled. Not resumable — start a new apply instead.
 
 ## Task states

--- a/pkg/state/apply.go
+++ b/pkg/state/apply.go
@@ -255,7 +255,7 @@ func IsState(s string, expected ...string) bool {
 
 // IsTerminalApplyState returns true if the state is a terminal state
 // where no further processing will occur. FailedRetryable is not terminal;
-// operator workers may claim and retry it.
+// operator drivers may claim and retry it.
 // Accepts any format (proto "STATE_COMPLETED", uppercase "COMPLETED", or
 // canonical lowercase "completed") — normalizes first.
 func IsTerminalApplyState(s string) bool {

--- a/pkg/state/task.go
+++ b/pkg/state/task.go
@@ -51,7 +51,7 @@ var TerminalTaskStates = []string{
 // IsTerminalTaskState returns true if the state is a terminal task state
 // where no further processing will occur.
 // Stopped is NOT terminal — a stopped task can be resumed via Start.
-// FailedRetryable is NOT terminal — operator workers may retry the task.
+// FailedRetryable is NOT terminal — operator drivers may retry the task.
 func IsTerminalTaskState(s string) bool {
 	switch s {
 	case Task.Completed, Task.Failed, Task.Reverted, Task.Cancelled:

--- a/pkg/storage/README.md
+++ b/pkg/storage/README.md
@@ -28,7 +28,7 @@ type Storage interface {
 | `ApplyStore` | Schema change execution state, heartbeat-based leasing |
 | `TaskStore` | Individual DDL tasks within an apply, progress tracking |
 | `ApplyLogStore` | Audit trail (state transitions, errors, progress events) |
-| `ControlRequestStore` | Durable user control intent that can be recovered by workers |
+| `ControlRequestStore` | Durable user control intent that can be recovered by drivers |
 | `CheckStore` | GitHub status check state |
 | `SettingsStore` | Admin-level key-value settings |
 
@@ -52,9 +52,9 @@ See [`pkg/state`](../state/) for the full state hierarchy (apply states, task st
 
 The apply store supports crash recovery through heartbeat-based leasing:
 
-- **Heartbeat**: Workers call `Heartbeat(applyID)` every 10 seconds to signal they're alive
+- **Heartbeat**: Drivers call `Heartbeat(applyID)` every 10 seconds to signal they're alive
 - **FindNextApply**: Claims one apply with a stale heartbeat (>1 minute since last update) by selecting it and refreshing its heartbeat in one transaction
-- If a worker crashes, its apply becomes claimable after the heartbeat times out
+- If a driver crashes, its apply becomes claimable after the heartbeat times out
 
 ## Key Types
 

--- a/pkg/storage/lease.go
+++ b/pkg/storage/lease.go
@@ -36,7 +36,7 @@ type operationLeaseContextKey struct{}
 // It is distinct from ApplyLease: it identifies the operation row and carries
 // the operation's own token, so storage writes can guard on the operation's
 // claim instead of the parent apply's. Keeping the two leases separate lets a
-// worker hold both at once during the migration to operation-scoped writes
+// driver hold both at once during the migration to operation-scoped writes
 // without conflating an operation token with the parent apply token.
 type OperationLease struct {
 	ApplyID     int64

--- a/pkg/storage/lease_test.go
+++ b/pkg/storage/lease_test.go
@@ -14,12 +14,12 @@ func TestOperationLease_Valid(t *testing.T) {
 	}{
 		{
 			name:  "fully populated",
-			lease: OperationLease{ApplyID: 1, OperationID: 2, Owner: "worker-0", Token: "tok"},
+			lease: OperationLease{ApplyID: 1, OperationID: 2, Owner: "driver-0", Token: "tok"},
 			want:  true,
 		},
 		{
 			name:  "missing token",
-			lease: OperationLease{ApplyID: 1, OperationID: 2, Owner: "worker-0"},
+			lease: OperationLease{ApplyID: 1, OperationID: 2, Owner: "driver-0"},
 			want:  false,
 		},
 		{
@@ -60,7 +60,7 @@ func TestOperationLeaseFromContext_Absent(t *testing.T) {
 }
 
 // An operation lease must not be readable as an apply lease and vice versa:
-// the two capabilities use distinct context keys so a worker can carry both at
+// the two capabilities use distinct context keys so a driver can carry both at
 // once without one masquerading as the other.
 func TestOperationAndApplyLeasesAreDistinct(t *testing.T) {
 	ctx := WithOperationLease(t.Context(), OperationLease{ApplyID: 1, OperationID: 2, Token: "op"})

--- a/pkg/storage/mysqlstore/applies.go
+++ b/pkg/storage/mysqlstore/applies.go
@@ -72,15 +72,15 @@ type txBeginner interface {
 
 // claimableApplyStates returns active apply states where operator recovery can
 // safely resume work after the heartbeat becomes stale. Pending has a separate
-// queue path and does not need to be stale before a worker claims it. Terminal
+// queue path and does not need to be stale before a driver claims it. Terminal
 // states are already done, failed_retryable has its own retry path, and stopped
 // requires an explicit user start.
 //
 // The PlanetScale setup-phase states (preparing_branch through
 // validating_deploy_request) are included: a stale heartbeat in any of them
-// unambiguously means the worker driving engine setup died, and the persisted
+// unambiguously means the driver driving engine setup died, and the persisted
 // branch/deploy metadata lets recovery resume the apply from stored state. A
-// healthy worker mid-setup keeps its heartbeat fresh, so it is never claimed out
+// healthy driver mid-setup keeps its heartbeat fresh, so it is never claimed out
 // from under itself. Leaving these states out would strand a crashed setup-phase
 // apply non-terminal and unclaimable, so no operator could ever recover it.
 //
@@ -1056,13 +1056,13 @@ func (s *applyStore) GetRecent(ctx context.Context, filter storage.RecentApplies
 // applies where heartbeat expired > 1 minute, and recently failed_retryable
 // applies that still have retry budget.
 // Apply creation/update enforces one active apply per database/type/environment,
-// so claims only need to lease one row and avoid worker races on that row.
+// so claims only need to lease one row and avoid driver races on that row.
 func (s *applyStore) FindNextApply(ctx context.Context, owner string) (*storage.Apply, error) {
 	if owner == "" {
 		return nil, fmt.Errorf("operator owner is required to claim apply: %w", storage.ErrApplyLeaseLost)
 	}
 	// Read committed keeps concurrent SKIP LOCKED claims from taking next-key
-	// range locks that can serialize workers across otherwise independent targets.
+	// range locks that can serialize drivers across otherwise independent targets.
 	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelReadCommitted})
 	if err != nil {
 		return nil, fmt.Errorf("begin claim apply transaction: %w", err)
@@ -1086,7 +1086,7 @@ func (s *applyStore) FindNextApply(ctx context.Context, owner string) (*storage.
 
 	// Apply creation/update enforces at most one active apply per
 	// database/type/environment. The claim query only needs to find stale work;
-	// FOR UPDATE SKIP LOCKED prevents concurrent workers from claiming the same row.
+	// FOR UPDATE SKIP LOCKED prevents concurrent drivers from claiming the same row.
 	row := tx.QueryRowContext(ctx, fmt.Sprintf(`
 		SELECT %s
 		FROM applies a
@@ -1383,7 +1383,7 @@ func (o claimOutcome) claimedAndComplete() bool {
 // persistApplyClaim rotates the lease (owner, token, acquired_at) onto apply in
 // memory and persists it inside tx, refreshing the heartbeat in the same write.
 // Pending, stopped-start, and retryable applies move into running as part of the
-// claim so another worker cannot immediately re-claim the same durable request
+// claim so another driver cannot immediately re-claim the same durable request
 // after the transaction releases its row lock; active applies just refresh the
 // heartbeat.
 //
@@ -1486,7 +1486,7 @@ func isStartingClaim(applyState string) bool {
 // transient state held while the driver waits for the data plane to leave
 // stopped after a start. WHERE state = ? guards against a concurrent transition
 // landing between the SELECT and this UPDATE; a zero rows-affected result means
-// another worker already moved the row, so the caller backs off cleanly. Reports
+// another driver already moved the row, so the caller backs off cleanly. Reports
 // false on that lost race.
 func transitionClaimToState(ctx context.Context, tx *sql.Tx, apply *storage.Apply, targetState, owner, leaseToken string) (bool, error) {
 	result, err := tx.ExecContext(ctx, `
@@ -1557,7 +1557,7 @@ func failPendingStartControlRequestTx(ctx context.Context, tx *sql.Tx, applyID i
 
 // Heartbeat updates the apply's updated_at timestamp to maintain the lease.
 // Should be called every 10 seconds while working on an apply.
-// If not called for > 1 minute, another worker can claim the apply via FindNextApply.
+// If not called for > 1 minute, another driver can claim the apply via FindNextApply.
 // When ctx has an apply lease, a stale token returns ErrApplyLeaseLost so the
 // old operator owner stops before writing state or external side effects.
 func (s *applyStore) Heartbeat(ctx context.Context, applyID int64) error {

--- a/pkg/storage/mysqlstore/applies_test.go
+++ b/pkg/storage/mysqlstore/applies_test.go
@@ -133,7 +133,7 @@ func TestApplyStore_CreateWithTasksCommitsQueueAtomically(t *testing.T) {
 	assert.Equal(t, applyID, tasks[1].ApplyID)
 
 	// A pending apply created with its full task set is immediately ready for
-	// operator dispatch; workers never see a partially populated task list.
+	// operator dispatch; drivers never see a partially populated task list.
 	claimed, err := store.Applies().FindNextApply(ctx, "test-owner")
 	require.NoError(t, err)
 	require.NotNil(t, claimed)
@@ -1276,7 +1276,7 @@ func TestApplyStore_UpdateDerivedStateLeaseGuard(t *testing.T) {
 	require.NoError(t, err)
 	task.ID = taskID
 
-	claimed, err := store.Applies().FindNextApply(ctx, "worker-a")
+	claimed, err := store.Applies().FindNextApply(ctx, "driver-a")
 	require.NoError(t, err)
 	require.NotNil(t, claimed)
 
@@ -1287,7 +1287,7 @@ func TestApplyStore_UpdateDerivedStateLeaseGuard(t *testing.T) {
 	expectedState := leased.State
 
 	// A stale lease cannot write, even when the expected state matches.
-	staleCtx := storage.WithApplyLease(ctx, storage.ApplyLease{ApplyID: apply.ID, Owner: "worker-old", Token: "stale-token"})
+	staleCtx := storage.WithApplyLease(ctx, storage.ApplyLease{ApplyID: apply.ID, Owner: "driver-old", Token: "stale-token"})
 	_, err = store.Applies().UpdateDerivedState(staleCtx, apply.ID, expectedState, state.Apply.Failed, "stale", nil, nil)
 	require.ErrorIs(t, err, storage.ErrApplyLeaseLost)
 
@@ -1319,7 +1319,7 @@ func TestApplyStore_UpdateDerivedStateOperationLeaseGuard(t *testing.T) {
 
 	opLeaseCtx := func(applyID, opID int64, token string) context.Context {
 		return storage.WithOperationLease(ctx, storage.OperationLease{
-			ApplyID: applyID, OperationID: opID, Owner: "worker", Token: token,
+			ApplyID: applyID, OperationID: opID, Owner: "driver", Token: token,
 		})
 	}
 
@@ -1333,7 +1333,7 @@ func TestApplyStore_UpdateDerivedStateOperationLeaseGuard(t *testing.T) {
 	// A current operation lease authorizes the projection swap.
 	apply := runningApply("apply_op_cas_ok", "staging-ok", 900)
 	opID := createApplyOperationForLeaseTest(t, store, apply.ID, "primary")
-	stampOperationLease(t, opID, "worker", "op-token")
+	stampOperationLease(t, opID, "driver", "op-token")
 	swapped, err := store.Applies().UpdateDerivedState(opLeaseCtx(apply.ID, opID, "op-token"), apply.ID, state.Apply.Running, state.Apply.Failed, "op failure", nil, nil)
 	require.NoError(t, err)
 	require.True(t, swapped, "a current operation lease must authorize the projection swap")
@@ -1344,7 +1344,7 @@ func TestApplyStore_UpdateDerivedStateOperationLeaseGuard(t *testing.T) {
 	// A stale operation token fails closed even when the expected state matches.
 	staleApply := runningApply("apply_op_cas_stale", "staging-stale", 901)
 	staleOpID := createApplyOperationForLeaseTest(t, store, staleApply.ID, "primary")
-	stampOperationLease(t, staleOpID, "worker", "op-token")
+	stampOperationLease(t, staleOpID, "driver", "op-token")
 	_, err = store.Applies().UpdateDerivedState(opLeaseCtx(staleApply.ID, staleOpID, "stale-op-token"), staleApply.ID, state.Apply.Running, state.Apply.Failed, "stale", nil, nil)
 	require.ErrorIs(t, err, storage.ErrApplyLeaseLost)
 	persisted, err := store.Applies().Get(ctx, staleApply.ID)
@@ -1359,11 +1359,11 @@ func TestApplyStore_UpdateDerivedStateOperationLeaseGuard(t *testing.T) {
 	// with a current apply lease also on the context.
 	precApply := runningApply("apply_op_cas_prec", "staging-prec", 903)
 	precOpID := createApplyOperationForLeaseTest(t, store, precApply.ID, "primary")
-	stampOperationLease(t, precOpID, "worker", "op-token")
-	_, err = testDB.ExecContext(ctx, `UPDATE applies SET lease_owner=?, lease_token=?, lease_acquired_at=NOW() WHERE id=?`, "current-worker", "apply-token", precApply.ID)
+	stampOperationLease(t, precOpID, "driver", "op-token")
+	_, err = testDB.ExecContext(ctx, `UPDATE applies SET lease_owner=?, lease_token=?, lease_acquired_at=NOW() WHERE id=?`, "current-driver", "apply-token", precApply.ID)
 	require.NoError(t, err)
 	bothCtx := storage.WithApplyLease(opLeaseCtx(precApply.ID, precOpID, "stale-op-token"), storage.ApplyLease{
-		ApplyID: precApply.ID, Owner: "current-worker", Token: "apply-token",
+		ApplyID: precApply.ID, Owner: "current-driver", Token: "apply-token",
 	})
 	_, err = store.Applies().UpdateDerivedState(bothCtx, precApply.ID, state.Apply.Running, state.Apply.Failed, "prec", nil, nil)
 	require.ErrorIs(t, err, storage.ErrApplyLeaseLost)
@@ -1376,7 +1376,7 @@ func TestApplyStore_UpdateDerivedStateOperationLeaseGuard(t *testing.T) {
 	// reconciled on the next poll rather than mistaken for a lost lease.
 	missApply := runningApply("apply_op_cas_miss", "staging-miss", 904)
 	missOpID := createApplyOperationForLeaseTest(t, store, missApply.ID, "primary")
-	stampOperationLease(t, missOpID, "worker", "op-token")
+	stampOperationLease(t, missOpID, "driver", "op-token")
 	swapped, err = store.Applies().UpdateDerivedState(opLeaseCtx(missApply.ID, missOpID, "op-token"), missApply.ID, state.Apply.Pending, state.Apply.Failed, "stale projection", nil, nil)
 	require.NoError(t, err, "a state mismatch under a current operation lease must not be reported as a lost lease")
 	assert.False(t, swapped, "the expected state no longer matches, so the swap must miss")
@@ -1434,10 +1434,10 @@ func TestApplyStore_UpdateRejectsOperationLeaseOnlyContext(t *testing.T) {
 	lock := createTestLock(t, store, "testdb", storage.DatabaseTypeMySQL, "staging")
 	apply := createTestApplyWithStateAndEnv(t, store, lock, "apply_update_oplease", 906, state.Apply.Running, "staging")
 	opID := createApplyOperationForLeaseTest(t, store, apply.ID, "primary")
-	stampOperationLease(t, opID, "worker", "op-token")
+	stampOperationLease(t, opID, "driver", "op-token")
 
 	opOnlyCtx := storage.WithOperationLease(ctx, storage.OperationLease{
-		ApplyID: apply.ID, OperationID: opID, Owner: "worker", Token: "op-token",
+		ApplyID: apply.ID, OperationID: opID, Owner: "driver", Token: "op-token",
 	})
 
 	apply.State = state.Apply.Failed
@@ -1450,9 +1450,9 @@ func TestApplyStore_UpdateRejectsOperationLeaseOnlyContext(t *testing.T) {
 
 	// A single-operation drive carries both leases, so the direct write lands on
 	// the parent-lease path.
-	_, err = testDB.ExecContext(ctx, `UPDATE applies SET lease_owner=?, lease_token=?, lease_acquired_at=NOW() WHERE id=?`, "current-worker", "apply-token", apply.ID)
+	_, err = testDB.ExecContext(ctx, `UPDATE applies SET lease_owner=?, lease_token=?, lease_acquired_at=NOW() WHERE id=?`, "current-driver", "apply-token", apply.ID)
 	require.NoError(t, err)
-	dualCtx := storage.WithApplyLease(opOnlyCtx, storage.ApplyLease{ApplyID: apply.ID, Owner: "current-worker", Token: "apply-token"})
+	dualCtx := storage.WithApplyLease(opOnlyCtx, storage.ApplyLease{ApplyID: apply.ID, Owner: "current-driver", Token: "apply-token"})
 	require.NoError(t, store.Applies().Update(dualCtx, apply))
 	written, err := store.Applies().Get(ctx, apply.ID)
 	require.NoError(t, err)
@@ -1472,7 +1472,7 @@ func TestApplyStore_HeartbeatRejectsOperationLeaseOnlyContext(t *testing.T) {
 	lock := createTestLock(t, store, "testdb", storage.DatabaseTypeMySQL, "staging")
 	apply := createTestApplyWithStateAndEnv(t, store, lock, "apply_heartbeat_oplease", 907, state.Apply.Running, "staging")
 	opID := createApplyOperationForLeaseTest(t, store, apply.ID, "primary")
-	stampOperationLease(t, opID, "worker", "op-token")
+	stampOperationLease(t, opID, "driver", "op-token")
 
 	_, err := testDB.ExecContext(ctx, `UPDATE applies SET updated_at = NOW() - INTERVAL 5 MINUTE WHERE id = ?`, apply.ID)
 	require.NoError(t, err)
@@ -1480,7 +1480,7 @@ func TestApplyStore_HeartbeatRejectsOperationLeaseOnlyContext(t *testing.T) {
 	require.NoError(t, err)
 
 	opOnlyCtx := storage.WithOperationLease(ctx, storage.OperationLease{
-		ApplyID: apply.ID, OperationID: opID, Owner: "worker", Token: "op-token",
+		ApplyID: apply.ID, OperationID: opID, Owner: "driver", Token: "op-token",
 	})
 	require.ErrorIs(t, store.Applies().Heartbeat(opOnlyCtx, apply.ID), storage.ErrApplyLeaseLost,
 		"an operation-lease-only context must not heartbeat the parent apply")
@@ -1489,9 +1489,9 @@ func TestApplyStore_HeartbeatRejectsOperationLeaseOnlyContext(t *testing.T) {
 	assert.Equal(t, before.UpdatedAt, unchanged.UpdatedAt, "the parent row must be untouched")
 
 	// A single-operation drive carries both leases, so the heartbeat lands.
-	_, err = testDB.ExecContext(ctx, `UPDATE applies SET lease_owner=?, lease_token=?, lease_acquired_at=NOW() WHERE id=?`, "current-worker", "apply-token", apply.ID)
+	_, err = testDB.ExecContext(ctx, `UPDATE applies SET lease_owner=?, lease_token=?, lease_acquired_at=NOW() WHERE id=?`, "current-driver", "apply-token", apply.ID)
 	require.NoError(t, err)
-	dualCtx := storage.WithApplyLease(opOnlyCtx, storage.ApplyLease{ApplyID: apply.ID, Owner: "current-worker", Token: "apply-token"})
+	dualCtx := storage.WithApplyLease(opOnlyCtx, storage.ApplyLease{ApplyID: apply.ID, Owner: "current-driver", Token: "apply-token"})
 	require.NoError(t, store.Applies().Heartbeat(dualCtx, apply.ID))
 	after, err := store.Applies().Get(ctx, apply.ID)
 	require.NoError(t, err)
@@ -1591,10 +1591,10 @@ func TestApplyStore_ClaimApplyByIDClaimsPendingWithTasks(t *testing.T) {
 
 	again, err := store.Applies().ClaimApplyByID(ctx, apply.ID, "operator-b")
 	require.NoError(t, err)
-	assert.Nil(t, again, "a freshly claimed apply is owned by its current worker")
+	assert.Nil(t, again, "a freshly claimed apply is owned by its current driver")
 }
 
-// ClaimApplyByID must not steal a fresh lease from a healthy apply-level worker,
+// ClaimApplyByID must not steal a fresh lease from a healthy apply-level driver,
 // so a running apply with a fresh heartbeat is not claimable; it only becomes
 // claimable once its heartbeat goes stale, matching FindNextApply recovery.
 func TestApplyStore_ClaimApplyByIDSkipsFreshRunningUntilStale(t *testing.T) {
@@ -1607,7 +1607,7 @@ func TestApplyStore_ClaimApplyByIDSkipsFreshRunningUntilStale(t *testing.T) {
 
 	fresh, err := store.Applies().ClaimApplyByID(ctx, apply.ID, "operator-a")
 	require.NoError(t, err)
-	assert.Nil(t, fresh, "a fresh running apply is owned by its active worker")
+	assert.Nil(t, fresh, "a fresh running apply is owned by its active driver")
 
 	_, err = testDB.ExecContext(ctx, `
 		UPDATE applies
@@ -1645,10 +1645,10 @@ func TestApplyStore_ClaimApplyByIDReturnsNilForTerminalAndMissing(t *testing.T) 
 
 // A PlanetScale apply transitions through engine setup-phase states
 // (preparing_branch through validating_deploy_request) before per-table work
-// begins. If the worker driving setup crashes, the apply is left in one of
-// those states; a fresh worker must reclaim it once the heartbeat goes stale so
+// begins. If the driver driving setup crashes, the apply is left in one of
+// those states; a fresh driver must reclaim it once the heartbeat goes stale so
 // setup resumes from persisted branch/deploy metadata. While the original
-// worker is still alive its heartbeat stays fresh, so the apply is not claimed
+// driver is still alive its heartbeat stays fresh, so the apply is not claimed
 // out from under it.
 func TestApplyStore_FindNextApplyClaimsStaleSetupPhase(t *testing.T) {
 	for _, setupState := range []string{
@@ -1669,7 +1669,7 @@ func TestApplyStore_FindNextApplyClaimsStaleSetupPhase(t *testing.T) {
 
 			fresh, err := store.Applies().FindNextApply(ctx, "operator-a")
 			require.NoError(t, err)
-			assert.Nil(t, fresh, "a setup-phase apply with a fresh heartbeat is owned by its active worker")
+			assert.Nil(t, fresh, "a setup-phase apply with a fresh heartbeat is owned by its active driver")
 
 			_, err = testDB.ExecContext(ctx, `
 				UPDATE applies
@@ -1691,7 +1691,7 @@ func TestApplyStore_FindNextApplyClaimsStaleSetupPhase(t *testing.T) {
 }
 
 // ClaimApplyByID is how the operation-level claim loop acquires the parent apply
-// lease after leasing a stale operation row. When a PlanetScale worker crashes
+// lease after leasing a stale operation row. When a PlanetScale driver crashes
 // mid-setup the operation row stays running (stale) while the parent apply sits
 // in a setup-phase state, so ClaimApplyByID must reclaim that stale parent for
 // recovery while still refusing one whose heartbeat is fresh.
@@ -1706,7 +1706,7 @@ func TestApplyStore_ClaimApplyByIDClaimsStaleSetupPhase(t *testing.T) {
 
 	fresh, err := store.Applies().ClaimApplyByID(ctx, apply.ID, "operator-a")
 	require.NoError(t, err)
-	assert.Nil(t, fresh, "a fresh setup-phase apply is owned by its active worker")
+	assert.Nil(t, fresh, "a fresh setup-phase apply is owned by its active driver")
 
 	_, err = testDB.ExecContext(ctx, `
 		UPDATE applies
@@ -1785,16 +1785,16 @@ func TestApplyStore_LeaseGuardsOwnedWrites(t *testing.T) {
 	require.NoError(t, err)
 	task.ID = taskID
 
-	claimed, err := store.Applies().FindNextApply(ctx, "worker-a")
+	claimed, err := store.Applies().FindNextApply(ctx, "driver-a")
 	require.NoError(t, err)
 	require.NotNil(t, claimed)
-	require.Equal(t, "worker-a", claimed.LeaseOwner)
+	require.Equal(t, "driver-a", claimed.LeaseOwner)
 	require.NotEmpty(t, claimed.LeaseToken)
 	require.NotNil(t, claimed.LeaseAcquiredAt)
 
-	staleCtx := storage.WithApplyLease(ctx, storage.ApplyLease{ApplyID: apply.ID, Owner: "worker-old", Token: "stale-token"})
+	staleCtx := storage.WithApplyLease(ctx, storage.ApplyLease{ApplyID: apply.ID, Owner: "driver-old", Token: "stale-token"})
 	claimed.State = state.Apply.Failed
-	claimed.ErrorMessage = "stale worker failure"
+	claimed.ErrorMessage = "stale driver failure"
 	require.ErrorIs(t, store.Applies().Update(staleCtx, claimed), storage.ErrApplyLeaseLost)
 	require.ErrorIs(t, store.Applies().Heartbeat(staleCtx, apply.ID), storage.ErrApplyLeaseLost)
 
@@ -1805,7 +1805,7 @@ func TestApplyStore_LeaseGuardsOwnedWrites(t *testing.T) {
 		Level:     storage.LogLevelInfo,
 		EventType: storage.LogEventStateTransition,
 		Source:    storage.LogSourceSchemaBot,
-		Message:   "stale worker log",
+		Message:   "stale driver log",
 	}), storage.ErrApplyLeaseLost)
 
 	persistedApply, err := store.Applies().Get(ctx, apply.ID)
@@ -1834,7 +1834,7 @@ func TestApplyStore_LeaseGuardsOwnedWrites(t *testing.T) {
 		Level:     storage.LogLevelInfo,
 		EventType: storage.LogEventStateTransition,
 		Source:    storage.LogSourceSchemaBot,
-		Message:   "owned worker log",
+		Message:   "owned driver log",
 	}))
 }
 
@@ -1943,7 +1943,7 @@ func TestApplyStore_FindNextApplyClaimsPendingControlRequestWithoutTasks(t *test
 
 	claimedAgain, err := store.Applies().FindNextApply(ctx, "test-owner")
 	require.NoError(t, err)
-	assert.Nil(t, claimedAgain, "claim heartbeat should prevent another worker from immediately taking the same start request")
+	assert.Nil(t, claimedAgain, "claim heartbeat should prevent another driver from immediately taking the same start request")
 }
 
 func TestApplyStore_FindNextApplyClaimsStoppedStartControlRequest(t *testing.T) {
@@ -1975,7 +1975,7 @@ func TestApplyStore_FindNextApplyClaimsStoppedStartControlRequest(t *testing.T) 
 
 	claimedAgain, err := store.Applies().FindNextApply(ctx, "test-owner")
 	require.NoError(t, err)
-	assert.Nil(t, claimedAgain, "claim transition should prevent another worker from taking the same stopped start request")
+	assert.Nil(t, claimedAgain, "claim transition should prevent another driver from taking the same stopped start request")
 }
 
 func TestApplyStore_FindNextApplyClaimsWaitingForDeployStartControlRequest(t *testing.T) {
@@ -2016,7 +2016,7 @@ func TestApplyStore_FindNextApplyClaimsWaitingForDeployStartControlRequest(t *te
 
 	claimedAgain, err := store.Applies().FindNextApply(ctx, "test-owner")
 	require.NoError(t, err)
-	assert.Nil(t, claimedAgain, "fresh processing lease should prevent another worker from taking the same deferred deploy start request")
+	assert.Nil(t, claimedAgain, "fresh processing lease should prevent another driver from taking the same deferred deploy start request")
 
 	_, err = testDB.ExecContext(ctx, `
 		UPDATE applies SET updated_at = NOW() - INTERVAL 2 MINUTE WHERE id = ?
@@ -2140,7 +2140,7 @@ func TestApplyStore_FindNextApplyClaimsStaleWaitingForCutoverControlRequest(t *t
 
 	freshClaim, err := store.Applies().FindNextApply(ctx, "test-owner")
 	require.NoError(t, err)
-	assert.Nil(t, freshClaim, "fresh waiting-for-cutover applies are owned by their active worker")
+	assert.Nil(t, freshClaim, "fresh waiting-for-cutover applies are owned by their active driver")
 
 	_, err = testDB.ExecContext(ctx, `
 		UPDATE applies
@@ -2162,7 +2162,7 @@ func TestApplyStore_FindNextApplyClaimsStaleWaitingForCutoverControlRequest(t *t
 
 	claimedAgain, err := store.Applies().FindNextApply(ctx, "test-owner")
 	require.NoError(t, err)
-	assert.Nil(t, claimedAgain, "claim heartbeat should prevent another worker from immediately taking the same stale cutover request")
+	assert.Nil(t, claimedAgain, "claim heartbeat should prevent another driver from immediately taking the same stale cutover request")
 }
 
 func TestApplyStore_FindNextApplySkipsFailedStoppedStartControlRequest(t *testing.T) {
@@ -2222,7 +2222,7 @@ func TestApplyStore_FindNextApplyDoesNotClaimFreshRunningStopControlRequest(t *t
 
 	claimed, err := store.Applies().FindNextApply(ctx, "test-owner")
 	require.NoError(t, err)
-	assert.Nil(t, claimed, "fresh running applies are owned by their active worker; pending stop must not create a second owner")
+	assert.Nil(t, claimed, "fresh running applies are owned by their active driver; pending stop must not create a second owner")
 }
 
 func TestApplyStore_FindNextApplyConcurrentPendingClaims(t *testing.T) {
@@ -2268,9 +2268,9 @@ func TestApplyStore_FindNextApplyConcurrentPendingClaims(t *testing.T) {
 	require.NoError(t, err)
 	apply.ID = applyID
 
-	const workers = 16
-	stores := make([]*Storage, workers)
-	for i := range workers {
+	const drivers = 16
+	stores := make([]*Storage, drivers)
+	for i := range drivers {
 		db, openErr := sql.Open("mysql", testDSNChangedRows)
 		require.NoError(t, openErr)
 		db.SetMaxOpenConns(1)
@@ -2287,11 +2287,11 @@ func TestApplyStore_FindNextApplyConcurrentPendingClaims(t *testing.T) {
 	var claimed []*storage.Apply
 	var claimErrors []error
 
-	for i := range workers {
-		workerStore := stores[i]
+	for i := range drivers {
+		driverStore := stores[i]
 		wg.Go(func() {
 			<-start
-			got, claimErr := workerStore.Applies().FindNextApply(ctx, "test-owner")
+			got, claimErr := driverStore.Applies().FindNextApply(ctx, "test-owner")
 
 			mu.Lock()
 			defer mu.Unlock()
@@ -2309,7 +2309,7 @@ func TestApplyStore_FindNextApplyConcurrentPendingClaims(t *testing.T) {
 	wg.Wait()
 
 	require.Empty(t, claimErrors)
-	require.Len(t, claimed, 1, "only one operator worker should claim a pending apply")
+	require.Len(t, claimed, 1, "only one operator driver should claim a pending apply")
 	assert.Equal(t, apply.ApplyIdentifier, claimed[0].ApplyIdentifier)
 	assert.Equal(t, state.Apply.Pending, claimed[0].State)
 

--- a/pkg/storage/mysqlstore/apply_comments_test.go
+++ b/pkg/storage/mysqlstore/apply_comments_test.go
@@ -219,7 +219,7 @@ func TestApplyCommentStore_LeaseGuardsWrites(t *testing.T) {
 		UPDATE applies
 		SET lease_owner = ?, lease_token = ?, lease_acquired_at = NOW()
 		WHERE id = ?
-	`, "current-worker", "current-token", apply.ID)
+	`, "current-driver", "current-token", apply.ID)
 	require.NoError(t, err)
 
 	comment := &storage.ApplyComment{
@@ -227,14 +227,14 @@ func TestApplyCommentStore_LeaseGuardsWrites(t *testing.T) {
 		CommentState:    state.Comment.Progress,
 		GitHubCommentID: 100,
 	}
-	staleCtx := storage.WithApplyLease(ctx, storage.ApplyLease{ApplyID: apply.ID, Owner: "old-worker", Token: "stale-token"})
+	staleCtx := storage.WithApplyLease(ctx, storage.ApplyLease{ApplyID: apply.ID, Owner: "old-driver", Token: "stale-token"})
 	require.ErrorIs(t, store.ApplyComments().Upsert(staleCtx, comment), storage.ErrApplyLeaseLost)
 
 	missing, err := store.ApplyComments().Get(ctx, apply.ID, state.Comment.Progress)
 	require.NoError(t, err)
 	assert.Nil(t, missing)
 
-	currentCtx := storage.WithApplyLease(ctx, storage.ApplyLease{ApplyID: apply.ID, Owner: "current-worker", Token: "current-token"})
+	currentCtx := storage.WithApplyLease(ctx, storage.ApplyLease{ApplyID: apply.ID, Owner: "current-driver", Token: "current-token"})
 	require.NoError(t, store.ApplyComments().Upsert(currentCtx, comment))
 	require.ErrorIs(t, store.ApplyComments().IncrementEditCount(staleCtx, apply.ID, state.Comment.Progress), storage.ErrApplyLeaseLost)
 

--- a/pkg/storage/mysqlstore/apply_operations.go
+++ b/pkg/storage/mysqlstore/apply_operations.go
@@ -532,7 +532,7 @@ func (s *applyOperationStore) GetEngineResumeState(ctx context.Context, operatio
 }
 
 // applyOperationHeartbeatStaleness is the lease window after which a claimed
-// apply_operations row may be re-claimed by another worker. Mirrors the apply
+// apply_operations row may be re-claimed by another driver. Mirrors the apply
 // heartbeat staleness in applies.go.
 const applyOperationHeartbeatStaleness = "1 MINUTE"
 
@@ -586,7 +586,7 @@ const applyOperationHeartbeatStaleness = "1 MINUTE"
 // siblings, so this gate is dormant regardless of policy.
 //
 // Mirrors ApplyStore.FindNextApply: SELECT ... FOR UPDATE SKIP LOCKED to
-// avoid worker races, READ COMMITTED isolation to prevent next-key range
+// avoid driver races, READ COMMITTED isolation to prevent next-key range
 // locks from serializing claims across otherwise independent rows.
 //
 // Caller: the operator's per-poll recovery (Service.recoverApplyOperation)
@@ -677,9 +677,9 @@ func (s *applyOperationStore) FindNextApplyOperation(ctx context.Context, owner 
 	//         stale — crash recovery, with no budget gate (the attempt was already
 	//         admitted and counted when the parent was claimed).
 	//     Claiming a failed_retryable parent transitions it to running and refreshes
-	//     applies.updated_at (see persistApplyClaim), so once a worker owns the
+	//     applies.updated_at (see persistApplyClaim), so once a driver owns the
 	//     retry neither sub-condition matches and peers back off instead of
-	//     churning on a row another worker is actively driving.
+	//     churning on a row another driver is actively driving.
 	//
 	// There is intentionally no "pending + pending start request" clause to
 	// match ApplyStore.FindNextApply's pending-start clause. That apply-level
@@ -796,7 +796,7 @@ func (s *applyOperationStore) FindNextApplyOperation(ctx context.Context, owner 
 		return nil, fmt.Errorf("query next claimable apply_operation: %w", err)
 	}
 
-	// Rotate a fresh operation lease onto the claimed row so the claiming worker
+	// Rotate a fresh operation lease onto the claimed row so the claiming driver
 	// can guard operation-scoped writes on this token. Mirrors persistApplyClaim
 	// at the apply level.
 	leaseToken := uuid.NewString()
@@ -836,7 +836,7 @@ func (s *applyOperationStore) FindNextApplyOperation(ctx context.Context, owner 
 		// Re-leasing a row that already started: a stale active heartbeat, or a
 		// stopped operation whose parent apply has a pending start request. Both
 		// keep their current state and are driven by the caller, so rotate the
-		// lease onto this worker and refresh the heartbeat.
+		// lease onto this driver and refresh the heartbeat.
 		_, err = tx.ExecContext(ctx, `
 			UPDATE apply_operations
 			SET updated_at = NOW(),
@@ -876,7 +876,7 @@ func (s *applyOperationStore) FindNextApplyOperation(ctx context.Context, owner 
 //     sibling stop blocking, matching the copy gate.
 //   - Recover a stale in-flight cutover. A row already in cutting_over or
 //     revert_window whose heartbeat has gone stale is re-leased without changing
-//     its state — its driver died mid-cutover and another worker resumes it. This
+//     its state — its driver died mid-cutover and another driver resumes it. This
 //     path carries no ordering gate: the row already started its cutover, so
 //     resuming is recovering work, not starting a new swap.
 //
@@ -989,7 +989,7 @@ func (s *applyOperationStore) FindNextApplyOperationCutover(ctx context.Context,
 		}
 	} else {
 		// Recovering a stale in-flight cutover (cutting_over or revert_window):
-		// keep the current state and rotate the lease onto this worker.
+		// keep the current state and rotate the lease onto this driver.
 		_, err = tx.ExecContext(ctx, `
 			UPDATE apply_operations
 			SET updated_at = NOW(),
@@ -1013,7 +1013,7 @@ func (s *applyOperationStore) FindNextApplyOperationCutover(ctx context.Context,
 }
 
 // Heartbeat refreshes updated_at to maintain the claim's lease. Should be
-// called periodically by a worker holding the lease. Silent no-op when the
+// called periodically by a driver holding the lease. Silent no-op when the
 // row no longer exists (mirrors ApplyStore.Heartbeat).
 func (s *applyOperationStore) Heartbeat(ctx context.Context, id int64) error {
 	guard, err := operationWriteGuardFromContext(ctx)
@@ -1157,7 +1157,7 @@ func (s *applyOperationStore) MarkPendingStoppedByApply(ctx context.Context, app
 	if rows == 0 {
 		// No pending rows changed: either there were none (lease still valid, a
 		// legitimate no-op) or the lease token no longer matches (ownership lost).
-		// Distinguish the two so a displaced worker fails closed.
+		// Distinguish the two so a displaced driver fails closed.
 		if err := ensureApplyLeaseStillOwned(ctx, s.db, lease); err != nil {
 			return 0, err
 		}

--- a/pkg/storage/mysqlstore/apply_operations_test.go
+++ b/pkg/storage/mysqlstore/apply_operations_test.go
@@ -676,7 +676,7 @@ func TestApplyOperationStore_FindNextApplyOperation_ClaimsPending(t *testing.T) 
 
 // TestApplyOperationStore_FindNextApplyOperation_SkipsFreshRunning verifies
 // that a running row whose heartbeat is fresh is *not* re-claimed: the active
-// worker still owns it.
+// driver still owns it.
 func TestApplyOperationStore_FindNextApplyOperation_SkipsFreshRunning(t *testing.T) {
 	clearTables(t)
 	ctx := t.Context()
@@ -877,7 +877,7 @@ func TestApplyOperationStore_FindNextApplyOperation_ClaimsWaitingForDeployWithPe
 
 	claimedAgain, err := store.ApplyOperations().FindNextApplyOperation(ctx, "test-operator")
 	require.NoError(t, err)
-	assert.Nil(t, claimedAgain, "fresh processing lease should prevent another worker from taking the same deferred deploy start request")
+	assert.Nil(t, claimedAgain, "fresh processing lease should prevent another driver from taking the same deferred deploy start request")
 
 	_, err = testDB.ExecContext(ctx, `
 		UPDATE apply_operations SET updated_at = NOW() - INTERVAL 2 MINUTE WHERE id = ?
@@ -1016,7 +1016,7 @@ func TestApplyOperationStore_FindNextApplyOperation_SkipsFailedRetryableStale(t 
 
 // TestApplyOperationStore_FindNextApplyOperation_SkipsFailedRetryableParentActivelyRetrying
 // verifies the failed_retryable claim is gated on the parent apply's state, not
-// just its retry budget. Once a worker claims the parent for retry it
+// just its retry budget. Once a driver claims the parent for retry it
 // transitions the parent to running (an active state) and refreshes its
 // heartbeat, while the child row intentionally stays failed_retryable. A peer
 // must not keep re-claiming that child every poll while the retry is healthy.
@@ -1044,9 +1044,9 @@ func TestApplyOperationStore_FindNextApplyOperation_SkipsFailedRetryableParentAc
 }
 
 // TestApplyOperationStore_FindNextApplyOperation_ClaimsFailedRetryableParentActiveStale
-// verifies crash recovery: if the worker driving a retry dies, the parent apply
+// verifies crash recovery: if the driver driving a retry dies, the parent apply
 // is left active (running) with a stale heartbeat while the child row still says
-// failed_retryable. Another worker must be able to reclaim that child to recover
+// failed_retryable. Another driver must be able to reclaim that child to recover
 // the in-flight retry, mirroring ApplyStore.FindNextApply's stale-active clause.
 func TestApplyOperationStore_FindNextApplyOperation_ClaimsFailedRetryableParentActiveStale(t *testing.T) {
 	clearTables(t)
@@ -1085,7 +1085,7 @@ func TestApplyOperationStore_FindNextApplyOperation_ClaimsFailedRetryableParentA
 
 	lock := createTestLock(t, store, "testdb", "mysql", "staging")
 	apply := createTestApplyWithStateAndEnv(t, store, lock, "apply_op_retryable_crash_spent", 1, state.Apply.Running, "staging")
-	// Last retry admitted (attempt at max) then the worker crashed: active + stale.
+	// Last retry admitted (attempt at max) then the driver crashed: active + stale.
 	_, err := testDB.ExecContext(ctx, `
 		UPDATE applies SET state = ?, attempt = ?, updated_at = NOW() - INTERVAL 2 MINUTE WHERE id = ?
 	`, state.Apply.Running, maxRecoveryAttempts, apply.ID)
@@ -1104,9 +1104,9 @@ func TestApplyOperationStore_FindNextApplyOperation_ClaimsFailedRetryableParentA
 
 // TestApplyOperationStore_FindNextApplyOperation_RecoversStaleSetupPhase
 // verifies crash recovery during PlanetScale engine setup under the
-// operation-claim model. While a worker drives setup the operation row is
+// operation-claim model. While a driver drives setup the operation row is
 // running and the parent apply moves through setup-phase states
-// (applying_branch_changes here). If that worker dies, both rows are left active
+// (applying_branch_changes here). If that driver dies, both rows are left active
 // with a stale heartbeat. A peer must be able to lease the stale operation and
 // then acquire the parent apply lease via ClaimApplyByID — both halves of the
 // recovery path — so setup resumes instead of stranding the apply forever.
@@ -1148,7 +1148,7 @@ func TestApplyOperationStore_FindNextApplyOperation_RecoversStaleSetupPhase(t *t
 }
 
 // TestApplyOperationStore_FindNextApplyOperation_ConcurrentClaims verifies
-// the SKIP LOCKED contract on a contended row: N workers race to claim a
+// the SKIP LOCKED contract on a contended row: N drivers race to claim a
 // single pending child row, and exactly one wins. Mirrors the apply-level
 // TestApplyStore_FindNextApplyConcurrentPendingClaims.
 func TestApplyOperationStore_FindNextApplyOperation_ConcurrentClaims(t *testing.T) {
@@ -1164,9 +1164,9 @@ func TestApplyOperationStore_FindNextApplyOperation_ConcurrentClaims(t *testing.
 	})
 	require.NoError(t, err)
 
-	const workers = 16
-	stores := make([]*Storage, workers)
-	for i := range workers {
+	const drivers = 16
+	stores := make([]*Storage, drivers)
+	for i := range drivers {
 		db, openErr := sql.Open("mysql", testDSNChangedRows)
 		require.NoError(t, openErr)
 		db.SetMaxOpenConns(1)
@@ -1183,12 +1183,12 @@ func TestApplyOperationStore_FindNextApplyOperation_ConcurrentClaims(t *testing.
 	var claimed []*storage.ApplyOperation
 	var claimErrors []error
 
-	for i := range workers {
-		workerStore := stores[i]
-		workerOwner := fmt.Sprintf("operator-%d", i)
+	for i := range drivers {
+		driverStore := stores[i]
+		driverOwner := fmt.Sprintf("operator-%d", i)
 		wg.Go(func() {
 			<-start
-			got, claimErr := workerStore.ApplyOperations().FindNextApplyOperation(ctx, workerOwner)
+			got, claimErr := driverStore.ApplyOperations().FindNextApplyOperation(ctx, driverOwner)
 
 			mu.Lock()
 			defer mu.Unlock()
@@ -1206,7 +1206,7 @@ func TestApplyOperationStore_FindNextApplyOperation_ConcurrentClaims(t *testing.
 	wg.Wait()
 
 	require.Empty(t, claimErrors)
-	require.Len(t, claimed, 1, "only one worker should claim a single pending apply_operation")
+	require.Len(t, claimed, 1, "only one driver should claim a single pending apply_operation")
 	assert.Equal(t, "region-a", claimed[0].Deployment)
 	assert.Equal(t, state.ApplyOperation.Pending, claimed[0].State, "caller sees the pre-claim state")
 
@@ -1942,7 +1942,7 @@ func TestApplyOperationStore_FindNextApplyOperationCutover_PendingStopBlocks(t *
 // TestApplyOperationStore_FindNextApplyOperationCutover_RecoversStaleInFlight
 // verifies the recovery path: a row already mid-cutover (cutting_over or
 // revert_window) whose heartbeat has gone stale is re-leased without changing
-// its state — its driver died and another worker resumes it. This path carries
+// its state — its driver died and another driver resumes it. This path carries
 // no ordering gate, because the row already started its swap.
 func TestApplyOperationStore_FindNextApplyOperationCutover_RecoversStaleInFlight(t *testing.T) {
 	for _, inFlight := range []string{state.ApplyOperation.CuttingOver, state.ApplyOperation.RevertWindow} {
@@ -2182,11 +2182,11 @@ func TestApplyOperationStore_LeaseGuardsWrites(t *testing.T) {
 		UPDATE applies
 		SET lease_owner = ?, lease_token = ?, lease_acquired_at = NOW()
 		WHERE id = ?
-	`, "current-worker", "current-token", apply.ID)
+	`, "current-driver", "current-token", apply.ID)
 	require.NoError(t, err)
 
-	staleCtx := storage.WithApplyLease(ctx, storage.ApplyLease{ApplyID: apply.ID, Owner: "old-worker", Token: "stale-token"})
-	currentCtx := storage.WithApplyLease(ctx, storage.ApplyLease{ApplyID: apply.ID, Owner: "current-worker", Token: "current-token"})
+	staleCtx := storage.WithApplyLease(ctx, storage.ApplyLease{ApplyID: apply.ID, Owner: "old-driver", Token: "stale-token"})
+	currentCtx := storage.WithApplyLease(ctx, storage.ApplyLease{ApplyID: apply.ID, Owner: "current-driver", Token: "current-token"})
 
 	updateID := createApplyOperationForLeaseTest(t, store, apply.ID, "region-update")
 	require.ErrorIs(t, store.ApplyOperations().UpdateState(staleCtx, updateID, state.ApplyOperation.Running), storage.ErrApplyLeaseLost)
@@ -2290,41 +2290,41 @@ func TestApplyOperationStore_OperationLeaseGuardsWrites(t *testing.T) {
 		UPDATE applies
 		SET lease_owner = ?, lease_token = ?, lease_acquired_at = NOW()
 		WHERE id = ?
-	`, "current-worker", "apply-token", apply.ID)
+	`, "current-driver", "apply-token", apply.ID)
 	require.NoError(t, err)
 
 	opCtx := func(id int64, token string) context.Context {
 		return storage.WithOperationLease(ctx, storage.OperationLease{
 			ApplyID:     apply.ID,
 			OperationID: id,
-			Owner:       "worker",
+			Owner:       "driver",
 			Token:       token,
 		})
 	}
 
 	updateID := createApplyOperationForLeaseTest(t, store, apply.ID, "op-update")
-	stampOperationLease(t, updateID, "worker", "op-token")
+	stampOperationLease(t, updateID, "driver", "op-token")
 	require.ErrorIs(t, store.ApplyOperations().UpdateState(opCtx(updateID, "stale-op-token"), updateID, state.ApplyOperation.Running), storage.ErrApplyLeaseLost)
 	assertApplyOperationState(t, store, updateID, state.ApplyOperation.Pending)
 	require.NoError(t, store.ApplyOperations().UpdateState(opCtx(updateID, "op-token"), updateID, state.ApplyOperation.Running))
 	assertApplyOperationState(t, store, updateID, state.ApplyOperation.Running)
 
 	startedID := createApplyOperationForLeaseTest(t, store, apply.ID, "op-started")
-	stampOperationLease(t, startedID, "worker", "op-token")
+	stampOperationLease(t, startedID, "driver", "op-token")
 	require.ErrorIs(t, store.ApplyOperations().MarkStarted(opCtx(startedID, "stale-op-token"), startedID), storage.ErrApplyLeaseLost)
 	assertApplyOperationState(t, store, startedID, state.ApplyOperation.Pending)
 	require.NoError(t, store.ApplyOperations().MarkStarted(opCtx(startedID, "op-token"), startedID))
 	assertApplyOperationState(t, store, startedID, state.ApplyOperation.Running)
 
 	completedID := createApplyOperationForLeaseTest(t, store, apply.ID, "op-completed")
-	stampOperationLease(t, completedID, "worker", "op-token")
+	stampOperationLease(t, completedID, "driver", "op-token")
 	require.ErrorIs(t, store.ApplyOperations().MarkCompleted(opCtx(completedID, "stale-op-token"), completedID), storage.ErrApplyLeaseLost)
 	assertApplyOperationState(t, store, completedID, state.ApplyOperation.Pending)
 	require.NoError(t, store.ApplyOperations().MarkCompleted(opCtx(completedID, "op-token"), completedID))
 	assertApplyOperationState(t, store, completedID, state.ApplyOperation.Completed)
 
 	failedID := createApplyOperationForLeaseTest(t, store, apply.ID, "op-failed")
-	stampOperationLease(t, failedID, "worker", "op-token")
+	stampOperationLease(t, failedID, "driver", "op-token")
 	require.ErrorIs(t, store.ApplyOperations().MarkFailed(opCtx(failedID, "stale-op-token"), failedID, "stale failure"), storage.ErrApplyLeaseLost)
 	failed, err := store.ApplyOperations().Get(ctx, failedID)
 	require.NoError(t, err)
@@ -2339,7 +2339,7 @@ func TestApplyOperationStore_OperationLeaseGuardsWrites(t *testing.T) {
 	assert.Equal(t, "current failure", failed.ErrorMessage)
 
 	heartbeatID := createApplyOperationForLeaseTest(t, store, apply.ID, "op-heartbeat")
-	stampOperationLease(t, heartbeatID, "worker", "op-token")
+	stampOperationLease(t, heartbeatID, "driver", "op-token")
 	_, err = testDB.ExecContext(ctx, `
 		UPDATE apply_operations SET updated_at = NOW() - INTERVAL 5 MINUTE WHERE id = ?
 	`, heartbeatID)
@@ -2356,7 +2356,7 @@ func TestApplyOperationStore_OperationLeaseGuardsWrites(t *testing.T) {
 	assert.True(t, afterCurrentHeartbeat.UpdatedAt.After(beforeHeartbeat.UpdatedAt))
 
 	resumeID := createApplyOperationForLeaseTest(t, store, apply.ID, "op-resume-state")
-	stampOperationLease(t, resumeID, "worker", "op-token")
+	stampOperationLease(t, resumeID, "driver", "op-token")
 	require.ErrorIs(t, store.ApplyOperations().SaveEngineResumeState(opCtx(resumeID, "stale-op-token"), resumeID, &storage.EngineResumeState{
 		ApplyOperationID: resumeID,
 		MigrationContext: "stale-context",
@@ -2379,9 +2379,9 @@ func TestApplyOperationStore_OperationLeaseGuardsWrites(t *testing.T) {
 	// Operation lease takes precedence: even with a current apply lease also on
 	// the context, a stale operation token must fail closed.
 	precedenceID := createApplyOperationForLeaseTest(t, store, apply.ID, "op-precedence")
-	stampOperationLease(t, precedenceID, "worker", "op-token")
+	stampOperationLease(t, precedenceID, "driver", "op-token")
 	bothCtx := storage.WithApplyLease(opCtx(precedenceID, "stale-op-token"), storage.ApplyLease{
-		ApplyID: apply.ID, Owner: "current-worker", Token: "apply-token",
+		ApplyID: apply.ID, Owner: "current-driver", Token: "apply-token",
 	})
 	require.ErrorIs(t, store.ApplyOperations().UpdateState(bothCtx, precedenceID, state.ApplyOperation.Running), storage.ErrApplyLeaseLost)
 	assertApplyOperationState(t, store, precedenceID, state.ApplyOperation.Pending)
@@ -2680,7 +2680,7 @@ func TestApplyOperationStore_MarkPendingStoppedByApply(t *testing.T) {
 	assert.Equal(t, int64(0), again, "no pending rows remain to stop")
 }
 
-// Under fan-out multi-operation mode the driving worker holds only an operation
+// Under fan-out multi-operation mode the driving driver holds only an operation
 // lease, not the parent apply lease. MarkPendingStoppedByApply must still let it
 // stop the apply's pending siblings, authorized by the owning operation row's
 // own lease token, and must fail closed when that token is stale or names a
@@ -2697,7 +2697,7 @@ func TestApplyOperationStore_MarkPendingStoppedByApply_OperationLease(t *testing
 	// so MarkPendingStoppedByApply never touches it.
 	ownerID := createApplyOperationForLeaseTest(t, store, apply.ID, "region-owner")
 	require.NoError(t, store.ApplyOperations().UpdateState(ctx, ownerID, state.ApplyOperation.Running))
-	stampOperationLease(t, ownerID, "worker", "op-token")
+	stampOperationLease(t, ownerID, "driver", "op-token")
 
 	pendingID := createApplyOperationForLeaseTest(t, store, apply.ID, "region-pending")
 
@@ -2705,7 +2705,7 @@ func TestApplyOperationStore_MarkPendingStoppedByApply_OperationLease(t *testing
 		return storage.WithOperationLease(ctx, storage.OperationLease{
 			ApplyID:     applyID,
 			OperationID: opID,
-			Owner:       "worker",
+			Owner:       "driver",
 			Token:       token,
 		})
 	}

--- a/pkg/storage/mysqlstore/checks_test.go
+++ b/pkg/storage/mysqlstore/checks_test.go
@@ -1066,7 +1066,7 @@ func TestCheckStore_CompleteForApplyLeaseGuard(t *testing.T) {
 		UPDATE applies
 		SET lease_owner = ?, lease_token = ?, lease_acquired_at = NOW()
 		WHERE id = ?
-	`, "current-worker", "current-token", apply.ID)
+	`, "current-driver", "current-token", apply.ID)
 	require.NoError(t, err)
 
 	check := &storage.Check{
@@ -1086,7 +1086,7 @@ func TestCheckStore_CompleteForApplyLeaseGuard(t *testing.T) {
 	check.Conclusion = "success"
 	check.HasChanges = false
 	staleApply := *apply
-	staleApply.LeaseOwner = "old-worker"
+	staleApply.LeaseOwner = "old-driver"
 	staleApply.LeaseToken = "stale-token"
 	updated, err := store.Checks().CompleteForApply(ctx, check, &staleApply)
 	require.ErrorIs(t, err, storage.ErrApplyLeaseLost)
@@ -1100,7 +1100,7 @@ func TestCheckStore_CompleteForApplyLeaseGuard(t *testing.T) {
 	assert.Equal(t, apply.ID, retrieved.ApplyID)
 
 	currentApply := *apply
-	currentApply.LeaseOwner = "current-worker"
+	currentApply.LeaseOwner = "current-driver"
 	currentApply.LeaseToken = "current-token"
 	updated, err = store.Checks().CompleteForApply(ctx, check, &currentApply)
 	require.NoError(t, err)
@@ -1261,7 +1261,7 @@ func TestCheckStore_MarkActionRequiredForApplyLeaseGuard(t *testing.T) {
 		UPDATE applies
 		SET lease_owner = ?, lease_token = ?, lease_acquired_at = NOW()
 		WHERE id = ?
-	`, "current-worker", "current-token", apply.ID)
+	`, "current-driver", "current-token", apply.ID)
 	require.NoError(t, err)
 
 	check := &storage.Check{
@@ -1281,7 +1281,7 @@ func TestCheckStore_MarkActionRequiredForApplyLeaseGuard(t *testing.T) {
 	check.HasChanges = true
 	check.Conclusion = "action_required"
 	staleApply := *apply
-	staleApply.LeaseOwner = "old-worker"
+	staleApply.LeaseOwner = "old-driver"
 	staleApply.LeaseToken = "stale-token"
 	updated, err := store.Checks().MarkActionRequiredForApply(ctx, check, &staleApply)
 	require.ErrorIs(t, err, storage.ErrApplyLeaseLost)
@@ -1296,7 +1296,7 @@ func TestCheckStore_MarkActionRequiredForApplyLeaseGuard(t *testing.T) {
 	assert.Equal(t, apply.ID, retrieved.ApplyID)
 
 	currentApply := *apply
-	currentApply.LeaseOwner = "current-worker"
+	currentApply.LeaseOwner = "current-driver"
 	currentApply.LeaseToken = "current-token"
 	updated, err = store.Checks().MarkActionRequiredForApply(ctx, check, &currentApply)
 	require.NoError(t, err)

--- a/pkg/storage/mysqlstore/control_requests_test.go
+++ b/pkg/storage/mysqlstore/control_requests_test.go
@@ -211,7 +211,7 @@ func TestControlRequestStore_LeaseGuardsPendingResolution(t *testing.T) {
 		UPDATE applies
 		SET lease_owner = ?, lease_token = ?, lease_acquired_at = NOW()
 		WHERE id = ?
-	`, "current-worker", "current-token", applyID)
+	`, "current-driver", "current-token", applyID)
 	require.NoError(t, err)
 
 	created, alreadyPending, err := store.ControlRequests().RequestPending(ctx, &storage.ApplyControlRequest{
@@ -223,7 +223,7 @@ func TestControlRequestStore_LeaseGuardsPendingResolution(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, alreadyPending)
 
-	staleCtx := storage.WithApplyLease(ctx, storage.ApplyLease{ApplyID: applyID, Owner: "old-worker", Token: "stale-token"})
+	staleCtx := storage.WithApplyLease(ctx, storage.ApplyLease{ApplyID: applyID, Owner: "old-driver", Token: "stale-token"})
 	require.ErrorIs(t, store.ControlRequests().CompletePending(staleCtx, applyID, storage.ControlOperationStart), storage.ErrApplyLeaseLost)
 	require.ErrorIs(t, store.ControlRequests().FailPending(staleCtx, applyID, storage.ControlOperationStart, "stale failure"), storage.ErrApplyLeaseLost)
 
@@ -232,7 +232,7 @@ func TestControlRequestStore_LeaseGuardsPendingResolution(t *testing.T) {
 	require.NotNil(t, pending)
 	assert.Equal(t, created.ID, pending.ID)
 
-	currentCtx := storage.WithApplyLease(ctx, storage.ApplyLease{ApplyID: applyID, Owner: "current-worker", Token: "current-token"})
+	currentCtx := storage.WithApplyLease(ctx, storage.ApplyLease{ApplyID: applyID, Owner: "current-driver", Token: "current-token"})
 	require.NoError(t, store.ControlRequests().CompletePending(currentCtx, applyID, storage.ControlOperationStart))
 	completed := getControlRequestByID(t, store, created.ID)
 	require.NotNil(t, completed)

--- a/pkg/storage/mysqlstore/locks_test.go
+++ b/pkg/storage/mysqlstore/locks_test.go
@@ -100,9 +100,9 @@ func TestLockStore_Acquire_SameOwnerConcurrent(t *testing.T) {
 	clearTables(t)
 	ctx := t.Context()
 
-	const workers = 16
-	stores := make([]*Storage, workers)
-	for i := range workers {
+	const drivers = 16
+	stores := make([]*Storage, drivers)
+	for i := range drivers {
 		db, openErr := sql.Open("mysql", testDSNChangedRows)
 		require.NoError(t, openErr)
 		db.SetMaxOpenConns(1)
@@ -118,12 +118,12 @@ func TestLockStore_Acquire_SameOwnerConcurrent(t *testing.T) {
 	var mu sync.Mutex
 	var errs []error
 
-	for i := range workers {
-		workerStore := stores[i]
+	for i := range drivers {
+		driverStore := stores[i]
 		planID := fmt.Sprintf("plan-%d", i)
 		wg.Go(func() {
 			<-start
-			err := workerStore.Locks().Acquire(ctx, &storage.Lock{
+			err := driverStore.Locks().Acquire(ctx, &storage.Lock{
 				DatabaseName:  "testdb",
 				DatabaseType:  "vitess",
 				Repository:    "org/repo",

--- a/pkg/storage/mysqlstore/tasks.go
+++ b/pkg/storage/mysqlstore/tasks.go
@@ -178,7 +178,7 @@ func (s *taskStore) GetByApplyID(ctx context.Context, applyID int64) ([]*storage
 // GetByApplyOperationID returns the tasks for a single apply_operation (one
 // deployment of a multi-deployment apply). While the config layer hard-blocks
 // more than one deployment per environment this returns the same rows as
-// GetByApplyID for the apply's single operation; it lets a worker drive and
+// GetByApplyID for the apply's single operation; it lets a driver drive and
 // reconcile one deployment independently once an apply fans out across several.
 func (s *taskStore) GetByApplyOperationID(ctx context.Context, applyOperationID int64) ([]*storage.Task, error) {
 	rows, err := s.db.QueryContext(ctx, `

--- a/pkg/storage/mysqlstore/tasks_test.go
+++ b/pkg/storage/mysqlstore/tasks_test.go
@@ -32,14 +32,14 @@ func TestTaskStore_OperationLeaseGuardsUpdate(t *testing.T) {
 		UPDATE applies
 		SET lease_owner = ?, lease_token = ?, lease_acquired_at = NOW()
 		WHERE id = ?
-	`, "current-worker", "apply-token", apply.ID)
+	`, "current-driver", "apply-token", apply.ID)
 	require.NoError(t, err)
 
 	opID, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
 		ApplyID: apply.ID, Deployment: "region-a", Target: "payments",
 	})
 	require.NoError(t, err)
-	stampOperationLease(t, opID, "worker", "op-token")
+	stampOperationLease(t, opID, "driver", "op-token")
 
 	now := time.Now()
 	taskID, err := store.Tasks().Create(ctx, &storage.Task{
@@ -68,7 +68,7 @@ func TestTaskStore_OperationLeaseGuardsUpdate(t *testing.T) {
 
 	opCtx := func(token string) context.Context {
 		return storage.WithOperationLease(ctx, storage.OperationLease{
-			ApplyID: apply.ID, OperationID: opID, Owner: "worker", Token: token,
+			ApplyID: apply.ID, OperationID: opID, Owner: "driver", Token: token,
 		})
 	}
 
@@ -87,7 +87,7 @@ func TestTaskStore_OperationLeaseGuardsUpdate(t *testing.T) {
 	// when a current apply lease is also on the context.
 	task.State = state.Task.Failed
 	bothCtx := storage.WithApplyLease(opCtx("stale-op-token"), storage.ApplyLease{
-		ApplyID: apply.ID, Owner: "current-worker", Token: "apply-token",
+		ApplyID: apply.ID, Owner: "current-driver", Token: "apply-token",
 	})
 	require.ErrorIs(t, store.Tasks().Update(bothCtx, task), storage.ErrApplyLeaseLost)
 	reloaded, err = store.Tasks().Get(ctx, "task_oplease_users")
@@ -98,7 +98,7 @@ func TestTaskStore_OperationLeaseGuardsUpdate(t *testing.T) {
 // TestTaskStore_GetByApplyOperationID verifies that tasks can be loaded for a
 // single apply_operation (one deployment) independently of its sibling
 // deployments under the same apply. This is the read primitive an operator
-// worker uses to drive only the deployment it has claimed.
+// driver uses to drive only the deployment it has claimed.
 func TestTaskStore_GetByApplyOperationID(t *testing.T) {
 	clearTables(t)
 	ctx := t.Context()

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -107,14 +107,14 @@ type CheckStore interface {
 
 	// CompleteForApply updates stored check state to a terminal state only if
 	// it still belongs to the given apply and no newer apply exists for the
-	// same PR/environment/database. Returns false when another worker changed
+	// same PR/environment/database. Returns false when another driver changed
 	// the stored state first.
 	CompleteForApply(ctx context.Context, check *Check, apply *Apply) (bool, error)
 
 	// MarkActionRequiredForApply marks stored check state action_required after
 	// a rollback only if it still belongs to that rollback apply and no newer
 	// apply exists for the same PR/environment/database. Returns false when
-	// another worker changed the stored state first.
+	// another driver changed the stored state first.
 	MarkActionRequiredForApply(ctx context.Context, check *Check, apply *Apply) (bool, error)
 
 	// Get returns stored check state by its unique key (PR + env + database), or nil if not found.
@@ -278,7 +278,7 @@ type ApplyStore interface {
 	// successful claim it rotates the lease (owner, token, acquired_at) and
 	// refreshes the heartbeat so operator-owned writes can fail closed after
 	// ownership changes. Returns the claimed apply, or nil if the apply does not
-	// exist or is not currently claimable (e.g. another worker holds a fresh
+	// exist or is not currently claimable (e.g. another driver holds a fresh
 	// lease or the apply is terminal). Used by the operation-level claim loop to
 	// acquire the parent apply lease after claiming an apply_operations row.
 	ClaimApplyByID(ctx context.Context, applyID int64, owner string) (*Apply, error)
@@ -302,7 +302,7 @@ type ApplyStore interface {
 
 	// Heartbeat updates the apply's updated_at timestamp to maintain the lease.
 	// Should be called every 10 seconds while working on an apply.
-	// If not called for > 1 minute, another worker can claim the apply.
+	// If not called for > 1 minute, another driver can claim the apply.
 	Heartbeat(ctx context.Context, applyID int64) error
 
 	// CheckLease verifies that an operator apply lease is still current without
@@ -472,7 +472,7 @@ type ApplyOperationStore interface {
 	// minute are re-leased without changing their state. Terminal rows
 	// (completed/failed/cancelled/stopped/reverted) are never claimed.
 	//
-	// owner identifies the claiming worker and is required; it is recorded as
+	// owner identifies the claiming driver and is required; it is recorded as
 	// the operation's lease owner. Returns the claimed row, or nil if nothing
 	// needs work.
 	FindNextApplyOperation(ctx context.Context, owner string) (*ApplyOperation, error)
@@ -492,12 +492,12 @@ type ApplyOperationStore interface {
 	// re-leased without changing its state — recovering an in-flight cutover whose
 	// driver died, which carries no ordering gate.
 	//
-	// owner identifies the claiming worker and is required. Returns the claimed
+	// owner identifies the claiming driver and is required. Returns the claimed
 	// row, or nil if nothing is ready to cut over.
 	FindNextApplyOperationCutover(ctx context.Context, owner string) (*ApplyOperation, error)
 
 	// Heartbeat refreshes the child row's updated_at timestamp to extend the
-	// claim's lease while a worker is acting on it. Mirrors ApplyStore.Heartbeat
+	// claim's lease while a driver is acting on it. Mirrors ApplyStore.Heartbeat
 	// semantics: silent no-op when the row no longer exists.
 	Heartbeat(ctx context.Context, id int64) error
 
@@ -539,7 +539,7 @@ type ApplyLogStore interface {
 }
 
 // ControlRequestStore manages durable user control requests.
-// A control request is behavioral state, not just audit: operator workers use
+// A control request is behavioral state, not just audit: operator drivers use
 // pending rows to recover accepted operations after process restarts.
 type ControlRequestStore interface {
 	// RequestPending records a pending request for an apply operation. If the

--- a/pkg/storage/types.go
+++ b/pkg/storage/types.go
@@ -405,7 +405,7 @@ type Apply struct {
 	// Once the retry budget is exhausted, the apply becomes failed.
 	Attempt int
 
-	// LeaseOwner identifies the worker that last claimed this apply. It is
+	// LeaseOwner identifies the driver that last claimed this apply. It is
 	// operator-facing context; LeaseToken is the ownership capability used for
 	// correctness.
 	LeaseOwner string

--- a/pkg/storage/types.go
+++ b/pkg/storage/types.go
@@ -411,7 +411,7 @@ type Apply struct {
 	LeaseOwner string
 
 	// LeaseToken is rotated on each claim. Owned writes must include the current
-	// token to avoid stale workers overwriting a newer owner.
+	// token to avoid stale drivers overwriting a newer owner.
 	LeaseToken string
 
 	// LeaseAcquiredAt records when the current lease was acquired.
@@ -513,9 +513,9 @@ type ApplyOperation struct {
 	CompletedAt *time.Time
 
 	// LeaseOwner, LeaseToken, and LeaseAcquiredAt are the operation's own claim
-	// lease, rotated when a worker claims the row via FindNextApplyOperation and
+	// lease, rotated when a driver claims the row via FindNextApplyOperation and
 	// refreshed by its heartbeat. They mirror the apply-level lease columns so a
-	// worker can guard operation-scoped writes on this row's token instead of the
+	// driver can guard operation-scoped writes on this row's token instead of the
 	// parent apply's, letting sibling deployments run independently.
 	LeaseOwner      string
 	LeaseToken      string
@@ -593,7 +593,7 @@ const (
 type ControlRequestStatus string
 
 const (
-	// ControlRequestPending means an operator worker still needs to act.
+	// ControlRequestPending means an operator driver still needs to act.
 	ControlRequestPending ControlRequestStatus = "pending"
 	// ControlRequestCompleted means the requested operation has been accepted.
 	ControlRequestCompleted ControlRequestStatus = "completed"

--- a/pkg/tern/README.md
+++ b/pkg/tern/README.md
@@ -47,7 +47,7 @@ The CLI or API calls `Plan()` with the desired schema files. The Tern client pas
 
 ### 3. Poll
 
-Background goroutines poll the engine for progress every 500ms and update task state in storage (rows copied, ETA, progress %). A heartbeat updates the apply's `updated_at` every 10 seconds to signal the worker is alive.
+Background goroutines poll the engine for progress every 500ms and update task state in storage (rows copied, ETA, progress %). A heartbeat updates the apply's `updated_at` every 10 seconds to signal the driver is alive.
 
 ### 4. Cutover
 

--- a/pkg/tern/client.go
+++ b/pkg/tern/client.go
@@ -83,7 +83,7 @@ type Client interface {
 	// Health checks the service health.
 	Health(ctx context.Context) error
 
-	// ResumeApply starts or resumes work claimed by an operator worker.
+	// ResumeApply starts or resumes work claimed by an operator driver.
 	// Fresh pending applies are dispatched for the first time; stale applies
 	// use checkpoint/resume capabilities of the underlying engine.
 	ResumeApply(ctx context.Context, apply *storage.Apply) error
@@ -91,7 +91,7 @@ type Client interface {
 	// ResumeApplyOperation starts or resumes a single apply_operation (one
 	// deployment of a multi-deployment apply), driving only that operation's
 	// tasks. The drive logic is identical to ResumeApply; the operation scope
-	// only narrows which tasks are loaded/re-queried so a worker can advance one
+	// only narrows which tasks are loaded/re-queried so a driver can advance one
 	// deployment independently of its siblings. Fails closed when no tasks match
 	// the operation rather than touching the rest of the apply.
 	ResumeApplyOperation(ctx context.Context, apply *storage.Apply, applyOperationID int64) error

--- a/pkg/tern/grpc_client.go
+++ b/pkg/tern/grpc_client.go
@@ -958,7 +958,7 @@ func (c *GRPCClient) Health(ctx context.Context) error {
 // scopes to the whole apply (all its operations) and uses the parent
 // applies.external_id, matching the single-operation behaviour. An
 // operation-scoped value restricts the drive to a single apply_operation (one
-// deployment) so a worker can advance one deployment independently of its
+// deployment) so a driver can advance one deployment independently of its
 // siblings; when the parent owns more than one operation it also routes the
 // remote apply id through that operation's engine_resume_context instead of the
 // shared parent external_id, so one deployment never reuses or overwrites
@@ -1143,7 +1143,7 @@ func (c *GRPCClient) ResumeApply(ctx context.Context, apply *storage.Apply) erro
 // deployment of a multi-deployment apply) over the remote (gRPC) path. The drive
 // logic is identical to ResumeApply; the operation scope only narrows the task
 // re-query sites (dispatch, progress poll, terminal reconcile, failure, stop) so
-// a worker advances one deployment independently of its siblings.
+// a driver advances one deployment independently of its siblings.
 func (c *GRPCClient) ResumeApplyOperation(ctx context.Context, apply *storage.Apply, applyOperationID int64) error {
 	if applyOperationID <= 0 {
 		return fmt.Errorf("apply operation id is required")
@@ -1809,7 +1809,7 @@ func tasksToProtoTableChanges(tasks []*storage.Task) []*ternv1.TableChange {
 	return changes
 }
 
-// storedApplyTransitionStatus describes whether a worker may copy a remote
+// storedApplyTransitionStatus describes whether a driver may copy a remote
 // failure or terminal result into the stored apply row after reloading storage.
 // Only the ready status may mutate storage; every other status explains why the
 // write must be skipped or retried.
@@ -1837,7 +1837,7 @@ func (c *GRPCClient) reloadStoredApplyForRemoteTransition(ctx context.Context, r
 	return storedApply, storedApplyTransitionReady, nil
 }
 
-// A terminal stored apply is usually authoritative: a stale worker must not
+// A terminal stored apply is usually authoritative: a stale driver must not
 // overwrite a newer completed/failed/reverted result. Stopped is the one
 // terminal state that may still be superseded when the caller is reconciling an
 // exact remote apply ID that is missing or no longer active.
@@ -2074,7 +2074,7 @@ func (c *GRPCClient) reconcileTerminalRemoteProgress(ctx context.Context, remote
 	}
 
 	// Keep the stored apply active until stored task rows are written. If task
-	// storage is unavailable, the operator can retry this worker instead of
+	// storage is unavailable, the operator can retry this driver instead of
 	// treating a terminal apply as fully reconciled.
 	storedTasks, err := c.loadApplyTasks(ctx, storedApply, scope)
 	if err != nil {
@@ -2124,7 +2124,7 @@ func (c *GRPCClient) persistTerminalStateFromRemote(ctx context.Context, storedA
 		return err
 	}
 	// Stopped is a terminal apply state, but it is not completion of a pending
-	// Start request. A start can be queued while the previous worker is still
+	// Start request. A start can be queued while the previous driver is still
 	// recording the stop; leave that request pending so the operator can claim
 	// the stopped row and perform the resume.
 	if !state.IsState(storedApply.State, state.Apply.Stopped) {

--- a/pkg/tern/grpc_client_test.go
+++ b/pkg/tern/grpc_client_test.go
@@ -886,7 +886,7 @@ func TestGRPCClient_ResumeApplyDispatchesQueuedRemoteApply(t *testing.T) {
 }
 
 func TestGRPCClient_ResumeApplyOperationDispatchesScopedTasks(t *testing.T) {
-	// An operator worker resumes a single apply_operation over the remote path.
+	// An operator driver resumes a single apply_operation over the remote path.
 	// The drive loads tasks scoped to that operation (GetByApplyOperationID) and
 	// dispatches only those, never widening to the whole apply's tasks.
 	server := &capturingTernServer{
@@ -1996,7 +1996,7 @@ func TestGRPCClient_ResumeApplyDoesNotRegressRunningApplyToPendingProgress(t *te
 	// A freshly dispatched remote apply can report pending before the remote
 	// engine starts copying rows. SchemaBot has already claimed the queued apply
 	// locally, so progress polling must not write pending back to the stored
-	// apply row and make it claimable by another operator worker.
+	// apply row and make it claimable by another operator driver.
 	server := &capturingTernServer{
 		remoteApplyID: "remote-pending-first",
 		progressStates: []ternv1.State{
@@ -2550,7 +2550,7 @@ func hasLogMessageContaining(logs []*storage.ApplyLog, want string) bool {
 
 func TestGRPCClient_PollReturnsTerminalStorageUpdateError(t *testing.T) {
 	// A terminal remote state is not enough by itself; the control plane must
-	// persist that terminal state to storage before the operator worker exits.
+	// persist that terminal state to storage before the operator driver exits.
 	client, cleanup := testCapturingGRPCClient(t, &capturingTernServer{
 		progressState:    ternv1.State_STATE_COMPLETED,
 		progressStateSet: true,
@@ -2622,8 +2622,8 @@ func TestGRPCClient_PollKeepsApplyActiveWhenTerminalTaskLoadFails(t *testing.T) 
 }
 
 func TestGRPCClient_PollSkipsTaskFinalizationWhenStoredApplyAlreadyTerminal(t *testing.T) {
-	// A stale worker can receive a terminal remote state after another worker
-	// has already terminalized the stored apply row. In that case the worker must
+	// A stale driver can receive a terminal remote state after another driver
+	// has already terminalized the stored apply row. In that case the driver must
 	// not rewrite tasks from its stale in-memory apply state.
 	client, cleanup := testCapturingGRPCClient(t, &capturingTernServer{
 		progressState:    ternv1.State_STATE_COMPLETED,
@@ -2696,7 +2696,7 @@ func TestGRPCClient_MarkRemoteApplyFailedReturnsTaskLoadError(t *testing.T) {
 
 func TestGRPCClient_ResumeApplyRejectsAmbiguousRemoteDispatchState(t *testing.T) {
 	// A stale active gRPC apply without an external_id is ambiguous: the prior
-	// worker may have sent the remote Apply RPC and crashed before persisting the
+	// driver may have sent the remote Apply RPC and crashed before persisting the
 	// returned data-plane ID. Fail closed instead of dispatching a duplicate
 	// remote schema change.
 	server := &capturingTernServer{remoteApplyID: "remote-duplicate"}
@@ -2988,8 +2988,8 @@ func TestGRPCClient_ResumeApply_ThreadsExternalID(t *testing.T) {
 }
 
 func TestGRPCClient_ResumeApplyStartsQueuedStartAfterClaim(t *testing.T) {
-	// An operator claim can move the apply row before the worker calls remote
-	// Start. The durable control request lets a later worker recover that
+	// An operator claim can move the apply row before the driver calls remote
+	// Start. The durable control request lets a later driver recover that
 	// intent and validate the remote stopped state.
 	server := &capturingTernServer{
 		progressState:    ternv1.State_STATE_STOPPED,
@@ -3252,8 +3252,8 @@ func TestGRPCClient_ResumeApplyStartErrorLeavesApplyStopped(t *testing.T) {
 }
 
 func TestGRPCClient_ResumeApplyProcessesQueuedStop(t *testing.T) {
-	// A pending durable stop is processed by the operator-owned worker before
-	// resume/start work. The worker mirrors remote stopped progress to storage
+	// A pending durable stop is processed by the operator-owned driver before
+	// resume/start work. The driver mirrors remote stopped progress to storage
 	// before completing the durable request.
 	server := &capturingTernServer{
 		progressState:    ternv1.State_STATE_STOPPED,
@@ -3311,7 +3311,7 @@ func TestGRPCClient_ResumeApplyProcessesQueuedStop(t *testing.T) {
 }
 
 func TestGRPCClient_ResumeApplyProcessesQueuedCutover(t *testing.T) {
-	// A pending durable cutover is processed by the operator-owned worker using
+	// A pending durable cutover is processed by the operator-owned driver using
 	// the remote apply ID, then completed once remote Tern accepts the request.
 	server := &capturingTernServer{
 		cutoverAccepted:  true,
@@ -3576,7 +3576,7 @@ func TestGRPCClient_ResumeApplyCompletesQueuedStartWhenRemoteAlreadyActive(t *te
 }
 
 func TestGRPCClient_ReconcileStoppedRemoteProgressKeepsQueuedStartPending(t *testing.T) {
-	// A Start request can be accepted while an older worker is still recording
+	// A Start request can be accepted while an older driver is still recording
 	// the remote stop. The stop sync must not consume the pending Start intent;
 	// the operator needs that durable request to claim and resume the apply.
 	now := time.Now()
@@ -3825,7 +3825,7 @@ func TestGRPCClient_ResumeApplyFailsWhenStoppedRemoteIsNotFound(t *testing.T) {
 func TestGRPCClient_PollFailsWhenRemoteApplyIsNotFound(t *testing.T) {
 	// A known remote apply ID returning NotFound means the data plane can no
 	// longer report progress for work the control plane believes exists. The
-	// stored apply fails so workers do not keep polling a stale remote ID.
+	// stored apply fails so drivers do not keep polling a stale remote ID.
 	client, cleanup := testCapturingGRPCClient(t, &capturingTernServer{
 		progressErr: status.Error(codes.NotFound, "apply not found"),
 	})

--- a/pkg/tern/local_apply_sequential.go
+++ b/pkg/tern/local_apply_sequential.go
@@ -251,7 +251,7 @@ func (c *LocalClient) startApplyHeartbeat(ctx context.Context, apply *storage.Ap
 			case <-ticker.C:
 				if err := c.storage.Applies().Heartbeat(hbCtx, apply.ID); err != nil {
 					if errors.Is(err, storage.ErrApplyLeaseLost) {
-						c.logger.Warn("heartbeat failed because apply lease was lost; local worker will stop executing and writing apply state",
+						c.logger.Warn("heartbeat failed because apply lease was lost; local driver will stop executing and writing apply state",
 							"apply_id", apply.ApplyIdentifier,
 							"database", apply.Database,
 							"environment", apply.Environment,

--- a/pkg/tern/local_client.go
+++ b/pkg/tern/local_client.go
@@ -1381,7 +1381,7 @@ func (c *LocalClient) Apply(ctx context.Context, req *ternv1.ApplyRequest) (*ter
 
 	// Direct client calls can still register a pending observer before starting
 	// the engine. API-created applies use the service-level observer registry
-	// because operator workers dispatch them asynchronously.
+	// because operator drivers dispatch them asynchronously.
 	if obs := c.consumePendingObserver(); obs != nil {
 		// Set the apply ID on the observer if it supports it (e.g., CommentObserver
 		// needs the ID to look up tracked comments for editing).

--- a/pkg/tern/local_client_integration_test.go
+++ b/pkg/tern/local_client_integration_test.go
@@ -1095,7 +1095,7 @@ func TestLocalClient_GroupedApplyKeepsClaimLeaseRunning(t *testing.T) {
 	assert.Equal(t, state.Apply.Completed, completed.State)
 }
 
-// An operator worker resumes a single apply_operation — one deployment of an
+// An operator driver resumes a single apply_operation — one deployment of an
 // apply — rather than the whole apply. ResumeApplyOperation loads only that
 // operation's tasks (via the operation-scoped read primitive) and drives them
 // to completion through the same engine path as ResumeApply.
@@ -2415,7 +2415,7 @@ func TestLocalClient_ResumeApplyGroupedStartRequestFailsWhenEngineRejects(t *tes
 }
 
 // This scenario covers restart recovery of a grouped Vitess apply whose opaque
-// engine resume state was persisted before the worker died. Recovery must hand
+// engine resume state was persisted before the driver died. Recovery must hand
 // that state back to the engine in exactly one grouped apply — even without
 // defer-cutover — so the engine reattaches to the in-flight deploy request
 // instead of opening a duplicate one. The rebuilt changes must keep the tasks'
@@ -3562,7 +3562,7 @@ func TestLocalClient_AtomicRetryableFailureQueuesOperatorRetry(t *testing.T) {
 	}
 
 	// The engine reports a failed result with Retryable=true. The local Tern
-	// worker should stop this attempt, keep the apply non-terminal, and leave
+	// driver should stop this attempt, keep the apply non-terminal, and leave
 	// already-completed task work untouched for the operator retry.
 	client.pollForCompletionAtomic(ctx, apply, tasks, &engine.Credentials{DSN: dsn}, nil, apply.GetOptions().Map(), false)
 

--- a/pkg/tern/local_control.go
+++ b/pkg/tern/local_control.go
@@ -867,7 +867,7 @@ func ensureApplyFailureMessage(apply *storage.Apply, tasks []*storage.Task) {
 // handleStopAllTasksTerminal handles the edge case where stop is requested but
 // every targeted task is already in a terminal state (completed, failed,
 // cancelled, or reverted). The apply row may still be non-terminal — e.g., a
-// worker exited after finalizing task rows but before the apply row — so the
+// driver exited after finalizing task rows but before the apply row — so the
 // apply's final state is derived from its task states rather than assumed.
 // A failed task must surface as a failed apply, never as a completed one, and
 // its failure reason is propagated so operators can triage from the apply

--- a/pkg/tern/local_control_resume.go
+++ b/pkg/tern/local_control_resume.go
@@ -454,8 +454,8 @@ func (c *LocalClient) prepareRetryableTasksForResume(ctx context.Context, apply 
 
 // prepareStoppedTasksForResume turns an operator-claimed start request back into
 // runnable task work. The start intent stays pending until stopped task rows are
-// requeued and the apply is ready for execution, so a worker crash can still be
-// recovered by another operator worker.
+// requeued and the apply is ready for execution, so a driver crash can still be
+// recovered by another operator driver.
 func (c *LocalClient) prepareStoppedTasksForResume(ctx context.Context, apply *storage.Apply, tasks []*storage.Task, startRequested bool) {
 	if !startRequested {
 		return
@@ -523,7 +523,7 @@ func (c *LocalClient) markApplyRecovering(ctx context.Context, apply *storage.Ap
 
 // launchAtomicResume sends all DDLs to the engine in one call, marks tasks and
 // apply as RUNNING, logs the provided message, and then polls for completion.
-// Operator-owned calls block so the worker owns the apply until terminal or
+// Operator-owned calls block so the driver owns the apply until terminal or
 // retry-waiting state; user start calls poll in the background and returns
 // after the engine accepts the resume.
 func (c *LocalClient) launchAtomicResume(ctx context.Context, apply *storage.Apply,
@@ -783,7 +783,7 @@ func (c *LocalClient) notifyTerminalObserver(apply *storage.Apply, tasks []*stor
 	}
 }
 
-// ResumeApply starts or resumes an apply claimed by an operator worker.
+// ResumeApply starts or resumes an apply claimed by an operator driver.
 // Pending applies are dispatched for the first time; stale applies use the
 // engine's resume metadata to continue after a missed heartbeat.
 func (c *LocalClient) ResumeApply(ctx context.Context, apply *storage.Apply) error {
@@ -799,7 +799,7 @@ func (c *LocalClient) ResumeApply(ctx context.Context, apply *storage.Apply) err
 // ResumeApplyOperation starts or resumes a single apply_operation (one
 // deployment of a multi-deployment apply), driving only that operation's tasks.
 // The drive logic is identical to ResumeApply; the only difference is that tasks
-// are loaded scoped to the operation rather than the whole apply, so a worker
+// are loaded scoped to the operation rather than the whole apply, so a driver
 // can advance one deployment independently of its siblings.
 func (c *LocalClient) ResumeApplyOperation(ctx context.Context, apply *storage.Apply, applyOperationID int64) error {
 	tasks, err := c.storage.Tasks().GetByApplyOperationID(ctx, applyOperationID)

--- a/pkg/tern/local_control_test.go
+++ b/pkg/tern/local_control_test.go
@@ -376,7 +376,7 @@ func TestLocalClient_StopSnapshotsProgressWithStoppedTaskNamespace(t *testing.T)
 	assert.Equal(t, "root@tcp(localhost:3306)/live_schema", eng.progressReq.Credentials.DSN)
 }
 
-// A stop request can race with a worker that finalized all task rows but
+// A stop request can race with a driver that finalized all task rows but
 // exited before finalizing the apply row. When every targeted task is already
 // terminal, stop derives the apply's final state from its tasks: an apply
 // whose tasks failed must finish as failed, never as completed, so the

--- a/pkg/tern/observer.go
+++ b/pkg/tern/observer.go
@@ -52,7 +52,7 @@ func (c *LocalClient) SetObserver(applyID int64, observer ProgressObserver) {
 
 // SetPendingObserver sets an observer that will be consumed by the next direct
 // client Apply() call. The API service uses its own pending-observer registry
-// because operator workers dispatch API-created applies asynchronously.
+// because operator drivers dispatch API-created applies asynchronously.
 func (c *LocalClient) SetPendingObserver(observer ProgressObserver) {
 	c.observerMu.Lock()
 	defer c.observerMu.Unlock()

--- a/pkg/tern/routing_client.go
+++ b/pkg/tern/routing_client.go
@@ -288,7 +288,7 @@ func (c *RoutingClient) Health(ctx context.Context) error {
 	return fmt.Errorf("routing client health requires a deployment-scoped client")
 }
 
-// ResumeApply starts or resumes work claimed by an operator worker.
+// ResumeApply starts or resumes work claimed by an operator driver.
 func (c *RoutingClient) ResumeApply(ctx context.Context, apply *storage.Apply) error {
 	client, err := c.clientForStoredApply(ctx, apply)
 	if err != nil {

--- a/pkg/webhook/apply_comment_e2e_test.go
+++ b/pkg/webhook/apply_comment_e2e_test.go
@@ -161,7 +161,7 @@ func TestE2EApplyCommentLifecycle(t *testing.T) {
 	applyID, err := st.Applies().Create(ctx, apply)
 	require.NoError(t, err)
 	apply.ID = applyID
-	apply.LeaseOwner = "comment-test-worker"
+	apply.LeaseOwner = "comment-test-driver"
 	apply.LeaseToken = "comment-test-token"
 	leaseAcquiredAt := time.Now()
 	apply.LeaseAcquiredAt = &leaseAcquiredAt
@@ -538,7 +538,7 @@ func TestE2EApplyCommentUpsertOnResume(t *testing.T) {
 	assert.Len(t, allComments, 2, "upsert should not create duplicate entries")
 }
 
-// This scenario covers a recovered PR observer whose operator worker has lost
+// This scenario covers a recovered PR observer whose operator driver has lost
 // ownership before it reaches terminal notification. The stale observer must not
 // edit progress, post a summary, mark summary state, or run terminal hooks.
 func TestE2ECommentObserverSkipsTerminalSideEffectsAfterLeaseLoss(t *testing.T) {
@@ -619,7 +619,7 @@ func TestE2ECommentObserverSkipsTerminalSideEffectsAfterLeaseLoss(t *testing.T) 
 		UPDATE applies
 		SET lease_owner = ?, lease_token = ?, lease_acquired_at = NOW()
 		WHERE id = ?
-	`, "current-worker", "current-token", applyID)
+	`, "current-driver", "current-token", applyID)
 	require.NoError(t, err)
 
 	progressCommentID := int64(4242)
@@ -642,7 +642,7 @@ func TestE2ECommentObserverSkipsTerminalSideEffectsAfterLeaseLoss(t *testing.T) 
 		ApplyID:        applyID,
 		ApplyLease: storage.ApplyLease{
 			ApplyID: applyID,
-			Owner:   "stale-worker",
+			Owner:   "stale-driver",
 			Token:   "stale-token",
 		},
 		Logger: logger,
@@ -653,7 +653,7 @@ func TestE2ECommentObserverSkipsTerminalSideEffectsAfterLeaseLoss(t *testing.T) 
 
 	terminalApply := *apply
 	terminalApply.State = state.Apply.Failed
-	terminalApply.ErrorMessage = "stale worker terminal state"
+	terminalApply.ErrorMessage = "stale driver terminal state"
 	terminalApply.CompletedAt = &now
 	observer.OnTerminal(&terminalApply, []*storage.Task{task})
 

--- a/pkg/webhook/bootstrap.go
+++ b/pkg/webhook/bootstrap.go
@@ -11,7 +11,7 @@ import (
 // commandTimeout is the default deadline for processing a single PR command.
 // Command handlers run as fire-and-forget goroutines after the webhook delivery
 // has been acknowledged; the timeout bounds their lifetime so an unresponsive
-// downstream (GitHub API, MySQL, Spirit) cannot leak a worker indefinitely.
+// downstream (GitHub API, MySQL, Spirit) cannot leak a driver indefinitely.
 const commandTimeout = 2 * time.Minute
 
 // commandBootstrap sets up the standard per-command context with a deadline

--- a/pkg/webhook/check_records.go
+++ b/pkg/webhook/check_records.go
@@ -171,7 +171,7 @@ func isApplyNewer(candidate, existing *storage.Apply) bool {
 
 // reconcileStaleChecks repairs stored check state from authoritative apply
 // state. The visible GitHub Check Run is the PR merge gate, but the apply row is
-// the source of truth for whether a schema change is still running. If a worker
+// the source of truth for whether a schema change is still running. If a driver
 // dies after the apply reaches a terminal state but before it updates stored
 // check state, the PR can be left with an in_progress aggregate forever.
 // Reconciliation runs before plan and apply commands so normal user activity can

--- a/pkg/webhook/comment_observer.go
+++ b/pkg/webhook/comment_observer.go
@@ -46,7 +46,7 @@ type CommentObserver struct {
 
 	// aggregateTerminalCASWinner marks a one-shot observer used by the operator
 	// to publish a multi-operation apply's single terminal summary after it won
-	// the aggregate projection compare-and-swap. Such a worker holds the
+	// the aggregate projection compare-and-swap. Such a driver holds the
 	// operation lease, not the parent apply lease, so the per-driver apply-lease
 	// authority does not apply; the won CAS is the authority. It bypasses the
 	// apply-lease checks and lease-scoped storage writes accordingly.
@@ -324,7 +324,7 @@ func (o *CommentObserver) shouldDeferCutover(apply *storage.Apply) bool {
 
 func (o *CommentObserver) leaseStillOwnsObserver(apply *storage.Apply, operation string) bool {
 	// The aggregate terminal observer is invoked by the operator that already won
-	// the non-terminal→terminal projection CAS. That worker holds the operation
+	// the non-terminal→terminal projection CAS. That driver holds the operation
 	// lease, not the parent apply lease, so the per-driver apply-lease authority
 	// does not apply here — the won CAS is the authority for this one publish.
 	if o.aggregateTerminalCASWinner {
@@ -346,7 +346,7 @@ func (o *CommentObserver) leaseStillOwnsObserver(apply *storage.Apply, operation
 
 	// GitHub comments and check updates are side effects outside MySQL's
 	// transaction boundary. Re-check the apply lease immediately before each
-	// side effect so a stale worker cannot publish progress, terminal comments,
+	// side effect so a stale driver cannot publish progress, terminal comments,
 	// or check updates after a newer operator owner has claimed the apply.
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()

--- a/pkg/webhook/comment_observer_test.go
+++ b/pkg/webhook/comment_observer_test.go
@@ -215,7 +215,7 @@ func TestCommentObserverErrorLogsWithoutApplyRecord(t *testing.T) {
 
 // The aggregate terminal observer is invoked by the operator that already won
 // the non-terminal→terminal projection CAS for a multi-operation apply. That
-// worker holds the operation lease, not the parent apply lease, so the one-shot
+// driver holds the operation lease, not the parent apply lease, so the one-shot
 // observer must publish without an apply lease — unlike the normal per-driver
 // observer, which fails closed when it cannot prove apply-lease ownership.
 func TestAggregateTerminalObserverBypassesApplyLeaseCheck(t *testing.T) {
@@ -232,7 +232,7 @@ func TestAggregateTerminalObserverBypassesApplyLeaseCheck(t *testing.T) {
 		"the aggregate terminal observer is authorized by the won CAS, not an apply lease")
 
 	// The lease-scoped storage write helper must likewise not attach a lease the
-	// aggregate worker does not hold, so comment-recording writes take storage's
+	// aggregate driver does not hold, so comment-recording writes take storage's
 	// no-apply-lease path instead of failing closed.
 	ctx := aggregate.contextWithApplyLease(t.Context(), unleasedApply)
 	_, hasLease := storage.ApplyLeaseFromContext(ctx)

--- a/pkg/webhook/webhook_e2e_test.go
+++ b/pkg/webhook/webhook_e2e_test.go
@@ -219,7 +219,7 @@ func setupE2EService(t *testing.T, appDBName string) *api.Service {
 	}, logger)
 	require.NoError(t, svc.SetOperatorPollInterval(100*time.Millisecond))
 	// Webhook E2E helpers use the real service lifecycle. Local applies are
-	// durably queued by ExecuteApply, then dispatched by operator workers.
+	// durably queued by ExecuteApply, then dispatched by operator drivers.
 	svc.StartOperator(ctx)
 	t.Cleanup(func() { _ = svc.Close() })
 
@@ -3365,7 +3365,7 @@ func TestE2EReconcileStaleInProgressCheckFailure(t *testing.T) {
 	svc := setupE2EService(t, dbName)
 	ctx := t.Context()
 
-	// Seed the terminal apply. This models a worker that reached a failed apply
+	// Seed the terminal apply. This models a driver that reached a failed apply
 	// state, then crashed before it updated GitHub check state.
 	apply := &storage.Apply{
 		ApplyIdentifier: "apply-stale-failed",
@@ -4106,7 +4106,7 @@ func TestE2EPassingAggregateSynchronizeUpdatesNewSHA(t *testing.T) {
 }
 
 // TestE2EAggregateUpdateSkipsStaleHeadSHA verifies that aggregate updates are
-// gated by the current PR commit SHA. A stale worker must not publish a check
+// gated by the current PR commit SHA. A stale driver must not publish a check
 // run for an older commit after the PR branch has moved.
 func TestE2EAggregateUpdateSkipsStaleHeadSHA(t *testing.T) {
 	dbName := "webhook_stale_sha_guard"


### PR DESCRIPTION
## What

Completes the `worker` → `driver` terminology rollout in code (Phase 1 added the AGENTS.md rule in #418). A *driver* is the operator goroutine that claims an apply via `FOR UPDATE SKIP LOCKED`, holds its lease, and drives it to a terminal state.

This renames internal symbols, comments, log fields, the lease-owner string, doc prose, and test fixtures from "worker" to "driver" across the codebase:

- **`pkg/api` symbols** (`operator.go`): `operatorWorker`→`operatorDriver`, `workerID`→`driverID`, `operatorLeaseOwner`→`driverLeaseOwner`, `workers`→`driverCount`, `workerCtx`→`driverCtx`.
- **Comments / logs / docs / test fixtures**: "operator worker"/"worker" → "driver" across `pkg/api`, `pkg/tern`, `pkg/storage`, `pkg/webhook`, `pkg/engine`, `pkg/state`, `pkg/cmd`, `integration/`, and `docs/*` — including the `storage.Apply.LeaseOwner`/`LeaseToken` comments.
- **`pkg/api/README.md`**: also corrects a stale `StartScheduler` reference (the real symbol is `StartOperator`) and the dead `scheduler.go` file-table entry left over from the earlier scheduler→operator rename.

## Why

AGENTS.md mandates "driver" (not "worker") for the lease-holding goroutine and reserves "worker" so it never collides with the Go MySQL/SQL driver. This aligns the whole codebase with that vocabulary. Pure rename — no behavior change.

## Operator-facing (observable) changes

- Structured log field key `"worker"` → `"driver"`; startup log `"workers"` → `"drivers"`.
- Log messages "operator worker started/stopping/context cancelled/woke…" → "operator driver …".
- Apply-event message "(worker N, state X)" → "(driver N, state X)".
- `lease_owner` value format `host/pid/worker-N` → `host/pid/driver-N`. Descriptive context only — `LeaseToken` governs claim correctness, so this is safe across a rolling deploy; no test depends on the format.

## Deferred follow-up (intentionally NOT in this PR)

The config knob is **deliberately left as-is** here and renamed in a separate, later PR — this is a known next step, not an omission:

- `operator_workers` (YAML key), `OperatorWorkers` / `DefaultOperatorWorkers` (fields), and the deprecated `scheduler_workers` alias → a `drivers` key, plus `docs/configuration.md`.
- Held back because it changes the **public config contract** and starts a *second* deprecation cycle immediately after `scheduler_workers` → `operator_workers` (the config would briefly accept three names for one knob). That deserves its own focused review and revert boundary, separate from this mechanical rename.

## Testing / validation

Unit + integration suites for all touched packages and `golangci-lint --new-from-rev=origin/main` (both build tags) pass.
