### PR TITLE
test(e2e): stabilize Vitess revert-window assertion

### DIFF
--- a/e2e/local/apply_wait_test.go
+++ b/e2e/local/apply_wait_test.go
@@ -79,6 +79,95 @@ func waitForApplyState(t *testing.T, endpoint, applyID, expectedState string, ti
 	)
 }
 
+func waitForApplyRevertWindow(t *testing.T, endpoint, applyID string, timeout time.Duration) string {
+	t.Helper()
+	var lastState, lastError, lastLogError, matchedState string
+	start := time.Now()
+	testutil.Poll(t, timeout, testutil.PollInterval,
+		func() bool {
+			ctx, cancel := context.WithTimeout(t.Context(), testutil.ProgressTimeout)
+			result, err := client.GetProgressCtx(ctx, endpoint, applyID)
+			cancel()
+			if err != nil {
+				t.Logf("waitForApplyRevertWindow: %s poll error: %v (elapsed=%s)", applyID, err, time.Since(start))
+				return false
+			}
+			newState := state.NormalizeState(result.State)
+			if newState != lastState {
+				t.Logf("waitForApplyRevertWindow: %s state=%s (elapsed=%s)", applyID, newState, time.Since(start))
+			}
+			lastState = newState
+			lastError = result.ErrorMessage
+			if state.IsState(lastState, state.Apply.RevertWindow) {
+				matchedState = lastState
+				return true
+			}
+			if !state.IsState(lastState, state.Apply.Completed) {
+				return false
+			}
+			recorded, err := applyRecordedState(t.Context(), applyID, state.Apply.RevertWindow)
+			if err != nil {
+				lastLogError = err.Error()
+				return false
+			}
+			lastLogError = ""
+			if recorded {
+				matchedState = lastState
+				return true
+			}
+			return false
+		},
+		func() string {
+			return fmt.Sprintf("timeout waiting for apply %s to enter or record state %q after %s, last API state: %q, error: %q, log_error: %q\n%s",
+				applyID, state.Apply.RevertWindow, time.Since(start), lastState, lastError, lastLogError,
+				applyTimeoutDiagnostics(applyID))
+		},
+	)
+	return matchedState
+}
+
+func applyRecordedState(ctx context.Context, applyID, expectedState string) (bool, error) {
+	dsn := os.Getenv("E2E_MYSQL_DSN")
+	if dsn == "" {
+		return false, fmt.Errorf("E2E_MYSQL_DSN not set")
+	}
+	db, err := sql.Open("mysql", dsn)
+	if err != nil {
+		return false, fmt.Errorf("open schemabot db: %w", err)
+	}
+	defer utils.CloseAndLog(db)
+
+	queryCtx, cancel := context.WithTimeout(ctx, testutil.ProgressTimeout)
+	defer cancel()
+	if err := db.PingContext(queryCtx); err != nil {
+		return false, fmt.Errorf("ping schemabot db for %s: %w", applyID, err)
+	}
+	rows, err := db.QueryContext(queryCtx, `
+		SELECT COALESCE(l.new_state, '')
+		FROM apply_logs l
+		JOIN applies a ON a.id = l.apply_id
+		WHERE a.apply_identifier = ?
+		ORDER BY l.id ASC
+	`, applyID)
+	if err != nil {
+		return false, fmt.Errorf("query apply logs for %s: %w", applyID, err)
+	}
+	defer utils.CloseAndLog(rows)
+	for rows.Next() {
+		var loggedState string
+		if err := rows.Scan(&loggedState); err != nil {
+			return false, fmt.Errorf("scan apply log state for %s: %w", applyID, err)
+		}
+		if state.IsState(loggedState, expectedState) {
+			return true, nil
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return false, fmt.Errorf("iterate apply log states for %s: %w", applyID, err)
+	}
+	return false, nil
+}
+
 // applyTimeoutDiagnostics returns a best-effort dump of the SchemaBot storage
 // state for applyID plus the operator's overall backlog, for inclusion in a
 // wait-timeout failure message. It answers the triage question when an apply

--- a/e2e/local/vitess_test.go
+++ b/e2e/local/vitess_test.go
@@ -1362,7 +1362,9 @@ func TestVitess_Apply_Timestamps(t *testing.T) {
 // --- Revert behavior tests ---
 
 func TestVitess_Apply_RevertWindow(t *testing.T) {
-	// Verify that applies without --skip-revert correctly reach the revert window state.
+	// Applies without --skip-revert must expose a revert window. The window may
+	// expire before the external test poll samples it, so the durable apply log is
+	// also accepted when progress has already finalized.
 	vitessAvailable(t)
 	clearSchemaBotState(t)
 
@@ -1389,7 +1391,10 @@ func TestVitess_Apply_RevertWindow(t *testing.T) {
 	applyID := extractApplyIDFromLog(applyOut)
 	require.NotEmpty(t, applyID, "expected apply ID in output")
 
-	waitForApplyState(t, endpoint, applyID, state.Apply.RevertWindow, testutil.PollDeadline)
+	matchedState := waitForApplyRevertWindow(t, endpoint, applyID, testutil.PollDeadline)
+	if state.IsState(matchedState, state.Apply.Completed) {
+		return
+	}
 
 	skipResp, err := client.CallSkipRevertAPI(endpoint, "staging", applyID)
 	require.NoError(t, err, "skip-revert after reaching revert_window")


### PR DESCRIPTION
## Why
The Vitess revert-window E2E can miss the short live revert-window state when LocalScale finalizes before the test poll samples it.

## What
- Accept durable apply-log evidence that the apply entered the revert window when progress has already completed
- Keep the live skip-revert API check when the test observes the revert window directly

## Risk Assessment
Low — this changes only E2E test assertions and preserves the revert-window safety invariant.

Generated with Amp