### PR TITLE
fix(storage): release barrier-parked deployment when a sibling permanently fails

### DIFF
--- a/pkg/storage/mysqlstore/applies.go
+++ b/pkg/storage/mysqlstore/applies.go
@@ -1685,8 +1685,9 @@ func (s *applyStore) ExpireRetryable(ctx context.Context) ([]*storage.RetryableA
 	}
 
 	// Terminalize the apply's retryable operation rows alongside the apply: once
-	// the parent's retry budget is spent the rollout's verdict is final, so a
-	// per-deployment operation that exhausted its retries is permanently failed,
+	// the apply is being expired — whether its retry budget is spent or its
+	// recovery freshness window has elapsed — the rollout's verdict is final, so
+	// a per-deployment operation that was still retryable is permanently failed,
 	// not retryable. The deployment-order claim gates read earlier.state from
 	// apply_operations, so a row left failed_retryable would keep blocking a
 	// healthy later deployment under on_failure "continue" even though the

--- a/pkg/storage/mysqlstore/applies.go
+++ b/pkg/storage/mysqlstore/applies.go
@@ -1684,6 +1684,25 @@ func (s *applyStore) ExpireRetryable(ctx context.Context) ([]*storage.RetryableA
 		return nil, fmt.Errorf("expire retryable tasks: %w", err)
 	}
 
+	// Terminalize the apply's retryable operation rows alongside the apply: once
+	// the parent's retry budget is spent the rollout's verdict is final, so a
+	// per-deployment operation that exhausted its retries is permanently failed,
+	// not retryable. The deployment-order claim gates read earlier.state from
+	// apply_operations, so a row left failed_retryable would keep blocking a
+	// healthy later deployment under on_failure "continue" even though the
+	// rollout has already failed. Only failed_retryable rows are flipped — a
+	// successor parked at waiting_for_cutover is a healthy deployment that must
+	// still be allowed to cut over, so it is left untouched.
+	opArgs := append([]any{state.ApplyOperation.Failed, state.ApplyOperation.FailedRetryable}, applyIDs...)
+	_, err = tx.ExecContext(ctx, fmt.Sprintf(`
+		UPDATE apply_operations
+		SET state = ?, completed_at = COALESCE(completed_at, NOW()), updated_at = NOW()
+		WHERE state = ? AND apply_id IN (%s)
+	`, placeholders(len(applyIDs))), opArgs...)
+	if err != nil {
+		return nil, fmt.Errorf("expire retryable apply_operations: %w", err)
+	}
+
 	applyArgs := append([]any{state.Apply.Failed}, applyIDs...)
 	_, err = tx.ExecContext(ctx, fmt.Sprintf(`
 		UPDATE applies

--- a/pkg/storage/mysqlstore/applies_test.go
+++ b/pkg/storage/mysqlstore/applies_test.go
@@ -2421,6 +2421,57 @@ func TestApplyStore_ExpireRetryableExpiresOldFailures(t *testing.T) {
 	assert.NotNil(t, persisted.CompletedAt)
 }
 
+// TestApplyStore_ExpireRetryableTerminalizesRetryableOperations verifies OC-5
+// Part A: when a multi-deployment apply's retry budget is spent, ExpireRetryable
+// terminalizes the apply's failed_retryable operation rows to failed alongside
+// the apply, but leaves a healthy successor parked at waiting_for_cutover
+// untouched. The deployment-order claim gates read earlier.state from
+// apply_operations, so a row left failed_retryable would keep blocking the
+// healthy successor from cutting over under on_failure "continue" even though
+// the rollout has already failed.
+func TestApplyStore_ExpireRetryableTerminalizesRetryableOperations(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", storage.DatabaseTypeMySQL, "staging")
+	apply := createTestApplyWithStateAndEnv(t, store, lock, "apply_retryable_ops_expired", 510, state.Apply.FailedRetryable, "staging")
+	apply.Attempt = maxRecoveryAttempts
+	require.NoError(t, store.Applies().Update(ctx, apply))
+
+	failedOpID, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-a", State: state.ApplyOperation.FailedRetryable,
+		OnFailure: storage.OnFailureContinue,
+	})
+	require.NoError(t, err)
+	parkedOpID, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-b", State: state.ApplyOperation.WaitingForCutover,
+		OnFailure: storage.OnFailureContinue,
+	})
+	require.NoError(t, err)
+
+	expired, err := store.Applies().ExpireRetryable(ctx)
+	require.NoError(t, err)
+	require.Len(t, expired, 1)
+	assert.Equal(t, state.Apply.Failed, expired[0].Apply.State)
+
+	persistedApply, err := store.Applies().Get(ctx, apply.ID)
+	require.NoError(t, err)
+	require.NotNil(t, persistedApply)
+	assert.Equal(t, state.Apply.Failed, persistedApply.State)
+
+	failedOp, err := store.ApplyOperations().Get(ctx, failedOpID)
+	require.NoError(t, err)
+	require.NotNil(t, failedOp)
+	assert.Equal(t, state.ApplyOperation.Failed, failedOp.State, "failed_retryable operation must be terminalized to failed once the parent budget is spent")
+	assert.NotNil(t, failedOp.CompletedAt, "terminalized operation must stamp completed_at")
+
+	parkedOp, err := store.ApplyOperations().Get(ctx, parkedOpID)
+	require.NoError(t, err)
+	require.NotNil(t, parkedOp)
+	assert.Equal(t, state.ApplyOperation.WaitingForCutover, parkedOp.State, "a healthy successor parked at the cutover barrier must be left untouched")
+}
+
 func TestApplyStore_FindMissingSummaryComment_ExcludesAppliesWithoutGitHubDestination(t *testing.T) {
 	clearTables(t)
 	ctx := t.Context()

--- a/pkg/storage/mysqlstore/apply_operations.go
+++ b/pkg/storage/mysqlstore/apply_operations.go
@@ -902,18 +902,23 @@ func (s *applyOperationStore) FindNextApplyOperation(ctx context.Context, owner 
 		// sibling parked at the cutover barrier under on_failure "continue". The
 		// EXISTS-sibling guard selects multi-op, and the failed_retryable parent
 		// guard keeps this to genuine redispatches (a terminal-failed parent never
-		// re-leases its operations).
+		// re-leases its operations). The attempt < budget guard makes the
+		// increment idempotent once the budget is spent: two operators can claim
+		// different failed_retryable operations of the same apply concurrently, and
+		// the row lock this UPDATE takes serializes them, so the second sees the
+		// already-incremented attempt and does not overshoot maxRecoveryAttempts.
 		if ad.State == state.ApplyOperation.FailedRetryable {
 			if _, err := tx.ExecContext(ctx, `
 				UPDATE applies a
 				SET a.attempt = a.attempt + 1, a.updated_at = NOW()
 				WHERE a.id = ?
 					AND a.state = ?
+					AND a.attempt < ?
 					AND EXISTS (
 						SELECT 1 FROM apply_operations o
 						WHERE o.apply_id = a.id AND o.id <> ?
 					)
-			`, ad.ApplyID, state.Apply.FailedRetryable, ad.ID); err != nil {
+			`, ad.ApplyID, state.Apply.FailedRetryable, maxRecoveryAttempts, ad.ID); err != nil {
 				return nil, fmt.Errorf("consume retry budget for apply_operation %d redispatch: %w", ad.ID, err)
 			}
 		}

