### PR TITLE
feat(api): resolve strata targets via the MySQL Etre assembler

### DIFF
--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -428,8 +428,8 @@ type EtreConfig struct {
 	// Addr is the Etre server address (supports secret refs, e.g. env:ETRE_ADDR).
 	Addr string `yaml:"addr"`
 	// DatabaseType selects the engine the resolver assembles connections for and
-	// is required (no implicit default): "mysql" reads the MySQL block; "vitess"
-	// reads the Vitess block.
+	// is required (no implicit default): "mysql" and "strata" read the MySQL
+	// block; "vitess" reads the Vitess block.
 	DatabaseType string `yaml:"database_type"`
 	// EntityType is the Etre entity type recording the target clusters.
 	EntityType string `yaml:"entity_type"`
@@ -441,7 +441,8 @@ type EtreConfig struct {
 	Labels map[string]string `yaml:"labels,omitempty"`
 	// AttributeFields are entity fields surfaced to the credential resolver.
 	AttributeFields []string `yaml:"attribute_fields,omitempty"`
-	// MySQL holds the MySQL engine knobs, read when DatabaseType is "mysql".
+	// MySQL holds the MySQL engine knobs, read when DatabaseType is "mysql" or
+	// "strata" (Strata is Aurora-backed and assembles its connection the same way).
 	MySQL EtreMySQLConfig `yaml:"mysql,omitempty"`
 	// Vitess holds the Vitess engine knobs, read when DatabaseType is "vitess".
 	Vitess EtreVitessConfig `yaml:"vitess,omitempty"`

--- a/pkg/api/target_resolver_factory.go
+++ b/pkg/api/target_resolver_factory.go
@@ -134,18 +134,24 @@ func buildEtreResolver(ctx context.Context, cfg EtreConfig, logger *slog.Logger)
 
 // etreAssembler selects the engine-specific connection assembler for the
 // configured database type, plus the secret decoder that backend needs. MySQL
-// builds a namespace-free DSN from the host; Vitess assembles PlanetScale API
-// metadata and decodes a token secret rather than a username/password. A new
-// engine (postgres, strata) is a new case here; an unsupported type fails closed.
+// builds a namespace-free DSN from the host; Strata is backed by an Aurora
+// cluster reached over the MySQL protocol, so it assembles its connection the
+// same way (host + port + credentials → DSN) and reads the same MySQL block;
+// Vitess assembles PlanetScale API metadata and decodes a token secret rather
+// than a username/password. A new engine (postgres) is a new case here; an
+// unsupported type fails closed.
 func etreAssembler(cfg EtreConfig) (inventory.ConnectionAssembler, inventory.SecretDecoder, error) {
 	switch cfg.DatabaseType {
 	case "":
-		return nil, nil, fmt.Errorf("target_resolver.etre.database_type is required (%q or %q)", storage.DatabaseTypeMySQL, storage.DatabaseTypeVitess)
-	case storage.DatabaseTypeMySQL:
+		return nil, nil, fmt.Errorf("target_resolver.etre.database_type is required (%q, %q, or %q)", storage.DatabaseTypeMySQL, storage.DatabaseTypeStrata, storage.DatabaseTypeVitess)
+	case storage.DatabaseTypeMySQL, storage.DatabaseTypeStrata:
 		if cfg.MySQL.HostField == "" {
-			return nil, nil, fmt.Errorf("target_resolver.etre.mysql.host_field is required for the %q engine", storage.DatabaseTypeMySQL)
+			return nil, nil, fmt.Errorf("target_resolver.etre.mysql.host_field is required for the %q engine", cfg.DatabaseType)
 		}
-		return inventory.MySQLConnectionAssembler{DefaultPort: cfg.MySQL.DefaultPort}, nil, nil
+		// Strata connects over the MySQL protocol but is a distinct data-plane
+		// engine, so the assembler reports the configured type — not plain "mysql" —
+		// for the resolver's request-type guard and the resolved target's type.
+		return inventory.MySQLConnectionAssembler{Type: cfg.DatabaseType, DefaultPort: cfg.MySQL.DefaultPort}, nil, nil
 	case storage.DatabaseTypeVitess:
 		return inventory.VitessConnectionAssembler{
 			OrganizationAttribute: cfg.Vitess.OrganizationAttribute,

--- a/pkg/api/target_resolver_factory_test.go
+++ b/pkg/api/target_resolver_factory_test.go
@@ -200,9 +200,40 @@ func TestBuildEtreResolverVitess(t *testing.T) {
 	assert.Contains(t, err.Error(), "password_ref")
 }
 
+// Strata is Aurora-backed and reached over the MySQL protocol, so it assembles
+// its connection from the MySQL block exactly as the MySQL engine does. The same
+// host_field validation applies, failing closed at startup when it is missing.
+func TestBuildEtreResolverStrata(t *testing.T) {
+	logger := slog.New(slog.DiscardHandler)
+	cfg := EtreConfig{
+		Addr: "https://etre.example", DatabaseType: storage.DatabaseTypeStrata,
+		EntityType: "aurora_cluster", TargetLabel: "dsid", EnvLabel: "env",
+		MySQL:       EtreMySQLConfig{HostField: "writer_endpoint"},
+		Credentials: EtreCredentialsConfig{Username: "ddl", PasswordRef: "env:DDL_PASSWORD"},
+	}
+
+	resolver, err := buildEtreResolver(t.Context(), cfg, logger)
+	require.NoError(t, err)
+	require.NotNil(t, resolver)
+
+	// The assembler must report the Strata engine type — not plain MySQL — or the
+	// resolver's request-type guard would reject "strata" requests and stamp the
+	// resolved target as MySQL, routing it to the wrong data-plane engine.
+	assembler, _, err := etreAssembler(cfg)
+	require.NoError(t, err)
+	assert.Equal(t, storage.DatabaseTypeStrata, assembler.DatabaseType())
+
+	noHost := cfg
+	noHost.MySQL.HostField = ""
+	_, err = buildEtreResolver(t.Context(), noHost, logger)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "host_field")
+	assert.Contains(t, err.Error(), storage.DatabaseTypeStrata)
+}
+
 // An unsupported database_type fails closed at startup rather than silently
-// resolving as MySQL, so adding an engine (postgres, strata) is a deliberate
-// change at the assembler-selection site.
+// resolving as MySQL, so adding an engine (postgres) is a deliberate change at
+// the assembler-selection site.
 func TestBuildEtreResolverRejectsUnsupportedEngine(t *testing.T) {
 	logger := slog.New(slog.DiscardHandler)
 	cfg := EtreConfig{

--- a/pkg/inventory/connection_assembler.go
+++ b/pkg/inventory/connection_assembler.go
@@ -29,6 +29,12 @@ type ConnectionAssembler interface {
 // MySQLConnectionAssembler assembles a namespace-free MySQL DSN. The schema is
 // injected per operation by the data plane, so the DSN carries no database name.
 type MySQLConnectionAssembler struct {
+	// Type is the engine type reported for assembled targets, defaulting to
+	// "mysql". An engine that connects over the MySQL protocol but routes to a
+	// distinct data-plane engine (for example "strata") sets this so the
+	// resolver's request-type guard and the resolved target's DatabaseType reflect
+	// the real engine rather than plain MySQL.
+	Type string
 	// DefaultPort is appended to the host when it has no port.
 	DefaultPort string
 	// Params are extra MySQL DSN parameters (for example TLS settings).
@@ -40,8 +46,13 @@ type MySQLConnectionAssembler struct {
 
 var _ ConnectionAssembler = MySQLConnectionAssembler{}
 
-// DatabaseType returns the MySQL engine type.
-func (MySQLConnectionAssembler) DatabaseType() string { return "mysql" }
+// DatabaseType returns the configured engine type, defaulting to "mysql".
+func (a MySQLConnectionAssembler) DatabaseType() string {
+	if a.Type == "" {
+		return "mysql"
+	}
+	return a.Type
+}
 
 // Assemble builds a namespace-free MySQL DSN from the host and credentials. The
 // endpoint attributes are unused for MySQL.


### PR DESCRIPTION
The Etre `TypeRoutingResolver` failed closed when a request's `database_type` was `strata`, because `etreAssembler` only had cases for `mysql` and `vitess` — an unsupported type is rejected at startup rather than silently resolving as MySQL.

Strata is Aurora-backed and reached over the MySQL protocol, so its connection is assembled exactly like the MySQL engine: host + port + credentials → DSN, reading the same `mysql` config block. This adds `strata` to the shared MySQL assembler case so a strata resolver builds instead of erroring.

- `etreAssembler`: `mysql` and `strata` now share one case using `MySQLConnectionAssembler`; the `host_field`-required error reports the actual `database_type`, and the missing-type error lists all three valid types.
- Config doc comments note that `strata` reads the `mysql` block.
- Added `TestBuildEtreResolverStrata` and updated the unsupported-engine test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)