### PR TITLE
fix(github): require tenant targets for scoped commands

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -600,6 +600,13 @@ the webhook delivery and skip it without adding reactions or comments, the same
 way an environment-scoped deployment skips commands for environments outside
 `allowed_environments`.
 
+When `tenant` is set, work commands must include a matching `--tenant` or `-t`
+target. Untargeted commands such as `schemabot plan -e production` and
+`schemabot apply -e production` are accepted without a PR response by the
+tenant-scoped deployment. This keeps multiple isolated deployments from acting
+on the same PR command. Deployments without `tenant` configured keep the
+existing behavior and do not require the flag.
+
 This routing identity is deliberately local to the server process. It is not
 stored on plans or applies and it does not change database target resolution.
 The isolated deployment's own storage, chart values, GitHub App configuration,
@@ -616,10 +623,10 @@ others. Operators can still direct help to a specific deployment with
 
 - **Environment scoping:** When `allowed_environments` is set, the instance only processes commands targeting those environments. Commands for other environments (e.g., `schemabot apply -e production` sent to the staging instance) are accepted without a PR response by this deployment. A deployment that allows the requested environment must process its own webhook delivery.
 
-- **Tenant scoping:** When `tenant` is set and a command includes `--tenant`,
-  only the matching deployment processes the command. Tenant scoping is a
-  webhook ownership filter, not a schema-change state field; untargeted commands
-  continue through the existing environment and unscoped-command routing.
+- **Tenant scoping:** When `tenant` is set, work commands must include a matching
+  `--tenant` or `-t` target. Tenant scoping is a webhook ownership filter, not a
+  schema-change state field; untargeted help and invalid-command responses
+  continue through the unscoped-command routing.
 
 - **Per-environment aggregate checks:** Each instance creates its own aggregate check run scoped to its environments (e.g., `SchemaBot (staging)`, `SchemaBot (production)`) instead of the default `SchemaBot` aggregate. Configure branch protection to require both aggregates. Set `github.check-name` when independent SchemaBot gates need distinct visible names; every instance in the same promotion chain should use the same base name.
 
@@ -629,7 +636,7 @@ others. Operators can still direct help to a specific deployment with
 
 - **Separate GitHub Apps:** Each instance needs its own GitHub App installation. Both Apps must be installed on the same repositories and configured to receive the same webhook events. GitHub delivers webhooks to all installed Apps independently.
 
-- **Unscoped command routing:** With two Apps on the same repo, commands not scoped to an environment (`help`, invalid commands) would get duplicate responses. Set `respond_to_unscoped: false` on the staging instance so only the production instance responds to these. Environment-scoped commands (`plan -e`, `apply -e`) are unaffected — they're already routed by `allowed_environments`.
+- **Unscoped command routing:** With two Apps on the same repo, commands not scoped to an environment or tenant (`help`, invalid commands) would get duplicate responses. Set `respond_to_unscoped: false` on one instance so only the designated instance responds to these. Work commands (`plan -e`, `apply -e`) must include `--tenant` or `-t` when the deployment has `tenant` configured.
 
 - **Backwards compatible:** When `allowed_environments` is not set or empty, the instance handles all environments and creates a single `SchemaBot` aggregate check — the same behavior as a single-instance deployment.
 

--- a/pkg/webhook/check_runs_test.go
+++ b/pkg/webhook/check_runs_test.go
@@ -230,6 +230,125 @@ func TestWebhookEnvironmentFiltering(t *testing.T) {
 	})
 }
 
