### PR TITLE
refactor(config): rename operator_workers config key to drivers

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -622,7 +622,7 @@ The operator is part of Tern orchestration. The API service starts it on server 
 
 Each operator driver runs immediately on startup, then polls every 10 seconds. The driver claims at most one apply per tick and resumes it through the Tern client for that apply's deployment and environment. Fresh applies also send a best-effort wake signal after their apply and task rows are committed, so a driver can claim them immediately instead of waiting for the next poll tick.
 
-`operator_workers` controls operator concurrency (the deprecated `operator_workers` alias is still accepted for one release). The default is four drivers, so an untuned server can still make progress across independent databases and environments concurrently. More drivers help larger installations with many independent schema changes because each driver can claim and resume a different target during the same operator tick.
+`drivers` controls operator concurrency (the deprecated `operator_workers` and `scheduler_workers` aliases are still accepted for one release). The default is four drivers, so an untuned server can still make progress across independent databases and environments concurrently. More drivers help larger installations with many independent schema changes because each driver can claim and resume a different target during the same operator tick.
 
 In a multi-pod deployment, every SchemaBot pod runs its own operator. Each operator has its own configurable driver pool, and every driver coordinates through shared storage before resuming an apply. When a recovered apply came from a PR comment, the driver attaches a reconstructed `ProgressObserver` before calling `ResumeApply()` so the resumed progress poller can keep updating PR comments.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -11,7 +11,7 @@
   - [Deployment Order](#deployment-order)
 - [Environment Order](#environment-order)
 - [Hybrid Mode](#hybrid-mode)
-- [Operator Workers](#operator-workers)
+- [Drivers](#drivers)
 - [Pending Drops](#pending-drops)
 - [Support Channel](#support-channel)
 - [Repository Allowlist](#repository-allowlist)
@@ -258,19 +258,19 @@ tern_deployments:
 
 Routing is always server-side. A database environment with `dsn` uses local mode. A database environment with `target` and `deployment` uses gRPC mode through the matching `tern_deployments` endpoint. A database that is not listed in `databases` is not routable.
 
-## Operator Workers
+## Drivers
 
-SchemaBot runs a background operator for apply work that needs server-side coordination. By default, four workers poll for claimable work so a server can make progress across independent databases and environments concurrently.
+SchemaBot runs a background operator for apply work that needs server-side coordination. By default, four drivers poll for claimable work so a server can make progress across independent databases and environments concurrently.
 
 ```yaml
-operator_workers: 4
+drivers: 4
 ```
 
-Increase `operator_workers` when one SchemaBot server should make operator progress across independent databases or environments concurrently. More workers help high-scale installations with many schema changes because each worker can claim and resume a different target during the same operator tick. The operator still excludes overlapping work for the same database and environment, so this improves concurrency across independent targets, not parallel execution against one target.
+Increase `drivers` when one SchemaBot server should make operator progress across independent databases or environments concurrently. More drivers help high-scale installations with many schema changes because each driver can claim and resume a different target during the same operator tick. The operator still excludes overlapping work for the same database and environment, so this improves concurrency across independent targets, not parallel execution against one target.
 
-An operator claim means selecting one stale apply and refreshing its heartbeat in the same storage transaction. That heartbeat refresh is the worker's lease while it reloads state and resumes the apply.
+A driver claim means selecting one stale apply and refreshing its heartbeat in the same storage transaction. That heartbeat refresh is the driver's lease while it reloads state and drives the apply to a terminal state.
 
-> **Deprecated:** the previous `scheduler_workers` key still works as an alias for `operator_workers` and is honored with a deprecation warning. Set only one of the two. The alias will be removed one release after the operator rename has soaked.
+> **Deprecated:** the previous `operator_workers` and `scheduler_workers` keys still work as aliases for `drivers` and are honored with a deprecation warning. Set only one of the three. The aliases will be removed one release after the driver rename has soaked.
 
 ## Pending Drops
 

--- a/integration/operator_test.go
+++ b/integration/operator_test.go
@@ -927,7 +927,7 @@ func TestOperator_ExpiresRetryableBudget(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	svc := schemabotapi.New(stor, &schemabotapi.ServerConfig{OperatorWorkers: 1}, nil, logger)
+	svc := schemabotapi.New(stor, &schemabotapi.ServerConfig{Drivers: 1}, nil, logger)
 	require.NoError(t, svc.SetOperatorPollInterval(50*time.Millisecond))
 	svc.StartOperator(ctx)
 	defer svc.StopOperator()
@@ -993,7 +993,7 @@ func TestOperator_MultipleWorkersResumeDifferentTargets(t *testing.T) {
 	blockingClient1 := newBlockingResumeClient(client1, blockedResume)
 
 	svc := schemabotapi.New(stor, &schemabotapi.ServerConfig{
-		OperatorWorkers: 2,
+		Drivers: 2,
 		Databases: map[string]schemabotapi.DatabaseConfig{
 			db1Name: {
 				Type: "mysql",

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -96,19 +96,25 @@ type ServerConfig struct {
 	// staging before production.
 	EnvironmentOrder []string `yaml:"environment_order"`
 
-	// OperatorWorkers is the number of concurrent operator workers that claim
-	// and resume applies. Each worker independently polls FindNextApply with
-	// FOR UPDATE SKIP LOCKED to prevent races. Defaults to DefaultOperatorWorkers.
-	OperatorWorkers int `yaml:"operator_workers"`
+	// Drivers is the number of concurrent operator drivers that claim and drive
+	// applies. Each driver independently polls FindNextApply with FOR UPDATE
+	// SKIP LOCKED to prevent races. Defaults to DefaultDrivers.
+	Drivers int `yaml:"drivers"`
 
-	// SchedulerWorkers is the deprecated alias for OperatorWorkers. It is kept
-	// so existing config files that still set scheduler_workers continue to
-	// load (the YAML decoder runs with KnownFields(true) and would otherwise
-	// reject the unknown key). Validate() copies it into OperatorWorkers when
-	// the new key is unset and logs a deprecation warning. Remove one release
-	// after the operator rename has soaked.
+	// OperatorWorkers is the deprecated alias for Drivers. It is kept so existing
+	// config files that still set operator_workers continue to load (the YAML
+	// decoder runs with KnownFields(true) and would otherwise reject the unknown
+	// key). Validate() folds it into Drivers when the new key is unset and logs a
+	// deprecation warning. Remove one release after the driver rename has soaked.
 	//
-	// Deprecated: use operator_workers.
+	// Deprecated: use drivers.
+	OperatorWorkers int `yaml:"operator_workers,omitempty"`
+
+	// SchedulerWorkers is the original deprecated alias for Drivers, predating
+	// operator_workers. It is kept for the same KnownFields(true) reason and is
+	// folded into Drivers by Validate() with a deprecation warning.
+	//
+	// Deprecated: use drivers.
 	SchedulerWorkers int `yaml:"scheduler_workers,omitempty"`
 
 	// OperatorClaimOperations switches scheduler workers to claim work at the
@@ -706,26 +712,41 @@ func LoadServerConfigFromFile(path string) (*ServerConfig, error) {
 	return &config, nil
 }
 
-// resolveDeprecatedOperatorWorkers folds the deprecated scheduler_workers key
-// into operator_workers. When only the deprecated key is set it is honored and
-// a deprecation warning is logged; setting both keys is rejected so the
-// effective value is never ambiguous.
-func (c *ServerConfig) resolveDeprecatedOperatorWorkers() error {
-	if c.SchedulerWorkers == 0 {
-		return nil
+// resolveDeprecatedDrivers folds the deprecated operator_workers and
+// scheduler_workers keys into drivers. When only a deprecated key is set it is
+// honored and a deprecation warning is logged; setting more than one of the
+// three keys is rejected so the effective value is never ambiguous.
+func (c *ServerConfig) resolveDeprecatedDrivers() error {
+	set := 0
+	if c.Drivers != 0 {
+		set++
 	}
 	if c.OperatorWorkers != 0 {
-		return fmt.Errorf("set only one of operator_workers or scheduler_workers (scheduler_workers is deprecated)")
+		set++
 	}
-	slog.Warn("scheduler_workers is deprecated; use operator_workers", "scheduler_workers", c.SchedulerWorkers)
-	c.OperatorWorkers = c.SchedulerWorkers
-	c.SchedulerWorkers = 0
+	if c.SchedulerWorkers != 0 {
+		set++
+	}
+	if set > 1 {
+		return fmt.Errorf("set only one of drivers, operator_workers, or scheduler_workers (operator_workers and scheduler_workers are deprecated)")
+	}
+
+	if c.OperatorWorkers != 0 {
+		slog.Warn("operator_workers is deprecated; use drivers", "operator_workers", c.OperatorWorkers)
+		c.Drivers = c.OperatorWorkers
+		c.OperatorWorkers = 0
+	}
+	if c.SchedulerWorkers != 0 {
+		slog.Warn("scheduler_workers is deprecated; use drivers", "scheduler_workers", c.SchedulerWorkers)
+		c.Drivers = c.SchedulerWorkers
+		c.SchedulerWorkers = 0
+	}
 	return nil
 }
 
 // Validate checks the configuration for required fields and consistency.
 func (c *ServerConfig) Validate() error {
-	if err := c.resolveDeprecatedOperatorWorkers(); err != nil {
+	if err := c.resolveDeprecatedDrivers(); err != nil {
 		return err
 	}
 

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -117,7 +117,7 @@ type ServerConfig struct {
 	// Deprecated: use drivers.
 	SchedulerWorkers int `yaml:"scheduler_workers,omitempty"`
 
-	// OperatorClaimOperations switches scheduler workers to claim work at the
+	// OperatorClaimOperations switches drivers to claim work at the
 	// apply_operations (per-deployment) level via FindNextApplyOperation instead
 	// of the apply level via FindNextApply. While the apply-create dual-write
 	// produces exactly one operation per apply, the two paths are equivalent;

--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -1532,7 +1532,7 @@ func TestEnqueueAuthorizedApplyWakesOperatorForQueuedApply(t *testing.T) {
 	applies := &capturingApplyStore{findCh: make(chan struct{}, 1)}
 	mock := &mockTernClient{resumeCh: make(chan *storage.Apply, 1)}
 	svc, _ := newQueueApplyTestService(trustedQueueApplyTestPlan(), mock, applies)
-	svc.config.OperatorWorkers = 1
+	svc.config.Drivers = 1
 	require.NoError(t, svc.SetOperatorPollInterval(time.Hour))
 	svc.StartOperator(t.Context())
 	t.Cleanup(svc.StopOperator)
@@ -2113,7 +2113,7 @@ func TestExecuteApplyWakesOperatorForQueuedLocalApply(t *testing.T) {
 	applies := &capturingApplyStore{findCh: make(chan struct{}, 1)}
 	mock := &mockTernClient{resumeCh: make(chan *storage.Apply, 1)}
 	svc, _ := newExecuteApplyTestService(mock, applies)
-	svc.config.OperatorWorkers = 1
+	svc.config.Drivers = 1
 	require.NoError(t, svc.SetOperatorPollInterval(time.Hour))
 	svc.StartOperator(t.Context())
 	t.Cleanup(svc.StopOperator)

--- a/pkg/api/operator.go
+++ b/pkg/api/operator.go
@@ -31,9 +31,9 @@ const (
 	// min(operatorPollInterval, ApplyOperationHeartbeatInterval).
 	ApplyOperationHeartbeatInterval = 10 * time.Second
 
-	// DefaultOperatorWorkers is the number of concurrent operator drivers
-	// when not configured via operator_workers in the server config.
-	DefaultOperatorWorkers = 4
+	// DefaultDrivers is the number of concurrent operator drivers
+	// when not configured via drivers in the server config.
+	DefaultDrivers = 4
 
 	// ApplyClaimLogTimeout bounds the best-effort apply-log append recording an
 	// operator claim, so a slow or hung storage layer cannot delay the resume
@@ -48,7 +48,7 @@ const (
 // includes queued applies, crash recovery for applies with stale heartbeats,
 // and retry recovery for transient engine failures.
 //
-// Launches N concurrent drivers (configured via operator_workers in config).
+// Launches N concurrent drivers (configured via drivers in config).
 // Each driver independently claims applies using FOR UPDATE SKIP LOCKED.
 // Call StopOperator to gracefully stop.
 func (s *Service) StartOperator(ctx context.Context) {
@@ -59,9 +59,9 @@ func (s *Service) StartOperator(ctx context.Context) {
 		return
 	}
 
-	driverCount := s.config.OperatorWorkers
+	driverCount := s.config.Drivers
 	if driverCount <= 0 {
-		driverCount = DefaultOperatorWorkers
+		driverCount = DefaultDrivers
 	}
 
 	stop := make(chan struct{})

--- a/pkg/api/operator_test.go
+++ b/pkg/api/operator_test.go
@@ -16,28 +16,35 @@ import (
 	"github.com/block/schemabot/pkg/tern"
 )
 
-func TestOperatorWorkersConfig(t *testing.T) {
-	t.Run("default workers", func(t *testing.T) {
+func TestDriversConfig(t *testing.T) {
+	t.Run("default drivers", func(t *testing.T) {
 		config := &ServerConfig{}
+		assert.Equal(t, 0, config.Drivers)
+		assert.Equal(t, 4, DefaultDrivers)
+	})
+
+	t.Run("configured drivers", func(t *testing.T) {
+		config := &ServerConfig{Drivers: 3}
+		assert.Equal(t, 3, config.Drivers)
+	})
+
+	t.Run("deprecated operator_workers folds into drivers", func(t *testing.T) {
+		config := &ServerConfig{OperatorWorkers: 2}
+		require.NoError(t, config.resolveDeprecatedDrivers())
+		assert.Equal(t, 2, config.Drivers)
 		assert.Equal(t, 0, config.OperatorWorkers)
-		assert.Equal(t, 4, DefaultOperatorWorkers)
 	})
 
-	t.Run("configured workers", func(t *testing.T) {
-		config := &ServerConfig{OperatorWorkers: 3}
-		assert.Equal(t, 3, config.OperatorWorkers)
-	})
-
-	t.Run("deprecated scheduler_workers folds into operator_workers", func(t *testing.T) {
+	t.Run("deprecated scheduler_workers folds into drivers", func(t *testing.T) {
 		config := &ServerConfig{SchedulerWorkers: 2}
-		require.NoError(t, config.resolveDeprecatedOperatorWorkers())
-		assert.Equal(t, 2, config.OperatorWorkers)
+		require.NoError(t, config.resolveDeprecatedDrivers())
+		assert.Equal(t, 2, config.Drivers)
 		assert.Equal(t, 0, config.SchedulerWorkers)
 	})
 
-	t.Run("setting both keys is rejected", func(t *testing.T) {
-		config := &ServerConfig{OperatorWorkers: 4, SchedulerWorkers: 2}
-		assert.Error(t, config.resolveDeprecatedOperatorWorkers())
+	t.Run("setting multiple keys is rejected", func(t *testing.T) {
+		config := &ServerConfig{Drivers: 4, OperatorWorkers: 2}
+		assert.Error(t, config.resolveDeprecatedDrivers())
 	})
 }
 

--- a/pkg/webhook/webhook_e2e_test.go
+++ b/pkg/webhook/webhook_e2e_test.go
@@ -203,7 +203,7 @@ func setupE2EService(t *testing.T, appDBName string) *api.Service {
 	t.Cleanup(func() { _ = localClient.Close() })
 
 	serverConfig := &api.ServerConfig{
-		OperatorWorkers: 1,
+		Drivers: 1,
 		Databases: map[string]api.DatabaseConfig{
 			appDBName: {
 				Type: "mysql",


### PR DESCRIPTION
## What

Renames the `operator_workers` config key to **`drivers`**, completing the driver-rename workstream (phases 1–2 renamed the terminology and internal symbols; this is the config-key phase).

- `drivers` is now the canonical key controlling operator concurrency.
- `operator_workers` and `scheduler_workers` are kept as deprecated aliases: each folds into `drivers` with a deprecation warning, and setting more than one of the three is rejected so the effective value is never ambiguous.
- Symbols follow: `OperatorWorkers`→`Drivers`, `DefaultOperatorWorkers`→`DefaultDrivers`, resolver→`resolveDeprecatedDrivers`.
- Docs and tests updated to match.

## Why

The lease-holding worker is now consistently called a *driver* throughout the code, comments, logs, and docs. The config key was the last surface still using the old term. Aliases are retained for one release so existing config files keep loading under `KnownFields(true)`, then removable after the rename soaks.

