### PR TITLE
feat(storage): exempt released paused rollouts in the claim predicate

### DIFF
--- a/pkg/storage/mysqlstore/apply_operations.go
+++ b/pkg/storage/mysqlstore/apply_operations.go
@@ -506,6 +506,48 @@ func (s *applyOperationStore) GetEngineResumeState(ctx context.Context, operatio
 // heartbeat staleness in applies.go.
 const applyOperationHeartbeatStaleness = "1 MINUTE"
 
+// releasedFailureExemptionSQL stops a terminal-failed earlier sibling from
+// blocking a later deployment's claim once the rollout policy says to keep
+// going: on_failure='continue', or on_failure='pause' after a release control
+// request latches the rollout open. A release latches while pending or
+// completed; a failed release does not (fail-closed), mirroring
+// storage.ApplyControlRequest.ReleasesPausedRollout. Only terminal `failed` is
+// exempted — in-flight or recoverable earlier siblings still block. The
+// fragment references the apply_operations and earlier aliases, so the copy
+// claim (FindNextApplyOperation) and the cutover claim
+// (FindNextApplyOperationCutover) embed it identically. Placeholders, in order:
+// earlier-failed state, continue, pause, release operation, pending, completed
+// (see releasedFailureExemptionArgs).
+const releasedFailureExemptionSQL = `NOT (
+	earlier.state = ?
+	AND (
+		apply_operations.on_failure = ?
+		OR (
+			apply_operations.on_failure = ?
+			AND EXISTS (
+				SELECT 1
+				FROM apply_control_requests AS release_req
+				WHERE release_req.apply_id = apply_operations.apply_id
+					AND release_req.operation = ?
+					AND release_req.status IN (?, ?)
+			)
+		)
+	)
+)`
+
+// releasedFailureExemptionArgs returns the positional arguments for
+// releasedFailureExemptionSQL, in placeholder order.
+func releasedFailureExemptionArgs() []any {
+	return []any{
+		state.ApplyOperation.Failed,
+		storage.OnFailureContinue,
+		storage.OnFailurePause,
+		storage.ControlOperationRelease,
+		storage.ControlRequestPending,
+		storage.ControlRequestCompleted,
+	}
+}
+
 // FindNextApplyOperation atomically claims the next apply_operations row that
 // needs attention and refreshes its heartbeat in the same transaction.
 //
@@ -544,11 +586,14 @@ const applyOperationHeartbeatStaleness = "1 MINUTE"
 // earlier sibling blocking every later sibling, so the rollout halts on the
 // first failure. "continue" treats a terminal `failed` earlier sibling as
 // settled so it no longer blocks: later deployments are still claimed and
-// attempted. Only terminal `failed` is exempted — pending, running,
-// failed_retryable, and stopped earlier siblings still block under both
+// attempted. "pause" holds the rollout like "halt" until an operator releases
+// it; once a release control request latches the apply open (pending or
+// completed), a terminal-failed earlier sibling stops blocking and the rollout
+// proceeds like "continue". Only terminal `failed` is exempted — pending,
+// running, failed_retryable, and stopped earlier siblings still block under all
 // policies (work is in-flight or recoverable). The policy governs only rollout
 // continuation; the apply's pass/fail verdict and the merge gate stay
-// fail-closed on any failed deployment.
+// fail-closed on any failed deployment. See releasedFailureExemptionSQL.
 //
 // A pending stop control request layers a hard halt on top: while a stop is
 // pending for the apply, no pending sibling is claimable for start, regardless
@@ -593,9 +638,9 @@ func (s *applyOperationStore) FindNextApplyOperation(ctx context.Context, owner 
 	// the blocking EXISTS true and its copy starts immediately (concurrent copy).
 	// Under rolling — and any unrecognized value, which fails closed to the
 	// serial gate via NOT IN (barrier, parallel) — only a completed earlier
-	// sibling stops blocking. The trailing on_failure/Failed pair drives the
-	// exemption: when the policy is "continue", a terminal-failed earlier sibling
-	// no longer blocks later ones.
+	// sibling stops blocking. The trailing releasedFailureExemptionArgs drive the
+	// exemption: a terminal-failed earlier sibling no longer blocks later ones
+	// under "continue", or under "pause" once a release latches the rollout open.
 	queryArgs = append(queryArgs,
 		storage.CutoverPolicyBarrier,
 		state.ApplyOperation.WaitingForCutover,
@@ -605,9 +650,8 @@ func (s *applyOperationStore) FindNextApplyOperation(ctx context.Context, owner 
 		storage.CutoverPolicyBarrier,
 		storage.CutoverPolicyParallel,
 		state.ApplyOperation.Completed,
-		storage.OnFailureContinue,
-		state.ApplyOperation.Failed,
 	)
+	queryArgs = append(queryArgs, releasedFailureExemptionArgs()...)
 	queryArgs = append(queryArgs,
 		storage.ApplyOperationKindGroupFinalizer,
 		storage.ApplyOperationKindWork,
@@ -717,7 +761,7 @@ func (s *applyOperationStore) FindNextApplyOperation(ctx context.Context, owner 
 										AND earlier.state <> ?
 									)
 								)
-								AND NOT (apply_operations.on_failure = ? AND earlier.state = ?)
+								AND `+releasedFailureExemptionSQL+`
 						)
 					)
 					OR (
@@ -1036,15 +1080,16 @@ func (s *applyOperationStore) FindNextApplyOperationCutover(ctx context.Context,
 	queryArgs := []any{storage.CutoverPolicyBarrier, storage.CutoverPolicyParallel}
 	// Start-a-parked-cutover gate (see SQL below). A waiting_for_cutover row is
 	// claimable only when no earlier deployment_order sibling is still
-	// non-completed; the on_failure/Failed pair is the "continue" exemption (a
-	// terminal-failed earlier sibling no longer blocks later cutovers), and the
-	// pending-stop NOT EXISTS makes `stop` halt remaining cutovers even under
-	// "continue".
+	// non-completed; releasedFailureExemptionArgs exempt a terminal-failed earlier
+	// sibling so it no longer blocks later cutovers under "continue", or under
+	// "pause" once a release latches the rollout open; and the pending-stop NOT
+	// EXISTS makes `stop` halt remaining cutovers even under those exemptions.
 	queryArgs = append(queryArgs,
 		state.ApplyOperation.WaitingForCutover,
 		state.ApplyOperation.Completed,
-		storage.OnFailureContinue,
-		state.ApplyOperation.Failed,
+	)
+	queryArgs = append(queryArgs, releasedFailureExemptionArgs()...)
+	queryArgs = append(queryArgs,
 		storage.ControlOperationStop, storage.ControlRequestPending,
 	)
 	// Recovery clause: a row already mid-cutover whose heartbeat has gone stale is
@@ -1080,7 +1125,7 @@ func (s *applyOperationStore) FindNextApplyOperationCutover(ctx context.Context,
 					WHERE earlier.apply_id = apply_operations.apply_id
 						AND (earlier.created_at, earlier.id) < (apply_operations.created_at, apply_operations.id)
 						AND earlier.state <> ?
-						AND NOT (apply_operations.on_failure = ? AND earlier.state = ?)
+						AND `+releasedFailureExemptionSQL+`
 				)
 				AND NOT EXISTS (
 					SELECT 1

--- a/pkg/storage/mysqlstore/apply_operations_test.go
+++ b/pkg/storage/mysqlstore/apply_operations_test.go
@@ -2236,11 +2236,12 @@ func TestApplyOperationStore_FindNextApplyOperation_OnFailureContinueStillBlocks
 }
 
 // TestApplyOperationStore_FindNextApplyOperation_UnrecognizedOnFailureBlocksFailedSibling
-// pins the fail-closed property of the claim predicate: only the exact value
-// "continue" exempts a terminal-failed earlier sibling. Any other stored value
-// — here "pause", which config validation rejects today but a future change or
-// a hand-written row could let reach storage — must keep the failed sibling
-// blocking so the rollout never races ahead on an unrecognized policy.
+// pins the fail-closed property of the claim predicate: only the recognized
+// continuation policies ("continue", or "pause" once released) exempt a
+// terminal-failed earlier sibling. Any other stored value — an unknown policy a
+// future change or a hand-written row could let reach storage — must keep the
+// failed sibling blocking so the rollout never races ahead on a policy the gate
+// does not understand.
 func TestApplyOperationStore_FindNextApplyOperation_UnrecognizedOnFailureBlocksFailedSibling(t *testing.T) {
 	clearTables(t)
 	ctx := t.Context()
@@ -2249,15 +2250,17 @@ func TestApplyOperationStore_FindNextApplyOperation_UnrecognizedOnFailureBlocksF
 	lock := createTestLock(t, store, "testdb", "mysql", "staging")
 	apply := createTestApply(t, store, lock, "apply_op_unrecognized", 1)
 
+	const unknownPolicy = "escalate"
+
 	// region-a failed; region-b is pending behind it. The failed row carries an
-	// unrecognized on_failure value, so the exemption (which keys on exact
-	// "continue") does not apply and the failed sibling keeps blocking.
+	// unrecognized on_failure value, so neither exemption applies and the failed
+	// sibling keeps blocking.
 	failedID, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
-		ApplyID: apply.ID, Deployment: "region-a", State: state.ApplyOperation.Failed, OnFailure: storage.OnFailurePause,
+		ApplyID: apply.ID, Deployment: "region-a", State: state.ApplyOperation.Failed, OnFailure: unknownPolicy,
 	})
 	require.NoError(t, err)
 	_, err = store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
-		ApplyID: apply.ID, Deployment: "region-b", OnFailure: storage.OnFailurePause,
+		ApplyID: apply.ID, Deployment: "region-b", OnFailure: unknownPolicy,
 	})
 	require.NoError(t, err)
 
