### PR TITLE
feat(auth): cache the CLI token per profile with hardened file permissions

### DIFF
--- a/pkg/cmd/client/config.go
+++ b/pkg/cmd/client/config.go
@@ -2,9 +2,12 @@ package client
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 
+	"github.com/block/spirit/pkg/utils"
 	"gopkg.in/yaml.v3"
 )
 
@@ -17,6 +20,10 @@ type Config struct {
 // Profile represents a named configuration profile.
 type Profile struct {
 	Endpoint string `yaml:"endpoint"`
+	// Token is the cached Bearer token for this profile's endpoint, written by
+	// `schemabot login`. Scoping it to a profile keeps a token bound to the
+	// server it was issued for, so it is never sent to a different endpoint.
+	Token string `yaml:"token,omitempty"`
 }
 
 // ConfigPath returns the path to the config file (~/.schemabot/config.yaml).
@@ -36,24 +43,72 @@ func LoadConfig() (*Config, error) {
 		return nil, err
 	}
 
-	data, err := os.ReadFile(path)
+	// Open once and read the permission bits from the same file descriptor we
+	// read the token from, so the credential check below applies to the exact
+	// file loaded — not a different file swapped in between a separate stat and
+	// read.
+	f, err := os.Open(path)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return &Config{Profiles: make(map[string]Profile)}, nil
 		}
-		return nil, fmt.Errorf("read config: %w", err)
+		return nil, fmt.Errorf("open config %s: %w", path, err)
+	}
+	defer utils.CloseAndLog(f)
+
+	info, err := f.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("stat config %s: %w", path, err)
+	}
+
+	data, err := io.ReadAll(f)
+	if err != nil {
+		return nil, fmt.Errorf("read config %s: %w", path, err)
 	}
 
 	var cfg Config
 	if err := yaml.Unmarshal(data, &cfg); err != nil {
-		return nil, fmt.Errorf("parse config: %w", err)
+		return nil, fmt.Errorf("parse config %s: %w", path, err)
 	}
 
 	if cfg.Profiles == nil {
 		cfg.Profiles = make(map[string]Profile)
 	}
 
+	// A config that caches a token is a credential file: refuse to use it if it
+	// is accessible by other users, so a leaked-permission token fails closed.
+	if configHasToken(&cfg) {
+		if err := requireSecureConfigMode(path, info.Mode()); err != nil {
+			return nil, err
+		}
+	}
+
 	return &cfg, nil
