### PR TITLE
feat(github): add tenant-scoped PR command routing

### DIFF
--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -656,7 +656,7 @@ schemabot apply -e staging --allow-unsafe
 | `schemabot rollback <apply-id> -e <env>` | Generate a rollback plan |
 | `schemabot rollback-confirm -e <env>` | Execute a rollback |
 
-**Options**: `-e <env>` environment, `-d <db>` database, `--defer-cutover`, `--allow-unsafe`, `--skip-revert` (Vitess)
+**Options**: `-e <env>` environment, `-d <db>` database, `-t, --tenant <name>` deployment routing, `--defer-cutover`, `--allow-unsafe`, `--skip-revert` (Vitess)
 
 **Quick start**: `plan` → `apply` → `apply-confirm`
 
@@ -684,7 +684,7 @@ That command wasn't recognized. Available commands:
 | `schemabot rollback <apply-id> -e <env>` | Generate a rollback plan |
 | `schemabot rollback-confirm -e <env>` | Execute a rollback |
 
-**Options**: `-e <env>` environment, `-d <db>` database, `--defer-cutover`, `--allow-unsafe`, `--skip-revert` (Vitess)
+**Options**: `-e <env>` environment, `-d <db>` database, `-t, --tenant <name>` deployment routing, `--defer-cutover`, `--allow-unsafe`, `--skip-revert` (Vitess)
 
 **Quick start**: `plan` → `apply` → `apply-confirm`
 
@@ -874,7 +874,7 @@ That command wasn't recognized. Available commands:
 | `schemabot rollback <apply-id> -e <env>` | Generate a rollback plan |
 | `schemabot rollback-confirm -e <env>` | Execute a rollback |
 
