### PR TITLE
fix(ux): distinguish terminal status comments

### DIFF
--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -771,11 +771,13 @@ That command wasn't recognized. Available commands:
 
 ### Apply failure
 
-## ❌ Schema Change Failed — Staging
+## Schema Change Status — Staging
 
 **Database**: `testapp` | **Apply ID**: `apply-a1b2c3d4e5f6`
 
 *Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
+
+**Status**: Failed
 
 📊 1/3 complete · 1 failed · 1 cancelled
 
@@ -1786,11 +1788,13 @@ _Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:0
 <summary><a name="single-table-completed"></a><strong>Single Table: Completed</strong></summary>
 
 
-## ✅ Schema Change Applied — Staging
+## Schema Change Status — Staging
 
 **Database**: `testapp` | **Apply ID**: `apply-a1b2c3d4e5f6`
 
 *Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
+
+**Status**: Applied
 
 ### Table Progress
 
@@ -1807,11 +1811,13 @@ ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
 <summary><a name="single-table-failed"></a><strong>Single Table: Failed</strong></summary>
 
 
-## ❌ Schema Change Failed — Staging
+## Schema Change Status — Staging
 
 **Database**: `testapp` | **Apply ID**: `apply-a1b2c3d4e5f6`
 
 *Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
+
+**Status**: Failed
 
 ### Table Progress
 
@@ -1837,11 +1843,13 @@ schemabot apply -e staging
 <summary><a name="single-table-stopped"></a><strong>Single Table: Stopped</strong></summary>
 
 
-## ⏹️ Schema Change Stopped — Staging
+## Schema Change Status — Staging
 
 **Database**: `testapp` | **Apply ID**: `apply-a1b2c3d4e5f6`
 
 *Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
+
+**Status**: Stopped
 
 ### Table Progress
 
@@ -2200,11 +2208,13 @@ _Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:0
 <summary><a name="all-completed"></a><strong>All Completed</strong></summary>
 
 
-## ✅ Schema Change Applied — Staging
+## Schema Change Status — Staging
 
 **Database**: `testapp` | **Apply ID**: `apply-a1b2c3d4e5f6`
 
 *Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
+
+**Status**: Applied
 
 📊 3/3 complete
 
@@ -2342,11 +2352,13 @@ _Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:0
 <summary><a name="first-table-failed"></a><strong>First Table Failed</strong></summary>
 
 
-## ❌ Schema Change Failed — Staging
+## Schema Change Status — Staging
 
 **Database**: `testapp` | **Apply ID**: `apply-a1b2c3d4e5f6`
 
 *Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
+
+**Status**: Failed
 
 📊 1 failed · 2 cancelled
 
@@ -2386,11 +2398,13 @@ schemabot apply -e staging
 <summary><a name="middle-table-failed"></a><strong>Middle Table Failed</strong></summary>
 
 
-## ❌ Schema Change Failed — Staging
+## Schema Change Status — Staging
 
 **Database**: `testapp` | **Apply ID**: `apply-a1b2c3d4e5f6`
 
 *Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
+
+**Status**: Failed
 
 📊 1/3 complete · 1 failed · 1 cancelled
 
@@ -2430,11 +2444,13 @@ schemabot apply -e staging
 <summary><a name="stopped"></a><strong>Stopped</strong></summary>
 
 
-## ⏹️ Schema Change Stopped — Staging
+## Schema Change Status — Staging
 
 **Database**: `testapp` | **Apply ID**: `apply-a1b2c3d4e5f6`
 
 *Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
+
+**Status**: Stopped
 
 📊 1/2 complete · 1 stopped
 
@@ -2498,11 +2514,13 @@ _Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:0
 <summary><a name="cancelled"></a><strong>Cancelled</strong></summary>
 
 
-## 🚫 Schema Change Cancelled — Staging
+## Schema Change Status — Staging
 
 **Database**: `testapp` | **Apply ID**: `apply-a1b2c3d4e5f6`
 
 *Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
+
+**Status**: Cancelled
 
 📊 1/2 complete · 1 cancelled
 
@@ -5257,11 +5275,13 @@ schemabot apply -e production
 <details>
 <summary>✅ eu — completed</summary>
 
-## ✅ Schema Change Applied — Production
+## Schema Change Status — Production
 
 **Database**: `payments_eu` | **Apply ID**: `apply-a1b2c3d4e5f6`
 
 *Applied by @aparajon at 2026-01-01 00:00:00 UTC*
+
+**Status**: Applied
 
 📊 3/3 complete
 
@@ -5291,11 +5311,13 @@ ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
 <details open>
 <summary>❌ us — failed</summary>
 
-## ❌ Schema Change Failed — Production
+## Schema Change Status — Production
 
 **Database**: `payments_us` | **Apply ID**: `apply-a1b2c3d4e5f6`
 
 *Applied by @aparajon at 2026-01-01 00:00:00 UTC*
