### PR TITLE
fix(cli): show loading state during API calls

### DIFF
--- a/pkg/cmd/commands/apply.go
+++ b/pkg/cmd/commands/apply.go
@@ -61,7 +61,12 @@ func (cmd *ApplyCmd) Run(g *Globals) error {
 	owner := client.GenerateCLIOwner()
 
 	// Check for existing active schema change
-	active, err := client.CheckActiveSchemaChange(ep, cfg.Database, cmd.Environment)
+	var active *client.ActiveSchemaChange
+	err = withLoading("Checking active schema changes...", cmd.Output != OutputFormatJSON, func() error {
+		var checkErr error
+		active, checkErr = client.CheckActiveSchemaChange(ep, cfg.Database, cmd.Environment)
+		return checkErr
+	})
 	if err != nil {
 		// Ignore status preflight errors; apply is still guarded server-side.
 	} else if active != nil && active.State != "" {
@@ -95,7 +100,12 @@ func (cmd *ApplyCmd) Run(g *Globals) error {
 	}
 
 	// Step 1: Generate plan
-	planResult, err := client.CallPlanAPI(ep, cfg.Database, cfg.Type, cmd.Environment, cfg.SchemaDir, cmd.Repository, cmd.PullRequest)
+	var planResult *apitypes.PlanResponse
+	err = withLoading("Generating schema change plan...", cmd.Output != OutputFormatJSON, func() error {
+		var planErr error
+		planResult, planErr = client.CallPlanAPI(ep, cfg.Database, cfg.Type, cmd.Environment, cfg.SchemaDir, cmd.Repository, cmd.PullRequest)
+		return planErr
+	})
 	if err != nil {
 		return err
 	}
@@ -145,7 +155,12 @@ func (cmd *ApplyCmd) Run(g *Globals) error {
 
 	// Check lock availability before showing plan (unless --force will break it anyway or --no-lock skips locking)
 	if !cmd.NoLock && !cmd.Force {
-		existingLock, err := client.GetLock(ep, cfg.Database, cfg.Type)
+		var existingLock *client.LockInfo
+		err := withLoading("Checking database lock...", cmd.Output != OutputFormatJSON, func() error {
+			var lockErr error
+			existingLock, lockErr = client.GetLock(ep, cfg.Database, cfg.Type)
+			return lockErr
+		})
 		if err != nil {
 			return fmt.Errorf("check lock: %w", err)
 		}
@@ -192,12 +207,19 @@ func (cmd *ApplyCmd) Run(g *Globals) error {
 	if !cmd.NoLock {
 		// If --force, break any existing lock first
 		if cmd.Force {
-			existingLock, err := client.GetLock(ep, cfg.Database, cfg.Type)
+			var existingLock *client.LockInfo
+			err := withLoading("Checking database lock...", cmd.Output != OutputFormatJSON, func() error {
+				var lockErr error
+				existingLock, lockErr = client.GetLock(ep, cfg.Database, cfg.Type)
+				return lockErr
+			})
 			if err != nil {
 				return fmt.Errorf("check existing lock: %w", err)
 			}
 			if existingLock != nil && existingLock.Owner != owner {
-				if err := client.ForceReleaseLock(ep, cfg.Database, cfg.Type); err != nil {
+				if err := withLoading("Releasing database lock...", cmd.Output != OutputFormatJSON, func() error {
+					return client.ForceReleaseLock(ep, cfg.Database, cfg.Type)
+				}); err != nil {
 					return fmt.Errorf("force release lock: %w", err)
 				}
 				templates.WriteLockForceReleased(cfg.Database, cfg.Type, existingLock.Owner)
@@ -205,10 +227,18 @@ func (cmd *ApplyCmd) Run(g *Globals) error {
 		}
 
 		// Acquire the lock
-		_, err = client.AcquireLock(ep, cfg.Database, cfg.Type, owner, cmd.Repository, cmd.PullRequest)
+		err = withLoading("Acquiring database lock...", cmd.Output != OutputFormatJSON, func() error {
+			_, lockErr := client.AcquireLock(ep, cfg.Database, cfg.Type, owner, cmd.Repository, cmd.PullRequest)
+			return lockErr
+		})
 		if errors.Is(err, client.ErrLockHeld) {
 			// Lock is held by someone else - show conflict message
-			existingLock, getErr := client.GetLock(ep, cfg.Database, cfg.Type)
+			var existingLock *client.LockInfo
+			getErr := withLoading("Checking database lock...", cmd.Output != OutputFormatJSON, func() error {
+				var lockErr error
+				existingLock, lockErr = client.GetLock(ep, cfg.Database, cfg.Type)
+				return lockErr
+			})
 			if getErr != nil || existingLock == nil {
 				return fmt.Errorf("database is locked by another user")
 			}

--- a/pkg/cmd/commands/common.go
+++ b/pkg/cmd/commands/common.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/block/schemabot/pkg/apitypes"
 	"github.com/block/schemabot/pkg/cmd/client"
+	"github.com/block/schemabot/pkg/cmd/internal/templates"
 	"github.com/block/schemabot/pkg/state"
 )
 
@@ -198,7 +199,7 @@ func withLoading(message string, show bool, fn func() error) error {
 		defer ticker.Stop()
 
 		for {
-			if _, err := fmt.Fprintf(loadingSpinnerWriter, "\r%s %s", loadingSpinnerFrames[frame%len(loadingSpinnerFrames)], message); err != nil {
+			if _, err := fmt.Fprintf(loadingSpinnerWriter, "\r%s%s %s%s", templates.ANSIDim, loadingSpinnerFrames[frame%len(loadingSpinnerFrames)], message, templates.ANSIReset); err != nil {
 				return
 			}
 			frame++

--- a/pkg/cmd/commands/common.go
+++ b/pkg/cmd/commands/common.go
@@ -166,7 +166,7 @@ func writeJSON(v any) error {
 }
 
 var (
-	loadingSpinnerDelay              = 400 * time.Millisecond
+	loadingSpinnerDelay              = 500 * time.Millisecond
 	loadingSpinnerInterval           = 100 * time.Millisecond
 	loadingSpinnerFrames             = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
 	loadingSpinnerWriter   io.Writer = os.Stderr

--- a/pkg/cmd/commands/common.go
+++ b/pkg/cmd/commands/common.go
@@ -11,6 +11,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"gopkg.in/yaml.v3"
@@ -164,6 +165,61 @@ func writeJSON(v any) error {
 	return enc.Encode(v)
 }
 
+var (
+	loadingSpinnerDelay              = 400 * time.Millisecond
+	loadingSpinnerInterval           = 100 * time.Millisecond
+	loadingSpinnerFrames             = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
+	loadingSpinnerWriter   io.Writer = os.Stderr
+	loadingSpinnerTerminal           = func() bool {
+		info, err := os.Stderr.Stat()
+		return err == nil && info.Mode()&os.ModeCharDevice != 0
+	}
+)
+
+func withLoading(message string, show bool, fn func() error) error {
+	if !show || !loadingSpinnerTerminal() {
+		return fn()
+	}
+
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		timer := time.NewTimer(loadingSpinnerDelay)
+		defer timer.Stop()
+
+		select {
+		case <-timer.C:
+		case <-done:
+			return
+		}
+
+		frame := 0
+		ticker := time.NewTicker(loadingSpinnerInterval)
+		defer ticker.Stop()
+
+		for {
+			if _, err := fmt.Fprintf(loadingSpinnerWriter, "\r%s %s", loadingSpinnerFrames[frame%len(loadingSpinnerFrames)], message); err != nil {
+				return
+			}
+			frame++
+
+			select {
+			case <-done:
+				if _, err := fmt.Fprint(loadingSpinnerWriter, "\r\033[2K"); err != nil {
+					return
+				}
+				return
+			case <-ticker.C:
+			}
+		}
+	})
+
+	err := fn()
+	close(done)
+	wg.Wait()
+	return err
+}
+
 // requireControlScope validates the explicit fields that scope a control operation.
 func requireControlScope(applyID, environment string) error {
 	if applyID == "" {
@@ -260,7 +316,12 @@ func applyAndWatch(ep string, planResult *apitypes.PlanResponse, database, envir
 
 	options := buildApplyOptions(planResult, deferCutover, deferDeploy, skipRevert, branch, watch, format)
 
-	applyResult, err := client.CallApplyAPI(ep, planResult.PlanID, environment, caller, options)
+	var applyResult *apitypes.ApplyResponse
+	err := withLoading("Submitting schema change...", format != OutputFormatJSON, func() error {
+		var applyErr error
+		applyResult, applyErr = client.CallApplyAPI(ep, planResult.PlanID, environment, caller, options)
+		return applyErr
+	})
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/commands/cutover.go
+++ b/pkg/cmd/commands/cutover.go
@@ -26,7 +26,12 @@ func (cmd *CutoverCmd) Run(g *Globals) error {
 	}
 
 	// Check current state first
-	result, err := client.GetProgress(ep, cmd.ApplyID)
+	var result *apitypes.ProgressResponse
+	err = withLoading("Loading schema change progress...", true, func() error {
+		var loadErr error
+		result, loadErr = client.GetProgress(ep, cmd.ApplyID)
+		return loadErr
+	})
 	if err == nil {
 		populateControlDisplayFields(&cmd.Database, result)
 		if state.IsState(result.State, state.Apply.Completed) {
@@ -45,7 +50,12 @@ func (cmd *CutoverCmd) Run(g *Globals) error {
 	}
 
 	// Trigger cutover
-	cutoverResult, err := client.CallCutoverAPI(ep, cmd.Environment, cmd.ApplyID)
+	var cutoverResult *apitypes.ControlResponse
+	err = withLoading("Requesting cutover...", true, func() error {
+		var cutoverErr error
+		cutoverResult, cutoverErr = client.CallCutoverAPI(ep, cmd.Environment, cmd.ApplyID)
+		return cutoverErr
+	})
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/commands/databases.go
+++ b/pkg/cmd/commands/databases.go
@@ -29,7 +29,12 @@ func (cmd *DatabasesCmd) Run(g *Globals) error {
 		return err
 	}
 
-	resp, err := client.ListDatabases(ep, client.ListDatabasesOptions{Type: cmd.Type})
+	var resp *apitypes.DatabaseListResponse
+	err = withLoading("Loading databases...", !cmd.JSON, func() error {
+		var loadErr error
+		resp, loadErr = client.ListDatabases(ep, client.ListDatabasesOptions{Type: cmd.Type})
+		return loadErr
+	})
 	if err != nil {
 		return fmt.Errorf("list databases: %w", err)
 	}

--- a/pkg/cmd/commands/loading_test.go
+++ b/pkg/cmd/commands/loading_test.go
@@ -1,0 +1,99 @@
+package commands
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type notifyingWriter struct {
+	buf     bytes.Buffer
+	wrote   chan struct{}
+	once    sync.Once
+	message string
+}
+
+func (w *notifyingWriter) Write(p []byte) (int, error) {
+	n, err := w.buf.Write(p)
+	if strings.Contains(string(p), w.message) {
+		w.once.Do(func() { close(w.wrote) })
+	}
+	return n, err
+}
+
+func (w *notifyingWriter) String() string {
+	return w.buf.String()
+}
+
+func TestWithLoadingShowsAndClearsSpinner(t *testing.T) {
+	writer := &notifyingWriter{wrote: make(chan struct{}), message: "Loading schema change status..."}
+	withTestLoadingSpinner(t, writer)
+
+	err := withLoading("Loading schema change status...", true, func() error {
+		select {
+		case <-writer.wrote:
+			return nil
+		case <-time.After(time.Second):
+			return errors.New("spinner did not render")
+		}
+	})
+
+	require.NoError(t, err)
+	assert.Contains(t, writer.String(), "Loading schema change status...")
+	assert.Contains(t, writer.String(), "\r\033[2K")
+}
+
+func TestWithLoadingReturnsCommandError(t *testing.T) {
+	writer := &notifyingWriter{wrote: make(chan struct{}), message: "Loading locks..."}
+	withTestLoadingSpinner(t, writer)
+	wantErr := errors.New("server unavailable")
+
+	err := withLoading("Loading locks...", true, func() error {
+		select {
+		case <-writer.wrote:
+			return wantErr
+		case <-time.After(time.Second):
+			return errors.New("spinner did not render")
+		}
+	})
+
+	require.ErrorIs(t, err, wantErr)
+	assert.Contains(t, writer.String(), "Loading locks...")
+	assert.Contains(t, writer.String(), "\r\033[2K")
+}
+
+func TestWithLoadingDisabledIsSilent(t *testing.T) {
+	var out bytes.Buffer
+	withTestLoadingSpinner(t, &out)
+
+	err := withLoading("Loading logs...", false, func() error { return nil })
+
+	require.NoError(t, err)
+	assert.Empty(t, out.String())
+}
+
+func withTestLoadingSpinner(t *testing.T, writer interface{ Write([]byte) (int, error) }) {
+	t.Helper()
+	originalDelay := loadingSpinnerDelay
+	originalInterval := loadingSpinnerInterval
+	originalWriter := loadingSpinnerWriter
+	originalTerminal := loadingSpinnerTerminal
+
+	loadingSpinnerDelay = 0
+	loadingSpinnerInterval = time.Hour
+	loadingSpinnerWriter = writer
+	loadingSpinnerTerminal = func() bool { return true }
+
+	t.Cleanup(func() {
+		loadingSpinnerDelay = originalDelay
+		loadingSpinnerInterval = originalInterval
+		loadingSpinnerWriter = originalWriter
+		loadingSpinnerTerminal = originalTerminal
+	})
+}

--- a/pkg/cmd/commands/loading_test.go
+++ b/pkg/cmd/commands/loading_test.go
@@ -78,6 +78,17 @@ func TestWithLoadingDisabledIsSilent(t *testing.T) {
 	assert.Empty(t, out.String())
 }
 
+func TestWithLoadingNonTerminalIsSilent(t *testing.T) {
+	var out bytes.Buffer
+	withTestLoadingSpinner(t, &out)
+	loadingSpinnerTerminal = func() bool { return false }
+
+	err := withLoading("Loading schema change progress...", true, func() error { return nil })
+
+	require.NoError(t, err)
+	assert.Empty(t, out.String())
+}
+
 func withTestLoadingSpinner(t *testing.T, writer interface{ Write([]byte) (int, error) }) {
 	t.Helper()
 	originalDelay := loadingSpinnerDelay

--- a/pkg/cmd/commands/locks.go
+++ b/pkg/cmd/commands/locks.go
@@ -17,7 +17,12 @@ func (cmd *LocksCmd) Run(g *Globals) error {
 		return err
 	}
 
-	locks, err := client.ListLocks(ep)
+	var locks []*client.LockInfo
+	err = withLoading("Loading locks...", true, func() error {
+		var loadErr error
+		locks, loadErr = client.ListLocks(ep)
+		return loadErr
+	})
 	if err != nil {
 		return fmt.Errorf("list locks: %w", err)
 	}

--- a/pkg/cmd/commands/logs.go
+++ b/pkg/cmd/commands/logs.go
@@ -50,7 +50,12 @@ func (cmd *LogsCmd) Run(g *Globals) error {
 
 // showLogs displays logs once and exits.
 func showLogs(endpoint, database, environment, applyID string, limit int) error {
-	logs, err := client.GetLogs(endpoint, database, environment, applyID, limit)
+	var logs []*client.LogEntry
+	err := withLoading("Loading logs...", true, func() error {
+		var loadErr error
+		logs, loadErr = client.GetLogs(endpoint, database, environment, applyID, limit)
+		return loadErr
+	})
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/commands/onboard.go
+++ b/pkg/cmd/commands/onboard.go
@@ -38,7 +38,12 @@ func (cmd *OnboardCmd) Run(g *Globals) error {
 	if err != nil {
 		return err
 	}
-	resp, err := client.CallPullSchemaAPI(ep, cmd.Database, cmd.Type, cmd.Environment, pullNamespaces...)
+	var resp *apitypes.PullSchemaResponse
+	err = withLoading("Pulling live schema...", true, func() error {
+		var pullErr error
+		resp, pullErr = client.CallPullSchemaAPI(ep, cmd.Database, cmd.Type, cmd.Environment, pullNamespaces...)
+		return pullErr
+	})
 	if err != nil {
 		if outputSchemaPullRequestError("Onboard", cmd.Database, cmd.Environment, err) {
 			return ErrSilent
@@ -289,7 +294,12 @@ func formatOnboardWriteError(operation, path string, written []string, err error
 }
 
 func verifyOnboardPlan(endpoint string, resp *apitypes.PullSchemaResponse, schemaDir string) error {
-	planResult, err := client.CallPlanAPI(endpoint, resp.Database, resp.Type, resp.Environment, schemaDir, "", 0)
+	var planResult *apitypes.PlanResponse
+	err := withLoading("Verifying pulled schema...", true, func() error {
+		var planErr error
+		planResult, planErr = client.CallPlanAPI(endpoint, resp.Database, resp.Type, resp.Environment, schemaDir, "", 0)
+		return planErr
+	})
 	if err != nil {
 		if outputPlanRequestError(resp.Database, resp.Environment, err) {
 			return ErrSilent

--- a/pkg/cmd/commands/plan.go
+++ b/pkg/cmd/commands/plan.go
@@ -56,7 +56,12 @@ func (cmd *PlanCmd) Run(g *Globals) error {
 	// If environment is not specified, get all environments and plan for each
 	var environments []string
 	if cmd.Environment == "" {
-		envs, err := client.GetEnvironments(ep, cfg.Database)
+		var envs []string
+		err := withLoading("Loading environments...", !cmd.JSON, func() error {
+			var loadErr error
+			envs, loadErr = client.GetEnvironments(ep, cfg.Database)
+			return loadErr
+		})
 		if err != nil {
 			if cmd.JSON {
 				return client.ExitWithJSON("api_error", err.Error())
@@ -74,7 +79,12 @@ func (cmd *PlanCmd) Run(g *Globals) error {
 	// Collect results for all environments
 	allResults := make(map[string]*apitypes.PlanResponse)
 	for _, env := range environments {
-		result, err := client.CallPlanAPI(ep, cfg.Database, cfg.Type, env, cfg.SchemaDir, cmd.Repository, cmd.PullRequest)
+		var result *apitypes.PlanResponse
+		err := withLoading("Generating schema change plan...", !cmd.JSON, func() error {
+			var planErr error
+			result, planErr = client.CallPlanAPI(ep, cfg.Database, cfg.Type, env, cfg.SchemaDir, cmd.Repository, cmd.PullRequest)
+			return planErr
+		})
 		if err != nil {
 			if cmd.JSON {
 				return client.ExitWithJSON("api_error", err.Error())

--- a/pkg/cmd/commands/progress.go
+++ b/pkg/cmd/commands/progress.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"fmt"
 
+	"github.com/block/schemabot/pkg/apitypes"
 	"github.com/block/schemabot/pkg/cmd/client"
 	"github.com/block/schemabot/pkg/cmd/internal/templates"
 )
@@ -29,7 +30,12 @@ func (cmd *ProgressCmd) Run(g *Globals) error {
 		return watchApplyProgressByApplyIDWithEnvironment(ep, cmd.ApplyID, cmd.Environment, true)
 	}
 
-	result, err := client.GetProgress(ep, cmd.ApplyID)
+	var result *apitypes.ProgressResponse
+	err = withLoading("Loading schema change progress...", true, func() error {
+		var loadErr error
+		result, loadErr = client.GetProgress(ep, cmd.ApplyID)
+		return loadErr
+	})
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/commands/pull.go
+++ b/pkg/cmd/commands/pull.go
@@ -25,9 +25,14 @@ func (cmd *PullCmd) Run(g *Globals) error {
 	if err != nil {
 		return err
 	}
-	resp, err := client.CallPullSchemaAPIWithOptions(ep, cmd.Database, cmd.Type, cmd.Environment, client.PullSchemaOptions{
-		Namespaces:    cmd.Namespaces,
-		CatalogDetail: cmd.CatalogDetail,
+	var resp *apitypes.PullSchemaResponse
+	err = withLoading("Pulling live schema...", true, func() error {
+		var pullErr error
+		resp, pullErr = client.CallPullSchemaAPIWithOptions(ep, cmd.Database, cmd.Type, cmd.Environment, client.PullSchemaOptions{
+			Namespaces:    cmd.Namespaces,
+			CatalogDetail: cmd.CatalogDetail,
+		})
+		return pullErr
 	})
 	if err != nil {
 		if outputSchemaPullRequestError("Pull", cmd.Database, cmd.Environment, err) {

--- a/pkg/cmd/commands/revert.go
+++ b/pkg/cmd/commands/revert.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log/slog"
 
+	"github.com/block/schemabot/pkg/apitypes"
 	"github.com/block/schemabot/pkg/cmd/client"
 	"github.com/block/schemabot/pkg/state"
 )
@@ -24,7 +25,12 @@ func (cmd *RevertCmd) Run(g *Globals) error {
 	}
 
 	// Check current state
-	result, err := client.GetProgress(ep, cmd.ApplyID)
+	var result *apitypes.ProgressResponse
+	err = withLoading("Loading schema change progress...", true, func() error {
+		var loadErr error
+		result, loadErr = client.GetProgress(ep, cmd.ApplyID)
+		return loadErr
+	})
 	if err == nil {
 		populateControlDisplayFields(&cmd.Database, result)
 		if !state.IsState(result.State, state.Apply.RevertWindow) {
@@ -35,7 +41,12 @@ func (cmd *RevertCmd) Run(g *Globals) error {
 			"apply_id", cmd.ApplyID, "environment", cmd.Environment, "error", err)
 	}
 
-	resp, err := client.CallRevertAPI(ep, cmd.Environment, cmd.ApplyID)
+	var resp *apitypes.ControlResponse
+	err = withLoading("Requesting revert...", true, func() error {
+		var revertErr error
+		resp, revertErr = client.CallRevertAPI(ep, cmd.Environment, cmd.ApplyID)
+		return revertErr
+	})
 	if err != nil {
 		return fmt.Errorf("revert failed: %w", err)
 	}

--- a/pkg/cmd/commands/rollback.go
+++ b/pkg/cmd/commands/rollback.go
@@ -27,7 +27,6 @@ func (cmd *RollbackCmd) Run(g *Globals) error {
 	}
 
 	// Step 1: Generate rollback plan from the specified apply
-	fmt.Println("Generating rollback plan...")
 	var planResult *apitypes.PlanResponse
 	err = withLoading("Generating rollback plan...", true, func() error {
 		var planErr error

--- a/pkg/cmd/commands/rollback.go
+++ b/pkg/cmd/commands/rollback.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/block/schemabot/pkg/apitypes"
 	"github.com/block/schemabot/pkg/cmd/client"
 	"github.com/block/schemabot/pkg/cmd/internal/templates"
 	"github.com/block/schemabot/pkg/state"
@@ -27,7 +28,12 @@ func (cmd *RollbackCmd) Run(g *Globals) error {
 
 	// Step 1: Generate rollback plan from the specified apply
 	fmt.Println("Generating rollback plan...")
-	planResult, err := client.CallRollbackPlanAPI(ep, cmd.ApplyID, cmd.Environment)
+	var planResult *apitypes.PlanResponse
+	err = withLoading("Generating rollback plan...", true, func() error {
+		var planErr error
+		planResult, planErr = client.CallRollbackPlanAPI(ep, cmd.ApplyID, cmd.Environment)
+		return planErr
+	})
 	if err != nil {
 		return err
 	}
@@ -37,7 +43,12 @@ func (cmd *RollbackCmd) Run(g *Globals) error {
 	dbType := planResult.DatabaseType
 
 	// Check for existing active schema change
-	active, err := client.CheckActiveSchemaChange(ep, database, environment)
+	var active *client.ActiveSchemaChange
+	err = withLoading("Checking active schema changes...", true, func() error {
+		var checkErr error
+		active, checkErr = client.CheckActiveSchemaChange(ep, database, environment)
+		return checkErr
+	})
 	if err != nil {
 		// Ignore status preflight errors; apply is still guarded server-side.
 	} else if active != nil && active.State != "" {
@@ -109,7 +120,12 @@ func (cmd *RollbackCmd) Run(g *Globals) error {
 	// Step 4: Acquire lock and apply the rollback
 	owner := client.GenerateCLIOwner()
 
-	existingLock, err := client.GetLock(ep, database, dbType)
+	var existingLock *client.LockInfo
+	err = withLoading("Checking database lock...", true, func() error {
+		var lockErr error
+		existingLock, lockErr = client.GetLock(ep, database, dbType)
+		return lockErr
+	})
 	if err != nil {
 		return fmt.Errorf("check lock: %w", err)
 	}
@@ -125,7 +141,10 @@ func (cmd *RollbackCmd) Run(g *Globals) error {
 		return fmt.Errorf("database is locked")
 	}
 
-	_, err = client.AcquireLock(ep, database, dbType, owner, "", 0)
+	err = withLoading("Acquiring database lock...", true, func() error {
+		_, lockErr := client.AcquireLock(ep, database, dbType, owner, "", 0)
+		return lockErr
+	})
 	if errors.Is(err, client.ErrLockHeld) {
 		return fmt.Errorf("database is locked by another user")
 	}

--- a/pkg/cmd/commands/settings.go
+++ b/pkg/cmd/commands/settings.go
@@ -62,7 +62,12 @@ func validateSettingKey(key string) error {
 }
 
 func listSettings(endpoint string) error {
-	settings, err := client.ListSettings(endpoint)
+	var settings []*client.Setting
+	err := withLoading("Loading settings...", true, func() error {
+		var loadErr error
+		settings, loadErr = client.ListSettings(endpoint)
+		return loadErr
+	})
 	if err != nil {
 		return err
 	}
@@ -89,7 +94,12 @@ func listSettings(endpoint string) error {
 }
 
 func getSetting(endpoint, key string) error {
-	value, err := client.GetSetting(endpoint, key)
+	var value string
+	err := withLoading("Loading setting...", true, func() error {
+		var loadErr error
+		value, loadErr = client.GetSetting(endpoint, key)
+		return loadErr
+	})
 	if err != nil {
 		return err
 	}
@@ -107,7 +117,9 @@ func setSetting(endpoint, key, value string) error {
 		return err
 	}
 
-	if err := client.SetSetting(endpoint, key, value); err != nil {
+	if err := withLoading("Updating setting...", true, func() error {
+		return client.SetSetting(endpoint, key, value)
+	}); err != nil {
 		return err
 	}
 

--- a/pkg/cmd/commands/skip_revert.go
+++ b/pkg/cmd/commands/skip_revert.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log/slog"
 
+	"github.com/block/schemabot/pkg/apitypes"
 	"github.com/block/schemabot/pkg/cmd/client"
 	"github.com/block/schemabot/pkg/state"
 )
@@ -24,7 +25,12 @@ func (cmd *SkipRevertCmd) Run(g *Globals) error {
 	}
 
 	// Check current state
-	result, err := client.GetProgress(ep, cmd.ApplyID)
+	var result *apitypes.ProgressResponse
+	err = withLoading("Loading schema change progress...", true, func() error {
+		var loadErr error
+		result, loadErr = client.GetProgress(ep, cmd.ApplyID)
+		return loadErr
+	})
 	if err == nil {
 		populateControlDisplayFields(&cmd.Database, result)
 		if !state.IsState(result.State, state.Apply.RevertWindow) {
@@ -35,7 +41,12 @@ func (cmd *SkipRevertCmd) Run(g *Globals) error {
 			"apply_id", cmd.ApplyID, "environment", cmd.Environment, "error", err)
 	}
 
-	resp, err := client.CallSkipRevertAPI(ep, cmd.Environment, cmd.ApplyID)
+	var resp *apitypes.ControlResponse
+	err = withLoading("Skipping revert window...", true, func() error {
+		var skipErr error
+		resp, skipErr = client.CallSkipRevertAPI(ep, cmd.Environment, cmd.ApplyID)
+		return skipErr
+	})
 	if err != nil {
 		return fmt.Errorf("skip-revert failed: %w", err)
 	}

--- a/pkg/cmd/commands/start.go
+++ b/pkg/cmd/commands/start.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"fmt"
 
+	"github.com/block/schemabot/pkg/apitypes"
 	"github.com/block/schemabot/pkg/cmd/client"
 	"github.com/block/schemabot/pkg/cmd/internal/templates"
 	"github.com/block/schemabot/pkg/state"
@@ -25,7 +26,12 @@ func (cmd *StartCmd) Run(g *Globals) error {
 	}
 
 	// Check current state first
-	result, err := client.GetProgress(ep, cmd.ApplyID)
+	var result *apitypes.ProgressResponse
+	err = withLoading("Loading schema change progress...", true, func() error {
+		var loadErr error
+		result, loadErr = client.GetProgress(ep, cmd.ApplyID)
+		return loadErr
+	})
 	if err != nil {
 		return fmt.Errorf("get progress: %w", err)
 	}
@@ -48,7 +54,12 @@ func (cmd *StartCmd) Run(g *Globals) error {
 	}
 
 	// Call start API
-	startResult, err := client.CallStartAPI(ep, cmd.Environment, cmd.ApplyID)
+	var startResult *apitypes.StartResponse
+	err = withLoading("Starting schema change...", true, func() error {
+		var startErr error
+		startResult, startErr = client.CallStartAPI(ep, cmd.Environment, cmd.ApplyID)
+		return startErr
+	})
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/commands/status.go
+++ b/pkg/cmd/commands/status.go
@@ -29,19 +29,24 @@ func (cmd *StatusCmd) Run(g *Globals) error {
 
 	// Mode 1: Show details for specific apply by ID
 	if cmd.ApplyIDArg != "" {
-		return showApplyByID(ep, cmd.ApplyIDArg, cmd.JSON)
+		return showApplyByID(ep, cmd.ApplyIDArg, cmd.JSON, !cmd.JSON)
 	}
 
 	// Mode 2: Show history for a database
 	if cmd.Database != "" {
-		return showDatabaseHistory(ep, cmd.Database, cmd.Environment, cmd.JSON)
+		return showDatabaseHistory(ep, cmd.Database, cmd.Environment, cmd.JSON, !cmd.JSON)
 	}
 
 	// Mode 3: List recent applies
-	result, err := client.GetStatus(ep, client.StatusOptions{
-		Limit:       cmd.Limit,
-		Environment: cmd.Environment,
-		Failed:      cmd.Failed,
+	var result *apitypes.StatusResponse
+	err = withLoading("Loading schema change status...", !cmd.JSON, func() error {
+		var loadErr error
+		result, loadErr = client.GetStatus(ep, client.StatusOptions{
+			Limit:       cmd.Limit,
+			Environment: cmd.Environment,
+			Failed:      cmd.Failed,
+		})
+		return loadErr
 	})
 	if err != nil {
 		return err
@@ -88,8 +93,13 @@ func activeApplyDataFromResponse(a *apitypes.ActiveApplyResponse) templates.Acti
 }
 
 // showApplyByID shows details for a specific apply by its ID.
-func showApplyByID(endpoint, applyID string, outputJSON bool) error {
-	result, err := client.GetProgress(endpoint, applyID)
+func showApplyByID(endpoint, applyID string, outputJSON, showLoader bool) error {
+	var result *apitypes.ProgressResponse
+	err := withLoading("Loading schema change details...", showLoader, func() error {
+		var loadErr error
+		result, loadErr = client.GetProgress(endpoint, applyID)
+		return loadErr
+	})
 	if err != nil {
 		if client.IsNotFound(err) {
 			fmt.Printf("No schema change found for apply '%s'\n", applyID)
@@ -116,8 +126,13 @@ func showApplyByID(endpoint, applyID string, outputJSON bool) error {
 }
 
 // showDatabaseHistory shows all applies for a database.
-func showDatabaseHistory(endpoint, database, environment string, outputJSON bool) error {
-	result, err := client.GetDatabaseHistory(endpoint, database, environment)
+func showDatabaseHistory(endpoint, database, environment string, outputJSON, showLoader bool) error {
+	var result *apitypes.DatabaseHistoryResponse
+	err := withLoading("Loading schema change history...", showLoader, func() error {
+		var loadErr error
+		result, loadErr = client.GetDatabaseHistory(endpoint, database, environment)
+		return loadErr
+	})
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/commands/stop.go
+++ b/pkg/cmd/commands/stop.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"fmt"
 
+	"github.com/block/schemabot/pkg/apitypes"
 	"github.com/block/schemabot/pkg/cmd/client"
 	"github.com/block/schemabot/pkg/cmd/internal/templates"
 	"github.com/block/schemabot/pkg/state"
@@ -24,7 +25,12 @@ func (cmd *StopCmd) Run(g *Globals) error {
 	}
 
 	// Check current state first
-	result, err := client.GetProgress(ep, cmd.ApplyID)
+	var result *apitypes.ProgressResponse
+	err = withLoading("Loading schema change progress...", true, func() error {
+		var loadErr error
+		result, loadErr = client.GetProgress(ep, cmd.ApplyID)
+		return loadErr
+	})
 	if err != nil {
 		return fmt.Errorf("get progress for apply %s: %w", cmd.ApplyID, err)
 	}
@@ -48,7 +54,12 @@ func (cmd *StopCmd) Run(g *Globals) error {
 	}
 
 	// Call stop API
-	stopResult, err := client.CallStopAPI(ep, cmd.Environment, cmd.ApplyID)
+	var stopResult *apitypes.StopResponse
+	err = withLoading("Stopping schema change...", true, func() error {
+		var stopErr error
+		stopResult, stopErr = client.CallStopAPI(ep, cmd.Environment, cmd.ApplyID)
+		return stopErr
+	})
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/commands/unlock.go
+++ b/pkg/cmd/commands/unlock.go
@@ -26,7 +26,12 @@ func (cmd *UnlockCmd) Run(g *Globals) error {
 
 	if cmd.Force {
 		// Force release - get lock info first to show previous owner
-		existingLock, err := client.GetLock(ep, cmd.Database, cmd.Type)
+		var existingLock *client.LockInfo
+		err := withLoading("Checking database lock...", true, func() error {
+			var lockErr error
+			existingLock, lockErr = client.GetLock(ep, cmd.Database, cmd.Type)
+			return lockErr
+		})
 		if err != nil {
 			return fmt.Errorf("check lock: %w", err)
 		}
@@ -35,7 +40,9 @@ func (cmd *UnlockCmd) Run(g *Globals) error {
 			return nil
 		}
 
-		if err := client.ForceReleaseLock(ep, cmd.Database, cmd.Type); err != nil {
+		if err := withLoading("Releasing database lock...", true, func() error {
+			return client.ForceReleaseLock(ep, cmd.Database, cmd.Type)
+		}); err != nil {
 			return fmt.Errorf("force release lock: %w", err)
 		}
 		templates.WriteLockForceReleased(cmd.Database, cmd.Type, existingLock.Owner)
@@ -43,14 +50,21 @@ func (cmd *UnlockCmd) Run(g *Globals) error {
 	}
 
 	// Normal release - ownership required
-	err = client.ReleaseLock(ep, cmd.Database, cmd.Type, owner)
+	err = withLoading("Releasing database lock...", true, func() error {
+		return client.ReleaseLock(ep, cmd.Database, cmd.Type, owner)
+	})
 	if errors.Is(err, client.ErrLockNotFound) {
 		templates.WriteNoLockFound(cmd.Database, cmd.Type)
 		return nil
 	}
 	if errors.Is(err, client.ErrLockNotOwned) {
 		// Show current owner
-		existingLock, getErr := client.GetLock(ep, cmd.Database, cmd.Type)
+		var existingLock *client.LockInfo
+		getErr := withLoading("Checking database lock...", true, func() error {
+			var lockErr error
+			existingLock, lockErr = client.GetLock(ep, cmd.Database, cmd.Type)
+			return lockErr
+		})
 		if getErr != nil || existingLock == nil {
 			return fmt.Errorf("lock is not owned by you")
 		}

--- a/pkg/cmd/commands/volume.go
+++ b/pkg/cmd/commands/volume.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"fmt"
 
+	"github.com/block/schemabot/pkg/apitypes"
 	"github.com/block/schemabot/pkg/cmd/client"
 	"github.com/block/schemabot/pkg/state"
 )
@@ -29,7 +30,12 @@ func (cmd *VolumeCmd) Run(g *Globals) error {
 	}
 
 	// Check current state first
-	result, err := client.GetProgress(ep, cmd.ApplyID)
+	var result *apitypes.ProgressResponse
+	err = withLoading("Loading schema change progress...", true, func() error {
+		var loadErr error
+		result, loadErr = client.GetProgress(ep, cmd.ApplyID)
+		return loadErr
+	})
 	if err != nil {
 		return fmt.Errorf("get progress: %w", err)
 	}
@@ -48,7 +54,12 @@ func (cmd *VolumeCmd) Run(g *Globals) error {
 	}
 
 	// Call volume API
-	volumeResult, err := client.CallVolumeAPI(ep, cmd.Environment, cmd.ApplyID, cmd.Volume)
+	var volumeResult *apitypes.VolumeResponse
+	err = withLoading("Updating schema change volume...", true, func() error {
+		var volumeErr error
+		volumeResult, volumeErr = client.CallVolumeAPI(ep, cmd.Environment, cmd.ApplyID, cmd.Volume)
+		return volumeErr
+	})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Why
Some CLI commands can appear hung while they wait for the SchemaBot API, especially status and other one-shot commands that print nothing until the response arrives.

## What
- Add a delayed stderr loading spinner for human-facing API calls
- Keep JSON, non-TTY, watch, follow, and TUI flows quiet
- Cover the spinner helper with focused behavior tests

## Risk Assessment
Low — this only changes CLI presentation around existing API calls, and stdout remains script-friendly.

Generated with Amp
