### PR TITLE
chore(tern): lower "Progress: selected task" log to Debug

### DIFF
--- a/pkg/tern/local_client.go
+++ b/pkg/tern/local_client.go
@@ -2058,7 +2058,7 @@ func (c *LocalClient) Progress(ctx context.Context, req *ternv1.ProgressRequest)
 			Engine: c.protoEngine(),
 		}, nil
 	}
-	c.logger.Info("Progress: selected task", "task_id", activeTask.TaskIdentifier, "state", activeTask.State, "apply_id", activeTask.ApplyID)
+	c.logger.Debug("Progress: selected task", "task_id", activeTask.TaskIdentifier, "state", activeTask.State, "apply_id", activeTask.ApplyID)
 
 	// Get ALL tasks for this apply (completed + running + pending)
 	currentApplyTasks := filterTasksByApply(tasks, activeTask.ApplyID)


### PR DESCRIPTION
`Progress: selected task` was logged at Info on every Progress poll. The control plane polls Progress frequently, so this floods the logs with no operational value. Lowered to Debug — still available for troubleshooting, without the per-poll noise.

One-line log-level change in `LocalClient.Progress` (`pkg/tern/local_client.go`).