### PR TITLE
fix(tern): release gRPC copy drive at the cutover barrier for fan-out ops

### DIFF
--- a/pkg/tern/grpc_client.go
+++ b/pkg/tern/grpc_client.go
@@ -1234,7 +1234,9 @@ func (c *GRPCClient) ResumeApplyOperationCutover(ctx context.Context, apply *sto
 	if !poll {
 		return nil
 	}
-	return c.pollForCompletion(ctx, apply, false, scope)
+	// The cutover drive must carry the swap past the barrier to terminal, so it
+	// never releases at waiting_for_cutover.
+	return c.pollForCompletion(ctx, apply, false, scope, false)
 }
 
 // triggerRemoteOperationCutover preflights the exact remote state for an ordered
@@ -1519,7 +1521,8 @@ func (c *GRPCClient) resumeApply(ctx context.Context, apply *storage.Apply, scop
 		}
 	}
 
-	return c.pollForCompletion(ctx, apply, startRequested, scope)
+	return c.pollForCompletion(ctx, apply, startRequested, scope,
+		shouldReleaseAtCutoverBarrier(apply, scope.multiOperation, scope.operation))
 }
 
 // completePendingStopBeforeRemoteStart completes an apply-level stop request
@@ -1857,7 +1860,8 @@ func (c *GRPCClient) dispatchPendingApply(ctx context.Context, apply *storage.Ap
 			oldApplyState)
 	}
 
