### PR TITLE
feat(storage): add shard_progress per-shard read-model + store

### DIFF
--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -41,6 +41,7 @@ func (m *mockStorage) ControlRequests() storage.ControlRequestStore  { return ni
 func (m *mockStorage) ApplyComments() storage.ApplyCommentStore      { return nil }
 func (m *mockStorage) ApplyOperations() storage.ApplyOperationStore  { return nil }
 func (m *mockStorage) VitessApplyData() storage.VitessApplyDataStore { return nil }
+func (m *mockStorage) ShardProgress() storage.ShardProgressStore     { return nil }
 func (m *mockStorage) Checks() storage.CheckStore                    { return nil }
 func (m *mockStorage) Settings() storage.SettingsStore               { return nil }
 func (m *mockStorage) Ping(ctx context.Context) error                { return m.pingErr }

--- a/pkg/schema/mysql/shard_progress.sql
+++ b/pkg/schema/mysql/shard_progress.sql
@@ -1,0 +1,18 @@
+CREATE TABLE `shard_progress` (
+  `id` bigint unsigned NOT NULL AUTO_INCREMENT,
+  `apply_operation_id` bigint unsigned NOT NULL,
+  `namespace` varchar(255) NOT NULL,
+  `table_name` varchar(255) NOT NULL,
+  `shard` varchar(255) NOT NULL,
+  `state` varchar(100) NOT NULL DEFAULT 'pending',
+  `progress_percent` int NOT NULL DEFAULT '0',
+  `rows_copied` bigint NOT NULL DEFAULT '0',
+  `rows_total` bigint NOT NULL DEFAULT '0',
+  `eta_seconds` bigint NOT NULL DEFAULT '0',
+  `cutover_attempts` int NOT NULL DEFAULT '0',
+  `ready_to_complete` tinyint(1) NOT NULL DEFAULT '0',
+  `created_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_operation_namespace_table_shard` (`apply_operation_id`,`namespace`,`table_name`,`shard`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci

--- a/pkg/storage/mysqlstore/shard_progress.go
+++ b/pkg/storage/mysqlstore/shard_progress.go
@@ -1,0 +1,72 @@
+package mysqlstore
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/block/spirit/pkg/utils"
+
+	"github.com/block/schemabot/pkg/storage"
+)
+
+type shardProgressStore struct {
+	db *sql.DB
+}
+
+// Upsert inserts or updates one shard's progress row, keyed by
+// (apply_operation_id, namespace, table_name, shard). Only the display fields are
+// updated on conflict; the key columns and created_at are preserved.
+func (s *shardProgressStore) Upsert(ctx context.Context, sp *storage.ShardProgress) error {
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO shard_progress
+			(apply_operation_id, namespace, table_name, shard, state, progress_percent, rows_copied, rows_total, eta_seconds, cutover_attempts, ready_to_complete)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON DUPLICATE KEY UPDATE
+			state = VALUES(state),
+			progress_percent = VALUES(progress_percent),
+			rows_copied = VALUES(rows_copied),
+			rows_total = VALUES(rows_total),
+			eta_seconds = VALUES(eta_seconds),
+			cutover_attempts = VALUES(cutover_attempts),
+			ready_to_complete = VALUES(ready_to_complete)`,
+		sp.ApplyOperationID, sp.Namespace, sp.TableName, sp.Shard, sp.State,
+		sp.ProgressPercent, sp.RowsCopied, sp.RowsTotal, sp.ETASeconds, sp.CutoverAttempts, sp.ReadyToComplete,
+	)
+	if err != nil {
+		return fmt.Errorf("upsert shard progress for operation %d %s.%s shard %s: %w",
+			sp.ApplyOperationID, sp.Namespace, sp.TableName, sp.Shard, err)
+	}
+	return nil
+}
+
+// GetByApplyOperationID returns all shard-progress rows for an operation, ordered
+// by namespace, table_name, shard so the renderer sees a stable order.
+func (s *shardProgressStore) GetByApplyOperationID(ctx context.Context, applyOperationID int64) ([]*storage.ShardProgress, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT apply_operation_id, namespace, table_name, shard, state, progress_percent, rows_copied, rows_total, eta_seconds, cutover_attempts, ready_to_complete
+		FROM shard_progress
+		WHERE apply_operation_id = ?
+		ORDER BY namespace, table_name, shard`, applyOperationID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("query shard progress for operation %d: %w", applyOperationID, err)
+	}
+	defer utils.CloseAndLog(rows)
+
+	var result []*storage.ShardProgress
+	for rows.Next() {
+		var sp storage.ShardProgress
+		if err := rows.Scan(
+			&sp.ApplyOperationID, &sp.Namespace, &sp.TableName, &sp.Shard, &sp.State,
+			&sp.ProgressPercent, &sp.RowsCopied, &sp.RowsTotal, &sp.ETASeconds, &sp.CutoverAttempts, &sp.ReadyToComplete,
+		); err != nil {
+			return nil, fmt.Errorf("scan shard progress for operation %d: %w", applyOperationID, err)
+		}
+		result = append(result, &sp)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate shard progress for operation %d: %w", applyOperationID, err)
+	}
+	return result, nil
+}

--- a/pkg/storage/mysqlstore/shard_progress.go
+++ b/pkg/storage/mysqlstore/shard_progress.go
@@ -17,11 +17,35 @@ type shardProgressStore struct {
 // Upsert inserts or updates one shard's progress row, keyed by
 // (apply_operation_id, namespace, table_name, shard). Only the display fields are
 // updated on conflict; the key columns and created_at are preserved.
+//
+// When the caller holds an operation lease (the operator's reconciler does), the
+// write is scoped to that lease via the source SELECT, so a displaced driver that
+// lost the lease fails closed instead of overwriting the read-model with stale
+// progress — matching the guard on other operation-scoped writes (tasks.Update).
+// Without a lease on the context the write is unguarded, as for any other store call.
 func (s *shardProgressStore) Upsert(ctx context.Context, sp *storage.ShardProgress) error {
-	_, err := s.db.ExecContext(ctx, `
+	// The row values come from a SELECT so the optional lease predicate can gate
+	// the whole insert/update: an empty source row (lease lost) writes nothing.
+	source := "SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?"
+	args := []any{
+		sp.ApplyOperationID, sp.Namespace, sp.TableName, sp.Shard, sp.State,
+		sp.ProgressPercent, sp.RowsCopied, sp.RowsTotal, sp.ETASeconds, sp.CutoverAttempts, sp.ReadyToComplete,
+	}
+
+	var verifyLeaseStillOwned func() error
+	if opLease, ok := storage.OperationLeaseFromContext(ctx); ok {
+		if !opLease.Valid() {
+			return fmt.Errorf("invalid operation lease for shard progress (operation %d): %w", sp.ApplyOperationID, storage.ErrApplyLeaseLost)
+		}
+		source += " FROM apply_operations ao WHERE ao.id = ? AND ao.lease_token = ?"
+		args = append(args, opLease.OperationID, opLease.Token)
+		verifyLeaseStillOwned = func() error { return ensureOperationLeaseStillOwned(ctx, s.db, opLease) }
+	}
+
+	result, err := s.db.ExecContext(ctx, `
 		INSERT INTO shard_progress
 			(apply_operation_id, namespace, table_name, shard, state, progress_percent, rows_copied, rows_total, eta_seconds, cutover_attempts, ready_to_complete)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		`+source+`
 		ON DUPLICATE KEY UPDATE
 			state = VALUES(state),
 			progress_percent = VALUES(progress_percent),
@@ -30,12 +54,24 @@ func (s *shardProgressStore) Upsert(ctx context.Context, sp *storage.ShardProgre
 			eta_seconds = VALUES(eta_seconds),
 			cutover_attempts = VALUES(cutover_attempts),
 			ready_to_complete = VALUES(ready_to_complete)`,
-		sp.ApplyOperationID, sp.Namespace, sp.TableName, sp.Shard, sp.State,
-		sp.ProgressPercent, sp.RowsCopied, sp.RowsTotal, sp.ETASeconds, sp.CutoverAttempts, sp.ReadyToComplete,
+		args...,
 	)
 	if err != nil {
 		return fmt.Errorf("upsert shard progress for operation %d %s.%s shard %s: %w",
 			sp.ApplyOperationID, sp.Namespace, sp.TableName, sp.Shard, err)
+	}
+	if verifyLeaseStillOwned == nil {
+		return nil
+	}
+	// Zero rows affected is either a no-op update (same values) or a lost lease;
+	// verifyLeaseStillOwned disambiguates — it returns ErrApplyLeaseLost only when
+	// the lease is actually gone, and nil for a benign no-op.
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("read shard progress upsert rows affected for operation %d: %w", sp.ApplyOperationID, err)
+	}
+	if rows == 0 {
+		return verifyLeaseStillOwned()
 	}
 	return nil
 }

--- a/pkg/storage/mysqlstore/shard_progress_test.go
+++ b/pkg/storage/mysqlstore/shard_progress_test.go
@@ -1,0 +1,120 @@
+//go:build integration
+
+package mysqlstore
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/block/schemabot/pkg/storage"
+)
+
+// shard_progress is the per-shard display read-model: the reconciler upserts one
+// row per (apply_operation, namespace, table, shard) and the renderer reads them
+// back per operation. These tests prove a fresh row round-trips, re-upserting the
+// same shard updates in place (no duplicate rows), reads are ordered, and one
+// operation's shards never leak into another's.
+
+func TestShardProgressStore_UpsertAndGet(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+	const opID = int64(1001)
+
+	sp := &storage.ShardProgress{
+		ApplyOperationID: opID,
+		Namespace:        "resolute",
+		TableName:        "users",
+		Shard:            "-80",
+		State:            "running",
+		ProgressPercent:  44,
+		RowsCopied:       220000,
+		RowsTotal:        500000,
+		ETASeconds:       720,
+		CutoverAttempts:  1,
+		ReadyToComplete:  false,
+	}
+	require.NoError(t, store.ShardProgress().Upsert(ctx, sp))
+
+	got, err := store.ShardProgress().GetByApplyOperationID(ctx, opID)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, opID, got[0].ApplyOperationID)
+	assert.Equal(t, "resolute", got[0].Namespace)
+	assert.Equal(t, "users", got[0].TableName)
+	assert.Equal(t, "-80", got[0].Shard)
+	assert.Equal(t, "running", got[0].State)
+	assert.Equal(t, 44, got[0].ProgressPercent)
+	assert.Equal(t, int64(220000), got[0].RowsCopied)
+	assert.Equal(t, int64(500000), got[0].RowsTotal)
+	assert.Equal(t, int64(720), got[0].ETASeconds)
+	assert.Equal(t, 1, got[0].CutoverAttempts)
+	assert.False(t, got[0].ReadyToComplete)
+}
+
+func TestShardProgressStore_UpsertIsIdempotent(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+	const opID = int64(1001)
+
+	sp := &storage.ShardProgress{
+		ApplyOperationID: opID, Namespace: "resolute", TableName: "users", Shard: "-80",
+		State: "running", ProgressPercent: 10, RowsCopied: 50000, RowsTotal: 500000,
+	}
+	require.NoError(t, store.ShardProgress().Upsert(ctx, sp))
+
+	// Re-upsert the same shard key with advanced progress: updates in place.
+	sp.State = "waiting_for_cutover"
+	sp.ProgressPercent = 100
+	sp.RowsCopied = 500000
+	sp.ReadyToComplete = true
+	require.NoError(t, store.ShardProgress().Upsert(ctx, sp))
+
+	got, err := store.ShardProgress().GetByApplyOperationID(ctx, opID)
+	require.NoError(t, err)
+	require.Len(t, got, 1, "re-upserting the same shard must update in place, not insert a duplicate")
+	assert.Equal(t, "waiting_for_cutover", got[0].State)
+	assert.Equal(t, 100, got[0].ProgressPercent)
+	assert.Equal(t, int64(500000), got[0].RowsCopied)
+	assert.True(t, got[0].ReadyToComplete)
+}
+
+func TestShardProgressStore_OrderedAndIsolatedByOperation(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+	const opA = int64(1001)
+	const opB = int64(1002)
+
+	// Insert opA's shards out of order; reads come back ordered (namespace, table, shard).
+	for _, sp := range []*storage.ShardProgress{
+		{ApplyOperationID: opA, Namespace: "resolute", TableName: "users", Shard: "80-", State: "running"},
+		{ApplyOperationID: opA, Namespace: "resolute", TableName: "users", Shard: "-80", State: "running"},
+		{ApplyOperationID: opA, Namespace: "reporting", TableName: "events", Shard: "-", State: "running"},
+	} {
+		require.NoError(t, store.ShardProgress().Upsert(ctx, sp))
+	}
+	// A shard under a different operation must not leak into opA's results.
+	require.NoError(t, store.ShardProgress().Upsert(ctx, &storage.ShardProgress{
+		ApplyOperationID: opB, Namespace: "resolute", TableName: "users", Shard: "-80", State: "running",
+	}))
+
+	got, err := store.ShardProgress().GetByApplyOperationID(ctx, opA)
+	require.NoError(t, err)
+	require.Len(t, got, 3, "only opA's shards")
+	assert.Equal(t, []string{"reporting", "resolute", "resolute"},
+		[]string{got[0].Namespace, got[1].Namespace, got[2].Namespace}, "ordered by namespace")
+	assert.Equal(t, []string{"-", "-80", "80-"},
+		[]string{got[0].Shard, got[1].Shard, got[2].Shard}, "then by table_name, shard")
+
+	gotB, err := store.ShardProgress().GetByApplyOperationID(ctx, opB)
+	require.NoError(t, err)
+	assert.Len(t, gotB, 1, "opB's shards are isolated from opA")
+
+	gotEmpty, err := store.ShardProgress().GetByApplyOperationID(ctx, int64(9999))
+	require.NoError(t, err)
+	assert.Empty(t, gotEmpty, "an operation with no shards returns no rows and no error")
+}

--- a/pkg/storage/mysqlstore/shard_progress_test.go
+++ b/pkg/storage/mysqlstore/shard_progress_test.go
@@ -3,6 +3,7 @@
 package mysqlstore
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -89,10 +90,13 @@ func TestShardProgressStore_OrderedAndIsolatedByOperation(t *testing.T) {
 	const opA = int64(1001)
 	const opB = int64(1002)
 
-	// Insert opA's shards out of order; reads come back ordered (namespace, table, shard).
+	// Insert opA's shards out of order — across two namespaces, and two tables
+	// within the `resolute` namespace — so the read exercises the full
+	// (namespace, table_name, shard) ordering, including table_name within a namespace.
 	for _, sp := range []*storage.ShardProgress{
 		{ApplyOperationID: opA, Namespace: "resolute", TableName: "users", Shard: "80-", State: "running"},
 		{ApplyOperationID: opA, Namespace: "resolute", TableName: "users", Shard: "-80", State: "running"},
+		{ApplyOperationID: opA, Namespace: "resolute", TableName: "orders", Shard: "-80", State: "running"},
 		{ApplyOperationID: opA, Namespace: "reporting", TableName: "events", Shard: "-", State: "running"},
 	} {
 		require.NoError(t, store.ShardProgress().Upsert(ctx, sp))
@@ -104,11 +108,17 @@ func TestShardProgressStore_OrderedAndIsolatedByOperation(t *testing.T) {
 
 	got, err := store.ShardProgress().GetByApplyOperationID(ctx, opA)
 	require.NoError(t, err)
-	require.Len(t, got, 3, "only opA's shards")
-	assert.Equal(t, []string{"reporting", "resolute", "resolute"},
-		[]string{got[0].Namespace, got[1].Namespace, got[2].Namespace}, "ordered by namespace")
-	assert.Equal(t, []string{"-", "-80", "80-"},
-		[]string{got[0].Shard, got[1].Shard, got[2].Shard}, "then by table_name, shard")
+	require.Len(t, got, 4, "only opA's shards")
+	gotKeys := make([][3]string, len(got))
+	for i, sp := range got {
+		gotKeys[i] = [3]string{sp.Namespace, sp.TableName, sp.Shard}
+	}
+	assert.Equal(t, [][3]string{
+		{"reporting", "events", "-"},  // namespace first
+		{"resolute", "orders", "-80"}, // then table_name within the namespace (orders < users)
+		{"resolute", "users", "-80"},  // then shard within the table
+		{"resolute", "users", "80-"},
+	}, gotKeys, "ordered by (namespace, table_name, shard)")
 
 	gotB, err := store.ShardProgress().GetByApplyOperationID(ctx, opB)
 	require.NoError(t, err)
@@ -117,4 +127,54 @@ func TestShardProgressStore_OrderedAndIsolatedByOperation(t *testing.T) {
 	gotEmpty, err := store.ShardProgress().GetByApplyOperationID(ctx, int64(9999))
 	require.NoError(t, err)
 	assert.Empty(t, gotEmpty, "an operation with no shards returns no rows and no error")
+}
+
+// When the caller holds an operation lease, Upsert is scoped to it so a displaced
+// driver that lost the lease fails closed instead of overwriting the read-model
+// with stale progress — the same guard tasks.Update enforces.
+func TestShardProgressStore_OperationLeaseGuardsUpsert(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", "mysql", "staging")
+	apply := createTestApply(t, store, lock, "apply_sp_oplease", 1)
+	opID, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-a", Target: "payments",
+	})
+	require.NoError(t, err)
+	stampOperationLease(t, opID, "driver", "op-token")
+
+	opCtx := func(token string) context.Context {
+		return storage.WithOperationLease(ctx, storage.OperationLease{
+			ApplyID: apply.ID, OperationID: opID, Owner: "driver", Token: token,
+		})
+	}
+
+	sp := &storage.ShardProgress{
+		ApplyOperationID: opID, Namespace: "resolute", TableName: "users", Shard: "-80",
+		State: "running", ProgressPercent: 30,
+	}
+
+	// A displaced driver (stale operation token) fails closed and writes nothing.
+	require.ErrorIs(t, store.ShardProgress().Upsert(opCtx("stale-op-token"), sp), storage.ErrApplyLeaseLost)
+	got, err := store.ShardProgress().GetByApplyOperationID(ctx, opID)
+	require.NoError(t, err)
+	assert.Empty(t, got, "a lost lease must not write shard progress")
+
+	// The lease holder writes successfully.
+	require.NoError(t, store.ShardProgress().Upsert(opCtx("op-token"), sp))
+	got, err = store.ShardProgress().GetByApplyOperationID(ctx, opID)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, "running", got[0].State)
+	assert.Equal(t, 30, got[0].ProgressPercent)
+
+	// A later stale write must not overwrite the lease holder's row.
+	sp.State = "failed"
+	require.ErrorIs(t, store.ShardProgress().Upsert(opCtx("stale-op-token"), sp), storage.ErrApplyLeaseLost)
+	got, err = store.ShardProgress().GetByApplyOperationID(ctx, opID)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, "running", got[0].State, "stale driver must not overwrite the read-model")
 }

--- a/pkg/storage/mysqlstore/storage.go
+++ b/pkg/storage/mysqlstore/storage.go
@@ -22,6 +22,7 @@ type Storage struct {
 	checks          *checkStore
 	settings        *settingsStore
 	vitessApplyData *vitessApplyDataStore
+	shardProgress   *shardProgressStore
 }
 
 // New creates a new MySQL storage instance.
@@ -39,6 +40,7 @@ func New(db *sql.DB) *Storage {
 		checks:          &checkStore{db: db},
 		settings:        &settingsStore{db: db},
 		vitessApplyData: &vitessApplyDataStore{db: db},
+		shardProgress:   &shardProgressStore{db: db},
 	}
 }
 
@@ -95,6 +97,11 @@ func (s *Storage) Settings() storage.SettingsStore {
 // VitessApplyData returns the Vitess apply data store.
 func (s *Storage) VitessApplyData() storage.VitessApplyDataStore {
 	return s.vitessApplyData
+}
+
+// ShardProgress returns the per-shard progress read-model store.
+func (s *Storage) ShardProgress() storage.ShardProgressStore {
+	return s.shardProgress
 }
 
 // Ping verifies the database connection is alive.

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -42,6 +42,9 @@ type Storage interface {
 	// VitessApplyData returns the Vitess apply data store.
 	VitessApplyData() VitessApplyDataStore
 
+	// ShardProgress returns the per-shard progress read-model store.
+	ShardProgress() ShardProgressStore
+
 	// Ping verifies the database connection is alive.
 	Ping(ctx context.Context) error
 
@@ -529,6 +532,21 @@ type VitessApplyDataStore interface {
 
 	// GetByApplyID returns the Vitess apply data for the given apply ID.
 	GetByApplyID(ctx context.Context, applyID int64) (*VitessApplyData, error)
+}
+
+// ShardProgressStore manages the per-shard progress read-model. The operator's
+// reconciler upserts one row per shard of a sharded change; the renderer reads
+// them back per operation. Rows are keyed by (apply_operation_id, namespace,
+// table_name, shard), so the deployment dimension is inherited from the operation
+// and multi-region shards never collide.
+type ShardProgressStore interface {
+	// Upsert inserts or updates one shard's progress, keyed by
+	// (apply_operation_id, namespace, table_name, shard).
+	Upsert(ctx context.Context, sp *ShardProgress) error
+
+	// GetByApplyOperationID returns all shard-progress rows for an operation,
+	// ordered by namespace, table_name, shard.
+	GetByApplyOperationID(ctx context.Context, applyOperationID int64) ([]*ShardProgress, error)
 }
 
 // ApplyLogStore manages apply log entries for debugging and audit.

--- a/pkg/storage/types.go
+++ b/pkg/storage/types.go
@@ -895,6 +895,26 @@ type ApplyLogFilter struct {
 	Limit     int    // Optional: limit results (default 100)
 }
 
+// ShardProgress is the per-shard display read-model for a sharded schema change,
+// one row per (apply_operation, namespace, table, shard) in the shard_progress
+// table. It is the persisted projection the operator's reconciler writes and the
+// renderer reads, so per-shard progress survives worker restarts and is consistent
+// across instances. It carries only display fields — execution state lives on the
+// operation row.
+type ShardProgress struct {
+	ApplyOperationID int64
+	Namespace        string
+	TableName        string
+	Shard            string
+	State            string
+	ProgressPercent  int
+	RowsCopied       int64
+	RowsTotal        int64
+	ETASeconds       int64
+	CutoverAttempts  int
+	ReadyToComplete  bool
+}
+
 // VitessApplyData holds Vitess-specific data for deploy request tracking.
 // Stored in vitess_apply_data table, one row per apply when database_type = 'vitess'.
 type VitessApplyData struct {

--- a/pkg/tern/local_client_test.go
+++ b/pkg/tern/local_client_test.go
@@ -425,6 +425,10 @@ func (s *exactProgressStorage) ControlRequests() storage.ControlRequestStore {
 func (s *exactProgressStorage) VitessApplyData() storage.VitessApplyDataStore {
 	return s.vitessApplyData
 }
+
+func (s *exactProgressStorage) ShardProgress() storage.ShardProgressStore {
+	return nil
+}
 func (s *exactProgressStorage) ApplyOperations() storage.ApplyOperationStore {
 	return s.applyOperations
 }

--- a/pkg/tern/local_control_test.go
+++ b/pkg/tern/local_control_test.go
@@ -114,6 +114,10 @@ func (s *controlTestStorage) VitessApplyData() storage.VitessApplyDataStore {
 	return nil
 }
 
+func (s *controlTestStorage) ShardProgress() storage.ShardProgressStore {
+	return nil
+}
+
 func (s *controlTestStorage) ApplyOperations() storage.ApplyOperationStore {
 	return s.applyOperations
 }


### PR DESCRIPTION
## Why this matters

Per-shard progress for sharded schema changes is recomputed live on every request today (e.g. re-querying `SHOW VITESS_MIGRATIONS`), so it can't be rendered consistently across instances, after a crash, or once the underlying rows age out. Persisting it as a read-model lets one reconciler write it and every reader read the same stored state.

## What it does

Adds the `shard_progress` table and `ShardProgressStore`, keyed by `(apply_operation_id, namespace, table_name, shard)`:
- `Upsert(sp)` — insert-or-update one shard's progress (idempotent on the key).
- `GetByApplyOperationID(id)` — all of an operation's shards, ordered `namespace, table_name, shard`.

Keying by `apply_operation_id` inherits the operation's `deployment`, so the same keyspace/table/shard under different deployments never collide. It carries only display fields (state, percent, rows, ETA, cutover attempts, ready-to-complete) — execution state stays on the operation row.

```
shard_progress
  apply_operation_id, namespace, table_name, shard   ← UNIQUE
  state, progress_percent, rows_copied, rows_total,
  eta_seconds, cutover_attempts, ready_to_complete
```

## Scope

**Additive and currently unwired** — this is the storage foundation; the write-through path that populates it (reconciler from the engine's progress) and rendering-from-stored are follow-ups, so it's safe to land ahead of them. `EnsureSchema` bootstraps the table on startup. Integration tests cover upsert idempotency (no duplicate rows on re-write), ordered reads, and per-operation isolation; the EnsureSchema integration test validates the schema parses via Spirit.

---
*PR drafted by Claude Code (Opus 4.8).*