### PR TITLE
fix(api): drive task stop during op-claim stop reconciliation

### DIFF
--- a/integration/operator_test.go
+++ b/integration/operator_test.go
@@ -350,6 +350,112 @@ func TestOperator_OperatorReconcilesOperationWhenParentTerminal(t *testing.T) {
 	assert.Equal(t, derived, parent.State, "parent apply state is derived from its child operations")
 }
 
+// TestOperator_StopReconciliationDrivesTaskStop covers the operation-claim stop
+// path for an apply whose operation row is still pending when a stop is
+// requested — the window before the operator claims and drives the operation.
+// Stop reconciliation must drive the data-plane stop so the task settles to
+// stopped, not only flip the operation and apply rows. Otherwise the apply reads
+// stopped while its task stays non-terminal, and a later start finds no stopped
+// task to resume.
+func TestOperator_StopReconciliationDrivesTaskStop(t *testing.T) {
+	ctx := t.Context()
+	appDBName, appDSN := createTestDB(t, "stop_reconcile_drive_")
+	ts := startTestServerOperator(t, appDBName, appDSN)
+
+	now := time.Now()
+	applyID, err := ts.Storage.Applies().Create(ctx, &storage.Apply{
+		ApplyIdentifier: "apply-stop-reconcile-drive",
+		Database:        appDBName,
+		DatabaseType:    "mysql",
+		Deployment:      appDBName,
+		Engine:          "spirit",
+		State:           state.Apply.Pending,
+		Options:         []byte("{}"),
+		Environment:     "staging",
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	})
+	require.NoError(t, err)
+
+	opID, err := ts.Storage.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID:    applyID,
+		Deployment: appDBName,
+		Target:     appDBName,
+		State:      state.ApplyOperation.Pending,
+	})
+	require.NoError(t, err)
+
+	const taskIdentifier = "task-stop-reconcile-drive"
+	_, err = ts.Storage.Tasks().Create(ctx, &storage.Task{
+		TaskIdentifier:   taskIdentifier,
+		ApplyID:          applyID,
+		ApplyOperationID: &opID,
+		Database:         appDBName,
+		DatabaseType:     "mysql",
+		Engine:           "spirit",
+		Environment:      "staging",
+		State:            state.Task.Pending,
+		TableName:        "users",
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	})
+	require.NoError(t, err)
+
+	_, _, err = ts.Storage.ControlRequests().RequestPending(ctx, &storage.ApplyControlRequest{
+		ApplyID:     applyID,
+		Operation:   storage.ControlOperationStop,
+		Status:      storage.ControlRequestPending,
+		RequestedBy: "test",
+	})
+	require.NoError(t, err)
+
+	// The operator drives the data-plane stop, settling the task to stopped
+	// before terminalizing the operation and apply rows. Wait for the full
+	// settled state in one condition: the operation and apply rows are
+	// terminalized after the task stop, so polling them independently would
+	// race that window. The load-bearing assertion is task == stopped: without
+	// the fix the operator flips the operation/apply rows but never drives the
+	// task, so this condition never holds and the test fails.
+	require.Eventually(t, func() bool {
+		task, err := ts.Storage.Tasks().Get(ctx, taskIdentifier)
+		if err != nil || task == nil || !state.IsState(task.State, state.Task.Stopped) {
+			return false
+		}
+		op, err := ts.Storage.ApplyOperations().Get(ctx, opID)
+		if err != nil || op == nil || !state.IsState(op.State, state.ApplyOperation.Stopped) {
+			return false
+		}
+		apply, err := ts.Storage.Applies().Get(ctx, applyID)
+		if err != nil || apply == nil || !state.IsState(apply.State, state.Apply.Stopped) {
+			return false
+		}
+		return true
+	}, 10*time.Second, 100*time.Millisecond,
+		"stop reconciliation must drive the task to stopped and terminalize the operation and apply rows")
+
+	task, err := ts.Storage.Tasks().Get(ctx, taskIdentifier)
+	require.NoError(t, err)
+	require.NotNil(t, task)
+	assert.Equal(t, state.Task.Stopped, task.State, "task settles to stopped via the data-plane drive")
+
+	op, err := ts.Storage.ApplyOperations().Get(ctx, opID)
+	require.NoError(t, err)
+	require.NotNil(t, op)
+	assert.Equal(t, state.ApplyOperation.Stopped, op.State, "operation row is terminalized to stopped")
+
+	apply, err := ts.Storage.Applies().Get(ctx, applyID)
+	require.NoError(t, err)
+	require.NotNil(t, apply)
+	assert.Equal(t, state.Apply.Stopped, apply.State, "apply settles to stopped")
+
+	// The stop request is completed once the apply has stopped.
+	require.Eventually(t, func() bool {
+		req, err := ts.Storage.ControlRequests().GetPending(ctx, applyID, storage.ControlOperationStop)
+		return err == nil && req == nil
+	}, 5*time.Second, 100*time.Millisecond,
+		"pending stop request is completed after the apply stops")
+}
+
 // TestOperator_OperationDeploymentDrivesByOperationDeployment proves the
 // operation-claim path routes the drive by the claimed apply_operations row's
 // own deployment, not the parent apply's stored deployment. The parent apply's

