### PR TITLE
feat(storage): fan out sharded apply operations

### DIFF
--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -1923,7 +1923,7 @@ func TestCreateStoredApplyFansOutOperationsForResolvedTargets(t *testing.T) {
 		controls:  &memoryControlRequestStore{},
 	}, cfg, map[string]tern.Client{}, logger)
 
-	apply, storedApplyID, err := svc.createStoredApply(t.Context(), executeApplyTestPlan(), ApplyRequest{Environment: "staging"}, nil, "apply-fanout", "")
+	apply, storedApplyID, err := svc.createStoredApply(t.Context(), executeApplyTestPlan(), ApplyRequest{Environment: "staging"}, nil, "apply-fanout", false)
 
 	require.NoError(t, err)
 	assert.Equal(t, int64(123), storedApplyID)
@@ -1946,6 +1946,112 @@ func TestCreateStoredApplyFansOutOperationsForResolvedTargets(t *testing.T) {
 	require.NotNil(t, tasks.tasks[1].ApplyOperationID)
 	assert.Equal(t, applies.operations[0].ID, *tasks.tasks[0].ApplyOperationID)
 	assert.Equal(t, applies.operations[1].ID, *tasks.tasks[1].ApplyOperationID)
+}
+
+func TestCreateStoredApplyFansOutShardedPlanOperations(t *testing.T) {
+	// A sharded plan queues one operation per changed shard/table so each shard
+	// can be claimed and driven independently while unchanged shards stay out of
+	// the apply operation set.
+	applies := &capturingApplyStore{}
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	tasks := &capturingTaskStore{}
+	applies.taskStore = tasks
+	plan := executeApplyTestPlan()
+	plan.DatabaseType = storage.DatabaseTypeStrata
+	plan.Target = "commerce-target"
+	plan.Namespaces = map[string]*storage.NamespacePlanData{
+		"commerce": {
+			Tables: []storage.TableChange{
+				{Namespace: "commerce", Table: "users", DDL: "ALTER TABLE `users` ADD COLUMN `email` varchar(255)", Operation: "alter"},
+			},
+		},
+	}
+	plan.Shards = []storage.ShardPlan{
+		{Namespace: "commerce", Shard: "80-", NeedsChange: true},
+		{Namespace: "commerce", Shard: "-80", NeedsChange: true},
+		{Namespace: "commerce", Shard: "-", NeedsChange: false},
+	}
+	cfg := testServerConfig()
+	cfg.Databases = map[string]DatabaseConfig{}
+	cfg.Databases["testdb"] = DatabaseConfig{
+		Type: storage.DatabaseTypeStrata,
+		Environments: map[string]EnvironmentConfig{
+			"staging": {Target: "commerce-target", Deployment: DefaultDeployment},
+		},
+	}
+	svc := New(&mockStorageWithApplyStores{
+		plans:     &staticPlanStore{plan: plan},
+		applies:   applies,
+		tasks:     tasks,
+		locks:     &emptyLockStore{},
+		applyLogs: &noopApplyLogStore{},
+		controls:  &memoryControlRequestStore{},
+	}, cfg, map[string]tern.Client{}, logger)
+
+	apply, storedApplyID, err := svc.createStoredApply(t.Context(), plan, ApplyRequest{Environment: "staging"}, nil, "apply-sharded-fanout", true)
+
+	require.NoError(t, err)
+	assert.Equal(t, int64(123), storedApplyID)
+	require.NotNil(t, apply)
+	assert.Equal(t, storage.EngineStrata, apply.Engine)
+	require.Len(t, applies.operations, 2)
+	assert.Equal(t, DefaultDeployment, applies.operations[0].Deployment)
+	assert.Equal(t, "commerce-target", applies.operations[0].Target)
+	assert.Equal(t, "commerce/-80/users", applies.operations[0].OperationKey)
+	assert.Equal(t, DefaultDeployment, applies.operations[1].Deployment)
+	assert.Equal(t, "commerce-target", applies.operations[1].Target)
+	assert.Equal(t, "commerce/80-/users", applies.operations[1].OperationKey)
+	require.Len(t, tasks.tasks, 2)
+	assert.Equal(t, "-80", tasks.tasks[0].Shard)
+	assert.Equal(t, "users", tasks.tasks[0].TableName)
+	require.NotNil(t, tasks.tasks[0].ApplyOperationID)
+	assert.Equal(t, applies.operations[0].ID, *tasks.tasks[0].ApplyOperationID)
+	assert.Equal(t, "80-", tasks.tasks[1].Shard)
+	assert.Equal(t, "users", tasks.tasks[1].TableName)
+	require.NotNil(t, tasks.tasks[1].ApplyOperationID)
+	assert.Equal(t, applies.operations[1].ID, *tasks.tasks[1].ApplyOperationID)
+}
+
+func TestCreateStoredApplyDoesNotShardWithoutClientOptIn(t *testing.T) {
+	applies := &capturingApplyStore{}
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	tasks := &capturingTaskStore{}
+	applies.taskStore = tasks
+	plan := executeApplyTestPlan()
+	plan.Namespaces = map[string]*storage.NamespacePlanData{
+		"commerce": {
+			Tables: []storage.TableChange{
+				{Namespace: "commerce", Table: "users", DDL: "ALTER TABLE `users` ADD COLUMN `email` varchar(255)", Operation: "alter"},
+			},
+		},
+	}
+	plan.Shards = []storage.ShardPlan{
+		{Namespace: "commerce", Shard: "-80", NeedsChange: true},
+		{Namespace: "commerce", Shard: "80-", NeedsChange: true},
+	}
+	svc := New(&mockStorageWithApplyStores{
+		plans:     &staticPlanStore{plan: plan},
+		applies:   applies,
+		tasks:     tasks,
+		locks:     &emptyLockStore{},
+		applyLogs: &noopApplyLogStore{},
+		controls:  &memoryControlRequestStore{},
+	}, testServerConfig(), map[string]tern.Client{}, logger)
+
+	_, _, err := svc.createStoredApply(t.Context(), plan, ApplyRequest{Environment: "staging"}, nil, "apply-no-sharded-fanout", false)
+
+	require.NoError(t, err)
+	require.Len(t, applies.operations, 1)
+	assert.Empty(t, applies.operations[0].OperationKey)
+	require.Len(t, tasks.tasks, 1)
+	assert.Empty(t, tasks.tasks[0].Shard)
+}
+
+func TestValidateShardOperationKeyPartsRejectsDelimiter(t *testing.T) {
+	err := validateShardOperationKeyParts("commerce", "-80/80-", "users")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "reserved delimiter")
 }
 
 func TestProgressByApplyIDServesQueuedRemoteApplyFromStorage(t *testing.T) {

--- a/pkg/api/plan_handlers.go
+++ b/pkg/api/plan_handlers.go
@@ -1104,9 +1104,16 @@ func buildShardedApplyOperationGroups(
 }
 
 func validateShardOperationKeyParts(namespace, shard, table string) error {
-	for label, value := range map[string]string{"namespace": namespace, "shard": shard, "table": table} {
-		if strings.Contains(value, "/") {
-			return fmt.Errorf("operation key %s component %q contains reserved delimiter %q", label, value, "/")
+	for _, part := range []struct {
+		label string
+		value string
+	}{
+		{label: "namespace", value: namespace},
+		{label: "shard", value: shard},
+		{label: "table", value: table},
+	} {
+		if strings.Contains(part.value, "/") {
+			return fmt.Errorf("operation key %s component %q contains reserved delimiter %q", part.label, part.value, "/")
 		}
 	}
 	return nil

--- a/pkg/api/plan_handlers.go
+++ b/pkg/api/plan_handlers.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"maps"
 	"net/http"
+	"sort"
 	"strings"
 	"time"
 
@@ -25,7 +26,10 @@ import (
 	"github.com/block/schemabot/pkg/schema"
 	"github.com/block/schemabot/pkg/state"
 	"github.com/block/schemabot/pkg/storage"
+	"github.com/block/schemabot/pkg/tern"
 )
+
+const applyOperationKeyMaxLen = 255
 
 // PlanRequest is the HTTP request body for POST /api/plan.
 type PlanRequest struct {
@@ -854,7 +858,7 @@ func (s *Service) queueValidatedApply(ctx context.Context, span trace.Span, plan
 		client.SetObserver(storedApplyID, observer)
 	}
 
-	applyIdentifier, storedApplyID, err := s.enqueueApply(ctx, plan, req, options, attachObserver)
+	applyIdentifier, storedApplyID, err := s.enqueueApply(ctx, plan, req, options, clientSupportsShardedApplyFanout(client), attachObserver)
 	if err != nil {
 		recordApplyError("enqueue apply", err)
 		return nil, 0, err
@@ -881,10 +885,11 @@ func (s *Service) enqueueApply(
 	plan *storage.Plan,
 	req ApplyRequest,
 	options map[string]string,
+	shardedFanoutSupported bool,
 	onApplyCreated func(int64),
 ) (string, int64, error) {
 	applyIdentifier := "apply-" + strings.ReplaceAll(uuid.New().String(), "-", "")[:16]
-	apply, storedApplyID, err := s.createStoredApply(ctx, plan, req, options, applyIdentifier, "")
+	apply, storedApplyID, err := s.createStoredApply(ctx, plan, req, options, applyIdentifier, shardedFanoutSupported)
 	if err != nil {
 		return "", 0, err
 	}
@@ -900,7 +905,7 @@ func (s *Service) createStoredApply(
 	req ApplyRequest,
 	options map[string]string,
 	applyIdentifier string,
-	externalID string,
+	shardedFanoutSupported bool,
 ) (*storage.Apply, int64, error) {
 	now := time.Now()
 	applyOpts := storage.ApplyOptionsFromMap(options)
@@ -945,7 +950,6 @@ func (s *Service) createStoredApply(
 		Deployment:      targets[0].Deployment,
 		Caller:          req.Caller,
 		InstallationID:  req.InstallationID,
-		ExternalID:      externalID,
 		Engine:          storage.EngineForType(plan.DatabaseType),
 		State:           state.Apply.Pending,
 		Options:         storage.MarshalApplyOptions(applyOpts),
@@ -954,48 +958,20 @@ func (s *Service) createStoredApply(
 	}
 
 	taskChanges := applyTaskChanges(plan)
-	buildTasks := func() []*storage.Task {
-		tasks := make([]*storage.Task, 0, len(taskChanges))
-		for _, ddlChange := range taskChanges {
-			task := &storage.Task{
-				TaskIdentifier: "task-" + strings.ReplaceAll(uuid.New().String(), "-", "")[:16],
-				PlanID:         plan.ID,
-				Database:       plan.Database,
-				DatabaseType:   plan.DatabaseType,
-				Engine:         storage.EngineForType(plan.DatabaseType),
-				Repository:     plan.Repository,
-				PullRequest:    plan.PullRequest,
-				Environment:    req.Environment,
-				State:          state.Task.Pending,
-				Options:        storage.MarshalApplyOptions(applyOpts),
-				Namespace:      ddlChange.Namespace,
-				TableName:      ddlChange.Table,
-				DDL:            ddlChange.DDL,
-				DDLAction:      ddlChange.Operation,
-				CreatedAt:      now,
-				UpdatedAt:      now,
-			}
-			tasks = append(tasks, task)
-		}
-		return tasks
-	}
-
 	cutoverPolicy := s.config.CutoverPolicyFor(plan.Database, req.Environment)
 	onFailure := s.config.OnFailure(plan.Database, req.Environment)
-	groups := make([]*storage.ApplyOperationWithTasks, 0, len(targets))
-	for _, target := range targets {
-		groups = append(groups, &storage.ApplyOperationWithTasks{
-			Operation: &storage.ApplyOperation{
-				Deployment:    target.Deployment,
-				Target:        target.Target,
-				State:         state.ApplyOperation.Pending,
-				CutoverPolicy: cutoverPolicy,
-				OnFailure:     onFailure,
-				CreatedAt:     now,
-				UpdatedAt:     now,
-			},
-			Tasks: buildTasks(),
-		})
+	groups, shardedFanout, err := buildApplyOperationGroups(plan, taskChanges, targets, req.Environment, applyOpts, cutoverPolicy, onFailure, now, shardedFanoutSupported)
+	if err != nil {
+		return nil, 0, err
+	}
+	if shardedFanout {
+		s.logger.Info("createStoredApply: queueing sharded apply operation groups",
+			"plan_id", plan.PlanIdentifier,
+			"database", plan.Database,
+			"database_type", plan.DatabaseType,
+			"environment", req.Environment,
+			"deployment_count", len(targets),
+			"operation_group_count", len(groups))
 	}
 
 	storedApplyID, err := s.storage.Applies().CreateWithGroupedOperations(ctx, apply, groups)
@@ -1021,6 +997,11 @@ func (s *Service) createStoredApply(
 	return apply, storedApplyID, nil
 }
 
+func clientSupportsShardedApplyFanout(client tern.Client) bool {
+	capability, ok := client.(tern.ShardedApplyFanoutSupport)
+	return ok && capability.SupportsShardedApplyFanout()
+}
+
 func applyTaskChanges(plan *storage.Plan) []storage.TableChange {
 	changes := append([]storage.TableChange{}, plan.FlatDDLChanges()...)
 	for namespace, nsData := range plan.Namespaces {
@@ -1033,6 +1014,179 @@ func applyTaskChanges(plan *storage.Plan) []storage.TableChange {
 		}
 	}
 	return changes
+}
+
+func buildApplyOperationGroups(
+	plan *storage.Plan,
+	taskChanges []storage.TableChange,
+	targets []routing.ExecutionTarget,
+	environment string,
+	applyOpts storage.ApplyOptions,
+	cutoverPolicy string,
+	onFailure string,
+	now time.Time,
+	shardedFanoutSupported bool,
+) ([]*storage.ApplyOperationWithTasks, bool, error) {
+	if shardedFanoutSupported && canBuildShardedOperationGroups(plan, taskChanges) {
+		groups, err := buildShardedApplyOperationGroups(plan, taskChanges, targets, environment, applyOpts, cutoverPolicy, onFailure, now)
+		if err != nil {
+			return nil, false, err
+		}
+		return groups, true, nil
+	}
+
+	groups := make([]*storage.ApplyOperationWithTasks, 0, len(targets))
+	for _, target := range targets {
+		groups = append(groups, &storage.ApplyOperationWithTasks{
+			Operation: newPendingApplyOperation(target, "", cutoverPolicy, onFailure, now),
+			Tasks:     buildApplyTasks(plan, taskChanges, environment, applyOpts, "", now),
+		})
+	}
+	return groups, false, nil
+}
+
+func canBuildShardedOperationGroups(plan *storage.Plan, taskChanges []storage.TableChange) bool {
+	if plan == nil || len(plan.Shards) == 0 || len(taskChanges) == 0 {
+		return false
+	}
+	shardsByNamespace := changingShardsByNamespace(plan.Shards)
+	if len(shardsByNamespace) == 0 {
+		return false
+	}
+	for _, ddlChange := range taskChanges {
+		if ddlChange.DDL == "" || ddlChange.Table == "" || ddlChange.Operation == "vschema_update" {
+			return false
+		}
+		if len(shardsByNamespace[ddlChange.Namespace]) == 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func buildShardedApplyOperationGroups(
+	plan *storage.Plan,
+	taskChanges []storage.TableChange,
+	targets []routing.ExecutionTarget,
+	environment string,
+	applyOpts storage.ApplyOptions,
+	cutoverPolicy string,
+	onFailure string,
+	now time.Time,
+) ([]*storage.ApplyOperationWithTasks, error) {
+	shardsByNamespace := changingShardsByNamespace(plan.Shards)
+	groups := make([]*storage.ApplyOperationWithTasks, 0, len(targets)*len(taskChanges))
+	groupsByTargetAndKey := make(map[string]*storage.ApplyOperationWithTasks)
+	for _, target := range targets {
+		for _, ddlChange := range taskChanges {
+			for _, shard := range shardsByNamespace[ddlChange.Namespace] {
+				if err := validateShardOperationKeyParts(ddlChange.Namespace, shard.Shard, ddlChange.Table); err != nil {
+					return nil, err
+				}
+				operationKey := shardOperationKey(ddlChange.Namespace, shard.Shard, ddlChange.Table)
+				if len(operationKey) > applyOperationKeyMaxLen {
+					return nil, fmt.Errorf("operation key for namespace %q shard %q table %q exceeds %d characters", ddlChange.Namespace, shard.Shard, ddlChange.Table, applyOperationKeyMaxLen)
+				}
+				groupKey := target.Deployment + "\x00" + operationKey
+				group := groupsByTargetAndKey[groupKey]
+				if group == nil {
+					group = &storage.ApplyOperationWithTasks{
+						Operation: newPendingApplyOperation(target, operationKey, cutoverPolicy, onFailure, now),
+					}
+					groupsByTargetAndKey[groupKey] = group
+					groups = append(groups, group)
+				}
+				group.Tasks = append(group.Tasks, buildApplyTask(plan, ddlChange, environment, applyOpts, shard.Shard, now))
+			}
+		}
+	}
+	return groups, nil
+}
+
+func validateShardOperationKeyParts(namespace, shard, table string) error {
+	for label, value := range map[string]string{"namespace": namespace, "shard": shard, "table": table} {
+		if strings.Contains(value, "/") {
+			return fmt.Errorf("operation key %s component %q contains reserved delimiter %q", label, value, "/")
+		}
+	}
+	return nil
+}
+
+func changingShardsByNamespace(shards []storage.ShardPlan) map[string][]storage.ShardPlan {
+	shardsByNamespace := make(map[string][]storage.ShardPlan)
+	for _, shard := range shards {
+		if !shard.NeedsChange {
+			continue
+		}
+		shardsByNamespace[shard.Namespace] = append(shardsByNamespace[shard.Namespace], shard)
+	}
+	for namespace := range shardsByNamespace {
+		sort.Slice(shardsByNamespace[namespace], func(i, j int) bool {
+			return shardsByNamespace[namespace][i].Shard < shardsByNamespace[namespace][j].Shard
+		})
+	}
+	return shardsByNamespace
+}
+
+func shardOperationKey(namespace, shard, table string) string {
+	return namespace + "/" + shard + "/" + table
+}
+
+func newPendingApplyOperation(target routing.ExecutionTarget, operationKey, cutoverPolicy, onFailure string, now time.Time) *storage.ApplyOperation {
+	return &storage.ApplyOperation{
+		Deployment:    target.Deployment,
+		OperationKey:  operationKey,
+		Target:        target.Target,
+		State:         state.ApplyOperation.Pending,
+		CutoverPolicy: cutoverPolicy,
+		OnFailure:     onFailure,
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}
+}
+
+func buildApplyTasks(
+	plan *storage.Plan,
+	taskChanges []storage.TableChange,
+	environment string,
+	applyOpts storage.ApplyOptions,
+	shard string,
+	now time.Time,
+) []*storage.Task {
+	tasks := make([]*storage.Task, 0, len(taskChanges))
+	for _, ddlChange := range taskChanges {
+		tasks = append(tasks, buildApplyTask(plan, ddlChange, environment, applyOpts, shard, now))
+	}
+	return tasks
+}
+
+func buildApplyTask(
+	plan *storage.Plan,
+	ddlChange storage.TableChange,
+	environment string,
+	applyOpts storage.ApplyOptions,
+	shard string,
+	now time.Time,
+) *storage.Task {
+	return &storage.Task{
+		TaskIdentifier: "task-" + strings.ReplaceAll(uuid.New().String(), "-", "")[:16],
+		PlanID:         plan.ID,
+		Database:       plan.Database,
+		DatabaseType:   plan.DatabaseType,
+		Engine:         storage.EngineForType(plan.DatabaseType),
+		Repository:     plan.Repository,
+		PullRequest:    plan.PullRequest,
+		Environment:    environment,
+		State:          state.Task.Pending,
+		Options:        storage.MarshalApplyOptions(applyOpts),
+		Namespace:      ddlChange.Namespace,
+		TableName:      ddlChange.Table,
+		Shard:          shard,
+		DDL:            ddlChange.DDL,
+		DDLAction:      ddlChange.Operation,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
 }
 
 // ExecuteRollbackPlanForApply generates a rollback plan for a specific apply.

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -235,16 +235,17 @@ type TableChange struct {
 }
 
 // ApplyRequest contains the input for starting a schema change.
-// On first apply, set ResumeState.MigrationContext to group related DDL.
+// On first apply, set the resume context to group related DDL.
 // On resume after restart, pass the full ResumeState from storage.
 type ApplyRequest struct {
-	PlanID      string             // Plan being executed (for tracing and apply→plan linkage)
-	Database    string             // Target database
-	Changes     []SchemaChange     // Per-namespace changes to apply (DDL + files from plan)
-	SchemaFiles schema.SchemaFiles // Full declarative schema files (for engines that apply whole files)
-	Options     map[string]string  // Options like "defer_cutover", "skip_revert"
-	ResumeState *ResumeState       // Migration context (fresh) or full resume state (restart)
-	Credentials *Credentials       // Resolved credentials (from discovery)
+	PlanID       string             // Plan being executed (for tracing and apply→plan linkage)
+	Database     string             // Target database
+	Changes      []SchemaChange     // Per-namespace changes to apply (DDL + files from plan)
+	TargetShards []string           // Optional shard selector for sharded engines
+	SchemaFiles  schema.SchemaFiles // Full declarative schema files (for engines that apply whole files)
+	Options      map[string]string  // Options like "defer_cutover", "skip_revert"
+	ResumeState  *ResumeState       // Fresh context or full resume state after restart
+	Credentials  *Credentials       // Resolved credentials (from discovery)
 
 	// OnStateChange is called by the engine to persist ResumeState at key milestones
 	// during Apply (e.g., after branch creation, after deploy request creation).

--- a/pkg/tern/apply_states_test.go
+++ b/pkg/tern/apply_states_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/block/spirit/pkg/statement"
-
 	"github.com/block/schemabot/pkg/engine"
 	"github.com/block/schemabot/pkg/state"
 	"github.com/block/schemabot/pkg/storage"
@@ -176,37 +174,6 @@ func TestApplyEventStateTransition(t *testing.T) {
 		assert.Equal(t, state.Apply.PreparingBranch, got)
 		assert.Equal(t, state.Apply.PreparingBranch, apply.State)
 	})
-}
-
-func TestPlanNamespacesToChanges_VSchemaOnlyWhenStored(t *testing.T) {
-	namespaces := map[string]*storage.NamespacePlanData{
-		"ks_with_vschema": {
-			Tables:    []storage.TableChange{{Table: "users", DDL: "ALTER TABLE users ADD COLUMN x INT", Operation: "alter"}},
-			Artifacts: map[string]string{"vschema.json": `{"tables":{"users":{}}}`},
-		},
-		"ks_without_vschema": {
-			Tables: []storage.TableChange{{Table: "orders", DDL: "ALTER TABLE orders ADD COLUMN y INT", Operation: "alter"}},
-		},
-	}
-
-	changes := planNamespacesToChanges(namespaces)
-	require.Len(t, changes, 2)
-
-	byNS := make(map[string]engine.SchemaChange)
-	for _, c := range changes {
-		byNS[c.Namespace] = c
-	}
-
-	// Keyspace with VSchema stored should have metadata["vschema"] set
-	assert.Equal(t, "true", byNS["ks_with_vschema"].Metadata["vschema_changed"])
-
-	// Keyspace without VSchema should NOT have metadata["vschema"] set
-	assert.Empty(t, byNS["ks_without_vschema"].Metadata["vschema_changed"],
-		"keyspace without VSchema change should not have vschema metadata")
-
-	// Operation field should be preserved (storage string → Spirit type via OpToStatementType)
-	assert.Equal(t, statement.StatementAlterTable, byNS["ks_with_vschema"].TableChanges[0].Operation)
-	assert.Equal(t, statement.StatementAlterTable, byNS["ks_without_vschema"].TableChanges[0].Operation)
 }
 
 func TestDeriveOverallState(t *testing.T) {

--- a/pkg/tern/client.go
+++ b/pkg/tern/client.go
@@ -120,3 +120,9 @@ type Client interface {
 	// Close releases any resources held by the client.
 	Close() error
 }
+
+// ShardedApplyFanoutSupport is an optional client capability for engines that
+// can drive sharded work as independent SchemaBot apply operations.
+type ShardedApplyFanoutSupport interface {
+	SupportsShardedApplyFanout() bool
+}

--- a/pkg/tern/grpc_client.go
+++ b/pkg/tern/grpc_client.go
@@ -101,6 +101,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
+	"sort"
 	"sync"
 	"time"
 
@@ -1785,15 +1786,16 @@ func (c *GRPCClient) dispatchPendingApply(ctx context.Context, apply *storage.Ap
 	}
 
 	resp, err := c.client.Apply(ctx, &ternv1.ApplyRequest{
-		PlanId:      plan.PlanIdentifier,
-		Options:     options,
-		Database:    apply.Database,
-		Type:        apply.DatabaseType,
-		DdlChanges:  tasksToProtoTableChanges(tasks),
-		SchemaFiles: schemaFilesToProto(plan.SchemaFiles),
-		Environment: apply.Environment,
-		Target:      target,
-		Caller:      apply.Caller,
+		PlanId:       plan.PlanIdentifier,
+		Options:      options,
+		Database:     apply.Database,
+		Type:         apply.DatabaseType,
+		DdlChanges:   tasksToProtoTableChanges(tasks),
+		SchemaFiles:  schemaFilesToProto(plan.SchemaFiles),
+		Environment:  apply.Environment,
+		Target:       target,
+		Caller:       apply.Caller,
+		TargetShards: taskTargetShards(tasks),
 	})
 	if err != nil {
 		if isAmbiguousRemoteApplyDispatchError(err) {
@@ -1974,6 +1976,23 @@ func tasksToProtoTableChanges(tasks []*storage.Task) []*ternv1.TableChange {
 		})
 	}
 	return changes
+}
+
+func taskTargetShards(tasks []*storage.Task) []string {
+	seen := make(map[string]struct{})
+	var shards []string
+	for _, task := range tasks {
+		if task.Shard == "" {
+			continue
+		}
+		if _, ok := seen[task.Shard]; ok {
+			continue
+		}
+		seen[task.Shard] = struct{}{}
+		shards = append(shards, task.Shard)
+	}
+	sort.Strings(shards)
+	return shards
 }
 
 // storedApplyTransitionStatus describes whether a driver may copy a remote

--- a/pkg/tern/grpc_client_test.go
+++ b/pkg/tern/grpc_client_test.go
@@ -918,6 +918,7 @@ func TestGRPCClient_ResumeApplyOperationDispatchesScopedTasks(t *testing.T) {
 		ApplyID:          apply.ID,
 		ApplyOperationID: &operationID,
 		TableName:        "users",
+		Shard:            "-80",
 		DDL:              "ALTER TABLE users ADD COLUMN email varchar(255)",
 		DDLAction:        "alter",
 		Namespace:        "default",
@@ -954,6 +955,7 @@ func TestGRPCClient_ResumeApplyOperationDispatchesScopedTasks(t *testing.T) {
 	require.NotNil(t, req, "expected operation-scoped apply to be dispatched to remote Tern")
 	require.Len(t, req.DdlChanges, 1)
 	assert.Equal(t, "users", req.DdlChanges[0].TableName)
+	assert.Equal(t, []string{"-80"}, req.TargetShards)
 }
 
 func TestGRPCClient_ResumeApplyOperationDispatchParksBarrierCutoverRemotely(t *testing.T) {

--- a/pkg/tern/local_apply.go
+++ b/pkg/tern/local_apply.go
@@ -6,7 +6,6 @@ import (
 	"log/slog"
 	"time"
 
-	"github.com/block/schemabot/pkg/ddl"
 	"github.com/block/schemabot/pkg/engine"
 	"github.com/block/schemabot/pkg/engine/spirit"
 	"github.com/block/schemabot/pkg/state"
@@ -418,31 +417,4 @@ func applyEventStateTransition(apply *storage.Apply, event engine.ApplyEvent, up
 		return ""
 	}
 	return newState
-}
-
-// planNamespacesToChanges converts stored plan namespace data to engine schema
-// changes for the Apply call. VSchema metadata is only set when the plan
-// stored a VSchema diff (i.e., the Plan detected a real change).
-func planNamespacesToChanges(namespaces map[string]*storage.NamespacePlanData) []engine.SchemaChange {
-	var changes []engine.SchemaChange
-	for namespace, nsData := range namespaces {
-		var tableChanges []engine.TableChange
-		for _, tc := range nsData.Tables {
-			tableChanges = append(tableChanges, engine.TableChange{
-				Table:     tc.Table,
-				DDL:       tc.DDL,
-				Operation: ddl.OpToStatementType(tc.Operation),
-			})
-		}
-		metadata := make(map[string]string)
-		if namespaceHasVSchemaArtifact(nsData) {
-			metadata["vschema_changed"] = "true"
-		}
-		changes = append(changes, engine.SchemaChange{
-			Namespace:    namespace,
-			TableChanges: tableChanges,
-			Metadata:     metadata,
-		})
-	}
-	return changes
 }

--- a/pkg/tern/local_apply_grouped.go
+++ b/pkg/tern/local_apply_grouped.go
@@ -42,9 +42,9 @@ func (c *LocalClient) executeGroupedApply(ctx context.Context, apply *storage.Ap
 	c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventInfo, storage.LogSourceSchemaBot,
 		"Calling engine.Apply for all tables", "", "")
 
-	// Build per-namespace changes from the plan. For Vitess databases, each
-	// namespace is a keyspace (e.g., "testapp", "testapp_sharded"). For MySQL,
-	c.logger.Info("building changes from plan", "namespaces", len(plan.Namespaces), "plan_id", plan.PlanIdentifier)
+	// Build per-namespace changes from the scoped tasks. Whole-apply drives pass
+	// every task, while operation-scoped drives pass only one operation's tasks.
+	c.logger.Info("building changes from scoped tasks", "task_count", len(tasks), "plan_id", plan.PlanIdentifier)
 	if len(plan.Namespaces) == 0 {
 		c.failApplyWithTasks(ctx, apply, tasks, "plan has no namespace data")
 		return
@@ -63,7 +63,7 @@ func (c *LocalClient) executeGroupedApply(ctx context.Context, apply *storage.Ap
 		c.failApplyWithTasks(ctx, apply, tasks, err.Error())
 		return
 	}
-	changes := planNamespacesToChanges(plan.Namespaces)
+	changes := groupedResumeChanges(tasks)
 
 	// Mark the apply as started before calling the engine. The engine may run
 	// for a long time (branch creation, DDL application, deploy request) and
@@ -83,16 +83,17 @@ func (c *LocalClient) executeGroupedApply(ctx context.Context, apply *storage.Ap
 		return
 	}
 
-	// Grouped mode: all DDLs in one engine call. Use the apply identifier as
-	// MigrationContext so all table work shares one context for progress tracking.
+	// Grouped mode: all DDLs in one engine call. Use the apply identifier so all
+	// table work shares one context for progress tracking.
 	result, err := eng.Apply(ctx, &engine.ApplyRequest{
-		Database:    apply.Database,
-		PlanID:      plan.PlanIdentifier,
-		Changes:     changes,
-		SchemaFiles: plan.SchemaFiles,
-		Options:     options,
-		ResumeState: &engine.ResumeState{MigrationContext: apply.ApplyIdentifier},
-		Credentials: creds,
+		Database:     apply.Database,
+		PlanID:       plan.PlanIdentifier,
+		Changes:      changes,
+		TargetShards: taskTargetShards(tasks),
+		SchemaFiles:  plan.SchemaFiles,
+		Options:      options,
+		ResumeState:  &engine.ResumeState{MigrationContext: apply.ApplyIdentifier},
+		Credentials:  creds,
 		OnEvent: func(event engine.ApplyEvent) {
 			oldState := apply.State
 			newState := deriveApplyPhase(event)

--- a/pkg/tern/local_client.go
+++ b/pkg/tern/local_client.go
@@ -1596,6 +1596,14 @@ func engineProgressIsExternallyAuthoritative(eng engine.Engine) bool {
 	return ok && source.ProgressIsExternallyAuthoritative()
 }
 
+// SupportsShardedApplyFanout reports whether this local client can drive
+// sharded work as independent SchemaBot apply operations. Engines that expose
+// externally authoritative progress own their execution ordering outside
+// SchemaBot, so apply-create must keep them as one operation.
+func (c *LocalClient) SupportsShardedApplyFanout() bool {
+	return !engineProgressIsExternallyAuthoritative(c.getEngine())
+}
+
 // Progress returns detailed progress for an active schema change.
 // Returns ALL tasks for the current apply: completed, running, and pending.
 // req.ApplyId is required so progress is always scoped to a single apply.

--- a/pkg/tern/local_client_test.go
+++ b/pkg/tern/local_client_test.go
@@ -893,6 +893,41 @@ func TestGroupedResumeChangesVSchemaOnly(t *testing.T) {
 	assert.Equal(t, "true", changes[0].Metadata["vschema_changed"])
 }
 
+func TestGroupedResumeChangesPreservesMultiNamespaceScopedTasks(t *testing.T) {
+	tasks := []*storage.Task{
+		{Namespace: "commerce", TableName: "users", DDL: "ALTER TABLE `users` ADD COLUMN `email` varchar(255)", DDLAction: "alter"},
+		{Namespace: "routing", TableName: "VSchema: routing", DDLAction: "vschema_update"},
+	}
+
+	changes := groupedResumeChanges(tasks)
+
+	require.Len(t, changes, 2)
+	byNamespace := make(map[string]engine.SchemaChange)
+	for _, change := range changes {
+		byNamespace[change.Namespace] = change
+	}
+	commerce := byNamespace["commerce"]
+	require.Len(t, commerce.TableChanges, 1)
+	assert.Equal(t, "users", commerce.TableChanges[0].Table)
+	assert.Equal(t, "ALTER TABLE `users` ADD COLUMN `email` varchar(255)", commerce.TableChanges[0].DDL)
+	assert.Equal(t, statement.StatementAlterTable, commerce.TableChanges[0].Operation)
+	assert.Empty(t, commerce.Metadata["vschema_changed"])
+	routing := byNamespace["routing"]
+	assert.Empty(t, routing.TableChanges)
+	assert.Equal(t, "true", routing.Metadata["vschema_changed"])
+}
+
+func TestTaskTargetShardsReturnsSortedUniqueShardSelector(t *testing.T) {
+	tasks := []*storage.Task{
+		{Shard: "80-"},
+		{Shard: ""},
+		{Shard: "-80"},
+		{Shard: "80-"},
+	}
+
+	assert.Equal(t, []string{"-80", "80-"}, taskTargetShards(tasks))
+}
+
 func TestLocalClient_ProcessPendingStopControlRequest(t *testing.T) {
 	apply := &storage.Apply{
 		ID:              123,

--- a/pkg/tern/local_control_resume.go
+++ b/pkg/tern/local_control_resume.go
@@ -625,13 +625,14 @@ func (c *LocalClient) launchAtomicResume(ctx context.Context, apply *storage.App
 	// engine keys per-table progress on the same namespace/table pairs the
 	// tasks carry.
 	result, err := eng.Apply(ctx, &engine.ApplyRequest{
-		Database:    apply.Database,
-		PlanID:      plan.PlanIdentifier,
-		Changes:     groupedResumeChanges(tasks),
-		SchemaFiles: plan.SchemaFiles,
-		Options:     options,
-		ResumeState: resumeState,
-		Credentials: creds,
+		Database:     apply.Database,
+		PlanID:       plan.PlanIdentifier,
+		Changes:      groupedResumeChanges(tasks),
+		TargetShards: taskTargetShards(tasks),
+		SchemaFiles:  plan.SchemaFiles,
+		Options:      options,
+		ResumeState:  resumeState,
+		Credentials:  creds,
 		OnStateChange: func(rs *engine.ResumeState) {
 			if rs == nil {
 				c.logger.Debug("OnStateChange: nil resume state", "apply_id", apply.ApplyIdentifier)

--- a/pkg/tern/progress_ownership_test.go
+++ b/pkg/tern/progress_ownership_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/block/schemabot/pkg/engine"
+	"github.com/block/schemabot/pkg/storage"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -57,4 +58,16 @@ func TestEngineProgressIsExternallyAuthoritative(t *testing.T) {
 			assert.Equal(t, tc.want, engineProgressIsExternallyAuthoritative(tc.eng))
 		})
 	}
+}
+
+func TestLocalClientSupportsShardedApplyFanoutOnlyForInstanceLocalEngines(t *testing.T) {
+	assert.False(t, (&LocalClient{
+		config:       LocalConfig{Type: storage.DatabaseTypeMySQL},
+		spiritEngine: &authoritativeEngine{authoritative: true},
+	}).SupportsShardedApplyFanout())
+
+	assert.True(t, (&LocalClient{
+		config:       LocalConfig{Type: storage.DatabaseTypeMySQL},
+		spiritEngine: &instanceLocalEngine{},
+	}).SupportsShardedApplyFanout())
 }


### PR DESCRIPTION
## Why
Stored shard metadata gives apply-create enough information to queue sharded work as independent operation rows instead of one deployment-wide operation.

## What
- Fan out sharded stored plans into operation-keyed apply operation groups when the resolved client opts in
- Scope local and gRPC engine dispatch to the claimed operation tasks and target shards
- Preserve existing unkeyed operation creation for non-sharded plans and non-opted-in clients

## Risk Assessment
Medium — this touches apply queueing and operation-scoped dispatch, but the new fanout path only activates when stored shard metadata is present and the resolved client explicitly supports sharded operation fanout.

## References
- Stacked on #489

Generated with Amp
