### PR TITLE
fix(github): defer multi-op terminal summary to the aggregate publisher

### DIFF
--- a/pkg/webhook/comment_observer.go
+++ b/pkg/webhook/comment_observer.go
@@ -276,42 +276,40 @@ func (o *CommentObserver) OnTerminal(apply *storage.Apply, tasks []*storage.Task
 		activeCommentState = state.Comment.Cutover
 	}
 
-	// A multi-operation (fan-out) apply publishes its single apply-level terminal
-	// summary through the operator's aggregate CAS-winner observer (see
-	// publishTerminalSummaryIfWon / NewAggregateTerminalCommentObserver), which
-	// re-derives the parent from all apply_operations and renders the full task
-	// set. A per-driver observer here holds only one operation's task slice, so
-	// it must not publish the summary for a multi-operation apply — doing so
-	// would post a duplicate, partial summary. Single-operation applies are
-	// unaffected and keep publishing through this path.
-	publishSummary := o.shouldPublishTerminalSummary(apply)
+	// Load the operation rows once and reuse them for the ownership decision and
+	// both comment renders below, so the terminal path reads apply_operations a
+	// single time per callback.
+	ops, opsErr := o.stor.ApplyOperations().ListByApply(ctx, o.applyID)
 
 	if activeCommentState == state.Comment.Cutover {
-		// Cutover comment gets the summary format — Apply ID, DDL, success message.
-		// No separate summary needed since the cutover comment IS the completion
-		// comment, so editing it to the summary format is itself the summary
-		// publish. Defer to the aggregate publisher for multi-operation applies.
-		if publishSummary {
-			finalBody := o.formatTerminalSummaryComment(apply, tasks)
-			o.editTrackedComment(apply, activeCommentState, finalBody)
-
-			// Upsert a summary marker so FindMissingSummaryComment (outbox query)
-			// doesn't false-positive on restart for cutover applies.
-			o.markSummaryPosted(apply, activeCommentState)
-		}
+		// The cutover comment IS the completion comment, so editing it to the
+		// summary format is the terminal publish — there is no separate summary
+		// comment to duplicate. Always edit it to its terminal rendering so it
+		// never stays frozen at "cutting over"; for a multi-operation apply the
+		// aggregate CAS-winner observer re-edits it with the full task set. The
+		// summary marker is always upserted so FindMissingSummaryComment (outbox
+		// query) doesn't false-positive on restart for cutover applies.
+		finalBody := o.summaryCommentFromOps(apply, ops, opsErr, tasks)
+		o.editTrackedComment(apply, activeCommentState, finalBody)
+		o.markSummaryPosted(apply, activeCommentState)
 	} else {
 		// Edit the progress comment to its final state (completed bars / error).
 		// This is the per-operation status freeze, not the apply-level summary, so
 		// it always runs; the aggregate publisher re-edits it with the full task
 		// set for multi-operation applies.
-		finalBody := o.formatStatusComment(apply, tasks)
+		finalBody := o.statusCommentFromOps(apply, ops, opsErr, tasks)
 		o.editTrackedComment(apply, activeCommentState, finalBody)
 
 		// Post a separate summary comment. A new comment is more reliable than
 		// an edit — GitHub renders edits with a delay, but new comments appear
-		// immediately and trigger notifications for PR subscribers.
-		if publishSummary {
-			summaryBody := o.formatTerminalSummaryComment(apply, tasks)
+		// immediately and trigger notifications for PR subscribers. A
+		// multi-operation (fan-out) apply publishes its single apply-level
+		// summary through the operator's aggregate CAS-winner observer instead
+		// (see publishTerminalSummaryIfWon / NewAggregateTerminalCommentObserver),
+		// so a per-driver observer holding one operation's task slice must defer
+		// to it rather than post a duplicate, partial summary.
+		if o.shouldPublishSeparateSummary(apply, ops, opsErr) {
+			summaryBody := o.summaryCommentFromOps(apply, ops, opsErr, tasks)
 			o.postAndTrackComment(apply, state.Comment.Summary, summaryBody)
 		}
 	}
@@ -325,27 +323,25 @@ func (o *CommentObserver) OnTerminal(apply *storage.Apply, tasks []*storage.Task
 	}
 }
 
