### PR TITLE
feat(api): config transport (unix socket + headers) for the Etre resolver

### DIFF
--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -433,10 +433,10 @@ type EtreConfig struct {
 	DatabaseType string `yaml:"database_type"`
 	// EntityType is the Etre entity type recording the target clusters.
 	EntityType string `yaml:"entity_type"`
-	// Headers are added to every Etre request, for deployments that reach Etre
-	// through a header-aware proxy or service mesh that routes by request header.
-	// Optional; no header is sent unless configured here.
-	Headers map[string]string `yaml:"headers,omitempty"`
+	// HTTP configures how Etre requests are transported, for deployments that
+	// reach Etre through a local egress proxy or header-routed service mesh.
+	// Optional; the default transport is used when unset.
+	HTTP EtreHTTPConfig `yaml:"http,omitempty"`
 	// TargetLabel is the Etre label the request's opaque target matches.
 	TargetLabel string `yaml:"target_label"`
 	// EnvLabel, when set, scopes the lookup to the request environment.
@@ -452,6 +452,20 @@ type EtreConfig struct {
 	Vitess EtreVitessConfig `yaml:"vitess,omitempty"`
 	// Credentials configures the credentials for the connection.
 	Credentials EtreCredentialsConfig `yaml:"credentials"`
+}
+
+// EtreHTTPConfig configures the transport for Etre requests. Both fields are
+// generic HTTP-client concerns, so a deployment behind any egress proxy or
+// header-routing mesh can be expressed in config without engine code.
+type EtreHTTPConfig struct {
+	// UnixSocket, when set, dials this unix domain socket for every Etre request
+	// instead of TCP (supports secret refs, e.g. env:EGRESS_SOCKET). Use it to
+	// reach Etre through a local egress proxy; the request Host (from Addr) is
+	// still sent so the proxy can route by host and Headers.
+	UnixSocket string `yaml:"unix_socket,omitempty"`
+	// Headers are added to every Etre request, for proxies/meshes that route by
+	// request header. No header is sent unless configured here.
+	Headers map[string]string `yaml:"headers,omitempty"`
 }
 
 // EtreMySQLConfig holds the MySQL-specific knobs for an Etre resolver: how to

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -433,6 +433,10 @@ type EtreConfig struct {
 	DatabaseType string `yaml:"database_type"`
 	// EntityType is the Etre entity type recording the target clusters.
 	EntityType string `yaml:"entity_type"`
+	// Headers are added to every Etre request, for deployments that reach Etre
+	// through a header-aware proxy or service mesh that routes by request header.
+	// Optional; no header is sent unless configured here.
+	Headers map[string]string `yaml:"headers,omitempty"`
 	// TargetLabel is the Etre label the request's opaque target matches.
 	TargetLabel string `yaml:"target_label"`
 	// EnvLabel, when set, scopes the lookup to the request environment.

--- a/pkg/api/target_resolver_factory.go
+++ b/pkg/api/target_resolver_factory.go
@@ -116,7 +116,7 @@ func buildEtreResolver(ctx context.Context, cfg EtreConfig, logger *slog.Logger)
 	if addr == "" {
 		return nil, fmt.Errorf("target_resolver.etre.addr resolved to an empty value")
 	}
-	client, err := etre.New(etre.Config{Addr: addr, EntityType: cfg.EntityType, Logger: logger})
+	client, err := etre.New(etre.Config{Addr: addr, EntityType: cfg.EntityType, Headers: cfg.Headers, Logger: logger})
 	if err != nil {
 		return nil, fmt.Errorf("build etre client: %w", err)
 	}

--- a/pkg/api/target_resolver_factory.go
+++ b/pkg/api/target_resolver_factory.go
@@ -116,7 +116,11 @@ func buildEtreResolver(ctx context.Context, cfg EtreConfig, logger *slog.Logger)
 	if addr == "" {
 		return nil, fmt.Errorf("target_resolver.etre.addr resolved to an empty value")
 	}
-	client, err := etre.New(etre.Config{Addr: addr, EntityType: cfg.EntityType, Headers: cfg.Headers, Logger: logger})
+	unixSocket, err := secrets.Resolve(cfg.HTTP.UnixSocket, "")
+	if err != nil {
+		return nil, fmt.Errorf("resolve target_resolver.etre.http.unix_socket: %w", err)
+	}
+	client, err := etre.New(etre.Config{Addr: addr, EntityType: cfg.EntityType, UnixSocket: unixSocket, Headers: cfg.HTTP.Headers, Logger: logger})
 	if err != nil {
 		return nil, fmt.Errorf("build etre client: %w", err)
 	}

--- a/pkg/etre/etre.go
+++ b/pkg/etre/etre.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"log/slog"
 	"maps"
+	"net"
 	"net/http"
 	"sort"
 	"strings"
@@ -36,8 +37,14 @@ type Config struct {
 	// EntityType is the Etre entity type this client queries.
 	EntityType string
 	// HTTPClient is used for Etre requests. The deployment owns any required
-	// routing/TLS. When nil, http.DefaultClient is used.
+	// routing/TLS. When nil, http.DefaultClient is used (or, if UnixSocket is set,
+	// a client that dials that socket).
 	HTTPClient *http.Client
+	// UnixSocket, when set and no HTTPClient is supplied, dials this unix domain
+	// socket for every Etre request instead of TCP. Use it to reach Etre through a
+	// local egress proxy; the request Host (from Addr) is still sent, so the proxy
+	// can route by host and Headers.
+	UnixSocket string
 	// Headers, when set, are added to every Etre request. Deployments that reach
 	// Etre through a header-aware proxy or service mesh can supply the routing
 	// headers that proxy requires; no header is baked into the client.
@@ -67,7 +74,11 @@ func New(cfg Config) (*Client, error) {
 	// first request, so default it here.
 	httpClient := cfg.HTTPClient
 	if httpClient == nil {
-		httpClient = http.DefaultClient
+		if cfg.UnixSocket != "" {
+			httpClient = unixSocketClient(cfg.UnixSocket)
+		} else {
+			httpClient = http.DefaultClient
+		}
 	}
 	if len(cfg.Headers) > 0 {
 		httpClient = clientWithHeaders(httpClient, cfg.Headers)
@@ -79,6 +90,22 @@ func New(cfg Config) (*Client, error) {
 		Retry:      cfg.Retry,
 	})
 	return newClient(entities, cfg.EntityType, cfg.Logger), nil
+}
+
+// unixSocketClient builds an HTTP client that dials the given unix domain
+// socket for every request instead of the request URL's host:port. The request
+// Host is still sent, so an egress proxy listening on the socket can route by
+// host (and any headers). It is the generic seam for reaching a service through
+// a local egress proxy rather than directly over TCP.
+func unixSocketClient(socketPath string) *http.Client {
+	return &http.Client{
+		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+				var dialer net.Dialer
+				return dialer.DialContext(ctx, "unix", socketPath)
+			},
+		},
+	}
 }
 
 // clientWithHeaders returns a shallow copy of base whose transport sets the

--- a/pkg/etre/etre.go
+++ b/pkg/etre/etre.go
@@ -13,6 +13,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"maps"
 	"net/http"
 	"sort"
 	"strings"
@@ -90,7 +91,9 @@ func clientWithHeaders(base *http.Client, headers map[string]string) *http.Clien
 		transport = http.DefaultTransport
 	}
 	copied := *base
