### PR TITLE
feat(storage): claim same-deployment shard work operations concurrently

### DIFF
--- a/pkg/storage/mysqlstore/apply_operations.go
+++ b/pkg/storage/mysqlstore/apply_operations.go
@@ -557,11 +557,15 @@ const applyOperationHeartbeatStaleness = "1 MINUTE"
 // staleness window) are re-leased without changing their state. Terminal
 // rows are never claimed.
 //
-// Sibling ordering: a pending row's claimability is gated on its earlier
-// siblings of the same apply (lower created_at, id) along deployment_order —
-// the order materialized by the apply-create dual-write into row insertion
-// order. The gate is cutover_policy-aware (the policy is captured per row at
-// apply-create):
+// Sibling ordering: a pending row's claimability is gated only on its earlier
+// siblings in an EARLIER deployment (rows of the same apply with a different
+// deployment and a lower created_at, id) along deployment_order — the order
+// materialized by the apply-create dual-write into row insertion order. Work
+// rows in the SAME deployment (the per-shard, per-namespace fan-out of a
+// sharded apply) do not gate each other, so a deployment's shard work drives
+// in parallel; the group_finalizer clause below still holds each namespace's
+// finalizer until that namespace's work siblings complete. The gate is
+// cutover_policy-aware (the policy is captured per row at apply-create):
 //
 //   - rolling (the default, and any non-barrier value — which fails closed to
 //     the serial gate): a pending row is claimable only once every earlier
@@ -594,9 +598,8 @@ const applyOperationHeartbeatStaleness = "1 MINUTE"
 //
 // The gate applies only to starting a pending row; an already-active row
 // re-leasing a stale heartbeat is recovering work it already started, so it
-// is never re-gated. While the operator flag is off and the single-deployment
-// hard-block stands, an apply has exactly one operation with no earlier
-// siblings, so this gate is dormant regardless of policy.
+// is never re-gated. A single-operation apply has no earlier-deployment
+// sibling, so the gate is a no-op for it regardless of policy.
 //
 // Mirrors ApplyStore.FindNextApply: SELECT ... FOR UPDATE SKIP LOCKED to
 // avoid driver races, READ COMMITTED isolation to prevent next-key range
@@ -604,9 +607,9 @@ const applyOperationHeartbeatStaleness = "1 MINUTE"
 //
 // Caller: the operator's per-poll recovery (Service.recoverApplyOperation)
 // claims one operation per tick through this primitive when operation-level