-// shouldPublishTerminalSummary reports whether this observer owns the apply-level
-// terminal summary. The aggregate CAS-winner observer (built by
+// shouldPublishSeparateSummary reports whether this observer owns the separate
+// apply-level terminal summary comment for a non-cutover apply, given the apply's
+// already-loaded operation rows. The aggregate CAS-winner observer (built by
 // NewAggregateTerminalCommentObserver after winning the non-terminal→terminal
 // projection CAS) always owns it. A per-driver observer owns it only for a
 // single-operation apply: a multi-operation apply has its summary published once
 // by the aggregate observer, which re-derives the parent from every
 // apply_operation and renders the full task set, so a per-driver observer here —
-// holding one operation's task slice — must defer to it. On a lookup failure it
-// returns false so no partial or duplicate summary is posted; startup
-// reconciliation (FindMissingSummaryComment) repairs a genuinely missing one.
-func (o *CommentObserver) shouldPublishTerminalSummary(apply *storage.Apply) bool {
+// holding one operation's task slice — must defer to it rather than post a
+// duplicate, partial summary. On a load failure it returns false so no partial
+// or duplicate summary is posted; startup reconciliation
+// (FindMissingSummaryComment) repairs a genuinely missing one.
+func (o *CommentObserver) shouldPublishSeparateSummary(apply *storage.Apply, ops []*storage.ApplyOperation, opsErr error) bool {
 	if o.aggregateTerminalCASWinner {
 		return true
 	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
-	ops, err := o.stor.ApplyOperations().ListByApply(ctx, o.applyID)
-	if err != nil {
+	if opsErr != nil {
 		o.logError(apply, "observer: failed to load apply operations for terminal summary ownership; leaving summary to reconciliation",
-			"error", err)
+			"error", opsErr)
 		return false
 	}
 	if len(ops) > 1 {
@@ -368,9 +364,17 @@ func (o *CommentObserver) formatStatusComment(apply *storage.Apply, tasks []*sto
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 	ops, err := o.stor.ApplyOperations().ListByApply(ctx, o.applyID)
-	if err != nil {
+	return o.statusCommentFromOps(apply, ops, err, tasks)
+}
+
+// statusCommentFromOps renders the status comment from already-loaded operation
+// rows, applying the same single-deployment fallback as formatStatusComment when
+// the load failed. Callers that already hold the operation set (e.g. OnTerminal)
+// use this to avoid re-reading apply_operations.
+func (o *CommentObserver) statusCommentFromOps(apply *storage.Apply, ops []*storage.ApplyOperation, opsErr error, tasks []*storage.Task) string {
+	if opsErr != nil {
 		o.logger.Error("observer: failed to load apply operations for comment dispatch; rendering single-deployment layout",
-			"apply_id", o.applyID, "error", err)
+			"apply_id", o.applyID, "error", opsErr)
 		return formatProgressComment(apply, tasks)
 	}
 	return formatApplyStatusComment(apply, ops, tasks)
@@ -388,9 +392,18 @@ func (o *CommentObserver) formatTerminalSummaryComment(apply *storage.Apply, tas
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 	ops, err := o.stor.ApplyOperations().ListByApply(ctx, o.applyID)
-	if err != nil {
+	return o.summaryCommentFromOps(apply, ops, err, tasks)
+}
+
+// summaryCommentFromOps renders the terminal summary from already-loaded
+// operation rows, applying the same single-deployment fallback as
+// formatTerminalSummaryComment when the load failed. Callers that already hold
+// the operation set (e.g. OnTerminal) use this to avoid re-reading
+// apply_operations.
+func (o *CommentObserver) summaryCommentFromOps(apply *storage.Apply, ops []*storage.ApplyOperation, opsErr error, tasks []*storage.Task) string {
+	if opsErr != nil {
 		o.logger.Error("observer: failed to load apply operations for summary comment dispatch; rendering single-deployment layout",
-			"apply_id", o.applyID, "error", err)
+			"apply_id", o.applyID, "error", opsErr)
 		return formatSummaryComment(apply, tasks)
 	}
 	return formatApplySummaryComment(apply, ops, tasks)

--- a/pkg/webhook/comment_observer.go
+++ b/pkg/webhook/comment_observer.go
@@ -120,6 +120,21 @@ func (o *CommentObserver) logError(apply *storage.Apply, msg string, args ...any
 	o.logger.Error(msg, append(fields, args...)...)
 }
 
+func (o *CommentObserver) logInfo(apply *storage.Apply, msg string, args ...any) {
+	fields := []any{
+		"repo", o.repo,
+		"pr", o.pr,
+	}
+	if apply != nil {
+		fields = append(fields,
+			"apply_id", apply.ApplyIdentifier,
+			"database", apply.Database,
+			"environment", apply.Environment,
+		)
+	}
+	o.logger.Info(msg, append(fields, args...)...)
+}
+
 // NewCommentObserver creates a new CommentObserver for posting PR comments.
 func NewCommentObserver(cfg CommentObserverConfig) *CommentObserver {
 	clk := clock.Default(cfg.Clock)
@@ -261,25 +276,44 @@ func (o *CommentObserver) OnTerminal(apply *storage.Apply, tasks []*storage.Task
 		activeCommentState = state.Comment.Cutover
 	}
 
+	// A multi-operation (fan-out) apply publishes its single apply-level terminal
+	// summary through the operator's aggregate CAS-winner observer (see
+	// publishTerminalSummaryIfWon / NewAggregateTerminalCommentObserver), which
+	// re-derives the parent from all apply_operations and renders the full task
+	// set. A per-driver observer here holds only one operation's task slice, so
+	// it must not publish the summary for a multi-operation apply — doing so
+	// would post a duplicate, partial summary. Single-operation applies are
+	// unaffected and keep publishing through this path.
+	publishSummary := o.shouldPublishTerminalSummary(apply)
+
 	if activeCommentState == state.Comment.Cutover {
 		// Cutover comment gets the summary format — Apply ID, DDL, success message.
-		// No separate summary needed since the cutover comment IS the completion comment.
-		finalBody := o.formatTerminalSummaryComment(apply, tasks)
-		o.editTrackedComment(apply, activeCommentState, finalBody)
+		// No separate summary needed since the cutover comment IS the completion
+		// comment, so editing it to the summary format is itself the summary
+		// publish. Defer to the aggregate publisher for multi-operation applies.
+		if publishSummary {
+			finalBody := o.formatTerminalSummaryComment(apply, tasks)
+			o.editTrackedComment(apply, activeCommentState, finalBody)
 
-		// Upsert a summary marker so FindMissingSummaryComment (outbox query)
-		// doesn't false-positive on restart for cutover applies.
-		o.markSummaryPosted(apply, activeCommentState)
+			// Upsert a summary marker so FindMissingSummaryComment (outbox query)
+			// doesn't false-positive on restart for cutover applies.
+			o.markSummaryPosted(apply, activeCommentState)
+		}
 	} else {
 		// Edit the progress comment to its final state (completed bars / error).
+		// This is the per-operation status freeze, not the apply-level summary, so
+		// it always runs; the aggregate publisher re-edits it with the full task
+		// set for multi-operation applies.
 		finalBody := o.formatStatusComment(apply, tasks)
 		o.editTrackedComment(apply, activeCommentState, finalBody)
 
 		// Post a separate summary comment. A new comment is more reliable than
 		// an edit — GitHub renders edits with a delay, but new comments appear
 		// immediately and trigger notifications for PR subscribers.
-		summaryBody := o.formatTerminalSummaryComment(apply, tasks)
-		o.postAndTrackComment(apply, state.Comment.Summary, summaryBody)
+		if publishSummary {
+			summaryBody := o.formatTerminalSummaryComment(apply, tasks)
+			o.postAndTrackComment(apply, state.Comment.Summary, summaryBody)
+		}
 	}
 
 	// Run terminal hook (e.g., update check runs)
@@ -289,6 +323,37 @@ func (o *CommentObserver) OnTerminal(apply *storage.Apply, tasks []*storage.Task
 	if o.OnTerminalHook != nil {
 		o.OnTerminalHook(apply)
 	}
+}
+
+// shouldPublishTerminalSummary reports whether this observer owns the apply-level
+// terminal summary. The aggregate CAS-winner observer (built by
+// NewAggregateTerminalCommentObserver after winning the non-terminal→terminal
+// projection CAS) always owns it. A per-driver observer owns it only for a
+// single-operation apply: a multi-operation apply has its summary published once
+// by the aggregate observer, which re-derives the parent from every
+// apply_operation and renders the full task set, so a per-driver observer here —
+// holding one operation's task slice — must defer to it. On a lookup failure it
+// returns false so no partial or duplicate summary is posted; startup
+// reconciliation (FindMissingSummaryComment) repairs a genuinely missing one.
+func (o *CommentObserver) shouldPublishTerminalSummary(apply *storage.Apply) bool {
+	if o.aggregateTerminalCASWinner {
+		return true
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	ops, err := o.stor.ApplyOperations().ListByApply(ctx, o.applyID)
+	if err != nil {
+		o.logError(apply, "observer: failed to load apply operations for terminal summary ownership; leaving summary to reconciliation",
+			"error", err)
+		return false
+	}
+	if len(ops) > 1 {
+		o.logInfo(apply, "observer: deferring terminal summary to aggregate publisher for multi-operation apply",
+			"operation_count", len(ops))
+		return false
+	}
+	return true
 }
 
 // formatStatusComment renders the apply's progress/cutover status comment,

--- a/pkg/webhook/comment_observer_test.go
+++ b/pkg/webhook/comment_observer_test.go
@@ -239,42 +239,44 @@ func TestAggregateTerminalObserverBypassesApplyLeaseCheck(t *testing.T) {
 	assert.False(t, hasLease, "aggregate terminal observer must not attach an apply lease to storage writes")
 }
 
-// A per-driver observer for a multi-operation apply must not publish the
-// apply-level terminal summary: it holds only one operation's task slice, so
+// A per-driver observer for a multi-operation apply must not publish a separate
+// apply-level summary comment: it holds only one operation's task slice, so
 // publishing here would post a duplicate, partial summary. The aggregate
 // CAS-winner observer owns that summary instead.
-func TestShouldPublishTerminalSummaryDefersForMultiOperationApply(t *testing.T) {
-	o := newDispatchTestObserver(&stubApplyOperationStore{ops: []*storage.ApplyOperation{
+func TestShouldPublishSeparateSummaryDefersForMultiOperationApply(t *testing.T) {
+	o := newDispatchTestObserver(nil)
+	ops := []*storage.ApplyOperation{
 		{ID: 1, Deployment: "eu", State: state.ApplyOperation.Completed},
 		{ID: 2, Deployment: "us", State: state.ApplyOperation.Completed},
-	}})
+	}
 
-	assert.False(t, o.shouldPublishTerminalSummary(completedApply()))
+	assert.False(t, o.shouldPublishSeparateSummary(completedApply(), ops, nil))
 }
 
 // A per-driver observer for a single-operation apply (every apply today, until
 // fan-out lands) owns and publishes the terminal summary unchanged.
-func TestShouldPublishTerminalSummaryPublishesForSingleOperationApply(t *testing.T) {
-	o := newDispatchTestObserver(&stubApplyOperationStore{ops: []*storage.ApplyOperation{
+func TestShouldPublishSeparateSummaryPublishesForSingleOperationApply(t *testing.T) {
+	o := newDispatchTestObserver(nil)
+	ops := []*storage.ApplyOperation{
 		{ID: 1, Deployment: "eu", State: state.ApplyOperation.Completed},
-	}})
+	}
 
-	assert.True(t, o.shouldPublishTerminalSummary(completedApply()))
+	assert.True(t, o.shouldPublishSeparateSummary(completedApply(), ops, nil))
 }
 
 // On an operation-load failure the per-driver observer must not publish: a
 // partial or duplicate summary is worse than none, and startup reconciliation
 // repairs a genuinely missing summary.
-func TestShouldPublishTerminalSummaryDefersOnLoadError(t *testing.T) {
-	o := newDispatchTestObserver(&stubApplyOperationStore{err: errors.New("db unavailable")})
+func TestShouldPublishSeparateSummaryDefersOnLoadError(t *testing.T) {
+	o := newDispatchTestObserver(nil)
 
-	assert.False(t, o.shouldPublishTerminalSummary(completedApply()))
+	assert.False(t, o.shouldPublishSeparateSummary(completedApply(), nil, errors.New("db unavailable")))
 }
 
 // The aggregate CAS-winner observer always owns the terminal summary — its
 // authority is the won non-terminal→terminal projection CAS, so it publishes
-// without consulting the operation set.
-func TestShouldPublishTerminalSummaryAlwaysTrueForAggregateWinner(t *testing.T) {
+// regardless of the operation set or a load failure.
+func TestShouldPublishSeparateSummaryAlwaysTrueForAggregateWinner(t *testing.T) {
 	cfg := CommentObserverConfig{
 		Repo:    "org/repo",
 		PR:      42,
@@ -283,5 +285,5 @@ func TestShouldPublishTerminalSummaryAlwaysTrueForAggregateWinner(t *testing.T) 
 	}
 	aggregate := NewAggregateTerminalCommentObserver(cfg)
 
-	assert.True(t, aggregate.shouldPublishTerminalSummary(completedApply()))
+	assert.True(t, aggregate.shouldPublishSeparateSummary(completedApply(), nil, errors.New("db unavailable")))
 }

--- a/pkg/webhook/comment_observer_test.go
+++ b/pkg/webhook/comment_observer_test.go
@@ -238,3 +238,50 @@ func TestAggregateTerminalObserverBypassesApplyLeaseCheck(t *testing.T) {
 	_, hasLease := storage.ApplyLeaseFromContext(ctx)
 	assert.False(t, hasLease, "aggregate terminal observer must not attach an apply lease to storage writes")
 }
+
+// A per-driver observer for a multi-operation apply must not publish the
+// apply-level terminal summary: it holds only one operation's task slice, so
+// publishing here would post a duplicate, partial summary. The aggregate
+// CAS-winner observer owns that summary instead.
+func TestShouldPublishTerminalSummaryDefersForMultiOperationApply(t *testing.T) {
+	o := newDispatchTestObserver(&stubApplyOperationStore{ops: []*storage.ApplyOperation{
+		{ID: 1, Deployment: "eu", State: state.ApplyOperation.Completed},
+		{ID: 2, Deployment: "us", State: state.ApplyOperation.Completed},
+	}})
+
+	assert.False(t, o.shouldPublishTerminalSummary(completedApply()))
+}
+
+// A per-driver observer for a single-operation apply (every apply today, until
+// fan-out lands) owns and publishes the terminal summary unchanged.
+func TestShouldPublishTerminalSummaryPublishesForSingleOperationApply(t *testing.T) {
+	o := newDispatchTestObserver(&stubApplyOperationStore{ops: []*storage.ApplyOperation{
+		{ID: 1, Deployment: "eu", State: state.ApplyOperation.Completed},
+	}})
+
+	assert.True(t, o.shouldPublishTerminalSummary(completedApply()))
+}
+
+// On an operation-load failure the per-driver observer must not publish: a
+// partial or duplicate summary is worse than none, and startup reconciliation
+// repairs a genuinely missing summary.
+func TestShouldPublishTerminalSummaryDefersOnLoadError(t *testing.T) {
+	o := newDispatchTestObserver(&stubApplyOperationStore{err: errors.New("db unavailable")})
+
+	assert.False(t, o.shouldPublishTerminalSummary(completedApply()))
+}
+
+// The aggregate CAS-winner observer always owns the terminal summary — its
+// authority is the won non-terminal→terminal projection CAS, so it publishes
+// without consulting the operation set.
+func TestShouldPublishTerminalSummaryAlwaysTrueForAggregateWinner(t *testing.T) {
+	cfg := CommentObserverConfig{
+		Repo:    "org/repo",
+		PR:      42,
+		ApplyID: 7,
+		Logger:  slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	aggregate := NewAggregateTerminalCommentObserver(cfg)
+
+	assert.True(t, aggregate.shouldPublishTerminalSummary(completedApply()))
+}


### PR DESCRIPTION
## Summary

A per-driver comment observer holds only **one operation's** task slice. For a
multi-operation (fan-out) apply, its `OnTerminal` would post a duplicate,
partial terminal **summary** comment alongside the operator's aggregate
CAS-winner publisher introduced in #420 — which is meant to be the single
publisher that re-derives the parent from every `apply_operation` and renders
the full task set.

This gates the per-driver summary publish on the apply being single-operation.
The aggregate CAS-winner observer always publishes (its authority is the won
non-terminal→terminal projection CAS). On an operation-lookup error the
per-driver path publishes nothing and leaves a genuinely missing summary to
startup reconciliation, since a partial/duplicate summary is worse than none.

Single-operation applies — every apply today, until the fan-out config flip —
are byte-for-byte unchanged. The fix lives in `CommentObserver.OnTerminal`
rather than the per-driver `pkg/tern` callsites, so the ownership rule sits
where the GitHub side effect is, and every terminal path (grouped, sequential,
resume, gRPC poll) is covered without threading operation-count logic through
tern control code.

Only the summary is gated. The per-operation progress-comment final edit and
the terminal hook (check-run refresh) still run; the aggregate observer
re-edits the progress comment with the full task set.

## Flow (before / after)

BEFORE (multi-op apply, on_failure=continue):
op A drive terminal ─┐
op B drive terminal ─┤── each per-driver OnTerminal posts a SUMMARY
op C drive terminal ─┘     (operation-scoped tasks → partial + duplicates)
operator CAS winner  ──── ALSO posts the aggregate summary   ⇒ N+1 summaries

AFTER (multi-op apply):
op A/B/C per-driver OnTerminal ── shouldPublishTerminalSummary? len(ops)>1 → skip summary
(still freezes progress comment + runs hook)
operator CAS winner ──────────── posts exactly ONE aggregate summary (all tasks)

AFTER (single-op apply, today):
per-driver OnTerminal ── len(ops)<=1 → publishes summary as before  (unchanged)

## References

- Builds on #420 (single-publisher aggregate terminal summary via the CAS winner).
