### PR TITLE
fix(secrets): support binary Secrets Manager values

### DIFF
--- a/pkg/awscreds/awscreds.go
+++ b/pkg/awscreds/awscreds.go
@@ -30,6 +30,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 
 	"github.com/block/schemabot/pkg/inventory"
+	"github.com/block/schemabot/pkg/secrets"
 )
 
 // defaultAccountAttribute is the endpoint attribute holding the target's AWS
@@ -301,18 +302,15 @@ func truncateToRunes(s string, maxLen int) string {
 	return string([]rune(s)[:maxLen])
 }
 
-// getSecretString reads a string secret value, rejecting binary secrets.
-func getSecretString(ctx context.Context, client *secretsmanager.Client, secretName string) (string, error) {
+// getSecretValue reads a secret's value from Secrets Manager (string or binary).
+func getSecretValue(ctx context.Context, client *secretsmanager.Client, secretName string) (string, error) {
 	resp, err := client.GetSecretValue(ctx, &secretsmanager.GetSecretValueInput{
 		SecretId: aws.String(secretName),
 	})
 	if err != nil {
 		return "", fmt.Errorf("get secret value: %w", err)
 	}
-	if resp.SecretString == nil {
-		return "", fmt.Errorf("secret %q has no string value (binary secrets are not supported)", secretName)
-	}
-	return *resp.SecretString, nil
+	return secrets.ValueFromGetSecretOutput(resp, secretName)
 }
 
 // ownAccountFetcher reads secrets from the caller's own account using a single
@@ -323,7 +321,7 @@ type ownAccountFetcher struct {
 
 // FetchSecret returns the raw secret string from the caller's own account.
 func (f *ownAccountFetcher) FetchSecret(ctx context.Context, _ string, secretName string) (string, error) {
-	return getSecretString(ctx, f.client, secretName)
+	return getSecretValue(ctx, f.client, secretName)
 }
 
 // assumeRoleFetcher reads secrets via Secrets Manager using per-account
@@ -341,7 +339,7 @@ type assumeRoleFetcher struct {
 
 // FetchSecret returns the raw secret string from the target account.
 func (f *assumeRoleFetcher) FetchSecret(ctx context.Context, accountID, secretName string) (string, error) {
-	return getSecretString(ctx, f.clientForAccount(accountID), secretName)
+	return getSecretValue(ctx, f.clientForAccount(accountID), secretName)
 }
 
 func (f *assumeRoleFetcher) clientForAccount(accountID string) *secretsmanager.Client {

--- a/pkg/awscreds/awscreds.go
+++ b/pkg/awscreds/awscreds.go
@@ -308,7 +308,7 @@ func getSecretValue(ctx context.Context, client *secretsmanager.Client, secretNa
 		SecretId: aws.String(secretName),
 	})
 	if err != nil {
-		return "", fmt.Errorf("get secret value: %w", err)
+		return "", fmt.Errorf("get secret value %q: %w", secretName, err)
 	}
 	return secrets.ValueFromGetSecretOutput(resp, secretName)
 }

--- a/pkg/secrets/resolve.go
+++ b/pkg/secrets/resolve.go
@@ -146,11 +146,9 @@ func resolveSecretsManager(ref string) (string, error) {
 		return "", fmt.Errorf("get secret %q: %w", secretName, err)
 	}
 
-	secretValue := ""
-	if result.SecretString != nil {
-		secretValue = *result.SecretString
-	} else {
-		return "", fmt.Errorf("secret %q has no string value (binary secrets not supported)", secretName)
+	secretValue, err := ValueFromGetSecretOutput(result, secretName)
+	if err != nil {
+		return "", err
 	}
 
 	// If no JSON key specified, return the whole secret
@@ -176,4 +174,19 @@ func resolveSecretsManager(ref string) (string, error) {
 	default:
 		return fmt.Sprintf("%v", v), nil
 	}
+}
+
+// ValueFromGetSecretOutput returns a secret's value, preferring the string form
+// and falling back to the binary form. Secrets Manager stores a value as exactly
+// one of the two; some secrets (for example a password written via the binary
+// API) only have the binary form, so decode those bytes as a string rather than
+// rejecting them. aws-sdk-go-v2 has already base64-decoded SecretBinary.
+func ValueFromGetSecretOutput(resp *secretsmanager.GetSecretValueOutput, secretName string) (string, error) {
+	if resp.SecretString != nil {
+		return *resp.SecretString, nil
+	}
+	if len(resp.SecretBinary) > 0 {
+		return string(resp.SecretBinary), nil
+	}
+	return "", fmt.Errorf("secret %q has no value", secretName)
 }

--- a/pkg/secrets/resolve.go
+++ b/pkg/secrets/resolve.go
@@ -176,16 +176,16 @@ func resolveSecretsManager(ref string) (string, error) {
 	}
 }
 
-// ValueFromGetSecretOutput returns a secret's value, preferring the string form
-// and falling back to the binary form. Secrets Manager stores a value as exactly
-// one of the two; some secrets (for example a password written via the binary
-// API) only have the binary form, so decode those bytes as a string rather than
-// rejecting them. aws-sdk-go-v2 has already base64-decoded SecretBinary.
+// ValueFromGetSecretOutput returns a secret's value. Secrets Manager populates
+// exactly one of SecretString or SecretBinary; this prefers the string form and
+// falls back to the binary bytes (already base64-decoded by the SDK), since some
+// secrets — for example a password written via the binary API — have only the
+// binary form. It errors only when neither form is present.
 func ValueFromGetSecretOutput(resp *secretsmanager.GetSecretValueOutput, secretName string) (string, error) {
 	if resp.SecretString != nil {
 		return *resp.SecretString, nil
 	}
-	if len(resp.SecretBinary) > 0 {
+	if resp.SecretBinary != nil {
 		return string(resp.SecretBinary), nil
 	}
 	return "", fmt.Errorf("secret %q has no value", secretName)

--- a/pkg/secrets/resolve_test.go
+++ b/pkg/secrets/resolve_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -67,3 +69,20 @@ func TestResolve_LiteralWithColon(t *testing.T) {
 
 // Note: secretsmanager: tests would require mocking AWS SDK or integration tests
 // The AWS functionality is tested via integration tests with LocalStack
+
+func TestValueFromGetSecretOutput(t *testing.T) {
+	// The string form is used when present.
+	got, err := ValueFromGetSecretOutput(&secretsmanager.GetSecretValueOutput{SecretString: aws.String("pw")}, "secret")
+	require.NoError(t, err)
+	assert.Equal(t, "pw", got)
+
+	// A binary-only secret falls back to its bytes rather than being rejected.
+	got, err = ValueFromGetSecretOutput(&secretsmanager.GetSecretValueOutput{SecretBinary: []byte("binary-pw")}, "secret")
+	require.NoError(t, err)
+	assert.Equal(t, "binary-pw", got)
+
+	// Neither form set is an error naming the secret.
+	_, err = ValueFromGetSecretOutput(&secretsmanager.GetSecretValueOutput{}, "secret")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "has no value")
+}

--- a/pkg/secrets/resolve_test.go
+++ b/pkg/secrets/resolve_test.go
@@ -81,6 +81,11 @@ func TestValueFromGetSecretOutput(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "binary-pw", got)
 
+	// An empty-but-present binary value round-trips as "" rather than erroring.
+	got, err = ValueFromGetSecretOutput(&secretsmanager.GetSecretValueOutput{SecretBinary: []byte{}}, "secret")
+	require.NoError(t, err)
+	assert.Empty(t, got)
+
 	// Neither form set is an error naming the secret.
 	_, err = ValueFromGetSecretOutput(&secretsmanager.GetSecretValueOutput{}, "secret")
 	require.Error(t, err)


### PR DESCRIPTION
## Why this matters
AWS Secrets Manager stores a value as **either** `SecretString` **or** `SecretBinary`. SchemaBot's two retrieval paths — the `secretsmanager:` reference resolver (`pkg/secrets`) and the `awssm` credential backend (`pkg/awscreds`) — both read only `SecretString` and rejected binary secrets with `"binary secrets are not supported"`. A secret written via the binary API comes back as `SecretBinary`, so resolving such a secret (e.g. a DDL password stored as binary) failed at resolution time.

## What it does
- Adds `secrets.ValueFromGetSecretOutput(resp, name)` — prefers the string form, falls back to the binary bytes (which aws-sdk-go-v2 has already base64-decoded), and errors only when neither is set.
- Routes **both** `pkg/awscreds` (`getSecretValue`) and `secrets.Resolve` through it, so the two paths behave consistently and can't drift. This removes the duplicated `SecretString`-only logic (and its identical limitation) from both.
- Unit test covers string / binary / neither.

Behavior for string secrets is unchanged; binary secrets now resolve instead of erroring.

*This PR was generated by Claude Code (claude-opus-4-8[1m]).*