### PR TITLE
refactor: collapse per-operation control plumbing behind shared helpers

### DIFF
--- a/pkg/api/control_handlers.go
+++ b/pkg/api/control_handlers.go
@@ -963,29 +963,36 @@ func stopRequestCounts(tasks []*storage.Task) (int64, int64) {
 	return stoppedCount, skippedCount
 }
 
-func (s *Service) createStopControlRequest(ctx context.Context, apply *storage.Apply, caller string, stoppedCount, skippedCount int64) (*storage.ApplyControlRequest, bool, error) {
+// createControlRequest marshals metadata and records a pending control request
+// for the given operation, keeping the per-operation create helpers to a single
+// descriptor call instead of duplicating the store/marshal/record boilerplate.
+func (s *Service) createControlRequest(ctx context.Context, apply *storage.Apply, op storage.ControlOperation, caller string, metadata any) (*storage.ApplyControlRequest, bool, error) {
 	controlStore := s.storage.ControlRequests()
 	if controlStore == nil {
 		return nil, false, fmt.Errorf("control request store is not available")
 	}
-	metadata, err := json.Marshal(stopControlRequestMetadata{
-		StoppedCount: stoppedCount,
-		SkippedCount: skippedCount,
-	})
+	metadataJSON, err := json.Marshal(metadata)
 	if err != nil {
-		return nil, false, fmt.Errorf("marshal stop control request metadata for apply %s: %w", apply.ApplyIdentifier, err)
+		return nil, false, fmt.Errorf("marshal %s control request metadata for apply %s: %w", op, apply.ApplyIdentifier, err)
 	}
 	controlReq, alreadyPending, err := controlStore.RequestPending(ctx, &storage.ApplyControlRequest{
 		ApplyID:     apply.ID,
-		Operation:   storage.ControlOperationStop,
+		Operation:   op,
 		Status:      storage.ControlRequestPending,
 		RequestedBy: caller,
-		Metadata:    metadata,
+		Metadata:    metadataJSON,
 	})
 	if err != nil {
-		return nil, false, fmt.Errorf("record stop control request for apply %s: %w", apply.ApplyIdentifier, err)
+		return nil, false, fmt.Errorf("record %s control request for apply %s: %w", op, apply.ApplyIdentifier, err)
 	}
 	return controlReq, alreadyPending, nil
+}
+
+func (s *Service) createStopControlRequest(ctx context.Context, apply *storage.Apply, caller string, stoppedCount, skippedCount int64) (*storage.ApplyControlRequest, bool, error) {
+	return s.createControlRequest(ctx, apply, storage.ControlOperationStop, caller, stopControlRequestMetadata{
+		StoppedCount: stoppedCount,
+		SkippedCount: skippedCount,
+	})
 }
 
 func (s *Service) pendingStopResponseIfPresent(ctx context.Context, apply *storage.Apply) (*ternv1.StopResponse, string, bool, error) {
@@ -1395,28 +1402,10 @@ func (s *Service) persistStartRequestForOperator(ctx context.Context, apply *sto
 }
 
 func (s *Service) createStartControlRequest(ctx context.Context, apply *storage.Apply, caller string, startedCount, skippedCount int64) (*storage.ApplyControlRequest, bool, error) {
-	controlStore := s.storage.ControlRequests()
-	if controlStore == nil {
-		return nil, false, fmt.Errorf("control request store is not available")
-	}
-	metadata, err := json.Marshal(startControlRequestMetadata{
+	return s.createControlRequest(ctx, apply, storage.ControlOperationStart, caller, startControlRequestMetadata{
 		StartedCount: startedCount,
 		SkippedCount: skippedCount,
 	})
-	if err != nil {
-		return nil, false, fmt.Errorf("marshal start control request metadata for apply %s: %w", apply.ApplyIdentifier, err)
-	}
-	controlReq, alreadyPending, err := controlStore.RequestPending(ctx, &storage.ApplyControlRequest{
-		ApplyID:     apply.ID,
-		Operation:   storage.ControlOperationStart,
-		Status:      storage.ControlRequestPending,
-		RequestedBy: caller,
-		Metadata:    metadata,
-	})
-	if err != nil {
-		return nil, false, fmt.Errorf("record start control request for apply %s: %w", apply.ApplyIdentifier, err)
-	}
-	return controlReq, alreadyPending, nil
 }
 
 func (s *Service) startResponseForPendingStartRequest(ctx context.Context, apply *storage.Apply) (*ternv1.StartResponse, string, error) {

--- a/pkg/api/control_handlers.go
+++ b/pkg/api/control_handlers.go
@@ -995,23 +995,58 @@ func (s *Service) createStopControlRequest(ctx context.Context, apply *storage.A
 	})
 }
 
-func (s *Service) pendingStopResponseIfPresent(ctx context.Context, apply *storage.Apply) (*ternv1.StopResponse, string, bool, error) {
+// pendingControlResponseIfPresent loads any pending control request for the
+// operation and renders it with build, so each operation's pending-response
+// lookup is a single descriptor call instead of duplicating the store/load/
+// render boilerplate.
+func pendingControlResponseIfPresent[R any](ctx context.Context, s *Service, apply *storage.Apply, op storage.ControlOperation, status string, build func(*storage.ApplyControlRequest) (R, error)) (R, string, bool, error) {
+	var zero R
 	controlStore := s.storage.ControlRequests()
 	if controlStore == nil {
-		return nil, "", false, fmt.Errorf("control request store is not available")
+		return zero, "", false, fmt.Errorf("control request store is not available")
 	}
-	controlReq, err := controlStore.GetPending(ctx, apply.ID, storage.ControlOperationStop)
+	controlReq, err := controlStore.GetPending(ctx, apply.ID, op)
 	if err != nil {
-		return nil, "", false, fmt.Errorf("load pending stop control request for apply %s: %w", apply.ApplyIdentifier, err)
+		return zero, "", false, fmt.Errorf("load pending %s control request for apply %s: %w", op, apply.ApplyIdentifier, err)
 	}
 	if controlReq == nil {
-		return nil, "", false, nil
+		return zero, "", false, nil
 	}
-	resp, err := stopResponseFromControlRequest(controlReq)
+	resp, err := build(controlReq)
 	if err != nil {
-		return nil, "", false, err
+		return zero, "", false, err
 	}
-	return resp, stopResponseStatusAlreadyRequested, true, nil
+	return resp, status, true, nil
+}
+
+// decodeControlRequestMetadata unmarshals the operation's stored metadata,
+// tolerating an empty payload so a metadata-less request decodes to the zero
+// value.
+func decodeControlRequestMetadata[M any](controlReq *storage.ApplyControlRequest, op storage.ControlOperation) (M, error) {
+	var metadata M
+	if len(controlReq.Metadata) > 0 {
+		if err := json.Unmarshal(controlReq.Metadata, &metadata); err != nil {
+			return metadata, fmt.Errorf("decode %s control request metadata for request %d: %w", op, controlReq.ID, err)
+		}
+	}
+	return metadata, nil
+}
+
+// applyControlRequestStatus maps a control request status onto a response via
+// the accepted/error setters, so every operation shares one status mapping.
+func applyControlRequestStatus(controlReq *storage.ApplyControlRequest, op storage.ControlOperation, setAccepted func(), setError func(string)) {
+	switch controlReq.Status {
+	case storage.ControlRequestPending, storage.ControlRequestCompleted:
+		setAccepted()
+	case storage.ControlRequestFailed:
+		setError(controlReq.ErrorMessage)
+	default:
+		setError(fmt.Sprintf("%s control request has unknown status: %s", op, controlReq.Status))
+	}
+}
+
+func (s *Service) pendingStopResponseIfPresent(ctx context.Context, apply *storage.Apply) (*ternv1.StopResponse, string, bool, error) {
+	return pendingControlResponseIfPresent(ctx, s, apply, storage.ControlOperationStop, stopResponseStatusAlreadyRequested, stopResponseFromControlRequest)
 }
 
 func stopResponseFromControlRequest(controlReq *storage.ApplyControlRequest) (*ternv1.StopResponse, error) {
@@ -1019,22 +1054,15 @@ func stopResponseFromControlRequest(controlReq *storage.ApplyControlRequest) (*t
 	if controlReq == nil {
 		return resp, nil
 	}
-	var metadata stopControlRequestMetadata
-	if len(controlReq.Metadata) > 0 {
-		if err := json.Unmarshal(controlReq.Metadata, &metadata); err != nil {
-			return nil, fmt.Errorf("decode stop control request metadata for request %d: %w", controlReq.ID, err)
-		}
+	metadata, err := decodeControlRequestMetadata[stopControlRequestMetadata](controlReq, storage.ControlOperationStop)
+	if err != nil {
+		return nil, err
 	}
 	resp.StoppedCount = metadata.StoppedCount
 	resp.SkippedCount = metadata.SkippedCount
-	switch controlReq.Status {
-	case storage.ControlRequestPending, storage.ControlRequestCompleted:
-		resp.Accepted = true
-	case storage.ControlRequestFailed:
-		resp.ErrorMessage = controlReq.ErrorMessage
-	default:
-		resp.ErrorMessage = fmt.Sprintf("stop control request has unknown status: %s", controlReq.Status)
-	}
+	applyControlRequestStatus(controlReq, storage.ControlOperationStop,
+		func() { resp.Accepted = true },
+		func(msg string) { resp.ErrorMessage = msg })
 	return resp, nil
 }
 
@@ -1420,22 +1448,7 @@ func (s *Service) startResponseForPendingStartRequest(ctx context.Context, apply
 }
 
 func (s *Service) pendingStartResponseIfPresent(ctx context.Context, apply *storage.Apply) (*ternv1.StartResponse, string, bool, error) {
-	controlStore := s.storage.ControlRequests()
-	if controlStore == nil {
-		return nil, "", false, fmt.Errorf("control request store is not available")
-	}
-	controlReq, err := controlStore.GetPending(ctx, apply.ID, storage.ControlOperationStart)
-	if err != nil {
-		return nil, "", false, fmt.Errorf("load pending start control request for apply %s: %w", apply.ApplyIdentifier, err)
-	}
-	if controlReq == nil {
-		return nil, "", false, nil
-	}
-	resp, err := startResponseFromControlRequest(controlReq)
-	if err != nil {
-		return nil, "", false, err
-	}
-	return resp, startResponseStatusAlreadyRequested, true, nil
+	return pendingControlResponseIfPresent(ctx, s, apply, storage.ControlOperationStart, startResponseStatusAlreadyRequested, startResponseFromControlRequest)
 }
 
 func startResponseFromControlRequest(controlReq *storage.ApplyControlRequest) (*ternv1.StartResponse, error) {
@@ -1443,22 +1456,15 @@ func startResponseFromControlRequest(controlReq *storage.ApplyControlRequest) (*
 	if controlReq == nil {
 		return resp, nil
 	}
-	var metadata startControlRequestMetadata
-	if len(controlReq.Metadata) > 0 {
-		if err := json.Unmarshal(controlReq.Metadata, &metadata); err != nil {
-			return nil, fmt.Errorf("decode start control request metadata for request %d: %w", controlReq.ID, err)
-		}
+	metadata, err := decodeControlRequestMetadata[startControlRequestMetadata](controlReq, storage.ControlOperationStart)
+	if err != nil {
+		return nil, err
 	}
 	resp.StartedCount = metadata.StartedCount
 	resp.SkippedCount = metadata.SkippedCount
-	switch controlReq.Status {
-	case storage.ControlRequestPending, storage.ControlRequestCompleted:
-		resp.Accepted = true
-	case storage.ControlRequestFailed:
-		resp.ErrorMessage = controlReq.ErrorMessage
-	default:
-		resp.ErrorMessage = fmt.Sprintf("start control request has unknown status: %s", controlReq.Status)
-	}
+	applyControlRequestStatus(controlReq, storage.ControlOperationStart,
+		func() { resp.Accepted = true },
+		func(msg string) { resp.ErrorMessage = msg })
 	return resp, nil
 }
 

--- a/pkg/cmd/client/client.go
+++ b/pkg/cmd/client/client.go
@@ -162,14 +162,21 @@ func CallApplyAPI(endpoint, planID, environment, caller string, options map[stri
 	return &result, nil
 }
 
-// CallCutoverAPI calls the cutover API and returns the typed result.
-func CallCutoverAPI(endpoint, environment, applyID string) (*apitypes.ControlResponse, error) {
+// callControlAPI posts an apply-scoped control request to path and decodes the
+// typed response. Control operations share the same ControlRequest body and
+// differ only by endpoint path and response type.
+func callControlAPI[Resp any](endpoint, path, environment, applyID string) (*Resp, error) {
 	req := apitypes.ControlRequest{Environment: environment, ApplyID: applyID, Caller: GenerateCLIOwner()}
-	var result apitypes.ControlResponse
-	if err := doPostInto(endpoint, "/api/cutover", req, &result); err != nil {
+	var result Resp
+	if err := doPostInto(endpoint, path, req, &result); err != nil {
 		return nil, err
 	}
 	return &result, nil
+}
+
+// CallCutoverAPI calls the cutover API and returns the typed result.
+func CallCutoverAPI(endpoint, environment, applyID string) (*apitypes.ControlResponse, error) {
+	return callControlAPI[apitypes.ControlResponse](endpoint, "/api/cutover", environment, applyID)
 }
 
 // GetProgress fetches progress for a schema change by apply ID.
@@ -308,22 +315,12 @@ func isSchemaFile(name string) bool {
 
 // CallStopAPI calls the stop API and returns the typed result.
 func CallStopAPI(endpoint, environment, applyID string) (*apitypes.StopResponse, error) {
-	req := apitypes.ControlRequest{Environment: environment, ApplyID: applyID, Caller: GenerateCLIOwner()}
-	var result apitypes.StopResponse
-	if err := doPostInto(endpoint, "/api/stop", req, &result); err != nil {
-		return nil, err
-	}
-	return &result, nil
+	return callControlAPI[apitypes.StopResponse](endpoint, "/api/stop", environment, applyID)
 }
 
 // CallStartAPI calls the start API and returns the typed result.
 func CallStartAPI(endpoint, environment, applyID string) (*apitypes.StartResponse, error) {
-	req := apitypes.ControlRequest{Environment: environment, ApplyID: applyID, Caller: GenerateCLIOwner()}
-	var result apitypes.StartResponse
-	if err := doPostInto(endpoint, "/api/start", req, &result); err != nil {
-		return nil, err
-	}
-	return &result, nil
+	return callControlAPI[apitypes.StartResponse](endpoint, "/api/start", environment, applyID)
 }
 
 // CallVolumeAPI calls the volume API and returns the typed result.
@@ -338,22 +335,12 @@ func CallVolumeAPI(endpoint, environment, applyID string, volume int) (*apitypes
 
 // CallRevertAPI calls the revert API and returns the typed result.
 func CallRevertAPI(endpoint, environment, applyID string) (*apitypes.ControlResponse, error) {
-	req := apitypes.ControlRequest{Environment: environment, ApplyID: applyID, Caller: GenerateCLIOwner()}
-	var result apitypes.ControlResponse
-	if err := doPostInto(endpoint, "/api/revert", req, &result); err != nil {
-		return nil, err
-	}
-	return &result, nil
+	return callControlAPI[apitypes.ControlResponse](endpoint, "/api/revert", environment, applyID)
 }
 
 // CallSkipRevertAPI calls the skip-revert API and returns the typed result.
 func CallSkipRevertAPI(endpoint, environment, applyID string) (*apitypes.ControlResponse, error) {
-	req := apitypes.ControlRequest{Environment: environment, ApplyID: applyID, Caller: GenerateCLIOwner()}
-	var result apitypes.ControlResponse
-	if err := doPostInto(endpoint, "/api/skip-revert", req, &result); err != nil {
-		return nil, err
-	}
-	return &result, nil
+	return callControlAPI[apitypes.ControlResponse](endpoint, "/api/skip-revert", environment, applyID)
 }
 
 // ExitWithJSON outputs a JSON error response and exits with code 1.

--- a/pkg/engine/planetscale/control.go
+++ b/pkg/engine/planetscale/control.go
@@ -8,28 +8,23 @@ import (
 	ps "github.com/planetscale/planetscale-go/planetscale"
 
 	"github.com/block/schemabot/pkg/engine"
+	"github.com/block/schemabot/pkg/psclient"
 )
 
 var _ engine.ControlResumeValidator = (*Engine)(nil)
 
 // Stop cancels the deploy request. This is permanent.
 func (e *Engine) Stop(ctx context.Context, req *engine.ControlRequest) (*engine.ControlResult, error) {
-	meta, err := controlMeta(engine.ControlStop, req)
+	meta, client, err := e.controlClient(engine.ControlStop, req)
 	if err != nil {
-		return nil, fmt.Errorf("decode control metadata: %w", err)
+		return nil, err
 	}
 
-	client, err := e.getClient(req.Credentials)
-	if err != nil {
-		return nil, fmt.Errorf("get planetscale client: %w", err)
-	}
-
-	_, err = client.CancelDeployRequest(ctx, &ps.CancelDeployRequestRequest{
+	if _, err := client.CancelDeployRequest(ctx, &ps.CancelDeployRequestRequest{
 		Organization: credOrg(req.Credentials),
 		Database:     req.Database,
 		Number:       meta.DeployRequestID,
-	})
-	if err != nil {
+	}); err != nil {
 		return nil, fmt.Errorf("cancel deploy request #%d (may have been deleted): %w", meta.DeployRequestID, err)
 	}
 
@@ -78,84 +73,79 @@ func (e *Engine) Start(ctx context.Context, req *engine.ControlRequest) (*engine
 
 // Cutover triggers the final schema swap via ApplyDeployRequest.
 func (e *Engine) Cutover(ctx context.Context, req *engine.ControlRequest) (*engine.ControlResult, error) {
-	meta, err := controlMeta(engine.ControlCutover, req)
-	if err != nil {
-		return nil, fmt.Errorf("decode control metadata: %w", err)
-	}
-
-	client, err := e.getClient(req.Credentials)
-	if err != nil {
-		return nil, fmt.Errorf("get planetscale client: %w", err)
-	}
-
-	dr, err := client.ApplyDeployRequest(ctx, &ps.ApplyDeployRequestRequest{
-		Organization: credOrg(req.Credentials),
-		Database:     req.Database,
-		Number:       meta.DeployRequestID,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("cutover deploy request #%d (may have been deleted): %w", meta.DeployRequestID, err)
-	}
-
-	return &engine.ControlResult{
-		Accepted:    true,
-		Message:     fmt.Sprintf("Cutover initiated for deploy request #%d", dr.Number),
-		ResumeState: req.ResumeState,
-	}, nil
+	return e.controlDeployRequest(ctx, engine.ControlCutover, req, "cutover", "Cutover initiated for",
+		func(ctx context.Context, client psclient.PSClient, number uint64) (*ps.DeployRequest, error) {
+			return client.ApplyDeployRequest(ctx, &ps.ApplyDeployRequestRequest{
+				Organization: credOrg(req.Credentials),
+				Database:     req.Database,
+				Number:       number,
+			})
+		})
 }
 
 // Revert rolls back a completed schema change during the revert window.
 func (e *Engine) Revert(ctx context.Context, req *engine.ControlRequest) (*engine.ControlResult, error) {
-	meta, err := controlMeta(engine.ControlRevert, req)
-	if err != nil {
-		return nil, fmt.Errorf("decode control metadata: %w", err)
-	}
-
-	client, err := e.getClient(req.Credentials)
-	if err != nil {
-		return nil, fmt.Errorf("get planetscale client: %w", err)
-	}
-
-	dr, err := client.RevertDeployRequest(ctx, &ps.RevertDeployRequestRequest{
-		Organization: credOrg(req.Credentials),
-		Database:     req.Database,
-		Number:       meta.DeployRequestID,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("revert deploy request #%d (may have been deleted): %w", meta.DeployRequestID, err)
-	}
-
-	return &engine.ControlResult{
-		Accepted:    true,
-		Message:     fmt.Sprintf("Revert initiated for deploy request #%d", dr.Number),
-		ResumeState: req.ResumeState,
-	}, nil
+	return e.controlDeployRequest(ctx, engine.ControlRevert, req, "revert", "Revert initiated for",
+		func(ctx context.Context, client psclient.PSClient, number uint64) (*ps.DeployRequest, error) {
+			return client.RevertDeployRequest(ctx, &ps.RevertDeployRequestRequest{
+				Organization: credOrg(req.Credentials),
+				Database:     req.Database,
+				Number:       number,
+			})
+		})
 }
 
 // SkipRevert closes the revert window, making the schema change permanent.
 func (e *Engine) SkipRevert(ctx context.Context, req *engine.ControlRequest) (*engine.ControlResult, error) {
-	meta, err := controlMeta(engine.ControlSkipRevert, req)
-	if err != nil {
-		return nil, fmt.Errorf("decode control metadata: %w", err)
-	}
+	return e.controlDeployRequest(ctx, engine.ControlSkipRevert, req, "skip revert for", "Revert window skipped for",
+		func(ctx context.Context, client psclient.PSClient, number uint64) (*ps.DeployRequest, error) {
+			return client.SkipRevertDeployRequest(ctx, &ps.SkipRevertDeployRequestRequest{
+				Organization: credOrg(req.Credentials),
+				Database:     req.Database,
+				Number:       number,
+			})
+		})
+}
 
+// controlClient validates the resume-state metadata for a control operation and
+// returns it together with a PlanetScale client for the request's credentials.
+func (e *Engine) controlClient(operation engine.ControlOperation, req *engine.ControlRequest) (*psMetadata, psclient.PSClient, error) {
+	meta, err := controlMeta(operation, req)
+	if err != nil {
+		return nil, nil, fmt.Errorf("decode control metadata: %w", err)
+	}
 	client, err := e.getClient(req.Credentials)
 	if err != nil {
-		return nil, fmt.Errorf("get planetscale client: %w", err)
+		return nil, nil, fmt.Errorf("get planetscale client: %w", err)
+	}
+	return meta, client, nil
+}
+
+// controlDeployRequest runs a deploy-request mutation that returns the updated
+// deploy request and reports a successful ControlResult. errVerb names the action
+// in the failure message; messagePrefix prefixes the success message, both
+// followed by "deploy request #<number>".
+func (e *Engine) controlDeployRequest(
+	ctx context.Context,
+	operation engine.ControlOperation,
+	req *engine.ControlRequest,
+	errVerb string,
+	messagePrefix string,
+	mutate func(ctx context.Context, client psclient.PSClient, number uint64) (*ps.DeployRequest, error),
+) (*engine.ControlResult, error) {
+	meta, client, err := e.controlClient(operation, req)
+	if err != nil {
+		return nil, err
 	}
 
-	dr, err := client.SkipRevertDeployRequest(ctx, &ps.SkipRevertDeployRequestRequest{
-		Organization: credOrg(req.Credentials),
-		Database:     req.Database,
-		Number:       meta.DeployRequestID,
-	})
+	dr, err := mutate(ctx, client, meta.DeployRequestID)
 	if err != nil {
-		return nil, fmt.Errorf("skip revert for deploy request #%d (may have been deleted): %w", meta.DeployRequestID, err)
+		return nil, fmt.Errorf("%s deploy request #%d (may have been deleted): %w", errVerb, meta.DeployRequestID, err)
 	}
 
 	return &engine.ControlResult{
 		Accepted:    true,
-		Message:     fmt.Sprintf("Revert window skipped for deploy request #%d", dr.Number),
+		Message:     fmt.Sprintf("%s deploy request #%d", messagePrefix, dr.Number),
 		ResumeState: req.ResumeState,
 	}, nil
 }

--- a/pkg/tern/control_requests.go
+++ b/pkg/tern/control_requests.go
@@ -9,7 +9,9 @@ import (
 	"github.com/block/schemabot/pkg/storage"
 )
 
-func pendingStartControlRequest(ctx context.Context, store storage.Storage, apply *storage.Apply) (*storage.ApplyControlRequest, error) {
+// pendingControlRequest loads the pending control request of the given operation
+// for an apply, returning nil when none is pending.
+func pendingControlRequest(ctx context.Context, store storage.Storage, apply *storage.Apply, operation storage.ControlOperation) (*storage.ApplyControlRequest, error) {
 	if store == nil {
 		return nil, fmt.Errorf("storage is not available")
 	}
@@ -17,92 +19,49 @@ func pendingStartControlRequest(ctx context.Context, store storage.Storage, appl
 	if controlStore == nil {
 		return nil, fmt.Errorf("control request store is not available")
 	}
-	controlReq, err := controlStore.GetPending(ctx, apply.ID, storage.ControlOperationStart)
+	controlReq, err := controlStore.GetPending(ctx, apply.ID, operation)
 	if err != nil {
-		return nil, fmt.Errorf("load pending start control request for apply %s: %w", apply.ApplyIdentifier, err)
+		return nil, fmt.Errorf("load pending %s control request for apply %s: %w", operation, apply.ApplyIdentifier, err)
 	}
 	return controlReq, nil
 }
 
-func completePendingStartControlRequests(ctx context.Context, store storage.Storage, apply *storage.Apply) error {
+// completePendingControlRequests marks the pending control request of the given
+// operation completed, after verifying the apply lease still holds.
+func completePendingControlRequests(ctx context.Context, store storage.Storage, apply *storage.Apply, operation storage.ControlOperation) error {
 	if store == nil {
 		return fmt.Errorf("storage is not available")
 	}
-	if err := ensureApplyLeaseForControlRequest(ctx, store, apply, storage.ControlOperationStart); err != nil {
+	if err := ensureApplyLeaseForControlRequest(ctx, store, apply, operation); err != nil {
 		return err
 	}
 	controlStore := store.ControlRequests()
 	if controlStore == nil {
 		return fmt.Errorf("control request store is not available")
 	}
-	if err := controlStore.CompletePending(ctx, apply.ID, storage.ControlOperationStart); err != nil {
-		return fmt.Errorf("complete pending start control request for apply %s: %w", apply.ApplyIdentifier, err)
+	if err := controlStore.CompletePending(ctx, apply.ID, operation); err != nil {
+		return fmt.Errorf("complete pending %s control request for apply %s: %w", operation, apply.ApplyIdentifier, err)
 	}
 	return nil
 }
 
-func failPendingStartControlRequests(ctx context.Context, store storage.Storage, apply *storage.Apply, errorMessage string) error {
+// failPendingControlRequests marks the pending control request of the given
+// operation terminally failed. A failed request is no longer pending, so the
+// operator-owned retry loop stops re-running the operation instead of spinning
+// on a permanent rejection.
+func failPendingControlRequests(ctx context.Context, store storage.Storage, apply *storage.Apply, operation storage.ControlOperation, errorMessage string) error {
 	if store == nil {
 		return fmt.Errorf("storage is not available")
 	}
-	if err := ensureApplyLeaseForControlRequest(ctx, store, apply, storage.ControlOperationStart); err != nil {
+	if err := ensureApplyLeaseForControlRequest(ctx, store, apply, operation); err != nil {
 		return err
 	}
 	controlStore := store.ControlRequests()
 	if controlStore == nil {
 		return fmt.Errorf("control request store is not available")
 	}
-	if err := controlStore.FailPending(ctx, apply.ID, storage.ControlOperationStart, errorMessage); err != nil {
-		return fmt.Errorf("fail pending start control request for apply %s: %w", apply.ApplyIdentifier, err)
-	}
-	return nil
-}
-
-func pendingCutoverControlRequest(ctx context.Context, store storage.Storage, apply *storage.Apply) (*storage.ApplyControlRequest, error) {
-	if store == nil {
-		return nil, fmt.Errorf("storage is not available")
-	}
-	controlStore := store.ControlRequests()
-	if controlStore == nil {
-		return nil, fmt.Errorf("control request store is not available")
-	}
-	controlReq, err := controlStore.GetPending(ctx, apply.ID, storage.ControlOperationCutover)
-	if err != nil {
-		return nil, fmt.Errorf("load pending cutover control request for apply %s: %w", apply.ApplyIdentifier, err)
-	}
-	return controlReq, nil
-}
-
-func completePendingCutoverControlRequests(ctx context.Context, store storage.Storage, apply *storage.Apply) error {
-	if store == nil {
-		return fmt.Errorf("storage is not available")
-	}
-	if err := ensureApplyLeaseForControlRequest(ctx, store, apply, storage.ControlOperationCutover); err != nil {
-		return err
-	}
-	controlStore := store.ControlRequests()
-	if controlStore == nil {
-		return fmt.Errorf("control request store is not available")
-	}
-	if err := controlStore.CompletePending(ctx, apply.ID, storage.ControlOperationCutover); err != nil {
-		return fmt.Errorf("complete pending cutover control request for apply %s: %w", apply.ApplyIdentifier, err)
-	}
-	return nil
-}
-
-func failPendingCutoverControlRequests(ctx context.Context, store storage.Storage, apply *storage.Apply, errorMessage string) error {
-	if store == nil {
-		return fmt.Errorf("storage is not available")
-	}
-	if err := ensureApplyLeaseForControlRequest(ctx, store, apply, storage.ControlOperationCutover); err != nil {
-		return err
-	}
-	controlStore := store.ControlRequests()
-	if controlStore == nil {
-		return fmt.Errorf("control request store is not available")
-	}
-	if err := controlStore.FailPending(ctx, apply.ID, storage.ControlOperationCutover, errorMessage); err != nil {
-		return fmt.Errorf("fail pending cutover control request for apply %s: %w", apply.ApplyIdentifier, err)
+	if err := controlStore.FailPending(ctx, apply.ID, operation, errorMessage); err != nil {
+		return fmt.Errorf("fail pending %s control request for apply %s: %w", operation, apply.ApplyIdentifier, err)
 	}
 	return nil
 }
@@ -163,58 +122,6 @@ func cutoverRequestFailedByApplyState(applyState string) bool {
 	return state.IsTerminalApplyState(applyState) && !cutoverRequestResolvedByApplyState(applyState)
 }
 
-func pendingStopControlRequest(ctx context.Context, store storage.Storage, apply *storage.Apply) (*storage.ApplyControlRequest, error) {
-	if store == nil {
-		return nil, fmt.Errorf("storage is not available")
-	}
-	controlStore := store.ControlRequests()
-	if controlStore == nil {
-		return nil, fmt.Errorf("control request store is not available")
-	}
-	controlReq, err := controlStore.GetPending(ctx, apply.ID, storage.ControlOperationStop)
-	if err != nil {
-		return nil, fmt.Errorf("load pending stop control request for apply %s: %w", apply.ApplyIdentifier, err)
-	}
-	return controlReq, nil
-}
-
-func completePendingStopControlRequests(ctx context.Context, store storage.Storage, apply *storage.Apply) error {
-	if store == nil {
-		return fmt.Errorf("storage is not available")
-	}
-	if err := ensureApplyLeaseForControlRequest(ctx, store, apply, storage.ControlOperationStop); err != nil {
-		return err
-	}
-	controlStore := store.ControlRequests()
-	if controlStore == nil {
-		return fmt.Errorf("control request store is not available")
-	}
-	if err := controlStore.CompletePending(ctx, apply.ID, storage.ControlOperationStop); err != nil {
-		return fmt.Errorf("complete pending stop control request for apply %s: %w", apply.ApplyIdentifier, err)
-	}
-	return nil
-}
-
-// failPendingStopControlRequests marks the pending stop request terminally
-// failed. A failed request is no longer pending, so the operator-owned retry
-// loop stops re-running stop instead of spinning on a permanent rejection.
-func failPendingStopControlRequests(ctx context.Context, store storage.Storage, apply *storage.Apply, errorMessage string) error {
-	if store == nil {
-		return fmt.Errorf("storage is not available")
-	}
-	if err := ensureApplyLeaseForControlRequest(ctx, store, apply, storage.ControlOperationStop); err != nil {
-		return err
-	}
-	controlStore := store.ControlRequests()
-	if controlStore == nil {
-		return fmt.Errorf("control request store is not available")
-	}
-	if err := controlStore.FailPending(ctx, apply.ID, storage.ControlOperationStop, errorMessage); err != nil {
-		return fmt.Errorf("fail pending stop control request for apply %s: %w", apply.ApplyIdentifier, err)
-	}
-	return nil
-}
-
 func ensureApplyLeaseForControlRequest(ctx context.Context, store storage.Storage, apply *storage.Apply, operation storage.ControlOperation) error {
 	lease, ok := storage.ApplyLeaseFromContext(ctx)
 	if !ok {
@@ -249,7 +156,7 @@ func completePendingStopIfStoredApplyResolved(ctx context.Context, store storage
 	if !state.IsTerminalApplyState(storedApply.State) {
 		return false, nil
 	}
-	if err := completePendingStopControlRequests(ctx, store, storedApply); err != nil {
+	if err := completePendingControlRequests(ctx, store, storedApply, storage.ControlOperationStop); err != nil {
 		return false, err
 	}
 	*apply = *storedApply

--- a/pkg/tern/grpc_client.go
+++ b/pkg/tern/grpc_client.go
@@ -445,7 +445,7 @@ func (c *GRPCClient) Cutover(ctx context.Context, req *ternv1.CutoverRequest) (*
 }
 
 func (c *GRPCClient) processPendingCutoverControlRequest(ctx context.Context, apply *storage.Apply, scope applyTaskScope) error {
-	controlReq, err := pendingCutoverControlRequest(ctx, c.storage, apply)
+	controlReq, err := pendingControlRequest(ctx, c.storage, apply, storage.ControlOperationCutover)
 	if err != nil {
 		return err
 	}
@@ -462,11 +462,11 @@ func (c *GRPCClient) processPendingCutoverControlRequest(ctx context.Context, ap
 			"state", apply.State)
 		c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventCutoverTriggered,
 			fmt.Sprintf("Pending remote cutover request completed for resolved apply%s", callerApplyLogSuffix(controlRequestCaller(controlReq))), "", "")
-		return completePendingCutoverControlRequests(ctx, c.storage, apply)
+		return completePendingControlRequests(ctx, c.storage, apply, storage.ControlOperationCutover)
 	}
 	if cutoverRequestFailedByApplyState(apply.State) {
 		message := fmt.Sprintf("cutover request was not applied because apply is %s", apply.State)
-		if err := failPendingCutoverControlRequests(ctx, c.storage, apply, message); err != nil {
+		if err := failPendingControlRequests(ctx, c.storage, apply, storage.ControlOperationCutover, message); err != nil {
 			return err
 		}
 		return fmt.Errorf("process pending gRPC cutover for apply %s: %s", apply.ApplyIdentifier, message)
@@ -498,12 +498,12 @@ func (c *GRPCClient) processPendingCutoverControlRequest(ctx context.Context, ap
 	remoteID := scope.remoteApplyID(apply)
 	if remoteID == "" {
 		message := "remote apply id is not available"
-		if err := failPendingCutoverControlRequests(ctx, c.storage, apply, message); err != nil {
+		if err := failPendingControlRequests(ctx, c.storage, apply, storage.ControlOperationCutover, message); err != nil {
 			return err
 		}
 		return fmt.Errorf("process pending gRPC cutover for apply %s: %s", apply.ApplyIdentifier, message)
 	}
-	if stopReq, err := pendingStopControlRequest(ctx, c.storage, apply); err != nil {
+	if stopReq, err := pendingControlRequest(ctx, c.storage, apply, storage.ControlOperationStop); err != nil {
 		return fmt.Errorf("check pending stop request before pending gRPC cutover for apply %s: %w", apply.ApplyIdentifier, err)
 	} else if stopReq != nil {
 		message := "schema change has a pending stop request; cutover is blocked until stop is processed"
@@ -518,7 +518,7 @@ func (c *GRPCClient) processPendingCutoverControlRequest(ctx context.Context, ap
 	})
 	if err != nil {
 		errorMessage := fmt.Sprintf("remote cutover failed: %v", err)
-		if failErr := failPendingCutoverControlRequests(ctx, c.storage, apply, errorMessage); failErr != nil {
+		if failErr := failPendingControlRequests(ctx, c.storage, apply, storage.ControlOperationCutover, errorMessage); failErr != nil {
 			return fmt.Errorf("request remote gRPC cutover for apply %s remote %s: %w; fail pending cutover request: %w", apply.ApplyIdentifier, remoteID, err, failErr)
 		}
 		c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelError, storage.LogEventError,
@@ -527,7 +527,7 @@ func (c *GRPCClient) processPendingCutoverControlRequest(ctx context.Context, ap
 	}
 	if resp == nil {
 		errorMessage := "not accepted"
-		if err := failPendingCutoverControlRequests(ctx, c.storage, apply, errorMessage); err != nil {
+		if err := failPendingControlRequests(ctx, c.storage, apply, storage.ControlOperationCutover, errorMessage); err != nil {
 			return err
 		}
 		c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelError, storage.LogEventError,
@@ -539,7 +539,7 @@ func (c *GRPCClient) processPendingCutoverControlRequest(ctx context.Context, ap
 		if resp.ErrorMessage != "" {
 			errorMessage = resp.ErrorMessage
 		}
-		if err := failPendingCutoverControlRequests(ctx, c.storage, apply, errorMessage); err != nil {
+		if err := failPendingControlRequests(ctx, c.storage, apply, storage.ControlOperationCutover, errorMessage); err != nil {
 			return err
 		}
 		c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelError, storage.LogEventError,
@@ -548,7 +548,7 @@ func (c *GRPCClient) processPendingCutoverControlRequest(ctx context.Context, ap
 	}
 	c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventCutoverTriggered,
 		fmt.Sprintf("Remote cutover accepted for apply %s (remote %s)%s", apply.ApplyIdentifier, remoteID, callerApplyLogSuffix(controlRequestCaller(controlReq))), "", "")
-	if err := completePendingCutoverControlRequests(ctx, c.storage, apply); err != nil {
+	if err := completePendingControlRequests(ctx, c.storage, apply, storage.ControlOperationCutover); err != nil {
 		return err
 	}
 	slog.Info("pending gRPC cutover request accepted and completed",
@@ -582,7 +582,7 @@ func logOperationDriveLeavesParentStop(apply *storage.Apply, scope applyTaskScop
 }
 
 func (c *GRPCClient) processPendingStopControlRequest(ctx context.Context, apply *storage.Apply, scope applyTaskScope) (bool, error) {
-	controlReq, err := pendingStopControlRequest(ctx, c.storage, apply)
+	controlReq, err := pendingControlRequest(ctx, c.storage, apply, storage.ControlOperationStop)
 	if err != nil {
 		return false, err
 	}
@@ -642,7 +642,7 @@ func (c *GRPCClient) processPendingStopControlRequest(ctx context.Context, apply
 			"state", apply.State)
 		c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventStopRequested,
 			fmt.Sprintf("Pending remote stop request completed for terminal apply%s", callerApplyLogSuffix(controlRequestCaller(controlReq))), "", "")
-		if err := completePendingStopControlRequests(ctx, c.storage, apply); err != nil {
+		if err := completePendingControlRequests(ctx, c.storage, apply, storage.ControlOperationStop); err != nil {
 			return true, err
 		}
 		return true, nil
@@ -665,7 +665,7 @@ func (c *GRPCClient) processPendingStopControlRequest(ctx context.Context, apply
 		if err := c.stopUndispatchedApply(ctx, apply, controlRequestCaller(controlReq), scope); err != nil {
 			return true, err
 		}
-		if err := completePendingStopControlRequests(ctx, c.storage, apply); err != nil {
+		if err := completePendingControlRequests(ctx, c.storage, apply, storage.ControlOperationStop); err != nil {
 			return true, err
 		}
 		return true, nil
@@ -729,7 +729,7 @@ func (c *GRPCClient) processPendingStopControlRequest(ctx context.Context, apply
 			logOperationDriveLeavesParentStop(apply, scope)
 			return true, nil
 		}
-		if err := completePendingStopControlRequests(ctx, c.storage, apply); err != nil {
+		if err := completePendingControlRequests(ctx, c.storage, apply, storage.ControlOperationStop); err != nil {
 			return true, err
 		}
 		if hasPendingStart, startErr := hasPendingStartControlRequest(ctx, c.storage, apply); startErr != nil {
@@ -811,7 +811,7 @@ func (c *GRPCClient) completeRemoteStopFromTerminalProgress(ctx context.Context,
 		logOperationDriveLeavesParentStop(apply, scope)
 		return true, nil
 	}
-	if err := completePendingStopControlRequests(ctx, c.storage, apply); err != nil {
+	if err := completePendingControlRequests(ctx, c.storage, apply, storage.ControlOperationStop); err != nil {
 		return false, err
 	}
 	c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventStopRequested,
@@ -1347,7 +1347,7 @@ func (c *GRPCClient) resumeApply(ctx context.Context, apply *storage.Apply, scop
 		return errors.New(errMsg)
 	}
 
-	startControlReq, err := pendingStartControlRequest(ctx, c.storage, apply)
+	startControlReq, err := pendingControlRequest(ctx, c.storage, apply, storage.ControlOperationStart)
 	if err != nil {
 		return err
 	}
@@ -1482,7 +1482,7 @@ func (c *GRPCClient) resumeApply(ctx context.Context, apply *storage.Apply, scop
 					return fmt.Errorf("persist stopped gRPC apply %s after start failure: %w", apply.ApplyIdentifier, reconcileErr)
 				}
 				if startRequested {
-					if failErr := failPendingStartControlRequests(ctx, c.storage, apply, message); failErr != nil {
+					if failErr := failPendingControlRequests(ctx, c.storage, apply, storage.ControlOperationStart, message); failErr != nil {
 						return failErr
 					}
 				}
@@ -1531,7 +1531,7 @@ func (c *GRPCClient) resumeApply(ctx context.Context, apply *storage.Apply, scop
 // parent stop (the operator projection owns it), so it must not start remote
 // work and leaves both the stop and start pending for the operator.
 func (c *GRPCClient) completePendingStopBeforeRemoteStart(ctx context.Context, apply *storage.Apply, scope applyTaskScope) (bool, error) {
-	controlReq, err := pendingStopControlRequest(ctx, c.storage, apply)
+	controlReq, err := pendingControlRequest(ctx, c.storage, apply, storage.ControlOperationStop)
 	if err != nil {
 		return false, fmt.Errorf("check pending stop before starting stopped gRPC apply %s: %w", apply.ApplyIdentifier, err)
 	}
@@ -1550,7 +1550,7 @@ func (c *GRPCClient) completePendingStopBeforeRemoteStart(ctx context.Context, a
 			"state", apply.State)
 		return true, nil
 	}
-	if err := completePendingStopControlRequests(ctx, c.storage, apply); err != nil {
+	if err := completePendingControlRequests(ctx, c.storage, apply, storage.ControlOperationStop); err != nil {
 		return false, fmt.Errorf("complete pending stop before starting stopped gRPC apply %s: %w", apply.ApplyIdentifier, err)
 	}
 	slog.Info("completed pending gRPC stop request before starting stopped remote apply",
@@ -1566,7 +1566,7 @@ func (c *GRPCClient) completePendingStopBeforeRemoteStart(ctx context.Context, a
 }
 
 func hasPendingStartControlRequest(ctx context.Context, store storage.Storage, apply *storage.Apply) (bool, error) {
-	controlReq, err := pendingStartControlRequest(ctx, store, apply)
+	controlReq, err := pendingControlRequest(ctx, store, apply, storage.ControlOperationStart)
 	if err != nil {
 		return false, err
 	}
@@ -1581,7 +1581,7 @@ func hasPendingStartControlRequest(ctx context.Context, store storage.Storage, a
 func (c *GRPCClient) waitForPendingStopBeforeStart(ctx context.Context, apply *storage.Apply, scope applyTaskScope, startControlReq *storage.ApplyControlRequest) (bool, error) {
 	loggedWait := false
 	for {
-		stopReq, err := pendingStopControlRequest(ctx, c.storage, apply)
+		stopReq, err := pendingControlRequest(ctx, c.storage, apply, storage.ControlOperationStop)
 		if err != nil {
 			return false, fmt.Errorf("check pending stop before pending gRPC start for apply %s: %w", apply.ApplyIdentifier, err)
 		}
@@ -1596,7 +1596,7 @@ func (c *GRPCClient) waitForPendingStopBeforeStart(ctx context.Context, apply *s
 			if err != nil {
 				return false, err
 			}
-			stillPending, err := pendingStopControlRequest(ctx, c.storage, apply)
+			stillPending, err := pendingControlRequest(ctx, c.storage, apply, storage.ControlOperationStop)
 			if err != nil {
 				return false, fmt.Errorf("recheck pending stop before deferring pending gRPC start for apply %s: %w", apply.ApplyIdentifier, err)
 			}
@@ -1640,14 +1640,14 @@ func (c *GRPCClient) waitForPendingStopBeforeStart(ctx context.Context, apply *s
 }
 
 func (c *GRPCClient) processPendingStartControlRequest(ctx context.Context, apply *storage.Apply, scope applyTaskScope) error {
-	controlReq, err := pendingStartControlRequest(ctx, c.storage, apply)
+	controlReq, err := pendingControlRequest(ctx, c.storage, apply, storage.ControlOperationStart)
 	if err != nil {
 		return err
 	}
 	if controlReq == nil {
 		return nil
 	}
-	if stopReq, err := pendingStopControlRequest(ctx, c.storage, apply); err != nil {
+	if stopReq, err := pendingControlRequest(ctx, c.storage, apply, storage.ControlOperationStop); err != nil {
 		return fmt.Errorf("check pending stop before pending gRPC start for apply %s: %w", apply.ApplyIdentifier, err)
 	} else if stopReq != nil {
 		slog.Info("pending gRPC start request is waiting for pending stop request to finish",
@@ -1666,7 +1666,7 @@ func (c *GRPCClient) processPendingStartControlRequest(ctx context.Context, appl
 	remoteID := scope.remoteApplyID(apply)
 	if remoteID == "" {
 		message := fmt.Sprintf("gRPC apply %s is waiting for deploy without a remote apply id; start dispatch state is ambiguous", apply.ApplyIdentifier)
-		if err := failPendingStartControlRequests(ctx, c.storage, apply, message); err != nil {
+		if err := failPendingControlRequests(ctx, c.storage, apply, storage.ControlOperationStart, message); err != nil {
 			return err
 		}
 		return errors.New(message)
@@ -1683,7 +1683,7 @@ func (c *GRPCClient) processPendingStartControlRequest(ctx context.Context, appl
 			"database", apply.Database,
 			"environment", apply.Environment,
 			"error", err)
-		if failErr := failPendingStartControlRequests(ctx, c.storage, apply, message); failErr != nil {
+		if failErr := failPendingControlRequests(ctx, c.storage, apply, storage.ControlOperationStart, message); failErr != nil {
 			return failErr
 		}
 		return fmt.Errorf("start gRPC deferred deploy %s: %w", apply.ApplyIdentifier, err)
@@ -2081,7 +2081,7 @@ func (c *GRPCClient) completeApplyStartRequestForScope(ctx context.Context, appl
 			"environment", apply.Environment)
 		return nil
 	}
-	return completePendingStartControlRequests(ctx, c.storage, apply)
+	return completePendingControlRequests(ctx, c.storage, apply, storage.ControlOperationStart)
 }
 
 // persistParentApply writes the parent applies row unless the drive is a
@@ -2247,7 +2247,7 @@ func (c *GRPCClient) reconcileTerminalRemoteProgress(ctx context.Context, remote
 		}
 		if storedApply != nil && state.IsTerminalApplyState(storedApply.State) {
 			if scope.suppressesDirectParentApplyWrites() {
-				controlReq, err := pendingStopControlRequest(ctx, c.storage, storedApply)
+				controlReq, err := pendingControlRequest(ctx, c.storage, storedApply, storage.ControlOperationStop)
 				if err != nil {
 					return fmt.Errorf("check pending stop after terminal remote progress for apply %s: %w", storedApply.ApplyIdentifier, err)
 				}
@@ -2256,7 +2256,7 @@ func (c *GRPCClient) reconcileTerminalRemoteProgress(ctx context.Context, remote
 				}
 				return nil
 			}
-			if err := completePendingStopControlRequests(ctx, c.storage, storedApply); err != nil {
+			if err := completePendingControlRequests(ctx, c.storage, storedApply, storage.ControlOperationStop); err != nil {
 				return err
 			}
 		}
@@ -2310,7 +2310,7 @@ func (c *GRPCClient) persistTerminalStateFromRemote(ctx context.Context, storedA
 	if err := c.storage.Applies().Update(ctx, storedApply); err != nil {
 		return fmt.Errorf("update terminal remote gRPC apply %s: %w", storedApply.ApplyIdentifier, err)
 	}
-	if err := completePendingStopControlRequests(ctx, c.storage, storedApply); err != nil {
+	if err := completePendingControlRequests(ctx, c.storage, storedApply, storage.ControlOperationStop); err != nil {
 		return err
 	}
 	// Stopped is a terminal apply state, but it is not completion of a pending
@@ -2318,7 +2318,7 @@ func (c *GRPCClient) persistTerminalStateFromRemote(ctx context.Context, storedA
 	// recording the stop; leave that request pending so the operator can claim
 	// the stopped row and perform the resume.
 	if !state.IsState(storedApply.State, state.Apply.Stopped) {
-		if err := completePendingStartControlRequests(ctx, c.storage, storedApply); err != nil {
+		if err := completePendingControlRequests(ctx, c.storage, storedApply, storage.ControlOperationStart); err != nil {
 			return err
 		}
 	}
@@ -2713,7 +2713,7 @@ func (c *GRPCClient) pollForCompletion(ctx context.Context, apply *storage.Apply
 					if err := c.reconcileTerminalRemoteProgress(ctx, apply, resp.Tables, now, scope); err != nil {
 						return fmt.Errorf("persist stopped gRPC apply %s after start grace period: %w", apply.ApplyIdentifier, err)
 					}
-					if err := failPendingStartControlRequests(ctx, c.storage, apply, message); err != nil {
+					if err := failPendingControlRequests(ctx, c.storage, apply, storage.ControlOperationStart, message); err != nil {
 						return err
 					}
 					return fmt.Errorf("start accepted for gRPC apply %s but %s", apply.ApplyIdentifier, message)

--- a/pkg/tern/local_apply_grouped.go
+++ b/pkg/tern/local_apply_grouped.go
@@ -732,7 +732,7 @@ func (c *LocalClient) handleAtomicProgressTick(ctx context.Context, eng engine.E
 			"stored_state", freshApply.State,
 			"progress_state", apply.State)
 		*apply = *freshApply
-		if err := completePendingStopControlRequests(ctx, c.storage, apply); err != nil {
+		if err := completePendingControlRequests(ctx, c.storage, apply, storage.ControlOperationStop); err != nil {
 			c.logger.Warn("failed to complete pending stop request for terminal apply; current apply owner will exit for operator retry",
 				"apply_id", apply.ApplyIdentifier, "error", err)
 			return true
@@ -779,7 +779,7 @@ func (c *LocalClient) handleAtomicProgressTick(ctx context.Context, eng engine.E
 				"apply_id", apply.ApplyIdentifier, "expected_state", expectedState, "derived_state", apply.State)
 			return true
 		}
-		if err := completePendingStopControlRequests(ctx, c.storage, apply); err != nil {
+		if err := completePendingControlRequests(ctx, c.storage, apply, storage.ControlOperationStop); err != nil {
 			c.logger.Warn("failed to complete pending stop request after terminal progress reconciliation; current apply owner will exit for operator retry",
 				"apply_id", apply.ApplyIdentifier, "error", err)
 			return true

--- a/pkg/tern/local_apply_sequential.go
+++ b/pkg/tern/local_apply_sequential.go
@@ -418,7 +418,7 @@ func (c *LocalClient) finalizeSequentialApply(ctx context.Context, apply *storag
 			"apply_id", apply.ApplyIdentifier,
 			"stored_state", freshApply.State)
 		*apply = *freshApply
-		if err := completePendingStopControlRequests(ctx, c.storage, apply); err != nil {
+		if err := completePendingControlRequests(ctx, c.storage, apply, storage.ControlOperationStop); err != nil {
 			c.logger.Warn("failed to complete pending stop request for terminal sequential apply",
 				"apply_id", apply.ApplyIdentifier, "error", err)
 		}
@@ -449,7 +449,7 @@ func (c *LocalClient) finalizeSequentialApply(ctx context.Context, apply *storag
 		c.logger.Error("failed to update apply state", "apply_id", apply.ApplyIdentifier, "state", apply.State, "error", err)
 	}
 	if state.IsTerminalApplyState(apply.State) {
-		if err := completePendingStopControlRequests(ctx, c.storage, apply); err != nil {
+		if err := completePendingControlRequests(ctx, c.storage, apply, storage.ControlOperationStop); err != nil {
 			c.logger.Warn("failed to complete pending stop request after sequential finalization",
 				"apply_id", apply.ApplyIdentifier, "error", err)
 			return

--- a/pkg/tern/local_client_test.go
+++ b/pkg/tern/local_client_test.go
@@ -1617,7 +1617,7 @@ func TestPrepareStoppedTasksForResumeQueuesOnlyStoppedTasks(t *testing.T) {
 			}
 			apply := &storage.Apply{ID: 123, State: applyState}
 
-			controlReq, err := pendingStartControlRequest(t.Context(), client.storage, apply)
+			controlReq, err := pendingControlRequest(t.Context(), client.storage, apply, storage.ControlOperationStart)
 			require.NoError(t, err)
 			client.prepareStoppedTasksForResume(t.Context(), apply, []*storage.Task{stoppedTask, completedTask}, controlReq != nil)
 

--- a/pkg/tern/local_control.go
+++ b/pkg/tern/local_control.go
@@ -129,7 +129,7 @@ func (c *LocalClient) cutover(ctx context.Context, req *ternv1.CutoverRequest, c
 			ErrorMessage: "Schema change is recovering after restart; cutover will be available once recovery completes.",
 		}, nil
 	}
-	if controlReq, err := pendingStopControlRequest(ctx, c.storage, apply); err != nil {
+	if controlReq, err := pendingControlRequest(ctx, c.storage, apply, storage.ControlOperationStop); err != nil {
 		return nil, fmt.Errorf("check pending stop request before cutover for apply %s: %w", apply.ApplyIdentifier, err)
 	} else if controlReq != nil {
 		c.logger.Info("cutover blocked because stop request is pending",
@@ -227,7 +227,7 @@ func (c *LocalClient) queueCutoverRequest(ctx context.Context, apply *storage.Ap
 }
 
 func (c *LocalClient) processPendingCutoverControlRequest(ctx context.Context, apply *storage.Apply) error {
-	controlReq, err := pendingCutoverControlRequest(ctx, c.storage, apply)
+	controlReq, err := pendingControlRequest(ctx, c.storage, apply, storage.ControlOperationCutover)
 	if err != nil {
 		return err
 	}
@@ -243,11 +243,11 @@ func (c *LocalClient) processPendingCutoverControlRequest(ctx context.Context, a
 			"state", apply.State)
 		c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventCutoverTriggered, storage.LogSourceSchemaBot,
 			fmt.Sprintf("Pending cutover request completed for resolved apply%s", callerApplyLogSuffix(controlRequestCaller(controlReq))), "", "")
-		return completePendingCutoverControlRequests(ctx, c.storage, apply)
+		return completePendingControlRequests(ctx, c.storage, apply, storage.ControlOperationCutover)
 	}
 	if cutoverRequestFailedByApplyState(apply.State) {
 		message := fmt.Sprintf("cutover request was not applied because apply is %s", apply.State)
-		if err := failPendingCutoverControlRequests(ctx, c.storage, apply, message); err != nil {
+		if err := failPendingControlRequests(ctx, c.storage, apply, storage.ControlOperationCutover, message); err != nil {
 			return err
 		}
 		return fmt.Errorf("process pending cutover for apply %s: %s", apply.ApplyIdentifier, message)
@@ -274,7 +274,7 @@ func (c *LocalClient) processPendingCutoverControlRequest(ctx context.Context, a
 			"state", apply.State)
 		return nil
 	}
-	if stopReq, err := pendingStopControlRequest(ctx, c.storage, apply); err != nil {
+	if stopReq, err := pendingControlRequest(ctx, c.storage, apply, storage.ControlOperationStop); err != nil {
 		return fmt.Errorf("check pending stop request before pending cutover for apply %s: %w", apply.ApplyIdentifier, err)
 	} else if stopReq != nil {
 		message := "schema change has a pending stop request; cutover is blocked until stop is processed"
@@ -289,14 +289,14 @@ func (c *LocalClient) processPendingCutoverControlRequest(ctx context.Context, a
 	}, controlRequestCaller(controlReq))
 	if err != nil {
 		errorMessage := err.Error()
-		if failErr := failPendingCutoverControlRequests(ctx, c.storage, apply, errorMessage); failErr != nil {
+		if failErr := failPendingControlRequests(ctx, c.storage, apply, storage.ControlOperationCutover, errorMessage); failErr != nil {
 			return fmt.Errorf("process pending cutover for apply %s: %w; fail pending cutover request: %w", apply.ApplyIdentifier, err, failErr)
 		}
 		return fmt.Errorf("process pending cutover for apply %s: %w", apply.ApplyIdentifier, err)
 	}
 	if resp == nil {
 		errorMessage := "not accepted"
-		if err := failPendingCutoverControlRequests(ctx, c.storage, apply, errorMessage); err != nil {
+		if err := failPendingControlRequests(ctx, c.storage, apply, storage.ControlOperationCutover, errorMessage); err != nil {
 			return err
 		}
 		return fmt.Errorf("process pending cutover for apply %s: %s", apply.ApplyIdentifier, errorMessage)
@@ -306,12 +306,12 @@ func (c *LocalClient) processPendingCutoverControlRequest(ctx context.Context, a
 		if resp.ErrorMessage != "" {
 			errorMessage = resp.ErrorMessage
 		}
-		if err := failPendingCutoverControlRequests(ctx, c.storage, apply, errorMessage); err != nil {
+		if err := failPendingControlRequests(ctx, c.storage, apply, storage.ControlOperationCutover, errorMessage); err != nil {
 			return err
 		}
 		return fmt.Errorf("process pending cutover for apply %s: %s", apply.ApplyIdentifier, errorMessage)
 	}
-	if err := completePendingCutoverControlRequests(ctx, c.storage, apply); err != nil {
+	if err := completePendingControlRequests(ctx, c.storage, apply, storage.ControlOperationCutover); err != nil {
 		return err
 	}
 	c.logger.Info("pending cutover request accepted and completed",
@@ -547,7 +547,7 @@ func (c *LocalClient) stopHandledUnlessStartPending(ctx context.Context, apply *
 }
 
 func (c *LocalClient) processPendingStopControlRequest(ctx context.Context, apply *storage.Apply) (bool, error) {
-	controlReq, err := pendingStopControlRequest(ctx, c.storage, apply)
+	controlReq, err := pendingControlRequest(ctx, c.storage, apply, storage.ControlOperationStop)
 	if err != nil {
 		return false, err
 	}
@@ -572,7 +572,7 @@ func (c *LocalClient) processPendingStopControlRequest(ctx context.Context, appl
 			"state", apply.State)
 		c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventStopRequested, storage.LogSourceSchemaBot,
 			fmt.Sprintf("Pending stop request completed for terminal apply%s", callerApplyLogSuffix(controlRequestCaller(controlReq))), "", "")
-		if err := completePendingStopControlRequests(ctx, c.storage, apply); err != nil {
+		if err := completePendingControlRequests(ctx, c.storage, apply, storage.ControlOperationStop); err != nil {
 			return true, err
 		}
 		return c.stopHandledUnlessStartPending(ctx, apply)
@@ -592,7 +592,7 @@ func (c *LocalClient) processPendingStopControlRequest(ctx context.Context, appl
 			"state", apply.State)
 		c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelWarn, storage.LogEventStopRequested, storage.LogSourceSchemaBot,
 			fmt.Sprintf("Pending stop request rejected: %s%s", message, callerApplyLogSuffix(controlRequestCaller(controlReq))), "", "")
-		if err := failPendingStopControlRequests(ctx, c.storage, apply, message); err != nil {
+		if err := failPendingControlRequests(ctx, c.storage, apply, storage.ControlOperationStop, message); err != nil {
 			return true, err
 		}
 		return true, nil

--- a/pkg/tern/local_control_resume.go
+++ b/pkg/tern/local_control_resume.go
@@ -213,14 +213,14 @@ func (c *LocalClient) startDeferredDeploy(ctx context.Context, apply *storage.Ap
 }
 
 func (c *LocalClient) processPendingStartControlRequest(ctx context.Context, apply *storage.Apply, options map[string]string, releaseAtCutoverBarrier bool) (bool, error) {
-	controlReq, err := pendingStartControlRequest(ctx, c.storage, apply)
+	controlReq, err := pendingControlRequest(ctx, c.storage, apply, storage.ControlOperationStart)
 	if err != nil {
 		return false, err
 	}
 	if controlReq == nil {
 		return false, nil
 	}
-	if stopReq, err := pendingStopControlRequest(ctx, c.storage, apply); err != nil {
+	if stopReq, err := pendingControlRequest(ctx, c.storage, apply, storage.ControlOperationStop); err != nil {
 		return true, fmt.Errorf("check pending stop before pending start for apply %s: %w", apply.ApplyIdentifier, err)
 	} else if stopReq != nil {
 		c.logger.Info("pending start request is waiting for pending stop request to finish",
@@ -237,7 +237,7 @@ func (c *LocalClient) processPendingStartControlRequest(ctx context.Context, app
 	}
 	started, err := c.startDeferredDeploy(ctx, apply, controlRequestCaller(controlReq))
 	if err != nil {
-		if failErr := failPendingStartControlRequests(ctx, c.storage, apply, err.Error()); failErr != nil {
+		if failErr := failPendingControlRequests(ctx, c.storage, apply, storage.ControlOperationStart, err.Error()); failErr != nil {
 			return true, fmt.Errorf("process pending start for apply %s: %w; fail pending start request: %w", apply.ApplyIdentifier, err, failErr)
 		}
 		return true, fmt.Errorf("process pending start for apply %s: %w", apply.ApplyIdentifier, err)
@@ -248,7 +248,7 @@ func (c *LocalClient) processPendingStartControlRequest(ctx context.Context, app
 		if resp != nil && resp.ErrorMessage != "" {
 			errorMessage = resp.ErrorMessage
 		}
-		if err := failPendingStartControlRequests(ctx, c.storage, apply, errorMessage); err != nil {
+		if err := failPendingControlRequests(ctx, c.storage, apply, storage.ControlOperationStart, errorMessage); err != nil {
 			return true, err
 		}
 		return true, fmt.Errorf("process pending start for apply %s: %s", apply.ApplyIdentifier, errorMessage)
@@ -261,7 +261,7 @@ func (c *LocalClient) processPendingStartControlRequest(ctx context.Context, app
 	if err := c.storage.Applies().Update(ctx, apply); err != nil {
 		return true, fmt.Errorf("update started deferred deploy apply %s: %w", apply.ApplyIdentifier, err)
 	}
-	if err := completePendingStartControlRequests(ctx, c.storage, apply); err != nil {
+	if err := completePendingControlRequests(ctx, c.storage, apply, storage.ControlOperationStart); err != nil {
 		return true, err
 	}
 	c.logger.Info("pending start request accepted and completed",
@@ -601,7 +601,7 @@ func (c *LocalClient) launchAtomicResume(ctx context.Context, apply *storage.App
 			return fmt.Errorf("mark grouped resume apply %s completed after final schema check: %w", apply.ApplyIdentifier, err)
 		}
 		if startRequested {
-			if err := completePendingStartControlRequests(ctx, c.storage, apply); err != nil {
+			if err := completePendingControlRequests(ctx, c.storage, apply, storage.ControlOperationStart); err != nil {
 				return err
 			}
 		}
@@ -696,7 +696,7 @@ func (c *LocalClient) launchAtomicResume(ctx context.Context, apply *storage.App
 			return fmt.Errorf("mark grouped resume apply %s %s: %w", apply.ApplyIdentifier, apply.State, err)
 		}
 		if startRequested {
-			if err := completePendingStartControlRequests(ctx, c.storage, apply); err != nil {
+			if err := completePendingControlRequests(ctx, c.storage, apply, storage.ControlOperationStart); err != nil {
 				return err
 			}
 		}
@@ -1065,7 +1065,7 @@ func (c *LocalClient) resumeApplyWithTasks(ctx context.Context, apply *storage.A
 		c.notifyTerminalObserver(apply, tasks)
 		return nil
 	}
-	startControlReq, err := pendingStartControlRequest(ctx, c.storage, apply)
+	startControlReq, err := pendingControlRequest(ctx, c.storage, apply, storage.ControlOperationStart)
 	if err != nil {
 		return err
 	}
@@ -1082,7 +1082,7 @@ func (c *LocalClient) resumeApplyWithTasks(ctx context.Context, apply *storage.A
 			c.logger.Error("failed to update apply state", "apply_id", apply.ApplyIdentifier, "state", state.Apply.Completed, "error", err)
 		}
 		if startRequested {
-			if err := completePendingStartControlRequests(ctx, c.storage, apply); err != nil {
+			if err := completePendingControlRequests(ctx, c.storage, apply, storage.ControlOperationStart); err != nil {
 				return err
 			}
 		}
@@ -1119,7 +1119,7 @@ func (c *LocalClient) resumeApplyWithTasks(ctx context.Context, apply *storage.A
 			return fmt.Errorf("mark sequential resume apply %s running: %w", apply.ApplyIdentifier, err)
 		}
 		if startRequested {
-			if err := completePendingStartControlRequests(ctx, c.storage, apply); err != nil {
+			if err := completePendingControlRequests(ctx, c.storage, apply, storage.ControlOperationStart); err != nil {
 				return err
 			}
 		}
@@ -1157,7 +1157,7 @@ func (c *LocalClient) handleGroupedResumeFailure(ctx context.Context, apply *sto
 		fmt.Sprintf("Recovery failed: %v", err), apply.State, state.Apply.Failed)
 	c.failApplyWithTasks(ctx, apply, tasks, err.Error())
 	if startRequested {
-		if failErr := failPendingStartControlRequests(ctx, c.storage, apply, err.Error()); failErr != nil {
+		if failErr := failPendingControlRequests(ctx, c.storage, apply, storage.ControlOperationStart, err.Error()); failErr != nil {
 			return failErr
 		}
 	}

--- a/pkg/tern/routing_client.go
+++ b/pkg/tern/routing_client.go
@@ -178,109 +178,77 @@ func (c *RoutingClient) Apply(ctx context.Context, req *ternv1.ApplyRequest) (*t
 	return resp, err
 }
 
-// Progress returns detailed progress for an active schema change.
-func (c *RoutingClient) Progress(ctx context.Context, req *ternv1.ProgressRequest) (*ternv1.ProgressResponse, error) {
+// routeApply resolves the deployment client for an apply-scoped request, then
+// dispatches a clone whose apply id is rewritten to the deployment-local tern
+// apply id and whose environment is normalized to the stored apply. The
+// operation name is used for routing context and the missing-request error.
+func routeApply[T any, PT applyScopedRequest[T], Resp any](
+	ctx context.Context,
+	c *RoutingClient,
+	req PT,
+	operation string,
+	setIdentity func(req PT, ternApplyID, environment string),
+	dispatch func(client Client, ctx context.Context, req PT) (*Resp, error),
+) (*Resp, error) {
 	if req == nil {
-		return nil, fmt.Errorf("progress request is required")
+		return nil, fmt.Errorf("%s request is required", operation)
 	}
-	client, apply, ternApplyID, err := c.clientForApply(ctx, req.ApplyId, req.Environment, "progress")
+	client, apply, ternApplyID, err := c.clientForApply(ctx, req.GetApplyId(), req.GetEnvironment(), operation)
 	if err != nil {
 		return nil, err
 	}
-	routedReq := proto.Clone(req).(*ternv1.ProgressRequest)
-	routedReq.ApplyId = ternApplyID
-	routedReq.Environment = apply.Environment
-	return client.Progress(ctx, routedReq)
+	routedReq := proto.Clone(req).(PT)
+	setIdentity(routedReq, ternApplyID, apply.Environment)
+	return dispatch(client, ctx, routedReq)
+}
+
+// Progress returns detailed progress for an active schema change.
+func (c *RoutingClient) Progress(ctx context.Context, req *ternv1.ProgressRequest) (*ternv1.ProgressResponse, error) {
+	return routeApply(ctx, c, req, "progress", func(r *ternv1.ProgressRequest, applyID, environment string) {
+		r.ApplyId, r.Environment = applyID, environment
+	}, Client.Progress)
 }
 
 // Cutover triggers the cutover phase when defer_cutover was used.
 func (c *RoutingClient) Cutover(ctx context.Context, req *ternv1.CutoverRequest) (*ternv1.CutoverResponse, error) {
-	if req == nil {
-		return nil, fmt.Errorf("cutover request is required")
-	}
-	client, apply, ternApplyID, err := c.clientForApply(ctx, req.ApplyId, req.Environment, "cutover")
-	if err != nil {
-		return nil, err
-	}
-	routedReq := proto.Clone(req).(*ternv1.CutoverRequest)
-	routedReq.ApplyId = ternApplyID
-	routedReq.Environment = apply.Environment
-	return client.Cutover(ctx, routedReq)
+	return routeApply(ctx, c, req, "cutover", func(r *ternv1.CutoverRequest, applyID, environment string) {
+		r.ApplyId, r.Environment = applyID, environment
+	}, Client.Cutover)
 }
 
 // Stop pauses an in-progress schema change.
 func (c *RoutingClient) Stop(ctx context.Context, req *ternv1.StopRequest) (*ternv1.StopResponse, error) {
-	if req == nil {
-		return nil, fmt.Errorf("stop request is required")
-	}
-	client, apply, ternApplyID, err := c.clientForApply(ctx, req.ApplyId, req.Environment, "stop")
-	if err != nil {
-		return nil, err
-	}
-	routedReq := proto.Clone(req).(*ternv1.StopRequest)
-	routedReq.ApplyId = ternApplyID
-	routedReq.Environment = apply.Environment
-	return client.Stop(ctx, routedReq)
+	return routeApply(ctx, c, req, "stop", func(r *ternv1.StopRequest, applyID, environment string) {
+		r.ApplyId, r.Environment = applyID, environment
+	}, Client.Stop)
 }
 
 // Start resumes a stopped schema change.
 func (c *RoutingClient) Start(ctx context.Context, req *ternv1.StartRequest) (*ternv1.StartResponse, error) {
-	if req == nil {
-		return nil, fmt.Errorf("start request is required")
-	}
-	client, apply, ternApplyID, err := c.clientForApply(ctx, req.ApplyId, req.Environment, "start")
-	if err != nil {
-		return nil, err
-	}
-	routedReq := proto.Clone(req).(*ternv1.StartRequest)
-	routedReq.ApplyId = ternApplyID
-	routedReq.Environment = apply.Environment
-	return client.Start(ctx, routedReq)
+	return routeApply(ctx, c, req, "start", func(r *ternv1.StartRequest, applyID, environment string) {
+		r.ApplyId, r.Environment = applyID, environment
+	}, Client.Start)
 }
 
 // Volume modifies the schema change speed/concurrency in-flight.
 func (c *RoutingClient) Volume(ctx context.Context, req *ternv1.VolumeRequest) (*ternv1.VolumeResponse, error) {
-	if req == nil {
-		return nil, fmt.Errorf("volume request is required")
-	}
-	client, apply, ternApplyID, err := c.clientForApply(ctx, req.ApplyId, req.Environment, "volume")
-	if err != nil {
-		return nil, err
-	}
-	routedReq := proto.Clone(req).(*ternv1.VolumeRequest)
-	routedReq.ApplyId = ternApplyID
-	routedReq.Environment = apply.Environment
-	return client.Volume(ctx, routedReq)
+	return routeApply(ctx, c, req, "volume", func(r *ternv1.VolumeRequest, applyID, environment string) {
+		r.ApplyId, r.Environment = applyID, environment
+	}, Client.Volume)
 }
 
 // Revert reverts a completed schema change during the revert window.
 func (c *RoutingClient) Revert(ctx context.Context, req *ternv1.RevertRequest) (*ternv1.RevertResponse, error) {
-	if req == nil {
-		return nil, fmt.Errorf("revert request is required")
-	}
-	client, apply, ternApplyID, err := c.clientForApply(ctx, req.ApplyId, req.Environment, "revert")
-	if err != nil {
-		return nil, err
-	}
-	routedReq := proto.Clone(req).(*ternv1.RevertRequest)
-	routedReq.ApplyId = ternApplyID
-	routedReq.Environment = apply.Environment
-	return client.Revert(ctx, routedReq)
+	return routeApply(ctx, c, req, "revert", func(r *ternv1.RevertRequest, applyID, environment string) {
+		r.ApplyId, r.Environment = applyID, environment
+	}, Client.Revert)
 }
 
 // SkipRevert skips the revert window and finalizes the schema change.
 func (c *RoutingClient) SkipRevert(ctx context.Context, req *ternv1.SkipRevertRequest) (*ternv1.SkipRevertResponse, error) {
-	if req == nil {
-		return nil, fmt.Errorf("skip revert request is required")
-	}
-	client, apply, ternApplyID, err := c.clientForApply(ctx, req.ApplyId, req.Environment, "skip revert")
-	if err != nil {
-		return nil, err
-	}
-	routedReq := proto.Clone(req).(*ternv1.SkipRevertRequest)
-	routedReq.ApplyId = ternApplyID
-	routedReq.Environment = apply.Environment
-	return client.SkipRevert(ctx, routedReq)
+	return routeApply(ctx, c, req, "skip revert", func(r *ternv1.SkipRevertRequest, applyID, environment string) {
+		r.ApplyId, r.Environment = applyID, environment
+	}, Client.SkipRevert)
 }
 
 // Health is not routable without a specific deployment and environment.

--- a/pkg/tern/target_router.go
+++ b/pkg/tern/target_router.go
@@ -194,95 +194,69 @@ func planAuthoritativeField(name, planID, requested, planValue string) (string, 
 	return planValue, nil
 }
 
-// Progress returns progress for a stored apply by routing through its target.
-func (r *TargetRouter) Progress(ctx context.Context, req *ternv1.ProgressRequest) (*ternv1.ProgressResponse, error) {
+// applyScopedRequest is implemented by the apply-scoped tern request protos,
+// which all carry an apply id and environment used to route to a deployment.
+type applyScopedRequest[T any] interface {
+	*T
+	proto.Message
+	GetApplyId() string
+	GetEnvironment() string
+}
+
+// routeStoredApply resolves the target client for an apply-scoped request and
+// dispatches the request to it, attaching any registered progress observer. The
+// operation name is used for routing context and the missing-request error.
+func routeStoredApply[T any, PT applyScopedRequest[T], Resp any](
+	ctx context.Context,
+	r *TargetRouter,
+	req PT,
+	operation string,
+	dispatch func(client Client, ctx context.Context, req PT) (*Resp, error),
+) (*Resp, error) {
 	if req == nil {
-		return nil, fmt.Errorf("progress request is required")
+		return nil, fmt.Errorf("%s request is required", operation)
 	}
-	client, apply, err := r.clientForApplyIdentifier(ctx, req.ApplyId, req.Environment, "progress")
+	client, apply, err := r.clientForApplyIdentifier(ctx, req.GetApplyId(), req.GetEnvironment(), operation)
 	if err != nil {
 		return nil, err
 	}
 	r.attachObserver(client, apply.ID)
-	return client.Progress(ctx, req)
+	return dispatch(client, ctx, req)
+}
+
+// Progress returns progress for a stored apply by routing through its target.
+func (r *TargetRouter) Progress(ctx context.Context, req *ternv1.ProgressRequest) (*ternv1.ProgressResponse, error) {
+	return routeStoredApply(ctx, r, req, "progress", Client.Progress)
 }
 
 // Cutover triggers cutover for a stored apply by routing through its target.
 func (r *TargetRouter) Cutover(ctx context.Context, req *ternv1.CutoverRequest) (*ternv1.CutoverResponse, error) {
-	if req == nil {
-		return nil, fmt.Errorf("cutover request is required")
-	}
-	client, apply, err := r.clientForApplyIdentifier(ctx, req.ApplyId, req.Environment, "cutover")
-	if err != nil {
-		return nil, err
-	}
-	r.attachObserver(client, apply.ID)
-	return client.Cutover(ctx, req)
+	return routeStoredApply(ctx, r, req, "cutover", Client.Cutover)
 }
 
 // Stop pauses a stored apply by routing through its target.
 func (r *TargetRouter) Stop(ctx context.Context, req *ternv1.StopRequest) (*ternv1.StopResponse, error) {
-	if req == nil {
-		return nil, fmt.Errorf("stop request is required")
-	}
-	client, apply, err := r.clientForApplyIdentifier(ctx, req.ApplyId, req.Environment, "stop")
-	if err != nil {
-		return nil, err
-	}
-	r.attachObserver(client, apply.ID)
-	return client.Stop(ctx, req)
+	return routeStoredApply(ctx, r, req, "stop", Client.Stop)
 }
 
 // Start resumes a stored apply by routing through its target.
 func (r *TargetRouter) Start(ctx context.Context, req *ternv1.StartRequest) (*ternv1.StartResponse, error) {
-	if req == nil {
-		return nil, fmt.Errorf("start request is required")
-	}
-	client, apply, err := r.clientForApplyIdentifier(ctx, req.ApplyId, req.Environment, "start")
-	if err != nil {
-		return nil, err
-	}
-	r.attachObserver(client, apply.ID)
-	return client.Start(ctx, req)
+	return routeStoredApply(ctx, r, req, "start", Client.Start)
 }
 
 // Volume modifies a stored apply by routing through its target.
 func (r *TargetRouter) Volume(ctx context.Context, req *ternv1.VolumeRequest) (*ternv1.VolumeResponse, error) {
-	if req == nil {
-		return nil, fmt.Errorf("volume request is required")
-	}
-	client, apply, err := r.clientForApplyIdentifier(ctx, req.ApplyId, req.Environment, "volume")
-	if err != nil {
-		return nil, err
-	}
-	r.attachObserver(client, apply.ID)
-	return client.Volume(ctx, req)
+	return routeStoredApply(ctx, r, req, "volume", Client.Volume)
 }
 
 // Revert reverts a stored apply by routing through its target.
 func (r *TargetRouter) Revert(ctx context.Context, req *ternv1.RevertRequest) (*ternv1.RevertResponse, error) {
-	if req == nil {
-		return nil, fmt.Errorf("revert request is required")
-	}
-	client, apply, err := r.clientForApplyIdentifier(ctx, req.ApplyId, req.Environment, "revert")
-	if err != nil {
-		return nil, err
-	}
-	r.attachObserver(client, apply.ID)
-	return client.Revert(ctx, req)
+	return routeStoredApply(ctx, r, req, "revert", Client.Revert)
 }
 
 // SkipRevert skips the revert window for a stored apply by routing through its target.
 func (r *TargetRouter) SkipRevert(ctx context.Context, req *ternv1.SkipRevertRequest) (*ternv1.SkipRevertResponse, error) {
-	if req == nil {
-		return nil, fmt.Errorf("skip revert request is required")
-	}
-	client, apply, err := r.clientForApplyIdentifier(ctx, req.ApplyId, req.Environment, "skip revert")
-	if err != nil {
-		return nil, err
-	}
-	r.attachObserver(client, apply.ID)
-	return client.SkipRevert(ctx, req)
+	return routeStoredApply(ctx, r, req, "skip revert", Client.SkipRevert)
 }
 
 // Health checks storage connectivity for the data-plane router.

--- a/pkg/webhook/control.go
+++ b/pkg/webhook/control.go
@@ -3,6 +3,7 @@ package webhook
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/block/schemabot/pkg/api"
 	"github.com/block/schemabot/pkg/apitypes"
@@ -125,58 +126,84 @@ func (h *Handler) loadApplyForPRControl(ctx context.Context, repo string, pr int
 	return apply, true
 }
 
+// runControlCommand runs the shared lifecycle of a PR control command and
+// returns the typed response only when the operation was accepted. It loads and
+// authorizes the apply, executes the operation, and converts any failure
+// (error, missing response, or rejection) into a PR comment. On a non-nil
+// return the caller renders the operation-specific acceptance comment.
+func runControlCommand[R any](
+	h *Handler,
+	ctx context.Context,
+	repo string, pr int, installationID int64, requestedBy string,
+	result CommandResult,
+	actionName string,
+	execute func(ctx context.Context, req apitypes.ControlRequest) (*R, error),
+	accepted func(*R) bool,
+	errorMessage func(*R) string,
+) *R {
+	apply, ok := h.loadApplyForPRControl(ctx, repo, pr, installationID, requestedBy, result, actionName)
+	if !ok {
+		return nil
+	}
+	client, blocked := h.actorAuthorizationClient(repo, pr, installationID, requestedBy, apply.Database, result.Environment, actionName)
+	if blocked {
+		return nil
+	}
+	if blocked := h.enforcePRCommandActorAuthorization(ctx, client, repo, pr, installationID, requestedBy, apply.Database, apply.DatabaseType, result.Environment, actionName); blocked {
+		return nil
+	}
+
+	caller := fmt.Sprintf("github:%s@%s#%d", requestedBy, repo, pr)
+	resp, err := execute(ctx, apitypes.ControlRequest{
+		ApplyID:     result.ApplyID,
+		Environment: result.Environment,
+		Caller:      caller,
+	})
+	if err != nil {
+		h.logControlCommandError(actionName, repo, pr, result.ApplyID, result.Environment, requestedBy, err)
+		h.postCommandError(repo, pr, installationID, actionName, result.Environment, requestedBy, err.Error())
+		return nil
+	}
+	if resp == nil {
+		h.logger.Error(actionName+" PR command returned no response",
+			"repo", repo,
+			"pr", pr,
+			"apply_id", result.ApplyID,
+			"environment", result.Environment,
+			"requested_by", requestedBy)
+		h.postCommandError(repo, pr, installationID, actionName, result.Environment, requestedBy,
+			fmt.Sprintf("SchemaBot accepted the %s command but returned no response", actionName))
+		return nil
+	}
+	if !accepted(resp) {
+		detail := errorMessage(resp)
+		if detail == "" {
+			detail = strings.ToUpper(actionName[:1]) + actionName[1:] + " was not accepted"
+		}
+		h.logger.Warn(actionName+" PR command was not accepted",
+			"repo", repo,
+			"pr", pr,
+			"apply_id", result.ApplyID,
+			"environment", result.Environment,
+			"requested_by", requestedBy,
+			"error_message", errorMessage(resp))
+		h.postCommandError(repo, pr, installationID, actionName, result.Environment, requestedBy, detail)
+		return nil
+	}
+	return resp
+}
+
 // handleStopCommand handles the "schemabot stop <apply-id> -e <env>" PR
 // comment command by recording durable stop intent for the operator owner.
 func (h *Handler) handleStopCommand(repo string, pr int, installationID int64, requestedBy string, result CommandResult) {
 	ctx, cancel := h.commandContext(commandTimeout)
 	defer cancel()
 
-	apply, ok := h.loadApplyForPRControl(ctx, repo, pr, installationID, requestedBy, result, action.Stop)
-	if !ok {
-		return
-	}
-	client, blocked := h.actorAuthorizationClient(repo, pr, installationID, requestedBy, apply.Database, result.Environment, action.Stop)
-	if blocked {
-		return
-	}
-	if blocked := h.enforcePRCommandActorAuthorization(ctx, client, repo, pr, installationID, requestedBy, apply.Database, apply.DatabaseType, result.Environment, action.Stop); blocked {
-		return
-	}
-
-	caller := fmt.Sprintf("github:%s@%s#%d", requestedBy, repo, pr)
-	resp, err := h.service.ExecuteStop(ctx, apitypes.ControlRequest{
-		ApplyID:     result.ApplyID,
-		Environment: result.Environment,
-		Caller:      caller,
-	})
-	if err != nil {
-		h.logControlCommandError(action.Stop, repo, pr, result.ApplyID, result.Environment, requestedBy, err)
-		h.postCommandError(repo, pr, installationID, action.Stop, result.Environment, requestedBy, err.Error())
-		return
-	}
+	resp := runControlCommand(h, ctx, repo, pr, installationID, requestedBy, result, action.Stop,
+		h.service.ExecuteStop,
+		func(r *apitypes.StopResponse) bool { return r.Accepted },
+		func(r *apitypes.StopResponse) string { return r.ErrorMessage })
 	if resp == nil {
-		h.logger.Error("stop PR command returned no response",
-			"repo", repo,
-			"pr", pr,
-			"apply_id", result.ApplyID,
-			"environment", result.Environment,
-			"requested_by", requestedBy)
-		h.postCommandError(repo, pr, installationID, action.Stop, result.Environment, requestedBy, "SchemaBot accepted the stop command but returned no response")
-		return
-	}
-	if !resp.Accepted {
-		detail := resp.ErrorMessage
-		if detail == "" {
-			detail = "Stop was not accepted"
-		}
-		h.logger.Warn("stop PR command was not accepted",
-			"repo", repo,
-			"pr", pr,
-			"apply_id", result.ApplyID,
-			"environment", result.Environment,
-			"requested_by", requestedBy,
-			"error_message", resp.ErrorMessage)
-		h.postCommandError(repo, pr, installationID, action.Stop, result.Environment, requestedBy, detail)
 		return
 	}
 
@@ -205,52 +232,11 @@ func (h *Handler) handleStartCommand(repo string, pr int, installationID int64, 
 	ctx, cancel := h.commandContext(commandTimeout)
 	defer cancel()
 
-	apply, ok := h.loadApplyForPRControl(ctx, repo, pr, installationID, requestedBy, result, action.Start)
-	if !ok {
-		return
-	}
-	client, blocked := h.actorAuthorizationClient(repo, pr, installationID, requestedBy, apply.Database, result.Environment, action.Start)
-	if blocked {
-		return
-	}
-	if blocked := h.enforcePRCommandActorAuthorization(ctx, client, repo, pr, installationID, requestedBy, apply.Database, apply.DatabaseType, result.Environment, action.Start); blocked {
-		return
-	}
-
-	caller := fmt.Sprintf("github:%s@%s#%d", requestedBy, repo, pr)
-	resp, err := h.service.ExecuteStart(ctx, apitypes.ControlRequest{
-		ApplyID:     result.ApplyID,
-		Environment: result.Environment,
-		Caller:      caller,
-	})
-	if err != nil {
-		h.logControlCommandError(action.Start, repo, pr, result.ApplyID, result.Environment, requestedBy, err)
-		h.postCommandError(repo, pr, installationID, action.Start, result.Environment, requestedBy, err.Error())
-		return
-	}
+	resp := runControlCommand(h, ctx, repo, pr, installationID, requestedBy, result, action.Start,
+		h.service.ExecuteStart,
+		func(r *apitypes.StartResponse) bool { return r.Accepted },
+		func(r *apitypes.StartResponse) string { return r.ErrorMessage })
 	if resp == nil {
-		h.logger.Error("start PR command returned no response",
-			"repo", repo,
-			"pr", pr,
-			"apply_id", result.ApplyID,
-			"environment", result.Environment,
-			"requested_by", requestedBy)
-		h.postCommandError(repo, pr, installationID, action.Start, result.Environment, requestedBy, "SchemaBot accepted the start command but returned no response")
-		return
-	}
-	if !resp.Accepted {
-		detail := resp.ErrorMessage
-		if detail == "" {
-			detail = "Start was not accepted"
-		}
-		h.logger.Warn("start PR command was not accepted",
-			"repo", repo,
-			"pr", pr,
-			"apply_id", result.ApplyID,
-			"environment", result.Environment,
-			"requested_by", requestedBy,
-			"error_message", resp.ErrorMessage)
-		h.postCommandError(repo, pr, installationID, action.Start, result.Environment, requestedBy, detail)
 		return
 	}
 
@@ -279,52 +265,11 @@ func (h *Handler) handleCutoverCommand(repo string, pr int, installationID int64
 	ctx, cancel := h.commandContext(commandTimeout)
 	defer cancel()
 
-	apply, ok := h.loadApplyForPRControl(ctx, repo, pr, installationID, requestedBy, result, action.Cutover)
-	if !ok {
-		return
-	}
-	client, blocked := h.actorAuthorizationClient(repo, pr, installationID, requestedBy, apply.Database, result.Environment, action.Cutover)
-	if blocked {
-		return
-	}
-	if blocked := h.enforcePRCommandActorAuthorization(ctx, client, repo, pr, installationID, requestedBy, apply.Database, apply.DatabaseType, result.Environment, action.Cutover); blocked {
-		return
-	}
-
-	caller := fmt.Sprintf("github:%s@%s#%d", requestedBy, repo, pr)
-	resp, err := h.service.ExecuteCutover(ctx, apitypes.ControlRequest{
-		ApplyID:     result.ApplyID,
-		Environment: result.Environment,
-		Caller:      caller,
-	})
-	if err != nil {
-		h.logControlCommandError(action.Cutover, repo, pr, result.ApplyID, result.Environment, requestedBy, err)
-		h.postCommandError(repo, pr, installationID, action.Cutover, result.Environment, requestedBy, err.Error())
-		return
-	}
+	resp := runControlCommand(h, ctx, repo, pr, installationID, requestedBy, result, action.Cutover,
+		h.service.ExecuteCutover,
+		func(r *apitypes.ControlResponse) bool { return r.Accepted },
+		func(r *apitypes.ControlResponse) string { return r.ErrorMessage })
 	if resp == nil {
-		h.logger.Error("cutover PR command returned no response",
-			"repo", repo,
-			"pr", pr,
-			"apply_id", result.ApplyID,
-			"environment", result.Environment,
-			"requested_by", requestedBy)
-		h.postCommandError(repo, pr, installationID, action.Cutover, result.Environment, requestedBy, "SchemaBot accepted the cutover command but returned no response")
-		return
-	}
-	if !resp.Accepted {
-		detail := resp.ErrorMessage
-		if detail == "" {
-			detail = "Cutover was not accepted"
-		}
-		h.logger.Warn("cutover PR command was not accepted",
-			"repo", repo,
-			"pr", pr,
-			"apply_id", result.ApplyID,
-			"environment", result.Environment,
-			"requested_by", requestedBy,
-			"error_message", resp.ErrorMessage)
-		h.postCommandError(repo, pr, installationID, action.Cutover, result.Environment, requestedBy, detail)
 		return
 	}
 


### PR DESCRIPTION
## Summary

The stop / start / cutover / revert / skip-revert control operations were each implemented by a near-identical block of code copy-pasted across many layers (control-request store helpers, the PlanetScale engine, the CLI API client, the PR-comment command handlers, the two request routers, and the API control-request handlers). This collapses each layer's per-operation duplication behind a single shared helper keyed by the operation, so the operations differ only in the data that is genuinely operation-specific.

**The main benefit: adding the next control operation now touches one shared helper per layer instead of pasting a new ~25–70 line block into each of six files.**

## What

- **`tern/control_requests.go`** — nine `pending/complete/fail` × `start/cutover/stop` helpers become three functions keyed by the control operation; ~50 call sites updated.
- **`planetscale/control.go`** — `controlClient` + `controlDeployRequest` host the shared metadata/client/result plumbing; cutover, revert, and skip-revert become one-line delegations.
- **`cmd/client`** — a generic `callControlAPI[Resp]` replaces five identical request/decode bodies.
- **`webhook/control.go`** — a generic `runControlCommand[R]` owns the shared load → authorize → execute → failure-to-comment lifecycle; each handler supplies only its operation and success render.
- **`tern` routing** — a generic `routeStoredApply`/`routeApply` (driven by an `applyScopedRequest` constraint and `Client.X` method expressions) replaces the per-operation router wrappers.
- **`api/control_handlers.go`** — an operation-keyed `createControlRequest` replaces the per-operation create helpers, and generic `pendingControlResponseIfPresent[R]` / `decodeControlRequestMetadata[M]` / `applyControlRequestStatus` helpers collapse the duplicated pending-response lookup, metadata decode, and status mapping; each operation supplies only its metadata struct and response type.

Behavior, log keys, comment payloads, and error/success messages are preserved exactly; the change is structural.

## Why

The duplicated blocks drifted independently and made every new control operation a multi-file change with high copy-paste risk. Centralizing the shared shape removes that risk and makes the operation-specific differences explicit.

**before:** add a control op = paste a near-identical block into each layer
```
╭──────────────┬──────────────┬──────────────┬──────────────┬──────────────┬──────────────╮
│ control_reqs │ ps engine    │ cli client   │ webhook      │ routers      │ api handlers │
│  +3 funcs    │  +1 method   │  +1 func     │  +1 ~70-line │  +2 wrappers │  +create &   │
│              │              │              │   handler    │              │   response   │
╰──────────────┴──────────────┴──────────────┴──────────────┴──────────────┴──────────────╯
```
**after:** one shared helper per layer; a new op supplies only its specifics
```
╭──────────────┬──────────────┬──────────────┬──────────────┬──────────────┬──────────────╮
│ op-keyed call│ controlDeploy│ callControlAPI│ runControl  │ routeApply   │ createControl│
│              │  Request(...)│   [Resp]     │  Command[R]  │  (op, fn)    │  Request +   │
│              │              │              │              │              │  responses   │
╰──────────────┴──────────────┴──────────────┴──────────────┴──────────────┴──────────────╯
```
