### PR TITLE
feat(ux): surface checksumming as a table-level progress state

### DIFF
--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -1964,6 +1964,50 @@ _Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:0
 </details>
 
 <details>
+<summary><a name="second-table-checksumming"></a><strong>Second Table Checksumming</strong></summary>
+
+
+## Schema Change In Progress
+
+**Database**: `testapp` | **Environment**: `staging` | **Apply ID**: `apply-a1b2c3d4e5f6` | **Elapsed**: 8m
+
+*Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
+
+📊 1/3 complete · 1 checksumming · 1 queued
+
+### Table Progress
+
+**`users`**: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦 🔍 Checksumming to verify data...
+
+```sql
+ALTER TABLE `users` ADD INDEX `idx_email`(`email`);
+```
+
+**`products`**: ⏳ Queued
+
+```sql
+ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
+```
+
+**`orders`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+
+```sql
+ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
+```
+
+
+---
+
+To stop this schema change:
+```
+schemabot stop apply-a1b2c3d4e5f6 -e staging
+```
+
+_Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:00 UTC</relative-time> (2026-01-01 00:00:00 UTC)_
+
+</details>
+
+<details>
 <summary><a name="third-table-running"></a><strong>Third Table Running</strong></summary>
 
 
@@ -3150,6 +3194,34 @@ Sequential mode: First complete, second running
      ~ orders: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦⬜⬜⬜⬜⬜⬜⬜⬜ 60%
        ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
        • Rows: 3,000,000 / 5,000,000 · ETA: 12m 15s
+
+     ~ products: ⏳ Queued
+       ALTER TABLE `products` ADD COLUMN `weight_grams` int DEFAULT 0;
+
+     ~ users: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+       ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
+
+
+```
+</details>
+
+<details>
+<summary><a name="mysql-multitable-second-table-checksumming"></a><strong>MySQL: Multi-table Second Table Checksumming</strong></summary>
+
+```
+
+Sequential mode: First complete, second checksumming
+
+┌──────────────────────────────────┐
+│  Apply ID:  apply-a1b2c3d4e5f6   │
+│  State:     Running              │
+│  Started:   Jan 15 14:05:00 UTC  │
+│  Duration:  25m                  │
+└──────────────────────────────────┘
+
+
+     ~ orders: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦 🔍 Checksumming to verify data...
+       ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
 
      ~ products: ⏳ Queued
        ALTER TABLE `products` ADD COLUMN `weight_grams` int DEFAULT 0;

