### PR TITLE
fix(github): post a fresh progress comment when a stopped apply resumes

### DIFF
--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -2137,6 +2137,35 @@ schemabot start apply-a1b2c3d4e5f6
 </details>
 
 <details>
+<summary><a name="resuming"></a><strong>Resuming</strong></summary>
+
+
+## Schema Change — Resuming
+
+**Database**: `testapp` | **Environment**: `staging` | **Apply ID**: `apply-a1b2c3d4e5f6` | **Elapsed**: 8m
+
+*Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
+
+### Table Progress
+
+**`users`**: 🔄 Resuming…
+
+```sql
+ALTER TABLE `users` ADD INDEX `idx_email`(`email`);
+```
+
+**`orders`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+
+```sql
+ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
+```
+
+
+_Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:00 UTC</relative-time> (2026-01-01 00:00:00 UTC)_
+
+</details>
+
+<details>
 <summary><a name="waiting-for-cutover"></a><strong>Waiting For Cutover</strong></summary>
 
 

--- a/pkg/cmd/internal/templates/preview_comment.go
+++ b/pkg/cmd/internal/templates/preview_comment.go
@@ -214,6 +214,7 @@ func previewCommentApplyFlowAllOutput() {
 		{"FIRST TABLE FAILED", func() { fmt.Print(webhooktemplates.PreviewCommentApplyFirstFailed()) }},
 		{"MIDDLE TABLE FAILED", func() { fmt.Print(webhooktemplates.PreviewCommentApplyFailed()) }},
 		{"STOPPED", func() { fmt.Print(webhooktemplates.PreviewCommentApplyStopped()) }},
+		{"RESUMING", func() { fmt.Print(webhooktemplates.PreviewCommentApplyResuming()) }},
 		// Cutover states
 		{"WAITING FOR CUTOVER", func() { fmt.Print(webhooktemplates.PreviewCommentApplyWaitingForCutover()) }},
 		{"CUTTING OVER", func() { fmt.Print(webhooktemplates.PreviewCommentApplyCuttingOver()) }},

--- a/pkg/schema/mysql/apply_comments.sql
+++ b/pkg/schema/mysql/apply_comments.sql
@@ -5,6 +5,7 @@ CREATE TABLE `apply_comments` (
   `github_comment_id` bigint NOT NULL,
   `edit_count` int NOT NULL DEFAULT '0',
   `last_edited_at` datetime DEFAULT NULL,
+  `superseded_at` datetime DEFAULT NULL,
   `created_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `updated_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`),

--- a/pkg/storage/mysqlstore/apply_comments.go
+++ b/pkg/storage/mysqlstore/apply_comments.go
@@ -129,6 +129,40 @@ func (s *applyCommentStore) DeleteByApply(ctx context.Context, applyID int64) er
 	return err
 }
 
+// Delete removes the tracked comment record for a single (apply_id, comment_state).
+// It stops SchemaBot editing that GitHub comment again; the comment itself is left
+// in place on the PR as a historical record. A missing row is not an error.
+func (s *applyCommentStore) Delete(ctx context.Context, applyID int64, commentState string) error {
+	lease, hasLease, err := applyLeaseFromContext(ctx, applyID)
+	if err != nil {
+		return err
+	}
+	if !hasLease {
+		_, err := s.db.ExecContext(ctx, `
+			DELETE FROM apply_comments WHERE apply_id = ? AND comment_state = ?
+		`, applyID, commentState)
+		return err
+	}
+	result, err := s.db.ExecContext(ctx, `
+		DELETE c FROM apply_comments c
+		JOIN applies a ON a.id = c.apply_id
+		WHERE c.apply_id = ? AND c.comment_state = ? AND a.lease_token = ?
+	`, applyID, commentState, lease.Token)
+	if err != nil {
+		return err
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("read apply comment delete rows affected for apply %d state %s: %w", applyID, commentState, err)
+	}
+	if rows == 0 {
+		if err := ensureApplyLeaseStillOwned(ctx, s.db, lease); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // scanApplyComment scans a single apply comment row, returning nil if not found.
 func scanApplyComment(row *sql.Row) (*storage.ApplyComment, error) {
 	comment, err := scanApplyCommentInto(row)

--- a/pkg/storage/mysqlstore/apply_comments.go
+++ b/pkg/storage/mysqlstore/apply_comments.go
@@ -13,7 +13,7 @@ import (
 )
 
 // applyCommentColumns lists all columns for SELECT queries.
-const applyCommentColumns = `id, apply_id, comment_state, github_comment_id, edit_count, last_edited_at, created_at, updated_at`
+const applyCommentColumns = `id, apply_id, comment_state, github_comment_id, edit_count, last_edited_at, superseded_at, created_at, updated_at`
 
 // applyCommentStore implements storage.ApplyCommentStore using MySQL.
 type applyCommentStore struct {
@@ -32,7 +32,8 @@ func (s *applyCommentStore) Upsert(ctx context.Context, comment *storage.ApplyCo
 			INSERT INTO apply_comments (apply_id, comment_state, github_comment_id)
 			VALUES (?, ?, ?)
 			ON DUPLICATE KEY UPDATE
-				github_comment_id = VALUES(github_comment_id)
+				github_comment_id = VALUES(github_comment_id),
+				superseded_at = NULL
 		`, comment.ApplyID, comment.CommentState, comment.GitHubCommentID)
 		return err
 	}
