### PR TITLE
feat(ux): show deployment-scoped operation status

### DIFF
--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -6688,12 +6688,16 @@ Apply ID: apply-multi-a1b2c3d4
 Environment: production
 
 🟢 us-east — ready for cutover — next in order (orders-us-east)
+  External operation ID: remote-op-us-east-001
+  External apply ID: remote-apply-us-east-001
 
      ~ orders: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦 Waiting for cutover
        ALTER TABLE `orders` ADD COLUMN `source` varchar(32);
 
 
 🔄 eu-west — running table copy (orders-eu-west)
+  External operation ID: remote-op-eu-west-001
+  External apply ID: remote-apply-eu-west-001
 
      ~ orders: 🟦🟦🟦🟦🟦🟦🟦⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ 35%
        ALTER TABLE `orders` ADD COLUMN `source` varchar(32);

--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -4650,6 +4650,30 @@ No recent schema changes
 </details>
 
 <details>
+<summary><a name="status-for-deployment"></a><strong>Status For Deployment</strong></summary>
+
+```
+
+1 active schema change
+
+  APPLY ID              EXTERNAL OP ID         DATABASE   ENV         DEPLOYMENT  STATE                STARTED        DURATION  CALLER
+  apply-multi-a1b2c3d4  remote-op-us-east-001  orders-db  production  us-east     Waiting for cutover  8 minutes ago  8m        octocat
+
+Use 'schemabot status <apply_id>' to view details
+
+Multiple matching operations:
+
+1 active schema change
+
+  APPLY ID                EXTERNAL OP ID  DATABASE      ENV         DEPLOYMENT  STATE    STARTED        DURATION  CALLER
+  apply-sharded-d5e6f7g8  -               inventory-db  production  us-east     Running  4 minutes ago  4m        octocat
+
+Use 'schemabot status <apply_id>' to view details
+
+```
+</details>
+
+<details>
 <summary><a name="status-history"></a><strong>Status History</strong></summary>
 
 ```

--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -4635,10 +4635,10 @@ Volume: ██░░░░░░░░░ 2/11
 
 3 active schema changes
 
-  APPLY ID      DATABASE   ENV         STATE                STARTED         DURATION  CALLER
-  apply_abc123  orders-db  staging     Running              15 minutes ago  15m       
-  apply_def456  users-db   production  Waiting for cutover  45 minutes ago  45m       
-  apply_ghi789  analytics  staging     Stopped              2 hours ago     2h        
+  APPLY ID      DATABASE   ENV         STATE                STARTED         CALLER
+  apply_abc123  orders-db  staging     Running              15 minutes ago  
+  apply_def456  users-db   production  Waiting for cutover  45 minutes ago  
+  apply_ghi789  analytics  staging     Stopped              2 hours ago     
 
 Use 'schemabot status <apply_id>' to view details
 
@@ -4656,8 +4656,8 @@ No recent schema changes
 
 1 active schema change
 
-  APPLY ID              EXTERNAL OP ID         DATABASE   ENV         DEPLOYMENT  STATE                STARTED        DURATION  CALLER
-  apply-multi-a1b2c3d4  remote-op-us-east-001  orders-db  production  us-east     Waiting for cutover  8 minutes ago  8m        octocat
+  APPLY ID              EXTERNAL OP ID         DATABASE   ENV         DEPLOYMENT  STATE                STARTED        CALLER
+  apply-multi-a1b2c3d4  remote-op-us-east-001  orders-db  production  us-east     Waiting for cutover  8 minutes ago  octocat
 
 Use 'schemabot status <apply_id>' to view details
 
@@ -4665,8 +4665,8 @@ Multiple matching operations:
 
 1 active schema change
 
-  APPLY ID                EXTERNAL OP ID  DATABASE      ENV         DEPLOYMENT  STATE    STARTED        DURATION  CALLER
-  apply-sharded-d5e6f7g8  -               inventory-db  production  us-east     Running  4 minutes ago  4m        octocat
+  APPLY ID                EXTERNAL OP ID  DATABASE      ENV         DEPLOYMENT  STATE    STARTED        CALLER
+  apply-sharded-d5e6f7g8  -               inventory-db  production  us-east     Running  4 minutes ago  octocat
 
 Use 'schemabot status <apply_id>' to view details
 

--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -132,6 +132,23 @@ func (s *staticApplyOperationStore) ListByApply(_ context.Context, applyID int64
 	return operations, nil
 }
 
+func (s *staticApplyOperationStore) ListByApplies(_ context.Context, applyIDs []int64) ([]*storage.ApplyOperation, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	applyIDSet := make(map[int64]bool, len(applyIDs))
+	for _, applyID := range applyIDs {
+		applyIDSet[applyID] = true
+	}
+	operations := make([]*storage.ApplyOperation, 0, len(s.operations))
+	for _, op := range s.operations {
+		if applyIDSet[op.ApplyID] {
+			operations = append(operations, op)
+		}
+	}
+	return operations, nil
+}
+
 func (s *staticApplyOperationStore) GetEngineResumeState(_ context.Context, operationID int64) (*storage.EngineResumeState, error) {
 	if s.resumeStateErr != nil {
 		return nil, s.resumeStateErr
@@ -236,6 +253,9 @@ func (s *recentApplyStore) GetRecent(_ context.Context, filter storage.RecentApp
 	applies := make([]*storage.Apply, 0, len(s.applies))
 	for _, apply := range s.applies {
 		if filter.Environment != "" && apply.Environment != filter.Environment {
+			continue
+		}
+		if filter.Deployment != "" && apply.Deployment != filter.Deployment {
 			continue
 		}
 		if len(filter.States) > 0 && !state.IsState(apply.State, filter.States...) {
@@ -2691,7 +2711,7 @@ func TestProgressFromLocalStorageIncludesOperationProgressAndTableDeployment(t *
 			},
 		}},
 		operations: &staticApplyOperationStore{operations: []*storage.ApplyOperation{
-			{ID: opAID, ApplyID: apply.ID, Deployment: "deploy-a", OperationKind: storage.ApplyOperationKindWork, Target: "target-a", State: state.ApplyOperation.Running, StartedAt: &startedAt},
+			{ID: opAID, ApplyID: apply.ID, Deployment: "deploy-a", ExternalID: "remote-apply-a", ExternalOperationID: "remote-operation-a", OperationKind: storage.ApplyOperationKindWork, Target: "target-a", State: state.ApplyOperation.Running, StartedAt: &startedAt},
 			{ID: opBID, ApplyID: apply.ID, Deployment: "deploy-b", OperationKind: storage.ApplyOperationKindGroupFinalizer, Target: "target-b", State: state.ApplyOperation.Failed, ErrorMessage: "engine failed", StartedAt: &startedAt, CompletedAt: &completedAt},
 		}},
 	}, testServerConfig(), nil, slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError})))
@@ -2701,6 +2721,8 @@ func TestProgressFromLocalStorageIncludesOperationProgressAndTableDeployment(t *
 	require.NoError(t, err)
 	require.Len(t, resp.Operations, 2)
 	assert.Equal(t, "deploy-a", resp.Operations[0].Deployment)
+	assert.Equal(t, "remote-apply-a", resp.Operations[0].ExternalID)
+	assert.Equal(t, "remote-operation-a", resp.Operations[0].ExternalOperationID)
 	assert.Equal(t, storage.ApplyOperationKindWork, resp.Operations[0].OperationKind)
 	assert.Equal(t, "target-a", resp.Operations[0].Target)
 	assert.Equal(t, state.ApplyOperation.Running, resp.Operations[0].State)
@@ -3208,6 +3230,136 @@ func TestHandleStatusLimitAndEnvironment(t *testing.T) {
 	assert.Equal(t, "apply-one", resp.Applies[0].ApplyID)
 	assert.Equal(t, "external-one", resp.Applies[0].ExternalID)
 	assert.Equal(t, "apply-two", resp.Applies[1].ApplyID)
+}
+
+func TestHandleStatusDeploymentFilterProjectsMatchingOperation(t *testing.T) {
+	now := time.Now().UTC()
+	startedAt := now.Add(-time.Minute)
+	applies := &recentApplyStore{
+		applies: []*storage.Apply{
+			{
+				ID:              101,
+				ApplyIdentifier: "apply-deployment",
+				ExternalID:      "parent-external",
+				Database:        "orders",
+				Environment:     "staging",
+				Deployment:      "deploy-a",
+				Engine:          storage.EngineSpirit,
+				State:           state.Apply.Running,
+				Caller:          "cli",
+				CreatedAt:       now,
+				UpdatedAt:       now,
+			},
+		},
+	}
+	operations := &staticApplyOperationStore{
+		operations: []*storage.ApplyOperation{
+			{
+				ID:                  202,
+				ApplyID:             101,
+				Deployment:          "deploy-a",
+				ExternalID:          "remote-apply-202",
+				ExternalOperationID: "remote-operation-202",
+				State:               state.Apply.Completed,
+				StartedAt:           &startedAt,
+				CreatedAt:           now,
+				UpdatedAt:           now,
+			},
+		},
+	}
+	stor := &mockStorageWithApplyStores{applies: applies, operations: operations}
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	svc := New(stor, testServerConfig(), nil, logger)
+	mux := http.NewServeMux()
+	svc.ConfigureRoutes(mux)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/status?environment=staging&deployment=deploy-a", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp apitypes.StatusResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	require.Len(t, applies.filters, 1)
+	assert.Equal(t, "staging", applies.filters[0].Environment)
+	assert.Equal(t, "deploy-a", applies.filters[0].Deployment)
+	assert.Equal(t, 0, resp.ActiveCount)
+	require.Len(t, resp.Applies, 1)
+	assert.Equal(t, "apply-deployment", resp.Applies[0].ApplyID)
+	assert.Equal(t, "remote-apply-202", resp.Applies[0].ExternalID)
+	assert.Equal(t, "remote-operation-202", resp.Applies[0].ExternalOperationID)
+	assert.Equal(t, "deploy-a", resp.Applies[0].Deployment)
+	assert.Equal(t, state.Apply.Completed, resp.Applies[0].State)
+}
+
+func TestHandleStatusDeploymentFilterSummarizesMatchingOperations(t *testing.T) {
+	now := time.Now().UTC()
+	startedAt := now.Add(-2 * time.Minute)
+	completedAt := now.Add(-time.Minute)
+	applies := &recentApplyStore{
+		applies: []*storage.Apply{
+			{
+				ID:              101,
+				ApplyIdentifier: "apply-deployment",
+				ExternalID:      "parent-external",
+				Database:        "orders",
+				Environment:     "staging",
+				Deployment:      "deploy-a",
+				Engine:          storage.EngineSpirit,
+				State:           state.Apply.Completed,
+				Caller:          "cli",
+				CreatedAt:       now,
+				UpdatedAt:       now,
+			},
+		},
+	}
+	operations := &staticApplyOperationStore{
+		operations: []*storage.ApplyOperation{
+			{
+				ID:                  202,
+				ApplyID:             101,
+				Deployment:          "deploy-a",
+				ExternalOperationID: "remote-operation-202",
+				State:               state.Apply.Completed,
+				StartedAt:           &startedAt,
+				CompletedAt:         &completedAt,
+				CreatedAt:           now.Add(-2 * time.Minute),
+				UpdatedAt:           completedAt,
+			},
+			{
+				ID:                  203,
+				ApplyID:             101,
+				Deployment:          "deploy-a",
+				ExternalOperationID: "remote-operation-203",
+				State:               state.Apply.Running,
+				StartedAt:           &startedAt,
+				CreatedAt:           now.Add(-90 * time.Second),
+				UpdatedAt:           now,
+			},
+		},
+	}
+	stor := &mockStorageWithApplyStores{applies: applies, operations: operations}
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	svc := New(stor, testServerConfig(), nil, logger)
+	mux := http.NewServeMux()
+	svc.ConfigureRoutes(mux)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/status?environment=staging&deployment=deploy-a", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp apitypes.StatusResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	assert.Equal(t, 1, resp.ActiveCount)
+	require.Len(t, resp.Applies, 1)
+	assert.Equal(t, "apply-deployment", resp.Applies[0].ApplyID)
+	assert.Empty(t, resp.Applies[0].ExternalID)
+	assert.Empty(t, resp.Applies[0].ExternalOperationID)
+	assert.Equal(t, "deploy-a", resp.Applies[0].Deployment)
+	assert.Equal(t, state.Apply.Running, resp.Applies[0].State)
 }
 
 func TestHandleStatusFailedFilter(t *testing.T) {

--- a/pkg/api/progress_handlers.go
+++ b/pkg/api/progress_handlers.go
@@ -217,14 +217,16 @@ func progressResponseFromProto(resp *ternv1.ProgressResponse) *apitypes.Progress
 
 func progressOperationResponseFromStorage(op *storage.ApplyOperation) *apitypes.ProgressOperationResponse {
 	resp := &apitypes.ProgressOperationResponse{
-		Deployment:    op.Deployment,
-		OperationKind: op.OperationKind,
-		Target:        op.Target,
-		State:         op.State,
-		CutoverPolicy: op.CutoverPolicy,
-		OnFailure:     op.OnFailure,
-		ErrorCode:     deriveErrorCode(op.State, op.ErrorMessage),
-		ErrorMessage:  op.ErrorMessage,
+		Deployment:          op.Deployment,
+		ExternalID:          op.ExternalID,
+		ExternalOperationID: op.ExternalOperationID,
+		OperationKind:       op.OperationKind,
+		Target:              op.Target,
+		State:               op.State,
+		CutoverPolicy:       op.CutoverPolicy,
+		OnFailure:           op.OnFailure,
+		ErrorCode:           deriveErrorCode(op.State, op.ErrorMessage),
+		ErrorMessage:        op.ErrorMessage,
 	}
 	if op.StartedAt != nil {
 		resp.StartedAt = op.StartedAt.Format(time.RFC3339)
@@ -741,6 +743,7 @@ func (s *Service) handleStatus(w http.ResponseWriter, r *http.Request) {
 	filter := storage.RecentAppliesFilter{
 		Limit:       limit + 1,
 		Environment: r.URL.Query().Get("environment"),
+		Deployment:  r.URL.Query().Get("deployment"),
 	}
 	if failuresOnly {
 		filter.States = []string{state.Apply.Failed, state.Apply.FailedRetryable}
@@ -756,30 +759,96 @@ func (s *Service) handleStatus(w http.ResponseWriter, r *http.Request) {
 		applies = applies[:limit]
 	}
 
-	activeCount := 0
-	for _, apply := range applies {
-		if !failuresOnly && !state.IsTerminalApplyState(apply.State) {
-			activeCount++
-		}
-	}
-
 	resp := &apitypes.StatusResponse{
-		ActiveCount:  activeCount,
 		Limit:        limit,
 		MaxLimit:     maxStatusLimit,
 		HasMore:      hasMore,
 		FailuresOnly: failuresOnly,
 		Applies:      make([]*apitypes.ActiveApplyResponse, 0, len(applies)),
 	}
+	operationsByApply := map[int64][]*storage.ApplyOperation{}
+	if filter.Deployment != "" {
+		applyIDs := make([]int64, 0, len(applies))
+		for _, apply := range applies {
+			applyIDs = append(applyIDs, apply.ID)
+		}
+		ops, err := s.storage.ApplyOperations().ListByApplies(r.Context(), applyIDs)
+		if err != nil {
+			s.logger.Error("get deployment operations for status failed",
+				"environment", filter.Environment,
+				"deployment", filter.Deployment,
+				"apply_count", len(applies),
+				"error", err)
+			s.writeError(w, http.StatusInternalServerError, "failed to get deployment operations for status")
+			return
+		}
+		for _, op := range ops {
+			operationsByApply[op.ApplyID] = append(operationsByApply[op.ApplyID], op)
+		}
+	}
 
 	for _, apply := range applies {
-		resp.Applies = append(resp.Applies, activeApplyResponseFromStorage(apply))
+		var opSummary *storage.ApplyOperation
+		if filter.Deployment != "" {
+			opSummary = statusOperationForDeployment(apply, operationsByApply[apply.ID], filter.Deployment)
+		}
+		active := activeApplyResponseFromStorage(apply, opSummary, filter.Deployment)
+		if !failuresOnly && !state.IsTerminalApplyState(active.State) {
+			resp.ActiveCount++
+		}
+		resp.Applies = append(resp.Applies, active)
 	}
 
 	s.writeJSON(w, http.StatusOK, resp)
 }
 
-func activeApplyResponseFromStorage(apply *storage.Apply) *apitypes.ActiveApplyResponse {
+func statusOperationForDeployment(apply *storage.Apply, ops []*storage.ApplyOperation, deployment string) *storage.ApplyOperation {
+	if apply == nil {
+		return nil
+	}
+	if deployment == "" {
+		return nil
+	}
+	var matches []*storage.ApplyOperation
+	for _, op := range ops {
+		if op.Deployment != deployment {
+			continue
+		}
+		matches = append(matches, op)
+	}
+	if len(matches) == 0 {
+		return nil
+	}
+	if len(matches) == 1 {
+		return matches[0]
+	}
+	states := make([]string, 0, len(matches))
+	summary := &storage.ApplyOperation{
+		ApplyID:    apply.ID,
+		Deployment: deployment,
+		CreatedAt:  matches[0].CreatedAt,
+		UpdatedAt:  matches[0].UpdatedAt,
+	}
+	for _, op := range matches {
+		states = append(states, op.State)
+		if summary.StartedAt == nil || (op.StartedAt != nil && op.StartedAt.Before(*summary.StartedAt)) {
+			summary.StartedAt = op.StartedAt
+		}
+		if op.CompletedAt != nil && (summary.CompletedAt == nil || op.CompletedAt.After(*summary.CompletedAt)) {
+			summary.CompletedAt = op.CompletedAt
+		}
+		if op.UpdatedAt.After(summary.UpdatedAt) {
+			summary.UpdatedAt = op.UpdatedAt
+		}
+		if summary.ErrorMessage == "" && state.IsState(op.State, state.ApplyOperation.Failed) {
+			summary.ErrorMessage = op.ErrorMessage
+		}
+	}
+	summary.State = state.DeriveApplyState(states)
+	return summary
+}
+
+func activeApplyResponseFromStorage(apply *storage.Apply, op *storage.ApplyOperation, deployment string) *apitypes.ActiveApplyResponse {
 	caller := apply.Caller
 	if caller == "" {
 		caller = "cli"
@@ -793,6 +862,7 @@ func activeApplyResponseFromStorage(apply *storage.Apply) *apitypes.ActiveApplyR
 		ExternalID:   apply.ExternalID,
 		Database:     apply.Database,
 		Environment:  apply.Environment,
+		Deployment:   deployment,
 		State:        apply.State,
 		Engine:       apply.Engine,
 		Caller:       caller,
@@ -804,6 +874,20 @@ func activeApplyResponseFromStorage(apply *storage.Apply) *apitypes.ActiveApplyR
 	}
 	if apply.CompletedAt != nil {
 		active.CompletedAt = apply.CompletedAt.Format("2006-01-02T15:04:05Z07:00")
+	}
+	if op != nil {
+		active.Deployment = op.Deployment
+		active.ExternalID = op.ExternalID
+		active.ExternalOperationID = op.ExternalOperationID
+		active.State = op.State
+		active.ErrorMessage = op.ErrorMessage
+		active.UpdatedAt = op.UpdatedAt.Format("2006-01-02T15:04:05Z07:00")
+		if op.StartedAt != nil {
+			active.StartedAt = op.StartedAt.Format("2006-01-02T15:04:05Z07:00")
+		}
+		if op.CompletedAt != nil {
+			active.CompletedAt = op.CompletedAt.Format("2006-01-02T15:04:05Z07:00")
+		}
 	}
 	opts := storage.ParseApplyOptions(apply.Options)
 	if opts.Volume > 0 {

--- a/pkg/apitypes/apitypes.go
+++ b/pkg/apitypes/apitypes.go
@@ -434,10 +434,12 @@ type ProgressResponse struct {
 
 // ProgressOperationResponse represents progress for one deployment operation.
 type ProgressOperationResponse struct {
-	Deployment    string `json:"deployment"`
-	OperationKind string `json:"operation_kind,omitempty"`
-	Target        string `json:"target,omitempty"`
-	State         string `json:"state"`
+	Deployment          string `json:"deployment"`
+	ExternalID          string `json:"external_id,omitempty"`
+	ExternalOperationID string `json:"external_operation_id,omitempty"`
+	OperationKind       string `json:"operation_kind,omitempty"`
+	Target              string `json:"target,omitempty"`
+	State               string `json:"state"`
 	// CutoverPolicy is the rollout boundary policy for this deployment operation.
 	CutoverPolicy string `json:"cutover_policy,omitempty"`
 	// OnFailure is the rollout failure policy for this deployment operation.
@@ -509,18 +511,20 @@ type DatabaseHistoryResponse struct {
 
 // ActiveApplyResponse represents a schema change in the status list.
 type ActiveApplyResponse struct {
-	ApplyID      string `json:"apply_id"`
-	ExternalID   string `json:"external_id,omitempty"`
-	Database     string `json:"database"`
-	Environment  string `json:"environment"`
-	State        string `json:"state"`
-	Engine       string `json:"engine"`
-	Caller       string `json:"caller"`
-	ErrorMessage string `json:"error_message,omitempty"`
-	StartedAt    string `json:"started_at,omitempty"`
-	CompletedAt  string `json:"completed_at,omitempty"`
-	UpdatedAt    string `json:"updated_at"`
-	Volume       int    `json:"volume,omitempty"`
+	ApplyID             string `json:"apply_id"`
+	ExternalID          string `json:"external_id,omitempty"`
+	ExternalOperationID string `json:"external_operation_id,omitempty"`
+	Database            string `json:"database"`
+	Environment         string `json:"environment"`
+	Deployment          string `json:"deployment,omitempty"`
+	State               string `json:"state"`
+	Engine              string `json:"engine"`
+	Caller              string `json:"caller"`
+	ErrorMessage        string `json:"error_message,omitempty"`
+	StartedAt           string `json:"started_at,omitempty"`
+	CompletedAt         string `json:"completed_at,omitempty"`
+	UpdatedAt           string `json:"updated_at"`
+	Volume              int    `json:"volume,omitempty"`
 }
 
 // StatusResponse is the HTTP response for GET /api/status.

--- a/pkg/apitypes/apitypes.go
+++ b/pkg/apitypes/apitypes.go
@@ -434,8 +434,10 @@ type ProgressResponse struct {
 
 // ProgressOperationResponse represents progress for one deployment operation.
 type ProgressOperationResponse struct {
-	Deployment          string `json:"deployment"`
-	ExternalID          string `json:"external_id,omitempty"`
+	Deployment string `json:"deployment"`
+	// ExternalID is the remote data plane's stable apply identifier.
+	ExternalID string `json:"external_id,omitempty"`
+	// ExternalOperationID is the remote data plane's numeric operation row ID.
 	ExternalOperationID string `json:"external_operation_id,omitempty"`
 	OperationKind       string `json:"operation_kind,omitempty"`
 	Target              string `json:"target,omitempty"`
@@ -511,8 +513,10 @@ type DatabaseHistoryResponse struct {
 
 // ActiveApplyResponse represents a schema change in the status list.
 type ActiveApplyResponse struct {
-	ApplyID             string `json:"apply_id"`
-	ExternalID          string `json:"external_id,omitempty"`
+	ApplyID string `json:"apply_id"`
+	// ExternalID is the remote data plane's stable apply identifier.
+	ExternalID string `json:"external_id,omitempty"`
+	// ExternalOperationID is the remote data plane's numeric operation row ID.
 	ExternalOperationID string `json:"external_operation_id,omitempty"`
 	Database            string `json:"database"`
 	Environment         string `json:"environment"`

--- a/pkg/cmd/client/client.go
+++ b/pkg/cmd/client/client.go
@@ -520,6 +520,7 @@ var (
 type StatusOptions struct {
 	Limit       int
 	Environment string
+	Deployment  string
 	Failed      bool
 }
 
@@ -534,6 +535,9 @@ func GetStatus(endpoint string, opts ...StatusOptions) (*apitypes.StatusResponse
 		}
 		if opts[0].Environment != "" {
 			values.Set("environment", opts[0].Environment)
+		}
+		if opts[0].Deployment != "" {
+			values.Set("deployment", opts[0].Deployment)
 		}
 		if opts[0].Failed {
 			values.Set("failed", "true")

--- a/pkg/cmd/commands/preview.go
+++ b/pkg/cmd/commands/preview.go
@@ -63,7 +63,7 @@ func (cmd *PreviewCmd) Run(g *Globals) error {
 	case templates.PreviewVolumeMode, templates.PreviewVolumeBar:
 		templates.PreviewCLIOutput(previewType)
 	// Status types
-	case templates.PreviewStatusList, templates.PreviewStatusHistory:
+	case templates.PreviewStatusList, templates.PreviewStatusDeployment, templates.PreviewStatusHistory:
 		templates.PreviewCLIOutput(previewType)
 	// Lint and unsafe types
 	case templates.PreviewLintViolations, templates.PreviewUnsafeBlocked,
@@ -212,6 +212,7 @@ Volume Control:
 
 Status:
   status_list           List of active schema changes
+  status_deployment     Deployment-scoped schema change status
   status_history        Database apply history
 
 Lint and Unsafe:

--- a/pkg/cmd/commands/preview_tui.go
+++ b/pkg/cmd/commands/preview_tui.go
@@ -63,8 +63,8 @@ var tuiPreviewScenarios = map[string]tuiPreviewScenario{
 				Caller:      "octocat",
 				StartedAt:   time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC).Format(time.RFC3339),
 				Operations: []*apitypes.ProgressOperationResponse{
-					{Deployment: "us-east", Target: "orders-us-east", State: state.ApplyOperation.WaitingForCutover, CutoverPolicy: storage.CutoverPolicyBarrier, OnFailure: storage.OnFailureHalt},
-					{Deployment: "eu-west", Target: "orders-eu-west", State: state.ApplyOperation.Running, CutoverPolicy: storage.CutoverPolicyBarrier, OnFailure: storage.OnFailureHalt},
+					{Deployment: "us-east", ExternalID: "remote-apply-us-east-001", ExternalOperationID: "remote-op-us-east-001", Target: "orders-us-east", State: state.ApplyOperation.WaitingForCutover, CutoverPolicy: storage.CutoverPolicyBarrier, OnFailure: storage.OnFailureHalt},
+					{Deployment: "eu-west", ExternalID: "remote-apply-eu-west-001", ExternalOperationID: "remote-op-eu-west-001", Target: "orders-eu-west", State: state.ApplyOperation.Running, CutoverPolicy: storage.CutoverPolicyBarrier, OnFailure: storage.OnFailureHalt},
 					{Deployment: "ap-south", Target: "orders-ap-south", State: state.ApplyOperation.Pending, CutoverPolicy: storage.CutoverPolicyBarrier, OnFailure: storage.OnFailureHalt},
 				},
 				Tables: []*apitypes.TableProgressResponse{

--- a/pkg/cmd/commands/status.go
+++ b/pkg/cmd/commands/status.go
@@ -14,6 +14,7 @@ type StatusCmd struct {
 	ApplyIDArg  string `arg:"" optional:"" help:"Apply ID to show details for" name:"apply_id"`
 	Database    string `short:"d" help:"Database name (show apply history)"`
 	Environment string `short:"e" help:"Environment filter"`
+	Deployment  string `help:"Deployment filter"`
 	Limit       int    `short:"n" help:"Maximum recent applies to show (default 20, max 1000)"`
 	Failed      bool   `help:"Show only failed recent applies" name:"failed"`
 	ExternalID  bool   `help:"Show external engine apply IDs" name:"external-id"`
@@ -44,6 +45,7 @@ func (cmd *StatusCmd) Run(g *Globals) error {
 		result, loadErr = client.GetStatus(ep, client.StatusOptions{
 			Limit:       cmd.Limit,
 			Environment: cmd.Environment,
+			Deployment:  cmd.Deployment,
 			Failed:      cmd.Failed,
 		})
 		return loadErr
@@ -69,6 +71,7 @@ func (cmd *StatusCmd) Run(g *Globals) error {
 		HasMore:        result.HasMore,
 		FailuresOnly:   result.FailuresOnly,
 		ShowExternalID: cmd.ExternalID,
+		Deployment:     cmd.Deployment,
 		Applies:        applies,
 	})
 
@@ -77,18 +80,20 @@ func (cmd *StatusCmd) Run(g *Globals) error {
 
 func activeApplyDataFromResponse(a *apitypes.ActiveApplyResponse) templates.ActiveApplyData {
 	return templates.ActiveApplyData{
-		ApplyID:      a.ApplyID,
-		ExternalID:   a.ExternalID,
-		Database:     a.Database,
-		Environment:  a.Environment,
-		State:        a.State,
-		Engine:       a.Engine,
-		Caller:       a.Caller,
-		ErrorMessage: a.ErrorMessage,
-		StartedAt:    a.StartedAt,
-		CompletedAt:  a.CompletedAt,
-		UpdatedAt:    a.UpdatedAt,
-		Volume:       a.Volume,
+		ApplyID:             a.ApplyID,
+		ExternalID:          a.ExternalID,
+		ExternalOperationID: a.ExternalOperationID,
+		Database:            a.Database,
+		Environment:         a.Environment,
+		Deployment:          a.Deployment,
+		State:               a.State,
+		Engine:              a.Engine,
+		Caller:              a.Caller,
+		ErrorMessage:        a.ErrorMessage,
+		StartedAt:           a.StartedAt,
+		CompletedAt:         a.CompletedAt,
+		UpdatedAt:           a.UpdatedAt,
+		Volume:              a.Volume,
 	}
 }
 

--- a/pkg/cmd/commands/watch_tui_test.go
+++ b/pkg/cmd/commands/watch_tui_test.go
@@ -289,6 +289,8 @@ func TestWatchModel_MultiDeploymentView(t *testing.T) {
 	assert.Contains(t, view, "Environment: production")
 	assertContainsInOrder(t, view,
 		"✅ us-east — completed (orders-us-east)",
+		"External operation ID: remote-op-us-east-test",
+		"External apply ID: remote-apply-us-east-test",
 		"❌ eu-west — failed (orders-eu-west)",
 		"⏸ ap-south — halted — eu-west failed (orders-ap-south)",
 	)
@@ -349,7 +351,7 @@ func multiDeploymentTUITestProgress() apitypes.ProgressResponse {
 		Database:    "orders",
 		Environment: "production",
 		Operations: []*apitypes.ProgressOperationResponse{
-			{Deployment: "us-east", Target: "orders-us-east", State: state.ApplyOperation.Completed, CutoverPolicy: storage.CutoverPolicyRolling, OnFailure: storage.OnFailureHalt},
+			{Deployment: "us-east", ExternalID: "remote-apply-us-east-test", ExternalOperationID: "remote-op-us-east-test", Target: "orders-us-east", State: state.ApplyOperation.Completed, CutoverPolicy: storage.CutoverPolicyRolling, OnFailure: storage.OnFailureHalt},
 			{Deployment: "eu-west", Target: "orders-eu-west", State: state.ApplyOperation.Failed, CutoverPolicy: storage.CutoverPolicyRolling, OnFailure: storage.OnFailureHalt, ErrorMessage: "duplicate key name 'idx_orders_source'"},
 			{Deployment: "ap-south", Target: "orders-ap-south", State: state.ApplyOperation.Pending, CutoverPolicy: storage.CutoverPolicyRolling, OnFailure: storage.OnFailureHalt},
 		},

--- a/pkg/cmd/commands/watch_tui_view_multi.go
+++ b/pkg/cmd/commands/watch_tui_view_multi.go
@@ -82,6 +82,12 @@ func (m WatchModel) writeDeploymentSection(b *strings.Builder, deployment presen
 		fmt.Fprintf(b, " (%s)", target)
 	}
 	b.WriteString("\n")
+	if externalOperationID := externalOperationIDForTUIDeployment(m.operations, deployment.Deployment); externalOperationID != "" {
+		fmt.Fprintf(b, "  External operation ID: %s\n", externalOperationID)
+	}
+	if externalID := externalIDForTUIDeployment(m.operations, deployment.Deployment); externalID != "" {
+		fmt.Fprintf(b, "  External apply ID: %s\n", externalID)
+	}
 
 	if deployment.Error != "" {
 		errStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("9"))
@@ -100,6 +106,24 @@ func targetForTUIDeployment(ops []templates.ProgressOperation, deployment string
 	for _, op := range ops {
 		if op.Deployment == deployment {
 			return op.Target
+		}
+	}
+	return ""
+}
+
+func externalOperationIDForTUIDeployment(ops []templates.ProgressOperation, deployment string) string {
+	for _, op := range ops {
+		if op.Deployment == deployment && op.ExternalOperationID != "" {
+			return op.ExternalOperationID
+		}
+	}
+	return ""
+}
+
+func externalIDForTUIDeployment(ops []templates.ProgressOperation, deployment string) string {
+	for _, op := range ops {
+		if op.Deployment == deployment && op.ExternalID != "" {
+			return op.ExternalID
 		}
 	}
 	return ""

--- a/pkg/cmd/internal/templates/preview.go
+++ b/pkg/cmd/internal/templates/preview.go
@@ -81,8 +81,9 @@ const (
 	PreviewVolumeMode PreviewType = "volume_mode" // Volume adjustment mode
 
 	// Status previews
-	PreviewStatusList    PreviewType = "status_list"    // List of active schema changes
-	PreviewStatusHistory PreviewType = "status_history" // Database apply history
+	PreviewStatusList       PreviewType = "status_list"       // List of active schema changes
+	PreviewStatusDeployment PreviewType = "status_deployment" // Deployment-scoped schema change status
+	PreviewStatusHistory    PreviewType = "status_history"    // Database apply history
 
 	// Lint and unsafe previews
 	PreviewLintViolations PreviewType = "lint_violations" // Lint violations output

--- a/pkg/cmd/internal/templates/preview_comment.go
+++ b/pkg/cmd/internal/templates/preview_comment.go
@@ -374,6 +374,7 @@ func previewCLIApplyAllOutput() {
 		{"START COMMAND", previewStartCommandOutput},
 		{"VOLUME MODE", previewVolumeModeOutput},
 		{"STATUS LIST", previewStatusListOutput},
+		{"STATUS FOR DEPLOYMENT", previewStatusDeploymentOutput},
 		{"STATUS HISTORY", previewStatusHistoryOutput},
 	}
 	printSections(sections)

--- a/pkg/cmd/internal/templates/preview_dispatch.go
+++ b/pkg/cmd/internal/templates/preview_dispatch.go
@@ -98,6 +98,8 @@ func PreviewCLIOutput(previewType PreviewType) {
 		previewVolumeModeOutput()
 	case PreviewStatusList:
 		previewStatusListOutput()
+	case PreviewStatusDeployment:
+		previewStatusDeploymentOutput()
 	case PreviewStatusHistory:
 		previewStatusHistoryOutput()
 	case PreviewLintViolations:

--- a/pkg/cmd/internal/templates/preview_status.go
+++ b/pkg/cmd/internal/templates/preview_status.go
@@ -72,6 +72,50 @@ func previewStatusListOutput() {
 	})
 }
 
+func previewStatusDeploymentOutput() {
+	WriteStatusList(StatusListData{
+		ActiveCount:    1,
+		ShowExternalID: true,
+		Deployment:     "us-east",
+		Applies: []ActiveApplyData{
+			{
+				ApplyID:             "apply-multi-a1b2c3d4",
+				ExternalOperationID: "remote-op-us-east-001",
+				Database:            "orders-db",
+				Environment:         "production",
+				Deployment:          "us-east",
+				State:               state.Apply.WaitingForCutover,
+				Engine:              "Spirit",
+				Caller:              "octocat",
+				StartedAt:           previewTime.Add(-8 * time.Minute).Format(time.RFC3339),
+				UpdatedAt:           previewTime.Add(-30 * time.Second).Format(time.RFC3339),
+			},
+		},
+	})
+
+	fmt.Println()
+	fmt.Println("Multiple matching operations:")
+	fmt.Println()
+	WriteStatusList(StatusListData{
+		ActiveCount:    1,
+		ShowExternalID: true,
+		Deployment:     "us-east",
+		Applies: []ActiveApplyData{
+			{
+				ApplyID:     "apply-sharded-d5e6f7g8",
+				Database:    "inventory-db",
+				Environment: "production",
+				Deployment:  "us-east",
+				State:       state.Apply.Running,
+				Engine:      "Spirit",
+				Caller:      "octocat",
+				StartedAt:   previewTime.Add(-4 * time.Minute).Format(time.RFC3339),
+				UpdatedAt:   previewTime.Add(-20 * time.Second).Format(time.RFC3339),
+			},
+		},
+	})
+}
+
 func previewStatusHistoryOutput() {
 	WriteDatabaseHistory(DatabaseHistoryData{
 		Database: "orders-db",

--- a/pkg/cmd/internal/templates/progress.go
+++ b/pkg/cmd/internal/templates/progress.go
@@ -832,7 +832,6 @@ func WriteStatusList(data StatusListData) {
 	maxDeployment := 10 // "DEPLOYMENT"
 	maxState := 5       // "STATE"
 	maxStarted := 7     // "STARTED"
-	maxDur := 8         // "DURATION"
 	for _, a := range data.Applies {
 		maxID = maxLen(maxID, len(a.ApplyID))
 		if data.ShowExternalID {
@@ -845,13 +844,12 @@ func WriteStatusList(data StatusListData) {
 		}
 		maxState = maxLen(maxState, len(state.Label(a.State)))
 		maxStarted = maxLen(maxStarted, len(formatStartedAt(a.StartedAt)))
-		maxDur = maxLen(maxDur, len(formatApplyDuration(a.StartedAt, a.CompletedAt)))
 	}
 
 	// Table header
 	switch {
 	case data.ShowExternalID && showDeployment:
-		fmt.Printf("  %s%-*s  %-*s  %-*s  %-*s  %-*s  %-*s  %-*s  %-*s  %s%s\n",
+		fmt.Printf("  %s%-*s  %-*s  %-*s  %-*s  %-*s  %-*s  %-*s  %s%s\n",
 			ANSIDim,
 			maxID, "APPLY ID",
 			maxExternal, statusExternalIDHeader(data),
@@ -860,11 +858,10 @@ func WriteStatusList(data StatusListData) {
 			maxDeployment, "DEPLOYMENT",
 			maxState, "STATE",
 			maxStarted, "STARTED",
-			maxDur, "DURATION",
 			"CALLER",
 			ANSIReset)
 	case data.ShowExternalID:
-		fmt.Printf("  %s%-*s  %-*s  %-*s  %-*s  %-*s  %-*s  %-*s  %s%s\n",
+		fmt.Printf("  %s%-*s  %-*s  %-*s  %-*s  %-*s  %-*s  %s%s\n",
 			ANSIDim,
 			maxID, "APPLY ID",
 			maxExternal, statusExternalIDHeader(data),
@@ -872,30 +869,27 @@ func WriteStatusList(data StatusListData) {
 			maxEnv, "ENV",
 			maxState, "STATE",
 			maxStarted, "STARTED",
-			maxDur, "DURATION",
 			"CALLER",
 			ANSIReset)
 	case showDeployment:
-		fmt.Printf("  %s%-*s  %-*s  %-*s  %-*s  %-*s  %-*s  %-*s  %s%s\n",
-			ANSIDim,
-			maxID, "APPLY ID",
-			maxDB, "DATABASE",
-			maxEnv, "ENV",
-			maxDeployment, "DEPLOYMENT",
-			maxState, "STATE",
-			maxStarted, "STARTED",
-			maxDur, "DURATION",
-			"CALLER",
-			ANSIReset)
-	default:
 		fmt.Printf("  %s%-*s  %-*s  %-*s  %-*s  %-*s  %-*s  %s%s\n",
 			ANSIDim,
 			maxID, "APPLY ID",
 			maxDB, "DATABASE",
 			maxEnv, "ENV",
+			maxDeployment, "DEPLOYMENT",
 			maxState, "STATE",
 			maxStarted, "STARTED",
-			maxDur, "DURATION",
+			"CALLER",
+			ANSIReset)
+	default:
+		fmt.Printf("  %s%-*s  %-*s  %-*s  %-*s  %-*s  %s%s\n",
+			ANSIDim,
+			maxID, "APPLY ID",
+			maxDB, "DATABASE",
+			maxEnv, "ENV",
+			maxState, "STATE",
+			maxStarted, "STARTED",
 			"CALLER",
 			ANSIReset)
 	}
@@ -912,7 +906,7 @@ func WriteStatusList(data StatusListData) {
 
 		switch {
 		case data.ShowExternalID && showDeployment:
-			fmt.Printf("  %-*s  %-*s  %-*s  %-*s  %-*s  %s  %-*s  %-*s  %s\n",
+			fmt.Printf("  %-*s  %-*s  %-*s  %-*s  %-*s  %s  %-*s  %s\n",
 				maxID, a.ApplyID,
 				maxExternal, statusExternalID(data, a),
 				maxDB, a.Database,
@@ -920,36 +914,32 @@ func WriteStatusList(data StatusListData) {
 				maxDeployment, a.Deployment,
 				coloredState,
 				maxStarted, formatStartedAt(a.StartedAt),
-				maxDur, formatApplyDuration(a.StartedAt, a.CompletedAt),
 				shortCaller(a.Caller))
 		case data.ShowExternalID:
-			fmt.Printf("  %-*s  %-*s  %-*s  %-*s  %s  %-*s  %-*s  %s\n",
+			fmt.Printf("  %-*s  %-*s  %-*s  %-*s  %s  %-*s  %s\n",
 				maxID, a.ApplyID,
 				maxExternal, statusExternalID(data, a),
 				maxDB, a.Database,
 				maxEnv, a.Environment,
 				coloredState,
 				maxStarted, formatStartedAt(a.StartedAt),
-				maxDur, formatApplyDuration(a.StartedAt, a.CompletedAt),
 				shortCaller(a.Caller))
 		case showDeployment:
-			fmt.Printf("  %-*s  %-*s  %-*s  %-*s  %s  %-*s  %-*s  %s\n",
+			fmt.Printf("  %-*s  %-*s  %-*s  %-*s  %s  %-*s  %s\n",
 				maxID, a.ApplyID,
 				maxDB, a.Database,
 				maxEnv, a.Environment,
 				maxDeployment, a.Deployment,
 				coloredState,
 				maxStarted, formatStartedAt(a.StartedAt),
-				maxDur, formatApplyDuration(a.StartedAt, a.CompletedAt),
 				shortCaller(a.Caller))
 		default:
-			fmt.Printf("  %-*s  %-*s  %-*s  %s  %-*s  %-*s  %s\n",
+			fmt.Printf("  %-*s  %-*s  %-*s  %s  %-*s  %s\n",
 				maxID, a.ApplyID,
 				maxDB, a.Database,
 				maxEnv, a.Environment,
 				coloredState,
 				maxStarted, formatStartedAt(a.StartedAt),
-				maxDur, formatApplyDuration(a.StartedAt, a.CompletedAt),
 				shortCaller(a.Caller))
 		}
 	}

--- a/pkg/cmd/internal/templates/progress.go
+++ b/pkg/cmd/internal/templates/progress.go
@@ -768,18 +768,20 @@ func WriteStartNoWatch(applyID, database, environment string) {
 
 // ActiveApplyData contains data for a single apply in the status list.
 type ActiveApplyData struct {
-	ApplyID      string
-	ExternalID   string
-	Database     string
-	Environment  string
-	State        string
-	Engine       string
-	Caller       string
-	ErrorMessage string
-	StartedAt    string
-	CompletedAt  string
-	UpdatedAt    string
-	Volume       int
+	ApplyID             string
+	ExternalID          string
+	ExternalOperationID string
+	Database            string
+	Environment         string
+	Deployment          string
+	State               string
+	Engine              string
+	Caller              string
+	ErrorMessage        string
+	StartedAt           string
+	CompletedAt         string
+	UpdatedAt           string
+	Volume              int
 }
 
 // StatusListData contains data for rendering the status list.
@@ -790,6 +792,7 @@ type StatusListData struct {
 	HasMore        bool
 	FailuresOnly   bool
 	ShowExternalID bool
+	Deployment     string
 	Applies        []ActiveApplyData
 }
 
@@ -821,31 +824,50 @@ func WriteStatusList(data StatusListData) {
 	fmt.Println()
 
 	// Calculate column widths from data
-	maxID := 8        // "APPLY ID"
-	maxExternal := 11 // "EXTERNAL ID"
-	maxDB := 8        // "DATABASE"
-	maxEnv := 3       // "ENV"
-	maxState := 5     // "STATE"
-	maxStarted := 7   // "STARTED"
-	maxDur := 8       // "DURATION"
+	showDeployment := statusListShowsDeployment(data)
+	maxID := 8 // "APPLY ID"
+	maxExternal := len(statusExternalIDHeader(data))
+	maxDB := 8          // "DATABASE"
+	maxEnv := 3         // "ENV"
+	maxDeployment := 10 // "DEPLOYMENT"
+	maxState := 5       // "STATE"
+	maxStarted := 7     // "STARTED"
+	maxDur := 8         // "DURATION"
 	for _, a := range data.Applies {
 		maxID = maxLen(maxID, len(a.ApplyID))
 		if data.ShowExternalID {
-			maxExternal = maxLen(maxExternal, len(statusExternalID(a)))
+			maxExternal = maxLen(maxExternal, len(statusExternalID(data, a)))
 		}
 		maxDB = maxLen(maxDB, len(a.Database))
 		maxEnv = maxLen(maxEnv, len(a.Environment))
+		if showDeployment {
+			maxDeployment = maxLen(maxDeployment, len(a.Deployment))
+		}
 		maxState = maxLen(maxState, len(state.Label(a.State)))
 		maxStarted = maxLen(maxStarted, len(formatStartedAt(a.StartedAt)))
 		maxDur = maxLen(maxDur, len(formatApplyDuration(a.StartedAt, a.CompletedAt)))
 	}
 
 	// Table header
-	if data.ShowExternalID {
+	switch {
+	case data.ShowExternalID && showDeployment:
+		fmt.Printf("  %s%-*s  %-*s  %-*s  %-*s  %-*s  %-*s  %-*s  %-*s  %s%s\n",
+			ANSIDim,
+			maxID, "APPLY ID",
+			maxExternal, statusExternalIDHeader(data),
+			maxDB, "DATABASE",
+			maxEnv, "ENV",
+			maxDeployment, "DEPLOYMENT",
+			maxState, "STATE",
+			maxStarted, "STARTED",
+			maxDur, "DURATION",
+			"CALLER",
+			ANSIReset)
+	case data.ShowExternalID:
 		fmt.Printf("  %s%-*s  %-*s  %-*s  %-*s  %-*s  %-*s  %-*s  %s%s\n",
 			ANSIDim,
 			maxID, "APPLY ID",
-			maxExternal, "EXTERNAL ID",
+			maxExternal, statusExternalIDHeader(data),
 			maxDB, "DATABASE",
 			maxEnv, "ENV",
 			maxState, "STATE",
@@ -853,7 +875,19 @@ func WriteStatusList(data StatusListData) {
 			maxDur, "DURATION",
 			"CALLER",
 			ANSIReset)
-	} else {
+	case showDeployment:
+		fmt.Printf("  %s%-*s  %-*s  %-*s  %-*s  %-*s  %-*s  %-*s  %s%s\n",
+			ANSIDim,
+			maxID, "APPLY ID",
+			maxDB, "DATABASE",
+			maxEnv, "ENV",
+			maxDeployment, "DEPLOYMENT",
+			maxState, "STATE",
+			maxStarted, "STARTED",
+			maxDur, "DURATION",
+			"CALLER",
+			ANSIReset)
+	default:
 		fmt.Printf("  %s%-*s  %-*s  %-*s  %-*s  %-*s  %-*s  %s%s\n",
 			ANSIDim,
 			maxID, "APPLY ID",
@@ -876,17 +910,39 @@ func WriteStatusList(data StatusListData) {
 			coloredState = colorFn(padded)
 		}
 
-		if data.ShowExternalID {
+		switch {
+		case data.ShowExternalID && showDeployment:
+			fmt.Printf("  %-*s  %-*s  %-*s  %-*s  %-*s  %s  %-*s  %-*s  %s\n",
+				maxID, a.ApplyID,
+				maxExternal, statusExternalID(data, a),
+				maxDB, a.Database,
+				maxEnv, a.Environment,
+				maxDeployment, a.Deployment,
+				coloredState,
+				maxStarted, formatStartedAt(a.StartedAt),
+				maxDur, formatApplyDuration(a.StartedAt, a.CompletedAt),
+				shortCaller(a.Caller))
+		case data.ShowExternalID:
 			fmt.Printf("  %-*s  %-*s  %-*s  %-*s  %s  %-*s  %-*s  %s\n",
 				maxID, a.ApplyID,
-				maxExternal, statusExternalID(a),
+				maxExternal, statusExternalID(data, a),
 				maxDB, a.Database,
 				maxEnv, a.Environment,
 				coloredState,
 				maxStarted, formatStartedAt(a.StartedAt),
 				maxDur, formatApplyDuration(a.StartedAt, a.CompletedAt),
 				shortCaller(a.Caller))
-		} else {
+		case showDeployment:
+			fmt.Printf("  %-*s  %-*s  %-*s  %-*s  %s  %-*s  %-*s  %s\n",
+				maxID, a.ApplyID,
+				maxDB, a.Database,
+				maxEnv, a.Environment,
+				maxDeployment, a.Deployment,
+				coloredState,
+				maxStarted, formatStartedAt(a.StartedAt),
+				maxDur, formatApplyDuration(a.StartedAt, a.CompletedAt),
+				shortCaller(a.Caller))
+		default:
 			fmt.Printf("  %-*s  %-*s  %-*s  %s  %-*s  %-*s  %s\n",
 				maxID, a.ApplyID,
 				maxDB, a.Database,
@@ -946,11 +1002,36 @@ func writeFailedStatusList(data StatusListData) {
 	}
 }
 
-func statusExternalID(a ActiveApplyData) string {
+func statusExternalID(data StatusListData, a ActiveApplyData) string {
+	if a.ExternalOperationID != "" {
+		return a.ExternalOperationID
+	}
+	if data.Deployment != "" {
+		return "-"
+	}
 	if a.ExternalID == "" {
 		return "-"
 	}
 	return a.ExternalID
+}
+
+func statusExternalIDHeader(data StatusListData) string {
+	if data.Deployment != "" {
+		return "EXTERNAL OP ID"
+	}
+	return "EXTERNAL ID"
+}
+
+func statusListShowsDeployment(data StatusListData) bool {
+	if data.Deployment != "" {
+		return true
+	}
+	for _, apply := range data.Applies {
+		if apply.Deployment != "" {
+			return true
+		}
+	}
+	return false
 }
 
 func statusFailureActor(a ActiveApplyData, showExternalID bool) string {
@@ -958,7 +1039,7 @@ func statusFailureActor(a ActiveApplyData, showExternalID bool) string {
 	if !showExternalID {
 		return caller
 	}
-	return caller + "; external_id=" + statusExternalID(a)
+	return caller + "; external_id=" + statusExternalID(StatusListData{}, a)
 }
 
 func formatFailureTimestamp(a ActiveApplyData) string {

--- a/pkg/cmd/internal/templates/progress_multi.go
+++ b/pkg/cmd/internal/templates/progress_multi.go
@@ -111,6 +111,12 @@ func writeDeploymentProgressSection(deployment presentation.Deployment, data Pro
 		fmt.Printf(" (%s)", target)
 	}
 	fmt.Println()
+	if externalOperationID := externalOperationIDForDeployment(data.Operations, deployment.Deployment); externalOperationID != "" {
+		fmt.Printf("  %sExternal operation ID: %s%s\n", ANSIDim, externalOperationID, ANSIReset)
+	}
+	if externalID := externalIDForDeployment(data.Operations, deployment.Deployment); externalID != "" {
+		fmt.Printf("  %sExternal apply ID: %s%s\n", ANSIDim, externalID, ANSIReset)
+	}
 
 	if deployment.Error != "" {
 		fmt.Printf("  %s%s%s\n", ANSIRed, deployment.Error, ANSIReset)
@@ -135,6 +141,24 @@ func targetForDeployment(ops []ProgressOperation, deployment string) string {
 	for _, op := range ops {
 		if op.Deployment == deployment {
 			return op.Target
+		}
+	}
+	return ""
+}
+
+func externalOperationIDForDeployment(ops []ProgressOperation, deployment string) string {
+	for _, op := range ops {
+		if op.Deployment == deployment && op.ExternalOperationID != "" {
+			return op.ExternalOperationID
+		}
+	}
+	return ""
+}
+
+func externalIDForDeployment(ops []ProgressOperation, deployment string) string {
+	for _, op := range ops {
+		if op.Deployment == deployment && op.ExternalID != "" {
+			return op.ExternalID
 		}
 	}
 	return ""

--- a/pkg/cmd/internal/templates/progress_multi_test.go
+++ b/pkg/cmd/internal/templates/progress_multi_test.go
@@ -18,7 +18,7 @@ func TestWriteProgressMultiDeploymentRendersAggregateAndSections(t *testing.T) {
 			State:       state.Apply.Running,
 			StartedAt:   "2026-06-16T10:00:00Z",
 			Operations: []ProgressOperation{
-				{Deployment: "region-a", Target: "orders-a", State: state.ApplyOperation.Completed, CutoverPolicy: storage.CutoverPolicyRolling, OnFailure: storage.OnFailureHalt},
+				{Deployment: "region-a", ExternalID: "remote-apply-region-a", ExternalOperationID: "remote-region-a", Target: "orders-a", State: state.ApplyOperation.Completed, CutoverPolicy: storage.CutoverPolicyRolling, OnFailure: storage.OnFailureHalt},
 				{Deployment: "region-b", Target: "orders-b", State: state.ApplyOperation.Failed, CutoverPolicy: storage.CutoverPolicyRolling, OnFailure: storage.OnFailureHalt, ErrorMessage: "duplicate column name 'region'"},
 				{Deployment: "region-c", Target: "orders-c", State: state.ApplyOperation.Pending, CutoverPolicy: storage.CutoverPolicyRolling, OnFailure: storage.OnFailureHalt},
 			},
@@ -41,6 +41,8 @@ func TestWriteProgressMultiDeploymentRendersAggregateAndSections(t *testing.T) {
 	assert.Contains(t, output, "First failure: region-b — duplicate column name 'region'")
 	assert.Contains(t, output, "Next: review failure in region-b")
 	assertLess(t, output, "✅ region-a — completed", "❌ region-b — failed")
+	assert.Contains(t, output, "External operation ID: remote-region-a")
+	assert.Contains(t, output, "External apply ID: remote-apply-region-a")
 	assertLess(t, output, "❌ region-b — failed", "⏸ region-c — halted — region-b failed")
 	assert.Contains(t, output, "users_a")
 	assert.Contains(t, output, "users_b")

--- a/pkg/cmd/internal/templates/progress_parse.go
+++ b/pkg/cmd/internal/templates/progress_parse.go
@@ -34,15 +34,17 @@ type ProgressData struct {
 
 // ProgressOperation represents progress for one deployment operation.
 type ProgressOperation struct {
-	Deployment    string
-	Target        string
-	State         string
-	CutoverPolicy string
-	OnFailure     string
-	ErrorMessage  string
-	ErrorCode     string
-	StartedAt     string
-	CompletedAt   string
+	Deployment          string
+	ExternalID          string
+	ExternalOperationID string
+	Target              string
+	State               string
+	CutoverPolicy       string
+	OnFailure           string
+	ErrorMessage        string
+	ErrorCode           string
+	StartedAt           string
+	CompletedAt         string
 }
 
 // TableProgress represents progress for a single table schema change.
@@ -146,15 +148,17 @@ func ParseProgressResponse(result *apitypes.ProgressResponse) ProgressData {
 
 	for _, op := range result.Operations {
 		data.Operations = append(data.Operations, ProgressOperation{
-			Deployment:    op.Deployment,
-			Target:        op.Target,
-			State:         state.NormalizeState(op.State),
-			CutoverPolicy: op.CutoverPolicy,
-			OnFailure:     op.OnFailure,
-			ErrorMessage:  op.ErrorMessage,
-			ErrorCode:     op.ErrorCode,
-			StartedAt:     op.StartedAt,
-			CompletedAt:   op.CompletedAt,
+			Deployment:          op.Deployment,
+			ExternalID:          op.ExternalID,
+			ExternalOperationID: op.ExternalOperationID,
+			Target:              op.Target,
+			State:               state.NormalizeState(op.State),
+			CutoverPolicy:       op.CutoverPolicy,
+			OnFailure:           op.OnFailure,
+			ErrorMessage:        op.ErrorMessage,
+			ErrorCode:           op.ErrorCode,
+			StartedAt:           op.StartedAt,
+			CompletedAt:         op.CompletedAt,
 		})
 	}
 

--- a/pkg/cmd/internal/templates/progress_parse_test.go
+++ b/pkg/cmd/internal/templates/progress_parse_test.go
@@ -15,15 +15,17 @@ func TestParseProgressResponseIncludesOperationsAndTableDeployments(t *testing.T
 		State: state.Apply.Running,
 		Operations: []*apitypes.ProgressOperationResponse{
 			{
-				Deployment:    "deploy-a",
-				Target:        "target-a",
-				State:         "STATE_RUNNING",
-				CutoverPolicy: "barrier",
-				OnFailure:     "continue",
-				ErrorCode:     "engine_error_retryable",
-				ErrorMessage:  "retryable failure",
-				StartedAt:     "2026-06-16T10:00:00Z",
-				CompletedAt:   "2026-06-16T10:05:00Z",
+				Deployment:          "deploy-a",
+				ExternalID:          "remote-apply-a",
+				ExternalOperationID: "remote-operation-a",
+				Target:              "target-a",
+				State:               "STATE_RUNNING",
+				CutoverPolicy:       "barrier",
+				OnFailure:           "continue",
+				ErrorCode:           "engine_error_retryable",
+				ErrorMessage:        "retryable failure",
+				StartedAt:           "2026-06-16T10:00:00Z",
+				CompletedAt:         "2026-06-16T10:05:00Z",
 			},
 		},
 		Tables: []*apitypes.TableProgressResponse{
@@ -42,6 +44,8 @@ func TestParseProgressResponseIncludesOperationsAndTableDeployments(t *testing.T
 
 	require.Len(t, data.Operations, 1)
 	assert.Equal(t, "deploy-a", data.Operations[0].Deployment)
+	assert.Equal(t, "remote-apply-a", data.Operations[0].ExternalID)
+	assert.Equal(t, "remote-operation-a", data.Operations[0].ExternalOperationID)
 	assert.Equal(t, "target-a", data.Operations[0].Target)
 	assert.Equal(t, state.Apply.Running, data.Operations[0].State)
 	assert.Equal(t, "barrier", data.Operations[0].CutoverPolicy)

--- a/pkg/cmd/internal/templates/progress_states_test.go
+++ b/pkg/cmd/internal/templates/progress_states_test.go
@@ -114,6 +114,37 @@ func TestWriteStatusListExternalID(t *testing.T) {
 	assert.Contains(t, output, "apply-complete")
 }
 
+func TestWriteStatusListDeploymentExternalOperationID(t *testing.T) {
+	output := captureStdout(t, func() {
+		WriteStatusList(StatusListData{
+			ActiveCount:    1,
+			Limit:          20,
+			MaxLimit:       1000,
+			ShowExternalID: true,
+			Deployment:     "deploy-a",
+			Applies: []ActiveApplyData{
+				{
+					ApplyID:             "apply-running",
+					ExternalID:          "parent-external",
+					ExternalOperationID: "remote-operation-a",
+					Database:            "orders",
+					Environment:         "staging",
+					Deployment:          "deploy-a",
+					State:               state.Apply.Running,
+					StartedAt:           "2026-05-28T12:00:00Z",
+					Caller:              "cli",
+				},
+			},
+		})
+	})
+
+	assert.Contains(t, output, "EXTERNAL OP ID")
+	assert.Contains(t, output, "DEPLOYMENT")
+	assert.Contains(t, output, "remote-operation-a")
+	assert.NotContains(t, output, "parent-external")
+	assert.Contains(t, output, "deploy-a")
+}
+
 func TestWriteStatusListFailedOnly(t *testing.T) {
 	output := captureStdout(t, func() {
 		WriteStatusList(StatusListData{

--- a/pkg/cmd/internal/templates/progress_states_test.go
+++ b/pkg/cmd/internal/templates/progress_states_test.go
@@ -57,6 +57,8 @@ func TestWriteStatusListHasMoreFooter(t *testing.T) {
 
 	assert.Contains(t, output, "Recent schema changes")
 	assert.Contains(t, output, "apply-example")
+	assert.Contains(t, output, "STARTED")
+	assert.NotContains(t, output, "DURATION")
 	assert.Contains(t, output, "Showing the 20 most recent schema changes. Use --limit N to show more.")
 	assert.Contains(t, output, "Use 'schemabot status <apply_id>' to view details")
 }

--- a/pkg/proto/tern.proto
+++ b/pkg/proto/tern.proto
@@ -489,6 +489,8 @@ message ApplyResponse {
   string error_message = 2;
   // The apply identifier for tracking this schema change.
   string apply_id = 3;
+  // The apply_operation identifier for operation-scoped callers.
+  string apply_operation_id = 4;
 }
 
 // ProgressRequest requests detailed progress for an active schema change.

--- a/pkg/proto/ternv1/tern.pb.go
+++ b/pkg/proto/ternv1/tern.pb.go
@@ -1671,9 +1671,11 @@ type ApplyResponse struct {
 	Accepted     bool                   `protobuf:"varint,1,opt,name=accepted,proto3" json:"accepted,omitempty"`
 	ErrorMessage string                 `protobuf:"bytes,2,opt,name=error_message,json=errorMessage,proto3" json:"error_message,omitempty"`
 	// The apply identifier for tracking this schema change.
-	ApplyId       string `protobuf:"bytes,3,opt,name=apply_id,json=applyId,proto3" json:"apply_id,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	ApplyId string `protobuf:"bytes,3,opt,name=apply_id,json=applyId,proto3" json:"apply_id,omitempty"`
+	// The apply_operation identifier for operation-scoped callers.
+	ApplyOperationId string `protobuf:"bytes,4,opt,name=apply_operation_id,json=applyOperationId,proto3" json:"apply_operation_id,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
 }
 
 func (x *ApplyResponse) Reset() {
@@ -1723,6 +1725,13 @@ func (x *ApplyResponse) GetErrorMessage() string {
 func (x *ApplyResponse) GetApplyId() string {
 	if x != nil {
 		return x.ApplyId
+	}
+	return ""
+}
+
+func (x *ApplyResponse) GetApplyOperationId() string {
+	if x != nil {
+		return x.ApplyOperationId
 	}
 	return ""
 }
@@ -3115,11 +3124,12 @@ const file_tern_proto_rawDesc = "" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\x1aT\n" +
 	"\x10SchemaFilesEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12*\n" +
-	"\x05value\x18\x02 \x01(\v2\x14.tern.v1.SchemaFilesR\x05value:\x028\x01\"k\n" +
+	"\x05value\x18\x02 \x01(\v2\x14.tern.v1.SchemaFilesR\x05value:\x028\x01\"\x99\x01\n" +
 	"\rApplyResponse\x12\x1a\n" +
 	"\baccepted\x18\x01 \x01(\bR\baccepted\x12#\n" +
 	"\rerror_message\x18\x02 \x01(\tR\ferrorMessage\x12\x19\n" +
-	"\bapply_id\x18\x03 \x01(\tR\aapplyId\"N\n" +
+	"\bapply_id\x18\x03 \x01(\tR\aapplyId\x12,\n" +
+	"\x12apply_operation_id\x18\x04 \x01(\tR\x10applyOperationId\"N\n" +
 	"\x0fProgressRequest\x12\x19\n" +
 	"\bapply_id\x18\x01 \x01(\tR\aapplyId\x12 \n" +
 	"\venvironment\x18\x02 \x01(\tR\venvironment\"\xa7\x02\n" +

--- a/pkg/schema/mysql/apply_operations.sql
+++ b/pkg/schema/mysql/apply_operations.sql
@@ -5,6 +5,8 @@ CREATE TABLE `apply_operations` (
   `operation_key` varchar(255) NOT NULL DEFAULT '',
   `operation_kind` varchar(32) NOT NULL DEFAULT 'work',
   `target` varchar(255) NOT NULL DEFAULT '',
+  `external_id` varchar(255) DEFAULT NULL,
+  `external_operation_id` varchar(255) DEFAULT NULL,
   `engine_resume_context` varchar(255) DEFAULT NULL,
   `engine_resume_metadata` json DEFAULT NULL,
   `state` varchar(100) NOT NULL DEFAULT 'pending',

--- a/pkg/storage/mysqlstore/applies.go
+++ b/pkg/storage/mysqlstore/applies.go
@@ -1062,6 +1062,14 @@ func (s *applyStore) GetRecent(ctx context.Context, filter storage.RecentApplies
 		where = append(where, "environment = ?")
 		args = append(args, filter.Environment)
 	}
+	if filter.Deployment != "" {
+		where = append(where, `(deployment = ? OR EXISTS (
+			SELECT 1
+			FROM apply_operations ao
+			WHERE ao.apply_id = applies.id AND ao.deployment = ?
+		))`)
+		args = append(args, filter.Deployment, filter.Deployment)
+	}
 	if len(filter.States) > 0 {
 		where = append(where, fmt.Sprintf("state IN (%s)", placeholders(len(filter.States))))
 		args = append(args, stringArgs(filter.States)...)

--- a/pkg/storage/mysqlstore/applies_test.go
+++ b/pkg/storage/mysqlstore/applies_test.go
@@ -1253,6 +1253,40 @@ func TestApplyStore_GetRecentLimitAndEnvironment(t *testing.T) {
 	assert.Equal(t, "apply_recent_staging_failed", applies[0].ApplyIdentifier)
 }
 
+func TestApplyStore_GetRecentDeploymentFilterMatchesParentAndOperation(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "recentdeploydb", "mysql", "staging")
+	createTestApplyWithStateEnvDeployment(t, store, lock, "apply_recent_parent_deployment", 214, state.Apply.Completed, "staging", "deploy-a")
+
+	operationMatch := createTestApplyWithStateEnvDeployment(t, store, lock, "apply_recent_operation_deployment", 215, state.Apply.Completed, "staging", "deploy-parent")
+	_, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID:             operationMatch.ID,
+		Deployment:          "deploy-a",
+		OperationKey:        "",
+		OperationKind:       storage.ApplyOperationKindWork,
+		Target:              "target-a",
+		State:               state.Apply.Completed,
+		CutoverPolicy:       storage.CutoverPolicyRolling,
+		OnFailure:           storage.OnFailureHalt,
+		EngineResumeContext: "remote-operation-1",
+	})
+	require.NoError(t, err)
+
+	createTestApplyWithStateEnvDeployment(t, store, lock, "apply_recent_other_deployment", 216, state.Apply.Completed, "staging", "deploy-b")
+
+	applies, err := store.Applies().GetRecent(ctx, storage.RecentAppliesFilter{
+		Limit:      10,
+		Deployment: "deploy-a",
+	})
+	require.NoError(t, err)
+	require.Len(t, applies, 2)
+	assert.Equal(t, "apply_recent_operation_deployment", applies[0].ApplyIdentifier)
+	assert.Equal(t, "apply_recent_parent_deployment", applies[1].ApplyIdentifier)
+}
+
 func TestApplyStore_Update(t *testing.T) {
 	clearTables(t)
 	ctx := t.Context()
@@ -3037,6 +3071,11 @@ func createTestApplyWithEnv(t *testing.T, store *Storage, lock *storage.Lock, ap
 
 func createTestApplyWithStateAndEnv(t *testing.T, store *Storage, lock *storage.Lock, applyID string, planID int64, applyState, env string) *storage.Apply {
 	t.Helper()
+	return createTestApplyWithStateEnvDeployment(t, store, lock, applyID, planID, applyState, env, "")
+}
+
+func createTestApplyWithStateEnvDeployment(t *testing.T, store *Storage, lock *storage.Lock, applyID string, planID int64, applyState, env, deployment string) *storage.Apply {
+	t.Helper()
 	ctx := t.Context()
 
 	apply := &storage.Apply{
@@ -3048,6 +3087,7 @@ func createTestApplyWithStateAndEnv(t *testing.T, store *Storage, lock *storage.
 		Repository:      lock.Repository,
 		PullRequest:     lock.PullRequest,
 		Environment:     env,
+		Deployment:      deployment,
 		Engine:          storage.EngineForType(lock.DatabaseType),
 		State:           applyState,
 	}

--- a/pkg/storage/mysqlstore/apply_operations.go
+++ b/pkg/storage/mysqlstore/apply_operations.go
@@ -8,6 +8,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -18,7 +19,7 @@ import (
 )
 
 // applyOperationColumns lists all columns for SELECT queries.
-const applyOperationColumns = `id, apply_id, deployment, operation_key, operation_kind, target, state, error_message,
+const applyOperationColumns = `id, apply_id, deployment, operation_key, operation_kind, target, external_id, external_operation_id, state, error_message,
 	cutover_policy, on_failure, attempt, started_at, completed_at, lease_owner, lease_token, lease_acquired_at,
 	engine_resume_context, engine_resume_metadata, created_at, updated_at`
 
