### PR TITLE
fix(tern): complete a task-less apply on recovery instead of failing it

### DIFF
--- a/pkg/tern/local_control_resume.go
+++ b/pkg/tern/local_control_resume.go
@@ -1239,12 +1239,25 @@ func (c *LocalClient) resumeApplyWithTasks(ctx context.Context, apply *storage.A
 		return nil
 	}
 	if len(tasks) == 0 && !isTasklessVSchemaOnlyPlan(tasks, plan) {
-		c.logger.Warn("no tasks found for apply, marking as failed",
+		// A task-less apply has no per-table work to drive — e.g. a sharded
+		// dispatch for a shard whose schema already matches the desired state (a
+		// no-op), or an apply whose tasks already completed. The initial drive
+		// completes such an apply (finalizeSequentialApply with no failed task);
+		// recovery must complete it too rather than failing it. (A VSchema-only
+		// plan is exempted above and re-driven below so its VSchema is applied.)
+		now := time.Now()
+		if freshApply, err := c.storage.Applies().Get(ctx, apply.ID); err == nil && freshApply != nil && state.IsTerminalApplyState(freshApply.State) {
+			// A concurrent drive already settled it — don't overwrite its verdict.
+			*apply = *freshApply
+			return nil
+		}
+		c.logger.Info("no tasks found for apply during recovery; completing as a no-op",
 			"apply_id", apply.ApplyIdentifier)
-		apply.State = state.Apply.Failed
-		apply.ErrorMessage = "no tasks found during recovery"
+		apply.State = state.Apply.Completed
+		apply.CompletedAt = &now
+		apply.UpdatedAt = now
 		if err := c.storage.Applies().Update(ctx, apply); err != nil {
-			c.logger.Error("failed to update apply state", "apply_id", apply.ApplyIdentifier, "state", state.Apply.Failed, "error", err)
+			c.logger.Error("failed to update apply state", "apply_id", apply.ApplyIdentifier, "state", state.Apply.Completed, "error", err)
 		}
 		c.notifyTerminalObserver(apply, tasks)
 		return nil

--- a/pkg/tern/local_control_resume.go
+++ b/pkg/tern/local_control_resume.go
@@ -1247,8 +1247,11 @@ func (c *LocalClient) resumeApplyWithTasks(ctx context.Context, apply *storage.A
 		// plan is exempted above and re-driven below so its VSchema is applied.)
 		now := time.Now()
 		if freshApply, err := c.storage.Applies().Get(ctx, apply.ID); err == nil && freshApply != nil && state.IsTerminalApplyState(freshApply.State) {
-			// A concurrent drive already settled it — don't overwrite its verdict.
+			// A concurrent drive already settled it — adopt its verdict and still
+			// notify this recovery's observer so a registered waiter (e.g. the PR
+			// check/comment) sees the terminal state instead of hanging.
 			*apply = *freshApply
+			c.notifyTerminalObserver(apply, tasks)
 			return nil
 		}
 		c.logger.Info("no tasks found for apply during recovery; completing as a no-op",
@@ -1257,7 +1260,9 @@ func (c *LocalClient) resumeApplyWithTasks(ctx context.Context, apply *storage.A
 		apply.CompletedAt = &now
 		apply.UpdatedAt = now
 		if err := c.storage.Applies().Update(ctx, apply); err != nil {
-			c.logger.Error("failed to update apply state", "apply_id", apply.ApplyIdentifier, "state", state.Apply.Completed, "error", err)
+			// Don't report a completion the operator can't see: surface the error so
+			// recovery retries, and notify the observer only after a durable write.
+			return fmt.Errorf("complete task-less apply %s during recovery: %w", apply.ApplyIdentifier, err)
 		}
 		c.notifyTerminalObserver(apply, tasks)
 		return nil

--- a/pkg/tern/local_control_resume_taskless_test.go
+++ b/pkg/tern/local_control_resume_taskless_test.go
@@ -1,0 +1,43 @@
+package tern
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/block/schemabot/pkg/state"
+	"github.com/block/schemabot/pkg/storage"
+)
+
+// A task-less apply recovered by the operator is a no-op — e.g. a sharded
+// dispatch for a shard whose schema already matches the desired state, or an
+// apply whose tasks already completed. The initial drive completes such an apply
+// (finalizeSequentialApply with no failed task), so recovery must complete it too
+// rather than failing it with "no tasks found during recovery". (A VSchema-only
+// plan is handled separately so its VSchema is still applied.)
+func TestResumeApply_TasklessNoOpCompletesNotFails(t *testing.T) {
+	apply := &storage.Apply{
+		ID: 1, PlanID: 7, ApplyIdentifier: "apply-noop",
+		Database: "cdb_resolute", DatabaseType: storage.DatabaseTypeStrata,
+		Environment: "production", State: state.Apply.Pending,
+	}
+	client := &LocalClient{
+		config: LocalConfig{Database: "cdb_resolute", Type: storage.DatabaseTypeStrata},
+		storage: &mockStorage{
+			applies: &mockApplyStore{apply: apply},
+			tasks:   &mockTaskStore{}, // no tasks for the apply
+			// A plan with no VSchema artifact, so it is not a VSchema-only plan —
+			// the exact case the recovery guard used to fail.
+			plans: &mockPlanStore{plan: &storage.Plan{ID: 7, PlanIdentifier: "plan-noop"}},
+		},
+		logger: slog.Default(),
+	}
+
+	err := client.ResumeApply(t.Context(), apply)
+	require.NoError(t, err)
+	assert.Equal(t, state.Apply.Completed, apply.State,
+		"a task-less no-op apply must complete on recovery, not be marked failed")
+	assert.NotEqual(t, state.Apply.Failed, apply.State)
+}

--- a/pkg/tern/local_control_resume_taskless_test.go
+++ b/pkg/tern/local_control_resume_taskless_test.go
@@ -1,6 +1,7 @@
 package tern
 
 import (
+	"errors"
 	"log/slog"
 	"testing"
 
@@ -40,4 +41,27 @@ func TestResumeApply_TasklessNoOpCompletesNotFails(t *testing.T) {
 	assert.Equal(t, state.Apply.Completed, apply.State,
 		"a task-less no-op apply must complete on recovery, not be marked failed")
 	assert.NotEqual(t, state.Apply.Failed, apply.State)
+}
+
+// If persisting the no-op completion fails, recovery surfaces the error so it
+// retries — rather than reporting a completion that was never written.
+func TestResumeApply_TasklessNoOpUpdateErrorReturnsError(t *testing.T) {
+	apply := &storage.Apply{
+		ID: 1, PlanID: 7, ApplyIdentifier: "apply-noop",
+		Database: "cdb_resolute", DatabaseType: storage.DatabaseTypeStrata,
+		Environment: "production", State: state.Apply.Pending,
+	}
+	client := &LocalClient{
+		config: LocalConfig{Database: "cdb_resolute", Type: storage.DatabaseTypeStrata},
+		storage: &mockStorage{
+			applies: &mockApplyStore{apply: apply, updateErr: errors.New("db down")},
+			tasks:   &mockTaskStore{},
+			plans:   &mockPlanStore{plan: &storage.Plan{ID: 7, PlanIdentifier: "plan-noop"}},
+		},
+		logger: slog.Default(),
+	}
+
+	err := client.ResumeApply(t.Context(), apply)
+	require.Error(t, err, "a failed completion write must be surfaced, not swallowed as success")
+	assert.Contains(t, err.Error(), "complete task-less apply")
 }


### PR DESCRIPTION
## Problem

seen in the data plane: A sharded apply succeeded (the `ALTER` completed on the shards that needed it), but the apply was then reported **failed** with `no tasks found during recovery`.

The operator's whole-apply recovery, `resumeApplyWithTasks` (`local_control_resume.go:1241`), marked **any** task-less apply as failed unless its plan was VSchema-only:

```go
if len(tasks) == 0 && !isTasklessVSchemaOnlyPlan(tasks, plan) {
    apply.State = state.Apply.Failed
    apply.ErrorMessage = "no tasks found during recovery"
    ...
}
```

But a task-less apply is a legitimate **no-op** — a sharded dispatch for a shard whose schema already matches the desired state (which is exactly what happens right after the change applies to the shards that needed it), or an apply whose tasks already completed. The **initial** drive completes such an apply (`finalizeSequentialApply` with no failed task); recovery diverged and failed it.

## Fix

Complete the task-less apply on recovery, mirroring the initial drive, with a reload guard so a concurrent drive's terminal verdict is never overwritten. Unchanged:
- The VSchema-only exemption (re-driven below so its VSchema is still applied).
- The operation-scoped recovery path (`ResumeApplyOperation`) already routes `group_finalizer` operations to `driveGroupFinalizer` and only fails closed for a truly-invalid operation id.

## Test

`TestResumeApply_TasklessNoOpCompletesNotFails`: a task-less, non-VSchema apply recovered via `ResumeApply` reaches `completed`, not `failed`. (Fails on `main` — the apply is marked `failed`.)