### PR TITLE
fix(sharded): clean apply attribution; guard empty per-shard DDL render

### DIFF
--- a/pkg/webhook/apply_execute.go
+++ b/pkg/webhook/apply_execute.go
@@ -96,7 +96,7 @@ func (h *Handler) executeApply(
 		options["allow_unsafe"] = "true"
 	}
 
-	caller := fmt.Sprintf("github:%s@%s#%d", requestedBy, repo, pr)
+	caller := formatGitHubCaller(requestedBy, repo, pr)
 
 	// Resolve the App factory for this repo once so the observer captures
 	// the correct App for all subsequent GitHub calls (comments, check runs).

--- a/pkg/webhook/caller.go
+++ b/pkg/webhook/caller.go
@@ -1,0 +1,27 @@
+package webhook
+
+import (
+	"fmt"
+	"strings"
+)
+
+// formatGitHubCaller builds the Caller string stored on applies and control
+// requests for a PR command: "github:<user>@<repo>#<pr>". actorFromCaller is its
+// inverse — keep the two in sync.
+func formatGitHubCaller(user, repo string, pr int) string {
+	return fmt.Sprintf("github:%s@%s#%d", user, repo, pr)
+}
+
+// actorFromCaller extracts the GitHub username from a Caller produced by
+// formatGitHubCaller. It returns "" for any other shape, so display code falls
+// back to a non-attributed line rather than rendering the raw structured caller.
+func actorFromCaller(caller string) string {
+	rest, ok := strings.CutPrefix(caller, "github:")
+	if !ok {
+		return ""
+	}
+	if at := strings.IndexByte(rest, '@'); at > 0 {
+		return rest[:at]
+	}
+	return ""
+}

