### PR TITLE
fix(github): land a completed rollback's check as action_required

### DIFF
--- a/pkg/storage/types.go
+++ b/pkg/storage/types.go
@@ -448,6 +448,17 @@ func (a *Apply) Lease() ApplyLease {
 	}
 }
 
+// IsRollback reports whether this apply reverts a previously applied schema
+// change. It reads the durable rollback option so any terminal path can tell a
+// rollback from an ordinary apply without the rollback command's in-memory
+// context.
+func (a *Apply) IsRollback() bool {
+	if a == nil {
+		return false
+	}
+	return ParseApplyOptions(a.Options).Rollback
+}
+
 // ApplyOperation represents one child row in the apply_operations table:
 // the per-(deployment, target) slice of a multi-deployment apply, and the
 // unit of work the operator (claim loop) reconciles.
@@ -581,6 +592,13 @@ type ApplyOptions struct {
 	// Target is the opaque endpoint-discovery target forwarded to Tern.
 	// Defaults to the apply database when empty.
 	Target string `json:"target,omitempty"`
+
+	// Rollback marks an apply that reverts a previously applied schema change
+	// (executed from a rollback plan). It is durable so any terminal path can
+	// distinguish a rollback from an ordinary apply: a completed rollback must
+	// leave the required check action_required (the PR's change has been reverted
+	// and must not merge as-is), not success.
+	Rollback bool `json:"rollback,omitempty"`
 }
 
 // ControlOperation identifies a user-requested control operation.
@@ -632,6 +650,7 @@ func ApplyOptionsFromMap(options map[string]string) ApplyOptions {
 		DeferDeploy:  options["defer_deploy"] == "true",
 		SkipRevert:   options["skip_revert"] == "true",
 		Target:       options["target"],
+		Rollback:     options["rollback"] == "true",
 	}
 	if rawVolume := options["volume"]; rawVolume != "" {
 		volume, err := strconv.Atoi(rawVolume)
@@ -665,6 +684,9 @@ func (opts ApplyOptions) Map() map[string]string {
 	}
 	if opts.Target != "" {
 		options["target"] = opts.Target
+	}
+	if opts.Rollback {
+		options["rollback"] = "true"
 	}
 	return options
 }

--- a/pkg/webhook/check_records.go
+++ b/pkg/webhook/check_records.go
@@ -240,6 +240,16 @@ func (h *Handler) reconcileStaleChecks(ctx context.Context, client *ghclient.Ins
 			"apply_state", apply.State, "check_apply_id", check.ApplyID,
 			"check_head_sha", check.HeadSHA)
 
+		// A completed rollback must reconcile to action_required, not success: its
+		// success is a reverted PR change that must not merge as-is. Route it to the
+		// rollback finalizer instead of the ordinary apply-result update, which
+		// would mark the check successful.
+		if apply.IsRollback() && state.IsState(apply.State, state.Apply.Completed) {
+			h.setCheckActionRequired(repo, pr, apply.InstallationID, apply)
+			reconciled = true
+			continue
+		}
+
 		updated, err := h.updateCheckRecordForApplyResult(ctx, repo, pr, apply)
 		if err != nil {
 			metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{

--- a/pkg/webhook/check_records.go
+++ b/pkg/webhook/check_records.go
@@ -246,6 +246,14 @@ func (h *Handler) reconcileStaleChecks(ctx context.Context, client *ghclient.Ins
 		// would mark the check successful.
 		if apply.IsRollback() && state.IsState(apply.State, state.Apply.Completed) {
 			h.setCheckActionRequired(repo, pr, apply.InstallationID, apply)
+			metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
+				Operation:    "stale_check_reconciliation",
+				Repository:   repo,
+				Database:     check.DatabaseName,
+				DatabaseType: check.DatabaseType,
+				Environment:  check.Environment,
+				Status:       "success",
+			})
 			reconciled = true
 			continue
 		}

--- a/pkg/webhook/check_records.go
+++ b/pkg/webhook/check_records.go
@@ -245,16 +245,22 @@ func (h *Handler) reconcileStaleChecks(ctx context.Context, client *ghclient.Ins
 		// rollback finalizer instead of the ordinary apply-result update, which
 		// would mark the check successful.
 		if apply.IsRollback() && state.IsState(apply.State, state.Apply.Completed) {
-			h.setCheckActionRequired(repo, pr, apply.InstallationID, apply)
-			metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
-				Operation:    "stale_check_reconciliation",
-				Repository:   repo,
-				Database:     check.DatabaseName,
-				DatabaseType: check.DatabaseType,
-				Environment:  check.Environment,
-				Status:       "success",
-			})
-			reconciled = true
+			// setCheckActionRequired emits its own rollback_finished
+			// success/skipped/error metric; only count the reconciliation as a
+			// success here when the stored check was actually updated, so an
+			// ownership-miss skip does not inflate the stale-reconcile success
+			// count or trigger a spurious aggregate refresh.
+			if h.setCheckActionRequired(repo, pr, apply.InstallationID, apply) {
+				metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
+					Operation:    "stale_check_reconciliation",
+					Repository:   repo,
+					Database:     check.DatabaseName,
+					DatabaseType: check.DatabaseType,
+					Environment:  check.Environment,
+					Status:       "success",
+				})
+				reconciled = true
+			}
 			continue
 		}
 
