### PR TITLE
feat(storage): add sharded apply group finalizers

### DIFF
--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -2078,6 +2078,8 @@ func TestCreateStoredApplyFansOutShardedPlanWithFinalizerOperation(t *testing.T)
 }
 
 func TestCreateStoredApplyDoesNotDropFinalizerOnlyNamespace(t *testing.T) {
+	// A routing-only namespace with no shard work keeps the apply on the
+	// single-operation path so the routing change is preserved.
 	applies := &capturingApplyStore{}
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
 	tasks := &capturingTaskStore{}

--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -1998,9 +1998,11 @@ func TestCreateStoredApplyFansOutShardedPlanOperations(t *testing.T) {
 	assert.Equal(t, DefaultDeployment, applies.operations[0].Deployment)
 	assert.Equal(t, "commerce-target", applies.operations[0].Target)
 	assert.Equal(t, "commerce/-80/users", applies.operations[0].OperationKey)
+	assert.Equal(t, storage.ApplyOperationKindWork, applies.operations[0].OperationKind)
 	assert.Equal(t, DefaultDeployment, applies.operations[1].Deployment)
 	assert.Equal(t, "commerce-target", applies.operations[1].Target)
 	assert.Equal(t, "commerce/80-/users", applies.operations[1].OperationKey)
+	assert.Equal(t, storage.ApplyOperationKindWork, applies.operations[1].OperationKind)
 	require.Len(t, tasks.tasks, 2)
 	assert.Equal(t, "-80", tasks.tasks[0].Shard)
 	assert.Equal(t, "users", tasks.tasks[0].TableName)
@@ -2010,6 +2012,116 @@ func TestCreateStoredApplyFansOutShardedPlanOperations(t *testing.T) {
 	assert.Equal(t, "users", tasks.tasks[1].TableName)
 	require.NotNil(t, tasks.tasks[1].ApplyOperationID)
 	assert.Equal(t, applies.operations[1].ID, *tasks.tasks[1].ApplyOperationID)
+}
+
+func TestCreateStoredApplyFansOutShardedPlanWithFinalizerOperation(t *testing.T) {
+	// A sharded plan with a namespace-level routing metadata change keeps the
+	// work operations shard-scoped and queues the metadata change as a finalizer
+	// operation that is driven through the same operation-scoped path.
+	applies := &capturingApplyStore{}
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	tasks := &capturingTaskStore{}
+	applies.taskStore = tasks
+	plan := executeApplyTestPlan()
+	plan.DatabaseType = storage.DatabaseTypeStrata
+	plan.Target = "commerce-target"
+	plan.Namespaces = map[string]*storage.NamespacePlanData{
+		"commerce": {
+			Artifacts: map[string]string{vSchemaArtifactName: "{\"sharded\":true}"},
+			Tables: []storage.TableChange{
+				{Namespace: "commerce", Table: "users", DDL: "ALTER TABLE `users` ADD COLUMN `email` varchar(255)", Operation: "alter"},
+			},
+		},
+	}
+	plan.Shards = []storage.ShardPlan{
+		{Namespace: "commerce", Shard: "80-", NeedsChange: true},
+		{Namespace: "commerce", Shard: "-80", NeedsChange: true},
+	}
+	cfg := testServerConfig()
+	cfg.Databases = map[string]DatabaseConfig{}
+	cfg.Databases["testdb"] = DatabaseConfig{
+		Type: storage.DatabaseTypeStrata,
+		Environments: map[string]EnvironmentConfig{
+			"staging": {Target: "commerce-target", Deployment: DefaultDeployment},
+		},
+	}
+	svc := New(&mockStorageWithApplyStores{
+		plans:     &staticPlanStore{plan: plan},
+		applies:   applies,
+		tasks:     tasks,
+		locks:     &emptyLockStore{},
+		applyLogs: &noopApplyLogStore{},
+		controls:  &memoryControlRequestStore{},
+	}, cfg, map[string]tern.Client{}, logger)
+
+	_, _, err := svc.createStoredApply(t.Context(), plan, ApplyRequest{Environment: "staging"}, nil, "apply-sharded-finalizer", true)
+
+	require.NoError(t, err)
+	require.Len(t, applies.operations, 3)
+	assert.Equal(t, "commerce/-80/users", applies.operations[0].OperationKey)
+	assert.Equal(t, storage.ApplyOperationKindWork, applies.operations[0].OperationKind)
+	assert.Equal(t, "commerce/80-/users", applies.operations[1].OperationKey)
+	assert.Equal(t, storage.ApplyOperationKindWork, applies.operations[1].OperationKind)
+	assert.Equal(t, "commerce/group_finalizer", applies.operations[2].OperationKey)
+	assert.Equal(t, storage.ApplyOperationKindGroupFinalizer, applies.operations[2].OperationKind)
+
+	require.Len(t, tasks.tasks, 3)
+	assert.Equal(t, "-80", tasks.tasks[0].Shard)
+	assert.Equal(t, "users", tasks.tasks[0].TableName)
+	assert.Equal(t, "80-", tasks.tasks[1].Shard)
+	assert.Equal(t, "users", tasks.tasks[1].TableName)
+	assert.Empty(t, tasks.tasks[2].Shard)
+	assert.Equal(t, "VSchema: commerce", tasks.tasks[2].TableName)
+	assert.Equal(t, "vschema_update", tasks.tasks[2].DDLAction)
+	require.NotNil(t, tasks.tasks[2].ApplyOperationID)
+	assert.Equal(t, applies.operations[2].ID, *tasks.tasks[2].ApplyOperationID)
+}
+
+func TestCreateStoredApplyDoesNotDropFinalizerOnlyNamespace(t *testing.T) {
+	applies := &capturingApplyStore{}
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	tasks := &capturingTaskStore{}
+	applies.taskStore = tasks
+	plan := executeApplyTestPlan()
+	plan.DatabaseType = storage.DatabaseTypeStrata
+	plan.Namespaces = map[string]*storage.NamespacePlanData{
+		"commerce": {
+			Tables: []storage.TableChange{
+				{Namespace: "commerce", Table: "users", DDL: "ALTER TABLE `users` ADD COLUMN `email` varchar(255)", Operation: "alter"},
+			},
+		},
+		"routing": {
+			Artifacts: map[string]string{vSchemaArtifactName: "{\"routing\":true}"},
+		},
+	}
+	plan.Shards = []storage.ShardPlan{{Namespace: "commerce", Shard: "-", NeedsChange: true}}
+	cfg := testServerConfig()
+	cfg.Databases = map[string]DatabaseConfig{}
+	cfg.Databases["testdb"] = DatabaseConfig{
+		Type: storage.DatabaseTypeStrata,
+		Environments: map[string]EnvironmentConfig{
+			"staging": {Target: "commerce-target", Deployment: DefaultDeployment},
+		},
+	}
+	svc := New(&mockStorageWithApplyStores{
+		plans:     &staticPlanStore{plan: plan},
+		applies:   applies,
+		tasks:     tasks,
+		locks:     &emptyLockStore{},
+		applyLogs: &noopApplyLogStore{},
+		controls:  &memoryControlRequestStore{},
+	}, cfg, map[string]tern.Client{}, logger)
+
+	_, _, err := svc.createStoredApply(t.Context(), plan, ApplyRequest{Environment: "staging"}, nil, "apply-finalizer-only-namespace", true)
+
+	require.NoError(t, err)
+	require.Len(t, applies.operations, 1)
+	assert.Empty(t, applies.operations[0].OperationKey)
+	assert.Equal(t, storage.ApplyOperationKindWork, applies.operations[0].OperationKind)
+	require.Len(t, tasks.tasks, 2)
+	assert.Equal(t, "users", tasks.tasks[0].TableName)
+	assert.Equal(t, "VSchema: routing", tasks.tasks[1].TableName)
+	assert.Equal(t, "vschema_update", tasks.tasks[1].DDLAction)
 }
 
 func TestCreateStoredApplyDoesNotShardWithoutClientOptIn(t *testing.T) {
@@ -2049,6 +2161,13 @@ func TestCreateStoredApplyDoesNotShardWithoutClientOptIn(t *testing.T) {
 
 func TestValidateShardOperationKeyPartsRejectsDelimiter(t *testing.T) {
 	err := validateShardOperationKeyParts("commerce", "-80/80-", "users")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "reserved delimiter")
+}
+
+func TestValidateOperationKeyPartRejectsFinalizerNamespaceDelimiter(t *testing.T) {
+	err := validateOperationKeyPart("namespace", "commerce/eu")
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "reserved delimiter")

--- a/pkg/api/operator_test.go
+++ b/pkg/api/operator_test.go
@@ -288,6 +288,28 @@ func TestUpdateApplyStateFromOperations_ContinuePolicy(t *testing.T) {
 	}
 }
 
+func TestUpdateApplyStateFromOperations_FinalizerPendingIsNonTerminal(t *testing.T) {
+	applyStore := &recordingApplyStore{swapped: true}
+	svc := newOperatorStateTestService(&listingApplyOperationStore{ops: []*storage.ApplyOperation{
+		{ID: 1, State: state.ApplyOperation.Completed, OperationKind: storage.ApplyOperationKindWork},
+		{ID: 2, State: state.ApplyOperation.Completed, OperationKind: storage.ApplyOperationKindWork},
+		{ID: 3, State: state.ApplyOperation.Pending, OperationKind: storage.ApplyOperationKindGroupFinalizer},
+	}}, applyStore)
+
+	apply := &storage.Apply{
+		ID:              3,
+		ApplyIdentifier: "apply-finalizer-pending",
+		State:           state.Apply.Running,
+		Environment:     "staging",
+	}
+
+	_, err := svc.updateApplyStateFromOperations(t.Context(), 1, apply, allowLeaseScopedFailedReopen)
+	require.NoError(t, err)
+	require.NotNil(t, applyStore.updated, "the pending finalizer must keep the aggregate non-terminal")
+	assert.Equal(t, state.Apply.Pending, applyStore.updated.State)
+	assert.Nil(t, applyStore.updated.CompletedAt)
+}
+
 // TestUpdateApplyStateFromOperations_ReopenFailedGuard verifies the terminal
 // guard's reopen exception. Under on_failure "continue" a sibling failure can
 // terminalize the parent apply to failed before the rollout settles; once a

--- a/pkg/api/plan_handlers.go
+++ b/pkg/api/plan_handlers.go
@@ -30,6 +30,7 @@ import (
 )
 
 const applyOperationKeyMaxLen = 255
+const finalizerOperationKeySegment = "group_finalizer"
 
 // PlanRequest is the HTTP request body for POST /api/plan.
 type PlanRequest struct {
@@ -1053,15 +1054,29 @@ func canBuildShardedOperationGroups(plan *storage.Plan, taskChanges []storage.Ta
 	if len(shardsByNamespace) == 0 {
 		return false
 	}
+	hasWorkChange := false
+	workNamespaces := make(map[string]struct{})
+	finalizerNamespaces := make(map[string]struct{})
 	for _, ddlChange := range taskChanges {
-		if ddlChange.DDL == "" || ddlChange.Table == "" || ddlChange.Operation == "vschema_update" {
+		if isGroupFinalizerChange(ddlChange) {
+			finalizerNamespaces[ddlChange.Namespace] = struct{}{}
+			continue
+		}
+		if ddlChange.DDL == "" || ddlChange.Table == "" {
 			return false
 		}
 		if len(shardsByNamespace[ddlChange.Namespace]) == 0 {
 			return false
 		}
+		workNamespaces[ddlChange.Namespace] = struct{}{}
+		hasWorkChange = true
 	}
-	return true
+	for namespace := range finalizerNamespaces {
+		if _, ok := workNamespaces[namespace]; !ok {
+			return false
+		}
+	}
+	return hasWorkChange
 }
 
 func buildShardedApplyOperationGroups(
@@ -1075,10 +1090,13 @@ func buildShardedApplyOperationGroups(
 	now time.Time,
 ) ([]*storage.ApplyOperationWithTasks, error) {
 	shardsByNamespace := changingShardsByNamespace(plan.Shards)
-	groups := make([]*storage.ApplyOperationWithTasks, 0, len(targets)*len(taskChanges))
+	workChanges, finalizerChanges := splitShardedTaskChanges(taskChanges)
+	groups := make([]*storage.ApplyOperationWithTasks, 0, len(targets)*(len(workChanges)+len(finalizerChanges)))
 	groupsByTargetAndKey := make(map[string]*storage.ApplyOperationWithTasks)
 	for _, target := range targets {
-		for _, ddlChange := range taskChanges {
+		workNamespaces := make(map[string]struct{})
+		for _, ddlChange := range workChanges {
+			workNamespaces[ddlChange.Namespace] = struct{}{}
 			for _, shard := range shardsByNamespace[ddlChange.Namespace] {
 				if err := validateShardOperationKeyParts(ddlChange.Namespace, shard.Shard, ddlChange.Table); err != nil {
 					return nil, err
@@ -1099,8 +1117,52 @@ func buildShardedApplyOperationGroups(
 				group.Tasks = append(group.Tasks, buildApplyTask(plan, ddlChange, environment, applyOpts, shard.Shard, now))
 			}
 		}
+		for _, namespace := range sortedFinalizerNamespaces(finalizerChanges) {
+			if _, ok := workNamespaces[namespace]; !ok {
+				return nil, fmt.Errorf("group finalizer for namespace %q has no work operation siblings", namespace)
+			}
+			if err := validateOperationKeyPart("namespace", namespace); err != nil {
+				return nil, err
+			}
+			operationKey := finalizerOperationKey(namespace)
+			if len(operationKey) > applyOperationKeyMaxLen {
+				return nil, fmt.Errorf("operation key for namespace %q finalizer exceeds %d characters", namespace, applyOperationKeyMaxLen)
+			}
+			operation := newPendingApplyOperation(target, operationKey, cutoverPolicy, onFailure, now)
+			operation.OperationKind = storage.ApplyOperationKindGroupFinalizer
+			groups = append(groups, &storage.ApplyOperationWithTasks{
+				Operation: operation,
+				Tasks:     []*storage.Task{buildApplyTask(plan, finalizerChanges[namespace], environment, applyOpts, "", now)},
+			})
+		}
 	}
 	return groups, nil
+}
+
+func splitShardedTaskChanges(taskChanges []storage.TableChange) ([]storage.TableChange, map[string]storage.TableChange) {
+	workChanges := make([]storage.TableChange, 0, len(taskChanges))
+	finalizerChanges := make(map[string]storage.TableChange)
+	for _, change := range taskChanges {
+		if isGroupFinalizerChange(change) {
+			finalizerChanges[change.Namespace] = change
+			continue
+		}
+		workChanges = append(workChanges, change)
+	}
+	return workChanges, finalizerChanges
+}
+
+func sortedFinalizerNamespaces(finalizerChanges map[string]storage.TableChange) []string {
+	namespaces := make([]string, 0, len(finalizerChanges))
+	for namespace := range finalizerChanges {
+		namespaces = append(namespaces, namespace)
+	}
+	sort.Strings(namespaces)
+	return namespaces
+}
+
+func isGroupFinalizerChange(change storage.TableChange) bool {
+	return change.Operation == "vschema_update"
 }
 
 func validateShardOperationKeyParts(namespace, shard, table string) error {
@@ -1112,9 +1174,16 @@ func validateShardOperationKeyParts(namespace, shard, table string) error {
 		{label: "shard", value: shard},
 		{label: "table", value: table},
 	} {
-		if strings.Contains(part.value, "/") {
-			return fmt.Errorf("operation key %s component %q contains reserved delimiter %q", part.label, part.value, "/")
+		if err := validateOperationKeyPart(part.label, part.value); err != nil {
+			return err
 		}
+	}
+	return nil
+}
+
+func validateOperationKeyPart(label, value string) error {
+	if strings.Contains(value, "/") {
+		return fmt.Errorf("operation key %s component %q contains reserved delimiter %q", label, value, "/")
 	}
 	return nil
 }
@@ -1139,10 +1208,15 @@ func shardOperationKey(namespace, shard, table string) string {
 	return namespace + "/" + shard + "/" + table
 }
 
+func finalizerOperationKey(namespace string) string {
+	return namespace + "/" + finalizerOperationKeySegment
+}
+
 func newPendingApplyOperation(target routing.ExecutionTarget, operationKey, cutoverPolicy, onFailure string, now time.Time) *storage.ApplyOperation {
 	return &storage.ApplyOperation{
 		Deployment:    target.Deployment,
 		OperationKey:  operationKey,
+		OperationKind: storage.ApplyOperationKindWork,
 		Target:        target.Target,
 		State:         state.ApplyOperation.Pending,
 		CutoverPolicy: cutoverPolicy,

--- a/pkg/api/plan_handlers.go
+++ b/pkg/api/plan_handlers.go
@@ -1162,6 +1162,7 @@ func sortedFinalizerNamespaces(finalizerChanges map[string]storage.TableChange) 
 }
 
 func isGroupFinalizerChange(change storage.TableChange) bool {
+	// Routing metadata is the only creation-time group-finalizer payload today.
 	return change.Operation == "vschema_update"
 }
 

--- a/pkg/schema/mysql/apply_operations.sql
+++ b/pkg/schema/mysql/apply_operations.sql
@@ -3,6 +3,7 @@ CREATE TABLE `apply_operations` (
   `apply_id` bigint unsigned NOT NULL,
   `deployment` varchar(255) NOT NULL,
   `operation_key` varchar(255) NOT NULL DEFAULT '',
+  `operation_kind` varchar(32) NOT NULL DEFAULT 'work',
   `target` varchar(255) NOT NULL DEFAULT '',
   `engine_resume_context` varchar(255) DEFAULT NULL,
   `engine_resume_metadata` json DEFAULT NULL,

--- a/pkg/storage/mysqlstore/apply_operations.go
+++ b/pkg/storage/mysqlstore/apply_operations.go
@@ -19,7 +19,7 @@ import (
 )
 
 // applyOperationColumns lists all columns for SELECT queries.
-const applyOperationColumns = `id, apply_id, deployment, operation_key, target, state, error_message,
+const applyOperationColumns = `id, apply_id, deployment, operation_key, operation_kind, target, state, error_message,
 	cutover_policy, on_failure, started_at, completed_at, lease_owner, lease_token, lease_acquired_at,
 	engine_resume_context, engine_resume_metadata, created_at, updated_at`
 
@@ -73,13 +73,18 @@ func insertApplyOperation(ctx context.Context, exec sqlExecer, ad *storage.Apply
 		onFailure = storage.OnFailureHalt
 	}
 
+	operationKind := ad.OperationKind
+	if operationKind == "" {
+		operationKind = storage.ApplyOperationKindWork
+	}
+
 	result, err := exec.ExecContext(ctx, `
 		INSERT INTO apply_operations (
-			apply_id, deployment, operation_key, target, state, error_message, cutover_policy, on_failure,
+			apply_id, deployment, operation_key, operation_kind, target, state, error_message, cutover_policy, on_failure,
 			started_at, completed_at, engine_resume_context, engine_resume_metadata
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`,
-		ad.ApplyID, ad.Deployment, ad.OperationKey, ad.Target, stateVal, nullString(ad.ErrorMessage), cutoverPolicy, onFailure,
+		ad.ApplyID, ad.Deployment, ad.OperationKey, operationKind, ad.Target, stateVal, nullString(ad.ErrorMessage), cutoverPolicy, onFailure,
 		ad.StartedAt, ad.CompletedAt, nullString(ad.EngineResumeContext), nullString(ad.EngineResumeMetadata),
 	)
 	if err != nil {
@@ -96,6 +101,7 @@ func insertApplyOperation(ctx context.Context, exec sqlExecer, ad *storage.Apply
 	}
 	ad.ID = id
 	ad.State = stateVal
+	ad.OperationKind = operationKind
 	ad.CutoverPolicy = cutoverPolicy
 	ad.OnFailure = onFailure
 	return id, nil
@@ -615,6 +621,7 @@ func (s *applyOperationStore) FindNextApplyOperation(ctx context.Context, owner 
 	activeStatePlaceholders := placeholders(len(activeStates))
 
 	queryArgs := []any{state.ApplyOperation.Pending}
+	queryArgs = append(queryArgs, storage.ApplyOperationKindGroupFinalizer)
 	// Sibling-gate args for the pending claim, cutover_policy-aware (see the
 	// gate SQL below). Under barrier, an earlier sibling stops blocking once it
 	// reaches the cutover barrier or succeeds (waiting_for_cutover, cutting_over,
@@ -633,6 +640,12 @@ func (s *applyOperationStore) FindNextApplyOperation(ctx context.Context, owner 
 		state.ApplyOperation.Completed,
 		storage.OnFailureContinue,
 		state.ApplyOperation.Failed,
+	)
+	queryArgs = append(queryArgs,
+		storage.ApplyOperationKindGroupFinalizer,
+		storage.ApplyOperationKindWork,
+		storage.ApplyOperationKindWork,
+		state.ApplyOperation.Completed,
 	)
 	// Pending stop gate: a pending operation is not claimable for start while
 	// its apply has a pending stop control request. This is what makes `stop`
@@ -717,22 +730,47 @@ func (s *applyOperationStore) FindNextApplyOperation(ctx context.Context, owner 
 		WHERE (
 			(
 				state = ?
-				AND NOT EXISTS (
-					SELECT 1
-					FROM apply_operations AS earlier
-					WHERE earlier.apply_id = apply_operations.apply_id
-						AND (earlier.created_at, earlier.id) < (apply_operations.created_at, apply_operations.id)
-						AND (
-							(
-								apply_operations.cutover_policy = ?
-								AND earlier.state NOT IN (?, ?, ?, ?)
-							)
-							OR (
-								apply_operations.cutover_policy <> ?
-								AND earlier.state <> ?
+				AND (
+					(
+						apply_operations.operation_kind <> ?
+						AND NOT EXISTS (
+							SELECT 1
+							FROM apply_operations AS earlier
+							WHERE earlier.apply_id = apply_operations.apply_id
+								AND (earlier.created_at, earlier.id) < (apply_operations.created_at, apply_operations.id)
+								AND (
+									(
+										apply_operations.cutover_policy = ?
+										AND earlier.state NOT IN (?, ?, ?, ?)
+									)
+									OR (
+										apply_operations.cutover_policy <> ?
+										AND earlier.state <> ?
+									)
+								)
+								AND NOT (apply_operations.on_failure = ? AND earlier.state = ?)
+						)
+					)
+					OR (
+						apply_operations.operation_kind = ?
+						AND EXISTS (
+							SELECT 1
+							FROM apply_operations AS sibling
+							WHERE sibling.apply_id = apply_operations.apply_id
+								AND sibling.deployment = apply_operations.deployment
+								AND sibling.operation_kind = ?
+								AND SUBSTRING_INDEX(sibling.operation_key, '/', 1) = SUBSTRING_INDEX(apply_operations.operation_key, '/', 1)
+						)
+						AND NOT EXISTS (
+							SELECT 1
+							FROM apply_operations AS sibling
+							WHERE sibling.apply_id = apply_operations.apply_id
+								AND sibling.deployment = apply_operations.deployment
+								AND sibling.operation_kind = ?
+								AND SUBSTRING_INDEX(sibling.operation_key, '/', 1) = SUBSTRING_INDEX(apply_operations.operation_key, '/', 1)
+								AND sibling.state <> ?
 							)
 						)
-						AND NOT (apply_operations.on_failure = ? AND earlier.state = ?)
 				)
 				AND NOT EXISTS (
 					SELECT 1
@@ -1288,7 +1326,7 @@ func scanApplyOperationInto(s scanner) (*storage.ApplyOperation, error) {
 	var startedAt, completedAt, leaseAcquiredAt sql.NullTime
 
 	if err := s.Scan(
-		&ad.ID, &ad.ApplyID, &ad.Deployment, &ad.OperationKey, &ad.Target, &ad.State, &errMsg,
+		&ad.ID, &ad.ApplyID, &ad.Deployment, &ad.OperationKey, &ad.OperationKind, &ad.Target, &ad.State, &errMsg,
 		&ad.CutoverPolicy, &ad.OnFailure, &startedAt, &completedAt, &ad.LeaseOwner, &ad.LeaseToken, &leaseAcquiredAt,
 		&engineResumeContext, &engineResumeMetadata, &ad.CreatedAt, &ad.UpdatedAt,
 	); err != nil {

--- a/pkg/storage/mysqlstore/apply_operations_test.go
+++ b/pkg/storage/mysqlstore/apply_operations_test.go
@@ -44,6 +44,7 @@ func TestApplyOperationStore_InsertAndGet(t *testing.T) {
 	assert.Equal(t, "region-a", got.Deployment)
 	assert.Equal(t, "payments", got.Target)
 	assert.Equal(t, state.ApplyOperation.Pending, got.State)
+	assert.Equal(t, storage.ApplyOperationKindWork, got.OperationKind)
 	assert.Equal(t, storage.CutoverPolicyRolling, got.CutoverPolicy, "an unset cutover_policy defaults to rolling")
 	assert.Empty(t, got.ErrorMessage)
 	assert.Nil(t, got.StartedAt)
@@ -52,6 +53,39 @@ func TestApplyOperationStore_InsertAndGet(t *testing.T) {
 	assert.Empty(t, got.EngineResumeMetadata)
 	assert.NotZero(t, got.CreatedAt)
 	assert.NotZero(t, got.UpdatedAt)
+}
+
+func TestApplyOperationStore_OperationKindRoundTrip(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", "mysql", "staging")
+	apply := createTestApply(t, store, lock, "apply_op_kind_roundtrip", 1)
+
+	defaulted := &storage.ApplyOperation{ApplyID: apply.ID, Deployment: "region-a", Target: "payments"}
+	defaultedID, err := store.ApplyOperations().Insert(ctx, defaulted)
+	require.NoError(t, err)
+	assert.Equal(t, storage.ApplyOperationKindWork, defaulted.OperationKind)
+
+	finalizerID, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID:       apply.ID,
+		Deployment:    "region-a",
+		OperationKey:  "commerce/group_finalizer",
+		OperationKind: storage.ApplyOperationKindGroupFinalizer,
+		Target:        "payments",
+	})
+	require.NoError(t, err)
+
+	gotDefaulted, err := store.ApplyOperations().Get(ctx, defaultedID)
+	require.NoError(t, err)
+	require.NotNil(t, gotDefaulted)
+	assert.Equal(t, storage.ApplyOperationKindWork, gotDefaulted.OperationKind)
+
+	gotFinalizer, err := store.ApplyOperations().Get(ctx, finalizerID)
+	require.NoError(t, err)
+	require.NotNil(t, gotFinalizer)
+	assert.Equal(t, storage.ApplyOperationKindGroupFinalizer, gotFinalizer.OperationKind)
 }
 
 // TestApplyOperationStore_CutoverPolicyRoundTrip verifies that an explicit
@@ -1497,6 +1531,78 @@ func TestApplyOperationStore_FindNextApplyOperation_OrdersSiblings(t *testing.T)
 	done, err := store.ApplyOperations().FindNextApplyOperation(ctx, "test-operator")
 	require.NoError(t, err)
 	assert.Nil(t, done)
+}
+
+func TestApplyOperationStore_FindNextApplyOperation_ClaimsFinalizerAfterWorkSiblingsComplete(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", "mysql", "staging")
+	apply := createTestApply(t, store, lock, "apply_op_finalizer_claim", 1)
+
+	workA, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-a", OperationKey: "commerce/-80/users", OperationKind: storage.ApplyOperationKindWork,
+	})
+	require.NoError(t, err)
+	workB, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-a", OperationKey: "commerce/80-/users", OperationKind: storage.ApplyOperationKindWork,
+	})
+	require.NoError(t, err)
+	finalizer, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-a", OperationKey: "commerce/group_finalizer", OperationKind: storage.ApplyOperationKindGroupFinalizer,
+	})
+	require.NoError(t, err)
+
+	claimed, err := store.ApplyOperations().FindNextApplyOperation(ctx, "test-operator")
+	require.NoError(t, err)
+	require.NotNil(t, claimed)
+	assert.Equal(t, workA, claimed.ID)
+	require.NoError(t, store.ApplyOperations().MarkCompleted(ctx, workA))
+
+	claimed, err = store.ApplyOperations().FindNextApplyOperation(ctx, "test-operator")
+	require.NoError(t, err)
+	require.NotNil(t, claimed)
+	assert.Equal(t, workB, claimed.ID)
+
+	blocked, err := store.ApplyOperations().FindNextApplyOperation(ctx, "test-operator")
+	require.NoError(t, err)
+	assert.Nil(t, blocked)
+
+	require.NoError(t, store.ApplyOperations().MarkCompleted(ctx, workB))
+	claimed, err = store.ApplyOperations().FindNextApplyOperation(ctx, "test-operator")
+	require.NoError(t, err)
+	require.NotNil(t, claimed)
+	assert.Equal(t, finalizer, claimed.ID)
+	assert.Equal(t, storage.ApplyOperationKindGroupFinalizer, claimed.OperationKind)
+}
+
+func TestApplyOperationStore_FindNextApplyOperation_BlocksFinalizerAfterFailedWorkSibling(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", "mysql", "staging")
+	apply := createTestApply(t, store, lock, "apply_op_finalizer_failed_work", 1)
+
+	workA, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-a", OperationKey: "commerce/-80/users", OperationKind: storage.ApplyOperationKindWork,
+	})
+	require.NoError(t, err)
+	workB, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-a", OperationKey: "commerce/80-/users", OperationKind: storage.ApplyOperationKindWork,
+	})
+	require.NoError(t, err)
+	_, err = store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-a", OperationKey: "commerce/group_finalizer", OperationKind: storage.ApplyOperationKindGroupFinalizer,
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, store.ApplyOperations().MarkCompleted(ctx, workA))
+	require.NoError(t, store.ApplyOperations().MarkFailed(ctx, workB, "copy failed"))
+	claimed, err := store.ApplyOperations().FindNextApplyOperation(ctx, "test-operator")
+	require.NoError(t, err)
+	assert.Nil(t, claimed)
 }
 
 // TestApplyOperationStore_FindNextApplyOperation_HaltsOnFailedSibling verifies

--- a/pkg/storage/types.go
+++ b/pkg/storage/types.go
@@ -204,6 +204,12 @@ const (
 	EngineStrata      = "strata"
 )
 
+// ApplyOperationKind constants classify operation rows by scheduling role.
+const (
+	ApplyOperationKindWork           = "work"
+	ApplyOperationKindGroupFinalizer = "group_finalizer"
+)
+
 // EngineForType returns the engine name for a database type.
 func EngineForType(dbType string) string {
 	switch dbType {
@@ -503,6 +509,11 @@ type ApplyOperation struct {
 	// OperationKey disambiguates multiple execution operations in the same apply
 	// and deployment. Empty is the legacy single-operation key.
 	OperationKey string
+
+	// OperationKind classifies the operation's scheduling role. The default
+	// "work" kind is ordinary engine work; "group_finalizer" runs after its
+	// grouped work siblings succeed.
+	OperationKind string
 
 	// Target is the Tern-facing address resolved for this deployment at apply
 	// time. Mirrors plans.target / applies.target


### PR DESCRIPTION
## Why
Sharded apply fanout needs a generic way to run namespace-level finalization after shard-scoped work succeeds.

## What
- Add an `operation_kind` marker for work and group-finalizer apply operations
- Queue namespace-level finalizers as real operation rows in the sharded fanout path
- Gate finalizer claimability on successful work siblings and keep aggregate state fail-closed

## Risk Assessment
Low — this stacks on unreleased sharded fanout behavior, and non-sharded or non-opted-in applies keep the existing single-operation path.

Generated with Amp
