### PR TITLE
fix(github): surface PlanetScale deploy-request phases as first-class apply states

### DIFF
--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -2021,6 +2021,37 @@ func TestProgressByApplyIDResolvesExternalIDForRemoteApply(t *testing.T) {
 	assert.Equal(t, state.Apply.Running, resp.State)
 }
 
+// The progress endpoint's headline state is always the stored apply state —
+// the single source of truth shared with the PR comment observer. Even when the
+// live engine reports a more advanced phase, the response reflects stored state
+// so the CLI status and the PR comment never disagree. Live engine progress
+// still drives per-table detail, just not the headline state.
+func TestProgressByApplyIDDisplaysStoredStateNotLiveProto(t *testing.T) {
+	mock := &mockTernClient{
+		isRemote: true,
+		progressResp: &ternv1.ProgressResponse{
+			ApplyId: "remote-apply-ps",
+			State:   ternv1.State_STATE_RUNNING,
+		},
+	}
+	apply := activeTestApply("apply-stored-state")
+	apply.ExternalID = "remote-apply-ps"
+	apply.State = state.Apply.WaitingForCutover
+	svc := newControlTestService(mock, apply)
+	mux := http.NewServeMux()
+	svc.ConfigureRoutes(mux)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/progress/apply/apply-stored-state", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	var resp apitypes.ProgressResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, state.Apply.WaitingForCutover, resp.State,
+		"displayed state must come from the stored apply state, not the live engine proto")
+}
+
 func TestProgressByApplyIDOnlySendsApplyIDAndEnvironment(t *testing.T) {
 	// Remote progress lookups use the apply ID as the stable routing key. The
 	// data plane should not need database routing hints to interpret that ID.

--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -2023,9 +2023,9 @@ func TestProgressByApplyIDResolvesExternalIDForRemoteApply(t *testing.T) {
 
 // The progress endpoint's headline state is always the stored apply state —
 // the single source of truth shared with the PR comment observer. Even when the
-// live engine reports a more advanced phase, the response reflects stored state
-// so the CLI status and the PR comment never disagree. Live engine progress
-// still drives per-table detail, just not the headline state.
+// live engine reports a different phase, the response reflects stored state so
+// the CLI status and the PR comment never disagree. Live engine progress still
+// drives per-table detail, just not the headline state.
 func TestProgressByApplyIDDisplaysStoredStateNotLiveProto(t *testing.T) {
 	mock := &mockTernClient{
 		isRemote: true,

--- a/pkg/api/progress_handlers.go
+++ b/pkg/api/progress_handlers.go
@@ -335,6 +335,12 @@ func (s *Service) handleProgressByApplyID(w http.ResponseWriter, r *http.Request
 	if freshApply, err := s.storage.Applies().GetByApplyIdentifier(r.Context(), applyID); err == nil && freshApply != nil {
 		apply = freshApply
 	}
+	// The displayed apply state is always the stored apply state — the single
+	// source of truth shared with the PR comment observer and the status list.
+	// The live engine progress (resp) drives per-table detail and percentages,
+	// but never the headline state: sourcing state from the engine here would
+	// let this endpoint disagree with the comment, which renders stored state.
+	httpResp.State = apply.State
 	if apply.StartedAt != nil {
 		httpResp.StartedAt = apply.StartedAt.Format(time.RFC3339)
 	}

--- a/pkg/state/apply.go
+++ b/pkg/state/apply.go
@@ -290,3 +290,20 @@ func IsSetupPhase(s string) bool {
 func IsPlanetScaleEngine(engine string) bool {
 	return strings.EqualFold(engine, "planetscale") || strings.EqualFold(engine, "ENGINE_PLANETSCALE")
 }
+
+// InitialActiveApplyState returns the state an apply enters the moment its work
+// is dispatched to the engine. Spirit begins copying rows immediately, so its
+// first active phase is Running. PlanetScale begins by preparing a branch and
+// staging a deploy request, so its first active phase is PreparingBranch.
+//
+// Dispatch must use this instead of hardcoding Running: stamping Running on a
+// PlanetScale apply that is only preparing its branch misrepresents the engine
+// lifecycle and outranks the real deploy-request phases the engine later
+// reports, pinning the stored state — and every surface that renders it — at a
+// row-copy phase that has not begun.
+func InitialActiveApplyState(engine string) string {
+	if IsPlanetScaleEngine(engine) {
+		return Apply.PreparingBranch
+	}
+	return Apply.Running
+}

--- a/pkg/state/apply_test.go
+++ b/pkg/state/apply_test.go
@@ -331,6 +331,21 @@ func TestNormalizeApplyState_NewStates(t *testing.T) {
 	assert.Equal(t, Apply.ValidatingDeployRequest, normalizeApplyState("VALIDATING_DEPLOY_REQUEST"))
 }
 
+func TestInitialActiveApplyState(t *testing.T) {
+	// Spirit begins copying rows immediately, so its first active phase is Running.
+	for _, engine := range []string{"spirit", "Spirit", "strata", "", "unknown"} {
+		assert.Equal(t, Apply.Running, InitialActiveApplyState(engine),
+			"non-PlanetScale engine %q should dispatch into Running", engine)
+	}
+
+	// PlanetScale begins by preparing a branch, so its first active phase is
+	// PreparingBranch — not the row-copy Running phase.
+	for _, engine := range []string{"planetscale", "PlanetScale", "ENGINE_PLANETSCALE"} {
+		assert.Equal(t, Apply.PreparingBranch, InitialActiveApplyState(engine),
+			"PlanetScale engine %q should dispatch into PreparingBranch", engine)
+	}
+}
+
 // rc builds a RolloutChild from a state and its continuation policy so the
 // truth-table cases below read like the rollout scenario they describe.
 func rc(state string, continueOnFailure bool) RolloutChild {

--- a/pkg/tern/grpc_client.go
+++ b/pkg/tern/grpc_client.go
@@ -1248,7 +1248,7 @@ func (c *GRPCClient) resumeApply(ctx context.Context, apply *storage.Apply, scop
 			return fmt.Errorf("start queued gRPC apply %s: %w", apply.ApplyIdentifier, err)
 		}
 		now := time.Now()
-		apply.State = state.Apply.Running
+		apply.State = state.InitialActiveApplyState(apply.Engine)
 		if apply.StartedAt == nil {
 			apply.StartedAt = &now
 		}
@@ -1558,7 +1558,7 @@ func (c *GRPCClient) processPendingStartControlRequest(ctx context.Context, appl
 	}
 	now := time.Now()
 	oldState := apply.State
-	apply.State = state.Apply.Running
+	apply.State = state.InitialActiveApplyState(apply.Engine)
 	if apply.StartedAt == nil {
 		apply.StartedAt = &now
 	}
@@ -1703,7 +1703,7 @@ func (c *GRPCClient) dispatchPendingApply(ctx context.Context, apply *storage.Ap
 	if err := c.persistRemoteApplyID(ctx, apply, scope, resp.ApplyId); err != nil {
 		return fmt.Errorf("store remote apply id for %s: %w", apply.ApplyIdentifier, err)
 	}
-	apply.State = state.Apply.Running
+	apply.State = state.InitialActiveApplyState(apply.Engine)
 	apply.ErrorMessage = ""
 	apply.CompletedAt = nil
 	if apply.StartedAt == nil {

--- a/pkg/tern/grpc_client_test.go
+++ b/pkg/tern/grpc_client_test.go
@@ -2107,6 +2107,30 @@ func TestApplyStateFromRemoteProgress(t *testing.T) {
 			remoteState: state.Apply.WaitingForCutover,
 			expected:    state.Apply.WaitingForCutover,
 		},
+		{
+			name:        "deploy-request phase advances from the dispatched preparing-branch state",
+			storedState: state.Apply.PreparingBranch,
+			remoteState: state.Apply.ValidatingDeployRequest,
+			expected:    state.Apply.ValidatingDeployRequest,
+		},
+		{
+			name:        "deploy-request apply advances into the row-copy running phase",
+			storedState: state.Apply.ValidatingDeployRequest,
+			remoteState: state.Apply.Running,
+			expected:    state.Apply.Running,
+		},
+		{
+			name:        "stale pending remote state does not reopen a preparing-branch apply",
+			storedState: state.Apply.PreparingBranch,
+			remoteState: state.Apply.Pending,
+			expected:    state.Apply.PreparingBranch,
+		},
+		{
+			name:        "a lagging deploy-request poll does not rewind a running apply",
+			storedState: state.Apply.Running,
+			remoteState: state.Apply.PreparingBranch,
+			expected:    state.Apply.Running,
+		},
 	}
 
 	for _, tc := range tests {

--- a/pkg/webhook/templates/apply.go
+++ b/pkg/webhook/templates/apply.go
@@ -549,8 +549,9 @@ func writeApplyFooter(sb *strings.Builder, data ApplyStatusCommentData) {
 		state.Apply.ValidatingBranch,
 		state.Apply.CreatingDeployRequest,
 		state.Apply.ValidatingDeployRequest:
-		// PlanetScale's deploy-request phases are active, stoppable work — the
-		// operator can halt the change before cutover just as during row copy.
+		// PlanetScale's branch and deploy-request phases are active, stoppable
+		// work — the operator can halt the change before cutover just as during
+		// row copy.
 		writeFooterAction(sb, "To stop this schema change:", fmt.Sprintf("schemabot stop %s", data.ApplyID))
 	case state.Apply.FailedRetryable:
 		writeFooterAction(sb, "An error interrupted this schema change. SchemaBot retries automatically and marks it failed if retries are exhausted. To stop retrying:", fmt.Sprintf("schemabot stop %s", data.ApplyID))

--- a/pkg/webhook/templates/apply.go
+++ b/pkg/webhook/templates/apply.go
@@ -544,6 +544,14 @@ func writeApplyFooter(sb *strings.Builder, data ApplyStatusCommentData) {
 		sb.WriteString("Cutover in progress — typically completes within seconds.\n")
 	case state.Apply.Running:
 		writeFooterAction(sb, "To stop this schema change:", fmt.Sprintf("schemabot stop %s", data.ApplyID))
+	case state.Apply.PreparingBranch,
+		state.Apply.ApplyingBranchChanges,
+		state.Apply.ValidatingBranch,
+		state.Apply.CreatingDeployRequest,
+		state.Apply.ValidatingDeployRequest:
+		// PlanetScale's deploy-request phases are active, stoppable work — the
+		// operator can halt the change before cutover just as during row copy.
+		writeFooterAction(sb, "To stop this schema change:", fmt.Sprintf("schemabot stop %s", data.ApplyID))
 	case state.Apply.FailedRetryable:
 		writeFooterAction(sb, "An error interrupted this schema change. SchemaBot retries automatically and marks it failed if retries are exhausted. To stop retrying:", fmt.Sprintf("schemabot stop %s", data.ApplyID))
 	case state.Apply.Stopped:

--- a/pkg/webhook/templates/apply_test.go
+++ b/pkg/webhook/templates/apply_test.go
@@ -175,6 +175,27 @@ func TestRenderApplyStatusComment_Running(t *testing.T) {
 	assert.Contains(t, result, "Queued")
 }
 
+// A PlanetScale apply in a deploy-request phase renders its first-class phase
+// header (not a generic "In Progress") and still offers the operator a stop
+// action — the change is active, stoppable work before cutover.
+func TestRenderApplyStatusComment_ValidatingDeployRequest(t *testing.T) {
+	data := ApplyStatusCommentData{
+		Database:    "boardgames",
+		Environment: "staging",
+		RequestedBy: "aparajon",
+		ApplyID:     "apply-7aa13cf03496454b",
+		State:       state.Apply.ValidatingDeployRequest,
+		Engine:      "PlanetScale",
+	}
+
+	result := RenderApplyStatusComment(data)
+
+	assert.Contains(t, result, "## Schema Change — Validating Deploy Request")
+	assert.NotContains(t, result, "## Schema Change In Progress")
+	assert.Contains(t, result, "To stop this schema change:")
+	assert.Contains(t, result, "schemabot stop apply-7aa13cf03496454b")
+}
+
 func TestRenderApplyStatusComment_RowCopyDisplaysOnePercentAfterCopyStarts(t *testing.T) {
 	data := ApplyStatusCommentData{
 		Database:    "testapp",


### PR DESCRIPTION
## Why this matters

A PlanetScale apply walks a real lifecycle before any rows copy: it prepares a branch, applies changes to it, validates, creates and validates a deploy request, then deploys. Operators watching a PR could not see any of that. The gRPC apply was stamped `running` the instant it dispatched — regardless of engine — and `running` outranks every deploy-request phase, so the stored apply state stayed pinned at `running` for the whole deploy request. The PR comment renders stored state, so it showed a generic "In Progress" until the change suddenly flipped to "Applied". The deploy-request phases were invisible exactly when an operator most wants to know where a change is.

Worse, the CLI status detail read engine-live state while the PR comment read stored state — two sources of truth that could (and did) disagree.

## What it does

- Adds `state.InitialActiveApplyState(engine)`: the phase an apply enters at dispatch — `preparing_branch` for PlanetScale, `running` for Spirit (unchanged).
- Dispatch uses it instead of hardcoding `running`. The existing progress-rank logic then advances the deploy-request phases on its own — no special-case guard.
- The deploy-request phases are active, stoppable work, so the progress comment offers a stop action during them.
- The progress endpoint sources the headline state from the stored apply (live engine progress still drives per-table detail), so the CLI status list, CLI status detail, and the PR comment share one source of truth.

```
PlanetScale, before:  pending ──dispatch──► running ─────────────────────► running ──► cutover
                                            (pinned; phases hidden)

PlanetScale, after:   pending ──dispatch──► preparing_branch ──► applying_branch_changes
                        ──► validating_branch ──► creating_deploy_request
                        ──► validating_deploy_request ──► waiting_for_deploy ──► running ──► cutover

Spirit (unchanged):   pending ──dispatch──► running ──► cutover
```

The change is a no-op for Spirit: `InitialActiveApplyState("spirit") == running` at every site, and the local Spirit dispatch path is untouched. Only `engine == planetscale` behaves differently.

## How it moves toward the northstar

Schema-change intelligence depends on operators trusting what they see. Surfacing the true engine lifecycle as first-class, consistently across every surface, makes the PR comment an accurate live view of a change rather than an opaque "In Progress" — and removes a class of CLI-vs-comment disagreement at its root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)