### PR TITLE
feat(github): compact per-shard status line in the PR comment

### DIFF
--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -2009,6 +2009,70 @@ _Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:0
 </details>
 
 <details>
+<summary><a name="sharded-shard-progress"></a><strong>Sharded: Shard Progress</strong></summary>
+
+
+## Schema Change In Progress
+
+**Database**: `commerce` | **Environment**: `staging` | **Apply ID**: `apply-7aa13cf03496454b`
+
+*Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
+
+### Table Progress
+
+**`users`**: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦⬜⬜⬜⬜⬜⬜⬜⬜ 62%
+
+```sql
+ALTER TABLE `users` ADD INDEX `idx_email`(`email`);
+```
+Rows: 914,707 / 1,466,232 · ETA: 3m 15s
+  └ shards: ✓ -40 · ◐ 40-80 62% · ◐ 80-c0 31% · ⏳ c0-
+
+
+---
+
+To stop this schema change:
+```
+schemabot stop apply-7aa13cf03496454b -e staging
+```
+
+_Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:00 UTC</relative-time> (2026-01-01 00:00:00 UTC)_
+
+</details>
+
+<details>
+<summary><a name="sharded-many-shards-256"></a><strong>Sharded: Many Shards (256)</strong></summary>
+
+
+## Schema Change In Progress
+
+**Database**: `commerce` | **Environment**: `staging` | **Apply ID**: `apply-7aa13cf03496454b`
+
+*Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
+
+### Table Progress
+
+**`orders`**: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦⬜⬜⬜⬜⬜⬜ 70%
+
+```sql
+ALTER TABLE `orders` ADD COLUMN `region` varchar(32);
+```
+Rows: 4,200,000,000 / 6,000,000,000 · ETA: 1h 30m
+  └ 256 shards: 200 ✓ · 52 ◐ copying · 4 ⏳ · slowest f7- 12%
+
+
+---
+
+To stop this schema change:
+```
+schemabot stop apply-7aa13cf03496454b -e staging
+```
+
+_Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:00 UTC</relative-time> (2026-01-01 00:00:00 UTC)_
+
+</details>
+
+<details>
 <summary><a name="all-completed"></a><strong>All Completed</strong></summary>
 
 

