### PR TITLE
fix(observability): persist per-shard progress for single-operation applies

### DIFF
--- a/pkg/storage/mysqlstore/tasks.go
+++ b/pkg/storage/mysqlstore/tasks.go
@@ -172,30 +172,41 @@ func (s *taskStore) Update(ctx context.Context, task *storage.Task) error {
 // write-through for reflected per-shard progress (e.g. PlanetScale shards from
 // SHOW VITESS_MIGRATIONS).
 //
-// It requires the operation lease on the context: the single lease-holding
-// operator is the only writer of an operation's per-shard rows, so the
-// lookup-then-write is serialized by that lease without a database-level unique
-// constraint. The insert is gated on the lease so a displaced operator that lost
-// the lease fails closed (ErrApplyLeaseLost) instead of writing stale rows, and
-// the update path reuses the lease-guarded Update. On conflict only the progress
-// fields change; identity and DDL are preserved.
+// It requires the drive's ownership lease on the context. A multi-operation
+// fan-out drive holds the operation lease; a single-operation (whole-apply)
+// drive holds only the apply lease. Either is a sufficient single-writer
+// guarantee for this operation's per-shard rows, so accept both, preferring the
+// operation lease when present (it is the narrower claim). The lookup-then-write
+// is serialized by that lease without a database-level unique constraint, and
+// the insert is gated on the matching lease token so a displaced operator fails
+// closed (ErrApplyLeaseLost) instead of writing stale rows. The update path
+// reuses the lease-guarded Update, which applies the same lease precedence. On
+// conflict only the progress fields change; identity and DDL are preserved.
 func (s *taskStore) UpsertShardProgress(ctx context.Context, task *storage.Task) error {
-	opLease, ok := storage.OperationLeaseFromContext(ctx)
-	if !ok {
-		return fmt.Errorf("upsert shard progress for %s.%s shard %q requires an operation lease", task.Namespace, task.TableName, task.Shard)
-	}
-	if !opLease.Valid() {
-		return fmt.Errorf("invalid operation lease for shard progress %s.%s shard %q: %w", task.Namespace, task.TableName, task.Shard, storage.ErrApplyLeaseLost)
-	}
 	if task.ApplyOperationID == nil {
 		return fmt.Errorf("upsert shard progress for %s.%s shard %q requires apply_operation_id", task.Namespace, task.TableName, task.Shard)
 	}
-	// Fail closed if the row targets a different operation than the held lease:
-	// the insert is gated on the leased operation, so without this a caller could
-	// write a row pointing at another apply_operation under this lease.
-	if *task.ApplyOperationID != opLease.OperationID {
-		return fmt.Errorf("upsert shard progress targets operation %d but the held lease is for operation %d", *task.ApplyOperationID, opLease.OperationID)
+
+	opLease, hasOpLease := storage.OperationLeaseFromContext(ctx)
+	if hasOpLease {
+		if !opLease.Valid() {
+			return fmt.Errorf("invalid operation lease for shard progress %s.%s shard %q: %w", task.Namespace, task.TableName, task.Shard, storage.ErrApplyLeaseLost)
+		}
+		// Fail closed if the row targets a different operation than the held lease:
+		// the insert is gated on the leased operation, so without this a caller could
+		// write a row pointing at another apply_operation under this lease.
+		if *task.ApplyOperationID != opLease.OperationID {
+			return fmt.Errorf("upsert shard progress targets operation %d but the held lease is for operation %d", *task.ApplyOperationID, opLease.OperationID)
+		}
 	}
+	applyLease, hasApplyLease, err := applyLeaseFromContext(ctx, task.ApplyID)
+	if err != nil {
+		return err
+	}
+	if !hasOpLease && !hasApplyLease {
+		return fmt.Errorf("upsert shard progress for %s.%s shard %q requires an operation or apply lease", task.Namespace, task.TableName, task.Shard)
+	}
+
 	// A per-shard row must identify its table and shard. An empty table_name
 	// would store NULL and never match the lookup (re-inserting every pass), and
 	// an empty shard would collide with the unsharded single-shard sentinel.
@@ -207,10 +218,10 @@ func (s *taskStore) UpsertShardProgress(ctx context.Context, task *storage.Task)
 	}
 
 	// Find the existing per-shard row under this operation. The lookup-then-write
-	// is safe without a unique constraint because the operation lease makes the
-	// caller the single writer of this operation's rows.
+	// is safe without a unique constraint because the held lease makes the caller
+	// the single writer of this operation's rows.
 	var id int64
-	err := s.db.QueryRowContext(ctx, `
+	err = s.db.QueryRowContext(ctx, `
 		SELECT id FROM tasks
 		WHERE apply_operation_id = ? AND namespace = ? AND table_name = ? AND shard = ?
 	`, *task.ApplyOperationID, task.Namespace, nullString(task.TableName), task.Shard).Scan(&id)
@@ -220,12 +231,46 @@ func (s *taskStore) UpsertShardProgress(ctx context.Context, task *storage.Task)
 		task.ID = id
 		return s.Update(ctx, task)
 	case errors.Is(err, sql.ErrNoRows):
-		// New shard row: insert gated on the lease so a lost lease fails closed.
-		return s.insertShardTaskGuarded(ctx, task, opLease)
+		// New shard row: insert gated on the held lease so a lost lease fails closed.
+		if hasOpLease {
+			return s.insertShardTaskGuarded(ctx, task, opLease)
+		}
+		return s.insertShardTaskGuardedByApply(ctx, task, applyLease)
 	default:
 		return fmt.Errorf("look up shard task for operation %d %s.%s shard %q: %w",
 			*task.ApplyOperationID, task.Namespace, task.TableName, task.Shard, err)
 	}
+}
+
+// shardTaskInsertColumns is the column list shared by the lease-guarded shard
+// inserts. Keep its order in sync with shardTaskInsertValues.
+const shardTaskInsertColumns = `
+	task_identifier, apply_id, apply_operation_id, plan_id, database_name, database_type,
+	namespace, table_name, shard, ddl, ddl_action,
+	engine, repository, pull_request, environment, state, error_message, options, attempt,
+	rows_copied, rows_total, progress_percent, eta_seconds, checksum_rows_checked, checksum_rows_total, cutover_attempts,
+	is_instant, ready_to_complete, engine_migration_id,
+	started_at, completed_at, created_at, updated_at`
+
+// shardTaskInsertValues returns the placeholder list and value args for a
+// per-shard task INSERT ... SELECT, matching shardTaskInsertColumns. The caller
+// appends its own lease-guard ("FROM <lease table> WHERE ... lease_token = ?")
+// and the guard's args.
+func shardTaskInsertValues(task *storage.Task) (string, []any) {
+	options := task.Options
+	if len(options) == 0 {
+		options = []byte("{}")
+	}
+	return `?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?`,
+		[]any{
+			task.TaskIdentifier, task.ApplyID, nullInt64Ptr(task.ApplyOperationID), task.PlanID, task.Database, task.DatabaseType,
+			task.Namespace, nullString(task.TableName), task.Shard, nullString(task.DDL), nullString(task.DDLAction),
+			task.Engine, task.Repository, task.PullRequest, task.Environment,
+			task.State, nullString(task.ErrorMessage), string(options), task.Attempt,
+			task.RowsCopied, task.RowsTotal, task.ProgressPercent, task.ETASeconds, task.ChecksumRowsChecked, task.ChecksumRowsTotal, task.CutoverAttempts,
+			task.IsInstant, task.ReadyToComplete, nullString(task.EngineMigrationID),
+			task.StartedAt, task.CompletedAt, task.CreatedAt, task.UpdatedAt,
+		}
 }
 
 // insertShardTaskGuarded inserts a new per-shard task row only while the
@@ -233,32 +278,14 @@ func (s *taskStore) UpsertShardProgress(ctx context.Context, task *storage.Task)
 // operation's lease_token matches means a displaced operator inserts zero rows
 // and fails closed rather than writing a stale shard row.
 func (s *taskStore) insertShardTaskGuarded(ctx context.Context, task *storage.Task, opLease storage.OperationLease) error {
-	options := task.Options
-	if len(options) == 0 {
-		options = []byte("{}")
-	}
+	values, args := shardTaskInsertValues(task)
+	args = append(args, opLease.OperationID, opLease.Token)
 	result, err := s.db.ExecContext(ctx, `
-		INSERT INTO tasks (
-			task_identifier, apply_id, apply_operation_id, plan_id, database_name, database_type,
-			namespace, table_name, shard, ddl, ddl_action,
-			engine, repository, pull_request, environment, state, error_message, options, attempt,
-			rows_copied, rows_total, progress_percent, eta_seconds, checksum_rows_checked, checksum_rows_total, cutover_attempts,
-			is_instant, ready_to_complete, engine_migration_id,
-			started_at, completed_at, created_at, updated_at
-		)
-		SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+		INSERT INTO tasks (`+shardTaskInsertColumns+`)
+		SELECT `+values+`
 		FROM apply_operations ao
 		WHERE ao.id = ? AND ao.lease_token = ?
-	`,
-		task.TaskIdentifier, task.ApplyID, nullInt64Ptr(task.ApplyOperationID), task.PlanID, task.Database, task.DatabaseType,
-		task.Namespace, nullString(task.TableName), task.Shard, nullString(task.DDL), nullString(task.DDLAction),
-		task.Engine, task.Repository, task.PullRequest, task.Environment,
-		task.State, nullString(task.ErrorMessage), string(options), task.Attempt,
-		task.RowsCopied, task.RowsTotal, task.ProgressPercent, task.ETASeconds, task.ChecksumRowsChecked, task.ChecksumRowsTotal, task.CutoverAttempts,
-		task.IsInstant, task.ReadyToComplete, nullString(task.EngineMigrationID),
-		task.StartedAt, task.CompletedAt, task.CreatedAt, task.UpdatedAt,
-		opLease.OperationID, opLease.Token,
-	)
+	`, args...)
 	if err != nil {
 		return fmt.Errorf("insert shard task for operation %d %s.%s shard %q: %w",
 			opLease.OperationID, task.Namespace, task.TableName, task.Shard, err)
@@ -270,6 +297,38 @@ func (s *taskStore) insertShardTaskGuarded(ctx context.Context, task *storage.Ta
 	if rows == 0 {
 		// Zero rows inserted means the operation lease is no longer current.
 		return ensureOperationLeaseStillOwned(ctx, s.db, opLease)
+	}
+	if newID, err := result.LastInsertId(); err == nil {
+		task.ID = newID
+	}
+	return nil
+}
+
+// insertShardTaskGuardedByApply is the whole-apply (single-operation drive)
+// companion to insertShardTaskGuarded: that drive holds the apply lease rather
+// than an operation lease, and that lease is the single-writer guarantee. The
+// INSERT ... SELECT ... WHERE the apply's lease_token matches means a displaced
+// operator inserts zero rows and fails closed rather than writing a stale row.
+func (s *taskStore) insertShardTaskGuardedByApply(ctx context.Context, task *storage.Task, lease storage.ApplyLease) error {
+	values, args := shardTaskInsertValues(task)
+	args = append(args, lease.ApplyID, lease.Token)
+	result, err := s.db.ExecContext(ctx, `
+		INSERT INTO tasks (`+shardTaskInsertColumns+`)
+		SELECT `+values+`
+		FROM applies a
+		WHERE a.id = ? AND a.lease_token = ?
+	`, args...)
+	if err != nil {
+		return fmt.Errorf("insert shard task for apply %d %s.%s shard %q: %w",
+			lease.ApplyID, task.Namespace, task.TableName, task.Shard, err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("read shard task insert rows affected for apply %d: %w", lease.ApplyID, err)
+	}
+	if rows == 0 {
+		// Zero rows inserted means the apply lease is no longer current.
+		return ensureApplyLeaseStillOwned(ctx, s.db, lease)
 	}
 	if newID, err := result.LastInsertId(); err == nil {
 		task.ID = newID

--- a/pkg/storage/mysqlstore/tasks.go
+++ b/pkg/storage/mysqlstore/tasks.go
@@ -231,7 +231,16 @@ func (s *taskStore) UpsertShardProgress(ctx context.Context, task *storage.Task)
 		task.ID = id
 		return s.Update(ctx, task)
 	case errors.Is(err, sql.ErrNoRows):
-		// New shard row: insert gated on the held lease so a lost lease fails closed.
+		// New shard row: verify the operation belongs to the task's apply before
+		// inserting. tasks has no foreign-key constraints, so neither the
+		// operation-lease guard (which only matches the operation token) nor the
+		// apply-lease guard (which only matches the apply token) would otherwise
+		// catch an inconsistent (apply_id, apply_operation_id) pair, which would
+		// corrupt the per-operation read-model. Fail closed on mismatch.
+		if err := s.verifyOperationBelongsToApply(ctx, *task.ApplyOperationID, task.ApplyID); err != nil {
+			return err
+		}
+		// Insert gated on the held lease so a displaced operator fails closed.
 		if hasOpLease {
 			return s.insertShardTaskGuarded(ctx, task, opLease)
 		}
@@ -239,6 +248,26 @@ func (s *taskStore) UpsertShardProgress(ctx context.Context, task *storage.Task)
 	default:
 		return fmt.Errorf("look up shard task for operation %d %s.%s shard %q: %w",
 			*task.ApplyOperationID, task.Namespace, task.TableName, task.Shard, err)
+	}
+}
+
+// verifyOperationBelongsToApply fails closed when apply_operation operationID
+// does not belong to applyID. tasks has no foreign-key constraints, so a
+// per-shard insert with an inconsistent (apply_id, apply_operation_id) pair
+// would silently corrupt the per-operation read-model; this guard rejects it
+// before the insert with an explicit error rather than a silent no-op.
+func (s *taskStore) verifyOperationBelongsToApply(ctx context.Context, operationID, applyID int64) error {
+	var opApplyID int64
+	err := s.db.QueryRowContext(ctx, `SELECT apply_id FROM apply_operations WHERE id = ?`, operationID).Scan(&opApplyID)
+	switch {
+	case errors.Is(err, sql.ErrNoRows):
+		return fmt.Errorf("shard progress references apply_operation %d that does not exist", operationID)
+	case err != nil:
+		return fmt.Errorf("verify apply_operation %d belongs to apply %d: %w", operationID, applyID, err)
+	case opApplyID != applyID:
+		return fmt.Errorf("shard progress apply_operation %d belongs to apply %d, not apply %d", operationID, opApplyID, applyID)
+	default:
+		return nil
 	}
 }
 

--- a/pkg/storage/mysqlstore/tasks_test.go
+++ b/pkg/storage/mysqlstore/tasks_test.go
@@ -547,4 +547,17 @@ func TestTaskStore_UpsertShardProgressUnderApplyLease(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, got, 1)
 	assert.Equal(t, state.Task.Completed, got[0].State, "a lost apply lease must not overwrite the shard row")
+
+	// A shard task whose operation belongs to a different apply is rejected:
+	// tasks has no FK constraints, so the apply-lease guard alone would not catch
+	// an inconsistent (apply_id, apply_operation_id) pair.
+	otherLock := createTestLock(t, store, "other_resolute", "vitess", "staging")
+	otherApply := createTestApply(t, store, otherLock, "apply_other_applylease", apply.PlanID)
+	otherOpID, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: otherApply.ID, Deployment: "region-a", Target: "resolute",
+	})
+	require.NoError(t, err)
+	crossApply := shardTask("a0-")
+	crossApply.ApplyOperationID = &otherOpID // belongs to otherApply, not the leased apply
+	require.ErrorContains(t, store.Tasks().UpsertShardProgress(applyCtx("apply-token"), crossApply), "belongs to apply")
 }

--- a/pkg/storage/mysqlstore/tasks_test.go
+++ b/pkg/storage/mysqlstore/tasks_test.go
@@ -389,9 +389,9 @@ func TestTaskStore_UpsertShardProgress(t *testing.T) {
 		}
 	}
 
