### PR TITLE
feat(ux): link the PlanetScale deploy request in the apply comment

### DIFF
--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -2194,6 +2194,8 @@ _Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:0
 
 *Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
 
+🔗 **Deploy request**: https://app.planetscale.com/acme/myapp/deploy-requests/42
+
 ### Table Progress
 
 **`users`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
@@ -3394,7 +3396,6 @@ Use 'schemabot start' to resume from checkpoint.
 │  Database:     myapp                     │
 │  Environment:  staging                   │
 │  State:        Refreshing branch schema  │
-│  Branch:       my-reusable-branch        │
 └──────────────────────────────────────────┘
 
 
@@ -3411,7 +3412,6 @@ Use 'schemabot start' to resume from checkpoint.
 │  Database:     myapp                                      │
 │  Environment:  staging                                    │
 │  State:        Applied keyspace myapp_sharded_003 (8/12)  │
-│  Branch:       schemabot-myapp-28471035                   │
 └───────────────────────────────────────────────────────────┘
 
 
@@ -3423,13 +3423,12 @@ Use 'schemabot start' to resume from checkpoint.
 
 ```
 
-┌──────────────────────────────────────────┐
-│  Apply ID:     apply-a1b2c3d4e5f6        │
-│  Database:     myapp                     │
-│  Environment:  staging                   │
-│  State:        Validating branch         │
-│  Branch:       schemabot-myapp-28471035  │
-└──────────────────────────────────────────┘
+┌────────────────────────────────────┐
+│  Apply ID:     apply-a1b2c3d4e5f6  │
+│  Database:     myapp               │
+│  Environment:  staging             │
+│  State:        Validating branch   │
+└────────────────────────────────────┘
 
 
 ```
@@ -3440,13 +3439,12 @@ Use 'schemabot start' to resume from checkpoint.
 
 ```
 
-┌──────────────────────────────────────────┐
-│  Apply ID:     apply-a1b2c3d4e5f6        │
-│  Database:     myapp                     │
-│  Environment:  staging                   │
-│  State:        Creating deploy request   │
-│  Branch:       schemabot-myapp-28471035  │
-└──────────────────────────────────────────┘
+┌─────────────────────────────────────────┐
+│  Apply ID:     apply-a1b2c3d4e5f6       │
+│  Database:     myapp                    │
+│  Environment:  staging                  │
+│  State:        Creating deploy request  │
+└─────────────────────────────────────────┘
 
 
 ```
@@ -3462,7 +3460,6 @@ Use 'schemabot start' to resume from checkpoint.
 │  Database:        myapp                                                        │
 │  Environment:     staging                                                      │
 │  State:           Validating deploy request                                    │
-│  Branch:          schemabot-myapp-28471035                                     │
 │  Deploy Request:  https://app.planetscale.com/my-org/myapp/deploy-requests/42  │
 └────────────────────────────────────────────────────────────────────────────────┘
 
@@ -3506,7 +3503,6 @@ Use 'schemabot start' to resume from checkpoint.
 │  Database:        myapp                                                        │
 │  Environment:     staging                                                      │
 │  State:           Running                                                      │
-│  Branch:          schemabot-myapp-28471035                                     │
 │  Deploy Request:  https://app.planetscale.com/my-org/myapp/deploy-requests/42  │
 │  Started:         Jan 15 14:29:30 UTC                                          │
 │  Duration:        30s                                                          │
@@ -3532,7 +3528,6 @@ Use 'schemabot start' to resume from checkpoint.
 │  Database:        myapp                                                        │
 │  Environment:     staging                                                      │
 │  State:           Completed                                                    │
-│  Branch:          schemabot-myapp-28471035                                     │
 │  Deploy Request:  https://app.planetscale.com/my-org/myapp/deploy-requests/42  │
 │  Started:         Jan 15 14:28:30 UTC                                          │
 │  Duration:        1m 30s                                                       │
@@ -3558,7 +3553,6 @@ Use 'schemabot start' to resume from checkpoint.
 │  Database:        commerce                                                        │
 │  Environment:     production                                                      │
 │  State:           Completed                                                       │
-│  Branch:          schemabot-commerce-72511904                                     │
 │  Deploy Request:  https://app.planetscale.com/my-org/commerce/deploy-requests/86  │
 │  Started:         Jan 15 14:28:00 UTC                                             │
 │  Duration:        2m                                                              │
@@ -3591,7 +3585,6 @@ Use 'schemabot start' to resume from checkpoint.
 │  Database:        myapp                                                        │
 │  Environment:     staging                                                      │
 │  State:           Failed                                                       │
-│  Branch:          schemabot-myapp-28471035                                     │
 │  Deploy Request:  https://app.planetscale.com/my-org/myapp/deploy-requests/42  │
 │  Started:         Jan 15 14:29:00 UTC                                          │
 │  Duration:        1m                                                           │
