### PR TITLE
deps(vitess): bump block/vitess to release-24.0 (topo schema "topo")

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -264,7 +264,7 @@ require (
 )
 
 // needed for Strata and vtcombo OnlineDDL suppport
-replace vitess.io/vitess => github.com/block/vitess v0.0.0-20260601162944-8318a748ceb1
+replace vitess.io/vitess => github.com/block/vitess v0.0.0-20260626202504-ceae63376aaa
 
 // needed for SPATIAL index support in Spirit v0.13.0
 replace github.com/pingcap/tidb/pkg/parser => github.com/block/tidb/pkg/parser v0.0.0-20260506200501-e528fd979fc8

--- a/go.sum
+++ b/go.sum
@@ -117,8 +117,8 @@ github.com/block/spirit v0.15.2-0.20260625160741-3bd8ca93a47b h1:8LFTfrv1giEGCbW
 github.com/block/spirit v0.15.2-0.20260625160741-3bd8ca93a47b/go.mod h1:ku7mCCKx7Wk4QrMa/mHnsqQhZkoUD2vdBkpjJEDk4lY=
 github.com/block/tidb/pkg/parser v0.0.0-20260506200501-e528fd979fc8 h1:+OfdTacrEyjlqcRUpBFX9uJ6ROBq6cUjwY4DClhnsdU=
 github.com/block/tidb/pkg/parser v0.0.0-20260506200501-e528fd979fc8/go.mod h1:zDLDsfNBU5+L6T4J9/OgWAHc/WZvMUjbpgHqQ/t3yKo=
-github.com/block/vitess v0.0.0-20260601162944-8318a748ceb1 h1:dnHGiR/N1+X2EM1FGzL4548iCzJcIAnhcMbEt026xHQ=
-github.com/block/vitess v0.0.0-20260601162944-8318a748ceb1/go.mod h1:tOLnFt2ryuSGSYZ9NxLjsRhYrWxGBxz/z0zxrvuWYwE=
+github.com/block/vitess v0.0.0-20260626202504-ceae63376aaa h1:TcxuMn8uWNfflF775gh65Tm5wdEQY15DvvmaKYKtl5U=
+github.com/block/vitess v0.0.0-20260626202504-ceae63376aaa/go.mod h1:tOLnFt2ryuSGSYZ9NxLjsRhYrWxGBxz/z0zxrvuWYwE=
 github.com/bndr/gotabulate v1.1.2 h1:yC9izuZEphojb9r+KYL4W9IJKO/ceIO8HDwxMA24U4c=
 github.com/bndr/gotabulate v1.1.2/go.mod h1:0+8yUgaPTtLRTjf49E8oju7ojpU11YmXyvq1LbPAb3U=
 github.com/bradleyfalzon/ghinstallation/v2 v2.18.0 h1:WPqnN6NS9XvYlOgZQAIseN7Z1uAiE+UxgDKlW7FvFuU=


### PR DESCRIPTION
Bumps the `block/vitess` replace to `release-24.0` (block/vitess#17), rolling forward from #15 through #16 (resolve-on-open) to #17.

block/vitess#17 makes the MySQL topo default schema `topo` (was `vitess_topo`), matching the schema provisioned everywhere — an apply that opened the topo server on the default previously hit a non-existent database. Topo connect errors also now name the host, schema, and user.

go.mod/go.sum only; builds clean.