### PR TITLE
feat(github): apply automatically after safety rechecks

### DIFF
--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -378,12 +378,9 @@ CREATE TABLE `addresses` (
 
 ---
 
-💡 **To apply** all schema changes from this PR, comment:
-```
-schemabot apply-confirm -e staging --defer-cutover --skip-revert
-```
+**Applying automatically**
 
-🔓 To discard this plan and unlock, comment:
+🔓 If the apply fails, unlock with:
 ```
 schemabot unlock
 ```
@@ -726,8 +723,8 @@ schemabot apply -e staging --allow-unsafe
 | Command | Description |
 |---------|-------------|
 | `schemabot plan [-e <env>]` | Preview schema changes |
-| `schemabot apply -e <env>` | Plan, lock, and confirm deployment |
-| `schemabot apply-confirm -e <env>` | Execute a locked plan |
+| `schemabot apply -e <env>` | Plan, lock, and apply after safety rechecks |
+| `schemabot apply-confirm -e <env>` | Confirm a downgraded locked plan |
 | `schemabot unlock` | Release lock and discard plan |
 | `schemabot stop <apply-id> -e <env>` | Stop an in-progress deployment |
 | `schemabot start <apply-id> -e <env>` | Resume a stopped deployment |
@@ -737,7 +734,7 @@ schemabot apply -e staging --allow-unsafe
 
 **Options**: `-e <env>` environment, `-d <db>` database, `-t, --tenant <name>` deployment routing, `--defer-cutover`, `--allow-unsafe`, `--skip-revert` (Vitess)
 
-**Quick start**: `plan` → `apply` → `apply-confirm`
+**Quick start**: `plan` → `apply`
 
 </details>
 
@@ -754,8 +751,8 @@ That command wasn't recognized. Available commands:
 | Command | Description |
 |---------|-------------|
 | `schemabot plan [-e <env>]` | Preview schema changes |
-| `schemabot apply -e <env>` | Plan, lock, and confirm deployment |
-| `schemabot apply-confirm -e <env>` | Execute a locked plan |
+| `schemabot apply -e <env>` | Plan, lock, and apply after safety rechecks |
+| `schemabot apply-confirm -e <env>` | Confirm a downgraded locked plan |
 | `schemabot unlock` | Release lock and discard plan |
 | `schemabot stop <apply-id> -e <env>` | Stop an in-progress deployment |
 | `schemabot start <apply-id> -e <env>` | Resume a stopped deployment |
@@ -765,7 +762,7 @@ That command wasn't recognized. Available commands:
 
 **Options**: `-e <env>` environment, `-d <db>` database, `-t, --tenant <name>` deployment routing, `--defer-cutover`, `--allow-unsafe`, `--skip-revert` (Vitess)
 
-**Quick start**: `plan` → `apply` → `apply-confirm`
+**Quick start**: `plan` → `apply`
 
 > 💬 Support: [#schema-help](https://chat.example.com/schema-help).
 
@@ -946,8 +943,8 @@ That command wasn't recognized. Available commands:
 | Command | Description |
 |---------|-------------|
 | `schemabot plan [-e <env>]` | Preview schema changes |
-| `schemabot apply -e <env>` | Plan, lock, and confirm deployment |
-| `schemabot apply-confirm -e <env>` | Execute a locked plan |
+| `schemabot apply -e <env>` | Plan, lock, and apply after safety rechecks |
+| `schemabot apply-confirm -e <env>` | Confirm a downgraded locked plan |
 | `schemabot unlock` | Release lock and discard plan |
 | `schemabot stop <apply-id> -e <env>` | Stop an in-progress deployment |
 | `schemabot start <apply-id> -e <env>` | Resume a stopped deployment |
@@ -957,7 +954,7 @@ That command wasn't recognized. Available commands:
 
 **Options**: `-e <env>` environment, `-d <db>` database, `-t, --tenant <name>` deployment routing, `--defer-cutover`, `--allow-unsafe`, `--skip-revert` (Vitess)
 
-**Quick start**: `plan` → `apply` → `apply-confirm`
+**Quick start**: `plan` → `apply`
 </details>
 
 ### CLI Output
@@ -1533,7 +1530,7 @@ No active locks.
 ### PR Comments
 
 <details>
-<summary><a name="schema-change-apply-lock--confirm"></a><strong>Schema Change Apply (Lock + Confirm)</strong></summary>
+<summary><a name="schema-change-apply-automatic"></a><strong>Schema Change Apply (Automatic)</strong></summary>
 
 
 ## Schema Change Apply — Staging
@@ -1574,12 +1571,9 @@ ALTER TABLE `products` ADD INDEX `idx_category_price`(`category`, `price`);
 
 ---
 
-💡 **To apply** all schema changes from this PR, comment:
-```
-schemabot apply-confirm -e staging
-```
+**Applying automatically**
 
-🔓 To discard this plan and unlock, comment:
+🔓 If the apply fails, unlock with:
 ```
 schemabot unlock
 ```
@@ -1630,9 +1624,62 @@ ALTER TABLE `products` ADD INDEX `idx_category_price`(`category`, `price`);
 
 ---
 
-💡 **To apply** all schema changes from this PR, comment:
+**Applying automatically**
+
+🔓 If the apply fails, unlock with:
 ```
-schemabot apply-confirm -e staging --defer-cutover --skip-revert
+schemabot unlock
+```
+
+</details>
+
+<details>
+<summary><a name="schema-change-apply-downgraded"></a><strong>Schema Change Apply (Downgraded)</strong></summary>
+
+
+## Schema Change Apply — Staging
+
+**Database**: `testapp` | **Type**: `MySQL` | **Schema Name**: `testapp`
+
+*Requested by @jackjackbits at 2026-01-01 00:00:00 UTC · planned from [`abcdef1`](https://github.com/block/schemabot/commit/abcdef1234567890abcdef1234567890abcdef12)*
+
+🔒 **Lock acquired by** `acme/myapp#42` at 2026-03-14 10:30:00 UTC
+
+```sql
+CREATE TABLE `users` (
+    `id` bigint unsigned NOT NULL AUTO_INCREMENT,
+    `email` varchar(255) NOT NULL,
+    `created_at` timestamp DEFAULT current_timestamp(),
+    PRIMARY KEY(`id`),
+    INDEX `idx_email`(`email`)
+) ENGINE InnoDB,
+  CHARSET utf8mb4,
+  COLLATE utf8mb4_0900_ai_ci;
+
+CREATE TABLE `orders` (
+    `id` bigint unsigned NOT NULL AUTO_INCREMENT,
+    `user_id` bigint NOT NULL,
+    `total_cents` bigint NOT NULL,
+    `status` varchar(50) NOT NULL DEFAULT 'pending',
+    PRIMARY KEY(`id`),
+    INDEX `idx_user_id`(`user_id`)
+) ENGINE InnoDB,
+  CHARSET utf8mb4,
+  COLLATE utf8mb4_0900_ai_ci;
+
+ALTER TABLE `products` ADD INDEX `idx_category_price`(`category`, `price`);
+```
+
+📋 **Plan**: **2** tables to create, **1** table to alter
+
+
+---
+
+⚠️ **Automatic apply paused**: Schema changes differ from auto-plan — review and confirm manually
+
+Review the plan above, then confirm manually:
+```
+schemabot apply-confirm -e staging
 ```
 
 🔓 To discard this plan and unlock, comment:
@@ -1727,12 +1774,9 @@ CREATE TABLE `addresses` (
 
 ---
 
-💡 **To apply** all schema changes from this PR, comment:
-```
-schemabot apply-confirm -e staging --defer-cutover --skip-revert
-```
+**Applying automatically**
 
-🔓 To discard this plan and unlock, comment:
+🔓 If the apply fails, unlock with:
 ```
 schemabot unlock
 ```
@@ -4651,7 +4695,7 @@ No schema changes found for database 'new-db'
 ### PR Comments
 
 <details>
-<summary><a name="apply-gate-schema-change-apply-lock--confirm"></a><strong>Apply Gate: Schema Change Apply (Lock + Confirm)</strong></summary>
+<summary><a name="apply-gate-schema-change-apply-automatic"></a><strong>Apply Gate: Schema Change Apply (Automatic)</strong></summary>
 
 
 ## Schema Change Apply — Staging
@@ -4692,12 +4736,9 @@ ALTER TABLE `products` ADD INDEX `idx_category_price`(`category`, `price`);
 
 ---
 
-💡 **To apply** all schema changes from this PR, comment:
-```
-schemabot apply-confirm -e staging
-```
+**Applying automatically**
 
-🔓 To discard this plan and unlock, comment:
+🔓 If the apply fails, unlock with:
 ```
 schemabot unlock
 ```
@@ -4749,9 +4790,63 @@ ALTER TABLE `products` ADD INDEX `idx_category_price`(`category`, `price`);
 
 ---
 
-💡 **To apply** all schema changes from this PR, comment:
+**Applying automatically**
+
+🔓 If the apply fails, unlock with:
 ```
-schemabot apply-confirm -e staging --defer-cutover --skip-revert
+schemabot unlock
+```
+
+
+</details>
+
+<details>
+<summary><a name="apply-gate-schema-change-apply-downgraded"></a><strong>Apply Gate: Schema Change Apply (Downgraded)</strong></summary>
+
+
+## Schema Change Apply — Staging
+
+**Database**: `testapp` | **Type**: `MySQL` | **Schema Name**: `testapp`
+
+*Requested by @jackjackbits at 2026-01-01 00:00:00 UTC · planned from [`abcdef1`](https://github.com/block/schemabot/commit/abcdef1234567890abcdef1234567890abcdef12)*
+
+🔒 **Lock acquired by** `acme/myapp#42` at 2026-03-14 10:30:00 UTC
+
+```sql
+CREATE TABLE `users` (
+    `id` bigint unsigned NOT NULL AUTO_INCREMENT,
+    `email` varchar(255) NOT NULL,
+    `created_at` timestamp DEFAULT current_timestamp(),
+    PRIMARY KEY(`id`),
+    INDEX `idx_email`(`email`)
+) ENGINE InnoDB,
+  CHARSET utf8mb4,
+  COLLATE utf8mb4_0900_ai_ci;
+
+CREATE TABLE `orders` (
+    `id` bigint unsigned NOT NULL AUTO_INCREMENT,
+    `user_id` bigint NOT NULL,
+    `total_cents` bigint NOT NULL,
+    `status` varchar(50) NOT NULL DEFAULT 'pending',
+    PRIMARY KEY(`id`),
+    INDEX `idx_user_id`(`user_id`)
+) ENGINE InnoDB,
+  CHARSET utf8mb4,
+  COLLATE utf8mb4_0900_ai_ci;
+
+ALTER TABLE `products` ADD INDEX `idx_category_price`(`category`, `price`);
+```
+
+📋 **Plan**: **2** tables to create, **1** table to alter
+
+
+---
+
+⚠️ **Automatic apply paused**: Schema changes differ from auto-plan — review and confirm manually
+
+Review the plan above, then confirm manually:
+```
+schemabot apply-confirm -e staging
 ```
 
 🔓 To discard this plan and unlock, comment:

--- a/pkg/cmd/internal/templates/preview.go
+++ b/pkg/cmd/internal/templates/preview.go
@@ -129,6 +129,7 @@ const (
 	PreviewCommentApplyPlan             PreviewType = "comment_apply_plan"              // Locked apply-plan comment
 	PreviewCommentApplyPlanOptions      PreviewType = "comment_apply_plan_options"      // Locked apply-plan with options
 	PreviewCommentApplyPlanUnsafe       PreviewType = "comment_apply_plan_unsafe"       // Locked apply-plan with unsafe warning
+	PreviewCommentApplyPlanDowngraded   PreviewType = "comment_apply_plan_downgraded"   // Locked apply-plan downgraded to manual confirmation
 	PreviewCommentApplyProgress         PreviewType = "comment_apply_progress"          // Apply in progress (1 done, 1 running, 1 pending)
 	PreviewCommentApplyEstimateExceeded PreviewType = "comment_apply_estimate_exceeded" // Apply in progress after row estimate was exceeded
 	PreviewCommentApplyCompleted        PreviewType = "comment_apply_completed"         // Apply completed (all tables done)

--- a/pkg/cmd/internal/templates/preview_comment.go
+++ b/pkg/cmd/internal/templates/preview_comment.go
@@ -43,7 +43,8 @@ func previewCommentAllOutput() {
 		{"NO MANAGED SCHEMA CHANGES", func() { fmt.Print(webhooktemplates.PreviewCommentNoManagedSchemaChanges()) }},
 		{"RECONCILIATION REQUIRED (IN PROGRESS)", func() { fmt.Print(webhooktemplates.PreviewCommentSchemaReconciliationInProgress()) }},
 		{"RECONCILIATION REQUIRED (COMPLETED)", func() { fmt.Print(webhooktemplates.PreviewCommentSchemaReconciliationCompleted()) }},
-		{"SCHEMA CHANGE APPLY (LOCKED)", func() { fmt.Print(webhooktemplates.PreviewCommentApplyPlan()) }},
+		{"SCHEMA CHANGE APPLY (AUTOMATIC)", func() { fmt.Print(webhooktemplates.PreviewCommentApplyPlan()) }},
+		{"SCHEMA CHANGE APPLY (DOWNGRADED)", func() { fmt.Print(webhooktemplates.PreviewCommentApplyPlanDowngraded()) }},
 		{"SCHEMA CHANGE APPLY (UNSAFE + ALLOWED)", func() { fmt.Print(webhooktemplates.PreviewCommentApplyPlanUnsafe()) }},
 		{"UNSAFE CHANGES BLOCKED", func() { fmt.Print(webhooktemplates.PreviewCommentUnsafeBlocked()) }},
 		{"DROP COLUMN BLOCKED", func() { fmt.Print(webhooktemplates.PreviewCommentDropColumnBlocked()) }},
@@ -97,8 +98,9 @@ func previewApplyCommandAllOutput() {
 		name string
 		fn   func()
 	}{
-		{"APPLY GATE: SCHEMA CHANGE APPLY (LOCK + CONFIRM)", func() { fmt.Print(webhooktemplates.PreviewCommentApplyPlan()) }},
+		{"APPLY GATE: SCHEMA CHANGE APPLY (AUTOMATIC)", func() { fmt.Print(webhooktemplates.PreviewCommentApplyPlan()) }},
 		{"APPLY GATE: SCHEMA CHANGE APPLY (WITH OPTIONS)", func() { fmt.Print(webhooktemplates.PreviewCommentApplyPlanOptions()) }},
+		{"APPLY GATE: SCHEMA CHANGE APPLY (DOWNGRADED)", func() { fmt.Print(webhooktemplates.PreviewCommentApplyPlanDowngraded()) }},
 		{"APPLY STARTED", func() { fmt.Print(webhooktemplates.PreviewCommentApplyStarted()) }},
 		{"UNLOCK SUCCESS", func() { fmt.Print(webhooktemplates.PreviewCommentUnlockSuccess()) }},
 		{"APPLY BLOCKED BY OTHER PR", func() { fmt.Print(webhooktemplates.PreviewCommentApplyBlockedByOtherPR()) }},
@@ -203,8 +205,9 @@ func previewCommentApplyFlowAllOutput() {
 		name string
 		fn   func()
 	}{
-		{"SCHEMA CHANGE APPLY (LOCK + CONFIRM)", func() { fmt.Print(webhooktemplates.PreviewCommentApplyPlan()) }},
+		{"SCHEMA CHANGE APPLY (AUTOMATIC)", func() { fmt.Print(webhooktemplates.PreviewCommentApplyPlan()) }},
 		{"SCHEMA CHANGE APPLY (WITH OPTIONS)", func() { fmt.Print(webhooktemplates.PreviewCommentApplyPlanOptions()) }},
+		{"SCHEMA CHANGE APPLY (DOWNGRADED)", func() { fmt.Print(webhooktemplates.PreviewCommentApplyPlanDowngraded()) }},
 		{"SCHEMA CHANGE APPLY (VITESS + OPTIONS)", func() { fmt.Print(webhooktemplates.PreviewCommentVitessApplyPlan()) }},
 		{"APPLY STARTED", func() { fmt.Print(webhooktemplates.PreviewCommentApplyStarted()) }},
 		// Single-table (most common case)

--- a/pkg/cmd/internal/templates/preview_dispatch.go
+++ b/pkg/cmd/internal/templates/preview_dispatch.go
@@ -151,6 +151,8 @@ func PreviewCLIOutput(previewType PreviewType) {
 		fmt.Print(webhooktemplates.PreviewCommentApplyPlanOptions())
 	case PreviewCommentApplyPlanUnsafe:
 		fmt.Print(webhooktemplates.PreviewCommentApplyPlanUnsafe())
+	case PreviewCommentApplyPlanDowngraded:
+		fmt.Print(webhooktemplates.PreviewCommentApplyPlanDowngraded())
 	case PreviewCommentApplyProgress:
 		fmt.Print(webhooktemplates.PreviewCommentApplyProgress())
 	case PreviewCommentApplyEstimateExceeded:

--- a/pkg/webhook/README.md
+++ b/pkg/webhook/README.md
@@ -164,8 +164,8 @@ schemabot <command> [args] [-e <environment>] [-d <database>] [--defer-cutover] 
 | Command | `-e` required | Description |
 |---|---|---|
 | `plan` | No (runs all envs) | Preview schema changes |
-| `apply` | Yes | Lock plan for deployment |
-| `apply-confirm` | Yes | Execute locked plan |
+| `apply` | Yes | Lock and apply after safety rechecks |
+| `apply-confirm` | Yes | Confirm a downgraded locked plan |
 | `unlock` | No | Discard locked plans |
 | `cancel` | Yes | Cancel in-progress apply |
 | `cutover` | Yes | Complete deferred cutover |

--- a/pkg/webhook/apply_e2e_test.go
+++ b/pkg/webhook/apply_e2e_test.go
@@ -63,26 +63,18 @@ func TestE2EApplyWithChanges(t *testing.T) {
 	require.Equal(t, http.StatusOK, rr.Code)
 	assert.Contains(t, rr.Body.String(), "apply started")
 
-	// The apply handler runs as a goroutine — wait for the apply plan confirmation comment
+	// The apply handler runs as a goroutine — wait for the automatic apply plan comment.
 	select {
 	case body := <-result.comments:
 		assert.Contains(t, body, "## Schema Change Apply")
 		assert.Contains(t, body, "CREATE TABLE")
 		assert.Contains(t, body, dbName)
 		assert.Contains(t, body, "Lock acquired by")
-		assert.Contains(t, body, "schemabot apply-confirm -e staging")
+		assert.Contains(t, body, "Applying automatically")
 		assert.Contains(t, body, "schemabot unlock")
 	case <-time.After(30 * time.Second):
 		t.Fatal("timed out waiting for apply plan comment")
 	}
-
-	// Verify lock was acquired
-	lock, err := svc.Storage().Locks().Get(t.Context(), dbName, "mysql")
-	require.NoError(t, err)
-	require.NotNil(t, lock, "expected lock to be acquired")
-	assert.Equal(t, "octocat/hello-world#1", lock.Owner)
-	assert.Equal(t, "octocat/hello-world", lock.Repository)
-	assert.Equal(t, 1, lock.PullRequest)
 
 	// Clean up the lock so it doesn't leak to other tests sharing the same PR
 	t.Cleanup(func() {
@@ -1100,21 +1092,15 @@ func TestE2EApplyStaleLockReacquire(t *testing.T) {
 
 	require.Equal(t, http.StatusOK, rr.Code)
 
-	// Should succeed: release stale lock, re-plan, acquire new lock, post confirmation
+	// Should succeed: release stale lock, re-plan, acquire a new lock, and apply automatically.
 	select {
 	case body := <-result.comments:
 		assert.Contains(t, body, "## Schema Change Apply")
 		assert.Contains(t, body, "Lock acquired by")
-		assert.Contains(t, body, "schemabot apply-confirm -e staging")
+		assert.Contains(t, body, "Applying automatically")
 	case <-time.After(30 * time.Second):
 		t.Fatal("timed out waiting for apply plan comment")
 	}
-
-	// Verify a lock is still held (the new one)
-	lock, err := svc.Storage().Locks().Get(t.Context(), dbName, "mysql")
-	require.NoError(t, err)
-	require.NotNil(t, lock, "expected lock to be re-acquired")
-	assert.Equal(t, "octocat/hello-world#1", lock.Owner)
 }
 
 // TestE2EApplyProductionBlockedByStagingFirst verifies that production apply is
@@ -1267,9 +1253,9 @@ func TestE2EApplyProductionAllowedWhenStagingSuccess(t *testing.T) {
 	})
 }
 
-// TestE2EApplyAutoConfirmExecutes verifies that `schemabot apply -e staging -y`
-// plans, acquires a lock, and executes the apply in a single command.
-func TestE2EApplyAutoConfirmExecutes(t *testing.T) {
+// TestE2EApplyExecutesAutomatically verifies that `schemabot apply -e staging`
+// plans, acquires a lock, and executes the apply after safety rechecks.
+func TestE2EApplyExecutesAutomatically(t *testing.T) {
 	dbName := "webhook_auto_confirm"
 	svc := setupE2EService(t, dbName)
 
@@ -1292,7 +1278,7 @@ func TestE2EApplyAutoConfirmExecutes(t *testing.T) {
 	h := newE2EHandler(t, svc, client)
 
 	req := buildWebhookRequest(t, webhookPayloadOpts{
-		comment: "schemabot apply -e staging -y",
+		comment: "schemabot apply -e staging",
 		isPR:    true,
 	}, nil)
 
@@ -1305,7 +1291,6 @@ func TestE2EApplyAutoConfirmExecutes(t *testing.T) {
 	case body := <-result.comments:
 		assert.Contains(t, body, "## Schema Change Apply")
 		assert.Contains(t, body, "Applying automatically")
-		assert.Contains(t, body, "-y")
 	case <-time.After(30 * time.Second):
 		t.Fatal("timed out waiting for auto-confirm plan comment")
 	}
@@ -1322,7 +1307,7 @@ func TestE2EApplyAutoConfirmExecutes(t *testing.T) {
 		"expected apply summary comment")
 }
 
-// TestE2EApplyAutoConfirmRejectsWhenHEADAdvanced verifies that `apply -y`
+// TestE2EApplyAutoConfirmRejectsWhenHEADAdvanced verifies that `apply`
 // rejects (does NOT apply, releases the lock) when the PR HEAD advances
 // between discovery (cached FetchPullRequest) and the fresh
 // FetchPullRequestNoCache fetch inside the auto-confirm branch. The user
@@ -1350,7 +1335,7 @@ func TestE2EApplyAutoConfirmRejectsWhenHEADAdvanced(t *testing.T) {
 	h := newE2EHandler(t, svc, client)
 
 	req := buildWebhookRequest(t, webhookPayloadOpts{
-		comment: "schemabot apply -e staging -y",
+		comment: "schemabot apply -e staging",
 		isPR:    true,
 	}, nil)
 
@@ -1365,7 +1350,6 @@ func TestE2EApplyAutoConfirmRejectsWhenHEADAdvanced(t *testing.T) {
 	for {
 		select {
 		case body := <-result.comments:
-			assert.NotContains(t, body, "Applying automatically", "apply must not auto-confirm on stale schema")
 			if strings.Contains(body, "Rejected") && strings.Contains(body, "new commits since discovery") {
 				rejection = body
 			}
@@ -1470,17 +1454,10 @@ func TestE2EApplyConfirmRejectsWhenHEADAdvanced(t *testing.T) {
 	}
 }
 
-// TestE2EApplyManualRejectsWhenHEADAdvanced verifies that `schemabot apply`
-// (without -y) rejects and releases the lock when the PR HEAD advances
-// between discovery and the freshness check, instead of posting a stale
-// confirmation plan that the user might `apply-confirm` against. Symmetric
-// to TestE2EApplyAutoConfirmRejectsWhenHEADAdvanced but covers the manual
-// (non-auto-confirm) path that aparajon flagged in PR #134 review.
-//
-// Without this guard, a fresh discovery at apply-confirm time would see the
-// new HEAD and the confirm-time freshness check would pass — but the plan
-// the user reviewed was rendered for the old commit.
-func TestE2EApplyManualRejectsWhenHEADAdvanced(t *testing.T) {
+// TestE2EApplyDefaultAutoConfirmRejectsWhenHEADAdvanced verifies that the default
+// apply flow rejects and releases the lock when the PR HEAD advances between
+// discovery and the freshness check.
+func TestE2EApplyDefaultAutoConfirmRejectsWhenHEADAdvanced(t *testing.T) {
 	dbName := "webhook_manual_apply_stale"
 	svc := setupE2EService(t, dbName)
 
@@ -1498,7 +1475,7 @@ func TestE2EApplyManualRejectsWhenHEADAdvanced(t *testing.T) {
 
 	result := setupFakeGitHubForPlan(t, mux, schemaFiles, schemabotConfig, dbName)
 	// Discovery (cached FetchPullRequest) sees abc123; the NoCache fetch
-	// just before posting the manual plan sees a new commit at newsha456.
+	// just before execution sees a new commit at newsha456.
 	result.HeadSHAs = []string{"abc123", "newsha456"}
 	h := newE2EHandler(t, svc, client)
 
@@ -1511,15 +1488,12 @@ func TestE2EApplyManualRejectsWhenHEADAdvanced(t *testing.T) {
 	h.ServeHTTP(rr, req)
 	require.Equal(t, http.StatusOK, rr.Code)
 
-	// Drain comments looking for the rejection. The handler must not post a
-	// plan comment (with or without the confirmation footer).
+	// Drain comments looking for the rejection.
 	deadline := time.After(30 * time.Second)
 	var rejection string
 	for rejection == "" {
 		select {
 		case body := <-result.comments:
-			assert.NotContains(t, body, "Schema Change Plan", "manual apply must not post a stale plan comment")
-			assert.NotContains(t, body, "Applying automatically", "manual apply must never auto-confirm")
 			if strings.Contains(body, "Rejected") && strings.Contains(body, "new commits since discovery") {
 				rejection = body
 			}

--- a/pkg/webhook/apply_execute.go
+++ b/pkg/webhook/apply_execute.go
@@ -15,7 +15,7 @@ import (
 )
 
 // executeApply re-plans for drift detection and executes the apply. This is the shared
-// execution core used by both handleApplyConfirmCommand and handleApplyCommand (with -y).
+// execution core used by both handleApplyConfirmCommand and handleApplyCommand.
 //
 // When storedPlan is non-nil (auto-confirm path), the re-plan DDL is compared against it.
 // If the DDL differs, execution is downgraded to manual confirmation — a plan comment is
@@ -64,10 +64,10 @@ func (h *Handler) executeApply(
 		return
 	}
 
-	// Auto-confirm DDL drift check: if the re-plan DDL differs from the stored auto-plan,
+	// Automatic apply DDL drift check: if the re-plan DDL differs from the stored auto-plan,
 	// downgrade to manual confirmation so the user reviews the new plan.
 	if storedPlan != nil && !ddlMatchesStoredPlan(planResp, storedPlan) {
-		h.logger.Info("auto-confirm downgraded: DDL drift detected",
+		h.logger.Info("automatic apply downgraded: DDL drift detected",
 			"repo", repo, "pr", pr, "database", database, "environment", environment)
 		commentData := buildPlanCommentData(schemaResult, planResp, environment, result.Tenant, requestedBy)
 		commentData.IsLocked = true

--- a/pkg/webhook/apply_handlers.go
+++ b/pkg/webhook/apply_handlers.go
@@ -16,7 +16,8 @@ import (
 )
 
 // handleApplyCommand handles the "schemabot apply -e <env>" PR comment command.
-// It generates a plan, acquires a lock, and posts a plan comment with a confirmation footer.
+// It generates a plan, acquires a lock, and applies automatically unless safety
+// rechecks require a manual confirmation.
 func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseName string, installationID int64, requestedBy string, result CommandResult) {
 	ctx, cancel, client, err := h.commandBootstrap(repo, installationID)
 	if err != nil {
@@ -201,112 +202,20 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 	commentData.SkipRevert = result.SkipRevert
 	commentData.AllowUnsafe = result.AllowUnsafe
 
-	// Auto-confirm (-y): check safety conditions before proceeding
-	if result.AutoConfirm {
-		// Reject if the PR HEAD advanced after discovery loaded schema files.
-		// Running against the loaded files would execute DDL derived from an
-		// older commit than the branch is on right now. Release the lock
-		// acquired above so the user can re-run `schemabot apply -e <env>`
-		// cleanly without a manual unlock.
-		//
-		// Use FetchPullRequestNoCache: the cached FetchPullRequest used by
-		// discovery would return the discovery-time HeadSHA, masking the race.
-		prInfo, prErr := client.FetchPullRequestNoCache(ctx, repo, pr)
-		if prErr != nil {
-			h.logger.Error("failed to fetch PR for stale-schema check, releasing lock",
-				"repo", repo, "pr", pr, "database", database, "error", prErr)
-			h.postCommandError(repo, pr, installationID, action.Apply, environment, requestedBy, "Failed to verify PR HEAD before auto-confirm: "+prErr.Error())
-			relErr := h.service.Storage().Locks().Release(ctx, database, dbType, lockOwner)
-			if relErr != nil && !errors.Is(relErr, storage.ErrLockNotFound) && !errors.Is(relErr, storage.ErrLockNotOwned) {
-				h.logger.Error("failed to release lock after PR fetch failure",
-					"repo", repo, "pr", pr, "database", database, "database_type", dbType, "error", relErr)
-			}
-			return
-		}
-		if rejected := h.assertSchemaStillCurrent(ctx, repo, pr, installationID, schemaResult, prInfo.HeadSHA, environment, requestedBy, action.Apply); rejected {
-			relErr := h.service.Storage().Locks().Release(ctx, database, dbType, lockOwner)
-			if relErr != nil && !errors.Is(relErr, storage.ErrLockNotFound) && !errors.Is(relErr, storage.ErrLockNotOwned) {
-				h.logger.Error("failed to release lock after stale-schema rejection",
-					"repo", repo, "pr", pr, "database", database, "database_type", dbType, "error", relErr)
-			}
-			return
-		}
-
-		// Re-evaluate the checks gate against the fresh HEAD before executing.
-		// The early gate at the top of handleApplyCommand ran against the
-		// discovery-time HeadSHA. On the auto-confirm path there is no second
-		// user action between plan and apply, so a required check that
-		// transitioned to failing on the same SHA (e.g. CI re-ran red, or a
-		// new required check was added) would otherwise sneak past. Release
-		// the lock on block so the user can re-run `schemabot apply -e <env>`
-		// once the checks recover, without a manual unlock.
-		//
-		// Use owner-scoped Release rather than ForceRelease: although this
-		// handler invocation acquired the lock earlier, ownership can change
-		// between acquisition and this point (e.g. `schemabot unlock` clears
-		// the lock and another PR acquires it). Release deletes only when
-		// owner matches; ErrLockNotFound / ErrLockNotOwned are expected here
-		// (lock may be absent or now held by another PR) and are not logged
-		// as errors.
-		if blocked := h.enforcePassingChecks(ctx, client, repo, pr, installationID, prInfo.HeadSHA, environment); blocked {
-			relErr := h.service.Storage().Locks().Release(ctx, database, dbType, lockOwner)
-			if relErr != nil && !errors.Is(relErr, storage.ErrLockNotFound) && !errors.Is(relErr, storage.ErrLockNotOwned) {
-				h.logger.Error("failed to release lock after fresh-HEAD checks gate block",
-					"repo", repo, "pr", pr, "database", database, "database_type", dbType, "error", relErr)
-			}
-			return
-		}
-
-		// Look up the plan we just created for DDL comparison in executeApply.
-		// Fail closed: if we can't load the plan, downgrade to manual confirmation
-		// rather than skipping the DDL drift check entirely.
-		storedPlan, planErr := h.service.Storage().Plans().Get(ctx, planResp.PlanID)
-		if planErr != nil || storedPlan == nil {
-			h.logger.Info("auto-confirm downgraded: could not load plan for DDL comparison",
-				"repo", repo, "pr", pr, "planID", planResp.PlanID, "error", planErr)
-			commentData.AutoConfirmDowngradeReason = "Could not verify plan — confirm manually"
-			h.postComment(repo, pr, installationID, templates.RenderPlanComment(commentData))
-			headSHA, checkRunErr := h.storeApplyPlanCheckRecord(ctx, client, repo, pr, schemaResult, planResp, environment)
-			if checkRunErr != nil {
-				h.logger.Error("failed to create apply plan check run", "repo", repo, "pr", pr, "error", checkRunErr)
-			}
-			if headSHA != "" {
-				h.updateAggregateCheck(ctx, client, repo, pr, headSHA)
-			}
-			return
-		}
-
-		commentData.AutoConfirm = true
-		h.postComment(repo, pr, installationID, templates.RenderPlanComment(commentData))
-		headSHA, checkErr := h.storeApplyPlanCheckRecord(ctx, client, repo, pr, schemaResult, planResp, environment)
-		if checkErr != nil {
-			h.logger.Error("failed to create apply plan check run", "repo", repo, "pr", pr, "error", checkErr)
-		}
-		if headSHA != "" {
-			h.updateAggregateCheck(ctx, client, repo, pr, headSHA)
-		}
-
-		// Check 2 (DDL drift) happens inside executeApply after re-plan
-		h.executeApply(ctx, client, repo, pr, schemaResult, environment, installationID, requestedBy, result, storedPlan)
-		return
-	}
-
-	// Manual apply: reject if the PR HEAD advanced after discovery loaded
-	// schema files. Posting the confirmation plan against the loaded files
-	// would render DDL for a commit the branch is no longer on — and the
-	// user's subsequent `apply-confirm` does its own fresh discovery, so the
-	// confirm-time freshness check passes against the new HEAD even though
-	// the plan the user reviewed was rendered for the old commit. Catching
-	// it here is the symmetric guard to the auto-confirm branch above.
-	// Use FetchPullRequestNoCache; the cached fetch returns the discovery
-	// SHA. Release the lock with owner-scoped Release so a concurrent
-	// `schemabot unlock` + re-acquire by another PR doesn't get its lock
-	// clobbered here; ErrLockNotFound / ErrLockNotOwned are expected.
+	// Check safety conditions before proceeding.
+	// Reject if the PR HEAD advanced after discovery loaded schema files.
+	// Running against the loaded files would execute DDL derived from an
+	// older commit than the branch is on right now. Release the lock
+	// acquired above so the user can re-run `schemabot apply -e <env>`
+	// cleanly without a manual unlock.
+	//
+	// Use FetchPullRequestNoCache: the cached FetchPullRequest used by
+	// discovery would return the discovery-time HeadSHA, masking the race.
 	prInfo, prErr := client.FetchPullRequestNoCache(ctx, repo, pr)
 	if prErr != nil {
 		h.logger.Error("failed to fetch PR for stale-schema check, releasing lock",
 			"repo", repo, "pr", pr, "database", database, "error", prErr)
-		h.postCommandError(repo, pr, installationID, action.Apply, environment, requestedBy, "Failed to verify PR HEAD before posting plan: "+prErr.Error())
+		h.postCommandError(repo, pr, installationID, action.Apply, environment, requestedBy, "Failed to verify PR HEAD before apply: "+prErr.Error())
 		relErr := h.service.Storage().Locks().Release(ctx, database, dbType, lockOwner)
 		if relErr != nil && !errors.Is(relErr, storage.ErrLockNotFound) && !errors.Is(relErr, storage.ErrLockNotOwned) {
 			h.logger.Error("failed to release lock after PR fetch failure",
@@ -323,9 +232,51 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 		return
 	}
 
-	h.postComment(repo, pr, installationID, templates.RenderPlanComment(commentData))
+	// Re-evaluate the checks gate against the fresh HEAD before executing.
+	// The early gate at the top of handleApplyCommand ran against the
+	// discovery-time HeadSHA. On the automatic apply path there is no second
+	// user action between plan and apply, so a required check that
+	// transitioned to failing on the same SHA (e.g. CI re-ran red, or a
+	// new required check was added) would otherwise sneak past. Release
+	// the lock on block so the user can re-run `schemabot apply -e <env>`
+	// once the checks recover, without a manual unlock.
+	//
+	// Use owner-scoped Release rather than ForceRelease: although this
+	// handler invocation acquired the lock earlier, ownership can change
+	// between acquisition and this point (e.g. `schemabot unlock` clears
+	// the lock and another PR acquires it). Release deletes only when
+	// owner matches; ErrLockNotFound / ErrLockNotOwned are expected here
+	// (lock may be absent or now held by another PR) and are not logged
+	// as errors.
+	if blocked := h.enforcePassingChecks(ctx, client, repo, pr, installationID, prInfo.HeadSHA, environment); blocked {
+		relErr := h.service.Storage().Locks().Release(ctx, database, dbType, lockOwner)
+		if relErr != nil && !errors.Is(relErr, storage.ErrLockNotFound) && !errors.Is(relErr, storage.ErrLockNotOwned) {
+			h.logger.Error("failed to release lock after fresh-HEAD checks gate block",
+				"repo", repo, "pr", pr, "database", database, "database_type", dbType, "error", relErr)
+		}
+		return
+	}
 
-	// Create check run (action_required — waiting for apply-confirm) and update aggregate
+	// Look up the plan we just created for DDL comparison in executeApply.
+	// Fail closed: if we can't load the plan, downgrade to manual confirmation
+	// rather than skipping the DDL drift check entirely.
+	storedPlan, planErr := h.service.Storage().Plans().Get(ctx, planResp.PlanID)
+	if planErr != nil || storedPlan == nil {
+		h.logger.Info("automatic apply downgraded: could not load plan for DDL comparison",
+			"repo", repo, "pr", pr, "planID", planResp.PlanID, "error", planErr)
+		commentData.AutoConfirmDowngradeReason = "Could not verify plan — confirm manually"
+		h.postComment(repo, pr, installationID, templates.RenderPlanComment(commentData))
+		headSHA, checkRunErr := h.storeApplyPlanCheckRecord(ctx, client, repo, pr, schemaResult, planResp, environment)
+		if checkRunErr != nil {
+			h.logger.Error("failed to create apply plan check run", "repo", repo, "pr", pr, "error", checkRunErr)
+		}
+		if headSHA != "" {
+			h.updateAggregateCheck(ctx, client, repo, pr, headSHA)
+		}
+		return
+	}
+
+	h.postComment(repo, pr, installationID, templates.RenderPlanComment(commentData))
 	headSHA, checkErr := h.storeApplyPlanCheckRecord(ctx, client, repo, pr, schemaResult, planResp, environment)
 	if checkErr != nil {
 		h.logger.Error("failed to create apply plan check run", "repo", repo, "pr", pr, "error", checkErr)
@@ -333,6 +284,9 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 	if headSHA != "" {
 		h.updateAggregateCheck(ctx, client, repo, pr, headSHA)
 	}
+
+	// Check 2 (DDL drift) happens inside executeApply after re-plan
+	h.executeApply(ctx, client, repo, pr, schemaResult, environment, installationID, requestedBy, result, storedPlan)
 }
 
 // handleApplyConfirmCommand handles the "schemabot apply-confirm -e <env>" PR comment command.

--- a/pkg/webhook/plan_test.go
+++ b/pkg/webhook/plan_test.go
@@ -213,7 +213,8 @@ func TestRenderPlanComment_UnsafeWithAllowUnsafe(t *testing.T) {
 
 	assert.Contains(t, rendered, "--allow-unsafe` enabled")
 	assert.Contains(t, rendered, "`users`")
-	assert.Contains(t, rendered, "apply-confirm -e staging --allow-unsafe")
+	assert.Contains(t, rendered, "Applying automatically")
+	assert.NotContains(t, rendered, "apply-confirm -e staging --allow-unsafe")
 }
 
 func TestRenderPlanComment_TenantScopedHints(t *testing.T) {
@@ -235,7 +236,7 @@ func TestRenderPlanComment_TenantScopedHints(t *testing.T) {
 		assert.Contains(t, rendered, "schemabot apply -e staging --tenant alpha")
 	})
 
-	t.Run("apply-confirm hint preserves tenant", func(t *testing.T) {
+	t.Run("automatic apply preserves tenant metadata without showing apply-confirm", func(t *testing.T) {
 		data := templates.PlanCommentData{
 			Database:    "testdb",
 			Environment: "staging",
@@ -251,6 +252,28 @@ func TestRenderPlanComment_TenantScopedHints(t *testing.T) {
 		rendered := templates.RenderPlanComment(data)
 
 		assert.Contains(t, rendered, "**Tenant**: `alpha`")
+		assert.Contains(t, rendered, "Applying automatically")
+		assert.NotContains(t, rendered, "schemabot apply-confirm -e staging --tenant alpha")
+	})
+
+	t.Run("downgrade hint preserves tenant", func(t *testing.T) {
+		data := templates.PlanCommentData{
+			Database:                   "testdb",
+			Environment:                "staging",
+			Tenant:                     "alpha",
+			IsMySQL:                    true,
+			IsLocked:                   true,
+			AutoConfirmDowngradeReason: "Schema changes differ from auto-plan — review and confirm manually",
+			Changes: []templates.KeyspaceChangeData{{
+				Keyspace:   "testdb",
+				Statements: []string{"ALTER TABLE `orders` ADD COLUMN `x` INT"},
+			}},
+		}
+
+		rendered := templates.RenderPlanComment(data)
+
+		assert.Contains(t, rendered, "**Tenant**: `alpha`")
+		assert.Contains(t, rendered, "Automatic apply paused")
 		assert.Contains(t, rendered, "schemabot apply-confirm -e staging --tenant alpha")
 	})
 

--- a/pkg/webhook/templates/help.go
+++ b/pkg/webhook/templates/help.go
@@ -6,8 +6,8 @@ func commandReference() string {
 	return `| Command | Description |
 |---------|-------------|
 | ` + "`schemabot plan [-e <env>]`" + ` | Preview schema changes |
-| ` + "`schemabot apply -e <env>`" + ` | Plan, lock, and confirm deployment |
-| ` + "`schemabot apply-confirm -e <env>`" + ` | Execute a locked plan |
+| ` + "`schemabot apply -e <env>`" + ` | Plan, lock, and apply after safety rechecks |
+| ` + "`schemabot apply-confirm -e <env>`" + ` | Confirm a downgraded locked plan |
 | ` + "`schemabot unlock`" + ` | Release lock and discard plan |
 | ` + "`schemabot stop <apply-id> -e <env>`" + ` | Stop an in-progress deployment |
 | ` + "`schemabot start <apply-id> -e <env>`" + ` | Resume a stopped deployment |
@@ -17,7 +17,7 @@ func commandReference() string {
 
 **Options**: ` + "`-e <env>`" + ` environment, ` + "`-d <db>`" + ` database, ` + "`-t, --tenant <name>`" + ` deployment routing, ` + "`--defer-cutover`" + `, ` + "`--allow-unsafe`" + `, ` + "`--skip-revert`" + ` (Vitess)
 
-**Quick start**: ` + "`plan`" + ` → ` + "`apply`" + ` → ` + "`apply-confirm`" + `
+**Quick start**: ` + "`plan`" + ` → ` + "`apply`" + `
 `
 }
 

--- a/pkg/webhook/templates/plan.go
+++ b/pkg/webhook/templates/plan.go
@@ -60,9 +60,8 @@ type PlanCommentData struct {
 	LockOwner    string
 	LockAcquired string // formatted timestamp
 
-	// Auto-confirm state
-	AutoConfirm                bool   // -y flag was used, will auto-execute
-	AutoConfirmDowngradeReason string // Non-empty: -y was downgraded to manual, this is the reason
+	// Automatic apply state
+	AutoConfirmDowngradeReason string // Non-empty when automatic apply downgraded to manual confirmation
 
 	RecoveredApplyOwnedCheckState bool
 }
@@ -161,23 +160,17 @@ func RenderPlanComment(data PlanCommentData) string {
 			applyConfirmCmd += " --skip-revert"
 		}
 
-		switch {
-		case data.AutoConfirmDowngradeReason != "":
-			// -y was downgraded to manual confirmation — show unlock since user needs to act
-			fmt.Fprintf(&sb, "⚠️ **Auto-confirm skipped**: %s\n\n", data.AutoConfirmDowngradeReason)
+		if data.AutoConfirmDowngradeReason != "" {
+			// Automatic apply was downgraded to manual confirmation — show unlock since user needs to act
+			fmt.Fprintf(&sb, "⚠️ **Automatic apply paused**: %s\n\n", data.AutoConfirmDowngradeReason)
 			sb.WriteString("Review the plan above, then confirm manually:\n")
 			fmt.Fprintf(&sb, "```\n%s\n```\n", applyConfirmCmd)
 			sb.WriteString("\n🔓 To discard this plan and unlock, comment:\n")
 			sb.WriteString("```\nschemabot unlock\n```\n")
-		case data.AutoConfirm:
-			// -y is proceeding — include unlock hint in case the apply fails before starting
-			sb.WriteString("**Applying automatically** (`-y` flag)\n")
+		} else {
+			// Automatic apply is proceeding — include unlock hint in case the apply fails before starting
+			sb.WriteString("**Applying automatically**\n")
 			sb.WriteString("\n🔓 If the apply fails, unlock with:\n")
-			sb.WriteString("```\nschemabot unlock\n```\n")
-		default:
-			// Normal two-step flow: confirm instructions + unlock option
-			writeApplyHint(&sb, applyConfirmCmd)
-			sb.WriteString("\n🔓 To discard this plan and unlock, comment:\n")
 			sb.WriteString("```\nschemabot unlock\n```\n")
 		}
 	} else {

--- a/pkg/webhook/templates/preview.go
+++ b/pkg/webhook/templates/preview.go
@@ -509,6 +509,25 @@ func PreviewCommentApplyPlanUnsafe() string {
 	})
 }
 
+// PreviewCommentApplyPlanDowngraded renders a locked apply-plan that requires
+// manual confirmation after automatic apply was downgraded by a safety recheck.
+func PreviewCommentApplyPlanDowngraded() string {
+	return RenderPlanComment(PlanCommentData{
+		Database:                   "testapp",
+		SchemaName:                 "testapp",
+		Environment:                "staging",
+		HeadSHA:                    previewHeadSHA,
+		Repository:                 previewRepository,
+		RequestedBy:                previewRequestedBy,
+		IsMySQL:                    true,
+		Changes:                    samplePlanChanges(),
+		IsLocked:                   true,
+		LockOwner:                  "acme/myapp#42",
+		LockAcquired:               "2026-03-14 10:30:00 UTC",
+		AutoConfirmDowngradeReason: "Schema changes differ from auto-plan — review and confirm manually",
+	})
+}
+
 // =============================================================================
 // Vitess Plan Comment Previews
 // =============================================================================


### PR DESCRIPTION
## Why
PR comment apply should feel like a single intentional action: when a user runs `schemabot apply`, SchemaBot already replans, checks PR freshness, evaluates check gates, and verifies DDL drift before queueing work. If those safety rechecks still match the reviewed plan, requiring a second `apply-confirm` comment adds friction without adding safety.

`apply-confirm` remains useful when the automatic path cannot prove the locked plan is still safe. In those cases, SchemaBot pauses and asks for explicit confirmation instead of silently proceeding.

## What
- Make `schemabot apply` queue the apply automatically after freshness, check-gate, and DDL drift rechecks pass
- Reserve `apply-confirm` for downgrade/manual-review cases where automatic apply pauses
- Update GitHub comment copy, help text, previews, generated template docs, and focused apply-flow tests to match the new UX

## Risk Assessment
Medium — this changes the default PR comment apply flow, but keeps the existing safety gates fail-closed and only skips the second confirmation when SchemaBot has revalidated the plan it is about to apply.

Generated with Amp
