### PR TITLE
feat(tern): materialize remote plan from apply request payload

### DIFF
--- a/pkg/tern/local_client.go
+++ b/pkg/tern/local_client.go
@@ -1211,6 +1211,121 @@ func (c *LocalClient) planMySQLNamespacesWithEngine(ctx context.Context, eng eng
 	return result, nil
 }
 
+// planForApplyRequest resolves the plan for an apply. It prefers a plan row in
+// this deployment's own storage (the single-deployment path, and the primary
+// deployment of a multi-deployment apply). When no local plan exists, a
+// non-primary deployment's Tern never planned locally — the plan was created on
+// the primary deployment's Tern — but the dispatch request carries the
+// authoritative DDL changes and schema files, so the plan is materialized from
+// them. A request with neither (a stale apply, or a local-mode apply for a plan
+// that does not exist here) has nothing to materialize and resolves to no plan.
+func (c *LocalClient) planForApplyRequest(ctx context.Context, req *ternv1.ApplyRequest) (*storage.Plan, error) {
+	plan, err := c.storage.Plans().Get(ctx, req.PlanId)
+	if err != nil {
+		return nil, fmt.Errorf("get plan %s: %w", req.PlanId, err)
+	}
+	if plan != nil {
+		return plan, nil
+	}
+	if len(req.DdlChanges) == 0 && len(req.SchemaFiles) == 0 {
+		return nil, nil
+	}
+	return c.materializeApplyRequestPlan(ctx, req)
+}
+
+// materializeApplyRequestPlan persists a local plan row from a dispatch
+// request's authoritative DDL changes and schema files so a non-primary
+// deployment applies exactly what the primary deployment planned.
+func (c *LocalClient) materializeApplyRequestPlan(ctx context.Context, req *ternv1.ApplyRequest) (*storage.Plan, error) {
+	schemaFiles := protoToSchemaFiles(req.SchemaFiles)
+	namespaces := namespacesFromApplyRequest(req.DdlChanges, schemaFiles, c.config.Database)
+	if len(namespaces) == 0 {
+		return nil, fmt.Errorf("materialize plan %s: apply request carried no DDL changes or schema files", req.PlanId)
+	}
+
+	target := req.Target
+	if target == "" {
+		target = c.config.Database
+	}
+	plan := &storage.Plan{
+		PlanIdentifier: req.PlanId,
+		Database:       c.config.Database,
+		DatabaseType:   c.config.Type,
+		Deployment:     c.config.Database,
+		Target:         target,
+		Environment:    req.Environment,
+		SchemaFiles:    schemaFiles,
+		Namespaces:     namespaces,
+		CreatedAt:      time.Now(),
+	}
+	c.logger.Info("Apply: materializing plan from dispatch request",
+		"plan_id", req.PlanId,
+		"database", c.config.Database,
+		"namespace_count", len(namespaces),
+	)
+
+	planID, err := c.storage.Plans().Create(ctx, plan)
+	if err != nil {
+		// A concurrent drive of the same operation may have materialized the
+		// plan first; reload and use the existing row rather than failing.
+		existing, getErr := c.storage.Plans().Get(ctx, req.PlanId)
+		if getErr == nil && existing != nil {
+			return existing, nil
+		}
+		return nil, fmt.Errorf("create materialized plan %s: %w", req.PlanId, err)
+	}
+	plan.ID = planID
+	return plan, nil
+}
+
+// namespacesFromApplyRequest rebuilds per-namespace plan data from a dispatch
+// request. Table changes are grouped by namespace; vschema changes are omitted
+// because the apply path re-derives the vschema task from the namespace's
+// vschema.json artifact, which is recovered from the declarative schema files.
+func namespacesFromApplyRequest(changes []*ternv1.TableChange, schemaFiles schema.SchemaFiles, fallbackNamespace string) map[string]*storage.NamespacePlanData {
+	namespaces := map[string]*storage.NamespacePlanData{}
+	ensure := func(ns string) *storage.NamespacePlanData {
+		if ns == "" {
+			ns = fallbackNamespace
+		}
+		if namespaces[ns] == nil {
+			namespaces[ns] = &storage.NamespacePlanData{}
+		}
+		return namespaces[ns]
+	}
+
+	for _, ch := range changes {
+		if ch == nil {
+			continue
+		}
+		if ch.ChangeType == ternv1.ChangeType_CHANGE_TYPE_VSCHEMA {
+			continue
+		}
+		nsData := ensure(ch.Namespace)
+		nsData.Tables = append(nsData.Tables, storage.TableChange{
+			Namespace: ch.Namespace,
+			Table:     ch.TableName,
+			DDL:       ch.Ddl,
+			Operation: protoChangeTypeToDDLAction(ch.ChangeType),
+		})
+	}
+
+	for ns, nsFiles := range schemaFiles {
+		if nsFiles == nil {
+			continue
+		}
+		if vs, ok := nsFiles.Files[vSchemaArtifactName]; ok && vs != "" {
+			nsData := ensure(ns)
+			if nsData.Artifacts == nil {
+				nsData.Artifacts = map[string]string{}
+			}
+			nsData.Artifacts[vSchemaArtifactName] = vs
+		}
+	}
+
+	return namespaces
+}
+
 // Apply executes a previously generated plan.
 // In local mode, Apply has additional conflict checking and polls for completion.
 //
