### PR TITLE
feat(presentation): surface running_degraded across rollout consumers

### DIFF
--- a/pkg/cmd/commands/watch_tui_test.go
+++ b/pkg/cmd/commands/watch_tui_test.go
@@ -298,6 +298,28 @@ func TestWatchModel_MultiDeploymentView(t *testing.T) {
 	assert.Contains(t, view, "Failed")
 }
 
+// Under on_failure continue a failed deployment with a still-running sibling
+// holds the rollout running_degraded: the multi-deployment TUI header shows
+// "running (degraded)" with a spinner, the running-sibling count, and the first
+// failure, rather than a premature terminal "failed" header.
+func TestWatchModel_MultiDeploymentViewRunningDegraded(t *testing.T) {
+	m := NewWatchModel("http://localhost:8080", "orders", "production", false)
+	m.applyID = "apply-degraded"
+	m.state = state.Apply.RunningDegraded
+	m.initialized = true
+	m.operations = []templates.ProgressOperation{
+		{Deployment: "eu", Target: "orders-eu", State: state.ApplyOperation.Failed, OnFailure: storage.OnFailureContinue, ErrorMessage: "duplicate column"},
+		{Deployment: "us", Target: "orders-us", State: state.ApplyOperation.Running, OnFailure: storage.OnFailureContinue},
+	}
+
+	view := m.View()
+
+	assert.Contains(t, view, "running (degraded)")
+	assert.Contains(t, view, "1 running · 1 failed")
+	assert.Contains(t, view, "⚠ First failure: eu — duplicate column")
+	assert.Contains(t, view, "🔄 us — running table copy")
+}
+
 func TestWatchModel_SingleDeploymentOutputDoesNotUseMultiView(t *testing.T) {
 	m := NewWatchModel("http://localhost:8080", "orders", "production", false)
 	m.applyID = "apply-single-test"

--- a/pkg/cmd/commands/watch_tui_view_multi.go
+++ b/pkg/cmd/commands/watch_tui_view_multi.go
@@ -30,18 +30,19 @@ func tuiOperationsForPresentation(ops []templates.ProgressOperation) []presentat
 	presentationOps := make([]presentation.Operation, 0, len(ops))
 	for _, op := range ops {
 		presentationOps = append(presentationOps, presentation.Operation{
-			Deployment:    op.Deployment,
-			State:         op.State,
-			Barrier:       op.CutoverPolicy == storage.CutoverPolicyBarrier,
-			HaltOnFailure: op.OnFailure != storage.OnFailureContinue,
-			Error:         op.ErrorMessage,
+			Deployment:        op.Deployment,
+			State:             op.State,
+			Barrier:           op.CutoverPolicy == storage.CutoverPolicyBarrier,
+			HaltOnFailure:     op.OnFailure != storage.OnFailureContinue,
+			ContinueOnFailure: op.OnFailure == storage.OnFailureContinue,
+			Error:             op.ErrorMessage,
 		})
 	}
 	return presentationOps
 }
 
 func (m WatchModel) writeMultiDeploymentHeader(b *strings.Builder, model presentation.Apply) {
-	if state.IsState(model.State, state.Apply.Running, state.Apply.Pending, state.Apply.WaitingForCutover, state.Apply.CuttingOver, state.Apply.Recovering) {
+	if state.IsState(model.State, state.Apply.Running, state.Apply.RunningDegraded, state.Apply.Pending, state.Apply.WaitingForCutover, state.Apply.CuttingOver, state.Apply.Recovering) {
 		b.WriteString(m.spinner.View() + model.Label + m.elapsed() + "\n")
 	} else {
 		b.WriteString(model.Label + "\n")

--- a/pkg/cmd/internal/templates/progress.go
+++ b/pkg/cmd/internal/templates/progress.go
@@ -407,6 +407,8 @@ func FormatProgressState(s string) string {
 		return "Idle"
 	case state.Apply.Running:
 		return ANSICyan + "🔄 Running" + ANSIReset
+	case state.Apply.RunningDegraded:
+		return ANSICyan + "🔄 Running (degraded)" + ANSIReset
 	case state.Apply.WaitingForDeploy:
 		return ANSIYellow + "🟨 Waiting for deploy" + ANSIReset
 	case state.Apply.WaitingForCutover:
@@ -1098,7 +1100,7 @@ func stateColorFunc(s string) func(string) string {
 		return colorWrap(ANSIRed)
 	case state.Apply.FailedRetryable:
 		return colorWrap(ANSIYellow)
-	case state.Apply.Running:
+	case state.Apply.Running, state.Apply.RunningDegraded:
 		return colorWrap(ANSICyan)
 	case state.Apply.WaitingForDeploy, state.Apply.WaitingForCutover, state.Apply.Recovering, state.Apply.CuttingOver:
 		return colorWrap(ANSIYellow)

--- a/pkg/cmd/internal/templates/progress_multi.go
+++ b/pkg/cmd/internal/templates/progress_multi.go
@@ -29,11 +29,12 @@ func progressOperationsForPresentation(ops []ProgressOperation) []presentation.O
 	presentationOps := make([]presentation.Operation, 0, len(ops))
 	for _, op := range ops {
 		presentationOps = append(presentationOps, presentation.Operation{
-			Deployment:    op.Deployment,
-			State:         op.State,
-			Barrier:       op.CutoverPolicy == storage.CutoverPolicyBarrier,
-			HaltOnFailure: op.OnFailure != storage.OnFailureContinue,
-			Error:         op.ErrorMessage,
+			Deployment:        op.Deployment,
+			State:             op.State,
+			Barrier:           op.CutoverPolicy == storage.CutoverPolicyBarrier,
+			HaltOnFailure:     op.OnFailure != storage.OnFailureContinue,
+			ContinueOnFailure: op.OnFailure == storage.OnFailureContinue,
+			Error:             op.ErrorMessage,
 		})
 	}
 	return presentationOps

--- a/pkg/cmd/internal/templates/progress_multi_test.go
+++ b/pkg/cmd/internal/templates/progress_multi_test.go
@@ -47,6 +47,34 @@ func TestWriteProgressMultiDeploymentRendersAggregateAndSections(t *testing.T) {
 	assert.Contains(t, output, "users_c")
 }
 
+// Under on_failure continue a failed deployment with a still-running sibling
+// holds the rollout running_degraded: the aggregate shows "running (degraded)"
+// rather than a premature "failed", surfaces the first failure, and offers no
+// review-failure next action while the rollout is still in flight.
+func TestWriteProgressMultiDeploymentContinueFailureShowsRunningDegraded(t *testing.T) {
+	output := captureStdout(t, func() {
+		WriteProgress(ProgressData{
+			ApplyID:     "apply-degraded",
+			Environment: "production",
+			State:       state.Apply.RunningDegraded,
+			Operations: []ProgressOperation{
+				{Deployment: "region-a", Target: "orders-a", State: state.ApplyOperation.Failed, CutoverPolicy: storage.CutoverPolicyRolling, OnFailure: storage.OnFailureContinue, ErrorMessage: "duplicate column name 'region'"},
+				{Deployment: "region-b", Target: "orders-b", State: state.ApplyOperation.Running, CutoverPolicy: storage.CutoverPolicyRolling, OnFailure: storage.OnFailureContinue},
+			},
+			Tables: []TableProgress{
+				{Deployment: "region-a", TableName: "users_a", ChangeType: "alter", DDL: "ALTER TABLE `users_a` ADD COLUMN `region` varchar(20)", Status: state.Task.Failed},
+				{Deployment: "region-b", TableName: "users_b", ChangeType: "alter", DDL: "ALTER TABLE `users_b` ADD COLUMN `region` varchar(20)", Status: state.Task.Running},
+			},
+		})
+	})
+
+	assert.Contains(t, output, "State:")
+	assert.Contains(t, output, "running (degraded)")
+	assert.Contains(t, output, "1 running · 1 failed")
+	assert.Contains(t, output, "First failure: region-a — duplicate column name 'region'")
+	assert.NotContains(t, output, "Next: review failure")
+}
+
 func TestWriteProgressSingleDeploymentDoesNotRenderMultiDeploymentAggregate(t *testing.T) {
 	data := ProgressData{
 		ApplyID:     "apply-single",

--- a/pkg/cmd/internal/templates/progress_states_test.go
+++ b/pkg/cmd/internal/templates/progress_states_test.go
@@ -31,6 +31,7 @@ func TestFormatProgressState_PlanetScalePhases(t *testing.T) {
 	assert.Contains(t, FormatProgressState(state.Apply.Cancelled), "Cancelled")
 	assert.Contains(t, FormatProgressState(state.Apply.FailedRetryable), "Retrying")
 	assert.Contains(t, FormatProgressState(state.Apply.Recovering), "Recovering")
+	assert.Contains(t, FormatProgressState(state.Apply.RunningDegraded), "Running (degraded)")
 }
 
 func TestWriteStatusListHasMoreFooter(t *testing.T) {
@@ -361,6 +362,7 @@ func TestStateColorFunc_PlanetScalePhases(t *testing.T) {
 		state.Apply.ValidatingDeployRequest,
 		state.Apply.Recovering,
 		state.Apply.Cancelled,
+		state.Apply.RunningDegraded,
 	} {
 		fn := stateColorFunc(s)
 		assert.NotNil(t, fn, "expected color function for state %q", s)

--- a/pkg/presentation/presentation.go
+++ b/pkg/presentation/presentation.go
@@ -44,6 +44,12 @@ type Operation struct {
 	// terminal-failed earlier sibling no longer blocks later deployments.
 	HaltOnFailure bool
 
+	// ContinueOnFailure is true only when the operation's on_failure policy is
+	// exactly "continue". The aggregate projection uses it to hold a rollout
+	// running_degraded past a continuable sibling failure; halt, pause, empty,
+	// and any unrecognized value must be false so the projection fails closed.
+	ContinueOnFailure bool
+
 	// Error is the operation's error detail, set when State is failed.
 	Error string
 }
@@ -138,7 +144,9 @@ type StateCount struct {
 // Apply is the surface-agnostic rollup for one logical apply.
 type Apply struct {
 	// State is the aggregate apply state derived from the child operation states
-	// via state.DeriveApplyState — the same projection that backs applies.state.
+	// via state.DeriveRolloutApplyState — the same policy-aware projection that
+	// backs applies.state, so a continue rollout still in flight past a failed
+	// sibling shows running_degraded here too rather than a premature failed.
 	State string
 
 	// Label is the operator-facing aggregate status (e.g. "waiting for cutover").
@@ -179,9 +187,12 @@ func (a Apply) MultiDeployment() bool {
 // must be in resolved deployment order (as returned by ListByApply); earlier
 // siblings are those before a given index.
 func Derive(ops []Operation) Apply {
-	rawStates := make([]string, len(ops))
+	children := make([]state.RolloutChild, len(ops))
 	for i, op := range ops {
-		rawStates[i] = op.State
+		children[i] = state.RolloutChild{
+			State:             op.State,
+			ContinueOnFailure: op.ContinueOnFailure,
+		}
 	}
 
 	deployments := make([]Deployment, len(ops))
@@ -189,7 +200,7 @@ func Derive(ops []Operation) Apply {
 		deployments[i] = deriveDeployment(ops, i)
 	}
 
-	aggState := state.DeriveApplyState(rawStates)
+	aggState := state.DeriveRolloutApplyState(children)
 	return Apply{
 		State:        aggState,
 		Label:        aggregateLabel(aggState),
@@ -379,6 +390,8 @@ func aggregateLabel(s string) string {
 		return "queued"
 	case state.Apply.Running:
 		return "running"
+	case state.Apply.RunningDegraded:
+		return "running (degraded)"
 	case state.Apply.WaitingForDeploy:
 		return "waiting for deploy"
 	case state.Apply.WaitingForCutover:

--- a/pkg/presentation/presentation_test.go
+++ b/pkg/presentation/presentation_test.go
@@ -21,6 +21,14 @@ func barrier(dep, st string) Operation {
 	return Operation{Deployment: dep, State: st, Barrier: true, HaltOnFailure: true}
 }
 
+// continuing builds a rolling, on_failure=continue operation. HaltOnFailure and
+// ContinueOnFailure are exact complements at the real boundary mappers (both
+// derive from the same on_failure value), so a continue operation sets
+// HaltOnFailure false and ContinueOnFailure true together.
+func continuing(dep, st string) Operation {
+	return Operation{Deployment: dep, State: st, HaltOnFailure: false, ContinueOnFailure: true}
+}
+
 // TestDerive_Empty: an apply with no operations rolls up to pending with no
 // deployments and is not treated as multi-deployment.
 func TestDerive_Empty(t *testing.T) {
@@ -128,15 +136,15 @@ func TestDerivePending_Ordering(t *testing.T) {
 		{
 			name: "no-halt: earlier failed no longer blocks",
 			ops: []Operation{
-				{Deployment: "eu", State: so.Failed, HaltOnFailure: false},
-				{Deployment: "us", State: so.Pending, HaltOnFailure: false},
+				continuing("eu", so.Failed),
+				continuing("us", so.Pending),
 			},
 			want:  StateQueuedNext,
 			label: "queued — next in order",
 		},
 		{
 			name:  "cancelled earlier halts regardless of halt flag",
-			ops:   []Operation{{Deployment: "eu", State: so.Cancelled, HaltOnFailure: false}, {Deployment: "us", State: so.Pending, HaltOnFailure: false}},
+			ops:   []Operation{continuing("eu", so.Cancelled), continuing("us", so.Pending)},
 			want:  StateHalted,
 			label: "halted — eu cancelled",
 		},
@@ -188,8 +196,8 @@ func TestDeriveWaitingForCutover_Ordering(t *testing.T) {
 		{
 			name: "no-halt: earlier failed does not block cutover (rollout continues past it)",
 			ops: []Operation{
-				{Deployment: "eu", State: so.Failed, HaltOnFailure: false},
-				{Deployment: "us", State: so.WaitingForCutover, HaltOnFailure: false},
+				continuing("eu", so.Failed),
+				continuing("us", so.WaitingForCutover),
 			},
 			want:  StateReadyForCutoverNext,
 			label: "ready for cutover — next in order",
@@ -258,15 +266,16 @@ func TestDerive_AggregateFailedHaltExample(t *testing.T) {
 	assert.Equal(t, StateHalted, got.Deployments[3].Presentation)
 }
 
-// TestDerive_CompletedWithOneFailedDeployment: under halt_on_failure=false the
-// rollout continues, so other deployments complete, but the aggregate stays
-// failed (the G3 render-half decision).
+// TestDerive_CompletedWithOneFailedDeployment: under on_failure continue the
+// rollout runs every sibling to a terminal state, but the verdict still
+// reflects the failure — once all siblings are terminal the aggregate settles
+// to failed, not running_degraded.
 func TestDerive_CompletedWithOneFailedDeployment(t *testing.T) {
 	got := Derive([]Operation{
-		{Deployment: "eu", State: so.Completed, HaltOnFailure: false},
-		{Deployment: "us", State: so.Completed, HaltOnFailure: false},
-		{Deployment: "au", State: so.Failed, HaltOnFailure: false},
-		{Deployment: "ca", State: so.Completed, HaltOnFailure: false},
+		continuing("eu", so.Completed),
+		continuing("us", so.Completed),
+		continuing("au", so.Failed),
+		continuing("ca", so.Completed),
 	})
 
 	assert.Equal(t, state.Apply.Failed, got.State)
@@ -314,9 +323,9 @@ func TestDerive_FirstFailureNoneWhenHealthy(t *testing.T) {
 // ErrorMessage is stamped from.
 func TestDerive_FirstFailurePicksEarliestInOrder(t *testing.T) {
 	got := Derive([]Operation{
-		{Deployment: "eu", State: so.Completed, HaltOnFailure: false},
-		{Deployment: "us", State: so.Failed, HaltOnFailure: false, Error: "first boom"},
-		{Deployment: "au", State: so.Failed, HaltOnFailure: false, Error: "second boom"},
+		continuing("eu", so.Completed),
+		{Deployment: "us", State: so.Failed, HaltOnFailure: false, ContinueOnFailure: true, Error: "first boom"},
+		{Deployment: "au", State: so.Failed, HaltOnFailure: false, ContinueOnFailure: true, Error: "second boom"},
 	})
 	require.NotNil(t, got.FirstFailure)
 	assert.Equal(t, "us", got.FirstFailure.Deployment)
@@ -325,18 +334,32 @@ func TestDerive_FirstFailurePicksEarliestInOrder(t *testing.T) {
 
 // TestDerive_FirstFailureWhileSiblingStillRunning: under on_failure continue an
 // earlier deployment can be failed while a later one is still copying. The
-// aggregate is fail-closed to failed, but the in-progress comment still has a
-// running deployment, so surfacing the first failure here lifts the reason onto
-// the status comment rather than waiting for the terminal summary.
+// rollout is held running_degraded so the live sibling runs to completion, and
+// the first failure is surfaced eagerly onto the in-progress comment rather than
+// waiting for the terminal summary.
 func TestDerive_FirstFailureWhileSiblingStillRunning(t *testing.T) {
 	got := Derive([]Operation{
-		{Deployment: "eu", State: so.Failed, HaltOnFailure: false, Error: "boom"},
-		{Deployment: "us", State: so.Running, HaltOnFailure: false},
+		{Deployment: "eu", State: so.Failed, HaltOnFailure: false, ContinueOnFailure: true, Error: "boom"},
+		continuing("us", so.Running),
 	})
-	assert.Equal(t, state.Apply.Failed, got.State)
+	assert.Equal(t, state.Apply.RunningDegraded, got.State)
+	assert.Equal(t, "running (degraded)", got.Label)
+	assert.Equal(t, NextAction{Kind: NextActionNone}, got.NextAction)
 	assert.Equal(t, StateRunningCopy, got.Deployments[1].Presentation)
 	require.NotNil(t, got.FirstFailure)
 	assert.Equal(t, "eu", got.FirstFailure.Deployment)
+}
+
+// TestDerive_HaltFailureWithRunningSiblingStaysFailed: a halt-policy failure is
+// fail-closed even while a sibling is still running — only on_failure continue
+// holds the rollout running_degraded.
+func TestDerive_HaltFailureWithRunningSiblingStaysFailed(t *testing.T) {
+	got := Derive([]Operation{
+		rolling("eu", so.Failed),
+		rolling("us", so.Running),
+	})
+	assert.Equal(t, state.Apply.Failed, got.State)
+	assert.Equal(t, "failed", got.Label)
 }
 
 // TestDerive_FirstFailureExcludesRetrying: a failed_retryable deployment is

--- a/pkg/webhook/multi_apply.go
+++ b/pkg/webhook/multi_apply.go
@@ -80,17 +80,20 @@ func deriveApplyPresentation(ops []*storage.ApplyOperation) presentation.Apply {
 }
 
 // applyOperationToPresentation maps one storage operation row to the neutral
-// presentation input, resolving the two rollout-policy values at the boundary:
-// cutover_policy "barrier" becomes the Barrier flag, and on_failure becomes the
-// HaltOnFailure flag — true unless on_failure is "continue", so any other value
-// fails closed to halting, the safe default the claim predicate also assumes.
+// presentation input, resolving the rollout-policy values at the boundary:
+// cutover_policy "barrier" becomes the Barrier flag, and on_failure becomes both
+// the HaltOnFailure flag — true unless on_failure is "continue" — and the
+// ContinueOnFailure flag — true only when on_failure is exactly "continue". Any
+// other value fails closed to halting, the safe default the claim predicate and
+// the aggregate projection also assume.
 func applyOperationToPresentation(op *storage.ApplyOperation) presentation.Operation {
 	return presentation.Operation{
-		Deployment:    op.Deployment,
-		State:         op.State,
-		Barrier:       op.CutoverPolicy == storage.CutoverPolicyBarrier,
-		HaltOnFailure: op.OnFailure != storage.OnFailureContinue,
-		Error:         op.ErrorMessage,
+		Deployment:        op.Deployment,
+		State:             op.State,
+		Barrier:           op.CutoverPolicy == storage.CutoverPolicyBarrier,
+		HaltOnFailure:     op.OnFailure != storage.OnFailureContinue,
+		ContinueOnFailure: op.OnFailure == storage.OnFailureContinue,
+		Error:             op.ErrorMessage,
 	}
 }
 

--- a/pkg/webhook/multi_apply_test.go
+++ b/pkg/webhook/multi_apply_test.go
@@ -122,14 +122,16 @@ func TestBuildDeploymentDetail_UsesOperationStateAndError(t *testing.T) {
 }
 
 // The storage→presentation boundary resolves the rollout policies: barrier flips
-// the Barrier flag, and on_failure becomes HaltOnFailure — true unless on_failure
-// is "continue", so an unset value resolves to halting (the safe default).
+// the Barrier flag, and on_failure becomes the complementary HaltOnFailure /
+// ContinueOnFailure pair — continue only when on_failure is exactly "continue",
+// so an unset value resolves to halting (the safe default).
 func TestApplyOperationToPresentation_ResolvesPolicies(t *testing.T) {
 	barrier := applyOperationToPresentation(&storage.ApplyOperation{
 		Deployment: "eu", State: state.ApplyOperation.Running, CutoverPolicy: storage.CutoverPolicyBarrier,
 	})
 	assert.True(t, barrier.Barrier)
 	assert.True(t, barrier.HaltOnFailure, "unset on_failure resolves to halting")
+	assert.False(t, barrier.ContinueOnFailure, "unset on_failure does not continue")
 
 	rolling := applyOperationToPresentation(&storage.ApplyOperation{
 		Deployment: "us", State: state.ApplyOperation.Running,
@@ -137,6 +139,7 @@ func TestApplyOperationToPresentation_ResolvesPolicies(t *testing.T) {
 	})
 	assert.False(t, rolling.Barrier)
 	assert.False(t, rolling.HaltOnFailure)
+	assert.True(t, rolling.ContinueOnFailure)
 }
 
 // Tasks without an apply_operation_id (legacy rows) are not attributable to a

--- a/pkg/webhook/templates/apply.go
+++ b/pkg/webhook/templates/apply.go
@@ -90,7 +90,10 @@ func writeApplyHeader(sb *strings.Builder, data ApplyStatusCommentData) {
 	switch data.State {
 	case state.Apply.Pending:
 		sb.WriteString("## Schema Change Starting\n\n")
-	case state.Apply.Running:
+	case state.Apply.Running, state.Apply.RunningDegraded:
+		// running_degraded is a continue rollout still in flight past a failed
+		// sibling: the change is still in progress, and the failed deployment is
+		// surfaced in the per-deployment breakdown, not the headline.
 		sb.WriteString("## Schema Change In Progress\n\n")
 	case state.Apply.FailedRetryable:
 		// Operator recovery retries the apply automatically, so it is still
@@ -542,7 +545,7 @@ func writeApplyFooter(sb *strings.Builder, data ApplyStatusCommentData) {
 	case state.Apply.CuttingOver:
 		sb.WriteString("\n---\n\n")
 		sb.WriteString("Cutover in progress — typically completes within seconds.\n")
-	case state.Apply.Running:
+	case state.Apply.Running, state.Apply.RunningDegraded:
 		writeFooterAction(sb, "To stop this schema change:", fmt.Sprintf("schemabot stop %s", data.ApplyID))
 	case state.Apply.PreparingBranch,
 		state.Apply.ApplyingBranchChanges,

--- a/pkg/webhook/templates/multi_apply_test.go
+++ b/pkg/webhook/templates/multi_apply_test.go
@@ -19,6 +19,10 @@ func rollingOp(dep, st string) presentation.Operation {
 	return presentation.Operation{Deployment: dep, State: st, HaltOnFailure: true}
 }
 
+func continuingOp(dep, st string) presentation.Operation {
+	return presentation.Operation{Deployment: dep, State: st, HaltOnFailure: false, ContinueOnFailure: true}
+}
+
 // A barrier rollout mid-flight (one deployment parked ready for cutover, one
 // copying, two queued behind it) renders an aggregate header with the running
 // title, a per-status count line, a single cutover next-action, an at-a-glance
@@ -131,18 +135,19 @@ func TestRenderMultiDeploymentApplyComment_UsesOneRenderTimestamp(t *testing.T) 
 // firstFailingOp builds a rolling, continue-policy operation carrying an error,
 // so a fan-out can fail one deployment and keep going.
 func firstFailingOp(dep, st, errMsg string) presentation.Operation {
-	return presentation.Operation{Deployment: dep, State: st, HaltOnFailure: false, Error: errMsg}
+	return presentation.Operation{Deployment: dep, State: st, HaltOnFailure: false, ContinueOnFailure: true, Error: errMsg}
 }
 
 // A failed deployment's reason is lifted to the aggregate header so an operator
 // sees what failed without expanding that deployment's section. Under on_failure
-// continue a later deployment is still copying, so the reason surfaces on the
-// in-progress status comment, and only the first failure in resolved order shows.
+// continue a later deployment is still copying, so the rollout is running_degraded
+// (still in progress) and the reason surfaces on the in-progress status comment,
+// with only the first failure in resolved order shown.
 func TestRenderMultiDeploymentApplyComment_FirstFailureSurfacesError(t *testing.T) {
 	model := presentation.Derive([]presentation.Operation{
 		firstFailingOp("us", so.Failed, "Error 1061: Duplicate key name idx"),
 		firstFailingOp("eu", so.Failed, "second failure"),
-		{Deployment: "au", State: so.Running, HaltOnFailure: false},
+		continuingOp("au", so.Running),
 	})
 	out := RenderMultiDeploymentApplyComment(MultiDeploymentApplyData{
 		Model:       model,
@@ -150,7 +155,10 @@ func TestRenderMultiDeploymentApplyComment_FirstFailureSurfacesError(t *testing.
 		Environment: "production",
 	})
 
-	// A later deployment is still running even though the aggregate is fail-closed.
+	// The rollout is still in progress (running_degraded), not headlined as failed.
+	assert.Contains(t, out, "## Schema Change In Progress")
+	assert.NotContains(t, out, "Schema Change Failed")
+	// A later deployment is still running while siblings have failed.
 	assert.Contains(t, out, "- 🔄 au — running table copy")
 	assert.Contains(t, out, "> ⚠️ **First failure:** <code>us</code> — Error 1061: Duplicate key name idx\n")
 	// Only the earliest failure is lifted to the header.


### PR DESCRIPTION
## What

Make the multi-deployment rollup policy-aware so a continue rollout that is
still in flight past a failed sibling renders as **running (degraded)** on the
PR comment, CLI `progress`, and watch TUI — matching the stored apply state.

- `presentation.Derive` now projects via the policy-aware rollout state, driven
  by a new `ContinueOnFailure` flag populated at every surface boundary.
- Adds `running_degraded` cases to the aggregate label, PR-comment header/footer,
  CLI color + state formatter, and the multi-deployment TUI spinner header.

## Why

The rollup previously derived the aggregate from the base projection, which
fails closed to `failed` as soon as any deployment fails. For a continue
rollout with siblings still copying, that contradicted the stored apply state
and told operators the change had failed while it was still running.

```diagram
continue rollout: one deployment failed, siblings still copying

  before                              after
╭─────────────────────╮            ╭──────────────────────────╮
│ aggregate = failed  │  ✗ wrong   │ aggregate = running       │  ✓ matches
│ "Schema Change      │  contra-   │             (degraded)    │  apply.state
│  Failed"            │  dicts     │ "Schema Change In         │
│                     │  apply     │  Progress"                │
╰─────────────────────╯  state     ╰──────────────────────────╯

settles to failed only once every sibling reaches a terminal state

Non-terminal by design: Check Runs stay in progress until the rollout settles.
