### PR TITLE
feat(auth): add OIDC auth-code + PKCE login helper

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,7 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.43.0
 	go.opentelemetry.io/otel/trace v1.43.0
 	golang.org/x/net v0.53.0
+	golang.org/x/oauth2 v0.36.0
 	golang.org/x/sync v0.20.0
 	golang.org/x/sys v0.43.0
 	golang.org/x/text v0.36.0
@@ -253,7 +254,6 @@ require (
 	golang.org/x/crypto v0.50.0 // indirect
 	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f // indirect
 	golang.org/x/mod v0.35.0 // indirect
-	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
 	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260414002931-afd174a4e478 // indirect

--- a/pkg/cmd/client/login.go
+++ b/pkg/cmd/client/login.go
@@ -1,0 +1,220 @@
+package client
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/coreos/go-oidc/v3/oidc"
+	"golang.org/x/oauth2"
+)
+
+// defaultLoginScopes are requested during login. "openid" is required for an
+// id_token; "email" and "groups" carry the identity and authorization claims
+// the server checks; "offline_access" asks the provider for a refresh token so
+// the session can be renewed without another browser round-trip.
+var defaultLoginScopes = []string{oidc.ScopeOpenID, "email", "groups", oidc.ScopeOfflineAccess}
+
+// loginCallbackPath is the loopback path the provider redirects back to after
+// the user authenticates.
+const loginCallbackPath = "/callback"
+
+// LoginConfig configures an interactive OIDC authorization-code login.
+type LoginConfig struct {
+	// Issuer is the OIDC issuer URL; its discovery document supplies the
+	// authorization and token endpoints.
+	Issuer string
+	// ClientID identifies SchemaBot as a public OAuth client (no secret; the
+	// PKCE verifier proves possession instead).
+	ClientID string
+	// RedirectPort is the loopback port the browser is redirected back to. It
+	// must match a redirect URI registered with the provider, so it is a fixed
+	// input rather than an ephemeral port.
+	RedirectPort int
+	// Scopes overrides defaultLoginScopes when non-empty.
+	Scopes []string
+}
+
+// LoginResult holds the tokens returned by a successful login.
+type LoginResult struct {
+	IDToken      string
+	AccessToken  string
+	RefreshToken string
+	Expiry       time.Time
+}
+
+// BrowserOpener opens the system browser at the given URL. Login calls it with
+// the authorization URL; the CLI wires a real opener while tests inject a
+// programmatic visitor.
+type BrowserOpener func(url string) error
+
+// callbackResult carries the outcome of the loopback redirect from the handler
+// goroutine back to Login.
+type callbackResult struct {
+	code string
+	err  error
+}
+
+// Login runs the OIDC authorization-code flow with PKCE for a public client:
+//
+//   - discover the provider's authorization and token endpoints,
+//   - start a loopback HTTP server on RedirectPort,
+//   - open the browser at the authorization URL (PKCE S256 challenge + state),
+//   - receive the code on the loopback redirect, verifying the state matches,
+//   - exchange the code (with the PKCE verifier) for tokens.
+//
+// ctx bounds the whole flow; cancelling it (or giving it a deadline) stops Login
+// waiting for the user. The loopback server is always shut down before Login
+// returns.
+func Login(ctx context.Context, cfg LoginConfig, open BrowserOpener) (*LoginResult, error) {
+	if cfg.Issuer == "" {
+		return nil, errors.New("login: issuer is required")
+	}
+	if cfg.ClientID == "" {
+		return nil, errors.New("login: client ID is required")
+	}
+	if cfg.RedirectPort == 0 {
+		return nil, errors.New("login: redirect port is required (it must match a registered redirect URI)")
+	}
+	if open == nil {
+		return nil, errors.New("login: browser opener is required")
+	}
+
+	provider, err := oidc.NewProvider(ctx, cfg.Issuer)
+	if err != nil {
+		return nil, fmt.Errorf("discover OIDC provider %s: %w", cfg.Issuer, err)
+	}
+
+	scopes := cfg.Scopes
+	if len(scopes) == 0 {
+		scopes = defaultLoginScopes
+	}
+
+	// Use the literal loopback IP for both the redirect URI and the listener
+	// bind so the browser reaches the exact socket the callback server is on.
+	// "localhost" can resolve to IPv6 (::1) while the listener is on IPv4,
+	// which would strand the callback; RFC 8252 §7.3 recommends the literal IP.
+	redirectURL := fmt.Sprintf("http://127.0.0.1:%d%s", cfg.RedirectPort, loginCallbackPath)
+	oauthCfg := &oauth2.Config{
+		ClientID:    cfg.ClientID,
+		Endpoint:    provider.Endpoint(),
+		RedirectURL: redirectURL,
+		Scopes:      scopes,
+	}
+
+	verifier := oauth2.GenerateVerifier()
+	state, err := randomURLSafe()
+	if err != nil {
+		return nil, fmt.Errorf("generate login state: %w", err)
+	}
+
+	listener, err := (&net.ListenConfig{}).Listen(ctx, "tcp", fmt.Sprintf("127.0.0.1:%d", cfg.RedirectPort))
+	if err != nil {
+		return nil, fmt.Errorf("listen on loopback port %d for the login redirect: %w", cfg.RedirectPort, err)
+	}
+
+	results := make(chan callbackResult, 1)
+	mux := http.NewServeMux()
+	mux.HandleFunc(loginCallbackPath, func(w http.ResponseWriter, r *http.Request) {
+		code, err := readCallback(r, state)
+		if err != nil {
+			http.Error(w, "Login failed: "+err.Error()+". You can close this tab and return to the terminal.", http.StatusBadRequest)
+		} else {
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			_, _ = w.Write([]byte("<html><body><h2>Login complete.</h2><p>You can close this tab and return to the terminal.</p></body></html>"))
+		}
+		// Deliver exactly one result; a duplicate or stray request is ignored.
+		select {
+		case results <- callbackResult{code: code, err: err}:
+		default:
+		}
+	})
+
+	srv := &http.Server{Handler: mux, ReadHeaderTimeout: 10 * time.Second}
+	serveErr := make(chan error, 1)
+	go func() {
+		// ErrServerClosed is the normal result of the deferred Shutdown; anything
+		// else means the callback server never came up, so surface it.
+		if err := srv.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			serveErr <- err
+		}
+	}()
+	defer func() {
+		// The request context has likely been cancelled by shutdown time; detach
+		// it but keep a bound so a stuck connection can't block the return.
+		shutdownCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+		defer cancel()
+		_ = srv.Shutdown(shutdownCtx)
+	}()
+
+	authURL := oauthCfg.AuthCodeURL(state, oauth2.AccessTypeOffline, oauth2.S256ChallengeOption(verifier))
+	if err := open(authURL); err != nil {
+		return nil, fmt.Errorf("open browser for login: %w", err)
+	}
+
+	var code string
+	select {
+	case <-ctx.Done():
+		return nil, fmt.Errorf("waiting for login callback: %w", ctx.Err())
+	case err := <-serveErr:
+		return nil, fmt.Errorf("login callback server failed on port %d: %w", cfg.RedirectPort, err)
+	case res := <-results:
+		if res.err != nil {
+			return nil, res.err
+		}
+		code = res.code
+	}
+
+	token, err := oauthCfg.Exchange(ctx, code, oauth2.VerifierOption(verifier))
+	if err != nil {
+		return nil, fmt.Errorf("exchange authorization code for token: %w", err)
+	}
+
+	rawID, ok := token.Extra("id_token").(string)
+	if !ok || rawID == "" {
+		return nil, errors.New("token response did not include an id_token")
+	}
+
+	return &LoginResult{
+		IDToken:      rawID,
+		AccessToken:  token.AccessToken,
+		RefreshToken: token.RefreshToken,
+		Expiry:       token.Expiry,
+	}, nil
+}
+
+// readCallback validates the loopback redirect and returns the authorization
+// code. A provider-reported error or a state mismatch (a sign the response did
+// not originate from the request this flow started) is surfaced as an error.
+func readCallback(r *http.Request, wantState string) (string, error) {
+	q := r.URL.Query()
+	if errCode := q.Get("error"); errCode != "" {
+		if desc := q.Get("error_description"); desc != "" {
+			return "", fmt.Errorf("authorization failed: %s: %s", errCode, desc)
+		}
+		return "", fmt.Errorf("authorization failed: %s", errCode)
+	}
+	if got := q.Get("state"); got != wantState {
+		return "", errors.New("authorization response state did not match the request")
+	}
+	code := q.Get("code")
+	if code == "" {
+		return "", errors.New("authorization response did not include a code")
+	}
+	return code, nil
+}
+
+// randomURLSafe returns 32 bytes of cryptographic randomness as a URL-safe
+// string, used for the unguessable OAuth state value.
+func randomURLSafe() (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}

