### PR TITLE
fix(sharded): name affected shards in plans; drop redundant DDL from applied comment

### DIFF
--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -5978,11 +5978,6 @@ schemabot apply -e production
 | `80-c0` | ⏳ waiting for -40 |
 | `c0-` | ⏳ waiting for -40 |
 
-`mutes`
-```sql
-ALTER TABLE `mutes` ADD INDEX `created_at`(`created_at`);
-```
-
 _Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:00 UTC</relative-time> (2026-01-01 00:00:00 UTC)_
 
 </details>
@@ -6009,11 +6004,6 @@ _Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:0
 | `40-80` | ⏸ halted — -40 failed |
 | `80-c0` | ⏸ halted — -40 failed |
 | `c0-` | ⏸ halted — -40 failed |
-
-`mutes`
-```sql
-ALTER TABLE `mutes` ADD INDEX `created_at`(`created_at`);
-```
 
 ---
 
@@ -6047,21 +6037,11 @@ Shards diverge — grouped by change:
 | `-40` | 🔄 running table copy |
 | `80-c0` | ⏳ waiting for -40 |
 
-`mutes`
-```sql
-ALTER TABLE `mutes` ADD INDEX `created_at`(`created_at`);
-```
-
 **shard `40-80`**
 
 | Shard | Status |
 | --- | --- |
 | `40-80` | ⏳ waiting for -40 |
-
-`mutes`
-```sql
-ALTER TABLE `mutes` ADD INDEX `created_at`(`created_at`), ADD COLUMN `reason` varchar(255);
-```
 
 _Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:00 UTC</relative-time> (2026-01-01 00:00:00 UTC)_
 </details>