@@ -3624,7 +3617,6 @@ The new apply will only process tables that haven't completed.
 │  Environment:     production                                                   │
 │  State:           Waiting for deploy                                           │
 │  Options:         ⏸️ Defer Deploy                                              │
-│  Branch:          schemabot-myapp-28471035                                     │
 │  Deploy Request:  https://app.planetscale.com/my-org/myapp/deploy-requests/50  │
 │  Started:         Jan 15 14:29:30 UTC                                          │
 │  Duration:        30s                                                          │
@@ -3650,7 +3642,6 @@ Press Enter to deploy or proceed via the PlanetScale console (ESC to detach)
 │  Environment:     production                                                   │
 │  State:           Waiting for cutover                                          │
 │  Options:         ⏸️ Defer Cutover                                             │
-│  Branch:          schemabot-myapp-28471035                                     │
 │  Deploy Request:  https://app.planetscale.com/my-org/myapp/deploy-requests/49  │
 │  Started:         Jan 15 14:27:00 UTC                                          │
 │  Duration:        3m                                                           │
@@ -3680,7 +3671,6 @@ Press Enter to deploy or proceed via the PlanetScale console (ESC to detach)
 │  Environment:     production                                                   │
 │  State:           Cutting over                                                 │
 │  Options:         ⏸️ Defer Cutover                                             │
-│  Branch:          schemabot-myapp-28471035                                     │
 │  Deploy Request:  https://app.planetscale.com/my-org/myapp/deploy-requests/49  │
 │  Started:         Jan 15 14:26:00 UTC                                          │
 │  Duration:        4m                                                           │
@@ -3709,7 +3699,6 @@ Press Enter to deploy or proceed via the PlanetScale console (ESC to detach)
 │  Database:        myapp                                                        │
 │  Environment:     staging                                                      │
 │  State:           Cancelled                                                    │
-│  Branch:          schemabot-myapp-28471035                                     │
 │  Deploy Request:  https://app.planetscale.com/my-org/myapp/deploy-requests/50  │
 │  Started:         Jan 15 14:28:00 UTC                                          │
 │  Duration:        2m                                                           │
@@ -3738,7 +3727,6 @@ Press Enter to deploy or proceed via the PlanetScale console (ESC to detach)
 │  Database:        commerce                                                        │
 │  Environment:     production                                                      │
 │  State:           Running                                                         │
-│  Branch:          schemabot-commerce-99182746                                     │
 │  Deploy Request:  https://app.planetscale.com/my-org/commerce/deploy-requests/28  │
 │  Started:         Jan 15 14:18:00 UTC                                             │
 │  Duration:        12m                                                             │
@@ -3775,7 +3763,6 @@ Press Enter to deploy or proceed via the PlanetScale console (ESC to detach)
 │  Database:        commerce                                                        │
 │  Environment:     production                                                      │
 │  State:           Running                                                         │
-│  Branch:          schemabot-commerce-99182746                                     │
 │  Deploy Request:  https://app.planetscale.com/my-org/commerce/deploy-requests/29  │
 │  Started:         Jan 15 14:22:00 UTC                                             │
 │  Duration:        8m                                                              │
@@ -3844,7 +3831,6 @@ Press Enter to deploy or proceed via the PlanetScale console (ESC to detach)
 │  Database:        myapp                                                        │
 │  Environment:     staging                                                      │
 │  State:           Running                                                      │
-│  Branch:          schemabot-myapp-28471035                                     │
 │  Deploy Request:  https://app.planetscale.com/my-org/myapp/deploy-requests/43  │
 │  Started:         Jan 15 14:29:50 UTC                                          │
 │  Duration:        10s                                                          │
@@ -3867,7 +3853,6 @@ Press Enter to deploy or proceed via the PlanetScale console (ESC to detach)
 │  Database:        myapp                                                        │
 │  Environment:     staging                                                      │
 │  State:           Running                                                      │
-│  Branch:          schemabot-myapp-28471035                                     │
 │  Deploy Request:  https://app.planetscale.com/my-org/myapp/deploy-requests/46  │
 │  Started:         Jan 15 14:29:50 UTC                                          │
 │  Duration:        10s                                                          │
@@ -3892,7 +3877,6 @@ Press Enter to deploy or proceed via the PlanetScale console (ESC to detach)
 │  Database:        myapp                                                        │
 │  Environment:     staging                                                      │
 │  State:           Running                                                      │
-│  Branch:          schemabot-myapp-28471035                                     │
 │  Deploy Request:  https://app.planetscale.com/my-org/myapp/deploy-requests/44  │
 │  Started:         Jan 15 14:29:40 UTC                                          │
 │  Duration:        20s                                                          │
