### PR TITLE
feat(storage): lease-held per-shard task upsert (UpsertShardProgress)

### DIFF
--- a/pkg/storage/mysqlstore/tasks.go
+++ b/pkg/storage/mysqlstore/tasks.go
@@ -159,6 +159,116 @@ func (s *taskStore) Update(ctx context.Context, task *storage.Task) error {
 	return nil
 }
 
+// UpsertShardProgress creates or updates the per-shard task row for
+// (apply_operation_id, namespace, table_name, shard). It is the operator's
+// write-through for reflected per-shard progress (e.g. PlanetScale shards from
+// SHOW VITESS_MIGRATIONS).
+//
+// It requires the operation lease on the context: the single lease-holding
+// operator is the only writer of an operation's per-shard rows, so the
+// lookup-then-write is serialized by that lease without a database-level unique
+// constraint. The insert is gated on the lease so a displaced operator that lost
+// the lease fails closed (ErrApplyLeaseLost) instead of writing stale rows, and
+// the update path reuses the lease-guarded Update. On conflict only the progress
+// fields change; identity and DDL are preserved.
+func (s *taskStore) UpsertShardProgress(ctx context.Context, task *storage.Task) error {
+	opLease, ok := storage.OperationLeaseFromContext(ctx)
+	if !ok {
+		return fmt.Errorf("upsert shard progress for %s.%s shard %q requires an operation lease", task.Namespace, task.TableName, task.Shard)
+	}
+	if !opLease.Valid() {
+		return fmt.Errorf("invalid operation lease for shard progress %s.%s shard %q: %w", task.Namespace, task.TableName, task.Shard, storage.ErrApplyLeaseLost)
+	}
+	if task.ApplyOperationID == nil {
+		return fmt.Errorf("upsert shard progress for %s.%s shard %q requires apply_operation_id", task.Namespace, task.TableName, task.Shard)
+	}
+	// Fail closed if the row targets a different operation than the held lease:
+	// the insert is gated on the leased operation, so without this a caller could
+	// write a row pointing at another apply_operation under this lease.
+	if *task.ApplyOperationID != opLease.OperationID {
+		return fmt.Errorf("upsert shard progress targets operation %d but the held lease is for operation %d", *task.ApplyOperationID, opLease.OperationID)
+	}
+	// A per-shard row must identify its table and shard. An empty table_name
+	// would store NULL and never match the lookup (re-inserting every pass), and
+	// an empty shard would collide with the unsharded single-shard sentinel.
+	if task.TableName == "" {
+		return fmt.Errorf("upsert shard progress for operation %d shard %q requires a table name", *task.ApplyOperationID, task.Shard)
+	}
+	if task.Shard == "" {
+		return fmt.Errorf("upsert shard progress for operation %d table %q requires a non-empty shard", *task.ApplyOperationID, task.TableName)
+	}
+
+	// Find the existing per-shard row under this operation. The lookup-then-write
+	// is safe without a unique constraint because the operation lease makes the
+	// caller the single writer of this operation's rows.
+	var id int64
+	err := s.db.QueryRowContext(ctx, `
+		SELECT id FROM tasks
+		WHERE apply_operation_id = ? AND namespace = ? AND table_name = ? AND shard = ?
+	`, *task.ApplyOperationID, task.Namespace, nullString(task.TableName), task.Shard).Scan(&id)
+	switch {
+	case err == nil:
+		// Existing shard row: update its progress fields under the lease guard.
+		task.ID = id
+		return s.Update(ctx, task)
+	case errors.Is(err, sql.ErrNoRows):
+		// New shard row: insert gated on the lease so a lost lease fails closed.
+		return s.insertShardTaskGuarded(ctx, task, opLease)
+	default:
+		return fmt.Errorf("look up shard task for operation %d %s.%s shard %q: %w",
+			*task.ApplyOperationID, task.Namespace, task.TableName, task.Shard, err)
+	}
+}
+
+// insertShardTaskGuarded inserts a new per-shard task row only while the
+// operation lease is still current. The INSERT ... SELECT ... WHERE the
+// operation's lease_token matches means a displaced operator inserts zero rows
+// and fails closed rather than writing a stale shard row.
+func (s *taskStore) insertShardTaskGuarded(ctx context.Context, task *storage.Task, opLease storage.OperationLease) error {
+	options := task.Options
+	if len(options) == 0 {
+		options = []byte("{}")
+	}
+	result, err := s.db.ExecContext(ctx, `
+		INSERT INTO tasks (
+			task_identifier, apply_id, apply_operation_id, plan_id, database_name, database_type,
+			namespace, table_name, shard, ddl, ddl_action,
+			engine, repository, pull_request, environment, state, error_message, options, attempt,
+			rows_copied, rows_total, progress_percent, eta_seconds, cutover_attempts,
+			is_instant, ready_to_complete, engine_migration_id,
+			started_at, completed_at, created_at, updated_at
+		)
+		SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+		FROM apply_operations ao
+		WHERE ao.id = ? AND ao.lease_token = ?
+	`,
+		task.TaskIdentifier, task.ApplyID, nullInt64Ptr(task.ApplyOperationID), task.PlanID, task.Database, task.DatabaseType,
+		task.Namespace, nullString(task.TableName), task.Shard, nullString(task.DDL), nullString(task.DDLAction),
+		task.Engine, task.Repository, task.PullRequest, task.Environment,
+		task.State, nullString(task.ErrorMessage), string(options), task.Attempt,
+		task.RowsCopied, task.RowsTotal, task.ProgressPercent, task.ETASeconds, task.CutoverAttempts,
+		task.IsInstant, task.ReadyToComplete, nullString(task.EngineMigrationID),
+		task.StartedAt, task.CompletedAt, task.CreatedAt, task.UpdatedAt,
+		opLease.OperationID, opLease.Token,
+	)
+	if err != nil {
+		return fmt.Errorf("insert shard task for operation %d %s.%s shard %q: %w",
+			opLease.OperationID, task.Namespace, task.TableName, task.Shard, err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("read shard task insert rows affected for operation %d: %w", opLease.OperationID, err)
+	}
+	if rows == 0 {
+		// Zero rows inserted means the operation lease is no longer current.
+		return ensureOperationLeaseStillOwned(ctx, s.db, opLease)
+	}
+	if newID, err := result.LastInsertId(); err == nil {
+		task.ID = newID
+	}
+	return nil
+}
+
 // GetByApplyID returns all tasks for an apply.
 func (s *taskStore) GetByApplyID(ctx context.Context, applyID int64) ([]*storage.Task, error) {
 	rows, err := s.db.QueryContext(ctx, `

--- a/pkg/storage/mysqlstore/tasks_test.go
+++ b/pkg/storage/mysqlstore/tasks_test.go
@@ -282,3 +282,122 @@ func TestTaskStore_UnshardedTaskHasEmptyShard(t *testing.T) {
 	assert.Equal(t, "", got.Shard, "unsharded tasks default to the empty-string shard")
 	assert.Equal(t, 0, got.CutoverAttempts)
 }
+
+// UpsertShardProgress is the operator's lease-held write-through for reflected
+// per-shard progress (e.g. PlanetScale shards from SHOW VITESS_MIGRATIONS). The
+// single lease-holding operator inserts a new per-shard task and updates it in
+// place on later passes (no duplicate row); a caller without the operation lease
+// is refused, and a displaced operator that lost the lease fails closed without
+// writing — on both the insert and update paths.
+func TestTaskStore_UpsertShardProgress(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "resolute", "vitess", "staging")
+	apply := createTestApply(t, store, lock, "apply_upsert_shard", 1)
+	opID, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-a", Target: "resolute",
+	})
+	require.NoError(t, err)
+	stampOperationLease(t, opID, "driver", "op-token")
+
+	opCtx := func(token string) context.Context {
+		return storage.WithOperationLease(ctx, storage.OperationLease{
+			ApplyID: apply.ID, OperationID: opID, Owner: "driver", Token: token,
+		})
+	}
+
+	now := time.Now()
+	shardTask := func(shard string) *storage.Task {
+		return &storage.Task{
+			TaskIdentifier:   "task-" + shard,
+			ApplyID:          apply.ID,
+			ApplyOperationID: &opID,
+			PlanID:           apply.PlanID,
+			Database:         apply.Database,
+			DatabaseType:     apply.DatabaseType,
+			Engine:           storage.EnginePlanetScale,
+			Environment:      apply.Environment,
+			State:            state.Task.Running,
+			Namespace:        "resolute",
+			TableName:        "users",
+			Shard:            shard,
+			DDL:              "ALTER TABLE `users` ADD COLUMN `email` varchar(255)",
+			DDLAction:        "ALTER",
+			RowsCopied:       100000,
+			RowsTotal:        500000,
+			ProgressPercent:  20,
+			CreatedAt:        now,
+			UpdatedAt:        now,
+		}
+	}
+
+	// Without an operation lease on the context the write is refused outright.
+	require.ErrorContains(t, store.Tasks().UpsertShardProgress(ctx, shardTask("-80")),
+		"requires an operation lease")
+
+	// A displaced operator (stale token) fails closed on the insert path: nothing written.
+	require.ErrorIs(t, store.Tasks().UpsertShardProgress(opCtx("stale"), shardTask("-80")), storage.ErrApplyLeaseLost)
+	got, err := store.Tasks().GetByApplyOperationID(ctx, opID)
+	require.NoError(t, err)
+	assert.Empty(t, got, "a lost lease must not insert a shard task")
+
+	// The lease holder inserts the shard row.
+	require.NoError(t, store.Tasks().UpsertShardProgress(opCtx("op-token"), shardTask("-80")))
+	got, err = store.Tasks().GetByApplyOperationID(ctx, opID)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, "-80", got[0].Shard)
+	assert.Equal(t, 20, got[0].ProgressPercent)
+
+	// Re-upserting the same shard with advanced progress updates in place — no duplicate row.
+	advanced := shardTask("-80")
+	advanced.State = state.Task.Completed
+	advanced.ProgressPercent = 100
+	advanced.RowsCopied = 500000
+	advanced.ReadyToComplete = true
+	require.NoError(t, store.Tasks().UpsertShardProgress(opCtx("op-token"), advanced))
+	got, err = store.Tasks().GetByApplyOperationID(ctx, opID)
+	require.NoError(t, err)
+	require.Len(t, got, 1, "re-upserting the same shard must update in place, not insert a duplicate")
+	assert.Equal(t, state.Task.Completed, got[0].State)
+	assert.Equal(t, 100, got[0].ProgressPercent)
+	assert.True(t, got[0].ReadyToComplete)
+
+	// A stale operator must not overwrite an existing shard row (update path fails closed).
+	stale := shardTask("-80")
+	stale.State = state.Task.Failed
+	stale.ProgressPercent = 5
+	require.ErrorIs(t, store.Tasks().UpsertShardProgress(opCtx("stale"), stale), storage.ErrApplyLeaseLost)
+	got, err = store.Tasks().GetByApplyOperationID(ctx, opID)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, state.Task.Completed, got[0].State, "a lost lease must not overwrite the shard row")
+	assert.Equal(t, 100, got[0].ProgressPercent)
+
+	// A different shard under the same operation is a separate row.
+	require.NoError(t, store.Tasks().UpsertShardProgress(opCtx("op-token"), shardTask("80-")))
+	got, err = store.Tasks().GetByApplyOperationID(ctx, opID)
+	require.NoError(t, err)
+	assert.Len(t, got, 2, "a different shard is its own per-shard task row")
+
+	// A row targeting a different operation than the held lease is refused, so
+	// the lease cannot gate a write that points at another operation.
+	mismatched := shardTask("c0-")
+	otherOp := opID + 1000
+	mismatched.ApplyOperationID = &otherOp
+	require.Error(t, store.Tasks().UpsertShardProgress(opCtx("op-token"), mismatched))
+
+	// A per-shard row must identify its table and shard.
+	noTable := shardTask("e0-")
+	noTable.TableName = ""
+	require.ErrorContains(t, store.Tasks().UpsertShardProgress(opCtx("op-token"), noTable), "requires a table name")
+	noShard := shardTask("")
+	require.ErrorContains(t, store.Tasks().UpsertShardProgress(opCtx("op-token"), noShard), "requires a non-empty shard")
+
+	// None of the refused writes created rows.
+	got, err = store.Tasks().GetByApplyOperationID(ctx, opID)
+	require.NoError(t, err)
+	assert.Len(t, got, 2, "refused writes must not create rows")
+}

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -371,6 +371,17 @@ type TaskStore interface {
 	// Returns ErrTaskNotFound if the task does not exist.
 	Update(ctx context.Context, task *Task) error
 
+	// UpsertShardProgress creates or updates the per-shard task row for
+	// (apply_operation_id, namespace, table_name, shard). It is the operator's
+	// write-through for reflected per-shard progress (e.g. PlanetScale shards
+	// discovered via SHOW VITESS_MIGRATIONS). It requires the operation lease on
+	// the context: the single lease-holding operator is the only writer of an
+	// operation's per-shard rows, so the lookup-then-write is serialized by that
+	// lease and needs no unique constraint. A displaced operator (lost lease)
+	// fails closed with ErrApplyLeaseLost. On conflict only the progress fields
+	// change; identity and DDL are preserved.
+	UpsertShardProgress(ctx context.Context, task *Task) error
+
 	// GetByApplyID returns all tasks for an apply.
 	// Used for aggregating task states to derive Apply state.
 	GetByApplyID(ctx context.Context, applyID int64) ([]*Task, error)


### PR DESCRIPTION
## Why this matters

Persisting per-shard progress needs a write that is safe under the apply's real concurrency: progress is polled from more than one place, so a naive create-or-update would race and produce duplicate per-shard rows. The safe writer is the **single operator that holds the operation's lease** — for a sharded engine like PlanetScale there is exactly one operation per apply (the deploy request), so one lease-holding operator owns all of that apply's per-shard writes.

## What it does

Adds `TaskStore.UpsertShardProgress` — creates or updates the per-shard `tasks` row keyed by `(apply_operation_id, namespace, table_name, shard)`:

- **Requires the operation lease on the context.** The single lease-holder is the only writer of an operation's per-shard rows, so the lookup-then-write is serialized by the lease and needs **no database-level unique constraint** — which also sidesteps the four-column index-key-length limit on `(operation, namespace, table, shard)`.
- **Fails closed.** The insert is gated on the lease (`INSERT ... SELECT ... WHERE` the operation's `lease_token` matches), so a displaced operator that lost the lease inserts zero rows and returns `ErrApplyLeaseLost` instead of writing a stale row. The update path reuses the lease-guarded `Update`.
- **Preserves identity on conflict** — only the progress fields change; `task_identifier`/DDL are untouched.

```
one operator (holds the deploy-request operation lease)
   └── UpsertShardProgress(ctx, task)   ← all of the apply's per-shard rows
```

Integration test covers: refusal without a lease, fail-closed on both the insert and update paths under a stale lease, in-place update (no duplicate), and a second shard as its own row.

This is the storage foundation; the operator-reconcile wiring that calls it with the per-shard engine results follows in the next PR.

*This PR was written by Claude (Opus 4.8).*