+func TestTenantScopedWorkCommandRouting(t *testing.T) {
+	t.Run("tenant deployment skips unscoped plan command", func(t *testing.T) {
+		service := api.New(nil, &api.ServerConfig{
+			Tenant: "alpha",
+			Repos:  map[string]api.RepoConfig{},
+		}, nil, testLogger())
+
+		h := &Handler{
+			service: service,
+			logger:  testLogger(),
+		}
+
+		req := buildWebhookRequest(t, webhookPayloadOpts{
+			comment: "schemabot plan -e staging",
+			isPR:    true,
+		}, nil)
+
+		rr := httpResponseRecorder()
+		h.ServeHTTP(rr, req)
+
+		require.Equal(t, http.StatusOK, rr.Code)
+		assert.Contains(t, rr.Body.String(), "tenant target required")
+	})
+
+	t.Run("tenant deployment skips unscoped apply command", func(t *testing.T) {
+		service := api.New(nil, &api.ServerConfig{
+			Tenant: "alpha",
+			Repos:  map[string]api.RepoConfig{},
+		}, nil, testLogger())
+
+		h := &Handler{
+			service: service,
+			logger:  testLogger(),
+		}
+
+		req := buildWebhookRequest(t, webhookPayloadOpts{
+			comment: "schemabot apply -e staging",
+			isPR:    true,
+		}, nil)
+
+		rr := httpResponseRecorder()
+		h.ServeHTTP(rr, req)
+
+		require.Equal(t, http.StatusOK, rr.Code)
+		assert.Contains(t, rr.Body.String(), "tenant target required")
+	})
+
+	t.Run("tenant deployment handles matching plan command", func(t *testing.T) {
+		client, mux := setupGitHubServer(t)
+		mux.HandleFunc("POST /repos/octocat/hello-world/issues/1/comments", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": 99})
+		})
+		mux.HandleFunc("POST /repos/octocat/hello-world/issues/comments/42/reactions", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": 1})
+		})
+
+		installClient := ghclient.NewInstallationClient(client, testLogger())
+		factory := &fakeClientFactory{client: installClient}
+
+		service := api.New(&emptyStorage{}, &api.ServerConfig{
+			Tenant: "alpha",
+			Repos:  map[string]api.RepoConfig{},
+		}, nil, testLogger())
+
+		h := &Handler{
+			service:   service,
+			ghClients: ghclient.NewSingleClientSet(defaultAppName, factory),
+			logger:    testLogger(),
+		}
+
+		req := buildWebhookRequest(t, webhookPayloadOpts{
+			comment: "schemabot plan -e staging -t alpha",
+			isPR:    true,
+		}, nil)
+
+		rr := httpResponseRecorder()
+		h.ServeHTTP(rr, req)
+
+		require.Equal(t, http.StatusOK, rr.Code)
+		assert.NotContains(t, rr.Body.String(), "tenant target required")
+		assert.NotContains(t, rr.Body.String(), "tenant handled by another instance")
+	})
+
+	t.Run("tenant deployment still uses respond_to_unscoped for help", func(t *testing.T) {
+		client, mux := setupGitHubServer(t)
+		mux.HandleFunc("POST /repos/octocat/hello-world/issues/1/comments", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": 99})
+		})
+
+		installClient := ghclient.NewInstallationClient(client, testLogger())
+		factory := &fakeClientFactory{client: installClient}
+
+		service := api.New(nil, &api.ServerConfig{
+			Tenant: "alpha",
+			Repos:  map[string]api.RepoConfig{},
+		}, nil, testLogger())
+
+		h := &Handler{
+			service:   service,
+			ghClients: ghclient.NewSingleClientSet(defaultAppName, factory),
+			logger:    testLogger(),
+		}
+
+		req := buildWebhookRequest(t, webhookPayloadOpts{
+			comment: "schemabot help",
+			isPR:    true,
+		}, nil)
+
+		rr := httpResponseRecorder()
+		h.ServeHTTP(rr, req)
+
+		require.Equal(t, http.StatusOK, rr.Code)
+		assert.Contains(t, rr.Body.String(), "help posted")
+	})
+}
+
 //go:fix inline
 func TestRespondToUnscoped(t *testing.T) {
 	falseVal := false

--- a/pkg/webhook/issue_comment.go
+++ b/pkg/webhook/issue_comment.go
@@ -126,6 +126,14 @@ func (h *Handler) handleIssueComment(ctx context.Context, metricApp string, w ht
 		})
 		return
 	}
+	if result.Tenant == "" && commandRequiresTenantTarget(result) && h.service != nil && h.service.Config().Tenant != "" {
+		h.logger.Info("ignoring work command without tenant target",
+			"repo", repo, "pr", pr, "tenant", h.service.Config().Tenant, "action", result.Action)
+		h.writeJSON(w, http.StatusOK, map[string]string{
+			"message": "tenant target required",
+		})
+		return
+	}
 
 	// Handle help command
 	if result.IsHelp {
@@ -307,6 +315,10 @@ func (h *Handler) handleIssueComment(ctx context.Context, metricApp string, w ht
 		h.postComment(repo, pr, installationID, templates.RenderInvalidCommand())
 		h.writeJSON(w, http.StatusOK, map[string]string{"message": "invalid command"})
 	}
+}
+
+func commandRequiresTenantTarget(result CommandResult) bool {
+	return !result.IsHelp && (result.Found || result.MissingEnv)
 }
 
 // postComment posts a comment on a PR.


### PR DESCRIPTION
## Summary

Require tenant-scoped deployments to ignore untargeted work-bearing PR commands before reacting or commenting. A deployment with `tenant: alpha` now handles `schemabot plan -e production -t alpha`, while `schemabot plan -e production` remains available to deployments without tenant mode and is ignored by tenant-scoped deployments.

Help and invalid-command responses continue to use `respond_to_unscoped`, so operators can still designate one deployment to answer unscoped UX commands. This keeps manual tenant routing explicit while leaving room for a future coordinated multi-tenant command.

🤖 Generated with Amp.
