### PR TITLE
fix(tern): thread the engine resume state through the sequential completion poll

### DIFF
--- a/pkg/tern/local_apply_sequential.go
+++ b/pkg/tern/local_apply_sequential.go
@@ -212,8 +212,12 @@ func (c *LocalClient) runEngineTask(ctx context.Context, apply *storage.Apply, t
 	c.transitionTaskState(ctx, task, 0, state.Task.Running, "")
 	c.logger.Info("task running", "task_id", task.TaskIdentifier, "table", task.TableName)
 
-	// Poll to completion
-	pollAction := c.pollTaskToCompletion(ctx, apply, task, taskCreds)
+	// Poll to completion. Thread the engine's returned resume state into the
+	// poll: a sharded engine (Strata) identifies the operation to report on from
+	// ResumeState.Metadata and errors without it, so Progress must carry what
+	// Apply returned. (Spirit reports per-database and returns no resume state, so
+	// this stays nil and its behaviour is unchanged.)
+	pollAction := c.pollTaskToCompletion(ctx, apply, task, taskCreds, result.ResumeState)
 	if pollAction == taskAbort || pollAction == taskStopped {
 		return pollAction
 	}
@@ -297,10 +301,12 @@ func (c *LocalClient) startApplyHeartbeat(ctx context.Context, apply *storage.Ap
 // pollForCompletionAtomic polls the engine for progress in atomic mode (all tasks share state).
 
 // pollTaskToCompletion polls a single task to completion (sequential mode).
-func (c *LocalClient) pollTaskToCompletion(ctx context.Context, apply *storage.Apply, task *storage.Task, creds *engine.Credentials) taskAction {
+func (c *LocalClient) pollTaskToCompletion(ctx context.Context, apply *storage.Apply, task *storage.Task, creds *engine.Credentials, resumeState *engine.ResumeState) taskAction {
 	eng := c.getEngine()
 	ticker := time.NewTicker(500 * time.Millisecond)
 	defer ticker.Stop()
+
+	var consecutiveErrors int
 
 	for {
 		select {
@@ -334,11 +340,27 @@ func (c *LocalClient) pollTaskToCompletion(ctx context.Context, apply *storage.A
 			result, err := eng.Progress(ctx, &engine.ProgressRequest{
 				Database:    task.Database,
 				Credentials: creds,
+				ResumeState: resumeState,
 			})
 			if err != nil {
-				c.logger.Warn("progress check failed", "error", err, "task_id", task.TaskIdentifier)
+				// A poll that can never succeed (e.g. a persistently malformed
+				// progress request) must not spin forever: an apply that cannot
+				// reach a terminal state holds the database's active-apply slot and
+				// blocks every later apply. Fail fast after a bounded run of errors,
+				// matching the grouped poll's behaviour.
+				consecutiveErrors++
+				c.logger.Warn("progress check failed", "error", err, "task_id", task.TaskIdentifier, "consecutive_errors", consecutiveErrors)
+				if consecutiveErrors >= 10 {
+					if c.shouldRetryEngineError(err) {
+						c.markTaskRetryable(ctx, task, fmt.Sprintf("progress polling failed after %d consecutive errors: %v", consecutiveErrors, err))
+						return taskFailed
+					}
+					c.markTaskFailed(ctx, task, fmt.Sprintf("progress polling failed after %d consecutive errors: %v", consecutiveErrors, err))
+					return taskFailed
+				}
 				continue
 			}
+			consecutiveErrors = 0
 
 			now := time.Now()
 			prevState := task.State

--- a/pkg/tern/local_apply_sequential.go
+++ b/pkg/tern/local_apply_sequential.go
@@ -343,11 +343,19 @@ func (c *LocalClient) pollTaskToCompletion(ctx context.Context, apply *storage.A
 				ResumeState: resumeState,
 			})
 			if err != nil {
-				// A poll that can never succeed (e.g. a persistently malformed
-				// progress request) must not spin forever: an apply that cannot
-				// reach a terminal state holds the database's active-apply slot and
-				// blocks every later apply. Fail fast after a bounded run of errors,
-				// matching the grouped poll's behaviour.
+				// A permanent error can never succeed on retry, so fail immediately
+				// rather than waiting out the consecutive-error budget — matching the
+				// grouped poll.
+				var permanent *engine.PermanentError
+				if errors.As(err, &permanent) {
+					c.logger.Error("progress check failed with permanent error", "error", err, "task_id", task.TaskIdentifier)
+					c.markTaskFailed(ctx, task, fmt.Sprintf("progress polling failed: %v", err))
+					return taskFailed
+				}
+				// A transient poll that nonetheless never succeeds must not spin
+				// forever: an apply that cannot reach a terminal state holds the
+				// database's active-apply slot and blocks every later apply. Fail
+				// after a bounded run of errors, matching the grouped poll.
 				consecutiveErrors++
 				c.logger.Warn("progress check failed", "error", err, "task_id", task.TaskIdentifier, "consecutive_errors", consecutiveErrors)
 				if consecutiveErrors >= 10 {

--- a/pkg/tern/local_apply_sequential_progress_test.go
+++ b/pkg/tern/local_apply_sequential_progress_test.go
@@ -60,7 +60,7 @@ func TestPollTaskToCompletion_ThreadsResumeState(t *testing.T) {
 		},
 		logger: slog.Default(),
 	}
-	resume := &engine.ResumeState{MigrationContext: "spirit-ctx", Metadata: "shard-meta"}
+	resume := &engine.ResumeState{Metadata: "shard-meta"}
 
 	action := client.pollTaskToCompletion(t.Context(), apply, task, nil, resume)
 
@@ -68,4 +68,42 @@ func TestPollTaskToCompletion_ThreadsResumeState(t *testing.T) {
 	assert.Equal(t, state.Task.Completed, task.State)
 	require.NotNil(t, eng.gotResumeState, "Progress must receive the resume state")
 	assert.Equal(t, "shard-meta", eng.gotResumeState.Metadata, "the engine's resume-state metadata is threaded into Progress")
+}
+
+// permanentProgressErrorEngine always fails Progress with a permanent error.
+type permanentProgressErrorEngine struct{ engine.Engine }
+
+func (permanentProgressErrorEngine) Name() string { return "permanent-error" }
+func (permanentProgressErrorEngine) Progress(context.Context, *engine.ProgressRequest) (*engine.ProgressResult, error) {
+	return nil, engine.NewPermanentError("deploy request not found")
+}
+
+// A permanent progress error fails the task immediately rather than waiting out
+// the consecutive-error budget, matching the grouped poll.
+func TestPollTaskToCompletion_PermanentErrorFailsFast(t *testing.T) {
+	task := &storage.Task{
+		ID: 1, ApplyID: 1, TaskIdentifier: "task-1",
+		Database: "cdb_resolute", DatabaseType: storage.DatabaseTypeStrata,
+		Namespace: "cdb_resolute_sharded", TableName: "mutes", Shard: "-40",
+		State: state.Task.Running,
+	}
+	apply := &storage.Apply{
+		ID: 1, ApplyIdentifier: "apply-1", Database: "cdb_resolute",
+		DatabaseType: storage.DatabaseTypeStrata, Environment: "staging",
+	}
+	client := &LocalClient{
+		config:       LocalConfig{Database: "cdb_resolute", Type: storage.DatabaseTypeStrata},
+		customEngine: permanentProgressErrorEngine{},
+		storage: &exactProgressStorage{
+			tasks:           &exactProgressTaskStore{tasks: []*storage.Task{task}},
+			controlRequests: &testControlRequestStore{},
+			logs:            &mockApplyLogStore{},
+		},
+		logger: slog.Default(),
+	}
+
+	action := client.pollTaskToCompletion(t.Context(), apply, task, nil, &engine.ResumeState{Metadata: "shard-meta"})
+
+	assert.Equal(t, taskFailed, action)
+	assert.Equal(t, state.Task.Failed, task.State, "a permanent progress error fails the task without exhausting the retry budget")
 }

--- a/pkg/tern/local_apply_sequential_progress_test.go
+++ b/pkg/tern/local_apply_sequential_progress_test.go
@@ -1,0 +1,71 @@
+package tern
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/block/schemabot/pkg/engine"
+	"github.com/block/schemabot/pkg/state"
+	"github.com/block/schemabot/pkg/storage"
+)
+
+// resumeRequiringEngine models a sharded engine (Strata): Progress identifies the
+// operation to report on from ResumeState.Metadata and errors without it. With it,
+// the operation reports completed.
+type resumeRequiringEngine struct {
+	engine.Engine
+	gotResumeState *engine.ResumeState
+}
+
+func (e *resumeRequiringEngine) Name() string { return "resume-requiring" }
+
+func (e *resumeRequiringEngine) Progress(_ context.Context, req *engine.ProgressRequest) (*engine.ProgressResult, error) {
+	e.gotResumeState = req.ResumeState
+	if req.ResumeState == nil || req.ResumeState.Metadata == "" {
+		return nil, fmt.Errorf("strata progress: missing resume state")
+	}
+	return &engine.ProgressResult{State: engine.StateCompleted}, nil
+}
+
+// The sequential poll must thread the engine's returned resume state into
+// Progress. A sharded engine (Strata) errors without ResumeState.Metadata, so a
+// dropped resume state means Progress fails every tick, the apply never reaches a
+// terminal state, and it hangs running — holding the database's active-apply slot
+// and blocking every later apply. Drive the poll against such an engine and assert
+// the task completes and the engine received the resume state.
+func TestPollTaskToCompletion_ThreadsResumeState(t *testing.T) {
+	task := &storage.Task{
+		ID: 1, ApplyID: 1, TaskIdentifier: "task-1",
+		Database: "cdb_resolute", DatabaseType: storage.DatabaseTypeStrata,
+		Namespace: "cdb_resolute_sharded", TableName: "mutes", Shard: "-40",
+		State: state.Task.Running,
+	}
+	apply := &storage.Apply{
+		ID: 1, ApplyIdentifier: "apply-1", Database: "cdb_resolute",
+		DatabaseType: storage.DatabaseTypeStrata, Environment: "staging",
+	}
+	eng := &resumeRequiringEngine{}
+	client := &LocalClient{
+		config:       LocalConfig{Database: "cdb_resolute", Type: storage.DatabaseTypeStrata},
+		customEngine: eng,
+		storage: &exactProgressStorage{
+			tasks:           &exactProgressTaskStore{tasks: []*storage.Task{task}},
+			controlRequests: &testControlRequestStore{},
+			logs:            &mockApplyLogStore{},
+		},
+		logger: slog.Default(),
+	}
+	resume := &engine.ResumeState{MigrationContext: "spirit-ctx", Metadata: "shard-meta"}
+
+	action := client.pollTaskToCompletion(t.Context(), apply, task, nil, resume)
+
+	assert.Equal(t, taskContinue, action, "the task completes once Progress can report on it")
+	assert.Equal(t, state.Task.Completed, task.State)
+	require.NotNil(t, eng.gotResumeState, "Progress must receive the resume state")
+	assert.Equal(t, "shard-meta", eng.gotResumeState.Metadata, "the engine's resume-state metadata is threaded into Progress")
+}


### PR DESCRIPTION
## Problem

A sharded (Strata) apply that completed its work would hang in `running` forever and then block **every** later apply on the database with:

```
create apply ... active apply exists for cdb_resolute/strata/staging deployments [cdb_resolute]: active apply already exists
```

Root cause: the sequential drive's completion poll (`pollTaskToCompletion`) called `engine.Progress` with **no `ResumeState`**:

```go
result, err := eng.Progress(ctx, &engine.ProgressRequest{
    Database:    task.Database,
    Credentials: creds,
})
```

Spirit reports per-database, so it never needed the resume state. But a sharded engine (Strata) identifies the operation to report on from `ResumeState.Metadata` and errors without it — `strata progress: missing resume state`. The poll then logged `progress check failed` and `continue`d **forever with no error cap**, so the task never reached a terminal state, the apply stayed `running`, and the control-plane active-apply guard rejected all subsequent applies. Each attempt left another stuck `running` apply behind.

(The grouped poll already threads the resume state — only the sequential path, which Strata uses, dropped it.)

## Fix

- Thread the resume state the engine returned from `Apply` into the poll's `Progress` calls, mirroring the grouped poll. Spirit returns no resume state, so its behaviour is unchanged (stays nil).
- Fail the task after a bounded run of consecutive progress errors (matching the grouped poll), so a poll that can never succeed can no longer wedge the database indefinitely.

## Test

`TestPollTaskToCompletion_ThreadsResumeState` drives the poll against an engine that requires `ResumeState.Metadata` (like Strata) and asserts the task completes and the engine received the resume state. Without the fix the engine errors every tick, the cap trips, and the task fails — so the test guards both behaviours.