### PR TITLE
fix(tern): pass the task's shard to the engine in the sequential drive (fixes "got 0")

### DIFF
--- a/pkg/tern/local_apply_sequential.go
+++ b/pkg/tern/local_apply_sequential.go
@@ -136,6 +136,35 @@ func (c *LocalClient) checkTaskReady(ctx context.Context, task *storage.Task) ta
 	return taskContinue
 }
 
+// sequentialEngineApplyRequest builds the engine request for one task in the
+// sequential drive. A sharded task carries the shard it targets; propagate it so
+// a sharded engine (Strata) receives exactly one target shard — without it the
+// engine rejects the work with "expected exactly one target shard, got 0" even
+// though the task is correctly shard-tagged. A non-sharded task has an empty
+// shard and leaves both shard fields unset, unchanged. The grouped and resume
+// drive paths already set TargetShards via taskTargetShards; this is the
+// single-task path's equivalent.
+func sequentialEngineApplyRequest(task *storage.Task, options map[string]string, creds *engine.Credentials) *engine.ApplyRequest {
+	change := engine.SchemaChange{
+		Namespace:    task.Namespace,
+		TableChanges: []engine.TableChange{{Table: task.TableName, DDL: task.DDL}},
+	}
+	if task.Shard != "" {
+		change.Shard = engine.Shard{Name: task.Shard}
+	}
+	req := &engine.ApplyRequest{
+		Database:    task.Database,
+		Changes:     []engine.SchemaChange{change},
+		Options:     options,
+		ResumeState: &engine.ResumeState{MigrationContext: task.TaskIdentifier},
+		Credentials: creds,
+	}
+	if task.Shard != "" {
+		req.TargetShards = []string{task.Shard}
+	}
+	return req
+}
+
 // runEngineTask calls the engine for a single DDL, marks the task running, and polls to completion.
 // Returns the outcome: taskContinue (completed), taskFailed, or taskStopped.
 func (c *LocalClient) runEngineTask(ctx context.Context, apply *storage.Apply, task *storage.Task, options map[string]string, creds *engine.Credentials) taskAction {
@@ -159,16 +188,7 @@ func (c *LocalClient) runEngineTask(ctx context.Context, apply *storage.Apply, t
 
 	// Sequential mode: one DDL per engine call. Use the task identifier as
 	// MigrationContext so each table's schema change is tracked independently.
-	result, err := c.getEngine().Apply(ctx, &engine.ApplyRequest{
-		Database: task.Database,
-		Changes: []engine.SchemaChange{{
-			Namespace:    task.Namespace,
-			TableChanges: []engine.TableChange{{Table: task.TableName, DDL: task.DDL}},
-		}},
-		Options:     options,
-		ResumeState: &engine.ResumeState{MigrationContext: task.TaskIdentifier},
-		Credentials: taskCreds,
-	})
+	result, err := c.getEngine().Apply(ctx, sequentialEngineApplyRequest(task, options, taskCreds))
 
 	if err != nil {
 		if c.shouldRetryEngineError(err) {

--- a/pkg/tern/local_apply_sequential.go
+++ b/pkg/tern/local_apply_sequential.go
@@ -186,8 +186,9 @@ func (c *LocalClient) runEngineTask(ctx context.Context, apply *storage.Apply, t
 		}
 	}
 
-	// Sequential mode: one DDL per engine call. Use the task identifier as
-	// MigrationContext so each table's schema change is tracked independently.
+	// Sequential mode: one DDL per engine call. The task identifier is used as the
+	// engine resume key (ResumeState.MigrationContext) so each table's schema
+	// change is tracked independently.
 	result, err := c.getEngine().Apply(ctx, sequentialEngineApplyRequest(task, options, taskCreds))
 
 	if err != nil {

--- a/pkg/tern/local_apply_sequential_shard_test.go
+++ b/pkg/tern/local_apply_sequential_shard_test.go
@@ -24,6 +24,7 @@ func TestSequentialEngineApplyRequest_PropagatesShard(t *testing.T) {
 	require.Equal(t, []string{"-40"}, req.TargetShards, "the task's shard must reach the engine as a single target shard")
 	require.Len(t, req.Changes, 1)
 	assert.Equal(t, "-40", req.Changes[0].Shard.Name, "the shard is also set on the SchemaChange")
+	require.Len(t, req.Changes[0].TableChanges, 1)
 	assert.Equal(t, "mutes", req.Changes[0].TableChanges[0].Table)
 	assert.Equal(t, task.DDL, req.Changes[0].TableChanges[0].DDL)
 }

--- a/pkg/tern/local_apply_sequential_shard_test.go
+++ b/pkg/tern/local_apply_sequential_shard_test.go
@@ -1,0 +1,44 @@
+package tern
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/block/schemabot/pkg/engine"
+	"github.com/block/schemabot/pkg/storage"
+)
+
+// A sharded task must reach the engine with exactly one target shard, or a
+// sharded engine (Strata) rejects it with "expected exactly one target shard,
+// got 0". The shard is also placed on the SchemaChange.
+func TestSequentialEngineApplyRequest_PropagatesShard(t *testing.T) {
+	task := &storage.Task{
+		TaskIdentifier: "task-1", Database: "cdb_resolute", Namespace: "cdb_resolute_sharded",
+		TableName: "mutes", Shard: "-40", DDL: "ALTER TABLE `mutes` ADD INDEX `created_at` (`created_at`)",
+	}
+
+	req := sequentialEngineApplyRequest(task, nil, nil)
+
+	require.Equal(t, []string{"-40"}, req.TargetShards, "the task's shard must reach the engine as a single target shard")
+	require.Len(t, req.Changes, 1)
+	assert.Equal(t, "-40", req.Changes[0].Shard.Name, "the shard is also set on the SchemaChange")
+	assert.Equal(t, "mutes", req.Changes[0].TableChanges[0].Table)
+	assert.Equal(t, task.DDL, req.Changes[0].TableChanges[0].DDL)
+}
+
+// A non-sharded task leaves the shard fields unset, so the non-sharded engine
+// path is unchanged.
+func TestSequentialEngineApplyRequest_NonShardedUnchanged(t *testing.T) {
+	task := &storage.Task{
+		TaskIdentifier: "task-1", Database: "testdb", Namespace: "testdb",
+		TableName: "users", DDL: "ALTER TABLE `users` ADD COLUMN `email` varchar(255)",
+	}
+
+	req := sequentialEngineApplyRequest(task, nil, nil)
+
+	assert.Empty(t, req.TargetShards, "a non-sharded task targets no shard")
+	require.Len(t, req.Changes, 1)
+	assert.Equal(t, engine.Shard{}, req.Changes[0].Shard, "no shard on the SchemaChange")
+}


### PR DESCRIPTION
## What

Fixes the persistent **"strata work operation expected exactly one target shard, got 0"** on sharded `cdb_resolute` applies — the actual root cause, not a rendering or deployment issue.

## Root cause

The sequential apply drive (`runEngineTask`) — the path the data plane uses to execute one task at a time — built the engine `ApplyRequest` **without `TargetShards`**, even when the task was shard-tagged:

```go
c.getEngine().Apply(ctx, &engine.ApplyRequest{
    Database: task.Database,
    Changes:  []engine.SchemaChange{{Namespace: task.Namespace, TableChanges: ...}},
    // no Shard, no TargetShards
})
```

A sharded engine (Strata) requires exactly one target shard (`applyWork`: `len(req.TargetShards) != 1`), so a per-shard task driven through this path was rejected with "got 0" — even though `task.Shard` was correctly set. The grouped and resume drives already set `TargetShards` via `taskTargetShards`; the single-task sequential path was the one gap.

This was confirmed from the data plane: the failing shard's task row carried its shard (`-40`), but the engine call dropped it.

## Fix

Extract `sequentialEngineApplyRequest`, which sets `SchemaChange.Shard` and `ApplyRequest.TargetShards` from `task.Shard` (and leaves both unset for a non-sharded task — that path is unchanged). Unit tests cover the sharded and non-sharded cases.

## Tests

`TestSequentialEngineApplyRequest_PropagatesShard` / `_NonShardedUnchanged`; full `pkg/tern` suite passes.

## Rollout

This is a **data-plane** fix — it ships to gap's `ternd` via a `block/schemabot` dependency bump (the same path as the `#535` bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
