### PR TITLE
feat(plan): show already-satisfied shards as a group in sharded plans

### DIFF
--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -5877,6 +5877,41 @@ schemabot apply -e production
 </details>
 
 <details>
+<summary><a name="plan-partially-applied-shards"></a><strong>Plan: Partially Applied Shards</strong></summary>
+
+
+## Schema Change Plan — Production
+
+**Database**: `cdb_resolute` | **Type**: `Strata`
+
+*Requested by @jackjackbits at 2026-01-01 00:00:00 UTC · planned from [`abcdef1`](https://github.com/block/schemabot/commit/abcdef1234567890abcdef1234567890abcdef12)*
+
+#### Keyspace: `cdb_resolute_sharded`
+Shards diverge — what applies where:
+
+**shard `-40`**
+
+_Already applied — no change._
+
+**shards `40-80`, `80-c0`, `c0-`**
+
+```sql
+ALTER TABLE `mutes` ADD INDEX `created_at`(`created_at`);
+```
+
+📋 **Plan**: 1 DDL statement
+
+
+---
+
+💡 **To apply** all schema changes from this PR, comment:
+```
+schemabot apply -e production
+```
+
+</details>
+
+<details>
 <summary><a name="plan-unsafe-change-on-one-shard"></a><strong>Plan: Unsafe Change On One Shard</strong></summary>
 
 

--- a/pkg/api/proto_helpers.go
+++ b/pkg/api/proto_helpers.go
@@ -228,11 +228,11 @@ func planResponseFromProto(resp *ternv1.PlanResponse) *apitypes.PlanResponse {
 				UnsafeReason: t.UnsafeReason,
 			})
 		}
-		// A shard is changing iff it carries changes (the proto contract); drop an
-		// empty shard plan so it never renders a blank shard section downstream.
-		if len(apiSP.Changes) == 0 {
-			continue
-		}
+		// An empty shard plan is a shard that already matches the desired schema
+		// while sibling shards change (a partially-applied keyspace). Keep it so the
+		// plan comment can show the divergent "already applied vs will change"
+		// picture; carrying no changes, it renders as a no-change group downstream
+		// and the apply fan-out skips it (a shard is changing iff it has changes).
 		httpResp.Shards = append(httpResp.Shards, apiSP)
 	}
 

--- a/pkg/api/proto_helpers_test.go
+++ b/pkg/api/proto_helpers_test.go
@@ -65,6 +65,29 @@ func TestPlanResponseFromProto_ChangeType(t *testing.T) {
 	assert.Equal(t, "drop", tables[2].ChangeType, "DROP should be lowercase 'drop', not proto enum string")
 }
 
