### PR TITLE
fix(cli): resolve database type from server config for pull and onboard

### DIFF
--- a/pkg/cmd/commands/onboard.go
+++ b/pkg/cmd/commands/onboard.go
@@ -19,7 +19,7 @@ type OnboardCmd struct {
 	Database          string   `short:"d" required:"" help:"Database name from SchemaBot server config"`
 	Environment       string   `short:"e" required:"" help:"Source environment to pull from"`
 	SchemaDir         string   `short:"s" required:"" help:"Schema root to write schemabot.yaml and namespace directories" name:"schema_dir"`
-	Type              string   `help:"Database type" default:"mysql" enum:"mysql"`
+	Type              string   `help:"Database type override; resolved from the server's registered config when omitted"`
 	Namespaces        []string `name:"namespace" help:"Concrete live namespace to onboard. Repeat for multiple namespaces. Omit to discover all non-reserved namespaces."`
 	TemplateEnvSuffix bool     `help:"Write namespaces ending in _<environment> as _$ENV directories" name:"template-env-suffix"`
 	DryRun            bool     `help:"Preview files without writing them" name:"dry-run"`

--- a/pkg/cmd/commands/pull.go
+++ b/pkg/cmd/commands/pull.go
@@ -14,7 +14,7 @@ import (
 type PullCmd struct {
 	Database      string   `short:"d" required:"" help:"Database name from SchemaBot server config"`
 	Environment   string   `short:"e" required:"" help:"Source environment to pull from"`
-	Type          string   `help:"Database type" default:"mysql" enum:"mysql"`
+	Type          string   `help:"Database type override; resolved from the server's registered config when omitted"`
 	Namespaces    []string `name:"namespace" help:"Concrete live namespace to pull. Repeat for multiple namespaces. Omit to discover all non-reserved namespaces."`
 	CatalogDetail string   `help:"Structured catalog detail to include" default:"basic" enum:"basic,detailed"`
 }

--- a/pkg/cmd/commands/pull_test.go
+++ b/pkg/cmd/commands/pull_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/alecthomas/kong"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -21,4 +22,23 @@ func TestWritePullSchemaResponseReturnsSchemaAsJSON(t *testing.T) {
 	assert.Equal(t, "mysql", got.Type)
 	assert.Equal(t, "production", got.Environment)
 	assert.Equal(t, "CREATE TABLE `users` (`id` bigint NOT NULL);\n", got.Namespaces["orders"].Tables["users"])
+}
+
+// The pull command resolves the database type from the server's registered
+// config, so --type is optional (defaults to empty) and accepts any engine the
+// server supports rather than being pinned to one type.
+func TestPullCmdTypeIsOptionalAndAcceptsAnyEngine(t *testing.T) {
+	var cli struct {
+		Pull PullCmd `cmd:""`
+	}
+	parser, err := kong.New(&cli)
+	require.NoError(t, err)
+
+	_, err = parser.Parse([]string{"pull", "-d", "boardgames", "-e", "staging"})
+	require.NoError(t, err)
+	assert.Empty(t, cli.Pull.Type, "type must default to empty so the server resolves it from config")
+
+	_, err = parser.Parse([]string{"pull", "-d", "boardgames", "-e", "staging", "--type", "vitess"})
+	require.NoError(t, err, "a non-mysql type must be accepted")
+	assert.Equal(t, "vitess", cli.Pull.Type)
 }


### PR DESCRIPTION
## Why this matters

The `pull` and `onboard` commands pinned `--type` to MySQL (a `mysql` default plus a `mysql`-only enum). The data plane supports pulling other engines, but the CLI couldn't reach them: the default `mysql` request type mismatched a database's registered type and was rejected server-side, while passing the real type was rejected at parse time. The result was that a registered non-MySQL database could not be pulled or onboarded from the CLI at all.

## What it does

- `--type` becomes an optional override. When omitted, the request carries no type and the server resolves it from the registered database config, then dispatches with the resolved type. Passing `--type` still works as an explicit override and is no longer restricted to a single engine.
- Adds a parse test asserting `--type` defaults to empty and accepts a non-MySQL value.

No server change is needed: the control plane already skips the type-mismatch check for an empty request type and dispatches the resolved config type to the data plane.

## How it moves toward the northstar

`pull` is the routed live-schema primitive the Global Schema API and onboarding are built on. Letting the server own type resolution means a caller only needs the database and environment — the same identifiers the registry is keyed on — to pull any registered database regardless of engine, which is what fleet-wide schema intelligence requires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)