### PR TITLE
fix(storage): retry transient InnoDB lock conflicts in control-request and check upserts

### DIFF
--- a/pkg/storage/mysqlstore/checks.go
+++ b/pkg/storage/mysqlstore/checks.go
@@ -36,25 +36,29 @@ func (s *checkStore) Upsert(ctx context.Context, check *storage.Check) error {
 		applyID = check.ApplyID
 	}
 
-	_, err := s.db.ExecContext(ctx, `
-		INSERT INTO checks (
-			repository, pull_request, head_sha,
-			environment, database_type, database_name,
-			check_run_id, apply_id, has_changes, status, conclusion, blocking_reason, error_message
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-		ON DUPLICATE KEY UPDATE
-			head_sha = VALUES(head_sha),
-			check_run_id = VALUES(check_run_id),
-			apply_id = VALUES(apply_id),
-			has_changes = VALUES(has_changes),
-			status = VALUES(status),
-			conclusion = VALUES(conclusion),
-			blocking_reason = VALUES(blocking_reason),
-			error_message = VALUES(error_message)
-	`, check.Repository, check.PullRequest, check.HeadSHA,
-		check.Environment, check.DatabaseType, check.DatabaseName,
-		checkRunID, applyID, check.HasChanges, check.Status, check.Conclusion, check.BlockingReason, check.ErrorMessage)
-	return err
+	op := fmt.Sprintf("upsert check result for %s#%d %s/%s/%s",
+		check.Repository, check.PullRequest, check.Environment, check.DatabaseType, check.DatabaseName)
+	return withLockRetry(ctx, op, func() error {
+		_, err := s.db.ExecContext(ctx, `
+			INSERT INTO checks (
+				repository, pull_request, head_sha,
+				environment, database_type, database_name,
+				check_run_id, apply_id, has_changes, status, conclusion, blocking_reason, error_message
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			ON DUPLICATE KEY UPDATE
+				head_sha = VALUES(head_sha),
+				check_run_id = VALUES(check_run_id),
+				apply_id = VALUES(apply_id),
+				has_changes = VALUES(has_changes),
+				status = VALUES(status),
+				conclusion = VALUES(conclusion),
+				blocking_reason = VALUES(blocking_reason),
+				error_message = VALUES(error_message)
+		`, check.Repository, check.PullRequest, check.HeadSHA,
+			check.Environment, check.DatabaseType, check.DatabaseName,
+			checkRunID, applyID, check.HasChanges, check.Status, check.Conclusion, check.BlockingReason, check.ErrorMessage)
+		return err
+	})
 }
 
 // UpsertPlanResult stores plan-derived check state without overwriting
@@ -65,49 +69,53 @@ func (s *checkStore) UpsertPlanResult(ctx context.Context, check *storage.Check)
 		checkRunID = check.CheckRunID
 	}
 
