### PR TITLE
feat(api): accept multi-deployment deployments maps

### DIFF
--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -864,14 +864,6 @@ func (c *ServerConfig) Validate() error {
 						return err
 					}
 				}
-				// The multi-deployment apply path (plan, progress, webhook)
-				// is not yet wired to ResolveDatabaseTargets, so accepting a
-				// >1-entry deployments map here would silently break every
-				// plan/apply with a confusing internal resolver error. Gate
-				// it at config load until the orchestration path lands.
-				if len(envConfig.Deployments) > 1 {
-					return fmt.Errorf("database %q environment %q multi-deployment (>1 entries) is not yet supported by this server; got %d deployments", name, env, len(envConfig.Deployments))
-				}
 				for deployment, dt := range envConfig.Deployments {
 					if deployment == "" {
 						return fmt.Errorf("database %q environment %q has a deployments map entry with an empty key", name, env)

--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -1238,10 +1238,9 @@ func TestServerConfig_ResolveDatabaseTargets(t *testing.T) {
 			"payments-c": {"production": "tern-c:9090"},
 		},
 	}
-	// This test exercises the resolver directly on a hand-built config so
-	// it can cover multi-deployment resolution; the Validate() gate on
-	// multi-deployment maps is covered separately by
-	// TestServerConfig_DeploymentsMapValidation.
+	// This test exercises the resolver directly on a hand-built config so it can
+	// cover multi-deployment resolution; deployments-map validation is covered
+	// separately by TestServerConfig_DeploymentsMapValidation.
 
 	t.Run("local DSN returns single element", func(t *testing.T) {
 		got, err := cfg.ResolveDatabaseTargets("localdb", "staging")
@@ -1364,9 +1363,8 @@ func TestServerConfig_ResolveDatabaseTargets_BypassValidate(t *testing.T) {
 }
 
 // TestServerConfig_ResolveDatabaseTargets_DeploymentOrder exercises the
-// resolver directly on hand-built multi-deployment configs (bypassing the
-// Validate() >1-entry gate) so it can cover deployment_order ordering and the
-// permutation checks the resolver enforces.
+// resolver directly on hand-built multi-deployment configs so it can cover
+// deployment_order ordering and the permutation checks the resolver enforces.
 func TestServerConfig_ResolveDatabaseTargets_DeploymentOrder(t *testing.T) {
 	makeCfg := func(env EnvironmentConfig) *ServerConfig {
 		return &ServerConfig{
@@ -1523,15 +1521,26 @@ func TestServerConfig_DeploymentsMapValidation(t *testing.T) {
 			tern: baseTern,
 		},
 		{
-			name: "multi-entry deployments map is rejected until orchestration is wired",
+			name: "multi-entry deployments map is accepted",
 			envConfig: EnvironmentConfig{
 				Deployments: map[string]DeploymentTarget{
 					"payments-a": {Target: "payments"},
 					"payments-b": {Target: "payments"},
 				},
 			},
-			tern:       baseTern,
-			wantErrSub: "multi-deployment (>1 entries) is not yet supported",
+			tern: baseTern,
+		},
+		{
+			name: "multi-entry deployments map with deployment_order and barrier cutover is accepted",
+			envConfig: EnvironmentConfig{
+				Deployments: map[string]DeploymentTarget{
+					"payments-a": {Target: "payments"},
+					"payments-b": {Target: "payments"},
+				},
+				DeploymentOrder: []string{"payments-a", "payments-b"},
+				CutoverPolicy:   storage.CutoverPolicyBarrier,
+			},
+			tern: baseTern,
 		},
 		{
 			name: "mixing scalar and map is rejected",


### PR DESCRIPTION
## Summary
Lifts the config-load hard gate that rejected `>1`-entry `deployments` maps.
This is the last artificial block on multi-deployment fan-out.

**Stacks on #<Leaf-A PR>** (canonical pull-schema). Retarget base to `main` once that merges.

## Why it's safe now
The multi-deployment apply path is already fan-out ready:
- `createStoredApply` resolves via `ResolveDatabaseTargets` and writes one
  `apply_operations` row per deployment.
- plan/progress/webhook use deployment-scoped clients; `PullSchema` routes to
  the primary deployment (Leaf A).
- operator claim/drive is per-operation and ordered-cutover support is merged.

## Changes
- `pkg/api/config.go`: remove the `>1 deployments not yet supported` rejection.
- `pkg/api/config_test.go`: flip the negative case to acceptance + add a
  `deployment_order`/barrier-cutover acceptance case; drop stale gate comments.

## Flow
Before: `config load → len > 1 ? → REJECT "not yet supported"`
After:  `config load → per-deployment validation → ACCEPT (apply path fans out)`

## Testing / validation
- `go build ./...`, `go vet ./pkg/api/`
- `go test ./pkg/api/ -count=1`
- `golangci-lint run --new-from-rev <base> ./pkg/api/` → 0 issues
