### PR TITLE
feat(spirit): surface row-copy ETA in progress

### DIFF
--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -6058,7 +6058,7 @@ Environment: production
 
      ~ orders: 🟦🟦🟦🟦🟦🟦🟦⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ 35%
        ALTER TABLE `orders` ADD COLUMN `source` varchar(32);
-       • Rows: 42,500 / 120,000
+       • Rows: 42,500 / 120,000 · ETA: 4m 0s
 
 
 ⏳ ap-south — waiting for eu-west (orders-ap-south)

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.14
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.1
 	github.com/aws/aws-sdk-go-v2/service/sts v1.43.3
-	github.com/block/spirit v0.15.1-0.20260617235652-98a38a253173
+	github.com/block/spirit v0.15.2-0.20260625000508-ce39327a7ec9
 	github.com/bradleyfalzon/ghinstallation/v2 v2.18.0
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10

--- a/go.sum
+++ b/go.sum
@@ -113,8 +113,8 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/block/spirit v0.15.1-0.20260617235652-98a38a253173 h1:+wbB4brtVUflISkTJsAnkzY+Xw8lTrIvTS3yvanpfN0=
-github.com/block/spirit v0.15.1-0.20260617235652-98a38a253173/go.mod h1:ku7mCCKx7Wk4QrMa/mHnsqQhZkoUD2vdBkpjJEDk4lY=
+github.com/block/spirit v0.15.2-0.20260625000508-ce39327a7ec9 h1:WBcVgShA4ZidIpFF87EoPM/Y7prvcwREUS5MT6Lvf2c=
+github.com/block/spirit v0.15.2-0.20260625000508-ce39327a7ec9/go.mod h1:ku7mCCKx7Wk4QrMa/mHnsqQhZkoUD2vdBkpjJEDk4lY=
 github.com/block/tidb/pkg/parser v0.0.0-20260506200501-e528fd979fc8 h1:+OfdTacrEyjlqcRUpBFX9uJ6ROBq6cUjwY4DClhnsdU=
 github.com/block/tidb/pkg/parser v0.0.0-20260506200501-e528fd979fc8/go.mod h1:zDLDsfNBU5+L6T4J9/OgWAHc/WZvMUjbpgHqQ/t3yKo=
 github.com/block/vitess v0.0.0-20260601162944-8318a748ceb1 h1:dnHGiR/N1+X2EM1FGzL4548iCzJcIAnhcMbEt026xHQ=

--- a/pkg/cmd/commands/apply.go
+++ b/pkg/cmd/commands/apply.go
@@ -847,12 +847,7 @@ func (e *logEmitter) emitProgressHeartbeat(tbl *apitypes.TableProgressResponse, 
 		)
 	}
 