@@ -3929,7 +3913,6 @@ Press Enter to deploy or proceed via the PlanetScale console (ESC to detach)
 │  Database:        myapp                                                        │
 │  Environment:     staging                                                      │
 │  State:           Running                                                      │
-│  Branch:          schemabot-myapp-28471035                                     │
 │  Deploy Request:  https://app.planetscale.com/my-org/myapp/deploy-requests/45  │
 │  Started:         Jan 15 14:29:30 UTC                                          │
 │  Duration:        30s                                                          │
@@ -3958,7 +3941,6 @@ Press Enter to deploy or proceed via the PlanetScale console (ESC to detach)
 │  Database:        myapp                                                        │
 │  Environment:     staging                                                      │
 │  State:           Running                                                      │
-│  Branch:          schemabot-myapp-28471035                                     │
 │  Deploy Request:  https://app.planetscale.com/my-org/myapp/deploy-requests/46  │
 │  Started:         Jan 15 14:29:15 UTC                                          │
 │  Duration:        45s                                                          │
@@ -3987,7 +3969,6 @@ Press Enter to deploy or proceed via the PlanetScale console (ESC to detach)
 │  Database:        myapp                                                        │
 │  Environment:     production                                                   │
 │  State:           Running                                                      │
-│  Branch:          schemabot-myapp-28471035                                     │
 │  Deploy Request:  https://app.planetscale.com/my-org/myapp/deploy-requests/51  │
 │  Started:         Jan 15 14:25:00 UTC                                          │
 │  Duration:        5m                                                           │
@@ -4166,7 +4147,6 @@ Vitess plan: Multi-keyspace with DDL + VSchema across keyspaces
 │  Database:        myapp                                                        │
 │  Environment:     staging                                                      │
 │  State:           Completed                                                    │
-│  Branch:          schemabot-myapp-28471035                                     │
 │  Deploy Request:  https://app.planetscale.com/my-org/myapp/deploy-requests/47  │
 │  Started:         Jan 15 14:29:57 UTC                                          │
 │  Duration:        3s                                                           │
@@ -4192,7 +4172,6 @@ Vitess plan: Multi-keyspace with DDL + VSchema across keyspaces
 │  Database:           myapp                                                        │
 │  Environment:        production                                                   │
 │  State:              Revert window                                                │
-│  Branch:             schemabot-myapp-28471035                                     │
 │  Deploy Request:     https://app.planetscale.com/my-org/myapp/deploy-requests/48  │
 │  Started:            Jan 15 14:28:00 UTC                                          │
 │  Duration:           30s                                                          │