+}
+
+// configHasToken reports whether any profile carries a cached token.
+func configHasToken(cfg *Config) bool {
+	for _, p := range cfg.Profiles {
+		if p.Token != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// requireSecureConfigMode verifies the config file is not readable or writable
+// by group or other users. The mode comes from an fstat on the open file the
+// token was read from, so the check applies to that exact file. On Windows the
+// reported mode is synthetic, so file ACLs are relied on instead and the check
+// is skipped.
+func requireSecureConfigMode(path string, mode os.FileMode) error {
+	if runtime.GOOS == "windows" {
+		return nil
+	}
+	if perm := mode.Perm(); perm&0o077 != 0 {
+		return fmt.Errorf("config file %s caches a token but is accessible by other users (mode %#o); restrict it with: chmod 600 %s", path, perm, path)
+	}
+	return nil
 }
 
 // SaveConfig saves the configuration to ~/.schemabot/config.yaml.
@@ -154,13 +209,40 @@ func ResolveEndpointWithProfile(endpointFlag, profileFlag string, configEndpoint
 // ResolveToken returns the Bearer token to authenticate with, checking in order:
 // 1. Explicit --token flag
 // 2. SCHEMABOT_TOKEN environment variable
+// 3. Cached token on the resolved profile (from `schemabot login`)
 // An empty result means no token is configured, which is correct against a
 // server with auth disabled.
-func ResolveToken(tokenFlag string) string {
+//
+// A cached profile token is bound to the endpoint it was issued for. The
+// endpoint override (--endpoint flag or SCHEMABOT_ENDPOINT) is passed in so the
+// profile token is attached only when the request is actually going to that
+// profile's endpoint: an override pointing elsewhere must never receive a token
+// issued for a different server. An explicit --token / SCHEMABOT_TOKEN always
+// wins, since the caller is supplying a credential for whatever endpoint they
+// chose.
+func ResolveToken(tokenFlag, endpointFlag, profileFlag string) (string, error) {
 	if tokenFlag != "" {
-		return tokenFlag
+		return tokenFlag, nil
 	}
-	return os.Getenv("SCHEMABOT_TOKEN")
+	if env := os.Getenv("SCHEMABOT_TOKEN"); env != "" {
+		return env, nil
+	}
+	profile, err := GetProfile(profileFlag)
+	if err != nil {
+		return "", err
+	}
+	if profile.Token == "" {
+		return "", nil
+	}
+
+	endpointOverride := endpointFlag
+	if endpointOverride == "" {
+		endpointOverride = os.Getenv("SCHEMABOT_ENDPOINT")
+	}
+	if endpointOverride != "" && trimSlash(endpointOverride) != trimSlash(profile.Endpoint) {
+		return "", nil
+	}
+	return profile.Token, nil
 }
 
 func trimSlash(s string) string {

--- a/pkg/cmd/client/config_token_test.go
+++ b/pkg/cmd/client/config_token_test.go
@@ -1,24 +1,159 @@
 package client
 
 import (
+	"os"
+	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
+// writeConfig writes a CLI config into an isolated HOME so resolution goes
+// through the normal config path without touching the developer's real config.
+func writeConfig(t *testing.T, cfg *Config, mode os.FileMode) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	dir := filepath.Join(home, ".schemabot")
+	require.NoError(t, os.MkdirAll(dir, 0o700))
+	data, err := yaml.Marshal(cfg)
+	require.NoError(t, err)
+	path := filepath.Join(dir, "config.yaml")
+	require.NoError(t, os.WriteFile(path, data, 0o600))
+	// Force the exact mode with Chmod, which (unlike WriteFile) is not masked by
+	// the process umask, so the permission checks are exercised deterministically.
+	require.NoError(t, os.Chmod(path, mode))
+}
+
 func TestResolveToken(t *testing.T) {
-	t.Run("flag takes precedence over env", func(t *testing.T) {
+	t.Run("flag takes precedence over env and profile", func(t *testing.T) {
+		writeConfig(t, &Config{Profiles: map[string]Profile{"default": {Token: "from-profile"}}}, 0o600)
 		t.Setenv("SCHEMABOT_TOKEN", "from-env")
-		assert.Equal(t, "from-flag", ResolveToken("from-flag"))
+		tok, err := ResolveToken("from-flag", "", "")
+		require.NoError(t, err)
+		assert.Equal(t, "from-flag", tok)
 	})
 
-	t.Run("falls back to env when flag is empty", func(t *testing.T) {
+	t.Run("env takes precedence over profile", func(t *testing.T) {
+		writeConfig(t, &Config{Profiles: map[string]Profile{"default": {Token: "from-profile"}}}, 0o600)
 		t.Setenv("SCHEMABOT_TOKEN", "from-env")
-		assert.Equal(t, "from-env", ResolveToken(""))
+		tok, err := ResolveToken("", "", "")
+		require.NoError(t, err)
+		assert.Equal(t, "from-env", tok)
 	})
 
-	t.Run("empty when neither is set", func(t *testing.T) {
+	t.Run("falls back to profile token", func(t *testing.T) {
+		writeConfig(t, &Config{
+			DefaultProfile: "default",
+			Profiles:       map[string]Profile{"default": {Endpoint: "https://sb.example.com", Token: "from-profile"}},
+		}, 0o600)
 		t.Setenv("SCHEMABOT_TOKEN", "")
-		assert.Empty(t, ResolveToken(""))
+		tok, err := ResolveToken("", "", "")
+		require.NoError(t, err)
+		assert.Equal(t, "from-profile", tok)
 	})
+
+	t.Run("empty when nothing is configured", func(t *testing.T) {
+		writeConfig(t, &Config{Profiles: map[string]Profile{}}, 0o600)
+		t.Setenv("SCHEMABOT_TOKEN", "")
+		tok, err := ResolveToken("", "", "")
+		require.NoError(t, err)
+		assert.Empty(t, tok)
+	})
+
+	t.Run("profile token withheld when endpoint flag overrides to another server", func(t *testing.T) {
+		writeConfig(t, &Config{
+			DefaultProfile: "default",
+			Profiles:       map[string]Profile{"default": {Endpoint: "https://sb.example.com", Token: "from-profile"}},
+		}, 0o600)
+		t.Setenv("SCHEMABOT_TOKEN", "")
+		tok, err := ResolveToken("", "https://other.example.com", "")
+		require.NoError(t, err)
+		assert.Empty(t, tok)
+	})
+
+	t.Run("profile token withheld when SCHEMABOT_ENDPOINT overrides to another server", func(t *testing.T) {
+		writeConfig(t, &Config{
+			DefaultProfile: "default",
+			Profiles:       map[string]Profile{"default": {Endpoint: "https://sb.example.com", Token: "from-profile"}},
+		}, 0o600)
+		t.Setenv("SCHEMABOT_TOKEN", "")
+		t.Setenv("SCHEMABOT_ENDPOINT", "https://other.example.com")
+		tok, err := ResolveToken("", "", "")
+		require.NoError(t, err)
+		assert.Empty(t, tok)
+	})
+
+	t.Run("profile token kept when endpoint override matches the profile endpoint", func(t *testing.T) {
+		writeConfig(t, &Config{
+			DefaultProfile: "default",
+			Profiles:       map[string]Profile{"default": {Endpoint: "https://sb.example.com", Token: "from-profile"}},
+		}, 0o600)
+		t.Setenv("SCHEMABOT_TOKEN", "")
+		tok, err := ResolveToken("", "https://sb.example.com/", "")
+		require.NoError(t, err)
+		assert.Equal(t, "from-profile", tok)
+	})
+
+	t.Run("explicit token wins even when endpoint is overridden", func(t *testing.T) {
+		writeConfig(t, &Config{
+			DefaultProfile: "default",
+			Profiles:       map[string]Profile{"default": {Endpoint: "https://sb.example.com", Token: "from-profile"}},
+		}, 0o600)
+		t.Setenv("SCHEMABOT_TOKEN", "")
+		tok, err := ResolveToken("from-flag", "https://other.example.com", "")
+		require.NoError(t, err)
+		assert.Equal(t, "from-flag", tok)
+	})
+}
+
+func TestLoadConfigRejectsInsecurePermsWhenTokenPresent(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission bits are synthetic on Windows")
+	}
+	writeConfig(t, &Config{Profiles: map[string]Profile{"default": {Token: "secret-token"}}}, 0o644)
+
+	_, err := LoadConfig()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "accessible by other users")
+}
+
+func TestLoadConfigRejectsInsecurePermsWhenTokenInNonDefaultProfile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission bits are synthetic on Windows")
+	}
+	// The credential check guards the file, not a single profile: a token cached
+	// in any profile makes the whole config a credential file.
+	writeConfig(t, &Config{
+		DefaultProfile: "default",
+		Profiles: map[string]Profile{
+			"default": {Endpoint: "https://sb.example.com"},
+			"prod":    {Endpoint: "https://prod.example.com", Token: "secret-token"},
+		},
+	}, 0o644)
+
+	_, err := LoadConfig()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "accessible by other users")
+}
+
+func TestLoadConfigAllowsInsecurePermsWithoutToken(t *testing.T) {
+	// A token-less config carries no secret, so loose permissions must not
+	// block ordinary endpoint resolution (backward compatible).
+	writeConfig(t, &Config{Profiles: map[string]Profile{"default": {Endpoint: "https://sb.example.com"}}}, 0o644)
+
+	cfg, err := LoadConfig()
+	require.NoError(t, err)
+	assert.Equal(t, "https://sb.example.com", cfg.Profiles["default"].Endpoint)
+}
+
+func TestLoadConfigAllowsSecurePermsWithToken(t *testing.T) {
+	writeConfig(t, &Config{Profiles: map[string]Profile{"default": {Token: "secret-token"}}}, 0o600)
+
+	cfg, err := LoadConfig()
+	require.NoError(t, err)
+	assert.Equal(t, "secret-token", cfg.Profiles["default"].Token)
 }

--- a/pkg/cmd/main.go
+++ b/pkg/cmd/main.go
@@ -64,9 +64,14 @@ func main() {
 
 	// Authenticate every API request with the resolved Bearer token. Empty when
 	// no token is configured, which is correct against a server with auth off.
-	client.SetAuthToken(client.ResolveToken(cli.Token))
+	token, err := client.ResolveToken(cli.Token, cli.Endpoint, cli.Profile)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "\033[31mError: %v\033[0m\n", err)
+		os.Exit(1)
+	}
+	client.SetAuthToken(token)
 
-	err := ctx.Run(&cli.Globals)
+	err = ctx.Run(&cli.Globals)
 	if err != nil {
 		// ErrSilent means the error was already displayed - just exit with code 1
 		if !errors.Is(err, commands.ErrSilent) {


### PR DESCRIPTION
**Why this matters**

The CLI needs somewhere to store a Bearer token so users don't re-paste it on every command — and a cached credential on disk must fail closed if its file permissions leak. This is the storage foundation for an interactive `schemabot login`. It lands dark: nothing writes a token yet, and token-less configs are completely unaffected, so a server with auth disabled keeps working with no token at all.

**What it does**

- Adds a per-profile `token` field to `~/.schemabot/config.yaml`, binding a token to the endpoint it was issued for so it is never sent to a different server.
- Token resolution now falls back to the stored profile token after `--token` and `SCHEMABOT_TOKEN` (flag > env > profile).
- When any profile caches a token, the config is treated as a credential file: loading one that is readable or writable by group/other fails closed with a `chmod 600` hint. The permission bits are read from the same file descriptor the token is read from, so the check can't be sidestepped by a file swapped in between a separate stat and read. Token-less configs keep working at any permission. The check is skipped on Windows, where the reported mode is synthetic and file ACLs govern access instead.

**How it fits**

Part of the optional client-side authentication workstream. Each piece lands dark behind the default allow-all authorizer; this one is the credential store that a later `login` command (interactive auth-code flow) writes into.
