### PR TITLE
feat(storage): track a per-operation attempt counter

### DIFF
--- a/pkg/schema/mysql/apply_operations.sql
+++ b/pkg/schema/mysql/apply_operations.sql
@@ -11,6 +11,7 @@ CREATE TABLE `apply_operations` (
   `error_message` text,
   `cutover_policy` varchar(16) NOT NULL DEFAULT 'rolling',
   `on_failure` varchar(16) NOT NULL DEFAULT 'halt',
+  `attempt` int NOT NULL DEFAULT '0',
   `lease_owner` varchar(255) NOT NULL DEFAULT '',
   `lease_token` varchar(64) NOT NULL DEFAULT '',
   `lease_acquired_at` datetime DEFAULT NULL,

--- a/pkg/storage/mysqlstore/apply_operations.go
+++ b/pkg/storage/mysqlstore/apply_operations.go
@@ -20,7 +20,7 @@ import (
 
 // applyOperationColumns lists all columns for SELECT queries.
 const applyOperationColumns = `id, apply_id, deployment, operation_key, operation_kind, target, state, error_message,
-	cutover_policy, on_failure, started_at, completed_at, lease_owner, lease_token, lease_acquired_at,
+	cutover_policy, on_failure, attempt, started_at, completed_at, lease_owner, lease_token, lease_acquired_at,
 	engine_resume_context, engine_resume_metadata, created_at, updated_at`
 
 // mysqlErrDupEntry is MySQL's error number for a duplicate-key violation.
@@ -952,6 +952,23 @@ func (s *applyOperationStore) FindNextApplyOperation(ctx context.Context, owner 
 		// the row lock this UPDATE takes serializes them, so the second sees the
 		// already-incremented attempt and does not overshoot maxRecoveryAttempts.
 		if ad.State == state.ApplyOperation.FailedRetryable {
+			// Advance the operation's own attempt: a failed_retryable re-claim is
+			// this operation's deliberate redispatch, so its dispatch generation
+			// rotates. Crash-recovery re-lease of an in-flight drive (the other
+			// arm of this default case) leaves attempt untouched so the orphaned
+			// dispatch's idempotency key stays stable and is reused, not
+			// duplicated. Unlike the parent budget bump below, this is not gated
+			// on multi-operation: attempt is operation-local and a sibling's
+			// retry must never rotate it.
+			if _, err := tx.ExecContext(ctx, `
+				UPDATE apply_operations
+				SET attempt = attempt + 1
+				WHERE id = ?
+			`, ad.ID); err != nil {
+				return nil, fmt.Errorf("advance attempt for apply_operation %d redispatch: %w", ad.ID, err)
+			}
+			ad.Attempt++
+
 			if _, err := tx.ExecContext(ctx, `
 				UPDATE applies a
 				SET a.attempt = a.attempt + 1, a.updated_at = NOW()
@@ -1357,7 +1374,7 @@ func scanApplyOperationInto(s scanner) (*storage.ApplyOperation, error) {
 
 	if err := s.Scan(
 		&ad.ID, &ad.ApplyID, &ad.Deployment, &ad.OperationKey, &ad.OperationKind, &ad.Target, &ad.State, &errMsg,
-		&ad.CutoverPolicy, &ad.OnFailure, &startedAt, &completedAt, &ad.LeaseOwner, &ad.LeaseToken, &leaseAcquiredAt,
+		&ad.CutoverPolicy, &ad.OnFailure, &ad.Attempt, &startedAt, &completedAt, &ad.LeaseOwner, &ad.LeaseToken, &leaseAcquiredAt,
 		&engineResumeContext, &engineResumeMetadata, &ad.CreatedAt, &ad.UpdatedAt,
 	); err != nil {
 		return nil, err

--- a/pkg/storage/mysqlstore/apply_operations.go
+++ b/pkg/storage/mysqlstore/apply_operations.go
@@ -952,22 +952,33 @@ func (s *applyOperationStore) FindNextApplyOperation(ctx context.Context, owner 
 		// the row lock this UPDATE takes serializes them, so the second sees the
 		// already-incremented attempt and does not overshoot maxRecoveryAttempts.
 		if ad.State == state.ApplyOperation.FailedRetryable {
-			// Advance the operation's own attempt: a failed_retryable re-claim is
-			// this operation's deliberate redispatch, so its dispatch generation
-			// rotates. Crash-recovery re-lease of an in-flight drive (the other
-			// arm of this default case) leaves attempt untouched so the orphaned
-			// dispatch's idempotency key stays stable and is reused, not
-			// duplicated. Unlike the parent budget bump below, this is not gated
-			// on multi-operation: attempt is operation-local and a sibling's
-			// retry must never rotate it.
-			if _, err := tx.ExecContext(ctx, `
-				UPDATE apply_operations
-				SET attempt = attempt + 1
-				WHERE id = ?
-			`, ad.ID); err != nil {
+			// Advance the operation's own attempt only on a genuine deliberate
+			// redispatch — the parent apply is still failed_retryable. A
+			// failed_retryable child is also re-claimed for crash recovery when
+			// the parent apply is already active (running) with a stale heartbeat
+			// (its retry was admitted, then the driver crashed); that re-lease
+			// must leave attempt untouched so the orphaned dispatch's idempotency
+			// key stays stable and is reused, not duplicated. The parent-state
+			// gate mirrors the budget bump below; the join lets one statement both
+			// test the parent state and write the child row. Unlike the budget
+			// bump this is not gated on multi-operation: attempt is
+			// operation-local and a sibling's retry must never rotate it.
+			res, err := tx.ExecContext(ctx, `
+				UPDATE apply_operations o
+				JOIN applies a ON a.id = o.apply_id
+				SET o.attempt = o.attempt + 1
+				WHERE o.id = ? AND a.state = ?
+			`, ad.ID, state.Apply.FailedRetryable)
+			if err != nil {
 				return nil, fmt.Errorf("advance attempt for apply_operation %d redispatch: %w", ad.ID, err)
 			}
-			ad.Attempt++
+			bumped, err := res.RowsAffected()
+			if err != nil {
+				return nil, fmt.Errorf("read attempt bump rows affected for apply_operation %d: %w", ad.ID, err)
+			}
+			if bumped > 0 {
+				ad.Attempt++
+			}
 
 			if _, err := tx.ExecContext(ctx, `
 				UPDATE applies a

--- a/pkg/storage/mysqlstore/apply_operations_test.go
+++ b/pkg/storage/mysqlstore/apply_operations_test.go
@@ -1423,6 +1423,44 @@ func TestApplyOperationStore_FindNextApplyOperation_CrashRecoveryLeavesOperation
 	assert.Equal(t, 0, persisted.Attempt, "crash-recovery re-lease must leave the persisted operation attempt unchanged")
 }
 
+// TestApplyOperationStore_FindNextApplyOperation_FailedRetryableCrashRecoveryLeavesOperationAttempt
+// verifies the deliberate-retry vs crash-recovery distinction for a
+// failed_retryable child: when the parent apply is already active (running) with
+// a stale heartbeat — its retry was admitted, then the driver crashed — the
+// re-claim recovers the in-flight drive and must NOT advance the operation's
+// attempt, so the orphaned dispatch's idempotency key stays stable. This is the
+// crash-recovery sibling of the deliberate-redispatch case (parent still
+// failed_retryable), which does advance the attempt.
+func TestApplyOperationStore_FindNextApplyOperation_FailedRetryableCrashRecoveryLeavesOperationAttempt(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", "mysql", "staging")
+	apply := createTestApplyWithStateAndEnv(t, store, lock, "apply_op_fr_crash_attempt", 1, state.Apply.Running, "staging")
+	// Parent claimed then crashed: running, budget remaining, heartbeat stale.
+	_, err := testDB.ExecContext(ctx, `
+		UPDATE applies SET state = ?, attempt = ?, updated_at = NOW() - INTERVAL 2 MINUTE WHERE id = ?
+	`, state.Apply.Running, maxRecoveryAttempts-1, apply.ID)
+	require.NoError(t, err)
+
+	id, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-a", State: state.ApplyOperation.FailedRetryable,
+	})
+	require.NoError(t, err)
+
+	claimed, err := store.ApplyOperations().FindNextApplyOperation(ctx, "recovery-operator")
+	require.NoError(t, err)
+	require.NotNil(t, claimed, "a failed_retryable child must be reclaimable when its parent retry crashed (active + stale)")
+	assert.Equal(t, id, claimed.ID)
+	assert.Equal(t, 0, claimed.Attempt, "crash recovery of a failed_retryable child (active parent) must not advance the operation attempt")
+
+	persisted, err := store.ApplyOperations().Get(ctx, id)
+	require.NoError(t, err)
+	require.NotNil(t, persisted)
+	assert.Equal(t, 0, persisted.Attempt, "the persisted operation attempt must be unchanged after crash recovery")
+}
+
 // TestApplyOperationStore_FindNextApplyOperation_SkipsFailedRetryableBudgetExhausted
 // verifies the recovery budget is enforced: once the parent apply's attempt
 // count reaches the limit, the failed_retryable operation is no longer

--- a/pkg/storage/mysqlstore/apply_operations_test.go
+++ b/pkg/storage/mysqlstore/apply_operations_test.go
@@ -1305,6 +1305,124 @@ func TestApplyOperationStore_FindNextApplyOperation_SingleOpRedispatchDoesNotCon
 	assert.Equal(t, maxRecoveryAttempts-1, persistedApply.Attempt, "a single-op apply's retry budget is charged by ClaimApplyByID, not by the operation claim")
 }
 
+// TestApplyOperationStore_FindNextApplyOperation_RedispatchAdvancesOperationAttempt
+// verifies that re-claiming a failed_retryable operation — its deliberate
+// redispatch — advances the operation's own attempt counter, both on the
+// returned row and as persisted. This is the per-operation dispatch generation
+// the operation-scoped idempotency key rotates on.
+func TestApplyOperationStore_FindNextApplyOperation_RedispatchAdvancesOperationAttempt(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", "mysql", "staging")
+	apply := createTestApplyWithStateAndEnv(t, store, lock, "apply_op_attempt_bump", 1, state.Apply.FailedRetryable, "staging")
+	_, err := testDB.ExecContext(ctx, `
+		UPDATE applies SET attempt = ?, updated_at = NOW() WHERE id = ?
+	`, maxRecoveryAttempts-1, apply.ID)
+	require.NoError(t, err)
+
+	id, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-a", State: state.ApplyOperation.FailedRetryable,
+	})
+	require.NoError(t, err)
+
+	claimed, err := store.ApplyOperations().FindNextApplyOperation(ctx, "test-operator")
+	require.NoError(t, err)
+	require.NotNil(t, claimed)
+	assert.Equal(t, id, claimed.ID)
+	assert.Equal(t, 1, claimed.Attempt, "a failed_retryable redispatch must advance the operation's own attempt")
+
+	persisted, err := store.ApplyOperations().Get(ctx, id)
+	require.NoError(t, err)
+	require.NotNil(t, persisted)
+	assert.Equal(t, 1, persisted.Attempt, "the advanced operation attempt must be persisted")
+}
+
+// TestApplyOperationStore_FindNextApplyOperation_SiblingRedispatchLeavesOperationAttempt
+// verifies the operation attempt is operation-local: redispatching one
+// failed_retryable operation advances the shared parent attempt but never a
+// sibling operation's own attempt. This is what keeps a sibling's idempotency
+// key stable while it sits in its dispatch-then-crash window, so it is not
+// dispatched a second time when an unrelated operation retries.
+func TestApplyOperationStore_FindNextApplyOperation_SiblingRedispatchLeavesOperationAttempt(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", "mysql", "staging")
+	apply := createTestApplyWithStateAndEnv(t, store, lock, "apply_op_sibling_attempt", 1, state.Apply.FailedRetryable, "staging")
+	_, err := testDB.ExecContext(ctx, `
+		UPDATE applies SET attempt = ?, updated_at = NOW() WHERE id = ?
+	`, maxRecoveryAttempts-1, apply.ID)
+	require.NoError(t, err)
+
+	// region-a is the failed_retryable operation about to be redispatched.
+	retryID, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-a", State: state.ApplyOperation.FailedRetryable,
+	})
+	require.NoError(t, err)
+	// region-b is a sibling in its own (running) drive; its attempt must not move.
+	siblingID, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-b", State: state.ApplyOperation.WaitingForCutover,
+	})
+	require.NoError(t, err)
+
+	claimed, err := store.ApplyOperations().FindNextApplyOperation(ctx, "test-operator")
+	require.NoError(t, err)
+	require.NotNil(t, claimed)
+	assert.Equal(t, retryID, claimed.ID, "the failed_retryable operation is the one redispatched")
+	assert.Equal(t, 1, claimed.Attempt, "the redispatched operation's own attempt advances")
+
+	persistedApply, err := store.Applies().Get(ctx, apply.ID)
+	require.NoError(t, err)
+	require.NotNil(t, persistedApply)
+	assert.Equal(t, maxRecoveryAttempts, persistedApply.Attempt, "the shared parent attempt advances on the redispatch")
+
+	sibling, err := store.ApplyOperations().Get(ctx, siblingID)
+	require.NoError(t, err)
+	require.NotNil(t, sibling)
+	assert.Equal(t, 0, sibling.Attempt, "a sibling's own attempt must not move when an unrelated operation retries")
+}
+
+// TestApplyOperationStore_FindNextApplyOperation_CrashRecoveryLeavesOperationAttempt
+// verifies that re-leasing a stale in-flight drive (crash recovery, not a
+// deliberate retry) leaves the operation's attempt untouched, so the orphaned
+// dispatch's idempotency key stays stable and the lost-response self-redispatch
+// is reused rather than duplicated.
+func TestApplyOperationStore_FindNextApplyOperation_CrashRecoveryLeavesOperationAttempt(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", "mysql", "staging")
+	apply := createTestApply(t, store, lock, "apply_op_crash_attempt", 1)
+
+	id, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-a",
+	})
+	require.NoError(t, err)
+	require.NoError(t, store.ApplyOperations().MarkStarted(ctx, id))
+
+	// Backdate the heartbeat past the staleness window so the running row is
+	// re-leasable as crash recovery.
+	_, err = testDB.ExecContext(ctx, `
+		UPDATE apply_operations SET updated_at = NOW() - INTERVAL 2 MINUTE WHERE id = ?
+	`, id)
+	require.NoError(t, err)
+
+	claimed, err := store.ApplyOperations().FindNextApplyOperation(ctx, "recovery-operator")
+	require.NoError(t, err)
+	require.NotNil(t, claimed)
+	assert.Equal(t, id, claimed.ID)
+	assert.Equal(t, 0, claimed.Attempt, "crash-recovery re-lease must not advance the operation attempt")
+
+	persisted, err := store.ApplyOperations().Get(ctx, id)
+	require.NoError(t, err)
+	require.NotNil(t, persisted)
+	assert.Equal(t, 0, persisted.Attempt, "crash-recovery re-lease must leave the persisted operation attempt unchanged")
+}
+
 // TestApplyOperationStore_FindNextApplyOperation_SkipsFailedRetryableBudgetExhausted
 // verifies the recovery budget is enforced: once the parent apply's attempt
 // count reaches the limit, the failed_retryable operation is no longer

