### PR TITLE
test(e2e): assert on_failure:continue cuts over healthy siblings

### DIFF
--- a/deploy/local/config/grpc-schemabot-multideploy.yaml
+++ b/deploy/local/config/grpc-schemabot-multideploy.yaml
@@ -11,9 +11,14 @@
 # rollout-failure policy:
 #   - production           -> on_failure: halt (default): a failed deployment
 #                             halts the rollout; healthy siblings do not cut over.
-#   - production-continue  -> on_failure: continue: a failed deployment is
-#                             treated as settled; healthy siblings still cut over
-#                             and complete, and the apply settles to failed.
+#   - production-continue  -> on_failure: continue: a failed deployment should
+#                             be treated as settled so healthy siblings still cut
+#                             over and complete while the apply settles to failed.
+#                             This env encodes that intended behavior; until the
+#                             barrier-release semantics for a continue-failed
+#                             predecessor land (OC-5), the healthy sibling parks
+#                             at waiting_for_cutover and the scenario is expected
+#                             to fail.
 # Both use cutover_policy: barrier and deployment_order [eu, us].
 
 # SchemaBot's own storage database

--- a/deploy/local/config/grpc-schemabot-multideploy.yaml
+++ b/deploy/local/config/grpc-schemabot-multideploy.yaml
@@ -1,25 +1,25 @@
 # SchemaBot Configuration (gRPC Mode - multi-deployment fan-out)
 #
-# A single (database, environment) — testapp/production — fans out to TWO
-# deployments (eu, us), each backed by its own remote Tern service and MySQL.
-# This is the shape exercised by the multi-deployment ordered-cutover
-# acceptance test.
+# A single (database, environment) fans out to TWO deployments (eu, us), each
+# backed by its own remote Tern service and MySQL. This is the shape exercised
+# by the multi-deployment ordered-cutover acceptance tests.
 #
 # Contrast with grpc-schemabot.yaml, which wires two Terns as two *environments*
 # (staging/production) of a single "default" deployment.
 #
-# NOTE: This config sets a deployments map with >1 entry. SchemaBot's config
-# validation currently rejects that with:
-#   "multi-deployment (>1 entries) is not yet supported by this server"
-# so a stack booted from this file will NOT come up until the server supports
-# deployments maps with more than one entry. The fixture is committed now so the
-# harness is ready the moment that support lands.
+# Two environments share the same pair of remote Terns, differing only in
+# rollout-failure policy:
+#   - production           -> on_failure: halt (default): a failed deployment
+#                             halts the rollout; healthy siblings do not cut over.
+#   - production-continue  -> on_failure: continue: a failed deployment is
+#                             treated as settled; healthy siblings still cut over
+#                             and complete, and the apply settles to failed.
+# Both use cutover_policy: barrier and deployment_order [eu, us].
 
 # SchemaBot's own storage database
 storage:
   dsn: "env:MYSQL_DSN"
 
-# gRPC mode: one environment (production) fanning out to two deployments.
 databases:
   testapp:
     type: mysql
@@ -34,10 +34,23 @@ databases:
             target: testapp
           us:
             target: testapp
+      production-continue:
+        cutover_policy: barrier
+        on_failure: continue
+        deployment_order:
+          - eu
+          - us
+        deployments:
+          eu:
+            target: testapp
+          us:
+            target: testapp
 
-# Per-deployment Tern gRPC endpoints.
+# Per-deployment Tern gRPC endpoints. Both environments reuse the same Terns.
 tern_deployments:
   eu:
     production: "tern-eu:9090"
+    production-continue: "tern-eu:9090"
   us:
     production: "tern-us:9090"
+    production-continue: "tern-us:9090"

--- a/e2e/grpc/multideploy_test.go
+++ b/e2e/grpc/multideploy_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/block/schemabot/e2e/testutil"
 	"github.com/block/schemabot/pkg/state"
 	"github.com/block/spirit/pkg/utils"
+	"github.com/go-sql-driver/mysql"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -207,6 +208,106 @@ func failedApplyState(s string) bool {
 	return state.IsState(s, state.Apply.Failed) || state.IsState(s, state.Apply.FailedRetryable)
 }
 