-	// Without an operation lease on the context the write is refused outright.
+	// Without any drive lease on the context the write is refused outright.
 	require.ErrorContains(t, store.Tasks().UpsertShardProgress(ctx, shardTask("-80")),
-		"requires an operation lease")
+		"requires an operation or apply lease")
 
 	// A displaced operator (stale token) fails closed on the insert path: nothing written.
 	require.ErrorIs(t, store.Tasks().UpsertShardProgress(opCtx("stale"), shardTask("-80")), storage.ErrApplyLeaseLost)
@@ -456,4 +456,95 @@ func TestTaskStore_UpsertShardProgress(t *testing.T) {
 	got, err = store.Tasks().GetShardProgressByApplyOperationID(ctx, opID)
 	require.NoError(t, err)
 	assert.Len(t, got, 2, "refused writes must not create rows")
+}
+
+// A single-operation (whole-apply) drive holds the apply lease rather than an
+// operation lease. UpsertShardProgress accepts the apply lease as the
+// single-writer guarantee, so per-shard rows are persisted for PlanetScale
+// applies that never claim an operation; a displaced operator (stale apply
+// token) still fails closed on both the insert and update paths.
+func TestTaskStore_UpsertShardProgressUnderApplyLease(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "resolute", "vitess", "staging")
+	apply := createTestApply(t, store, lock, "apply_upsert_shard_applylease", 1)
+	opID, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-a", Target: "resolute",
+	})
+	require.NoError(t, err)
+
+	// The whole-apply drive holds the apply lease; no operation lease is claimed.
+	_, err = testDB.ExecContext(ctx, `
+		UPDATE applies SET lease_owner = ?, lease_token = ?, lease_acquired_at = NOW() WHERE id = ?
+	`, "driver", "apply-token", apply.ID)
+	require.NoError(t, err)
+
+	applyCtx := func(token string) context.Context {
+		return storage.WithApplyLease(ctx, storage.ApplyLease{
+			ApplyID: apply.ID, Owner: "driver", Token: token,
+		})
+	}
+
+	now := time.Now()
+	shardTask := func(shard string) *storage.Task {
+		return &storage.Task{
+			TaskIdentifier:   "task-applylease-" + shard,
+			ApplyID:          apply.ID,
+			ApplyOperationID: &opID,
+			PlanID:           apply.PlanID,
+			Database:         apply.Database,
+			DatabaseType:     apply.DatabaseType,
+			Engine:           storage.EnginePlanetScale,
+			Environment:      apply.Environment,
+			State:            state.Task.Running,
+			Namespace:        "resolute",
+			TableName:        "users",
+			Shard:            shard,
+			DDL:              "ALTER TABLE `users` ADD INDEX `idx_email` (`email`)",
+			DDLAction:        "ALTER",
+			RowsCopied:       100000,
+			RowsTotal:        500000,
+			ProgressPercent:  20,
+			CreatedAt:        now,
+			UpdatedAt:        now,
+		}
+	}
+
+	// A displaced operator (stale apply token) fails closed on the insert path.
+	require.ErrorIs(t, store.Tasks().UpsertShardProgress(applyCtx("stale"), shardTask("-80")), storage.ErrApplyLeaseLost)
+	got, err := store.Tasks().GetShardProgressByApplyOperationID(ctx, opID)
+	require.NoError(t, err)
+	assert.Empty(t, got, "a lost apply lease must not insert a shard task")
+
+	// The apply-lease holder inserts the shard row.
+	require.NoError(t, store.Tasks().UpsertShardProgress(applyCtx("apply-token"), shardTask("-80")))
+	got, err = store.Tasks().GetShardProgressByApplyOperationID(ctx, opID)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, "-80", got[0].Shard)
+	assert.Equal(t, 20, got[0].ProgressPercent)
+
+	// Re-upserting advances the same row in place under the apply lease.
+	advanced := shardTask("-80")
+	advanced.State = state.Task.Completed
+	advanced.ProgressPercent = 100
+	advanced.RowsCopied = 500000
+	require.NoError(t, store.Tasks().UpsertShardProgress(applyCtx("apply-token"), advanced))
+	got, err = store.Tasks().GetShardProgressByApplyOperationID(ctx, opID)
+	require.NoError(t, err)
+	require.Len(t, got, 1, "re-upserting the same shard must update in place")
+	assert.Equal(t, state.Task.Completed, got[0].State)
+	assert.Equal(t, 100, got[0].ProgressPercent)
+
+	// A stale apply token must not overwrite the existing shard row (update path fails closed).
+	stale := shardTask("-80")
+	stale.State = state.Task.Failed
+	stale.ProgressPercent = 5
+	require.ErrorIs(t, store.Tasks().UpsertShardProgress(applyCtx("stale"), stale), storage.ErrApplyLeaseLost)
+	got, err = store.Tasks().GetShardProgressByApplyOperationID(ctx, opID)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, state.Task.Completed, got[0].State, "a lost apply lease must not overwrite the shard row")
 }

