### PR TITLE
fix(storage): claim deferred-deploy operations by parent apply state

### DIFF
--- a/pkg/storage/mysqlstore/apply_operations.go
+++ b/pkg/storage/mysqlstore/apply_operations.go
@@ -648,8 +648,16 @@ func (s *applyOperationStore) FindNextApplyOperation(ctx context.Context, owner 
 	queryArgs = append(queryArgs,
 		state.ApplyOperation.Stopped,
 		storage.ControlOperationStart, storage.ControlRequestPending)
+	// Deferred-deploy start gate keys on the PARENT apply state, not the
+	// operation state: the operation row stays active (running) while the apply
+	// parks at waiting_for_deploy, because the copy phase finished and only the
+	// deploy is deferred. The operation row is never persisted to
+	// waiting_for_deploy, so an operation-state predicate would never match.
+	// Gating on the parent's waiting_for_deploy state mirrors
+	// ApplyStore.FindNextApply's deferred-deploy clause.
+	queryArgs = append(queryArgs, stringArgs(activeStates)...)
+	queryArgs = append(queryArgs, state.Apply.WaitingForDeploy)
 	queryArgs = append(queryArgs,
-		state.ApplyOperation.WaitingForDeploy,
 		storage.ControlOperationStart, storage.ControlRequestPending)
 	queryArgs = append(queryArgs, state.ApplyOperation.FailedRetryable)
 	queryArgs = append(queryArgs, state.Apply.FailedRetryable, maxRecoveryAttempts, retryableRecoveryFreshnessDays)
@@ -662,8 +670,11 @@ func (s *applyOperationStore) FindNextApplyOperation(ctx context.Context, owner 
 	//   - A stopped operation whose parent apply has a pending start request is
 	//     reclaimable so the operator can resume it.
 	//
-	//   - A waiting-for-deploy operation whose parent apply has a pending start
-	//     request is reclaimable so the operator can trigger the deferred deploy.
+	//   - An active operation whose PARENT apply is waiting_for_deploy and has a
+	//     pending start request is reclaimable so the operator can trigger the
+	//     deferred deploy. The operation row stays running while the apply parks
+	//     at waiting_for_deploy (only the deploy is deferred), so this gate keys
+	//     on the parent apply state, mirroring ApplyStore.FindNextApply.
 	//
 	//   - A failed_retryable operation is reclaimable only while its PARENT apply
 	//     is itself claimable for that operation's recovery. The operator claim
@@ -749,7 +760,13 @@ func (s *applyOperationStore) FindNextApplyOperation(ctx context.Context, owner 
 				)
 			)
 			OR (
-				state = ?
+				state IN (%s)
+				AND EXISTS (
+					SELECT 1
+					FROM applies a
+					WHERE a.id = apply_operations.apply_id
+						AND a.state = ?
+				)
 				AND EXISTS (
 					SELECT 1
 					FROM apply_control_requests cr
@@ -786,7 +803,7 @@ func (s *applyOperationStore) FindNextApplyOperation(ctx context.Context, owner 
 		ORDER BY created_at, id
 		LIMIT 1
 		FOR UPDATE SKIP LOCKED
-	`, applyOperationColumns, activeStatePlaceholders, applyOperationHeartbeatStaleness, activeStatePlaceholders, applyOperationHeartbeatStaleness), queryArgs...)
+	`, applyOperationColumns, activeStatePlaceholders, applyOperationHeartbeatStaleness, activeStatePlaceholders, activeStatePlaceholders, applyOperationHeartbeatStaleness), queryArgs...)
 
 	ad, err := scanApplyOperationInto(row)
 	if errors.Is(err, sql.ErrNoRows) {

--- a/pkg/storage/mysqlstore/apply_operations_test.go
+++ b/pkg/storage/mysqlstore/apply_operations_test.go
@@ -890,6 +890,97 @@ func TestApplyOperationStore_FindNextApplyOperation_ClaimsWaitingForDeployWithPe
 	assert.Equal(t, id, reclaimed.ID)
 }
 
+// TestApplyOperationStore_FindNextApplyOperation_ClaimsRunningOpWhenParentWaitingForDeploy
+// covers the real deferred-deploy shape: while the apply parks at
+// waiting_for_deploy, the operation row stays running (the copy phase finished,
+// only the deploy is deferred). A pending start request must re-claim that
+// running operation so the operator can trigger the deferred deploy — the gate
+// keys on the parent apply's waiting_for_deploy state, not the operation state.
+func TestApplyOperationStore_FindNextApplyOperation_ClaimsRunningOpWhenParentWaitingForDeploy(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", storage.DatabaseTypeVitess, "staging")
+	apply := createTestApplyWithStateAndEnv(t, store, lock, "apply_op_running_parent_waiting", 1, state.Apply.WaitingForDeploy, "staging")
+
+	id, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-a", State: state.ApplyOperation.Running,
+	})
+	require.NoError(t, err)
+	// The operation holds a fresh heartbeat (updated_at = NOW()) from its own
+	// in-flight copy drive, but its lease was acquired before the start request,
+	// so the lease-age gate admits the claim.
+	_, err = testDB.ExecContext(ctx, `
+		UPDATE apply_operations
+		SET lease_owner = 'copy-owner', lease_token = 'copy-token', lease_acquired_at = NOW() - INTERVAL 2 MINUTE, updated_at = NOW()
+		WHERE id = ?
+	`, id)
+	require.NoError(t, err)
+
+	_, _, err = store.ControlRequests().RequestPending(ctx, &storage.ApplyControlRequest{
+		ApplyID:     apply.ID,
+		Operation:   storage.ControlOperationStart,
+		Status:      storage.ControlRequestPending,
+		RequestedBy: "operator",
+	})
+	require.NoError(t, err)
+
+	claimed, err := store.ApplyOperations().FindNextApplyOperation(ctx, "test-operator")
+	require.NoError(t, err)
+	require.NotNil(t, claimed, "running operation under a waiting-for-deploy parent with a pending start request must be reclaimable")
+	assert.Equal(t, id, claimed.ID)
+	assert.Equal(t, state.ApplyOperation.Running, claimed.State, "re-claim must keep the running state for the resume drive to trigger the deploy")
+	assert.Equal(t, "test-operator", claimed.LeaseOwner)
+	assert.NotEmpty(t, claimed.LeaseToken)
+
+	persisted, err := store.ApplyOperations().Get(ctx, id)
+	require.NoError(t, err)
+	require.NotNil(t, persisted)
+	assert.Equal(t, state.ApplyOperation.Running, persisted.State)
+	assert.Equal(t, "test-operator", persisted.LeaseOwner)
+	assert.Equal(t, claimed.LeaseToken, persisted.LeaseToken)
+}
+
+// TestApplyOperationStore_FindNextApplyOperation_SkipsRunningOpStartBeforeWaitingForDeploy
+// verifies the deferred-deploy gate does not steal a healthy operation lease
+// when a start request lands before the apply has reached waiting_for_deploy. A
+// running operation whose parent is still validating the deploy request must not
+// be re-claimed by the start request — that protects the "start too early" path.
+func TestApplyOperationStore_FindNextApplyOperation_SkipsRunningOpStartBeforeWaitingForDeploy(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", storage.DatabaseTypeVitess, "staging")
+	apply := createTestApplyWithStateAndEnv(t, store, lock, "apply_op_running_parent_running", 1, state.Apply.Running, "staging")
+
+	id, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-a", State: state.ApplyOperation.Running,
+	})
+	require.NoError(t, err)
+	// Fresh lease and heartbeat: the operation is actively being driven, so no
+	// staleness clause applies either.
+	_, err = testDB.ExecContext(ctx, `
+		UPDATE apply_operations
+		SET lease_owner = 'copy-owner', lease_token = 'copy-token', lease_acquired_at = NOW(), updated_at = NOW()
+		WHERE id = ?
+	`, id)
+	require.NoError(t, err)
+
+	_, _, err = store.ControlRequests().RequestPending(ctx, &storage.ApplyControlRequest{
+		ApplyID:     apply.ID,
+		Operation:   storage.ControlOperationStart,
+		Status:      storage.ControlRequestPending,
+		RequestedBy: "operator",
+	})
+	require.NoError(t, err)
+
+	claimed, err := store.ApplyOperations().FindNextApplyOperation(ctx, "test-operator")
+	require.NoError(t, err)
+	assert.Nil(t, claimed, "a running operation must not be re-claimed by a start request before its parent reaches waiting_for_deploy")
+}
+
 // TestApplyOperationStore_FindNextApplyOperation_SkipsStoppedWithCompletedStart
 // verifies the claim predicate filters on a *pending* start request: once the
 // start request is no longer pending, the stopped operation is terminal again


