### PR TITLE
fix(ux): show a starting indicator instead of a stuck 0% during copy ramp-up

### DIFF
--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -3740,8 +3740,9 @@ Use 'schemabot start' to resume from checkpoint.
 
   ── myapp_sharded ──
 
-     ~ customers: Staging schema changes...
+     ~ customers: ⏳ Starting copy...
        ALTER TABLE `customers` ADD INDEX `idx_created_at`(`created_at`);
+       • Rows: 0 / 124,760,460
        • Shards: 2 (2 copying)
            ◉ -80: 0% (0/60,483,380 rows)
            ◉ 80-: 0% (0/64,277,080 rows)

--- a/pkg/cmd/commands/watch_tui_view.go
+++ b/pkg/cmd/commands/watch_tui_view.go
@@ -126,6 +126,16 @@ func (m WatchModel) progressView() string {
 		b.WriteString(m.spinner.View() + "Starting...\n")
 	}
 
+	// Keep the PlanetScale deploy request link visible throughout the apply,
+	// not only during deploy-request setup, so operators can open the console
+	// to inspect a copy in flight. Setup phases already show it inline above;
+	// terminal states surface it via the exit context.
+	if !state.IsSetupPhase(m.state) && !state.IsTerminalApplyState(m.state) && m.metadata != nil {
+		if url := m.metadata["deploy_request_url"]; url != "" {
+			fmt.Fprintf(&b, "  Deploy Request:  %s\n", url)
+		}
+	}
+
 	// Show table progress once past branch setup phases.
 	if !state.IsSetupPhase(m.state) {
 		m.renderTables(&b, tables)

--- a/pkg/cmd/commands/watch_tui_vitess_test.go
+++ b/pkg/cmd/commands/watch_tui_vitess_test.go
@@ -171,3 +171,21 @@ func TestTUIBranchApplyProgress(t *testing.T) {
 		})
 	}
 }
+
+// The deploy request link stays visible while the apply is running, not only
+// during deploy-request setup, so an operator watching a long copy can open the
+// PlanetScale console to inspect it.
+func TestTUIShowsDeployRequestURLWhileRunning(t *testing.T) {
+	const url = "https://app.planetscale.com/block-staging/boardgames/deploy-requests/106"
+	m := WatchModel{
+		state:       state.Apply.Running,
+		metadata:    map[string]string{"deploy_request_url": url},
+		tables:      []tableProgress{{Name: "customers", Keyspace: "boardgames_sharded", Status: "running"}},
+		initialized: true,
+		spinner:     spinner.New(),
+		engine:      "PlanetScale",
+	}
+
+	view := m.progressView()
+	assert.Contains(t, view, "Deploy Request:  "+url)
+}

--- a/pkg/cmd/internal/templates/preview_progress.go
+++ b/pkg/cmd/internal/templates/preview_progress.go
@@ -347,7 +347,7 @@ func previewVitessStagingOutput() {
 				TableName: "customers", Namespace: "myapp_sharded",
 				DDL:    "ALTER TABLE `customers` ADD INDEX `idx_created_at`(`created_at`)",
 				Status: state.Apply.Running,
-				// RowsTotal > 0 but RowsCopied == 0 triggers "Staging schema changes..."
+				// RowsTotal > 0 but RowsCopied == 0 triggers "⏳ Starting copy..."
 				RowsCopied: 0,
 				RowsTotal:  124760460,
 				Shards: []ShardProgress{

--- a/pkg/cmd/internal/templates/progress.go
+++ b/pkg/cmd/internal/templates/progress.go
@@ -620,13 +620,16 @@ func FormatTableProgressWithActivity(t TableProgress, activityBar, activityLabel
 			}
 			fmt.Fprintf(&b, "    %s\n", t.ProgressDetail)
 		}
-	case t.RowsTotal > 0 && t.RowsCopied == 0 && len(t.Shards) > 0:
-		// Staging phase — shards have row totals but no rows copied yet.
-		// Show "Staging schema changes..." instead of a misleading 0% bar.
-		fmt.Fprintf(&b, indentTable+progressSymbol(t.ChangeType)+"%s: Staging schema changes...\n", t.TableName)
+	case t.RowsTotal > 0 && t.RowsCopied == 0:
+		// Row total is known but the copy hasn't reported progress yet
+		// (Vitess VReplication / Spirit ramp-up — can take a while on a large
+		// table). Show a starting indicator and the row total instead of a 0%
+		// bar that reads as stuck.
+		fmt.Fprintf(&b, indentTable+progressSymbol(t.ChangeType)+"%s: ⏳ Starting copy...\n", t.TableName)
 		if t.DDL != "" {
 			b.WriteString(formatProgressDDL(t.DDL))
 		}
+		writeStructuredRowsAndETA(&b, t)
 	case t.RowsTotal > 0:
 		if ui.EstimateExceeded(t.RowsCopied, t.RowsTotal) {
 			b.WriteString(formatEstimateExceededTable(t, t.RowsCopied, activityBar, activityLabel))

--- a/pkg/cmd/internal/templates/progress_states_test.go
+++ b/pkg/cmd/internal/templates/progress_states_test.go
@@ -193,6 +193,38 @@ func TestFormatTableProgress_ChangeTypeSymbol(t *testing.T) {
 	}
 }
 
+// A running table whose row total is known but with nothing copied yet (the
+// VReplication / Spirit ramp-up window) shows a starting indicator and the row
+// total, not a 0% bar that reads as stuck. Holds whether or not per-shard data
+// has arrived.
+func TestFormatTableProgress_StartingCopy(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		shards []ShardProgress
+	}{
+		{name: "no shard data yet"},
+		{name: "sharded", shards: []ShardProgress{
+			{Shard: "-80", Status: state.Task.Running, RowsTotal: 70_000_000},
+			{Shard: "80-", Status: state.Task.Running, RowsTotal: 74_484_274},
+		}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			output := FormatTableProgress(TableProgress{
+				TableName: "customers", ChangeType: "alter", Status: state.Apply.Running,
+				DDL:        "ALTER TABLE `customers` ADD INDEX `idx_updated_at`(`updated_at`)",
+				RowsCopied: 0, RowsTotal: 144_484_274, PercentComplete: 0,
+				Shards: tt.shards,
+			})
+			// The table line shows the starting indicator and total, never a
+			// bare 0% bar. (Per-shard detail lines may still show 0% — that is
+			// the separate per-shard rendering path.)
+			assert.Contains(t, output, "customers: ⏳ Starting copy...")
+			assert.Contains(t, output, "Rows: 0 / 144,484,274")
+			assert.NotContains(t, output, "customers: "+ui.ProgressBarRowCopy(0))
+		})
+	}
+}
+
 // A checksumming table renders its verify progress rather than a row-copy
 // percent — its copy is done and the engine is now verifying the data, which
 // can run for hours on a large table.

