### PR TITLE
test(e2e): add multi-deployment fan-out gRPC fixture

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -402,11 +402,11 @@ test-e2e-grpc: build ## Run gRPC e2e tests in isolated environment
 	$(E2E_GRPC_ENV) docker compose -p schemabot-e2e-grpc -f deploy/local/docker-compose.grpc.yml down -v; \
 	exit $$TEST_EXIT_CODE
 
-# Run the multi-deployment fan-out gRPC e2e fixture (E2E-1).
+# Run the multi-deployment fan-out gRPC e2e fixture.
 # One environment (testapp/production) fans out to two deployments (eu, us),
 # each backed by its own remote Tern + MySQL.
-# NOT part of `make test-e2e`: the stack cannot boot until the >1-deployments
-# config hard-block is lifted (MD-9b-ii). Run manually once that lands.
+# NOT part of `make test-e2e`: the stack cannot boot until the server supports
+# deployments maps with more than one entry. Run manually once that lands.
 # Ports: SchemaBot=15370, SchemaBot-MySQL=15371, EU-MySQL=15372, US-MySQL=15373
 #        EU-HTTP=15380, EU-gRPC=15390, US-HTTP=15382, US-gRPC=15392
 E2E_GRPC_MD_ENV := SCHEMABOT_PORT=15370 \
@@ -418,7 +418,7 @@ E2E_GRPC_MD_ENV := SCHEMABOT_PORT=15370 \
 	TERN_US_PORT=15382 \
 	TERN_US_GRPC_PORT=15392
 
-test-e2e-grpc-multideploy: build ## Run multi-deployment fan-out gRPC e2e fixture (E2E-1; blocked on MD-9b-ii)
+test-e2e-grpc-multideploy: build ## Run multi-deployment fan-out gRPC e2e fixture (needs server support for >1-entry deployments maps)
 	@echo "Starting isolated multi-deployment gRPC e2e environment..."
 	CGO_ENABLED=0 GOOS=linux go build -ldflags "$(LDFLAGS)" -o bin/schemabot-linux ./pkg/cmd
 	cp bin/schemabot-linux deploy/local/schemabot-dev
@@ -433,7 +433,7 @@ test-e2e-grpc-multideploy: build ## Run multi-deployment fan-out gRPC e2e fixtur
 		fi; \
 		if [ $$i -eq 90 ]; then \
 			echo "Timeout waiting for multi-deployment SchemaBot gRPC e2e environment"; \
-			echo "(expected until MD-9b-ii lifts the >1-deployments config hard-block)"; \
+			echo "(expected until the server supports deployments maps with more than one entry)"; \
 			$(E2E_GRPC_MD_ENV) docker compose -p schemabot-e2e-grpc-md -f deploy/local/docker-compose.grpc-multideploy.yml logs; \
 			$(E2E_GRPC_MD_ENV) docker compose -p schemabot-e2e-grpc-md -f deploy/local/docker-compose.grpc-multideploy.yml down -v; \
 			exit 1; \

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ endif
 E2E_TEST_TIMEOUT ?= 10m
 E2E_TEST_FLAGS ?=
 
-.PHONY: help lint lint-fix setup test test-unit test-e2e test-e2e-grpc test-e2e-k8s test-e2e-local-down test-e2e-mysql test-e2e-vitess test-integration test-localscale build-localscale-image test-coverage build install clean proto up up-telemetry up-grpc down down-grpc status mysql logs logs-grpc test-endpoints plan-testapp apply-testapp seed-testapp seed-testapp-large seed-vitess demo demo-vitess demo-grpc demo-grpc-logs wait-healthy wait-healthy-grpc wait-localscale cli
+.PHONY: help lint lint-fix setup test test-unit test-e2e test-e2e-grpc test-e2e-grpc-multideploy test-e2e-k8s test-e2e-local-down test-e2e-mysql test-e2e-vitess test-integration test-localscale build-localscale-image test-coverage build install clean proto up up-telemetry up-grpc down down-grpc status mysql logs logs-grpc test-endpoints plan-testapp apply-testapp seed-testapp seed-testapp-large seed-vitess demo demo-vitess demo-grpc demo-grpc-logs wait-healthy wait-healthy-grpc wait-localscale cli
 
 # Multi-line message definitions
 define HELP_HEADER