-	_, err := s.db.ExecContext(ctx, `
-		INSERT INTO checks (
-			repository, pull_request, head_sha,
-			environment, database_type, database_name,
-			check_run_id, apply_id, has_changes, status, conclusion, blocking_reason, error_message
-		) VALUES (?, ?, ?, ?, ?, ?, ?, NULL, ?, ?, ?, ?, ?)
-	`, check.Repository, check.PullRequest, check.HeadSHA,
-		check.Environment, check.DatabaseType, check.DatabaseName,
-		checkRunID, check.HasChanges, check.Status, check.Conclusion, check.BlockingReason, check.ErrorMessage)
-	// Fast path: no existing check state for this PR/environment/database, so the
-	// insert is the complete write. Any non-duplicate error is a real storage
-	// failure; duplicate key means the row exists and needs the guarded update
-	// below.
-	if err == nil {
-		return nil
-	}
-	if !isDuplicateKeyError(err) {
-		return err
-	}
+	op := fmt.Sprintf("upsert plan check result for %s#%d %s/%s/%s",
+		check.Repository, check.PullRequest, check.Environment, check.DatabaseType, check.DatabaseName)
+	return withLockRetry(ctx, op, func() error {
+		_, err := s.db.ExecContext(ctx, `
+			INSERT INTO checks (
+				repository, pull_request, head_sha,
+				environment, database_type, database_name,
+				check_run_id, apply_id, has_changes, status, conclusion, blocking_reason, error_message
+			) VALUES (?, ?, ?, ?, ?, ?, ?, NULL, ?, ?, ?, ?, ?)
+		`, check.Repository, check.PullRequest, check.HeadSHA,
+			check.Environment, check.DatabaseType, check.DatabaseName,
+			checkRunID, check.HasChanges, check.Status, check.Conclusion, check.BlockingReason, check.ErrorMessage)
+		// Fast path: no existing check state for this PR/environment/database, so
+		// the insert is the complete write. Any non-duplicate error is a real
+		// storage failure; duplicate key means the row exists and needs the
+		// guarded update below.
+		if err == nil {
+			return nil
+		}
+		if !isDuplicateKeyError(err) {
+			return err
+		}
 
-	// Preserve in-progress apply-owned state regardless of the plan's head SHA.
-	// Once an apply has started, the stored row is authoritative until the apply
-	// completes (CompleteForApply, MarkActionRequiredForApply) or an explicit
-	// recovery path releases it. A plan result — even from a newer PR commit that
-	// diffs cleanly against the mid-apply database — must not take ownership or
-	// convert the row into a passing check.
-	_, err = s.db.ExecContext(ctx, `
-		UPDATE checks
-		SET head_sha = ?,
-		    check_run_id = ?,
-		    apply_id = NULL,
-		    has_changes = ?,
-		    status = ?,
-		    conclusion = ?,
-		    blocking_reason = ?,
-		    error_message = ?
-		WHERE repository = ? AND pull_request = ?
-		  AND environment = ? AND database_type = ? AND database_name = ?
-		  AND NOT (status = ? AND apply_id IS NOT NULL)
-	`, check.HeadSHA, checkRunID, check.HasChanges, check.Status, check.Conclusion, check.BlockingReason, check.ErrorMessage,
-		check.Repository, check.PullRequest, check.Environment, check.DatabaseType, check.DatabaseName,
-		checkStatusInProgress)
-	return err
+		// Preserve in-progress apply-owned state regardless of the plan's head SHA.
+		// Once an apply has started, the stored row is authoritative until the apply
+		// completes (CompleteForApply, MarkActionRequiredForApply) or an explicit
+		// recovery path releases it. A plan result — even from a newer PR commit that
+		// diffs cleanly against the mid-apply database — must not take ownership or
+		// convert the row into a passing check.
+		_, err = s.db.ExecContext(ctx, `
+			UPDATE checks
+			SET head_sha = ?,
+			    check_run_id = ?,
+			    apply_id = NULL,
+			    has_changes = ?,
+			    status = ?,
+			    conclusion = ?,
+			    blocking_reason = ?,
+			    error_message = ?
+			WHERE repository = ? AND pull_request = ?
+			  AND environment = ? AND database_type = ? AND database_name = ?
+			  AND NOT (status = ? AND apply_id IS NOT NULL)
+		`, check.HeadSHA, checkRunID, check.HasChanges, check.Status, check.Conclusion, check.BlockingReason, check.ErrorMessage,
+			check.Repository, check.PullRequest, check.Environment, check.DatabaseType, check.DatabaseName,
+			checkStatusInProgress)
+		return err
+	})
 }
 
 // RecoverApplyOwnedCheckWithNoOpPlan updates same-head apply-owned stored check

