### PR TITLE
feat(ux): render checksum verify progress in progress views

### DIFF
--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -2024,11 +2024,12 @@ _Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:0
 
 ### Table Progress
 
-**`users`**: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦 🔍 Checksumming to verify data...
+**`users`**: 🟦🟦🟦🟦⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ 🔍 Checksumming to verify data (21%)
 
 ```sql
 ALTER TABLE `users` ADD INDEX `idx_email`(`email`);
 ```
+Rows verified: 321,450 / 1,466,232
 
 **`products`**: ⏳ Queued
 
@@ -3273,8 +3274,9 @@ Sequential mode: First complete, second checksumming
 └──────────────────────────────────┘
 
 
-     ~ orders: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦 🔍 Checksumming to verify data...
+     ~ orders: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦⬜⬜⬜⬜⬜⬜⬜⬜ 🔍 Checksumming to verify data (60%)
        ALTER TABLE `orders` ADD INDEX `idx_user_status`(`user_id`, `status`);
+       • Rows verified: 3,000,000 / 5,000,000
 
      ~ products: ⏳ Queued
        ALTER TABLE `products` ADD COLUMN `weight_grams` int DEFAULT 0;

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.14
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.1
 	github.com/aws/aws-sdk-go-v2/service/sts v1.43.3
-	github.com/block/spirit v0.15.2-0.20260625000508-ce39327a7ec9
+	github.com/block/spirit v0.15.2-0.20260625160741-3bd8ca93a47b
 	github.com/bradleyfalzon/ghinstallation/v2 v2.18.0
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10

--- a/go.sum
+++ b/go.sum
@@ -113,8 +113,8 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/block/spirit v0.15.2-0.20260625000508-ce39327a7ec9 h1:WBcVgShA4ZidIpFF87EoPM/Y7prvcwREUS5MT6Lvf2c=
-github.com/block/spirit v0.15.2-0.20260625000508-ce39327a7ec9/go.mod h1:ku7mCCKx7Wk4QrMa/mHnsqQhZkoUD2vdBkpjJEDk4lY=
+github.com/block/spirit v0.15.2-0.20260625160741-3bd8ca93a47b h1:8LFTfrv1giEGCbWEEvEK9gZ0UB1U7DFbHhrKs80aNL4=
+github.com/block/spirit v0.15.2-0.20260625160741-3bd8ca93a47b/go.mod h1:ku7mCCKx7Wk4QrMa/mHnsqQhZkoUD2vdBkpjJEDk4lY=
 github.com/block/tidb/pkg/parser v0.0.0-20260506200501-e528fd979fc8 h1:+OfdTacrEyjlqcRUpBFX9uJ6ROBq6cUjwY4DClhnsdU=
 github.com/block/tidb/pkg/parser v0.0.0-20260506200501-e528fd979fc8/go.mod h1:zDLDsfNBU5+L6T4J9/OgWAHc/WZvMUjbpgHqQ/t3yKo=
 github.com/block/vitess v0.0.0-20260601162944-8318a748ceb1 h1:dnHGiR/N1+X2EM1FGzL4548iCzJcIAnhcMbEt026xHQ=

