### PR TITLE
fix(api): don't let retryable-apply expiry errors starve operator claims

### DIFF
--- a/pkg/api/operator.go
+++ b/pkg/api/operator.go
@@ -167,9 +167,11 @@ func (s *Service) operatorDriver(ctx context.Context, driverID int, stop <-chan 
 	}
 }
 
-// recoverApplies claims and resumes applies that need attention.
-// Each call claims one apply (if available) to keep the scheduling loop responsive.
-func (s *Service) recoverApplies(ctx context.Context, driverID int) {
+// expireRetryableApplies runs the retryable-apply expiry maintenance pass,
+// terminalizing failed_retryable applies that have exhausted their attempts or
+// freshness window. It is best-effort: a storage error is logged and recorded
+// but not returned, so the caller can still claim new work in the same tick.
+func (s *Service) expireRetryableApplies(ctx context.Context, driverID int) {
 	expired, err := s.storage.Applies().ExpireRetryable(ctx)
 	if err != nil {
 		s.logger.Error("operator: failed to expire retryable applies", "driver", driverID, "error", err)
@@ -187,6 +189,16 @@ func (s *Service) recoverApplies(ctx context.Context, driverID int) {
 			"reason", expiration.Reason)
 		metrics.RecordOperatorResumeFailure(ctx, apply.Database, apply.Deployment, apply.Environment, string(expiration.Reason))
 	}
+}
+
+// recoverApplies claims and resumes applies that need attention.
+// Each call claims one apply (if available) to keep the scheduling loop responsive.
+func (s *Service) recoverApplies(ctx context.Context, driverID int) {
+	// Retryable-apply expiry is best-effort maintenance: run it first, but a
+	// storage failure here must not stop the driver from claiming new pending
+	// work in the same tick, or a transient expiry error would starve every
+	// queued apply behind it.
+	s.expireRetryableApplies(ctx, driverID)
 
 	owner := driverLeaseOwner(driverID)
 

--- a/pkg/api/operator_test.go
+++ b/pkg/api/operator_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"os"
 	"sync"
@@ -1122,4 +1123,37 @@ type singleCutoverOpStore struct {
 func (s *singleCutoverOpStore) FindNextApplyOperationCutover(context.Context, string) (*storage.ApplyOperation, error) {
 	op := *s.op
 	return &op, nil
+}
+
+// expiryErrorApplyStore fails the retryable-apply expiry maintenance pass and
+// records whether the claim path (FindNextApply) was still reached afterwards.
+type expiryErrorApplyStore struct {
+	storage.ApplyStore
+	findNextCalled bool
+}
+
+func (s *expiryErrorApplyStore) ExpireRetryable(context.Context) ([]*storage.RetryableApplyExpiration, error) {
+	return nil, errors.New("storage unavailable")
+}
+
+func (s *expiryErrorApplyStore) FindNextApply(context.Context, string) (*storage.Apply, error) {
+	s.findNextCalled = true
+	return nil, nil
+}
+
+// Retryable-apply expiry is best-effort maintenance: a storage failure there
+// must not stop a driver from claiming new pending work in the same tick, or a
+// transient expiry error would starve every queued apply behind it.
+func TestRecoverApplies_ExpiryErrorDoesNotBlockClaim(t *testing.T) {
+	applyStore := &expiryErrorApplyStore{}
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	claimOperations := false
+	cfg := testServerConfig()
+	cfg.OperatorClaimOperations = &claimOperations
+	svc := New(&mockStorageWithApplyStores{applies: applyStore}, cfg, nil, logger)
+
+	svc.recoverApplies(t.Context(), 1)
+
+	assert.True(t, applyStore.findNextCalled,
+		"FindNextApply must run even when ExpireRetryable fails")
 }


### PR DESCRIPTION
## Summary
`recoverApplies` ran the retryable-apply expiry maintenance pass first and `return`ed on its error *before* attempting any claim. A transient storage error in `ExpireRetryable` therefore blocked every driver from claiming queued pending applies until the error cleared — a self-inflicted starvation path on a tier-0 scheduling loop.

## What
- Extract the expiry pass into a best-effort `expireRetryableApplies` helper that logs + records the error but does not return.
- `recoverApplies` runs it, then always proceeds to the claim path (operation-claim or legacy `FindNextApply`).
- Add a focused regression test proving `FindNextApply` still runs when `ExpireRetryable` fails.

## Why
Expiry is maintenance; claiming new work is the driver's primary job and must not depend on maintenance succeeding.

## Before / after

Before — an `ExpireRetryable` error aborts the whole tick, so claiming never runs:
```
recoverApplies(tick)
│
▼
ExpireRetryable
├─ error ─▶ log + metric ─▶ return        ✗  claim never runs
│
└─ ok ────▶ handle expirations ─▶ claim    ✓
```

After — expiry is best-effort; both branches fall through to the claim:
```
recoverApplies(tick)
│
▼
expireRetryableApplies   (best-effort: never returns to caller)
├─ error ─▶ log + metric ───────────┐
│                                    │
└─ ok ────▶ handle expirations ──────┤
▼
claim                ✓  always runs
(FindNextApply /
recoverApplyOperation)
```