### PR TITLE
test(e2e): multi-deployment ordered-cutover acceptance test (E2E-2)

### DIFF
--- a/e2e/grpc/multideploy_test.go
+++ b/e2e/grpc/multideploy_test.go
@@ -6,8 +6,10 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"maps"
 	"net/http"
 	"os"
+	"slices"
 	"testing"
 	"time"
 
@@ -114,22 +116,31 @@ func multiDeployCreateTestTable(t *testing.T, deployment, tableName, ddl string)
 	dsn := multiDeployTernMySQLDSN(t, deployment)
 	db, err := sql.Open("mysql", dsn)
 	require.NoErrorf(t, err, "open tern mysql (%s)", deployment)
+	// Defer close immediately so the handle is reclaimed even if the create
+	// below fails a require.* assertion, and so close errors are logged.
+	defer utils.CloseAndLog(db)
 	_, err = db.ExecContext(t.Context(), ddl)
 	require.NoErrorf(t, err, "create table %s on %s", tableName, deployment)
-	_ = db.Close()
 
 	t.Cleanup(func() {
 		db2, err := sql.Open("mysql", dsn)
 		if err != nil {
+			t.Logf("cleanup: open tern mysql (%s): %v", deployment, err)
 			return
 		}
 		defer utils.CloseAndLog(db2)
+		// t.Context() is cancelled once the test finishes, so derive a
+		// cancellation-immune context with a bounded timeout for cleanup DDL.
+		ctx, cancel := context.WithTimeout(context.WithoutCancel(t.Context()), 30*time.Second)
+		defer cancel()
 		for _, suffix := range []string{"_new", "_old", "_chkpnt", ""} {
 			name := tableName
 			if suffix != "" {
 				name = "_" + tableName + suffix
 			}
-			_, _ = db2.ExecContext(context.Background(), "DROP TABLE IF EXISTS `"+name+"`") //nolint:usetesting // cleanup
+			if _, err := db2.ExecContext(ctx, "DROP TABLE IF EXISTS `"+name+"`"); err != nil {
+				t.Logf("cleanup: drop table %s on %s: %v", name, deployment, err)
+			}
 		}
 	})
 }
@@ -172,6 +183,23 @@ func multiDeployOperationStates(t *testing.T, applyID string) map[string]grpcOpe
 		byDeployment[op.Deployment] = op
 	}
 	return byDeployment
+}
+
+// multiDeployOps fetches per-deployment operation states and fails fast if
+// either expected deployment is missing. An apply commits all of its
+// apply_operations rows in one transaction, so once the apply is accepted a
+// missing row is a real defect — not a transient — and the test should fail
+// immediately with a clear message rather than poll for minutes against empty
+// state strings.
+func multiDeployOps(t *testing.T, applyID string, deployments ...string) map[string]grpcOperationProgress {
+	t.Helper()
+	ops := multiDeployOperationStates(t, applyID)
+	for _, d := range deployments {
+		_, ok := ops[d]
+		require.Truef(t, ok, "progress missing operation for deployment %q; present: %v",
+			d, slices.Sorted(maps.Keys(ops)))
+	}
+	return ops
 }
 
 // failedApplyState reports whether a state is a failed terminal apply state.
@@ -230,7 +258,7 @@ func TestGRPCMultiDeploy_OrderedCutover(t *testing.T) {
 	)
 	testutil.Poll(t, orderedCutoverDeadline, testutil.PollInterval,
 		func() bool {
-			ops := multiDeployOperationStates(t, apply.ApplyID)
+			ops := multiDeployOps(t, apply.ApplyID, first, second)
 			firstOp, secondOp := ops[first], ops[second]
 
 			// Happy path: neither deployment should fail.
@@ -331,7 +359,7 @@ func TestGRPCMultiDeploy_FailureHaltsRollout(t *testing.T) {
 	// from cutting over once a sibling has failed.
 	testutil.Poll(t, orderedCutoverDeadline, testutil.PollInterval,
 		func() bool {
-			ops := multiDeployOperationStates(t, apply.ApplyID)
+			ops := multiDeployOps(t, apply.ApplyID, first, second)
 			require.Falsef(t, state.IsState(ops[second].State, state.Apply.Completed),
 				"halt violated: %s completed despite %s failing (state %q)", second, first, ops[first].State)
 			return failedApplyState(ops[first].State)


### PR DESCRIPTION
## Summary

Adds the ordered-cutover acceptance test that the multi-deployment fan-out
fixture was built for. A single `(database, environment)` fans out to two
deployments under `cutover_policy: barrier` with an explicit `deployment_order`,
and the test proves the operator drives cutover strictly in order — and halts
the rollout when a deployment fails.

The `>1 deployments` config gate (#466) and the canonical pull-schema behavior
(#464) are now merged. The fixture itself landed in #460.

## Why

The fan-out fixture (#460) only verified the stack boots and resolves both
remote deployments. This PR exercises the actual safety behavior: barrier
ordering and fail-closed halting across deployments, end to end over gRPC.

## What I added

- `TestGRPCMultiDeploy_OrderedCutover` — both deployments copy concurrently and
  park at the barrier; the earlier deployment cuts over and completes before the
  later one is allowed to. Asserts the later deployment parks at
  `waiting_for_cutover`, never completes ahead of the earlier one, and that
  completion timestamps confirm the order.
- `TestGRPCMultiDeploy_FailureHaltsRollout` — the earlier deployment is seeded
  with duplicate data so adding a `UNIQUE` key fails its copy; the later
  deployment is healthy. The rollout halts: the later deployment never cuts over
  to completed and the apply settles to failed.
- Per-deployment operation rows on the gRPC progress test helper, plus
  multi-deployment seed/table/state helpers; both tests run under the existing
  `E2E_MULTIDEPLOY=1` `test-e2e-grpc-multideploy` target.

## Flow

Ordered cutover (happy path):
```
fan-out apply ─→ [eu, us]   barrier · deployment_order [eu, us]
eu: copy ─→ waiting_for_cutover ─→ cutover ─→ completed
us: copy ─→ waiting_for_cutover ───────(parks)──────→ cutover ─→ completed
▲ us cannot complete before eu
```
Failure halts the rollout:
```
fan-out apply ─→ [eu, us]   barrier · on_failure: halt (default)
eu: ADD UNIQUE(name) on duplicate data ─→ copy FAILS
us: copy ─→ waiting_for_cutover ──(never cuts over)──→ ✗
rollout halts ⇒ apply = failed, us ≠ completed
```
## Testing / validation

`go vet -tags=e2e` and `golangci-lint --build-tags=e2e` pass. The tests run via
`make test-e2e-grpc-multideploy` (docker-compose stack), gated behind
`E2E_MULTIDEPLOY=1` and excluded from the default e2e run.
