### PR TITLE
fix(ci): shard multi-deployment e2e tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -265,11 +265,19 @@ jobs:
           docker compose -f deploy/e2e/docker-compose.yml logs --tail=300 schemabot localscale 2>/dev/null || true
 
   e2e-grpc-multideploy:
-    name: "E2E gRPC Multi-Deployment Tests"
+    name: "E2E gRPC Multi-Deployment Tests (${{ matrix.shard }})"
     needs: changes
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - shard: ordered
+            run: TestGRPCMultiDeploy_(SchemaBot_Health|TernHealth_BothDeployments|Plan_FansOut|OrderedCutover|OrderedCutoverObservability)$$
+          - shard: failure-policy
+            run: TestGRPCMultiDeploy_(FailureHaltsRollout|OnFailureContinue)$$
     steps:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # actions/checkout@v6
       - name: "Configure Go"
@@ -286,7 +294,7 @@ jobs:
           key: go-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('go.sum') }}
           restore-keys: go-${{ runner.os }}-${{ runner.arch }}-
       - name: "Test"
-        run: make test-e2e-grpc-multideploy
+        run: make test-e2e-grpc-multideploy E2E_GRPC_MD_RUN='${{ matrix.run }}'
       - name: "Container logs on failure"
         if: failure()
         run: |

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ else
 endif
 E2E_TEST_TIMEOUT ?= 10m
 E2E_TEST_FLAGS ?=
+E2E_GRPC_MD_RUN ?= TestGRPCMultiDeploy
 
 .PHONY: help lint lint-fix setup test test-unit test-e2e test-e2e-grpc test-e2e-grpc-multideploy test-e2e-k8s test-e2e-local-down test-e2e-mysql test-e2e-vitess test-integration test-localscale build-localscale-image test-coverage build install clean proto up up-telemetry up-grpc down down-grpc status mysql logs logs-grpc test-endpoints plan-testapp apply-testapp seed-testapp seed-testapp-large seed-vitess demo demo-vitess demo-grpc demo-grpc-logs wait-healthy wait-healthy-grpc wait-localscale cli
 
@@ -446,7 +447,7 @@ test-e2e-grpc-multideploy: build ## Run multi-deployment fan-out gRPC e2e fixtur
 	E2E_SCHEMABOT_MYSQL_DSN="root:testpassword@tcp(localhost:15371)/schemabot" \
 	E2E_TERN_EU_MYSQL_DSN="root:testpassword@tcp(localhost:15372)/testapp" \
 	E2E_TERN_US_MYSQL_DSN="root:testpassword@tcp(localhost:15373)/testapp" \
-	$(GOTEST) -count=1 -v -tags=e2e -timeout=10m -run TestGRPCMultiDeploy ./e2e/grpc/... ; \
+	$(GOTEST) -count=1 -v -tags=e2e -timeout=10m -run '$(E2E_GRPC_MD_RUN)' ./e2e/grpc/... ; \
 	TEST_EXIT_CODE=$$?; \
 	echo "Tearing down multi-deployment gRPC e2e environment..."; \
 	$(E2E_GRPC_MD_ENV) docker compose -p schemabot-e2e-grpc-md -f deploy/local/docker-compose.grpc-multideploy.yml down -v; \

--- a/e2e/grpc/multideploy_test.go
+++ b/e2e/grpc/multideploy_test.go
@@ -437,8 +437,8 @@ func TestGRPCMultiDeploy_FailureHaltsRollout(t *testing.T) {
 	// The earlier deployment gets identical names so adding UNIQUE(name) fails
 	// during its copy; the later deployment gets unique names so it would
 	// succeed if the rollout were allowed to proceed past the failure.
-	multiDeploySeedRows(t, first, tableName, "name, data", "'dup', REPEAT('x', 200)", 10000)
-	multiDeploySeedRows(t, second, tableName, "name, data", "CONCAT('user_', seq), REPEAT('x', 200)", 10000)
+	multiDeploySeedRows(t, first, tableName, "name, data", "'dup', REPEAT('x', 200)", 2)
+	multiDeploySeedRows(t, second, tableName, "name, data", "CONCAT('user_', seq), REPEAT('x', 200)", 2)
 
 	multiDeployEnsureNoActiveChange(t, database, env, first, second)
 
@@ -613,8 +613,8 @@ func TestGRPCMultiDeploy_OnFailureContinue(t *testing.T) {
 	}
 	// The earlier deployment gets identical names so adding UNIQUE(name) fails
 	// during its copy; the later deployment gets unique names so it completes.
-	multiDeploySeedRows(t, first, tableName, "name, data", "'dup', REPEAT('x', 200)", 10000)
-	multiDeploySeedRows(t, second, tableName, "name, data", "CONCAT('user_', seq), REPEAT('x', 200)", 10000)
+	multiDeploySeedRows(t, first, tableName, "name, data", "'dup', REPEAT('x', 200)", 2)
+	multiDeploySeedRows(t, second, tableName, "name, data", "CONCAT('user_', seq), REPEAT('x', 200)", 2)
 
 	multiDeployEnsureNoActiveChange(t, database, env, first, second)
 


### PR DESCRIPTION
The newly gated multi-deployment gRPC e2e job was slow enough to hit the package timeout when the failure-policy scenario spent minutes copying rows before reaching the intended failure. Make the failure-policy fixtures fail fast and split the CI job into two matrix shards so ordered-cutover and failure-policy coverage run independently.

## What
- Add `E2E_GRPC_MD_RUN` so the multi-deployment e2e make target can run a selected test subset.
- Split the `e2e-grpc-multideploy` GitHub Actions job into `ordered` and `failure-policy` shards.
- Seed only the duplicate rows needed for the failure-policy tests, while leaving copy/cutover scenarios seeded for full ordered-rollout coverage.

## Why
This keeps the recently enabled multi-deployment coverage in CI without letting a single slow failure scenario consume the whole package timeout and cascade into unrelated test failures.

Generated with Amp
