### PR TITLE
feat(api): route plan/progress/webhook through the primary deployment

### DIFF
--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -1230,6 +1230,31 @@ func (c *ServerConfig) ResolveDatabaseTarget(database, environment string) (rout
 	return targets[0], nil
 }
 
+// ResolvePrimaryDatabaseTarget returns the primary deployment for a configured
+// database/environment: the first entry in rollout order (explicit
+// deployment_order when set, otherwise alphabetical). For single-deployment
+// environments this is the only target; for multi-deployment environments it is
+// the lead deployment the rollout starts from.
+//
+// Use this where a single representative route is needed but a multi-deployment
+// environment must not be rejected — planning a schema diff, routing a progress
+// poll, or labelling a metric. The deployment chosen here matches the apply
+// row's own stored deployment (createStoredApply uses the same primary), while
+// the apply itself fans out across the full target set at create time.
+// Callers that require exactly one configured deployment use
+// ResolveDatabaseTarget; callers that act on every deployment use
+// ResolveDatabaseTargets.
+func (c *ServerConfig) ResolvePrimaryDatabaseTarget(database, environment string) (routing.ExecutionTarget, error) {
+	targets, err := c.ResolveDatabaseTargets(database, environment)
+	if err != nil {
+		return routing.ExecutionTarget{}, err
+	}
+	if len(targets) == 0 {
+		return routing.ExecutionTarget{}, fmt.Errorf("database %q environment %q resolved no deployments", database, environment)
+	}
+	return targets[0], nil
+}
+
 // orderedDeploymentKeys returns the keys of a deployments map in rollout order:
 // the explicit deployment_order when set, otherwise alphabetical for
 // deterministic resolution. When an order is given it is validated to be a

--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -1300,6 +1300,24 @@ func TestServerConfig_ResolveDatabaseTargets(t *testing.T) {
 		assert.Equal(t, "tenant-a", got.Deployment)
 		assert.Equal(t, "cluster-production-001", got.Target)
 	})
+
+	t.Run("ResolvePrimaryDatabaseTarget returns the lead deployment for multi-deployment", func(t *testing.T) {
+		got, err := cfg.ResolvePrimaryDatabaseTarget("multidb", "production")
+		require.NoError(t, err)
+		assert.Equal(t, routing.ExecutionTarget{DatabaseType: "mysql", Deployment: "payments-a", Target: "payments"}, got)
+	})
+
+	t.Run("ResolvePrimaryDatabaseTarget returns the single target for scalar remote", func(t *testing.T) {
+		got, err := cfg.ResolvePrimaryDatabaseTarget("scalardb", "production")
+		require.NoError(t, err)
+		assert.Equal(t, routing.ExecutionTarget{DatabaseType: "vitess", Deployment: "tenant-a", Target: "cluster-production-001"}, got)
+	})
+
+	t.Run("ResolvePrimaryDatabaseTarget errors on unknown database", func(t *testing.T) {
+		_, err := cfg.ResolvePrimaryDatabaseTarget("missing", "production")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not configured")
+	})
 }
 
 // TestServerConfig_ResolveDatabaseTargets_BypassValidate covers the cases
