### PR TITLE
feat(tern): fan sharded applies out per shard on the data plane

### DIFF
--- a/pkg/api/service.go
+++ b/pkg/api/service.go
@@ -551,6 +551,7 @@ func (s *Service) newLocalTernClient(key, database, dbType string, envConfig Env
 		Metadata:        metadata,
 		WakeOperator:    s.wakeOperator,
 		EngineFactories: s.engineFactories,
+		ClaimOperations: s.config.ShouldClaimOperations(),
 	}, s.storage, s.logger)
 	if err != nil {
 		return nil, fmt.Errorf("create local tern client for %s: %w", key, err)

--- a/pkg/serve/serve.go
+++ b/pkg/serve/serve.go
@@ -547,6 +547,7 @@ func buildGRPCTernClient(ctx context.Context, config *api.ServerConfig, st *mysq
 // share identical execution semantics and can resolve custom database types.
 func grpcLocalClientFactory(config *api.ServerConfig, wakeOperator func(applyIdentifier, database, environment string), engineFactories map[string]tern.EngineFactory) tern.LocalClientFactory {
 	pendingDropsDisabled := !config.PendingDropsEnabled()
+	claimOperations := config.ShouldClaimOperations()
 	return func(cfg tern.LocalConfig, st storage.Storage, logger *slog.Logger) (tern.Client, error) {
 		if pendingDropsDisabled {
 			if cfg.Metadata == nil {
@@ -557,6 +558,10 @@ func grpcLocalClientFactory(config *api.ServerConfig, wakeOperator func(applyIde
 		if cfg.WakeOperator == nil {
 			cfg.WakeOperator = wakeOperator
 		}
+		// Mirror the operator's claim mode onto the client so Apply creates the
+		// operations the operator will claim (fanning a sharded engine out per
+		// shard) instead of driving the whole apply inline.
+		cfg.ClaimOperations = claimOperations
 		// Merge the embedder registry into this config so custom types always
 		// resolve, regardless of whether the resolved config already carries
 		// factories. Build a fresh map so the caller's is never mutated, and let
@@ -695,13 +700,20 @@ func getEnv(key, defaultValue string) string {
 }
 
 // applyDataPlaneClaimDefault sets the operator claim mode for a data-plane tern
-// process. A process serving the Tern proto over gRPC drives applies inline via
-// LocalClient and does not own the apply_operations lifecycle, so its operator
-// must recover work at the apply level via FindNextApply; operation-level
-// claiming reads a vestigial operation row that never tracks the apply and so
-// cannot resume it. When the mode is unset, default it to apply-level claiming
-// for this process; an operator can still opt in explicitly. Operation-level
-// claiming is a control-plane concept. Reports whether the default was applied.
+// process. By default a process serving the Tern proto over gRPC drives applies
+// inline via LocalClient, so its operator recovers work at the apply level via
+// FindNextApply; mixing inline drive with operation-level claiming is unsafe
+// because an inline-driven operation holds the apply lease but not the
+// operation lease, so an operation claimer would double-drive it. When the mode
+// is unset, default it to apply-level claiming for this process.
+//
+// A data plane CAN opt in to operation-level claiming explicitly
+// (operator_claim_operations: true). When it does, LocalClient.Apply stops
+// driving inline and instead creates the apply's operations for the operator to
+// claim and drive (see LocalClient.ClaimOperations); this is what lets a sharded
+// engine fan a plan out into one claimable work operation per shard, since the
+// engine is handed a single target shard per operation. Reports whether the
+// default was applied.
 func applyDataPlaneClaimDefault(cfg *api.ServerConfig, isDataPlane bool) bool {
 	if !isDataPlane || cfg.OperatorClaimOperations != nil {
 		return false

--- a/pkg/tern/local_apply_fanout.go
+++ b/pkg/tern/local_apply_fanout.go
@@ -1,0 +1,190 @@
+package tern
+
+import (
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/block/schemabot/pkg/state"
+	"github.com/block/schemabot/pkg/storage"
+)
+
+// finalizerOperationKeySegment is the trailing operation-key segment of a
+// namespace's group_finalizer. It matches the control-plane constant of the
+// same value in pkg/api.
+const finalizerOperationKeySegment = "group_finalizer"
+
+// buildApplyOperationGroups builds the apply_operations (and their tasks) for an
+// apply created on a data-plane Tern that claims work at the operation level.
+//
+// It is the LocalClient counterpart to the control-plane fan-out in pkg/api
+// (buildApplyOperationGroups / buildShardedApplyOperationGroups): a sharded
+// engine whose plan carries changing shards fans the apply out into one work
+// operation per (namespace, shard, table), each carrying a single shard-tagged
+// task, so the operator can claim and drive each shard independently and hand
+// the engine exactly one target shard. Every namespace that changes its VSchema
+// also gets a task-less group_finalizer that runs once its shard work
+// completes. Any other apply (no sharded engine, or a plan with no changing
+// shards) stays a single whole-deployment work operation carrying all the
+// tasks, preserving the pre-fan-out shape.
+//
+// The data plane resolves no cutover policy / on_failure (it has no environment
+// config, unlike the API apply path), so operations are created with the
+// store's safe defaults — matching the prior single-operation behavior.
+func (c *LocalClient) buildApplyOperationGroups(apply *storage.Apply, plan *storage.Plan, ddlChanges []storage.TableChange, optionsJSON []byte, now time.Time) []*storage.ApplyOperationWithTasks {
+	if c.SupportsShardedApplyFanout() {
+		if groups := c.buildShardedOperationGroups(apply, plan, ddlChanges, optionsJSON, now); groups != nil {
+			return groups
+		}
+	}
+
+	// Single whole-deployment work operation carrying every task. This is the
+	// operation-claiming shape of the legacy single-operation apply, so a
+	// non-sharded engine (or a plan with no changing shards) is driven exactly as
+	// before, just claimed at the operation level.
+	tasks := make([]*storage.Task, len(ddlChanges))
+	for i, ddlChange := range ddlChanges {
+		tasks[i] = c.newApplyTask(apply, plan, ddlChange, "", optionsJSON, now)
+	}
+	return []*storage.ApplyOperationWithTasks{{
+		Operation: c.newWorkOperation(apply, plan, "", now),
+		Tasks:     tasks,
+	}}
+}
+
+// buildShardedOperationGroups returns one work operation per (namespace, shard,
+// table) plus a group_finalizer per VSchema-changing namespace, or nil when the
+// plan cannot be fanned out per shard — no changing shards, or a changing
+// namespace whose table work has no shard membership — so the caller falls back
+// to a single operation. It mirrors api.canBuildShardedOperationGroups and
+// api.buildShardedApplyOperationGroups for the single-deployment data plane.
+func (c *LocalClient) buildShardedOperationGroups(apply *storage.Apply, plan *storage.Plan, ddlChanges []storage.TableChange, optionsJSON []byte, now time.Time) []*storage.ApplyOperationWithTasks {
+	if len(plan.Shards) == 0 || len(ddlChanges) == 0 {
+		return nil
+	}
+	shardsByNamespace := changingShardsByNamespace(plan.Shards)
+	if len(shardsByNamespace) == 0 {
+		return nil
+	}
+	for _, ddlChange := range ddlChanges {
+		if ddlChange.DDL == "" || ddlChange.Table == "" {
+			return nil
+		}
+		if len(shardsByNamespace[ddlChange.Namespace]) == 0 {
+			return nil
+		}
+	}
+
+	groups := make([]*storage.ApplyOperationWithTasks, 0, len(ddlChanges))
+	for _, ddlChange := range ddlChanges {
+		for _, shard := range shardsByNamespace[ddlChange.Namespace] {
+			op := c.newWorkOperation(apply, plan, shardOperationKey(ddlChange.Namespace, shard.Shard, ddlChange.Table), now)
+			task := c.newApplyTask(apply, plan, ddlChange, shard.Shard, optionsJSON, now)
+			groups = append(groups, &storage.ApplyOperationWithTasks{
+				Operation: op,
+				Tasks:     []*storage.Task{task},
+			})
+		}
+	}
+
+	// A VSchema-changing namespace gets a task-less group_finalizer; the operator
+	// drives it from the plan once the namespace's shard work completes. A
+	// namespace with no shard work would have failed the per-change check above,
+	// so a finalizer here always trails real shard work.
+	for _, namespace := range vschemaFinalizerNamespaces(plan) {
+		op := c.newWorkOperation(apply, plan, finalizerOperationKey(namespace), now)
+		op.OperationKind = storage.ApplyOperationKindGroupFinalizer
+		groups = append(groups, &storage.ApplyOperationWithTasks{Operation: op})
+	}
+	return groups
+}
+
+// newWorkOperation builds a pending work apply_operation for this deployment.
+// CutoverPolicy and OnFailure are left unset so the store applies its safe
+// defaults, matching the data plane's prior single-operation behavior.
+func (c *LocalClient) newWorkOperation(apply *storage.Apply, plan *storage.Plan, operationKey string, now time.Time) *storage.ApplyOperation {
+	return &storage.ApplyOperation{
+		Deployment:    apply.Deployment,
+		Target:        plan.Target,
+		OperationKey:  operationKey,
+		OperationKind: storage.ApplyOperationKindWork,
+		State:         state.ApplyOperation.Pending,
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}
+}
+
+// newApplyTask builds a pending task for one DDL change on one shard. An empty
+// shard targets the whole deployment (non-sharded engines); a non-empty shard
+// scopes the task to that shard so the operator hands the engine exactly one
+// target shard.
+func (c *LocalClient) newApplyTask(apply *storage.Apply, plan *storage.Plan, ddlChange storage.TableChange, shard string, optionsJSON []byte, now time.Time) *storage.Task {
+	return &storage.Task{
+		TaskIdentifier: "task-" + uuidSuffix(),
+		PlanID:         plan.ID,
+		Database:       plan.Database,
+		DatabaseType:   plan.DatabaseType,
+		Engine:         apply.Engine,
+		Repository:     plan.Repository,
+		PullRequest:    plan.PullRequest,
+		Environment:    apply.Environment,
+		State:          state.Task.Pending,
+		Options:        optionsJSON,
+		TableName:      ddlChange.Table,
+		Namespace:      ddlChange.Namespace,
+		Shard:          shard,
+		DDL:            ddlChange.DDL,
+		DDLAction:      ddlChange.Operation,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+}
+
+func uuidSuffix() string {
+	return strings.ReplaceAll(uuid.New().String(), "-", "")[:16]
+}
+
+// changingShardsByNamespace groups a plan's changing shards by namespace,
+// sorted by shard name. It mirrors the control-plane helper of the same name in
+// pkg/api.
+func changingShardsByNamespace(shards []storage.ShardPlan) map[string][]storage.ShardPlan {
+	byNamespace := make(map[string][]storage.ShardPlan)
+	for _, shard := range shards {
+		if !shard.NeedsChange {
+			continue
+		}
+		byNamespace[shard.Namespace] = append(byNamespace[shard.Namespace], shard)
+	}
+	for namespace := range byNamespace {
+		sort.Slice(byNamespace[namespace], func(i, j int) bool {
+			return byNamespace[namespace][i].Shard < byNamespace[namespace][j].Shard
+		})
+	}
+	return byNamespace
+}
+
+// shardOperationKey and finalizerOperationKey build operation keys in the same
+// namespace/shard/table format the control plane uses, so a data-plane apply's
+// operations are keyed identically to the control-plane fan-out.
+func shardOperationKey(namespace, shard, table string) string {
+	return namespace + "/" + shard + "/" + table
+}
+
+func finalizerOperationKey(namespace string) string {
+	return namespace + "/" + finalizerOperationKeySegment
+}
+
+// vschemaFinalizerNamespaces returns, sorted, every namespace in the plan that
+// carries a VSchema artifact and therefore needs a group_finalizer.
+func vschemaFinalizerNamespaces(plan *storage.Plan) []string {
+	var namespaces []string
+	for namespace, nsData := range plan.Namespaces {
+		if namespaceHasVSchemaArtifact(nsData) {
+			namespaces = append(namespaces, namespace)
+		}
+	}
+	sort.Strings(namespaces)
+	return namespaces
+}

--- a/pkg/tern/local_apply_fanout_test.go
+++ b/pkg/tern/local_apply_fanout_test.go
@@ -1,0 +1,158 @@
+package tern
+
+import (
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/block/schemabot/pkg/state"
+	"github.com/block/schemabot/pkg/storage"
+)
+
+const fanoutNamespace = "cdb_resolute_sharded"
+
+func fanoutTestTime() time.Time { return time.Unix(1700000000, 0).UTC() }
+
+func shardedPlan(shards ...string) *storage.Plan {
+	plan := &storage.Plan{
+		ID:           7,
+		Database:     "cdb-resolute",
+		DatabaseType: storage.DatabaseTypeStrata,
+		Target:       "cdb-resolute",
+	}
+	for _, shard := range shards {
+		plan.Shards = append(plan.Shards, storage.ShardPlan{
+			Shard:       shard,
+			Namespace:   fanoutNamespace,
+			NeedsChange: true,
+		})
+	}
+	return plan
+}
+
+func mutesIndexChange() []storage.TableChange {
+	return []storage.TableChange{{
+		Namespace: fanoutNamespace,
+		Table:     "mutes",
+		DDL:       "ALTER TABLE `mutes` ADD INDEX (`created_at`)",
+		Operation: "alter",
+	}}
+}
+
+func fanoutTestClient() *LocalClient {
+	return &LocalClient{
+		config: LocalConfig{Database: "cdb-resolute", Type: storage.DatabaseTypeStrata},
+		logger: slog.Default(),
+	}
+}
+
+// A sharded plan fans out into one pending work operation per (namespace, shard,
+// table), each carrying a single shard-tagged task, with shards in sorted order.
+// This is the shape the operator claims to hand the engine exactly one target
+// shard per operation.
+func TestBuildShardedOperationGroupsFansOutPerShard(t *testing.T) {
+	c := fanoutTestClient()
+	apply := &storage.Apply{Deployment: "cdb-resolute", Environment: "production", Engine: storage.EngineStrata}
+	plan := shardedPlan("80-c0", "-40", "c0-", "40-80") // intentionally unsorted
+
+	groups := c.buildShardedOperationGroups(apply, plan, mutesIndexChange(), nil, fanoutTestTime())
+	require.Len(t, groups, 4, "one work operation per changing shard")
+
+	wantShards := []string{"-40", "40-80", "80-c0", "c0-"}
+	for i, group := range groups {
+		shard := wantShards[i]
+		require.NotNil(t, group.Operation)
+		assert.Equal(t, storage.ApplyOperationKindWork, group.Operation.OperationKind)
+		assert.Equal(t, state.ApplyOperation.Pending, group.Operation.State)
+		assert.Equal(t, "cdb-resolute", group.Operation.Deployment)
+		assert.Equal(t, "cdb-resolute", group.Operation.Target)
+		assert.Equal(t, fanoutNamespace+"/"+shard+"/mutes", group.Operation.OperationKey,
+			"operation key must encode namespace/shard/table")
+
+		require.Len(t, group.Tasks, 1, "each shard operation carries exactly one task")
+		task := group.Tasks[0]
+		assert.Equal(t, shard, task.Shard, "task must be tagged with its shard")
+		assert.Equal(t, "mutes", task.TableName)
+		assert.Equal(t, fanoutNamespace, task.Namespace)
+		assert.Equal(t, state.Task.Pending, task.State)
+		assert.Equal(t, storage.EngineStrata, task.Engine)
+	}
+}
+
+// taskTargetShards over a single shard operation's tasks yields exactly one
+// shard — the invariant the strata engine's work path enforces.
+func TestShardedOperationGroupsYieldSingleTargetShard(t *testing.T) {
+	c := fanoutTestClient()
+	apply := &storage.Apply{Deployment: "cdb-resolute", Engine: storage.EngineStrata}
+	groups := c.buildShardedOperationGroups(apply, shardedPlan("-80", "80-"), mutesIndexChange(), nil, fanoutTestTime())
+	require.Len(t, groups, 2)
+	for _, group := range groups {
+		assert.Len(t, taskTargetShards(group.Tasks), 1,
+			"each operation must resolve to exactly one target shard")
+	}
+}
+
+// A VSchema-changing namespace also gets a task-less group_finalizer that trails
+// its shard work.
+func TestBuildShardedOperationGroupsAppendsVSchemaFinalizer(t *testing.T) {
+	c := fanoutTestClient()
+	apply := &storage.Apply{Deployment: "cdb-resolute", Engine: storage.EngineStrata}
+	plan := shardedPlan("-80", "80-")
+	plan.Namespaces = map[string]*storage.NamespacePlanData{
+		fanoutNamespace: {Artifacts: map[string]string{vSchemaArtifactName: "{}"}},
+	}
+
+	groups := c.buildShardedOperationGroups(apply, plan, mutesIndexChange(), nil, fanoutTestTime())
+	require.Len(t, groups, 3, "two shard work operations plus one finalizer")
+
+	finalizer := groups[len(groups)-1]
+	assert.Equal(t, storage.ApplyOperationKindGroupFinalizer, finalizer.Operation.OperationKind)
+	assert.Equal(t, fanoutNamespace+"/"+finalizerOperationKeySegment, finalizer.Operation.OperationKey)
+	assert.Empty(t, finalizer.Tasks, "a group_finalizer carries no tasks")
+}
+
+// When the plan has no per-shard membership for the changing tables, the sharded
+// builder declines (returns nil) so the caller falls back to a single operation.
+func TestBuildShardedOperationGroupsDeclinesWithoutShards(t *testing.T) {
+	c := fanoutTestClient()
+	apply := &storage.Apply{Deployment: "cdb-resolute", Engine: storage.EngineStrata}
+
+	assert.Nil(t, c.buildShardedOperationGroups(apply, &storage.Plan{ID: 1}, mutesIndexChange(), nil, fanoutTestTime()),
+		"no shards at all → decline")
+
+	// A changing namespace whose changing table's namespace has no shard rows
+	// must decline rather than silently dropping the table's work.
+	otherNamespaceChange := []storage.TableChange{{Namespace: "other", Table: "t", DDL: "ALTER TABLE `t` ADD COLUMN c int"}}
+	assert.Nil(t, c.buildShardedOperationGroups(apply, shardedPlan("-80"), otherNamespaceChange, nil, fanoutTestTime()),
+		"changing table namespace with no shard membership → decline")
+}
+
+// The non-sharded fallback (no changing shards) produces a single whole-deployment
+// work operation carrying every task with no shard, preserving the pre-fan-out
+// shape. A custom engine that does not report externally-authoritative progress
+// makes SupportsShardedApplyFanout report true, so this exercises the fallback
+// inside buildApplyOperationGroups rather than the engine gate.
+func TestBuildApplyOperationGroupsFallsBackToSingleOperation(t *testing.T) {
+	c := fanoutTestClient()
+	c.customEngine = namedPlanEngine{name: storage.EngineStrata}
+	require.True(t, c.SupportsShardedApplyFanout())
+
+	apply := &storage.Apply{Deployment: "cdb-resolute", Engine: storage.EngineStrata}
+	ddlChanges := []storage.TableChange{
+		{Namespace: fanoutNamespace, Table: "mutes", DDL: "ALTER TABLE `mutes` ADD INDEX (`created_at`)", Operation: "alter"},
+		{Namespace: fanoutNamespace, Table: "logs", DDL: "ALTER TABLE `logs` ADD INDEX (`created_at`)", Operation: "alter"},
+	}
+
+	// No shards on the plan → no per-shard fan-out → single operation.
+	groups := c.buildApplyOperationGroups(apply, &storage.Plan{ID: 1, Target: "cdb-resolute"}, ddlChanges, nil, fanoutTestTime())
+	require.Len(t, groups, 1)
+	assert.Equal(t, storage.ApplyOperationKindWork, groups[0].Operation.OperationKind)
+	assert.Empty(t, groups[0].Operation.OperationKey, "single operation uses the legacy empty key")
+	require.Len(t, groups[0].Tasks, 2, "all tasks ride the one operation")
+	for _, task := range groups[0].Tasks {
+		assert.Empty(t, task.Shard, "non-sharded tasks carry no shard")
+	}
+}

--- a/pkg/tern/local_client.go
+++ b/pkg/tern/local_client.go
@@ -157,6 +157,17 @@ type LocalConfig struct {
 	// api.Service.RegisterEngine); NewLocalClient uses the matching factory for a
 	// Type that has no built-in engine.
 	EngineFactories map[string]EngineFactory
+
+	// ClaimOperations mirrors ServerConfig.ShouldClaimOperations: when true the
+	// operator drives applies by claiming apply_operations rows, so Apply creates
+	// the apply's operations (fanning a sharded engine out into one work
+	// operation per shard) and leaves them for the operator to claim and drive
+	// rather than driving the whole apply inline. When false (the default) Apply
+	// keeps the legacy single-operation, inline-driven path. The two modes must
+	// not be mixed on one process: an inline-driven operation holds the apply
+	// lease but not the operation lease, so an operation-level claimer would
+	// double-drive it.
+	ClaimOperations bool
 }
 
 // EngineFactory builds an Engine for a database type this build does not
@@ -1777,54 +1788,47 @@ func (c *LocalClient) Apply(ctx context.Context, req *ternv1.ApplyRequest) (*ter
 		)
 	}
 
-	tasks := make([]*storage.Task, len(ddlChanges))
-	for i, ddlChange := range ddlChanges {
-		taskIdentifier := "task-" + strings.ReplaceAll(uuid.New().String(), "-", "")[:16]
-		tasks[i] = &storage.Task{
-			TaskIdentifier: taskIdentifier,
-			PlanID:         plan.ID,
-			Database:       plan.Database,
-			DatabaseType:   plan.DatabaseType,
-			Engine:         eng.Name(),
-			Repository:     plan.Repository,
-			PullRequest:    plan.PullRequest,
-			Environment:    req.Environment,
-			State:          state.Task.Pending,
-			Options:        optionsJSON,
-			TableName:      ddlChange.Table,
-			Namespace:      ddlChange.Namespace,
-			DDL:            ddlChange.DDL,
-			DDLAction:      ddlChange.Operation,
-			CreatedAt:      now,
-			UpdatedAt:      now,
-		}
-	}
-
-	// Dual-write one apply_operations row alongside the applies row in the
-	// same transaction so every apply created via the Tern client carries a
-	// claimable, resumable operation. CreateWithTasksAndOperations links each
-	// task to the single operation via ApplyOperationID, which the engine
-	// resume-state path requires and the operator claim loop selects on.
+	// Build the apply's operations and their tasks, then create them atomically
+	// with the apply row. CreateWith{Grouped,TasksAnd}Operations links each task
+	// to its operation via ApplyOperationID, which the engine resume-state path
+	// requires and the operator claim loop selects on.
+	//
+	// Two shapes, selected by claim mode:
+	//   - Operation-claiming (ClaimOperations): the operator drives each operation,
+	//     so buildApplyOperationGroups fans a sharded engine out into one work
+	//     operation per shard (each with a single shard-tagged task) and the
+	//     operator hands the engine exactly one target shard. The apply is not
+	//     driven inline here — that would race the operator, which holds the
+	//     operation lease the inline path does not.
+	//   - Legacy inline drive (default): one apply_operations row carries all
+	//     tasks and this client drives the whole apply inline in the background.
 	//
 	// CutoverPolicy and HaltOnFailure are intentionally left unset: the Tern
 	// client has no environment config to resolve them from (unlike the API
 	// apply path), so the store applies its safe defaults (rolling cutover,
 	// halt on failure).
-	operations := []*storage.ApplyOperation{{
-		Deployment: apply.Deployment,
-		Target:     plan.Target,
-		State:      state.ApplyOperation.Pending,
-		CreatedAt:  now,
-		UpdatedAt:  now,
-	}}
-
-	applyID, err := c.storage.Applies().CreateWithTasksAndOperations(ctx, apply, tasks, operations)
+	var (
+		applyID     int64
+		inlineTasks []*storage.Task
+	)
+	if c.config.ClaimOperations {
+		groups := c.buildApplyOperationGroups(apply, plan, ddlChanges, optionsJSON, now)
+		applyID, err = c.storage.Applies().CreateWithGroupedOperations(ctx, apply, groups)
+	} else {
+		tasks := make([]*storage.Task, len(ddlChanges))
+		for i, ddlChange := range ddlChanges {
+			tasks[i] = c.newApplyTask(apply, plan, ddlChange, "", optionsJSON, now)
+		}
+		operations := []*storage.ApplyOperation{c.newWorkOperation(apply, plan, "", now)}
+		applyID, err = c.storage.Applies().CreateWithTasksAndOperations(ctx, apply, tasks, operations)
+		inlineTasks = tasks
+	}
 	if err != nil {
 		// Two same-key dispatches racing to create: the loser sees a duplicate
 		// idempotency key (or the active-apply guard the create runs). Resolve by
 		// key so the winner's apply is returned instead of a create error.
 		if existing, lookupErr := c.existingIdempotentApply(ctx, req); lookupErr != nil {
-			return nil, fmt.Errorf("create apply %s with tasks and operations (idempotency re-lookup also failed): %w", applyIdentifier, errors.Join(err, lookupErr))
+			return nil, fmt.Errorf("create apply %s with operations (idempotency re-lookup also failed): %w", applyIdentifier, errors.Join(err, lookupErr))
 		} else if existing != nil {
 			c.logger.Info("Apply: idempotency key resolved a create race",
 				"apply_id", existing.ApplyIdentifier,
@@ -1834,7 +1838,7 @@ func (c *LocalClient) Apply(ctx context.Context, req *ternv1.ApplyRequest) (*ter
 			metrics.RecordRemoteApplyDedup(ctx, req.Database, req.Environment, "create_race")
 			return &ternv1.ApplyResponse{Accepted: true, ApplyId: existing.ApplyIdentifier}, nil
 		}
-		return nil, fmt.Errorf("create apply %s with tasks and operations: %w", applyIdentifier, err)
+		return nil, fmt.Errorf("create apply %s with operations: %w", applyIdentifier, err)
 	}
 	apply.ID = applyID
 
@@ -1855,13 +1859,26 @@ func (c *LocalClient) Apply(ctx context.Context, req *ternv1.ApplyRequest) (*ter
 		c.SetObserver(apply.ID, obs)
 	}
 
+	if c.config.ClaimOperations {
+		// The operator claims and drives each operation (one per shard for a
+		// sharded engine). Nudge it to pick up the freshly created operations
+		// promptly instead of waiting for the next poll.
+		if c.config.WakeOperator != nil {
+			c.config.WakeOperator(apply.ApplyIdentifier, apply.Database, req.Environment)
+		}
+		return &ternv1.ApplyResponse{
+			Accepted: true,
+			ApplyId:  apply.ApplyIdentifier,
+		}, nil
+	}
+
 	// Start apply in background with cancellable context (Stop() cancels this)
 	applyCtx, cancelApply := context.WithCancel(context.WithoutCancel(ctx))
 	cancelGeneration := c.setApplyCancel(cancelApply)
 	// A fresh dispatch (including a remote gRPC drive) has no operation context,
 	// so it never auto-parks at the cutover barrier; ordered-cutover parking is
 	// driven by the operator's operation-scoped resume path.
-	c.startApplyExecution(applyCtx, cancelGeneration, cancelApply, apply, tasks, plan, options, false)
+	c.startApplyExecution(applyCtx, cancelGeneration, cancelApply, apply, inlineTasks, plan, options, false)
 
 	return &ternv1.ApplyResponse{
 		Accepted: true,


### PR DESCRIPTION
A data-plane Tern drives applies inline via LocalClient.Apply, which built a single apply_operation carrying namespace-level tasks with no shard. A sharded engine (e.g. GAP's Strata engine) requires exactly one target shard per work operation, so it rejected these applies with "expected exactly one target shard, got 0" — the sharded plan was never fanned out, because the fan-out only existed in the control-plane api.Service path and is gated on a client capability the GRPCClient does not implement.

Teach LocalClient.Apply to fan out when the operator claims at the operation level (LocalConfig.ClaimOperations, mirrored from ShouldClaimOperations):

- buildApplyOperationGroups builds one work operation per (namespace, shard, table) with a single shard-tagged task for a sharded engine whose plan carries changing shards, plus a task-less group_finalizer per VSchema- changing namespace; any other apply stays a single whole-deployment work operation. This mirrors the control-plane fan-out for one deployment.
- In ClaimOperations mode Apply creates the operations and wakes the operator to claim and drive each (handing the engine one shard per operation) instead of driving the whole apply inline; mixing inline drive with operation claiming is unsafe because the inline path holds the apply lease but not the operation lease. The legacy single-operation, inline-driven path is unchanged when ClaimOperations is false (the default).

Thread ClaimOperations from ServerConfig.ShouldClaimOperations() at the LocalClient construction sites (serve grpcLocalClientFactory, api.Service).