### PR TITLE
fix(github): follow symlinked namespace directories in schema discovery

### DIFF
--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -1456,8 +1456,8 @@ func (ic *InstallationClient) symlinkedNamespaceLocators(ctx context.Context, re
 	if !schemaPathWithinDirectory(".", resolved) {
 		return nil, fmt.Errorf("schema namespace symlink %s points outside the repository: %s", entry.GetPath(), target)
 	}
-	if resolved == "." || resolved == path.Clean(schemaPath) {
-		return nil, fmt.Errorf("schema namespace symlink %s must point to a distinct directory, not the repository root or its own schema root: %s", entry.GetPath(), target)
+	if resolved == "." || resolved == path.Clean(schemaPath) || resolved == path.Clean(entry.GetPath()) {
+		return nil, fmt.Errorf("schema namespace symlink %s must point to a distinct directory, not the repository root, its own schema root, or itself: %s", entry.GetPath(), target)
 	}
 
 	targetEntries, err := ic.fetchDirectoryContents(ctx, repo, resolved, ref)

--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -1072,6 +1072,10 @@ type TreeEntry struct {
 	Size int
 }
 
+// gitSymlinkMode is the git tree file mode for a symbolic link. Symlinks appear
+// as "blob" tree entries with this mode; their content is the target path.
+const gitSymlinkMode = "120000"
+
 // FetchGitTree fetches the entire directory tree in one API call using recursive mode.
 func (ic *InstallationClient) FetchGitTree(ctx context.Context, repo, treeSHA string) ([]TreeEntry, bool, error) {
 	owner, repoName := splitRepo(repo)
@@ -1218,7 +1222,7 @@ type fileResult struct {
 //	  schema/commerce/orders.sql
 //	  schema/customers/users.sql
 func (ic *InstallationClient) FetchSchemaFilesOptimized(ctx context.Context, repo string, headSHA, schemaPath, dbType string) ([]GitHubFile, error) {
-	entries, err := ic.schemaDirectoryEntries(ctx, repo, headSHA, schemaPath)
+	locators, err := ic.schemaFileLocators(ctx, repo, headSHA, schemaPath)
 	if err != nil {
 		if IsNotFoundError(err) {
 			return ic.fetchSchemaFilesFromTree(ctx, repo, headSHA, schemaPath)
@@ -1226,41 +1230,42 @@ func (ic *InstallationClient) FetchSchemaFilesOptimized(ctx context.Context, rep
 		return nil, err
 	}
 
-	var filesToFetch []*gh.RepositoryContent
-	for _, entry := range entries {
-		if entry.GetType() != "file" {
+	var filesToFetch []schemaFileLocator
+	for _, loc := range locators {
+		if !isManagedSchemaFile(loc.displayPath) {
 			continue
 		}
-		if !isManagedSchemaFile(entry.GetPath()) {
-			continue
-		}
-		filesToFetch = append(filesToFetch, entry)
+		filesToFetch = append(filesToFetch, loc)
 	}
 
 	if len(filesToFetch) == 0 {
 		return []GitHubFile{}, nil
 	}
 
-	// Fetch all file contents in parallel with concurrency limit
+	// Fetch all file contents in parallel with concurrency limit. Content is
+	// fetched from fetchPath (the real path on the branch — the symlink target
+	// for files reached through a symlinked namespace, since the Contents API
+	// does not traverse symlinked directories), but each file is labeled with
+	// displayPath so namespace grouping uses the symlink name.
 	results := make(chan fileResult, len(filesToFetch))
 	var wg sync.WaitGroup
 	semaphore := make(chan struct{}, 10)
 
-	for _, entry := range filesToFetch {
+	for _, loc := range filesToFetch {
 		wg.Go(func() {
 			semaphore <- struct{}{}
 			defer func() { <-semaphore }()
 
-			content, err := ic.FetchFileContent(ctx, repo, entry.GetPath(), headSHA)
+			content, err := ic.FetchFileContent(ctx, repo, loc.fetchPath, headSHA)
 			if err != nil {
-				results <- fileResult{err: fmt.Errorf("fetch %s: %w", entry.GetPath(), err)}
+				results <- fileResult{err: fmt.Errorf("fetch %s: %w", loc.fetchPath, err)}
 				return
 			}
 			results <- fileResult{
 				file: GitHubFile{
-					Name:    path.Base(entry.GetPath()),
+					Name:    path.Base(loc.displayPath),
 					Content: content,
-					Path:    entry.GetPath(),
+					Path:    loc.displayPath,
 				},
 			}
 		})
@@ -1307,6 +1312,15 @@ func (ic *InstallationClient) fetchSchemaFilesFromTree(ctx context.Context, repo
 		}
 		if !strings.HasPrefix(entry.Path, schemaPathPrefix) {
 			continue
+		}
+		// A symbolic link under the schema root (such as a symlinked namespace
+		// directory) is recorded in the git tree as a blob whose content is the
+		// target path, not the target's files — which live elsewhere in the tree
+		// and outside schemaPathPrefix. The tree fallback cannot resolve it, so
+		// fail closed rather than silently dropping the symlinked schema. The
+		// Contents API path (schemaFileLocators) resolves these.
+		if entry.Mode == gitSymlinkMode {
+			return nil, fmt.Errorf("schema path %s in repo %s ref %s contains a symlink the git-tree fallback cannot resolve: %s", schemaPath, repo, headSHA, entry.Path)
 		}
 		if !isManagedSchemaFile(entry.Path) {
 			continue
@@ -1366,30 +1380,104 @@ func (ic *InstallationClient) fetchSchemaFilesFromTree(ctx context.Context, repo
 	return files, nil
 }
 
-func (ic *InstallationClient) schemaDirectoryEntries(ctx context.Context, repo, ref, schemaPath string) ([]*gh.RepositoryContent, error) {
+// schemaFileLocator points at one schema file. fetchPath is where its content
+// lives on the branch (used to GET content); displayPath is the path under the
+// schema root used for namespace grouping. The two differ only when the file is
+// reached through a symlinked namespace directory: fetchPath is the real symlink
+// target, displayPath keeps the symlink (keyspace) name.
+type schemaFileLocator struct {
+	fetchPath   string
+	displayPath string
+}
+
+// schemaFileLocators lists every schema file directly under the schema root and
+// its namespace subdirectories. A namespace entry may be a real directory or a
+// symlink to a directory elsewhere in the repository; symlinked namespaces are
+// resolved so their files are discovered under the symlink's name. This is the
+// server-side equivalent of the CLI following symlinks on the local filesystem.
+func (ic *InstallationClient) schemaFileLocators(ctx context.Context, repo, ref, schemaPath string) ([]schemaFileLocator, error) {
 	rootEntries, err := ic.fetchDirectoryContents(ctx, repo, schemaPath, ref)
 	if err != nil {
 		return nil, err
 	}
 
-	entries := make([]*gh.RepositoryContent, 0, len(rootEntries))
-	entries = append(entries, rootEntries...)
+	var locators []schemaFileLocator
 	for _, entry := range rootEntries {
-		if entry.GetType() != "dir" {
-			continue
+		switch entry.GetType() {
+		case "file":
+			// Flat layout: a file directly under the schema root.
+			locators = append(locators, schemaFileLocator{fetchPath: entry.GetPath(), displayPath: entry.GetPath()})
+		case "dir":
+			subEntries, err := ic.fetchDirectoryContents(ctx, repo, entry.GetPath(), ref)
+			if err != nil {
+				return nil, fmt.Errorf("fetch schema namespace directory %s: %w", entry.GetPath(), err)
+			}
+			for _, sub := range subEntries {
+				if sub.GetType() != "file" {
+					ic.logger.Debug("skipping non-file entry in schema namespace directory",
+						"repo", repo, "ref", ref, "path", sub.GetPath(), "type", sub.GetType())
+					continue
+				}
+				locators = append(locators, schemaFileLocator{fetchPath: sub.GetPath(), displayPath: sub.GetPath()})
+			}
+		case "symlink":
+			symlinked, err := ic.symlinkedNamespaceLocators(ctx, repo, ref, schemaPath, entry)
+			if err != nil {
+				return nil, err
+			}
+			locators = append(locators, symlinked...)
+		default:
+			ic.logger.Debug("skipping unsupported schema entry type",
+				"repo", repo, "ref", ref, "path", entry.GetPath(), "type", entry.GetType())
 		}
-
-		subEntries, err := ic.fetchDirectoryContents(ctx, repo, entry.GetPath(), ref)
-		if err != nil {
-			return nil, fmt.Errorf("fetch schema namespace directory %s: %w", entry.GetPath(), err)
-		}
-		entries = append(entries, subEntries...)
 	}
 
-	sort.Slice(entries, func(i, j int) bool {
-		return entries[i].GetPath() < entries[j].GetPath()
+	sort.Slice(locators, func(i, j int) bool {
+		return locators[i].displayPath < locators[j].displayPath
 	})
-	return entries, nil
+	return locators, nil
+}
+
+// symlinkedNamespaceLocators resolves a symlinked namespace directory under the
+// schema root and returns a locator for each file inside the symlink target,
+// keyed under the symlink's own name. The target must be a repository-relative
+// directory that stays inside the repository; absolute targets and targets that
+// escape the repository root are rejected.
+func (ic *InstallationClient) symlinkedNamespaceLocators(ctx context.Context, repo, ref, schemaPath string, entry *gh.RepositoryContent) ([]schemaFileLocator, error) {
+	symlinkName := path.Base(entry.GetPath())
+	target := strings.TrimSpace(entry.GetTarget())
+	if target == "" {
+		return nil, fmt.Errorf("schema namespace symlink %s has empty target", entry.GetPath())
+	}
+	if strings.HasPrefix(target, "/") {
+		return nil, fmt.Errorf("schema namespace symlink %s points to absolute path %s", entry.GetPath(), target)
+	}
+	resolved := path.Clean(path.Join(schemaPath, target))
+	if !schemaPathWithinDirectory(".", resolved) {
+		return nil, fmt.Errorf("schema namespace symlink %s points outside the repository: %s", entry.GetPath(), target)
+	}
+	if resolved == "." || resolved == path.Clean(schemaPath) {
+		return nil, fmt.Errorf("schema namespace symlink %s must point to a distinct directory, not the repository root or its own schema root: %s", entry.GetPath(), target)
+	}
+
+	targetEntries, err := ic.fetchDirectoryContents(ctx, repo, resolved, ref)
+	if err != nil {
+		return nil, fmt.Errorf("resolve schema namespace symlink %s target %s: %w", entry.GetPath(), resolved, err)
+	}
+
+	locators := make([]schemaFileLocator, 0, len(targetEntries))
+	for _, sub := range targetEntries {
+		if sub.GetType() != "file" {
+			ic.logger.Debug("skipping non-file entry in symlinked schema namespace target",
+				"repo", repo, "ref", ref, "symlink", entry.GetPath(), "target_path", sub.GetPath(), "type", sub.GetType())
+			continue
+		}
+		locators = append(locators, schemaFileLocator{
+			fetchPath:   sub.GetPath(),
+			displayPath: path.Join(schemaPath, symlinkName, path.Base(sub.GetPath())),
+		})
+	}
+	return locators, nil
 }
 
 func isManagedSchemaFile(filePath string) bool {

--- a/pkg/github/client_test.go
+++ b/pkg/github/client_test.go
@@ -290,6 +290,105 @@ func TestFetchSchemaFilesOptimizedSmallDirectory(t *testing.T) {
 	assert.Equal(t, "CREATE TABLE users (id INT);", files[0].Content)
 }
 
+// A namespace directory under the schema root may be a symlink to a directory
+// elsewhere in the repository (the layout some services use to share one
+// canonical table set across many keyspaces). The server-side discovery follows
+// the symlink, fetches the target's files, and presents them under the symlink's
+// name so each symlinked keyspace becomes its own namespace — even when several
+// symlinks point at the same target.
+func TestFetchSchemaFilesOptimizedFollowsSymlinkedNamespaces(t *testing.T) {
+	client, mux := setupRateLimitedTestGitHubServer(t)
+
+	mux.HandleFunc("GET /repos/octocat/hello-world/contents/schema", func(w http.ResponseWriter, _ *http.Request) {
+		entries := []gh.RepositoryContent{
+			{Type: new("file"), Name: new("schemabot.yaml"), Path: new("schema/schemabot.yaml")},
+			{Type: new("symlink"), Name: new("shard_001"), Path: new("schema/shard_001"), Target: new("../canonical/shard")},
+			{Type: new("symlink"), Name: new("shard_002"), Path: new("schema/shard_002"), Target: new("../canonical/shard")},
+		}
+		require.NoError(t, json.NewEncoder(w).Encode(entries))
+	})
+	mux.HandleFunc("GET /repos/octocat/hello-world/contents/canonical/shard", func(w http.ResponseWriter, _ *http.Request) {
+		entries := []gh.RepositoryContent{
+			{Type: new("file"), Name: new("orders.sql"), Path: new("canonical/shard/orders.sql")},
+		}
+		require.NoError(t, json.NewEncoder(w).Encode(entries))
+	})
+	mux.HandleFunc("GET /repos/octocat/hello-world/contents/canonical/shard/orders.sql", func(w http.ResponseWriter, _ *http.Request) {
+		require.NoError(t, json.NewEncoder(w).Encode(gh.RepositoryContent{
+			Type:     new("file"),
+			Name:     new("orders.sql"),
+			Path:     new("canonical/shard/orders.sql"),
+			Encoding: new("base64"),
+			Content:  new(base64.StdEncoding.EncodeToString([]byte("CREATE TABLE orders (id INT);"))),
+		}))
+	})
+
+	ic := NewInstallationClient(client, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	files, err := ic.FetchSchemaFilesOptimized(t.Context(), "octocat/hello-world", "abc123", "schema", "vitess")
+	require.NoError(t, err)
+
+	// Both symlinked keyspaces are discovered, each carrying the shared target's
+	// content but labeled under its own namespace path.
+	require.Len(t, files, 2)
+	assert.Equal(t, "schema/shard_001/orders.sql", files[0].Path)
+	assert.Equal(t, "schema/shard_002/orders.sql", files[1].Path)
+	for _, f := range files {
+		assert.Equal(t, "orders.sql", f.Name)
+		assert.Equal(t, "CREATE TABLE orders (id INT);", f.Content)
+	}
+
+	// Grouping keys each file under its symlink (keyspace) name.
+	grouped, err := groupFilesByNamespace(files, "schema", "")
+	require.NoError(t, err)
+	require.Contains(t, grouped, "shard_001")
+	require.Contains(t, grouped, "shard_002")
+}
+
+// A symlinked namespace whose target escapes the repository root is rejected
+// rather than followed, so a crafted schema layout cannot read files outside the
+// repository.
+func TestFetchSchemaFilesOptimizedRejectsEscapingSymlink(t *testing.T) {
+	client, mux := setupRateLimitedTestGitHubServer(t)
+
+	mux.HandleFunc("GET /repos/octocat/hello-world/contents/schema", func(w http.ResponseWriter, _ *http.Request) {
+		entries := []gh.RepositoryContent{
+			{Type: new("symlink"), Name: new("evil"), Path: new("schema/evil"), Target: new("../../../../etc")},
+		}
+		require.NoError(t, json.NewEncoder(w).Encode(entries))
+	})
+
+	ic := NewInstallationClient(client, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	_, err := ic.FetchSchemaFilesOptimized(t.Context(), "octocat/hello-world", "abc123", "schema", "mysql")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "outside the repository")
+}
+
+// When the Contents API cannot list the schema root, discovery falls back to the
+// git tree. A symlinked namespace there is a mode-120000 blob whose target's
+// files live outside the schema root, so the fallback cannot resolve it and must
+// fail closed rather than silently dropping the symlinked schema (which would
+// otherwise surface as a missing keyspace / spurious DROP proposals).
+func TestFetchSchemaFilesFromTreeFailsClosedOnSymlink(t *testing.T) {
+	client, mux := setupRateLimitedTestGitHubServer(t)
+
+	mux.HandleFunc("GET /repos/octocat/hello-world/contents/schema", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+	mux.HandleFunc("GET /repos/octocat/hello-world/git/trees/abc123", func(w http.ResponseWriter, _ *http.Request) {
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+			"truncated": false,
+			"tree": []map[string]any{
+				{"path": "schema/shard_001", "mode": "120000", "type": "blob", "sha": "deadbeef"},
+			},
+		}))
+	})
+
+	ic := NewInstallationClient(client, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	_, err := ic.FetchSchemaFilesOptimized(t.Context(), "octocat/hello-world", "abc123", "schema", "mysql")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "symlink")
+}
+
 // TestFindCheckRunByNameAcceptsTrustedSiblingAppCheckRun covers the
 // split-deployment topology where the looked-up check run was created by a
 // sibling SchemaBot deployment's GitHub App. The lookup must return the

--- a/pkg/github/client_test.go
+++ b/pkg/github/client_test.go
@@ -363,6 +363,25 @@ func TestFetchSchemaFilesOptimizedRejectsEscapingSymlink(t *testing.T) {
 	assert.Contains(t, err.Error(), "outside the repository")
 }
 
+// A namespace symlink that resolves back to its own path is rejected rather than
+// re-fetched, which would otherwise loop or surface a confusing "not a directory"
+// error from the directory listing.
+func TestFetchSchemaFilesOptimizedRejectsSelfReferentialSymlink(t *testing.T) {
+	client, mux := setupRateLimitedTestGitHubServer(t)
+
+	mux.HandleFunc("GET /repos/octocat/hello-world/contents/schema", func(w http.ResponseWriter, _ *http.Request) {
+		entries := []gh.RepositoryContent{
+			{Type: new("symlink"), Name: new("shard_001"), Path: new("schema/shard_001"), Target: new("shard_001")},
+		}
+		require.NoError(t, json.NewEncoder(w).Encode(entries))
+	})
+
+	ic := NewInstallationClient(client, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	_, err := ic.FetchSchemaFilesOptimized(t.Context(), "octocat/hello-world", "abc123", "schema", "mysql")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "distinct directory")
+}
+
 // When the Contents API cannot list the schema root, discovery falls back to the
 // git tree. A symlinked namespace there is a mode-120000 blob whose target's
 // files live outside the schema root, so the fallback cannot resolve it and must


### PR DESCRIPTION
## Why

A repository may lay out its declarative schema so that a namespace (keyspace) directory under the schema root is a **symlink** to a directory elsewhere in the repo — e.g. several keyspaces sharing one canonical table set. The CLI, which walks the local filesystem, already follows these symlinks. The **server-side** path (the webhook/check flow that reads PR files via the GitHub Contents API) did not: `schemaDirectoryEntries` only recursed into namespace entries of type `dir`, so a symlinked namespace was skipped and its tables were never fetched — surfacing as `no schema files found ... for environment`.

## What

Resolve symlinked namespace directories during server-side discovery:

```
schema/<ns> ── symlink ──▶ canonical/<dir>/*.sql
   │                              │
   │  content fetched from        │  (Contents API does not
   ▼  the real target path        ▼   traverse symlinks)
grouped under <ns>  ◀── displayPath keeps the symlink (keyspace) name
```

- Each file under the symlink target is keyed under the **symlink's own name**, so each symlinked keyspace becomes its own namespace. Multiple symlinks pointing at the same target each fan out independently.
- Content is fetched from the resolved **target** path (the Contents API won't traverse a symlinked directory) while namespace grouping uses the symlink name — `schemaFileLocator` carries both.
- Targets must be repository-relative and stay inside the repo; absolute targets, repo-escaping targets (`..`), and root/self targets are rejected.
- The directory-listing cap still fails closed on symlink-target listings, and the git-tree fallback (used when the Contents listing is unavailable) now **fails closed** on a symlinked namespace rather than silently dropping it, since it cannot resolve the target from the tree alone.

Tests cover the fan-out case, the escaping-target rejection, and the tree-fallback fail-closed path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)