### PR TITLE
refactor(vitess): source deploy display metadata from the progress result

### DIFF
--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -88,13 +88,21 @@ func (m *mockStorageWithPlanLookup) Plans() storage.PlanStore { return m.plans }
 
 type mockStorageWithApplyStores struct {
 	mockStorage
-	plans      storage.PlanStore
-	applies    storage.ApplyStore
-	tasks      storage.TaskStore
-	locks      storage.LockStore
-	applyLogs  storage.ApplyLogStore
-	controls   storage.ControlRequestStore
-	operations storage.ApplyOperationStore
+	plans           storage.PlanStore
+	applies         storage.ApplyStore
+	tasks           storage.TaskStore
+	locks           storage.LockStore
+	applyLogs       storage.ApplyLogStore
+	controls        storage.ControlRequestStore
+	operations      storage.ApplyOperationStore
+	vitessApplyData storage.VitessApplyDataStore
+}
+
+func (m *mockStorageWithApplyStores) VitessApplyData() storage.VitessApplyDataStore {
+	if m.vitessApplyData == nil {
+		return &staticVitessApplyDataStore{}
+	}
+	return m.vitessApplyData
 }
 
 func (m *mockStorageWithApplyStores) Plans() storage.PlanStore         { return m.plans }
@@ -114,8 +122,10 @@ func (m *mockStorageWithApplyStores) ApplyOperations() storage.ApplyOperationSto
 
 type staticApplyOperationStore struct {
 	storage.ApplyOperationStore
-	operations []*storage.ApplyOperation
-	err        error
+	operations      []*storage.ApplyOperation
+	err             error
+	resumeStateByOp map[int64]*storage.EngineResumeState
+	resumeStateErr  error
 }
 
 func (s *staticApplyOperationStore) ListByApply(_ context.Context, applyID int64) ([]*storage.ApplyOperation, error) {
@@ -129,6 +139,32 @@ func (s *staticApplyOperationStore) ListByApply(_ context.Context, applyID int64
 		}
 	}
 	return operations, nil