-**Options**: `-e <env>` environment, `-d <db>` database, `--defer-cutover`, `--allow-unsafe`, `--skip-revert` (Vitess)
+**Options**: `-e <env>` environment, `-d <db>` database, `-t, --tenant <name>` deployment routing, `--defer-cutover`, `--allow-unsafe`, `--skip-revert` (Vitess)
 
 **Quick start**: `plan` → `apply` → `apply-confirm`
 </details>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,6 +21,7 @@
   - [Staging Instance](#staging-instance)
   - [Production Instance](#production-instance)
   - [Environment-local gRPC targets](#environment-local-grpc-targets)
+  - [Tenant-scoped command routing](#tenant-scoped-command-routing)
   - [How it works](#how-it-works)
   - [Auto-plan behavior](#auto-plan-behavior)
 - [Multi-App Routing](#multi-app-routing)
@@ -573,9 +574,52 @@ tern_deployments:
 
 Do not require the staging ConfigMap to contain production targets, or the production ConfigMap to contain staging targets. Each instance resolves only the environments it owns.
 
+### Tenant-scoped command routing
+
+When multiple isolated SchemaBot deployments are installed on the same
+repository and handle the same environment names, use the server-side `tenant`
+setting to give each deployment a stable command-routing identity:
+
+```yaml
+tenant: alpha
+allowed_environments:
+  - production
+```
+
+A PR comment can then target exactly one deployment:
+
+```text
+schemabot plan -e production --tenant alpha
+schemabot apply -e production --tenant alpha
+schemabot help -t alpha
+```
+
+Only the deployment whose configured `tenant` exactly matches the `--tenant`
+or `-t` flag reacts to the comment or posts a response. Other deployments accept
+the webhook delivery and skip it without adding reactions or comments, the same
+way an environment-scoped deployment skips commands for environments outside
+`allowed_environments`.
+
+This routing identity is deliberately local to the server process. It is not
+stored on plans or applies and it does not change database target resolution.
+The isolated deployment's own storage, chart values, GitHub App configuration,
+and database routing remain the source of truth for the work it owns.
+
+Use `respond_to_unscoped` separately for commands that do not carry `--tenant`.
+For example, if several deployments are installed on the same repository, pick
+one deployment to answer untargeted `schemabot help` and invalid commands by
+leaving `respond_to_unscoped` enabled there and setting it to `false` on the
+others. Operators can still direct help to a specific deployment with
+`schemabot help --tenant <name>` or `schemabot help -t <name>`.
+
 ### How it works
 
 - **Environment scoping:** When `allowed_environments` is set, the instance only processes commands targeting those environments. Commands for other environments (e.g., `schemabot apply -e production` sent to the staging instance) are accepted without a PR response by this deployment. A deployment that allows the requested environment must process its own webhook delivery.
+
+- **Tenant scoping:** When `tenant` is set and a command includes `--tenant`,
+  only the matching deployment processes the command. Tenant scoping is a
+  webhook ownership filter, not a schema-change state field; untargeted commands
+  continue through the existing environment and unscoped-command routing.
 
 - **Per-environment aggregate checks:** Each instance creates its own aggregate check run scoped to its environments (e.g., `SchemaBot (staging)`, `SchemaBot (production)`) instead of the default `SchemaBot` aggregate. Configure branch protection to require both aggregates. Set `github.check-name` when independent SchemaBot gates need distinct visible names; every instance in the same promotion chain should use the same base name.
 

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -92,6 +92,13 @@ type ServerConfig struct {
 	// When empty or nil, all environments are allowed.
 	AllowedEnvironments []string `yaml:"allowed_environments"`
 
+	// Tenant optionally names this isolated SchemaBot instance for PR command
+	// routing. When a PR comment includes `--tenant <name>`, only the instance
+	// with the same configured tenant responds. The value is not persisted on
+	// plans or applies; it only decides whether this webhook delivery is owned by
+	// the current process.
+	Tenant string `yaml:"tenant,omitempty"`
+
 	// EnvironmentOrder defines the server-owned promotion order. Defaults to
 	// staging before production.
 	EnvironmentOrder []string `yaml:"environment_order"`
@@ -916,6 +923,9 @@ func (c *ServerConfig) Validate() error {
 	if err := c.Storage.validateLocalDSNConfig("storage"); err != nil {
 		return err
 	}
+	if c.Tenant != "" && !isValidTenantName(c.Tenant) {
+		return fmt.Errorf("tenant must start with a letter or number and contain only letters, numbers, underscores, or hyphens")
+	}
 
 	if err := c.Auth.Validate(); err != nil {
 		return fmt.Errorf("auth config: %w", err)
@@ -1514,6 +1524,31 @@ func (c *ServerConfig) IsEnvironmentAllowed(env string) bool {
 		return true
 	}
 	return slices.Contains(c.AllowedEnvironments, env)
+}
+
+// ShouldRespondToTenant returns whether this instance should handle a PR
+// command scoped with `--tenant`. Untargeted commands remain eligible for the
+// normal environment and unscoped-command routing. Targeted commands are handled
+// only by the instance whose configured tenant matches exactly.
+func (c *ServerConfig) ShouldRespondToTenant(tenant string) bool {
+	if tenant == "" {
+		return true
+	}
+	return c != nil && c.Tenant == tenant
+}
+
+func isValidTenantName(tenant string) bool {
+	for i, r := range tenant {
+		switch {
+		case r >= 'a' && r <= 'z':
+		case r >= 'A' && r <= 'Z':
+		case r >= '0' && r <= '9':
+		case i > 0 && (r == '_' || r == '-'):
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 // PromotionEnvironmentOrder returns the server-owned environment promotion

--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -2374,6 +2374,78 @@ allowed_environments:
 	})
 }
 
+func TestServerConfig_ShouldRespondToTenant(t *testing.T) {
+	t.Run("untargeted commands are allowed", func(t *testing.T) {
+		cfg := ServerConfig{Tenant: "alpha"}
+		assert.True(t, cfg.ShouldRespondToTenant(""))
+	})
+
+	t.Run("matching tenant is allowed", func(t *testing.T) {
+		cfg := ServerConfig{Tenant: "alpha"}
+		assert.True(t, cfg.ShouldRespondToTenant("alpha"))
+	})
+
+	t.Run("different tenant is rejected", func(t *testing.T) {
+		cfg := ServerConfig{Tenant: "alpha"}
+		assert.False(t, cfg.ShouldRespondToTenant("beta"))
+	})
+
+	t.Run("unset tenant rejects targeted commands", func(t *testing.T) {
+		cfg := ServerConfig{}
+		assert.False(t, cfg.ShouldRespondToTenant("alpha"))
+	})
+
+	t.Run("nil receiver rejects targeted commands", func(t *testing.T) {
+		var cfg *ServerConfig
+		assert.False(t, cfg.ShouldRespondToTenant("alpha"))
+	})
+}
+
+func TestServerConfig_ValidateTenantName(t *testing.T) {
+	baseConfig := func() *ServerConfig {
+		return &ServerConfig{
+			Databases: map[string]DatabaseConfig{
+				"testapp": {
+					Type: "mysql",
+					Environments: map[string]EnvironmentConfig{
+						"staging": {DSN: "root@tcp(localhost:3306)/testapp"},
+					},
+				},
+			},
+		}
+	}
+
+	t.Run("valid tenant name", func(t *testing.T) {
+		cfg := baseConfig()
+		cfg.Tenant = "alpha_1-prod"
+		require.NoError(t, cfg.Validate())
+	})
+
+	t.Run("tenant with whitespace is rejected", func(t *testing.T) {
+		cfg := baseConfig()
+		cfg.Tenant = "alpha beta"
+		err := cfg.Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "tenant must start with a letter or number")
+	})
+
+	t.Run("tenant with command-unsafe punctuation is rejected", func(t *testing.T) {
+		cfg := baseConfig()
+		cfg.Tenant = "alpha@example"
+		err := cfg.Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "tenant must start with a letter or number")
+	})
+
+	t.Run("tenant that looks like a flag is rejected", func(t *testing.T) {
+		cfg := baseConfig()
+		cfg.Tenant = "--alpha"
+		err := cfg.Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "tenant must start with a letter or number")
+	})
+}
+
 func TestServerConfig_ShouldRequirePassingChecks(t *testing.T) {
 	t.Run("nil receiver defaults to true", func(t *testing.T) {
 		var cfg *ServerConfig

--- a/pkg/webhook/apply_execute.go
+++ b/pkg/webhook/apply_execute.go
@@ -69,7 +69,7 @@ func (h *Handler) executeApply(
 	if storedPlan != nil && !ddlMatchesStoredPlan(planResp, storedPlan) {
 		h.logger.Info("auto-confirm downgraded: DDL drift detected",
 			"repo", repo, "pr", pr, "database", database, "environment", environment)
-		commentData := buildPlanCommentData(schemaResult, planResp, environment, requestedBy)
+		commentData := buildPlanCommentData(schemaResult, planResp, environment, result.Tenant, requestedBy)
 		commentData.IsLocked = true
 		commentData.AutoConfirmDowngradeReason = "Schema changes differ from auto-plan — review and confirm manually"
 		h.postComment(repo, pr, installationID, templates.RenderPlanComment(commentData))
@@ -78,7 +78,7 @@ func (h *Handler) executeApply(
 
 	// Block unsafe changes on confirm (re-plan may have detected new unsafe changes)
 	if len(planResp.UnsafeChanges()) > 0 && !result.AllowUnsafe {
-		commentData := buildPlanCommentData(schemaResult, planResp, environment, requestedBy)
+		commentData := buildPlanCommentData(schemaResult, planResp, environment, result.Tenant, requestedBy)
 		h.logger.Info("apply blocked by unsafe changes", "repo", repo, "pr", pr, "database", database, "environment", environment)
 		h.postComment(repo, pr, installationID, templates.RenderUnsafeChangesBlocked(commentData))
 		return

--- a/pkg/webhook/apply_handlers.go
+++ b/pkg/webhook/apply_handlers.go
@@ -162,14 +162,14 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 
 	// No changes — post a regular plan comment (no lock, no confirm footer)
 	if len(planResp.FlatTables()) == 0 {
-		commentData := buildPlanCommentData(schemaResult, planResp, environment, requestedBy)
+		commentData := buildPlanCommentData(schemaResult, planResp, environment, result.Tenant, requestedBy)
 		h.postComment(repo, pr, installationID, templates.RenderPlanComment(commentData))
 		return
 	}
 
 	// Block unsafe changes unless --allow-unsafe was specified
 	if len(planResp.UnsafeChanges()) > 0 && !result.AllowUnsafe {
-		commentData := buildPlanCommentData(schemaResult, planResp, environment, requestedBy)
+		commentData := buildPlanCommentData(schemaResult, planResp, environment, result.Tenant, requestedBy)
 		h.logger.Info("apply blocked by unsafe changes", "repo", repo, "pr", pr, "database", database, "environment", environment)
 		h.postComment(repo, pr, installationID, templates.RenderUnsafeChangesBlocked(commentData))
 		return
@@ -193,7 +193,7 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 	}
 
 	// Build plan comment data with lock info
-	commentData := buildPlanCommentData(schemaResult, planResp, environment, requestedBy)
+	commentData := buildPlanCommentData(schemaResult, planResp, environment, result.Tenant, requestedBy)
 	commentData.IsLocked = true
 	commentData.LockOwner = lockOwner
 	commentData.LockAcquired = time.Now().UTC().Format("2006-01-02 15:04:05 UTC")

--- a/pkg/webhook/check_runs_test.go
+++ b/pkg/webhook/check_runs_test.go
@@ -280,6 +280,168 @@ func TestRespondToUnscoped(t *testing.T) {
 		assert.Contains(t, rr.Body.String(), "unscoped command skipped")
 	})
 
+	t.Run("targeted command skipped by non-matching tenant", func(t *testing.T) {
+		service := api.New(nil, &api.ServerConfig{
+			Tenant:            "alpha",
+			RespondToUnscoped: &trueVal,
+			Repos:             map[string]api.RepoConfig{},
+		}, nil, testLogger())
+
+		h := &Handler{
+			service: service,
+			logger:  testLogger(),
+		}
+
+		req := buildWebhookRequest(t, webhookPayloadOpts{
+			comment: "schemabot help --tenant beta",
+			isPR:    true,
+		}, nil)
+
+		rr := httpResponseRecorder()
+		h.ServeHTTP(rr, req)
+
+		require.Equal(t, http.StatusOK, rr.Code)
+		assert.Contains(t, rr.Body.String(), "tenant handled by another instance")
+	})
+
+	t.Run("invalid tenant flag is ignored before reactions or comments", func(t *testing.T) {
+		service := api.New(nil, &api.ServerConfig{
+			Tenant:            "alpha",
+			RespondToUnscoped: &trueVal,
+			Repos:             map[string]api.RepoConfig{},
+		}, nil, testLogger())
+
+		h := &Handler{
+			service: service,
+			logger:  testLogger(),
+		}
+
+		req := buildWebhookRequest(t, webhookPayloadOpts{
+			comment: "schemabot help --tenant alpha@example",
+			isPR:    true,
+		}, nil)
+
+		rr := httpResponseRecorder()
+		h.ServeHTTP(rr, req)
+
+		require.Equal(t, http.StatusOK, rr.Code)
+		assert.Contains(t, rr.Body.String(), "invalid tenant flag")
+	})
+
+	t.Run("targeted help bypasses respond_to_unscoped", func(t *testing.T) {
+		client, mux := setupGitHubServer(t)
+		mux.HandleFunc("POST /repos/octocat/hello-world/issues/1/comments", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": 99})
+		})
+		mux.HandleFunc("POST /repos/octocat/hello-world/issues/comments/42/reactions", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": 1})
+		})
+
+		installClient := ghclient.NewInstallationClient(client, testLogger())
+		factory := &fakeClientFactory{client: installClient}
+
+		service := api.New(nil, &api.ServerConfig{
+			Tenant:            "alpha",
+			RespondToUnscoped: &falseVal,
+			Repos:             map[string]api.RepoConfig{},
+		}, nil, testLogger())
+
+		h := &Handler{
+			service:   service,
+			ghClients: ghclient.NewSingleClientSet(defaultAppName, factory),
+			logger:    testLogger(),
+		}
+
+		req := buildWebhookRequest(t, webhookPayloadOpts{
+			comment: "schemabot help -t alpha",
+			isPR:    true,
+		}, nil)
+
+		rr := httpResponseRecorder()
+		h.ServeHTTP(rr, req)
+
+		require.Equal(t, http.StatusOK, rr.Code)
+		assert.Contains(t, rr.Body.String(), "help posted")
+	})
+
+	t.Run("targeted invalid command bypasses respond_to_unscoped", func(t *testing.T) {
+		client, mux := setupGitHubServer(t)
+		mux.HandleFunc("POST /repos/octocat/hello-world/issues/1/comments", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": 99})
+		})
+		mux.HandleFunc("POST /repos/octocat/hello-world/issues/comments/42/reactions", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": 1})
+		})
+
+		installClient := ghclient.NewInstallationClient(client, testLogger())
+		factory := &fakeClientFactory{client: installClient}
+
+		service := api.New(nil, &api.ServerConfig{
+			Tenant:            "alpha",
+			RespondToUnscoped: &falseVal,
+			Repos:             map[string]api.RepoConfig{},
+		}, nil, testLogger())
+
+		h := &Handler{
+			service:   service,
+			ghClients: ghclient.NewSingleClientSet(defaultAppName, factory),
+			logger:    testLogger(),
+		}
+
+		req := buildWebhookRequest(t, webhookPayloadOpts{
+			comment: "schemabot wat -t alpha",
+			isPR:    true,
+		}, nil)
+
+		rr := httpResponseRecorder()
+		h.ServeHTTP(rr, req)
+
+		require.Equal(t, http.StatusOK, rr.Code)
+		assert.Contains(t, rr.Body.String(), "invalid command")
+	})
+
+	t.Run("short tenant flag routes to matching deployment", func(t *testing.T) {
+		client, mux := setupGitHubServer(t)
+		mux.HandleFunc("POST /repos/octocat/hello-world/issues/1/comments", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": 99})
+		})
+		mux.HandleFunc("POST /repos/octocat/hello-world/issues/comments/42/reactions", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": 1})
+		})
+
+		installClient := ghclient.NewInstallationClient(client, testLogger())
+		factory := &fakeClientFactory{client: installClient}
+
+		service := api.New(nil, &api.ServerConfig{
+			Tenant:            "alpha",
+			RespondToUnscoped: &trueVal,
+			Repos:             map[string]api.RepoConfig{},
+		}, nil, testLogger())
+
+		h := &Handler{
+			service:   service,
+			ghClients: ghclient.NewSingleClientSet(defaultAppName, factory),
+			logger:    testLogger(),
+		}
+
+		req := buildWebhookRequest(t, webhookPayloadOpts{
+			comment: "schemabot help -t alpha",
+			isPR:    true,
+		}, nil)
+
+		rr := httpResponseRecorder()
+		h.ServeHTTP(rr, req)
+
+		require.Equal(t, http.StatusOK, rr.Code)
+		assert.Contains(t, rr.Body.String(), "help posted")
+	})
+
 	t.Run("help responds when respond_to_unscoped is true", func(t *testing.T) {
 		client, mux := setupGitHubServer(t)
 		mux.HandleFunc("POST /repos/octocat/hello-world/issues/1/comments", func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/webhook/commands.go
+++ b/pkg/webhook/commands.go
@@ -107,6 +107,8 @@ type CommandParser struct {
 	applyIDRegex      *regexp.Regexp
 	environmentRegex  *regexp.Regexp
 	databaseRegex     *regexp.Regexp
+	tenantRegex       *regexp.Regexp
+	tenantFlagRegex   *regexp.Regexp
 	skipRevertRegex   *regexp.Regexp
 	deferCutoverRegex *regexp.Regexp
 	allowUnsafeRegex  *regexp.Regexp
@@ -123,6 +125,8 @@ func NewCommandParser() *CommandParser {
 		applyIDRegex:      regexp.MustCompile(`(?i)\b(apply[_-][a-f0-9]+)\b`),
 		environmentRegex:  regexp.MustCompile(`(?i)-e\s+(staging|production)`),
 		databaseRegex:     regexp.MustCompile(`(?i)-d\s+([a-zA-Z0-9_-]+)`),
+		tenantRegex:       regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_-]*$`),
+		tenantFlagRegex:   regexp.MustCompile(`(?i)(?:^|\s)(?:--tenant|-t)(?:[ \t]+([^\s]+))?`),
 		skipRevertRegex:   regexp.MustCompile(`(?i)--skip-revert\b`),
 		deferCutoverRegex: regexp.MustCompile(`(?i)--defer-cutover\b`),
 		allowUnsafeRegex:  regexp.MustCompile(`(?i)--allow-unsafe\b`),
@@ -137,6 +141,8 @@ type CommandResult struct {
 	ApplyID      string // Positional apply identifier for apply-scoped commands.
 	Environment  string
 	Database     string // Optional -d flag value
+	Tenant       string // Optional --tenant/-t routing target for this command.
+	TenantError  bool   // True when --tenant/-t is present without a valid routing target.
 	SkipRevert   bool
 	DeferCutover bool
 	AllowUnsafe  bool
@@ -163,25 +169,48 @@ type CommandResult struct {
 //     "invalid command" comment under the respond_to_unscoped policy.
 func (p *CommandParser) ParseCommand(body string) CommandResult {
 	body = markdownDirectiveText(body)
+	directive, ok := p.firstDirectiveLine(body)
+	if !ok {
+		return CommandResult{}
+	}
+	tenant, tenantErr := p.extractTenant(directive)
 
-	if p.helpRegex.MatchString(body) {
-		return CommandResult{Action: action.Help, IsHelp: true, IsMention: true}
+	if p.helpRegex.MatchString(directive) {
+		return CommandResult{Action: action.Help, Tenant: tenant, TenantError: tenantErr, IsHelp: true, IsMention: true}
 	}
 
-	matches := p.commandRegex.FindStringSubmatch(body)
+	matches := p.commandRegex.FindStringSubmatch(directive)
 	if len(matches) < 2 {
-		if p.mentionRegex.MatchString(body) {
-			return CommandResult{IsMention: true}
-		}
-		return CommandResult{}
+		return CommandResult{Tenant: tenant, TenantError: tenantErr, IsMention: true}
 	}
 
 	name := strings.ToLower(matches[1])
 	spec, ok := specByName[name]
 	if !ok {
-		return CommandResult{IsMention: true}
+		return CommandResult{Tenant: tenant, TenantError: tenantErr, IsMention: true}
 	}
-	return p.applySpec(spec, body)
+	return p.applySpec(spec, directive, tenant, tenantErr)
+}
+
+func (p *CommandParser) firstDirectiveLine(body string) (string, bool) {
+	for line := range strings.Lines(body) {
+		line = strings.TrimRight(line, "\r\n")
+		if p.mentionRegex.MatchString(line) {
+			return line, true
+		}
+	}
+	return "", false
+}
+
+func (p *CommandParser) extractTenant(body string) (string, bool) {
+	match := p.tenantFlagRegex.FindStringSubmatch(body)
+	if len(match) == 0 {
+		return "", false
+	}
+	if len(match) < 2 || match[1] == "" || !p.tenantRegex.MatchString(match[1]) {
+		return "", true
+	}
+	return match[1], false
 }
 
 func markdownDirectiveText(body string) string {
@@ -208,10 +237,12 @@ func isMarkdownFence(line string) bool {
 // applySpec populates CommandResult from a body using the per-command spec.
 // Each spec field gates the corresponding regex extraction, so flags only
 // affect commands that opted in via the registry.
-func (p *CommandParser) applySpec(spec CommandSpec, body string) CommandResult {
+func (p *CommandParser) applySpec(spec CommandSpec, body, tenant string, tenantErr bool) CommandResult {
 	result := CommandResult{
-		Action:    spec.Name,
-		IsMention: true,
+		Action:      spec.Name,
+		Tenant:      tenant,
+		TenantError: tenantErr,
+		IsMention:   true,
 	}
 
 	if spec.HasApplyID {

--- a/pkg/webhook/commands_test.go
+++ b/pkg/webhook/commands_test.go
@@ -95,6 +95,149 @@ func TestHasDatabaseFlag(t *testing.T) {
 	assert.False(t, p.HasDatabaseFlag("schemabot rollback apply_abc123 -e staging"))
 }
 
+func TestParseTenantFlag(t *testing.T) {
+	parser := NewCommandParser()
+
+	tests := []struct {
+		name   string
+		body   string
+		result CommandResult
+	}{
+		{
+			name: "plan command",
+			body: "schemabot plan -e staging --tenant alpha",
+			result: CommandResult{
+				Action:      action.Plan,
+				Environment: "staging",
+				Tenant:      "alpha",
+				Found:       true,
+				IsMention:   true,
+			},
+		},
+		{
+			name: "apply command",
+			body: "schemabot apply -e production --tenant tenant-1 --allow-unsafe",
+			result: CommandResult{
+				Action:      action.Apply,
+				Environment: "production",
+				Tenant:      "tenant-1",
+				AllowUnsafe: true,
+				Found:       true,
+				IsMention:   true,
+			},
+		},
+		{
+			name: "short flag",
+			body: "schemabot plan -e staging -t alpha_1",
+			result: CommandResult{
+				Action:      action.Plan,
+				Environment: "staging",
+				Tenant:      "alpha_1",
+				Found:       true,
+				IsMention:   true,
+			},
+		},
+		{
+			name: "help command",
+			body: "schemabot help --tenant alpha",
+			result: CommandResult{
+				Action:    action.Help,
+				Tenant:    "alpha",
+				IsHelp:    true,
+				IsMention: true,
+			},
+		},
+		{
+			name: "invalid command",
+			body: "schemabot wat --tenant alpha",
+			result: CommandResult{
+				Tenant:    "alpha",
+				IsMention: true,
+			},
+		},
+		{
+			name: "missing value",
+			body: "schemabot plan -e staging --tenant",
+			result: CommandResult{
+				Action:      action.Plan,
+				Environment: "staging",
+				TenantError: true,
+				Found:       true,
+				IsMention:   true,
+			},
+		},
+		{
+			name: "short flag missing value",
+			body: "schemabot plan -e staging -t",
+			result: CommandResult{
+				Action:      action.Plan,
+				Environment: "staging",
+				TenantError: true,
+				Found:       true,
+				IsMention:   true,
+			},
+		},
+		{
+			name: "invalid value",
+			body: "schemabot plan -e staging --tenant alpha@example",
+			result: CommandResult{
+				Action:      action.Plan,
+				Environment: "staging",
+				TenantError: true,
+				Found:       true,
+				IsMention:   true,
+			},
+		},
+		{
+			name: "tenant value cannot look like another flag",
+			body: "schemabot apply -e staging --tenant --allow-unsafe",
+			result: CommandResult{
+				Action:      action.Apply,
+				Environment: "staging",
+				TenantError: true,
+				AllowUnsafe: true,
+				Found:       true,
+				IsMention:   true,
+			},
+		},
+		{
+			name: "tenant prose after directive is ignored",
+			body: "schemabot plan -e staging\n\nDo not use --tenant here.",
+			result: CommandResult{
+				Action:      action.Plan,
+				Environment: "staging",
+				Found:       true,
+				IsMention:   true,
+			},
+		},
+		{
+			name: "tenant prose before directive is ignored",
+			body: "Do not use --tenant here.\n\nschemabot plan -e staging",
+			result: CommandResult{
+				Action:      action.Plan,
+				Environment: "staging",
+				Found:       true,
+				IsMention:   true,
+			},
+		},
+		{
+			name: "environment prose after directive is ignored",
+			body: "schemabot plan\n\nUse -e staging later.",
+			result: CommandResult{
+				Action:     action.Plan,
+				MissingEnv: true,
+				IsMention:  true,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.result, parser.ParseCommand(tc.body))
+		})
+	}
+}
+
 func TestCommandSupportsDatabaseFlag(t *testing.T) {
 	assert.True(t, commandSupportsDatabaseFlag(action.Plan))
 	assert.True(t, commandSupportsDatabaseFlag(action.Apply))

--- a/pkg/webhook/issue_comment.go
+++ b/pkg/webhook/issue_comment.go
@@ -107,9 +107,29 @@ func (h *Handler) handleIssueComment(ctx context.Context, metricApp string, w ht
 		return
 	}
 
+	if result.TenantError {
+		h.logger.Info("ignoring command with invalid tenant flag",
+			"repo", repo, "pr", pr, "action", result.Action)
+		h.writeJSON(w, http.StatusOK, map[string]string{
+			"message": "invalid tenant flag",
+		})
+		return
+	}
+
+	// When a command names a tenant, only the matching isolated deployment should
+	// react or post comments. This mirrors allowed_environments routing for -e.
+	if result.Tenant != "" && h.service != nil && !h.service.Config().ShouldRespondToTenant(result.Tenant) {
+		h.logger.Info("ignoring command for non-owned tenant",
+			"repo", repo, "pr", pr, "tenant", result.Tenant, "action", result.Action)
+		h.writeJSON(w, http.StatusOK, map[string]string{
+			"message": "tenant handled by another instance",
+		})
+		return
+	}
+
 	// Handle help command
 	if result.IsHelp {
-		if h.service != nil && !h.service.Config().ShouldRespondToUnscoped() {
+		if result.Tenant == "" && h.service != nil && !h.service.Config().ShouldRespondToUnscoped() {
 			h.logger.Debug("skipping help command (respond_to_unscoped is false)", "repo", repo, "pr", pr)
 			h.writeJSON(w, http.StatusOK, map[string]string{"message": "unscoped command skipped"})
 			return
@@ -126,7 +146,7 @@ func (h *Handler) handleIssueComment(ctx context.Context, metricApp string, w ht
 			// Plan without -e: run for all configured environments
 			h.logger.Info("plan without -e flag", "repo", repo, "pr", pr)
 			h.goSafe(repo, pr, installationID, func() {
-				h.handleMultiEnvPlan(repo, pr, result.Database, installationID, requestedBy, false)
+				h.handleMultiEnvPlan(repo, pr, result.Database, result.Tenant, installationID, requestedBy, false)
 			})
 			h.writeJSON(w, http.StatusOK, map[string]string{"message": "multi-env plan started"})
 			return
@@ -171,7 +191,7 @@ func (h *Handler) handleIssueComment(ctx context.Context, metricApp string, w ht
 
 	// Handle invalid command (schemabot mentioned but command not recognized)
 	if !result.Found {
-		if h.service != nil && !h.service.Config().ShouldRespondToUnscoped() {
+		if result.Tenant == "" && h.service != nil && !h.service.Config().ShouldRespondToUnscoped() {
 			h.logger.Debug("skipping invalid command response (respond_to_unscoped is false)", "repo", repo, "pr", pr)
 			h.writeJSON(w, http.StatusOK, map[string]string{"message": "unscoped command skipped"})
 			return
@@ -232,7 +252,7 @@ func (h *Handler) handleIssueComment(ctx context.Context, metricApp string, w ht
 
 	switch result.Action {
 	case action.Plan:
-		h.handlePlanCommand(w, repo, pr, result.Environment, result.Database, installationID, requestedBy)
+		h.handlePlanCommand(w, repo, pr, result.Environment, result.Database, result.Tenant, installationID, requestedBy)
 	case action.Help:
 		h.postComment(repo, pr, installationID, templates.RenderHelpComment())
 		h.writeJSON(w, http.StatusOK, map[string]string{"message": "help posted"})

--- a/pkg/webhook/plan.go
+++ b/pkg/webhook/plan.go
@@ -15,7 +15,7 @@ import (
 )
 
 // handlePlanCommand handles the "schemabot plan -e <env>" command.
-func (h *Handler) handlePlanCommand(w http.ResponseWriter, repo string, pr int, environment, databaseName string, installationID int64, requestedBy string) {
+func (h *Handler) handlePlanCommand(w http.ResponseWriter, repo string, pr int, environment, databaseName, tenant string, installationID int64, requestedBy string) {
 	ctx, cancel, client, err := h.commandBootstrap(repo, installationID)
 	if err != nil {
 		h.logger.Error("plan: failed to bootstrap command", "error", err)
@@ -112,7 +112,7 @@ func (h *Handler) handlePlanCommand(w http.ResponseWriter, repo string, pr int, 
 	}
 
 	// Build plan comment data
-	commentData := buildPlanCommentData(schemaResult, planResp, environment, requestedBy)
+	commentData := buildPlanCommentData(schemaResult, planResp, environment, tenant, requestedBy)
 
 	metrics.RecordPlan(ctx, repo, schemaResult.Database, deployment, environment, "success")
 
@@ -138,7 +138,7 @@ func (h *Handler) handlePlanCommand(w http.ResponseWriter, repo string, pr int, 
 
 // handleMultiEnvPlan runs plan for all configured environments and posts a single combined comment.
 // When isAutoPlan is true and no environments have changes or errors, the comment is skipped to reduce PR noise.
-func (h *Handler) handleMultiEnvPlan(repo string, pr int, databaseName string, installationID int64, requestedBy string, isAutoPlan bool) {
+func (h *Handler) handleMultiEnvPlan(repo string, pr int, databaseName, tenant string, installationID int64, requestedBy string, isAutoPlan bool) {
 	ctx, cancel, client, err := h.commandBootstrap(repo, installationID)
 	if err != nil {
 		h.logger.Error("multi-env plan: failed to bootstrap command", "error", err)
@@ -306,7 +306,7 @@ func (h *Handler) handleMultiEnvPlan(repo string, pr int, databaseName string, i
 			headSHA = sha
 		}
 
-		commentData := buildPlanCommentData(schemaResult, planResp, env, requestedBy)
+		commentData := buildPlanCommentData(schemaResult, planResp, env, tenant, requestedBy)
 		commentData.RecoveredApplyOwnedCheckState = recoveredApplyOwnedCheckState
 		multiEnvData.Plans[env] = &commentData
 	}
@@ -427,10 +427,11 @@ func (h *Handler) handleSchemaRequestError(repo string, pr int, installationID i
 }
 
 // buildPlanCommentData converts plan results into template data.
-func buildPlanCommentData(schema *ghclient.SchemaRequestResult, planResp *apitypes.PlanResponse, environment, requestedBy string) templates.PlanCommentData {
+func buildPlanCommentData(schema *ghclient.SchemaRequestResult, planResp *apitypes.PlanResponse, environment, tenant, requestedBy string) templates.PlanCommentData {
 	data := templates.PlanCommentData{
 		Database:    schema.Database,
 		Environment: environment,
+		Tenant:      tenant,
 		HeadSHA:     schema.HeadSHA,
 		Repository:  schema.Repository,
 		RequestedBy: requestedBy,

--- a/pkg/webhook/plan_test.go
+++ b/pkg/webhook/plan_test.go
@@ -41,7 +41,7 @@ func TestBuildPlanCommentData_UnsafeChangesPopulated(t *testing.T) {
 		}},
 	}
 
-	data := buildPlanCommentData(schema, planResp, "staging", "testuser")
+	data := buildPlanCommentData(schema, planResp, "staging", "", "testuser")
 
 	assert.True(t, data.HasUnsafeChanges, "expected HasUnsafeChanges=true when plan contains unsafe table changes")
 	require.Len(t, data.UnsafeChanges, 1)
@@ -69,7 +69,7 @@ func TestBuildPlanCommentData_NoUnsafeChanges(t *testing.T) {
 		}},
 	}
 
-	data := buildPlanCommentData(schema, planResp, "staging", "testuser")
+	data := buildPlanCommentData(schema, planResp, "staging", "", "testuser")
 
 	assert.False(t, data.HasUnsafeChanges)
 	assert.Empty(t, data.UnsafeChanges)
@@ -104,7 +104,7 @@ func TestBuildPlanCommentData_MixedSafeAndUnsafe(t *testing.T) {
 		}},
 	}
 
-	data := buildPlanCommentData(schema, planResp, "staging", "testuser")
+	data := buildPlanCommentData(schema, planResp, "staging", "", "testuser")
 
 	assert.True(t, data.HasUnsafeChanges)
 	require.Len(t, data.UnsafeChanges, 1)
@@ -159,6 +159,45 @@ func TestRenderPlanComment_UnsafeWithAllowUnsafe(t *testing.T) {
 	assert.Contains(t, rendered, "--allow-unsafe` enabled")
 	assert.Contains(t, rendered, "`users`")
 	assert.Contains(t, rendered, "apply-confirm -e staging --allow-unsafe")
+}
+
+func TestRenderPlanComment_TenantScopedHints(t *testing.T) {
+	t.Run("plan hint preserves tenant", func(t *testing.T) {
+		data := templates.PlanCommentData{
+			Database:    "testdb",
+			Environment: "staging",
+			Tenant:      "alpha",
+			IsMySQL:     true,
+			Changes: []templates.KeyspaceChangeData{{
+				Keyspace:   "testdb",
+				Statements: []string{"ALTER TABLE `orders` ADD COLUMN `x` INT"},
+			}},
+		}
+
+		rendered := templates.RenderPlanComment(data)
+
+		assert.Contains(t, rendered, "**Tenant**: `alpha`")
+		assert.Contains(t, rendered, "schemabot apply -e staging --tenant alpha")
+	})
+
+	t.Run("apply-confirm hint preserves tenant", func(t *testing.T) {
+		data := templates.PlanCommentData{
+			Database:    "testdb",
+			Environment: "staging",
+			Tenant:      "alpha",
+			IsMySQL:     true,
+			IsLocked:    true,
+			Changes: []templates.KeyspaceChangeData{{
+				Keyspace:   "testdb",
+				Statements: []string{"ALTER TABLE `orders` ADD COLUMN `x` INT"},
+			}},
+		}
+
+		rendered := templates.RenderPlanComment(data)
+
+		assert.Contains(t, rendered, "**Tenant**: `alpha`")
+		assert.Contains(t, rendered, "schemabot apply-confirm -e staging --tenant alpha")
+	})
 }
 
 func TestRenderPlanComment_NoUnsafe_NoWarning(t *testing.T) {
@@ -302,4 +341,26 @@ func TestRenderUnsafeChangesBlocked_UsedByApplyFlow(t *testing.T) {
 	assert.Contains(t, rendered, "DROP TABLE removes all data")
 	assert.Contains(t, rendered, "--allow-unsafe")
 	assert.Contains(t, rendered, "schemabot apply -e staging --allow-unsafe")
+}
+
+func TestRenderUnsafeChangesBlocked_PreservesTenantInRetryCommand(t *testing.T) {
+	data := templates.PlanCommentData{
+		Database:    "testdb",
+		Environment: "staging",
+		Tenant:      "alpha",
+		IsMySQL:     true,
+		Changes: []templates.KeyspaceChangeData{{
+			Keyspace:   "testdb",
+			Statements: []string{"DROP TABLE `orders`"},
+		}},
+		UnsafeChanges: []templates.UnsafeChangeData{{
+			Table:  "orders",
+			Reason: "DROP TABLE removes all data",
+		}},
+	}
+
+	rendered := templates.RenderUnsafeChangesBlocked(data)
+
+	assert.Contains(t, rendered, "**Tenant**: `alpha`")
+	assert.Contains(t, rendered, "schemabot apply -e staging --tenant alpha --allow-unsafe")
 }

--- a/pkg/webhook/pull_request.go
+++ b/pkg/webhook/pull_request.go
@@ -164,7 +164,7 @@ func (h *Handler) runAutoPlanForPR(ctx context.Context, client *ghclient.Install
 	for _, cfg := range configs {
 		database := cfg.Config.Database
 		h.goSafe(repo, pr, installationID, func() {
-			h.handleMultiEnvPlan(repo, pr, database, installationID, "", true)
+			h.handleMultiEnvPlan(repo, pr, database, "", installationID, "", true)
 		})
 	}
 

--- a/pkg/webhook/templates/apply_commands.go
+++ b/pkg/webhook/templates/apply_commands.go
@@ -130,7 +130,12 @@ func RenderUnsafeChangesBlocked(data PlanCommentData) string {
 	writeUnsafeDropGuidance(&sb, data.UnsafeChanges)
 
 	sb.WriteString("**🚨 To proceed with these destructive changes, re-run with `--allow-unsafe`:**\n")
-	fmt.Fprintf(&sb, "```\nschemabot apply -e %s --allow-unsafe\n```\n", data.Environment)
+	applyCmd := fmt.Sprintf("schemabot apply -e %s", data.Environment)
+	if data.Tenant != "" {
+		applyCmd += fmt.Sprintf(" --tenant %s", data.Tenant)
+	}
+	applyCmd += " --allow-unsafe"
+	fmt.Fprintf(&sb, "```\n%s\n```\n", applyCmd)
 
 	return sb.String()
 }

--- a/pkg/webhook/templates/help.go
+++ b/pkg/webhook/templates/help.go
@@ -15,7 +15,7 @@ func commandReference() string {
 | ` + "`schemabot rollback <apply-id> -e <env>`" + ` | Generate a rollback plan |
 | ` + "`schemabot rollback-confirm -e <env>`" + ` | Execute a rollback |
 
-**Options**: ` + "`-e <env>`" + ` environment, ` + "`-d <db>`" + ` database, ` + "`--defer-cutover`" + `, ` + "`--allow-unsafe`" + `, ` + "`--skip-revert`" + ` (Vitess)
+**Options**: ` + "`-e <env>`" + ` environment, ` + "`-d <db>`" + ` database, ` + "`-t, --tenant <name>`" + ` deployment routing, ` + "`--defer-cutover`" + `, ` + "`--allow-unsafe`" + `, ` + "`--skip-revert`" + ` (Vitess)
 
 **Quick start**: ` + "`plan`" + ` → ` + "`apply`" + ` → ` + "`apply-confirm`" + `
 `

--- a/pkg/webhook/templates/plan.go
+++ b/pkg/webhook/templates/plan.go
@@ -29,6 +29,7 @@ type PlanCommentData struct {
 	Database    string
 	SchemaName  string // Schema directory name (e.g. filepath.Base of schema dir)
 	Environment string
+	Tenant      string
 	HeadSHA     string
 	Repository  string
 	RequestedBy string // Empty means auto-generated
@@ -133,6 +134,9 @@ func RenderPlanComment(data PlanCommentData) string {
 
 	if data.IsLocked {
 		applyConfirmCmd := fmt.Sprintf("schemabot apply-confirm -e %s", data.Environment)
+		if data.Tenant != "" {
+			applyConfirmCmd += fmt.Sprintf(" --tenant %s", data.Tenant)
+		}
 		if data.AllowUnsafe {
 			applyConfirmCmd += " --allow-unsafe"
 		}
@@ -163,7 +167,11 @@ func RenderPlanComment(data PlanCommentData) string {
 			sb.WriteString("```\nschemabot unlock\n```\n")
 		}
 	} else {
-		writeApplyHint(&sb, fmt.Sprintf("schemabot apply -e %s", data.Environment))
+		applyCmd := fmt.Sprintf("schemabot apply -e %s", data.Environment)
+		if data.Tenant != "" {
+			applyCmd += fmt.Sprintf(" --tenant %s", data.Tenant)
+		}
+		writeApplyHint(&sb, applyCmd)
 	}
 
 	return sb.String()
@@ -184,6 +192,9 @@ func writePlanMetadata(sb *strings.Builder, data PlanCommentData) {
 	}
 	if data.Environment != "" {
 		parts = append(parts, fmt.Sprintf("**Environment**: `%s`", data.Environment))
+	}
+	if data.Tenant != "" {
+		parts = append(parts, fmt.Sprintf("**Tenant**: `%s`", data.Tenant))
 	}
 	fmt.Fprintf(sb, "%s\n", strings.Join(parts, " | "))
 }


### PR DESCRIPTION
## Why
Multiple isolated SchemaBot deployments can receive the same PR comment webhook. Operators need a server-side routing guard so a targeted command is handled by exactly one deployment.

## What
- Add optional server-side `tenant` identity for PR command routing
- Parse `--tenant <name>` / `-t <name>` on PR comments and skip non-matching deployments before reactions/comments
- Preserve tenant-scoped follow-up commands in plan/apply retry hints
- Document the routing model alongside multi-environment deployment configuration

Example workflow:
```text
schemabot plan -e production -t alpha
# only the deployment configured with `tenant: alpha` responds

schemabot apply -e production -t alpha
# plan comments and retry hints keep the tenant target

schemabot apply-confirm -e production -t alpha
# the same deployment owns the confirmation path
```

Generated with Amp