+
+**Status**: Failed
 
 📊 1/3 complete · 1 failed · 1 cancelled
 
@@ -5366,11 +5388,13 @@ _No details available yet._
 <details>
 <summary>✅ eu — completed</summary>
 
-## ✅ Schema Change Applied — Production
+## Schema Change Status — Production
 
 **Database**: `payments_eu` | **Apply ID**: `apply-a1b2c3d4e5f6`
 
 *Applied by @aparajon at 2026-01-01 00:00:00 UTC*
+
+**Status**: Applied
 
 📊 3/3 complete
 
@@ -5400,11 +5424,13 @@ ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
 <details>
 <summary>✅ us — completed</summary>
 
-## ✅ Schema Change Applied — Production
+## Schema Change Status — Production
 
 **Database**: `payments_us` | **Apply ID**: `apply-a1b2c3d4e5f6`
 
 *Applied by @aparajon at 2026-01-01 00:00:00 UTC*
+
+**Status**: Applied
 
 📊 3/3 complete
 
@@ -5434,11 +5460,13 @@ ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
 <details>
 <summary>✅ au — completed</summary>
 
-## ✅ Schema Change Applied — Production
+## Schema Change Status — Production
 
 **Database**: `payments_au` | **Apply ID**: `apply-a1b2c3d4e5f6`
 
 *Applied by @aparajon at 2026-01-01 00:00:00 UTC*
+
+**Status**: Applied
 
 📊 3/3 complete
 