--- a/pkg/webhook/templates/apply.go
+++ b/pkg/webhook/templates/apply.go
@@ -688,6 +688,15 @@ func renderRunningTable(sb *strings.Builder, table TableProgressData) {
 		}
 
 		pct := ui.RowCopyDisplayPercent(table.PercentComplete, table.RowsCopied)
+		if pct == 0 {
+			// Row total is known but the copy hasn't reported progress yet
+			// (VReplication / Spirit ramp-up). A 0% bar reads as stuck, so show
+			// a starting indicator and the row total instead.
+			fmt.Fprintf(sb, "**`%s`**: ⏳ Starting copy...\n", table.TableName)
+			writeDDLLine(sb, table.DDL)
+			writeRowsAndETA(sb, table)
+			return
+		}
 		bar := ui.ProgressBarRowCopy(pct)
 		fmt.Fprintf(sb, "**`%s`**: %s %d%%\n", table.TableName, bar, pct)
 		writeDDLLine(sb, table.DDL)

--- a/pkg/webhook/templates/apply_test.go
+++ b/pkg/webhook/templates/apply_test.go
@@ -536,6 +536,28 @@ func TestRenderApplyStatusComment_RowCopyDisplaysOnePercentAfterCopyStarts(t *te
 	assert.NotContains(t, result, " 0%")
 }
 
+func TestRenderApplyStatusComment_StartingCopyBeforeRowsReported(t *testing.T) {
+	data := ApplyStatusCommentData{
+		Database:    "testapp",
+		Environment: "staging",
+		RequestedBy: "aparajon",
+		State:       state.Apply.Running,
+		Engine:      "PlanetScale",
+		Tables: []TableProgressData{
+			{TableName: "customers", DDL: "ALTER TABLE `customers` ADD INDEX `idx_updated_at`(`updated_at`)", Status: state.Task.Running, RowsCopied: 0, RowsTotal: 144_484_274, PercentComplete: 0},
+		},
+	}
+
+	result := RenderApplyStatusComment(data)
+
+	// Row total is known but nothing has copied yet (VReplication ramp-up).
+	// Show a starting indicator and the row total, never a bare 0% bar that
+	// reads as stuck.
+	assert.Contains(t, result, "**`customers`**: ⏳ Starting copy...")
+	assert.Contains(t, result, "Rows: 0 / 144,484,274")
+	assert.NotContains(t, result, " 0%")
+}
+
 func TestRenderApplyStatusComment_EstimateExceeded(t *testing.T) {
 	data := ApplyStatusCommentData{
 		Database:    "testapp",


### PR DESCRIPTION
## Why this matters

A row copy on a large table reports its row *total* before any rows are actually copied — the VReplication / Spirit ramp-up window. During that window the progress views rendered a bare `0%` bar, which reads as *stuck* on a multi-minute copy and prompts operators to wonder whether the apply is wedged. It isn't — it's working.

## What it does

- **PR comment**: when the row total is known but `RowsCopied == 0`, render `⏳ Starting copy...` plus the row total (`Rows: 0 / N`) instead of an empty `0%` bar.
- **CLI progress views**: the existing "don't show a misleading 0%" treatment only applied when per-shard data was present, so a table without per-shard rows still fell through to the `0%` bar. It now applies whenever a copy hasn't reported progress yet, with the same `⏳ Starting copy...` wording so the CLI and PR comment match.
- **Live watch view**: keep the deploy request link visible while the apply is running, not only during deploy-request setup, so an operator watching a long copy can open the console to inspect it.

Pure presentation — no change to apply behavior, state machine, or safety gates.

## How it moves toward northstar

Operators should be able to trust the progress surfaces during an apply. A view that looks frozen on a healthy long-running copy erodes that trust and invites unnecessary intervention; an honest "starting" state and a persistent deploy-request link keep the human oriented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)