### PR TITLE
fix(github): include -e environment flag in apply footer control commands

### DIFF
--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -1696,7 +1696,7 @@ Rows: 3,500,000 / 7,200,000 · ETA: 5m 30s
 
 To stop this schema change:
 ```
-schemabot stop apply-a1b2c3d4e5f6
+schemabot stop apply-a1b2c3d4e5f6 -e staging
 ```
 
 _Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:00 UTC</relative-time> (2026-01-01 00:00:00 UTC)_
@@ -1778,7 +1778,7 @@ Rows: 156,342 / 397,453
 
 Paused — to resume from where it stopped:
 ```
-schemabot start apply-a1b2c3d4e5f6
+schemabot start apply-a1b2c3d4e5f6 -e staging
 ```
 
 </details>
@@ -1820,7 +1820,7 @@ ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
 
 To stop this schema change:
 ```
-schemabot stop apply-a1b2c3d4e5f6
+schemabot stop apply-a1b2c3d4e5f6 -e staging
 ```
 
 _Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:00 UTC</relative-time> (2026-01-01 00:00:00 UTC)_
@@ -1865,7 +1865,7 @@ ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
 
 To stop this schema change:
 ```
-schemabot stop apply-a1b2c3d4e5f6
+schemabot stop apply-a1b2c3d4e5f6 -e staging
 ```
 
 _Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:00 UTC</relative-time> (2026-01-01 00:00:00 UTC)_
@@ -1910,7 +1910,7 @@ ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
 
 To stop this schema change:
 ```
-schemabot stop apply-a1b2c3d4e5f6
+schemabot stop apply-a1b2c3d4e5f6 -e staging
 ```
 
 _Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:00 UTC</relative-time> (2026-01-01 00:00:00 UTC)_
@@ -1956,7 +1956,7 @@ ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
 
 To stop this schema change:
 ```
-schemabot stop apply-a1b2c3d4e5f6
+schemabot stop apply-a1b2c3d4e5f6 -e staging
 ```
 
 _Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:00 UTC</relative-time> (2026-01-01 00:00:00 UTC)_
@@ -2001,7 +2001,7 @@ ALTER TABLE `users` ADD INDEX `idx_email`(`email`);
 
 To stop this schema change:
 ```
-schemabot stop apply-a1b2c3d4e5f6
+schemabot stop apply-a1b2c3d4e5f6 -e staging
 ```
 
 _Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:00 UTC</relative-time> (2026-01-01 00:00:00 UTC)_
@@ -2163,7 +2163,7 @@ ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
 
 Paused — to resume from where it stopped:
 ```
-schemabot start apply-a1b2c3d4e5f6
+schemabot start apply-a1b2c3d4e5f6 -e staging
 ```
 
 </details>
@@ -2269,7 +2269,7 @@ ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
 
 To proceed with cutover:
 ```
-schemabot cutover apply-a1b2c3d4e5f6
+schemabot cutover apply-a1b2c3d4e5f6 -e staging
 ```
 
 _Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:00 UTC</relative-time> (2026-01-01 00:00:00 UTC)_
@@ -2483,7 +2483,7 @@ ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
 
 Paused — to resume from where it stopped:
 ```
-schemabot start apply-a1b2c3d4e5f6
+schemabot start apply-a1b2c3d4e5f6 -e staging
 ```
 
 </details>
@@ -4707,7 +4707,7 @@ schemabot apply -e staging
 
 To cut over `eu`:
 ```
-schemabot cutover apply-a1b2c3d4e5f6
+schemabot cutover apply-a1b2c3d4e5f6 -e production
 ```
 
 - 🟢 eu — ready for cutover — next in order
@@ -4753,7 +4753,7 @@ ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
 
 To proceed with cutover:
 ```
-schemabot cutover apply-a1b2c3d4e5f6
+schemabot cutover apply-a1b2c3d4e5f6 -e production
 ```
 
 </details>
@@ -4795,7 +4795,7 @@ ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
 
 To stop this schema change:
 ```
-schemabot stop apply-a1b2c3d4e5f6
+schemabot stop apply-a1b2c3d4e5f6 -e production
 ```
 
 </details>

