### PR TITLE
feat(cli): add schema change cancel command

### DIFF
--- a/pkg/cmd/commands/cancel.go
+++ b/pkg/cmd/commands/cancel.go
@@ -1,0 +1,85 @@
+package commands
+
+import (
+	"fmt"
+
+	"github.com/block/schemabot/pkg/apitypes"
+	"github.com/block/schemabot/pkg/cmd/client"
+	"github.com/block/schemabot/pkg/cmd/internal/templates"
+	"github.com/block/schemabot/pkg/state"
+)
+
+// CancelCmd cancels an in-progress schema change permanently.
+type CancelCmd struct {
+	ControlFlags
+}
+
+// Run executes the cancel command.
+func (cmd *CancelCmd) Run(g *Globals) error {
+	if err := cmd.RequireApplyID(); err != nil {
+		return err
+	}
+	ep, err := cmd.Resolve(g)
+	if err != nil {
+		return err
+	}
+
+	var result *apitypes.ProgressResponse
+	err = withLoading("Loading schema change progress...", true, func() error {
+		var loadErr error
+		result, loadErr = client.GetProgress(ep, cmd.ApplyID)
+		return loadErr
+	})
+	if err != nil {
+		return fmt.Errorf("get progress for apply %s: %w", cmd.ApplyID, err)
+	}
+	populateControlDisplayFields(&cmd.Database, result)
+
+	curState := result.State
+	if state.IsState(curState, state.NoActiveChange) || curState == "" {
+		fmt.Printf("No active schema change for %s\n", formatControlTarget(cmd.ApplyID, cmd.Database, cmd.Environment))
+		return nil
+	}
+	if state.IsTerminalApplyState(curState) && !state.IsState(curState, state.Apply.Stopped) {
+		fmt.Printf("Schema change already terminal (state: %s) - nothing to cancel\n", curState)
+		return nil
+	}
+	if !isCancelAllowedState(curState) {
+		return fmt.Errorf("cannot cancel schema change in state: %s", curState)
+	}
+
+	var cancelResult *apitypes.CancelResponse
+	err = withLoading("Cancelling schema change...", true, func() error {
+		var cancelErr error
+		cancelResult, cancelErr = client.CallCancelAPI(ep, cmd.Environment, cmd.ApplyID)
+		return cancelErr
+	})
+	if err != nil {
+		return err
+	}
+	if err := checkAccepted(cancelResponseWrapper{cancelResult}, "cancel"); err != nil {
+		return err
+	}
+
+	templates.WriteCancelSuccess(templates.CancelData{
+		Database:       cmd.Database,
+		Environment:    cmd.Environment,
+		CancelledCount: int(cancelResult.CancelledCount),
+		SkippedCount:   int(cancelResult.SkippedCount),
+	})
+	return nil
+}
+
+func isCancelAllowedState(s string) bool {
+	return state.IsState(s,
+		state.Apply.Pending,
+		state.Apply.Running,
+		state.Apply.RunningDegraded,
+		state.Apply.Recovering,
+		state.Apply.CuttingOver,
+		state.Apply.WaitingForDeploy,
+		state.Apply.WaitingForCutover,
+		state.Apply.FailedRetryable,
+		state.Apply.Stopped,
+	)
+}

--- a/pkg/cmd/commands/cancel.go
+++ b/pkg/cmd/commands/cancel.go
@@ -12,6 +12,7 @@ import (
 // CancelCmd cancels an in-progress schema change permanently.
 type CancelCmd struct {
 	ControlFlags
+	AutoApprove bool `short:"y" help:"Skip confirmation prompt" name:"auto-approve"`
 }
 
 // Run executes the cancel command.
@@ -44,8 +45,23 @@ func (cmd *CancelCmd) Run(g *Globals) error {
 		fmt.Printf("Schema change already terminal (state: %s) - nothing to cancel\n", curState)
 		return nil
 	}
-	if !isCancelAllowedState(curState) {
-		return fmt.Errorf("cannot cancel schema change in state: %s", curState)
+
+	// Cancellation is permanent and non-resumable; require explicit confirmation
+	// unless auto-approved. The server is the source of truth for which remaining
+	// (non-terminal, or stopped) states are cancellable.
+	if !cmd.AutoApprove {
+		fmt.Printf("About to permanently cancel the schema change for %s (state: %s).\n",
+			formatControlTarget(cmd.ApplyID, cmd.Database, cmd.Environment), curState)
+		confirmed, err := confirmAction(
+			"This cannot be resumed. Only 'yes' will be accepted: ",
+			"\nCancel aborted.",
+		)
+		if err != nil {
+			return err
+		}
+		if !confirmed {
+			return nil
+		}
 	}
 
 	var cancelResult *apitypes.CancelResponse
@@ -68,18 +84,4 @@ func (cmd *CancelCmd) Run(g *Globals) error {
 		SkippedCount:   int(cancelResult.SkippedCount),
 	})
 	return nil
-}
-
-func isCancelAllowedState(s string) bool {
-	return state.IsState(s,
-		state.Apply.Pending,
-		state.Apply.Running,
-		state.Apply.RunningDegraded,
-		state.Apply.Recovering,
-		state.Apply.CuttingOver,
-		state.Apply.WaitingForDeploy,
-		state.Apply.WaitingForCutover,
-		state.Apply.FailedRetryable,
-		state.Apply.Stopped,
-	)
 }

