### PR TITLE
fix(ux): show environment on single-env auto-plan comments

### DIFF
--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -689,9 +689,9 @@ schemabot apply -e staging --allow-unsafe
 <summary><a name="drop-index-blocked"></a><strong>Drop Index Blocked</strong></summary>
 
 
-## MySQL Schema Change Plan
+## Schema Change Plan — Staging
 
-**Database**: `testapp` | **Schema Name**: `testapp` | **Environment**: `staging`
+**Database**: `testapp` | **Type**: `MySQL` | **Schema Name**: `testapp`
 
 *Requested by @jackjackbits at 2026-01-01 00:00:00 UTC · planned from [`abcdef1`](https://github.com/block/schemabot/commit/abcdef1234567890abcdef1234567890abcdef12)*
 

--- a/pkg/webhook/plan_test.go
+++ b/pkg/webhook/plan_test.go
@@ -287,6 +287,34 @@ func TestRenderPlanComment_EnvironmentScopedTitle(t *testing.T) {
 		assert.Equal(t, "## Schema Change Plan", firstLine)
 		assert.Contains(t, rendered, "**Type**: `MySQL`")
 	})
+
+	t.Run("single environment multi-env plan title includes environment", func(t *testing.T) {
+		data := templates.MultiEnvPlanCommentData{
+			Database:     "testdb",
+			IsMySQL:      true,
+			Environments: []string{"staging"},
+			Plans: map[string]*templates.PlanCommentData{
+				"staging": {
+					Database:    "testdb",
+					Environment: "staging",
+					IsMySQL:     true,
+					Changes: []templates.KeyspaceChangeData{{
+						Keyspace:   "testdb",
+						Statements: []string{"ALTER TABLE `orders` ADD COLUMN `x` INT"},
+					}},
+				},
+			},
+			Errors: map[string]string{},
+		}
+
+		rendered := templates.RenderMultiEnvPlanComment(data)
+		firstLine, _, _ := strings.Cut(rendered, "\n")
+
+		assert.Equal(t, "## Schema Change Plan — Staging", firstLine)
+		assert.Contains(t, rendered, "**Type**: `MySQL`")
+		assert.NotContains(t, rendered, "### Staging")
+		assert.Contains(t, rendered, "schemabot apply -e staging")
+	})
 }
 
 func TestRenderPlanComment_NoUnsafe_NoWarning(t *testing.T) {
@@ -405,7 +433,9 @@ func TestRenderMultiEnvPlanComment_ShowsPRHeadSHA(t *testing.T) {
 	}
 
 	rendered := templates.RenderMultiEnvPlanComment(data)
+	firstLine, _, _ := strings.Cut(rendered, "\n")
 
+	assert.Equal(t, "## Schema Change Plan — Staging", firstLine)
 	assert.Contains(t, rendered, "planned from [`abcdef1`](https://github.com/block/schemabot/commit/abcdef1234567890)")
 	assert.NotContains(t, rendered, "**PR head SHA**")
 }
@@ -420,8 +450,10 @@ func TestRenderMultiEnvPlanComment_StrataHeaderWithErrors(t *testing.T) {
 	}
 
 	rendered := templates.RenderMultiEnvPlanComment(data)
+	firstLine, _, _ := strings.Cut(rendered, "\n")
 
-	assert.Contains(t, rendered, "## Schema Change Plan")
+	assert.Equal(t, "## Schema Change Plan — Staging", firstLine)
+	assert.Contains(t, rendered, "**Type**: `Strata`")
 }
 
 func TestUserFacingErrorExplainsNoHealthyUpstream(t *testing.T) {

--- a/pkg/webhook/templates/plan.go
+++ b/pkg/webhook/templates/plan.go
@@ -494,10 +494,14 @@ type MultiEnvPlanCommentData struct {
 // RenderMultiEnvPlanComment renders a combined plan comment showing all environments.
 // If all environments have identical plans, deduplicates into a single section.
 func RenderMultiEnvPlanComment(data MultiEnvPlanCommentData) string {
+	if plan, ok := singleEnvironmentPlan(data); ok {
+		return RenderPlanComment(plan)
+	}
+
 	var sb strings.Builder
 
 	// Header
-	sb.WriteString("## Schema Change Plan\n\n")
+	writeEnvironmentTitle(&sb, "Schema Change Plan", singleEnvironmentTitleEnvironment(data.Environments))
 
 	writePlanMetadata(&sb, PlanCommentData{Database: data.Database, SchemaName: data.SchemaName, DatabaseType: data.DatabaseType, IsMySQL: data.IsMySQL})
 	writePlanAttribution(&sb, PlanCommentData{
@@ -553,6 +557,50 @@ func RenderMultiEnvPlanComment(data MultiEnvPlanCommentData) string {
 	writeMultiEnvFooter(&sb, data)
 
 	return sb.String()
+}
+
+func singleEnvironmentPlan(data MultiEnvPlanCommentData) (PlanCommentData, bool) {
+	if len(data.Environments) != 1 || len(data.Errors) > 0 {
+		return PlanCommentData{}, false
+	}
+	environment := data.Environments[0]
+	plan, ok := data.Plans[environment]
+	if !ok || plan == nil {
+		return PlanCommentData{}, false
+	}
+	merged := *plan
+	if merged.Database == "" {
+		merged.Database = data.Database
+	}
+	if merged.SchemaName == "" {
+		merged.SchemaName = data.SchemaName
+	}
+	if merged.Environment == "" {
+		merged.Environment = environment
+	}
+	if merged.HeadSHA == "" {
+		merged.HeadSHA = data.HeadSHA
+	}
+	if merged.Repository == "" {
+		merged.Repository = data.Repository
+	}
+	if merged.DatabaseType == "" {
+		merged.DatabaseType = data.DatabaseType
+	}
+	if !merged.IsMySQL {
+		merged.IsMySQL = data.IsMySQL
+	}
+	if merged.RequestedBy == "" {
+		merged.RequestedBy = data.RequestedBy
+	}
+	return merged, true
+}
+
+func singleEnvironmentTitleEnvironment(environments []string) string {
+	if len(environments) != 1 {
+		return ""
+	}
+	return environments[0]
 }
 
 func schemaChangePlanDatabaseTypeLabel(databaseType string, isMySQL bool) string {

--- a/pkg/webhook/webhook_e2e_test.go
+++ b/pkg/webhook/webhook_e2e_test.go
@@ -1012,7 +1012,8 @@ func TestE2EAutoPlan(t *testing.T) {
 	// Auto-plan runs in a background goroutine — wait for the plan comment
 	select {
 	case body := <-result.comments:
-		assert.Contains(t, body, "Schema Change Plan")
+		firstLine, _, _ := strings.Cut(body, "\n")
+		assert.Equal(t, "## Schema Change Plan — Staging", firstLine)
 		assert.Contains(t, body, "CREATE TABLE")
 		assert.Contains(t, body, dbName)
 	case <-time.After(30 * time.Second):


### PR DESCRIPTION
## Why
Single-environment auto-plan comments should show the environment in the title, matching manual plan comments and making split deployment PR timelines easier to scan.

## What
- Reuse the single-environment plan renderer when auto-plan only contains one environment
- Keep true multi-environment plan comments on the combined renderer with a generic title
- Cover the auto-plan path with an integration assertion and update generated preview output

## Risk Assessment
Low — this only changes GitHub PR comment rendering. Schema change planning, storage, and apply execution are unchanged.

Generated with Amp
