### PR TITLE
ci: run the barrier-release bounded guard in the e2e multi-deploy matrix

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -275,7 +275,7 @@ jobs:
       matrix:
         include:
           - shard: ordered
-            run: TestGRPCMultiDeploy_(SchemaBot_Health|TernHealth_BothDeployments|Plan_FansOut|OrderedCutover|OrderedCutoverObservability)$$
+            run: TestGRPCMultiDeploy_(SchemaBot_Health|TernHealth_BothDeployments|Plan_FansOut|OrderedCutover|OrderedCutoverObservability|BarrierReleaseBounded)$$
           - shard: failure-policy
             run: TestGRPCMultiDeploy_(FailureHaltsRollout|OnFailureContinue)$$
     steps:


### PR DESCRIPTION
## Summary

The multi-deployment e2e CI job shards its tests by name via a regex matrix. The ordered-cutover barrier-release bounded guard was not in any shard, so it would be defined but never executed in CI. This adds it to the `ordered` shard.

## What

Add `BarrierReleaseBounded` to the `ordered` shard's `-run` regex in the `e2e-grpc-multideploy` job. The guard exercises ordered cutover, so it belongs with the other ordered-cutover tests.

## Before / after

BEFORE — guard defined but unreachable in CI
```
╭─ e2e-grpc-multideploy matrix ───────────────────────────────╮
│ shard: ordered          ▶ SchemaBot_Health                  │
│                           TernHealth_BothDeployments        │
│                           Plan_FansOut                      │
│                           OrderedCutover                    │
│                           OrderedCutoverObservability       │
│ shard: failure-policy   ▶ FailureHaltsRollout               │
│                           OnFailureContinue                 │
│                                                             │
│ BarrierReleaseBounded   ▶ (matched by no shard) ✗ never run │
╰─────────────────────────────────────────────────────────────╯
```
AFTER — guard runs every build
```
╭─ e2e-grpc-multideploy matrix ───────────────────────────────╮
│ shard: ordered          ▶ SchemaBot_Health                  │
│                           TernHealth_BothDeployments        │
│                           Plan_FansOut                      │
│                           OrderedCutover                    │
│                           OrderedCutoverObservability       │
│                           BarrierReleaseBounded  ✓ added    │
│ shard: failure-policy   ▶ FailureHaltsRollout               │
│                           OnFailureContinue                 │
╰─────────────────────────────────────────────────────────────╯
```
## Why

A regression guard that never runs provides no protection. This is order-independent with the PR that introduces the test: until that test exists on the branch the regex matches nothing extra (no failure); once it lands, the guard runs on every build.
