### PR TITLE
fix(operator): balance active-applies gauge for fan-out applies

### DIFF
--- a/pkg/api/operator.go
+++ b/pkg/api/operator.go
@@ -1570,6 +1570,24 @@ func (s *Service) updateApplyStateFromOperations(ctx context.Context, driverID i
 		"driver", driverID, "apply_id", apply.ApplyIdentifier,
 		"database", apply.Database, "environment", apply.Environment,
 		"previous_state", apply.State, "derived_state", derived, "operation_count", len(ops))
+
+	// Own the active-apply gauge for multi-operation applies. The enqueue-time
+	// increment is keyed to the parent's primary deployment, and operation-scoped
+	// drives suppress the parent-level metric, so the projection that wins the
+	// parent transition is the single point that must release it: -1 when the
+	// rollout first reaches a terminal state, and +1 if a continuable failure
+	// reopens the parent to keep it running, so the gauge tracks whether the
+	// apply is still in flight. Single-operation applies keep decrementing in
+	// their direct drive and are left untouched here.
+	if len(ops) > 1 {
+		switch {
+		case !state.IsTerminalApplyState(apply.State) && state.IsTerminalApplyState(derived):
+			metrics.AdjustActiveApplies(ctx, -1, apply.Database, apply.Deployment, apply.Environment)
+		case state.IsTerminalApplyState(apply.State) && !state.IsTerminalApplyState(derived):
+			metrics.AdjustActiveApplies(ctx, 1, apply.Database, apply.Deployment, apply.Environment)
+		}
+	}
+
 	return applyProjectionResult{
 		Swapped:        true,
 		PreviousState:  apply.State,

--- a/pkg/api/operator_active_applies_test.go
+++ b/pkg/api/operator_active_applies_test.go
@@ -23,7 +23,10 @@ func installManualMeterReader(t *testing.T) *sdkmetric.ManualReader {
 	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
 	prev := otel.GetMeterProvider()
 	otel.SetMeterProvider(mp)
-	t.Cleanup(func() { otel.SetMeterProvider(prev) })
+	t.Cleanup(func() {
+		otel.SetMeterProvider(prev)
+		require.NoError(t, mp.Shutdown(t.Context()))
+	})
 	return reader
 }
 

--- a/pkg/api/operator_active_applies_test.go
+++ b/pkg/api/operator_active_applies_test.go
@@ -1,0 +1,149 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	"github.com/block/schemabot/pkg/state"
+	"github.com/block/schemabot/pkg/storage"
+)
+
+// installManualMeterReader points the global meter provider at an in-memory
+// reader for the duration of a test so the test can assert metric deltas, then
+// restores the previous provider.
+func installManualMeterReader(t *testing.T) *sdkmetric.ManualReader {
+	t.Helper()
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	prev := otel.GetMeterProvider()
+	otel.SetMeterProvider(mp)
+	t.Cleanup(func() { otel.SetMeterProvider(prev) })
+	return reader
+}
+
+// activeAppliesValue returns the schemabot.active_applies up/down counter value
+// for a database/deployment/environment series, and whether such a series exists.
+func activeAppliesValue(t *testing.T, reader *sdkmetric.ManualReader, database, deployment, environment string) (int64, bool) {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(t.Context(), &rm))
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != "schemabot.active_applies" {
+				continue
+			}
+			sum, ok := m.Data.(metricdata.Sum[int64])
+			require.True(t, ok, "active_applies should be a Sum[int64] up/down counter")
+			for _, dp := range sum.DataPoints {
+				if attrEquals(dp.Attributes, "database", database) &&
+					attrEquals(dp.Attributes, "deployment", deployment) &&
+					attrEquals(dp.Attributes, "environment", environment) {
+					return dp.Value, true
+				}
+			}
+		}
+	}
+	return 0, false
+}
+
+func attrEquals(set attribute.Set, key, want string) bool {
+	v, ok := set.Value(attribute.Key(key))
+	return ok && v.AsString() == want
+}
+
+// The enqueue-time active-apply increment is keyed to a fan-out apply's primary
+// deployment, and operation-scoped drives suppress the parent-level metric, so
+// the operator projection that wins the parent state transition owns releasing
+// it: it decrements once when a multi-operation rollout first reaches a terminal
+// state, re-increments if a continuable failure reopens the parent, and leaves
+// single-operation applies (which still decrement in their direct drive)
+// untouched.
+func TestUpdateApplyStateFromOperations_ActiveAppliesAccounting(t *testing.T) {
+	const (
+		database    = "testdb"
+		deployment  = "eu"
+		environment = "production"
+	)
+
+	newApply := func(parentState string) *storage.Apply {
+		return &storage.Apply{
+			ID:              42,
+			ApplyIdentifier: "apply-active",
+			State:           parentState,
+			Database:        database,
+			Deployment:      deployment,
+			Environment:     environment,
+		}
+	}
+
+	t.Run("multi-operation rollout decrements once on terminal", func(t *testing.T) {
+		reader := installManualMeterReader(t)
+		applyStore := &recordingApplyStore{swapped: true}
+		svc := newOperatorStateTestService(&listingApplyOperationStore{ops: []*storage.ApplyOperation{
+			{ID: 1, State: state.ApplyOperation.Completed},
+			{ID: 2, State: state.ApplyOperation.Completed},
+		}}, applyStore)
+
+		_, err := svc.updateApplyStateFromOperations(t.Context(), 1, newApply(state.Apply.Running), allowLeaseScopedFailedReopen)
+		require.NoError(t, err)
+		require.NotNil(t, applyStore.updated)
+		assert.Equal(t, state.Apply.Completed, applyStore.updated.State)
+
+		value, ok := activeAppliesValue(t, reader, database, deployment, environment)
+		require.True(t, ok, "terminalizing a multi-op rollout must adjust the active-apply gauge")
+		assert.Equal(t, int64(-1), value)
+	})
+
+	t.Run("single-operation rollout leaves the gauge to the direct drive", func(t *testing.T) {
+		reader := installManualMeterReader(t)
+		applyStore := &recordingApplyStore{swapped: true}
+		svc := newOperatorStateTestService(&listingApplyOperationStore{ops: []*storage.ApplyOperation{
+			{ID: 1, State: state.ApplyOperation.Completed},
+		}}, applyStore)
+
+		_, err := svc.updateApplyStateFromOperations(t.Context(), 1, newApply(state.Apply.Running), allowLeaseScopedFailedReopen)
+		require.NoError(t, err)
+
+		_, ok := activeAppliesValue(t, reader, database, deployment, environment)
+		assert.False(t, ok, "single-op projection must not touch the gauge; its drive owns the decrement")
+	})
+
+	t.Run("lost projection race does not adjust the gauge", func(t *testing.T) {
+		reader := installManualMeterReader(t)
+		applyStore := &recordingApplyStore{swapped: false}
+		svc := newOperatorStateTestService(&listingApplyOperationStore{ops: []*storage.ApplyOperation{
+			{ID: 1, State: state.ApplyOperation.Completed},
+			{ID: 2, State: state.ApplyOperation.Completed},
+		}}, applyStore)
+
+		_, err := svc.updateApplyStateFromOperations(t.Context(), 1, newApply(state.Apply.Running), allowLeaseScopedFailedReopen)
+		require.NoError(t, err)
+
+		_, ok := activeAppliesValue(t, reader, database, deployment, environment)
+		assert.False(t, ok, "a CAS that loses the race must not adjust the gauge")
+	})
+
+	t.Run("continuable reopen re-increments the gauge", func(t *testing.T) {
+		reader := installManualMeterReader(t)
+		applyStore := &recordingApplyStore{swapped: true}
+		svc := newOperatorStateTestService(&listingApplyOperationStore{ops: []*storage.ApplyOperation{
+			{ID: 1, State: state.ApplyOperation.Failed, OnFailure: storage.OnFailureContinue},
+			{ID: 2, State: state.ApplyOperation.Running, OnFailure: storage.OnFailureContinue},
+		}}, applyStore)
+
+		_, err := svc.updateApplyStateFromOperations(t.Context(), 1, newApply(state.Apply.Failed), allowLeaseScopedFailedReopen)
+		require.NoError(t, err)
+		require.NotNil(t, applyStore.updated)
+		assert.Equal(t, state.Apply.RunningDegraded, applyStore.updated.State)
+
+		value, ok := activeAppliesValue(t, reader, database, deployment, environment)
+		require.True(t, ok, "reopening a failed rollout must re-acquire the active-apply gauge")
+		assert.Equal(t, int64(1), value)
+	})
+}


### PR DESCRIPTION
## Summary
`schemabot_active_applies` leaks +1 per fan-out (multi-op) apply. The
enqueue-time increment is keyed to the parent's primary deployment, but
the terminal -1 only lived in the Tern direct-drive path — which
operation-scoped gRPC drives early-return past. The gauge therefore never
drains for multi-deploy applies. Not a timing race.

## Changes
- Own the gauge at the single parent-projection CAS winner
  (`updateApplyStateFromOperations`), gated to `len(ops) > 1`:
  -1 on nonterminal→terminal, +1 on continuable reopen.
- Single-op applies keep decrementing in their direct drive (unchanged).
- New unit tests assert the gauge via an OTel manual reader: terminal
  decrement, single-op untouched, lost-race no-op, reopen re-increment.

## Testing / validation
- `go test ./pkg/api/` (full suite), `go vet ./pkg/api/`, `go build ./...` — all green.
- Live drain proof deferred: requires the OC-6 (#486) barrier stack, since
  without it the ordered-cutover happy path never terminalizes.

## References
- Surfaced as a separate product fix alongside the OC-6 / observability work (#486).
