### PR TITLE
feat: add parallel cutover policy for concurrent copy

### DIFF
--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -861,9 +861,9 @@ func (c *ServerConfig) Validate() error {
 					return fmt.Errorf("database %q environment %q sets cutover_policy without a deployments map", name, env)
 				}
 				switch envConfig.CutoverPolicy {
-				case storage.CutoverPolicyRolling, storage.CutoverPolicyBarrier:
+				case storage.CutoverPolicyRolling, storage.CutoverPolicyBarrier, storage.CutoverPolicyParallel:
 				default:
-					return fmt.Errorf("database %q environment %q has invalid cutover_policy %q (want %q or %q)", name, env, envConfig.CutoverPolicy, storage.CutoverPolicyRolling, storage.CutoverPolicyBarrier)
+					return fmt.Errorf("database %q environment %q has invalid cutover_policy %q (want %q, %q, or %q)", name, env, envConfig.CutoverPolicy, storage.CutoverPolicyRolling, storage.CutoverPolicyBarrier, storage.CutoverPolicyParallel)
 				}
 			}
 			if envConfig.OnFailure != "" {

--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -1484,9 +1484,10 @@ func TestServerConfig_CutoverPolicyFor(t *testing.T) {
 			"payments": {
 				Type: "mysql",
 				Environments: map[string]EnvironmentConfig{
-					"policy-unset":   {Target: "payments", Deployment: "payments-a"},
-					"policy-rolling": {Deployments: map[string]DeploymentTarget{"payments-a": {Target: "payments"}}, CutoverPolicy: storage.CutoverPolicyRolling},
-					"policy-barrier": {Deployments: map[string]DeploymentTarget{"payments-a": {Target: "payments"}}, CutoverPolicy: storage.CutoverPolicyBarrier},
+					"policy-unset":    {Target: "payments", Deployment: "payments-a"},
+					"policy-rolling":  {Deployments: map[string]DeploymentTarget{"payments-a": {Target: "payments"}}, CutoverPolicy: storage.CutoverPolicyRolling},
+					"policy-barrier":  {Deployments: map[string]DeploymentTarget{"payments-a": {Target: "payments"}}, CutoverPolicy: storage.CutoverPolicyBarrier},
+					"policy-parallel": {Deployments: map[string]DeploymentTarget{"payments-a": {Target: "payments"}}, CutoverPolicy: storage.CutoverPolicyParallel},
 				},
 			},
 		},
@@ -1495,6 +1496,7 @@ func TestServerConfig_CutoverPolicyFor(t *testing.T) {
 	assert.Equal(t, storage.CutoverPolicyRolling, cfg.CutoverPolicyFor("payments", "policy-unset"), "unset defaults to rolling")
 	assert.Equal(t, storage.CutoverPolicyRolling, cfg.CutoverPolicyFor("payments", "policy-rolling"), "explicit rolling is rolling")
 	assert.Equal(t, storage.CutoverPolicyBarrier, cfg.CutoverPolicyFor("payments", "policy-barrier"), "explicit barrier is barrier")
+	assert.Equal(t, storage.CutoverPolicyParallel, cfg.CutoverPolicyFor("payments", "policy-parallel"), "explicit parallel is parallel")
 	assert.Equal(t, storage.CutoverPolicyRolling, cfg.CutoverPolicyFor("payments", "missing-env"), "unconfigured env defaults to rolling")
 	assert.Equal(t, storage.CutoverPolicyRolling, cfg.CutoverPolicyFor("missing-db", "policy-barrier"), "unconfigured database defaults to rolling")
 }
@@ -1674,6 +1676,16 @@ func TestServerConfig_DeploymentsMapValidation(t *testing.T) {
 					"payments-a": {Target: "payments"},
 				},
 				CutoverPolicy: storage.CutoverPolicyBarrier,
+			},
+			tern: baseTern,
+		},
+		{
+			name: "cutover_policy parallel with a deployments map is accepted",
+			envConfig: EnvironmentConfig{
+				Deployments: map[string]DeploymentTarget{
+					"payments-a": {Target: "payments"},
+				},
+				CutoverPolicy: storage.CutoverPolicyParallel,
 			},
 			tern: baseTern,
 		},

--- a/pkg/cmd/commands/watch_tui_view_multi.go
+++ b/pkg/cmd/commands/watch_tui_view_multi.go
@@ -33,6 +33,7 @@ func tuiOperationsForPresentation(ops []templates.ProgressOperation) []presentat
 			Deployment:        op.Deployment,
 			State:             op.State,
 			Barrier:           op.CutoverPolicy == storage.CutoverPolicyBarrier,
