### PR TITLE
feat(planetscale): surface VSchema status via engine resume metadata

### DIFF
--- a/pkg/engine/planetscale/planetscale.go
+++ b/pkg/engine/planetscale/planetscale.go
@@ -437,6 +437,14 @@ type psMetadata struct {
 	IsInstant        bool       `json:"is_instant,omitempty"`
 	DeferredDeploy   bool       `json:"deferred_deploy,omitempty"`
 
+	// VSchemaStatus tracks the deploy's VSchema-application phase so it can be
+	// surfaced from stored state without a synthetic task row. Empty when the
+	// deploy carries no VSchema change; "applying" once the deploy reaches the
+	// VSchema phase; "applied" once it completes after that phase. The renderer
+	// reads it through the display-metadata projection (PSDisplayMetadata), the
+	// same path branch/deploy-URL/instant use.
+	VSchemaStatus string `json:"vschema_status,omitempty"`
+
 	// ExistingMigrationCtxs is the set of SHOW VITESS_MIGRATIONS contexts that
 	// already existed just before this deploy started, keyed by context. It is
 	// the durable baseline that lets a later process — a resume on another pod,
@@ -798,6 +806,30 @@ func deployStateToMessage(drState string) string {
 	default:
 		return fmt.Sprintf("Processing (%s)", drState)
 	}
+}
+
+// VSchema-application status values surfaced on the progress projection. Empty
+// means the deploy carries no VSchema change (or hasn't reached the phase yet).
+const (
+	vschemaStatusApplying = "applying"
+	vschemaStatusApplied  = "applied"
+)
+
+// nextVSchemaStatus advances the stored VSchema status from the current deploy
+// state. It becomes "applying" when the deploy enters the VSchema phase, and
+// "applied" once a deploy that went through that phase completes. A deploy that
+// never reaches the VSchema phase (instant DDL, no VSchema change) keeps an
+// empty status, so no VSchema indicator is surfaced for it.
+func nextVSchemaStatus(current, drState string) string {
+	switch drState {
+	case deployState.InProgressVSchema:
+		return vschemaStatusApplying
+	case deployState.Complete, deployState.CompletePendingRevert:
+		if current == vschemaStatusApplying {
+			return vschemaStatusApplied
+		}
+	}
+	return current
 }
 
 // sortedKeyspaces returns keyspace names from SchemaFiles in sorted order.

--- a/pkg/engine/planetscale/planetscale_test.go
+++ b/pkg/engine/planetscale/planetscale_test.go
@@ -422,3 +422,26 @@ func TestFormatDeployRequestError(t *testing.T) {
 		assert.Equal(t, "deploy request #99 failed during preparation (state: error)", msg)
 	})
 }
+
+func TestNextVSchemaStatus(t *testing.T) {
+	tests := []struct {
+		name     string
+		current  string
+		drState  string
+		expected string
+	}{
+		{"enters vschema phase", "", deployState.InProgressVSchema, vschemaStatusApplying},
+		{"stays applying mid-phase", vschemaStatusApplying, deployState.InProgressVSchema, vschemaStatusApplying},
+		{"applied on complete after phase", vschemaStatusApplying, deployState.Complete, vschemaStatusApplied},
+		{"applied on complete_pending_revert after phase", vschemaStatusApplying, deployState.CompletePendingRevert, vschemaStatusApplied},
+		{"complete without prior phase stays empty", "", deployState.Complete, ""},
+		{"unrelated state leaves applying untouched", vschemaStatusApplying, deployState.InProgress, vschemaStatusApplying},
+		{"unrelated state leaves empty untouched", "", deployState.Queued, ""},
+		{"already applied is stable on complete", vschemaStatusApplied, deployState.Complete, vschemaStatusApplied},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, nextVSchemaStatus(tc.current, tc.drState))
+		})
+	}
+}

