### PR TITLE
feat(tern): fail closed when a materialized remote plan drifts from live schema

### DIFF
--- a/pkg/tern/local_client.go
+++ b/pkg/tern/local_client.go
@@ -1249,6 +1249,10 @@ func (c *LocalClient) materializeApplyRequestPlan(ctx context.Context, req *tern
 		return nil, fmt.Errorf("materialize plan %s: apply request carried no DDL changes or schema files", req.PlanId)
 	}
 
+	if err := c.verifyMaterializedPlanMatchesLiveSchema(ctx, req, schemaFiles); err != nil {
+		return nil, fmt.Errorf("materialize plan %s: %w", req.PlanId, err)
+	}
+
 	target := req.Target
 	if target == "" {
 		target = c.config.Database
@@ -1364,6 +1368,191 @@ func materializedTableChangeOperation(ch *ternv1.TableChange) (string, error) {
 		return "", fmt.Errorf("classify DDL for table %q: %w", ch.TableName, err)
 	}
 	return op, nil
+}
+
+// driftChangeKey identifies a single table DDL change for drift comparison. Two
+// changes are the same iff they target the same namespace and table with the
+// same operation and canonicalized DDL.
+type driftChangeKey struct {
+	namespace string
+	table     string
+	operation string
+	ddl       string
+}
+
+// driftChangeMultiset counts table DDL changes by key so duplicate changes are
+// compared exactly (set equality would silently tolerate a duplicated change).
+type driftChangeMultiset map[driftChangeKey]int
+
+// verifyMaterializedPlanMatchesLiveSchema fails closed unless the reviewed DDL
+// carried by a dispatch request is exactly what this deployment would plan
+// against its own live schema. A non-primary deployment never planned locally —
+// the reviewed plan was computed against the primary deployment's live schema —
+// so blindly materializing it would silently replay the primary's DDL on a
+// deployment whose schema may have drifted. Recomputing the local diff and
+// requiring an exact match keeps non-primary drift from being applied unreviewed.
+func (c *LocalClient) verifyMaterializedPlanMatchesLiveSchema(ctx context.Context, req *ternv1.ApplyRequest, schemaFiles schema.SchemaFiles) error {
+	if len(req.TargetShards) > 0 {
+		return fmt.Errorf("drift guard does not support shard-scoped applies (target_shards=%v); a whole-deployment replan cannot be compared to a shard subset", req.TargetShards)
+	}
+
+	result, err := c.planWithEngine(ctx, &ternv1.PlanRequest{
+		Database:    c.config.Database,
+		Type:        c.config.Type,
+		Environment: req.Environment,
+		Target:      req.Target,
+	}, c.config.Database, schemaFiles)
+	if err != nil {
+		return fmt.Errorf("recompute local plan: %w", err)
+	}
+
+	recomputed, err := c.driftMultisetFromPlanResult(result)
+	if err != nil {
+		return fmt.Errorf("recomputed plan: %w", err)
+	}
+	dispatched, err := c.driftMultisetFromApplyRequest(req.DdlChanges)
+	if err != nil {
+		return fmt.Errorf("dispatched plan: %w", err)
+	}
+	if err := compareDriftMultisets(recomputed, dispatched); err != nil {
+		return fmt.Errorf("local schema has drifted from the reviewed plan (database %q, target %q): %w", c.config.Database, req.Target, err)
+	}
+
+	if err := compareVSchemaParity(vschemaNamespacesFromPlanResult(c, result), vschemaNamespacesFromApplyRequest(c, req.DdlChanges)); err != nil {
+		return fmt.Errorf("local vschema has drifted from the reviewed plan (database %q, target %q): %w", c.config.Database, req.Target, err)
+	}
+	return nil
+}
+
+// driftMultisetFromPlanResult builds the table DDL multiset this deployment
+// would plan against its own live schema. VSchema changes carry no table DDL and
+// are compared separately, so they are excluded here.
+func (c *LocalClient) driftMultisetFromPlanResult(result *engine.PlanResult) (driftChangeMultiset, error) {
+	ms := driftChangeMultiset{}
+	for _, sc := range result.Changes {
+		ns := c.planNamespace(sc.Namespace)
+		for _, tc := range sc.TableChanges {
+			canon, err := canonicalDDLForDrift(tc.DDL)
+			if err != nil {
+				return nil, fmt.Errorf("table %q: %w", tc.Table, err)
+			}
+			ms[driftChangeKey{ns, tc.Table, ddl.StatementTypeToOp(tc.Operation), canon}]++
+		}
+	}
+	return ms, nil
+}
+
+// driftMultisetFromApplyRequest builds the table DDL multiset the dispatch
+// request carries as the reviewed, authoritative plan. VSchema changes are
+// compared separately and excluded here. Nil entries are corrupt input and fail
+// closed.
+func (c *LocalClient) driftMultisetFromApplyRequest(changes []*ternv1.TableChange) (driftChangeMultiset, error) {
+	ms := driftChangeMultiset{}
+	for _, ch := range changes {
+		if ch == nil {
+			return nil, fmt.Errorf("dispatch request carried a nil table change")
+		}
+		if ch.ChangeType == ternv1.ChangeType_CHANGE_TYPE_VSCHEMA {
+			continue
+		}
+		op, err := materializedTableChangeOperation(ch)
+		if err != nil {
+			return nil, err
+		}
+		canon, err := canonicalDDLForDrift(ch.Ddl)
+		if err != nil {
+			return nil, fmt.Errorf("table %q: %w", ch.TableName, err)
+		}
+		ms[driftChangeKey{c.planNamespace(ch.Namespace), ch.TableName, op, canon}]++
+	}
+	return ms, nil
+}
+
+// canonicalDDLForDrift normalizes a DDL statement for comparison and fails
+// closed if it cannot be parsed — ddl.Canonicalize returns the input unchanged
+// on a parse failure, so an unparseable statement would otherwise compare by raw
+// text and could mask drift.
+func canonicalDDLForDrift(raw string) (string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", fmt.Errorf("empty DDL")
+	}
+	if _, _, err := ddl.ClassifyStatement(raw); err != nil {
+		return "", fmt.Errorf("unparseable DDL: %w", err)
+	}
+	return ddl.Canonicalize(raw), nil
+}
+
+// compareDriftMultisets reports drift unless the recomputed and dispatched table
+// DDL multisets are exactly equal.
+func compareDriftMultisets(recomputed, dispatched driftChangeMultiset) error {
+	var missing, unexpected []string
+	for key, want := range dispatched {
+		if recomputed[key] < want {
+			missing = append(missing, formatDriftKey(key))
+		}
+	}
+	for key, have := range recomputed {
+		if have > dispatched[key] {
+			unexpected = append(unexpected, formatDriftKey(key))
+		}
+	}
+	if len(missing) == 0 && len(unexpected) == 0 {
+		return nil
+	}
+	sort.Strings(missing)
+	sort.Strings(unexpected)
+	return fmt.Errorf("reviewed changes this deployment would not plan: %v; changes this deployment would plan that were not reviewed: %v", missing, unexpected)
+}
+
+func formatDriftKey(k driftChangeKey) string {
+	return fmt.Sprintf("%s.%s/%s", k.namespace, k.table, k.operation)
+}
+
+// vschemaNamespacesFromPlanResult returns the namespaces the recomputed plan
+// detected a vschema change for.
+func vschemaNamespacesFromPlanResult(c *LocalClient, result *engine.PlanResult) map[string]bool {
+	out := map[string]bool{}
+	for _, sc := range result.Changes {
+		if sc.Metadata["vschema_changed"] == "true" {
+			out[c.planNamespace(sc.Namespace)] = true
+		}
+	}
+	return out
+}
+
+// vschemaNamespacesFromApplyRequest returns the namespaces the dispatch request
+// carries a vschema change for.
+func vschemaNamespacesFromApplyRequest(c *LocalClient, changes []*ternv1.TableChange) map[string]bool {
+	out := map[string]bool{}
+	for _, ch := range changes {
+		if ch != nil && ch.ChangeType == ternv1.ChangeType_CHANGE_TYPE_VSCHEMA {
+			out[c.planNamespace(ch.Namespace)] = true
+		}
+	}
+	return out
+}
+
+// compareVSchemaParity reports drift unless the recomputed and dispatched
+// vschema-changed namespaces are exactly equal.
+func compareVSchemaParity(recomputed, dispatched map[string]bool) error {
+	var missing, unexpected []string
+	for ns := range dispatched {
+		if !recomputed[ns] {
+			missing = append(missing, ns)
+		}
+	}
+	for ns := range recomputed {
+		if !dispatched[ns] {
+			unexpected = append(unexpected, ns)
+		}
+	}
+	if len(missing) == 0 && len(unexpected) == 0 {
+		return nil
+	}
+	sort.Strings(missing)
+	sort.Strings(unexpected)
+	return fmt.Errorf("reviewed vschema changes this deployment would not plan: %v; vschema changes this deployment would plan that were not reviewed: %v", missing, unexpected)
 }
 
 // Apply executes a previously generated plan.

