### PR TITLE
refactor(storage): share transaction rollback helper

### DIFF
--- a/pkg/storage/mysqlstore/applies.go
+++ b/pkg/storage/mysqlstore/applies.go
@@ -142,12 +142,6 @@ func nonTerminalApplyStatePredicate(column string) (string, []any) {
 	return fmt.Sprintf("%s NOT IN (%s)", column, placeholders(len(terminalStates))), stringArgs(terminalStates)
 }
 
-func rollbackApplyTx(ctx context.Context, tx *sql.Tx, operation string) {
-	if err := tx.Rollback(); err != nil && !errors.Is(err, sql.ErrTxDone) {
-		slog.WarnContext(ctx, "failed to roll back apply transaction", "operation", operation, "error", err)
-	}
-}
-
 func beginApplyWriteTx(ctx context.Context, beginner txBeginner, operation string) (*applyWriteTx, error) {
 	tx, err := beginner.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelRepeatableRead})
 	if err != nil {
@@ -178,7 +172,7 @@ func (w *applyWriteTx) close(ctx context.Context, operation string) {
 		return
 	}
 	if w.tx != nil {
-		rollbackApplyTx(ctx, w.tx, operation)
+		rollbackTx(ctx, w.tx, operation)
 	}
 	if w.targetLockConn != nil {
 		releaseApplyTargetLockConn(ctx, w.targetLockConn, w.targetLockName, operation)
@@ -1088,7 +1082,7 @@ func (s *applyStore) FindNextApply(ctx context.Context, owner string) (*storage.
 	if err != nil {
 		return nil, fmt.Errorf("begin claim apply transaction: %w", err)
 	}
-	defer rollbackApplyTx(ctx, tx, "claim apply")
+	defer rollbackTx(ctx, tx, "claim apply")
 
 	activeStates := claimableApplyStates()
 	activeStatePlaceholders := placeholders(len(activeStates))
@@ -1193,7 +1187,7 @@ func (s *applyStore) ClaimApplyByID(ctx context.Context, applyID int64, owner st
 	if err != nil {
 		return nil, fmt.Errorf("begin claim apply %d transaction: %w", applyID, err)
 	}
-	defer rollbackApplyTx(ctx, tx, "claim apply by id")
+	defer rollbackTx(ctx, tx, "claim apply by id")
 
 	activeStates := claimableApplyStates()
 	activeStatePlaceholders := placeholders(len(activeStates))
@@ -1293,7 +1287,7 @@ func (s *applyStore) FindNextApplyForStopReconciliation(ctx context.Context, own
 	if err != nil {
 		return nil, fmt.Errorf("begin claim apply for stop reconciliation transaction: %w", err)
 	}
-	defer rollbackApplyTx(ctx, tx, "claim apply for stop reconciliation")
+	defer rollbackTx(ctx, tx, "claim apply for stop reconciliation")
 
 	// Parent eligibility: pending plus the active recovery-claimable states
 	// (claimableApplyStates); the resumable failed_retryable and stopped states
@@ -1657,7 +1651,7 @@ func (s *applyStore) ExpireRetryable(ctx context.Context) ([]*storage.RetryableA
 	if err != nil {
 		return nil, fmt.Errorf("begin expire retryable applies transaction: %w", err)
 	}
-	defer rollbackApplyTx(ctx, tx, "expire retryable applies")
+	defer rollbackTx(ctx, tx, "expire retryable applies")
 
 	rows, err := tx.QueryContext(ctx, `
 		SELECT `+applyColumns+`

--- a/pkg/storage/mysqlstore/apply_operations.go
+++ b/pkg/storage/mysqlstore/apply_operations.go
@@ -584,7 +584,7 @@ func (s *applyOperationStore) FindNextApplyOperation(ctx context.Context, owner 
 	if err != nil {
 		return nil, fmt.Errorf("begin claim apply_operation transaction: %w", err)
 	}
-	defer rollbackApplyTx(ctx, tx, "claim apply_operation")
+	defer rollbackTx(ctx, tx, "claim apply_operation")
 
 	activeStates := claimableApplyStates()
 	activeStatePlaceholders := placeholders(len(activeStates))
@@ -1011,7 +1011,7 @@ func (s *applyOperationStore) FindNextApplyOperationCutover(ctx context.Context,
 	if err != nil {
 		return nil, fmt.Errorf("begin claim apply_operation cutover transaction: %w", err)
 	}
-	defer rollbackApplyTx(ctx, tx, "claim apply_operation cutover")
+	defer rollbackTx(ctx, tx, "claim apply_operation cutover")
 
 	// Eligibility gate (the three leading conditions in the SQL below). The
 	// cutover worker may only claim operations it is actually responsible for

--- a/pkg/storage/mysqlstore/control_requests.go
+++ b/pkg/storage/mysqlstore/control_requests.go
@@ -56,7 +56,7 @@ func (s *controlRequestStore) requestPending(ctx context.Context, req *storage.A
 	if err != nil {
 		return nil, false, fmt.Errorf("begin control request transaction for apply %d operation %s: %w", req.ApplyID, req.Operation, err)
 	}
-	defer rollbackControlRequestTx(ctx, tx, "request pending")
+	defer rollbackTx(ctx, tx, "request pending")
 
 	existing, err := s.getByApplyOperationForUpdate(ctx, tx, req.ApplyID, req.Operation)
 	if err != nil {
@@ -226,12 +226,6 @@ func (s *controlRequestStore) getByApplyOperationForUpdate(
 		return nil, fmt.Errorf("get control request for apply %d operation %s: %w", applyID, operation, err)
 	}
 	return req, nil
-}
-
-func rollbackControlRequestTx(ctx context.Context, tx *sql.Tx, operation string) {
-	if err := tx.Rollback(); err != nil && !errors.Is(err, sql.ErrTxDone) {
-		slog.WarnContext(ctx, "failed to roll back control request transaction", "operation", operation, "error", err)
-	}
 }
 
 func scanControlRequest(s scanner) (*storage.ApplyControlRequest, error) {

--- a/pkg/storage/mysqlstore/sql_helpers.go
+++ b/pkg/storage/mysqlstore/sql_helpers.go
@@ -1,7 +1,21 @@
 // sql_helpers.go provides shared utilities for MySQL store implementations.
 package mysqlstore
 
-import "database/sql"
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"log/slog"
+)
+
+// rollbackTx rolls back tx, logging a warning if the rollback fails for a
+// reason other than the transaction already being finished. operation is
+// included in the log to identify the originating call site.
+func rollbackTx(ctx context.Context, tx *sql.Tx, operation string) {
+	if err := tx.Rollback(); err != nil && !errors.Is(err, sql.ErrTxDone) {
+		slog.WarnContext(ctx, "failed to roll back transaction", "operation", operation, "error", err)
+	}
+}
 
 // scanner is implemented by both *sql.Row and *sql.Rows.
 // Used by scan helpers to work with both single-row and multi-row queries.


### PR DESCRIPTION
## Summary
Two MySQL-store rollback helpers were byte-identical except for their log message. Collapse them into a single `rollbackTx` in `sql_helpers.go` so the next transactional store path reuses it instead of adding another copy.

## What
- Add `rollbackTx(ctx, tx, operation)` to `sql_helpers.go`.
- Remove `rollbackApplyTx` (`applies.go`) and `rollbackControlRequestTx` (`control_requests.go`).
- Point all 8 call sites at the shared helper.

## Why
Removes a parallel maintenance point: rollback logging behavior now lives in one place, and adding another transactional path no longer means copying a third near-identical helper.

```diagram
        before                              after
╭───────────────────────╮          ╭───────────────────────╮
│ rollbackApplyTx       │          │                       │
│  "apply transaction"  │──────╮   │  rollbackTx           │
├───────────────────────┤      ├──▶│  "transaction"        │
│ rollbackControlReqTx  │──────╯   │  (sql_helpers.go)     │
│  "control request ..."│          ╰───────────────────────╯
╰───────────────────────╯
