### PR TITLE
test(api): dormant multi-operation integration matrix

### DIFF
--- a/pkg/api/operator_multi_operation_integration_test.go
+++ b/pkg/api/operator_multi_operation_integration_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 // TestOperatorMultiOperationMatrix proves the DORMANT multi-deployment fan-out
-// path before the config flip (fan-out PR 11). Config.Validate() still rejects
+// path before the config flip enables it. Config.Validate() still rejects
 // >1 deployment, so a real apply never owns more than one operation today; this
 // matrix reaches the multi-op path the only way production cannot — by seeding
 // an apply with N apply_operations via CreateWithGroupedOperations (the exact
@@ -259,7 +259,7 @@ func TestOperatorMultiOperationMatrix(t *testing.T) {
 		// the operation leases do not serialize on a shared parent lease. Each
 		// drive also probes that a direct parent write fails closed under the
 		// operation-only lease.
-		gate := newDriveGate(2)
+		gate := newDriveGate(t, 2)
 		svc := newMatrixService(t, stor, matrixClients(stor, rec, map[string]matrixOutcome{
 			"region-a": {taskState: state.Task.Completed, gate: gate, probeParentWrite: true},
 			"region-b": {taskState: state.Task.Completed, gate: gate, probeParentWrite: true},
@@ -357,6 +357,7 @@ func (s seededMultiOpApply) opID(deployment string) int64 { return s.ops[deploym
 
 func seedGroupedApply(t *testing.T, ctx context.Context, stor storage.Storage, spec multiOpSeed) seededMultiOpApply {
 	t.Helper()
+	require.NotEmpty(t, spec.deployments, "seedGroupedApply requires at least one deployment")
 	now := time.Now()
 	apply := &storage.Apply{
 		ApplyIdentifier: spec.applyIdentifier,
@@ -488,7 +489,7 @@ func driveOneOperation(t *testing.T, ctx context.Context, svc *matrixService, re
 }
 
 // matrixClients builds one deterministic tern.Client per deployment, keyed by
-// the "deployment/environment" form the service uses to route.
+// the "deployment/environment" format the service uses to route.
 func matrixClients(stor storage.Storage, rec *driveRecorder, outcomes map[string]matrixOutcome) map[string]tern.Client {
 	clients := make(map[string]tern.Client, len(outcomes))
 	for dep, outcome := range outcomes {
@@ -547,7 +548,7 @@ func (m *matrixTernClient) ResumeApplyOperation(ctx context.Context, apply *stor
 		if state.IsState(m.outcome.taskState, state.Task.Failed) {
 			task.ErrorMessage = m.outcome.errMsg
 		}
-		if state.IsTerminalApplyState(m.outcome.taskState) {
+		if state.IsTerminalTaskState(m.outcome.taskState) {
 			now := time.Now()
 			task.CompletedAt = &now
 		}
@@ -637,13 +638,14 @@ func (r *matrixSummaryRecorder) lastTasks() []*storage.Task {
 // driveGate releases all participants only once the expected number have arrived,
 // proving the operation drives run concurrently rather than serializing.
 type driveGate struct {
+	t        *testing.T
 	wg       sync.WaitGroup
 	released chan struct{}
 	once     sync.Once
 }
 
-func newDriveGate(participants int) *driveGate {
-	g := &driveGate{released: make(chan struct{})}
+func newDriveGate(t *testing.T, participants int) *driveGate {
+	g := &driveGate{t: t, released: make(chan struct{})}
 	g.wg.Add(participants)
 	return g
 }
@@ -659,9 +661,11 @@ func (g *driveGate) arriveAndWait() {
 	select {
 	case <-g.released:
 	case <-time.After(20 * time.Second):
-		// A participant never arrived: the drives serialized instead of running
-		// concurrently. Unblock so the test fails on the assertions rather than
-		// hanging.
+		// A participant never arrived within the deadline: the drives serialized
+		// instead of running concurrently, which defeats the invariant this gate
+		// enforces. Fail the test, then unblock so it reports the failure rather
+		// than hanging.
+		g.t.Errorf("drive gate timed out: drives serialized instead of running concurrently")
 	}
 }
 

--- a/pkg/api/operator_multi_operation_integration_test.go
+++ b/pkg/api/operator_multi_operation_integration_test.go
@@ -1,0 +1,691 @@
+//go:build integration
+
+package api
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log/slog"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/block/spirit/pkg/utils"
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/modules/mysql"
+
+	"github.com/block/schemabot/pkg/state"
+	"github.com/block/schemabot/pkg/storage"
+	"github.com/block/schemabot/pkg/storage/mysqlstore"
+	"github.com/block/schemabot/pkg/tern"
+	"github.com/block/schemabot/pkg/testutil"
+)
+
+// TestOperatorMultiOperationMatrix proves the DORMANT multi-deployment fan-out
+// path before the config flip (fan-out PR 11). Config.Validate() still rejects
+// >1 deployment, so a real apply never owns more than one operation today; this
+// matrix reaches the multi-op path the only way production cannot — by seeding
+// an apply with N apply_operations via CreateWithGroupedOperations (the exact
+// dormant bypass helper) and driving the operator's unexported claim/drive
+// entrypoints directly against real MySQL storage.
+//
+// The drive is wired to deterministic per-deployment tern.Client fakes that
+// mutate only their own operation's task rows under the operation lease already
+// on the context. This exercises the real SQL claim gate (FOR UPDATE SKIP
+// LOCKED, sibling ordering, pending-stop block, stale-active reclaim), the real
+// operation-lease authorization, and the real aggregate-CAS projection — but
+// avoids Spirit DDL, progress polling, and the background operator goroutines,
+// all of which would add flakiness irrelevant to the fan-out invariants.
+//
+// Each subtest maps to the safety invariants in the fan-out implementation plan
+// risk table (ordering, halt/continue, barrier overlap, pending-stop,
+// op-lease-only parent writes, single-publisher terminal summary).
+func TestOperatorMultiOperationMatrix(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	ctx := t.Context()
+	db := startMatrixContainer(t, ctx)
+	stor := mysqlstore.New(db)
+
+	t.Run("RollingHaltCompletesInOrder", func(t *testing.T) {
+		resetMatrixTables(t, ctx, db)
+		seed := seedGroupedApply(t, ctx, stor, multiOpSeed{
+			applyIdentifier: "matrix-rolling-halt-ok",
+			parentState:     state.Apply.Pending,
+			cutoverPolicy:   storage.CutoverPolicyRolling,
+			onFailure:       storage.OnFailureHalt,
+			deployments:     []string{"region-a", "region-b", "region-c"},
+			opState:         state.ApplyOperation.Pending,
+			taskState:       state.Task.Pending,
+		})
+
+		rec := &driveRecorder{}
+		svc := newMatrixService(t, stor, matrixClients(stor, rec, map[string]matrixOutcome{
+			"region-a": {taskState: state.Task.Completed},
+			"region-b": {taskState: state.Task.Completed},
+			"region-c": {taskState: state.Task.Completed},
+		}))
+
+		driveNextOperation(t, ctx, svc, 1)
+		driveNextOperation(t, ctx, svc, 2)
+		driveNextOperation(t, ctx, svc, 3)
+
+		assert.Equal(t, []string{"region-a", "region-b", "region-c"}, rec.resumeOrder(),
+			"rolling policy must drive deployments serially in deployment_order")
+		for _, dep := range seed.deployments {
+			assert.Equal(t, state.ApplyOperation.Completed, opState(t, ctx, stor, seed.opID(dep)),
+				"operation %s must be completed", dep)
+		}
+		apply := getApply(t, ctx, stor, seed.applyID)
+		assert.Equal(t, state.Apply.Completed, apply.State, "parent apply must aggregate to completed")
+		assert.NotNil(t, apply.StartedAt, "parent started_at must be stamped by the projection")
+		assert.NotNil(t, apply.CompletedAt, "parent completed_at must be stamped by the projection")
+		assert.Equal(t, 1, svc.matrixSummary.count(), "the aggregate terminal summary must publish exactly once")
+		assert.Len(t, svc.matrixSummary.lastTasks(), len(seed.deployments),
+			"the summary must include every operation's task")
+		assert.Zero(t, svc.matrixSummary.recoveredCount(), "a multi-op drive must not fire the per-driver recovered observer")
+	})
+
+	t.Run("RollingHaltFailureStopsAtFirstDeployment", func(t *testing.T) {
+		resetMatrixTables(t, ctx, db)
+		seed := seedGroupedApply(t, ctx, stor, multiOpSeed{
+			applyIdentifier: "matrix-rolling-halt-fail",
+			parentState:     state.Apply.Pending,
+			cutoverPolicy:   storage.CutoverPolicyRolling,
+			onFailure:       storage.OnFailureHalt,
+			deployments:     []string{"region-a", "region-b", "region-c"},
+			opState:         state.ApplyOperation.Pending,
+			taskState:       state.Task.Pending,
+		})
+
+		rec := &driveRecorder{}
+		svc := newMatrixService(t, stor, matrixClients(stor, rec, map[string]matrixOutcome{
+			"region-a": {taskState: state.Task.Failed, errMsg: "region-a boom"},
+			"region-b": {taskState: state.Task.Completed},
+			"region-c": {taskState: state.Task.Completed},
+		}))
+
+		driveNextOperation(t, ctx, svc, 1) // region-a fails
+		driveNextOperation(t, ctx, svc, 2) // halt: nothing claimable behind the failed sibling
+
+		assert.Equal(t, []string{"region-a"}, rec.resumeOrder(),
+			"halt must not start a later deployment behind a failed earlier sibling")
+		assert.Equal(t, state.ApplyOperation.Failed, opState(t, ctx, stor, seed.opID("region-a")))
+		assert.Equal(t, state.ApplyOperation.Pending, opState(t, ctx, stor, seed.opID("region-b")))
+		assert.Equal(t, state.ApplyOperation.Pending, opState(t, ctx, stor, seed.opID("region-c")))
+		apply := getApply(t, ctx, stor, seed.applyID)
+		assert.Equal(t, state.Apply.Failed, apply.State, "first failure halts the rollout to failed")
+		assert.Contains(t, apply.ErrorMessage, "region-a", "aggregate message must name the failed deployment")
+		assert.Equal(t, 1, svc.matrixSummary.count(), "terminal summary publishes once on the failed verdict")
+	})
+
+	t.Run("RollingContinueFailureRunsRemainingAndSettlesFailed", func(t *testing.T) {
+		resetMatrixTables(t, ctx, db)
+		seed := seedGroupedApply(t, ctx, stor, multiOpSeed{
+			applyIdentifier: "matrix-rolling-continue",
+			parentState:     state.Apply.Pending,
+			cutoverPolicy:   storage.CutoverPolicyRolling,
+			onFailure:       storage.OnFailureContinue,
+			deployments:     []string{"region-a", "region-b"},
+			opState:         state.ApplyOperation.Pending,
+			taskState:       state.Task.Pending,
+		})
+
+		rec := &driveRecorder{}
+		svc := newMatrixService(t, stor, matrixClients(stor, rec, map[string]matrixOutcome{
+			"region-a": {taskState: state.Task.Failed, errMsg: "region-a degraded"},
+			"region-b": {taskState: state.Task.Completed},
+		}))
+
+		// region-a fails; continue holds the rollout running_degraded, no summary.
+		driveNextOperation(t, ctx, svc, 1)
+		assert.Equal(t, state.ApplyOperation.Failed, opState(t, ctx, stor, seed.opID("region-a")))
+		assert.Equal(t, state.Apply.RunningDegraded, getApply(t, ctx, stor, seed.applyID).State,
+			"continue must hold the parent running_degraded while siblings are in flight")
+		assert.Equal(t, 0, svc.matrixSummary.count(), "no terminal summary until the rollout settles")
+
+		// region-b runs (continue exempts it from the failed earlier sibling) and
+		// the rollout settles to failed — continue governs continuation, not the verdict.
+		driveNextOperation(t, ctx, svc, 2)
+		assert.Equal(t, []string{"region-a", "region-b"}, rec.resumeOrder())
+		assert.Equal(t, state.ApplyOperation.Completed, opState(t, ctx, stor, seed.opID("region-b")))
+		apply := getApply(t, ctx, stor, seed.applyID)
+		assert.Equal(t, state.Apply.Failed, apply.State, "a continued rollout still settles to the failed verdict")
+		assert.Contains(t, apply.ErrorMessage, "region-a", "the failed verdict names the first failure")
+		assert.Equal(t, 1, svc.matrixSummary.count(), "exactly one terminal summary once settled")
+	})
+
+	t.Run("BarrierParksCopyAndClaimsNextDeployment", func(t *testing.T) {
+		resetMatrixTables(t, ctx, db)
+		seed := seedGroupedApply(t, ctx, stor, multiOpSeed{
+			applyIdentifier: "matrix-barrier-park",
+			parentState:     state.Apply.Pending,
+			cutoverPolicy:   storage.CutoverPolicyBarrier,
+			onFailure:       storage.OnFailureHalt,
+			deployments:     []string{"region-a", "region-b"},
+			opState:         state.ApplyOperation.Pending,
+			taskState:       state.Task.Pending,
+		})
+
+		rec := &driveRecorder{}
+		// Each copy drive parks its operation at the cutover barrier
+		// (waiting_for_cutover) rather than completing.
+		svc := newMatrixService(t, stor, matrixClients(stor, rec, map[string]matrixOutcome{
+			"region-a": {taskState: state.Task.WaitingForCutover},
+			"region-b": {taskState: state.Task.WaitingForCutover},
+		}))
+
+		driveNextOperation(t, ctx, svc, 1) // region-a parks at the barrier
+		// Under barrier a later deployment's COPY phase may start once the earlier
+		// sibling reaches the barrier — it does not wait for completion.
+		driveNextOperation(t, ctx, svc, 2) // region-b's copy is allowed to start
+
+		assert.Equal(t, []string{"region-a", "region-b"}, rec.resumeOrder(),
+			"barrier must let the next deployment's copy start once the earlier sibling parks")
+		assert.Equal(t, state.ApplyOperation.WaitingForCutover, opState(t, ctx, stor, seed.opID("region-a")))
+		assert.Equal(t, state.ApplyOperation.WaitingForCutover, opState(t, ctx, stor, seed.opID("region-b")))
+		apply := getApply(t, ctx, stor, seed.applyID)
+		assert.False(t, state.IsTerminalApplyState(apply.State), "a parked rollout must not be terminal")
+		assert.Equal(t, state.Apply.WaitingForCutover, apply.State)
+		assert.Equal(t, 0, svc.matrixSummary.count(), "no terminal summary while parked at the barrier")
+
+		// With both copy phases parked and reserved for the ordered cutover claim,
+		// the copy claim finds nothing more to drive.
+		rec2 := rec.resumeOrder()
+		driveNextOperation(t, ctx, svc, 3)
+		assert.Equal(t, rec2, rec.resumeOrder(), "parked barrier operations must not be re-leased by the copy claim")
+	})
+
+	t.Run("PendingStopStopsPendingSiblingsAndCompletesStop", func(t *testing.T) {
+		resetMatrixTables(t, ctx, db)
+		// A continue rollout that already failed one deployment and still has a
+		// pending sibling, with a queued stop: the stop must halt the pending
+		// sibling and settle the apply rather than starting more deployments.
+		seed := seedGroupedApply(t, ctx, stor, multiOpSeed{
+			applyIdentifier: "matrix-pending-stop",
+			parentState:     state.Apply.RunningDegraded,
+			cutoverPolicy:   storage.CutoverPolicyRolling,
+			onFailure:       storage.OnFailureContinue,
+			deployments:     []string{"region-a", "region-b"},
+			perOpState: map[string]string{
+				"region-a": state.ApplyOperation.Failed,
+				"region-b": state.ApplyOperation.Pending,
+			},
+			perTaskState: map[string]string{
+				"region-a": state.Task.Failed,
+				"region-b": state.Task.Pending,
+			},
+		})
+		requestPendingStop(t, ctx, stor, seed.applyID)
+
+		rec := &driveRecorder{}
+		svc := newMatrixService(t, stor, matrixClients(stor, rec, map[string]matrixOutcome{}))
+
+		svc.recoverApplies(ctx, 1)
+
+		assert.Empty(t, rec.resumeOrder(), "stop reconciliation must not drive any operation")
+		assert.Equal(t, state.ApplyOperation.Stopped, opState(t, ctx, stor, seed.opID("region-b")),
+			"the pending sibling must be stopped, not started, under a pending stop")
+		apply := getApply(t, ctx, stor, seed.applyID)
+		assert.Equal(t, state.Apply.Failed, apply.State, "failed + stopped settles the rollout to failed")
+		assert.True(t, stopRequestCompleted(t, ctx, stor, seed.applyID), "the pending stop request must be completed")
+		assert.Equal(t, 1, svc.matrixSummary.count(), "the settled rollout still owes exactly one terminal summary")
+	})
+
+	t.Run("ConcurrentSiblingCompletionsPublishOneSummary", func(t *testing.T) {
+		resetMatrixTables(t, ctx, db)
+		seed := seedGroupedApply(t, ctx, stor, multiOpSeed{
+			applyIdentifier: "matrix-concurrent",
+			parentState:     state.Apply.Running,
+			cutoverPolicy:   storage.CutoverPolicyRolling,
+			onFailure:       storage.OnFailureHalt,
+			deployments:     []string{"region-a", "region-b"},
+			opState:         state.ApplyOperation.Running,
+			taskState:       state.Task.Running,
+		})
+		// Backdate both operation heartbeats so the stale-active reclaim makes both
+		// rows claimable at once by two racing drivers.
+		stalenessBackdate(t, ctx, db, seed.applyID)
+
+		rec := &driveRecorder{}
+		// Both drives block until both have entered ResumeApplyOperation, proving
+		// the operation leases do not serialize on a shared parent lease. Each
+		// drive also probes that a direct parent write fails closed under the
+		// operation-only lease.
+		gate := newDriveGate(2)
+		svc := newMatrixService(t, stor, matrixClients(stor, rec, map[string]matrixOutcome{
+			"region-a": {taskState: state.Task.Completed, gate: gate, probeParentWrite: true},
+			"region-b": {taskState: state.Task.Completed, gate: gate, probeParentWrite: true},
+		}))
+
+		// Each driver polls for an operation the way the operator loop does: a
+		// single FindNextApplyOperation can return nil when a peer claims first,
+		// so retry until this driver drives one. The gate then holds both inside
+		// their drive at once, proving the operation leases do not serialize.
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() { defer wg.Done(); driveOneOperation(t, ctx, svc, rec, 1) }()
+		go func() { defer wg.Done(); driveOneOperation(t, ctx, svc, rec, 2) }()
+		wg.Wait()
+
+		assert.ElementsMatch(t, []string{"region-a", "region-b"}, rec.resumeOrder(),
+			"both operations must be claimed concurrently by distinct drivers")
+		assert.Equal(t, state.ApplyOperation.Completed, opState(t, ctx, stor, seed.opID("region-a")))
+		assert.Equal(t, state.ApplyOperation.Completed, opState(t, ctx, stor, seed.opID("region-b")))
+		assert.Equal(t, state.Apply.Completed, getApply(t, ctx, stor, seed.applyID).State)
+		assert.Equal(t, 1, svc.matrixSummary.count(),
+			"only the aggregate-CAS winner publishes the terminal summary")
+		parentWriteErrs := rec.parentWriteErrors()
+		require.Len(t, parentWriteErrs, 2, "both drives must have probed the parent write")
+		for _, err := range parentWriteErrs {
+			assert.ErrorIs(t, err, storage.ErrApplyLeaseLost,
+				"an operation-only lease must not authorize a direct parent applies write")
+		}
+	})
+}
+
+// --- harness ------------------------------------------------------------
+
+func startMatrixContainer(t *testing.T, ctx context.Context) *sql.DB {
+	t.Helper()
+	container, err := mysql.Run(ctx,
+		"mysql:8.0",
+		mysql.WithDatabase("schemabot_test"),
+		mysql.WithUsername("root"),
+		mysql.WithPassword("test"),
+	)
+	require.NoError(t, err, "failed to start mysql")
+	t.Cleanup(func() {
+		if err := testcontainers.TerminateContainer(container); err != nil {
+			t.Logf("failed to terminate container: %v", err)
+		}
+	})
+
+	dsn, err := testutil.ContainerConnectionString(ctx, container, "parseTime=true")
+	require.NoError(t, err, "failed to get connection string")
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	require.NoError(t, EnsureSchema(dsn, logger), "failed to ensure schema")
+
+	db, err := sql.Open("mysql", dsn)
+	require.NoError(t, err, "failed to open database")
+	require.NoError(t, db.PingContext(ctx), "failed to ping database")
+	t.Cleanup(func() { utils.CloseAndLog(db) })
+	return db
+}
+
+// resetMatrixTables clears the rows the matrix touches so each subtest shares one
+// container without leaking claimable operations across cases.
+func resetMatrixTables(t *testing.T, ctx context.Context, db *sql.DB) {
+	t.Helper()
+	for _, table := range []string{"tasks", "apply_operations", "apply_control_requests", "apply_logs", "applies"} {
+		_, err := db.ExecContext(ctx, "DELETE FROM "+table)
+		require.NoErrorf(t, err, "reset table %s", table)
+	}
+}
+
+// --- seeding ------------------------------------------------------------
+
+type multiOpSeed struct {
+	applyIdentifier string
+	parentState     string
+	cutoverPolicy   string
+	onFailure       string
+	deployments     []string
+	// opState / taskState set a uniform initial state for every operation/task.
+	opState   string
+	taskState string
+	// perOpState / perTaskState override the uniform state per deployment.
+	perOpState   map[string]string
+	perTaskState map[string]string
+}
+
+type seededMultiOpApply struct {
+	applyID     int64
+	deployments []string
+	ops         map[string]int64
+}
+
+func (s seededMultiOpApply) opID(deployment string) int64 { return s.ops[deployment] }
+
+func seedGroupedApply(t *testing.T, ctx context.Context, stor storage.Storage, spec multiOpSeed) seededMultiOpApply {
+	t.Helper()
+	now := time.Now()
+	apply := &storage.Apply{
+		ApplyIdentifier: spec.applyIdentifier,
+		Database:        "payments",
+		DatabaseType:    storage.DatabaseTypeMySQL,
+		Repository:      "octocat/hello-world",
+		PullRequest:     1,
+		Environment:     "staging",
+		Deployment:      spec.deployments[0],
+		Caller:          "matrix-test",
+		Engine:          storage.EngineForType(storage.DatabaseTypeMySQL),
+		State:           spec.parentState,
+		Options:         storage.MarshalApplyOptions(storage.ApplyOptions{}),
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+
+	groups := make([]*storage.ApplyOperationWithTasks, 0, len(spec.deployments))
+	for _, dep := range spec.deployments {
+		opState := spec.opState
+		if s, ok := spec.perOpState[dep]; ok {
+			opState = s
+		}
+		taskState := spec.taskState
+		if s, ok := spec.perTaskState[dep]; ok {
+			taskState = s
+		}
+		groups = append(groups, &storage.ApplyOperationWithTasks{
+			Operation: &storage.ApplyOperation{
+				Deployment:    dep,
+				Target:        "payments-" + dep,
+				State:         opState,
+				CutoverPolicy: spec.cutoverPolicy,
+				OnFailure:     spec.onFailure,
+				CreatedAt:     now,
+				UpdatedAt:     now,
+			},
+			Tasks: []*storage.Task{{
+				TaskIdentifier: spec.applyIdentifier + "-" + dep,
+				Database:       "payments",
+				DatabaseType:   storage.DatabaseTypeMySQL,
+				Engine:         storage.EngineForType(storage.DatabaseTypeMySQL),
+				Repository:     "octocat/hello-world",
+				PullRequest:    1,
+				Environment:    "staging",
+				State:          taskState,
+				Options:        storage.MarshalApplyOptions(storage.ApplyOptions{}),
+				Namespace:      "payments",
+				TableName:      "widgets",
+				DDL:            "ALTER TABLE widgets ADD COLUMN c int",
+				DDLAction:      "alter",
+				CreatedAt:      now,
+				UpdatedAt:      now,
+			}},
+		})
+	}
+
+	applyID, err := stor.Applies().CreateWithGroupedOperations(ctx, apply, groups)
+	require.NoError(t, err, "seed grouped apply")
+
+	ops := make(map[string]int64, len(groups))
+	for _, group := range groups {
+		ops[group.Operation.Deployment] = group.Operation.ID
+	}
+	return seededMultiOpApply{applyID: applyID, deployments: spec.deployments, ops: ops}
+}
+
+func requestPendingStop(t *testing.T, ctx context.Context, stor storage.Storage, applyID int64) {
+	t.Helper()
+	_, _, err := stor.ControlRequests().RequestPending(ctx, &storage.ApplyControlRequest{
+		ApplyID:     applyID,
+		Operation:   storage.ControlOperationStop,
+		Status:      storage.ControlRequestPending,
+		RequestedBy: "matrix-test",
+	})
+	require.NoError(t, err, "request pending stop")
+}
+
+func stalenessBackdate(t *testing.T, ctx context.Context, db *sql.DB, applyID int64) {
+	t.Helper()
+	_, err := db.ExecContext(ctx,
+		"UPDATE apply_operations SET updated_at = NOW() - INTERVAL 2 MINUTE WHERE apply_id = ?", applyID)
+	require.NoError(t, err, "backdate operation heartbeats")
+}
+
+// --- service + fakes ----------------------------------------------------
+
+func newMatrixService(t *testing.T, stor storage.Storage, clients map[string]tern.Client) *matrixService {
+	t.Helper()
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	cfg := &ServerConfig{OperatorClaimOperations: true}
+	svc := New(stor, cfg, clients, logger)
+
+	summary := &matrixSummaryRecorder{}
+	svc.OnApplyTerminalSummary = func(_ context.Context, apply *storage.Apply, tasks []*storage.Task) error {
+		summary.record(apply, tasks)
+		return nil
+	}
+	svc.OnApplyRecovered = func(*storage.Apply) { summary.recordRecovered() }
+	return &matrixService{Service: svc, matrixSummary: summary}
+}
+
+type matrixService struct {
+	*Service
+	matrixSummary *matrixSummaryRecorder
+}
+
+func driveNextOperation(t *testing.T, ctx context.Context, svc *matrixService, driverID int) {
+	t.Helper()
+	svc.recoverApplyOperation(ctx, driverID, fmt.Sprintf("matrix-driver-%d", driverID))
+}
+
+// driveOneOperation polls like a real operator driver until this driver actually
+// drives one operation. A single claim can find nothing when a peer claims first,
+// so it retries with a bounded deadline rather than giving up after one attempt.
+func driveOneOperation(t *testing.T, ctx context.Context, svc *matrixService, rec *driveRecorder, driverID int) {
+	t.Helper()
+	owner := fmt.Sprintf("matrix-driver-%d", driverID)
+	deadline := time.Now().Add(20 * time.Second)
+	for time.Now().Before(deadline) {
+		before := rec.resumeCount()
+		svc.recoverApplyOperation(ctx, driverID, owner)
+		if rec.resumeCount() > before {
+			return // this driver (or a peer it unblocked) drove an operation
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Errorf("driver %d never drove an operation within the deadline", driverID)
+}
+
+// matrixClients builds one deterministic tern.Client per deployment, keyed by
+// the "deployment/environment" form the service uses to route.
+func matrixClients(stor storage.Storage, rec *driveRecorder, outcomes map[string]matrixOutcome) map[string]tern.Client {
+	clients := make(map[string]tern.Client, len(outcomes))
+	for dep, outcome := range outcomes {
+		clients[dep+"/staging"] = &matrixTernClient{
+			mockTernClient: &mockTernClient{},
+			stor:           stor,
+			deployment:     dep,
+			rec:            rec,
+			outcome:        outcome,
+		}
+	}
+	return clients
+}
+
+type matrixOutcome struct {
+	taskState        string
+	errMsg           string
+	gate             *driveGate
+	probeParentWrite bool
+}
+
+// matrixTernClient is a deterministic tern.Client that simulates one
+// deployment's drive by transitioning that operation's own task rows under the
+// operation lease already on the context, then letting the real operator derive
+// the operation and aggregate parent state. It embeds mockTernClient only to
+// satisfy the rest of the tern.Client interface.
+type matrixTernClient struct {
+	*mockTernClient
+	stor       storage.Storage
+	deployment string
+	rec        *driveRecorder
+	outcome    matrixOutcome
+}
+
+func (m *matrixTernClient) ResumeApplyOperation(ctx context.Context, apply *storage.Apply, applyOperationID int64) error {
+	m.rec.recordResume(m.deployment)
+
+	if m.outcome.gate != nil {
+		m.outcome.gate.arriveAndWait()
+	}
+
+	if m.outcome.probeParentWrite {
+		// A direct parent write under the operation-only lease must fail closed:
+		// the parent applies row is owned solely by the projection CAS.
+		probe := *apply
+		probe.State = state.Apply.Completed
+		m.rec.recordParentWrite(m.stor.Applies().Update(ctx, &probe))
+	}
+
+	tasks, err := m.stor.Tasks().GetByApplyOperationID(ctx, applyOperationID)
+	if err != nil {
+		return fmt.Errorf("matrix fake: load tasks for operation %d: %w", applyOperationID, err)
+	}
+	for _, task := range tasks {
+		task.State = m.outcome.taskState
+		if state.IsState(m.outcome.taskState, state.Task.Failed) {
+			task.ErrorMessage = m.outcome.errMsg
+		}
+		if state.IsTerminalApplyState(m.outcome.taskState) {
+			now := time.Now()
+			task.CompletedAt = &now
+		}
+		if err := m.stor.Tasks().Update(ctx, task); err != nil {
+			return fmt.Errorf("matrix fake: update task %d for deployment %s: %w", task.ID, m.deployment, err)
+		}
+	}
+	return nil
+}
+
+// --- recorders ----------------------------------------------------------
+
+type driveRecorder struct {
+	mu          sync.Mutex
+	order       []string
+	parentWrite []error
+}
+
+func (r *driveRecorder) recordResume(deployment string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.order = append(r.order, deployment)
+}
+
+func (r *driveRecorder) recordParentWrite(err error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.parentWrite = append(r.parentWrite, err)
+}
+
+func (r *driveRecorder) resumeOrder() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]string(nil), r.order...)
+}
+
+func (r *driveRecorder) resumeCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.order)
+}
+
+func (r *driveRecorder) parentWriteErrors() []error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]error(nil), r.parentWrite...)
+}
+
+type matrixSummaryRecorder struct {
+	mu        sync.Mutex
+	calls     int
+	tasks     []*storage.Task
+	recovered int
+}
+
+func (r *matrixSummaryRecorder) record(_ *storage.Apply, tasks []*storage.Task) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.calls++
+	r.tasks = tasks
+}
+
+func (r *matrixSummaryRecorder) recordRecovered() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.recovered++
+}
+
+func (r *matrixSummaryRecorder) count() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.calls
+}
+
+func (r *matrixSummaryRecorder) recoveredCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.recovered
+}
+
+func (r *matrixSummaryRecorder) lastTasks() []*storage.Task {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]*storage.Task(nil), r.tasks...)
+}
+
+// driveGate releases all participants only once the expected number have arrived,
+// proving the operation drives run concurrently rather than serializing.
+type driveGate struct {
+	wg       sync.WaitGroup
+	released chan struct{}
+	once     sync.Once
+}
+
+func newDriveGate(participants int) *driveGate {
+	g := &driveGate{released: make(chan struct{})}
+	g.wg.Add(participants)
+	return g
+}
+
+func (g *driveGate) arriveAndWait() {
+	g.wg.Done()
+	g.once.Do(func() {
+		go func() {
+			g.wg.Wait()
+			close(g.released)
+		}()
+	})
+	select {
+	case <-g.released:
+	case <-time.After(20 * time.Second):
+		// A participant never arrived: the drives serialized instead of running
+		// concurrently. Unblock so the test fails on the assertions rather than
+		// hanging.
+	}
+}
+
+// --- read helpers -------------------------------------------------------
+
+func getApply(t *testing.T, ctx context.Context, stor storage.Storage, applyID int64) *storage.Apply {
+	t.Helper()
+	apply, err := stor.Applies().Get(ctx, applyID)
+	require.NoError(t, err)
+	require.NotNil(t, apply)
+	return apply
+}
+
+func opState(t *testing.T, ctx context.Context, stor storage.Storage, opID int64) string {
+	t.Helper()
+	op, err := stor.ApplyOperations().Get(ctx, opID)
+	require.NoError(t, err)
+	require.NotNil(t, op)
+	return op.State
+}
+
+func stopRequestCompleted(t *testing.T, ctx context.Context, stor storage.Storage, applyID int64) bool {
+	t.Helper()
+	pending, err := stor.ControlRequests().GetPending(ctx, applyID, storage.ControlOperationStop)
+	require.NoError(t, err)
+	return pending == nil
+}


### PR DESCRIPTION
## What and Why ?

Adds the dormant multi-deployment integration test matrix — the last test gate before the config flip. It proves the multi-operation drive path is correct *while it is still unreachable from normal config* (`Validate()` still rejects more than one deployment).

`TestOperatorMultiOperationMatrix` seeds an apply with N operations via `CreateWithGroupedOperations` and drives the operator's claim/drive entrypoints directly against real MySQL, using deterministic per-deployment tern fakes that mutate only their own operation's task rows under the operation lease. No engine DDL, no progress polling, no background operator loop — so the matrix exercises the real claim gate, operation-lease authorization, and aggregate-CAS projection without timing flakiness.

Cases, each pinned to a safety invariant:

- **Rolling + halt, success** — serial drive in deployment order; parent aggregates completed; exactly one terminal summary; per-driver recovered observer suppressed.
- **Rolling + halt, failure** — first failure halts; later deployments never start; failed verdict names the deployment.
- **Rolling + continue, failure** — parent held `running_degraded` while a sibling is in flight, then settles `failed`; one summary.
- **Barrier** — a later deployment's copy may start once the earlier sibling parks at the barrier; parked operations are not re-leased by the copy claim.
- **Pending stop** — a queued stop halts the pending sibling, settles the rollout, and completes the stop request.
- **Concurrent siblings** — operation leases do not serialize on a shared parent lease; a direct parent write under an operation-only lease fails closed (`ErrApplyLeaseLost`); only the aggregate-CAS winner publishes the terminal summary.
```
claim gate (FOR UPDATE SKIP LOCKED)        per-deployment fake          aggregate CAS
op[a] ─▶ recoverApplyOperation ─▶ ResumeApplyOperation(op tasks) ─▶ updateApplyStateFromOperations
op[b] ─▶        (op-lease only, no parent lease)                 ─▶  (single publisher)
```
The end-to-end ordered-cutover *drive* is intentionally deferred: the operator cutover entrypoint lands in a separate in-review PR. Barrier copy-park is covered here; `FindNextApplyOperationCutover` ordering is covered by existing storage tests.

Test-only; no production code changes.
