### PR TITLE
feat(tern): add operation-scoped cutover drive for ordered cutover

### DIFF
--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -520,48 +520,49 @@ func hasApplyLogMessageContaining(logs []*storage.ApplyLog, want string) bool {
 
 // mockTernClient implements tern.Client for testing.
 type mockTernClient struct {
-	healthErr         error
-	planResp          *ternv1.PlanResponse
-	planErr           error
-	planReq           *ternv1.PlanRequest
-	pullSchemaResp    *ternv1.PullSchemaResponse
-	pullSchemaErr     error
-	pullSchemaReq     *ternv1.PullSchemaRequest
-	pullSchemaReqs    []*ternv1.PullSchemaRequest
-	pullSchemaHook    func(*ternv1.PullSchemaRequest) (*ternv1.PullSchemaResponse, error)
-	applyResp         *ternv1.ApplyResponse
-	applyErr          error
-	applyReq          *ternv1.ApplyRequest
-	progressResp      *ternv1.ProgressResponse
-	progressErr       error
-	progressReq       *ternv1.ProgressRequest
-	volumeResp        *ternv1.VolumeResponse
-	volumeErr         error
-	volumeReq         *ternv1.VolumeRequest // captured request
-	stopResp          *ternv1.StopResponse
-	stopErr           error
-	stopReq           *ternv1.StopRequest // captured request
-	stopHook          func()
-	startResp         *ternv1.StartResponse
-	startErr          error
-	startReq          *ternv1.StartRequest // captured request
-	cutoverResp       *ternv1.CutoverResponse
-	cutoverErr        error
-	cutoverReq        *ternv1.CutoverRequest // captured request
-	revertResp        *ternv1.RevertResponse
-	revertErr         error
-	revertReq         *ternv1.RevertRequest // captured request
-	skipRevertResp    *ternv1.SkipRevertResponse
-	skipRevertErr     error
-	skipRevertReq     *ternv1.SkipRevertRequest // captured request
-	resumeMu          sync.Mutex
-	resumeErr         error
-	resumeApply       *storage.Apply
-	resumeOperationID int64
-	resumeCh          chan *storage.Apply
-	observerApplyID   int64
-	observer          tern.ProgressObserver
-	isRemote          bool
+	healthErr                error
+	planResp                 *ternv1.PlanResponse
+	planErr                  error
+	planReq                  *ternv1.PlanRequest
+	pullSchemaResp           *ternv1.PullSchemaResponse
+	pullSchemaErr            error
+	pullSchemaReq            *ternv1.PullSchemaRequest
+	pullSchemaReqs           []*ternv1.PullSchemaRequest
+	pullSchemaHook           func(*ternv1.PullSchemaRequest) (*ternv1.PullSchemaResponse, error)
+	applyResp                *ternv1.ApplyResponse
+	applyErr                 error
+	applyReq                 *ternv1.ApplyRequest
+	progressResp             *ternv1.ProgressResponse
+	progressErr              error
+	progressReq              *ternv1.ProgressRequest
+	volumeResp               *ternv1.VolumeResponse
+	volumeErr                error
+	volumeReq                *ternv1.VolumeRequest // captured request
+	stopResp                 *ternv1.StopResponse
+	stopErr                  error
+	stopReq                  *ternv1.StopRequest // captured request
+	stopHook                 func()
+	startResp                *ternv1.StartResponse
+	startErr                 error
+	startReq                 *ternv1.StartRequest // captured request
+	cutoverResp              *ternv1.CutoverResponse
+	cutoverErr               error
+	cutoverReq               *ternv1.CutoverRequest // captured request
+	revertResp               *ternv1.RevertResponse
+	revertErr                error
+	revertReq                *ternv1.RevertRequest // captured request
+	skipRevertResp           *ternv1.SkipRevertResponse
+	skipRevertErr            error
+	skipRevertReq            *ternv1.SkipRevertRequest // captured request
+	resumeMu                 sync.Mutex
+	resumeErr                error
+	resumeApply              *storage.Apply
+	resumeOperationID        int64
+	resumeCutoverOperationID int64
+	resumeCh                 chan *storage.Apply
+	observerApplyID          int64
+	observer                 tern.ProgressObserver
+	isRemote                 bool
 }
 
 func (m *mockTernClient) Health(ctx context.Context) error { return m.healthErr }
@@ -661,6 +662,22 @@ func (m *mockTernClient) ResumeApplyOperation(ctx context.Context, apply *storag
 	m.resumeMu.Lock()
 	m.resumeApply = apply
 	m.resumeOperationID = applyOperationID
+	resumeCh := m.resumeCh
+	resumeErr := m.resumeErr
+	m.resumeMu.Unlock()
+
+	if resumeCh != nil {
+		select {
+		case resumeCh <- apply:
+		default:
+		}
+	}
+	return resumeErr
+}
+func (m *mockTernClient) ResumeApplyOperationCutover(ctx context.Context, apply *storage.Apply, applyOperationID int64) error {
+	m.resumeMu.Lock()
+	m.resumeApply = apply
+	m.resumeCutoverOperationID = applyOperationID
 	resumeCh := m.resumeCh
 	resumeErr := m.resumeErr
 	m.resumeMu.Unlock()

--- a/pkg/tern/client.go
+++ b/pkg/tern/client.go
@@ -18,6 +18,14 @@ import (
 // callers can match it with errors.Is regardless of the transport.
 var ErrNoTasksForApplyOperation = errors.New("no tasks found for apply operation")
 
+// ErrOperationCutoverUnsupportedRemote is returned by
+// GRPCClient.ResumeApplyOperationCutover. The remote (gRPC) drive does not yet
+// park an operation at the cutover barrier, so there is no parked checkpoint for
+// it to resume and drive through cutover; the remote park/drive is a deliberate
+// follow-up. Returning a sentinel keeps the operator fail-closed for the remote
+// transport rather than silently dropping the claim.
+var ErrOperationCutoverUnsupportedRemote = errors.New("operation cutover drive is not supported for remote (gRPC) applies")
+
 // ErrApplyOperationRowMissing is returned by ResumeApplyOperation when tasks
 // scope to the operation but the apply_operation row itself is absent. It is a
 // distinct, more accurate cause than the no-tasks case, but wraps
@@ -87,6 +95,17 @@ type Client interface {
 	// deployment independently of its siblings. Fails closed when no tasks match
 	// the operation rather than touching the rest of the apply.
 	ResumeApplyOperation(ctx context.Context, apply *storage.Apply, applyOperationID int64) error
+
+	// ResumeApplyOperationCutover drives a single apply_operation that is parked
+	// at the cutover barrier (waiting_for_cutover) through its cutover phase:
+	// waiting_for_cutover → cutting_over → revert_window → completed. It is the
+	// deployment-ordered counterpart to ResumeApplyOperation's copy drive — the
+	// operator claims a parked operation whose turn it is (via the cutover-claim
+	// predicate) and calls this to perform the high-risk swap, while siblings
+	// stay parked. Unlike ResumeApplyOperation it never re-parks: it resumes the
+	// operation's engine checkpoint and forces the cutover. Fails closed when no
+	// tasks match the operation, like ResumeApplyOperation.
+	ResumeApplyOperationCutover(ctx context.Context, apply *storage.Apply, applyOperationID int64) error
 
 	// Endpoint returns the address this client connects to.
 	// For GRPCClient, this is the dial address (e.g., "tern-staging:9090").

--- a/pkg/tern/cutover_barrier.go
+++ b/pkg/tern/cutover_barrier.go
@@ -1,6 +1,19 @@
 package tern
 
-import "github.com/block/schemabot/pkg/storage"
+import (
+	"github.com/block/schemabot/pkg/state"
+	"github.com/block/schemabot/pkg/storage"
+)
+
+// isCutoverDriveState reports whether an operation is in a phase the ordered
+// cutover drive may resume: parked at the barrier (waiting_for_cutover) or
+// already mid-cutover (cutting_over / revert_window) for stale-lease recovery.
+// These are exactly the states the OC-1 cutover-claim predicate selects. A
+// copy-phase or terminal operation is rejected so a mismatched or stale claim
+// can never force an unrelated operation through the high-risk swap.
+func isCutoverDriveState(opState string) bool {
+	return state.IsState(opState, state.Apply.WaitingForCutover, state.Apply.CuttingOver, state.Apply.RevertWindow)
+}
 
 // shouldAutoDeferCutover reports whether an operation-scoped copy drive must park
 // at the cutover barrier automatically. It is true only for an operation of a

--- a/pkg/tern/cutover_barrier_test.go
+++ b/pkg/tern/cutover_barrier_test.go
@@ -102,6 +102,30 @@ func TestGroupedApplyHonoursEffectiveOptions(t *testing.T) {
 	assert.Equal(t, "spirit_atomic_cutover", groupedApplyMode(apply, effective))
 }
 
+// The cutover drive may resume an operation parked at the barrier or already
+// mid-cutover (stale-lease recovery), but never a copy-phase or terminal one.
+func TestIsCutoverDriveState(t *testing.T) {
+	tests := []struct {
+		state string
+		want  bool
+	}{
+		{state.Apply.WaitingForCutover, true},
+		{state.Apply.CuttingOver, true},
+		{state.Apply.RevertWindow, true},
+		{state.Apply.Pending, false},
+		{state.Apply.Running, false},
+		{state.Apply.WaitingForDeploy, false},
+		{state.Apply.Completed, false},
+		{state.Apply.Failed, false},
+		{state.Apply.Stopped, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.state, func(t *testing.T) {
+			assert.Equal(t, tt.want, isCutoverDriveState(tt.state))
+		})
+	}
+}
+
 // An ordered-cutover drive (forceCutoverResume) must load the parked engine
 // checkpoint even though the barrier park deliberately leaves DeferCutover unset
 // on the shared apply, while still requiring the apply to actually be parked.

--- a/pkg/tern/cutover_barrier_test.go
+++ b/pkg/tern/cutover_barrier_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/block/schemabot/pkg/state"
 	"github.com/block/schemabot/pkg/storage"
 )
 
@@ -99,4 +100,31 @@ func TestGroupedApplyHonoursEffectiveOptions(t *testing.T) {
 	effective := effectiveCopyDriveOptions(apply, true, barrierOp()).Map()
 	assert.True(t, c.usesGroupedApply(apply, effective))
 	assert.Equal(t, "spirit_atomic_cutover", groupedApplyMode(apply, effective))
+}
+
+// An ordered-cutover drive (forceCutoverResume) must load the parked engine
+// checkpoint even though the barrier park deliberately leaves DeferCutover unset
+// on the shared apply, while still requiring the apply to actually be parked.
+func TestShouldInspectCutoverSignalForResume(t *testing.T) {
+	parked := func(opts storage.ApplyOptions) *storage.Apply {
+		return &storage.Apply{State: state.Apply.WaitingForCutover, Options: storage.MarshalApplyOptions(opts)}
+	}
+
+	tests := []struct {
+		name               string
+		apply              *storage.Apply
+		forceCutoverResume bool
+		want               bool
+	}{
+		{"manual defer recovery inspects without force", parked(storage.ApplyOptions{DeferCutover: true}), false, true},
+		{"barrier park needs force to inspect", parked(storage.ApplyOptions{}), false, false},
+		{"forced cutover drive inspects parked op", parked(storage.ApplyOptions{}), true, true},
+		{"force ignored when not parked", &storage.Apply{State: state.Apply.Running}, true, false},
+		{"nil apply never inspects", nil, true, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, shouldInspectCutoverSignalForResume(tt.apply, tt.forceCutoverResume))
+		})
+	}
 }

--- a/pkg/tern/grpc_client.go
+++ b/pkg/tern/grpc_client.go
@@ -1135,6 +1135,18 @@ func (c *GRPCClient) ResumeApplyOperation(ctx context.Context, apply *storage.Ap
 	return c.resumeApply(ctx, apply, scope)
 }
 
+// ResumeApplyOperationCutover is not supported on the remote (gRPC) path. The
+// remote drive does not park an operation at the cutover barrier, so there is no
+// parked checkpoint to resume and drive through cutover. Fail closed with a
+// sentinel rather than attempting a drive that cannot exist yet; the operator
+// reserves the parked operation for a future remote cutover drive.
+func (c *GRPCClient) ResumeApplyOperationCutover(ctx context.Context, apply *storage.Apply, applyOperationID int64) error {
+	if apply == nil {
+		return fmt.Errorf("apply is required")
+	}
+	return fmt.Errorf("apply_operation %d (apply %s): %w", applyOperationID, apply.ApplyIdentifier, ErrOperationCutoverUnsupportedRemote)
+}
+
 // resumeApply runs work claimed by the operator. Fresh queued applies have no
 // external_id yet, so this first dispatches them to remote Tern and stores the
 // returned ID. The call then polls until the apply reaches a stored terminal

--- a/pkg/tern/grpc_client_test.go
+++ b/pkg/tern/grpc_client_test.go
@@ -1362,6 +1362,18 @@ func TestGRPCClient_ResumeApplyOperationFailureRecordsTasksOnlyForMultiOpApply(t
 	assert.Empty(t, applyStore.updates, "a multi-op failure must not write the parent applies row directly")
 }
 
+// The remote (gRPC) transport does not park an operation at the cutover barrier,
+// so there is no parked checkpoint for a cutover drive to resume. The operator
+// must fail closed on the sentinel rather than silently dropping the claim.
+func TestGRPCClient_ResumeApplyOperationCutoverFailsClosedUnsupported(t *testing.T) {
+	client, cleanup := testCapturingGRPCClient(t, &capturingTernServer{})
+	defer cleanup()
+
+	err := client.ResumeApplyOperationCutover(t.Context(), &storage.Apply{ApplyIdentifier: "apply-x"}, 7)
+	require.ErrorIs(t, err, ErrOperationCutoverUnsupportedRemote)
+	assert.Contains(t, err.Error(), "apply-x")
+}
+
 func TestGRPCClient_ResumeApplyOperationRejectsMissingOperationID(t *testing.T) {
 	client, cleanup := testCapturingGRPCClient(t, &capturingTernServer{})
 	defer cleanup()

--- a/pkg/tern/local_client_integration_test.go
+++ b/pkg/tern/local_client_integration_test.go
@@ -1339,6 +1339,173 @@ func TestLocalClient_ResumeApplyOperationCutoverFailsClosedOnNoTasks(t *testing.
 	assert.Equal(t, state.Apply.WaitingForCutover, after.State, "a task-less cutover claim must not mutate the parked parent apply state")
 }
 
+// The cutover drive is operation-scoped and must fail closed when the operation
+// does not belong to the passed-in apply, so a mismatched (apply, operation)
+// pair can never force another apply's deployment through cutover.
+func TestLocalClient_ResumeApplyOperationCutoverFailsClosedOnApplyMismatch(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	_, dsn := setupMySQLContainer(t)
+	setupStorageSchema(t, dsn)
+	cleanupTasks(t, dsn)
+	cleanupTestTables(t, dsn)
+
+	ctx := t.Context()
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	stor := createStorage(t, dsn)
+	defer utils.CloseAndLog(stor)
+
+	client, err := NewLocalClient(LocalConfig{
+		Database:  "testdb",
+		Type:      storage.DatabaseTypeMySQL,
+		TargetDSN: dsn,
+	}, stor, logger)
+	require.NoError(t, err)
+	defer utils.CloseAndLog(client)
+
+	ownerApplyID, operationID := seedCutoverOperationWithTask(ctx, t, stor, state.ApplyOperation.WaitingForCutover)
+
+	// A different apply that does not own the operation.
+	now := time.Now()
+	otherApply := &storage.Apply{
+		ApplyIdentifier: fmt.Sprintf("apply-cutover-other-%d", time.Now().UnixNano()),
+		Database:        "otherdb",
+		DatabaseType:    storage.DatabaseTypeMySQL,
+		Deployment:      "otherdb",
+		Engine:          storage.EngineSpirit,
+		State:           state.Apply.WaitingForCutover,
+		Options:         storage.MarshalApplyOptions(storage.ApplyOptions{}),
+		Environment:     localClientTestEnvironment,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+	otherApplyID, err := stor.Applies().Create(ctx, otherApply)
+	require.NoError(t, err)
+	otherApply.ID = otherApplyID
+
+	err = client.ResumeApplyOperationCutover(ctx, otherApply, operationID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "belongs to apply")
+
+	owner, err := stor.Applies().Get(ctx, ownerApplyID)
+	require.NoError(t, err)
+	require.NotNil(t, owner)
+	assert.Equal(t, state.Apply.WaitingForCutover, owner.State, "a mismatched cutover claim must not touch the operation's real parent apply")
+}
+
+// A copy-phase or terminal operation must never be forced into a cutover drive;
+// only operations parked at or recovering through the cutover barrier are
+// eligible. Here the operation is still running its copy phase.
+func TestLocalClient_ResumeApplyOperationCutoverFailsClosedOnWrongState(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	_, dsn := setupMySQLContainer(t)
+	setupStorageSchema(t, dsn)
+	cleanupTasks(t, dsn)
+	cleanupTestTables(t, dsn)
+
+	ctx := t.Context()
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	stor := createStorage(t, dsn)
+	defer utils.CloseAndLog(stor)
+
+	client, err := NewLocalClient(LocalConfig{
+		Database:  "testdb",
+		Type:      storage.DatabaseTypeMySQL,
+		TargetDSN: dsn,
+	}, stor, logger)
+	require.NoError(t, err)
+	defer utils.CloseAndLog(client)
+
+	applyID, operationID := seedCutoverOperationWithTask(ctx, t, stor, state.ApplyOperation.Running)
+
+	apply, err := stor.Applies().Get(ctx, applyID)
+	require.NoError(t, err)
+	require.NotNil(t, apply)
+
+	err = client.ResumeApplyOperationCutover(ctx, apply, operationID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not parked or recovering for cutover")
+
+	after, err := stor.Applies().Get(ctx, applyID)
+	require.NoError(t, err)
+	require.NotNil(t, after)
+	assert.Equal(t, state.Apply.Running, after.State, "a copy-phase operation must not be driven through cutover")
+}
+
+// seedCutoverOperationWithTask creates a plan, apply (in opState's apply-level
+// equivalent), one operation in opState, and a single task scoped to it. It
+// returns the apply ID and operation ID so cutover trust-boundary tests have a
+// real (apply, operation, task) trio to exercise the guards against.
+func seedCutoverOperationWithTask(ctx context.Context, t *testing.T, stor storage.Storage, opState string) (int64, int64) {
+	t.Helper()
+	ddl := "ALTER TABLE `users` ADD COLUMN cutover_note VARCHAR(255)"
+	plan := &storage.Plan{
+		PlanIdentifier: fmt.Sprintf("plan-cutover-guard-%d", time.Now().UnixNano()),
+		Database:       "testdb",
+		DatabaseType:   storage.DatabaseTypeMySQL,
+		Deployment:     "testdb",
+		Environment:    localClientTestEnvironment,
+		CreatedAt:      time.Now(),
+		Namespaces: map[string]*storage.NamespacePlanData{
+			"testdb": {Tables: []storage.TableChange{{Namespace: "testdb", Table: "users", DDL: ddl, Operation: "alter"}}},
+		},
+	}
+	planID, err := stor.Plans().Create(ctx, plan)
+	require.NoError(t, err)
+
+	now := time.Now()
+	apply := &storage.Apply{
+		ApplyIdentifier: fmt.Sprintf("apply-cutover-guard-%d", time.Now().UnixNano()),
+		PlanID:          planID,
+		Database:        "testdb",
+		DatabaseType:    storage.DatabaseTypeMySQL,
+		Deployment:      "testdb",
+		Engine:          storage.EngineSpirit,
+		State:           opState,
+		Options:         storage.MarshalApplyOptions(storage.ApplyOptions{}),
+		Environment:     localClientTestEnvironment,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+	applyID, err := stor.Applies().Create(ctx, apply)
+	require.NoError(t, err)
+
+	operationID, err := stor.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID:    applyID,
+		Deployment: "testdb",
+		Target:     "testdb",
+		State:      opState,
+	})
+	require.NoError(t, err)
+
+	_, err = stor.Tasks().Create(ctx, &storage.Task{
+		TaskIdentifier:   fmt.Sprintf("task-cutover-guard-%d", time.Now().UnixNano()),
+		ApplyID:          applyID,
+		ApplyOperationID: &operationID,
+		PlanID:           planID,
+		Database:         "testdb",
+		DatabaseType:     storage.DatabaseTypeMySQL,
+		Engine:           storage.EngineSpirit,
+		State:            state.Task.WaitingForCutover,
+		TableName:        "users",
+		Namespace:        "testdb",
+		DDL:              ddl,
+		DDLAction:        "alter",
+		Options:          storage.MarshalApplyOptions(storage.ApplyOptions{}),
+		Environment:      localClientTestEnvironment,
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	})
+	require.NoError(t, err)
+
+	return applyID, operationID
+}
+
 // This scenario covers an operator-owned grouped start where the target schema
 // advances between the recovery re-plan and the final pre-dispatch schema check.
 // The operator should complete durable state without reissuing engine apply work.

--- a/pkg/tern/local_client_integration_test.go
+++ b/pkg/tern/local_client_integration_test.go
@@ -1276,6 +1276,69 @@ func TestLocalClient_ResumeApplyOperationFailsClosedOnNoTasks(t *testing.T) {
 	assert.Equal(t, state.Apply.Running, after.State, "a task-less operation must not mutate the parent apply state")
 }
 
+// The ordered-cutover drive is operation-scoped like the copy drive: a claim for
+// an operation that resolves to no tasks is invalid or stale and must fail
+// closed with ErrNoTasksForApplyOperation without mutating the parked parent
+// apply, so the operator can terminalize just that operation.
+func TestLocalClient_ResumeApplyOperationCutoverFailsClosedOnNoTasks(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	_, dsn := setupMySQLContainer(t)
+	setupStorageSchema(t, dsn)
+	cleanupTasks(t, dsn)
+	cleanupTestTables(t, dsn)
+
+	ctx := t.Context()
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	stor := createStorage(t, dsn)
+	defer utils.CloseAndLog(stor)
+
+	client, err := NewLocalClient(LocalConfig{
+		Database:  "testdb",
+		Type:      storage.DatabaseTypeMySQL,
+		TargetDSN: dsn,
+	}, stor, logger)
+	require.NoError(t, err)
+	defer utils.CloseAndLog(client)
+
+	now := time.Now()
+	apply := &storage.Apply{
+		ApplyIdentifier: fmt.Sprintf("apply-op-cutover-notasks-%d", time.Now().UnixNano()),
+		Database:        "testdb",
+		DatabaseType:    storage.DatabaseTypeMySQL,
+		Deployment:      "testdb",
+		Engine:          storage.EngineSpirit,
+		State:           state.Apply.WaitingForCutover,
+		Options:         storage.MarshalApplyOptions(storage.ApplyOptions{}),
+		Environment:     localClientTestEnvironment,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+	applyID, err := stor.Applies().Create(ctx, apply)
+	require.NoError(t, err)
+	apply.ID = applyID
+
+	// Insert an operation parked at the barrier but deliberately no tasks.
+	operationID, err := stor.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID:    applyID,
+		Deployment: "testdb",
+		Target:     "testdb",
+		State:      state.ApplyOperation.WaitingForCutover,
+	})
+	require.NoError(t, err)
+
+	err = client.ResumeApplyOperationCutover(ctx, apply, operationID)
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrNoTasksForApplyOperation, "the empty-operation fail-closed signal must be matchable with errors.Is")
+
+	after, err := stor.Applies().Get(ctx, applyID)
+	require.NoError(t, err)
+	require.NotNil(t, after)
+	assert.Equal(t, state.Apply.WaitingForCutover, after.State, "a task-less cutover claim must not mutate the parked parent apply state")
+}
+
 // This scenario covers an operator-owned grouped start where the target schema
 // advances between the recovery re-plan and the final pre-dispatch schema check.
 // The operator should complete durable state without reissuing engine apply work.

--- a/pkg/tern/local_control_resume.go
+++ b/pkg/tern/local_control_resume.go
@@ -820,6 +820,12 @@ func (c *LocalClient) ResumeApplyOperation(ctx context.Context, apply *storage.A
 	if op == nil {
 		return fmt.Errorf("apply_operation %d (apply %s): %w", applyOperationID, apply.ApplyIdentifier, ErrApplyOperationRowMissing)
 	}
+	// Trust-boundary guard: the operation must belong to the passed-in apply, or
+	// an operation-scoped drive could advance another apply's deployment under
+	// this apply's state. The routing and gRPC paths enforce the same invariant.
+	if op.ApplyID != apply.ID {
+		return fmt.Errorf("apply_operation %d belongs to apply %d, not %s (%d)", applyOperationID, op.ApplyID, apply.ApplyIdentifier, apply.ID)
+	}
 	siblings, err := c.storage.ApplyOperations().ListByApply(ctx, apply.ID)
 	if err != nil {
 		return fmt.Errorf("list apply_operations for apply %s: %w", apply.ApplyIdentifier, err)
@@ -842,6 +848,9 @@ func (c *LocalClient) ResumeApplyOperation(ctx context.Context, apply *storage.A
 // operation, so an empty result fails closed the same way ResumeApplyOperation
 // does rather than failing the whole parent apply.
 func (c *LocalClient) ResumeApplyOperationCutover(ctx context.Context, apply *storage.Apply, applyOperationID int64) error {
+	if apply == nil {
+		return fmt.Errorf("stored apply is required to drive apply_operation %d cutover", applyOperationID)
+	}
 	tasks, err := c.storage.Tasks().GetByApplyOperationID(ctx, applyOperationID)
 	if err != nil {
 		return fmt.Errorf("get tasks for apply_operation %d (apply %s): %w", applyOperationID, apply.ApplyIdentifier, err)
@@ -855,6 +864,17 @@ func (c *LocalClient) ResumeApplyOperationCutover(ctx context.Context, apply *st
 	}
 	if op == nil {
 		return fmt.Errorf("apply_operation %d (apply %s): %w", applyOperationID, apply.ApplyIdentifier, ErrApplyOperationRowMissing)
+	}
+	// Trust-boundary guard: the operation must belong to the passed-in apply, or
+	// the cutover drive could force another apply's deployment through its swap
+	// under this apply's state. The routing and gRPC paths enforce the same.
+	if op.ApplyID != apply.ID {
+		return fmt.Errorf("apply_operation %d belongs to apply %d, not %s (%d)", applyOperationID, op.ApplyID, apply.ApplyIdentifier, apply.ID)
+	}
+	// Fail closed unless the operation is actually in a cutover phase. A
+	// copy-phase or terminal operation must never be forced into a cutover drive.
+	if !isCutoverDriveState(op.State) {
+		return fmt.Errorf("apply_operation %d (apply %s) is in state %q, not parked or recovering for cutover", applyOperationID, apply.ApplyIdentifier, op.State)
 	}
 	// Force the cutover: clear DeferCutover so the drive auto-triggers the swap
 	// when the engine reaches waiting_for_cutover, and never release at the

--- a/pkg/tern/local_control_resume.go
+++ b/pkg/tern/local_control_resume.go
@@ -476,6 +476,22 @@ func shouldInspectDeferredCutoverSignal(apply *storage.Apply) bool {
 		state.IsState(apply.State, state.Apply.WaitingForCutover, state.Apply.Recovering)
 }
 
+// shouldInspectCutoverSignalForResume reports whether the resume path must load
+// the engine's cutover checkpoint before driving. It is true for the normal
+// deferred-cutover recovery (shouldInspectDeferredCutoverSignal) and, in
+// addition, for an ordered-cutover drive (forceCutoverResume) of a parked
+// operation. The barrier park deliberately does not persist DeferCutover onto
+// the shared apply (it is an execution-time, per-operation decision), so the
+// stored-options check alone would miss a parked operation; the force flag
+// covers that case while still requiring the apply to actually be parked.
+func shouldInspectCutoverSignalForResume(apply *storage.Apply, forceCutoverResume bool) bool {
+	if shouldInspectDeferredCutoverSignal(apply) {
+		return true
+	}
+	return forceCutoverResume && apply != nil &&
+		state.IsState(apply.State, state.Apply.WaitingForCutover, state.Apply.Recovering)
+}
+
 func (c *LocalClient) markApplyRecovering(ctx context.Context, apply *storage.Apply, tasks []*storage.Task) error {
 	c.logger.Info("entering recovery state for deferred cutover checkpoint",
 		"apply_id", apply.ApplyIdentifier,
@@ -777,7 +793,7 @@ func (c *LocalClient) ResumeApply(ctx context.Context, apply *storage.Apply) err
 	}
 	// Whole-apply scope has no single operation to order, so the stored apply
 	// options govern the drive directly (no automatic barrier park).
-	return c.resumeApplyWithTasks(ctx, apply, tasks, apply.GetOptions().Map(), false)
+	return c.resumeApplyWithTasks(ctx, apply, tasks, apply.GetOptions().Map(), false, false)
 }
 
 // ResumeApplyOperation starts or resumes a single apply_operation (one
@@ -815,13 +831,46 @@ func (c *LocalClient) ResumeApplyOperation(ctx context.Context, apply *storage.A
 	// unchanged.
 	releaseAtCutoverBarrier := shouldReleaseAtCutoverBarrier(apply, multiOperation, op)
 	options := effectiveCopyDriveOptions(apply, multiOperation, op).Map()
-	return c.resumeApplyWithTasks(ctx, apply, tasks, options, releaseAtCutoverBarrier)
+	return c.resumeApplyWithTasks(ctx, apply, tasks, options, releaseAtCutoverBarrier, false)
+}
+
+// ResumeApplyOperationCutover drives a single apply_operation parked at the
+// cutover barrier (waiting_for_cutover) through its cutover phase. It is the
+// deployment-ordered counterpart to ResumeApplyOperation's copy drive: the
+// operator claims the parked operation whose turn it is and calls this to force
+// the high-risk swap, while siblings stay parked. Tasks are scoped to the
+// operation, so an empty result fails closed the same way ResumeApplyOperation
+// does rather than failing the whole parent apply.
+func (c *LocalClient) ResumeApplyOperationCutover(ctx context.Context, apply *storage.Apply, applyOperationID int64) error {
+	tasks, err := c.storage.Tasks().GetByApplyOperationID(ctx, applyOperationID)
+	if err != nil {
+		return fmt.Errorf("get tasks for apply_operation %d (apply %s): %w", applyOperationID, apply.ApplyIdentifier, err)
+	}
+	if len(tasks) == 0 {
+		return fmt.Errorf("apply_operation %d (apply %s): %w", applyOperationID, apply.ApplyIdentifier, ErrNoTasksForApplyOperation)
+	}
+	op, err := c.storage.ApplyOperations().Get(ctx, applyOperationID)
+	if err != nil {
+		return fmt.Errorf("get apply_operation %d (apply %s): %w", applyOperationID, apply.ApplyIdentifier, err)
+	}
+	if op == nil {
+		return fmt.Errorf("apply_operation %d (apply %s): %w", applyOperationID, apply.ApplyIdentifier, ErrApplyOperationRowMissing)
+	}
+	// Force the cutover: clear DeferCutover so the drive auto-triggers the swap
+	// when the engine reaches waiting_for_cutover, and never release at the
+	// barrier (this drive *is* the ordered-cutover claim, not the copy park).
+	// The barrier park deliberately does not persist DeferCutover onto the
+	// shared apply, so forceCutoverResume tells the resume path to still load
+	// the parked engine checkpoint before driving.
+	opts := apply.GetOptions()
+	opts.DeferCutover = false
+	return c.resumeApplyWithTasks(ctx, apply, tasks, opts.Map(), false, true)
 }
 
 // resumeApplyWithTasks drives an apply (or one of its operations) from the set
 // of tasks the caller has loaded. Callers choose whether tasks are scoped to the
 // whole apply or to a single operation.
-func (c *LocalClient) resumeApplyWithTasks(ctx context.Context, apply *storage.Apply, tasks []*storage.Task, options map[string]string, releaseAtCutoverBarrier bool) error {
+func (c *LocalClient) resumeApplyWithTasks(ctx context.Context, apply *storage.Apply, tasks []*storage.Task, options map[string]string, releaseAtCutoverBarrier bool, forceCutoverResume bool) error {
 	if len(tasks) == 0 {
 		c.logger.Warn("no tasks found for apply, marking as failed",
 			"apply_id", apply.ApplyIdentifier)
@@ -873,7 +922,7 @@ func (c *LocalClient) resumeApplyWithTasks(ctx context.Context, apply *storage.A
 		fmt.Sprintf("Recovering apply (heartbeat expired, was in %s state)", apply.State), "", "")
 
 	deferredCutoverSignalAbsent := false
-	if shouldInspectDeferredCutoverSignal(apply) {
+	if shouldInspectCutoverSignalForResume(apply, forceCutoverResume) {
 		signalExists, signalSupported, err := c.deferredCutoverSignalExists(ctx, apply)
 		if err != nil {
 			c.logger.Warn("deferred cutover recovery could not verify engine cutover signal; operator will retry",

--- a/pkg/tern/routing_client.go
+++ b/pkg/tern/routing_client.go
@@ -315,6 +315,24 @@ func (c *RoutingClient) ResumeApplyOperation(ctx context.Context, apply *storage
 	return client.ResumeApplyOperation(ctx, operationScopedApply(apply, operation), applyOperationID)
 }
 
+// ResumeApplyOperationCutover drives one parked operation through its cutover
+// phase, routing to the deployment's client just like ResumeApplyOperation.
+func (c *RoutingClient) ResumeApplyOperationCutover(ctx context.Context, apply *storage.Apply, applyOperationID int64) error {
+	if apply == nil {
+		return fmt.Errorf("stored apply is required for routing")
+	}
+	operation, err := c.loadApplyOperation(ctx, apply, applyOperationID)
+	if err != nil {
+		return err
+	}
+	client, err := c.clientForDeployment(ctx, operation.Deployment, apply.Environment)
+	if err != nil {
+		return fmt.Errorf("get client for apply %q operation %d deployment %q environment %q: %w", apply.ApplyIdentifier, applyOperationID, operation.Deployment, apply.Environment, err)
+	}
+	c.attachObserver(client, apply.ID)
+	return client.ResumeApplyOperationCutover(ctx, operationScopedApply(apply, operation), applyOperationID)
+}
+
 // Endpoint returns a descriptive endpoint for the routing wrapper.
 func (c *RoutingClient) Endpoint() string { return "routing" }
 

--- a/pkg/tern/routing_client_test.go
+++ b/pkg/tern/routing_client_test.go
@@ -51,17 +51,18 @@ func (l routingApplyOperationLookup) ListByApply(_ context.Context, applyID int6
 type routingRecordingClient struct {
 	Client
 
-	pullSchemaReq      *ternv1.PullSchemaRequest
-	planReq            *ternv1.PlanRequest
-	applyReq           *ternv1.ApplyRequest
-	applyErr           error
-	progressReq        *ternv1.ProgressRequest
-	resumeApply        *storage.Apply
-	resumeOperationID  int64
-	pendingObserverSet bool
-	pendingObserver    ProgressObserver
-	observerApplyID    int64
-	isRemote           bool
+	pullSchemaReq            *ternv1.PullSchemaRequest
+	planReq                  *ternv1.PlanRequest
+	applyReq                 *ternv1.ApplyRequest
+	applyErr                 error
+	progressReq              *ternv1.ProgressRequest
+	resumeApply              *storage.Apply
+	resumeOperationID        int64
+	resumeCutoverOperationID int64
+	pendingObserverSet       bool
+	pendingObserver          ProgressObserver
+	observerApplyID          int64
+	isRemote                 bool
 }
 
 func (c *routingRecordingClient) PullSchema(_ context.Context, req *ternv1.PullSchemaRequest) (*ternv1.PullSchemaResponse, error) {
@@ -95,6 +96,12 @@ func (c *routingRecordingClient) ResumeApply(_ context.Context, apply *storage.A
 func (c *routingRecordingClient) ResumeApplyOperation(_ context.Context, apply *storage.Apply, applyOperationID int64) error {
 	c.resumeApply = apply
 	c.resumeOperationID = applyOperationID
+	return nil
+}
+
+func (c *routingRecordingClient) ResumeApplyOperationCutover(_ context.Context, apply *storage.Apply, applyOperationID int64) error {
+	c.resumeApply = apply
+	c.resumeCutoverOperationID = applyOperationID
 	return nil
 }
 
@@ -695,6 +702,45 @@ func TestRoutingClientResumeApplyOperationRoutesByStoredOperation(t *testing.T) 
 	assert.Equal(t, "east", apply.Deployment)
 	assert.Equal(t, "target-east", apply.GetOptions().Target)
 	assert.Equal(t, int64(7), clients["west/staging"].resumeOperationID)
+	assert.Equal(t, int64(42), clients["west/staging"].observerApplyID)
+}
+
+func TestRoutingClientResumeApplyOperationCutoverRoutesByStoredOperation(t *testing.T) {
+	clients := map[string]*routingRecordingClient{
+		"east/staging": {},
+		"west/staging": {},
+	}
+	apply := &storage.Apply{
+		ID:              42,
+		ApplyIdentifier: "apply-123",
+		Deployment:      "east",
+		Environment:     "staging",
+	}
+	apply.SetOptions(storage.ApplyOptions{Target: "target-east"})
+	routingClient := newTestRoutingClient(t, RoutingClientConfig{
+		Resolver:    routingResolverFunc(func(context.Context, routing.Request) ([]routing.ExecutionTarget, error) { return nil, nil }),
+		PlanLookup:  routingPlanLookup{},
+		ApplyLookup: routingApplyLookup{},
+		ApplyOperationLookup: routingApplyOperationLookup{
+			7: {
+				ID:         7,
+				ApplyID:    42,
+				Deployment: "west",
+				Target:     "target-west",
+			},
+		},
+		ClientForDeployment: testDeploymentClientFunc(clients),
+	})
+	routingClient.SetObserver(42, routingNoopObserver{})
+
+	err := routingClient.ResumeApplyOperationCutover(t.Context(), apply, 7)
+
+	require.NoError(t, err)
+	assert.Nil(t, clients["east/staging"].resumeApply)
+	require.NotNil(t, clients["west/staging"].resumeApply)
+	assert.Equal(t, "west", clients["west/staging"].resumeApply.Deployment)
+	assert.Equal(t, "target-west", clients["west/staging"].resumeApply.GetOptions().Target)
+	assert.Equal(t, int64(7), clients["west/staging"].resumeCutoverOperationID)
 	assert.Equal(t, int64(42), clients["west/staging"].observerApplyID)
 }
 

--- a/pkg/tern/target_router.go
+++ b/pkg/tern/target_router.go
@@ -310,6 +310,17 @@ func (r *TargetRouter) ResumeApplyOperation(ctx context.Context, apply *storage.
 	return client.ResumeApplyOperation(ctx, apply, applyOperationID)
 }
 
+// ResumeApplyOperationCutover drives one parked apply operation through its
+// cutover phase by routing through its stored target.
+func (r *TargetRouter) ResumeApplyOperationCutover(ctx context.Context, apply *storage.Apply, applyOperationID int64) error {
+	client, err := r.clientForStoredApply(ctx, apply)
+	if err != nil {
+		return err
+	}
+	r.attachObserver(client, apply.ID)
+	return client.ResumeApplyOperationCutover(ctx, apply, applyOperationID)
+}
+
 // Endpoint returns a descriptive endpoint for the router.
 func (r *TargetRouter) Endpoint() string { return "target-router" }
 

--- a/pkg/tern/target_router_test.go
+++ b/pkg/tern/target_router_test.go
@@ -143,6 +143,11 @@ func (c *targetRouterRecordingClient) ResumeApplyOperation(_ context.Context, ap
 	return nil
 }
 
+func (c *targetRouterRecordingClient) ResumeApplyOperationCutover(_ context.Context, apply *storage.Apply, _ int64) error {
+	c.resumeApply = apply
+	return nil
+}
+
 func (c *targetRouterRecordingClient) Endpoint() string { return "recording" }
 
 func (c *targetRouterRecordingClient) IsRemote() bool { return false }


### PR DESCRIPTION
## What

New tern `Client` entrypoint `ResumeApplyOperationCutover` that resumes a single
apply operation **parked at the cutover barrier** (`waiting_for_cutover`) and
forces it through the swap: `waiting_for_cutover → cutting_over → revert_window →
completed`, while sibling operations stay parked.

- Clears `DeferCutover` in execution-time options + passes
  `releaseAtCutoverBarrier=false` so the existing atomic poll auto-triggers
  cutover and never re-parks.
- Adds a `forceCutoverResume` flag (consumed only by the new
  `shouldInspectCutoverSignalForResume` gate) so the drive loads the parked
  engine checkpoint.
- Routing / target-router wrappers pass through; gRPC fails closed
  (`ErrOperationCutoverUnsupportedRemote`).
- Operation-scoped: a claim resolving to no tasks fails closed without touching
  the parent apply.

## Why

This is the deployment-ordered counterpart to the existing copy drive. The
barrier park (OC-2) stops the copy phase but nothing drives the ordered cutover
yet; this slice supplies that drive. The park deliberately does not persist
`DeferCutover` onto the shared apply, so the resume path needs an explicit signal
to re-enter the checkpoint branch — hence `forceCutoverResume`.

Additive and **dormant**: no caller until the operator cutover claim (OC-3b)
wires it in. Remote (gRPC) park/drive is a deliberate follow-up.

```diagram
ResumeApplyOperationCutover(apply, opID)
  ├─ scope tasks to op  → fail closed if none
  ├─ opts.DeferCutover = false               (force the swap)
  └─ resumeApplyWithTasks(releaseAtCutoverBarrier=false, forceCutoverResume=true)
        └─ shouldInspectCutoverSignalForResume   ← loads parked checkpoint,
           then atomic poll auto-triggers cutover (no re-park)
```

## Testing

Unit (shouldInspectCutoverSignalForResume, gRPC sentinel, routing passthrough)
- local integration fail-closed. go build, go vet, make lint clean.
