### PR TITLE
fix(tern): route data-plane cutover to the apply owner through storage

### DIFF
--- a/pkg/tern/cutover_ownership_test.go
+++ b/pkg/tern/cutover_ownership_test.go
@@ -1,0 +1,52 @@
+package tern
+
+import (
+	"log/slog"
+	"testing"
+
+	ternv1 "github.com/block/schemabot/pkg/proto/ternv1"
+	"github.com/block/schemabot/pkg/state"
+	"github.com/block/schemabot/pkg/storage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A cutover RPC can land on any instance sharing the route's storage. It must
+// record a durable cutover request for the apply owner to process, never invoke
+// the receiving instance's local engine — which may be running a different
+// schema change or none.
+func TestCutoverQueuesRequestForOwner(t *testing.T) {
+	apply := &storage.Apply{
+		ID:              7,
+		ApplyIdentifier: "apply-cutover-queue",
+		Database:        "testdb",
+		Environment:     "staging",
+		State:           state.Apply.WaitingForCutover,
+	}
+	controlRequests := &testControlRequestStore{}
+	eng := &fakeControlEngine{}
+	client := &LocalClient{
+		config: LocalConfig{Database: "testdb", Type: storage.DatabaseTypeMySQL},
+		storage: &mockStorage{
+			applies:         &mockApplyStore{apply: apply},
+			controlRequests: controlRequests,
+		},
+		spiritEngine: eng,
+		logger:       slog.Default(),
+	}
+
+	resp, err := client.Cutover(t.Context(), &ternv1.CutoverRequest{
+		ApplyId:     apply.ApplyIdentifier,
+		Environment: "staging",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.True(t, resp.Accepted, "cutover request should be accepted (queued)")
+
+	require.Len(t, controlRequests.requests, 1, "a durable cutover request should be queued for the owner")
+	assert.Equal(t, storage.ControlOperationCutover, controlRequests.requests[0].Operation)
+	assert.Equal(t, apply.ID, controlRequests.requests[0].ApplyID)
+	assert.Equal(t, storage.ControlRequestPending, controlRequests.requests[0].Status)
+
+	assert.Zero(t, eng.cutoverCount, "the receiving instance must not invoke its local engine; the owner performs the cutover")
+}

--- a/pkg/tern/grpc_client_test.go
+++ b/pkg/tern/grpc_client_test.go
@@ -598,6 +598,14 @@ type mockApplyStore struct {
 	updates   []*storage.Apply
 }
 
+func (m *mockApplyStore) GetByApplyIdentifier(context.Context, string) (*storage.Apply, error) {
+	if m.apply == nil {
+		return nil, nil
+	}
+	apply := *m.apply
+	return &apply, nil
+}
+
 func (m *mockApplyStore) Get(context.Context, int64) (*storage.Apply, error) {
 	if m.apply == nil {
 		return nil, nil

--- a/pkg/tern/local_client_integration_test.go
+++ b/pkg/tern/local_client_integration_test.go
@@ -1571,14 +1571,21 @@ func TestLocalClient_ResumeApplyDeferredCutoverRecoveryPreservesCutoverReadyStor
 	require.NoError(t, err)
 	assert.Equal(t, ternv1.State_STATE_RECOVERING, progressResp.State)
 
+	// A cutover request is queued for the apply owner; it is not performed while
+	// the apply is recovering, so storage stays in the recovery state until the
+	// owner reattaches and proves cutover readiness.
 	cutoverResp, err := client.Cutover(ctx, &ternv1.CutoverRequest{
 		ApplyId:     apply.ApplyIdentifier,
 		Environment: localClientTestEnvironment,
 	})
 	require.NoError(t, err)
 	require.NotNil(t, cutoverResp)
-	assert.False(t, cutoverResp.Accepted)
-	assert.Contains(t, cutoverResp.ErrorMessage, "recovering")
+	assert.True(t, cutoverResp.Accepted, "cutover is queued for the owner even during recovery")
+
+	storedApply, err = stor.Applies().Get(ctx, applyID)
+	require.NoError(t, err)
+	require.NotNil(t, storedApply)
+	assert.Equal(t, state.Apply.Recovering, storedApply.State, "queuing a cutover must not perform it while recovering")
 
 	recoveryEngine.progress = &engine.ProgressResult{
 		State: engine.StateRunning,

--- a/pkg/tern/local_control.go
+++ b/pkg/tern/local_control.go
@@ -13,8 +13,58 @@ import (
 )
 
 // Cutover triggers the cutover phase when defer_cutover was used.
+// Cutover queues a durable cutover request. The instance that owns the schema
+// change performs the cutover when it observes the pending request through
+// shared storage, so the request is safe on any instance serving this route.
 func (c *LocalClient) Cutover(ctx context.Context, req *ternv1.CutoverRequest) (*ternv1.CutoverResponse, error) {
-	return c.cutover(ctx, req, "")
+	return c.requestCutover(ctx, req, "")
+}
+
+// requestCutover resolves the target apply and records a durable cutover request
+// for its owner to process. It never invokes the local engine, mirroring how
+// stop and start are routed to the apply owner.
+func (c *LocalClient) requestCutover(ctx context.Context, req *ternv1.CutoverRequest, caller string) (*ternv1.CutoverResponse, error) {
+	c.logger.Info("Cutover requested", "database", c.config.Database, "type", c.config.Type, "apply_id", req.ApplyId, "environment", req.Environment, "caller", caller)
+	apply, err := c.resolveCutoverApply(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	if apply == nil {
+		return nil, fmt.Errorf("no active schema change")
+	}
+	return c.queueCutoverRequest(ctx, apply, caller)
+}
+
+// resolveCutoverApply finds the apply a cutover request targets, by apply
+// identifier when provided or by the database's active task otherwise.
+func (c *LocalClient) resolveCutoverApply(ctx context.Context, req *ternv1.CutoverRequest) (*storage.Apply, error) {
+	if req.ApplyId != "" {
+		apply, err := c.storage.Applies().GetByApplyIdentifier(ctx, req.ApplyId)
+		if err != nil {
+			return nil, fmt.Errorf("load apply %s before cutover: %w", req.ApplyId, err)
+		}
+		if apply == nil {
+			return nil, fmt.Errorf("load apply %s before cutover: %w", req.ApplyId, storage.ErrApplyNotFound)
+		}
+		return apply, nil
+	}
+
+	task, err := c.getActiveTaskForDatabase(ctx, c.config.Database)
+	if err != nil {
+		return nil, err
+	}
+	if task == nil {
+		c.logger.Info("cutover request found no active task", "database", c.config.Database, "type", c.config.Type)
+		return nil, nil
+	}
+	apply, err := c.storage.Applies().Get(ctx, task.ApplyID)
+	if err != nil {
+		return nil, fmt.Errorf("load apply %d before cutover: %w", task.ApplyID, err)
+	}
+	if apply == nil {
+		return nil, fmt.Errorf("load apply %d before cutover: %w", task.ApplyID, storage.ErrApplyNotFound)
+	}
+	return apply, nil
 }
 
 func (c *LocalClient) cutover(ctx context.Context, req *ternv1.CutoverRequest, caller string) (*ternv1.CutoverResponse, error) {
@@ -130,6 +180,49 @@ func (c *LocalClient) cutover(ctx context.Context, req *ternv1.CutoverRequest, c
 		return &ternv1.CutoverResponse{Accepted: false, ErrorMessage: errorMessage}, nil
 	}
 
+	return &ternv1.CutoverResponse{Accepted: true}, nil
+}
+
+// queueCutoverRequest records a durable cutover control request and returns
+// once it is queued. The instance that owns the schema change observes the
+// pending request through shared storage and performs the cutover, the same way
+// stop and start are routed to the owner. A cutover RPC can land on any instance
+// sharing the route's storage, so it must never act on a local engine that may
+// not be running this schema change.
+func (c *LocalClient) queueCutoverRequest(ctx context.Context, apply *storage.Apply, caller string) (*ternv1.CutoverResponse, error) {
+	controlStore := c.storage.ControlRequests()
+	if controlStore == nil {
+		return nil, fmt.Errorf("control request store is not available")
+	}
+	requestedBy := caller
+	if requestedBy == "" {
+		requestedBy = "tern-grpc"
+	}
+	_, alreadyPending, err := controlStore.RequestPending(ctx, &storage.ApplyControlRequest{
+		ApplyID:     apply.ID,
+		Operation:   storage.ControlOperationCutover,
+		Status:      storage.ControlRequestPending,
+		RequestedBy: requestedBy,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("record cutover control request for apply %s: %w", apply.ApplyIdentifier, err)
+	}
+	if alreadyPending {
+		c.logger.Info("cutover request already pending for apply owner",
+			"apply_id", apply.ApplyIdentifier,
+			"database", apply.Database,
+			"environment", apply.Environment,
+			"requested_by", requestedBy)
+	} else {
+		c.logger.Info("cutover request queued for apply owner",
+			"apply_id", apply.ApplyIdentifier,
+			"database", apply.Database,
+			"environment", apply.Environment,
+			"requested_by", requestedBy)
+		c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventCutoverTriggered, storage.LogSourceSchemaBot,
+			fmt.Sprintf("Cutover request queued for apply owner%s", callerApplyLogSuffix(requestedBy)), "", "")
+	}
+	c.wakeOperatorForControlRequest(apply)
 	return &ternv1.CutoverResponse{Accepted: true}, nil
 }
 

--- a/pkg/tern/local_control_test.go
+++ b/pkg/tern/local_control_test.go
@@ -470,9 +470,10 @@ func TestLocalClient_StopAllTasksTerminalDerivesApplyState(t *testing.T) {
 	}
 }
 
-// PlanetScale cutover must include the opaque resume state recorded for the
-// apply. If that state is missing, LocalClient returns an error before
-// invoking the engine so the storage invariant violation is visible.
+// When the apply owner performs a cutover, the request must include the opaque
+// resume state recorded for the apply. If that state is missing, the owner
+// returns an error before invoking the engine so the storage invariant
+// violation is visible.
 func TestLocalClient_CutoverRequiresEngineResumeState(t *testing.T) {
 	operationID := int64(99)
 	apply := &storage.Apply{ID: 42, ApplyIdentifier: "apply-vitess-control"}
@@ -486,7 +487,7 @@ func TestLocalClient_CutoverRequiresEngineResumeState(t *testing.T) {
 	eng := &controlCaptureEngine{}
 	client := newVitessControlTestClient(apply, []*storage.Task{task}, nil, eng)
 
-	_, err := client.Cutover(t.Context(), &ternv1.CutoverRequest{ApplyId: apply.ApplyIdentifier})
+	_, err := client.cutover(t.Context(), &ternv1.CutoverRequest{ApplyId: apply.ApplyIdentifier}, "")
 
 	require.ErrorIs(t, err, storage.ErrEngineResumeStateNotFound)
 	assert.Nil(t, eng.cutoverReq, "cutover should not call the engine without resume state")
@@ -544,7 +545,7 @@ func TestLocalClient_CutoverRequiresCompleteEngineResumeState(t *testing.T) {
 			resumeState := maybeEngineResumeStateFromPlanetScaleData(operationID, tc.resumeData)
 			client := newVitessControlTestClient(apply, []*storage.Task{task}, resumeState, eng)
 
-			_, err := client.Cutover(t.Context(), &ternv1.CutoverRequest{ApplyId: apply.ApplyIdentifier})
+			_, err := client.cutover(t.Context(), &ternv1.CutoverRequest{ApplyId: apply.ApplyIdentifier}, "")
 
 			require.ErrorContains(t, err, "cutover control resume state is incomplete")
 			require.ErrorContains(t, err, tc.missingPart)
@@ -577,7 +578,7 @@ func TestLocalClient_CutoverPassesEngineResumeState(t *testing.T) {
 	eng := &controlCaptureEngine{}
 	client := newVitessControlTestClient(apply, []*storage.Task{task}, resumeState, eng)
 
-	resp, err := client.Cutover(t.Context(), &ternv1.CutoverRequest{ApplyId: apply.ApplyIdentifier})
+	resp, err := client.cutover(t.Context(), &ternv1.CutoverRequest{ApplyId: apply.ApplyIdentifier}, "")
 
 	require.NoError(t, err)
 	assert.True(t, resp.Accepted)


### PR DESCRIPTION
## Why this matters

A cutover RPC can be load-balanced onto any instance that shares a data-plane route's storage. The Spirit engine holds schema-change state in instance-local memory, so an instance that received the RPC but is **not** running the schema change rejected the cutover from its own engine (`schema change was not started with defer_cutover`) or acted on unrelated state. Cutover only succeeded when the RPC happened to land on the owning instance.

This is the same instance-local-state-read-on-the-wrong-instance class as progress polling — here on the control path instead of the read path.

## What it does

The cutover RPC now records a **durable cutover control request** and returns once it's queued, mirroring how stop and start are routed to the owner (#378). The instance that owns the schema change observes the pending request through shared storage and performs the cutover; the engine is invoked only by the owner.

```
            Cutover (any instance)
                    |
                    v
          +-------------------+        the owning instance's poll loop
          |  shared storage   | <----- finds the pending request and
          +-------------------+        performs the cutover on its engine
```

Engine resume-state validation and the deferred-cutover recovery guard now run on the owner's execution path rather than on the receiving RPC.

## Safety

The cutover is performed only by the instance running the schema change, so a request balanced onto a non-owning instance can no longer be rejected or misapplied. Cutover requests are durable, so an owner that is mid-recovery applies the cutover once it is cutover-ready rather than rejecting it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)