@@ -2265,7 +2268,7 @@ func TestApplyOperationStore_FindNextApplyOperation_UnrecognizedOnFailureBlocksF
 	// known enum on the way into storage.
 	failedRow, err := store.ApplyOperations().Get(ctx, failedID)
 	require.NoError(t, err)
-	assert.Equal(t, storage.OnFailurePause, failedRow.OnFailure, "an unrecognized on_failure value is stored as-is")
+	assert.Equal(t, unknownPolicy, failedRow.OnFailure, "an unrecognized on_failure value is stored as-is")
 
 	// Backdate the failed row so staleness can't be the reason it's skipped —
 	// the only thing holding the rollout is the earlier failed sibling.
@@ -2277,6 +2280,180 @@ func TestApplyOperationStore_FindNextApplyOperation_UnrecognizedOnFailureBlocksF
 	claimed, err := store.ApplyOperations().FindNextApplyOperation(ctx, "test-operator")
 	require.NoError(t, err)
 	assert.Nil(t, claimed, "an unrecognized on_failure value must fail closed and keep the failed sibling blocking")
+}
+
+// TestApplyOperationStore_FindNextApplyOperation_OnFailurePauseBlocksUntilReleased
+// verifies that on_failure "pause" holds the rollout like "halt" until a human
+// releases it: a terminal-failed earlier sibling keeps later deployments
+// blocked while no release control request exists for the apply.
+func TestApplyOperationStore_FindNextApplyOperation_OnFailurePauseBlocksUntilReleased(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", "mysql", "staging")
+	apply := createTestApply(t, store, lock, "apply_op_pause_blocks", 1)
+
+	failedID, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-a", State: state.ApplyOperation.Failed, OnFailure: storage.OnFailurePause,
+	})
+	require.NoError(t, err)
+	for _, deployment := range []string{"region-b", "region-c"} {
+		_, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+			ApplyID: apply.ID, Deployment: deployment, OnFailure: storage.OnFailurePause,
+		})
+		require.NoError(t, err)
+	}
+
+	// Backdate the failed row so staleness can't be the reason it's skipped —
+	// the only thing holding the rollout is the unreleased pause.
+	_, err = testDB.ExecContext(ctx, `
+		UPDATE apply_operations SET updated_at = NOW() - INTERVAL 1 HOUR WHERE id = ?
+	`, failedID)
+	require.NoError(t, err)
+
+	claimed, err := store.ApplyOperations().FindNextApplyOperation(ctx, "test-operator")
+	require.NoError(t, err)
+	assert.Nil(t, claimed, "on_failure pause must keep later siblings blocked until released")
+}
+
+// TestApplyOperationStore_FindNextApplyOperation_OnFailurePauseClaimsPastFailedSiblingAfterRelease
+// verifies the released-failure exemption: once a release control request
+// latches a paused apply open, a terminal-failed earlier sibling stops blocking
+// and the rollout proceeds to the next ordered deployment, exactly like
+// "continue".
+func TestApplyOperationStore_FindNextApplyOperation_OnFailurePauseClaimsPastFailedSiblingAfterRelease(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", "mysql", "staging")
+	apply := createTestApply(t, store, lock, "apply_op_pause_release", 1)
+
+	failedID, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-a", State: state.ApplyOperation.Failed, OnFailure: storage.OnFailurePause,
+	})
+	require.NoError(t, err)
+	for _, deployment := range []string{"region-b", "region-c"} {
+		_, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+			ApplyID: apply.ID, Deployment: deployment, OnFailure: storage.OnFailurePause,
+		})
+		require.NoError(t, err)
+	}
+
+	_, err = testDB.ExecContext(ctx, `
+		UPDATE apply_operations SET updated_at = NOW() - INTERVAL 1 HOUR WHERE id = ?
+	`, failedID)
+	require.NoError(t, err)
+
+	// Without a release the rollout is held.
+	held, err := store.ApplyOperations().FindNextApplyOperation(ctx, "test-operator")
+	require.NoError(t, err)
+	require.Nil(t, held, "the paused rollout must be held before a release exists")
+
+	// A pending release latches the apply open.
+	_, _, err = store.ControlRequests().RequestPending(ctx, &storage.ApplyControlRequest{
+		ApplyID:     apply.ID,
+		Operation:   storage.ControlOperationRelease,
+		Status:      storage.ControlRequestPending,
+		RequestedBy: "operator",
+	})
+	require.NoError(t, err)
+
+	claimed, err := store.ApplyOperations().FindNextApplyOperation(ctx, "test-operator")
+	require.NoError(t, err)
+	require.NotNil(t, claimed, "a released pause must let the rollout proceed past a failed sibling")
+	assert.Equal(t, "region-b", claimed.Deployment, "the next ordered deployment after the failed one is claimed")
+
+	stored, err := store.ApplyOperations().Get(ctx, claimed.ID)
+	require.NoError(t, err)
+	assert.Equal(t, state.ApplyOperation.Running, stored.State, "the claimed pending row is transitioned to running")
+}
+
+// TestApplyOperationStore_FindNextApplyOperation_OnFailurePauseFailedReleaseStaysBlocked
+// verifies the latch is fail-closed: a release control request that itself
+// failed does not exempt the failed sibling, so the rollout stays paused until
+// a release actually succeeds.
+func TestApplyOperationStore_FindNextApplyOperation_OnFailurePauseFailedReleaseStaysBlocked(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", "mysql", "staging")
+	apply := createTestApply(t, store, lock, "apply_op_pause_failed_release", 1)
+
+	failedID, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-a", State: state.ApplyOperation.Failed, OnFailure: storage.OnFailurePause,
+	})
+	require.NoError(t, err)
+	_, err = store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-b", OnFailure: storage.OnFailurePause,
+	})
+	require.NoError(t, err)
+
+	_, err = testDB.ExecContext(ctx, `
+		UPDATE apply_operations SET updated_at = NOW() - INTERVAL 1 HOUR WHERE id = ?
+	`, failedID)
+	require.NoError(t, err)
+
+	_, _, err = store.ControlRequests().RequestPending(ctx, &storage.ApplyControlRequest{
+		ApplyID:     apply.ID,
+		Operation:   storage.ControlOperationRelease,
+		Status:      storage.ControlRequestPending,
+		RequestedBy: "operator",
+	})
+	require.NoError(t, err)
+	require.NoError(t, store.ControlRequests().FailPending(ctx, apply.ID, storage.ControlOperationRelease, "remote release failed"))
+
+	claimed, err := store.ApplyOperations().FindNextApplyOperation(ctx, "test-operator")
+	require.NoError(t, err)
+	assert.Nil(t, claimed, "a failed release must not latch the rollout open")
+}
+
+// TestApplyOperationStore_FindNextApplyOperation_OnFailurePauseReleaseStillBlockedByStop
+// verifies that `stop` dominates `release`: even after a paused apply is
+// released, a pending stop control request keeps the next pending sibling from
+// being claimed, so an operator can abort a rollout they just released.
+func TestApplyOperationStore_FindNextApplyOperation_OnFailurePauseReleaseStillBlockedByStop(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", "mysql", "staging")
+	apply := createTestApply(t, store, lock, "apply_op_pause_release_stop", 1)
+
+	failedID, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-a", State: state.ApplyOperation.Failed, OnFailure: storage.OnFailurePause,
+	})
+	require.NoError(t, err)
+	_, err = store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-b", OnFailure: storage.OnFailurePause,
+	})
+	require.NoError(t, err)
+
+	_, err = testDB.ExecContext(ctx, `
+		UPDATE apply_operations SET updated_at = NOW() - INTERVAL 1 HOUR WHERE id = ?
+	`, failedID)
+	require.NoError(t, err)
+
+	_, _, err = store.ControlRequests().RequestPending(ctx, &storage.ApplyControlRequest{
+		ApplyID:     apply.ID,
+		Operation:   storage.ControlOperationRelease,
+		Status:      storage.ControlRequestPending,
+		RequestedBy: "operator",
+	})
+	require.NoError(t, err)
+	_, _, err = store.ControlRequests().RequestPending(ctx, &storage.ApplyControlRequest{
+		ApplyID:     apply.ID,
+		Operation:   storage.ControlOperationStop,
+		Status:      storage.ControlRequestPending,
+		RequestedBy: "operator",
+	})
+	require.NoError(t, err)
+
+	claimed, err := store.ApplyOperations().FindNextApplyOperation(ctx, "test-operator")
+	require.NoError(t, err)
+	assert.Nil(t, claimed, "a pending stop must dominate a release and keep the pending sibling blocked")
 }
 
 // TestApplyOperationStore_FindNextApplyOperation_BarrierClaimsPastSiblingAtCutoverBarrier