--- a/pkg/tern/local_apply_grouped.go
+++ b/pkg/tern/local_apply_grouped.go
@@ -1128,15 +1128,19 @@ func (c *LocalClient) syncAtomicTaskProgress(ctx context.Context, tasks []*stora
 
 // writeShardProgress persists a table's per-shard breakdown as per-shard tasks
 // (shard != ""), so the renderer can show per-shard state from storage instead
-// of a live re-query. It runs only inside the operator's lease-held drive:
-// UpsertShardProgress requires the operation lease, and read-path callers (which
-// carry no operation lease) skip it so a plain progress read never writes. A
-// failed shard write is logged, not fatal — the next reconcile re-applies it.
+// of a live re-query. It runs only inside the operator's lease-held drive: a
+// multi-operation fan-out drive holds the operation lease, a single-operation
+// (whole-apply) drive holds the apply lease, and UpsertShardProgress accepts
+// either. Read-path callers carry neither lease and skip, so a plain progress
+// read never writes. A failed shard write is logged, not fatal — the next
+// reconcile re-applies it.
 func (c *LocalClient) writeShardProgress(ctx context.Context, table *storage.Task, tp *engine.TableProgress, now time.Time) {
 	if len(tp.Shards) == 0 {
 		return
 	}
-	if _, ok := storage.OperationLeaseFromContext(ctx); !ok {
+	_, hasOpLease := storage.OperationLeaseFromContext(ctx)
+	_, hasApplyLease := storage.ApplyLeaseFromContext(ctx)
+	if !hasOpLease && !hasApplyLease {
 		return
 	}
 	var operationID int64

--- a/pkg/tern/shard_writethrough_integration_test.go
+++ b/pkg/tern/shard_writethrough_integration_test.go
@@ -149,10 +149,29 @@ func TestWriteShardProgressPersistsPerShardTasksUnderLease(t *testing.T) {
 		}
 	}
 
-	// A read-path caller (no operation lease) must not write.
+	// A single-operation (whole-apply) drive holds the apply lease instead of an
+	// operation lease; the write-through accepts it and persists per-shard rows
+	// so the PlanetScale per-shard breakdown reaches storage even when no
+	// operation is claimed. Clear the operation-lease rows first (keeping the
+	// parent apply), then stamp the apply lease and drive under it alone.
+	_, err = leaseDB.ExecContext(ctx, `DELETE FROM tasks`)
+	require.NoError(t, err)
+	_, err = leaseDB.ExecContext(ctx, `
+		UPDATE applies SET lease_owner = ?, lease_token = ?, lease_acquired_at = NOW() WHERE id = ?
+	`, "driver", "apply-token", applyID)
+	require.NoError(t, err)
+	applyLeaseCtx := storage.WithApplyLease(ctx, storage.ApplyLease{
+		ApplyID: applyID, Owner: "driver", Token: "apply-token",
+	})
+	client.writeShardProgress(applyLeaseCtx, perTable, tp, time.Now())
+	got, err = stor.Tasks().GetShardProgressByApplyOperationID(ctx, opID)
+	require.NoError(t, err)
+	assert.Len(t, got, 2, "the apply lease alone persists per-shard tasks for a single-operation drive")
+
+	// A read-path caller (no drive lease) must not write.
 	cleanupTasks(t, dsn)
 	client.writeShardProgress(ctx, perTable, tp, time.Now())
 	got, err = stor.Tasks().GetShardProgressByApplyOperationID(ctx, opID)
 	require.NoError(t, err)
-	assert.Empty(t, got, "without an operation lease the drive write-through is a no-op")
+	assert.Empty(t, got, "without a drive lease the write-through is a no-op")
 }


### PR DESCRIPTION
## Why this matters

Per-shard progress is a reflected read-model: the operator drive writes each table's per-shard breakdown as per-shard task rows, which the CLI and PR comment then render. That write-through required the **operation** lease — but a single-operation (whole-apply) drive holds only the **apply** lease. So a sharded apply with a single DDL never persisted per-shard rows, and the per-shard breakdown was always empty in both the CLI and the PR comment, even though the per-table aggregate row counts (written ungated) flowed through normally.

Operators watching a sharded copy could see overall progress but not which shards were lagging or stuck — exactly the signal they need during a long copy or an incident.

## What it does

Accept the apply lease as an equivalent single-writer guarantee. For a single-operation drive the apply lease already makes the driver the sole writer of the operation's rows, so it serializes the per-shard write-through just as the operation lease does for the multi-operation fan-out.

```
multi-operation fan-out  → operation lease → per-shard write-through ✓ (unchanged)
single-operation drive   → apply lease     → per-shard write-through ✓ (now)
read path                → no lease         → no-op (unchanged)
```

- `UpsertShardProgress` now accepts either the operation lease or the apply lease, preferring the operation lease when present (the narrower claim).
- The new-row insert is gated on the matching lease token (operation or apply) so a displaced operator still inserts zero rows and fails closed; the update path reuses the lease-guarded `Update`, which already applies the same lease precedence.
- The drive's write-through gate accepts either lease; read-path callers carry neither and remain a no-op.
- Extracted the shared per-shard INSERT column list so the two lease-guarded inserts can't drift.

## How it moves toward northstar

Per-shard visibility is the difference between "the change is progressing" and "shard `-80` is stuck while the rest finished." Making the per-shard read-model populate for the common single-operation case lets operators trust the progress surfaces for sharded applies, not just the multi-operation fan-out path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)