### PR TITLE
test(e2e): clear tern storage per deployment in multideploy cleanup

### DIFF
--- a/e2e/grpc/multideploy_test.go
+++ b/e2e/grpc/multideploy_test.go
@@ -300,7 +300,10 @@ func multiDeployEnsureNoActiveChange(t *testing.T, database, env string, deploym
 				"environment": env,
 				"apply_id":    active.ApplyID,
 			})
+			status := resp.StatusCode
 			_ = resp.Body.Close()
+			require.Equalf(t, http.StatusOK, status,
+				"release cutover barrier for %s/%s (apply %s)", database, env, active.ApplyID)
 			time.Sleep(time.Second)
 			continue
 		}


### PR DESCRIPTION
## What and Why ?

The multi-deployment fan-out fixture runs one Tern storage DB **per deployment**
(`eu`/`us`), but the merged ordered-cutover e2e tests (#467) called the
single-deployment cleanup helper (`grpcEnsureNoActiveChange` → production Tern
DSN), which never matched the fan-out stack. As a result those tests could not
actually run live — masked only because the suite isn't in CI yet (E2E-5).

## Before / after

```diagram
BEFORE — single-deployment cleanup vs fan-out stack
───────────────────────────────────────────────────
test ─▶ grpcEnsureNoActiveChange(db, env)
          └─▶ grpcTernMySQLDSN("production")  ──╳  no such DSN in fan-out
                                                   (E2E_TERN_PRODUCTION_MYSQL_DSN unset)
   tern-eu storage [stale rows] ─┐
   tern-us storage [stale rows] ─┴─▶ never cleared ─▶ next test sees active change ─▶ can't run live
```
```
AFTER — per-deployment cleanup matches the fixture topology
───────────────────────────────────────────────────────────
test ─▶ multiDeployEnsureNoActiveChange(db, env, eu, us)
          ├─▶ multiDeployClearTernStorage(eu) ─▶ tern-eu storage [clean]
          └─▶ multiDeployClearTernStorage(us) ─▶ tern-us storage [clean]
                                                   └─▶ next test starts clean ─▶ runs live ✅
```

## Testing / validation

gofmt / go vet -tags=e2e / golangci-lint --build-tags=e2e / go build
clean. With these helpers the merged E2E-2 ordered-cutover tests run green
against the live E2E_MULTIDEPLOY=1 docker fan-out stack.

## References

- Unblocks live runs of E2E-2 (#467) and the rest of the multideploy e2e suite (E2E-3a #482, E2E-4, E2E-5).