--- a/pkg/webhook/templates/plan.go
+++ b/pkg/webhook/templates/plan.go
@@ -400,10 +400,13 @@ func writePlanDDLBlock(sb *strings.Builder, statements []string) {
 func writeShardedPlanDDL(sb *strings.Builder, shards []KeyspaceShardChange) {
 	groups := groupKeyspaceShardsByStatements(shards)
 	if len(groups) <= 1 {
-		// A single group of changing shards shows the DDL once. A lone group of
-		// satisfied shards means nothing is changing, so render nothing rather
-		// than an empty code block.
+		// A single group of changing shards shows the DDL once, but still names the
+		// shards it applies to — a sharded plan must always show which shards are
+		// affected, even when the change is uniform across them. A lone group of
+		// satisfied shards means nothing is changing, so render nothing rather than
+		// an empty code block.
 		if len(groups) == 1 && !groups[0].Satisfied {
+			fmt.Fprintf(sb, "**%s**\n\n", planShardList(groups[0].Shards))
 			writePlanDDLBlock(sb, groups[0].Statements)
 		}
 		return

--- a/pkg/webhook/templates/sharded_apply.go
+++ b/pkg/webhook/templates/sharded_apply.go
@@ -10,13 +10,13 @@ import (
 
 // ShardedApplyData is the input to the sharded-apply comment: an apply that fans
 // out across the shards of a single keyspace within one deployment. Its unit of
-// work is one operation per (shard, table). Shards are grouped by their change
-// signature: an apply whose shards all need the same change renders one status
-// table with the DDL once, and an apply whose shards diverge — different tables,
-// or the same table computing to different DDL because shards drifted — renders
-// one group per distinct change set, each tying its shards' statuses to the DDL
-// it runs. This is distinct from the multi-deployment comment, whose unit is the
-// deployment.
+// work is one operation per (shard, table). The applied comment shows shard
+// status only — the DDL is already shown in the plan and apply-gate comments, so
+// it is not repeated here. Shards are still grouped by their change signature so
+// a divergent apply (shards that drifted to different changes) shows which shards
+// moved together: a uniform apply renders one status table, a divergent one
+// renders a labelled status group per distinct change set. This is distinct from
+// the multi-deployment comment, whose unit is the deployment.
 type ShardedApplyData struct {
 	// State is the aggregate apply state (state.Apply.*), driving the headline.
 	State string
@@ -59,7 +59,9 @@ type ShardCell struct {
 	DDL   string
 }
 
-// ShardChange is one table's DDL within a group, shown once for the whole group.
+// ShardChange is one table's DDL within a group. The DDL is not rendered in the
+// applied comment; it defines the group's change signature so shards that apply
+// the same change are grouped together.
 type ShardChange struct {
 	Table string
 	DDL   string
@@ -75,8 +77,9 @@ type shardGroup struct {
 // RenderShardedApplyComment renders the PR comment for a sharded apply: the
 // shared apply header and metadata, a per-shard count histogram, the first
 // failed shard's error lifted to the top, then the shards grouped by change
-// signature — a single group renders one status table with the DDL once; more
-// than one renders a labelled group per distinct change set.
+// signature — a single group renders one status table; more than one renders a
+// labelled status group per distinct change set. The comment is status-only; the
+// DDL is shown in the plan and apply-gate comments, not repeated here.
 func RenderShardedApplyComment(data ShardedApplyData) string {
 	var sb strings.Builder
 	renderedAt := currentTimestamp()

--- a/pkg/webhook/templates/sharded_apply.go
+++ b/pkg/webhook/templates/sharded_apply.go
@@ -88,18 +88,19 @@ func RenderShardedApplyComment(data ShardedApplyData) string {
 	writeShardFirstFailure(&sb, data.Shards)
 
 	fmt.Fprintf(&sb, "\n#### Keyspace `%s`\n", data.Keyspace)
+	// The applied comment shows shard status only. The DDL (what changes) is
+	// already shown in the plan and apply-gate comments, so repeating it here adds
+	// nothing — and rendering "DDL unavailable" when the apply path has no per-shard
+	// DDL is pure noise. Shards are still grouped by change so a divergent apply
+	// shows which shards moved together.
 	groups := groupShardsBySignature(data.Shards, data.Cells)
 	if len(groups) <= 1 {
 		writeShardStatusTable(&sb, data.Shards)
-		if len(groups) == 1 {
-			writeGroupDDL(&sb, groups[0].Changes)
-		}
 	} else {
 		sb.WriteString("\nShards diverge — grouped by change:\n")
 		for _, g := range groups {
 			fmt.Fprintf(&sb, "\n**%s**\n", shardList(g.Shards))
 			writeShardStatusTable(&sb, g.Shards)
-			writeGroupDDL(&sb, g.Changes)
 		}
 	}
 
@@ -243,20 +244,6 @@ func writeShardStatusTable(sb *strings.Builder, shards []ShardStatus) {
 	sb.WriteString("\n| Shard | Status |\n| --- | --- |\n")
 	for _, s := range shards {
 		fmt.Fprintf(sb, "| `%s` | %s |\n", s.Shard, shardStatusCell(s))
-	}
-}
-
-// writeGroupDDL writes a group's table changes, each DDL once.
-func writeGroupDDL(sb *strings.Builder, changes []ShardChange) {
-	for _, c := range changes {
-		// Guard against an empty DDL, which would render a blank ```sql box. The
-		// DDL should always be present; if it is missing the change data is
-		// incomplete, so say so rather than show an empty code block.
-		if strings.TrimSpace(c.DDL) == "" {
-			fmt.Fprintf(sb, "\n`%s` — _DDL unavailable_\n", c.Table)
-			continue
-		}
-		fmt.Fprintf(sb, "\n`%s`\n```sql\n%s\n```\n", c.Table, c.DDL)
 	}
 }
 

--- a/pkg/webhook/templates/sharded_apply_test.go
+++ b/pkg/webhook/templates/sharded_apply_test.go
@@ -1,11 +1,9 @@
 package templates
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"github.com/block/schemabot/pkg/state"
 )
@@ -15,7 +13,8 @@ const mutesDDL = "ALTER TABLE `mutes` ADD INDEX `created_at`(`created_at`);"
 func mutesCell(shard string) ShardCell { return ShardCell{Shard: shard, Table: "mutes", DDL: mutesDDL} }
 
 // A uniform sharded apply (every shard the same single change) renders one
-// status table and shows the DDL once — no per-shard grouping.
+// status table and no per-shard grouping. The DDL is not repeated in the applied
+// comment — it is shown in the plan and apply-gate comments.
 func TestRenderShardedApplyComment_UniformSingleTable(t *testing.T) {
 	out := RenderShardedApplyComment(ShardedApplyData{
 		State: state.Apply.Running, Environment: "staging", Database: "cdb_resolute",
@@ -30,7 +29,7 @@ func TestRenderShardedApplyComment_UniformSingleTable(t *testing.T) {
 	assert.Contains(t, out, "**Shards**: 1 running table copy, 1 queued")
 	assert.Contains(t, out, "| Shard | Status |")
 	assert.NotContains(t, out, "grouped by change", "a uniform apply is not grouped")
-	assert.Equal(t, 1, strings.Count(out, "```sql"), "the shared DDL is shown exactly once")
+	assert.NotContains(t, out, "```sql", "the applied comment shows status only, not DDL")
 }
 
 // A failed shard's error is lifted to the top and shown in its status row.
@@ -72,9 +71,9 @@ func TestRenderShardedApplyComment_FailedRetryableSurfacesErrorAndStop(t *testin
 	assert.Contains(t, out, "schemabot stop apply-x")
 }
 
-// When shards diverge, they are grouped by change signature: each group lists
-// its shards' statuses next to the exact DDL it runs. The same table computing
-// to different DDL across shards yields two groups.
+// When shards diverge, they are still grouped by change signature so the applied
+// comment shows which shards moved together — but the DDL itself is not repeated
+// here (it lives in the plan and apply-gate comments).
 func TestRenderShardedApplyComment_DivergentGroupsByVariant(t *testing.T) {
 	const driftDDL = "ALTER TABLE `mutes` ADD INDEX `created_at`(`created_at`), ADD COLUMN `reason` varchar(255);"
 	out := RenderShardedApplyComment(ShardedApplyData{
@@ -87,7 +86,7 @@ func TestRenderShardedApplyComment_DivergentGroupsByVariant(t *testing.T) {
 		},
 		Cells: []ShardCell{
 			mutesCell("-40"),
-			{Shard: "40-80", Table: "mutes", DDL: driftDDL},
+			{Shard: "40-80", Table: "mutes", DDL: driftDDL}, // different signature → its own group
 			mutesCell("80-c0"),
 		},
 	})
@@ -95,33 +94,12 @@ func TestRenderShardedApplyComment_DivergentGroupsByVariant(t *testing.T) {
 	assert.Contains(t, out, "Shards diverge — grouped by change:")
 	assert.Contains(t, out, "**shards `-40`, `80-c0`**", "shards sharing the standard change are one group")
 	assert.Contains(t, out, "**shard `40-80`**", "the drifted shard is its own group")
-	assert.Contains(t, out, driftDDL)
-	assert.Equal(t, 2, strings.Count(out, "```sql"), "one DDL block per group")
+	assert.NotContains(t, out, "```sql", "the applied comment shows status only, not DDL")
+	assert.NotContains(t, out, driftDDL, "the DDL is not repeated in the applied comment")
 }
 
-// A change whose DDL never reached the comment (incomplete change data) renders
-// a "DDL unavailable" note instead of an empty ```sql box that reads as a no-op.
-func TestRenderShardedApplyComment_EmptyDDLRendersUnavailable(t *testing.T) {
-	out := RenderShardedApplyComment(ShardedApplyData{
-		State: state.Apply.Running, Environment: "staging", Database: "cdb_resolute",
-		Keyspace: "cdb_resolute_sharded", ApplyID: "apply-x",
-		Shards: []ShardStatus{
-			{Shard: "-40", Emoji: "🔄", Label: "running table copy", State: state.ApplyOperation.Running},
-			{Shard: "80-", Emoji: "⏳", Label: "queued — next in order", State: state.ApplyOperation.Pending},
-		},
-		Cells: []ShardCell{
-			{Shard: "-40", Table: "mutes", DDL: "   "}, // whitespace-only DDL is treated as missing
-			{Shard: "80-", Table: "mutes", DDL: ""},
-		},
-	})
-
-	assert.Contains(t, out, "`mutes` — _DDL unavailable_", "the missing DDL is called out")
-	assert.Equal(t, 0, strings.Count(out, "```sql"), "no blank SQL box for the missing DDL")
-}
-
-// A single-shard divergent group degrades cleanly: one group, no spurious
-// grouping header for a uniform apply (covered above) — here every shard shares
-// the same multi-table change set, so it is still one group.
+// A uniform multi-table change set is one group (no spurious "grouped by change"
+// header), and the applied comment shows status only — no DDL.
 func TestRenderShardedApplyComment_UniformMultiTableIsOneGroup(t *testing.T) {
 	blocks := func(shard string) ShardCell {
 		return ShardCell{Shard: shard, Table: "blocks", DDL: "ALTER TABLE `blocks` ADD INDEX `created_at`(`created_at`);"}
@@ -138,5 +116,5 @@ func TestRenderShardedApplyComment_UniformMultiTableIsOneGroup(t *testing.T) {
 
 	assert.NotContains(t, out, "grouped by change", "identical multi-table change sets are one group")
 	assert.Contains(t, out, "| Shard | Status |")
-	require.Equal(t, 2, strings.Count(out, "```sql"), "both tables' DDL shown once")
+	assert.NotContains(t, out, "```sql", "the applied comment shows status only, not DDL")
 }

--- a/pkg/webhook/templates/sharded_plan_test.go
+++ b/pkg/webhook/templates/sharded_plan_test.go
@@ -57,7 +57,7 @@ func TestRenderPlanComment_ShardedPartiallyApplied(t *testing.T) {
 }
 
 // A uniform sharded plan (every shard the same change) shows the DDL once with
-// no divergence header.
+// no divergence header — but still names which shards are affected.
 func TestRenderPlanComment_ShardedUniform(t *testing.T) {
 	stmt := "ALTER TABLE `mutes` ADD INDEX `created_at`(`created_at`)"
 	out := RenderPlanComment(PlanCommentData{
@@ -73,6 +73,7 @@ func TestRenderPlanComment_ShardedUniform(t *testing.T) {
 	})
 
 	assert.NotContains(t, out, "diverge", "a uniform plan is not grouped")
+	assert.Contains(t, out, "**shards `-40`, `80-`**", "a uniform plan still names the affected shards")
 	assert.Equal(t, 1, strings.Count(out, "```sql"), "the shared DDL is shown once")
 }
 


### PR DESCRIPTION
Two sharded-comment fixes, both seen on a real cdb_resolute apply.

## 1. Plan / apply-gate comments didn't show which shards are affected

A **uniform** sharded plan rendered the DDL but never named the shards:

```
#### Keyspace: `cdb_resolute_sharded`
```sql
ALTER TABLE `mutes` ADD INDEX `created_at`(`created_at`);
```
```

`writeShardedPlanDDL` only listed shards in the *divergent* path. It now names the affected shards in the single-group (uniform) case too, so a sharded plan — and the apply-gate comment that reuses the plan rendering — **always** shows what shards will be affected:

```
#### Keyspace: `cdb_resolute_sharded`
**shards `-40`, `40-80`, `80-c0`, `c0-`**
```sql
ALTER TABLE `mutes` ADD INDEX `created_at`(`created_at`);
```
```

## 2. Applied comment showed `mutes — DDL unavailable`

The applied comment repeated the per-table DDL, and when the apply path had no per-shard DDL it rendered `` `mutes` — _DDL unavailable_ ``. The DDL (what changes) is already shown in the plan and apply-gate comments, so the applied comment now shows **shard status only**. Shards are still grouped by change signature, so a divergent apply still shows which shards moved together — just without repeating the DDL. Removes the now-unused `writeGroupDDL`.

## Tests

- `TestRenderPlanComment_ShardedUniform` now asserts the affected shards are named.
- The apply-comment tests assert status-only (no ```sql), divergent grouping retained; the empty-DDL "unavailable" test is removed with the behaviour.
- TEMPLATES.md regenerated.