### PR TITLE
feat(vitess): resolve a vtgate DSN for per-shard progress

### DIFF
--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -486,6 +486,13 @@ type EtreVitessConfig struct {
 	// APIURL is the PlanetScale-compatible API base URL; a per-target override in
 	// the credential secret takes precedence.
 	APIURL string `yaml:"api_url,omitempty"`
+	// HostField is the entity field holding the vtgate host used for SHOW
+	// VITESS_MIGRATIONS progress. Optional: when unset (or the credentials carry
+	// no MySQL username) the target is API-only and progress falls back to the
+	// deploy-request state.
+	HostField string `yaml:"host_field,omitempty"`
+	// DefaultPort is appended to the vtgate host when it carries no port.
+	DefaultPort string `yaml:"default_port,omitempty"`
 }
 
 // EtreCredentialsConfig configures credentials for an Etre-resolved target.

--- a/pkg/api/target_resolver_factory.go
+++ b/pkg/api/target_resolver_factory.go
@@ -129,7 +129,7 @@ func buildEtreResolver(ctx context.Context, cfg EtreConfig, logger *slog.Logger)
 		TargetLabel:     cfg.TargetLabel,
 		Labels:          cfg.Labels,
 		EnvLabel:        cfg.EnvLabel,
-		HostField:       cfg.MySQL.HostField,
+		HostField:       etreHostField(cfg),
 		AttributeFields: resolverAttributeFields(cfg),
 		Credentials:     creds,
 		Assembler:       assembler,
@@ -144,6 +144,17 @@ func buildEtreResolver(ctx context.Context, cfg EtreConfig, logger *slog.Logger)
 // Vitess assembles PlanetScale API metadata and decodes a token secret rather
 // than a username/password. A new engine (postgres) is a new case here; an
 // unsupported type fails closed.