### PR DESCRIPTION
## What

`FindNextApplyOperation` now claims an active operation for a deferred-deploy
start when its **parent apply** is `waiting_for_deploy` and a pending start
request exists, instead of gating on the operation row's own state.

## Why

Under operation-level claiming, a `defer_deploy` apply parks at
`waiting_for_deploy` while its `apply_operations` row stays `running` — the
copy phase has finished and only the deploy is deferred, and the operation row
is never persisted to `waiting_for_deploy`. The previous clause keyed on
`apply_operations.state = waiting_for_deploy`, so a start request was never
picked up; the stale-active recovery clause only fires after a minute, so the
apply hung at `waiting_for_deploy`. The apply-level path already keys this on
the parent apply state; this change mirrors that.

This is enablement work for defaulting operator claiming to the operation level.

## Flow
```
BEFORE                                AFTER
apply = waiting_for_deploy            apply = waiting_for_deploy
op    = running                       op    = running
Start -> pending START                Start -> pending START
gate keyed on op state               gate keyed on parent apply state
(op never wfd) -> no claim           (op active + parent wfd) -> claim
-> apply hangs                       -> deploy triggered -> completes
```
The lease-age guard is preserved: an in-flight operation is not re-claimed
every poll, and a start request that lands before the apply reaches
`waiting_for_deploy` does not steal the operation lease.

## Testing / validation

- New storage test reproduces the bug (running op, parent waiting_for_deploy):
  fails without the fix, passes with it.
- New guard test ensures a too-early start does not claim the running op.
- Existing claim tests and the full storage integration suite pass.
