### PR TITLE
fix(tern): serve progress from storage for instance-local engines

### DIFF
--- a/e2e/k8s/dataplane_progress_ownership_test.go
+++ b/e2e/k8s/dataplane_progress_ownership_test.go
@@ -1,0 +1,245 @@
+//go:build e2e
+
+package k8s
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/block/schemabot/e2e/testutil"
+	ternv1 "github.com/block/schemabot/pkg/proto/ternv1"
+	"github.com/block/schemabot/pkg/state"
+	"github.com/block/spirit/pkg/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+)
+
+// TestK8s_ProgressFromNonOwningPodDoesNotCorruptApply verifies that when one
+// logical data-plane route is served by multiple instances sharing storage, a
+// Progress request answered by an instance that is NOT executing the queried
+// schema change cannot report or persist a terminal state while the owning
+// instance is still copying rows.
+//
+// Each instance holds its own in-memory Spirit engine. An instance that has
+// finished an unrelated schema change still holds that completed state in
+// memory. If a Progress request for a different, in-flight apply is balanced
+// onto it, it must fall back to shared stored state rather than trusting its own
+// engine — otherwise it would report another schema change's terminal state and
+// drive the in-flight apply's shared record to completed before its DDL has been
+// applied, causing the owning instance to abandon the still-running copy.
+//
+// The control-plane gRPC client pins to a single data-plane instance, so this
+// test drives plan/apply/progress against specific pods directly to place the
+// owning and non-owning roles deterministically, the same way production
+// service-mesh load balancing can spread Progress across instances.
+func TestK8s_ProgressFromNonOwningPodDoesNotCorruptApply(t *testing.T) {
+	cleanupState(t)
+
+	pods := podNamesForInstance(t, "data-plane")
+	require.GreaterOrEqual(t, len(pods), 2, "expected k8s e2e data plane to run at least two replicas")
+
+	ownerClient := dialDataPlanePod(t, pods[0])
+	nonOwnerClient := dialDataPlanePod(t, pods[1])
+
+	targetDSN := testutil.TernStagingDSN(t)
+	ternDSN := storageDSNs(t)[0]
+
+	// Prime the non-owning instance with a completed schema change so its
+	// in-memory engine holds terminal state for an unrelated schema change.
+	primeTable := testutil.UniqueTableName("dp_prime")
+	createIndexAddTable(t, primeTable, targetDSN, 2000)
+	_, primeApplyID := planAndApplyIndexOnPod(t, nonOwnerClient, primeTable)
+	waitForPodApplyState(t, nonOwnerClient, primeApplyID, ternv1.State_STATE_COMPLETED, 3*time.Minute)
+
+	// Start a long-running schema change on the owning instance and let it reach
+	// the row-copy phase so it is unambiguously in flight.
+	longTable := testutil.UniqueTableName("dp_long")
+	createIndexAddTable(t, longTable, targetDSN, 500000)
+	_, longApplyID := planAndApplyIndexOnPod(t, ownerClient, longTable)
+	waitForPodRowCopyInFlight(t, ownerClient, longApplyID, longTable)
+
+	// While the owning instance is still copying, repeatedly ask the non-owning
+	// instance — whose engine holds the primed schema change's completed state —
+	// for the long apply's progress. It must never report the apply terminal,
+	// never drive the shared record terminal, and never let the index appear
+	// before the owner finishes the copy.
+	observedInFlight := false
+	for range 20 {
+		ownerResp := podProgress(t, ownerClient, longApplyID)
+		if ownerResp.State == ternv1.State_STATE_COMPLETED {
+			break
+		}
+		require.Equal(t, ternv1.State_STATE_RUNNING, ownerResp.State,
+			"owning instance should still be running the long apply")
+		observedInFlight = true
+
+		nonOwnerResp := podProgress(t, nonOwnerClient, longApplyID)
+		assert.NotEqual(t, ternv1.State_STATE_COMPLETED, nonOwnerResp.State,
+			"non-owning instance reported the in-flight apply as completed")
+		assert.NotEqual(t, ternv1.State_STATE_FAILED, nonOwnerResp.State,
+			"non-owning instance reported the in-flight apply as failed")
+
+		applyState, _ := storedK8sApplyAndTaskStates(t, ternDSN, longApplyID)
+		assert.False(t, state.IsTerminalApplyState(applyState),
+			"non-owning instance drove the shared apply record terminal (%s) while the copy was in flight", applyState)
+
+		// The index must not have been applied while the copy is still in flight.
+		assert.False(t, indexExists(t, targetDSN, longTable, "idx_account_created"),
+			"index was applied before the row copy finished")
+	}
+	require.True(t, observedInFlight, "expected to observe the long schema change in flight on the owning instance")
+
+	// The owning instance finishes the apply correctly.
+	waitForPodApplyState(t, ownerClient, longApplyID, ternv1.State_STATE_COMPLETED, 3*time.Minute)
+	waitForIndex(t, targetDSN, longTable, "idx_account_created", testutil.PollDeadline)
+}
+
+// dialDataPlanePod port-forwards a single data-plane pod's gRPC port and returns
+// a Tern client bound to that specific instance.
+func dialDataPlanePod(t *testing.T, pod string) ternv1.TernClient {
+	t.Helper()
+	address := startDataPlanePodGRPCPortForward(t, pod)
+	conn, err := grpc.NewClient(address, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	t.Cleanup(func() { utils.CloseAndLog(conn) })
+	client := ternv1.NewTernClient(conn)
+	waitForPodGRPCReady(t, client)
+	return client
+}
+
+// waitForPodGRPCReady waits for the pod's port-forward to accept connections.
+// kubectl port-forward returns before the tunnel is established and grpc dials
+// lazily, so the first RPC can hit a refused connection. A sentinel Progress
+// call resolves once the transport is up — any application-level response (the
+// apply is not found) means the connection works; only a transport-level
+// Unavailable means the forward is not ready yet.
+func waitForPodGRPCReady(t *testing.T, client ternv1.TernClient) {
+	t.Helper()
+	var lastErr error
+	testutil.Poll(t, testutil.PollDeadline, testutil.PollInterval,
+		func() bool {
+			ctx, cancel := context.WithTimeout(t.Context(), testutil.ProgressTimeout)
+			defer cancel()
+			_, lastErr = client.Progress(ctx, &ternv1.ProgressRequest{ApplyId: "readiness-probe", Environment: "staging"})
+			return status.Code(lastErr) != codes.Unavailable
+		},
+		func() string {
+			return fmt.Sprintf("data-plane pod gRPC port-forward never became ready: %v", lastErr)
+		})
+}
+
+// createIndexAddTable creates the index-add fixture table on the target and
+// seeds it so the eventual index add has a measurable row-copy phase.
+func createIndexAddTable(t *testing.T, tableName, targetDSN string, rowCount int) {
+	t.Helper()
+	testutil.CreateTestTableWithCleanup(t, targetDSN, tableName, fmt.Sprintf(
+		`CREATE TABLE %s (id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY, account_id BIGINT NOT NULL, event_type VARCHAR(100) NOT NULL, created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci`, tableName),
+		storageDSNs(t)...)
+	testutil.SeedRows(t, targetDSN, tableName, "account_id, event_type",
+		"FLOOR(1 + RAND() * 100000), ELT(FLOOR(1 + RAND() * 5), 'type_a', 'type_b', 'type_c', 'type_d', 'type_e')", rowCount)
+}
+
+// planAndApplyIndexOnPod plans and applies an index add for the given table
+// directly against one data-plane instance, making that instance the owner of
+// the resulting apply. Returns the data-plane plan and apply identifiers.
+func planAndApplyIndexOnPod(t *testing.T, client ternv1.TernClient, tableName string) (planID, applyID string) {
+	t.Helper()
+	schemaFiles := map[string]*ternv1.SchemaFiles{
+		"testapp": {Files: map[string]string{
+			tableName + ".sql": fmt.Sprintf(
+				`CREATE TABLE %s (id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY, account_id BIGINT NOT NULL, event_type VARCHAR(100) NOT NULL, created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP, KEY idx_account_created (account_id, created_at)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;`, tableName),
+		}},
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancel()
+	planResp, err := client.Plan(ctx, &ternv1.PlanRequest{
+		Database:    "testapp",
+		Type:        "mysql",
+		Environment: "staging",
+		SchemaFiles: schemaFiles,
+	})
+	require.NoError(t, err, "plan on data-plane pod")
+	require.NotEmpty(t, planResp.PlanId, "plan on data-plane pod returned no changes")
+
+	applyCtx, applyCancel := context.WithTimeout(t.Context(), 30*time.Second)
+	defer applyCancel()
+	applyResp, err := client.Apply(applyCtx, &ternv1.ApplyRequest{
+		PlanId:      planResp.PlanId,
+		Environment: "staging",
+		Caller:      "e2e",
+	})
+	require.NoError(t, err, "apply on data-plane pod")
+	require.True(t, applyResp.Accepted, "apply not accepted: %s", applyResp.ErrorMessage)
+	require.NotEmpty(t, applyResp.ApplyId, "apply on data-plane pod returned empty apply id")
+	return planResp.PlanId, applyResp.ApplyId
+}
+
+// podProgress fetches progress for an apply from a specific data-plane instance.
+func podProgress(t *testing.T, client ternv1.TernClient, applyID string) *ternv1.ProgressResponse {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(t.Context(), testutil.ProgressTimeout)
+	defer cancel()
+	resp, err := client.Progress(ctx, &ternv1.ProgressRequest{ApplyId: applyID, Environment: "staging"})
+	require.NoError(t, err, "progress from data-plane pod")
+	return resp
+}
+
+// waitForPodApplyState polls a specific instance until the apply reaches the
+// expected state.
+func waitForPodApplyState(t *testing.T, client ternv1.TernClient, applyID string, expected ternv1.State, timeout time.Duration) {
+	t.Helper()
+	var last ternv1.State
+	testutil.Poll(t, timeout, testutil.PollInterval,
+		func() bool {
+			last = podProgress(t, client, applyID).State
+			return last == expected
+		},
+		func() string {
+			return fmt.Sprintf("timeout waiting for apply %s to reach %s on data-plane pod, last state: %s", applyID, expected, last)
+		})
+}
+
+// waitForPodRowCopyInFlight polls a specific instance until the apply is running
+// with the table's row copy underway, so callers can act while it is in flight.
+func waitForPodRowCopyInFlight(t *testing.T, client ternv1.TernClient, applyID, tableName string) {
+	t.Helper()
+	var last *ternv1.ProgressResponse
+	testutil.Poll(t, 2*time.Minute, testutil.PollInterval,
+		func() bool {
+			last = podProgress(t, client, applyID)
+			if last.State != ternv1.State_STATE_RUNNING {
+				return false
+			}
+			for _, table := range last.Tables {
+				if table.TableName == tableName && hasRowCopyProgress(table.RowsTotal, table.RowsCopied, table.PercentComplete) {
+					return true
+				}
+			}
+			return false
+		},
+		func() string {
+			return fmt.Sprintf("timeout waiting for apply %s row copy to be in flight on %s: last=%v", applyID, tableName, last)
+		})
+}
+
+// indexExists reports whether the named index is present on the table.
+func indexExists(t *testing.T, dsn, tableName, indexName string) bool {
+	t.Helper()
+	db, err := sql.Open("mysql", dsn)
+	require.NoError(t, err)
+	defer utils.CloseAndLog(db)
+	require.NoError(t, db.PingContext(t.Context()))
+
+	rows, err := db.QueryContext(t.Context(), fmt.Sprintf("SHOW INDEX FROM `%s` WHERE Key_name = ?", tableName), indexName)
+	require.NoError(t, err)
+	defer utils.CloseAndLog(rows)
+	return rows.Next()
+}

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -84,6 +84,30 @@ type DeferredCutoverSignalChecker interface {
 	DeferredCutoverSignalExists(ctx context.Context, req *DeferredCutoverSignalRequest) (bool, error)
 }
 
+// ExternallyAuthoritativeProgress is an optional interface for engines whose
+// Progress result reflects authoritative external state (for example a remote
+// online-DDL service) rather than instance-local in-memory state.
+//
+// This distinction matters when one logical data-plane route is served by
+// multiple instances that share storage. A progress request can be balanced
+// onto any instance. An engine that reads progress from instance-local memory
+// only knows about the schema change that instance is running, so a request
+// served by another instance would observe unrelated or stale state — its
+// progress must instead come from shared storage, which the instance driving
+// the schema change keeps current. An engine that reads progress from external
+// authoritative state returns the same correct answer on every instance, so it
+// may be queried directly regardless of which instance answers.
+//
+// Engines that do not implement this interface are treated as instance-local:
+// their progress is served from shared storage. This fails closed — a new
+// engine is never trusted cross-instance unless it explicitly declares its
+// progress authoritative.
+type ExternallyAuthoritativeProgress interface {
+	// ProgressIsExternallyAuthoritative reports whether this engine's Progress
+	// result is correct regardless of which instance answers.
+	ProgressIsExternallyAuthoritative() bool
+}
+
 // DeferredCutoverSignalRequest identifies the target database whose deferred
 // cutover signal should be inspected.
 type DeferredCutoverSignalRequest struct {

--- a/pkg/engine/planetscale/planetscale.go
+++ b/pkg/engine/planetscale/planetscale.go
@@ -534,6 +534,16 @@ type Engine struct {
 
 // Compile-time check that Engine implements the interface.
 var _ engine.Engine = (*Engine)(nil)
+var _ engine.ExternallyAuthoritativeProgress = (*Engine)(nil)
+
+// ProgressIsExternallyAuthoritative reports that PlanetScale progress is read
+// from PlanetScale's deploy-request and VITESS_MIGRATIONS state rather than
+// instance-local memory, so any instance returns the same correct result and
+// the progress read path may query the engine directly regardless of which
+// instance owns the schema change.
+func (e *Engine) ProgressIsExternallyAuthoritative() bool {
+	return true
+}
 
 // New creates a new PlanetScale engine with the given logger.
 func New(logger *slog.Logger) *Engine {

--- a/pkg/tern/local_client.go
+++ b/pkg/tern/local_client.go
@@ -1419,6 +1419,26 @@ func (c *LocalClient) getEngine() engine.Engine {
 	}
 }
 
+// engineProgressIsExternallyAuthoritative reports whether the progress read path
+// may query the engine directly for live progress, or must serve progress from
+// shared storage instead.
+//
+// One logical data-plane route can be served by multiple instances that share
+// storage. A progress request can be balanced onto any instance. An engine
+// whose progress comes from instance-local memory only knows the schema change
+// that instance is running, so an instance that is not driving the queried
+// schema change would observe unrelated or stale state — its progress must come
+// from storage, which the driving instance keeps current. An engine whose
+// progress comes from authoritative external state returns the same correct
+// result on every instance and may be queried directly.
+//
+// This fails closed: an engine that does not declare its progress authoritative
+// is served from storage.
+func engineProgressIsExternallyAuthoritative(eng engine.Engine) bool {
+	source, ok := eng.(engine.ExternallyAuthoritativeProgress)
+	return ok && source.ProgressIsExternallyAuthoritative()
+}
+
 // Progress returns detailed progress for an active schema change.
 // Returns ALL tasks for the current apply: completed, running, and pending.
 // req.ApplyId is required so progress is always scoped to a single apply.
@@ -1545,7 +1565,17 @@ func (c *LocalClient) Progress(ctx context.Context, req *ternv1.ProgressRequest)
 	if queryDuringPending && activeTask.State == state.Task.Pending {
 		queryLiveProgress = true
 	}
-	if eng != nil && queryLiveProgress {
+	// Live engine progress is read only when the engine's progress is
+	// authoritative on any instance. Instance-local engines (Spirit) are served
+	// from stored progress, which the instance driving the schema change keeps
+	// current, so a progress request balanced onto a non-driving instance cannot
+	// observe unrelated or stale engine state.
+	serveEngineProgress := eng != nil && queryLiveProgress && engineProgressIsExternallyAuthoritative(eng)
+	if eng != nil && queryLiveProgress && !serveEngineProgress {
+		c.logger.Debug("Progress: serving stored progress; engine progress is instance-local",
+			"apply_id", apply.ApplyIdentifier, "task_id", activeTask.TaskIdentifier, "database", c.config.Database)
+	}
+	if serveEngineProgress {
 		progressReq := &engine.ProgressRequest{
 			Database:    c.config.Database,
 			Credentials: creds,

--- a/pkg/tern/local_client_integration_test.go
+++ b/pkg/tern/local_client_integration_test.go
@@ -1613,6 +1613,10 @@ func TestLocalClient_ResumeApplyDeferredCutoverRecoveryPreservesCutoverReadyStor
 	require.NotNil(t, storedTask)
 	assert.Equal(t, state.Task.Recovering, storedTask.State)
 
+	// The read path never advances recovery state from the engine — surfacing
+	// cutover readiness is the apply owner's job. Even when the engine reports
+	// the schema change is waiting for cutover, progress reflects the stored
+	// recovery state until the owner persists the transition.
 	recoveryEngine.progress = &engine.ProgressResult{
 		State: engine.StateWaitingForCutover,
 		Tables: []engine.TableProgress{{
@@ -1622,6 +1626,26 @@ func TestLocalClient_ResumeApplyDeferredCutoverRecoveryPreservesCutoverReadyStor
 			Progress:  100,
 		}},
 	}
+	progressResp, err = client.Progress(ctx, &ternv1.ProgressRequest{
+		ApplyId:     apply.ApplyIdentifier,
+		Environment: localClientTestEnvironment,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, ternv1.State_STATE_RECOVERING, progressResp.State)
+
+	// Once the owner reattach loop proves cutover readiness and persists it,
+	// progress reflects the cutover-ready state from storage on any instance.
+	storedTask, err = stor.Tasks().Get(ctx, task.TaskIdentifier)
+	require.NoError(t, err)
+	require.NotNil(t, storedTask)
+	storedTask.State = state.Task.WaitingForCutover
+	require.NoError(t, stor.Tasks().Update(ctx, storedTask))
+	storedApply, err = stor.Applies().Get(ctx, applyID)
+	require.NoError(t, err)
+	require.NotNil(t, storedApply)
+	storedApply.State = state.Apply.WaitingForCutover
+	require.NoError(t, stor.Applies().Update(ctx, storedApply))
+
 	progressResp, err = client.Progress(ctx, &ternv1.ProgressRequest{
 		ApplyId:     apply.ApplyIdentifier,
 		Environment: localClientTestEnvironment,

--- a/pkg/tern/local_client_test.go
+++ b/pkg/tern/local_client_test.go
@@ -326,20 +326,28 @@ func (s *exactProgressTaskStore) Update(context.Context, *storage.Task) error {
 
 type fakeControlEngine struct {
 	engine.Engine
-	stopCount      int
-	startCount     int
-	cutoverCount   int
-	cutoverResult  *engine.ControlResult
-	cutoverErr     error
-	progressReq    *engine.ProgressRequest
-	progressResult *engine.ProgressResult
-	progressErr    error
-	planResult     *engine.PlanResult
-	applyResult    *engine.ApplyResult
-	applyErr       error
+	stopCount               int
+	startCount              int
+	cutoverCount            int
+	cutoverResult           *engine.ControlResult
+	cutoverErr              error
+	progressReq             *engine.ProgressRequest
+	progressResult          *engine.ProgressResult
+	progressErr             error
+	planResult              *engine.PlanResult
+	applyResult             *engine.ApplyResult
+	applyErr                error
+	externallyAuthoritative bool
 }
 
 func (e *fakeControlEngine) Name() string { return "fake" }
+
+// ProgressIsExternallyAuthoritative models an engine whose progress is read from
+// authoritative external state (like PlanetScale) when set, so the progress read
+// path queries it directly instead of serving from stored progress.
+func (e *fakeControlEngine) ProgressIsExternallyAuthoritative() bool {
+	return e.externallyAuthoritative
+}
 
 func (e *fakeControlEngine) Plan(context.Context, *engine.PlanRequest) (*engine.PlanResult, error) {
 	if e.planResult != nil {
@@ -629,7 +637,7 @@ func TestLocalClient_VitessProgressRequiresEngineResumeState(t *testing.T) {
 		TableName:        "users",
 		State:            state.Task.Running,
 	}
-	eng := &fakeControlEngine{}
+	eng := &fakeControlEngine{externallyAuthoritative: true}
 	client := &LocalClient{
 		config: LocalConfig{
 			Database: "testdb",
@@ -677,7 +685,7 @@ func TestLocalClient_VitessProgressPassesAndPersistsEngineResumeState(t *testing
 	}
 	updatedMetadata := `{"branch_name":"branch-123","deploy_request_id":321,"deploy_request_url":"https://example.test/deploys/321","is_instant":true}`
 	applyOperations := &exactProgressApplyOperationStore{data: storedResumeState}
-	eng := &fakeControlEngine{progressResult: &engine.ProgressResult{
+	eng := &fakeControlEngine{externallyAuthoritative: true, progressResult: &engine.ProgressResult{
 		State: engine.StateRunning,
 		ResumeState: &engine.ResumeState{
 			MigrationContext: "ctx-123",

--- a/pkg/tern/progress_ownership_test.go
+++ b/pkg/tern/progress_ownership_test.go
@@ -1,0 +1,60 @@
+package tern
+
+import (
+	"testing"
+
+	"github.com/block/schemabot/pkg/engine"
+	"github.com/stretchr/testify/assert"
+)
+
+// authoritativeEngine models an engine whose progress is read from authoritative
+// external state (e.g. a remote online-DDL service), so it is correct on any
+// instance.
+type authoritativeEngine struct {
+	engine.Engine
+	authoritative bool
+}
+
+func (e *authoritativeEngine) ProgressIsExternallyAuthoritative() bool {
+	return e.authoritative
+}
+
+// instanceLocalEngine models an engine whose progress comes from instance-local
+// memory and does not declare the capability at all.
+type instanceLocalEngine struct {
+	engine.Engine
+}
+
+// The progress read path may query an engine directly only when that engine's
+// progress is authoritative regardless of which instance answers. Instance-local
+// engines must be served from shared storage instead, and an engine that does
+// not declare the capability must default to storage (fail closed).
+func TestEngineProgressIsExternallyAuthoritative(t *testing.T) {
+	tests := []struct {
+		name string
+		eng  engine.Engine
+		want bool
+	}{
+		{
+			name: "engine declaring authoritative progress is queried directly",
+			eng:  &authoritativeEngine{authoritative: true},
+			want: true,
+		},
+		{
+			name: "engine declaring non-authoritative progress is served from storage",
+			eng:  &authoritativeEngine{authoritative: false},
+			want: false,
+		},
+		{
+			name: "engine without the capability defaults to storage",
+			eng:  &instanceLocalEngine{},
+			want: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, engineProgressIsExternallyAuthoritative(tc.eng))
+		})
+	}
+}


### PR DESCRIPTION
## Why this matters

When a data-plane route is served by multiple instances that share storage, each instance holds its own in-memory Spirit engine, but any instance can answer a `Progress` request. The read path queried whichever instance's engine answered — so a request balanced onto an instance that was **not** running the queried schema change observed unrelated or stale state: it advanced the active task to that engine's state and could mark the apply terminal in shared storage. The instance actually driving the apply then saw its record terminal and abandoned the still-running copy, reporting the apply complete before its DDL was applied.

## What it does

Progress is now served from **shared storage**, which the instance driving the schema change keeps current — so it is correct on any instance.

```
                Progress (any instance)
                        |
                        v
              +-------------------+        the driving instance writes
              |  shared storage   | <----- live progress + terminal state
              +-------------------+        (only it touches the engine)
                        ^
   every other instance reads storage; none touch a foreign engine
```

The read path only queries an engine directly when that engine's progress reflects **authoritative external state** and is therefore correct regardless of which instance answers. That is declared via the optional `engine.ExternallyAuthoritativeProgress` interface:

- **Spirit (MySQL)** — instance-local in-memory progress → not implemented → served from storage (storage already holds row counts, percent, ETA, state, written by the driving instance every poll).
- **PlanetScale (Vitess)** — progress read from the deploy request / `VITESS_MIGRATIONS` → implements the interface → queried directly on any instance, preserving per-shard detail that storage does not hold.

This **fails closed**: a new engine is served from storage unless it explicitly declares its progress authoritative. It mirrors how durable control requests are owned — storage is the cross-instance source of truth, and only the instance driving the schema change touches its in-memory engine and advances stored state. It also stays open to serving every engine from storage later (e.g. once per-shard progress is persisted, PlanetScale can drop the declaration).

## Safety

Started applies remain authoritative: terminal state is written only by the instance driving the apply, never inferred from an unrelated instance's engine.

Includes a k8s e2e regression test that serves a progress request from an instance not running an in-flight schema change and asserts it cannot report or persist a terminal state, plus unit coverage for the storage-vs-engine gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)