+// A shard plan with no changes is a shard already matching the desired schema
+// in a partially-applied keyspace. planResponseFromProto must carry it (rather
+// than dropping it) so the plan comment can show the divergent state; the
+// changing shard is carried with its DDL alongside.
+func TestPlanResponseFromProto_CarriesSatisfiedShard(t *testing.T) {
+	resp := &ternv1.PlanResponse{
+		Shards: []*ternv1.ShardPlan{
+			{Namespace: "cdb_resolute_sharded", Shard: "-40"}, // satisfied: no changes
+			{Namespace: "cdb_resolute_sharded", Shard: "40-80", Changes: []*ternv1.TableChange{
+				{TableName: "mutes", Ddl: "ALTER TABLE `mutes` ADD INDEX `created_at`(`created_at`)", ChangeType: ternv1.ChangeType_CHANGE_TYPE_ALTER},
+			}},
+		},
+	}
+
+	result := planResponseFromProto(resp)
+
+	require.Len(t, result.Shards, 2, "the satisfied shard is carried, not dropped")
+	assert.Equal(t, "-40", result.Shards[0].Shard)
+	assert.Empty(t, result.Shards[0].Changes, "the satisfied shard carries no changes")
+	assert.Equal(t, "40-80", result.Shards[1].Shard)
+	require.Len(t, result.Shards[1].Changes, 1, "the changing shard keeps its DDL")
+}
+
 func TestProtoChangesToNamespacesPreservesUnsafeMetadata(t *testing.T) {
 	namespaces, err := protoChangesToNamespaces([]*ternv1.SchemaChange{{
 		Namespace: "testapp",

--- a/pkg/cmd/internal/templates/preview_comment.go
+++ b/pkg/cmd/internal/templates/preview_comment.go
@@ -276,6 +276,7 @@ func previewCommentShardedAllOutput() {
 		fn   func()
 	}{
 		{"PLAN: DIVERGENT SHARDS", func() { fmt.Print(webhooktemplates.PreviewCommentShardedPlanDivergent()) }},
+		{"PLAN: PARTIALLY APPLIED SHARDS", func() { fmt.Print(webhooktemplates.PreviewCommentShardedPlanPartiallyApplied()) }},
 		{"PLAN: UNSAFE CHANGE ON ONE SHARD", func() { fmt.Print(webhooktemplates.PreviewCommentShardedPlanUnsafe()) }},
 		{"APPLY IN PROGRESS", func() { fmt.Print(webhooktemplates.PreviewCommentShardedApplyInProgress()) }},
 		{"APPLY FAILED (ONE SHARD FAILED)", func() { fmt.Print(webhooktemplates.PreviewCommentShardedApplyFailed()) }},
@@ -387,7 +388,11 @@ func printSections(sections []struct {
 		if i > 0 {
 			fmt.Println()
 		}
-		fmt.Println("---", s.name, strings.Repeat("-", 50-len(s.name)))
+		// Clamp the trailing rule so a section name longer than the target width
+		// doesn't pass a negative count to strings.Repeat (which panics and would
+		// abort the whole TEMPLATES.md regeneration).
+		dashes := max(50-len(s.name), 0)
+		fmt.Println("---", s.name, strings.Repeat("-", dashes))
 		fmt.Println()
 		s.fn()
 	}

--- a/pkg/webhook/plan.go
+++ b/pkg/webhook/plan.go
@@ -3,6 +3,7 @@ package webhook
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"time"
 
@@ -486,6 +487,7 @@ func buildPlanCommentData(schema *ghclient.SchemaRequestResult, planResp *apityp
 	// Per-shard changes, grouped by keyspace, so a sharded keyspace can show what
 	// applies to which shard rather than the collapsed namespace-level view.
 	shardsByKeyspace := make(map[string][]templates.KeyspaceShardChange)
+	var malformedShardErrors []string
 	for _, sp := range planResp.Shards {
 		if sp == nil {
 			continue
@@ -497,15 +499,21 @@ func buildPlanCommentData(schema *ghclient.SchemaRequestResult, planResp *apityp
 			}
 			shard.Statements = append(shard.Statements, t.DDL)
 		}
-		// A shard with zero changes already matches the desired schema while
-		// sibling shards change; carry it as a satisfied (no-change) group so a
-		// partially-applied keyspace renders its divergent "already applied vs will
-		// change" state instead of hiding the shard. A shard that carries changes
-		// but yields no usable DDL is malformed — skip it.
 		if len(shard.Statements) == 0 {
 			if len(sp.Changes) > 0 {
+				// The shard reported changes but none produced usable DDL — the
+				// plan is incomplete for this shard. Surface it as an error rather
+				// than dropping the shard, which would silently hide the divergent
+				// state this view exists to show.
+				malformedShardErrors = append(malformedShardErrors, fmt.Sprintf(
+					"shard %q in keyspace %q reported %d change(s) with no DDL — plan is incomplete for this shard",
+					sp.Shard, sp.Namespace, len(sp.Changes)))
 				continue
 			}
+			// A shard with zero changes already matches the desired schema while
+			// sibling shards change; carry it as a satisfied (no-change) group so a
+			// partially-applied keyspace renders its divergent "already applied vs
+			// will change" state instead of hiding the shard.
 			shard.Satisfied = true
 		}
 		shardsByKeyspace[sp.Namespace] = append(shardsByKeyspace[sp.Namespace], shard)
@@ -554,8 +562,11 @@ func buildPlanCommentData(schema *ghclient.SchemaRequestResult, planResp *apityp
 		})
 	}
 
-	// Add errors
-	data.Errors = planResp.Errors
+	// Add errors. Malformed-shard errors (changes reported with no usable DDL)
+	// are surfaced alongside the plan's own errors so the operator sees the plan
+	// is incomplete rather than reading a silently-shortened shard list.
+	data.Errors = append(data.Errors, planResp.Errors...)
+	data.Errors = append(data.Errors, malformedShardErrors...)
 
 	return data
 }

--- a/pkg/webhook/plan.go
+++ b/pkg/webhook/plan.go
@@ -497,10 +497,16 @@ func buildPlanCommentData(schema *ghclient.SchemaRequestResult, planResp *apityp
 			}
 			shard.Statements = append(shard.Statements, t.DDL)
 		}
-		// A shard with no DDL is not changing; skipping it keeps it out of the
-		// shard-grouped rendering and the change count.
+		// A shard with zero changes already matches the desired schema while
+		// sibling shards change; carry it as a satisfied (no-change) group so a
+		// partially-applied keyspace renders its divergent "already applied vs will
+		// change" state instead of hiding the shard. A shard that carries changes
+		// but yields no usable DDL is malformed — skip it.
 		if len(shard.Statements) == 0 {
-			continue
+			if len(sp.Changes) > 0 {
+				continue
+			}
+			shard.Satisfied = true
 		}
 		shardsByKeyspace[sp.Namespace] = append(shardsByKeyspace[sp.Namespace], shard)
 	}

--- a/pkg/webhook/plan_test.go
+++ b/pkg/webhook/plan_test.go
@@ -70,6 +70,63 @@ func TestBuildPlanCommentData_PerShardUnsafe(t *testing.T) {
 	assert.Equal(t, []string{"40-80"}, data.UnsafeChanges[0].Shards, "the unsafe change is scoped to the drifted shard")
 }
 
+// A shard that already matches the desired schema while siblings change is
+// carried as a satisfied (no-change) group, so a partially-applied keyspace
+// renders its divergent state instead of hiding the shard.
+func TestBuildPlanCommentData_CarriesSatisfiedShard(t *testing.T) {
+	schema := &ghclient.SchemaRequestResult{Database: "cdb_resolute", Type: "strata"}
+	const mutes = "ALTER TABLE `mutes` ADD INDEX `created_at`(`created_at`)"
+	planResp := &apitypes.PlanResponse{
+		Changes: []*apitypes.SchemaChangeResponse{{
+			Namespace:    "cdb_resolute_sharded",
+			TableChanges: []*apitypes.TableChangeResponse{{TableName: "mutes", DDL: mutes, ChangeType: "alter"}},
+		}},
+		Shards: []*apitypes.ShardPlanResponse{
+			{Namespace: "cdb_resolute_sharded", Shard: "-40"}, // already matches — no changes
+			{Namespace: "cdb_resolute_sharded", Shard: "40-80", Changes: []*apitypes.TableChangeResponse{{TableName: "mutes", DDL: mutes, ChangeType: "alter"}}},
+		},
+	}
+
+	data := buildPlanCommentData(schema, planResp, "staging", "", "testuser")
+
+	require.Len(t, data.Changes, 1)
+	require.Len(t, data.Changes[0].Shards, 2, "the satisfied shard is carried, not dropped")
+	assert.Equal(t, "-40", data.Changes[0].Shards[0].Shard)
+	assert.True(t, data.Changes[0].Shards[0].Satisfied, "a shard with no changes is marked satisfied")
+	assert.Empty(t, data.Changes[0].Shards[0].Statements)
+	assert.False(t, data.Changes[0].Shards[1].Satisfied, "the changing shard is not satisfied")
+	assert.Empty(t, data.Errors, "a satisfied shard is not an error")
+}
+
+// A shard that reports changes but produces no usable DDL is malformed: the plan
+// is incomplete for that shard. It is surfaced as an error rather than silently
+// dropped, which would hide the divergent state the sharded view exists to show.
+func TestBuildPlanCommentData_MalformedShardSurfacesError(t *testing.T) {
+	schema := &ghclient.SchemaRequestResult{Database: "cdb_resolute", Type: "strata"}
+	const mutes = "ALTER TABLE `mutes` ADD INDEX `created_at`(`created_at`)"
+	planResp := &apitypes.PlanResponse{
+		Changes: []*apitypes.SchemaChangeResponse{{
+			Namespace:    "cdb_resolute_sharded",
+			TableChanges: []*apitypes.TableChangeResponse{{TableName: "mutes", DDL: mutes, ChangeType: "alter"}},
+		}},
+		Shards: []*apitypes.ShardPlanResponse{
+			{Namespace: "cdb_resolute_sharded", Shard: "-40", Changes: []*apitypes.TableChangeResponse{{TableName: "mutes", DDL: mutes, ChangeType: "alter"}}},
+			// Reports a change but yields no DDL — malformed.
+			{Namespace: "cdb_resolute_sharded", Shard: "40-80", Changes: []*apitypes.TableChangeResponse{{TableName: "mutes", DDL: "", ChangeType: "alter"}}},
+		},
+	}
+
+	data := buildPlanCommentData(schema, planResp, "staging", "", "testuser")
+
+	require.Len(t, data.Changes, 1)
+	require.Len(t, data.Changes[0].Shards, 1, "the malformed shard is not carried into the rendered shards")
+	assert.Equal(t, "-40", data.Changes[0].Shards[0].Shard)
+	require.Len(t, data.Errors, 1, "the malformed shard is surfaced as an error")
+	assert.Contains(t, data.Errors[0], `shard "40-80"`)
+	assert.Contains(t, data.Errors[0], `keyspace "cdb_resolute_sharded"`)
+	assert.Contains(t, data.Errors[0], "no DDL")
+}
+
 func TestBuildPlanCommentData_UnsafeChangesPopulated(t *testing.T) {
 	schema := &ghclient.SchemaRequestResult{
 		Database: "testdb",

--- a/pkg/webhook/templates/plan.go
+++ b/pkg/webhook/templates/plan.go
@@ -401,9 +401,9 @@ func writeShardedPlanDDL(sb *strings.Builder, shards []KeyspaceShardChange) {
 	groups := groupKeyspaceShardsByStatements(shards)
 	if len(groups) <= 1 {
 		// A single group of changing shards shows the DDL once. A lone group of
-		// satisfied shards (no statements) means nothing is changing, so render
-		// nothing rather than an empty code block.
-		if len(groups) == 1 && len(groups[0].Statements) > 0 {
+		// satisfied shards means nothing is changing, so render nothing rather
+		// than an empty code block.
+		if len(groups) == 1 && !groups[0].Satisfied {
 			writePlanDDLBlock(sb, groups[0].Statements)
 		}
 		return
@@ -411,9 +411,9 @@ func writeShardedPlanDDL(sb *strings.Builder, shards []KeyspaceShardChange) {
 	sb.WriteString("Shards diverge — what applies where:\n\n")
 	for _, g := range groups {
 		fmt.Fprintf(sb, "**%s**\n\n", planShardList(g.Shards))
-		// A satisfied group already matches the desired schema (no statements);
-		// say so instead of rendering an empty code block.
-		if len(g.Statements) == 0 {
+		// A satisfied group already matches the desired schema; say so instead
+		// of rendering an empty code block.
+		if g.Satisfied {
 			sb.WriteString("_Already applied — no change._\n\n")
 			continue
 		}
@@ -424,18 +424,20 @@ func writeShardedPlanDDL(sb *strings.Builder, shards []KeyspaceShardChange) {
 type keyspaceShardGroup struct {
 	Shards     []string
 	Statements []string
+	Satisfied  bool
 }
 
-// groupKeyspaceShardsByStatements buckets shards whose statement set is
-// identical, preserving resolved order, so a uniform keyspace yields one group.
+// groupKeyspaceShardsByStatements buckets shards whose statement set and
+// satisfied status are identical, preserving resolved order, so a uniform
+// keyspace yields one group.
 func groupKeyspaceShardsByStatements(shards []KeyspaceShardChange) []keyspaceShardGroup {
 	var order []string
 	bySig := make(map[string]*keyspaceShardGroup)
 	for _, s := range shards {
-		sig := strings.Join(s.Statements, "\x01")
+		sig := shardGroupSignature(s)
 		g := bySig[sig]
 		if g == nil {
-			g = &keyspaceShardGroup{Statements: s.Statements}
+			g = &keyspaceShardGroup{Statements: s.Statements, Satisfied: s.Satisfied}
 			bySig[sig] = g
 			order = append(order, sig)
 		}
@@ -446,6 +448,19 @@ func groupKeyspaceShardsByStatements(shards []KeyspaceShardChange) []keyspaceSha
 		groups = append(groups, *bySig[sig])
 	}
 	return groups
+}
+
+// shardGroupSignature keys shards into the same group only when they carry the
+// same planned statements and the same satisfied status. Keying on Satisfied —
+// not just an empty statement set — keeps a satisfied shard from ever merging
+// with a changing shard, and ensures only a shard explicitly marked satisfied
+// renders as "already applied".
+func shardGroupSignature(s KeyspaceShardChange) string {
+	status := "change"
+	if s.Satisfied {
+		status = "satisfied"
+	}
+	return status + "\x02" + strings.Join(s.Statements, "\x01")
 }
 
 // planShardList renders a group's shards as "shard `x`" or "shards `x`, `y`".

--- a/pkg/webhook/templates/plan.go
+++ b/pkg/webhook/templates/plan.go
@@ -84,6 +84,11 @@ type KeyspaceChangeData struct {
 type KeyspaceShardChange struct {
 	Shard      string
 	Statements []string
+	// Satisfied marks a shard that already matches the desired schema while
+	// sibling shards in the keyspace change — a partially-applied keyspace. It
+	// carries no Statements and renders as an "already applied" group, so the
+	// plan comment shows the divergent state rather than hiding the shard.
+	Satisfied bool
 }
 
 // RenderPlanComment renders the plan comment markdown.
@@ -395,7 +400,10 @@ func writePlanDDLBlock(sb *strings.Builder, statements []string) {
 func writeShardedPlanDDL(sb *strings.Builder, shards []KeyspaceShardChange) {
 	groups := groupKeyspaceShardsByStatements(shards)
 	if len(groups) <= 1 {
-		if len(groups) == 1 {
+		// A single group of changing shards shows the DDL once. A lone group of
+		// satisfied shards (no statements) means nothing is changing, so render
+		// nothing rather than an empty code block.
+		if len(groups) == 1 && len(groups[0].Statements) > 0 {
 			writePlanDDLBlock(sb, groups[0].Statements)
 		}
 		return
@@ -403,6 +411,12 @@ func writeShardedPlanDDL(sb *strings.Builder, shards []KeyspaceShardChange) {
 	sb.WriteString("Shards diverge — what applies where:\n\n")
 	for _, g := range groups {
 		fmt.Fprintf(sb, "**%s**\n\n", planShardList(g.Shards))
+		// A satisfied group already matches the desired schema (no statements);
+		// say so instead of rendering an empty code block.
+		if len(g.Statements) == 0 {
+			sb.WriteString("_Already applied — no change._\n\n")
+			continue
+		}
 		writePlanDDLBlock(sb, g.Statements)
 	}
 }

--- a/pkg/webhook/templates/preview_sharded.go
+++ b/pkg/webhook/templates/preview_sharded.go
@@ -98,6 +98,27 @@ func PreviewCommentShardedPlanDivergent() string {
 	})
 }
 
+// PreviewCommentShardedPlanPartiallyApplied renders a sharded plan where one
+// shard already has the change (e.g. an interrupted earlier rollout) and the
+// rest still need it. The satisfied shard renders as an "already applied" group
+// so the partially-applied keyspace shows its divergent state.
+func PreviewCommentShardedPlanPartiallyApplied() string {
+	idx := "ALTER TABLE `mutes` ADD INDEX `created_at`(`created_at`)"
+	return RenderPlanComment(PlanCommentData{
+		Database: "cdb_resolute", Environment: "production", DatabaseType: "strata",
+		HeadSHA: previewHeadSHA, Repository: previewRepository, RequestedBy: previewRequestedBy,
+		Changes: []KeyspaceChangeData{{
+			Keyspace: "cdb_resolute_sharded",
+			Shards: []KeyspaceShardChange{
+				{Shard: "-40", Satisfied: true},
+				{Shard: "40-80", Statements: []string{idx}},
+				{Shard: "80-c0", Statements: []string{idx}},
+				{Shard: "c0-", Statements: []string{idx}},
+			},
+		}},
+	})
+}
+
 // PreviewCommentShardedPlanUnsafe renders a sharded plan where one shard's
 // combined ALTER drops a column (unsafe), flagged with the shard.
 func PreviewCommentShardedPlanUnsafe() string {

--- a/pkg/webhook/templates/sharded_plan_test.go
+++ b/pkg/webhook/templates/sharded_plan_test.go
@@ -30,6 +30,32 @@ func TestRenderPlanComment_ShardedDivergent(t *testing.T) {
 	assert.Equal(t, 2, strings.Count(out, "```sql"), "one DDL block per group")
 }
 
+// A partially-applied keyspace — some shards already have the change, the rest
+// don't — is divergent: the satisfied shards render as an "already applied"
+// group alongside the changing shards' DDL, instead of being hidden (which
+// would mislead the operator into reading it as a clean uniform apply).
+func TestRenderPlanComment_ShardedPartiallyApplied(t *testing.T) {
+	stmt := "ALTER TABLE `mutes` ADD INDEX `created_at`(`created_at`)"
+	out := RenderPlanComment(PlanCommentData{
+		Database: "cdb_resolute", Environment: "staging", DatabaseType: "strata",
+		Changes: []KeyspaceChangeData{{
+			Keyspace: "cdb_resolute_sharded",
+			Shards: []KeyspaceShardChange{
+				{Shard: "-40", Satisfied: true}, // already has the index
+				{Shard: "40-80", Statements: []string{stmt}},
+				{Shard: "80-c0", Statements: []string{stmt}},
+				{Shard: "c0-", Statements: []string{stmt}},
+			},
+		}},
+	})
+
+	assert.Contains(t, out, "Shards diverge — what applies where:", "a partially-applied keyspace is divergent")
+	assert.Contains(t, out, "Already applied — no change.", "satisfied shards are surfaced, not hidden")
+	assert.Contains(t, out, "**shard `-40`**", "the satisfied shard is named")
+	assert.Contains(t, out, "**shards `40-80`, `80-c0`, `c0-`**", "the changing shards share one group")
+	assert.Equal(t, 1, strings.Count(out, "```sql"), "the satisfied group shows no empty code block")
+}
+
 // A uniform sharded plan (every shard the same change) shows the DDL once with
 // no divergence header.
 func TestRenderPlanComment_ShardedUniform(t *testing.T) {


### PR DESCRIPTION
## Problem

When a sharded keyspace is **partially applied** — some shards already carry the change while others don't (e.g. an interrupted rollout, drift, or the serial-apply bug fixed in #556 leaving only one shard changed) — re-planning rendered a clean *uniform* apply over just the shards that still needed it. The already-satisfied shards were dropped at the plan-comment builder, so the operator couldn't tell the keyspace was in a divergent, partially-applied state.

Root cause: satisfied shards were dropped at two layers — the gap strata plan (separate PR) and schemabot's `planResponseFromProto` / `webhook/plan.go` — so they never reached the divergence grouping, which then saw only the uniform changing shards.

## Fix

Carry already-satisfied shards through as a shard plan with **no changes**, and render them as an *"already applied — no change"* group alongside the changing shards' DDL, so the divergent "what applies where" template fires.

- `proto_helpers`: `planResponseFromProto` keeps empty-change shard plans (previously dropped)
- `webhook/plan`: carry satisfied shards into `KeyspaceShardChange{Satisfied: true}`
- `templates/plan`: render the satisfied group, with no empty SQL block
- `preview`: add a partially-applied sharded plan preview (now in `TEMPLATES.md`)
- `preview_comment`: clamp the section rule so a long section name can't pass a negative count to `strings.Repeat` and abort the `TEMPLATES.md` regeneration

A shard with no changes still builds **no apply operation** (`changingShardsByNamespace` already excludes it), so this is presentation-only for the plan comment.

## Companion

The data plane must *emit* satisfied shards for this to take effect — a separate gap PR changes `strataengine` to emit changeless shards within a partially-applied keyspace.

## Test

- `TestRenderPlanComment_ShardedPartiallyApplied` — satisfied shards surface as an "already applied" group; no empty SQL block
- `TestPlanResponseFromProto_CarriesSatisfiedShard` — empty-change shard plans are no longer dropped in the proto→API conversion