--- a/pkg/engine/planetscale/progress.go
+++ b/pkg/engine/planetscale/progress.go
@@ -73,26 +73,31 @@ func (e *Engine) Progress(ctx context.Context, req *engine.ProgressRequest) (*en
 
 	// Update metadata with DeployedAt when available (used by tern layer for
 	// revert window timeout calculation).
+	metaChanged := false
 	if dr.DeployedAt != nil && meta.DeployedAt == nil {
 		meta.DeployedAt = dr.DeployedAt
-		if encoded, encErr := encodePSMetadata(meta); encErr == nil {
-			req.ResumeState = &engine.ResumeState{
-				MigrationContext: req.ResumeState.MigrationContext,
-				Metadata:         encoded,
-			}
-		}
+		metaChanged = true
 	}
 
 	// Track the VSchema-application phase so it can be surfaced from stored state
-	// without a synthetic task row. Persist it through the resume state so a
-	// progress read served from storage projects it via PSDisplayMetadata.
+	// without a synthetic task row. Persisting it through the resume state lets a
+	// progress read served from storage project it via PSDisplayMetadata.
 	if vs := nextVSchemaStatus(meta.VSchemaStatus, dr.DeploymentState); vs != meta.VSchemaStatus {
 		meta.VSchemaStatus = vs
-		if encoded, encErr := encodePSMetadata(meta); encErr == nil {
-			req.ResumeState = &engine.ResumeState{
-				MigrationContext: req.ResumeState.MigrationContext,
-				Metadata:         encoded,
-			}
+		metaChanged = true
+	}
+
+	// Re-encode once if anything changed. A failed encode would desync the live
+	// progress projection from what persists to storage, so surface it rather
+	// than continuing with stale resume state.
+	if metaChanged {
+		encoded, err := encodePSMetadata(meta)
+		if err != nil {
+			return nil, fmt.Errorf("encode planetscale resume metadata for deploy request #%d: %w", meta.DeployRequestID, err)
+		}
+		req.ResumeState = &engine.ResumeState{
+			MigrationContext: req.ResumeState.MigrationContext,
+			Metadata:         encoded,
 		}
 	}
 

--- a/pkg/engine/planetscale/progress.go
+++ b/pkg/engine/planetscale/progress.go
@@ -83,6 +83,19 @@ func (e *Engine) Progress(ctx context.Context, req *engine.ProgressRequest) (*en
 		}
 	}
 
+	// Track the VSchema-application phase so it can be surfaced from stored state
+	// without a synthetic task row. Persist it through the resume state so a
+	// progress read served from storage projects it via PSDisplayMetadata.
+	if vs := nextVSchemaStatus(meta.VSchemaStatus, dr.DeploymentState); vs != meta.VSchemaStatus {
+		meta.VSchemaStatus = vs
+		if encoded, encErr := encodePSMetadata(meta); encErr == nil {
+			req.ResumeState = &engine.ResumeState{
+				MigrationContext: req.ResumeState.MigrationContext,
+				Metadata:         encoded,
+			}
+		}
+	}
+
 	// Late schema-change-context recovery. A progress poll can run in a process
 	// that never captured the pre-deploy baseline — a different replica, or an
 	// apply whose deploy was created before Vitess exposed its context — so the
@@ -590,6 +603,9 @@ func psDisplayMetadata(meta *psMetadata) map[string]string {
 	}
 	if meta.DeferredDeploy {
 		set("deferred_deploy", "true")
+	}
+	if meta.VSchemaStatus != "" {
+		set("vschema_status", meta.VSchemaStatus)
 	}
 	return m
 }

--- a/pkg/tern/state_converters.go
+++ b/pkg/tern/state_converters.go
@@ -284,6 +284,7 @@ type psMetadataForStorage struct {
 	DeployedAt       *time.Time `json:"deployed_at,omitempty"`
 	IsInstant        bool       `json:"is_instant,omitempty"`
 	DeferredDeploy   bool       `json:"deferred_deploy,omitempty"`
+	VSchemaStatus    string     `json:"vschema_status,omitempty"`
 }
 
 func decodePSMetadataForStorage(s string) (*psMetadataForStorage, error) {
@@ -330,6 +331,9 @@ func PSDisplayMetadata(resumeStateMetadata string) (map[string]string, error) {
 	}
 	if meta.DeferredDeploy {
 		set("deferred_deploy", "true")
+	}
+	if meta.VSchemaStatus != "" {
+		set("vschema_status", meta.VSchemaStatus)
 	}
 	return m, nil
 }

--- a/pkg/tern/state_converters_test.go
+++ b/pkg/tern/state_converters_test.go
@@ -32,13 +32,14 @@ func TestProtoToSchemaFiles_NilNamespaceValue(t *testing.T) {
 func TestPSDisplayMetadata(t *testing.T) {
 	// A populated resume-state blob projects every display field the renderer
 	// surfaces for a PlanetScale apply.
-	m, err := PSDisplayMetadata(`{"branch_name":"schemabot-db-1","deploy_request_url":"https://app/deploy/9","is_instant":true,"deferred_deploy":true}`)
+	m, err := PSDisplayMetadata(`{"branch_name":"schemabot-db-1","deploy_request_url":"https://app/deploy/9","is_instant":true,"deferred_deploy":true,"vschema_status":"applying"}`)
 	require.NoError(t, err)
 	require.NotNil(t, m)
 	assert.Equal(t, "schemabot-db-1", m["branch_name"])
 	assert.Equal(t, "https://app/deploy/9", m["deploy_request_url"])
 	assert.Equal(t, "true", m["is_instant"])
 	assert.Equal(t, "true", m["deferred_deploy"])
+	assert.Equal(t, "applying", m["vschema_status"])
 
 	// An empty blob yields no fields and no error.
 	m, err = PSDisplayMetadata("")


### PR DESCRIPTION
## Why this matters

VSchema status (whether the VSchema change is applying or applied during a cutover) is engine-specific state. It belongs in the engine's opaque resume metadata, surfaced to readers through the same display-metadata projection every other engine-specific field uses — not modeled as a special-cased task.

## What it does

Teaches the PlanetScale engine to carry VSchema status in its resume metadata and surface it as a `vschema_status` display field:

- `psMetadata` gains a `vschema_status` field, advanced through `applying` → `applied` as the deploy moves through its VSchema sub-phase.
- Both the live engine projection and the stored-state projection (`PSDisplayMetadata`) emit `vschema_status`, so it flows into the progress response on both the live and render-from-stored paths automatically.

This change is additive and observable only as a new key in the progress response's display metadata — no rendering or task behavior changes yet.

## How it moves toward the northstar

This is the first slice of moving VSchema status off a synthetic task and onto operation state. Follow-ups render the indicator from this field across the CLI/watch/PR surfaces and remove the synthetic task entirely.
