### PR TITLE
feat(state): add dormant paused apply state and rollout projection

### DIFF
--- a/pkg/state/apply.go
+++ b/pkg/state/apply.go
@@ -255,12 +255,13 @@ func DeriveRolloutApplyState(children []RolloutChild) string {
 	return Apply.RunningDegraded
 }
 
-// hasLaterNonTerminal reports whether any child after index i (in deployment
-// order) is not yet in a terminal apply state. A pause-held failure only holds
-// the rollout when there is such later work for the operator to release or stop.
-func hasLaterNonTerminal(children []RolloutChild, i int) bool {
-	for j := i + 1; j < len(children); j++ {
-		if !IsTerminalApplyState(children[j].State) {
+// hasLaterNonTerminal reports whether any child after failedIndex (in
+// deployment order) is not yet in a terminal apply state. A pause-held failure
+// only holds the rollout when there is such later work for the operator to
+// release or stop.
+func hasLaterNonTerminal(children []RolloutChild, failedIndex int) bool {
+	for later := failedIndex + 1; later < len(children); later++ {
+		if !IsTerminalApplyState(children[later].State) {
 			return true
 		}
 	}

--- a/pkg/state/apply.go
+++ b/pkg/state/apply.go
@@ -149,7 +149,9 @@ func DeriveApplyState(taskStates []string) string {
 //
 // Both default to false, so "halt" and any unrecognized policy fail closed: a
 // failed sibling keeps the apply failed. The two flags are mutually exclusive —
-// a child is either continuable, pause-held, or fail-closed.
+// a child is either continuable, pause-held, or fail-closed. Setting both is a
+// caller bug; the projection fails closed in that case rather than loosening
+// rollout gating.
 //
 // Children must be supplied in deployment order (the same (created_at, id) order
 // the claim predicate uses), because a pause-held failure only holds the rollout
@@ -221,6 +223,11 @@ func DeriveRolloutApplyState(children []RolloutChild) string {
 			continue
 		}
 		switch {
+		case c.ContinueOnFailure && c.PauseOnFailure:
+			// Invalid: the flags are mutually exclusive. Fail closed rather than
+			// let a caller bug loosen rollout gating by silently winning the
+			// continue branch below.
+			hardFail = true
 		case c.ContinueOnFailure:
 			// continue, or a released pause: does not force a terminal verdict
 			// and does not hold the rollout.

--- a/pkg/state/apply.go
+++ b/pkg/state/apply.go
@@ -16,6 +16,7 @@ var Apply = struct {
 	Pending           string
 	Running           string
 	RunningDegraded   string
+	Paused            string
 	Resuming          string
 	WaitingForDeploy  string
 	WaitingForCutover string
@@ -41,6 +42,7 @@ var Apply = struct {
 	Pending:           "pending",
 	Running:           "running",
 	RunningDegraded:   "running_degraded",
+	Paused:            "paused",
 	Resuming:          "resuming",
 	WaitingForDeploy:  "waiting_for_deploy",
 	WaitingForCutover: "waiting_for_cutover",
@@ -132,20 +134,36 @@ func DeriveApplyState(taskStates []string) string {
 }
 
 // RolloutChild is one apply_operation's contribution to the parent apply's
-// rollout projection: its derived state plus whether the on_failure policy
-// captured on that operation lets the rollout continue past a terminal failure.
+// rollout projection: its derived state plus how the on_failure policy captured
+// on that operation treats a terminal failure of this child.
 //
-// ContinueOnFailure must be set by the caller using the exact-match semantics of
-// the claim predicate: only the literal on_failure value "continue" is
-// continuable; "halt", "pause", and any unrecognized value are not, so the
-// projection fails closed (a failed sibling keeps the apply failed) on anything
-// but an explicit continue.
+// The caller sets the two flags using the exact-match semantics of the claim
+// predicate, so the projection mirrors what the operator will actually do:
+//
+//   - ContinueOnFailure: the failure does not block later siblings and does not
+//     force an immediate terminal verdict. True for on_failure "continue", and
+//     for on_failure "pause" once the rollout has been released (a released
+//     pause behaves like continue for ordering).
+//   - PauseOnFailure: the failure holds the rollout for a human. True for
+//     on_failure "pause" before release.
+//
+// Both default to false, so "halt" and any unrecognized policy fail closed: a
+// failed sibling keeps the apply failed. The two flags are mutually exclusive —
+// a child is either continuable, pause-held, or fail-closed.
+//
+// Children must be supplied in deployment order (the same (created_at, id) order
+// the claim predicate uses), because a pause-held failure only holds the rollout
+// when there is later, not-yet-terminal work to hold.
 type RolloutChild struct {
 	// State is the child operation's derived apply state.
 	State string
-	// ContinueOnFailure is true only when the operation's on_failure policy is
-	// exactly "continue".
+	// ContinueOnFailure is true when the operation's on_failure policy lets the
+	// rollout continue past this child's terminal failure ("continue", or a
+	// released "pause").
 	ContinueOnFailure bool
+	// PauseOnFailure is true when the operation's on_failure policy is an
+	// unreleased "pause": a terminal failure holds the rollout for a human.
+	PauseOnFailure bool
 }
 
 // DeriveRolloutApplyState projects the parent apply's state over all of its
@@ -159,15 +177,23 @@ type RolloutChild struct {
 // verdict so the remaining siblings get their turn instead of the first failure
 // terminalizing the whole apply.
 //
-// When the base projection is failed (at least one child terminally failed):
+// When the base projection is failed (at least one child terminally failed),
+// each failed child is classified by its policy flags:
 //
-//   - if any failed child is not continuable (ContinueOnFailure false), the
-//     failure stands and the apply is failed (fail closed, matching halt); else
-//   - if every child is terminal, the rollout is settled and the apply is
-//     failed (the verdict still reflects the failure); else
-//   - the apply is held running_degraded so the still-in-flight siblings can
-//     run to completion under continue while surfacing that a sibling has
-//     already failed.
+//   - halt or unrecognized (both flags false): the failure stands and the apply
+//     is failed (fail closed); this dominates every other outcome.
+//   - unreleased pause (PauseOnFailure) with later, not-yet-terminal work to
+//     hold: the apply is held paused so a human can release or stop it.
+//   - continue, or a released pause (ContinueOnFailure): the failure neither
+//     forces a terminal verdict nor holds the rollout.
+//
+// After classifying every child, in precedence order:
+//
+//   - any fail-closed child → failed;
+//   - else any pause-held child → paused;
+//   - else if every child is terminal → failed (the verdict still reflects the
+//     failure once the continue/released rollout has settled);
+//   - else → running_degraded (continue/released siblings still in flight).
 //
 // An empty child set returns Pending, matching DeriveApplyState.
 func DeriveRolloutApplyState(children []RolloutChild) string {
@@ -185,18 +211,53 @@ func DeriveRolloutApplyState(children []RolloutChild) string {
 	}
 
 	allTerminal := true
-	for _, c := range children {
-		if IsState(c.State, Apply.Failed) && !c.ContinueOnFailure {
-			return Apply.Failed
-		}
+	hardFail := false
+	pausedHold := false
+	for i, c := range children {
 		if !IsTerminalApplyState(c.State) {
 			allTerminal = false
 		}
+		if !IsState(c.State, Apply.Failed) {
+			continue
+		}
+		switch {
+		case c.ContinueOnFailure:
+			// continue, or a released pause: does not force a terminal verdict
+			// and does not hold the rollout.
+		case c.PauseOnFailure && hasLaterNonTerminal(children, i):
+			// unreleased pause with later work still to run: hold for a human.
+			pausedHold = true
+		case c.PauseOnFailure:
+			// unreleased pause with nothing later to hold: the rollout is
+			// effectively settled, so let the terminal/degraded checks below
+			// decide rather than forcing failed here.
+		default:
+			// halt or any unrecognized policy: fail closed.
+			hardFail = true
+		}
+	}
+	if hardFail {
+		return Apply.Failed
+	}
+	if pausedHold {
+		return Apply.Paused
 	}
 	if allTerminal {
 		return Apply.Failed
 	}
 	return Apply.RunningDegraded
+}
+
+// hasLaterNonTerminal reports whether any child after index i (in deployment
+// order) is not yet in a terminal apply state. A pause-held failure only holds
+// the rollout when there is such later work for the operator to release or stop.
+func hasLaterNonTerminal(children []RolloutChild, i int) bool {
+	for j := i + 1; j < len(children); j++ {
+		if !IsTerminalApplyState(children[j].State) {
+			return true
+		}
+	}
+	return false
 }
 
 // normalizeApplyState converts a task state string to its canonical lowercase form.
@@ -208,6 +269,8 @@ func normalizeApplyState(raw string) string {
 		return Apply.Running
 	case "RUNNING_DEGRADED":
 		return Apply.RunningDegraded
+	case "PAUSED":
+		return Apply.Paused
 	case "WAITING_FOR_DEPLOY":
 		return Apply.WaitingForDeploy
 	case "WAITING_FOR_CUTOVER":

--- a/pkg/state/apply_test.go
+++ b/pkg/state/apply_test.go
@@ -517,6 +517,14 @@ func TestDeriveRolloutApplyState_PausePolicy(t *testing.T) {
 			children: []RolloutChild{rcPause(Apply.Failed), rc(Apply.Failed, false), rcPause(Apply.Pending)},
 			want:     Apply.Failed,
 		},
+		{
+			name: "invalid both-flags failure fails closed rather than continuing",
+			children: []RolloutChild{
+				{State: Apply.Failed, ContinueOnFailure: true, PauseOnFailure: true},
+				rc(Apply.Pending, true),
+			},
+			want: Apply.Failed,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/state/apply_test.go
+++ b/pkg/state/apply_test.go
@@ -185,6 +185,7 @@ func TestIsTerminalApplyState(t *testing.T) {
 		Apply.Pending,
 		Apply.Running,
 		Apply.RunningDegraded,
+		Apply.Paused,
 		Apply.FailedRetryable,
 		Apply.WaitingForCutover,
 		Apply.CuttingOver,
@@ -211,6 +212,7 @@ func TestIsRunningApplyState(t *testing.T) {
 	}
 	for _, s := range []string{
 		Apply.Pending,
+		Apply.Paused,
 		Apply.WaitingForDeploy,
 		Apply.WaitingForCutover,
 		Apply.Recovering,
@@ -235,6 +237,8 @@ func TestNormalizeState(t *testing.T) {
 		{"running", Apply.Running},
 		{"RUNNING_DEGRADED", Apply.RunningDegraded},
 		{"running_degraded", Apply.RunningDegraded},
+		{"PAUSED", Apply.Paused},
+		{"paused", Apply.Paused},
 		{"WAITING_FOR_DEPLOY", Apply.WaitingForDeploy},
 		{"waiting_for_deploy", Apply.WaitingForDeploy},
 		{"WAITING_FOR_CUTOVER", Apply.WaitingForCutover},
@@ -352,6 +356,12 @@ func rc(state string, continueOnFailure bool) RolloutChild {
 	return RolloutChild{State: state, ContinueOnFailure: continueOnFailure}
 }
 
+// rcPause builds a RolloutChild under an unreleased on_failure=pause policy.
+// A released pause behaves like continue, so those cases use rc(state, true).
+func rcPause(state string) RolloutChild {
+	return RolloutChild{State: state, PauseOnFailure: true}
+}
+
 func TestDeriveRolloutApplyState_Empty(t *testing.T) {
 	assert.Equal(t, Apply.Pending, DeriveRolloutApplyState(nil))
 	assert.Equal(t, Apply.Pending, DeriveRolloutApplyState([]RolloutChild{}))
@@ -400,8 +410,9 @@ func TestDeriveRolloutApplyState_NoFailureMatchesBase(t *testing.T) {
 }
 
 // TestDeriveRolloutApplyState_FailurePolicy is the truth table for the failed
-// base case: continue holds the apply active until siblings settle, while halt,
-// pause, and unrecognized policies fail closed to the failed verdict.
+// base case: continue holds the apply active until siblings settle, while halt
+// and unrecognized policies fail closed to the failed verdict. The pause policy
+// has its own truth table in TestDeriveRolloutApplyState_PausePolicy.
 func TestDeriveRolloutApplyState_FailurePolicy(t *testing.T) {
 	cases := []struct {
 		name     string
@@ -442,6 +453,69 @@ func TestDeriveRolloutApplyState_FailurePolicy(t *testing.T) {
 			name:     "continue failure with completed and pending holds running_degraded",
 			children: []RolloutChild{rc(Apply.Failed, true), rc(Apply.Completed, true), rc(Apply.Pending, true)},
 			want:     Apply.RunningDegraded,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, DeriveRolloutApplyState(tc.children))
+		})
+	}
+}
+
+// TestDeriveRolloutApplyState_PausePolicy is the truth table for on_failure=pause.
+// An unreleased pause failure holds the apply paused while later siblings still
+// have work to do, settles failed once nothing is left to hold, and — once
+// released — behaves exactly like continue. Children are in deployment order.
+func TestDeriveRolloutApplyState_PausePolicy(t *testing.T) {
+	cases := []struct {
+		name     string
+		children []RolloutChild
+		want     string
+	}{
+		{
+			name:     "pause failure with later pending sibling holds paused",
+			children: []RolloutChild{rcPause(Apply.Failed), rcPause(Apply.Pending)},
+			want:     Apply.Paused,
+		},
+		{
+			name:     "pause failure with later running sibling holds paused",
+			children: []RolloutChild{rcPause(Apply.Failed), rcPause(Apply.Running)},
+			want:     Apply.Paused,
+		},
+		{
+			name:     "pause failure with all later siblings terminal settles failed",
+			children: []RolloutChild{rcPause(Apply.Failed), rcPause(Apply.Completed)},
+			want:     Apply.Failed,
+		},
+		{
+			name:     "single pause failure with nothing to hold settles failed",
+			children: []RolloutChild{rcPause(Apply.Failed)},
+			want:     Apply.Failed,
+		},
+		{
+			name:     "pause failure last in order with earlier sibling still running settles running_degraded",
+			children: []RolloutChild{rcPause(Apply.Running), rcPause(Apply.Failed)},
+			want:     Apply.RunningDegraded,
+		},
+		{
+			name:     "earlier pause-held failure holds paused even when a later pause failure has nothing to hold",
+			children: []RolloutChild{rcPause(Apply.Failed), rcPause(Apply.Pending), rcPause(Apply.Failed)},
+			want:     Apply.Paused,
+		},
+		{
+			name:     "released pause (continue) failure with pending sibling holds running_degraded",
+			children: []RolloutChild{rc(Apply.Failed, true), rc(Apply.Pending, true)},
+			want:     Apply.RunningDegraded,
+		},
+		{
+			name:     "released pause (continue) failure with all siblings terminal settles failed",
+			children: []RolloutChild{rc(Apply.Failed, true), rc(Apply.Completed, true)},
+			want:     Apply.Failed,
+		},
+		{
+			name:     "halt failure dominates a pause-held sibling and fails closed",
+			children: []RolloutChild{rcPause(Apply.Failed), rc(Apply.Failed, false), rcPause(Apply.Pending)},
+			want:     Apply.Failed,
 		},
 	}
 	for _, tc := range cases {

--- a/pkg/state/metadata.go
+++ b/pkg/state/metadata.go
@@ -44,6 +44,9 @@ var applyMetadata = map[string]ApplyStateInfo{
 	Apply.RunningDegraded: {
 		Label: "Running (degraded)",
 	},
+	Apply.Paused: {
+		Label: "Paused",
+	},
 	Apply.Resuming: {
 		Label: "Resuming",
 	},


### PR DESCRIPTION
## Summary
Adds the `paused` apply state and teaches `DeriveRolloutApplyState` the `on_failure: pause` policy. This is the first, fully **dormant** slice of the pause rollout-continuation work: config still rejects `on_failure: pause` and no caller sets the new flag yet, so production behaviour is unchanged.

`pause` is the deliberate middle ground between `halt` (stop at first failure) and `continue` (roll forward automatically): hold the rollout after a failure until a human releases (continue) or stops (abort) it. `pause` was reserved as a known enum value in #317 (validation-rejected) and the legacy boolean dropped in #338; this slice begins implementing it.

## What changed
- New non-terminal `paused` apply state + metadata label + normalization.
- `RolloutChild` gains a `PauseOnFailure` flag (defaults false → `halt`/`continue` unchanged).
- `DeriveRolloutApplyState` projects `paused` when an unreleased-pause deployment fails while later siblings still have work; settles `failed` once nothing is left to hold; a released pause behaves like `continue`. `halt`/unknown still fail closed and dominate.

## Behaviour — failed-base projection (before → after)

BEFORE
```
failed base ─▶ any failed child not "continue"? ──yes─▶ failed
│ no
▼
all children terminal? ──yes─▶ failed
│ no
▼
running_degraded
```
AFTER
```
failed base ─▶ any halt/unknown failed child? ──yes─▶ failed   (fail-closed, dominates)
│ no
▼
unreleased-pause failed child w/ later work? ──yes─▶ paused   ◀── NEW
│ no
▼
all children terminal? ──yes─▶ failed
│ no
▼
running_degraded   (continue / released-pause still in flight)
```
The merge gate stays fail-closed throughout: any failed deployment still yields a `failed` verdict regardless of policy — `on_failure` only governs rollout continuation, never the verdict.