--- a/pkg/cmd/internal/templates/preview_comment.go
+++ b/pkg/cmd/internal/templates/preview_comment.go
@@ -211,6 +211,7 @@ func previewCommentApplyFlowAllOutput() {
 		{"FIRST TABLE RUNNING", func() { fmt.Print(webhooktemplates.PreviewCommentApplyFirstRunning()) }},
 		{"SECOND TABLE RUNNING", func() { fmt.Print(webhooktemplates.PreviewCommentApplyProgress()) }},
 		{"SECOND TABLE ESTIMATE EXCEEDED", func() { fmt.Print(webhooktemplates.PreviewCommentApplyEstimateExceeded()) }},
+		{"SECOND TABLE CHECKSUMMING", func() { fmt.Print(webhooktemplates.PreviewCommentApplyChecksumming()) }},
 		{"THIRD TABLE RUNNING", func() { fmt.Print(webhooktemplates.PreviewCommentApplyThirdRunning()) }},
 		// Sharded tables: compact per-shard summary (inline for few, collapsed for many)
 		{"SHARDED: SHARD PROGRESS", func() { fmt.Print(webhooktemplates.PreviewCommentApplyShardProgress()) }},
@@ -305,6 +306,7 @@ func previewCLIApplyAllOutput() {
 		{"MYSQL: MULTI-TABLE ALL PENDING", previewSeqPendingOutput},
 		{"MYSQL: MULTI-TABLE FIRST TABLE RUNNING", previewSeqFirstRunOutput},
 		{"MYSQL: MULTI-TABLE SECOND TABLE RUNNING", previewSeqSecondRunOutput},
+		{"MYSQL: MULTI-TABLE SECOND TABLE CHECKSUMMING", previewSeqChecksummingOutput},
 		{"MYSQL: MULTI-TABLE THIRD TABLE RUNNING", previewSeqThirdRunOutput},
 		{"MYSQL: MULTI-TABLE ALL COMPLETED", previewSeqAllDoneOutput},
 		{"MYSQL: MULTI-TABLE FIRST TABLE FAILED", previewSeqFirstFailOutput},

--- a/pkg/cmd/internal/templates/preview_sequential.go
+++ b/pkg/cmd/internal/templates/preview_sequential.go
@@ -104,6 +104,24 @@ func previewSeqThirdRunOutput() {
 	WriteProgress(data)
 }
 
+func previewSeqChecksummingOutput() {
+	fmt.Println("Sequential mode: First complete, second checksumming")
+	fmt.Println()
+
+	data := ProgressData{
+		State:     state.Apply.Running,
+		Engine:    "Spirit",
+		ApplyID:   "apply-a1b2c3d4e5f6",
+		StartedAt: previewTime.Add(-25 * time.Minute).Format(time.RFC3339),
+		Tables: []TableProgress{
+			{TableName: "users", DDL: seqDDLs[0].ddl, Status: state.Apply.Completed},
+			{TableName: "orders", DDL: seqDDLs[1].ddl, Status: state.Task.Checksumming},
+			{TableName: "products", DDL: seqDDLs[2].ddl, Status: state.Apply.Pending},
+		},
+	}
+	WriteProgress(data)
+}
+
 func previewSeqAllDoneOutput() {
 	fmt.Println("Sequential mode: All tables completed successfully")
 	fmt.Println()

--- a/pkg/cmd/internal/templates/progress.go
+++ b/pkg/cmd/internal/templates/progress.go
@@ -458,6 +458,15 @@ func FormatTableProgressWithActivity(t TableProgress, activityBar, activityLabel
 		b.WriteString("\n")
 		b.WriteString(FormatShardProgress(t.Shards))
 		return b.String()
+	case state.Task.Checksumming:
+		bar := ui.ProgressBarRowCopy(100) // blue — row copy done, verifying data
+		fmt.Fprintf(&b, indentTable+progressSymbol(t.ChangeType)+"%s: %s 🔍 Checksumming to verify data...\n", t.TableName, bar)
+		if t.DDL != "" {
+			b.WriteString(formatProgressDDL(t.DDL))
+		}
+		b.WriteString("\n")
+		b.WriteString(FormatShardProgress(t.Shards))
+		return b.String()
 	case state.Apply.WaitingForCutover:
 		bar := ui.ProgressBarRowCopy(100) // blue — in progress, row copy done
 		fmt.Fprintf(&b, indentTable+progressSymbol(t.ChangeType)+"%s: %s Waiting for cutover\n", t.TableName, bar)

--- a/pkg/cmd/internal/templates/progress_states_test.go
+++ b/pkg/cmd/internal/templates/progress_states_test.go
@@ -193,6 +193,21 @@ func TestFormatTableProgress_ChangeTypeSymbol(t *testing.T) {
 	}
 }
 
+// A checksumming table renders its own verify label rather than a row-copy
+// percent — its copy is done and the engine is now verifying the data.
+func TestFormatTableProgress_Checksumming(t *testing.T) {
+	tp := TableProgress{
+		TableName:  "orders",
+		ChangeType: "alter",
+		Status:     state.Task.Checksumming,
+	}
+
+	output := FormatTableProgress(tp)
+
+	assert.Contains(t, output, "orders: ")
+	assert.Contains(t, output, "🔍 Checksumming to verify data...")
+}
+
 func TestFormatTableProgress_InstantDDL(t *testing.T) {
 	tp := TableProgress{
 		TableName:  "users",

--- a/pkg/state/apply.go
+++ b/pkg/state/apply.go
@@ -275,6 +275,11 @@ func normalizeApplyState(raw string) string {
 		return Apply.Pending
 	case "RUNNING":
 		return Apply.Running
+	// Checksumming is a table-level (task) state, not an apply state: while one
+	// or more tables verify their copied data, the apply as a whole is still
+	// running. Fold it into Running for the aggregate derivation.
+	case "CHECKSUMMING":
+		return Apply.Running
 	case "RUNNING_DEGRADED":
 		return Apply.RunningDegraded
 	case "PAUSED":

--- a/pkg/state/apply_test.go
+++ b/pkg/state/apply_test.go
@@ -88,6 +88,22 @@ func TestDeriveApplyState_AnyRunning(t *testing.T) {
 	}
 }
 
+// Checksumming is a table-level state, not an apply state: while tables verify
+// their copied data the apply as a whole is still running, so it derives to
+// RUNNING rather than a distinct apply state.
+func TestDeriveApplyState_ChecksummingDerivesRunning(t *testing.T) {
+	testCases := [][]string{
+		{"checksumming"},
+		{"CHECKSUMMING"},
+		{"RUNNING", "checksumming"},
+		{"COMPLETED", "checksumming", "PENDING"},
+	}
+
+	for _, states := range testCases {
+		assert.Equal(t, Apply.Running, DeriveApplyState(states), "input: %v", states)
+	}
+}
+
 func TestDeriveApplyState_AllWaitingForDeploy(t *testing.T) {
 	states := []string{"WAITING_FOR_DEPLOY", "WAITING_FOR_DEPLOY"}
 	assert.Equal(t, Apply.WaitingForDeploy, DeriveApplyState(states))

--- a/pkg/state/task.go
+++ b/pkg/state/task.go
@@ -12,6 +12,7 @@ import (
 var Task = struct {
 	Pending           string
 	Running           string
+	Checksumming      string
 	WaitingForDeploy  string
 	WaitingForCutover string
 	Recovering        string
@@ -26,6 +27,7 @@ var Task = struct {
 }{
 	Pending:           "pending",
 	Running:           "running",
+	Checksumming:      "checksumming",
 	WaitingForDeploy:  "waiting_for_deploy",
 	WaitingForCutover: "waiting_for_cutover",
 	Recovering:        "recovering",
@@ -62,14 +64,14 @@ func IsTerminalTaskState(s string) bool {
 }
 
 // IsInFlightTaskState returns true if the state implies the engine is actively
-// working on the task. These are the only states for which a missing engine
-// migration means the task was abandoned (e.g. a server crash). Resting states
-// such as Stopped and FailedRetryable also have no active engine work, but that
+// working on the task. These are the only states for which missing engine-side
+// work means the task was abandoned (e.g. a server crash). Resting states such
+// as Stopped and FailedRetryable also have no active engine work, but that
 // absence is expected — Spirit keeps the checkpoint while the operator decides
 // whether to resume or retry — so they are excluded here.
 func IsInFlightTaskState(s string) bool {
 	switch NormalizeState(s) {
-	case Task.Running, Task.WaitingForCutover, Task.CuttingOver, Task.WaitingForDeploy, Task.Recovering:
+	case Task.Running, Task.Checksumming, Task.WaitingForCutover, Task.CuttingOver, Task.WaitingForDeploy, Task.Recovering:
 		return true
 	default:
 		return false
@@ -91,13 +93,20 @@ func NormalizeTaskStatus(raw string) string {
 		spiritstatus.Close.String():
 		return Task.Completed
 
+	// Checksumming — Spirit verifies the copied data against the source before
+	// cutover. On a large table this phase can run for hours, so it is surfaced
+	// as its own table state rather than folded into Running. PostChecksum stays
+	// Running: it is applying changeset deltas accumulated during the verify, not
+	// verifying.
+	case spiritstatus.Checksum.String():
+		return Task.Checksumming
+
 	// Running — Spirit sub-states (camelCase from Spirit's State.String())
 	case spiritstatus.CopyRows.String(),
 		spiritstatus.Initial.String(),
 		spiritstatus.ApplyChangeset.String(),
 		spiritstatus.RestoreSecondaryIndexes.String(),
 		spiritstatus.AnalyzeTable.String(),
-		spiritstatus.Checksum.String(),
 		spiritstatus.PostChecksum.String(),
 		spiritstatus.ErrCleanup.String():
 		return Task.Running
@@ -129,7 +138,7 @@ func NormalizeTaskStatus(raw string) string {
 		return Task.Cancelled
 
 	// Pass-through for already-normalized values
-	case Task.Pending, Task.Running, Task.Completed, Task.Stopped, Task.Failed,
+	case Task.Pending, Task.Running, Task.Checksumming, Task.Completed, Task.Stopped, Task.Failed,
 		Task.FailedRetryable, Task.RevertWindow, Task.Reverted,
 		Task.WaitingForDeploy, Task.WaitingForCutover, Task.Recovering,
 		Task.CuttingOver, Task.Cancelled:
@@ -139,7 +148,7 @@ func NormalizeTaskStatus(raw string) string {
 	switch normalized := NormalizeState(s); normalized {
 	case NormalizeState(string(vitessstatus.OnlineDDLStatusComplete)):
 		return Task.Completed
-	case Task.Pending, Task.Running, Task.Completed, Task.Stopped, Task.Failed,
+	case Task.Pending, Task.Running, Task.Checksumming, Task.Completed, Task.Stopped, Task.Failed,
 		Task.FailedRetryable, Task.RevertWindow, Task.Reverted,
 		Task.WaitingForDeploy, Task.WaitingForCutover, Task.Recovering,
 		Task.CuttingOver, Task.Cancelled:

--- a/pkg/state/task_test.go
+++ b/pkg/state/task_test.go
@@ -17,7 +17,7 @@ func TestNormalizeTaskStatus_SpiritStates(t *testing.T) {
 		{spiritstatus.ApplyChangeset.String(), Task.Running},
 		{spiritstatus.RestoreSecondaryIndexes.String(), Task.Running},
 		{spiritstatus.AnalyzeTable.String(), Task.Running},
-		{spiritstatus.Checksum.String(), Task.Running},
+		{spiritstatus.Checksum.String(), Task.Checksumming},
 		{spiritstatus.PostChecksum.String(), Task.Running},
 		{spiritstatus.ErrCleanup.String(), Task.Running},
 		{spiritstatus.WaitingOnSentinelTable.String(), Task.WaitingForCutover},

--- a/pkg/tern/local_client.go
+++ b/pkg/tern/local_client.go
@@ -2380,12 +2380,17 @@ func activeTaskProgressRank(taskState string) (int, bool) {
 		return 1, true
 	case state.Task.Running:
 		return 2, true
-	case state.Task.WaitingForCutover:
+	case state.Task.Checksumming:
+		// Row copy is done; the engine is verifying the copied data. Ranks after
+		// Running and before WaitingForCutover — the phase the table moves through
+		// next — so a later poll never regresses a checksumming table to Running.
 		return 3, true
-	case state.Task.CuttingOver:
+	case state.Task.WaitingForCutover:
 		return 4, true
-	case state.Task.RevertWindow:
+	case state.Task.CuttingOver:
 		return 5, true
+	case state.Task.RevertWindow:
+		return 6, true
 	default:
 		return 0, false
 	}

--- a/pkg/ui/format.go
+++ b/pkg/ui/format.go
@@ -201,7 +201,7 @@ func PluralizeLabel(singular, plural string, count int) string {
 // Used by both CLI (watch TUI) and PR comment rendering for consistent ordering.
 func TableStatePriority(taskState string) int {
 	switch taskState {
-	case state.Task.Running, state.Task.CuttingOver:
+	case state.Task.Running, state.Task.Checksumming, state.Task.CuttingOver:
 		return 0 // active — top
 	case state.Task.WaitingForCutover, state.Task.Recovering, state.Task.FailedRetryable:
 		return 1

--- a/pkg/webhook/templates/apply.go
+++ b/pkg/webhook/templates/apply.go
@@ -232,7 +232,7 @@ func writeProgressSummary(sb *strings.Builder, tables []TableProgressData) {
 		return
 	}
 
-	var completed, running, queued, failed, retrying, stopped, waiting, recovering, cutting, cancelled int
+	var completed, running, checksumming, queued, failed, retrying, stopped, waiting, recovering, cutting, cancelled int
 	var runningPct int
 	var runningEstimateExceeded bool
 
@@ -247,6 +247,8 @@ func writeProgressSummary(sb *strings.Builder, tables []TableProgressData) {
 			} else {
 				runningPct = ui.RowCopyDisplayPercent(t.PercentComplete, t.RowsCopied)
 			}
+		case state.Task.Checksumming:
+			checksumming++
 		case state.Task.Pending:
 			queued++
 		case state.Task.WaitingForCutover:
@@ -285,6 +287,13 @@ func writeProgressSummary(sb *strings.Builder, tables []TableProgressData) {
 			label += fmt.Sprintf(" (%d%%)", runningPct)
 		}
 		parts = append(parts, label)
+	}
+	if checksumming > 0 {
+		if multi {
+			parts = append(parts, fmt.Sprintf("%d checksumming", checksumming))
+		} else {
+			parts = append(parts, "checksumming")
+		}
 	}
 	if queued > 0 && multi {
 		parts = append(parts, fmt.Sprintf("%d queued", queued))
@@ -418,6 +427,13 @@ func renderTableProgress(sb *strings.Builder, table TableProgressData) {
 		fmt.Fprintf(sb, "**`%s`**: %s \u2713 Complete\n", table.TableName, bar)
 		writeDDLLine(sb, table.DDL)
 
+	case state.Task.Checksumming:
+		// Row copy is complete; the engine is verifying the copied data against
+		// the source before cutover. On a large table this can run for hours.
+		bar := ui.ProgressBarRowCopy(100)
+		fmt.Fprintf(sb, "**`%s`**: %s \U0001f50d Checksumming to verify data...\n", table.TableName, bar)
+		writeDDLLine(sb, table.DDL)
+
 	case state.Task.WaitingForCutover:
 		bar := ui.ProgressBarWaitingCutover()
 		if table.ReadyToComplete {
@@ -491,7 +507,7 @@ func renderShardSummary(sb *strings.Builder, table TableProgressData) {
 		return
 	}
 	switch state.NormalizeTaskStatus(table.Status) {
-	case state.Task.Running, state.Task.Recovering, state.Task.CuttingOver, state.Task.WaitingForCutover:
+	case state.Task.Running, state.Task.Checksumming, state.Task.Recovering, state.Task.CuttingOver, state.Task.WaitingForCutover:
 		// in flight — a breakdown adds signal
 	default:
 		return // completed/pending/cancelled/failed: no breakdown, stay quiet

--- a/pkg/webhook/templates/apply_test.go
+++ b/pkg/webhook/templates/apply_test.go
@@ -131,6 +131,31 @@ func TestUnsafeDropUsageTarget(t *testing.T) {
 	}
 }
 
+// A table that has finished copying enters the checksum phase, where the engine
+// verifies the copied data before cutover. It is a table-level state: the apply
+// header stays "In Progress" while the per-table line and summary report
+// checksumming, since on a large table the verify can run for hours.
+func TestRenderApplyStatusComment_Checksumming(t *testing.T) {
+	data := ApplyStatusCommentData{
+		Database:    "testapp",
+		Environment: "staging",
+		RequestedBy: "aparajon",
+		State:       "running",
+		Engine:      "Spirit",
+		Tables: []TableProgressData{
+			{TableName: "orders", DDL: "ALTER TABLE `orders` ADD INDEX `idx_user_id` (`user_id`)", Status: "checksumming"},
+			{TableName: "users", DDL: "ALTER TABLE `users` ADD INDEX `idx_email` (`email`)", Status: "pending"},
+		},
+	}
+
+	result := RenderApplyStatusComment(data)
+
+	assert.Contains(t, result, "## Schema Change In Progress", "apply stays in progress; checksumming is table-level")
+	assert.Contains(t, result, "**`orders`**")
+	assert.Contains(t, result, "🔍 Checksumming to verify data")
+	assert.Contains(t, result, "1 checksumming")
+}
+
 func TestRenderApplyStatusComment_Running(t *testing.T) {
 	withTemplateTimestamp(t, "2026-06-16 19:42:00 UTC")
 	data := ApplyStatusCommentData{

--- a/pkg/webhook/templates/preview.go
+++ b/pkg/webhook/templates/preview.go
@@ -771,6 +771,16 @@ func PreviewCommentApplyProgress() string {
 	return RenderApplyStatusComment(sampleApplyData(state.Apply.Running, tables))
 }
 
+// PreviewCommentApplyChecksumming renders an apply comment where a table has
+// finished copying and entered the checksum phase to verify the copied data.
+func PreviewCommentApplyChecksumming() string {
+	tables := sampleApplyTables()
+	tables[0].Status = state.Task.Completed
+	tables[1].Status = state.Task.Checksumming
+	tables[2].Status = state.Task.Pending
+	return RenderApplyStatusComment(sampleApplyData(state.Apply.Running, tables))
+}
+
 // PreviewCommentApplyEstimateExceeded renders an apply comment where the active row copy has exceeded MySQL's initial estimate.
 func PreviewCommentApplyEstimateExceeded() string {
 	tables := sampleApplyTables()


### PR DESCRIPTION
## Why this matters

Spirit's post-copy checksum phase — where it verifies the copied data against the source before cutover — was folded into a table's `running` state. On a large table this verify can run for hours, so an operator watching progress sees "running" with no indication the copy is done and verification is underway.

## What it does

Surfaces checksumming as its own **table-level** state:

- `NormalizeTaskStatus` maps Spirit's checksum status to `Task.Checksumming` (PostChecksum stays `running` — it applies changeset deltas, it doesn't verify).
- The CLI and PR progress views render "🔍 Checksumming to verify data" for such a table; the summary counts "N checksumming".
- It is **not** an apply state: while one or more tables verify, the apply as a whole is still running, so a checksumming task derives to a running apply and ranks as active work for ordering and shard summaries.

```
copyRows (running) ─► checksum (checksumming) ─► waiting_for_cutover ─► cutting_over
                          └─ apply stays "running" throughout
```

## How it moves toward the northstar

This is the state foundation; a follow-up threads the structured rows-verified progress (verify percent) through the same surfaces so the multi-hour verify shows real movement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)