-	copied.Transport = &headerRoundTripper{base: transport, headers: headers}
+	// Snapshot the headers so the transport holds an immutable copy: a caller
+	// mutating its map after construction can't race RoundTrip's iteration.
+	copied.Transport = &headerRoundTripper{base: transport, headers: maps.Clone(headers)}
 	return &copied
 }
 

--- a/pkg/etre/etre.go
+++ b/pkg/etre/etre.go
@@ -37,6 +37,10 @@ type Config struct {
 	// HTTPClient is used for Etre requests. The deployment owns any required
 	// routing/TLS. When nil, http.DefaultClient is used.
 	HTTPClient *http.Client
+	// Headers, when set, are added to every Etre request. Deployments that reach
+	// Etre through a header-aware proxy or service mesh can supply the routing
+	// headers that proxy requires; no header is baked into the client.
+	Headers map[string]string
 	// Retry is the per-request retry count on network or API error.
 	Retry uint
 	// Logger receives debug logs for lookups. Defaults to slog.Default().
@@ -64,6 +68,9 @@ func New(cfg Config) (*Client, error) {
 	if httpClient == nil {
 		httpClient = http.DefaultClient
 	}
+	if len(cfg.Headers) > 0 {
+		httpClient = clientWithHeaders(httpClient, cfg.Headers)
+	}
 	entities := etre.NewEntityClientWithConfig(etre.EntityClientConfig{
 		EntityType: cfg.EntityType,
 		Addr:       cfg.Addr,
@@ -71,6 +78,38 @@ func New(cfg Config) (*Client, error) {
 		Retry:      cfg.Retry,
 	})
 	return newClient(entities, cfg.EntityType, cfg.Logger), nil
+}
+
+// clientWithHeaders returns a shallow copy of base whose transport sets the
+// given headers on every request. The original client and its transport are
+// left unmodified, so a shared client (including http.DefaultClient) is safe to
+// pass in.
+func clientWithHeaders(base *http.Client, headers map[string]string) *http.Client {
+	transport := base.Transport
+	if transport == nil {
+		transport = http.DefaultTransport
+	}
+	copied := *base
+	copied.Transport = &headerRoundTripper{base: transport, headers: headers}
+	return &copied
+}
+
+// headerRoundTripper sets a fixed set of headers on every request before
+// delegating to the wrapped RoundTripper. It is the generic seam a deployment
+// uses to route Etre requests through a header-aware proxy or mesh; the client
+// itself knows nothing about which headers mean what.
+type headerRoundTripper struct {
+	base    http.RoundTripper
+	headers map[string]string
+}
+
+func (h *headerRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Clone so the caller's request (and its header map) is never mutated.
+	cloned := req.Clone(req.Context())
+	for k, v := range h.headers {
+		cloned.Header.Set(k, v)
+	}
+	return h.base.RoundTrip(cloned)
 }
 
 // newClient constructs a Client over a given entity client. It exists so tests

--- a/pkg/etre/etre_test.go
+++ b/pkg/etre/etre_test.go
@@ -135,3 +135,38 @@ func TestNewValidatesConfig(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, c)
 }
+
+// Configured headers must be sent on every Etre request, so a deployment behind
+// a header-routed proxy or mesh can supply the routing headers that path needs.
+func TestNewSendsConfiguredHeaders(t *testing.T) {
+	var gotHeaders http.Header
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotHeaders = r.Header.Clone()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[{"name":"orders","host":"orders.example:3306"}]`))
+	}))
+	defer srv.Close()
+
+	c, err := New(Config{
+		Addr:       srv.URL,
+		EntityType: "cluster",
+		Headers:    map[string]string{"X-Env-Override": "production", "X-Route-Label": "etre"},
+	})
+	require.NoError(t, err)
+
+	_, err = c.QueryOne(t.Context(), map[string]string{"name": "orders"})
+	require.NoError(t, err)
+	require.NotNil(t, gotHeaders)
+	assert.Equal(t, "production", gotHeaders.Get("X-Env-Override"))
+	assert.Equal(t, "etre", gotHeaders.Get("X-Route-Label"))
+}
+
+// Wrapping a shared client (here, the default client) to add headers must not
+// mutate the original client's transport.
+func TestClientWithHeadersDoesNotMutateBase(t *testing.T) {
+	base := &http.Client{}
+	wrapped := clientWithHeaders(base, map[string]string{"X-Test": "1"})
+	assert.Nil(t, base.Transport, "base client transport must be untouched")
+	assert.NotNil(t, wrapped.Transport)
+	assert.NotSame(t, base, wrapped)
+}

--- a/pkg/etre/etre_test.go
+++ b/pkg/etre/etre_test.go
@@ -3,8 +3,10 @@ package etre
 import (
 	"context"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"testing"
 
 	"github.com/square/etre"
@@ -176,4 +178,48 @@ func TestClientWithHeadersDoesNotMutateBase(t *testing.T) {
 	assert.Nil(t, base.Transport, "base client transport must be untouched")
 	assert.NotNil(t, wrapped.Transport)
 	assert.NotSame(t, base, wrapped)
+}
+
+// A configured unix socket makes every Etre request dial that socket instead of
+// the Addr host — the path for reaching Etre through a local egress proxy. The
+// Addr host is intentionally unresolvable to prove the socket is used, and the
+// configured headers still ride along for the proxy to route by.
+func TestNewDialsUnixSocket(t *testing.T) {
+	socketPath := filepath.Join(t.TempDir(), "etre.sock")
+	var lc net.ListenConfig
+	ln, err := lc.Listen(t.Context(), "unix", socketPath)
+	require.NoError(t, err)
+
+	type captured struct {
+		host    string
+		headers http.Header
+	}
+	capCh := make(chan captured, 1)
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capCh <- captured{host: r.Host, headers: r.Header.Clone()}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[{"name":"orders","host":"orders.example:3306"}]`))
+	}))
+	srv.Listener = ln
+	srv.Start()
+	defer srv.Close()
+
+	c, err := New(Config{
+		Addr:       "http://etre.invalid",
+		EntityType: "cluster",
+		UnixSocket: socketPath,
+		Headers:    map[string]string{"X-Env-Override": "production"},
+	})
+	require.NoError(t, err)
+
+	_, err = c.QueryOne(t.Context(), map[string]string{"name": "orders"})
+	require.NoError(t, err)
+	var got captured
+	select {
+	case got = <-capCh:
+	default:
+		t.Fatal("Etre handler was not invoked over the unix socket")
+	}
+	assert.Equal(t, "etre.invalid", got.host, "request Host (from Addr) is preserved for proxy routing")
+	assert.Equal(t, "production", got.headers.Get("X-Env-Override"))
 }

