### PR TITLE
feat(api): pull schema from the primary deployment for fan-out environments

### DIFF
--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -1178,64 +1178,103 @@ func TestExecutePullSchemaRejectsUnsupportedType(t *testing.T) {
 	assert.Equal(t, storage.DatabaseTypeStrata, unsupportedErr.DatabaseType)
 }
 
-func TestExecutePullSchemaRejectsMultiDeploymentEnvironment(t *testing.T) {
+// A multi-deployment environment pulls its live schema from the primary
+// deployment (first in deployment_order); the apply itself fans out across
+// every deployment.
+func TestExecutePullSchemaRoutesPrimaryDeployment(t *testing.T) {
+	euClient := &mockTernClient{
+		pullSchemaResp: &ternv1.PullSchemaResponse{
+			Database:    "orders",
+			Type:        storage.DatabaseTypeMySQL,
+			Environment: "production",
+			Namespaces: map[string]*ternv1.PulledNamespace{
+				"orders": {Tables: map[string]string{"users": "CREATE TABLE `users` (`id` bigint NOT NULL);\n"}},
+			},
+			TableCount: 1,
+		},
+	}
+	usClient := &mockTernClient{}
 	cfg := &ServerConfig{
 		Databases: map[string]DatabaseConfig{
 			"orders": {
 				Type: storage.DatabaseTypeMySQL,
 				Environments: map[string]EnvironmentConfig{
 					"production": {
+						DeploymentOrder: []string{"eu", "us"},
 						Deployments: map[string]DeploymentTarget{
-							"primary":   {Target: "orders-primary"},
-							"secondary": {Target: "orders-secondary"},
+							"eu": {Target: "orders-eu"},
+							"us": {Target: "orders-us"},
 						},
 					},
 				},
 			},
 		},
 		TernDeployments: TernConfig{
-			"primary":   {"production": "primary.example.com:80"},
-			"secondary": {"production": "secondary.example.com:80"},
+			"eu": {"production": "eu.example.com:80"},
+			"us": {"production": "us.example.com:80"},
 		},
 	}
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
-	svc := New(&mockStorage{}, cfg, map[string]tern.Client{}, logger)
+	svc := New(&mockStorage{}, cfg, map[string]tern.Client{
+		"eu/production": euClient,
+		"us/production": usClient,
+	}, logger)
 
-	_, err := svc.ExecutePullSchema(t.Context(), apitypes.PullSchemaRequest{
+	resp, err := svc.ExecutePullSchema(t.Context(), apitypes.PullSchemaRequest{
 		Database:    "orders",
 		Environment: "production",
 		Type:        storage.DatabaseTypeMySQL,
 	})
 
-	var ambiguousErr *ambiguousPullSchemaTargetError
-	require.ErrorAs(t, err, &ambiguousErr)
-	assert.Equal(t, "orders", ambiguousErr.Database)
-	assert.Equal(t, "production", ambiguousErr.Environment)
-	assert.Equal(t, 2, ambiguousErr.Count)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, int32(1), resp.TableCount)
+	require.NotNil(t, euClient.pullSchemaReq, "primary deployment should be pulled")
+	assert.Equal(t, "orders-eu", euClient.pullSchemaReq.Target)
+	assert.Equal(t, storage.DatabaseTypeMySQL, euClient.pullSchemaReq.Type)
+	assert.Nil(t, usClient.pullSchemaReq, "non-primary deployment must not be pulled")
 }
 
-func TestPullSchemaHandlerRejectsMultiDeploymentEnvironment(t *testing.T) {
+// The /api/pull handler succeeds for a multi-deployment environment, returning
+// the live schema pulled from the primary deployment.
+func TestPullSchemaHandlerRoutesPrimaryDeployment(t *testing.T) {
+	euClient := &mockTernClient{
+		pullSchemaResp: &ternv1.PullSchemaResponse{
+			Database:    "orders",
+			Type:        storage.DatabaseTypeMySQL,
+			Environment: "production",
+			Namespaces: map[string]*ternv1.PulledNamespace{
+				"orders": {Tables: map[string]string{"users": "CREATE TABLE `users` (`id` bigint NOT NULL);\n"}},
+			},
+			TableCount: 1,
+		},
+	}
+	usClient := &mockTernClient{}
 	cfg := &ServerConfig{
 		Databases: map[string]DatabaseConfig{
 			"orders": {
 				Type: storage.DatabaseTypeMySQL,
 				Environments: map[string]EnvironmentConfig{
 					"production": {
+						DeploymentOrder: []string{"eu", "us"},
 						Deployments: map[string]DeploymentTarget{
-							"primary":   {Target: "orders-primary"},
-							"secondary": {Target: "orders-secondary"},
+							"eu": {Target: "orders-eu"},
+							"us": {Target: "orders-us"},
 						},
 					},
 				},
 			},
 		},
 		TernDeployments: TernConfig{
-			"primary":   {"production": "primary.example.com:80"},
-			"secondary": {"production": "secondary.example.com:80"},
+			"eu": {"production": "eu.example.com:80"},
+			"us": {"production": "us.example.com:80"},
 		},
 	}
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
-	svc := New(&mockStorage{}, cfg, map[string]tern.Client{}, logger)
+	svc := New(&mockStorage{}, cfg, map[string]tern.Client{
+		"eu/production": euClient,
+		"us/production": usClient,
+	}, logger)
 	mux := http.NewServeMux()
 	svc.ConfigureRoutes(mux)
 
@@ -1245,8 +1284,10 @@ func TestPullSchemaHandlerRejectsMultiDeploymentEnvironment(t *testing.T) {
 
 	mux.ServeHTTP(w, req)
 
-	assert.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
-	assert.Contains(t, w.Body.String(), "resolves to 2 deployments")
+	assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	require.NotNil(t, euClient.pullSchemaReq, "primary deployment should be pulled")
+	assert.Equal(t, "orders-eu", euClient.pullSchemaReq.Target)
+	assert.Nil(t, usClient.pullSchemaReq, "non-primary deployment must not be pulled")
 }
 
 func TestExecuteApplySourcePolicyAllowsDirectPlan(t *testing.T) {

--- a/pkg/api/plan_handlers.go
+++ b/pkg/api/plan_handlers.go
@@ -145,11 +145,12 @@ func (s *Service) ExecutePullSchema(ctx context.Context, req apitypes.PullSchema
 	)
 	defer span.End()
 
-	// Pull the live schema from the primary deployment (first in
-	// deployment_order, otherwise the only deployment). For a multi-deployment
-	// environment the primary is the canonical source for the schema diff; the
-	// apply itself fans out across every deployment. This matches the route
-	// ExecutePlan resolves and the deployment createStoredApply records.
+	// Pull the live schema from the primary deployment (first in rollout order:
+	// explicit deployment_order when set, otherwise alphabetical). For a
+	// multi-deployment environment the primary is the canonical source for the
+	// schema diff; the apply itself fans out across every deployment. This
+	// matches the route ExecutePlan resolves and the deployment
+	// createStoredApply records.
 	resolvedTarget, err := s.config.ResolvePrimaryDatabaseTarget(req.Database, req.Environment)
 	if err != nil {
 		span.RecordError(err)

--- a/pkg/api/plan_handlers.go
+++ b/pkg/api/plan_handlers.go
@@ -56,16 +56,6 @@ func (e *unsupportedPullSchemaError) Error() string {
 	return fmt.Sprintf("pull schema supports %s and %s databases; got %s", storage.DatabaseTypeMySQL, storage.DatabaseTypeVitess, e.DatabaseType)
 }
 
-type ambiguousPullSchemaTargetError struct {
-	Database    string
-	Environment string
-	Count       int
-}
-
-func (e *ambiguousPullSchemaTargetError) Error() string {
-	return fmt.Sprintf("pull schema for database %q environment %q resolves to %d deployments; pull schema currently requires an environment with exactly one deployment", e.Database, e.Environment, e.Count)
-}
-
 // RemoteDeploymentUnavailableError carries routing metadata for remote
 // schema change service availability failures so callers can render actionable
 // operator-facing errors without parsing strings.
@@ -125,12 +115,6 @@ func (s *Service) handlePullSchema(w http.ResponseWriter, r *http.Request) {
 			s.writeError(w, http.StatusNotImplemented, err.Error())
 			return
 		}
-		var ambiguousErr *ambiguousPullSchemaTargetError
-		if errors.As(err, &ambiguousErr) {
-			s.logger.Warn("pull schema rejected for multi-deployment environment", "database", ambiguousErr.Database, "environment", ambiguousErr.Environment, "deployment_count", ambiguousErr.Count)
-			s.writeError(w, http.StatusBadRequest, err.Error())
-			return
-		}
 		var unavailableErr *RemoteDeploymentUnavailableError
 		if errors.As(err, &unavailableErr) {
 			s.logger.Error("pull schema failed because remote deployment is unavailable",
@@ -161,19 +145,17 @@ func (s *Service) ExecutePullSchema(ctx context.Context, req apitypes.PullSchema
 	)
 	defer span.End()
 
-	resolvedTargets, err := s.config.ResolveDatabaseTargets(req.Database, req.Environment)
+	// Pull the live schema from the primary deployment (first in
+	// deployment_order, otherwise the only deployment). For a multi-deployment
+	// environment the primary is the canonical source for the schema diff; the
+	// apply itself fans out across every deployment. This matches the route
+	// ExecutePlan resolves and the deployment createStoredApply records.
+	resolvedTarget, err := s.config.ResolvePrimaryDatabaseTarget(req.Database, req.Environment)
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(otelcodes.Error, "resolve target")
 		return nil, fmt.Errorf("resolve target for %s/%s: %w", req.Database, req.Environment, err)
 	}
-	if len(resolvedTargets) != 1 {
-		ambiguousErr := &ambiguousPullSchemaTargetError{Database: req.Database, Environment: req.Environment, Count: len(resolvedTargets)}
-		span.RecordError(ambiguousErr)
-		span.SetStatus(otelcodes.Error, "ambiguous target")
-		return nil, ambiguousErr
-	}
-	resolvedTarget := resolvedTargets[0]
 	if req.Type != "" && req.Type != resolvedTarget.DatabaseType {
 		typeErr := fmt.Errorf("database %q type %q does not match server config type %q", req.Database, req.Type, resolvedTarget.DatabaseType)
 		span.RecordError(typeErr)
@@ -199,15 +181,15 @@ func (s *Service) ExecutePullSchema(ctx context.Context, req apitypes.PullSchema
 		return nil, err
 	}
 
-	client, err := s.RoutingTernClient()
+	client, err := s.TernClient(resolvedTarget.Deployment, req.Environment)
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(otelcodes.Error, "tern client")
 		return nil, fmt.Errorf("database %q (%s): %w", req.Database, req.Environment, err)
 	}
 
-	isRemoteTarget := s.executionTargetUsesRemoteClient(resolvedTarget.Deployment, req.Environment)
-	s.logger.Info("ExecutePullSchema: calling routing client PullSchema",
+	isRemoteTarget := client.IsRemote()
+	s.logger.Info("ExecutePullSchema: calling PullSchema",
 		"database", req.Database,
 		"type", resolvedTarget.DatabaseType,
 		"deployment", resolvedTarget.Deployment,
@@ -228,6 +210,7 @@ func (s *Service) ExecutePullSchema(ctx context.Context, req apitypes.PullSchema
 		resp, pullErr := client.PullSchema(ctx, &ternv1.PullSchemaRequest{
 			Database:      req.Database,
 			Type:          resolvedTarget.DatabaseType,
+			Target:        resolvedTarget.Target,
 			Environment:   req.Environment,
 			Namespace:     namespace,
 			CatalogDetail: catalogDetail,
@@ -341,16 +324,6 @@ func mergePullSchemaResponse(merged, resp *ternv1.PullSchemaResponse, requestedN
 	}
 	merged.TableCount += resp.TableCount
 	return nil
-}
-
-func (s *Service) executionTargetUsesRemoteClient(deployment, environment string) bool {
-	if dbConfig := s.config.Database(deployment); dbConfig != nil {
-		if envConfig, ok := dbConfig.Environments[environment]; ok && envConfig.HasLocalDSN() {
-			return false
-		}
-	}
-	_, err := s.config.TernDeployments.Endpoint(deployment, environment)
-	return err == nil
 }
 
 // ApplyRequest is the HTTP request body for POST /api/apply.


### PR DESCRIPTION
## Summary
`ExecutePullSchema` rejected any environment that resolved to more than one
deployment. It now pulls the live schema from the **primary deployment** (first
in `deployment_order`, otherwise the only deployment) — the canonical source for
the schema diff — matching the route the plan path already resolves. The apply
itself continues to fan out across every deployment.

before:  pull(db/env) -> resolve targets -> len>1 ? -> ERROR (HTTP 400)
after:   pull(db/env) -> resolve PRIMARY (first in deployment_order)
-> deployment-scoped Tern client -> PullSchema
(non-primary deployments are not pulled; apply still fans out to all)

## Changes
- Resolve the primary target and route the pull through a deployment-scoped Tern
  client, setting the request target explicitly.
- Remove the now-obsolete ambiguous-target error, its HTTP mapping, and an
  unused remote-target helper.
- Replace the negative multi-deployment reject tests with positive tests that
  assert the schema is pulled from the primary deployment and not from the rest.

## Testing / validation
Unit tests for the pull-schema service and handler paths; `go build`, `go vet`,
and lint pass.