@@ -400,6 +400,56 @@ test-e2e-grpc: build ## Run gRPC e2e tests in isolated environment
 	TEST_EXIT_CODE=$$?; \
 	echo "Tearing down gRPC e2e environment..."; \
 	$(E2E_GRPC_ENV) docker compose -p schemabot-e2e-grpc -f deploy/local/docker-compose.grpc.yml down -v; \
+	exit $$TEST_EXIT_CODE
+
+# Run the multi-deployment fan-out gRPC e2e fixture (E2E-1).
+# One environment (testapp/production) fans out to two deployments (eu, us),
+# each backed by its own remote Tern + MySQL.
+# NOT part of `make test-e2e`: the stack cannot boot until the >1-deployments
+# config hard-block is lifted (MD-9b-ii). Run manually once that lands.
+# Ports: SchemaBot=15370, SchemaBot-MySQL=15371, EU-MySQL=15372, US-MySQL=15373
+#        EU-HTTP=15380, EU-gRPC=15390, US-HTTP=15382, US-gRPC=15392
+E2E_GRPC_MD_ENV := SCHEMABOT_PORT=15370 \
+	SCHEMABOT_MYSQL_PORT=15371 \
+	TERN_EU_MYSQL_PORT=15372 \
+	TERN_US_MYSQL_PORT=15373 \
+	TERN_EU_PORT=15380 \
+	TERN_EU_GRPC_PORT=15390 \
+	TERN_US_PORT=15382 \
+	TERN_US_GRPC_PORT=15392
+
+test-e2e-grpc-multideploy: build ## Run multi-deployment fan-out gRPC e2e fixture (E2E-1; blocked on MD-9b-ii)
+	@echo "Starting isolated multi-deployment gRPC e2e environment..."
+	CGO_ENABLED=0 GOOS=linux go build -ldflags "$(LDFLAGS)" -o bin/schemabot-linux ./pkg/cmd
+	cp bin/schemabot-linux deploy/local/schemabot-dev
+	@$(E2E_GRPC_MD_ENV) docker compose -p schemabot-e2e-grpc-md -f deploy/local/docker-compose.grpc-multideploy.yml down -v 2>/dev/null || true
+	@$(E2E_GRPC_MD_ENV) docker compose -p schemabot-e2e-grpc-md -f deploy/local/docker-compose.grpc-multideploy.yml up --build -d
+	@rm -f deploy/local/schemabot-dev
+	@echo "Waiting for multi-deployment SchemaBot gRPC e2e environment to be healthy..."
+	@for i in $$(seq 1 90); do \
+		if curl -sf http://localhost:15370/health > /dev/null 2>&1; then \
+			echo "Multi-deployment SchemaBot gRPC e2e environment is healthy"; \
+			break; \
+		fi; \
+		if [ $$i -eq 90 ]; then \
+			echo "Timeout waiting for multi-deployment SchemaBot gRPC e2e environment"; \
+			echo "(expected until MD-9b-ii lifts the >1-deployments config hard-block)"; \
+			$(E2E_GRPC_MD_ENV) docker compose -p schemabot-e2e-grpc-md -f deploy/local/docker-compose.grpc-multideploy.yml logs; \
+			$(E2E_GRPC_MD_ENV) docker compose -p schemabot-e2e-grpc-md -f deploy/local/docker-compose.grpc-multideploy.yml down -v; \
+			exit 1; \
+		fi; \
+		sleep 1; \
+	done
+	@echo "Running multi-deployment gRPC e2e tests..."
+	@E2E_MULTIDEPLOY=1 \
+	E2E_SCHEMABOT_URL=http://localhost:15370 \
+	E2E_SCHEMABOT_MYSQL_DSN="root:testpassword@tcp(localhost:15371)/schemabot" \
+	E2E_TERN_EU_MYSQL_DSN="root:testpassword@tcp(localhost:15372)/testapp" \
+	E2E_TERN_US_MYSQL_DSN="root:testpassword@tcp(localhost:15373)/testapp" \
+	$(GOTEST) -count=1 -v -tags=e2e -timeout=10m -run TestGRPCMultiDeploy ./e2e/grpc/... ; \
+	TEST_EXIT_CODE=$$?; \
+	echo "Tearing down multi-deployment gRPC e2e environment..."; \
+	$(E2E_GRPC_MD_ENV) docker compose -p schemabot-e2e-grpc-md -f deploy/local/docker-compose.grpc-multideploy.yml down -v; \
 	exit $$TEST_EXIT_CODE
 
 # Run k8s e2e tests on minikube. Starts minikube if needed.

