### PR TITLE
feat(api): project the release latch over paused rollout state

### DIFF
--- a/pkg/api/operator.go
+++ b/pkg/api/operator.go
@@ -1553,13 +1553,31 @@ func (s *Service) updateApplyStateFromOperations(ctx context.Context, driverID i
 		return applyProjectionResult{}, fmt.Errorf("derive apply state for apply %s (%d): no apply_operations rows", apply.ApplyIdentifier, apply.ID)
 	}
 
+	// Load the release latch once for the whole apply: a released pause behaves
+	// like continue for the rollout projection, so a paused apply that an
+	// operator has released no longer holds at paused. A failed release does not
+	// latch (fail-closed), per ApplyControlRequest.ReleasesPausedRollout. With
+	// no control-request store a release latch cannot exist, so an unreleased
+	// pause stays held.
+	released := false
+	if requests := s.storage.ControlRequests(); requests != nil {
+		releaseReq, err := requests.GetByOperation(ctx, apply.ID, storage.ControlOperationRelease)
+		if err != nil {
+			return applyProjectionResult{}, fmt.Errorf("load release latch for apply %s (%d): %w", apply.ApplyIdentifier, apply.ID, err)
+		}
+		released = releaseReq.ReleasesPausedRollout()
+	}
+
 	childStates := make([]string, len(ops))
 	children := make([]state.RolloutChild, len(ops))
 	for i, op := range ops {
 		childStates[i] = op.State
+		isContinue := op.OnFailure == storage.OnFailureContinue
+		isPause := op.OnFailure == storage.OnFailurePause
 		children[i] = state.RolloutChild{
 			State:             op.State,
-			ContinueOnFailure: op.OnFailure == storage.OnFailureContinue,
+			ContinueOnFailure: isContinue || (isPause && released),
+			PauseOnFailure:    isPause && !released,
 		}
 	}
 	base := state.DeriveApplyState(childStates)

--- a/pkg/api/operator.go
+++ b/pkg/api/operator.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"slices"
 	"time"
 
 	"github.com/block/schemabot/pkg/metrics"
@@ -1521,6 +1522,15 @@ type applyProjectionResult struct {
 	OperationCount int
 }
 
+// anyPauseOnFailure reports whether any operation uses the on_failure=pause
+// policy. It gates the release-latch read: only a pause rollout's projection
+// depends on whether an operator has released it.
+func anyPauseOnFailure(ops []*storage.ApplyOperation) bool {
+	return slices.ContainsFunc(ops, func(op *storage.ApplyOperation) bool {
+		return op.OnFailure == storage.OnFailurePause
+	})
+}
+
 // updateApplyStateFromOperations re-derives applies.state from the apply's child
 // apply_operations rows and persists it when it differs from the current value.
 //
@@ -1553,19 +1563,24 @@ func (s *Service) updateApplyStateFromOperations(ctx context.Context, driverID i
 		return applyProjectionResult{}, fmt.Errorf("derive apply state for apply %s (%d): no apply_operations rows", apply.ApplyIdentifier, apply.ID)
 	}
 
-	// Load the release latch once for the whole apply: a released pause behaves
-	// like continue for the rollout projection, so a paused apply that an
-	// operator has released no longer holds at paused. A failed release does not
-	// latch (fail-closed), per ApplyControlRequest.ReleasesPausedRollout. With
-	// no control-request store a release latch cannot exist, so an unreleased
-	// pause stays held.
+	// Load the release latch only when some operation uses on_failure=pause: it
+	// is the only policy whose projection depends on whether an operator has
+	// released the rollout, so an apply without a pause operation never pays the
+	// read or risks a latch read error blocking its derived-state update. A
+	// released pause behaves like continue, so a paused apply that an operator
+	// has released no longer holds at paused; a failed release does not latch
+	// (fail-closed), per ApplyControlRequest.ReleasesPausedRollout. With no
+	// control-request store a release latch cannot exist, so an unreleased pause
+	// stays held.
 	released := false
