### PR TITLE
fix(webhook): pass the schema check when apply finds no changes

### DIFF
--- a/pkg/webhook/apply_e2e_test.go
+++ b/pkg/webhook/apply_e2e_test.go
@@ -955,10 +955,12 @@ func TestE2EApplyConfirmNoChanges(t *testing.T) {
 		return err == nil && check != nil && check.Conclusion == checkConclusionSuccess && !check.HasChanges
 	}, 5*time.Second, 100*time.Millisecond, "no-changes apply must record a passing per-database check")
 
-	aggregate, err := svc.Storage().Checks().Get(t.Context(), "octocat/hello-world", 1, aggregateSentinel, aggregateSentinel, aggregateSentinel)
-	require.NoError(t, err)
-	require.NotNil(t, aggregate, "aggregate check must exist after a no-changes apply")
-	assert.Equal(t, checkConclusionSuccess, aggregate.Conclusion, "no-changes apply must pass the aggregate schema check")
+	// Poll the aggregate too: publishing it includes a GitHub check-run call that
+	// can lag the per-database upsert.
+	require.Eventually(t, func() bool {
+		aggregate, err := svc.Storage().Checks().Get(t.Context(), "octocat/hello-world", 1, aggregateSentinel, aggregateSentinel, aggregateSentinel)
+		return err == nil && aggregate != nil && aggregate.Conclusion == checkConclusionSuccess
+	}, 5*time.Second, 100*time.Millisecond, "no-changes apply must pass the aggregate schema check")
 }
 
 func TestE2EUnlockBlockedByActiveApply(t *testing.T) {

--- a/pkg/webhook/apply_e2e_test.go
+++ b/pkg/webhook/apply_e2e_test.go
@@ -947,6 +947,18 @@ func TestE2EApplyConfirmNoChanges(t *testing.T) {
 		lock, err := svc.Storage().Locks().Get(t.Context(), dbName, "mysql")
 		return err == nil && lock == nil
 	}, 5*time.Second, 100*time.Millisecond, "expected lock to be released after no-changes confirm")
+
+	// A no-changes apply must set the schema check to passing here — the operator
+	// should not have to re-run plan just to clear it.
+	require.Eventually(t, func() bool {
+		check, err := svc.Storage().Checks().Get(t.Context(), "octocat/hello-world", 1, "staging", "mysql", dbName)
+		return err == nil && check != nil && check.Conclusion == checkConclusionSuccess && !check.HasChanges
+	}, 5*time.Second, 100*time.Millisecond, "no-changes apply must record a passing per-database check")
+
+	aggregate, err := svc.Storage().Checks().Get(t.Context(), "octocat/hello-world", 1, aggregateSentinel, aggregateSentinel, aggregateSentinel)
+	require.NoError(t, err)
+	require.NotNil(t, aggregate, "aggregate check must exist after a no-changes apply")
+	assert.Equal(t, checkConclusionSuccess, aggregate.Conclusion, "no-changes apply must pass the aggregate schema check")
 }
 
 func TestE2EUnlockBlockedByActiveApply(t *testing.T) {

--- a/pkg/webhook/apply_execute.go
+++ b/pkg/webhook/apply_execute.go
@@ -60,6 +60,16 @@ func (h *Handler) executeApply(
 			h.logger.Error("failed to release lock after no-changes confirm",
 				"repo", repo, "pr", pr, "database", database, "database_type", dbType, "error", relErr)
 		}
+		// The target already matches the PR schema — apply found nothing to do.
+		// Record the passing (no-change) check result and refresh the aggregate so
+		// the schema check goes green here, instead of leaving it pending until the
+		// user re-runs plan just to clear it.
+		if headSHA, checkErr := h.storeApplyPlanCheckRecord(ctx, client, repo, pr, schemaResult, planResp, environment); checkErr != nil {
+			h.logger.Error("failed to record no-changes check after apply",
+				"repo", repo, "pr", pr, "database", database, "database_type", dbType, "environment", environment, "error", checkErr)
+		} else if headSHA != "" {
+			h.updateAggregateCheck(ctx, client, repo, pr, headSHA)
+		}
 		h.postComment(repo, pr, installationID, templates.RenderApplyConfirmNoChanges(database, environment))
 		return
 	}

--- a/pkg/webhook/apply_execute.go
+++ b/pkg/webhook/apply_execute.go
@@ -62,8 +62,8 @@ func (h *Handler) executeApply(
 		}
 		// The target already matches the PR schema — apply found nothing to do.
 		// Record the passing (no-change) check result and refresh the aggregate so
-		// the schema check goes green here, instead of leaving it pending until the
-		// user re-runs plan just to clear it.
+		// the schema check reflects that the target is up to date, the same as the
+		// no-change plan path.
 		if headSHA, checkErr := h.storeApplyPlanCheckRecord(ctx, client, repo, pr, schemaResult, planResp, environment); checkErr != nil {
 			h.logger.Error("failed to record no-changes check after apply",
 				"repo", repo, "pr", pr, "database", database, "database_type", dbType, "environment", environment, "error", checkErr)


### PR DESCRIPTION
## Problem

When `schemabot apply -e <env>` re-planned and found the target already matched the PR schema, `executeApply` released the lock and posted the "No Changes Detected" comment — but never recorded the check result. So the PR's schema check stayed pending, and the operator had to run `plan` again just to turn it green.

This is important because if an apply fails to complete, it is idempotent and should be able to be run again (because changes are declarative). If there are no changes, it should update the status check to passed.

## Fix

In the no-changes branch of `executeApply`, record the passing check and refresh the aggregate — exactly what `handlePlanCommand` already does after a no-change plan:

```go
if headSHA, checkErr := h.storeApplyPlanCheckRecord(ctx, client, repo, pr, schemaResult, planResp, environment); checkErr != nil {
    ... log ...
} else if headSHA != "" {
    h.updateAggregateCheck(ctx, client, repo, pr, headSHA)
}
```

`storeApplyPlanCheckRecord` → `upsertPlanCheckRecord` writes a `success` conclusion for an empty plan, so the check goes green immediately.

## Test

Extends `TestE2EApplyConfirmNoChanges` to assert that after a no-changes apply, both the per-database check and the aggregate check reach `success` (previously it only checked the comment + lock release). Compiles under `-tags=integration`; the MySQL-backed run is exercised in CI.