--- a/pkg/cmd/client/login_test.go
+++ b/pkg/cmd/client/login_test.go
@@ -1,0 +1,265 @@
+package client
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeOIDC is an in-process OIDC provider: it serves discovery, an
+// authorization endpoint that auto-approves and redirects back with a code, and
+// a token endpoint that verifies the PKCE verifier against the challenge it was
+// issued. It lets the login flow be exercised end-to-end without a browser or a
+// real provider, and proves the PKCE S256 round-trip is correct.
+type fakeOIDC struct {
+	server *httptest.Server
+
+	mu         sync.Mutex
+	challenges map[string]string // authorization code -> code_challenge
+	lastMethod string            // code_challenge_method seen at the authz endpoint
+
+	// Knobs for negative cases.
+	stateOverride string // when set, echo this state instead of the request's
+	authError     string // when set, redirect with ?error=<authError>
+
+	idToken      string
+	accessToken  string
+	refreshToken string
+	omitIDToken  bool // when true, the token response omits the id_token
+}
+
+func newFakeOIDC(t *testing.T) *fakeOIDC {
+	t.Helper()
+	f := &fakeOIDC{
+		challenges:   map[string]string{},
+		idToken:      "header.payload.signature",
+		accessToken:  "test-access-token",
+		refreshToken: "test-refresh-token",
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, _ *http.Request) {
+		base := f.server.URL
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"issuer":                                base,
+			"authorization_endpoint":                base + "/auth",
+			"token_endpoint":                        base + "/token",
+			"jwks_uri":                              base + "/keys",
+			"id_token_signing_alg_values_supported": []string{"RS256"},
+			"response_types_supported":              []string{"code"},
+			"scopes_supported":                      []string{"openid", "email", "groups", "offline_access"},
+		})
+	})
+	mux.HandleFunc("/auth", f.handleAuth)
+	mux.HandleFunc("/token", f.handleToken)
+
+	f.server = httptest.NewServer(mux)
+	t.Cleanup(f.server.Close)
+	return f
+}
+
+func (f *fakeOIDC) issuer() string { return f.server.URL }
+
+func (f *fakeOIDC) handleAuth(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	redirectURI := q.Get("redirect_uri")
+
+	f.mu.Lock()
+	f.lastMethod = q.Get("code_challenge_method")
+	const code = "test-auth-code"
+	f.challenges[code] = q.Get("code_challenge")
+	f.mu.Unlock()
+
+	state := q.Get("state")
+	if f.stateOverride != "" {
+		state = f.stateOverride
+	}
+
+	loc := redirectURI + "?state=" + state
+	if f.authError != "" {
+		loc += "&error=" + f.authError + "&error_description=" + "denied+by+test"
+	} else {
+		loc += "&code=test-auth-code"
+	}
+	http.Redirect(w, r, loc, http.StatusFound)
+}
+
+func (f *fakeOIDC) handleToken(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, "bad form", http.StatusBadRequest)
+		return
+	}
+	code := r.Form.Get("code")
+	verifier := r.Form.Get("code_verifier")
+
+	f.mu.Lock()
+	challenge := f.challenges[code]
+	f.mu.Unlock()
+
+	sum := sha256.Sum256([]byte(verifier))
+	if challenge == "" || base64.RawURLEncoding.EncodeToString(sum[:]) != challenge {
+		http.Error(w, `{"error":"invalid_grant"}`, http.StatusBadRequest)
+		return
+	}
+
+	body := map[string]any{
+		"access_token":  f.accessToken,
+		"token_type":    "Bearer",
+		"refresh_token": f.refreshToken,
+		"expires_in":    3600,
+	}
+	if !f.omitIDToken {
+		body["id_token"] = f.idToken
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(body)
+}
+
+// freeLoopbackPort returns a currently-free loopback port for the login
+// redirect listener.
+func freeLoopbackPort(t *testing.T) int {
+	t.Helper()
+	l, err := (&net.ListenConfig{}).Listen(t.Context(), "tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := l.Addr().(*net.TCPAddr).Port
+	require.NoError(t, l.Close())
+	return port
+}
+
+// browserVisitor returns an opener that fetches the authorization URL the way a
+// browser would, following the redirect back to the loopback callback server.
+// It runs synchronously and returns any transport error so a broken flow fails
+// the test fast instead of hanging until the test deadline. The callback
+// handler delivers its result on a buffered channel, so the visit completes
+// without waiting for Login to read it.
+func browserVisitor(ctx context.Context) BrowserOpener {
+	return func(u string) error {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+		if err != nil {
+			return err
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return err
+		}
+		defer func() { _ = resp.Body.Close() }()
+		return nil
+	}
+}
+
+func TestLogin(t *testing.T) {
+	f := newFakeOIDC(t)
+	ctx := t.Context()
+
+	result, err := Login(ctx, LoginConfig{
+		Issuer:       f.issuer(),
+		ClientID:     "schemabot-cli",
+		RedirectPort: freeLoopbackPort(t),
+	}, browserVisitor(ctx))
+	require.NoError(t, err)
+
+	assert.Equal(t, "header.payload.signature", result.IDToken)
+	assert.Equal(t, "test-access-token", result.AccessToken)
+	assert.Equal(t, "test-refresh-token", result.RefreshToken)
+	assert.False(t, result.Expiry.IsZero(), "token expiry should be populated from expires_in")
+
+	// The flow must use PKCE with S256; the token endpoint already rejected any
+	// verifier that didn't hash to the challenge, so reaching here proves the
+	// round-trip, and the method is asserted explicitly.
+	f.mu.Lock()
+	method := f.lastMethod
+	f.mu.Unlock()
+	assert.Equal(t, "S256", method)
+}
+
+func TestLoginRejectsStateMismatch(t *testing.T) {
+	f := newFakeOIDC(t)
+	f.stateOverride = "tampered-state"
+	ctx := t.Context()
+
+	_, err := Login(ctx, LoginConfig{
+		Issuer:       f.issuer(),
+		ClientID:     "schemabot-cli",
+		RedirectPort: freeLoopbackPort(t),
+	}, browserVisitor(ctx))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "state")
+}
+
+func TestLoginSurfacesProviderError(t *testing.T) {
+	f := newFakeOIDC(t)
+	f.authError = "access_denied"
+	ctx := t.Context()
+
+	_, err := Login(ctx, LoginConfig{
+		Issuer:       f.issuer(),
+		ClientID:     "schemabot-cli",
+		RedirectPort: freeLoopbackPort(t),
+	}, browserVisitor(ctx))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "access_denied")
+}
+
+func TestLoginRequiresIDToken(t *testing.T) {
+	f := newFakeOIDC(t)
+	f.omitIDToken = true
+	ctx := t.Context()
+
+	_, err := Login(ctx, LoginConfig{
+		Issuer:       f.issuer(),
+		ClientID:     "schemabot-cli",
+		RedirectPort: freeLoopbackPort(t),
+	}, browserVisitor(ctx))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "id_token")
+}
+
+func TestLoginStopsWhenContextCancelled(t *testing.T) {
+	f := newFakeOIDC(t)
+	ctx, cancel := context.WithCancel(t.Context())
+
+	// Cancel at the moment the browser would open, before any callback arrives,
+	// so Login is waiting on the redirect when the context goes away.
+	opener := func(string) error {
+		cancel()
+		return nil
+	}
+
+	_, err := Login(ctx, LoginConfig{
+		Issuer:       f.issuer(),
+		ClientID:     "schemabot-cli",
+		RedirectPort: freeLoopbackPort(t),
+	}, opener)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+func TestLoginValidatesConfig(t *testing.T) {
+	noop := func(string) error { return nil }
+	cases := map[string]LoginConfig{
+		"missing issuer":    {ClientID: "c", RedirectPort: 1},
+		"missing client ID": {Issuer: "https://issuer.example.com", RedirectPort: 1},
+		"missing port":      {Issuer: "https://issuer.example.com", ClientID: "c"},
+	}
+	for name, cfg := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, err := Login(t.Context(), cfg, noop)
+			require.Error(t, err)
+		})
+	}
+
+	t.Run("nil opener", func(t *testing.T) {
+		_, err := Login(t.Context(), LoginConfig{Issuer: "https://issuer.example.com", ClientID: "c", RedirectPort: 1}, nil)
+		require.Error(t, err)
+	})
+}


### PR DESCRIPTION
**Why this matters**

A CLI needs a way to obtain a token interactively without users hand-copying credentials. This adds the OIDC login engine — the authorization-code + PKCE flow — that an interactive `login` command will drive. It lands as a standalone helper; nothing calls it yet, so there is no behavior change.

**What it does**

- Adds `client.Login`, which runs the OAuth2 authorization-code flow with PKCE for a public client: discovers the provider's endpoints, starts a loopback callback server, opens the browser at the authorization URL (S256 challenge + a random state), receives the code on the loopback redirect (verifying the state matches), and exchanges it — with the PKCE verifier — for tokens.
- Binds the callback listener to the loopback interface and verifies the state on the redirect, so a stray or forged request can't complete the flow with someone else's code.
- The browser opener is injected by the caller, keeping the helper testable and free of UI assumptions; the whole flow is bounded by the caller's context and the callback server is always shut down before returning.
- Promotes `golang.org/x/oauth2` to a direct dependency.

**How it fits**

Part of the optional client-side authentication workstream. This is the login engine; a later change wires the interactive `login` / `logout` commands and the on-disk token cache around it, and adds the end-to-end test against a real OIDC provider.