--- a/pkg/storage/types.go
+++ b/pkg/storage/types.go
@@ -550,11 +550,15 @@ type ApplyOperation struct {
 	OnFailure string
 
 	// Attempt counts deliberate redispatches of this operation. It starts at 0
-	// and advances only when a driver re-claims the row from failed_retryable —
-	// the operation's own retry — not on crash-recovery re-lease of an in-flight
-	// drive. It is the operation-local counterpart to applies.attempt: a sibling
-	// operation's retry advances the shared parent attempt but never this row's,
-	// so an operation-scoped dispatch generation rotates only on its own retry.
+	// and advances only when a driver re-claims the row as a deliberate retry —
+	// the operation is failed_retryable and so is its parent apply. It does not
+	// advance on a crash-recovery re-lease (a still-active parent with a stale
+	// heartbeat, or an in-flight drive whose driver died), so an orphaned
+	// dispatch's idempotency key stays stable and is reused rather than
+	// duplicated. It is the operation-local counterpart to applies.attempt: a
+	// sibling operation's retry advances the shared parent attempt but never this
+	// row's, so an operation-scoped dispatch generation rotates only on its own
+	// retry.
 	Attempt int
 
 	// StartedAt is when the operator claimed this child row and execution began.

--- a/pkg/storage/types.go
+++ b/pkg/storage/types.go
@@ -549,6 +549,14 @@ type ApplyOperation struct {
 	// omits the policy never silently degrades to the less-safe behaviour.
 	OnFailure string
 
+	// Attempt counts deliberate redispatches of this operation. It starts at 0
+	// and advances only when a driver re-claims the row from failed_retryable —
+	// the operation's own retry — not on crash-recovery re-lease of an in-flight
+	// drive. It is the operation-local counterpart to applies.attempt: a sibling
+	// operation's retry advances the shared parent attempt but never this row's,
+	// so an operation-scoped dispatch generation rotates only on its own retry.
+	Attempt int
+
 	// StartedAt is when the operator claimed this child row and execution began.
 	StartedAt *time.Time
 


### PR DESCRIPTION
## Summary

Adds an `attempt` counter to `apply_operations`, advanced only when a driver re-claims a row from `failed_retryable` — the operation's own deliberate redispatch. Crash-recovery re-lease of an in-flight drive leaves it untouched, and a sibling operation's retry never moves it. It is the operation-local counterpart to `applies.attempt`.

## What

- New `apply_operations.attempt INT NOT NULL DEFAULT 0` (picked up automatically by `EnsureSchema`).
- `ApplyOperation.Attempt` field; scanned in `applyOperationColumns`.
- In `FindNextApplyOperation`, a `failed_retryable` re-claim bumps the operation's own attempt (ungated on multi-op, since attempt is operation-local), alongside the existing parent-budget bump.
- Integration tests: redispatch advances the op attempt; a sibling's redispatch leaves it at 0; crash-recovery re-lease leaves it unchanged.

## Why

The shared parent `applies.attempt` is incremented by *any* operation's `failed_retryable` re-claim. Anything keying a per-operation dispatch generation off the parent attempt would rotate whenever an unrelated sibling retried. A durable, operation-local attempt lets an operation-scoped dispatch generation rotate on its own retry and stay stable across a sibling's.

```diff
A sibling's failed_retryable retry:

  applies.attempt            n ─────────────► n+1   (shared, bumped)
  op A (the one retrying)    a ─────────────► a+1   (its own retry)
  op B (in crash window)     b ─────────────► b     (UNCHANGED — key stays stable)
```


### Relationship to #502

This is the prerequisite leaf for #502's "multi-operation key rotation" review item. #502 introduces remoteApplyIdempotencyKey, whose operation-scoped variant currently embeds the parent apply.Attempt; a sibling's retry rotates the key and re-runs DDL once fan-out is enabled. This PR adds the operation-local attempt that the key needs but does not touch the key itself.

Merge order: this PR first, then #502. After this lands, #502 rebases onto main and changes the op-scoped branch of remoteApplyIdempotencyKey from apply.Attempt to scope.operation.Attempt (plus the doc-comment fix and a sibling-retry-interleave test). The bug is latent until multi-operation fan-out is enabled, so the two can also be tracked separately if needed.