@@ -407,7 +413,11 @@ func (h *Handler) updateCheckRecordForApplyResult(ctx context.Context, repo stri
 
 // setCheckActionRequired sets the rollback apply's check back to action_required.
 // Used after a rollback completes because the PR's schema changes need to be re-applied.
-func (h *Handler) setCheckActionRequired(repo string, pr int, installationID int64, apply *storage.Apply) {
+// It reports whether the stored check was actually updated; callers that count
+// their own reconciliation outcome should not record success on a skip (this
+// function already emits its own skipped/ownership-miss metric). It emits its own
+// rollback_finished success/skipped/error metrics regardless.
+func (h *Handler) setCheckActionRequired(repo string, pr int, installationID int64, apply *storage.Apply) bool {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
@@ -426,7 +436,7 @@ func (h *Handler) setCheckActionRequired(repo string, pr int, installationID int
 			"database_type", apply.DatabaseType, "environment", apply.Environment,
 			"apply_id", apply.ID, "apply_identifier", apply.ApplyIdentifier,
 			"error", err)
-		return
+		return false
 	}
 	if check == nil {
 		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
@@ -441,7 +451,7 @@ func (h *Handler) setCheckActionRequired(repo string, pr int, installationID int
 			"repo", repo, "pr", pr, "database", apply.Database,
 			"database_type", apply.DatabaseType, "environment", apply.Environment,
 			"apply_id", apply.ID, "apply_identifier", apply.ApplyIdentifier)
-		return
+		return false
 	}
 
 	check.Status = checkStatusCompleted
@@ -465,7 +475,7 @@ func (h *Handler) setCheckActionRequired(repo string, pr int, installationID int
 			"apply_id", apply.ID, "apply_identifier", apply.ApplyIdentifier,
 			"check_apply_id", check.ApplyID, "check_status", check.Status,
 			"check_head_sha", check.HeadSHA, "error", err)
-		return
+		return false
 	}
 	if !updated {
 		metrics.RecordCheckOwnershipMiss(ctx, "rollback_finished", repo, apply.Database, apply.DatabaseType, apply.Deployment, apply.Environment)
@@ -483,7 +493,7 @@ func (h *Handler) setCheckActionRequired(repo string, pr int, installationID int
 			"apply_id", apply.ID, "apply_identifier", apply.ApplyIdentifier,
 			"apply_state", apply.State, "check_apply_id", check.ApplyID,
 			"check_status", check.Status, "check_head_sha", check.HeadSHA)
-		return
+		return false
 	}
 
 	h.logger.Info("check set to action_required after rollback",
@@ -510,4 +520,5 @@ func (h *Handler) setCheckActionRequired(repo string, pr int, installationID int
 			"apply_id", apply.ID, "apply_identifier", apply.ApplyIdentifier,
 			"error", err)
 	}
+	return true
 }