-	// Try to extract ETA from Spirit progress detail
-	if tbl.ProgressDetail != "" {
-		if info := templates.ParseSpiritProgress(tbl.ProgressDetail); info != nil && info.ETA != "" && info.ETA != "TBD" {
-			kvs = append(kvs, "eta", info.ETA)
-		}
-	} else if tbl.ETASeconds > 0 {
+	if tbl.ETASeconds > 0 {
 		kvs = append(kvs, "eta", ui.FormatETA(tbl.ETASeconds))
 	}
 

--- a/pkg/cmd/commands/apply_log_test.go
+++ b/pkg/cmd/commands/apply_log_test.go
@@ -215,7 +215,7 @@ func TestLogEmitter_EmitTableStateChange(t *testing.T) {
 }
 
 func TestLogEmitter_EmitProgressHeartbeat(t *testing.T) {
-	t.Run("with ETA from progress detail", func(t *testing.T) {
+	t.Run("structured ETA renders alongside a Spirit progress detail", func(t *testing.T) {
 		e := &logEmitter{applyID: "apply-test"}
 		ts := &tableLogState{taskID: "task-orders-1"}
 		tbl := &apitypes.TableProgressResponse{
@@ -223,7 +223,8 @@ func TestLogEmitter_EmitProgressHeartbeat(t *testing.T) {
 			PercentComplete: 45,
 			RowsCopied:      99450,
 			RowsTotal:       221000,
-			ProgressDetail:  "99450/221000 45.00% copyRows ETA 5m 30s",
+			ETASeconds:      330,
+			ProgressDetail:  "99450/221000 45.00% copyRows",
 		}
 
 		output := captureOutput(t, func() {
@@ -235,7 +236,7 @@ func TestLogEmitter_EmitProgressHeartbeat(t *testing.T) {
 		assert.Contains(t, plain, "table=orders")
 		assert.Contains(t, plain, "progress=45%")
 		assert.Contains(t, plain, "rows=99,450/221,000")
-		assert.Contains(t, plain, "eta=")
+		assert.Contains(t, plain, "5m 30s")
 	})
 
 	t.Run("with ETA from ETASeconds", func(t *testing.T) {

--- a/pkg/cmd/commands/watch_tui.go
+++ b/pkg/cmd/commands/watch_tui.go
@@ -68,7 +68,7 @@ type tableProgress struct {
 	RowsCopied     int64
 	RowsTotal      int64
 	Percent        int
-	ETA            string
+	ETASeconds     int64
 	ProgressDetail string
 	IsInstant      bool
 	Shards         []shardProgress

--- a/pkg/cmd/commands/watch_tui_commands.go
+++ b/pkg/cmd/commands/watch_tui_commands.go
@@ -248,6 +248,7 @@ func parseProgressResult(result *apitypes.ProgressResponse) progressMsg {
 			RowsCopied:     tbl.RowsCopied,
 			RowsTotal:      tbl.RowsTotal,
 			Percent:        int(tbl.PercentComplete),
+			ETASeconds:     tbl.ETASeconds,
 			ProgressDetail: tbl.ProgressDetail,
 			IsInstant:      tbl.IsInstant,
 		}
@@ -256,7 +257,6 @@ func parseProgressResult(result *apitypes.ProgressResponse) progressMsg {
 				tp.Percent = info.Percent
 				tp.RowsCopied = info.RowsCopied
 				tp.RowsTotal = info.RowsTotal
-				tp.ETA = info.ETA
 			}
 		}
 		for _, sh := range tbl.Shards {

--- a/pkg/cmd/commands/watch_tui_view.go
+++ b/pkg/cmd/commands/watch_tui_view.go
@@ -284,8 +284,9 @@ func recoveringCopyPercent(tables []tableProgress) (int, bool) {
 func toTemplateTables(tables []tableProgress) []templates.TableProgress {
 	result := make([]templates.TableProgress, len(tables))
 	for i, t := range tables {
-		// Derive table-level ETA from max shard ETA for Vitess tables
-		var etaSeconds int64
+		// Table-level ETA: the table's own estimate (MySQL/Spirit), or the
+		// slowest shard's for a sharded (Vitess) table.
+		etaSeconds := t.ETASeconds
 		for _, sh := range t.Shards {
 			if sh.ETASeconds > etaSeconds {
 				etaSeconds = sh.ETASeconds

--- a/pkg/cmd/internal/templates/progress.go
+++ b/pkg/cmd/internal/templates/progress.go
@@ -588,12 +588,9 @@ func FormatTableProgressWithActivity(t TableProgress, activityBar, activityLabel
 			if t.DDL != "" {
 				b.WriteString(formatProgressDDL(t.DDL))
 			}
-			// Rows and ETA on same line
-			if info.ETA != "" && info.ETA != "TBD" {
-				fmt.Fprintf(&b, indentDetail+"Rows: %s / %s · ETA: %s\n", ui.FormatNumber(ui.ClampRows(info.RowsCopied, info.RowsTotal)), ui.FormatNumber(info.RowsTotal), info.ETA)
-			} else {
-				fmt.Fprintf(&b, indentDetail+"Rows: %s / %s\n", ui.FormatNumber(ui.ClampRows(info.RowsCopied, info.RowsTotal)), ui.FormatNumber(info.RowsTotal))
-			}
+			// Rows and ETA on the same line, rendered from the structured ETA
+			// so the CLI and PR comment show the same value via FormatETA.
+			writeStructuredRowsAndETA(&b, t)
 			if info.State != "" && info.State != "copyRows" {
 				fmt.Fprintf(&b, indentDetail+"Status: %s\n", info.State)
 			}

--- a/pkg/cmd/internal/templates/progress_parse.go
+++ b/pkg/cmd/internal/templates/progress_parse.go
@@ -4,15 +4,15 @@ import (
 	"math"
 	"regexp"
 	"strconv"
-	"strings"
 
 	"github.com/block/schemabot/pkg/apitypes"
 	"github.com/block/schemabot/pkg/state"
 )
 
-// spiritProgressPattern matches Spirit progress strings like "71436/221193 32.30% copyRows ETA TBD"
-// or "71436/221193 32.30% copyRows ETA 5m 30s (-1m from 3m ago)".
-var spiritProgressPattern = regexp.MustCompile(`(\d+)/(\d+)\s+([\d.]+)%\s+(\w+)(?:\s+ETA\s+([^\(]+))?`)
+// spiritProgressPattern matches the row-copy prefix of a Spirit progress
+// string, e.g. "71436/221193 32.30% copyRows". The ETA is carried separately as
+// a structured field, so it is not parsed out of this string.
+var spiritProgressPattern = regexp.MustCompile(`(\d+)/(\d+)\s+([\d.]+)%\s+(\w+)`)
 
 // ProgressData contains data for rendering schema change progress.
 type ProgressData struct {
@@ -90,7 +90,6 @@ type SpiritProgressInfo struct {
 	RowsCopied int64
 	RowsTotal  int64
 	Percent    int
-	ETA        string // "TBD", "5m 30s", etc.
 	State      string // "copyRows", "checksum", etc.
 }
 
@@ -110,17 +109,12 @@ func ParseSpiritProgress(progress string) *SpiritProgressInfo {
 	rowsTotal, _ := strconv.ParseInt(matches[2], 10, 64)
 	percentFloat, _ := strconv.ParseFloat(matches[3], 64)
 	state := matches[4]
-	eta := ""
-	if len(matches) > 5 {
-		eta = strings.TrimSpace(matches[5])
-	}
 
 	return &SpiritProgressInfo{
 		RowsCopied: rowsCopied,
 		RowsTotal:  rowsTotal,
 		Percent:    int(math.Round(percentFloat)),
 		State:      state,
-		ETA:        eta,
 	}
 }
 

--- a/pkg/cmd/internal/templates/progress_states_test.go
+++ b/pkg/cmd/internal/templates/progress_states_test.go
@@ -260,6 +260,27 @@ func TestFormatTableProgress_RowCopyDisplaysOnePercentAfterCopyStarts(t *testing
 	assert.NotContains(t, output, " 0%")
 }
 
+// A Spirit row-copy reports its detail string and a structured ETA. The CLI
+// renders the ETA from the structured field (the same source and FormatETA the
+// PR comment uses), so the two surfaces show an identical "Rows … · ETA …" line
+// even though the detail string itself no longer carries the ETA.
+func TestFormatTableProgress_RowCopyShowsStructuredETA(t *testing.T) {
+	tp := TableProgress{
+		TableName:       "users",
+		ChangeType:      "alter",
+		Status:          state.Apply.Running,
+		RowsCopied:      45_000,
+		RowsTotal:       100_000,
+		PercentComplete: 45,
+		ETASeconds:      340,
+		ProgressDetail:  "45000/100000 45% copyRows",
+	}
+
+	output := FormatTableProgress(tp)
+
+	assert.Contains(t, output, "Rows: 45,000 / 100,000 · ETA: 5m 40s")
+}
+
 func TestFormatTableProgress_FailedRetryableKeepsProgress(t *testing.T) {
 	t.Run("with progress", func(t *testing.T) {
 		tp := TableProgress{

--- a/pkg/engine/spirit/spirit.go
+++ b/pkg/engine/spirit/spirit.go
@@ -525,9 +525,10 @@ func (e *Engine) Progress(ctx context.Context, req *engine.ProgressRequest) (*en
 
 // buildSpiritTableProgress maps Spirit's per-table progress into engine
 // TableProgress. Spirit reports a single remaining row-copy estimate for the
-// whole runner, so the ETA is surfaced on the tables still copying; completed
-// tables keep 0, as do estimates that aren't ready yet (still measuring the
-// copy rate, or essentially done).
+// whole runner, so the ETA is surfaced on the tables still copying that have an
+// established row total; completed tables keep 0, as do tables without a total
+// yet and estimates that aren't ready (still measuring the copy rate, or
+// essentially done).
 func buildSpiritTableProgress(prog status.Progress, stateStr string, ddlByTable, tableNamespace map[string]string) []engine.TableProgress {
 	var etaSeconds int64
 	if prog.ETA.State == status.ETAReady {
@@ -552,7 +553,7 @@ func buildSpiritTableProgress(prog status.Progress, stateStr string, ddlByTable,
 		if st.IsComplete {
 			tp.State = "completed"
 			tp.Progress = 100
-		} else {
+		} else if st.RowsTotal > 0 {
 			tp.ETASeconds = etaSeconds
 		}
 		tableProgress = append(tableProgress, tp)

--- a/pkg/engine/spirit/spirit.go
+++ b/pkg/engine/spirit/spirit.go
@@ -483,33 +483,7 @@ func (e *Engine) Progress(ctx context.Context, req *engine.ProgressRequest) (*en
 
 	// If Spirit provides per-table progress, use it
 	if len(spiritProgress.Tables) > 0 {
-		for _, st := range spiritProgress.Tables {
-			rowsCopied := int64(st.RowsCopied)
-			rowsTotal := int64(st.RowsTotal)
-			tp := engine.TableProgress{
-				Namespace:  rm.tableNamespace[st.TableName],
-				Table:      st.TableName,
-				DDL:        ddlByTable[st.TableName],
-				State:      stateStr,
-				RowsCopied: rowsCopied,
-				RowsTotal:  rowsTotal,
-			}
-			// Calculate percent (clamp to 100 — concurrent inserts can cause RowsCopied > RowsTotal)
-			if st.RowsTotal > 0 {
-				tp.Progress = min(int(float64(st.RowsCopied)/float64(st.RowsTotal)*100), 100)
-			}
-
-			// Build progress detail string (ETA is shown at status line level, not per-table)
-			if st.RowsTotal > 0 {
-				tp.ProgressDetail = fmt.Sprintf("%d/%d %d%% copyRows",
-					st.RowsCopied, st.RowsTotal, tp.Progress)
-			}
-			if st.IsComplete {
-				tp.State = "completed"
-				tp.Progress = 100
-			}
-			tableProgress = append(tableProgress, tp)
-		}
+		tableProgress = buildSpiritTableProgress(spiritProgress, stateStr, ddlByTable, rm.tableNamespace)
 	} else {
 		// Fallback: no per-table progress available
 		for i, tableName := range rm.tables {
@@ -547,6 +521,43 @@ func (e *Engine) Progress(ctx context.Context, req *engine.ProgressRequest) (*en
 		Tables:       tableProgress,
 		ResumeState:  req.ResumeState,
 	}, nil
+}
+
+// buildSpiritTableProgress maps Spirit's per-table progress into engine
+// TableProgress. Spirit reports a single remaining row-copy estimate for the
+// whole runner, so the ETA is surfaced on the tables still copying; completed
+// tables keep 0, as do estimates that aren't ready yet (still measuring the
+// copy rate, or essentially done).
+func buildSpiritTableProgress(prog status.Progress, stateStr string, ddlByTable, tableNamespace map[string]string) []engine.TableProgress {
+	var etaSeconds int64
+	if prog.ETA.State == status.ETAReady {
+		etaSeconds = int64(prog.ETA.Duration.Seconds())
+	}
+	tableProgress := make([]engine.TableProgress, 0, len(prog.Tables))
+	for _, st := range prog.Tables {
+		tp := engine.TableProgress{
+			Namespace:  tableNamespace[st.TableName],
+			Table:      st.TableName,
+			DDL:        ddlByTable[st.TableName],
+			State:      stateStr,
+			RowsCopied: int64(st.RowsCopied),
+			RowsTotal:  int64(st.RowsTotal),
+		}
+		// Calculate percent (clamp to 100 — concurrent inserts can cause RowsCopied > RowsTotal)
+		if st.RowsTotal > 0 {
+			tp.Progress = min(int(float64(st.RowsCopied)/float64(st.RowsTotal)*100), 100)
+			tp.ProgressDetail = fmt.Sprintf("%d/%d %d%% copyRows",
+				st.RowsCopied, st.RowsTotal, tp.Progress)
+		}
+		if st.IsComplete {
+			tp.State = "completed"
+			tp.Progress = 100
+		} else {
+			tp.ETASeconds = etaSeconds
+		}
+		tableProgress = append(tableProgress, tp)
+	}
+	return tableProgress
 }
 
 // progressState resolves the state reported for a progress poll. The tracked

--- a/pkg/engine/spirit/spirit_test.go
+++ b/pkg/engine/spirit/spirit_test.go
@@ -148,6 +148,18 @@ func TestBuildSpiritTableProgress(t *testing.T) {
 		assert.Equal(t, int64(0), orders.ETASeconds, "completed table carries no ETA")
 	})
 
+	t.Run("ready ETA is withheld from a table without an established total", func(t *testing.T) {
+		prog := status.Progress{
+			ETA:    status.ETA{State: status.ETAReady, Duration: 90 * time.Second},
+			Tables: []status.TableProgress{{TableName: "users", RowsCopied: 0, RowsTotal: 0}},
+		}
+		got := buildSpiritTableProgress(prog, "copyRows", ddlByTable, tableNamespace)
+		require.Len(t, got, 1)
+		assert.Equal(t, int64(0), got[0].ETASeconds, "no row total means no ETA")
+		assert.Equal(t, 0, got[0].Progress)
+		assert.Empty(t, got[0].ProgressDetail)
+	})
+
 	notReady := []struct {
 		name string
 		eta  status.ETA

--- a/pkg/engine/spirit/spirit_test.go
+++ b/pkg/engine/spirit/spirit_test.go
@@ -2,9 +2,11 @@ package spirit
 
 import (
 	"testing"
+	"time"
 
 	"github.com/block/spirit/pkg/status"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/block/schemabot/pkg/engine"
 )
@@ -104,6 +106,65 @@ func TestProgressState(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.want, progressState(tt.rm, tt.spiritState))
+		})
+	}
+}
+
+// TestBuildSpiritTableProgress verifies that Spirit's per-table progress is
+// mapped into engine TableProgress, and that the runner's single row-copy ETA
+// is surfaced on tables still copying only once it is ready: a still-measuring
+// or essentially-done estimate is not yet a number, so those tables (and any
+// already-complete table) report no ETA rather than a misleading value.
+func TestBuildSpiritTableProgress(t *testing.T) {
+	ddlByTable := map[string]string{"users": "ALTER TABLE `users` ADD COLUMN `email` VARCHAR(255)"}
+	tableNamespace := map[string]string{"users": "app"}
+
+	t.Run("ready ETA surfaces on copying tables, not completed ones", func(t *testing.T) {
+		prog := status.Progress{
+			ETA: status.ETA{State: status.ETAReady, Duration: 90 * time.Second},
+			Tables: []status.TableProgress{
+				{TableName: "users", RowsCopied: 45000, RowsTotal: 100000},
+				{TableName: "orders", RowsCopied: 1000, RowsTotal: 1000, IsComplete: true},
+			},
+		}
+
+		got := buildSpiritTableProgress(prog, "copyRows", ddlByTable, tableNamespace)
+		require.Len(t, got, 2)
+
+		users := got[0]
+		assert.Equal(t, "users", users.Table)
+		assert.Equal(t, "app", users.Namespace)
+		assert.Equal(t, "ALTER TABLE `users` ADD COLUMN `email` VARCHAR(255)", users.DDL)
+		assert.Equal(t, "copyRows", users.State)
+		assert.Equal(t, int64(45000), users.RowsCopied)
+		assert.Equal(t, int64(100000), users.RowsTotal)
+		assert.Equal(t, 45, users.Progress)
+		assert.Equal(t, "45000/100000 45% copyRows", users.ProgressDetail)
+		assert.Equal(t, int64(90), users.ETASeconds)
+
+		orders := got[1]
+		assert.Equal(t, "completed", orders.State)
+		assert.Equal(t, 100, orders.Progress)
+		assert.Equal(t, int64(0), orders.ETASeconds, "completed table carries no ETA")
+	})
+
+	notReady := []struct {
+		name string
+		eta  status.ETA
+	}{
+		{"measuring carries no ETA", status.ETA{State: status.ETAMeasuring}},
+		{"due carries no ETA", status.ETA{State: status.ETADue}},
+		{"none carries no ETA", status.ETA{State: status.ETANone}},
+	}
+	for _, tt := range notReady {
+		t.Run(tt.name, func(t *testing.T) {
+			prog := status.Progress{
+				ETA:    tt.eta,
+				Tables: []status.TableProgress{{TableName: "users", RowsCopied: 45000, RowsTotal: 100000}},
+			}
+			got := buildSpiritTableProgress(prog, "copyRows", ddlByTable, tableNamespace)
+			require.Len(t, got, 1)
+			assert.Equal(t, int64(0), got[0].ETASeconds)
 		})
 	}
 }

--- a/pkg/ui/format.go
+++ b/pkg/ui/format.go
@@ -43,16 +43,25 @@ func VSchemaStatusLabel(status string) string {
 	}
 }
 
-// FormatETA formats a duration in seconds as a human-readable string.
-// Examples: 45 → "45s", 195 → "3m 15s", 3700 → "1h 1m"
+// FormatETA formats a duration in seconds as a human-readable string, using the
+// two largest non-zero units so a long copy stays readable.
+// Examples: 45 → "45s", 195 → "3m 15s", 3700 → "1h 1m", 180000 → "2d 2h"
 func FormatETA(seconds int64) string {
-	if seconds < 60 {
+	const (
+		minute = 60
+		hour   = 60 * minute
+		day    = 24 * hour
+	)
+	switch {
+	case seconds < minute:
 		return fmt.Sprintf("%ds", seconds)
+	case seconds < hour:
+		return fmt.Sprintf("%dm %ds", seconds/minute, seconds%minute)
+	case seconds < day:
+		return fmt.Sprintf("%dh %dm", seconds/hour, (seconds%hour)/minute)
+	default:
+		return fmt.Sprintf("%dd %dh", seconds/day, (seconds%day)/hour)
 	}
-	if seconds < 3600 {
-		return fmt.Sprintf("%dm %ds", seconds/60, seconds%60)
-	}
-	return fmt.Sprintf("%dh %dm", seconds/3600, (seconds%3600)/60)
 }
 
 // ClampRows returns rows clamped to total for display purposes.

--- a/pkg/ui/format_test.go
+++ b/pkg/ui/format_test.go
@@ -47,6 +47,31 @@ func TestProgressBarActivity(t *testing.T) {
 	assert.Zero(t, strings.Count(bar, ColorEmpty))
 }
 
+func TestFormatETA(t *testing.T) {
+	tests := []struct {
+		name    string
+		seconds int64
+		want    string
+	}{
+		{"zero", 0, "0s"},
+		{"sub-minute", 45, "45s"},
+		{"exactly a minute", 60, "1m 0s"},
+		{"minutes and seconds", 195, "3m 15s"},
+		{"exactly an hour", 3600, "1h 0m"},
+		{"hours and minutes", 3700, "1h 1m"},
+		{"just under a day", 86399, "23h 59m"},
+		{"exactly a day", 86400, "1d 0h"},
+		{"days and hours", 180000, "2d 2h"},
+		{"multi-week copy", 1814400, "21d 0h"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, FormatETA(tt.seconds))
+		})
+	}
+}
+
 func TestRowCopyDisplayPercent(t *testing.T) {
 	assert.Equal(t, 0, RowCopyDisplayPercent(0, 0))
 	assert.Equal(t, 1, RowCopyDisplayPercent(0, 42))


### PR DESCRIPTION
## Why this matters

A long row-copy shows how many rows have copied but not *how much longer* — operators can't tell a change that's nearly done from one with hours to go.

## What it does

Surfaces Spirit's structured row-copy ETA (`status.Progress.ETA`) across every progress surface:

- **Populates** `engine.TableProgress.ETASeconds` from it, so the templates that already render `Rows: X / Y · ETA: …` light up for Spirit changes (PlanetScale already populated the same field).
- **Only when ready** — withheld while Spirit is still measuring the rate, when the copy is essentially done (cutover pending), or when a table has no established row total, so we never show a misleading number.
- **One source of truth** — the CLI, watch TUI, and apply log heartbeat used to re-parse the ETA out of Spirit's detail string and only fall back to the structured field; they now all read `ETASeconds` via the shared `FormatETA`, and the dead string-parsing is removed.
- **Readable durations** — `FormatETA` now uses the two largest non-zero units with a day tier, so a multi-day copy reads `2d 2h` instead of `48h 0m`.

Requires the Spirit bump in this PR for the new `status.Progress.ETA` field.

<details>
<summary>Preview: in-progress PR comment with ETA</summary>

## Schema Change In Progress

**Database**: `testapp` | **Environment**: `staging` | **Apply ID**: `apply-a1b2c3d4e5f6` | **Elapsed**: 8m

### Table Progress

**`orders`**: 🟦🟦🟦🟦⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ 22%

```sql
ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
```
Rows: 321,450 / 1,466,232 · ETA: 5m 40s

**`users`**: ⏳ Queued

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)