### PR TITLE
refactor(storage): share zero-rows lease fail-closed check

### DIFF
--- a/pkg/storage/mysqlstore/applies.go
+++ b/pkg/storage/mysqlstore/applies.go
@@ -420,12 +420,13 @@ func ensureApplyLeaseStillOwned(ctx context.Context, db queryRower, lease storag
 // still valid) or the lease token no longer matches because ownership was lost.
 // It reloads the lease to distinguish the two so a displaced driver returns
 // ErrApplyLeaseLost instead of silently treating a lost lease as a no-op. desc
-// identifies the operation in the rows-affected error. The affected row count is
-// returned for callers that need it.
-func confirmLeaseOnZeroRows(ctx context.Context, db queryRower, result sql.Result, lease storage.ApplyLease, desc string) (int64, error) {
+// names the write and target identifies the row(s) in the rows-affected error
+// ("read <desc> rows affected for <target>"). The affected row count is returned
+// for callers that need it.
+func confirmLeaseOnZeroRows(ctx context.Context, db queryRower, result sql.Result, lease storage.ApplyLease, desc, target string) (int64, error) {
 	rows, err := result.RowsAffected()
 	if err != nil {
-		return 0, fmt.Errorf("read %s rows affected: %w", desc, err)
+		return 0, fmt.Errorf("read %s rows affected for %s: %w", desc, target, err)
 	}
 	if rows == 0 {
 		if err := ensureApplyLeaseStillOwned(ctx, db, lease); err != nil {
@@ -1649,7 +1650,7 @@ func (s *applyStore) Heartbeat(ctx context.Context, applyID int64) error {
 		return fmt.Errorf("heartbeat apply %d: %w", applyID, err)
 	}
 	if hasLease {
-		if _, err := confirmLeaseOnZeroRows(ctx, s.db, result, lease, fmt.Sprintf("heartbeat apply %d", applyID)); err != nil {
+		if _, err := confirmLeaseOnZeroRows(ctx, s.db, result, lease, "heartbeat", fmt.Sprintf("apply %d", applyID)); err != nil {
 			return err
 		}
 	}

--- a/pkg/storage/mysqlstore/applies.go
+++ b/pkg/storage/mysqlstore/applies.go
@@ -415,6 +415,26 @@ func ensureApplyLeaseStillOwned(ctx context.Context, db queryRower, lease storag
 	return nil
 }
 
+// confirmLeaseOnZeroRows fails closed when a lease-scoped write changed no rows.
+// Zero rows is ambiguous: either a legitimate idempotent no-op (the lease is
+// still valid) or the lease token no longer matches because ownership was lost.
+// It reloads the lease to distinguish the two so a displaced driver returns
+// ErrApplyLeaseLost instead of silently treating a lost lease as a no-op. desc
+// identifies the operation in the rows-affected error. The affected row count is
+// returned for callers that need it.
+func confirmLeaseOnZeroRows(ctx context.Context, db queryRower, result sql.Result, lease storage.ApplyLease, desc string) (int64, error) {
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("read %s rows affected: %w", desc, err)
+	}
+	if rows == 0 {
+		if err := ensureApplyLeaseStillOwned(ctx, db, lease); err != nil {
+			return rows, err
+		}
+	}
+	return rows, nil
+}
+
 // applyTargetForUpdate resolves the (database, type, environment, deployment)
 // target an update should lock and check against. The stored row is
 // authoritative, so it is reloaded whenever the in-memory apply is missing the
@@ -1629,14 +1649,8 @@ func (s *applyStore) Heartbeat(ctx context.Context, applyID int64) error {
 		return fmt.Errorf("heartbeat apply %d: %w", applyID, err)
 	}
 	if hasLease {
-		rows, err := result.RowsAffected()
-		if err != nil {
-			return fmt.Errorf("read heartbeat rows affected for apply %d: %w", applyID, err)
-		}
-		if rows == 0 {
-			if err := ensureApplyLeaseStillOwned(ctx, s.db, lease); err != nil {
-				return err
-			}
+		if _, err := confirmLeaseOnZeroRows(ctx, s.db, result, lease, fmt.Sprintf("heartbeat apply %d", applyID)); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/pkg/storage/mysqlstore/apply_operations.go
+++ b/pkg/storage/mysqlstore/apply_operations.go
@@ -1207,7 +1207,7 @@ func (s *applyOperationStore) DeleteByApply(ctx context.Context, applyID int64) 
 	if err != nil {
 		return fmt.Errorf("delete apply_operations for apply %d: %w", applyID, err)
 	}
-	if _, err := confirmLeaseOnZeroRows(ctx, s.db, result, lease, fmt.Sprintf("delete apply_operations for apply %d", applyID)); err != nil {
+	if _, err := confirmLeaseOnZeroRows(ctx, s.db, result, lease, "deleted apply_operations", fmt.Sprintf("apply %d", applyID)); err != nil {
 		return err
 	}
 	return nil
@@ -1296,7 +1296,7 @@ func (s *applyOperationStore) MarkPendingStoppedByApply(ctx context.Context, app
 	if err != nil {
 		return 0, fmt.Errorf("stop pending apply_operations for apply %d: %w", applyID, err)
 	}
-	rows, err := confirmLeaseOnZeroRows(ctx, s.db, result, lease, fmt.Sprintf("stop pending apply_operations for apply %d", applyID))
+	rows, err := confirmLeaseOnZeroRows(ctx, s.db, result, lease, "stopped pending apply_operations", fmt.Sprintf("apply %d", applyID))
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/storage/mysqlstore/apply_operations.go
+++ b/pkg/storage/mysqlstore/apply_operations.go
@@ -1207,14 +1207,8 @@ func (s *applyOperationStore) DeleteByApply(ctx context.Context, applyID int64) 
 	if err != nil {
 		return fmt.Errorf("delete apply_operations for apply %d: %w", applyID, err)
 	}
-	rows, err := result.RowsAffected()
-	if err != nil {
-		return fmt.Errorf("read deleted apply_operations rows affected for apply %d: %w", applyID, err)
-	}
-	if rows == 0 {
-		if err := ensureApplyLeaseStillOwned(ctx, s.db, lease); err != nil {
-			return err
-		}
+	if _, err := confirmLeaseOnZeroRows(ctx, s.db, result, lease, fmt.Sprintf("delete apply_operations for apply %d", applyID)); err != nil {
+		return err
 	}
 	return nil
 }
@@ -1302,17 +1296,9 @@ func (s *applyOperationStore) MarkPendingStoppedByApply(ctx context.Context, app
 	if err != nil {
 		return 0, fmt.Errorf("stop pending apply_operations for apply %d: %w", applyID, err)
 	}
-	rows, err := result.RowsAffected()
+	rows, err := confirmLeaseOnZeroRows(ctx, s.db, result, lease, fmt.Sprintf("stop pending apply_operations for apply %d", applyID))
 	if err != nil {
-		return 0, fmt.Errorf("read stopped pending apply_operations rows affected for apply %d: %w", applyID, err)
-	}
-	if rows == 0 {
-		// No pending rows changed: either there were none (lease still valid, a
-		// legitimate no-op) or the lease token no longer matches (ownership lost).
-		// Distinguish the two so a displaced driver fails closed.
-		if err := ensureApplyLeaseStillOwned(ctx, s.db, lease); err != nil {
-			return 0, err
-		}
+		return 0, err
 	}
 	return rows, nil
 }

--- a/pkg/storage/mysqlstore/control_requests.go
+++ b/pkg/storage/mysqlstore/control_requests.go
@@ -146,14 +146,8 @@ func (s *controlRequestStore) CompletePending(ctx context.Context, applyID int64
 		return fmt.Errorf("complete pending control requests for apply %d operation %s: %w", applyID, operation, err)
 	}
 	if hasLease {
-		rows, err := result.RowsAffected()
-		if err != nil {
-			return fmt.Errorf("read completed control request rows affected for apply %d operation %s: %w", applyID, operation, err)
-		}
-		if rows == 0 {
-			if err := ensureApplyLeaseStillOwned(ctx, s.db, lease); err != nil {
-				return err
-			}
+		if _, err := confirmLeaseOnZeroRows(ctx, s.db, result, lease, fmt.Sprintf("complete pending control requests for apply %d operation %s", applyID, operation)); err != nil {
+			return err
 		}
 	}
 	return nil
@@ -182,14 +176,8 @@ func (s *controlRequestStore) FailPending(ctx context.Context, applyID int64, op
 		return fmt.Errorf("fail pending control requests for apply %d operation %s: %w", applyID, operation, err)
 	}
 	if hasLease {
-		rows, err := result.RowsAffected()
-		if err != nil {
-			return fmt.Errorf("read failed control request rows affected for apply %d operation %s: %w", applyID, operation, err)
-		}
-		if rows == 0 {
-			if err := ensureApplyLeaseStillOwned(ctx, s.db, lease); err != nil {
-				return err
-			}
+		if _, err := confirmLeaseOnZeroRows(ctx, s.db, result, lease, fmt.Sprintf("fail pending control requests for apply %d operation %s", applyID, operation)); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/pkg/storage/mysqlstore/control_requests.go
+++ b/pkg/storage/mysqlstore/control_requests.go
@@ -146,7 +146,7 @@ func (s *controlRequestStore) CompletePending(ctx context.Context, applyID int64
 		return fmt.Errorf("complete pending control requests for apply %d operation %s: %w", applyID, operation, err)
 	}
 	if hasLease {
-		if _, err := confirmLeaseOnZeroRows(ctx, s.db, result, lease, fmt.Sprintf("complete pending control requests for apply %d operation %s", applyID, operation)); err != nil {
+		if _, err := confirmLeaseOnZeroRows(ctx, s.db, result, lease, "completed control request", fmt.Sprintf("apply %d operation %s", applyID, operation)); err != nil {
 			return err
 		}
 	}
@@ -176,7 +176,7 @@ func (s *controlRequestStore) FailPending(ctx context.Context, applyID int64, op
 		return fmt.Errorf("fail pending control requests for apply %d operation %s: %w", applyID, operation, err)
 	}
 	if hasLease {
-		if _, err := confirmLeaseOnZeroRows(ctx, s.db, result, lease, fmt.Sprintf("fail pending control requests for apply %d operation %s", applyID, operation)); err != nil {
+		if _, err := confirmLeaseOnZeroRows(ctx, s.db, result, lease, "failed control request", fmt.Sprintf("apply %d operation %s", applyID, operation)); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
## Summary
Five lease-scoped writes (`Heartbeat`, `DeleteByApply`, `MarkPendingStoppedByApply`, `CompletePending`, `FailPending`) each repeated the same fail-closed block: when the write changed zero rows, reload the lease to distinguish a legitimate idempotent no-op from a lost lease, so a displaced driver returns `ErrApplyLeaseLost` instead of silently treating a lost lease as a no-op. Extract this into a single `confirmLeaseOnZeroRows` helper.

## What
- Add `confirmLeaseOnZeroRows(ctx, db, result, lease, desc) (int64, error)` beside `ensureApplyLeaseStillOwned`.
- Route all five sites through it; the one caller that needs the affected-row count keeps using the return value.

## Why
**This is a tier-0 fail-closed safety invariant that was duplicated five times.** Consolidating it puts the rationale and behavior in one documented place so future call sites can't drift. Behavior is unchanged — only the rows-affected error wording is normalized.

## Before / after
```
before — same block copy-pasted in 5 methods

Heartbeat ─────────────┐
DeleteByApply ─────────┤
MarkPendingStopped ────┤   rows, err := result.RowsAffected()
CompletePending ───────┤   if err != nil { return ...wrap... }
FailPending ───────────┘   if rows == 0 {
ensureApplyLeaseStillOwned(...)   // fail closed
}
```

```
after — one helper, five callers

Heartbeat ─────────────┐
DeleteByApply ─────────┤
MarkPendingStopped ────┼──▶ confirmLeaseOnZeroRows(ctx, db, result, lease, desc)
CompletePending ───────┤        └─ RowsAffected==0 ─▶ ensureApplyLeaseStillOwned
FailPending ───────────┘                              (fail closed, one place)
```