--- a/deploy/local/config/grpc-schemabot-multideploy.yaml
+++ b/deploy/local/config/grpc-schemabot-multideploy.yaml
@@ -1,0 +1,43 @@
+# SchemaBot Configuration (gRPC Mode - multi-deployment fan-out)
+#
+# E2E-1 fixture: a single (database, environment) — testapp/production — fans
+# out to TWO deployments (eu, us), each backed by its own remote Tern service
+# and MySQL. This is the shape exercised by the multi-deployment ordered-cutover
+# acceptance test (E2E-2).
+#
+# Contrast with grpc-schemabot.yaml, which wires two Terns as two *environments*
+# (staging/production) of a single "default" deployment.
+#
+# NOTE: This config sets a deployments map with >1 entry. SchemaBot's config
+# validation currently rejects that with:
+#   "multi-deployment (>1 entries) is not yet supported by this server"
+# so a stack booted from this file will NOT come up until the MD-9b-ii hard-block
+# lift lands (gated behind MD-9b-i / block/schemabot#431). The fixture is
+# committed now so the harness is ready the moment that block is removed.
+
+# SchemaBot's own storage database
+storage:
+  dsn: "env:MYSQL_DSN"
+
+# gRPC mode: one environment (production) fanning out to two deployments.
+databases:
+  testapp:
+    type: mysql
+    environments:
+      production:
+        cutover_policy: barrier
+        deployment_order:
+          - eu
+          - us
+        deployments:
+          eu:
+            target: testapp
+          us:
+            target: testapp
+
+# Per-deployment Tern gRPC endpoints.
+tern_deployments:
+  eu:
+    production: "tern-eu:9090"
+  us:
+    production: "tern-us:9090"

--- a/deploy/local/config/grpc-schemabot-multideploy.yaml
+++ b/deploy/local/config/grpc-schemabot-multideploy.yaml
@@ -1,9 +1,9 @@
 # SchemaBot Configuration (gRPC Mode - multi-deployment fan-out)
 #
-# E2E-1 fixture: a single (database, environment) — testapp/production — fans
-# out to TWO deployments (eu, us), each backed by its own remote Tern service
-# and MySQL. This is the shape exercised by the multi-deployment ordered-cutover
-# acceptance test (E2E-2).
+# A single (database, environment) — testapp/production — fans out to TWO
+# deployments (eu, us), each backed by its own remote Tern service and MySQL.
+# This is the shape exercised by the multi-deployment ordered-cutover
+# acceptance test.
 #
 # Contrast with grpc-schemabot.yaml, which wires two Terns as two *environments*
 # (staging/production) of a single "default" deployment.
@@ -11,9 +11,9 @@
 # NOTE: This config sets a deployments map with >1 entry. SchemaBot's config
 # validation currently rejects that with:
 #   "multi-deployment (>1 entries) is not yet supported by this server"
-# so a stack booted from this file will NOT come up until the MD-9b-ii hard-block
-# lift lands (gated behind MD-9b-i / block/schemabot#431). The fixture is
-# committed now so the harness is ready the moment that block is removed.
+# so a stack booted from this file will NOT come up until the server supports
+# deployments maps with more than one entry. The fixture is committed now so the
+# harness is ready the moment that support lands.
 
 # SchemaBot's own storage database
 storage:

--- a/deploy/local/docker-compose.grpc-multideploy.yml
+++ b/deploy/local/docker-compose.grpc-multideploy.yml
@@ -1,0 +1,179 @@
+# gRPC mode: SchemaBot + two Tern deployments (eu, us) of ONE environment.
+#
+# E2E-1 fixture for the multi-deployment ordered-cutover acceptance test.
+# A single (database, environment) — testapp/production — fans out to two
+# deployments, each backed by its own remote Tern service and isolated MySQL.
+#
+# This differs from docker-compose.grpc.yml, which wires two Terns as two
+# *environments* (staging/production) of a single "default" deployment.
+#
+# NOTE: SchemaBot will NOT boot from this stack until the >1-deployments config
+# hard-block is lifted (MD-9b-ii, gated behind MD-9b-i / block/schemabot#431).
+# Until then, the schemabot container exits at startup with:
+#   "multi-deployment (>1 entries) is not yet supported by this server"
+# The fixture is committed now so the harness is ready when that block lands.
+#
+# Usage (default ports):
+#   docker-compose -f docker-compose.grpc-multideploy.yml up
+#
+# Access (default ports):
+#   SchemaBot:        http://localhost:13380
+#   Tern EU:          http://localhost:13384 (HTTP), localhost:13385 (gRPC)
+#   Tern US:          http://localhost:13386 (HTTP), localhost:13387 (gRPC)
+#   EU MySQL:         localhost:13382
+#   US MySQL:         localhost:13383
+name: schemabot-grpc-multideploy
+
+services:
+  # =============================================================================
+  # Tern EU deployment (production environment)
+  # =============================================================================
+  tern-eu-mysql:
+    image: mysql:8.0
+    container_name: tern-eu-mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: testpassword
+      MYSQL_DATABASE: tern
+      MYSQL_INITDB_SKIP_TZINFO: "1"
+    volumes:
+      - ./mysql-init/init-tern.sql:/docker-entrypoint-initdb.d/init-tern.sql:ro
+      - ./mysql-init/mysql-config/my.cnf:/etc/mysql/conf.d/schemabot.cnf:ro
+      - tern-eu-mysql-data:/var/lib/mysql
+    ports:
+      - "${TERN_EU_MYSQL_PORT:-13382}:3306"
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1", "-ptestpassword"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  tern-eu:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    container_name: tern-eu
+    environment:
+      MYSQL_DSN: "root:testpassword@tcp(tern-eu-mysql:3306)/tern?parseTime=true&multiStatements=true"
+      TERN_TARGET_DSN: "root:testpassword@tcp(tern-eu-mysql:3306)/testapp?parseTime=true&multiStatements=true"
+      SCHEMABOT_CONFIG_FILE: "/config/grpc-tern.yaml"
+      TERN_ENVIRONMENT: "production"
+      PORT: "8080"
+      GRPC_PORT: "9090"
+      LOG_LEVEL: "debug"
+    volumes:
+      - ./config:/config:ro
+    ports:
+      - "${TERN_EU_PORT:-13384}:8080"
+      - "${TERN_EU_GRPC_PORT:-13385}:9090"
+    depends_on:
+      tern-eu-mysql:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:8080/health"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  # =============================================================================
+  # Tern US deployment (production environment)
+  # =============================================================================
+  tern-us-mysql:
+    image: mysql:8.0
+    container_name: tern-us-mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: testpassword
+      MYSQL_DATABASE: tern
+      MYSQL_INITDB_SKIP_TZINFO: "1"
+    volumes:
+      - ./mysql-init/init-tern.sql:/docker-entrypoint-initdb.d/init-tern.sql:ro
+      - ./mysql-init/mysql-config/my.cnf:/etc/mysql/conf.d/schemabot.cnf:ro
+      - tern-us-mysql-data:/var/lib/mysql
+    ports:
+      - "${TERN_US_MYSQL_PORT:-13383}:3306"
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1", "-ptestpassword"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  tern-us:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    container_name: tern-us
+    environment:
+      MYSQL_DSN: "root:testpassword@tcp(tern-us-mysql:3306)/tern?parseTime=true&multiStatements=true"
+      TERN_TARGET_DSN: "root:testpassword@tcp(tern-us-mysql:3306)/testapp?parseTime=true&multiStatements=true"
+      SCHEMABOT_CONFIG_FILE: "/config/grpc-tern.yaml"
+      TERN_ENVIRONMENT: "production"
+      PORT: "8080"
+      GRPC_PORT: "9090"
+      LOG_LEVEL: "debug"
+    volumes:
+      - ./config:/config:ro
+    ports:
+      - "${TERN_US_PORT:-13386}:8080"
+      - "${TERN_US_GRPC_PORT:-13387}:9090"
+    depends_on:
+      tern-us-mysql:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:8080/health"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  # =============================================================================
+  # SchemaBot
+  # =============================================================================
+  # SchemaBot's internal storage database
+  # Note: Schema is applied by SchemaBot on startup (dogfooding)
+  schemabot-mysql:
+    image: mysql:8.0
+    container_name: schemabot-mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: testpassword
+      MYSQL_DATABASE: schemabot
+      MYSQL_INITDB_SKIP_TZINFO: "1"
+    ports:
+      - "${SCHEMABOT_MYSQL_PORT:-13381}:3306"
+    volumes:
+      - ./mysql-init/mysql-config/my.cnf:/etc/mysql/conf.d/schemabot.cnf:ro
+      - schemabot-mysql-data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1", "-ptestpassword"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  schemabot:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    container_name: schemabot
+    environment:
+      MYSQL_DSN: "root:testpassword@tcp(schemabot-mysql:3306)/schemabot?parseTime=true&multiStatements=true"
+      SCHEMABOT_CONFIG_FILE: "/config/grpc-schemabot-multideploy.yaml"
+      PORT: "8080"
+      LOG_LEVEL: "debug"
+    volumes:
+      - ./config:/config:ro
+    ports:
+      - "${SCHEMABOT_PORT:-13380}:8080"
+    depends_on:
+      schemabot-mysql:
+        condition: service_healthy
+      tern-eu:
+        condition: service_healthy
+      tern-us:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:8080/health"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+volumes:
+  tern-eu-mysql-data:
+  tern-us-mysql-data:
+  schemabot-mysql-data:

--- a/deploy/local/docker-compose.grpc-multideploy.yml
+++ b/deploy/local/docker-compose.grpc-multideploy.yml
@@ -1,17 +1,20 @@
 # gRPC mode: SchemaBot + two Tern deployments (eu, us) of ONE environment.
 #
-# E2E-1 fixture for the multi-deployment ordered-cutover acceptance test.
+# Fixture for the multi-deployment ordered-cutover acceptance test.
 # A single (database, environment) — testapp/production — fans out to two
 # deployments, each backed by its own remote Tern service and isolated MySQL.
 #
 # This differs from docker-compose.grpc.yml, which wires two Terns as two
 # *environments* (staging/production) of a single "default" deployment.
 #
-# NOTE: SchemaBot will NOT boot from this stack until the >1-deployments config
-# hard-block is lifted (MD-9b-ii, gated behind MD-9b-i / block/schemabot#431).
-# Until then, the schemabot container exits at startup with:
+# NOTE: SchemaBot will NOT boot from this stack until the server supports
+# deployments maps with more than one entry. Until then, the schemabot service
+# exits at startup with:
 #   "multi-deployment (>1 entries) is not yet supported by this server"
-# The fixture is committed now so the harness is ready when that block lands.
+# The fixture is committed now so the harness is ready when that support lands.
+#
+# Container names are intentionally omitted so Docker Compose project scoping
+# (-p) keeps this fixture isolated from other local stacks.
 #
 # Usage (default ports):
 #   docker-compose -f docker-compose.grpc-multideploy.yml up
@@ -30,7 +33,6 @@ services:
   # =============================================================================
   tern-eu-mysql:
     image: mysql:8.0
-    container_name: tern-eu-mysql
     environment:
       MYSQL_ROOT_PASSWORD: testpassword
       MYSQL_DATABASE: tern
@@ -51,7 +53,6 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.dev
-    container_name: tern-eu
     environment:
       MYSQL_DSN: "root:testpassword@tcp(tern-eu-mysql:3306)/tern?parseTime=true&multiStatements=true"
       TERN_TARGET_DSN: "root:testpassword@tcp(tern-eu-mysql:3306)/testapp?parseTime=true&multiStatements=true"
@@ -79,7 +80,6 @@ services:
   # =============================================================================
   tern-us-mysql:
     image: mysql:8.0
-    container_name: tern-us-mysql
     environment:
       MYSQL_ROOT_PASSWORD: testpassword
       MYSQL_DATABASE: tern
@@ -100,7 +100,6 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.dev
-    container_name: tern-us
     environment:
       MYSQL_DSN: "root:testpassword@tcp(tern-us-mysql:3306)/tern?parseTime=true&multiStatements=true"
       TERN_TARGET_DSN: "root:testpassword@tcp(tern-us-mysql:3306)/testapp?parseTime=true&multiStatements=true"
@@ -130,7 +129,6 @@ services:
   # Note: Schema is applied by SchemaBot on startup (dogfooding)
   schemabot-mysql:
     image: mysql:8.0