--- a/pkg/cmd/internal/templates/progress.go
+++ b/pkg/cmd/internal/templates/progress.go
@@ -114,9 +114,6 @@ func WriteProgress(data ProgressData) {
 		}
 	}
 	if data.Metadata != nil {
-		if branch := data.Metadata["branch_name"]; branch != "" {
-			rows = append(rows, BoxRow{"Branch", branch})
-		}
 		if url := data.Metadata["deploy_request_url"]; url != "" {
 			rows = append(rows, BoxRow{"Deploy Request", url})
 		}

--- a/pkg/webhook/apply.go
+++ b/pkg/webhook/apply.go
@@ -14,21 +14,22 @@ import (
 	"github.com/block/schemabot/pkg/webhook/templates"
 )
 
-// buildApplyCommentData maps storage types to template data. vschemaChanges
-// carries the apply's per-keyspace VSchema application state, projected from
-// engine display metadata by resolveVSchemaByOperation (nil when there is none).
-// shardsByTable holds the per-shard detail rows grouped by table (nil for
-// unsharded engines); it is attached to each table's progress for the compact
-// per-shard summary.
-func buildApplyCommentData(apply *storage.Apply, tasks []*storage.Task, vschemaChanges []apitypes.VSchemaChange, shardsByTable map[string][]*storage.Task) templates.ApplyStatusCommentData {
+// buildApplyCommentData maps storage types to template data. display carries the
+// apply's per-operation engine display projection (VSchema application state and
+// the PlanetScale deploy-request URL), resolved from engine resume metadata by
+// resolveDisplayByOperation (zero value when there is none). shardsByTable holds
+// the per-shard detail rows grouped by table (nil for unsharded engines); it is
+// attached to each table's progress for the compact per-shard summary.
+func buildApplyCommentData(apply *storage.Apply, tasks []*storage.Task, display operationDisplay, shardsByTable map[string][]*storage.Task) templates.ApplyStatusCommentData {
 	data := templates.ApplyStatusCommentData{
-		ApplyID:        apply.ApplyIdentifier,
-		Database:       apply.Database,
-		Environment:    apply.Environment,
-		State:          apply.State,
-		Engine:         apply.Engine,
-		ErrorMessage:   apply.ErrorMessage,
-		VSchemaChanges: vschemaChanges,
+		ApplyID:          apply.ApplyIdentifier,
+		Database:         apply.Database,
+		Environment:      apply.Environment,
+		State:            apply.State,
+		Engine:           apply.Engine,
+		ErrorMessage:     apply.ErrorMessage,
+		VSchemaChanges:   display.VSchema,
+		DeployRequestURL: display.DeployRequestURL,
 	}
 	if apply.StartedAt != nil {
 		data.StartedAt = apply.StartedAt.Format(time.RFC3339)
@@ -40,47 +41,57 @@ func buildApplyCommentData(apply *storage.Apply, tasks []*storage.Task, vschemaC
 	return data
 }
 
-// resolveVSchemaByOperation projects each operation's VSchema display state from
-// the engine resume metadata persisted on the apply's operations — the same
-// storage-backed projection the progress API uses (overlayStoredDisplayMetadata).
-// The comment path builds from storage and never reads the engine progress
-// response, so VSchema must be projected here too. Best-effort: a non-PlanetScale
-// apply, an operation without resume state, or a decode error contributes
-// nothing rather than blocking the comment.
-func resolveVSchemaByOperation(ctx context.Context, stor storage.Storage, apply *storage.Apply, ops []*storage.ApplyOperation) map[int64][]apitypes.VSchemaChange {
+// operationDisplay is the per-operation engine display projection surfaced in the
+// PR comment: VSchema application state and the PlanetScale deploy-request URL.
+// Both come from the same engine resume metadata, so they are resolved together.
+type operationDisplay struct {
+	VSchema          []apitypes.VSchemaChange
+	DeployRequestURL string
+}
+
+// resolveDisplayByOperation projects each operation's engine display state
+// (VSchema status + deploy-request URL) from the engine resume metadata persisted
+// on the apply's operations — the same storage-backed projection the progress API
+// uses (overlayStoredDisplayMetadata). The comment path builds from storage and
+// never reads the engine progress response, so it is projected here too.
+// Best-effort: a non-PlanetScale apply, an operation without resume state, or a
+// decode error contributes nothing rather than blocking the comment.
+func resolveDisplayByOperation(ctx context.Context, stor storage.Storage, apply *storage.Apply, ops []*storage.ApplyOperation) map[int64]operationDisplay {
 	if apply == nil || apply.Engine != storage.EnginePlanetScale || len(ops) == 0 {
 		return nil
 	}
-	var byOp map[int64][]apitypes.VSchemaChange
+	var byOp map[int64]operationDisplay
 	for _, op := range ops {
 		rs, err := stor.ApplyOperations().GetEngineResumeState(ctx, op.ID)
 		if errors.Is(err, storage.ErrEngineResumeStateNotFound) {
 			continue
 		}
 		if err != nil {
-			slog.Warn("comment will omit VSchema status: failed to load engine resume state",
+			slog.Warn("comment will omit engine display metadata: failed to load engine resume state",
 				"apply_id", apply.ApplyIdentifier, "apply_operation_id", op.ID, "error", err)
 			continue
 		}
 		display, err := tern.PSDisplayMetadata(rs.Metadata)
 		if err != nil {
-			slog.Warn("comment will omit VSchema status: failed to decode engine resume state",
+			slog.Warn("comment will omit engine display metadata: failed to decode engine resume state",
 				"apply_id", apply.ApplyIdentifier, "apply_operation_id", op.ID, "error", err)
 			continue
 		}
 		changes, err := apitypes.ParseVSchemaChanges(display)
 		if err != nil {
+			// A malformed VSchema blob should not also drop the deploy-request URL,
+			// so log and continue with no VSchema rather than skipping the operation.
 			slog.Warn("comment will omit VSchema status: failed to parse VSchema changes",
 				"apply_id", apply.ApplyIdentifier, "apply_operation_id", op.ID, "error", err)
-			continue
 		}
-		if len(changes) == 0 {
+		od := operationDisplay{VSchema: changes, DeployRequestURL: display["deploy_request_url"]}
+		if len(od.VSchema) == 0 && od.DeployRequestURL == "" {
 			continue
 		}
 		if byOp == nil {
-			byOp = make(map[int64][]apitypes.VSchemaChange, len(ops))
+			byOp = make(map[int64]operationDisplay, len(ops))
 		}
-		byOp[op.ID] = changes
+		byOp[op.ID] = od
 	}
 	return byOp
 }
@@ -157,12 +168,12 @@ func shardCommentTableKey(applyOperationID *int64, namespace, table string) stri
 // It is the no-operations fallback (load error, or the initial rollback comment),
 // so it carries no VSchema — the observer refreshes VSchema once operations load.
 func formatProgressComment(apply *storage.Apply, tasks []*storage.Task, shardsByTable map[string][]*storage.Task) string {
-	return templates.RenderApplyStatusComment(buildApplyCommentData(apply, tasks, nil, shardsByTable))
+	return templates.RenderApplyStatusComment(buildApplyCommentData(apply, tasks, operationDisplay{}, shardsByTable))
 }
 
 // formatSummaryComment renders the final summary comment for a terminal apply
 // state. Like formatProgressComment it is the no-operations fallback and carries
 // no VSchema.
 func formatSummaryComment(apply *storage.Apply, tasks []*storage.Task, shardsByTable map[string][]*storage.Task) string {
-	return templates.RenderApplySummaryComment(buildApplyCommentData(apply, tasks, nil, shardsByTable))
+	return templates.RenderApplySummaryComment(buildApplyCommentData(apply, tasks, operationDisplay{}, shardsByTable))
 }

--- a/pkg/webhook/apply_test.go
+++ b/pkg/webhook/apply_test.go
@@ -176,7 +176,7 @@ func TestBuildApplyCommentData(t *testing.T) {
 		},
 	}
 
-	data := buildApplyCommentData(apply, tasks, nil, nil)
+	data := buildApplyCommentData(apply, tasks, operationDisplay{}, nil)
 
 	assert.Equal(t, "apply-abc123", data.ApplyID)
 	assert.Equal(t, "testdb", data.Database)
@@ -198,7 +198,7 @@ func TestBuildApplyCommentData_DefaultNamespace(t *testing.T) {
 		{TableName: "users", State: state.Task.Running},
 	}
 
-	data := buildApplyCommentData(apply, tasks, nil, nil)
+	data := buildApplyCommentData(apply, tasks, operationDisplay{}, nil)
 
 	assert.Equal(t, "testdb", data.Tables[0].Namespace, "empty namespace should default to database name")
 }

--- a/pkg/webhook/comment_observer.go
+++ b/pkg/webhook/comment_observer.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/block/schemabot/pkg/api"
-	"github.com/block/schemabot/pkg/apitypes"
 	"github.com/block/schemabot/pkg/clock"
 	"github.com/block/schemabot/pkg/github"
 	"github.com/block/schemabot/pkg/state"
@@ -409,16 +408,17 @@ func (o *CommentObserver) statusCommentFromOps(apply *storage.Apply, ops []*stor
 			"apply_id", o.applyID, "error", opsErr)
 		return formatProgressComment(apply, tasks, shardsByTable)
 	}
-	return formatApplyStatusComment(apply, ops, tasks, o.resolveVSchema(apply, ops), shardsByTable)
+	return formatApplyStatusComment(apply, ops, tasks, o.resolveDisplay(apply, ops), shardsByTable)
 }
 
-// resolveVSchema projects the apply's per-operation VSchema display state for
-// comment rendering. It uses a short, independent deadline so a slow storage
-// read degrades to a comment without VSchema rather than blocking the update.
-func (o *CommentObserver) resolveVSchema(apply *storage.Apply, ops []*storage.ApplyOperation) map[int64][]apitypes.VSchemaChange {
+// resolveDisplay projects the apply's per-operation engine display state (VSchema
+// status + deploy-request URL) for comment rendering. It uses a short, independent
+// deadline so a slow storage read degrades to a comment without these fields
+// rather than blocking the update.
+func (o *CommentObserver) resolveDisplay(apply *storage.Apply, ops []*storage.ApplyOperation) map[int64]operationDisplay {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
-	return resolveVSchemaByOperation(ctx, o.stor, apply, ops)
+	return resolveDisplayByOperation(ctx, o.stor, apply, ops)
 }
 
 // formatTerminalSummaryComment renders the apply's terminal summary comment,
@@ -447,7 +447,7 @@ func (o *CommentObserver) summaryCommentFromOps(apply *storage.Apply, ops []*sto
 			"apply_id", o.applyID, "error", opsErr)
 		return formatSummaryComment(apply, tasks, shardsByTable)
 	}
-	return formatApplySummaryComment(apply, ops, tasks, o.resolveVSchema(apply, ops), shardsByTable)
+	return formatApplySummaryComment(apply, ops, tasks, o.resolveDisplay(apply, ops), shardsByTable)
 }
 
 func (o *CommentObserver) shouldDeferCutover(apply *storage.Apply) bool {

--- a/pkg/webhook/handler.go
+++ b/pkg/webhook/handler.go
@@ -367,7 +367,7 @@ func (h *Handler) ReconcileMissingSummaryComments(ctx context.Context) {
 				"apply_id", apply.ApplyIdentifier, "error", err)
 			ops = nil
 		}
-		summaryBody := formatApplySummaryComment(apply, ops, tasks, resolveVSchemaByOperation(ctx, h.service.Storage(), apply, ops), nil)
+		summaryBody := formatApplySummaryComment(apply, ops, tasks, resolveDisplayByOperation(ctx, h.service.Storage(), apply, ops), nil)
 		h.postAndTrackComment(ctx, apply.Repository, apply.PullRequest, apply.InstallationID, apply.ID, state.Comment.Summary, summaryBody)
 	}
 }

--- a/pkg/webhook/multi_apply.go
+++ b/pkg/webhook/multi_apply.go
@@ -3,7 +3,6 @@ package webhook
 import (
 	"time"
 
-	"github.com/block/schemabot/pkg/apitypes"
 	"github.com/block/schemabot/pkg/presentation"
 	"github.com/block/schemabot/pkg/storage"
 	"github.com/block/schemabot/pkg/webhook/templates"
@@ -19,11 +18,11 @@ import (
 // ops must be in resolved deployment order (as returned by
 // ApplyOperations().ListByApply); tasks are the apply's tasks across all
 // deployments, regrouped per operation for the multi-deployment layout.
-func formatApplyStatusComment(apply *storage.Apply, ops []*storage.ApplyOperation, tasks []*storage.Task, vschemaByOp map[int64][]apitypes.VSchemaChange, shardsByTable map[string][]*storage.Task) string {
+func formatApplyStatusComment(apply *storage.Apply, ops []*storage.ApplyOperation, tasks []*storage.Task, displayByOp map[int64]operationDisplay, shardsByTable map[string][]*storage.Task) string {
 	if len(ops) <= 1 {
-		return templates.RenderApplyStatusComment(buildApplyCommentData(apply, tasks, singleOpVSchema(ops, vschemaByOp), shardsByTable))
+		return templates.RenderApplyStatusComment(buildApplyCommentData(apply, tasks, singleOpDisplay(ops, displayByOp), shardsByTable))
 	}
-	return templates.RenderMultiDeploymentApplyComment(buildMultiApplyData(apply, ops, tasks, vschemaByOp, shardsByTable))
+	return templates.RenderMultiDeploymentApplyComment(buildMultiApplyData(apply, ops, tasks, displayByOp, shardsByTable))
 }
 
 // formatApplySummaryComment renders the terminal summary PR comment for an apply,
@@ -36,33 +35,33 @@ func formatApplyStatusComment(apply *storage.Apply, ops []*storage.ApplyOperatio
 // ops must be in resolved deployment order (as returned by
 // ApplyOperations().ListByApply); tasks are the apply's tasks across all
 // deployments, regrouped per operation for the multi-deployment layout.
-func formatApplySummaryComment(apply *storage.Apply, ops []*storage.ApplyOperation, tasks []*storage.Task, vschemaByOp map[int64][]apitypes.VSchemaChange, shardsByTable map[string][]*storage.Task) string {
+func formatApplySummaryComment(apply *storage.Apply, ops []*storage.ApplyOperation, tasks []*storage.Task, displayByOp map[int64]operationDisplay, shardsByTable map[string][]*storage.Task) string {
 	if len(ops) <= 1 {
-		return templates.RenderApplySummaryComment(buildApplyCommentData(apply, tasks, singleOpVSchema(ops, vschemaByOp), shardsByTable))
+		return templates.RenderApplySummaryComment(buildApplyCommentData(apply, tasks, singleOpDisplay(ops, displayByOp), shardsByTable))
 	}
-	return templates.RenderMultiDeploymentApplySummaryComment(buildMultiApplyData(apply, ops, tasks, vschemaByOp, shardsByTable))
+	return templates.RenderMultiDeploymentApplySummaryComment(buildMultiApplyData(apply, ops, tasks, displayByOp, shardsByTable))
 }
 
-// singleOpVSchema returns the VSchema changes for a zero/one-operation apply
-// rendered with the single-deployment layout: the lone operation's changes, or
-// nil when the apply has no operation (legacy) or no VSchema.
-func singleOpVSchema(ops []*storage.ApplyOperation, vschemaByOp map[int64][]apitypes.VSchemaChange) []apitypes.VSchemaChange {
+// singleOpDisplay returns the engine display projection for a zero/one-operation
+// apply rendered with the single-deployment layout: the lone operation's display,
+// or the zero value when the apply has no operation (legacy) or no display data.
+func singleOpDisplay(ops []*storage.ApplyOperation, displayByOp map[int64]operationDisplay) operationDisplay {
 	if len(ops) != 1 {
-		return nil
+		return operationDisplay{}
 	}
-	return vschemaByOp[ops[0].ID]
+	return displayByOp[ops[0].ID]
 }
 
 // buildMultiApplyData assembles the multi-deployment comment input: the derived
 // rollup plus each deployment's own single-deployment comment data, so each
 // deployment's section reuses the existing per-table renderer.
-func buildMultiApplyData(apply *storage.Apply, ops []*storage.ApplyOperation, tasks []*storage.Task, vschemaByOp map[int64][]apitypes.VSchemaChange, shardsByTable map[string][]*storage.Task) templates.MultiDeploymentApplyData {
+func buildMultiApplyData(apply *storage.Apply, ops []*storage.ApplyOperation, tasks []*storage.Task, displayByOp map[int64]operationDisplay, shardsByTable map[string][]*storage.Task) templates.MultiDeploymentApplyData {
 	tasksByOp := groupTasksByOperation(tasks)
 
 	model := deriveApplyPresentation(ops)
 	details := make(map[string]templates.ApplyStatusCommentData, len(ops))
 	for _, op := range ops {
-		details[op.Deployment] = buildDeploymentDetail(apply, op, tasksByOp[op.ID], vschemaByOp[op.ID], shardsByTable)
+		details[op.Deployment] = buildDeploymentDetail(apply, op, tasksByOp[op.ID], displayByOp[op.ID], shardsByTable)
 	}
 
 	data := templates.MultiDeploymentApplyData{
@@ -113,16 +112,17 @@ func applyOperationToPresentation(op *storage.ApplyOperation) presentation.Opera
 // identity and timing, and the deployment's own tasks. The deployment's database
 // target is shown via the section's deployment name; the per-table rows fall back
 // to the apply database for namespace, matching the single-deployment renderer.
-func buildDeploymentDetail(apply *storage.Apply, op *storage.ApplyOperation, tasks []*storage.Task, vschemaChanges []apitypes.VSchemaChange, shardsByTable map[string][]*storage.Task) templates.ApplyStatusCommentData {
+func buildDeploymentDetail(apply *storage.Apply, op *storage.ApplyOperation, tasks []*storage.Task, display operationDisplay, shardsByTable map[string][]*storage.Task) templates.ApplyStatusCommentData {
 	data := templates.ApplyStatusCommentData{
-		ApplyID:        apply.ApplyIdentifier,
-		Database:       apply.Database,
-		Environment:    apply.Environment,
-		State:          op.State,
-		Engine:         apply.Engine,
-		ErrorMessage:   op.ErrorMessage,
-		Tables:         tableProgressFromTasks(apply.Database, tasks, shardsByTable),
-		VSchemaChanges: vschemaChanges,
+		ApplyID:          apply.ApplyIdentifier,
+		Database:         apply.Database,
+		Environment:      apply.Environment,
+		State:            op.State,
+		Engine:           apply.Engine,
+		ErrorMessage:     op.ErrorMessage,
+		Tables:           tableProgressFromTasks(apply.Database, tasks, shardsByTable),
+		VSchemaChanges:   display.VSchema,
+		DeployRequestURL: display.DeployRequestURL,
 	}
 	if apply.StartedAt != nil {
 		data.StartedAt = apply.StartedAt.Format(time.RFC3339)

--- a/pkg/webhook/multi_apply_test.go
+++ b/pkg/webhook/multi_apply_test.go
@@ -147,7 +147,7 @@ func TestBuildMultiApplyData_ScopesShardsByOperation(t *testing.T) {
 // the parent apply's aggregate state.
 func TestBuildDeploymentDetail_UsesOperationStateAndError(t *testing.T) {
 	op := &storage.ApplyOperation{ID: 1, Deployment: "us", State: state.ApplyOperation.Failed, ErrorMessage: "lock wait timeout"}
-	detail := buildDeploymentDetail(runningApply(), op, nil, nil, nil)
+	detail := buildDeploymentDetail(runningApply(), op, nil, operationDisplay{}, nil)
 	assert.Equal(t, state.Apply.Failed, detail.State)
 	assert.Equal(t, "lock wait timeout", detail.ErrorMessage)
 	assert.Equal(t, "payments", detail.Database)

--- a/pkg/webhook/templates/apply.go
+++ b/pkg/webhook/templates/apply.go
@@ -64,6 +64,12 @@ type ApplyStatusCommentData struct {
 	// the engine's display metadata rather than as a per-table task. Empty when
 	// the apply carries no VSchema change.
 	VSchemaChanges []apitypes.VSchemaChange
+
+	// DeployRequestURL links the PlanetScale deploy request driving this apply
+	// (Vitess/PlanetScale only). It is the operator's entry point into the deploy
+	// request's own progress, which the comment does not otherwise surface. Empty
+	// for engines without a deploy request or before one is created.
+	DeployRequestURL string
 }
 
 // RenderApplyStatusComment renders a PR comment for the current apply status.
@@ -82,6 +88,10 @@ func renderApplyStatusComment(data ApplyStatusCommentData, includeLastUpdated bo
 	// Metadata line
 	writeApplyMetadata(&sb, data, renderedAt)
 	writeApplyStatusDetail(&sb, data.State)
+
+	// Deploy-request link (PlanetScale) — the operator's entry point into the
+	// deploy request's own progress, which the comment does not otherwise surface.
+	writeDeployRequestLink(&sb, data)
 
 	// Cutover readiness summary
 	if data.State == state.Apply.WaitingForCutover || data.State == state.Apply.CuttingOver {
@@ -202,6 +212,17 @@ func applyStatusDetail(applyState string) string {
 		}
 		return humanizeState(applyState)
 	}
+}
+
+// writeDeployRequestLink writes a link to the PlanetScale deploy request driving
+// the apply, when one is known. For a Vitess/PlanetScale apply the meaningful
+// in-flight work happens in the deploy request, so this gives the operator a way
+// to follow it directly rather than hunting for it in the PlanetScale UI.
+func writeDeployRequestLink(sb *strings.Builder, data ApplyStatusCommentData) {
+	if data.DeployRequestURL == "" {
+		return
+	}
+	fmt.Fprintf(sb, "\n🔗 **Deploy request**: %s\n", data.DeployRequestURL)
 }
 
 // writeCutoverSummary writes a readiness summary for cutover states,

--- a/pkg/webhook/templates/apply_test.go
+++ b/pkg/webhook/templates/apply_test.go
@@ -338,6 +338,25 @@ func TestRenderApplyStatusComment_ValidatingDeployRequest(t *testing.T) {
 	assert.Contains(t, result, "schemabot stop apply-7aa13cf03496454b -e staging")
 }
 
+// A PlanetScale apply links its deploy request so the operator can follow the
+// deploy's own progress (the comment does not otherwise surface it). The link is
+// omitted when no deploy request exists yet.
+func TestRenderApplyStatusComment_DeployRequestLink(t *testing.T) {
+	base := ApplyStatusCommentData{
+		Database: "boardgames", Environment: "staging", RequestedBy: "aparajon",
+		ApplyID: "apply-7aa13cf03496454b", State: state.Apply.Running, Engine: "PlanetScale",
+		Tables: []TableProgressData{{TableName: "customers", Status: state.Task.Running}},
+	}
+
+	withURL := base
+	withURL.DeployRequestURL = "https://app.planetscale.com/block-staging/boardgames/deploy-requests/103"
+	result := RenderApplyStatusComment(withURL)
+	assert.Contains(t, result, "🔗 **Deploy request**: https://app.planetscale.com/block-staging/boardgames/deploy-requests/103")
+
+	// No deploy request yet — no link line.
+	assert.NotContains(t, RenderApplyStatusComment(base), "Deploy request**:")
+}
+
 func TestRenderApplyStatusComment_RowCopyDisplaysOnePercentAfterCopyStarts(t *testing.T) {
 	data := ApplyStatusCommentData{
 		Database:    "testapp",

--- a/pkg/webhook/templates/preview.go
+++ b/pkg/webhook/templates/preview.go
@@ -837,6 +837,7 @@ func PreviewCommentApplyVitessDDLWithVSchema() string {
 	}
 	data := sampleApplyData(state.Apply.Running, tables)
 	data.Engine = "PlanetScale"
+	data.DeployRequestURL = "https://app.planetscale.com/acme/myapp/deploy-requests/42"
 	data.VSchemaChanges = []apitypes.VSchemaChange{
 		{Namespace: "myapp_sharded", Status: "applying", Diff: `+ "xxhash": {"type": "xxhash"}`},
 	}


### PR DESCRIPTION
## Why this matters

A Vitess/PlanetScale apply does its real in-flight work inside a PlanetScale **deploy request**, but the PR comment surfaced neither a link to it nor any deploy progress. While the deploy ran, an operator watching the comment saw only:

```
**`<table>`**: Running...
```

— for minutes, with no way to follow the actual work. To find the deploy request they had to leave GitHub and hunt for it in the PlanetScale UI. The CLI already renders the deploy-request URL from the engine metadata; the comment simply dropped it.

## What it does

- Threads the **deploy-request URL** into the apply comment and renders it under the header for PlanetScale applies:
  ```
  🔗 **Deploy request**: <url>
  ```
- Resolves it from the **same per-operation engine display metadata** as VSchema status. The two are now read together via one `operationDisplay{VSchema, DeployRequestURL}` projection, so the engine resume state is loaded once instead of threading another positional argument through every comment builder.
- Drops the redundant **`Branch:`** row from the CLI `status` detail box — the deploy-request URL is the operator-facing entry point; the branch name is noise. Both surfaces now show only the URL.

```
comment header (state)         comment header (state)
Database | Env | Apply ID  →    Database | Env | Apply ID
### Table Progress             🔗 Deploy request: <url>      ← new
  table: Running...            ### Table Progress
                                 table: Running...
```

## How it moves toward the northstar

The GitHub PR comment is the primary operator surface for schema changes. For a sharded/Vitess apply the meaningful in-flight signal lives in the deploy request, so the comment should be a complete entry point — an operator should never have to leave it to understand or follow an in-flight change. This is the first of several deploy-request UX gaps; it makes the comment self-sufficient for following the deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)