--- a/pkg/tern/local_client.go
+++ b/pkg/tern/local_client.go
@@ -1506,7 +1506,11 @@ func compareDriftMultisets(recomputed, dispatched driftChangeMultiset) error {
 }
 
 func formatDriftKey(k driftChangeKey) string {
-	return fmt.Sprintf("%s.%s/%s", k.namespace, k.table, k.operation)
+	// Include the canonicalized DDL: the multiset keys on it, so two changes for
+	// the same namespace/table/operation that differ only in DDL must render
+	// differently or the drift message would list identical-looking entries on
+	// both sides and hide what actually drifted.
+	return fmt.Sprintf("%s.%s/%s (%s)", k.namespace, k.table, k.operation, k.ddl)
 }
 
 // vschemaNamespacesFromPlanResult returns the namespaces the recomputed plan

--- a/pkg/tern/local_plan_drift_guard_test.go
+++ b/pkg/tern/local_plan_drift_guard_test.go
@@ -189,3 +189,31 @@ func TestDriftGuard_RecomputeErrorFailsClosed(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "recompute local plan")
 }
+
+// canonicalDDLForDrift must fail closed on DDL it cannot parse: ddl.Canonicalize
+// returns its input unchanged on a parse failure, so without this guard an
+// unparseable statement would silently compare by raw text and could mask drift.
+func TestCanonicalDDLForDrift_FailsClosed(t *testing.T) {
+	t.Run("unparseable DDL is rejected", func(t *testing.T) {
+		_, err := canonicalDDLForDrift("this is not valid sql")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unparseable DDL")
+	})
+
+	t.Run("empty DDL is rejected", func(t *testing.T) {
+		_, err := canonicalDDLForDrift("   ")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "empty DDL")
+	})
+
+	t.Run("parseable DDL is canonicalized", func(t *testing.T) {
+		// Whitespace and unquoted identifiers normalize to the same canonical form
+		// regardless of incidental formatting, so equivalent DDL compares equal.
+		spaced, err := canonicalDDLForDrift("ALTER TABLE   users   ADD COLUMN email varchar(255)")
+		require.NoError(t, err)
+		quoted, err := canonicalDDLForDrift("ALTER TABLE `users` ADD COLUMN `email` varchar(255)")
+		require.NoError(t, err)
+		assert.Equal(t, quoted, spaced)
+		assert.NotEmpty(t, spaced)
+	})
+}

