### PR TITLE
fix(github): show engine labels in schema change comments

### DIFF
--- a/pkg/webhook/plan.go
+++ b/pkg/webhook/plan.go
@@ -248,6 +248,7 @@ func (h *Handler) handleMultiEnvPlan(repo string, pr int, databaseName, tenant s
 			multiEnvData.Database = schemaResult.Database
 			multiEnvData.HeadSHA = schemaResult.HeadSHA
 			multiEnvData.Repository = schemaResult.Repository
+			multiEnvData.DatabaseType = schemaResult.Type
 			multiEnvData.IsMySQL = schemaResult.Type == "mysql"
 
 			// Stale-schema gate for user-triggered `schemabot plan` only.
@@ -429,13 +430,14 @@ func (h *Handler) handleSchemaRequestError(repo string, pr int, installationID i
 // buildPlanCommentData converts plan results into template data.
 func buildPlanCommentData(schema *ghclient.SchemaRequestResult, planResp *apitypes.PlanResponse, environment, tenant, requestedBy string) templates.PlanCommentData {
 	data := templates.PlanCommentData{
-		Database:    schema.Database,
-		Environment: environment,
-		Tenant:      tenant,
-		HeadSHA:     schema.HeadSHA,
-		Repository:  schema.Repository,
-		RequestedBy: requestedBy,
-		IsMySQL:     schema.Type == "mysql",
+		Database:     schema.Database,
+		Environment:  environment,
+		Tenant:       tenant,
+		HeadSHA:      schema.HeadSHA,
+		Repository:   schema.Repository,
+		RequestedBy:  requestedBy,
+		DatabaseType: schema.Type,
+		IsMySQL:      schema.Type == "mysql",
 	}
 
 	// Build keyspace changes from namespace-grouped plan response

--- a/pkg/webhook/plan_test.go
+++ b/pkg/webhook/plan_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/block/schemabot/pkg/api"
 	"github.com/block/schemabot/pkg/apitypes"
 	ghclient "github.com/block/schemabot/pkg/github"
+	"github.com/block/schemabot/pkg/storage"
 	"github.com/block/schemabot/pkg/webhook/templates"
 )
 
@@ -73,6 +74,7 @@ func TestBuildPlanCommentData_NoUnsafeChanges(t *testing.T) {
 
 	assert.False(t, data.HasUnsafeChanges)
 	assert.Empty(t, data.UnsafeChanges)
+	assert.Equal(t, "mysql", data.DatabaseType)
 	assert.Equal(t, "abcdef1234567890", data.HeadSHA)
 	assert.Equal(t, "block/schemabot", data.Repository)
 }
@@ -216,6 +218,54 @@ func TestRenderPlanComment_NoUnsafe_NoWarning(t *testing.T) {
 	assert.NotContains(t, rendered, "Unsafe")
 }
 
+func TestRenderPlanComment_StrataHeader(t *testing.T) {
+	data := templates.PlanCommentData{
+		Database:     "testdb",
+		Environment:  "staging",
+		DatabaseType: storage.DatabaseTypeStrata,
+		Changes: []templates.KeyspaceChangeData{{
+			Keyspace:   "testdb",
+			Statements: []string{"ALTER TABLE `users` ADD COLUMN `email` varchar(255)"},
+		}},
+	}
+
+	rendered := templates.RenderPlanComment(data)
+
+	assert.Contains(t, rendered, "## Strata Schema Change Plan")
+}
+
+func TestRenderPlanComment_CustomDatabaseTypeHeader(t *testing.T) {
+	data := templates.PlanCommentData{
+		Database:     "testdb",
+		Environment:  "staging",
+		DatabaseType: "custom-engine",
+		Changes: []templates.KeyspaceChangeData{{
+			Keyspace:   "testdb",
+			Statements: []string{"ALTER TABLE `users` ADD COLUMN `email` varchar(255)"},
+		}},
+	}
+
+	rendered := templates.RenderPlanComment(data)
+
+	assert.Contains(t, rendered, "## Custom Engine Schema Change Plan")
+}
+
+func TestRenderPlanComment_PostgresHeader(t *testing.T) {
+	data := templates.PlanCommentData{
+		Database:     "testdb",
+		Environment:  "staging",
+		DatabaseType: "postgres",
+		Changes: []templates.KeyspaceChangeData{{
+			Keyspace:   "testdb",
+			Statements: []string{"ALTER TABLE `users` ADD COLUMN `email` varchar(255)"},
+		}},
+	}
+
+	rendered := templates.RenderPlanComment(data)
+
+	assert.Contains(t, rendered, "## PostgreSQL Schema Change Plan")
+}
+
 func TestRenderPlanComment_ShowsPRHeadSHA(t *testing.T) {
 	data := templates.PlanCommentData{
 		Database:    "testdb",
@@ -268,6 +318,20 @@ func TestRenderMultiEnvPlanComment_ShowsPRHeadSHA(t *testing.T) {
 
 	assert.Contains(t, rendered, "planned from [`abcdef1`](https://github.com/block/schemabot/commit/abcdef1234567890)")
 	assert.NotContains(t, rendered, "**PR head SHA**")
+}
+
+func TestRenderMultiEnvPlanComment_StrataHeaderWithErrors(t *testing.T) {
+	data := templates.MultiEnvPlanCommentData{
+		Database:     "testdb",
+		DatabaseType: storage.DatabaseTypeStrata,
+		Environments: []string{"staging"},
+		Plans:        map[string]*templates.PlanCommentData{},
+		Errors:       map[string]string{"staging": "resolver unavailable"},
+	}
+
+	rendered := templates.RenderMultiEnvPlanComment(data)
+
+	assert.Contains(t, rendered, "## Strata Schema Change Plan")
 }
 
 func TestUserFacingErrorExplainsNoHealthyUpstream(t *testing.T) {
@@ -340,6 +404,28 @@ func TestRenderUnsafeChangesBlocked_UsedByApplyFlow(t *testing.T) {
 	assert.Contains(t, rendered, "`users`")
 	assert.Contains(t, rendered, "DROP TABLE removes all data")
 	assert.Contains(t, rendered, "--allow-unsafe")
+	assert.Contains(t, rendered, "schemabot apply -e staging --allow-unsafe")
+}
+
+func TestRenderUnsafeChangesBlocked_CustomDatabaseTypeHeader(t *testing.T) {
+	data := templates.PlanCommentData{
+		Database:     "testdb",
+		Environment:  "staging",
+		DatabaseType: "custom-engine",
+		Changes: []templates.KeyspaceChangeData{{
+			Keyspace:   "testdb",
+			Statements: []string{"DROP TABLE `users`"},
+		}},
+		HasUnsafeChanges: true,
+		UnsafeChanges: []templates.UnsafeChangeData{{
+			Table:  "users",
+			Reason: "DROP TABLE removes all data",
+		}},
+	}
+
+	rendered := templates.RenderUnsafeChangesBlocked(data)
+
+	assert.Contains(t, rendered, "## Custom Engine Schema Change Plan")
 	assert.Contains(t, rendered, "schemabot apply -e staging --allow-unsafe")
 }
 

--- a/pkg/webhook/rollback.go
+++ b/pkg/webhook/rollback.go
@@ -198,11 +198,12 @@ func (h *Handler) handleRollbackCommand(repo string, pr int, installationID int6
 	// auditability, but rollback-confirm loads the lock-pinned rollback plan so
 	// the user does not need to repeat the apply ID.
 	commentData := templates.PlanCommentData{
-		Database:    database,
-		Environment: environment,
-		RequestedBy: requestedBy,
-		IsMySQL:     dbType == "mysql",
-		ApplyID:     apply.ApplyIdentifier,
+		Database:     database,
+		Environment:  environment,
+		RequestedBy:  requestedBy,
+		DatabaseType: dbType,
+		IsMySQL:      dbType == "mysql",
+		ApplyID:      apply.ApplyIdentifier,
 	}
 
 	for _, sc := range planResp.Changes {

--- a/pkg/webhook/templates/apply_commands.go
+++ b/pkg/webhook/templates/apply_commands.go
@@ -95,10 +95,7 @@ func RenderUnsafeChangesBlocked(data PlanCommentData) string {
 
 	// Render the full plan first (DDL, lint warnings, etc.) so the user can see
 	// what would change — but without a lock or confirm footer.
-	dbTypeLabel := "Vitess"
-	if data.IsMySQL {
-		dbTypeLabel = "MySQL"
-	}
+	dbTypeLabel := schemaChangePlanDatabaseTypeLabel(data.DatabaseType, data.IsMySQL)
 	fmt.Fprintf(&sb, "## %s Schema Change Plan\n\n", dbTypeLabel)
 
 	writePlanMetadata(&sb, data)

--- a/pkg/webhook/templates/plan.go
+++ b/pkg/webhook/templates/plan.go
@@ -7,6 +7,7 @@ import (
 	"github.com/block/spirit/pkg/statement"
 
 	"github.com/block/schemabot/pkg/ddl"
+	"github.com/block/schemabot/pkg/storage"
 	"github.com/block/schemabot/pkg/ui"
 )
 
@@ -26,15 +27,16 @@ type UnsafeChangeData struct {
 
 // PlanCommentData contains all data needed to render a plan comment.
 type PlanCommentData struct {
-	Database    string
-	SchemaName  string // Schema directory name (e.g. filepath.Base of schema dir)
-	Environment string
-	Tenant      string
-	HeadSHA     string
-	Repository  string
-	RequestedBy string // Empty means auto-generated
-	IsMySQL     bool
-	ApplyID     string
+	Database     string
+	SchemaName   string // Schema directory name (e.g. filepath.Base of schema dir)
+	Environment  string
+	Tenant       string
+	HeadSHA      string
+	Repository   string
+	RequestedBy  string // Empty means auto-generated
+	DatabaseType string
+	IsMySQL      bool
+	ApplyID      string
 
 	Changes        []KeyspaceChangeData
 	LintViolations []LintViolationData
@@ -74,10 +76,7 @@ func RenderPlanComment(data PlanCommentData) string {
 	var sb strings.Builder
 
 	// Header
-	dbTypeLabel := "Vitess"
-	if data.IsMySQL {
-		dbTypeLabel = "MySQL"
-	}
+	dbTypeLabel := schemaChangePlanDatabaseTypeLabel(data.DatabaseType, data.IsMySQL)
 	if data.IsLocked {
 		sb.WriteString("## Schema Change Apply\n\n")
 	} else {
@@ -452,12 +451,13 @@ func pluralize(singular string, count int) string {
 // MultiEnvPlanCommentData contains data for rendering a multi-environment plan
 // in a single comment. Used when `schemabot plan` is run without `-e`.
 type MultiEnvPlanCommentData struct {
-	Database    string
-	SchemaName  string
-	HeadSHA     string
-	Repository  string
-	IsMySQL     bool
-	RequestedBy string
+	Database     string
+	SchemaName   string
+	HeadSHA      string
+	Repository   string
+	DatabaseType string
+	IsMySQL      bool
+	RequestedBy  string
 
 	// Environments in display order (staging first, production second, etc.)
 	Environments []string
@@ -475,10 +475,7 @@ func RenderMultiEnvPlanComment(data MultiEnvPlanCommentData) string {
 	var sb strings.Builder
 
 	// Header
-	dbTypeLabel := "Vitess"
-	if data.IsMySQL {
-		dbTypeLabel = "MySQL"
-	}
+	dbTypeLabel := schemaChangePlanDatabaseTypeLabel(data.DatabaseType, data.IsMySQL)
 	fmt.Fprintf(&sb, "## %s Schema Change Plan\n\n", dbTypeLabel)
 
 	writePlanMetadata(&sb, PlanCommentData{Database: data.Database, SchemaName: data.SchemaName})
@@ -535,6 +532,42 @@ func RenderMultiEnvPlanComment(data MultiEnvPlanCommentData) string {
 	writeMultiEnvFooter(&sb, data)
 
 	return sb.String()
+}
+
+func schemaChangePlanDatabaseTypeLabel(databaseType string, isMySQL bool) string {
+	databaseType = strings.TrimSpace(databaseType)
+	switch databaseType {
+	case storage.DatabaseTypeMySQL:
+		return "MySQL"
+	case storage.DatabaseTypeStrata:
+		return "Strata"
+	case storage.DatabaseTypeVitess:
+		return "Vitess"
+	case "postgres", "postgresql":
+		return "PostgreSQL"
+	}
+	if databaseType != "" {
+		if label := titleDatabaseType(databaseType); label != "" {
+			return label
+		}
+	}
+	if isMySQL {
+		return "MySQL"
+	}
+	return "Vitess"
+}
+
+func titleDatabaseType(databaseType string) string {
+	parts := strings.FieldsFunc(databaseType, func(r rune) bool {
+		return r == '-' || r == '_' || r == ' '
+	})
+	for i, part := range parts {
+		if part == "" {
+			continue
+		}
+		parts[i] = strings.ToUpper(part[:1]) + strings.ToLower(part[1:])
+	}
+	return strings.Join(parts, " ")
 }
 
 // writeEnvironmentPlanSection writes the plan body for a single environment within a multi-env comment.

--- a/pkg/webhook/templates/rollback.go
+++ b/pkg/webhook/templates/rollback.go
@@ -11,10 +11,7 @@ func RenderRollbackPlanComment(data PlanCommentData) string {
 	var sb strings.Builder
 
 	// Header
-	dbTypeLabel := "Vitess"
-	if data.IsMySQL {
-		dbTypeLabel = "MySQL"
-	}
+	dbTypeLabel := schemaChangePlanDatabaseTypeLabel(data.DatabaseType, data.IsMySQL)
 	fmt.Fprintf(&sb, "## %s Schema Rollback Plan\n\n", dbTypeLabel)
 
 	writePlanMetadata(&sb, data)

--- a/pkg/webhook/templates/rollback_test.go
+++ b/pkg/webhook/templates/rollback_test.go
@@ -74,6 +74,26 @@ func TestRenderRollbackPlanComment_Vitess(t *testing.T) {
 	assert.NotContains(t, rendered, "schemabot rollback-confirm -e staging -d")
 }
 
+func TestRenderRollbackPlanComment_CustomDatabaseTypeHeader(t *testing.T) {
+	data := PlanCommentData{
+		Database:     "myks",
+		Environment:  "staging",
+		RequestedBy:  "admin",
+		DatabaseType: "custom-engine",
+		ApplyID:      "apply_abc123",
+		Changes: []KeyspaceChangeData{
+			{
+				Keyspace:   "myks",
+				Statements: []string{"ALTER TABLE `t1` DROP INDEX `idx_foo`"},
+			},
+		},
+	}
+
+	rendered := RenderRollbackPlanComment(data)
+	assert.Contains(t, rendered, "## Custom Engine Schema Rollback Plan")
+	assert.Contains(t, rendered, "schemabot rollback-confirm -e staging")
+}
+
 func TestRenderRollbackPlanComment_WithLintViolations(t *testing.T) {
 	data := PlanCommentData{
 		Database:    "testapp",


### PR DESCRIPTION
GitHub schema change comments used a MySQL/non-MySQL split, so newer engine types could appear with Vitess wording. Render the database type label from the stored/requested type instead, with canonical labels for MySQL, Vitess, Strata, and PostgreSQL plus a readable fallback for other custom engine types.

## What
- Thread database type into plan comment data for single-environment, multi-environment, unsafe-blocked, and rollback plan comments.
- Use one shared label helper across those headers so engine names stay consistent.
- Cover Strata, PostgreSQL, and custom engine labels with focused template tests.

## Why
This keeps PR comment UX accurate as SchemaBot supports additional engines without adding one-off template branches for every new type.

Generated with Amp
