### PR TITLE
feat(tern): persist per-shard progress from the operator's lease-held drive

### DIFF
--- a/pkg/storage/mysqlstore/tasks.go
+++ b/pkg/storage/mysqlstore/tasks.go
@@ -269,12 +269,15 @@ func (s *taskStore) insertShardTaskGuarded(ctx context.Context, task *storage.Ta
 	return nil
 }
 
-// GetByApplyID returns all tasks for an apply.
+// GetByApplyID returns the per-table tasks for an apply. Per-shard detail rows
+// (shard != "") are excluded: they are a reflected read-model written by the
+// operator and must not re-enter the per-table drive/gating/progress pipeline on
+// reload. Read those via GetShardProgressByApplyOperationID.
 func (s *taskStore) GetByApplyID(ctx context.Context, applyID int64) ([]*storage.Task, error) {
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT `+taskColumns+`
 		FROM tasks
-		WHERE apply_id = ?
+		WHERE apply_id = ? AND shard = ''
 		ORDER BY created_at DESC
 	`, applyID)
 	if err != nil {
@@ -285,16 +288,17 @@ func (s *taskStore) GetByApplyID(ctx context.Context, applyID int64) ([]*storage
 	return scanTasks(rows)
 }
 
-// GetByApplyOperationID returns the tasks for a single apply_operation (one
-// deployment of a multi-deployment apply). While the config layer hard-blocks
-// more than one deployment per environment this returns the same rows as
-// GetByApplyID for the apply's single operation; it lets a driver drive and
+// GetByApplyOperationID returns the per-table tasks for a single apply_operation
+// (one deployment of a multi-deployment apply). It lets a driver drive and
 // reconcile one deployment independently once an apply fans out across several.
+// Per-shard detail rows (shard != "") are excluded for the same reason as
+// GetByApplyID: they must stay write-only relative to the per-table pipeline and
+// are read via GetShardProgressByApplyOperationID.
 func (s *taskStore) GetByApplyOperationID(ctx context.Context, applyOperationID int64) ([]*storage.Task, error) {
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT `+taskColumns+`
 		FROM tasks
-		WHERE apply_operation_id = ?
+		WHERE apply_operation_id = ? AND shard = ''
 		ORDER BY created_at DESC, id DESC
 	`, applyOperationID)
 	if err != nil {
@@ -312,6 +316,26 @@ func (s *taskStore) GetByApplyOperationID(ctx context.Context, applyOperationID 
 		return []*storage.Task{}, nil
 	}
 	return tasks, nil
+}
+
+// GetShardProgressByApplyOperationID returns the per-shard task rows
+// (shard != "") for an operation, ordered by namespace, table_name, shard. It is
+// the read companion to UpsertShardProgress: the per-table loaders exclude these
+// rows, so this is how the renderer (and tests) read the per-shard breakdown
+// without the rows re-entering the per-table pipeline.
+func (s *taskStore) GetShardProgressByApplyOperationID(ctx context.Context, applyOperationID int64) ([]*storage.Task, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT `+taskColumns+`
+		FROM tasks
+		WHERE apply_operation_id = ? AND shard != ''
+		ORDER BY namespace, table_name, shard
+	`, applyOperationID)
+	if err != nil {
+		return nil, fmt.Errorf("query shard progress tasks for apply_operation %d: %w", applyOperationID, err)
+	}
+	defer utils.CloseAndLog(rows)
+
+	return scanTasks(rows)
 }
 
 // GetByDatabase returns all tasks for a database.

--- a/pkg/storage/mysqlstore/tasks_test.go
+++ b/pkg/storage/mysqlstore/tasks_test.go
@@ -226,10 +226,15 @@ func TestTaskStore_PerShardTaskRoundTrip(t *testing.T) {
 	assert.Equal(t, "-80", got.Shard)
 	assert.Equal(t, 1, got.CutoverAttempts)
 
-	// Both shards of the same table coexist under one operation.
-	tasks, err := store.Tasks().GetByApplyOperationID(ctx, opID)
+	// Both shards of the same table coexist under one operation. They are read
+	// via the per-shard reader; the per-table GetByApplyOperationID excludes them
+	// so they never re-enter the per-table pipeline on reload.
+	tasks, err := store.Tasks().GetShardProgressByApplyOperationID(ctx, opID)
 	require.NoError(t, err)
 	require.Len(t, tasks, 2)
+	perTable, err := store.Tasks().GetByApplyOperationID(ctx, opID)
+	require.NoError(t, err)
+	assert.Empty(t, perTable, "per-shard rows must not leak into the per-table loader")
 	shardAttempts := map[string]int{}
 	for _, task := range tasks {
 		assert.Equal(t, "users", task.TableName)
@@ -339,13 +344,13 @@ func TestTaskStore_UpsertShardProgress(t *testing.T) {
 
 	// A displaced operator (stale token) fails closed on the insert path: nothing written.
 	require.ErrorIs(t, store.Tasks().UpsertShardProgress(opCtx("stale"), shardTask("-80")), storage.ErrApplyLeaseLost)
-	got, err := store.Tasks().GetByApplyOperationID(ctx, opID)
+	got, err := store.Tasks().GetShardProgressByApplyOperationID(ctx, opID)
 	require.NoError(t, err)
 	assert.Empty(t, got, "a lost lease must not insert a shard task")
 
 	// The lease holder inserts the shard row.
 	require.NoError(t, store.Tasks().UpsertShardProgress(opCtx("op-token"), shardTask("-80")))
-	got, err = store.Tasks().GetByApplyOperationID(ctx, opID)
+	got, err = store.Tasks().GetShardProgressByApplyOperationID(ctx, opID)
 	require.NoError(t, err)
 	require.Len(t, got, 1)
 	assert.Equal(t, "-80", got[0].Shard)
@@ -358,7 +363,7 @@ func TestTaskStore_UpsertShardProgress(t *testing.T) {
 	advanced.RowsCopied = 500000
 	advanced.ReadyToComplete = true
 	require.NoError(t, store.Tasks().UpsertShardProgress(opCtx("op-token"), advanced))
-	got, err = store.Tasks().GetByApplyOperationID(ctx, opID)
+	got, err = store.Tasks().GetShardProgressByApplyOperationID(ctx, opID)
 	require.NoError(t, err)
 	require.Len(t, got, 1, "re-upserting the same shard must update in place, not insert a duplicate")
 	assert.Equal(t, state.Task.Completed, got[0].State)
@@ -370,7 +375,7 @@ func TestTaskStore_UpsertShardProgress(t *testing.T) {
 	stale.State = state.Task.Failed
 	stale.ProgressPercent = 5
 	require.ErrorIs(t, store.Tasks().UpsertShardProgress(opCtx("stale"), stale), storage.ErrApplyLeaseLost)
-	got, err = store.Tasks().GetByApplyOperationID(ctx, opID)
+	got, err = store.Tasks().GetShardProgressByApplyOperationID(ctx, opID)
 	require.NoError(t, err)
 	require.Len(t, got, 1)
 	assert.Equal(t, state.Task.Completed, got[0].State, "a lost lease must not overwrite the shard row")
@@ -378,7 +383,7 @@ func TestTaskStore_UpsertShardProgress(t *testing.T) {
 
 	// A different shard under the same operation is a separate row.
 	require.NoError(t, store.Tasks().UpsertShardProgress(opCtx("op-token"), shardTask("80-")))
-	got, err = store.Tasks().GetByApplyOperationID(ctx, opID)
+	got, err = store.Tasks().GetShardProgressByApplyOperationID(ctx, opID)
 	require.NoError(t, err)
 	assert.Len(t, got, 2, "a different shard is its own per-shard task row")
 
@@ -397,7 +402,7 @@ func TestTaskStore_UpsertShardProgress(t *testing.T) {
 	require.ErrorContains(t, store.Tasks().UpsertShardProgress(opCtx("op-token"), noShard), "requires a non-empty shard")
 
 	// None of the refused writes created rows.
-	got, err = store.Tasks().GetByApplyOperationID(ctx, opID)
+	got, err = store.Tasks().GetShardProgressByApplyOperationID(ctx, opID)
 	require.NoError(t, err)
 	assert.Len(t, got, 2, "refused writes must not create rows")
 }

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -386,10 +386,18 @@ type TaskStore interface {
 	// Used for aggregating task states to derive Apply state.
 	GetByApplyID(ctx context.Context, applyID int64) ([]*Task, error)
 
-	// GetByApplyOperationID returns the tasks for a single apply_operation
-	// (one deployment of a multi-deployment apply). Used to drive and
-	// reconcile one operation independently of its sibling deployments.
+	// GetByApplyOperationID returns the per-table tasks for a single
+	// apply_operation (one deployment of a multi-deployment apply). Used to drive
+	// and reconcile one operation independently of its sibling deployments.
+	// Per-shard detail rows are excluded — read them via
+	// GetShardProgressByApplyOperationID.
 	GetByApplyOperationID(ctx context.Context, applyOperationID int64) ([]*Task, error)
+
+	// GetShardProgressByApplyOperationID returns the per-shard detail task rows
+	// (shard != "") for an operation. These are a reflected read-model the
+	// per-table loaders exclude, so they never re-enter the per-table pipeline;
+	// the renderer reads the per-shard breakdown through this method.
+	GetShardProgressByApplyOperationID(ctx context.Context, applyOperationID int64) ([]*Task, error)
 
 	// GetByDatabase returns all tasks for a database.
 	GetByDatabase(ctx context.Context, database string) ([]*Task, error)

--- a/pkg/tern/local_apply_grouped.go
+++ b/pkg/tern/local_apply_grouped.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
+
 	"github.com/block/schemabot/pkg/engine"
 	"github.com/block/schemabot/pkg/metrics"
 	"github.com/block/schemabot/pkg/state"
@@ -1030,6 +1032,10 @@ func (c *LocalClient) syncAtomicTaskProgress(ctx context.Context, tasks []*stora
 			if tp.CompletedAt != nil && !retryableFailure && task.CompletedAt == nil {
 				task.CompletedAt = tp.CompletedAt
 			}
+			// Persist the per-shard breakdown as per-shard tasks so the renderer
+			// can show per-shard state from storage. No-op outside the lease-held
+			// operator drive (read-path callers carry no operation lease).
+			c.writeShardProgress(ctx, task, tp, now)
 		} else if instantFromMetadata {
 			task.IsInstant = true
 			if result.State.IsTerminal() && !retryableFailure {
@@ -1051,6 +1057,71 @@ func (c *LocalClient) syncAtomicTaskProgress(ctx context.Context, tasks []*stora
 			task.ProgressPercent = 100
 		}
 		c.transitionTaskState(ctx, task, 0, taskStateWithNoBackwardProgress(task.State, newState), "")
+	}
+}
+
+// writeShardProgress persists a table's per-shard breakdown as per-shard tasks
+// (shard != ""), so the renderer can show per-shard state from storage instead
+// of a live re-query. It runs only inside the operator's lease-held drive:
+// UpsertShardProgress requires the operation lease, and read-path callers (which
+// carry no operation lease) skip it so a plain progress read never writes. A
+// failed shard write is logged, not fatal — the next reconcile re-applies it.
+func (c *LocalClient) writeShardProgress(ctx context.Context, table *storage.Task, tp *engine.TableProgress, now time.Time) {
+	if len(tp.Shards) == 0 {
+		return
+	}
+	if _, ok := storage.OperationLeaseFromContext(ctx); !ok {
+		return
+	}
+	var operationID int64
+	if table.ApplyOperationID != nil {
+		operationID = *table.ApplyOperationID
+	}
+	for _, sh := range tp.Shards {
+		shardTask := &storage.Task{
+			TaskIdentifier:   "task-" + strings.ReplaceAll(uuid.New().String(), "-", "")[:16],
+			ApplyID:          table.ApplyID,
+			ApplyOperationID: table.ApplyOperationID,
+			PlanID:           table.PlanID,
+			Database:         table.Database,
+			DatabaseType:     table.DatabaseType,
+			Engine:           table.Engine,
+			Repository:       table.Repository,
+			PullRequest:      table.PullRequest,
+			Environment:      table.Environment,
+			Namespace:        table.Namespace,
+			TableName:        table.TableName,
+			Shard:            sh.Shard,
+			DDL:              table.DDL,
+			DDLAction:        table.DDLAction,
+			State:            state.NormalizeShardStatus(sh.State),
+			RowsCopied:       sh.RowsCopied,
+			RowsTotal:        sh.RowsTotal,
+			ProgressPercent:  sh.Progress,
+			ETASeconds:       int(sh.ETASeconds),
+			CutoverAttempts:  sh.CutoverAttempts,
+			CreatedAt:        now,
+			UpdatedAt:        now,
+		}
+		err := c.storage.Tasks().UpsertShardProgress(ctx, shardTask)
+		if err == nil {
+			continue
+		}
+		if errors.Is(err, storage.ErrApplyLeaseLost) {
+			// A peer claimed the operation; this driver is displaced and the new
+			// owner reconciles the remaining shards. Stop write-through — every
+			// further shard would fail the same way. Expected during failover.
+			c.logger.Debug("operator: stopping shard progress write-through, operation lease lost",
+				"apply_id", table.ApplyID, "apply_operation_id", operationID,
+				"database", table.Database, "environment", table.Environment,
+				"namespace", table.Namespace, "table", table.TableName, "shard", sh.Shard)
+			return
+		}
+		c.logger.Error("operator: failed to persist shard progress",
+			"apply_id", table.ApplyID, "apply_operation_id", operationID,
+			"database", table.Database, "environment", table.Environment,
+			"namespace", table.Namespace, "table", table.TableName, "shard", sh.Shard,
+			"error", err)
 	}
 }
 

--- a/pkg/tern/shard_writethrough_integration_test.go
+++ b/pkg/tern/shard_writethrough_integration_test.go
@@ -1,0 +1,153 @@
+//go:build integration
+
+package tern
+
+import (
+	"database/sql"
+	"fmt"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/block/spirit/pkg/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/block/schemabot/pkg/engine"
+	"github.com/block/schemabot/pkg/state"
+	"github.com/block/schemabot/pkg/storage"
+)
+
+// The operator's lease-held drive persists a table's per-shard breakdown as
+// per-shard tasks, so the renderer can show per-shard state from storage. A
+// read-path caller without the operation lease must not write — it only renders.
+func TestWriteShardProgressPersistsPerShardTasksUnderLease(t *testing.T) {
+	dsn := sharedDSN
+	setupStorageSchema(t, dsn)
+	t.Cleanup(func() { cleanupTasks(t, dsn) })
+
+	ctx := t.Context()
+	stor := createStorage(t, dsn)
+	logger := slog.New(slog.DiscardHandler)
+
+	now := time.Now()
+	plan := &storage.Plan{
+		PlanIdentifier: fmt.Sprintf("plan-shard-%d", now.UnixNano()),
+		Database:       "testdb",
+		DatabaseType:   storage.DatabaseTypeVitess,
+		Deployment:     "region-a",
+		Environment:    localClientTestEnvironment,
+		CreatedAt:      now,
+		Namespaces: map[string]*storage.NamespacePlanData{
+			"resolute": {Tables: []storage.TableChange{
+				{Namespace: "resolute", Table: "users", DDL: "ALTER TABLE `users` ADD COLUMN email VARCHAR(255)", Operation: "alter"},
+			}},
+		},
+	}
+	planID, err := stor.Plans().Create(ctx, plan)
+	require.NoError(t, err)
+
+	apply := &storage.Apply{
+		ApplyIdentifier: fmt.Sprintf("apply-shard-%d", now.UnixNano()),
+		PlanID:          planID,
+		Database:        "testdb",
+		DatabaseType:    storage.DatabaseTypeVitess,
+		Deployment:      "region-a",
+		Engine:          storage.EnginePlanetScale,
+		State:           state.Apply.Running,
+		Environment:     localClientTestEnvironment,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+	applyID, err := stor.Applies().Create(ctx, apply)
+	require.NoError(t, err)
+
+	opID, err := stor.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID:    applyID,
+		Deployment: "region-a",
+		Target:     "resolute",
+		State:      state.ApplyOperation.Running,
+	})
+	require.NoError(t, err)
+
+	// Stamp the operation lease the operator drive holds.
+	leaseDB, err := sql.Open("mysql", dsn)
+	require.NoError(t, err)
+	defer utils.CloseAndLog(leaseDB)
+	require.NoError(t, leaseDB.PingContext(ctx))
+	_, err = leaseDB.ExecContext(ctx, `
+		UPDATE apply_operations SET lease_owner = ?, lease_token = ?, lease_acquired_at = NOW() WHERE id = ?
+	`, "driver", "op-token", opID)
+	require.NoError(t, err)
+
+	client := &LocalClient{storage: stor, logger: logger}
+
+	perTable := &storage.Task{
+		TaskIdentifier:   fmt.Sprintf("task-users-%d", now.UnixNano()),
+		ApplyID:          applyID,
+		ApplyOperationID: &opID,
+		PlanID:           planID,
+		Database:         "testdb",
+		DatabaseType:     storage.DatabaseTypeVitess,
+		Engine:           storage.EnginePlanetScale,
+		Environment:      localClientTestEnvironment,
+		State:            state.Task.Running,
+		Namespace:        "resolute",
+		TableName:        "users",
+		DDL:              "ALTER TABLE `users` ADD COLUMN email VARCHAR(255)",
+		DDLAction:        "alter",
+	}
+	tp := &engine.TableProgress{
+		Namespace: "resolute",
+		Table:     "users",
+		Shards: []engine.ShardProgress{
+			{Shard: "-80", State: "running", Progress: 44, RowsCopied: 220000, RowsTotal: 500000, ETASeconds: 720, CutoverAttempts: 1},
+			{Shard: "80-", State: "running", Progress: 60, RowsCopied: 300000, RowsTotal: 500000, ETASeconds: 480},
+		},
+	}
+
+	leaseCtx := storage.WithOperationLease(ctx, storage.OperationLease{
+		ApplyID: applyID, OperationID: opID, Owner: "driver", Token: "op-token",
+	})
+
+	// Under the lease, both shards are persisted as per-shard tasks.
+	client.writeShardProgress(leaseCtx, perTable, tp, now)
+
+	got, err := stor.Tasks().GetByApplyOperationID(ctx, opID)
+	require.NoError(t, err)
+	require.Len(t, got, 2, "both shards persisted as per-shard tasks")
+	byShard := map[string]*storage.Task{}
+	for _, task := range got {
+		assert.Equal(t, "resolute", task.Namespace)
+		assert.Equal(t, "users", task.TableName)
+		byShard[task.Shard] = task
+	}
+	require.Contains(t, byShard, "-80")
+	require.Contains(t, byShard, "80-")
+	assert.Equal(t, 44, byShard["-80"].ProgressPercent)
+	assert.Equal(t, int64(220000), byShard["-80"].RowsCopied)
+	assert.Equal(t, int64(500000), byShard["-80"].RowsTotal)
+	assert.Equal(t, 720, byShard["-80"].ETASeconds)
+	assert.Equal(t, 1, byShard["-80"].CutoverAttempts)
+	assert.Equal(t, 60, byShard["80-"].ProgressPercent)
+
+	// A later drive pass updates in place — no duplicate rows.
+	tp.Shards[0].Progress = 100
+	tp.Shards[0].RowsCopied = 500000
+	client.writeShardProgress(leaseCtx, perTable, tp, time.Now())
+	got, err = stor.Tasks().GetByApplyOperationID(ctx, opID)
+	require.NoError(t, err)
+	require.Len(t, got, 2, "re-running the drive updates shards in place, no duplicates")
+	for _, task := range got {
+		if task.Shard == "-80" {
+			assert.Equal(t, 100, task.ProgressPercent, "shard -80 advanced to 100%")
+		}
+	}
+
+	// A read-path caller (no operation lease) must not write.
+	cleanupTasks(t, dsn)
+	client.writeShardProgress(ctx, perTable, tp, time.Now())
+	got, err = stor.Tasks().GetByApplyOperationID(ctx, opID)
+	require.NoError(t, err)
+	assert.Empty(t, got, "without an operation lease the drive write-through is a no-op")
+}

--- a/pkg/tern/shard_writethrough_integration_test.go
+++ b/pkg/tern/shard_writethrough_integration_test.go
@@ -113,9 +113,14 @@ func TestWriteShardProgressPersistsPerShardTasksUnderLease(t *testing.T) {
 	// Under the lease, both shards are persisted as per-shard tasks.
 	client.writeShardProgress(leaseCtx, perTable, tp, now)
 
-	got, err := stor.Tasks().GetByApplyOperationID(ctx, opID)
+	got, err := stor.Tasks().GetShardProgressByApplyOperationID(ctx, opID)
 	require.NoError(t, err)
 	require.Len(t, got, 2, "both shards persisted as per-shard tasks")
+	// The per-table loader must not surface shard rows, so the operator drive
+	// never re-processes them as per-table tasks on the next reload.
+	perTableRows, err := stor.Tasks().GetByApplyOperationID(ctx, opID)
+	require.NoError(t, err)
+	assert.Empty(t, perTableRows, "per-shard rows must not leak into the per-table loader")
 	byShard := map[string]*storage.Task{}
 	for _, task := range got {
 		assert.Equal(t, "resolute", task.Namespace)
@@ -135,7 +140,7 @@ func TestWriteShardProgressPersistsPerShardTasksUnderLease(t *testing.T) {
 	tp.Shards[0].Progress = 100
 	tp.Shards[0].RowsCopied = 500000
 	client.writeShardProgress(leaseCtx, perTable, tp, time.Now())
-	got, err = stor.Tasks().GetByApplyOperationID(ctx, opID)
+	got, err = stor.Tasks().GetShardProgressByApplyOperationID(ctx, opID)
 	require.NoError(t, err)
 	require.Len(t, got, 2, "re-running the drive updates shards in place, no duplicates")
 	for _, task := range got {
@@ -147,7 +152,7 @@ func TestWriteShardProgressPersistsPerShardTasksUnderLease(t *testing.T) {
 	// A read-path caller (no operation lease) must not write.
 	cleanupTasks(t, dsn)
 	client.writeShardProgress(ctx, perTable, tp, time.Now())
-	got, err = stor.Tasks().GetByApplyOperationID(ctx, opID)
+	got, err = stor.Tasks().GetShardProgressByApplyOperationID(ctx, opID)
 	require.NoError(t, err)
 	assert.Empty(t, got, "without an operation lease the drive write-through is a no-op")
 }


### PR DESCRIPTION
## Why this matters

#451 added the lease-held per-shard upsert; this calls it from the place that actually holds the operation lease — the operator's drive — so per-shard progress becomes durable and the renderer can show the per-shard breakdown from storage instead of a live `SHOW VITESS_MIGRATIONS` re-query.

## What it does

Wires `UpsertShardProgress` into `syncAtomicTaskProgress` (the grouped-apply progress sync). For each table with engine progress, it write-throughs `TableProgress.Shards` as per-shard `tasks`:

- **Lease-held single writer.** The write runs only inside the operator drive — `UpsertShardProgress` requires the operation lease, and `writeShardProgress` no-ops when no operation lease is on the context, so a read-path `Progress()` call never writes.
- **Expand phase only.** Per-table task rows are left untouched. Rendering and gating switch to the per-shard rows in a later change; the per-table anchor is removed for sharded engines only after that (the contract step).
- **Spirit unaffected.** Unsharded `TableProgress` carries no shards, so the write-through is a no-op for MySQL.

```
operator drive (holds the deploy-request operation lease)
  └── syncAtomicTaskProgress
        └── writeShardProgress → UpsertShardProgress (per shard)
```

Integration test: under the lease both shards persist with correct fields, a second pass updates in place (no duplicates), and without an operation lease the write-through is a no-op.

*This PR was written by Claude (Opus 4.8).*