### PR TITLE
feat(observability): shadow-compare persisted per-shard progress vs live

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -66,6 +66,32 @@ func RecordPlan(ctx context.Context, repo, database, deployment, environment, st
 	)
 }
 
+// RecordShardProgressShadowCompare records whether the persisted per-shard
+// progress matched the live engine result for an apply during a progress poll.
+// It is the rollout signal for switching the read path to render shards from
+// stored: result "match" means stored == live; "divergent" means they differed
+// (different shard set or per-shard state). A nonzero divergent rate means the
+// persisted shard read-model is not yet trustworthy enough to render from —
+// investigate before flipping the read path off the live query.
+func RecordShardProgressShadowCompare(ctx context.Context, database, environment, result string) {
+	meter := otel.Meter(meterName)
+	counter, err := meter.Int64Counter("schemabot.shard_progress.shadow_compare.total",
+		otelmetric.WithDescription("Per-poll comparison of persisted per-shard progress against the live engine result"),
+		otelmetric.WithUnit("{comparison}"),
+	)
+	if err != nil {
+		slog.Warn("failed to create shard progress shadow compare counter", "error", err)
+		return
+	}
+	counter.Add(ctx, 1,
+		otelmetric.WithAttributes(
+			attribute.String("database", database),
+			EnvironmentAttribute(environment),
+			attribute.String("result", result),
+		),
+	)
+}
+
 // RecordPlanDuration records the duration of a plan operation.
 func RecordPlanDuration(ctx context.Context, duration time.Duration, repo, database, deployment, environment, status string) {
 	meter := otel.Meter(meterName)

--- a/pkg/tern/local_client.go
+++ b/pkg/tern/local_client.go
@@ -107,6 +107,7 @@ import (
 	"github.com/block/schemabot/pkg/engine"
 	"github.com/block/schemabot/pkg/engine/planetscale"
 	"github.com/block/schemabot/pkg/engine/spirit"
+	"github.com/block/schemabot/pkg/metrics"
 	"github.com/block/schemabot/pkg/mysqlconn"
 	ternv1 "github.com/block/schemabot/pkg/proto/ternv1"
 	"github.com/block/schemabot/pkg/psclient"
@@ -1807,6 +1808,11 @@ func (c *LocalClient) Progress(ctx context.Context, req *ternv1.ProgressRequest)
 		tables = append(tables, tp)
 	}
 
+	// Shadow-compare the persisted per-shard rows against the live engine result
+	// (render still uses live above). The divergence metric validates whether the
+	// read path can be switched to render shards from stored.
+	c.shadowCompareShardProgress(ctx, apply, currentApplyTasks, engineTableProgress)
+
 	// Derive overall state from ALL tasks in this apply.
 	// If tasks are all pending, check the apply record for a more specific state
 	// (e.g., preparing_branch, creating_deploy_request during PlanetScale setup).
@@ -1935,6 +1941,79 @@ func engineTableProgressOmittedRowTotals(task *storage.Task, progress *engine.Ta
 		return false
 	}
 	return task.RowsTotal > 0 && progress.RowsTotal <= 0
+}
+
+// shadowCompareShardProgress compares the persisted per-shard task rows against
+// the live engine result and emits a divergence metric per poll. The read path
+// still renders shards from the live result; this only validates that the
+// persisted read-model matches, so the read path can later be switched to render
+// shards from storage once divergence is ~0. It is a no-op for non-Vitess applies
+// and when the live result has no shards to compare against.
+func (c *LocalClient) shadowCompareShardProgress(ctx context.Context, apply *storage.Apply, tasks []*storage.Task, live map[string]*engine.TableProgress) {
+	if c.config.Type != storage.DatabaseTypeVitess || len(live) == 0 {
+		return
+	}
+
+	// Load the persisted shard rows for the apply's operations, grouped by table.
+	storedByTable := map[string][]*storage.Task{}
+	seenOps := map[int64]bool{}
+	for _, t := range tasks {
+		if t.ApplyOperationID == nil || seenOps[*t.ApplyOperationID] {
+			continue
+		}
+		seenOps[*t.ApplyOperationID] = true
+		shardTasks, err := c.storage.Tasks().GetShardProgressByApplyOperationID(ctx, *t.ApplyOperationID)
+		if err != nil {
+			c.logger.Warn("shard progress shadow-compare skipped: failed to load shard rows",
+				"apply_id", apply.ApplyIdentifier, "apply_operation_id", *t.ApplyOperationID, "error", err)
+			return
+		}
+		for _, st := range shardTasks {
+			key := progressTableKey(st.Namespace, st.TableName)
+			storedByTable[key] = append(storedByTable[key], st)
+		}
+	}
+
+	compared, diverged := false, false
+	for key, tp := range live {
+		if len(tp.Shards) == 0 {
+			continue
+		}
+		compared = true
+		if shardProgressDiverges(tp.Shards, storedByTable[key]) {
+			diverged = true
+			break
+		}
+	}
+	if !compared {
+		return
+	}
+	result := "match"
+	if diverged {
+		result = "divergent"
+	}
+	metrics.RecordShardProgressShadowCompare(ctx, apply.Database, apply.Environment, result)
+}
+
+// shardProgressDiverges reports whether the live engine shards differ from the
+// persisted shard rows for a table — a different shard set, or any shard whose
+// persisted state does not match the live state. Progress counts are allowed to
+// lag between polls, so only the shard set and normalized state are compared.
+func shardProgressDiverges(live []engine.ShardProgress, stored []*storage.Task) bool {
+	if len(live) != len(stored) {
+		return true
+	}
+	storedState := make(map[string]string, len(stored))
+	for _, s := range stored {
+		storedState[s.Shard] = state.NormalizeTaskStatus(s.State)
+	}
+	for _, l := range live {
+		st, ok := storedState[l.Shard]
+		if !ok || st != state.NormalizeShardStatus(l.State) {
+			return true
+		}
+	}
+	return false
 }
 
 func progressTableStatus(storedTaskState, engineTableState string) string {

--- a/pkg/tern/local_client_test.go
+++ b/pkg/tern/local_client_test.go
@@ -324,6 +324,13 @@ func (s *exactProgressTaskStore) Update(context.Context, *storage.Task) error {
 	return s.err
 }
 
+// GetShardProgressByApplyOperationID returns no persisted shard rows; the
+// shadow-compare in Progress() invokes it but these tests assert on the rendered
+// response, not the shadow metric.
+func (s *exactProgressTaskStore) GetShardProgressByApplyOperationID(context.Context, int64) ([]*storage.Task, error) {
+	return nil, s.err
+}
+
 type fakeControlEngine struct {
 	engine.Engine
 	stopCount               int
@@ -2700,4 +2707,33 @@ func TestLocalClientProtoEngineReflectsRegisteredEngine(t *testing.T) {
 	}, nil, slog.Default())
 	require.NoError(t, err)
 	assert.Equal(t, ternv1.Engine_ENGINE_STRATA, c.protoEngine())
+}
+
+// shardProgressDiverges is the shadow-compare check: the persisted per-shard rows
+// match the live engine result only when the shard set and each shard's
+// normalized state agree. Progress counts may lag, so they are not compared.
+func TestShardProgressDiverges(t *testing.T) {
+	live := []engine.ShardProgress{
+		{Shard: "-80", State: "running"},
+		{Shard: "80-", State: "running"},
+	}
+
+	assert.False(t, shardProgressDiverges(live, []*storage.Task{
+		{Shard: "-80", State: state.Task.Running},
+		{Shard: "80-", State: state.Task.Running},
+	}), "same shard set and states must not diverge")
+
+	assert.True(t, shardProgressDiverges(live, []*storage.Task{
+		{Shard: "-80", State: state.Task.Running},
+	}), "a different shard count diverges")
+
+	assert.True(t, shardProgressDiverges(live, []*storage.Task{
+		{Shard: "-80", State: state.Task.Running},
+		{Shard: "80-", State: state.Task.Completed},
+	}), "a per-shard state mismatch diverges")
+
+	assert.True(t, shardProgressDiverges(live, []*storage.Task{
+		{Shard: "-80", State: state.Task.Running},
+		{Shard: "c0-", State: state.Task.Running},
+	}), "a different shard name diverges")
 }