-// claiming is enabled. The per-deployment fan-out loop — driving multiple
-// sibling operations of the same apply concurrently — is deferred to the
-// multi-deployment apply workstream.
+// claiming is enabled. Multiple drivers each claim a different claimable row
+// (FOR UPDATE SKIP LOCKED), so same-deployment shard work siblings of one
+// apply drive concurrently across the driver pool.
 func (s *applyOperationStore) FindNextApplyOperation(ctx context.Context, owner string) (*storage.ApplyOperation, error) {
 	if owner == "" {
 		return nil, fmt.Errorf("operator owner is required to claim apply_operation: %w", storage.ErrApplyLeaseLost)
@@ -718,10 +721,11 @@ func (s *applyOperationStore) FindNextApplyOperation(ctx context.Context, owner 
 	// task-gated (state = pending AND EXISTS tasks); a start request lets a
 	// no-task pending apply be claimed. Operation-level pending claimability is
 	// instead deployment-order-gated (the clause below), so a pending operation
-	// is already claimable the moment it is legal to start — once every earlier
-	// sibling has completed. A parent start request must not relax that gate:
-	// adding an ungated pending-start clause would let a later deployment be
-	// claimed out of order while an earlier sibling is still non-completed, and
+	// is already claimable the moment it is legal to start — once every
+	// earlier-deployment sibling has completed. A parent start request must not
+	// relax that gate: adding an ungated pending-start clause would let a later
+	// deployment be claimed out of order while an earlier one is still
+	// non-completed, and
 	// a gated one would be redundant with the pending clause below. Start
 	// requests resume eligible work; they do not reorder the rollout.
 	row := tx.QueryRowContext(ctx, fmt.Sprintf(`
@@ -737,6 +741,7 @@ func (s *applyOperationStore) FindNextApplyOperation(ctx context.Context, owner 
 							SELECT 1
 							FROM apply_operations AS earlier
 							WHERE earlier.apply_id = apply_operations.apply_id
+								AND earlier.deployment <> apply_operations.deployment
 								AND (earlier.created_at, earlier.id) < (apply_operations.created_at, apply_operations.id)
 								AND (
 									(

--- a/pkg/storage/mysqlstore/apply_operations_test.go
+++ b/pkg/storage/mysqlstore/apply_operations_test.go
@@ -1650,6 +1650,127 @@ func TestApplyOperationStore_FindNextApplyOperation_ClaimsFinalizerAfterWorkSibl
 	assert.Equal(t, storage.ApplyOperationKindGroupFinalizer, claimed.OperationKind)
 }
 
+// TestApplyOperationStore_FindNextApplyOperation_ClaimsSameDeploymentShardWorkConcurrently
+// verifies that the per-shard work operations of one deployment fan out: a
+// later shard is claimable while an earlier shard of the same deployment is
+// still running, so multiple drivers drive a deployment's shards in parallel.
+// The group_finalizer still waits until every shard work sibling completes.
+func TestApplyOperationStore_FindNextApplyOperation_ClaimsSameDeploymentShardWorkConcurrently(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", "mysql", "staging")
+	apply := createTestApply(t, store, lock, "apply_op_parallel_shards", 1)
+
+	shardA, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-a", OperationKey: "commerce/-80/users", OperationKind: storage.ApplyOperationKindWork,
+	})
+	require.NoError(t, err)
+	shardB, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-a", OperationKey: "commerce/80-/users", OperationKind: storage.ApplyOperationKindWork,
+	})
+	require.NoError(t, err)
+	finalizer, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-a", OperationKey: "commerce/group_finalizer", OperationKind: storage.ApplyOperationKindGroupFinalizer,
+	})
+	require.NoError(t, err)
+
+	// First claim takes the lowest-ordered shard and leaves it running.
+	first, err := store.ApplyOperations().FindNextApplyOperation(ctx, "driver-1")
+	require.NoError(t, err)
+	require.NotNil(t, first)
+	assert.Equal(t, shardA, first.ID)
+
+	// The sibling shard is claimable while shardA is still running — they are
+	// not serialized within the deployment.
+	second, err := store.ApplyOperations().FindNextApplyOperation(ctx, "driver-2")
+	require.NoError(t, err)
+	require.NotNil(t, second, "sibling shard must be claimable while the first shard is still running")
+	assert.Equal(t, shardB, second.ID)
+
+	// With both shards running (neither completed), the finalizer is not yet
+	// claimable, so a third claim yields nothing.
+	blocked, err := store.ApplyOperations().FindNextApplyOperation(ctx, "driver-3")
+	require.NoError(t, err)
+	assert.Nil(t, blocked, "group_finalizer must wait until every shard work sibling completes")
+
+	require.NoError(t, store.ApplyOperations().MarkCompleted(ctx, shardA))
+	require.NoError(t, store.ApplyOperations().MarkCompleted(ctx, shardB))
+
+	claimed, err := store.ApplyOperations().FindNextApplyOperation(ctx, "driver-1")
+	require.NoError(t, err)
+	require.NotNil(t, claimed)
+	assert.Equal(t, finalizer, claimed.ID)
+	assert.Equal(t, storage.ApplyOperationKindGroupFinalizer, claimed.OperationKind)
+}
+
+// TestApplyOperationStore_FindNextApplyOperation_OrdersDeploymentsWithShards
+// verifies that sharded fan-out keeps cross-deployment ordering intact: a later
+// deployment's shard work stays unclaimable until every operation of the
+// earlier deployment — its shards and its group_finalizer — has completed, even
+// though shards within a deployment run in parallel.
+func TestApplyOperationStore_FindNextApplyOperation_OrdersDeploymentsWithShards(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", "mysql", "staging")
+	apply := createTestApply(t, store, lock, "apply_op_ordered_shards", 1)
+
+	aShard1, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-a", OperationKey: "commerce/-80/users", OperationKind: storage.ApplyOperationKindWork,
+	})
+	require.NoError(t, err)
+	aShard2, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-a", OperationKey: "commerce/80-/users", OperationKind: storage.ApplyOperationKindWork,
+	})
+	require.NoError(t, err)
+	aFinalizer, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-a", OperationKey: "commerce/group_finalizer", OperationKind: storage.ApplyOperationKindGroupFinalizer,
+	})
+	require.NoError(t, err)
+	bShard1, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-b", OperationKey: "commerce/-80/users", OperationKind: storage.ApplyOperationKindWork,
+	})
+	require.NoError(t, err)
+
+	// Both region-a shards are claimable in parallel.
+	first, err := store.ApplyOperations().FindNextApplyOperation(ctx, "driver-1")
+	require.NoError(t, err)
+	require.NotNil(t, first)
+	assert.Equal(t, aShard1, first.ID)
+	second, err := store.ApplyOperations().FindNextApplyOperation(ctx, "driver-2")
+	require.NoError(t, err)
+	require.NotNil(t, second)
+	assert.Equal(t, aShard2, second.ID)
+
+	// region-b's shard must not start while region-a is still in flight.
+	blocked, err := store.ApplyOperations().FindNextApplyOperation(ctx, "driver-3")
+	require.NoError(t, err)
+	assert.Nil(t, blocked, "region-b shard must wait while region-a is still running")
+
+	require.NoError(t, store.ApplyOperations().MarkCompleted(ctx, aShard1))
+	require.NoError(t, store.ApplyOperations().MarkCompleted(ctx, aShard2))
+
+	// region-a's finalizer is claimable now, but region-b still waits for it.
+	claimed, err := store.ApplyOperations().FindNextApplyOperation(ctx, "driver-1")
+	require.NoError(t, err)
+	require.NotNil(t, claimed)
+	assert.Equal(t, aFinalizer, claimed.ID)
+	blocked, err = store.ApplyOperations().FindNextApplyOperation(ctx, "driver-3")
+	require.NoError(t, err)
+	assert.Nil(t, blocked, "region-b shard must wait until region-a's finalizer completes")
+
+	require.NoError(t, store.ApplyOperations().MarkCompleted(ctx, aFinalizer))
+
+	// region-a fully complete → region-b's shard is finally claimable.
+	claimed, err = store.ApplyOperations().FindNextApplyOperation(ctx, "driver-3")
+	require.NoError(t, err)
+	require.NotNil(t, claimed)
+	assert.Equal(t, bShard1, claimed.ID)
+}
+
 func TestApplyOperationStore_FindNextApplyOperation_BlocksFinalizerAfterFailedWorkSibling(t *testing.T) {
 	clearTables(t)
 	ctx := t.Context()


### PR DESCRIPTION
## Summary
The operation claim gate serialized every earlier sibling, so a sharded apply's
per-shard work rows ran one at a time. This gates only on earlier *deployments*,
letting a deployment's shard work fan out across the driver pool while preserving
cross-deployment ordering and the `group_finalizer` gate.

## What
`FindNextApplyOperation`'s pending work-op gate now requires
`earlier.deployment <> apply_operations.deployment`, so same-deployment shard
work siblings no longer block each other. Cross-deployment ordering still holds
(rows are inserted in deployment order, so `id` reflects it); the per-namespace
`group_finalizer` gate is untouched.

## Why
Operation-level claiming alone gave correct-but-serial shard applies. Parallel
shard drive is the unlock for sharded multi-deployment applies; the claim
predicate was the last serialization point.

## Before / after
```
BEFORE: shards serialize within a deployment   AFTER: shards run in parallel
a/-80  ──► running                              a/-80 ──┐
a/80-  ──► BLOCKED until a/-80 completes         a/80- ──┤► both claimable
finalizer ──► waits for all work                 finalizer ► waits for all work
── dep-b waits for ALL of dep-a ──────────       ── dep-b STILL waits for ALL of dep-a ──
```