### PR TITLE
test(e2e): stabilize vitess apply flake — cleanup ordering + timeout diagnostics

### DIFF
--- a/e2e/local/apply_wait_test.go
+++ b/e2e/local/apply_wait_test.go
@@ -4,12 +4,16 @@ package local
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/block/spirit/pkg/utils"
 	"github.com/stretchr/testify/require"
 
 	"github.com/block/schemabot/e2e/testutil"
@@ -68,10 +72,128 @@ func waitForApplyState(t *testing.T, endpoint, applyID, expectedState string, ti
 			return lastState == expected
 		},
 		func() string {
-			return fmt.Sprintf("timeout waiting for apply %s state %q after %s, last API state: %q, error: %q",
-				applyID, expectedState, time.Since(start), lastState, lastError)
+			return fmt.Sprintf("timeout waiting for apply %s state %q after %s, last API state: %q, error: %q\n%s",
+				applyID, expectedState, time.Since(start), lastState, lastError,
+				applyTimeoutDiagnostics(applyID))
 		},
 	)
+}
+
+// applyTimeoutDiagnostics returns a best-effort dump of the SchemaBot storage
+// state for applyID plus the operator's overall backlog, for inclusion in a
+// wait-timeout failure message. It answers the triage question when an apply
+// never leaves its starting state: whether a driver ever claimed the apply or
+// its operations (lease_owner, updated_at), and whether the operator pool is
+// busy with other in-flight applies. It never fails the test — any query error
+// is rendered into the returned text, since the caller is already on the
+// timeout path.
+func applyTimeoutDiagnostics(applyID string) string {
+	dsn := os.Getenv("E2E_MYSQL_DSN")
+	if dsn == "" {
+		return "diagnostics: E2E_MYSQL_DSN not set"
+	}
+	db, err := sql.Open("mysql", dsn)
+	if err != nil {
+		return fmt.Sprintf("diagnostics: open schemabot db: %v", err)
+	}
+	defer utils.CloseAndLog(db)
+
+	ctx, cancel := context.WithTimeout(context.Background(), testutil.ProgressTimeout)
+	defer cancel()
+
+	var b strings.Builder
+	b.WriteString("--- apply timeout diagnostics ---\n")
+
+	var (
+		applyDBID                        int64
+		applyState, leaseOwner, applyErr string
+		attempt                          int
+		updatedAt                        string
+	)
+	err = db.QueryRowContext(ctx,
+		"SELECT id, state, attempt, lease_owner, updated_at, COALESCE(error_message, '') "+
+			"FROM applies WHERE apply_identifier = ?", applyID).
+		Scan(&applyDBID, &applyState, &attempt, &leaseOwner, &updatedAt, &applyErr)
+	switch {
+	case errors.Is(err, sql.ErrNoRows):
+		fmt.Fprintf(&b, "applies: no row for %s\n", applyID)
+		return b.String()
+	case err != nil:
+		fmt.Fprintf(&b, "applies: query error: %v\n", err)
+		return b.String()
+	}
+	fmt.Fprintf(&b, "applies: id=%d state=%q attempt=%d lease_owner=%q updated_at=%s error=%q\n",
+		applyDBID, applyState, attempt, leaseOwner, updatedAt, applyErr)
+
+	opRows, err := db.QueryContext(ctx,
+		"SELECT id, deployment, state, lease_owner, updated_at FROM apply_operations "+
+			"WHERE apply_id = ? ORDER BY id", applyDBID)
+	if err != nil {
+		fmt.Fprintf(&b, "apply_operations: query error: %v\n", err)
+	} else {
+		func() {
+			defer utils.CloseAndLog(opRows)
+			for opRows.Next() {
+				var (
+					opID                              int64
+					deployment, opState, opLeaseOwner string
+					opUpdatedAt                       string
+				)
+				if err := opRows.Scan(&opID, &deployment, &opState, &opLeaseOwner, &opUpdatedAt); err != nil {
+					fmt.Fprintf(&b, "apply_operations: scan error: %v\n", err)
+					return
+				}
+				fmt.Fprintf(&b, "  operation id=%d deployment=%q state=%q lease_owner=%q updated_at=%s\n",
+					opID, deployment, opState, opLeaseOwner, opUpdatedAt)
+			}
+		}()
+	}
+
+	// Operator backlog: how many other applies are in flight (non-terminal)
+	// when this one is stuck. A busy pool here points at driver starvation.
+	backlogRows, err := db.QueryContext(ctx,
+		"SELECT state, COUNT(*) FROM applies GROUP BY state ORDER BY state")
+	if err != nil {
+		fmt.Fprintf(&b, "applies backlog: query error: %v\n", err)
+	} else {
+		func() {
+			defer utils.CloseAndLog(backlogRows)
+			b.WriteString("applies by state:")
+			for backlogRows.Next() {
+				var s string
+				var n int
+				if err := backlogRows.Scan(&s, &n); err != nil {
+					fmt.Fprintf(&b, " scan error: %v", err)
+					return
+				}
+				fmt.Fprintf(&b, " %s=%d", s, n)
+			}
+			b.WriteString("\n")
+		}()
+	}
+
+	logRows, err := db.QueryContext(ctx,
+		"SELECT level, event_type, COALESCE(old_state, ''), COALESCE(new_state, ''), message, created_at "+
+			"FROM apply_logs WHERE apply_id = ? ORDER BY id DESC LIMIT 20", applyDBID)
+	if err != nil {
+		fmt.Fprintf(&b, "apply_logs: query error: %v\n", err)
+	} else {
+		func() {
+			defer utils.CloseAndLog(logRows)
+			b.WriteString("recent apply_logs (newest first):\n")
+			for logRows.Next() {
+				var level, eventType, oldState, newState, message, createdAt string
+				if err := logRows.Scan(&level, &eventType, &oldState, &newState, &message, &createdAt); err != nil {
+					fmt.Fprintf(&b, "  scan error: %v\n", err)
+					return
+				}
+				fmt.Fprintf(&b, "  [%s] %s %s->%s %s: %s\n",
+					createdAt, level, oldState, newState, eventType, message)
+			}
+		}()
+	}
+
+	return b.String()
 }
 
 func waitForApplyAnyState(t *testing.T, endpoint, applyID string, expectedStates []string, timeout time.Duration) string {

--- a/e2e/local/apply_wait_test.go
+++ b/e2e/local/apply_wait_test.go
@@ -146,11 +146,16 @@ func applyTimeoutDiagnostics(applyID string) string {
 				fmt.Fprintf(&b, "  operation id=%d deployment=%q state=%q lease_owner=%q updated_at=%s\n",
 					opID, deployment, opState, opLeaseOwner, opUpdatedAt)
 			}
+			if err := opRows.Err(); err != nil {
+				fmt.Fprintf(&b, "apply_operations: row iteration error: %v\n", err)
+			}
 		}()
 	}
 