+// multiDeployTernStorageDSN returns the DSN for one deployment's Tern storage
+// database (the `tern` schema on that deployment's MySQL instance, alongside
+// the `testapp` target schema).
+func multiDeployTernStorageDSN(t *testing.T, deployment string) string {
+	t.Helper()
+	cfg, err := mysql.ParseDSN(multiDeployTernMySQLDSN(t, deployment))
+	require.NoErrorf(t, err, "parse tern dsn (%s)", deployment)
+	cfg.DBName = "tern"
+	return cfg.FormatDSN()
+}
+
+// multiDeployClearTernStorage clears every deployment's Tern storage so the
+// next test starts clean. Unlike the single-deployment helper, the fan-out
+// stack keeps one Tern storage DB per deployment instance, so a sibling's rows
+// would otherwise linger and keep its operation active.
+func multiDeployClearTernStorage(t *testing.T, deployments ...string) {
+	t.Helper()
+	for _, d := range deployments {
+		db, err := sql.Open("mysql", multiDeployTernStorageDSN(t, d))
+		if err != nil {
+			t.Logf("cleanup: open tern storage db (%s): %v", d, err)
+			continue
+		}
+		func() {
+			defer utils.CloseAndLog(db)
+			ctx, cancel := context.WithTimeout(context.WithoutCancel(t.Context()), 30*time.Second)
+			defer cancel()
+
+			rows, err := db.QueryContext(ctx, "SHOW TABLES")
+			if err != nil {
+				t.Logf("cleanup: show tables on tern storage (%s): %v", d, err)
+				return
+			}
+			var tables []string
+			for rows.Next() {
+				var table string
+				if err := rows.Scan(&table); err != nil {
+					t.Logf("cleanup: scan tern table name (%s): %v", d, err)
+					break
+				}
+				tables = append(tables, table)
+			}
+			rowsErr := rows.Err()
+			utils.CloseAndLog(rows)
+			if rowsErr != nil {
+				t.Logf("cleanup: iterate tern tables (%s): %v", d, rowsErr)
+				return
+			}
+			for _, table := range tables {
+				if _, err := db.ExecContext(ctx, "DELETE FROM `"+table+"`"); err != nil {
+					t.Logf("cleanup: clear tern table %s (%s): %v", table, d, err)
+				}
+			}
+		}()
+	}
+}
+
+// multiDeployEnsureNoActiveChange clears any active schema change for the
+// fan-out (database, env). It mirrors grpcEnsureNoActiveChange but clears Tern
+// storage on every deployment instance, since the fan-out keeps a separate Tern
+// storage DB per deployment.
+func multiDeployEnsureNoActiveChange(t *testing.T, database, env string, deployments ...string) {
+	t.Helper()
+
+	deadline := time.Now().Add(time.Minute)
+	for time.Now().Before(deadline) {
+		active := grpcFindLatestApplyForDatabase(t, database, env)
+
+		// Terminal applies, including failed applies, do not hold active locks,
+		// so clear storage directly rather than reverting.
+		if active == nil || state.IsTerminalApplyState(active.State) ||
+			state.IsState(active.State, state.Apply.RevertWindow, state.Apply.Reverted) {
+			multiDeployClearTernStorage(t, deployments...)
+			grpcClearSchemabotState(t)
+			return
+		}
+
+		if state.IsState(active.State, state.Apply.FailedRetryable) {
+			multiDeployClearTernStorage(t, deployments...)
+			grpcClearSchemabotState(t)
+			time.Sleep(500 * time.Millisecond)
+			continue
+		}
+
+		// Parked at the cutover barrier from a prior test — release it.
+		if state.IsState(active.State, state.Apply.WaitingForCutover) {
+			resp := grpcPost(t, "/api/cutover", map[string]string{
+				"environment": env,
+				"apply_id":    active.ApplyID,
+			})
+			_ = resp.Body.Close()
+			time.Sleep(time.Second)
+			continue
+		}
+
+		time.Sleep(time.Second)
+	}
+	require.Fail(t, "could not ensure no active schema change within deadline")
+}
+
 // TestGRPCMultiDeploy_OrderedCutover verifies that a single fan-out apply over
 // two deployments honours barrier-policy ordered cutover.
 //