--- a/pkg/api/operator.go
+++ b/pkg/api/operator.go
@@ -640,13 +640,16 @@ func (s *Service) recoverMultiApplyOperation(ctx context.Context, driverID int, 
 }
 
 // recoverApplyPendingStop drives stop reconciliation for an apply that has a
-// pending stop request but no claimable operation to carry it. Under on_failure
-// "continue" a failed earlier sibling can leave an apply with only terminal and
-// pending operations; the claim gate keeps the pending ones from starting, so
-// the normal operation-claim path never visits the apply and its stop would
-// strand forever. This path claims such an apply directly, stops its pending
-// siblings, re-derives the parent, and completes the stop once the apply is
-// terminal.
+// pending stop request but no claimable operation to carry it. Two cases reach
+// here: an apply whose operation row is still pending while its task is already
+// running (a direct data-plane apply marks the task running before the operator
+// claims the operation), and an on_failure "continue" rollout where a failed
+// earlier sibling left only terminal and pending operations that the claim gate
+// keeps from starting. In both cases the normal operation-claim path never
+// drives the apply, so its stop would strand forever. This path claims the apply
+// directly, drives the data-plane stop so the engine halts and the tasks settle
+// to stopped, terminalizes the pending operation rows, re-derives the parent,
+// and completes the stop once the apply is terminal.
 //
 // Returns true when this tick is consumed by stop reconciliation — an apply was
 // claimed (whether the reconciliation that followed succeeded or hit an error)
@@ -676,7 +679,39 @@ func (s *Service) recoverApplyPendingStop(ctx context.Context, driverID int, own
 	}
 	applyLeaseCtx := storage.WithApplyLease(ctx, lease)
 