--- a/pkg/api/progress_handlers.go
+++ b/pkg/api/progress_handlers.go
@@ -172,18 +172,20 @@ func progressResponseFromProto(resp *ternv1.ProgressResponse) *apitypes.Progress
 
 	for _, t := range resp.Tables {
 		tpr := &apitypes.TableProgressResponse{
-			TableName:       t.TableName,
-			Keyspace:        t.Namespace,
-			ChangeType:      changeTypeToString(t.ChangeType),
-			DDL:             t.Ddl,
-			Status:          t.Status,
-			RowsCopied:      t.RowsCopied,
-			RowsTotal:       t.RowsTotal,
-			PercentComplete: t.PercentComplete,
-			ETASeconds:      t.EtaSeconds,
-			IsInstant:       t.IsInstant,
-			ProgressDetail:  t.ProgressDetail,
-			TaskID:          t.TaskId,
+			TableName:           t.TableName,
+			Keyspace:            t.Namespace,
+			ChangeType:          changeTypeToString(t.ChangeType),
+			DDL:                 t.Ddl,
+			Status:              t.Status,
+			RowsCopied:          t.RowsCopied,
+			RowsTotal:           t.RowsTotal,
+			PercentComplete:     t.PercentComplete,
+			ETASeconds:          t.EtaSeconds,
+			ChecksumRowsChecked: t.ChecksumRowsChecked,
+			ChecksumRowsTotal:   t.ChecksumRowsTotal,
+			IsInstant:           t.IsInstant,
+			ProgressDetail:      t.ProgressDetail,
+			TaskID:              t.TaskId,
 		}
 		for _, sh := range t.Shards {
 			var pct int32
@@ -904,16 +906,18 @@ func (s *Service) progressFromLocalStorage(ctx context.Context, apply *storage.A
 
 	for _, task := range tasks {
 		tpr := &apitypes.TableProgressResponse{
-			TableName:       task.TableName,
-			Keyspace:        task.Namespace,
-			ChangeType:      task.DDLAction,
-			DDL:             task.DDL,
-			Status:          task.State,
-			RowsCopied:      task.RowsCopied,
-			RowsTotal:       task.RowsTotal,
-			PercentComplete: int32(task.ProgressPercent),
-			IsInstant:       task.IsInstant,
-			TaskID:          task.TaskIdentifier,
+			TableName:           task.TableName,
+			Keyspace:            task.Namespace,
+			ChangeType:          task.DDLAction,
+			DDL:                 task.DDL,
+			Status:              task.State,
+			RowsCopied:          task.RowsCopied,
+			RowsTotal:           task.RowsTotal,
+			PercentComplete:     int32(task.ProgressPercent),
+			ChecksumRowsChecked: task.ChecksumRowsChecked,
+			ChecksumRowsTotal:   task.ChecksumRowsTotal,
+			IsInstant:           task.IsInstant,
+			TaskID:              task.TaskIdentifier,
 		}
 		if task.ApplyOperationID != nil {
 			if deployment, ok := deploymentByOperationID[*task.ApplyOperationID]; ok {
@@ -976,6 +980,8 @@ func (s *Service) syncTasksFromTern(ctx context.Context, apply *storage.Apply, t
 		task.RowsCopied = tp.RowsCopied
 		task.RowsTotal = tp.RowsTotal
 		task.ProgressPercent = int(tp.PercentComplete)
+		task.ChecksumRowsChecked = tp.ChecksumRowsChecked
+		task.ChecksumRowsTotal = tp.ChecksumRowsTotal
 		task.UpdatedAt = now
 		if err := s.storage.Tasks().Update(ctx, task); err != nil {
 			s.logger.Error("sync task failed", "task_id", task.TaskIdentifier, "error", err)

--- a/pkg/apitypes/apitypes.go
+++ b/pkg/apitypes/apitypes.go
@@ -395,20 +395,24 @@ type TableProgressResponse struct {
 	DDL       string `json:"ddl"`
 	// Deployment attributes this table/task to a deployment in a multi-deployment apply.
 	// Empty for single-deployment applies.
-	Deployment      string                   `json:"deployment,omitempty"`
-	Keyspace        string                   `json:"keyspace,omitempty"`
-	ChangeType      string                   `json:"change_type,omitempty"` // create, alter, drop
-	Status          string                   `json:"status"`
-	RowsCopied      int64                    `json:"rows_copied"`
-	RowsTotal       int64                    `json:"rows_total"`
-	PercentComplete int32                    `json:"percent_complete"`
-	ETASeconds      int64                    `json:"eta_seconds,omitempty"`
-	IsInstant       bool                     `json:"is_instant,omitempty"`
-	ProgressDetail  string                   `json:"progress_detail,omitempty"`
-	TaskID          string                   `json:"task_id,omitempty"`
-	StartedAt       string                   `json:"started_at,omitempty"`
-	CompletedAt     string                   `json:"completed_at,omitempty"`
-	Shards          []*ShardProgressResponse `json:"shards,omitempty"`
+	Deployment      string `json:"deployment,omitempty"`
+	Keyspace        string `json:"keyspace,omitempty"`
+	ChangeType      string `json:"change_type,omitempty"` // create, alter, drop
+	Status          string `json:"status"`
+	RowsCopied      int64  `json:"rows_copied"`
+	RowsTotal       int64  `json:"rows_total"`
+	PercentComplete int32  `json:"percent_complete"`
+	ETASeconds      int64  `json:"eta_seconds,omitempty"`
+	// Checksum phase progress: rows verified so far and total to verify.
+	// Non-zero only while the table is checksumming (verifying copied data).
+	ChecksumRowsChecked int64                    `json:"checksum_rows_checked,omitempty"`
+	ChecksumRowsTotal   int64                    `json:"checksum_rows_total,omitempty"`
+	IsInstant           bool                     `json:"is_instant,omitempty"`
+	ProgressDetail      string                   `json:"progress_detail,omitempty"`
+	TaskID              string                   `json:"task_id,omitempty"`
+	StartedAt           string                   `json:"started_at,omitempty"`
+	CompletedAt         string                   `json:"completed_at,omitempty"`
+	Shards              []*ShardProgressResponse `json:"shards,omitempty"`
 }
 
 // ShardProgressResponse contains per-shard progress for Vitess schema changes.

--- a/pkg/cmd/internal/templates/preview_sequential.go
+++ b/pkg/cmd/internal/templates/preview_sequential.go
@@ -115,7 +115,7 @@ func previewSeqChecksummingOutput() {
 		StartedAt: previewTime.Add(-25 * time.Minute).Format(time.RFC3339),
 		Tables: []TableProgress{
 			{TableName: "users", DDL: seqDDLs[0].ddl, Status: state.Apply.Completed},
-			{TableName: "orders", DDL: seqDDLs[1].ddl, Status: state.Task.Checksumming},
+			{TableName: "orders", DDL: seqDDLs[1].ddl, Status: state.Task.Checksumming, ChecksumRowsChecked: 3000000, ChecksumRowsTotal: 5000000},
 			{TableName: "products", DDL: seqDDLs[2].ddl, Status: state.Apply.Pending},
 		},
 	}

--- a/pkg/cmd/internal/templates/progress.go
+++ b/pkg/cmd/internal/templates/progress.go
@@ -459,10 +459,22 @@ func FormatTableProgressWithActivity(t TableProgress, activityBar, activityLabel
 		b.WriteString(FormatShardProgress(t.Shards))
 		return b.String()
 	case state.Task.Checksumming:
-		bar := ui.ProgressBarRowCopy(100) // blue — row copy done, verifying data
-		fmt.Fprintf(&b, indentTable+progressSymbol(t.ChangeType)+"%s: %s 🔍 Checksumming to verify data...\n", t.TableName, bar)
-		if t.DDL != "" {
-			b.WriteString(formatProgressDDL(t.DDL))
+		// Row copy is done; the engine is verifying the copied data against the
+		// source. On a large table this can run for hours, so show how far the
+		// verify has progressed once Spirit has reported a total.
+		if t.ChecksumRowsTotal > 0 {
+			pct := ui.ClampPercent(int(t.ChecksumRowsChecked * 100 / t.ChecksumRowsTotal))
+			fmt.Fprintf(&b, indentTable+progressSymbol(t.ChangeType)+"%s: %s 🔍 Checksumming to verify data (%d%%)\n", t.TableName, ui.ProgressBarRowCopy(pct), pct)
+			if t.DDL != "" {
+				b.WriteString(formatProgressDDL(t.DDL))
+			}
+			fmt.Fprintf(&b, indentDetail+"Rows verified: %s / %s\n",
+				ui.FormatNumber(ui.ClampRows(t.ChecksumRowsChecked, t.ChecksumRowsTotal)), ui.FormatNumber(t.ChecksumRowsTotal))
+		} else {
+			fmt.Fprintf(&b, indentTable+progressSymbol(t.ChangeType)+"%s: %s 🔍 Checksumming to verify data...\n", t.TableName, ui.ProgressBarRowCopy(100))
+			if t.DDL != "" {
+				b.WriteString(formatProgressDDL(t.DDL))
+			}
 		}
 		b.WriteString("\n")
 		b.WriteString(FormatShardProgress(t.Shards))

--- a/pkg/cmd/internal/templates/progress_parse.go
+++ b/pkg/cmd/internal/templates/progress_parse.go
@@ -57,9 +57,13 @@ type TableProgress struct {
 	RowsTotal       int64
 	PercentComplete int
 	ETASeconds      int64
-	IsInstant       bool
-	ProgressDetail  string // e.g., Spirit: "12.5% copyRows ETA 1h 30m"
-	Shards          []ShardProgress
+	// Checksum phase progress: rows verified so far and total to verify.
+	// Non-zero only while the table is checksumming (verifying copied data).
+	ChecksumRowsChecked int64
+	ChecksumRowsTotal   int64
+	IsInstant           bool
+	ProgressDetail      string // e.g., Spirit: "12.5% copyRows ETA 1h 30m"
+	Shards              []ShardProgress
 }
 
 // ShardProgress contains per-shard progress for template rendering.
@@ -156,18 +160,20 @@ func ParseProgressResponse(result *apitypes.ProgressResponse) ProgressData {
 
 	for _, tbl := range result.Tables {
 		tp := TableProgress{
-			TableName:       tbl.TableName,
-			Deployment:      tbl.Deployment,
-			Namespace:       tbl.Keyspace,
-			ChangeType:      tbl.ChangeType,
-			DDL:             tbl.DDL,
-			Status:          state.NormalizeState(tbl.Status),
-			RowsCopied:      tbl.RowsCopied,
-			RowsTotal:       tbl.RowsTotal,
-			PercentComplete: int(tbl.PercentComplete),
-			ETASeconds:      tbl.ETASeconds,
-			IsInstant:       tbl.IsInstant,
-			ProgressDetail:  tbl.ProgressDetail,
+			TableName:           tbl.TableName,
+			Deployment:          tbl.Deployment,
+			Namespace:           tbl.Keyspace,
+			ChangeType:          tbl.ChangeType,
+			DDL:                 tbl.DDL,
+			Status:              state.NormalizeState(tbl.Status),
+			RowsCopied:          tbl.RowsCopied,
+			RowsTotal:           tbl.RowsTotal,
+			PercentComplete:     int(tbl.PercentComplete),
+			ETASeconds:          tbl.ETASeconds,
+			ChecksumRowsChecked: tbl.ChecksumRowsChecked,
+			ChecksumRowsTotal:   tbl.ChecksumRowsTotal,
+			IsInstant:           tbl.IsInstant,
+			ProgressDetail:      tbl.ProgressDetail,
 		}
 		for _, sh := range tbl.Shards {
 			tp.Shards = append(tp.Shards, ShardProgress{

--- a/pkg/cmd/internal/templates/progress_states_test.go
+++ b/pkg/cmd/internal/templates/progress_states_test.go
@@ -193,19 +193,24 @@ func TestFormatTableProgress_ChangeTypeSymbol(t *testing.T) {
 	}
 }
 
-// A checksumming table renders its own verify label rather than a row-copy
-// percent — its copy is done and the engine is now verifying the data.
+// A checksumming table renders its verify progress rather than a row-copy
+// percent — its copy is done and the engine is now verifying the data, which
+// can run for hours on a large table.
 func TestFormatTableProgress_Checksumming(t *testing.T) {
-	tp := TableProgress{
-		TableName:  "orders",
-		ChangeType: "alter",
-		Status:     state.Task.Checksumming,
-	}
+	// Before Spirit reports a total, the verify shows an indeterminate label.
+	measuring := FormatTableProgress(TableProgress{
+		TableName: "orders", ChangeType: "alter", Status: state.Task.Checksumming,
+	})
+	assert.Contains(t, measuring, "orders: ")
+	assert.Contains(t, measuring, "🔍 Checksumming to verify data...")
 
-	output := FormatTableProgress(tp)
-
-	assert.Contains(t, output, "orders: ")
-	assert.Contains(t, output, "🔍 Checksumming to verify data...")
+	// Once a total is known, it shows how far the verify has progressed.
+	withProgress := FormatTableProgress(TableProgress{
+		TableName: "orders", ChangeType: "alter", Status: state.Task.Checksumming,
+		ChecksumRowsChecked: 321450, ChecksumRowsTotal: 1466232,
+	})
+	assert.Contains(t, withProgress, "🔍 Checksumming to verify data (21%)")
+	assert.Contains(t, withProgress, "Rows verified: 321,450 / 1,466,232")
 }
 
 func TestFormatTableProgress_InstantDDL(t *testing.T) {

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -340,19 +340,23 @@ type ProgressResult struct {
 
 // TableProgress tracks progress for a single table.
 type TableProgress struct {
-	Namespace      string          // Schema/keyspace name when the engine can distinguish it
-	Table          string          // Table name
-	State          string          // "pending", "copying", "ready", "complete", "failed"
-	Progress       int             // 0-100 percent
-	RowsCopied     int64           // Actual rows copied
-	RowsTotal      int64           // Total rows to copy
-	ETASeconds     int64           // Estimated seconds remaining
-	Shards         []ShardProgress // Per-shard breakdown (for Vitess)
-	IsInstant      bool            // True if using instant DDL
-	ProgressDetail string          // Human-readable progress (e.g., Spirit: "12.5% copyRows ETA 1h 30m")
-	DDL            string          // The DDL statement being applied
-	StartedAt      *time.Time      // When execution actually began (from engine, e.g., SHOW VITESS_MIGRATIONS started_timestamp)
-	CompletedAt    *time.Time      // When execution completed (from engine)
+	Namespace  string // Schema/keyspace name when the engine can distinguish it
+	Table      string // Table name
+	State      string // "pending", "copying", "ready", "complete", "failed"
+	Progress   int    // 0-100 percent
+	RowsCopied int64  // Actual rows copied
+	RowsTotal  int64  // Total rows to copy
+	ETASeconds int64  // Estimated seconds remaining
+	// Checksum phase progress: rows verified so far and the total to verify.
+	// Populated while the table is checksumming (verifying copied data), 0 otherwise.
+	ChecksumRowsChecked int64
+	ChecksumRowsTotal   int64
+	Shards              []ShardProgress // Per-shard breakdown (for Vitess)
+	IsInstant           bool            // True if using instant DDL
+	ProgressDetail      string          // Human-readable progress (e.g., Spirit: "12.5% copyRows ETA 1h 30m")
+	DDL                 string          // The DDL statement being applied
+	StartedAt           *time.Time      // When execution actually began (from engine, e.g., SHOW VITESS_MIGRATIONS started_timestamp)
+	CompletedAt         *time.Time      // When execution completed (from engine)
 }
 
 // ShardProgress tracks progress for a single shard.

--- a/pkg/engine/spirit/spirit.go
+++ b/pkg/engine/spirit/spirit.go
@@ -556,6 +556,14 @@ func buildSpiritTableProgress(prog status.Progress, stateStr string, ddlByTable,
 		} else if st.RowsTotal > 0 {
 			tp.ETASeconds = etaSeconds
 		}
+		// Spirit reports a single runner-wide checksum estimate (rows verified so
+		// far / total to verify), populated only during the verify phase and zero
+		// otherwise. Surface it on the tables still in flight so consumers can
+		// render verify progress; completed tables keep zero.
+		if !st.IsComplete {
+			tp.ChecksumRowsChecked = int64(prog.Checksum.RowsChecked)
+			tp.ChecksumRowsTotal = int64(prog.Checksum.RowsTotal)
+		}
 		tableProgress = append(tableProgress, tp)
 	}
 	return tableProgress

--- a/pkg/proto/tern.proto
+++ b/pkg/proto/tern.proto
@@ -479,6 +479,10 @@ message TableProgress {
   repeated ShardProgress shards = 11;
   string progress_detail = 12;
   ChangeType change_type = 13;
+  // Checksum phase progress: rows verified so far and the total to verify.
+  // Populated while the table is checksumming (verifying copied data), 0 otherwise.
+  int64 checksum_rows_checked = 14;
+  int64 checksum_rows_total = 15;
 }
 
 // ProgressResponse contains detailed progress information.

--- a/pkg/proto/ternv1/tern.pb.go
+++ b/pkg/proto/ternv1/tern.pb.go
@@ -1742,8 +1742,12 @@ type TableProgress struct {
 	Shards          []*ShardProgress       `protobuf:"bytes,11,rep,name=shards,proto3" json:"shards,omitempty"`
 	ProgressDetail  string                 `protobuf:"bytes,12,opt,name=progress_detail,json=progressDetail,proto3" json:"progress_detail,omitempty"`
 	ChangeType      ChangeType             `protobuf:"varint,13,opt,name=change_type,json=changeType,proto3,enum=tern.v1.ChangeType" json:"change_type,omitempty"`
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
+	// Checksum phase progress: rows verified so far and the total to verify.
+	// Populated while the table is checksumming (verifying copied data), 0 otherwise.
+	ChecksumRowsChecked int64 `protobuf:"varint,14,opt,name=checksum_rows_checked,json=checksumRowsChecked,proto3" json:"checksum_rows_checked,omitempty"`
+	ChecksumRowsTotal   int64 `protobuf:"varint,15,opt,name=checksum_rows_total,json=checksumRowsTotal,proto3" json:"checksum_rows_total,omitempty"`
+	unknownFields       protoimpl.UnknownFields
+	sizeCache           protoimpl.SizeCache
 }
 
 func (x *TableProgress) Reset() {
@@ -1865,6 +1869,20 @@ func (x *TableProgress) GetChangeType() ChangeType {
 		return x.ChangeType
 	}
 	return ChangeType_CHANGE_TYPE_OTHER
+}
+
+func (x *TableProgress) GetChecksumRowsChecked() int64 {
+	if x != nil {
+		return x.ChecksumRowsChecked
+	}
+	return 0
+}
+
+func (x *TableProgress) GetChecksumRowsTotal() int64 {
+	if x != nil {
+		return x.ChecksumRowsTotal
+	}
+	return 0
 }
 
 // ProgressResponse contains detailed progress information.
@@ -2947,7 +2965,7 @@ const file_tern_proto_rawDesc = "" +
 	"etaSeconds\x12)\n" +
 	"\x10cutover_attempts\x18\x06 \x01(\x05R\x0fcutoverAttempts\x120\n" +
 	"\x14last_cutover_attempt\x18\a \x01(\tR\x12lastCutoverAttempt\x12*\n" +
-	"\x11ready_to_complete\x18\b \x01(\bR\x0freadyToComplete\"\xc9\x03\n" +
+	"\x11ready_to_complete\x18\b \x01(\bR\x0freadyToComplete\"\xad\x04\n" +
 	"\rTableProgress\x12\x17\n" +
 	"\atask_id\x18\x01 \x01(\tR\x06taskId\x12\x1c\n" +
 	"\tnamespace\x18\x02 \x01(\tR\tnamespace\x12\x1d\n" +
@@ -2968,7 +2986,9 @@ const file_tern_proto_rawDesc = "" +
 	"\x06shards\x18\v \x03(\v2\x16.tern.v1.ShardProgressR\x06shards\x12'\n" +
 	"\x0fprogress_detail\x18\f \x01(\tR\x0eprogressDetail\x124\n" +
 	"\vchange_type\x18\r \x01(\x0e2\x13.tern.v1.ChangeTypeR\n" +
-	"changeType\"\xc7\x03\n" +
+	"changeType\x122\n" +
+	"\x15checksum_rows_checked\x18\x0e \x01(\x03R\x13checksumRowsChecked\x12.\n" +
+	"\x13checksum_rows_total\x18\x0f \x01(\x03R\x11checksumRowsTotal\"\xc7\x03\n" +
 	"\x10ProgressResponse\x12\x19\n" +
 	"\bapply_id\x18\x01 \x01(\tR\aapplyId\x12$\n" +
 	"\x05state\x18\x02 \x01(\x0e2\x0e.tern.v1.StateR\x05state\x12'\n" +

--- a/pkg/schema/mysql/tasks.sql
+++ b/pkg/schema/mysql/tasks.sql
@@ -23,6 +23,8 @@ CREATE TABLE `tasks` (
   `rows_total` bigint DEFAULT '0',
   `progress_percent` int DEFAULT '0',
   `eta_seconds` int DEFAULT NULL,
+  `checksum_rows_checked` bigint DEFAULT '0',
+  `checksum_rows_total` bigint DEFAULT '0',
   `cutover_attempts` int NOT NULL DEFAULT '0',
   `is_instant` tinyint(1) DEFAULT '0',
   `ready_to_complete` tinyint(1) DEFAULT '0',

--- a/pkg/storage/mysqlstore/tasks.go
+++ b/pkg/storage/mysqlstore/tasks.go
@@ -18,7 +18,7 @@ import (
 const taskColumns = `id, task_identifier, apply_id, apply_operation_id, plan_id, database_name, database_type,
 	namespace, table_name, shard, ddl, ddl_action,
 	engine, repository, pull_request, environment, state, error_message, options, attempt,
-	rows_copied, rows_total, progress_percent, eta_seconds, cutover_attempts,
+	rows_copied, rows_total, progress_percent, eta_seconds, checksum_rows_checked, checksum_rows_total, cutover_attempts,
 	is_instant, ready_to_complete, engine_migration_id,
 	started_at, completed_at, created_at, updated_at`
 
@@ -65,16 +65,16 @@ func insertTask(ctx context.Context, execer taskInserter, task *storage.Task) (i
 			task_identifier, apply_id, apply_operation_id, plan_id, database_name, database_type,
 			namespace, table_name, shard, ddl, ddl_action,
 			engine, repository, pull_request, environment, state, error_message, options, attempt,
-			rows_copied, rows_total, progress_percent, eta_seconds, cutover_attempts,
+			rows_copied, rows_total, progress_percent, eta_seconds, checksum_rows_checked, checksum_rows_total, cutover_attempts,
 			is_instant, ready_to_complete, engine_migration_id,
 			started_at, completed_at, created_at, updated_at
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`,
 		task.TaskIdentifier, task.ApplyID, nullInt64Ptr(task.ApplyOperationID), task.PlanID, task.Database, task.DatabaseType,
 		task.Namespace, nullString(task.TableName), task.Shard, nullString(task.DDL), nullString(task.DDLAction),
 		task.Engine, task.Repository, task.PullRequest, task.Environment,
 		task.State, nullString(task.ErrorMessage), string(options), task.Attempt,
-		task.RowsCopied, task.RowsTotal, task.ProgressPercent, task.ETASeconds, task.CutoverAttempts,
+		task.RowsCopied, task.RowsTotal, task.ProgressPercent, task.ETASeconds, task.ChecksumRowsChecked, task.ChecksumRowsTotal, task.CutoverAttempts,
 		task.IsInstant, task.ReadyToComplete, nullString(task.EngineMigrationID),
 		task.StartedAt, task.CompletedAt, task.CreatedAt, task.UpdatedAt,
 	)
@@ -111,7 +111,7 @@ func (s *taskStore) Get(ctx context.Context, taskIdentifier string) (*storage.Ta
 func (s *taskStore) Update(ctx context.Context, task *storage.Task) error {
 	args := []any{
 		task.State, nullString(task.ErrorMessage), nullJSON(task.Options), task.Attempt,
-		task.RowsCopied, task.RowsTotal, task.ProgressPercent, task.ETASeconds, task.CutoverAttempts,
+		task.RowsCopied, task.RowsTotal, task.ProgressPercent, task.ETASeconds, task.ChecksumRowsChecked, task.ChecksumRowsTotal, task.CutoverAttempts,
 		task.IsInstant, task.ReadyToComplete, nullString(task.EngineMigrationID),
 		task.StartedAt, task.CompletedAt,
 		task.ID,
@@ -146,7 +146,7 @@ func (s *taskStore) Update(ctx context.Context, task *storage.Task) error {
 	result, err := s.db.ExecContext(ctx, `
 		UPDATE tasks SET
 			state = ?, error_message = ?, options = ?, attempt = ?,
-			rows_copied = ?, rows_total = ?, progress_percent = ?, eta_seconds = ?, cutover_attempts = ?,
+			rows_copied = ?, rows_total = ?, progress_percent = ?, eta_seconds = ?, checksum_rows_checked = ?, checksum_rows_total = ?, cutover_attempts = ?,
 			is_instant = ?, ready_to_complete = ?, engine_migration_id = ?,
 			started_at = ?, completed_at = ?, updated_at = NOW()
 		WHERE id = ?`+leasePredicate+`
@@ -242,11 +242,11 @@ func (s *taskStore) insertShardTaskGuarded(ctx context.Context, task *storage.Ta
 			task_identifier, apply_id, apply_operation_id, plan_id, database_name, database_type,
 			namespace, table_name, shard, ddl, ddl_action,
 			engine, repository, pull_request, environment, state, error_message, options, attempt,
-			rows_copied, rows_total, progress_percent, eta_seconds, cutover_attempts,
+			rows_copied, rows_total, progress_percent, eta_seconds, checksum_rows_checked, checksum_rows_total, cutover_attempts,
 			is_instant, ready_to_complete, engine_migration_id,
 			started_at, completed_at, created_at, updated_at
 		)
-		SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+		SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
 		FROM apply_operations ao
 		WHERE ao.id = ? AND ao.lease_token = ?
 	`,
@@ -254,7 +254,7 @@ func (s *taskStore) insertShardTaskGuarded(ctx context.Context, task *storage.Ta
 		task.Namespace, nullString(task.TableName), task.Shard, nullString(task.DDL), nullString(task.DDLAction),
 		task.Engine, task.Repository, task.PullRequest, task.Environment,
 		task.State, nullString(task.ErrorMessage), string(options), task.Attempt,
-		task.RowsCopied, task.RowsTotal, task.ProgressPercent, task.ETASeconds, task.CutoverAttempts,
+		task.RowsCopied, task.RowsTotal, task.ProgressPercent, task.ETASeconds, task.ChecksumRowsChecked, task.ChecksumRowsTotal, task.CutoverAttempts,
 		task.IsInstant, task.ReadyToComplete, nullString(task.EngineMigrationID),
 		task.StartedAt, task.CompletedAt, task.CreatedAt, task.UpdatedAt,
 		opLease.OperationID, opLease.Token,
@@ -498,6 +498,8 @@ func scanTaskInto(s scanner) (*storage.Task, error) {
 		&task.RowsTotal,
 		&task.ProgressPercent,
 		&etaSeconds,
+		&task.ChecksumRowsChecked,
+		&task.ChecksumRowsTotal,
 		&task.CutoverAttempts,
 		&task.IsInstant,
 		&task.ReadyToComplete,

--- a/pkg/storage/types.go
+++ b/pkg/storage/types.go
@@ -849,7 +849,11 @@ type Task struct {
 	RowsTotal       int64 // Total rows to copy
 	ProgressPercent int   // 0-100
 	ETASeconds      int   // Estimated seconds remaining
-	CutoverAttempts int   // Number of cutover attempts for this shard
+	// Checksum phase progress: rows verified so far and total to verify.
+	// Non-zero only while the task is checksumming (verifying copied data).
+	ChecksumRowsChecked int64
+	ChecksumRowsTotal   int64
+	CutoverAttempts     int // Number of cutover attempts for this shard
 
 	// Execution flags
 	IsInstant         bool   // True if INSTANT DDL (no copy needed)

--- a/pkg/tern/grpc_client.go
+++ b/pkg/tern/grpc_client.go
@@ -2434,6 +2434,8 @@ func (c *GRPCClient) syncStoredTasksFromRemoteTasks(
 			storedTask.RowsCopied = remoteTask.RowsCopied
 			storedTask.RowsTotal = remoteTask.RowsTotal
 			storedTask.ProgressPercent = int(remoteTask.PercentComplete)
+			storedTask.ChecksumRowsChecked = remoteTask.ChecksumRowsChecked
+			storedTask.ChecksumRowsTotal = remoteTask.ChecksumRowsTotal
 		}
 		if state.IsState(storedTask.State, state.Task.Completed) && storedTask.ProgressPercent != 100 {
 			storedTask.ProgressPercent = 100

--- a/pkg/tern/local_apply_grouped.go
+++ b/pkg/tern/local_apply_grouped.go
@@ -1061,6 +1061,8 @@ func (c *LocalClient) syncAtomicTaskProgress(ctx context.Context, tasks []*stora
 			task.RowsTotal = tp.RowsTotal
 			task.ProgressPercent = tp.Progress
 			task.ETASeconds = int(tp.ETASeconds)
+			task.ChecksumRowsChecked = tp.ChecksumRowsChecked
+			task.ChecksumRowsTotal = tp.ChecksumRowsTotal
 			task.IsInstant = tp.IsInstant
 			if tp.StartedAt != nil && task.StartedAt == nil {
 				task.StartedAt = tp.StartedAt

--- a/pkg/tern/local_apply_sequential.go
+++ b/pkg/tern/local_apply_sequential.go
@@ -333,6 +333,8 @@ func (c *LocalClient) pollTaskToCompletion(ctx context.Context, apply *storage.A
 				task.RowsTotal = tp.RowsTotal
 				task.ProgressPercent = tp.Progress
 				task.ETASeconds = int(tp.ETASeconds)
+				task.ChecksumRowsChecked = tp.ChecksumRowsChecked
+				task.ChecksumRowsTotal = tp.ChecksumRowsTotal
 				task.IsInstant = tp.IsInstant
 			}
 

--- a/pkg/tern/local_client.go
+++ b/pkg/tern/local_client.go
@@ -2066,6 +2066,8 @@ func (c *LocalClient) Progress(ctx context.Context, req *ternv1.ProgressRequest)
 		tp.PercentComplete = int32(t.ProgressPercent)
 		tp.RowsCopied = t.RowsCopied
 		tp.RowsTotal = t.RowsTotal
+		tp.ChecksumRowsChecked = t.ChecksumRowsChecked
+		tp.ChecksumRowsTotal = t.ChecksumRowsTotal
 		// Clamp to 100% only for successfully completed tasks — Vitess row
 		// counts can lag slightly due to concurrent inserts during copy.
 		if state.IsState(t.State, state.Task.Completed) && t.RowsTotal > 0 {

--- a/pkg/tern/local_control.go
+++ b/pkg/tern/local_control.go
@@ -819,6 +819,8 @@ func (c *LocalClient) markTasksWithState(ctx context.Context, tasks []*storage.T
 			task.RowsTotal = et.RowsTotal
 			task.ProgressPercent = et.Progress
 			task.ETASeconds = int(et.ETASeconds)
+			task.ChecksumRowsChecked = et.ChecksumRowsChecked
+			task.ChecksumRowsTotal = et.ChecksumRowsTotal
 		}
 
 		c.transitionTaskState(ctx, task, task.ApplyID, newState,

--- a/pkg/webhook/apply.go
+++ b/pkg/webhook/apply.go
@@ -101,18 +101,20 @@ func tableProgressFromTasks(databaseFallback string, tasks []*storage.Task, shar
 			ns = databaseFallback
 		}
 		out = append(out, templates.TableProgressData{
-			Namespace:       ns,
-			TableName:       t.TableName,
-			DDL:             t.DDL,
-			Status:          string(t.State),
-			RowsCopied:      t.RowsCopied,
-			RowsTotal:       t.RowsTotal,
-			PercentComplete: t.ProgressPercent,
-			ETASeconds:      int64(t.ETASeconds),
-			IsInstant:       t.IsInstant,
-			ReadyToComplete: t.ReadyToComplete,
-			ErrorMessage:    t.ErrorMessage,
-			Shards:          shardProgressForTable(shardsByTable, t.ApplyOperationID, t.Namespace, t.TableName),
+			Namespace:           ns,
+			TableName:           t.TableName,
+			DDL:                 t.DDL,
+			Status:              string(t.State),
+			RowsCopied:          t.RowsCopied,
+			RowsTotal:           t.RowsTotal,
+			PercentComplete:     t.ProgressPercent,
+			ETASeconds:          int64(t.ETASeconds),
+			ChecksumRowsChecked: t.ChecksumRowsChecked,
+			ChecksumRowsTotal:   t.ChecksumRowsTotal,
+			IsInstant:           t.IsInstant,
+			ReadyToComplete:     t.ReadyToComplete,
+			ErrorMessage:        t.ErrorMessage,
+			Shards:              shardProgressForTable(shardsByTable, t.ApplyOperationID, t.Namespace, t.TableName),
 		})
 	}
 	return out

--- a/pkg/webhook/templates/apply.go
+++ b/pkg/webhook/templates/apply.go
@@ -24,8 +24,12 @@ type TableProgressData struct {
 	RowsTotal       int64
 	PercentComplete int
 	ETASeconds      int64
-	IsInstant       bool
-	ReadyToComplete bool
+	// Checksum phase progress: rows verified so far and total to verify.
+	// Non-zero only while the table is checksumming (verifying copied data).
+	ChecksumRowsChecked int64
+	ChecksumRowsTotal   int64
+	IsInstant           bool
+	ReadyToComplete     bool
 
 	// ErrorMessage is the task's last error. Rendered for states where the
 	// per-table error explains what the user is seeing (e.g. a retrying task).
@@ -431,10 +435,18 @@ func renderTableProgress(sb *strings.Builder, table TableProgressData) {
 
 	case state.Task.Checksumming:
 		// Row copy is complete; the engine is verifying the copied data against
-		// the source before cutover. On a large table this can run for hours.
-		bar := ui.ProgressBarRowCopy(100)
-		fmt.Fprintf(sb, "**`%s`**: %s \U0001f50d Checksumming to verify data...\n", table.TableName, bar)
-		writeDDLLine(sb, table.DDL)
+		// the source before cutover. On a large table this can run for hours, so
+		// show how far the verify has progressed once Spirit reports a total.
+		if table.ChecksumRowsTotal > 0 {
+			pct := ui.ClampPercent(int(table.ChecksumRowsChecked * 100 / table.ChecksumRowsTotal))
+			fmt.Fprintf(sb, "**`%s`**: %s \U0001f50d Checksumming to verify data (%d%%)\n", table.TableName, ui.ProgressBarRowCopy(pct), pct)
+			writeDDLLine(sb, table.DDL)
+			fmt.Fprintf(sb, "Rows verified: %s / %s\n",
+				ui.FormatNumber(ui.ClampRows(table.ChecksumRowsChecked, table.ChecksumRowsTotal)), ui.FormatNumber(table.ChecksumRowsTotal))
+		} else {
+			fmt.Fprintf(sb, "**`%s`**: %s \U0001f50d Checksumming to verify data...\n", table.TableName, ui.ProgressBarRowCopy(100))
+			writeDDLLine(sb, table.DDL)
+		}
 
 	case state.Task.WaitingForCutover:
 		bar := ui.ProgressBarWaitingCutover()

--- a/pkg/webhook/templates/apply_test.go
+++ b/pkg/webhook/templates/apply_test.go
@@ -164,7 +164,7 @@ func TestRenderApplyStatusComment_Checksumming(t *testing.T) {
 		State:       "running",
 		Engine:      "Spirit",
 		Tables: []TableProgressData{
-			{TableName: "orders", DDL: "ALTER TABLE `orders` ADD INDEX `idx_user_id` (`user_id`)", Status: "checksumming"},
+			{TableName: "orders", DDL: "ALTER TABLE `orders` ADD INDEX `idx_user_id` (`user_id`)", Status: "checksumming", ChecksumRowsChecked: 321450, ChecksumRowsTotal: 1466232},
 			{TableName: "users", DDL: "ALTER TABLE `users` ADD INDEX `idx_email` (`email`)", Status: "pending"},
 		},
 	}
@@ -173,7 +173,8 @@ func TestRenderApplyStatusComment_Checksumming(t *testing.T) {
 
 	assert.Contains(t, result, "## Schema Change In Progress", "apply stays in progress; checksumming is table-level")
 	assert.Contains(t, result, "**`orders`**")
-	assert.Contains(t, result, "🔍 Checksumming to verify data")
+	assert.Contains(t, result, "🔍 Checksumming to verify data (21%)")
+	assert.Contains(t, result, "Rows verified: 321,450 / 1,466,232")
 	assert.Contains(t, result, "1 checksumming")
 }
 

--- a/pkg/webhook/templates/preview.go
+++ b/pkg/webhook/templates/preview.go
@@ -792,6 +792,8 @@ func PreviewCommentApplyChecksumming() string {
 	tables := sampleApplyTables()
 	tables[0].Status = state.Task.Completed
 	tables[1].Status = state.Task.Checksumming
+	tables[1].ChecksumRowsChecked = 321450
+	tables[1].ChecksumRowsTotal = 1466232
 	tables[2].Status = state.Task.Pending
 	return RenderApplyStatusComment(sampleApplyData(state.Apply.Running, tables))
 }


### PR DESCRIPTION
## Why this matters

Checksumming a large table can run for hours. With only a "Checksumming" label and no movement, an operator can't tell a verify that's advancing from one that's hung.

## What it does

Threads Spirit's structured checksum progress (rows verified / total to verify) through to both progress surfaces:

- Dedicated `ChecksumRowsChecked` / `ChecksumRowsTotal` flow **Spirit → engine → storage (new `tasks` columns) → API types → tern proto → templates**, mirroring the row-copy counters.
- The CLI and PR comment render **"Checksumming to verify data (N%)"** with a **"Rows verified: X / Y"** line once a total is known, falling back to the indeterminate label before then.
- The verify phase ranks between row-copy and cutover in the no-backward-progress ordering, so a later poll never regresses a checksumming table.

```
status.Progress.Checksum {RowsChecked, RowsTotal}
   └─► engine.TableProgress ─► tasks row ─► apitypes / ternv1 proto
        ├─► CLI : "🔍 Checksumming to verify data (60%)" + "Rows verified: 3,000,000 / 5,000,000"
        └─► PR  : same, in the per-table line
```

Stacked on #526 (the `Task.Checksumming` state) and requires the Spirit bump in this PR for `status.Progress.Checksum`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)