--- a/pkg/cmd/commands/common.go
+++ b/pkg/cmd/commands/common.go
@@ -254,6 +254,11 @@ type stopResponseWrapper struct{ r *apitypes.StopResponse }
 func (w stopResponseWrapper) IsAccepted() bool        { return w.r.Accepted }
 func (w stopResponseWrapper) GetErrorMessage() string { return w.r.ErrorMessage }
 
+type cancelResponseWrapper struct{ r *apitypes.CancelResponse }
+
+func (w cancelResponseWrapper) IsAccepted() bool        { return w.r.Accepted }
+func (w cancelResponseWrapper) GetErrorMessage() string { return w.r.ErrorMessage }
+
 type startResponseWrapper struct{ r *apitypes.StartResponse }
 
 func (w startResponseWrapper) IsAccepted() bool        { return w.r.Accepted }

--- a/pkg/cmd/internal/templates/progress.go
+++ b/pkg/cmd/internal/templates/progress.go
@@ -730,6 +730,30 @@ func WriteStopSuccess(data StopData) {
 	}
 }
 
+// CancelData contains data for rendering cancel command output.
+type CancelData struct {
+	Database       string
+	Environment    string
+	CancelledCount int
+	SkippedCount   int
+}
+
+// WriteCancelSuccess writes the cancel command success output.
+func WriteCancelSuccess(data CancelData) {
+	fmt.Printf("%s%s✖ Schema change cancelled%s\n", ANSIBold, ANSIRed, ANSIReset)
+	fmt.Println()
+	fmt.Printf("Database:    %s\n", data.Database)
+	fmt.Printf("Environment: %s\n", data.Environment)
+	if data.CancelledCount > 0 {
+		fmt.Printf("Cancelled:   %d table(s)\n", data.CancelledCount)
+	}
+	if data.SkippedCount > 0 {
+		fmt.Printf("Skipped:     %d table(s) (already terminal)\n", data.SkippedCount)
+	}
+	fmt.Println()
+	fmt.Printf("%sThis schema change cannot be resumed.%s\n", ANSIDim, ANSIReset)
+}
+
 // StartData contains data for rendering start command output.
 type StartData struct {
 	Database     string

--- a/pkg/cmd/main.go
+++ b/pkg/cmd/main.go
@@ -32,6 +32,7 @@ type CLI struct {
 	Progress   commands.ProgressCmd   `cmd:"" help:"Get schema change progress"`
 	Cutover    commands.CutoverCmd    `cmd:"" help:"Trigger cutover for a deferred schema change"`
 	Stop       commands.StopCmd       `cmd:"" help:"Stop an in-progress schema change"`
+	Cancel     commands.CancelCmd     `cmd:"" help:"Cancel a schema change permanently"`
 	Start      commands.StartCmd      `cmd:"" help:"Resume a stopped schema change"`
 	Volume     commands.VolumeCmd     `cmd:"" help:"Adjust schema change speed (1-11)"`
 	Revert     commands.RevertCmd     `cmd:"" help:"Revert a completed schema change during the revert window"`


### PR DESCRIPTION
## Why
Once the backend can record and drive permanent cancel requests, operators need a first-class CLI entry point instead of overloading `stop` for terminal aborts.

## What
- Add `schemabot cancel` for permanent schema change cancellation
- Call the cancel API from the CLI client
- Prompt for explicit confirmation before cancelling — permanent and non-resumable — with `-y` / `--auto-approve` to skip, consistent with `apply` and `rollback`
- Defer cancellable-state decisions to the server instead of a client-side allowlist, so valid non-terminal states (e.g. PlanetScale setup phases, paused/resuming) are not wrongly blocked
- Render cancel-specific command output and accepted/skipped counts

## Risk Assessment
Low — this is a thin CLI layer on top of the backend cancel API (#573).

---
*PR summary updated by Claude Code (Opus 4.8).*
