### PR TITLE
fix(ux): reduce auto-plan comment noise

### DIFF
--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -535,8 +535,9 @@ func (ic *InstallationClient) fetchPullRequest(ctx context.Context, repo string,
 
 // PRFile represents a file changed in a PR.
 type PRFile struct {
-	Filename string
-	Status   string // added, removed, modified, renamed
+	Filename         string
+	PreviousFilename string
+	Status           string // added, removed, modified, renamed
 }
 
 // GitHub caps pull request file listings at this documented maximum and does
@@ -544,6 +545,10 @@ type PRFile struct {
 // the cap as incomplete so schema discovery fails closed instead of assuming
 // there are no managed schema changes later in the list.
 const maxGitHubPRFiles = 3000
+
+// GitHub includes at most this many changed files on compare responses.
+// Treat reaching the cap as incomplete so comment suppression fails open.
+const maxGitHubCompareFiles = 300
 
 // FetchPRFiles gets the list of files changed in a PR.
 func (ic *InstallationClient) FetchPRFiles(ctx context.Context, repo string, pr int) ([]PRFile, error) {
@@ -573,8 +578,9 @@ func (ic *InstallationClient) FetchPRFiles(ctx context.Context, repo string, pr 
 		}
 		for _, f := range readResult.files {
 			allFiles = append(allFiles, PRFile{
-				Filename: f.GetFilename(),
-				Status:   f.GetStatus(),
+				Filename:         f.GetFilename(),
+				PreviousFilename: f.GetPreviousFilename(),
+				Status:           f.GetStatus(),
 			})
 		}
 		if len(allFiles) >= maxGitHubPRFiles {
@@ -587,6 +593,34 @@ func (ic *InstallationClient) FetchPRFiles(ctx context.Context, repo string, pr 
 	}
 
 	return allFiles, nil
+}
+
+// FetchChangedFilesBetween gets the files changed between two refs.
+func (ic *InstallationClient) FetchChangedFilesBetween(ctx context.Context, repo string, base, head string) ([]PRFile, error) {
+	owner, repoName := splitRepo(repo)
+	readResult, err := retryGitHubUnavailableRead(ctx, ic.logger, "compare commits", []any{"repo", repo, "base", base, "head", head}, func(ctx context.Context) (*gh.CommitsComparison, error) {
+		comparison, _, err := ic.client.Repositories.CompareCommits(ctx, owner, repoName, base, head, nil)
+		if err != nil {
+			return nil, fmt.Errorf("compare commits %s...%s: %w", base, head, classifyGitHubAPIError(err))
+		}
+		return comparison, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	files := make([]PRFile, 0, len(readResult.Files))
+	for _, f := range readResult.Files {
+		files = append(files, PRFile{
+			Filename:         f.GetFilename(),
+			PreviousFilename: f.GetPreviousFilename(),
+			Status:           f.GetStatus(),
+		})
+	}
+	if len(files) >= maxGitHubCompareFiles {
+		return nil, fmt.Errorf("compare commits %s...%s for %s reached GitHub API file limit: %w", base, head, repo, ErrPRFilesIncomplete)
+	}
+	return files, nil
 }
 
 // CheckRunOptions contains options for creating or updating a GitHub Check Run.

--- a/pkg/github/config.go
+++ b/pkg/github/config.go
@@ -394,6 +394,21 @@ func isSchemaFile(filename string) bool {
 	return strings.HasSuffix(filename, ".sql") || strings.HasSuffix(filename, "vschema.json")
 }
 
+// HasSchemaInputFiles reports whether a changed file list touches inputs that
+// should refresh the visible SchemaBot plan.
+func HasSchemaInputFiles(files []PRFile) bool {
+	for _, file := range files {
+		if isSchemaInputFile(file.Filename) || isSchemaInputFile(file.PreviousFilename) {
+			return true
+		}
+	}
+	return false
+}
+
+func isSchemaInputFile(filename string) bool {
+	return isSchemaFile(filename) || isConfigFile(filename)
+}
+
 func isConfigFile(filename string) bool {
 	return path.Base(filename) == ConfigFileName
 }

--- a/pkg/github/config_test.go
+++ b/pkg/github/config_test.go
@@ -35,6 +35,50 @@ environments:
 	assert.Contains(t, err.Error(), "field environments not found")
 }
 
+func TestHasSchemaInputFiles(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		files []PRFile
+		want  bool
+	}{
+		{
+			name:  "schema SQL file",
+			files: []PRFile{{Filename: "schema/users.sql", Status: "modified"}},
+			want:  true,
+		},
+		{
+			name:  "VSchema file",
+			files: []PRFile{{Filename: "schema/main/vschema.json", Status: "modified"}},
+			want:  true,
+		},
+		{
+			name:  "SchemaBot config file",
+			files: []PRFile{{Filename: "schema/schemabot.yaml", Status: "modified"}},
+			want:  true,
+		},
+		{
+			name:  "renamed schema file",
+			files: []PRFile{{Filename: "docs/users.md", PreviousFilename: "schema/users.sql", Status: "renamed"}},
+			want:  true,
+		},
+		{
+			name:  "application file",
+			files: []PRFile{{Filename: "app/service.go", Status: "modified"}},
+			want:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.want, HasSchemaInputFiles(tt.files))
+		})
+	}
+}
+
 func TestFindAllConfigsForPRClassifiesGitHubUnavailable(t *testing.T) {
 	setGitHubUnavailableReadRetryDelay(t, time.Millisecond)
 

--- a/pkg/webhook/check_run.go
+++ b/pkg/webhook/check_run.go
@@ -115,7 +115,7 @@ func (h *Handler) handleCheckRun(w http.ResponseWriter, body []byte) {
 		"check_run_id", payload.CheckRun.ID,
 		"check_name", payload.CheckRun.Name)
 
-	message := h.runAutoPlanForPR(ctx, client, repo, pr, payload.CheckRun.HeadSHA, installationID, "check_run.rerequested", true)
+	message := h.runAutoPlanForPR(ctx, client, repo, pr, payload.CheckRun.HeadSHA, installationID, "check_run.rerequested", "check_run.rerequested", "")
 
 	h.writeJSON(w, http.StatusOK, map[string]string{"message": message})
 }

--- a/pkg/webhook/check_run.go
+++ b/pkg/webhook/check_run.go
@@ -115,7 +115,7 @@ func (h *Handler) handleCheckRun(w http.ResponseWriter, body []byte) {
 		"check_run_id", payload.CheckRun.ID,
 		"check_name", payload.CheckRun.Name)
 
-	message := h.runAutoPlanForPR(ctx, client, repo, pr, payload.CheckRun.HeadSHA, installationID, "check_run.rerequested")
+	message := h.runAutoPlanForPR(ctx, client, repo, pr, payload.CheckRun.HeadSHA, installationID, "check_run.rerequested", true)
 
 	h.writeJSON(w, http.StatusOK, map[string]string{"message": message})
 }