--- a/pkg/etre/etre_test.go
+++ b/pkg/etre/etre_test.go
@@ -139,9 +139,11 @@ func TestNewValidatesConfig(t *testing.T) {
 // Configured headers must be sent on every Etre request, so a deployment behind
 // a header-routed proxy or mesh can supply the routing headers that path needs.
 func TestNewSendsConfiguredHeaders(t *testing.T) {
-	var gotHeaders http.Header
+	// Pass the captured headers back over a channel so the handler goroutine and
+	// the test goroutine don't share a variable without synchronization.
+	headerCh := make(chan http.Header, 1)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotHeaders = r.Header.Clone()
+		headerCh <- r.Header.Clone()
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`[{"name":"orders","host":"orders.example:3306"}]`))
 	}))
@@ -156,13 +158,18 @@ func TestNewSendsConfiguredHeaders(t *testing.T) {
 
 	_, err = c.QueryOne(t.Context(), map[string]string{"name": "orders"})
 	require.NoError(t, err)
-	require.NotNil(t, gotHeaders)
+	var gotHeaders http.Header
+	select {
+	case gotHeaders = <-headerCh:
+	default:
+		t.Fatal("Etre handler was not invoked")
+	}
 	assert.Equal(t, "production", gotHeaders.Get("X-Env-Override"))
 	assert.Equal(t, "etre", gotHeaders.Get("X-Route-Label"))
 }
 