--- a/pkg/storage/mysqlstore/control_requests.go
+++ b/pkg/storage/mysqlstore/control_requests.go
@@ -18,23 +18,34 @@ type controlRequestStore struct {
 }
 
 func (s *controlRequestStore) RequestPending(ctx context.Context, req *storage.ApplyControlRequest) (*storage.ApplyControlRequest, bool, error) {
-	controlReq, alreadyPending, err := s.requestPending(ctx, req)
-	if err == nil || !isDuplicateKeyError(err) {
-		return controlReq, alreadyPending, err
-	}
+	var controlReq *storage.ApplyControlRequest
+	var alreadyPending bool
+	op := fmt.Sprintf("request control request for apply %d operation %s", req.ApplyID, req.Operation)
+	err := withLockRetry(ctx, op, func() error {
+		var attemptErr error
+		controlReq, alreadyPending, attemptErr = s.requestPending(ctx, req)
+		if attemptErr == nil || !isDuplicateKeyError(attemptErr) {
+			return attemptErr
+		}
 
-	slog.DebugContext(ctx, "retrying control request after duplicate insert",
-		"apply_id", req.ApplyID,
-		"operation", req.Operation)
+		slog.DebugContext(ctx, "retrying control request after duplicate insert",
+			"apply_id", req.ApplyID,
+			"operation", req.Operation)
 
-	// requestPending opens its transaction at READ COMMITTED. The unique key on
-	// apply_id + operation is the durable guard when two first-time callers both
-	// observe no row and race to insert. Retry once so the losing insert re-reads
-	// the winning row and returns "already requested"; if the retry also fails,
-	// return that storage error instead of hiding an unexpected conflict.
-	controlReq, alreadyPending, err = s.requestPending(ctx, req)
+		// requestPending opens its transaction at READ COMMITTED. The unique key
+		// on apply_id + operation is the durable guard when two first-time
+		// callers both observe no row and race to insert. Re-read once so the
+		// losing insert returns the winning row as "already requested"; if the
+		// re-read also fails, return that storage error instead of hiding an
+		// unexpected conflict.
+		controlReq, alreadyPending, attemptErr = s.requestPending(ctx, req)
+		if attemptErr != nil {
+			return fmt.Errorf("retry control request after duplicate insert for apply %d operation %s: %w", req.ApplyID, req.Operation, attemptErr)
+		}
+		return nil
+	})
 	if err != nil {
-		return nil, false, fmt.Errorf("retry control request after duplicate insert for apply %d operation %s: %w", req.ApplyID, req.Operation, err)
+		return nil, false, err
 	}
 	return controlReq, alreadyPending, nil
 }

--- a/pkg/storage/mysqlstore/locks.go
+++ b/pkg/storage/mysqlstore/locks.go
@@ -7,9 +7,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"math/rand/v2"
 	"strings"
-	"time"
 
 	"github.com/block/schemabot/pkg/storage"
 	"github.com/block/spirit/pkg/utils"
