### PR TITLE
fix(tern): avoid nil deref when engine Progress errors in conflict check

### DIFF
--- a/pkg/tern/local_apply.go
+++ b/pkg/tern/local_apply.go
@@ -78,10 +78,12 @@ func (c *LocalClient) tryResolveStaleTask(ctx context.Context, t *storage.Task, 
 		Database:    database,
 		Credentials: c.credentials(),
 	})
-	c.logger.Debug("conflict check: engine progress", "task_id", t.TaskIdentifier, "engine_state", result.State, "message", result.Message, "err", err)
 	if err != nil {
+		// result is nil on error, so it must not be dereferenced here.
+		c.logger.Debug("conflict check: engine progress failed", "task_id", t.TaskIdentifier, "err", err)
 		return false
 	}
+	c.logger.Debug("conflict check: engine progress", "task_id", t.TaskIdentifier, "engine_state", result.State, "message", result.Message)
 
 	// Engine says terminal — update storage and unblock.
 	// IMPORTANT: Only trust terminal states, NOT "No active schema change".

--- a/pkg/tern/local_apply.go
+++ b/pkg/tern/local_apply.go
@@ -79,8 +79,8 @@ func (c *LocalClient) tryResolveStaleTask(ctx context.Context, t *storage.Task, 
 		Credentials: c.credentials(),
 	})
 	if err != nil {
-		// result is nil on error, so it must not be dereferenced here.
-		c.logger.Debug("conflict check: engine progress failed", "task_id", t.TaskIdentifier, "err", err)
+		// result may be nil when err is non-nil, so it must not be dereferenced here.
+		c.logger.Warn("conflict check: engine progress failed", "task_id", t.TaskIdentifier, "err", err)
 		return false
 	}
 	c.logger.Debug("conflict check: engine progress", "task_id", t.TaskIdentifier, "engine_state", result.State, "message", result.Message)

--- a/pkg/tern/local_apply_conflict_test.go
+++ b/pkg/tern/local_apply_conflict_test.go
@@ -1,6 +1,7 @@
 package tern
 
 import (
+	"errors"
 	"log/slog"
 	"testing"
 
@@ -92,6 +93,43 @@ func TestConflictCheckPreservesRetryableTask(t *testing.T) {
 	require.Error(t, err, "a new apply must be refused while a retryable task holds the database")
 	assert.Contains(t, err.Error(), "schema change already in progress")
 	assert.Equal(t, state.Task.FailedRetryable, retryable.State)
+}
+
+// When the engine's Progress call errors it returns a nil result. The conflict
+// check must treat the task as unresolved (and keep it blocking) without
+// dereferencing that nil result — an earlier version logged result.State before
+// the error check and panicked, crashing the Apply RPC whenever Progress failed
+// (e.g. a DB connection torn down during shutdown).
+func TestConflictCheckHandlesProgressError(t *testing.T) {
+	running := &storage.Task{
+		ID:             5,
+		TaskIdentifier: "task-running",
+		Database:       "testdb",
+		DatabaseType:   storage.DatabaseTypeMySQL,
+		TableName:      "events",
+		State:          state.Task.Running,
+	}
+	client := &LocalClient{
+		config: LocalConfig{
+			Database: "testdb",
+			Type:     storage.DatabaseTypeMySQL,
+		},
+		storage: &exactProgressStorage{
+			tasks: &exactProgressTaskStore{tasks: []*storage.Task{running}},
+			logs:  &mockApplyLogStore{},
+		},
+		spiritEngine: &fakeControlEngine{
+			progressErr: errors.New("engine unreachable"),
+		},
+		logger: slog.Default(),
+	}
+
+	require.NotPanics(t, func() {
+		resolved := client.tryResolveStaleTask(t.Context(), running, "testdb")
+		assert.False(t, resolved, "task must not be resolved when the engine progress call errors")
+	})
+	assert.Equal(t, state.Task.Running, running.State, "task state must be left untouched on progress error")
+	assert.Nil(t, running.CompletedAt)
 }
 
 // A running task whose engine has gone silent (e.g. the server crashed mid-apply)

--- a/pkg/tern/local_apply_conflict_test.go
+++ b/pkg/tern/local_apply_conflict_test.go
@@ -95,11 +95,11 @@ func TestConflictCheckPreservesRetryableTask(t *testing.T) {
 	assert.Equal(t, state.Task.FailedRetryable, retryable.State)
 }
 
-// When the engine's Progress call errors it returns a nil result. The conflict
+// When the engine's Progress call errors it may return a nil result. The conflict
 // check must treat the task as unresolved (and keep it blocking) without
-// dereferencing that nil result — an earlier version logged result.State before
-// the error check and panicked, crashing the Apply RPC whenever Progress failed
-// (e.g. a DB connection torn down during shutdown).
+// dereferencing the result when err is non-nil — an earlier version logged
+// result.State before the error check and panicked, crashing the Apply RPC
+// whenever Progress failed (e.g. a DB connection torn down during shutdown).
 func TestConflictCheckHandlesProgressError(t *testing.T) {
 	running := &storage.Task{
 		ID:             5,


### PR DESCRIPTION
## Problem

An Apply RPC panicked with a nil pointer dereference, surfaced by the grpc recovery interceptor as `Internal desc = runtime error: invalid memory address or nil pointer dereference`:

```
tern.(*LocalClient).tryResolveStaleTask  .../pkg/tern/local_apply.go:81
tern.(*LocalClient).findBlockingTask     .../pkg/tern/local_apply.go:55
tern.(*LocalClient).checkActiveTaskConflict .../pkg/tern/local_apply.go:26
tern.(*LocalClient).Apply                .../pkg/tern/local_client.go:1725
```

`tryResolveStaleTask` logged `result.State` / `result.Message` in a debug line placed **before** the `if err != nil` check:

```go
result, err := eng.Progress(ctx, &engine.ProgressRequest{...})
c.logger.Debug("conflict check: engine progress", ..., "engine_state", result.State, "message", result.Message, "err", err) // ← line 81
if err != nil {
    return false
}
```

`Engine.Progress` returns a **nil** result alongside a non-nil error on many paths (DSN parse failure, current-schema fetch failure, a DB connection torn down during shutdown, etc.). On any such error, the debug log dereferenced the nil `result` and panicked, crashing the Apply RPC.

## Fix

Move the debug log below the error check so `result` is only dereferenced when non-nil, and log the error on its own line.

## Test

Adds `TestConflictCheckHandlesProgressError`, which drives `tryResolveStaleTask` with an engine that returns `(nil, err)` and asserts it does not panic, returns `false` (task stays blocking), and leaves the task state untouched. Verified the test panics on `main` without the fix and passes with it.