-    container_name: schemabot-mysql
     environment:
       MYSQL_ROOT_PASSWORD: testpassword
       MYSQL_DATABASE: schemabot
@@ -150,7 +148,6 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.dev
-    container_name: schemabot
     environment:
       MYSQL_DSN: "root:testpassword@tcp(schemabot-mysql:3306)/schemabot?parseTime=true&multiStatements=true"
       SCHEMABOT_CONFIG_FILE: "/config/grpc-schemabot-multideploy.yaml"

--- a/e2e/grpc/multideploy_test.go
+++ b/e2e/grpc/multideploy_test.go
@@ -12,27 +12,28 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Multi-deployment fan-out fixture (E2E-1).
+// Multi-deployment fan-out fixture.
 //
 // Scenario: a single (database, environment) — testapp/production — fans out to
 // two deployments (eu, us), each backed by its own remote Tern over gRPC, with
 // deployment_order [eu, us] and cutover_policy: barrier (see
 // deploy/local/docker-compose.grpc-multideploy.yml and
-// config/grpc-schemabot-multideploy.yaml).
+// deploy/local/config/grpc-schemabot-multideploy.yaml).
 //
 // This file only verifies that the multi-deployment stack boots and that
 // SchemaBot resolves both remote deployments — the foundation the ordered
-// cutover acceptance test (E2E-2) builds on.
+// cutover acceptance test builds on.
 //
-// The fixture cannot boot until the >1-deployments config hard-block is lifted
-// (MD-9b-ii), so these tests are gated behind E2E_MULTIDEPLOY=1 and are skipped
-// in the standard gRPC e2e run. The make target test-e2e-grpc-multideploy sets
-// the flag and stands up the multi-deployment stack.
+// The fixture cannot boot until the server supports deployments maps with more
+// than one entry, so these tests are gated behind E2E_MULTIDEPLOY=1 and are
+// skipped in the standard gRPC e2e run. The make target
+// test-e2e-grpc-multideploy sets the flag and stands up the multi-deployment
+// stack.
 
 func requireMultiDeploy(t *testing.T) {
 	t.Helper()
 	if os.Getenv("E2E_MULTIDEPLOY") != "1" {
-		t.Skip("multi-deployment fixture gated behind E2E_MULTIDEPLOY=1 (blocked on MD-9b-ii: >1-deployments config hard-block)")
+		t.Skip("multi-deployment fixture gated behind E2E_MULTIDEPLOY=1 (requires server support for deployments maps with >1 entry)")
 	}
 }
 

