### PR TITLE
test(api): register deployment clients in the pending-stop matrix case

### DIFF
--- a/pkg/api/operator_multi_operation_integration_test.go
+++ b/pkg/api/operator_multi_operation_integration_test.go
@@ -226,7 +226,17 @@ func TestOperatorMultiOperationMatrix(t *testing.T) {
 		requestPendingStop(t, ctx, stor, seed.applyID)
 
 		rec := &driveRecorder{}
-		svc := newMatrixService(t, stor, matrixClients(stor, rec, map[string]matrixOutcome{}))
+		// Stop reconciliation drives the data-plane stop through the apply's
+		// deployment client before terminalizing the pending siblings, so every
+		// deployment must resolve to a client — as it always does in production,
+		// where Config.Validate ties each deployment to a configured tern
+		// deployment. No operation is driven under a pending stop (the claim gate
+		// blocks the pending sibling and the stop path uses the whole-apply drive),
+		// so these outcomes are never reached via ResumeApplyOperation.
+		svc := newMatrixService(t, stor, matrixClients(stor, rec, map[string]matrixOutcome{
+			"region-a": {taskState: state.Task.Failed},
+			"region-b": {taskState: state.Task.Pending},
+		}))
 
 		svc.recoverApplies(ctx, 1)
 


### PR DESCRIPTION
## What this fixes

`main` is red: `TestOperatorMultiOperationMatrix/PendingStopStopsPendingSiblingsAndCompletesStop` fails deterministically in the Integration job, so every open PR inherits a failing required check.

## Root cause

The subtest seeds an apply on deployment `region-a` but registers no tern client for it — it passes an empty outcomes map, unlike every other subtest in the matrix. Stop reconciliation drives the data-plane stop through the apply's deployment client before terminalizing the pending siblings, so the missing client makes `resumeClaimedApply` fail closed (`tern deployment not configured`): the pending sibling is never stopped, the apply never settles, and the stop request never completes.

## Fix

Register a client per deployment for this subtest, matching the other matrix subtests and production, where `Config.Validate` ties every deployment to a configured tern deployment. No operation is driven under a pending stop, so the outcomes are never reached via `ResumeApplyOperation` — they exist only so the deployments resolve to a client for the whole-apply stop drive.

Test-only change; the operator behavior under test was already correct.

---
*PR drafted by Claude Code (Opus 4.8).*