--- a/pkg/cmd/internal/templates/preview_comment.go
+++ b/pkg/cmd/internal/templates/preview_comment.go
@@ -212,6 +212,9 @@ func previewCommentApplyFlowAllOutput() {
 		{"SECOND TABLE RUNNING", func() { fmt.Print(webhooktemplates.PreviewCommentApplyProgress()) }},
 		{"SECOND TABLE ESTIMATE EXCEEDED", func() { fmt.Print(webhooktemplates.PreviewCommentApplyEstimateExceeded()) }},
 		{"THIRD TABLE RUNNING", func() { fmt.Print(webhooktemplates.PreviewCommentApplyThirdRunning()) }},
+		// Sharded tables: compact per-shard summary (inline for few, collapsed for many)
+		{"SHARDED: SHARD PROGRESS", func() { fmt.Print(webhooktemplates.PreviewCommentApplyShardProgress()) }},
+		{"SHARDED: MANY SHARDS (256)", func() { fmt.Print(webhooktemplates.PreviewCommentApplyManyShardProgress()) }},
 		{"ALL COMPLETED", func() { fmt.Print(webhooktemplates.PreviewCommentApplyCompleted()) }},
 		{"VITESS: VSCHEMA ONLY", func() { fmt.Print(webhooktemplates.PreviewCommentApplyVitessVSchemaOnly()) }},
 		{"VITESS: DDL + VSCHEMA", func() { fmt.Print(webhooktemplates.PreviewCommentApplyVitessDDLWithVSchema()) }},

--- a/pkg/webhook/apply.go
+++ b/pkg/webhook/apply.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"sort"
 	"time"
 
 	"github.com/block/schemabot/pkg/apitypes"
@@ -15,7 +16,10 @@ import (
 // buildApplyCommentData maps storage types to template data. vschemaChanges
 // carries the apply's per-keyspace VSchema application state, projected from
 // engine display metadata by resolveVSchemaByOperation (nil when there is none).
-func buildApplyCommentData(apply *storage.Apply, tasks []*storage.Task, vschemaChanges []apitypes.VSchemaChange) templates.ApplyStatusCommentData {
+// shardsByTable holds the per-shard detail rows grouped by table (nil for
+// unsharded engines); it is attached to each table's progress for the compact
+// per-shard summary.
+func buildApplyCommentData(apply *storage.Apply, tasks []*storage.Task, vschemaChanges []apitypes.VSchemaChange, shardsByTable map[string][]*storage.Task) templates.ApplyStatusCommentData {
 	data := templates.ApplyStatusCommentData{
 		ApplyID:        apply.ApplyIdentifier,
 		Database:       apply.Database,
@@ -31,7 +35,7 @@ func buildApplyCommentData(apply *storage.Apply, tasks []*storage.Task, vschemaC
 	if apply.CompletedAt != nil {
 		data.CompletedAt = apply.CompletedAt.Format(time.RFC3339)
 	}
-	data.Tables = tableProgressFromTasks(apply.Database, tasks)
+	data.Tables = tableProgressFromTasks(apply.Database, tasks, shardsByTable)
 	return data
 }
 
@@ -83,8 +87,9 @@ func resolveVSchemaByOperation(ctx context.Context, stor storage.Storage, apply 
 // tableProgressFromTasks maps storage tasks to per-table template rows. The
 // databaseFallback is used as a task's namespace when the task has none, so the
 // single-deployment and per-deployment builders render table identities the same
-// way.
-func tableProgressFromTasks(databaseFallback string, tasks []*storage.Task) []templates.TableProgressData {
+// way. shardsByTable (keyed by shardCommentTableKey on the raw namespace) supplies
+// each table's per-shard breakdown when present.
+func tableProgressFromTasks(databaseFallback string, tasks []*storage.Task, shardsByTable map[string][]*storage.Task) []templates.TableProgressData {
 	if len(tasks) == 0 {
 		return nil
 	}
@@ -106,21 +111,50 @@ func tableProgressFromTasks(databaseFallback string, tasks []*storage.Task) []te
 			IsInstant:       t.IsInstant,
 			ReadyToComplete: t.ReadyToComplete,
 			ErrorMessage:    t.ErrorMessage,
+			Shards:          shardProgressForTable(shardsByTable, t.Namespace, t.TableName),
 		})
 	}
 	return out
 }
 
+// shardProgressForTable returns the per-shard summary rows for a table, sorted by
+// shard name for stable rendering. The map is keyed on the raw task namespace
+// (the same value the shard rows carry), so it is looked up before the database
+// fallback is applied.
+func shardProgressForTable(shardsByTable map[string][]*storage.Task, namespace, table string) []templates.ShardProgressData {
+	rows := shardsByTable[shardCommentTableKey(namespace, table)]
+	if len(rows) == 0 {
+		return nil
+	}
+	out := make([]templates.ShardProgressData, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, templates.ShardProgressData{
+			Shard:           r.Shard,
+			Status:          string(r.State),
+			PercentComplete: r.ProgressPercent,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Shard < out[j].Shard })
+	return out
+}
+
+// shardCommentTableKey keys the per-table shard map for the PR comment. It uses
+// the raw namespace (before any database fallback) so table rows and shard rows —
+// which both carry the same raw namespace — line up.
+func shardCommentTableKey(namespace, table string) string {
+	return namespace + "\x00" + table
+}
+
 // formatProgressComment renders the progress comment using the template system.
 // It is the no-operations fallback (load error, or the initial rollback comment),
 // so it carries no VSchema — the observer refreshes VSchema once operations load.
-func formatProgressComment(apply *storage.Apply, tasks []*storage.Task) string {
-	return templates.RenderApplyStatusComment(buildApplyCommentData(apply, tasks, nil))
+func formatProgressComment(apply *storage.Apply, tasks []*storage.Task, shardsByTable map[string][]*storage.Task) string {
+	return templates.RenderApplyStatusComment(buildApplyCommentData(apply, tasks, nil, shardsByTable))
 }
 
 // formatSummaryComment renders the final summary comment for a terminal apply
 // state. Like formatProgressComment it is the no-operations fallback and carries
 // no VSchema.
-func formatSummaryComment(apply *storage.Apply, tasks []*storage.Task) string {
-	return templates.RenderApplySummaryComment(buildApplyCommentData(apply, tasks, nil))
+func formatSummaryComment(apply *storage.Apply, tasks []*storage.Task, shardsByTable map[string][]*storage.Task) string {
+	return templates.RenderApplySummaryComment(buildApplyCommentData(apply, tasks, nil, shardsByTable))
 }

--- a/pkg/webhook/apply.go
+++ b/pkg/webhook/apply.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log/slog"
 	"sort"
+	"strconv"
 	"time"
 
 	"github.com/block/schemabot/pkg/apitypes"
@@ -111,18 +112,19 @@ func tableProgressFromTasks(databaseFallback string, tasks []*storage.Task, shar
 			IsInstant:       t.IsInstant,
 			ReadyToComplete: t.ReadyToComplete,
 			ErrorMessage:    t.ErrorMessage,
-			Shards:          shardProgressForTable(shardsByTable, t.Namespace, t.TableName),
+			Shards:          shardProgressForTable(shardsByTable, t.ApplyOperationID, t.Namespace, t.TableName),
 		})
 	}
 	return out
 }
 
 // shardProgressForTable returns the per-shard summary rows for a table, sorted by
-// shard name for stable rendering. The map is keyed on the raw task namespace
-// (the same value the shard rows carry), so it is looked up before the database
-// fallback is applied.
-func shardProgressForTable(shardsByTable map[string][]*storage.Task, namespace, table string) []templates.ShardProgressData {
-	rows := shardsByTable[shardCommentTableKey(namespace, table)]
+// shard name for stable rendering. The map is keyed by the table's owning
+// apply operation plus its raw namespace (the same values the shard rows carry),
+// so a multi-deployment apply that shares a namespace/table name across
+// deployments keeps each deployment's shards in its own section.
+func shardProgressForTable(shardsByTable map[string][]*storage.Task, applyOperationID *int64, namespace, table string) []templates.ShardProgressData {
+	rows := shardsByTable[shardCommentTableKey(applyOperationID, namespace, table)]
 	if len(rows) == 0 {
 		return nil
 	}
@@ -138,11 +140,17 @@ func shardProgressForTable(shardsByTable map[string][]*storage.Task, namespace, 
 	return out
 }
 
-// shardCommentTableKey keys the per-table shard map for the PR comment. It uses
-// the raw namespace (before any database fallback) so table rows and shard rows —
-// which both carry the same raw namespace — line up.
-func shardCommentTableKey(namespace, table string) string {
-	return namespace + "\x00" + table
+// shardCommentTableKey keys the per-table shard map for the PR comment. It scopes
+// the key by the owning apply operation so a multi-deployment apply does not merge
+// shards across deployments, then by the raw namespace (before any database
+// fallback) so table rows and shard rows — which both carry the same raw
+// namespace — line up. A nil operation (legacy single-deployment task) keys to 0.
+func shardCommentTableKey(applyOperationID *int64, namespace, table string) string {
+	var opID int64
+	if applyOperationID != nil {
+		opID = *applyOperationID
+	}
+	return strconv.FormatInt(opID, 10) + "\x00" + namespace + "\x00" + table
 }
 
 // formatProgressComment renders the progress comment using the template system.

--- a/pkg/webhook/apply_test.go
+++ b/pkg/webhook/apply_test.go
@@ -35,7 +35,7 @@ func TestFormatProgressComment(t *testing.T) {
 		},
 	}
 
-	body := formatProgressComment(apply, tasks)
+	body := formatProgressComment(apply, tasks, nil)
 
 	// Template renders rich progress bars instead of a table
 	assert.Contains(t, body, "testdb")
@@ -57,7 +57,7 @@ func TestFormatProgressComment_NoTasks(t *testing.T) {
 		State:       state.Apply.Pending,
 	}
 
-	body := formatProgressComment(apply, nil)
+	body := formatProgressComment(apply, nil, nil)
 
 	assert.Contains(t, body, "testdb")
 	assert.Contains(t, body, "Starting")
@@ -72,7 +72,7 @@ func TestFormatProgressComment_WithError(t *testing.T) {
 		ErrorMessage: "connection refused",
 	}
 
-	body := formatProgressComment(apply, nil)
+	body := formatProgressComment(apply, nil, nil)
 
 	assert.Contains(t, body, "connection refused")
 	assert.Contains(t, body, "Failed")
@@ -100,7 +100,7 @@ func TestFormatProgressCommentCutoverState(t *testing.T) {
 		{TableName: "orders", State: state.Task.WaitingForCutover, ReadyToComplete: true},
 	}
 
-	body := formatProgressComment(apply, tasks)
+	body := formatProgressComment(apply, tasks, nil)
 
 	assert.Contains(t, body, "Cutover")
 	assert.Contains(t, body, "testdb")
@@ -120,7 +120,7 @@ func TestFormatSummaryComment(t *testing.T) {
 		{TableName: "orders", State: state.Task.Completed},
 	}
 
-	body := formatSummaryComment(apply, tasks)
+	body := formatSummaryComment(apply, tasks, nil)
 
 	assert.Contains(t, body, "Schema Change Applied")
 	assert.Contains(t, body, "`users`")
@@ -140,7 +140,7 @@ func TestFormatSummaryComment_Failed(t *testing.T) {
 		{TableName: "users", State: state.Task.Failed},
 	}
 
-	body := formatSummaryComment(apply, tasks)
+	body := formatSummaryComment(apply, tasks, nil)
 
 	assert.Contains(t, body, "duplicate column")
 	assert.Contains(t, body, "Failed")
@@ -176,7 +176,7 @@ func TestBuildApplyCommentData(t *testing.T) {
 		},
 	}
 
-	data := buildApplyCommentData(apply, tasks, nil)
+	data := buildApplyCommentData(apply, tasks, nil, nil)
 
 	assert.Equal(t, "apply-abc123", data.ApplyID)
 	assert.Equal(t, "testdb", data.Database)
@@ -198,7 +198,7 @@ func TestBuildApplyCommentData_DefaultNamespace(t *testing.T) {
 		{TableName: "users", State: state.Task.Running},
 	}
 
-	data := buildApplyCommentData(apply, tasks, nil)
+	data := buildApplyCommentData(apply, tasks, nil, nil)
 
 	assert.Equal(t, "testdb", data.Tables[0].Namespace, "empty namespace should default to database name")
 }

--- a/pkg/webhook/comment_observer.go
+++ b/pkg/webhook/comment_observer.go
@@ -381,13 +381,18 @@ func (o *CommentObserver) shardsByTable(ctx context.Context, apply *storage.Appl
 	}
 	byTable := map[string][]*storage.Task{}
 	for _, op := range ops {
-		shardTasks, err := o.stor.Tasks().GetShardProgressByApplyOperationID(ctx, op.ID)
+		if err := ctx.Err(); err != nil {
+			o.logError(apply, "comment per-shard summary will omit remaining operations' shards: context done", "error", err)
+			break
+		}
+		opID := op.ID
+		shardTasks, err := o.stor.Tasks().GetShardProgressByApplyOperationID(ctx, opID)
 		if err != nil {
-			o.logError(apply, "comment per-shard summary will omit an operation's shards: failed to load shard rows", "apply_operation_id", op.ID, "error", err)
+			o.logError(apply, "comment per-shard summary will omit an operation's shards: failed to load shard rows", "apply_operation_id", opID, "error", err)
 			continue
 		}
 		for _, st := range shardTasks {
-			key := shardCommentTableKey(st.Namespace, st.TableName)
+			key := shardCommentTableKey(&opID, st.Namespace, st.TableName)
 			byTable[key] = append(byTable[key], st)
 		}
 	}

--- a/pkg/webhook/comment_observer.go
+++ b/pkg/webhook/comment_observer.go
@@ -281,6 +281,7 @@ func (o *CommentObserver) OnTerminal(apply *storage.Apply, tasks []*storage.Task
 	// both comment renders below, so the terminal path reads apply_operations a
 	// single time per callback.
 	ops, opsErr := o.stor.ApplyOperations().ListByApply(ctx, o.applyID)
+	shardsByTable := o.shardsByTable(ctx, apply, ops)
 
 	if activeCommentState == state.Comment.Cutover {
 		// The cutover comment IS the completion comment, so editing it to the
@@ -290,7 +291,7 @@ func (o *CommentObserver) OnTerminal(apply *storage.Apply, tasks []*storage.Task
 		// aggregate CAS-winner observer re-edits it with the full task set. The
 		// summary marker is always upserted so FindMissingSummaryComment (outbox
 		// query) doesn't false-positive on restart for cutover applies.
-		finalBody := o.summaryCommentFromOps(apply, ops, opsErr, tasks)
+		finalBody := o.summaryCommentFromOps(apply, ops, opsErr, tasks, shardsByTable)
 		o.editTrackedComment(apply, activeCommentState, finalBody)
 		o.markSummaryPosted(apply, activeCommentState)
 	} else {
@@ -298,7 +299,7 @@ func (o *CommentObserver) OnTerminal(apply *storage.Apply, tasks []*storage.Task
 		// This is the per-operation status freeze, not the apply-level summary, so
 		// it always runs; the aggregate publisher re-edits it with the full task
 		// set for multi-operation applies.
-		finalBody := o.statusCommentFromOps(apply, ops, opsErr, tasks)
+		finalBody := o.statusCommentFromOps(apply, ops, opsErr, tasks, shardsByTable)
 		o.editTrackedComment(apply, activeCommentState, finalBody)
 
 		// Post a separate summary comment. A new comment is more reliable than
@@ -310,7 +311,7 @@ func (o *CommentObserver) OnTerminal(apply *storage.Apply, tasks []*storage.Task
 		// so a per-driver observer holding one operation's task slice must defer
 		// to it rather than post a duplicate, partial summary.
 		if o.shouldPublishSeparateSummary(apply, ops, opsErr) {
-			summaryBody := o.summaryCommentFromOps(apply, ops, opsErr, tasks)
+			summaryBody := o.summaryCommentFromOps(apply, ops, opsErr, tasks, shardsByTable)
 			o.postAndTrackComment(apply, state.Comment.Summary, summaryBody)
 		}
 	}
@@ -365,20 +366,45 @@ func (o *CommentObserver) formatStatusComment(apply *storage.Apply, tasks []*sto
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 	ops, err := o.stor.ApplyOperations().ListByApply(ctx, o.applyID)
-	return o.statusCommentFromOps(apply, ops, err, tasks)
+	return o.statusCommentFromOps(apply, ops, err, tasks, o.shardsByTable(ctx, apply, ops))
+}
+
+// shardsByTable loads an apply's per-shard detail rows and groups them by table
+// for the compact per-shard summary in the PR comment. Only sharded engines
+// write these rows; MySQL never does, so it is skipped and any other engine is
+// queried, returning an empty map (and so no shard summary) when an apply has no
+// shard rows. Best-effort: a failed load for one operation just omits its shards
+// from this render rather than failing the comment.
+func (o *CommentObserver) shardsByTable(ctx context.Context, apply *storage.Apply, ops []*storage.ApplyOperation) map[string][]*storage.Task {
+	if apply == nil || apply.DatabaseType == storage.DatabaseTypeMySQL {
+		return nil
+	}
+	byTable := map[string][]*storage.Task{}
+	for _, op := range ops {
+		shardTasks, err := o.stor.Tasks().GetShardProgressByApplyOperationID(ctx, op.ID)
+		if err != nil {
+			o.logError(apply, "comment per-shard summary will omit an operation's shards: failed to load shard rows", "apply_operation_id", op.ID, "error", err)
+			continue
+		}
+		for _, st := range shardTasks {
+			key := shardCommentTableKey(st.Namespace, st.TableName)
+			byTable[key] = append(byTable[key], st)
+		}
+	}
+	return byTable
 }
 
 // statusCommentFromOps renders the status comment from already-loaded operation
 // rows, applying the same single-deployment fallback as formatStatusComment when
 // the load failed. Callers that already hold the operation set (e.g. OnTerminal)
 // use this to avoid re-reading apply_operations.
-func (o *CommentObserver) statusCommentFromOps(apply *storage.Apply, ops []*storage.ApplyOperation, opsErr error, tasks []*storage.Task) string {
+func (o *CommentObserver) statusCommentFromOps(apply *storage.Apply, ops []*storage.ApplyOperation, opsErr error, tasks []*storage.Task, shardsByTable map[string][]*storage.Task) string {
 	if opsErr != nil {
 		o.logger.Error("observer: failed to load apply operations for comment dispatch; rendering single-deployment layout",
 			"apply_id", o.applyID, "error", opsErr)
-		return formatProgressComment(apply, tasks)
+		return formatProgressComment(apply, tasks, shardsByTable)
 	}
-	return formatApplyStatusComment(apply, ops, tasks, o.resolveVSchema(apply, ops))
+	return formatApplyStatusComment(apply, ops, tasks, o.resolveVSchema(apply, ops), shardsByTable)
 }
 
 // resolveVSchema projects the apply's per-operation VSchema display state for
@@ -402,7 +428,7 @@ func (o *CommentObserver) formatTerminalSummaryComment(apply *storage.Apply) str
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 	ops, err := o.stor.ApplyOperations().ListByApply(ctx, o.applyID)
-	return o.summaryCommentFromOps(apply, ops, err, nil)
+	return o.summaryCommentFromOps(apply, ops, err, nil, o.shardsByTable(ctx, apply, ops))
 }
 
 // summaryCommentFromOps renders the terminal summary from already-loaded
@@ -410,13 +436,13 @@ func (o *CommentObserver) formatTerminalSummaryComment(apply *storage.Apply) str
 // formatTerminalSummaryComment when the load failed. Callers that already hold
 // the operation set (e.g. OnTerminal) use this to avoid re-reading
 // apply_operations.
-func (o *CommentObserver) summaryCommentFromOps(apply *storage.Apply, ops []*storage.ApplyOperation, opsErr error, tasks []*storage.Task) string {
+func (o *CommentObserver) summaryCommentFromOps(apply *storage.Apply, ops []*storage.ApplyOperation, opsErr error, tasks []*storage.Task, shardsByTable map[string][]*storage.Task) string {
 	if opsErr != nil {
 		o.logger.Error("observer: failed to load apply operations for summary comment dispatch; rendering single-deployment layout",
 			"apply_id", o.applyID, "error", opsErr)
-		return formatSummaryComment(apply, tasks)
+		return formatSummaryComment(apply, tasks, shardsByTable)
 	}
-	return formatApplySummaryComment(apply, ops, tasks, o.resolveVSchema(apply, ops))
+	return formatApplySummaryComment(apply, ops, tasks, o.resolveVSchema(apply, ops), shardsByTable)
 }
 
 func (o *CommentObserver) shouldDeferCutover(apply *storage.Apply) bool {

--- a/pkg/webhook/comment_observer_test.go
+++ b/pkg/webhook/comment_observer_test.go
@@ -45,6 +45,18 @@ type stubStorage struct {
 
 func (s *stubStorage) ApplyOperations() storage.ApplyOperationStore { return s.ops }
 
+func (s *stubStorage) Tasks() storage.TaskStore { return stubTaskStore{} }
+
+// stubTaskStore supplies the per-shard read the comment dispatch path makes; the
+// routing tests have no shard rows, so it returns none.
+type stubTaskStore struct {
+	storage.TaskStore
+}
+
+func (stubTaskStore) GetShardProgressByApplyOperationID(context.Context, int64) ([]*storage.Task, error) {
+	return nil, nil
+}
+
 func newDispatchTestObserver(opStore storage.ApplyOperationStore) *CommentObserver {
 	return &CommentObserver{
 		stor:   &stubStorage{ops: opStore},

--- a/pkg/webhook/handler.go
+++ b/pkg/webhook/handler.go
@@ -367,7 +367,7 @@ func (h *Handler) ReconcileMissingSummaryComments(ctx context.Context) {
 				"apply_id", apply.ApplyIdentifier, "error", err)
 			ops = nil
 		}
-		summaryBody := formatApplySummaryComment(apply, ops, tasks, resolveVSchemaByOperation(ctx, h.service.Storage(), apply, ops))
+		summaryBody := formatApplySummaryComment(apply, ops, tasks, resolveVSchemaByOperation(ctx, h.service.Storage(), apply, ops), nil)
 		h.postAndTrackComment(ctx, apply.Repository, apply.PullRequest, apply.InstallationID, apply.ID, state.Comment.Summary, summaryBody)
 	}
 }

--- a/pkg/webhook/multi_apply.go
+++ b/pkg/webhook/multi_apply.go
@@ -19,11 +19,11 @@ import (
 // ops must be in resolved deployment order (as returned by
 // ApplyOperations().ListByApply); tasks are the apply's tasks across all
 // deployments, regrouped per operation for the multi-deployment layout.
-func formatApplyStatusComment(apply *storage.Apply, ops []*storage.ApplyOperation, tasks []*storage.Task, vschemaByOp map[int64][]apitypes.VSchemaChange) string {
+func formatApplyStatusComment(apply *storage.Apply, ops []*storage.ApplyOperation, tasks []*storage.Task, vschemaByOp map[int64][]apitypes.VSchemaChange, shardsByTable map[string][]*storage.Task) string {
 	if len(ops) <= 1 {
-		return templates.RenderApplyStatusComment(buildApplyCommentData(apply, tasks, singleOpVSchema(ops, vschemaByOp)))
+		return templates.RenderApplyStatusComment(buildApplyCommentData(apply, tasks, singleOpVSchema(ops, vschemaByOp), shardsByTable))
 	}
-	return templates.RenderMultiDeploymentApplyComment(buildMultiApplyData(apply, ops, tasks, vschemaByOp))
+	return templates.RenderMultiDeploymentApplyComment(buildMultiApplyData(apply, ops, tasks, vschemaByOp, shardsByTable))
 }
 
 // formatApplySummaryComment renders the terminal summary PR comment for an apply,
@@ -36,11 +36,11 @@ func formatApplyStatusComment(apply *storage.Apply, ops []*storage.ApplyOperatio
 // ops must be in resolved deployment order (as returned by
 // ApplyOperations().ListByApply); tasks are the apply's tasks across all
 // deployments, regrouped per operation for the multi-deployment layout.
-func formatApplySummaryComment(apply *storage.Apply, ops []*storage.ApplyOperation, tasks []*storage.Task, vschemaByOp map[int64][]apitypes.VSchemaChange) string {
+func formatApplySummaryComment(apply *storage.Apply, ops []*storage.ApplyOperation, tasks []*storage.Task, vschemaByOp map[int64][]apitypes.VSchemaChange, shardsByTable map[string][]*storage.Task) string {
 	if len(ops) <= 1 {
-		return templates.RenderApplySummaryComment(buildApplyCommentData(apply, tasks, singleOpVSchema(ops, vschemaByOp)))
+		return templates.RenderApplySummaryComment(buildApplyCommentData(apply, tasks, singleOpVSchema(ops, vschemaByOp), shardsByTable))
 	}
-	return templates.RenderMultiDeploymentApplySummaryComment(buildMultiApplyData(apply, ops, tasks, vschemaByOp))
+	return templates.RenderMultiDeploymentApplySummaryComment(buildMultiApplyData(apply, ops, tasks, vschemaByOp, shardsByTable))
 }
 
 // singleOpVSchema returns the VSchema changes for a zero/one-operation apply
@@ -56,13 +56,13 @@ func singleOpVSchema(ops []*storage.ApplyOperation, vschemaByOp map[int64][]apit
 // buildMultiApplyData assembles the multi-deployment comment input: the derived
 // rollup plus each deployment's own single-deployment comment data, so each
 // deployment's section reuses the existing per-table renderer.
-func buildMultiApplyData(apply *storage.Apply, ops []*storage.ApplyOperation, tasks []*storage.Task, vschemaByOp map[int64][]apitypes.VSchemaChange) templates.MultiDeploymentApplyData {
+func buildMultiApplyData(apply *storage.Apply, ops []*storage.ApplyOperation, tasks []*storage.Task, vschemaByOp map[int64][]apitypes.VSchemaChange, shardsByTable map[string][]*storage.Task) templates.MultiDeploymentApplyData {
 	tasksByOp := groupTasksByOperation(tasks)
 
 	model := deriveApplyPresentation(ops)
 	details := make(map[string]templates.ApplyStatusCommentData, len(ops))
 	for _, op := range ops {
-		details[op.Deployment] = buildDeploymentDetail(apply, op, tasksByOp[op.ID], vschemaByOp[op.ID])
+		details[op.Deployment] = buildDeploymentDetail(apply, op, tasksByOp[op.ID], vschemaByOp[op.ID], shardsByTable)
 	}
 
 	data := templates.MultiDeploymentApplyData{
@@ -113,7 +113,7 @@ func applyOperationToPresentation(op *storage.ApplyOperation) presentation.Opera
 // identity and timing, and the deployment's own tasks. The deployment's database
 // target is shown via the section's deployment name; the per-table rows fall back
 // to the apply database for namespace, matching the single-deployment renderer.
-func buildDeploymentDetail(apply *storage.Apply, op *storage.ApplyOperation, tasks []*storage.Task, vschemaChanges []apitypes.VSchemaChange) templates.ApplyStatusCommentData {
+func buildDeploymentDetail(apply *storage.Apply, op *storage.ApplyOperation, tasks []*storage.Task, vschemaChanges []apitypes.VSchemaChange, shardsByTable map[string][]*storage.Task) templates.ApplyStatusCommentData {
 	data := templates.ApplyStatusCommentData{
 		ApplyID:        apply.ApplyIdentifier,
 		Database:       apply.Database,
@@ -121,7 +121,7 @@ func buildDeploymentDetail(apply *storage.Apply, op *storage.ApplyOperation, tas
 		State:          op.State,
 		Engine:         apply.Engine,
 		ErrorMessage:   op.ErrorMessage,
-		Tables:         tableProgressFromTasks(apply.Database, tasks),
+		Tables:         tableProgressFromTasks(apply.Database, tasks, shardsByTable),
 		VSchemaChanges: vschemaChanges,
 	}
 	if apply.StartedAt != nil {

--- a/pkg/webhook/multi_apply_test.go
+++ b/pkg/webhook/multi_apply_test.go
@@ -111,6 +111,38 @@ func TestBuildMultiApplyData_RoutesTasksByOperation(t *testing.T) {
 	assert.Equal(t, "orders", data.Details["us"].Tables[0].TableName)
 }
 
+// Per-shard rows are scoped to their owning deployment: when two deployments
+// share a namespace and table name, each section shows only its own shards
+// rather than a merged list across deployments.
+func TestBuildMultiApplyData_ScopesShardsByOperation(t *testing.T) {
+	euID, usID := int64(1), int64(2)
+	ops := []*storage.ApplyOperation{
+		{ID: euID, Deployment: "eu", State: state.ApplyOperation.Running},
+		{ID: usID, Deployment: "us", State: state.ApplyOperation.Running},
+	}
+	tasks := []*storage.Task{
+		{ApplyOperationID: &euID, Namespace: "commerce", TableName: "users", State: state.Task.Running},
+		{ApplyOperationID: &usID, Namespace: "commerce", TableName: "users", State: state.Task.Running},
+	}
+	shardsByTable := map[string][]*storage.Task{
+		shardCommentTableKey(&euID, "commerce", "users"): {
+			{Shard: "-80", State: state.Task.Completed, ProgressPercent: 100},
+		},
+		shardCommentTableKey(&usID, "commerce", "users"): {
+			{Shard: "80-", State: state.Task.Running, ProgressPercent: 40},
+		},
+	}
+
+	data := buildMultiApplyData(runningApply(), ops, tasks, nil, shardsByTable)
+
+	require.Len(t, data.Details["eu"].Tables, 1)
+	require.Len(t, data.Details["eu"].Tables[0].Shards, 1)
+	assert.Equal(t, "-80", data.Details["eu"].Tables[0].Shards[0].Shard)
+	require.Len(t, data.Details["us"].Tables, 1)
+	require.Len(t, data.Details["us"].Tables[0].Shards, 1)
+	assert.Equal(t, "80-", data.Details["us"].Tables[0].Shards[0].Shard)
+}
+
 // The per-deployment section reflects the operation's own state and error, not
 // the parent apply's aggregate state.
 func TestBuildDeploymentDetail_UsesOperationStateAndError(t *testing.T) {

--- a/pkg/webhook/multi_apply_test.go
+++ b/pkg/webhook/multi_apply_test.go
@@ -22,7 +22,7 @@ func runningApply() *storage.Apply {
 // An apply with no operation rows (legacy, predating apply_operations) renders
 // the single-deployment comment unchanged — no aggregate header.
 func TestFormatApplyStatusComment_NoOperationsRendersSingle(t *testing.T) {
-	out := formatApplyStatusComment(runningApply(), nil, nil, nil)
+	out := formatApplyStatusComment(runningApply(), nil, nil, nil, nil)
 	assert.Contains(t, out, "## Schema Change In Progress")
 	assert.NotContains(t, out, "**Deployments**:")
 }
@@ -33,7 +33,7 @@ func TestFormatApplyStatusComment_OneOperationRendersSingle(t *testing.T) {
 	ops := []*storage.ApplyOperation{
 		{ID: 1, Deployment: "eu", State: state.ApplyOperation.Running},
 	}
-	out := formatApplyStatusComment(runningApply(), ops, nil, nil)
+	out := formatApplyStatusComment(runningApply(), ops, nil, nil, nil)
 	assert.NotContains(t, out, "**Deployments**:")
 	assert.NotContains(t, out, "- 🔄 eu")
 }
@@ -45,7 +45,7 @@ func TestFormatApplyStatusComment_MultipleOperationsRendersMulti(t *testing.T) {
 		{ID: 1, Deployment: "eu", State: state.ApplyOperation.Completed, CutoverPolicy: storage.CutoverPolicyBarrier},
 		{ID: 2, Deployment: "us", State: state.ApplyOperation.Running, CutoverPolicy: storage.CutoverPolicyBarrier},
 	}
-	out := formatApplyStatusComment(runningApply(), ops, nil, nil)
+	out := formatApplyStatusComment(runningApply(), ops, nil, nil, nil)
 	assert.Contains(t, out, "## Schema Change In Progress")
 	assert.Contains(t, out, "**Deployments**: 1 completed, 1 running")
 	assert.Contains(t, out, "- ✅ eu — completed")
@@ -61,7 +61,7 @@ func completedApply() *storage.Apply {
 // An apply with no operation rows (legacy) renders the single-deployment summary
 // unchanged — no aggregate header.
 func TestFormatApplySummaryComment_NoOperationsRendersSingle(t *testing.T) {
-	out := formatApplySummaryComment(completedApply(), nil, nil, nil)
+	out := formatApplySummaryComment(completedApply(), nil, nil, nil, nil)
 	assert.Contains(t, out, "## ✅ Schema Change Applied")
 	assert.NotContains(t, out, "**Deployments**:")
 }
@@ -72,7 +72,7 @@ func TestFormatApplySummaryComment_OneOperationRendersSingle(t *testing.T) {
 	ops := []*storage.ApplyOperation{
 		{ID: 1, Deployment: "eu", State: state.ApplyOperation.Completed},
 	}
-	out := formatApplySummaryComment(completedApply(), ops, nil, nil)
+	out := formatApplySummaryComment(completedApply(), ops, nil, nil, nil)
 	assert.NotContains(t, out, "**Deployments**:")
 	assert.NotContains(t, out, "- ✅ eu")
 }
@@ -85,7 +85,7 @@ func TestFormatApplySummaryComment_MultipleOperationsRendersMulti(t *testing.T) 
 		{ID: 1, Deployment: "eu", State: state.ApplyOperation.Completed},
 		{ID: 2, Deployment: "us", State: state.ApplyOperation.Completed},
 	}
-	out := formatApplySummaryComment(completedApply(), ops, nil, nil)
+	out := formatApplySummaryComment(completedApply(), ops, nil, nil, nil)
 	assert.Contains(t, out, "## ✅ Schema Change Applied")
 	assert.Contains(t, out, "**Deployments**: 2 completed")
 	assert.Contains(t, out, "- ✅ eu — completed")
@@ -103,7 +103,7 @@ func TestBuildMultiApplyData_RoutesTasksByOperation(t *testing.T) {
 		{ApplyOperationID: new(int64(2)), TableName: "orders", State: state.Task.Running},
 		{ApplyOperationID: new(int64(1)), TableName: "customers", State: state.Task.Running},
 	}
-	data := buildMultiApplyData(runningApply(), ops, tasks, nil)
+	data := buildMultiApplyData(runningApply(), ops, tasks, nil, nil)
 
 	require.Len(t, data.Details["eu"].Tables, 1)
 	assert.Equal(t, "customers", data.Details["eu"].Tables[0].TableName)
@@ -115,7 +115,7 @@ func TestBuildMultiApplyData_RoutesTasksByOperation(t *testing.T) {
 // the parent apply's aggregate state.
 func TestBuildDeploymentDetail_UsesOperationStateAndError(t *testing.T) {
 	op := &storage.ApplyOperation{ID: 1, Deployment: "us", State: state.ApplyOperation.Failed, ErrorMessage: "lock wait timeout"}
-	detail := buildDeploymentDetail(runningApply(), op, nil, nil)
+	detail := buildDeploymentDetail(runningApply(), op, nil, nil, nil)
 	assert.Equal(t, state.Apply.Failed, detail.State)
 	assert.Equal(t, "lock wait timeout", detail.ErrorMessage)
 	assert.Equal(t, "payments", detail.Database)

--- a/pkg/webhook/rollback.go
+++ b/pkg/webhook/rollback.go
@@ -474,7 +474,7 @@ func (h *Handler) handleRollbackConfirmCommand(repo string, pr int, environment 
 	// Post initial progress comment for the observer to edit. VSchema status is
 	// omitted on this first comment — the observer refreshes it from engine
 	// display metadata on the next progress tick.
-	progressBody := formatProgressComment(apply, nil)
+	progressBody := formatProgressComment(apply, nil, nil)
 	h.postAndTrackComment(ctx, repo, pr, installationID, applyID, state.Comment.Progress, progressBody)
 }
 

--- a/pkg/webhook/templates/apply.go
+++ b/pkg/webhook/templates/apply.go
@@ -30,6 +30,21 @@ type TableProgressData struct {
 	// ErrorMessage is the task's last error. Rendered for states where the
 	// per-table error explains what the user is seeing (e.g. a retrying task).
 	ErrorMessage string
+
+	// Shards is the per-shard breakdown for a sharded table. Empty for unsharded
+	// engines. Rendered as a single compact summary line
+	// while the table is in flight (see renderShardSummary); detailed per-shard
+	// row counts/ETAs stay in the CLI, not the PR comment.
+	Shards []ShardProgressData
+}
+
+// ShardProgressData is the high-level status of one shard, for the compact
+// per-shard summary in the PR comment. It intentionally carries only state +
+// percent (no row counts/ETA) to keep the comment quiet.
+type ShardProgressData struct {
+	Shard           string
+	Status          string // canonical lowercase shard/task state
+	PercentComplete int
 }
 
 // ApplyStatusCommentData contains all data needed to render an apply status PR comment.
@@ -460,7 +475,120 @@ func renderTableProgress(sb *strings.Builder, table TableProgressData) {
 		renderRunningTable(sb, table)
 	}
 
+	renderShardSummary(sb, table)
+
 	sb.WriteString("\n")
+}
+
+// renderShardSummary appends a single compact per-shard status line for a
+// sharded table, only while it is in flight. It keeps the PR
+// comment quiet: at most one extra line per table. With few shards it lists each
+// shard's state (and percent for actively-copying shards); with many it collapses
+// to per-state counts plus the slowest copying shard, so even hundreds of shards
+// fit on one line. Detailed per-shard rows/ETAs stay in the CLI.
+func renderShardSummary(sb *strings.Builder, table TableProgressData) {
+	if len(table.Shards) <= 1 {
+		return
+	}
+	switch state.NormalizeTaskStatus(table.Status) {
+	case state.Task.Running, state.Task.Recovering, state.Task.CuttingOver, state.Task.WaitingForCutover:
+		// in flight — a breakdown adds signal
+	default:
+		return // completed/pending/cancelled/failed: no breakdown, stay quiet
+	}
+
+	const inlineLimit = 8
+	if len(table.Shards) <= inlineLimit {
+		parts := make([]string, 0, len(table.Shards))
+		for _, sh := range table.Shards {
+			if isCopyingShardStatus(sh.Status) && sh.PercentComplete > 0 {
+				parts = append(parts, fmt.Sprintf("%s %s %d%%", shardGlyph(sh.Status), sh.Shard, sh.PercentComplete))
+			} else {
+				parts = append(parts, fmt.Sprintf("%s %s", shardGlyph(sh.Status), sh.Shard))
+			}
+		}
+		fmt.Fprintf(sb, "  └ shards: %s\n", strings.Join(parts, " · "))
+		return
+	}
+
+	var complete, copying, ready, failed, queued, other int
+	slowestShard := ""
+	slowestPct := -1
+	for _, sh := range table.Shards {
+		switch state.NormalizeShardStatus(sh.Status) {
+		case state.Task.Completed:
+			complete++
+		case state.Task.WaitingForCutover:
+			ready++
+		case state.Task.Failed, state.Task.FailedRetryable:
+			failed++
+		case state.Task.Pending:
+			queued++
+		default:
+			if isCopyingShardStatus(sh.Status) {
+				copying++
+				if slowestPct < 0 || sh.PercentComplete < slowestPct {
+					slowestPct = sh.PercentComplete
+					slowestShard = sh.Shard
+				}
+			} else {
+				other++
+			}
+		}
+	}
+	var buckets []string
+	if complete > 0 {
+		buckets = append(buckets, fmt.Sprintf("%d ✓", complete))
+	}
+	if copying > 0 {
+		buckets = append(buckets, fmt.Sprintf("%d ◐ copying", copying))
+	}
+	if ready > 0 {
+		buckets = append(buckets, fmt.Sprintf("%d ● ready", ready))
+	}
+	if queued > 0 {
+		buckets = append(buckets, fmt.Sprintf("%d ⏳", queued))
+	}
+	if failed > 0 {
+		buckets = append(buckets, fmt.Sprintf("%d ✗ failed", failed))
+	}
+	if other > 0 {
+		buckets = append(buckets, fmt.Sprintf("%d …", other))
+	}
+	line := fmt.Sprintf("  └ %d shards: %s", len(table.Shards), strings.Join(buckets, " · "))
+	if slowestShard != "" && slowestPct >= 0 {
+		line += fmt.Sprintf(" · slowest %s %d%%", slowestShard, slowestPct)
+	}
+	sb.WriteString(line + "\n")
+}
+
+// shardGlyph maps a shard's status to its compact summary glyph.
+func shardGlyph(status string) string {
+	switch state.NormalizeShardStatus(status) {
+	case state.Task.Completed:
+		return "✓" // ✓
+	case state.Task.WaitingForCutover:
+		return "●" // ●
+	case state.Task.Failed, state.Task.FailedRetryable:
+		return "✗" // ✗
+	case state.Task.Pending:
+		return "⏳" // ⏳
+	default:
+		if isCopyingShardStatus(status) {
+			return "◐" // ◐
+		}
+		return "•" // •
+	}
+}
+
+// isCopyingShardStatus reports whether a shard is actively doing copy/cutover work.
+func isCopyingShardStatus(status string) bool {
+	switch state.NormalizeShardStatus(status) {
+	case state.Task.Running, state.Task.Recovering, state.Task.CuttingOver:
+		return true
+	default:
+		return false
+	}
 }
 
 // renderRunningTable renders a table that is actively copying rows.

--- a/pkg/webhook/templates/apply_test.go
+++ b/pkg/webhook/templates/apply_test.go
@@ -232,6 +232,63 @@ func TestRenderApplyStatusComment_VSchema(t *testing.T) {
 	})
 }
 
+// A sharded table renders a compact per-shard summary while in flight: each
+// shard inline when few, collapsed to per-state counts + the slowest copier when
+// many, and nothing once the table completes or when there is a single shard.
+func TestRenderApplyStatusComment_ShardSummary(t *testing.T) {
+	withTemplateTimestamp(t, "2026-06-16 19:42:00 UTC")
+
+	// Inline: ≤8 shards list each shard's status; only the copying shard shows a percent.
+	inline := RenderApplyStatusComment(ApplyStatusCommentData{
+		Database: "shop", Environment: "staging", State: "running", Engine: "Vitess",
+		Tables: []TableProgressData{{
+			TableName: "users", Status: "running", PercentComplete: 50,
+			Shards: []ShardProgressData{
+				{Shard: "-80", Status: "completed", PercentComplete: 100},
+				{Shard: "80-", Status: "running", PercentComplete: 45},
+			},
+		}},
+	})
+	assert.Contains(t, inline, "shards:")
+	assert.Contains(t, inline, "✓ -80")
+	assert.Contains(t, inline, "◐ 80- 45%")
+
+	// Collapsed: >8 shards bucket by state and name the slowest copier.
+	many := make([]ShardProgressData, 0, 12)
+	for i := range 9 {
+		many = append(many, ShardProgressData{Shard: fmt.Sprintf("c%d", i), Status: "completed", PercentComplete: 100})
+	}
+	many = append(many,
+		ShardProgressData{Shard: "slow1", Status: "running", PercentComplete: 12},
+		ShardProgressData{Shard: "fast1", Status: "running", PercentComplete: 80},
+		ShardProgressData{Shard: "q1", Status: "pending"},
+	)
+	collapsed := RenderApplyStatusComment(ApplyStatusCommentData{
+		Database: "shop", Environment: "staging", State: "running", Engine: "Vitess",
+		Tables: []TableProgressData{{TableName: "orders", Status: "running", PercentComplete: 70, Shards: many}},
+	})
+	assert.Contains(t, collapsed, "12 shards:")
+	assert.Contains(t, collapsed, "9 ✓")
+	assert.Contains(t, collapsed, "2 ◐ copying")
+	assert.Contains(t, collapsed, "slowest slow1 12%")
+
+	// Suppressed once the table completes — no shard line even with shard rows.
+	done := RenderApplyStatusComment(ApplyStatusCommentData{
+		Database: "shop", Environment: "staging", State: "completed", Engine: "Vitess",
+		Tables: []TableProgressData{{TableName: "users", Status: "completed",
+			Shards: []ShardProgressData{{Shard: "-80", Status: "completed"}, {Shard: "80-", Status: "completed"}}}},
+	})
+	assert.NotContains(t, done, "shards:")
+
+	// A single shard adds no signal — no breakdown.
+	single := RenderApplyStatusComment(ApplyStatusCommentData{
+		Database: "shop", Environment: "staging", State: "running", Engine: "Vitess",
+		Tables: []TableProgressData{{TableName: "users", Status: "running", PercentComplete: 30,
+			Shards: []ShardProgressData{{Shard: "0", Status: "running", PercentComplete: 30}}}},
+	})
+	assert.NotContains(t, single, "shards:")
+}
+
 // A PlanetScale apply in a deploy-request phase renders its first-class phase
 // header (not a generic "In Progress") and still offers the operator a stop
 // action — the change is active, stoppable work before cutover.

--- a/pkg/webhook/templates/apply_test.go
+++ b/pkg/webhook/templates/apply_test.go
@@ -245,13 +245,17 @@ func TestRenderApplyStatusComment_ShardSummary(t *testing.T) {
 			TableName: "users", Status: "running", PercentComplete: 50,
 			Shards: []ShardProgressData{
 				{Shard: "-80", Status: "completed", PercentComplete: 100},
-				{Shard: "80-", Status: "running", PercentComplete: 45},
+				{Shard: "80-c0", Status: "running", PercentComplete: 45},
+				{Shard: "c0-", Status: "waiting_for_cutover", PercentComplete: 100},
 			},
 		}},
 	})
 	assert.Contains(t, inline, "shards:")
 	assert.Contains(t, inline, "✓ -80")
-	assert.Contains(t, inline, "◐ 80- 45%")
+	assert.Contains(t, inline, "◐ 80-c0 45%")
+	// A shard ready for cutover shows ● and no percent (it is no longer copying).
+	assert.Contains(t, inline, "● c0-")
+	assert.NotContains(t, inline, "● c0- 100%")
 
 	// Collapsed: >8 shards bucket by state and name the slowest copier.
 	many := make([]ShardProgressData, 0, 12)
@@ -261,15 +265,17 @@ func TestRenderApplyStatusComment_ShardSummary(t *testing.T) {
 	many = append(many,
 		ShardProgressData{Shard: "slow1", Status: "running", PercentComplete: 12},
 		ShardProgressData{Shard: "fast1", Status: "running", PercentComplete: 80},
+		ShardProgressData{Shard: "ready1", Status: "waiting_for_cutover", PercentComplete: 100},
 		ShardProgressData{Shard: "q1", Status: "pending"},
 	)
 	collapsed := RenderApplyStatusComment(ApplyStatusCommentData{
 		Database: "shop", Environment: "staging", State: "running", Engine: "Vitess",
 		Tables: []TableProgressData{{TableName: "orders", Status: "running", PercentComplete: 70, Shards: many}},
 	})
-	assert.Contains(t, collapsed, "12 shards:")
+	assert.Contains(t, collapsed, "13 shards:")
 	assert.Contains(t, collapsed, "9 ✓")
 	assert.Contains(t, collapsed, "2 ◐ copying")
+	assert.Contains(t, collapsed, "1 ● ready")
 	assert.Contains(t, collapsed, "slowest slow1 12%")
 
 	// Suppressed once the table completes — no shard line even with shard rows.

--- a/pkg/webhook/templates/preview.go
+++ b/pkg/webhook/templates/preview.go
@@ -1,6 +1,7 @@
 package templates
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/block/schemabot/pkg/apitypes"
@@ -838,6 +839,81 @@ func PreviewCommentApplyVitessMultiKeyspaceVSchema() string {
 		{Namespace: "commerce_sharded", Status: "applying", Diff: `+ "xxhash": {"type": "xxhash"}`},
 	}
 	return RenderApplyStatusComment(data)
+}
+
+// PreviewCommentApplyShardProgress renders a sharded apply where one table is
+// copying across a handful of shards, exercising the inline per-shard summary
+// (each shard listed, a percent only on the actively-copying shards).
+func PreviewCommentApplyShardProgress() string {
+	shards := []ShardProgressData{
+		{Shard: "-40", Status: state.Task.Completed, PercentComplete: 100},
+		{Shard: "40-80", Status: state.Task.Running, PercentComplete: 62},
+		{Shard: "80-c0", Status: state.Task.Running, PercentComplete: 31},
+		{Shard: "c0-", Status: state.Task.Pending},
+	}
+	return RenderApplyStatusComment(ApplyStatusCommentData{
+		Database:    "commerce",
+		Environment: "staging",
+		RequestedBy: "jackjackbits",
+		ApplyID:     "apply-7aa13cf03496454b",
+		State:       state.Apply.Running,
+		Engine:      "Vitess",
+		Tables: []TableProgressData{{
+			Namespace:       "commerce",
+			TableName:       "users",
+			DDL:             "ALTER TABLE `users` ADD INDEX `idx_email` (`email`)",
+			Status:          state.Task.Running,
+			RowsCopied:      914707,
+			RowsTotal:       1466232,
+			PercentComplete: 62,
+			ETASeconds:      195,
+			Shards:          shards,
+		}},
+	})
+}
+
+// PreviewCommentApplyManyShardProgress renders a sharded apply where a table is
+// copying across 256 shards, exercising the collapsed per-shard summary
+// (per-state counts plus the slowest copier, so the line stays compact).
+func PreviewCommentApplyManyShardProgress() string {
+	const total = 256
+	shards := make([]ShardProgressData, 0, total)
+	for i := range total {
+		sh := ShardProgressData{Shard: fmt.Sprintf("%02x-", i)}
+		switch {
+		case i < 200:
+			sh.Status = state.Task.Completed
+			sh.PercentComplete = 100
+		case i == 247:
+			sh.Status = state.Task.Running
+			sh.PercentComplete = 12 // the laggard the collapsed line names
+		case i < 252:
+			sh.Status = state.Task.Running
+			sh.PercentComplete = 55 + i%20
+		default:
+			sh.Status = state.Task.Pending
+		}
+		shards = append(shards, sh)
+	}
+	return RenderApplyStatusComment(ApplyStatusCommentData{
+		Database:    "commerce",
+		Environment: "staging",
+		RequestedBy: "jackjackbits",
+		ApplyID:     "apply-7aa13cf03496454b",
+		State:       state.Apply.Running,
+		Engine:      "Vitess",
+		Tables: []TableProgressData{{
+			Namespace:       "commerce",
+			TableName:       "orders",
+			DDL:             "ALTER TABLE `orders` ADD COLUMN `region` varchar(32)",
+			Status:          state.Task.Running,
+			RowsCopied:      4200000000,
+			RowsTotal:       6000000000,
+			PercentComplete: 70,
+			ETASeconds:      5400,
+			Shards:          shards,
+		}},
+	})
 }
 
 // PreviewCommentApplyCompleted renders a sample apply-completed comment.


### PR DESCRIPTION
## Why this matters

For a sharded apply, per-shard progress was modeled, persisted, and rendered by the **CLI** — but the **PR comment showed table-level progress only**. The webhook reads table tasks (`GetByApplyID` excludes shard rows), so a reviewer watching the PR couldn't see whether one shard was lagging or where a sharded apply stood.

## What it does

Adds a single, deliberately quiet per-shard summary line under each sharded table, **only while the table is in flight**:

- Skipped for unsharded / single-shard tables, and suppressed once the table completes (a done table needs no breakdown).
- **≤8 shards** — list each shard with a status glyph; a percent appears only on the actively-copying shard(s):
  ```
  **`users`**: 🟦 Row copy in progress (45%)
    └ shards: ✓ -80 · ◐ 80- 45%
  ```
- **>8 shards** — collapse to per-state counts + the slowest copier, so hundreds of shards still fit one line:
  ```
  **`orders`**: 🟦 Row copy in progress (70%)
    └ 32 shards: 24 ✓ · 6 ◐ copying · 2 ⏳ · slowest 80-c0 38%
  ```

Glyphs: `✓` complete · `◐` copying · `●` ready-for-cutover · `✗` failed · `⏳` queued. High-level status per shard only — detailed row counts/ETAs stay in the CLI to keep the comment quiet.

```
data flow:  engine per-shard (SHOW VITESS_MIGRATIONS)
              → stored shard task rows (shard != '')
              → observer GetShardProgressByApplyOperationID, grouped by table
              → compact summary line per in-flight sharded table
```

The per-shard rows thread through both the single- and multi-deployment comment builders; the load is best-effort (a failed shard read just omits that operation's shards for the render).
