### PR TITLE
fix(github): refine apply comment UX

### DIFF
--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -380,11 +380,6 @@ CREATE TABLE `addresses` (
 
 **Applying automatically**
 
-🔓 If the apply fails, unlock with:
-```
-schemabot unlock
-```
-
 </details>
 
 <details>
@@ -1573,11 +1568,6 @@ ALTER TABLE `products` ADD INDEX `idx_category_price`(`category`, `price`);
 
 **Applying automatically**
 
-🔓 If the apply fails, unlock with:
-```
-schemabot unlock
-```
-
 </details>
 
 <details>
@@ -1625,11 +1615,6 @@ ALTER TABLE `products` ADD INDEX `idx_category_price`(`category`, `price`);
 ---
 
 **Applying automatically**
-
-🔓 If the apply fails, unlock with:
-```
-schemabot unlock
-```
 
 </details>
 
@@ -1775,11 +1760,6 @@ CREATE TABLE `addresses` (
 ---
 
 **Applying automatically**
-
-🔓 If the apply fails, unlock with:
-```
-schemabot unlock
-```
 
 </details>
 
@@ -2751,9 +2731,11 @@ Cutover is already in progress. SchemaBot will keep reporting progress from the 
 **Database**: `testapp`
 
 
-> All 3 tables applied successfully — your schema changes are live!
+> Applied successfully — your schema changes are live!
 
-<details><summary>Applied details (3 tables)</summary>
+<details><summary>Apply details (3 tables)</summary>
+
+**Apply ID**: `apply-a1b2c3d4e5f6`
 
 
 **`orders`**
@@ -2772,8 +2754,6 @@ ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
 ```
 
 </details>
-
-_Apply ID: `apply-a1b2c3d4e5f6`_
 
 </details>
 
@@ -2894,9 +2874,11 @@ This schema change was cancelled and cannot be resumed. Open a new schema change
 **Database**: `testapp`
 
 
-> All 8 tables applied successfully — your schema changes are live!
+> Applied successfully — your schema changes are live!
 
-<details><summary>Applied details (8 tables)</summary>
+<details><summary>Apply details (8 tables)</summary>
+
+**Apply ID**: `apply-a1b2c3d4e5f6`
 
 
 **`orders`**
@@ -2941,8 +2923,6 @@ ALTER TABLE `notifications` ADD INDEX `idx_user_status`(`user_id`, `status`);
 
 </details>
 
-_Apply ID: `apply-a1b2c3d4e5f6`_
-
 </details>
 
 <details>
@@ -2954,9 +2934,11 @@ _Apply ID: `apply-a1b2c3d4e5f6`_
 **Database**: `testapp`
 
 
-> Schema change applied successfully — your changes are live!
+> Applied successfully — your schema changes are live!
 
-<details><summary>Applied details (1 table, 1 VSchema update)</summary>
+<details><summary>Apply details (1 table, 1 VSchema update)</summary>
+
+**Apply ID**: `apply-a1b2c3d4e5f6`
 
 Applied by namespace:
 
@@ -2980,8 +2962,6 @@ ALTER TABLE `users` ADD COLUMN `phone` varchar(20);
 
 </details>
 
-_Apply ID: `apply-a1b2c3d4e5f6`_
-
 </details>
 
 <details>
@@ -2993,9 +2973,11 @@ _Apply ID: `apply-a1b2c3d4e5f6`_
 **Database**: `testapp`
 
 
-> VSchema applied successfully — your changes are live!
+> Applied successfully — your schema change is live!
 
-<details><summary>Applied details (1 VSchema update)</summary>
+<details><summary>Apply details (1 VSchema update)</summary>
+
+**Apply ID**: `apply-a1b2c3d4e5f6`
 
 
 ### VSchema
@@ -3007,8 +2989,6 @@ _Apply ID: `apply-a1b2c3d4e5f6`_
 ```
 
 </details>
-
-_Apply ID: `apply-a1b2c3d4e5f6`_
 
 </details>
 
@@ -3142,9 +3122,11 @@ schemabot apply -e staging
 **Database**: `testapp`
 
 
-> All 5 tables applied successfully — your schema changes are live!
+> Applied successfully — your schema changes are live!
 
-<details><summary>Applied details (5 tables)</summary>
+<details><summary>Apply details (5 tables)</summary>
+
+**Apply ID**: `apply-a1b2c3d4e5f6`
 
 Applied by namespace:
 
@@ -3187,8 +3169,6 @@ ALTER TABLE `events` ADD INDEX `idx_created_at`(`created_at`);
 ```
 
 </details>
-
-_Apply ID: `apply-a1b2c3d4e5f6`_
 </details>
 
 ### CLI Output
@@ -4739,11 +4719,6 @@ ALTER TABLE `products` ADD INDEX `idx_category_price`(`category`, `price`);
 
 **Applying automatically**
 
-🔓 If the apply fails, unlock with:
-```
-schemabot unlock
-```
-
 
 </details>
 
@@ -4792,11 +4767,6 @@ ALTER TABLE `products` ADD INDEX `idx_category_price`(`category`, `price`);
 ---
 
 **Applying automatically**
-
-🔓 If the apply fails, unlock with:
-```
-schemabot unlock
-```
 
 
 </details>
@@ -5615,9 +5585,11 @@ ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
 **Database**: `payments_eu`
 
 
-> All 3 tables applied successfully — your schema changes are live!
+> Applied successfully — your schema changes are live!
 
-<details><summary>Applied details (3 tables)</summary>
+<details><summary>Apply details (3 tables)</summary>
+
+**Apply ID**: `apply-a1b2c3d4e5f6`
 
 
 ### ✅ testapp
@@ -5638,8 +5610,6 @@ ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
 ```
 
 </details>
-
-_Apply ID: `apply-a1b2c3d4e5f6`_
 
 </details>
 
@@ -5651,9 +5621,11 @@ _Apply ID: `apply-a1b2c3d4e5f6`_
 **Database**: `payments_us`
 
 
-> All 3 tables applied successfully — your schema changes are live!
+> Applied successfully — your schema changes are live!
 
-<details><summary>Applied details (3 tables)</summary>
+<details><summary>Apply details (3 tables)</summary>
+
+**Apply ID**: `apply-a1b2c3d4e5f6`
 
 
 ### ✅ testapp
@@ -5674,8 +5646,6 @@ ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
 ```
 
 </details>
-
-_Apply ID: `apply-a1b2c3d4e5f6`_
 
 </details>
 
@@ -5687,9 +5657,11 @@ _Apply ID: `apply-a1b2c3d4e5f6`_
 **Database**: `payments_au`
 
 
-> All 3 tables applied successfully — your schema changes are live!
+> Applied successfully — your schema changes are live!
 
-<details><summary>Applied details (3 tables)</summary>
+<details><summary>Apply details (3 tables)</summary>
+
+**Apply ID**: `apply-a1b2c3d4e5f6`
 
 
 ### ✅ testapp
@@ -5710,8 +5682,6 @@ ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
 ```
 
 </details>
-
-_Apply ID: `apply-a1b2c3d4e5f6`_
 
 </details>
 
@@ -5751,9 +5721,11 @@ schemabot apply -e production
 **Database**: `payments_eu`
 
 
-> All 3 tables applied successfully — your schema changes are live!
+> Applied successfully — your schema changes are live!
 
-<details><summary>Applied details (3 tables)</summary>
+<details><summary>Apply details (3 tables)</summary>
+
+**Apply ID**: `apply-a1b2c3d4e5f6`
 
 
 ### ✅ testapp
@@ -5774,8 +5746,6 @@ ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
 ```
 
 </details>
-
-_Apply ID: `apply-a1b2c3d4e5f6`_
 
 </details>
 

--- a/pkg/webhook/apply_e2e_test.go
+++ b/pkg/webhook/apply_e2e_test.go
@@ -71,7 +71,6 @@ func TestE2EApplyWithChanges(t *testing.T) {
 		assert.Contains(t, body, dbName)
 		assert.Contains(t, body, "Lock acquired by")
 		assert.Contains(t, body, "Applying automatically")
-		assert.Contains(t, body, "schemabot unlock")
 	case <-time.After(30 * time.Second):
 		t.Fatal("timed out waiting for apply plan comment")
 	}

--- a/pkg/webhook/apply_test.go
+++ b/pkg/webhook/apply_test.go
@@ -125,7 +125,7 @@ func TestFormatSummaryComment(t *testing.T) {
 	assert.Contains(t, body, "Schema Change Applied")
 	assert.Contains(t, body, "`users`")
 	assert.Contains(t, body, "`orders`")
-	assert.Contains(t, body, "applied successfully")
+	assert.Contains(t, body, "Applied successfully")
 }
 
 func TestFormatSummaryComment_Failed(t *testing.T) {

--- a/pkg/webhook/comment_observer_test.go
+++ b/pkg/webhook/comment_observer_test.go
@@ -97,7 +97,7 @@ func TestCommentObserverRendersVSchemaFromEngineResumeState(t *testing.T) {
 	t.Run("terminal summary of a VSchema-only apply reports the VSchema outcome", func(t *testing.T) {
 		body := observer(`{"vschema_status":"applied","vschema_diffs":[{"namespace":"commerce_sharded","diff":"+ \"xxhash\": {}"}]}`).
 			formatTerminalSummaryComment(psApply(state.Apply.Completed))
-		assert.Contains(t, body, "VSchema applied successfully")
+		assert.Contains(t, body, "Applied successfully — your schema change is live!")
 		assert.Contains(t, body, "**`commerce_sharded`**: Applied")
 		assert.NotContains(t, body, "0 tables")
 	})

--- a/pkg/webhook/templates/apply.go
+++ b/pkg/webhook/templates/apply.go
@@ -996,6 +996,11 @@ func formatDuration(d time.Duration) string {
 
 func writeCompletedSummaryDetails(sb *strings.Builder, data ApplyStatusCommentData) {
 	if len(data.Tables) == 0 && len(data.VSchemaChanges) == 0 {
+		// No per-operation detail to collapse (e.g. a task-less apply that found
+		// no changes). Still surface the Apply ID so the summary stays auditable.
+		if data.ApplyID != "" {
+			fmt.Fprintf(sb, "\n_Apply ID: `%s`_\n", data.ApplyID)
+		}
 		return
 	}
 

--- a/pkg/webhook/templates/apply.go
+++ b/pkg/webhook/templates/apply.go
@@ -868,26 +868,14 @@ func countTableOutcomes(tables []TableProgressData) (completed, failed int) {
 func writeSummaryCompleted(sb *strings.Builder, data ApplyStatusCommentData, totalTables int) {
 	writeApplyHeader(sb, data)
 	writeSummaryCompletedMetadata(sb, data)
-	var msg string
-	switch {
-	case totalTables == 0 && len(data.VSchemaChanges) > 0:
-		// VSchema-only apply: no per-table tasks, so report the VSchema outcome.
-		msg = "VSchema applied successfully — your changes are live!"
-	case totalTables == 0:
-		msg = "Schema change applied successfully — your changes are live!"
-	case totalTables == 1:
-		msg = "Schema change applied successfully — your changes are live!"
-	default:
-		msg = fmt.Sprintf("All %d tables applied successfully — your schema changes are live!", totalTables)
+	// A VSchema update counts as a schema change alongside table changes, so the
+	// singular/plural wording reflects the total operation count.
+	msg := "Applied successfully — your schema changes are live!"
+	if totalTables+len(data.VSchemaChanges) == 1 {
+		msg = "Applied successfully — your schema change is live!"
 	}
 	writeSuccessBlock(sb, msg)
 	writeCompletedSummaryDetails(sb, data)
-	if data.ApplyID != "" {
-		if !strings.HasSuffix(sb.String(), "\n\n") {
-			sb.WriteString("\n")
-		}
-		fmt.Fprintf(sb, "_Apply ID: `%s`_\n", data.ApplyID)
-	}
 }
 
 // writeSummaryCompletedMetadata writes a clean metadata line for completed applies.
@@ -1012,6 +1000,9 @@ func writeCompletedSummaryDetails(sb *strings.Builder, data ApplyStatusCommentDa
 	}
 
 	fmt.Fprintf(sb, "\n<details><summary>%s</summary>\n\n", completedSummaryDetailsLabel(data))
+	if data.ApplyID != "" {
+		fmt.Fprintf(sb, "**Apply ID**: `%s`\n\n", data.ApplyID)
+	}
 	writeCompletedNamespaceSummary(sb, data)
 	if len(data.Tables) > 0 {
 		writeSummaryTableListWithOptions(sb, data, false)
@@ -1028,7 +1019,7 @@ func completedSummaryDetailsLabel(data ApplyStatusCommentData) string {
 	if len(data.VSchemaChanges) > 0 {
 		parts = append(parts, fmt.Sprintf("%d VSchema %s", len(data.VSchemaChanges), pluralize("update", len(data.VSchemaChanges))))
 	}
-	return fmt.Sprintf("Applied details (%s)", strings.Join(parts, ", "))
+	return fmt.Sprintf("Apply details (%s)", strings.Join(parts, ", "))
 }
 
 type completedNamespaceSummary struct {

--- a/pkg/webhook/templates/apply_test.go
+++ b/pkg/webhook/templates/apply_test.go
@@ -1199,7 +1199,7 @@ func TestPreviewCommentSummaryCompleted(t *testing.T) {
 	result := PreviewCommentSummaryCompleted()
 
 	assert.Contains(t, result, "Schema Change Applied")
-	assert.Contains(t, result, "All 3 tables applied successfully")
+	assert.Contains(t, result, "Applied successfully — your schema changes are live!")
 	// Single namespace matching database name — header skipped
 	assert.NotContains(t, result, "### ")
 	assert.Contains(t, result, "**`orders`**")
@@ -1281,8 +1281,8 @@ func TestRenderApplySummaryComment_VSchemaOnly(t *testing.T) {
 	result := RenderApplySummaryComment(data)
 
 	assert.NotContains(t, result, "0 tables")
-	assert.Contains(t, result, "VSchema applied successfully")
-	assert.Contains(t, result, "<details><summary>Applied details (1 VSchema update)</summary>")
+	assert.Contains(t, result, "Applied successfully — your schema change is live!")
+	assert.Contains(t, result, "<details><summary>Apply details (1 VSchema update)</summary>")
 	assert.Contains(t, result, "### VSchema")
 	assert.Contains(t, result, "**`commerce_sharded`**: Applied")
 }
@@ -1290,13 +1290,13 @@ func TestRenderApplySummaryComment_VSchemaOnly(t *testing.T) {
 func TestPreviewCommentSummaryCompletedLargeCollapsesAppliedDetails(t *testing.T) {
 	result := PreviewCommentSummaryCompletedLarge()
 
-	assert.Contains(t, result, "All 8 tables applied successfully")
-	assert.Contains(t, result, "<details><summary>Applied details (8 tables)</summary>")
-	assert.Contains(t, result, "_Apply ID: `apply-a1b2c3d4e5f6`_")
+	assert.Contains(t, result, "Applied successfully — your schema changes are live!")
+	assert.Contains(t, result, "<details><summary>Apply details (8 tables)</summary>")
+	assert.Contains(t, result, "**Apply ID**: `apply-a1b2c3d4e5f6`")
 	assert.Equal(t, 1, strings.Count(result, "</details>"))
 }
 
-func TestRenderApplySummaryCommentCompletedCollapsedDetailsSeparateApplyID(t *testing.T) {
+func TestRenderApplySummaryCommentCompletedCollapsedDetailsApplyIDInside(t *testing.T) {
 	tableNames := []string{"users", "orders", "products", "invoices", "payments", "shipments"}
 	tables := make([]TableProgressData, 0, len(tableNames))
 	for _, tableName := range tableNames {
@@ -1320,17 +1320,21 @@ func TestRenderApplySummaryCommentCompletedCollapsedDetailsSeparateApplyID(t *te
 
 	result := RenderApplySummaryComment(data)
 
-	assert.Contains(t, result, "<details><summary>Applied details (6 tables)</summary>")
+	assert.Contains(t, result, "<details><summary>Apply details (6 tables)</summary>")
 	assert.Contains(t, result, "### ✅ testapp_primary")
-	assert.Contains(t, result, "</details>\n\n_Apply ID: `apply-a1b2c3d4e5f6`_")
-	assert.NotContains(t, result, "</details>\n_Apply ID")
+	// The Apply ID lives inside the collapsed details block, not as a trailing line.
+	assert.Contains(t, result, "**Apply ID**: `apply-a1b2c3d4e5f6`")
+	assert.NotContains(t, result, "_Apply ID:")
+	idIdx := strings.Index(result, "**Apply ID**: `apply-a1b2c3d4e5f6`")
+	closeIdx := strings.LastIndex(result, "</details>")
+	assert.True(t, idIdx >= 0 && idIdx < closeIdx, "Apply ID should appear inside the details, before the closing tag")
 }
 
 func TestPreviewCommentSummaryCompletedVitessTracksVSchema(t *testing.T) {
 	result := PreviewCommentSummaryCompletedVitessDDLWithVSchema()
 
-	assert.Contains(t, result, "Schema change applied successfully")
-	assert.Contains(t, result, "<details><summary>Applied details (1 table, 1 VSchema update)</summary>")
+	assert.Contains(t, result, "Applied successfully — your schema changes are live!")
+	assert.Contains(t, result, "<details><summary>Apply details (1 table, 1 VSchema update)</summary>")
 	assert.Contains(t, result, "**`users`**")
 	assert.Contains(t, result, "### VSchema")
 	assert.Contains(t, result, "**`myapp_sharded`**: Applied")
@@ -1340,8 +1344,8 @@ func TestPreviewCommentSummaryCompletedVitessVSchemaOnly(t *testing.T) {
 	result := PreviewCommentSummaryCompletedVitessVSchemaOnly()
 
 	assert.NotContains(t, result, "0 tables")
-	assert.Contains(t, result, "VSchema applied successfully")
-	assert.Contains(t, result, "<details><summary>Applied details (1 VSchema update)</summary>")
+	assert.Contains(t, result, "Applied successfully — your schema change is live!")
+	assert.Contains(t, result, "<details><summary>Apply details (1 VSchema update)</summary>")
 	assert.Contains(t, result, "### VSchema")
 	assert.Contains(t, result, "**`myapp_sharded`**: Applied")
 }
@@ -1372,7 +1376,7 @@ func TestRenderApplySummaryCommentCompletedMultiNamespaceVSchemaSummary(t *testi
 
 	result := RenderApplySummaryComment(data)
 
-	assert.Contains(t, result, "<details><summary>Applied details (2 tables, 2 VSchema updates)</summary>")
+	assert.Contains(t, result, "<details><summary>Apply details (2 tables, 2 VSchema updates)</summary>")
 	assert.Contains(t, result, "- `commerce`: 1 table, 1 VSchema update")
 	assert.Contains(t, result, "- `customers`: 1 table")
 	assert.Contains(t, result, "- `customers_sharded`: 1 VSchema update")

--- a/pkg/webhook/templates/apply_test.go
+++ b/pkg/webhook/templates/apply_test.go
@@ -1287,6 +1287,24 @@ func TestRenderApplySummaryComment_VSchemaOnly(t *testing.T) {
 	assert.Contains(t, result, "**`commerce_sharded`**: Applied")
 }
 
+// A task-less apply that completes with no table or VSchema changes still
+// surfaces its Apply ID so the summary stays auditable — without rendering an
+// empty details block or an "Apply details ()" label.
+func TestRenderApplySummaryComment_TasklessStillShowsApplyID(t *testing.T) {
+	data := ApplyStatusCommentData{
+		ApplyID:     "apply-tasklessabc",
+		Database:    "testapp",
+		Environment: "staging",
+		State:       state.Apply.Completed,
+	}
+
+	result := RenderApplySummaryComment(data)
+
+	assert.Contains(t, result, "_Apply ID: `apply-tasklessabc`_")
+	assert.NotContains(t, result, "Apply details ()")
+	assert.NotContains(t, result, "<details>")
+}
+
 func TestPreviewCommentSummaryCompletedLargeCollapsesAppliedDetails(t *testing.T) {
 	result := PreviewCommentSummaryCompletedLarge()
 

--- a/pkg/webhook/templates/multi_apply_test.go
+++ b/pkg/webhook/templates/multi_apply_test.go
@@ -308,7 +308,7 @@ func TestRenderMultiDeploymentApplySummaryComment_CompletedReusesSummaryRenderer
 	assert.Contains(t, out, "- ✅ us — completed")
 
 	// Each <details> body is the summary renderer's output, not the status one.
-	assert.Contains(t, out, "Schema change applied successfully — your changes are live!")
+	assert.Contains(t, out, "Applied successfully — your schema change is live!")
 	assert.Contains(t, out, "**Database**: `payments_eu`")
 	assert.Contains(t, out, "**Database**: `payments_us`")
 }

--- a/pkg/webhook/templates/plan.go
+++ b/pkg/webhook/templates/plan.go
@@ -133,8 +133,10 @@ func RenderPlanComment(data PlanCommentData) string {
 		writeUnsafeWarning(&sb, data.UnsafeChanges, data.AllowUnsafe, data.IsMySQL)
 	}
 
-	// Lint violations
-	if len(data.LintViolations) > 0 {
+	// Lint violations — shown on the plan comment for review, omitted on the
+	// locked apply comment where they are noise (the operator already reviewed
+	// them at plan time).
+	if len(data.LintViolations) > 0 && !data.IsLocked {
 		writeLintViolations(&sb, data.LintViolations)
 	}
 
@@ -173,10 +175,9 @@ func RenderPlanComment(data PlanCommentData) string {
 			sb.WriteString("\n🔓 To discard this plan and unlock, comment:\n")
 			sb.WriteString("```\nschemabot unlock\n```\n")
 		} else {
-			// Automatic apply is proceeding — include unlock hint in case the apply fails before starting
+			// Automatic apply is proceeding. No unlock hint — it's noise on the
+			// happy path; the operator can still unlock from the CLI if needed.
 			sb.WriteString("**Applying automatically**\n")
-			sb.WriteString("\n🔓 If the apply fails, unlock with:\n")
-			sb.WriteString("```\nschemabot unlock\n```\n")
 		}
 	} else {
 		applyCmd := fmt.Sprintf("schemabot apply -e %s", data.Environment)

--- a/pkg/webhook/templates/sharded_plan_test.go
+++ b/pkg/webhook/templates/sharded_plan_test.go
@@ -7,6 +7,31 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// Lint warnings belong on the plan comment, where the operator reviews them
+// before applying. On the locked apply comment they are noise — the operator
+// already saw them at plan time — so the apply comment omits them.
+func TestRenderPlanComment_LintShownOnPlanNotOnApply(t *testing.T) {
+	data := PlanCommentData{
+		Database: "testapp", Environment: "staging", IsMySQL: true,
+		Changes: []KeyspaceChangeData{{
+			Keyspace:   "testapp",
+			Statements: []string{"ALTER TABLE `users` ADD COLUMN `email` varchar(255)"},
+		}},
+		LintViolations: []LintViolationData{
+			{Message: "Column added without DEFAULT value", Table: "users", LinterName: "no_default"},
+		},
+	}
+
+	plan := RenderPlanComment(data)
+	assert.Contains(t, plan, "⚠️ **Lint Warnings**:", "the plan comment surfaces lint for review")
+	assert.Contains(t, plan, "Column added without DEFAULT value")
+
+	data.IsLocked = true
+	apply := RenderPlanComment(data)
+	assert.NotContains(t, apply, "Lint Warnings", "the locked apply comment omits lint as noise")
+	assert.NotContains(t, apply, "Column added without DEFAULT value")
+}
+
 // A sharded plan whose shards diverge renders "what applies where": one DDL
 // block per distinct change set, each labelled with the shards it applies to.
 func TestRenderPlanComment_ShardedDivergent(t *testing.T) {


### PR DESCRIPTION
## Why this matters

Watching real applies through the PR comment surfaced a few rough edges in the comment copy — small individually, but together they make the happy path read as noisier and less polished than it should. These are pure presentation fixes to the apply/summary comments.

## What it does

- **Apply ID lives with the details.** The terminal summary's collapsible header is renamed `Applied details (N)` → `Apply details (N)`, and the Apply ID moves *inside* that block instead of trailing after it.
- **Cleaner success line.** The completed-summary message becomes `Applied successfully — your schema change is live!`, with singular/plural driven by the total operation count — and a VSchema update counts as an operation alongside table changes (1 table + 1 VSchema update → "changes are live"; 1 VSchema update alone → "change is live"). Replaces the wordier per-shape variants.
- **No unlock hint on auto-apply.** When a `schemabot apply` proceeds automatically, the comment no longer appends the "🔓 if the apply fails, unlock with…" block — it's noise on the happy path; "Applying automatically" already says what's happening.
- **Lint warnings only on the plan comment.** The locked apply comment no longer repeats lint warnings — the operator already reviewed them at plan time; repeating them at apply time is noise.

No behavior change — comment rendering only. TEMPLATES.md regenerated; assertions updated; added a focused test that lint shows on the plan comment and is omitted on the locked apply comment.

## How it moves toward northstar

The PR comment is the primary surface operators read during a schema change. Trimming repeated/low-value text and keeping identifiers where they're expected makes the happy path easier to scan and trust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)