-	if err := s.stopPendingOperationsForPendingStop(applyLeaseCtx, driverID, apply); err != nil {
+	// Drive the pending stop through the data plane before terminalizing any
+	// rows. The data-plane drive (ResumeApply -> processPendingStopControlRequest
+	// -> stopOwnedApply) halts live engine work and sets the apply's tasks to
+	// stopped. Without it, an apply whose operation row is still pending while its
+	// task is already running would have its operation and apply rows marked
+	// stopped while the task keeps running, leaving no stopped task for a later
+	// start to resume. applyOperationID 0 selects the whole-apply drive: this path
+	// holds the apply lease, not an operation lease, because no single operation
+	// is carrying the stop.
+	resumed, err := s.resumeClaimedApply(applyLeaseCtx, driverID, apply, 0, "")
+	if err != nil {
+		// Fail closed: leave the pending stop and pending operation rows untouched
+		// so the next tick reclaims this apply and retries the data-plane stop.
+		s.logger.Error("operator: failed to drive data-plane stop during stop reconciliation",
+			"driver", driverID, "apply_id", apply.ApplyIdentifier,
+			"database", apply.Database, "environment", apply.Environment, "error", err)
+		return true
+	}
+	if !resumed {
+		s.logger.Warn("operator: data-plane stop drive did not run during stop reconciliation; leaving stop for retry",
+			"driver", driverID, "apply_id", apply.ApplyIdentifier,
+			"database", apply.Database, "environment", apply.Environment)
+		return true
+	}
+
+	// The data-plane drive stopped the tasks and completed the stop control
+	// request, but it does not touch apply_operations rows. Terminalize the
+	// still-pending operations so the derived parent state below stays stopped and
+	// the operation rows match the now-stopped tasks. The stop request is already
+	// completed, so this goes through the unguarded helper rather than
+	// stopPendingOperationsForPendingStop (which would no-op without a pending
+	// stop).
+	if err := s.markPendingOperationsStopped(applyLeaseCtx, driverID, apply); err != nil {
 		s.logger.Error("operator: failed to stop pending sibling operations during stop reconciliation",
 			"driver", driverID, "apply_id", apply.ApplyIdentifier,
 			"database", apply.Database, "environment", apply.Environment, "error", err)
@@ -731,7 +766,16 @@ func (s *Service) stopPendingOperationsForPendingStop(ctx context.Context, drive
 	if controlReq == nil {
 		return nil
 	}
+	return s.markPendingOperationsStopped(ctx, driverID, apply)
+}
 
+// markPendingOperationsStopped terminalizes every still-pending operation of the
+// apply to stopped. Callers must have already established the stop intent — a
+// pending stop request, or a completed data-plane stop drive — because this does
+// not re-check the control request. That lets it run after the data-plane drive
+// has already completed the stop request, where the pending-stop guard in
+// stopPendingOperationsForPendingStop would otherwise short-circuit to a no-op.
+func (s *Service) markPendingOperationsStopped(ctx context.Context, driverID int, apply *storage.Apply) error {
 	stopped, err := s.storage.ApplyOperations().MarkPendingStoppedByApply(ctx, apply.ID)
 	if err != nil {
 		return fmt.Errorf("stop pending apply_operations for apply %s (%d): %w", apply.ApplyIdentifier, apply.ID, err)

--- a/pkg/api/operator.go
+++ b/pkg/api/operator.go
@@ -688,19 +688,15 @@ func (s *Service) recoverApplyPendingStop(ctx context.Context, driverID int, own
 	// start to resume. applyOperationID 0 selects the whole-apply drive: this path
 	// holds the apply lease, not an operation lease, because no single operation
 	// is carrying the stop.
-	resumed, err := s.resumeClaimedApply(applyLeaseCtx, driverID, apply, 0, "")
-	if err != nil {
+	// resumeClaimedApply returns (true, nil) on success and (false, err) on every
+	// failure, so the error is the only signal we need here.
+	if _, err := s.resumeClaimedApply(applyLeaseCtx, driverID, apply, 0, ""); err != nil {
 		// Fail closed: leave the pending stop and pending operation rows untouched
 		// so the next tick reclaims this apply and retries the data-plane stop.
 		s.logger.Error("operator: failed to drive data-plane stop during stop reconciliation",
 			"driver", driverID, "apply_id", apply.ApplyIdentifier,
-			"database", apply.Database, "environment", apply.Environment, "error", err)
-		return true
-	}
-	if !resumed {
-		s.logger.Warn("operator: data-plane stop drive did not run during stop reconciliation; leaving stop for retry",
-			"driver", driverID, "apply_id", apply.ApplyIdentifier,
-			"database", apply.Database, "environment", apply.Environment)
+			"database", apply.Database, "deployment", apply.Deployment,
+			"environment", apply.Environment, "error", err)
 		return true
 	}
 


### PR DESCRIPTION
## What

When the operator claims an apply that has a pending stop but no claimable
operation, the stop reconciliation path now drives the data-plane stop
through the whole-apply resume path before it terminalizes the operation
and apply rows. Adds a deterministic integration test for the path.

## Why

Previously this path only flipped the `apply_operations` and `applies` rows
to stopped. If the operation row was still pending while its task was
already running, the rows read stopped while the task kept running — leaving
no stopped task for a later start to resume. Routing through
`ResumeApply → processPendingStopControlRequest → stopOwnedApply` halts the
engine and settles the task to stopped first, then the rows are
terminalized to match.

This unblocks the parked default-operation-level claiming work.

## Flow
```

BEFORE (bug)                          AFTER (fix)
╭──────────────────────────╮          ╭──────────────────────────╮
│ recoverApplyPendingStop  │          │ recoverApplyPendingStop  │
│  claim apply lease       │          │  claim apply lease       │
│  mark op rows  → stopped │          │  resumeClaimedApply(0)   │──▶ data-plane
│  derive apply  → stopped │          │   → stopOwnedApply       │    stop: task→stopped
│  (task still RUNNING ✗)  │          │  markPendingOpsStopped   │
╰──────────────────────────╯          │  derive apply  → stopped │
   later start: no stopped            ╰──────────────────────────╯
   task to resume → fails                later start: resumes OK ✓
```

## Testing / validation

- New `TestOperator_StopReconciliationDrivesTaskStop` is stable 6/6 with the
  fix and deterministically fails without it (times out waiting for the task
  to stop).
- All `TestOperator` integration tests and existing pending-stop unit tests
  pass; build, vet, gofmt clean.