+			Parallel:          op.CutoverPolicy == storage.CutoverPolicyParallel,
 			HaltOnFailure:     op.OnFailure != storage.OnFailureContinue,
 			ContinueOnFailure: op.OnFailure == storage.OnFailureContinue,
 			Error:             op.ErrorMessage,

--- a/pkg/cmd/internal/templates/progress_multi.go
+++ b/pkg/cmd/internal/templates/progress_multi.go
@@ -32,6 +32,7 @@ func progressOperationsForPresentation(ops []ProgressOperation) []presentation.O
 			Deployment:        op.Deployment,
 			State:             op.State,
 			Barrier:           op.CutoverPolicy == storage.CutoverPolicyBarrier,
+			Parallel:          op.CutoverPolicy == storage.CutoverPolicyParallel,
 			HaltOnFailure:     op.OnFailure != storage.OnFailureContinue,
 			ContinueOnFailure: op.OnFailure == storage.OnFailureContinue,
 			Error:             op.ErrorMessage,

--- a/pkg/presentation/presentation.go
+++ b/pkg/presentation/presentation.go
@@ -39,6 +39,16 @@ type Operation struct {
 	// succeeds; under rolling only a completed earlier sibling stops blocking.
 	Barrier bool
 
+	// Parallel is true when the operation's cutover_policy is "parallel" (resolved
+	// by the caller from storage.CutoverPolicyParallel). Under parallel the copy
+	// phase has no earlier-sibling gate at all — every deployment copies
+	// concurrently from the start — so a pending operation is never shown waiting
+	// for or halted by an earlier sibling. Cutover ordering is unchanged (it is
+	// strict-complete and policy-independent), so a parked parallel operation
+	// still waits for earlier cutovers exactly like barrier. Barrier and Parallel
+	// are mutually exclusive: the caller derives each from the same stored policy.
+	Parallel bool
+
 	// HaltOnFailure is the resolved halt-on-failure policy (the caller derefs the
 	// stored *bool, treating nil as true — the safe default). When false, a
 	// terminal-failed earlier sibling no longer blocks later deployments.
@@ -269,6 +279,14 @@ func deriveDeployment(ops []Operation, i int) Deployment {
 // label agrees with what the operator will claim next.
 func derivePending(d *Deployment, ops []Operation, i int) {
 	op := ops[i]
+	// Under parallel the copy phase has no earlier-sibling gate, so a pending
+	// operation is immediately claimable regardless of any earlier sibling — it
+	// is never halted by or waiting for one. Mirror FindNextApplyOperation, whose
+	// copy-start gate matches no arm for parallel.
+	if op.Parallel {
+		d.set(StateQueuedNext, "queued — next in order", "⏳", false)
+		return
+	}
 	if h := haltingBlocker(ops, i); h != nil {
 		d.set(StateHalted, fmt.Sprintf("halted — %s %s", h.Deployment, haltedReason(h.State)), "⏸", true)
 		return

--- a/pkg/presentation/presentation_test.go
+++ b/pkg/presentation/presentation_test.go
@@ -21,6 +21,13 @@ func barrier(dep, st string) Operation {
 	return Operation{Deployment: dep, State: st, Barrier: true, HaltOnFailure: true}
 }
 
+// parallel builds a parallel, halt-on-failure operation. Under parallel the copy
+// phase has no earlier-sibling gate, so a pending parallel operation is never
+// shown waiting for or halted by an earlier sibling.
+func parallel(dep, st string) Operation {
+	return Operation{Deployment: dep, State: st, Parallel: true, HaltOnFailure: true}
+}
+
 // continuing builds a rolling, on_failure=continue operation. HaltOnFailure and
 // ContinueOnFailure are exact complements at the real boundary mappers (both
 // derive from the same on_failure value), so a continue operation sets
@@ -128,6 +135,30 @@ func TestDerivePending_Ordering(t *testing.T) {
 			label: "waiting for eu",
 		},
 		{
+			name:  "parallel: earlier still copying does not block (concurrent copy)",
+			ops:   []Operation{parallel("eu", so.Running), parallel("us", so.Pending)},
+			want:  StateQueuedNext,
+			label: "queued — next in order",
+		},
+		{
+			name:  "parallel: earlier pending does not block",
+			ops:   []Operation{parallel("eu", so.Pending), parallel("us", so.Pending)},
+			want:  StateQueuedNext,
+			label: "queued — next in order",
+		},
+		{
+			name:  "parallel: earlier failed does not halt copy start",
+			ops:   []Operation{parallel("eu", so.Failed), parallel("us", so.Pending)},
+			want:  StateQueuedNext,
+			label: "queued — next in order",
+		},
+		{
+			name:  "parallel: earlier cancelled does not halt copy start",
+			ops:   []Operation{parallel("eu", so.Cancelled), parallel("us", so.Pending)},
+			want:  StateQueuedNext,
+			label: "queued — next in order",
+		},
+		{
 			name:  "halt: earlier failed halts the rollout",
 			ops:   []Operation{rolling("eu", so.Failed), rolling("us", so.Pending)},
 			want:  StateHalted,
@@ -190,6 +221,12 @@ func TestDeriveWaitingForCutover_Ordering(t *testing.T) {
 		{
 			name:  "barrier: earlier also at barrier still blocks cutover (cutover stays ordered)",
 			ops:   []Operation{barrier("eu", so.WaitingForCutover), barrier("us", so.WaitingForCutover)},
+			want:  StateReadyForCutoverWaiting,
+			label: "ready for cutover — waiting for eu",
+		},
+		{
+			name:  "parallel: earlier also at barrier still blocks cutover (cutover stays ordered)",
+			ops:   []Operation{parallel("eu", so.WaitingForCutover), parallel("us", so.WaitingForCutover)},
 			want:  StateReadyForCutoverWaiting,
 			label: "ready for cutover — waiting for eu",
 		},

--- a/pkg/storage/mysqlstore/apply_operations.go
+++ b/pkg/storage/mysqlstore/apply_operations.go
@@ -588,11 +588,14 @@ func (s *applyOperationStore) FindNextApplyOperation(ctx context.Context, owner 
 	// Sibling-gate args for the pending claim, cutover_policy-aware (see the
 	// gate SQL below). Under barrier, an earlier sibling stops blocking once it
 	// reaches the cutover barrier or succeeds (waiting_for_cutover, cutting_over,
-	// revert_window, completed); under rolling — and any non-barrier value, which
-	// fails closed to the serial gate — only a completed earlier sibling stops
-	// blocking. The trailing on_failure/Failed pair drives the exemption: when
-	// the policy is "continue", a terminal-failed earlier sibling no longer
-	// blocks later ones.
+	// revert_window, completed). Under parallel there is intentionally no arm: a
+	// parallel operation matches neither branch, so no earlier sibling can make
+	// the blocking EXISTS true and its copy starts immediately (concurrent copy).
+	// Under rolling — and any unrecognized value, which fails closed to the
+	// serial gate via NOT IN (barrier, parallel) — only a completed earlier
+	// sibling stops blocking. The trailing on_failure/Failed pair drives the
+	// exemption: when the policy is "continue", a terminal-failed earlier sibling
+	// no longer blocks later ones.
 	queryArgs = append(queryArgs,
 		storage.CutoverPolicyBarrier,
 		state.ApplyOperation.WaitingForCutover,
@@ -600,6 +603,7 @@ func (s *applyOperationStore) FindNextApplyOperation(ctx context.Context, owner 
 		state.ApplyOperation.RevertWindow,
 		state.ApplyOperation.Completed,
 		storage.CutoverPolicyBarrier,
+		storage.CutoverPolicyParallel,
 		state.ApplyOperation.Completed,
 		storage.OnFailureContinue,
 		state.ApplyOperation.Failed,
@@ -620,13 +624,14 @@ func (s *applyOperationStore) FindNextApplyOperation(ctx context.Context, owner 
 		storage.ControlOperationStop, storage.ControlRequestPending)
 	queryArgs = append(queryArgs, stringArgs(activeStates)...)
 	// Stale-active barrier-park exemption (see the staleness clause below): a
-	// multi-deployment operation parked at the cutover barrier under the barrier
-	// policy is reserved for the deployment-ordered cutover claim, so the copy
-	// claim must not re-lease it as stale-active work. A single-operation apply
-	// has no sibling and is never exempted, so manual --defer-cutover behaviour
-	// is unchanged.
+	// multi-deployment operation parked at the cutover barrier under an
+	// ordered-cutover policy (barrier or parallel) is reserved for the
+	// deployment-ordered cutover claim, so the copy claim must not re-lease it as
+	// stale-active work. A single-operation apply has no sibling and is never
+	// exempted, so manual --defer-cutover behaviour is unchanged.
 	queryArgs = append(queryArgs,
-		state.ApplyOperation.WaitingForCutover, storage.CutoverPolicyBarrier)
+		state.ApplyOperation.WaitingForCutover,
+		storage.CutoverPolicyBarrier, storage.CutoverPolicyParallel)
 	queryArgs = append(queryArgs,
 		state.ApplyOperation.Stopped,
 		storage.ControlOperationStart, storage.ControlRequestPending)
@@ -708,7 +713,7 @@ func (s *applyOperationStore) FindNextApplyOperation(ctx context.Context, owner 
 										AND earlier.state NOT IN (?, ?, ?, ?)
 									)
 									OR (
-										apply_operations.cutover_policy <> ?
+										apply_operations.cutover_policy NOT IN (?, ?)
 										AND earlier.state <> ?
 									)
 								)
@@ -741,7 +746,7 @@ func (s *applyOperationStore) FindNextApplyOperation(ctx context.Context, owner 
 				AND updated_at < NOW() - INTERVAL %s
 				AND NOT (
 					state = ?
-					AND cutover_policy = ?
+					AND cutover_policy IN (?, ?)
 					AND EXISTS (
 						SELECT 1
 						FROM apply_operations AS sibling
@@ -1012,8 +1017,10 @@ func (s *applyOperationStore) FindNextApplyOperationCutover(ctx context.Context,
 	// driving — exactly the population OC-2 parks-and-releases. This mirrors
 	// shouldReleaseAtCutoverBarrier in pkg/tern/cutover_barrier.go:
 	//
-	//   1. cutover_policy = barrier — rolling rows are never deployment-ordered
-	//      at the cutover phase.
+	//   1. cutover_policy is ordered (barrier or parallel) — rolling rows are
+	//      never deployment-ordered at the cutover phase. Barrier and parallel
+	//      both park at the barrier and cut over in deployment order; they differ
+	//      only in the copy-start gate, so both are eligible here.
 	//   2. multi-operation apply (EXISTS sibling) — a single-op apply has no
 	//      siblings to order, so it never auto-defers; its cutover stays on the
 	//      copy/manual path. Mirrors shouldAutoDeferCutover's multiOperation arg.
@@ -1026,7 +1033,7 @@ func (s *applyOperationStore) FindNextApplyOperationCutover(ctx context.Context,
 	// The gate wraps BOTH claim branches (start and stale recovery): a stale
 	// cutting_over/revert_window row outside this population reached that state
 	// via the copy/manual path, so recovering it here would steal legitimate work.
-	queryArgs := []any{storage.CutoverPolicyBarrier}
+	queryArgs := []any{storage.CutoverPolicyBarrier, storage.CutoverPolicyParallel}
 	// Start-a-parked-cutover gate (see SQL below). A waiting_for_cutover row is
 	// claimable only when no earlier deployment_order sibling is still
 	// non-completed; the on_failure/Failed pair is the "continue" exemption (a
@@ -1051,7 +1058,7 @@ func (s *applyOperationStore) FindNextApplyOperationCutover(ctx context.Context,
 	row := tx.QueryRowContext(ctx, fmt.Sprintf(`
 		SELECT %s
 		FROM apply_operations
-		WHERE apply_operations.cutover_policy = ?
+		WHERE apply_operations.cutover_policy IN (?, ?)
 		AND EXISTS (
 			SELECT 1
 			FROM apply_operations AS sibling

--- a/pkg/storage/mysqlstore/apply_operations_test.go
+++ b/pkg/storage/mysqlstore/apply_operations_test.go
@@ -117,10 +117,23 @@ func TestApplyOperationStore_CutoverPolicyRoundTrip(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, storage.CutoverPolicyRolling, defaultedOp.CutoverPolicy, "Insert normalizes an empty policy to rolling on the passed struct")
 
+	parallelID, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID:       apply.ID,
+		Deployment:    "region-c",
+		Target:        "payments",
+		CutoverPolicy: storage.CutoverPolicyParallel,
+	})
+	require.NoError(t, err)
+
 	barrier, err := store.ApplyOperations().Get(ctx, barrierID)
 	require.NoError(t, err)
 	require.NotNil(t, barrier)
 	assert.Equal(t, storage.CutoverPolicyBarrier, barrier.CutoverPolicy, "an explicit barrier policy round-trips unchanged")
+
+	parallel, err := store.ApplyOperations().Get(ctx, parallelID)
+	require.NoError(t, err)
+	require.NotNil(t, parallel)
+	assert.Equal(t, storage.CutoverPolicyParallel, parallel.CutoverPolicy, "an explicit parallel policy round-trips unchanged")
 
 	defaulted, err := store.ApplyOperations().Get(ctx, defaultedID)
 	require.NoError(t, err)
@@ -2391,6 +2404,76 @@ func TestApplyOperationStore_FindNextApplyOperation_BarrierStillBlocksOnRunningS
 	assert.Nil(t, claimed, "barrier must still block a later deployment while an earlier sibling is still copying")
 }
 
+// TestApplyOperationStore_FindNextApplyOperation_ParallelClaimsPastRunningSibling
+// verifies the defining parallel behaviour: the copy phase has no earlier-sibling
+// gate, so a later deployment may start copying while an earlier sibling is still
+// copying (running) — every deployment copies concurrently. This is exactly the
+// case barrier blocks.
+func TestApplyOperationStore_FindNextApplyOperation_ParallelClaimsPastRunningSibling(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", "mysql", "staging")
+	apply := createTestApply(t, store, lock, "apply_op_parallel_running", 1)
+
+	// region-a is still copying (running, fresh so not stale-reclaimable);
+	// region-b is pending behind it. Both carry the parallel policy.
+	_, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-a",
+		State: state.ApplyOperation.Running, CutoverPolicy: storage.CutoverPolicyParallel,
+	})
+	require.NoError(t, err)
+	regionBID, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-b", CutoverPolicy: storage.CutoverPolicyParallel,
+	})
+	require.NoError(t, err)
+
+	claimed, err := store.ApplyOperations().FindNextApplyOperation(ctx, "test-operator")
+	require.NoError(t, err)
+	require.NotNil(t, claimed, "parallel must let a later deployment copy while an earlier sibling is still copying")
+	assert.Equal(t, regionBID, claimed.ID)
+	assert.Equal(t, "region-b", claimed.Deployment)
+}
+
+// TestApplyOperationStore_FindNextApplyOperation_ParallelClaimsPastFailedSibling
+// verifies that parallel drops copy-phase ordering entirely: a terminal-failed
+// earlier sibling does not block a later deployment's copy start, because the
+// copy gate has no earlier-sibling arm for parallel at all. Cutover ordering
+// (where halt-on-failure still applies) is enforced separately on the cutover
+// claim path.
+func TestApplyOperationStore_FindNextApplyOperation_ParallelClaimsPastFailedSibling(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", "mysql", "staging")
+	apply := createTestApply(t, store, lock, "apply_op_parallel_failed", 1)
+
+	failedID, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-a",
+		State: state.ApplyOperation.Failed, CutoverPolicy: storage.CutoverPolicyParallel,
+	})
+	require.NoError(t, err)
+	regionBID, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-b", CutoverPolicy: storage.CutoverPolicyParallel,
+	})
+	require.NoError(t, err)
+
+	// Backdate the failed row so staleness can't be confused with the reason the
+	// later row is claimable; parallel claims past it on copy regardless.
+	_, err = testDB.ExecContext(ctx, `
+		UPDATE apply_operations SET updated_at = NOW() - INTERVAL 1 HOUR WHERE id = ?
+	`, failedID)
+	require.NoError(t, err)
+
+	claimed, err := store.ApplyOperations().FindNextApplyOperation(ctx, "test-operator")
+	require.NoError(t, err)
+	require.NotNil(t, claimed, "parallel must let a later deployment copy past a failed earlier sibling")
+	assert.Equal(t, regionBID, claimed.ID)
+	assert.Equal(t, "region-b", claimed.Deployment)
+}
+
 // TestApplyOperationStore_FindNextApplyOperation_BarrierHaltsOnFailedSibling
 // verifies that barrier does not weaken halt-on-first-failure: a terminal-failed
 // earlier sibling still blocks later deployments under barrier, so a failed
@@ -2461,6 +2544,45 @@ func TestApplyOperationStore_FindNextApplyOperation_SkipsStaleMultiOpBarrierPark
 	claimed, err := store.ApplyOperations().FindNextApplyOperation(ctx, "test-operator")
 	require.NoError(t, err)
 	assert.Nil(t, claimed, "the copy claim must not re-lease a parked multi-op barrier deployment")
+}
+
+// TestApplyOperationStore_FindNextApplyOperation_SkipsStaleMultiOpParallelParked
+// verifies the stale-park exemption covers parallel too: a multi-deployment
+// parallel operation parked at the cutover barrier is reserved for the
+// deployment-ordered cutover claim, so the copy claim must not re-lease it even
+// once its heartbeat goes stale. Without the exemption a parked parallel
+// deployment would be re-driven on the copy path and loop.
+func TestApplyOperationStore_FindNextApplyOperation_SkipsStaleMultiOpParallelParked(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", "mysql", "staging")
+	apply := createTestApply(t, store, lock, "apply_op_parallel_parked_skip", 1)
+
+	parkedID, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-a",
+		State: state.ApplyOperation.WaitingForCutover, CutoverPolicy: storage.CutoverPolicyParallel,
+	})
+	require.NoError(t, err)
+	// A completed sibling makes this a multi-operation apply without leaving any
+	// other claimable (pending) row, so the parked row is the only candidate.
+	_, err = store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-b",
+		State: state.ApplyOperation.Completed, CutoverPolicy: storage.CutoverPolicyParallel,
+	})
+	require.NoError(t, err)
+
+	// Backdate the parked row past the staleness window so only the barrier-park
+	// exemption — not freshness — keeps it from being re-claimed.
+	_, err = testDB.ExecContext(ctx, `
+		UPDATE apply_operations SET updated_at = NOW() - INTERVAL 2 MINUTE WHERE id = ?
+	`, parkedID)
+	require.NoError(t, err)
+
+	claimed, err := store.ApplyOperations().FindNextApplyOperation(ctx, "test-operator")
+	require.NoError(t, err)
+	assert.Nil(t, claimed, "the copy claim must not re-lease a parked multi-op parallel deployment")
 }
 
 // TestApplyOperationStore_FindNextApplyOperation_ClaimsStaleSingleOpBarrierParked
@@ -2934,6 +3056,45 @@ func TestApplyOperationStore_FindNextApplyOperationCutover_SkipsRollingPolicy(t 
 	claimed, err := store.ApplyOperations().FindNextApplyOperationCutover(ctx, "cutover-operator")
 	require.NoError(t, err)
 	assert.Nil(t, claimed, "the cutover worker must not claim rolling-policy operations")
+}
+
+// TestApplyOperationStore_FindNextApplyOperationCutover_ClaimsParallel verifies
+// the strand guard for parallel: a multi-deployment parallel operation parked at
+// the cutover barrier IS eligible for the deployment-ordered cutover claim, just
+// like barrier. Parallel and barrier share identical cutover sequencing; they
+// differ only in the copy-start gate. Without this, a parked parallel operation
+// would never be claimed for cutover and would be stranded.
+func TestApplyOperationStore_FindNextApplyOperationCutover_ClaimsParallel(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", "mysql", "staging")
+	apply := createTestApply(t, store, lock, "apply_op_cutover_parallel", 1)
+
+	id, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-a", Target: "payments",
+		State: state.ApplyOperation.WaitingForCutover, CutoverPolicy: storage.CutoverPolicyParallel,
+	})
+	require.NoError(t, err)
+	// A completed earlier sibling makes this a multi-operation apply and leaves
+	// no earlier non-completed sibling to block the ordered cutover claim.
+	_, err = store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-z",
+		State: state.ApplyOperation.Completed, CutoverPolicy: storage.CutoverPolicyParallel,
+	})
+	require.NoError(t, err)
+
+	claimed, err := store.ApplyOperations().FindNextApplyOperationCutover(ctx, "cutover-operator")
+	require.NoError(t, err)
+	require.NotNil(t, claimed, "the cutover worker must claim a parked multi-op parallel deployment")
+	assert.Equal(t, id, claimed.ID)
+	assert.Equal(t, state.ApplyOperation.WaitingForCutover, claimed.State, "returned row carries its pre-claim state")
+
+	persisted, err := store.ApplyOperations().Get(ctx, id)
+	require.NoError(t, err)
+	require.NotNil(t, persisted)
+	assert.Equal(t, state.ApplyOperation.CuttingOver, persisted.State, "cutover claim must transition waiting_for_cutover → cutting_over")
 }
 
 // TestApplyOperationStore_FindNextApplyOperationCutover_SkipsSingleOpBarrier

--- a/pkg/storage/types.go
+++ b/pkg/storage/types.go
@@ -22,7 +22,25 @@ const (
 	// CutoverPolicyBarrier lets later deployments run their copy phase once
 	// earlier siblings reach the cutover barrier, while cutover stays ordered.
 	CutoverPolicyBarrier = "barrier"
+
+	// CutoverPolicyParallel drops copy-phase ordering entirely: every deployment
+	// copies concurrently from the start, with no earlier-sibling gate on copy
+	// start. Only the cutover phase stays deployment-ordered, exactly like
+	// barrier. This collapses copy wall-clock toward "longest copy" for rollouts
+	// whose hours-long copy dominates, while preserving the ordered, one-at-a-time
+	// cutover swaps.
+	CutoverPolicyParallel = "parallel"
 )
+
+// IsOrderedCutoverPolicy reports whether a cutover policy parks each
+// multi-deployment operation at the cutover barrier and drives the high-risk
+// swaps in deployment order via the cutover-claim path. Both barrier and
+// parallel share this ordered-cutover behaviour; they differ only in the
+// copy-start gate (barrier staggers copies, parallel runs them concurrently).
+// rolling and any unrecognized value are not ordered-cutover policies.
+func IsOrderedCutoverPolicy(policy string) bool {
+	return policy == CutoverPolicyBarrier || policy == CutoverPolicyParallel
+}
 
 // On-failure policies control multi-deployment rollout continuation when an
 // earlier deployment terminally fails. Like the cutover policy, the value is

--- a/pkg/tern/cutover_barrier.go
+++ b/pkg/tern/cutover_barrier.go
@@ -17,13 +17,15 @@ func isCutoverDriveState(opState string) bool {
 
 // shouldAutoDeferCutover reports whether an operation-scoped copy drive must park
 // at the cutover barrier automatically. It is true only for an operation of a
-// multi-deployment (fan-out) apply running under the barrier cutover policy, so
-// the high-risk cutover swaps can later be driven in deployment order by the
-// cutover-claim path. A single-operation apply has no siblings to order, so it
-// never auto-defers even when its stored cutover_policy is barrier: behaviour is
-// unchanged until multi-deployment fan-out lands.
+// multi-deployment (fan-out) apply running under an ordered-cutover policy
+// (barrier or parallel), so the high-risk cutover swaps can later be driven in
+// deployment order by the cutover-claim path. The two policies differ only in
+// the copy-start gate, not in how cutover is sequenced, so both park here. A
+// single-operation apply has no siblings to order, so it never auto-defers even
+// when its stored cutover_policy is ordered: behaviour is unchanged until
+// multi-deployment fan-out lands.
 func shouldAutoDeferCutover(multiOperation bool, op *storage.ApplyOperation) bool {
-	return multiOperation && op != nil && op.CutoverPolicy == storage.CutoverPolicyBarrier
+	return multiOperation && op != nil && storage.IsOrderedCutoverPolicy(op.CutoverPolicy)
 }
 
 // shouldReleaseAtCutoverBarrier reports whether an operation-scoped copy drive

--- a/pkg/tern/cutover_barrier_test.go
+++ b/pkg/tern/cutover_barrier_test.go
@@ -17,6 +17,10 @@ func rollingOp() *storage.ApplyOperation {
 	return &storage.ApplyOperation{CutoverPolicy: storage.CutoverPolicyRolling}
 }
 
+func parallelOp() *storage.ApplyOperation {
+	return &storage.ApplyOperation{CutoverPolicy: storage.CutoverPolicyParallel}
+}
+
 func TestShouldAutoDeferCutover(t *testing.T) {
 	tests := []struct {
 		name           string
@@ -25,7 +29,9 @@ func TestShouldAutoDeferCutover(t *testing.T) {
 		want           bool
 	}{
 		{"multi-op barrier parks", true, barrierOp(), true},
+		{"multi-op parallel parks", true, parallelOp(), true},
 		{"single-op barrier does not park", false, barrierOp(), false},
+		{"single-op parallel does not park", false, parallelOp(), false},
 		{"multi-op rolling does not park", true, rollingOp(), false},
 		{"multi-op nil op does not park", true, nil, false},
 		{"single-op rolling does not park", false, rollingOp(), false},
@@ -46,8 +52,11 @@ func TestShouldReleaseAtCutoverBarrier(t *testing.T) {
 		want           bool
 	}{
 		{"multi-op barrier auto-releases", false, true, barrierOp(), true},
+		{"multi-op parallel auto-releases", false, true, parallelOp(), true},
 		{"manual defer holds the claim", true, true, barrierOp(), false},
+		{"manual defer holds the claim (parallel)", true, true, parallelOp(), false},
 		{"single-op barrier does not release", false, false, barrierOp(), false},
+		{"single-op parallel does not release", false, false, parallelOp(), false},
 		{"multi-op rolling does not release", false, true, rollingOp(), false},
 	}
 	for _, tt := range tests {

--- a/pkg/webhook/multi_apply.go
+++ b/pkg/webhook/multi_apply.go
@@ -101,6 +101,7 @@ func applyOperationToPresentation(op *storage.ApplyOperation) presentation.Opera
 		Deployment:        op.Deployment,
 		State:             op.State,
 		Barrier:           op.CutoverPolicy == storage.CutoverPolicyBarrier,
+		Parallel:          op.CutoverPolicy == storage.CutoverPolicyParallel,
 		HaltOnFailure:     op.OnFailure != storage.OnFailureContinue,
 		ContinueOnFailure: op.OnFailure == storage.OnFailureContinue,
 		Error:             op.ErrorMessage,

--- a/pkg/webhook/multi_apply.go
+++ b/pkg/webhook/multi_apply.go
@@ -91,7 +91,8 @@ func deriveApplyPresentation(ops []*storage.ApplyOperation) presentation.Apply {
 
 // applyOperationToPresentation maps one storage operation row to the neutral
 // presentation input, resolving the rollout-policy values at the boundary:
-// cutover_policy "barrier" becomes the Barrier flag, and on_failure becomes both
+// cutover_policy "barrier" becomes the Barrier flag and "parallel" becomes the
+// Parallel flag (the two are mutually exclusive), and on_failure becomes both
 // the HaltOnFailure flag — true unless on_failure is "continue" — and the
 // ContinueOnFailure flag — true only when on_failure is exactly "continue". Any
 // other value fails closed to halting, the safe default the claim predicate and


### PR DESCRIPTION
## Summary

Adds a third multi-deployment `cutover_policy`, `parallel`, that drops copy-phase ordering entirely — every deployment copies concurrently from the start — while keeping the high-risk cutover swaps strictly deployment-ordered, exactly like `barrier`. This collapses copy wall-clock toward "longest copy" for rollouts whose long copy phase dominates, instead of paying it once per deployment in series.

## What

`parallel` shares 100% of `barrier`'s behaviour (park at the cutover barrier, release the claim for the deployment-ordered cutover path, stale-park exemption, cutover-claim eligibility) and differs in exactly one place: the copy-start gate has no earlier-sibling arm, so a deployment's copy is claimable immediately regardless of any sibling's state.

A new `storage.IsOrderedCutoverPolicy` helper centralizes the `{barrier, parallel}` "parks + ordered cutover" set so every park / release / cutover-claim predicate stays in agreement — a single missed site would strand a parked operation.

- New `CutoverPolicyParallel` constant + `IsOrderedCutoverPolicy` helper
- Config validation accepts `parallel`
- Copy-start gate: `parallel` matches no arm (never blocked); rolling/unknown still fail closed to the serial gate
- Stale-park exemption and cutover-claim eligibility both extend to `parallel`
- Tern park/release/defer logic uses the shared helper
- Presentation: a pending `parallel` deployment is never shown waiting for or halted by an earlier sibling; cutover ordering display is unchanged

## Why

`barrier` only staggers copies (a later copy waits for the earlier sibling to reach the barrier), so it trims per-step cutover/revert latency but does not collapse copy wall-clock. Environments whose copy phase runs for hours need true concurrent copy with ordered cutover — that is `parallel`.

## How the cutover policies sequence a rollout

### Existing policies

`rolling` (default) — fully serial: a later deployment does not start its copy until the earlier sibling has completed (copy + cutover + revert window).
```
eu  ███████▶┤cut├┤rw├
us                   ███████▶┤cut├┤rw├          copy starts only after eu completes
au                                    ███████▶┤cut├┤rw├
```
`barrier` — a later copy may start once the earlier sibling reaches the cutover barrier; cutover stays ordered. Trims the per-step cutover/revert latency but copies are still staggered (one at a time).
```
eu  ███████▶┤cut├┤rw├
us          ███████▶┤cut├┤rw├                   copy starts at eu's barrier
au                   ███████▶┤cut├┤rw├
```

### New in this PR

`parallel` — copy-phase ordering dropped entirely: every deployment copies at once; only cutover stays ordered (eu ▶ us ▶ au). Collapses copy wall-clock toward "longest copy".
```
eu  ███████▶┤cut├┤rw├
us  ███████▶───────▶┤cut├┤rw├                   copy concurrent; cutover waits its turn
au  ███████▶────────────▶┤cut├┤rw├
```

## Compatibility

This adds a new persisted `cutover_policy` value. It is not backward-compatible with older binaries: do not enable `cutover_policy: parallel` in config until all server/operator pods are upgraded, and avoid rolling back while active `parallel` rows exist.