--- a/pkg/storage/mysqlstore/apply_operations.go
+++ b/pkg/storage/mysqlstore/apply_operations.go
@@ -891,6 +891,32 @@ func (s *applyOperationStore) FindNextApplyOperation(ctx context.Context, owner 
 		if err != nil {
 			return nil, fmt.Errorf("refresh heartbeat for claimed apply_operation %d: %w", ad.ID, err)
 		}
+
+		// Re-claiming a failed_retryable operation is a redispatch, so consume one
+		// unit of the parent apply's retry budget. Only multi-operation applies are
+		// charged here: a single-operation apply's parent attempt is incremented by
+		// the ClaimApplyByID its drive performs, so bumping here too would
+		// double-count. Without this, an operation-only multi-deployment retry never
+		// advances applies.attempt, so ExpireRetryable's budget path never fires and
+		// a permanently failing deployment retries forever — stranding a healthy
+		// sibling parked at the cutover barrier under on_failure "continue". The
+		// EXISTS-sibling guard selects multi-op, and the failed_retryable parent
+		// guard keeps this to genuine redispatches (a terminal-failed parent never
+		// re-leases its operations).
+		if ad.State == state.ApplyOperation.FailedRetryable {
+			if _, err := tx.ExecContext(ctx, `
+				UPDATE applies a
+				SET a.attempt = a.attempt + 1, a.updated_at = NOW()
+				WHERE a.id = ?
+					AND a.state = ?
+					AND EXISTS (
+						SELECT 1 FROM apply_operations o
+						WHERE o.apply_id = a.id AND o.id <> ?
+					)
+			`, ad.ApplyID, state.Apply.FailedRetryable, ad.ID); err != nil {
+				return nil, fmt.Errorf("consume retry budget for apply_operation %d redispatch: %w", ad.ID, err)
+			}
+		}
 	}
 
 	if err := tx.Commit(); err != nil {

--- a/pkg/storage/mysqlstore/apply_operations_test.go
+++ b/pkg/storage/mysqlstore/apply_operations_test.go
@@ -1132,6 +1132,79 @@ func TestApplyOperationStore_FindNextApplyOperation_ClaimsFailedRetryableWithinB
 	assert.WithinDuration(t, time.Now(), persisted.UpdatedAt, 5*time.Second, "heartbeat must be refreshed on re-claim")
 }
 