--- a/pkg/webhook/issue_comment.go
+++ b/pkg/webhook/issue_comment.go
@@ -154,7 +154,7 @@ func (h *Handler) handleIssueComment(ctx context.Context, metricApp string, w ht
 			// Plan without -e: run for all configured environments
 			h.logger.Info("plan without -e flag", "repo", repo, "pr", pr)
 			h.goSafe(repo, pr, installationID, func() {
-				h.handleMultiEnvPlan(repo, pr, result.Database, result.Tenant, installationID, requestedBy, false)
+				h.handleMultiEnvPlan(repo, pr, result.Database, result.Tenant, installationID, requestedBy, false, true)
 			})
 			h.writeJSON(w, http.StatusOK, map[string]string{"message": "multi-env plan started"})
 			return

--- a/pkg/webhook/plan.go
+++ b/pkg/webhook/plan.go
@@ -138,7 +138,7 @@ func (h *Handler) handlePlanCommand(w http.ResponseWriter, repo string, pr int, 
 
 // handleMultiEnvPlan runs plan for all configured environments and posts a single combined comment.
 // When isAutoPlan is true and no environments have changes or errors, the comment is skipped to reduce PR noise.
-func (h *Handler) handleMultiEnvPlan(repo string, pr int, databaseName, tenant string, installationID int64, requestedBy string, isAutoPlan bool) {
+func (h *Handler) handleMultiEnvPlan(repo string, pr int, databaseName, tenant string, installationID int64, requestedBy string, isAutoPlan bool, postPlanComment bool) {
 	ctx, cancel, client, err := h.commandBootstrap(repo, installationID)
 	if err != nil {
 		h.logger.Error("multi-env plan: failed to bootstrap command", "error", err)
@@ -342,6 +342,11 @@ func (h *Handler) handleMultiEnvPlan(repo string, pr int, databaseName, tenant s
 			h.logger.Info("auto-plan: no changes detected, skipping comment", "repo", repo, "pr", pr)
 			return
 		}
+	}
+
+	if !postPlanComment {
+		h.logger.Info("auto-plan refreshed checks without posting plan comment", "repo", repo, "pr", pr, "database", multiEnvData.Database)
+		return
 	}
 
 	// Post a single combined comment

--- a/pkg/webhook/pull_request.go
+++ b/pkg/webhook/pull_request.go
@@ -101,8 +101,7 @@ func (h *Handler) handlePullRequest(ctx context.Context, metricApp string, w htt
 	}
 	defer cancel()
 
-	postPlanComment := h.shouldPostAutoPlanComment(ctx, client, payload.Action, repo, pr, payload.Before, headSHA)
-	message := h.runAutoPlanForPR(ctx, client, repo, pr, headSHA, installationID, "pull_request", postPlanComment)
+	message := h.runAutoPlanForPR(ctx, client, repo, pr, headSHA, installationID, "pull_request", payload.Action, payload.Before)
 	h.writeJSON(w, http.StatusOK, map[string]string{"message": message})
 }
 
@@ -142,7 +141,7 @@ func (h *Handler) shouldPostAutoPlanComment(ctx context.Context, client *ghclien
 	return false
 }
 
-func (h *Handler) runAutoPlanForPR(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, headSHA string, installationID int64, source string, postPlanComment bool) string {
+func (h *Handler) runAutoPlanForPR(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, headSHA string, installationID int64, source string, action string, beforeSHA string) string {
 	// Discover all configs matching changed schema files in this PR
 	configs, err := client.FindAllConfigsForPR(ctx, repo, pr)
 	if err != nil {
@@ -184,6 +183,7 @@ func (h *Handler) runAutoPlanForPR(ctx context.Context, client *ghclient.Install
 		})
 		return "no schema files in PR"
 	}
+	postPlanComment := h.shouldPostAutoPlanComment(ctx, client, action, repo, pr, beforeSHA, headSHA)
 
 	// Launch auto-plan for each discovered config
 	for _, cfg := range configs {

--- a/pkg/webhook/pull_request.go
+++ b/pkg/webhook/pull_request.go
@@ -16,6 +16,7 @@ import (
 // pullRequestPayload represents the relevant fields from a GitHub pull_request webhook.
 type pullRequestPayload struct {
 	Action      string `json:"action"`
+	Before      string `json:"before"`
 	PullRequest struct {
 		Number int `json:"number"`
 		Head   struct {
@@ -100,7 +101,8 @@ func (h *Handler) handlePullRequest(ctx context.Context, metricApp string, w htt
 	}
 	defer cancel()
 
-	message := h.runAutoPlanForPR(ctx, client, repo, pr, headSHA, installationID, "pull_request")
+	postPlanComment := h.shouldPostAutoPlanComment(ctx, client, payload.Action, repo, pr, payload.Before, headSHA)
+	message := h.runAutoPlanForPR(ctx, client, repo, pr, headSHA, installationID, "pull_request", postPlanComment)
 	h.writeJSON(w, http.StatusOK, map[string]string{"message": message})
 }
 
@@ -117,7 +119,30 @@ func (h *Handler) autoPlanBootstrap(repo string, installationID int64) (context.
 	return ctx, cancel, client, nil
 }
 
-func (h *Handler) runAutoPlanForPR(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, headSHA string, installationID int64, source string) string {
+func (h *Handler) shouldPostAutoPlanComment(ctx context.Context, client *ghclient.InstallationClient, action, repo string, pr int, beforeSHA, headSHA string) bool {
+	if action != "synchronize" {
+		return true
+	}
+	if beforeSHA == "" {
+		h.logger.Info("auto-plan will post plan comment because synchronize payload has no previous HEAD SHA",
+			"repo", repo, "pr", pr, "head_sha", headSHA)
+		return true
+	}
+	files, err := client.FetchChangedFilesBetween(ctx, repo, beforeSHA, headSHA)
+	if err != nil {
+		h.logger.Warn("auto-plan will post plan comment because changed files could not be compared",
+			"repo", repo, "pr", pr, "before_sha", beforeSHA, "head_sha", headSHA, "error", err)
+		return true
+	}
+	if ghclient.HasSchemaInputFiles(files) {
+		return true
+	}
+	h.logger.Info("auto-plan will refresh checks without posting a plan comment because synchronize changed no schema inputs",
+		"repo", repo, "pr", pr, "before_sha", beforeSHA, "head_sha", headSHA)
+	return false
+}
+
+func (h *Handler) runAutoPlanForPR(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, headSHA string, installationID int64, source string, postPlanComment bool) string {
 	// Discover all configs matching changed schema files in this PR
 	configs, err := client.FindAllConfigsForPR(ctx, repo, pr)
 	if err != nil {
@@ -164,7 +189,7 @@ func (h *Handler) runAutoPlanForPR(ctx context.Context, client *ghclient.Install
 	for _, cfg := range configs {
 		database := cfg.Config.Database
 		h.goSafe(repo, pr, installationID, func() {
-			h.handleMultiEnvPlan(repo, pr, database, "", installationID, "", true)
+			h.handleMultiEnvPlan(repo, pr, database, "", installationID, "", true, postPlanComment)
 		})
 	}
 

--- a/pkg/webhook/testhelpers_test.go
+++ b/pkg/webhook/testhelpers_test.go
@@ -43,9 +43,10 @@ func setupGitHubServer(t *testing.T) (*gh.Client, *http.ServeMux) {
 
 // prWebhookPayloadOpts configures how buildPRWebhookRequest constructs the payload.
 type prWebhookPayloadOpts struct {
-	action  string // "opened", "synchronize", "reopened", "closed", etc.
-	headSHA string
-	headRef string
+	action    string // "opened", "synchronize", "reopened", "closed", etc.
+	beforeSHA string
+	headSHA   string
+	headRef   string
 }
 
 type checkRunWebhookPayloadOpts struct {
@@ -87,6 +88,9 @@ func buildPRWebhookRequest(t *testing.T, opts prWebhookPayloadOpts, secret []byt
 		"installation": map[string]any{
 			"id": 12345,
 		},
+	}
+	if opts.beforeSHA != "" {
+		payload["before"] = opts.beforeSHA
 	}
 
 	body, err := json.Marshal(payload)

--- a/pkg/webhook/webhook_e2e_test.go
+++ b/pkg/webhook/webhook_e2e_test.go
@@ -531,6 +531,14 @@ func setupFakeGitHubForPlanWithPRFiles(t *testing.T, mux *http.ServeMux, schemaS
 	return result
 }
 
+func registerCompareFiles(t *testing.T, mux *http.ServeMux, baseSHA, headSHA string, files []*gh.CommitFile) {
+	t.Helper()
+
+	mux.HandleFunc("GET /repos/octocat/hello-world/compare/"+baseSHA+"..."+headSHA, func(w http.ResponseWriter, _ *http.Request) {
+		require.NoError(t, json.NewEncoder(w).Encode(gh.CommitsComparison{Files: files}))
+	})
+}
+
 func TestE2EPlanWithChanges(t *testing.T) {
 	dbName := "webhook_plan_changes"
 	svc := setupE2EService(t, dbName)
@@ -1019,6 +1027,65 @@ func TestE2EAutoPlan(t *testing.T) {
 		assert.Equal(t, "action_required", cr.Conclusion)
 	case <-time.After(10 * time.Second):
 		t.Fatal("timed out waiting for check run")
+	}
+}
+
+// A push that only changes non-schema inputs still refreshes SchemaBot checks
+// for the new PR commit without adding another plan comment to the PR timeline.
+func TestE2EAutoPlanSynchronizeApplicationOnlyChangeSkipsComment(t *testing.T) {
+	dbName := "webhook_autoplan_app_only_sync"
+	svc := setupE2EService(t, dbName)
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	client := gh.NewClient(nil)
+	client.BaseURL, _ = url.Parse(server.URL + "/")
+
+	schemabotConfig := fmt.Sprintf("database: %s\ntype: mysql\n", dbName)
+	schemaFiles := map[string]string{
+		"users.sql": "CREATE TABLE `users` (\n  `id` bigint unsigned NOT NULL AUTO_INCREMENT,\n  `name` varchar(255) NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;",
+	}
+
+	result := setupFakeGitHubForPlan(t, mux, schemaFiles, schemabotConfig, dbName)
+	registerCompareFiles(t, mux, "oldsha", "newsha", []*gh.CommitFile{{
+		Filename: new("app/service.go"),
+		Status:   new("modified"),
+	}})
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	installClient := ghclient.NewInstallationClient(client, logger)
+	factory := &fakeClientFactory{client: installClient}
+
+	h := NewHandler(svc, factory, nil, logger)
+
+	req := buildPRWebhookRequest(t, prWebhookPayloadOpts{
+		action:    "synchronize",
+		beforeSHA: "oldsha",
+		headSHA:   "newsha",
+		headRef:   "feature-branch",
+	}, nil)
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), "auto-plan started")
+
+	select {
+	case cr := <-result.checkRuns:
+		assert.Contains(t, cr.Name, "SchemaBot")
+		assert.Equal(t, "completed", cr.Status)
+		assert.Equal(t, "action_required", cr.Conclusion)
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for check run")
+	}
+
+	select {
+	case body := <-result.comments:
+		t.Fatalf("expected no comment for application-only synchronize, got: %s", body)
+	case <-time.After(3 * time.Second):
 	}
 }
 


### PR DESCRIPTION
## Why
Repeated auto-plan comments make active PRs noisy when authors push non-schema follow-up commits after a schema change is already present.

## What
- Suppress visible auto-plan comments on synchronize events that only touch non-schema inputs
- Keep auto-plan check refresh behavior unchanged for new PR commits
- Treat SQL files, VSchema files, and `schemabot.yaml` as schema inputs that still refresh the visible plan

## Risk Assessment
Low — this only suppresses PR comment creation for application-only synchronize events. Check Run refreshes still execute, and compare uncertainty fails open by posting the plan comment.

Generated with Amp
