### PR TITLE
fix(github): retry transient plan transport failures

### DIFF
--- a/pkg/webhook/plan.go
+++ b/pkg/webhook/plan.go
@@ -98,7 +98,7 @@ func (h *Handler) handlePlanCommand(w http.ResponseWriter, repo string, pr int, 
 	}
 
 	// Execute plan via the service
-	planResp, err := h.service.ExecutePlan(ctx, planReq)
+	planResp, err := h.executePlanWithTransientRetry(ctx, planReq, repo, pr)
 	if err != nil {
 		h.logger.Error("plan execution failed", "repo", repo, "pr", pr, "database", schemaResult.Database, "deployment", deployment, "environment", environment, "error", err)
 		metrics.RecordPlan(ctx, repo, schemaResult.Database, deployment, environment, "error")
@@ -285,7 +285,7 @@ func (h *Handler) handleMultiEnvPlan(repo string, pr int, databaseName, tenant s
 			SourceTrusted: true,
 		}
 
-		planResp, err := h.service.ExecutePlan(ctx, planReq)
+		planResp, err := h.executePlanWithTransientRetry(ctx, planReq, repo, pr)
 		if err != nil {
 			h.logger.Error("plan execution failed", "repo", repo, "pr", pr, "env", env, "error", err)
 			multiEnvData.Errors[env] = userFacingError(err)

--- a/pkg/webhook/plan_retry.go
+++ b/pkg/webhook/plan_retry.go
@@ -14,12 +14,18 @@ import (
 	"github.com/block/schemabot/pkg/metrics"
 )
 
-// defaultTransientPlanRetryDelay is the pause before retrying a plan request
-// that failed with transient remote unavailability. Webhook commands respond
-// asynchronously through PR comments, so a short wait is invisible to the
-// user, and it gives the network path time to recover beyond the gRPC
-// client's own sub-second retry budget.
-const defaultTransientPlanRetryDelay = 3 * time.Second
+const (
+	// defaultTransientPlanRetryDelay is the pause before retrying a plan request
+	// that failed with transient remote unavailability. Webhook commands respond
+	// asynchronously through PR comments, so a short wait is invisible to the
+	// user, and it gives the network path time to recover beyond the gRPC
+	// client's own sub-second retry budget.
+	defaultTransientPlanRetryDelay = 3 * time.Second
+
+	// maxTransientPlanRetries bounds webhook plan retries so brief transport
+	// blips can recover without hiding sustained remote deployment outages.
+	maxTransientPlanRetries = 3
+)
 
 // isTransientRemotePlanError reports whether a plan failure means the remote
 // deployment was unreachable (a retryable transport condition) rather than a
@@ -39,7 +45,7 @@ func (h *Handler) planRetryDelay() time.Duration {
 	return defaultTransientPlanRetryDelay
 }
 
-// executePlanWithTransientRetry runs ExecutePlan and retries once when the
+// executePlanWithTransientRetry runs ExecutePlan and retries when the
 // failure is transient remote unavailability. Plan requests are safe to
 // re-send: each attempt produces an independent plan record and only the
 // returned plan ID is used. Every other failure class (policy, validation,
@@ -47,9 +53,9 @@ func (h *Handler) planRetryDelay() time.Duration {
 //
 // Failing a webhook command on a brief network blip costs the user the whole
 // command ceremony — for apply-confirm that means re-running apply and
-// confirming again. One delayed retry absorbs blips that outlast the gRPC
-// client's retry budget while still surfacing sustained outages within
-// seconds.
+// confirming again. A bounded delayed retry loop absorbs blips that outlast
+// the gRPC client's retry budget while still surfacing sustained outages
+// within seconds.
 func (h *Handler) executePlanWithTransientRetry(ctx context.Context, planReq api.PlanRequest, repo string, pr int) (*apitypes.PlanResponse, error) {
 	planResp, err := h.service.ExecutePlan(ctx, planReq)
 	if err == nil || !isTransientRemotePlanError(err) {
@@ -57,39 +63,58 @@ func (h *Handler) executePlanWithTransientRetry(ctx context.Context, planReq api
 	}
 
 	delay := h.planRetryDelay()
-	h.logger.Warn("plan failed with transient remote unavailability; retrying once",
-		"repo", repo,
-		"pr", pr,
-		"database", planReq.Database,
-		"environment", planReq.Environment,
-		"retry_delay", delay,
-		"error", err)
-
-	timer := time.NewTimer(delay)
-	defer timer.Stop()
-	select {
-	case <-ctx.Done():
-		return nil, fmt.Errorf("plan retry for %s/%s cancelled: %w", planReq.Database, planReq.Environment, ctx.Err())
-	case <-timer.C:
-	}
-
-	planResp, retryErr := h.service.ExecutePlan(ctx, planReq)
-	if retryErr != nil {
-		metrics.RecordTransientPlanRetry(ctx, planReq.Database, planReq.Environment, "exhausted")
-		h.logger.Error("plan retry failed; remote deployment is still unavailable",
+	lastErr := err
+	for retryAttempt := 1; retryAttempt <= maxTransientPlanRetries; retryAttempt++ {
+		h.logger.Warn("plan failed with transient remote unavailability; retrying",
 			"repo", repo,
 			"pr", pr,
 			"database", planReq.Database,
 			"environment", planReq.Environment,
-			"error", retryErr)
-		return nil, retryErr
+			"retry_attempt", retryAttempt,
+			"max_retries", maxTransientPlanRetries,
+			"retry_delay", delay,
+			"error", lastErr)
+
+		timer := time.NewTimer(delay)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return nil, fmt.Errorf("plan retry for %s/%s cancelled: %w", planReq.Database, planReq.Environment, ctx.Err())
+		case <-timer.C:
+		}
+
+		planResp, retryErr := h.service.ExecutePlan(ctx, planReq)
+		if retryErr == nil {
+			metrics.RecordTransientPlanRetry(ctx, planReq.Database, planReq.Environment, "recovered")
+			h.logger.Info("plan retry recovered from transient remote unavailability",
+				"repo", repo,
+				"pr", pr,
+				"database", planReq.Database,
+				"environment", planReq.Environment,
+				"retry_attempt", retryAttempt,
+				"plan_id", planResp.PlanID)
+			return planResp, nil
+		}
+		if !isTransientRemotePlanError(retryErr) {
+			h.logger.Warn("plan retry reached non-transient failure; stopping retries",
+				"repo", repo,
+				"pr", pr,
+				"database", planReq.Database,
+				"environment", planReq.Environment,
+				"retry_attempt", retryAttempt,
+				"error", retryErr)
+			return nil, retryErr
+		}
+		lastErr = retryErr
 	}
-	metrics.RecordTransientPlanRetry(ctx, planReq.Database, planReq.Environment, "recovered")
-	h.logger.Info("plan retry recovered from transient remote unavailability",
+
+	metrics.RecordTransientPlanRetry(ctx, planReq.Database, planReq.Environment, "exhausted")
+	h.logger.Error("plan retries exhausted; remote deployment is still unavailable",
 		"repo", repo,
 		"pr", pr,
 		"database", planReq.Database,
 		"environment", planReq.Environment,
-		"plan_id", planResp.PlanID)
-	return planResp, nil
+		"max_retries", maxTransientPlanRetries,
+		"error", lastErr)
+	return nil, lastErr
 }

--- a/pkg/webhook/plan_retry.go
+++ b/pkg/webhook/plan_retry.go
@@ -63,6 +63,7 @@ func (h *Handler) executePlanWithTransientRetry(ctx context.Context, planReq api
 	}
 
 	delay := h.planRetryDelay()
+	firstErr := err
 	lastErr := err
 	for retryAttempt := 1; retryAttempt <= maxTransientPlanRetries; retryAttempt++ {
 		h.logger.Warn("plan failed with transient remote unavailability; retrying",
@@ -96,6 +97,7 @@ func (h *Handler) executePlanWithTransientRetry(ctx context.Context, planReq api
 			return planResp, nil
 		}
 		if !isTransientRemotePlanError(retryErr) {
+			metrics.RecordTransientPlanRetry(ctx, planReq.Database, planReq.Environment, "stopped_non_transient")
 			h.logger.Warn("plan retry reached non-transient failure; stopping retries",
 				"repo", repo,
 				"pr", pr,
@@ -115,6 +117,7 @@ func (h *Handler) executePlanWithTransientRetry(ctx context.Context, planReq api
 		"database", planReq.Database,
 		"environment", planReq.Environment,
 		"max_retries", maxTransientPlanRetries,
-		"error", lastErr)
-	return nil, lastErr
+		"first_error", firstErr,
+		"last_error", lastErr)
+	return nil, firstErr
 }

--- a/pkg/webhook/plan_retry_test.go
+++ b/pkg/webhook/plan_retry_test.go
@@ -97,8 +97,8 @@ func planRetryTestRequest() api.PlanRequest {
 }
 
 // A brief remote outage during a webhook command's plan request is absorbed:
-// the handler retries once after the configured delay and the command flow
-// continues with the successful plan instead of posting a failure comment.
+// the handler retries after the configured delay and the command flow continues
+// with the successful plan instead of posting a failure comment.
 func TestExecutePlanTransientRetryRecovers(t *testing.T) {
 	client := &flakyPlanTernClient{
 		failPlans: 1,
@@ -111,12 +111,29 @@ func TestExecutePlanTransientRetryRecovers(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	assert.Equal(t, "plan-after-retry", resp.PlanID)
-	assert.Equal(t, 2, client.calls(), "handler should retry the failed plan attempt once")
+	assert.Equal(t, 2, client.calls(), "handler should stop retrying after the first successful plan")
 }
 
-// A sustained remote outage still surfaces within one retry: the handler does
-// not loop, and the caller posts the same operator-visible error it would
-// have without retries.
+// A longer transient outage can recover on the final bounded retry without the
+// caller posting an operator-visible failure comment.
+func TestExecutePlanTransientRetryRecoversOnFinalRetry(t *testing.T) {
+	client := &flakyPlanTernClient{
+		failPlans: maxTransientPlanRetries,
+		planErr:   grpcstatus.Error(grpccodes.Unavailable, "upstream connect error"),
+	}
+	h := newPlanRetryTestHandler(client, time.Millisecond)
+
+	resp, err := h.executePlanWithTransientRetry(t.Context(), planRetryTestRequest(), "octocat/hello-world", 1)
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, "plan-after-retry", resp.PlanID)
+	assert.Equal(t, maxTransientPlanRetries+1, client.calls(), "handler should allow the final configured retry to recover")
+}
+
+// A sustained remote outage still surfaces after the bounded retries: the
+// handler does not loop forever, and the caller posts the same operator-visible
+// error it would have without retries.
 func TestExecutePlanTransientRetryExhausted(t *testing.T) {
 	client := &flakyPlanTernClient{
 		failPlans: 10,
@@ -132,7 +149,7 @@ func TestExecutePlanTransientRetryExhausted(t *testing.T) {
 	require.True(t, errors.As(err, &remoteErr), "exhausted retry should surface the remote unavailability error")
 	assert.Equal(t, "remote", remoteErr.Deployment)
 	assert.Equal(t, "orders-target", remoteErr.Target)
-	assert.Equal(t, 2, client.calls(), "handler should stop after one retry")
+	assert.Equal(t, maxTransientPlanRetries+1, client.calls(), "handler should stop after the configured retry budget")
 }
 
 // Only transient remote unavailability is retried. Deterministic failures

--- a/pkg/webhook/plan_retry_test.go
+++ b/pkg/webhook/plan_retry_test.go
@@ -48,6 +48,32 @@ func (c *flakyPlanTernClient) calls() int {
 	return c.planCalls
 }
 
+type sequencePlanTernClient struct {
+	tern.Client
+	mu        sync.Mutex
+	planCalls int
+	errors    []error
+}
+
+func (c *sequencePlanTernClient) Plan(context.Context, *ternv1.PlanRequest) (*ternv1.PlanResponse, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.planCalls++
+	if c.planCalls <= len(c.errors) {
+		return nil, c.errors[c.planCalls-1]
+	}
+	return &ternv1.PlanResponse{PlanId: "plan-after-retry"}, nil
+}
+
+func (c *sequencePlanTernClient) IsRemote() bool   { return true }
+func (c *sequencePlanTernClient) Endpoint() string { return "remote:9090" }
+
+func (c *sequencePlanTernClient) calls() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.planCalls
+}
+
 type planRetryStorage struct {
 	emptyStorage
 }
@@ -168,6 +194,24 @@ func TestExecutePlanNoRetryForNonTransientErrors(t *testing.T) {
 	assert.Nil(t, resp)
 	assert.Contains(t, err.Error(), "schema name is required")
 	assert.Equal(t, 1, client.calls(), "non-transient failures must not be retried")
+}
+
+// If a transient retry reaches a deterministic failure, retries stop and the
+// deterministic error is surfaced immediately instead of spending the remaining
+// retry budget.
+func TestExecutePlanTransientRetryStopsOnNonTransientError(t *testing.T) {
+	client := &sequencePlanTernClient{errors: []error{
+		grpcstatus.Error(grpccodes.Unavailable, "upstream connect error"),
+		grpcstatus.Error(grpccodes.InvalidArgument, "schema name is required"),
+	}}
+	h := newPlanRetryTestHandler(client, time.Millisecond)
+
+	resp, err := h.executePlanWithTransientRetry(t.Context(), planRetryTestRequest(), "octocat/hello-world", 1)
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), "schema name is required")
+	assert.Equal(t, 2, client.calls(), "handler should stop when a retry reaches a deterministic failure")
 }
 
 // A cancelled webhook context aborts the retry wait immediately instead of


### PR DESCRIPTION
## Why
Webhook-driven plans can fail on brief remote transport interruptions even when a retry a few seconds later would succeed. That creates unnecessary failure comments and check updates for transient availability blips.

## What
- Route manual and auto-plan execution through the existing transient plan retry helper
- Allow up to three retries for remote unavailability before surfacing the original failure
- Record retry outcomes for recovered, exhausted, and non-transient-stop paths
- Keep deterministic planning, validation, and policy errors unretried

## Risk Assessment
Low — the retry path is limited to webhook plan requests that fail with remote unavailability, and sustained outages still fail closed after the bounded retry budget.

Generated with Amp
