### PR TITLE
feat(storage): add apply operation keys

### DIFF
--- a/pkg/schema/mysql/apply_operations.sql
+++ b/pkg/schema/mysql/apply_operations.sql
@@ -2,6 +2,7 @@ CREATE TABLE `apply_operations` (
   `id` bigint unsigned NOT NULL AUTO_INCREMENT,
   `apply_id` bigint unsigned NOT NULL,
   `deployment` varchar(255) NOT NULL,
+  `operation_key` varchar(255) NOT NULL DEFAULT '',
   `target` varchar(255) NOT NULL DEFAULT '',
   `engine_resume_context` varchar(255) DEFAULT NULL,
   `engine_resume_metadata` json DEFAULT NULL,
@@ -17,7 +18,7 @@ CREATE TABLE `apply_operations` (
   `created_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `updated_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`),
-  UNIQUE KEY `idx_apply_operation` (`apply_id`,`deployment`),
+  UNIQUE KEY `idx_apply_operation` (`apply_id`,`deployment`,`operation_key`),
   KEY `idx_deployment_state` (`deployment`,`state`),
   KEY `idx_state_created_id` (`state`,`created_at`,`id`),
   KEY `idx_apply_created_id` (`apply_id`,`created_at`,`id`)

--- a/pkg/storage/errors.go
+++ b/pkg/storage/errors.go
@@ -50,7 +50,7 @@ var (
 	ErrApplyOperationNotFound = errors.New("apply operation not found")
 
 	// ErrApplyOperationExists is returned when an apply_operations row for
-	// (apply_id, deployment) is being inserted but already exists.
+	// (apply_id, deployment, operation_key) is being inserted but already exists.
 	ErrApplyOperationExists = errors.New("apply operation already exists")
 
 	// ErrVitessApplyDataNotFound is returned when no vitess apply data exists for an apply.

--- a/pkg/storage/mysqlstore/applies_test.go
+++ b/pkg/storage/mysqlstore/applies_test.go
@@ -709,12 +709,12 @@ func TestApplyStore_CreateWithTasksAndOperationsRollsBackOnOperationFailure(t *t
 		CreatedAt:       now,
 		UpdatedAt:       now,
 	}
-	// Two operations sharing the same deployment violates the
-	// UNIQUE KEY (apply_id, deployment) constraint on the second insert and
+	// Two operations sharing the same storage identity violate the UNIQUE KEY
+	// (apply_id, deployment, operation_key) constraint on the second insert and
 	// must roll back the whole transaction — no orphan apply or tasks rows.
 	operations := []*storage.ApplyOperation{
-		{Deployment: "payments-a", Target: "payments", State: state.ApplyOperation.Pending, CreatedAt: now, UpdatedAt: now},
-		{Deployment: "payments-a", Target: "payments", State: state.ApplyOperation.Pending, CreatedAt: now, UpdatedAt: now},
+		{Deployment: "payments-a", OperationKey: "schema", Target: "payments", State: state.ApplyOperation.Pending, CreatedAt: now, UpdatedAt: now},
+		{Deployment: "payments-a", OperationKey: "schema", Target: "payments", State: state.ApplyOperation.Pending, CreatedAt: now, UpdatedAt: now},
 	}
 
 	_, err := store.Applies().CreateWithTasksAndOperations(ctx, apply, nil, operations)

--- a/pkg/storage/mysqlstore/apply_operations.go
+++ b/pkg/storage/mysqlstore/apply_operations.go
@@ -1,6 +1,6 @@
 // apply_operations.go implements ApplyOperationStore for per-(apply,
-// deployment) child rows under a multi-deployment apply — the unit of work
-// the operator claims.
+// deployment, operation_key) child rows under a multi-operation apply — the
+// unit of work the operator claims.
 package mysqlstore
 
 import (
@@ -19,7 +19,7 @@ import (
 )
 
 // applyOperationColumns lists all columns for SELECT queries.
-const applyOperationColumns = `id, apply_id, deployment, target, state, error_message,
+const applyOperationColumns = `id, apply_id, deployment, operation_key, target, state, error_message,
 	cutover_policy, on_failure, started_at, completed_at, lease_owner, lease_token, lease_acquired_at,
 	engine_resume_context, engine_resume_metadata, created_at, updated_at`
 
@@ -33,7 +33,7 @@ type applyOperationStore struct {
 }
 
 // Insert stores a new apply_operations row and returns its ID.
-// Translates a unique-key conflict on (apply_id, deployment) into
+// Translates a unique-key conflict on (apply_id, deployment, operation_key) into
 // storage.ErrApplyOperationExists so callers can branch cleanly.
 func (s *applyOperationStore) Insert(ctx context.Context, ad *storage.ApplyOperation) (int64, error) {
 	return insertApplyOperation(ctx, s.db, ad)
@@ -48,8 +48,8 @@ type sqlExecer interface {
 
 // insertApplyOperation inserts one apply_operations row using the supplied
 // executer (pool or transaction). On success the row's ID and State fields
-// are set. A duplicate-key violation on (apply_id, deployment) is translated
-// to storage.ErrApplyOperationExists for callers to branch on.
+// are set. A duplicate-key violation on (apply_id, deployment, operation_key)
+// is translated to storage.ErrApplyOperationExists for callers to branch on.
 func insertApplyOperation(ctx context.Context, exec sqlExecer, ad *storage.ApplyOperation) (int64, error) {
 	stateVal := ad.State
 	if stateVal == "" {
@@ -75,11 +75,11 @@ func insertApplyOperation(ctx context.Context, exec sqlExecer, ad *storage.Apply
 
 	result, err := exec.ExecContext(ctx, `
 		INSERT INTO apply_operations (
-			apply_id, deployment, target, state, error_message, cutover_policy, on_failure,
+			apply_id, deployment, operation_key, target, state, error_message, cutover_policy, on_failure,
 			started_at, completed_at, engine_resume_context, engine_resume_metadata
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`,
-		ad.ApplyID, ad.Deployment, ad.Target, stateVal, nullString(ad.ErrorMessage), cutoverPolicy, onFailure,
+		ad.ApplyID, ad.Deployment, ad.OperationKey, ad.Target, stateVal, nullString(ad.ErrorMessage), cutoverPolicy, onFailure,
 		ad.StartedAt, ad.CompletedAt, nullString(ad.EngineResumeContext), nullString(ad.EngineResumeMetadata),
 	)
 	if err != nil {
@@ -87,7 +87,7 @@ func insertApplyOperation(ctx context.Context, exec sqlExecer, ad *storage.Apply
 		if errors.As(err, &mysqlErr) && mysqlErr.Number == mysqlErrDupEntry {
 			return 0, storage.ErrApplyOperationExists
 		}
-		return 0, fmt.Errorf("insert apply_operations (apply=%d, deployment=%s): %w", ad.ApplyID, ad.Deployment, err)
+		return 0, fmt.Errorf("insert apply_operations (apply=%d, deployment=%s, operation_key=%s): %w", ad.ApplyID, ad.Deployment, ad.OperationKey, err)
 	}
 
 	id, err := result.LastInsertId()
@@ -111,13 +111,20 @@ func (s *applyOperationStore) Get(ctx context.Context, id int64) (*storage.Apply
 	return scanApplyOperation(row)
 }
 
-// GetByApplyAndDeployment returns the child row for (apply_id, deployment), or nil if not found.
+// GetByApplyAndDeployment returns the legacy unkeyed child row for
+// (apply_id, deployment), or nil if not found.
 func (s *applyOperationStore) GetByApplyAndDeployment(ctx context.Context, applyID int64, deployment string) (*storage.ApplyOperation, error) {
+	return s.GetByApplyDeploymentAndOperationKey(ctx, applyID, deployment, "")
+}
+
+// GetByApplyDeploymentAndOperationKey returns the child row for
+// (apply_id, deployment, operation_key), or nil if not found.
+func (s *applyOperationStore) GetByApplyDeploymentAndOperationKey(ctx context.Context, applyID int64, deployment, operationKey string) (*storage.ApplyOperation, error) {
 	row := s.db.QueryRowContext(ctx, `
 		SELECT `+applyOperationColumns+`
 		FROM apply_operations
-		WHERE apply_id = ? AND deployment = ?
-	`, applyID, deployment)
+		WHERE apply_id = ? AND deployment = ? AND operation_key = ?
+	`, applyID, deployment, operationKey)
 	return scanApplyOperation(row)
 }
 
@@ -1281,7 +1288,7 @@ func scanApplyOperationInto(s scanner) (*storage.ApplyOperation, error) {
 	var startedAt, completedAt, leaseAcquiredAt sql.NullTime
 
 	if err := s.Scan(
-		&ad.ID, &ad.ApplyID, &ad.Deployment, &ad.Target, &ad.State, &errMsg,
+		&ad.ID, &ad.ApplyID, &ad.Deployment, &ad.OperationKey, &ad.Target, &ad.State, &errMsg,
 		&ad.CutoverPolicy, &ad.OnFailure, &startedAt, &completedAt, &ad.LeaseOwner, &ad.LeaseToken, &leaseAcquiredAt,
 		&engineResumeContext, &engineResumeMetadata, &ad.CreatedAt, &ad.UpdatedAt,
 	); err != nil {

--- a/pkg/storage/mysqlstore/apply_operations.go
+++ b/pkg/storage/mysqlstore/apply_operations.go
@@ -1,6 +1,6 @@
 // apply_operations.go implements ApplyOperationStore for per-(apply,
 // deployment, operation_key) child rows under a multi-operation apply — the
-// unit of work the operator claims.
+// unit of work the driver claims.
 package mysqlstore
 
 import (

--- a/pkg/storage/mysqlstore/apply_operations_test.go
+++ b/pkg/storage/mysqlstore/apply_operations_test.go
@@ -194,6 +194,27 @@ func TestApplyOperationStore_GetByApplyAndDeployment(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, got)
 	assert.Equal(t, "region-a", got.Deployment)
+	assert.Empty(t, got.OperationKey)
+
+	_, err = store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-a", OperationKey: "shard/-80", Target: "payments",
+	})
+	require.NoError(t, err)
+
+	got, err = store.ApplyOperations().GetByApplyAndDeployment(ctx, apply.ID, "region-a")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Empty(t, got.OperationKey, "legacy lookup must return the unkeyed operation")
+
+	got, err = store.ApplyOperations().GetByApplyDeploymentAndOperationKey(ctx, apply.ID, "region-a", "shard/-80")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "region-a", got.Deployment)
+	assert.Equal(t, "shard/-80", got.OperationKey)
+
+	got, err = store.ApplyOperations().GetByApplyDeploymentAndOperationKey(ctx, apply.ID, "region-a", "shard/80-")
+	require.NoError(t, err)
+	require.Nil(t, got)
 
 	// Unknown deployment for this apply → nil, no error.
 	got, err = store.ApplyOperations().GetByApplyAndDeployment(ctx, apply.ID, "region-zzz")
@@ -214,9 +235,21 @@ func TestApplyOperationStore_UniqueConstraint(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// Duplicate (apply_id, deployment) → typed error.
+	// Duplicate (apply_id, deployment, operation_key) → typed error.
 	_, err = store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
 		ApplyID: apply.ID, Deployment: "region-a",
+	})
+	require.ErrorIs(t, err, storage.ErrApplyOperationExists)
+
+	// Same deployment with a distinct operation key for the same apply → ok.
+	_, err = store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-a", OperationKey: "shard/-80",
+	})
+	require.NoError(t, err)
+
+	// Duplicate keyed operation → typed error.
+	_, err = store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-a", OperationKey: "shard/-80",
 	})
 	require.ErrorIs(t, err, storage.ErrApplyOperationExists)
 
@@ -250,7 +283,7 @@ func TestApplyOperationStore_ListByApply(t *testing.T) {
 	// Insert three children in deployment order.
 	for _, dep := range []string{"region-a", "region-b", "region-c"} {
 		_, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
-			ApplyID: apply.ID, Deployment: dep, Target: "payments",
+			ApplyID: apply.ID, Deployment: dep, OperationKey: "schema", Target: "payments",
 		})
 		require.NoError(t, err)
 	}
@@ -262,10 +295,43 @@ func TestApplyOperationStore_ListByApply(t *testing.T) {
 	// ListByApply is ordered by (created_at, id); rows inserted in the same
 	// second tie-break on id, preserving insertion (deployment) order.
 	deps := make([]string, len(got))
+	operationKeys := make([]string, len(got))
 	for i, ad := range got {
 		deps[i] = ad.Deployment
+		operationKeys[i] = ad.OperationKey
 	}
 	assert.Equal(t, []string{"region-a", "region-b", "region-c"}, deps)
+	assert.Equal(t, []string{"schema", "schema", "schema"}, operationKeys)
+}
+
+func TestApplyOperationStore_ListByApply_AllowsMultipleOperationKeysPerDeployment(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", "mysql", "staging")
+	apply := createTestApply(t, store, lock, "apply_md_same_deployment_keys", 1)
+
+	for _, operationKey := range []string{"shard/-80", "shard/80-"} {
+		_, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+			ApplyID:      apply.ID,
+			Deployment:   "region-a",
+			OperationKey: operationKey,
+			Target:       "payments",
+		})
+		require.NoError(t, err)
+	}
+
+	got, err := store.ApplyOperations().ListByApply(ctx, apply.ID)
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+
+	operationKeys := make([]string, len(got))
+	for i, ad := range got {
+		assert.Equal(t, "region-a", ad.Deployment)
+		operationKeys[i] = ad.OperationKey
+	}
+	assert.Equal(t, []string{"shard/-80", "shard/80-"}, operationKeys)
 }
 
 // TestApplyOperationStore_ListByApply_OrderedByCreatedAt proves ListByApply

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -467,7 +467,7 @@ type ApplyOperationStore interface {
 	// (apply_id, deployment, operation_key), or nil if not found.
 	GetByApplyDeploymentAndOperationKey(ctx context.Context, applyID int64, deployment, operationKey string) (*ApplyOperation, error)
 
-	// ListByApply returns all child rows for an apply in stable claim order.
+	// ListByApply returns all child rows for an apply in (created_at, id) order.
 	ListByApply(ctx context.Context, applyID int64) ([]*ApplyOperation, error)
 
 	// UpdateState transitions a child row to a new state. Updates the state

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -448,26 +448,26 @@ type ApplyCommentStore interface {
 	Supersede(ctx context.Context, applyID int64, commentState string) error
 }
 
-// ApplyOperationStore manages per-(apply, deployment) child rows for
-// multi-deployment applies. One apply owns 1..N apply_operations rows.
-//
-// Pure storage primitive: no orchestration code reads or writes these rows
-// yet — the apply-create dual-write and the operator's per-row claim + lock
-// relocation arrive in subsequent PRs in the multi-deployment apply
-// workstream.
+// ApplyOperationStore manages per-(apply, deployment, operation_key) child rows
+// for multi-operation applies. One apply owns 1..N apply_operations rows.
 type ApplyOperationStore interface {
 	// Insert stores a new apply_operations row and returns its ID.
-	// Fails with a uniqueness error if (apply_id, deployment) already exists.
+	// Fails with a uniqueness error if (apply_id, deployment, operation_key)
+	// already exists.
 	Insert(ctx context.Context, ad *ApplyOperation) (int64, error)
 
 	// Get returns a child row by ID, or nil if not found.
 	Get(ctx context.Context, id int64) (*ApplyOperation, error)
 
-	// GetByApplyAndDeployment returns the child row for (apply_id, deployment),
-	// or nil if not found.
+	// GetByApplyAndDeployment returns the legacy unkeyed child row for
+	// (apply_id, deployment), or nil if not found.
 	GetByApplyAndDeployment(ctx context.Context, applyID int64, deployment string) (*ApplyOperation, error)
 
-	// ListByApply returns all child rows for an apply, ordered by id ascending.
+	// GetByApplyDeploymentAndOperationKey returns the child row for
+	// (apply_id, deployment, operation_key), or nil if not found.
+	GetByApplyDeploymentAndOperationKey(ctx context.Context, applyID int64, deployment, operationKey string) (*ApplyOperation, error)
+
+	// ListByApply returns all child rows for an apply in stable claim order.
 	ListByApply(ctx context.Context, applyID int64) ([]*ApplyOperation, error)
 
 	// UpdateState transitions a child row to a new state. Updates the state

--- a/pkg/storage/types.go
+++ b/pkg/storage/types.go
@@ -460,13 +460,13 @@ func (a *Apply) IsRollback() bool {
 }
 
 // ApplyOperation represents one child row in the apply_operations table:
-// the per-(deployment, operation_key, target) slice of a multi-operation apply,
-// and the unit of work the operator (claim loop) reconciles.
+// the per-(deployment, operation_key) slice of a multi-operation apply, and the
+// unit of work the driver claim loop reconciles.
 //
 // In the multi-operation data model, one applies row owns 1..N
 // apply_operations rows. Each row carries its
 // own state machine (mirroring state.Apply, so cutover/stop/revert/triage
-// work per-row), its own lock identity, and its own progress; the operator
+// work per-row), its own lock identity, and its own progress; the driver
 // can act on each operation independently while keeping `apply_id` as the
 // user-facing handle for the whole rollout. applies.state is derived from
 // the child rows' states via the existing state.DeriveApplyState().
@@ -487,12 +487,12 @@ type ApplyOperation struct {
 	// and deployment. Empty is the legacy single-operation key.
 	OperationKey string
 
-	// Target is the Tern-facing target selected by server config at apply
-	// time for this deployment. Mirrors plans.target / applies.target
+	// Target is the Tern-facing address resolved for this deployment at apply
+	// time. Mirrors plans.target / applies.target
 	// semantics. Empty for legacy / single-deployment shapes.
 	Target string
 
-	// State is the per-deployment state machine value. See state.ApplyOperation.
+	// State is the per-operation state machine value. See state.ApplyOperation.
 	State string
 
 	// ErrorMessage contains error details if state is failed.

--- a/pkg/storage/types.go
+++ b/pkg/storage/types.go
@@ -460,31 +460,32 @@ func (a *Apply) IsRollback() bool {
 }
 
 // ApplyOperation represents one child row in the apply_operations table:
-// the per-(deployment, target) slice of a multi-deployment apply, and the
-// unit of work the operator (claim loop) reconciles.
+// the per-(deployment, operation_key, target) slice of a multi-operation apply,
+// and the unit of work the operator (claim loop) reconciles.
 //
-// In the multi-deployment data model, one applies row owns 1..N
-// apply_operations rows — one per target deployment. Each row carries its
+// In the multi-operation data model, one applies row owns 1..N
+// apply_operations rows. Each row carries its
 // own state machine (mirroring state.Apply, so cutover/stop/revert/triage
 // work per-row), its own lock identity, and its own progress; the operator
-// can act on each deployment independently while keeping `apply_id` as the
+// can act on each operation independently while keeping `apply_id` as the
 // user-facing handle for the whole rollout. applies.state is derived from
 // the child rows' states via the existing state.DeriveApplyState().
-//
-// Pure storage primitive: no caller writes these rows yet — the apply-create
-// dual-write arrives in a subsequent PR in the multi-deployment apply
-// workstream.
 type ApplyOperation struct {
 	// ID is the unique identifier (BIGINT AUTO_INCREMENT).
 	ID int64
 
-	// ApplyID points to applies.id. Unique together with Deployment.
+	// ApplyID points to applies.id. Unique together with Deployment and
+	// OperationKey.
 	ApplyID int64
 
 	// Deployment is the Tern deployment name this child row targets
 	// (e.g. "region-a", "payments-eu"). Drawn from the resolved
 	// environment-level deployments map in server config.
 	Deployment string
+
+	// OperationKey disambiguates multiple execution operations in the same apply
+	// and deployment. Empty is the legacy single-operation key.
+	OperationKey string
 
 	// Target is the Tern-facing target selected by server config at apply
 	// time for this deployment. Mirrors plans.target / applies.target


### PR DESCRIPTION
## Why
Allow apply operation storage to distinguish multiple execution operations that share the same apply and deployment.

## What
- Add `operation_key` to the `apply_operations` storage identity
- Preserve legacy unkeyed lookup behavior for existing single-operation callers
- Add keyed lookup and storage coverage for uniqueness and round-tripping

## Risk Assessment
Low — this is a storage identity extension with a backward-compatible empty-key default for existing callers.

Generated with Amp