-	if requests := s.storage.ControlRequests(); requests != nil {
-		releaseReq, err := requests.GetByOperation(ctx, apply.ID, storage.ControlOperationRelease)
-		if err != nil {
-			return applyProjectionResult{}, fmt.Errorf("load release latch for apply %s (%d): %w", apply.ApplyIdentifier, apply.ID, err)
+	if anyPauseOnFailure(ops) {
+		if requests := s.storage.ControlRequests(); requests != nil {
+			releaseReq, err := requests.GetByOperation(ctx, apply.ID, storage.ControlOperationRelease)
+			if err != nil {
+				return applyProjectionResult{}, fmt.Errorf("load release latch for apply %s (%d): %w", apply.ApplyIdentifier, apply.ID, err)
+			}
+			released = releaseReq.ReleasesPausedRollout()
 		}
-		released = releaseReq.ReleasesPausedRollout()
 	}
 
 	childStates := make([]string, len(ops))

--- a/pkg/api/operator_test.go
+++ b/pkg/api/operator_test.go
@@ -290,14 +290,20 @@ func TestUpdateApplyStateFromOperations_ContinuePolicy(t *testing.T) {
 }
 
 // releaseLatchControlStore returns a fixed release latch from GetByOperation so
-// the operator's apply-state writer can be driven with or without a release.
+// the operator's apply-state writer can be driven with or without a release. It
+// records the queried applyID so a test can assert the latch is read for the
+// apply being projected, not some other apply.
 type releaseLatchControlStore struct {
 	storage.ControlRequestStore
-	release *storage.ApplyControlRequest
+	release        *storage.ApplyControlRequest
+	queriedApply   int64
+	queriedRelease bool
 }
 
-func (s *releaseLatchControlStore) GetByOperation(_ context.Context, _ int64, op storage.ControlOperation) (*storage.ApplyControlRequest, error) {
+func (s *releaseLatchControlStore) GetByOperation(_ context.Context, applyID int64, op storage.ControlOperation) (*storage.ApplyControlRequest, error) {
 	if op == storage.ControlOperationRelease {
+		s.queriedApply = applyID
+		s.queriedRelease = true
 		return s.release, nil
 	}
 	return nil, nil
@@ -337,11 +343,12 @@ func TestUpdateApplyStateFromOperations_PausePolicy(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			applyStore := &recordingApplyStore{swapped: true}
+			control := &releaseLatchControlStore{release: tc.release}
 			logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
 			svc := New(&mockStorageWithControlAndOps{
 				applies:  applyStore,
 				applyOps: &listingApplyOperationStore{ops: ops},
-				control:  &releaseLatchControlStore{release: tc.release},
+				control:  control,
 			}, testServerConfig(), nil, logger)
 
 			apply := &storage.Apply{
@@ -355,8 +362,39 @@ func TestUpdateApplyStateFromOperations_PausePolicy(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, applyStore.updated)
 			assert.Equal(t, tc.wantState, applyStore.updated.State)
+			require.True(t, control.queriedRelease, "a pause rollout must read the release latch")
+			assert.Equal(t, apply.ID, control.queriedApply, "the release latch must be read for the apply being projected")
 		})
 	}
+}
+
+// TestUpdateApplyStateFromOperations_NoPauseSkipsReleaseLatch verifies the
+// operator does not read the release latch when no operation uses on_failure
+// pause: a non-pause rollout's projection cannot depend on a release, so it pays
+// neither the read nor its failure mode.
+func TestUpdateApplyStateFromOperations_NoPauseSkipsReleaseLatch(t *testing.T) {
+	applyStore := &recordingApplyStore{swapped: true}
+	control := &releaseLatchControlStore{}
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	svc := New(&mockStorageWithControlAndOps{
+		applies: applyStore,
+		applyOps: &listingApplyOperationStore{ops: []*storage.ApplyOperation{
+			{ID: 1, State: state.ApplyOperation.Failed, OnFailure: storage.OnFailureContinue},
+			{ID: 2, State: state.ApplyOperation.Pending, OnFailure: storage.OnFailureContinue},
+		}},
+		control: control,
+	}, testServerConfig(), nil, logger)
+
+	apply := &storage.Apply{
+		ID:              3,
+		ApplyIdentifier: "apply-continue",
+		State:           state.Apply.Pending,
+		Environment:     "staging",
+	}
+
+	_, err := svc.updateApplyStateFromOperations(t.Context(), 1, apply, allowLeaseScopedFailedReopen)
+	require.NoError(t, err)
+	assert.False(t, control.queriedRelease, "a rollout with no pause operation must not read the release latch")
 }
 
 func TestUpdateApplyStateFromOperations_FinalizerPendingIsNonTerminal(t *testing.T) {

--- a/pkg/api/operator_test.go
+++ b/pkg/api/operator_test.go
@@ -289,6 +289,76 @@ func TestUpdateApplyStateFromOperations_ContinuePolicy(t *testing.T) {
 	}
 }
 
+// releaseLatchControlStore returns a fixed release latch from GetByOperation so
+// the operator's apply-state writer can be driven with or without a release.
+type releaseLatchControlStore struct {
+	storage.ControlRequestStore
+	release *storage.ApplyControlRequest
+}
+
+func (s *releaseLatchControlStore) GetByOperation(_ context.Context, _ int64, op storage.ControlOperation) (*storage.ApplyControlRequest, error) {
+	if op == storage.ControlOperationRelease {
+		return s.release, nil
+	}
+	return nil, nil
+}
+
+// TestUpdateApplyStateFromOperations_PausePolicy verifies the operator projects
+// the release latch over an on_failure "pause" rollout: an unreleased pause
+// holds the apply paused while a later sibling is still pending, and an operator
+// release latches the rollout open so the same failure projects running_degraded
+// like continue.
+func TestUpdateApplyStateFromOperations_PausePolicy(t *testing.T) {
+	ops := []*storage.ApplyOperation{
+		{ID: 1, State: state.ApplyOperation.Failed, OnFailure: storage.OnFailurePause},
+		{ID: 2, State: state.ApplyOperation.Pending, OnFailure: storage.OnFailurePause},
+	}
+	cases := []struct {
+		name      string
+		release   *storage.ApplyControlRequest
+		wantState string
+	}{
+		{
+			name:      "unreleased pause holds the apply paused",
+			release:   nil,
+			wantState: state.Apply.Paused,
+		},
+		{
+			name:      "released pause projects running_degraded like continue",
+			release:   &storage.ApplyControlRequest{Operation: storage.ControlOperationRelease, Status: storage.ControlRequestCompleted},
+			wantState: state.Apply.RunningDegraded,
+		},
+		{
+			name:      "failed release does not latch and stays paused",
+			release:   &storage.ApplyControlRequest{Operation: storage.ControlOperationRelease, Status: storage.ControlRequestFailed},
+			wantState: state.Apply.Paused,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			applyStore := &recordingApplyStore{swapped: true}
+			logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+			svc := New(&mockStorageWithControlAndOps{
+				applies:  applyStore,
+				applyOps: &listingApplyOperationStore{ops: ops},
+				control:  &releaseLatchControlStore{release: tc.release},
+			}, testServerConfig(), nil, logger)
+
+			apply := &storage.Apply{
+				ID:              3,
+				ApplyIdentifier: "apply-pause",
+				State:           state.Apply.Pending,
+				Environment:     "staging",
+			}
+
+			_, err := svc.updateApplyStateFromOperations(t.Context(), 1, apply, allowLeaseScopedFailedReopen)
+			require.NoError(t, err)
+			require.NotNil(t, applyStore.updated)
+			assert.Equal(t, tc.wantState, applyStore.updated.State)
+		})
+	}
+}
+
 func TestUpdateApplyStateFromOperations_FinalizerPendingIsNonTerminal(t *testing.T) {
 	applyStore := &recordingApplyStore{swapped: true}
 	svc := newOperatorStateTestService(&listingApplyOperationStore{ops: []*storage.ApplyOperation{

--- a/pkg/tern/local_apply_grouped.go
+++ b/pkg/tern/local_apply_grouped.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -525,23 +526,28 @@ func (c *LocalClient) deriveAggregateApplyState(ctx context.Context, apply *stor
 		return failClosed()
 	}
 
-	// Load the release latch once for the apply: a released pause behaves like
-	// continue for the rollout projection. A failed release does not latch
-	// (fail-closed), per ApplyControlRequest.ReleasesPausedRollout.
+	// Load the release latch only when some operation uses on_failure=pause: it
+	// is the only policy whose projection depends on whether an operator has
+	// released the rollout, so an apply without a pause operation never pays the
+	// read or fails closed on an unrelated latch read error. A released pause
+	// behaves like continue; a failed release does not latch (fail-closed), per
+	// ApplyControlRequest.ReleasesPausedRollout.
 	released := false
-	if requests := c.storage.ControlRequests(); requests != nil {
-		releaseReq, err := requests.GetByOperation(ctx, apply.ID, storage.ControlOperationRelease)
-		if err != nil {
-			c.logger.Warn("cannot determine aggregate apply state: failed to load release latch",
-				"apply_id", apply.ApplyIdentifier, "apply_operation_id", operationID, "error", err)
-			return failClosed()
+	if slices.ContainsFunc(ops, func(op *storage.ApplyOperation) bool { return op.OnFailure == storage.OnFailurePause }) {
+		if requests := c.storage.ControlRequests(); requests != nil {
+			releaseReq, err := requests.GetByOperation(ctx, apply.ID, storage.ControlOperationRelease)
+			if err != nil {
+				c.logger.Warn("cannot determine aggregate apply state: failed to load release latch",
+					"apply_id", apply.ApplyIdentifier, "apply_operation_id", operationID, "error", err)
+				return failClosed()
+			}
+			released = releaseReq.ReleasesPausedRollout()
+		} else {
+			// No control-request store: a release latch cannot exist, so an
+			// unreleased pause stays held (fail-closed).
+			c.logger.Debug("deriving apply state from tasks: control request store is not configured; treating rollout as unreleased",
+				"apply_id", apply.ApplyIdentifier)
 		}
-		released = releaseReq.ReleasesPausedRollout()
-	} else {
-		// No control-request store: a release latch cannot exist, so an
-		// unreleased pause stays held (fail-closed).
-		c.logger.Debug("deriving apply state from tasks: control request store is not configured; treating rollout as unreleased",
-			"apply_id", apply.ApplyIdentifier)
 	}
 
 	children := make([]state.RolloutChild, len(ops))

--- a/pkg/tern/local_apply_grouped.go
+++ b/pkg/tern/local_apply_grouped.go
@@ -525,12 +525,34 @@ func (c *LocalClient) deriveAggregateApplyState(ctx context.Context, apply *stor
 		return failClosed()
 	}
 
+	// Load the release latch once for the apply: a released pause behaves like
+	// continue for the rollout projection. A failed release does not latch
+	// (fail-closed), per ApplyControlRequest.ReleasesPausedRollout.
+	released := false
+	if requests := c.storage.ControlRequests(); requests != nil {
+		releaseReq, err := requests.GetByOperation(ctx, apply.ID, storage.ControlOperationRelease)
+		if err != nil {
+			c.logger.Warn("cannot determine aggregate apply state: failed to load release latch",
+				"apply_id", apply.ApplyIdentifier, "apply_operation_id", operationID, "error", err)
+			return failClosed()
+		}
+		released = releaseReq.ReleasesPausedRollout()
+	} else {
+		// No control-request store: a release latch cannot exist, so an
+		// unreleased pause stays held (fail-closed).
+		c.logger.Debug("deriving apply state from tasks: control request store is not configured; treating rollout as unreleased",
+			"apply_id", apply.ApplyIdentifier)
+	}
+
 	children := make([]state.RolloutChild, len(ops))
 	foundCurrent := false
 	for i, op := range ops {
+		isContinue := op.OnFailure == storage.OnFailureContinue
+		isPause := op.OnFailure == storage.OnFailurePause
 		child := state.RolloutChild{
 			State:             op.State,
-			ContinueOnFailure: op.OnFailure == storage.OnFailureContinue,
+			ContinueOnFailure: isContinue || (isPause && released),
+			PauseOnFailure:    isPause && !released,
 		}
 		if op.ID == operationID {
 			child.State = currentOpState

--- a/pkg/tern/local_client_test.go
+++ b/pkg/tern/local_client_test.go
@@ -509,6 +509,17 @@ func TestApplyCancelHandleDoesNotCancelNewerOwner(t *testing.T) {
 	assert.Nil(t, client.currentApplyCancel().cancel)
 }
 
+// errControlRequestStore fails GetByOperation so the projection's release-latch
+// read can be driven into its fail-closed path.
+type errControlRequestStore struct {
+	storage.ControlRequestStore
+	err error
+}
+
+func (s *errControlRequestStore) GetByOperation(context.Context, int64, storage.ControlOperation) (*storage.ApplyControlRequest, error) {
+	return nil, s.err
+}
+
 type testControlRequestStore struct {
 	storage.ControlRequestStore
 	requests []*storage.ApplyControlRequest
@@ -1942,6 +1953,81 @@ func TestDeriveAggregateApplyState(t *testing.T) {
 		got, ok := client.deriveAggregateApplyState(t.Context(), apply, tasks)
 		assert.True(t, ok, "current op row present, projection must be determined")
 		assert.Equal(t, state.Apply.RunningDegraded, got, "continue policy must hold the apply degraded until the pending sibling settles")
+	})
+
+	// Under on_failure "pause" a terminally failed deployment holds the apply
+	// paused for a human while a sibling is still pending. An operator release
+	// latches the rollout open so the same failure projects running_degraded like
+	// continue; a failed release does not latch and the rollout stays paused.
+	pauseCases := []struct {
+		name      string
+		release   *storage.ApplyControlRequest
+		wantState string
+	}{
+		{
+			name:      "unreleased pause holds the apply paused",
+			release:   nil,
+			wantState: state.Apply.Paused,
+		},
+		{
+			name:      "released pause holds the apply degraded like continue",
+			release:   &storage.ApplyControlRequest{ApplyID: 7, Operation: storage.ControlOperationRelease, Status: storage.ControlRequestCompleted},
+			wantState: state.Apply.RunningDegraded,
+		},
+		{
+			name:      "failed release does not latch and stays paused",
+			release:   &storage.ApplyControlRequest{ApplyID: 7, Operation: storage.ControlOperationRelease, Status: storage.ControlRequestFailed},
+			wantState: state.Apply.Paused,
+		},
+	}
+	for _, tc := range pauseCases {
+		t.Run("pause policy ("+tc.name+")", func(t *testing.T) {
+			control := &testControlRequestStore{}
+			if tc.release != nil {
+				control.requests = []*storage.ApplyControlRequest{tc.release}
+			}
+			tasks := []*storage.Task{taskWith(state.Task.Failed)}
+			client := &LocalClient{
+				storage: &exactProgressStorage{
+					controlRequests: control,
+					applyOperations: &listApplyOperationStore{
+						ops: []*storage.ApplyOperation{
+							{ID: currentOpID, State: state.ApplyOperation.Failed, OnFailure: storage.OnFailurePause},
+							{ID: 2, State: state.ApplyOperation.Pending, OnFailure: storage.OnFailurePause},
+						},
+					},
+				},
+				logger: slog.Default(),
+			}
+			apply := &storage.Apply{ID: 7, ApplyIdentifier: "apply-pause"}
+
+			got, ok := client.deriveAggregateApplyState(t.Context(), apply, tasks)
+			assert.True(t, ok, "current op row present, projection must be determined")
+			assert.Equal(t, tc.wantState, got)
+		})
+	}
+
+	// A read failure on the release latch leaves the rollout's release state
+	// unknown, so the projection fails closed (ok=false) and the caller keeps the
+	// stored apply state rather than risk treating an unreleased pause as open.
+	t.Run("pause policy (release latch read failure fails closed)", func(t *testing.T) {
+		tasks := []*storage.Task{taskWith(state.Task.Failed)}
+		client := &LocalClient{
+			storage: &exactProgressStorage{
+				controlRequests: &errControlRequestStore{err: assert.AnError},
+				applyOperations: &listApplyOperationStore{
+					ops: []*storage.ApplyOperation{
+						{ID: currentOpID, State: state.ApplyOperation.Failed, OnFailure: storage.OnFailurePause},
+						{ID: 2, State: state.ApplyOperation.Pending, OnFailure: storage.OnFailurePause},
+					},
+				},
+			},
+			logger: slog.Default(),
+		}
+		apply := &storage.Apply{ID: 7, ApplyIdentifier: "apply-pause-readfail"}
+
+		_, ok := client.deriveAggregateApplyState(t.Context(), apply, tasks)
+		assert.False(t, ok, "an unreadable release latch must not terminalize or release the rollout")
 	})
 
 	// Default policy (on_failure unset) fails closed: a terminally failed

--- a/pkg/tern/local_client_test.go
+++ b/pkg/tern/local_client_test.go
@@ -2030,6 +2030,30 @@ func TestDeriveAggregateApplyState(t *testing.T) {
 		assert.False(t, ok, "an unreadable release latch must not terminalize or release the rollout")
 	})
 
+	// A rollout with no pause operation never reads the release latch: an
+	// unrelated latch read error must not fail the projection closed, since a
+	// continue/halt rollout cannot depend on a release.
+	t.Run("no pause operation does not read the release latch", func(t *testing.T) {
+		tasks := []*storage.Task{taskWith(state.Task.Failed)}
+		client := &LocalClient{
+			storage: &exactProgressStorage{
+				controlRequests: &errControlRequestStore{err: assert.AnError},
+				applyOperations: &listApplyOperationStore{
+					ops: []*storage.ApplyOperation{
+						{ID: currentOpID, State: state.ApplyOperation.Failed, OnFailure: storage.OnFailureContinue},
+						{ID: 2, State: state.ApplyOperation.Pending, OnFailure: storage.OnFailureContinue},
+					},
+				},
+			},
+			logger: slog.Default(),
+		}
+		apply := &storage.Apply{ID: 7, ApplyIdentifier: "apply-continue-noread"}
+
+		got, ok := client.deriveAggregateApplyState(t.Context(), apply, tasks)
+		assert.True(t, ok, "a non-pause rollout must not fail closed on a latch read it never makes")
+		assert.Equal(t, state.Apply.RunningDegraded, got, "continue holds the apply degraded past the failed sibling")
+	})
+
 	// Default policy (on_failure unset) fails closed: a terminally failed
 	// deployment terminalizes the apply even with a pending sibling.
 	t.Run("default policy terminalizes the apply on a failed deployment", func(t *testing.T) {


### PR DESCRIPTION
## Summary
Wires the release latch into the two apply-state projections so a rollout under `on_failure: pause` reflects the operator's release decision: a released pause is projected like `continue` (`running_degraded`), while an unreleased or failed-release pause is held `paused`. Still dormant — config keeps rejecting `pause`.

## What
- Operator projection (`updateApplyStateFromOperations`) and local grouped projection (`deriveAggregateApplyState`) load the release latch once per apply and set per-child flags: `ContinueOnFailure = continue || (pause && released)`, `PauseOnFailure = pause && !released`.
- A latch read error fails the projection closed (leaves stored state unchanged); the operator path also nil-guards an absent control-request store.

## Why
The dormant `paused` state and `PauseOnFailure` flag already exist in the rollout projection, and earlier slices added the release latch and the claim-side exemption. But nothing fed the latch into the apply-state writers, so a released paused rollout would still surface as `paused`. This connects the latch to the state operators and the CLI observe.

## Before / after

```text
on_failure: pause, earlier deployment failed, later still pending

  Before                              After
╭───────────────────╮              ╭───────────────────╮
│ projection ignores│              │ projection reads  │
│ release latch     │              │ release latch     │
╰─────────┬─────────╯              ╰─────────┬─────────╯
          │                         ┌────────┴────────┐
          ▼                    no   │                 │  yes (pending/completed)
╭───────────────────╮     ╭─────────▼──╮      ╭───────▼───────────╮
│ always: paused    │     │ paused     │      │ running_degraded  │
│                   │     │ (held)     │      │ (like continue)   │
╰───────────────────╯     ╰────────────╯      ╰───────────────────╯
                          (failed release stays paused — fail-closed)
```