--- a/e2e/grpc/multideploy_test.go
+++ b/e2e/grpc/multideploy_test.go
@@ -1,0 +1,77 @@
+//go:build e2e
+
+package grpc
+
+import (
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/block/spirit/pkg/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Multi-deployment fan-out fixture (E2E-1).
+//
+// Scenario: a single (database, environment) — testapp/production — fans out to
+// two deployments (eu, us), each backed by its own remote Tern over gRPC, with
+// deployment_order [eu, us] and cutover_policy: barrier (see
+// deploy/local/docker-compose.grpc-multideploy.yml and
+// config/grpc-schemabot-multideploy.yaml).
+//
+// This file only verifies that the multi-deployment stack boots and that
+// SchemaBot resolves both remote deployments — the foundation the ordered
+// cutover acceptance test (E2E-2) builds on.
+//
+// The fixture cannot boot until the >1-deployments config hard-block is lifted
+// (MD-9b-ii), so these tests are gated behind E2E_MULTIDEPLOY=1 and are skipped
+// in the standard gRPC e2e run. The make target test-e2e-grpc-multideploy sets
+// the flag and stands up the multi-deployment stack.
+
+func requireMultiDeploy(t *testing.T) {
+	t.Helper()
+	if os.Getenv("E2E_MULTIDEPLOY") != "1" {
+		t.Skip("multi-deployment fixture gated behind E2E_MULTIDEPLOY=1 (blocked on MD-9b-ii: >1-deployments config hard-block)")
+	}
+}
+
+func TestGRPCMultiDeploy_SchemaBot_Health(t *testing.T) {
+	requireMultiDeploy(t)
+	resp := grpcGet(t, "/health") //nolint:bodyclose // closed via utils.CloseAndLog
+	defer utils.CloseAndLog(resp.Body)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	var result map[string]string
+	grpcDecodeJSON(t, resp, &result)
+	assert.Equal(t, "ok", result["status"])
+}
+
+func TestGRPCMultiDeploy_TernHealth_BothDeployments(t *testing.T) {
+	requireMultiDeploy(t)
+	for _, deployment := range []string{"eu", "us"} {
+		resp := grpcGet(t, "/tern-health/"+deployment+"/production") //nolint:bodyclose // closed via utils.CloseAndLog
+		func() {
+			defer utils.CloseAndLog(resp.Body)
+			require.Equalf(t, http.StatusOK, resp.StatusCode, "tern-health for deployment %q", deployment)
+			var result map[string]string
+			grpcDecodeJSON(t, resp, &result)
+			assert.Equalf(t, "ok", result["status"], "tern-health status for deployment %q", deployment)
+		}()
+	}
+}
+
+// TestGRPCMultiDeploy_Plan_FansOut verifies a plan against the fanned-out
+// (testapp, production) environment succeeds, proving SchemaBot loaded the
+// >1-deployment config and resolved both remote deployments.
+func TestGRPCMultiDeploy_Plan_FansOut(t *testing.T) {
+	requireMultiDeploy(t)
+	tableName := uniqueGRPCTableName("md_fanout")
+	plan := grpcPlan(t, "testapp", "production", map[string]string{
+		tableName + ".sql": "CREATE TABLE " + tableName + " (\n" +
+			"  id BIGINT UNSIGNED AUTO_INCREMENT,\n" +
+			"  PRIMARY KEY (id)\n" +
+			") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci",
+	})
+	require.Empty(t, plan.Errors, "plan errors")
+	require.NotEmpty(t, plan.PlanID, "plan_id")
+}


### PR DESCRIPTION
## What

Adds a gRPC e2e fixture where a single `(database, environment)` fans out to
**two deployments**, each backed by its own remote Tern and MySQL, with an
explicit `deployment_order` and `cutover_policy: barrier`.

## Why

The existing `docker-compose.grpc.yml` wires two Terns as two *environments*
(staging/production) of one deployment — it can't exercise the multi-deployment
fan-out path. This fixture is the harness the ordered-cutover acceptance test
builds on. It's committed now so it's ready the moment the `>1 deployments`
config gate is lifted; until then it stays out of the default e2e run.

## Before / after
```
docker-compose.grpc.yml (existing)       docker-compose.grpc-multideploy.yml (new)
one "default" deployment                 one environment -> two deployments
+-------- SchemaBot --------+            +--------- SchemaBot ---------+
| testapp                   |            | testapp/production          |
|  +- staging   -> tern-stg |            |  cutover_policy: barrier    |
|  +- production-> tern-prod|            |  deployment_order: [eu, us] |
+---------------------------+            |   +- eu -> tern-eu (+mysql) |
two Terns = two ENVIRONMENTS            |   +- us -> tern-us (+mysql) |
+-----------------------------+
two Terns = two DEPLOYMENTS
of ONE environment
```
## What I added

- **`deploy/local/config/grpc-schemabot-multideploy.yaml`** — SchemaBot config:
  `testapp/production` fans out to `eu`/`us` with `deployment_order` +
  `cutover_policy: barrier`, plus per-deployment `tern_deployments` endpoints.
- **`deploy/local/docker-compose.grpc-multideploy.yml`** — two Terns (`eu`, `us`),
  each with its own MySQL, both serving the `production` environment, fronted by
  one SchemaBot + storage MySQL.
- **`e2e/grpc/multideploy_test.go`** — boot/resolve smoke tests: SchemaBot health,
  per-deployment Tern health for both `eu` and `us`, and a fan-out plan against
  `(testapp, production)`.
- **`Makefile`** — new `test-e2e-grpc-multideploy` target on isolated ports;
  **not** part of `make test-e2e`.

## Gating

The fixture cannot boot yet: config validation rejects a `>1`-entry deployments
map. So the tests `t.Skip` unless `E2E_MULTIDEPLOY=1` and the make target is
standalone — the standard gRPC e2e run is unaffected. Once the hard-block lifts,
the harness runs as-is.

## Testing / validation

- Config YAML parses under strict known-fields and fails **only** on the intended
  `>1 deployments` gate.
- `docker compose config -q` passes; `go build ./...` and `go vet -tags=e2e ./e2e/grpc/` clean.