--- a/pkg/webhook/templates/apply.go
+++ b/pkg/webhook/templates/apply.go
@@ -532,9 +532,9 @@ func writeRowsAndETA(sb *strings.Builder, table TableProgressData) {
 func writeApplyFooter(sb *strings.Builder, data ApplyStatusCommentData) {
 	switch data.State {
 	case state.Apply.WaitingForDeploy:
-		writeFooterAction(sb, "To deploy:", fmt.Sprintf("schemabot cutover %s", data.ApplyID))
+		writeFooterAction(sb, "To deploy:", fmt.Sprintf("schemabot cutover %s -e %s", data.ApplyID, data.Environment))
 	case state.Apply.WaitingForCutover:
-		writeFooterAction(sb, "To proceed with cutover:", fmt.Sprintf("schemabot cutover %s", data.ApplyID))
+		writeFooterAction(sb, "To proceed with cutover:", fmt.Sprintf("schemabot cutover %s -e %s", data.ApplyID, data.Environment))
 	case state.Apply.Recovering:
 		sb.WriteString("\n---\n\n")
 		if pct, ok := recoveringCopyPercent(data.Tables); ok {
@@ -546,7 +546,7 @@ func writeApplyFooter(sb *strings.Builder, data ApplyStatusCommentData) {
 		sb.WriteString("\n---\n\n")
 		sb.WriteString("Cutover in progress — typically completes within seconds.\n")
 	case state.Apply.Running, state.Apply.RunningDegraded:
-		writeFooterAction(sb, "To stop this schema change:", fmt.Sprintf("schemabot stop %s", data.ApplyID))
+		writeFooterAction(sb, "To stop this schema change:", fmt.Sprintf("schemabot stop %s -e %s", data.ApplyID, data.Environment))
 	case state.Apply.PreparingBranch,
 		state.Apply.ApplyingBranchChanges,
 		state.Apply.ValidatingBranch,
@@ -555,19 +555,19 @@ func writeApplyFooter(sb *strings.Builder, data ApplyStatusCommentData) {
 		// PlanetScale's branch and deploy-request phases are active, stoppable
 		// work — the operator can halt the change before cutover just as during
 		// row copy.
-		writeFooterAction(sb, "To stop this schema change:", fmt.Sprintf("schemabot stop %s", data.ApplyID))
+		writeFooterAction(sb, "To stop this schema change:", fmt.Sprintf("schemabot stop %s -e %s", data.ApplyID, data.Environment))
 	case state.Apply.FailedRetryable:
-		writeFooterAction(sb, "An error interrupted this schema change. SchemaBot retries automatically and marks it failed if retries are exhausted. To stop retrying:", fmt.Sprintf("schemabot stop %s", data.ApplyID))
+		writeFooterAction(sb, "An error interrupted this schema change. SchemaBot retries automatically and marks it failed if retries are exhausted. To stop retrying:", fmt.Sprintf("schemabot stop %s -e %s", data.ApplyID, data.Environment))
 	case state.Apply.Stopped:
-		writeFooterAction(sb, "Paused — to resume from where it stopped:", fmt.Sprintf("schemabot start %s", data.ApplyID))
+		writeFooterAction(sb, "Paused — to resume from where it stopped:", fmt.Sprintf("schemabot start %s -e %s", data.ApplyID, data.Environment))
 	case state.Apply.Cancelled:
 		sb.WriteString("\n---\n\n")
 		sb.WriteString("This schema change was cancelled and cannot be resumed. Open a new schema change to apply it again.\n")
 	case state.Apply.Failed:
 		writeFooterAction(sb, "To retry:", fmt.Sprintf("schemabot apply -e %s", data.Environment))
 	case state.Apply.RevertWindow:
-		writeFooterAction(sb, "To revert:", fmt.Sprintf("schemabot revert %s", data.ApplyID))
-		fmt.Fprintf(sb, "\nTo skip revert and keep changes:\n```\nschemabot skip-revert %s\n```\n", data.ApplyID)
+		writeFooterAction(sb, "To revert:", fmt.Sprintf("schemabot revert %s -e %s", data.ApplyID, data.Environment))
+		fmt.Fprintf(sb, "\nTo skip revert and keep changes:\n```\nschemabot skip-revert %s -e %s\n```\n", data.ApplyID, data.Environment)
 	}
 }
 
@@ -672,7 +672,7 @@ func writeSummaryStopped(sb *strings.Builder, data ApplyStatusCommentData, compl
 	}
 
 	writeSummaryTableList(sb, data)
-	writeFooterAction(sb, "Paused — to resume from where it stopped:", fmt.Sprintf("schemabot start %s", data.ApplyID))
+	writeFooterAction(sb, "Paused — to resume from where it stopped:", fmt.Sprintf("schemabot start %s -e %s", data.ApplyID, data.Environment))
 }
 
 // writeSummaryCancelled renders the terminal summary for a cancelled schema

--- a/pkg/webhook/templates/apply_test.go
+++ b/pkg/webhook/templates/apply_test.go
@@ -193,7 +193,7 @@ func TestRenderApplyStatusComment_ValidatingDeployRequest(t *testing.T) {
 	assert.Contains(t, result, "## Schema Change — Validating Deploy Request")
 	assert.NotContains(t, result, "## Schema Change In Progress")
 	assert.Contains(t, result, "To stop this schema change:")
-	assert.Contains(t, result, "schemabot stop apply-7aa13cf03496454b")
+	assert.Contains(t, result, "schemabot stop apply-7aa13cf03496454b -e staging")
 }
 
 func TestRenderApplyStatusComment_RowCopyDisplaysOnePercentAfterCopyStarts(t *testing.T) {
@@ -394,7 +394,7 @@ func TestRenderApplyStatusComment_FailedRetryable(t *testing.T) {
 	// Footer explains automatic retry — including the failure outcome when
 	// retries are exhausted — and offers stop, not a manual re-apply.
 	assert.Contains(t, result, "SchemaBot retries automatically and marks it failed if retries are exhausted")
-	assert.Contains(t, result, "schemabot stop apply-abc123")
+	assert.Contains(t, result, "schemabot stop apply-abc123 -e staging")
 	assert.NotContains(t, result, "transient")
 	assert.NotContains(t, result, "schemabot apply -e staging")
 }
@@ -1184,7 +1184,7 @@ func TestRenderApplyStatusComment_WaitingForCutover_ReadyNotReady(t *testing.T) 
 	assert.Contains(t, result, "Waiting for cutover")
 
 	// Footer has cutover command
-	assert.Contains(t, result, "schemabot cutover apply-abc123")
+	assert.Contains(t, result, "schemabot cutover apply-abc123 -e staging")
 }
 
 func TestRenderApplyStatusComment_WaitingForCutover_AllReady(t *testing.T) {
@@ -1220,6 +1220,6 @@ func TestRenderApplyStatusComment_RevertWindow(t *testing.T) {
 
 	assert.Contains(t, result, "Pending Revert")
 	assert.Contains(t, result, "Complete (pending revert)")
-	assert.Contains(t, result, "schemabot revert apply-abc123")
-	assert.Contains(t, result, "schemabot skip-revert apply-abc123")
+	assert.Contains(t, result, "schemabot revert apply-abc123 -e staging")
+	assert.Contains(t, result, "schemabot skip-revert apply-abc123 -e staging")
 }

--- a/pkg/webhook/templates/multi_apply.go
+++ b/pkg/webhook/templates/multi_apply.go
@@ -169,9 +169,9 @@ func writeAggregateNextAction(sb *strings.Builder, data MultiDeploymentApplyData
 	case presentation.NextActionCutover:
 		writeFooterAction(sb,
 			fmt.Sprintf("To cut over `%s`:", na.Deployment),
-			fmt.Sprintf("schemabot cutover %s", data.ApplyID))
+			fmt.Sprintf("schemabot cutover %s -e %s", data.ApplyID, data.Environment))
 	case presentation.NextActionResume:
-		writeFooterAction(sb, "Paused — to resume from where it stopped:", fmt.Sprintf("schemabot start %s", data.ApplyID))
+		writeFooterAction(sb, "Paused — to resume from where it stopped:", fmt.Sprintf("schemabot start %s -e %s", data.ApplyID, data.Environment))
 	case presentation.NextActionReviewFailure:
 		// revert applies only to a deployment still in its post-cutover revert
 		// window, not to a failure; the recovery path for a failed apply is a

--- a/pkg/webhook/templates/multi_apply_test.go
+++ b/pkg/webhook/templates/multi_apply_test.go
@@ -52,7 +52,7 @@ func TestRenderMultiDeploymentApplyComment_BarrierInProgress(t *testing.T) {
 	// aggregate is still running. The command is the executable apply-ID form the
 	// CLI accepts today (no --deployment flag yet).
 	assert.Contains(t, out, "To cut over `eu`:")
-	assert.Contains(t, out, "schemabot cutover apply-123")
+	assert.Contains(t, out, "schemabot cutover apply-123 -e production")
 	assert.NotContains(t, out, "--deployment")
 
 	// Per-deployment summary lines, in resolved order, with derived labels.


### PR DESCRIPTION
The in-progress and terminal apply comment footers rendered copy-paste `stop`/`start`/`cutover`/`revert`/`skip-revert` commands with only the apply ID (e.g. `schemabot stop apply-abc123`). The CLI requires both an apply ID and `-e <environment>`, so copying these verbatim failed with `--environment is required`.

This appends `-e <env>` to every ID-targeted control command in the single- and multi-deployment footers, matching the commands already rendered in the reconciliation comment. The environment is sourced from the persisted apply record, which is always populated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)