@@ -238,7 +339,7 @@ func TestGRPCMultiDeploy_OrderedCutover(t *testing.T) {
 			"CONCAT('user_', seq), REPEAT('x', 200)", 10000)
 	}
 
-	grpcEnsureNoActiveChange(t, database, env)
+	multiDeployEnsureNoActiveChange(t, database, env, first, second)
 
 	// Widen the primary key from INT to BIGINT to force a full table copy on
 	// every deployment.
@@ -306,7 +407,7 @@ func TestGRPCMultiDeploy_OrderedCutover(t *testing.T) {
 		"expected %s (completed %s) to cut over no earlier than %s (completed %s)",
 		second, final[second].CompletedAt, first, final[first].CompletedAt)
 
-	grpcEnsureNoActiveChange(t, database, env)
+	multiDeployEnsureNoActiveChange(t, database, env, first, second)
 }
 
 // TestGRPCMultiDeploy_FailureHaltsRollout verifies that a deployment failure
@@ -340,7 +441,7 @@ func TestGRPCMultiDeploy_FailureHaltsRollout(t *testing.T) {
 	multiDeploySeedRows(t, first, tableName, "name, data", "'dup', REPEAT('x', 200)", 10000)
 	multiDeploySeedRows(t, second, tableName, "name, data", "CONCAT('user_', seq), REPEAT('x', 200)", 10000)
 
-	grpcEnsureNoActiveChange(t, database, env)
+	multiDeployEnsureNoActiveChange(t, database, env, first, second)
 
 	// Add a UNIQUE index on name; the earlier deployment's duplicate data makes
 	// its copy fail.
@@ -380,7 +481,7 @@ func TestGRPCMultiDeploy_FailureHaltsRollout(t *testing.T) {
 	prog := grpcProgressByApplyID(t, apply.ApplyID)
 	assert.Truef(t, failedApplyState(prog.State), "aggregate apply state should be failed, was %q", prog.State)
 
-	grpcEnsureNoActiveChange(t, database, env)
+	multiDeployEnsureNoActiveChange(t, database, env, first, second)
 }
 
 // TestGRPCMultiDeploy_OnFailureContinue verifies that `on_failure: continue`
@@ -415,7 +516,7 @@ func TestGRPCMultiDeploy_OnFailureContinue(t *testing.T) {
 	multiDeploySeedRows(t, first, tableName, "name, data", "'dup', REPEAT('x', 200)", 10000)
 	multiDeploySeedRows(t, second, tableName, "name, data", "CONCAT('user_', seq), REPEAT('x', 200)", 10000)
 
-	grpcEnsureNoActiveChange(t, database, env)
+	multiDeployEnsureNoActiveChange(t, database, env, first, second)
 
 	plan := grpcPlan(t, database, env, map[string]string{
 		tableName + ".sql": fmt.Sprintf(
@@ -453,5 +554,5 @@ func TestGRPCMultiDeploy_OnFailureContinue(t *testing.T) {
 	prog := grpcProgressByApplyID(t, apply.ApplyID)
 	assert.Truef(t, failedApplyState(prog.State), "aggregate apply state should be failed, was %q", prog.State)
 
-	grpcEnsureNoActiveChange(t, database, env)
+	multiDeployEnsureNoActiveChange(t, database, env, first, second)
 }

--- a/e2e/grpc/multideploy_test.go
+++ b/e2e/grpc/multideploy_test.go
@@ -227,14 +227,16 @@ func multiDeployClearTernStorage(t *testing.T, deployments ...string) {
 	t.Helper()
 	for _, d := range deployments {
 		db, err := sql.Open("mysql", multiDeployTernStorageDSN(t, d))
-		if err != nil {
-			t.Logf("cleanup: open tern storage db (%s): %v", d, err)
-			continue
-		}
+		require.NoErrorf(t, err, "cleanup: open tern storage db (%s)", d)
 		func() {
 			defer utils.CloseAndLog(db)
 			ctx, cancel := context.WithTimeout(context.WithoutCancel(t.Context()), 30*time.Second)
 			defer cancel()
+
+			// sql.Open is lazy and rarely validates the DSN or connectivity, so
+			// ping before issuing cleanup queries: a silently skipped cleanup
+			// leaves a sibling's Tern rows behind and makes later tests flaky.
+			require.NoErrorf(t, db.PingContext(ctx), "cleanup: ping tern storage db (%s)", d)
 
 			rows, err := db.QueryContext(ctx, "SHOW TABLES")
 			if err != nil {
@@ -533,18 +535,18 @@ func TestGRPCMultiDeploy_OnFailureContinue(t *testing.T) {
 	// earlier failure.
 	testutil.Poll(t, orderedCutoverDeadline, testutil.PollInterval,
 		func() bool {
-			ops := multiDeployOperationStates(t, apply.ApplyID)
+			ops := multiDeployOps(t, apply.ApplyID, first, second)
 			return failedApplyState(ops[first].State) &&
 				state.IsState(ops[second].State, state.Apply.Completed)
 		},
 		func() string {
-			ops := multiDeployOperationStates(t, apply.ApplyID)
+			ops := multiDeployOps(t, apply.ApplyID, first, second)
 			return fmt.Sprintf("waiting for %s failed + %s completed; %s=%q %s=%q",
 				first, second, first, ops[first].State, second, ops[second].State)
 		},
 	)
 
-	final := multiDeployOperationStates(t, apply.ApplyID)
+	final := multiDeployOps(t, apply.ApplyID, first, second)
 	assert.Truef(t, failedApplyState(final[first].State), "%s should be failed, was %q", first, final[first].State)
 	assert.Truef(t, state.IsState(final[second].State, state.Apply.Completed),
 		"%s should complete under on_failure: continue, was %q", second, final[second].State)

--- a/e2e/grpc/multideploy_test.go
+++ b/e2e/grpc/multideploy_test.go
@@ -382,3 +382,76 @@ func TestGRPCMultiDeploy_FailureHaltsRollout(t *testing.T) {
 
 	grpcEnsureNoActiveChange(t, database, env)
 }
+
+// TestGRPCMultiDeploy_OnFailureContinue verifies that `on_failure: continue`
+// lets a barrier-policy fan-out finish healthy deployments despite a sibling
+// failure.
+//
+// Scenario: testapp/production-continue fans out to [eu, us] with
+// deployment_order [eu, us], cutover_policy: barrier, and on_failure: continue.
+// The earlier deployment (eu) is seeded with duplicate data so adding a UNIQUE
+// key fails its copy; the later deployment (us) is healthy. Because the policy
+// is continue, eu's failure is treated as settled rather than halting the
+// rollout: us still cuts over and reaches completed. The apply itself settles
+// to failed — continue governs rollout continuation, not the pass/fail verdict.
+func TestGRPCMultiDeploy_OnFailureContinue(t *testing.T) {
+	requireMultiDeploy(t)
+
+	const (
+		database = "testapp"
+		env      = "production-continue"
+	)
+	// Matches deployment_order in grpc-schemabot-multideploy.yaml.
+	first, second := "eu", "us"
+
+	tableName := uniqueGRPCTableName("md_continue")
+	createDDL := fmt.Sprintf(
+		"CREATE TABLE %s (id INT NOT NULL AUTO_INCREMENT PRIMARY KEY, name VARCHAR(255) NOT NULL, data TEXT)", tableName)
+	for _, d := range []string{first, second} {
+		multiDeployCreateTestTable(t, d, tableName, createDDL)
+	}
+	// The earlier deployment gets identical names so adding UNIQUE(name) fails
+	// during its copy; the later deployment gets unique names so it completes.
+	multiDeploySeedRows(t, first, tableName, "name, data", "'dup', REPEAT('x', 200)", 10000)
+	multiDeploySeedRows(t, second, tableName, "name, data", "CONCAT('user_', seq), REPEAT('x', 200)", 10000)
+
+	grpcEnsureNoActiveChange(t, database, env)
+
+	plan := grpcPlan(t, database, env, map[string]string{
+		tableName + ".sql": fmt.Sprintf(
+			"CREATE TABLE %s (id INT NOT NULL AUTO_INCREMENT PRIMARY KEY, name VARCHAR(255) NOT NULL, data TEXT, UNIQUE KEY uniq_name (name));", tableName),
+	})
+	require.Empty(t, plan.Errors, "plan errors: %v", plan.Errors)
+	require.NotEmpty(t, plan.PlanID, "plan_id")
+
+	apply := grpcApply(t, plan.PlanID, env, nil)
+	require.True(t, apply.Accepted, "apply not accepted: %s", apply.ErrorMessage)
+
+	// Wait until both deployments are terminal: the earlier failed, the later
+	// completed. Under continue, the later sibling must not be blocked by the
+	// earlier failure.
+	testutil.Poll(t, orderedCutoverDeadline, testutil.PollInterval,
+		func() bool {
+			ops := multiDeployOperationStates(t, apply.ApplyID)
+			return failedApplyState(ops[first].State) &&
+				state.IsState(ops[second].State, state.Apply.Completed)
+		},
+		func() string {
+			ops := multiDeployOperationStates(t, apply.ApplyID)
+			return fmt.Sprintf("waiting for %s failed + %s completed; %s=%q %s=%q",
+				first, second, first, ops[first].State, second, ops[second].State)
+		},
+	)
+
+	final := multiDeployOperationStates(t, apply.ApplyID)
+	assert.Truef(t, failedApplyState(final[first].State), "%s should be failed, was %q", first, final[first].State)
+	assert.Truef(t, state.IsState(final[second].State, state.Apply.Completed),
+		"%s should complete under on_failure: continue, was %q", second, final[second].State)
+
+	// The apply settles to failed even though a sibling completed — continue
+	// governs rollout continuation, not the verdict.
+	prog := grpcProgressByApplyID(t, apply.ApplyID)
+	assert.Truef(t, failedApplyState(prog.State), "aggregate apply state should be failed, was %q", prog.State)
+
+	grpcEnsureNoActiveChange(t, database, env)
+}


### PR DESCRIPTION
## Summary

Adds a multi-deployment fan-out e2e test (`TestGRPCMultiDeploy_OnFailureContinue`)
and a `production-continue` config env to prove that, under
`cutover_policy: barrier` + `on_failure: continue`, a failed earlier deployment
does **not** block a healthy later one — the later still cuts over to `completed`
while the apply settles to `failed`.

> **Draft — currently red.** This PR is the live reproducer for a product gap
> (tracked as **OC-5**): the later deployment now copies but parks at
> `waiting_for_cutover` forever. See below.

## Why / what it surfaces

`#475` (materialize remote plan from apply request payload) cleared the upstream
`plan not found` dispatch, so the successor deployment now plans and copies. But
the ordered-cutover barrier only releases a successor once its predecessor reaches
`completed` — a predecessor that **failed under `on_failure: continue` never
does**, so the healthy successor hangs at `waiting_for_cutover`
(`cutover_attempts=0`) until timeout. This is not a timing race; it is a missing
barrier-release semantic. Fixing it is OC-5.

```diagram
BEFORE (#466, pre-#475)                AFTER (#475, this PR — still red)
─────────────────────────             ──────────────────────────────────
eu  ─fail─▶ apply failed               eu  ─fail─▶ apply settles failed
us  ─▶ "plan not found" ╳              us  ─▶ plan ─▶ copy ─▶ waiting_for_cutover
        (never dispatched)                     barrier needs eu==completed ──╳ never released

                                       OC-5 fix (follow-up):
                                       treat eu's continue-failure as "settled"
                                       ─▶ release us ─▶ us cutover ─▶ completed
```

## Harness note

Bundles a per-deployment tern-storage cleanup helper
(multiDeployEnsureNoActiveChange) because the fan-out stack keeps one Tern
storage DB per deployment and the single-deployment cleanup never matched. The
same helper ships independently as the standalone harness PR; once that merges,
rebasing this branch drops the helper diff and leaves only the test + config.

## Testing / validation
```
gofmt / go vet -tags=e2e / golangci-lint --build-tags=e2e / go build
all clean. 

Live E2E_MULTIDEPLOY=1 run reproduces the red state above
(eu=failed, us stuck at waiting_for_cutover → timeout) — kept red on
purpose until OC-5 lands.
```
## References

- Blocked on OC-5 (continue barrier-release)
- Builds on #475 (remote plan materialization)
- Harness helper also extracted as the standalone multideploy tern-cleanup PR
