### PR TITLE
Load sharded work tasks by operation key

### DIFF
--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -2641,8 +2641,8 @@ func TestProgressFromLocalStorageIncludesOperationProgressAndTableDeployment(t *
 			},
 		}},
 		operations: &staticApplyOperationStore{operations: []*storage.ApplyOperation{
-			{ID: opAID, ApplyID: apply.ID, Deployment: "deploy-a", Target: "target-a", State: state.ApplyOperation.Running, StartedAt: &startedAt},
-			{ID: opBID, ApplyID: apply.ID, Deployment: "deploy-b", Target: "target-b", State: state.ApplyOperation.Failed, ErrorMessage: "engine failed", StartedAt: &startedAt, CompletedAt: &completedAt},
+			{ID: opAID, ApplyID: apply.ID, Deployment: "deploy-a", OperationKind: storage.ApplyOperationKindWork, Target: "target-a", State: state.ApplyOperation.Running, StartedAt: &startedAt},
+			{ID: opBID, ApplyID: apply.ID, Deployment: "deploy-b", OperationKind: storage.ApplyOperationKindGroupFinalizer, Target: "target-b", State: state.ApplyOperation.Failed, ErrorMessage: "engine failed", StartedAt: &startedAt, CompletedAt: &completedAt},
 		}},
 	}, testServerConfig(), nil, slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError})))
 
@@ -2651,10 +2651,12 @@ func TestProgressFromLocalStorageIncludesOperationProgressAndTableDeployment(t *
 	require.NoError(t, err)
 	require.Len(t, resp.Operations, 2)
 	assert.Equal(t, "deploy-a", resp.Operations[0].Deployment)
+	assert.Equal(t, storage.ApplyOperationKindWork, resp.Operations[0].OperationKind)
 	assert.Equal(t, "target-a", resp.Operations[0].Target)
 	assert.Equal(t, state.ApplyOperation.Running, resp.Operations[0].State)
 	assert.Equal(t, startedAt.Format(time.RFC3339), resp.Operations[0].StartedAt)
 	assert.Equal(t, "deploy-b", resp.Operations[1].Deployment)
+	assert.Equal(t, storage.ApplyOperationKindGroupFinalizer, resp.Operations[1].OperationKind)
 	assert.Equal(t, apitypes.ErrCodeEngineError, resp.Operations[1].ErrorCode)
 	assert.Equal(t, "engine failed", resp.Operations[1].ErrorMessage)
 	assert.Equal(t, completedAt.Format(time.RFC3339), resp.Operations[1].CompletedAt)

--- a/pkg/api/operator_multi_operation_integration_test.go
+++ b/pkg/api/operator_multi_operation_integration_test.go
@@ -93,6 +93,44 @@ func TestOperatorMultiOperationMatrix(t *testing.T) {
 		assert.Zero(t, svc.matrixSummary.recoveredCount(), "a multi-op drive must not fire the per-driver recovered observer")
 	})
 
