### PR TITLE
fix(github): scope comment titles by environment

### DIFF
--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -11,9 +11,9 @@ All templates rendered with sample data.
 <summary><a name="mysql-plan"></a><strong>MySQL Plan</strong></summary>
 
 
-## MySQL Schema Change Plan
+## Schema Change Plan — Staging
 
-**Database**: `testapp` | **Schema Name**: `testapp` | **Environment**: `staging`
+**Database**: `testapp` | **Type**: `MySQL` | **Schema Name**: `testapp`
 
 *Requested by @jackjackbits at 2026-01-01 00:00:00 UTC · planned from [`abcdef1`](https://github.com/block/schemabot/commit/abcdef1234567890abcdef1234567890abcdef12)*
 
@@ -59,12 +59,59 @@ schemabot apply -e staging
 </details>
 
 <details>
+<summary><a name="mysql-plan-tenant-target"></a><strong>MySQL Plan (Tenant Target)</strong></summary>
+
+
+## Schema Change Plan — Staging
+
+**Database**: `testapp` | **Type**: `MySQL` | **Schema Name**: `testapp` | **Tenant**: `alpha`
+
+*Requested by @jackjackbits at 2026-01-01 00:00:00 UTC · planned from [`abcdef1`](https://github.com/block/schemabot/commit/abcdef1234567890abcdef1234567890abcdef12)*
+
+```sql
+CREATE TABLE `users` (
+    `id` bigint unsigned NOT NULL AUTO_INCREMENT,
+    `email` varchar(255) NOT NULL,
+    `created_at` timestamp DEFAULT current_timestamp(),
+    PRIMARY KEY(`id`),
+    INDEX `idx_email`(`email`)
+) ENGINE InnoDB,
+  CHARSET utf8mb4,
+  COLLATE utf8mb4_0900_ai_ci;
+
+CREATE TABLE `orders` (
+    `id` bigint unsigned NOT NULL AUTO_INCREMENT,
+    `user_id` bigint NOT NULL,
+    `total_cents` bigint NOT NULL,
+    `status` varchar(50) NOT NULL DEFAULT 'pending',
+    PRIMARY KEY(`id`),
+    INDEX `idx_user_id`(`user_id`)
+) ENGINE InnoDB,
+  CHARSET utf8mb4,
+  COLLATE utf8mb4_0900_ai_ci;
+
+ALTER TABLE `products` ADD INDEX `idx_category_price`(`category`, `price`);
+```
+
+📋 **Plan**: **2** tables to create, **1** table to alter
+
+
+---
+
+💡 **To apply** all schema changes from this PR, comment:
+```
+schemabot apply -e staging --tenant alpha
+```
+
+</details>
+
+<details>
 <summary><a name="mysql-plan-no-changes"></a><strong>MySQL Plan (No Changes)</strong></summary>
 
 
-## MySQL Schema Change Plan
+## Schema Change Plan — Staging
 
-**Database**: `testapp` | **Schema Name**: `testapp` | **Environment**: `staging`
+**Database**: `testapp` | **Type**: `MySQL` | **Schema Name**: `testapp`
 
 *Requested by @jackjackbits at 2026-01-01 00:00:00 UTC · planned from [`abcdef1`](https://github.com/block/schemabot/commit/abcdef1234567890abcdef1234567890abcdef12)*
 
@@ -162,9 +209,9 @@ Choose one:
 <summary><a name="vitess-plan"></a><strong>Vitess Plan</strong></summary>
 
 
-## Vitess Schema Change Plan
+## Schema Change Plan — Staging
 
-**Database**: `commerce` | **Environment**: `staging`
+**Database**: `commerce` | **Type**: `Vitess`
 
 *Requested by @jackjackbits at 2026-01-01 00:00:00 UTC · planned from [`abcdef1`](https://github.com/block/schemabot/commit/abcdef1234567890abcdef1234567890abcdef12)*
 
@@ -250,9 +297,9 @@ schemabot apply -e staging
 <summary><a name="schema-change-apply-locked--options"></a><strong>Schema Change Apply (Locked + Options)</strong></summary>
 
 
-## Schema Change Apply
+## Schema Change Apply — Staging
 
-**Database**: `commerce` | **Environment**: `staging`
+**Database**: `commerce` | **Type**: `Vitess`
 
 *Requested by @jackjackbits at 2026-01-01 00:00:00 UTC · planned from [`abcdef1`](https://github.com/block/schemabot/commit/abcdef1234567890abcdef1234567890abcdef12)*
 
@@ -347,9 +394,9 @@ schemabot unlock
 <summary><a name="mysql-multischema-plan"></a><strong>MySQL Multi-schema Plan</strong></summary>
 
 
-## MySQL Schema Change Plan
+## Schema Change Plan — Staging
 
-**Database**: `myapp` | **Environment**: `staging`
+**Database**: `myapp` | **Type**: `MySQL`
 
 *Requested by @jackjackbits at 2026-01-01 00:00:00 UTC · planned from [`abcdef1`](https://github.com/block/schemabot/commit/abcdef1234567890abcdef1234567890abcdef12)*
 
@@ -390,9 +437,9 @@ schemabot apply -e staging
 <summary><a name="multienv-plan-identical"></a><strong>Multi-env Plan (Identical)</strong></summary>
 
 
-## MySQL Schema Change Plan
+## Schema Change Plan
 
-**Database**: `testapp`
+**Database**: `testapp` | **Type**: `MySQL` | **Schema Name**: `testapp`
 
 *Requested by @jackjackbits at 2026-01-01 00:00:00 UTC · planned from [`abcdef1`](https://github.com/block/schemabot/commit/abcdef1234567890abcdef1234567890abcdef12)*
 
@@ -443,9 +490,9 @@ schemabot apply -e production
 <summary><a name="multienv-plan-different"></a><strong>Multi-env Plan (Different)</strong></summary>
 
 
-## MySQL Schema Change Plan
+## Schema Change Plan
 
-**Database**: `testapp`
+**Database**: `testapp` | **Type**: `MySQL` | **Schema Name**: `testapp`
 
 *Requested by @jackjackbits at 2026-01-01 00:00:00 UTC · planned from [`abcdef1`](https://github.com/block/schemabot/commit/abcdef1234567890abcdef1234567890abcdef12)*
 
@@ -495,9 +542,9 @@ schemabot apply -e production
 <summary><a name="multienv-plan-error"></a><strong>Multi-env Plan (Error)</strong></summary>
 
 
-## MySQL Schema Change Plan
+## Schema Change Plan
 
-**Database**: `testapp`
+**Database**: `testapp` | **Type**: `MySQL` | **Schema Name**: `testapp`
 
 *Requested by @jackjackbits at 2026-01-01 00:00:00 UTC · planned from [`abcdef1`](https://github.com/block/schemabot/commit/abcdef1234567890abcdef1234567890abcdef12)*
 
@@ -553,9 +600,9 @@ schemabot plan -e production
 <summary><a name="multienv-plan-lint-warnings"></a><strong>Multi-env Plan (Lint Warnings)</strong></summary>
 
 
-## MySQL Schema Change Plan
+## Schema Change Plan
 
-**Database**: `testapp`
+**Database**: `testapp` | **Type**: `MySQL` | **Schema Name**: `testapp`
 
 *Started at 2026-01-01 00:00:00 UTC · planned from [`abcdef1`](https://github.com/block/schemabot/commit/abcdef1234567890abcdef1234567890abcdef12)*
 
@@ -610,9 +657,9 @@ schemabot apply -e production
 <summary><a name="drop-column-blocked"></a><strong>Drop Column Blocked</strong></summary>
 
 
-## MySQL Schema Change Plan
+## Schema Change Plan — Staging
 
-**Database**: `testapp` | **Schema Name**: `testapp` | **Environment**: `staging`
+**Database**: `testapp` | **Type**: `MySQL` | **Schema Name**: `testapp`
 
 *Requested by @jackjackbits at 2026-01-01 00:00:00 UTC · planned from [`abcdef1`](https://github.com/block/schemabot/commit/abcdef1234567890abcdef1234567890abcdef12)*
 
@@ -692,9 +739,9 @@ That command wasn't recognized. Available commands:
 
 ### Apply failure
 
-## ❌ Schema Change Failed
+## ❌ Schema Change Failed — Staging
 
-**Database**: `testapp` | **Environment**: `staging` | **Apply ID**: `apply-a1b2c3d4e5f6` | **Elapsed**: 8m
+**Database**: `testapp` | **Apply ID**: `apply-a1b2c3d4e5f6`
 
 *Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
 
@@ -1134,9 +1181,9 @@ Production
 <summary><a name="apply-blocked-by-other-pr"></a><strong>Apply Blocked By Other PR</strong></summary>
 
 
-## 🔒 Apply Blocked
+## 🔒 Apply Blocked — Staging
 
-**Database**: `testapp` | **Environment**: `staging`
+**Database**: `testapp`
 
 *Requested by @jackjackbits at 2026-01-01 00:00:00 UTC*
 
@@ -1153,9 +1200,9 @@ Wait for the other PR to complete or ask the lock holder to run `schemabot unloc
 <summary><a name="apply-blocked-by-cli"></a><strong>Apply Blocked By CLI</strong></summary>
 
 
-## 🔒 Apply Blocked
+## 🔒 Apply Blocked — Staging
 
-**Database**: `testapp` | **Environment**: `staging`
+**Database**: `testapp`
 
 *Requested by @jackjackbits at 2026-01-01 00:00:00 UTC*
 
@@ -1175,9 +1222,9 @@ schemabot unlock -d testapp --force
 <summary><a name="unlock-success"></a><strong>Unlock Success</strong></summary>
 
 
-## 🔓 Lock Released
+## 🔓 Lock Released — Staging
 
-**Database**: `testapp` | **Environment**: `staging`
+**Database**: `testapp`
 
 *Released by @jackjackbits at 2026-01-01 00:00:00 UTC*
 
@@ -1189,9 +1236,9 @@ The database is now available for schema changes.
 <summary><a name="apply-already-in-progress"></a><strong>Apply Already In Progress</strong></summary>
 
 
-## ⚠️ Apply Already In Progress
+## ⚠️ Apply Already In Progress — Staging
 
-**Database**: `testapp` | **Environment**: `staging`
+**Database**: `testapp`
 
 *Requested by @jackjackbits at 2026-01-01 00:00:00 UTC*
 
@@ -1205,9 +1252,9 @@ Wait for it to complete or stop it first.
 <summary><a name="no-lock-found"></a><strong>No Lock Found</strong></summary>
 
 
-## 🔒 No Lock Found
+## 🔒 No Lock Found — Staging
 
-**Database**: `testapp` | **Environment**: `staging`
+**Database**: `testapp`
 
 No apply lock is held for this database. Run `apply` first to generate a plan and acquire the lock.
 
@@ -1221,9 +1268,9 @@ schemabot apply -e staging
 <summary><a name="blocked-by-prior-env-pending"></a><strong>Blocked By Prior Env (Pending)</strong></summary>
 
 
-## ❌ Apply Blocked
+## ❌ Apply Blocked — Production
 
-**Database**: `testapp` | **Environment**: `production`
+**Database**: `testapp`
 
 Staging has pending changes. Apply staging first before applying to production.
 
@@ -1237,9 +1284,9 @@ schemabot apply -e staging
 <summary><a name="blocked-by-prior-env-failed"></a><strong>Blocked By Prior Env (Failed)</strong></summary>
 
 
-## ❌ Apply Blocked
+## ❌ Apply Blocked — Production
 
-**Database**: `testapp` | **Environment**: `production`
+**Database**: `testapp`
 
 Staging failed. Fix the issue and re-apply staging before applying to production.
 
@@ -1253,9 +1300,9 @@ schemabot apply -e staging
 <summary><a name="blocked-by-prior-env-in-progress"></a><strong>Blocked By Prior Env (In Progress)</strong></summary>
 
 
-## ⏳ Apply Blocked
+## ⏳ Apply Blocked — Production
 
-**Database**: `testapp` | **Environment**: `production`
+**Database**: `testapp`
 
 Staging is currently in progress. Wait for it to complete before applying to production.
 
@@ -1455,9 +1502,9 @@ No active locks.
 <summary><a name="schema-change-apply-lock--confirm"></a><strong>Schema Change Apply (Lock + Confirm)</strong></summary>
 
 
-## Schema Change Apply
+## Schema Change Apply — Staging
 
-**Database**: `testapp` | **Schema Name**: `testapp` | **Environment**: `staging`
+**Database**: `testapp` | **Type**: `MySQL` | **Schema Name**: `testapp`
 
 *Requested by @jackjackbits at 2026-01-01 00:00:00 UTC · planned from [`abcdef1`](https://github.com/block/schemabot/commit/abcdef1234567890abcdef1234567890abcdef12)*
 
@@ -1509,9 +1556,9 @@ schemabot unlock
 <summary><a name="schema-change-apply-with-options"></a><strong>Schema Change Apply (With Options)</strong></summary>
 
 
-## Schema Change Apply
+## Schema Change Apply — Staging
 
-**Database**: `testapp` | **Schema Name**: `testapp` | **Environment**: `staging`
+**Database**: `testapp` | **Type**: `MySQL` | **Schema Name**: `testapp`
 
 *Requested by @jackjackbits at 2026-01-01 00:00:00 UTC · planned from [`abcdef1`](https://github.com/block/schemabot/commit/abcdef1234567890abcdef1234567890abcdef12)*
 
@@ -1565,9 +1612,9 @@ schemabot unlock
 <summary><a name="schema-change-apply-vitess--options"></a><strong>Schema Change Apply (Vitess + Options)</strong></summary>
 
 
-## Schema Change Apply
+## Schema Change Apply — Staging
 
-**Database**: `commerce` | **Environment**: `staging`
+**Database**: `commerce` | **Type**: `Vitess`
 
 *Requested by @jackjackbits at 2026-01-01 00:00:00 UTC · planned from [`abcdef1`](https://github.com/block/schemabot/commit/abcdef1234567890abcdef1234567890abcdef12)*
 
@@ -1662,9 +1709,9 @@ schemabot unlock
 <summary><a name="apply-started"></a><strong>Apply Started</strong></summary>
 
 
-## Schema Change In Progress
+## Schema Change In Progress — Staging
 
-**Database**: `testapp` | **Environment**: `staging` | **Apply ID**: `apply-a1b2c3d4e5f6`
+**Database**: `testapp` | **Apply ID**: `apply-a1b2c3d4e5f6`
 
 *Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
 
@@ -1676,9 +1723,9 @@ Schema changes are being applied. Progress updates will be posted as new comment
 <summary><a name="single-table-running"></a><strong>Single Table: Running</strong></summary>
 
 
-## Schema Change In Progress
+## Schema Change In Progress — Staging
 
-**Database**: `testapp` | **Environment**: `staging` | **Apply ID**: `apply-a1b2c3d4e5f6` | **Elapsed**: 8m
+**Database**: `testapp` | **Apply ID**: `apply-a1b2c3d4e5f6`
 
 *Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
 
@@ -1707,9 +1754,9 @@ _Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:0
 <summary><a name="single-table-completed"></a><strong>Single Table: Completed</strong></summary>
 
 
-## ✅ Schema Change Applied
+## ✅ Schema Change Applied — Staging
 
-**Database**: `testapp` | **Environment**: `staging` | **Apply ID**: `apply-a1b2c3d4e5f6` | **Elapsed**: 8m
+**Database**: `testapp` | **Apply ID**: `apply-a1b2c3d4e5f6`
 
 *Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
 
@@ -1728,9 +1775,9 @@ ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
 <summary><a name="single-table-failed"></a><strong>Single Table: Failed</strong></summary>
 
 
-## ❌ Schema Change Failed
+## ❌ Schema Change Failed — Staging
 
-**Database**: `testapp` | **Environment**: `staging` | **Apply ID**: `apply-a1b2c3d4e5f6` | **Elapsed**: 8m
+**Database**: `testapp` | **Apply ID**: `apply-a1b2c3d4e5f6`
 
 *Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
 
@@ -1758,9 +1805,9 @@ schemabot apply -e staging
 <summary><a name="single-table-stopped"></a><strong>Single Table: Stopped</strong></summary>
 
 
-## ⏹️ Schema Change Stopped
+## ⏹️ Schema Change Stopped — Staging
 
-**Database**: `testapp` | **Environment**: `staging` | **Apply ID**: `apply-a1b2c3d4e5f6` | **Elapsed**: 8m
+**Database**: `testapp` | **Apply ID**: `apply-a1b2c3d4e5f6`
 
 *Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
 
@@ -1787,9 +1834,9 @@ schemabot start apply-a1b2c3d4e5f6 -e staging
 <summary><a name="all-pending"></a><strong>All Pending</strong></summary>
 
 
-## Schema Change In Progress
+## Schema Change In Progress — Staging
 
-**Database**: `testapp` | **Environment**: `staging` | **Apply ID**: `apply-a1b2c3d4e5f6` | **Elapsed**: 8m
+**Database**: `testapp` | **Apply ID**: `apply-a1b2c3d4e5f6`
 
 *Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
 
@@ -1831,9 +1878,9 @@ _Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:0
 <summary><a name="first-table-running"></a><strong>First Table Running</strong></summary>
 
 
-## Schema Change In Progress
+## Schema Change In Progress — Staging
 
-**Database**: `testapp` | **Environment**: `staging` | **Apply ID**: `apply-a1b2c3d4e5f6` | **Elapsed**: 8m
+**Database**: `testapp` | **Apply ID**: `apply-a1b2c3d4e5f6`
 
 *Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
 
@@ -1876,9 +1923,9 @@ _Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:0
 <summary><a name="second-table-running"></a><strong>Second Table Running</strong></summary>
 
 
-## Schema Change In Progress
+## Schema Change In Progress — Staging
 
-**Database**: `testapp` | **Environment**: `staging` | **Apply ID**: `apply-a1b2c3d4e5f6` | **Elapsed**: 8m
+**Database**: `testapp` | **Apply ID**: `apply-a1b2c3d4e5f6`
 
 *Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
 
@@ -1921,9 +1968,9 @@ _Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:0
 <summary><a name="second-table-estimate-exceeded"></a><strong>Second Table Estimate Exceeded</strong></summary>
 
 
-## Schema Change In Progress
+## Schema Change In Progress — Staging
 
-**Database**: `testapp` | **Environment**: `staging` | **Apply ID**: `apply-a1b2c3d4e5f6` | **Elapsed**: 8m
+**Database**: `testapp` | **Apply ID**: `apply-a1b2c3d4e5f6`
 
 *Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
 
@@ -1967,9 +2014,9 @@ _Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:0
 <summary><a name="third-table-running"></a><strong>Third Table Running</strong></summary>
 
 
-## Schema Change In Progress
+## Schema Change In Progress — Staging
 
-**Database**: `testapp` | **Environment**: `staging` | **Apply ID**: `apply-a1b2c3d4e5f6` | **Elapsed**: 8m
+**Database**: `testapp` | **Apply ID**: `apply-a1b2c3d4e5f6`
 
 *Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
 
@@ -2012,9 +2059,9 @@ _Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:0
 <summary><a name="sharded-shard-progress"></a><strong>Sharded: Shard Progress</strong></summary>
 
 
-## Schema Change In Progress
+## Schema Change In Progress — Staging
 
-**Database**: `commerce` | **Environment**: `staging` | **Apply ID**: `apply-7aa13cf03496454b`
+**Database**: `commerce` | **Apply ID**: `apply-7aa13cf03496454b`
 
 *Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
 
@@ -2044,9 +2091,9 @@ _Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:0
 <summary><a name="sharded-many-shards-256"></a><strong>Sharded: Many Shards (256)</strong></summary>
 
 
-## Schema Change In Progress
+## Schema Change In Progress — Staging
 
-**Database**: `commerce` | **Environment**: `staging` | **Apply ID**: `apply-7aa13cf03496454b`
+**Database**: `commerce` | **Apply ID**: `apply-7aa13cf03496454b`
 
 *Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
 
@@ -2076,9 +2123,9 @@ _Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:0
 <summary><a name="all-completed"></a><strong>All Completed</strong></summary>
 
 
-## ✅ Schema Change Applied
+## ✅ Schema Change Applied — Staging
 
-**Database**: `testapp` | **Environment**: `staging` | **Apply ID**: `apply-a1b2c3d4e5f6` | **Elapsed**: 8m
+**Database**: `testapp` | **Apply ID**: `apply-a1b2c3d4e5f6`
 
 *Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
 
@@ -2111,9 +2158,9 @@ ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
 <summary><a name="vitess-vschema-only"></a><strong>Vitess: VSchema Only</strong></summary>
 
 
-## Schema Change In Progress
+## Schema Change In Progress — Staging
 
-**Database**: `testapp` | **Environment**: `staging` | **Apply ID**: `apply-a1b2c3d4e5f6` | **Elapsed**: 8m
+**Database**: `testapp` | **Apply ID**: `apply-a1b2c3d4e5f6`
 
 *Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
 
@@ -2141,9 +2188,9 @@ _Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:0
 <summary><a name="vitess-ddl--vschema"></a><strong>Vitess: DDL + VSchema</strong></summary>
 
 
-## Schema Change In Progress
+## Schema Change In Progress — Staging
 
-**Database**: `testapp` | **Environment**: `staging` | **Apply ID**: `apply-a1b2c3d4e5f6` | **Elapsed**: 8m
+**Database**: `testapp` | **Apply ID**: `apply-a1b2c3d4e5f6`
 
 *Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
 
@@ -2180,9 +2227,9 @@ _Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:0
 <summary><a name="vitess-multikeyspace-vschema"></a><strong>Vitess: Multi-keyspace VSchema</strong></summary>
 
 
-## Schema Change In Progress
+## Schema Change In Progress — Staging
 
-**Database**: `testapp` | **Environment**: `staging` | **Apply ID**: `apply-a1b2c3d4e5f6` | **Elapsed**: 8m
+**Database**: `testapp` | **Apply ID**: `apply-a1b2c3d4e5f6`
 
 *Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
 
@@ -2216,9 +2263,9 @@ _Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:0
 <summary><a name="first-table-failed"></a><strong>First Table Failed</strong></summary>
 
 
-## ❌ Schema Change Failed
+## ❌ Schema Change Failed — Staging
 
-**Database**: `testapp` | **Environment**: `staging` | **Apply ID**: `apply-a1b2c3d4e5f6` | **Elapsed**: 8m
+**Database**: `testapp` | **Apply ID**: `apply-a1b2c3d4e5f6`
 
 *Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
 
@@ -2260,9 +2307,9 @@ schemabot apply -e staging
 <summary><a name="middle-table-failed"></a><strong>Middle Table Failed</strong></summary>
 
 
-## ❌ Schema Change Failed
+## ❌ Schema Change Failed — Staging
 
-**Database**: `testapp` | **Environment**: `staging` | **Apply ID**: `apply-a1b2c3d4e5f6` | **Elapsed**: 8m
+**Database**: `testapp` | **Apply ID**: `apply-a1b2c3d4e5f6`
 
 *Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
 
@@ -2304,9 +2351,9 @@ schemabot apply -e staging
 <summary><a name="stopped"></a><strong>Stopped</strong></summary>
 
 
-## ⏹️ Schema Change Stopped
+## ⏹️ Schema Change Stopped — Staging
 
-**Database**: `testapp` | **Environment**: `staging` | **Apply ID**: `apply-a1b2c3d4e5f6` | **Elapsed**: 8m
+**Database**: `testapp` | **Apply ID**: `apply-a1b2c3d4e5f6`
 
 *Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
 
@@ -2341,11 +2388,13 @@ schemabot start apply-a1b2c3d4e5f6 -e staging
 <summary><a name="resuming"></a><strong>Resuming</strong></summary>
 
 
-## Schema Change — Resuming
+## Schema Change In Progress — Staging
 
-**Database**: `testapp` | **Environment**: `staging` | **Apply ID**: `apply-a1b2c3d4e5f6` | **Elapsed**: 8m
+**Database**: `testapp` | **Apply ID**: `apply-a1b2c3d4e5f6`
 
 *Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
+
+**Status**: Resuming
 
 ### Table Progress
 
@@ -2370,9 +2419,9 @@ _Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:0
 <summary><a name="cancelled"></a><strong>Cancelled</strong></summary>
 
 
-## 🚫 Schema Change Cancelled
+## 🚫 Schema Change Cancelled — Staging
 
-**Database**: `testapp` | **Environment**: `staging` | **Apply ID**: `apply-a1b2c3d4e5f6` | **Elapsed**: 8m
+**Database**: `testapp` | **Apply ID**: `apply-a1b2c3d4e5f6`
 
 *Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
 
@@ -2403,11 +2452,13 @@ This schema change was cancelled and cannot be resumed. Open a new schema change
 <summary><a name="waiting-for-cutover"></a><strong>Waiting For Cutover</strong></summary>
 
 
-## Schema Change — Waiting for Cutover
+## Schema Change In Progress — Staging
 
-**Database**: `testapp` | **Environment**: `staging` | **Apply ID**: `apply-a1b2c3d4e5f6` | **Elapsed**: 8m
+**Database**: `testapp` | **Apply ID**: `apply-a1b2c3d4e5f6`
 
 *Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
+
+**Status**: Waiting for Cutover
 
 **0/3** table(s) ready for cutover — waiting on 3
 
@@ -2449,11 +2500,13 @@ _Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:0
 <summary><a name="cutting-over"></a><strong>Cutting Over</strong></summary>
 
 
-## Schema Change — Cutting Over
+## Schema Change In Progress — Staging
 
-**Database**: `testapp` | **Environment**: `staging` | **Apply ID**: `apply-a1b2c3d4e5f6` | **Elapsed**: 8m
+**Database**: `testapp` | **Apply ID**: `apply-a1b2c3d4e5f6`
 
 *Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
+
+**Status**: Cutting Over
 
 **0/3** table(s) ready for cutover — waiting on 3
 
@@ -2552,9 +2605,9 @@ Cutover is already in progress. SchemaBot will keep reporting progress from the 
 <summary><a name="summary-completed"></a><strong>Summary: Completed</strong></summary>
 
 
-## ✅ Schema Change Applied
+## ✅ Schema Change Applied — Staging
 
-**Database**: `testapp` | **Environment**: `staging`
+**Database**: `testapp`
 
 
 > All 3 tables applied successfully — your schema changes are live!
@@ -2582,9 +2635,9 @@ _Apply ID: `apply-a1b2c3d4e5f6`_
 <summary><a name="summary-failed"></a><strong>Summary: Failed</strong></summary>
 
 
-## ❌ Schema Change Failed
+## ❌ Schema Change Failed — Staging
 
-**Database**: `testapp` | **Environment**: `staging` | **Apply ID**: `apply-a1b2c3d4e5f6` | **Duration**: 8m
+**Database**: `testapp` | **Apply ID**: `apply-a1b2c3d4e5f6` | **Duration**: 8m
 
 *Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
 
@@ -2629,9 +2682,9 @@ schemabot apply -e staging
 <summary><a name="summary-stopped"></a><strong>Summary: Stopped</strong></summary>
 
 
-## ⏹️ Schema Change Stopped
+## ⏹️ Schema Change Stopped — Staging
 
-**Database**: `testapp` | **Environment**: `staging` | **Apply ID**: `apply-a1b2c3d4e5f6` | **Duration**: 45m
+**Database**: `testapp` | **Apply ID**: `apply-a1b2c3d4e5f6` | **Duration**: 45m
 
 *Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
 
@@ -2661,9 +2714,9 @@ schemabot start apply-a1b2c3d4e5f6 -e staging
 <summary><a name="summary-cancelled"></a><strong>Summary: Cancelled</strong></summary>
 
 
-## 🚫 Schema Change Cancelled
+## 🚫 Schema Change Cancelled — Staging
 
-**Database**: `testapp` | **Environment**: `staging` | **Apply ID**: `apply-a1b2c3d4e5f6` | **Duration**: 45m
+**Database**: `testapp` | **Apply ID**: `apply-a1b2c3d4e5f6` | **Duration**: 45m
 
 *Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
 
@@ -2690,9 +2743,9 @@ This schema change was cancelled and cannot be resumed. Open a new schema change
 <summary><a name="summary-completed-large"></a><strong>Summary: Completed (Large)</strong></summary>
 
 
-## ✅ Schema Change Applied
+## ✅ Schema Change Applied — Staging
 
-**Database**: `testapp` | **Environment**: `staging`
+**Database**: `testapp`
 
 
 > All 8 tables applied successfully — your schema changes are live!
@@ -2745,9 +2798,9 @@ _Apply ID: `apply-a1b2c3d4e5f6`_
 <summary><a name="summary-failed-large"></a><strong>Summary: Failed (Large)</strong></summary>
 
 
-## ❌ Schema Change Failed
+## ❌ Schema Change Failed — Staging
 
-**Database**: `testapp` | **Environment**: `staging` | **Apply ID**: `apply-a1b2c3d4e5f6` | **Duration**: 3h 30m
+**Database**: `testapp` | **Apply ID**: `apply-a1b2c3d4e5f6` | **Duration**: 3h 30m
 
 *Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
 
@@ -2809,9 +2862,9 @@ schemabot apply -e staging
 <summary><a name="summary-multinamespace-failed"></a><strong>Summary: Multi-namespace Failed</strong></summary>
 
 
-## ❌ Schema Change Failed
+## ❌ Schema Change Failed — Staging
 
-**Database**: `testapp` | **Environment**: `staging` | **Apply ID**: `apply-a1b2c3d4e5f6` | **Duration**: 8m
+**Database**: `testapp` | **Apply ID**: `apply-a1b2c3d4e5f6` | **Duration**: 8m
 
 *Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
 
@@ -2866,9 +2919,9 @@ schemabot apply -e staging
 <summary><a name="summary-multinamespace-completed"></a><strong>Summary: Multi-namespace Completed</strong></summary>
 
 
-## ✅ Schema Change Applied
+## ✅ Schema Change Applied — Staging
 
-**Database**: `testapp` | **Environment**: `staging`
+**Database**: `testapp`
 
 
 > All 5 tables applied successfully — your schema changes are live!
@@ -4410,9 +4463,9 @@ No schema changes found for database 'new-db'
 <summary><a name="apply-gate-schema-change-apply-lock--confirm"></a><strong>Apply Gate: Schema Change Apply (Lock + Confirm)</strong></summary>
 
 
-## Schema Change Apply
+## Schema Change Apply — Staging
 
-**Database**: `testapp` | **Schema Name**: `testapp` | **Environment**: `staging`
+**Database**: `testapp` | **Type**: `MySQL` | **Schema Name**: `testapp`
 
 *Requested by @jackjackbits at 2026-01-01 00:00:00 UTC · planned from [`abcdef1`](https://github.com/block/schemabot/commit/abcdef1234567890abcdef1234567890abcdef12)*
 
@@ -4465,9 +4518,9 @@ schemabot unlock
 <summary><a name="apply-gate-schema-change-apply-with-options"></a><strong>Apply Gate: Schema Change Apply (With Options)</strong></summary>
 
 
-## Schema Change Apply
+## Schema Change Apply — Staging
 
-**Database**: `testapp` | **Schema Name**: `testapp` | **Environment**: `staging`
+**Database**: `testapp` | **Type**: `MySQL` | **Schema Name**: `testapp`
 
 *Requested by @jackjackbits at 2026-01-01 00:00:00 UTC · planned from [`abcdef1`](https://github.com/block/schemabot/commit/abcdef1234567890abcdef1234567890abcdef12)*
 
@@ -4522,9 +4575,9 @@ schemabot unlock
 <summary><a name="apply-started"></a><strong>Apply Started</strong></summary>
 
 
-## Schema Change In Progress
+## Schema Change In Progress — Staging
 
-**Database**: `testapp` | **Environment**: `staging` | **Apply ID**: `apply-a1b2c3d4e5f6`
+**Database**: `testapp` | **Apply ID**: `apply-a1b2c3d4e5f6`
 
 *Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
 
@@ -4537,9 +4590,9 @@ Schema changes are being applied. Progress updates will be posted as new comment
 <summary><a name="unlock-success"></a><strong>Unlock Success</strong></summary>
 
 
-## 🔓 Lock Released
+## 🔓 Lock Released — Staging
 
-**Database**: `testapp` | **Environment**: `staging`
+**Database**: `testapp`
 
 *Released by @jackjackbits at 2026-01-01 00:00:00 UTC*
 
@@ -4552,9 +4605,9 @@ The database is now available for schema changes.
 <summary><a name="apply-blocked-by-other-pr"></a><strong>Apply Blocked By Other PR</strong></summary>
 
 
-## 🔒 Apply Blocked
+## 🔒 Apply Blocked — Staging
 
-**Database**: `testapp` | **Environment**: `staging`
+**Database**: `testapp`
 
 *Requested by @jackjackbits at 2026-01-01 00:00:00 UTC*
 
@@ -4572,9 +4625,9 @@ Wait for the other PR to complete or ask the lock holder to run `schemabot unloc
 <summary><a name="apply-blocked-by-cli"></a><strong>Apply Blocked By CLI</strong></summary>
 
 
-## 🔒 Apply Blocked
+## 🔒 Apply Blocked — Staging
 
-**Database**: `testapp` | **Environment**: `staging`
+**Database**: `testapp`
 
 *Requested by @jackjackbits at 2026-01-01 00:00:00 UTC*
 
@@ -4595,9 +4648,9 @@ schemabot unlock -d testapp --force
 <summary><a name="apply-already-in-progress"></a><strong>Apply Already In Progress</strong></summary>
 
 
-## ⚠️ Apply Already In Progress
+## ⚠️ Apply Already In Progress — Staging
 
-**Database**: `testapp` | **Environment**: `staging`
+**Database**: `testapp`
 
 *Requested by @jackjackbits at 2026-01-01 00:00:00 UTC*
 
@@ -4612,9 +4665,9 @@ Wait for it to complete or stop it first.
 <summary><a name="no-lock-found"></a><strong>No Lock Found</strong></summary>
 
 
-## 🔒 No Lock Found
+## 🔒 No Lock Found — Staging
 
-**Database**: `testapp` | **Environment**: `staging`
+**Database**: `testapp`
 
 No apply lock is held for this database. Run `apply` first to generate a plan and acquire the lock.
 
@@ -4629,9 +4682,9 @@ schemabot apply -e staging
 <summary><a name="blocked-by-prior-env-pending"></a><strong>Blocked By Prior Env (Pending)</strong></summary>
 
 
-## ❌ Apply Blocked
+## ❌ Apply Blocked — Production
 
-**Database**: `testapp` | **Environment**: `production`
+**Database**: `testapp`
 
 Staging has pending changes. Apply staging first before applying to production.
 
@@ -4646,9 +4699,9 @@ schemabot apply -e staging
 <summary><a name="blocked-by-prior-env-failed"></a><strong>Blocked By Prior Env (Failed)</strong></summary>
 
 
-## ❌ Apply Blocked
+## ❌ Apply Blocked — Production
 
-**Database**: `testapp` | **Environment**: `production`
+**Database**: `testapp`
 
 Staging failed. Fix the issue and re-apply staging before applying to production.
 
@@ -4663,9 +4716,9 @@ schemabot apply -e staging
 <summary><a name="blocked-by-prior-env-in-progress"></a><strong>Blocked By Prior Env (In Progress)</strong></summary>
 
 
-## ⏳ Apply Blocked
+## ⏳ Apply Blocked — Production
 
-**Database**: `testapp` | **Environment**: `production`
+**Database**: `testapp`
 
 Staging is currently in progress. Wait for it to complete before applying to production.
 
@@ -4832,9 +4885,7 @@ Cutover is already in progress. SchemaBot will keep reporting progress from the 
 <summary><a name="checks-gate-not-passing"></a><strong>Checks Gate: Not Passing</strong></summary>
 
 
-## ❌ Apply Blocked
-
-**Environment**: `staging`
+## ❌ Apply Blocked — Staging
 
 Cannot apply while PR checks are not passing:
 
@@ -4855,9 +4906,7 @@ schemabot apply -e staging
 <summary><a name="checks-gate-in-progress"></a><strong>Checks Gate: In Progress</strong></summary>
 
 
-## ⏳ Apply Blocked
-
-**Environment**: `staging`
+## ⏳ Apply Blocked — Staging
 
 Cannot apply while PR checks are still running:
 
@@ -4881,9 +4930,9 @@ schemabot apply -e staging
 <summary><a name="barrier-rollout-in-progress"></a><strong>Barrier Rollout In Progress</strong></summary>
 
 
-## Schema Change In Progress
+## Schema Change In Progress — Production
 
-**Environment**: `production` | **Apply ID**: `apply-a1b2c3d4e5f6` | **Elapsed**: 12m
+**Apply ID**: `apply-a1b2c3d4e5f6`
 
 *Applied by @aparajon at 2026-01-01 00:00:00 UTC*
 
@@ -4904,11 +4953,13 @@ schemabot cutover apply-a1b2c3d4e5f6 -e production
 <details open>
 <summary>🟢 eu — ready for cutover — next in order</summary>
 
-## Schema Change — Waiting for Cutover
+## Schema Change In Progress — Production
 
-**Database**: `payments_eu` | **Environment**: `production` | **Apply ID**: `apply-a1b2c3d4e5f6` | **Elapsed**: 8m
+**Database**: `payments_eu` | **Apply ID**: `apply-a1b2c3d4e5f6`
 
 *Applied by @aparajon at 2026-01-01 00:00:00 UTC*
+
+**Status**: Waiting for Cutover
 
 **0/3** table(s) ready for cutover — waiting on 3
 
@@ -4947,9 +4998,9 @@ schemabot cutover apply-a1b2c3d4e5f6 -e production
 <details open>
 <summary>🔄 us — running table copy</summary>
 
-## Schema Change In Progress
+## Schema Change In Progress — Production
 
-**Database**: `payments_us` | **Environment**: `production` | **Apply ID**: `apply-a1b2c3d4e5f6` | **Elapsed**: 8m
+**Database**: `payments_us` | **Apply ID**: `apply-a1b2c3d4e5f6`
 
 *Applied by @aparajon at 2026-01-01 00:00:00 UTC*
 
@@ -5008,9 +5059,9 @@ _Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:0
 <summary><a name="halt-on-failure-one-deployment-failed"></a><strong>Halt On Failure (One Deployment Failed)</strong></summary>
 
 
-## ❌ Schema Change Failed
+## ❌ Schema Change Failed — Production
 
-**Environment**: `production` | **Apply ID**: `apply-a1b2c3d4e5f6` | **Elapsed**: 20m
+**Apply ID**: `apply-a1b2c3d4e5f6`
 
 *Applied by @aparajon at 2026-01-01 00:00:00 UTC*
 
@@ -5033,9 +5084,9 @@ schemabot apply -e production
 <details>
 <summary>✅ eu — completed</summary>
 
-## ✅ Schema Change Applied
+## ✅ Schema Change Applied — Production
 
-**Database**: `payments_eu` | **Environment**: `production` | **Apply ID**: `apply-a1b2c3d4e5f6` | **Elapsed**: 8m
+**Database**: `payments_eu` | **Apply ID**: `apply-a1b2c3d4e5f6`
 
 *Applied by @aparajon at 2026-01-01 00:00:00 UTC*
 
@@ -5067,9 +5118,9 @@ ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
 <details open>
 <summary>❌ us — failed</summary>
 
-## ❌ Schema Change Failed
+## ❌ Schema Change Failed — Production
 
-**Database**: `payments_us` | **Environment**: `production` | **Apply ID**: `apply-a1b2c3d4e5f6` | **Elapsed**: 8m
+**Database**: `payments_us` | **Apply ID**: `apply-a1b2c3d4e5f6`
 
 *Applied by @aparajon at 2026-01-01 00:00:00 UTC*
 
@@ -5127,9 +5178,9 @@ _No details available yet._
 <summary><a name="all-deployments-completed"></a><strong>All Deployments Completed</strong></summary>
 
 
-## ✅ Schema Change Applied
+## ✅ Schema Change Applied — Production
 
-**Environment**: `production` | **Apply ID**: `apply-a1b2c3d4e5f6` | **Elapsed**: 28m
+**Apply ID**: `apply-a1b2c3d4e5f6`
 
 *Applied by @aparajon at 2026-01-01 00:00:00 UTC*
 
@@ -5142,9 +5193,9 @@ _No details available yet._
 <details>
 <summary>✅ eu — completed</summary>
 
-## ✅ Schema Change Applied
+## ✅ Schema Change Applied — Production
 
-**Database**: `payments_eu` | **Environment**: `production` | **Apply ID**: `apply-a1b2c3d4e5f6` | **Elapsed**: 8m
+**Database**: `payments_eu` | **Apply ID**: `apply-a1b2c3d4e5f6`
 
 *Applied by @aparajon at 2026-01-01 00:00:00 UTC*
 
@@ -5176,9 +5227,9 @@ ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
 <details>
 <summary>✅ us — completed</summary>
 
-## ✅ Schema Change Applied
+## ✅ Schema Change Applied — Production
 
-**Database**: `payments_us` | **Environment**: `production` | **Apply ID**: `apply-a1b2c3d4e5f6` | **Elapsed**: 8m
+**Database**: `payments_us` | **Apply ID**: `apply-a1b2c3d4e5f6`
 
 *Applied by @aparajon at 2026-01-01 00:00:00 UTC*
 
@@ -5210,9 +5261,9 @@ ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
 <details>
 <summary>✅ au — completed</summary>
 
-## ✅ Schema Change Applied
+## ✅ Schema Change Applied — Production
 
-**Database**: `payments_au` | **Environment**: `production` | **Apply ID**: `apply-a1b2c3d4e5f6` | **Elapsed**: 8m
+**Database**: `payments_au` | **Apply ID**: `apply-a1b2c3d4e5f6`
 
 *Applied by @aparajon at 2026-01-01 00:00:00 UTC*
 
@@ -5247,9 +5298,9 @@ ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
 <summary><a name="summary-all-deployments-completed"></a><strong>Summary: All Deployments Completed</strong></summary>
 
 
-## ✅ Schema Change Applied
+## ✅ Schema Change Applied — Production
 
-**Environment**: `production` | **Apply ID**: `apply-a1b2c3d4e5f6` | **Elapsed**: 28m
+**Apply ID**: `apply-a1b2c3d4e5f6`
 
 *Applied by @aparajon at 2026-01-01 00:00:00 UTC*
 
@@ -5262,9 +5313,9 @@ ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
 <details>
 <summary>✅ eu — completed</summary>
 
-## ✅ Schema Change Applied
+## ✅ Schema Change Applied — Production
 
-**Database**: `payments_eu` | **Environment**: `production`
+**Database**: `payments_eu`
 
 
 > All 3 tables applied successfully — your schema changes are live!
@@ -5293,9 +5344,9 @@ _Apply ID: `apply-a1b2c3d4e5f6`_
 <details>
 <summary>✅ us — completed</summary>
 
-## ✅ Schema Change Applied
+## ✅ Schema Change Applied — Production
 
-**Database**: `payments_us` | **Environment**: `production`
+**Database**: `payments_us`
 
 
 > All 3 tables applied successfully — your schema changes are live!
@@ -5324,9 +5375,9 @@ _Apply ID: `apply-a1b2c3d4e5f6`_
 <details>
 <summary>✅ au — completed</summary>
 
-## ✅ Schema Change Applied
+## ✅ Schema Change Applied — Production
 
-**Database**: `payments_au` | **Environment**: `production`
+**Database**: `payments_au`
 
 
 > All 3 tables applied successfully — your schema changes are live!
@@ -5358,9 +5409,9 @@ _Apply ID: `apply-a1b2c3d4e5f6`_
 <summary><a name="summary-halt-on-failure-one-deployment-failed"></a><strong>Summary: Halt On Failure (One Deployment Failed)</strong></summary>
 
 
-## ❌ Schema Change Failed
+## ❌ Schema Change Failed — Production
 
-**Environment**: `production` | **Apply ID**: `apply-a1b2c3d4e5f6` | **Elapsed**: 19m
+**Apply ID**: `apply-a1b2c3d4e5f6`
 
 *Applied by @aparajon at 2026-01-01 00:00:00 UTC*
 
@@ -5383,9 +5434,9 @@ schemabot apply -e production
 <details>
 <summary>✅ eu — completed</summary>
 
-## ✅ Schema Change Applied
+## ✅ Schema Change Applied — Production
 
-**Database**: `payments_eu` | **Environment**: `production`
+**Database**: `payments_eu`
 
 
 > All 3 tables applied successfully — your schema changes are live!
@@ -5414,9 +5465,9 @@ _Apply ID: `apply-a1b2c3d4e5f6`_
 <details open>
 <summary>❌ us — failed</summary>
 
-## ❌ Schema Change Failed
+## ❌ Schema Change Failed — Production
 
-**Database**: `payments_us` | **Environment**: `production` | **Apply ID**: `apply-a1b2c3d4e5f6`
+**Database**: `payments_us` | **Apply ID**: `apply-a1b2c3d4e5f6`
 
 *Applied by @aparajon at 2026-01-01 00:00:00 UTC*
 

--- a/pkg/cmd/commands/preview.go
+++ b/pkg/cmd/commands/preview.go
@@ -70,7 +70,8 @@ func (cmd *PreviewCmd) Run(g *Globals) error {
 		templates.PreviewUnsafeAllowed, templates.PreviewLintAll:
 		templates.PreviewCLIOutput(previewType)
 	// Comment template types
-	case templates.PreviewCommentPlan, templates.PreviewCommentPlanEmpty,
+	case templates.PreviewCommentPlan, templates.PreviewCommentPlanTenant,
+		templates.PreviewCommentPlanEmpty,
 		templates.PreviewCommentNoManagedSchema,
 		templates.PreviewCommentReconcileInProgress,
 		templates.PreviewCommentReconcileCompleted,
@@ -232,6 +233,7 @@ Interactive TUI:
 
 Comment Templates (GitHub PR comments):
   comment_plan                  Plan comment with DDL changes + lint violations
+  comment_plan_tenant           Tenant-targeted plan comment
   comment_plan_empty            Plan comment with no changes
   comment_no_managed_schema     No managed schema changes in current PR
   comment_reconcile_in_progress Empty diff with an in-progress apply

--- a/pkg/cmd/internal/templates/preview.go
+++ b/pkg/cmd/internal/templates/preview.go
@@ -109,6 +109,7 @@ const (
 
 	// Comment template previews (GitHub PR comments)
 	PreviewCommentPlan                  PreviewType = "comment_plan"                    // Plan comment with DDL changes + lint violations
+	PreviewCommentPlanTenant            PreviewType = "comment_plan_tenant"             // Tenant-targeted plan comment
 	PreviewCommentPlanEmpty             PreviewType = "comment_plan_empty"              // Plan comment with no changes
 	PreviewCommentNoManagedSchema       PreviewType = "comment_no_managed_schema"       // No managed schema changes in current PR
 	PreviewCommentReconcileInProgress   PreviewType = "comment_reconcile_in_progress"   // Empty diff with in-progress apply-owned state

--- a/pkg/cmd/internal/templates/preview_comment.go
+++ b/pkg/cmd/internal/templates/preview_comment.go
@@ -38,6 +38,7 @@ func previewCommentAllOutput() {
 		fn   func()
 	}{
 		{"PLAN COMMENT", func() { fmt.Print(webhooktemplates.PreviewCommentPlan()) }},
+		{"PLAN COMMENT (TENANT TARGET)", func() { fmt.Print(webhooktemplates.PreviewCommentPlanTenant()) }},
 		{"PLAN COMMENT (NO CHANGES)", func() { fmt.Print(webhooktemplates.PreviewCommentPlanNoChanges()) }},
 		{"NO MANAGED SCHEMA CHANGES", func() { fmt.Print(webhooktemplates.PreviewCommentNoManagedSchemaChanges()) }},
 		{"RECONCILIATION REQUIRED (IN PROGRESS)", func() { fmt.Print(webhooktemplates.PreviewCommentSchemaReconciliationInProgress()) }},
@@ -148,6 +149,7 @@ func previewCommentPlanAllOutput() {
 		fn   func()
 	}{
 		{"MYSQL PLAN", func() { fmt.Print(webhooktemplates.PreviewCommentPlan()) }},
+		{"MYSQL PLAN (TENANT TARGET)", func() { fmt.Print(webhooktemplates.PreviewCommentPlanTenant()) }},
 		{"MYSQL PLAN (NO CHANGES)", func() { fmt.Print(webhooktemplates.PreviewCommentPlanNoChanges()) }},
 		{"NO MANAGED SCHEMA CHANGES", func() { fmt.Print(webhooktemplates.PreviewCommentNoManagedSchemaChanges()) }},
 		{"RECONCILIATION REQUIRED (IN PROGRESS)", func() { fmt.Print(webhooktemplates.PreviewCommentSchemaReconciliationInProgress()) }},

--- a/pkg/cmd/internal/templates/preview_dispatch.go
+++ b/pkg/cmd/internal/templates/preview_dispatch.go
@@ -111,6 +111,8 @@ func PreviewCLIOutput(previewType PreviewType) {
 	// Comment template previews
 	case PreviewCommentPlan:
 		fmt.Print(webhooktemplates.PreviewCommentPlan())
+	case PreviewCommentPlanTenant:
+		fmt.Print(webhooktemplates.PreviewCommentPlanTenant())
 	case PreviewCommentPlanEmpty:
 		fmt.Print(webhooktemplates.PreviewCommentPlanNoChanges())
 	case PreviewCommentNoManagedSchema:

--- a/pkg/webhook/apply_comment_e2e_test.go
+++ b/pkg/webhook/apply_comment_e2e_test.go
@@ -430,15 +430,17 @@ func TestE2EResumeRotatesProgressComment(t *testing.T) {
 	})
 
 	// First progress tick after resume rotates the progress comment. While the
-	// apply is in the Resuming window the comment renders state-only: the row-copy
-	// percent is indeterminate (continuation vs fresh copy), so no bar is shown.
+	// apply is in the Resuming window the comment keeps the stable in-progress
+	// title and renders state-only: the row-copy percent is indeterminate
+	// (continuation vs fresh copy), so no bar is shown.
 	obs.OnProgress(apply, []*storage.Task{task})
 
 	var newProgressID int64
 	select {
 	case created := <-capture.creates:
 		newProgressID = created.ID
-		assert.Contains(t, created.Body, "Schema Change — Resuming")
+		assert.Contains(t, created.Body, "Schema Change In Progress — Staging")
+		assert.Contains(t, created.Body, "**Status**: Resuming")
 		assert.Contains(t, created.Body, "Resuming…")
 		assert.NotContains(t, created.Body, "Stopped")
 		assert.NotContains(t, created.Body, "50%", "the indeterminate resume window must not show a stale percent")

--- a/pkg/webhook/plan_test.go
+++ b/pkg/webhook/plan_test.go
@@ -200,6 +200,93 @@ func TestRenderPlanComment_TenantScopedHints(t *testing.T) {
 		assert.Contains(t, rendered, "**Tenant**: `alpha`")
 		assert.Contains(t, rendered, "schemabot apply-confirm -e staging --tenant alpha")
 	})
+
+	t.Run("preview shows tenant metadata without putting tenant in title", func(t *testing.T) {
+		rendered := templates.PreviewCommentPlanTenant()
+		firstLine, _, _ := strings.Cut(rendered, "\n")
+
+		assert.Equal(t, "## Schema Change Plan — Staging", firstLine)
+		assert.Contains(t, rendered, "**Tenant**: `alpha`")
+		assert.Contains(t, rendered, "schemabot apply -e staging --tenant alpha")
+		assert.NotContains(t, firstLine, "alpha")
+	})
+}
+
+func TestRenderPlanComment_EnvironmentScopedTitle(t *testing.T) {
+	t.Run("plan title includes environment without tenant", func(t *testing.T) {
+		data := templates.PlanCommentData{
+			Database:     "testdb",
+			Environment:  "production",
+			Tenant:       "alpha",
+			DatabaseType: storage.DatabaseTypeStrata,
+			Changes: []templates.KeyspaceChangeData{{
+				Keyspace:   "testdb",
+				Statements: []string{"ALTER TABLE `orders` ADD COLUMN `x` INT"},
+			}},
+		}
+
+		rendered := templates.RenderPlanComment(data)
+		firstLine, _, _ := strings.Cut(rendered, "\n")
+
+		assert.Equal(t, "## Schema Change Plan — Production", firstLine)
+		assert.Contains(t, rendered, "**Type**: `Strata`")
+		assert.NotContains(t, firstLine, "alpha")
+	})
+
+	t.Run("locked apply title includes environment", func(t *testing.T) {
+		data := templates.PlanCommentData{
+			Database:    "testdb",
+			Environment: "staging",
+			IsMySQL:     true,
+			IsLocked:    true,
+			Changes: []templates.KeyspaceChangeData{{
+				Keyspace:   "testdb",
+				Statements: []string{"ALTER TABLE `orders` ADD COLUMN `x` INT"},
+			}},
+		}
+
+		rendered := templates.RenderPlanComment(data)
+		firstLine, _, _ := strings.Cut(rendered, "\n")
+
+		assert.Equal(t, "## Schema Change Apply — Staging", firstLine)
+		assert.Contains(t, rendered, "**Type**: `MySQL`")
+	})
+
+	t.Run("environment suffix preserves identifier separators", func(t *testing.T) {
+		data := templates.PlanCommentData{
+			Database:    "testdb",
+			Environment: "prod_us-east",
+			IsMySQL:     true,
+			Changes: []templates.KeyspaceChangeData{{
+				Keyspace:   "testdb",
+				Statements: []string{"ALTER TABLE `orders` ADD COLUMN `x` INT"},
+			}},
+		}
+
+		rendered := templates.RenderPlanComment(data)
+		firstLine, _, _ := strings.Cut(rendered, "\n")
+
+		assert.Equal(t, "## Schema Change Plan — Prod_us-east", firstLine)
+	})
+
+	t.Run("multi environment plan title stays generic", func(t *testing.T) {
+		data := templates.MultiEnvPlanCommentData{
+			Database:     "testdb",
+			IsMySQL:      true,
+			Environments: []string{"staging", "production"},
+			Plans: map[string]*templates.PlanCommentData{
+				"staging":    {Database: "testdb", Environment: "staging", IsMySQL: true},
+				"production": {Database: "testdb", Environment: "production", IsMySQL: true},
+			},
+			Errors: map[string]string{},
+		}
+
+		rendered := templates.RenderMultiEnvPlanComment(data)
+		firstLine, _, _ := strings.Cut(rendered, "\n")
+
+		assert.Equal(t, "## Schema Change Plan", firstLine)
+		assert.Contains(t, rendered, "**Type**: `MySQL`")
+	})
 }
 
 func TestRenderPlanComment_NoUnsafe_NoWarning(t *testing.T) {
@@ -231,7 +318,8 @@ func TestRenderPlanComment_StrataHeader(t *testing.T) {
 
 	rendered := templates.RenderPlanComment(data)
 
-	assert.Contains(t, rendered, "## Strata Schema Change Plan")
+	assert.Contains(t, rendered, "## Schema Change Plan")
+	assert.Contains(t, rendered, "**Type**: `Strata`")
 }
 
 func TestRenderPlanComment_CustomDatabaseTypeHeader(t *testing.T) {
@@ -247,7 +335,8 @@ func TestRenderPlanComment_CustomDatabaseTypeHeader(t *testing.T) {
 
 	rendered := templates.RenderPlanComment(data)
 
-	assert.Contains(t, rendered, "## Custom Engine Schema Change Plan")
+	assert.Contains(t, rendered, "## Schema Change Plan")
+	assert.Contains(t, rendered, "**Type**: `Custom Engine`")
 }
 
 func TestRenderPlanComment_PostgresHeader(t *testing.T) {
@@ -263,7 +352,8 @@ func TestRenderPlanComment_PostgresHeader(t *testing.T) {
 
 	rendered := templates.RenderPlanComment(data)
 
-	assert.Contains(t, rendered, "## PostgreSQL Schema Change Plan")
+	assert.Contains(t, rendered, "## Schema Change Plan")
+	assert.Contains(t, rendered, "**Type**: `PostgreSQL`")
 }
 
 func TestRenderPlanComment_ShowsPRHeadSHA(t *testing.T) {
@@ -331,7 +421,7 @@ func TestRenderMultiEnvPlanComment_StrataHeaderWithErrors(t *testing.T) {
 
 	rendered := templates.RenderMultiEnvPlanComment(data)
 
-	assert.Contains(t, rendered, "## Strata Schema Change Plan")
+	assert.Contains(t, rendered, "## Schema Change Plan")
 }
 
 func TestUserFacingErrorExplainsNoHealthyUpstream(t *testing.T) {
@@ -425,7 +515,7 @@ func TestRenderUnsafeChangesBlocked_CustomDatabaseTypeHeader(t *testing.T) {
 
 	rendered := templates.RenderUnsafeChangesBlocked(data)
 
-	assert.Contains(t, rendered, "## Custom Engine Schema Change Plan")
+	assert.Contains(t, rendered, "## Schema Change Plan")
 	assert.Contains(t, rendered, "schemabot apply -e staging --allow-unsafe")
 }
 

--- a/pkg/webhook/templates/apply.go
+++ b/pkg/webhook/templates/apply.go
@@ -81,6 +81,7 @@ func renderApplyStatusComment(data ApplyStatusCommentData, includeLastUpdated bo
 
 	// Metadata line
 	writeApplyMetadata(&sb, data, renderedAt)
+	writeApplyStatusDetail(&sb, data.State)
 
 	// Cutover readiness summary
 	if data.State == state.Apply.WaitingForCutover || data.State == state.Apply.CuttingOver {
@@ -113,70 +114,94 @@ func renderApplyStatusComment(data ApplyStatusCommentData, includeLastUpdated bo
 // writeApplyHeader writes the comment header with a state-specific title.
 func writeApplyHeader(sb *strings.Builder, data ApplyStatusCommentData) {
 	switch data.State {
-	case state.Apply.Pending:
-		sb.WriteString("## Schema Change Starting\n\n")
-	case state.Apply.Running, state.Apply.RunningDegraded:
+	case state.Apply.Pending,
+		state.Apply.Running,
+		state.Apply.RunningDegraded,
+		state.Apply.FailedRetryable,
+		state.Apply.WaitingForDeploy,
+		state.Apply.WaitingForCutover,
+		state.Apply.Recovering,
+		state.Apply.Resuming,
+		state.Apply.CuttingOver,
+		state.Apply.PreparingBranch,
+		state.Apply.ApplyingBranchChanges,
+		state.Apply.ValidatingBranch,
+		state.Apply.CreatingDeployRequest,
+		state.Apply.ValidatingDeployRequest:
 		// running_degraded is a continue rollout still in flight past a failed
 		// sibling: the change is still in progress, and the failed deployment is
 		// surfaced in the per-deployment breakdown, not the headline.
-		sb.WriteString("## Schema Change In Progress\n\n")
-	case state.Apply.FailedRetryable:
-		// Operator recovery retries the apply automatically, so it is still
-		// in progress from the user's perspective. The retry detail is
-		// surfaced per table in the progress section, not in the headline.
-		sb.WriteString("## Schema Change In Progress\n\n")
-	case state.Apply.WaitingForDeploy:
-		sb.WriteString("## Schema Change — Waiting for Deploy\n\n")
-	case state.Apply.WaitingForCutover:
-		sb.WriteString("## Schema Change — Waiting for Cutover\n\n")
-	case state.Apply.Recovering:
-		sb.WriteString("## Schema Change — Recovering\n\n")
-	case state.Apply.Resuming:
-		sb.WriteString("## Schema Change — Resuming\n\n")
-	case state.Apply.CuttingOver:
-		sb.WriteString("## Schema Change — Cutting Over\n\n")
+		writeEnvironmentTitle(sb, "Schema Change In Progress", data.Environment)
 	case state.Apply.RevertWindow:
-		sb.WriteString("## Schema Change Applied (Pending Revert)\n\n")
+		writeEnvironmentTitle(sb, "Schema Change Applied (Pending Revert)", data.Environment)
 	case state.Apply.Completed:
-		sb.WriteString("## ✅ Schema Change Applied\n\n")
+		writeEnvironmentTitle(sb, "✅ Schema Change Applied", data.Environment)
 	case state.Apply.Failed:
-		sb.WriteString("## ❌ Schema Change Failed\n\n")
+		writeEnvironmentTitle(sb, "❌ Schema Change Failed", data.Environment)
 	case state.Apply.Stopped:
-		sb.WriteString("## ⏹️ Schema Change Stopped\n\n")
+		writeEnvironmentTitle(sb, "⏹️ Schema Change Stopped", data.Environment)
 	case state.Apply.Reverted:
-		sb.WriteString("## ↩️ Schema Change Reverted\n\n")
+		writeEnvironmentTitle(sb, "↩️ Schema Change Reverted", data.Environment)
 	case state.Apply.Cancelled:
-		sb.WriteString("## 🚫 Schema Change Cancelled\n\n")
-	case state.Apply.PreparingBranch:
-		sb.WriteString("## Schema Change — Preparing Branch\n\n")
-	case state.Apply.ApplyingBranchChanges:
-		sb.WriteString("## Schema Change — Applying Branch Changes\n\n")
-	case state.Apply.ValidatingBranch:
-		sb.WriteString("## Schema Change — Validating Branch\n\n")
-	case state.Apply.CreatingDeployRequest:
-		sb.WriteString("## Schema Change — Creating Deploy Request\n\n")
-	case state.Apply.ValidatingDeployRequest:
-		sb.WriteString("## Schema Change — Validating Deploy Request\n\n")
+		writeEnvironmentTitle(sb, "🚫 Schema Change Cancelled", data.Environment)
 	default:
-		fmt.Fprintf(sb, "## Schema Change — %s\n\n", humanizeState(data.State))
+		if state.IsTerminalApplyState(data.State) {
+			writeEnvironmentTitle(sb, fmt.Sprintf("Schema Change: %s", humanizeState(data.State)), data.Environment)
+		} else {
+			writeEnvironmentTitle(sb, "Schema Change In Progress", data.Environment)
+		}
 	}
 }
 
-// writeApplyMetadata writes the database, environment, apply ID, elapsed time, and requester info.
+// writeApplyMetadata writes the database, apply ID, and requester info.
 func writeApplyMetadata(sb *strings.Builder, data ApplyStatusCommentData, renderedAt string) {
 	var parts []string
 	parts = append(parts, fmt.Sprintf("**Database**: `%s`", data.Database))
-	if data.Environment != "" {
-		parts = append(parts, fmt.Sprintf("**Environment**: `%s`", data.Environment))
-	}
 	if data.ApplyID != "" {
 		parts = append(parts, fmt.Sprintf("**Apply ID**: `%s`", data.ApplyID))
 	}
-	if elapsed := applyElapsed(data); elapsed != "" {
-		parts = append(parts, fmt.Sprintf("**Elapsed**: %s", elapsed))
-	}
 	fmt.Fprintf(sb, "%s\n", strings.Join(parts, " | "))
 	writeAppliedByOrTimestampAt(sb, data.RequestedBy, renderedAt)
+}
+
+func writeApplyStatusDetail(sb *strings.Builder, applyState string) {
+	detail := applyStatusDetail(applyState)
+	if detail == "" {
+		return
+	}
+	fmt.Fprintf(sb, "\n**Status**: %s\n", detail)
+}
+
+func applyStatusDetail(applyState string) string {
+	switch applyState {
+	case state.Apply.Pending:
+		return "Starting"
+	case state.Apply.WaitingForDeploy:
+		return "Waiting for Deploy"
+	case state.Apply.WaitingForCutover:
+		return "Waiting for Cutover"
+	case state.Apply.Recovering:
+		return "Recovering"
+	case state.Apply.Resuming:
+		return "Resuming"
+	case state.Apply.CuttingOver:
+		return "Cutting Over"
+	case state.Apply.PreparingBranch:
+		return "Preparing Branch"
+	case state.Apply.ApplyingBranchChanges:
+		return "Applying Branch Changes"
+	case state.Apply.ValidatingBranch:
+		return "Validating Branch"
+	case state.Apply.CreatingDeployRequest:
+		return "Creating Deploy Request"
+	case state.Apply.ValidatingDeployRequest:
+		return "Validating Deploy Request"
+	default:
+		if applyState == "" || state.IsTerminalApplyState(applyState) || state.IsState(applyState, state.Apply.Running, state.Apply.RunningDegraded, state.Apply.FailedRetryable) {
+			return ""
+		}
+		return humanizeState(applyState)
+	}
 }
 
 // writeCutoverSummary writes a readiness summary for cutover states,
@@ -197,29 +222,6 @@ func writeCutoverSummary(sb *strings.Builder, tables []TableProgressData) {
 	} else {
 		fmt.Fprintf(sb, "\n**%d/%d** table(s) ready for cutover — waiting on %d\n", ready, total, total-ready)
 	}
-}
-
-// applyElapsed returns a human-readable elapsed duration.
-// For terminal states (completed/failed/stopped), it uses CompletedAt - StartedAt.
-// For in-progress states, it uses NowFunc() - StartedAt.
-func applyElapsed(data ApplyStatusCommentData) string {
-	if data.StartedAt == "" {
-		return ""
-	}
-	startTime, err := time.Parse(time.RFC3339, data.StartedAt)
-	if err != nil {
-		return ""
-	}
-	var end time.Time
-	if data.CompletedAt != "" {
-		end, err = time.Parse(time.RFC3339, data.CompletedAt)
-		if err != nil {
-			return ""
-		}
-	} else {
-		end = NowFunc()
-	}
-	return formatDuration(end.Sub(startTime))
 }
 
 // writeProgressSummary writes a one-line progress summary before the per-table breakdown.
@@ -751,7 +753,7 @@ func RenderApplySummaryComment(data ApplyStatusCommentData) string {
 	case state.Apply.Cancelled:
 		writeSummaryCancelled(&sb, data, completedCount, totalTables)
 	default:
-		fmt.Fprintf(&sb, "## Schema Change \u2014 %s\n\n", humanizeState(data.State))
+		writeEnvironmentTitle(&sb, fmt.Sprintf("Schema Change: %s", humanizeState(data.State)), data.Environment)
 		writeSummaryMetadata(&sb, data)
 	}
 
@@ -798,14 +800,10 @@ func writeSummaryCompleted(sb *strings.Builder, data ApplyStatusCommentData, tot
 }
 
 // writeSummaryCompletedMetadata writes a clean metadata line for completed applies.
-// Only shows database and environment — apply ID and duration are operational details
-// that add clutter without value for most users.
+// Only shows database — environment is already in the title, and apply ID plus
+// duration are operational details that add clutter without value for most users.
 func writeSummaryCompletedMetadata(sb *strings.Builder, data ApplyStatusCommentData) {
-	if data.Environment != "" {
-		fmt.Fprintf(sb, "**Database**: `%s` | **Environment**: `%s`\n", data.Database, data.Environment)
-	} else {
-		fmt.Fprintf(sb, "**Database**: `%s`\n", data.Database)
-	}
+	writeDBLine(sb, data.Database)
 	sb.WriteString("\n")
 }
 
@@ -855,13 +853,9 @@ func writeSummaryCancelled(sb *strings.Builder, data ApplyStatusCommentData, com
 }
 
 func writeSummaryMetadata(sb *strings.Builder, data ApplyStatusCommentData) {
-	// Combine database, environment, apply ID, and duration on one metadata line
+	// Combine database, apply ID, and duration on one metadata line.
 	var parts []string
-	if data.Environment != "" {
-		parts = append(parts, fmt.Sprintf("**Database**: `%s` | **Environment**: `%s`", data.Database, data.Environment))
-	} else {
-		parts = append(parts, fmt.Sprintf("**Database**: `%s`", data.Database))
-	}
+	parts = append(parts, fmt.Sprintf("**Database**: `%s`", data.Database))
 	if data.ApplyID != "" {
 		parts = append(parts, fmt.Sprintf("**Apply ID**: `%s`", data.ApplyID))
 	}

--- a/pkg/webhook/templates/apply_commands.go
+++ b/pkg/webhook/templates/apply_commands.go
@@ -95,8 +95,7 @@ func RenderUnsafeChangesBlocked(data PlanCommentData) string {
 
 	// Render the full plan first (DDL, lint warnings, etc.) so the user can see
 	// what would change — but without a lock or confirm footer.
-	dbTypeLabel := schemaChangePlanDatabaseTypeLabel(data.DatabaseType, data.IsMySQL)
-	fmt.Fprintf(&sb, "## %s Schema Change Plan\n\n", dbTypeLabel)
+	writeEnvironmentTitle(&sb, "Schema Change Plan", data.Environment)
 
 	writePlanMetadata(&sb, data)
 	writePlanAttribution(&sb, data)
@@ -141,7 +140,7 @@ func RenderUnsafeChangesBlocked(data PlanCommentData) string {
 func RenderApplyStarted(data ApplyStatusCommentData) string {
 	var sb strings.Builder
 
-	sb.WriteString("## Schema Change In Progress\n\n")
+	writeEnvironmentTitle(&sb, "Schema Change In Progress", data.Environment)
 	writeApplyMetadata(&sb, data, currentTimestamp())
 	sb.WriteString("\nSchema changes are being applied. Progress updates will be posted as new comments.\n")
 
@@ -176,8 +175,8 @@ func RenderApplyStopped(data ApplyStatusCommentData) string {
 func RenderUnlockSuccess(database, environment, releasedBy string) string {
 	var sb strings.Builder
 
-	sb.WriteString("## 🔓 Lock Released\n\n")
-	writeDBEnvLine(&sb, database, environment)
+	writeEnvironmentTitle(&sb, "🔓 Lock Released", environment)
+	writeDBLine(&sb, database)
 	fmt.Fprintf(&sb, "\n*Released by @%s at %s*\n", releasedBy, currentTimestamp())
 	sb.WriteString("\nThe database is now available for schema changes.\n")
 
@@ -188,8 +187,8 @@ func RenderUnlockSuccess(database, environment, releasedBy string) string {
 func RenderApplyBlockedByOtherPR(data ApplyLockConflictData) string {
 	var sb strings.Builder
 
-	sb.WriteString("## 🔒 Apply Blocked\n\n")
-	writeDBEnvLine(&sb, data.Database, data.Environment)
+	writeEnvironmentTitle(&sb, "🔒 Apply Blocked", data.Environment)
+	writeDBLine(&sb, data.Database)
 	writeRequesterOrTimestamp(&sb, data.RequestedBy)
 	sb.WriteString("\n")
 
@@ -222,8 +221,8 @@ func RenderApplyBlockedByOtherPR(data ApplyLockConflictData) string {
 func RenderApplyInProgress(data ApplyLockConflictData) string {
 	var sb strings.Builder
 
-	sb.WriteString("## ⚠️ Apply Already In Progress\n\n")
-	writeDBEnvLine(&sb, data.Database, data.Environment)
+	writeEnvironmentTitle(&sb, "⚠️ Apply Already In Progress", data.Environment)
+	writeDBLine(&sb, data.Database)
 	writeRequesterOrTimestamp(&sb, data.RequestedBy)
 	sb.WriteString("\n")
 	fmt.Fprintf(&sb, "An apply is already running for this PR (apply ID: `%s`, state: `%s`).\n\n",
@@ -247,8 +246,8 @@ func RenderNoLocksFound() string {
 func RenderCannotUnlock(database, environment, applyID, applyState string) string {
 	var sb strings.Builder
 
-	sb.WriteString("## ⚠️ Cannot Unlock\n\n")
-	writeDBEnvLine(&sb, database, environment)
+	writeEnvironmentTitle(&sb, "⚠️ Cannot Unlock", environment)
+	writeDBLine(&sb, database)
 	sb.WriteString("\n")
 	fmt.Fprintf(&sb, "An apply is currently active (apply ID: `%s`, state: `%s`).\n\n",
 		applyID, applyState)
@@ -261,8 +260,8 @@ func RenderCannotUnlock(database, environment, applyID, applyState string) strin
 func RenderApplyConfirmNoChanges(database, environment string) string {
 	var sb strings.Builder
 
-	sb.WriteString("## No Changes Detected\n\n")
-	writeDBEnvLine(&sb, database, environment)
+	writeEnvironmentTitle(&sb, "No Changes Detected", environment)
+	writeDBLine(&sb, database)
 	sb.WriteString("\nThe database is already up to date — no schema changes needed. Lock released.\n")
 
 	return sb.String()
@@ -286,8 +285,8 @@ type StaleSchemaRejectionData struct {
 func RenderStaleSchemaRejection(data StaleSchemaRejectionData) string {
 	var sb strings.Builder
 
-	sb.WriteString("## ⚠️ Rejected — new commits since discovery\n\n")
-	writeDBEnvLine(&sb, data.Database, data.Environment)
+	writeEnvironmentTitle(&sb, "⚠️ Rejected — new commits since discovery", data.Environment)
+	writeDBLine(&sb, data.Database)
 	sb.WriteString("\n")
 	fmt.Fprintf(&sb, "Schema files were loaded at `%s`, but the current PR HEAD is `%s`. ", data.DiscoverySHA, data.CurrentSHA)
 	sb.WriteString("These files no longer match what is on the branch.\n\n")
@@ -320,8 +319,8 @@ type StalePlanRejectionData struct {
 func RenderStalePlanRejection(data StalePlanRejectionData) string {
 	var sb strings.Builder
 
-	sb.WriteString("## ⚠️ Rejected — the plan you confirmed is stale\n\n")
-	writeDBEnvLine(&sb, data.Database, data.Environment)
+	writeEnvironmentTitle(&sb, "⚠️ Rejected — the plan you confirmed is stale", data.Environment)
+	writeDBLine(&sb, data.Database)
 	sb.WriteString("\n")
 	fmt.Fprintf(&sb, "The confirmation plan was rendered at `%s`, but the current PR HEAD is `%s`. ", data.PlanSHA, data.CurrentSHA)
 	sb.WriteString("New commits have landed since the plan was posted, so the DDL you reviewed no longer matches what is on the branch.\n\n")
@@ -339,8 +338,8 @@ func RenderStalePlanRejection(data StalePlanRejectionData) string {
 func RenderApplyConfirmNoLock(database, environment string) string {
 	var sb strings.Builder
 
-	sb.WriteString("## 🔒 No Lock Found\n\n")
-	writeDBEnvLine(&sb, database, environment)
+	writeEnvironmentTitle(&sb, "🔒 No Lock Found", environment)
+	writeDBLine(&sb, database)
 	sb.WriteString("\n")
 	sb.WriteString("No apply lock is held for this database. Run `apply` first to generate a plan and acquire the lock.\n\n")
 	fmt.Fprintf(&sb, "```\nschemabot apply -e %s\n```\n", environment)
@@ -353,8 +352,8 @@ func RenderApplyConfirmNoLock(database, environment string) string {
 func RenderApplyBlockedByPriorEnv(database, environment, priorEnv, status, action string) string {
 	var sb strings.Builder
 
-	sb.WriteString("## ❌ Apply Blocked\n\n")
-	writeDBEnvLine(&sb, database, environment)
+	writeEnvironmentTitle(&sb, "❌ Apply Blocked", environment)
+	writeDBLine(&sb, database)
 	sb.WriteString("\n")
 	fmt.Fprintf(&sb, "%s %s. %s before applying to %s.\n\n", capitalizeFirst(priorEnv), status, action, environment)
 	fmt.Fprintf(&sb, "```\nschemabot apply -e %s\n```\n", priorEnv)
@@ -377,8 +376,7 @@ type BlockingCheck struct {
 func RenderApplyBlockedByNonPassingChecks(environment string, notPassing []BlockingCheck) string {
 	var sb strings.Builder
 
-	sb.WriteString("## ❌ Apply Blocked\n\n")
-	fmt.Fprintf(&sb, "**Environment**: `%s`\n\n", environment)
+	writeEnvironmentTitle(&sb, "❌ Apply Blocked", environment)
 	if len(notPassing) == 0 {
 		// Defensive: callers should only invoke this template when at least
 		// one non-passing check has been identified. Render a generic message
@@ -415,8 +413,7 @@ type CheckStatusAccessDetails struct {
 func RenderApplyBlockedByCheckStatusError(environment string, err error, details *CheckStatusAccessDetails) string {
 	var sb strings.Builder
 
-	sb.WriteString("## ❌ Apply Blocked\n\n")
-	fmt.Fprintf(&sb, "**Environment**: `%s`\n\n", environment)
+	writeEnvironmentTitle(&sb, "❌ Apply Blocked", environment)
 
 	if err != nil && strings.Contains(err.Error(), "Resource not accessible") {
 		app := "SchemaBot GitHub App"
@@ -474,8 +471,7 @@ func RenderApplyBlockedByCheckStatusError(environment string, err error, details
 func RenderApplyBlockedByInProgressChecks(environment string, inProgress, notReported []BlockingCheck) string {
 	var sb strings.Builder
 
-	sb.WriteString("## ⏳ Apply Blocked\n\n")
-	fmt.Fprintf(&sb, "**Environment**: `%s`\n\n", environment)
+	writeEnvironmentTitle(&sb, "⏳ Apply Blocked", environment)
 	if len(inProgress) == 0 && len(notReported) == 0 {
 		// Defensive: callers should only invoke this template when at least
 		// one in-progress or not-reported check has been identified. Render a
@@ -575,8 +571,8 @@ func RenderApplyBlockedByUntrustedPriorEnvCheck(priorEnv, checkName string, untr
 func RenderApplyBlockedByPriorEnvInProgress(database, environment, priorEnv string) string {
 	var sb strings.Builder
 
-	sb.WriteString("## ⏳ Apply Blocked\n\n")
-	writeDBEnvLine(&sb, database, environment)
+	writeEnvironmentTitle(&sb, "⏳ Apply Blocked", environment)
+	writeDBLine(&sb, database)
 	sb.WriteString("\n")
 	fmt.Fprintf(&sb, "%s is currently in progress. Wait for it to complete before applying to %s.\n\n", capitalizeFirst(priorEnv), environment)
 	fmt.Fprintf(&sb, "Once %s completes, retry:\n", priorEnv)
@@ -593,8 +589,7 @@ func RenderApplyBlockedByPriorEnvInProgress(database, environment, priorEnv stri
 func RenderApplyBlockedByUnlistedEnvironment(environment string, promotionOrder []string) string {
 	var sb strings.Builder
 
-	sb.WriteString("## ❌ Apply Blocked\n\n")
-	fmt.Fprintf(&sb, "**Environment**: `%s`\n\n", environment)
+	writeEnvironmentTitle(&sb, "❌ Apply Blocked", environment)
 	fmt.Fprintf(&sb, "`%s` is not in the configured promotion order, so SchemaBot cannot determine which environments must be applied before it and cannot enforce staging-first ordering.\n\n", environment)
 	if len(promotionOrder) > 0 {
 		fmt.Fprintf(&sb, "Configured promotion order: `%s`\n\n", strings.Join(promotionOrder, "` → `"))

--- a/pkg/webhook/templates/apply_test.go
+++ b/pkg/webhook/templates/apply_test.go
@@ -34,6 +34,27 @@ func TestRenderApplyBlockedByCLILockUsesValidUnlockCommand(t *testing.T) {
 	assert.NotContains(t, rendered, "schemabot unlock -d example-db -e staging --force")
 }
 
+func TestRenderApplyCommentsIncludeEnvironmentInTitle(t *testing.T) {
+	t.Run("status title", func(t *testing.T) {
+		rendered := RenderApplyStatusComment(ApplyStatusCommentData{
+			Database:    "testapp",
+			Environment: "production",
+			State:       state.Apply.Running,
+		})
+		firstLine, _, _ := strings.Cut(rendered, "\n")
+
+		assert.Equal(t, "## Schema Change In Progress — Production", firstLine)
+		assert.NotContains(t, rendered, "**Elapsed**")
+	})
+
+	t.Run("blocked title", func(t *testing.T) {
+		rendered := RenderApplyBlockedByPriorEnv("testapp", "production", "staging", "has pending changes", "Apply staging first")
+		firstLine, _, _ := strings.Cut(rendered, "\n")
+
+		assert.Equal(t, "## ❌ Apply Blocked — Production", firstLine)
+	})
+}
+
 func TestUnsafeDropUsageTarget(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -151,7 +172,8 @@ func TestRenderApplyStatusComment_Running(t *testing.T) {
 	assert.Contains(t, result, "## Schema Change In Progress")
 	assert.Contains(t, result, "@aparajon")
 	assert.Contains(t, result, "`testapp`")
-	assert.Contains(t, result, "`staging`")
+	assert.Contains(t, result, "— Staging")
+	assert.NotContains(t, result, "**Environment**")
 	assert.Contains(t, result, "_Last updated: <relative-time datetime=\"2026-06-16T19:42:00Z\">2026-06-16 19:42:00 UTC</relative-time> (2026-06-16 19:42:00 UTC)_")
 	assert.NotContains(t, result, "**Last updated**")
 	// Progress summary
@@ -310,8 +332,8 @@ func TestRenderApplyStatusComment_ValidatingDeployRequest(t *testing.T) {
 
 	result := RenderApplyStatusComment(data)
 
-	assert.Contains(t, result, "## Schema Change — Validating Deploy Request")
-	assert.NotContains(t, result, "## Schema Change In Progress")
+	assert.Contains(t, result, "## Schema Change In Progress")
+	assert.Contains(t, result, "**Status**: Validating Deploy Request")
 	assert.Contains(t, result, "To stop this schema change:")
 	assert.Contains(t, result, "schemabot stop apply-7aa13cf03496454b -e staging")
 }
@@ -624,7 +646,7 @@ func TestRenderApplyStatusComment_Resuming(t *testing.T) {
 
 	result := RenderApplyStatusComment(data)
 
-	assert.Contains(t, result, "## Schema Change — Resuming")
+	assert.Contains(t, result, "## Schema Change In Progress")
 	assert.Contains(t, result, "🔄 Resuming…")
 	assert.NotContains(t, result, "21%", "the indeterminate resume window must not show the stale pre-stop percent")
 	assert.NotContains(t, result, "21,000 / 100,000", "the indeterminate resume window must not show stale row counts")
@@ -885,7 +907,7 @@ func TestPreviewCommentApplyStopped(t *testing.T) {
 func TestPreviewCommentApplyResuming(t *testing.T) {
 	result := PreviewCommentApplyResuming()
 
-	assert.Contains(t, result, "Schema Change — Resuming")
+	assert.Contains(t, result, "Schema Change In Progress")
 	assert.Contains(t, result, "🔄 Resuming…")
 	// The indeterminate resume window hides the stale pre-stop percent.
 	assert.NotContains(t, result, "72%")
@@ -1050,7 +1072,7 @@ func TestRenderApplyBlockedByNonPassingChecks(t *testing.T) {
 	result := RenderApplyBlockedByNonPassingChecks("staging", notPassing)
 
 	assert.Contains(t, result, "## ❌ Apply Blocked")
-	assert.Contains(t, result, "`staging`")
+	assert.Contains(t, result, "— Staging")
 	assert.Contains(t, result, "Cannot apply while PR checks are not passing")
 	assert.Contains(t, result, "| Check | Status |")
 	assert.Contains(t, result, "| `CI / unit-tests` | failure |")
@@ -1065,7 +1087,7 @@ func TestRenderApplyBlockedByNonPassingChecks_SingleCheck(t *testing.T) {
 
 	result := RenderApplyBlockedByNonPassingChecks("production", notPassing)
 
-	assert.Contains(t, result, "`production`")
+	assert.Contains(t, result, "— Production")
 	assert.Contains(t, result, "| `security-scan` | error |")
 	assert.Contains(t, result, "schemabot apply -e production")
 }
@@ -1073,13 +1095,13 @@ func TestRenderApplyBlockedByNonPassingChecks_SingleCheck(t *testing.T) {
 func TestRenderApplyBlockedByNonPassingChecks_EmptyList(t *testing.T) {
 	// Defensive guard: rendering with an empty slice must not emit an empty
 	// Markdown table (header row with zero data rows). It should fall back
-	// to a generic message that still preserves the header, environment,
+	// to a generic message that still preserves the environment-scoped header
 	// and retry block.
 	for _, notPassing := range [][]BlockingCheck{nil, {}} {
 		result := RenderApplyBlockedByNonPassingChecks("staging", notPassing)
 
 		assert.Contains(t, result, "## ❌ Apply Blocked")
-		assert.Contains(t, result, "**Environment**: `staging`")
+		assert.Contains(t, result, "— Staging")
 		assert.Contains(t, result, "Cannot apply while PR checks are not passing.")
 		assert.Contains(t, result, "Get the checks passing — fix failures and re-run cancelled or stale checks — then retry:\n```\nschemabot apply -e staging\n```",
 			"retry command must be inside a fenced code block immediately after the retry copy")
@@ -1097,7 +1119,7 @@ func TestRenderApplyBlockedByCheckStatusError(t *testing.T) {
 		result := RenderApplyBlockedByCheckStatusError("staging", err, nil)
 
 		assert.Contains(t, result, "## ❌ Apply Blocked")
-		assert.Contains(t, result, "**Environment**: `staging`")
+		assert.Contains(t, result, "— Staging")
 		assert.Contains(t, result, "Unable to verify PR check statuses")
 		assert.Contains(t, result, "get combined commit status: 500 Internal Server Error")
 		assert.Contains(t, result, "Resolve the issue and retry:\n```\nschemabot apply -e staging\n```",
@@ -1113,7 +1135,7 @@ func TestRenderApplyBlockedByCheckStatusError(t *testing.T) {
 		})
 
 		assert.Contains(t, result, "## ❌ Apply Blocked")
-		assert.Contains(t, result, "**Environment**: `production`")
+		assert.Contains(t, result, "— Production")
 		assert.Contains(t, result, "SchemaBot GitHub App `schemabot-prod`")
 		assert.Contains(t, result, "cannot read PR check statuses")
 		assert.Contains(t, result, "**Checks: Read**")
@@ -1145,7 +1167,7 @@ func TestRenderApplyBlockedByCheckStatusError(t *testing.T) {
 		result := RenderApplyBlockedByCheckStatusError("staging", nil, nil)
 
 		assert.Contains(t, result, "## ❌ Apply Blocked")
-		assert.Contains(t, result, "**Environment**: `staging`")
+		assert.Contains(t, result, "— Staging")
 		assert.Contains(t, result, "Unable to verify PR check statuses.")
 		assert.Contains(t, result, "Retry:\n```\nschemabot apply -e staging\n```",
 			"retry command must be inside a fenced code block immediately after the retry copy")
@@ -1225,7 +1247,7 @@ func TestRenderApplyBlockedByInProgressChecks(t *testing.T) {
 	result := RenderApplyBlockedByInProgressChecks("staging", inProgress, nil)
 
 	assert.Contains(t, result, "⏳ Apply Blocked")
-	assert.Contains(t, result, "`staging`")
+	assert.Contains(t, result, "— Staging")
 	assert.Contains(t, result, "still running")
 	assert.Contains(t, result, "| `CI / unit-tests` | in_progress |")
 	assert.Contains(t, result, "| `CI / integration` | queued |")
@@ -1247,7 +1269,7 @@ func TestRenderApplyBlockedByInProgressChecks_NotReported(t *testing.T) {
 	result := RenderApplyBlockedByInProgressChecks("production", nil, notReported)
 
 	assert.Contains(t, result, "⏳ Apply Blocked")
-	assert.Contains(t, result, "`production`")
+	assert.Contains(t, result, "— Production")
 	assert.Contains(t, result, "have not reported on this commit")
 	assert.Contains(t, result, "| `Security scan` | not reported |")
 	assert.Contains(t, result, "If a check never reports, waiting will not unblock the apply.")
@@ -1283,13 +1305,13 @@ func TestRenderApplyBlockedByInProgressChecks_InProgressAndNotReported(t *testin
 func TestRenderApplyBlockedByInProgressChecks_EmptyList(t *testing.T) {
 	// Defensive guard: rendering with empty slices must not emit an empty
 	// Markdown table (header row with zero data rows). It should fall back
-	// to a generic message that still preserves the header, environment,
+	// to a generic message that still preserves the environment-scoped header
 	// and retry block.
 	for _, inProgress := range [][]BlockingCheck{nil, {}} {
 		result := RenderApplyBlockedByInProgressChecks("staging", inProgress, nil)
 
 		assert.Contains(t, result, "## ⏳ Apply Blocked")
-		assert.Contains(t, result, "**Environment**: `staging`")
+		assert.Contains(t, result, "— Staging")
 		assert.Contains(t, result, "Cannot apply until PR checks finish verifying this commit.")
 		assert.Contains(t, result, "Wait for checks to complete and retry:\n```\nschemabot apply -e staging\n```",
 			"retry command must be inside a fenced code block immediately after the retry copy")

--- a/pkg/webhook/templates/common.go
+++ b/pkg/webhook/templates/common.go
@@ -23,6 +23,31 @@ func humanizeState(s string) string {
 	return capitalizeFirst(strings.ReplaceAll(s, "_", " "))
 }
 
+func environmentTitleSuffix(environment string) string {
+	environment = strings.TrimSpace(environment)
+	if environment == "" {
+		return ""
+	}
+	return " — " + capitalizeFirst(environment)
+}
+
+func titleLabel(value string) string {
+	parts := strings.FieldsFunc(value, func(r rune) bool {
+		return r == '-' || r == '_' || r == ' '
+	})
+	for i, part := range parts {
+		if part == "" {
+			continue
+		}
+		parts[i] = strings.ToUpper(part[:1]) + strings.ToLower(part[1:])
+	}
+	return strings.Join(parts, " ")
+}
+
+func writeEnvironmentTitle(sb *strings.Builder, title, environment string) {
+	fmt.Fprintf(sb, "## %s%s\n\n", title, environmentTitleSuffix(environment))
+}
+
 // TimestampFunc is the function used to generate timestamps in templates.
 // Override in previews/tests to produce deterministic output.
 var TimestampFunc = func() string {
@@ -136,4 +161,11 @@ func writeDBEnvLine(sb *strings.Builder, database, environment string) {
 	} else {
 		fmt.Fprintf(sb, "**Database**: `%s`\n", database)
 	}
+}
+
+func writeDBLine(sb *strings.Builder, database string) {
+	if database == "" {
+		return
+	}
+	fmt.Fprintf(sb, "**Database**: `%s`\n", database)
 }

--- a/pkg/webhook/templates/multi_apply.go
+++ b/pkg/webhook/templates/multi_apply.go
@@ -51,14 +51,14 @@ type MultiDeploymentApplyData struct {
 // per deployment carrying today's per-table UX scoped to that deployment.
 //
 // The single-deployment case is intentionally not handled here: callers render
-// it with RenderApplyStatusComment so that UX stays byte-for-byte unchanged.
+// it with RenderApplyStatusComment so the title and detail vocabulary stay shared.
 func RenderMultiDeploymentApplyComment(data MultiDeploymentApplyData) string {
 	var sb strings.Builder
 	renderedAt := currentTimestamp()
 
 	// Aggregate header: reuse the single-deployment title map keyed on the
 	// derived aggregate state so the headline vocabulary is identical.
-	writeApplyHeader(&sb, ApplyStatusCommentData{State: data.Model.State})
+	writeApplyHeader(&sb, ApplyStatusCommentData{State: data.Model.State, Environment: data.Environment})
 	writeAggregateMetadata(&sb, data, renderedAt)
 	writeDeploymentCounts(&sb, data.Model.Counts)
 	writeAggregateFirstFailure(&sb, data.Model.FirstFailure)
@@ -85,11 +85,11 @@ func RenderMultiDeploymentApplyComment(data MultiDeploymentApplyData) string {
 // summary (RenderApplySummaryComment) rather than its in-progress status.
 //
 // The single-deployment case is intentionally not handled here: callers render
-// it with RenderApplySummaryComment so that UX stays byte-for-byte unchanged.
+// it with RenderApplySummaryComment so the title and detail vocabulary stay shared.
 func RenderMultiDeploymentApplySummaryComment(data MultiDeploymentApplyData) string {
 	var sb strings.Builder
 
-	writeApplyHeader(&sb, ApplyStatusCommentData{State: data.Model.State})
+	writeApplyHeader(&sb, ApplyStatusCommentData{State: data.Model.State, Environment: data.Environment})
 	writeAggregateMetadata(&sb, data, currentTimestamp())
 	writeDeploymentCounts(&sb, data.Model.Counts)
 	writeAggregateFirstFailure(&sb, data.Model.FirstFailure)
@@ -105,17 +105,12 @@ func RenderMultiDeploymentApplySummaryComment(data MultiDeploymentApplyData) str
 
 // writeAggregateMetadata writes the apply-level metadata line. The database is
 // intentionally omitted — it is per-deployment and shown in each deployment's
-// section — so the aggregate carries only the environment, apply ID, elapsed
-// time, and requester.
+// section — so the aggregate carries only the apply ID and requester.
 func writeAggregateMetadata(sb *strings.Builder, data MultiDeploymentApplyData, renderedAt string) {
-	// Environment and ApplyID are always populated from the persisted apply, so
-	// they are rendered unconditionally; only the optional elapsed time is guarded.
+	// ApplyID is always populated from the persisted apply, so it is rendered
+	// unconditionally. Environment is already in the title.
 	parts := []string{
-		fmt.Sprintf("**Environment**: `%s`", data.Environment),
 		fmt.Sprintf("**Apply ID**: `%s`", data.ApplyID),
-	}
-	if elapsed := applyElapsed(ApplyStatusCommentData{StartedAt: data.StartedAt, CompletedAt: data.CompletedAt}); elapsed != "" {
-		parts = append(parts, fmt.Sprintf("**Elapsed**: %s", elapsed))
 	}
 	fmt.Fprintf(sb, "%s\n", strings.Join(parts, " | "))
 	writeAppliedByOrTimestampAt(sb, data.RequestedBy, renderedAt)

--- a/pkg/webhook/templates/multi_apply_test.go
+++ b/pkg/webhook/templates/multi_apply_test.go
@@ -42,7 +42,7 @@ func TestRenderMultiDeploymentApplyComment_BarrierInProgress(t *testing.T) {
 	})
 
 	assert.Contains(t, out, "## Schema Change In Progress")
-	assert.Contains(t, out, "**Environment**: `production`")
+	assert.Contains(t, out, "— Production")
 	assert.Contains(t, out, "**Apply ID**: `apply-123`")
 	assert.Contains(t, out, "_Last updated: <relative-time datetime=\"2026-06-16T19:43:00Z\">2026-06-16 19:43:00 UTC</relative-time> (2026-06-16 19:43:00 UTC)_")
 	assert.NotContains(t, out, "**Last updated**")

--- a/pkg/webhook/templates/plan.go
+++ b/pkg/webhook/templates/plan.go
@@ -76,11 +76,10 @@ func RenderPlanComment(data PlanCommentData) string {
 	var sb strings.Builder
 
 	// Header
-	dbTypeLabel := schemaChangePlanDatabaseTypeLabel(data.DatabaseType, data.IsMySQL)
 	if data.IsLocked {
-		sb.WriteString("## Schema Change Apply\n\n")
+		writeEnvironmentTitle(&sb, "Schema Change Apply", data.Environment)
 	} else {
-		fmt.Fprintf(&sb, "## %s Schema Change Plan\n\n", dbTypeLabel)
+		writeEnvironmentTitle(&sb, "Schema Change Plan", data.Environment)
 	}
 
 	writePlanMetadata(&sb, data)
@@ -186,11 +185,9 @@ func writeApplyHint(sb *strings.Builder, command string) {
 // Schema name (the schema directory) is shown for MySQL. Vitess uses keyspace headers instead.
 func writePlanMetadata(sb *strings.Builder, data PlanCommentData) {
 	parts := []string{fmt.Sprintf("**Database**: `%s`", data.Database)}
+	parts = append(parts, fmt.Sprintf("**Type**: `%s`", schemaChangePlanDatabaseTypeLabel(data.DatabaseType, data.IsMySQL)))
 	if data.IsMySQL && data.SchemaName != "" {
 		parts = append(parts, fmt.Sprintf("**Schema Name**: `%s`", data.SchemaName))
-	}
-	if data.Environment != "" {
-		parts = append(parts, fmt.Sprintf("**Environment**: `%s`", data.Environment))
 	}
 	if data.Tenant != "" {
 		parts = append(parts, fmt.Sprintf("**Tenant**: `%s`", data.Tenant))
@@ -475,10 +472,9 @@ func RenderMultiEnvPlanComment(data MultiEnvPlanCommentData) string {
 	var sb strings.Builder
 
 	// Header
-	dbTypeLabel := schemaChangePlanDatabaseTypeLabel(data.DatabaseType, data.IsMySQL)
-	fmt.Fprintf(&sb, "## %s Schema Change Plan\n\n", dbTypeLabel)
+	sb.WriteString("## Schema Change Plan\n\n")
 
-	writePlanMetadata(&sb, PlanCommentData{Database: data.Database, SchemaName: data.SchemaName})
+	writePlanMetadata(&sb, PlanCommentData{Database: data.Database, SchemaName: data.SchemaName, DatabaseType: data.DatabaseType, IsMySQL: data.IsMySQL})
 	writePlanAttribution(&sb, PlanCommentData{
 		HeadSHA:     data.HeadSHA,
 		Repository:  data.Repository,
@@ -558,16 +554,7 @@ func schemaChangePlanDatabaseTypeLabel(databaseType string, isMySQL bool) string
 }
 
 func titleDatabaseType(databaseType string) string {
-	parts := strings.FieldsFunc(databaseType, func(r rune) bool {
-		return r == '-' || r == '_' || r == ' '
-	})
-	for i, part := range parts {
-		if part == "" {
-			continue
-		}
-		parts[i] = strings.ToUpper(part[:1]) + strings.ToLower(part[1:])
-	}
-	return strings.Join(parts, " ")
+	return titleLabel(databaseType)
 }
 
 // writeEnvironmentPlanSection writes the plan body for a single environment within a multi-env comment.

--- a/pkg/webhook/templates/preview.go
+++ b/pkg/webhook/templates/preview.go
@@ -54,6 +54,21 @@ func PreviewCommentPlan() string {
 	})
 }
 
+// PreviewCommentPlanTenant renders a tenant-targeted plan comment.
+func PreviewCommentPlanTenant() string {
+	return RenderPlanComment(PlanCommentData{
+		Database:    "testapp",
+		SchemaName:  "testapp",
+		Environment: "staging",
+		Tenant:      "alpha",
+		HeadSHA:     previewHeadSHA,
+		Repository:  previewRepository,
+		RequestedBy: previewRequestedBy,
+		IsMySQL:     true,
+		Changes:     samplePlanChanges(),
+	})
+}
+
 // PreviewCommentPlanNoChanges renders a sample plan comment with no changes detected.
 func PreviewCommentPlanNoChanges() string {
 	return RenderPlanComment(PlanCommentData{

--- a/pkg/webhook/templates/rollback.go
+++ b/pkg/webhook/templates/rollback.go
@@ -11,8 +11,7 @@ func RenderRollbackPlanComment(data PlanCommentData) string {
 	var sb strings.Builder
 
 	// Header
-	dbTypeLabel := schemaChangePlanDatabaseTypeLabel(data.DatabaseType, data.IsMySQL)
-	fmt.Fprintf(&sb, "## %s Schema Rollback Plan\n\n", dbTypeLabel)
+	writeEnvironmentTitle(&sb, "Schema Rollback Plan", data.Environment)
 
 	writePlanMetadata(&sb, data)
 	writeRequesterOrTimestamp(&sb, data.RequestedBy)

--- a/pkg/webhook/templates/rollback_test.go
+++ b/pkg/webhook/templates/rollback_test.go
@@ -26,10 +26,11 @@ func TestRenderRollbackPlanComment_WithChanges(t *testing.T) {
 	}
 
 	rendered := RenderRollbackPlanComment(data)
-	assert.Contains(t, rendered, "## MySQL Schema Rollback Plan")
+	assert.Contains(t, rendered, "## Schema Rollback Plan — Staging")
+	assert.Contains(t, rendered, "**Type**: `MySQL`")
 	assert.Contains(t, rendered, "@testuser")
 	assert.Contains(t, rendered, "`testapp`")
-	assert.Contains(t, rendered, "`staging`")
+	assert.Contains(t, rendered, "— Staging")
 	assert.Contains(t, rendered, "DROP INDEX")
 	assert.Contains(t, rendered, "DROP COLUMN")
 	assert.Contains(t, rendered, "destructive changes")
@@ -48,7 +49,7 @@ func TestRenderRollbackPlanComment_NoChanges(t *testing.T) {
 	}
 
 	rendered := RenderRollbackPlanComment(data)
-	assert.Contains(t, rendered, "## MySQL Schema Rollback Plan")
+	assert.Contains(t, rendered, "## Schema Rollback Plan")
 	assert.Contains(t, rendered, "already matches the original schema")
 	assert.NotContains(t, rendered, "schemabot rollback-confirm")
 }
@@ -69,7 +70,8 @@ func TestRenderRollbackPlanComment_Vitess(t *testing.T) {
 	}
 
 	rendered := RenderRollbackPlanComment(data)
-	assert.Contains(t, rendered, "## Vitess Schema Rollback Plan")
+	assert.Contains(t, rendered, "## Schema Rollback Plan")
+	assert.Contains(t, rendered, "**Type**: `Vitess`")
 	assert.Contains(t, rendered, "schemabot rollback-confirm -e staging")
 	assert.NotContains(t, rendered, "schemabot rollback-confirm -e staging -d")
 }
@@ -90,7 +92,8 @@ func TestRenderRollbackPlanComment_CustomDatabaseTypeHeader(t *testing.T) {
 	}
 
 	rendered := RenderRollbackPlanComment(data)
-	assert.Contains(t, rendered, "## Custom Engine Schema Rollback Plan")
+	assert.Contains(t, rendered, "## Schema Rollback Plan")
+	assert.Contains(t, rendered, "**Type**: `Custom Engine`")
 	assert.Contains(t, rendered, "schemabot rollback-confirm -e staging")
 }
 

--- a/pkg/webhook/webhook_e2e_test.go
+++ b/pkg/webhook/webhook_e2e_test.go
@@ -573,7 +573,7 @@ func TestE2EPlanWithChanges(t *testing.T) {
 	// Verify plan comment was posted
 	select {
 	case body := <-result.comments:
-		assert.Contains(t, body, "## MySQL Schema Change Plan")
+		assert.Contains(t, body, "## Schema Change Plan")
 		assert.Contains(t, body, "CREATE TABLE")
 		assert.Contains(t, body, dbName)
 		assert.Contains(t, body, "staging")
@@ -873,7 +873,7 @@ func TestE2EMultiEnvPlan(t *testing.T) {
 	select {
 	case body := <-result.comments:
 		// Should be a combined comment (not separate per env)
-		assert.Contains(t, body, "## MySQL Schema Change Plan")
+		assert.Contains(t, body, "## Schema Change Plan")
 		assert.Contains(t, body, "CREATE TABLE")
 		assert.Contains(t, body, dbName)
 
@@ -948,7 +948,7 @@ func TestE2EMultiEnvPlanDifferentChanges(t *testing.T) {
 	// Wait for the combined comment
 	select {
 	case body := <-result.comments:
-		assert.Contains(t, body, "## MySQL Schema Change Plan")
+		assert.Contains(t, body, "## Schema Change Plan")
 
 		// Plans differ: staging has no changes, production has changes
 		// Should NOT be deduplicated — should show separate sections
@@ -2390,7 +2390,7 @@ func TestE2EPlanUsesServerSideTarget(t *testing.T) {
 	// Verify plan comment was posted with the expected DDL
 	select {
 	case body := <-result.comments:
-		assert.Contains(t, body, "## MySQL Schema Change Plan")
+		assert.Contains(t, body, "## Schema Change Plan")
 		assert.Contains(t, body, "CREATE TABLE")
 		assert.Contains(t, body, dbName)
 	case <-time.After(10 * time.Second):
@@ -2654,7 +2654,7 @@ func TestE2ERollbackPlanViaWebhook(t *testing.T) {
 	// Step 5: Verify rollback plan comment was posted
 	select {
 	case body := <-result.comments:
-		assert.Contains(t, body, "## MySQL Schema Rollback Plan")
+		assert.Contains(t, body, "## Schema Rollback Plan")
 		assert.Contains(t, body, "DROP INDEX", "rollback should drop the index we added")
 		assert.Contains(t, body, "schemabot rollback-confirm -e staging")
 		assert.Contains(t, body, "schemabot unlock")


### PR DESCRIPTION
## Why
When multiple SchemaBot deployments comment on the same PR, the environment needs to be visible where users scan first: the comment title.

## What
- Scope single-environment PR comment titles with the environment, such as `Schema Change Plan — Staging`
- Keep plan and rollback titles generic, with database type shown as `Type` metadata
- Remove redundant environment and elapsed metadata from title-scoped comment headers
- Keep active apply titles stable as `Schema Change In Progress`, with specific phase details in `Status`
- Regenerate `TEMPLATES.md` with the updated preview output

## Risk Assessment
Low — this only changes GitHub PR comment rendering and generated preview docs; schema change execution and storage behavior are unchanged.

Generated with Amp