+// TestApplyOperationStore_FindNextApplyOperation_MultiOpRedispatchConsumesParentBudget
+// verifies OC-5 Part B2: an operation-only redispatch of a failed_retryable
+// operation in a multi-deployment apply consumes one unit of the parent apply's
+// retry budget (applies.attempt += 1). Without this the operation-only retry
+// path never advances applies.attempt, so ExpireRetryable's budget gate never
+// fires and a permanently failing deployment retries forever — stranding a
+// healthy sibling parked at the cutover barrier under on_failure "continue".
+func TestApplyOperationStore_FindNextApplyOperation_MultiOpRedispatchConsumesParentBudget(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", "mysql", "staging")
+	apply := createTestApplyWithStateAndEnv(t, store, lock, "apply_op_multiop_budget", 1, state.Apply.FailedRetryable, "staging")
+	_, err := testDB.ExecContext(ctx, `
+		UPDATE applies SET attempt = ?, updated_at = NOW() WHERE id = ?
+	`, maxRecoveryAttempts-1, apply.ID)
+	require.NoError(t, err)
+
+	redispatchID, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-a", State: state.ApplyOperation.FailedRetryable,
+	})
+	require.NoError(t, err)
+	// A sibling operation makes this a genuine multi-deployment apply.
+	_, err = store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-b", State: state.ApplyOperation.WaitingForCutover,
+	})
+	require.NoError(t, err)
+
+	claimed, err := store.ApplyOperations().FindNextApplyOperation(ctx, "test-operator")
+	require.NoError(t, err)
+	require.NotNil(t, claimed, "the failed_retryable operation within budget must be reclaimable")
+	assert.Equal(t, redispatchID, claimed.ID)
+
+	persistedApply, err := store.Applies().Get(ctx, apply.ID)
+	require.NoError(t, err)
+	require.NotNil(t, persistedApply)
+	assert.Equal(t, maxRecoveryAttempts, persistedApply.Attempt, "a multi-op redispatch must consume one unit of the parent retry budget")
+}
+
+// TestApplyOperationStore_FindNextApplyOperation_SingleOpRedispatchDoesNotConsumeParentBudget
+// verifies OC-5 Part B2's guard: a single-operation apply's parent attempt is
+// incremented by the ClaimApplyByID its drive performs, so the operation claim
+// must NOT also bump it — doing so would double-count the budget. The
+// EXISTS-sibling guard keeps the redispatch charge to multi-op applies only.
+func TestApplyOperationStore_FindNextApplyOperation_SingleOpRedispatchDoesNotConsumeParentBudget(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", "mysql", "staging")
+	apply := createTestApplyWithStateAndEnv(t, store, lock, "apply_op_singleop_budget", 1, state.Apply.FailedRetryable, "staging")
+	_, err := testDB.ExecContext(ctx, `
+		UPDATE applies SET attempt = ?, updated_at = NOW() WHERE id = ?
+	`, maxRecoveryAttempts-1, apply.ID)
+	require.NoError(t, err)
+
+	id, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-a", State: state.ApplyOperation.FailedRetryable,
+	})
+	require.NoError(t, err)
+
+	claimed, err := store.ApplyOperations().FindNextApplyOperation(ctx, "test-operator")
+	require.NoError(t, err)
+	require.NotNil(t, claimed)
+	assert.Equal(t, id, claimed.ID)
+
+	persistedApply, err := store.Applies().Get(ctx, apply.ID)
+	require.NoError(t, err)
+	require.NotNil(t, persistedApply)
+	assert.Equal(t, maxRecoveryAttempts-1, persistedApply.Attempt, "a single-op apply's retry budget is charged by ClaimApplyByID, not by the operation claim")
+}
+
 // TestApplyOperationStore_FindNextApplyOperation_SkipsFailedRetryableBudgetExhausted
 // verifies the recovery budget is enforced: once the parent apply's attempt
 // count reaches the limit, the failed_retryable operation is no longer


### PR DESCRIPTION
## Summary

Under `cutover_policy: barrier` + `on_failure: continue`, a permanently failing
deployment stranded a healthy sibling parked at the cutover barrier and the
rollout never settled.

**Why:** the failing deployment's operation row stayed `failed_retryable` and the
operation-only redispatch path never advanced the parent apply's retry budget, so
the budget gate never fired. The deployment-order claim gate reads the
predecessor's state, so a row stuck at `failed_retryable` kept blocking the
healthy successor from cutting over.

**Fix:**
- When an apply is expired — budget spent or recovery-freshness window elapsed —
  terminalize its `failed_retryable` operation rows to `failed`. Successors
  parked at `waiting_for_cutover` are left untouched.
- Charge one unit of the parent retry budget on multi-op operation-only
  redispatches (guarded to multi-op applies, so single-op applies — already
  charged by their drive — aren't double-counted), so the budget can be spent and
  expiry can settle the rollout `failed`. The increment is capped at the budget
  so concurrent redispatches of different operations can't overshoot.

## Before / after
```
before:  op fails -> failed_retryable -> redispatch (attempt unchanged) -> loops forever
ExpireRetryable never fires
healthy sibling stranded at barrier
```

```
after:   op fails -> failed_retryable -> redispatch (attempt += 1, capped) -> budget spent
-> ExpireRetryable: apply -> failed, op -> failed
-> sibling released, cuts over; aggregate settles failed
```