--- a/pkg/webhook/caller_test.go
+++ b/pkg/webhook/caller_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestActorFromCaller(t *testing.T) {
-	assert.Equal(t, "morgo", actorFromCaller("github:morgo@squareup/gap#11890"), "extract the username from the structured caller")
+	assert.Equal(t, "morgo", actorFromCaller("github:morgo@block/example#11890"), "extract the username from the structured caller")
 	assert.Equal(t, "", actorFromCaller("morgo"), "an unrecognised caller yields no actor")
 	assert.Equal(t, "", actorFromCaller(""), "empty caller yields no actor")
 	assert.Equal(t, "", actorFromCaller("github:"), "missing @ yields no actor")
@@ -15,5 +15,5 @@ func TestActorFromCaller(t *testing.T) {
 
 // formatGitHubCaller and actorFromCaller are inverses: the actor round-trips.
 func TestGitHubCallerRoundTrip(t *testing.T) {
-	assert.Equal(t, "morgo", actorFromCaller(formatGitHubCaller("morgo", "squareup/gap", 11890)))
+	assert.Equal(t, "morgo", actorFromCaller(formatGitHubCaller("morgo", "block/example", 11890)))
 }

--- a/pkg/webhook/caller_test.go
+++ b/pkg/webhook/caller_test.go
@@ -1,0 +1,19 @@
+package webhook
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestActorFromCaller(t *testing.T) {
+	assert.Equal(t, "morgo", actorFromCaller("github:morgo@squareup/gap#11890"), "extract the username from the structured caller")
+	assert.Equal(t, "", actorFromCaller("morgo"), "an unrecognised caller yields no actor")
+	assert.Equal(t, "", actorFromCaller(""), "empty caller yields no actor")
+	assert.Equal(t, "", actorFromCaller("github:"), "missing @ yields no actor")
+}
+
+// formatGitHubCaller and actorFromCaller are inverses: the actor round-trips.
+func TestGitHubCallerRoundTrip(t *testing.T) {
+	assert.Equal(t, "morgo", actorFromCaller(formatGitHubCaller("morgo", "squareup/gap", 11890)))
+}

--- a/pkg/webhook/control.go
+++ b/pkg/webhook/control.go
@@ -153,7 +153,7 @@ func runControlCommand[R any](
 		return nil
 	}
 
-	caller := fmt.Sprintf("github:%s@%s#%d", requestedBy, repo, pr)
+	caller := formatGitHubCaller(requestedBy, repo, pr)
 	resp, err := execute(ctx, apitypes.ControlRequest{
 		ApplyID:     result.ApplyID,
 		Environment: result.Environment,

--- a/pkg/webhook/sharded_apply.go
+++ b/pkg/webhook/sharded_apply.go
@@ -35,6 +35,21 @@ func isFinalizerOperationKey(key string) bool {
 	return ok && ns != "" && !strings.Contains(ns, "/")
 }
 
+// shardedApplyActor extracts the display username from an apply's Caller. The
+// webhook stores it as "github:<user>@<repo>#<pr>"; the comment shows just
+// "@<user>". An unrecognised format returns "" so the attribution falls back to
+// the timestamp rather than rendering the raw structured caller.
+func shardedApplyActor(caller string) string {
+	rest, ok := strings.CutPrefix(caller, "github:")
+	if !ok {
+		return ""
+	}
+	if at := strings.IndexByte(rest, '@'); at > 0 {
+		return rest[:at]
+	}
+	return ""
+}
+
 // isShardedApply reports whether the apply's operations are the per-shard
 // fan-out of a single keyspace within one deployment: at least one work
 // operation carries a "namespace/shard/table" key, every operation is a shard
@@ -125,7 +140,7 @@ func buildShardedApplyData(apply *storage.Apply, ops []*storage.ApplyOperation, 
 		Database:    apply.Database,
 		Keyspace:    keyspace,
 		ApplyID:     apply.ApplyIdentifier,
-		RequestedBy: apply.Caller,
+		RequestedBy: shardedApplyActor(apply.Caller),
 		Shards:      shardStatuses(shardOrder, opsByShard, tasksByOp),
 		Cells:       cells,
 	}

--- a/pkg/webhook/sharded_apply.go
+++ b/pkg/webhook/sharded_apply.go
@@ -35,21 +35,6 @@ func isFinalizerOperationKey(key string) bool {
 	return ok && ns != "" && !strings.Contains(ns, "/")
 }
 
-// shardedApplyActor extracts the display username from an apply's Caller. The
-// webhook stores it as "github:<user>@<repo>#<pr>"; the comment shows just
-// "@<user>". An unrecognised format returns "" so the attribution falls back to
-// the timestamp rather than rendering the raw structured caller.
-func shardedApplyActor(caller string) string {
-	rest, ok := strings.CutPrefix(caller, "github:")
-	if !ok {
-		return ""
-	}
-	if at := strings.IndexByte(rest, '@'); at > 0 {
-		return rest[:at]
-	}
-	return ""
-}
-
 // isShardedApply reports whether the apply's operations are the per-shard
 // fan-out of a single keyspace within one deployment: at least one work
 // operation carries a "namespace/shard/table" key, every operation is a shard
@@ -140,7 +125,7 @@ func buildShardedApplyData(apply *storage.Apply, ops []*storage.ApplyOperation, 
 		Database:    apply.Database,
 		Keyspace:    keyspace,
 		ApplyID:     apply.ApplyIdentifier,
-		RequestedBy: shardedApplyActor(apply.Caller),
+		RequestedBy: actorFromCaller(apply.Caller),
 		Shards:      shardStatuses(shardOrder, opsByShard, tasksByOp),
 		Cells:       cells,
 	}

--- a/pkg/webhook/sharded_apply_test.go
+++ b/pkg/webhook/sharded_apply_test.go
@@ -11,6 +11,29 @@ import (
 	"github.com/block/schemabot/pkg/storage"
 )
 
+func TestShardedApplyActor(t *testing.T) {
+	assert.Equal(t, "morgo", shardedApplyActor("github:morgo@squareup/gap#11890"), "extract the username from the structured caller")
+	assert.Equal(t, "", shardedApplyActor("morgo"), "an unrecognised caller falls back to the timestamp")
+	assert.Equal(t, "", shardedApplyActor(""), "empty caller falls back to the timestamp")
+}
+
+// A sharded apply comment renders the attribution from the username, not the raw
+// structured caller (which produced a malformed "@github:morgo@…#…" line).
+func TestFormatApplyStatusComment_ShardedAttributionFromCaller(t *testing.T) {
+	apply := &storage.Apply{
+		ApplyIdentifier: "apply-x", Database: "cdb_resolute", Environment: "staging", State: state.Apply.Running,
+		Caller: "github:morgo@squareup/gap#11890",
+	}
+	op := &storage.ApplyOperation{ID: 1, ApplyID: 1, Deployment: "cake", OperationKey: "cdb_resolute_sharded/-40/mutes", State: state.ApplyOperation.Running, CutoverPolicy: storage.CutoverPolicyRolling, OnFailure: storage.OnFailureHalt}
+	oid := int64(1)
+	tasks := []*storage.Task{{ID: 1, ApplyID: 1, ApplyOperationID: &oid, Namespace: "cdb_resolute_sharded", TableName: "mutes", Shard: "-40", DDL: "ALTER TABLE `mutes` ADD INDEX a"}}
+
+	out := formatApplyStatusComment(apply, []*storage.ApplyOperation{op}, tasks, nil, nil)
+
+	assert.Contains(t, out, "by @morgo at", "attribution shows the clean username")
+	assert.NotContains(t, out, "github:", "the raw structured caller is not rendered")
+}
+
 func TestParseShardOperationKey(t *testing.T) {
 	ns, shard, table, ok := parseShardOperationKey("cdb_resolute_sharded/-40/mutes")
 	require.True(t, ok)

--- a/pkg/webhook/sharded_apply_test.go
+++ b/pkg/webhook/sharded_apply_test.go
@@ -11,12 +11,6 @@ import (
 	"github.com/block/schemabot/pkg/storage"
 )
 
-func TestShardedApplyActor(t *testing.T) {
-	assert.Equal(t, "morgo", shardedApplyActor("github:morgo@squareup/gap#11890"), "extract the username from the structured caller")
-	assert.Equal(t, "", shardedApplyActor("morgo"), "an unrecognised caller falls back to the timestamp")
-	assert.Equal(t, "", shardedApplyActor(""), "empty caller falls back to the timestamp")
-}
-
 // A sharded apply comment renders the attribution from the username, not the raw
 // structured caller (which produced a malformed "@github:morgo@…#…" line).
 func TestFormatApplyStatusComment_ShardedAttributionFromCaller(t *testing.T) {

--- a/pkg/webhook/sharded_apply_test.go
+++ b/pkg/webhook/sharded_apply_test.go
@@ -16,7 +16,7 @@ import (
 func TestFormatApplyStatusComment_ShardedAttributionFromCaller(t *testing.T) {
 	apply := &storage.Apply{
 		ApplyIdentifier: "apply-x", Database: "cdb_resolute", Environment: "staging", State: state.Apply.Running,
-		Caller: "github:morgo@squareup/gap#11890",
+		Caller: "github:morgo@block/example#11890",
 	}
 	op := &storage.ApplyOperation{ID: 1, ApplyID: 1, Deployment: "cake", OperationKey: "cdb_resolute_sharded/-40/mutes", State: state.ApplyOperation.Running, CutoverPolicy: storage.CutoverPolicyRolling, OnFailure: storage.OnFailureHalt}
 	oid := int64(1)

--- a/pkg/webhook/templates/sharded_apply.go
+++ b/pkg/webhook/templates/sharded_apply.go
@@ -249,6 +249,13 @@ func writeShardStatusTable(sb *strings.Builder, shards []ShardStatus) {
 // writeGroupDDL writes a group's table changes, each DDL once.
 func writeGroupDDL(sb *strings.Builder, changes []ShardChange) {
 	for _, c := range changes {
+		// Guard against an empty DDL, which would render a blank ```sql box. The
+		// DDL should always be present; if it is missing the change data is
+		// incomplete, so say so rather than show an empty code block.
+		if strings.TrimSpace(c.DDL) == "" {
+			fmt.Fprintf(sb, "\n`%s` — _DDL unavailable_\n", c.Table)
+			continue
+		}
 		fmt.Fprintf(sb, "\n`%s`\n```sql\n%s\n```\n", c.Table, c.DDL)
 	}
 }

--- a/pkg/webhook/templates/sharded_apply_test.go
+++ b/pkg/webhook/templates/sharded_apply_test.go
@@ -99,6 +99,26 @@ func TestRenderShardedApplyComment_DivergentGroupsByVariant(t *testing.T) {
 	assert.Equal(t, 2, strings.Count(out, "```sql"), "one DDL block per group")
 }
 
+// A change whose DDL never reached the comment (incomplete change data) renders
+// a "DDL unavailable" note instead of an empty ```sql box that reads as a no-op.
+func TestRenderShardedApplyComment_EmptyDDLRendersUnavailable(t *testing.T) {
+	out := RenderShardedApplyComment(ShardedApplyData{
+		State: state.Apply.Running, Environment: "staging", Database: "cdb_resolute",
+		Keyspace: "cdb_resolute_sharded", ApplyID: "apply-x",
+		Shards: []ShardStatus{
+			{Shard: "-40", Emoji: "🔄", Label: "running table copy", State: state.ApplyOperation.Running},
+			{Shard: "80-", Emoji: "⏳", Label: "queued — next in order", State: state.ApplyOperation.Pending},
+		},
+		Cells: []ShardCell{
+			{Shard: "-40", Table: "mutes", DDL: "   "}, // whitespace-only DDL is treated as missing
+			{Shard: "80-", Table: "mutes", DDL: ""},
+		},
+	})
+
+	assert.Contains(t, out, "`mutes` — _DDL unavailable_", "the missing DDL is called out")
+	assert.Equal(t, 0, strings.Count(out, "```sql"), "no blank SQL box for the missing DDL")
+}
+
 // A single-shard divergent group degrades cleanly: one group, no spurious
 // grouping header for a uniform apply (covered above) — here every shard shares
 // the same multi-table change set, so it is still one group.


### PR DESCRIPTION
## What

Two follow-up fixes to the sharded apply comment (#546):

1. **Clean apply attribution.** The sharded apply comment rendered the raw structured caller (`github:<user>@<repo>#<pr>`) as a malformed `*Applied by @github:morgo@…#…*`. `shardedApplyActor` now extracts just the username (`@morgo`), falling back to the timestamp for an unrecognised caller — matching the multi-deployment comment.

2. **Guard empty per-shard DDL.** `writeGroupDDL` no longer emits a blank ` ```sql ` box when a change's DDL is empty; it renders `` `table` — _DDL unavailable_ `` so incomplete change data is obvious instead of looking like a broken empty code block.

## Note (not fixed here)

An empty per-shard DDL — and the related data-plane "expected exactly one target shard, got 0" — is a **data** symptom: the per-shard task rows are created without their `{shard, DDL}` payload. A task's shard tag and DDL are written together at fan-out, so an empty DDL is the same root cause as the empty `TargetShards`. That's a task-creation / stored-plan issue under separate investigation, not a rendering bug.

## Tests

`shardedApplyActor` extraction + the apply comment rendering the clean username (not the raw caller); existing `pkg/webhook` suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