@@ -19,16 +17,6 @@ import (
 // lockColumns lists all columns for SELECT queries.
 const lockColumns = `id, database_name, database_type, repository, pull_request, owner,
 	pending_plan_id, created_at, updated_at`
-
-// acquireMaxAttempts bounds how many times Acquire retries a transient lock
-// conflict before giving up. Concurrent same-owner callers racing to claim the
-// same key can make InnoDB pick one as a deadlock victim; the victim is rolled
-// back, so a bounded retry resolves the race.
-const acquireMaxAttempts = 5
-
-// acquireBaseBackoff is the first retry delay; it grows exponentially with
-// full jitter on each subsequent attempt.
-const acquireBaseBackoff = 5 * time.Millisecond
 
 // lockStore implements storage.LockStore using MySQL.
 type lockStore struct {
@@ -44,24 +32,10 @@ type lockStore struct {
 // confirm command loads. A re-acquire that passes an empty PendingPlanID (CLI)
 // leaves the existing value intact.
 func (s *lockStore) Acquire(ctx context.Context, lock *storage.Lock) error {
-	var lastErr error
-	for attempt := range acquireMaxAttempts {
-		if attempt > 0 {
-			if err := sleepBackoff(ctx, attempt); err != nil {
-				return err
-			}
-		}
-		err := s.acquireOnce(ctx, lock)
-		if err == nil {
-			return nil
-		}
-		if !isRetryableLockError(err) {
-			return err
-		}
-		lastErr = err
-	}
-	return fmt.Errorf("acquire lock for %s/%s owner=%s after %d attempts: %w",
-		lock.DatabaseName, lock.DatabaseType, lock.Owner, acquireMaxAttempts, lastErr)
+	op := fmt.Sprintf("acquire lock for %s/%s owner=%s", lock.DatabaseName, lock.DatabaseType, lock.Owner)
+	return withLockRetry(ctx, op, func() error {
+		return s.acquireOnce(ctx, lock)
+	})
 }
 
 // acquireOnce performs a single claim attempt. Concurrent same-owner callers
@@ -325,38 +299,4 @@ func isDuplicateKeyError(err error) bool {
 		return true
 	}
 	return err != nil && strings.Contains(err.Error(), "Duplicate entry")
-}
-
-// MySQL error codes for transient lock contention. InnoDB picks a deadlock
-// victim (1213) or times out a lock wait (1205) when callers race for the same
-// rows; both roll the statement back, so the caller can safely retry.
-const (
-	mysqlErrDeadlock        = 1213
-	mysqlErrLockWaitTimeout = 1205
-)
-
-// isRetryableLockError reports whether err is a transient InnoDB lock conflict
-// that resolves on retry: a deadlock victim or a lock-wait timeout. Both leave
-// the database unchanged, so re-running the operation is safe.
-func isRetryableLockError(err error) bool {
-	var mysqlErr *gomysql.MySQLError
-	if !errors.As(err, &mysqlErr) {
-		return false
-	}
-	return mysqlErr.Number == mysqlErrDeadlock || mysqlErr.Number == mysqlErrLockWaitTimeout
-}
-
-// sleepBackoff waits before the next retry using exponential backoff with full
-// jitter, returning early if the context is cancelled.
-func sleepBackoff(ctx context.Context, attempt int) error {
-	maxDelay := acquireBaseBackoff << (attempt - 1)
-	delay := time.Duration(rand.Int64N(int64(maxDelay) + 1))
-	timer := time.NewTimer(delay)
-	defer timer.Stop()
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	case <-timer.C:
-		return nil
-	}
 }

--- a/pkg/storage/mysqlstore/retry.go
+++ b/pkg/storage/mysqlstore/retry.go
@@ -1,7 +1,8 @@
 // retry.go centralizes retry handling for transient InnoDB lock contention.
 // Concurrent callers racing for the same rows can be chosen as a deadlock victim
-// or time out waiting for a lock; both roll the statement back, so the operation
-// can be safely re-run.
+// or time out waiting for a lock; both roll the failed work back — the offending
+// statement, or the whole transaction when the work runs inside one — so the
+// operation can be safely re-run.
 package mysqlstore
 
 import (
@@ -24,7 +25,8 @@ const lockRetryBaseBackoff = 5 * time.Millisecond
 
 // MySQL error codes for transient lock contention. InnoDB picks a deadlock
 // victim (1213) or times out a lock wait (1205) when callers race for the same
-// rows; both roll the statement back, so the caller can safely retry.
+// rows; both roll back the failed attempt (statement or enclosing transaction),
+// so the caller can safely retry.
 const (
 	mysqlErrDeadlock        = 1213
 	mysqlErrLockWaitTimeout = 1205
@@ -34,9 +36,10 @@ const (
 // victim 1213, lock-wait timeout 1205) with bounded attempts and jittered
 // backoff. It returns promptly if the context is cancelled between attempts.
 //
-// fn must be idempotent: a retried statement was rolled back, so re-running it
-// from a clean read is safe. Non-retryable errors (including genuine
-// application conflicts) are returned immediately, unchanged.
+// fn must be idempotent: a retried attempt was fully rolled back — the offending
+// statement, or the entire transaction when fn runs one — so re-running it from a
+// clean read is safe. Non-retryable errors (including genuine application
+// conflicts) are returned immediately, unchanged.
 func withLockRetry(ctx context.Context, op string, fn func() error) error {
 	var lastErr error
 	for attempt := range lockRetryMaxAttempts {

--- a/pkg/storage/mysqlstore/retry.go
+++ b/pkg/storage/mysqlstore/retry.go
@@ -1,0 +1,84 @@
+// retry.go centralizes retry handling for transient InnoDB lock contention.
+// Concurrent callers racing for the same rows can be chosen as a deadlock victim
+// or time out waiting for a lock; both roll the statement back, so the operation
+// can be safely re-run.
+package mysqlstore
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/rand/v2"
+	"time"
+
+	gomysql "github.com/go-sql-driver/mysql"
+)
+
+// lockRetryMaxAttempts bounds how many times a transient lock conflict is
+// retried before giving up.
+const lockRetryMaxAttempts = 5
+
+// lockRetryBaseBackoff is the first retry delay; it grows exponentially with
+// full jitter on each subsequent attempt.
+const lockRetryBaseBackoff = 5 * time.Millisecond
+
+// MySQL error codes for transient lock contention. InnoDB picks a deadlock
+// victim (1213) or times out a lock wait (1205) when callers race for the same
+// rows; both roll the statement back, so the caller can safely retry.
+const (
+	mysqlErrDeadlock        = 1213
+	mysqlErrLockWaitTimeout = 1205
+)
+
+// withLockRetry runs fn, retrying transient InnoDB lock conflicts (deadlock
+// victim 1213, lock-wait timeout 1205) with bounded attempts and jittered
+// backoff. It returns promptly if the context is cancelled between attempts.
+//
+// fn must be idempotent: a retried statement was rolled back, so re-running it
+// from a clean read is safe. Non-retryable errors (including genuine
+// application conflicts) are returned immediately, unchanged.
+func withLockRetry(ctx context.Context, op string, fn func() error) error {
+	var lastErr error
+	for attempt := range lockRetryMaxAttempts {
+		if attempt > 0 {
+			if err := sleepBackoff(ctx, attempt); err != nil {
+				return err
+			}
+		}
+		err := fn()
+		if err == nil {
+			return nil
+		}
+		if !isRetryableLockError(err) {
+			return err
+		}
+		lastErr = err
+	}
+	return fmt.Errorf("%s after %d attempts: %w", op, lockRetryMaxAttempts, lastErr)
+}
+
+// isRetryableLockError reports whether err is a transient InnoDB lock conflict
+// that resolves on retry: a deadlock victim or a lock-wait timeout. Both leave
+// the database unchanged, so re-running the operation is safe.
+func isRetryableLockError(err error) bool {
+	var mysqlErr *gomysql.MySQLError
+	if !errors.As(err, &mysqlErr) {
+		return false
+	}
+	return mysqlErr.Number == mysqlErrDeadlock || mysqlErr.Number == mysqlErrLockWaitTimeout
+}
+
+// sleepBackoff waits before the next retry using exponential backoff with full
+// jitter, returning early if the context is cancelled.
+func sleepBackoff(ctx context.Context, attempt int) error {
+	maxDelay := lockRetryBaseBackoff << (attempt - 1)
+	delay := time.Duration(rand.Int64N(int64(maxDelay) + 1))
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}

--- a/pkg/storage/mysqlstore/retry_test.go
+++ b/pkg/storage/mysqlstore/retry_test.go
@@ -1,0 +1,94 @@
+package mysqlstore
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	gomysql "github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsRetryableLockError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"deadlock 1213", &gomysql.MySQLError{Number: mysqlErrDeadlock, Message: "Deadlock found"}, true},
+		{"lock wait timeout 1205", &gomysql.MySQLError{Number: mysqlErrLockWaitTimeout, Message: "Lock wait timeout exceeded"}, true},
+		{"wrapped deadlock", fmt.Errorf("insert lock: %w", &gomysql.MySQLError{Number: mysqlErrDeadlock}), true},
+		{"duplicate key 1062", &gomysql.MySQLError{Number: 1062, Message: "Duplicate entry"}, false},
+		{"non-mysql error", errors.New("boom"), false},
+		{"nil", nil, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isRetryableLockError(tt.err))
+		})
+	}
+}
+
+func TestWithLockRetry_SucceedsFirstAttempt(t *testing.T) {
+	calls := 0
+	err := withLockRetry(t.Context(), "op", func() error {
+		calls++
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, calls)
+}
+
+func TestWithLockRetry_RetriesThenSucceeds(t *testing.T) {
+	calls := 0
+	err := withLockRetry(t.Context(), "op", func() error {
+		calls++
+		if calls < 3 {
+			return &gomysql.MySQLError{Number: mysqlErrDeadlock, Message: "Deadlock found"}
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 3, calls)
+}
+
+func TestWithLockRetry_ExhaustsAttempts(t *testing.T) {
+	calls := 0
+	err := withLockRetry(t.Context(), "acquire something", func() error {
+		calls++
+		return &gomysql.MySQLError{Number: mysqlErrLockWaitTimeout, Message: "Lock wait timeout exceeded"}
+	})
+	require.Error(t, err)
+	assert.Equal(t, lockRetryMaxAttempts, calls)
+	assert.Contains(t, err.Error(), "acquire something")
+	assert.Contains(t, err.Error(), fmt.Sprintf("after %d attempts", lockRetryMaxAttempts))
+	// The terminal lock error is preserved in the chain.
+	assert.True(t, isRetryableLockError(err))
+}
+
+func TestWithLockRetry_NonRetryableReturnsImmediately(t *testing.T) {
+	sentinel := errors.New("genuine conflict")
+	calls := 0
+	err := withLockRetry(t.Context(), "op", func() error {
+		calls++
+		return sentinel
+	})
+	require.ErrorIs(t, err, sentinel)
+	assert.Equal(t, 1, calls, "non-retryable error must not be retried")
+}
+
+func TestWithLockRetry_RespectsContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	calls := 0
+	err := withLockRetry(ctx, "op", func() error {
+		calls++
+		return &gomysql.MySQLError{Number: mysqlErrDeadlock, Message: "Deadlock found"}
+	})
+	require.ErrorIs(t, err, context.Canceled)
+	// First attempt runs (no pre-attempt wait); the cancelled context stops the
+	// backoff before a second attempt.
+	assert.Equal(t, 1, calls)
+}


### PR DESCRIPTION
## Summary

Follow-up to #477. That PR added bounded deadlock-retry to lock `Acquire`; this
generalizes the same handling and applies it to the other storage paths that
race the same way on concurrent same-key writes.

## Why

Several storage writes resolve an INSERT race by re-reading on duplicate-key
(`1062`), but under contention InnoDB can instead return a deadlock victim
(`1213`) or lock-wait timeout (`1205`). Those are transient — the statement is
rolled back — so the operation should retry rather than hard-fail.

## What

- New `withLockRetry` helper (`retry.go`): bounded attempts, exponential backoff
  with full jitter, context-aware; retries only `1213`/`1205`, returns all other
  errors (including genuine conflicts) immediately.
- `lockStore.Acquire` now uses the shared helper.
- `controlRequestStore.RequestPending` and the `checkStore` upserts
  (`UpsertResult`, `UpsertPlanResult`) are wrapped — concurrent control-request
  claims and concurrent webhook-driven check-state writes hit the same race.
- Unit tests for the retry policy (classification, retry-then-succeed, attempt
  exhaustion, non-retryable pass-through, context cancellation).