--- a/pkg/webhook/check_records_rollback_test.go
+++ b/pkg/webhook/check_records_rollback_test.go
@@ -3,6 +3,7 @@
 package webhook
 
 import (
+	"context"
 	"database/sql"
 	"log/slog"
 	"net/url"
@@ -32,6 +33,7 @@ func TestRefreshChecksForTerminalApply_CompletedRollbackIsActionRequired(t *test
 
 	db, err := sql.Open("mysql", e2eSchemabotDSN)
 	require.NoError(t, err)
+	require.NoError(t, db.PingContext(ctx))
 	t.Cleanup(func() { _ = db.Close() })
 
 	const (
@@ -41,12 +43,16 @@ func TestRefreshChecksForTerminalApply_CompletedRollbackIsActionRequired(t *test
 		env  = "staging"
 	)
 
-	clear := func() {
-		_, _ = db.ExecContext(ctx, "DELETE FROM checks WHERE repository = ? AND pull_request = ?", repo, pr)
-		_, _ = db.ExecContext(ctx, "DELETE FROM applies WHERE repository = ? AND pull_request = ?", repo, pr)
+	clear := func(c context.Context) {
+		_, err := db.ExecContext(c, "DELETE FROM checks WHERE repository = ? AND pull_request = ?", repo, pr)
+		require.NoError(t, err)
+		_, err = db.ExecContext(c, "DELETE FROM applies WHERE repository = ? AND pull_request = ?", repo, pr)
+		require.NoError(t, err)
 	}
-	clear()
-	t.Cleanup(clear)
+	clear(ctx)
+	// Cleanup runs after t.Context() is cancelled, so derive a non-cancelled
+	// context from it for the cleanup deletes.
+	t.Cleanup(func() { clear(context.WithoutCancel(ctx)) })
 
 	st := mysqlstore.New(db)
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))

--- a/pkg/webhook/check_records_rollback_test.go
+++ b/pkg/webhook/check_records_rollback_test.go
@@ -1,0 +1,106 @@
+//go:build integration
+
+package webhook
+
+import (
+	"database/sql"
+	"log/slog"
+	"net/url"
+	"os"
+	"testing"
+
+	gh "github.com/google/go-github/v86/github"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/block/schemabot/pkg/api"
+	ghclient "github.com/block/schemabot/pkg/github"
+	"github.com/block/schemabot/pkg/state"
+	"github.com/block/schemabot/pkg/storage"
+	"github.com/block/schemabot/pkg/storage/mysqlstore"
+)
+
+// A rollback reverts a previously applied schema change, so once it completes
+// the required status check must read action_required — the PR's change is gone
+// from the environment and the PR must not merge as-is. Operation-level operator
+// claiming drives the rollback to terminal through the durable summary path
+// (refreshChecksForTerminalApply), which suppresses the rollback command's own
+// observer, so the durable path must itself recognize a rollback and refuse to
+// mark the check successful.
+func TestRefreshChecksForTerminalApply_CompletedRollbackIsActionRequired(t *testing.T) {
+	ctx := t.Context()
+
+	db, err := sql.Open("mysql", e2eSchemabotDSN)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	const (
+		repo = "octocat/rollback-check"
+		pr   = 8
+		dbn  = "rollback_check_db"
+		env  = "staging"
+	)
+
+	clear := func() {
+		_, _ = db.ExecContext(ctx, "DELETE FROM checks WHERE repository = ? AND pull_request = ?", repo, pr)
+		_, _ = db.ExecContext(ctx, "DELETE FROM applies WHERE repository = ? AND pull_request = ?", repo, pr)
+	}
+	clear()
+	t.Cleanup(clear)
+
+	st := mysqlstore.New(db)
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	svc := api.New(st, &api.ServerConfig{}, nil, logger)
+
+	// setCheckActionRequired resolves a GitHub client to refresh the aggregate
+	// Check Run after writing stored state. Point it at an unrouted test server:
+	// the stored update (the behavior under test) lands first, and the GitHub
+	// refresh fails gracefully without a real installation.
+	ghClient := gh.NewClient(nil)
+	ghClient.BaseURL, err = url.Parse("http://127.0.0.1:0/")
+	require.NoError(t, err)
+	factory := &fakeClientFactory{client: ghclient.NewInstallationClient(ghClient, logger)}
+	h := NewHandler(svc, factory, nil, logger)
+
+	apply := &storage.Apply{
+		ApplyIdentifier: "apply-rollback-terminal",
+		Database:        dbn,
+		DatabaseType:    "mysql",
+		Repository:      repo,
+		PullRequest:     pr,
+		Environment:     env,
+		Engine:          storage.EngineSpirit,
+		InstallationID:  4242,
+		State:           state.Apply.Completed,
+		Options:         storage.MarshalApplyOptions(storage.ApplyOptions{AllowUnsafe: true, Rollback: true}),
+	}
+	applyID, err := st.Applies().Create(ctx, apply)
+	require.NoError(t, err)
+	apply.ID = applyID
+
+	// rollback-confirm marked the check in_progress and owned by the rollback
+	// apply before the operator drove it.
+	require.NoError(t, st.Checks().Upsert(ctx, &storage.Check{
+		Repository:   repo,
+		PullRequest:  pr,
+		HeadSHA:      "abc123",
+		Environment:  env,
+		DatabaseType: "mysql",
+		DatabaseName: dbn,
+		CheckRunID:   1,
+		ApplyID:      applyID,
+		HasChanges:   false,
+		Status:       checkStatusInProgress,
+	}))
+
+	h.refreshChecksForTerminalApply(ctx, apply, "test rollback terminal")
+
+	check, err := st.Checks().Get(ctx, repo, pr, env, "mysql", dbn)
+	require.NoError(t, err)
+	require.NotNil(t, check)
+	assert.Equal(t, checkStatusCompleted, check.Status)
+	assert.Equal(t, checkConclusionActionRequired, check.Conclusion, "a completed rollback must block the PR, not pass it")
+	assert.Equal(t, rollbackCompletedBlock.blockingReason, check.BlockingReason)
+	assert.True(t, check.HasChanges, "the PR's reverted change is still outstanding")
+	assert.Zero(t, check.ApplyID, "rollback finalization releases check ownership so a re-apply can take over")
+}

--- a/pkg/webhook/handler.go
+++ b/pkg/webhook/handler.go
@@ -232,6 +232,17 @@ func (h *Handler) refreshChecksForTerminalApply(ctx context.Context, a *storage.
 			"context", logCtx,
 		}
 	}
+	// A completed rollback reverted the PR's schema change, so its required check
+	// must land action_required, not success — otherwise the PR could merge with
+	// the change missing. The rollback command registers an observer that does
+	// this, but an operator-driven (multi-operation) or recovery terminal
+	// suppresses that per-driver observer and routes here instead, so the
+	// rollback intent must be honored from the durable apply.
+	if a.IsRollback() && state.IsState(a.State, state.Apply.Completed) {
+		h.logger.Info("refreshing check to action_required for completed rollback", checkFields()...)
+		h.setCheckActionRequired(a.Repository, a.PullRequest, a.InstallationID, a)
+		return
+	}
 	updated, err := h.updateCheckRecordForApplyResult(ctx, a.Repository, a.PullRequest, a)
 	if err != nil {
 		h.logger.Error("observer: failed to update check record for terminal apply",

--- a/pkg/webhook/rollback.go
+++ b/pkg/webhook/rollback.go
@@ -330,9 +330,13 @@ func (h *Handler) handleRollbackConfirmCommand(repo string, pr int, environment 
 		return
 	}
 
-	// Build apply options — rollback always allows unsafe changes
+	// Build apply options — rollback always allows unsafe changes, and is marked
+	// as a rollback so the terminal check update lands action_required (the PR's
+	// change is reverted) even when an operator driver, not this command's
+	// observer, publishes the terminal result.
 	options := map[string]string{
 		"allow_unsafe": "true",
+		"rollback":     "true",
 	}
 	if result.DeferCutover {
 		options["defer_cutover"] = "true"


### PR DESCRIPTION
A rollback reverts a previously applied schema change, so once it completes the required status check must read `action_required` — the PR's change is gone from the environment and the PR must not merge as-is.

The rollback command registers an observer that does this, but operation-level operator claiming drives the rollback to terminal through the durable summary path, which suppresses that per-driver observer. That path was rollback-unaware and marked the check **successful**, so a completed PR-comment rollback left a green check that allowed the PR to merge with its change reverted.

This marks rollback applies durably (`storage.ApplyOptions.Rollback`) and teaches the durable terminal and stale-check reconciliation paths to finalize a completed rollback as `action_required`, matching the rollback command's own observer.

```
rollback-confirm → operator drives → terminal
  before:  refreshChecksForTerminalApply → success      ✗ PR mergeable, change reverted
  after:   refreshChecksForTerminalApply → action_required ✓ PR blocked until reconciled
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)