+	t.Run("ShardedWorkCompletesBeforeGroupFinalizer", func(t *testing.T) {
+		// A sharded apply with namespace-level finalization drives shard work
+		// operations first, keeps the aggregate non-terminal while the finalizer is
+		// pending, then completes only after the finalizer operation succeeds.
+		resetMatrixTables(t, ctx, db)
+		seed := seedShardedFinalizerApply(t, ctx, stor)
+
+		rec := &driveRecorder{}
+		svc := newMatrixService(t, stor, matrixClients(stor, rec, map[string]matrixOutcome{
+			"region-a": {taskState: state.Task.Completed},
+		}))
+
+		driveNextOperation(t, ctx, svc, 1)
+		driveNextOperation(t, ctx, svc, 2)
+
+		assert.Equal(t, state.ApplyOperation.Completed, opState(t, ctx, stor, seed.workAID))
+		assert.Equal(t, state.ApplyOperation.Completed, opState(t, ctx, stor, seed.workBID))
+		assert.Equal(t, state.ApplyOperation.Pending, opState(t, ctx, stor, seed.finalizerID))
+		assert.Equal(t, state.Apply.Pending, getApply(t, ctx, stor, seed.applyID).State,
+			"completed shard work plus a pending finalizer must remain non-terminal")
+
+		driveNextOperation(t, ctx, svc, 3)
+
+		assert.Equal(t, []string{
+			"commerce/-80/users",
+			"commerce/80-/users",
+			"commerce/group_finalizer",
+		}, rec.resumeOperationKeys())
+		assert.Equal(t, []string{
+			storage.ApplyOperationKindWork,
+			storage.ApplyOperationKindWork,
+			storage.ApplyOperationKindGroupFinalizer,
+		}, rec.resumeOperationKinds())
+		assert.Equal(t, state.ApplyOperation.Completed, opState(t, ctx, stor, seed.finalizerID))
+		assert.Equal(t, state.Apply.Completed, getApply(t, ctx, stor, seed.applyID).State)
+		assert.Equal(t, 1, svc.matrixSummary.count(), "terminal summary publishes after the finalizer completes")
+	})
+
 	t.Run("RollingHaltFailureStopsAtFirstDeployment", func(t *testing.T) {
 		resetMatrixTables(t, ctx, db)
 		seed := seedGroupedApply(t, ctx, stor, multiOpSeed{
@@ -365,6 +403,13 @@ type seededMultiOpApply struct {
 
 func (s seededMultiOpApply) opID(deployment string) int64 { return s.ops[deployment] }
 
+type seededShardedFinalizerApply struct {
+	applyID     int64
+	workAID     int64
+	workBID     int64
+	finalizerID int64
+}
+
 func seedGroupedApply(t *testing.T, ctx context.Context, stor storage.Storage, spec multiOpSeed) seededMultiOpApply {
 	t.Helper()
 	require.NotEmpty(t, spec.deployments, "seedGroupedApply requires at least one deployment")
@@ -433,6 +478,75 @@ func seedGroupedApply(t *testing.T, ctx context.Context, stor storage.Storage, s
 		ops[group.Operation.Deployment] = group.Operation.ID
 	}
 	return seededMultiOpApply{applyID: applyID, deployments: spec.deployments, ops: ops}
+}
+
+func seedShardedFinalizerApply(t *testing.T, ctx context.Context, stor storage.Storage) seededShardedFinalizerApply {
+	t.Helper()
+	now := time.Now()
+	apply := &storage.Apply{
+		ApplyIdentifier: "matrix-sharded-finalizer",
+		Database:        "payments",
+		DatabaseType:    storage.DatabaseTypeStrata,
+		Repository:      "octocat/hello-world",
+		PullRequest:     1,
+		Environment:     "staging",
+		Deployment:      "region-a",
+		Caller:          "matrix-test",
+		Engine:          storage.EngineForType(storage.DatabaseTypeStrata),
+		State:           state.Apply.Pending,
+		Options:         storage.MarshalApplyOptions(storage.ApplyOptions{}),
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+
+	groups := []*storage.ApplyOperationWithTasks{
+		newShardedFinalizerGroup(now, "commerce/-80/users", storage.ApplyOperationKindWork, "users", "alter", "-80", "ALTER TABLE `users` ADD COLUMN `email` varchar(255)"),
+		newShardedFinalizerGroup(now, "commerce/80-/users", storage.ApplyOperationKindWork, "users", "alter", "80-", "ALTER TABLE `users` ADD COLUMN `email` varchar(255)"),
+		newShardedFinalizerGroup(now, "commerce/group_finalizer", storage.ApplyOperationKindGroupFinalizer, "VSchema: commerce", "vschema_update", "", ""),
+	}
+
+	applyID, err := stor.Applies().CreateWithGroupedOperations(ctx, apply, groups)
+	require.NoError(t, err, "seed sharded finalizer apply")
+	return seededShardedFinalizerApply{
+		applyID:     applyID,
+		workAID:     groups[0].Operation.ID,
+		workBID:     groups[1].Operation.ID,
+		finalizerID: groups[2].Operation.ID,
+	}
+}
+
+func newShardedFinalizerGroup(now time.Time, operationKey, operationKind, table, action, shard, ddl string) *storage.ApplyOperationWithTasks {
+	return &storage.ApplyOperationWithTasks{
+		Operation: &storage.ApplyOperation{
+			Deployment:    "region-a",
+			OperationKey:  operationKey,
+			OperationKind: operationKind,
+			Target:        "payments-region-a",
+			State:         state.ApplyOperation.Pending,
+			CutoverPolicy: storage.CutoverPolicyRolling,
+			OnFailure:     storage.OnFailureHalt,
+			CreatedAt:     now,
+			UpdatedAt:     now,
+		},
+		Tasks: []*storage.Task{{
+			TaskIdentifier: "task-" + operationKey,
+			Database:       "payments",
+			DatabaseType:   storage.DatabaseTypeStrata,
+			Engine:         storage.EngineForType(storage.DatabaseTypeStrata),
+			Repository:     "octocat/hello-world",
+			PullRequest:    1,
+			Environment:    "staging",
+			State:          state.Task.Pending,
+			Options:        storage.MarshalApplyOptions(storage.ApplyOptions{}),
+			Namespace:      "commerce",
+			TableName:      table,
+			Shard:          shard,
+			DDL:            ddl,
+			DDLAction:      action,
+			CreatedAt:      now,
+			UpdatedAt:      now,
+		}},
+	}
 }
 
 func requestPendingStop(t *testing.T, ctx context.Context, stor storage.Storage, applyID int64) {
@@ -535,7 +649,14 @@ type matrixTernClient struct {
 }
 
 func (m *matrixTernClient) ResumeApplyOperation(ctx context.Context, apply *storage.Apply, applyOperationID int64) error {
-	m.rec.recordResume(m.deployment)
+	op, err := m.stor.ApplyOperations().Get(ctx, applyOperationID)
+	if err != nil {
+		return fmt.Errorf("matrix fake: load operation %d: %w", applyOperationID, err)
+	}
+	if op == nil {
+		return fmt.Errorf("matrix fake: operation %d not found", applyOperationID)
+	}
+	m.rec.recordResume(m.deployment, op)
 
 	if m.outcome.gate != nil {
 		m.outcome.gate.arriveAndWait()
@@ -574,13 +695,17 @@ func (m *matrixTernClient) ResumeApplyOperation(ctx context.Context, apply *stor
 type driveRecorder struct {
 	mu          sync.Mutex
 	order       []string
+	opKeys      []string
+	opKinds     []string
 	parentWrite []error
 }
 
-func (r *driveRecorder) recordResume(deployment string) {
+func (r *driveRecorder) recordResume(deployment string, op *storage.ApplyOperation) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.order = append(r.order, deployment)
+	r.opKeys = append(r.opKeys, op.OperationKey)
+	r.opKinds = append(r.opKinds, op.OperationKind)
 }
 
 func (r *driveRecorder) recordParentWrite(err error) {
@@ -599,6 +724,18 @@ func (r *driveRecorder) resumeCount() int {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	return len(r.order)
+}
+
+func (r *driveRecorder) resumeOperationKeys() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]string(nil), r.opKeys...)
+}
+
+func (r *driveRecorder) resumeOperationKinds() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]string(nil), r.opKinds...)
 }
 
 func (r *driveRecorder) parentWriteErrors() []error {

--- a/pkg/api/progress_handlers.go
+++ b/pkg/api/progress_handlers.go
@@ -216,6 +216,7 @@ func progressResponseFromProto(resp *ternv1.ProgressResponse) *apitypes.Progress
 func progressOperationResponseFromStorage(op *storage.ApplyOperation) *apitypes.ProgressOperationResponse {
 	resp := &apitypes.ProgressOperationResponse{
 		Deployment:    op.Deployment,
+		OperationKind: op.OperationKind,
 		Target:        op.Target,
 		State:         op.State,
 		CutoverPolicy: op.CutoverPolicy,

--- a/pkg/apitypes/apitypes.go
+++ b/pkg/apitypes/apitypes.go
@@ -375,9 +375,10 @@ type ProgressResponse struct {
 
 // ProgressOperationResponse represents progress for one deployment operation.
 type ProgressOperationResponse struct {
-	Deployment string `json:"deployment"`
-	Target     string `json:"target,omitempty"`
-	State      string `json:"state"`
+	Deployment    string `json:"deployment"`
+	OperationKind string `json:"operation_kind,omitempty"`
+	Target        string `json:"target,omitempty"`
+	State         string `json:"state"`
 	// CutoverPolicy is the rollout boundary policy for this deployment operation.
 	CutoverPolicy string `json:"cutover_policy,omitempty"`
 	// OnFailure is the rollout failure policy for this deployment operation.

--- a/pkg/storage/mysqlstore/tasks.go
+++ b/pkg/storage/mysqlstore/tasks.go
@@ -297,7 +297,7 @@ func (s *taskStore) GetByApplyID(ctx context.Context, applyID int64) ([]*storage
 }
 
 // GetByApplyOperationID returns the drive tasks for a single apply_operation.
-// Unsharded operations load their per-table rows (shard = ”). Sharded work
+// Unsharded operations load their per-table rows (shard = ""). Sharded work
 // operations load the row whose namespace/shard/table matches the operation key,
 // so TargetShards can be rebuilt from storage while reflected per-shard progress
 // rows for unsharded operations stay out of the drive pipeline.

--- a/pkg/storage/mysqlstore/tasks.go
+++ b/pkg/storage/mysqlstore/tasks.go
@@ -22,6 +22,14 @@ const taskColumns = `id, task_identifier, apply_id, apply_operation_id, plan_id,
 	is_instant, ready_to_complete, engine_migration_id,
 	started_at, completed_at, created_at, updated_at`
 
+func prefixedTaskColumns(alias string) string {
+	parts := strings.Split(taskColumns, ",")
+	for i, part := range parts {
+		parts[i] = alias + "." + strings.TrimSpace(part)
+	}
+	return strings.Join(parts, ", ")
+}
+
 // terminalTaskStatesSQL is formatted for SQL IN clause.
 var terminalTaskStatesSQL = func() string {
 	parts := make([]string, 0, len(state.TerminalTaskStates))
@@ -288,19 +296,26 @@ func (s *taskStore) GetByApplyID(ctx context.Context, applyID int64) ([]*storage
 	return scanTasks(rows)
 }
 
-// GetByApplyOperationID returns the per-table tasks for a single apply_operation
-// (one deployment of a multi-deployment apply). It lets a driver drive and
-// reconcile one deployment independently once an apply fans out across several.
-// Per-shard detail rows (shard != "") are excluded for the same reason as
-// GetByApplyID: they must stay write-only relative to the per-table pipeline and
-// are read via GetShardProgressByApplyOperationID.
+// GetByApplyOperationID returns the drive tasks for a single apply_operation.
+// Unsharded operations load their per-table rows (shard = ”). Sharded work
+// operations load the row whose namespace/shard/table matches the operation key,
+// so TargetShards can be rebuilt from storage while reflected per-shard progress
+// rows for unsharded operations stay out of the drive pipeline.
 func (s *taskStore) GetByApplyOperationID(ctx context.Context, applyOperationID int64) ([]*storage.Task, error) {
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT `+taskColumns+`
-		FROM tasks
-		WHERE apply_operation_id = ? AND shard = ''
-		ORDER BY created_at DESC, id DESC
-	`, applyOperationID)
+		SELECT `+prefixedTaskColumns("t")+`
+		FROM tasks t
+		JOIN apply_operations ao ON ao.id = t.apply_operation_id
+		WHERE t.apply_operation_id = ?
+			AND (
+				t.shard = ''
+				OR (
+					ao.operation_kind = ?
+					AND ao.operation_key = CONCAT(t.namespace, '/', t.shard, '/', t.table_name)
+				)
+			)
+		ORDER BY t.created_at DESC, t.id DESC
+	`, applyOperationID, storage.ApplyOperationKindWork)
 	if err != nil {
 		return nil, fmt.Errorf("query tasks for apply_operation %d: %w", applyOperationID, err)
 	}

--- a/pkg/storage/mysqlstore/tasks.go
+++ b/pkg/storage/mysqlstore/tasks.go
@@ -311,6 +311,7 @@ func (s *taskStore) GetByApplyOperationID(ctx context.Context, applyOperationID 
 				t.shard = ''
 				OR (
 					ao.operation_kind = ?
+					-- Keep this in sync with shardOperationKey's namespace/shard/table format.
 					AND ao.operation_key = CONCAT(t.namespace, '/', t.shard, '/', t.table_name)
 				)
 			)

--- a/pkg/storage/mysqlstore/tasks_test.go
+++ b/pkg/storage/mysqlstore/tasks_test.go
@@ -226,9 +226,9 @@ func TestTaskStore_PerShardTaskRoundTrip(t *testing.T) {
 	assert.Equal(t, "-80", got.Shard)
 	assert.Equal(t, 1, got.CutoverAttempts)
 
-	// Both shards of the same table coexist under one operation. They are read
-	// via the per-shard reader; the per-table GetByApplyOperationID excludes them
-	// so they never re-enter the per-table pipeline on reload.
+	// Both shards of the same table coexist under one operation. With no sharded
+	// operation key, GetByApplyOperationID treats them as reflected progress rows
+	// and keeps them out of the drive pipeline on reload.
 	tasks, err := store.Tasks().GetShardProgressByApplyOperationID(ctx, opID)
 	require.NoError(t, err)
 	require.Len(t, tasks, 2)
@@ -251,6 +251,57 @@ func TestTaskStore_PerShardTaskRoundTrip(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 2, reloaded.CutoverAttempts, "cutover_attempts is updatable")
 	assert.Equal(t, "-80", reloaded.Shard, "shard is fixed at creation, not changed by Update")
+}
+
+// A sharded work operation's operation key identifies which shard task is real
+// drive input. Other shard rows remain progress detail and must not be replayed
+// as extra table changes if the operation is resumed.
+func TestTaskStore_GetByApplyOperationIDIncludesMatchingShardedWorkTask(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "resolute", storage.DatabaseTypeStrata, "staging")
+	apply := createTestApply(t, store, lock, "apply_sharded_work_tasks", 1)
+	opID, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID:       apply.ID,
+		Deployment:    "region-a",
+		OperationKey:  "commerce/-80/users",
+		OperationKind: storage.ApplyOperationKindWork,
+		Target:        "resolute",
+	})
+	require.NoError(t, err)
+
+	now := time.Now()
+	createShardTask := func(identifier, shard string) {
+		_, err := store.Tasks().Create(ctx, &storage.Task{
+			TaskIdentifier:   identifier,
+			ApplyID:          apply.ID,
+			ApplyOperationID: &opID,
+			PlanID:           apply.PlanID,
+			Database:         apply.Database,
+			DatabaseType:     apply.DatabaseType,
+			Engine:           storage.EngineStrata,
+			Environment:      apply.Environment,
+			State:            state.Task.Pending,
+			Namespace:        "commerce",
+			TableName:        "users",
+			Shard:            shard,
+			DDL:              "ALTER TABLE `users` ADD COLUMN `email` varchar(255)",
+			DDLAction:        "ALTER",
+			CreatedAt:        now,
+			UpdatedAt:        now,
+		})
+		require.NoError(t, err)
+	}
+	createShardTask("task_users_-80", "-80")
+	createShardTask("task_users_80-", "80-")
+
+	tasks, err := store.Tasks().GetByApplyOperationID(ctx, opID)
+	require.NoError(t, err)
+	require.Len(t, tasks, 1)
+	assert.Equal(t, "task_users_-80", tasks[0].TaskIdentifier)
+	assert.Equal(t, "-80", tasks[0].Shard)
 }
 
 // An unsharded engine (MySQL/Spirit) uses the empty-string shard sentinel, which

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -394,10 +394,11 @@ type TaskStore interface {
 	// Used for aggregating task states to derive Apply state.
 	GetByApplyID(ctx context.Context, applyID int64) ([]*Task, error)
 
-	// GetByApplyOperationID returns the per-table tasks for a single
-	// apply_operation (one deployment of a multi-deployment apply). Used to drive
-	// and reconcile one operation independently of its sibling deployments.
-	// Per-shard detail rows are excluded — read them via
+	// GetByApplyOperationID returns the drive tasks for a single apply_operation.
+	// Unsharded operations return their per-table tasks. Sharded work operations
+	// return the task whose namespace/shard/table matches the operation key so the
+	// drive can rebuild its shard selector. Reflected per-shard progress rows that
+	// do not match a sharded work operation key are excluded — read them via
 	// GetShardProgressByApplyOperationID.
 	GetByApplyOperationID(ctx context.Context, applyOperationID int64) ([]*Task, error)
 


### PR DESCRIPTION
This updates operation-scoped task loading so sharded work operations recognize the task row identified by their generic operation key, while reflected shard-progress rows stay out of ordinary operation drives.

It also surfaces each stored operation's generic operation kind in progress responses, so callers can distinguish work operations from group finalizers, and adds MySQL-backed lifecycle coverage proving sharded work operations complete before the group finalizer and the aggregate stays non-terminal until the finalizer succeeds.

🤖 Generated with Amp.