--- a/pkg/webhook/issue_comment.go
+++ b/pkg/webhook/issue_comment.go
@@ -393,6 +393,9 @@ func appendSupportChannelFooter(body string, support api.SupportChannelConfig) s
 func shouldShowSupportChannel(body string) bool {
 	firstLine, _, _ := strings.Cut(body, "\n")
 	firstLine = strings.ToLower(firstLine)
+	if strings.Contains(body, "\n**Status**: Failed\n") {
+		return true
+	}
 
 	if strings.Contains(firstLine, "help") {
 		return true

--- a/pkg/webhook/templates/apply.go
+++ b/pkg/webhook/templates/apply.go
@@ -87,7 +87,7 @@ func renderApplyStatusComment(data ApplyStatusCommentData, includeLastUpdated bo
 	var sb strings.Builder
 
 	// Header varies by state
-	writeApplyHeader(&sb, data)
+	writeApplyStatusHeader(&sb, data)
 
 	// Metadata line
 	writeApplyMetadata(&sb, data, renderedAt)
@@ -123,6 +123,14 @@ func renderApplyStatusComment(data ApplyStatusCommentData, includeLastUpdated bo
 	}
 
 	return sb.String()
+}
+
+func writeApplyStatusHeader(sb *strings.Builder, data ApplyStatusCommentData) {
+	if state.IsTerminalApplyState(data.State) {
+		writeEnvironmentTitle(sb, "Schema Change Status", data.Environment)
+		return
+	}
+	writeApplyHeader(sb, data)
 }
 
 // writeApplyHeader writes the comment header with a state-specific title.
@@ -202,7 +210,18 @@ func writeApplyStatusDetail(sb *strings.Builder, applyState string) {
 }
 
 func applyStatusDetail(applyState string) string {
+	applyState = state.NormalizeState(applyState)
 	switch applyState {
+	case state.Apply.Completed:
+		return "Applied"
+	case state.Apply.Failed:
+		return "Failed"
+	case state.Apply.Stopped:
+		return "Stopped"
+	case state.Apply.Reverted:
+		return "Reverted"
+	case state.Apply.Cancelled:
+		return "Cancelled"
 	case state.Apply.Pending:
 		return "Starting"
 	case state.Apply.WaitingForDeploy:

--- a/pkg/webhook/templates/apply_test.go
+++ b/pkg/webhook/templates/apply_test.go
@@ -599,7 +599,8 @@ func TestRenderApplyStatusComment_Completed(t *testing.T) {
 
 	result := RenderApplyStatusComment(data)
 
-	assert.Contains(t, result, "## ✅ Schema Change Applied")
+	assert.Contains(t, result, "## Schema Change Status — Staging")
+	assert.Contains(t, result, "**Status**: Applied")
 	assert.Contains(t, result, "### Table Progress")
 	// Progress summary line
 	assert.Contains(t, result, "📊 2/2 complete")
@@ -660,7 +661,8 @@ func TestRenderApplyStatusComment_Failed(t *testing.T) {
 
 	result := RenderApplyStatusComment(data)
 
-	assert.Contains(t, result, "## ❌ Schema Change Failed")
+	assert.Contains(t, result, "## Schema Change Status — Staging")
+	assert.Contains(t, result, "**Status**: Failed")
 	assert.Contains(t, result, "⚠️ **Error:**")
 	assert.Contains(t, result, "lock wait timeout exceeded")
 	assert.Contains(t, result, "🟥") // red bar for failed table
@@ -672,6 +674,24 @@ func TestRenderApplyStatusComment_Failed(t *testing.T) {
 	assert.Contains(t, result, "1 cancelled")
 	assert.Contains(t, result, "To retry:")
 	assert.Contains(t, result, "schemabot apply -e staging")
+}
+
+func TestTerminalStatusAndSummaryCommentTitlesAreDistinct(t *testing.T) {
+	data := ApplyStatusCommentData{
+		Database:     "testapp",
+		Environment:  "staging",
+		State:        state.Apply.Failed,
+		ErrorMessage: "lock wait timeout exceeded",
+		Tables: []TableProgressData{
+			{TableName: "users", Status: state.Task.Failed},
+		},
+	}
+
+	statusTitle := strings.SplitN(RenderApplyStatusComment(data), "\n", 2)[0]
+	summaryTitle := strings.SplitN(RenderApplySummaryComment(data), "\n", 2)[0]
+
+	assert.Equal(t, "## Schema Change Status — Staging", statusTitle)
+	assert.Equal(t, "## ❌ Schema Change Failed — Staging", summaryTitle)
 }
 
 // A retryable failure is operator-recovery state, not a user-facing outcome:
@@ -792,7 +812,8 @@ func TestRenderApplyStatusComment_Stopped(t *testing.T) {
 
 	result := RenderApplyStatusComment(data)
 
-	assert.Contains(t, result, "## ⏹️ Schema Change Stopped")
+	assert.Contains(t, result, "## Schema Change Status — Staging")
+	assert.Contains(t, result, "**Status**: Stopped")
 	assert.Contains(t, result, "🟧") // orange bar for stopped
 	assert.Contains(t, result, "⏹️ Stopped at 72%")
 	assert.Contains(t, result, "72,000 / 100,000")
@@ -848,7 +869,8 @@ func TestRenderApplyStatusComment_Cancelled(t *testing.T) {
 
 	result := RenderApplyStatusComment(data)
 
-	assert.Contains(t, result, "## 🚫 Schema Change Cancelled")
+	assert.Contains(t, result, "## Schema Change Status — Staging")
+	assert.Contains(t, result, "**Status**: Cancelled")
 	assert.Contains(t, result, "cannot be resumed")
 	assert.Contains(t, result, "Open a new schema change")
 	assert.NotContains(t, result, "schemabot start", "a cancelled change is permanent — no resume affordance")
@@ -1096,14 +1118,16 @@ func TestPreviewCommentApplyEstimateExceeded(t *testing.T) {
 func TestPreviewCommentApplyCompleted(t *testing.T) {
 	result := PreviewCommentApplyCompleted()
 
-	assert.Contains(t, result, "Schema Change Applied")
+	assert.Contains(t, result, "Schema Change Status")
+	assert.Contains(t, result, "**Status**: Applied")
 	assert.Contains(t, result, "### Table Progress")
 }
 
 func TestPreviewCommentApplyFailed(t *testing.T) {
 	result := PreviewCommentApplyFailed()
 
-	assert.Contains(t, result, "Schema Change Failed")
+	assert.Contains(t, result, "Schema Change Status")
+	assert.Contains(t, result, "**Status**: Failed")
 	assert.Contains(t, result, "lock wait timeout")
 	assert.Contains(t, result, "Cancelled (not started)")
 }
@@ -1111,7 +1135,8 @@ func TestPreviewCommentApplyFailed(t *testing.T) {
 func TestPreviewCommentApplyStopped(t *testing.T) {
 	result := PreviewCommentApplyStopped()
 
-	assert.Contains(t, result, "Schema Change Stopped")
+	assert.Contains(t, result, "Schema Change Status")
+	assert.Contains(t, result, "**Status**: Stopped")
 	assert.Contains(t, result, "Stopped at 72%")
 	assert.Contains(t, result, "schemabot start")
 }
@@ -1128,7 +1153,8 @@ func TestPreviewCommentApplyResuming(t *testing.T) {
 func TestPreviewCommentApplyCancelled(t *testing.T) {
 	result := PreviewCommentApplyCancelled()
 
-	assert.Contains(t, result, "🚫 Schema Change Cancelled")
+	assert.Contains(t, result, "Schema Change Status")
+	assert.Contains(t, result, "**Status**: Cancelled")
 	assert.Contains(t, result, "cannot be resumed")
 	assert.NotContains(t, result, "schemabot start", "a cancelled change is permanent — no resume affordance")
 }


### PR DESCRIPTION
## Why
When an apply reaches a terminal state, SchemaBot edits the progress comment and posts a final summary. Those comments can look duplicated when both use the same terminal headline.

## What
- Render terminal progress comments with a neutral `Schema Change Status` title
- Keep final summary comments using the terminal outcome title
- Surface the terminal outcome in the progress comment as a `Status` field

## Risk Assessment
Low — this only changes GitHub PR comment rendering for terminal apply status comments.

Generated with Amp