@@ -75,11 +76,11 @@ func insertApplyOperation(ctx context.Context, exec sqlExecer, ad *storage.Apply
 
 	result, err := exec.ExecContext(ctx, `
 		INSERT INTO apply_operations (
-			apply_id, deployment, operation_key, operation_kind, target, state, error_message, cutover_policy, on_failure,
+			apply_id, deployment, operation_key, operation_kind, target, external_id, external_operation_id, state, error_message, cutover_policy, on_failure,
 			started_at, completed_at, engine_resume_context, engine_resume_metadata
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`,
-		ad.ApplyID, ad.Deployment, ad.OperationKey, operationKind, ad.Target, stateVal, nullString(ad.ErrorMessage), cutoverPolicy, onFailure,
+		ad.ApplyID, ad.Deployment, ad.OperationKey, operationKind, ad.Target, nullString(ad.ExternalID), nullString(ad.ExternalOperationID), stateVal, nullString(ad.ErrorMessage), cutoverPolicy, onFailure,
 		ad.StartedAt, ad.CompletedAt, nullString(ad.EngineResumeContext), nullString(ad.EngineResumeMetadata),
 	)
 	if err != nil {
@@ -142,6 +143,31 @@ func (s *applyOperationStore) ListByApply(ctx context.Context, applyID int64) ([
 	`, applyID)
 	if err != nil {
 		return nil, fmt.Errorf("query apply_operations for apply %d: %w", applyID, err)
+	}
+	defer utils.CloseAndLog(rows)
+
+	return scanApplyOperations(rows)
+}
+
+// ListByApplies returns all child rows for the requested applies in
+// (apply_id, created_at, id) order.
+func (s *applyOperationStore) ListByApplies(ctx context.Context, applyIDs []int64) ([]*storage.ApplyOperation, error) {
+	if len(applyIDs) == 0 {
+		return nil, nil
+	}
+	placeholders := strings.TrimRight(strings.Repeat("?,", len(applyIDs)), ",")
+	args := make([]any, 0, len(applyIDs))
+	for _, applyID := range applyIDs {
+		args = append(args, applyID)
+	}
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT `+applyOperationColumns+`
+		FROM apply_operations
+		WHERE apply_id IN (`+placeholders+`)
+		ORDER BY apply_id, created_at, id
+	`, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query apply_operations for %d applies: %w", len(applyIDs), err)
 	}
 	defer utils.CloseAndLog(rows)
 
@@ -441,6 +467,54 @@ func (s *applyOperationStore) MarkFailed(ctx context.Context, id int64, errMsg s
 func (s *applyOperationStore) MarkTerminal(ctx context.Context, id int64, newState string) error {
 	return s.execStateUpdate(ctx, id, fmt.Sprintf("mark apply_operation terminal (state=%s)", newState),
 		"ao.state = ?, ao.completed_at = COALESCE(ao.completed_at, NOW())", newState)
+}
+
+// SaveExternalOperationID stores the remote data plane's apply_operation_id on
+// the operation row. It refuses empty IDs so callers do not convert a missing
+// remote field into an apparent successful correlation.
+func (s *applyOperationStore) SaveExternalOperationID(ctx context.Context, operationID int64, externalOperationID string) error {
+	if externalOperationID == "" {
+		return fmt.Errorf("save external operation id for apply_operation %d: external operation id is empty", operationID)
+	}
+	guard, err := operationWriteGuardFromContext(ctx)
+	if err != nil {
+		return err
+	}
+	args := append([]any{externalOperationID, operationID}, guard.args()...)
+	result, err := s.db.ExecContext(ctx, `
+		UPDATE apply_operations ao
+		`+guard.join()+`
+		SET ao.external_operation_id = ?
+		WHERE ao.id = ?`+guard.predicate()+`
+	`, args...)
+	if err != nil {
+		return fmt.Errorf("save external operation id for apply_operation %d: %w", operationID, err)
+	}
+	return s.checkUpdatedOrExists(ctx, result, operationID, guard, false)
+}
+
+// SaveExternalID stores the remote data plane's apply_id on the operation row.
+// It refuses empty IDs so callers do not convert a missing remote field into an
+// apparent successful correlation.
+func (s *applyOperationStore) SaveExternalID(ctx context.Context, operationID int64, externalID string) error {
+	if externalID == "" {
+		return fmt.Errorf("save external id for apply_operation %d: external id is empty", operationID)
+	}
+	guard, err := operationWriteGuardFromContext(ctx)
+	if err != nil {
+		return err
+	}
+	args := append([]any{externalID, operationID}, guard.args()...)
+	result, err := s.db.ExecContext(ctx, `
+		UPDATE apply_operations ao
+		`+guard.join()+`
+		SET ao.external_id = ?
+		WHERE ao.id = ?`+guard.predicate()+`
+	`, args...)
+	if err != nil {
+		return fmt.Errorf("save external id for apply_operation %d: %w", operationID, err)
+	}
+	return s.checkUpdatedOrExists(ctx, result, operationID, guard, false)
 }
 
 // SaveEngineResumeState stores opaque engine state on the operation that owns
@@ -1375,11 +1449,13 @@ func scanApplyOperations(rows *sql.Rows) ([]*storage.ApplyOperation, error) {
 func scanApplyOperationInto(s scanner) (*storage.ApplyOperation, error) {
 	var ad storage.ApplyOperation
 	var errMsg sql.NullString
+	var externalID sql.NullString
+	var externalOperationID sql.NullString
 	var engineResumeContext, engineResumeMetadata sql.NullString
 	var startedAt, completedAt, leaseAcquiredAt sql.NullTime
 
 	if err := s.Scan(
-		&ad.ID, &ad.ApplyID, &ad.Deployment, &ad.OperationKey, &ad.OperationKind, &ad.Target, &ad.State, &errMsg,
+		&ad.ID, &ad.ApplyID, &ad.Deployment, &ad.OperationKey, &ad.OperationKind, &ad.Target, &externalID, &externalOperationID, &ad.State, &errMsg,
 		&ad.CutoverPolicy, &ad.OnFailure, &ad.Attempt, &startedAt, &completedAt, &ad.LeaseOwner, &ad.LeaseToken, &leaseAcquiredAt,
 		&engineResumeContext, &engineResumeMetadata, &ad.CreatedAt, &ad.UpdatedAt,
 	); err != nil {
@@ -1388,6 +1464,12 @@ func scanApplyOperationInto(s scanner) (*storage.ApplyOperation, error) {
 
 	if errMsg.Valid {
 		ad.ErrorMessage = errMsg.String
+	}
+	if externalID.Valid {
+		ad.ExternalID = externalID.String
+	}
+	if externalOperationID.Valid {
+		ad.ExternalOperationID = externalOperationID.String
 	}
 	if startedAt.Valid {
 		t := startedAt.Time

--- a/pkg/storage/mysqlstore/apply_operations_test.go
+++ b/pkg/storage/mysqlstore/apply_operations_test.go
@@ -26,9 +26,11 @@ func TestApplyOperationStore_InsertAndGet(t *testing.T) {
 	apply := createTestApply(t, store, lock, "apply_md_insert", 1)
 
 	ad := &storage.ApplyOperation{
-		ApplyID:    apply.ID,
-		Deployment: "region-a",
-		Target:     "payments",
+		ApplyID:             apply.ID,
+		Deployment:          "region-a",
+		Target:              "payments",
+		ExternalID:          "remote-apply-a",
+		ExternalOperationID: "remote-operation-a",
 	}
 
 	id, err := store.ApplyOperations().Insert(ctx, ad)
@@ -43,6 +45,8 @@ func TestApplyOperationStore_InsertAndGet(t *testing.T) {
 	assert.Equal(t, apply.ID, got.ApplyID)
 	assert.Equal(t, "region-a", got.Deployment)
 	assert.Equal(t, "payments", got.Target)
+	assert.Equal(t, "remote-apply-a", got.ExternalID)
+	assert.Equal(t, "remote-operation-a", got.ExternalOperationID)
 	assert.Equal(t, state.ApplyOperation.Pending, got.State)
 	assert.Equal(t, storage.ApplyOperationKindWork, got.OperationKind)
 	assert.Equal(t, storage.CutoverPolicyRolling, got.CutoverPolicy, "an unset cutover_policy defaults to rolling")
@@ -53,6 +57,52 @@ func TestApplyOperationStore_InsertAndGet(t *testing.T) {
 	assert.Empty(t, got.EngineResumeMetadata)
 	assert.NotZero(t, got.CreatedAt)
 	assert.NotZero(t, got.UpdatedAt)
+}
+
+func TestApplyOperationStore_SaveExternalOperationID(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", "mysql", "staging")
+	apply := createTestApply(t, store, lock, "apply_save_external_operation", 1)
+
+	operationID, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID:    apply.ID,
+		Deployment: "region-a",
+		Target:     "payments",
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, store.ApplyOperations().SaveExternalOperationID(ctx, operationID, "remote-operation-1"))
+
+	got, err := store.ApplyOperations().Get(ctx, operationID)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "remote-operation-1", got.ExternalOperationID)
+}
+
+func TestApplyOperationStore_SaveExternalID(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", "mysql", "staging")
+	apply := createTestApply(t, store, lock, "apply_save_operation_external", 1)
+
+	operationID, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID:    apply.ID,
+		Deployment: "region-a",
+		Target:     "payments",
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, store.ApplyOperations().SaveExternalID(ctx, operationID, "remote-apply-1"))
+
+	got, err := store.ApplyOperations().Get(ctx, operationID)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "remote-apply-1", got.ExternalID)
 }
 
 func TestApplyOperationStore_OperationKindRoundTrip(t *testing.T) {

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -350,6 +350,7 @@ type ApplyOperationWithTasks struct {
 type RecentAppliesFilter struct {
 	Limit       int
 	Environment string
+	Deployment  string
 	States      []string
 }
 
@@ -474,6 +475,10 @@ type ApplyOperationStore interface {
 	// ListByApply returns all child rows for an apply in (created_at, id) order.
 	ListByApply(ctx context.Context, applyID int64) ([]*ApplyOperation, error)
 
+	// ListByApplies returns all child rows for the requested applies in
+	// (apply_id, created_at, id) order.
+	ListByApplies(ctx context.Context, applyIDs []int64) ([]*ApplyOperation, error)
+
 	// UpdateState transitions a child row to a new state. Updates the state
 	// column only; for transitions that should also stamp started_at or
 	// completed_at, use MarkStarted / MarkCompleted / MarkFailed instead.
@@ -494,6 +499,14 @@ type ApplyOperationStore interface {
 	// completed_at nil (use UpdateState). Use MarkCompleted / MarkFailed for
 	// completed / failed.
 	MarkTerminal(ctx context.Context, id int64, newState string) error
+
+	// SaveExternalOperationID stores the remote data plane's apply_operation_id
+	// on the operation that owns the dispatch.
+	SaveExternalOperationID(ctx context.Context, operationID int64, externalOperationID string) error
+
+	// SaveExternalID stores the remote data plane's apply_id on the operation
+	// that owns the dispatch.
+	SaveExternalID(ctx context.Context, operationID int64, externalID string) error
 
 	// SaveEngineResumeState stores opaque engine resume state on the operation.
 	SaveEngineResumeState(ctx context.Context, operationID int64, resumeState *EngineResumeState) error

--- a/pkg/storage/types.go
+++ b/pkg/storage/types.go
@@ -600,14 +600,14 @@ type ApplyOperation struct {
 	// semantics. Empty for legacy / single-deployment shapes.
 	Target string
 
-	// ExternalID is the remote data plane's apply_id for this operation. It is
-	// scoped to the operation because a multi-operation parent apply has no
-	// single authoritative remote apply id.
+	// ExternalID is the remote data plane's stable apply identifier for this
+	// operation. It is scoped to the operation because a multi-operation parent
+	// apply has no single authoritative remote apply identifier.
 	ExternalID string
 
-	// ExternalOperationID is the remote data plane's apply_operation_id for this
-	// operation. Empty for local applies and for remote data planes that do not
-	// return operation IDs.
+	// ExternalOperationID is the remote data plane's numeric operation row ID for
+	// this operation. Empty for local applies and for remote data planes that do
+	// not return operation IDs.
 	ExternalOperationID string
 
 	// State is the per-operation state machine value. See state.ApplyOperation.

--- a/pkg/storage/types.go
+++ b/pkg/storage/types.go
@@ -600,6 +600,16 @@ type ApplyOperation struct {
 	// semantics. Empty for legacy / single-deployment shapes.
 	Target string
 
+	// ExternalID is the remote data plane's apply_id for this operation. It is
+	// scoped to the operation because a multi-operation parent apply has no
+	// single authoritative remote apply id.
+	ExternalID string
+
+	// ExternalOperationID is the remote data plane's apply_operation_id for this
+	// operation. Empty for local applies and for remote data planes that do not
+	// return operation IDs.
+	ExternalOperationID string
+
 	// State is the per-operation state machine value. See state.ApplyOperation.
 	State string
 

--- a/pkg/tern/grpc_client.go
+++ b/pkg/tern/grpc_client.go
@@ -965,9 +965,9 @@ func (c *GRPCClient) Health(ctx context.Context) error {
 // operation-scoped value restricts the drive to a single apply_operation (one
 // deployment) so a driver can advance one deployment independently of its
 // siblings; when the parent owns more than one operation it also routes the
-// remote apply id through that operation's engine_resume_context instead of the
-// shared parent external_id, so one deployment never reuses or overwrites
-// another deployment's remote apply id.
+// remote apply id through that operation's external_id instead of the shared
+// parent external_id, so one deployment never reuses or overwrites another
+// deployment's remote apply id.
 type applyTaskScope struct {
 	applyOperationID int64
 
@@ -991,9 +991,9 @@ func (s applyTaskScope) isOperationScoped() bool {
 }
 
 // usesOperationRemoteResume reports whether the remote apply id for this drive
-// lives on the claimed operation's engine_resume_context rather than the parent
-// applies.external_id. Only multi-operation drives do; single-operation and
-// whole-apply drives keep using the parent external_id.
+// lives on the claimed operation rather than the parent applies.external_id.
+// Only multi-operation drives do; single-operation and whole-apply drives keep
+// using the parent external_id.
 func (s applyTaskScope) usesOperationRemoteResume() bool {
 	return s.multiOperation && s.operation != nil
 }
@@ -1022,10 +1022,13 @@ func (s applyTaskScope) finalizerOperationScope() bool {
 
 // remoteApplyID resolves the remote Tern apply id sent on this drive's
 // Progress/Stop/Start/Cutover calls. Multi-operation drives read the claimed
-// operation's engine_resume_context (which may be empty before dispatch);
-// everything else reads the parent external_id.
+// operation's external_id (which may be empty before dispatch); everything
+// else reads the parent external_id.
 func (s applyTaskScope) remoteApplyID(apply *storage.Apply) string {
 	if s.usesOperationRemoteResume() {
+		if s.operation.ExternalID != "" {
+			return s.operation.ExternalID
+		}
 		return s.operation.EngineResumeContext
 	}
 	return apply.ExternalID
@@ -1114,10 +1117,10 @@ func remoteApplyIdempotencyKey(apply *storage.Apply, scope applyTaskScope) strin
 // persistRemoteApplyID stores the remote Tern apply id returned by dispatch.
 // Single-operation drives keep it on the parent applies.external_id (mutated in
 // place so the caller's Applies().Update persists it). Multi-operation drives
-// write it to the claimed operation's engine_resume_context and never touch the
-// parent external_id, refusing to overwrite a different existing id so one
-// deployment can't clobber another deployment's remote apply id.
-func (c *GRPCClient) persistRemoteApplyID(ctx context.Context, apply *storage.Apply, scope applyTaskScope, remoteID string) error {
+// write it to the claimed operation's external_id and never touch the parent
+// external_id, refusing to overwrite a different existing id so one deployment
+// can't clobber another deployment's remote apply id.
+func (c *GRPCClient) persistRemoteApplyID(ctx context.Context, apply *storage.Apply, scope applyTaskScope, remoteID, remoteOperationID string) error {
 	if remoteID == "" {
 		return fmt.Errorf("refusing to persist empty remote apply id for apply %s", apply.ApplyIdentifier)
 	}
@@ -1133,17 +1136,26 @@ func (c *GRPCClient) persistRemoteApplyID(ctx context.Context, apply *storage.Ap
 	if current.ApplyID != apply.ID {
 		return fmt.Errorf("apply_operation %d belongs to apply %d, not %s (%d)", op.ID, current.ApplyID, apply.ApplyIdentifier, apply.ID)
 	}
-	if current.EngineResumeContext != "" && current.EngineResumeContext != remoteID {
-		return fmt.Errorf("apply_operation %d already has remote apply id %q; refusing to overwrite with %q", op.ID, current.EngineResumeContext, remoteID)
+	currentRemoteID := current.ExternalID
+	if currentRemoteID == "" {
+		currentRemoteID = current.EngineResumeContext
 	}
-	if err := c.storage.ApplyOperations().SaveEngineResumeState(ctx, op.ID, &storage.EngineResumeState{
-		ApplyOperationID: op.ID,
-		MigrationContext: remoteID,
-		Metadata:         "{}",
-	}); err != nil {
+	if currentRemoteID != "" && currentRemoteID != remoteID {
+		return fmt.Errorf("apply_operation %d already has remote apply id %q; refusing to overwrite with %q", op.ID, currentRemoteID, remoteID)
+	}
+	if remoteOperationID != "" && current.ExternalOperationID != "" && current.ExternalOperationID != remoteOperationID {
+		return fmt.Errorf("apply_operation %d already has remote apply_operation id %q; refusing to overwrite with %q", op.ID, current.ExternalOperationID, remoteOperationID)
+	}
+	if err := c.storage.ApplyOperations().SaveExternalID(ctx, op.ID, remoteID); err != nil {
 		return fmt.Errorf("store remote apply id for apply_operation %d: %w", op.ID, err)
 	}
-	op.EngineResumeContext = remoteID
+	op.ExternalID = remoteID
+	if remoteOperationID != "" {
+		if err := c.storage.ApplyOperations().SaveExternalOperationID(ctx, op.ID, remoteOperationID); err != nil {
+			return fmt.Errorf("store remote apply_operation id for apply_operation %d: %w", op.ID, err)
+		}
+		op.ExternalOperationID = remoteOperationID
+	}
 	return nil
 }
 
@@ -1296,7 +1308,7 @@ func (c *GRPCClient) dispatchRemoteGroupFinalizer(ctx context.Context, apply *st
 			}
 			return fmt.Errorf("dispatch group_finalizer apply_operation %d (apply %s): %s", op.ID, apply.ApplyIdentifier, errMsg)
 		}
-		if err := c.persistRemoteApplyID(ctx, apply, scope, resp.ApplyId); err != nil {
+		if err := c.persistRemoteApplyID(ctx, apply, scope, resp.ApplyId, resp.ApplyOperationId); err != nil {
 			return fmt.Errorf("store remote apply id for group_finalizer apply_operation %d: %w", op.ID, err)
 		}
 	}
@@ -1986,7 +1998,7 @@ func (c *GRPCClient) dispatchPendingApply(ctx context.Context, apply *storage.Ap
 	// after this point can resume the exact remote operation instead of
 	// dispatching a duplicate. Multi-operation drives store it on the claimed
 	// operation row; single-operation drives mutate apply.ExternalID in place.
-	if err := c.persistRemoteApplyID(ctx, apply, scope, resp.ApplyId); err != nil {
+	if err := c.persistRemoteApplyID(ctx, apply, scope, resp.ApplyId, resp.ApplyOperationId); err != nil {
 		return fmt.Errorf("store remote apply id for %s: %w", apply.ApplyIdentifier, err)
 	}
 	apply.State = state.InitialActiveApplyState(apply.Engine)

--- a/pkg/tern/grpc_client.go
+++ b/pkg/tern/grpc_client.go
@@ -1156,6 +1156,14 @@ func (c *GRPCClient) persistRemoteApplyID(ctx context.Context, apply *storage.Ap
 		}
 		op.ExternalOperationID = remoteOperationID
 	}
+	slog.InfoContext(ctx, "stored remote gRPC apply identifiers for operation",
+		"apply_id", apply.ApplyIdentifier,
+		"apply_operation_id", op.ID,
+		"deployment", op.Deployment,
+		"operation_key", op.OperationKey,
+		"operation_kind", op.OperationKind,
+		"external_id", remoteID,
+		"external_operation_id", remoteOperationID)
 	return nil
 }
 

--- a/pkg/tern/grpc_client_test.go
+++ b/pkg/tern/grpc_client_test.go
@@ -450,26 +450,27 @@ func TestGRPCClient_Close(t *testing.T) {
 // server defaults to STATE_COMPLETED.
 type capturingTernServer struct {
 	ternv1.UnimplementedTernServer
-	mu               sync.Mutex
-	applyReq         *ternv1.ApplyRequest
-	applyErr         error
-	remoteApplyID    string
-	stopApplyID      string
-	startApplyID     string
-	cutoverApplyID   string
-	progressApplyID  string
-	progressReq      *ternv1.ProgressRequest
-	progressState    ternv1.State // state returned by Progress; 0 = STATE_COMPLETED
-	progressStateSet bool
-	progressStates   []ternv1.State
-	progressTables   []*ternv1.TableProgress
-	progressError    string
-	progressErr      error
-	startErr         error
-	cutoverErr       error
-	cutoverAccepted  bool
-	cutoverMessage   string
-	startCalled      bool // tracks whether Start was actually invoked
+	mu                sync.Mutex
+	applyReq          *ternv1.ApplyRequest
+	applyErr          error
+	remoteApplyID     string
+	remoteOperationID string
+	stopApplyID       string
+	startApplyID      string
+	cutoverApplyID    string
+	progressApplyID   string
+	progressReq       *ternv1.ProgressRequest
+	progressState     ternv1.State // state returned by Progress; 0 = STATE_COMPLETED
+	progressStateSet  bool
+	progressStates    []ternv1.State
+	progressTables    []*ternv1.TableProgress
+	progressError     string
+	progressErr       error
+	startErr          error
+	cutoverErr        error
+	cutoverAccepted   bool
+	cutoverMessage    string
+	startCalled       bool // tracks whether Start was actually invoked
 }
 
 func (s *capturingTernServer) Apply(_ context.Context, req *ternv1.ApplyRequest) (*ternv1.ApplyResponse, error) {
@@ -479,12 +480,13 @@ func (s *capturingTernServer) Apply(_ context.Context, req *ternv1.ApplyRequest)
 	if applyID == "" {
 		applyID = "remote-apply-123"
 	}
+	operationID := s.remoteOperationID
 	err := s.applyErr
 	s.mu.Unlock()
 	if err != nil {
 		return nil, err
 	}
-	return &ternv1.ApplyResponse{Accepted: true, ApplyId: applyID}, nil
+	return &ternv1.ApplyResponse{Accepted: true, ApplyId: applyID, ApplyOperationId: operationID}, nil
 }
 
 func (s *capturingTernServer) Start(_ context.Context, req *ternv1.StartRequest) (*ternv1.StartResponse, error) {
@@ -689,7 +691,7 @@ type mockStorage struct {
 
 // mockApplyOperationStore is an in-memory ApplyOperationStore for the remote
 // drive tests. It backs the operation lookups (Get/ListByApply) and the per-op
-// remote resume id write (SaveEngineResumeState) that the fan-out drive uses.
+// remote identifier writes that the fan-out drive uses.
 type mockApplyOperationStore struct {
 	storage.ApplyOperationStore
 	ops          map[int64]*storage.ApplyOperation
@@ -709,6 +711,20 @@ func (m *mockApplyOperationStore) ListByApply(_ context.Context, applyID int64) 
 	var ops []*storage.ApplyOperation
 	for _, op := range m.ops {
 		if op != nil && op.ApplyID == applyID {
+			ops = append(ops, op)
+		}
+	}
+	return ops, nil
+}
+
+func (m *mockApplyOperationStore) ListByApplies(_ context.Context, applyIDs []int64) ([]*storage.ApplyOperation, error) {
+	applyIDSet := make(map[int64]bool, len(applyIDs))
+	for _, applyID := range applyIDs {
+		applyIDSet[applyID] = true
+	}
+	var ops []*storage.ApplyOperation
+	for _, op := range m.ops {
+		if op != nil && applyIDSet[op.ApplyID] {
 			ops = append(ops, op)
 		}
 	}
@@ -755,6 +771,30 @@ func (m *mockApplyOperationStore) MarkFailed(_ context.Context, id int64, errMsg
 	op.State = state.ApplyOperation.Failed
 	op.ErrorMessage = errMsg
 	op.CompletedAt = &now
+	return nil
+}
+
+func (m *mockApplyOperationStore) SaveExternalOperationID(_ context.Context, operationID int64, externalOperationID string) error {
+	if m.saveErr != nil {
+		return m.saveErr
+	}
+	op, ok := m.ops[operationID]
+	if !ok {
+		return storage.ErrApplyOperationNotFound
+	}
+	op.ExternalOperationID = externalOperationID
+	return nil
+}
+
+func (m *mockApplyOperationStore) SaveExternalID(_ context.Context, operationID int64, externalID string) error {
+	if m.saveErr != nil {
+		return m.saveErr
+	}
+	op, ok := m.ops[operationID]
+	if !ok {
+		return storage.ErrApplyOperationNotFound
+	}
+	op.ExternalID = externalID
 	return nil
 }
 
@@ -1309,11 +1349,14 @@ func TestGRPCClient_ResumeApplyOperationDispatchDoesNotDeferRollingCutover(t *te
 
 func TestGRPCClient_ResumeApplyOperationStoresRemoteIDOnOperationForMultiOpApply(t *testing.T) {
 	// On a multi-deployment apply, each deployment gets its own remote Tern apply
-	// id. Dispatching one operation must store its remote id on that operation's
-	// engine_resume_context and must NOT touch the parent applies.external_id,
-	// which has no single authoritative value across deployments.
+	// id and remote apply_operation id. Dispatching one operation must store the
+	// remote apply id on that operation's external_id, store the remote
+	// operation id separately for operator UX, and must NOT touch the parent
+	// applies.external_id, which has no single authoritative value across
+	// deployments.
 	server := &capturingTernServer{
-		remoteApplyID: "remote-op-west-1",
+		remoteApplyID:     "remote-op-west-1",
+		remoteOperationID: "remote-operation-west-1",
 		progressTables: []*ternv1.TableProgress{{
 			Namespace:       "default",
 			TableName:       "users",
@@ -1373,18 +1416,89 @@ func TestGRPCClient_ResumeApplyOperationStoresRemoteIDOnOperationForMultiOpApply
 
 	assert.Empty(t, applyStore.updates, "a multi-op drive must never write the parent applies row directly; parent state is owned by the projection CAS")
 	assert.Empty(t, apply.ExternalID, "multi-op dispatch must not write the parent apply external_id")
-	assert.Equal(t, "remote-op-west-1", operationStore.ops[operationID].EngineResumeContext,
+	assert.Equal(t, "remote-op-west-1", operationStore.ops[operationID].ExternalID,
 		"the remote apply id must be stored on the claimed operation")
-	assert.Empty(t, operationStore.ops[siblingID].EngineResumeContext,
+	assert.Empty(t, operationStore.ops[operationID].EngineResumeContext,
+		"new remote dispatches must not store data-plane apply ids in opaque engine resume context")
+	assert.Equal(t, "remote-operation-west-1", operationStore.ops[operationID].ExternalOperationID,
+		"the remote apply_operation id must be stored on the claimed operation")
+	assert.Empty(t, operationStore.ops[siblingID].ExternalID,
 		"the sibling operation's remote id must be untouched")
-	require.Len(t, operationStore.savedResumes, 1)
-	assert.Equal(t, operationID, operationStore.savedResumes[0].ApplyOperationID)
-	assert.Equal(t, "remote-op-west-1", operationStore.savedResumes[0].MigrationContext)
+	assert.Empty(t, operationStore.ops[siblingID].ExternalOperationID,
+		"the sibling operation's remote operation id must be untouched")
+	assert.Empty(t, operationStore.savedResumes)
 
 	req := server.getApplyRequest()
 	require.NotNil(t, req)
 	require.Len(t, req.DdlChanges, 1)
 	assert.Equal(t, "users", req.DdlChanges[0].TableName)
+}
+
+func TestGRPCClient_ResumeApplyOperationRefusesExternalOperationIDMismatch(t *testing.T) {
+	server := &capturingTernServer{
+		remoteApplyID:     "remote-op-west-1",
+		remoteOperationID: "remote-operation-west-2",
+		progressTables: []*ternv1.TableProgress{{
+			Namespace:       "default",
+			TableName:       "users",
+			Status:          state.Task.Completed,
+			PercentComplete: 100,
+		}},
+	}
+	client, cleanup := testCapturingGRPCClient(t, server)
+	defer cleanup()
+
+	apply := &storage.Apply{
+		ID:              7,
+		ApplyIdentifier: "apply-multi-op-mismatch",
+		PlanID:          99,
+		Database:        "testdb",
+		DatabaseType:    storage.DatabaseTypeMySQL,
+		Environment:     "staging",
+		State:           state.Apply.Pending,
+	}
+	apply.SetOptions(storage.ApplyOptions{Target: "testdb-target"})
+	operationID := int64(42)
+	task := &storage.Task{
+		ID:               11,
+		TaskIdentifier:   "task-users",
+		ApplyID:          apply.ID,
+		ApplyOperationID: &operationID,
+		TableName:        "users",
+		DDL:              "ALTER TABLE users ADD COLUMN email varchar(255)",
+		DDLAction:        "alter",
+		Namespace:        "default",
+		State:            state.Task.Pending,
+	}
+	operationStore := &mockApplyOperationStore{ops: map[int64]*storage.ApplyOperation{
+		operationID: {
+			ID:                  operationID,
+			ApplyID:             apply.ID,
+			Deployment:          "west",
+			State:               state.ApplyOperation.Pending,
+			ExternalOperationID: "remote-operation-west-1",
+		},
+		43: {ID: 43, ApplyID: apply.ID, Deployment: "east", State: state.ApplyOperation.Pending},
+	}}
+	client.storage = &mockStorage{
+		applies: &mockApplyStore{apply: apply},
+		tasks: &mockTaskStore{
+			tasks:           []*storage.Task{task},
+			getByApplyIDErr: errors.New("whole-apply task load must not be used for operation-scoped resume"),
+		},
+		plans: &mockPlanStore{plan: &storage.Plan{
+			ID:             apply.PlanID,
+			PlanIdentifier: "plan-multi-op-mismatch",
+		}},
+		operations: operationStore,
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+	err := client.ResumeApplyOperation(ctx, apply, operationID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already has remote apply_operation id")
+	assert.Equal(t, "remote-operation-west-1", operationStore.ops[operationID].ExternalOperationID)
 }
 
 func TestGRPCClient_ResumeApplyOperationStartsQueuedRemoteWithoutWritingParent(t *testing.T) {

--- a/pkg/tern/local_client.go
+++ b/pkg/tern/local_client.go
@@ -93,6 +93,7 @@ import (
 	"log/slog"
 	"maps"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -1700,7 +1701,11 @@ func (c *LocalClient) Apply(ctx context.Context, req *ternv1.ApplyRequest) (*ter
 			"state", existing.State,
 		)
 		metrics.RecordRemoteApplyDedup(ctx, req.Database, req.Environment, "hit")
-		return &ternv1.ApplyResponse{Accepted: true, ApplyId: existing.ApplyIdentifier}, nil
+		applyOperationID, err := c.applyResponseOperationID(ctx, existing)
+		if err != nil {
+			return nil, err
+		}
+		return &ternv1.ApplyResponse{Accepted: true, ApplyId: existing.ApplyIdentifier, ApplyOperationId: applyOperationID}, nil
 	}
 
 	// Look up the plan, materializing it from the dispatch request when this
@@ -1760,7 +1765,11 @@ func (c *LocalClient) Apply(ctx context.Context, req *ternv1.ApplyRequest) (*ter
 				"state", existing.State,
 			)
 			metrics.RecordRemoteApplyDedup(ctx, req.Database, req.Environment, "conflict_race")
-			return &ternv1.ApplyResponse{Accepted: true, ApplyId: existing.ApplyIdentifier}, nil
+			applyOperationID, err := c.applyResponseOperationID(ctx, existing)
+			if err != nil {
+				return nil, err
+			}
+			return &ternv1.ApplyResponse{Accepted: true, ApplyId: existing.ApplyIdentifier, ApplyOperationId: applyOperationID}, nil
 		}
 		return &ternv1.ApplyResponse{
 			Accepted:     false,
@@ -1897,7 +1906,11 @@ func (c *LocalClient) Apply(ctx context.Context, req *ternv1.ApplyRequest) (*ter
 				"state", existing.State,
 			)
 			metrics.RecordRemoteApplyDedup(ctx, req.Database, req.Environment, "create_race")
-			return &ternv1.ApplyResponse{Accepted: true, ApplyId: existing.ApplyIdentifier}, nil
+			applyOperationID, err := c.applyResponseOperationID(ctx, existing)
+			if err != nil {
+				return nil, err
+			}
+			return &ternv1.ApplyResponse{Accepted: true, ApplyId: existing.ApplyIdentifier, ApplyOperationId: applyOperationID}, nil
 		}
 		return nil, fmt.Errorf("create apply %s with tasks and operations: %w", applyIdentifier, err)
 	}
@@ -1929,9 +1942,31 @@ func (c *LocalClient) Apply(ctx context.Context, req *ternv1.ApplyRequest) (*ter
 	c.startApplyExecution(applyCtx, cancelGeneration, cancelApply, apply, tasks, plan, options, false)
 
 	return &ternv1.ApplyResponse{
-		Accepted: true,
-		ApplyId:  apply.ApplyIdentifier,
+		Accepted:         true,
+		ApplyId:          apply.ApplyIdentifier,
+		ApplyOperationId: strconv.FormatInt(operations[0].ID, 10),
 	}, nil
+}
+
+func (c *LocalClient) applyResponseOperationID(ctx context.Context, apply *storage.Apply) (string, error) {
+	if apply == nil {
+		return "", fmt.Errorf("apply is required")
+	}
+	store := c.storage.ApplyOperations()
+	if store == nil {
+		return "", fmt.Errorf("apply operation store is not configured")
+	}
+	ops, err := store.ListByApply(ctx, apply.ID)
+	if err != nil {
+		return "", fmt.Errorf("list apply_operations for apply %s: %w", apply.ApplyIdentifier, err)
+	}
+	if len(ops) != 1 {
+		c.logger.Debug("ApplyResponse omits apply_operation_id because apply has no single child operation",
+			"apply_id", apply.ApplyIdentifier,
+			"operation_count", len(ops))
+		return "", nil
+	}
+	return strconv.FormatInt(ops[0].ID, 10), nil
 }
 
 // getEngine returns the appropriate engine based on database type.


### PR DESCRIPTION
## Why
Multi-operation schema changes do not have one authoritative remote apply ID on the parent apply. Operators need deployment-scoped status and progress views that show the right child-operation identifiers without overloading opaque engine resume state.

## What
- Add `schemabot status --deployment` and thread the filter through the status API and storage query
- Add operation-scoped `external_id` and `external_operation_id` fields on `apply_operations`
- Store new multi-operation remote apply IDs on child operations, while keeping parent `applies.external_id` for compatibility
- Render operation-scoped IDs in detailed progress, TUI rollout progress, and deployment status
- Log when SchemaBot records remote operation identifiers so operators can correlate local operation rows with remote execution
- Simplify status list timing by showing `STARTED` without a redundant duration column

```text
Single-operation compatibility

applies.external_id ───────────────▶ remote apply_id
apply_operations[0]                 (child row exists, parent ID remains usable)
```

```text
Multi-operation model

applies                         user-facing aggregate; no single remote apply_id
└─ apply_operations[]
   ├─ external_id ─────────────▶ remote apply_id for this child dispatch
   └─ external_operation_id ──▶ remote apply_operation_id for this child dispatch
```

```text
Deployment-scoped status

status --deployment X
├─ one matching child operation      show its external_id / external_operation_id
└─ multiple matching child operations derive one deployment state, omit single IDs

status <apply_id>
└─ detailed progress lists each child operation and its IDs
```

## CLI Preview

```text
$ schemabot status -e production --deployment us-east --external-id

1 active schema change

  APPLY ID              EXTERNAL OP ID         DATABASE   ENV         DEPLOYMENT  STATE                STARTED        CALLER
  apply-multi-a1b2c3d4  remote-op-us-east-001  orders-db  production  us-east     Waiting for cutover  8 minutes ago  octocat

Use 'schemabot status <apply_id>' to view details
```

When a deployment has multiple matching child operations, the status row still summarizes the deployment state but avoids showing a misleading singular remote operation ID:

```text
1 active schema change

  APPLY ID                EXTERNAL OP ID  DATABASE      ENV         DEPLOYMENT  STATE    STARTED        CALLER
  apply-sharded-d5e6f7g8  -               inventory-db  production  us-east     Running  4 minutes ago  octocat

Use 'schemabot status <apply_id>' to view details
```

## TUI Preview

```text
⣾ running
1 ready for cutover · 1 running · 1 waiting
Apply ID: apply-multi-a1b2c3d4
Environment: production

🟢 us-east — ready for cutover — next in order (orders-us-east)
  External operation ID: remote-op-us-east-001
  External apply ID: remote-apply-us-east-001

🔄 eu-west — running table copy (orders-eu-west)
  External operation ID: remote-op-eu-west-001
  External apply ID: remote-apply-eu-west-001
```

## Risk Assessment
Medium — this touches status, storage, and Tern protocol surfaces. The schema changes are additive, existing unfiltered status behavior remains unchanged, and old operation rows can still be read through the legacy resume-context fallback during rollout.

Generated with Amp