@@ -2878,6 +3055,93 @@ func TestApplyOperationStore_FindNextApplyOperationCutover_OnFailureContinueClai
 	require.NoError(t, err)
 	require.NotNil(t, claimed, "on_failure continue must let the cutover proceed past a failed sibling")
 	assert.Equal(t, "region-b", claimed.Deployment)
+
+	persisted, err := store.ApplyOperations().Get(ctx, claimed.ID)
+	require.NoError(t, err)
+	assert.Equal(t, state.ApplyOperation.CuttingOver, persisted.State, "the claimed parked row is transitioned to cutting_over")
+}
+
+// TestApplyOperationStore_FindNextApplyOperationCutover_OnFailurePauseBlocksUntilReleased
+// verifies the cutover gate mirrors the copy gate under "pause": a
+// terminal-failed earlier sibling keeps a later parked cutover blocked while no
+// release control request exists for the apply.
+func TestApplyOperationStore_FindNextApplyOperationCutover_OnFailurePauseBlocksUntilReleased(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", "mysql", "staging")
+	apply := createTestApply(t, store, lock, "apply_op_cutover_pause_blocks", 1)
+
+	failedID, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-a",
+		State: state.ApplyOperation.Failed, OnFailure: storage.OnFailurePause,
+		CutoverPolicy: storage.CutoverPolicyBarrier,
+	})
+	require.NoError(t, err)
+	_, err = store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-b",
+		State: state.ApplyOperation.WaitingForCutover, OnFailure: storage.OnFailurePause,
+		CutoverPolicy: storage.CutoverPolicyBarrier,
+	})
+	require.NoError(t, err)
+
+	_, err = testDB.ExecContext(ctx, `
+		UPDATE apply_operations SET updated_at = NOW() - INTERVAL 1 HOUR WHERE id = ?
+	`, failedID)
+	require.NoError(t, err)
+
+	claimed, err := store.ApplyOperations().FindNextApplyOperationCutover(ctx, "cutover-operator")
+	require.NoError(t, err)
+	assert.Nil(t, claimed, "on_failure pause must keep a later cutover blocked until released")
+}
+
+// TestApplyOperationStore_FindNextApplyOperationCutover_OnFailurePauseClaimsPastFailedSiblingAfterRelease
+// verifies the released-failure exemption applies to the cutover gate too: once
+// a release control request (here already completed) latches the paused apply
+// open, the failed earlier sibling stops blocking and the parked cutover is
+// claimed.
+func TestApplyOperationStore_FindNextApplyOperationCutover_OnFailurePauseClaimsPastFailedSiblingAfterRelease(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", "mysql", "staging")
+	apply := createTestApply(t, store, lock, "apply_op_cutover_pause_release", 1)
+
+	failedID, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-a",
+		State: state.ApplyOperation.Failed, OnFailure: storage.OnFailurePause,
+		CutoverPolicy: storage.CutoverPolicyBarrier,
+	})
+	require.NoError(t, err)
+	parkedID, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-b",
+		State: state.ApplyOperation.WaitingForCutover, OnFailure: storage.OnFailurePause,
+		CutoverPolicy: storage.CutoverPolicyBarrier,
+	})
+	require.NoError(t, err)
+
+	_, err = testDB.ExecContext(ctx, `
+		UPDATE apply_operations SET updated_at = NOW() - INTERVAL 1 HOUR WHERE id = ?
+	`, failedID)
+	require.NoError(t, err)
+
+	// A completed release latches the apply open just as a pending one does.
+	_, _, err = store.ControlRequests().RequestPending(ctx, &storage.ApplyControlRequest{
+		ApplyID:     apply.ID,
+		Operation:   storage.ControlOperationRelease,
+		Status:      storage.ControlRequestPending,
+		RequestedBy: "operator",
+	})
+	require.NoError(t, err)
+	require.NoError(t, store.ControlRequests().CompletePending(ctx, apply.ID, storage.ControlOperationRelease))
+
+	claimed, err := store.ApplyOperations().FindNextApplyOperationCutover(ctx, "cutover-operator")
+	require.NoError(t, err)
+	require.NotNil(t, claimed, "a released pause must let the cutover proceed past a failed sibling")
+	assert.Equal(t, "region-b", claimed.Deployment)
+	assert.Equal(t, parkedID, claimed.ID)
 
 	persisted, err := store.ApplyOperations().Get(ctx, claimed.ID)
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary
Teaches the apply-operation claim predicate to honor the release latch added in the previous slice: under `on_failure: pause`, a terminal-failed earlier sibling stops blocking later deployments once an operator releases the rollout, mirroring `continue`. Still dormant — config keeps rejecting `pause`.

