### PR TITLE
ci: cap integration-test package parallelism at two lanes

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -154,7 +154,11 @@ jobs:
           key: go-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('go.sum') }}
           restore-keys: go-${{ runner.os }}-${{ runner.arch }}-
       - name: "Test"
-        run: go test -tags=integration -timeout=10m -count=1 $(go list -tags=integration ./... | grep -v /localscale)
+        # Cap package-level parallelism: the integration suite runs many heavy
+        # MySQL/Spirit package binaries that otherwise thrash CPU and the shared
+        # MySQL, starving operator claim loops and causing spurious pending-apply
+        # timeouts. Two lanes keeps wall time within the job budget.
+        run: go test -tags=integration -timeout=10m -count=1 -p=2 $(go list -tags=integration ./... | grep -v /localscale)
 
   localscale-matrix:
     name: "LocalScale Matrix"

--- a/Makefile
+++ b/Makefile
@@ -575,7 +575,11 @@ test-unit: ## Run unit tests with race detection
 # Note: -race is omitted because Spirit (upstream) has known data races in
 # Runner.initChunkers/Progress. Our unit tests cover race detection for our code.
 test-integration: ## Run integration tests
-	$(GOTEST) -tags=integration -timeout=10m ./...
+	# -p=2 caps package-level parallelism: the integration suite runs many heavy
+	# MySQL/Spirit package binaries that otherwise thrash CPU and the shared
+	# MySQL, starving operator claim loops and causing spurious pending-apply
+	# timeouts.
+	$(GOTEST) -tags=integration -timeout=10m -p=2 ./...
 
 # Run tests with coverage (unit + integration, merged per-package breakdown)
 #   make test-coverage              # Unit + integration (requires Docker for testcontainers)


### PR DESCRIPTION
## Summary
The "Integration Tests" job runs the whole `-tags=integration` module, so Go executes many heavy MySQL/Spirit package test binaries concurrently on a single runner. Under that CPU/DB contention the in-process operator claim loop can be starved long enough that a freshly created apply never gets claimed within its wait window, producing spurious `last state: "pending"` timeouts on tests like `TestCLI_Schemabot_Local`.

## What
- Add `-p=2` to the integration `go test` invocation in the CI job and to the `test-integration` make target.

## Why
Two lanes relieves the contention at the root (CPU + shared MySQL) without raising any test timeout or skipping tests. Wall time stays within the 10m job budget (makespan balances to ~6–7 min across two lanes). This is a flake-stability fix, not a behavior change.

## Before / after

Before — `-p` defaults to GOMAXPROCS (~4), so 4 heavy test binaries run at once and thrash one CPU + one shared MySQL; the in-process operator loop is starved and a pending apply never gets claimed:
```
one runner (≈4 vCPU) + one shared MySQL
╭───────────────────────────────────────────────╮
│ lane 1 │ integration   ███████████████  (268s)│
│ lane 2 │ pkg/api       ██████████       (178s)│
│ lane 3 │ pkg/engine    ███████          (108s)│  ← CPU + MySQL
│ lane 4 │ pkg/tern      █████            ( 64s)│    saturated
╰───────────────────────────────────────────────╯
operator claim loop starved ─▶ apply stuck "pending" ─▶ timeout ✗
```
After — `-p=2` caps to 2 lanes; the scheduler balances the binaries (~6–7 min makespan) and leaves CPU/DB headroom so the operator claims within the wait window:
```
one runner (≈4 vCPU) + one shared MySQL
╭───────────────────────────────────────────────╮
│ lane 1 │ integration ███████  ▸ pkg/tern ███  │
│ lane 2 │ pkg/api ████  ▸ pkg/engine ███  ▸ …  │  ← headroom left
╰───────────────────────────────────────────────╯
operator claim loop runs ─▶ apply claimed ─▶ completed ✓
```
## References
Observed failure: `TestCLI_Schemabot_Local/apply_accepted` timed out with `last state: "pending"` — https://github.com/block/schemabot/actions/runs/28199350340/job/83534602384 (Integration Tests job on #532, whose diff is unrelated to that test).
