### PR TITLE
feat(operator): drive ordered cutover under operation lease only

### DIFF
--- a/pkg/api/operator.go
+++ b/pkg/api/operator.go
@@ -198,6 +198,13 @@ func (s *Service) recoverApplies(ctx context.Context, driverID int) {
 		if s.recoverApplyPendingStop(ctx, driverID, owner) {
 			return
 		}
+		// Drive a barrier-parked cutover whose deployment-ordered turn it is
+		// before claiming new copy work, so the high-risk ordered swaps make
+		// progress ahead of starting more copy phases. Dormant until the
+		// multi-deployment fan-out lands (nothing parks at the barrier today).
+		if s.recoverApplyOperationCutover(ctx, driverID, owner) {
+			return
+		}
 		s.recoverApplyOperation(ctx, driverID, owner)
 		return
 	}
@@ -497,6 +504,17 @@ func (s *Service) recoverSingleApplyOperation(ctx context.Context, driverID int,
 // driven from its own tasks, then the parent is re-derived from the operation
 // rows.
 func (s *Service) recoverMultiApplyOperation(ctx context.Context, driverID int, op *storage.ApplyOperation, opLease storage.OperationLease) {
+	s.driveClaimedMultiOperation(ctx, driverID, op, opLease, false)
+}
+
+// driveClaimedMultiOperation drives one claimed operation of a multi-operation
+// apply under the operation lease only and settles the parent via the projection
+// CAS. cutover selects the drive phase: false runs the operation's copy phase
+// (ResumeApplyOperation), true forces a barrier-parked operation through its swap
+// (ResumeApplyOperationCutover). The parent applies row is never written by the
+// drive — the driver owns only its operation row and tasks; the parent state and
+// the once-only terminal summary are this method's projection responsibility.
+func (s *Service) driveClaimedMultiOperation(ctx context.Context, driverID int, op *storage.ApplyOperation, opLease storage.OperationLease, cutover bool) {
 	operationLeaseCtx := storage.WithOperationLease(ctx, opLease)
 
 	apply, err := s.storage.Applies().Get(operationLeaseCtx, op.ApplyID)
@@ -548,7 +566,7 @@ func (s *Service) recoverMultiApplyOperation(ctx context.Context, driverID int, 
 	// Suppress the per-driver terminal observer: the aggregate terminal summary
 	// is published once by the projection CAS winner, not per deployment.
 	resumed, resumeErr := s.resumeClaimedApplyWithOptions(runCtx, driverID, apply, op.ID, op.Deployment,
-		resumeClaimedApplyOptions{suppressRecoveredObserver: true})
+		resumeClaimedApplyOptions{suppressRecoveredObserver: true, cutover: cutover})
 	stopHeartbeat()
 	if !resumed && errors.Is(resumeErr, tern.ErrNoTasksForApplyOperation) {
 		// The drive failed closed: the operation has no tasks, so it can never
@@ -637,6 +655,66 @@ func (s *Service) recoverMultiApplyOperation(ctx context.Context, driverID int, 
 			"deployment", op.Deployment, "environment", finalApply.Environment, "error", err)
 		return
 	}
+}
+
+// recoverApplyOperationCutover claims the next barrier-parked operation whose
+// deployment-ordered turn it is to cut over and drives it through its swap. It is
+// the cutover counterpart to recoverApplyOperation's copy claim: the storage
+// predicate (FindNextApplyOperationCutover) only returns operations of a
+// multi-operation barrier apply, so the drive always runs under the operation
+// lease only and the parent applies row is settled by the projection CAS. With
+// one operation per apply today nothing parks at the barrier, so this is dormant
+// until the multi-deployment fan-out lands.
+//
+// Returns true when this tick is consumed by a cutover claim — an operation was
+// claimed (whether or not the drive that followed succeeded) or the claim itself
+// errored — so the caller does not also run the normal copy-operation claim this
+// tick. Returns false only when nothing is ready to cut over.
+func (s *Service) recoverApplyOperationCutover(ctx context.Context, driverID int, owner string) bool {
+	op, err := s.storage.ApplyOperations().FindNextApplyOperationCutover(ctx, owner)
+	if err != nil {
+		s.logger.Error("operator: failed to claim apply_operation cutover", "driver", driverID, "lease_owner", owner, "error", err)
+		metrics.RecordOperatorClaimFailure(ctx, "operation_cutover_storage_error")
+		return true
+	}
+	if op == nil {
+		s.logger.Debug("operator: no apply_operation to cut over", "driver", driverID)
+		return false
+	}
+
+	// The claim rotated a fresh operation lease onto the row; it is the
+	// capability that guards this operation's writes, so fail closed if missing.
+	opLease := op.Lease()
+	if !opLease.Valid() {
+		s.logger.Error("operator: claimed apply_operation cutover without a valid operation lease token; operation will not be driven",
+			"driver", driverID, "lease_owner", owner, "apply_operation_id", op.ID,
+			"apply_db_id", op.ApplyID, "deployment", op.Deployment)
+		metrics.RecordOperatorClaimFailure(ctx, "missing_operation_cutover_lease_token")
+		return true
+	}
+
+	// The cutover predicate already gates to multi-operation barrier applies, but
+	// the operation-lease-only drive (and its parent-write suppression) is only
+	// correct for a genuine multi-operation apply, so verify the set before
+	// driving rather than trusting the claim alone.
+	ops, err := s.storage.ApplyOperations().ListByApply(ctx, op.ApplyID)
+	if err != nil {
+		s.logger.Error("operator: failed to list operations for claimed cutover; operation will not be driven",
+			"driver", driverID, "lease_owner", owner, "apply_operation_id", op.ID,
+			"apply_db_id", op.ApplyID, "deployment", op.Deployment, "error", err)
+		metrics.RecordOperatorClaimFailure(ctx, "operation_cutover_set_list_error")
+		return true
+	}
+	if len(ops) <= 1 || !operationSetContainsID(ops, op.ID) {
+		s.logger.Error("operator: claimed cutover operation is not part of a multi-operation apply set; operation will not be driven",
+			"driver", driverID, "lease_owner", owner, "apply_operation_id", op.ID,
+			"apply_db_id", op.ApplyID, "deployment", op.Deployment, "operation_count", len(ops))
+		metrics.RecordOperatorClaimFailure(ctx, "operation_cutover_set_invalid")
+		return true
+	}
+
+	s.driveClaimedMultiOperation(ctx, driverID, op, opLease, true)
+	return true
 }
 
 // recoverApplyPendingStop drives stop reconciliation for an apply that has a
@@ -895,6 +973,11 @@ type resumeClaimedApplyOptions struct {
 	// terminal summary is published once by the projection CAS winner, not per
 	// deployment, so the per-driver observer must not fire.
 	suppressRecoveredObserver bool
+	// cutover routes the operation through ResumeApplyOperationCutover instead of
+	// ResumeApplyOperation: it drives a single operation parked at the cutover
+	// barrier through its high-risk swap (the deployment-ordered cutover claim)
+	// rather than running its copy phase.
+	cutover bool
 }
 
 func (s *Service) resumeClaimedApplyWithOptions(ctx context.Context, driverID int, apply *storage.Apply, applyOperationID int64, operationDeployment string, opts resumeClaimedApplyOptions) (bool, error) {
@@ -964,11 +1047,15 @@ func (s *Service) resumeClaimedApplyWithOptions(ctx context.Context, driverID in
 	}
 	// The operation-claim path scopes the drive to the single deployment it
 	// leased so sibling deployments are unaffected; ResumeApplyOperation fails
-	// closed when no tasks scope to the operation. The legacy whole-apply path
-	// (applyOperationID == 0) drives every task of the apply.
-	if applyOperationID > 0 {
+	// closed when no tasks scope to the operation. The cutover variant drives a
+	// barrier-parked operation through its swap instead of its copy phase. The
+	// legacy whole-apply path (applyOperationID == 0) drives every task.
+	switch {
+	case applyOperationID > 0 && opts.cutover:
+		err = client.ResumeApplyOperationCutover(ctx, apply, applyOperationID)
+	case applyOperationID > 0:
 		err = client.ResumeApplyOperation(ctx, apply, applyOperationID)
-	} else {
+	default:
 		err = client.ResumeApply(ctx, apply)
 	}
 	if err != nil {

--- a/pkg/api/operator_test.go
+++ b/pkg/api/operator_test.go
@@ -940,3 +940,157 @@ func TestRecoverMultiApplyOperation_FailsTaskLessOperationAgainstReloadedParent(
 	assert.Equal(t, state.ApplyOperation.Failed, opStore.op.State,
 		"the task-less operation row must be marked failed")
 }
+
+// cutoverOpStore backs the cutover claim path: FindNextApplyOperationCutover
+// hands back the barrier-parked operation whose turn it is, ListByApply reports a
+// genuine multi-operation set (so the operation-lease-only drive is valid), and
+// MarkFailed terminalizes the claimed row.
+type cutoverOpStore struct {
+	storage.ApplyOperationStore
+	mu      sync.Mutex
+	op      *storage.ApplyOperation
+	sibling *storage.ApplyOperation
+	claimed bool
+}
+
+func (s *cutoverOpStore) FindNextApplyOperationCutover(context.Context, string) (*storage.ApplyOperation, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.claimed = true
+	op := *s.op
+	return &op, nil
+}
+
+func (s *cutoverOpStore) Get(context.Context, int64) (*storage.ApplyOperation, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	op := *s.op
+	return &op, nil
+}
+
+func (s *cutoverOpStore) ListByApply(context.Context, int64) ([]*storage.ApplyOperation, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	op := *s.op
+	sibling := *s.sibling
+	return []*storage.ApplyOperation{&op, &sibling}, nil
+}
+
+func (s *cutoverOpStore) MarkFailed(_ context.Context, _ int64, errMsg string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.op.State = state.ApplyOperation.Failed
+	s.op.ErrorMessage = errMsg
+	return nil
+}
+
+func (s *cutoverOpStore) Heartbeat(context.Context, int64) error { return nil }
+
+// The cutover claim path drives a barrier-parked operation through its swap via
+// ResumeApplyOperationCutover, not the copy-phase ResumeApplyOperation, and only
+// when the claimed operation belongs to a genuine multi-operation apply so the
+// operation-lease-only drive (with parent-write suppression) is valid.
+func TestRecoverApplyOperationCutover_RoutesThroughCutoverDrive(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	applyStore := &casApplyStore{
+		template: storage.Apply{
+			ID:              7,
+			ApplyIdentifier: "apply-cutover",
+			Database:        "testdb",
+			DatabaseType:    storage.DatabaseTypeMySQL,
+			Environment:     "staging",
+		},
+		state: state.Apply.Running,
+	}
+	opStore := &cutoverOpStore{
+		op: &storage.ApplyOperation{
+			ID:         42,
+			ApplyID:    7,
+			Deployment: "west",
+			State:      state.ApplyOperation.CuttingOver,
+			LeaseOwner: "driver-1",
+			LeaseToken: "token-1",
+		},
+		sibling: &storage.ApplyOperation{
+			ID:         41,
+			ApplyID:    7,
+			Deployment: "east",
+			State:      state.ApplyOperation.Completed,
+		},
+	}
+	// Fail closed on no tasks so the drive short-circuits to the task-less
+	// terminalization; the routing assertion only needs the cutover entrypoint to
+	// have been called.
+	deploymentClient := &mockTernClient{resumeErr: tern.ErrNoTasksForApplyOperation}
+
+	svc := New(
+		&recoverTestStorage{applies: applyStore, ops: opStore},
+		testServerConfig(),
+		map[string]tern.Client{"west/staging": deploymentClient},
+		logger,
+	)
+
+	consumed := svc.recoverApplyOperationCutover(t.Context(), 1, "driver-1")
+
+	assert.True(t, consumed, "claiming a parked cutover must consume the tick")
+	assert.True(t, opStore.claimed, "the cutover claim predicate must be queried")
+	deploymentClient.resumeMu.Lock()
+	cutoverID := deploymentClient.resumeCutoverOperationID
+	copyID := deploymentClient.resumeOperationID
+	deploymentClient.resumeMu.Unlock()
+	assert.Equal(t, int64(42), cutoverID, "the operation must be driven through the cutover entrypoint")
+	assert.Equal(t, int64(0), copyID, "the cutover claim must not route through the copy-phase entrypoint")
+	assert.Equal(t, state.ApplyOperation.Failed, opStore.op.State,
+		"the task-less cutover operation must be terminalized failed")
+}
+
+// A claimed cutover operation that is not part of a multi-operation apply must
+// not be driven: the operation-lease-only path (and its parent-write
+// suppression) is only correct for a genuine fan-out, so a single-operation set
+// fails closed without calling any resume entrypoint.
+func TestRecoverApplyOperationCutover_RejectsSingleOperationSet(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	applyStore := &casApplyStore{
+		template: storage.Apply{ID: 7, ApplyIdentifier: "apply-cutover-single", Database: "testdb", DatabaseType: storage.DatabaseTypeMySQL, Environment: "staging"},
+		state:    state.Apply.Running,
+	}
+	opStore := &recoverOperationStore{op: &storage.ApplyOperation{
+		ID:         42,
+		ApplyID:    7,
+		Deployment: "west",
+		State:      state.ApplyOperation.CuttingOver,
+		LeaseOwner: "driver-1",
+		LeaseToken: "token-1",
+	}}
+	deploymentClient := &mockTernClient{}
+
+	svc := New(
+		&recoverTestStorage{applies: applyStore, ops: &singleCutoverOpStore{recoverOperationStore: opStore}},
+		testServerConfig(),
+		map[string]tern.Client{"west/staging": deploymentClient},
+		logger,
+	)
+
+	consumed := svc.recoverApplyOperationCutover(t.Context(), 1, "driver-1")
+
+	assert.True(t, consumed, "claiming any operation consumes the tick even when it is rejected")
+	deploymentClient.resumeMu.Lock()
+	cutoverID := deploymentClient.resumeCutoverOperationID
+	copyID := deploymentClient.resumeOperationID
+	deploymentClient.resumeMu.Unlock()
+	assert.Equal(t, int64(0), cutoverID, "a single-operation set must not be driven through cutover")
+	assert.Equal(t, int64(0), copyID, "a single-operation set must not be driven through copy")
+}
+
+// singleCutoverOpStore exposes a recoverOperationStore (single-operation
+// ListByApply) through the cutover claim predicate.
+type singleCutoverOpStore struct {
+	*recoverOperationStore
+}
+
+func (s *singleCutoverOpStore) FindNextApplyOperationCutover(context.Context, string) (*storage.ApplyOperation, error) {
+	op := *s.op
+	return &op, nil
+}

--- a/pkg/tern/local_apply_grouped.go
+++ b/pkg/tern/local_apply_grouped.go
@@ -735,6 +735,29 @@ func (c *LocalClient) handleAtomicProgressTick(ctx context.Context, eng engine.E
 		}
 	}
 
+	// A multi-operation drive (operation lease only) owns its operation, not the
+	// parent applies row: it has synced its tasks and run the engine's auto
+	// actions above, but the parent state, terminal side-effects, and the
+	// terminal summary are the operator's projection to make after the drive
+	// returns. Stop polling once this operation's own tasks settle (or park at
+	// the cutover barrier); the operator persists the operation row and projects
+	// the parent. Without this, a drive that won the terminal projection CAS here
+	// would suppress the operator's once-only terminal summary.
+	if suppressParentApplyWrites(ctx) {
+		opState := state.DeriveApplyState(taskStates(tasks))
+		if releaseAtCutoverBarrier && state.IsState(opState, state.Apply.WaitingForCutover) {
+			c.logger.Info("operation parked at cutover barrier; exiting copy drive",
+				"mode", groupedApplyMode(apply, options), "apply_id", apply.ApplyIdentifier, "operation_state", opState)
+			return true
+		}
+		if state.IsTerminalApplyState(opState) || state.IsState(opState, state.Apply.FailedRetryable) {
+			c.logger.Info("operation settled; exiting operation drive for operator projection",
+				"mode", groupedApplyMode(apply, options), "apply_id", apply.ApplyIdentifier, "operation_state", opState)
+			return true
+		}
+		return false
+	}
+
 	// Update apply state from persisted task state so recovery guards can keep
 	// storage ahead of stale engine progress until Spirit reaches the cutover wait again.
 	if derived, ok := c.deriveAggregateApplyState(ctx, apply, tasks); ok {

--- a/pkg/tern/local_control_resume.go
+++ b/pkg/tern/local_control_resume.go
@@ -492,6 +492,24 @@ func shouldInspectCutoverSignalForResume(apply *storage.Apply, forceCutoverResum
 		state.IsState(apply.State, state.Apply.WaitingForCutover, state.Apply.Recovering)
 }
 
+// suppressParentApplyWrites reports whether the current drive runs under an
+// operation lease only (no parent apply lease). That is the multi-operation
+// fan-out case: the parent applies row is owned solely by the operator's
+// rollout-projection CAS, so the drive must not write it directly — storage
+// fails such writes closed with ErrApplyLeaseLost, and the cutover drive's
+// recovering/running writes would otherwise abort the whole drive. A
+// single-operation or whole-apply drive carries the parent apply lease and
+// writes (and heartbeats) the parent directly, so this returns false for them.
+// The operator advances the parent via updateApplyStateFromOperations after the
+// drive returns.
+func suppressParentApplyWrites(ctx context.Context) bool {
+	if _, ok := storage.ApplyLeaseFromContext(ctx); ok {
+		return false
+	}
+	opLease, ok := storage.OperationLeaseFromContext(ctx)
+	return ok && opLease.Valid()
+}
+
 func (c *LocalClient) markApplyRecovering(ctx context.Context, apply *storage.Apply, tasks []*storage.Task) error {
 	c.logger.Info("entering recovery state for deferred cutover checkpoint",
 		"apply_id", apply.ApplyIdentifier,
@@ -513,6 +531,12 @@ func (c *LocalClient) markApplyRecovering(ctx context.Context, apply *storage.Ap
 	apply.State = state.Apply.Recovering
 	apply.CompletedAt = nil
 	apply.UpdatedAt = time.Now()
+	// A multi-operation drive owns only its operation: the parent recovering
+	// write is the operator's projection to make, and a direct write here fails
+	// closed under the operation-only lease. Tasks are already recovering above.
+	if suppressParentApplyWrites(ctx) {
+		return nil
+	}
 	if err := c.storage.Applies().Update(ctx, apply); err != nil {
 		return fmt.Errorf("mark apply %s recovering after restart: %w", apply.ApplyIdentifier, err)
 	}
@@ -530,6 +554,13 @@ func (c *LocalClient) launchAtomicResume(ctx context.Context, apply *storage.App
 	tasks []*storage.Task, plan *storage.Plan, options map[string]string, logMessage string, block bool, startRequested bool, releaseAtCutoverBarrier bool) error {
 
 	allTasks := tasks
+	// A multi-operation drive (operation lease only) owns its operation, not the
+	// parent applies row: it must not write the parent state, complete parent
+	// stop/start requests, adjust the apply-level active metric, fire the parent
+	// terminal observer, or heartbeat the parent. The operator advances the
+	// parent via the projection CAS after the drive returns; the operation row is
+	// heartbeated by the operator. Task and engine state are still persisted.
+	suppressParent := suppressParentApplyWrites(ctx)
 	eng := c.getEngine()
 	if eng == nil {
 		return fmt.Errorf("no engine available for grouped resume apply %s", apply.ApplyIdentifier)
@@ -559,6 +590,12 @@ func (c *LocalClient) launchAtomicResume(ctx context.Context, apply *storage.App
 		apply.State = state.Apply.Completed
 		apply.CompletedAt = &now
 		apply.UpdatedAt = now
+		// The drive's tasks are already terminal, so the operator derives this
+		// operation completed and projects the parent; skip the parent writes and
+		// side-effects a multi-operation drive does not own.
+		if suppressParent {
+			return nil
+		}
 		if err := c.storage.Applies().Update(ctx, apply); err != nil {
 			c.logger.Error("failed to update apply state", "apply_id", apply.ApplyIdentifier, "state", state.Apply.Completed, "error", err)
 			return fmt.Errorf("mark grouped resume apply %s completed after final schema check: %w", apply.ApplyIdentifier, err)
@@ -649,36 +686,55 @@ func (c *LocalClient) launchAtomicResume(ctx context.Context, apply *storage.App
 		apply.State = state.Apply.Recovering
 	}
 	apply.UpdatedAt = now
-	if err := c.storage.Applies().Update(ctx, apply); err != nil {
-		c.logger.Error("failed to update apply state", "apply_id", apply.ApplyIdentifier, "state", apply.State, "error", err)
-		return fmt.Errorf("mark grouped resume apply %s %s: %w", apply.ApplyIdentifier, apply.State, err)
-	}
-	if startRequested {
-		if err := completePendingStartControlRequests(ctx, c.storage, apply); err != nil {
-			return err
+	// A multi-operation drive does not write the parent running state or complete
+	// parent start requests; the operator projected the parent running before the
+	// drive. Tasks are already running/recovering above.
+	if !suppressParent {
+		if err := c.storage.Applies().Update(ctx, apply); err != nil {
+			c.logger.Error("failed to update apply state", "apply_id", apply.ApplyIdentifier, "state", apply.State, "error", err)
+			return fmt.Errorf("mark grouped resume apply %s %s: %w", apply.ApplyIdentifier, apply.State, err)
 		}
+		if startRequested {
+			if err := completePendingStartControlRequests(ctx, c.storage, apply); err != nil {
+				return err
+			}
+		}
+		c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventStateTransition, storage.LogSourceSchemaBot,
+			logMessage, oldApplyState, apply.State)
 	}
-
-	c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventStateTransition, storage.LogSourceSchemaBot,
-		logMessage, oldApplyState, apply.State)
 
 	if block {
 		pollCtx, cancelPoll := context.WithCancel(ctx)
 		defer cancelPoll()
-		stopHeartbeat := c.startApplyHeartbeat(pollCtx, apply, cancelPoll)
+		// Heartbeat the parent apply only when this drive owns it; a
+		// multi-operation drive's parent heartbeat fails closed under the
+		// operation-only lease and would cancel the run, so the operator
+		// heartbeats the operation row instead.
+		stopHeartbeat := c.startParentApplyHeartbeat(pollCtx, apply, suppressParent, cancelPoll)
 		defer stopHeartbeat()
 		c.pollForCompletionAtomic(pollCtx, apply, tasks, creds, resumeState, options, releaseAtCutoverBarrier)
 		return nil
 	}
 
 	resumeCtx, cancelResume := context.WithCancel(context.WithoutCancel(ctx))
-	stopHeartbeat := c.startApplyHeartbeat(resumeCtx, apply, cancelResume)
+	stopHeartbeat := c.startParentApplyHeartbeat(resumeCtx, apply, suppressParent, cancelResume)
 	go func() {
 		defer cancelResume()
 		defer stopHeartbeat()
 		c.pollForCompletionAtomic(resumeCtx, apply, tasks, creds, resumeState, options, releaseAtCutoverBarrier)
 	}()
 	return nil
+}
+
+// startParentApplyHeartbeat starts the parent apply heartbeat when this drive
+// owns the parent apply lease. A multi-operation drive (operation lease only)
+// does not own the parent row — its heartbeat fails closed and would cancel the
+// run — so this returns a no-op and the operator heartbeats the operation row.
+func (c *LocalClient) startParentApplyHeartbeat(ctx context.Context, apply *storage.Apply, suppressParent bool, cancelApply ...context.CancelFunc) context.CancelFunc {
+	if suppressParent {
+		return func() {}
+	}
+	return c.startApplyHeartbeat(ctx, apply, cancelApply...)
 }
 
 // errGroupedResumeStateUnavailable marks a resume attempt whose persisted engine

--- a/pkg/tern/local_control_test.go
+++ b/pkg/tern/local_control_test.go
@@ -795,3 +795,32 @@ func TestLocalClient_StopRejectsRevertWindow(t *testing.T) {
 	assert.Equal(t, state.Task.RevertWindow, task.State, "revert-window task must not be marked cancelled by stop")
 	assert.Equal(t, state.Apply.RevertWindow, apply.State, "revert-window apply must not be marked cancelled by stop")
 }
+
+// suppressParentApplyWrites engages only for an operation-lease-only drive (a
+// multi-operation fan-out): the parent applies row is owned by the operator's
+// projection CAS, so the drive must not write it. A drive carrying the parent
+// apply lease (single-operation or whole-apply) writes the parent directly.
+func TestSuppressParentApplyWrites(t *testing.T) {
+	applyLease := storage.ApplyLease{ApplyID: 1, Owner: "d", Token: "t"}
+	opLease := storage.OperationLease{ApplyID: 1, OperationID: 2, Owner: "d", Token: "t"}
+
+	t.Run("operation lease only suppresses", func(t *testing.T) {
+		ctx := storage.WithOperationLease(t.Context(), opLease)
+		assert.True(t, suppressParentApplyWrites(ctx))
+	})
+	t.Run("apply lease writes the parent directly", func(t *testing.T) {
+		ctx := storage.WithApplyLease(t.Context(), applyLease)
+		assert.False(t, suppressParentApplyWrites(ctx))
+	})
+	t.Run("dual lease writes the parent directly", func(t *testing.T) {
+		ctx := storage.WithOperationLease(storage.WithApplyLease(t.Context(), applyLease), opLease)
+		assert.False(t, suppressParentApplyWrites(ctx))
+	})
+	t.Run("no lease does not suppress", func(t *testing.T) {
+		assert.False(t, suppressParentApplyWrites(t.Context()))
+	})
+	t.Run("invalid operation lease does not suppress", func(t *testing.T) {
+		ctx := storage.WithOperationLease(t.Context(), storage.OperationLease{})
+		assert.False(t, suppressParentApplyWrites(ctx))
+	})
+}


### PR DESCRIPTION
## What & why

Stacked on #430 (→ #426). Adds the **operator cutover claim path** that makes a barrier-parked, deployment-ordered cutover actually get driven, and fixes the local drive so it can run under an **operation lease only**.

**The gap:** OC-3a shipped `ResumeApplyOperationCutover` (the tern drive) but nothing claimed parked operations, and the local drive still wrote the parent `applies` row directly. For a multi-operation apply the driver holds only the operation lease — the parent row is owned by the operator's rollout-projection CAS — so those direct writes fail closed (`ErrApplyLeaseLost`) and abort the drive.

**The fix:**
1. **Operator claim** — `recoverApplyOperationCutover` claims via `FindNextApplyOperationCutover`, verifies a genuine multi-op set, and reuses the multi-op drive through an extracted `driveClaimedMultiOperation(…, cutover=true)`, routing to `ResumeApplyOperationCutover` via a new `resumeClaimedApplyOptions{cutover}`. Wired into the tick after `recoverApplyPendingStop`, before `recoverApplyOperation`.
2. **Parent-write suppression** — one ctx-derived seam, `suppressParentApplyWrites(ctx)` (operation lease present, apply lease absent — the same condition storage uses to fail closed), gates the parent writes/heartbeat/side-effects in `markApplyRecovering`, `launchAtomicResume`, and the `handleAtomicProgressTick` quiesce block. Under suppression the drive persists only its tasks/engine state and exits when its own operation settles; the operator's projection CAS owns the parent terminalization and the once-only terminal summary.

The seam fixes the cutover drive **and** the (also-dormant) local multi-op copy drive, since they share these functions.
```
single-op / whole-apply (apply lease)   multi-op fan-out (operation lease only)
─────────────────────────────────────   ───────────────────────────────────────
markApplyRecovering ─ writes parent      ─ skip (operator projects)
launchAtomicResume  ─ Running/Completed   ─ skip parent state + heartbeat + metric + observer
progress poll       ─ CAS + summary       ─ exit when op settles; operator owns CAS + summary
│                                          │
▼                                          ▼
drive owns parent              operator updateApplyStateFromOperations
+ publishTerminalSummaryIfWon (once)
```
Dormant behind `OperatorClaimOperations` + the multi-op gate (one operation per apply today). gRPC remote cutover stays deferred (`ErrOperationCutoverUnsupportedRemote`) — future work.