### PR DESCRIPTION
## Why this matters

The operator now persists per-shard progress (#453), but the read path still renders the per-shard breakdown from the live `SHOW VITESS_MIGRATIONS` result. The goal is to render from stored — but flipping the read path off the live query is only safe once we know the persisted read-model actually matches live. This is the **shadow-compare** rollout step (render unchanged; measure divergence first).

## What it does

On each vitess progress poll, loads the persisted per-shard rows (`GetShardProgressByApplyOperationID`) and compares them against the live engine result per table — **same shard set + same normalized per-shard state** (progress counts may lag between polls, so they're not compared). Emits:

```
schemabot.shard_progress.shadow_compare.total{database, environment, result=match|divergent}
```

**Rendering is unchanged** — this only measures whether stored == live, so the read path can be flipped to render shards from stored (T1.3b) once the divergent rate is ~0. The metric is actionable: a nonzero divergent rate means the persisted read-model isn't yet trustworthy to render from — investigate before flipping.

No-op for non-vitess applies and when the live result has no shards. The comparison (`shardProgressDiverges`) is a pure, unit-tested function.

Part of T1.3 (render/gate from stored); T1.3b flips rendering and T1.3c adds queued-from-plan + the expected-set gate.

*This PR was written by Claude (Opus 4.8).*