@@ -1225,10 +1340,12 @@ func (c *LocalClient) Apply(ctx context.Context, req *ternv1.ApplyRequest) (*ter
 		return nil, fmt.Errorf("environment is required")
 	}
 
-	// Look up the plan
-	plan, err := c.storage.Plans().Get(ctx, req.PlanId)
+	// Look up the plan, materializing it from the dispatch request when this
+	// deployment did not plan locally (a non-primary deployment of a
+	// multi-deployment apply).
+	plan, err := c.planForApplyRequest(ctx, req)
 	if err != nil {
-		return nil, fmt.Errorf("get plan: %w", err)
+		return nil, fmt.Errorf("resolve plan %s for apply: %w", req.PlanId, err)
 	}
 	if plan == nil {
 		return &ternv1.ApplyResponse{

--- a/pkg/tern/local_client.go
+++ b/pkg/tern/local_client.go
@@ -1237,8 +1237,14 @@ func (c *LocalClient) planForApplyRequest(ctx context.Context, req *ternv1.Apply
 // request's authoritative DDL changes and schema files so a non-primary
 // deployment applies exactly what the primary deployment planned.
 func (c *LocalClient) materializeApplyRequestPlan(ctx context.Context, req *ternv1.ApplyRequest) (*storage.Plan, error) {
-	schemaFiles := protoToSchemaFiles(req.SchemaFiles)
-	namespaces := namespacesFromApplyRequest(req.DdlChanges, schemaFiles, c.config.Database)
+	schemaFiles, err := c.normalizeSchemaFiles(protoToSchemaFiles(req.SchemaFiles))
+	if err != nil {
+		return nil, fmt.Errorf("materialize plan %s: normalize schema files: %w", req.PlanId, err)
+	}
+	namespaces, err := c.namespacesFromApplyRequest(req.DdlChanges, schemaFiles)
+	if err != nil {
+		return nil, fmt.Errorf("materialize plan %s: %w", req.PlanId, err)
+	}
 	if len(namespaces) == 0 {
 		return nil, fmt.Errorf("materialize plan %s: apply request carried no DDL changes or schema files", req.PlanId)
 	}
@@ -1279,15 +1285,21 @@ func (c *LocalClient) materializeApplyRequestPlan(ctx context.Context, req *tern
 }
 
 // namespacesFromApplyRequest rebuilds per-namespace plan data from a dispatch
-// request. Table changes are grouped by namespace; vschema changes are omitted
-// because the apply path re-derives the vschema task from the namespace's
-// vschema.json artifact, which is recovered from the declarative schema files.
-func namespacesFromApplyRequest(changes []*ternv1.TableChange, schemaFiles schema.SchemaFiles, fallbackNamespace string) map[string]*storage.NamespacePlanData {
+// request so a deployment that did not plan locally applies exactly what the
+// primary deployment planned. Table changes are grouped by namespace (resolved
+// through planNamespace so the empty and MySQL "default" namespaces map to the
+// database, consistent with plan-time), and each operation is recovered from the
+// authoritative DDL. A vschema change is not a table change — it is applied from
+// the namespace's vschema.json artifact — so the artifact is attached only to
+// namespaces whose request carries an explicit vschema change, mirroring
+// plan-time behavior (the artifact is stored only when the plan detected a
+// change). Attaching it unconditionally would create spurious vschema_update
+// tasks on DDL-only plans, since Vitess always ships a vschema.json schema file.
+func (c *LocalClient) namespacesFromApplyRequest(changes []*ternv1.TableChange, schemaFiles schema.SchemaFiles) (map[string]*storage.NamespacePlanData, error) {
 	namespaces := map[string]*storage.NamespacePlanData{}
+	vschemaChangedNamespaces := map[string]bool{}
 	ensure := func(ns string) *storage.NamespacePlanData {
-		if ns == "" {
-			ns = fallbackNamespace
-		}
+		ns = c.planNamespace(ns)
 		if namespaces[ns] == nil {
 			namespaces[ns] = &storage.NamespacePlanData{}
 		}
@@ -1299,31 +1311,59 @@ func namespacesFromApplyRequest(changes []*ternv1.TableChange, schemaFiles schem
 			continue
 		}
 		if ch.ChangeType == ternv1.ChangeType_CHANGE_TYPE_VSCHEMA {
+			ensure(ch.Namespace)
+			vschemaChangedNamespaces[c.planNamespace(ch.Namespace)] = true
 			continue
+		}
+		op, err := materializedTableChangeOperation(ch)
+		if err != nil {
+			return nil, err
 		}
 		nsData := ensure(ch.Namespace)
 		nsData.Tables = append(nsData.Tables, storage.TableChange{
 			Namespace: ch.Namespace,
 			Table:     ch.TableName,
 			DDL:       ch.Ddl,
-			Operation: protoChangeTypeToDDLAction(ch.ChangeType),
+			Operation: op,
 		})
 	}
 
-	for ns, nsFiles := range schemaFiles {
-		if nsFiles == nil {
-			continue
+	for ns := range vschemaChangedNamespaces {
+		nsFiles := schemaFiles[ns]
+		vs := ""
+		if nsFiles != nil {
+			vs = nsFiles.Files[vSchemaArtifactName]
 		}
-		if vs, ok := nsFiles.Files[vSchemaArtifactName]; ok && vs != "" {
-			nsData := ensure(ns)
-			if nsData.Artifacts == nil {
-				nsData.Artifacts = map[string]string{}
-			}
-			nsData.Artifacts[vSchemaArtifactName] = vs
+		if vs == "" {
+			return nil, fmt.Errorf("apply request indicates a vschema change for namespace %q but carries no %s artifact", ns, vSchemaArtifactName)
 		}
+		nsData := namespaces[ns]
+		if nsData.Artifacts == nil {
+			nsData.Artifacts = map[string]string{}
+		}
+		nsData.Artifacts[vSchemaArtifactName] = vs
 	}
 
-	return namespaces
+	return namespaces, nil
+}
+
+// materializedTableChangeOperation recovers the storage operation for a
+// materialized table change. The proto change type is authoritative when it maps
+// to a known DDL action; otherwise the operation is classified from the request's
+// authoritative DDL so an unmapped change type does not persist an "unknown"
+// action that would resume as a no-op.
+func materializedTableChangeOperation(ch *ternv1.TableChange) (string, error) {
+	if op := protoChangeTypeToDDLAction(ch.ChangeType); op != "unknown" {
+		return op, nil
+	}
+	if strings.TrimSpace(ch.Ddl) == "" {
+		return "", fmt.Errorf("table change for %q has an unrecognized change type and no DDL to classify", ch.TableName)
+	}
+	op, _, err := ddl.ClassifyStatementOp(ch.Ddl)
+	if err != nil {
+		return "", fmt.Errorf("classify DDL for table %q: %w", ch.TableName, err)
+	}
+	return op, nil
 }
 
 // Apply executes a previously generated plan.

--- a/pkg/tern/local_plan_materialize_test.go
+++ b/pkg/tern/local_plan_materialize_test.go
@@ -1,0 +1,174 @@
+package tern
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	ternv1 "github.com/block/schemabot/pkg/proto/ternv1"
+	"github.com/block/schemabot/pkg/schema"
+	"github.com/block/schemabot/pkg/storage"
+)
+
+// fakePlanStore lets a test script the plan Get/Create behavior the plan
+// materialization path depends on.
+type fakePlanStore struct {
+	storage.PlanStore
+	getFn     func(planIdentifier string) (*storage.Plan, error)
+	createID  int64
+	createErr error
+	created   *storage.Plan
+}
+
+func (f *fakePlanStore) Get(_ context.Context, planIdentifier string) (*storage.Plan, error) {
+	return f.getFn(planIdentifier)
+}
+
+func (f *fakePlanStore) Create(_ context.Context, plan *storage.Plan) (int64, error) {
+	f.created = plan
+	return f.createID, f.createErr
+}
+
+type fakePlanStorage struct {
+	storage.Storage
+	plans storage.PlanStore
+}
+
+func (s *fakePlanStorage) Plans() storage.PlanStore { return s.plans }
+
+func newPlanMaterializeClient(plans storage.PlanStore) *LocalClient {
+	return &LocalClient{
+		config:  LocalConfig{Database: "testapp", Type: storage.DatabaseTypeMySQL},
+		storage: &fakePlanStorage{plans: plans},
+		logger:  slog.Default(),
+	}
+}
+
+// A deployment that planned locally resolves its own stored plan and never
+// materializes a new one from the dispatch request.
+func TestPlanForApplyRequest_LocalPlanWins(t *testing.T) {
+	existing := &storage.Plan{ID: 11, PlanIdentifier: "plan_local"}
+	store := &fakePlanStore{getFn: func(string) (*storage.Plan, error) { return existing, nil }}
+	c := newPlanMaterializeClient(store)
+
+	got, err := c.planForApplyRequest(t.Context(), &ternv1.ApplyRequest{
+		PlanId:     "plan_local",
+		DdlChanges: []*ternv1.TableChange{{TableName: "users", Ddl: "ALTER TABLE `users` ADD COLUMN `email` varchar(255)", ChangeType: ternv1.ChangeType_CHANGE_TYPE_ALTER}},
+	})
+
+	require.NoError(t, err)
+	assert.Same(t, existing, got)
+	assert.Nil(t, store.created, "must not materialize when a local plan exists")
+}
+
+// A non-primary deployment with no local plan materializes one from the
+// authoritative DDL changes and schema files carried by the dispatch request.
+func TestPlanForApplyRequest_MaterializesFromRequest(t *testing.T) {
+	store := &fakePlanStore{
+		getFn:    func(string) (*storage.Plan, error) { return nil, nil },
+		createID: 42,
+	}
+	c := newPlanMaterializeClient(store)
+
+	got, err := c.planForApplyRequest(t.Context(), &ternv1.ApplyRequest{
+		PlanId:      "plan_remote",
+		Environment: "staging",
+		Target:      "testapp-us",
+		DdlChanges: []*ternv1.TableChange{
+			{TableName: "users", Ddl: "ALTER TABLE `users` ADD COLUMN `email` varchar(255)", ChangeType: ternv1.ChangeType_CHANGE_TYPE_ALTER, Namespace: "testapp"},
+		},
+		SchemaFiles: map[string]*ternv1.SchemaFiles{
+			"testapp": {Files: map[string]string{"users.sql": "CREATE TABLE `users` ..."}},
+		},
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, int64(42), got.ID)
+	assert.Equal(t, "plan_remote", got.PlanIdentifier)
+	assert.Equal(t, "testapp", got.Database)
+	assert.Equal(t, "testapp-us", got.Target)
+	assert.Equal(t, "staging", got.Environment)
+
+	require.NotNil(t, store.created)
+	ns := store.created.Namespaces["testapp"]
+	require.NotNil(t, ns)
+	require.Len(t, ns.Tables, 1)
+	assert.Equal(t, "users", ns.Tables[0].Table)
+	assert.Equal(t, "alter", ns.Tables[0].Operation)
+	assert.Contains(t, store.created.SchemaFiles, "testapp")
+}
+
+// With no local plan and a request that carries no DDL or schema files there is
+// nothing to materialize, so the apply resolves to no plan (the caller then
+// returns the "plan not found" rejection).
+func TestPlanForApplyRequest_NoPayloadResolvesNil(t *testing.T) {
+	store := &fakePlanStore{getFn: func(string) (*storage.Plan, error) { return nil, nil }}
+	c := newPlanMaterializeClient(store)
+
+	got, err := c.planForApplyRequest(t.Context(), &ternv1.ApplyRequest{PlanId: "plan_missing"})
+
+	require.NoError(t, err)
+	assert.Nil(t, got)
+	assert.Nil(t, store.created)
+}
+
+// If two drivers race to materialize the same plan, the loser's Create fails on
+// the duplicate identifier and it reuses the winner's row instead of erroring.
+func TestPlanForApplyRequest_DuplicateCreateReloads(t *testing.T) {
+	winner := &storage.Plan{ID: 7, PlanIdentifier: "plan_race"}
+	calls := 0
+	store := &fakePlanStore{
+		getFn: func(string) (*storage.Plan, error) {
+			calls++
+			if calls == 1 {
+				return nil, nil // first lookup: not yet materialized
+			}
+			return winner, nil // reload after the duplicate Create
+		},
+		createErr: errors.New("duplicate plan_identifier"),
+	}
+	c := newPlanMaterializeClient(store)
+
+	got, err := c.planForApplyRequest(t.Context(), &ternv1.ApplyRequest{
+		PlanId:     "plan_race",
+		DdlChanges: []*ternv1.TableChange{{TableName: "users", Ddl: "ALTER TABLE `users` ADD COLUMN `email` varchar(255)", ChangeType: ternv1.ChangeType_CHANGE_TYPE_ALTER, Namespace: "testapp"}},
+	})
+
+	require.NoError(t, err)
+	assert.Same(t, winner, got)
+}
+
+// namespacesFromApplyRequest groups DDL by namespace, falls back to the client
+// database for unnamespaced changes, drops vschema table changes (re-derived at
+// apply time), and recovers the vschema artifact from the schema files.
+func TestNamespacesFromApplyRequest(t *testing.T) {
+	changes := []*ternv1.TableChange{
+		{TableName: "users", Ddl: "ALTER TABLE `users` ADD COLUMN `email` varchar(255)", ChangeType: ternv1.ChangeType_CHANGE_TYPE_ALTER, Namespace: "shop"},
+		{TableName: "orders", Ddl: "CREATE TABLE `orders` (`id` bigint)", ChangeType: ternv1.ChangeType_CHANGE_TYPE_CREATE, Namespace: ""},
+		{TableName: "VSchema: shop", ChangeType: ternv1.ChangeType_CHANGE_TYPE_VSCHEMA, Namespace: "shop"},
+	}
+	schemaFiles := schema.SchemaFiles{
+		"shop": {Files: map[string]string{vSchemaArtifactName: `{"sharded":true}`}},
+	}
+
+	got := namespacesFromApplyRequest(changes, schemaFiles, "fallbackdb")
+
+	require.Contains(t, got, "shop")
+	require.Contains(t, got, "fallbackdb")
+
+	shop := got["shop"]
+	require.Len(t, shop.Tables, 1, "vschema change must not become a table change")
+	assert.Equal(t, "users", shop.Tables[0].Table)
+	assert.Equal(t, "alter", shop.Tables[0].Operation)
+	assert.Equal(t, `{"sharded":true}`, shop.Artifacts[vSchemaArtifactName])
+
+	fallback := got["fallbackdb"]
+	require.Len(t, fallback.Tables, 1)
+	assert.Equal(t, "orders", fallback.Tables[0].Table)
+	assert.Equal(t, "create", fallback.Tables[0].Operation)
+}

--- a/pkg/tern/local_plan_materialize_test.go
+++ b/pkg/tern/local_plan_materialize_test.go
@@ -145,8 +145,10 @@ func TestPlanForApplyRequest_DuplicateCreateReloads(t *testing.T) {
 
 // namespacesFromApplyRequest groups DDL by namespace, falls back to the client
 // database for unnamespaced changes, drops vschema table changes (re-derived at
-// apply time), and recovers the vschema artifact from the schema files.
+// apply time), and recovers the vschema artifact from the schema files only for
+// namespaces with an explicit vschema change.
 func TestNamespacesFromApplyRequest(t *testing.T) {
+	c := newPlanMaterializeClient(&fakePlanStore{})
 	changes := []*ternv1.TableChange{
 		{TableName: "users", Ddl: "ALTER TABLE `users` ADD COLUMN `email` varchar(255)", ChangeType: ternv1.ChangeType_CHANGE_TYPE_ALTER, Namespace: "shop"},
 		{TableName: "orders", Ddl: "CREATE TABLE `orders` (`id` bigint)", ChangeType: ternv1.ChangeType_CHANGE_TYPE_CREATE, Namespace: ""},
@@ -156,10 +158,11 @@ func TestNamespacesFromApplyRequest(t *testing.T) {
 		"shop": {Files: map[string]string{vSchemaArtifactName: `{"sharded":true}`}},
 	}
 
-	got := namespacesFromApplyRequest(changes, schemaFiles, "fallbackdb")
+	got, err := c.namespacesFromApplyRequest(changes, schemaFiles)
+	require.NoError(t, err)
 
 	require.Contains(t, got, "shop")
-	require.Contains(t, got, "fallbackdb")
+	require.Contains(t, got, "testapp")
 
 	shop := got["shop"]
 	require.Len(t, shop.Tables, 1, "vschema change must not become a table change")
@@ -167,8 +170,74 @@ func TestNamespacesFromApplyRequest(t *testing.T) {
 	assert.Equal(t, "alter", shop.Tables[0].Operation)
 	assert.Equal(t, `{"sharded":true}`, shop.Artifacts[vSchemaArtifactName])
 
-	fallback := got["fallbackdb"]
+	fallback := got["testapp"]
 	require.Len(t, fallback.Tables, 1)
 	assert.Equal(t, "orders", fallback.Tables[0].Table)
 	assert.Equal(t, "create", fallback.Tables[0].Operation)
+}
+
+// A DDL-only request whose schema files still carry vschema.json (the common
+// Vitess case) must not attach the vschema artifact, so Apply() does not create
+// a spurious vschema_update task.
+func TestNamespacesFromApplyRequest_DDLOnlyOmitsVSchemaArtifact(t *testing.T) {
+	c := newPlanMaterializeClient(&fakePlanStore{})
+	changes := []*ternv1.TableChange{
+		{TableName: "users", Ddl: "ALTER TABLE `users` ADD COLUMN `email` varchar(255)", ChangeType: ternv1.ChangeType_CHANGE_TYPE_ALTER, Namespace: "shop"},
+	}
+	schemaFiles := schema.SchemaFiles{
+		"shop": {Files: map[string]string{vSchemaArtifactName: `{"sharded":true}`}},
+	}
+
+	got, err := c.namespacesFromApplyRequest(changes, schemaFiles)
+	require.NoError(t, err)
+
+	require.Contains(t, got, "shop")
+	assert.Empty(t, got["shop"].Artifacts[vSchemaArtifactName], "DDL-only request must not materialize a vschema artifact")
+}
+
+// A vschema change with no vschema.json artifact in the schema files fails
+// closed rather than silently dropping the vschema update.
+func TestNamespacesFromApplyRequest_VSchemaChangeWithoutArtifactFailsClosed(t *testing.T) {
+	c := newPlanMaterializeClient(&fakePlanStore{})
+	changes := []*ternv1.TableChange{
+		{TableName: "VSchema: shop", ChangeType: ternv1.ChangeType_CHANGE_TYPE_VSCHEMA, Namespace: "shop"},
+	}
+
+	_, err := c.namespacesFromApplyRequest(changes, schema.SchemaFiles{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "vschema change")
+}
+
+// MySQL treats the literal "default" namespace as the database namespace, so a
+// change carrying Namespace="default" is grouped under the database, consistent
+// with planNamespace at plan time.
+func TestNamespacesFromApplyRequest_DefaultNamespaceMapsToDatabase(t *testing.T) {
+	c := newPlanMaterializeClient(&fakePlanStore{})
+	changes := []*ternv1.TableChange{
+		{TableName: "users", Ddl: "ALTER TABLE `users` ADD COLUMN `email` varchar(255)", ChangeType: ternv1.ChangeType_CHANGE_TYPE_ALTER, Namespace: "default"},
+	}
+
+	got, err := c.namespacesFromApplyRequest(changes, schema.SchemaFiles{})
+	require.NoError(t, err)
+
+	require.Contains(t, got, "testapp")
+	assert.NotContains(t, got, "default")
+	require.Len(t, got["testapp"].Tables, 1)
+	assert.Equal(t, "users", got["testapp"].Tables[0].Table)
+}
+
+// An unmapped change type recovers a real operation from the request's
+// authoritative DDL instead of persisting "unknown".
+func TestNamespacesFromApplyRequest_UnmappedChangeTypeClassifiesDDL(t *testing.T) {
+	c := newPlanMaterializeClient(&fakePlanStore{})
+	changes := []*ternv1.TableChange{
+		{TableName: "orders", Ddl: "CREATE TABLE `orders` (`id` bigint)", ChangeType: ternv1.ChangeType_CHANGE_TYPE_OTHER, Namespace: ""},
+	}
+
+	got, err := c.namespacesFromApplyRequest(changes, schema.SchemaFiles{})
+	require.NoError(t, err)
+
+	require.Contains(t, got, "testapp")
+	require.Len(t, got["testapp"].Tables, 1)
+	assert.Equal(t, "create", got["testapp"].Tables[0].Operation)
 }

--- a/pkg/tern/state_converters.go
+++ b/pkg/tern/state_converters.go
@@ -150,6 +150,25 @@ func ddlActionToProtoChangeType(action string) ternv1.ChangeType {
 	}
 }
 
+// protoChangeTypeToDDLAction converts a proto ChangeType back to the lowercase
+// DDLAction string used in storage. It is the inverse of
+// ddlActionToProtoChangeType and is used to rebuild a plan's table changes from
+// a dispatch request on a deployment that did not plan locally.
+func protoChangeTypeToDDLAction(ct ternv1.ChangeType) string {
+	switch ct {
+	case ternv1.ChangeType_CHANGE_TYPE_VSCHEMA:
+		return "vschema_update"
+	case ternv1.ChangeType_CHANGE_TYPE_CREATE:
+		return ddl.StatementTypeToOp(statement.StatementCreateTable)
+	case ternv1.ChangeType_CHANGE_TYPE_ALTER:
+		return ddl.StatementTypeToOp(statement.StatementAlterTable)
+	case ternv1.ChangeType_CHANGE_TYPE_DROP:
+		return ddl.StatementTypeToOp(statement.StatementDropTable)
+	default:
+		return "unknown"
+	}
+}
+
 // filterTasksByApply returns only tasks belonging to the specified apply, sorted by ID (execution order).
 func filterTasksByApply(tasks []*storage.Task, applyID int64) []*storage.Task {
 	var filtered []*storage.Task


### PR DESCRIPTION
## What

When a Tern deployment receives an apply but has no local plan row, it now
materializes the plan from the DDL changes and schema files already carried in
the dispatch request, instead of rejecting with "plan not found".

## Why

Plans are created on the **primary** deployment only. In a multi-deployment
apply, each non-primary deployment drives against its own Tern (with its own
storage), which never planned locally — so `LocalClient.Apply` could not resolve
the plan. The dispatch request already carries the authoritative DDL + schema
files, so the non-primary deployment can apply exactly what the primary planned.

PLAN TIME (primary only)        APPLY DRIVE (per operation, gRPC)
ExecutePlan -> tern-eu          op eu -> tern-eu.Apply(planId)
plan row in eu storage          Plans().Get  found -> apply

                      BEFORE  op us -> tern-us.Apply(planId)
                                Plans().Get  nil  -> "plan not found" X

                      AFTER   op us -> tern-us.Apply(planId, DdlChanges, SchemaFiles)
                                Plans().Get  nil  -> materialize from payload -> apply

Single-deployment behavior is unchanged (the local plan row always wins).
Materialization can only trigger once the `>1 deployments` config guard is
lifted, so this is dormant-safe and covered by unit tests now. Vschema changes
are re-derived at apply time from the recovered `vschema.json` artifact.
