### PR TITLE
refactor(vitess): move revert_skipped off vitess_apply_data to apply state

### DIFF
--- a/pkg/api/control_handlers.go
+++ b/pkg/api/control_handlers.go
@@ -1619,25 +1619,10 @@ func (s *Service) handleSkipRevert(w http.ResponseWriter, r *http.Request) {
 	}
 	metrics.RecordControlOperation(r.Context(), "skip_revert", apply.Database, apply.Deployment, apply.Environment, controlStatus(resp.Accepted))
 
-	// Record skip-revert on VitessApplyData for progress visibility
+	// Record skip-revert on the apply for progress visibility.
 	if resp.Accepted && apply.Engine == storage.EnginePlanetScale {
-		vitessDataStore := s.storage.VitessApplyData()
-		if vitessDataStore == nil {
-			s.logger.Error("vitess apply data store not available after skip-revert", "apply_id", apply.ID, "apply_identifier", apply.ApplyIdentifier)
-		} else {
-			vad, err := vitessDataStore.GetByApplyID(r.Context(), apply.ID)
-			switch {
-			case err != nil:
-				s.logger.Error("failed to load vitess apply data after skip-revert", "apply_id", apply.ID, "apply_identifier", apply.ApplyIdentifier, "error", err)
-			case vad == nil:
-				s.logger.Warn("vitess apply data missing after skip-revert", "apply_id", apply.ID, "apply_identifier", apply.ApplyIdentifier)
-			default:
-				now := time.Now()
-				vad.RevertSkippedAt = &now
-				if err := vitessDataStore.Save(r.Context(), vad); err != nil {
-					s.logger.Error("failed to save vitess apply data after skip-revert", "apply_id", apply.ID, "apply_identifier", apply.ApplyIdentifier, "error", err)
-				}
-			}
+		if err := s.storage.Applies().SetRevertSkipped(r.Context(), apply.ID, time.Now()); err != nil {
+			s.logger.Error("failed to record skip-revert on apply", "apply_id", apply.ID, "apply_identifier", apply.ApplyIdentifier, "error", err)
 		}
 	}
 	if resp.Accepted {

--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -4417,3 +4417,16 @@ func TestRollbackSchemaFilesRejectsPlanWithoutCapturedOriginalFiles(t *testing.T
 	assert.Nil(t, schemaFiles)
 	assert.Contains(t, err.Error(), `no original schema files available for rollback namespace "shop"`)
 }
+
+// setRevertSkippedMetadata surfaces the skip-revert flag from the apply's stored
+// revert_skipped_at, so progress consumers show that revert was skipped — read
+// from apply state, not an engine-specific side table.
+func TestSetRevertSkippedMetadata(t *testing.T) {
+	resp := &apitypes.ProgressResponse{}
+	setRevertSkippedMetadata(resp, &storage.Apply{})
+	assert.NotContains(t, resp.Metadata, "revert_skipped", "no flag before skip-revert is dispatched")
+
+	now := time.Now()
+	setRevertSkippedMetadata(resp, &storage.Apply{RevertSkippedAt: &now})
+	assert.Equal(t, "true", resp.Metadata["revert_skipped"], "flag set once revert_skipped_at is present")
+}

--- a/pkg/api/progress_handlers.go
+++ b/pkg/api/progress_handlers.go
@@ -359,7 +359,7 @@ func (s *Service) handleProgressByApplyID(w http.ResponseWriter, r *http.Request
 
 	overlayApplyOptions(httpResp, apply)
 
-	s.overlayVitessMetadata(r.Context(), httpResp, apply)
+	setRevertSkippedMetadata(httpResp, apply)
 
 	// Overlay per-table timestamps from task records. The proto response
 	// doesn't carry task timestamps, but storage has them from engine
@@ -385,45 +385,18 @@ func (s *Service) handleProgressByApplyID(w http.ResponseWriter, r *http.Request
 	s.writeJSON(w, http.StatusOK, httpResp)
 }
 
-// overlayVitessMetadata merges the skip-revert status into the response. The
-// engine's display fields (branch_name, deploy_request_url, is_instant,
-// deferred_deploy) now arrive on the response via the engine's progress
-// projection, so only revert_skipped — core control state, not engine data — is
-// read from storage here. (That field moves off vitess_apply_data in a later
-// change; this overlay disappears with it.)
-func (s *Service) overlayVitessMetadata(ctx context.Context, resp *apitypes.ProgressResponse, apply *storage.Apply) {
-	if apply == nil {
-		slog.Warn("progress response will omit revert status: no apply record",
-			"apply_id", resp.ApplyID,
-			"database", resp.Database,
-			"environment", resp.Environment)
+// setRevertSkippedMetadata surfaces the skip-revert flag from the apply's stored
+// revert_skipped_at, so progress consumers can show that revert was skipped and
+// finalization is in progress. It reads apply state — no engine-specific side
+// table — and is a no-op until skip-revert has been dispatched.
+func setRevertSkippedMetadata(resp *apitypes.ProgressResponse, apply *storage.Apply) {
+	if apply == nil || apply.RevertSkippedAt == nil {
 		return
 	}
-	if apply.Engine != storage.EnginePlanetScale {
-		return
+	if resp.Metadata == nil {
+		resp.Metadata = make(map[string]string)
 	}
-	// Best-effort enrichment — the progress response is still served without the
-	// revert status, so log at Warn rather than Error.
-	vad, err := s.storage.VitessApplyData().GetByApplyID(ctx, apply.ID)
-	if errors.Is(err, storage.ErrVitessApplyDataNotFound) {
-		// No row yet is expected when skip-revert has not been requested; there
-		// is simply no revert status to overlay. Not an error worth logging.
-		return
-	}
-	if err != nil {
-		slog.Warn("progress response will omit revert status: failed to load vitess apply data",
-			"apply_id", apply.ApplyIdentifier,
-			"database", apply.Database,
-			"environment", apply.Environment,
-			"error", err)
-		return
-	}
-	if vad.RevertSkippedAt != nil {
-		if resp.Metadata == nil {
-			resp.Metadata = make(map[string]string)
-		}
-		resp.Metadata["revert_skipped"] = "true"
-	}
+	resp.Metadata["revert_skipped"] = "true"
 }
 
 // overlayStoredDisplayMetadata populates the PlanetScale display fields
@@ -864,7 +837,7 @@ func (s *Service) progressFromLocalStorage(ctx context.Context, apply *storage.A
 		httpResp.ErrorMessage = apply.ErrorMessage
 	}
 	overlayApplyOptions(httpResp, apply)
-	s.overlayVitessMetadata(ctx, httpResp, apply)
+	setRevertSkippedMetadata(httpResp, apply)
 	operations, deploymentByOperationID := s.bestEffortProgressOperations(ctx, apply)
 	httpResp.Operations = operations
 	s.overlayStoredDisplayMetadata(ctx, httpResp, apply, deploymentByOperationID)

--- a/pkg/schema/mysql/applies.sql
+++ b/pkg/schema/mysql/applies.sql
@@ -22,6 +22,7 @@ CREATE TABLE `applies` (
   `lease_acquired_at` datetime DEFAULT NULL,
   `started_at` datetime DEFAULT NULL,
   `completed_at` datetime DEFAULT NULL,
+  `revert_skipped_at` datetime DEFAULT NULL,
   `created_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `updated_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`),

--- a/pkg/storage/mysqlstore/applies.go
+++ b/pkg/storage/mysqlstore/applies.go
@@ -26,13 +26,13 @@ const applyColumns = `id, apply_identifier, lock_id, plan_id, database_name, dat
 	repository, pull_request, environment, deployment, caller, installation_id, external_id, engine,
 	state, error_message, options, attempt,
 	lease_owner, lease_token, lease_acquired_at,
-	created_at, started_at, completed_at, updated_at`
+	created_at, started_at, completed_at, updated_at, revert_skipped_at`
 
 const applyColumnsForApplyAlias = `a.id, a.apply_identifier, a.lock_id, a.plan_id, a.database_name, a.database_type,
 	a.repository, a.pull_request, a.environment, a.deployment, a.caller, a.installation_id, a.external_id, a.engine,
 	a.state, a.error_message, a.options, a.attempt,
 	a.lease_owner, a.lease_token, a.lease_acquired_at,
-	a.created_at, a.started_at, a.completed_at, a.updated_at`
+	a.created_at, a.started_at, a.completed_at, a.updated_at, a.revert_skipped_at`
 
 const (
 	// maxRecoveryAttempts is the retry budget for failed_retryable applies. The
@@ -1560,6 +1560,24 @@ func failPendingStartControlRequestTx(ctx context.Context, tx *sql.Tx, applyID i
 // If not called for > 1 minute, another driver can claim the apply via FindNextApply.
 // When ctx has an apply lease, a stale token returns ErrApplyLeaseLost so the
 // old operator owner stops before writing state or external side effects.
+// SetRevertSkipped records when skip-revert was dispatched for an apply. It is a
+// targeted update of revert_skipped_at only — it touches no other apply fields
+// and is not lease-guarded — so both the control-plane skip-revert handler (no
+// lease) and the data-plane finalizer can set this visibility flag.
+//
+// updated_at is pinned to its current value so this write does not trip the
+// column's ON UPDATE CURRENT_TIMESTAMP. updated_at is the apply's lease
+// heartbeat (the staleness gate in FindNextApply); bumping it here would renew
+// the heartbeat from a non-lease caller and could delay another driver's
+// recovery claim.
+func (s *applyStore) SetRevertSkipped(ctx context.Context, applyID int64, at time.Time) error {
+	if _, err := s.db.ExecContext(ctx,
+		`UPDATE applies SET revert_skipped_at = ?, updated_at = updated_at WHERE id = ?`, at, applyID); err != nil {
+		return fmt.Errorf("set revert_skipped_at for apply %d: %w", applyID, err)
+	}
+	return nil
+}
+
 func (s *applyStore) Heartbeat(ctx context.Context, applyID int64) error {
 	// A drive that holds only an operation lease must never bump the parent
 	// applies row: under fan-out the parent's liveness is owned by the parent
@@ -1862,7 +1880,7 @@ func scanApplies(rows *sql.Rows) ([]*storage.Apply, error) {
 // scanApplyInto scans apply data from any scanner (Row or Rows).
 func scanApplyInto(s scanner) (*storage.Apply, error) {
 	var apply storage.Apply
-	var leaseAcquiredAt, startedAt, completedAt sql.NullTime
+	var leaseAcquiredAt, startedAt, completedAt, revertSkippedAt sql.NullTime
 	var options []byte
 
 	err := s.Scan(
@@ -1872,7 +1890,7 @@ func scanApplyInto(s scanner) (*storage.Apply, error) {
 		&apply.Caller, &apply.InstallationID, &apply.ExternalID, &apply.Engine,
 		&apply.State, &apply.ErrorMessage, &options, &apply.Attempt,
 		&apply.LeaseOwner, &apply.LeaseToken, &leaseAcquiredAt,
-		&apply.CreatedAt, &startedAt, &completedAt, &apply.UpdatedAt,
+		&apply.CreatedAt, &startedAt, &completedAt, &apply.UpdatedAt, &revertSkippedAt,
 	)
 	if err != nil {
 		return nil, err
@@ -1889,6 +1907,9 @@ func scanApplyInto(s scanner) (*storage.Apply, error) {
 	}
 	if completedAt.Valid {
 		apply.CompletedAt = &completedAt.Time
+	}
+	if revertSkippedAt.Valid {
+		apply.RevertSkippedAt = &revertSkippedAt.Time
 	}
 
 	return &apply, nil

--- a/pkg/storage/mysqlstore/applies_test.go
+++ b/pkg/storage/mysqlstore/applies_test.go
@@ -3148,3 +3148,37 @@ func TestApplyStore_FindNextApplyForStopReconciliation_SkipsApplyWithoutPendingS
 	require.NoError(t, err)
 	assert.Nil(t, claimed, "an apply without a pending stop is not a reconciliation candidate")
 }
+
+// SetRevertSkipped records skip-revert on the apply and the timestamp round-trips
+// through Get, so progress can show that revert was skipped without an
+// engine-specific side table. It is a targeted write that leaves other fields
+// (here, state) untouched.
+func TestApplyStore_SetRevertSkipped(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", "vitess", "staging")
+	apply := createTestApply(t, store, lock, "apply_revert_skipped", 1)
+
+	got, err := store.Applies().Get(ctx, apply.ID)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Nil(t, got.RevertSkippedAt, "revert_skipped_at starts unset")
+
+	// Age updated_at so a heartbeat bump would be observable: updated_at is the
+	// apply's lease heartbeat (the staleness gate in FindNextApply), and
+	// SetRevertSkipped must not renew it from a non-lease caller.
+	_, err = testDB.ExecContext(ctx, `UPDATE applies SET updated_at = NOW() - INTERVAL 5 MINUTE WHERE id = ?`, apply.ID)
+	require.NoError(t, err)
+	before, err := store.Applies().Get(ctx, apply.ID)
+	require.NoError(t, err)
+
+	require.NoError(t, store.Applies().SetRevertSkipped(ctx, apply.ID, time.Now()))
+
+	got, err = store.Applies().Get(ctx, apply.ID)
+	require.NoError(t, err)
+	require.NotNil(t, got.RevertSkippedAt, "revert_skipped_at round-trips through Get")
+	assert.Equal(t, apply.State, got.State, "SetRevertSkipped must not change other apply fields")
+	assert.Equal(t, before.UpdatedAt, got.UpdatedAt, "SetRevertSkipped preserves the lease heartbeat (updated_at)")
+}

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -305,6 +305,14 @@ type ApplyStore interface {
 	// If not called for > 1 minute, another driver can claim the apply.
 	Heartbeat(ctx context.Context, applyID int64) error
 
+	// SetRevertSkipped records when skip-revert was dispatched for an apply, so
+	// progress consumers can show that revert was skipped and finalization is in
+	// progress. It is a targeted write of revert_skipped_at that preserves the
+	// apply's updated_at lease heartbeat and touches no other fields; both the
+	// control-plane skip-revert handler (no lease) and the data-plane finalizer
+	// call it without disturbing recovery-claim staleness.
+	SetRevertSkipped(ctx context.Context, applyID int64, at time.Time) error
+
 	// CheckLease verifies that an operator apply lease is still current without
 	// mutating the apply row.
 	CheckLease(ctx context.Context, lease ApplyLease) error

--- a/pkg/storage/types.go
+++ b/pkg/storage/types.go
@@ -426,6 +426,12 @@ type Apply struct {
 	// CompletedAt is when the apply reached a terminal state.
 	CompletedAt *time.Time
 
+	// RevertSkippedAt records when skip-revert was dispatched for this apply.
+	// Non-nil means revert was skipped and finalization is in progress; it is
+	// core control state surfaced to progress consumers, set by both the
+	// control-plane skip-revert handler and the data-plane finalizer.
+	RevertSkippedAt *time.Time
+
 	// UpdatedAt is when the apply was last updated.
 	UpdatedAt time.Time
 }

--- a/pkg/tern/local_apply_grouped.go
+++ b/pkg/tern/local_apply_grouped.go
@@ -917,15 +917,11 @@ func (c *LocalClient) handleAtomicProgressTick(ctx context.Context, eng engine.E
 	return false
 }
 
-// markRevertSkipped sets RevertSkippedAt on the VitessApplyData record so
-// progress consumers know finalization is in progress.
+// markRevertSkipped records skip-revert on the apply so progress consumers know
+// finalization is in progress.
 func (c *LocalClient) markRevertSkipped(ctx context.Context, apply *storage.Apply) {
-	now := time.Now()
-	if vad, err := c.storage.VitessApplyData().GetByApplyID(ctx, apply.ID); err == nil {
-		vad.RevertSkippedAt = &now
-		if saveErr := c.storage.VitessApplyData().Save(ctx, vad); saveErr != nil {
-			c.logger.Warn("failed to save revert_skipped_at", "apply_id", apply.ApplyIdentifier, "error", saveErr)
-		}
+	if err := c.storage.Applies().SetRevertSkipped(ctx, apply.ID, time.Now()); err != nil {
+		c.logger.Warn("failed to record skip-revert on apply", "apply_id", apply.ApplyIdentifier, "error", err)
 	}
 }
 


### PR DESCRIPTION
## Why this matters

`revert_skipped_at` is **core control state** (skip-revert was dispatched; finalization is in progress), not engine data. It only lived in `vitess_apply_data` so the progress overlay could read it back. Moving it to the apply row removes the last reader of the side table from the progress path.

## What it does

- Adds `applies.revert_skipped_at` + `Apply.RevertSkippedAt` + a targeted `Applies().SetRevertSkipped(applyID, at)` store method — a single-column write that touches no other fields and isn't lease-guarded, so both writers use it: the control-plane skip-revert handler (no lease) and the data-plane finalizer.
- The progress reader surfaces the `revert_skipped` flag from **apply state** (`setRevertSkippedMetadata`) instead of loading `vitess_apply_data`, so **`overlayVitessMetadata` is deleted entirely** — combined with #456 (display fields → engine result), the progress path no longer reads the side table at all.

## Scope

After this, **`vitess_apply_data` has no readers**. The remaining (now-redundant) writes and the table/store/struct itself are removed in the final leaf.

Tests: `SetRevertSkipped` round-trips through `Get` without touching other fields; `setRevertSkippedMetadata` sets the flag from apply state. EnsureSchema stays idempotent with the new column; build/vet/lint + api/tern/storage suites green.

*This PR was written by Claude (Opus 4.8).*