### PR TITLE
feat(api): serve multi-operation apply progress and control from storage

### DIFF
--- a/pkg/api/control_handlers.go
+++ b/pkg/api/control_handlers.go
@@ -532,7 +532,13 @@ func (s *Service) executeCutoverForApply(ctx context.Context, client tern.Client
 		s.wakeOperator(apply.ApplyIdentifier, apply.Database, apply.Environment)
 		return &apitypes.ControlResponse{Accepted: true}, http.StatusAccepted, nil
 	}
-	readiness, err := s.cutoverRequestReadiness(ctx, client, apply, ternApplyID)
+	multiOp, err := s.applyHasMultipleOperations(ctx, apply)
+	if err != nil {
+		err := fmt.Errorf("check operation count for apply %s before cutover: %w", apply.ApplyIdentifier, err)
+		metrics.RecordControlOperation(ctx, "cutover", apply.Database, apply.Deployment, apply.Environment, "error")
+		return nil, 0, err
+	}
+	readiness, err := s.cutoverRequestReadiness(ctx, client, apply, ternApplyID, multiOp)
 	if err != nil {
 		err := fmt.Errorf("check cutover readiness for apply %s: %w", apply.ApplyIdentifier, err)
 		metrics.RecordControlOperation(ctx, "cutover", apply.Database, apply.Deployment, apply.Environment, "error")
@@ -607,7 +613,7 @@ const (
 	cutoverRequestRecovering
 )
 
-func (s *Service) cutoverRequestReadiness(ctx context.Context, client tern.Client, apply *storage.Apply, ternApplyID string) (cutoverRequestReadiness, error) {
+func (s *Service) cutoverRequestReadiness(ctx context.Context, client tern.Client, apply *storage.Apply, ternApplyID string, multiOp bool) (cutoverRequestReadiness, error) {
 	if state.IsState(apply.State, state.Apply.WaitingForCutover) {
 		return cutoverRequestReady, nil
 	}
@@ -617,7 +623,12 @@ func (s *Service) cutoverRequestReadiness(ctx context.Context, client tern.Clien
 	if state.IsState(apply.State, state.Apply.Recovering) {
 		return cutoverRequestRecovering, nil
 	}
-	if client != nil && client.IsRemote() && ternApplyID != "" {
+	// A multi-operation apply has no single remote data-plane apply id, so a
+	// remote probe keyed on one ternApplyID would report at most one operation's
+	// readiness. Derive readiness from the stored task rows below, which span
+	// every operation of the apply, and let the operator drive cutover per
+	// operation.
+	if !multiOp && client != nil && client.IsRemote() && ternApplyID != "" {
 		progress, err := client.Progress(ctx, &ternv1.ProgressRequest{
 			ApplyId:     ternApplyID,
 			Environment: apply.Environment,
@@ -752,6 +763,22 @@ func (s *Service) executeStopForApply(ctx context.Context, client tern.Client, a
 }
 
 func (s *Service) tryImmediateStopAfterQueue(ctx context.Context, client tern.Client, apply *storage.Apply, ternApplyID, environment, caller string) {
+	// A multi-operation apply has no single data-plane apply id: each operation
+	// drives against its own deployment with its own remote apply. An apply-scoped
+	// immediate stop keyed on a single ternApplyID would stop at most one operation
+	// and leave its siblings running. Skip the immediate attempt and let the
+	// operator fan the durable stop request out to every operation and reconcile
+	// the aggregate. The durable stop request is already queued at this point.
+	if multiOp, err := s.applyHasMultipleOperations(ctx, apply); err != nil {
+		s.logger.Warn("could not determine apply operation count; attempting single-deployment immediate stop",
+			"apply_id", apply.ApplyIdentifier, "database", apply.Database, "environment", apply.Environment, "error", err)
+	} else if multiOp {
+		s.logger.Info("immediate stop skipped for multi-operation apply; operator will fan out the durable stop request per operation",
+			"apply_id", apply.ApplyIdentifier, "database", apply.Database, "environment", apply.Environment, "requested_by", caller)
+		s.logControlOperationForApply(ctx, apply, caller, storage.LogEventStopRequested,
+			"Stop queued; operator will stop each deployment of this multi-deployment apply")
+		return
+	}
 	if client == nil {
 		s.logger.Warn("immediate stop not attempted because Tern client is unavailable; durable stop request remains pending for apply owner retry",
 			"apply_id", apply.ApplyIdentifier,

--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -869,6 +869,18 @@ func newControlTestServiceWithTasks(client tern.Client, apply *storage.Apply, ta
 	}, logger)
 }
 
+func newControlTestServiceWithOperations(client tern.Client, apply *storage.Apply, tasks []*storage.Task, operations []*storage.ApplyOperation) *Service {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	return New(&mockStorageWithApplyStores{
+		applies:    &staticApplyStore{apply: apply},
+		tasks:      &capturingTaskStore{tasks: tasks},
+		controls:   &memoryControlRequestStore{},
+		operations: &staticApplyOperationStore{operations: operations},
+	}, testServerConfig(), map[string]tern.Client{
+		"default/staging": client,
+	}, logger)
+}
+
 func newTestService() *Service {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
 	return New(&mockStorage{}, testServerConfig(), nil, logger)
@@ -2381,8 +2393,8 @@ func newActiveProgressServiceWithOperations(client tern.Client, apply *storage.A
 }
 
 func TestProgressByApplyIDActivePathIncludesOperations(t *testing.T) {
-	// The active (proto Progress RPC) path enriches the response with the
-	// apply's per-deployment operation rows from control-plane storage.
+	// A single-operation active apply reaches the proto Progress RPC path and
+	// enriches the response with its operation row from control-plane storage.
 	mock := &mockTernClient{
 		isRemote:     true,
 		progressResp: &ternv1.ProgressResponse{State: ternv1.State_STATE_RUNNING},
@@ -2391,7 +2403,6 @@ func TestProgressByApplyIDActivePathIncludesOperations(t *testing.T) {
 	apply.ExternalID = "remote-active-ops"
 	operations := &staticApplyOperationStore{operations: []*storage.ApplyOperation{
 		{ID: 1, ApplyID: apply.ID, Deployment: "deploy-a", Target: "target-a", State: state.ApplyOperation.Running},
-		{ID: 2, ApplyID: apply.ID, Deployment: "deploy-b", Target: "target-b", State: state.ApplyOperation.Failed, ErrorMessage: "engine failed"},
 	}}
 	svc := newActiveProgressServiceWithOperations(mock, apply, operations)
 	mux := http.NewServeMux()
@@ -2402,10 +2413,43 @@ func TestProgressByApplyIDActivePathIncludesOperations(t *testing.T) {
 	mux.ServeHTTP(w, req)
 
 	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
-	require.NotNil(t, mock.progressReq, "active apply must reach the proto Progress RPC path")
+	require.NotNil(t, mock.progressReq, "single-operation active apply must reach the proto Progress RPC path")
 
 	var resp apitypes.ProgressResponse
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Len(t, resp.Operations, 1)
+	assert.Equal(t, "deploy-a", resp.Operations[0].Deployment)
+	assert.Equal(t, state.ApplyOperation.Running, resp.Operations[0].State)
+}
+
+func TestProgressByApplyIDMultiOperationServedFromStorage(t *testing.T) {
+	// A multi-operation apply has no single data-plane apply id, so its progress
+	// is served from storage: the proto Progress RPC is not called, the headline
+	// state is the stored aggregate, and every operation row is included.
+	mock := &mockTernClient{
+		isRemote:     true,
+		progressResp: &ternv1.ProgressResponse{State: ternv1.State_STATE_RUNNING},
+	}
+	apply := activeTestApply("apply-multi-ops")
+	apply.ExternalID = "remote-multi-ops"
+	operations := &staticApplyOperationStore{operations: []*storage.ApplyOperation{
+		{ID: 1, ApplyID: apply.ID, Deployment: "deploy-a", Target: "target-a", State: state.ApplyOperation.Running},
+		{ID: 2, ApplyID: apply.ID, Deployment: "deploy-b", Target: "target-b", State: state.ApplyOperation.Failed, ErrorMessage: "engine failed"},
+	}}
+	svc := newActiveProgressServiceWithOperations(mock, apply, operations)
+	mux := http.NewServeMux()
+	svc.ConfigureRoutes(mux)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/progress/apply/apply-multi-ops", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	require.Nil(t, mock.progressReq, "multi-operation apply must not call the single-deployment proto Progress RPC")
+
+	var resp apitypes.ProgressResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, state.Apply.Running, resp.State)
 	require.Len(t, resp.Operations, 2)
 	assert.Equal(t, "deploy-a", resp.Operations[0].Deployment)
 	assert.Equal(t, state.ApplyOperation.Running, resp.Operations[0].State)
@@ -3552,6 +3596,36 @@ func TestStopHandler(t *testing.T) {
 		assert.Equal(t, http.StatusBadRequest, w.Code)
 		assert.Contains(t, w.Body.String(), "environment is required")
 	})
+
+	t.Run("multi-operation apply queues durable stop without an immediate single-deployment stop", func(t *testing.T) {
+		// A multi-operation apply has no single data-plane apply id, so the
+		// immediate stop is skipped: the durable request is queued for the
+		// operator to fan out per operation, and the single-deployment remote
+		// Stop RPC is never called.
+		mock := &mockTernClient{isRemote: true, stopResp: &ternv1.StopResponse{Accepted: true}}
+		apply := activeTestApply("apply-multi-stop")
+		tasks := []*storage.Task{
+			{ID: 30, TaskIdentifier: "task-multi-stop", ApplyID: apply.ID, State: state.Task.Running},
+		}
+		svc := newControlTestServiceWithOperations(mock, apply, tasks, []*storage.ApplyOperation{
+			{ID: 1, ApplyID: apply.ID, Deployment: "deploy-a", Target: "target-a", State: state.ApplyOperation.Running},
+			{ID: 2, ApplyID: apply.ID, Deployment: "deploy-b", Target: "target-b", State: state.ApplyOperation.Running},
+		})
+		mux := http.NewServeMux()
+		svc.ConfigureRoutes(mux)
+
+		body := `{"environment": "staging", "apply_id": "apply-multi-stop"}`
+		req := httptest.NewRequestWithContext(t.Context(), "POST", "/api/stop", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
+		assert.Nil(t, mock.stopReq, "multi-operation apply must not issue a single-deployment immediate stop")
+		controlReq, err := svc.storage.ControlRequests().GetPending(t.Context(), apply.ID, storage.ControlOperationStop)
+		require.NoError(t, err)
+		require.NotNil(t, controlReq, "durable stop request must be queued for the operator")
+	})
 }
 
 func TestStartHandler(t *testing.T) {
@@ -4326,6 +4400,37 @@ func TestCutoverHandler(t *testing.T) {
 
 		assert.Equal(t, http.StatusBadRequest, w.Code)
 		assert.Contains(t, w.Body.String(), "environment is required")
+	})
+
+	t.Run("multi-operation apply derives cutover readiness from storage, not a single remote probe", func(t *testing.T) {
+		// A multi-operation apply has no single remote data-plane apply id, so
+		// readiness is derived from the stored task rows that span every
+		// operation — the single-deployment remote progress probe is not called —
+		// and the durable cutover request is queued for the operator.
+		mock := &mockTernClient{isRemote: true}
+		apply := activeTestApply("apply-multi-cutover")
+		tasks := []*storage.Task{
+			{ID: 40, TaskIdentifier: "task-multi-cutover", ApplyID: apply.ID, State: state.Task.WaitingForCutover},
+		}
+		svc := newControlTestServiceWithOperations(mock, apply, tasks, []*storage.ApplyOperation{
+			{ID: 1, ApplyID: apply.ID, Deployment: "deploy-a", Target: "target-a", State: state.ApplyOperation.WaitingForCutover},
+			{ID: 2, ApplyID: apply.ID, Deployment: "deploy-b", Target: "target-b", State: state.ApplyOperation.WaitingForCutover},
+		})
+		mux := http.NewServeMux()
+		svc.ConfigureRoutes(mux)
+
+		body := `{"environment": "staging", "apply_id": "apply-multi-cutover", "caller": "cli:cutter"}`
+		req := httptest.NewRequestWithContext(t.Context(), "POST", "/api/cutover", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
+		assert.Nil(t, mock.progressReq, "multi-operation apply must not probe a single-deployment remote for cutover readiness")
+		assert.Nil(t, mock.cutoverReq, "request path should queue operator work without calling Tern cutover")
+		controlReq, err := svc.storage.ControlRequests().GetPending(t.Context(), apply.ID, storage.ControlOperationCutover)
+		require.NoError(t, err)
+		require.NotNil(t, controlReq, "durable cutover request must be queued for the operator")
 	})
 }
 

--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -2457,6 +2457,50 @@ func TestProgressByApplyIDMultiOperationServedFromStorage(t *testing.T) {
 	assert.Equal(t, "engine failed", resp.Operations[1].ErrorMessage)
 }
 
+func TestProgressByApplyIDMultiOperationFallsBackToSingleDeploymentOnStorageError(t *testing.T) {
+	// A multi-operation apply is normally served from storage, but if the
+	// storage read fails the handler must fall back to the single-deployment
+	// path rather than fail the request: every apply created today has one
+	// operation, so this only degrades the dormant multi-op case.
+	mock := &mockTernClient{
+		isRemote:     true,
+		progressResp: &ternv1.ProgressResponse{State: ternv1.State_STATE_RUNNING},
+	}
+	apply := activeTestApply("apply-multi-ops-fallback")
+	apply.ExternalID = "remote-multi-ops-fallback"
+	operations := &staticApplyOperationStore{operations: []*storage.ApplyOperation{
+		{ID: 1, ApplyID: apply.ID, Deployment: "deploy-a", Target: "target-a", State: state.ApplyOperation.Running},
+		{ID: 2, ApplyID: apply.ID, Deployment: "deploy-b", Target: "target-b", State: state.ApplyOperation.Running},
+	}}
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	svc := New(&mockStorageWithApplyStores{
+		applies:    &staticApplyStore{apply: apply},
+		tasks:      &capturingTaskStore{err: errors.New("tasks store unavailable")},
+		controls:   &memoryControlRequestStore{},
+		operations: operations,
+	}, testServerConfig(), map[string]tern.Client{
+		"default/staging": mock,
+	}, logger)
+	mux := http.NewServeMux()
+	svc.ConfigureRoutes(mux)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/progress/apply/apply-multi-ops-fallback", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	require.NotNil(t, mock.progressReq, "storage-error fallback must reach the single-deployment proto Progress RPC path")
+
+	var resp apitypes.ProgressResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, state.Apply.Running, resp.State)
+	// Operation rows were listed successfully, so the per-deployment enrichment
+	// is still present even though the storage progress read fell back.
+	require.Len(t, resp.Operations, 2)
+	assert.Equal(t, "deploy-a", resp.Operations[0].Deployment)
+	assert.Equal(t, "deploy-b", resp.Operations[1].Deployment)
+}
+
 func TestProgressByApplyIDActivePathToleratesOperationStorageError(t *testing.T) {
 	// Operation enrichment is observability, not a safety gate: a storage error
 	// from ListByApply must omit operations rather than fail the request.

--- a/pkg/api/progress_handlers.go
+++ b/pkg/api/progress_handlers.go
@@ -115,6 +115,22 @@ func progressTableKey(namespace, table string) string {
 	return namespace + progressTableKeySep + table
 }
 
+// applyHasMultipleOperations reports whether an apply fanned out to more than
+// one deployment operation. A multi-operation apply has no single data-plane
+// apply id — each operation carries its own — and its aggregate state is
+// derived by the operator from the operation rows, so apply-scoped routing to a
+// single primary remote id (progress, immediate control) must be avoided.
+func (s *Service) applyHasMultipleOperations(ctx context.Context, apply *storage.Apply) (bool, error) {
+	if apply == nil {
+		return false, fmt.Errorf("apply is required")
+	}
+	ops, err := s.storage.ApplyOperations().ListByApply(ctx, apply.ID)
+	if err != nil {
+		return false, fmt.Errorf("list apply operations for apply %d (%s): %w", apply.ID, apply.ApplyIdentifier, err)
+	}
+	return len(ops) > 1, nil
+}
+
 func storedDeploymentForApply(apply *storage.Apply) (string, error) {
 	if apply == nil {
 		return "", fmt.Errorf("apply is required")
@@ -280,6 +296,28 @@ func (s *Service) handleProgressByApplyID(w http.ResponseWriter, r *http.Request
 		httpResp, err := s.progressFromLocalStorage(r.Context(), apply)
 		if err != nil {
 			s.logger.Error("failed to read apply progress from storage", "apply_id", applyID, "state", apply.State, "error", err)
+			s.writeErrorCode(w, http.StatusInternalServerError, apitypes.ErrCodeStorageError, "failed to read tasks: "+err.Error())
+			return
+		}
+		s.writeJSON(w, http.StatusOK, httpResp)
+		return
+	}
+
+	// A multi-operation apply has no single remote data-plane id — each
+	// operation carries its own — and its aggregate state is derived by the
+	// operator from the operation rows. Serve it from storage so operators see
+	// the real aggregate state and the per-deployment breakdown, not a
+	// single-deployment remote view keyed on a parent id that does not exist
+	// (which would also rewrite a running aggregate to pending). On a storage
+	// error, fall back to the single-deployment path: every apply created today
+	// has one operation, so this only degrades the dormant multi-op case.
+	if multiOp, err := s.applyHasMultipleOperations(r.Context(), apply); err != nil {
+		s.logger.Warn("could not determine apply operation count; serving progress via the single-deployment path",
+			"apply_id", applyID, "database", apply.Database, "environment", apply.Environment, "error", err)
+	} else if multiOp {
+		httpResp, err := s.progressFromLocalStorage(r.Context(), apply)
+		if err != nil {
+			s.logger.Error("failed to read multi-operation apply progress from storage", "apply_id", applyID, "state", apply.State, "error", err)
 			s.writeErrorCode(w, http.StatusInternalServerError, apitypes.ErrCodeStorageError, "failed to read tasks: "+err.Error())
 			return
 		}

--- a/pkg/api/progress_handlers.go
+++ b/pkg/api/progress_handlers.go
@@ -240,13 +240,23 @@ func (s *Service) progressOperationsForApply(ctx context.Context, apply *storage
 	if err != nil {
 		return nil, nil, fmt.Errorf("list apply operations for apply %d (%s): %w", apply.ID, apply.ApplyIdentifier, err)
 	}
+	responses, deploymentByOperationID := progressOperationsFromRows(ops)
+	return responses, deploymentByOperationID, nil
+}
+
+// progressOperationsFromRows projects already-fetched operation rows into the
+// API response shape and the operation-id→deployment map. Keeping the
+// transformation separate from the storage read lets a single ListByApply
+// result feed both multi-operation detection and per-deployment enrichment on
+// the polled progress path.
+func progressOperationsFromRows(ops []*storage.ApplyOperation) ([]*apitypes.ProgressOperationResponse, map[int64]string) {
 	responses := make([]*apitypes.ProgressOperationResponse, 0, len(ops))
 	deploymentByOperationID := make(map[int64]string, len(ops))
 	for _, op := range ops {
 		responses = append(responses, progressOperationResponseFromStorage(op))
 		deploymentByOperationID[op.ID] = op.Deployment
 	}
-	return responses, deploymentByOperationID, nil
+	return responses, deploymentByOperationID
 }
 
 func (s *Service) bestEffortProgressOperations(ctx context.Context, apply *storage.Apply) ([]*apitypes.ProgressOperationResponse, map[int64]string) {
@@ -303,6 +313,15 @@ func (s *Service) handleProgressByApplyID(w http.ResponseWriter, r *http.Request
 		return
 	}
 
+	// List the operation rows once: the result drives both multi-operation
+	// detection here and the per-deployment enrichment on the single-deployment
+	// path below, so a polled progress read hits apply_operations a single time.
+	ops, opsErr := s.storage.ApplyOperations().ListByApply(r.Context(), apply.ID)
+	if opsErr != nil {
+		s.logger.Warn("could not determine apply operation count; serving progress via the single-deployment path",
+			"apply_id", applyID, "database", apply.Database, "environment", apply.Environment, "error", opsErr)
+	}
+
 	// A multi-operation apply has no single remote data-plane id — each
 	// operation carries its own — and its aggregate state is derived by the
 	// operator from the operation rows. Serve it from storage so operators see
@@ -311,18 +330,15 @@ func (s *Service) handleProgressByApplyID(w http.ResponseWriter, r *http.Request
 	// (which would also rewrite a running aggregate to pending). On a storage
 	// error, fall back to the single-deployment path: every apply created today
 	// has one operation, so this only degrades the dormant multi-op case.
-	if multiOp, err := s.applyHasMultipleOperations(r.Context(), apply); err != nil {
-		s.logger.Warn("could not determine apply operation count; serving progress via the single-deployment path",
-			"apply_id", applyID, "database", apply.Database, "environment", apply.Environment, "error", err)
-	} else if multiOp {
+	if opsErr == nil && len(ops) > 1 {
 		httpResp, err := s.progressFromLocalStorage(r.Context(), apply)
 		if err != nil {
-			s.logger.Error("failed to read multi-operation apply progress from storage", "apply_id", applyID, "state", apply.State, "error", err)
-			s.writeErrorCode(w, http.StatusInternalServerError, apitypes.ErrCodeStorageError, "failed to read tasks: "+err.Error())
+			s.logger.Warn("failed to read multi-operation apply progress from storage; falling back to the single-deployment path",
+				"apply_id", applyID, "state", apply.State, "error", err)
+		} else {
+			s.writeJSON(w, http.StatusOK, httpResp)
 			return
 		}
-		s.writeJSON(w, http.StatusOK, httpResp)
-		return
 	}
 
 	// Active apply — use the deployment stored on the apply record.
@@ -367,7 +383,12 @@ func (s *Service) handleProgressByApplyID(w http.ResponseWriter, r *http.Request
 	}
 
 	httpResp := progressResponseFromProto(resp)
-	httpResp.Operations, _ = s.bestEffortProgressOperations(r.Context(), apply)
+	// Reuse the operation rows already listed above for multi-op detection.
+	// Operation rows are observability enrichment, not an apply safety gate, so
+	// a storage error (already logged) just omits the per-deployment breakdown.
+	if opsErr == nil {
+		httpResp.Operations, _ = progressOperationsFromRows(ops)
+	}
 	httpResp.ApplyID = apply.ApplyIdentifier
 	httpResp.Database = apply.Database
 	httpResp.Environment = apply.Environment


### PR DESCRIPTION
## What

A multi-operation apply (one apply fanned out to N deployment operations) has no
single data-plane apply id — each operation carries its own. This routes its
progress and control through storage / the operator instead of a single primary
remote apply id:

- **Progress** — a multi-op apply is served from storage (real aggregate state +
  per-deployment breakdown) rather than a single-deployment remote probe keyed on
  a parent id that does not exist.
- **Stop** — the immediate single-deployment stop is skipped; the durable stop
  request is queued for the operator to fan out per operation.
- **Cutover** — readiness is derived from the stored task rows that span every
  operation, not a single remote progress probe.

## Why

Plans/applies fan out to N operations, each driving against its own deployment
(its own remote Tern). An apply-scoped immediate stop or remote progress/cutover
probe keyed on one ternApplyId would touch at most one operation and misreport or
mis-control its siblings.
```
                PROGRESS / STOP / CUTOVER for an apply
BEFORE  apply ──▶ single primary remote id ──▶ probes/stops one op only ✗
```

```
AFTER   1 op   ──▶ proto RPC + op-row enrichment            (unchanged)
N ops  ──▶ storage aggregate + per-op breakdown
stop: queue durable intent, operator fans out
cutover: readiness from stored tasks (all ops)
```
Dormant for single-operation applies (every apply owns one operation today); on a
storage error the progress path falls back to the single-deployment path.