-// Wrapping a shared client (here, the default client) to add headers must not
-// mutate the original client's transport.
+// Wrapping a client to add headers must not mutate the original client's
+// transport, so a shared client is safe to pass in.
 func TestClientWithHeadersDoesNotMutateBase(t *testing.T) {
 	base := &http.Client{}
 	wrapped := clientWithHeaders(base, map[string]string{"X-Test": "1"})


### PR DESCRIPTION
## Why

The Etre target resolver builds a plain HTTP client. Deployments that reach Etre through a **local egress proxy** (e.g. a sidecar that listens on a unix domain socket and routes by request host/header) can't reach it with a plain client — the proxy's virtual host isn't resolvable over DNS, and the request must be dialed over the socket. There was no way to express that transport in config.

## What

Add an optional `http` block to the Etre resolver config covering the two generic transport concerns:

```yaml
target_resolver:
  defaults:
    mysql:
      resolver:
        type: etre
        entity_type: aurora_cluster
        addr: http://etre.internal
        http:
          unix_socket: env:EGRESS_SOCKET   # dial this socket instead of TCP
          headers:                         # set on every Etre request
            X-Env-Override: production
```

- **`unix_socket`** — when set (and no `HTTPClient` is injected), the etre client dials this unix domain socket for every request instead of TCP, while still sending the `addr` host so the proxy can route by host. Supports secret refs (`env:`/`file:`/`secretsmanager:`).
- **`headers`** — added to every request, for proxies/meshes that route by header. Snapshotted and applied via a cloning `RoundTripper`, so the caller's client/request is never mutated.
- Both are generic HTTP-client concepts — the client stays agnostic about what any of it means. When unset, the default transport is used (no behavior change).

## Tests

- A configured `unix_socket` is dialed for the request (proven with an **unresolvable** `addr` host) and configured headers ride along.
- Configured headers are sent end-to-end; wrapping a shared client doesn't mutate it. All `-race` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)