### PR TITLE
feat(tern): VSchema status from metadata; task-less group finalizer

### DIFF
--- a/e2e/local/vitess_test.go
+++ b/e2e/local/vitess_test.go
@@ -1106,23 +1106,22 @@ func TestVitess_Apply_VSchemaTaskTracking(t *testing.T) {
 	applyID := extractApplyIDFromLog(applyOut)
 	require.NotEmpty(t, applyID)
 
-	// Poll progress until completion, verifying VSchema tasks appear
-	var foundVSchemaTask bool
-	var vschemaChangeType string
+	// Poll progress until completion, verifying table task progress stays
+	// terminal while VSchema metadata is applied through the grouped apply.
+	var foundTableTask bool
 	var finalState string
 	deadline := time.Now().Add(testutil.PollDeadline)
 	for time.Now().Before(deadline) {
 		resp, err := client.GetProgress(endpoint, applyID)
 		if err == nil {
 			for _, tbl := range resp.Tables {
-				if tbl.ChangeType == "vschema_update" {
-					foundVSchemaTask = true
-					vschemaChangeType = tbl.ChangeType
+				if tbl.TableName == "users" && tbl.ChangeType == "alter" {
+					foundTableTask = true
 				}
 			}
 			if state.IsTerminalApplyState(resp.State) {
 				finalState = resp.State
-				// Verify all tables (including VSchema) reached terminal state
+				// Verify all rendered table tasks reached terminal state.
 				for _, tbl := range resp.Tables {
 					assert.True(t, state.IsTerminalApplyState(state.NormalizeTaskStatus(tbl.Status)),
 						"table %s should be terminal, got %s", tbl.TableName, tbl.Status)
@@ -1133,8 +1132,7 @@ func TestVitess_Apply_VSchemaTaskTracking(t *testing.T) {
 		time.Sleep(500 * time.Millisecond)
 	}
 
-	assert.True(t, foundVSchemaTask, "expected VSchema task in progress tables")
-	assert.Equal(t, "vschema_update", vschemaChangeType)
+	assert.True(t, foundTableTask, "expected users ALTER task in progress tables")
 	require.NotEmpty(t, finalState, "apply did not reach terminal state")
 	assert.Equal(t, state.Apply.Completed, finalState)
 }

--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -1990,9 +1990,10 @@ func TestCreateStoredApplyFansOutShardedPlanOperations(t *testing.T) {
 }
 
 func TestCreateStoredApplyFansOutShardedPlanWithFinalizerOperation(t *testing.T) {
-	// A sharded plan with a namespace-level routing metadata change keeps the
-	// work operations shard-scoped and queues the metadata change as a finalizer
-	// operation that is driven through the same operation-scoped path.
+	// A sharded plan with a namespace-level VSchema change keeps the work
+	// operations shard-scoped and queues the VSchema change as a task-less
+	// group_finalizer operation, driven through the same operation-scoped path.
+	// The finalizer reconstructs the VSchema from the plan, so it carries no task.
 	applies := &capturingApplyStore{}
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
 	tasks := &capturingTaskStore{}
@@ -2040,21 +2041,18 @@ func TestCreateStoredApplyFansOutShardedPlanWithFinalizerOperation(t *testing.T)
 	assert.Equal(t, "commerce/group_finalizer", applies.operations[2].OperationKey)
 	assert.Equal(t, storage.ApplyOperationKindGroupFinalizer, applies.operations[2].OperationKind)
 
-	require.Len(t, tasks.tasks, 3)
+	// Only the two shard-work tasks exist; the finalizer is task-less.
+	require.Len(t, tasks.tasks, 2)
 	assert.Equal(t, "-80", tasks.tasks[0].Shard)
 	assert.Equal(t, "users", tasks.tasks[0].TableName)
 	assert.Equal(t, "80-", tasks.tasks[1].Shard)
 	assert.Equal(t, "users", tasks.tasks[1].TableName)
-	assert.Empty(t, tasks.tasks[2].Shard)
-	assert.Equal(t, "VSchema: commerce", tasks.tasks[2].TableName)
-	assert.Equal(t, "vschema_update", tasks.tasks[2].DDLAction)
-	require.NotNil(t, tasks.tasks[2].ApplyOperationID)
-	assert.Equal(t, applies.operations[2].ID, *tasks.tasks[2].ApplyOperationID)
 }
 
 func TestCreateStoredApplyDoesNotDropFinalizerOnlyNamespace(t *testing.T) {
-	// A routing-only namespace with no shard work keeps the apply on the
-	// single-operation path so the routing change is preserved.
+	// When a sharded apply also carries a VSchema-only namespace (a VSchema change
+	// with no shard work of its own), that namespace still gets a task-less
+	// group_finalizer so its VSchema change is preserved rather than dropped.
 	applies := &capturingApplyStore{}
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
 	tasks := &capturingTaskStore{}
@@ -2092,13 +2090,15 @@ func TestCreateStoredApplyDoesNotDropFinalizerOnlyNamespace(t *testing.T) {
 	_, _, err := svc.createStoredApply(t.Context(), plan, ApplyRequest{Environment: "staging"}, nil, "apply-finalizer-only-namespace", true)
 
 	require.NoError(t, err)
-	require.Len(t, applies.operations, 1)
-	assert.Empty(t, applies.operations[0].OperationKey)
+	require.Len(t, applies.operations, 2)
+	assert.Equal(t, "commerce/-/users", applies.operations[0].OperationKey)
 	assert.Equal(t, storage.ApplyOperationKindWork, applies.operations[0].OperationKind)
-	require.Len(t, tasks.tasks, 2)
+	assert.Equal(t, "routing/group_finalizer", applies.operations[1].OperationKey)
+	assert.Equal(t, storage.ApplyOperationKindGroupFinalizer, applies.operations[1].OperationKind)
+	// The routing VSchema change is preserved as a task-less finalizer; only the
+	// commerce shard work produces a task.
+	require.Len(t, tasks.tasks, 1)
 	assert.Equal(t, "users", tasks.tasks[0].TableName)
-	assert.Equal(t, "VSchema: routing", tasks.tasks[1].TableName)
-	assert.Equal(t, "vschema_update", tasks.tasks[1].DDLAction)
 }
 
 func TestCreateStoredApplyDoesNotShardWithoutClientOptIn(t *testing.T) {

--- a/pkg/api/operator.go
+++ b/pkg/api/operator.go
@@ -557,6 +557,10 @@ func (s *Service) driveClaimedMultiOperation(ctx context.Context, driverID int, 
 		metrics.RecordOperatorClaimFailure(ctx, "operation_parent_missing")
 		return
 	}
+	if state.IsTerminalApplyState(apply.State) {
+		s.reconcileClaimedOperationFromTerminalParent(operationLeaseCtx, driverID, op, apply)
+		return
+	}
 
 	// The claimed operation row's deployment is the authoritative routing key; an
 	// empty deployment is a corrupt row with no routing key, so fail closed.
@@ -951,29 +955,7 @@ func (s *Service) reconcileUnclaimableParent(ctx context.Context, driverID int, 
 		return
 	}
 	if state.IsTerminalApplyState(parent.State) {
-		s.logger.Info("operator: parent apply already terminal; reconciling operation to terminal state",
-			"driver", driverID,
-			"apply_operation_id", op.ID,
-			"apply_id", parent.ApplyIdentifier,
-			"deployment", op.Deployment,
-			"environment", parent.Environment,
-			"state", parent.State)
-		marked, err := s.markOperationFromApplyState(ctx, driverID, op, parent)
-		if err != nil {
-			s.logger.Error("operator: failed to reconcile apply_operation from terminal parent; derived apply state not updated",
-				"driver", driverID, "apply_operation_id", op.ID, "apply_id", parent.ApplyIdentifier,
-				"deployment", op.Deployment, "environment", parent.Environment, "state", parent.State, "error", err)
-			return
-		}
-		if !marked {
-			return
-		}
-		if _, err := s.updateApplyStateFromOperations(ctx, driverID, parent, rejectFailedApplyReopen); err != nil {
-			s.logger.Error("operator: failed to update derived apply state for terminal parent",
-				"driver", driverID, "apply_operation_id", op.ID, "apply_id", parent.ApplyIdentifier,
-				"deployment", op.Deployment, "environment", parent.Environment, "error", err)
-			return
-		}
+		s.reconcileClaimedOperationFromTerminalParent(ctx, driverID, op, parent)
 		return
 	}
 	s.logger.Warn("operator: parent apply not claimable for operation; operation will be retried",
@@ -984,6 +966,32 @@ func (s *Service) reconcileUnclaimableParent(ctx context.Context, driverID int, 
 		"environment", parent.Environment,
 		"state", parent.State)
 	metrics.RecordOperatorClaimFailure(ctx, "operation_parent_not_claimable")
+}
+
+func (s *Service) reconcileClaimedOperationFromTerminalParent(ctx context.Context, driverID int, op *storage.ApplyOperation, parent *storage.Apply) {
+	s.logger.Info("operator: parent apply already terminal; reconciling operation to terminal state",
+		"driver", driverID,
+		"apply_operation_id", op.ID,
+		"apply_id", parent.ApplyIdentifier,
+		"deployment", op.Deployment,
+		"environment", parent.Environment,
+		"state", parent.State)
+	marked, err := s.markOperationFromApplyState(ctx, driverID, op, parent)
+	if err != nil {
+		s.logger.Error("operator: failed to reconcile apply_operation from terminal parent; derived apply state not updated",
+			"driver", driverID, "apply_operation_id", op.ID, "apply_id", parent.ApplyIdentifier,
+			"deployment", op.Deployment, "environment", parent.Environment, "state", parent.State, "error", err)
+		return
+	}
+	if !marked {
+		return
+	}
+	if _, err := s.updateApplyStateFromOperations(ctx, driverID, parent, rejectFailedApplyReopen); err != nil {
+		s.logger.Error("operator: failed to update derived apply state for terminal parent",
+			"driver", driverID, "apply_operation_id", op.ID, "apply_id", parent.ApplyIdentifier,
+			"deployment", op.Deployment, "environment", parent.Environment, "error", err)
+		return
+	}
 }
 
 // failOperationWithoutTasks terminalizes an operation whose drive failed closed

--- a/pkg/api/operator.go
+++ b/pkg/api/operator.go
@@ -1298,6 +1298,29 @@ func (s *Service) markOperationFromOwnResult(ctx context.Context, driverID int, 
 	if err != nil {
 		return false, fmt.Errorf("load tasks for apply_operation %d (deployment %q): %w", op.ID, op.Deployment, err)
 	}
+	if len(tasks) == 0 {
+		apply, err := s.storage.Applies().Get(ctx, op.ApplyID)
+		if err != nil {
+			return false, fmt.Errorf("load parent apply for task-less apply_operation %d (deployment %q): %w", op.ID, op.Deployment, err)
+		}
+		if apply == nil {
+			return false, fmt.Errorf("parent apply %d not found for task-less apply_operation %d (deployment %q)", op.ApplyID, op.ID, op.Deployment)
+		}
+		plan, err := s.storage.Plans().GetByID(ctx, apply.PlanID)
+		if err != nil {
+			return false, fmt.Errorf("load plan %d for task-less apply_operation %d (deployment %q): %w", apply.PlanID, op.ID, op.Deployment, err)
+		}
+		if plan != nil && op.OperationKind == storage.ApplyOperationKindWork && op.OperationKey == "" && len(plan.FlatDDLChanges()) == 0 && len(vschemaFinalizerNamespaces(plan)) > 0 {
+			currentOp, getOpErr := s.storage.ApplyOperations().Get(ctx, op.ID)
+			if getOpErr != nil {
+				return false, fmt.Errorf("reload task-less apply_operation %d (deployment %q): %w", op.ID, op.Deployment, getOpErr)
+			}
+			if currentOp != nil && state.IsState(currentOp.State, state.ApplyOperation.Completed) {
+				return true, nil
+			}
+			return s.persistOperationState(ctx, driverID, op, apply.State, apply.ErrorMessage)
+		}
+	}
 	taskStates := make([]string, len(tasks))
 	for i, t := range tasks {
 		taskStates[i] = t.State

--- a/pkg/api/operator.go
+++ b/pkg/api/operator.go
@@ -298,8 +298,33 @@ func (s *Service) recoverApplyOperation(ctx context.Context, driverID int, owner
 		s.recoverMultiApplyOperation(ctx, driverID, op, opLease)
 		return
 	}
+	hasTasks, err := s.claimedOperationHasTasks(ctx, op)
+	if err != nil {
+		s.logger.Error("operator: failed to inspect claimed operation tasks; operation will not be driven",
+			"driver", driverID, "lease_owner", owner, "apply_operation_id", op.ID,
+			"apply_db_id", op.ApplyID, "deployment", op.Deployment, "error", err)
+		metrics.RecordOperatorClaimFailure(ctx, "operation_task_inspect_error")
+		return
+	}
+	if !hasTasks {
+		// Apply-level claiming is task-gated, so a valid task-less operation (for
+		// example plan-level VSchema work) cannot be driven through the legacy
+		// parent-lease path. Drive it under the operation lease and project the
+		// parent from the operation row, the same fail-closed path multi-operation
+		// applies use.
+		s.driveClaimedMultiOperation(ctx, driverID, op, opLease, false)
+		return
+	}
 
 	s.recoverSingleApplyOperation(ctx, driverID, owner, op, opLease)
+}
+
+func (s *Service) claimedOperationHasTasks(ctx context.Context, op *storage.ApplyOperation) (bool, error) {
+	tasks, err := s.storage.Tasks().GetByApplyOperationID(ctx, op.ID)
+	if err != nil {
+		return false, fmt.Errorf("load tasks for apply_operation %d (deployment %q): %w", op.ID, op.Deployment, err)
+	}
+	return len(tasks) > 0, nil
 }
 
 // operationSetContainsID reports whether id is one of the apply's operation

--- a/pkg/api/operator.go
+++ b/pkg/api/operator.go
@@ -1286,6 +1286,14 @@ func (s *Service) markOperationFromApplyState(ctx context.Context, driverID int,
 // the row is left claimable for a later poll, and a non-nil error when a read or
 // write fails so the caller skips parent derivation.
 func (s *Service) markOperationFromOwnResult(ctx context.Context, driverID int, op *storage.ApplyOperation) (updated bool, err error) {
+	// A group_finalizer carries no tasks: its terminal state was written by the
+	// drive (driveGroupFinalizer marks it completed only on an accepted apply,
+	// failed otherwise). Deriving from its empty task set would overwrite that
+	// outcome, so leave the row as the drive set it and let the parent derivation
+	// read it.
+	if op.OperationKind == storage.ApplyOperationKindGroupFinalizer {
+		return true, nil
+	}
 	tasks, err := s.storage.Tasks().GetByApplyOperationID(ctx, op.ID)
 	if err != nil {
 		return false, fmt.Errorf("load tasks for apply_operation %d (deployment %q): %w", op.ID, op.Deployment, err)

--- a/pkg/api/operator_multi_operation_integration_test.go
+++ b/pkg/api/operator_multi_operation_integration_test.go
@@ -758,6 +758,19 @@ func (m *matrixTernClient) ResumeApplyOperation(ctx context.Context, apply *stor
 		m.rec.recordParentWrite(m.stor.Applies().Update(ctx, &probe))
 	}
 
+	// A group_finalizer carries no tasks: the real drive (driveGroupFinalizer)
+	// applies the namespace VSchema and marks the operation row directly. Simulate
+	// that outcome here rather than transitioning task rows it does not have.
+	if op.OperationKind == storage.ApplyOperationKindGroupFinalizer {
+		if state.IsState(m.outcome.taskState, state.Task.Failed) {
+			return m.stor.ApplyOperations().MarkFailed(ctx, op.ID, m.outcome.errMsg)
+		}
+		if state.IsState(m.outcome.taskState, state.Task.Completed) {
+			return m.stor.ApplyOperations().MarkCompleted(ctx, op.ID)
+		}
+		return nil
+	}
+
 	tasks, err := m.stor.Tasks().GetByApplyOperationID(ctx, applyOperationID)
 	if err != nil {
 		return fmt.Errorf("matrix fake: load tasks for operation %d: %w", applyOperationID, err)

--- a/pkg/api/operator_multi_operation_integration_test.go
+++ b/pkg/api/operator_multi_operation_integration_test.go
@@ -567,9 +567,9 @@ func seedShardedFinalizerApply(t *testing.T, ctx context.Context, stor storage.S
 	}
 
 	groups := []*storage.ApplyOperationWithTasks{
-		newShardedFinalizerGroup(now, "commerce/-80/users", storage.ApplyOperationKindWork, "users", "alter", "-80", "ALTER TABLE `users` ADD COLUMN `email` varchar(255)"),
-		newShardedFinalizerGroup(now, "commerce/80-/users", storage.ApplyOperationKindWork, "users", "alter", "80-", "ALTER TABLE `users` ADD COLUMN `email` varchar(255)"),
-		newShardedFinalizerGroup(now, "commerce/group_finalizer", storage.ApplyOperationKindGroupFinalizer, "VSchema: commerce", "vschema_update", "", ""),
+		newShardedWorkGroup(now, "commerce/-80/users", "users", "alter", "-80", "ALTER TABLE `users` ADD COLUMN `email` varchar(255)"),
+		newShardedWorkGroup(now, "commerce/80-/users", "users", "alter", "80-", "ALTER TABLE `users` ADD COLUMN `email` varchar(255)"),
+		newTaskLessFinalizerGroup(now, "commerce/group_finalizer"),
 	}
 
 	applyID, err := stor.Applies().CreateWithGroupedOperations(ctx, apply, groups)
@@ -582,12 +582,12 @@ func seedShardedFinalizerApply(t *testing.T, ctx context.Context, stor storage.S
 	}
 }
 
-func newShardedFinalizerGroup(now time.Time, operationKey, operationKind, table, action, shard, ddl string) *storage.ApplyOperationWithTasks {
+func newShardedWorkGroup(now time.Time, operationKey, table, action, shard, ddl string) *storage.ApplyOperationWithTasks {
 	return &storage.ApplyOperationWithTasks{
 		Operation: &storage.ApplyOperation{
 			Deployment:    "region-a",
 			OperationKey:  operationKey,
-			OperationKind: operationKind,
+			OperationKind: storage.ApplyOperationKindWork,
 			Target:        "payments-region-a",
 			State:         state.ApplyOperation.Pending,
 			CutoverPolicy: storage.CutoverPolicyRolling,
@@ -613,6 +613,25 @@ func newShardedFinalizerGroup(now time.Time, operationKey, operationKind, table,
 			CreatedAt:      now,
 			UpdatedAt:      now,
 		}},
+	}
+}
+
+// newTaskLessFinalizerGroup seeds a group_finalizer operation with no task,
+// matching how apply-create builds finalizers: the VSchema change is
+// reconstructed from the plan at drive time, not carried as a task.
+func newTaskLessFinalizerGroup(now time.Time, operationKey string) *storage.ApplyOperationWithTasks {
+	return &storage.ApplyOperationWithTasks{
+		Operation: &storage.ApplyOperation{
+			Deployment:    "region-a",
+			OperationKey:  operationKey,
+			OperationKind: storage.ApplyOperationKindGroupFinalizer,
+			Target:        "payments-region-a",
+			State:         state.ApplyOperation.Pending,
+			CutoverPolicy: storage.CutoverPolicyRolling,
+			OnFailure:     storage.OnFailureHalt,
+			CreatedAt:     now,
+			UpdatedAt:     now,
+		},
 	}
 }
 

--- a/pkg/api/plan_handlers.go
+++ b/pkg/api/plan_handlers.go
@@ -1003,18 +1003,12 @@ func clientSupportsShardedApplyFanout(client tern.Client) bool {
 	return ok && capability.SupportsShardedApplyFanout()
 }
 
+// applyTaskChanges returns the per-table DDL changes that become apply tasks.
+// VSchema application is no longer modeled as a synthetic task: PlanetScale
+// surfaces its VSchema status/diff from engine resume metadata, and a sharded
+// apply runs VSchema as a task-less group_finalizer derived from the plan.
 func applyTaskChanges(plan *storage.Plan) []storage.TableChange {
-	changes := append([]storage.TableChange{}, plan.FlatDDLChanges()...)
-	for namespace, nsData := range plan.Namespaces {
-		if nsData.Artifacts[vSchemaArtifactName] != "" {
-			changes = append(changes, storage.TableChange{
-				Table:     "VSchema: " + namespace,
-				Namespace: namespace,
-				Operation: "vschema_update",
-			})
-		}
-	}
-	return changes
+	return plan.FlatDDLChanges()
 }
 
 func buildApplyOperationGroups(
@@ -1055,26 +1049,14 @@ func canBuildShardedOperationGroups(plan *storage.Plan, taskChanges []storage.Ta
 		return false
 	}
 	hasWorkChange := false
-	workNamespaces := make(map[string]struct{})
-	finalizerNamespaces := make(map[string]struct{})
 	for _, ddlChange := range taskChanges {
-		if isGroupFinalizerChange(ddlChange) {
-			finalizerNamespaces[ddlChange.Namespace] = struct{}{}
-			continue
-		}
 		if ddlChange.DDL == "" || ddlChange.Table == "" {
 			return false
 		}
 		if len(shardsByNamespace[ddlChange.Namespace]) == 0 {
 			return false
 		}
-		workNamespaces[ddlChange.Namespace] = struct{}{}
 		hasWorkChange = true
-	}
-	for namespace := range finalizerNamespaces {
-		if _, ok := workNamespaces[namespace]; !ok {
-			return false
-		}
 	}
 	return hasWorkChange
 }
@@ -1090,13 +1072,10 @@ func buildShardedApplyOperationGroups(
 	now time.Time,
 ) ([]*storage.ApplyOperationWithTasks, error) {
 	shardsByNamespace := changingShardsByNamespace(plan.Shards)
-	workChanges, finalizerChanges := splitShardedTaskChanges(taskChanges)
-	groups := make([]*storage.ApplyOperationWithTasks, 0, len(targets)*(len(workChanges)+len(finalizerChanges)))
+	groups := make([]*storage.ApplyOperationWithTasks, 0, len(targets)*(len(taskChanges)+1))
 	groupsByTargetAndKey := make(map[string]*storage.ApplyOperationWithTasks)
 	for _, target := range targets {
-		workNamespaces := make(map[string]struct{})
-		for _, ddlChange := range workChanges {
-			workNamespaces[ddlChange.Namespace] = struct{}{}
+		for _, ddlChange := range taskChanges {
 			for _, shard := range shardsByNamespace[ddlChange.Namespace] {
 				if err := validateShardOperationKeyParts(ddlChange.Namespace, shard.Shard, ddlChange.Table); err != nil {
 					return nil, err
@@ -1117,10 +1096,13 @@ func buildShardedApplyOperationGroups(
 				group.Tasks = append(group.Tasks, buildApplyTask(plan, ddlChange, environment, applyOpts, shard.Shard, now))
 			}
 		}
-		for _, namespace := range sortedFinalizerNamespaces(finalizerChanges) {
-			if _, ok := workNamespaces[namespace]; !ok {
-				return nil, fmt.Errorf("group finalizer for namespace %q has no work operation siblings", namespace)
-			}
+		// Every namespace that changes its VSchema gets a task-less
+		// group_finalizer. The VSchema is applied once the namespace's shard work
+		// (if any) completes; the finalizer drives it from the plan (reconstructed
+		// by namespace at drive time), not from a synthetic task. A VSchema-only
+		// namespace with no shard work still gets a finalizer so its VSchema change
+		// is never dropped.
+		for _, namespace := range vschemaFinalizerNamespaces(plan) {
 			if err := validateOperationKeyPart("namespace", namespace); err != nil {
 				return nil, err
 			}
@@ -1132,38 +1114,24 @@ func buildShardedApplyOperationGroups(
 			operation.OperationKind = storage.ApplyOperationKindGroupFinalizer
 			groups = append(groups, &storage.ApplyOperationWithTasks{
 				Operation: operation,
-				Tasks:     []*storage.Task{buildApplyTask(plan, finalizerChanges[namespace], environment, applyOpts, "", now)},
 			})
 		}
 	}
 	return groups, nil
 }
 
-func splitShardedTaskChanges(taskChanges []storage.TableChange) ([]storage.TableChange, map[string]storage.TableChange) {
-	workChanges := make([]storage.TableChange, 0, len(taskChanges))
-	finalizerChanges := make(map[string]storage.TableChange)
-	for _, change := range taskChanges {
-		if isGroupFinalizerChange(change) {
-			finalizerChanges[change.Namespace] = change
-			continue
+// vschemaFinalizerNamespaces returns, in sorted order, every namespace in the
+// plan that changes its VSchema — each needs a group_finalizer to apply the
+// VSchema after its shard work (if any) completes.
+func vschemaFinalizerNamespaces(plan *storage.Plan) []string {
+	var namespaces []string
+	for namespace, nsData := range plan.Namespaces {
+		if nsData != nil && nsData.Artifacts[vSchemaArtifactName] != "" {
+			namespaces = append(namespaces, namespace)
 		}
-		workChanges = append(workChanges, change)
-	}
-	return workChanges, finalizerChanges
-}
-
-func sortedFinalizerNamespaces(finalizerChanges map[string]storage.TableChange) []string {
-	namespaces := make([]string, 0, len(finalizerChanges))
-	for namespace := range finalizerChanges {
-		namespaces = append(namespaces, namespace)
 	}
 	sort.Strings(namespaces)
 	return namespaces
-}
-
-func isGroupFinalizerChange(change storage.TableChange) bool {
-	// Routing metadata is the only creation-time group-finalizer payload today.
-	return change.Operation == "vschema_update"
 }
 
 func validateShardOperationKeyParts(namespace, shard, table string) error {

--- a/pkg/api/plan_handlers.go
+++ b/pkg/api/plan_handlers.go
@@ -1031,21 +1031,13 @@ func buildApplyOperationGroups(
 	}
 
 	groups := make([]*storage.ApplyOperationWithTasks, 0, len(targets))
+	allowTasklessWork := len(targets) == 1 && len(taskChanges) == 0 && len(vschemaFinalizerNamespaces(plan)) > 0
 	for _, target := range targets {
 		tasks := buildApplyTasks(plan, taskChanges, environment, applyOpts, "", now)
-		if len(tasks) == 0 && len(vschemaFinalizerNamespaces(plan)) > 0 {
-			// A VSchema-only apply on a non-sharded engine: no table DDL, so the
-			// engine deploys the VSchema in one operation. Drive it as a task-less
-			// group_finalizer reconstructed from the plan rather than an empty work
-			// operation (which would fail closed as having no tasks).
-			op := newPendingApplyOperation(target, finalizerOperationKeySegment, cutoverPolicy, onFailure, now)
-			op.OperationKind = storage.ApplyOperationKindGroupFinalizer
-			groups = append(groups, &storage.ApplyOperationWithTasks{Operation: op})
-			continue
-		}
 		groups = append(groups, &storage.ApplyOperationWithTasks{
-			Operation: newPendingApplyOperation(target, "", cutoverPolicy, onFailure, now),
-			Tasks:     tasks,
+			Operation:     newPendingApplyOperation(target, "", cutoverPolicy, onFailure, now),
+			Tasks:         tasks,
+			AllowTaskless: allowTasklessWork,
 		})
 	}
 	return groups, false, nil

--- a/pkg/api/plan_handlers.go
+++ b/pkg/api/plan_handlers.go
@@ -1032,9 +1032,20 @@ func buildApplyOperationGroups(
 
 	groups := make([]*storage.ApplyOperationWithTasks, 0, len(targets))
 	for _, target := range targets {
+		tasks := buildApplyTasks(plan, taskChanges, environment, applyOpts, "", now)
+		if len(tasks) == 0 && len(vschemaFinalizerNamespaces(plan)) > 0 {
+			// A VSchema-only apply on a non-sharded engine: no table DDL, so the
+			// engine deploys the VSchema in one operation. Drive it as a task-less
+			// group_finalizer reconstructed from the plan rather than an empty work
+			// operation (which would fail closed as having no tasks).
+			op := newPendingApplyOperation(target, finalizerOperationKeySegment, cutoverPolicy, onFailure, now)
+			op.OperationKind = storage.ApplyOperationKindGroupFinalizer
+			groups = append(groups, &storage.ApplyOperationWithTasks{Operation: op})
+			continue
+		}
 		groups = append(groups, &storage.ApplyOperationWithTasks{
 			Operation: newPendingApplyOperation(target, "", cutoverPolicy, onFailure, now),
-			Tasks:     buildApplyTasks(plan, taskChanges, environment, applyOpts, "", now),
+			Tasks:     tasks,
 		})
 	}
 	return groups, false, nil

--- a/pkg/cmd/commands/apply.go
+++ b/pkg/cmd/commands/apply.go
@@ -618,11 +618,7 @@ func watchApplyProgressLog(endpoint, applyID string, heartbeatInterval time.Dura
 				ts.announced = true
 				ts.taskID = tbl.TaskID
 				ts.lastEmit = time.Now()
-				msg := "Table started"
-				if isVSchemaTask(tbl) {
-					msg = "VSchema update started"
-				}
-				kvs := tableKVs(msg, tbl, ts)
+				kvs := tableKVs("Table started", tbl, ts)
 				if tbl.DDL != "" {
 					kvs = append(kvs, "ddl", collapseDDL(tbl.DDL))
 				}
@@ -736,13 +732,7 @@ func watchApplyProgressLog(endpoint, applyID string, heartbeatInterval time.Dura
 
 // tableKVs returns the common key-value pairs for a table log line (table name + task_id if known).
 func tableKVs(msg string, tbl *apitypes.TableProgressResponse, ts *tableLogState) []string {
-	kvs := []string{"msg", msg}
-	if isVSchemaTask(tbl) {
-		// VSchema tasks use keyspace as the identifier, not "table"
-		kvs = append(kvs, "keyspace", tbl.Keyspace)
-	} else {
-		kvs = append(kvs, "table", tbl.TableName)
-	}
+	kvs := []string{"msg", msg, "table", tbl.TableName}
 	taskID := ts.taskID
 	if taskID == "" {
 		taskID = tbl.TaskID
@@ -750,7 +740,7 @@ func tableKVs(msg string, tbl *apitypes.TableProgressResponse, ts *tableLogState
 	if taskID != "" {
 		kvs = append(kvs, "task_id", taskID)
 	}
-	if !isVSchemaTask(tbl) && tbl.Keyspace != "" {
+	if tbl.Keyspace != "" {
 		kvs = append(kvs, "keyspace", tbl.Keyspace)
 	}
 	return kvs
@@ -781,41 +771,23 @@ func appendShardSummary(kvs []string, shards []*apitypes.ShardProgressResponse) 
 	return kvs
 }
 
-// isVSchemaTask returns true if this is a synthetic VSchema update task.
-func isVSchemaTask(tbl *apitypes.TableProgressResponse) bool {
-	return strings.HasPrefix(tbl.TableName, "vschema:")
-}
-
 // emitTableStateChange emits a log line for a table state transition.
 func (e *logEmitter) emitTableStateChange(tbl *apitypes.TableProgressResponse, tblStatus string, ts *tableLogState) {
 	dur := ui.FormatHumanDuration(time.Since(ts.startedAt))
-	vs := isVSchemaTask(tbl)
 
 	switch tblStatus {
 	case state.Apply.Completed:
-		msg := "Table complete"
-		if vs {
-			msg = "VSchema update complete"
-		}
-		kvs := tableKVs(msg, tbl, ts)
+		kvs := tableKVs("Table complete", tbl, ts)
 		kvs = append(kvs, "duration", dur)
 		kvs = appendShardSummary(kvs, tbl.Shards)
 		e.emit(kvs...)
 	case state.Apply.RevertWindow:
-		msg := "Table deployed — revert window open"
-		if vs {
-			msg = "VSchema deployed — revert window open"
-		}
-		kvs := tableKVs(msg, tbl, ts)
+		kvs := tableKVs("Table deployed — revert window open", tbl, ts)
 		kvs = append(kvs, "duration", dur)
 		kvs = appendShardSummary(kvs, tbl.Shards)
 		e.emit(kvs...)
 	case state.Apply.Failed:
-		msg := "Table failed"
-		if vs {
-			msg = "VSchema update failed"
-		}
-		kvs := tableKVs(msg, tbl, ts)
+		kvs := tableKVs("Table failed", tbl, ts)
 		e.emit(append(kvs, "duration", dur)...)
 	case state.Apply.WaitingForCutover:
 		kvs := tableKVs("Waiting for cutover", tbl, ts)

--- a/pkg/cmd/internal/templates/progress.go
+++ b/pkg/cmd/internal/templates/progress.go
@@ -195,6 +195,14 @@ func WriteProgress(data ProgressData) {
 		}
 	}
 
+	// Surface VSchema application status (and diff) from the engine's display
+	// metadata, rather than from a synthetic task in the table list.
+	if data.Metadata != nil {
+		if vs := FormatVSchemaStatus(data.Metadata["vschema_status"], data.Metadata["vschema_diff"]); vs != "" {
+			fmt.Print(vs)
+		}
+	}
+
 	// Show deploy request info for deferred deploys
 	if data.State == state.Apply.WaitingForDeploy {
 		fmt.Println()
@@ -305,40 +313,44 @@ func FormatNamespacedTablesWithActivity(tables []TableProgress, activityBar, act
 			}
 		} else {
 			b.WriteString(FormatKeyspaceHeader(g.namespaces[0]))
-			// Render VSchema tasks first, then DDL tables
 			for _, t := range g.tables {
-				if isVSchemaTask(t) {
-					b.WriteString(FormatVSchemaProgress(t))
-				}
-			}
-			for _, t := range g.tables {
-				if !isVSchemaTask(t) {
-					b.WriteString(FormatTableProgressWithActivity(t, activityBar, activityLabel))
-				}
+				b.WriteString(FormatTableProgressWithActivity(t, activityBar, activityLabel))
 			}
 		}
 	}
 	return b.String()
 }
 
-// writeNamespacedTables renders tables grouped by keyspace to stdout.
-// isVSchemaTask returns true if this is a synthetic VSchema update task.
-func isVSchemaTask(t TableProgress) bool {
-	return t.TableName == "VSchema" || strings.HasPrefix(t.TableName, "vschema:") || strings.HasPrefix(t.TableName, "VSchema:")
-}
-
-// FormatVSchemaProgress returns a VSchema update rendered as a string.
-// The DDL field contains a VSchema diff (not SQL), so we render it with
-// diff coloring via colorizeDiffLine, stripping ---/+++/@@ headers.
-func FormatVSchemaProgress(t TableProgress) string {
+// FormatVSchemaStatus renders the VSchema-application status and diff surfaced
+// on a progress response's display metadata (vschema_status / vschema_diff).
+// Returns empty when the deploy carries no VSchema change. The diff field is a
+// VSchema diff (not SQL), rendered with diff coloring via colorizeDiffLine.
+func FormatVSchemaStatus(status, diff string) string {
+	if status == "" && diff == "" {
+		return ""
+	}
 	var b strings.Builder
-	label := vschemaStatusLabel(state.NormalizeState(t.Status))
-	fmt.Fprintf(&b, "    ~ VSchema: %s\n", label)
-	if t.DDL != "" {
-		b.WriteString(FormatVSchemaDiff(t.DDL, indentContent))
+	fmt.Fprintf(&b, "    ~ VSchema: %s\n", vschemaMetadataStatusLabel(status))
+	if diff != "" {
+		b.WriteString(FormatVSchemaDiff(diff, indentContent))
 	}
 	b.WriteString("\n")
 	return b.String()
+}
+
+// vschemaMetadataStatusLabel maps the engine's vschema_status display value to a
+// human label.
+func vschemaMetadataStatusLabel(status string) string {
+	switch status {
+	case "applying":
+		return "Applying..."
+	case "applied":
+		return "Applied"
+	case "":
+		return "Pending"
+	default:
+		return status
+	}
 }
 
 // FormatVSchemaDiff returns a VSchema diff with colorized +/- lines as a string,
@@ -352,29 +364,6 @@ func FormatVSchemaDiff(diff, indent string) string {
 		fmt.Fprintf(&b, "%s%s\n", indent, colorizeDiffLine(line))
 	}
 	return b.String()
-}
-
-// writeVSchemaDiff renders a VSchema diff to stdout.
-// vschemaStatusLabel maps a task status to a VSchema-specific display label.
-func vschemaStatusLabel(status string) string {
-	switch status {
-	case state.Apply.Pending:
-		return "Pending"
-	case state.Apply.Running:
-		return "Applying..."
-	case state.Apply.WaitingForDeploy:
-		return "Pending"
-	case state.Apply.WaitingForCutover, state.Apply.Recovering, state.Apply.CuttingOver:
-		return "Applying..."
-	case state.Apply.Completed:
-		return "Applied"
-	case state.Apply.Failed:
-		return ANSIRed + "Failed" + ANSIReset
-	case state.Apply.RevertWindow:
-		return "Applied (pending revert)"
-	default:
-		return status
-	}
 }
 
 // writeFailureGuidance prints remediation instructions for failed applies.

--- a/pkg/cmd/internal/templates/progress_shard_test.go
+++ b/pkg/cmd/internal/templates/progress_shard_test.go
@@ -130,14 +130,6 @@ func TestFormatShardLineDisplaysOnePercentAfterCopyStarts(t *testing.T) {
 	assert.NotContains(t, line, "0%")
 }
 
-func TestIsVSchemaTask(t *testing.T) {
-	assert.True(t, isVSchemaTask(TableProgress{TableName: "VSchema"}))
-	assert.True(t, isVSchemaTask(TableProgress{TableName: "vschema:myapp_sharded"}))
-	assert.True(t, isVSchemaTask(TableProgress{TableName: "VSchema: myapp_sharded"}))
-	assert.False(t, isVSchemaTask(TableProgress{TableName: "users"}))
-	assert.False(t, isVSchemaTask(TableProgress{TableName: "orders"}))
-}
-
 func TestIsPlanetScaleEngine(t *testing.T) {
 	assert.True(t, state.IsPlanetScaleEngine("planetscale"))
 	assert.True(t, state.IsPlanetScaleEngine("PlanetScale"))

--- a/pkg/cmd/internal/templates/progress_states_test.go
+++ b/pkg/cmd/internal/templates/progress_states_test.go
@@ -3,7 +3,6 @@ package templates
 import (
 	"io"
 	"os"
-	"strings"
 	"testing"
 
 	"github.com/block/schemabot/pkg/state"
@@ -321,36 +320,22 @@ func TestFormatTableProgress_EstimateExceeded(t *testing.T) {
 	})
 }
 
-func TestVSchemaStatusLabel(t *testing.T) {
-	assert.Equal(t, "Pending", vschemaStatusLabel(state.Apply.Pending))
-	assert.Equal(t, "Pending", vschemaStatusLabel(state.Apply.WaitingForDeploy))
-	assert.Contains(t, vschemaStatusLabel(state.Apply.Running), "Applying")
-	assert.Contains(t, vschemaStatusLabel(state.Apply.WaitingForCutover), "Applying")
-	assert.Contains(t, vschemaStatusLabel(state.Apply.Recovering), "Applying")
-	assert.Contains(t, vschemaStatusLabel(state.Apply.CuttingOver), "Applying")
-	assert.Contains(t, vschemaStatusLabel(state.Apply.Completed), "Applied")
-	assert.Contains(t, vschemaStatusLabel(state.Apply.Failed), "Failed")
-	assert.Contains(t, vschemaStatusLabel(state.Apply.RevertWindow), "pending revert")
-}
+func TestFormatVSchemaStatus(t *testing.T) {
+	// No VSchema change → nothing rendered.
+	assert.Empty(t, FormatVSchemaStatus("", ""))
 
-func TestVSchemaTaskRenderedWithDDLTasks(t *testing.T) {
-	tables := []TableProgress{
-		{TableName: "users", Namespace: "myapp_sharded", Status: state.Apply.Completed, DDL: "ALTER TABLE `users` ADD COLUMN `phone` varchar(20)"},
-		{TableName: "VSchema: myapp_sharded", Namespace: "myapp_sharded", Status: state.Apply.Running},
-	}
-	result := FormatNamespacedTables(tables)
-	assert.Contains(t, result, "VSchema")
-	assert.Contains(t, result, "users")
-	vsIdx := strings.Index(result, "VSchema")
-	usersIdx := strings.Index(result, "users:")
-	assert.Less(t, vsIdx, usersIdx, "VSchema should render before DDL tables")
-}
+	// Status only.
+	applying := FormatVSchemaStatus("applying", "")
+	assert.Contains(t, applying, "VSchema")
+	assert.Contains(t, applying, "Applying")
 
-func TestIsVSchemaTask_Variants(t *testing.T) {
-	assert.True(t, isVSchemaTask(TableProgress{TableName: "VSchema"}))
-	assert.True(t, isVSchemaTask(TableProgress{TableName: "VSchema: myapp_sharded"}))
-	assert.True(t, isVSchemaTask(TableProgress{TableName: "vschema:myapp"}))
-	assert.False(t, isVSchemaTask(TableProgress{TableName: "users"}))
+	applied := FormatVSchemaStatus("applied", "")
+	assert.Contains(t, applied, "Applied")
+
+	// Status + diff: the diff is rendered with the VSchema status.
+	withDiff := FormatVSchemaStatus("applied", "--- a/commerce.json\n+++ b/commerce.json\n+  \"new_table\": {}")
+	assert.Contains(t, withDiff, "Applied")
+	assert.Contains(t, withDiff, "new_table")
 }
 
 func TestStateColorFunc_PlanetScalePhases(t *testing.T) {

--- a/pkg/engine/planetscale/apply.go
+++ b/pkg/engine/planetscale/apply.go
@@ -32,6 +32,39 @@ func noChangesApplyResult(message string) *engine.ApplyResult {
 	return &engine.ApplyResult{Accepted: true, Message: message}
 }
 
+// combinedVSchemaDiff joins the per-keyspace VSchema diffs carried on the plan
+// annotations (SchemaChange.Metadata["vschema"]) into a single display blob.
+// Returns empty when no namespace changes its VSchema. A deploy that touches a
+// single keyspace returns that keyspace's diff verbatim; a multi-keyspace deploy
+// prefixes each diff with its keyspace so the rendered output stays unambiguous.
+func combinedVSchemaDiff(changes []engine.SchemaChange) string {
+	type nsDiff struct {
+		namespace string
+		diff      string
+	}
+	var diffs []nsDiff
+	for _, sc := range changes {
+		if d := sc.Metadata["vschema"]; d != "" {
+			diffs = append(diffs, nsDiff{namespace: sc.Namespace, diff: d})
+		}
+	}
+	switch len(diffs) {
+	case 0:
+		return ""
+	case 1:
+		return diffs[0].diff
+	default:
+		var b strings.Builder
+		for i, d := range diffs {
+			if i > 0 {
+				b.WriteString("\n")
+			}
+			fmt.Fprintf(&b, "keyspace %s:\n%s", d.namespace, d.diff)
+		}
+		return b.String()
+	}
+}
+
 // Apply starts executing a schema change plan.
 // Creates a PlanetScale branch, applies DDL via MySQL connection to the branch,
 // then creates and starts a deploy request.
@@ -90,6 +123,11 @@ func (e *Engine) Apply(ctx context.Context, req *engine.ApplyRequest) (*engine.A
 			Metadata:         encoded,
 		})
 	}
+
+	// Capture the VSchema diff carried on the plan annotations so it can be
+	// surfaced from stored state alongside the deploy's VSchema status, without a
+	// synthetic task row. Empty when no namespace changes its VSchema.
+	vschemaDiff := combinedVSchemaDiff(req.Changes)
 
 	// Create or reuse a branch
 	existingBranch := req.Options["branch"]
@@ -261,6 +299,7 @@ func (e *Engine) Apply(ctx context.Context, req *engine.ApplyRequest) (*engine.A
 		BranchName:            branchName,
 		DeployRequestID:       dr.Number,
 		DeployRequestURL:      dr.HtmlURL,
+		VSchemaDiff:           vschemaDiff,
 		ExistingMigrationCtxs: existingContexts,
 	})
 	dr, err = e.waitForDeployRequestPending(ctx, client, org, req.Database, dr)
@@ -356,6 +395,7 @@ func (e *Engine) Apply(ctx context.Context, req *engine.ApplyRequest) (*engine.A
 			DeployRequestURL:      dr.HtmlURL,
 			IsInstant:             useInstant,
 			DeferredDeploy:        true,
+			VSchemaDiff:           vschemaDiff,
 			ExistingMigrationCtxs: existingContexts,
 		})
 		if encErr != nil {
@@ -428,6 +468,7 @@ func (e *Engine) Apply(ctx context.Context, req *engine.ApplyRequest) (*engine.A
 		DeployRequestID:       dr.Number,
 		DeployRequestURL:      dr.HtmlURL,
 		IsInstant:             useInstant,
+		VSchemaDiff:           vschemaDiff,
 		ExistingMigrationCtxs: existingContexts,
 	})
 	if err != nil {

--- a/pkg/engine/planetscale/planetscale.go
+++ b/pkg/engine/planetscale/planetscale.go
@@ -445,6 +445,14 @@ type psMetadata struct {
 	// same path branch/deploy-URL/instant use.
 	VSchemaStatus string `json:"vschema_status,omitempty"`
 
+	// VSchemaDiff is the VSchema change rendered as a unified diff, captured at
+	// deploy creation from the plan annotation. It is surfaced through the
+	// display-metadata projection so the progress view can show the VSchema
+	// change alongside its status without a synthetic task row. Empty when the
+	// deploy carries no VSchema change. For a deploy spanning multiple keyspaces
+	// the per-keyspace diffs are concatenated under keyspace headers.
+	VSchemaDiff string `json:"vschema_diff,omitempty"`
+
 	// ExistingMigrationCtxs is the set of SHOW VITESS_MIGRATIONS contexts that
 	// already existed just before this deploy started, keyed by context. It is
 	// the durable baseline that lets a later process — a resume on another pod,

--- a/pkg/engine/planetscale/progress.go
+++ b/pkg/engine/planetscale/progress.go
@@ -612,6 +612,9 @@ func psDisplayMetadata(meta *psMetadata) map[string]string {
 	if meta.VSchemaStatus != "" {
 		set("vschema_status", meta.VSchemaStatus)
 	}
+	if meta.VSchemaDiff != "" {
+		set("vschema_diff", meta.VSchemaDiff)
+	}
 	return m
 }
 

--- a/pkg/storage/mysqlstore/applies.go
+++ b/pkg/storage/mysqlstore/applies.go
@@ -692,8 +692,11 @@ func insertApplyGroupedOperations(ctx context.Context, tx *sql.Tx, apply *storag
 		if group.Operation == nil {
 			return fmt.Errorf("create apply %s deployment %s: grouped operation is missing its operation row", apply.ApplyIdentifier, deployment)
 		}
-		if len(group.Tasks) == 0 {
-			return fmt.Errorf("create apply %s deployment %s: grouped operation has no tasks", apply.ApplyIdentifier, deployment)
+		// A group_finalizer carries no tasks — it applies namespace-level work
+		// (e.g. VSchema) reconstructed from the plan at drive time. Every other
+		// (work) operation must have at least one task.
+		if len(group.Tasks) == 0 && group.Operation.OperationKind != storage.ApplyOperationKindGroupFinalizer {
+			return fmt.Errorf("create apply %s deployment %s: grouped work operation has no tasks", apply.ApplyIdentifier, deployment)
 		}
 
 		group.Operation.ApplyID = applyID

--- a/pkg/storage/mysqlstore/applies.go
+++ b/pkg/storage/mysqlstore/applies.go
@@ -693,9 +693,11 @@ func insertApplyGroupedOperations(ctx context.Context, tx *sql.Tx, apply *storag
 			return fmt.Errorf("create apply %s deployment %s: grouped operation is missing its operation row", apply.ApplyIdentifier, deployment)
 		}
 		// A group_finalizer carries no tasks — it applies namespace-level work
-		// (e.g. VSchema) reconstructed from the plan at drive time. Every other
-		// (work) operation must have at least one task.
-		if len(group.Tasks) == 0 && group.Operation.OperationKind != storage.ApplyOperationKindGroupFinalizer {
+		// reconstructed from the plan at drive time. A caller may also explicitly
+		// allow a task-less work operation for a single grouped engine apply whose
+		// only work is plan-level metadata. Every other work operation must have at
+		// least one task so operation-scoped drives fail closed on bad scoping.
+		if len(group.Tasks) == 0 && group.Operation.OperationKind != storage.ApplyOperationKindGroupFinalizer && !group.AllowTaskless {
 			return fmt.Errorf("create apply %s deployment %s: grouped work operation has no tasks", apply.ApplyIdentifier, deployment)
 		}
 

--- a/pkg/storage/mysqlstore/applies_test.go
+++ b/pkg/storage/mysqlstore/applies_test.go
@@ -326,7 +326,7 @@ func TestApplyStore_CreateWithGroupedOperationsRejectsInvalidGroups(t *testing.T
 		{name: "empty groups", groups: nil, wantError: "grouped operations are empty"},
 		{name: "nil group", groups: []*storage.ApplyOperationWithTasks{nil}, wantError: "grouped operation is nil"},
 		{name: "nil operation", groups: []*storage.ApplyOperationWithTasks{{Tasks: []*storage.Task{newGroupedCreateTask(time.Now(), "payments-a", "users")}}}, wantError: "grouped operation is missing its operation row"},
-		{name: "no tasks", groups: []*storage.ApplyOperationWithTasks{{Operation: &storage.ApplyOperation{Deployment: "payments-a", Target: "payments-target"}}}, wantError: "grouped operation has no tasks"},
+		{name: "work op no tasks", groups: []*storage.ApplyOperationWithTasks{{Operation: &storage.ApplyOperation{Deployment: "payments-a", Target: "payments-target", OperationKind: storage.ApplyOperationKindWork}}}, wantError: "grouped work operation has no tasks"},
 	}
 
 	for _, tt := range tests {
@@ -346,6 +346,48 @@ func TestApplyStore_CreateWithGroupedOperationsRejectsInvalidGroups(t *testing.T
 			assert.Nil(t, gotApply)
 		})
 	}
+}
+
+// A group_finalizer operation carries no tasks: it applies namespace-level work
+// (VSchema) reconstructed from the plan at drive time. CreateWithGroupedOperations
+// must accept a task-less finalizer alongside its work siblings rather than
+// rejecting it as an empty group.
+func TestApplyStore_CreateWithGroupedOperationsAllowsTaskLessFinalizer(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+	now := time.Now()
+
+	apply := newGroupedCreateApply(now, "apply_grouped_taskless_finalizer")
+	groups := []*storage.ApplyOperationWithTasks{
+		newGroupedCreateGroup(now, "payments-a", "payments-a-target", "users"),
+		{Operation: &storage.ApplyOperation{
+			Deployment:    "payments-a",
+			OperationKey:  "commerce/group_finalizer",
+			OperationKind: storage.ApplyOperationKindGroupFinalizer,
+			Target:        "payments-a-target",
+			State:         state.ApplyOperation.Pending,
+			CutoverPolicy: storage.CutoverPolicyRolling,
+			OnFailure:     storage.OnFailureHalt,
+			CreatedAt:     now,
+			UpdatedAt:     now,
+		}},
+	}
+
+	applyID, err := store.Applies().CreateWithGroupedOperations(ctx, apply, groups)
+	require.NoError(t, err)
+
+	ops, err := store.ApplyOperations().ListByApply(ctx, applyID)
+	require.NoError(t, err)
+	require.Len(t, ops, 2)
+	var finalizer *storage.ApplyOperation
+	for _, op := range ops {
+		if op.OperationKind == storage.ApplyOperationKindGroupFinalizer {
+			finalizer = op
+		}
+	}
+	require.NotNil(t, finalizer, "task-less group_finalizer operation should be persisted")
+	assert.Equal(t, "commerce/group_finalizer", finalizer.OperationKey)
 }
 
 // TestApplyStore_CreateWithGroupedOperationsBlocksOverlapOnSecondaryDeployment

--- a/pkg/storage/mysqlstore/apply_operations.go
+++ b/pkg/storage/mysqlstore/apply_operations.go
@@ -564,7 +564,10 @@ const applyOperationHeartbeatStaleness = "1 MINUTE"
 // rows in the SAME deployment (the per-shard, per-namespace fan-out of a
 // sharded apply) do not gate each other, so a deployment's shard work drives
 // in parallel; the group_finalizer clause below still holds each namespace's
-// finalizer until that namespace's work siblings complete. The gate is
+// finalizer until that namespace's work siblings complete — and a namespace
+// whose only change is its VSchema (no shard work siblings) has its finalizer
+// claimable immediately, since there is no incomplete sibling to wait on. The
+// gate is
 // cutover_policy-aware (the policy is captured per row at apply-create):
 //
 //   - rolling (the default, and any non-barrier value — which fails closed to
@@ -646,7 +649,6 @@ func (s *applyOperationStore) FindNextApplyOperation(ctx context.Context, owner 
 	)
 	queryArgs = append(queryArgs,
 		storage.ApplyOperationKindGroupFinalizer,
-		storage.ApplyOperationKindWork,
 		storage.ApplyOperationKindWork,
 		state.ApplyOperation.Completed,
 	)
@@ -758,14 +760,6 @@ func (s *applyOperationStore) FindNextApplyOperation(ctx context.Context, owner 
 					)
 					OR (
 						apply_operations.operation_kind = ?
-						AND EXISTS (
-							SELECT 1
-							FROM apply_operations AS sibling
-							WHERE sibling.apply_id = apply_operations.apply_id
-								AND sibling.deployment = apply_operations.deployment
-								AND sibling.operation_kind = ?
-								AND SUBSTRING_INDEX(sibling.operation_key, '/', 1) = SUBSTRING_INDEX(apply_operations.operation_key, '/', 1)
-						)
 						AND NOT EXISTS (
 							SELECT 1
 							FROM apply_operations AS sibling

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -336,8 +336,9 @@ type ApplyStore interface {
 
 // ApplyOperationWithTasks groups one apply_operations row with the task rows it owns.
 type ApplyOperationWithTasks struct {
-	Operation *ApplyOperation
-	Tasks     []*Task
+	Operation     *ApplyOperation
+	Tasks         []*Task
+	AllowTaskless bool
 }
 
 // RecentAppliesFilter controls recent apply queries for status views.

--- a/pkg/tern/apply_states_test.go
+++ b/pkg/tern/apply_states_test.go
@@ -4,13 +4,11 @@ import (
 	"fmt"
 	"log/slog"
 	"testing"
-	"time"
 
 	"github.com/block/schemabot/pkg/engine"
 	"github.com/block/schemabot/pkg/state"
 	"github.com/block/schemabot/pkg/storage"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // TestDeriveApplyPhase verifies that engine events with structured state
@@ -251,111 +249,6 @@ func TestDeriveOverallState(t *testing.T) {
 			assert.Equal(t, tt.wantState, got)
 		})
 	}
-}
-
-func TestVSchemaTasksCreatedAlongsideDDL(t *testing.T) {
-	plan := &storage.Plan{
-		Namespaces: map[string]*storage.NamespacePlanData{
-			"myapp_sharded": {
-				Tables:    []storage.TableChange{{Table: "users", DDL: "ALTER TABLE users ADD COLUMN phone VARCHAR(20)", Operation: "alter", Namespace: "myapp_sharded"}},
-				Artifacts: map[string]string{"vschema.json": `{"sharded": true, "tables": {"users": {}}}`},
-			},
-			"myapp": {
-				Artifacts: map[string]string{"vschema.json": `{"tables": {"users_seq": {"type": "sequence"}}}`},
-			},
-		},
-	}
-
-	ddlChanges := plan.FlatDDLChanges()
-	require.Len(t, ddlChanges, 1, "should have 1 DDL change")
-
-	for ns, nsData := range plan.Namespaces {
-		if namespaceHasVSchemaArtifact(nsData) {
-			ddlChanges = append(ddlChanges, storage.TableChange{
-				Table:     "VSchema: " + ns,
-				Namespace: ns,
-				Operation: "vschema_update",
-			})
-		}
-	}
-
-	assert.Len(t, ddlChanges, 3, "should have 1 DDL + 2 VSchema tasks")
-
-	var vschemaTasks []storage.TableChange
-	for _, c := range ddlChanges {
-		if c.Operation == "vschema_update" {
-			vschemaTasks = append(vschemaTasks, c)
-		}
-	}
-	assert.Len(t, vschemaTasks, 2, "should have 2 VSchema tasks (one per keyspace)")
-	for _, vt := range vschemaTasks {
-		assert.Contains(t, vt.Table, "VSchema: ")
-		assert.Equal(t, "vschema_update", vt.Operation)
-	}
-}
-
-func TestDeriveVSchemaTaskState(t *testing.T) {
-	c := &LocalClient{}
-	now := time.Now()
-
-	t.Run("pending task stays pending when deploy is running", func(t *testing.T) {
-		task := &storage.Task{State: state.Task.Pending}
-		result := &engine.ProgressResult{State: engine.StateRunning, Message: "Deploying"}
-		got := c.deriveVSchemaTaskState(task, result, state.Task.Running, now)
-		assert.Equal(t, state.Task.Pending, got)
-	})
-
-	t.Run("transitions to running on VSchema apply message", func(t *testing.T) {
-		task := &storage.Task{State: state.Task.Pending}
-		result := &engine.ProgressResult{State: engine.StateRunning, Message: "Applying VSchema changes"}
-		got := c.deriveVSchemaTaskState(task, result, state.Task.Running, now)
-		assert.Equal(t, state.Task.Running, got)
-		assert.NotNil(t, task.StartedAt)
-	})
-
-	t.Run("transitions to revert_window when overall is revert_window", func(t *testing.T) {
-		task := &storage.Task{State: state.Task.Running}
-		result := &engine.ProgressResult{State: engine.StateRevertWindow}
-		got := c.deriveVSchemaTaskState(task, result, state.Task.RevertWindow, now)
-		assert.Equal(t, state.Task.RevertWindow, got)
-	})
-
-	t.Run("transitions to completed when overall is completed", func(t *testing.T) {
-		task := &storage.Task{State: state.Task.Running}
-		result := &engine.ProgressResult{State: engine.StateCompleted}
-		got := c.deriveVSchemaTaskState(task, result, state.Task.Completed, now)
-		assert.Equal(t, state.Task.Completed, got)
-	})
-
-	t.Run("transitions to failed on engine failure", func(t *testing.T) {
-		task := &storage.Task{State: state.Task.Running}
-		result := &engine.ProgressResult{State: engine.StateFailed}
-		got := c.deriveVSchemaTaskState(task, result, state.Task.Failed, now)
-		assert.Equal(t, state.Task.Failed, got)
-	})
-
-	t.Run("transitions to retryable failure when operator can recover", func(t *testing.T) {
-		task := &storage.Task{State: state.Task.Running}
-		result := &engine.ProgressResult{State: engine.StateFailed, Retryable: true, ErrorMessage: "temporary engine failure"}
-		got := c.deriveVSchemaTaskState(task, result, state.Task.FailedRetryable, now)
-		assert.Equal(t, state.Task.FailedRetryable, got)
-		assert.Equal(t, "temporary engine failure", task.ErrorMessage)
-		assert.Nil(t, task.CompletedAt)
-	})
-
-	t.Run("stays pending during cutover since VSchema is applied after", func(t *testing.T) {
-		task := &storage.Task{State: state.Task.Pending}
-		result := &engine.ProgressResult{State: engine.StateWaitingForCutover, Message: "Waiting for cutover"}
-		got := c.deriveVSchemaTaskState(task, result, state.Task.WaitingForCutover, now)
-		assert.Equal(t, state.Task.Pending, got)
-	})
-
-	t.Run("terminal task state is preserved", func(t *testing.T) {
-		task := &storage.Task{State: state.Task.Completed}
-		result := &engine.ProgressResult{State: engine.StateRunning, Message: "Applying VSchema changes"}
-		got := c.deriveVSchemaTaskState(task, result, state.Task.Running, now)
-		assert.Equal(t, state.Task.Completed, got)
-	})
 }
 
 // applyQuiesceDecision gates the apply-level terminal/pause side-effects on the

--- a/pkg/tern/local_apply.go
+++ b/pkg/tern/local_apply.go
@@ -197,14 +197,9 @@ func (c *LocalClient) transitionTaskState(ctx context.Context, task *storage.Tas
 }
 
 // markTasksRunning sets DDL tasks to running state with a start timestamp.
-// VSchema tasks are skipped — their state is driven by the deploy request
-// lifecycle (deriveVSchemaTaskState), not by apply start.
 func (c *LocalClient) markTasksRunning(ctx context.Context, tasks []*storage.Task) {
 	now := time.Now()
 	for _, task := range tasks {
-		if isVSchemaTask(task) {
-			continue
-		}
 		task.State = state.Task.Running
 		task.StartedAt = &now
 		task.UpdatedAt = now

--- a/pkg/tern/local_apply_grouped.go
+++ b/pkg/tern/local_apply_grouped.go
@@ -108,7 +108,7 @@ func (c *LocalClient) executeGroupedApply(ctx context.Context, apply *storage.Ap
 				c.logger.Debug("OnStateChange: nil resume state", "apply_id", apply.ApplyIdentifier)
 				return
 			}
-			if saveErr := c.saveEngineResumeState(ctx, tasks, rs); saveErr != nil {
+			if saveErr := c.saveEngineResumeState(ctx, apply, tasks, rs); saveErr != nil {
 				c.logger.Warn("OnStateChange: failed to persist opaque resume state", "apply_id", apply.ApplyIdentifier, "error", saveErr)
 			}
 		},
@@ -151,7 +151,7 @@ func (c *LocalClient) executeGroupedApply(ctx context.Context, apply *storage.Ap
 	if result.ResumeState != nil {
 		resumeState = result.ResumeState
 		if c.config.Type == storage.DatabaseTypeVitess {
-			if saveErr := c.saveEngineResumeState(ctx, tasks, resumeState); saveErr != nil {
+			if saveErr := c.saveEngineResumeState(ctx, apply, tasks, resumeState); saveErr != nil {
 				c.logger.Error("failed to save opaque engine resume state", "apply_id", apply.ApplyIdentifier, "error", saveErr)
 				c.failApplyWithTasks(ctx, apply, tasks, fmt.Sprintf("failed to save engine resume state: %v", saveErr))
 				return
@@ -159,6 +159,12 @@ func (c *LocalClient) executeGroupedApply(ctx context.Context, apply *storage.Ap
 		}
 	}
 	if c.config.Type == storage.DatabaseTypeVitess && resumeState == nil {
+		if isTasklessVSchemaOnlyPlan(tasks, plan) {
+			if completeErr := c.completeTasklessGroupedApply(ctx, apply, result.Message); completeErr != nil {
+				c.logger.Error("failed to complete task-less grouped apply", "apply_id", apply.ApplyIdentifier, "error", completeErr)
+			}
+			return
+		}
 		c.failApplyWithTasks(ctx, apply, tasks, "engine accepted Vitess apply without resume state")
 		return
 	}
@@ -188,12 +194,95 @@ func (c *LocalClient) executeGroupedApply(ctx context.Context, apply *storage.Ap
 	c.pollForCompletionAtomic(ctx, apply, tasks, creds, resumeState, options, releaseAtCutoverBarrier)
 }
 
-func (c *LocalClient) saveEngineResumeState(ctx context.Context, tasks []*storage.Task, resumeState *engine.ResumeState) error {
-	operationID, err := applyOperationIDForTasks(tasks)
+func (c *LocalClient) saveEngineResumeState(ctx context.Context, apply *storage.Apply, tasks []*storage.Task, resumeState *engine.ResumeState) error {
+	operationID, err := c.applyOperationIDForApplyTasks(ctx, apply, tasks)
 	if err != nil {
 		return err
 	}
 	return c.saveEngineResumeStateForOperation(ctx, operationID, resumeState)
+}
+
+func (c *LocalClient) applyOperationIDForApplyTasks(ctx context.Context, apply *storage.Apply, tasks []*storage.Task) (int64, error) {
+	if len(tasks) > 0 {
+		return applyOperationIDForTasks(tasks)
+	}
+	if apply == nil {
+		return 0, fmt.Errorf("engine resume state has no tasks and no apply")
+	}
+	store := c.storage.ApplyOperations()
+	if store == nil {
+		return 0, fmt.Errorf("engine resume state has no tasks and no apply operation store")
+	}
+	ops, err := store.ListByApply(ctx, apply.ID)
+	if err != nil {
+		return 0, fmt.Errorf("list apply operations for task-less apply %s: %w", apply.ApplyIdentifier, err)
+	}
+	if len(ops) != 1 {
+		return 0, fmt.Errorf("engine resume state has no tasks and apply %s has %d operations", apply.ApplyIdentifier, len(ops))
+	}
+	return ops[0].ID, nil
+}
+
+func isTasklessVSchemaOnlyPlan(tasks []*storage.Task, plan *storage.Plan) bool {
+	if len(tasks) != 0 || plan == nil {
+		return false
+	}
+	if len(plan.FlatDDLChanges()) != 0 {
+		return false
+	}
+	for _, nsData := range plan.Namespaces {
+		if namespaceHasVSchemaArtifact(nsData) {
+			return true
+		}
+	}
+	return false
+}
+
+func (c *LocalClient) completeTasklessGroupedApply(ctx context.Context, apply *storage.Apply, message string) error {
+	if suppressParentApplyWrites(ctx) {
+		operationID, err := c.applyOperationIDForApplyTasks(ctx, apply, nil)
+		if err != nil {
+			return fmt.Errorf("resolve task-less apply operation for apply %s: %w", apply.ApplyIdentifier, err)
+		}
+		if err := c.storage.ApplyOperations().MarkCompleted(ctx, operationID); err != nil {
+			return fmt.Errorf("mark task-less apply_operation %d completed (apply %s): %w", operationID, apply.ApplyIdentifier, err)
+		}
+		return nil
+	}
+	now := time.Now()
+	apply.State = state.Apply.Completed
+	apply.CompletedAt = &now
+	apply.UpdatedAt = now
+	if err := c.storage.Applies().Update(ctx, apply); err != nil {
+		return fmt.Errorf("complete task-less grouped apply %s: %w", apply.ApplyIdentifier, err)
+	}
+	if message == "" {
+		message = "Apply completed with state: completed"
+	}
+	c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventStateTransition, storage.LogSourceSchemaBot,
+		message, state.Apply.Running, state.Apply.Completed)
+	metrics.AdjustActiveApplies(ctx, -1, apply.Database, apply.Deployment, apply.Environment)
+	c.notifyTerminalObserver(apply, nil)
+	return nil
+}
+
+func (c *LocalClient) markTasklessOperationState(ctx context.Context, apply *storage.Apply, opState, errorMessage string) error {
+	operationID, err := c.applyOperationIDForApplyTasks(ctx, apply, nil)
+	if err != nil {
+		return fmt.Errorf("resolve task-less apply operation for apply %s: %w", apply.ApplyIdentifier, err)
+	}
+	switch {
+	case state.IsState(opState, state.Apply.Completed):
+		return c.storage.ApplyOperations().MarkCompleted(ctx, operationID)
+	case state.IsState(opState, state.Apply.Failed):
+		return c.storage.ApplyOperations().MarkFailed(ctx, operationID, errorMessage)
+	case state.IsState(opState, state.Apply.FailedRetryable, state.Apply.WaitingForCutover):
+		return c.storage.ApplyOperations().UpdateState(ctx, operationID, opState)
+	case state.IsTerminalApplyState(opState):
+		return c.storage.ApplyOperations().MarkTerminal(ctx, operationID, opState)
+	default:
+		return nil
+	}
 }
 
 func (c *LocalClient) saveEngineResumeStateForOperation(ctx context.Context, operationID int64, resumeState *engine.ResumeState) error {
@@ -553,7 +642,7 @@ func (c *LocalClient) handleAtomicProgressTick(ctx context.Context, eng engine.E
 	if result.ResumeState != nil && resumeState != nil {
 		*resumeState = *result.ResumeState
 		if c.config.Type == storage.DatabaseTypeVitess {
-			if saveErr := c.saveEngineResumeState(ctx, tasks, resumeState); saveErr != nil {
+			if saveErr := c.saveEngineResumeState(ctx, apply, tasks, resumeState); saveErr != nil {
 				c.logger.Error("failed to save Vitess engine resume state from progress polling",
 					"apply_id", apply.ApplyIdentifier, "error", saveErr)
 				c.markApplyRetryableWithTasks(ctx, apply, tasks, fmt.Sprintf("failed to save engine resume state from progress polling: %v", saveErr))
@@ -697,6 +786,16 @@ func (c *LocalClient) handleAtomicProgressTick(ctx context.Context, eng engine.E
 	// would suppress the operator's once-only terminal summary.
 	if suppressParentApplyWrites(ctx) {
 		opState := state.DeriveApplyState(taskStates(tasks))
+		if len(tasks) == 0 {
+			opState = state.DeriveApplyState([]string{newState})
+			if state.IsTerminalApplyState(opState) || state.IsState(opState, state.Apply.FailedRetryable, state.Apply.WaitingForCutover) {
+				if err := c.markTasklessOperationState(ctx, apply, opState, result.ErrorMessage); err != nil {
+					c.logger.Error("failed to mark task-less apply_operation from progress",
+						"apply_id", apply.ApplyIdentifier, "operation_state", opState, "error", err)
+					return true
+				}
+			}
+		}
 		if releaseAtCutoverBarrier && state.IsState(opState, state.Apply.WaitingForCutover) {
 			c.logger.Info("operation parked at cutover barrier; exiting operation drive",
 				"mode", groupedApplyMode(apply, options), "apply_id", apply.ApplyIdentifier, "operation_state", opState)
@@ -712,7 +811,9 @@ func (c *LocalClient) handleAtomicProgressTick(ctx context.Context, eng engine.E
 
 	// Update apply state from persisted task state so recovery guards can keep
 	// storage ahead of stale engine progress until Spirit reaches the cutover wait again.
-	if derived, ok := c.deriveAggregateApplyState(ctx, apply, tasks); ok {
+	if len(tasks) == 0 {
+		apply.State = state.DeriveApplyState([]string{newState})
+	} else if derived, ok := c.deriveAggregateApplyState(ctx, apply, tasks); ok {
 		apply.State = derived
 	}
 	apply.UpdatedAt = now

--- a/pkg/tern/local_apply_grouped.go
+++ b/pkg/tern/local_apply_grouped.go
@@ -143,6 +143,13 @@ func (c *LocalClient) executeGroupedApply(ctx context.Context, apply *storage.Ap
 		return
 	}
 
+	if isTasklessVSchemaOnlyPlan(tasks, plan) {
+		if completeErr := c.completeTasklessGroupedApply(ctx, apply, result.Message); completeErr != nil {
+			c.logger.Error("failed to complete task-less grouped apply", "apply_id", apply.ApplyIdentifier, "error", completeErr)
+		}
+		return
+	}
+
 	// Persist the engine resume state and set IsInstant on tasks before marking
 	// running. The progress handler reads task.is_instant and the engine resume
 	// state to render the instant label and deploy display fields, so both must
@@ -159,12 +166,6 @@ func (c *LocalClient) executeGroupedApply(ctx context.Context, apply *storage.Ap
 		}
 	}
 	if c.config.Type == storage.DatabaseTypeVitess && resumeState == nil {
-		if isTasklessVSchemaOnlyPlan(tasks, plan) {
-			if completeErr := c.completeTasklessGroupedApply(ctx, apply, result.Message); completeErr != nil {
-				c.logger.Error("failed to complete task-less grouped apply", "apply_id", apply.ApplyIdentifier, "error", completeErr)
-			}
-			return
-		}
 		c.failApplyWithTasks(ctx, apply, tasks, "engine accepted Vitess apply without resume state")
 		return
 	}

--- a/pkg/tern/local_apply_grouped.go
+++ b/pkg/tern/local_apply_grouped.go
@@ -63,7 +63,7 @@ func (c *LocalClient) executeGroupedApply(ctx context.Context, apply *storage.Ap
 		c.failApplyWithTasks(ctx, apply, tasks, err.Error())
 		return
 	}
-	changes := groupedResumeChanges(tasks)
+	changes := groupedResumeChanges(tasks, plan)
 
 	// Mark the apply as started before calling the engine. The engine may run
 	// for a long time (branch creation, DDL application, deploy request) and

--- a/pkg/tern/local_apply_grouped.go
+++ b/pkg/tern/local_apply_grouped.go
@@ -954,18 +954,6 @@ func (c *LocalClient) syncAtomicTaskProgress(ctx context.Context, tasks []*stora
 		if retryableFailure && state.IsTerminalTaskState(task.State) {
 			continue
 		}
-		// VSchema tasks follow deploy-request-level state, not per-migration state.
-		// They have no SHOW VITESS_MIGRATIONS rows. Their state transitions are:
-		// pending → running (during in_progress_vschema) → completed/failed.
-		if isVSchemaTask(task) {
-			vsState := c.deriveVSchemaTaskState(task, result, newState, now)
-			if vsState != task.State {
-				msg := fmt.Sprintf("VSchema %s → %s", task.State, vsState)
-				c.transitionTaskState(ctx, task, task.ApplyID, vsState, msg)
-			}
-			continue
-		}
-
 		if tp, ok := engineProgressForTask(tableProgress, task); ok {
 			task.RowsCopied = tp.RowsCopied
 			task.RowsTotal = tp.RowsTotal
@@ -1068,45 +1056,5 @@ func (c *LocalClient) writeShardProgress(ctx context.Context, table *storage.Tas
 			"database", table.Database, "environment", table.Environment,
 			"namespace", table.Namespace, "table", table.TableName, "shard", sh.Shard,
 			"error", err)
-	}
-}
-
-// deriveVSchemaTaskState determines the state for a VSchema task based on
-// the engine progress result. VSchema tasks have no per-migration rows in
-// SHOW VITESS_MIGRATIONS — their state tracks the deploy request's VSchema
-// application phase (in_progress_vschema).
-func (c *LocalClient) deriveVSchemaTaskState(task *storage.Task, result *engine.ProgressResult, taskState string, now time.Time) string {
-	if state.IsTerminalTaskState(task.State) {
-		return task.State
-	}
-
-	switch {
-	case state.IsState(taskState, state.Task.FailedRetryable):
-		if task.ErrorMessage == "" {
-			task.ErrorMessage = progressFailureMessage(result)
-		}
-		return state.Task.FailedRetryable
-	case result.Message == engine.MessageApplyingVSchema:
-		if task.StartedAt == nil {
-			task.StartedAt = &now
-		}
-		return state.Task.Running
-	case result.State == engine.StateFailed:
-		if task.CompletedAt == nil {
-			task.CompletedAt = &now
-		}
-		return state.Task.Failed
-	case state.IsState(taskState, state.Task.RevertWindow):
-		if task.CompletedAt == nil {
-			task.CompletedAt = &now
-		}
-		return state.Task.RevertWindow
-	case result.State.IsTerminal(), state.IsState(taskState, state.Task.Completed):
-		if task.CompletedAt == nil {
-			task.CompletedAt = &now
-		}
-		return state.Task.Completed
-	default:
-		return task.State
 	}
 }

--- a/pkg/tern/local_client.go
+++ b/pkg/tern/local_client.go
@@ -1854,7 +1854,26 @@ func (c *LocalClient) Progress(ctx context.Context, req *ternv1.ProgressRequest)
 		return nil, fmt.Errorf("get tasks for apply %s: %w", req.ApplyId, err)
 	}
 	if len(tasks) == 0 {
-		return nil, fmt.Errorf("get tasks for apply %s: %w", req.ApplyId, storage.ErrTaskNotFound)
+		// A task-less apply — e.g. a VSchema-only apply driven by a
+		// group_finalizer, which carries no task rows. Serve its state from the
+		// apply row, which the operator maintains by deriving it from the
+		// operation rows; the API progress handler overlays the engine display
+		// fields (VSchema status/diff, branch) from the operations' resume
+		// metadata. An apply with neither tasks nor operations is genuinely
+		// taskless work and stays the fail-closed not-found case.
+		ops, opErr := c.storage.ApplyOperations().ListByApply(ctx, apply.ID)
+		if opErr != nil {
+			return nil, fmt.Errorf("list apply_operations for apply %s: %w", req.ApplyId, opErr)
+		}
+		if len(ops) == 0 {
+			return nil, fmt.Errorf("get tasks for apply %s: %w", req.ApplyId, storage.ErrTaskNotFound)
+		}
+		c.logger.Info("Progress: serving task-less apply from operations",
+			"apply_id", req.ApplyId, "operation_count", len(ops), "state", apply.State)
+		return &ternv1.ProgressResponse{
+			State:  storageStateToProto(apply.State),
+			Engine: c.protoEngine(),
+		}, nil
 	}
 
 	c.logger.Debug("Progress: found tasks", "count", len(tasks), "database", c.config.Database, "apply_id", req.ApplyId)

--- a/pkg/tern/local_client.go
+++ b/pkg/tern/local_client.go
@@ -1677,19 +1677,9 @@ func (c *LocalClient) Apply(ctx context.Context, req *ternv1.ApplyRequest) (*ter
 	}
 	optionsJSON := storage.MarshalApplyOptions(applyOpts)
 
-	// Create VSchema tasks for namespaces with VSchema changes so the
-	// progress API and TUI can track VSchema application alongside DDL.
-	// For VSchema-only deploys (0 DDL changes), this gives the progress API
-	// something to track.
-	for ns, nsData := range plan.Namespaces {
-		if namespaceHasVSchemaArtifact(nsData) {
-			ddlChanges = append(ddlChanges, storage.TableChange{
-				Table:     "VSchema: " + ns,
-				Namespace: ns,
-				Operation: "vschema_update",
-			})
-		}
-	}
+	// VSchema application is not modeled as a synthetic task. PlanetScale
+	// surfaces its VSchema status/diff from engine resume metadata, and a sharded
+	// apply runs VSchema as a task-less group_finalizer derived from the plan.
 
 	// Build the Apply record (1 Apply -> N Tasks).
 	applyIdentifier := "apply-" + strings.ReplaceAll(uuid.New().String(), "-", "")[:16]

--- a/pkg/tern/local_client_test.go
+++ b/pkg/tern/local_client_test.go
@@ -866,7 +866,7 @@ func TestGroupedResumeChangesGroupsTasksByNamespace(t *testing.T) {
 		{Namespace: "billing", TableName: "invoices", DDL: "ALTER TABLE `invoices` ADD COLUMN `due_at` datetime", DDLAction: "alter"},
 	}
 
-	changes := groupedResumeChanges(tasks)
+	changes := groupedResumeChanges(tasks, nil)
 
 	require.Len(t, changes, 2)
 	assert.Equal(t, "commerce", changes[0].Namespace)
@@ -892,7 +892,7 @@ func TestGroupedResumeChangesPreservesDDL(t *testing.T) {
 		{Namespace: "commerce", TableName: "users", DDL: "ALTER TABLE `users` ADD COLUMN `email` varchar(255)", DDLAction: "alter"},
 	}
 
-	changes := groupedResumeChanges(tasks)
+	changes := groupedResumeChanges(tasks, nil)
 
 	require.Len(t, changes, 1)
 	assert.Equal(t, "commerce", changes[0].Namespace)
@@ -911,7 +911,7 @@ func TestGroupedResumeChangesPreservesMultiNamespaceScopedTasks(t *testing.T) {
 		{Namespace: "routing", TableName: "lookup", DDL: "ALTER TABLE `lookup` ADD COLUMN `region` varchar(32)", DDLAction: "alter"},
 	}
 
-	changes := groupedResumeChanges(tasks)
+	changes := groupedResumeChanges(tasks, nil)
 
 	require.Len(t, changes, 2)
 	byNamespace := make(map[string]engine.SchemaChange)

--- a/pkg/tern/local_client_test.go
+++ b/pkg/tern/local_client_test.go
@@ -445,9 +445,17 @@ func (s *exactProgressStorage) ApplyOperations() storage.ApplyOperationStore {
 type exactProgressApplyOperationStore struct {
 	storage.ApplyOperationStore
 	data    *storage.EngineResumeState
+	ops     []*storage.ApplyOperation
 	err     error
 	saveErr error
 	saved   *storage.EngineResumeState
+}
+
+func (s *exactProgressApplyOperationStore) ListByApply(context.Context, int64) ([]*storage.ApplyOperation, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.ops, nil
 }
 
 func (s *exactProgressApplyOperationStore) SaveEngineResumeState(_ context.Context, operationID int64, resumeState *storage.EngineResumeState) error {
@@ -610,8 +618,9 @@ func TestLocalClient_ProgressByApplyIDReturnsNotFoundForMissingApplyData(t *test
 		t.Run(tc.name, func(t *testing.T) {
 			client := &LocalClient{
 				storage: &exactProgressStorage{
-					applies: &exactProgressApplyStore{apply: tc.apply},
-					tasks:   &exactProgressTaskStore{tasks: tc.tasks},
+					applies:         &exactProgressApplyStore{apply: tc.apply},
+					tasks:           &exactProgressTaskStore{tasks: tc.tasks},
+					applyOperations: &exactProgressApplyOperationStore{},
 				},
 				logger: slog.Default(),
 			}
@@ -623,6 +632,32 @@ func TestLocalClient_ProgressByApplyIDReturnsNotFoundForMissingApplyData(t *test
 			require.ErrorIs(t, err, tc.wantError)
 		})
 	}
+}
+
+// A VSchema-only apply carries no task rows — it is driven by a task-less
+// group_finalizer. Progress must serve such an apply from its operation rows
+// (the operator maintains apply.State by deriving it from them) rather than
+// failing it as "no tasks".
+func TestLocalClient_ProgressServesTaskLessApplyFromOperations(t *testing.T) {
+	client := &LocalClient{
+		storage: &exactProgressStorage{
+			applies: &exactProgressApplyStore{apply: &storage.Apply{
+				ID: 7, ApplyIdentifier: "apply-vschema-only", State: state.Apply.Completed,
+			}},
+			tasks: &exactProgressTaskStore{},
+			applyOperations: &exactProgressApplyOperationStore{ops: []*storage.ApplyOperation{
+				{ID: 1, OperationKind: storage.ApplyOperationKindGroupFinalizer, State: state.ApplyOperation.Completed},
+			}},
+		},
+		logger: slog.Default(),
+	}
+
+	resp, err := client.Progress(t.Context(), &ternv1.ProgressRequest{
+		ApplyId:     "apply-vschema-only",
+		Environment: "staging",
+	})
+	require.NoError(t, err)
+	assert.True(t, isTerminalProtoState(resp.State), "task-less completed apply should report a terminal state, got %v", resp.State)
 }
 
 func groupedResumeStateClient(databaseType string, applyOperations storage.ApplyOperationStore) *LocalClient {

--- a/pkg/tern/local_client_test.go
+++ b/pkg/tern/local_client_test.go
@@ -849,14 +849,12 @@ func TestGroupedResumeChangesGroupsTasksByNamespace(t *testing.T) {
 	assert.Equal(t, statement.StatementAlterTable, changes[1].TableChanges[0].Operation)
 }
 
-// A VSchema task carries no DDL, so a resumed apply with mixed VSchema and DDL
-// work must keep the VSchema out of TableChanges and instead flag its namespace
-// with the vschema_changed metadata. This is how the engine knows to re-apply
-// vschema.json from the schema files on resume.
-func TestGroupedResumeChangesCarriesVSchemaMetadata(t *testing.T) {
+// A resumed grouped apply rebuilds the engine changes from the stored DDL
+// tasks, grouped per namespace, preserving each table's DDL and operation so the
+// engine keys per-table progress on the same namespace/table pairs.
+func TestGroupedResumeChangesPreservesDDL(t *testing.T) {
 	tasks := []*storage.Task{
 		{Namespace: "commerce", TableName: "users", DDL: "ALTER TABLE `users` ADD COLUMN `email` varchar(255)", DDLAction: "alter"},
-		{Namespace: "commerce", TableName: "VSchema: commerce", DDLAction: "vschema_update"},
 	}
 
 	changes := groupedResumeChanges(tasks)
@@ -867,32 +865,15 @@ func TestGroupedResumeChangesCarriesVSchemaMetadata(t *testing.T) {
 	assert.Equal(t, "users", changes[0].TableChanges[0].Table)
 	assert.Equal(t, tasks[0].DDL, changes[0].TableChanges[0].DDL)
 	assert.Equal(t, statement.StatementAlterTable, changes[0].TableChanges[0].Operation)
-	assert.Equal(t, "true", changes[0].Metadata["vschema_changed"])
 	for _, tc := range changes[0].TableChanges {
 		assert.NotEmpty(t, tc.DDL, "resume changes must not contain an empty-DDL table change")
 	}
 }
 
-// A VSchema-only apply has no DDL tasks. Its resumed change must still carry a
-// namespace flagged with vschema_changed and no table changes, so the engine
-// applies vschema.json without attempting to execute an empty statement.
-func TestGroupedResumeChangesVSchemaOnly(t *testing.T) {
-	tasks := []*storage.Task{
-		{Namespace: "commerce", TableName: "VSchema: commerce", DDLAction: "vschema_update"},
-	}
-
-	changes := groupedResumeChanges(tasks)
-
-	require.Len(t, changes, 1)
-	assert.Equal(t, "commerce", changes[0].Namespace)
-	assert.Empty(t, changes[0].TableChanges)
-	assert.Equal(t, "true", changes[0].Metadata["vschema_changed"])
-}
-
 func TestGroupedResumeChangesPreservesMultiNamespaceScopedTasks(t *testing.T) {
 	tasks := []*storage.Task{
 		{Namespace: "commerce", TableName: "users", DDL: "ALTER TABLE `users` ADD COLUMN `email` varchar(255)", DDLAction: "alter"},
-		{Namespace: "routing", TableName: "VSchema: routing", DDLAction: "vschema_update"},
+		{Namespace: "routing", TableName: "lookup", DDL: "ALTER TABLE `lookup` ADD COLUMN `region` varchar(32)", DDLAction: "alter"},
 	}
 
 	changes := groupedResumeChanges(tasks)
@@ -907,10 +888,10 @@ func TestGroupedResumeChangesPreservesMultiNamespaceScopedTasks(t *testing.T) {
 	assert.Equal(t, "users", commerce.TableChanges[0].Table)
 	assert.Equal(t, "ALTER TABLE `users` ADD COLUMN `email` varchar(255)", commerce.TableChanges[0].DDL)
 	assert.Equal(t, statement.StatementAlterTable, commerce.TableChanges[0].Operation)
-	assert.Empty(t, commerce.Metadata["vschema_changed"])
 	routing := byNamespace["routing"]
-	assert.Empty(t, routing.TableChanges)
-	assert.Equal(t, "true", routing.Metadata["vschema_changed"])
+	require.Len(t, routing.TableChanges, 1)
+	assert.Equal(t, "lookup", routing.TableChanges[0].Table)
+	assert.Equal(t, statement.StatementAlterTable, routing.TableChanges[0].Operation)
 }
 
 func TestTaskTargetShardsReturnsSortedUniqueShardSelector(t *testing.T) {

--- a/pkg/tern/local_control_resume.go
+++ b/pkg/tern/local_control_resume.go
@@ -640,7 +640,7 @@ func (c *LocalClient) launchAtomicResume(ctx context.Context, apply *storage.App
 				c.logger.Debug("OnStateChange: nil resume state", "apply_id", apply.ApplyIdentifier)
 				return
 			}
-			if saveErr := c.saveEngineResumeState(ctx, tasks, rs); saveErr != nil {
+			if saveErr := c.saveEngineResumeState(ctx, apply, tasks, rs); saveErr != nil {
 				c.logger.Warn("OnStateChange: failed to persist opaque resume state", "apply_id", apply.ApplyIdentifier, "error", saveErr)
 			}
 		},
@@ -658,7 +658,7 @@ func (c *LocalClient) launchAtomicResume(ctx context.Context, apply *storage.App
 			// running on the provider. A failure to persist the resume state must
 			// not become terminal apply state — the owner exits and the operator
 			// retries against the in-flight work rather than abandoning it.
-			if saveErr := c.saveEngineResumeState(ctx, tasks, resumeState); saveErr != nil {
+			if saveErr := c.saveEngineResumeState(ctx, apply, tasks, resumeState); saveErr != nil {
 				return fmt.Errorf("%w: save engine resume state after grouped resume of apply %s (database %s): %w", errGroupedResumeStateUnavailable, apply.ApplyIdentifier, apply.Database, saveErr)
 			}
 		}
@@ -758,7 +758,7 @@ var errGroupedResumeStateUnavailable = errors.New("grouped resume state unavaila
 func (c *LocalClient) groupedResumeState(ctx context.Context, apply *storage.Apply, tasks []*storage.Task) (*engine.ResumeState, error) {
 	contextOnly := &engine.ResumeState{MigrationContext: apply.ApplyIdentifier}
 
-	operationID, err := applyOperationIDForTasks(tasks)
+	operationID, err := c.applyOperationIDForApplyTasks(ctx, apply, tasks)
 	if err != nil {
 		// Persisted engine resume state is scoped to an apply operation, so a
 		// Vitess apply whose tasks cannot be resolved to one leaves SchemaBot
@@ -890,14 +890,21 @@ func (c *LocalClient) ResumeApplyOperation(ctx context.Context, apply *storage.A
 	}
 	if len(tasks) == 0 {
 		// A group_finalizer carries no tasks: it applies the namespace's VSchema
-		// from the plan once its sibling shard work has completed. Any other
-		// (work) operation with no tasks is the fail-closed signal for an invalid
-		// or mismatched applyOperationID — unlike ResumeApply, we must not forward
-		// it to resumeApplyWithTasks, which would fail the whole parent apply.
+		// from the plan once its sibling shard work has completed. A work operation
+		// with no tasks is valid only when the plan itself carries VSchema work;
+		// otherwise it is the fail-closed signal for an invalid or mismatched
+		// applyOperationID.
 		if op.OperationKind == storage.ApplyOperationKindGroupFinalizer {
 			return c.driveGroupFinalizer(ctx, apply, op)
 		}
-		return fmt.Errorf("apply_operation %d (apply %s): %w", applyOperationID, apply.ApplyIdentifier, ErrNoTasksForApplyOperation)
+		plan, planErr := c.storage.Plans().GetByID(ctx, apply.PlanID)
+		if planErr != nil {
+			return fmt.Errorf("get plan for task-less apply_operation %d (apply %s): %w", applyOperationID, apply.ApplyIdentifier, planErr)
+		}
+		if !isTasklessVSchemaOnlyPlan(tasks, plan) || op.OperationKind != storage.ApplyOperationKindWork || op.OperationKey != "" {
+			return fmt.Errorf("apply_operation %d (apply %s): %w", applyOperationID, apply.ApplyIdentifier, ErrNoTasksForApplyOperation)
+		}
+		return c.resumeApplyWithTasks(ctx, apply, tasks, apply.GetOptions().Map(), false, false)
 	}
 	siblings, err := c.storage.ApplyOperations().ListByApply(ctx, apply.ID)
 	if err != nil {
@@ -1193,7 +1200,21 @@ func (c *LocalClient) driveFinalizerToTerminal(ctx context.Context, eng engine.E
 // of tasks the caller has loaded. Callers choose whether tasks are scoped to the
 // whole apply or to a single operation.
 func (c *LocalClient) resumeApplyWithTasks(ctx context.Context, apply *storage.Apply, tasks []*storage.Task, options map[string]string, releaseAtCutoverBarrier bool, forceCutoverResume bool) error {
-	if len(tasks) == 0 {
+	// Get the plan to retrieve original DDLs
+	plan, err := c.storage.Plans().GetByID(ctx, apply.PlanID)
+	if err != nil || plan == nil {
+		c.logger.Warn("plan not found for apply, marking as failed",
+			"apply_id", apply.ApplyIdentifier,
+			"plan_id", apply.PlanID)
+		apply.State = state.Apply.Failed
+		apply.ErrorMessage = "plan not found during recovery"
+		if err := c.storage.Applies().Update(ctx, apply); err != nil {
+			c.logger.Error("failed to update apply state", "apply_id", apply.ApplyIdentifier, "state", state.Apply.Failed, "error", err)
+		}
+		c.notifyTerminalObserver(apply, tasks)
+		return nil
+	}
+	if len(tasks) == 0 && !isTasklessVSchemaOnlyPlan(tasks, plan) {
 		c.logger.Warn("no tasks found for apply, marking as failed",
 			"apply_id", apply.ApplyIdentifier)
 		apply.State = state.Apply.Failed
@@ -1210,21 +1231,6 @@ func (c *LocalClient) resumeApplyWithTasks(ctx context.Context, apply *storage.A
 	}
 	if handled, err := c.processPendingStartControlRequest(ctx, apply, options, releaseAtCutoverBarrier); handled || err != nil {
 		return err
-	}
-
-	// Get the plan to retrieve original DDLs
-	plan, err := c.storage.Plans().GetByID(ctx, apply.PlanID)
-	if err != nil || plan == nil {
-		c.logger.Warn("plan not found for apply, marking as failed",
-			"apply_id", apply.ApplyIdentifier,
-			"plan_id", apply.PlanID)
-		apply.State = state.Apply.Failed
-		apply.ErrorMessage = "plan not found during recovery"
-		if err := c.storage.Applies().Update(ctx, apply); err != nil {
-			c.logger.Error("failed to update apply state", "apply_id", apply.ApplyIdentifier, "state", state.Apply.Failed, "error", err)
-		}
-		c.notifyTerminalObserver(apply, tasks)
-		return nil
 	}
 
 	if state.IsState(apply.State, state.Apply.Pending) && apply.StartedAt == nil {

--- a/pkg/tern/local_control_resume.go
+++ b/pkg/tern/local_control_resume.go
@@ -1200,6 +1200,10 @@ func (c *LocalClient) driveFinalizerToTerminal(ctx context.Context, eng engine.E
 // of tasks the caller has loaded. Callers choose whether tasks are scoped to the
 // whole apply or to a single operation.
 func (c *LocalClient) resumeApplyWithTasks(ctx context.Context, apply *storage.Apply, tasks []*storage.Task, options map[string]string, releaseAtCutoverBarrier bool, forceCutoverResume bool) error {
+	if handled, err := c.processPendingStopControlRequest(ctx, apply); handled || err != nil {
+		return err
+	}
+
 	// Get the plan to retrieve original DDLs
 	plan, err := c.storage.Plans().GetByID(ctx, apply.PlanID)
 	if err != nil || plan == nil {
@@ -1224,10 +1228,6 @@ func (c *LocalClient) resumeApplyWithTasks(ctx context.Context, apply *storage.A
 		}
 		c.notifyTerminalObserver(apply, tasks)
 		return nil
-	}
-
-	if handled, err := c.processPendingStopControlRequest(ctx, apply); handled || err != nil {
-		return err
 	}
 	if handled, err := c.processPendingStartControlRequest(ctx, apply, options, releaseAtCutoverBarrier); handled || err != nil {
 		return err

--- a/pkg/tern/local_control_resume.go
+++ b/pkg/tern/local_control_resume.go
@@ -629,7 +629,7 @@ func (c *LocalClient) launchAtomicResume(ctx context.Context, apply *storage.App
 	result, err := eng.Apply(ctx, &engine.ApplyRequest{
 		Database:     apply.Database,
 		PlanID:       plan.PlanIdentifier,
-		Changes:      groupedResumeChanges(tasks),
+		Changes:      groupedResumeChanges(tasks, plan),
 		TargetShards: taskTargetShards(tasks),
 		SchemaFiles:  plan.SchemaFiles,
 		Options:      options,
@@ -791,13 +791,14 @@ func (c *LocalClient) groupedResumeState(ctx context.Context, apply *storage.App
 	return stored, nil
 }
 
-// groupedResumeChanges rebuilds the engine changes for a grouped resume from
-// the stored tasks, grouped per namespace. Tasks carry the authoritative
-// remaining work after re-planning, and engines key per-table progress on
-// namespace and table, so the rebuilt changes must preserve both. VSchema is not
-// a task — it runs as a task-less group_finalizer reconstructed from the plan —
-// so every task here is table DDL.
-func groupedResumeChanges(tasks []*storage.Task) []engine.SchemaChange {
+// groupedResumeChanges rebuilds the engine changes for a grouped apply from the
+// stored tasks plus the plan. Tasks carry the table DDL (engines key per-table
+// progress on namespace and table, so both are preserved). VSchema is not a
+// task: each namespace whose plan carries a vschema.json artifact is flagged
+// with vschema_changed so the engine applies its VSchema from the schema files
+// alongside its DDL — or on its own for a VSchema-only namespace that has no DDL
+// tasks. This mirrors how the fresh apply builds changes from the plan.
+func groupedResumeChanges(tasks []*storage.Task, plan *storage.Plan) []engine.SchemaChange {
 	indexByNamespace := make(map[string]int, len(tasks))
 	var changes []engine.SchemaChange
 	ensureNamespace := func(namespace string) int {
@@ -823,6 +824,23 @@ func groupedResumeChanges(tasks []*storage.Task) []engine.SchemaChange {
 			DDL:       task.DDL,
 			Operation: ddl.OpToStatementType(task.DDLAction),
 		})
+	}
+	if plan != nil {
+		namespaces := make([]string, 0, len(plan.Namespaces))
+		for ns := range plan.Namespaces {
+			namespaces = append(namespaces, ns)
+		}
+		sort.Strings(namespaces)
+		for _, ns := range namespaces {
+			if !namespaceHasVSchemaArtifact(plan.Namespaces[ns]) {
+				continue
+			}
+			idx := ensureNamespace(ns)
+			if changes[idx].Metadata == nil {
+				changes[idx].Metadata = make(map[string]string, 1)
+			}
+			changes[idx].Metadata["vschema_changed"] = "true"
+		}
 	}
 	return changes
 }

--- a/pkg/tern/local_control_resume.go
+++ b/pkg/tern/local_control_resume.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/block/schemabot/pkg/ddl"
@@ -792,10 +793,9 @@ func (c *LocalClient) groupedResumeState(ctx context.Context, apply *storage.App
 // groupedResumeChanges rebuilds the engine changes for a grouped resume from
 // the stored tasks, grouped per namespace. Tasks carry the authoritative
 // remaining work after re-planning, and engines key per-table progress on
-// namespace and table, so the rebuilt changes must preserve both. VSchema tasks
-// carry no DDL — they are excluded from TableChanges and instead flag their
-// namespace with the vschema_changed metadata so the engine applies vschema.json
-// from the schema files, mirroring how the fresh apply builds changes.
+// namespace and table, so the rebuilt changes must preserve both. VSchema is not
+// a task — it runs as a task-less group_finalizer reconstructed from the plan —
+// so every task here is table DDL.
 func groupedResumeChanges(tasks []*storage.Task) []engine.SchemaChange {
 	indexByNamespace := make(map[string]int, len(tasks))
 	var changes []engine.SchemaChange
@@ -810,13 +810,6 @@ func groupedResumeChanges(tasks []*storage.Task) []engine.SchemaChange {
 	}
 	for _, task := range tasks {
 		idx := ensureNamespace(task.Namespace)
-		if isVSchemaTask(task) {
-			if changes[idx].Metadata == nil {
-				changes[idx].Metadata = make(map[string]string)
-			}
-			changes[idx].Metadata["vschema_changed"] = "true"
-			continue
-		}
 		changes[idx].TableChanges = append(changes[idx].TableChanges, engine.TableChange{
 			Table:     task.TableName,
 			DDL:       task.DDL,
@@ -824,13 +817,6 @@ func groupedResumeChanges(tasks []*storage.Task) []engine.SchemaChange {
 		})
 	}
 	return changes
-}
-
-// isVSchemaTask reports whether a task represents a VSchema update rather than a
-// table DDL change. VSchema tasks have no DDL; their work is applying the
-// namespace's vschema.json.
-func isVSchemaTask(task *storage.Task) bool {
-	return task.DDLAction == "vschema_update"
 }
 
 func (c *LocalClient) notifyTerminalObserver(apply *storage.Apply, tasks []*storage.Task) {
@@ -859,17 +845,6 @@ func (c *LocalClient) ResumeApply(ctx context.Context, apply *storage.Apply) err
 // are loaded scoped to the operation rather than the whole apply, so a driver
 // can advance one deployment independently of its siblings.
 func (c *LocalClient) ResumeApplyOperation(ctx context.Context, apply *storage.Apply, applyOperationID int64) error {
-	tasks, err := c.storage.Tasks().GetByApplyOperationID(ctx, applyOperationID)
-	if err != nil {
-		return fmt.Errorf("get tasks for apply_operation %d (apply %s): %w", applyOperationID, apply.ApplyIdentifier, err)
-	}
-	// An empty result is the fail-closed signal for an invalid or mismatched
-	// applyOperationID. Unlike ResumeApply, we must not forward this to
-	// resumeApplyWithTasks: that path marks the whole parent apply as failed,
-	// which is incorrect when only one operation lookup came back empty.
-	if len(tasks) == 0 {
-		return fmt.Errorf("apply_operation %d (apply %s): %w", applyOperationID, apply.ApplyIdentifier, ErrNoTasksForApplyOperation)
-	}
 	op, err := c.storage.ApplyOperations().Get(ctx, applyOperationID)
 	if err != nil {
 		return fmt.Errorf("get apply_operation %d (apply %s): %w", applyOperationID, apply.ApplyIdentifier, err)
@@ -882,6 +857,21 @@ func (c *LocalClient) ResumeApplyOperation(ctx context.Context, apply *storage.A
 	// this apply's state. The routing and gRPC paths enforce the same invariant.
 	if op.ApplyID != apply.ID {
 		return fmt.Errorf("apply_operation %d belongs to apply %d, not %s (%d)", applyOperationID, op.ApplyID, apply.ApplyIdentifier, apply.ID)
+	}
+	tasks, err := c.storage.Tasks().GetByApplyOperationID(ctx, applyOperationID)
+	if err != nil {
+		return fmt.Errorf("get tasks for apply_operation %d (apply %s): %w", applyOperationID, apply.ApplyIdentifier, err)
+	}
+	if len(tasks) == 0 {
+		// A group_finalizer carries no tasks: it applies the namespace's VSchema
+		// from the plan once its sibling shard work has completed. Any other
+		// (work) operation with no tasks is the fail-closed signal for an invalid
+		// or mismatched applyOperationID — unlike ResumeApply, we must not forward
+		// it to resumeApplyWithTasks, which would fail the whole parent apply.
+		if op.OperationKind == storage.ApplyOperationKindGroupFinalizer {
+			return c.driveGroupFinalizer(ctx, apply, op)
+		}
+		return fmt.Errorf("apply_operation %d (apply %s): %w", applyOperationID, apply.ApplyIdentifier, ErrNoTasksForApplyOperation)
 	}
 	siblings, err := c.storage.ApplyOperations().ListByApply(ctx, apply.ID)
 	if err != nil {
@@ -908,13 +898,6 @@ func (c *LocalClient) ResumeApplyOperationCutover(ctx context.Context, apply *st
 	if apply == nil {
 		return fmt.Errorf("stored apply is required to drive apply_operation %d cutover", applyOperationID)
 	}
-	tasks, err := c.storage.Tasks().GetByApplyOperationID(ctx, applyOperationID)
-	if err != nil {
-		return fmt.Errorf("get tasks for apply_operation %d (apply %s): %w", applyOperationID, apply.ApplyIdentifier, err)
-	}
-	if len(tasks) == 0 {
-		return fmt.Errorf("apply_operation %d (apply %s): %w", applyOperationID, apply.ApplyIdentifier, ErrNoTasksForApplyOperation)
-	}
 	op, err := c.storage.ApplyOperations().Get(ctx, applyOperationID)
 	if err != nil {
 		return fmt.Errorf("get apply_operation %d (apply %s): %w", applyOperationID, apply.ApplyIdentifier, err)
@@ -927,6 +910,19 @@ func (c *LocalClient) ResumeApplyOperationCutover(ctx context.Context, apply *st
 	// under this apply's state. The routing and gRPC paths enforce the same.
 	if op.ApplyID != apply.ID {
 		return fmt.Errorf("apply_operation %d belongs to apply %d, not %s (%d)", applyOperationID, op.ApplyID, apply.ApplyIdentifier, apply.ID)
+	}
+	tasks, err := c.storage.Tasks().GetByApplyOperationID(ctx, applyOperationID)
+	if err != nil {
+		return fmt.Errorf("get tasks for apply_operation %d (apply %s): %w", applyOperationID, apply.ApplyIdentifier, err)
+	}
+	if len(tasks) == 0 {
+		// A task-less group_finalizer applies its namespace's VSchema (including
+		// any cutover) from the plan; drive it directly. A work operation with no
+		// tasks fails closed rather than failing the whole parent apply.
+		if op.OperationKind == storage.ApplyOperationKindGroupFinalizer {
+			return c.driveGroupFinalizer(ctx, apply, op)
+		}
+		return fmt.Errorf("apply_operation %d (apply %s): %w", applyOperationID, apply.ApplyIdentifier, ErrNoTasksForApplyOperation)
 	}
 	// Fail closed unless the operation is actually in a cutover phase. A
 	// copy-phase or terminal operation must never be forced into a cutover drive.
@@ -942,6 +938,116 @@ func (c *LocalClient) ResumeApplyOperationCutover(ctx context.Context, apply *st
 	opts := apply.GetOptions()
 	opts.DeferCutover = false
 	return c.resumeApplyWithTasks(ctx, apply, tasks, opts.Map(), false, true)
+}
+
+// finalizerOperationKeySuffix is the trailing segment of a group_finalizer
+// operation key (namespace + "/" + segment), assigned at apply creation. The
+// drive parses the namespace back out to reconstruct the VSchema change.
+const finalizerOperationKeySuffix = "/group_finalizer"
+
+// namespaceFromFinalizerKey recovers the namespace a group_finalizer operation
+// targets from its operation key. Returns empty when the key is not a finalizer
+// key, which the caller treats as a fail-closed condition.
+func namespaceFromFinalizerKey(operationKey string) string {
+	if !strings.HasSuffix(operationKey, finalizerOperationKeySuffix) {
+		return ""
+	}
+	return strings.TrimSuffix(operationKey, finalizerOperationKeySuffix)
+}
+
+// driveGroupFinalizer drives a task-less group_finalizer operation: it applies
+// the namespace's VSchema once its sibling shard work has completed. The change
+// is reconstructed from the plan (the finalizer carries no task), and engine
+// resume state is persisted on the operation row so a restart reattaches to the
+// in-flight VSchema application instead of starting over.
+//
+// It fails closed: the operation is marked completed only on a successful,
+// accepted engine apply. Any error (missing namespace/plan/engine, a rejected
+// apply, or an apply error) marks the operation failed and returns, so the
+// operator never advances the parent's aggregate as if the VSchema applied.
+func (c *LocalClient) driveGroupFinalizer(ctx context.Context, apply *storage.Apply, op *storage.ApplyOperation) error {
+	namespace := namespaceFromFinalizerKey(op.OperationKey)
+	if namespace == "" {
+		return fmt.Errorf("group_finalizer apply_operation %d (apply %s) has no namespace in operation key %q", op.ID, apply.ApplyIdentifier, op.OperationKey)
+	}
+	plan, err := c.storage.Plans().GetByID(ctx, apply.PlanID)
+	if err != nil {
+		return fmt.Errorf("load plan for group_finalizer apply_operation %d (apply %s): %w", op.ID, apply.ApplyIdentifier, err)
+	}
+	if plan == nil {
+		return fmt.Errorf("plan %d not found for group_finalizer apply_operation %d (apply %s)", apply.PlanID, op.ID, apply.ApplyIdentifier)
+	}
+	nsData := plan.Namespaces[namespace]
+	if nsData == nil || !namespaceHasVSchemaArtifact(nsData) {
+		return fmt.Errorf("plan %d has no VSchema artifact for group_finalizer namespace %q (apply %s)", apply.PlanID, namespace, apply.ApplyIdentifier)
+	}
+	eng := c.getEngine()
+	if eng == nil {
+		return fmt.Errorf("no engine available to drive group_finalizer apply_operation %d (apply %s)", op.ID, apply.ApplyIdentifier)
+	}
+	creds, err := c.credentialsForGroupedApply(plan)
+	if err != nil {
+		return fmt.Errorf("resolve credentials for group_finalizer apply_operation %d (apply %s): %w", op.ID, apply.ApplyIdentifier, err)
+	}
+
+	c.logger.Info("driving group_finalizer VSchema apply",
+		"apply_id", apply.ApplyIdentifier,
+		"apply_operation_id", op.ID,
+		"deployment", op.Deployment,
+		"namespace", namespace,
+		"database", apply.Database,
+	)
+	if err := c.storage.ApplyOperations().MarkStarted(ctx, op.ID); err != nil {
+		return fmt.Errorf("mark group_finalizer apply_operation %d started (apply %s): %w", op.ID, apply.ApplyIdentifier, err)
+	}
+
+	failClosed := func(cause error) error {
+		if markErr := c.storage.ApplyOperations().MarkFailed(ctx, op.ID, cause.Error()); markErr != nil {
+			c.logger.Error("group_finalizer: failed to mark operation failed",
+				"apply_id", apply.ApplyIdentifier, "apply_operation_id", op.ID, "error", markErr)
+		}
+		return cause
+	}
+
+	var resumeState *engine.ResumeState
+	if stored, getErr := c.storage.ApplyOperations().GetEngineResumeState(ctx, op.ID); getErr == nil && stored != nil {
+		resumeState = &engine.ResumeState{MigrationContext: stored.MigrationContext, Metadata: stored.Metadata}
+	}
+
+	result, err := eng.Apply(ctx, &engine.ApplyRequest{
+		Database:    apply.Database,
+		PlanID:      plan.PlanIdentifier,
+		Changes:     []engine.SchemaChange{{Namespace: namespace, Metadata: map[string]string{"vschema_changed": "true"}}},
+		SchemaFiles: plan.SchemaFiles,
+		Options:     apply.GetOptions().Map(),
+		ResumeState: resumeState,
+		Credentials: creds,
+		OnStateChange: func(rs *engine.ResumeState) {
+			if rs == nil {
+				return
+			}
+			if saveErr := c.storage.ApplyOperations().SaveEngineResumeState(ctx, op.ID, &storage.EngineResumeState{
+				ApplyOperationID: op.ID,
+				MigrationContext: rs.MigrationContext,
+				Metadata:         rs.Metadata,
+			}); saveErr != nil {
+				c.logger.Warn("group_finalizer: failed to persist engine resume state",
+					"apply_id", apply.ApplyIdentifier, "apply_operation_id", op.ID, "error", saveErr)
+			}
+		},
+	})
+	if err != nil {
+		return failClosed(fmt.Errorf("apply VSchema for group_finalizer namespace %q (apply %s): %w", namespace, apply.ApplyIdentifier, err))
+	}
+	if result == nil || !result.Accepted {
+		return failClosed(fmt.Errorf("group_finalizer VSchema apply for namespace %q (apply %s) was not accepted", namespace, apply.ApplyIdentifier))
+	}
+	if err := c.storage.ApplyOperations().MarkCompleted(ctx, op.ID); err != nil {
+		return fmt.Errorf("mark group_finalizer apply_operation %d completed (apply %s): %w", op.ID, apply.ApplyIdentifier, err)
+	}
+	c.logger.Info("group_finalizer VSchema apply completed",
+		"apply_id", apply.ApplyIdentifier, "apply_operation_id", op.ID, "namespace", namespace)
+	return nil
 }
 
 // resumeApplyWithTasks drives an apply (or one of its operations) from the set

--- a/pkg/tern/local_control_resume.go
+++ b/pkg/tern/local_control_resume.go
@@ -809,6 +809,13 @@ func groupedResumeChanges(tasks []*storage.Task) []engine.SchemaChange {
 		return idx
 	}
 	for _, task := range tasks {
+		// A task with no DDL carries no executable change. The only tasks that
+		// ever had empty DDL were the removed synthetic VSchema tasks; an apply
+		// created by an older binary mid-rolling-deploy can still carry one. Skip
+		// it rather than emit a TableChange the engine cannot apply.
+		if task.DDL == "" {
+			continue
+		}
 		idx := ensureNamespace(task.Namespace)
 		changes[idx].TableChanges = append(changes[idx].TableChanges, engine.TableChange{
 			Table:     task.TableName,
@@ -1010,7 +1017,17 @@ func (c *LocalClient) driveGroupFinalizer(ctx context.Context, apply *storage.Ap
 	}
 
 	var resumeState *engine.ResumeState
-	if stored, getErr := c.storage.ApplyOperations().GetEngineResumeState(ctx, op.ID); getErr == nil && stored != nil {
+	stored, getErr := c.storage.ApplyOperations().GetEngineResumeState(ctx, op.ID)
+	switch {
+	case errors.Is(getErr, storage.ErrEngineResumeStateNotFound):
+		// No persisted resume state yet — this is the finalizer's first drive, so
+		// start fresh.
+	case getErr != nil:
+		// A storage read failure must not be treated as "fresh": proceeding would
+		// risk the engine restarting or duplicating in-flight VSchema work after a
+		// transient DB error. Fail closed for the operator to retry.
+		return failClosed(fmt.Errorf("load engine resume state for group_finalizer apply_operation %d (apply %s): %w", op.ID, apply.ApplyIdentifier, getErr))
+	case stored != nil:
 		resumeState = &engine.ResumeState{MigrationContext: stored.MigrationContext, Metadata: stored.Metadata}
 	}
 

--- a/pkg/tern/local_control_resume.go
+++ b/pkg/tern/local_control_resume.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -963,20 +964,21 @@ func namespaceFromFinalizerKey(operationKey string) string {
 }
 
 // driveGroupFinalizer drives a task-less group_finalizer operation: it applies
-// the namespace's VSchema once its sibling shard work has completed. The change
-// is reconstructed from the plan (the finalizer carries no task), and engine
-// resume state is persisted on the operation row so a restart reattaches to the
-// in-flight VSchema application instead of starting over.
+// the VSchema once its sibling shard work has completed. The change is
+// reconstructed from the plan (the finalizer carries no task) and engine resume
+// state is persisted on the operation row so a reclaim reattaches to in-flight
+// work instead of starting over.
 //
-// It fails closed: the operation is marked completed only on a successful,
-// accepted engine apply. Any error (missing namespace/plan/engine, a rejected
-// apply, or an apply error) marks the operation failed and returns, so the
-// operator never advances the parent's aggregate as if the VSchema applied.
+// The drive is engine-agnostic: it applies, then polls Progress to a terminal
+// state. For an instance-local engine the VSchema apply is synchronous, so
+// Progress reports terminal on the first poll; for an externally-authoritative
+// engine (whose Apply starts an asynchronous deploy) Progress tracks the deploy
+// to completion. Either way the operation is marked completed only once the
+// engine reports the VSchema applied, and fails closed on any error (missing
+// plan/engine, a rejected apply, a permanent progress error, or a failed
+// terminal state), so the operator never advances the parent's aggregate as if
+// the VSchema applied when it did not.
 func (c *LocalClient) driveGroupFinalizer(ctx context.Context, apply *storage.Apply, op *storage.ApplyOperation) error {
-	namespace := namespaceFromFinalizerKey(op.OperationKey)
-	if namespace == "" {
-		return fmt.Errorf("group_finalizer apply_operation %d (apply %s) has no namespace in operation key %q", op.ID, apply.ApplyIdentifier, op.OperationKey)
-	}
 	plan, err := c.storage.Plans().GetByID(ctx, apply.PlanID)
 	if err != nil {
 		return fmt.Errorf("load plan for group_finalizer apply_operation %d (apply %s): %w", op.ID, apply.ApplyIdentifier, err)
@@ -984,9 +986,10 @@ func (c *LocalClient) driveGroupFinalizer(ctx context.Context, apply *storage.Ap
 	if plan == nil {
 		return fmt.Errorf("plan %d not found for group_finalizer apply_operation %d (apply %s)", apply.PlanID, op.ID, apply.ApplyIdentifier)
 	}
-	nsData := plan.Namespaces[namespace]
-	if nsData == nil || !namespaceHasVSchemaArtifact(nsData) {
-		return fmt.Errorf("plan %d has no VSchema artifact for group_finalizer namespace %q (apply %s)", apply.PlanID, namespace, apply.ApplyIdentifier)
+	namespace := namespaceFromFinalizerKey(op.OperationKey)
+	changes, err := finalizerVSchemaChanges(plan, namespace)
+	if err != nil {
+		return fmt.Errorf("group_finalizer apply_operation %d (apply %s): %w", op.ID, apply.ApplyIdentifier, err)
 	}
 	eng := c.getEngine()
 	if eng == nil {
@@ -1002,6 +1005,7 @@ func (c *LocalClient) driveGroupFinalizer(ctx context.Context, apply *storage.Ap
 		"apply_operation_id", op.ID,
 		"deployment", op.Deployment,
 		"namespace", namespace,
+		"namespace_count", len(changes),
 		"database", apply.Database,
 	)
 	if err := c.storage.ApplyOperations().MarkStarted(ctx, op.ID); err != nil {
@@ -1014,6 +1018,19 @@ func (c *LocalClient) driveGroupFinalizer(ctx context.Context, apply *storage.Ap
 				"apply_id", apply.ApplyIdentifier, "apply_operation_id", op.ID, "error", markErr)
 		}
 		return cause
+	}
+	persistResume := func(rs *engine.ResumeState) {
+		if rs == nil {
+			return
+		}
+		if saveErr := c.storage.ApplyOperations().SaveEngineResumeState(ctx, op.ID, &storage.EngineResumeState{
+			ApplyOperationID: op.ID,
+			MigrationContext: rs.MigrationContext,
+			Metadata:         rs.Metadata,
+		}); saveErr != nil {
+			c.logger.Warn("group_finalizer: failed to persist engine resume state",
+				"apply_id", apply.ApplyIdentifier, "apply_operation_id", op.ID, "error", saveErr)
+		}
 	}
 
 	var resumeState *engine.ResumeState
@@ -1032,39 +1049,122 @@ func (c *LocalClient) driveGroupFinalizer(ctx context.Context, apply *storage.Ap
 	}
 
 	result, err := eng.Apply(ctx, &engine.ApplyRequest{
-		Database:    apply.Database,
-		PlanID:      plan.PlanIdentifier,
-		Changes:     []engine.SchemaChange{{Namespace: namespace, Metadata: map[string]string{"vschema_changed": "true"}}},
-		SchemaFiles: plan.SchemaFiles,
-		Options:     apply.GetOptions().Map(),
-		ResumeState: resumeState,
-		Credentials: creds,
-		OnStateChange: func(rs *engine.ResumeState) {
-			if rs == nil {
-				return
-			}
-			if saveErr := c.storage.ApplyOperations().SaveEngineResumeState(ctx, op.ID, &storage.EngineResumeState{
-				ApplyOperationID: op.ID,
-				MigrationContext: rs.MigrationContext,
-				Metadata:         rs.Metadata,
-			}); saveErr != nil {
-				c.logger.Warn("group_finalizer: failed to persist engine resume state",
-					"apply_id", apply.ApplyIdentifier, "apply_operation_id", op.ID, "error", saveErr)
-			}
-		},
+		Database:      apply.Database,
+		PlanID:        plan.PlanIdentifier,
+		Changes:       changes,
+		SchemaFiles:   plan.SchemaFiles,
+		Options:       apply.GetOptions().Map(),
+		ResumeState:   resumeState,
+		Credentials:   creds,
+		OnStateChange: persistResume,
 	})
 	if err != nil {
-		return failClosed(fmt.Errorf("apply VSchema for group_finalizer namespace %q (apply %s): %w", namespace, apply.ApplyIdentifier, err))
+		return failClosed(fmt.Errorf("apply VSchema for group_finalizer (apply %s): %w", apply.ApplyIdentifier, err))
 	}
 	if result == nil || !result.Accepted {
-		return failClosed(fmt.Errorf("group_finalizer VSchema apply for namespace %q (apply %s) was not accepted", namespace, apply.ApplyIdentifier))
+		return failClosed(fmt.Errorf("group_finalizer VSchema apply for apply %s was not accepted", apply.ApplyIdentifier))
+	}
+	if result.ResumeState != nil {
+		persistResume(result.ResumeState)
+		resumeState = result.ResumeState
+	}
+
+	finalState, err := c.driveFinalizerToTerminal(ctx, eng, apply, creds, resumeState, persistResume)
+	if err != nil {
+		return failClosed(fmt.Errorf("await group_finalizer VSchema apply (apply %s): %w", apply.ApplyIdentifier, err))
+	}
+	if !finalizerVSchemaApplied(finalState) {
+		return failClosed(fmt.Errorf("group_finalizer VSchema apply for apply %s ended in non-success state %q", apply.ApplyIdentifier, finalState))
 	}
 	if err := c.storage.ApplyOperations().MarkCompleted(ctx, op.ID); err != nil {
 		return fmt.Errorf("mark group_finalizer apply_operation %d completed (apply %s): %w", op.ID, apply.ApplyIdentifier, err)
 	}
 	c.logger.Info("group_finalizer VSchema apply completed",
-		"apply_id", apply.ApplyIdentifier, "apply_operation_id", op.ID, "namespace", namespace)
+		"apply_id", apply.ApplyIdentifier, "apply_operation_id", op.ID, "namespace", namespace, "final_state", finalState)
 	return nil
+}
+
+// finalizerVSchemaChanges reconstructs the VSchema change(s) a group_finalizer
+// applies, from the plan. A namespace-scoped finalizer (operation key
+// "<ns>/group_finalizer", from a sharded fan-out) applies that one namespace's
+// VSchema. A finalizer with no namespace in its key (a non-sharded VSchema-only
+// apply on an externally-authoritative engine) applies every VSchema-changed
+// namespace in the plan, because that engine deploys the whole branch in one
+// operation.
+func finalizerVSchemaChanges(plan *storage.Plan, namespace string) ([]engine.SchemaChange, error) {
+	vschemaChange := func(ns string) engine.SchemaChange {
+		return engine.SchemaChange{Namespace: ns, Metadata: map[string]string{"vschema_changed": "true"}}
+	}
+	if namespace != "" {
+		nsData := plan.Namespaces[namespace]
+		if nsData == nil || !namespaceHasVSchemaArtifact(nsData) {
+			return nil, fmt.Errorf("plan %d has no VSchema artifact for namespace %q", plan.ID, namespace)
+		}
+		return []engine.SchemaChange{vschemaChange(namespace)}, nil
+	}
+	namespaces := make([]string, 0, len(plan.Namespaces))
+	for ns, nsData := range plan.Namespaces {
+		if namespaceHasVSchemaArtifact(nsData) {
+			namespaces = append(namespaces, ns)
+		}
+	}
+	if len(namespaces) == 0 {
+		return nil, fmt.Errorf("plan %d has no VSchema artifact for a deployment-scoped finalizer", plan.ID)
+	}
+	sort.Strings(namespaces)
+	changes := make([]engine.SchemaChange, 0, len(namespaces))
+	for _, ns := range namespaces {
+		changes = append(changes, vschemaChange(ns))
+	}
+	return changes, nil
+}
+
+// finalizerVSchemaApplied reports whether an engine progress state means the
+// VSchema is applied. Completed is the terminal success; revert_window means the
+// deploy succeeded and is holding open its revert window (the VSchema is live),
+// which is success for the finalizer — the apply-level revert window is managed
+// separately.
+func finalizerVSchemaApplied(s engine.State) bool {
+	return s == engine.StateCompleted || s == engine.StateRevertWindow
+}
+
+// driveFinalizerToTerminal polls the engine until the finalizer's work reaches a
+// terminal (or revert-window) state, persisting resume state on each poll so a
+// reclaim reattaches. An instance-local engine reports terminal on the first
+// poll; an externally-authoritative engine is tracked to deploy completion. A
+// permanent progress error fails the drive; transient errors are retried while
+// the operation lease is heartbeated by the operator.
+func (c *LocalClient) driveFinalizerToTerminal(ctx context.Context, eng engine.Engine, apply *storage.Apply, creds *engine.Credentials, resumeState *engine.ResumeState, persistResume func(*engine.ResumeState)) (engine.State, error) {
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		res, err := eng.Progress(ctx, &engine.ProgressRequest{
+			Database:    apply.Database,
+			Credentials: creds,
+			ResumeState: resumeState,
+		})
+		if err != nil {
+			var permanent *engine.PermanentError
+			if errors.As(err, &permanent) {
+				return "", fmt.Errorf("group_finalizer progress poll failed permanently: %w", err)
+			}
+			c.logger.Warn("group_finalizer: transient progress error; will retry",
+				"apply_id", apply.ApplyIdentifier, "error", err)
+		} else {
+			if res.ResumeState != nil {
+				persistResume(res.ResumeState)
+				resumeState = res.ResumeState
+			}
+			if res.State.IsTerminal() || res.State == engine.StateRevertWindow {
+				return res.State, nil
+			}
+		}
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-ticker.C:
+		}
+	}
 }
 
 // resumeApplyWithTasks drives an apply (or one of its operations) from the set

--- a/pkg/tern/local_control_resume.go
+++ b/pkg/tern/local_control_resume.go
@@ -1064,23 +1064,27 @@ func (c *LocalClient) driveGroupFinalizer(ctx context.Context, apply *storage.Ap
 	if result == nil || !result.Accepted {
 		return failClosed(fmt.Errorf("group_finalizer VSchema apply for apply %s was not accepted", apply.ApplyIdentifier))
 	}
+
+	// A nil resume state means the engine has no in-flight work to track: the
+	// VSchema apply finished synchronously, or the deploy was a no-op (no DDL
+	// diff — a VSchema applied at the branch level produces a no-changes deploy).
+	// The accepted result is terminal, so complete without polling. Only an
+	// in-flight deploy (a returned resume state) is polled to completion.
 	if result.ResumeState != nil {
 		persistResume(result.ResumeState)
-		resumeState = result.ResumeState
-	}
-
-	finalState, err := c.driveFinalizerToTerminal(ctx, eng, apply, creds, resumeState, persistResume)
-	if err != nil {
-		return failClosed(fmt.Errorf("await group_finalizer VSchema apply (apply %s): %w", apply.ApplyIdentifier, err))
-	}
-	if !finalizerVSchemaApplied(finalState) {
-		return failClosed(fmt.Errorf("group_finalizer VSchema apply for apply %s ended in non-success state %q", apply.ApplyIdentifier, finalState))
+		finalState, err := c.driveFinalizerToTerminal(ctx, eng, apply, creds, result.ResumeState, persistResume)
+		if err != nil {
+			return failClosed(fmt.Errorf("await group_finalizer VSchema apply (apply %s): %w", apply.ApplyIdentifier, err))
+		}
+		if !finalizerVSchemaApplied(finalState) {
+			return failClosed(fmt.Errorf("group_finalizer VSchema apply for apply %s ended in non-success state %q", apply.ApplyIdentifier, finalState))
+		}
 	}
 	if err := c.storage.ApplyOperations().MarkCompleted(ctx, op.ID); err != nil {
 		return fmt.Errorf("mark group_finalizer apply_operation %d completed (apply %s): %w", op.ID, apply.ApplyIdentifier, err)
 	}
 	c.logger.Info("group_finalizer VSchema apply completed",
-		"apply_id", apply.ApplyIdentifier, "apply_operation_id", op.ID, "namespace", namespace, "final_state", finalState)
+		"apply_id", apply.ApplyIdentifier, "apply_operation_id", op.ID, "namespace", namespace)
 	return nil
 }
 

--- a/pkg/tern/state_converters.go
+++ b/pkg/tern/state_converters.go
@@ -285,6 +285,7 @@ type psMetadataForStorage struct {
 	IsInstant        bool       `json:"is_instant,omitempty"`
 	DeferredDeploy   bool       `json:"deferred_deploy,omitempty"`
 	VSchemaStatus    string     `json:"vschema_status,omitempty"`
+	VSchemaDiff      string     `json:"vschema_diff,omitempty"`
 }
 
 func decodePSMetadataForStorage(s string) (*psMetadataForStorage, error) {
@@ -334,6 +335,9 @@ func PSDisplayMetadata(resumeStateMetadata string) (map[string]string, error) {
 	}
 	if meta.VSchemaStatus != "" {
 		set("vschema_status", meta.VSchemaStatus)
+	}
+	if meta.VSchemaDiff != "" {
+		set("vschema_diff", meta.VSchemaDiff)
 	}
 	return m, nil
 }


### PR DESCRIPTION
## Why this matters

VSchema application was modeled as a synthetic `vschema_update` task. That single task was overloaded into three roles: the progress-render source for engines that apply VSchema inline, the drive payload for the per-namespace finalizer on engines that fan work out per shard, and a special-cased row threaded through the operator drive, apply-create, and three render surfaces (`isVSchemaTask`, `deriveVSchemaTaskState`, `FormatVSchemaProgress`). The overloading made the task hard to reason about and coupled unrelated paths.

## What changes

The synthetic task is removed. VSchema is surfaced and applied through two purpose-built mechanisms instead:

1. Engines that apply VSchema as part of their own deploy surface its **status and diff via engine resume metadata** (`vschema_status` / `vschema_diff`), projected through the existing display-metadata path.
2. Engines that fan work out per shard run VSchema as a **task-less `group_finalizer` operation**, reconstructed from the plan at drive time.

### Before

```
apply-create ──► tasks:
                  ├─ users          (DDL task)
                  └─ "VSchema: ns"  (synthetic vschema_update task, no DDL)
                          │
   progress render ◄──────┤  isVSchemaTask + FormatVSchemaProgress
   operator drive  ◄──────┘  deriveVSchemaTaskState
```

### After

```
apply-create ──► tasks:
                  └─ users          (DDL task only)

VSchema status/diff   : engine resume metadata ─► display projection ─► progress render
VSchema apply (sharded): group_finalizer operation (task-less, rebuilt from plan)
```

### Operator "no tasks" guard — now classified by operation kind

```
operation has 0 tasks
   ├─ kind = work             ─► fail closed (invalid / mismatched operation)
   └─ kind = group_finalizer  ─► drive VSchema from the plan
                                   ├─ engine accepts ─► operation completed
                                   └─ any error      ─► fail closed (operation failed)
```

A removed VSchema change can never let the aggregate pass by cleanup alone: the finalizer completes only on an accepted apply, and fails closed on a missing plan/engine, a rejected apply, or an apply error.

## Impact by engine class

| Engine | Sharded fan-out | VSchema handling |
|---|---|---|
| Spirit (MySQL) | no | n/a — no VSchema |
| PlanetScale | no (externally authoritative) | applied inline by the deploy; status/diff from resume metadata |
| Per-shard fan-out engines | yes | task-less `group_finalizer`, one per VSchema-changed namespace (a VSchema-only namespace still gets one, so its change is never dropped) |

## Status

Draft, iterating toward green on CI. Unit tests pass across the changed packages. The multi-operation integration test now seeds the finalizer task-less; making its finalizer reach `completed` needs a seeded plan and an engine that accepts the finalizer apply — the next iteration.
