### PR TITLE
ci: add stable Lint rollup check for the merge queue

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -87,3 +87,33 @@ jobs:
       - name: webhookheaders analyzer
         if: matrix.name == 'default'
         run: make check-webhookheaders
+
+  # Stable rollup for the lint matrix so a single check name can gate a merge,
+  # mirroring the E2E/LocalScale/K8s rollups in test.yaml. The golangci matrix
+  # check names (`lint (default)`, `lint (integration, …)`, `lint (e2e, …)`)
+  # change with the matrix, so require this `Lint` check instead.
+  lint-rollup:
+    name: "Lint"
+    needs: [changes, golangci]
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - shell: bash
+        env:
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          CHANGES_CODE: ${{ needs.changes.outputs.code }}
+          GOLANGCI_RESULT: ${{ needs.golangci.result }}
+        run: |
+          set -euo pipefail
+          if [ "$CHANGES_RESULT" != "success" ]; then
+            echo "::error::changes job failed"
+            exit 1
+          fi
+          if [ "$CHANGES_CODE" != "true" ]; then
+            echo "Docs-only PR; lint intentionally skipped."
+            exit 0
+          fi
+          if [ "$GOLANGCI_RESULT" != "success" ]; then
+            echo "::error::golangci result=$GOLANGCI_RESULT"
+            exit 1
+          fi


### PR DESCRIPTION
## What and Why ?

Adds a `Lint` rollup job to `lint.yaml` that `needs` the `golangci` matrix and reports a single fixed check name — mirroring the existing `E2E Tests` / `LocalScale Tests` / `K8s E2E Tests` rollups in `test.yaml`.

The `golangci` matrix emits per-leg check names (`lint (default)`, `lint (integration, …)`, `lint (e2e, …)`) that change whenever the matrix changes, so they can't be pinned as a required status check. The rollup gives one stable `Lint` check to require as a merge-queue gate. It fails closed if the `changes` detection job fails or any `golangci` leg is non-success, and skips cleanly on docs-only PRs.