-	return c.pollForCompletion(ctx, apply, false, scope)
+	return c.pollForCompletion(ctx, apply, false, scope,
+		shouldReleaseAtCutoverBarrier(apply, scope.multiOperation, scope.operation))
 }
 
 func isAmbiguousRemoteApplyDispatchError(err error) bool {
@@ -2558,7 +2562,16 @@ func applyProgressRank(applyState string) int {
 
 // pollForCompletion polls the remote Tern for progress and updates SchemaBot's storage.
 // Also maintains heartbeat to keep the lease on the apply.
-func (c *GRPCClient) pollForCompletion(ctx context.Context, apply *storage.Apply, allowStoppedAfterStart bool, scope applyTaskScope) error {
+//
+// releaseAtCutoverBarrier mirrors the LocalClient copy drive: when set, an
+// operation-scoped barrier copy drive exits the moment the remote reaches
+// waiting_for_cutover so the operator persists the parked operation row and
+// frees it for the deployment-ordered cutover claim, instead of holding the
+// lease and polling the parked remote indefinitely. It is false for the cutover
+// drive (which must drive the swap past the barrier to terminal) and for
+// single-operation / whole-apply drives (which keep waiting for a manual
+// cutover unchanged).
+func (c *GRPCClient) pollForCompletion(ctx context.Context, apply *storage.Apply, allowStoppedAfterStart bool, scope applyTaskScope, releaseAtCutoverBarrier bool) error {
 	ticker := time.NewTicker(grpcProgressPollInterval)
 	defer ticker.Stop()
 
@@ -2738,6 +2751,24 @@ func (c *GRPCClient) pollForCompletion(ctx context.Context, apply *storage.Apply
 			}
 			if persisted && oldApplyState != apply.State {
 				c.logApplyStateTransition(ctx, apply, storage.LogLevelInfo, fmt.Sprintf("Remote apply changed state: %s -> %s", oldApplyState, apply.State), oldApplyState)
+			}
+
+			// Park-and-release at the cutover barrier, mirroring the LocalClient
+			// copy drive. The tasks were just synced to waiting_for_cutover above,
+			// so exit the drive here: the operator persists the operation row at
+			// waiting_for_cutover and frees it for the deployment-ordered cutover
+			// claim. Without this an operation-scoped barrier copy drive would
+			// hold its lease and poll the parked remote forever, so the cutover
+			// claim never sees a parked operation and the rollout stalls.
+			if releaseAtCutoverBarrier && state.IsState(apply.State, state.Apply.WaitingForCutover) {
+				slog.Info("operation parked at cutover barrier; exiting remote copy drive",
+					"apply_id", apply.ApplyIdentifier,
+					"external_id", apply.ExternalID,
+					"database", apply.Database,
+					"environment", apply.Environment,
+					"deployment", apply.Deployment,
+					"operation_state", apply.State)
+				return nil
 			}
 		}
 	}

--- a/pkg/tern/grpc_client.go
+++ b/pkg/tern/grpc_client.go
@@ -2755,11 +2755,9 @@ func (c *GRPCClient) pollForCompletion(ctx context.Context, apply *storage.Apply
 
 			// Park-and-release at the cutover barrier, mirroring the LocalClient
 			// copy drive. The tasks were just synced to waiting_for_cutover above,
-			// so exit the drive here: the operator persists the operation row at
-			// waiting_for_cutover and frees it for the deployment-ordered cutover
-			// claim. Without this an operation-scoped barrier copy drive would
-			// hold its lease and poll the parked remote forever, so the cutover
-			// claim never sees a parked operation and the rollout stalls.
+			// so exit the drive here and release the lease: the operator persists
+			// the operation row at waiting_for_cutover and frees it for the
+			// deployment-ordered cutover claim to pick up.
 			if releaseAtCutoverBarrier && state.IsState(apply.State, state.Apply.WaitingForCutover) {
 				slog.Info("operation parked at cutover barrier; exiting remote copy drive",
 					"apply_id", apply.ApplyIdentifier,

--- a/pkg/tern/grpc_client_test.go
+++ b/pkg/tern/grpc_client_test.go
@@ -2326,10 +2326,8 @@ func TestGRPCClient_ProgressPollAdoptsTerminalTablesAfterStart(t *testing.T) {
 
 // An operation-scoped barrier copy drive must stop driving the moment the remote
 // parks at the cutover barrier: it persists the operation's tasks at
-// waiting_for_cutover and returns so the operator can mark the operation row
-// parked and free it for the deployment-ordered cutover claim. Without releasing
-// here the drive would hold its lease and poll the parked remote forever, so the
-// cutover claim never sees a parked operation and the rollout stalls.
+// waiting_for_cutover and returns, releasing its lease so the operator can mark
+// the operation row parked and free it for the deployment-ordered cutover claim.
 func TestGRPCClient_PollForCompletionReleasesAtCutoverBarrier(t *testing.T) {
 	server := &capturingTernServer{
 		progressState:    ternv1.State_STATE_WAITING_FOR_CUTOVER,

--- a/pkg/tern/grpc_client_test.go
+++ b/pkg/tern/grpc_client_test.go
@@ -2157,7 +2157,7 @@ func TestGRPCClient_ProgressPollTerminalErrorFailsApply(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(t.Context(), 3*time.Second)
 	defer cancel()
-	err := client.pollForCompletion(ctx, apply, false, wholeApplyTaskScope())
+	err := client.pollForCompletion(ctx, apply, false, wholeApplyTaskScope(), false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid apply_id")
 
@@ -2204,7 +2204,7 @@ func TestGRPCClient_ProgressPollRepeatedRetryableErrorsPauseApply(t *testing.T) 
 
 	ctx, cancel := context.WithTimeout(t.Context(), 7*time.Second)
 	defer cancel()
-	err := client.pollForCompletion(ctx, apply, false, wholeApplyTaskScope())
+	err := client.pollForCompletion(ctx, apply, false, wholeApplyTaskScope(), false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "remote service unavailable")
 
@@ -2266,7 +2266,7 @@ func TestGRPCClient_ProgressPollBoundsStoppedAfterStart(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
 	defer cancel()
-	err := client.pollForCompletion(ctx, apply, true, wholeApplyTaskScope())
+	err := client.pollForCompletion(ctx, apply, true, wholeApplyTaskScope(), false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "start accepted")
 	assert.Contains(t, err.Error(), "remained stopped after start grace period")
@@ -2318,10 +2318,115 @@ func TestGRPCClient_ProgressPollAdoptsTerminalTablesAfterStart(t *testing.T) {
 		logs:    &mockApplyLogStore{},
 	}
 
-	err := client.pollForCompletion(t.Context(), apply, true, wholeApplyTaskScope())
+	err := client.pollForCompletion(t.Context(), apply, true, wholeApplyTaskScope(), false)
 	require.NoError(t, err)
 	assert.Equal(t, state.Apply.Completed, apply.State)
 	assert.Equal(t, state.Task.Completed, task.State)
+}
+
+// An operation-scoped barrier copy drive must stop driving the moment the remote
+// parks at the cutover barrier: it persists the operation's tasks at
+// waiting_for_cutover and returns so the operator can mark the operation row
+// parked and free it for the deployment-ordered cutover claim. Without releasing
+// here the drive would hold its lease and poll the parked remote forever, so the
+// cutover claim never sees a parked operation and the rollout stalls.
+func TestGRPCClient_PollForCompletionReleasesAtCutoverBarrier(t *testing.T) {
+	server := &capturingTernServer{
+		progressState:    ternv1.State_STATE_WAITING_FOR_CUTOVER,
+		progressStateSet: true,
+		progressTables: []*ternv1.TableProgress{{
+			Namespace:       "default",
+			TableName:       "users",
+			Status:          state.Task.WaitingForCutover,
+			PercentComplete: 100,
+		}},
+	}
+	client, cleanup := testCapturingGRPCClient(t, server)
+	defer cleanup()
+
+	apply := &storage.Apply{
+		ID:              60,
+		ApplyIdentifier: "apply-barrier-park",
+		Database:        "testdb",
+		DatabaseType:    storage.DatabaseTypeMySQL,
+		Deployment:      "eu",
+		Environment:     "production",
+		ExternalID:      "remote-barrier-park",
+		State:           state.Apply.Running,
+	}
+	storedApply := *apply
+	task := &storage.Task{
+		ID:             61,
+		TaskIdentifier: "task-barrier-park",
+		ApplyID:        apply.ID,
+		Namespace:      "default",
+		TableName:      "users",
+		State:          state.Task.Running,
+	}
+	client.storage = &mockStorage{
+		applies: &mockApplyStore{apply: &storedApply},
+		tasks:   &mockTaskStore{tasks: []*storage.Task{task}},
+		logs:    &mockApplyLogStore{},
+	}
+
+	// A generous deadline: the drive must return promptly at the barrier, not
+	// run until the deadline.
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+	err := client.pollForCompletion(ctx, apply, false, wholeApplyTaskScope(), true)
+	require.NoError(t, err)
+	assert.Equal(t, state.Apply.WaitingForCutover, apply.State)
+	assert.Equal(t, state.Task.WaitingForCutover, task.State)
+}
+
+// The cutover drive (and any non-barrier drive) must NOT release at the barrier:
+// it keeps polling a remote parked at waiting_for_cutover so it can carry the
+// swap past the barrier to terminal. With releaseAtCutoverBarrier false the
+// drive polls until the context deadline rather than returning.
+func TestGRPCClient_PollForCompletionDoesNotReleaseWhenBarrierReleaseDisabled(t *testing.T) {
+	server := &capturingTernServer{
+		progressState:    ternv1.State_STATE_WAITING_FOR_CUTOVER,
+		progressStateSet: true,
+		progressTables: []*ternv1.TableProgress{{
+			Namespace:       "default",
+			TableName:       "users",
+			Status:          state.Task.WaitingForCutover,
+			PercentComplete: 100,
+		}},
+	}
+	client, cleanup := testCapturingGRPCClient(t, server)
+	defer cleanup()
+
+	apply := &storage.Apply{
+		ID:              62,
+		ApplyIdentifier: "apply-barrier-hold",
+		Database:        "testdb",
+		DatabaseType:    storage.DatabaseTypeMySQL,
+		Deployment:      "eu",
+		Environment:     "production",
+		ExternalID:      "remote-barrier-hold",
+		State:           state.Apply.Running,
+	}
+	storedApply := *apply
+	task := &storage.Task{
+		ID:             63,
+		TaskIdentifier: "task-barrier-hold",
+		ApplyID:        apply.ID,
+		Namespace:      "default",
+		TableName:      "users",
+		State:          state.Task.Running,
+	}
+	client.storage = &mockStorage{
+		applies: &mockApplyStore{apply: &storedApply},
+		tasks:   &mockTaskStore{tasks: []*storage.Task{task}},
+		logs:    &mockApplyLogStore{},
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+	err := client.pollForCompletion(ctx, apply, false, wholeApplyTaskScope(), false)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, state.Apply.WaitingForCutover, apply.State)
 }
 
 func TestGRPCClient_ResumeApplyDoesNotRegressRunningApplyToPendingProgress(t *testing.T) {
@@ -2712,7 +2817,7 @@ func TestGRPCClient_PollSetsTerminalTaskMetadataFromRemoteTaskProgress(t *testin
 
 	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
 	defer cancel()
-	err := client.pollForCompletion(ctx, apply, false, wholeApplyTaskScope())
+	err := client.pollForCompletion(ctx, apply, false, wholeApplyTaskScope(), false)
 	require.NoError(t, err)
 
 	assert.Equal(t, state.Task.Completed, task.State)
@@ -2756,7 +2861,7 @@ func TestGRPCClient_PollReconcilesLaggingTaskWhenRemoteApplyCompletedAndTaskProg
 
 	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
 	defer cancel()
-	err := client.pollForCompletion(ctx, apply, false, wholeApplyTaskScope())
+	err := client.pollForCompletion(ctx, apply, false, wholeApplyTaskScope(), false)
 	require.NoError(t, err)
 
 	assert.Equal(t, state.Apply.Completed, applyStore.apply.State)
@@ -2799,7 +2904,7 @@ func TestGRPCClient_PollKeepsApplyActiveWhenReconcilingLaggingTaskStorageFails(t
 
 	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
 	defer cancel()
-	err := client.pollForCompletion(ctx, apply, false, wholeApplyTaskScope())
+	err := client.pollForCompletion(ctx, apply, false, wholeApplyTaskScope(), false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "storage unavailable")
 	assert.Equal(t, state.Apply.Running, applyStore.apply.State)
@@ -2845,7 +2950,7 @@ func TestGRPCClient_PollReconcilesLaggingTaskWhenRemoteApplyStoppedAndTaskProgre
 
 	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
 	defer cancel()
-	err := client.pollForCompletion(ctx, apply, false, wholeApplyTaskScope())
+	err := client.pollForCompletion(ctx, apply, false, wholeApplyTaskScope(), false)
 	require.NoError(t, err)
 
 	assert.Equal(t, state.Apply.Stopped, applyStore.apply.State)
@@ -2933,7 +3038,7 @@ func TestGRPCClient_PollReturnsTerminalStorageUpdateError(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
 	defer cancel()
-	err := client.pollForCompletion(ctx, apply, false, wholeApplyTaskScope())
+	err := client.pollForCompletion(ctx, apply, false, wholeApplyTaskScope(), false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "update terminal remote gRPC apply")
 	assert.Contains(t, err.Error(), "storage unavailable")
@@ -2969,7 +3074,7 @@ func TestGRPCClient_PollKeepsApplyActiveWhenTerminalTaskLoadFails(t *testing.T) 
 
 	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
 	defer cancel()
-	err := client.pollForCompletion(ctx, apply, false, wholeApplyTaskScope())
+	err := client.pollForCompletion(ctx, apply, false, wholeApplyTaskScope(), false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "load tasks to sync terminal gRPC progress")
 	assert.Contains(t, err.Error(), "task storage unavailable")
@@ -3012,7 +3117,7 @@ func TestGRPCClient_PollSkipsTaskFinalizationWhenStoredApplyAlreadyTerminal(t *t
 
 	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
 	defer cancel()
-	err := client.pollForCompletion(ctx, apply, false, wholeApplyTaskScope())
+	err := client.pollForCompletion(ctx, apply, false, wholeApplyTaskScope(), false)
 	require.NoError(t, err)
 
 	assert.Equal(t, state.Apply.Failed, apply.State)
@@ -4243,7 +4348,7 @@ func TestGRPCClient_PollFailsWhenRemoteApplyIsNotFound(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
 	defer cancel()
-	err := client.pollForCompletion(ctx, apply, false, wholeApplyTaskScope())
+	err := client.pollForCompletion(ctx, apply, false, wholeApplyTaskScope(), false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "remote-not-found")
 
@@ -4284,7 +4389,7 @@ func TestGRPCClient_PollFailsWhenExactRemoteApplyHasNoActiveProgress(t *testing.
 
 	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
 	defer cancel()
-	err := client.pollForCompletion(ctx, apply, false, wholeApplyTaskScope())
+	err := client.pollForCompletion(ctx, apply, false, wholeApplyTaskScope(), false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no active schema change")
 
@@ -4322,7 +4427,7 @@ func TestGRPCClient_PollFailsWhenRemoteApplyStateIsUnmapped(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
 	defer cancel()
-	err := client.pollForCompletion(ctx, apply, false, wholeApplyTaskScope())
+	err := client.pollForCompletion(ctx, apply, false, wholeApplyTaskScope(), false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unmapped remote state")
 	assert.Equal(t, state.Apply.Running, apply.State)
@@ -4366,7 +4471,7 @@ func TestGRPCClient_RemoteProgressLossDoesNotOverwriteTerminalApply(t *testing.T
 
 	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
 	defer cancel()
-	err := client.pollForCompletion(ctx, apply, false, wholeApplyTaskScope())
+	err := client.pollForCompletion(ctx, apply, false, wholeApplyTaskScope(), false)
 	require.Error(t, err)
 
 	assert.Equal(t, state.Apply.Completed, apply.State)


### PR DESCRIPTION
## What

The remote gRPC copy drive now releases its lease when a fan-out operation
parks at the cutover barrier (`waiting_for_cutover`), mirroring the LocalClient
copy drive. `pollForCompletion` takes a `releaseAtCutoverBarrier` flag:

- copy / dispatch drives pass `shouldReleaseAtCutoverBarrier(...)` — they exit
  at the barrier so the operator can persist the parked operation row and free
  it for the deployment-ordered cutover claim.
- the cutover drive passes `false` — it must carry the swap past the barrier to
  terminal.

Single-operation / whole-apply drives and manual `--defer-cutover` applies are
unchanged.

> Stacked on #484 — review/merge that first.

## Why

The remote drive had no equivalent of the local barrier release. An
operation-scoped barrier copy that reached `waiting_for_cutover` kept polling
the parked remote forever, holding its lease. The deployment-ordered cutover
claim never saw a parked operation, so multi-deployment rollouts stalled: the
operator logged `no apply_operation to cut over` indefinitely and the engine
eventually timed out on the sentinel.

This is a real control-flow gap on the remote path, not a timing race.

## Before / After

BEFORE
```
copy drive ──▶ remote: waiting_for_cutover
│
└─▶ keeps polling parked remote, holds lease ──▶ ∞
cutover claim never sees a parked op ──▶ rollout stalls
```
AFTER
```
copy drive ──▶ remote: waiting_for_cutover
│
├─▶ persist tasks parked + release lease ──▶ return
│
▼
operator: cutover claim picks parked op in deployment order
│
eu cuts over ──▶ completed ──▶ us released ──▶ cuts over ──▶ completed
```
## Tests

- New unit tests in `pkg/tern/grpc_client_test.go`: release-at-barrier returns
  promptly and persists `waiting_for_cutover`; release-disabled keeps polling to
  the context deadline.
- Live `E2E_MULTIDEPLOY=1` ordered-cutover run: previously a 300s timeout, now
  completes with correct ordered cutover (later deployment never cuts over
  before the earlier one completes).