@@ -1389,6 +1407,24 @@ func TestServerConfig_ResolveDatabaseTargets_DeploymentOrder(t *testing.T) {
 		got, err := cfg.ResolveDatabaseTargets("payments", "production")
 		require.NoError(t, err)
 		assert.Equal(t, []string{"payments-a", "payments-b", "payments-c"}, resolvedOrder(t, got))
+	})
+
+	t.Run("primary target is the first deployment in explicit rollout order", func(t *testing.T) {
+		cfg := makeCfg(EnvironmentConfig{
+			Deployments:     deployments,
+			DeploymentOrder: []string{"payments-c", "payments-a", "payments-b"},
+		})
+		got, err := cfg.ResolvePrimaryDatabaseTarget("payments", "production")
+		require.NoError(t, err)
+		assert.Equal(t, "payments-c", got.Deployment)
+		assert.Equal(t, "payments", got.Target)
+	})
+
+	t.Run("primary target falls back to alphabetical first when order unset", func(t *testing.T) {
+		cfg := makeCfg(EnvironmentConfig{Deployments: deployments})
+		got, err := cfg.ResolvePrimaryDatabaseTarget("payments", "production")
+		require.NoError(t, err)
+		assert.Equal(t, "payments-a", got.Deployment)
 	})
 
 	t.Run("deployment_order missing a deployment errors", func(t *testing.T) {

--- a/pkg/api/plan_handlers.go
+++ b/pkg/api/plan_handlers.go
@@ -432,7 +432,7 @@ func (s *Service) ExecutePlan(ctx context.Context, req PlanRequest) (*apitypes.P
 	planStart := time.Now()
 	deployment := ""
 
-	resolvedTarget, err := s.config.ResolveDatabaseTarget(req.Database, req.Environment)
+	resolvedTarget, err := s.config.ResolvePrimaryDatabaseTarget(req.Database, req.Environment)
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(otelcodes.Error, "resolve target")

--- a/pkg/api/progress_handlers.go
+++ b/pkg/api/progress_handlers.go
@@ -125,7 +125,7 @@ func (s *Service) deploymentForDatabaseEnvironment(database, deployment, environ
 	if deployment != "" {
 		return deployment, nil
 	}
-	resolved, err := s.config.ResolveDatabaseTarget(database, environment)
+	resolved, err := s.config.ResolvePrimaryDatabaseTarget(database, environment)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/webhook/plan.go
+++ b/pkg/webhook/plan.go
@@ -75,7 +75,7 @@ func (h *Handler) handlePlanCommand(w http.ResponseWriter, repo string, pr int, 
 	// Build PlanRequest in the format expected by the API service
 	prNumber := int32(pr)
 	deployment := ""
-	if resolvedTarget, err := h.service.Config().ResolveDatabaseTarget(schemaResult.Database, environment); err != nil {
+	if resolvedTarget, err := h.service.Config().ResolvePrimaryDatabaseTarget(schemaResult.Database, environment); err != nil {
 		h.logger.Warn("plan metric deployment is unknown because target resolution failed",
 			"repo", repo,
 			"pr", pr,


### PR DESCRIPTION
## What and Why ?

The plan diff (`ExecutePlan`), the progress-poll deployment fallback, and the webhook plan metric label each resolve a single deployment via `ResolveDatabaseTarget`, which errors on a multi-entry `deployments` map. That makes these three paths the blocker to ever accepting a >1-deployment environment.

This routes them through the **primary** deployment instead — the first entry in rollout order (`deployment_order`, alphabetical fallback), which is the same deployment apply creation already stamps on `applies.deployment`. A multi-deployment environment can now be planned and polled. The plan stays a single row routed at the primary; the apply itself fans out across the full target set at create time (#390).

Behaviour is unchanged for single-deployment environments (the only kind currently accepted) — the >1 path stays dormant until the multi-entry config gate is lifted in a later change.

## Changes

- Add `ResolvePrimaryDatabaseTarget`, returning the lead deployment in rollout order. `ResolveDatabaseTarget` (errors on >1) is retained for callers that require exactly one deployment.
- Switch `ExecutePlan`, the progress-poll deployment fallback, and the webhook plan metric label to the primary resolver.
```
BEFORE  plan / progress / webhook ─▶ ResolveDatabaseTarget ─▶ ERROR when >1
AFTER   plan / progress / webhook ─▶ ResolvePrimaryDatabaseTarget ─▶ targets[0]
(first in deployment_order)
```
## References

- Complements the apply-create fan-out (#390), which fans one plan out into per-deployment operations.

## Before → after flow
```
BEFORE  (single-deployment resolve — errors on a >1 deployments map)
╭──────────────╮ ╭───────────────────────────╮ ╭──────────────────────────╮
│ ExecutePlan  │ │ deploymentForDatabaseEnv  │ │ webhook plan metric label│
│ (diff+route) │ │ (progress poll fallback)  │ │                          │
╰──────┬───────╯ ╰─────────────┬─────────────╯ ╰────────────┬─────────────╯
       │                       │                            │
       ╰───────────────────────┴──────────────┬─────────────╯
                                              ▼
                              ╭─────────────────────────────╮
                              │ ResolveDatabaseTarget        │
                              │  len==1 → targets[0]         │
                              │  len>1  → ERROR "use         │   ✗ blocks lifting
                              │           ResolveDatabaseTargets"   the hard-block
                              ╰─────────────────────────────╯

AFTER  (primary-deployment resolve — tolerates N>1, dormant under the gate)
╭──────────────╮ ╭───────────────────────────╮ ╭──────────────────────────╮
│ ExecutePlan  │ │ deploymentForDatabaseEnv  │ │ webhook plan metric label│
╰──────┬───────╯ ╰─────────────┬─────────────╯ ╰────────────┬─────────────╯
       │                       │                             │
       ╰───────────────────────┴──────────────┬──────────────╯
                                              ▼
                       ╭──────────────────────────────────────╮
                       │ ResolvePrimaryDatabaseTarget         │
                       │  → ResolveDatabaseTargets()[0]       │
                       │    = first in deployment_order       │
                       │      (alphabetical fallback)         │
                       ╰────────────────────┬─────────────────╯
                                            │  same primary stamped on
                                            ▼  applies.deployment
                       ╭──────────────────────────────────────╮
                       │ createStoredApply  → fans out to ALL │
                       │ targets at apply time (#390)         │
                       ╰──────────────────────────────────────╯
```