### PR TITLE
fix(storage): retry lock Acquire on transient InnoDB deadlock

### DIFF
--- a/pkg/storage/mysqlstore/locks.go
+++ b/pkg/storage/mysqlstore/locks.go
@@ -7,7 +7,9 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"math/rand/v2"
 	"strings"
+	"time"
 
 	"github.com/block/schemabot/pkg/storage"
 	"github.com/block/spirit/pkg/utils"
@@ -17,6 +19,16 @@ import (
 // lockColumns lists all columns for SELECT queries.
 const lockColumns = `id, database_name, database_type, repository, pull_request, owner,
 	pending_plan_id, created_at, updated_at`
+
+// acquireMaxAttempts bounds how many times Acquire retries a transient lock
+// conflict before giving up. Concurrent same-owner callers racing to claim the
+// same key can make InnoDB pick one as a deadlock victim; the victim is rolled
+// back, so a bounded retry resolves the race.
+const acquireMaxAttempts = 5
+
+// acquireBaseBackoff is the first retry delay; it grows exponentially with
+// full jitter on each subsequent attempt.
+const acquireBaseBackoff = 5 * time.Millisecond
 
 // lockStore implements storage.LockStore using MySQL.
 type lockStore struct {
@@ -32,6 +44,30 @@ type lockStore struct {
 // confirm command loads. A re-acquire that passes an empty PendingPlanID (CLI)
 // leaves the existing value intact.
 func (s *lockStore) Acquire(ctx context.Context, lock *storage.Lock) error {
+	var lastErr error
+	for attempt := range acquireMaxAttempts {
+		if attempt > 0 {
+			if err := sleepBackoff(ctx, attempt); err != nil {
+				return err
+			}
+		}
+		err := s.acquireOnce(ctx, lock)
+		if err == nil {
+			return nil
+		}
+		if !isRetryableLockError(err) {
+			return err
+		}
+		lastErr = err
+	}
+	return fmt.Errorf("acquire lock for %s/%s owner=%s after %d attempts: %w",
+		lock.DatabaseName, lock.DatabaseType, lock.Owner, acquireMaxAttempts, lastErr)
+}
+
+// acquireOnce performs a single claim attempt. Concurrent same-owner callers
+// racing to claim the same key can hit a transient InnoDB lock conflict on the
+// INSERT below; Acquire retries those.
+func (s *lockStore) acquireOnce(ctx context.Context, lock *storage.Lock) error {
 	existing, err := s.Get(ctx, lock.DatabaseName, lock.DatabaseType)
 	if err != nil {
 		return fmt.Errorf("read existing lock for %s/%s: %w", lock.DatabaseName, lock.DatabaseType, err)
@@ -289,4 +325,38 @@ func isDuplicateKeyError(err error) bool {
 		return true
 	}
 	return err != nil && strings.Contains(err.Error(), "Duplicate entry")
+}
+
+// MySQL error codes for transient lock contention. InnoDB picks a deadlock
+// victim (1213) or times out a lock wait (1205) when callers race for the same
+// rows; both roll the statement back, so the caller can safely retry.
+const (
+	mysqlErrDeadlock        = 1213
+	mysqlErrLockWaitTimeout = 1205
+)
+
+// isRetryableLockError reports whether err is a transient InnoDB lock conflict
+// that resolves on retry: a deadlock victim or a lock-wait timeout. Both leave
+// the database unchanged, so re-running the operation is safe.
+func isRetryableLockError(err error) bool {
+	var mysqlErr *gomysql.MySQLError
+	if !errors.As(err, &mysqlErr) {
+		return false
+	}
+	return mysqlErr.Number == mysqlErrDeadlock || mysqlErr.Number == mysqlErrLockWaitTimeout
+}
+
+// sleepBackoff waits before the next retry using exponential backoff with full
+// jitter, returning early if the context is cancelled.
+func sleepBackoff(ctx context.Context, attempt int) error {
+	maxDelay := acquireBaseBackoff << (attempt - 1)
+	delay := time.Duration(rand.Int64N(int64(maxDelay) + 1))
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
 }


### PR DESCRIPTION
## Summary

`lockStore.Acquire` could fail spuriously when multiple same-owner callers raced
to claim the same lock key concurrently. This makes the claim resilient to
transient InnoDB lock conflicts by retrying them.

## Why (root cause)

Two concurrent applies for the same PR and database (e.g. a staging and a
production apply-confirm) share one owner and one lock key, so both are expected
to succeed. They both fall through `Get` (no row yet) and race on the same
`INSERT` into the `UNIQUE(database_name, database_type)` key.

Under that contention InnoDB does not always return a clean duplicate-key error
(`1062`) to the losers — it can pick one as a **deadlock victim** and return
`1213 (40001): Deadlock found`. `Acquire` only recognized `1062` (re-read the
winner and treat a same-owner winner as success); a `1213` fell through to the
bare `insert lock ...` error and surfaced as a hard failure, even though the
losing statement was fully rolled back and the claim would have succeeded on a
retry. This showed up as a flaky integration test
(`TestLockStore_Acquire_SameOwnerConcurrent`) under concurrent load.

## What (fix)

- `Acquire` now wraps a single claim attempt (`acquireOnce`) in a bounded retry
  loop with exponential backoff plus full jitter, and is context-aware (it
  returns promptly on cancellation).
- It retries only transient lock conflicts: deadlock (`1213`) and lock-wait
  timeout (`1205`). Both roll the statement back and leave the database
  unchanged, so the retry is safe and idempotent.
- On the next attempt the winning row is committed, so the same owner resolves
  through the existing same-owner path to success. Non-retryable errors and a
  genuinely held lock by another owner still return immediately, unchanged.

## How the duplicate-key and deadlock paths relate

Every statement here runs in autocommit, so each `INSERT` and each `Get` is its
own transaction. The two error outcomes of the `INSERT` race are complementary:

- **`1062` (duplicate key)** is returned immediately only when the conflicting
  unique-key row is **already committed**. So a clean `1062` guarantees the
  winner is durable, and the follow-up `Get` (a fresh read view) reliably sees
  it — no retry needed. The loser then branches on the row: a same-owner winner
  is success; another owner is `ErrLockHeld`; a row that vanished between the
  `1062` and the read (released meanwhile) is `ErrLockHeld`.
- **`1213` / `1205`** arise instead when the loser's `INSERT` has to **wait** on
  a row whose inserting transaction is still in flight — InnoDB resolves that
  wait by rolling the loser back (deadlock victim or lock-wait timeout). The new
  retry loop re-runs the attempt; by then the winner has committed, so it
  collapses into the same re-read-and-succeed path as `1062`.

```
loser INSERT hits an ALREADY-COMMITTED row ─→ 1062 ────────→ Get sees winner ✔ (no retry)
loser INSERT waits on an IN-FLIGHT row      ─→ 1213 / 1205 ─→ victim rolled back ─→ retry
                                                              (winner commits meanwhile)
                                                              re-read sees winner ✔
```

### Before

```
two same-owner callers ─→ INSERT race on UNIQUE key
  winner ─→ row committed ─────────────────────────→ success
  loser  ─→ 1062 dup-key  ─→ re-read winner ───────→ success
  loser  ─→ 1213 deadlock ─→ (unhandled) ──────────→ ✗ hard failure
```

### After

```
two same-owner callers ─→ INSERT race on UNIQUE key
  winner ─→ row committed ─────────────────────────→ success
  loser  ─→ 1062 dup-key  ─→ re-read winner ───────→ success
  loser  ─→ 1213 / 1205   ─→ retry (bounded, backoff)
                              victim rolled back ⇒ safe
                              re-read committed winner ─→ success
```