+// etreHostField returns the entity field holding the connection host for the
+// configured engine. MySQL/Strata resolve a MySQL host; Vitess resolves the
+// optional vtgate host used for SHOW VITESS_MIGRATIONS progress (its own block,
+// since it is independent of the PlanetScale API connection).
+func etreHostField(cfg EtreConfig) string {
+	if cfg.DatabaseType == storage.DatabaseTypeVitess {
+		return cfg.Vitess.HostField
+	}
+	return cfg.MySQL.HostField
+}
+
 func etreAssembler(cfg EtreConfig) (inventory.ConnectionAssembler, inventory.SecretDecoder, error) {
 	switch cfg.DatabaseType {
 	case "":
@@ -160,6 +171,7 @@ func etreAssembler(cfg EtreConfig) (inventory.ConnectionAssembler, inventory.Sec
 		return inventory.VitessConnectionAssembler{
 			OrganizationAttribute: cfg.Vitess.OrganizationAttribute,
 			APIURL:                cfg.Vitess.APIURL,
+			DefaultPort:           cfg.Vitess.DefaultPort,
 		}, inventory.DecodePlanetScaleSecret, nil
 	default:
 		return nil, nil, fmt.Errorf("target_resolver.etre.database_type %q is not supported", cfg.DatabaseType)

--- a/pkg/engine/planetscale/apply.go
+++ b/pkg/engine/planetscale/apply.go
@@ -56,11 +56,13 @@ func (e *Engine) Apply(ctx context.Context, req *engine.ApplyRequest) (*engine.A
 	)
 
 	// Per-shard and row-copy progress come from SHOW VITESS_MIGRATIONS, which the
-	// engine reads over a vtgate MySQL connection. Without that DSN the apply still
-	// runs (DDL goes through the PlanetScale API), but progress degrades to the
-	// deploy-request state only — no rows, no per-shard breakdown. Surface it once
-	// per apply so a blank progress bar is explained rather than a silent skip.
-	if req.Credentials == nil || req.Credentials.DSN == "" {
+	// engine reads over a vtgate MySQL connection. With API credentials but no
+	// vtgate DSN the apply still runs (DDL goes through the PlanetScale API), but
+	// progress degrades to the deploy-request state only — no rows, no per-shard
+	// breakdown. Surface it once per apply so a blank progress bar is explained
+	// rather than a silent skip. (A nil Credentials fails hard in getClient below,
+	// so it is not the degraded-progress case and is not warned here.)
+	if req.Credentials != nil && req.Credentials.DSN == "" {
 		e.logger.Warn("vitess apply has no vtgate DSN: per-shard and row-copy progress will be unavailable (deploy-request state only); check the target resolver's vtgate endpoint and credentials",
 			"database", req.Database, "plan_id", req.PlanID)
 	}

--- a/pkg/engine/planetscale/apply.go
+++ b/pkg/engine/planetscale/apply.go
@@ -55,6 +55,16 @@ func (e *Engine) Apply(ctx context.Context, req *engine.ApplyRequest) (*engine.A
 		"database", req.Database,
 	)
 
+	// Per-shard and row-copy progress come from SHOW VITESS_MIGRATIONS, which the
+	// engine reads over a vtgate MySQL connection. Without that DSN the apply still
+	// runs (DDL goes through the PlanetScale API), but progress degrades to the
+	// deploy-request state only — no rows, no per-shard breakdown. Surface it once
+	// per apply so a blank progress bar is explained rather than a silent skip.
+	if req.Credentials == nil || req.Credentials.DSN == "" {
+		e.logger.Warn("vitess apply has no vtgate DSN: per-shard and row-copy progress will be unavailable (deploy-request state only); check the target resolver's vtgate endpoint and credentials",
+			"database", req.Database, "plan_id", req.PlanID)
+	}
+
 	client, err := e.getClient(req.Credentials)
 	if err != nil {
 		return nil, fmt.Errorf("get planetscale client: %w", err)

--- a/pkg/engine/planetscale/progress.go
+++ b/pkg/engine/planetscale/progress.go
@@ -145,9 +145,9 @@ func (e *Engine) Progress(ctx context.Context, req *engine.ProgressRequest) (*en
 	// Enrich with per-shard progress from SHOW VITESS_MIGRATIONS.
 	// Requires a vtgate DSN (Credentials.DSN) and a migration context
 	// (from the engine resume state) to query per-shard state.
-	hasMigrationContext := req.Credentials.DSN != "" &&
-		req.ResumeState != nil && req.ResumeState.MigrationContext != ""
-	if hasMigrationContext {
+	hasVtgateDSN := req.Credentials.DSN != ""
+	hasMigrationContext := req.ResumeState != nil && req.ResumeState.MigrationContext != ""
+	if hasVtgateDSN && hasMigrationContext {
 		tables, overallProgress := e.queryVitessMigrations(ctx, client, req.Database, req.Credentials, req.ResumeState.MigrationContext)
 		e.logger.Debug("vitess migrations queried",
 			"database", req.Database,
@@ -161,10 +161,14 @@ func (e *Engine) Progress(ctx context.Context, req *engine.ProgressRequest) (*en
 			}
 		}
 	} else {
+		// No per-shard/row-copy progress this poll. Missing vtgate DSN is a target
+		// resolution gap that persists for the whole apply (warned once at apply
+		// start); missing migration context is transient during setup/recovery.
+		// Either way the comment and CLI fall back to deploy-request state.
 		e.logger.Debug("skipping per-shard progress",
 			"database", req.Database,
-			"has_vtgate_dsn", req.Credentials.DSN != "",
-			"has_migration_context", req.ResumeState != nil && req.ResumeState.MigrationContext != "",
+			"has_vtgate_dsn", hasVtgateDSN,
+			"has_migration_context", hasMigrationContext,
 		)
 	}
 

--- a/pkg/engine/planetscale/progress.go
+++ b/pkg/engine/planetscale/progress.go
@@ -161,9 +161,9 @@ func (e *Engine) Progress(ctx context.Context, req *engine.ProgressRequest) (*en
 			}
 		}
 	} else {
-		// No per-shard/row-copy progress this poll. Missing vtgate DSN is a target
+		// No per-shard/row-copy progress this poll. A missing vtgate DSN is a target
 		// resolution gap that persists for the whole apply (warned once at apply
-		// start); missing migration context is transient during setup/recovery.
+		// start); an unset MigrationContext is transient during setup/recovery.
 		// Either way the comment and CLI fall back to deploy-request state.
 		e.logger.Debug("skipping per-shard progress",
 			"database", req.Database,

--- a/pkg/etre/resolver_test.go
+++ b/pkg/etre/resolver_test.go
@@ -88,6 +88,43 @@ func TestEtreResolverResolvesMySQLTarget(t *testing.T) {
 	assert.Equal(t, "", cfg.DBName, "MySQL DSN must be namespace-free; the request supplies the schema")
 }
 
+// End to end with the real Vitess assembler: the resolver looks up the endpoint
+// (vtgate host) and the credentials (read-only vtgate user/pass + API token), and
+// the assembler produces a namespace-free vtgate DSN for SHOW VITESS_MIGRATIONS
+// progress alongside the PlanetScale API metadata.
+func TestEtreResolverResolvesVitessTarget(t *testing.T) {
+	entity := etre.Entity{"endpoint": "vtgate.example", "organization": "acme"}
+	creds := &capturingCredResolver{creds: &inventory.Credentials{
+		Username: "vt-user",
+		Password: "vt-pass",
+		Metadata: map[string]string{
+			inventory.MetadataTokenName:  "tok-id",
+			inventory.MetadataTokenValue: "tok-secret",
+		},
+	}}
+	r := newEtreResolverForTest(t, nil, []etre.Entity{entity}, EtreResolverConfig{
+		TargetLabel:     "dsid",
+		HostField:       "endpoint",
+		AttributeFields: []string{"organization"},
+		Credentials:     creds,
+		Assembler:       inventory.VitessConnectionAssembler{DefaultPort: "3306"},
+	})
+
+	target, err := r.ResolveTarget(t.Context(), inventory.Request{Target: "boardgames-dsid", DatabaseType: "vitess"})
+	require.NoError(t, err)
+
+	assert.Equal(t, "vitess", target.DatabaseType)
+	assert.Equal(t, "acme", target.Metadata[inventory.MetadataOrganization])
+	assert.Equal(t, "tok-secret", target.Metadata[inventory.MetadataTokenValue])
+
+	cfg, err := mysql.ParseDSN(target.DSN)
+	require.NoError(t, err)
+	assert.Equal(t, "vt-user", cfg.User)
+	assert.Equal(t, "vt-pass", cfg.Passwd)
+	assert.Equal(t, "vtgate.example:3306", cfg.Addr)
+	assert.Equal(t, "", cfg.DBName, "vtgate DSN is namespace-free; the schema is supplied per operation")
+}
+
 // The resolver surfaces the endpoint host and configured attributes to both the
 // credential resolver and the assembler, and returns the assembler's output.
 func TestEtreResolverDelegatesToAssembler(t *testing.T) {

--- a/pkg/inventory/connection_assembler.go
+++ b/pkg/inventory/connection_assembler.go
@@ -99,11 +99,17 @@ const (
 // tests).
 const DefaultPlanetScaleAPIURL = "https://api.planetscale.com"
 
-// VitessConnectionAssembler assembles a metadata-only Target for Vitess via
-// PlanetScale. Vitess connects through the PlanetScale API rather than a MySQL
-// DSN, so connection details travel in Metadata: the organization comes from the
-// resolved endpoint's attributes, the service token from credentials, and the
-// API URL from deployment configuration.
+// VitessConnectionAssembler assembles a Target for Vitess via PlanetScale.
+// Vitess applies DDL through the PlanetScale API (organization + service token,
+// carried in Metadata), so those fields are always populated: the organization
+// comes from the resolved endpoint's attributes, the service token from
+// credentials, and the API URL from deployment configuration.
+//
+// When the resolved endpoint also exposes a vtgate host and the credentials carry
+// a MySQL username, the assembler additionally returns a namespace-free vtgate
+// DSN so the engine can read per-shard progress via SHOW VITESS_MIGRATIONS.
+// Without a host or username the DSN is empty and progress degrades to the
+// deploy-request state only.
 type VitessConnectionAssembler struct {
 	// OrganizationAttribute is the endpoint attribute holding the PlanetScale
 	// organization. Defaults to "organization" when empty.
@@ -112,6 +118,12 @@ type VitessConnectionAssembler struct {
 	// the credential secret (api_url) takes precedence; this is the deployment
 	// default, itself falling back to DefaultPlanetScaleAPIURL when empty.
 	APIURL string
+	// DefaultPort is appended to the vtgate host when it carries no port. Empty
+	// means the resolved endpoint must already include one.
+	DefaultPort string
+	// Params are extra MySQL DSN parameters for the vtgate connection (for
+	// example TLS settings).
+	Params map[string]string
 	// Metadata is attached to every assembled target for engine-specific
 	// configuration the data plane reads, merged after the resolved fields.
 	Metadata map[string]string
@@ -122,10 +134,12 @@ var _ ConnectionAssembler = VitessConnectionAssembler{}
 // DatabaseType returns the Vitess engine type.
 func (VitessConnectionAssembler) DatabaseType() string { return "vitess" }
 
-// Assemble builds a metadata-only Vitess Target. The host is unused — Vitess
-// reaches the database through the PlanetScale API keyed by organization, not a
-// host endpoint. The returned DSN is always empty.
-func (a VitessConnectionAssembler) Assemble(_ string, attrs map[string]string, creds *Credentials) (string, map[string]string, error) {
+// Assemble builds a Vitess Target. The PlanetScale API fields (organization,
+// service token, API URL) always populate Metadata. When a vtgate host and a
+// MySQL username are available, a namespace-free vtgate DSN is also returned for
+// SHOW VITESS_MIGRATIONS progress; otherwise the DSN is empty (progress falls
+// back to the deploy-request state).
+func (a VitessConnectionAssembler) Assemble(host string, attrs map[string]string, creds *Credentials) (string, map[string]string, error) {
 	if creds == nil {
 		return "", nil, fmt.Errorf("vitess connection requires credentials")
 	}
@@ -162,22 +176,58 @@ func (a VitessConnectionAssembler) Assemble(_ string, attrs map[string]string, c
 	metadata[MetadataTokenName] = tokenName
 	metadata[MetadataTokenValue] = tokenValue
 	metadata[MetadataAPIURL] = apiURL
-	return "", metadata, nil
+	return a.vtgateDSN(host, creds), metadata, nil
 }
 
-// DecodePlanetScaleSecret decodes a PlanetScale credential secret into engine
-// metadata for a Vitess target. The secret is JSON carrying a service token in
-// "name=value" form and an optional API URL override:
+// vtgateDSN builds the namespace-free MySQL DSN the engine uses to read per-shard
+// progress via SHOW VITESS_MIGRATIONS at the vtgate. It returns "" — not an error
+// — when the endpoint exposes no vtgate host or the credentials carry no MySQL
+// username: that target is simply API-only and reports deploy-request-level
+// progress. The schema is injected per operation, so the DSN carries no database.
+func (a VitessConnectionAssembler) vtgateDSN(host string, creds *Credentials) string {
+	if host == "" || creds.Username == "" {
+		return ""
+	}
+	// Append the default port only when the host has none (net.SplitHostPort
+	// errors when no port is present, including for bare IPv6).
+	if a.DefaultPort != "" {
+		if _, _, err := net.SplitHostPort(host); err != nil {
+			host = net.JoinHostPort(host, a.DefaultPort)
+		}
+	}
+	cfg := mysql.NewConfig()
+	cfg.User = creds.Username
+	cfg.Passwd = creds.Password
+	cfg.Net = "tcp"
+	cfg.Addr = host
+	if len(a.Params) > 0 {
+		cfg.Params = maps.Clone(a.Params)
+	}
+	return cfg.FormatDSN()
+}
+
+// DecodePlanetScaleSecret decodes a PlanetScale credential secret into a Vitess
+// Target's credentials. The secret is JSON carrying a service token in
+// "name=value" form (for the PlanetScale API), an optional API URL override, and
+// optional read-only vtgate MySQL credentials used for SHOW VITESS_MIGRATIONS
+// progress:
 //
-//	{"token": "<id>=<value>", "api_url": "https://..."}
+//	{"token": "<id>=<value>", "api_url": "https://...",
+//	 "vtgate_username": "...", "vtgate_password": "..."}
 //
-// The organization is not part of the secret — it comes from the inventory
-// entity. As a SecretDecoder it plugs into any credential backend that fetches
-// the raw secret (a reference, or an assumed-role Secrets Manager read).
+// The token populates engine Metadata; the vtgate username/password populate the
+// MySQL Username/Password the assembler builds the vtgate DSN from. When the
+// vtgate fields are absent the target is API-only and progress falls back to the
+// deploy-request state. The organization is not part of the secret — it comes
+// from the inventory entity. As a SecretDecoder it plugs into any credential
+// backend that fetches the raw secret (a reference, or an assumed-role Secrets
+// Manager read).
 func DecodePlanetScaleSecret(raw string) (*Credentials, error) {
 	var secret struct {
-		Token  string `json:"token"`
-		APIURL string `json:"api_url"`
+		Token          string `json:"token"`
+		APIURL         string `json:"api_url"`
+		VtgateUsername string `json:"vtgate_username"`
+		VtgatePassword string `json:"vtgate_password"`
 	}
 	if err := json.Unmarshal([]byte(raw), &secret); err != nil {
 		return nil, fmt.Errorf("parse planetscale secret as JSON: %w", err)
@@ -193,5 +243,9 @@ func DecodePlanetScaleSecret(raw string) (*Credentials, error) {
 	if secret.APIURL != "" {
 		metadata[MetadataAPIURL] = secret.APIURL
 	}
-	return &Credentials{Metadata: metadata}, nil
+	return &Credentials{
+		Username: secret.VtgateUsername,
+		Password: secret.VtgatePassword,
+		Metadata: metadata,
+	}, nil
 }

--- a/pkg/inventory/connection_assembler_test.go
+++ b/pkg/inventory/connection_assembler_test.go
@@ -106,18 +106,51 @@ func TestVitessConnectionAssemblerBuildsMetadataTarget(t *testing.T) {
 	}, meta)
 }
 
-// The host argument is irrelevant for Vitess; resolution keys on organization.
-func TestVitessConnectionAssemblerIgnoresHost(t *testing.T) {
+// A vtgate DSN is only produced when the credentials carry a MySQL username. A
+// token-only credential (PlanetScale API access, no MySQL user) yields the API
+// metadata but no DSN, so the apply runs API-only with deploy-request-level
+// progress — even when a host is present.
+func TestVitessConnectionAssemblerNoVtgateDSNWithoutMySQLUsername(t *testing.T) {
 	a := VitessConnectionAssembler{}
 
-	_, meta, err := a.Assemble(
-		"writer.example:3306",
+	dsn, meta, err := a.Assemble(
+		"vtgate.example:3306",
 		map[string]string{MetadataOrganization: "acme"},
 		&Credentials{Metadata: map[string]string{MetadataTokenName: "id", MetadataTokenValue: "secret"}},
 	)
 	require.NoError(t, err)
+	assert.Empty(t, dsn, "no MySQL username → no vtgate DSN even with a host")
 	assert.Equal(t, DefaultPlanetScaleAPIURL, meta[MetadataAPIURL])
 	assert.Equal(t, "acme", meta[MetadataOrganization])
+}
+
+// When the endpoint exposes a vtgate host and the credentials carry a MySQL
+// username/password, the assembler returns a namespace-free vtgate DSN for SHOW
+// VITESS_MIGRATIONS progress, alongside the PlanetScale API metadata.
+func TestVitessConnectionAssemblerBuildsVtgateDSN(t *testing.T) {
+	a := VitessConnectionAssembler{APIURL: "https://localscale.test", DefaultPort: "3306"}
+
+	dsn, meta, err := a.Assemble(
+		"vtgate.example",
+		map[string]string{MetadataOrganization: "acme"},
+		&Credentials{
+			Username: "ddl-user",
+			Password: "ddl-pass",
+			Metadata: map[string]string{MetadataTokenName: "tok-id", MetadataTokenValue: "tok-secret"},
+		},
+	)
+	require.NoError(t, err)
+	// PlanetScale API metadata is still populated.
+	assert.Equal(t, "acme", meta[MetadataOrganization])
+	assert.Equal(t, "tok-secret", meta[MetadataTokenValue])
+	// And a namespace-free vtgate DSN is produced for progress queries.
+	cfg, err := mysql.ParseDSN(dsn)
+	require.NoError(t, err)
+	assert.Equal(t, "ddl-user", cfg.User)
+	assert.Equal(t, "ddl-pass", cfg.Passwd)
+	assert.Equal(t, "tcp", cfg.Net)
+	assert.Equal(t, "vtgate.example:3306", cfg.Addr)
+	assert.Equal(t, "", cfg.DBName, "vtgate DSN is namespace-free; the schema is supplied per operation")
 }
 
 // A custom organization attribute lets the resolver surface the organization
@@ -214,6 +247,19 @@ func TestDecodePlanetScaleSecretOptionalAPIURL(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "tok-id", creds.Metadata[MetadataTokenName])
 	assert.NotContains(t, creds.Metadata, MetadataAPIURL, "api_url is optional in the secret")
+}
+
+// A secret carrying read-only vtgate credentials populates the MySQL
+// Username/Password the assembler builds the vtgate DSN from, alongside the API
+// token metadata. The vtgate fields are optional — a token-only secret leaves
+// them empty (covered by TestDecodePlanetScaleSecret).
+func TestDecodePlanetScaleSecretVtgateCredentials(t *testing.T) {
+	creds, err := DecodePlanetScaleSecret(
+		`{"token":"tok-id=tok-secret","vtgate_username":"vt-user","vtgate_password":"vt-pass"}`)
+	require.NoError(t, err)
+	assert.Equal(t, "vt-user", creds.Username)
+	assert.Equal(t, "vt-pass", creds.Password)
+	assert.Equal(t, "tok-id", creds.Metadata[MetadataTokenName])
 }
 
 func TestDecodePlanetScaleSecretRejectsBadInput(t *testing.T) {


### PR DESCRIPTION
## Why this matters

A Vitess/PlanetScale apply surfaces per-shard and row-copy progress by reading `SHOW VITESS_MIGRATIONS` over a **vtgate MySQL connection**. The progress query is gated on `Credentials.DSN != ""`, but the Vitess Etre assembler returned an **empty DSN unconditionally** — so the query was skipped on every progress poll. The result: no per-shard rows were ever written and the per-table task stayed at `rows_total = 0`, so an in-flight Vitess apply showed only its deploy-request state with **no copy progress** — a bare "Running…" for the whole copy, in both the PR comment and the CLI. There was also no visible signal explaining the blank progress (the skip was `Debug`-only).

## What it does

- **`VitessConnectionAssembler`** now builds a namespace-free vtgate MySQL DSN from a resolved vtgate host + MySQL credentials, **alongside** the PlanetScale API metadata (organization / service token / API URL) it already produces. When no host or MySQL username is available, the DSN stays empty and the target is API-only — degrading gracefully to deploy-request-level progress.
- The Etre resolver reads the vtgate host from a **per-engine host field**, and the resolver factory threads the Vitess host field + default port through `EtreVitessConfig`.
- **Observability:** a Warn is logged once per apply when a Vitess apply resolves with no vtgate DSN (stating progress will be unavailable), and the per-poll skip log now names the reason — missing DSN (a resolution gap, persists for the apply) vs missing migration context (transient during setup). Previously the only signal was an unshipped `Debug` line.

```
resolve target ─▶ VitessConnectionAssembler.Assemble(host, attrs, creds)
                     ├─ API metadata (org, token, api_url)        ← always
                     └─ vtgate DSN  (host + MySQL user/pass)      ← new, when available
                          └─▶ Credentials.DSN ─▶ SHOW VITESS_MIGRATIONS ─▶ per-shard + row-copy progress
```

## How it moves toward the northstar

Vitess applies are a first-class engine, and an operator watching a sharded change must be able to see it actually progressing — per-shard and row-copy — not a static "Running…". This restores the data the progress UX is built on, and makes the degraded (no-DSN) case observable instead of silent. No behavior change for targets that don't resolve a vtgate host: the DSN stays empty and progress falls back as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)