--- a/pkg/tern/local_plan_drift_guard_test.go
+++ b/pkg/tern/local_plan_drift_guard_test.go
@@ -1,0 +1,191 @@
+package tern
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/block/schemabot/pkg/engine"
+	ternv1 "github.com/block/schemabot/pkg/proto/ternv1"
+	"github.com/block/schemabot/pkg/storage"
+	"github.com/block/spirit/pkg/statement"
+)
+
+// A non-primary deployment whose recomputed local plan exactly matches the
+// reviewed DDL materializes the plan: there is no drift to block.
+func TestDriftGuard_MatchMaterializes(t *testing.T) {
+	store := &fakePlanStore{getFn: func(string) (*storage.Plan, error) { return nil, nil }, createID: 5}
+	c := newPlanMaterializeClientWithPlan(store, alterUsersEmailPlan())
+
+	got, err := c.planForApplyRequest(t.Context(), &ternv1.ApplyRequest{
+		PlanId: "plan_ok",
+		DdlChanges: []*ternv1.TableChange{
+			{TableName: "users", Ddl: "ALTER TABLE `users` ADD COLUMN `email` varchar(255)", ChangeType: ternv1.ChangeType_CHANGE_TYPE_ALTER, Namespace: "testapp"},
+		},
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, int64(5), got.ID)
+}
+
+// Whitespace and quoting differences between the recomputed DDL and the reviewed
+// DDL are normalized away by canonicalization, so they are not drift.
+func TestDriftGuard_CanonicalizationTolerant(t *testing.T) {
+	recomputed := &engine.PlanResult{Changes: []engine.SchemaChange{{
+		Namespace: "testapp",
+		TableChanges: []engine.TableChange{{
+			Table:     "users",
+			Operation: statement.StatementAlterTable,
+			DDL:       "ALTER TABLE users ADD COLUMN email varchar(255)",
+		}},
+	}}}
+	store := &fakePlanStore{getFn: func(string) (*storage.Plan, error) { return nil, nil }, createID: 6}
+	c := newPlanMaterializeClientWithPlan(store, recomputed)
+
+	_, err := c.planForApplyRequest(t.Context(), &ternv1.ApplyRequest{
+		PlanId: "plan_canon",
+		DdlChanges: []*ternv1.TableChange{
+			{TableName: "users", Ddl: "ALTER TABLE `users` ADD COLUMN `email` varchar(255)", ChangeType: ternv1.ChangeType_CHANGE_TYPE_ALTER, Namespace: "testapp"},
+		},
+	})
+
+	require.NoError(t, err)
+}
+
+// A reviewed change this deployment would not plan (local schema already has the
+// column) fails closed rather than replaying unreviewed DDL.
+func TestDriftGuard_MissingReviewedChangeFailsClosed(t *testing.T) {
+	store := &fakePlanStore{getFn: func(string) (*storage.Plan, error) { return nil, nil }}
+	c := newPlanMaterializeClientWithPlan(store, &engine.PlanResult{}) // recomputes no changes
+
+	_, err := c.planForApplyRequest(t.Context(), &ternv1.ApplyRequest{
+		PlanId: "plan_drift",
+		DdlChanges: []*ternv1.TableChange{
+			{TableName: "users", Ddl: "ALTER TABLE `users` ADD COLUMN `email` varchar(255)", ChangeType: ternv1.ChangeType_CHANGE_TYPE_ALTER, Namespace: "testapp"},
+		},
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "drifted")
+	assert.Nil(t, store.created, "must not materialize a drifted plan")
+}
+
+// A change this deployment would plan that was never reviewed (local schema is
+// behind the desired files in a way the primary did not see) fails closed.
+func TestDriftGuard_UnexpectedLocalChangeFailsClosed(t *testing.T) {
+	store := &fakePlanStore{getFn: func(string) (*storage.Plan, error) { return nil, nil }}
+	c := newPlanMaterializeClientWithPlan(store, alterUsersEmailPlan())
+
+	_, err := c.planForApplyRequest(t.Context(), &ternv1.ApplyRequest{
+		PlanId: "plan_extra",
+		DdlChanges: []*ternv1.TableChange{
+			{TableName: "orders", Ddl: "CREATE TABLE `orders` (`id` bigint)", ChangeType: ternv1.ChangeType_CHANGE_TYPE_CREATE, Namespace: "testapp"},
+		},
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "drifted")
+}
+
+// Different DDL for the same table/operation is drift even though the
+// namespace/table/action triple matches.
+func TestDriftGuard_DifferentDDLSameTableFailsClosed(t *testing.T) {
+	store := &fakePlanStore{getFn: func(string) (*storage.Plan, error) { return nil, nil }}
+	c := newPlanMaterializeClientWithPlan(store, alterUsersEmailPlan())
+
+	_, err := c.planForApplyRequest(t.Context(), &ternv1.ApplyRequest{
+		PlanId: "plan_diff_ddl",
+		DdlChanges: []*ternv1.TableChange{
+			{TableName: "users", Ddl: "ALTER TABLE `users` ADD COLUMN `phone` varchar(255)", ChangeType: ternv1.ChangeType_CHANGE_TYPE_ALTER, Namespace: "testapp"},
+		},
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "drifted")
+}
+
+// A shard-scoped apply cannot be drift-checked against a whole-deployment
+// replan, so it fails closed.
+func TestDriftGuard_ShardScopedFailsClosed(t *testing.T) {
+	store := &fakePlanStore{getFn: func(string) (*storage.Plan, error) { return nil, nil }}
+	c := newPlanMaterializeClientWithPlan(store, alterUsersEmailPlan())
+
+	_, err := c.planForApplyRequest(t.Context(), &ternv1.ApplyRequest{
+		PlanId:       "plan_shard",
+		TargetShards: []string{"-80"},
+		DdlChanges: []*ternv1.TableChange{
+			{TableName: "users", Ddl: "ALTER TABLE `users` ADD COLUMN `email` varchar(255)", ChangeType: ternv1.ChangeType_CHANGE_TYPE_ALTER, Namespace: "testapp"},
+		},
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "shard")
+}
+
+// A vschema change the reviewed plan carries but this deployment would not plan
+// is drift, even when the table DDL matches exactly.
+func TestDriftGuard_VSchemaParityFailsClosed(t *testing.T) {
+	store := &fakePlanStore{getFn: func(string) (*storage.Plan, error) { return nil, nil }}
+	// Recomputed plan has the table change but no vschema change.
+	c := newPlanMaterializeClientWithPlan(store, alterUsersEmailPlan())
+
+	_, err := c.planForApplyRequest(t.Context(), &ternv1.ApplyRequest{
+		PlanId: "plan_vschema",
+		DdlChanges: []*ternv1.TableChange{
+			{TableName: "users", Ddl: "ALTER TABLE `users` ADD COLUMN `email` varchar(255)", ChangeType: ternv1.ChangeType_CHANGE_TYPE_ALTER, Namespace: "testapp"},
+			{TableName: "VSchema: testapp", ChangeType: ternv1.ChangeType_CHANGE_TYPE_VSCHEMA, Namespace: "testapp"},
+		},
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "vschema")
+}
+
+// A matching vschema change on both sides is not drift.
+func TestDriftGuard_VSchemaParityMatches(t *testing.T) {
+	recomputed := &engine.PlanResult{Changes: []engine.SchemaChange{{
+		Namespace: "testapp",
+		Metadata:  map[string]string{"vschema_changed": "true"},
+	}}}
+	store := &fakePlanStore{getFn: func(string) (*storage.Plan, error) { return nil, nil }, createID: 9}
+	c := newPlanMaterializeClientWithPlan(store, recomputed)
+
+	_, err := c.planForApplyRequest(t.Context(), &ternv1.ApplyRequest{
+		PlanId: "plan_vschema_ok",
+		DdlChanges: []*ternv1.TableChange{
+			{TableName: "VSchema: testapp", ChangeType: ternv1.ChangeType_CHANGE_TYPE_VSCHEMA, Namespace: "testapp"},
+		},
+		SchemaFiles: map[string]*ternv1.SchemaFiles{
+			"testapp": {Files: map[string]string{vSchemaArtifactName: `{"sharded":true}`}},
+		},
+	})
+
+	require.NoError(t, err)
+}
+
+// An engine failure during recompute surfaces as an error: the guard never
+// fails open when it cannot recompute.
+func TestDriftGuard_RecomputeErrorFailsClosed(t *testing.T) {
+	store := &fakePlanStore{getFn: func(string) (*storage.Plan, error) { return nil, nil }}
+	c := newPlanMaterializeClient(store)
+	c.config.TargetDSN = "user:pass@tcp(127.0.0.1:3306)/testapp"
+	c.spiritEngine = fakePlanEngine{
+		planFn: func(ctx context.Context, _ *engine.PlanRequest) (*engine.PlanResult, error) {
+			return nil, errors.New("engine boom")
+		},
+	}
+
+	_, err := c.planForApplyRequest(t.Context(), &ternv1.ApplyRequest{
+		PlanId: "plan_engine_err",
+		DdlChanges: []*ternv1.TableChange{
+			{TableName: "users", Ddl: "ALTER TABLE `users` ADD COLUMN `email` varchar(255)", ChangeType: ternv1.ChangeType_CHANGE_TYPE_ALTER, Namespace: "testapp"},
+		},
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "recompute local plan")
+}

--- a/pkg/tern/local_plan_materialize_test.go
+++ b/pkg/tern/local_plan_materialize_test.go
@@ -9,9 +9,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/block/schemabot/pkg/engine"
 	ternv1 "github.com/block/schemabot/pkg/proto/ternv1"
 	"github.com/block/schemabot/pkg/schema"
 	"github.com/block/schemabot/pkg/storage"
+	"github.com/block/spirit/pkg/statement"
 )
 
 // fakePlanStore lets a test script the plan Get/Create behavior the plan
@@ -48,6 +50,45 @@ func newPlanMaterializeClient(plans storage.PlanStore) *LocalClient {
 	}
 }
 
+// fakePlanEngine implements only engine.Plan so the drift guard can recompute a
+// local plan in tests without a live database. All other engine methods are
+// inherited from the embedded nil interface and must not be called.
+type fakePlanEngine struct {
+	engine.Engine
+	planFn func(context.Context, *engine.PlanRequest) (*engine.PlanResult, error)
+}
+
+func (e fakePlanEngine) Plan(ctx context.Context, req *engine.PlanRequest) (*engine.PlanResult, error) {
+	return e.planFn(ctx, req)
+}
+
+// newPlanMaterializeClientWithPlan returns a materialize client whose drift
+// guard recomputes the given plan result against "live" schema. The DB-bearing
+// TargetDSN keeps planWithEngine on the single-namespace path.
+func newPlanMaterializeClientWithPlan(plans storage.PlanStore, result *engine.PlanResult) *LocalClient {
+	c := newPlanMaterializeClient(plans)
+	c.config.TargetDSN = "user:pass@tcp(127.0.0.1:3306)/testapp"
+	c.spiritEngine = fakePlanEngine{
+		planFn: func(context.Context, *engine.PlanRequest) (*engine.PlanResult, error) { return result, nil },
+	}
+	return c
+}
+
+// alterUsersEmailPlan is the recomputed plan that exactly matches the reviewed
+// ALTER used across the materialize-path tests.
+func alterUsersEmailPlan() *engine.PlanResult {
+	return &engine.PlanResult{
+		Changes: []engine.SchemaChange{{
+			Namespace: "testapp",
+			TableChanges: []engine.TableChange{{
+				Table:     "users",
+				Operation: statement.StatementAlterTable,
+				DDL:       "ALTER TABLE `users` ADD COLUMN `email` varchar(255)",
+			}},
+		}},
+	}
+}
+
 // A deployment that planned locally resolves its own stored plan and never
 // materializes a new one from the dispatch request.
 func TestPlanForApplyRequest_LocalPlanWins(t *testing.T) {
@@ -72,7 +113,7 @@ func TestPlanForApplyRequest_MaterializesFromRequest(t *testing.T) {
 		getFn:    func(string) (*storage.Plan, error) { return nil, nil },
 		createID: 42,
 	}
-	c := newPlanMaterializeClient(store)
+	c := newPlanMaterializeClientWithPlan(store, alterUsersEmailPlan())
 
 	got, err := c.planForApplyRequest(t.Context(), &ternv1.ApplyRequest{
 		PlanId:      "plan_remote",
@@ -132,7 +173,7 @@ func TestPlanForApplyRequest_DuplicateCreateReloads(t *testing.T) {
 		},
 		createErr: errors.New("duplicate plan_identifier"),
 	}
-	c := newPlanMaterializeClient(store)
+	c := newPlanMaterializeClientWithPlan(store, alterUsersEmailPlan())
 
 	got, err := c.planForApplyRequest(t.Context(), &ternv1.ApplyRequest{
 		PlanId:     "plan_race",


### PR DESCRIPTION
## What

A non-primary deployment that did not plan locally now recomputes its own diff against its live schema and refuses to materialize a remote plan unless that diff exactly matches the reviewed DDL the dispatch request carries. Mismatch fails closed — the plan is never persisted and nothing is applied.

## Why

Only the primary deployment plans. The reviewed/approved DDL is computed against the primary's live schema. Materializing it verbatim on another deployment assumes that deployment is in the same starting state — if it has drifted, the primary's DDL gets replayed unreviewed, so non-primary drift is silently applied and invisible to reviewers.

The guard turns that silent divergence into a hard stop: this deployment must independently derive the same change set, or the apply is refused.

## Behavior
```
BEFORE                                  AFTER
dispatched DDL (reviewed on primary)    dispatched DDL (reviewed on primary)
|                                       |
v                                       v
materialize (trust primary)            recompute local diff vs live schema
|                                       |
v                               exact match?
replay primary's DDL <- drift           |- yes -> materialize -> apply
silently applied                        |- no  -> FAIL CLOSED (no apply)
```
- Comparison is an exact multiset keyed by namespace / table / operation / canonicalized DDL.
- DDL is canonicalized to absorb formatting/quoting differences, but unparseable DDL fails closed (canonicalization alone would compare raw text and could mask drift).
- VSchema changes carry no table DDL; they are compared as a separate namespace-parity check.
- Shard-scoped applies are refused (a whole-deployment replan cannot be compared to a shard subset).
- Scope is the materialize path only — the primary deployment already planned locally and is unaffected.

## Testing

Unit tests cover exact match, canonicalization tolerance, missing/unexpected/changed DDL drift, vschema parity (match and mismatch), shard rejection, and recompute-error fail-closed. `go build`, `go vet`, `go test ./pkg/tern/`, and `golangci-lint` all pass.