## What
- Adds a shared `releasedFailureExemptionSQL` fragment (+ `releasedFailureExemptionArgs`) embedded identically in both the copy claim (`FindNextApplyOperation`) and the cutover claim (`FindNextApplyOperationCutover`).
- A terminal `failed` earlier sibling is exempted when the policy is `continue`, or `pause` once a `release` control request is pending or completed.

## Why
The prior slice added the release control op and `ReleasesPausedRollout`, but nothing consumed it on the claim path, so a released paused rollout would never claim its later deployments. This wires the latch into the gate that decides what runs next.

A failed release does **not** latch (fail-closed), and a pending stop still dominates: only the rollout-continuation decision changes, never the apply's pass/fail verdict or the merge gate.

## Before / after

```text
on_failure: pause, earlier sibling = failed

  Before                                   After
╭──────────────────╮                     ╭──────────────────╮
│ earlier: FAILED  │                     │ earlier: FAILED  │
╰────────┬─────────╯                     ╰────────┬─────────╯
         │ blocks                                 │ release pending/completed?
         ▼                                  ┌─────┴─────┐
╭──────────────────╮                     no │           │ yes
│ later: never     │                ╭───────▼──╮   ╭─────▼──────────╮
│ claimed (held)   │                │ blocked  │   │ later: claimed │
╰──────────────────╯                │ (held)   │   │ (like continue)│
                                    ╰──────────╯   ╰────────────────╯
```