+}
+
+func (s *staticApplyOperationStore) GetEngineResumeState(_ context.Context, operationID int64) (*storage.EngineResumeState, error) {
+	if s.resumeStateErr != nil {
+		return nil, s.resumeStateErr
+	}
+	if rs, ok := s.resumeStateByOp[operationID]; ok {
+		return rs, nil
+	}
+	return nil, storage.ErrEngineResumeStateNotFound
+}
+
+type staticVitessApplyDataStore struct {
+	storage.VitessApplyDataStore
+	data map[int64]*storage.VitessApplyData
+	err  error
+}
+
+func (s *staticVitessApplyDataStore) GetByApplyID(_ context.Context, applyID int64) (*storage.VitessApplyData, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	if d, ok := s.data[applyID]; ok {
+		return d, nil
+	}
+	return nil, storage.ErrVitessApplyDataNotFound
 }
 
 type staticPlanStore struct {
@@ -2370,6 +2406,78 @@ func TestProgressFromLocalStorageSingleDeploymentOmitsOperationFields(t *testing
 	assert.Empty(t, resp.Operations)
 	require.Len(t, resp.Tables, 1)
 	assert.Empty(t, resp.Tables[0].Deployment)
+}
+
+// A completed PlanetScale apply served from storage still surfaces the deploy
+// display fields (branch, deploy-request URL, instant/deferred flags). The
+// engine is not polled on the storage path, so these are read from the durable
+// engine resume state persisted on the apply's operation — the "let me look at
+// what happened" case must not lose the deploy-request link.
+func TestProgressFromLocalStorageOverlaysDisplayMetadataFromResumeState(t *testing.T) {
+	opID := int64(77)
+	apply := &storage.Apply{
+		ID:              30,
+		ApplyIdentifier: "apply_ps_completed",
+		Database:        "testdb",
+		DatabaseType:    storage.DatabaseTypeVitess,
+		Environment:     "staging",
+		Engine:          storage.EnginePlanetScale,
+		State:           state.Apply.Completed,
+	}
+	svc := New(&mockStorageWithApplyStores{
+		tasks: &capturingTaskStore{tasks: []*storage.Task{
+			{ApplyID: apply.ID, ApplyOperationID: &opID, TaskIdentifier: "task_users", TableName: "users", Namespace: "testdb", DDLAction: "alter", DDL: "ALTER TABLE users ADD COLUMN email varchar(255)", State: state.Task.Completed, Database: "testdb", DatabaseType: storage.DatabaseTypeVitess, Engine: storage.EnginePlanetScale, Environment: "staging"},
+		}},
+		operations: &staticApplyOperationStore{
+			operations: []*storage.ApplyOperation{
+				{ID: opID, ApplyID: apply.ID, Deployment: "testdb", Target: "testdb", State: state.ApplyOperation.Completed},
+			},
+			resumeStateByOp: map[int64]*storage.EngineResumeState{
+				opID: {ApplyOperationID: opID, Metadata: `{"branch_name":"schemabot-testdb-123","deploy_request_url":"https://app.planetscale.com/org/testdb/deploy-requests/42","is_instant":true,"deferred_deploy":true}`},
+			},
+		},
+	}, testServerConfig(), nil, slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError})))
+
+	resp, err := svc.progressFromLocalStorage(t.Context(), apply)
+
+	require.NoError(t, err)
+	require.NotNil(t, resp.Metadata)
+	assert.Equal(t, "schemabot-testdb-123", resp.Metadata["branch_name"])
+	assert.Equal(t, "https://app.planetscale.com/org/testdb/deploy-requests/42", resp.Metadata["deploy_request_url"])
+	assert.Equal(t, "true", resp.Metadata["is_instant"])
+	assert.Equal(t, "true", resp.Metadata["deferred_deploy"])
+}
+
+// An apply with no engine resume state (e.g. one that predates resume-state
+// persistence) is served from storage without the deploy display fields and
+// without error — the overlay is best-effort enrichment, never a gate.
+func TestProgressFromLocalStorageWithoutResumeStateOmitsDisplayMetadata(t *testing.T) {
+	opID := int64(88)
+	apply := &storage.Apply{
+		ID:              31,
+		ApplyIdentifier: "apply_ps_no_resume",
+		Database:        "testdb",
+		DatabaseType:    storage.DatabaseTypeVitess,
+		Environment:     "staging",
+		Engine:          storage.EnginePlanetScale,
+		State:           state.Apply.Completed,
+	}
+	svc := New(&mockStorageWithApplyStores{
+		tasks: &capturingTaskStore{tasks: []*storage.Task{
+			{ApplyID: apply.ID, ApplyOperationID: &opID, TaskIdentifier: "task_users", TableName: "users", Namespace: "testdb", DDLAction: "alter", DDL: "ALTER TABLE users ADD COLUMN email varchar(255)", State: state.Task.Completed, Database: "testdb", DatabaseType: storage.DatabaseTypeVitess, Engine: storage.EnginePlanetScale, Environment: "staging"},
+		}},
+		operations: &staticApplyOperationStore{
+			operations: []*storage.ApplyOperation{
+				{ID: opID, ApplyID: apply.ID, Deployment: "testdb", Target: "testdb", State: state.ApplyOperation.Completed},
+			},
+		},
+	}, testServerConfig(), nil, slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError})))
+
+	resp, err := svc.progressFromLocalStorage(t.Context(), apply)
+
+	require.NoError(t, err)
+	assert.Empty(t, resp.Metadata["branch_name"])
+	assert.Empty(t, resp.Metadata["deploy_request_url"])
 }
 
 func TestValidateRollbackSourceApplyAcceptsLatestCompletedApplyWithOriginalFiles(t *testing.T) {

--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -2191,6 +2191,24 @@ func TestProgressResponseFromProtoPreservesVSchemaChangeType(t *testing.T) {
 	assert.Equal(t, "vschema_update", resp.Tables[0].ChangeType)
 }
 
+// The engine's display metadata on the progress response (branch, deploy-request
+// URL, instant) is carried through to the API response, so the renderer no longer
+// needs the vitess_apply_data side-table overlay for it.
+func TestProgressResponseFromProtoCopiesMetadata(t *testing.T) {
+	resp := progressResponseFromProto(&ternv1.ProgressResponse{
+		State: ternv1.State_STATE_RUNNING,
+		Metadata: map[string]string{
+			"branch_name":        "branch-x",
+			"deploy_request_url": "https://app.example/deploy/7",
+			"is_instant":         "true",
+		},
+	})
+
+	assert.Equal(t, "branch-x", resp.Metadata["branch_name"])
+	assert.Equal(t, "https://app.example/deploy/7", resp.Metadata["deploy_request_url"])
+	assert.Equal(t, "true", resp.Metadata["is_instant"])
+}
+
 func TestProgressFromLocalStorageIncludesOperationProgressAndTableDeployment(t *testing.T) {
 	startedAt := time.Date(2026, 6, 16, 10, 0, 0, 0, time.UTC)
 	completedAt := startedAt.Add(5 * time.Minute)

--- a/pkg/api/progress_handlers.go
+++ b/pkg/api/progress_handlers.go
@@ -426,6 +426,60 @@ func (s *Service) overlayVitessMetadata(ctx context.Context, resp *apitypes.Prog
 	}
 }
 
+// overlayStoredDisplayMetadata populates the PlanetScale display fields
+// (branch_name, deploy_request_url, is_instant, deferred_deploy) on a progress
+// response served from storage. On the live path these arrive from the engine's
+// progress projection; terminal, stopped, and resuming applies are served from
+// storage without polling the engine, so they are read from the durable engine
+// resume state persisted on the apply's operation. Best-effort: a value already
+// set by the caller is never overwritten, and applies that predate resume-state
+// persistence simply render without these fields.
+func (s *Service) overlayStoredDisplayMetadata(ctx context.Context, resp *apitypes.ProgressResponse, apply *storage.Apply, operationIDs map[int64]string) {
+	if apply == nil || apply.Engine != storage.EnginePlanetScale {
+		return
+	}
+	for opID := range operationIDs {
+		rs, err := s.storage.ApplyOperations().GetEngineResumeState(ctx, opID)
+		if errors.Is(err, storage.ErrEngineResumeStateNotFound) {
+			// Expected for operations that have not persisted engine state yet
+			// (or predate resume-state persistence) — nothing to overlay.
+			slog.Debug("progress response has no engine resume state to overlay",
+				"apply_id", apply.ApplyIdentifier, "apply_operation_id", opID)
+			continue
+		}
+		if err != nil {
+			slog.Warn("progress response will omit engine display fields: failed to load engine resume state",
+				"apply_id", apply.ApplyIdentifier,
+				"apply_operation_id", opID,
+				"database", apply.Database,
+				"environment", apply.Environment,
+				"error", err)
+			continue
+		}
+		display, err := tern.PSDisplayMetadata(rs.Metadata)
+		if err != nil {
+			slog.Warn("progress response will omit engine display fields: failed to decode engine resume state",
+				"apply_id", apply.ApplyIdentifier,
+				"apply_operation_id", opID,
+				"database", apply.Database,
+				"environment", apply.Environment,
+				"error", err)
+			continue
+		}
+		if len(display) == 0 {
+			continue
+		}
+		if resp.Metadata == nil {
+			resp.Metadata = make(map[string]string, len(display))
+		}
+		for k, v := range display {
+			if resp.Metadata[k] == "" {
+				resp.Metadata[k] = v
+			}
+		}
+	}
+}
+
 // handleDatabaseHistory handles GET /api/history/{database} requests.
 // Returns all applies for a database, sorted by created_at desc.
 func (s *Service) handleDatabaseHistory(w http.ResponseWriter, r *http.Request) {
@@ -813,6 +867,7 @@ func (s *Service) progressFromLocalStorage(ctx context.Context, apply *storage.A
 	s.overlayVitessMetadata(ctx, httpResp, apply)
 	operations, deploymentByOperationID := s.bestEffortProgressOperations(ctx, apply)
 	httpResp.Operations = operations
+	s.overlayStoredDisplayMetadata(ctx, httpResp, apply, deploymentByOperationID)
 
 	for _, task := range tasks {
 		tpr := &apitypes.TableProgressResponse{

--- a/pkg/api/progress_handlers.go
+++ b/pkg/api/progress_handlers.go
@@ -2,8 +2,10 @@ package api
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
+	"maps"
 	"net/http"
 	"sort"
 	"strconv"
@@ -183,6 +185,13 @@ func progressResponseFromProto(resp *ternv1.ProgressResponse) *apitypes.Progress
 			})
 		}
 		httpResp.Tables = append(httpResp.Tables, tpr)
+	}
+
+	// Carry the engine's display metadata (branch_name, deploy_request_url,
+	// is_instant, deferred_deploy) from the progress projection to the response.
+	if len(resp.Metadata) > 0 {
+		httpResp.Metadata = make(map[string]string, len(resp.Metadata))
+		maps.Copy(httpResp.Metadata, resp.Metadata)
 	}
 
 	return httpResp
@@ -376,11 +385,15 @@ func (s *Service) handleProgressByApplyID(w http.ResponseWriter, r *http.Request
 	s.writeJSON(w, http.StatusOK, httpResp)
 }
 
-// overlayVitessMetadata loads VitessApplyData for the given apply and merges
-// engine-specific metadata (deploy request URL, revert status) into the response.
+// overlayVitessMetadata merges the skip-revert status into the response. The
+// engine's display fields (branch_name, deploy_request_url, is_instant,
+// deferred_deploy) now arrive on the response via the engine's progress
+// projection, so only revert_skipped — core control state, not engine data — is
+// read from storage here. (That field moves off vitess_apply_data in a later
+// change; this overlay disappears with it.)
 func (s *Service) overlayVitessMetadata(ctx context.Context, resp *apitypes.ProgressResponse, apply *storage.Apply) {
 	if apply == nil {
-		slog.Warn("progress response will omit vitess metadata: no apply record",
+		slog.Warn("progress response will omit revert status: no apply record",
 			"apply_id", resp.ApplyID,
 			"database", resp.Database,
 			"environment", resp.Environment)
@@ -389,33 +402,26 @@ func (s *Service) overlayVitessMetadata(ctx context.Context, resp *apitypes.Prog
 	if apply.Engine != storage.EnginePlanetScale {
 		return
 	}
-	// The overlay is best-effort enrichment — the progress response is still
-	// served without the engine metadata, so log at Warn rather than Error.
+	// Best-effort enrichment — the progress response is still served without the
+	// revert status, so log at Warn rather than Error.
 	vad, err := s.storage.VitessApplyData().GetByApplyID(ctx, apply.ID)
+	if errors.Is(err, storage.ErrVitessApplyDataNotFound) {
+		// No row yet is expected when skip-revert has not been requested; there
+		// is simply no revert status to overlay. Not an error worth logging.
+		return
+	}
 	if err != nil {
-		slog.Warn("progress response will omit vitess metadata: failed to load vitess apply data",
+		slog.Warn("progress response will omit revert status: failed to load vitess apply data",
 			"apply_id", apply.ApplyIdentifier,
 			"database", apply.Database,
 			"environment", apply.Environment,
 			"error", err)
 		return
 	}
-	if resp.Metadata == nil {
-		resp.Metadata = make(map[string]string)
-	}
-	if vad.BranchName != "" {
-		resp.Metadata["branch_name"] = vad.BranchName
-	}
-	if vad.DeployRequestURL != "" {
-		resp.Metadata["deploy_request_url"] = vad.DeployRequestURL
-	}
-	if vad.IsInstant {
-		resp.Metadata["is_instant"] = "true"
-	}
-	if vad.DeferredDeploy {
-		resp.Metadata["deferred_deploy"] = "true"
-	}
 	if vad.RevertSkippedAt != nil {
+		if resp.Metadata == nil {
+			resp.Metadata = make(map[string]string)
+		}
 		resp.Metadata["revert_skipped"] = "true"
 	}
 }

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -314,6 +314,12 @@ type ProgressResult struct {
 	Retryable    bool   // True when a failed progress result can be retried
 	Tables       []TableProgress
 	ResumeState  *ResumeState // Updated resume state (engines may update MigrationContext/Metadata during polling)
+
+	// Metadata carries engine-specific display fields for the progress response
+	// (e.g. PlanetScale branch_name, deploy_request_url, is_instant). It lets the
+	// engine surface structured status to the renderer without core decoding the
+	// opaque ResumeState.Metadata or reading an engine-specific side table.
+	Metadata map[string]string
 }
 
 // TableProgress tracks progress for a single table.

--- a/pkg/engine/planetscale/progress.go
+++ b/pkg/engine/planetscale/progress.go
@@ -37,8 +37,9 @@ func (e *Engine) Progress(ctx context.Context, req *engine.ProgressRequest) (*en
 
 	if meta.DeployRequestID == 0 {
 		return &engine.ProgressResult{
-			State:   engine.StatePending,
-			Message: fmt.Sprintf("Setting up branch %s", meta.BranchName),
+			State:    engine.StatePending,
+			Message:  fmt.Sprintf("Setting up branch %s", meta.BranchName),
+			Metadata: psDisplayMetadata(meta),
 		}, nil
 	}
 
@@ -96,6 +97,7 @@ func (e *Engine) Progress(ctx context.Context, req *engine.ProgressRequest) (*en
 		State:       engineState,
 		Message:     deployStateToMessage(dr.DeploymentState),
 		ResumeState: req.ResumeState,
+		Metadata:    psDisplayMetadata(meta),
 	}
 
 	// Enrich with per-shard progress from SHOW VITESS_MIGRATIONS.
@@ -465,6 +467,38 @@ func validateMigrationContext(s string) error {
 		return fmt.Errorf("invalid context: contains unsafe characters")
 	}
 	return nil
+}
+
+// psDisplayMetadata projects the engine's deploy metadata into the progress
+// result's display fields, so the renderer gets branch / deploy-request URL /
+// instant / deferred status straight from the progress result — no core decoding
+// of the opaque resume state and no engine-specific side table.
+func psDisplayMetadata(meta *psMetadata) map[string]string {
+	if meta == nil {
+		return nil
+	}
+	// Allocate lazily: most polls set at least one field, but a bare metadata
+	// blob should return nil without allocating on the hot progress path.
+	var m map[string]string
+	set := func(k, v string) {
+		if m == nil {
+			m = make(map[string]string, 4)
+		}
+		m[k] = v
+	}
+	if meta.BranchName != "" {
+		set("branch_name", meta.BranchName)
+	}
+	if meta.DeployRequestURL != "" {
+		set("deploy_request_url", meta.DeployRequestURL)
+	}
+	if meta.IsInstant {
+		set("is_instant", "true")
+	}
+	if meta.DeferredDeploy {
+		set("deferred_deploy", "true")
+	}
+	return m
 }
 
 // parseProgressPercent parses the Vitess schema_migrations.progress column,

--- a/pkg/engine/planetscale/progress_test.go
+++ b/pkg/engine/planetscale/progress_test.go
@@ -287,3 +287,32 @@ func TestSelectSchemaChangeContext(t *testing.T) {
 		assert.Equal(t, []string{"singularity:new-change"}, candidates)
 	})
 }
+
+// The engine surfaces its deploy display fields on the progress result so the
+// renderer reads them from the progress projection rather than a side table.
+func TestPSDisplayMetadata(t *testing.T) {
+	t.Run("populates the set fields", func(t *testing.T) {
+		m := psDisplayMetadata(&psMetadata{
+			BranchName:       "branch-x",
+			DeployRequestURL: "https://app.example/deploy/7",
+			IsInstant:        true,
+			DeferredDeploy:   true,
+		})
+		assert.Equal(t, "branch-x", m["branch_name"])
+		assert.Equal(t, "https://app.example/deploy/7", m["deploy_request_url"])
+		assert.Equal(t, "true", m["is_instant"])
+		assert.Equal(t, "true", m["deferred_deploy"])
+	})
+	t.Run("omits empty and false fields", func(t *testing.T) {
+		m := psDisplayMetadata(&psMetadata{BranchName: "b"})
+		assert.Equal(t, "b", m["branch_name"])
+		_, hasURL := m["deploy_request_url"]
+		assert.False(t, hasURL)
+		_, hasInstant := m["is_instant"]
+		assert.False(t, hasInstant)
+	})
+	t.Run("nil when nothing is set", func(t *testing.T) {
+		assert.Nil(t, psDisplayMetadata(&psMetadata{}))
+		assert.Nil(t, psDisplayMetadata(nil))
+	})
+}

--- a/pkg/tern/local_client.go
+++ b/pkg/tern/local_client.go
@@ -1555,6 +1555,7 @@ func (c *LocalClient) Progress(ctx context.Context, req *ternv1.ProgressRequest)
 	// For Vitess, load opaque ResumeState so the engine can poll the deploy
 	// request and query SHOW VITESS_MIGRATIONS.
 	var engineResult *engine.ProgressResult
+	var engineMetadata map[string]string
 	var vitessApplyIsInstant bool
 	// Query engine for live progress. For Vitess, also query during pending state
 	// to surface PlanetScale states (preparing branch, deploy request, etc.).
@@ -1587,19 +1588,15 @@ func (c *LocalClient) Progress(ctx context.Context, req *ternv1.ProgressRequest)
 				return nil, fmt.Errorf("load Vitess engine resume state for progress task %s: %w", activeTask.TaskIdentifier, resumeErr)
 			}
 			progressReq.ResumeState = resumeState
-			vad, vadErr := c.storage.VitessApplyData().GetByApplyID(ctx, activeTask.ApplyID)
-			switch {
-			case vadErr != nil:
-				c.logger.Error("failed to load VitessApplyData for progress", "apply_id", activeTask.ApplyID, "error", vadErr)
-			case vad == nil:
-				c.logger.Warn("VitessApplyData not found for progress — apply may still be initializing", "apply_id", activeTask.ApplyID)
-			default:
-				vitessApplyIsInstant = vad.IsInstant
-			}
 		}
 		result, err := eng.Progress(ctx, progressReq)
 		if err == nil {
 			engineResult = result
+			// The engine surfaces display fields (branch, deploy-request URL,
+			// is_instant, deferred) on the result; the renderer reads them from
+			// here instead of the vitess_apply_data side table.
+			engineMetadata = result.Metadata
+			vitessApplyIsInstant = result.Metadata["is_instant"] == "true"
 			if c.config.Type == storage.DatabaseTypeVitess && result.ResumeState != nil {
 				operationID, operationErr := applyOperationIDForTask(activeTask)
 				if operationErr != nil {
@@ -1856,6 +1853,16 @@ func (c *LocalClient) Progress(ctx context.Context, req *ternv1.ProgressRequest)
 		Tables:       tables,
 		Summary:      summary,
 		ErrorMessage: errorMessage,
+	}
+
+	// Surface the engine's display metadata (e.g. PlanetScale branch_name,
+	// deploy_request_url, is_instant) on the response so the renderer reads it
+	// from the progress projection rather than an engine-specific side table.
+	for k, v := range engineMetadata {
+		if resp.Metadata == nil {
+			resp.Metadata = make(map[string]string, len(engineMetadata))
+		}
+		resp.Metadata[k] = v
 	}
 
 	// Populate apply_id, engine, and volume from the apply record.

--- a/pkg/tern/state_converters.go
+++ b/pkg/tern/state_converters.go
@@ -2,6 +2,7 @@ package tern
 
 import (
 	"encoding/json"
+	"fmt"
 	"maps"
 	"sort"
 	"time"
@@ -275,4 +276,41 @@ func decodePSMetadataForStorage(s string) (*psMetadataForStorage, error) {
 		return nil, err
 	}
 	return &m, nil
+}
+
+// PSDisplayMetadata decodes a PlanetScale engine resume-state blob into the
+// display fields surfaced on the progress response (branch_name,
+// deploy_request_url, is_instant, deferred_deploy). It is the projection a
+// progress response served from storage uses when the engine was not polled,
+// mirroring the live-path projection in the PlanetScale engine. It returns a nil
+// map when the blob is empty or carries no display fields, so callers render
+// without these fields rather than failing.
+func PSDisplayMetadata(resumeStateMetadata string) (map[string]string, error) {
+	meta, err := decodePSMetadataForStorage(resumeStateMetadata)
+	if err != nil {
+		return nil, fmt.Errorf("decode planetscale resume metadata for display: %w", err)
+	}
+	if meta == nil {
+		return nil, nil
+	}
+	var m map[string]string
+	set := func(k, v string) {
+		if m == nil {
+			m = make(map[string]string, 4)
+		}
+		m[k] = v
+	}
+	if meta.BranchName != "" {
+		set("branch_name", meta.BranchName)
+	}
+	if meta.DeployRequestURL != "" {
+		set("deploy_request_url", meta.DeployRequestURL)
+	}
+	if meta.IsInstant {
+		set("is_instant", "true")
+	}
+	if meta.DeferredDeploy {
+		set("deferred_deploy", "true")
+	}
+	return m, nil
 }

--- a/pkg/tern/state_converters_test.go
+++ b/pkg/tern/state_converters_test.go
@@ -28,3 +28,29 @@ func TestProtoToSchemaFiles_NilNamespaceValue(t *testing.T) {
 		"users.sql": "CREATE TABLE users (id bigint primary key)",
 	}, result["payments"].Files)
 }
+
+func TestPSDisplayMetadata(t *testing.T) {
+	// A populated resume-state blob projects every display field the renderer
+	// surfaces for a PlanetScale apply.
+	m, err := PSDisplayMetadata(`{"branch_name":"schemabot-db-1","deploy_request_url":"https://app/deploy/9","is_instant":true,"deferred_deploy":true}`)
+	require.NoError(t, err)
+	require.NotNil(t, m)
+	assert.Equal(t, "schemabot-db-1", m["branch_name"])
+	assert.Equal(t, "https://app/deploy/9", m["deploy_request_url"])
+	assert.Equal(t, "true", m["is_instant"])
+	assert.Equal(t, "true", m["deferred_deploy"])
+
+	// An empty blob yields no fields and no error.
+	m, err = PSDisplayMetadata("")
+	require.NoError(t, err)
+	assert.Nil(t, m)
+
+	// A blob with no display fields set yields a nil map, never an empty alloc.
+	m, err = PSDisplayMetadata(`{"deploy_request_id":42}`)
+	require.NoError(t, err)
+	assert.Nil(t, m)
+
+	// Malformed JSON surfaces an error rather than silently dropping fields.
+	_, err = PSDisplayMetadata(`{not json`)
+	require.Error(t, err)
+}


### PR DESCRIPTION
## Why this matters

`vitess_apply_data` is a side table that exists mostly so core can read deploy fields the engine already holds in its opaque `ResumeState.Metadata`. The progress API decodes those fields into the table, then reads them back to overlay onto the response. This is the first step of removing that table: have the engine surface its display fields directly, so nothing reads the side table for display.

## What it does

Adds a `Metadata map[string]string` to `engine.ProgressResult` and threads the PlanetScale deploy display fields (`branch_name`, `deploy_request_url`, `is_instant`, `deferred_deploy`) through it:

```
PlanetScale Progress() → ProgressResult.Metadata
  → ternv1.ProgressResponse.metadata (existing proto field)
  → progressResponseFromProto → apitypes ProgressResponse.Metadata
```

- The API's progress overlay **no longer reads `vitess_apply_data`** for those four display fields — they arrive on the response from the engine projection.
- `local_client` reads `is_instant` from the engine result instead of loading `vitess_apply_data`.

## Scope (expand phase)

`revert_skipped` is **core control state**, not engine data, so it still reads from the table here and relocates in the next change. The table's *writes* and the table itself are removed in the final step, once nothing reads it.

Tests: `psDisplayMetadata` field projection, and `progressResponseFromProto` carrying the metadata through. Build + vet + `engine`/`api`/`tern` unit suites green.

*This PR was written by Claude (Opus 4.8).*