-	// Operator backlog: how many other applies are in flight (non-terminal)
-	// when this one is stuck. A busy pool here points at driver starvation.
+	// Operator backlog: every apply grouped by state, so triage can see how
+	// many sit in non-terminal states (e.g. pending, running) competing for
+	// drivers when this one is stuck. A large non-terminal count points at
+	// driver-pool starvation.
 	backlogRows, err := db.QueryContext(ctx,
 		"SELECT state, COUNT(*) FROM applies GROUP BY state ORDER BY state")
 	if err != nil {
@@ -167,6 +172,9 @@ func applyTimeoutDiagnostics(applyID string) string {
 					return
 				}
 				fmt.Fprintf(&b, " %s=%d", s, n)
+			}
+			if err := backlogRows.Err(); err != nil {
+				fmt.Fprintf(&b, " row iteration error: %v", err)
 			}
 			b.WriteString("\n")
 		}()
@@ -189,6 +197,9 @@ func applyTimeoutDiagnostics(applyID string) string {
 				}
 				fmt.Fprintf(&b, "  [%s] %s %s->%s %s: %s\n",
 					createdAt, level, oldState, newState, eventType, message)
+			}
+			if err := logRows.Err(); err != nil {
+				fmt.Fprintf(&b, "  row iteration error: %v\n", err)
 			}
 		}()
 	}

--- a/e2e/local/helpers_test.go
+++ b/e2e/local/helpers_test.go
@@ -279,8 +279,13 @@ func ensureNoActiveChange(t *testing.T, endpoint string) {
 
 func clearSchemaBotState(t *testing.T) {
 	t.Helper()
-	clearSchemaBotStorage(t)
+	// Reset LocalScale first so any Vitess deploy still executing from a prior
+	// test is cancelled before its SchemaBot rows are deleted. Clearing storage
+	// first deletes rows out from under an in-flight operator drive, which keeps
+	// that driver busy unwinding a lost lease and can starve the next test's
+	// apply of a free driver.
 	resetLocalScaleState(t)
+	clearSchemaBotStorage(t)
 }
 
 func clearSchemaBotStorage(t *testing.T) {


### PR DESCRIPTION
## What
- Reset LocalScale (cancel in-flight Vitess deploys) **before** clearing SchemaBot storage in the per-test cleanup, instead of after.
- On apply-wait timeout, dump the `applies` row, its `apply_operations` rows, the operator's applies-by-state backlog, and recent `apply_logs`.

## Why
A shared, long-lived SchemaBot server runs many Vitess e2e tests in one shard. An apply intermittently sat in `pending` for the full 30s wait and was never claimed, while the operator was demonstrably busy resuming other applies — i.e. driver-pool starvation from leftover/in-flight work.

Clearing storage first deletes rows out from under an in-flight operator drive, leaving that driver unwinding a lost lease (the lease-lost churn seen in CI) and unable to claim the next test's apply. Resetting LocalScale first cancels the deploy so the drive ends quickly and the pool is free for the next test.

## Cleanup ordering: before vs after

Before — clear storage first:
```
test N cleanup
└─ DELETE applies/operations ──▶ rows vanish under an in-flight drive
│
driver mid Vitess deploy ◀───┘  ▶ "apply lease lost", keeps churning
│
└─ reset LocalScale (later)        ▼
test N+1: create apply ───▶ pending ───▶ no free driver ───▶ 30s timeout ✗
```
After — cancel Vitess deploy first:
```
test N cleanup
└─ reset LocalScale ──▶ Vitess deploy cancelled
│
driver drive ends quickly, releases cleanly
▼
└─ DELETE applies/operations  (no in-flight drive to disturb)
test N+1: create apply ───▶ pending ───▶ free driver claims ───▶ completed ✓
```

The failure window was previously lost to tail-only container logs. The timeout dump makes any recurrence diagnosable — it shows whether a driver ever claimed the apply (lease_owner/updated_at) and whether the pool is saturated with other applies. It is best-effort and never fails the test itself.

This does not change the operator's scheduling. If the dump confirms starvation, the operator-side fix (re-arm a wake after a successful claim so a busy pool drains backlog instead of waiting a full poll interval) is a follow-up.
