### PR TITLE
fix(github): resolve symlinked namespace target via direct fetch

### DIFF
--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -1447,6 +1447,18 @@ func (ic *InstallationClient) symlinkedNamespaceLocators(ctx context.Context, re
 	symlinkName := path.Base(entry.GetPath())
 	target := strings.TrimSpace(entry.GetTarget())
 	if target == "" {
+		// The Contents API does not populate a symlink's target in a directory
+		// listing — only when the symlink path is fetched directly. Resolve it
+		// with a follow-up fetch before giving up.
+		content, _, err := ic.fetchRepositoryContents(ctx, repo, entry.GetPath(), ref)
+		if err != nil {
+			return nil, fmt.Errorf("resolve schema namespace symlink %s target: %w", entry.GetPath(), err)
+		}
+		if content != nil {
+			target = strings.TrimSpace(content.GetTarget())
+		}
+	}
+	if target == "" {
 		return nil, fmt.Errorf("schema namespace symlink %s has empty target", entry.GetPath())
 	}
 	if strings.HasPrefix(target, "/") {

--- a/pkg/github/client_test.go
+++ b/pkg/github/client_test.go
@@ -299,13 +299,26 @@ func TestFetchSchemaFilesOptimizedSmallDirectory(t *testing.T) {
 func TestFetchSchemaFilesOptimizedFollowsSymlinkedNamespaces(t *testing.T) {
 	client, mux := setupRateLimitedTestGitHubServer(t)
 
+	// The Contents API directory listing returns symlink entries WITHOUT a
+	// target; the target is only populated when the symlink path is fetched
+	// directly (mirrored by the per-symlink handlers below).
 	mux.HandleFunc("GET /repos/octocat/hello-world/contents/schema", func(w http.ResponseWriter, _ *http.Request) {
 		entries := []gh.RepositoryContent{
 			{Type: new("file"), Name: new("schemabot.yaml"), Path: new("schema/schemabot.yaml")},
-			{Type: new("symlink"), Name: new("shard_001"), Path: new("schema/shard_001"), Target: new("../canonical/shard")},
-			{Type: new("symlink"), Name: new("shard_002"), Path: new("schema/shard_002"), Target: new("../canonical/shard")},
+			{Type: new("symlink"), Name: new("shard_001"), Path: new("schema/shard_001")},
+			{Type: new("symlink"), Name: new("shard_002"), Path: new("schema/shard_002")},
 		}
 		require.NoError(t, json.NewEncoder(w).Encode(entries))
+	})
+	mux.HandleFunc("GET /repos/octocat/hello-world/contents/schema/shard_001", func(w http.ResponseWriter, _ *http.Request) {
+		require.NoError(t, json.NewEncoder(w).Encode(gh.RepositoryContent{
+			Type: new("symlink"), Name: new("shard_001"), Path: new("schema/shard_001"), Target: new("../canonical/shard"),
+		}))
+	})
+	mux.HandleFunc("GET /repos/octocat/hello-world/contents/schema/shard_002", func(w http.ResponseWriter, _ *http.Request) {
+		require.NoError(t, json.NewEncoder(w).Encode(gh.RepositoryContent{
+			Type: new("symlink"), Name: new("shard_002"), Path: new("schema/shard_002"), Target: new("../canonical/shard"),
+		}))
 	})
 	mux.HandleFunc("GET /repos/octocat/hello-world/contents/canonical/shard", func(w http.ResponseWriter, _ *http.Request) {
 		entries := []gh.RepositoryContent{


### PR DESCRIPTION
## Why

Following up on the symlinked-namespace discovery change: a valid symlinked namespace directory still failed to plan with `schema namespace symlink … has empty target`.

The GitHub Contents API **does not populate a symlink entry's `target` in a directory listing** — the target is only returned when the symlink path is fetched directly. Discovery read the (empty) listing target and rejected the symlink, so resolution got past "no schema files found" only to fail on an empty target.

## What

When a symlink entry from the directory listing has no `target`, fetch the symlink path directly to resolve it before giving up — the same individual fetch `resolveSchemaRootForEnvironment` already uses for environment-root symlinks. The existing repo-containment, absolute-path, and self/root-target guards still apply to the resolved target.

The symlinked-namespace test now mirrors real GitHub: the directory listing returns symlink entries with **no** target, and the target is populated only on a direct fetch of the symlink path — so it exercises this resolution path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)