### PR TITLE
feat(storage): add release control op and paused-rollout latch

### DIFF
--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -291,6 +291,18 @@ func (s *memoryControlRequestStore) GetPending(_ context.Context, applyID int64,
 	return nil, nil
 }
 
+func (s *memoryControlRequestStore) GetByOperation(_ context.Context, applyID int64, operation storage.ControlOperation) (*storage.ApplyControlRequest, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, v := range slices.Backward(s.requests) {
+		req := v
+		if req.ApplyID == applyID && req.Operation == operation {
+			return cloneControlRequest(req), nil
+		}
+	}
+	return nil, nil
+}
+
 func (s *memoryControlRequestStore) CompletePending(_ context.Context, applyID int64, operation storage.ControlOperation) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/pkg/storage/mysqlstore/control_requests.go
+++ b/pkg/storage/mysqlstore/control_requests.go
@@ -123,6 +123,19 @@ func (s *controlRequestStore) GetPending(ctx context.Context, applyID int64, ope
 	return scanControlRequest(row)
 }
 
+func (s *controlRequestStore) GetByOperation(ctx context.Context, applyID int64, operation storage.ControlOperation) (*storage.ApplyControlRequest, error) {
+	row := s.db.QueryRowContext(ctx, `
+		SELECT `+controlRequestColumns+`
+		FROM apply_control_requests
+		WHERE apply_id = ? AND operation = ?
+	`, applyID, operation)
+	req, err := scanControlRequest(row)
+	if err != nil {
+		return nil, fmt.Errorf("get control request for apply %d operation %s: %w", applyID, operation, err)
+	}
+	return req, nil
+}
+
 func (s *controlRequestStore) CompletePending(ctx context.Context, applyID int64, operation storage.ControlOperation) error {
 	lease, hasLease, err := applyLeaseFromContext(ctx, applyID)
 	if err != nil {

--- a/pkg/storage/mysqlstore/control_requests_test.go
+++ b/pkg/storage/mysqlstore/control_requests_test.go
@@ -239,6 +239,107 @@ func TestControlRequestStore_LeaseGuardsPendingResolution(t *testing.T) {
 	assert.Equal(t, storage.ControlRequestCompleted, completed.Status)
 }
 
+// A release is a one-way latch: requesting it twice (an operator double-click or
+// a retried release call) converges on the single durable row rather than
+// creating extra control work.
+func TestControlRequestStore_RequestPendingReleaseLatchIdempotent(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	applyID := createControlRequestTestApply(t, store, "apply_control_request_release")
+	first, alreadyPending, err := store.ControlRequests().RequestPending(ctx, &storage.ApplyControlRequest{
+		ApplyID:     applyID,
+		Operation:   storage.ControlOperationRelease,
+		Status:      storage.ControlRequestPending,
+		RequestedBy: "operator-a",
+		Metadata:    []byte(`{}`),
+	})
+	require.NoError(t, err)
+	require.False(t, alreadyPending)
+
+	second, alreadyPending, err := store.ControlRequests().RequestPending(ctx, &storage.ApplyControlRequest{
+		ApplyID:     applyID,
+		Operation:   storage.ControlOperationRelease,
+		Status:      storage.ControlRequestPending,
+		RequestedBy: "operator-b",
+		Metadata:    []byte(`{}`),
+	})
+	require.NoError(t, err)
+	require.True(t, alreadyPending)
+	assert.Equal(t, first.ID, second.ID)
+}
+
+// GetByOperation reads the latch regardless of status, so callers can observe a
+// completed (or failed) release that GetPending hides. The release latch holds a
+// paused rollout open while pending or completed; a failed release does not
+// latch (fail-closed), matching ApplyControlRequest.ReleasesPausedRollout.
+func TestControlRequestStore_GetByOperationReturnsRegardlessOfStatus(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	applyID := createControlRequestTestApply(t, store, "apply_control_request_get_by_op")
+
+	none, err := store.ControlRequests().GetByOperation(ctx, applyID, storage.ControlOperationRelease)
+	require.NoError(t, err)
+	assert.Nil(t, none)
+
+	created, _, err := store.ControlRequests().RequestPending(ctx, &storage.ApplyControlRequest{
+		ApplyID:   applyID,
+		Operation: storage.ControlOperationRelease,
+		Status:    storage.ControlRequestPending,
+		Metadata:  []byte(`{}`),
+	})
+	require.NoError(t, err)
+
+	pending, err := store.ControlRequests().GetByOperation(ctx, applyID, storage.ControlOperationRelease)
+	require.NoError(t, err)
+	require.NotNil(t, pending)
+	assert.Equal(t, created.ID, pending.ID)
+	assert.Equal(t, storage.ControlRequestPending, pending.Status)
+	assert.True(t, pending.ReleasesPausedRollout())
+
+	require.NoError(t, store.ControlRequests().CompletePending(ctx, applyID, storage.ControlOperationRelease))
+
+	gone, err := store.ControlRequests().GetPending(ctx, applyID, storage.ControlOperationRelease)
+	require.NoError(t, err)
+	assert.Nil(t, gone)
+
+	completed, err := store.ControlRequests().GetByOperation(ctx, applyID, storage.ControlOperationRelease)
+	require.NoError(t, err)
+	require.NotNil(t, completed)
+	assert.Equal(t, created.ID, completed.ID)
+	assert.Equal(t, storage.ControlRequestCompleted, completed.Status)
+	assert.True(t, completed.ReleasesPausedRollout())
+}
+
+// A failed release does not latch the rollout open: GetByOperation still returns
+// the row for audit, but ReleasesPausedRollout reports false so the rollout
+// stays paused until a fresh release succeeds.
+func TestControlRequestStore_GetByOperationFailedReleaseDoesNotLatch(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	applyID := createControlRequestTestApply(t, store, "apply_control_request_failed_release")
+	_, _, err := store.ControlRequests().RequestPending(ctx, &storage.ApplyControlRequest{
+		ApplyID:   applyID,
+		Operation: storage.ControlOperationRelease,
+		Status:    storage.ControlRequestPending,
+		Metadata:  []byte(`{}`),
+	})
+	require.NoError(t, err)
+	require.NoError(t, store.ControlRequests().FailPending(ctx, applyID, storage.ControlOperationRelease, "remote release failed"))
+
+	failed, err := store.ControlRequests().GetByOperation(ctx, applyID, storage.ControlOperationRelease)
+	require.NoError(t, err)
+	require.NotNil(t, failed)
+	assert.Equal(t, storage.ControlRequestFailed, failed.Status)
+	assert.Equal(t, "remote release failed", failed.ErrorMessage)
+	assert.False(t, failed.ReleasesPausedRollout())
+}
+
 func getControlRequestByID(t *testing.T, store *Storage, id int64) *storage.ApplyControlRequest {
 	t.Helper()
 	row := store.db.QueryRowContext(t.Context(), `

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -582,6 +582,13 @@ type ControlRequestStore interface {
 	// GetPending returns the pending request for an apply operation.
 	GetPending(ctx context.Context, applyID int64, operation ControlOperation) (*ApplyControlRequest, error)
 
+	// GetByOperation returns the request for an apply operation regardless of
+	// status (nil if none). Unlike GetPending it does not filter on status, so
+	// callers can observe a completed or failed latch — for example the release
+	// latch that exempts a paused rollout (see ReleasesPausedRollout). At most
+	// one row exists per (apply_id, operation).
+	GetByOperation(ctx context.Context, applyID int64, operation ControlOperation) (*ApplyControlRequest, error)
+
 	// CompletePending marks the pending request for an apply operation completed.
 	CompletePending(ctx context.Context, applyID int64, operation ControlOperation) error
 

--- a/pkg/storage/types.go
+++ b/pkg/storage/types.go
@@ -677,6 +677,12 @@ const (
 	ControlOperationStop ControlOperation = "stop"
 	// ControlOperationCutover triggers deferred cutover.
 	ControlOperationCutover ControlOperation = "cutover"
+	// ControlOperationRelease releases a rollout paused after a failure under
+	// on_failure 'pause', letting the held later deployments proceed (like
+	// 'continue'). It is a one-way latch and is deliberately distinct from
+	// 'start': 'start' resumes stopped work and carries no claim-ordering
+	// clause, so it cannot release a paused rollout.
+	ControlOperationRelease ControlOperation = "release"
 )
 
 // ControlRequestStatus is the durable processing status for a control request.
@@ -705,6 +711,17 @@ type ApplyControlRequest struct {
 	CompletedAt  *time.Time
 	CreatedAt    time.Time
 	UpdatedAt    time.Time
+}
+
+// ReleasesPausedRollout reports whether this request latches a rollout paused
+// under on_failure 'pause' open, so the held later deployments may proceed.
+// release is a one-way latch: a release request that is pending or completed
+// releases the rollout; a failed release attempt does not latch, so the rollout
+// stays paused (fail-closed). Any non-release operation never releases.
+func (r *ApplyControlRequest) ReleasesPausedRollout() bool {
+	return r != nil &&
+		r.Operation == ControlOperationRelease &&
+		(r.Status == ControlRequestPending || r.Status == ControlRequestCompleted)
 }
 
 // ApplyOptionsFromMap converts API/proto option strings into typed storage options.

--- a/pkg/storage/types_test.go
+++ b/pkg/storage/types_test.go
@@ -37,6 +37,50 @@ func TestApplyOptionsFromMapRoundTrip(t *testing.T) {
 	}, options.Map())
 }
 
+// TestReleasesPausedRollout verifies the one-way release latch semantics: a
+// pending or completed release request releases a paused rollout, while a
+// failed release, any non-release operation, and a nil request do not (the
+// rollout stays paused — fail-closed).
+func TestReleasesPausedRollout(t *testing.T) {
+	tests := []struct {
+		name string
+		req  *ApplyControlRequest
+		want bool
+	}{
+		{name: "nil request", req: nil, want: false},
+		{
+			name: "pending release latches",
+			req:  &ApplyControlRequest{Operation: ControlOperationRelease, Status: ControlRequestPending},
+			want: true,
+		},
+		{
+			name: "completed release latches",
+			req:  &ApplyControlRequest{Operation: ControlOperationRelease, Status: ControlRequestCompleted},
+			want: true,
+		},
+		{
+			name: "failed release does not latch",
+			req:  &ApplyControlRequest{Operation: ControlOperationRelease, Status: ControlRequestFailed},
+			want: false,
+		},
+		{
+			name: "pending start is not a release",
+			req:  &ApplyControlRequest{Operation: ControlOperationStart, Status: ControlRequestPending},
+			want: false,
+		},
+		{
+			name: "completed stop is not a release",
+			req:  &ApplyControlRequest{Operation: ControlOperationStop, Status: ControlRequestCompleted},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.req.ReleasesPausedRollout())
+		})
+	}
+}
+
 // TestApplyOptionsFromMapIgnoresInvalidVolume verifies that malformed numeric
 // options and out-of-range volumes are ignored instead of being persisted back
 // into apply metadata.

--- a/pkg/tern/local_client_test.go
+++ b/pkg/tern/local_client_test.go
@@ -544,6 +544,16 @@ func (s *testControlRequestStore) GetPending(_ context.Context, applyID int64, o
 	return nil, nil
 }
 
+func (s *testControlRequestStore) GetByOperation(_ context.Context, applyID int64, operation storage.ControlOperation) (*storage.ApplyControlRequest, error) {
+	for _, v := range slices.Backward(s.requests) {
+		req := v
+		if req.ApplyID == applyID && req.Operation == operation {
+			return cloneTestControlRequest(req), nil
+		}
+	}
+	return nil, nil
+}
+
 func (s *testControlRequestStore) CompletePending(_ context.Context, applyID int64, operation storage.ControlOperation) error {
 	for _, req := range s.requests {
 		if req.ApplyID == applyID && req.Operation == operation && req.Status == storage.ControlRequestPending {


### PR DESCRIPTION
## Summary
PR-2 of the `on_failure: pause` workstream. Adds the `release` control-request
vocabulary and a status-agnostic read so later slices can detect when a paused
rollout has been released. Config still rejects `pause`, so this slice is
dormant — nothing activates in production.

## What
- New control op `ControlOperationRelease = "release"`, distinct from `start`.
- `ControlRequestStore.GetByOperation` — reads a control request by
  `(apply_id, operation)` regardless of status (where `GetPending` only sees
  `pending`), so the projection can observe a completed latch.
- `ApplyControlRequest.ReleasesPausedRollout()` — encodes the latch policy in
  one place: a `pending` or `completed` release latches the rollout open; a
  `failed` release (or any non-release op) does not, so the rollout stays
  paused (fail-closed).

## Why
`release` is the human "continue this paused rollout" decision. It must be a
one-way latch that downstream slices (claim predicate, projection, API/CLI) can
read consistently. Reusing `start` would muddy ordering semantics — `start`
resumes stopped work and carries no claim-ordering clause, so it cannot release
a rollout. A dedicated op plus a single shared latch predicate keeps the SQL
gate and operator intent unambiguous.

## Before / after
```
BEFORE — control ops: start | stop | cutover
reads: GetPending (pending only)
a failed earlier sibling under on_failure=pause has no way to be released

   ╭─────────╮  human wants to continue?  ╭──────────────────────╮
   │ paused  │ ─────────────────────────▶ │no release vocabulary │
   ╰─────────╯                            ╰──────────────────────╯
```

```
AFTER — control ops: start | stop | cutover | release
reads: GetPending (pending only) + GetByOperation (any status)
latch policy in ReleasesPausedRollout()

   ╭─────────╮   release (pending/completed)   ╭───────────────────╮
   │ paused  │ ─────────────────────────────▶  │latched → proceed  │
   ╰─────────╯                                 ╰───────────────────╯
        │  release failed / none
        ▼
   ╭─────────╮
   │ paused  │  (fail-closed: stays paused)
   ╰─────────╯
```