@@ -42,7 +43,8 @@ func (s *applyCommentStore) Upsert(ctx context.Context, comment *storage.ApplyCo
 		SELECT ?, ?, ? FROM applies a
 		WHERE a.id = ? AND a.lease_token = ?
 		ON DUPLICATE KEY UPDATE
-			github_comment_id = VALUES(github_comment_id)
+			github_comment_id = VALUES(github_comment_id),
+			superseded_at = NULL
 	`, comment.ApplyID, comment.CommentState, comment.GitHubCommentID, comment.ApplyID, lease.Token)
 	if err != nil {
 		return err
@@ -129,33 +131,40 @@ func (s *applyCommentStore) DeleteByApply(ctx context.Context, applyID int64) er
 	return err
 }
 
-// Delete removes the tracked comment record for a single (apply_id, comment_state).
-// It stops SchemaBot editing that GitHub comment again; the comment itself is left
-// in place on the PR as a historical record. A missing row is not an error.
-func (s *applyCommentStore) Delete(ctx context.Context, applyID int64, commentState string) error {
+// Supersede retires the tracked comment for a single (apply_id, comment_state) by
+// stamping superseded_at, without deleting the row or the GitHub comment. The
+// comment stays on the PR as a record; SchemaBot just no longer treats it as the
+// active comment for its state (so it is not edited again and does not re-trigger
+// resume detection). A missing or already-superseded row is not an error. A later
+// Upsert for the same state clears superseded_at, making the row active again.
+func (s *applyCommentStore) Supersede(ctx context.Context, applyID int64, commentState string) error {
 	lease, hasLease, err := applyLeaseFromContext(ctx, applyID)
 	if err != nil {
 		return err
 	}
 	if !hasLease {
 		_, err := s.db.ExecContext(ctx, `
-			DELETE FROM apply_comments WHERE apply_id = ? AND comment_state = ?
+			UPDATE apply_comments SET superseded_at = NOW()
+			WHERE apply_id = ? AND comment_state = ? AND superseded_at IS NULL
 		`, applyID, commentState)
 		return err
 	}
 	result, err := s.db.ExecContext(ctx, `
-		DELETE c FROM apply_comments c
+		UPDATE apply_comments c
 		JOIN applies a ON a.id = c.apply_id
-		WHERE c.apply_id = ? AND c.comment_state = ? AND a.lease_token = ?
+		SET c.superseded_at = NOW()
+		WHERE c.apply_id = ? AND c.comment_state = ? AND c.superseded_at IS NULL AND a.lease_token = ?
 	`, applyID, commentState, lease.Token)
 	if err != nil {
 		return err
 	}
 	rows, err := result.RowsAffected()
 	if err != nil {
-		return fmt.Errorf("read apply comment delete rows affected for apply %d state %s: %w", applyID, commentState, err)
+		return fmt.Errorf("read apply comment supersede rows affected for apply %d state %s: %w", applyID, commentState, err)
 	}
 	if rows == 0 {
+		// Zero rows can mean the row was missing, already superseded, or the lease
+		// was lost. The first two are benign; surface only a lost lease.
 		if err := ensureApplyLeaseStillOwned(ctx, s.db, lease); err != nil {
 			return err
 		}
@@ -191,7 +200,7 @@ func scanApplyCommentInto(s scanner) (*storage.ApplyComment, error) {
 	err := s.Scan(
 		&comment.ID, &comment.ApplyID, &comment.CommentState,
 		&comment.GitHubCommentID, &comment.EditCount, &comment.LastEditedAt,
-		&comment.CreatedAt, &comment.UpdatedAt,
+		&comment.SupersededAt, &comment.CreatedAt, &comment.UpdatedAt,
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/storage/mysqlstore/apply_comments_test.go
+++ b/pkg/storage/mysqlstore/apply_comments_test.go
@@ -171,13 +171,13 @@ func TestApplyCommentStore_DeleteByApply(t *testing.T) {
 	require.NoError(t, store.ApplyComments().DeleteByApply(ctx, 99999))
 }
 
-func TestApplyCommentStore_Delete(t *testing.T) {
+func TestApplyCommentStore_Supersede(t *testing.T) {
 	clearTables(t)
 	ctx := t.Context()
 	store := New(testDB)
 
 	lock := createTestLock(t, store, "testdb", "mysql", "staging")
-	apply := createTestApply(t, store, lock, "apply_comment_del_one", 1)
+	apply := createTestApply(t, store, lock, "apply_comment_supersede", 1)
 
 	require.NoError(t, store.ApplyComments().Upsert(ctx, &storage.ApplyComment{
 		ApplyID: apply.ID, CommentState: state.Comment.Progress, GitHubCommentID: 100,
@@ -186,21 +186,35 @@ func TestApplyCommentStore_Delete(t *testing.T) {
 		ApplyID: apply.ID, CommentState: state.Comment.Summary, GitHubCommentID: 101,
 	}))
 
-	// Delete only the summary marker; the progress comment must remain tracked.
-	require.NoError(t, store.ApplyComments().Delete(ctx, apply.ID, state.Comment.Summary))
+	// Supersede the summary marker. The row is retired in place, not deleted, and
+	// the progress comment is untouched.
+	require.NoError(t, store.ApplyComments().Supersede(ctx, apply.ID, state.Comment.Summary))
 
 	summary, err := store.ApplyComments().Get(ctx, apply.ID, state.Comment.Summary)
 	require.NoError(t, err)
-	assert.Nil(t, summary)
+	require.NotNil(t, summary, "the superseded row is kept, not deleted")
+	assert.NotNil(t, summary.SupersededAt, "the row is marked superseded")
+	assert.Equal(t, int64(101), summary.GitHubCommentID, "the GitHub comment id is preserved")
 
 	progress, err := store.ApplyComments().Get(ctx, apply.ID, state.Comment.Progress)
 	require.NoError(t, err)
 	require.NotNil(t, progress)
+	assert.Nil(t, progress.SupersededAt)
 	assert.Equal(t, int64(100), progress.GitHubCommentID)
 
-	// Deleting a comment state that does not exist is a no-op, not an error.
-	require.NoError(t, store.ApplyComments().Delete(ctx, apply.ID, state.Comment.Summary))
-	require.NoError(t, store.ApplyComments().Delete(ctx, 99999, state.Comment.Progress))
+	// Re-posting a summary (e.g. on a later stop) reactivates the row.
+	require.NoError(t, store.ApplyComments().Upsert(ctx, &storage.ApplyComment{
+		ApplyID: apply.ID, CommentState: state.Comment.Summary, GitHubCommentID: 102,
+	}))
+	summary, err = store.ApplyComments().Get(ctx, apply.ID, state.Comment.Summary)
+	require.NoError(t, err)
+	require.NotNil(t, summary)
+	assert.Nil(t, summary.SupersededAt, "a re-posted summary is active again")
+	assert.Equal(t, int64(102), summary.GitHubCommentID)
+
+	// Superseding a missing or already-superseded state is a no-op, not an error.
+	require.NoError(t, store.ApplyComments().Supersede(ctx, apply.ID, state.Comment.Cutover))
+	require.NoError(t, store.ApplyComments().Supersede(ctx, 99999, state.Comment.Progress))
 }
 
 func TestApplyCommentStore_UniqueConstraint(t *testing.T) {

--- a/pkg/storage/mysqlstore/apply_comments_test.go
+++ b/pkg/storage/mysqlstore/apply_comments_test.go
@@ -171,6 +171,38 @@ func TestApplyCommentStore_DeleteByApply(t *testing.T) {
 	require.NoError(t, store.ApplyComments().DeleteByApply(ctx, 99999))
 }
 
+func TestApplyCommentStore_Delete(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", "mysql", "staging")
+	apply := createTestApply(t, store, lock, "apply_comment_del_one", 1)
+
+	require.NoError(t, store.ApplyComments().Upsert(ctx, &storage.ApplyComment{
+		ApplyID: apply.ID, CommentState: state.Comment.Progress, GitHubCommentID: 100,
+	}))
+	require.NoError(t, store.ApplyComments().Upsert(ctx, &storage.ApplyComment{
+		ApplyID: apply.ID, CommentState: state.Comment.Summary, GitHubCommentID: 101,
+	}))
+
+	// Delete only the summary marker; the progress comment must remain tracked.
+	require.NoError(t, store.ApplyComments().Delete(ctx, apply.ID, state.Comment.Summary))
+
+	summary, err := store.ApplyComments().Get(ctx, apply.ID, state.Comment.Summary)
+	require.NoError(t, err)
+	assert.Nil(t, summary)
+
+	progress, err := store.ApplyComments().Get(ctx, apply.ID, state.Comment.Progress)
+	require.NoError(t, err)
+	require.NotNil(t, progress)
+	assert.Equal(t, int64(100), progress.GitHubCommentID)
+
+	// Deleting a comment state that does not exist is a no-op, not an error.
+	require.NoError(t, store.ApplyComments().Delete(ctx, apply.ID, state.Comment.Summary))
+	require.NoError(t, store.ApplyComments().Delete(ctx, 99999, state.Comment.Progress))
+}
+
 func TestApplyCommentStore_UniqueConstraint(t *testing.T) {
 	clearTables(t)
 	ctx := t.Context()

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -413,11 +413,12 @@ type ApplyCommentStore interface {
 	// DeleteByApply removes all comment records for an apply.
 	DeleteByApply(ctx context.Context, applyID int64) error
 
-	// Delete removes the tracked comment record for a single
-	// (apply_id, comment_state). The GitHub comment itself is left in place; only
-	// SchemaBot's tracking of it is dropped, so it is no longer edited. A missing
-	// row is not an error.
-	Delete(ctx context.Context, applyID int64, commentState string) error
+	// Supersede retires the tracked comment for a single (apply_id, comment_state)
+	// by stamping superseded_at — the row and the GitHub comment are kept, but
+	// SchemaBot no longer treats it as the active comment for its state. A later
+	// Upsert for the same state clears superseded_at. A missing or already-
+	// superseded row is not an error.
+	Supersede(ctx context.Context, applyID int64, commentState string) error
 }
 
 // ApplyOperationStore manages per-(apply, deployment) child rows for

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -412,6 +412,12 @@ type ApplyCommentStore interface {
 
 	// DeleteByApply removes all comment records for an apply.
 	DeleteByApply(ctx context.Context, applyID int64) error
+
+	// Delete removes the tracked comment record for a single
+	// (apply_id, comment_state). The GitHub comment itself is left in place; only
+	// SchemaBot's tracking of it is dropped, so it is no longer edited. A missing
+	// row is not an error.
+	Delete(ctx context.Context, applyID int64, commentState string) error
 }
 
 // ApplyOperationStore manages per-(apply, deployment) child rows for

--- a/pkg/storage/types.go
+++ b/pkg/storage/types.go
@@ -808,6 +808,12 @@ type ApplyComment struct {
 	// LastEditedAt is when the comment was last edited via the GitHub API.
 	LastEditedAt *time.Time
 
+	// SupersededAt is set when this comment has been retired by a newer one
+	// (e.g. a stopped-summary marker consumed when the apply resumes). The row and
+	// the GitHub comment are kept; SchemaBot just no longer treats it as the active
+	// comment for its state. Nil means active.
+	SupersededAt *time.Time
+
 	// CreatedAt is when the comment was first posted.
 	CreatedAt time.Time
 

--- a/pkg/tern/grpc_client.go
+++ b/pkg/tern/grpc_client.go
@@ -1367,6 +1367,9 @@ func (c *GRPCClient) resumeApply(ctx context.Context, apply *storage.Apply, scop
 				apply.StartedAt = &now
 			}
 			remoteStartRequested = true
+			if err := c.requeueStoppedTasksForRemoteStart(ctx, apply, scope); err != nil {
+				return err
+			}
 		}
 
 		persisted, err := c.persistParentApply(ctx, apply, scope, "refresh stopped gRPC apply before start")
@@ -1778,6 +1781,35 @@ func isTerminalRemoteProgressError(err error) bool {
 	default:
 		return false
 	}
+}
+
+// requeueStoppedTasksForRemoteStart requeues an apply's stopped task rows once the
+// data plane accepts a start. The gRPC drive delegates the engine to remote Tern,
+// so it must mirror LocalClient.prepareStoppedTasksForResume: a task left at
+// "stopped" is pinned there by taskStateWithNoBackwardProgress on every later
+// progress poll (a stopped task blocks active engine progress), so the resumed row
+// copy would never surface in stored task state and the PR progress comment would
+// keep rendering "Stopped" while the data plane is actively copying. Requeuing to
+// pending lets the next progress sync advance the task to running.
+func (c *GRPCClient) requeueStoppedTasksForRemoteStart(ctx context.Context, apply *storage.Apply, scope applyTaskScope) error {
+	tasks, err := c.loadApplyTasks(ctx, apply, scope)
+	if err != nil {
+		return fmt.Errorf("load tasks to requeue stopped gRPC apply %s for start: %w", apply.ApplyIdentifier, err)
+	}
+	for _, task := range tasks {
+		if !state.IsState(task.State, state.Task.Stopped) {
+			continue
+		}
+		oldState := task.State
+		task.State = state.Task.Pending
+		task.CompletedAt = nil
+		if err := c.storage.Tasks().Update(ctx, task); err != nil {
+			return fmt.Errorf("requeue stopped task %s for gRPC apply %s start: %w", task.TaskIdentifier, apply.ApplyIdentifier, err)
+		}
+		c.logTaskStateTransition(ctx, apply.ID, task,
+			fmt.Sprintf("Task %s requeued for start", task.TableName), oldState)
+	}
+	return nil
 }
 
 func (c *GRPCClient) prepareDispatchTasks(ctx context.Context, apply *storage.Apply, tasks []*storage.Task) error {

--- a/pkg/tern/grpc_client_test.go
+++ b/pkg/tern/grpc_client_test.go
@@ -3095,6 +3095,42 @@ func TestGRPCClient_ResumeApplyPublishesResumingUntilDataPlaneLeavesStopped(t *t
 	assert.Nil(t, startReq, "the start control request must be completed once the resume is driven")
 }
 
+func TestGRPCClient_RequeueStoppedTasksForRemoteStart(t *testing.T) {
+	// When the data plane accepts a start, the gRPC drive must requeue the apply's
+	// stopped task rows to pending. Otherwise taskStateWithNoBackwardProgress pins
+	// them at stopped on every later progress poll (stopped blocks active engine
+	// progress), so the resumed row copy never surfaces and the PR comment keeps
+	// rendering "Stopped" while the data plane copies. Tasks in other states are
+	// left untouched.
+	client, cleanup := testCapturingGRPCClient(t, &capturingTernServer{})
+	defer cleanup()
+
+	completedAt := time.Now()
+	apply := &storage.Apply{
+		ID:              1,
+		ApplyIdentifier: "apply-requeue-stopped",
+		Database:        "testdb",
+		Environment:     "staging",
+		State:           state.Apply.Resuming,
+	}
+	taskStore := &mockTaskStore{tasks: []*storage.Task{
+		{TaskIdentifier: "t-stopped", ApplyID: 1, State: state.Task.Stopped, TableName: "users", CompletedAt: &completedAt},
+		{TaskIdentifier: "t-completed", ApplyID: 1, State: state.Task.Completed, TableName: "orders"},
+	}}
+	client.storage = &mockStorage{
+		applies: &mockApplyStore{apply: apply},
+		tasks:   taskStore,
+		logs:    &mockApplyLogStore{},
+	}
+
+	err := client.requeueStoppedTasksForRemoteStart(t.Context(), apply, wholeApplyTaskScope())
+	require.NoError(t, err)
+
+	assert.Equal(t, state.Task.Pending, taskStore.tasks[0].State, "stopped task must be requeued to pending on resume")
+	assert.Nil(t, taskStore.tasks[0].CompletedAt, "requeued task must clear its completed timestamp")
+	assert.Equal(t, state.Task.Completed, taskStore.tasks[1].State, "non-stopped task must be left untouched")
+}
+
 func TestGRPCClient_ResumeApplyCompletesQueuedStopBeforeQueuedStart(t *testing.T) {
 	// Start can arrive immediately after stop progress is visible. The operator
 	// should consume the resolved stop request and continue with the queued start

--- a/pkg/webhook/apply_comment_e2e_test.go
+++ b/pkg/webhook/apply_comment_e2e_test.go
@@ -342,7 +342,9 @@ func TestE2EResumeRotatesProgressComment(t *testing.T) {
 	lock, err = st.Locks().Get(ctx, "e2e_rotate_db", "mysql")
 	require.NoError(t, err)
 
-	// The apply has resumed: it is active again (Running) after an operator start.
+	// The apply has just been started again after a stop: the data plane accepted
+	// the start, so the apply is in the Resuming window (it may still report stopped
+	// briefly) before it transitions to Running.
 	apply := &storage.Apply{
 		ApplyIdentifier: fmt.Sprintf("apply_e2e_rotate_%d", time.Now().UnixNano()),
 		LockID:          lock.ID,
@@ -354,7 +356,7 @@ func TestE2EResumeRotatesProgressComment(t *testing.T) {
 		Environment:     "staging",
 		InstallationID:  12345,
 		Engine:          "spirit",
-		State:           state.Apply.Running,
+		State:           state.Apply.Resuming,
 	}
 	applyID, err := st.Applies().Create(ctx, apply)
 	require.NoError(t, err)
@@ -367,7 +369,7 @@ func TestE2EResumeRotatesProgressComment(t *testing.T) {
 		UPDATE applies
 		SET lease_owner = ?, lease_token = ?, lease_acquired_at = ?, state = ?
 		WHERE id = ?
-	`, apply.LeaseOwner, apply.LeaseToken, leaseAcquiredAt, state.Apply.Running, applyID)
+	`, apply.LeaseOwner, apply.LeaseToken, leaseAcquiredAt, state.Apply.Resuming, applyID)
 	require.NoError(t, err)
 
 	// The task is copying again after resume.
@@ -422,15 +424,19 @@ func TestE2EResumeRotatesProgressComment(t *testing.T) {
 		Clock:          fake,
 	})
 
-	// First progress tick after resume rotates the progress comment.
+	// First progress tick after resume rotates the progress comment. While the
+	// apply is in the Resuming window the comment renders state-only: the row-copy
+	// percent is indeterminate (continuation vs fresh copy), so no bar is shown.
 	obs.OnProgress(apply, []*storage.Task{task})
 
 	var newProgressID int64
 	select {
 	case created := <-capture.creates:
 		newProgressID = created.ID
-		assert.Contains(t, created.Body, "Schema Change In Progress")
+		assert.Contains(t, created.Body, "Schema Change — Resuming")
+		assert.Contains(t, created.Body, "Resuming…")
 		assert.NotContains(t, created.Body, "Stopped")
+		assert.NotContains(t, created.Body, "50%", "the indeterminate resume window must not show a stale percent")
 	case <-time.After(5 * time.Second):
 		t.Fatal("expected a new progress comment to be posted on resume")
 	}
@@ -445,7 +451,9 @@ func TestE2EResumeRotatesProgressComment(t *testing.T) {
 	require.NoError(t, err)
 	assert.Nil(t, summary, "stopped summary marker should be consumed after rotation")
 
-	// A later tick edits the new comment in place — it does not rotate again.
+	// Once the data plane leaves stopped the apply is Running: a later tick edits
+	// the new comment in place (it does not rotate again) and now shows the bar.
+	apply.State = state.Apply.Running
 	fake.Advance(activeInterval + time.Second)
 	task.RowsCopied = 700
 	task.ProgressPercent = 70
@@ -454,6 +462,7 @@ func TestE2EResumeRotatesProgressComment(t *testing.T) {
 	select {
 	case edited := <-capture.edits:
 		assert.Equal(t, newProgressID, edited.CommentID, "later edits land on the new comment")
+		assert.Contains(t, edited.Body, "70%", "once running, the new comment shows real row-copy progress")
 	case created := <-capture.creates:
 		t.Fatalf("resume must rotate exactly once; got another new comment %d", created.ID)
 	case <-time.After(5 * time.Second):

--- a/pkg/webhook/apply_comment_e2e_test.go
+++ b/pkg/webhook/apply_comment_e2e_test.go
@@ -447,14 +447,17 @@ func TestE2EResumeRotatesProgressComment(t *testing.T) {
 	}
 	assert.NotEqual(t, stoppedProgressID, newProgressID, "resume must post a new comment, not reuse the stopped one")
 
-	// The progress row now tracks the new comment; the summary marker is consumed.
+	// The progress row now tracks the new comment; the stopped-summary marker is
+	// consumed by being superseded — the row and its GitHub comment are kept, not
+	// deleted.
 	prog, err := st.ApplyComments().Get(ctx, applyID, state.Comment.Progress)
 	require.NoError(t, err)
 	require.NotNil(t, prog)
 	assert.Equal(t, newProgressID, prog.GitHubCommentID)
 	summary, err := st.ApplyComments().Get(ctx, applyID, state.Comment.Summary)
 	require.NoError(t, err)
-	assert.Nil(t, summary, "stopped summary marker should be consumed after rotation")
+	require.NotNil(t, summary, "the stopped-summary row is retired, not deleted")
+	assert.NotNil(t, summary.SupersededAt, "the stopped-summary marker is superseded after rotation")
 
 	// Once the data plane leaves stopped the apply is Running: a later tick edits
 	// the new comment in place (it does not rotate again) and now shows the bar.

--- a/pkg/webhook/apply_comment_e2e_test.go
+++ b/pkg/webhook/apply_comment_e2e_test.go
@@ -326,10 +326,15 @@ func TestE2EResumeRotatesProgressComment(t *testing.T) {
 
 	st := mysqlstore.New(schemabotDB)
 
-	_, _ = schemabotDB.ExecContext(ctx, "DELETE FROM apply_comments")
-	_, _ = schemabotDB.ExecContext(ctx, "DELETE FROM tasks WHERE repository = 'org/repo-rotate'")
-	_, _ = schemabotDB.ExecContext(ctx, "DELETE FROM applies WHERE repository = 'org/repo-rotate'")
-	_, _ = schemabotDB.ExecContext(ctx, "DELETE FROM locks WHERE repository = 'org/repo-rotate'")
+	for _, stmt := range []string{
+		"DELETE FROM apply_comments",
+		"DELETE FROM tasks WHERE repository = 'org/repo-rotate'",
+		"DELETE FROM applies WHERE repository = 'org/repo-rotate'",
+		"DELETE FROM locks WHERE repository = 'org/repo-rotate'",
+	} {
+		_, err = schemabotDB.ExecContext(ctx, stmt)
+		require.NoError(t, err)
+	}
 
 	lock := &storage.Lock{
 		DatabaseName: "e2e_rotate_db",

--- a/pkg/webhook/apply_comment_e2e_test.go
+++ b/pkg/webhook/apply_comment_e2e_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/block/spirit/pkg/utils"
 
 	"github.com/block/schemabot/pkg/api"
+	"github.com/block/schemabot/pkg/clock"
 	ghclient "github.com/block/schemabot/pkg/github"
 	"github.com/block/schemabot/pkg/state"
 	"github.com/block/schemabot/pkg/storage"
@@ -309,6 +310,168 @@ func TestE2EApplyCommentLifecycle(t *testing.T) {
 	assert.Equal(t, progressCommentID, commentStates[state.Comment.Progress])
 	assert.Equal(t, cutoverCommentID, commentStates[state.Comment.Cutover])
 	assert.Equal(t, summaryCommentID, commentStates[state.Comment.Summary])
+}
+
+// When a stopped apply resumes, the observer posts a fresh progress comment and
+// tracks that as the live one, rather than re-editing the comment frozen at
+// "Stopped". The prior progress comment is left in place as the record of where
+// the apply paused, the stopped summary marker is consumed, and later progress
+// edits land on the new comment.
+func TestE2EResumeRotatesProgressComment(t *testing.T) {
+	ctx := t.Context()
+
+	schemabotDB, err := sql.Open("mysql", e2eSchemabotDSN)
+	require.NoError(t, err)
+	t.Cleanup(func() { utils.CloseAndLog(schemabotDB) })
+
+	st := mysqlstore.New(schemabotDB)
+
+	_, _ = schemabotDB.ExecContext(ctx, "DELETE FROM apply_comments")
+	_, _ = schemabotDB.ExecContext(ctx, "DELETE FROM tasks WHERE repository = 'org/repo-rotate'")
+	_, _ = schemabotDB.ExecContext(ctx, "DELETE FROM applies WHERE repository = 'org/repo-rotate'")
+	_, _ = schemabotDB.ExecContext(ctx, "DELETE FROM locks WHERE repository = 'org/repo-rotate'")
+
+	lock := &storage.Lock{
+		DatabaseName: "e2e_rotate_db",
+		DatabaseType: "mysql",
+		Repository:   "org/repo-rotate",
+		PullRequest:  142,
+		Owner:        "org/repo-rotate#142",
+	}
+	require.NoError(t, st.Locks().Acquire(ctx, lock))
+	lock, err = st.Locks().Get(ctx, "e2e_rotate_db", "mysql")
+	require.NoError(t, err)
+
+	// The apply has resumed: it is active again (Running) after an operator start.
+	apply := &storage.Apply{
+		ApplyIdentifier: fmt.Sprintf("apply_e2e_rotate_%d", time.Now().UnixNano()),
+		LockID:          lock.ID,
+		PlanID:          1,
+		Database:        "e2e_rotate_db",
+		DatabaseType:    "mysql",
+		Repository:      "org/repo-rotate",
+		PullRequest:     142,
+		Environment:     "staging",
+		InstallationID:  12345,
+		Engine:          "spirit",
+		State:           state.Apply.Running,
+	}
+	applyID, err := st.Applies().Create(ctx, apply)
+	require.NoError(t, err)
+	apply.ID = applyID
+	apply.LeaseOwner = "resume-test-driver"
+	apply.LeaseToken = "resume-test-token"
+	leaseAcquiredAt := time.Now()
+	apply.LeaseAcquiredAt = &leaseAcquiredAt
+	_, err = schemabotDB.ExecContext(ctx, `
+		UPDATE applies
+		SET lease_owner = ?, lease_token = ?, lease_acquired_at = ?, state = ?
+		WHERE id = ?
+	`, apply.LeaseOwner, apply.LeaseToken, leaseAcquiredAt, state.Apply.Running, applyID)
+	require.NoError(t, err)
+
+	// The task is copying again after resume.
+	now := time.Now()
+	task := &storage.Task{
+		TaskIdentifier:  fmt.Sprintf("task_e2e_rotate_%d", now.UnixNano()),
+		ApplyID:         applyID,
+		PlanID:          1,
+		Database:        "e2e_rotate_db",
+		DatabaseType:    "mysql",
+		Engine:          "spirit",
+		Repository:      "org/repo-rotate",
+		PullRequest:     142,
+		Environment:     "staging",
+		State:           state.Task.Running,
+		TableName:       "users",
+		DDL:             "ALTER TABLE users ADD INDEX idx_email (email)",
+		DDLAction:       "alter",
+		RowsCopied:      500,
+		RowsTotal:       1000,
+		ProgressPercent: 50,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+	_, err = st.Tasks().Create(ctx, task)
+	require.NoError(t, err)
+
+	installClient, capture := setupFakeGitHubForComments(t)
+	factory := &fakeClientFactory{client: installClient}
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	serverConfig := &api.ServerConfig{}
+	svc := api.New(st, serverConfig, map[string]tern.Client{}, logger)
+	t.Cleanup(func() { _ = svc.Close() })
+	h := NewHandler(svc, factory, nil, logger)
+
+	// Seed the pre-resume comments left by the stop: the progress comment frozen at
+	// "Stopped" and the stopped summary marker that signals a resume is in progress.
+	h.postAndTrackComment(ctx, "org/repo-rotate", 142, 12345, applyID, state.Comment.Progress, "Stopped at 21%")
+	stoppedProgressID := requireCommentCreate(t, capture)
+	h.postAndTrackComment(ctx, "org/repo-rotate", 142, 12345, applyID, state.Comment.Summary, "Schema Change Stopped")
+	requireCommentCreate(t, capture)
+
+	fake := clock.NewFake(now)
+	obs := NewCommentObserver(CommentObserverConfig{
+		GHClient:       factory,
+		Storage:        st,
+		Repo:           "org/repo-rotate",
+		PR:             142,
+		InstallationID: 12345,
+		ApplyID:        applyID,
+		Logger:         logger,
+		Clock:          fake,
+	})
+
+	// First progress tick after resume rotates the progress comment.
+	obs.OnProgress(apply, []*storage.Task{task})
+
+	var newProgressID int64
+	select {
+	case created := <-capture.creates:
+		newProgressID = created.ID
+		assert.Contains(t, created.Body, "Schema Change In Progress")
+		assert.NotContains(t, created.Body, "Stopped")
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected a new progress comment to be posted on resume")
+	}
+	assert.NotEqual(t, stoppedProgressID, newProgressID, "resume must post a new comment, not reuse the stopped one")
+
+	// The progress row now tracks the new comment; the summary marker is consumed.
+	prog, err := st.ApplyComments().Get(ctx, applyID, state.Comment.Progress)
+	require.NoError(t, err)
+	require.NotNil(t, prog)
+	assert.Equal(t, newProgressID, prog.GitHubCommentID)
+	summary, err := st.ApplyComments().Get(ctx, applyID, state.Comment.Summary)
+	require.NoError(t, err)
+	assert.Nil(t, summary, "stopped summary marker should be consumed after rotation")
+
+	// A later tick edits the new comment in place — it does not rotate again.
+	fake.Advance(activeInterval + time.Second)
+	task.RowsCopied = 700
+	task.ProgressPercent = 70
+	obs.OnProgress(apply, []*storage.Task{task})
+
+	select {
+	case edited := <-capture.edits:
+		assert.Equal(t, newProgressID, edited.CommentID, "later edits land on the new comment")
+	case created := <-capture.creates:
+		t.Fatalf("resume must rotate exactly once; got another new comment %d", created.ID)
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected an in-place edit of the new progress comment on the next tick")
+	}
+}
+
+// requireCommentCreate returns the next captured comment-create id, failing if
+// none arrives.
+func requireCommentCreate(t *testing.T, capture *commentCapture) int64 {
+	t.Helper()
+	select {
+	case created := <-capture.creates:
+		return created.ID
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for comment create")
+		return 0
+	}
 }
 
 func TestE2EReconcileMissingSummaryCommentsPostsSummary(t *testing.T) {

--- a/pkg/webhook/comment_observer.go
+++ b/pkg/webhook/comment_observer.go
@@ -466,9 +466,10 @@ func (o *CommentObserver) rotateProgressCommentForResume(apply *storage.Apply, t
 		o.logError(apply, "observer: failed to check for summary comment before resume rotation", "error", err)
 		return false
 	}
-	if summary == nil {
-		// No summary comment — the apply has not been stopped, so there is nothing
-		// to rotate. This is the common path on every progress tick.
+	if summary == nil || summary.SupersededAt != nil {
+		// No active summary comment — either the apply has not been stopped, or a
+		// prior resume already consumed the marker. Nothing to rotate. This is the
+		// common path on every progress tick.
 		return false
 	}
 
@@ -476,7 +477,7 @@ func (o *CommentObserver) rotateProgressCommentForResume(apply *storage.Apply, t
 	o.postAndTrackComment(apply, state.Comment.Progress, body)
 	o.resumeRotated = true
 
-	if err := o.stor.ApplyComments().Delete(o.contextWithApplyLease(ctx, apply), o.applyID, state.Comment.Summary); err != nil {
+	if err := o.stor.ApplyComments().Supersede(o.contextWithApplyLease(ctx, apply), o.applyID, state.Comment.Summary); err != nil {
 		o.logError(apply, "observer: failed to consume summary marker after resume rotation", "error", err)
 		return true
 	}

--- a/pkg/webhook/comment_observer.go
+++ b/pkg/webhook/comment_observer.go
@@ -58,6 +58,7 @@ type CommentObserver struct {
 	lastRowsCopied    int64
 	stagnantTicks     int
 	hasCutoverComment bool
+	resumeRotated     bool
 }
 
 const (
@@ -448,6 +449,15 @@ func (o *CommentObserver) editTrackedComment(apply *storage.Apply, commentState 
 // exactly once and the eventual terminal summary is posted fresh. Returns true
 // when it rotated.
 func (o *CommentObserver) rotateProgressCommentForResume(apply *storage.Apply, tasks []*storage.Task) bool {
+	if o.resumeRotated {
+		// This observer already rotated for the current resume. Guard against
+		// re-rotating (and posting duplicate fresh comments) on later ticks if the
+		// summary-marker delete below failed to land. A fresh observer on a later
+		// drive claim starts with this unset and rotates once more, bounding any
+		// duplicate to one per drive rather than one per tick.
+		return false
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
@@ -464,6 +474,7 @@ func (o *CommentObserver) rotateProgressCommentForResume(apply *storage.Apply, t
 
 	body := o.formatStatusComment(apply, tasks)
 	o.postAndTrackComment(apply, state.Comment.Progress, body)
+	o.resumeRotated = true
 
 	if err := o.stor.ApplyComments().Delete(o.contextWithApplyLease(ctx, apply), o.applyID, state.Comment.Summary); err != nil {
 		o.logError(apply, "observer: failed to consume summary marker after resume rotation", "error", err)

--- a/pkg/webhook/comment_observer.go
+++ b/pkg/webhook/comment_observer.go
@@ -192,6 +192,18 @@ func (o *CommentObserver) OnProgress(apply *storage.Apply, tasks []*storage.Task
 		return
 	}
 
+	// A summary comment present while the apply is active again means the apply
+	// was stopped and has resumed — stopped is the only terminal state that
+	// returns to active. Post a fresh progress comment to track the resumed row
+	// copy and leave the prior comment frozen at "Stopped" as the record of where
+	// the apply paused.
+	if !state.IsTerminalApplyState(apply.State) && o.rotateProgressCommentForResume(apply, tasks) {
+		o.lastState = currentState
+		o.lastProgressPost = now
+		o.stagnantTicks = 0
+		return
+	}
+
 	// Adaptive rate limiting — ported from watchApplyProgress.
 	// Edit every 5s when progress is moving, slow to 30s when stagnant.
 	var totalRows int64
@@ -423,6 +435,43 @@ func (o *CommentObserver) editTrackedComment(apply *storage.Apply, commentState 
 	if err := o.stor.ApplyComments().IncrementEditCount(o.contextWithApplyLease(ctx, apply), o.applyID, commentState); err != nil {
 		o.logError(apply, "observer: failed to increment edit count", "error", err, "comment_state", commentState)
 	}
+}
+
+// rotateProgressCommentForResume posts a fresh progress comment when a resumed
+// apply is detected, so the resumed row copy is tracked in a new comment instead
+// of re-editing the comment frozen at "Stopped". The signal is durable and
+// cross-pod safe: OnTerminal writes a summary comment when an apply stops, so an
+// active apply with a summary comment present has resumed. On rotation it posts a
+// new progress comment — postAndTrackComment overwrites the tracked progress
+// comment id, so later progress edits land on the new comment while the prior one
+// stays frozen as the record — and consumes the summary marker so it rotates
+// exactly once and the eventual terminal summary is posted fresh. Returns true
+// when it rotated.
+func (o *CommentObserver) rotateProgressCommentForResume(apply *storage.Apply, tasks []*storage.Task) bool {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	summary, err := o.stor.ApplyComments().Get(ctx, o.applyID, state.Comment.Summary)
+	if err != nil {
+		o.logError(apply, "observer: failed to check for summary comment before resume rotation", "error", err)
+		return false
+	}
+	if summary == nil {
+		// No summary comment — the apply has not been stopped, so there is nothing
+		// to rotate. This is the common path on every progress tick.
+		return false
+	}
+
+	body := o.formatStatusComment(apply, tasks)
+	o.postAndTrackComment(apply, state.Comment.Progress, body)
+
+	if err := o.stor.ApplyComments().Delete(o.contextWithApplyLease(ctx, apply), o.applyID, state.Comment.Summary); err != nil {
+		o.logError(apply, "observer: failed to consume summary marker after resume rotation", "error", err)
+		return true
+	}
+	o.logger.Info("observer: posted fresh progress comment for resumed apply",
+		"apply_id", o.applyID, "repo", o.repo, "pr", o.pr, "state", apply.State)
+	return true
 }
 
 // postAndTrackComment creates a comment and stores its ID.

--- a/pkg/webhook/templates/apply.go
+++ b/pkg/webhook/templates/apply.go
@@ -349,6 +349,7 @@ func writeTableProgressSection(sb *strings.Builder, data ApplyStatusCommentData)
 func renderResumingTable(sb *strings.Builder, table TableProgressData) {
 	fmt.Fprintf(sb, "**`%s`**: \U0001f504 Resuming…\n", table.TableName)
 	writeDDLLine(sb, table.DDL)
+	sb.WriteString("\n")
 }
 
 // tableStatePriority returns a sort key: lower = rendered first (active on top, completed on bottom).

--- a/pkg/webhook/templates/apply.go
+++ b/pkg/webhook/templates/apply.go
@@ -103,6 +103,8 @@ func writeApplyHeader(sb *strings.Builder, data ApplyStatusCommentData) {
 		sb.WriteString("## Schema Change — Waiting for Cutover\n\n")
 	case state.Apply.Recovering:
 		sb.WriteString("## Schema Change — Recovering\n\n")
+	case state.Apply.Resuming:
+		sb.WriteString("## Schema Change — Resuming\n\n")
 	case state.Apply.CuttingOver:
 		sb.WriteString("## Schema Change — Cutting Over\n\n")
 	case state.Apply.RevertWindow:
@@ -313,7 +315,13 @@ func writeProgressSummary(sb *strings.Builder, tables []TableProgressData) {
 // writeTableProgressSection writes the per-table progress breakdown.
 // Tables are sorted: active/running first, then pending, then completed/terminal last.
 func writeTableProgressSection(sb *strings.Builder, data ApplyStatusCommentData) {
-	writeProgressSummary(sb, data.Tables)
+	// During the resume window the per-table percents are indeterminate (the data
+	// plane has not reported continuation vs fresh copy yet), so the aggregate
+	// running-percent summary would surface stale pre-stop numbers. The per-table
+	// "Resuming…" lines below convey state without it.
+	if data.State != state.Apply.Resuming {
+		writeProgressSummary(sb, data.Tables)
+	}
 	sb.WriteString("\n### Table Progress\n\n")
 
 	sorted := make([]TableProgressData, len(data.Tables))
@@ -323,8 +331,24 @@ func writeTableProgressSection(sb *strings.Builder, data ApplyStatusCommentData)
 	})
 
 	for _, table := range sorted {
+		// While the apply is resuming, the data plane has not yet reported whether
+		// the schema change continues from its checkpoint or restarts from scratch,
+		// so the row-copy percent is indeterminate. Render state-only until the
+		// apply transitions to running and real progress is known.
+		if data.State == state.Apply.Resuming && !state.IsTerminalTaskState(state.NormalizeTaskStatus(table.Status)) {
+			renderResumingTable(sb, table)
+			continue
+		}
 		renderTableProgress(sb, table)
 	}
+}
+
+// renderResumingTable renders a table while the apply is resuming, before the
+// data plane reports whether the change continues from its checkpoint or restarts
+// from scratch. The percent is intentionally omitted during this window.
+func renderResumingTable(sb *strings.Builder, table TableProgressData) {
+	fmt.Fprintf(sb, "**`%s`**: \U0001f504 Resuming…\n", table.TableName)
+	writeDDLLine(sb, table.DDL)
 }
 
 // tableStatePriority returns a sort key: lower = rendered first (active on top, completed on bottom).

--- a/pkg/webhook/templates/apply_test.go
+++ b/pkg/webhook/templates/apply_test.go
@@ -621,6 +621,15 @@ func TestPreviewCommentApplyStopped(t *testing.T) {
 	assert.Contains(t, result, "schemabot start")
 }
 
+func TestPreviewCommentApplyResuming(t *testing.T) {
+	result := PreviewCommentApplyResuming()
+
+	assert.Contains(t, result, "Schema Change — Resuming")
+	assert.Contains(t, result, "🔄 Resuming…")
+	// The indeterminate resume window hides the stale pre-stop percent.
+	assert.NotContains(t, result, "72%")
+}
+
 func TestPreviewCommentApplyWaitingForCutover(t *testing.T) {
 	result := PreviewCommentApplyWaitingForCutover()
 

--- a/pkg/webhook/templates/apply_test.go
+++ b/pkg/webhook/templates/apply_test.go
@@ -366,6 +366,34 @@ func TestRenderApplyStatusComment_Stopped(t *testing.T) {
 	assert.Contains(t, result, "schemabot start")
 }
 
+func TestRenderApplyStatusComment_Resuming(t *testing.T) {
+	// While an apply is resuming, the data plane has not yet reported whether the
+	// change continues from its checkpoint or restarts from scratch, so the row-copy
+	// percent is indeterminate. Non-terminal tables render state-only ("Resuming…")
+	// even though they still carry the pre-stop counters; already-terminal tables
+	// keep their final state.
+	data := ApplyStatusCommentData{
+		Database:    "testapp",
+		Environment: "staging",
+		RequestedBy: "aparajon",
+		State:       state.Apply.Resuming,
+		Engine:      "Spirit",
+		Tables: []TableProgressData{
+			{TableName: "orders", DDL: "ALTER TABLE `orders` ADD INDEX `idx_user_id` (`user_id`)", Status: "completed"},
+			{TableName: "users", DDL: "ALTER TABLE `users` ADD INDEX `idx_email` (`email`)", Status: "running", RowsCopied: 21000, RowsTotal: 100000, PercentComplete: 21},
+		},
+	}
+
+	result := RenderApplyStatusComment(data)
+
+	assert.Contains(t, result, "## Schema Change — Resuming")
+	assert.Contains(t, result, "🔄 Resuming…")
+	assert.NotContains(t, result, "21%", "the indeterminate resume window must not show the stale pre-stop percent")
+	assert.NotContains(t, result, "21,000 / 100,000", "the indeterminate resume window must not show stale row counts")
+	// An already-terminal table keeps its final state during resume.
+	assert.Contains(t, result, "✓ Complete")
+}
+
 func TestRenderApplyStatusComment_WaitingForCutover(t *testing.T) {
 	data := ApplyStatusCommentData{
 		Database:    "testapp",

--- a/pkg/webhook/templates/preview.go
+++ b/pkg/webhook/templates/preview.go
@@ -813,6 +813,22 @@ func PreviewCommentApplyStopped() string {
 	return RenderApplyStatusComment(sampleApplyData(state.Apply.Stopped, tables))
 }
 
+// PreviewCommentApplyResuming renders a sample comment for an apply that has just
+// been started again after a stop. During the resuming window the data plane has
+// not yet reported whether the change continues from its checkpoint or restarts
+// from scratch, so the row-copy percent is indeterminate: non-terminal tables
+// render state-only ("Resuming…") despite carrying their pre-stop counters, while
+// already-completed tables keep their final state.
+func PreviewCommentApplyResuming() string {
+	tables := sampleApplyTables()[:2]
+	tables[0].Status = state.Task.Completed
+	tables[1].Status = state.Task.Running
+	tables[1].RowsCopied = 1055687
+	tables[1].RowsTotal = 1466232
+	tables[1].PercentComplete = 72
+	return RenderApplyStatusComment(sampleApplyData(state.Apply.Resuming, tables))
+}
+
 // PreviewCommentApplyWaitingForCutover renders a sample waiting-for-cutover comment.
 func PreviewCommentApplyWaitingForCutover() string {
 	tables := sampleApplyTables()


### PR DESCRIPTION
## Why this matters

When an operator stops a schema change and then starts it again, the PR progress comment kept rendering **"Stopped at N%"** while the data plane was actively copying rows again. During an incident that's dangerously misleading — the comment said paused while the change was live. The CLI showed `Running`; the PR comment showed `Stopped`. Two independent causes, both fixed here.

## What it does

**1. Stored task state advances on resume (data correctness).** The gRPC drive transitioned the *apply* `Stopped → Resuming → Running` but never requeued the *task* rows. A task left at `stopped` is pinned there by the no-backward-progress guard on every later progress poll (a stopped task blocks active engine progress), so the resumed copy never surfaced in stored task state — and the per-table badge renders from that stored state. The local drive already requeues stopped tasks before polling; the gRPC drive now mirrors it.

**2. A fresh progress comment on resume (UX).** The progress comment was edited in place across the stop/resume boundary, reusing the comment frozen at "Stopped". On resume the observer now posts a **new** progress comment and tracks it as the live one; the prior comment stays in place as the record of where the apply paused. Resume is detected durably and cross-pod-safely from the summary comment written on stop (consumed after rotation so it fires exactly once and the terminal summary posts fresh).

**3. State-only rendering during the resume window.** A start can resume from checkpoint *or*, past binlog expiry, restart from scratch at 0% — the data plane doesn't report which until the first post-resume poll. While the apply is `Resuming`, each non-terminal table renders "Resuming…" with no bar (and the aggregate percent summary is suppressed), so the fresh comment never shows a stale percent that could then jump backward. Once `Running`, the real bar appears.

```
stop   → OnTerminal: progress comment → "Stopped at N%" (frozen), summary comment posted
start  → drive requeues stopped tasks → pending; apply → Resuming
         observer sees (active + summary exists) ⟹ resume:
            • posts a NEW progress comment (old one left as the record)
            • consumes the summary marker
         comment renders "Resuming…" (no percent) until → Running, then the bar
```

A new `ApplyCommentStore.Delete(applyID, commentState)` consumes the summary marker.

## Toward the northstar

Resume/stop is core to safe operator control of long-running changes. This makes the PR comment — the primary operator surface — tell the truth across the full stop→resume lifecycle, including the awkward checkpoint-expired restart. Follow-ups captured separately: surfacing "restarted from scratch" as an explicit data-plane signal, and promoting per-engine stop semantics (resumable pause vs permanent cancel) to an engine capability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)